### PR TITLE
toppartitions: don't transport schema_ptr across shards

### DIFF
--- a/db/data_listeners.hh
+++ b/db/data_listeners.hh
@@ -91,7 +91,7 @@ struct toppartitions_item_key {
 
     struct comp {
         bool operator()(const toppartitions_item_key& k1, const toppartitions_item_key& k2) const {
-            return k1.schema == k2.schema && k1.key.equal(*k2.schema, k2.key);
+            return k1.schema->id() == k2.schema->id() && k1.key.equal(*k2.schema, k2.key);
         }
     };
 

--- a/db/data_listeners.hh
+++ b/db/data_listeners.hh
@@ -31,6 +31,7 @@
 #include "mutation_reader.hh"
 #include "frozen_mutation.hh"
 #include "utils/top_k.hh"
+#include "schema_registry.hh"
 
 #include <vector>
 #include <set>
@@ -98,6 +99,31 @@ struct toppartitions_item_key {
     explicit operator sstring() const;
 };
 
+// Like toppartitions_item_key, but uses global_schema_ptr, so can be safely transported across shards
+struct toppartitions_global_item_key {
+    global_schema_ptr schema;
+    dht::decorated_key key;
+
+    toppartitions_global_item_key(toppartitions_item_key&& tik) : schema(std::move(tik.schema)), key(std::move(tik.key)) {}
+    operator toppartitions_item_key() const {
+        return toppartitions_item_key(schema, key);
+    }
+
+    struct hash {
+        size_t operator()(const toppartitions_global_item_key& k) const {
+            return std::hash<dht::token>()(k.key.token());
+        }
+    };
+
+    struct comp {
+        bool operator()(const toppartitions_global_item_key& k1, const toppartitions_global_item_key& k2) const {
+            return k1.schema.get()->id() == k2.schema.get()->id() && k1.key.equal(*k2.schema.get(), k2.key);
+        }
+    };
+
+    explicit operator sstring() const;
+};
+
 class toppartitions_data_listener : public data_listener, public weakly_referencable<toppartitions_data_listener> {
     friend class toppartitions_query;
 
@@ -107,6 +133,10 @@ class toppartitions_data_listener : public data_listener, public weakly_referenc
 
 public:
     using top_k = utils::space_saving_top_k<toppartitions_item_key, toppartitions_item_key::hash, toppartitions_item_key::comp>;
+    using global_top_k = utils::space_saving_top_k<toppartitions_global_item_key, toppartitions_global_item_key::hash, toppartitions_global_item_key::comp>;
+public:
+    static global_top_k::results globalize(top_k::results&& r);
+    static top_k::results localize(const global_top_k::results& r);
 private:
     top_k _top_k_read;
     top_k _top_k_write;

--- a/schema_registry.cc
+++ b/schema_registry.cc
@@ -265,11 +265,9 @@ global_schema_ptr::global_schema_ptr(const global_schema_ptr& o)
     : global_schema_ptr(o.get())
 { }
 
-global_schema_ptr::global_schema_ptr(global_schema_ptr&& o) {
+global_schema_ptr::global_schema_ptr(global_schema_ptr&& o) noexcept {
     auto current = engine().cpu_id();
-    if (o._cpu_of_origin != current) {
-        throw std::runtime_error("Attempted to move global_schema_ptr across shards");
-    }
+    assert(o._cpu_of_origin == current);
     _ptr = std::move(o._ptr);
     _cpu_of_origin = current;
 }

--- a/schema_registry.hh
+++ b/schema_registry.hh
@@ -173,7 +173,7 @@ public:
     // The other may come from a different shard.
     global_schema_ptr(const global_schema_ptr& other);
     // The other must come from current shard.
-    global_schema_ptr(global_schema_ptr&& other);
+    global_schema_ptr(global_schema_ptr&& other) noexcept;
     // May be invoked across shards. Always returns an engaged pointer.
     schema_ptr get() const;
     operator schema_ptr() const { return get(); }

--- a/tests/database_test.cc
+++ b/tests/database_test.cc
@@ -38,6 +38,9 @@
 #include "db/config.hh"
 #include "db/commitlog/commitlog_replayer.hh"
 #include "tmpdir.hh"
+#include "db/data_listeners.hh"
+
+using namespace std::chrono_literals;
 
 SEASTAR_TEST_CASE(test_safety_after_truncate) {
     auto cfg = make_shared<db::config>();
@@ -447,5 +450,22 @@ SEASTAR_TEST_CASE(clear_nonexistent_snapshot) {
     return do_with_some_data([] (cql_test_env& e) {
         e.local_db().clear_snapshot("test", {"ks"}).get();
         return make_ready_future<>();
+    });
+}
+
+
+// toppartitions_query caused a lw_shared_ptr to cross shards when moving results, #5104
+SEASTAR_TEST_CASE(toppartitions_cross_shard_schema_ptr) {
+    return do_with_cql_env_thread([] (cql_test_env& e) {
+        e.execute_cql("CREATE TABLE ks.tab (id int PRIMARY KEY)").get();
+        db::toppartitions_query tq(e.db(), "ks", "tab", 1s, 100, 100);
+        tq.scatter().get();
+        auto q = e.prepare("INSERT INTO ks.tab(id) VALUES(?)").get0();
+        // Generate many values to ensure crossing shards
+        for (auto i = 0; i != 100; ++i) {
+            e.execute_prepared(q, {cql3::raw_value::make_value(int32_type->decompose(i))}).get();
+        }
+        // This should trigger the bug in debug mode
+        tq.gather().get();
     });
 }


### PR DESCRIPTION
When the toppartitions operation gathers results, it copies partition
keys with their schema_ptr:s. When these schema_ptr:s are copies
or destroyed, they can cause leaks or premature frees of the schema
in its original shard since reference count operations in are not atomic.

Fix that by converting the schema_ptr to a global_schema_ptr during
transportation.

Fixes #5104 (direct bug)
Fixes #5018 (schema prematurely freed, toppartitions previously executed on that node)
Fixes #4973 (corrupted memory pool of the same size class as schema, toppartitions previously executed on that node)

Tests: new test added that fails with the existing code in debug mode, manual toppartitions test