### PR TITLE
relocatable: switch from run-time relocation to install-time relocation

### DIFF
--- a/dist/debian/rules.mustache
+++ b/dist/debian/rules.mustache
@@ -34,7 +34,9 @@ override_dh_installinit:
 	dh_installinit --no-start --name node-exporter
 
 override_dh_strip:
-	dh_strip -Xlibprotobuf.so.15 -Xld.so --dbg-package={{product}}-server-dbg
+	# The binaries (ethtool...patchelf) don't pass dh_strip after going through patchelf. Since they are
+	# already stripped, nothing is lost if we exclude them, so that's what we do.
+	dh_strip -Xlibprotobuf.so.15 -Xld.so -Xethtool -Xgawk -Xgzip -Xhwloc-calc -Xhwloc-distrib -Xifconfig -Xlscpu -Xnetstat -Xpatchelf --dbg-package={{product}}-server-dbg
 
 override_dh_makeshlibs:
 

--- a/install.sh
+++ b/install.sh
@@ -89,6 +89,29 @@ if [ -n "$pkg" ] && [ "$pkg" != "server" -a "$pkg" != "conf" -a "$pkg" != "kerne
     exit 1
 fi
 
+patchelf() {
+    # patchelf comes from the build system, so it needs the build system's ld.so and
+    # shared libraries. We can't use patchelf on patchelf itself, so invoke it via
+    # ld.so.
+    LD_LIBRARY_PATH="$PWD/libreloc" libreloc/ld.so libexec/patchelf "$@"
+}
+
+adjust_bin() {
+    local bin="$1"
+    # We could add --set-rpath too, but then debugedit (called by rpmbuild) barfs
+    # on the result. So use LD_LIBRARY_PATH in the thunk, below.
+    patchelf \
+	--set-interpreter "$prefix/libreloc/ld.so" \
+	"$root/$prefix/libexec/$bin"
+    cat > "$root/$prefix/bin/$bin" <<EOF
+#!/bin/bash -e
+export GNUTLS_SYSTEM_PRIORITY_FILE="\${GNUTLS_SYSTEM_PRIORITY_FILE-$prefix/libreloc/gnutls.config}"
+export LD_LIBRARY_PATH="$prefix/libreloc"
+exec -a "\$0" "$prefix/libexec/$bin" "\$@"
+EOF
+    chmod +x "$root/$prefix/bin/$bin"
+}
+
 rprefix="$root/$prefix"
 retc="$root/etc"
 rusr="$root/usr"
@@ -145,16 +168,13 @@ if [ -z "$pkg" ] || [ "$pkg" = "server" ]; then
     install -m644 dist/common/systemd/*.timer -Dt "$rusr"/lib/systemd/system
     install -m755 seastar/scripts/seastar-cpu-map.sh -Dt "$rprefix"/scripts
     install -m755 seastar/dpdk/usertools/dpdk-devbind.py -Dt "$rprefix"/scripts
-    install -m755 bin/* -Dt "$rprefix/bin"
+    install -m755 libreloc/* -Dt "$rprefix/libreloc"
     # some files in libexec are symlinks, which "install" dereferences
     # use cp -P for the symlinks instead.
-    install -m755 libexec/*.bin -Dt "$rprefix/libexec"
-    for f in libexec/*; do
-        if [[ "$f" != *.bin ]]; then
-            cp -P "$f" "$rprefix/libexec"
-        fi
+    install -m755 libexec/* -Dt "$rprefix/libexec"
+    for bin in libexec/*; do
+	adjust_bin "${bin#libexec/}"
     done
-    install -m755 libreloc/* -Dt "$rprefix/libreloc"
     ln -srf "$rprefix/bin/scylla" "$rusr/bin/scylla"
     ln -srf "$rprefix/bin/iotune" "$rusr/bin/iotune"
 


### PR DESCRIPTION
Our current relocation works by invoking the dynamic linker with the
executable as an argument. This confuses gdb since the kernel records
the dynamic linker as the executable, not the real executable.

Switch to install-time relocation with patchelf: when installing the
executable and libraries, all paths are known, and we can update the
path to the dynamic loader and to the dynamic libraries.

Since patchelf itself is dynamically linked, we have to relocate it
dynamically (with the old method of invoking it via the dynamic linker).
This is okay since it's a one-time operation and since we don't expect
to debug core dumps of patchelf crashes.

We lose the ability to run scylla directly from the uninstalled
tarball, but since the nonroot installer is already moving in the
direction of requiring install.sh, that is not a great loss, and
certainly the ability to debug is more important.

dh_strip barfs on some binaries which were treated with patchelf,
so exclude them from dh_strip. This doesn't lose any functionality,
since these binaries didn't have debug information to begin with
(they are already-stripped Fedora executables).

Fixes #4673.