### PR TITLE
Let the compiler optimize more aggresively when compiling a release.

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -127,7 +127,7 @@ modes = {
     'release': {
         'sanitize': '',
         'sanitize_libs': '',
-        'opt': '-O2',
+        'opt': '-O3',
         'libs': '',
     },
 }


### PR DESCRIPTION
-O2 does not inline functions and does not perform other optimizations that might shave us some runtime.
For more information see https://gcc.gnu.org/onlinedocs/gcc-4.3.1/gcc/Optimize-Options.html#Optimize-Options