### PR TITLE
storage_service: Reject nodetool cleanup when there is pending ranges

### DIFF
--- a/dht/boot_strapper.cc
+++ b/dht/boot_strapper.cc
@@ -62,7 +62,9 @@ future<> boot_strapper::bootstrap() {
         return streamer->add_ranges(keyspace_name, ranges);
     }).then([this, streamer] {
         _abort_source.check();
-        return streamer->stream_async().handle_exception([streamer] (std::exception_ptr eptr) {
+        return streamer->stream_async().then([streamer] () {
+            service::get_local_storage_service().finish_bootstrapping();
+        }).handle_exception([streamer] (std::exception_ptr eptr) {
             blogger.warn("Error during bootstrap: {}", eptr);
             return make_exception_future<>(std::move(eptr));
         });

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -715,6 +715,11 @@ void storage_service::join_token_ring(int delay) {
         db::system_keyspace::update_tokens(_bootstrap_tokens).get();
         bootstrap();
         // bootstrap will block until finished
+        if (_is_bootstrap_mode) {
+            auto err = format("We are not supposed in bootstrap mode any more");
+            slogger.warn("{}", err);
+            throw std::runtime_error(err);
+        }
     } else {
         maybe_start_sys_dist_ks();
         size_t num_tokens = _db.local().get_config().num_tokens();
@@ -819,6 +824,7 @@ void storage_service::mark_existing_views_as_built() {
 
 // Runs inside seastar::async context
 void storage_service::bootstrap() {
+    _is_bootstrap_mode = true;
     if (!db().local().is_replacing()) {
         // Wait until we know tokens of existing node before announcing join status.
         _gossiper.wait_for_range_setup().get();

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -259,6 +259,9 @@ private:
 
     std::optional<inet_address> _removing_node;
 
+    /* Are we starting this node in bootstrap mode? */
+    bool _is_bootstrap_mode;
+
     bool _initialized;
 
     bool _joined = false;
@@ -343,6 +346,10 @@ private:
 public:
     sstables::sstable_version_types sstables_format() const { return _sstables_format; }
     void enable_all_features();
+
+    void finish_bootstrapping() {
+        _is_bootstrap_mode = false;
+    }
 
     void set_gossip_tokens(const std::unordered_set<dht::token>& local_tokens);
 #if 0
@@ -547,6 +554,10 @@ private:
     void bootstrap();
 
 public:
+    bool is_bootstrap_mode() {
+        return _is_bootstrap_mode;
+    }
+
 #if 0
 
     public TokenMetadata getTokenMetadata()

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -2379,6 +2379,8 @@ private:
     void notify_up(inet_address endpoint);
     void notify_joined(inet_address endpoint);
     void notify_cql_change(inet_address endpoint, bool ready);
+public:
+    future<bool> is_cleanup_allowed(sstring keyspace);
 };
 
 future<> init_storage_service(sharded<abort_source>& abort_sources, distributed<database>& db, sharded<gms::gossiper>& gossiper, sharded<auth::service>& auth_service,


### PR DESCRIPTION
From Shlomi:
```
4 node cluster Node A, B, C, D (Node A: seed)
cassandra-stress write n=10000000 -pop seq=1..10000000 -node <seed-node>
cassandra-stress read duration=10h -pop seq=1..10000000 -node <seed-node>
while read is progressing
Node D: nodetool decommission
Node A: nodetool status node - wait for UL
Node A: nodetool cleanup (while decommission progresses)

I get the error on c-s once decommission ends
  java.io.IOException: Operation x0 on key(s) [383633374d31504b5030]: Data returned was not validated
```
The problem is when a node gets new ranges, e.g, the bootstrapping node, the
existing nodes after a node is removed or decommissioned, nodetool cleanup will
remove data within the new ranges which the node just gets from other nodes.

To fix, we should reject the nodetool cleanup when there is pending ranges on that node.

Note, rejecting nodetool cleanup is not a full protection because new ranges
can be assigned to the node while cleanup is still in progress. However, it is
a good start to reject until we have full protection solution.

Refs: #5045
