### PR TITLE
Add python tests using tox

### DIFF
--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -61,6 +61,7 @@ fedora_packages=(
     python3-magic
     python3-psutil
     python3-cassandra-driver
+    python3-tox
     dnf-utils
     pigz
     net-tools

--- a/tox.ini
+++ b/tox.ini
@@ -1,20 +1,27 @@
 [tox]
-usedevelop=True
-skipdist=True
+skip_missing_interpreters = True
 
 [testenv]
 deps =
+    black
     pytest
     pytest-flake8
-
 commands =
+    black --diff --check .
     pytest --flake8 -k 'not tests'
 
-[flake8]
-max-line-length = 120
-exclude = .ropeproject,.tox,tests
-show-source = False
-
 [pytest]
+# see .flake8 file in the black project:
+# https://github.com/ambv/black/blob/master/.flake8
 flake8-ignore =
-    E501
+    C901
+    E
+    W503
+flake8-select = F
+filterwarnings =
+    # For Python 2 flake8
+    ignore:.*You passed a bytestring as `filenames`:DeprecationWarning:flake8.options.config
+    # For Python 3.7 flake8
+    ignore:Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated:DeprecationWarning:
+flake8-max-complexity = 18
+flake8-max-line-length = 88


### PR DESCRIPTION
These commits allows us to test our python code base using tox and (finally) leverage our tox.ini configuration to integrate this automated testing in the test suite.

- adds `python3-tox` installation dependency
- modifies `tox.ini` to test for the black python code style + flake8
- adds a non-default `python` test mode to the `tests.py` for automation

These commits are meant to be as readable as possible and not to break the current tests while allowing us to acknowledge all the code style and modifications to be done on the python code base.

If this is accepted, this will be used as the source of other proposals to fix all the python code base.