### PR TITLE
Implement tuple_type_impl::to_string_impl.

### DIFF
--- a/tests/types_test.cc
+++ b/tests/types_test.cc
@@ -484,7 +484,7 @@ BOOST_AUTO_TEST_CASE(test_tuple) {
     auto native_to_c = [] (native_type v) {
         return std::make_tuple(extract<int32_t>(v[0]), extract<int64_t>(v[1]), extract<sstring>(v[2]));
     };
-    auto c_to_native = [] (std::tuple<opt<int32_t>, opt<int64_t>, opt<sstring>> v) {
+    auto c_to_native = [] (c_type v) {
         return native_type({std::get<0>(v), std::get<1>(v), std::get<2>(v)});
     };
     auto native_to_bytes = [t] (native_type v) {
@@ -510,6 +510,13 @@ BOOST_AUTO_TEST_CASE(test_tuple) {
     auto b2 = c_to_bytes(v2);
     BOOST_REQUIRE(t->compare(b1, b2) > 0);
     BOOST_REQUIRE(t->compare(b2, b2) == 0);
+
+    auto test_string_conversion = [=] (c_type v, sstring s) {
+        BOOST_REQUIRE_EQUAL(t->to_string(c_to_bytes(v)), s);
+        BOOST_REQUIRE(t->equal(t->from_string(s), c_to_bytes(v)));
+    };
+
+    test_string_conversion({10, {}, "a@@:b:c"}, "10:@:a\\@\\@\\:b\\:c");
 }
 
 void test_validation_fails(const shared_ptr<const abstract_type>& type, bytes_view v)

--- a/types.cc
+++ b/types.cc
@@ -3447,12 +3447,12 @@ static std::vector<sstring_view> split_field_strings(sstring_view v) {
 
 // Replace "\:" with ":" and "\@" with "@".
 static std::string unescape(sstring_view s) {
-    static thread_local std::regex escaped_colon_re("\\\\:");
-    static thread_local std::regex escaped_at_re("\\\\@");
-    std::string result(s);
-    result = std::regex_replace(result, escaped_colon_re, ":");
-    result = std::regex_replace(result, escaped_at_re, "@");
-    return result;
+    return std::regex_replace(std::string(s), std::regex("\\\\([@:])"), "$1");
+}
+
+// Replace ":" with "\:" and "@" with "\@".
+static std::string escape(sstring_view s) {
+    return std::regex_replace(std::string(s), std::regex("[@:]"), "\\$0");
 }
 
 // Concat list of bytes into a single bytes.
@@ -3492,8 +3492,29 @@ tuple_type_impl::from_string(sstring_view s) const {
 }
 
 sstring
-tuple_type_impl::to_string_impl(const data_value&) const {
-    throw std::runtime_error(format("{} not implemented", __PRETTY_FUNCTION__));
+tuple_type_impl::to_string_impl(const data_value& v) const {
+    const auto& b = from_value(v);
+    if (b.empty()) {
+        return "";
+    }
+
+    std::ostringstream out;
+    for (size_t i = 0; i < b.size(); ++i) {
+        if (i > 0) {
+            out << ":";
+        }
+
+        const auto& val = b[i];
+        if (val.is_null()) {
+            out << "@";
+        } else {
+            // We use ':' as delimiter and '@' to represent null, so they need to be escaped in the tuple's fields.
+            auto typ = type(i);
+            out << escape(typ->to_string(typ->decompose(val)));
+        }
+    }
+
+    return out.str();
 }
 
 sstring tuple_type_impl::to_json_string(bytes_view bv) const {


### PR DESCRIPTION
Resolves #4633 (tuple_type was the only type for which to_string wasn't implemented yet).