### PR TITLE
use labels to represent protocol-level statistics

### DIFF
--- a/thrift/server.cc
+++ b/thrift/server.cc
@@ -302,18 +302,21 @@ thrift_server::requests_served() const {
     return _requests_served;
 }
 
+static const metrics::label class_label("protocol");
+
 thrift_stats::thrift_stats(thrift_server& server) {
     namespace sm = seastar::metrics;
+    auto proto_label_instance = class_label("thrift");
 
-    _metrics.add_group("thrift", {
-        sm::make_derive("thrift-connections", [&server] { return server.total_connections(); },
-                        sm::description("Rate of creation of new Thrift connections.")),
+    _metrics.add_group("transport", {
+        sm::make_derive("connections", [&server] { return server.total_connections(); },
+                        sm::description("Rate of creation of new Thrift connections."), {proto_label_instance}),
 
         sm::make_gauge("current_connections", [&server] { return server.current_connections(); },
-                        sm::description("Holds a current number of opened Thrift connections.")),
+                        sm::description("Holds a current number of opened Thrift connections."), {proto_label_instance}),
 
-        sm::make_derive("served", [&server] { return server.requests_served(); },
-                        sm::description("Rate of serving Thrift requests.")),
+        sm::make_derive("requests_served", [&server] { return server.requests_served(); },
+                        sm::description("Rate of serving Thrift requests."), {proto_label_instance}),
     });
 }
 


### PR DESCRIPTION
We currently support the thrift and CQL protocols, and I see activity in
the mailing list being done in order to add Redis. Not that we plan to
add any other, but 3 already justifies some level of commonality. The
metrics for the thrift and CQL protocols predate our usage of prometheus
labels, so they use names like "thrift_served" and
"transport_requests_served", and same for connections and others.

This makes it harder to answer questions like "what is the total
throughput of my cluster across all protocols?", since we have to sum up
all possible protocols, and that's exactly what labels are for.

Not all concepts translates well from one protocol to another, but most
do, and to the extent that they do this change will make it easier for
our monitoring stack to display good metrics as new protocols are added.

Signed-off-by: Glauber Costa <glauber@scylladb.com>