### PR TITLE
Move reader_concurrency_semaphore in front of row_cache

### DIFF
--- a/database.hh
+++ b/database.hh
@@ -592,12 +592,36 @@ private:
                                         const io_priority_class& pc,
                                         tracing::trace_state_ptr trace_state,
                                         streamed_mutation::forwarding fwd,
-                                        mutation_reader::forwarding fwd_mr) const;
+                                        mutation_reader::forwarding fwd_mr,
+                                        reader_resource_tracker tracker) const;
 
     snapshot_source sstables_as_snapshot_source();
     partition_presence_checker make_partition_presence_checker(lw_shared_ptr<sstables::sstable_set>);
     std::chrono::steady_clock::time_point _sstable_writes_disabled_at;
     void do_trigger_compaction();
+    // do_make_reader() / do_make_streaming_reader() are called after the reader_concurrency_semaphore
+    // has been obtained.
+    flat_mutation_reader do_make_reader(schema_ptr schema,
+            const dht::partition_range& range,
+            const query::partition_slice& slice,
+            const io_priority_class& pc,
+            tracing::trace_state_ptr trace_state,
+            streamed_mutation::forwarding fwd,
+            mutation_reader::forwarding fwd_mr,
+            reader_resource_tracker tracker) const;
+    flat_mutation_reader do_make_streaming_reader(schema_ptr schema, const dht::partition_range& range,
+            const query::partition_slice& slice,
+            mutation_reader::forwarding fwd_mr,
+            reader_resource_tracker tracker) const;
+    static flat_mutation_reader maybe_restrict_reader(reader_concurrency_semaphore* sem,
+            schema_ptr schema,
+            const dht::partition_range& range,
+            const query::partition_slice& slice,
+            const io_priority_class& pc,
+            tracing::trace_state_ptr trace_state,
+            streamed_mutation::forwarding fwd,
+            mutation_reader::forwarding fwd_mr,
+            mutation_source ms);
 public:
     bool has_shared_sstables() const {
         return bool(_sstables_need_rewrite.size());

--- a/database.hh
+++ b/database.hh
@@ -329,8 +329,8 @@ public:
         bool enable_dangerous_direct_import_of_cassandra_counters = false;
         ::dirty_memory_manager* dirty_memory_manager = &default_dirty_memory_manager;
         ::dirty_memory_manager* streaming_dirty_memory_manager = &default_dirty_memory_manager;
-        reader_concurrency_semaphore* read_concurrency_semaphore;
-        reader_concurrency_semaphore* streaming_read_concurrency_semaphore;
+        reader_concurrency_semaphore* read_concurrency_semaphore = nullptr;
+        reader_concurrency_semaphore* streaming_read_concurrency_semaphore = nullptr;
         ::cf_stats* cf_stats = nullptr;
         seastar::scheduling_group memtable_scheduling_group;
         seastar::scheduling_group memtable_to_cache_scheduling_group;

--- a/database.hh
+++ b/database.hh
@@ -685,7 +685,7 @@ public:
             const query::partition_slice& slice,
             mutation_reader::forwarding fwd_mr = mutation_reader::forwarding::no) const;
 
-    flat_mutation_reader make_streaming_reader(schema_ptr schema, const dht::partition_range& range) {
+    flat_mutation_reader make_streaming_reader(schema_ptr schema, const dht::partition_range& range) const {
         return make_streaming_reader(schema, range, schema->full_slice());
     }
 

--- a/row_cache.hh
+++ b/row_cache.hh
@@ -40,6 +40,7 @@
 #include <seastar/core/metrics_registration.hh>
 #include "flat_mutation_reader.hh"
 #include "mutation_cleaner.hh"
+#include "reader_concurrency_semaphore.hh"
 
 namespace bi = boost::intrusive;
 
@@ -495,7 +496,8 @@ public:
                                      const io_priority_class& = default_priority_class(),
                                      tracing::trace_state_ptr trace_state = nullptr,
                                      streamed_mutation::forwarding fwd = streamed_mutation::forwarding::no,
-                                     mutation_reader::forwarding fwd_mr = mutation_reader::forwarding::no);
+                                     mutation_reader::forwarding fwd_mr = mutation_reader::forwarding::no,
+                                     reader_resource_tracker = no_resource_tracking());
 
     flat_mutation_reader make_reader(schema_ptr s, const dht::partition_range& range = query::full_partition_range) {
         auto& full_slice = s->full_slice();

--- a/table.cc
+++ b/table.cc
@@ -330,11 +330,8 @@ table::make_sstable_reader(schema_ptr s,
                                    const io_priority_class& pc,
                                    tracing::trace_state_ptr trace_state,
                                    streamed_mutation::forwarding fwd,
-                                   mutation_reader::forwarding fwd_mr) const {
-    auto* semaphore = service::get_local_streaming_read_priority().id() == pc.id()
-        ? _config.streaming_read_concurrency_semaphore
-        : _config.read_concurrency_semaphore;
-
+                                   mutation_reader::forwarding fwd_mr,
+                                   reader_resource_tracker tracker) const {
     // CAVEAT: if make_sstable_reader() is called on a single partition
     // we want to optimize and read exactly this partition. As a
     // consequence, fast_forward_to() will *NOT* work on the result,
@@ -384,11 +381,7 @@ table::make_sstable_reader(schema_ptr s,
         }
     }();
 
-    if (semaphore) {
-        return make_restricted_flat_reader(*semaphore, std::move(ms), std::move(s), pr, slice, pc, std::move(trace_state), fwd, fwd_mr);
-    } else {
-        return ms.make_reader(std::move(s), pr, slice, pc, std::move(trace_state), fwd, fwd_mr);
-    }
+    return ms.make_reader(std::move(s), pr, slice, pc, std::move(trace_state), fwd, fwd_mr, tracker);
 }
 
 // Exposed for testing, not performance critical.
