### PR TITLE
transport: wait for the connections to finish when stopping

### DIFF
--- a/transport/server.cc
+++ b/transport/server.cc
@@ -607,6 +607,7 @@ future<> cql_server::connection::process_request() {
                     auto response = response_f.get0();
                     update_client_state(response);
                     write_response(std::move(response.cql_response), std::move(mem_permit), _compression);
+                    _ready_to_respond = _ready_to_respond.finally([leave = std::move(leave)] {});
                 } catch (...) {
                     clogger.error("request processing failed: {}", std::current_exception());
                 }


### PR DESCRIPTION
During CQL request processing, a gate is used to ensure that
the connection is not shut down until all ongoing requests
are done. However, the gate might have been left too early
if the database was not ready to respond immediately - which
could result in trying to respond to an already closed connection
later. This issue is solved by postponing leaving the gate
until the continuation chain that handles the request is finished.

Refs #4808