### PR TITLE
Improve compaction logging

### DIFF
--- a/sstables/compaction.cc
+++ b/sstables/compaction.cc
@@ -390,7 +390,8 @@ private:
             _ancestors.push_back(sst->generation());
             _info->start_size += sst->bytes_on_disk();
             _info->total_partitions += sst->get_estimated_key_count();
-            formatted_msg += format("{}{}:level={:d}", delim, sst->component_basename(component_type::Data), sst->get_sstable_level());
+            formatted_msg += format("{}{}:level={:d}:run={}", delim, sst->component_basename(component_type::Data),
+                    sst->get_sstable_level(), sst->run_identifier());
             delim = ", ";
 
             // Do not actually compact a sstable that is fully expired and can be safely
@@ -434,7 +435,8 @@ private:
 
         const char* delim = "";
         for (auto& newtab : _info->new_sstables) {
-            new_sstables_msg += format("{}{}:level={:d}", delim, newtab->component_basename(component_type::Data), newtab->get_sstable_level());
+            new_sstables_msg += format("{}{}:level={:d}:run={}", delim, newtab->component_basename(component_type::Data),
+                    newtab->get_sstable_level(), newtab->run_identifier());
             delim = ", ";
         }
 

--- a/sstables/compaction.cc
+++ b/sstables/compaction.cc
@@ -384,12 +384,14 @@ private:
         sstring formatted_msg = format("ks={} cf={} [", _schema->ks_name(), _schema->cf_name());
         auto fully_expired = get_fully_expired_sstables(_cf, _sstables, gc_clock::now() - _schema->gc_grace_seconds());
 
+        const char* delim = "";
         for (auto& sst : _sstables) {
             // Compacted sstable keeps track of its ancestors.
             _ancestors.push_back(sst->generation());
             _info->start_size += sst->bytes_on_disk();
             _info->total_partitions += sst->get_estimated_key_count();
-            formatted_msg += format("{}:level={:d}, ", sst->get_filename(), sst->get_sstable_level());
+            formatted_msg += format("{}{}:level={:d}", delim, sst->get_filename(), sst->get_sstable_level());
+            delim = ", ";
 
             // Do not actually compact a sstable that is fully expired and can be safely
             // dropped without ressurrecting old data.
@@ -430,8 +432,10 @@ private:
         auto throughput = duration.count() > 0 ? (double(_info->end_size) / (1024*1024)) / duration.count() : double{};
         sstring new_sstables_msg;
 
+        const char* delim = "";
         for (auto& newtab : _info->new_sstables) {
-            new_sstables_msg += format("{}:level={:d}, ", newtab->get_filename(), newtab->get_sstable_level());
+            new_sstables_msg += format("{}{}:level={:d}", delim, newtab->get_filename(), newtab->get_sstable_level());
+            delim = ", ";
         }
 
         // FIXME: there is some missing information in the log message below.

--- a/sstables/compaction.cc
+++ b/sstables/compaction.cc
@@ -381,7 +381,7 @@ private:
 
     flat_mutation_reader setup() {
         auto ssts = make_lw_shared<sstables::sstable_set>(_cf.get_compaction_strategy().make_sstable_set(_schema));
-        sstring formatted_msg = "[";
+        sstring formatted_msg = format("ks={} cf={} [", _schema->ks_name(), _schema->cf_name());
         auto fully_expired = get_fully_expired_sstables(_cf, _sstables, gc_clock::now() - _schema->gc_grace_seconds());
 
         for (auto& sst : _sstables) {

--- a/sstables/compaction.cc
+++ b/sstables/compaction.cc
@@ -566,11 +566,11 @@ public:
     }
 
     void report_start(const sstring& formatted_msg) const override {
-        clogger.info("Compacting {}", formatted_msg);
+        clogger.info("[compaction {}] Compacting {}", format("{:#010x}", _info->compaction_id), formatted_msg);
     }
 
     void report_finish(const sstring& formatted_msg, std::chrono::time_point<db_clock> ended_at) const override {
-        clogger.info("Compacted {}", formatted_msg);
+        clogger.info("[compaction {}] Compacted {}", format("{:#010x}", _info->compaction_id), formatted_msg);
     }
 
     void backlog_tracker_adjust_charges() override {
@@ -718,11 +718,11 @@ public:
     }
 
     void report_start(const sstring& formatted_msg) const override {
-        clogger.info("Cleaning {}", formatted_msg);
+        clogger.info("[compaction {}] Cleaning {}", format("{:#010x}", _info->compaction_id), formatted_msg);
     }
 
     void report_finish(const sstring& formatted_msg, std::chrono::time_point<db_clock> ended_at) const override {
-        clogger.info("Cleaned {}", formatted_msg);
+        clogger.info("[compaction {}] Cleaned {}", format("{:#010x}", _info->compaction_id), formatted_msg);
     }
 
     std::function<bool(const dht::decorated_key&)> filter_func() const override {
@@ -819,11 +819,11 @@ public:
     }
 
     void report_start(const sstring& formatted_msg) const override {
-        clogger.info("Resharding {}", formatted_msg);
+        clogger.info("[compaction {}] Resharding {}", format("{:#010x}", _info->compaction_id), formatted_msg);
     }
 
     void report_finish(const sstring& formatted_msg, std::chrono::time_point<db_clock> ended_at) const override {
-        clogger.info("Resharded {}", formatted_msg);
+        clogger.info("[compaction {}] Resharded {}", format("{:#010x}", _info->compaction_id), formatted_msg);
     }
 
     void backlog_tracker_adjust_charges() override { }

--- a/sstables/compaction.cc
+++ b/sstables/compaction.cc
@@ -43,6 +43,7 @@
 #include <utility>
 #include <assert.h>
 #include <algorithm>
+#include <random>
 
 #include <boost/range/algorithm.hpp>
 #include <boost/range/adaptors.hpp>
@@ -976,6 +977,11 @@ get_fully_expired_sstables(column_family& cf, const std::vector<sstables::shared
         }
     }
     return candidates;
+}
+
+compaction_info::compaction_info() {
+    static thread_local auto gen = std::default_random_engine(std::random_device{}());
+    compaction_id = gen();
 }
 
 }

