### PR TITLE
Fix storage service for tests

### DIFF
--- a/tests/cql_test_env.cc
+++ b/tests/cql_test_env.cc
@@ -534,39 +534,3 @@ future<> do_with_cql_env_thread(std::function<void(cql_test_env&)> func, cql_tes
         });
     }, std::move(cfg_in));
 }
-
-class storage_service_for_tests::impl {
-    sharded<gms::feature_service> _feature_service;
-    sharded<gms::gossiper> _gossiper;
-    distributed<database> _db;
-    db::config _cfg;
-    sharded<auth::service> _auth_service;
-    sharded<db::system_distributed_keyspace> _sys_dist_ks;
-    sharded<db::view::view_update_generator> _view_update_generator;
-public:
-    impl() {
-        auto thread = seastar::thread_impl::get();
-        assert(thread);
-        utils::fb_utilities::set_broadcast_address(gms::inet_address("localhost"));
-        utils::fb_utilities::set_broadcast_rpc_address(gms::inet_address("localhost"));
-        _feature_service.start().get();
-        _gossiper.start(std::ref(_feature_service), std::ref(_cfg)).get();
-        netw::get_messaging_service().start(gms::inet_address("127.0.0.1"), 7000, false).get();
-        service::get_storage_service().start(std::ref(_db), std::ref(_gossiper), std::ref(_auth_service), std::ref(_sys_dist_ks), std::ref(_view_update_generator), std::ref(_feature_service), true).get();
-        service::get_storage_service().invoke_on_all([] (auto& ss) {
-            ss.enable_all_features();
-        }).get();
-    }
-    ~impl() {
-        service::get_storage_service().stop().get();
-        netw::get_messaging_service().stop().get();
-        _db.stop().get();
-        _gossiper.stop().get();
-        _feature_service.stop().get();
-    }
-};
-
-storage_service_for_tests::storage_service_for_tests() : _impl(std::make_unique<impl>()) {
-}
-
-storage_service_for_tests::~storage_service_for_tests() = default;

--- a/tests/test_services.cc
+++ b/tests/test_services.cc
@@ -44,6 +44,7 @@ public:
     impl() {
         auto thread = seastar::thread_impl::get();
         assert(thread);
+        _cfg.broadcast_to_all_shards().get();
         utils::fb_utilities::set_broadcast_address(gms::inet_address("localhost"));
         utils::fb_utilities::set_broadcast_rpc_address(gms::inet_address("localhost"));
         _feature_service.start().get();


### PR DESCRIPTION
Fix another source of flakyness in `mutation_reader_test`. This one is caused by `storage_service_for_tests` lacking a `config::broadcast_to_all_shards()` call, triggering an invalid memory access (or SEGFAULT) when run on more than one shards.

Refs: #4695