### PR TITLE
Issues/3803

### DIFF
--- a/cql3/restrictions/primary_key_restrictions.hh
+++ b/cql3/restrictions/primary_key_restrictions.hh
@@ -106,6 +106,11 @@ public:
     virtual size_t prefix_size() const {
         return 0;
     }
+
+    size_t prefix_size(const schema_ptr schema) const {
+        return 0;
+    }
+
 };
 
 template<>
@@ -127,6 +132,25 @@ template<>
 inline bool primary_key_restrictions<clustering_key>::needs_filtering(const schema& schema) const  {
     // Currently only overloaded single_column_primary_key_restrictions will require ALLOW FILTERING
     return false;
+}
+
+template<>
+inline size_t primary_key_restrictions<clustering_key>::prefix_size(const schema_ptr schema) const {
+
+    auto column_defs = get_column_defs();
+    size_t count = 0;
+    if (schema->clustering_key_columns().empty()) {
+        return count;
+    }
+    column_id expected_column_id = schema->clustering_key_columns().begin()->id;
+    for (auto&& cdef : column_defs) {
+        if (schema->position(*cdef) != expected_column_id) {
+            return count;
+        }
+        expected_column_id++;
+        count++;
+    }
+    return count;
 }
 
 }

--- a/cql3/restrictions/single_column_primary_key_restrictions.hh
+++ b/cql3/restrictions/single_column_primary_key_restrictions.hh
@@ -166,19 +166,7 @@ public:
     }
 
     virtual size_t prefix_size() const override {
-        size_t count = 0;
-        if (_schema->clustering_key_columns().empty()) {
-            return count;
-        }
-        column_id expected_column_id = _schema->clustering_key_columns().begin()->id;
-        for (const auto& restriction_entry : _restrictions->restrictions()) {
-            if (_schema->position(*restriction_entry.first) != expected_column_id) {
-                return count;
-            }
-            expected_column_id++;
-            count++;
-        }
-        return count;
+        return primary_key_restrictions<ValueType>::prefix_size(_schema);
     }
 
     ::shared_ptr<single_column_primary_key_restrictions<clustering_key>> get_longest_prefix_restrictions() {

--- a/cql3/restrictions/statement_restrictions.cc
+++ b/cql3/restrictions/statement_restrictions.cc
@@ -337,6 +337,19 @@ const std::vector<::shared_ptr<restrictions>>& statement_restrictions::index_res
     return _index_restrictions;
 }
 
+std::optional<secondary_index::index> statement_restrictions::find_idx(secondary_index::secondary_index_manager& sim) const {
+    for (::shared_ptr<cql3::restrictions::restrictions> restriction : index_restrictions()) {
+        for (const auto& cdef : restriction->get_column_defs()) {
+            for (auto index : sim.list_indexes()) {
+                if (index.depends_on(*cdef)) {
+                    return std::make_optional<secondary_index::index>(std::move(index));
+                }
+            }
+        }
+    }
+    return std::nullopt;
+}
+
 void statement_restrictions::process_partition_key_restrictions(bool has_queriable_index, bool for_view, bool allow_filtering) {
     // If there is a queriable index, no special condition are required on the other restrictions.
     // But we still need to know 2 things:

--- a/cql3/restrictions/statement_restrictions.cc
+++ b/cql3/restrictions/statement_restrictions.cc
@@ -350,6 +350,39 @@ std::optional<secondary_index::index> statement_restrictions::find_idx(secondary
     return std::nullopt;
 }
 
+std::vector<const column_definition*> statement_restrictions::get_column_defs_for_filtering(database& db) const {
+    std::vector<const column_definition*> column_defs_for_filtering;
+    if (need_filtering()) {
+        auto& sim = db.find_column_family(_schema).get_index_manager();
+        std::optional<secondary_index::index> opt_idx = find_idx(sim);
+        auto column_uses_indexing = [&opt_idx] (const column_definition* cdef) {
+            return opt_idx && opt_idx->depends_on(*cdef);
+        };
+        if (_partition_key_restrictions->needs_filtering(*_schema)) {
+            for (auto&& cdef : _partition_key_restrictions->get_column_defs()) {
+                if (!column_uses_indexing(cdef)) {
+                    column_defs_for_filtering.emplace_back(cdef);
+                }
+            }
+        }
+        if (_clustering_columns_restrictions->needs_filtering(*_schema)) {
+            column_id first_non_prefix_id = _schema->clustering_key_columns().begin()->id +
+                    _clustering_columns_restrictions->prefix_size(_schema);
+            for (auto&& cdef : _clustering_columns_restrictions->get_column_defs()) {
+                if ((!column_uses_indexing(cdef)) && (cdef->id >= first_non_prefix_id)) {
+                    column_defs_for_filtering.emplace_back(cdef);
+                }
+            }
+        }
+        for (auto&& cdef : _nonprimary_key_restrictions->get_column_defs()) {
+            if (!column_uses_indexing(cdef)) {
+                column_defs_for_filtering.emplace_back(cdef);
+            }
+        }
+    }
+    return column_defs_for_filtering;
+}
+
 void statement_restrictions::process_partition_key_restrictions(bool has_queriable_index, bool for_view, bool allow_filtering) {
     // If there is a queriable index, no special condition are required on the other restrictions.
     // But we still need to know 2 things:

--- a/cql3/restrictions/statement_restrictions.hh
+++ b/cql3/restrictions/statement_restrictions.hh
@@ -164,6 +164,13 @@ public:
     }
 
     /**
+     * Builds a possibly empty collection of column definitions that will be used for filtering
+     * @param db - the database context
+     * @return A list with the column definitions needed for filtering.
+     */
+    std::vector<const column_definition*> get_column_defs_for_filtering(database& db) const;
+
+    /**
      * Determines the index to be used with the restriction.
      * @param db - the database context (for extracting index manager)
      * @return If an index can be used, an optional containing this index, otherwise an empty optional.

--- a/cql3/restrictions/statement_restrictions.hh
+++ b/cql3/restrictions/statement_restrictions.hh
@@ -164,6 +164,13 @@ public:
     }
 
     /**
+     * Determines the index to be used with the restriction.
+     * @param db - the database context (for extracting index manager)
+     * @return If an index can be used, an optional containing this index, otherwise an empty optional.
+     */
+    std::optional<secondary_index::index> find_idx(secondary_index::secondary_index_manager& sim) const;
+
+    /**
      * Checks if the partition key has some unrestricted components.
      * @return <code>true</code> if the partition key has some unrestricted components, <code>false</code> otherwise.
      */

--- a/cql3/selection/selection.cc
+++ b/cql3/selection/selection.cc
@@ -156,9 +156,9 @@ public:
         return _factories->uses_function(ks_name, function_name);
     }
 
