### PR TITLE
storage_proxy: fix iterator liveness issue in on_down

### DIFF
--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -3685,11 +3685,13 @@ void storage_proxy::on_up(const gms::inet_address& endpoint) {};
 
 void storage_proxy::on_down(const gms::inet_address& endpoint) {
     assert(thread::running_in_thread());
-    for (auto it = _view_update_handlers_list->begin(); it != _view_update_handlers_list->end(); ++it) {
+    auto it = _view_update_handlers_list->begin();
+    while (it != _view_update_handlers_list->end()) {
         auto guard = it->shared_from_this();
         if (it->get_targets().count(endpoint) > 0) {
             it->timeout_cb();
         }
+        ++it;
         seastar::thread::yield();
     }
 };


### PR DESCRIPTION
The loop over view update handlers used a guard in order to ensure
that the object is not prematurely destroyed (thus invalidating
the iterator), but the guard itself was not in the right scope.
Fixed by replacinga 'for' loop with a 'while' loop, which moves
the iterator incrementation inside the scope in which it's still
guarded and valid.

Fixes #4866

Tests: unit(dev)