### PR TITLE
Some refactoring of node startup code.

### DIFF
--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -1472,9 +1472,6 @@ std::unordered_set<dht::token> decode_tokens(set_type_impl::native_type& tokens)
     return tset;
 }
 
-/**
- * Record tokens being used by another node
- */
 future<> update_tokens(gms::inet_address ep, const std::unordered_set<dht::token>& tokens)
 {
     if (ep == utils::fb_utilities::get_broadcast_address()) {
@@ -1648,9 +1645,6 @@ future<> remove_endpoint(gms::inet_address ep) {
     });
 }
 
-    /**
-     * This method is used to update the System Keyspace with the new tokens for this node
-    */
 future<> update_tokens(const std::unordered_set<dht::token>& tokens) {
     if (tokens.empty()) {
         throw std::invalid_argument("remove_endpoint should be used instead");

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -1485,21 +1485,6 @@ future<> update_tokens(gms::inet_address ep, const std::unordered_set<dht::token
     });
 }
 
-future<std::unordered_set<dht::token>> update_local_tokens(
-    const std::unordered_set<dht::token> add_tokens,
-    const std::unordered_set<dht::token> rm_tokens) {
-    return get_saved_tokens().then([add_tokens = std::move(add_tokens), rm_tokens = std::move(rm_tokens)] (auto tokens) {
-        for (auto& x : rm_tokens) {
-            tokens.erase(x);
-        }
-        for (auto& x : add_tokens) {
-            tokens.insert(x);
-        }
-        return update_tokens(tokens).then([tokens] {
-            return tokens;
-        });
-    });
-}
 
 future<std::unordered_map<gms::inet_address, std::unordered_set<dht::token>>> load_tokens() {
     sstring req = format("SELECT peer, tokens FROM system.{}", PEERS);

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -1454,7 +1454,7 @@ future<db_clock::time_point> get_truncated_at(utils::UUID cf_id) {
     });
 }
 
