### PR TITLE
tests: cql_test_env: disable commitlog O_DSYNC

### DIFF
--- a/tests/cql_test_env.cc
+++ b/tests/cql_test_env.cc
@@ -64,7 +64,12 @@ cql_test_config::cql_test_config()
 
 cql_test_config::cql_test_config(const db::config& cfg)
     : db_config(seastar::make_shared<db::config>(cfg))
-{}
+{
+    // This causes huge amounts of commitlog writes to allocate space on disk,
+    // which all get thrown away when the test is done. This can cause timeouts
+    // if /tmp is not tmpfs.
+    db_config->commitlog_use_o_dsync() = false;
+}
 
 cql_test_config::cql_test_config(const cql_test_config&) = default;
 cql_test_config::~cql_test_config() = default;


### PR DESCRIPTION
O_DSYNC causes commitlog to pre-allocate each commitlog segment by writing
zeroes into it. In normal operation, this is amortized over the many
times the segment will be reused. In tests, this is wasteful, but under
the default workstation configuration with /tmp using tmpfs, no actual
writes occur.

However on a non-default configuration with /tmp mounted on a real disk,
this causes huge disk I/O and eventually a crash (observed in
schema_change_test). The crash is likely only caused indirectly, as the
extra I/O (exacerbated by many tests running in parallel) xcauses timeouts.

I reproduced this problem by running 15 copies of schema_change_test in
parallel with /tmp mounted on a real filesystem. Without this change, I
usually observe one or two of the copies crashing, with the change they
complete (and much more quickly, too).
