### PR TITLE
cql3: Handle empty LIKE pattern

### DIFF
--- a/tests/cql_query_test.cc
+++ b/tests/cql_query_test.cc
@@ -3937,15 +3937,15 @@ SEASTAR_TEST_CASE(test_like_operator_bind_marker) {
     });
 }
 
-#if 0 // TODO: Enable when like_matcher handles blank pattern.
 SEASTAR_TEST_CASE(test_like_operator_blank_pattern) {
     return do_with_cql_env_thread([] (cql_test_env& e) {
-        cquery_nofail(e, "create table t (s text primary key, )");
-        cquery_nofail(e, "insert into t (s) values ('abc')");
+        cquery_nofail(e, "create table t (p int primary key, s text)");
+        cquery_nofail(e, "insert into t (p, s) values (1, 'abc')");
         require_rows(e, "select s from t where s like '' allow filtering", {});
+        cquery_nofail(e, "insert into t (p, s) values (2, '')");
+        require_rows(e, "select s from t where s like '' allow filtering", {{T("")}});
     });
 }
-#endif
 
 SEASTAR_TEST_CASE(test_like_operator_ascii) {
     return do_with_cql_env_thread([] (cql_test_env& e) {

--- a/tests/like_matcher_test.cc
+++ b/tests/like_matcher_test.cc
@@ -40,6 +40,13 @@ BOOST_AUTO_TEST_CASE(test_literal) {
     BOOST_TEST(!matches(m, u8" abc"));
 }
 
+BOOST_AUTO_TEST_CASE(test_empty) {
+    auto m = matcher(u8"");
+    BOOST_TEST(matches(m, u8""));
+    BOOST_TEST(!matches(m, u8" "));
+    BOOST_TEST(!matches(m, u8"abcd"));
+}
+
 BOOST_AUTO_TEST_CASE(test_underscore_start) {
     auto m = matcher(u8"_a");
     BOOST_TEST(matches(m, u8"aa"));

--- a/utils/like_matcher.cc
+++ b/utils/like_matcher.cc
@@ -68,6 +68,9 @@ void process_char(wchar_t c, wstring& re, bool& escaping) {
 
 /// Returns a regex string matching the given LIKE pattern.
 wstring regex_from_pattern(bytes_view pattern) {
+    if (pattern.empty()) {
+        return L"^$"; // Like SQL, empty pattern matches only empty text.
+    }
     using namespace boost::locale::conv;
     wstring wpattern = utf_to_utf<wchar_t>(pattern.begin(), pattern.end(), stop);
     if (wpattern.back() == L'\\') {


### PR DESCRIPTION
Match SQL's LIKE in allowing an empty pattern, which matches only an empty text field.

Tests: unit (dev)