### PR TITLE
Auto-expand replication_factor for NetworkTopologyStrategy

### DIFF
--- a/cql3/statements/create_keyspace_statement.cc
+++ b/cql3/statements/create_keyspace_statement.cc
@@ -110,7 +110,8 @@ void create_keyspace_statement::validate(service::storage_proxy&, const service:
 future<shared_ptr<cql_transport::event::schema_change>> create_keyspace_statement::announce_migration(service::storage_proxy& proxy, bool is_local_only)
 {
     return make_ready_future<>().then([this, is_local_only] {
-        return service::get_local_migration_manager().announce_new_keyspace(_attrs->as_ks_metadata(_name), is_local_only);
+        const auto& tm = service::get_local_storage_service().get_token_metadata();
+        return service::get_local_migration_manager().announce_new_keyspace(_attrs->as_ks_metadata(_name, tm), is_local_only);
     }).then_wrapped([this] (auto&& f) {
         try {
             f.get();

--- a/cql3/statements/ks_prop_defs.hh
+++ b/cql3/statements/ks_prop_defs.hh
@@ -42,6 +42,7 @@
 #pragma once
 
 #include "cql3/statements/property_definitions.hh"
+#include "locator/token_metadata.hh"
 
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/core/sstring.hh>
@@ -59,14 +60,15 @@ public:
     static constexpr auto KW_REPLICATION = "replication";
 
     static constexpr auto REPLICATION_STRATEGY_CLASS_KEY = "class";
+    static constexpr auto REPLICATION_FACTOR_KEY = "replication_factor";
 private:
     std::optional<sstring> _strategy_class;
 public:
     void validate();
     std::map<sstring, sstring> get_replication_options() const;
     std::optional<sstring> get_replication_strategy_class() const;
-    lw_shared_ptr<keyspace_metadata> as_ks_metadata(sstring ks_name);
-    lw_shared_ptr<keyspace_metadata> as_ks_metadata_update(lw_shared_ptr<keyspace_metadata> old);
+    lw_shared_ptr<keyspace_metadata> as_ks_metadata(sstring ks_name, const locator::token_metadata&);
+    lw_shared_ptr<keyspace_metadata> as_ks_metadata_update(lw_shared_ptr<keyspace_metadata> old, const locator::token_metadata&);
 
 #if 0
     public KSMetaData asKSMetadataUpdate(KSMetaData old) throws RequestValidationException


### PR DESCRIPTION
If the user supplies the 'replication_factor' to the 'NetworkTopologyStrategy' class,
it will expand into a replication factor for each existing DC for their convenience.
Resolves #4210.
