### PR TITLE
Add overall python code QA and guidelines with flake8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,7 @@ dist/ami/scylla_deploy.sh
 Cql.tokens
 .kdev4
 *.kdev4
+.cache
+.tox
+*.egg-info
+__pycache__

--- a/HACKING.md
+++ b/HACKING.md
@@ -52,6 +52,24 @@ A test target can be any executable. A non-zero return code indicates test failu
 
 Most tests in the Scylla repository are built using the [Boost.Test](http://www.boost.org/doc/libs/1_64_0/libs/test/doc/html/index.html) library. Utilities for writing tests with Seastar futures are also included.
 
+### Testing python code
+
+Python code style guidelines are tested and validated using `tox` and its `tox.ini` configuration file.
+
+To run those tests locally, setup a virtualenv like this:
+
+```bash
+$ virtualenv -p python3 $HOME/scylla_venv
+$ source $HOME/scylla_venv/bin/activate
+(scylla_venv) $ pip install tox
+```
+
+Then execute `tox` to run the tests on the python code base:
+
+```bash
+(scylla_venv) $ tox
+```
+
 ### Preparing patches
 
 All changes to Scylla are submitted as patches to the public mailing list. Once a patch is approved by one of the maintainers of the project, it is committed to the maintainers' copy of the repository at https://github.com/scylladb/scylla.

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,12 @@
+from setuptools import find_packages, setup
+
+setup(
+    name="scylla",
+    description='NoSQL data store using the seastar framework, compatible with Apache Cassandra',
+    url='https://github.com/scylladb/scylla',
+    download_url='https://github.com/scylladb/scylla/tags',
+    license='AGPL',
+    platforms='any',
+    packages=find_packages(),
+    include_package_data=True,
+    install_requires=[])

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,20 @@
+[tox]
+usedevelop=True
+skipdist=True
+
+[testenv]
+deps =
+    pytest
+    pytest-flake8
+
+commands =
+    pytest --flake8 -k 'not tests'
+
+[flake8]
+max-line-length = 120
+exclude = .ropeproject,.tox,tests
+show-source = False
+
+[pytest]
+flake8-ignore =
+    E501


### PR DESCRIPTION
ScyllaDB loves python & python loves ScyllaDB.

It would benefit the project to start enforcing some code guidelines
and basic QA with a linter along a PEP8 respect thanks to flake8.

This patch adds a tox config to at least start with an assessment
of the work to be done on all .py files in the code base.

To reduce its noise, tests on long lines (> 80char) are ignored
for now.

If this is accepted, this will be used as a base to propose patches to fix the various corrections found on .py files in the code base.