### PR TITLE
Decouple cql stats from paging

### DIFF
--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -914,6 +914,7 @@ indexed_table_select_statement::do_execute(service::storage_proxy& proxy,
             return repeat([this, &builder, &options, &internal_options, &proxy, &state, now, whole_partitions, partition_slices, restrictions_need_filtering] () {
                 auto consume_results = [this, &builder, &options, &internal_options, restrictions_need_filtering] (foreign_ptr<lw_shared_ptr<query::result>> results, lw_shared_ptr<query::read_command> cmd) {
                     if (restrictions_need_filtering) {
+                        _stats.filtered_rows_read_total += *results->row_count();
                         query::result_view::consume(*results, cmd->slice, cql3::selection::result_set_builder::visitor(builder, *_schema, *_selection,
                                 cql3::selection::result_set_builder::restrictions_filter(_restrictions, options, cmd->row_limit, _schema, cmd->slice.partition_row_limit())));
                     } else {

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -335,7 +335,7 @@ select_statement::do_execute(service::storage_proxy& proxy,
     command->slice.options.set<query::partition_slice::option::allow_short_read>();
     auto timeout_duration = options.get_timeout_config().*get_timeout_config_selector();
     auto p = service::pager::query_pagers::pager(_schema, _selection,
-            state, options, command, std::move(key_ranges), _stats, restrictions_need_filtering ? _restrictions : nullptr);
+            state, options, command, std::move(key_ranges), restrictions_need_filtering ? _restrictions : nullptr);
 
     if (aggregate || nonpaged_filtering) {
         return do_with(
@@ -347,9 +347,10 @@ select_statement::do_execute(service::storage_proxy& proxy,
                                 auto timeout = db::timeout_clock::now() + timeout_duration;
                                 return p->fetch_page(builder, page_size, now, timeout);
                             }
-                    ).then([this, &builder, restrictions_need_filtering] {
+                    ).then([this, p, &builder, restrictions_need_filtering] {
                                 auto rs = builder.build();
                                 if (restrictions_need_filtering) {
+                                    _stats.filtered_rows_read_total += p->stats().rows_read_total;
                                     _stats.filtered_rows_matched_total += rs->size();
                                 }
                                 update_stats_rows_read(rs->size());
@@ -392,6 +393,7 @@ select_statement::do_execute(service::storage_proxy& proxy,
                 }
 
                 if (restrictions_need_filtering) {
+                    _stats.filtered_rows_read_total += p->stats().rows_read_total;
                     _stats.filtered_rows_matched_total += rs->size();
                 }
                 update_stats_rows_read(rs->size());
@@ -1100,7 +1102,7 @@ indexed_table_select_statement::read_posting_list(service::storage_proxy& proxy,
     }
 
     auto p = service::pager::query_pagers::pager(_view_schema, selection,
-            state, options, cmd, std::move(partition_ranges), _stats, nullptr);
+            state, options, cmd, std::move(partition_ranges), nullptr);
     return p->fetch_page(options.get_page_size(), now, timeout).then([p, &options, limit, now] (std::unique_ptr<cql3::result_set> rs) {
         rs->get_metadata().set_paging_state(p->state());
         return ::make_shared<cql_transport::messages::result_message::rows>(result(std::move(rs)));

--- a/service/pager/query_pager.hh
+++ b/service/pager/query_pager.hh
@@ -70,6 +70,12 @@ namespace pager {
  * is done even though it is.
  */
 class query_pager {
+public:
+    struct stats {
+        // Total number of rows read by this pager, based on all pages it fetched
+        size_t rows_read_total = 0;
+    };
+
 protected:
     // remember if we use clustering. if not, each partition == one row
     const bool _has_clustering_keys;
@@ -89,6 +95,7 @@ protected:
     paging_state::replicas_per_token_range _last_replicas;
     std::optional<db::read_repair_decision> _query_read_repair_decision;
     uint32_t _rows_fetched_for_last_partition = 0;
+    stats _stats;
 public:
     query_pager(schema_ptr s, shared_ptr<const cql3::selection::selection> selection,
                 service::query_state& state,
@@ -140,6 +147,10 @@ public:
      * to a paging_state instance which will return 0 on calling get_remaining() on it.
      */
     ::shared_ptr<const paging_state> state() const;
+
+    const stats& stats() const {
+        return _stats;
+    }
 
 protected:
     template<typename Base>

--- a/service/pager/query_pagers.cc
+++ b/service/pager/query_pagers.cc
@@ -224,18 +224,15 @@ future<cql3::result_generator> query_pager::fetch_page_generator(uint32_t page_s
 
 class filtering_query_pager : public query_pager {
     ::shared_ptr<cql3::restrictions::statement_restrictions> _filtering_restrictions;
-    cql3::cql_stats& _stats;
 public:
     filtering_query_pager(schema_ptr s, shared_ptr<const cql3::selection::selection> selection,
                 service::query_state& state,
                 const cql3::query_options& options,
                 lw_shared_ptr<query::read_command> cmd,
                 dht::partition_range_vector ranges,
-                ::shared_ptr<cql3::restrictions::statement_restrictions> filtering_restrictions,
-                cql3::cql_stats& stats)
+                ::shared_ptr<cql3::restrictions::statement_restrictions> filtering_restrictions)
         : query_pager(s, selection, state, options, std::move(cmd), std::move(ranges))
         , _filtering_restrictions(std::move(filtering_restrictions))
-        , _stats(stats)
         {}
     virtual ~filtering_query_pager() {}
 
@@ -244,12 +241,13 @@ public:
             _last_replicas = std::move(qr.last_replicas);
             _query_read_repair_decision = qr.read_repair_decision;
             qr.query_result->ensure_counts();
-            _stats.filtered_rows_read_total += *qr.query_result->row_count();
+            _stats.rows_read_total += *qr.query_result->row_count();
             handle_result(cql3::selection::result_set_builder::visitor(builder, *_schema, *_selection,
                           cql3::selection::result_set_builder::restrictions_filter(_filtering_restrictions, _options, _max, _schema, _per_partition_limit, _last_pkey, _rows_fetched_for_last_partition)),
                           std::move(qr.query_result), page_size, now);
         });
     }
+
 protected:
     virtual uint32_t max_rows_to_fetch(uint32_t page_size) override {
         return page_size;
@@ -406,7 +404,6 @@ bool service::pager::query_pagers::may_need_paging(const schema& s, uint32_t pag
         service::query_state& state, const cql3::query_options& options,
         lw_shared_ptr<query::read_command> cmd,
         dht::partition_range_vector ranges,
-        cql3::cql_stats& stats,
         ::shared_ptr<cql3::restrictions::statement_restrictions> filtering_restrictions) {
     // If partition row limit is applied to paging, we still need to fall back
     // to filtering the results to avoid extraneous rows on page breaks.
@@ -415,7 +412,7 @@ bool service::pager::query_pagers::may_need_paging(const schema& s, uint32_t pag
     }
     if (filtering_restrictions) {
         return ::make_shared<filtering_query_pager>(std::move(s), std::move(selection), state,
-                    options, std::move(cmd), std::move(ranges), std::move(filtering_restrictions), stats);
+                    options, std::move(cmd), std::move(ranges), std::move(filtering_restrictions));
     }
     return ::make_shared<query_pager>(std::move(s), std::move(selection), state,
             options, std::move(cmd), std::move(ranges));

--- a/service/pager/query_pagers.hh
+++ b/service/pager/query_pagers.hh
@@ -66,7 +66,6 @@ public:
             const cql3::query_options&,
             lw_shared_ptr<query::read_command>,
             dht::partition_range_vector,
-            cql3::cql_stats& stats,
             ::shared_ptr<cql3::restrictions::statement_restrictions> filtering_restrictions = nullptr);
 };
 


### PR DESCRIPTION
Pager belongs to a different layer than CQL and thus should not be
coupled with CQL stats - if any different frontends want to use paging,
they shouldn't be forced to instantiate CQL stats at all.

Same goes with CQL restrictions, but that will require much bigger
refactoring, so is left for later.

Also, one bump for filtering metrics was missing, so it's hereby added.

@nyh @avikivity