### PR TITLE
repair: Adjust parallelism according to memory size

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -901,7 +901,8 @@ int main(int ac, char** av) {
                     });
                 });
             }).get();
-            repair_service rs(gossiper);
+            auto max_memory_repair = db.local().get_available_memory() * 0.1;
+            repair_service rs(gossiper, max_memory_repair);
             repair_init_messaging_service_handler(rs, sys_dist_ks, view_update_generator).get();
             supervisor::notify("starting storage service", true);
             auto& ss = service::get_local_storage_service();

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -2099,7 +2099,7 @@ private:
 
     size_t get_max_row_buf_size(row_level_diff_detect_algorithm algo) {
         // Max buffer size per repair round
-        return is_rpc_stream_supported(algo) ?  32 * 1024 * 1024 : 256 * 1024;
+        return is_rpc_stream_supported(algo) ?  tracker::max_repair_memory_per_range() : 256 * 1024;
     }
 
     // Step A: Negotiate sync boundary to use
@@ -2438,10 +2438,10 @@ class row_level_repair_gossip_helper : public gms::i_endpoint_state_change_subsc
     }
 };
 
-repair_service::repair_service(distributed<gms::gossiper>& gossiper)
+repair_service::repair_service(distributed<gms::gossiper>& gossiper, size_t max_repair_memory)
     : _gossiper(gossiper)
     , _gossip_helper(make_shared<row_level_repair_gossip_helper>())
-    , _tracker(smp::count) {
+    , _tracker(smp::count, max_repair_memory) {
     _gossiper.local().register_(_gossip_helper);
 }
 

--- a/repair/row_level.hh
+++ b/repair/row_level.hh
@@ -36,7 +36,7 @@ struct repair_service {
     distributed<gms::gossiper>& _gossiper;
     shared_ptr<row_level_repair_gossip_helper> _gossip_helper;
     tracker _tracker;
-    repair_service(distributed<gms::gossiper>& gossiper);
+    repair_service(distributed<gms::gossiper>& gossiper, size_t max_repair_memory);
     ~repair_service();
 };
 


### PR DESCRIPTION
After commit 8a0c4d5 (Merge "Repair switch to rpc stream" from Asias),
we increased the row buffer size for repair from 512KiB to 32MiB per
repair instance. We allow repairing 16 ranges (16 repair instance) in
parallel per repair request. So, a node can consume 16 * 32MiB = 512MiB
per user requested repair. In addition, the repair master node can hold
data from all the repair followers, so the memory usage on repair master
can be larger than 512MiB. We need to provide a way to limit the memory
usage.

In this patch, we limit the total memory used by repair to 10% of the
shard memory. The ranges that can be repaired in parallel is:

max_repair_ranges_in_parallel = max_repair_memory / max_repair_memory_per_range.

For example, if each shard has 4096MiB of memory, then we will have
max_repair_ranges_in_parallel = 4096MiB / 32MiB = 12.

Fixes #4675