### PR TITLE
Implement `sstable_info` API command (info on sstables)

### DIFF
--- a/api/api-doc/storage_service.json
+++ b/api/api-doc/storage_service.json
@@ -2164,7 +2164,42 @@
                ]
             }
          ]
-      }
+      },
+      {
+         "path":"/storage_service/sstable_info",
+         "operations":[
+            {
+               "method":"GET",
+               "summary":"SSTable information",
+               "type":"array",
+               "items":{
+                  "type":"table_sstables"
+               },
+               "nickname":"sstable_info",
+               "produces":[
+                  "application/json"
+               ],
+               "parameters":[
+                  {
+                     "name":"keyspace",
+                     "description":"The keyspace",
+                     "required":false,
+                     "allowMultiple":false,
+                     "type":"string",
+                     "paramType":"query"
+                  },
+                  {
+                     "name":"cf",
+                     "description":"column family name",
+                     "required":false,
+                     "allowMultiple":false,
+                     "type":"string",
+                     "paramType":"query"
+                  }
+               ]
+            }
+         ]
+      }      
    ],
    "models":{
       "mapper":{
@@ -2324,6 +2359,92 @@
                "description":"The endpoint details"
             }
          }
+      },
+      "named_maps":{
+        "id":"named_maps",
+        "properties":{
+            "group":{
+                "type":"string"
+            },
+            "attributes":{
+                "type":"array",
+                "items":{
+                    "type":"mapper"
+                }
+            }
+        }
+      },
+      "sstable":{
+        "id":"sstable",
+        "properties":{
+            "size":{
+               "type":"long",
+               "description":"Total size in bytes of sstable"
+            },
+            "data_size":{
+                "type":"long",
+                "description":"The size in bytes on disk of data"
+            },
+            "index_size":{
+               "type":"long",
+               "description":"The size in bytes on disk of index"
+            },
+            "filter_size":{
+               "type":"long",
+               "description":"The size in bytes on disk of filter"
+            },
+            "timestamp":{
+                "type":"datetime",
+                "description":"File creation time"
+            },
+            "generation":{
+                "type":"long",
+                "description":"SSTable generation"
+            },
+            "level":{
+               "type":"long",
+               "description":"SSTable level"
+            },
+            "version":{
+               "type":"string",
+               "enum":[
+                  "ka", "la", "mc"
+               ],
+               "description":"SSTable version"
+            },
+            "properties":{
+                "type":"array",
+                "description":"SSTable attributes",
+                "items":{
+                    "type":"mapper"
+                }
+            },
+            "extended_properties":{
+                "type":"array",
+                "description":"SSTable extended attributes",
+                "items":{
+                    "type":"named_maps"
+                }
+            }
+        }
+      },
+      "table_sstables":{
+        "id":"table_sstables",
+        "description":"Per-table SSTable info and attributes",
+        "properties":{
+            "keyspace":{
+                "type":"string"
+            },
+            "table":{
+                "type":"string"
+            },
+            "sstables":{
+                "type":"array",
+                "items":{
+                    "$ref":"sstable"
+                }
+            }
+        }
       }
    }
 }

--- a/sstables/compress.cc
+++ b/sstables/compress.cc
@@ -253,6 +253,9 @@ public:
     operator bool() const {
         return _compressor != nullptr;
     }
+    const compressor_ptr& compressor() const {
+        return _compressor;
+    }
 };
 
 local_compression::local_compression(compressor_ptr p)
@@ -316,6 +319,9 @@ void compression::update(uint64_t compressed_file_length) {
     _compressed_file_length = compressed_file_length;
 }
 
+compressor_ptr get_sstable_compressor(const compression& c) {
+    return local_compression(c).compressor();
+}
 
 // locate() takes a byte position in the uncompressed stream, and finds the
 // the location of the compressed chunk on disk which contains it, and the

--- a/sstables/compress.hh
+++ b/sstables/compress.hh
@@ -367,6 +367,9 @@ public:
     friend class sstable;
 };
 
+// for API query only. Free function just to distinguish it from an accessor in compression
+compressor_ptr get_sstable_compressor(const compression&);
+
 // Note: compression_metadata is passed by reference; The caller is
 // responsible for keeping the compression_metadata alive as long as there
 // are open streams on it. This should happen naturally on a higher level -

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -542,8 +542,9 @@ private:
 
     sstables_stats _stats;
 
+public:
     const bool has_component(component_type f) const;
-
+private:
     future<file> open_file(component_type, open_flags, file_open_options = {});
 
     template <component_type Type, typename T>

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -33,6 +33,7 @@
 #include <seastar/core/distributed.hh>
 #include <unordered_set>
 #include <unordered_map>
+#include <variant>
 #include "types.hh"
 #include "clustering_key_filter.hh"
 #include <seastar/core/enum.hh>
@@ -948,6 +949,15 @@ class file_io_extension {
 public:
     virtual ~file_io_extension() {}
     virtual future<file> wrap_file(sstable&, component_type, file, open_flags flags) = 0;
+    // optionally return a map of attributes for a given sstable,
+    // suitable for "describe".
+    // This would preferably be interesting info on what/why the extension did
+    // to this table.
+    using attr_value_type = std::variant<sstring, std::map<sstring, sstring>>;
+    using attr_value_map = std::map<sstring, attr_value_type>;
+    virtual attr_value_map get_attributes(const sstable&) const {
+        return {};
+    }
 };
 
 }

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -796,6 +796,10 @@ public:
 
     double get_compression_ratio() const;
 
+    const sstables::compression& get_compression() const {
+        return _components->compression;
+    }
+
     future<> mutate_sstable_level(uint32_t);
 
     const summary& get_summary() const {


### PR DESCRIPTION
Refs #4726

Implement the api portion of a "describe sstables" command. 

Adds rest types for collecting both fixed and dynamic attributes, some grouped. Allows extensions to add attributes as well. (Hint hint)

v2:
* Use (not really legal) nested "type" in json
* Rename "table" param to "cf" for consistency
* Some comments on data sizes
* Stream result to avoid huge string allocations on final json