### PR TITLE
streaming: Move stream_mutation_fragments_cmd to a new file

### DIFF
--- a/message/messaging_service.cc
+++ b/message/messaging_service.cc
@@ -90,6 +90,7 @@
 #include "frozen_mutation.hh"
 #include "flat_mutation_reader.hh"
 #include "streaming/stream_manager.hh"
+#include "streaming/stream_mutation_fragments_cmd.hh"
 
 namespace netw {
 

--- a/message/messaging_service.hh
+++ b/message/messaging_service.hh
@@ -36,6 +36,7 @@
 #include "tracing/tracing.hh"
 #include "digest_algorithm.hh"
 #include "streaming/stream_reason.hh"
+#include "streaming/stream_mutation_fragments_cmd.hh"
 #include "cache_temperature.hh"
 
 #include <list>

--- a/streaming/stream_mutation_fragments_cmd.hh
+++ b/streaming/stream_mutation_fragments_cmd.hh
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2019 ScyllaDB
+ */
+
+/*
+ * This file is part of Scylla.
+ *
+ * Scylla is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Scylla is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+namespace streaming {
+
+enum class stream_mutation_fragments_cmd : uint8_t {
+    error,
+    mutation_fragment_data,
+    end_of_stream,
+};
+
+
+}

--- a/streaming/stream_session.cc
+++ b/streaming/stream_session.cc
@@ -66,6 +66,7 @@
 #include <boost/range/adaptor/map.hpp>
 #include "../db/view/view_update_generator.hh"
 #include "mutation_source_metadata.hh"
+#include "streaming/stream_mutation_fragments_cmd.hh"
 
 namespace streaming {
 

--- a/streaming/stream_session.hh
+++ b/streaming/stream_session.hh
@@ -350,10 +350,4 @@ private:
     future<> receiving_failed(UUID cf_id);
 };
 
-enum class stream_mutation_fragments_cmd : uint8_t {
-    error,
-    mutation_fragment_data,
-    end_of_stream,
-};
-
 } // namespace streaming

--- a/streaming/stream_transfer_task.cc
+++ b/streaming/stream_transfer_task.cc
@@ -42,6 +42,7 @@
 #include "streaming/stream_session.hh"
 #include "streaming/stream_manager.hh"
 #include "streaming/stream_reason.hh"
+#include "streaming/stream_mutation_fragments_cmd.hh"
 #include "mutation_reader.hh"
 #include "frozen_mutation.hh"
 #include "mutation.hh"


### PR DESCRIPTION
Avoid including the lengthy stream_session.hh in messaging_service.

More importantly, fix the build because currently messaging_service.cc
and messaging_service.hh does not include stream_mutation_fragments_cmd.
I am not sure why it builds on my machine. Spotted this when backporting
the "streaming: Send error code from the sender to receiver" to 3.0
branch.

Refs: #4789