### PR TITLE
storage_service: Reject nodetool cleanup when there is pending ranges

### DIFF
--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -3554,5 +3554,16 @@ db::schema_features storage_service::cluster_schema_features() const {
     return f;
 }
 
+future<bool> storage_service::is_cleanup_allowed(sstring keyspace) {
+    return get_storage_service().invoke_on(0, [keyspace = std::move(keyspace)] (storage_service& ss) {
+        auto my_address = ss.get_broadcast_address();
+        auto pending_ranges = ss.get_token_metadata().get_pending_ranges(keyspace, my_address).size();
+        bool is_bootstrap_mode = ss._is_bootstrap_mode;
+        slogger.debug("is_cleanup_allowed: keyspace={}, is_bootstrap_mode={}, pending_ranges={}",
+                keyspace, is_bootstrap_mode, pending_ranges);
+        return !is_bootstrap_mode && pending_ranges == 0;
+    });
+}
+
 } // namespace service
 

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -2376,6 +2376,8 @@ private:
     void notify_up(inet_address endpoint);
     void notify_joined(inet_address endpoint);
     void notify_cql_change(inet_address endpoint, bool ready);
+public:
+    future<bool> is_cleanup_allowed(sstring keyspace);
 };
 
 future<> init_storage_service(sharded<abort_source>& abort_sources, distributed<database>& db, sharded<gms::gossiper>& gossiper, sharded<auth::service>& auth_service,


### PR DESCRIPTION
From Shlomi:

4 node cluster Node A, B, C, D (Node A: seed)
cassandra-stress write n=10000000 -pop seq=1..10000000 -node <seed-node>
cassandra-stress read duration=10h -pop seq=1..10000000 -node <seed-node>
while read is progressing
Node D: nodetool decommission
Node A: nodetool status node - wait for UL
Node A: nodetool cleanup (while decommission progresses)

I get the error on c-s once decommission ends
  java.io.IOException: Operation x0 on key(s) [383633374d31504b5030]: Data returned was not validated

The problem is when a node gets new ranges, e.g, the bootstrapping node, the
existing nodes after a node is removed or decommissioned, nodetool cleanup will
remove data within the new ranges which the node just gets from other nodes.

To fix, we should reject the nodetool cleanup when there is pending ranges on that node.

Note, rejecting nodetool cleanup is not a full protection because new ranges
can be assigned to the node while cleanup is still in progress. However, it is
a good start to reject until we have full protection solution.

Fixes: #5045