### PR TITLE
fix prompt of latest version

### DIFF
--- a/dist/common/scripts/scylla-housekeeping
+++ b/dist/common/scripts/scylla-housekeeping
@@ -138,12 +138,15 @@ def check_version(ar):
             params = params + "&rtype=" + repo_type
         versions = get_json_from_url(version_url + params)
         latest_version = versions["version"]
-        latest_patch_version = versions["latest_patch_version"]
+        latest_patch_version = versions.get("latest_patch_version")
     except Exception:
         traceln("Unable to retrieve version information")
         return
 
-    if latest_patch_version != latest_version:
+    if latest_patch_version is None:
+        traceln("Your current Scylla version is ", current_version, ", does not find official latest patch release, ",
+                "and the latest official minor release is " + latest_version)
+    elif latest_patch_version != latest_version:
         # user is using an older minor version
         if version_compare(current_version, latest_patch_version):
             # user is also running an older patch version

--- a/dist/common/scripts/scylla-housekeeping
+++ b/dist/common/scripts/scylla-housekeeping
@@ -181,7 +181,7 @@ if args.config != "":
     if not os.path.isfile(args.config):
         traceln("Config file ", args.config, " is missing, terminating")
         sys.exit(0)
-    config = configparser.SafeConfigParser()
+    config = configparser.ConfigParser()
     config.read(args.config)
 uid = None
 if args.uuid != "":


### PR DESCRIPTION
### add special prompt for lack of latest_patch_version

`Unable to retrieve version information` is prompted if you run a RC release
until GA version is released. We also prompt same in some error cases.

### This patch added special prompt for this normal case.

fix DeprecationWarning of SafeConfigParser

DeprecationWarning: The SafeConfigParser class has been renamed to ConfigParser
in Python 3.2. This alias will be removed in future versions. Use ConfigParser
directly instead.
  config = configparser.SafeConfigParser()

/CC @amnonh 