### PR TITLE
Warn user about using SimpleStrategy with Multi DC deployment

### DIFF
--- a/cql3/statements/create_keyspace_statement.hh
+++ b/cql3/statements/create_keyspace_statement.hh
@@ -44,6 +44,7 @@
 #include "cql3/statements/schema_altering_statement.hh"
 #include "cql3/statements/ks_prop_defs.hh"
 #include "transport/event.hh"
+#include "log.hh"
 
 #include <seastar/core/shared_ptr.hh>
 
@@ -54,6 +55,8 @@ namespace statements {
 /** A <code>CREATE KEYSPACE</code> statement parsed from a CQL query. */
 class create_keyspace_statement : public schema_altering_statement {
 private:
+    static logging::logger _logger;
+
     sstring _name;
     shared_ptr<ks_prop_defs> _attrs;
     bool _if_not_exists;
@@ -86,6 +89,9 @@ public:
     virtual std::unique_ptr<prepared> prepare(database& db, cql_stats& stats) override;
 
     virtual future<> grant_permissions_to_creator(const service::client_state&) override;
+
+    virtual future<::shared_ptr<messages::result_message>>
+    execute(service::storage_proxy& proxy, service::query_state& state, const query_options& options) override;
 };
 
 }

--- a/transport/messages/result_message_base.hh
+++ b/transport/messages/result_message_base.hh
@@ -26,6 +26,7 @@ namespace cql_transport {
 namespace messages {
 
 class result_message {
+    std::vector<sstring> _warnings;
 public:
     class visitor;
     class visitor_base;
@@ -33,6 +34,14 @@ public:
     virtual ~result_message() {}
 
     virtual void accept(visitor&) const = 0;
+
+    void add_warning(sstring w) {
+        _warnings.push_back(std::move(w));
+    }
+
+    const std::vector<sstring>& warnings() const {
+        return _warnings;
+    }
 
     //
     // Message types:

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -1218,6 +1218,10 @@ std::unique_ptr<cql_server::response>
 cql_server::connection::make_result(int16_t stream, shared_ptr<messages::result_message> msg, const tracing::trace_state_ptr& tr_state, bool skip_metadata)
 {
     auto response = std::make_unique<cql_server::response>(stream, cql_binary_opcode::RESULT, tr_state);
+    if (__builtin_expect(!msg->warnings().empty() && _version > 3, false)) {
+        response->set_frame_flag(cql_frame_flags::warning);
+        response->write_string_list(msg->warnings());
+    }
     fmt_visitor fmt{_version, *response, skip_metadata};
     msg->accept(fmt);
     return response;

--- a/transport/server.hh
+++ b/transport/server.hh
@@ -60,6 +60,7 @@ enum class cql_compression {
 enum cql_frame_flags {
     compression = 0x01,
     tracing     = 0x02,
+    warning     = 0x08,
 };
 
 struct [[gnu::packed]] cql_binary_frame_v1 {


### PR DESCRIPTION
If the user creates a keyspace with the 'SimpleStrategy' replication class
in a multi-datacenter environment, they will receive a warning in the CQL shell
and in the server logs.
Resolves #4481 and #4651.