### PR TITLE
build: adjust libthread_db file name to match gdb expectations

### DIFF
--- a/scripts/create-relocatable-package.py
+++ b/scripts/create-relocatable-package.py
@@ -78,7 +78,7 @@ for exe in executables:
     libs.update(ldd(exe))
 
 # manually add libthread_db for debugging thread
-libs.update({'libthread_db-1.0.so': '/lib64/libthread_db-1.0.so'})
+libs.update({'libthread_db.so.1': '/lib64/libthread_db-1.0.so'})
 
 ld_so = libs['ld.so']
 


### PR DESCRIPTION
gdb searches for libthread_db.so using its canonical name of libthread_db.so.1 rather
than the file name of libthread_db-1.0.so, so use that name to store the file in the
archive.

Fixes #4996.