### PR TITLE
cql3/functions: add missing min/max/count functions for ascii type

### DIFF
--- a/cql3/functions/aggregate_fcts.hh
+++ b/cql3/functions/aggregate_fcts.hh
@@ -233,6 +233,11 @@ struct aggregate_type_for {
 };
 
 template<>
+struct aggregate_type_for<ascii_native_type> {
+    using type = ascii_native_type::primary_type;
+};
+
+template<>
 struct aggregate_type_for<simple_date_native_type> {
     using type = simple_date_native_type::primary_type;
 };

--- a/cql3/functions/functions.cc
+++ b/cql3/functions/functions.cc
@@ -114,6 +114,10 @@ functions::init() {
     declare(aggregate_fcts::make_max_function<sstring>());
     declare(aggregate_fcts::make_min_function<sstring>());
 
+    declare(aggregate_fcts::make_count_function<ascii_native_type>());
+    declare(aggregate_fcts::make_max_function<ascii_native_type>());
+    declare(aggregate_fcts::make_min_function<ascii_native_type>());
+
     declare(aggregate_fcts::make_count_function<simple_date_native_type>());
     declare(aggregate_fcts::make_max_function<simple_date_native_type>());
     declare(aggregate_fcts::make_min_function<simple_date_native_type>());

--- a/tests/cql_assertions.cc
+++ b/tests/cql_assertions.cc
@@ -92,6 +92,24 @@ rows_assertions::rows_assertions::is_not_null() {
     return is_not_empty();
 }
 
+rows_assertions
+rows_assertions::with_column_types(std::initializer_list<data_type> column_types) {
+    auto meta = _rows->rs().result_set().get_metadata();
+    const auto& columns = meta.get_names();
+    if (column_types.size() != columns.size()) {
+        fail(format("Expected {:d} columns, got {:d}", column_types.size(), meta.column_count()));
+    }
+    auto expected_it = column_types.begin();
+    auto actual_it = columns.begin();
+    for (int i = 0; i < (int)columns.size(); i++) {
+        const auto& expected_type = *expected_it++;
+        const auto& actual_spec = *actual_it++;
+        if (expected_type != actual_spec->type) {
+            fail(format("Column {:d}: expected type {}, got {}", i, expected_type->name(), actual_spec->type->name()));
+        }
+    }
+    return {*this};
+}
 
 rows_assertions
 rows_assertions::with_row(std::initializer_list<bytes_opt> values) {

--- a/tests/cql_assertions.hh
+++ b/tests/cql_assertions.hh
@@ -36,6 +36,7 @@ public:
     rows_assertions with_size(size_t size);
     rows_assertions is_empty();
     rows_assertions is_not_empty();
+    rows_assertions with_column_types(std::initializer_list<data_type> column_types);
     rows_assertions with_row(std::initializer_list<bytes_opt> values);
 
     // Verifies that the result has the following rows and only that rows, in that order.

--- a/tests/cql_query_test.cc
+++ b/tests/cql_query_test.cc
@@ -1464,6 +1464,159 @@ SEASTAR_TEST_CASE(test_functions) {
     });
 }
 
