### PR TITLE
Correctly handle null/unset frozen collection/UDT columns in INSERT JSON.

### DIFF
--- a/cql3/statements/update_statement.cc
+++ b/cql3/statements/update_statement.cc
@@ -200,7 +200,7 @@ insert_prepared_json_statement::execute_set_value(mutation& m, const clustering_
             maps::setter::execute(m, prefix, params, column, ::make_shared<maps::value>(std::map<bytes, bytes, serialized_compare>(serialized_compare(empty_type))));
         },
         [&] (const user_type_impl&) {
-            user_types::setter(column, ::make_shared<user_types::value>(std::vector<bytes_opt>())).execute(m, prefix, params);
+            user_types::setter::execute(m, prefix, params, column, ::make_shared<user_types::value>(std::vector<bytes_opt>()));
         },
         [&] (const abstract_type& type) {
             if (type.is_collection()) {
@@ -227,9 +227,8 @@ insert_prepared_json_statement::execute_set_value(mutation& m, const clustering_
                 ::make_shared(maps::value::from_serialized(fragmented_temporary_buffer::view(*value), mtype, sf)));
     },
     [&] (const user_type_impl& utype) {
-        user_types::setter(column,
-                ::make_shared(user_types::value::from_serialized(fragmented_temporary_buffer::view(*value), utype)))
-            .execute(m, prefix, params);
+        user_types::setter::execute(m, prefix, params, column,
+                ::make_shared(user_types::value::from_serialized(fragmented_temporary_buffer::view(*value), utype)));
     },
     [&] (const abstract_type& type) {
         if (type.is_collection()) {

--- a/cql3/statements/update_statement.cc
+++ b/cql3/statements/update_statement.cc
@@ -191,16 +191,16 @@ insert_prepared_json_statement::execute_set_value(mutation& m, const clustering_
     if (!value) {
         visit(*column.type, make_visitor(
         [&] (const list_type_impl&) {
-            lists::setter::execute(m, prefix, params, column, ::make_shared<lists::value>(std::vector<bytes_opt>()));
+            lists::setter::execute(m, prefix, params, column, {});
         },
         [&] (const set_type_impl&) {
-            sets::setter::execute(m, prefix, params, column, ::make_shared<sets::value>(std::set<bytes, serialized_compare>(serialized_compare(empty_type))));
+            sets::setter::execute(m, prefix, params, column, {});
         },
         [&] (const map_type_impl&) {
-            maps::setter::execute(m, prefix, params, column, ::make_shared<maps::value>(std::map<bytes, bytes, serialized_compare>(serialized_compare(empty_type))));
+            maps::setter::execute(m, prefix, params, column, {});
         },
         [&] (const user_type_impl&) {
-            user_types::setter::execute(m, prefix, params, column, ::make_shared<user_types::value>(std::vector<bytes_opt>()));
+            user_types::setter::execute(m, prefix, params, column, {});
         },
         [&] (const abstract_type& type) {
             if (type.is_collection()) {

--- a/cql3/user_types.cc
+++ b/cql3/user_types.cc
@@ -243,6 +243,10 @@ shared_ptr<terminal> user_types::marker::bind(const query_options& options) {
 
 void user_types::setter::execute(mutation& m, const clustering_key_prefix& row_key, const update_parameters& params) {
     auto value = _t->bind(params._options);
+    execute(m, row_key, params, column, std::move(value));
+}
+
+void user_types::setter::execute(mutation& m, const clustering_key_prefix& row_key, const update_parameters& params, const column_definition& column, ::shared_ptr<terminal> value) {
     if (value == constants::UNSET_VALUE) {
         return;
     }

--- a/cql3/user_types.hh
+++ b/cql3/user_types.hh
@@ -117,6 +117,7 @@ public:
         using operation::operation;
 
         virtual void execute(mutation& m, const clustering_key_prefix& row_key, const update_parameters& params) override;
+        static void execute(mutation& m, const clustering_key_prefix& prefix, const update_parameters& params, const column_definition& column, ::shared_ptr<terminal> value);
     };
 
     class setter_by_field : public operation {


### PR DESCRIPTION
When using INSERT JSON with frozen collection/UDT columns, if the columns were left unspecified or set to null, the statement would create an empty non-null value for these columns instead of using null values as it should have. For example:
```
cqlsh:b> create table t (k text primary key, l frozen<list<int>>, m frozen<map<int, int>>, s frozen<set<int>>, u frozen<ut>);
cqlsh:b> insert into t JSON '{"k": "insert_json"}';
cqlsh:b> select * from t;
 k                 | l    | m    | s    | u
-------------------+------+------+------+------
       insert_json |     [] |     {} |     {} |        
```

This PR fixes this.
Resolves #5246 and closes #5270.