### PR TITLE
Fedora 25 need `python3-YAML`

### DIFF
--- a/dist/redhat/scylla.spec.in
+++ b/dist/redhat/scylla.spec.in
@@ -31,6 +31,7 @@ BuildRequires:  libaio-devel libstdc++-devel cryptopp-devel hwloc-devel numactl-
 %{?fedora:BuildRequires: boost-devel ragel antlr3-tool antlr3-C++-devel python3 gcc-c++ libasan libubsan python3-pyparsing dnf-yum}
 %{?rhel:BuildRequires: scylla-libstdc++-static scylla-boost-devel scylla-boost-static scylla-ragel scylla-antlr3-tool scylla-antlr3-C++-devel python34 scylla-gcc-c++ >= 5.1.1, python34-pyparsing}
 Requires:       scylla-conf systemd-libs hwloc collectd PyYAML python-urwid pciutils pyparsing python-requests curl util-linux python-setuptools pciutils
+%{?fedora:Requires: python3-PyYAML}
 %{?rhel:Requires: python34 python34-PyYAML}
 Conflicts:      abrt
 


### PR DESCRIPTION
If `python3-YAML` is not installed, the following error will appear while
starting scylla-server service.

scylla_prepare[6385]: Traceback (most recent call last):
scylla_prepare[6385]:   File "/usr/lib/scylla/scylla-blocktune", line 102, in <module>
scylla_prepare[6385]:     tune_yaml('/etc/scylla/scylla.yaml')
scylla_prepare[6385]:   File "/usr/lib/scylla/scylla-blocktune", line 85, in tune_yaml
scylla_prepare[6385]:     import yaml
scylla_prepare[6385]: ImportError: No module named 'yaml'