### PR TITLE
cql3: error msg w/ arg counts for prepared stmts with wrong arg cnt

### DIFF
--- a/cql3/query_processor.cc
+++ b/cql3/query_processor.cc
@@ -277,7 +277,10 @@ query_processor::process(const sstring_view& query_string, service::query_state&
     auto p = get_statement(query_string, query_state.get_client_state());
     auto cql_statement = p->statement;
     if (cql_statement->get_bound_terms() != options.get_values_count()) {
-        throw exceptions::invalid_request_exception("Invalid amount of bind variables");
+        const auto msg = format("Invalid amount of bind variables: expected {:d} received {:d}",
+                cql_statement->get_bound_terms(),
+                options.get_values_count());
+        throw exceptions::invalid_request_exception(msg);
     }
     options.prepare(p->bound_names);
 

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -807,8 +807,11 @@ future<std::unique_ptr<cql_server::response>> cql_server::connection::process_ex
     auto stmt = prepared->statement;
     tracing::trace(query_state.get_trace_state(), "Checking bounds");
     if (stmt->get_bound_terms() != options.get_values_count()) {
-        tracing::trace(query_state.get_trace_state(), "Invalid amount of bind variables: expected {:d} received {:d}", stmt->get_bound_terms(), options.get_values_count());
-        throw exceptions::invalid_request_exception("Invalid amount of bind variables");
+        const auto msg = format("Invalid amount of bind variables: expected {:d} received {:d}",
+                stmt->get_bound_terms(),
+                options.get_values_count());
+        tracing::trace(query_state.get_trace_state(), msg);
+        throw exceptions::invalid_request_exception(msg);
     }
 
     options.prepare(prepared->bound_names);


### PR DESCRIPTION
Issue: https://github.com/scylladb/scylla/issues/3748
Very small change: added argument count (expectation vs. reality) to error msg within `invalid_request_exception` when number of bound params does not match the statement.