### PR TITLE
CDC (atomic) delta + (non-optional) pre-image data columns

### DIFF
--- a/cdc/cdc.cc
+++ b/cdc/cdc.cc
@@ -20,6 +20,8 @@
  */
 
 #include <utility>
+#include <algorithm>
+
 #include <seastar/util/defer.hh>
 #include <seastar/core/thread.hh>
 
@@ -34,6 +36,9 @@
 #include "service/migration_manager.hh"
 #include "service/storage_service.hh"
 #include "types/tuple.hh"
+#include "cql3/statements/select_statement.hh"
+#include "cql3/multi_column_relation.hh"
+#include "cql3/tuples.hh"
 
 using locator::snitch_ptr;
 using locator::token_metadata;
@@ -52,6 +57,7 @@ template<> struct hash<std::pair<net::inet_address, unsigned int>> {
 
 }
 
+using namespace std::chrono_literals;
 
 namespace cdc {
 
@@ -322,6 +328,71 @@ public:
             }
         }
         return res;
+    }
+
+    static db::timeout_clock::time_point default_timeout() {
+        return db::timeout_clock::now() + 10s;
+    }
+
+    future<lw_shared_ptr<cql3::untyped_result_set>> pre_image_select(
+            service::storage_proxy& proxy,
+            service::client_state& client_state,
+            db::consistency_level cl,
+            const mutation& m)
+    {
+        auto& p = m.partition();
+        if (p.partition_tombstone() || !p.row_tombstones().empty() || p.clustered_rows().empty()) {
+            return make_ready_future<lw_shared_ptr<cql3::untyped_result_set>>();
+        }
+
+        dht::partition_range_vector partition_ranges{dht::partition_range(m.decorated_key())};
+
+        auto&& pc = _schema->partition_key_columns();
+        auto&& cc = _schema->clustering_key_columns();
+
+        std::vector<query::clustering_range> bounds;
+        if (cc.empty()) {
+            bounds.push_back(query::clustering_range::make_open_ended_both_sides());
+        } else {
+            for (const rows_entry& r : p.clustered_rows()) {
+                auto& ck = r.key();
+                bounds.push_back(query::clustering_range::make_singular(ck));
+            }
+        }
+
+        std::vector<const column_definition*> columns;
+        columns.reserve(_schema->all_columns().size());
+
+        std::transform(pc.begin(), pc.end(), std::back_inserter(columns), [](auto& c) { return &c; });
+        std::transform(cc.begin(), cc.end(), std::back_inserter(columns), [](auto& c) { return &c; });
+
+        query::column_id_vector static_columns, regular_columns;
+
+        auto sk = column_kind::static_column;
+        auto rk = column_kind::regular_column;
+        // TODO: this assumes all mutations touch the same set of columns. This might not be true, and we may need to do more horrible set operation here. 
+        for (auto& [r, cids, kind] : { std::tie(p.static_row(), static_columns, sk), std::tie(p.clustered_rows().begin()->row().cells(), regular_columns, rk) }) {
+            r.for_each_cell([&](column_id id, const atomic_cell_or_collection&) {
+                auto& cdef =_schema->column_at(kind, id);
+                cids.emplace_back(id);
+                columns.emplace_back(&cdef);
+            });
+        }
+
+        auto selection = cql3::selection::selection::for_columns(_schema, std::move(columns));
+        auto partition_slice = query::partition_slice(std::move(bounds), std::move(static_columns), std::move(regular_columns), selection->get_query_options());
+        auto command = ::make_lw_shared<query::read_command>(_schema->id(), _schema->version(), partition_slice, query::max_partitions);
+
+        return proxy.query(_schema, std::move(command), std::move(partition_ranges), cl, service::storage_proxy::coordinator_query_options(default_timeout(), empty_service_permit(), client_state)).then(
+                [this, partition_slice = std::move(partition_slice), selection = std::move(selection)] (service::storage_proxy::coordinator_query_result qr) -> lw_shared_ptr<cql3::untyped_result_set> {
+                    cql3::selection::result_set_builder builder(*selection, gc_clock::now(), cql_serialization_format::latest());
+                    query::result_view::consume(*qr.query_result, partition_slice, cql3::selection::result_set_builder::visitor(builder, *_schema, *selection));
+                    auto result_set = builder.build();
+                    if (!result_set || result_set->empty()) {
+                        return {};
+                    }
+                    return make_lw_shared<cql3::untyped_result_set>(*result_set);
+        });
     }
 };
 

