### PR TITLE
Improve cpu instruction set support checks

### DIFF
--- a/dist/common/scripts/scylla_prepare
+++ b/dist/common/scripts/scylla_prepare
@@ -25,7 +25,19 @@ import sys
 import glob
 from scylla_util import *
 
+def verify_cpu():
+    if platform.machine() == 'x86_64':
+        needed_flags = set(['sse4_2', 'pclmulqdq'])
+        for line in open('/proc/cpuinfo'):
+            if line.startswith('flags'):
+                flags = set(line.split()[2:])
+                if not needed_flags <= flags:
+                    print('Scylla requires the sse4.2 and clmul instruction sets, check your processor and hypervisor')
+                    sys.exit(1)
+
 if __name__ == '__main__':
+    verify_cpu()
+
     if os.getuid() > 0:
         print('Requires root permission.')
         sys.exit(1)

--- a/main.cc
+++ b/main.cc
@@ -299,8 +299,8 @@ verify_rlimit(bool developer_mode) {
 
 static bool cpu_sanity() {
 #if defined(__x86_64__) || defined(__i386__)
-    if (!__builtin_cpu_supports("sse4.2")) {
-        std::cerr << "Scylla requires a processor with SSE 4.2 support\n";
+    if (!__builtin_cpu_supports("sse4.2") || !__builtin_cpu_supports("pclmul")) {
+        std::cerr << "Scylla requires a processor with SSE 4.2 and PCLMUL support\n";
         return false;
     }
 #endif


### PR DESCRIPTION
To prevent termination with SIGILL, tighten the instruction set support checks. First, check for CLMUL too. Second, add a check in `scylla_prepare` to catch the problem early.

Fixes #4921.