### PR TITLE
repair: Fix tracker::start and tracker::done in case of error

### DIFF
--- a/repair/repair.hh
+++ b/repair/repair.hh
@@ -234,11 +234,11 @@ private:
     // by one shared.
     std::vector<semaphore> _range_parallelism_semaphores;
     static const size_t _max_repair_memory_per_range = 32 * 1024 * 1024;
+    void start(int id);
+    void done(int id, bool succeeded);
 public:
     explicit tracker(size_t nr_shards, size_t max_repair_memory);
     ~tracker();
-    void start(int id);
-    void done(int id, bool succeeded);
     repair_status get(int id);
     int next_repair_command();
     future<> shutdown();
@@ -251,6 +251,7 @@ public:
     void abort_all_repairs();
     semaphore& range_parallelism_semaphore();
     static size_t max_repair_memory_per_range() { return _max_repair_memory_per_range; }
+    future<> run(int id, std::function<future<> ()> func);
 };
 
 future<uint64_t> estimate_partitions(seastar::sharded<database>& db, const sstring& keyspace,


### PR DESCRIPTION
repair: Fix tracker::start and tracker::done in case of error

The operation after gate.enter() in tracker::start() can fail and throw,
we should call gate.leave() in such case to avoid unbalanced enter and
leave calls. tracker::done() has similar issue too.

Fix it by removing the gate enter and leave logic in tracker start and
done. A helper tracker::run() is introduced to take care of the gate and
repair status.

In addition, the errro log is improved. It now logs exceptions on all
shards in the summary. e.g.,

[shard 0] repair - repair id 1 failed: std::runtime_error
({shard 0: std::runtime_error (error0), shard 1: std::runtime_error (error1)})

Fixes #5074
