### PR TITLE
Validate position in partition monotonicity

### DIFF
--- a/db/config.cc
+++ b/db/config.cc
@@ -155,6 +155,12 @@ struct convert<db::config::seed_provider_type> {
 
 }
 
+#if defined(DEBUG)
+#define ENABLE_SSTABLE_KEY_VALIDATION true
+#else
+#define ENABLE_SSTABLE_KEY_VALIDATION false
+#endif
+
 #define str(x)  #x
 #define _mk_init(name, type, deflt, status, desc, ...)  , name(this, str(name), value_status::status, type(deflt), desc)
 
@@ -678,7 +684,7 @@ db::config::config(std::shared_ptr<db::extensions> exts)
     , enable_keyspace_column_family_metrics(this, "enable_keyspace_column_family_metrics", value_status::Used, false, "Enable per keyspace and per column family metrics reporting")
     , enable_sstable_data_integrity_check(this, "enable_sstable_data_integrity_check", value_status::Used, false, "Enable interposer which checks for integrity of every sstable write."
         " Performance is affected to some extent as a result. Useful to help debugging problems that may arise at another layers.")
-    , enable_sstable_key_validation(this, "enable_sstable_key_validation", value_status::Used, false, "Enable validation of partition and clustering keys monotonicity"
+    , enable_sstable_key_validation(this, "enable_sstable_key_validation", value_status::Used, ENABLE_SSTABLE_KEY_VALIDATION, "Enable validation of partition and clustering keys monotonicity"
         " Performance is affected to some extent as a result. Useful to help debugging problems that may arise at another layers.")
     , cpu_scheduler(this, "cpu_scheduler", value_status::Used, true, "Enable cpu scheduling")
     , view_building(this, "view_building", value_status::Used, true, "Enable view building; should only be set to false when the node is experience issues due to view building")

--- a/db/config.cc
+++ b/db/config.cc
@@ -678,6 +678,8 @@ db::config::config(std::shared_ptr<db::extensions> exts)
     , enable_keyspace_column_family_metrics(this, "enable_keyspace_column_family_metrics", value_status::Used, false, "Enable per keyspace and per column family metrics reporting")
     , enable_sstable_data_integrity_check(this, "enable_sstable_data_integrity_check", value_status::Used, false, "Enable interposer which checks for integrity of every sstable write."
         " Performance is affected to some extent as a result. Useful to help debugging problems that may arise at another layers.")
+    , enable_sstable_key_validation(this, "enable_sstable_key_validation", value_status::Used, false, "Enable validation of partition and clustering keys monotonicity"
+        " Performance is affected to some extent as a result. Useful to help debugging problems that may arise at another layers.")
     , cpu_scheduler(this, "cpu_scheduler", value_status::Used, true, "Enable cpu scheduling")
     , view_building(this, "view_building", value_status::Used, true, "Enable view building; should only be set to false when the node is experience issues due to view building")
     , enable_sstables_mc_format(this, "enable_sstables_mc_format", value_status::Used, true, "Enable SSTables 'mc' format to be used as the default file format")

--- a/db/config.hh
+++ b/db/config.hh
@@ -275,6 +275,7 @@ public:
     named_value<bool> enable_deprecated_partitioners;
     named_value<bool> enable_keyspace_column_family_metrics;
     named_value<bool> enable_sstable_data_integrity_check;
+    named_value<bool> enable_sstable_key_validation;
     named_value<bool> cpu_scheduler;
     named_value<bool> view_building;
     named_value<bool> enable_sstables_mc_format;

--- a/flat_mutation_reader.cc
+++ b/flat_mutation_reader.cc
@@ -922,11 +922,15 @@ bool mutation_fragment_stream_validator::operator()(const dht::decorated_key& dk
     return true;
 }
 
-mutation_fragment_stream_validator::mutation_fragment_stream_validator(const schema& s)
+mutation_fragment_stream_validator::mutation_fragment_stream_validator(const schema& s, bool compare_keys)
     : _schema(s)
     , _prev_kind(mutation_fragment::kind::partition_end)
     , _prev_pos(position_in_partition::end_of_partition_tag_t{})
-{ }
+    , _prev_region(partition_region::partition_end)
+    , _compare_keys(compare_keys)
+{
+    fmr_logger.debug("[validator {}] Will validate {} monotonicity.", static_cast<void*>(this), compare_keys ? "keys" : "only partition regions");
+}
 
 mutation_fragment_stream_validator::~mutation_fragment_stream_validator() {
     if (_prev_kind != mutation_fragment::kind::partition_end) {
@@ -937,26 +941,39 @@ mutation_fragment_stream_validator::~mutation_fragment_stream_validator() {
 bool mutation_fragment_stream_validator::operator()(const mutation_fragment& mv) {
     auto kind = mv.mutation_fragment_kind();
     auto pos = mv.position();
+    auto region = pos.region();
     bool valid = false;
 
     fmr_logger.debug("[validator {}] {}:{}", static_cast<void*>(this), kind, pos);
 
     if (mv.is_partition_start()) {
         valid = (_prev_kind == mutation_fragment::kind::partition_end);
-    } else {
+    } else if (_compare_keys) {
         auto less = position_in_partition::less_compare(_schema);
         if (_prev_kind != mutation_fragment::kind::range_tombstone) {
             valid = less(_prev_pos, pos);
         } else {
             valid = !less(pos, _prev_pos);
         }
+    } else if (region != partition_region::clustered) {
+        valid = (_prev_region < region);
+    } else {
+        valid = (_prev_region <= region);
     }
 
     if (__builtin_expect(!valid, false)) {
-        on_internal_error(fmr_logger, format("[validator {}] Unexpected mutation fragment: previous {}:{}, current {}:{}", static_cast<void*>(this), _prev_kind, _prev_pos, kind, pos));
+        auto fmt = "[validator {}] Unexpected mutation fragment: previous {}:{}, current {}:{}";
+        sstring msg = _compare_keys ?
+                format(fmt, static_cast<void*>(this), _prev_kind, _prev_pos, kind, pos) :
+                format(fmt, static_cast<void*>(this), _prev_kind, _prev_region, kind, pos);
+        on_internal_error(fmr_logger, msg);
     }
 
     _prev_kind = mv.mutation_fragment_kind();
-    _prev_pos = pos;
+    if (_compare_keys) {
+        _prev_pos = pos;
+    } else {
+        _prev_region = region;
+    }
     return true;
 }

--- a/flat_mutation_reader.hh
+++ b/flat_mutation_reader.hh
@@ -731,3 +731,16 @@ future<> consume_partitions(flat_mutation_reader& reader, Consumer consumer, db:
 
 flat_mutation_reader
 make_generating_reader(schema_ptr s, std::function<future<mutation_fragment_opt> ()> get_next_fragment);
+
+// Track position_in_partition transitions and validate monotonicity.
+class mutation_fragment_stream_validator {
+    const schema& _schema;
+    mutation_fragment::kind _prev_kind;
+    position_in_partition _prev_pos;
+public:
+    mutation_fragment_stream_validator(const schema& s);
+    ~mutation_fragment_stream_validator();
+
+    bool operator()(const dht::decorated_key& dk);
+    bool operator()(const mutation_fragment& mv);
+};

--- a/flat_mutation_reader.hh
+++ b/flat_mutation_reader.hh
@@ -737,8 +737,10 @@ class mutation_fragment_stream_validator {
     const schema& _schema;
     mutation_fragment::kind _prev_kind;
     position_in_partition _prev_pos;
+    partition_region _prev_region;
+    bool _compare_keys;
 public:
-    mutation_fragment_stream_validator(const schema& s);
+    mutation_fragment_stream_validator(const schema& s, bool compare_keys = false);
     ~mutation_fragment_stream_validator();
 
     bool operator()(const dht::decorated_key& dk);

--- a/mutation_fragment.hh
+++ b/mutation_fragment.hh
@@ -553,6 +553,7 @@ inline position_in_partition_view partition_end::position() const
     return position_in_partition_view(position_in_partition_view::end_of_partition_tag_t());
 }
 
+std::ostream& operator<<(std::ostream&, partition_region);
 std::ostream& operator<<(std::ostream&, mutation_fragment::kind);
 
 using mutation_fragment_opt = optimized_optional<mutation_fragment>;

--- a/position_in_partition.hh
+++ b/position_in_partition.hh
@@ -251,6 +251,17 @@ public:
             }
         }
 
+    position_in_partition& operator=(position_in_partition_view view) {
+        _type = view._type;
+        _bound_weight = view._bound_weight;
+        if (view._ck) {
+            _ck = *view._ck;
+        } else {
+            _ck.reset();
+        }
+        return *this;
+    }
+
     static position_in_partition before_all_clustered_rows() {
         return {position_in_partition::range_tag_t(), bound_view::bottom()};
     }

--- a/sstables/compaction.cc
+++ b/sstables/compaction.cc
@@ -461,7 +461,7 @@ private:
         };
     }
 
-    virtual flat_mutation_reader::filter filter_func() const {
+    virtual flat_mutation_reader::filter make_partition_filter() const {
         return [] (const dht::decorated_key&) {
             return true;
         };
@@ -585,7 +585,7 @@ public:
         };
     }
 
-    virtual flat_mutation_reader::filter filter_func() const override {
+    virtual flat_mutation_reader::filter make_partition_filter() const override {
         return [] (const dht::decorated_key& dk){
             return dht::shard_of(dk.token()) == engine().cpu_id();
         };
@@ -724,7 +724,7 @@ public:
         clogger.info("Cleaned {}", formatted_msg);
     }
 
-    flat_mutation_reader::filter filter_func() const override {
+    flat_mutation_reader::filter make_partition_filter() const override {
         dht::token_range_vector owned_ranges = service::get_local_storage_service().get_local_ranges(_schema->ks_name());
 
         return [this, owned_ranges = std::move(owned_ranges)] (const dht::decorated_key& dk) {
@@ -876,7 +876,7 @@ future<compaction_info> compaction::run(std::unique_ptr<compaction> c) {
             // leave this block either successfully or exceptionally with the reader object
             // destroyed.
             auto r = std::move(reader);
-            r.consume_in_thread(std::move(cfc), c->filter_func(), db::no_timeout);
+            r.consume_in_thread(std::move(cfc), c->make_partition_filter(), db::no_timeout);
         } catch (...) {
             c->delete_sstables_for_interrupted_compaction();
             c = nullptr; // make sure writers are stopped while running in thread context

--- a/sstables/compaction.cc
+++ b/sstables/compaction.cc
@@ -461,7 +461,7 @@ private:
         };
     }
 
-    virtual std::function<bool(const dht::decorated_key&)> filter_func() const {
+    virtual flat_mutation_reader::filter filter_func() const {
         return [] (const dht::decorated_key&) {
             return true;
         };
@@ -585,7 +585,7 @@ public:
         };
     }
 
-    virtual std::function<bool(const dht::decorated_key&)> filter_func() const override {
+    virtual flat_mutation_reader::filter filter_func() const override {
         return [] (const dht::decorated_key& dk){
             return dht::shard_of(dk.token()) == engine().cpu_id();
         };
@@ -724,7 +724,7 @@ public:
         clogger.info("Cleaned {}", formatted_msg);
     }
 
-    std::function<bool(const dht::decorated_key&)> filter_func() const override {
+    flat_mutation_reader::filter filter_func() const override {
         dht::token_range_vector owned_ranges = service::get_local_storage_service().get_local_ranges(_schema->ks_name());
 
         return [this, owned_ranges = std::move(owned_ranges)] (const dht::decorated_key& dk) {

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -2412,7 +2412,7 @@ future<> sstable::write_components(
     }
     return seastar::async([this, mr = std::move(mr), estimated_partitions, schema = std::move(schema), cfg, stats, &pc] () mutable {
         auto wr = get_writer(*schema, estimated_partitions, cfg, stats, pc);
-        auto validator = mutation_fragment_stream_validator(*schema);
+        auto validator = mutation_fragment_stream_validator(*schema, get_config().enable_sstable_key_validation());
         mr.consume_in_thread(std::move(wr), std::move(validator), db::no_timeout);
     });
 }

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -2412,7 +2412,8 @@ future<> sstable::write_components(
     }
     return seastar::async([this, mr = std::move(mr), estimated_partitions, schema = std::move(schema), cfg, stats, &pc] () mutable {
         auto wr = get_writer(*schema, estimated_partitions, cfg, stats, pc);
-        mr.consume_in_thread(std::move(wr), db::no_timeout);
+        auto validator = mutation_fragment_stream_validator(*schema);
+        mr.consume_in_thread(std::move(wr), std::move(validator), db::no_timeout);
     });
 }
 

--- a/tests/flat_mutation_reader_test.cc
+++ b/tests/flat_mutation_reader_test.cc
@@ -619,14 +619,14 @@ void test_flat_stream(schema_ptr s, std::vector<mutation> muts, reversed_partiti
     BOOST_REQUIRE_EQUAL(muts2[0], muts[0]);
 
     if (thread) {
-        auto filter = [&] (const dht::decorated_key& dk) {
+        auto filter = flat_mutation_reader::filter([&] (const dht::decorated_key& dk) {
             for (auto j = size_t(0); j < muts.size(); j += 2) {
                 if (dk.equal(*s, muts[j].decorated_key())) {
                     return false;
                 }
             }
             return true;
-        };
+        });
         BOOST_TEST_MESSAGE("Consume all, filtered");
         fmr = flat_mutation_reader_from_mutations(muts);
         muts2 = fmr.consume_in_thread(flat_stream_consumer(s, reversed), std::move(filter), db::no_timeout);


### PR DESCRIPTION
Introduce `mutation_fragment_stream_validator` class and use it as a Filter to `flat_mutation_reader::consume_in_thread` from `sstable::write_components` to validate partition region and optionally clustering key monotonicity.

Fixes #4803
