### PR TITLE
tests/mutation_reader_test stabilize test_multishard_combining_reader_non_strictly_monotonic_positions

### DIFF
--- a/tests/mutation_reader_test.cc
+++ b/tests/mutation_reader_test.cc
@@ -2035,11 +2035,12 @@ std::deque<mutation_fragment> make_fragments_with_non_monotonic_positions(simple
     std::deque<mutation_fragment> fragments;
 
     fragments.emplace_back(partition_start{std::move(pkey), {}});
+    const auto tombstone_deletion_time = gc_clock::now();
 
     int i = 0;
     size_t mem_usage = fragments.back().memory_usage(*s.schema());
     while (mem_usage <= max_buffer_size * 2) {
-        fragments.emplace_back(s.make_range_tombstone(query::clustering_range::make(s.make_ckey(0), s.make_ckey(i + 1))));
+        fragments.emplace_back(s.make_range_tombstone(query::clustering_range::make(s.make_ckey(0), s.make_ckey(i + 1)), tombstone_deletion_time));
         mem_usage += fragments.back().memory_usage(*s.schema());
         ++i;
     }

--- a/tests/simple_schema.hh
+++ b/tests/simple_schema.hh
@@ -153,6 +153,9 @@ public:
         range_tombstone rt(bv_range.first, bv_range.second, t);
         return rt;
     }
+    range_tombstone make_range_tombstone(const query::clustering_range& range, gc_clock::time_point deletion_time) {
+        return make_range_tombstone(range, tombstone(new_timestamp(), deletion_time));
+    }
 
     mutation new_mutation(sstring pk) {
         return mutation(_s, make_pkey(pk));


### PR DESCRIPTION
Currently the
`test_multishard_combining_reader_non_strictly_monotonic_positions` is
flaky. The test is somewhat unconventional, in that it doesn't use the
same instance of data as the input to the test and as it's expected
output, instead it invokes the method which generates this data
(`make_fragments_with_non_monotonic_positions()`) twice, first to
generate the input, and a secondly to generate the expected output. This
means that the test is prone to any deviation in the data generated by
said method. One such deviation, discovered recently, is that the method
doesn't explicitly specify the deletion time of the generated range
tombstones. This results in this deletion time sometimes differing
between the test input and the expected output. Solve by explicitly
passing the same deletion time to all created range tombstones.

Refs: #4695