### PR TITLE
recreate dependent user types

### DIFF
--- a/cql3/cql3_type.hh
+++ b/cql3/cql3_type.hh
@@ -76,7 +76,7 @@ public:
         virtual bool references_user_type(const sstring&) const;
         virtual std::optional<sstring> keyspace() const;
         virtual void freeze();
-        virtual cql3_type prepare_internal(const sstring& keyspace, lw_shared_ptr<user_types_metadata>) = 0;
+        virtual cql3_type prepare_internal(const sstring& keyspace, user_types_metadata&) = 0;
         virtual cql3_type prepare(database& db, const sstring& keyspace);
         static shared_ptr<raw> from(cql3_type type);
         static shared_ptr<raw> user_type(ut_name name);

--- a/cql3/statements/alter_type_statement.cc
+++ b/cql3/statements/alter_type_statement.cc
@@ -122,18 +122,6 @@ void alter_type_statement::do_announce_migration(database& db, ::keyspace& ks, b
             }
         }
     }
-
-    // Other user types potentially using the updated type
-    for (auto&& ut : ks.metadata()->user_types()->get_all_types() | boost::adaptors::map_values) {
-        // Re-updating the type we've just updated would be harmless but useless so we avoid it.
-        if (ut->_keyspace != updated->_keyspace || ut->_name != updated->_name) {
-            auto upd_opt = ut->update_user_type(updated);
-            if (upd_opt) {
-                service::get_local_migration_manager().announce_type_update(
-                    static_pointer_cast<const user_type_impl>(*upd_opt), is_local_only).get();
-            }
-        }
-    }
 }
 
 future<shared_ptr<cql_transport::event::schema_change>> alter_type_statement::announce_migration(service::storage_proxy& proxy, bool is_local_only)

--- a/db/cql_type_parser.cc
+++ b/db/cql_type_parser.cc
@@ -104,11 +104,11 @@ public:
         std::vector<sstring> field_names;
         std::vector<::shared_ptr<cql3::cql3_type::raw>> field_types;
 
-        user_type prepare(const sstring& keyspace, lw_shared_ptr<user_types_metadata> user_types) const {
+        user_type prepare(const sstring& keyspace, user_types_metadata& user_types) const {
             std::vector<data_type> fields;
             fields.reserve(field_types.size());
             std::transform(field_types.begin(), field_types.end(), std::back_inserter(fields), [&](auto& r) {
-                return r->prepare_internal(keyspace, *user_types).get_type();
+                return r->prepare_internal(keyspace, user_types).get_type();
             });
             std::vector<bytes> names;
             names.reserve(field_names.size());
@@ -161,7 +161,11 @@ public:
             }
         }
 
-        auto types = _ks.user_types();
+        // Create a copy of the existing types, so that we don't
+        // modify the one in the keyspace. It is up to the caller to
+        // do that.
+        user_types_metadata types = *_ks.user_types();
+
         const auto &ks_name = _ks.name();
         std::vector<user_type> created;
 
@@ -178,7 +182,7 @@ public:
             }
 
             created.push_back(e->prepare(ks_name, types));
-            types->add_type(created.back());
+            types.add_type(created.back());
             resolvable_types.pop_front();
         }
 

--- a/db/cql_type_parser.cc
+++ b/db/cql_type_parser.cc
@@ -83,7 +83,7 @@ data_type db::cql_type_parser::parse(const sstring& keyspace, const sstring& str
     }
 
     auto raw = parse_raw(str);
-    auto cql = raw->prepare_internal(keyspace, user_types);
+    auto cql = raw->prepare_internal(keyspace, *user_types);
     return cql.get_type();
 }
 
@@ -108,7 +108,7 @@ public:
             std::vector<data_type> fields;
             fields.reserve(field_types.size());
             std::transform(field_types.begin(), field_types.end(), std::back_inserter(fields), [&](auto& r) {
-                return r->prepare_internal(keyspace, user_types).get_type();
+                return r->prepare_internal(keyspace, *user_types).get_type();
             });
             std::vector<bytes> names;
             names.reserve(field_names.size());

