### PR TITLE
thrift, transport: switch to new seastar accept() API

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1087,7 +1087,6 @@ if args.target != '':
 seastar_ldflags = args.user_ldflags
 seastar_flags += ['--compiler', args.cxx, '--c-compiler', args.cc, '--cflags=%s' % (seastar_cflags), '--ldflags=%s' % (seastar_ldflags),
                   '--c++-dialect=gnu++17', '--use-std-optional-variant-stringview=1', '--optflags=%s' % (modes['release']['cxx_ld_flags']), ]
-seastar_flags += ['--api-level=1']   # old-style variadic future return from server_socket::accept()
 
 libdeflate_cflags = seastar_cflags
 zstd_cflags = seastar_cflags + ' -Wno-implicit-fallthrough'

--- a/thrift/server.cc
+++ b/thrift/server.cc
@@ -230,7 +230,8 @@ thrift_server::do_accepts(int which, bool keepalive) {
         return;
     }
     with_gate(_stop_gate, [&, this] {
-        return _listeners[which].accept().then([this, which, keepalive] (connected_socket fd, socket_address addr) {
+        return _listeners[which].accept().then([this, which, keepalive] (accept_result ar) {
+            auto&& [fd, addr] = ar;
             fd.set_nodelay(true);
             fd.set_keepalive(keepalive);
             with_gate(_stop_gate, [&, this] {


### PR DESCRIPTION
Seastar switched accept() to return a single struct instead of a variadic future,
adjust the code to the new API to avoid deprecation warnings.
