### PR TITLE
Catch unclosed partition sstable write

### DIFF
--- a/db/config.cc
+++ b/db/config.cc
@@ -673,6 +673,7 @@ db::config::config(std::shared_ptr<db::extensions> exts)
         " It is not enough to have ever since upgraded to newer versions of Cassandra. If you EVER used a version earlier than 2.1 in the cluster where these SSTables come from, DO NOT TURN ON THIS OPTION! You will corrupt your data. You have been warned.")
     , enable_shard_aware_drivers(this, "enable_shard_aware_drivers", value_status::Used, true, "Enable native transport drivers to use connection-per-shard for better performance")
     , enable_ipv6_dns_lookup(this, "enable_ipv6_lookup", value_status::Used, false, "Use IPv6 address resolution")
+    , abort_on_internal_error(this, "abort_on_internal_error", liveness::LiveUpdate, value_status::Used, false, "Abort the server instead of throwing exception when internal invariants are violated")
 
     , default_log_level(this, "default_log_level", value_status::Used)
     , logger_log_level(this, "logger_log_level", value_status::Used)

--- a/db/config.hh
+++ b/db/config.hh
@@ -279,6 +279,7 @@ public:
     named_value<bool> enable_dangerous_direct_import_of_cassandra_counters;
     named_value<bool> enable_shard_aware_drivers;
     named_value<bool> enable_ipv6_dns_lookup;
+    named_value<bool> abort_on_internal_error;
 
     seastar::logging_settings logging_settings(const boost::program_options::variables_map&) const;
 

--- a/main.cc
+++ b/main.cc
@@ -629,6 +629,12 @@ int main(int ac, char** av) {
             if (opts.count("developer-mode")) {
                 smp::invoke_on_all([] { engine().set_strict_dma(false); }).get();
             }
+
+            auto abort_on_internal_error_observer = cfg->abort_on_internal_error.observe([] (bool val) {
+                set_abort_on_internal_error(val);
+            });
+            set_abort_on_internal_error(cfg->abort_on_internal_error());
+
             supervisor::notify("creating tracing");
             tracing::backend_registry tracing_backend_registry;
             tracing::register_tracing_keyspace_backend(tracing_backend_registry);

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -2112,11 +2112,15 @@ stop_iteration components_writer::consume_end_of_partition() {
         _first_key = *_partition_key;
     }
     _last_key = std::move(*_partition_key);
+    _partition_key = std::nullopt;
 
     return get_offset() < _max_sstable_size ? stop_iteration::no : stop_iteration::yes;
 }
 
 void components_writer::consume_end_of_stream() {
+    if (_partition_key) {
+        on_internal_error(sstlog, "Mutation stream ends with unclosed partition during write");
+    }
     // what if there is only one partition? what if it is empty?
     seal_summary(_sst._components->summary, std::move(_first_key), std::move(_last_key), _index_sampling_state);
 

--- a/tests/cql_test_env.cc
+++ b/tests/cql_test_env.cc
@@ -360,6 +360,7 @@ public:
                 create_directories((cfg->view_hints_directory() + "/" + std::to_string(i)).c_str());
             }
 
+            set_abort_on_internal_error(true);
             const gms::inet_address listen("127.0.0.1");
             auto& ms = netw::get_messaging_service();
             // don't start listening so tests can be run in parallel

--- a/utils/config_file.hh
+++ b/utils/config_file.hh
@@ -207,6 +207,10 @@ public:
             return updateable_value<T>(the_value());
         }
 
+        observer<T> observe(std::function<void (const T&)> callback) const {
+            return the_value().observe(std::move(callback));
+        }
+
         void add_command_line_option(bpo::options_description_easy_init&,
                         const std::string_view&, const std::string_view&) override;
         void set_value(const YAML::Node&) override;

--- a/utils/exceptions.hh
+++ b/utils/exceptions.hh
@@ -21,8 +21,12 @@
 
 #pragma once
 
+#include <seastar/core/sstring.hh>
+
 #include <functional>
 #include <system_error>
+
+namespace seastar { class logger; }
 
 typedef std::function<bool (const std::system_error &)> system_error_lambda_t;
 
@@ -45,3 +49,10 @@ public:
 
     const std::error_code& code() const { return _code; }
 };
+
+// Controls whether on_internal_error() aborts or throws.
+void set_abort_on_internal_error(bool do_abort);
+
+// Handles reporting of violation of internal invariants.
+// Callers can assume that it does not return. May throw.
+[[noreturn]] void on_internal_error(seastar::logger&, const seastar::sstring& reason);


### PR DESCRIPTION
Not emitting partition_end for a partition is incorrect. SStable
writer assumes that it is emitted. If it's not, the sstable will not
be written correctly. The partition index entry for the last partition
will be left partially written, which will result in errors during
reads. Also, statistics and sstable key ranges will not include the
last partition.

It's better to catch this problem at the time of writing, and not
generate bad sstables.

Another way of handling this would be to implicitly generate a
partition_end, but I don't think that we should do this. We cannot
trust the mutation stream when invariants are violated, we don't know
if this was really the last partition which was supposed to be
written. So it's safer to fail the write.

Enabled for both mc and la/ka.

Passing --abort-on-internal-error on the command line will switch to
aborting instead of throwing an exception.

The reason we don't abort by default is that it may bring the whole
cluster down and cause unavailability, while it may not be necessary
to do so. It's safer to fail just the affected operation,
e.g. repair. However, failing the operation with an exception leaves
little information for debugging the root cause. So the idea is that the
user would enable aborts on only one of the nodes in the cluster to
get a core dump and not bring the whole cluster down.