### PR TITLE
Reduce number of created layers

### DIFF
--- a/dist/docker/redhat/Dockerfile
+++ b/dist/docker/redhat/Dockerfile
@@ -7,16 +7,16 @@ ENV container docker
 VOLUME [ "/sys/fs/cgroup" ]
 
 #install scylla
-RUN curl http://downloads.scylladb.com/rpm/unstable/centos/master/latest/scylla.repo -o /etc/yum.repos.d/scylla.repo
-RUN yum -y install epel-release
-RUN yum -y clean expire-cache
-RUN yum -y update
-RUN yum -y remove boost-thread boost-system
-RUN yum -y install scylla hostname supervisor
-RUN yum clean all
-
+RUN set -ex ; \
+    curl http://downloads.scylladb.com/rpm/unstable/centos/master/latest/scylla.repo -o /etc/yum.repos.d/scylla.repo ; \
+    yum -y install epel-release ; \
+    yum -y clean expire-cache ; \
+    yum -y update ; \
+    yum -y remove boost-thread boost-system ; \
+    yum -y install scylla hostname supervisor ; \
+    yum clean all ; \
 #install python3 for our main script
-RUN yum -y install python34 python34-PyYAML
+    yum -y install python34 python34-PyYAML
 
 ADD scylla_bashrc /scylla_bashrc
 RUN cat /scylla_bashrc >> /etc/bashrc


### PR DESCRIPTION
Every time "RUN" "ADD" etc are used another layer is created. So as a suggestion, use multi-line one-liners to reduce the number of layers. RUN of yum clean in particular creates a layer that masks over the junk in the lower layers. So it looks like yum caches are cleared but they arent.

The list of ADD's needs more thought, but the RUN's all mixed in together could be moved upwards into the single long RUN command