### PR TITLE
sstable: mc: reader: Optimize multi-partition scans for data sets with small partitions

### DIFF
--- a/sstables/mp_row_consumer.hh
+++ b/sstables/mp_row_consumer.hh
@@ -260,7 +260,9 @@ private:
         while (!_reader->is_buffer_full()) {
             auto mfo = _range_tombstones.get_next(_fwd_end);
             if (!mfo) {
-                _reader->on_out_of_clustering_range();
+                if (!_reader->_partition_finished) {
+                    _reader->on_out_of_clustering_range();
+                }
                 break;
             }
             _reader->push_mutation_fragment(std::move(*mfo));

--- a/sstables/mp_row_consumer.hh
+++ b/sstables/mp_row_consumer.hh
@@ -703,9 +703,12 @@ public:
     // Sets streamed_mutation::_end_of_range when there are no more fragments for the query range.
     // Returns information whether the parser should continue to parse more
     // input and produce more fragments or we have collected enough and should yield.
+    // Returns proceed:yes only when all pending fragments have been pushed.
     proceed push_ready_fragments() {
         if (_ready) {
-            return push_ready_fragments_with_ready_set();
+            if (push_ready_fragments_with_ready_set() == proceed::no) {
+                return proceed::no;
+            }
         }
 
         if (_out_of_range) {

--- a/sstables/mutation_fragment_filter.hh
+++ b/sstables/mutation_fragment_filter.hh
@@ -87,8 +87,8 @@ public:
             return result::store_and_finish;
         }
         bool inside_requested_ranges = _walker.advance_to(pos);
-        _out_of_range |= _walker.out_of_range();
         if (!inside_requested_ranges) {
+            _out_of_range |= _walker.out_of_range();
             return result::ignore;
         }
         return result::emit;
@@ -96,8 +96,8 @@ public:
 
     result apply(const range_tombstone& rt) {
         bool inside_requested_ranges = _walker.advance_to(rt.position(), rt.end_position());
-        _out_of_range |= _walker.out_of_range();
         if (!inside_requested_ranges) {
+            _out_of_range |= _walker.out_of_range();
             return result::ignore;
         }
         if (is_after_fwd_window(rt.position())) {

--- a/sstables/partition.cc
+++ b/sstables/partition.cc
@@ -330,8 +330,6 @@ private:
             throw malformed_sstable_exception("consumer not at partition boundary", _sst->get_filename());
         }
 
-        _sst->get_stats().on_partition_read();
-
         // It's better to obtain partition information from the index if we already have it.
         // We can save on IO if the user will skip past the front of partition immediately.
         //
@@ -402,6 +400,7 @@ private:
         _current_partition_key = std::move(key);
         push_mutation_fragment(
             mutation_fragment(partition_start(*_current_partition_key, tomb)));
+        _sst->get_stats().on_partition_read();
     }
     bool is_initialized() const {
         return bool(_context);

--- a/sstables/partition.cc
+++ b/sstables/partition.cc
@@ -413,7 +413,7 @@ private:
         return _initialize();
     }
 public:
-    void on_end_of_stream() {
+    void on_out_of_clustering_range() override {
         if (_fwd == streamed_mutation::forwarding::yes) {
             _end_of_stream = true;
         } else {

--- a/sstables/partition.cc
+++ b/sstables/partition.cc
@@ -83,7 +83,7 @@ concept bool RowConsumer() {
         { t.is_mutation_end() } -> bool;
         { t.setup_for_partition(pk) } -> void;
         { t.get_mutation() } -> std::optional<new_mutation>;
-        { t.push_ready_fragments() } -> row_consumer::proceed;
+        { t.push_ready_fragments() } -> void
         { t.maybe_skip() } -> std::optional<position_in_partition_view>;
         { t.fast_forward_to(std::move(cr), timeout) } -> std::optional<position_in_partition_view>;
     };

--- a/sstables/row.hh
+++ b/sstables/row.hh
@@ -1346,7 +1346,12 @@ public:
             _consumer.on_end_of_stream();
             return;
         }
-        if (_state != state::PARTITION_START || _prestate != prestate::NONE) {
+
+        // We may end up in state::DELETION_TIME after consuming last partition's end marker
+        // and proceeding to attempt to parse the next partition, since state::DELETION_TIME
+        // is the first state corresponding to the contents of a new partition.
+        if (_state != state::DELETION_TIME
+                && (_state != state::PARTITION_START || _prestate != prestate::NONE)) {
             throw malformed_sstable_exception("end of input, but not end of partition");
         }
     }


### PR DESCRIPTION
Currently, parser and the consumer save its state and return the
control to the caller, which then figures out that it needs to enter a
new partition, and that it doesn't need to skip. We do it twice, after
row end, and after row start. All this work could be avoided if the
consumer installed by the reader adjusted its state and pushed the
fragments on the spot. This patch achieves just that.

This results in less CPU overhead.

The ka/la reader is left still stopping after row end.

Brings a 20% improvement in frag/s for a full scan in perf_fast_forward (Haswell, NVMe):

 perf_fast_forward -c1 -m1G  --run-tests=small-partition-skips:

Before:

```
   read    skip      time (s)   iterations     frags     frag/s    mad f/s    max f/s    min f/s    avg aio    aio      (KiB) blocked dropped  idx hit idx miss  idx blk    c hit   c miss    c blk    cpu
-> 1       0         0.952372            4   1000000    1050009        755    1050765    1046585      976.0    971     124256       1       0        0        0        0        0        0        0  99.7%
```

After:

```
   read    skip      time (s)   iterations     frags     frag/s    mad f/s    max f/s    min f/s    avg aio    aio      (KiB) blocked dropped  idx hit idx miss  idx blk    c hit   c miss    c blk    cpu
-> 1       0         0.790178            4   1000000    1265538       1150    1266687    1263684      975.0    971     124256       2       0        0        0        0        0        0        0  99.6%

```


Tests:
 - unit (dev)
