### PR TITLE
Fix appending_hash<row> ignoring cells after first null

### DIFF
--- a/mutation_partition.cc
+++ b/mutation_partition.cc
@@ -680,7 +680,7 @@ void appending_hash<row>::operator()(Hasher& h, const row& cells, const schema& 
     for (auto id : columns) {
         const cell_and_hash* cell_and_hash = cells.find_cell_and_hash(id);
         if (!cell_and_hash) {
-            return;
+            continue;
         }
         auto&& def = s.column_at(kind, id);
         if (def.is_atomic()) {

--- a/mutation_partition.cc
+++ b/mutation_partition.cc
@@ -675,45 +675,45 @@ void write_counter_cell(RowWriter& w, const query::partition_slice& slice, ::ato
   });
 }
 
-    template<typename Hasher>
-    void appending_hash<row>::operator()(Hasher& h, const row& cells, const schema& s, column_kind kind, const query::column_id_vector& columns, max_timestamp& max_ts) const {
-        for (auto id : columns) {
-            const cell_and_hash* cell_and_hash = cells.find_cell_and_hash(id);
-            if (!cell_and_hash) {
-                return;
-            }
-            auto&& def = s.column_at(kind, id);
-            if (def.is_atomic()) {
-                max_ts.update(cell_and_hash->cell.as_atomic_cell(def).timestamp());
-                if constexpr (query::using_hash_of_hash_v<Hasher>) {
-                    if (cell_and_hash->hash) {
-                        feed_hash(h, *cell_and_hash->hash);
-                    } else {
-                        query::default_hasher cellh;
-                        feed_hash(cellh, cell_and_hash->cell.as_atomic_cell(def), def);
-                        feed_hash(h, cellh.finalize_uint64());
-                    }
+template<typename Hasher>
+void appending_hash<row>::operator()(Hasher& h, const row& cells, const schema& s, column_kind kind, const query::column_id_vector& columns, max_timestamp& max_ts) const {
+    for (auto id : columns) {
+        const cell_and_hash* cell_and_hash = cells.find_cell_and_hash(id);
+        if (!cell_and_hash) {
+            return;
+        }
+        auto&& def = s.column_at(kind, id);
+        if (def.is_atomic()) {
+            max_ts.update(cell_and_hash->cell.as_atomic_cell(def).timestamp());
+            if constexpr (query::using_hash_of_hash_v<Hasher>) {
+                if (cell_and_hash->hash) {
+                    feed_hash(h, *cell_and_hash->hash);
                 } else {
-                    feed_hash(h, cell_and_hash->cell.as_atomic_cell(def), def);
+                    query::default_hasher cellh;
+                    feed_hash(cellh, cell_and_hash->cell.as_atomic_cell(def), def);
+                    feed_hash(h, cellh.finalize_uint64());
                 }
             } else {
-                auto&& cm = cell_and_hash->cell.as_collection_mutation();
-                auto&& ctype = static_pointer_cast<const collection_type_impl>(def.type);
-                max_ts.update(ctype->last_update(cm));
-                if constexpr (query::using_hash_of_hash_v<Hasher>) {
-                    if (cell_and_hash->hash) {
-                        feed_hash(h, *cell_and_hash->hash);
-                    } else {
-                        query::default_hasher cellh;
-                        feed_hash(cellh, cm, def);
-                        feed_hash(h, cellh.finalize_uint64());
-                    }
+                feed_hash(h, cell_and_hash->cell.as_atomic_cell(def), def);
+            }
+        } else {
+            auto&& cm = cell_and_hash->cell.as_collection_mutation();
+            auto&& ctype = static_pointer_cast<const collection_type_impl>(def.type);
+            max_ts.update(ctype->last_update(cm));
+            if constexpr (query::using_hash_of_hash_v<Hasher>) {
+                if (cell_and_hash->hash) {
+                    feed_hash(h, *cell_and_hash->hash);
                 } else {
-                    feed_hash(h, cm, def);
+                    query::default_hasher cellh;
+                    feed_hash(cellh, cm, def);
+                    feed_hash(h, cellh.finalize_uint64());
                 }
+            } else {
+                feed_hash(h, cm, def);
             }
         }
     }
+}
 
 cell_hash_opt row::cell_hash_for(column_id id) const {
     if (_type == storage_type::vector) {

--- a/mutation_partition.cc
+++ b/mutation_partition.cc
@@ -675,19 +675,8 @@ void write_counter_cell(RowWriter& w, const query::partition_slice& slice, ::ato
   });
 }
 
-// Used to return the timestamp of the latest update to the row
-struct max_timestamp {
-    api::timestamp_type max = api::missing_timestamp;
-
-    void update(api::timestamp_type ts) {
-        max = std::max(max, ts);
-    }
-};
-
-template<>
-struct appending_hash<row> {
     template<typename Hasher>
-    void operator()(Hasher& h, const row& cells, const schema& s, column_kind kind, const query::column_id_vector& columns, max_timestamp& max_ts) const {
+    void appending_hash<row>::operator()(Hasher& h, const row& cells, const schema& s, column_kind kind, const query::column_id_vector& columns, max_timestamp& max_ts) const {
         for (auto id : columns) {
             const cell_and_hash* cell_and_hash = cells.find_cell_and_hash(id);
             if (!cell_and_hash) {
@@ -725,7 +714,6 @@ struct appending_hash<row> {
             }
         }
     }
-};
 
 cell_hash_opt row::cell_hash_for(column_id id) const {
     if (_type == storage_type::vector) {

--- a/mutation_partition.hh
+++ b/mutation_partition.hh
@@ -368,6 +368,21 @@ public:
     friend std::ostream& operator<<(std::ostream& os, const printer& p);
 };
 
+// Used to return the timestamp of the latest update to the row
+struct max_timestamp {
+    api::timestamp_type max = api::missing_timestamp;
+
+    void update(api::timestamp_type ts) {
+        max = std::max(max, ts);
+    }
+};
+
+template<>
+struct appending_hash<row> {
+    template<typename Hasher>
+    void operator()(Hasher& h, const row& cells, const schema& s, column_kind kind, const query::column_id_vector& columns, max_timestamp& max_ts) const;
+};
+
 class row_marker;
 int compare_row_marker_for_merge(const row_marker& left, const row_marker& right) noexcept;
 

--- a/tests/mutation_test.cc
+++ b/tests/mutation_test.cc
@@ -1860,3 +1860,36 @@ SEASTAR_THREAD_TEST_CASE(test_collection_compaction) {
     BOOST_CHECK(!cmut.tomb);
     BOOST_CHECK(cmut.cells.empty());
 }
+
+// Reproducer for #4567: "appending_hash<row> ignores cells after first null"
+SEASTAR_THREAD_TEST_CASE(test_appending_hash_row_4567) {
+    auto s = schema_builder("ks", "cf")
+        .with_column("pk", bytes_type, column_kind::partition_key)
+        .with_column("ck", bytes_type, column_kind::clustering_key)
+        .with_column("r1", bytes_type)
+        .with_column("r2", bytes_type)
+        .with_column("r3", bytes_type)
+        .build();
+
+    auto r1 = row();
+    r1.append_cell(0, atomic_cell::make_live(*bytes_type, 1, bytes{}));
+    r1.append_cell(2, atomic_cell::make_live(*bytes_type, 1, to_bytes("aaa")));
+
+    auto r2 = row();
+    r2.append_cell(0, atomic_cell::make_live(*bytes_type, 1, bytes{}));
+    r2.append_cell(2, atomic_cell::make_live(*bytes_type, 1, to_bytes("bbb")));
+
+    BOOST_CHECK(!r1.equal(column_kind::regular_column, *s, r2, *s));
+
+    auto compute_hash = [&] (const row& r, const query::column_id_vector& columns) {
+        auto hasher = xx_hasher{};
+        max_timestamp ts;
+        appending_hash<row>{}(hasher, r, *s, column_kind::regular_column, columns, ts);
+        return hasher.finalize_uint64();
+    };
+
+    BOOST_CHECK_EQUAL(compute_hash(r1, { 1 }), compute_hash(r2, { 1 }));
+    BOOST_CHECK_EQUAL(compute_hash(r1, { 0, 1 }), compute_hash(r2, { 0, 1 }));
+    BOOST_CHECK_NE(compute_hash(r1, { 0, 2 }), compute_hash(r2, { 0, 2 }));
+    BOOST_CHECK_NE(compute_hash(r1, { 0, 1, 2 }), compute_hash(r2, { 0, 1, 2 }));
+}


### PR DESCRIPTION
This series fixes a bug in `appending_hash<row>` that caused it to ignore any cells after the first missing one. A reproducer test case is included.