### PR TITLE
Cql3: lift infinite bound check

### DIFF
--- a/database.hh
+++ b/database.hh
@@ -1296,6 +1296,8 @@ private:
     friend db::data_listeners;
     std::unique_ptr<db::data_listeners> _data_listeners;
 
+    bool _supports_infinite_bound_range_deletions = false;
+
     future<> init_commitlog();
     future<> apply_in_memory(const frozen_mutation& m, schema_ptr m_schema, db::rp_handle&&, db::timeout_clock::time_point timeout);
     future<> apply_in_memory(const mutation& m, column_family& cf, db::rp_handle&&, db::timeout_clock::time_point timeout);
@@ -1509,6 +1511,14 @@ public:
 
     db::data_listeners& data_listeners() const {
         return *_data_listeners;
+    }
+
+    void enable_infinite_bound_range_deletions() {
+        _supports_infinite_bound_range_deletions = true;
+    }
+
+    bool supports_infinite_bound_range_deletions() {
+        return _supports_infinite_bound_range_deletions;
     }
 };
 

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -184,6 +184,13 @@ storage_service::storage_service(distributed<database>& db, gms::gossiper& gossi
     } else {
         _sstables_format = sstables::sstable_version_types::mc;
     }
+
+    _unbounded_range_tombstones_feature.when_enabled().then([&db] () mutable {
+        slogger.debug("Enabling infinite bound range deletions");
+        db.invoke_on_all([] (database& local_db) mutable {
+            local_db.enable_infinite_bound_range_deletions();
+        });
+    });
 }
 
 void storage_service::enable_all_features() {

--- a/tests/cql_query_test.cc
+++ b/tests/cql_query_test.cc
@@ -1064,18 +1064,12 @@ SEASTAR_TEST_CASE(test_range_deletion_scenarios) {
             e.execute_cql(format("insert into cf (p, c, v) values (1, {:d}, 'abc');", i)).get();
         }
 
-        try {
-            e.execute_cql("delete from cf where p = 1 and c <= 3").get();
-            BOOST_FAIL("should've thrown");
-        } catch (...) { }
-        try {
-            e.execute_cql("delete from cf where p = 1 and c >= 0").get();
-            BOOST_FAIL("should've thrown");
-        } catch (...) { }
+        e.execute_cql("delete from cf where p = 1 and c <= 3").get();
+        e.execute_cql("delete from cf where p = 1 and c >= 8").get();
 
-        e.execute_cql("delete from cf where p = 1 and c >= 0 and c <= 3").get();
+        e.execute_cql("delete from cf where p = 1 and c >= 0 and c <= 5").get();
         auto msg = e.execute_cql("select * from cf").get0();
-        assert_that(msg).is_rows().with_size(6);
+        assert_that(msg).is_rows().with_size(2);
         e.execute_cql("delete from cf where p = 1 and c > 3 and c < 10").get();
         msg = e.execute_cql("select * from cf").get0();
         assert_that(msg).is_rows().with_size(0);


### PR DESCRIPTION
If the database supports infinite bound range deletions,
CQL layer will no longer throw an error indicating that both ranges
need to be specified.
    
Fixes #432
    
(cherry picked from commit 17acedb0c610d69cbc9675a02af467e44fa5b175)
    
Update test_range_deletion_scenarios unit test accordingly.