### PR TITLE
Alternator add https support

### DIFF
--- a/alternator-test/README.md
+++ b/alternator-test/README.md
@@ -31,3 +31,20 @@ and ~/.aws/config with the default region to use in the test:
 region = us-east-1
 ```
 
+## HTTPS support
+
+In order to run tests with HTTPS, run pytest with `--https` parameter. Note that the Scylla cluster needs to be provided
+with alternator\_tls\_port configuration option in order to initialize a HTTPS server.
+Moreover, running an instance of a HTTPS server requires a certificate. Here's how to easily generate
+a key and a self-signed certificate, which is sufficient to run `--https` tests:
+
+```
+openssl genrsa 2048 > scylla.key
+openssl req -new -x509 -nodes -sha256 -days 365 -key scylla.key -out scylla.crt
+```
+
+If this pair is put into `SCYLLA_DATA_DIR/conf/` directory, it will be enough
+to allow the alternator HTTPS server to think it's been authorized and properly certified.
+Still, boto3 library issues warnings that the certificate used for communication is self-signed,
+and thus should not be trusted. For the sake of running local tests this warning can be safely ignored.
+

--- a/alternator-test/conftest.py
+++ b/alternator-test/conftest.py
@@ -65,6 +65,10 @@ def dynamodb(request):
         local_url = 'https://localhost:8043' if request.config.getoption('https') else 'http://localhost:8000'
         # Disable verifying in order to be able to use self-signed TLS certificates
         verify = not request.config.getoption('https')
+        # Silencing the 'Unverified HTTPS request warning'
+        if request.config.getoption('https'):
+            import urllib3
+            urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
         return boto3.resource('dynamodb', endpoint_url=local_url, verify=verify,
             region_name='us-east-1', aws_access_key_id='whatever', aws_secret_access_key='whatever')
 

--- a/alternator-test/conftest.py
+++ b/alternator-test/conftest.py
@@ -43,6 +43,9 @@ if (LooseVersion(botocore.__version__) < LooseVersion('1.12.54')):
 def pytest_addoption(parser):
     parser.addoption("--aws", action="store_true",
         help="run against AWS instead of a local Scylla installation")
+    parser.addoption("--https", action="store_true",
+        help="communicate via HTTPS protocol on port 8043 instead of HTTP when"
+            " running against a local Scylla installation")
 
 # "dynamodb" fixture: set up client object for communicating with the DynamoDB
 # API. Currently this chooses either Amazon's DynamoDB in the default region
@@ -59,7 +62,10 @@ def dynamodb(request):
         # requires us to specify dummy region and credential parameters,
         # otherwise the user is forced to properly configure ~/.aws even
         # for local runs.
-        return boto3.resource('dynamodb', endpoint_url='http://localhost:8000',
+        local_url = 'https://localhost:8043' if request.config.getoption('https') else 'http://localhost:8000'
+        # Disable verifying in order to be able to use self-signed TLS certificates
+        verify = not request.config.getoption('https')
+        return boto3.resource('dynamodb', endpoint_url=local_url, verify=verify,
             region_name='us-east-1', aws_access_key_id='whatever', aws_secret_access_key='whatever')
 
 # "test_table" fixture: Create and return a temporary table to be used in tests

--- a/alternator-test/test_describe_endpoints.py
+++ b/alternator-test/test_describe_endpoints.py
@@ -22,7 +22,7 @@ import boto3
 # Test that the DescribeEndpoints operation works as expected: that it
 # returns one endpoint (it may return more, but it never does this in
 # Amazon), and this endpoint can be used to make more requests.
-def test_describe_endpoints(dynamodb):
+def test_describe_endpoints(request, dynamodb):
     endpoints = dynamodb.meta.client.describe_endpoints()['Endpoints']
     # It is not strictly necessary that only a single endpoint be returned,
     # but this is what Amazon DynamoDB does today (and so does Alternator).
@@ -34,14 +34,16 @@ def test_describe_endpoints(dynamodb):
         # send it another describe_endpoints() request ;-) Note that the
         # address does not include the "http://" or "https://" prefix, and
         # we need to choose one manually.
-        url = "http://" + address
+        prefix = "https://" if request.config.getoption('https') else "http://"
+        verify = not request.config.getoption('https')
+        url = prefix + address
         if address.endswith('.amazonaws.com'):
-            boto3.client('dynamodb',endpoint_url=url).describe_endpoints()
+            boto3.client('dynamodb',endpoint_url=url, verify=verify).describe_endpoints()
         else:
             # Even though we connect to the local installation, Boto3 still
             # requires us to specify dummy region and credential parameters,
             # otherwise the user is forced to properly configure ~/.aws even
             # for local runs.
-            boto3.client('dynamodb',endpoint_url=url, region_name='us-east-1', aws_access_key_id='whatever', aws_secret_access_key='whatever').describe_endpoints()
+            boto3.client('dynamodb',endpoint_url=url, region_name='us-east-1', aws_access_key_id='whatever', aws_secret_access_key='whatever', verify=verify).describe_endpoints()
         # Nothing to check here - if the above call failed with an exception,
         # the test would fail.

--- a/alternator/server.cc
+++ b/alternator/server.cc
@@ -153,19 +153,38 @@ void server::set_routes(routes& r) {
     r.add(operation_type::POST, url("/"), handler);
 }
 
-future<> server::init(net::inet_address addr, uint16_t port) {
-    return _executor.invoke_on_all([] (executor& e) {
-        return e.start();
-    }).then([this] {
-        return _control.start();
-    }).then([this] {
-        return _control.set_routes(std::bind(&server::set_routes, this, std::placeholders::_1));
-    }).then([this, addr, port] {
-        return _control.listen(socket_address{addr, port});
-    }).then([addr, port] {
-        slogger.info("Alternator HTTP server listening on {} port {}", addr, port);
-    }).handle_exception([addr, port] (std::exception_ptr e) {
-        slogger.warn("Failed to set up Alternator HTTP server on {} port {}: {}", addr, port, e);
+future<> server::init(net::inet_address addr, std::optional<uint16_t> port, std::optional<uint16_t> https_port, std::optional<tls::credentials_builder> creds) {
+    if (!port && !https_port) {
+        return make_exception_future<>(std::runtime_error("Either regular port or TLS port"
+                " must be specified in order to init an alternator HTTP server instance"));
+    }
+    return seastar::async([this, addr, port, https_port, creds] {
+        try {
+            _executor.invoke_on_all([] (executor& e) {
+                return e.start();
+            }).get();
+
+            if (port) {
+                _control.start().get();
+                _control.set_routes(std::bind(&server::set_routes, this, std::placeholders::_1)).get();
+                _control.listen(socket_address{addr, *port}).get();
+                slogger.info("Alternator HTTP server listening on {} port {}", addr, *port);
+            }
+            if (https_port) {
+                _https_control.start().get();
+                _https_control.set_routes(std::bind(&server::set_routes, this, std::placeholders::_1)).get();
+                _https_control.server().invoke_on_all([creds] (http_server& serv) {
+                    return serv.set_tls_credentials(creds->build_server_credentials());
+                }).get();
+
+                _https_control.listen(socket_address{addr, *https_port}).get();
+                slogger.info("Alternator HTTPS server listening on {} port {}", addr, *https_port);
+            }
+        } catch (...) {
+            slogger.warn("Failed to set up Alternator HTTP server on {} port {}, TLS port {}: {}",
+                    addr, port ? std::to_string(*port) : "OFF", https_port ? std::to_string(*https_port) : "OFF", std::current_exception());
+            throw;
+        }
     });
 }
 

--- a/alternator/server.hh
+++ b/alternator/server.hh
@@ -24,16 +24,19 @@
 #include "alternator/executor.hh"
 #include <seastar/core/future.hh>
 #include <seastar/http/httpd.hh>
+#include <seastar/net/tls.hh>
+#include <optional>
 
 namespace alternator {
 
 class server {
     seastar::httpd::http_server_control _control;
+    seastar::httpd::http_server_control _https_control;
     seastar::sharded<executor>& _executor;
 public:
     server(seastar::sharded<executor>& executor) : _executor(executor) {}
 
-    seastar::future<> init(net::inet_address addr, uint16_t port);
+    seastar::future<> init(net::inet_address addr, std::optional<uint16_t> port, std::optional<uint16_t> https_port, std::optional<tls::credentials_builder> creds);
 private:
     void set_routes(seastar::httpd::routes& r);
 };

--- a/db/config.cc
+++ b/db/config.cc
@@ -701,6 +701,7 @@ db::config::config(std::shared_ptr<db::extensions> exts)
             "Maximum number of distinct clustering key restrictions per query. This limit places a bound on the size of IN tuples, "
             "especially when multiple clustering key columns have IN restrictions. Increasing this value can result in server instability.")
     , alternator_port(this, "alternator_port", value_status::Used, 0, "Alternator API port")
+    , alternator_https_port(this, "alternator_https_port", value_status::Used, 0, "Alternator API HTTPS port")
     , alternator_address(this, "alternator_address", value_status::Used, "0.0.0.0", "Alternator API listening address")
     , default_log_level(this, "default_log_level", value_status::Used)
     , logger_log_level(this, "logger_log_level", value_status::Used)

--- a/db/config.hh
+++ b/db/config.hh
@@ -287,6 +287,7 @@ public:
     named_value<uint32_t> max_clustering_key_restrictions_per_query;
 
     named_value<uint16_t> alternator_port;
+    named_value<uint16_t> alternator_https_port;
     named_value<sstring> alternator_address;
 
     seastar::logging_settings logging_settings(const boost::program_options::variables_map&) const;

--- a/docs/alternator/alternator.md
+++ b/docs/alternator/alternator.md
@@ -52,7 +52,8 @@ progresses and compatibility continues to improve.
 
 ### API Server
 * Transport: HTTP mostly supported, but small features like CRC header and
-  compression are still missing. HTTPS not tested.
+  compression are still missing. HTTPS supported on top of HTTP, so small
+  features may still be missing.
 * Authorization (verifying the originator of the request): Not yet supported.
 * DNS server for load balancing: Not yet supported. Client needs to pick
   one of the live Scylla nodes and send a request to it.


### PR DESCRIPTION
This series adds HTTPS support for alternator. It depends on not-merged-yet @amnonh's series that adds TLS support to Seastar's HTTP server. The series comes with `--https` option added to alternator-test, which makes the test harness run all the tests with HTTPS instead of HTTP. All the tests pass, albeit with security warnings that a self-signed x509 certificate was used and it should not be trusted.

Fixes https://github.com/scylladb/scylla/issues/5042
Refs https://github.com/scylladb/seastar/pull/685

/CC @nyh