### PR TITLE
streaming: Do not call rpc stream flush in send_mutation_fragments

### DIFF
--- a/streaming/stream_transfer_task.cc
+++ b/streaming/stream_transfer_task.cc
@@ -213,8 +213,6 @@ future<> send_mutation_fragments(lw_shared_ptr<send_info> si) {
                     });
                 }).then([&sink] () mutable {
                     return sink(frozen_mutation_fragment(bytes_ostream()), stream_mutation_fragments_cmd::end_of_stream);
-                }).then([&sink] () mutable {
-                    return sink.flush();
                 }).handle_exception([&sink] (std::exception_ptr ep) mutable {
                     // Notify the receiver the sender has failed
                     return sink(frozen_mutation_fragment(bytes_ostream()), stream_mutation_fragments_cmd::error).then([ep = std::move(ep)] () mutable {


### PR DESCRIPTION
The stream close() guarantees the data sent will be flushed. No need to
call the stream flush() since the stream is not reused.

Follow up fix for commit bac987e32ada (streaming: Send error code from
the sender to receiver).

Fixes: #4789
