### PR TITLE
test: random_schema::make_ckeys: fix inifinte loop

### DIFF
--- a/tests/random_schema.cc
+++ b/tests/random_schema.cc
@@ -963,10 +963,8 @@ std::vector<data_model::mutation_description::key> random_schema::make_ckeys(siz
     std::set<clustering_key, clustering_key::less_compare> keys{clustering_key::less_compare{*_schema}};
     value_generator val_gen;
 
-    uint32_t i{0};
-    while (keys.size() < n) {
+    for (uint32_t i = 0; i < n; i++) {
         keys.emplace(clustering_key::from_exploded(make_clustering_key(i, val_gen)));
-        ++i;
     }
 
     return boost::copy_range<std::vector<data_model::mutation_description::key>>(keys |
@@ -1062,8 +1060,8 @@ future<std::vector<mutation>> generate_random_mutations(
                 return;
             }
 
-            const auto clustering_row_count = clustering_row_count_dist(engine);
-            auto ckeys = random_schema.make_ckeys(clustering_row_count);
+            auto ckeys = random_schema.make_ckeys(clustering_row_count_dist(engine));
+            const auto clustering_row_count = ckeys.size();
             for (uint32_t ck = 0; ck < clustering_row_count; ++ck) {
                 random_schema.add_row(engine, mut, ckeys[ck], ts_gen, exp_gen);
             }

--- a/tests/random_schema.hh
+++ b/tests/random_schema.hh
@@ -205,11 +205,12 @@ public:
     /// schema and `n` will map to the same generated value.
     data_model::mutation_description::key make_ckey(uint32_t n);
 
-    /// Make n clustering keys.
+    /// Make up to n clustering keys.
     ///
     /// Key are in clustering order.
     /// This method is deterministic, the pair of the seed used to generate the
     /// schema and `n` will map to the same generated values.
+    /// Fewer than n keys may be returned if the schema limits the clustering keys space.
     std::vector<data_model::mutation_description::key> make_ckeys(size_t n);
 
     data_model::mutation_description new_mutation(data_model::mutation_description::key pkey);


### PR DESCRIPTION
Allow returning fewer random clustering keys than requested since
the schema may limit the total number we can generate, for example,
if there is only one boolean clustering column.

Fixes #5161

Signed-off-by: Benny Halevy <bhalevy@scylladb.com>

Tests: unit(dev)
1000 runs of mutation_test in release mode.