### PR TITLE
Move SizeTiered tables towards zero backlog

### DIFF
--- a/sstables/compaction.hh
+++ b/sstables/compaction.hh
@@ -44,6 +44,8 @@ namespace sstables {
         // Calls compaction manager's task for this compaction to release reference to exhausted sstables.
         std::function<void(const std::vector<shared_sstable>& exhausted_sstables)> release_exhausted;
 
+        bool idle = false;
+
         compaction_descriptor() = default;
 
         explicit compaction_descriptor(std::vector<sstables::shared_sstable> sstables, int level = 0, uint64_t max_sstable_bytes = std::numeric_limits<uint64_t>::max())

--- a/sstables/leveled_manifest.hh
+++ b/sstables/leveled_manifest.hh
@@ -266,6 +266,7 @@ public:
             }
         }
 
+        // Nothing better to do, push data into the highest levels.
         for (size_t i = _generations.size() - 1; i > 0; --i) {
             auto& sstables = get_level(i);
             if (sstables.empty()) {
@@ -277,6 +278,7 @@ public:
             }
             auto descriptor = get_descriptor_for_level(i-1, last_compacted_keys, compaction_counter);
             if (descriptor.sstables.size() > 0) {
+                descriptor.idle = true;
                 return descriptor;
             }
         }

--- a/sstables/size_tiered_compaction_strategy.hh
+++ b/sstables/size_tiered_compaction_strategy.hh
@@ -319,7 +319,9 @@ size_tiered_compaction_strategy::get_sstables_for_compaction(column_family& cfs,
         auto it = std::min_element(sstables.begin(), sstables.end(), [] (auto& i, auto& j) {
             return i->get_stats_metadata().min_timestamp < j->get_stats_metadata().min_timestamp;
         });
-        return sstables::compaction_descriptor({ *it });
+        auto desc = sstables::compaction_descriptor({ *it });
+        desc.idle = true;
+        return desc;
     }
     return sstables::compaction_descriptor();
 }


### PR DESCRIPTION
Right now, we advertise that the compaction controller will work to
bring us to a zero-backlog state, but there is at least one situation in
which that doesn't happen.
    
When we coded the controller we made sure that STCS would compact any
two SSTables with this goal in mind even if there were not min_threshold
SSTables avaialable, but we ended up only doing that if the SSTables are
in the same level.
    
That works well if the workload is a simple ingestion workloads where
each level is exactly twice as big as the previous one, since eventually
SSTables will be at the same level, but it doesn't work well if the
sizes of the levels are very uneven.

This fixes the issue by making sure we can compact cross-level in case
there is nothing better to do.