### PR TITLE
database: Add counter for the number of schema changes

### DIFF
--- a/database.cc
+++ b/database.cc
@@ -531,6 +531,12 @@ database::setup_metrics() {
         sm::make_total_operations("total_view_updates_failed_remote", _cf_stats.total_view_updates_failed_remote,
                 sm::description("Total number of view updates generated for tables and failed to be sent to remote replicas.")),
     });
+    if (engine().cpu_id() == 0) {
+        _metrics.add_group("database", {
+                sm::make_derive("schema_changed", _schema_change_count,
+                        sm::description("The number of times the schema changed")),
+        });
+    }
 }
 
 database::~database() {
@@ -540,6 +546,9 @@ database::~database() {
 }
 
 void database::update_version(const utils::UUID& version) {
+    if (_version != version) {
+        _schema_change_count++;
+    }
     _version = version;
 }
 

--- a/database.hh
+++ b/database.hh
@@ -1280,6 +1280,7 @@ private:
     std::unordered_map<std::pair<sstring, sstring>, utils::UUID, utils::tuple_hash> _ks_cf_to_uuid;
     std::unique_ptr<db::commitlog> _commitlog;
     utils::UUID _version;
+    uint32_t _schema_change_count = 0;
     // compaction_manager object is referenced by all column families of a database.
     std::unique_ptr<compaction_manager> _compaction_manager;
     seastar::metrics::metric_groups _metrics;


### PR DESCRIPTION
Schema changes can have big effects on performance, typically it should
be a rare event.

It is useful to monitor how frequently the schema changes.
This patch adds a counter that increases each time a schema changes.

After this patch the metrics would look like:

```
# HELP scylla_database_schema_changed The number of times the schema changed
# TYPE scylla_database_schema_changed counter
scylla_database_schema_changed{shard="0",type="derive"} 2
```

Fixes #4785

Signed-off-by: Amnon Heiman <amnon@scylladb.com>