### PR TITLE
Let compaction wait on background deletions

### DIFF
--- a/table.cc
+++ b/table.cc
@@ -1158,6 +1158,7 @@ table::rebuild_sstable_list(const std::vector<sstables::shared_sstable>& new_sst
     _sstables = make_lw_shared(std::move(new_sstable_list));
 }
 
+// Note: must run in a seastar thread
 void
 table::on_compaction_completion(const std::vector<sstables::shared_sstable>& new_sstables,
                                     const std::vector<sstables::shared_sstable>& sstables_to_remove) {
@@ -1199,16 +1200,19 @@ table::on_compaction_completion(const std::vector<sstables::shared_sstable>& new
 
     rebuild_statistics();
 
-    // This is done in the background, so we can consider this compaction completed.
-    (void)seastar::with_gate(_sstable_deletion_gate, [this, sstables_to_remove] {
-       return with_semaphore(_sstable_deletion_sem, 1, [this, sstables_to_remove = std::move(sstables_to_remove)] {
-        return sstables::delete_atomically(sstables_to_remove).then_wrapped([this, sstables_to_remove] (future<> f) {
-            std::exception_ptr eptr;
-            try {
-                f.get();
-            } catch(...) {
-                eptr = std::current_exception();
-            }
+    auto f = seastar::with_gate(_sstable_deletion_gate, [this, sstables_to_remove] {
+       return with_semaphore(_sstable_deletion_sem, 1, [sstables_to_remove = std::move(sstables_to_remove)] {
+           return sstables::delete_atomically(std::move(sstables_to_remove));
+       });
+    });
+
+    try {
+        f.get();
+    } catch (...) {
+        // There is nothing more we can do here.
+        // Any remaining SSTables will eventually be re-compacted and re-deleted.
+        tlogger.error("Compacted SSTables deletion failed: {}. Ignored.", std::current_exception());
+    }
 
             // unconditionally remove compacted sstables from _sstables_compacted_but_not_deleted,
             // or they could stay forever in the set, resulting in deleted files remaining
@@ -1220,14 +1224,6 @@ table::on_compaction_completion(const std::vector<sstables::shared_sstable>& new
             });
             _sstables_compacted_but_not_deleted.erase(e, _sstables_compacted_but_not_deleted.end());
             rebuild_statistics();
-
-            if (eptr) {
-                return make_exception_future<>(eptr);
-            }
-            return make_ready_future<>();
-         });
-        });
-    });
 }
 
 // For replace/remove_ancestors_needed_write, note that we need to update the compaction backlog

--- a/table.cc
+++ b/table.cc
@@ -1214,16 +1214,16 @@ table::on_compaction_completion(const std::vector<sstables::shared_sstable>& new
         tlogger.error("Compacted SSTables deletion failed: {}. Ignored.", std::current_exception());
     }
 
-            // unconditionally remove compacted sstables from _sstables_compacted_but_not_deleted,
-            // or they could stay forever in the set, resulting in deleted files remaining
-            // opened and disk space not being released until shutdown.
-            std::unordered_set<sstables::shared_sstable> s(
-                   sstables_to_remove.begin(), sstables_to_remove.end());
-            auto e = boost::range::remove_if(_sstables_compacted_but_not_deleted, [&] (sstables::shared_sstable sst) -> bool {
-                return s.count(sst);
-            });
-            _sstables_compacted_but_not_deleted.erase(e, _sstables_compacted_but_not_deleted.end());
-            rebuild_statistics();
+    // unconditionally remove compacted sstables from _sstables_compacted_but_not_deleted,
+    // or they could stay forever in the set, resulting in deleted files remaining
+    // opened and disk space not being released until shutdown.
+    std::unordered_set<sstables::shared_sstable> s(
+           sstables_to_remove.begin(), sstables_to_remove.end());
+    auto e = boost::range::remove_if(_sstables_compacted_but_not_deleted, [&] (sstables::shared_sstable sst) -> bool {
+        return s.count(sst);
+    });
+    _sstables_compacted_but_not_deleted.erase(e, _sstables_compacted_but_not_deleted.end());
+    rebuild_statistics();
 }
 
 // For replace/remove_ancestors_needed_write, note that we need to update the compaction backlog


### PR DESCRIPTION
In several cases in distributed testing (dtest) we trigger compaction using nodetool compact assuming that when it is done, it is indeed really done.
However, the way compaction is currently implemented in scylla, it may leave behind some background tasks to delete the old sstables that were compacted.

This commit changes major compaction (triggered via the ss::force_keyspace_compaction api) so it would wait on the background deletes and will return only when they finish.
    
Fixes #4909

Tests: unit(dev), nodetool_refresh_with_data_perms_test, test_nodetool_snapshot_during_major_compaction