### PR TITLE
Scyllatop: one pass update of multiple metrics

### DIFF
--- a/tools/scyllatop/dumptostdout.py
+++ b/tools/scyllatop/dumptostdout.py
@@ -1,5 +1,6 @@
 import livedata
 import views.stdout
+import logging
 
 
 class _FakeLoop:
@@ -8,6 +9,7 @@ class _FakeLoop:
         self._liveData = liveData
 
     def draw_screen(self):
+        logging.debug("iterations={}".format(self._iterations))
         if self._iterations is None:
             return
 

--- a/tools/scyllatop/dumptostdout.py
+++ b/tools/scyllatop/dumptostdout.py
@@ -18,9 +18,9 @@ class _FakeLoop:
             self._liveData.stop()
 
 
-def dumpToStdout(metricPatterns, interval, collectd, iterations):
+def dumpToStdout(metricPatterns, interval, collectd, iterations, ttl=None):
     stdout = views.stdout.Stdout()
-    liveData = livedata.LiveData(metricPatterns, interval, collectd)
+    liveData = livedata.LiveData(metricPatterns, interval, collectd, ttl)
     liveData.addView(stdout)
 
     loop = _FakeLoop(liveData, iterations)

--- a/tools/scyllatop/fake.py
+++ b/tools/scyllatop/fake.py
@@ -30,14 +30,18 @@ class FakeMetric(Metric):
     @classmethod
     def discover(self, unused):
         results = []
+
+        def _add_metric(metric, results):
+            m = FakeMetric(metric, None)
+            m.add_to_results(results)
+
         for cpu in range(4):
-            results += [
-                FakeMetric('localhost/cpu-{}/cache'.format(cpu), None),
-                FakeMetric('localhost/cpu-{}/storage_proxy'.format(cpu), None),
-                FakeMetric('localhost/cpu-{}/transport'.format(cpu), None)]
+            _add_metric('localhost/cpu-{}/cache'.format(cpu))
+            _add_metric('localhost/cpu-{}/storage_proxy'.format(cpu))
+            _add_metric('localhost/cpu-{}/transport'.format(cpu))
 
         for x in range(100):
-            results.append(FakeMetric('localhost/fake_{}/{}'.format(x, random.choice('abcdefghijklmnopqrstuvwxyz')), None))
+            _add_metric('localhost/fake_{}/{}'.format(x, random.choice('abcdefghijklmnopqrstuvwxyz')))
         return results
 
 

--- a/tools/scyllatop/fake.py
+++ b/tools/scyllatop/fake.py
@@ -29,7 +29,7 @@ class FakeMetric(Metric):
 
     @classmethod
     def discover(self, unused):
-        results = []
+        results = {}
 
         def _add_metric(metric, results):
             m = FakeMetric(metric, None)

--- a/tools/scyllatop/livedata.py
+++ b/tools/scyllatop/livedata.py
@@ -8,7 +8,7 @@ import defaults
 
 class LiveData(object):
     def __init__(self, metricPatterns, interval, metric_source):
-        logging.info('will query metric_source every {0} seconds'.format(interval))
+        logging.info('will query metric_source {} every {} seconds'.format(metric_source, interval))
         self._startedAt = time.time()
         self._measurements = []
         self._interval = interval
@@ -18,6 +18,7 @@ class LiveData(object):
         self._stop = False
 
     def addView(self, view):
+        logging.debug('addView {}'.format(view))
         self._views.append(view)
 
     @property
@@ -29,6 +30,7 @@ class LiveData(object):
             self._setupUserSpecifiedMetrics(metricPatterns)
         else:
             self._setupUserSpecifiedMetrics(defaults.DEFAULT_METRIC_PATTERNS)
+        logging.debug('_initializeMetrics: {} measurements'.format(len(self._measurements)))
 
     def _setupUserSpecifiedMetrics(self, metricPatterns):
         availableSymbols = [m.symbol for m in metric.Metric.discover(self._metric_source)]
@@ -48,10 +50,14 @@ class LiveData(object):
         while not self._stop:
             for metric_obj in self._measurements:
                 self._update(metric_obj)
+            logging.debug('go: updated {} measurements'.format(len(self._measurements)))
 
             for view in self._views:
+                logging.debug('go: updating view {}'.format(view))
                 view.update(self)
