### PR TITLE
relocatable: erase build directory from executable and debug info

### DIFF
--- a/reloc/build_reloc.sh
+++ b/reloc/build_reloc.sh
@@ -2,7 +2,7 @@
 
 . /etc/os-release
 
-DEFAULT_FLAGS="--enable-dpdk"
+DEFAULT_FLAGS="--enable-dpdk --cflags=-ffile-prefix-map=$PWD=."
 DEFAULT_MODE="release"
 
 print_usage() {


### PR DESCRIPTION
The build directory is meaningless, since it is typically some
directory in a continuous integration server. That means someone
debugging the relocatable package needs to issue the gdb command
'set substitute-path' with the correct arguments, or they lose
source debugging. Doing so in the relocatable package build saves
this step.

The default build is not modified, since a typical local build
benefits from having the paths hardcoded, as the debugger will
find the sources automatically.