+struct aggregate_function_test {
+    private:
+    cql_test_env& _e;
+    shared_ptr<const abstract_type> _column_type;
+    std::vector<data_value> _sorted_values;
+
+    sstring table_name() {
+        return "cf_" + _column_type->cql3_type_name();
+    }
+    void call_function_and_expect(const char* fname, data_type type, data_value expected) {
+        auto msg = _e.execute_cql(format("select {}(value) from {}", fname, table_name())).get0();
+        assert_that(msg).is_rows()
+            .with_size(1)
+            .with_column_types({type})
+            .with_row({
+                {expected.serialize()}
+            });
+    }
+public:
+    template<typename... T>
+    explicit aggregate_function_test(cql_test_env& e, shared_ptr<const abstract_type> column_type, T... sorted_values)
+        : _e(e), _column_type(column_type), _sorted_values{data_value(sorted_values)...}
+    {
+        const auto cf_name = table_name();
+        _e.create_table([column_type, cf_name] (sstring ks_name) {
+            return schema({}, ks_name, cf_name,
+                {{"pk", utf8_type}}, {{"ck", int32_type}}, {{"value", column_type}}, {}, utf8_type);
+        }).get();
+
+        auto prepared = _e.prepare(format("insert into {} (pk, ck, value) values ('key1', ?, ?)", cf_name)).get0();
+        for (int i = 0; i < (int)_sorted_values.size(); i++) {
+            const auto& value = _sorted_values[i];
+            BOOST_ASSERT(&*value.type() == &*_column_type);
+            std::vector<cql3::raw_value> raw_values {
+                cql3::raw_value::make_value(int32_type->decompose(int32_t(i))),
+                cql3::raw_value::make_value(value.serialize())
+            };
+            _e.execute_prepared(prepared, std::move(raw_values)).get();
+        }
+    }
+    aggregate_function_test& test_min() {
+        call_function_and_expect("min", _column_type, _sorted_values.front());
+        return *this;
+    }
+    aggregate_function_test& test_max() {
+        call_function_and_expect("max", _column_type, _sorted_values.back());
+        return *this;
+    }
+    aggregate_function_test& test_count() {
+        call_function_and_expect("count", long_type, int64_t(_sorted_values.size()));
+        return *this;
+    }
+    aggregate_function_test& test_sum(data_value expected_result) {
+        call_function_and_expect("sum", _column_type, expected_result);
+        return *this;
+    }
+    aggregate_function_test& test_avg(data_value expected_result) {
+        call_function_and_expect("avg", _column_type, expected_result);
+        return *this;
+    }
+    aggregate_function_test& test_min_max_count() {
+        test_min();
+        test_max();
+        test_count();
+        return *this;
+    }
+};
+
+SEASTAR_TEST_CASE(test_aggregate_functions) {
+    return do_with_cql_env_thread([] (cql_test_env& e) {
+        // Numeric types
+        aggregate_function_test(e, byte_type, int8_t(1), int8_t(2), int8_t(3))
+            .test_min_max_count()
+            .test_sum(int8_t(6))
+            .test_avg(int8_t(2));
+        aggregate_function_test(e, short_type, int16_t(1), int16_t(2), int16_t(3))
+            .test_min_max_count()
+            .test_sum(int16_t(6))
+            .test_avg(int16_t(2));
+        aggregate_function_test(e, int32_type, int32_t(1), int32_t(2), int32_t(3))
+            .test_min_max_count()
+            .test_sum(int32_t(6))
+            .test_avg(int32_t(2));
+        aggregate_function_test(e, long_type, int64_t(1), int64_t(2), int64_t(3))
+            .test_min_max_count()
+            .test_sum(int64_t(6))
+            .test_avg(int64_t(2));
+
+        aggregate_function_test(e, varint_type,
+            boost::multiprecision::cpp_int(1),
+            boost::multiprecision::cpp_int(2),
+            boost::multiprecision::cpp_int(3)
+        ).test_min_max_count()
+            .test_sum(boost::multiprecision::cpp_int(6))
+            .test_avg(boost::multiprecision::cpp_int(2));
+
+        aggregate_function_test(e, decimal_type,
+            big_decimal("1.0"),
+            big_decimal("2.0"),
+            big_decimal("3.0")
+        ).test_min_max_count()
+            .test_sum(big_decimal("6.0"))
+            .test_avg(big_decimal("2.0"));
+
+        aggregate_function_test(e, float_type, 1.0f, 2.0f, 3.0f)
+            .test_min_max_count()
+            .test_sum(6.0f)
+            .test_avg(2.0f);
+        aggregate_function_test(e, double_type, 1.0, 2.0, 3.0)
+            .test_min_max_count()
+            .test_sum(6.0)
+            .test_avg(2.0);
+
+        // Ordered types
+        aggregate_function_test(e, utf8_type, sstring("abcd"), sstring("efgh"), sstring("ijkl"))
+            .test_min_max_count();
+        aggregate_function_test(e, bytes_type, bytes("abcd"), bytes("efgh"), bytes("ijkl"))
+            .test_min_max_count();
+        aggregate_function_test(e, ascii_type,
+            ascii_native_type{"abcd"},
+            ascii_native_type{"efgh"},
+            ascii_native_type{"ijkl"}
+        ).test_min_max_count();
+
+        aggregate_function_test(e, simple_date_type,
+            simple_date_native_type{1},
+            simple_date_native_type{2},
+            simple_date_native_type{3}
+        ).test_min_max_count();
+
+        const db_clock::time_point now = db_clock::now();
+        aggregate_function_test(e, timestamp_type,
+            now,
+            now + std::chrono::seconds(1),
+            now + std::chrono::seconds(2)
+        ).test_min_max_count();
+
+        aggregate_function_test(e, timeuuid_type,
+            timeuuid_native_type{utils::UUID("00000000-0000-1000-0000-000000000000")},
+            timeuuid_native_type{utils::UUID("00000000-0000-1000-0000-000000000001")},
+            timeuuid_native_type{utils::UUID("00000000-0000-1000-0000-000000000002")}
+        ).test_min_max_count();
+
+        aggregate_function_test(e, uuid_type,
+            utils::UUID("00000000-0000-1000-0000-000000000000"),
+            utils::UUID("00000000-0000-1000-0000-000000000001"),
+            utils::UUID("00000000-0000-1000-0000-000000000002")
+        ).test_min_max_count();
+
+        aggregate_function_test(e, boolean_type, false, true).test_min_max_count();
+    });
+}
+
 static const api::timestamp_type the_timestamp = 123456789;
 SEASTAR_TEST_CASE(test_writetime_and_ttl) {
     return do_with_cql_env([] (cql_test_env& e) {

--- a/types.hh
+++ b/types.hh
@@ -966,6 +966,12 @@ shared_ptr<const abstract_type> data_type_for<db_clock::time_point>() {
 
 template <>
 inline
+shared_ptr<const abstract_type> data_type_for<ascii_native_type>() {
+    return ascii_type;
+}
+
+template <>
+inline
 shared_ptr<const abstract_type> data_type_for<time_native_type>() {
     return time_type;
 }


### PR DESCRIPTION
Adds missing overloads of functions `count`, `min`, `max` for type `ascii`.

Now they work:

```
cqlsh> CREATE KEYSPACE ks WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1};
cqlsh> USE ks;
cqlsh:ks> CREATE TABLE test_ascii (id int PRIMARY KEY, value ascii);
cqlsh:ks> INSERT INTO test_ascii (id, value) VALUES (0, 'abcd');
cqlsh:ks> INSERT INTO test_ascii (id, value) VALUES (1, 'efgh');
cqlsh:ks> INSERT INTO test_ascii (id, value) VALUES (2, 'ijkl');
cqlsh:ks> SELECT * FROM test_ascii;

 id | value
----+-------
  1 |  efgh
  0 |  abcd
  2 |  ijkl

(3 rows)
cqlsh:ks> SELECT count(value) FROM test_ascii;

 system.count(value)
---------------------
                   3

(1 rows)
cqlsh:ks> SELECT min(value) FROM test_ascii;

 system.min(value)
-------------------
              abcd

(1 rows)
cqlsh:ks> SELECT max(value) FROM test_ascii;

 system.max(value)
-------------------
              ijkl

(1 rows)
```
Tests:
- unit(release)
- cql_group_functions_tests.py (with added check for `ascii` type)

Fixes #5147.