### PR TITLE
Repair based node operation

### DIFF
--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -1689,3 +1689,7 @@ future<> do_decommission_removenode_with_repair(seastar::sharded<database>& db, 
         rlogger.info("{}: finished with keyspaces={}, leaving_node={}", op, keyspaces, leaving_node);
     });
 }
+
+future<> decommission_with_repair(seastar::sharded<database>& db, locator::token_metadata tm) {
+    return do_decommission_removenode_with_repair(db, std::move(tm), utils::fb_utilities::get_broadcast_address());
+}

--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -1744,3 +1744,8 @@ future<> do_rebuild_replace_with_repair(seastar::sharded<database>& db, locator:
         rlogger.info("{}: finished with keyspaces={}, source_dc={}", op, keyspaces, source_dc);
     });
 }
+
+future<> rebuild_with_repair(seastar::sharded<database>& db, locator::token_metadata tm, sstring source_dc) {
+    auto op = sstring("rebuild_with_repair");
+    return do_rebuild_replace_with_repair(db, std::move(tm), std::move(op), std::move(source_dc));
+}

--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -1693,3 +1693,7 @@ future<> do_decommission_removenode_with_repair(seastar::sharded<database>& db, 
 future<> decommission_with_repair(seastar::sharded<database>& db, locator::token_metadata tm) {
     return do_decommission_removenode_with_repair(db, std::move(tm), utils::fb_utilities::get_broadcast_address());
 }
+
+future<> removenode_with_repair(seastar::sharded<database>& db, locator::token_metadata tm, gms::inet_address leaving_node) {
+    return do_decommission_removenode_with_repair(db, std::move(tm), std::move(leaving_node));
+}

--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -1749,3 +1749,9 @@ future<> rebuild_with_repair(seastar::sharded<database>& db, locator::token_meta
     auto op = sstring("rebuild_with_repair");
     return do_rebuild_replace_with_repair(db, std::move(tm), std::move(op), std::move(source_dc));
 }
+
+future<> replace_with_repair(seastar::sharded<database>& db, locator::token_metadata tm) {
+    auto op = sstring("replace_with_repair");
+    auto source_dc = sstring("");
+    return do_rebuild_replace_with_repair(db, std::move(tm), std::move(op), std::move(source_dc));
+}

--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -1697,3 +1697,50 @@ future<> decommission_with_repair(seastar::sharded<database>& db, locator::token
 future<> removenode_with_repair(seastar::sharded<database>& db, locator::token_metadata tm, gms::inet_address leaving_node) {
     return do_decommission_removenode_with_repair(db, std::move(tm), std::move(leaving_node));
 }
+
+future<> do_rebuild_replace_with_repair(seastar::sharded<database>& db, locator::token_metadata tm, sstring op, sstring source_dc) {
+    return seastar::async([&db, tm = std::move(tm), source_dc = std::move(source_dc), op = std::move(op)] () mutable {
+        auto keyspaces = db.local().get_non_system_keyspaces();
+        rlogger.info("{}: started with keyspaces={}, source_dc={}", op, keyspaces, source_dc);
+        auto myip = utils::fb_utilities::get_broadcast_address();
+        for (auto& keyspace_name : keyspaces) {
+            if (!db.local().has_keyspace(keyspace_name)) {
+                rlogger.info("{}: keyspace={} does not exist any more, ignoring it", op, keyspace_name);
+                continue;
+            }
+            auto& ks = db.local().find_keyspace(keyspace_name);
+            auto& strat = ks.get_replication_strategy();
+            dht::token_range_vector ranges = strat.get_ranges(myip);
+            std::unordered_map<dht::token_range, repair_neighbors> range_sources;
+            rlogger.info("{}: started with keyspace={}, source_dc={}, nr_ranges={}", op, keyspace_name, source_dc, ranges.size());
+            for (auto it = ranges.begin(); it != ranges.end();) {
+                auto& r = *it;
+                if (need_preempt()) {
+                    seastar::thread::yield();
+                }
+                auto end_token = r.end() ? r.end()->value() : dht::maximum_token();
+                auto& snitch_ptr = locator::i_endpoint_snitch::get_local_snitch_ptr();
+                auto neighbors = boost::copy_range<std::vector<gms::inet_address>>(strat.calculate_natural_endpoints(end_token, tm) |
+                    boost::adaptors::filtered([myip, &source_dc, &snitch_ptr] (const gms::inet_address& node) {
+                        if (node == myip) {
+                            return false;
+                        }
+                        return source_dc.empty() ? true : snitch_ptr->get_datacenter(node) == source_dc;
+                    })
+                );
+                rlogger.debug("{}: keyspace={}, range={}, neighbors={}", op, keyspace_name, r, neighbors);
+                if (!neighbors.empty()) {
+                    range_sources[r] = repair_neighbors(std::move(neighbors));
+                    it++;
+                } else {
+                    // Skip the range with zero neighbors
+                    it = ranges.erase(it);
+                }
+            }
+            auto nr_ranges = ranges.size();
+            sync_data_with_repair(db, keyspace_name, std::move(ranges), std::move(range_sources)).get();
+            rlogger.info("{}: finished with keyspace={}, source_dc={}, nr_ranges={}", op, keyspace_name, source_dc, nr_ranges);
+        }
+        rlogger.info("{}: finished with keyspaces={}, source_dc={}", op, keyspaces, source_dc);
+    });
+}

--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -944,9 +944,22 @@ static future<> repair_cf_range(repair_info& ri,
 // Comparable to RepairSession in Origin
 static future<> repair_range(repair_info& ri, const dht::token_range& range) {
     auto id = utils::UUID_gen::get_time_UUID();
-    return do_with(get_neighbors(ri.db.local(), ri.keyspace, range, ri.data_centers, ri.hosts), [&ri, range, id] (std::vector<gms::inet_address>& neighbors) {
+    auto neighbors = ri.neighbors.empty() ? get_neighbors(ri.db.local(), ri.keyspace, range, ri.data_centers, ri.hosts) : ri.neighbors[range];
+    return do_with(std::move(neighbors.all), std::move(neighbors.mandatory), [&ri, range, id] (auto& neighbors, auto& mandatory_neighbors) {
       auto live_neighbors = boost::copy_range<std::vector<gms::inet_address>>(neighbors |
                     boost::adaptors::filtered([] (const gms::inet_address& node) { return gms::get_local_gossiper().is_alive(node); }));
+      for (auto& node : mandatory_neighbors) {
+           auto it = std::find(live_neighbors.begin(), live_neighbors.end(), node);
+           if (it == live_neighbors.end()) {
+                ri.nr_failed_ranges++;
+                auto status = format("failed: mandatory neighbor={} is not alive", node);
+                rlogger.error("Repair {} out of {} ranges, id={}, shard={}, keyspace={}, table={}, range={}, peers={}, live_peers={}, status={}",
+                    ri.ranges_index, ri.ranges.size(), ri.id, ri.shard, ri.keyspace, ri.cfs, range, neighbors, live_neighbors, status);
+                ri.abort();
+                return make_exception_future<>(std::runtime_error(format("Repair mandatory neighbor={} is not alive, keyspace={}, mandatory_neighbors={}",
+                    node, ri.keyspace, mandatory_neighbors)));
+           }
+      }
       if (live_neighbors.size() != neighbors.size()) {
             ri.nr_failed_ranges++;
             auto status = live_neighbors.empty() ? "skipped" : "partial";
@@ -1464,5 +1477,52 @@ future<> repair_shutdown(seastar::sharded<database>& db) {
 future<> repair_abort_all(seastar::sharded<database>& db) {
     return db.invoke_on_all([] (database& localdb) {
         repair_tracker().abort_all_repairs();
+    });
+}
+
+future<> sync_data_with_repair(seastar::sharded<database>& db,
+        sstring keyspace,
+        dht::token_range_vector ranges,
+        std::unordered_map<dht::token_range, repair_neighbors> neighbors) {
+    if (ranges.empty()) {
+        return make_ready_future<>();
+    }
+    return smp::submit_to(0, [&db, keyspace = std::move(keyspace), ranges = std::move(ranges), neighbors = std::move(neighbors)] () mutable {
+        int id = repair_tracker().next_repair_command();
+        rlogger.info("repair id {} to sync data for keyspace={}, status=started", id, keyspace);
+        repair_tracker().start(id);
+        auto fail = defer([id] { repair_tracker().done(id, false); });
+        auto cfs = list_column_families(db.local(), keyspace);
+        std::vector<future<>> repair_results;
+        repair_results.reserve(smp::count);
+        for (auto shard : boost::irange(unsigned(0), smp::count)) {
+            auto f = db.invoke_on(shard, [keyspace, cfs, id, ranges,
+                    data_centers = std::vector<sstring>(), hosts = std::vector<sstring>(), neighbors] (database& localdb) mutable {
+                auto ri = make_lw_shared<repair_info>(service::get_local_storage_service().db(),
+                        std::move(keyspace), std::move(ranges), std::move(cfs),
+                        id, std::move(data_centers), std::move(hosts));
+                ri->neighbors = std::move(neighbors);
+                return repair_ranges(ri);
+            });
+            repair_results.push_back(std::move(f));
+        }
+        return when_all(repair_results.begin(), repair_results.end()).then([id, keyspace, fail = std::move(fail)] (std::vector<future<>> results) mutable {
+            bool success = true;
+            if (std::any_of(results.begin(), results.end(), [] (auto&& f) { return f.failed(); })) {
+                success = false;
+                rlogger.info("repair id {} to sync data for keyspace={}, status=failed", id, keyspace);
+            } else {
+                fail.cancel();
+                repair_tracker().done(id, true);
+                rlogger.info("repair id {} to sync data for keyspace={}, status=succeeded", id, keyspace);
+            }
+            for (auto& f : results) {
+                f.ignore_ready_future();
+            }
+            if (success) {
+                return make_ready_future<>();
+            }
+            return make_exception_future<>(std::runtime_error(format("Failed to sync data with repair id {}, keyspace={}", id, keyspace)));
+        });
     });
 }

--- a/repair/repair.hh
+++ b/repair/repair.hh
@@ -149,6 +149,20 @@ public:
     sstring get_stats();
 };
 
+class repair_neighbors {
+public:
+    std::vector<gms::inet_address> all;
+    std::vector<gms::inet_address> mandatory;
+    repair_neighbors() = default;
+    repair_neighbors(std::vector<gms::inet_address> a)
+        : all(std::move(a)) {
+    }
+    repair_neighbors(std::vector<gms::inet_address> a, std::vector<gms::inet_address> m)
+        : all(std::move(a))
+        , mandatory(std::move(m)) {
+    }
+};
+
 class repair_info {
 public:
     seastar::sharded<database>& db;
@@ -159,6 +173,7 @@ public:
     shard_id shard;
     std::vector<sstring> data_centers;
     std::vector<sstring> hosts;
+    std::unordered_map<dht::token_range, repair_neighbors> neighbors;
     size_t nr_failed_ranges = 0;
     bool aborted = false;
     // Map of peer -> <cf, ranges>

--- a/repair/repair.hh
+++ b/repair/repair.hh
@@ -49,6 +49,7 @@ public:
 future<> bootstrap_with_repair(seastar::sharded<database>& db, locator::token_metadata tm, std::unordered_set<dht::token> tokens);
 future<> decommission_with_repair(seastar::sharded<database>& db, locator::token_metadata tm);
 future<> removenode_with_repair(seastar::sharded<database>& db, locator::token_metadata tm, gms::inet_address leaving_node);
+future<> rebuild_with_repair(seastar::sharded<database>& db, locator::token_metadata tm, sstring source_dc);
 
 // NOTE: repair_start() can be run on any node, but starts a node-global
 // operation.

--- a/repair/repair.hh
+++ b/repair/repair.hh
@@ -46,6 +46,8 @@ public:
     repair_stopped_exception() : repair_exception("Repair stopped") { }
 };
 
+future<> bootstrap_with_repair(seastar::sharded<database>& db, locator::token_metadata tm, std::unordered_set<dht::token> tokens);
+
 // NOTE: repair_start() can be run on any node, but starts a node-global
 // operation.
 // repair_start() starts the requested repair on this node. It returns an

--- a/repair/repair.hh
+++ b/repair/repair.hh
@@ -47,6 +47,7 @@ public:
 };
 
 future<> bootstrap_with_repair(seastar::sharded<database>& db, locator::token_metadata tm, std::unordered_set<dht::token> tokens);
+future<> decommission_with_repair(seastar::sharded<database>& db, locator::token_metadata tm);
 
 // NOTE: repair_start() can be run on any node, but starts a node-global
 // operation.

--- a/repair/repair.hh
+++ b/repair/repair.hh
@@ -50,6 +50,7 @@ future<> bootstrap_with_repair(seastar::sharded<database>& db, locator::token_me
 future<> decommission_with_repair(seastar::sharded<database>& db, locator::token_metadata tm);
 future<> removenode_with_repair(seastar::sharded<database>& db, locator::token_metadata tm, gms::inet_address leaving_node);
 future<> rebuild_with_repair(seastar::sharded<database>& db, locator::token_metadata tm, sstring source_dc);
+future<> replace_with_repair(seastar::sharded<database>& db, locator::token_metadata tm);
 
 // NOTE: repair_start() can be run on any node, but starts a node-global
 // operation.

--- a/repair/repair.hh
+++ b/repair/repair.hh
@@ -48,6 +48,7 @@ public:
 
 future<> bootstrap_with_repair(seastar::sharded<database>& db, locator::token_metadata tm, std::unordered_set<dht::token> tokens);
 future<> decommission_with_repair(seastar::sharded<database>& db, locator::token_metadata tm);
+future<> removenode_with_repair(seastar::sharded<database>& db, locator::token_metadata tm, gms::inet_address leaving_node);
 
 // NOTE: repair_start() can be run on any node, but starts a node-global
 // operation.


### PR DESCRIPTION
storage_service: Switch to repair based node operation

Here is a simple introduction to the node operations scylla supports and
some of the issues.

- Replace operation

   It is used to replace a dead node. The token ring does not change. It
   pulls data from only one of the replicas which might not be the
   latest copy.

- Rebuild operation

   It is used to get all the data this node owns form other nodes. It
   pulls data from only one of the replicas which might not be the
   latest copy.

- Bootstrap operation

   It is used to add a new node into the cluster. The token ring
   changes. Do no suffer from the "not the latest replica” issue. New
   node pulls data from existing nodes that are losing the token range.

   Suffer from failed streaming. We split the ranges in 10 groups and we
   stream one group at a time. Restream the group if failed, causing
   unnecessary data transmission on wire.

   Bootstrap is not resumable. Failure after 99.99% of data is streamed.
   If we restart the node again, we need to stream all the data again
   even if the node already has 99.99% of the data.

- Decommission operation

   It is used to remove a live node form the cluster. Token ring
   changes.  Do not suffer “not the latest replica” issue. The leaving
   node pushes data to existing nodes.

   It suffers from resumable issue like bootstrap operation.

- Removenode operation

   It is used to remove a dead node out of the cluster. Existing nodes
   pulls data from other existing nodes for the new ranges it own. It
   pulls from one of the replicas which might not be the latest copy.

To solve all the issues above. We could use repair based node operation.
The idea behind repair based node operations is simple: use repair to
sync data between replicas instead of streaming.

The benefits:

   - Latest copy is guaranteed

   - Resumable in nature

   - No extra data is streamed on wire
     E.g., rebuild twice, will not stream the same data twice

   - Unified code path for all the node operations

   - Free repair operation during bootstrap, replace operation and so on.

Fixes: #3003
Fixes: #4208
Tests: update_cluster_layout_tests.py + replace_address_test.py + manual test
