### PR TITLE
alternator: Add build byproducts to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ CMakeLists.txt.user
 __pycache__CMakeLists.txt.user
 .gdbinit
 resources
+.pytest_cache
+/expressions.tokens


### PR DESCRIPTION
Add .pytest_cache and expressions.tokens to the top-level .gitignore.

@psarna @nyh 