### PR TITLE
IPv6 support

### DIFF
--- a/api/messaging_service.cc
+++ b/api/messaging_service.cc
@@ -76,7 +76,7 @@ future_json_function get_server_getter(std::function<uint64_t(const rpc::stats&)
         auto get_shard_map = [f](messaging_service& ms) {
             std::unordered_map<gms::inet_address, unsigned long> map;
             ms.foreach_server_connection_stats([&map, f] (const rpc::client_info& info, const rpc::stats& stats) mutable {
-                map[gms::inet_address(net::ipv4_address(info.addr))] = f(stats);
+                map[gms::inet_address(info.addr.addr())] = f(stats);
             });
             return map;
         };

--- a/db/config.cc
+++ b/db/config.cc
@@ -672,6 +672,7 @@ db::config::config(std::shared_ptr<db::extensions> exts)
     , enable_dangerous_direct_import_of_cassandra_counters(this, "enable_dangerous_direct_import_of_cassandra_counters", value_status::Used, false, "Only turn this option on if you want to import tables from Cassandra containing counters, and you are SURE that no counters in that table were created in a version earlier than Cassandra 2.1."
         " It is not enough to have ever since upgraded to newer versions of Cassandra. If you EVER used a version earlier than 2.1 in the cluster where these SSTables come from, DO NOT TURN ON THIS OPTION! You will corrupt your data. You have been warned.")
     , enable_shard_aware_drivers(this, "enable_shard_aware_drivers", value_status::Used, true, "Enable native transport drivers to use connection-per-shard for better performance")
+    , enable_ipv6_dns_lookup(this, "enable_ipv6_lookup", value_status::Used, false, "Use IPv6 address resolution")
 
     , default_log_level(this, "default_log_level", value_status::Used)
     , logger_log_level(this, "logger_log_level", value_status::Used)

--- a/db/config.hh
+++ b/db/config.hh
@@ -278,6 +278,7 @@ public:
     named_value<bool> enable_sstables_mc_format;
     named_value<bool> enable_dangerous_direct_import_of_cassandra_counters;
     named_value<bool> enable_shard_aware_drivers;
+    named_value<bool> enable_ipv6_dns_lookup;
 
     seastar::logging_settings logging_settings(const boost::program_options::variables_map&) const;
 

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -1605,7 +1605,6 @@ future<> update_peer_info(gms::inet_address ep, sstring column_name, Value value
 // sets are not needed, since tokens are updated by another method
 template future<> update_peer_info<sstring>(gms::inet_address ep, sstring column_name, sstring);
 template future<> update_peer_info<utils::UUID>(gms::inet_address ep, sstring column_name, utils::UUID);
-template future<> update_peer_info<net::ipv4_address>(gms::inet_address ep, sstring column_name, net::ipv4_address);
 template future<> update_peer_info<net::inet_address>(gms::inet_address ep, sstring column_name, net::inet_address);
 
 future<> update_hints_dropped(gms::inet_address ep, utils::UUID time_period, int value) {

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -1606,6 +1606,7 @@ future<> update_peer_info(gms::inet_address ep, sstring column_name, Value value
 template future<> update_peer_info<sstring>(gms::inet_address ep, sstring column_name, sstring);
 template future<> update_peer_info<utils::UUID>(gms::inet_address ep, sstring column_name, utils::UUID);
 template future<> update_peer_info<net::ipv4_address>(gms::inet_address ep, sstring column_name, net::ipv4_address);
+template future<> update_peer_info<net::inet_address>(gms::inet_address ep, sstring column_name, net::inet_address);
 
 future<> update_hints_dropped(gms::inet_address ep, utils::UUID time_period, int value) {
     // with 30 day TTL

--- a/gms/inet_address.cc
+++ b/gms/inet_address.cc
@@ -37,6 +37,7 @@
  */
 
 #include <seastar/net/inet_address.hh>
+#include <seastar/net/dns.hh>
 #include <seastar/core/print.hh>
 #include <seastar/core/future.hh>
 #include "inet_address.hh"
@@ -44,7 +45,7 @@
 using namespace seastar;
 
 future<gms::inet_address> gms::inet_address::lookup(sstring name, opt_family family) {
-    return seastar::net::inet_address::find(name, family.value_or(net::inet_address::family::INET)).then([](seastar::net::inet_address&& a) {
+    return seastar::net::dns::resolve_name(name, family).then([](seastar::net::inet_address&& a) {
         return make_ready_future<gms::inet_address>(a);
     });
 }

--- a/gms/inet_address.cc
+++ b/gms/inet_address.cc
@@ -43,8 +43,8 @@
 
 using namespace seastar;
 
-future<gms::inet_address> gms::inet_address::lookup(sstring name) {
-    return seastar::net::inet_address::find(name, net::inet_address::family::INET).then([](seastar::net::inet_address&& a) {
+future<gms::inet_address> gms::inet_address::lookup(sstring name, opt_family family) {
+    return seastar::net::inet_address::find(name, family.value_or(net::inet_address::family::INET)).then([](seastar::net::inet_address&& a) {
         return make_ready_future<gms::inet_address>(a);
     });
 }

--- a/gms/inet_address.cc
+++ b/gms/inet_address.cc
@@ -43,12 +43,8 @@
 
 using namespace seastar;
 
-gms::inet_address::inet_address(const net::inet_address& in)
-    : inet_address(in.as_ipv4_address())
-{}
-
 future<gms::inet_address> gms::inet_address::lookup(sstring name) {
-    return seastar::net::inet_address::find(name, seastar::net::inet_address::family::INET).then([](seastar::net::inet_address&& a) {
+    return seastar::net::inet_address::find(name, net::inet_address::family::INET).then([](seastar::net::inet_address&& a) {
         return make_ready_future<gms::inet_address>(a);
     });
 }

--- a/gms/inet_address.hh
+++ b/gms/inet_address.hh
@@ -29,10 +29,7 @@
 #include <seastar/net/socket_defs.hh>
 #include "utils/serialization.hh"
 #include <sstream>
-
-namespace seastar::net {
-    class inet_address;
-}
+#include <optional>
 
 namespace gms {
 
@@ -48,7 +45,6 @@ public:
         : _addr(net::ipv4_address(ip)) {
     }
     inet_address(const net::inet_address& addr) : _addr(addr) {}
-
     inet_address(const socket_address& sa)
         : inet_address(sa.addr())
     {}
@@ -95,7 +91,9 @@ public:
     }
     friend struct std::hash<inet_address>;
 
-    static future<inet_address> lookup(sstring);
+    using opt_family = std::optional<net::inet_address::family>;
+
+    static future<inet_address> lookup(sstring, opt_family = {});
 };
 
 std::ostream& operator<<(std::ostream& os, const inet_address& x);

--- a/gms/inet_address_serializer.hh
+++ b/gms/inet_address_serializer.hh
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2019 ScyllaDB
+ */
+
+/*
+ * This file is part of Scylla.
+ *
+ * See the LICENSE.PROPRIETARY file in the top-level directory for licensing information.
+ */
+
+#pragma once
+
+#include "inet_address.hh"
+#include "serializer.hh"
+
+namespace ser {
+
+/**
+ * Manual definition of inet_address serialization.
+ * Because inet_address was initially hardcoded to
+ * ipv4, its wire format is not very forward compatible.
+ *
+ * Since we potentially need to communicate with older
+ * version nodes, we manually define the new serial format
+ * for inet_address to be:
+ *
+ * ipv4: 4  bytes address
+ * ipv6: 4  bytes marker 0xffffffff (invalid address)
+ *       16 bytes data -> address
+ *
+ * As long as we are restricted to ipv4 (config/user responsibility)
+ * we will be able to swap gossip with older nodes. Once the
+ * cluster is fully updated, user can enable ipv6 and we will be
+ * happy and addressing all the molecules.
+ *
+ */
+template<>
+struct serializer<gms::inet_address> {
+    template<typename Input>
+    static gms::inet_address read(Input& in) {
+        auto sz = deserialize(in, boost::type<uint32_t>());
+        if (sz == std::numeric_limits<uint32_t>::max()) {
+            seastar::net::ipv6_address addr(deserialize(in, boost::type<net::ipv6_address::ipv6_bytes>()));
+            return gms::inet_address(addr);
+        }
+        return gms::inet_address(sz);
+    }
+    template<typename Output>
+    static void write(Output& out, gms::inet_address v) {
+        auto& addr = v.addr();
+        if (addr.is_ipv6()) {
+            serialize(out, std::numeric_limits<uint32_t>::max());
+            auto bv = v.bytes();
+            out.write(reinterpret_cast<const char *>(bv.data()), bv.size());
+        } else {
+            uint32_t ip = addr.as_ipv4_address().ip;
+            // must write this little (or rather host) endian
+            serialize(out, ip);
+        }
+    }
+    template<typename Input>
+    static void skip(Input& v) {
+        read(v);
+    }
+};
+
+
+}

--- a/idl/gossip_digest.idl.hh
+++ b/idl/gossip_digest.idl.hh
@@ -38,10 +38,6 @@ enum class application_state:int {
         SUPPORTED_FEATURES
 };
 
-class inet_address final {
-  uint32_t raw_addr();
-};
-
 class versioned_value {
     sstring value;
     int version;

--- a/init.cc
+++ b/init.cc
@@ -65,7 +65,8 @@ void init_ms_fd_gossiper(sharded<gms::gossiper>& gossiper
                 , double phi
                 , bool sltba)
 {
-    const auto listen = gms::inet_address::lookup(listen_address_in).get0();
+    auto family = cfg.enable_ipv6_dns_lookup() ? std::nullopt : std::make_optional(net::inet_address::family::INET);
+    const auto listen = gms::inet_address::lookup(listen_address_in, family).get0();
 
     using encrypt_what = netw::messaging_service::encrypt_what;
     using compress_what = netw::messaging_service::compress_what;
@@ -138,7 +139,7 @@ void init_ms_fd_gossiper(sharded<gms::gossiper>& gossiper
         while (begin < seeds_str.length() && begin != (next=seeds_str.find(",",begin))) {
             auto seed = boost::trim_copy(seeds_str.substr(begin,next-begin));
             try {
-                seeds.emplace(gms::inet_address::lookup(seed).get0());
+                seeds.emplace(gms::inet_address::lookup(seed, family).get0());
             } catch (...) {
                 startlog.error("Bad configuration: invalid value in 'seeds': '{}': {}", seed, std::current_exception());
                 throw bad_configuration_error();

--- a/locator/ec2_snitch.cc
+++ b/locator/ec2_snitch.cc
@@ -63,7 +63,7 @@ future<> ec2_snitch::start() {
 }
 
 future<sstring> ec2_snitch::aws_api_call(sstring addr, sstring cmd) {
-    return engine().net().connect(make_ipv4_address(ipv4_addr{addr}))
+    return engine().net().connect(socket_address(inet_address{addr}))
     .then([this, addr, cmd] (connected_socket fd) {
         _sd = std::move(fd);
         _in = std::move(_sd.input());

--- a/locator/gce_snitch.cc
+++ b/locator/gce_snitch.cc
@@ -111,7 +111,7 @@ future<sstring> gce_snitch::gce_api_call(sstring addr, sstring cmd) {
         using namespace boost::algorithm;
 
         net::inet_address a = seastar::net::dns::resolve_name(addr, net::inet_address::family::INET).get0();
-        connected_socket sd(connect(make_ipv4_address(ipv4_addr(a, 80))).get0());
+        connected_socket sd(connect(socket_address(a, 80)).get0());
         input_stream<char> in(sd.input());
         output_stream<char> out(sd.output());
         sstring zone_req(seastar::format("GET {} HTTP/1.1\r\nHost: metadata\r\nMetadata-Flavor: Google\r\n\r\n", cmd));

--- a/locator/rack_inferring_snitch.hh
+++ b/locator/rack_inferring_snitch.hh
@@ -61,11 +61,11 @@ struct rack_inferring_snitch : public snitch_base {
     }
 
     virtual sstring get_rack(inet_address endpoint) override {
-        return std::to_string((endpoint.raw_addr() >> 8) & 0xFF);
+        return std::to_string(uint8_t(endpoint.bytes()[2]));
     }
 
     virtual sstring get_datacenter(inet_address endpoint) override {
-        return std::to_string((endpoint.raw_addr() >> 16) & 0xFF);
+        return std::to_string(uint8_t(endpoint.bytes()[1]));
     }
 
     virtual sstring get_name() const override {

--- a/main.cc
+++ b/main.cc
@@ -509,6 +509,7 @@ int main(int ac, char** av) {
             uint16_t api_port = cfg->api_port();
             ctx.api_dir = cfg->api_ui_dir();
             ctx.api_doc = cfg->api_doc_dir();
+            auto family = cfg->enable_ipv6_dns_lookup() ? std::nullopt : std::make_optional(net::inet_address::family::INET);
             sstring listen_address = cfg->listen_address();
             sstring rpc_address = cfg->rpc_address();
             sstring api_address = cfg->api_address() != "" ? cfg->api_address() : rpc_address;
@@ -517,7 +518,7 @@ int main(int ac, char** av) {
             std::optional<std::vector<sstring>> hinted_handoff_enabled = parse_hinted_handoff_enabled(cfg->hinted_handoff_enabled());
             auto prom_addr = [&] {
                 try {
-                    return seastar::net::dns::get_host_by_name(cfg->prometheus_address()).get0();
+                    return seastar::net::dns::get_host_by_name(cfg->prometheus_address(), family).get0();
                 } catch (...) {
                     std::throw_with_nested(std::runtime_error(fmt::format("Unable to resolve prometheus_address {}", cfg->prometheus_address())));
                 }
@@ -543,14 +544,14 @@ int main(int ac, char** av) {
             }
             if (!broadcast_address.empty()) {
                 try {
-                    utils::fb_utilities::set_broadcast_address(gms::inet_address::lookup(broadcast_address).get0());
+                    utils::fb_utilities::set_broadcast_address(gms::inet_address::lookup(broadcast_address, family).get0());
                 } catch (...) {
                     startlog.error("Bad configuration: invalid 'broadcast_address': {}: {}", broadcast_address, std::current_exception());
                     throw bad_configuration_error();
                 }
             } else if (!listen_address.empty()) {
                 try {
-                    utils::fb_utilities::set_broadcast_address(gms::inet_address::lookup(listen_address).get0());
+                    utils::fb_utilities::set_broadcast_address(gms::inet_address::lookup(listen_address, family).get0());
                 } catch (...) {
                     startlog.error("Bad configuration: invalid 'listen_address': {}: {}", listen_address, std::current_exception());
                     throw bad_configuration_error();
@@ -561,13 +562,13 @@ int main(int ac, char** av) {
             }
 
             if (!broadcast_rpc_address.empty()) {
-                utils::fb_utilities::set_broadcast_rpc_address(gms::inet_address::lookup(broadcast_rpc_address).get0());
+                utils::fb_utilities::set_broadcast_rpc_address(gms::inet_address::lookup(broadcast_rpc_address, family).get0());
             } else {
                 if (rpc_address == "0.0.0.0") {
                     startlog.error("If rpc_address is set to a wildcard address {}, then you must set broadcast_rpc_address to a value other than {}", rpc_address, rpc_address);
                     throw bad_configuration_error();
                 }
-                utils::fb_utilities::set_broadcast_rpc_address(gms::inet_address::lookup(rpc_address).get0());
+                utils::fb_utilities::set_broadcast_rpc_address(gms::inet_address::lookup(rpc_address, family).get0());
             }
 
             // TODO: lib.

--- a/main.cc
+++ b/main.cc
@@ -535,7 +535,7 @@ int main(int ac, char** av) {
                 }));
                 prometheus::start(prometheus_server, pctx);
                 with_scheduling_group(maintenance_scheduling_group, [&] {
-                  return prometheus_server.listen(ipv4_addr{prom_addr.addr_list.front(), pport}).handle_exception([pport, &cfg] (auto ep) {
+                  return prometheus_server.listen(socket_address{prom_addr.addr_list.front(), pport}).handle_exception([pport, &cfg] (auto ep) {
                     startlog.error("Could not start Prometheus API server on {}:{}: {}", cfg->prometheus_address(), pport, ep);
                     return make_exception_future<>(ep);
                   });
@@ -618,7 +618,7 @@ int main(int ac, char** av) {
             ctx.http_server.start("API").get();
             api::set_server_init(ctx).get();
             with_scheduling_group(maintenance_scheduling_group, [&] {
-                return ctx.http_server.listen(ipv4_addr{ip, api_port});
+                return ctx.http_server.listen(socket_address{ip, api_port});
             }).get();
             startlog.info("Scylla API server listening on {}:{} ...", api_address, api_port);
             static sharded<auth::service> auth_service;

--- a/message/messaging_service.cc
+++ b/message/messaging_service.cc
@@ -23,6 +23,7 @@
 #include <seastar/core/distributed.hh>
 #include "gms/failure_detector.hh"
 #include "gms/gossiper.hh"
+#include "gms/inet_address_serializer.hh"
 #include "service/storage_service.hh"
 #include "streaming/prepare_message.hh"
 #include "gms/gossip_digest_syn.hh"

--- a/message/messaging_service.cc
+++ b/message/messaging_service.cc
@@ -200,7 +200,7 @@ std::ostream& operator<<(std::ostream& os, const msg_addr& x) {
 
 size_t msg_addr::hash::operator()(const msg_addr& id) const {
     // Ignore cpu id for now since we do not really support // shard to shard connections
-    return std::hash<uint32_t>()(id.addr.raw_addr());
+    return std::hash<bytes_view>()(id.addr.bytes());
 }
 
 messaging_service::shard_info::shard_info(shared_ptr<rpc_protocol_client_wrapper>&& client)
@@ -601,7 +601,7 @@ shared_ptr<messaging_service::rpc_protocol_client_wrapper> messaging_service::ge
         return true;
     }();
 
-    auto remote_addr = socket_address(get_preferred_ip(id.addr).raw_addr(), must_encrypt ? _ssl_port : _port);
+    auto remote_addr = socket_address(get_preferred_ip(id.addr), must_encrypt ? _ssl_port : _port);
 
     rpc::client_options opts;
     // send keepalive messages each minute if connection is idle, drop connection after 10 failures

--- a/service/client_state.hh
+++ b/service/client_state.hh
@@ -179,7 +179,6 @@ public:
             , _cpu_of_origin(engine().cpu_id())
             , _is_internal(true)
             , _is_thrift(false)
-            , _remote_address(ipv4_addr())
     {}
 
     ///

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -2192,7 +2192,7 @@ future<> storage_service::start_rpc_server() {
                 //engine().at_exit([tserver] {
                 //    return tserver->stop();
                 //});
-                return tserver->invoke_on_all(&thrift_server::listen, ipv4_addr{ip, port}, keepalive);
+                return tserver->invoke_on_all(&thrift_server::listen, socket_address{ip, port}, keepalive);
             });
         }).then([addr, port] {
             slogger.info("Thrift server listening on {}:{} ...", addr, port);
@@ -2251,11 +2251,11 @@ future<> storage_service::start_native_transport() {
                 auto f = make_ready_future();
 
                 struct listen_cfg {
-                    ipv4_addr addr;
+                    socket_address addr;
                     std::shared_ptr<seastar::tls::credentials_builder> cred;
                 };
 
-                std::vector<listen_cfg> configs({ { ipv4_addr{ip, cfg.native_transport_port()} }});
+                std::vector<listen_cfg> configs({ { socket_address{ip, cfg.native_transport_port()} }});
 
                 // main should have made sure values are clean and neatish
                 if (ceo.at("enabled") == "true") {
@@ -2280,7 +2280,7 @@ future<> storage_service::start_native_transport() {
                     slogger.info("Enabling encrypted CQL connections between client and server");
 
                     if (cfg.native_transport_port_ssl.is_set() && cfg.native_transport_port_ssl() != cfg.native_transport_port()) {
-                        configs.emplace_back(listen_cfg{ipv4_addr{ip, cfg.native_transport_port_ssl()}, std::move(cred)});
+                        configs.emplace_back(listen_cfg{{ip, cfg.native_transport_port_ssl()}, std::move(cred)});
                     } else {
                         configs.back().cred = std::move(cred);
                     }

--- a/thrift/server.cc
+++ b/thrift/server.cc
@@ -216,10 +216,10 @@ thrift_server::connection::shutdown() {
 }
 
 future<>
-thrift_server::listen(ipv4_addr addr, bool keepalive) {
+thrift_server::listen(socket_address addr, bool keepalive) {
     listen_options lo;
     lo.reuse_address = true;
-    _listeners.push_back(engine().listen(make_ipv4_address(addr), lo));
+    _listeners.push_back(engine().listen(addr, lo));
     do_accepts(_listeners.size() - 1, keepalive);
     return make_ready_future<>();
 }

--- a/thrift/server.hh
+++ b/thrift/server.hh
@@ -119,7 +119,7 @@ private:
 public:
     thrift_server(distributed<database>& db, distributed<cql3::query_processor>& qp, auth::service&, thrift_server_config config);
     ~thrift_server();
-    future<> listen(ipv4_addr addr, bool keepalive);
+    future<> listen(socket_address addr, bool keepalive);
     future<> stop();
     void do_accepts(int which, bool keepalive);
     uint64_t total_connections() const;

--- a/transport/event.cc
+++ b/transport/event.cc
@@ -47,7 +47,7 @@ event::event(const event_type& type_)
     : type{type_}
 { }
 
-event::topology_change::topology_change(change_type change, const ipv4_addr& node)
+event::topology_change::topology_change(change_type change, const socket_address& node)
     : event{event_type::TOPOLOGY_CHANGE}
     , change{change}
     , node{node}
@@ -55,15 +55,15 @@ event::topology_change::topology_change(change_type change, const ipv4_addr& nod
 
 event::topology_change event::topology_change::new_node(const gms::inet_address& host, uint16_t port)
 {
-    return topology_change{change_type::NEW_NODE, ipv4_addr{host.raw_addr(), port}};
+    return topology_change{change_type::NEW_NODE, socket_address{host, port}};
 }
 
 event::topology_change event::topology_change::removed_node(const gms::inet_address& host, uint16_t port)
 {
-    return topology_change{change_type::REMOVED_NODE, ipv4_addr{host.raw_addr(), port}};
+    return topology_change{change_type::REMOVED_NODE, socket_address{host, port}};
 }
 
-event::status_change::status_change(status_type status, const ipv4_addr& node)
+event::status_change::status_change(status_type status, const socket_address& node)
     : event{event_type::STATUS_CHANGE}
     , status{status}
     , node{node}
@@ -71,12 +71,12 @@ event::status_change::status_change(status_type status, const ipv4_addr& node)
 
 event::status_change event::status_change::node_up(const gms::inet_address& host, uint16_t port)
 {
-    return status_change{status_type::UP, ipv4_addr{host.raw_addr(), port}};
+    return status_change{status_type::UP, socket_address{host, port}};
 }
 
 event::status_change event::status_change::node_down(const gms::inet_address& host, uint16_t port)
 {
-    return status_change{status_type::DOWN, ipv4_addr{host.raw_addr(), port}};
+    return status_change{status_type::DOWN, socket_address{host, port}};
 }
 
 event::schema_change::schema_change(const change_type change_, const target_type target_, const sstring& keyspace_, const std::optional<sstring>& table_or_type_or_function_)

--- a/transport/event.hh
+++ b/transport/event.hh
@@ -69,9 +69,9 @@ public:
     enum class change_type { NEW_NODE, REMOVED_NODE, MOVED_NODE };
 
     const change_type change;
-    const ipv4_addr node;
+    const socket_address node;
 
-    topology_change(change_type change, const ipv4_addr& node);
+    topology_change(change_type change, const socket_address& node);
 
     static topology_change new_node(const gms::inet_address& host, uint16_t port);
 
@@ -83,9 +83,9 @@ public:
     enum class status_type { UP, DOWN };
 
     const status_type status;
-    const ipv4_addr node;
+    const socket_address node;
 
-    status_change(status_type status, const ipv4_addr& node);
+    status_change(status_type status, const socket_address& node);
 
     static status_change node_up(const gms::inet_address& host, uint16_t port);
 

--- a/transport/event_notifier.cc
+++ b/transport/event_notifier.cc
@@ -242,7 +242,7 @@ void cql_server::event_notifier::on_join_cluster(const gms::inet_address& endpoi
     for (auto&& conn : _topology_change_listeners) {
         using namespace cql_transport;
         if (!conn->_pending_requests_gate.is_closed()) {
-            conn->write_response(conn->make_topology_change_event(event::topology_change::new_node(endpoint, conn->_server_addr.port)));
+            conn->write_response(conn->make_topology_change_event(event::topology_change::new_node(endpoint, conn->_server_addr.port())));
         };
     }
 }
@@ -252,7 +252,7 @@ void cql_server::event_notifier::on_leave_cluster(const gms::inet_address& endpo
     for (auto&& conn : _topology_change_listeners) {
         using namespace cql_transport;
         if (!conn->_pending_requests_gate.is_closed()) {
-            conn->write_response(conn->make_topology_change_event(event::topology_change::removed_node(endpoint, conn->_server_addr.port)));
+            conn->write_response(conn->make_topology_change_event(event::topology_change::removed_node(endpoint, conn->_server_addr.port())));
         };
     }
 }
@@ -265,7 +265,7 @@ void cql_server::event_notifier::on_up(const gms::inet_address& endpoint)
         for (auto&& conn : _status_change_listeners) {
             using namespace cql_transport;
             if (!conn->_pending_requests_gate.is_closed()) {
-                conn->write_response(conn->make_status_change_event(event::status_change::node_up(endpoint, conn->_server_addr.port)));
+                conn->write_response(conn->make_status_change_event(event::status_change::node_up(endpoint, conn->_server_addr.port())));
             };
         }
     }
@@ -279,7 +279,7 @@ void cql_server::event_notifier::on_down(const gms::inet_address& endpoint)
         for (auto&& conn : _status_change_listeners) {
             using namespace cql_transport;
             if (!conn->_pending_requests_gate.is_closed()) {
-                conn->write_response(conn->make_status_change_event(event::status_change::node_down(endpoint, conn->_server_addr.port)));
+                conn->write_response(conn->make_status_change_event(event::status_change::node_down(endpoint, conn->_server_addr.port())));
             };
         }
     }

--- a/transport/response.hh
+++ b/transport/response.hh
@@ -82,7 +82,7 @@ public:
     void write_string_list(std::vector<sstring> string_list);
     void write_bytes(bytes b);
     void write_short_bytes(bytes b);
-    void write_inet(ipv4_addr inet);
+    void write_inet(socket_address inet);
     void write_consistency(db::consistency_level c);
     void write_string_map(std::map<sstring, sstring> string_map);
     void write_string_multimap(std::multimap<sstring, sstring> string_map);

--- a/transport/server.hh
+++ b/transport/server.hh
@@ -135,8 +135,8 @@ private:
 public:
     cql_server(distributed<service::storage_proxy>& proxy, distributed<cql3::query_processor>& qp, cql_load_balance lb, auth::service&,
             cql_server_config config);
-    future<> listen(ipv4_addr addr, std::shared_ptr<seastar::tls::credentials_builder> = {}, bool keepalive = false);
-    future<> do_accepts(int which, bool keepalive, ipv4_addr server_addr);
+    future<> listen(socket_address addr, std::shared_ptr<seastar::tls::credentials_builder> = {}, bool keepalive = false);
+    future<> do_accepts(int which, bool keepalive, socket_address server_addr);
     future<> stop();
 public:
     using response = cql_transport::response;
@@ -155,7 +155,7 @@ private:
         };
 
         cql_server& _server;
-        ipv4_addr _server_addr;
+        socket_address _server_addr;
         connected_socket _fd;
         input_stream<char> _read_buf;
         output_stream<char> _write_buf;
@@ -185,7 +185,7 @@ private:
                 tracing_request_type>;
         static thread_local execution_stage_type _process_request_stage;
     public:
-        connection(cql_server& server, ipv4_addr server_addr, connected_socket&& fd, socket_address addr);
+        connection(cql_server& server, socket_address server_addr, connected_socket&& fd, socket_address addr);
         ~connection();
         future<> process();
         future<> process_request();

--- a/types.cc
+++ b/types.cc
@@ -3927,6 +3927,8 @@ data_value::data_value(seastar::net::inet_address v) : data_value(make_new(inet_
 
 data_value::data_value(seastar::net::ipv4_address v) : data_value(seastar::net::inet_address(v)) {
 }
+data_value::data_value(seastar::net::ipv6_address v) : data_value(seastar::net::inet_address(v)) {
+}
 
 data_value::data_value(simple_date_native_type v) : data_value(make_new(simple_date_type, v.days)) {
 }

--- a/types.hh
+++ b/types.hh
@@ -378,6 +378,7 @@ public:
     data_value(float);
     data_value(double);
     data_value(net::ipv4_address);
+    data_value(net::ipv6_address);
     data_value(seastar::net::inet_address);
     data_value(simple_date_native_type);
     data_value(timestamp_native_type);


### PR DESCRIPTION
Fixes #2027

Modifies inet address type in scylla to use seastar::net::inet_address,
and removes explicit use of ipv4_addr in various network code in favour
of socket_address. Thus capable of resolving and binding to ipv6.

Adds config option to enable/disable ipv6 (default enabled), so
upgrading cluster can continue to work while running mixed version
nodes (since gossip message address serialization becomes different).

v2:
* Made serialization of gms::inet_address ipv6 aware (encoding
  addresses so that ipv4 encoding remains the same).
* Made address lookup family optional
* Added enable/disable option
* Removed legacy "raw" access

v3:
* Rebased on master
* Renamed enable_ipv6 to enable_ipv6_dns_lookup