### PR TITLE
normalized python3 compatibility, shebang and encoding

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1,4 +1,5 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2015 ScyllaDB
 #

--- a/dist/ami/files/scylla_install_ami
+++ b/dist/ami/files/scylla_install_ami
@@ -1,4 +1,5 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
 #
 # Copyright 2018 ScyllaDB
 #

--- a/dist/common/scripts/hex2list.py
+++ b/dist/common/scripts/hex2list.py
@@ -1,4 +1,5 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
 #
 # Copyright 2016 ScyllaDB
 #

--- a/dist/common/scripts/node_exporter_install
+++ b/dist/common/scripts/node_exporter_install
@@ -1,4 +1,5 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
 #
 # Copyright 2018 ScyllaDB
 #

--- a/dist/common/scripts/scylla-blocktune
+++ b/dist/common/scripts/scylla-blocktune
@@ -1,5 +1,5 @@
-#!/usr/bin/python3
-
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2018 ScyllaDB
 #

--- a/dist/common/scripts/scylla_blocktune.py
+++ b/dist/common/scripts/scylla_blocktune.py
@@ -1,5 +1,5 @@
-#!/usr/bin/python3
-
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2016 ScyllaDB
 #

--- a/dist/common/scripts/scylla_bootparam_setup
+++ b/dist/common/scripts/scylla_bootparam_setup
@@ -1,4 +1,5 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
 #
 # Copyright 2018 ScyllaDB
 #

--- a/dist/common/scripts/scylla_config_get.py
+++ b/dist/common/scripts/scylla_config_get.py
@@ -1,4 +1,5 @@
-#!/usr/bin/python2
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
 #
 # Copyright 2016 ScyllaDB
 #

--- a/dist/common/scripts/scylla_coredump_setup
+++ b/dist/common/scripts/scylla_coredump_setup
@@ -1,4 +1,5 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
 #
 # Copyright 2018 ScyllaDB
 #

--- a/dist/common/scripts/scylla_cpuscaling_setup
+++ b/dist/common/scripts/scylla_cpuscaling_setup
@@ -1,4 +1,5 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
 #
 # Copyright 2018 ScyllaDB
 #

--- a/dist/common/scripts/scylla_cpuset_setup
+++ b/dist/common/scripts/scylla_cpuset_setup
@@ -1,4 +1,5 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
 #
 # Copyright 2018 ScyllaDB
 #

--- a/dist/common/scripts/scylla_dev_mode_setup
+++ b/dist/common/scripts/scylla_dev_mode_setup
@@ -1,4 +1,5 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
 #
 # Copyright 2018 ScyllaDB
 #

--- a/dist/common/scripts/scylla_ec2_check
+++ b/dist/common/scripts/scylla_ec2_check
@@ -1,4 +1,5 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
 #
 # Copyright 2018 ScyllaDB
 #

--- a/dist/common/scripts/scylla_fstrim
+++ b/dist/common/scripts/scylla_fstrim
@@ -1,4 +1,5 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
 #
 # Copyright 2017 ScyllaDB
 #

--- a/dist/common/scripts/scylla_fstrim_setup
+++ b/dist/common/scripts/scylla_fstrim_setup
@@ -1,4 +1,5 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
 #
 # Copyright 2018 ScyllaDB
 #

--- a/dist/common/scripts/scylla_io_setup
+++ b/dist/common/scripts/scylla_io_setup
@@ -1,6 +1,9 @@
-#!/usr/bin/python3
-
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
 # Copyright (C) 2017 ScyllaDB
+#
+
 #
 # This file is part of Scylla.
 #

--- a/dist/common/scripts/scylla_kernel_check
+++ b/dist/common/scripts/scylla_kernel_check
@@ -1,4 +1,5 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
 #
 # Copyright 2018 ScyllaDB
 #

--- a/dist/common/scripts/scylla_ntp_setup
+++ b/dist/common/scripts/scylla_ntp_setup
@@ -1,4 +1,5 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
 #
 # Copyright 2018 ScyllaDB
 #

--- a/dist/common/scripts/scylla_prepare
+++ b/dist/common/scripts/scylla_prepare
@@ -1,4 +1,5 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
 #
 # Copyright 2018 ScyllaDB
 #
@@ -58,7 +59,7 @@ if __name__ == '__main__':
         for n in glob.glob('/sys/devices/system/node/node?'):
             with open('{n}/hugepages/hugepages-2048kB/nr_hugepages'.format(n=n), 'w') as f:
                 f.write(nr_hugepages)
