### PR TITLE
Return preimage from CDC only when it's enabled

### DIFF
--- a/tests/cdc_test.cc
+++ b/tests/cdc_test.cc
@@ -201,7 +201,7 @@ SEASTAR_THREAD_TEST_CASE(test_primary_key_logging) {
 
 SEASTAR_THREAD_TEST_CASE(test_pre_image_logging) {
     do_with_cql_env_thread([](cql_test_env& e) {
-        cquery_nofail(e, "CREATE TABLE ks.tbl (pk int, pk2 int, ck int, ck2 int, val int, PRIMARY KEY((pk, pk2), ck, ck2)) WITH cdc = {'enabled':'true'}");
+        cquery_nofail(e, "CREATE TABLE ks.tbl (pk int, pk2 int, ck int, ck2 int, val int, PRIMARY KEY((pk, pk2), ck, ck2)) WITH cdc = {'enabled':'true', 'preimage':'true'}");
         cquery_nofail(e, "INSERT INTO ks.tbl(pk, pk2, ck, ck2, val) VALUES(1, 11, 111, 1111, 11111)");
 
         auto select_log = [&] {

--- a/tests/cdc_test.cc
+++ b/tests/cdc_test.cc
@@ -20,6 +20,7 @@
  */
 
 #include <seastar/testing/thread_test_case.hh>
+#include <string>
 
 #include "cdc/cdc.hh"
 #include "tests/cql_assertions.hh"
@@ -27,6 +28,8 @@
 #include "transport/messages/result_message.hh"
 #include "types.hh"
 #include "types/tuple.hh"
+
+using namespace std::string_literals;
 
 SEASTAR_THREAD_TEST_CASE(test_with_cdc_parameter) {
     do_with_cql_env_thread([](cql_test_env& e) {
@@ -201,49 +204,58 @@ SEASTAR_THREAD_TEST_CASE(test_primary_key_logging) {
 
 SEASTAR_THREAD_TEST_CASE(test_pre_image_logging) {
     do_with_cql_env_thread([](cql_test_env& e) {
-        cquery_nofail(e, "CREATE TABLE ks.tbl (pk int, pk2 int, ck int, ck2 int, val int, PRIMARY KEY((pk, pk2), ck, ck2)) WITH cdc = {'enabled':'true', 'preimage':'true'}");
-        cquery_nofail(e, "INSERT INTO ks.tbl(pk, pk2, ck, ck2, val) VALUES(1, 11, 111, 1111, 11111)");
+        auto test = [&e] (bool enabled) {
+            cquery_nofail(e, "CREATE TABLE ks.tbl (pk int, pk2 int, ck int, ck2 int, val int, PRIMARY KEY((pk, pk2), ck, ck2)) WITH cdc = {'enabled':'true', 'preimage':'"s + (enabled ? "true" : "false") + "'}");
+            cquery_nofail(e, "INSERT INTO ks.tbl(pk, pk2, ck, ck2, val) VALUES(1, 11, 111, 1111, 11111)");
 
-        auto select_log = [&] {
-            auto msg = e.execute_cql(format("SELECT * FROM ks.{}", cdc::log_name("tbl"))).get0();
-            auto rows = dynamic_pointer_cast<cql_transport::messages::result_message::rows>(msg);
-            BOOST_REQUIRE(rows);
-            return rows;
+            auto select_log = [&] {
+                auto msg = e.execute_cql(format("SELECT * FROM ks.{}", cdc::log_name("tbl"))).get0();
+                auto rows = dynamic_pointer_cast<cql_transport::messages::result_message::rows>(msg);
+                BOOST_REQUIRE(rows);
+                return rows;
+            };
+
+            auto rows = select_log();
+
+            BOOST_REQUIRE(to_bytes_filtered(*rows, cdc::operation::pre_image).empty());
+
+            auto first = to_bytes_filtered(*rows, cdc::operation::update);
+
+            auto ck2_index = column_index(*rows, "_ck2");
+            auto val_index = column_index(*rows, "_val");
+
+            auto val_type = tuple_type_impl::get_instance({ data_type_for<std::underlying_type_t<cdc::column_op>>(), int32_type, long_type});
+            auto val = *first[0][val_index];
+
+            BOOST_REQUIRE_EQUAL(int32_type->decompose(1111), first[0][ck2_index]);
+            BOOST_REQUIRE_EQUAL(data_value(11111), value_cast<tuple_type_impl::native_type>(val_type->deserialize(bytes_view(val))).at(1));
+
+            auto last = 11111;
+            for (auto i = 0u; i < 10; ++i) {
+                auto nv = last + 1;
+                cquery_nofail(e, "UPDATE ks.tbl SET val=" + std::to_string(nv) +" where pk=1 AND pk2=11 AND ck=111 AND ck2=1111");
+
+                rows = select_log();
+
+                auto pre_image = to_bytes_filtered(*rows, cdc::operation::pre_image);
+                auto second = to_bytes_filtered(*rows, cdc::operation::update);
+
+                if (!enabled) {
+                    BOOST_REQUIRE(pre_image.empty());
+                } else {
+                    sort_by_time(*rows, second);
+                    BOOST_REQUIRE_EQUAL(pre_image.size(), i + 1);
+
+                    val = *pre_image.back()[val_index];
+                    BOOST_REQUIRE_EQUAL(int32_type->decompose(1111), pre_image[0][ck2_index]);
+                    BOOST_REQUIRE_EQUAL(data_value(last), value_cast<tuple_type_impl::native_type>(val_type->deserialize(bytes_view(val))).at(1));
+                }
+
+                last = nv;
+            }
+            e.execute_cql("DROP TABLE ks.tbl").get();
         };
-
-        auto rows = select_log();
-
-        BOOST_REQUIRE(to_bytes_filtered(*rows, cdc::operation::pre_image).empty());
-
-        auto first = to_bytes_filtered(*rows, cdc::operation::update);
-
-        auto ck2_index = column_index(*rows, "_ck2");
-        auto val_index = column_index(*rows, "_val");
-
-        auto val_type = tuple_type_impl::get_instance({ data_type_for<std::underlying_type_t<cdc::column_op>>(), int32_type, long_type});
-        auto val = *first[0][val_index];
-
-        BOOST_REQUIRE_EQUAL(int32_type->decompose(1111), first[0][ck2_index]);
-        BOOST_REQUIRE_EQUAL(data_value(11111), value_cast<tuple_type_impl::native_type>(val_type->deserialize(bytes_view(val))).at(1));
-
-        auto last = 11111;
-        for (auto i = 0u; i < 10; ++i) {
-            auto nv = last + 1;
-            cquery_nofail(e, "UPDATE ks.tbl SET val=" + std::to_string(nv) +" where pk=1 AND pk2=11 AND ck=111 AND ck2=1111");
-
-            rows = select_log();
-
-            auto pre_image = to_bytes_filtered(*rows, cdc::operation::pre_image);
-            auto second = to_bytes_filtered(*rows, cdc::operation::update);
-            sort_by_time(*rows, second);
-
-            BOOST_REQUIRE_EQUAL(pre_image.size(), i + 1);
-
-            val = *pre_image.back()[val_index];
-            BOOST_REQUIRE_EQUAL(int32_type->decompose(1111), pre_image[0][ck2_index]);
-            BOOST_REQUIRE_EQUAL(data_value(last), value_cast<tuple_type_impl::native_type>(val_type->deserialize(bytes_view(val))).at(1));
-
-            last = nv;
-        }
+        test(true);
+        test(false);
     }).get();
 }


### PR DESCRIPTION
Users should be able to decide whether they need preimage or not. There is already an option for that but it's not respected by the implementation. This PR adds support for this functionality.

Tests: unit(dev).