### PR TITLE
tests.py: increase default timeout from 300s to 1800s

### DIFF
--- a/test.py
+++ b/test.py
@@ -194,7 +194,7 @@ if __name__ == "__main__":
                         help="Run only test whose name contains given string")
     parser.add_argument('--mode', choices=all_modes,
                         help="Run only tests for given build mode")
-    parser.add_argument('--timeout', action="store", default="300", type=int,
+    parser.add_argument('--timeout', action="store", default="1800", type=int,
                         help="timeout value for test execution")
     parser.add_argument('--jenkins', action="store",
                         help="jenkins output file prefix")


### PR DESCRIPTION
network_topology_strategy_test takes more than 300s to run which
makes default tests.py fail if one does not tune its timeout.

network_topology_strategy_test takes roughly 19min to run so 30min
seems like a sane test.py timeout default.

Note: This has not been picked by Jenkins CI because the scylladb
jenkins uses a "--timeout 30000" parameter.
