### PR TITLE
Add names to semaphores

### DIFF
--- a/database.hh
+++ b/database.hh
@@ -479,7 +479,7 @@ private:
     // sstables deleted by compaction in parallel, a race condition which could
     // easily result in failure.
     // Locking order: must be acquired either independently or after _sstables_lock
-    seastar::semaphore _sstable_deletion_sem = {1};
+    seastar::named_semaphore _sstable_deletion_sem = {1, named_semaphore_exception_factory{"sstable deletion"}};
     // There are situations in which we need to stop writing sstables. Flushers will take
     // the read lock, and the ones that wish to stop that process will take the write lock.
     rwlock _sstables_lock;
@@ -1267,7 +1267,7 @@ private:
     reader_concurrency_semaphore _streaming_concurrency_sem;
     reader_concurrency_semaphore _system_read_concurrency_sem;
 
-    semaphore _sstable_load_concurrency_sem{max_concurrent_sstable_loads()};
+    named_semaphore _sstable_load_concurrency_sem{max_concurrent_sstable_loads(), named_semaphore_exception_factory{"sstable load concurrency"}};
 
     db::timeout_semaphore _view_update_concurrency_sem{max_memory_pending_view_updates()};
 
@@ -1504,7 +1504,7 @@ public:
     std::unordered_set<sstring> get_initial_tokens();
     std::optional<gms::inet_address> get_replace_address();
     bool is_replacing();
-    semaphore& sstable_load_concurrency_sem() {
+    named_semaphore& sstable_load_concurrency_sem() {
         return _sstable_load_concurrency_sem;
     }
     void register_connection_drop_notifier(netw::messaging_service& ms);

--- a/db/hints/manager.hh
+++ b/db/hints/manager.hh
@@ -471,7 +471,7 @@ private:
     stats _stats;
     seastar::metrics::metric_groups _metrics;
     std::unordered_set<ep_key_type> _eps_with_pending_hints;
-    seastar::semaphore _drain_lock = {1};
+    seastar::named_semaphore _drain_lock = {1, named_semaphore_exception_factory{"drain lock"}};
 
 public:
     manager(sstring hints_directory, std::vector<sstring> hinted_dcs, int64_t max_hint_window_ms, resource_manager&res_manager, distributed<database>& db);
@@ -550,7 +550,7 @@ public:
         return _hints_dir_device_id;
     }
 
-    seastar::semaphore& drain_lock() noexcept {
+    seastar::named_semaphore& drain_lock() noexcept {
         return _drain_lock;
     }
 

--- a/db/hints/resource_manager.cc
+++ b/db/hints/resource_manager.cc
@@ -51,7 +51,7 @@ future<bool> is_mountpoint(const fs::path& path) {
     });
 }
 
