### PR TITLE
Optimize type find

### DIFF
--- a/types.hh
+++ b/types.hh
@@ -815,7 +815,7 @@ class reversed_type_impl : public abstract_type {
         , _underlying_type(t)
     {}
 public:
-    shared_ptr<const abstract_type> underlying_type() const {
+    const data_type& underlying_type() const {
         return _underlying_type;
     }
 

--- a/types/collection.hh
+++ b/types/collection.hh
@@ -104,7 +104,7 @@ protected:
     data_type _elements;
     explicit listlike_collection_type_impl(kind k, sstring name, data_type elements,bool is_multi_cell);
 public:
-    data_type get_elements_type() const { return _elements; }
+    const data_type& get_elements_type() const { return _elements; }
 };
 
 template <typename BytesViewIterator>

--- a/types/map.hh
+++ b/types/map.hh
@@ -45,8 +45,8 @@ class map_type_impl final : public concrete_type<std::vector<std::pair<data_valu
 public:
     static shared_ptr<const map_type_impl> get_instance(data_type keys, data_type values, bool is_multi_cell);
     map_type_impl(data_type keys, data_type values, bool is_multi_cell);
-    data_type get_keys_type() const { return _keys; }
-    data_type get_values_type() const { return _values; }
+    const data_type& get_keys_type() const { return _keys; }
+    const data_type& get_values_type() const { return _values; }
     virtual data_type name_comparator() const override { return _keys; }
     virtual data_type value_comparator() const override { return _values; }
     virtual data_type freeze() const override;


### PR DESCRIPTION
This avoids a double dispatch on _kind and also removes a few shared_ptr copies.

The extra work was a small regression from the recent types refactoring.
