### PR TITLE
config_file.hh: get_value return a pointer to the value

### DIFF
--- a/utils/config_file.hh
+++ b/utils/config_file.hh
@@ -156,7 +156,7 @@ public:
             return const_cast<named_value*>(this)->the_value();
         }
         virtual const void* current_value() const override {
-            return &the_value();
+            return &the_value().get();
         }
     public:
         typedef T type;


### PR DESCRIPTION
The get_value method returns a pointer to the value that is used by the
value_to_json method.

The assumption is that the void pointer points to the actual value.

Fixes #4678

Signed-off-by: Amnon Heiman <amnon@scylladb.com>

Scylla doesn't use pull-requests, please send a patch to the [mailing list](mailto:scylladb-dev@googlegroups.com) instead.
See our [contributing guidelines](../CONTRIBUTING.md) and our [Scylla development guidelines](../HACKING.md) for more information.

If you have any questions please don't hesitate to send a mail to the [dev list](mailto:scylladb-dev@googlegroups.com).
