### PR TITLE
Fix possible stalls in row level repair

### DIFF
--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -1016,7 +1016,7 @@ private:
         _last_sync_boundary = _current_sync_boundary;
         size_t current_size = row_buf_size();
         return read_rows_from_disk(current_size).then([this, skipped_sync_boundary = std::move(skipped_sync_boundary)] (std::list<repair_row> new_rows) mutable {
-            size_t new_rows_size = boost::accumulate(new_rows, size_t(0), [] (size_t x, const repair_row& r) { return x + r.size(); });
+            size_t new_rows_size = get_repair_rows_size(new_rows);
             size_t new_rows_nr = new_rows.size();
             _row_buf.splice(_row_buf.end(), new_rows);
             std::optional<repair_sync_boundary> sb_max;

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -168,6 +168,7 @@ static thread_local row_level_repair_metrics _metrics;
 static const std::vector<row_level_diff_detect_algorithm>& suportted_diff_detect_algorithms() {
     static std::vector<row_level_diff_detect_algorithm> _algorithms = {
         row_level_diff_detect_algorithm::send_full_set,
+        row_level_diff_detect_algorithm::send_full_set_rpc_stream,
     };
     return _algorithms;
 };

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -1116,7 +1116,6 @@ private:
     future<std::list<repair_row>>
     get_row_diff(std::unordered_set<repair_hash> set_diff, needs_all_rows_t needs_all_rows = needs_all_rows_t::no) {
         if (needs_all_rows) {
-            std::list<repair_row> rows;
             if (!_repair_master || _nr_peer_nodes == 1) {
                 return make_ready_future<std::list<repair_row>>(std::move(_working_row_buf));
             }

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -807,12 +807,13 @@ public:
         });
     }
 
+    // Must run inside a seastar thread
     static std::unordered_set<repair_hash>
     get_set_diff(const std::unordered_set<repair_hash>& x, const std::unordered_set<repair_hash>& y) {
         std::unordered_set<repair_hash> set_diff;
         // Note std::set_difference needs x and y are sorted.
         std::copy_if(x.begin(), x.end(), std::inserter(set_diff, set_diff.end()),
-                [&y] (auto& item) { return y.find(item) == y.end(); });
+                [&y] (auto& item) { thread::maybe_yield(); return y.find(item) == y.end(); });
         return set_diff;
     }
 
@@ -2334,9 +2335,14 @@ private:
         check_in_shutdown();
         _ri.check_in_abort();
         std::unordered_set<repair_hash> local_row_hash_sets = master.working_row_hashes().get0();
