### PR TITLE
tools: toolchain: update to Fedora 30 / gcc 9

### DIFF
--- a/tools/toolchain/Dockerfile
+++ b/tools/toolchain/Dockerfile
@@ -1,9 +1,8 @@
-FROM fedora:29
+FROM fedora:30
 ADD ./install-dependencies.sh ./
 ADD ./seastar/install-dependencies.sh ./seastar/
 ADD ./tools/toolchain/system-auth ./
-RUN dnf -y install 'dnf-command(copr)' \
-    && dnf -y copr enable scylladb/toolchain \
+RUN : \
     && dnf -y install ccache \
     && dnf -y install gdb \
     && /bin/bash -x ./install-dependencies.sh && dnf -y update && dnf clean all \

--- a/tools/toolchain/image
+++ b/tools/toolchain/image
@@ -1,1 +1,1 @@
-docker.io/scylladb/scylla-toolchain:fedora-29-20190603
+docker.io/scylladb/scylla-toolchain:fedora-30-20190617


### PR DESCRIPTION
Update the toolchain baseline to Fedora 30, which includes gcc 9.

Note to maintainer: even more than usual, this should be applied as a patch, because it is based on next rather than master. This is because only next supports gcc 9, and I'm too impatient to wait for promotion.