### PR TITLE
thrift/: support version 0.11+ after THRIFT-2221 (fix #3097)

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -25,7 +25,7 @@ Running `./install-dependencies.sh` (as root) installs the appropriate packages 
 On Ubuntu and Debian based Linux distributions, some packages
 required to build Scylla are missing in the official upstream:
 
-- libthrift-dev and libthrift, version 0.9 or 0.10 (0.11 won't work)
+- libthrift-dev and libthrift
 - antlr3-c++-dev
 
 Try running ```sudo ./scripts/scylla_current_repo``` to add Scylla upstream,

--- a/configure.py
+++ b/configure.py
@@ -1125,6 +1125,12 @@ if not os.path.exists(xxhash_dir) or not os.listdir(xxhash_dir):
 if not args.staticboost:
     args.user_cflags += ' -DBOOST_TEST_DYN_LINK'
 
+# thrift version detection, see #4538
+thrift_version = subprocess.check_output(["thrift", "-version"]).decode("utf-8").split(" ")[-1]
+thrift_boost_versions = ["0.{}.".format(n) for n in range(1, 11)]
+if any(filter(thrift_version.startswith, thrift_boost_versions)):
+    args.user_cflags += ' -DTHRIFT_USES_BOOST'
+
 for pkg in pkgs:
     args.user_cflags += ' ' + pkg_config(pkg, '--cflags')
     libs += ' ' + pkg_config(pkg, '--libs')

--- a/thrift/server.cc
+++ b/thrift/server.cc
@@ -41,7 +41,10 @@
 #include <limits>
 #include <cctype>
 #include <vector>
+
+#ifdef THRIFT_USES_BOOST
 #include <boost/make_shared.hpp>
+#endif
 
 static logging::logger tlogger("thrift");
 
@@ -97,9 +100,9 @@ struct thrift_server::connection::fake_transport : TTransport {
 thrift_server::connection::connection(thrift_server& server, connected_socket&& fd, socket_address addr)
         : _server(server), _fd(std::move(fd)), _read_buf(_fd.input())
         , _write_buf(_fd.output())
-        , _transport(boost::make_shared<thrift_server::connection::fake_transport>(this))
-        , _input(boost::make_shared<TMemoryBuffer>())
-        , _output(boost::make_shared<TMemoryBuffer>())
+        , _transport(thrift_std::make_shared<thrift_server::connection::fake_transport>(this))
+        , _input(thrift_std::make_shared<TMemoryBuffer>())
+        , _output(thrift_std::make_shared<TMemoryBuffer>())
         , _in_proto(_server._protocol_factory->getProtocol(_input))
         , _out_proto(_server._protocol_factory->getProtocol(_output))
         , _processor(_server._processor_factory->getProcessor({ _in_proto, _out_proto, _transport })) {

--- a/thrift/server.hh
+++ b/thrift/server.hh
@@ -35,6 +35,12 @@ class thrift_server;
 class thrift_stats;
 class database;
 
+#ifdef THRIFT_USES_BOOST
+namespace thrift_std = boost;
+#else
+namespace thrift_std = std;
+#endif
+
 namespace cassandra {
 
 static const sstring thrift_version = "20.1.0";
@@ -80,12 +86,12 @@ class thrift_server {
         input_stream<char> _read_buf;
         output_stream<char> _write_buf;
         temporary_buffer<char> _in_tmp;
-        boost::shared_ptr<fake_transport> _transport;
-        boost::shared_ptr<apache::thrift::transport::TMemoryBuffer> _input;
-        boost::shared_ptr<apache::thrift::transport::TMemoryBuffer> _output;
-        boost::shared_ptr<apache::thrift::protocol::TProtocol> _in_proto;
-        boost::shared_ptr<apache::thrift::protocol::TProtocol> _out_proto;
-        boost::shared_ptr<apache::thrift::async::TAsyncProcessor> _processor;
+        thrift_std::shared_ptr<fake_transport> _transport;
+        thrift_std::shared_ptr<apache::thrift::transport::TMemoryBuffer> _input;
+        thrift_std::shared_ptr<apache::thrift::transport::TMemoryBuffer> _output;
+        thrift_std::shared_ptr<apache::thrift::protocol::TProtocol> _in_proto;
+        thrift_std::shared_ptr<apache::thrift::protocol::TProtocol> _out_proto;
+        thrift_std::shared_ptr<apache::thrift::async::TAsyncProcessor> _processor;
         promise<> _processor_promise;
     public:
         connection(thrift_server& server, connected_socket&& fd, socket_address addr);
@@ -101,9 +107,9 @@ class thrift_server {
 private:
     std::vector<server_socket> _listeners;
     std::unique_ptr<thrift_stats> _stats;
-    boost::shared_ptr<::cassandra::CassandraCobSvIfFactory> _handler_factory;
+    thrift_std::shared_ptr<::cassandra::CassandraCobSvIfFactory> _handler_factory;
     std::unique_ptr<apache::thrift::protocol::TProtocolFactory> _protocol_factory;
-    boost::shared_ptr<apache::thrift::async::TAsyncProcessorFactory> _processor_factory;
+    thrift_std::shared_ptr<apache::thrift::async::TAsyncProcessorFactory> _processor_factory;
     uint64_t _total_connections = 0;
     uint64_t _current_connections = 0;
     uint64_t _requests_served = 0;


### PR DESCRIPTION
Thrift 0.11 changed to generate c++ code with
std::shared_ptr instead of boost::shared_ptr.

- https://issues.apache.org/jira/browse/THRIFT-2221

This was forcing scylla to stick with older versions
of thrift.

Fixes issue #3097.
