### PR TITLE
gossip: Make boot process faster and safer

### DIFF
--- a/gms/gossiper.cc
+++ b/gms/gossiper.cc
@@ -2062,6 +2062,11 @@ future<> gossiper::wait_for_range_setup() {
     return wait_for_gossip(ring_delay);
 }
 
+void gossiper::set_node_to_be_replaced(gms::inet_address node) {
+    logger.info("Set node to be replaced = {}", node);
+    _node_to_be_replaced = node;
+}
+
 bool gossiper::is_safe_for_bootstrap(inet_address endpoint) {
     auto* eps = get_endpoint_state_for_endpoint_ptr(endpoint);
 

--- a/gms/gossiper.hh
+++ b/gms/gossiper.hh
@@ -563,6 +563,8 @@ public:
 public:
     future<> wait_for_gossip_to_settle();
     future<> wait_for_range_setup();
+public:
+    void set_node_to_be_replaced(gms::inet_address node);
 private:
     future<> wait_for_gossip(std::chrono::milliseconds, std::optional<int32_t> = {});
 
@@ -571,6 +573,7 @@ private:
     bool _ms_registered = false;
     bool _gossiped_to_seed = false;
     bool _gossip_settled = false;
+    std::optional<gms::inet_address> _node_to_be_replaced;
 
     class msg_proc_guard;
 private:

--- a/idl/gossip_digest.idl.hh
+++ b/idl/gossip_digest.idl.hh
@@ -74,4 +74,8 @@ class gossip_digest_ack2 {
     std::map<gms::inet_address, gms::endpoint_state> get_endpoint_state_map();
 };
 
+class gossip_query_token_status_response {
+    std::map<sstring, sstring> status;
+};
+
 }

--- a/locator/token_metadata.cc
+++ b/locator/token_metadata.cc
@@ -30,6 +30,14 @@
 #include <algorithm>
 #include <boost/icl/interval.hpp>
 #include <boost/icl/interval_map.hpp>
+#include "xx_hasher.hh"
+#include "bytes_ostream.hh"
+#include "gms/inet_address_serializer.hh"
+#include "serializer_impl.hh"
+#include "idl/token.dist.hh"
+#include "idl/token.dist.impl.hh"
+#include "idl/range.dist.hh"
+#include "idl/range.dist.impl.hh"
 
 namespace locator {
 
@@ -621,6 +629,90 @@ std::multimap<inet_address, token> token_metadata::get_endpoint_to_token_map_for
     return cloned;
 }
 
+// Must run inside a seastar thread
+static uint64_t get_hash_for_map(const std::unordered_map<dht::token, gms::inet_address>& unordered) {
+    if (unordered.empty()) {
+        return 0;
+    }
+    std::map<dht::token, gms::inet_address> map(unordered.begin(), unordered.end());
+    xx_hasher h;
+    bytes_ostream out;
+    for (auto& x : map) {
+        thread::maybe_yield();
+        out.clear();
+        ser::serialize(out, x.first);
+        ser::serialize(out, x.second);
+        feed_hash(h, out.linearize());
+    }
+    return h.finalize_uint64();
+}
+
+// Must run inside a seastar thread
+static uint64_t get_hash_for_set(const std::unordered_set<gms::inet_address>& unordered) {
+    if (unordered.empty()) {
+        return 0;
+    }
+    std::set<gms::inet_address> nodes(unordered.begin(), unordered.end());
+    xx_hasher h;
+    bytes_ostream out;
+    for (auto& node: nodes) {
+        thread::maybe_yield();
+        out.clear();
+        ser::serialize(out, node);
+        feed_hash(h, out.linearize());
+    }
+    return h.finalize_uint64();
+}
+
+// Must run inside a seastar thread
+uint64_t token_metadata::get_normal_token_hash() {
+    return get_hash_for_map(get_token_to_endpoint());
+}
+
+// Must run inside a seastar thread
+uint64_t token_metadata::get_bootstrap_token_hash() {
+    return get_hash_for_map(get_bootstrap_tokens());
+}
+
+// Must run inside a seastar thread
+uint64_t token_metadata::get_leaving_endpoints_hash() {
+    return get_hash_for_set(get_leaving_endpoints());
+}
+
+// Must run inside a seastar thread
+uint64_t token_metadata::get_pending_ranges_hash() {
+    if (_pending_ranges_map.empty()) {
+        return 0;
+    }
+    std::map<sstring, uint64_t> keyspace_hash_map;
+    bytes_ostream out;
+    for (auto& x : _pending_ranges_map) {
+        struct less {
+            bool operator()(const range<token>& l, const range<token>& r) const {
+                return format("{}", l) < format("{}", r);
+            }
+        };
+        std::map<range<token>, std::unordered_set<inet_address>, less> map(x.second.begin(), x.second.end());
+        xx_hasher h;
+        for (auto& y : map) {
+            thread::maybe_yield();
+            out.clear();
+            ser::serialize(out, y.first);
+            ser::serialize(out, get_hash_for_set(y.second));
+            feed_hash(h, out.linearize());
+        }
+        keyspace_hash_map[x.first] = h.finalize_uint64();
+    }
+    xx_hasher h;
+    for (auto& x : keyspace_hash_map) {
+        thread::maybe_yield();
+        out.clear();
+        ser::serialize(out, x.first);
+        ser::serialize(out, x.second);
+        feed_hash(h, out.linearize());
+    }
+    return h.finalize_uint64();
+}
 
 /////////////////// class topology /////////////////////////////////////////////
 inline void topology::clear() {

--- a/locator/token_metadata.hh
+++ b/locator/token_metadata.hh
@@ -1015,6 +1015,14 @@ public:
         ++_ring_version;
         //cachedTokenMap.set(null);
     }
