### PR TITLE
commitlog: change variadic stream in read_log_file to future<struct>

### DIFF
--- a/db/commitlog/commitlog.hh
+++ b/db/commitlog/commitlog.hh
@@ -102,6 +102,11 @@ public:
     class segment;
 
     friend class rp_handle;
+
+    struct buffer_and_replay_position {
+        fragmented_temporary_buffer buffer;
+        replay_position position;
+    };
 private:
     ::shared_ptr<segment_manager> _segment_manager;
 public:
@@ -344,7 +349,7 @@ public:
     future<std::vector<sstring>> list_existing_segments() const;
     future<std::vector<sstring>> list_existing_segments(const sstring& dir) const;
 
-    typedef std::function<future<>(fragmented_temporary_buffer, replay_position)> commit_load_reader_func;
+    typedef std::function<future<>(buffer_and_replay_position)> commit_load_reader_func;
 
     class segment_error : public std::exception {};
 
@@ -380,7 +385,7 @@ public:
         }
     };
 
-    static future<std::unique_ptr<subscription<fragmented_temporary_buffer, replay_position>>> read_log_file(
+    static future<std::unique_ptr<subscription<buffer_and_replay_position>>> read_log_file(
             const sstring&, const sstring&, seastar::io_priority_class read_io_prio_class, commit_load_reader_func, position_type = 0, const db::extensions* = nullptr);
 private:
     commitlog(config);

--- a/db/hints/manager.cc
+++ b/db/hints/manager.cc
@@ -742,7 +742,8 @@ bool manager::end_point_hints_manager::sender::send_one_file(const sstring& fnam
     lw_shared_ptr<send_one_file_ctx> ctx_ptr = make_lw_shared<send_one_file_ctx>(_last_schema_ver_to_column_mapping);
 
     try {
-        auto s = commitlog::read_log_file(fname, manager::FILENAME_PREFIX, service::get_local_streaming_read_priority(), [this, secs_since_file_mod, &fname, ctx_ptr] (fragmented_temporary_buffer buf, db::replay_position rp) mutable {
+        auto s = commitlog::read_log_file(fname, manager::FILENAME_PREFIX, service::get_local_streaming_read_priority(), [this, secs_since_file_mod, &fname, ctx_ptr] (commitlog::buffer_and_replay_position buf_rp) mutable {
+            auto&& [buf, rp] = buf_rp;
             // Check that we can still send the next hint. Don't try to send it if the destination host
             // is DOWN or if we have already failed to send some of the previous hints.
             if (!draining() && ctx_ptr->state.contains(send_state::segment_replay_failed)) {

--- a/tests/commitlog_test.cc
+++ b/tests/commitlog_test.cc
@@ -306,7 +306,8 @@ SEASTAR_TEST_CASE(test_commitlog_delete_when_over_disk_limit) {
 SEASTAR_TEST_CASE(test_commitlog_reader){
     static auto count_mutations_in_segment = [] (sstring path) -> future<size_t> {
         auto count = make_lw_shared<size_t>(0);
-        return db::commitlog::read_log_file(path, db::commitlog::descriptor::FILENAME_PREFIX, service::get_local_commitlog_priority(), [count](fragmented_temporary_buffer buf, db::replay_position rp) {
+        return db::commitlog::read_log_file(path, db::commitlog::descriptor::FILENAME_PREFIX, service::get_local_commitlog_priority(), [count](db::commitlog::buffer_and_replay_position buf_rp) {
+            auto&& [buf, rp] = buf_rp;
             auto linearization_buffer = bytes_ostream();
             auto in = buf.get_istream();
             auto str = to_sstring_view(in.read_bytes_view(buf.size_bytes(), linearization_buffer));
@@ -410,7 +411,8 @@ SEASTAR_TEST_CASE(test_commitlog_entry_corruption){
                         BOOST_REQUIRE(!segments.empty());
                         auto seg = segments[0];
                         return corrupt_segment(seg, rps->at(1).pos + 4, 0x451234ab).then([seg, rps, &log] {
-                            return db::commitlog::read_log_file(seg, db::commitlog::descriptor::FILENAME_PREFIX, service::get_local_commitlog_priority(), [rps](fragmented_temporary_buffer buf, db::replay_position rp) {
+                            return db::commitlog::read_log_file(seg, db::commitlog::descriptor::FILENAME_PREFIX, service::get_local_commitlog_priority(), [rps](db::commitlog::buffer_and_replay_position buf_rp) {
+                                auto&& [buf, rp] = buf_rp;
                                 BOOST_CHECK_EQUAL(rp, rps->at(0));
                                 return make_ready_future<>();
                             }).then([](auto s) {
@@ -453,7 +455,7 @@ SEASTAR_TEST_CASE(test_commitlog_chunk_corruption){
                         BOOST_REQUIRE(!segments.empty());
                         auto seg = segments[0];
                         return corrupt_segment(seg, rps->at(0).pos - 4, 0x451234ab).then([seg, rps, &log] {
-                            return db::commitlog::read_log_file(seg, db::commitlog::descriptor::FILENAME_PREFIX, service::get_local_commitlog_priority(), [rps](fragmented_temporary_buffer buf, db::replay_position rp) {
+                            return db::commitlog::read_log_file(seg, db::commitlog::descriptor::FILENAME_PREFIX, service::get_local_commitlog_priority(), [rps](db::commitlog::buffer_and_replay_position buf_rp) {
                                 BOOST_FAIL("Should not reach");
                                 return make_ready_future<>();
                             }).then([](auto s) {
@@ -495,7 +497,7 @@ SEASTAR_TEST_CASE(test_commitlog_reader_produce_exception){
                         auto segments = log.get_active_segment_names();
                         BOOST_REQUIRE(!segments.empty());
                         auto seg = segments[0];
-                        return db::commitlog::read_log_file(seg, db::commitlog::descriptor::FILENAME_PREFIX, service::get_local_commitlog_priority(), [](fragmented_temporary_buffer buf, db::replay_position rp) {
+                        return db::commitlog::read_log_file(seg, db::commitlog::descriptor::FILENAME_PREFIX, service::get_local_commitlog_priority(), [](db::commitlog::buffer_and_replay_position buf_rp) {
                             return make_exception_future(std::runtime_error("I am in a throwing mode"));
                         }).then([](auto s) {
                             return do_with(std::move(s), [](auto& s) {


### PR DESCRIPTION
Since seastar::streams are based on future/promise, variadic streams
suffer the same fate as variadic futures - deprecation and eventual
removal.

This patch therefore replaces a variadic stream in commitlog::read_log_file()
with a non-variadic stream, via a helper struct.

Tests: unit (dev)