### PR TITLE
tests: add test for filtering+paging+aggregation

### DIFF
--- a/tests/filtering_test.cc
+++ b/tests/filtering_test.cc
@@ -1153,3 +1153,27 @@ SEASTAR_TEST_CASE(test_filtering) {
 
     });
 }
+
+SEASTAR_TEST_CASE(test_filtering_paging_and_aggregation) {
+    return do_with_cql_env_thread([] (cql_test_env& e) {
+        e.execute_cql("CREATE TABLE fpa (id int primary key, v int)").get();
+        for (int i = 0; i < 1000; ++i) {
+            e.execute_cql(format("INSERT INTO fpa (id, v) VALUES ({}, {})", i, i % 2)).get();
+        }
+
+        auto qo = std::make_unique<cql3::query_options>(db::consistency_level::LOCAL_ONE, infinite_timeout_config, std::vector<cql3::raw_value>{},
+                cql3::query_options::specific_options{2, nullptr, {}, api::new_timestamp()});
+        auto msg = e.execute_cql("SELECT sum(id) FROM fpa WHERE v = 0 ALLOW FILTERING;", std::move(qo)).get0();
+        // Even though we set up paging, we still expect a single result from an aggregation function
+        assert_that(msg).is_rows().with_rows({
+            { int32_type->decompose(249500), int32_type->decompose(0)},
+        });
+
+        qo = std::make_unique<cql3::query_options>(db::consistency_level::LOCAL_ONE, infinite_timeout_config, std::vector<cql3::raw_value>{},
+                cql3::query_options::specific_options{3, nullptr, {}, api::new_timestamp()});
+        msg = e.execute_cql("SELECT avg(id) FROM fpa WHERE v = 1 ALLOW FILTERING;", std::move(qo)).get0();
+        assert_that(msg).is_rows().with_rows({
+            { int32_type->decompose(500), int32_type->decompose(1)},
+        });
+    });
+}


### PR DESCRIPTION
The test case ensures that filtering with paging works fine if
an aggretation function is used - the results should be presented
as a single aggregated value, without partial results per-page.

Ref #4540