### PR TITLE
types: Fix decimal to integer and varint to integer conversion

### DIFF
--- a/tests/castas_fcts_test.cc
+++ b/tests/castas_fcts_test.cc
@@ -113,6 +113,35 @@ SEASTAR_TEST_CASE(test_unsupported_conversions) {
     });
 }
 
+SEASTAR_TEST_CASE(test_decimal_to_bigint) {
+    return do_with_cql_env_thread([&](auto& e) {
+        e.execute_cql("CREATE TABLE test (key text primary key, value decimal)").get();
+        e.execute_cql("INSERT INTO test (key, value) VALUES ('k1', 9223372036854775807)").get();
+        e.execute_cql("INSERT INTO test (key, value) VALUES ('k2', 9223372036854775808)").get();
+        e.execute_cql("INSERT INTO test (key, value) VALUES ('k3', 18446744073709551615)").get();
+        e.execute_cql("INSERT INTO test (key, value) VALUES ('k4', 18446744073709551616)").get();
+        e.execute_cql("INSERT INTO test (key, value) VALUES ('k5', 18446744073709551617)").get();
+        e.execute_cql("INSERT INTO test (key, value) VALUES ('k6', 18446744073709551617.1)").get();
+        e.execute_cql("INSERT INTO test (key, value) VALUES ('k7', 18446744073709551617.9)").get();
+        e.execute_cql("INSERT INTO test (key, value) VALUES ('k8', -1)").get();
+        e.execute_cql("INSERT INTO test (key, value) VALUES ('k9', -9223372036854775808)").get();
+        e.execute_cql("INSERT INTO test (key, value) VALUES ('k10', -9223372036854775809)").get();
+        auto v = e.execute_cql("SELECT key,CAST(value as bigint) from test").get0();
+        assert_that(v).is_rows().with_rows_ignore_order({
+            {{utf8_type->decompose("k1")}, {long_type->decompose(std::numeric_limits<int64_t>::max())}},
+            {{utf8_type->decompose("k2")}, {long_type->decompose(std::numeric_limits<int64_t>::min())}},
+            {{utf8_type->decompose("k3")}, {long_type->decompose(int64_t(-1))}},
+            {{utf8_type->decompose("k4")}, {long_type->decompose(int64_t(0))}},
+            {{utf8_type->decompose("k5")}, {long_type->decompose(int64_t(1))}},
+            {{utf8_type->decompose("k6")}, {long_type->decompose(int64_t(1))}},
+            {{utf8_type->decompose("k7")}, {long_type->decompose(int64_t(1))}},
+            {{utf8_type->decompose("k8")}, {long_type->decompose(int64_t(-1))}},
+            {{utf8_type->decompose("k9")}, {long_type->decompose(std::numeric_limits<int64_t>::min())}},
+            {{utf8_type->decompose("k10")}, {long_type->decompose(std::numeric_limits<int64_t>::max())}},
+        });
+    });
+}
+
 SEASTAR_TEST_CASE(test_numeric_casts_in_selection_clause) {
     return do_with_cql_env_thread([&] (auto& e) {
         e.execute_cql("CREATE TABLE test (a tinyint primary key,"

--- a/types.cc
+++ b/types.cc
@@ -3544,12 +3544,11 @@ std::function<data_value(data_value)> make_castas_fctn_from_decimal_to_float() {
     };
 }
 
-template<typename ToType>
-std::function<data_value(data_value)> make_castas_fctn_from_decimal_to_integer() {
+std::function<data_value(data_value)> make_castas_fctn_from_decimal_to_varint() {
     return [](data_value from) -> data_value {
         auto val_from = value_cast<big_decimal>(from);
         boost::multiprecision::cpp_int ten(10);
-        return static_cast<ToType>(val_from.unscaled_value() / boost::multiprecision::pow(ten, val_from.scale()));
+        return static_cast<boost::multiprecision::cpp_int>(val_from.unscaled_value() / boost::multiprecision::pow(ten, val_from.scale()));
     };
 }
 
@@ -3747,7 +3746,7 @@ thread_local castas_fctns_map castas_fctns {
     { {varint_type, float_type}, make_castas_fctn_simple<boost::multiprecision::cpp_int, float>() },
     { {varint_type, double_type}, make_castas_fctn_simple<boost::multiprecision::cpp_int, double>() },
     { {varint_type, varint_type}, make_castas_fctn_simple<boost::multiprecision::cpp_int, boost::multiprecision::cpp_int>() },
-    { {varint_type, decimal_type}, make_castas_fctn_from_decimal_to_integer<boost::multiprecision::cpp_int>() },
+    { {varint_type, decimal_type}, make_castas_fctn_from_decimal_to_varint() },
 
     { {decimal_type, byte_type}, make_castas_fctn_from_integer_to_decimal<int8_t>() },
     { {decimal_type, short_type}, make_castas_fctn_from_integer_to_decimal<int16_t>() },

--- a/types.cc
+++ b/types.cc
@@ -3550,6 +3550,16 @@ static boost::multiprecision::cpp_int from_decimal_to_cppint(const data_value& f
     return val_from.unscaled_value() / boost::multiprecision::pow(ten, val_from.scale());
 }
 
+template<typename ToType>
+std::function<data_value(data_value)> make_castas_fctn_from_decimal_to_integer() {
+    return [](data_value from) -> data_value {
+        auto varint = from_decimal_to_cppint(from);
+        bool negative = varint < 0;
+        uint64_t v = negative ? static_cast<uint64_t>(-varint) : static_cast<uint64_t>(varint);
+        return static_cast<ToType>(negative ? -v : v);
+    };
+}
+
 std::function<data_value(data_value)> make_castas_fctn_from_decimal_to_varint() {
     return [](data_value from) -> data_value {
         return from_decimal_to_cppint(from);
@@ -3696,7 +3706,7 @@ thread_local castas_fctns_map castas_fctns {
     { {byte_type, float_type}, make_castas_fctn_simple<int8_t, float>() },
     { {byte_type, double_type}, make_castas_fctn_simple<int8_t, double>() },
     { {byte_type, varint_type}, make_castas_fctn_simple<int8_t, boost::multiprecision::cpp_int>() },
-    { {byte_type, decimal_type}, make_castas_fctn_from_decimal_to_float<int8_t>() },
+    { {byte_type, decimal_type}, make_castas_fctn_from_decimal_to_integer<int8_t>() },
 
     { {short_type, byte_type}, make_castas_fctn_simple<int16_t, int8_t>() },
     { {short_type, short_type}, make_castas_fctn_simple<int16_t, int16_t>() },
@@ -3705,7 +3715,7 @@ thread_local castas_fctns_map castas_fctns {
     { {short_type, float_type}, make_castas_fctn_simple<int16_t, float>() },
     { {short_type, double_type}, make_castas_fctn_simple<int16_t, double>() },
     { {short_type, varint_type}, make_castas_fctn_simple<int16_t, boost::multiprecision::cpp_int>() },
-    { {short_type, decimal_type}, make_castas_fctn_from_decimal_to_float<int16_t>() },
+    { {short_type, decimal_type}, make_castas_fctn_from_decimal_to_integer<int16_t>() },
 
     { {int32_type, byte_type}, make_castas_fctn_simple<int32_t, int8_t>() },
     { {int32_type, short_type}, make_castas_fctn_simple<int32_t, int16_t>() },
@@ -3714,7 +3724,7 @@ thread_local castas_fctns_map castas_fctns {
     { {int32_type, float_type}, make_castas_fctn_simple<int32_t, float>() },
     { {int32_type, double_type}, make_castas_fctn_simple<int32_t, double>() },
     { {int32_type, varint_type}, make_castas_fctn_simple<int32_t, boost::multiprecision::cpp_int>() },
-    { {int32_type, decimal_type}, make_castas_fctn_from_decimal_to_float<int32_t>() },
+    { {int32_type, decimal_type}, make_castas_fctn_from_decimal_to_integer<int32_t>() },
 
     { {long_type, byte_type}, make_castas_fctn_simple<int64_t, int8_t>() },
     { {long_type, short_type}, make_castas_fctn_simple<int64_t, int16_t>() },
@@ -3723,7 +3733,7 @@ thread_local castas_fctns_map castas_fctns {
     { {long_type, float_type}, make_castas_fctn_simple<int64_t, float>() },
     { {long_type, double_type}, make_castas_fctn_simple<int64_t, double>() },
     { {long_type, varint_type}, make_castas_fctn_simple<int64_t, boost::multiprecision::cpp_int>() },
-    { {long_type, decimal_type}, make_castas_fctn_from_decimal_to_float<int64_t>() },
+    { {long_type, decimal_type}, make_castas_fctn_from_decimal_to_integer<int64_t>() },
 
     { {float_type, byte_type}, make_castas_fctn_simple<float, int8_t>() },
     { {float_type, short_type}, make_castas_fctn_simple<float, int16_t>() },

--- a/types.cc
+++ b/types.cc
@@ -3550,13 +3550,18 @@ static boost::multiprecision::cpp_int from_decimal_to_cppint(const data_value& f
     return val_from.unscaled_value() / boost::multiprecision::pow(ten, val_from.scale());
 }
 
+template <typename ToType>
+static ToType from_varint_to_integer(const boost::multiprecision::cpp_int& varint) {
+    bool negative = varint < 0;
+    uint64_t v = negative ? static_cast<uint64_t>(-varint) : static_cast<uint64_t>(varint);
+    return static_cast<ToType>(negative ? -v : v);
+}
+
 template<typename ToType>
 std::function<data_value(data_value)> make_castas_fctn_from_decimal_to_integer() {
     return [](data_value from) -> data_value {
         auto varint = from_decimal_to_cppint(from);
-        bool negative = varint < 0;
-        uint64_t v = negative ? static_cast<uint64_t>(-varint) : static_cast<uint64_t>(varint);
-        return static_cast<ToType>(negative ? -v : v);
+        return from_varint_to_integer<ToType>(varint);
     };
 }
 

--- a/types.cc
+++ b/types.cc
@@ -3544,11 +3544,15 @@ std::function<data_value(data_value)> make_castas_fctn_from_decimal_to_float() {
     };
 }
 
+static boost::multiprecision::cpp_int from_decimal_to_cppint(const data_value& from) {
+    const auto& val_from = value_cast<big_decimal>(from);
+    boost::multiprecision::cpp_int ten(10);
+    return val_from.unscaled_value() / boost::multiprecision::pow(ten, val_from.scale());
+}
+
 std::function<data_value(data_value)> make_castas_fctn_from_decimal_to_varint() {
     return [](data_value from) -> data_value {
-        auto val_from = value_cast<big_decimal>(from);
-        boost::multiprecision::cpp_int ten(10);
-        return static_cast<boost::multiprecision::cpp_int>(val_from.unscaled_value() / boost::multiprecision::pow(ten, val_from.scale()));
+        return from_decimal_to_cppint(from);
     };
 }
 

--- a/types.cc
+++ b/types.cc
@@ -3558,6 +3558,14 @@ static ToType from_varint_to_integer(const boost::multiprecision::cpp_int& varin
 }
 
 template<typename ToType>
+std::function<data_value(data_value)> make_castas_fctn_from_varint_to_integer() {
+    return [](data_value from) -> data_value {
+        const auto& varint = value_cast<boost::multiprecision::cpp_int>(from);
+        return from_varint_to_integer<ToType>(varint);
+    };
+}
+
+template<typename ToType>
 std::function<data_value(data_value)> make_castas_fctn_from_decimal_to_integer() {
     return [](data_value from) -> data_value {
         auto varint = from_decimal_to_cppint(from);
@@ -3710,7 +3718,7 @@ thread_local castas_fctns_map castas_fctns {
     { {byte_type, long_type}, make_castas_fctn_simple<int8_t, int64_t>() },
     { {byte_type, float_type}, make_castas_fctn_simple<int8_t, float>() },
     { {byte_type, double_type}, make_castas_fctn_simple<int8_t, double>() },
-    { {byte_type, varint_type}, make_castas_fctn_simple<int8_t, boost::multiprecision::cpp_int>() },
+    { {byte_type, varint_type}, make_castas_fctn_from_varint_to_integer<int8_t>() },
     { {byte_type, decimal_type}, make_castas_fctn_from_decimal_to_integer<int8_t>() },
 
     { {short_type, byte_type}, make_castas_fctn_simple<int16_t, int8_t>() },
@@ -3719,7 +3727,7 @@ thread_local castas_fctns_map castas_fctns {
     { {short_type, long_type}, make_castas_fctn_simple<int16_t, int64_t>() },
     { {short_type, float_type}, make_castas_fctn_simple<int16_t, float>() },
     { {short_type, double_type}, make_castas_fctn_simple<int16_t, double>() },
-    { {short_type, varint_type}, make_castas_fctn_simple<int16_t, boost::multiprecision::cpp_int>() },
+    { {short_type, varint_type}, make_castas_fctn_from_varint_to_integer<int16_t>() },
     { {short_type, decimal_type}, make_castas_fctn_from_decimal_to_integer<int16_t>() },
 
     { {int32_type, byte_type}, make_castas_fctn_simple<int32_t, int8_t>() },
@@ -3728,7 +3736,7 @@ thread_local castas_fctns_map castas_fctns {
     { {int32_type, long_type}, make_castas_fctn_simple<int32_t, int64_t>() },
     { {int32_type, float_type}, make_castas_fctn_simple<int32_t, float>() },
     { {int32_type, double_type}, make_castas_fctn_simple<int32_t, double>() },
-    { {int32_type, varint_type}, make_castas_fctn_simple<int32_t, boost::multiprecision::cpp_int>() },
+    { {int32_type, varint_type}, make_castas_fctn_from_varint_to_integer<int32_t>() },
     { {int32_type, decimal_type}, make_castas_fctn_from_decimal_to_integer<int32_t>() },
 
     { {long_type, byte_type}, make_castas_fctn_simple<int64_t, int8_t>() },
@@ -3737,7 +3745,7 @@ thread_local castas_fctns_map castas_fctns {
     { {long_type, long_type}, make_castas_fctn_simple<int64_t, int64_t>() },
     { {long_type, float_type}, make_castas_fctn_simple<int64_t, float>() },
     { {long_type, double_type}, make_castas_fctn_simple<int64_t, double>() },
-    { {long_type, varint_type}, make_castas_fctn_simple<int64_t, boost::multiprecision::cpp_int>() },
+    { {long_type, varint_type}, make_castas_fctn_from_varint_to_integer<int64_t>() },
     { {long_type, decimal_type}, make_castas_fctn_from_decimal_to_integer<int64_t>() },
 
     { {float_type, byte_type}, make_castas_fctn_simple<float, int8_t>() },


### PR DESCRIPTION
The release notes for boost 1.67.0 includes:

Breaking Change: When converting a multiprecision integer to a narrower type, if the value is too large (or negative) to fit in the smaller type, then the result is either the maximum (or minimum) value of the target 

Since we just moved out of boost 1.66, we have to update our code.

This fixes issue #4960