### PR TITLE
remove date type

### DIFF
--- a/concrete_types.hh
+++ b/concrete_types.hh
@@ -118,13 +118,6 @@ struct bytes_type_impl final : public concrete_type<bytes> {
     bytes_type_impl();
 };
 
-// This is the old version of timestamp_type_impl, but has been replaced as it
-// wasn't comparing pre-epoch timestamps correctly. This is kept for backward
-// compatibility but shouldn't be used in new code.
-struct date_type_impl final : public concrete_type<db_clock::time_point> {
-    date_type_impl();
-};
-
 struct timeuuid_type_impl final : public concrete_type<utils::UUID> {
     timeuuid_type_impl();
 };
@@ -150,7 +143,6 @@ template <typename Func> concept bool CanHandleAllTypes = requires(Func f) {
     { f(*static_cast<const byte_type_impl*>(nullptr)) }        -> visit_ret_type<Func>;
     { f(*static_cast<const bytes_type_impl*>(nullptr)) }       -> visit_ret_type<Func>;
     { f(*static_cast<const counter_type_impl*>(nullptr)) }     -> visit_ret_type<Func>;
-    { f(*static_cast<const date_type_impl*>(nullptr)) }        -> visit_ret_type<Func>;
     { f(*static_cast<const decimal_type_impl*>(nullptr)) }     -> visit_ret_type<Func>;
     { f(*static_cast<const double_type_impl*>(nullptr)) }      -> visit_ret_type<Func>;
     { f(*static_cast<const duration_type_impl*>(nullptr)) }    -> visit_ret_type<Func>;
@@ -190,8 +182,6 @@ static inline visit_ret_type<Func> visit(const abstract_type& t, Func&& f) {
         return f(*static_cast<const bytes_type_impl*>(&t));
     case abstract_type::kind::counter:
         return f(*static_cast<const counter_type_impl*>(&t));
-    case abstract_type::kind::date:
-        return f(*static_cast<const date_type_impl*>(&t));
     case abstract_type::kind::decimal:
         return f(*static_cast<const decimal_type_impl*>(&t));
     case abstract_type::kind::double_kind:

--- a/cql3/functions/aggregate_fcts.hh
+++ b/cql3/functions/aggregate_fcts.hh
@@ -238,11 +238,6 @@ struct aggregate_type_for<simple_date_native_type> {
 };
 
 template<>
-struct aggregate_type_for<timestamp_native_type> {
-    using type = timestamp_native_type::primary_type;
-};
-
-template<>
 struct aggregate_type_for<timeuuid_native_type> {
     using type = timeuuid_native_type::primary_type;
 };

--- a/cql3/functions/functions.cc
+++ b/cql3/functions/functions.cc
@@ -115,9 +115,9 @@ functions::init() {
     declare(aggregate_fcts::make_max_function<simple_date_native_type>());
     declare(aggregate_fcts::make_min_function<simple_date_native_type>());
 
-    declare(aggregate_fcts::make_count_function<timestamp_native_type>());
-    declare(aggregate_fcts::make_max_function<timestamp_native_type>());
-    declare(aggregate_fcts::make_min_function<timestamp_native_type>());
+    declare(aggregate_fcts::make_count_function<db_clock::time_point>());
+    declare(aggregate_fcts::make_max_function<db_clock::time_point>());
+    declare(aggregate_fcts::make_min_function<db_clock::time_point>());
 
     declare(aggregate_fcts::make_count_function<timeuuid_native_type>());
     declare(aggregate_fcts::make_max_function<timeuuid_native_type>());

--- a/cql3/functions/time_uuid_fcts.hh
+++ b/cql3/functions/time_uuid_fcts.hh
@@ -133,7 +133,7 @@ inline shared_ptr<function>
 make_currenttimestamp_fct() {
     return make_native_scalar_function<true>("currenttimestamp", timestamp_type, {},
             [] (cql_serialization_format sf, const std::vector<bytes_opt>& values) -> bytes_opt {
-        return {timestamp_type->decompose(timestamp_native_type{db_clock::now()})};
+        return {timestamp_type->decompose(db_clock::now())};
     });
 }
 
@@ -153,7 +153,7 @@ make_currentdate_fct() {
     return make_native_scalar_function<true>("currentdate", simple_date_type, {},
             [] (cql_serialization_format sf, const std::vector<bytes_opt>& values) -> bytes_opt {
         auto to_simple_date = get_castas_fctn(simple_date_type, timestamp_type);
-        return {simple_date_type->decompose(to_simple_date(timestamp_native_type{db_clock::now()}))};
+        return {simple_date_type->decompose(to_simple_date(db_clock::now()))};
     });
 }
 

--- a/tests/random_schema.cc
+++ b/tests/random_schema.cc
@@ -434,8 +434,8 @@ data_value generate_timeuuid_value(std::mt19937&, size_t) {
 }
 
 data_value generate_timestamp_value(std::mt19937& engine, size_t) {
-    using pt = timestamp_native_type::primary_type;
-    return data_value(timestamp_native_type{pt(pt::duration(random::get_int<pt::rep>(engine)))});
+    using pt = db_clock::time_point;
+    return data_value(pt(pt::duration(random::get_int<pt::rep>(engine))));
 }
 
 data_value generate_simple_date_value(std::mt19937& engine, size_t) {

--- a/tests/random_schema.cc
+++ b/tests/random_schema.cc
@@ -51,7 +51,6 @@ type_generator::type_generator(random_schema_specification& spec) : _spec(spec) 
         simple_type_generator{bytes_type},
         simple_type_generator{utf8_type},
         simple_type_generator{boolean_type},
-        simple_type_generator{date_type},
         simple_type_generator{timeuuid_type},
         simple_type_generator{timestamp_type},
         simple_type_generator{simple_date_type},
@@ -425,10 +424,6 @@ data_value generate_boolean_value(std::mt19937& engine, size_t) {
     return data_value(bool(dist(engine)));
 }
 
-data_value generate_date_value(std::mt19937& engine, size_t) {
-    return data_value(db_clock::time_point(db_clock::duration(random::get_int<std::make_unsigned_t<db_clock::rep>>(engine))));
-}
-
 data_value generate_timeuuid_value(std::mt19937&, size_t) {
     return data_value(timeuuid_native_type{utils::UUID_gen::get_time_UUID()});
 }
@@ -539,7 +534,6 @@ value_generator::value_generator()
             {bytes_type.get(), &generate_bytes_value},
             {utf8_type.get(), &generate_utf8_value},
             {boolean_type.get(), &generate_boolean_value},
-            {date_type.get(), &generate_date_value},
             {timeuuid_type.get(), &generate_timeuuid_value},
             {timestamp_type.get(), &generate_timestamp_value},
             {simple_date_type.get(), &generate_simple_date_value},

--- a/tests/types_test.cc
+++ b/tests/types_test.cc
@@ -304,10 +304,6 @@ BOOST_AUTO_TEST_CASE(test_timestamp_string_conversions) {
     test_timestamp_like_string_conversions(timestamp_type);
 }
 
-BOOST_AUTO_TEST_CASE(test_date_string_conversions) {
-    test_timestamp_like_string_conversions(date_type);
-}
-
 BOOST_AUTO_TEST_CASE(test_boolean_type_string_conversions) {
     BOOST_REQUIRE(boolean_type->equal(boolean_type->from_string(""), boolean_type->decompose(false)));
     BOOST_REQUIRE(boolean_type->equal(boolean_type->from_string("false"), boolean_type->decompose(false)));
@@ -893,8 +889,6 @@ SEASTAR_TEST_CASE(test_simple_type_compatibility) {
         { nc, utf8_type, bytes_type },
         { nc, ascii_type, bytes_type },
         { nc, ascii_type, utf8_type },
-        { cc, timestamp_type, date_type },
-        { cc, date_type, timestamp_type },
     };
     for (auto&& tc : tests) {
         tc.verify(tc.to, tc.from);

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -1526,11 +1526,6 @@ public:
     static void encode(cql_server::response& r, data_type type) {
         type = type->underlying_type();
 
-        // For compatibility sake, we still return DateType as the timestamp type in resultSet metadata (#5723)
-        if (type == date_type) {
-            type = timestamp_type;
-        }
-
         auto i = type_id_to_type.right.find(type);
         if (i != type_id_to_type.right.end()) {
             r.write_short(static_cast<std::underlying_type<type_id>::type>(i->second));

--- a/types.cc
+++ b/types.cc
@@ -3465,16 +3465,13 @@ data_value::data_value(seastar::net::ipv6_address v) : data_value(seastar::net::
 data_value::data_value(simple_date_native_type v) : data_value(make_new(simple_date_type, v.days)) {
 }
 
-data_value::data_value(timestamp_native_type v) : data_value(make_new(timestamp_type, v.tp)) {
-}
-
 data_value::data_value(time_native_type v) : data_value(make_new(time_type, v.nanoseconds)) {
 }
 
 data_value::data_value(timeuuid_native_type v) : data_value(make_new(timeuuid_type, v.uuid)) {
 }
 
-data_value::data_value(db_clock::time_point v) : data_value(make_new(date_type, v)) {
+data_value::data_value(db_clock::time_point v) : data_value(make_new(timestamp_type, v)) {
 }
 
 data_value::data_value(boost::multiprecision::cpp_int v) : data_value(make_new(varint_type, v)) {

--- a/types.hh
+++ b/types.hh
@@ -436,7 +436,6 @@ public:
         byte,
         bytes,
         counter,
-        date,
         decimal,
         double_kind,
         duration,
@@ -877,7 +876,6 @@ extern thread_local const shared_ptr<const abstract_type> ascii_type;
 extern thread_local const shared_ptr<const abstract_type> bytes_type;
 extern thread_local const shared_ptr<const abstract_type> utf8_type;
 extern thread_local const shared_ptr<const abstract_type> boolean_type;
-extern thread_local const shared_ptr<const abstract_type> date_type;
 extern thread_local const shared_ptr<const abstract_type> timeuuid_type;
 extern thread_local const shared_ptr<const abstract_type> timestamp_type;
 extern thread_local const shared_ptr<const abstract_type> simple_date_type;

--- a/types.hh
+++ b/types.hh
@@ -327,11 +327,6 @@ struct simple_date_native_type {
     primary_type days;
 };
 
-struct timestamp_native_type {
-    using primary_type = db_clock::time_point;
-    primary_type tp;
-};
-
 struct time_native_type {
     using primary_type = int64_t;
     primary_type nanoseconds;
@@ -381,7 +376,6 @@ public:
     data_value(net::ipv6_address);
     data_value(seastar::net::inet_address);
     data_value(simple_date_native_type);
-    data_value(timestamp_native_type);
     data_value(time_native_type);
     data_value(timeuuid_native_type);
     data_value(db_clock::time_point);
@@ -943,19 +937,13 @@ shared_ptr<const abstract_type> data_type_for<utils::UUID>() {
 template <>
 inline
 shared_ptr<const abstract_type> data_type_for<db_clock::time_point>() {
-    return date_type;
+    return timestamp_type;
 }
 
 template <>
 inline
 shared_ptr<const abstract_type> data_type_for<simple_date_native_type>() {
     return simple_date_type;
-}
-
-template <>
-inline
-shared_ptr<const abstract_type> data_type_for<timestamp_native_type>() {
-    return timestamp_type;
 }
 
 template <>


### PR DESCRIPTION
This is split in two patches so that it is easy to drop the last one if it turns out we need to keep date_type.