### PR TITLE
misc_services: Don't gossip hit rates when they are not used

### DIFF
--- a/database.hh
+++ b/database.hh
@@ -876,7 +876,7 @@ public:
     }
 
     void set_hit_rate(gms::inet_address addr, cache_temperature rate);
-    cache_hit_rate get_hit_rate(gms::inet_address addr);
+    std::optional<cache_hit_rate> get_hit_rate(gms::inet_address addr);
     void drop_hit_rate(gms::inet_address addr);
 
     future<> run_with_compaction_disabled(std::function<future<> ()> func);

--- a/db/consistency_level.cc
+++ b/db/consistency_level.cc
@@ -214,15 +214,18 @@ filter_for_query(consistency_level cl,
         auto get_hit_rate = [cf] (gms::inet_address ep) -> float {
             constexpr float max_hit_rate = 0.999;
             auto ht = cf->get_hit_rate(ep);
-            if (float(ht.rate) < 0) {
-                return float(ht.rate);
-            } else if (lowres_clock::now() - ht.last_updated > std::chrono::milliseconds(1000)) {
+            if (!ht) {
+                return 0.0;
+            }
+            if (float(ht->rate) < 0) {
+                return float(ht->rate);
+            } else if (lowres_clock::now() - ht->last_updated > std::chrono::milliseconds(1000)) {
                 // if a cache entry is not updates for a while try to send traffic there
                 // to get more up to date data, mark it updated to not send to much traffic there
-                cf->set_hit_rate(ep, ht.rate);
+                cf->set_hit_rate(ep, ht->rate);
                 return max_hit_rate;
             } else {
-                return std::min(float(ht.rate), max_hit_rate); // calculation below cannot work with hit rate 1
+                return std::min(float(ht->rate), max_hit_rate); // calculation below cannot work with hit rate 1
             }
         };
 

--- a/main.cc
+++ b/main.cc
@@ -1027,12 +1027,20 @@ int main(int ac, char** av) {
                 lb->stop_broadcasting().get();
             });
             supervisor::notify("starting cf cache hit rate calculator");
-            cf_cache_hitrate_calculator.start(std::ref(db), std::ref(cf_cache_hitrate_calculator)).get();
-            auto stop_cache_hitrate_calculator = defer_with_log_on_error([&cf_cache_hitrate_calculator] {
+
+            if (db.local().get_config().cache_hit_rate_read_balancing()) {
+                cf_cache_hitrate_calculator.start(std::ref(db), std::ref(cf_cache_hitrate_calculator)).get();
+            }
+            auto stop_cache_hitrate_calculator = defer_with_log_on_error([&cf_cache_hitrate_calculator, &db] {
+                if (!db.local().get_config().cache_hit_rate_read_balancing()) {
+                    return;
+                }
                 startlog.info("stopping cf cache hit rate calculator");
-                return cf_cache_hitrate_calculator.stop().get();
+                cf_cache_hitrate_calculator.stop().get();
             });
-            cf_cache_hitrate_calculator.local().run_on(engine().cpu_id());
+            if (db.local().get_config().cache_hit_rate_read_balancing()) {
+                cf_cache_hitrate_calculator.local().run_on(engine().cpu_id());
+            }
 
             supervisor::notify("starting view update backlog broker");
             static sharded<service::view_update_backlog_broker> view_backlog_broker;

--- a/service/misc_services.cc
+++ b/service/misc_services.cc
@@ -40,6 +40,7 @@
 
 #include "load_broadcaster.hh"
 #include "cache_hitrate_calculator.hh"
+#include "db/config.hh"
 #include "db/system_keyspace.hh"
 #include "gms/application_state.hh"
 #include "service/storage_service.hh"

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -3058,7 +3058,8 @@ storage_proxy::query_partition_key_range_concurrent(storage_proxy::clock_type::t
                     struct {
                         column_family* cf = nullptr;
                         float operator()(const gms::inet_address& ep) const {
-                            return float(cf->get_hit_rate(ep).rate);
+                            auto ht = cf->get_hit_rate(ep);
+                            return ht ? float(ht->rate) : 0.0;
                         }
                     } ep_to_hr{pcf};
                     return *boost::range::min_element(range | boost::adaptors::transformed(ep_to_hr));

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -536,7 +536,8 @@ void storage_service::prepare_to_join(std::vector<inet_address> loaded_endpoints
     app_states.emplace(gms::application_state::RPC_ADDRESS, value_factory.rpcaddress(broadcast_rpc_address));
     app_states.emplace(gms::application_state::RELEASE_VERSION, value_factory.release_version());
     app_states.emplace(gms::application_state::SUPPORTED_FEATURES, value_factory.supported_features(features));
-    app_states.emplace(gms::application_state::CACHE_HITRATES, value_factory.cache_hitrates(""));
+    app_states.emplace(gms::application_state::CACHE_HITRATES,
+            value_factory.cache_hitrates(db().local().get_config().cache_hit_rate_read_balancing() ? "" : "DISABLED"));
     app_states.emplace(gms::application_state::SCHEMA_TABLES_VERSION, versioned_value(db::schema_tables::version));
     app_states.emplace(gms::application_state::RPC_READY, value_factory.cql_ready(false));
     app_states.emplace(gms::application_state::VIEW_BACKLOG, versioned_value(""));


### PR DESCRIPTION
When cache_hit_rate_read_balancing is set to false,
heat-weighted load balancing is turned off and we
gossip cache hit rates for no good reason.
The size of gossiped data is linear on number of tables
in the database so it's good to avoid such traffic
when it is not used.

Fixes #5183

Signed-off-by: Piotr Jastrzebski piotr@scylladb.com