### PR TITLE
make sure failure to create snapshots won't crash the node

### DIFF
--- a/distributed_loader.cc
+++ b/distributed_loader.cc
@@ -610,7 +610,7 @@ future<> distributed_loader::cleanup_column_family_temp_sst_dirs(sstring sstdir)
             fs::path dirpath = sstdir / de.name;
             if (sstables::sstable::is_temp_dir(dirpath)) {
                 dblog.info("Found temporary sstable directory: {}, removing", dirpath);
-                futures.push_back(lister::rmdir(dirpath));
+                futures.push_back(io_check([dirpath = std::move(dirpath)] () { return lister::rmdir(dirpath); }));
             }
             return make_ready_future<>();
         }).then([&futures] {

--- a/lister.cc
+++ b/lister.cc
@@ -2,7 +2,6 @@
 #include <seastar/core/reactor.hh>
 #include <seastar/util/log.hh>
 #include "lister.hh"
-#include "disk-error-handler.hh"
 #include "checked-file-impl.hh"
 
 static seastar::logger llogger("lister");
@@ -69,10 +68,10 @@ future<> lister::rmdir(fs::path dir) {
         if (de.type.value() == directory_entry_type::directory) {
             return rmdir(std::move(current_entry_path));
         } else {
-            return io_check(remove_file, current_entry_path.native());
+            return remove_file(current_entry_path.native());
         }
     }).then([dir] {
         // ...then kill the directory itself
-        return io_check(remove_file, dir.native());
+        return remove_file(dir.native());
     });
 }


### PR DESCRIPTION
Issue #4558 describes a situation in which failure to execute clearsnapshots
will hard crash the node. The problem is that clearsnapshots will internally use
lister::rmdir, which in turn has two in-tree users: clearing snapshots and clearing
temporary directories during sstable creation. The way it is currently
coded, it wraps the io functions in io_check, which means that failures
to remove the directory will crash the database.
    
We recently saw how benign failures crashed a database during
clearsnapshot: we had snapshot creation running in parallel, adding more
files to the directory that wasn't empty by the time of deletion.  I
have also seen very often users add files to existing directories by
accident, which is another possibility to trigger that.
    
This patch removes the io_check from lister, and moves it to the caller
in which we want to be more strict. We still want to be strict about
the creation of temporary directories, since users shouldn't be touching
that in any way.

Also while working on that, I realized we have no tests for snapshots of
any kind in tree, so let's write some