### PR TITLE
main: make sure stopping view builder service with defer() doesn't throw

### DIFF
--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -1164,6 +1164,10 @@ future<> view_builder::stop() {
         return _sem.wait().then([this] {
             _sem.broken();
             return _build_step.join();
+        }).handle_exception_type([] (const broken_semaphore&) {
+            // ignored
+        }).handle_exception_type([] (const semaphore_timed_out&) {
+            // ignored
         });
     });
 }


### PR DESCRIPTION
Stopping view builder occurs in a destructor of deferred_action,
and as such should not throw, or it will end the program with
terminate(). Instead, the exception will be logged.

Fixes #4875

@bhalevy it's a likely cause for 4875, as view_builder stopping involves breaking a semaphore, and breaking a semaphore creates an exceptional future, which will throw on calling `.get()` on it.
@denesb kudos for pointing out the root cause