### PR TITLE
storage_proxy: protect _view_update_handlers_list iterators from invalidation

### DIFF
--- a/service/storage_proxy.hh
+++ b/service/storage_proxy.hh
@@ -80,6 +80,7 @@ namespace service {
 class abstract_write_response_handler;
 class abstract_read_executor;
 class mutation_holder;
+class view_update_write_response_handler;
 
 using replicas_per_token_range = std::unordered_map<dht::token_range, std::vector<utils::UUID>>;
 
@@ -474,6 +475,7 @@ public:
     friend class abstract_write_response_handler;
     friend class speculating_read_executor;
     friend class view_update_backlog_broker;
+    friend class view_update_write_response_handler;
 };
 
 extern distributed<storage_proxy> _the_storage_proxy;


### PR DESCRIPTION
on_down() iterates over _view_update_handlers_list, but it yields during iteration,
and while it yields, elements in that list can be removed, resulting in a
use-after-free.

Prevent this by registering iterators that can be potentially invalidated, and
any time we remove an element from the list, check whether we're removing an element
that is being pointed to by a live iterator. If that is the case, advance the iterator
so that it points at a valid element (or at the end of the list).

Fixes #4912.

Tests: unit (dev)