### PR TITLE
gossiper: Improve the gossip timer callback lock handling

### DIFF
--- a/gms/gossiper.hh
+++ b/gms/gossiper.hh
@@ -119,8 +119,6 @@ private:
     semaphore _callback_running{1};
     semaphore _apply_state_locally_semaphore{100};
 public:
-    future<> timer_callback_lock() { return _callback_running.wait(); }
-    void timer_callback_unlock() { _callback_running.signal(); }
     sstring get_cluster_name();
     sstring get_partitioner_name();
     inet_address get_broadcast_address() const {


### PR DESCRIPTION
- Update the outdated comments in do_stop_gossiping. It was
  storage_service not storage_proxy that used the lock. More
  importantly, storage_service does not use it any more.

- Drop the unused timer_callback_lock and timer_callback_unlock API

- Use with_semaphore to make sure the semaphore usage is balanced.

- Add log in gossiper::do_stop_gossiping when it tries to take the
  semaphore to help debug hang during the shutdown.

Refs: #4891
Refs: #4971