### PR TITLE
Fix possible stalls in row level repair

### DIFF
--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -1016,7 +1016,7 @@ private:
         _last_sync_boundary = _current_sync_boundary;
         size_t current_size = row_buf_size();
         return read_rows_from_disk(current_size).then([this, skipped_sync_boundary = std::move(skipped_sync_boundary)] (std::list<repair_row> new_rows) mutable {
-            size_t new_rows_size = boost::accumulate(new_rows, size_t(0), [] (size_t x, const repair_row& r) { return x + r.size(); });
+            size_t new_rows_size = get_repair_rows_size(new_rows);
             size_t new_rows_nr = new_rows.size();
             _row_buf.splice(_row_buf.end(), new_rows);
             std::optional<repair_sync_boundary> sb_max;

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -168,6 +168,7 @@ static thread_local row_level_repair_metrics _metrics;
 static const std::vector<row_level_diff_detect_algorithm>& suportted_diff_detect_algorithms() {
     static std::vector<row_level_diff_detect_algorithm> _algorithms = {
         row_level_diff_detect_algorithm::send_full_set,
+        row_level_diff_detect_algorithm::send_full_set_rpc_stream,
     };
     return _algorithms;
 };

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -302,7 +302,7 @@ class repair_row {
     std::optional<repair_hash> _hash;
     lw_shared_ptr<mutation_fragment> _mf;
 public:
-    repair_row() = delete;
+    repair_row() = default;
     repair_row(std::optional<frozen_mutation_fragment> fm,
             std::optional<position_in_partition> pos,
             lw_shared_ptr<const decorated_key_with_hash> dk_with_hash,

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -1133,6 +1133,45 @@ private:
         });
     }
 
+    // Give a list of rows, apply the rows to disk and update the _working_row_buf and _peer_row_hash_sets if requested
+    // Must run inside a seastar thread
+    void apply_rows_on_master_in_thread(repair_rows_on_wire rows, gms::inet_address from, update_working_row_buf update_buf,
+            update_peer_row_hash_sets update_hash_set, unsigned node_idx = 0) {
+        if (rows.empty()) {
+            return;
+        }
+        auto row_diff = to_repair_rows_list(rows).get0();
+        auto sz = get_repair_rows_size(row_diff);
+        stats().rx_row_bytes += sz;
+        stats().rx_row_nr += row_diff.size();
+        stats().rx_row_nr_peer[from] += row_diff.size();
+        if (update_buf) {
+            std::list<repair_row> tmp;
+            tmp.swap(_working_row_buf);
+            // Both row_diff and _working_row_buf and are ordered, merging
+            // two sored list to make sure the combination of row_diff
+            // and _working_row_buf are ordered.
+            std::merge(tmp.begin(), tmp.end(), row_diff.begin(), row_diff.end(), std::back_inserter(_working_row_buf),
+                [this] (const repair_row& x, const repair_row& y) { thread::maybe_yield(); return _cmp(x.boundary(), y.boundary()) < 0; });
+        }
+        if (update_hash_set) {
+            _peer_row_hash_sets[node_idx] = boost::copy_range<std::unordered_set<repair_hash>>(row_diff |
+                    boost::adaptors::transformed([] (repair_row& r) { thread::maybe_yield(); return r.hash(); }));
+        }
+        _repair_writer.create_writer(node_idx);
+        for (auto& r : row_diff) {
+            if (update_buf) {
+                _working_row_buf_combined_hash.add(r.hash());
+            }
+            // The repair_row here is supposed to have
+            // mutation_fragment attached because we have stored it in
+            // to_repair_rows_list above where the repair_row is created.
+            mutation_fragment mf = std::move(r.get_mutation_fragment());
+            auto dk_with_hash = r.get_dk_with_hash();
+            _repair_writer.do_write(node_idx, std::move(dk_with_hash), std::move(mf)).get();
+        }
+    }
+
     future<>
     apply_rows_on_follower(repair_rows_on_wire rows) {
         if (rows.empty()) {

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -1065,11 +1065,6 @@ private:
         });
     }
 
-    std::unordered_set<repair_hash>
-    get_full_row_hashes() {
-        return working_row_hashes();
-    }
-
     // Return rows in the _working_row_buf with hash within the given sef_diff
     // Give a set of row hashes, return the corresponding rows
     // If needs_all_rows is set, return all the rows in _working_row_buf, ignore the set_diff
@@ -1282,7 +1277,7 @@ public:
     future<std::unordered_set<repair_hash>>
     get_full_row_hashes_handler() {
         return with_gate(_gate, [this] {
-            return get_full_row_hashes();
+            return working_row_hashes();
         });
     }
 


### PR DESCRIPTION
After switching to rpc stream interface, we increased the row buffer
size. Code works on the buffer that do not yield can stall the reactor.

This series fixes the issue by futurizing or running the code in thread
 and yield.

Fixes:  #4642