### PR TITLE
add note about installing the rpm-build package

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,12 @@ sudo yum install yaml-cpp-devel lz4-devel zlib-devel snappy-devel jsoncpp-devel 
 
 ## Building Fedora RPM
 
-As a pre-requisite, you need to install [Mock](https://fedoraproject.org/wiki/Mock) on your machine:
+As a pre-requisite, you need to install [Mock](https://fedoraproject.org/wiki/Mock)
+and rpm-build on your machine:
 
 ```
-# Install mock:
-sudo yum install mock
+# Install mock and rpm-build:
+sudo yum install mock rpm-build
 
 # Add user to the "mock" group:
 usermod -a -G mock $USER && newgrp mock


### PR DESCRIPTION
To build the Scylla RPM you need `/usr/bin/rpmbuild` on your system, which is provided by the `rpm-build` package.