### PR TITLE
reloc: do not install dependencies when building the relocatable package

### DIFF
--- a/reloc/build_reloc.sh
+++ b/reloc/build_reloc.sh
@@ -14,7 +14,6 @@ print_usage() {
     echo "  --clean                 clean build directory"
     echo "  --compiler PATH         C++ compiler path"
     echo "  --c-compiler PATH       C compiler path"
-    echo "  --nodeps                skip installing dependencies"
     exit 1
 }
 
@@ -24,7 +23,6 @@ JOBS=
 CLEAN=
 COMPILER=
 CCOMPILER=
-NODEPS=
 while [ $# -gt 0 ]; do
     case "$1" in
         "--configure-flags")
@@ -52,7 +50,6 @@ while [ $# -gt 0 ]; do
             shift 2
             ;;
         "--nodeps")
-            NODEPS=yes
             shift 1
             ;;
         *)
@@ -80,10 +77,6 @@ fi
 
 if [ -f build/$MODE/scylla-package.tar.gz ]; then
     rm build/$MODE/scylla-package.tar.gz
-fi
-
-if [ -z "$NODEPS" ]; then
-    sudo ./install-dependencies.sh
 fi
 
 NINJA=$(which ninja-build) &&:


### PR DESCRIPTION
The dependencies are provided by the frozen toolchain. If a dependency
is missing, we must update the toolchain rather than rely on build-time
installation, which is not reproducible (as different package versions
are available at different times).

Luckily "dnf install" does not update an already-installed package. Had
that been a case, none of our builds would have been reproducible, since
packages would be updated to the latest version as of the build time rather
than the version selected by the frozen toolchain.

So, to prevent missing packages in the frozen toolchain translating to
an unreproducible build, remove the support for installing dependencies
from reloc/build_reloc.sh. We still parse the --nodeps option in case some
script uses it.

Fixes #5222.

Tests: reloc/build_reloc.sh.