### PR TITLE
Collection: use utils::chunked_vector to store the cells

### DIFF
--- a/types.cc
+++ b/types.cc
@@ -2712,7 +2712,7 @@ bool collection_type_impl::mutation::compact_and_expire(row_tombstone base_tomb,
         tomb = tombstone();
     }
     t.apply(base_tomb.regular());
-    std::vector<std::pair<bytes, atomic_cell>> survivors;
+    utils::chunked_vector<std::pair<bytes, atomic_cell>> survivors;
     for (auto&& name_and_cell : cells) {
         atomic_cell& cell = name_and_cell.second;
         auto cannot_erase_cell = [&] {

--- a/types.cc
+++ b/types.cc
@@ -2795,7 +2795,7 @@ collection_type_impl::merge(collection_mutation_view a, collection_mutation_view
             compare,
             merge);
     merged.tomb = std::max(aa.tomb, bb.tomb);
-    return serialize_mutation_form(merged);
+    return serialize_mutation_form(std::move(merged));
   });
  });
 }
@@ -2825,7 +2825,7 @@ collection_type_impl::difference(collection_mutation_view a, collection_mutation
     if (aa.tomb > bb.tomb) {
         diff.tomb = aa.tomb;
     }
-    return serialize_mutation_form(diff);
+    return serialize_mutation_form(std::move(diff));
   });
  });
 }

--- a/types/collection.hh
+++ b/types/collection.hh
@@ -26,6 +26,7 @@
 #include <vector>
 
 #include "types.hh"
+#include "utils/chunked_vector.hh"
 
 class collection_type_impl : public abstract_type {
     static logging::logger _logger;
@@ -52,7 +53,7 @@ public:
     // representation of a collection mutation, key/value pairs, value is a mutation itself
     struct mutation {
         tombstone tomb;
-        std::vector<std::pair<bytes, atomic_cell>> cells;
+        utils::chunked_vector<std::pair<bytes, atomic_cell>> cells;
         // Expires cells based on query_time. Expires tombstones based on max_purgeable and gc_before.
         // Removes cells covered by tomb or this->tomb.
         bool compact_and_expire(row_tombstone tomb, gc_clock::time_point query_time,
@@ -60,7 +61,7 @@ public:
     };
     struct mutation_view {
         tombstone tomb;
-        std::vector<std::pair<bytes_view, atomic_cell_view>> cells;
+        utils::chunked_vector<std::pair<bytes_view, atomic_cell_view>> cells;
         mutation materialize(const collection_type_impl&) const;
     };
     virtual data_type name_comparator() const = 0;


### PR DESCRIPTION
This is a band-aid patch that is supposed to fix the immediate problem of large collections causing large allocations. The proper fix is to use IMR but that will take time. In the meanwhile alleviate the pressure on the memory allocator by using a chunked storage collection (`utils::chunked_vector`) instead of `std::vector`. In the linked issue `seastar::chunked_fifo` was also proposed as the container to use, however chunked fifo is not traversable in reverse which disqualifies it from this role.

Refs: #3602