### PR TITLE
toppartitions: fix race between listener removal and reads

### DIFF
--- a/db/data_listeners.cc
+++ b/db/data_listeners.cc
@@ -84,8 +84,11 @@ flat_mutation_reader toppartitions_data_listener::on_read(const schema_ptr& s, c
         return std::move(rd);
     }
     dblog.trace("toppartitions_data_listener::on_read: {}.{}", s->ks_name(), s->cf_name());
-    return make_filtering_reader(std::move(rd), [this, &range, &slice, s = std::move(s)] (const dht::decorated_key& dk) {
-        _top_k_read.append(toppartitions_item_key{s, dk});
+    return make_filtering_reader(std::move(rd), [zis = this->weak_from_this(), &range, &slice, s = std::move(s)] (const dht::decorated_key& dk) {
+        // The data query may be executing after the toppartitions_data_listener object has been removed, so check
+        if (zis) {
+            zis->_top_k_read.append(toppartitions_item_key{s, dk});
+        }
         return true;
     });
 }

--- a/db/data_listeners.hh
+++ b/db/data_listeners.hh
@@ -24,6 +24,7 @@
 #include <seastar/core/distributed.hh>
 #include <seastar/core/future.hh>
 #include <seastar/core/distributed.hh>
+#include <seastar/core/weak_ptr.hh>
 
 #include "schema.hh"
 #include "flat_mutation_reader.hh"
@@ -97,7 +98,7 @@ struct toppartitions_item_key {
     explicit operator sstring() const;
 };
 
-class toppartitions_data_listener : public data_listener {
+class toppartitions_data_listener : public data_listener, public weakly_referencable<toppartitions_data_listener> {
     friend class toppartitions_query;
 
     database& _db;


### PR DESCRIPTION
Data listener reads are implemented as flat_mutation_readers, which
take a reference to the listener and then execute asynchronously.
The listener can be removed between the time when the reference is
taken and actual execution, resulting in a dangling pointer
dereference.

Fix by using a weak_ptr to avoid writing to a destroyed object. Note that writes
don't need protection because they execute atomically.

Fixes #4661.

Tests: unit (dev)
