### PR TITLE
CDC (atomic) delta + (non-optional) pre-image data columns

### DIFF
--- a/cdc/cdc.cc
+++ b/cdc/cdc.cc
@@ -232,7 +232,7 @@ private:
     schema_ptr _log_schema;
     utils::UUID _time;
     bytes _decomposed_time;
-    const streams_type& _streams;
+    ::shared_ptr<const transformer::streams_type> _streams;
     const column_definition& _op_col;
 
     clustering_key set_pk_columns(const partition_key& pk, int batch_no, mutation& m) const {
@@ -257,24 +257,26 @@ private:
     }
 
     partition_key stream_id(const net::inet_address& ip, unsigned int shard_id) const {
-        auto it = _streams.find(std::make_pair(ip, shard_id));
-        if (it == std::end(_streams)) {
+        auto it = _streams->find(std::make_pair(ip, shard_id));
+        if (it == std::end(*_streams)) {
                 throw std::runtime_error(format("No stream found for node {} and shard {}", ip, shard_id));
         }
         return partition_key::from_exploded(*_log_schema, { uuid_type->decompose(it->second) });
     }
 public:
-    transformer(db_context ctx, schema_ptr s, const streams_type& streams)
+    transformer(db_context ctx, schema_ptr s, ::shared_ptr<const transformer::streams_type> streams)
         : _ctx(ctx)
         , _schema(std::move(s))
         , _log_schema(ctx._proxy.get_db().local().find_schema(_schema->ks_name(), log_name(_schema->cf_name())))
         , _time(utils::UUID_gen::get_time_UUID())
         , _decomposed_time(timeuuid_type->decompose(_time))
-        , _streams(streams)
+        , _streams(std::move(streams))
         , _op_col(*_log_schema->get_column_definition(to_bytes("operation")))
     {}
 
-    mutation transform(const mutation& m) const {
+    // TODO: is pre-image data based on query enough. We only have actual column data. Do we need
+    // more details like tombstones/ttl? Probably not but keep in mind.
+    mutation transform(const mutation& m, const cql3::untyped_result_set* rs = nullptr) const {
         auto& t = m.token();
         auto&& ep = _ctx._token_metadata.get_endpoint(
                 _ctx._token_metadata.first_token(t));
@@ -326,16 +328,45 @@ public:
             // should be update or deletion
             int batch_no = 0;
             for (const rows_entry& r : p.clustered_rows()) {
-                auto log_ck = set_pk_columns(m.key(), batch_no, res);
                 auto ck_value = r.key().explode(*_schema);
+
+                std::optional<clustering_key> pikey;
+                const cql3::untyped_result_set_row * pirow = nullptr;
+
+                if (rs) {
+                    for (auto& utr : *rs) {
+                        bool match = true;
+                        for (auto& c : _schema->clustering_key_columns()) {
+                            auto rv = utr.get_view(c.name_as_text());
+                            auto cv = r.key().get_component(*_schema, c.component_index());
+                            if (rv != cv) {
+                                match = false;
+                                break;
+                            }
+                        }
+                        if (match) {
+                            pikey = set_pk_columns(m.key(), batch_no, res);
+                            set_operation(*pikey, operation::pre_image, res);
+                            pirow = &utr;
+                            ++batch_no;
+                            break;
+                        }
+                    }
+                }
+
+                auto log_ck = set_pk_columns(m.key(), batch_no, res);
+
                 size_t pos = 0;
                 for (const auto& column : _schema->clustering_key_columns()) {
                     assert (pos < ck_value.size());
                     auto cdef = _log_schema->get_column_definition(to_bytes("_" + column.name()));
-                    auto value = atomic_cell::make_live(*column.type,
-                                                        _time.timestamp(),
-                                                        bytes_view(ck_value[pos]));
-                    res.set_cell(log_ck, *cdef, std::move(value));
+                    res.set_cell(log_ck, *cdef, atomic_cell::make_live(*column.type, _time.timestamp(), bytes_view(ck_value[pos])));
+
+                    if (pirow) {
+                        assert(pirow->has(column.name_as_text()));
+                        res.set_cell(*pikey, *cdef, atomic_cell::make_live(*column.type, _time.timestamp(), bytes_view(ck_value[pos])));
+                    }
+
                     ++pos;
                 }
 
@@ -362,15 +393,25 @@ public:
 
                         values[0] = data_type_for<column_op_native_type>()->decompose(data_value(static_cast<column_op_native_type>(op)));
                         res.set_cell(log_ck, *dst, atomic_cell::make_live(*dst->type, _time.timestamp(), tuple_type_impl::build_value(values)));
+
+                        if (pirow && pirow->has(cdef.name_as_text())) {
+                            values[0] = data_type_for<column_op_native_type>()->decompose(data_value(static_cast<column_op_native_type>(column_op::set)));
+                            values[1] = pirow->get_blob(cdef.name_as_text());
+                            values[2] = std::nullopt;
+
+                            assert(std::addressof(res.partition().clustered_row(*_log_schema, *pikey)) != std::addressof(res.partition().clustered_row(*_log_schema, log_ck)));
+                            assert(pikey->explode() != log_ck.explode());
+                            res.set_cell(*pikey, *dst, atomic_cell::make_live(*dst->type, _time.timestamp(), tuple_type_impl::build_value(values)));
+                        }
                     } else {
                         cdc_log.warn("Non-atomic cell ignored {}.{}:{}", _schema->ks_name(), _schema->cf_name(), cdef.name_as_text());
                     }
                 });
-
                 set_operation(log_ck, operation::update, res);
                 ++batch_no;
             }
         }