@@ -428,13 +421,14 @@ table::find_row(schema_ptr s, const dht::decorated_key& partition_key, clusterin
 }
 
 flat_mutation_reader
-table::make_reader(schema_ptr s,
+table::do_make_reader(schema_ptr s,
                            const dht::partition_range& range,
                            const query::partition_slice& slice,
                            const io_priority_class& pc,
                            tracing::trace_state_ptr trace_state,
                            streamed_mutation::forwarding fwd,
-                           mutation_reader::forwarding fwd_mr) const {
+                           mutation_reader::forwarding fwd_mr,
+                           reader_resource_tracker tracker) const {
     if (_virtual_reader) {
         return (*_virtual_reader).make_reader(s, range, slice, pc, trace_state, fwd, fwd_mr);
     }
@@ -467,9 +461,9 @@ table::make_reader(schema_ptr s,
     }
 
     if (_config.enable_cache && !slice.options.contains(query::partition_slice::option::bypass_cache)) {
-        readers.emplace_back(_cache.make_reader(s, range, slice, pc, std::move(trace_state), fwd, fwd_mr));
+        readers.emplace_back(_cache.make_reader(s, range, slice, pc, std::move(trace_state), fwd, fwd_mr, tracker));
     } else {
-        readers.emplace_back(make_sstable_reader(s, _sstables, range, slice, pc, std::move(trace_state), fwd, fwd_mr));
+        readers.emplace_back(make_sstable_reader(s, _sstables, range, slice, pc, std::move(trace_state), fwd, fwd_mr, tracker));
     }
 
     auto comb_reader = make_combined_reader(s, std::move(readers), fwd, fwd_mr);
@@ -477,6 +471,48 @@ table::make_reader(schema_ptr s,
         return _config.data_listeners->on_read(s, range, slice, std::move(comb_reader));
     } else {
         return comb_reader;
+    }
+}
+
+flat_mutation_reader
+table::make_reader(schema_ptr s,
+                           const dht::partition_range& range,
+                           const query::partition_slice& slice,
+                           const io_priority_class& pc,
+                           tracing::trace_state_ptr trace_state,
+                           streamed_mutation::forwarding fwd,
+                           mutation_reader::forwarding fwd_mr) const {
+    auto* semaphore = _config.read_concurrency_semaphore;
+
+    auto ms = mutation_source([this] (
+            schema_ptr s,
+            const dht::partition_range& pr,
+            const query::partition_slice& slice,
+            const io_priority_class& pc,
+            tracing::trace_state_ptr trace_state,
+            streamed_mutation::forwarding fwd,
+            mutation_reader::forwarding fwd_mr,
+            reader_resource_tracker tracker) {
+        return do_make_reader(std::move(s), pr, slice, pc, std::move(trace_state), fwd, fwd_mr, tracker);
+    });
+    return maybe_restrict_reader(semaphore, std::move(s), range, slice, pc, std::move(trace_state),
+            fwd, fwd_mr, std::move(ms));
+}
+
+flat_mutation_reader
+table::maybe_restrict_reader(reader_concurrency_semaphore* semaphore,
+        schema_ptr schema,
+        const dht::partition_range& range,
+        const query::partition_slice& slice,
+        const io_priority_class& pc,
+        tracing::trace_state_ptr trace_state,
+        streamed_mutation::forwarding fwd,
+        mutation_reader::forwarding fwd_mr,
+        mutation_source ms) {
+    if (semaphore) {
+        return make_restricted_flat_reader(*semaphore, std::move(ms), std::move(schema), range, slice, pc, std::move(trace_state), fwd, fwd_mr);
+    } else {
+        return ms.make_reader(std::move(schema), range, slice, pc, std::move(trace_state), fwd, fwd_mr);
     }
 }
 
@@ -504,8 +540,8 @@ table::make_streaming_reader(schema_ptr s,
     return make_flat_multi_range_reader(s, std::move(source), ranges, slice, pc, nullptr, mutation_reader::forwarding::no);
 }
 
-flat_mutation_reader table::make_streaming_reader(schema_ptr schema, const dht::partition_range& range,
-        const query::partition_slice& slice, mutation_reader::forwarding fwd_mr) const {
+flat_mutation_reader table::do_make_streaming_reader(schema_ptr schema, const dht::partition_range& range,
+        const query::partition_slice& slice, mutation_reader::forwarding fwd_mr, reader_resource_tracker tracker) const {
     const auto& pc = service::get_local_streaming_read_priority();
     auto trace_state = tracing::trace_state_ptr();
     const auto fwd = streamed_mutation::forwarding::no;
@@ -515,8 +551,24 @@ flat_mutation_reader table::make_streaming_reader(schema_ptr schema, const dht::
     for (auto&& mt : *_memtables) {
         readers.emplace_back(mt->make_flat_reader(schema, range, slice, pc, trace_state, fwd, fwd_mr));
     }
-    readers.emplace_back(make_sstable_reader(schema, _sstables, range, slice, pc, std::move(trace_state), fwd, fwd_mr));
+    readers.emplace_back(make_sstable_reader(schema, _sstables, range, slice, pc, std::move(trace_state), fwd, fwd_mr, std::move(tracker)));
     return make_combined_reader(std::move(schema), std::move(readers), fwd, fwd_mr);
+}
+
+flat_mutation_reader table::make_streaming_reader(schema_ptr schema, const dht::partition_range& range,
+        const query::partition_slice& slice, mutation_reader::forwarding fwd_mr) const {
+    const auto& pc = service::get_local_streaming_read_priority();
+    auto trace_state = tracing::trace_state_ptr();
+    const auto fwd = streamed_mutation::forwarding::no;
+
+    auto ms = mutation_source([this] (schema_ptr s, const dht::partition_range& pr, const query::partition_slice& slice,
+                    const io_priority_class& pc, tracing::trace_state_ptr trace, streamed_mutation::forwarding fwd_sm,
+                    mutation_reader::forwarding fwd_mr, reader_resource_tracker rt) {
+        return do_make_streaming_reader(std::move(s), pr, slice, fwd_mr, std::move(rt));
+    });
+
+    return maybe_restrict_reader(_config.streaming_read_concurrency_semaphore, std::move(schema), range, slice,
+            pc, std::move(trace_state), fwd, fwd_mr, std::move(ms));
 }
 
 future<std::vector<locked_cell>> table::lock_counter_cells(const mutation& m, db::timeout_clock::time_point timeout) {
@@ -1590,8 +1642,9 @@ table::sstables_as_snapshot_source() {
                 const io_priority_class& pc,
                 tracing::trace_state_ptr trace_state,
                 streamed_mutation::forwarding fwd,
-                mutation_reader::forwarding fwd_mr) {
-            return make_sstable_reader(std::move(s), sst_set, r, slice, pc, std::move(trace_state), fwd, fwd_mr);
+                mutation_reader::forwarding fwd_mr,
+                reader_resource_tracker tracker) {
+            return make_sstable_reader(std::move(s), sst_set, r, slice, pc, std::move(trace_state), fwd, fwd_mr, std::move(tracker));
         }, [this, sst_set] {
             return make_partition_presence_checker(sst_set);
         });
@@ -2441,7 +2494,8 @@ table::make_reader_excluding_sstable(schema_ptr s,
     auto effective_sstables = ::make_lw_shared<sstables::sstable_set>(*_sstables);
     effective_sstables->erase(sst);
 
-    readers.emplace_back(make_sstable_reader(s, std::move(effective_sstables), range, slice, pc, std::move(trace_state), fwd, fwd_mr));
+    // no resource tracking as this there is just one reader like this
+    readers.emplace_back(make_sstable_reader(s, std::move(effective_sstables), range, slice, pc, std::move(trace_state), fwd, fwd_mr, no_resource_tracking()));
     return make_combined_reader(s, std::move(readers), fwd, fwd_mr);
 }
 

--- a/table.cc
+++ b/table.cc
@@ -336,52 +336,26 @@ table::make_sstable_reader(schema_ptr s,
     // we want to optimize and read exactly this partition. As a
     // consequence, fast_forward_to() will *NOT* work on the result,
     // regardless of what the fwd_mr parameter says.
-    auto ms = [&] () -> mutation_source {
+    {
         if (pr.is_singular() && pr.start()->value().has_key()) {
             const dht::ring_position& pos = pr.start()->value();
             if (dht::shard_of(pos.token()) != engine().cpu_id()) {
-                return mutation_source([] (
-                        schema_ptr s,
-                        const dht::partition_range& pr,
-                        const query::partition_slice& slice,
-                        const io_priority_class& pc,
-                        tracing::trace_state_ptr trace_state,
-                        streamed_mutation::forwarding fwd,
-                        mutation_reader::forwarding fwd_mr,
-                        reader_resource_tracker tracker) {
+                {
                     return make_empty_flat_reader(s); // range doesn't belong to this shard
-                });
+                }
             }
 
-            return mutation_source([this, sstables=std::move(sstables)] (
-                    schema_ptr s,
-                    const dht::partition_range& pr,
-                    const query::partition_slice& slice,
-                    const io_priority_class& pc,
-                    tracing::trace_state_ptr trace_state,
-                    streamed_mutation::forwarding fwd,
-                    mutation_reader::forwarding fwd_mr,
-                    reader_resource_tracker tracker) {
+            {
                 return create_single_key_sstable_reader(const_cast<column_family*>(this), std::move(s), std::move(sstables),
                         _stats.estimated_sstable_per_read, pr, slice, pc, tracker, std::move(trace_state), fwd, fwd_mr);
-            });
+            }
         } else {
-            return mutation_source([sstables=std::move(sstables)] (
-                    schema_ptr s,
-                    const dht::partition_range& pr,
-                    const query::partition_slice& slice,
-                    const io_priority_class& pc,
-                    tracing::trace_state_ptr trace_state,
-                    streamed_mutation::forwarding fwd,
-                    mutation_reader::forwarding fwd_mr,
-                    reader_resource_tracker tracker) {
+            {
                 return make_local_shard_sstable_reader(std::move(s), std::move(sstables), pr, slice, pc,
                         tracker, std::move(trace_state), fwd, fwd_mr);
-            });
+            }
         }
-    }();
-
-    return ms.make_reader(std::move(s), pr, slice, pc, std::move(trace_state), fwd, fwd_mr, tracker);
+    }
 }
 
 // Exposed for testing, not performance critical.

--- a/table.cc
+++ b/table.cc
@@ -498,13 +498,7 @@ table::make_streaming_reader(schema_ptr s,
 
     auto source = mutation_source([this] (schema_ptr s, const dht::partition_range& range, const query::partition_slice& slice,
                                       const io_priority_class& pc, tracing::trace_state_ptr trace_state, streamed_mutation::forwarding fwd, mutation_reader::forwarding fwd_mr) {
-        std::vector<flat_mutation_reader> readers;
-        readers.reserve(_memtables->size() + 1);
-        for (auto&& mt : *_memtables) {
-            readers.emplace_back(mt->make_flat_reader(s, range, slice, pc, trace_state, fwd, fwd_mr));
-        }
-        readers.emplace_back(make_sstable_reader(s, _sstables, range, slice, pc, std::move(trace_state), fwd, fwd_mr));
-        return make_combined_reader(s, std::move(readers), fwd, fwd_mr);
+        return make_streaming_reader(std::move(s), range);
     });
 
     return make_flat_multi_range_reader(s, std::move(source), ranges, slice, pc, nullptr, mutation_reader::forwarding::no);

--- a/table.cc
+++ b/table.cc
@@ -356,7 +356,7 @@ table::make_sstable_reader(schema_ptr s,
                 });
             }
 
-            return mutation_source([semaphore, this, sstables=std::move(sstables)] (
+            return mutation_source([this, sstables=std::move(sstables)] (
                     schema_ptr s,
                     const dht::partition_range& pr,
                     const query::partition_slice& slice,
@@ -369,7 +369,7 @@ table::make_sstable_reader(schema_ptr s,
                         _stats.estimated_sstable_per_read, pr, slice, pc, tracker, std::move(trace_state), fwd, fwd_mr);
             });
         } else {
-            return mutation_source([semaphore, sstables=std::move(sstables)] (
+            return mutation_source([sstables=std::move(sstables)] (
                     schema_ptr s,
                     const dht::partition_range& pr,
                     const query::partition_slice& slice,


### PR DESCRIPTION
Currently, all requests accepted by the replica are passed to row_cache for processing. Misses are placed on a queue managed by reader_concurrency_semaphore where they can be admitted when resources allow, expired and rejected if the spend too long on the queue, or rejected outright if the queue is too long.

This approach has a problem when reads hit the cache and are hard to process (for example, due to reading many small rows per query). Each query will consume a relatively large of CPU time, and so it is easy to queue new requests faster than old requests can be retired. This results in memory consumption increasing without bounds.

This patchset changes the ordering so that the reader_concurrency_semaphore is in front of the cache. Each request is first queued on the reader_concurrency_semaphore so it has a chance to be rejected before expensive processing, fixing the problem.

Later, we might also add accounting for resources consumed by the cache.

Fixes #4758.

Tests: unit (dev, debug)