-        if dist_name() == 'Ubuntu': 
+        if dist_name() == 'Ubuntu':
             run('hugeadm --create-mounts')
         fi
     else:

--- a/dist/common/scripts/scylla_raid_setup
+++ b/dist/common/scripts/scylla_raid_setup
@@ -1,4 +1,5 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
 #
 # Copyright 2018 ScyllaDB
 #

--- a/dist/common/scripts/scylla_selinux_setup
+++ b/dist/common/scripts/scylla_selinux_setup
@@ -1,4 +1,5 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
 #
 # Copyright 2018 ScyllaDB
 #

--- a/dist/common/scripts/scylla_setup
+++ b/dist/common/scripts/scylla_setup
@@ -1,4 +1,5 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
 #
 # Copyright 2018 ScyllaDB
 #

--- a/dist/common/scripts/scylla_stop
+++ b/dist/common/scripts/scylla_stop
@@ -1,4 +1,5 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
 #
 # Copyright 2018 ScyllaDB
 #
@@ -32,7 +33,7 @@ if __name__ == '__main__':
     else:
         cfg = sysconfig_parser('/etc/default/scylla-server')
 
-    
+
     if cfg.get('NETWORK_MODE') == 'virtio':
         run('ip tuntap del mode tap dev {TAP}'.format(TAP=cfg.get('TAP')))
     elif cfg.get('NETWORK_MODE') == 'dpdk':

--- a/dist/common/scripts/scylla_sysconfig_setup
+++ b/dist/common/scripts/scylla_sysconfig_setup
@@ -1,4 +1,5 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
 #
 # Copyright 2018 ScyllaDB
 #

--- a/dist/docker/redhat/docker-entrypoint.py
+++ b/dist/docker/redhat/docker-entrypoint.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
 import os
 import sys
 import scyllasetup

--- a/fix_system_distributed_tables.py
+++ b/fix_system_distributed_tables.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
 #
 # Copyright 2017 ScyllaDB
 #
@@ -121,7 +122,7 @@ def validate_and_fix(args):
                     print("{}.{} doesn't exist - skipping".format(ks, table_name))
                     continue
 
-                print "Adjusting {}.{}".format(ks, table_name)
+                print("Adjusting {}.{}".format(ks, table_name))
 
                 table_meta = ks_meta.tables[table_name]
                 for column_name, column_type in table_cols.items():
@@ -133,12 +134,12 @@ def validate_and_fix(args):
                     else:
                         try:
                             session.execute("ALTER TABLE {}.{} ADD {} {}".format(ks, table_name, column_name, column_type))
-                            print "{}.{}: added column '{}' of the type '{}'".format(ks, table_name, column_name, column_type)
+                            print("{}.{}: added column '{}' of the type '{}'".format(ks, table_name, column_name, column_type))
                         except Exception:
-                            print "ERROR: {}.{}: failed to add column '{}' with type '{}': {}".format(ks, table_name, column_name, column_type, sys.exc_info())
+                            print("ERROR: {}.{}: failed to add column '{}' with type '{}': {}".format(ks, table_name, column_name, column_type, sys.exc_info()))
                             res = False
     except Exception:
-        print "ERROR: {}".format(sys.exc_info())
+        print("ERROR: {}".format(sys.exc_info()))
         res = False
 
     return res

--- a/gen_segmented_compress_params.py
+++ b/gen_segmented_compress_params.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-
+# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2017 ScyllaDB
 #

--- a/idl-compiler.py
+++ b/idl-compiler.py
@@ -1,4 +1,5 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
 #
 # Copyright 2016 ScyllaDB
 #

--- a/scripts/create-relocatable-package.py
+++ b/scripts/create-relocatable-package.py
@@ -1,5 +1,5 @@
-#!/usr/bin/python3
-
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2018 ScyllaDB
 #

--- a/scripts/find-maintainer
+++ b/scripts/find-maintainer
@@ -1,4 +1,5 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
 
 import argparse
 import fnmatch

--- a/scripts/jobs
+++ b/scripts/jobs
@@ -1,5 +1,5 @@
-#!/usr/bin/python3
-
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2018 ScyllaDB
 #

--- a/scylla-gdb.py
+++ b/scylla-gdb.py
@@ -1,3 +1,6 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
 import gdb
 import gdb.printing
 import uuid

--- a/scylla-housekeeping
+++ b/scylla-housekeeping
@@ -1,4 +1,5 @@
-#!/usr/bin/python2
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2016 ScyllaDB
 #
