### PR TITLE
cql3: Drop support in altering column type for alignment with cassandra

### DIFF
--- a/cql3/statements/alter_table_statement.hh
+++ b/cql3/statements/alter_table_statement.hh
@@ -84,7 +84,6 @@ public:
     virtual std::unique_ptr<prepared> prepare(database& db, cql_stats& stats) override;
 private:
     void add_column(schema_ptr schema, const table& cf, schema_builder& cfm, std::vector<view_ptr>& view_updates, const shared_ptr<column_identifier> column_name, const cql3_type validator, const column_definition* def, bool is_static);
-    void alter_column(schema_ptr schema, const table& cf, schema_builder& cfm, std::vector<view_ptr>& view_updates, const shared_ptr<column_identifier> column_name, const cql3_type validator, const column_definition* def, bool is_static);
     void drop_column(schema_ptr schema, const table& cf, schema_builder& cfm, std::vector<view_ptr>& view_updates, const shared_ptr<column_identifier> column_name, const cql3_type validator, const column_definition* def, bool is_static);
 };
 

--- a/tests/cql_query_test.cc
+++ b/tests/cql_query_test.cc
@@ -2741,28 +2741,25 @@ SEASTAR_TEST_CASE(test_alter_table) {
             return e.execute_cql("alter table tat with comment = 'This is a comment.';").discard_result();
         }).then([&e] {
             BOOST_REQUIRE_EQUAL(e.local_db().find_schema("ks", "tat")->comment(), sstring("This is a comment."));
-            return e.execute_cql("alter table tat alter r2 type blob;").discard_result();
-        }).then([&e] {
             return e.execute_cql("select pk1, c1, ck2, r1, r2 from tat;");
         }).then([&e] (shared_ptr<cql_transport::messages::result_message> msg) {
             assert_that(msg).is_rows().with_rows({
                 { int32_type->decompose(1), int32_type->decompose(2), int32_type->decompose(3), int32_type->decompose(4), int32_type->decompose(5) },
             });
         }).then([&e] {
-            return e.execute_cql("insert into tat (pk1, c1, ck2, r2) values (1, 2, 3, 0x1234567812345678);").discard_result();
+            return e.execute_cql("insert into tat (pk1, c1, ck2, r2) values (1, 2, 3, 4);").discard_result();
         }).then([&e] {
             return e.execute_cql("select pk1, c1, ck2, r1, r2 from tat;");
         }).then([&e] (shared_ptr<cql_transport::messages::result_message> msg) {
             assert_that(msg).is_rows().with_rows({
-                { int32_type->decompose(1), int32_type->decompose(2), int32_type->decompose(3), int32_type->decompose(4), from_hex("1234567812345678") },
+                { int32_type->decompose(1), int32_type->decompose(2), int32_type->decompose(3), int32_type->decompose(4), int32_type->decompose(4) },
             });
-        }).then([&e] {
             return e.execute_cql("alter table tat rename pk1 to p1 and ck2 to c2;").discard_result();
         }).then([&e] {
             return e.execute_cql("select p1, c1, c2, r1, r2 from tat;");
         }).then([&e] (shared_ptr<cql_transport::messages::result_message> msg) {
             assert_that(msg).is_rows().with_rows({
-                { int32_type->decompose(1), int32_type->decompose(2), int32_type->decompose(3), int32_type->decompose(4), from_hex("1234567812345678") },
+                { int32_type->decompose(1), int32_type->decompose(2), int32_type->decompose(3), int32_type->decompose(4), int32_type->decompose(4) },
             });
             return e.execute_cql("alter table tat add r1_2 int;").discard_result();
         }).then([&e] {
@@ -2771,21 +2768,21 @@ SEASTAR_TEST_CASE(test_alter_table) {
             return e.execute_cql("select * from tat;");
         }).then([&e] (shared_ptr<cql_transport::messages::result_message> msg) {
             assert_that(msg).is_rows().with_rows({
-                { int32_type->decompose(1), int32_type->decompose(2), int32_type->decompose(3), int32_type->decompose(4), int32_type->decompose(6), from_hex("1234567812345678") },
+                { int32_type->decompose(1), int32_type->decompose(2), int32_type->decompose(3), int32_type->decompose(4), int32_type->decompose(6), int32_type->decompose(4) },
             });
             return e.execute_cql("alter table tat drop r1;").discard_result();
         }).then([&e] {
             return e.execute_cql("select * from tat;");
         }).then([&e] (shared_ptr<cql_transport::messages::result_message> msg) {
             assert_that(msg).is_rows().with_rows({
-                { int32_type->decompose(1), int32_type->decompose(2), int32_type->decompose(3), int32_type->decompose(6), from_hex("1234567812345678") },
+                { int32_type->decompose(1), int32_type->decompose(2), int32_type->decompose(3), int32_type->decompose(6), int32_type->decompose(4) },
             });
             return e.execute_cql("alter table tat add r1 int;").discard_result();
         }).then([&e] {
             return e.execute_cql("select * from tat;");
         }).then([&e] (shared_ptr<cql_transport::messages::result_message> msg) {
             assert_that(msg).is_rows().with_rows({
-                { int32_type->decompose(1), int32_type->decompose(2), int32_type->decompose(3), {}, int32_type->decompose(6), from_hex("1234567812345678") },
+                { int32_type->decompose(1), int32_type->decompose(2), int32_type->decompose(3), {}, int32_type->decompose(6), int32_type->decompose(4) },
             });
             return e.execute_cql("alter table tat drop r2;").discard_result();
         }).then([&e] {

--- a/tests/schema_change_test.cc
+++ b/tests/schema_change_test.cc
@@ -447,10 +447,16 @@ SEASTAR_TEST_CASE(test_notifications) {
             BOOST_REQUIRE_EQUAL(listener.update_column_family_count, 2);
             BOOST_REQUIRE_EQUAL(listener.columns_changed_count, 2);
 
-            e.execute_cql("alter table tests.table1 alter s1 type blob;").get();
 
-            BOOST_REQUIRE_EQUAL(listener.update_column_family_count, 3);
-            BOOST_REQUIRE_EQUAL(listener.columns_changed_count, 3);
+            // In cql spec 3.4.4 the alter column was deprecated since it was not a major version,
+            // the solution was to keep the parsing capability but throw an exception that will indicate
+            // thet the operation is no longer supported.
+            // See CASSANDRA-12443
+            BOOST_REQUIRE_THROW(e.execute_cql("alter table tests.table1 alter s1 type blob;").get() ,
+                                    exceptions::invalid_request_exception);
+
+            BOOST_REQUIRE_EQUAL(listener.update_column_family_count, 2);
+            BOOST_REQUIRE_EQUAL(listener.columns_changed_count, 2);
 
             e.execute_cql("drop table tests.table1;").get();
 

--- a/tests/view_schema_test.cc
+++ b/tests/view_schema_test.cc
@@ -715,56 +715,6 @@ SEASTAR_TEST_CASE(test_drop_table_with_active_mv) {
     });
 }
 
-SEASTAR_TEST_CASE(test_alter_table) {
-    return do_with_cql_env_thread([] (auto& e) {
-        e.execute_cql("create table cf (p int, c text, primary key (p, c));").get();
-        e.execute_cql("create materialized view vcf as select * from cf "
-                      "where p is not null and c is not null "
-                      "primary key (p, c)").get();
-        e.execute_cql("alter table cf alter c type blob").get();
-    });
-}
-
-SEASTAR_TEST_CASE(test_alter_reversed_type_base_table) {
-    return do_with_cql_env_thread([] (auto& e) {
-        e.execute_cql("create table cf (p int, c text, primary key (p, c)) with clustering order by (c desc);").get();
-        e.execute_cql("create materialized view vcf as select * from cf "
-                      "where p is not null and c is not null "
-                      "primary key (p, c) with clustering order by (c asc)").get();
-        e.execute_cql("alter table cf alter c type blob").get();
-    });
-}
-
-SEASTAR_TEST_CASE(test_alter_reversed_type_view_table) {
-    return do_with_cql_env_thread([] (auto& e) {
-        e.execute_cql("create table cf (p int, c text, primary key (p, c));").get();
-        e.execute_cql("create materialized view vcf as select * from cf "
-                      "where p is not null and c is not null "
-                      "primary key (p, c) with clustering order by (c desc)").get();
-        e.execute_cql("alter table cf alter c type blob").get();
-    });
-}
-
-SEASTAR_TEST_CASE(test_alter_compatible_type) {
-    return do_with_cql_env_thread([] (auto& e) {
-        e.execute_cql("create table cf (p int, c text, primary key (p));").get();
-        e.execute_cql("create materialized view vcf as select * from cf "
-                      "where p is not null and c is not null "
-                      "primary key (p, c) with clustering order by (c desc)").get();
-        e.execute_cql("alter table cf alter c type blob").get();
-    });
-}
-
-SEASTAR_TEST_CASE(test_alter_incompatible_type) {
-    return do_with_cql_env_thread([] (auto& e) {
-        e.execute_cql("create table cf (p int, c int, primary key (p));").get();
-        e.execute_cql("create materialized view vcf as select * from cf "
-                      "where p is not null and c is not null "
-                      "primary key (p, c) with clustering order by (c desc)").get();
-        assert_that_failed(e.execute_cql("alter table cf alter c type blob"));
-    });
-}
-
 SEASTAR_TEST_CASE(test_drop_non_existing) {
     return do_with_cql_env_thread([] (auto& e) {
         assert_that_failed(e.execute_cql("drop materialized view view_doees_not_exist;"));


### PR DESCRIPTION
Cassandra dropped the support for queries of the form:
ALTER TABLE [table_name] ALTER [column_name] TYPE [cql3_type]
For alignment reasons we do it too. Since it is not a major
version transition the syntax itself is stil parsed and instead
of parsing error the user will get a message ( implemented using
a thrown exception) that sais the request is invalid and that
changing column types in not alowed.
Along with that also the unit tests that used the command were
changed to expect the failure of not to use the command at all.
Some tests that were aimed to test this specific command were
removed.

For referrence see the Cassandra issue: CASSANDRA-12443.

Testing:
  1. Unit Tests
  2. Gating dtests

Fixes #4550

Scylla doesn't use pull-requests, please send a patch to the [mailing list](mailto:scylladb-dev@googlegroups.com) instead.
See our [contributing guidelines](../CONTRIBUTING.md) and our [Scylla development guidelines](../HACKING.md) for more information.

If you have any questions please don't hesitate to send a mail to the [dev list](mailto:scylladb-dev@googlegroups.com).
