### PR TITLE
test: add 'eventually' block to index paging test

### DIFF
--- a/tests/secondary_index_test.cc
+++ b/tests/secondary_index_test.cc
@@ -1144,54 +1144,54 @@ SEASTAR_TEST_CASE(test_indexing_paging_and_aggregation) {
             cquery_nofail(e, format("INSERT INTO fpa (id, v) VALUES ({}, {})", i + 1, i % 2).c_str());
         }
 
-      eventually([&] {
-        auto qo = std::make_unique<cql3::query_options>(db::consistency_level::LOCAL_ONE, infinite_timeout_config, std::vector<cql3::raw_value>{},
-                cql3::query_options::specific_options{2, nullptr, {}, api::new_timestamp()});
-        auto msg = cquery_nofail(e, "SELECT sum(id) FROM fpa WHERE v = 0;", std::move(qo));
-        // Even though we set up paging, we still expect a single result from an aggregation function.
-        // Also, instead of the user-provided page size, internal DEFAULT_COUNT_PAGE_SIZE is expected to be used.
-        assert_that(msg).is_rows().with_rows({
-            { int32_type->decompose(row_count * row_count / 4)},
-        });
+        eventually([&] {
+            auto qo = std::make_unique<cql3::query_options>(db::consistency_level::LOCAL_ONE, infinite_timeout_config, std::vector<cql3::raw_value>{},
+                    cql3::query_options::specific_options{2, nullptr, {}, api::new_timestamp()});
+            auto msg = cquery_nofail(e, "SELECT sum(id) FROM fpa WHERE v = 0;", std::move(qo));
+            // Even though we set up paging, we still expect a single result from an aggregation function.
+            // Also, instead of the user-provided page size, internal DEFAULT_COUNT_PAGE_SIZE is expected to be used.
+            assert_that(msg).is_rows().with_rows({
+                { int32_type->decompose(row_count * row_count / 4)},
+            });
 
-        // Even if paging is not explicitly used, the query will be internally paged to avoid OOM.
-        msg = cquery_nofail(e, "SELECT sum(id) FROM fpa WHERE v = 1;");
-        assert_that(msg).is_rows().with_rows({
-            { int32_type->decompose(row_count * row_count / 4 + row_count / 2)},
-        });
+            // Even if paging is not explicitly used, the query will be internally paged to avoid OOM.
+            msg = cquery_nofail(e, "SELECT sum(id) FROM fpa WHERE v = 1;");
+            assert_that(msg).is_rows().with_rows({
+                { int32_type->decompose(row_count * row_count / 4 + row_count / 2)},
+            });
 
-        qo = std::make_unique<cql3::query_options>(db::consistency_level::LOCAL_ONE, infinite_timeout_config, std::vector<cql3::raw_value>{},
-                cql3::query_options::specific_options{3, nullptr, {}, api::new_timestamp()});
-        msg = cquery_nofail(e, "SELECT avg(id) FROM fpa WHERE v = 1;", std::move(qo));
-        assert_that(msg).is_rows().with_rows({
-            { int32_type->decompose(row_count / 2 + 1)},
+            qo = std::make_unique<cql3::query_options>(db::consistency_level::LOCAL_ONE, infinite_timeout_config, std::vector<cql3::raw_value>{},
+                    cql3::query_options::specific_options{3, nullptr, {}, api::new_timestamp()});
+            msg = cquery_nofail(e, "SELECT avg(id) FROM fpa WHERE v = 1;", std::move(qo));
+            assert_that(msg).is_rows().with_rows({
+                { int32_type->decompose(row_count / 2 + 1)},
+            });
         });
-      });
 
         // Similar, but this time a non-prefix clustering key part is indexed (wrt. issue 3405, after which we have
         // a special code path for indexing composite non-prefix clustering keys).
         cquery_nofail(e, "CREATE TABLE fpa2 (id int, c1 int, c2 int, primary key (id, c1, c2))");
         cquery_nofail(e, "CREATE INDEX ON fpa2(c2)");
 
-      eventually([&] {
-        for (int i = 0; i < row_count; ++i) {
-            cquery_nofail(e, format("INSERT INTO fpa2 (id, c1, c2) VALUES ({}, {}, {})", i + 1, i + 1, i % 2).c_str());
-        }
+        eventually([&] {
+            for (int i = 0; i < row_count; ++i) {
+                cquery_nofail(e, format("INSERT INTO fpa2 (id, c1, c2) VALUES ({}, {}, {})", i + 1, i + 1, i % 2).c_str());
+            }
 
-        auto qo = std::make_unique<cql3::query_options>(db::consistency_level::LOCAL_ONE, infinite_timeout_config, std::vector<cql3::raw_value>{},
-                cql3::query_options::specific_options{2, nullptr, {}, api::new_timestamp()});
-        auto msg = cquery_nofail(e, "SELECT sum(id) FROM fpa2 WHERE c2 = 0;", std::move(qo));
-        // Even though we set up paging, we still expect a single result from an aggregation function
-        assert_that(msg).is_rows().with_rows({
-            { int32_type->decompose(row_count * row_count / 4)},
-        });
+            auto qo = std::make_unique<cql3::query_options>(db::consistency_level::LOCAL_ONE, infinite_timeout_config, std::vector<cql3::raw_value>{},
+                    cql3::query_options::specific_options{2, nullptr, {}, api::new_timestamp()});
+            auto msg = cquery_nofail(e, "SELECT sum(id) FROM fpa2 WHERE c2 = 0;", std::move(qo));
+            // Even though we set up paging, we still expect a single result from an aggregation function
+            assert_that(msg).is_rows().with_rows({
+                { int32_type->decompose(row_count * row_count / 4)},
+            });
 
-        qo = std::make_unique<cql3::query_options>(db::consistency_level::LOCAL_ONE, infinite_timeout_config, std::vector<cql3::raw_value>{},
-                cql3::query_options::specific_options{3, nullptr, {}, api::new_timestamp()});
-        msg = cquery_nofail(e, "SELECT avg(id) FROM fpa2 WHERE c2 = 1;", std::move(qo));
-        assert_that(msg).is_rows().with_rows({
-            { int32_type->decompose(row_count / 2 + 1)},
+            qo = std::make_unique<cql3::query_options>(db::consistency_level::LOCAL_ONE, infinite_timeout_config, std::vector<cql3::raw_value>{},
+                    cql3::query_options::specific_options{3, nullptr, {}, api::new_timestamp()});
+            msg = cquery_nofail(e, "SELECT avg(id) FROM fpa2 WHERE c2 = 1;", std::move(qo));
+            assert_that(msg).is_rows().with_rows({
+                { int32_type->decompose(row_count / 2 + 1)},
+            });
         });
-      });
     });
 }

--- a/tests/secondary_index_test.cc
+++ b/tests/secondary_index_test.cc
@@ -1144,6 +1144,7 @@ SEASTAR_TEST_CASE(test_indexing_paging_and_aggregation) {
             cquery_nofail(e, format("INSERT INTO fpa (id, v) VALUES ({}, {})", i + 1, i % 2).c_str());
         }
 
+      eventually([&] {
         auto qo = std::make_unique<cql3::query_options>(db::consistency_level::LOCAL_ONE, infinite_timeout_config, std::vector<cql3::raw_value>{},
                 cql3::query_options::specific_options{2, nullptr, {}, api::new_timestamp()});
         auto msg = cquery_nofail(e, "SELECT sum(id) FROM fpa WHERE v = 0;", std::move(qo));
@@ -1165,18 +1166,21 @@ SEASTAR_TEST_CASE(test_indexing_paging_and_aggregation) {
         assert_that(msg).is_rows().with_rows({
             { int32_type->decompose(row_count / 2 + 1)},
         });
+      });
 
         // Similar, but this time a non-prefix clustering key part is indexed (wrt. issue 3405, after which we have
         // a special code path for indexing composite non-prefix clustering keys).
         cquery_nofail(e, "CREATE TABLE fpa2 (id int, c1 int, c2 int, primary key (id, c1, c2))");
         cquery_nofail(e, "CREATE INDEX ON fpa2(c2)");
+
+      eventually([&] {
         for (int i = 0; i < row_count; ++i) {
             cquery_nofail(e, format("INSERT INTO fpa2 (id, c1, c2) VALUES ({}, {}, {})", i + 1, i + 1, i % 2).c_str());
         }
 
-        qo = std::make_unique<cql3::query_options>(db::consistency_level::LOCAL_ONE, infinite_timeout_config, std::vector<cql3::raw_value>{},
+        auto qo = std::make_unique<cql3::query_options>(db::consistency_level::LOCAL_ONE, infinite_timeout_config, std::vector<cql3::raw_value>{},
                 cql3::query_options::specific_options{2, nullptr, {}, api::new_timestamp()});
-        msg = cquery_nofail(e, "SELECT sum(id) FROM fpa2 WHERE c2 = 0;", std::move(qo));
+        auto msg = cquery_nofail(e, "SELECT sum(id) FROM fpa2 WHERE c2 = 0;", std::move(qo));
         // Even though we set up paging, we still expect a single result from an aggregation function
         assert_that(msg).is_rows().with_rows({
             { int32_type->decompose(row_count * row_count / 4)},
@@ -1188,5 +1192,6 @@ SEASTAR_TEST_CASE(test_indexing_paging_and_aggregation) {
         assert_that(msg).is_rows().with_rows({
             { int32_type->decompose(row_count / 2 + 1)},
         });
+      });
     });
 }


### PR DESCRIPTION
Without 'eventually', the test is flaky because the index can still
be not up to date while checking its conditions.

Fixes #4670

Tests: unit(dev)

@bhalevy 