### PR TITLE
Fix timestamp_type_impl::timestamp_from_string.

### DIFF
--- a/tests/types_test.cc
+++ b/tests/types_test.cc
@@ -253,6 +253,8 @@ void test_timestamp_like_string_conversions(data_type timestamp_type) {
     BOOST_REQUIRE(timestamp_type->equal(timestamp_type->from_string("2015-07-02 23:00-0100"), timestamp_type->decompose(tp)));
     BOOST_REQUIRE(timestamp_type->equal(timestamp_type->from_string("2015-07-03T00:00+0000"), timestamp_type->decompose(tp)));
     BOOST_REQUIRE(timestamp_type->equal(timestamp_type->from_string("2015-07-03T01:00:00+0000"), timestamp_type->decompose(tp + 1h)));
+    BOOST_REQUIRE(timestamp_type->equal(timestamp_type->from_string("2015-07-03t00:00:00z"), timestamp_type->decompose(tp)));
+    BOOST_REQUIRE(timestamp_type->equal(timestamp_type->from_string("2015-07-03T00:00:00Z"), timestamp_type->decompose(tp)));
     BOOST_REQUIRE(timestamp_type->equal(timestamp_type->from_string("2015-07-03T00:00:00.123+0000"), timestamp_type->decompose(tp + 123ms)));
     BOOST_REQUIRE(timestamp_type->equal(timestamp_type->from_string("2015-07-03T12:30:00+1230"), timestamp_type->decompose(tp)));
     BOOST_REQUIRE(timestamp_type->equal(timestamp_type->from_string("2015-07-02T23:00-0100"), timestamp_type->decompose(tp)));

--- a/types.cc
+++ b/types.cc
@@ -884,7 +884,7 @@ public:
                 auto t2 = local_tz::utc_to_local(t - tz_offset);
                 auto dst_offset = t2 - t;
                 t -= tz_offset + dst_offset;
-            } else {
+            } else if (tz != "z") {
                 throw marshal_exception(format("Unable to parse timezone '{}'", tz));
             }
             return (t - boost::posix_time::from_time_t(0)).total_milliseconds();


### PR DESCRIPTION
Now it accepts the 'z' or 'Z' timezone, denoting UTC+00:00.
Fixes #4641.

Since Scylla is already liberal when parsing the string (accepting 't' between date and time), I decided to follow this trend and accept 'z' as timezone too.