### PR TITLE
Handle termination signals during streaming

### DIFF
--- a/dht/boot_strapper.cc
+++ b/dht/boot_strapper.cc
@@ -51,7 +51,7 @@ namespace dht {
 future<> boot_strapper::bootstrap() {
     blogger.debug("Beginning bootstrap process: sorted_tokens={}", _token_metadata.sorted_tokens());
 
-    auto streamer = make_lw_shared<range_streamer>(_db, _token_metadata, _tokens, _address, "Bootstrap", streaming::stream_reason::bootstrap);
+    auto streamer = make_lw_shared<range_streamer>(_db, _token_metadata, _abort_source, _tokens, _address, "Bootstrap", streaming::stream_reason::bootstrap);
     streamer->add_source_filter(std::make_unique<range_streamer::failure_detector_source_filter>(gms::get_local_gossiper().get_unreachable_members()));
     auto keyspaces = make_lw_shared<std::vector<sstring>>(_db.local().get_non_system_keyspaces());
     return do_for_each(*keyspaces, [this, keyspaces, streamer] (sstring& keyspace_name) {
@@ -61,6 +61,7 @@ future<> boot_strapper::bootstrap() {
         blogger.debug("Will stream keyspace={}, ranges={}", keyspace_name, ranges);
         return streamer->add_ranges(keyspace_name, ranges);
     }).then([this, streamer] {
+        _abort_source.check();
         return streamer->stream_async().then([streamer] () {
             service::get_local_storage_service().finish_bootstrapping();
         }).handle_exception([streamer] (std::exception_ptr eptr) {

--- a/dht/boot_strapper.hh
+++ b/dht/boot_strapper.hh
@@ -42,6 +42,7 @@
 #include <unordered_set>
 #include "database_fwd.hh"
 #include <seastar/core/distributed.hh>
+#include <seastar/core/abort_source.hh>
 
 namespace dht {
 
@@ -50,14 +51,16 @@ class boot_strapper {
     using token_metadata = locator::token_metadata;
     using token = dht::token;
     distributed<database>& _db;
+    abort_source& _abort_source;
     /* endpoint that needs to be bootstrapped */
     inet_address _address;
     /* token of the node being bootstrapped. */
     std::unordered_set<token> _tokens;
     token_metadata _token_metadata;
 public:
-    boot_strapper(distributed<database>& db, inet_address addr, std::unordered_set<token> tokens, token_metadata tmd)
+    boot_strapper(distributed<database>& db, abort_source& abort_source, inet_address addr, std::unordered_set<token> tokens, token_metadata tmd)
         : _db(db)
+        , _abort_source(abort_source)
         , _address(addr)
         , _tokens(tokens)
         , _token_metadata(tmd) {

--- a/init.cc
+++ b/init.cc
@@ -37,9 +37,10 @@ logging::logger startlog("init");
 // duplicated in cql_test_env.cc
 // until proper shutdown is done.
 
-void init_storage_service(distributed<database>& db, sharded<gms::gossiper>& gossiper, sharded<auth::service>& auth_service, sharded<db::system_distributed_keyspace>& sys_dist_ks,
+void init_storage_service(sharded<abort_source>& abort_source,
+        distributed<database>& db, sharded<gms::gossiper>& gossiper, sharded<auth::service>& auth_service, sharded<db::system_distributed_keyspace>& sys_dist_ks,
         sharded<db::view::view_update_generator>& view_update_generator, sharded<gms::feature_service>& feature_service, service::storage_service_config config) {
-    service::init_storage_service(db, gossiper, auth_service, sys_dist_ks, view_update_generator, feature_service, config).get();
+    service::init_storage_service(abort_source, db, gossiper, auth_service, sys_dist_ks, view_update_generator, feature_service, config).get();
     // #293 - do not stop anything
     //engine().at_exit([] { return service::deinit_storage_service(); });
 }

--- a/init.hh
+++ b/init.hh
@@ -23,6 +23,7 @@
 #include <seastar/core/sstring.hh>
 #include <seastar/core/future.hh>
 #include <seastar/core/distributed.hh>
+#include <seastar/core/abort_source.hh>
 #include "auth/service.hh"
 #include "db/system_distributed_keyspace.hh"
 #include "database_fwd.hh"
@@ -46,7 +47,8 @@ extern logging::logger startlog;
 
 class bad_configuration_error : public std::exception {};
 
-void init_storage_service(distributed<database>& db, sharded<gms::gossiper>& gossiper, sharded<auth::service>& auth_service, sharded<db::system_distributed_keyspace>& sys_dist_ks,
+void init_storage_service(sharded<abort_source>& abort_sources,
+        distributed<database>& db, sharded<gms::gossiper>& gossiper, sharded<auth::service>& auth_service, sharded<db::system_distributed_keyspace>& sys_dist_ks,
         sharded<db::view::view_update_generator>& view_update_generator, sharded<gms::feature_service>& feature_service);
 
 struct init_scheduling_config {

--- a/main.cc
+++ b/main.cc
@@ -683,7 +683,7 @@ int main(int ac, char** av) {
             supervisor::notify("initializing storage service");
             service::storage_service_config sscfg;
             sscfg.available_memory = memory::stats().total_memory();
-            init_storage_service(db, gossiper, auth_service, sys_dist_ks, view_update_generator, feature_service, sscfg);
+            init_storage_service(stop_signal.as_sharded_abort_source(), db, gossiper, auth_service, sys_dist_ks, view_update_generator, feature_service, sscfg);
             supervisor::notify("starting per-shard database core");
 
             // Note: changed from using a move here, because we want the config object intact.

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -145,6 +145,7 @@ private:
     /* JMX notification serial number counter */
     private final AtomicLong notificationSerialNumber = new AtomicLong();
 #endif
+    abort_source& _abort_source;
     gms::feature_service& _feature_service;
     distributed<database>& _db;
     gms::gossiper& _gossiper;
@@ -169,7 +170,7 @@ private:
     size_t _service_memory_total;
     semaphore _service_memory_limiter;
 public:
-    storage_service(distributed<database>& db, gms::gossiper& gossiper, sharded<auth::service>&, sharded<db::system_distributed_keyspace>&, sharded<db::view::view_update_generator>&, gms::feature_service& feature_service, storage_service_config config, /* only for tests */ bool for_testing = false, /* only for tests */ std::set<sstring> disabled_features = {});
+    storage_service(abort_source& as, distributed<database>& db, gms::gossiper& gossiper, sharded<auth::service>&, sharded<db::system_distributed_keyspace>&, sharded<db::view::view_update_generator>&, gms::feature_service& feature_service, storage_service_config config, /* only for tests */ bool for_testing = false, /* only for tests */ std::set<sstring> disabled_features = {});
     void isolate_on_error();
     void isolate_on_commit_error();
 
@@ -2376,7 +2377,7 @@ private:
     void notify_cql_change(inet_address endpoint, bool ready);
 };
 
-future<> init_storage_service(distributed<database>& db, sharded<gms::gossiper>& gossiper, sharded<auth::service>& auth_service, sharded<db::system_distributed_keyspace>& sys_dist_ks,
+future<> init_storage_service(sharded<abort_source>& abort_sources, distributed<database>& db, sharded<gms::gossiper>& gossiper, sharded<auth::service>& auth_service, sharded<db::system_distributed_keyspace>& sys_dist_ks,
         sharded<db::view::view_update_generator>& view_update_generator, sharded<gms::feature_service>& feature_service, storage_service_config config);
 future<> deinit_storage_service();
 

--- a/tests/test_services.cc
+++ b/tests/test_services.cc
@@ -33,6 +33,7 @@
 
 
 class storage_service_for_tests::impl {
+    sharded<abort_source> _abort_source;
     sharded<gms::feature_service> _feature_service;
     sharded<gms::gossiper> _gossiper;
     distributed<database> _db;
@@ -47,12 +48,13 @@ public:
         _cfg.broadcast_to_all_shards().get();
         utils::fb_utilities::set_broadcast_address(gms::inet_address("localhost"));
         utils::fb_utilities::set_broadcast_rpc_address(gms::inet_address("localhost"));
+        _abort_source.start().get();
         _feature_service.start().get();
         _gossiper.start(std::ref(_feature_service), std::ref(_cfg)).get();
         netw::get_messaging_service().start(gms::inet_address("127.0.0.1"), 7000, false).get();
         service::storage_service_config sscfg;
         sscfg.available_memory = memory::stats().total_memory();
-        service::get_storage_service().start(std::ref(_db), std::ref(_gossiper), std::ref(_auth_service), std::ref(_sys_dist_ks), std::ref(_view_update_generator), std::ref(_feature_service), sscfg, true).get();
+        service::get_storage_service().start(std::ref(_abort_source), std::ref(_db), std::ref(_gossiper), std::ref(_auth_service), std::ref(_sys_dist_ks), std::ref(_view_update_generator), std::ref(_feature_service), sscfg, true).get();
         service::get_storage_service().invoke_on_all([] (auto& ss) {
             ss.enable_all_features();
         }).get();
@@ -63,6 +65,7 @@ public:
         _db.stop().get();
         _gossiper.stop().get();
         _feature_service.stop().get();
+        _abort_source.stop().get();
     }
 };
 


### PR DESCRIPTION
In b19792405faee91e, we changed the shutdown process not to rely on the global reactor-defined exit, but instead added a local variable to hold the shutdown state. However, we did not propagate that state everywhere, and now streaming processes are not able to abort.

Fix that by enhancing stop_signal with a sharded<abort_source> member that can be propagated to services. Propagate it to storage_service and thence to boot_strapper and range_streamer so that streaming processes can be aborted.

Fixes #4674
Fixes #4501 

Tests: unit (dev), manual bootstrap test
