### PR TITLE
hints: Reduce hint sending parallelism

### DIFF
--- a/db/hints/manager.cc
+++ b/db/hints/manager.cc
@@ -684,7 +684,7 @@ future<> manager::end_point_hints_manager::sender::send_one_mutation(frozen_muta
 }
 
 future<> manager::end_point_hints_manager::sender::send_one_hint(lw_shared_ptr<send_one_file_ctx> ctx_ptr, fragmented_temporary_buffer buf, db::replay_position rp, gc_clock::duration secs_since_file_mod, const sstring& fname) {
-    return _resource_manager.get_send_units_for(buf.size_bytes()).then([this, secs_since_file_mod, &fname, buf = std::move(buf), rp, ctx_ptr] (auto units) mutable {
+    return _resource_manager.get_send_units_for(_ep_key, buf.size_bytes()).then([this, secs_since_file_mod, &fname, buf = std::move(buf), rp, ctx_ptr] (auto units) mutable {
         // Future is waited on indirectly in `send_one_file()` (via `ctx_ptr->file_send_gate`).
         (void)with_gate(ctx_ptr->file_send_gate, [this, secs_since_file_mod, &fname, buf = std::move(buf), rp, ctx_ptr] () mutable {
             try {

--- a/db/hints/resource_manager.hh
+++ b/db/hints/resource_manager.hh
@@ -117,7 +117,7 @@ private:
 class resource_manager {
     const size_t _max_send_in_flight_memory;
     const size_t _min_send_hint_budget;
-    seastar::semaphore _send_limiter;
+    std::unordered_map<gms::inet_address, std::unique_ptr<seastar::semaphore>> _send_limiters;
 
     space_watchdog::shard_managers_set _shard_managers;
     space_watchdog::per_device_limits_map _per_device_limits_map;
@@ -132,14 +132,13 @@ public:
     resource_manager(size_t max_send_in_flight_memory)
         : _max_send_in_flight_memory(std::max(max_send_in_flight_memory, max_hints_send_queue_length))
         , _min_send_hint_budget(_max_send_in_flight_memory / max_hints_send_queue_length)
-        , _send_limiter(_max_send_in_flight_memory)
         , _space_watchdog(_shard_managers, _per_device_limits_map)
     {}
 
     resource_manager(resource_manager&&) = delete;
     resource_manager& operator=(resource_manager&&) = delete;
 
-    future<semaphore_units<semaphore_default_exception_factory>> get_send_units_for(size_t buf_size);
+    future<semaphore_units<semaphore_default_exception_factory>> get_send_units_for(gms::inet_address addr, size_t buf_size);
 
     future<> start(shared_ptr<service::storage_proxy> proxy_ptr, shared_ptr<gms::gossiper> gossiper_ptr, shared_ptr<service::storage_service> ss_ptr);
     void allow_replaying() noexcept;

--- a/db/hints/resource_manager.hh
+++ b/db/hints/resource_manager.hh
@@ -116,22 +116,21 @@ private:
 
 class resource_manager {
     const size_t _max_send_in_flight_memory;
-    const size_t _min_send_hint_budget;
     std::unordered_map<gms::inet_address, std::unique_ptr<seastar::semaphore>> _send_limiters;
 
     space_watchdog::shard_managers_set _shard_managers;
     space_watchdog::per_device_limits_map _per_device_limits_map;
     space_watchdog _space_watchdog;
+    shared_ptr<gms::gossiper> _gossiper_ptr; // Initialized in start()
 
 public:
     static constexpr size_t hint_segment_size_in_mb = 32;
     static constexpr size_t max_hints_per_ep_size_mb = 128; // 4 files 32MB each
-    static constexpr size_t max_hints_send_queue_length = 128;
+    static constexpr size_t max_hints_send_queue_length = 20;
 
 public:
     resource_manager(size_t max_send_in_flight_memory)
         : _max_send_in_flight_memory(std::max(max_send_in_flight_memory, max_hints_send_queue_length))
-        , _min_send_hint_budget(_max_send_in_flight_memory / max_hints_send_queue_length)
         , _space_watchdog(_shard_managers, _per_device_limits_map)
     {}
 

--- a/gms/gossiper.cc
+++ b/gms/gossiper.cc
@@ -797,6 +797,18 @@ std::set<inet_address> gossiper::get_live_members() {
     return live_members;
 }
 
+size_t gossiper::get_live_members_count() const {
+    const auto myip = get_broadcast_address();
+    size_t count = _live_endpoints.size();
+    if (std::find(_live_endpoints.begin(), _live_endpoints.end(), myip) == _live_endpoints.end()) {
+        ++count;
+    }
+    if (is_shutdown(myip)) {
+        --count;
+    }
+    return count;
+}
+
 std::set<inet_address> gossiper::get_live_token_owners() {
     std::set<inet_address> token_owners;
     for (auto& member : get_live_members()) {

--- a/gms/gossiper.hh
+++ b/gms/gossiper.hh
@@ -265,6 +265,7 @@ public:
     void unregister_(shared_ptr<i_endpoint_state_change_subscriber> subscriber);
 
     std::set<inet_address> get_live_members();
+    size_t get_live_members_count() const;
 
     std::set<inet_address> get_live_token_owners();
 

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -4208,7 +4208,7 @@ future<> storage_proxy::truncate_blocking(sstring keyspace, sstring cfname) {
         // Since the truncate operation is so aggressive and is typically only
         // invoked by an admin, for simplicity we require that all nodes are up
         // to perform the operation.
-        auto live_members = gossiper.get_live_members().size();
+        auto live_members = gossiper.get_live_members_count();
 
         throw exceptions::unavailable_exception(db::consistency_level::ALL,
                 live_members + gossiper.get_unreachable_members().size(),

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -642,7 +642,7 @@ void storage_service::join_token_ring(int delay) {
         set_mode(mode::JOINING, "waiting for ring information", true);
         auto& gossiper = gms::get_gossiper().local();
         // first sleep the delay to make sure we see *at least* one other node
-        for (int i = 0; i < delay && gossiper.get_live_members().size() < 2; i += 1000) {
+        for (int i = 0; i < delay && gossiper.get_live_members_count() < 2; i += 1000) {
             sleep_abortable(std::chrono::seconds(1), _abort_source).get();
         }
         // if our schema hasn't matched yet, keep sleeping until it does


### PR DESCRIPTION
Currently, we impose a limit of 128 hints to be sent simultaneously by one shard. This patch changes this limit in the following ways:
- There is a separate limit for each pair (source shard, destination node),
- Each pair is limited to `20 / (number of known live nodes - 1)` hints sent simultaneously.

Fixes #4974.

Tests:
- unit(release)
- dtest: hintedhandoff_additional_test(release)