### PR TITLE
API:column_family.cc Add get_build_index implmentation

### DIFF
--- a/api/column_family.cc
+++ b/api/column_family.cc
@@ -26,7 +26,6 @@
 #include "sstables/sstables.hh"
 #include "utils/estimated_histogram.hh"
 #include <algorithm>
-
 #include "db/system_keyspace_view_types.hh"
 #include "db/data_listeners.hh"
 
@@ -255,12 +254,11 @@ class sum_ratio {
     uint64_t _n = 0;
     T _total = 0;
 public:
-    future<> operator()(T value) {
+    void operator()(T value) {
         if (value > 0) {
             _total += value;
             _n++;
         }
-        return make_ready_future<>();
     }
     // Returns average value of all registered ratios.
     T get() && {


### PR DESCRIPTION
This Patch adds an implementation of the get build index API and remove a
FIXME.

The API returns a list of secondary indexes belongs to a column family.

Example:

CREATE KEYSPACE scylla_demo WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '1'};

CREATE TABLE scylla_demo.mytableID (     uid uuid,     text text,     time timeuuid,     PRIMARY KEY (uid, time) );
CREATE index on scylla_demo.mytableID (time);

$ curl -X GET 'http://localhost:10000/column_family/built_indexes/scylla_demo%3Amytableid'
["mytableid_time_idx"]

Signed-off-by: Amnon Heiman <amnon@scylladb.com>