+            logging.debug('go: sleeping for {} seconds'.format(self._interval))
             time.sleep(self._interval)
+            logging.debug('go: drawing screen...')
             mainLoop.draw_screen()
 
     def _update(self, metric_obj):

--- a/tools/scyllatop/livedata.py
+++ b/tools/scyllatop/livedata.py
@@ -17,7 +17,7 @@ class LiveData(object):
             self._metricPatterns = metricPatterns
         else:
             self._metricPatterns = defaults.DEFAULT_METRIC_PATTERNS
-        self._initializeMetrics()
+        self._results = self._discoverMetrics()
         self._views = []
         self._stop = False
 
@@ -33,13 +33,14 @@ class LiveData(object):
     def measurements(self):
         return self._results.values()
 
-    def _initializeMetrics(self):
-        self._results = metric.Metric.discover(self._metric_source)
-        logging.debug('_initializeMetrics: {} results discovered'.format(len(self._results)))
-        for symbol in self._results:
+    def _discoverMetrics(self):
+        results = metric.Metric.discover(self._metric_source)
+        logging.debug('_discoverMetrics: {} results discovered'.format(len(results)))
+        for symbol in results:
             if not self._matches(symbol, self._metricPatterns):
-                self._results.pop(symbol)
-        logging.debug('_initializeMetrics: {} results matched'.format(len(self._results)))
+                results.pop(symbol)
+        logging.debug('_initializeMetrics: {} results matched'.format(len(results)))
+        return results
 
     def _matches(self, symbol, metricPatterns):
         for pattern in metricPatterns:
@@ -49,10 +50,20 @@ class LiveData(object):
         return False
 
     def go(self, mainLoop):
+        num_updated = 0
+        num_absent = 0
+        num_added = 0
         while not self._stop:
-            for metric_obj in self.measurements:
-                self._update(metric_obj)
-            logging.debug('go: updated {} measurements'.format(len(self.measurements)))
+            new_results = self._discoverMetrics();
+            for metric in self._results:
+                if not metric in new_results:
+                    metric_obj = self._results[metric]
+                    metric_obj.markAbsent()
+                    num_absent += 1
+            num_updated = len(self._results) - num_absent
+            num_added = len(new_results) - num_updated
+            self._results.update(new_results)
+            logging.debug('go: updated {} measurements, added {}, {} marked absent'.format(num_updated, num_added, num_absent))
 
             for view in self._views:
                 logging.debug('go: updating view {}'.format(view))

--- a/tools/scyllatop/livedata.py
+++ b/tools/scyllatop/livedata.py
@@ -13,7 +13,11 @@ class LiveData(object):
         self._measurements = []
         self._interval = interval
         self._metric_source = metric_source
-        self._initializeMetrics(metricPatterns)
+        if metricPatterns and len(metricPatterns) > 0:
+            self._metricPatterns = metricPatterns
+        else:
+            self._metricPatterns = defaults.DEFAULT_METRIC_PATTERNS
+        self._initializeMetrics()
         self._views = []
         self._stop = False
 
@@ -25,16 +29,9 @@ class LiveData(object):
     def measurements(self):
         return self._measurements
 
-    def _initializeMetrics(self, metricPatterns):
-        if len(metricPatterns) > 0:
-            self._setupUserSpecifiedMetrics(metricPatterns)
-        else:
-            self._setupUserSpecifiedMetrics(defaults.DEFAULT_METRIC_PATTERNS)
-        logging.debug('_initializeMetrics: {} measurements'.format(len(self._measurements)))
-
-    def _setupUserSpecifiedMetrics(self, metricPatterns):
+    def _initializeMetrics(self):
         availableSymbols = [m.symbol for m in metric.Metric.discover(self._metric_source)]
-        symbols = [symbol for symbol in availableSymbols if self._matches(symbol, metricPatterns)]
+        symbols = [symbol for symbol in availableSymbols if self._matches(symbol, self._metricPatterns)]
         for symbol in symbols:
                 logging.info('adding {0}'.format(symbol))
                 self._measurements.append(metric.Metric(symbol, self._metric_source, ""))

--- a/tools/scyllatop/metric.py
+++ b/tools/scyllatop/metric.py
@@ -43,11 +43,12 @@ class Metric(object):
             self._status[key] = 'not available'
 
     def add_to_results(self, results):
