### PR TITLE
test_udt_mutations fixes

### DIFF
--- a/tests/mutation_test.cc
+++ b/tests/mutation_test.cc
@@ -361,7 +361,7 @@ SEASTAR_THREAD_TEST_CASE(test_udt_mutations) {
     i->as_collection_mutation().with_deserialized(*ut, [&] (collection_mutation_view_description m) {
         // one cell for each field that has been set. mut3 and mut1 should have been merged
         BOOST_REQUIRE(m.cells.size() == 3);
-        BOOST_REQUIRE(std::all_of(m.cells.begin(), m.cells.begin(), [] (const auto& c) { return c.second.is_live(); }));
+        BOOST_REQUIRE(std::all_of(m.cells.begin(), m.cells.end(), [] (const auto& c) { return c.second.is_live(); }));
 
         auto cells_equal = [] (const auto& c1, const auto& c2) {
             return c1.first == c2.first && c1.second.value().linearize() == c2.second.value().linearize();

--- a/tests/mutation_test.cc
+++ b/tests/mutation_test.cc
@@ -323,7 +323,7 @@ SEASTAR_TEST_CASE(test_list_mutations) {
 }
 
 SEASTAR_THREAD_TEST_CASE(test_udt_mutations) {
-    // (a int, b text, c long)
+    // (a int, b text, c long, d text)
     auto ut = user_type_impl::get_instance("ks", to_bytes("ut"),
             {to_bytes("a"), to_bytes("b"), to_bytes("c"), to_bytes("d")},
             {int32_type, utf8_type, long_type, utf8_type},

--- a/tests/mutation_test.cc
+++ b/tests/mutation_test.cc
@@ -337,7 +337,7 @@ SEASTAR_THREAD_TEST_CASE(test_udt_mutations) {
 
     // {a: 0, c: 2}
     auto mut1 = make_collection_mutation({}, serialize_field_index(0), make_collection_member(int32_type, 0),
-            serialize_field_index(2), make_collection_member(long_type, 2));
+            serialize_field_index(2), make_collection_member(long_type, int64_t(2)));
     mutation m1(s, key);
     m1.set_static_cell(column, mut1.serialize(*ut));
     mt->apply(m1);
@@ -349,7 +349,7 @@ SEASTAR_THREAD_TEST_CASE(test_udt_mutations) {
     mt->apply(m2);
 
     // {c: 3}
-    auto mut3 = make_collection_mutation({}, serialize_field_index(2), make_collection_member(long_type, 3));
+    auto mut3 = make_collection_mutation({}, serialize_field_index(2), make_collection_member(long_type, int64_t(3)));
     mutation m3(s, key);
     m3.set_static_cell(column, mut3.serialize(*ut));
     mt->apply(m3);
@@ -370,7 +370,7 @@ SEASTAR_THREAD_TEST_CASE(test_udt_mutations) {
         auto cell_a = std::make_pair(serialize_field_index(0), make_collection_member(int32_type, 0));
         BOOST_REQUIRE(cells_equal(m.cells[0], std::pair<bytes_view, atomic_cell_view>(cell_a.first, cell_a.second)));
 
-        auto cell_c = std::make_pair(serialize_field_index(2), make_collection_member(long_type, 3));
+        auto cell_c = std::make_pair(serialize_field_index(2), make_collection_member(long_type, int64_t(3)));
         BOOST_REQUIRE(cells_equal(m.cells[1], std::pair<bytes_view, atomic_cell_view>(cell_c.first, cell_c.second)));
 
         auto cell_d = std::make_pair(serialize_field_index(3), make_collection_member(utf8_type, "text"));


### PR DESCRIPTION
mutation_test/test_udt_mutations kept failing on my machine and I tracked it down to the 3rd patch in this series (use int64_t constants for long_type).  While at it, this series also fixes a comment and the end iterator in `BOOST_REQUIRE(std::all_of(...))`

mutation_test: test_udt_mutations: fixup udt comment
mutation_test: test_udt_mutations: fix end iterator in call to std::all_of
mutation_test: test_udt_mutations: use int64_t constants for long_type

Test: mutation_test(dev, debug)