### PR TITLE
Complete the LIKE operator

### DIFF
--- a/cql3/Cql.g
+++ b/cql3/Cql.g
@@ -1491,6 +1491,7 @@ relationType returns [const cql3::operator_type* op = nullptr]
     | '>'  { $op = &cql3::operator_type::GT; }
     | '>=' { $op = &cql3::operator_type::GTE; }
     | '!=' { $op = &cql3::operator_type::NEQ; }
+    | K_LIKE { $op = &cql3::operator_type::LIKE; }
     ;
 
 relation[std::vector<cql3::relation_ptr>& clauses]
@@ -1736,6 +1737,7 @@ basic_unreserved_keyword returns [sstring str]
         | K_JSON
         | K_CACHE
         | K_BYPASS
+        | K_LIKE
         | K_PER
         | K_PARTITION
         | K_GROUP
@@ -1890,7 +1892,9 @@ K_PARTITION:   P A R T I T I O N;
 K_SCYLLA_TIMEUUID_LIST_INDEX: S C Y L L A '_' T I M E U U I D '_' L I S T '_' I N D E X;
 K_SCYLLA_COUNTER_SHARD_LIST: S C Y L L A '_' C O U N T E R '_' S H A R D '_' L I S T; 
 
-K_GROUP:      G R O U P;
+K_GROUP:       G R O U P;
+
+K_LIKE:        L I K E;
 
 // Case-insensitive alpha characters
 fragment A: ('a'|'A');

--- a/cql3/multi_column_relation.hh
+++ b/cql3/multi_column_relation.hh
@@ -188,6 +188,11 @@ protected:
         throw exceptions::invalid_request_exception(format("{} cannot be used for Multi-column relations", get_operator()));
     }
 