--- a/cdc/cdc.cc
+++ b/cdc/cdc.cc
@@ -372,41 +372,47 @@ public:
 
                 std::vector<bytes_opt> values(3);
 
-                r.row().cells().for_each_cell([&](column_id id, const atomic_cell_or_collection& cell) {
-                    auto& cdef = _schema->column_at(column_kind::regular_column, id);
-                    auto* dst = _log_schema->get_column_definition(to_bytes("_" + cdef.name()));
-                    // todo: collections.
-                    if (cdef.is_atomic()) {
-                        column_op op;
+                auto process_cells = [&](const row& r, column_kind ckind) {
+                    r.for_each_cell([&](column_id id, const atomic_cell_or_collection& cell) {
+                        auto& cdef = _schema->column_at(ckind, id);
+                        auto* dst = _log_schema->get_column_definition(to_bytes("_" + cdef.name()));
+                        // todo: collections.
+                        if (cdef.is_atomic()) {
+                            column_op op;
 
-                        values[1] = values[2] = std::nullopt;
-                        auto view = cell.as_atomic_cell(cdef);
-                        if (view.is_live()) {
-                            op = column_op::set;
-                            values[1] = view.value().linearize();
-                            if (view.is_live_and_has_ttl()) {
-                                values[2] = long_type->decompose(data_value(view.ttl().count()));
+                            values[1] = values[2] = std::nullopt;
+                            auto view = cell.as_atomic_cell(cdef);
+                            if (view.is_live()) {
+                                op = column_op::set;
+                                values[1] = view.value().linearize();
+                                if (view.is_live_and_has_ttl()) {
+                                    values[2] = long_type->decompose(data_value(view.ttl().count()));
+                                }
+                            } else {
+                                op = column_op::del;
+                            }
+
+                            values[0] = data_type_for<column_op_native_type>()->decompose(data_value(static_cast<column_op_native_type>(op)));
+                            res.set_cell(log_ck, *dst, atomic_cell::make_live(*dst->type, _time.timestamp(), tuple_type_impl::build_value(values)));
+
+                            if (pirow && pirow->has(cdef.name_as_text())) {
+                                values[0] = data_type_for<column_op_native_type>()->decompose(data_value(static_cast<column_op_native_type>(column_op::set)));
+                                values[1] = pirow->get_blob(cdef.name_as_text());
+                                values[2] = std::nullopt;
+
+                                assert(std::addressof(res.partition().clustered_row(*_log_schema, *pikey)) != std::addressof(res.partition().clustered_row(*_log_schema, log_ck)));
+                                assert(pikey->explode() != log_ck.explode());
+                                res.set_cell(*pikey, *dst, atomic_cell::make_live(*dst->type, _time.timestamp(), tuple_type_impl::build_value(values)));
                             }
                         } else {
-                            op = column_op::del;
+                            cdc_log.warn("Non-atomic cell ignored {}.{}:{}", _schema->ks_name(), _schema->cf_name(), cdef.name_as_text());                            
                         }
+                    });
+                };
 
-                        values[0] = data_type_for<column_op_native_type>()->decompose(data_value(static_cast<column_op_native_type>(op)));
-                        res.set_cell(log_ck, *dst, atomic_cell::make_live(*dst->type, _time.timestamp(), tuple_type_impl::build_value(values)));
+                process_cells(r.row().cells(), column_kind::regular_column);
+                process_cells(p.static_row(), column_kind::static_column);
 
-                        if (pirow && pirow->has(cdef.name_as_text())) {
-                            values[0] = data_type_for<column_op_native_type>()->decompose(data_value(static_cast<column_op_native_type>(column_op::set)));
-                            values[1] = pirow->get_blob(cdef.name_as_text());
-                            values[2] = std::nullopt;
-
-                            assert(std::addressof(res.partition().clustered_row(*_log_schema, *pikey)) != std::addressof(res.partition().clustered_row(*_log_schema, log_ck)));
-                            assert(pikey->explode() != log_ck.explode());
-                            res.set_cell(*pikey, *dst, atomic_cell::make_live(*dst->type, _time.timestamp(), tuple_type_impl::build_value(values)));
-                        }
-                    } else {
-                        cdc_log.warn("Non-atomic cell ignored {}.{}:{}", _schema->ks_name(), _schema->cf_name(), cdef.name_as_text());
-                    }
-                });
                 set_operation(log_ck, operation::update, res);
                 ++batch_no;
             }

--- a/cdc/cdc.hh
+++ b/cdc/cdc.hh
@@ -166,6 +166,19 @@ struct db_context final {
 /// param[in] schema schema of a table for which CDC tables are being created
 seastar::future<> setup(db_context ctx, schema_ptr schema);
 
+// cdc log table operation
+enum class operation : int8_t {
+    // note: these values will eventually be read by a third party, probably not privvy to this
+    // enum decl, so don't change the constant values (or the datatype). 
+    pre_image = 0, update = 1, row_delete = 2, range_delete_start = 3, range_delete_end = 4, partition_delete = 5
+};
+
+// cdc log data column operation
+enum class column_op : int8_t {
+    // same as "operation". Do not edit values or type/type unless you _really_ want to. 
+    set = 0, del = 1, add = 2,
+};
+
 /// \brief Deletes CDC Log and CDC Description tables for a given table
 ///
 /// This function cleans up all CDC related tables created for a given table.

--- a/cql3/untyped_result_set.cc
+++ b/cql3/untyped_result_set.cc
@@ -69,25 +69,34 @@ bool cql3::untyped_result_set_row::has(const sstring& name) const {
 
 using cql_transport::messages::result_message;
 
+cql3::untyped_result_set::untyped_result_set(const cql3::result_set& rs) {
+    auto& cn = rs.get_metadata().get_names();
+    for (auto& r : rs.rows()) {
+        // r is const ref. TODO: make this more efficient by either wrapping result set
+        // or adding modifying accessors to it. 
+        _rows.emplace_back(cn, r); 
+    }
+}
+
 cql3::untyped_result_set::untyped_result_set(::shared_ptr<result_message> msg)
     : _rows([msg]{
     class visitor : public result_message::visitor_base {
     public:
-        rows_type rows;
+        std::optional<untyped_result_set> res;
         void visit(const result_message::rows& rmrs) override {
             auto& rs = rmrs.rs();
-            auto& cn = rs.get_metadata().get_names();
-            auto set = rs.result_set();
-            for (auto& r : set.rows()) {
-                rows.emplace_back(cn, std::move(r));
-            }
+            auto set = rs.result_set(); // accessor by value. 
+            res.emplace(set); // construct untyped_result_set by const ref. 
         }
     };
     visitor v;
     if (msg != nullptr) {
         msg->accept(v);
     }
-    return std::move(v.rows);
+    if (v.res) {
+        return std::move(v.res->_rows);
+    }
+    return rows_type{};
 }())
 {}
 

--- a/cql3/untyped_result_set.hh
+++ b/cql3/untyped_result_set.hh
@@ -63,12 +63,15 @@ public:
     untyped_result_set_row(const untyped_result_set_row&) = delete;
 
     bool has(const sstring&) const;
-    bytes get_blob(const sstring& name) const {
+    bytes_view get_view(const sstring& name) const {
         return *_data.at(name);
+    }
+    bytes get_blob(const sstring& name) const {
+        return bytes(get_view(name));
     }
     template<typename T>
     T get_as(const sstring& name) const {
-        return value_cast<T>(data_type_for<T>()->deserialize(get_blob(name)));
+        return value_cast<T>(data_type_for<T>()->deserialize(get_view(name)));
     }
     template<typename T>
     std::optional<T> get_opt(const sstring& name) const {
@@ -87,7 +90,7 @@ public:
         auto vec =
                 value_cast<map_type_impl::native_type>(
                         map_type_impl::get_instance(keytype, valtype, false)->deserialize(
-                                get_blob(name)));
+                                get_view(name)));
         std::transform(vec.begin(), vec.end(), out,
                 [](auto& p) {
                     return std::pair<K, V>(value_cast<K>(p.first), value_cast<V>(p.second));
@@ -106,7 +109,7 @@ public:
         auto vec =
                 value_cast<list_type_impl::native_type>(
                         list_type_impl::get_instance(valtype, false)->deserialize(
-                                get_blob(name)));
+                                get_view(name)));
         std::transform(vec.begin(), vec.end(), out, [](auto& v) { return value_cast<V>(v); });
     }
     template<typename V, typename ... Rest>

--- a/cql3/untyped_result_set.hh
+++ b/cql3/untyped_result_set.hh
@@ -143,6 +143,8 @@ public:
     }
 };
 