-        results.append(self)
-
+        if not isinstance(results, dict):
+            raise Exception("results must be a dictionary")
+        results[self._symbol] = self
     @classmethod
     def _discover(cls, metric_source, with_help = False):
-        results = []
+        results = {}
         logging.info('discovering metrics{}...'.format(" with help" if with_help else ""))
         response = metric_source.query_list()
         for line in response:

--- a/tools/scyllatop/metric.py
+++ b/tools/scyllatop/metric.py
@@ -39,6 +39,9 @@ class Metric(object):
         for key in list(self._status.keys()):
             self._status[key] = 'not available'
 
+    def add_to_results(self, results):
+        results.append(self)
+
     @classmethod
     def _discover(cls, metric_source, with_help = False):
         results = []
@@ -52,9 +55,10 @@ class Metric(object):
             match = pattern.search(line)
             if match:
                 metric = match.groupdict()['metric']
-                logging.debug('discover list result: {0}'.format(metric))
                 hlp = match.groupdict()['help'] if with_help else ""
-                results.append(Metric(metric, metric_source, hlp))
+                m = Metric(metric, metric_source, hlp)
+                m.add_to_results(results)
+                logging.debug('discover: {}'.format(m))
 
         logging.info('found {} metrics'.format(len(results)))
         return results

--- a/tools/scyllatop/metric.py
+++ b/tools/scyllatop/metric.py
@@ -21,18 +21,21 @@ class Metric(object):
     def status(self):
         return self._status
 
+    def update_info(self, line):
+        match = self._metric_source._METRIC_INFO_PATTERN.search(line)
+        if match is None:
+            raise parseexception.ParseException('could not parse metric pattern from line: {0}'.format(line))
+        key = match.groupdict()['key']
+        value = match.groupdict()['value']
+        self._status[key] = value
+
     def update(self):
         response = self._metric_source.query_val(self._symbol)
         if response is None:
             self.markAbsent()
             return
         for line in response:
-            match = self._metric_source._METRIC_INFO_PATTERN.search(line)
-            if match is None:
-                raise parseexception.ParseException('could not parse metric pattern from line: {0}'.format(line))
-            key = match.groupdict()['key']
-            value = match.groupdict()['value']
-            self._status[key] = value
+            self.update_info(line)
             logging.debug('update {}: {}'.format(self.symbol, line.strip()))
 
     def markAbsent(self):

--- a/tools/scyllatop/metric.py
+++ b/tools/scyllatop/metric.py
@@ -8,6 +8,8 @@ class Metric(object):
         self._metric_source = metric_source
         self._status = {}
         self._help_line = hlp
+        self._expiration = None
+        self._absent = False
 
     @property
     def symbol(self):
@@ -20,6 +22,14 @@ class Metric(object):
     @property
     def status(self):
         return self._status
+
+    @property
+    def is_absent(self):
+        return self._absent
+
+    @property
+    def expiration(self):
+        return self._expiration
 
     def update_info(self, line):
         match = self._metric_source._METRIC_INFO_PATTERN.search(line)
@@ -38,9 +48,11 @@ class Metric(object):
             self.update_info(line)
             logging.debug('update {}: {}'.format(self.symbol, line.strip()))
 
-    def markAbsent(self):
+    def markAbsent(self, expiration=None):
         for key in list(self._status.keys()):
             self._status[key] = 'not available'
+        self._absent = True
+        self._expiration = expiration
 
     def add_to_results(self, results):
         if not isinstance(results, dict):

--- a/tools/scyllatop/metric.py
+++ b/tools/scyllatop/metric.py
@@ -60,6 +60,7 @@ class Metric(object):
                 metric = match.groupdict()['metric']
                 hlp = match.groupdict()['help'] if with_help else ""
                 m = Metric(metric, metric_source, hlp)
+                m.update_info(line)
                 m.add_to_results(results)
                 logging.debug('discover: {}'.format(m))
 

--- a/tools/scyllatop/scyllatop.py
+++ b/tools/scyllatop/scyllatop.py
@@ -110,7 +110,7 @@ if __name__ == '__main__':
         shell()
         quit()
     if arguments.list:
-        pprint.pprint([m.symbol + m.help for m in metric.Metric.discover_with_help(metric_source)])
+        pprint.pprint([m.symbol + m.help for m in metric.Metric.discover_with_help(metric_source).values()])
         quit()
 
     logging.debug('arguments={} isatty={}'.format(arguments, sys.stdout.isatty()))