@@ -19,17 +20,13 @@
 # You should have received a copy of the GNU General Public License
 # along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
 #
-from __future__ import print_function
 
 import argparse
 import json
-import urllib
-import urllib2
-import requests
-import ConfigParser
 import os
 import sys
 import subprocess
+import configparser
 import uuid
 import re
 import glob
@@ -40,36 +37,45 @@ quiet = False
 # Temporary url for the review
 version_url = "https://i6a5h9l1kl.execute-api.us-east-1.amazonaws.com/prod/check_version"
 
+
 def trace(*vals):
     print(''.join(vals))
+
 
 def traceln(*vals):
     trace(*(vals + ('\n',)))
 
+
 def help(args):
     parser.print_help()
 
+
 def sh_command(*args):
     p = subprocess.Popen(args, stdout=subprocess.PIPE,
-                                    stderr=subprocess.PIPE)
+                         stderr=subprocess.PIPE)
     out, err = p.communicate()
     if err:
         raise Exception(err)
     return out
 
+
 def get_json_from_url(path):
     data = sh_command("curl", "-s", "-X", "GET", path)
     return json.loads(data)
 
+
 def get_api(path):
     return get_json_from_url("http://" + api_address + path)
+
 
 def version_compare(a, b):
     return parse_version(a) < parse_version(b)
 
+
 def create_uuid_file(fl):
     with open(args.uuid_file, 'w') as myfile:
         myfile.write(str(uuid.uuid1()) + "\n")
+
 
 def sanitize_version(version):
     """
@@ -81,6 +87,7 @@ def sanitize_version(version):
     else:
         return version
 
+
 def get_repo_file(dir):
     files = glob.glob(dir)
     files.sort(key=os.path.getmtime, reverse=True)
@@ -91,6 +98,7 @@ def get_repo_file(dir):
                 if match:
                     return match.group(2), match.group(1)
     return None, None
+
 
 def check_version(ar):
     if config and (not config.has_option("housekeeping", "check-version") or not config.getboolean("housekeeping", "check-version")):
@@ -117,7 +125,7 @@ def check_version(ar):
         versions = get_json_from_url(version_url + params)
         latest_version = versions["version"]
         latest_patch_version = versions["latest_patch_version"]
-    except:
+    except Exception:
         traceln("Unable to retrieve version information")
         return
 
@@ -131,6 +139,7 @@ def check_version(ar):
             traceln("You current Scylla release is ", current_version, " the latest minor release is ", latest_version, " go to http://www.scylladb.com for upgrade instructions")
     elif version_compare(current_version, latest_patch_version):
             traceln("You current Scylla release is ", current_version, " while the latest patch release is ", latest_patch_version, ", update for the latest bug fixes and improvements")
+
 
 parser = argparse.ArgumentParser(description='ScyllaDB help report tool', conflict_handler="resolve")
 parser.add_argument('-q', '--quiet', action='store_true', default=False, help='Quiet mode')
@@ -158,7 +167,7 @@ if args.config != "":
     if not os.path.isfile(args.config):
         traceln("Config file ", args.config, " is missing, terminating")
         sys.exit(0)
-    config = ConfigParser.SafeConfigParser()
+    config = configparser.SafeConfigParser()
     config.read(args.config)
 uid = None
 if args.uuid != "":

--- a/setup.py
+++ b/setup.py
@@ -9,4 +9,13 @@ setup(
     platforms='any',
     packages=find_packages(),
     include_package_data=True,
-    install_requires=[])
+    install_requires=[],
+    classifiers=[
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.4",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+    ],
+)

--- a/test.py
+++ b/test.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2015 ScyllaDB
 #

--- a/tools/scyllatop/prometheus.py
+++ b/tools/scyllatop/prometheus.py
@@ -1,5 +1,3 @@
-#! /usr/bin/python
-
 import urllib2
 import re
 

--- a/tools/scyllatop/scyllatop.py
+++ b/tools/scyllatop/scyllatop.py
@@ -1,4 +1,6 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
 import argparse
 import sys
 import threading


### PR DESCRIPTION
This series of patches ensures that all the Python code base is python3 compliant
and consistent by applying the following logic:

- python3 classifier on setup.py to explicitly state our python compatibility matrix
- add UTF-8 encoding header
- correct every shebang to the same /usr/bin/env python3
- shebang is only added on scripts meant to be executed on their own (removed otherwise)
- migrate some leftover scripts from python2 to python3 with minimal QA

This work is important to prepare for a more drastic change on Python code styling
using the black formatter and the setting up of automated QA checks on Python code base.