-future<semaphore_units<semaphore_default_exception_factory>> resource_manager::get_send_units_for(size_t buf_size) {
+future<semaphore_units<named_semaphore::exception_factory>> resource_manager::get_send_units_for(size_t buf_size) {
     // Let's approximate the memory size the mutation is going to consume by the size of its serialized form
     size_t hint_memory_budget = std::max(_min_send_hint_budget, buf_size);
     // Allow a very big mutation to be sent out by consuming the whole shard budget

--- a/db/view/view_builder.hh
+++ b/db/view/view_builder.hh
@@ -153,7 +153,7 @@ class view_builder final : public service::migration_listener::only_view_notific
     // Ensures bookkeeping operations are serialized, meaning that while we execute
     // a build step we don't consider newly added or removed views. This simplifies
     // the algorithms. Also synchronizes an operation wrt. a call to stop().
-    seastar::semaphore _sem{1};
+    seastar::named_semaphore _sem{1, named_semaphore_exception_factory{"view builder"}};
     seastar::abort_source _as;
     future<> _started = make_ready_future<>();
     // Used to coordinate between shards the conclusion of the build process for a particular view.

--- a/db/view/view_update_generator.hh
+++ b/db/view/view_update_generator.hh
@@ -38,7 +38,7 @@ class view_update_generator {
     seastar::abort_source _as;
     future<> _started = make_ready_future<>();
     seastar::condition_variable _pending_sstables;
-    semaphore _registration_sem{registration_queue_size};
+    named_semaphore _registration_sem{registration_queue_size, named_semaphore_exception_factory{"view update generator"}};
     struct sstable_with_table {
         sstables::shared_sstable sst;
         lw_shared_ptr<table> t;

--- a/repair/repair.hh
+++ b/repair/repair.hh
@@ -175,7 +175,7 @@ public:
     size_t current_sub_ranges_nr_out = 0;
     int ranges_index = 0;
     // Only allow one stream_plan in flight
-    semaphore sp_parallelism_semaphore{1};
+    named_semaphore sp_parallelism_semaphore{1, named_semaphore_exception_factory{"repair sp parallelism"}};
     lw_shared_ptr<streaming::stream_plan> _sp_in;
     lw_shared_ptr<streaming::stream_plan> _sp_out;
     repair_stats _stats;
@@ -232,7 +232,7 @@ private:
     // Each element in the vector is the semaphore used to control the maximum
     // ranges that can be repaired in parallel. Each element will be accessed
     // by one shared.
-    std::vector<semaphore> _range_parallelism_semaphores;
+    std::vector<named_semaphore> _range_parallelism_semaphores;
     static const size_t _max_repair_memory_per_range = 32 * 1024 * 1024;
     void start(int id);
     void done(int id, bool succeeded);
@@ -249,7 +249,7 @@ public:
     std::vector<int> get_active() const;
     size_t nr_running_repair_jobs();
     void abort_all_repairs();
-    semaphore& range_parallelism_semaphore();
+    named_semaphore& range_parallelism_semaphore();
     static size_t max_repair_memory_per_range() { return _max_repair_memory_per_range; }
     future<> run(int id, std::function<future<> ()> func);
 };

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -101,10 +101,10 @@ using bind_messaging_port = bool_class<bind_messaging_port_tag>;
 
 class feature_enabled_listener : public gms::feature::listener {
     storage_service& _s;
-    seastar::semaphore& _sem;
+    seastar::named_semaphore& _sem;
     sstables::sstable_version_types _format;
 public:
-    feature_enabled_listener(storage_service& s, seastar::semaphore& sem, sstables::sstable_version_types format)
+    feature_enabled_listener(storage_service& s, seastar::named_semaphore& sem, sstables::sstable_version_types format)
         : _s(s)
         , _sem(sem)
         , _format(format)
@@ -342,7 +342,7 @@ private:
     gms::feature _nonfrozen_udts;
 
     sstables::sstable_version_types _sstables_format = sstables::sstable_version_types::ka;
-    seastar::semaphore _feature_listeners_sem = {1};
+    seastar::named_semaphore _feature_listeners_sem = {1, named_semaphore_exception_factory{"feature listeners"}};
     feature_enabled_listener _la_feature_listener;
     feature_enabled_listener _mc_feature_listener;
 public:


### PR DESCRIPTION
By default, semaphore exceptions bring along very little context:
either that *a* semaphore was broken or that it timed out.
In order to make debugging easier without introducing significant
runtime costs, a notion of named semaphore is added.
A named semaphore is simply a semaphore with statically defined
name, which is present in its errors, bringing valuable context.
A semaphore defined as: 
```cpp
  auto sem = semaphore(0);
```
will present the following message when it breaks:
  "Semaphore broken"
However, a named semaphore:
```cpp
  struct name { static constexpr const char* value = "io_concurrency_sem"; };  
  auto named_sem = named_semaphore<name>(0);
```
will present a message with at least some debugging context:
```cpp
  "Semaphore broken: io_concurrency_sem"
```
It's not much, but it would really help in pinpointing bugs
without having to inspect core dumps.

At the same time, it does not incur any costs for normal
semaphore operations, but instead only uses more CPU in case
an error is actually thrown, which is considered rare
and not to be on the hot path.

Tests: unit(dev), manual: hardcoding a failure in view builder results
in the following error message:
init - Startup failed: utils::broken_named_semaphore (Semaphore broken: view_builder)
as opposed to previous:
init - Startup failed: broken_semaphore (Semaphore broken)

Refs #4999