### PR TITLE
Fix legacy token column handling for local indexes

### DIFF
--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -86,7 +86,7 @@ cql3::statements::select_statement& view_info::select_statement() const {
         // FIXME(sarna): legacy code, should be removed after "computed_columns" feature is guaranteed
         // to be available on every node. Then, we won't need to check if this view is backing a secondary index.
         const column_definition* legacy_token_column = nullptr;
-        if (service::get_local_storage_service().db().local().find_column_family(base_id()).get_index_manager().is_index(_schema)) {
+        if (service::get_local_storage_service().db().local().find_column_family(base_id()).get_index_manager().is_global_index(_schema)) {
            if (!_schema.clustering_key_columns().empty()) {
                legacy_token_column = &_schema.clustering_key_columns().front();
            }

--- a/index/secondary_index_manager.cc
+++ b/index/secondary_index_manager.cc
@@ -181,4 +181,10 @@ bool secondary_index_manager::is_index(const schema& s) const {
     });
 }
 
+bool secondary_index_manager::is_global_index(const schema& s) const {
+    return boost::algorithm::any_of(_indices | boost::adaptors::map_values, [&s] (const index& i) {
+        return !i.metadata().local() && s.cf_name() == index_table_name(i.metadata().name());
+    });
+}
+
 }

--- a/index/secondary_index_manager.hh
+++ b/index/secondary_index_manager.hh
@@ -77,6 +77,7 @@ public:
     std::vector<index> list_indexes() const;
     bool is_index(view_ptr) const;
     bool is_index(const schema& s) const;
+    bool is_global_index(const schema& s) const;
 private:
     void add_index(const index_metadata& im);
 };


### PR DESCRIPTION
Calculating the select statement for given view_info structure
used to work fine, but once local indexes were introduced, a subtle
bug appeared: the legacy token column does not exist in local indexes
and a valid clustering key column was omitted instead.
That results in potentially incorrect partition slices being used later
in read-before-write.
There's a long term plan for removing select_statement from
view info altogether, but nonetheless the bug needs to be fixed first.

@nyh @avikivity 

Branch: master, 3.1

Tests: unit(dev) + manual confirmation that a correct legacy column is picked