### PR TITLE
storage_proxy: fix on_down for view updates and topology changes

### DIFF
--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -3760,8 +3760,8 @@ void storage_proxy::on_down(const gms::inet_address& endpoint) {
     auto it = _view_update_handlers_list->begin();
     while (it != _view_update_handlers_list->end()) {
         auto guard = it->shared_from_this();
-        if (it->get_targets().count(endpoint) > 0 && _response_handlers.find(it->id()) != _response_handlers.end()) {
-            it->timeout_cb();
+        if (it->get_targets().count(endpoint) > 0) {
+            got_failure_response(it->id(), endpoint, 1, {});
         }
         ++it;
         if (seastar::thread::should_yield()) {


### PR DESCRIPTION
The discussion in issue #5114 contained a valid point by Gleb,
that the current code which forces MV updates to be timed out
and redirected to hinted handoff in on_down() is not correct during
topology changes. It is so, because the code wrongly assumes that
for every update there's only one destination endpoint.
A simple fix for this is to call this sequence:
  handler.failure(endpoint, 1);
  handler.check_for_early_completion();
instead of timing out the handler unconditionally.

To make the fix more consise, an existing utility function
got_failure_response() is called. Its purpose is to handle receiving
a failure from one of the endpoints, and the exact same procedure
should be launched in on_down(), when a node is discovered to be down
and thus is not expected to send a response.
The original code was written in order to break a 5 minute timeout
set for the view updates and the same behavior is ensured, with the
addition of handling topology changes correctly.

Refs #5114

@nyh @gleb-cloudius 