--- a/tools/scyllatop/scyllatop.py
+++ b/tools/scyllatop/scyllatop.py
@@ -113,6 +113,7 @@ if __name__ == '__main__':
         pprint.pprint([m.symbol + m.help for m in metric.Metric.discover_with_help(metric_source)])
         quit()
 
+    logging.debug('arguments={} isatty={}'.format(arguments, sys.stdout.isatty()))
     try:
         if not sys.stdout.isatty() or arguments.batch:
             dumptostdout.dumpToStdout(arguments.metricPattern, arguments.interval, metric_source, arguments.iterations)

--- a/tools/scyllatop/scyllatop.py
+++ b/tools/scyllatop/scyllatop.py
@@ -26,7 +26,7 @@ def shell():
         logging.error('shell mode requires IPython to be installed')
 
 
-def fancyUserInterface(metricPatterns, interval, metric_source):
+def fancyUserInterface(metricPatterns, interval, metric_source, ttl):
     aggregateView = views.aggregate.Aggregate()
     simpleView = views.simple.Simple()
     userInput = userinput.UserInput()
@@ -34,7 +34,7 @@ def fancyUserInterface(metricPatterns, interval, metric_source):
     userInput.setLoop(loop)
     userInput.setMap(M=aggregateView, S=simpleView)
     try:
-        liveData = livedata.LiveData(metricPatterns, interval, metric_source)
+        liveData = livedata.LiveData(metricPatterns, interval, metric_source, ttl)
     except Exception as inst:
         print("scyllatop failed connecting to Scylla With an error: {error}".format(error=inst))
         sys.exit(1)
@@ -80,6 +80,7 @@ if __name__ == '__main__':
     parser.add_argument('-F', '--fake', action='store_true', help="fake metric updates - this is for developers only")
     parser.add_argument('-n', '--iterations', type=int, default=None, help="Exit after a given number of iterations. This is only relevant if output is redirected")
     parser.add_argument('-b', '--batch', action='store_true', help="batch mode - dump metrics to stdout instead of using an interactive user session")
+    parser.add_argument('-t', '--ttl', type=int, default=60, help="Keep absent metrics for ttl seconds (default=60)")
     arguments = parser.parse_args()
     stream_log = logging.StreamHandler()
     stream_log.setLevel(logging.ERROR)
@@ -116,8 +117,8 @@ if __name__ == '__main__':
     logging.debug('arguments={} isatty={}'.format(arguments, sys.stdout.isatty()))
     try:
         if not sys.stdout.isatty() or arguments.batch:
-            dumptostdout.dumpToStdout(arguments.metricPattern, arguments.interval, metric_source, arguments.iterations)
+            dumptostdout.dumpToStdout(arguments.metricPattern, arguments.interval, metric_source, arguments.iterations, arguments.ttl)
         else:
-            fancyUserInterface(arguments.metricPattern, arguments.interval, metric_source)
+            fancyUserInterface(arguments.metricPattern, arguments.interval, metric_source, arguments.ttl)
     except KeyboardInterrupt:
         pass

--- a/tools/scyllatop/views/stdout.py
+++ b/tools/scyllatop/views/stdout.py
@@ -1,10 +1,12 @@
 from . import base
 from . import helpers
 import sys
+import logging
 
 
 class Stdout(base.Base):
     def update(self, liveData):
+        logging.debug('stdout: {} measurements'.format(len(liveData.measurements)))
         for metric in liveData.measurements:
             print('{} {}'.format(metric.symbol, helpers.formatValues(metric.status)))
         sys.stdout.flush()


### PR DESCRIPTION
Update previous results dictionary using the update_metrics method.
It calls metric_source.query_list to get a list of results (similar to discover()) then for each line in the response it updates results dictionary.

New results may be appeneded depending on the do_append parameter (True by default).
    
Previously, with prometheous, each metric.update called query_list resulting in O(n^2) when all metric were updated, like in the scylla_top dtest - causing test timeout when testing debug build.
(E.g. [dtest-debug/216/testReport/scyllatop_test/TestScyllaTop/default_start_test/](http://jenkins.scylladb.com/view/master/job/scylla-master/job/dtest-debug/216/testReport/scyllatop_test/TestScyllaTop/default_start_test/))