### PR TITLE
docker: relax permission checks

### DIFF
--- a/dist/docker/redhat/etc/supervisord.conf.d/scylla-housekeeping.conf
+++ b/dist/docker/redhat/etc/supervisord.conf.d/scylla-housekeeping.conf
@@ -4,4 +4,3 @@ stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
-user=scylla

--- a/dist/docker/redhat/etc/supervisord.conf.d/scylla-jmx.conf
+++ b/dist/docker/redhat/etc/supervisord.conf.d/scylla-jmx.conf
@@ -4,4 +4,3 @@ stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
-user=scylla

--- a/dist/docker/redhat/etc/supervisord.conf.d/scylla-server.conf
+++ b/dist/docker/redhat/etc/supervisord.conf.d/scylla-server.conf
@@ -4,4 +4,3 @@ stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
-user=scylla


### PR DESCRIPTION
Commit e3f7fe44c04006bfe601713dde97a0bd1436d499 added file owner validation to prevent Scylla from crashing when it tries to touch a file it doesn't own. However, under docker, we cannot expect to pass this check since user IDs are from different namespaces: the process runs in a container namespace, but the data files usually come from a mounted volume, and so their uids are from the host namespace.

So we need to relax the check. We do this by reverting b1226fb15a5a8f0ac4d37733df3c5ba12d84644c, which causes Scylla to run as euid 0 in docker, and by special-casing euid 0 in the ownership verification step.

Fixes #4823.