### PR TITLE
Partition/row hit/miss counters for memtable write operations

### DIFF
--- a/api/column_family.hh
+++ b/api/column_family.hh
@@ -109,9 +109,9 @@ future<json::json_return_type> map_reduce_cf(http_context& ctx, I init,
 }
 
 future<json::json_return_type>  get_cf_stats(http_context& ctx, const sstring& name,
-        int64_t column_family::stats::*f);
+        int64_t column_family_stats::*f);
 
 future<json::json_return_type>  get_cf_stats(http_context& ctx,
-        int64_t column_family::stats::*f);
+        int64_t column_family_stats::*f);
 
 }

--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -192,7 +192,7 @@ void set_storage_service(http_context& ctx, routes& r) {
     });
 
     ss::get_load.set(r, [&ctx](std::unique_ptr<request> req) {
-        return get_cf_stats(ctx, &column_family::stats::live_disk_space_used);
+        return get_cf_stats(ctx, &column_family_stats::live_disk_space_used);
     });
 
     ss::get_load_map.set(r, [] (std::unique_ptr<request> req) {
@@ -867,7 +867,7 @@ void set_storage_service(http_context& ctx, routes& r) {
     });
 
     ss::get_metrics_load.set(r, [&ctx](std::unique_ptr<request> req) {
-        return get_cf_stats(ctx, &column_family::stats::live_disk_space_used);
+        return get_cf_stats(ctx, &column_family_stats::live_disk_space_used);
     });
 
     ss::get_exceptions.set(r, [](const_req req) {

--- a/canonical_mutation.cc
+++ b/canonical_mutation.cc
@@ -79,7 +79,8 @@ mutation canonical_mutation::to_mutation(schema_ptr s) const {
 
     if (version == m.schema()->version()) {
         auto partition_view = mutation_partition_view::from_view(mv.partition());
-        m.partition().apply(*m.schema(), partition_view, *m.schema());
+        mutation_application_stats app_stats;
+        m.partition().apply(*m.schema(), partition_view, *m.schema(), app_stats);
     } else {
         column_mapping cm = mv.mapping();
         converting_mutation_partition_applier v(cm, *m.schema(), m.partition());

--- a/database.cc
+++ b/database.cc
@@ -1339,7 +1339,7 @@ future<> memtable_list::request_flush() {
 }
 
 lw_shared_ptr<memtable> memtable_list::new_memtable() {
-    return make_lw_shared<memtable>(_current_schema(), *_dirty_memory_manager, this, _compaction_scheduling_group);
+    return make_lw_shared<memtable>(_current_schema(), *_dirty_memory_manager, _table_stats, this, _compaction_scheduling_group);
 }
 
 future<flush_permit> flush_permit::reacquire_sstable_write_permit() && {

--- a/memtable.hh
+++ b/memtable.hh
@@ -121,6 +121,7 @@ public:
 };
 
 class dirty_memory_manager;
+struct table_stats;
 
 // Managed by lw_shared_ptr<>.
 class memtable final : public enable_lw_shared_from_this<memtable>, private logalloc::region {
@@ -146,6 +147,7 @@ private:
     // monotonic. That combined source in this case is cache + memtable.
     mutation_source_opt _underlying;
     uint64_t _flushed_memory = 0;
+    table_stats& _table_stats;
 
     class memtable_encoding_stats_collector : public encoding_stats_collector {
     private:
@@ -185,8 +187,8 @@ private:
     void clear() noexcept;
     uint64_t dirty_size() const;
 public:
-    explicit memtable(schema_ptr schema, dirty_memory_manager&, memtable_list *memtable_list = nullptr,
-        seastar::scheduling_group compaction_scheduling_group = seastar::current_scheduling_group());
+    explicit memtable(schema_ptr schema, dirty_memory_manager&, table_stats& table_stats, memtable_list *memtable_list = nullptr,
+            seastar::scheduling_group compaction_scheduling_group = seastar::current_scheduling_group());
     // Used for testing that want to control the flush process.
     explicit memtable(schema_ptr schema);
     ~memtable();

--- a/mutation.cc
+++ b/mutation.cc
@@ -182,11 +182,13 @@ mutation::upgrade(const schema_ptr& new_schema) {
 }
 
 void mutation::apply(mutation&& m) {
-    partition().apply(*schema(), std::move(m.partition()), *m.schema());
+    mutation_application_stats app_stats;
+    partition().apply(*schema(), std::move(m.partition()), *m.schema(), app_stats);
 }
 
 void mutation::apply(const mutation& m) {
-    partition().apply(*schema(), m.partition(), *m.schema());
+    mutation_application_stats app_stats;
+    partition().apply(*schema(), m.partition(), *m.schema(), app_stats);
 }
 
 void mutation::apply(const mutation_fragment& mf) {

--- a/partition_version.hh
+++ b/partition_version.hh
@@ -352,7 +352,7 @@ public:
     // If possible, merges the version pointed to by this snapshot with
     // adjacent partition versions. Leaves the snapshot in an unspecified state.
     // Can be retried if previous merge attempt has failed.
-    stop_iteration merge_partition_versions();
+    stop_iteration merge_partition_versions(mutation_application_stats& app_stats);
 
     // Prepares the snapshot for cleaning by moving to the right-most unreferenced version.
     // Returns stop_iteration::yes if there is nothing to merge with and the snapshot
@@ -535,8 +535,8 @@ public:
     // Assumes this instance and mp are fully continuous.
     // Use only on non-evictable entries.
     // Must not be called when is_locked().
-    void apply(const schema& s, const mutation_partition& mp, const schema& mp_schema);
-    void apply(const schema& s, mutation_partition&& mp, const schema& mp_schema);
+    void apply(const schema& s, const mutation_partition& mp, const schema& mp_schema, mutation_application_stats& app_stats);
+    void apply(const schema& s, mutation_partition&& mp, const schema& mp_schema, mutation_application_stats& app_stats);
 
     // Adds mutation_partition represented by "other" to the one represented
     // by this entry.

--- a/row_cache.cc
+++ b/row_cache.cc
@@ -50,9 +50,15 @@ row_cache::create_underlying_reader(read_context& ctx, mutation_source& src, con
     return src.make_reader(_schema, pr, ctx.slice(), ctx.pc(), ctx.trace_state(), streamed_mutation::forwarding::yes);
 }
 
+static thread_local mutation_application_stats dummy_app_stats;
+
 cache_tracker::cache_tracker()
-    : _garbage(_region, this)
-    , _memtable_cleaner(_region, nullptr)
+    : cache_tracker(dummy_app_stats)
+{}
+
+cache_tracker::cache_tracker(mutation_application_stats& app_stats)
+    : _garbage(_region, this, app_stats)
+    , _memtable_cleaner(_region, nullptr, app_stats)
 {
     setup_metrics();
 

--- a/row_cache.hh
+++ b/row_cache.hh
@@ -237,6 +237,7 @@ private:
 private:
     void setup_metrics();
 public:
+    cache_tracker(mutation_application_stats&);
     cache_tracker();
     ~cache_tracker();
     void clear();

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -2855,7 +2855,8 @@ public:
             });
             auto m = boost::accumulate(v, mutation(schema, it->par->mut().key(*schema)), [this, schema] (mutation& m, const version& ver) {
                 if (ver.par) {
-                    m.partition().apply(*schema, ver.par->mut().partition(), *schema);
+                    mutation_application_stats app_stats;
+                    m.partition().apply(*schema, ver.par->mut().partition(), *schema, app_stats);
                 }
                 return std::move(m);
             });

--- a/table.cc
+++ b/table.cc
@@ -1096,6 +1096,10 @@ void table::set_metrics() {
     if (_config.enable_metrics_reporting) {
         _metrics.add_group("column_family", {
                 ms::make_derive("memtable_switch", ms::description("Number of times flush has resulted in the memtable being switched out"), _stats.memtable_switch_count)(cf)(ks),
+                ms::make_counter("memtable_partition_writes", [this] () { return _stats.memtable_partition_insertions + _stats.memtable_partition_hits; }, ms::description("Number of write operations performed on partitions in memtables"))(cf)(ks),
+                ms::make_counter("memtable_partition_hits", _stats.memtable_partition_hits, ms::description("Number of times a write operation was issued on an existing partition in memtables"))(cf)(ks),
+                ms::make_counter("memtable_row_writes", _stats.memtable_app_stats.row_writes, ms::description("Number of row writes performed in memtables"))(cf)(ks),
+                ms::make_counter("memtable_row_hits", _stats.memtable_app_stats.row_hits, ms::description("Number of rows overwritten by write operations in memtables"))(cf)(ks),
                 ms::make_gauge("pending_tasks", ms::description("Estimated number of tasks pending for this column family"), _stats.pending_flushes)(cf)(ks),
                 ms::make_gauge("live_disk_space", ms::description("Live disk space used"), _stats.live_disk_space_used)(cf)(ks),
                 ms::make_gauge("total_disk_space", ms::description("Total disk space used"), _stats.total_disk_space_used)(cf)(ks),
@@ -1536,7 +1540,7 @@ inline bool table::manifest_json_filter(const fs::path&, const directory_entry& 
 lw_shared_ptr<memtable_list>
 table::make_memory_only_memtable_list() {
     auto get_schema = [this] { return schema(); };
-    return make_lw_shared<memtable_list>(std::move(get_schema), _config.dirty_memory_manager, _config.memory_compaction_scheduling_group);
+    return make_lw_shared<memtable_list>(std::move(get_schema), _config.dirty_memory_manager, _stats, _config.memory_compaction_scheduling_group);
 }
 
 lw_shared_ptr<memtable_list>
@@ -1545,7 +1549,7 @@ table::make_memtable_list() {
         return seal_active_memtable(std::move(permit));
     };
     auto get_schema = [this] { return schema(); };
-    return make_lw_shared<memtable_list>(std::move(seal), std::move(get_schema), _config.dirty_memory_manager, _config.memory_compaction_scheduling_group);
+    return make_lw_shared<memtable_list>(std::move(seal), std::move(get_schema), _config.dirty_memory_manager, _stats, _config.memory_compaction_scheduling_group);
 }
 
 lw_shared_ptr<memtable_list>
@@ -1554,7 +1558,7 @@ table::make_streaming_memtable_list() {
         return seal_active_streaming_memtable_immediate(std::move(permit));
     };
     auto get_schema =  [this] { return schema(); };
-    return make_lw_shared<memtable_list>(std::move(seal), std::move(get_schema), _config.streaming_dirty_memory_manager, _config.streaming_scheduling_group);
+    return make_lw_shared<memtable_list>(std::move(seal), std::move(get_schema), _config.streaming_dirty_memory_manager, _stats, _config.streaming_scheduling_group);
 }
 
 lw_shared_ptr<memtable_list>
@@ -1563,7 +1567,7 @@ table::make_streaming_memtable_big_list(streaming_memtable_big& smb) {
         return seal_active_streaming_memtable_big(smb, std::move(permit));
     };
     auto get_schema =  [this] { return schema(); };
-    return make_lw_shared<memtable_list>(std::move(seal), std::move(get_schema), _config.streaming_dirty_memory_manager, _config.streaming_scheduling_group);
+    return make_lw_shared<memtable_list>(std::move(seal), std::move(get_schema), _config.streaming_dirty_memory_manager, _stats, _config.streaming_scheduling_group);
 }
 
 table::table(schema_ptr schema, config config, db::commitlog* cl, compaction_manager& compaction_manager,

--- a/tests/counter_test.cc
+++ b/tests/counter_test.cc
@@ -317,26 +317,28 @@ SEASTAR_TEST_CASE(test_counter_mutations) {
         BOOST_REQUIRE_EQUAL(fm2.unfreeze(s), m2);
         BOOST_REQUIRE_EQUAL(fm3.unfreeze(s), m3);
 
+        mutation_application_stats app_stats;
+
         auto m0 = m1;
-        m0.partition().apply(*s, fm2.partition(), *s);
+        m0.partition().apply(*s, fm2.partition(), *s, app_stats);
         m = m1;
         m.apply(m2);
         BOOST_REQUIRE_EQUAL(m, m0);
 
         m0 = m2;
-        m0.partition().apply(*s, fm1.partition(), *s);
+        m0.partition().apply(*s, fm1.partition(), *s, app_stats);
         m = m2;
         m.apply(m1);
         BOOST_REQUIRE_EQUAL(m, m0);
 
         m0 = m1;
-        m0.partition().apply(*s, fm3.partition(), *s);
+        m0.partition().apply(*s, fm3.partition(), *s, app_stats);
         m = m1;
         m.apply(m3);
         BOOST_REQUIRE_EQUAL(m, m0);
 
         m0 = m3;
-        m0.partition().apply(*s, fm1.partition(), *s);
+        m0.partition().apply(*s, fm1.partition(), *s, app_stats);
         m = m3;
         m.apply(m1);
         BOOST_REQUIRE_EQUAL(m, m0);

--- a/tests/flat_mutation_reader_test.cc
+++ b/tests/flat_mutation_reader_test.cc
@@ -215,8 +215,9 @@ SEASTAR_TEST_CASE(test_fragmenting_and_freezing) {
 
             auto m2 = fms.back().unfreeze(m.schema());
             fms.pop_back();
+            mutation_application_stats app_stats;
             while (!fms.empty()) {
-                m2.partition().apply(*m.schema(), fms.back().partition(), *m.schema());
+                m2.partition().apply(*m.schema(), fms.back().partition(), *m.schema(), app_stats);
                 fms.pop_back();
             }
             BOOST_REQUIRE_EQUAL(m, m2);

--- a/tests/mvcc_test.cc
+++ b/tests/mvcc_test.cc
@@ -42,6 +42,8 @@
 using namespace std::chrono_literals;
 
 
+static thread_local mutation_application_stats app_stats_for_tests;
+
 // Verifies that tombstones in "list" are monotonic, overlap with the requested range,
 // and have information equivalent with "expected" in that range.
 static
@@ -81,10 +83,11 @@ void check_tombstone_slice(const schema& s, std::vector<range_tombstone> list,
 SEASTAR_TEST_CASE(test_range_tombstone_slicing) {
     return seastar::async([] {
         logalloc::region r;
-        mutation_cleaner cleaner(r, no_cache_tracker);
+        mutation_cleaner cleaner(r, no_cache_tracker, app_stats_for_tests);
         simple_schema table;
         auto s = table.schema();
         with_allocator(r.allocator(), [&] {
+            mutation_application_stats app_stats;
             logalloc::reclaim_lock l(r);
 
             auto rt1 = table.make_range_tombstone(table.make_ckey_range(1, 2));
@@ -127,7 +130,7 @@ SEASTAR_TEST_CASE(test_range_tombstone_slicing) {
             m2.apply_delete(*s, rt5);
 
             auto&& v2 = e.add_version(*s, no_cache_tracker);
-            v2.partition().apply_weak(*s, m2, *s);
+            v2.partition().apply_weak(*s, m2, *s, app_stats);
             auto snap2 = e.read(r, cleaner, s, no_cache_tracker);
 
             check_range(*snap2, table.make_ckey_range(0, 0), {});
@@ -174,7 +177,7 @@ public:
     mvcc_container(schema_ptr s, no_tracker)
         : _schema(s)
         , _region_holder(std::make_optional<logalloc::region>())
-        , _cleaner_holder(std::make_optional<mutation_cleaner>(*_region_holder, nullptr))
+        , _cleaner_holder(std::make_optional<mutation_cleaner>(*_region_holder, nullptr, app_stats_for_tests))
         , _region(&*_region_holder)
         , _cleaner(&*_cleaner_holder)
     { }
@@ -267,7 +270,7 @@ public:
 void mvcc_partition::apply_to_evictable(partition_entry&& src, schema_ptr src_schema) {
     with_allocator(region().allocator(), [&] {
         logalloc::allocating_section as;
-        mutation_cleaner src_cleaner(region(), no_cache_tracker);
+        mutation_cleaner src_cleaner(region(), no_cache_tracker, app_stats_for_tests);
         auto c = as(region(), [&] {
             if (_s != src_schema) {
                 src.upgrade(src_schema, _s, src_cleaner, no_cache_tracker);
@@ -301,7 +304,8 @@ void mvcc_partition::apply(const mutation_partition& mp, schema_ptr mp_s) {
         } else {
             logalloc::allocating_section as;
             as(region(), [&] {
-                _e.apply(*_s, mp, *mp_s);
+                mutation_application_stats app_stats;
+                _e.apply(*_s, mp, *mp_s, app_stats);
             });
         }
     });
@@ -498,6 +502,7 @@ SEASTAR_TEST_CASE(test_apply_to_incomplete_respects_continuity) {
 
             // Without active reader
             auto test = [&] (bool with_active_reader) {
+                mutation_application_stats app_stats;
                 auto e = ms.make_evictable(m3.partition());
 
                 auto snap1 = e.read();
@@ -522,7 +527,7 @@ SEASTAR_TEST_CASE(test_apply_to_incomplete_respects_continuity) {
                 }
 
                 auto expected = mutation_partition(*s, before);
-                expected.apply_weak(*s, std::move(expected_to_apply_slice));
+                expected.apply_weak(*s, std::move(expected_to_apply_slice), app_stats);
 
                 e += to_apply;
                 assert_that(s, e.squashed())
@@ -593,7 +598,7 @@ SEASTAR_TEST_CASE(test_snapshot_cursor_is_consistent_with_merging_for_nonevictab
     // Tests that reading many versions using a cursor gives the logical mutation back.
     return seastar::async([] {
         logalloc::region r;
-        mutation_cleaner cleaner(r, no_cache_tracker);
+        mutation_cleaner cleaner(r, no_cache_tracker, app_stats_for_tests);
         with_allocator(r.allocator(), [&] {
             random_mutation_generator gen(random_mutation_generator::generate_counters::no);
             auto s = gen.schema();
@@ -607,12 +612,13 @@ SEASTAR_TEST_CASE(test_snapshot_cursor_is_consistent_with_merging_for_nonevictab
             m3.partition().make_fully_continuous();
 
             {
+                mutation_application_stats app_stats;
                 logalloc::reclaim_lock rl(r);
                 auto e = partition_entry(mutation_partition(*s, m3.partition()));
                 auto snap1 = e.read(r, cleaner, s, no_cache_tracker);
-                e.apply(*s, m2.partition(), *s);
+                e.apply(*s, m2.partition(), *s, app_stats);
                 auto snap2 = e.read(r, cleaner, s, no_cache_tracker);
-                e.apply(*s, m1.partition(), *s);
+                e.apply(*s, m1.partition(), *s, app_stats);
 
                 auto expected = e.squashed(*s);
                 auto snap = e.read(r, cleaner, s, no_cache_tracker);
@@ -860,14 +866,16 @@ SEASTAR_TEST_CASE(test_apply_is_atomic) {
 
                 alloc.fail_after(fail_offset++);
                 try {
-                    e.apply(*target.schema(), std::move(m2), *second.schema());
+                    mutation_application_stats app_stats;
+                    e.apply(*target.schema(), std::move(m2), *second.schema(), app_stats);
                     alloc.stop_failing();
                     break;
                 } catch (const std::bad_alloc&) {
+                    mutation_application_stats app_stats;
                     assert_that(mutation(target.schema(), target.decorated_key(), e.squashed(*target.schema())))
                         .is_equal_to(target)
                         .has_same_continuity(target);
-                    e.apply(*target.schema(), std::move(m2), *second.schema());
+                    e.apply(*target.schema(), std::move(m2), *second.schema(), app_stats);
                     assert_that(mutation(target.schema(), target.decorated_key(), e.squashed(*target.schema())))
                         .is_equal_to(expected)
                         .has_same_continuity(expected);
@@ -887,7 +895,7 @@ SEASTAR_TEST_CASE(test_apply_is_atomic) {
 SEASTAR_TEST_CASE(test_versions_are_merged_when_snapshots_go_away) {
     return seastar::async([] {
         logalloc::region r;
-        mutation_cleaner cleaner(r, nullptr);
+        mutation_cleaner cleaner(r, nullptr, app_stats_for_tests);
         with_allocator(r.allocator(), [&] {
             random_mutation_generator gen(random_mutation_generator::generate_counters::no);
             auto s = gen.schema();
@@ -905,8 +913,9 @@ SEASTAR_TEST_CASE(test_versions_are_merged_when_snapshots_go_away) {
                 auto snap1 = e.read(r, cleaner, s, nullptr);
 
                 {
+                    mutation_application_stats app_stats;
                     logalloc::reclaim_lock rl(r);
-                    e.apply(*s, m2.partition(), *s);
+                    e.apply(*s, m2.partition(), *s, app_stats);
                 }
 
                 auto snap2 = e.read(r, cleaner, s, nullptr);
@@ -925,8 +934,9 @@ SEASTAR_TEST_CASE(test_versions_are_merged_when_snapshots_go_away) {
                 auto snap1 = e.read(r, cleaner, s, nullptr);
 
                 {
+                    mutation_application_stats app_stats;
                     logalloc::reclaim_lock rl(r);
-                    e.apply(*s, m2.partition(), *s);
+                    e.apply(*s, m2.partition(), *s, app_stats);
                 }
 
                 auto snap2 = e.read(r, cleaner, s, nullptr);

--- a/tests/perf/perf_idl.cc
+++ b/tests/perf/perf_idl.cc
@@ -63,7 +63,8 @@ PERF_TEST_F(frozen_mutation, unfreeze_one_small_row)
 PERF_TEST_F(frozen_mutation, apply_one_small_row)
 {
     auto m = mutation(schema(), frozen_one_small_row().key(*schema()));
-    m.partition().apply(*schema(), frozen_one_small_row().partition(), *schema());
+    mutation_application_stats app_stats;
+    m.partition().apply(*schema(), frozen_one_small_row().partition(), *schema(), app_stats);
     perf_tests::do_not_optimize(m);
 }
 

--- a/tests/row_cache_test.cc
+++ b/tests/row_cache_test.cc
@@ -1592,8 +1592,9 @@ SEASTAR_TEST_CASE(test_mvcc) {
             auto m1 = m1_;
             m1.partition().make_fully_continuous();
 
+            mutation_application_stats app_stats;
             auto m2 = mutation(m1.schema(), m1.decorated_key());
-            m2.partition().apply(*s, m2_.partition(), *s);
+            m2.partition().apply(*s, m2_.partition(), *s, app_stats);
             m2.partition().make_fully_continuous();
 
             test(m1, m2, false);


### PR DESCRIPTION
Fixes issue: #3912

Adds four new per-table metrics for counting writes performed on memtables:
- `memtable_partition_writes` - number of write operations performed on partitions in memtables,
- `memtable_partition_hits` - number of write operations performed on partitions that previously existed in a memtable,
- `memtable_row_writes` - number of row write operations performed in memtables,
- `memtable_row_hits` - number of row write operations that overwrote rows previously present in a memtable.