### PR TITLE
sstables: compaction_manager: #include seastarx.hh

### DIFF
--- a/sstables/compaction_manager.hh
+++ b/sstables/compaction_manager.hh
@@ -38,6 +38,7 @@
 #include "compaction_weight_registration.hh"
 #include "compaction_backlog_manager.hh"
 #include "backlog_controller.hh"
+#include "seastarx.hh"
 
 class table;
 using column_family = table;


### PR DESCRIPTION
Make it easier for the IDE to resolve references to the seastar
namespace. In any case include files should be stand-alone and not
depend on previously included files.