+    virtual ::shared_ptr<restrictions::restriction> new_LIKE_restriction(
+            database& db, schema_ptr schema, ::shared_ptr<variable_specifications> bound_names) override {
+        throw exceptions::invalid_request_exception("LIKE cannot be used for Multi-column relations");
+    }
+
     virtual ::shared_ptr<relation> maybe_rename_identifier(const column_identifier::raw& from, column_identifier::raw to) override {
         auto new_entities = boost::copy_range<decltype(_entities)>(_entities | boost::adaptors::transformed([&] (auto&& entity) {
             return *entity == from ? ::make_shared<column_identifier::raw>(to) : entity;

--- a/cql3/operator.cc
+++ b/cql3/operator.cc
@@ -53,5 +53,6 @@ const operator_type operator_type::CONTAINS(5, operator_type::CONTAINS, "CONTAIN
 const operator_type operator_type::CONTAINS_KEY(6, operator_type::CONTAINS_KEY, "CONTAINS_KEY");
 const operator_type operator_type::NEQ(8, operator_type::NEQ, "!=");
 const operator_type operator_type::IS_NOT(9, operator_type::IS_NOT, "IS NOT");
+const operator_type operator_type::LIKE(10, operator_type::LIKE, "LIKE");
 
 }

--- a/cql3/operator.hh
+++ b/cql3/operator.hh
@@ -60,6 +60,7 @@ public:
     static const operator_type CONTAINS_KEY;
     static const operator_type NEQ;
     static const operator_type IS_NOT;
+    static const operator_type LIKE;
 private:
     int32_t _b;
     const operator_type& _reverse;

--- a/cql3/relation.hh
+++ b/cql3/relation.hh
@@ -160,6 +160,8 @@ public:
             // This case is not supposed to happen: statement_restrictions
             // constructor does not call this function for views' IS_NOT.
             throw exceptions::invalid_request_exception(format("Unsupported \"IS NOT\" relation: {}", to_string()));
+        } else if (_relation_type == operator_type::LIKE) {
+            return new_LIKE_restriction(db, schema, bound_names);
         } else {
             throw exceptions::invalid_request_exception(format("Unsupported \"!=\" relation: {}", to_string()));
         }
@@ -219,6 +221,12 @@ public:
      */
     virtual ::shared_ptr<restrictions::restriction> new_contains_restriction(database& db, schema_ptr schema,
         ::shared_ptr<variable_specifications> bound_names, bool isKey) = 0;
+
+    /**
+     * Creates a new LIKE restriction instance.
+     */
+    virtual ::shared_ptr<restrictions::restriction> new_LIKE_restriction(database& db, schema_ptr schema,
+        ::shared_ptr<variable_specifications> bound_names) = 0;
 
     /**
      * Renames an identifier in this Relation, if applicable.

--- a/cql3/restrictions/abstract_restriction.hh
+++ b/cql3/restrictions/abstract_restriction.hh
@@ -82,6 +82,10 @@ public:
         return false;
     }
 
+    virtual bool is_LIKE() const {
+        return false;
+    }
+
     virtual bool has_bound(statements::bound b) const override {
         return true;
     }

--- a/cql3/restrictions/primary_key_restrictions.hh
+++ b/cql3/restrictions/primary_key_restrictions.hh
@@ -91,7 +91,8 @@ public:
     }
 
     virtual bool needs_filtering(const schema& schema) const {
-        return !empty() && !is_on_token() && (has_unrestricted_components(schema) || is_contains() || is_slice());
+        return !empty() && !is_on_token() &&
+                (has_unrestricted_components(schema) || is_contains() || is_slice() || is_LIKE());
     }
 
     // NOTICE(sarna): This function is useless for partition key restrictions,

--- a/cql3/restrictions/single_column_restriction.hh
+++ b/cql3/restrictions/single_column_restriction.hh
@@ -415,6 +415,10 @@ public:
         return index.supports_expression(_column_def, cql3::operator_type::LIKE);
     }
 
+    virtual bool is_LIKE() const override {
+        return true;
+    }
+
     virtual sstring to_string() const override {
         return format("LIKE({})", _value->to_string());
     }

--- a/cql3/restrictions/statement_restrictions.cc
+++ b/cql3/restrictions/statement_restrictions.cc
@@ -35,6 +35,7 @@
 #include "types/map.hh"
 #include "types/list.hh"
 #include "types/set.hh"
+#include "utils/like_matcher.hh"
 
 namespace cql3 {
 namespace restrictions {
@@ -913,6 +914,31 @@ bool token_restriction::slice::is_satisfied_by(const schema& schema,
         }
     }
     return satisfied;
+}
+
+bool single_column_restriction::LIKE::is_satisfied_by(const schema& schema,
+        const partition_key& key,
+        const clustering_key_prefix& ckey,
+        const row& cells,
+        const query_options& options,
+        gc_clock::time_point now) const {
+    if (!_column_def.type->is_string()) {
+        throw exceptions::invalid_request_exception("LIKE is allowed only on string types");
+    }
+    auto cell_value = get_value(schema, key, ckey, cells, now);
+    return !cell_value ? false :
+            cell_value->with_linearized([&] (bytes_view data) {
+                 auto pattern = to_bytes_opt(_value->bind_and_get(options));
+                 return pattern ? like_matcher(*pattern)(data) : false;
+            });
+}
+
+bool single_column_restriction::LIKE::is_satisfied_by(bytes_view data, const query_options& options) const {
+    if (!_column_def.type->is_string()) {
+        throw exceptions::invalid_request_exception("LIKE is allowed only on string types");
+    }
+    auto pattern = to_bytes_opt(_value->bind_and_get(options));
+    return pattern ? like_matcher(*pattern)(data) : false;
 }
 
 }

--- a/cql3/single_column_relation.cc
+++ b/cql3/single_column_relation.cc
@@ -95,6 +95,18 @@ single_column_relation::new_IN_restriction(database& db, schema_ptr schema, ::sh
     return ::make_shared<single_column_restriction::IN_with_values>(column_def, std::move(terms));
 }
 
+::shared_ptr<restrictions::restriction>
+single_column_relation::new_LIKE_restriction(
+        database& db, schema_ptr schema, ::shared_ptr<variable_specifications> bound_names) {
+    const column_definition& column_def = to_column_definition(schema, _entity);
+    if (!column_def.type->is_string()) {
+        throw exceptions::invalid_request_exception(
+                format("LIKE is allowed only on string types, which {} is not", column_def.name_as_text()));
+    }
+    // TODO: introduce single_column_restriction::LIKE.
+    return ::shared_ptr<restrictions::restriction>{};
+}
+
 std::vector<::shared_ptr<column_specification>>
 single_column_relation::to_receivers(schema_ptr schema, const column_definition& column_def)
 {

--- a/cql3/single_column_relation.cc
+++ b/cql3/single_column_relation.cc
@@ -103,8 +103,8 @@ single_column_relation::new_LIKE_restriction(
         throw exceptions::invalid_request_exception(
                 format("LIKE is allowed only on string types, which {} is not", column_def.name_as_text()));
     }
-    // TODO: introduce single_column_restriction::LIKE.
-    return ::shared_ptr<restrictions::restriction>{};
+    auto term = to_term(to_receivers(schema, column_def), _value, db, schema->ks_name(), bound_names);
+    return ::make_shared<single_column_restriction::LIKE>(column_def, std::move(term));
 }
 
 std::vector<::shared_ptr<column_specification>>

--- a/cql3/single_column_relation.hh
+++ b/cql3/single_column_relation.hh
@@ -183,6 +183,9 @@ protected:
         return ::make_shared<restrictions::single_column_restriction::contains>(column_def, std::move(term), is_key);
     }
 
+    virtual ::shared_ptr<restrictions::restriction> new_LIKE_restriction(
+            database& db, schema_ptr schema, ::shared_ptr<variable_specifications> bound_names) override;
+
     virtual ::shared_ptr<relation> maybe_rename_identifier(const column_identifier::raw& from, column_identifier::raw to) override {
         return *_entity == from
             ? ::make_shared(single_column_relation(

--- a/cql3/token_relation.cc
+++ b/cql3/token_relation.cc
@@ -116,6 +116,11 @@ std::vector<::shared_ptr<cql3::column_specification>> cql3::token_relation::to_r
                     get_operator()));
 }
 
+::shared_ptr<cql3::restrictions::restriction> cql3::token_relation::new_LIKE_restriction(
+        database&, schema_ptr, ::shared_ptr<variable_specifications>) {
+    throw exceptions::invalid_request_exception("LIKE cannot be used with the token function");
+}
+
 sstring cql3::token_relation::to_string() const {
     return format("token({}) {} {}", join(", ", _entities), get_operator(), _value);
 }

--- a/cql3/token_relation.hh
+++ b/cql3/token_relation.hh
@@ -114,6 +114,10 @@ public:
             ::shared_ptr<variable_specifications> bound_names, bool isKey)
                     override;
 
+    ::shared_ptr<restrictions::restriction> new_LIKE_restriction(database& db,
+            schema_ptr schema,
+            ::shared_ptr<variable_specifications> bound_names) override;
+
     ::shared_ptr<relation> maybe_rename_identifier(const column_identifier::raw& from, column_identifier::raw to) override;
 
     sstring to_string() const override;

--- a/tests/cql_query_test.cc
+++ b/tests/cql_query_test.cc
@@ -3842,3 +3842,139 @@ SEASTAR_TEST_CASE(test_aggregate_and_simple_selection_together) {
         return make_ready_future<>();
     });
 }
+
+SEASTAR_TEST_CASE(test_like_operator) {
+    return do_with_cql_env_thread([] (cql_test_env& e) {
+        cquery_nofail(e, "create table t (p int primary key, s text)");
+        require_rows(e, "select s from t where s like 'abc' allow filtering", {});
+        cquery_nofail(e, "insert into t (p, s) values (1, 'abc')");
+        require_rows(e, "select s from t where s like 'abc' allow filtering", {{T("abc")}});
+        require_rows(e, "select s from t where s like 'ab_' allow filtering", {{T("abc")}});
+        cquery_nofail(e, "insert into t (p, s) values (2, 'abb')");
+        require_rows(e, "select s from t where s like 'ab_' allow filtering", {{T("abc")}, {T("abb")}});
+        require_rows(e, "select s from t where s like '%c' allow filtering", {{T("abc")}});
+        require_rows(e, "select s from t where s like 'aaa' allow filtering", {});
+    });
+}
+
+SEASTAR_TEST_CASE(test_like_operator_on_partition_key) {
+    return do_with_cql_env_thread([] (cql_test_env& e) {
+        // Fully constrained:
+        cquery_nofail(e, "create table t (s text primary key)");
+        cquery_nofail(e, "insert into t (s) values ('abc')");
+        require_rows(e, "select s from t where s like 'a__' allow filtering", {{T("abc")}});
+        cquery_nofail(e, "insert into t (s) values ('acc')");
+        require_rows(e, "select s from t where s like 'a__' allow filtering", {{T("abc")}, {T("acc")}});
+
+        // Partially constrained:
+        cquery_nofail(e, "create table t2 (s1 text, s2 text, primary key((s1, s2)))");
+        cquery_nofail(e, "insert into t2 (s1, s2) values ('abc', 'abc')");
+        require_rows(e, "select s2 from t2 where s2 like 'a%' allow filtering", {{T("abc")}});
+        cquery_nofail(e, "insert into t2 (s1, s2) values ('aba', 'aba')");
+        require_rows(e, "select s2 from t2 where s2 like 'a%' allow filtering", {{T("abc")}, {T("aba")}});
+    });
+}
+
+SEASTAR_TEST_CASE(test_like_operator_on_clustering_key) {
+    return do_with_cql_env_thread([] (cql_test_env& e) {
+        cquery_nofail(e, "create table t (p int, s text, primary key(p, s))");
+        cquery_nofail(e, "insert into t (p, s) values (1, 'abc')");
+        require_rows(e, "select s from t where s like '%c' allow filtering", {{T("abc")}});
+        cquery_nofail(e, "insert into t (p, s) values (2, 'acc')");
+        require_rows(e, "select s from t where s like '%c' allow filtering", {{T("abc")}, {T("acc")}});
+    });
+}
+
+SEASTAR_TEST_CASE(test_like_operator_conjunction) {
+    return do_with_cql_env_thread([] (cql_test_env& e) {
+        cquery_nofail(e, "create table t (s1 text primary key, s2 text)");
+        cquery_nofail(e, "insert into t (s1, s2) values ('abc', 'ABC')");
+        cquery_nofail(e, "insert into t (s1, s2) values ('a', 'A')");
+        require_rows(e, "select * from t where s1 like 'a%' and s2 like '__C' allow filtering",
+                     {{T("abc"), T("ABC")}});
+        BOOST_REQUIRE_EXCEPTION(
+                e.execute_cql("select * from t where s1 like 'a%' and s1 = 'abc' allow filtering").get(),
+                exceptions::invalid_request_exception,
+                exception_predicate::message_contains("more than one relation"));
+    });
+}
+
+SEASTAR_TEST_CASE(test_like_operator_static_column) {
+    return do_with_cql_env_thread([] (cql_test_env& e) {
+        cquery_nofail(e, "create table t (p int, c text, s text static, primary key(p, c))");
+        require_rows(e, "select s from t where s like '%c' allow filtering", {});
+        cquery_nofail(e, "insert into t (p, s) values (1, 'abc')");
+        require_rows(e, "select s from t where s like '%c' allow filtering", {{T("abc")}});
+        require_rows(e, "select * from t where c like '%' allow filtering", {});
+    });
+}
+
+SEASTAR_TEST_CASE(test_like_operator_bind_marker) {
+    return do_with_cql_env_thread([] (cql_test_env& e) {
+        cquery_nofail(e, "create table t (s text primary key, )");
+        cquery_nofail(e, "insert into t (s) values ('abc')");
+        try {
+            auto result = e.execute_prepared(
+                    e.prepare("select s from t where s like ? allow filtering").get0(),
+                    {cql3::raw_value::make_value(T("_b_"))}).get0();
+            assert_that(result).is_rows().with_rows_ignore_order({{T("abc")}});
+        }
+        catch (const std::exception& e) {
+            BOOST_FAIL(e.what());
+        }
+    });
+}
+
+#if 0 // TODO: Enable when like_matcher handles blank pattern.
+SEASTAR_TEST_CASE(test_like_operator_blank_pattern) {
+    return do_with_cql_env_thread([] (cql_test_env& e) {
+        cquery_nofail(e, "create table t (s text primary key, )");
+        cquery_nofail(e, "insert into t (s) values ('abc')");
+        require_rows(e, "select s from t where s like '' allow filtering", {});
+    });
+}
+#endif
+
+SEASTAR_TEST_CASE(test_like_operator_ascii) {
+    return do_with_cql_env_thread([] (cql_test_env& e) {
+        cquery_nofail(e, "create table t (s ascii primary key, )");
+        cquery_nofail(e, "insert into t (s) values ('abc')");
+        require_rows(e, "select s from t where s like '%c' allow filtering", {{T("abc")}});
+    });
+}
+
+SEASTAR_TEST_CASE(test_like_operator_varchar) {
+    return do_with_cql_env_thread([] (cql_test_env& e) {
+        cquery_nofail(e, "create table t (s varchar primary key, )");
+        cquery_nofail(e, "insert into t (s) values ('abc')");
+        require_rows(e, "select s from t where s like '%c' allow filtering", {{T("abc")}});
+    });
+}
+
+SEASTAR_TEST_CASE(test_like_operator_on_nonstring) {
+    return do_with_cql_env_thread([] (cql_test_env& e) {
+        cquery_nofail(e, "create table t (k int primary key, s text)");
+        BOOST_REQUIRE_EXCEPTION(
+                e.execute_cql("select * from t where k like 123 allow filtering").get(),
+                exceptions::invalid_request_exception,
+                exception_predicate::message_contains("only on string types"));
+#if 0 // TODO: Enable when query::result_set::consume() is fixed.
+        BOOST_REQUIRE_EXCEPTION(
+                e.execute_prepared(
+                        e.prepare("select s from t where s like ? allow filtering").get0(),
+                        {cql3::raw_value::make_value(I(1))}).get(),
+                exceptions::invalid_request_exception,
+                exception_predicate::message_contains("only on string types"));
+#endif
+    });
+}
+
+SEASTAR_TEST_CASE(test_like_operator_on_token) {
+    return do_with_cql_env_thread([] (cql_test_env& e) {
+        cquery_nofail(e, "create table t (s text primary key)");
+        BOOST_REQUIRE_EXCEPTION(
+                e.execute_cql("select * from t where token(s) like 'abc' allow filtering").get(),
+                exceptions::invalid_request_exception,
+                exception_predicate::message_contains("token function"));
+    });
+}

--- a/types.cc
+++ b/types.cc
@@ -360,6 +360,9 @@ struct string_type_impl : public concrete_type<sstring> {
     virtual bool is_byte_order_comparable() const override {
         return true;
     }
+    virtual bool is_string() const override {
+        return true;
+    }
     virtual size_t hash(bytes_view v) const override {
         return std::hash<bytes_view>()(v);
     }

--- a/types.hh
+++ b/types.hh
@@ -596,6 +596,7 @@ public:
     }
     virtual bytes from_json_object(const Json::Value& value, cql_serialization_format sf) const = 0;
     virtual bool is_counter() const { return false; }
+    virtual bool is_string() const { return false; }
     virtual bool is_collection() const { return false; }
     virtual bool is_multi_cell() const { return false; }
     virtual bool is_atomic() const { return !is_multi_cell(); }


### PR DESCRIPTION
Implement LIKE parsing, intermediate representation, and query processing.  Add tests for this implementation (leaving the LIKE functionality tests in `tests/like_matcher_test.cc`).

Refs #4477.