-set_type_impl::native_type prepare_tokens(std::unordered_set<dht::token>& tokens) {
+static set_type_impl::native_type prepare_tokens(const std::unordered_set<dht::token>& tokens) {
     set_type_impl::native_type tset;
     for (auto& t: tokens) {
         tset.push_back(dht::global_partitioner().to_sstring(t));

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -1475,7 +1475,7 @@ std::unordered_set<dht::token> decode_tokens(set_type_impl::native_type& tokens)
 /**
  * Record tokens being used by another node
  */
-future<> update_tokens(gms::inet_address ep, std::unordered_set<dht::token> tokens)
+future<> update_tokens(gms::inet_address ep, const std::unordered_set<dht::token>& tokens)
 {
     if (ep == utils::fb_utilities::get_broadcast_address()) {
         return remove_endpoint(ep);
@@ -1651,7 +1651,7 @@ future<> remove_endpoint(gms::inet_address ep) {
     /**
      * This method is used to update the System Keyspace with the new tokens for this node
     */
-future<> update_tokens(std::unordered_set<dht::token> tokens) {
+future<> update_tokens(const std::unordered_set<dht::token>& tokens) {
     if (tokens.empty()) {
         throw std::invalid_argument("remove_endpoint should be used instead");
     }

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -162,8 +162,8 @@ future<> setup(distributed<database>& db,
                distributed<cql3::query_processor>& qp,
                distributed<service::storage_service>& ss);
 future<> update_schema_version(utils::UUID version);
-future<> update_tokens(std::unordered_set<dht::token> tokens);
-future<> update_tokens(gms::inet_address ep, std::unordered_set<dht::token> tokens);
+future<> update_tokens(const std::unordered_set<dht::token>& tokens);
+future<> update_tokens(gms::inet_address ep, const std::unordered_set<dht::token>& tokens);
 
 future<> update_preferred_ip(gms::inet_address ep, gms::inet_address preferred_ip);
 future<std::unordered_map<gms::inet_address, gms::inet_address>> get_preferred_ips();

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -486,17 +486,6 @@ enum class bootstrap_state {
 #endif
 
     /**
-     * Convenience method to update the list of tokens in the local system keyspace.
-     *
-     * @param addTokens tokens to add
-     * @param rmTokens tokens to remove
-     * @return the collection of persisted tokens
-     */
-    future<std::unordered_set<dht::token>> update_local_tokens(
-        const std::unordered_set<dht::token> add_tokens,
-        const std::unordered_set<dht::token> rm_tokens);
-
-    /**
      * Return a map of stored tokens to IP addresses
      *
      */

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -162,7 +162,15 @@ future<> setup(distributed<database>& db,
                distributed<cql3::query_processor>& qp,
                distributed<service::storage_service>& ss);
 future<> update_schema_version(utils::UUID version);
+
+/*
+ * Save tokens used by this node in the LOCAL table.
+ */
 future<> update_tokens(const std::unordered_set<dht::token>& tokens);
+
+/**
+ * Record tokens being used by another node in the PEERS table.
+ */
 future<> update_tokens(gms::inet_address ep, const std::unordered_set<dht::token>& tokens);
 
 future<> update_preferred_ip(gms::inet_address ep, gms::inet_address preferred_ip);
@@ -500,6 +508,10 @@ enum class bootstrap_state {
      */
     future<std::unordered_map<gms::inet_address, utils::UUID>> load_host_ids();
 
+    /*
+     * Read this node's tokens stored in the LOCAL table.
+     * Used to initialize a restarting node.
+     */
     future<std::unordered_set<dht::token>> get_saved_tokens();
 
     future<std::unordered_map<gms::inet_address, sstring>> load_peer_features();

--- a/dht/boot_strapper.cc
+++ b/dht/boot_strapper.cc
@@ -62,9 +62,7 @@ future<> boot_strapper::bootstrap() {
         return streamer->add_ranges(keyspace_name, ranges);
     }).then([this, streamer] {
         _abort_source.check();
-        return streamer->stream_async().then([streamer] () {
-            service::get_local_storage_service().finish_bootstrapping();
-        }).handle_exception([streamer] (std::exception_ptr eptr) {
+        return streamer->stream_async().handle_exception([streamer] (std::exception_ptr eptr) {
             blogger.warn("Error during bootstrap: {}", eptr);
             return make_exception_future<>(std::move(eptr));
         });

--- a/locator/token_metadata.cc
+++ b/locator/token_metadata.cc
@@ -102,7 +102,7 @@ void token_metadata::update_normal_tokens(std::unordered_set<token> tokens, inet
  *
  * @param endpointTokens
  */
-void token_metadata::update_normal_tokens(std::unordered_map<inet_address, std::unordered_set<token>>& endpoint_tokens) {
+void token_metadata::update_normal_tokens(const std::unordered_map<inet_address, std::unordered_set<token>>& endpoint_tokens) {
     if (endpoint_tokens.empty()) {
         return;
     }
@@ -110,7 +110,7 @@ void token_metadata::update_normal_tokens(std::unordered_map<inet_address, std::
     bool should_sort_tokens = false;
     for (auto&& i : endpoint_tokens) {
         inet_address endpoint = i.first;
-        std::unordered_set<token>& tokens = i.second;
+        const auto& tokens = i.second;
 
         if (tokens.empty()) {
             auto msg = format("tokens is empty in update_normal_tokens");

--- a/locator/token_metadata.hh
+++ b/locator/token_metadata.hh
@@ -234,7 +234,7 @@ public:
     const std::vector<token>& sorted_tokens() const;
     void update_normal_token(token token, inet_address endpoint);
     void update_normal_tokens(std::unordered_set<token> tokens, inet_address endpoint);
-    void update_normal_tokens(std::unordered_map<inet_address, std::unordered_set<token>>& endpoint_tokens);
+    void update_normal_tokens(const std::unordered_map<inet_address, std::unordered_set<token>>& endpoint_tokens);
     const token& first_token(const token& start) const;
     size_t first_token_index(const token& start) const;
     std::optional<inet_address> get_endpoint(const token& token) const;

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -1112,7 +1112,7 @@ void storage_service::handle_state_left(inet_address endpoint, std::vector<sstri
 }
 
 void storage_service::handle_state_moving(inet_address endpoint, std::vector<sstring> pieces) {
-    throw std::runtime_error(format("Move opeartion is not supported only more, endpoint={}", endpoint));
+    throw std::runtime_error(format("Move operation is not supported anymore, endpoint={}", endpoint));
 }
 
 void storage_service::handle_state_removing(inet_address endpoint, std::vector<sstring> pieces) {

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -715,11 +715,6 @@ void storage_service::join_token_ring(int delay) {
         db::system_keyspace::update_tokens(_bootstrap_tokens).get();
         bootstrap();
         // bootstrap will block until finished
-        if (_is_bootstrap_mode) {
-            auto err = format("We are not supposed in bootstrap mode any more");
-            slogger.warn("{}", err);
-            throw std::runtime_error(err);
-        }
     } else {
         maybe_start_sys_dist_ks();
         size_t num_tokens = _db.local().get_config().num_tokens();
@@ -818,7 +813,6 @@ void storage_service::mark_existing_views_as_built() {
 
 // Runs inside seastar::async context
 void storage_service::bootstrap() {
-    _is_bootstrap_mode = true;
     if (!db().local().is_replacing()) {
         // Wait until we know tokens of existing node before announcing join status.
         _gossiper.wait_for_range_setup().get();

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -969,7 +969,6 @@ void storage_service::handle_state_normal(inet_address endpoint) {
 
     std::unordered_set<token> tokens_to_update_in_metadata;
     std::unordered_set<token> tokens_to_update_in_system_keyspace;
-    std::unordered_set<token> local_tokens_to_remove;
     std::unordered_set<inet_address> endpoints_to_remove;
 
     slogger.debug("Node {} state normal, token {}", endpoint, tokens);
@@ -1070,9 +1069,6 @@ void storage_service::handle_state_normal(inet_address endpoint) {
             }
             return make_ready_future<>();
         }).get();
-    }
-    if (!local_tokens_to_remove.empty()) {
-        db::system_keyspace::update_local_tokens(std::unordered_set<dht::token>(), local_tokens_to_remove).discard_result().get();
     }
 
     // Send joined notification only when this node was not a member prior to this

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -707,9 +707,7 @@ void storage_service::join_token_ring(int delay) {
             } else {
                 sleep_abortable(get_ring_delay(), _abort_source).get();
             }
-            std::stringstream ss;
-            ss << _bootstrap_tokens;
-            set_mode(mode::JOINING, format("Replacing a node with token(s): {}", ss.str()), true);
+            set_mode(mode::JOINING, format("Replacing a node with token(s): {}", _bootstrap_tokens), true);
             // _bootstrap_tokens was previously set in prepare_to_join using tokens gossiped by the replaced node
         }
         maybe_start_sys_dist_ks();

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -351,8 +351,6 @@ public:
         _is_bootstrap_mode = false;
     }
 
-    /** This method updates the local token on disk  */
-    void set_tokens(std::unordered_set<token> tokens);
     void set_gossip_tokens(const std::unordered_set<dht::token>& local_tokens);
 #if 0
 

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -262,10 +262,6 @@ private:
     /* Are we starting this node in bootstrap mode? */
     bool _is_bootstrap_mode;
 
-    /* we bootstrap but do NOT join the ring unless told to do so */
-    // FIXME: System.getProperty("cassandra.write_survey", "false")
-    bool _is_survey_mode = false;
-
     bool _initialized;
 
     bool _joined = false;

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -547,9 +547,13 @@ private:
     void set_mode(mode m, bool log);
     void set_mode(mode m, sstring msg, bool log);
     void mark_existing_views_as_built();
-public:
-    void bootstrap(std::unordered_set<token> tokens);
 
+    // Stream data for which we become a new replica.
+    // Before that, if we're not replacing another node, inform other nodes about our chosen tokens (_bootstrap_tokens)
+    // and wait for RING_DELAY ms so that we receive new writes from coordinators during streaming.
+    void bootstrap();
+
+public:
     bool is_bootstrap_mode() {
         return _is_bootstrap_mode;
     }

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -259,9 +259,6 @@ private:
 
     std::optional<inet_address> _removing_node;
 
-    /* Are we starting this node in bootstrap mode? */
-    bool _is_bootstrap_mode;
-
     bool _initialized;
 
     bool _joined = false;
@@ -346,10 +343,6 @@ private:
 public:
     sstables::sstable_version_types sstables_format() const { return _sstables_format; }
     void enable_all_features();
-
-    void finish_bootstrapping() {
-        _is_bootstrap_mode = false;
-    }
 
     void set_gossip_tokens(const std::unordered_set<dht::token>& local_tokens);
 #if 0
@@ -554,10 +547,6 @@ private:
     void bootstrap();
 
 public:
-    bool is_bootstrap_mode() {
-        return _is_bootstrap_mode;
-    }
-
 #if 0
 
     public TokenMetadata getTokenMetadata()


### PR DESCRIPTION
The node startup code (in particular the functions storage_service::prepare_to_join and storage_service::join_token_ring) is complicated and hard to understand.

This patch set aims to simplify it at least a bit by removing some dead code, moving code around so it's easier to understand and adding some comments that explain what the code does.
I did it to help me prepare for implementing generation and gossiping of CDC streams.

The decisions I made are pretty subjective, I won't be surprised if anyone disagrees. I hope we can agree on something at least.

Please review carefully.