### PR TITLE
alternator-test: Skip tests that prevent restart

### DIFF
--- a/alternator-test/test_gsi.py
+++ b/alternator-test/test_gsi.py
@@ -481,7 +481,7 @@ def test_gsi_5(test_table_gsi_5):
 # "ProjectionType:: KEYS_ONLY" works. We note that it projects both
 # the index's key, *and* the base table's key. So items which had different
 # base-table keys cannot suddenly become the same item in the index.
-@pytest.mark.xfail(reason="GSI not supported")
+@pytest.mark.skip(reason="Leaves sstable in bogus format, preventing Scylla restart")
 def test_gsi_projection_keys_only(dynamodb):
     table = create_test_table(dynamodb,
         KeySchema=[ { 'AttributeName': 'p', 'KeyType': 'HASH' } ],
@@ -509,7 +509,7 @@ def test_gsi_projection_keys_only(dynamodb):
 # Test for "ProjectionType:: INCLUDE". The secondary table includes the
 # its own and the base's keys (as in KEYS_ONLY) plus the extra keys given
 # in NonKeyAttributes.
-@pytest.mark.xfail(reason="GSI not supported")
+@pytest.mark.skip(reason="Leaves sstable in bogus format, preventing Scylla restart")
 def test_gsi_projection_include(dynamodb):
     table = create_test_table(dynamodb,
         KeySchema=[ { 'AttributeName': 'p', 'KeyType': 'HASH' } ],
@@ -672,7 +672,7 @@ def test_gsi_backfill(dynamodb):
     table.delete()
 
 # Test deleting an existing GSI using UpdateTable
-@pytest.mark.xfail(reason="GSI not supported")
+@pytest.mark.skip(reason="Leaves sstable in bogus format, preventing Scylla restart")
 def test_gsi_delete(dynamodb):
     table = create_test_table(dynamodb,
         KeySchema=[ { 'AttributeName': 'p', 'KeyType': 'HASH' } ],


### PR DESCRIPTION
Although currently marked `xfail`, these tests still run and leave
sstables in some bogus state.  Upon restart, Scylla exits with error
message:

database - Exception while populating keyspace 'alternator' with column family 'alternator_test_1572540235701:hello' from file '.../data/alternator/alternator_test_1572540235701:hello-a10640b2fbfd11e9b09e000000000001': sstables::malformed_sstable_exception (invalid version for file mc-33-big-Filter.db with path .../data/alternator/alternator_test_1572540235701:hello-a10640b2fbfd11e9b09e000000000001. Path doesn't match known pattern.)

Signed-off-by: Dejan Mircevski <dejan@scylladb.com>