### PR TITLE
utils: loading_cache: prevent bogus discarded future warning

### DIFF
--- a/utils/loading_cache.hh
+++ b/utils/loading_cache.hh
@@ -580,7 +580,9 @@ private:
         }
 
         // Reload all those which value needs to be reloaded.
-        with_gate(_timer_reads_gate, [this] {
+        // We can discard the return value of with_gate() since stop() will wait
+        // got the gate to be closed (and thus for these continuations to complete).
+        (void)with_gate(_timer_reads_gate, [this] {
             auto to_reload = boost::copy_range<utils::chunked_vector<timestamped_val_ptr>>(_lru_list
                     | boost::adaptors::filtered([this] (ts_value_lru_entry& lru_entry) {
                         return lru_entry.timestamped_value().loaded() + _refresh < loading_cache_clock_type::now();


### PR DESCRIPTION
The future is safe to discard, so cast it to const and add a
comment explaining why it is safe.

It would be better done with a new API for gate, but we can
change that when that new API is available.
