### PR TITLE
install.sh: be consistent about $root/$prefix

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -101,13 +101,13 @@ adjust_bin() {
     # We could add --set-rpath too, but then debugedit (called by rpmbuild) barfs
     # on the result. So use LD_LIBRARY_PATH in the thunk, below.
     patchelf \
-	--set-interpreter "$prefix/libreloc/ld.so" \
+	--set-interpreter "$root/$prefix/libreloc/ld.so" \
 	"$root/$prefix/libexec/$bin"
     cat > "$root/$prefix/bin/$bin" <<EOF
 #!/bin/bash -e
-export GNUTLS_SYSTEM_PRIORITY_FILE="\${GNUTLS_SYSTEM_PRIORITY_FILE:-$prefix/libreloc/gnutls.config}"
-export LD_LIBRARY_PATH="$prefix/libreloc"
-exec -a "\$0" "$prefix/libexec/$bin" "\$@"
+export GNUTLS_SYSTEM_PRIORITY_FILE="\${GNUTLS_SYSTEM_PRIORITY_FILE:-$root/$prefix/libreloc/gnutls.config}"
+export LD_LIBRARY_PATH="$root/$prefix/libreloc"
+exec -a "\$0" "$root/$prefix/libexec/$bin" "\$@"
 EOF
     chmod +x "$root/$prefix/bin/$bin"
 }

--- a/install.sh
+++ b/install.sh
@@ -28,7 +28,7 @@ Usage: install.sh [options]
 
 Options:
   --root /path/to/root     alternative install root (default /)
-  --prefix /prefix         directory prefix (default /usr)
+  --prefix /prefix         directory prefix (default /opt/scylladb)
   --python3 /opt/python3   path of the python3 interpreter relative to install root (default /opt/scylladb/python3/bin/python3)
   --housekeeping           enable housekeeping service
   --target centos          specify target distribution

--- a/install.sh
+++ b/install.sh
@@ -105,7 +105,7 @@ adjust_bin() {
 	"$root/$prefix/libexec/$bin"
     cat > "$root/$prefix/bin/$bin" <<EOF
 #!/bin/bash -e
-export GNUTLS_SYSTEM_PRIORITY_FILE="\${GNUTLS_SYSTEM_PRIORITY_FILE-$prefix/libreloc/gnutls.config}"
+export GNUTLS_SYSTEM_PRIORITY_FILE="\${GNUTLS_SYSTEM_PRIORITY_FILE:-$prefix/libreloc/gnutls.config}"
 export LD_LIBRARY_PATH="$prefix/libreloc"
 exec -a "\$0" "$prefix/libexec/$bin" "\$@"
 EOF


### PR DESCRIPTION
Fix #4949

- install.sh: adjust_bin: be consistent about $root/$prefix
- install.sh: fix default substitution for GNUTLS_SYSTEM_PRIORITY_FILE
- install.sh: fix default prefix in usage message

Test:
```
$ ./tools/toolchain/dbuild ./reloc/build_reloc.sh --mode dev
$ mkdir /tmp/scylla-package
$ cd /tmp/scylla-package
$ tar xzf ~/dev/scylla/build/dev/scylla-package.tar.gz
$ ./install.sh --root /tmp/install --prefix node1 --target centos --disttype redhat
$ /tmp/install/node1/bin/scylla --help
```

Also, manually validated `/tmp/install/node1/libreloc/gnutls.config`