### PR TITLE
lsa: Assert no cross-shard region locking

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -843,7 +843,6 @@ pure_boost_tests = set([
     'tests/range_test',
     'tests/crc_test',
     'tests/checksum_utils_test',
-    'tests/managed_vector_test',
     'tests/dynamic_bitset_test',
     'tests/idl_test',
     'tests/cartesian_product_test',

--- a/tests/managed_vector_test.cc
+++ b/tests/managed_vector_test.cc
@@ -19,9 +19,8 @@
  * along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#define BOOST_TEST_MODULE core
-
 #include <boost/test/unit_test.hpp>
+#include <seastar/testing/thread_test_case.hh>
 
 #include "utils/managed_vector.hh"
 #include "utils/logalloc.hh"
@@ -60,7 +59,7 @@ void verify_empty(const Vector& vec) {
     }
 }
 
-BOOST_AUTO_TEST_CASE(test_emplace) {
+SEASTAR_THREAD_TEST_CASE(test_emplace) {
     managed_vector<unsigned> vec;
     fill(vec);
     verify_filled(vec);
@@ -69,7 +68,7 @@ BOOST_AUTO_TEST_CASE(test_emplace) {
     verify_empty(vec);
 }
 
-BOOST_AUTO_TEST_CASE(test_copy) {
+SEASTAR_THREAD_TEST_CASE(test_copy) {
     managed_vector<unsigned> vec;
 
     managed_vector<unsigned> vec2(vec);
@@ -82,7 +81,7 @@ BOOST_AUTO_TEST_CASE(test_copy) {
     verify_filled(vec3);
 }
 
-BOOST_AUTO_TEST_CASE(test_move) {
+SEASTAR_THREAD_TEST_CASE(test_move) {
     managed_vector<unsigned> vec;
 
     managed_vector<unsigned> vec2(std::move(vec));
@@ -95,7 +94,7 @@ BOOST_AUTO_TEST_CASE(test_move) {
     verify_filled(vec3);
 }
 
-BOOST_AUTO_TEST_CASE(test_erase) {
+SEASTAR_THREAD_TEST_CASE(test_erase) {
     managed_vector<unsigned> vec;
     fill(vec);
 
@@ -110,7 +109,7 @@ BOOST_AUTO_TEST_CASE(test_erase) {
     BOOST_CHECK_EQUAL(idx, count);
 }
 
-BOOST_AUTO_TEST_CASE(test_resize_up) {
+SEASTAR_THREAD_TEST_CASE(test_resize_up) {
     managed_vector<unsigned> vec;
     fill(vec);
     vec.resize(count + 5);
@@ -129,7 +128,7 @@ BOOST_AUTO_TEST_CASE(test_resize_up) {
     BOOST_CHECK_EQUAL(idx, count + 5);
 }
 
-BOOST_AUTO_TEST_CASE(test_resize_down) {
+SEASTAR_THREAD_TEST_CASE(test_resize_down) {
     managed_vector<unsigned> vec;
     fill(vec);
     vec.resize(5);
@@ -143,7 +142,7 @@ BOOST_AUTO_TEST_CASE(test_resize_down) {
     BOOST_CHECK_EQUAL(idx, 5);
 }
 
-BOOST_AUTO_TEST_CASE(test_compaction) {
+SEASTAR_THREAD_TEST_CASE(test_compaction) {
     logalloc::region reg;
     with_allocator(reg.allocator(), [&] {
         managed_vector<unsigned> vec;

--- a/utils/logalloc.hh
+++ b/utils/logalloc.hh
@@ -547,8 +547,10 @@ public:
 class basic_region_impl : public allocation_strategy {
 protected:
     bool _reclaiming_enabled = true;
+    seastar::shard_id _cpu = seastar::local_engine->cpu_id();
 public:
     void set_reclaiming_enabled(bool enabled) {
+        assert(seastar::local_engine->cpu_id() == _cpu);
         _reclaiming_enabled = enabled;
     }
 


### PR DESCRIPTION
We observed an abort on bad_alloc which was not caused by real OOM,
but could be explained by cache region being locked from a different
shard, which is not allowed, concurrently with memory reclamation.
    
It's impossible now to prove this, or, if that was indeed the case, to
determine which code path was attempting such lock. This patch adds an
assert which would catch such incorrect locking at the attempt.
    
Refs #4978

Tests:
  - unit (dev, release, debug)
