### PR TITLE
transport: make sure returning connection errors happens inside the gate

### DIFF
--- a/transport/server.cc
+++ b/transport/server.cc
@@ -493,22 +493,22 @@ cql_server::connection::~connection() {
 
 future<> cql_server::connection::process()
 {
-    return do_until([this] {
-        return _read_buf.eof();
-    }, [this] {
-        return with_gate(_pending_requests_gate, [this] {
+    return with_gate(_pending_requests_gate, [this] {
+        return do_until([this] {
+            return _read_buf.eof();
+        }, [this] {
             return process_request();
+        }).then_wrapped([this] (future<> f) {
+            try {
+                f.get();
+            } catch (const exceptions::cassandra_exception& ex) {
+                write_response(make_error(0, ex.code(), ex.what(), tracing::trace_state_ptr()));
+            } catch (std::exception& ex) {
+                write_response(make_error(0, exceptions::exception_code::SERVER_ERROR, ex.what(), tracing::trace_state_ptr()));
+            } catch (...) {
+                write_response(make_error(0, exceptions::exception_code::SERVER_ERROR, "unknown error", tracing::trace_state_ptr()));
+            }
         });
-    }).then_wrapped([this] (future<> f) {
-        try {
-            f.get();
-        } catch (const exceptions::cassandra_exception& ex) {
-            write_response(make_error(0, ex.code(), ex.what(), tracing::trace_state_ptr()));
-        } catch (std::exception& ex) {
-            write_response(make_error(0, exceptions::exception_code::SERVER_ERROR, ex.what(), tracing::trace_state_ptr()));
-        } catch (...) {
-            write_response(make_error(0, exceptions::exception_code::SERVER_ERROR, "unknown error", tracing::trace_state_ptr()));
-        }
     }).finally([this] {
         return _pending_requests_gate.close().then([this] {
             _server._notifier->unregister_connection(this);


### PR DESCRIPTION
Previously, the gate could get closed too early, which would result in shutting down the server
before it had an opportunity to respond to the client.

The only thing this patch does is to move `with_gate` one level up - instead of wrapping processing requests only, it also wraps the part that sends errors to clients.

Refs #4818 , this patch was originally a part of this pull request, but it was written in an incorrect manner and changed the order of continuations by mistake by putting error handling inside the `do_until`.