--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -1131,10 +1131,31 @@ static std::vector<V> get_list(const query::result_set_row& row, const sstring& 
 // Create types for a given keyspace. This takes care of topologically sorting user defined types.
 template <typename T> static std::vector<user_type> create_types(keyspace_metadata& ks, T&& range) {
     cql_type_parser::raw_builder builder(ks);
+    std::unordered_set<bytes> names;
     for (const query::result_set_row& row : range) {
-        builder.add(row.get_nonnull<sstring>("type_name"),
-                        get_list<sstring>(row, "field_names"),
-                        get_list<sstring>(row, "field_types"));
+        auto name = row.get_nonnull<sstring>("type_name");
+        names.insert(to_bytes(name));
+        builder.add(std::move(name), get_list<sstring>(row, "field_names"), get_list<sstring>(row, "field_types"));
+    }
+    // Add user types that use any of the above types. From the
+    // database point of view they haven't changed since the content
+    // of system.types is the same for them. The runtime objects in
+    // the other hand now point to out of date types, so we need to
+    // recreate them.
+    for (const auto& p : ks.user_types()->get_all_types()) {
+        const user_type& t = p.second;
+        if (names.count(t->_name) != 0) {
+            continue;
+        }
+        for (const auto& name : names) {
+            if (t->references_user_type(t->_keyspace, name)) {
+                std::vector<sstring> field_types;
+                for (const data_type& f : t->field_types()) {
+                    field_types.push_back(f->as_cql3_type().to_string());
+                }
+                builder.add(t->get_name_as_string(), t->string_field_names(), std::move(field_types));
+            }
+        }
     }
     return builder.build();
 }

--- a/tests/schema_change_test.cc
+++ b/tests/schema_change_test.cc
@@ -422,6 +422,47 @@ public:
     virtual void on_drop_view(const sstring&, const sstring&) override { ++drop_view_count; }
 };
 
+SEASTAR_TEST_CASE(test_alter_nested_type) {
+    return do_with_cql_env_thread([](cql_test_env& e) {
+        e.execute_cql("CREATE TYPE foo (foo_k int);").get();
+        e.execute_cql("CREATE TYPE bar (bar_k frozen<foo>);").get();
+        e.execute_cql("alter type foo add zed_v int;").get();
+        e.execute_cql("CREATE TABLE tbl (key int PRIMARY KEY, val frozen<bar>);").get();
+        e.execute_cql("insert into tbl (key, val) values (1, {bar_k: {foo_k: 2, zed_v: 3} });").get();
+    });
+}
+
+SEASTAR_TEST_CASE(test_nested_type_mutation_in_update) {
+    // ALTER TYPE always creates a mutation with a single type. This
+    // creates a mutation with 2 types, one nested in the other, to
+    // show that we can handle that.
+    return do_with_cql_env_thread([](cql_test_env& e) {
+        counting_migration_listener listener;
+        service::get_local_migration_manager().register_listener(&listener);
+
+        e.execute_cql("CREATE TYPE foo (foo_k int);").get();
+        e.execute_cql("CREATE TYPE bar (bar_k frozen<foo>);").get();
+
+        BOOST_REQUIRE_EQUAL(listener.create_user_type_count, 2);
+
+        service::migration_manager& mm = service::get_local_migration_manager();
+        auto&& keyspace = e.db().local().find_keyspace("ks").metadata();
+
+        auto type1 = user_type_impl::get_instance("ks", to_bytes("foo"), {"foo_k", "extra"}, {int32_type, int32_type});
+        auto muts1 = db::schema_tables::make_create_type_mutations(keyspace, type1, api::new_timestamp());
+
+        auto type2 = user_type_impl::get_instance("ks", to_bytes("bar"), {"bar_k", "extra"}, {type1, int32_type});
+        auto muts2 = db::schema_tables::make_create_type_mutations(keyspace, type2, api::new_timestamp());
+
+        auto muts = muts1;
+        muts.insert(muts.end(), muts2.begin(), muts2.end());
+        mm.announce(std::move(muts), false).get();
+
+        BOOST_REQUIRE_EQUAL(listener.create_user_type_count, 2);
+        BOOST_REQUIRE_EQUAL(listener.update_user_type_count, 2);
+    });
+}
+
 SEASTAR_TEST_CASE(test_notifications) {
     return do_with_cql_env([](cql_test_env& e) {
         return seastar::async([&] {

--- a/types/user.hh
+++ b/types/user.hh
@@ -51,6 +51,7 @@ public:
     bytes_view field_name(size_t i) const { return _field_names[i]; }
     sstring field_name_as_string(size_t i) const { return _string_field_names[i]; }
     const std::vector<bytes>& field_names() const { return _field_names; }
+    const std::vector<sstring>& string_field_names() const { return _string_field_names; }
     sstring get_name_as_string() const;
 
 private:


### PR DESCRIPTION
When a user type changes we were not recreating other uses types that use it. This patch series fixes that and makes it clear which code is responsible for it.
