### PR TITLE
Redis API in Scylla

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -456,6 +456,8 @@ arg_parser.add_argument('--enable-alloc-failure-injector', dest='alloc_failure_i
                         help='enable allocation failure injection')
 arg_parser.add_argument('--with-antlr3', dest='antlr3_exec', action='store', default=None,
                         help='path to antlr3 executable')
+arg_parser.add_argument('--with-ragel', dest='ragel_exec', action='store', default='ragel',
+        help='path to ragel executable')
 args = arg_parser.parse_args()
 
 defines = ['XXH_PRIVATE_API',
@@ -802,6 +804,26 @@ alternator = [
        'alternator/auth.cc',
 ]
 
+redis = [
+        'redis/service.cc',
+        'redis/server.cc',
+        'redis/query_processor.cc',
+        'redis/protocol_parser.rl',
+        'redis/keyspace_utils.cc',
+        'redis/options.cc',
+        'redis/stats.cc',
+        'redis/mutation_utils.cc',
+        'redis/query_utils.cc',
+        'redis/abstract_command.cc',
+        'redis/command_factory.cc',
+        'redis/commands/unknown.cc',
+        'redis/commands/ping.cc',
+        'redis/commands/set.cc',
+        'redis/commands/get.cc',
+        'redis/commands/del.cc',
+        'redis/commands/select.cc',
+        ]
+
 idls = ['idl/gossip_digest.idl.hh',
         'idl/uuid.idl.hh',
         'idl/range.idl.hh',
@@ -847,7 +869,7 @@ scylla_tests_dependencies = scylla_core + idls + scylla_tests_generic_dependenci
 ]
 
 deps = {
-    'scylla': idls + ['main.cc', 'release.cc'] + scylla_core + api + alternator,
+    'scylla': idls + ['main.cc', 'release.cc'] + scylla_core + api + alternator + redis,
 }
 
 pure_boost_tests = set([
@@ -1237,6 +1259,11 @@ if args.antlr3_exec:
 else:
     antlr3_exec = "antlr3"
 
+if args.ragel_exec:
+    ragel_exec = args.ragel_exec
+else:
+    ragel_exec = "ragel"
+
 for mode in build_modes:
     configure_zstd(outdir, mode)
 
@@ -1271,6 +1298,11 @@ with open(buildfile_tmp, 'w') as f:
             command = {ninja} -C $subdir $target
             restat = 1
             description = NINJA $out
+        rule ragel
+            # sed away a bug in ragel 7 that emits some extraneous _nfa* variables
+            # (the $$ is collapsed to a single one by ninja)
+            command = {ragel_exec} -G2 -o $out $in && sed -i -e '1h;2,$$H;$$!d;g' -re 's/static const char _nfa[^;]*;//g' $out
+            description = RAGEL $out
         rule run
             command = $in > $out
             description = GEN $out
@@ -1335,6 +1367,7 @@ with open(buildfile_tmp, 'w') as f:
         swaggers = {}
         serializers = {}
         thrifts = set()
+        ragels = {}
         antlr3_grammars = set()
         seastar_dep = 'build/{}/seastar/libseastar.a'.format(mode)
         for binary in build_artifacts:
@@ -1392,6 +1425,9 @@ with open(buildfile_tmp, 'w') as f:
                 elif src.endswith('.json'):
                     hh = '$builddir/' + mode + '/gen/' + src + '.hh'
                     swaggers[hh] = src
+                elif src.endswith('.rl'):
+                    hh = '$builddir/' + mode + '/gen/' + src.replace('.rl', '.hh')
+                    ragels[hh] = src
                 elif src.endswith('.thrift'):
                     thrifts.add(src)
                 elif src.endswith('.g'):
@@ -1420,6 +1456,7 @@ with open(buildfile_tmp, 'w') as f:
             gen_headers += g.headers('$builddir/{}/gen'.format(mode))
         gen_headers += list(swaggers.keys())
         gen_headers += list(serializers.keys())
+        gen_headers += list(ragels.keys())
         gen_headers_dep = ' '.join(gen_headers)
 
         for obj in compiles:
@@ -1433,6 +1470,9 @@ with open(buildfile_tmp, 'w') as f:
         for hh in serializers:
             src = serializers[hh]
             f.write('build {}: serializer {} | idl-compiler.py\n'.format(hh, src))
+        for hh in ragels:
+            src = ragels[hh]
+            f.write('build {}: ragel {}\n'.format(hh, src))
         for thrift in thrifts:
             outs = ' '.join(thrift.generated('$builddir/{}/gen'.format(mode)))
             f.write('build {}: thrift.{} {}\n'.format(outs, mode, thrift.source))

--- a/db/config.cc
+++ b/db/config.cc
@@ -713,6 +713,21 @@ db::config::config(std::shared_ptr<db::extensions> exts)
     , alternator_address(this, "alternator_address", value_status::Used, "0.0.0.0", "Alternator API listening address")
     , alternator_enforce_authorization(this, "alternator_enforce_authorization", value_status::Used, false, "Enforce checking the authorization header for every request in Alternator")
     , abort_on_ebadf(this, "abort_on_ebadf", value_status::Used, true, "Abort the server on incorrect file descriptor access. Throws exception when disabled.")
+    , redis_transport_port(this, "redis_transport_port", value_status::Used, 6379, "Port on which the REDIS transport listens for clients.")
+    // FIXME: 9142 has been used by native_transport_port_ssl
+    , redis_transport_port_ssl(this, "redis_transport_port_ssl", value_status::Used, 9142, "Port on which the REDIS TLS native transport listens for clients.")
+    , enable_redis_protocol(this, "enable_redis_protocol", value_status::Used, false, "Enable redis protocol; Scylla will process redis protocol as a redis cluster if enable.")
+    , redis_read_consistency_level(this, "redis_read_consistency_level", value_status::Used, "ONE", "Consistency level for read operations for redis.")
+    , redis_write_consistency_level(this, "redis_write_consistency_level", value_status::Used, "ANY", "Consistency level for write operations for redis.")
+    , redis_default_database_count(this, "redis_default_database_count", value_status::Used, 16, "Default database count for the redis cluster.")
+    , redis_keyspace_options(this, "redis_keyspace_options", value_status::Used, {}, 
+            "Enable redis protocol, list of properties of replication of redis keyspace. The available options are:\n"
+            "\n"
+            "\tclass : (Default: SimpleStrategy ).\n"
+            "\treplication_factor: (Default: 1) If the class is SimpleStrategy, set the replication factor for the strategy.\n"
+            "\tdatacenter_i: (Default: 1) If the class is NetworkTopologyStrategy, set the replication factor per datacenter.\n"
+            "\n"
+            "The properties of replication for redis keyspace.")
 
     , default_log_level(this, "default_log_level", value_status::Used)
     , logger_log_level(this, "logger_log_level", value_status::Used)

--- a/db/config.hh
+++ b/db/config.hh
@@ -297,6 +297,14 @@ public:
     named_value<bool> alternator_enforce_authorization;
     named_value<bool> abort_on_ebadf;
 
+    named_value<uint16_t> redis_transport_port;
+    named_value<uint16_t> redis_transport_port_ssl;
+    named_value<bool> enable_redis_protocol;
+    named_value<sstring> redis_read_consistency_level;
+    named_value<sstring> redis_write_consistency_level;
+    named_value<uint16_t> redis_default_database_count;
+    named_value<string_map> redis_keyspace_options;
+
     seastar::logging_settings logging_settings(const boost::program_options::variables_map&) const;
 
     boost::program_options::options_description_easy_init&

--- a/docs/redis/redis.md
+++ b/docs/redis/redis.md
@@ -1,0 +1,362 @@
+Redis API in Scylla
+
+## 1. Overview
+
+Redis is a very  famous NoSQL in-memory data structure store that stores a
+mapping of keys to different types of values, and familiar to many developers.
+It supports data structures such as STRINGs, HASHes, LISTs, SETs, ZSETs(sorted sets),
+and other data structures. Redis has built-in replication, Lua
+scripting, LRU eviction, transactions and different levels of on-disk
+persistence. Now Redis as memory store service is provided by many cloud
+platforms.
+
+In this document, the detailed design and implementation of Redis that build on
+top of Scylla is provided. At the beginning, the main feature, which is as a
+data structures store, is design and  implmented. In the future, the reset
+features of Redis will be supported.
+
+## 2. Motivation
+
+In contrast,  [Scylla](https://www.scylladb.com/) has advantage and amazing
+features:
+
+* Low and consistent latency
+* Data persistence
+* High availability
+* High throughtput
+* Highly scalable
+* Auto tuning
+
+If Redis build on the top of Scylla, it has the above features automatically.
+It's achived great progress in cluster master managment, data persistence,
+failover and replication.
+
+The benefits to the users are easy to use and develop in their production
+environment, and taking avantages of Scylla.
+
+## 3. The Protocol Server
+
+Redis clients communicate with the Redis server using a protocol called
+**RESP** (REdis Serialization Protocol). The protocol is binary-safe and
+easy to be implement at client side, which was designed specifically for
+Redis.
+
+Redis server accepts commands composed of different arguments. Once a
+command is received, it's processed and a reply is sent back to the client.
+Two kind of Redis clients are widely used, the smart Redis client and
+simple Redis client. When using smart Redis client to connect the Redis
+cluster, it will send the commands to the right Redis server. Because the
+client will get the hash slots and server nodes mapping data at the bootrap
+time. When using simple Redis client,  the server address is needed, and
+all the requests are sent to this address, and the requests only send to
+the single Redis server.
+
+In Scylla terminology, the node receiving the request acts as the the
+coordinator, and often passes the request on to one or more other nodes,
+which hold copies of the requested data.  Any node of Scylla cluster can
+process the request correctly. In other words, Client can send request to
+any node of Redis cluster built on the top of Scylla. Obviously, the simple
+client can accesses the Redis cluster built on the top of Scylla, when
+provided address is not an IP but rather a single domain name, which a
+client resloves a random Scylla node IP address. The smart Redis client
+queries the mapping information between hash slots and Server nodes. We
+just fill the mapping with random Scylla node IP address.
+
+Before you can start using Scylla with Redis API, you must set the
+`enable_redis_protocol` configuration option (visa the command line or YAML),
+to `true`, which default is `false`. By default, the Scylla will listen on the
+port (default is 6379, you can set the `redis_transport_prot` to other value).
+
+With Redis enabled, every Scylla node listens for Redis requests on this port.
+These requests, in [RESP](https://redis.io/topics/protocol) format over TCP,
+are parsed and result in calls to internal Scylla C++ functions.
+
+## 4. Data Model
+
+Out of box, every Redis cluster supports 16 databases. The default database
+is 0 but it allows us to change that to any number from 0-15 (and allow us
+to configure Redis to support more databases). Each database provides
+a distinct keyspace, independent from the others. Use `SELECT n`
+to change databases. Redis allows us to store keys that map to any one of
+five different  basic data structure types:  STRINGs,  LISTs,  SETs,
+HASHes, and  ZSETs. (In fact, Now Redis has support other structure types,
+but the basic structure types are used widely).
+
+In this proposal, We use the column family of Scylla to simulate the
+database within Redis. At the bootrap phase, the column familes with fixed
+name should be created (if not exists) or loaded.
+
+We known that, Redis allows us to store keys that map to any one of the
+basic data structures. Scylla supports variant type, which allows us to
+define one table to store all kind of these Redis data. For example ,we
+create the table with the schame as follow:
+
+```
+CREATE TABLE redis （
+    key text,
+    value variant\<text, list\<text\>, map\<text\>\>,
+    PRIMARY KEY(key)
+）WITH ...
+```
+
+However,  it's need to prefetch the whole elements of this type structure
+into memory in Scylla, even modifying only one element of the structures.
+The main limitation is that the size of the data structure is not allowed
+to be exceeded the limit of the server's memory size. And the operations
+will have more performance cost with bigger data structure.
+
+> In Redis, maximum length of a list is 23^2  - 1 elements (4294967295,
+> more than 4 billion of elements per list). And maximum length of
+> element (as a string) is 512MB. It's very common that the size of data
+> structure is exceeded the server's memory size.
+
+So single table to store all the data strucutures is not good idea, instead
+of five independent tables are created to hold the the different Redis
+structure types within each column family related Redis database. In other
+words, all of the STRINGs of the Redis will be stored in a table within the
+column family, and all of the LISTs' elements will be stored in anther
+table within the column family, and so on.
+
+> When building Redis on top of Scylla, for every Redis  database (16
+> databases as default), 1 column family with 5 tables in Scylla
+> will be created.
+
+The disadvantages of this proposal is that, we can not the TYPE command of
+Redis. The different type strutures are stored in the different Scylla
+tables, and each Scylla table provide the independent keyspace. In Redis,
+keys are unique in the database. However,  the keys with column family of
+Scylla are not unique. Beacause the keys are splited into independent
+Scylla tables, it's different to original Redis.
+
+**IMPORTANT NOTE**: The keys with database of Redis are not unique  in this
+proposal, is the main difference with original Redis.
+
+> This limitation is acceptable. The top layer of bussness system knows the
+> context of the keys.
+
+In the rest of this section, the details of schema of tables within column
+family are provided.
+
+### 4.1  Table Schema of STRINGs
+
+In Redis, STRINGs are similar to strings that we see in other languages or
+other key-value stores. Every data item only has two parts, KEY and VALUE.
+The partition in the Scylla table owns the TTL property. We just need two
+columns in the table to store Redis STRING data.
+
+The maximum allowed key and value size is 512 MB. Very long key size is not
+good idea.
+
+Within the Scylla column family, we create the table named `STRINGs to
+store the string structure of Redis. The table STRINGs is created by
+following CQL:
+
+```
+CREATE TABLE STRINGs (
+    pkey text,
+    data text,
+    PRIMARY KEY (key)
+) WITH ... ;
+```
+
+Every Key-Value pair is stored as one partition within STRINGs table.
+All commands of STRINGs and some shared commands will operate this table.
+
+### 4.2 Table Schema of LISTs
+
+In Redis, LISTs store an ordered sequence of strings which sorted by
+insertion order. It allows us to push items to the front and the back of
+the LIST with LPUSH/RPUSH, and to pop items from the front and back of the
+list with LPOP/RPOP, and to fetch an item at a given position with LINDEX,
+and to fetch a range of items with LRANGE.
+
+Maximum length of a list is 23^2  - 1 elements (4294967295, more than 4
+billion of elements per list). And maximum length of element (as a string) is 512MB.
+
+As we known, Scylla supports 3 kinds of collections, lists, maps,
+and sets. We do not use the lists collection to store Redis LISTs
+structure. Because, the LISTs structure in Redis may contains many
+elements ( Maximum is more than 4 billion of elements per list).
+When updating the lists collection in Scylla, the whole elements
+will be loaded into memory.
+
+The better way is that the LISTs of Redis are stored as the
+partition of the Scylla table. All commons of Redis LISTs will
+operate on this table, which is created by following CQL:
+
+```
+CREATE TABLE LISTs (
+    pkey text,
+    ckey text,
+    data text,
+    PRIMARY KEY(pkey, ckey)
+) WITH ... ;
+```
+
+The pkey is mapped to Redis LISTs key, and ckey is the UUID of the
+insertion timestamp, which will be keep the right order as the insertion
+order. The element's value is stored in the data column within LISTs table.
+
+### 4.3  Table Schema of HASHes
+
+In Redis, HASHes are maps between the string fields and the string values.
+The fields are unique within a HASH structure in Redis. The values that can
+be stored in HASHes are the same as what can be stored as normal STRINGs.
+
+HASHes provide constant time basic operations like HGET, HSET, HEXISTS etc.
+
+As mentioned above, Scylla provides the 3 kinds of collection data type,
+including map.
+We do not use this collection type of Scylla to strore HASHes data with the
+same reason.
+
+The better way is that the HASHes of Redis are stored as the partition of
+the Scylla table. All commons of Redis HASHes will operate on this table,
+which is created by following CQL:
+
+```
+CREATE TABLE HASHes (
+    pkey text,
+    ckey text,
+    data text,
+    PRIMARY KEY(pkey, ckey)
+) WITH ... ;
+```
+
+The HASHes structure is stored as the partition of Scylla table. The pkey
+is the partition key. The HASHes structure's field is storted as ckey
+(cluster key in HASHes table). The HASHes structure's value is stored as
+data column.
+
+### 4.4 Table Schema of SETs
+
+In Redis, SETs allows us to store sequence of strings, and uses a hash
+table to keep all strings unique.
+
+For the same reason as LISTs/HASHes, we do not use the collection type of
+Scylla to store Redis SETs data. The table is created by following CQL:
+
+```
+CREATE TABLE SETs (
+    pkey text,
+    ckey text,
+    PRIMARY KEY(pkey, ckey)
+) WITH ... ;
+```
+
+Unlike HASHes, There is not data column in SETs table. Every SETs structure
+is stored as a partition in SETs table. We use the cluster key to store the
+item of Redis SETs.
+
+### 4.5 Table Schema of ZSETs(Sorted SETs)
+
+In fact, ZSETs in Redis is similar to HASHes, which maps the STRINGs key to
+value. Like HASHes, the keys (called  MEMBERS) are unique. But the values (called
+SCORES) are limited to floating-point numbers.  ZSETs have the
+unique property in Redis of being able to be accessed by member (like aHASH),
+but items can also be accessed by the sorted order and values of the scores.
+
+Essentially speaking, the ZSETs looks like special SETs. The SETs structure
+maps a key (as STRING) to a collection of STRINGs. But the ZSETs structure
+maps a key (as STRING) to a collection of ITEMs which associated with a
+score. It allows us to fetch data by score.
+
+To store ZSETs data,  the scylla table is created by following CQL:
+
+```
+CREATE TABLE ZSETs (
+    pkey text,
+    ckey double,
+    data text,
+    PRIMARY KEY(pkey, ckey)
+) WITH ... ;
+```
+
+Like other stutures mentioned above, a ZSETs strucutre is stored as a
+partition within the ZSETs table.
+
+## 5. Implementation of Commands
+
+In Scylla, high write performance is achieved by ensuring that writes do
+not require reads from disk. However, in Redis, the object level atomic
+updates is [supported](https://redis.io/topics/transactions),  and the
+transaction is supported (e.g. CAS).  In this proposal, the commands, which
+require a read before the write (a.k.a read-modify-write), are implemented
+in an unsafe way, that simply performs a read before the write.
+
+Fortunately, the LWT is soon comming to Scylla.  By then the
+read-modify-write commands will be implemented based on LWT.
+
+**IMPORTANT NOTE**:
+
+The commands, that require a read before the write, are not atomic. It's
+anther difference with original Redis.
+
+### 5.1 RMW Command
+
+The RMW Commond is that the sequence of operations (Read-Modify-Write)
+require by this command needs to be performed atomically.
+
+For instance, APPEND command of STRINGs, is typical RMW command. First,
+read the key from database, modify it's value (based on the exists value),
+and write the new value back. These sequence of operations should be
+performed atomically.
+
+As mentioned above, Scylla currently does not support LWT. The RMW commands
+are implemented in an unsafe way in this proposal. It simply performs a
+read before the write.
+
+Asumming Scylla has supported the LWT, there is no difference with the
+original Reids about the RMW commands.
+
+### 5.2 Non-RMW Command
+
+The Non-RMW command only performs a single read or write operation. For
+instance, The SET, GET, EXISTS of STRINGs strucutures. The behaviour of
+these commands are not difference with the original Redis.
+
+### 5.3 Transaction
+
+For the same reason as RMW command, the transaction is not supported
+currently.
+
+> In fact, some commands (e.g. MSET of STRINGs) are also not supported,
+> which also need the transcation mechanism.
+
+### 5.4 Time to Live (TTL)
+
+In Redis, the TTL is only specified to entrie key-value pair. Scylla has
+compaction mechanism to remove expired data.  We can set the TTL the
+partition for the given partition key. We also can rewrite the  partition
+with new TTL value.
+
+The partition ( stores the key-value pair of Redis strucutres) will be
+deleted eventually, when the associated TTL is older than current
+timestamp.
+
+### 5.5 Consistency
+
+Redis Cluster is not able to [guarantee strong
+onsistency](https://redis.io/topics/cluster-tutorial).
+
+In Scylla, data is always replicated automatically.  Read  or  write
+operations can occur to data stored on any of the replicated nodes. The
+[Consistency Level
+(CL)](https://docs.scylladb.com/glossary/#term-consistency-level-cl)
+determines how many replicas in a cluster that must acknowledge read or
+[write
+operations](https://docs.scylladb.com/glossary/#term-write-operation)
+before it is considered successful.
+
+We can use the fault tolerance mechanism of Scylla, to make the
+consistency of Redis operations configurable.
+
+### 5.6 Implementation of Shared Commands
+
+In Redis, data strucutures have the shared commands (e.g. DEL, EXISTS).
+And other commands usually operate on special one data structure of Redis.
+As mentioned above,
+we split the key set into 5 different Scylla table. The shared commands
+should operate on these tables in parallel. For instance, DEL command,
+which allows user to remove any key in Redis database, should delete the
+given key from 5 different Scylla tables.

--- a/main.cc
+++ b/main.cc
@@ -70,6 +70,7 @@
 #include "cql3/cql_config.hh"
 
 #include "alternator/server.hh"
+#include "redis/service.hh"
 
 namespace fs = std::filesystem;
 
@@ -1103,6 +1104,12 @@ int main(int ac, char** av) {
                 alternator_server.init(addr, alternator_port, alternator_https_port, creds, cfg->alternator_enforce_authorization()).get();
             }
 
+            static redis_service redis;
+            if (cfg->enable_redis_protocol()) {
+                redis.init(std::ref(proxy), std::ref(db), std::ref(auth_service), *cfg).get();
+                startlog.info("Redis server listening on port {}", cfg->redis_transport_port());
+            }
+
             if (cfg->defragment_memory_on_idle()) {
                 smp::invoke_on_all([] () {
                     engine().set_idle_cpu_handler([] (reactor::work_waiting_on_reactor check_for_work) {
@@ -1122,6 +1129,7 @@ int main(int ac, char** av) {
             api::set_server_done(ctx).get();
             supervisor::notify("serving");
             // Register at_exit last, so that storage_service::drain_on_shutdown will be called first
+
             auto stop_repair = defer_with_log_on_error([] {
                 startlog.info("stopping repair");
                 repair_shutdown(service::get_local_storage_service().db()).get();
@@ -1150,6 +1158,14 @@ int main(int ac, char** av) {
                     return db.get_compaction_manager().stop();
                 }).get();
             });
+
+            auto stop_redis_service = defer_with_log_on_error([&cfg] {
+                if (cfg->enable_redis_protocol()) {
+                    startlog.info("stopping redis service");
+                    redis.stop().get();
+                }
+            });
+
             startlog.info("Scylla version {} initialization completed.", scylla_version());
             stop_signal.wait().get();
             startlog.info("Signal received; shutting down");

--- a/redis-test/README.md
+++ b/redis-test/README.md
@@ -1,0 +1,14 @@
+Tests for Scylla with Redis API that should also pass, identically, against Redis.
+
+Tests use the redis library for Redis API, and the pytest frameworks
+(both are available from Linux distributions, or with "pip install").
+
+To run all tests against the local installation of Scylla with Redis API on
+localhost:6379, just run `pytest`.
+
+Some additional pytest options:
+* To run all tests in a single file, do `pytest test_strings.py`.
+* To run a single specific test, do `pytest test_strings.py::set`.
+* Additional useful pytest options, especially useful for debugging tests:
+  * -v: show the names of each individual test running instead of just dots.
+  * -s: show the full output of running tests (by default, pytest captures the test's output and only displays it if a test fails)

--- a/redis-test/test_strings.py
+++ b/redis-test/test_strings.py
@@ -1,0 +1,103 @@
+#
+# Copyright (C) 2019 pengjian.uestc @ gmail.com
+#
+#
+# This file is part of Scylla.
+#
+# Scylla is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Scylla is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+import pytest
+import redis
+import logging
+from util import random_string, connect
+
+logger = logging.getLogger('redis-test')
+
+def test_set_get_delete():
+    r = connect()
+    key = random_string(10)
+    val = random_string(10)
+
+    assert r.set(key, val) == True
+    assert r.get(key) == val
+    assert r.delete(key) == 1
+    assert r.get(key) == 0
+
+
+def test_get():
+    r = connect()
+    key = random_string(10)
+    r.delete(key)
+
+    assert r.get(key) == 0
+
+def test_del_existent_key():
+    r = connect()
+    key = random_string(10)
+    val = random_string(10)
+
+    r.set(key, val)
+    assert r.get(key) == val
+    assert r.delete(key) == 1
+
+def test_del_non_existent_key():
+    r = connect()
+    key = random_string(10)
+    r.delete(key)
+    assert r.delete(key) == 0
+
+def test_set_empty_string():
+    r = connect()
+    key = random_string(10)
+    val = ""
+    r.set(key, val)
+    assert r.get(key) == val
+    r.delete(key)
+
+def test_set_large_string():
+    r = connect()
+    key = random_string(10)
+    val = random_string(4096)
+    r.set(key, val)
+    assert r.get(key) == val
+    r.delete(key)
+
+def test_ping():
+    r = connect()
+    assert r.ping() == True
+
+def test_select():
+    r = connect()
+    key = random_string(10)
+    val = random_string(4096)
+    r.set(key, val)
+    assert r.get(key) == val
+
+    logger.debug('Switch to database 1')
+    assert r.execute_command('SELECT 1') == 'OK'
+    assert r.get(key) == None
+
+    logger.debug('Switch back to default database 0')
+    assert r.execute_command('SELECT 0') == 'OK'
+    assert r.get(key) == val
+    r.delete(key)
+    assert r.get(key) == None
+
+    logger.debug('Try to switch to invalid database 16')
+    try:
+        r.execute_command('SELECT 16')
+        raise Exception('Expect that `SELECT 16` does not work')
+    except redis.exceptions.ResponseError as ex:
+        assert str(ex) == 'invalid DB index'

--- a/redis-test/util.py
+++ b/redis-test/util.py
@@ -1,0 +1,31 @@
+#
+# Copyright (C) 2019 pengjian.uestc @ gmail.com
+#
+#
+# This file is part of Scylla.
+#
+# Scylla is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Scylla is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+import string
+import random
+import redis
+
+def connect(host='localhost', port=6379):
+    return redis.Redis(host, port, decode_responses=True)
+
+def random_string(size=10):
+    """Generate a random string of fixed length """
+    letters = string.ascii_lowercase
+    return ''.join(random.choice(letters) for i in range(size))

--- a/redis/abstract_command.cc
+++ b/redis/abstract_command.cc
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2019 pengjian.uestc @ gmail.com
+ */
+
+/*
+ * This file is part of Scylla.
+ *
+ * Scylla is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Scylla is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "abstract_command.hh"
+
+namespace redis {
+
+} // end of redis namespace

--- a/redis/abstract_command.hh
+++ b/redis/abstract_command.hh
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2019 pengjian.uestc @ gmail.com
+ */
+
+/*
+ * This file is part of Scylla.
+ *
+ * Scylla is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Scylla is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+#include "bytes.hh"
+#include "seastar/core/future.hh"
+#include "seastar/core/sstring.hh"
+#include "redis/request.hh"
+#include "redis/reply.hh"
+#include "mutation.hh"
+#include "db/consistency_level_type.hh"
+#include "db/timeout_clock.hh"
+#include "db/system_keyspace.hh"
+#include "service/storage_proxy.hh"
+#include "keys.hh"
+#include "timestamp.hh"
+#include <unordered_map>
+
+class service_permit;
+
+namespace redis {
+
+class redis_options;
+class redis_message;
+
+class abstract_command : public enable_shared_from_this<abstract_command> {
+protected:
+    bytes _name;
+public:
+    abstract_command(bytes&& name)
+        : _name(std::move(name))
+    {
+    }
+    virtual ~abstract_command() {};
+
+    virtual future<redis_message> execute(service::storage_proxy&, redis::redis_options&, service_permit permit) = 0;
+    const bytes& name() const { return _name; }
+};
+
+} // end of redis namespace

--- a/redis/command_factory.cc
+++ b/redis/command_factory.cc
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2019 pengjian.uestc @ gmail.com
+ */
+
+/*
+ * This file is part of Scylla.
+ *
+ * Scylla is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Scylla is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "redis/command_factory.hh"
+#include "service/storage_proxy.hh"
+#include "redis/commands/unknown.hh"
+#include "redis/commands/ping.hh"
+#include "redis/commands/get.hh"
+#include "redis/commands/set.hh"
+#include "redis/commands/del.hh"
+#include "redis/commands/select.hh"
+#include "log.hh"
+
+namespace redis {
+
+static logging::logger logging("command_factory");
+
+shared_ptr<abstract_command> command_factory::create(service::storage_proxy& proxy, request&& req)
+{
+    static thread_local std::unordered_map<bytes, std::function<shared_ptr<abstract_command> (service::storage_proxy& proxy, request&& req)>> _commands =
+    { 
+        { "ping",  [] (service::storage_proxy& proxy, request&& req) { return commands::ping::prepare(proxy, std::move(req)); } }, 
+        { "select",  [] (service::storage_proxy& proxy, request&& req) { return commands::select::prepare(proxy, std::move(req)); } }, 
+        { "get",  [] (service::storage_proxy& proxy, request&& req) { return commands::get::prepare(proxy, std::move(req)); } }, 
+        { "set",  [] (service::storage_proxy& proxy, request&& req) { return commands::set::prepare(proxy, std::move(req)); } }, 
+        { "del",  [] (service::storage_proxy& proxy, request&& req) { return commands::del::prepare(proxy, std::move(req)); } }, 
+    };
+    auto&& command = _commands.find(req._command);
+    if (command != _commands.end()) {
+        return (command->second)(proxy, std::move(req));
+    }
+    auto& b = req._command;
+    logging.error("receive unknown command = {}", sstring(reinterpret_cast<const char*>(b.data()), b.size()));
+    return commands::unknown::prepare(proxy, std::move(req));
+}
+
+}

--- a/redis/command_factory.hh
+++ b/redis/command_factory.hh
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2019 pengjian.uestc @ gmail.com
+ */
+
+/*
+ * This file is part of Scylla.
+ *
+ * Scylla is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Scylla is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "bytes.hh"
+#include "seastar/core/shared_ptr.hh"
+#include "abstract_command.hh"
+#include "redis/options.hh"
+
+namespace service {
+    class storage_proxy;
+}
+
+namespace redis {
+using namespace seastar;
+class request;
+class command_factory {
+public:
+    command_factory() {}
+    ~command_factory() {}
+    static shared_ptr<abstract_command> create(service::storage_proxy&, request&&);
+};
+}

--- a/redis/commands/del.cc
+++ b/redis/commands/del.cc
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2019 pengjian.uestc @ gmail.com
+ */
+
+/*
+ * This file is part of Scylla.
+ *
+ * Scylla is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Scylla is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "redis/commands/del.hh"
+#include "seastar/core/shared_ptr.hh"
+#include "redis/request.hh"
+#include "redis/reply.hh"
+#include "service_permit.hh"
+#include "types.hh"
+#include "service/storage_proxy.hh"
+#include "service/client_state.hh"
+#include "redis/options.hh"
+#include "redis/mutation_utils.hh"
+
+namespace redis {
+
+namespace commands {
+
+shared_ptr<abstract_command> del::prepare(service::storage_proxy& proxy, request&& req)
+{
+    if (req.arguments_size() != 1) {
+        throw wrong_arguments_exception(1, req.arguments_size(), req._command);
+    }
+    return seastar::make_shared<del> (std::move(req._command), std::move(req._args[0]));
+}
+
+future<redis_message> del::execute(service::storage_proxy& proxy, redis::redis_options& options, service_permit permit)
+{
+    return redis::delete_object(proxy, options, std::move(_key), permit).then([] {
+       return redis_message::one();
+    });
+}
+
+}
+}

--- a/redis/commands/del.hh
+++ b/redis/commands/del.hh
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2019 pengjian.uestc @ gmail.com
+ */
+
+/*
+ * This file is part of Scylla.
+ *
+ * Scylla is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Scylla is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "redis/request.hh"
+#include "redis/abstract_command.hh"
+
+namespace redis {
+
+namespace commands {
+
+class del : public abstract_command {
+    bytes _key;
+public:
+    static shared_ptr<abstract_command> prepare(service::storage_proxy& proxy, request&& req);
+    del(bytes&& name, bytes&& key) 
+        : abstract_command(std::move(name)) 
+        , _key(std::move(key))
+    {
+    }
+    ~del() {}
+    future<redis_message> execute(service::storage_proxy&, redis_options&, service_permit) override;
+};
+}
+}

--- a/redis/commands/get.cc
+++ b/redis/commands/get.cc
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2019 pengjian.uestc @ gmail.com
+ */
+
+/*
+ * This file is part of Scylla.
+ *
+ * Scylla is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Scylla is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "redis/commands/get.hh"
+#include "seastar/core/shared_ptr.hh"
+#include "redis/request.hh"
+#include "redis/reply.hh"
+#include "types.hh"
+#include "service_permit.hh"
+#include "service/storage_proxy.hh"
+#include "service/client_state.hh"
+#include "redis/options.hh"
+#include "redis/query_utils.hh"
+
+namespace redis {
+
+namespace commands {
+
+shared_ptr<abstract_command> get::prepare(service::storage_proxy& proxy, request&& req)
+{
+    if (req.arguments_size() != 1) {
+        throw wrong_arguments_exception(1, req.arguments_size(), req._command);
+    }
+    return seastar::make_shared<get> (std::move(req._command), std::move(req._args[0]));
+}
+
+future<redis_message> get::execute(service::storage_proxy& proxy, redis::redis_options& options, service_permit permit)
+{
+    return redis::read_strings(proxy, options, _key, permit).then([] (auto result) {
+        if (result->has_result()) {
+            return redis_message::make_strings_result(std::move(result->result()));
+        }
+        // FIXME: we should returns nil string if key does not exist
+        return redis_message::err();
+    });
+}
+
+}
+}

--- a/redis/commands/get.hh
+++ b/redis/commands/get.hh
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2019 pengjian.uestc @ gmail.com
+ */
+
+/*
+ * This file is part of Scylla.
+ *
+ * Scylla is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Scylla is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "redis/request.hh"
+#include "redis/abstract_command.hh"
+
+namespace redis {
+
+namespace commands {
+
+class get : public abstract_command {
+    bytes _key;
+public:
+    static shared_ptr<abstract_command> prepare(service::storage_proxy& proxy, request&& req);
+    get(bytes&& name, bytes&& key) 
+        : abstract_command(std::move(name)) 
+        , _key(std::move(key))
+    {
+    }
+    ~get() {}
+    future<redis_message> execute(service::storage_proxy&, redis_options&, service_permit) override;
+};
+}
+}

--- a/redis/commands/ping.cc
+++ b/redis/commands/ping.cc
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2019 pengjian.uestc @ gmail.com
+ */
+
+/*
+ * This file is part of Scylla.
+ *
+ * Scylla is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Scylla is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "redis/commands/ping.hh"
+#include "seastar/core/shared_ptr.hh"
+#include "redis/request.hh"
+#include "redis/reply.hh"
+#include "types.hh"
+#include "service/storage_proxy.hh"
+#include "service/client_state.hh"
+#include "redis/options.hh"
+#include "service_permit.hh"
+
+namespace redis {
+
+namespace commands {
+
+shared_ptr<abstract_command> ping::prepare(service::storage_proxy& proxy, request&& req)
+{
+    return seastar::make_shared<ping> (std::move(req._command));
+}
+
+future<redis_message> ping::execute(service::storage_proxy&, redis::redis_options&, service_permit)
+{
+    return redis_message::pong();
+}
+
+}
+}

--- a/redis/commands/ping.hh
+++ b/redis/commands/ping.hh
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2019 pengjian.uestc @ gmail.com
+ */
+
+/*
+ * This file is part of Scylla.
+ *
+ * Scylla is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Scylla is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "redis/request.hh"
+#include "redis/abstract_command.hh"
+
+class service_permit;
+
+namespace redis {
+
+namespace commands {
+
+class ping : public abstract_command {
+public:
+    static shared_ptr<abstract_command> prepare(service::storage_proxy& proxy, request&& req);
+    
+    ping(bytes&& name) : abstract_command(std::move(name))
+    {
+    }
+
+    ~ping()
+    {
+    }
+    
+    future<redis_message> execute(service::storage_proxy&, redis_options&, service_permit) override;
+};
+
+}
+}

--- a/redis/commands/select.cc
+++ b/redis/commands/select.cc
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2019 pengjian.uestc @ gmail.com
+ */
+
+/*
+ * This file is part of Scylla.
+ *
+ * Scylla is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Scylla is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "redis/commands/select.hh"
+#include "seastar/core/shared_ptr.hh"
+#include "redis/request.hh"
+#include "redis/reply.hh"
+#include "types.hh"
+#include "service/storage_proxy.hh"
+#include "service/client_state.hh"
+#include "redis/options.hh"
+#include "service_permit.hh"
+#include <string>
+
+namespace redis {
+
+namespace commands {
+
+shared_ptr<abstract_command> select::prepare(service::storage_proxy& proxy, request&& req)
+{
+    if (req.arguments_size() != 1) {
+        throw wrong_arguments_exception(1, req.arguments_size(), req._command);
+    }
+    long index = -1;
+    try {
+        index = std::stol(std::string(reinterpret_cast<const char*>(req._args[0].data()), req._args[0].size()));
+    }
+    catch (...) {
+        throw invalid_db_index_exception();
+    }
+    return seastar::make_shared<select> (std::move(req._command), index);
+}
+
+future<redis_message> select::execute(service::storage_proxy&, redis::redis_options& options, service_permit)
+{
+    if (_index < 0 || static_cast<size_t>(_index) >= options.get_total_redis_db_count()) {
+        throw invalid_db_index_exception();
+    }
+    options.set_keyspace_name(sprint("REDIS_%zu", static_cast<size_t>(_index)));
+    return redis_message::ok();
+}
+
+}
+}

--- a/redis/commands/select.hh
+++ b/redis/commands/select.hh
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2019 pengjian.uestc @ gmail.com
+ */
+
+/*
+ * This file is part of Scylla.
+ *
+ * Scylla is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Scylla is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "redis/request.hh"
+#include "redis/abstract_command.hh"
+
+class service_permit;
+
+namespace redis {
+
+namespace commands {
+
+class select : public abstract_command {
+    long _index;
+public:
+    static shared_ptr<abstract_command> prepare(service::storage_proxy& proxy, request&& req);
+    
+    select(bytes&& name, long index)
+        : abstract_command(std::move(name))
+        , _index(index)
+    {
+    }
+
+    ~select()
+    {
+    }
+    
+    future<redis_message> execute(service::storage_proxy&, redis_options&, service_permit) override;
+};
+
+}
+}

--- a/redis/commands/set.cc
+++ b/redis/commands/set.cc
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2019 pengjian.uestc @ gmail.com
+ */
+
+/*
+ * This file is part of Scylla.
+ *
+ * Scylla is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Scylla is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "redis/commands/set.hh"
+#include "seastar/core/shared_ptr.hh"
+#include "redis/request.hh"
+#include "redis/reply.hh"
+#include "service_permit.hh"
+#include "types.hh"
+#include "service/storage_proxy.hh"
+#include "service/client_state.hh"
+#include "redis/options.hh"
+#include "redis/mutation_utils.hh"
+
+namespace redis {
+
+namespace commands {
+
+shared_ptr<abstract_command> set::prepare(service::storage_proxy& proxy, request&& req)
+{
+    if (req.arguments_size() != 2) {
+        throw wrong_arguments_exception(2, req.arguments_size(), req._command);
+    }
+    return seastar::make_shared<set> (std::move(req._command), std::move(req._args[0]), std::move(req._args[1]), 0);
+}
+
+future<redis_message> set::execute(service::storage_proxy& proxy, redis::redis_options& options, service_permit permit)
+{
+    return redis::write_strings(proxy, options, std::move(_key), std::move(_data), _ttl, permit).then([] {
+        return redis_message::ok();
+    });
+}
+
+}
+}

--- a/redis/commands/set.hh
+++ b/redis/commands/set.hh
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2019 pengjian.uestc @ gmail.com
+ */
+
+/*
+ * This file is part of Scylla.
+ *
+ * Scylla is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Scylla is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "redis/request.hh"
+#include "redis/abstract_command.hh"
+
+namespace redis {
+
+namespace commands {
+
+class set : public abstract_command {
+    bytes _key;
+    bytes _data;
+    long _ttl = 0;
+public:
+    static shared_ptr<abstract_command> prepare(service::storage_proxy& proxy, request&& req);
+    set(bytes&& name, bytes&& key, bytes&& data, long ttl) 
+        : abstract_command(std::move(name)) 
+        , _key(std::move(key))
+        , _data(std::move(data))
+        , _ttl(ttl)
+    {
+    }
+    set(bytes&& name, bytes&& key, bytes&& data)
+        : set(std::move(name), std::move(key), std::move(data), 0)
+    {
+    }
+    ~set() {}
+    future<redis_message> execute(service::storage_proxy&, redis_options&, service_permit) override;
+};
+}
+}

--- a/redis/commands/unknown.cc
+++ b/redis/commands/unknown.cc
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2019 pengjian.uestc @ gmail.com
+ */
+
+/*
+ * This file is part of Scylla.
+ *
+ * Scylla is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Scylla is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "redis/commands/unknown.hh"
+#include "seastar/core/shared_ptr.hh"
+#include "redis/request.hh"
+#include "redis/reply.hh"
+#include "types.hh"
+#include "service/storage_proxy.hh"
+#include "redis/options.hh"
+#include "service_permit.hh"
+
+namespace redis {
+
+namespace commands {
+
+shared_ptr<abstract_command> unknown::prepare(service::storage_proxy& proxy, request&& req)
+{
+    return seastar::make_shared<unknown> (std::move(req._command));
+}
+
+future<redis_message> unknown::execute(service::storage_proxy&, redis::redis_options&, service_permit)
+{
+    return redis_message::unknown(_name);
+}
+/*
+shared_ptr<abstract_command> unexpected::prepare(service::storage_proxy& proxy, const service::client_state& cs, request&& req)
+{
+    return seastar::make_shared<unexpected> (std::move(req._command));
+}
+
+future<redis_message> unexpected::execute(service::storage_proxy&, service::client_state&, redis::redis_options&)
+{
+    return redis_message::make_exception(_name);
+}
+*/
+}
+}

--- a/redis/commands/unknown.hh
+++ b/redis/commands/unknown.hh
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2019 pengjian.uestc @ gmail.com
+ */
+
+/*
+ * This file is part of Scylla.
+ *
+ * Scylla is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Scylla is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "redis/request.hh"
+#include "redis/abstract_command.hh"
+
+namespace redis {
+
+namespace commands {
+
+class unknown : public abstract_command {
+public:
+    static shared_ptr<abstract_command> prepare(service::storage_proxy& proxy, request&& req);
+    
+    unknown(bytes&& name) : abstract_command(std::move(name))
+    {
+    }
+
+    ~unknown()
+    {
+    }
+    
+    future<redis_message> execute(service::storage_proxy&, redis_options&, service_permit permit) override;
+};
+/*
+class unexpected : public abstract_command {
+public:
+    static shared_ptr<abstract_command> prepare(service::storage_proxy& proxy, const service::client_state& cs, request&& req);
+    
+    unexpected(bytes&& name, bytes&& message) : abstract_command(std::move(name))
+    {
+    }
+
+    ~unexpected()
+    {
+    }
+    
+    future<redis_message> execute(service::storage_proxy&, service::client_state&, redis_options&) override;
+};
+*/
+}
+}

--- a/redis/exceptions.hh
+++ b/redis/exceptions.hh
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2019 pengjian.uestc @ gmail.com
+ */
+
+/*
+ * This file is part of Scylla.
+ *
+ * Scylla is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Scylla is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <stdexcept>
+#include <seastar/core/print.hh>
+
+class redis_exception : public std::exception {
+    sstring _message;
+public:
+    redis_exception(sstring message) : _message(std::move(message)) {}
+    virtual const char* what() const noexcept override { return _message.begin(); }
+    const sstring& what_message() const noexcept { return _message; }
+};
+
+class wrong_arguments_exception : public redis_exception {
+public:
+    wrong_arguments_exception(size_t expected, size_t given, const bytes& command)
+        : redis_exception(sprint("wrong number of arguments (given %ld, expected %ld) for '%s' command", given, expected, sstring(reinterpret_cast<const char*>(command.data()), command.size())))
+    {
+    }
+};
+
+class invalid_arguments_exception : public redis_exception {
+public:
+    invalid_arguments_exception(const bytes& command) : redis_exception(sprint("invalid argument for '%s' command", command)) {}
+};
+
+class invalid_db_index_exception : public redis_exception {
+public:
+    invalid_db_index_exception() : redis_exception("invalid DB index") {}
+};

--- a/redis/keyspace_utils.cc
+++ b/redis/keyspace_utils.cc
@@ -1,0 +1,210 @@
+/*
+ * Copyright (C) 2019 pengjian.uestc @ gmail.com
+ */
+
+/*
+ * This file is part of Scylla.
+ *
+ * Scylla is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Scylla is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "redis/keyspace_utils.hh"
+#include "schema_builder.hh"
+#include "types.hh"
+#include "exceptions/exceptions.hh"
+#include "cql3/statements/ks_prop_defs.hh"
+#include "seastar/core/future.hh"
+#include <memory>
+#include "log.hh"
+#include "db/query_context.hh"
+#include "auth/service.hh"
+#include "service/migration_manager.hh"
+#include "service/client_state.hh"
+#include "service/storage_service.hh"
+#include "transport/server.hh"
+#include "db/system_keyspace.hh"
+#include "schema.hh"
+#include "database.hh"
+#include "gms/gossiper.hh"
+#include <seastar/core/print.hh>
+
+using namespace seastar;
+
+namespace redis {
+
+static logging::logger logger("keyspace_utils");
+schema_ptr strings_schema(sstring ks_name) {
+     schema_builder builder(make_lw_shared(schema(generate_legacy_id(ks_name, redis::STRINGs), ks_name, redis::STRINGs,
+     // partition key
+     {{"pkey", utf8_type}},
+     // clustering key
+     {},
+     // regular columns
+     {{"data", utf8_type}},
+     // static columns
+     {},
+     // regular column name type
+     utf8_type,
+     // comment
+     "save STRINGs for redis"
+    )));
+    builder.set_gc_grace_seconds(0);
+    builder.with(schema_builder::compact_storage::yes);
+    builder.with_version(db::system_keyspace::generate_schema_version(builder.uuid()));
+    return builder.build(schema_builder::compact_storage::yes);
+}
+
+schema_ptr lists_schema(sstring ks_name) {
+     schema_builder builder(make_lw_shared(schema(generate_legacy_id(ks_name, redis::LISTs), ks_name, redis::LISTs,
+     // partition key
+     {{"pkey", utf8_type}},
+     // clustering key
+     {{"ckey", bytes_type}},
+     // regular columns
+     {{"data", utf8_type}},
+     // static columns
+     {},
+     // regular column name type
+     utf8_type,
+     // comment
+     "save LISTs for redis"
+    )));
+    builder.set_gc_grace_seconds(0);
+    builder.with(schema_builder::compact_storage::yes);
+    builder.with_version(db::system_keyspace::generate_schema_version(builder.uuid()));
+    return builder.build(schema_builder::compact_storage::yes);
+}
+
+schema_ptr hashes_schema(sstring ks_name) {
+     schema_builder builder(make_lw_shared(schema(generate_legacy_id(ks_name, redis::HASHes), ks_name, redis::HASHes,
+     // partition key
+     {{"pkey", utf8_type}},
+     // clustering key
+     {{"ckey", utf8_type}},
+     // regular columns
+     {{"data", utf8_type}},
+     // static columns
+     {},
+     // regular column name type
+     utf8_type,
+     // comment
+     "save HASHes for redis"
+    )));
+    builder.set_gc_grace_seconds(0);
+    builder.with(schema_builder::compact_storage::yes);
+    builder.with_version(db::system_keyspace::generate_schema_version(builder.uuid()));
+    return builder.build(schema_builder::compact_storage::yes);
+}
+
+schema_ptr sets_schema(sstring ks_name) {
+     schema_builder builder(make_lw_shared(schema(generate_legacy_id(ks_name, redis::SETs), ks_name, redis::SETs,
+     // partition key
+     {{"pkey", utf8_type}},
+     // clustering key
+     {{"ckey", utf8_type}},
+     // regular columns
+     {},
+     // static columns
+     {},
+     // regular column name type
+     utf8_type,
+     // comment
+     "save SETs for redis"
+    )));
+    builder.set_gc_grace_seconds(0);
+    builder.with(schema_builder::compact_storage::yes);
+    builder.with_version(db::system_keyspace::generate_schema_version(builder.uuid()));
+    return builder.build(schema_builder::compact_storage::yes);
+}
+
+schema_ptr zsets_schema(sstring ks_name) {
+     schema_builder builder(make_lw_shared(schema(generate_legacy_id(ks_name, redis::ZSETs), ks_name, redis::ZSETs,
+     // partition key
+     {{"pkey", utf8_type}},
+     // clustering key
+     {{"ckey", double_type}},
+     // regular columns
+     {{"data", utf8_type}},
+     // static columns
+     {},
+     // regular column name type
+     utf8_type,
+     // comment
+     "save ZSETs for redis"
+    )));
+    builder.set_gc_grace_seconds(0);
+    builder.with(schema_builder::compact_storage::yes);
+    builder.with_version(db::system_keyspace::generate_schema_version(builder.uuid()));
+    return builder.build(schema_builder::compact_storage::yes);
+}
+
+future<> create_keyspace_if_not_exists_impl(db::config& config, int default_replication_factor) {
+    auto keyspace_options = config.redis_keyspace_options();
+    if (keyspace_options.count("class") == 0) {
+        keyspace_options["class"] = "SimpleStrategy";
+        keyspace_options["replication_factor"] = sprint("%d", default_replication_factor);
+    }
+    auto keyspace_gen = [&config, keyspace_options = std::move(keyspace_options)]  (sstring name) {
+        auto& proxy = service::get_local_storage_proxy();
+        if (proxy.get_db().local().has_keyspace(name)) {
+            return make_ready_future<>();
+        }
+        auto attrs = make_shared<cql3::statements::ks_prop_defs>();
+        attrs->add_property(cql3::statements::ks_prop_defs::KW_DURABLE_WRITES, "true");
+        std::map<sstring, sstring> replication_properties;
+        for (auto&& e : keyspace_options) {
+            replication_properties.emplace(e.first, e.second);
+        }
+        attrs->add_property(cql3::statements::ks_prop_defs::KW_REPLICATION, replication_properties); 
+        attrs->validate();
+        const auto& tm = service::get_local_storage_service().get_token_metadata();
+        return service::get_local_migration_manager().announce_new_keyspace(attrs->as_ks_metadata(name, tm), false);
+    };
+    auto table_gen = [] (sstring ks_name, sstring cf_name, schema_ptr schema) {
+        auto& proxy = service::get_local_storage_proxy();
+        if (proxy.get_db().local().has_schema(ks_name, cf_name)) {
+            return make_ready_future<>();
+        }
+        logger.info("Create keyspace: {}, table: {} for redis.", ks_name, cf_name);
+        return service::get_local_migration_manager().announce_new_column_family(schema, false);
+    };
+    // create 16 default database for redis.
+    return parallel_for_each(boost::irange<unsigned>(0, 16), [keyspace_gen = std::move(keyspace_gen), table_gen = std::move(table_gen)] (auto c) {
+        auto ks_name = sprint("REDIS_%d", c);
+        return keyspace_gen(ks_name).then([ks_name, table_gen] {
+            return when_all_succeed(
+                table_gen(ks_name, redis::STRINGs, strings_schema(ks_name)),
+                table_gen(ks_name, redis::LISTs, lists_schema(ks_name)),
+                table_gen(ks_name, redis::SETs, sets_schema(ks_name)),
+                table_gen(ks_name, redis::HASHes, hashes_schema(ks_name)),
+                table_gen(ks_name, redis::ZSETs, zsets_schema(ks_name))
+            ).then([] {
+                return make_ready_future<>();
+            });
+        });
+    });
+}
+
+future<> maybe_create_keyspace(db::config& config) {
+    return gms::get_up_endpoint_count().then([&config] (auto live_endpoint_count) {
+        int replication_factor = 3;
+        if (live_endpoint_count < replication_factor) {
+            replication_factor = 1;
+            logger.warn("Creating keyspace for redis with unsafe, live endpoint nodes count: {}.", live_endpoint_count);
+        }
+        return create_keyspace_if_not_exists_impl(config, replication_factor);
+    });
+}
+
+}

--- a/redis/keyspace_utils.hh
+++ b/redis/keyspace_utils.hh
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2019 pengjian.uestc @ gmail.com
+ */
+
+/*
+ * This file is part of Scylla.
+ *
+ * Scylla is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Scylla is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include  "db/config.hh"
+#include "seastar/core/future.hh"
+#include "seastar/core/sstring.hh"
+
+using namespace seastar;
+
+namespace redis {
+
+static constexpr auto DATA_COLUMN_NAME = "data";
+static constexpr auto STRINGs         = "STRINGs";
+static constexpr auto LISTs           = "LISTs";
+static constexpr auto HASHes          = "HASHes";
+static constexpr auto SETs            = "SETs";
+static constexpr auto ZSETs           = "ZSETs";
+
+future<> maybe_create_keyspace(db::config& cfg);
+
+}

--- a/redis/mutation_utils.cc
+++ b/redis/mutation_utils.cc
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2019 pengjian.uestc @ gmail.com
+ */
+
+/*
+ * This file is part of Scylla.
+ *
+ * Scylla is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Scylla is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "redis/mutation_utils.hh"
+#include "types.hh"
+#include "service/storage_service.hh"
+#include "schema.hh"
+#include "database.hh"
+#include <seastar/core/print.hh>
+#include "redis/keyspace_utils.hh"
+#include "redis/options.hh"
+#include "mutation.hh"
+#include "service_permit.hh"
+
+using namespace seastar;
+
+namespace redis {
+
+atomic_cell make_cell(const schema_ptr schema,
+        const abstract_type& type,
+        bytes_view value,
+        long cttl = 0)
+{
+
+    if (cttl > 0) {
+        auto ttl = std::chrono::seconds(cttl);
+        return atomic_cell::make_live(type, api::new_timestamp(), value, gc_clock::now() + ttl, ttl, atomic_cell::collection_member::no);
+    }   
+    auto ttl = schema->default_time_to_live();
+    if (ttl.count() > 0) {
+        return atomic_cell::make_live(type, api::new_timestamp(), value, gc_clock::now() + ttl, ttl, atomic_cell::collection_member::no);
+    }   
+    return atomic_cell::make_live(type, api::new_timestamp(), value, atomic_cell::collection_member::no);
+}  
+
+mutation make_mutation(service::storage_proxy& proxy, const redis_options& options, bytes&& key, bytes&& data, long ttl) {
+    auto schema = get_schema(proxy, options.get_keyspace_name(), redis::STRINGs);
+    const column_definition& column = *schema->get_column_definition(redis::DATA_COLUMN_NAME);
+    auto pkey = partition_key::from_single_value(*schema, key);
+    auto m = mutation(schema, std::move(pkey));
+    auto cell = make_cell(schema, *(column.type.get()), data, ttl);
+    m.set_clustered_cell(clustering_key::make_empty(), column, std::move(cell));
+    return m;
+}
+
+future<> write_strings(service::storage_proxy& proxy, redis::redis_options& options, bytes&& key, bytes&& data, long ttl, service_permit permit) {
+    db::timeout_clock::time_point timeout = db::timeout_clock::now() + options.get_write_timeout();
+    auto m = make_mutation(proxy, options, std::move(key), std::move(data), ttl);
+    auto write_consistency_level = options.get_write_consistency_level();
+    return proxy.mutate(std::vector<mutation> {std::move(m)}, write_consistency_level, timeout, nullptr, permit);
+}
+
+
+mutation make_tombstone(service::storage_proxy& proxy, const redis_options& options, const sstring& cf_name, const bytes& key) {
+    auto schema = get_schema(proxy, options.get_keyspace_name(), cf_name);
+    auto pkey = partition_key::from_single_value(*schema, key);
+    auto m = mutation(schema, std::move(pkey));
+    m.partition().apply(tombstone { api::new_timestamp(), gc_clock::now() }); 
+    return m;
+}
+
+future<> delete_object(service::storage_proxy& proxy, redis::redis_options& options, bytes&& key, service_permit permit) {
+    
+    db::timeout_clock::time_point timeout = db::timeout_clock::now() + options.get_write_timeout();
+    auto write_consistency_level = options.get_write_consistency_level();
+    std::vector<sstring> tables { redis::STRINGs, redis::LISTs, redis::HASHes, redis::SETs, redis::ZSETs }; 
+    
+    auto remove = [&proxy, timeout, write_consistency_level, permit, &options, key = std::move(key)] (const sstring& cf_name) {
+        auto m = make_tombstone(proxy, options, cf_name, key);
+        return proxy.mutate(std::vector<mutation> {std::move(m)}, write_consistency_level, timeout, nullptr, permit);
+    };  
+    return parallel_for_each(tables.begin(), tables.end(), remove);
+}
+
+}

--- a/redis/mutation_utils.hh
+++ b/redis/mutation_utils.hh
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2019 pengjian.uestc @ gmail.com
+ */
+
+/*
+ * This file is part of Scylla.
+ *
+ * Scylla is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Scylla is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+#include "types.hh"
+
+class service_permit;
+
+namespace service {
+class storage_proxy;
+}
+
+class mutation;
+namespace redis {
+
+class redis_options;
+
+future<> write_strings(service::storage_proxy& proxy, redis::redis_options& options, bytes&& key, bytes&& data, long ttl, service_permit permit);
+future<> delete_object(service::storage_proxy& proxy, redis::redis_options& options, bytes&& key, service_permit permit);
+
+}

--- a/redis/options.cc
+++ b/redis/options.cc
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2019 pengjian.uestc @ gmail.com
+ */
+
+/*
+ * This file is part of Scylla.
+ *
+ * Scylla is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Scylla is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "redis/options.hh"
+#include "types.hh"
+#include "service/storage_service.hh"
+#include "service/storage_proxy.hh"
+#include "schema.hh"
+#include "database.hh"
+#include <seastar/core/print.hh>
+#include "redis/keyspace_utils.hh"
+
+using namespace seastar;
+
+namespace redis {
+
+schema_ptr get_schema(service::storage_proxy& proxy, const sstring& ks_name, const sstring& cf_name) {
+    auto& db = proxy.get_db().local();
+    auto schema = db.find_schema(ks_name, cf_name);
+    return schema;
+}
+
+}

--- a/redis/options.hh
+++ b/redis/options.hh
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) 2019 pengjian.uestc @ gmail.com
+ */
+
+/*
+ * This file is part of Scylla.
+ *
+ * Scylla is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Scylla is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <stdexcept>
+#include "timeout_config.hh"
+#include "db/consistency_level_type.hh"
+#include "seastar/core/sstring.hh"
+#include "seastar/net/socket_defs.hh"
+#include "schema.hh"
+#include "service/client_state.hh"
+#include "auth/service.hh"
+
+using namespace seastar;
+
+namespace service {
+class storage_proxy;
+}
+
+namespace redis {
+
+class redis_options {
+    sstring _ks_name;
+    const db::consistency_level _read_consistency;
+    const db::consistency_level _write_consistency;
+    const timeout_config& _timeout_config;
+    service::client_state _client_state;
+    size_t _total_redis_db_count;
+public:
+    //redis_options(redis_options&&) = default;
+    
+    //explicit redis_options(const redis_options&) = default;
+   
+    explicit redis_options(const db::consistency_level rcl,
+        const db::consistency_level wcl,
+        const timeout_config& tc,
+        auth::service& auth,
+        const socket_address addr,
+        size_t total_redis_db_count)
+        :_ks_name("REDIS_0")
+        ,_read_consistency(rcl)
+        ,_write_consistency(wcl)
+        ,_timeout_config(tc)
+        ,_client_state(service::client_state::external_tag{}, auth, addr)
+        ,_total_redis_db_count(total_redis_db_count)
+    {
+    }
+    explicit redis_options(const sstring& ks_name,
+        const db::consistency_level rcl,
+        const db::consistency_level wcl,
+        const timeout_config& tc,
+        auth::service& auth,
+        const socket_address addr,
+        size_t total_redis_db_count)
+        :_ks_name(ks_name)
+        ,_read_consistency(rcl)
+        ,_write_consistency(wcl)
+        ,_timeout_config(tc)
+        ,_client_state(service::client_state::external_tag{}, auth, addr)
+        ,_total_redis_db_count(total_redis_db_count)
+    {
+    }
+
+    const db::consistency_level get_read_consistency_level() const { return _read_consistency; }
+    const db::consistency_level get_write_consistency_level() const { return _write_consistency; }
+
+    const timeout_config& get_timeout_config() const { return _timeout_config; }
+    const db::timeout_clock::duration get_read_timeout() const { return _timeout_config.read_timeout; }
+    const db::timeout_clock::duration get_write_timeout() const { return _timeout_config.write_timeout; }
+    const sstring& get_keyspace_name() const { return _ks_name; }
+    service::client_state& get_client_state() { return _client_state; }
+
+    void set_keyspace_name(const sstring ks_name) { _ks_name = ks_name; }
+    size_t get_total_redis_db_count() const { return _total_redis_db_count; }
+};
+
+schema_ptr get_schema(service::storage_proxy& proxy, const sstring& ks_name, const sstring& cf_name);
+
+}

--- a/redis/protocol_parser.rl
+++ b/redis/protocol_parser.rl
@@ -1,0 +1,141 @@
+/*
+ * Copyright (C) 2019 pengjian.uestc @ gmail.com
+ */
+
+/*
+ * This file is part of Scylla.
+ *
+ * Scylla is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Scylla is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <memory>
+#include <iostream>
+#include <algorithm>
+#include <functional>
+#include "bytes.hh"
+#include "redis/request.hh"
+#include <seastar/core/ragel.hh>
+
+using namespace seastar;
+using namespace redis;
+%%{
+
+machine redis_resp_protocol;
+
+access _fsm_;
+
+action mark {
+    g.mark_start(p);
+}
+
+action start_blob {
+    g.mark_start(p);
+    _size_left = _arg_size;
+}
+
+action start_command {
+    g.mark_start(p);
+    _size_left = _arg_size;
+}
+
+action advance_blob {
+    auto len = std::min(static_cast<uint32_t>(pe - p), _size_left);
+    _size_left -= len;
+    p += len;
+    if (_size_left == 0) {
+      _req._args.push_back(str());
+      p--;
+      fret;
+    }
+    p--;
+}
+
+action advance_command {
+    auto len = std::min(static_cast<uint32_t>(pe - p), _size_left);
+    _size_left -= len;
+    p += len;
+    if (_size_left == 0) {
+      _req._command = str();
+      p--;
+      fret;
+    }
+    p--;
+}
+
+
+crlf = '\r\n';
+u32 = digit+ >{ _u32 = 0;}  ${ _u32 *= 10; _u32 += fc - '0';};
+args_count = '*' u32 crlf ${_req._args_count = _u32 - 1;};
+blob := any+ >start_blob $advance_blob;
+command := any+ >start_command $advance_command;
+arg = '$' u32 crlf ${ _arg_size = _u32;};
+
+main := (args_count (arg @{fcall command; } crlf) (arg @{fcall blob; } crlf)+) ${_req._state = request_state::ok;};
+
+prepush {
+    prepush();
+}
+
+postpop {
+    postpop();
+}
+
+}%%
+
+class redis_protocol_parser : public ragel_parser_base<redis_protocol_parser> {
+    %% write data nofinal noprefix;
+public:
+    redis::request _req;
+    uint32_t _u32;
+    uint32_t _arg_size;
+    uint32_t _size_left;
+public:
+    virtual void init() {
+        init_base();
+        _req._state = request_state::error;
+        _req._args.clear();
+        _req._args_count = 0;
+        _size_left = 0;
+        _arg_size = 0;
+        %% write init;
+    }
+
+    char* parse(char* p, char* pe, char* eof) {
+        sstring_builder::guard g(_builder, p, pe);
+        auto str = [this, &g, &p] {
+            g.mark_end(p);
+            auto s =  get_str();
+            return to_bytes(s);
+        };
+
+        %% write exec;
+        if (_req._state != request_state::error) {
+            return p;
+        }
+        if (p != pe) {
+            p = pe;
+            return p;
+        }
+        return nullptr;
+    }
+    
+    bool eof() const {
+        return _req._state == request_state::eof;
+    }
+    
+    redis::request& get_request() { 
+        std::transform(_req._command.begin(), _req._command.end(), _req._command.begin(), ::tolower);
+        return _req;
+    }
+};

--- a/redis/query_processor.cc
+++ b/redis/query_processor.cc
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2019 pengjian.uestc @ gmail.com
+ */
+
+/*
+ * This file is part of Scylla.
+ *
+ * Scylla is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Scylla is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "redis/query_processor.hh"
+#include "redis/request.hh"
+#include "redis/reply.hh"
+#include "redis/command_factory.hh"
+#include "timeout_config.hh"
+#include "redis/options.hh"
+#include "service_permit.hh"
+
+namespace redis {
+
+distributed<query_processor> _the_query_processor;
+
+query_processor::query_processor(service::storage_proxy& proxy, distributed<database>& db)
+        : _proxy(proxy)
+        , _db(db)
+{
+}
+
+query_processor::~query_processor() {
+}
+
+future<> query_processor::start() {
+    return make_ready_future<>();
+}
+
+future<> query_processor::stop() {
+    // wait for all running command finished.
+    return _pending_command_gate.close().then([] {
+        return make_ready_future<>();
+    });
+}
+
+future<redis_message> query_processor::process(request&& req, redis::redis_options& opts, service_permit permit) {
+    return with_gate(_pending_command_gate, [this, req = std::move(req), &opts, permit] () mutable {
+        return do_with(command_factory::create(_proxy, std::move(req)), [this, &opts, permit] (auto& e) {
+           return e->execute(_proxy, seastar::ref(opts), permit);
+        });
+    });
+}
+
+}

--- a/redis/query_processor.hh
+++ b/redis/query_processor.hh
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2019 pengjian.uestc @ gmail.com
+ */
+
+/*
+ * This file is part of Scylla.
+ *
+ * Scylla is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Scylla is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <seastar/core/distributed.hh>
+#include <seastar/core/shared_ptr.hh>
+#include <seastar/core/gate.hh>
+#include <seastar/core/metrics_registration.hh>
+
+
+using namespace seastar;
+
+class database;
+class service_permit;
+
+namespace service {
+class storage_proxy;
+}
+
+namespace redis {
+
+class redis_options;
+struct request;
+struct reply;
+class redis_message;
+
+class query_processor {
+    service::storage_proxy& _proxy;
+    distributed<database>& _db;
+    seastar::metrics::metric_groups _metrics;
+    seastar::gate _pending_command_gate;
+public:
+    query_processor(service::storage_proxy& proxy, distributed<database>& db);
+
+    ~query_processor();
+
+    distributed<database>& db() {
+        return _db;
+    }
+
+    service::storage_proxy& proxy() {
+        return _proxy;
+    }
+
+    future<redis_message> process(request&&, redis_options&, service_permit);
+
+    future<> start();
+    future<> stop();
+};
+
+}

--- a/redis/query_utils.cc
+++ b/redis/query_utils.cc
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2019 pengjian.uestc @ gmail.com
+ */
+
+/*
+ * This file is part of Scylla.
+ *
+ * Scylla is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Scylla is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#include "redis/query_utils.hh"
+#include "redis/options.hh"
+#include "timeout_config.hh"
+#include "service/client_state.hh"
+#include "service/storage_proxy.hh"
+#include "dht/i_partitioner.hh"
+#include "partition_slice_builder.hh"
+#include "query-result-reader.hh"
+#include "gc_clock.hh"
+#include "service_permit.hh"
+#include "redis/keyspace_utils.hh"
+
+namespace redis {
+class strings_result_builder {
+    lw_shared_ptr<strings_result> _data;
+    const query::partition_slice& _partition_slice;
+    const schema_ptr _schema;
+private:
+    void add_cell(const column_definition& col, const std::optional<query::result_atomic_cell_view>& cell)
+    {
+        if (cell) {
+            cell->value().with_linearized([this, &col] (bytes_view cell_view) {
+                auto&& dv = col.type->deserialize_value(cell_view);
+                auto&& d = dv.serialize();
+                _data->_result = std::move(d);
+                _data->_has_result = true;
+            });
+        }
+    }
+public:
+    strings_result_builder(lw_shared_ptr<strings_result> data, const schema_ptr schema, const query::partition_slice& ps)
+        : _data(data)
+        , _partition_slice(ps)
+        , _schema(schema)
+    {
+    }
+    void accept_new_partition(const partition_key& key, uint32_t row_count) {}
+    void accept_new_partition(uint32_t row_count) {}
+    void accept_new_row(const clustering_key& key, const query::result_row_view& static_row, const query::result_row_view& row)
+    {
+        auto row_iterator = row.iterator();
+        for (auto&& id : _partition_slice.regular_columns) {
+            add_cell(_schema->regular_column_at(id), row_iterator.next_atomic_cell());
+        }
+    }
+    void accept_new_row(const query::result_row_view& static_row, const query::result_row_view& row) {}
+    void accept_partition_end(const query::result_row_view& static_row) {}
+};
+
+future<lw_shared_ptr<strings_result>> read_strings(service::storage_proxy& proxy, const redis_options& options, const bytes& key, service_permit permit) {
+    auto schema = get_schema(proxy, options.get_keyspace_name(), redis::STRINGs);
+    auto ps = partition_slice_builder(*schema).build();
+    query::read_command cmd(schema->id(), schema->version(), ps, 1, gc_clock::now(), std::nullopt, 1); 
+    auto pkey = partition_key::from_single_value(*schema, key);
+    auto partition_range = dht::partition_range::make_singular(dht::global_partitioner().decorate_key(*schema, std::move(pkey)));
+    dht::partition_range_vector partition_ranges;
+    partition_ranges.emplace_back(std::move(partition_range));
+    auto read_consistency_level = options.get_read_consistency_level();
+    db::timeout_clock::time_point timeout = db::timeout_clock::now() + options.get_read_timeout();
+    return proxy.query(schema, make_lw_shared(std::move(cmd)), std::move(partition_ranges), read_consistency_level, {timeout, permit, service::client_state::for_internal_calls()}).then([ps, schema] (auto qr) {
+        return query::result_view::do_with(*qr.query_result, [&] (query::result_view v) {
+            auto pd = make_lw_shared<strings_result>();
+            v.consume(ps, strings_result_builder(pd, schema, ps));
+            return pd;
+        }); 
+    }); 
+}
+
+}

--- a/redis/query_utils.hh
+++ b/redis/query_utils.hh
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2019 pengjian.uestc @ gmail.com
+ */
+
+/*
+ * This file is part of Scylla.
+ *
+ * Scylla is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Scylla is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "seastar/core/shared_ptr.hh"
+#include "seastar/core/future.hh"
+#include "bytes.hh"
+
+using namespace seastar;
+
+namespace service {
+class storage_proxy;
+class client_state;
+}
+
+class service_permit;
+
+namespace redis {
+
+class redis_options;
+
+struct strings_result {
+    bytes _result;
+    bool _has_result;
+    bytes& result() { return _result; }
+    bool has_result() const { return _has_result; }
+};
+
+future<lw_shared_ptr<strings_result>> read_strings(service::storage_proxy&, const redis_options&, const bytes&, service_permit);
+
+}

--- a/redis/reply.hh
+++ b/redis/reply.hh
@@ -1,0 +1,105 @@
+/*
+ * Copyright (C) 2019 pengjian.uestc @ gmail.com
+ */
+
+/*
+ * This file is part of Scylla.
+ *
+ * Scylla is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Scylla is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "bytes.hh"
+#include "seastar/core/sharded.hh"
+#include "seastar/core/shared_ptr.hh"
+#include <seastar/core/print.hh>
+#include "seastar/core/scattered_message.hh"
+#include "redis/exceptions.hh"
+
+using namespace seastar;
+
+namespace redis {
+
+class redis_message final {
+    seastar::lw_shared_ptr<scattered_message<char>> _message;
+public:
+    redis_message() = delete;
+    redis_message(const redis_message&) = delete;
+    redis_message& operator=(const redis_message&) = delete;
+    redis_message(redis_message&& o) noexcept : _message(std::move(o._message)) {}
+    redis_message(lw_shared_ptr<scattered_message<char>> m) noexcept : _message(m) {}
+    static future<redis_message> ok() {
+        auto m = make_lw_shared<scattered_message<char>> ();
+        m->append_static("+OK\r\n");
+        return make_ready_future<redis_message>(m);
+    }
+    static future<redis_message> pong() {
+        auto m = make_lw_shared<scattered_message<char>> ();
+        m->append_static("+PONG\r\n");
+        return make_ready_future<redis_message>(m);
+    }
+    static future<redis_message> err() {
+        auto m = make_lw_shared<scattered_message<char>> ();
+        m->append_static(":0\r\n");
+        return make_ready_future<redis_message>(m);
+    }
+    static future<redis_message> one() {
+        auto m = make_lw_shared<scattered_message<char>> ();
+        m->append_static(":1\r\n");
+        return make_ready_future<redis_message>(m);
+    }
+    static future<redis_message> zero() {
+        return err();
+    }
+    static future<redis_message> make_strings_result(bytes result) {
+        auto m = make_lw_shared<scattered_message<char>> ();
+        write_bytes(m, result);
+        return make_ready_future<redis_message>(m);
+    }
+    static future<redis_message> unknown(const bytes& name) {
+        return from_exception(make_message("-ERR unknown command '%s'\r\n", to_sstring(name)));
+    }
+    static future<redis_message> exception(const redis_exception& e) {
+        return from_exception(make_message("-ERR %s\r\n", e.what_message()));
+    }
+    static future<redis_message> make_exception(const sstring& em) {
+        return from_exception(make_message("-ERR %s\r\n", em)); 
+    }
+    inline lw_shared_ptr<scattered_message<char>> message() { return _message; }
+private:
+    static future<redis_message> from_exception(sstring data) {
+         auto m = make_lw_shared<scattered_message<char>> (); 
+         m->append(data);
+         return make_ready_future<redis_message>(m);
+    }  
+    template<typename... Args>
+    static inline sstring make_message(const char* fmt, Args&&... args) noexcept {
+        try {
+            return sprint(fmt, std::forward<Args>(args)...);
+        } catch (...) {
+            return sstring();
+        }   
+    }
+    static sstring to_sstring(const bytes& b) {
+        return sstring(reinterpret_cast<const char*>(b.data()), b.size());
+    }
+    static void write_bytes(lw_shared_ptr<scattered_message<char>> m, bytes& b) {
+        m->append(sstring(sprint("$%d\r\n", b.size())));
+        m->append(sstring(reinterpret_cast<const char*>(b.data()), b.size()));
+        m->append_static("\r\n");
+    }   
+};
+
+}

--- a/redis/request.hh
+++ b/redis/request.hh
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2019 pengjian.uestc @ gmail.com
+ */
+
+/*
+ * This file is part of Scylla.
+ *
+ * Scylla is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Scylla is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <vector>
+#include "bytes.hh"
+
+namespace redis {
+
+    enum class request_state {
+    error,
+    eof,
+    ok, 
+};
+
+struct request {
+    request_state _state; 
+    bytes _command;
+    uint32_t _args_count;
+    std::vector<bytes> _args;
+    size_t arguments_size() const { return _args.size(); }
+    size_t total_request_size() const {
+        size_t r = 0;
+        for (size_t i = 0; i < _args.size(); ++i) {
+            r += _args[i].size();
+        }
+        return r;
+    }
+};
+
+}

--- a/redis/server.cc
+++ b/redis/server.cc
@@ -1,0 +1,272 @@
+/*
+ * Copyright (C) 2019 pengjian.uestc @ gmail.com
+ */
+
+/*
+ * This file is part of Scylla.
+ *
+ * Scylla is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Scylla is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "redis/server.hh"
+#include "service/storage_service.hh"
+#include "db/consistency_level_type.hh"
+#include "db/config.hh"
+#include "db/write_type.hh"
+#include <seastar/core/future-util.hh>
+#include <seastar/core/reactor.hh>
+#include <seastar/net/byteorder.hh>
+#include <seastar/core/execution_stage.hh>
+#include "service/query_state.hh"
+#include "exceptions/exceptions.hh"
+#include "auth/authenticator.hh"
+#include <cassert>
+#include <string>
+#include "redis/request.hh"
+#include "redis/reply.hh"
+#include <unordered_map>
+
+namespace redis_transport {
+
+static logging::logger logging("redis_server");
+
+redis_server::redis_server(distributed<service::storage_proxy>& proxy, distributed<redis::query_processor>& qp, auth::service& auth_service, redis_server_config config)
+    : _proxy(proxy)
+    , _query_processor(qp)
+    , _config(config)
+    , _max_request_size(config._max_request_size)
+    , _memory_available(_max_request_size)
+    , _auth_service(auth_service)
+    , _total_redis_db_count(config._total_redis_db_count)
+{
+}
+
+future<> redis_server::stop() {
+    _stopping = true;
+    size_t nr = 0;
+    size_t nr_total = _listeners.size();
+    logging.debug("redis_server: abort accept nr_total={}", nr_total);
+    for (auto&& l : _listeners) {
+        l.abort_accept();
+        logging.debug("redis_server: abort accept {} out of {} done", ++nr, nr_total);
+    }
+    auto nr_conn = make_lw_shared<size_t>(0);
+    auto nr_conn_total = _connections_list.size();
+    logging.debug("redis_server: shutdown connection nr_total={}", nr_conn_total);
+    return parallel_for_each(_connections_list.begin(), _connections_list.end(), [nr_conn, nr_conn_total] (auto&& c) {
+        return c.shutdown().then([nr_conn, nr_conn_total] {
+            logging.debug("redis_server: shutdown connection {} out of {} done", ++(*nr_conn), nr_conn_total);
+        });
+    }).then([this] {
+        return std::move(_stopped);
+    });
+}
+
+future<> redis_server::listen(socket_address addr, std::shared_ptr<seastar::tls::credentials_builder> creds, bool keepalive) {
+    listen_options lo;
+    lo.reuse_address = true;
+    server_socket ss;
+    try {
+        ss = creds
+          ? seastar::tls::listen(creds->build_server_credentials(), addr, lo)
+          : engine().listen(addr, lo);
+    } catch (...) {
+        throw std::runtime_error(sprint("Redis server error while listening on %s -> %s", addr, std::current_exception()));
+    }
+    _listeners.emplace_back(std::move(ss));
+    _stopped = when_all(std::move(_stopped), do_accepts(_listeners.size() - 1, keepalive, addr)).discard_result();
+    return make_ready_future<>();
+}
+
+future<> redis_server::do_accepts(int which, bool keepalive, socket_address server_addr) {
+    return repeat([this, which, keepalive, server_addr] {
+        ++_stats._connections_being_accepted;
+        return _listeners[which].accept().then_wrapped([this, which, keepalive, server_addr] (future<accept_result> f_cs_sa) mutable {
+            --_stats._connections_being_accepted;
+            if (_stopping) {
+                f_cs_sa.ignore_ready_future();
+                maybe_idle();
+                return stop_iteration::yes;
+            }
+            auto cs_sa = f_cs_sa.get0();
+            auto fd = std::move(cs_sa.connection);
+            auto addr = std::move(cs_sa.remote_address);
+            fd.set_nodelay(true);
+            fd.set_keepalive(keepalive);
+            auto conn = make_shared<connection>(*this, server_addr, std::move(fd), std::move(addr));
+            ++_stats._connects;
+            ++_stats._connections;
+            (void)conn->process().then_wrapped([this, conn] (future<> f) {
+                --_stats._connections;
+                try {
+                    f.get();
+                } catch (...) {
+                    logging.debug("connection error: {}", std::current_exception());
+                }
+            });
+            return stop_iteration::no;
+        }).handle_exception([] (auto ep) {
+            logging.debug("accept failed: {}", ep);
+            return stop_iteration::no;
+        });
+    });
+}
+
+future<redis_server::result> redis_server::connection::process_request_one(redis::request&& request, redis::redis_options& opts, service_permit permit) {
+    return futurize_apply([this, request = std::move(request), &opts, permit] () mutable {
+        return _server._query_processor.local().process(std::move(request), seastar::ref(opts), permit).then([] (auto&& message) {
+            return make_ready_future<redis_server::result> (std::move(message));
+        });
+    });
+}
+
+redis_server::connection::connection(redis_server& server, socket_address server_addr, connected_socket&& fd, socket_address addr)
+    : _server(server)
+    , _server_addr(server_addr)
+    , _fd(std::move(fd))
+    , _read_buf(_fd.input())
+    , _write_buf(_fd.output())
+    , _options(server._config._read_consistency_level, server._config._write_consistency_level, server._config._timeout_config, server._auth_service, addr, server._total_redis_db_count)
+{
+    ++_server._stats._total_connections;
+    ++_server._stats._current_connections;
+    _server._connections_list.push_back(*this);
+}
+
+redis_server::connection::~connection() {
+    --_server._stats._current_connections;
+    _server._connections_list.erase(_server._connections_list.iterator_to(*this));
+    _server.maybe_idle();
+}
+
+future<> redis_server::connection::process()
+{
+    return do_until([this] {
+        return _read_buf.eof();
+    }, [this] {
+        return with_gate(_pending_requests_gate, [this] {
+            return process_request().then_wrapped([this] (auto f) {
+                try {
+                    f.get();
+                }
+                catch (redis_exception& e) {
+                    write_reply(e);
+                }
+                catch (std::exception& e) {
+                    write_reply(redis_exception { e.what() });
+                }
+                catch (...) {
+                    write_reply(redis_exception { "Unknown exception" });
+                }
+            });
+        });
+    }).finally([this] {
+        return _pending_requests_gate.close().then([this] {
+            return _ready_to_respond.finally([this] {
+                return _write_buf.close();
+            });
+        });
+    });
+}
+
+future<> redis_server::connection::shutdown()
+{
+    try {
+        _fd.shutdown_input();
+        _fd.shutdown_output();
+    } catch (...) {
+    }
+    return make_ready_future<>();
+}
+
+thread_local redis_server::connection::execution_stage_type redis_server::connection::_process_request_stage {"redis_transport", &connection::process_request_one};
+
+future<redis_server::result> redis_server::connection::process_request_internal() {
+    return _process_request_stage(this, std::move(_parser.get_request()), seastar::ref(_options), empty_service_permit());
+}
+
+void redis_server::connection::write_reply(const redis_exception& e)
+{
+    _ready_to_respond = _ready_to_respond.then([this, exception_message = e.what_message()] () mutable {
+        return redis_message::make_exception(exception_message).then([this] (auto&& result) {
+            auto m = result.message();
+            return _write_buf.write(std::move(*m)).then([this] {
+                return _write_buf.flush();
+            });
+        });
+    });
+}
+
+void redis_server::connection::write_reply(redis_server::result result)
+{
+    _ready_to_respond = _ready_to_respond.then([this, result = std::move(result)] () mutable {
+        auto m = result.make_message();
+        return _write_buf.write(std::move(*m)).then([this] {
+            return _write_buf.flush();
+        });
+    });
+}
+future<> redis_server::connection::process_request() {
+    _parser.init();
+    return _read_buf.consume(_parser).then([this] {
+        ++_server._stats._requests_serving;
+        _pending_requests_gate.enter();
+        utils::latency_counter lc;
+        lc.start();
+        auto leave = defer([this] { _pending_requests_gate.leave(); });
+        return process_request_internal().then([this, leave = std::move(leave), lc = std::move(lc)] (auto&& result) mutable {
+            --_server._stats._requests_serving;
+            try {
+                write_reply(std::move(result));
+                ++_server._stats._requests_served;
+                _server._stats._requests.mark(lc.stop().latency());
+                if (lc.is_start()) {
+                    _server._stats._estimated_requests_latency.add(lc.latency(), _server._stats._requests.hist.count);
+                }
+            } catch (...) {
+                logging.error("request processing failed: {}", std::current_exception());
+            }
+        });
+    });
+}
+
+static inline bytes_view to_bytes_view(temporary_buffer<char>& b)
+{
+    using byte = bytes_view::value_type;
+    return bytes_view(reinterpret_cast<const byte*>(b.get()), b.size());
+}
+
+}
+
+db::consistency_level make_consistency_level(const sstring& level)
+{
+    std::unordered_map<sstring, db::consistency_level> consistency_levels {
+        {"ONE", db::consistency_level::ONE},
+        {"QUORUM", db::consistency_level::QUORUM},
+        {"LOCAL_QUORUM", db::consistency_level::LOCAL_QUORUM},
+        {"EACH_QUORUM", db::consistency_level::EACH_QUORUM},
+        {"ALL", db::consistency_level::ALL},
+        {"ANY", db::consistency_level::ANY},
+        {"TWO", db::consistency_level::TWO},
+        {"THREE", db::consistency_level::THREE},
+        {"SERIAL", db::consistency_level::SERIAL},
+        {"LOCAL_SERIAL", db::consistency_level::LOCAL_SERIAL},
+        {"LOCAL_ONE", db::consistency_level::LOCAL_ONE},
+    };
+    auto iter_cl = consistency_levels.find(level);
+    if (iter_cl == consistency_levels.end()) {
+        return db::consistency_level::ONE;
+    }
+    return iter_cl->second;
+}

--- a/redis/server.hh
+++ b/redis/server.hh
@@ -1,0 +1,148 @@
+/*
+ * Copyright (C) 2019 pengjian.uestc @ gmail.com
+ */
+
+/*
+ * This file is part of Scylla.
+ *
+ * Scylla is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Scylla is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "auth/service.hh"
+#include "service/storage_proxy.hh"
+#include "service_permit.hh"
+#include "redis/query_processor.hh"
+#include "redis/request.hh"
+#include "cql3/values.hh"
+#include "auth/authenticator.hh"
+#include "timeout_config.hh"
+#include <memory>
+#include <seastar/net/tls.hh>
+#include <seastar/core/semaphore.hh>
+#include "seastar/core/distributed.hh"
+#include "seastar/core/reactor.hh"
+#include "utils/fragmented_temporary_buffer.hh"
+#include "utils/estimated_histogram.hh"
+#include "redis/protocol_parser.hh"
+#include "redis/request.hh"
+#include "redis/reply.hh"
+#include "redis/options.hh"
+#include  "service/client_state.hh"
+#include "redis/stats.hh"
+
+db::consistency_level make_consistency_level(const sstring&);
+
+namespace db {
+class config;
+};
+class redis_exception;
+
+namespace redis_transport {
+
+struct redis_server_config {
+    ::timeout_config _timeout_config;
+    size_t _max_request_size;
+    db::consistency_level _read_consistency_level;
+    db::consistency_level _write_consistency_level;
+    size_t _total_redis_db_count;
+};
+
+class redis_server {
+    std::vector<server_socket> _listeners;
+    distributed<service::storage_proxy>& _proxy;
+    distributed<redis::query_processor>& _query_processor;
+    redis_server_config _config;
+    size_t _max_request_size;
+    semaphore _memory_available;
+    redis::stats _stats;
+private:
+    uint64_t _requests_blocked_memory = 0;
+    auth::service& _auth_service;
+    size_t _total_redis_db_count;
+public:
+    redis_server(distributed<service::storage_proxy>& proxy, distributed<redis::query_processor>& qp, auth::service& auth_service, redis_server_config config);
+    future<> listen(socket_address addr, std::shared_ptr<seastar::tls::credentials_builder> = {}, bool keepalive = false);
+    future<> do_accepts(int which, bool keepalive, socket_address server_addr);
+    future<> stop();
+public:
+    struct result {
+        result(redis::redis_message&& m) : _data(make_foreign(std::make_unique<redis::redis_message>(std::move(m)))) {}
+        foreign_ptr<std::unique_ptr<redis::redis_message>> _data;
+        inline lw_shared_ptr<scattered_message<char>> make_message()  {
+            return _data->message();
+        }
+    };
+    using response_type = result;
+private:
+    class fmt_visitor;
+    friend class connection;
+    class connection : public boost::intrusive::list_base_hook<> {
+       // using result = redis_server::result;
+        redis_server& _server;
+        socket_address _server_addr;
+        connected_socket _fd;
+        input_stream<char> _read_buf;
+        output_stream<char> _write_buf;
+        redis_protocol_parser _parser;
+        seastar::gate _pending_requests_gate;
+        //service::client_state _client_state;
+        redis::redis_options _options;
+        future<> _ready_to_respond = make_ready_future<>();
+        unsigned _request_cpu = 0;
+    private:
+        enum class tracing_request_type : uint8_t {
+            not_requested,
+            no_write_on_close,
+            write_on_close
+        };  
+
+        using execution_stage_type = inheriting_concrete_execution_stage<
+                future<redis_server::result>,
+                redis_server::connection*,
+                redis::request&&,
+                redis::redis_options&,
+                service_permit
+        >;
+        static thread_local execution_stage_type _process_request_stage;
+    public:
+        connection(redis_server& server, socket_address server_addr, connected_socket&& fd, socket_address addr);
+        ~connection();
+        future<> process();
+        future<> process_request();
+        void write_reply(const redis_exception&);
+        void write_reply(redis_server::result result);
+        future<> shutdown();
+    private:
+        const ::timeout_config& timeout_config() { return _server.timeout_config(); }
+        friend class process_request_executor;
+        future<result> process_request_one(redis::request&& request, redis::redis_options&, service_permit permit);
+        future<result> process_request_internal();
+    };
+
+private:
+    bool _stopping = false;
+    promise<> _all_connections_stopped;
+    future<> _stopped = _all_connections_stopped.get_future();
+    boost::intrusive::list<connection> _connections_list;
+private:
+    void maybe_idle() {
+        if (_stopping && !_stats._connections_being_accepted && !_stats._current_connections) {
+            _all_connections_stopped.set_value();
+        }
+    }
+    const ::timeout_config& timeout_config() { return _config._timeout_config; }
+};
+}

--- a/redis/service.cc
+++ b/redis/service.cc
@@ -1,0 +1,148 @@
+/*
+ * Copyright (C) 2019 pengjian.uestc @ gmail.com
+ */
+
+/*
+ * This file is part of Scylla.
+ *
+ * Scylla is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Scylla is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "redis/service.hh"
+#include "redis/keyspace_utils.hh"
+#include "redis/server.hh"
+#include "db/config.hh"
+#include "log.hh"
+#include "auth/common.hh"
+#include "database.hh"
+
+static logging::logger slogger("redis_service");
+
+redis_service::redis_service()
+{
+}
+
+redis_service::~redis_service()
+{
+}
+
+future<> redis_service::listen(distributed<auth::service>& auth_service, db::config& cfg)
+{
+    if (_server) {
+        return make_ready_future<>();
+    }
+    auto server = make_shared<distributed<redis_transport::redis_server>>();
+    _server = server;
+
+    auto make_timeout_config = [] (db::config& cfg) {
+        timeout_config tc;
+        tc.read_timeout = cfg.read_request_timeout_in_ms() * 1ms; 
+        tc.write_timeout = cfg.write_request_timeout_in_ms() * 1ms; 
+        tc.range_read_timeout = cfg.range_request_timeout_in_ms() * 1ms; 
+        tc.counter_write_timeout = cfg.counter_write_request_timeout_in_ms() * 1ms; 
+        tc.truncate_timeout = cfg.truncate_request_timeout_in_ms() * 1ms; 
+        tc.cas_timeout = cfg.cas_contention_timeout_in_ms() * 1ms; 
+        tc.other_timeout = cfg.request_timeout_in_ms() * 1ms; 
+        return tc;
+    };
+
+    auto addr = cfg.rpc_address();
+    auto preferred = cfg.rpc_interface_prefer_ipv6() ? std::make_optional(net::inet_address::family::INET6) : std::nullopt;
+    auto family = cfg.enable_ipv6_dns_lookup() || preferred ? std::nullopt : std::make_optional(net::inet_address::family::INET);
+    auto ceo = cfg.client_encryption_options();
+    auto keepalive = cfg.rpc_keepalive();
+    redis_transport::redis_server_config redis_cfg;
+    redis_cfg._timeout_config = make_timeout_config(cfg);
+    redis_cfg._read_consistency_level = make_consistency_level(cfg.redis_read_consistency_level());
+    redis_cfg._write_consistency_level = make_consistency_level(cfg.redis_write_consistency_level());
+    redis_cfg._max_request_size = memory::stats().total_memory() / 10;
+    redis_cfg._total_redis_db_count = cfg.redis_default_database_count();
+    return gms::inet_address::lookup(addr, family, preferred).then([this, server, addr, &cfg, keepalive, ceo = std::move(ceo), redis_cfg, &auth_service] (seastar::net::inet_address ip) {
+        return server->start(std::ref(service::get_storage_proxy()), std::ref(_query_processor), std::ref(auth_service), redis_cfg).then([server, &cfg, addr, ip, ceo, keepalive]() {
+            auto f = make_ready_future();
+            struct listen_cfg {
+                socket_address addr;
+                std::shared_ptr<seastar::tls::credentials_builder> cred;
+            };
+
+            std::vector<listen_cfg> configs({ { socket_address{ip, cfg.redis_transport_port()} }});
+
+            // main should have made sure values are clean and neatish
+            if (ceo.at("enabled") == "true") {
+                auto cred = std::make_shared<seastar::tls::credentials_builder>();
+
+                cred->set_dh_level(seastar::tls::dh_params::level::MEDIUM);
+                cred->set_priority_string(db::config::default_tls_priority);
+
+                if (ceo.count("priority_string")) {
+                    cred->set_priority_string(ceo.at("priority_string"));
+                }
+                if (ceo.count("require_client_auth") && ceo.at("require_client_auth") == "true") {
+                    cred->set_client_auth(seastar::tls::client_auth::REQUIRE);
+                }
+
+                f = cred->set_x509_key_file(ceo.at("certificate"), ceo.at("keyfile"), seastar::tls::x509_crt_format::PEM);
+
+                if (ceo.count("truststore")) {
+                    f = f.then([cred, f = ceo.at("truststore")] { return cred->set_x509_trust_file(f, seastar::tls::x509_crt_format::PEM); });
+                }
+
+                slogger.info("Enabling encrypted REDIS connections between client and server");
+
+                if (cfg.redis_transport_port_ssl.is_set() && cfg.redis_transport_port_ssl() != cfg.redis_transport_port()) {
+                    configs.emplace_back(listen_cfg{{ip, cfg.redis_transport_port_ssl()}, std::move(cred)});
+                } else {
+                    configs.back().cred = std::move(cred);
+                }
+            }
+
+            return f.then([server, configs = std::move(configs), keepalive] {
+                return parallel_for_each(configs, [server, keepalive](const listen_cfg & cfg) {
+                    return server->invoke_on_all(&redis_transport::redis_server::listen, cfg.addr, cfg.cred, keepalive).then([cfg] {
+                        slogger.info("Starting listening for REDIS clients on {} ({})", cfg.addr, cfg.cred ? "encrypted" : "unencrypted");
+                    });
+                });
+            });
+        });
+    });
+}
+
+future<> redis_service::init(distributed<service::storage_proxy>& proxy, distributed<database>& db, distributed<auth::service>& auth_service, db::config& cfg)
+{
+    // 1. Create keyspace/tables used by redis API if not exists.
+    // 2. Initialize the redis query processor.
+    // 3. Listen on the redis transport port.
+    return redis::maybe_create_keyspace(cfg).then([this, &proxy, &db] {
+        auto& proxy = service::get_storage_proxy();
+        return _query_processor.start(std::ref(proxy), std::ref(db));
+    }).then([this] {
+        return _query_processor.invoke_on_all([] (auto& processor) {
+            return processor.start();
+        });
+    }).then([this, &cfg, &auth_service] {
+        return listen(auth_service, cfg);
+    });
+}
+
+future<> redis_service::stop()
+{
+    // If the `enable_redis_protocol disable, the redis_service::init is not
+    // invoked at all. Do nothing if `_server is null.
+    if (_server) {
+        return _server->stop().then([this] {
+            return _query_processor.stop();
+        });
+    }
+    return make_ready_future<>();
+}

--- a/redis/service.hh
+++ b/redis/service.hh
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2019 pengjian.uestc @ gmail.com
+ */
+
+/*
+ * This file is part of Scylla.
+ *
+ * Scylla is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Scylla is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "seastar/core/future.hh"
+#include "seastar/core/shared_ptr.hh"
+#include "seastar/core/distributed.hh"
+
+using namespace seastar;
+
+namespace db {
+class config;
+};
+
+namespace redis {
+class query_processor;
+}
+
+namespace redis_transport {
+class redis_server;
+}
+
+namespace auth {
+class service;
+}
+
+namespace service {
+class storage_proxy;
+}
+
+class database;
+
+class redis_service {
+    distributed<redis::query_processor> _query_processor;
+    shared_ptr<distributed<redis_transport::redis_server>> _server;
+private:
+    future<> listen(distributed<auth::service>& auth_service, db::config& cfg);
+public:
+    redis_service();
+    ~redis_service();
+    future<> init(distributed<service::storage_proxy>& proxy, distributed<database>& db, distributed<auth::service>& auth_service, db::config& cfg);
+    future<> stop();
+};

--- a/redis/stats.cc
+++ b/redis/stats.cc
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2019 pengjian.uestc @ gmail.com
+ */
+
+/*
+ * This file is part of Scylla.
+ *
+ * Scylla is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Scylla is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "redis/stats.hh"
+
+#include <seastar/core/metrics.hh>
+
+namespace redis {
+
+const char* REDIS_METRICS = "redis";
+
+stats::stats() : api_operations{} {
+    seastar::metrics::label op("op");
+    _metrics.add_group("redis", {
+#define OPERATION(name, CamelCaseName) \
+            seastar::metrics::make_total_operations("operation", api_operations.name._counter, \
+                seastar::metrics::description("number of operations via redis API"), {op(CamelCaseName)}), \
+            seastar::metrics::make_histogram("op_latency", \
+                seastar::metrics::description("Latency histogram of an operation via redis API"), {op(CamelCaseName)}, [this]{return api_operations.name._latency.get_histogram(1,20);}),
+            OPERATION(_get, "get")
+            OPERATION(_set, "set")
+            OPERATION(_del, "del")
+            OPERATION(_ping, "ping")
+            OPERATION(_select, "select")
+    });
+    _metrics.add_group("redis", {
+        seastar::metrics::make_derive("redis-connections", _connects,
+            seastar::metrics::description("Counts a number of client connections.")),
+        seastar::metrics::make_gauge("current_connections", _connections,
+            seastar::metrics::description("Holds a current number of client connections.")),
+        seastar::metrics::make_derive("requests_served", _requests_served,
+            seastar::metrics::description("Counts a number of served requests.")),
+        seastar::metrics::make_gauge("requests_serving", _requests_serving,
+            seastar::metrics::description("Holds a number of requests that are being processed right now.")),
+        seastar::metrics::make_histogram("requests_latency", seastar::metrics::description("The general requests latency histogram"), [this]{ return _estimated_requests_latency.get_histogram(16, 20);}),
+    });
+}
+
+}

--- a/redis/stats.hh
+++ b/redis/stats.hh
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2019 pengjian.uestc @ gmail.com
+ */
+
+/*
+ * This file is part of Scylla.
+ *
+ * Scylla is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Scylla is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <cstdint>
+
+#include <seastar/core/metrics_registration.hh>
+#include "seastarx.hh"
+#include "utils/estimated_histogram.hh"
+#include "utils/histogram.hh"
+
+namespace redis {
+
+class stats {
+public:
+    stats();
+    struct counter_type {
+        uint64_t _counter = 0;
+        utils::estimated_histogram _latency;
+    };
+
+    struct {
+        counter_type _get;
+        counter_type _set;
+        counter_type _del;
+        counter_type _ping;
+        counter_type _select;
+    } api_operations;
+    
+    uint64_t _connects = 0;
+    uint64_t _connections = 0;
+    uint64_t _requests_served = 0;
+    uint64_t _requests_serving = 0;
+    uint64_t _total_connections = 0;
+    uint64_t _current_connections = 0;
+    uint64_t _connections_being_accepted = 0;
+    utils::estimated_histogram _estimated_requests_latency;
+    utils::timed_rate_moving_average_and_histogram _requests;
+private:
+    seastar::metrics::metric_groups _metrics;
+};
+
+}


### PR DESCRIPTION
The detailed design and implementation of Redis API in Scylla is provided in the doc/redis/redis.md.
The redis commands (such as PING, GET, SET, DEL) are already implemented.