### PR TITLE
Add listen/rpc "prefer_ipv6" options to DNS lookup

### DIFF
--- a/db/config.cc
+++ b/db/config.cc
@@ -672,9 +672,8 @@ db::config::config(std::shared_ptr<db::extensions> exts)
     , enable_dangerous_direct_import_of_cassandra_counters(this, "enable_dangerous_direct_import_of_cassandra_counters", value_status::Used, false, "Only turn this option on if you want to import tables from Cassandra containing counters, and you are SURE that no counters in that table were created in a version earlier than Cassandra 2.1."
         " It is not enough to have ever since upgraded to newer versions of Cassandra. If you EVER used a version earlier than 2.1 in the cluster where these SSTables come from, DO NOT TURN ON THIS OPTION! You will corrupt your data. You have been warned.")
     , enable_shard_aware_drivers(this, "enable_shard_aware_drivers", value_status::Used, true, "Enable native transport drivers to use connection-per-shard for better performance")
-    , enable_ipv6_dns_lookup(this, "enable_ipv6_lookup", value_status::Used, false, "Use IPv6 address resolution")
+    , enable_ipv6_dns_lookup(this, "enable_ipv6_dns_lookup", value_status::Used, false, "Use IPv6 address resolution")
     , abort_on_internal_error(this, "abort_on_internal_error", liveness::LiveUpdate, value_status::Used, false, "Abort the server instead of throwing exception when internal invariants are violated")
-
     , default_log_level(this, "default_log_level", value_status::Used)
     , logger_log_level(this, "logger_log_level", value_status::Used)
     , log_to_stdout(this, "log_to_stdout", value_status::Used)

--- a/db/config.cc
+++ b/db/config.cc
@@ -247,6 +247,12 @@ db::config::config(std::shared_ptr<db::extensions> exts)
         "Related information: Network\n")
     , rpc_interface(this, "rpc_interface", value_status::Unused, "eth1",
         "The listen address for client connections. Interfaces must correspond to a single address, IP aliasing is not supported. See rpc_address.")
+    , rpc_interface_prefer_ipv6(this, "rpc_interface_prefer_ipv6", value_status::Used, false,
+        "If you choose to specify the interface by name and the interface has an ipv4 and an ipv6 address\n"
+        "you can specify which should be chosen using rpc_interface_prefer_ipv6. If false the first ipv4\n"
+        "address will be used. If true the first ipv6 address will be used. Defaults to false preferring\n"
+        "ipv4. If there is only one address it will be selected regardless of ipv4/ipv6"
+    )
     , seed_provider(this, "seed_provider", value_status::Used, seed_provider_type("org.apache.cassandra.locator.SimpleSeedProvider"),
         "The addresses of hosts deemed contact points. Scylla nodes use the -seeds list to find each other and learn the topology of the ring.\n"
         "\n"

--- a/db/config.cc
+++ b/db/config.cc
@@ -184,6 +184,12 @@ db::config::config(std::shared_ptr<db::extensions> exts)
         "Never specify 0.0.0.0; it is always wrong.")
     , listen_interface(this, "listen_interface", value_status::Unused, "eth0",
         "The interface that Scylla binds to for connecting to other Scylla nodes. Interfaces must correspond to a single address, IP aliasing is not supported. See listen_address.")
+    , listen_interface_prefer_ipv6(this, "listen_interface_prefer_ipv6", value_status::Used, false,
+        "If you choose to specify the interface by name and the interface has an ipv4 and an ipv6 address\n"
+        "you can specify which should be chosen using listen_interface_prefer_ipv6. If false the first ipv4\n"
+        "address will be used. If true the first ipv6 address will be used. Defaults to false preferring\n"
+        "ipv4. If there is only one address it will be selected regardless of ipv4/ipv6."
+    )
     /* Default directories */
     /* If you have changed any of the default directories during installation, make sure you have root access and set these properties: */
     , commitlog_directory(this, "commitlog_directory", value_status::Used, "/var/lib/scylla/commitlog",

--- a/db/config.hh
+++ b/db/config.hh
@@ -122,6 +122,7 @@ public:
     named_value<sstring> endpoint_snitch;
     named_value<sstring> rpc_address;
     named_value<sstring> rpc_interface;
+    named_value<bool> rpc_interface_prefer_ipv6;
     named_value<seed_provider_type> seed_provider;
     named_value<uint32_t> compaction_throughput_mb_per_sec;
     named_value<uint32_t> compaction_large_partition_warning_threshold_mb;

--- a/db/config.hh
+++ b/db/config.hh
@@ -111,6 +111,7 @@ public:
     named_value<sstring> cluster_name;
     named_value<sstring> listen_address;
     named_value<sstring> listen_interface;
+    named_value<bool> listen_interface_prefer_ipv6;
     named_value<sstring> commitlog_directory;
     named_value<string_list> data_file_directories;
     named_value<sstring> hints_directory;

--- a/gms/inet_address.cc
+++ b/gms/inet_address.cc
@@ -44,8 +44,13 @@
 
 using namespace seastar;
 
-future<gms::inet_address> gms::inet_address::lookup(sstring name, opt_family family) {
-    return seastar::net::dns::resolve_name(name, family).then([](seastar::net::inet_address&& a) {
-        return make_ready_future<gms::inet_address>(a);
+future<gms::inet_address> gms::inet_address::lookup(sstring name, opt_family family, opt_family preferred) {
+    return seastar::net::dns::get_host_by_name(name, family).then([preferred](seastar::net::hostent&& h) {
+        for (auto& addr : h.addr_list) {
+            if (!preferred || addr.in_family() == preferred) {
+                return gms::inet_address(addr);
+            }
+        }
+        return gms::inet_address(h.addr_list.front());
     });
 }

--- a/gms/inet_address.hh
+++ b/gms/inet_address.hh
@@ -93,7 +93,7 @@ public:
 
     using opt_family = std::optional<net::inet_address::family>;
 
-    static future<inet_address> lookup(sstring, opt_family = {});
+    static future<inet_address> lookup(sstring, opt_family family = {}, opt_family preferred = {});
 };
 
 std::ostream& operator<<(std::ostream& os, const inet_address& x);


### PR DESCRIPTION
Add listen/rpc "prefer_ipv6" options to DNS lookup of bind addresses for API/rpc/prometheus etc .

Fixes #4751
    
Adds using a preferred address family to dns name lookups related to
listen address and rpc address, adhering to the respective "prefer" options.
    
API, prometheus and broadcast address are all considered to be covered by
the "listen_interface_prefer_ipv6" option.
    
Note: scylla does not yet support actual interface binding, but these
options should apply equally to address name parameters.
    
Setting a "prefer_ipv6" option automtially enables ipv6 dns family query.