### PR TITLE
build: fix double linkage of Seastar libraries in tests

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1348,7 +1348,7 @@ with open(buildfile_tmp, 'w') as f:
                         local_libs += ' ' + maybe_static(args.staticboost, '-lboost_unit_test_framework')
                     if binary not in tests_not_using_seastar_test_framework:
                         pc_path = pc[mode].replace('seastar.pc', 'seastar-testing.pc')
-                        local_libs += ' ' + pkg_config(pc_path, '--libs', '--static')
+                        local_libs += ' ' + pkg_config(pc_path, '--libs')
                     if has_thrift:
                         local_libs += ' ' + thrift_libs + ' ' + maybe_static(args.staticboost, '-lboost_system')
                     # Our code's debugging information is huge, and multiplied


### PR DESCRIPTION
Tests that use the seastar test framework link with its libraries (as described
pkg-config --libs --static seastar-testing.pc). The output of that command however
also includes seastar's libraries, because seastar-testing.pc explicitly depends
on seastar. As a result, the linker command line specifies each seastar library
(and its dependencies) twice.

Up to now this has not been a problem; the linker ignores the doubly-specified
libraries. However with a recent Seastar fix, this starts failing with --enable-dpdk,
because dpdk libraries are linked with --whole-archive. This forces the linker to
include the library in the executable, and if this is done twice, the linker
complains about duplicate symbols.

Fix by removing the --static flag from the pkg-config command line. Since we
explicitly include seastar dependencies, it is not needed. With this we can build
Scylla tests with recent Seastar and with --enable-dpdk.