+
+    uint64_t get_normal_token_hash();
+
+    uint64_t get_bootstrap_token_hash();
+
+    uint64_t get_leaving_endpoints_hash();
+
+    uint64_t get_pending_ranges_hash();
 };
 
 }

--- a/message/messaging_service.cc
+++ b/message/messaging_service.cc
@@ -449,6 +449,7 @@ static constexpr unsigned do_get_rpc_client_idx(messaging_verb verb) {
     case messaging_verb::GOSSIP_DIGEST_ACK2:
     case messaging_verb::GOSSIP_SHUTDOWN:
     case messaging_verb::GOSSIP_ECHO:
+    case messaging_verb::GOSSIP_QUERY_TOKEN_STATUS:
     case messaging_verb::GET_SCHEMA_VERSION:
         return 1;
     case messaging_verb::PREPARE_MESSAGE:
@@ -907,6 +908,17 @@ void messaging_service::unregister_gossip_echo() {
 }
 future<> messaging_service::send_gossip_echo(msg_addr id) {
     return send_message_timeout<void>(this, messaging_verb::GOSSIP_ECHO, std::move(id), 3000ms);
+}
+
+// GOSSIP_QUERY_TOKEN_STATUS
+void messaging_service::register_gossip_query_token_status(std::function<future<gms::gossip_query_token_status_response> (const rpc::client_info& cinfo)>&& func) {
+    register_handler(this, messaging_verb::GOSSIP_QUERY_TOKEN_STATUS, std::move(func));
+}
+void messaging_service::unregister_gossip_query_token_status() {
+    _rpc->unregister_handler(netw::messaging_verb::GOSSIP_QUERY_TOKEN_STATUS);
+}
+future<gms::gossip_query_token_status_response> messaging_service::send_gossip_query_token_status(msg_addr id) {
+    return send_message_timeout<gms::gossip_query_token_status_response>(this, messaging_verb::GOSSIP_QUERY_TOKEN_STATUS, std::move(id), 5000ms);
 }
 
 void messaging_service::register_gossip_shutdown(std::function<rpc::no_wait_type (inet_address from)>&& func) {

--- a/message/messaging_service.hh
+++ b/message/messaging_service.hh
@@ -53,6 +53,7 @@ namespace gms {
     class gossip_digest_syn;
     class gossip_digest_ack;
     class gossip_digest_ack2;
+    class gossip_query_token_status_response;
 }
 
 namespace utils {
@@ -134,7 +135,8 @@ enum class messaging_verb : int32_t {
     REPAIR_GET_ROW_DIFF_WITH_RPC_STREAM = 36,
     REPAIR_PUT_ROW_DIFF_WITH_RPC_STREAM = 37,
     REPAIR_GET_FULL_ROW_HASHES_WITH_RPC_STREAM = 38,
-    LAST = 39,
+    GOSSIP_QUERY_TOKEN_STATUS = 39,
+    LAST = 40,
 };
 
 } // namespace netw
@@ -362,6 +364,11 @@ public:
     void register_gossip_echo(std::function<future<> ()>&& func);
     void unregister_gossip_echo();
     future<> send_gossip_echo(msg_addr id);
+
+    // Wrapper for GOSSIP_QUERY_TOKEN_STATUS verb
+    void register_gossip_query_token_status(std::function<future<gms::gossip_query_token_status_response> (const rpc::client_info& cinfo)>&& func);
+    void unregister_gossip_query_token_status();
+    future<gms::gossip_query_token_status_response> send_gossip_query_token_status(msg_addr id);
 
     // Wrapper for GOSSIP_SHUTDOWN
     void register_gossip_shutdown(std::function<rpc::no_wait_type (inet_address from)>&& func);

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -776,12 +776,6 @@ void storage_service::join_token_ring(int delay) {
         // start participating in the ring.
         db::system_keyspace::set_bootstrap_state(db::system_keyspace::bootstrap_state::COMPLETED).get();
         set_tokens(_bootstrap_tokens);
-        // remove the existing info about the replaced node.
-        if (!current.empty()) {
-            for (auto existing : current) {
-                _gossiper.replaced_endpoint(existing);
-            }
-        }
         if (_token_metadata.sorted_tokens().empty()) {
             auto err = format("join_token_ring: Sorted token in token_metadata is empty");
             slogger.error("{}", err);
@@ -999,11 +993,24 @@ void storage_service::handle_state_normal(inet_address endpoint) {
     if (_gossiper.uses_host_id(endpoint)) {
         auto host_id = _gossiper.get_host_id(endpoint);
         auto existing = _token_metadata.get_endpoint_for_host_id(host_id);
+        auto replace_addr = db().local().get_replace_address();
         if (db().local().is_replacing() &&
-            db().local().get_replace_address() &&
-                _gossiper.get_endpoint_state_for_endpoint_ptr(db().local().get_replace_address().value())  &&
-            (host_id == _gossiper.get_host_id(db().local().get_replace_address().value()))) {
-            slogger.warn("Not updating token metadata for {} because I am replacing it", endpoint);
+            replace_addr &&
+            _gossiper.get_endpoint_state_for_endpoint_ptr(*replace_addr) &&
+            host_id == _gossiper.get_host_id(*replace_addr)) {
+            slogger.warn("Not updating token metadata for {} because I am replacing it, myip={}, node={} becomes normal status, existing node={}, node to be replaced={}",
+                    endpoint, get_broadcast_address(), endpoint, existing, *replace_addr);
+            // If the replacing node becomes NORMAL status, we can remove the
+            // node to be replaced from token_metadata. However, if the
+            // replacing node has the same ip address as the node to be
+            // replaced, we should not remove the node itself from
+            // token_metadata.
+            if (endpoint == get_broadcast_address() && *replace_addr != get_broadcast_address()) {
+               slogger.info("Remove the node to be replaced={} from token_metadata because the replacing node={} has become NORMAL status",
+                        *replace_addr, get_broadcast_address());
+                _token_metadata.remove_endpoint(*replace_addr);
+                endpoints_to_remove.insert(*replace_addr);
+            }
         } else {
             if (existing && *existing != endpoint) {
                 if (*existing == get_broadcast_address()) {
@@ -1071,10 +1078,6 @@ void storage_service::handle_state_normal(inet_address endpoint) {
 
     for (auto ep : endpoints_to_remove) {
         remove_endpoint(ep);
-        auto replace_addr = db().local().get_replace_address();
-        if (db().local().is_replacing() && replace_addr && *replace_addr == ep) {
-            _gossiper.replacement_quarantine(ep); // quarantine locally longer than normally; see CASSANDRA-8260
-        }
     }
     slogger.debug("handle_state_normal: endpoint={} tokens_to_update_in_system_keyspace = {}", endpoint, tokens_to_update_in_system_keyspace);
     if (!tokens_to_update_in_system_keyspace.empty()) {


### PR DESCRIPTION
gossip: Make boot process faster and safer

During boot up, we need to wait for gossip in multiple places:

1) Wait for gossip to settle to enable features. See commit
71bf757b2c8fb372bfd115ed00bf56069331d7cc ("gossiper: Enable features
only after gossip is settled").

2) Wait until local node knows tokens of peer nodes before announcing
join status. To make sure when the writes sent by the other nodes for
pending token range arrives, the local node knows all the tokens of the
cluster. See commit 89b769a073da1a1727b913159d85b97fe911676c.

3) Wait until peer nodes know the bootstrap tokens of local node before
streaming. To make sure all peer nodes knows the pending token range
before the streaming starts, so that all writes after streaming starts
that belong to the pending token range will be forwarded to the new node.

4) Wait until gossip is settled before start the cql server. See commit
8c909122a6a6b90ddb50ea8be250829c199616ab.

Before this patch, we sleep ring_delay which is 30 seconds by default
and wait for the size of endpoint_state_map does not change over some
time. The time out based approach does not guarantee the above
conditions are met. It can wait foo much or wait too few.

This patch introduces a new method. Instead of waiting for some
arbitrary time, we ask peer nodes to return the number of nodes it
knows, the checksum of normal tokens, the checksum of bootstrap tokens
and the checksum of gossip status (e.g., NORMAL), the checksum of nodes
leaving the cluster. If the checksums between local node and all remote
nodes are identical, it is guaranteed all nodes have the same view of
tokens and nodes status.

A new RPC verb GOSSIP_QUERY_TOKEN_STATUS is introduced for this new
method. If any of the nodes in the cluster does not support this new
verb, or a node is down and can not respond the new verb, it will
fallback to the old timeout based method. A nice thing is that we do not
need to negotiate between nodes if GOSSIP_QUERY_TOKEN_STATUS is
supported. When the node that supports GOSSIP_QUERY_TOKEN_STATUS send
this verb to node that does not support it during boot process, the
sender will get rpc::unknown_verb_error then it will fallback.

With this patch, we observed significant improvement in scylla boot time.

To bootstrap a single node with the default 30s ring_delay:
Before: 88 seconds
After: 4 seconds

To run update_cluster_layout_tests.py:TestUpdateClusterLayout.simple_add_node_1_test
Before: 141 seconds
After: 25 seconds

To run update_cluster_layout_tests.py:TestLargeScaleCluster.add_50_nodes_test
to increase a cluster from 3 nodes to 12 nodes
Before: 866 seconds
After: 111 seconds

Fixes: #4755
Refs: #4632
Tests: update_cluster_layout_tests.py + replace_address_test.py  + manual test