+class result_set;
+
 class untyped_result_set {
 public:
     using row = untyped_result_set_row;
@@ -151,6 +153,7 @@ public:
     using iterator = rows_type::const_iterator;
 
     untyped_result_set(::shared_ptr<cql_transport::messages::result_message>);
+    untyped_result_set(const cql3::result_set&);
     untyped_result_set(untyped_result_set&&) = default;
 
     const_iterator begin() const {

--- a/tests/cdc_test.cc
+++ b/tests/cdc_test.cc
@@ -25,6 +25,8 @@
 #include "tests/cql_assertions.hh"
 #include "tests/cql_test_env.hh"
 #include "transport/messages/result_message.hh"
+#include "types.hh"
+#include "types/tuple.hh"
 
 SEASTAR_THREAD_TEST_CASE(test_with_cdc_parameter) {
     do_with_cql_env_thread([](cql_test_env& e) {
@@ -87,6 +89,49 @@ SEASTAR_THREAD_TEST_CASE(test_with_cdc_parameter) {
     }).get();
 }
 
+static std::vector<std::vector<bytes_opt>> to_bytes(const cql_transport::messages::result_message::rows& rows) {
+    auto rs = rows.rs().result_set().rows();
+    std::vector<std::vector<bytes_opt>> results;
+    for (auto it = rs.begin(); it != rs.end(); ++it) {
+        results.push_back(*it);
+    }
+    return results;
+}
+
+static size_t column_index(const cql_transport::messages::result_message::rows& rows, const sstring& name) {
+    size_t res = 0;
+    for (auto& col : rows.rs().get_metadata().get_names()) {
+        if (col->name->text() == name) {
+            return res;
+        }
+        ++res;
+    }
+    throw std::invalid_argument("No such column: " + name);
+}
+
+template<typename Comp = std::equal_to<bytes_opt>>
+static std::vector<std::vector<bytes_opt>> to_bytes_filtered(const cql_transport::messages::result_message::rows& rows, cdc::operation op, const Comp& comp = {}) {
+    static const auto op_type = data_type_for<std::underlying_type_t<cdc::operation>>();
+
+    auto results = to_bytes(rows);
+    auto op_index = column_index(rows, "operation");
+    auto op_bytes = op_type->decompose(std::underlying_type_t<cdc::operation>(op));
+
+    results.erase(std::remove_if(results.begin(), results.end(), [&](const std::vector<bytes_opt>& bo) {
+        return !comp(op_bytes, bo[op_index]);
+    }), results.end());
+
+    return results;
+}
+
+static void sort_by_time(const cql_transport::messages::result_message::rows& rows, std::vector<std::vector<bytes_opt>>& results) {
+    auto time_index = column_index(rows, "time");
+    std::sort(results.begin(), results.end(),
+            [time_index] (const std::vector<bytes_opt>& a, const std::vector<bytes_opt>& b) {
+                return timeuuid_type->as_less_comparator()(*a[time_index], *b[time_index]);
+            });
+}
+
 SEASTAR_THREAD_TEST_CASE(test_primary_key_logging) {
     do_with_cql_env_thread([](cql_test_env& e) {
         cquery_nofail(e, "CREATE TABLE ks.tbl (pk int, pk2 int, ck int, ck2 int, val int, PRIMARY KEY((pk, pk2), ck, ck2)) WITH cdc = {'enabled':'true'}");
@@ -100,18 +145,14 @@ SEASTAR_THREAD_TEST_CASE(test_primary_key_logging) {
         cquery_nofail(e, "DELETE FROM ks.tbl WHERE pk = 1 AND pk2 = 11 AND ck > 222 AND ck <= 444");
         cquery_nofail(e, "UPDATE ks.tbl SET val = 555 WHERE pk = 2 AND pk2 = 11 AND ck = 111 AND ck2 = 1111");
         cquery_nofail(e, "DELETE FROM ks.tbl WHERE pk = 1 AND pk2 = 11");
-        auto msg = e.execute_cql(format("SELECT time, \"_pk\", \"_pk2\", \"_ck\", \"_ck2\" FROM ks.{}", cdc::log_name("tbl"))).get0();
+        auto msg = e.execute_cql(format("SELECT time, \"_pk\", \"_pk2\", \"_ck\", \"_ck2\", operation FROM ks.{}", cdc::log_name("tbl"))).get0();
         auto rows = dynamic_pointer_cast<cql_transport::messages::result_message::rows>(msg);
         BOOST_REQUIRE(rows);
-        auto rs = rows->rs().result_set().rows();
-        std::vector<std::vector<bytes_opt>> results;
-        for (auto it = rs.begin(); it != rs.end(); ++it) {
-            results.push_back(*it);
-        }
-        std::sort(results.begin(), results.end(),
-                [] (const std::vector<bytes_opt>& a, const std::vector<bytes_opt>& b) {
-                    return timeuuid_type->as_less_comparator()(*a[0], *b[0]);
-                });
+
+        auto results = to_bytes_filtered(*rows, cdc::operation::pre_image, std::not_equal_to<bytes_opt>{});
+
+        sort_by_time(*rows, results);
+
         auto actual_i = results.begin();
         auto actual_end = results.end();
         auto assert_row = [&] (int pk, int pk2, int ck = -1, int ck2 = -1) {
@@ -155,5 +196,54 @@ SEASTAR_THREAD_TEST_CASE(test_primary_key_logging) {
         // DELETE FROM ks.tbl WHERE pk = 1 AND pk2 = 11
         assert_row(1, 11);
         BOOST_REQUIRE(actual_i == actual_end);
+    }).get();
+}
+
+SEASTAR_THREAD_TEST_CASE(test_pre_image_logging) {
+    do_with_cql_env_thread([](cql_test_env& e) {
+        cquery_nofail(e, "CREATE TABLE ks.tbl (pk int, pk2 int, ck int, ck2 int, val int, PRIMARY KEY((pk, pk2), ck, ck2)) WITH cdc = {'enabled':'true'}");
+        cquery_nofail(e, "INSERT INTO ks.tbl(pk, pk2, ck, ck2, val) VALUES(1, 11, 111, 1111, 11111)");
+
+        auto select_log = [&] {
+            auto msg = e.execute_cql(format("SELECT * FROM ks.{}", cdc::log_name("tbl"))).get0();
+            auto rows = dynamic_pointer_cast<cql_transport::messages::result_message::rows>(msg);
+            BOOST_REQUIRE(rows);
+            return rows;
+        };
+
+        auto rows = select_log();        
+
+        BOOST_REQUIRE(to_bytes_filtered(*rows, cdc::operation::pre_image).empty());
+
+        auto first = to_bytes_filtered(*rows, cdc::operation::update);
+
+        auto ck2_index = column_index(*rows, "_ck2");
+        auto val_index = column_index(*rows, "_val");
+
+        auto val_type = tuple_type_impl::get_instance({ data_type_for<std::underlying_type_t<cdc::column_op>>(), int32_type, long_type});
+        auto val = *first[0][val_index];
+
+        BOOST_REQUIRE_EQUAL(int32_type->decompose(1111), first[0][ck2_index]);
+        BOOST_REQUIRE_EQUAL(data_value(11111), value_cast<tuple_type_impl::native_type>(val_type->deserialize(bytes_view(val))).at(1));
+
+        auto last = 11111;
+        for (auto i = 0u; i < 10; ++i) {
+            auto nv = last + 1;
+            cquery_nofail(e, "UPDATE ks.tbl SET val=" + std::to_string(nv) +" where pk=1 AND pk2=11 AND ck=111 AND ck2=1111");
+
+            rows = select_log();      
+
+            auto pre_image = to_bytes_filtered(*rows, cdc::operation::pre_image);
+            auto second = to_bytes_filtered(*rows, cdc::operation::update);
+            sort_by_time(*rows, second);
+
+            BOOST_REQUIRE_EQUAL(pre_image.size(), i + 1);
+
+            val = *pre_image.back()[val_index];
+            BOOST_REQUIRE_EQUAL(int32_type->decompose(1111), pre_image[0][ck2_index]);
+            BOOST_REQUIRE_EQUAL(data_value(last), value_cast<tuple_type_impl::native_type>(val_type->deserialize(bytes_view(val))).at(1));
+
+            last = nv;
+        }
     }).get();
 }

--- a/tests/cql_assertions.cc
+++ b/tests/cql_assertions.cc
@@ -180,7 +180,7 @@ rows_assertions rows_assertions::with_serialized_columns_count(size_t columns_co
 }
 
 shared_ptr<cql_transport::messages::result_message> cquery_nofail(
-        cql_test_env& env, const char* query, std::unique_ptr<cql3::query_options>&& qo, const std::experimental::source_location& loc) {
+        cql_test_env& env, const seastar::sstring& query, std::unique_ptr<cql3::query_options>&& qo, const std::experimental::source_location& loc) {
     try {
         if (qo) {
             return env.execute_cql(query, std::move(qo)).get0();

--- a/tests/cql_assertions.hh
+++ b/tests/cql_assertions.hh
@@ -85,6 +85,6 @@ void assert_that_failed(future<T...>&& f)
 /// \note Should be called from a seastar::thread context, as it awaits the CQL result.
 shared_ptr<cql_transport::messages::result_message> cquery_nofail(
         cql_test_env& env,
-        const char* query,
+        const seastar::sstring& query,
         std::unique_ptr<cql3::query_options>&& qo = nullptr,
         const std::experimental::source_location& loc = std::experimental::source_location::current());


### PR DESCRIPTION
Adds delta and pre-image data column writes for the atomic columns in a cdc-enabled table. 

Note that in this patch set it is still unconditional. Adding option support comes in next set. 

Uses code more or less derived from alternator to select pre-image, using raw query interface. So should be fairly low overhead to query generation. Pre-image and delta mutations are mixed in with the actual modification mutations to generate the full cdc log (sans post-image). 

Rebased on lastest master as of 2019-10-21.