### PR TITLE
main: stop view builder conditionally

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -934,9 +934,11 @@ int main(int ac, char** av) {
                 service::get_local_storage_service().drain_on_shutdown().get();
             });
 
-            auto stop_view_builder = defer([] {
-                startlog.info("stopping view builder");
-                view_builder.stop().get();
+            auto stop_view_builder = defer([cfg] {
+                if (cfg->view_building()) {
+                    startlog.info("stopping view builder");
+                    view_builder.stop().get();
+                }
             });
 
             auto stop_compaction_manager = defer([&db] {


### PR DESCRIPTION
The view builder is started only if it's enabled in config,
via the view_building=true variable. Unfortunately, stopping
the builder was unconditional, which may result in failed
assertions during shutdown. To remedy this, view building
is stopped only if it was previously started.

Fixes #4589