-        parallel_for_each(boost::irange(size_t(0), _all_live_peer_nodes.size()), [&, this] (size_t idx) {
-            auto set_diff = repair_meta::get_set_diff(local_row_hash_sets, master.peer_row_hash_sets(idx));
+        auto sz = _all_live_peer_nodes.size();
+        std::vector<std::unordered_set<repair_hash>> set_diffs(sz);
+        for (size_t idx : boost::irange(size_t(0), sz)) {
+            set_diffs[idx] = repair_meta::get_set_diff(local_row_hash_sets, master.peer_row_hash_sets(idx));
+        }
+        parallel_for_each(boost::irange(size_t(0), sz), [&, this] (size_t idx) {
             auto needs_all_rows = repair_meta::needs_all_rows_t(master.peer_row_hash_sets(idx).empty());
+            auto& set_diff = set_diffs[idx];
             rlogger.debug("Calling master.put_row_diff to node {}, set_diff={}, needs_all_rows={}", _all_live_peer_nodes[idx], set_diff.size(), needs_all_rows);
             if (master.use_rpc_stream()) {
                 return master.put_row_diff_with_rpc_stream(std::move(set_diff), needs_all_rows, _all_live_peer_nodes[idx], idx);

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -928,12 +928,18 @@ private:
                && engine().cpu_id() == _master_node_shard_config.shard;
     }
 
-    size_t get_repair_rows_size(const std::list<repair_row>& rows) const {
-        return boost::accumulate(rows, size_t(0), [] (size_t x, const repair_row& r) { return x + r.size(); });
+    future<size_t> get_repair_rows_size(const std::list<repair_row>& rows) const {
+        return do_with(size_t(0), [&rows] (size_t& sz) {
+            return do_for_each(rows, [&sz] (const repair_row& r) mutable {
+                sz += r.size();
+            }).then([&sz] {
+                return sz;
+            });
+        });
     }
 
     // Get the size of rows in _row_buf
-    size_t row_buf_size() const {
+    future<size_t> row_buf_size() const {
         return get_repair_rows_size(_row_buf);
     }
 
@@ -1020,18 +1026,21 @@ private:
         // Here is the place we update _last_sync_boundary
         rlogger.trace("SET _last_sync_boundary from {} to {}", _last_sync_boundary, _current_sync_boundary);
         _last_sync_boundary = _current_sync_boundary;
-        size_t current_size = row_buf_size();
-        return read_rows_from_disk(current_size).then([this, skipped_sync_boundary = std::move(skipped_sync_boundary)] (std::list<repair_row> new_rows, size_t new_rows_size) mutable {
-            size_t new_rows_nr = new_rows.size();
-            _row_buf.splice(_row_buf.end(), new_rows);
-            return row_buf_csum().then([this, new_rows_size, new_rows_nr, skipped_sync_boundary = std::move(skipped_sync_boundary)] (repair_hash row_buf_combined_hash) {
-                std::optional<repair_sync_boundary> sb_max;
-                if (!_row_buf.empty()) {
-                    sb_max = _row_buf.back().boundary();
-                }
-                rlogger.debug("get_sync_boundary: Got nr={} rows, sb_max={}, row_buf_size={}, repair_hash={}, skipped_sync_boundary={}",
-                        new_rows_nr, sb_max, row_buf_size(), row_buf_combined_hash, skipped_sync_boundary);
-                return get_sync_boundary_response{sb_max, row_buf_combined_hash, row_buf_size(), new_rows_size, new_rows_nr};
+        return row_buf_size().then([this, sb = std::move(skipped_sync_boundary)] (size_t cur_size) {
+            return read_rows_from_disk(cur_size).then([this, sb = std::move(sb)] (std::list<repair_row> new_rows, size_t new_rows_size) mutable {
+                size_t new_rows_nr = new_rows.size();
+                _row_buf.splice(_row_buf.end(), new_rows);
+                return row_buf_csum().then([this, new_rows_size, new_rows_nr, sb = std::move(sb)] (repair_hash row_buf_combined_hash) {
+                    return row_buf_size().then([this, new_rows_size, new_rows_nr, row_buf_combined_hash, sb = std::move(sb)] (size_t row_buf_bytes) {
+                        std::optional<repair_sync_boundary> sb_max;
+                        if (!_row_buf.empty()) {
+                            sb_max = _row_buf.back().boundary();
+                        }
+                        rlogger.debug("get_sync_boundary: Got nr={} rows, sb_max={}, row_buf_size={}, repair_hash={}, skipped_sync_boundary={}",
+                                new_rows_nr, sb_max, row_buf_bytes, row_buf_combined_hash, sb);
+                        return get_sync_boundary_response{sb_max, row_buf_combined_hash, row_buf_bytes, new_rows_size, new_rows_nr};
+                    });
+                });
             });
         });
     }
@@ -1145,7 +1154,7 @@ private:
             return;
         }
         auto row_diff = to_repair_rows_list(rows).get0();
-        auto sz = get_repair_rows_size(row_diff);
+        auto sz = get_repair_rows_size(row_diff).get0();
         stats().rx_row_bytes += sz;
         stats().rx_row_nr += row_diff.size();
         stats().rx_row_nr_peer[from] += row_diff.size();
@@ -1198,24 +1207,26 @@ private:
     }
 
     future<repair_rows_on_wire> to_repair_rows_on_wire(std::list<repair_row> row_list) {
-        _metrics.tx_row_nr += row_list.size();
-        _metrics.tx_row_bytes += get_repair_rows_size(row_list);
         return do_with(repair_rows_on_wire(), std::move(row_list), [this] (repair_rows_on_wire& rows, std::list<repair_row>& row_list) {
-            return do_for_each(row_list, [this, &rows] (repair_row& r) {
-                auto pk = r.get_dk_with_hash()->dk.key();
-                // No need to search from the beginning of the rows. Look at the end of repair_rows_on_wire is enough.
-                if (rows.empty()) {
-                    rows.push_back(repair_row_on_wire(std::move(pk), {std::move(r.get_frozen_mutation())}));
-                } else {
-                    auto& row = rows.back();
-                    if (pk.legacy_equal(*_schema, row.get_key())) {
-                        row.push_mutation_fragment(std::move(r.get_frozen_mutation()));
-                    } else {
+            return get_repair_rows_size(row_list).then([this, &rows, &row_list] (size_t row_bytes) {
+                _metrics.tx_row_nr += row_list.size();
+                _metrics.tx_row_bytes += row_bytes;
+                return do_for_each(row_list, [this, &rows] (repair_row& r) {
+                    auto pk = r.get_dk_with_hash()->dk.key();
+                    // No need to search from the beginning of the rows. Look at the end of repair_rows_on_wire is enough.
+                    if (rows.empty()) {
                         rows.push_back(repair_row_on_wire(std::move(pk), {std::move(r.get_frozen_mutation())}));
+                    } else {
+                        auto& row = rows.back();
+                        if (pk.legacy_equal(*_schema, row.get_key())) {
+                            row.push_mutation_fragment(std::move(r.get_frozen_mutation()));
+                        } else {
+                            rows.push_back(repair_row_on_wire(std::move(pk), {std::move(r.get_frozen_mutation())}));
+                        }
                     }
-                }
-            }).then([&rows] {
-                return std::move(rows);
+                }).then([&rows] {
+                    return std::move(rows);
+                });
             });
         });
     };
@@ -1622,12 +1633,16 @@ public:
                 if (row_diff.size() != sz) {
                     throw std::runtime_error("row_diff.size() != set_diff.size()");
                 }
-                stats().tx_row_nr += row_diff.size();
-                stats().tx_row_nr_peer[remote_node] += row_diff.size();
-                stats().tx_row_bytes += get_repair_rows_size(row_diff);
-                stats().rpc_call_nr++;
-                return to_repair_rows_on_wire(std::move(row_diff)).then([this, remote_node] (repair_rows_on_wire rows)  {
-                    return netw::get_local_messaging_service().send_repair_put_row_diff(msg_addr(remote_node), _repair_meta_id, std::move(rows));
+                return do_with(std::move(row_diff), [this, remote_node] (std::list<repair_row>& row_diff) {
+                    return get_repair_rows_size(row_diff).then([this, remote_node, &row_diff] (size_t row_bytes) mutable {
+                        stats().tx_row_nr += row_diff.size();
+                        stats().tx_row_nr_peer[remote_node] += row_diff.size();
+                        stats().tx_row_bytes += row_bytes;
+                        stats().rpc_call_nr++;
+                        return to_repair_rows_on_wire(std::move(row_diff)).then([this, remote_node] (repair_rows_on_wire rows)  {
+                            return netw::get_local_messaging_service().send_repair_put_row_diff(msg_addr(remote_node), _repair_meta_id, std::move(rows));
+                        });
+                    });
                 });
             });
         }
@@ -1695,17 +1710,21 @@ public:
                 if (row_diff.size() != sz) {
                     throw std::runtime_error("row_diff.size() != set_diff.size()");
                 }
-                stats().tx_row_nr += row_diff.size();
-                stats().tx_row_nr_peer[remote_node] += row_diff.size();
-                stats().tx_row_bytes += get_repair_rows_size(row_diff);
-                stats().rpc_call_nr++;
-                return to_repair_rows_on_wire(std::move(row_diff)).then([this, remote_node, node_idx] (repair_rows_on_wire rows)  {
-                    return  _sink_source_for_put_row_diff.get_sink_source(remote_node, node_idx).then(
-                            [this, rows = std::move(rows), remote_node, node_idx]
-                            (rpc::sink<repair_row_on_wire_with_cmd>& sink, rpc::source<repair_stream_cmd>& source) mutable {
-                        auto source_op = put_row_diff_source_op(remote_node, node_idx, source);
-                        auto sink_op = put_row_diff_sink_op(std::move(rows), sink, remote_node);
-                        return when_all_succeed(std::move(source_op), std::move(sink_op));
+                return do_with(std::move(row_diff), [this, remote_node, node_idx] (std::list<repair_row>& row_diff) {
+                    return get_repair_rows_size(row_diff).then([this, remote_node, node_idx, &row_diff] (size_t row_bytes) mutable {
+                        stats().tx_row_nr += row_diff.size();
+                        stats().tx_row_nr_peer[remote_node] += row_diff.size();
+                        stats().tx_row_bytes += row_bytes;
+                        stats().rpc_call_nr++;
+                        return to_repair_rows_on_wire(std::move(row_diff)).then([this, remote_node, node_idx] (repair_rows_on_wire rows)  {
+                            return  _sink_source_for_put_row_diff.get_sink_source(remote_node, node_idx).then(
+                                    [this, rows = std::move(rows), remote_node, node_idx]
+                                    (rpc::sink<repair_row_on_wire_with_cmd>& sink, rpc::source<repair_stream_cmd>& source) mutable {
+                                auto source_op = put_row_diff_source_op(remote_node, node_idx, source);
+                                auto sink_op = put_row_diff_sink_op(std::move(rows), sink, remote_node);
+                                return when_all_succeed(std::move(source_op), std::move(sink_op));
+                            });
+                        });
                     });
                 });
             });

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -302,7 +302,7 @@ class repair_row {
     std::optional<repair_hash> _hash;
     lw_shared_ptr<mutation_fragment> _mf;
 public:
-    repair_row() = delete;
+    repair_row() = default;
     repair_row(std::optional<frozen_mutation_fragment> fm,
             std::optional<position_in_partition> pos,
             lw_shared_ptr<const decorated_key_with_hash> dk_with_hash,

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -1133,6 +1133,45 @@ private:
         });
     }
 
+    // Give a list of rows, apply the rows to disk and update the _working_row_buf and _peer_row_hash_sets if requested
+    // Must run inside a seastar thread
+    void apply_rows_on_master_in_thread(repair_rows_on_wire rows, gms::inet_address from, update_working_row_buf update_buf,
+            update_peer_row_hash_sets update_hash_set, unsigned node_idx = 0) {
+        if (rows.empty()) {
+            return;
+        }
+        auto row_diff = to_repair_rows_list(rows).get0();
+        auto sz = get_repair_rows_size(row_diff);
+        stats().rx_row_bytes += sz;
+        stats().rx_row_nr += row_diff.size();
+        stats().rx_row_nr_peer[from] += row_diff.size();
+        if (update_buf) {
+            std::list<repair_row> tmp;
+            tmp.swap(_working_row_buf);
+            // Both row_diff and _working_row_buf and are ordered, merging
+            // two sored list to make sure the combination of row_diff
+            // and _working_row_buf are ordered.
+            std::merge(tmp.begin(), tmp.end(), row_diff.begin(), row_diff.end(), std::back_inserter(_working_row_buf),
+                [this] (const repair_row& x, const repair_row& y) { thread::maybe_yield(); return _cmp(x.boundary(), y.boundary()) < 0; });
+        }
+        if (update_hash_set) {
+            _peer_row_hash_sets[node_idx] = boost::copy_range<std::unordered_set<repair_hash>>(row_diff |
+                    boost::adaptors::transformed([] (repair_row& r) { thread::maybe_yield(); return r.hash(); }));
+        }
+        _repair_writer.create_writer(node_idx);
+        for (auto& r : row_diff) {
+            if (update_buf) {
+                _working_row_buf_combined_hash.add(r.hash());
+            }
+            // The repair_row here is supposed to have
+            // mutation_fragment attached because we have stored it in
+            // to_repair_rows_list above where the repair_row is created.
+            mutation_fragment mf = std::move(r.get_mutation_fragment());
+            auto dk_with_hash = r.get_dk_with_hash();
+            _repair_writer.do_write(node_idx, std::move(dk_with_hash), std::move(mf)).get();
+        }
+    }
+
     future<>
     apply_rows_on_follower(repair_rows_on_wire rows) {
         if (rows.empty()) {

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -1065,11 +1065,6 @@ private:
         });
     }
 
-    std::unordered_set<repair_hash>
-    get_full_row_hashes() {
-        return working_row_hashes();
-    }
-
     // Return rows in the _working_row_buf with hash within the given sef_diff
     // Give a set of row hashes, return the corresponding rows
     // If needs_all_rows is set, return all the rows in _working_row_buf, ignore the set_diff
@@ -1282,7 +1277,7 @@ public:
     future<std::unordered_set<repair_hash>>
     get_full_row_hashes_handler() {
         return with_gate(_gate, [this] {
-            return get_full_row_hashes();
+            return working_row_hashes();
         });
     }
 


### PR DESCRIPTION
After switching to rpc stream interface, we increased the row buffer
size. Code works on the buffer that do not yield can stall the reactor.

This series fixes the issue by futurizing or running the code in thread
and yield.

Fixes: #4642