-    virtual uint32_t add_column_for_ordering(const column_definition& c) override {
-        uint32_t index = selection::add_column_for_ordering(c);
-        _factories->add_selector_for_ordering(c, index);
+    virtual uint32_t add_column_for_post_processing(const column_definition& c) override {
+        uint32_t index = selection::add_column_for_post_processing(c);
+        _factories->add_selector_for_post_processing(c, index);
         return index;
     }
 
@@ -227,7 +227,7 @@ protected:
     return simple_selection::make(schema, std::move(columns), false);
 }
 
-uint32_t selection::add_column_for_ordering(const column_definition& c) {
+uint32_t selection::add_column_for_post_processing(const column_definition& c) {
     _columns.push_back(&c);
     _metadata->add_non_serialized_column(c.column_specification);
     return _columns.size() - 1;

--- a/cql3/selection/selection.hh
+++ b/cql3/selection/selection.hh
@@ -176,7 +176,7 @@ public:
     static ::shared_ptr<selection> wildcard(schema_ptr schema);
     static ::shared_ptr<selection> for_columns(schema_ptr schema, std::vector<const column_definition*> columns);
 
-    virtual uint32_t add_column_for_ordering(const column_definition& c);
+    virtual uint32_t add_column_for_post_processing(const column_definition& c);
 
     virtual bool uses_function(const sstring &ks_name, const sstring& function_name) const {
         return false;

--- a/cql3/selection/selector_factories.cc
+++ b/cql3/selection/selector_factories.cc
@@ -76,7 +76,7 @@ bool selector_factories::uses_function(const sstring& ks_name, const sstring& fu
     return false;
 }
 
-void selector_factories::add_selector_for_ordering(const column_definition& def, uint32_t index) {
+void selector_factories::add_selector_for_post_processing(const column_definition& def, uint32_t index) {
     _factories.emplace_back(simple_selector::new_factory(def.name_as_text(), index, def.type));
 }
 

--- a/cql3/selection/selector_factories.hh
+++ b/cql3/selection/selector_factories.hh
@@ -97,11 +97,12 @@ public:
     bool uses_function(const sstring& ks_name, const sstring& function_name) const;
 
     /**
-     * Adds a new <code>Selector.Factory</code> for a column that is needed only for ORDER BY purposes.
+     * Adds a new <code>Selector.Factory</code> for a column that is needed only for ORDER BY or post
+     * processing purposes.
      * @param def the column that is needed for ordering
      * @param index the index of the column definition in the Selection's list of columns
      */
-    void add_selector_for_ordering(const column_definition& def, uint32_t index);
+    void add_selector_for_post_processing(const column_definition& def, uint32_t index);
 
     /**
      * Checks if this <code>SelectorFactories</code> contains only factories for aggregates.

--- a/cql3/statements/raw/select_statement.hh
+++ b/cql3/statements/raw/select_statement.hh
@@ -141,6 +141,10 @@ private:
     /** If ALLOW FILTERING was not specified, this verifies that it is not needed */
     void check_needs_filtering(::shared_ptr<restrictions::statement_restrictions> restrictions);
 
+    void ensure_filtering_columns_retrieval(database& db,
+                                            ::shared_ptr<selection::selection> selection,
+                                            ::shared_ptr<restrictions::statement_restrictions> restrictions);
+
     bool contains_alias(::shared_ptr<column_identifier> name);
 
     ::shared_ptr<column_specification> limit_receiver();

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -1252,7 +1252,7 @@ select_statement::get_ordering_comparator(schema_ptr schema,
         }
         auto index = selection->index_of(*def);
         if (index < 0) {
-            index = selection->add_column_for_ordering(*def);
+            index = selection->add_column_for_post_processing(*def);
         }
 
         sorters.emplace_back(index, def->type);

--- a/cql3/statements/select_statement.hh
+++ b/cql3/statements/select_statement.hh
@@ -186,10 +186,6 @@ public:
                                    schema_ptr view_schema);
 
 private:
-    static stdx::optional<secondary_index::index> find_idx(database& db,
-                                                           schema_ptr schema,
-                                                           ::shared_ptr<restrictions::statement_restrictions> restrictions);
-
     virtual future<::shared_ptr<cql_transport::messages::result_message>> do_execute(service::storage_proxy& proxy,
                                                                                      service::query_state& state, const query_options& options) override;
 

--- a/tests/cql_assertions.cc
+++ b/tests/cql_assertions.cc
@@ -143,3 +143,11 @@ rows_assertions result_msg_assertions::is_rows() {
 result_msg_assertions assert_that(shared_ptr<cql_transport::messages::result_message> msg) {
     return result_msg_assertions(msg);
 }
+
+rows_assertions rows_assertions::with_serialized_columns_count(size_t columns_count) {
+    size_t serialized_column_count = _rows->rs().get_metadata().column_count();
+    if (serialized_column_count != columns_count) {
+        fail(sprint("Expected %d serialized columns(s) but got %d", columns_count, serialized_column_count));
+    }
+    return {*this};
+}

--- a/tests/cql_assertions.hh
+++ b/tests/cql_assertions.hh
@@ -40,6 +40,7 @@ public:
     rows_assertions with_rows(std::initializer_list<std::initializer_list<bytes_opt>> rows);
     // Verifies that the result has the following rows and only those rows.
     rows_assertions with_rows_ignore_order(std::vector<std::vector<bytes_opt>> rows);
+    rows_assertions with_serialized_columns_count(size_t columns_count);
 };
 
 class result_msg_assertions {

--- a/tests/cql_query_test.cc
+++ b/tests/cql_query_test.cc
@@ -4053,3 +4053,74 @@ SEASTAR_TEST_CASE(test_select_with_mixed_order_table) {
         }
     });
 }
+
+SEASTAR_TEST_CASE(test_filtering) {
+    return do_with_cql_env_thread([] (cql_test_env& e) {
+        e.execute_cql("CREATE TABLE cf (k int, v int,m int,n int,o int,p int static, PRIMARY KEY ((k,v),m,n));").get();
+        e.execute_cql(
+                "BEGIN UNLOGGED BATCH \n"
+                "INSERT INTO cf (k, v, m, n, o, p) VALUES (1, 1, 1, 1, 1 ,1 ); \n"
+                "INSERT INTO cf (k, v, m, n, o, p) VALUES (2, 1, 2, 1, 2 ,2 ); \n"
+                "INSERT INTO cf (k, v, m, n, o, p) VALUES (3, 1, 3, 1, 3 ,3 ); \n"
+                "INSERT INTO cf (k, v, m, n, o, p) VALUES (4, 2, 1, 2, 4 ,4 ); \n"
+                "INSERT INTO cf (k, v, m, n, o, p) VALUES (5, 2, 2, 2, 5 ,5 ); \n"
+                "INSERT INTO cf (k, v, m, n, o, p) VALUES (6, 2, 3, 2, 6 ,6 ); \n"
+                "INSERT INTO cf (k, v, m, n, o, p) VALUES (7, 3, 1, 3, 7 ,7 ); \n"
+                "INSERT INTO cf (k, v, m, n, o, p) VALUES (8, 3, 2, 3, 8 ,8 ); \n"
+                "INSERT INTO cf (k, v, m, n, o, p) VALUES (9, 3, 3, 3, 9 ,9 ); \n"
+                "INSERT INTO cf (k, v, m, n, o, p) VALUES (10, 4, 1, 4,10,10); \n"
+                "INSERT INTO cf (k, v, m, n, o, p) VALUES (11, 4, 2, 4,11,11); \n"
+                "INSERT INTO cf (k, v, m, n, o, p) VALUES (12, 5, 3, 5,12,12); \n"
+                "INSERT INTO cf (k, v, m, n, o, p) VALUES (12, 5, 4, 5,13,13); \n"
+                "APPLY BATCH;"
+        ).get();
+
+        // Notice the with_serialized_columns_count() check before the set comparison.
+        // Since we are dealing with the result set before serializing to the client,
+        // there is an extra column that is used for the filtering, this column will
+        // not be present in the responce to the client and with_serialized_columns_count()
+        // verifies exactly that.
+
+        // test filtering on partition keys
+        {
+            auto msg = e.execute_cql("SELECT k FROM cf WHERE v=3 ALLOW FILTERING;").get0();
+            assert_that(msg).is_rows().with_serialized_columns_count(1).with_rows_ignore_order({
+                { int32_type->decompose(7), int32_type->decompose(3)},
+                { int32_type->decompose(8), int32_type->decompose(3) },
+                { int32_type->decompose(9), int32_type->decompose(3) },
+            });
+        }
+
+        // test filtering on clustering keys
+        {
+            auto msg = e.execute_cql("SELECT k FROM cf WHERE n=4 ALLOW FILTERING;").get0();
+            assert_that(msg).is_rows().with_serialized_columns_count(1).with_rows_ignore_order({
+                { int32_type->decompose(10), int32_type->decompose(4) },
+                { int32_type->decompose(11), int32_type->decompose(4) },
+            });
+        }
+
+        //test filtering on regular columns
+        {
+            auto msg = e.execute_cql("SELECT k FROM cf WHERE o>7 ALLOW FILTERING;").get0();
+            assert_that(msg).is_rows().with_serialized_columns_count(1).with_rows_ignore_order({
+                { int32_type->decompose(8),  int32_type->decompose(8) },
+                { int32_type->decompose(9),  int32_type->decompose(9) },
+                { int32_type->decompose(10), int32_type->decompose(10) },
+                { int32_type->decompose(11), int32_type->decompose(11) },
+                { int32_type->decompose(12), int32_type->decompose(12) },
+                { int32_type->decompose(12), int32_type->decompose(13) },
+            });
+        }
+
+        //test filtering on static columns
+        {
+            auto msg = e.execute_cql("SELECT k FROM cf WHERE p>=10 AND p<=12 ALLOW FILTERING;").get0();
+            assert_that(msg).is_rows().with_serialized_columns_count(1).with_rows_ignore_order({
+                { int32_type->decompose(10), int32_type->decompose(10) },
+                { int32_type->decompose(11), int32_type->decompose(11) },
+            });
+        }
+
+    });
+}


### PR DESCRIPTION
This patchset fixes issue 3803. When a select statement with filtering
is executed and the column that is needed for the filtering is not
present in the select clause, rows that should have been filtered out
according to this column will still be present in the result set.

Eliran Sinvani (6):
  cql3 : rename selection metadata manipulation functions
  cql3 : add prefix size common functionality to all clustering
    restrictions
  cql3 : refactor find_idx to be part of statement restrictions object
  cql3 : ensure retrieval of columns for filtering
  cql3 unit test: add assertion for the number of serialized coumns
  unit test: add test for filtering queries without the filtered column

 cql3/restrictions/primary_key_restrictions.hh | 25 +++++++
 cql3/restrictions/restrictions.hh             | 17 +++++
 .../single_column_restrictions.hh             | 16 -----
 cql3/restrictions/statement_restrictions.cc   | 49 +++++++++++++
 cql3/restrictions/statement_restrictions.hh   | 14 ++++
 cql3/selection/selection.cc                   |  8 +--
 cql3/selection/selection.hh                   |  2 +-
 cql3/selection/selector_factories.cc          |  2 +-
 cql3/selection/selector_factories.hh          |  5 +-
 cql3/statements/raw/select_statement.hh       |  4 ++
 cql3/statements/select_statement.cc           | 42 +++++------
 cql3/statements/select_statement.hh           |  4 --
 tests/cql_assertions.cc                       |  8 +++
 tests/cql_assertions.hh                       |  1 +
 tests/cql_query_test.cc                       | 71 +++++++++++++++++++
 15 files changed, 220 insertions(+), 48 deletions(-)