--- a/sstables/compaction.cc
+++ b/sstables/compaction.cc
@@ -390,7 +390,7 @@ private:
             _ancestors.push_back(sst->generation());
             _info->start_size += sst->bytes_on_disk();
             _info->total_partitions += sst->get_estimated_key_count();
-            formatted_msg += format("{}{}:level={:d}", delim, sst->get_filename(), sst->get_sstable_level());
+            formatted_msg += format("{}{}:level={:d}", delim, sst->component_basename(component_type::Data), sst->get_sstable_level());
             delim = ", ";
 
             // Do not actually compact a sstable that is fully expired and can be safely
@@ -434,7 +434,7 @@ private:
 
         const char* delim = "";
         for (auto& newtab : _info->new_sstables) {
-            new_sstables_msg += format("{}{}:level={:d}", delim, newtab->get_filename(), newtab->get_sstable_level());
+            new_sstables_msg += format("{}{}:level={:d}", delim, newtab->component_basename(component_type::Data), newtab->get_sstable_level());
             delim = ", ";
         }
 

--- a/sstables/compaction.hh
+++ b/sstables/compaction.hh
@@ -97,7 +97,7 @@ namespace sstables {
         uint64_t end_size = 0;
         uint64_t total_partitions = 0;
         uint64_t total_keys_written = 0;
-        int64_t ended_at;
+        int64_t ended_at = -1;
         std::vector<shared_sstable> new_sstables;
         sstring stop_requested;
         bool tracking = true;

--- a/sstables/compaction.hh
+++ b/sstables/compaction.hh
@@ -107,6 +107,9 @@ namespace sstables {
             const std::vector<shared_sstable> added;
         };
         std::vector<replacement> pending_replacements;
+        unsigned compaction_id;
+
+        compaction_info();
 
         bool is_stop_requested() const {
             return stop_requested.size() > 0;


### PR DESCRIPTION
In this series:
1. Generate and a unique random identifier per compaction and print it on report_start/finish
2. Cleanup printout of sstable lists
3. Print also the run_identofier for each sstable to the log

Fixes #4778

Test: unit (dev), compaction_test.py:TestCompaction_with_SizeTieredCompactionStrategy.sstable_deletion_test (dev)