+
         return res;
     }
 
@@ -501,7 +542,7 @@ public:
     }
 };
 
-static future<transformer::streams_type> get_streams(
+static future<::shared_ptr<transformer::streams_type>> get_streams(
         db_context ctx,
         const sstring& ks_name,
         const sstring& cf_name,
@@ -526,7 +567,7 @@ static future<transformer::streams_type> get_streams(
                     .build();
             streams_builder builder{ *s };
             v.consume(slice, builder);
-            return builder.build();
+            return ::make_shared<transformer::streams_type>(builder.build());
         });
     });
 }
@@ -537,15 +578,20 @@ future<std::vector<mutation>> append_log_mutations(
         service::storage_proxy::clock_type::time_point timeout,
         service::query_state& qs,
         std::vector<mutation> muts) {
-    return get_streams(ctx, s->ks_name(), s->cf_name(), timeout, qs).then(
-            [ctx, s = std::move(s), muts = std::move(muts)]
-            (transformer::streams_type streams) mutable {
-        transformer trans(ctx, std::move(s), streams);
-        muts.reserve(2 * muts.size());
-        for(int i = 0, size = muts.size(); i < size; ++i) {
-            muts.push_back(trans.transform(muts[i]));
-        }
-        return std::move(muts);
+    auto mp = ::make_lw_shared<std::vector<mutation>>(std::move(muts));
+
+    return get_streams(ctx, s->ks_name(), s->cf_name(), timeout, qs).then([ctx, s = std::move(s), mp, &qs](::shared_ptr<transformer::streams_type> streams) mutable {
+        mp->reserve(2 * mp->size());
+        auto trans = make_lw_shared<transformer>(ctx, s, std::move(streams));
+        auto i = mp->begin();
+        auto e = mp->end();
+        return parallel_for_each(i, e, [ctx, &qs, trans, mp](mutation& m) {
+            return trans->pre_image_select(ctx._proxy, qs.get_client_state(), db::consistency_level::LOCAL_QUORUM, m).then([trans, mp, &m](lw_shared_ptr<cql3::untyped_result_set> rs) {
+                mp->push_back(trans->transform(m, rs.get()));
+            });
+        }).then([mp] {
+            return std::move(*mp);
+        });
     });
 }
 

--- a/cdc/cdc.cc
+++ b/cdc/cdc.cc
@@ -372,41 +372,47 @@ public:
 
                 std::vector<bytes_opt> values(3);
 
-                r.row().cells().for_each_cell([&](column_id id, const atomic_cell_or_collection& cell) {
-                    auto& cdef = _schema->column_at(column_kind::regular_column, id);
-                    auto* dst = _log_schema->get_column_definition(to_bytes("_" + cdef.name()));
-                    // todo: collections.
-                    if (cdef.is_atomic()) {
-                        column_op op;
+                auto process_cells = [&](const row& r, column_kind ckind) {
+                    r.for_each_cell([&](column_id id, const atomic_cell_or_collection& cell) {
+                        auto& cdef = _schema->column_at(ckind, id);
+                        auto* dst = _log_schema->get_column_definition(to_bytes("_" + cdef.name()));
+                        // todo: collections.
+                        if (cdef.is_atomic()) {
+                            column_op op;
 
-                        values[1] = values[2] = std::nullopt;
-                        auto view = cell.as_atomic_cell(cdef);
-                        if (view.is_live()) {
-                            op = column_op::set;
-                            values[1] = view.value().linearize();
-                            if (view.is_live_and_has_ttl()) {
-                                values[2] = long_type->decompose(data_value(view.ttl().count()));
+                            values[1] = values[2] = std::nullopt;
+                            auto view = cell.as_atomic_cell(cdef);
+                            if (view.is_live()) {
+                                op = column_op::set;
+                                values[1] = view.value().linearize();
+                                if (view.is_live_and_has_ttl()) {
+                                    values[2] = long_type->decompose(data_value(view.ttl().count()));
+                                }
+                            } else {
+                                op = column_op::del;
+                            }
+
+                            values[0] = data_type_for<column_op_native_type>()->decompose(data_value(static_cast<column_op_native_type>(op)));
+                            res.set_cell(log_ck, *dst, atomic_cell::make_live(*dst->type, _time.timestamp(), tuple_type_impl::build_value(values)));
+
+                            if (pirow && pirow->has(cdef.name_as_text())) {
+                                values[0] = data_type_for<column_op_native_type>()->decompose(data_value(static_cast<column_op_native_type>(column_op::set)));
+                                values[1] = pirow->get_blob(cdef.name_as_text());
+                                values[2] = std::nullopt;
+
+                                assert(std::addressof(res.partition().clustered_row(*_log_schema, *pikey)) != std::addressof(res.partition().clustered_row(*_log_schema, log_ck)));
+                                assert(pikey->explode() != log_ck.explode());
+                                res.set_cell(*pikey, *dst, atomic_cell::make_live(*dst->type, _time.timestamp(), tuple_type_impl::build_value(values)));
                             }
                         } else {
-                            op = column_op::del;
+                            cdc_log.warn("Non-atomic cell ignored {}.{}:{}", _schema->ks_name(), _schema->cf_name(), cdef.name_as_text());
                         }
+                    });
+                };
 
-                        values[0] = data_type_for<column_op_native_type>()->decompose(data_value(static_cast<column_op_native_type>(op)));
-                        res.set_cell(log_ck, *dst, atomic_cell::make_live(*dst->type, _time.timestamp(), tuple_type_impl::build_value(values)));
+                process_cells(r.row().cells(), column_kind::regular_column);
+                process_cells(p.static_row().get(), column_kind::static_column);
 
-                        if (pirow && pirow->has(cdef.name_as_text())) {
-                            values[0] = data_type_for<column_op_native_type>()->decompose(data_value(static_cast<column_op_native_type>(column_op::set)));
-                            values[1] = pirow->get_blob(cdef.name_as_text());
-                            values[2] = std::nullopt;
-
-                            assert(std::addressof(res.partition().clustered_row(*_log_schema, *pikey)) != std::addressof(res.partition().clustered_row(*_log_schema, log_ck)));
-                            assert(pikey->explode() != log_ck.explode());
-                            res.set_cell(*pikey, *dst, atomic_cell::make_live(*dst->type, _time.timestamp(), tuple_type_impl::build_value(values)));
-                        }
-                    } else {
-                        cdc_log.warn("Non-atomic cell ignored {}.{}:{}", _schema->ks_name(), _schema->cf_name(), cdef.name_as_text());
-                    }
-                });
                 set_operation(log_ck, operation::update, res);
                 ++batch_no;
             }

--- a/cdc/cdc.hh
+++ b/cdc/cdc.hh
@@ -166,6 +166,19 @@ struct db_context final {
 /// param[in] schema schema of a table for which CDC tables are being created
 seastar::future<> setup(db_context ctx, schema_ptr schema);
 
+// cdc log table operation
+enum class operation : int8_t {
+    // note: these values will eventually be read by a third party, probably not privvy to this
+    // enum decl, so don't change the constant values (or the datatype).
+    pre_image = 0, update = 1, row_delete = 2, range_delete_start = 3, range_delete_end = 4, partition_delete = 5
+};
+
+// cdc log data column operation
+enum class column_op : int8_t {
+    // same as "operation". Do not edit values or type/type unless you _really_ want to.
+    set = 0, del = 1, add = 2,
+};
+
 /// \brief Deletes CDC Log and CDC Description tables for a given table
 ///
 /// This function cleans up all CDC related tables created for a given table.

--- a/cql3/untyped_result_set.hh
+++ b/cql3/untyped_result_set.hh
@@ -63,12 +63,15 @@ public:
     untyped_result_set_row(const untyped_result_set_row&) = delete;
 
     bool has(const sstring&) const;
-    bytes get_blob(const sstring& name) const {
+    bytes_view get_view(const sstring& name) const {
         return *_data.at(name);
+    }
+    bytes get_blob(const sstring& name) const {
+        return bytes(get_view(name));
     }
     template<typename T>
     T get_as(const sstring& name) const {
-        return value_cast<T>(data_type_for<T>()->deserialize(get_blob(name)));
+        return value_cast<T>(data_type_for<T>()->deserialize(get_view(name)));
     }
     template<typename T>
     std::optional<T> get_opt(const sstring& name) const {
@@ -87,7 +90,7 @@ public:
         auto vec =
                 value_cast<map_type_impl::native_type>(
                         map_type_impl::get_instance(keytype, valtype, false)->deserialize(
-                                get_blob(name)));
+                                get_view(name)));
         std::transform(vec.begin(), vec.end(), out,
                 [](auto& p) {
                     return std::pair<K, V>(value_cast<K>(p.first), value_cast<V>(p.second));
@@ -106,7 +109,7 @@ public:
         auto vec =
                 value_cast<list_type_impl::native_type>(
                         list_type_impl::get_instance(valtype, false)->deserialize(
-                                get_blob(name)));
+                                get_view(name)));
         std::transform(vec.begin(), vec.end(), out, [](auto& v) { return value_cast<V>(v); });
     }
     template<typename V, typename ... Rest>

--- a/cql3/untyped_result_set.hh
+++ b/cql3/untyped_result_set.hh
@@ -143,6 +143,8 @@ public:
     }
 };
 
+class result_set;
+
 class untyped_result_set {
 public:
     using row = untyped_result_set_row;
@@ -151,6 +153,7 @@ public:
     using iterator = rows_type::const_iterator;
 
     untyped_result_set(::shared_ptr<cql_transport::messages::result_message>);
+    untyped_result_set(const cql3::result_set&);
     untyped_result_set(untyped_result_set&&) = default;
 
     const_iterator begin() const {

--- a/tests/cql_assertions.cc
+++ b/tests/cql_assertions.cc
@@ -180,7 +180,7 @@ rows_assertions rows_assertions::with_serialized_columns_count(size_t columns_co
 }
 
 shared_ptr<cql_transport::messages::result_message> cquery_nofail(
-        cql_test_env& env, const char* query, std::unique_ptr<cql3::query_options>&& qo, const std::experimental::source_location& loc) {
+        cql_test_env& env, const seastar::sstring& query, std::unique_ptr<cql3::query_options>&& qo, const std::experimental::source_location& loc) {
     try {
         if (qo) {
             return env.execute_cql(query, std::move(qo)).get0();

--- a/tests/cql_assertions.hh
+++ b/tests/cql_assertions.hh
@@ -85,6 +85,6 @@ void assert_that_failed(future<T...>&& f)
 /// \note Should be called from a seastar::thread context, as it awaits the CQL result.
 shared_ptr<cql_transport::messages::result_message> cquery_nofail(
         cql_test_env& env,
-        const char* query,
+        const seastar::sstring& query,
         std::unique_ptr<cql3::query_options>&& qo = nullptr,
         const std::experimental::source_location& loc = std::experimental::source_location::current());


### PR DESCRIPTION
This PR is a clone of #5217 with debug tests fixed. 

Adds delta and pre-image data column writes for the atomic columns in a cdc-enabled table.

Note that in this patch set it is still unconditional. Adding option support comes in next set.

Uses code more or less derived from alternator to select pre-image, using raw query interface. So should be fairly low overhead to query generation. Pre-image and delta mutations are mixed in with the actual modification mutations to generate the full cdc log (sans post-image).

Rebased on lastest master as of 2019-10-28.