### PR TITLE
do not keep the scylla metadata in memory

### DIFF
--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -1275,6 +1275,19 @@ future<> sstable::open_data() {
         if (_shards.empty()) {
             _shards = compute_shards_for_this_sstable();
         }
+        auto* sm = _components->scylla_metadata->data.get<scylla_metadata_type::Sharding, sharding_metadata>();
+        if (!sm) {
+            return make_ready_future<>();
+        }
+        auto c = &sm->token_ranges.elements;
+        // Sharding information uses a lot of memory and once we're doing with this computation we will no longer use it.
+        return do_until([c] { return c->empty(); }, [c] {
+            c->pop_back();
+            return make_ready_future<>();
+        }).then([this, c] () mutable {
+            c = {};
+            return make_ready_future<>();
+        });
     });
 }
 


### PR DESCRIPTION
There is no reason to keep the Scylla Metadata component in memory
after it is read, parsed, and its information fed into the SSTable.

We have seen systems in which the Scylla metadata component is one
of the heaviest memory users, more than the Summary and Filter.

The run identifier is trivially small, so are the feature bits. The
shard information is stored post-parsed once we call
compute_shards_for_this_sstable().

This patch proposes to just get rid of the metadata component copy
in memory altogether once all of that information is already read.

Tests: unit (release), + manual scylla write load + reshard.

Signed-off-by: Glauber Costa <glauber@scylladb.com>