### PR TITLE
repair: Fix use after free in do_estimate_partitions_on_local_shard

### DIFF
--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -880,13 +880,12 @@ private:
     }
 
     future<uint64_t> do_estimate_partitions_on_local_shard() {
-        auto sstables = _cf.get_sstables();
-        auto partition_count = make_lw_shared<uint64_t>(0);
-        return do_for_each(*sstables, [this, partition_count] (const sstables::shared_sstable& sst) mutable {
-            *partition_count += sst->estimated_keys_for_range(_range);
-            return make_ready_future<>();
-        }).then([partition_count] {
-            return *partition_count;
+        return do_with(_cf.get_sstables(), uint64_t(0), [this] (lw_shared_ptr<const sstable_list>& sstables, uint64_t& partition_count) {
+            return do_for_each(*sstables, [this, &partition_count] (const sstables::shared_sstable& sst) mutable {
+                partition_count += sst->estimated_keys_for_range(_range);
+            }).then([&partition_count] {
+                return partition_count;
+            });
         });
     }
 


### PR DESCRIPTION
We need to keep the sstables object alive during the operation of
do_for_each.

Notes: No need to backport to 3.1.

Fixes #4811
