### PR TITLE
Fix TTL serialization breakage

### DIFF
--- a/db/config.cc
+++ b/db/config.cc
@@ -700,6 +700,10 @@ db::config::config(std::shared_ptr<db::extensions> exts)
     , max_clustering_key_restrictions_per_query(this, "max_clustering_key_restrictions_per_query", liveness::LiveUpdate, value_status::Used, 100,
             "Maximum number of distinct clustering key restrictions per query. This limit places a bound on the size of IN tuples, "
             "especially when multiple clustering key columns have IN restrictions. Increasing this value can result in server instability.")
+    , enable_3_1_0_compatibility_mode(this, "enable_3_1_0_compatibility_mode", value_status::Used, false,
+        "Set to true if the cluster was initially installed from 3.1.0. If it was upgraded from an earlier version,"
+        " or installed from a later version, leave this set to false. This adjusts the communication protocol to"
+        " work around a bug in Scylla 3.1.0")
     , alternator_port(this, "alternator_port", value_status::Used, 0, "Alternator API port")
     , alternator_https_port(this, "alternator_https_port", value_status::Used, 0, "Alternator API HTTPS port")
     , alternator_address(this, "alternator_address", value_status::Used, "0.0.0.0", "Alternator API listening address")

--- a/db/config.hh
+++ b/db/config.hh
@@ -285,6 +285,7 @@ public:
     named_value<bool> abort_on_internal_error;
     named_value<uint32_t> max_partition_key_restrictions_per_query;
     named_value<uint32_t> max_clustering_key_restrictions_per_query;
+    named_value<bool> enable_3_1_0_compatibility_mode;
 
     named_value<uint16_t> alternator_port;
     named_value<uint16_t> alternator_https_port;

--- a/gc_clock.hh
+++ b/gc_clock.hh
@@ -86,3 +86,37 @@ struct appending_hash<gc_clock::time_point> {
         }
     }
 };
+
+
+namespace ser {
+
+// Forward-declaration - defined in serializer.hh, to avoid including it here.
+
+template <typename Output>
+void serialize_gc_clock_duration_value(Output& out, int64_t value);
+
+template <typename Input>
+int64_t deserialize_gc_clock_duration_value(Input& in);
+
+template <typename T>
+struct serializer;
+
+template <>
+struct serializer<gc_clock::duration> {
+    template <typename Input>
+    static gc_clock::duration read(Input& in) {
+        return gc_clock::duration(deserialize_gc_clock_duration_value(in));
+    }
+
+    template <typename Output>
+    static void write(Output& out, gc_clock::duration d) {
+        serialize_gc_clock_duration_value(out, d.count());
+    }
+
+    template <typename Input>
+    static void skip(Input& in) {
+        read(in);
+    }
+};
+
+}

--- a/serializer.hh
+++ b/serializer.hh
@@ -303,6 +303,38 @@ struct normalize<bytes_ostream> {
 template <typename T, typename U>
 struct is_equivalent : std::is_same<typename normalize<std::remove_const_t<std::remove_reference_t<T>>>::type, typename normalize<std::remove_const_t <std::remove_reference_t<U>>>::type> {
 };
+
+// gc_clock duration values were serialized as 32-bit prior to 3.1, and
+// are serialized as 64-bit in 3.1.0.
+//
+// TTL values are capped to 20 years, which fits into 32 bits, so
+// truncation is not a concern.
+
+inline bool gc_clock_using_3_1_0_serialization = false;
+
+template <typename Output>
+void
+serialize_gc_clock_duration_value(Output& out, int64_t v) {
+    if (!gc_clock_using_3_1_0_serialization) {
+        // This should have been caught by the CQL layer, so this is just
+        // for extra safety.
+        assert(int32_t(v) == v);
+        serializer<int32_t>::write(out, v);
+    } else {
+        serializer<int64_t>::write(out, v);
+    }
+}
+
+template <typename Input>
+int64_t
+deserialize_gc_clock_duration_value(Input& in) {
+    if (!gc_clock_using_3_1_0_serialization) {
+        return serializer<int32_t>::read(in);
+    } else {
+        return serializer<int64_t>::read(in);
+    }
+}
+
 }
 
 /*


### PR DESCRIPTION
Commit 93270dd8e04e3caf0e7586311badbaf121c14d3f changed gc_clock to be 64-bit, to fix the Y2038 problem. While 64-bit tombstone::deletion_time is serialized in a compatible way, TTLs (gc_clock::duration) were not.

This patchset reverts TTL serialization to the 32-bit serialization format, and also allows opting-in to the 64-bit format in case a cluster was installed with the broken code. Only Scylla 3.1.0 is vulnerable.

Fixes #4855 

Tests: unit (dev)