### PR TITLE
Adding a schema file when creating a snapshot

### DIFF
--- a/database.hh
+++ b/database.hh
@@ -827,6 +827,24 @@ public:
     future<> snapshot(sstring name);
     future<std::unordered_map<sstring, snapshot_details>> get_snapshot_details();
 
+    /*!
+     * \brief write the schema to a 'schema.cql' file at the given directory.
+     *
+     * When doing a snapshot, the snapshot directory contains a 'schema.cql' file
+     * with a CQL command that can be used to generate the schema.
+     * The content is is similar to the result of the CQL DESCRIBE command of the table.
+     *
+     * When a schema has indexes, local indexes or views, those indexes and views
+     * are represented by their own schemas.
+     * In those cases, the method would write the relevant information for each of the schemas:
+     *
+     * The schema of the base table would output a file with the CREATE TABLE command
+     * and the schema of the view that is used for the index would output a file with the
+     * CREATE INDEX command.
+     * The same is true for local index and MATERIALIZED VIEW.
+     */
+    future<> write_schema_as_cql(sstring dir) const;
+
     const bool incremental_backups_enabled() const {
         return _config.enable_incremental_backups;
     }

--- a/index/secondary_index_manager.cc
+++ b/index/secondary_index_manager.cc
@@ -50,6 +50,7 @@
 
 #include <boost/range/adaptor/map.hpp>
 #include <boost/algorithm/cxx11/any_of.hpp>
+#include <boost/algorithm/string/predicate.hpp>
 
 namespace secondary_index {
 
@@ -98,6 +99,13 @@ void secondary_index_manager::add_index(const index_metadata& im) {
 
 sstring index_table_name(const sstring& index_name) {
     return format("{}_index", index_name);
+}
+
+sstring index_name_from_table_name(const sstring& table_name) {
+    if (table_name.size() < 7 || !boost::algorithm::ends_with(table_name, "_index")) {
+        throw std::runtime_error(format("Table {} does not have _index suffix", table_name));
+    }
+    return table_name.substr(0, table_name.size() - 6); // remove the _index suffix from an index name;
 }
 
 static bytes get_available_token_column_name(const schema& schema) {

--- a/index/secondary_index_manager.hh
+++ b/index/secondary_index_manager.hh
@@ -52,6 +52,13 @@ namespace secondary_index {
 
 sstring index_table_name(const sstring& index_name);
 
+/*!
+ * \brief a reverse of index_table_name
+ * It gets a table_name and return the index name that was used
+ * to create that table.
+ */
+sstring index_name_from_table_name(const sstring& table_name);
+
 class index {
     sstring _target_column;
     index_metadata _im;

--- a/schema.hh
+++ b/schema.hh
@@ -909,6 +909,24 @@ public:
     // Search for an existing index with same kind and options.
     std::optional<index_metadata> find_index_noname(const index_metadata& target) const;
     friend std::ostream& operator<<(std::ostream& os, const schema& s);
+    /*!
+     * \brief stream the CQL DESCRIBE output.
+     *
+     * CQL DESCRIBE is implemented at the driver level. This method mimic that functionality
+     * inside Scylla.
+     *
+     * The output of DESCRIBE is the CQL command to create the described table with its indexes and views.
+     *
+     * For tables with Indexes or Materialized Views, the CQL DESCRIBE is split between the base and view tables.
+     * Calling the describe method on the base table schema would result with the CQL "CREATE TABLE"
+     * command for creating that table only.
+     *
+     * Calling the describe method on a view schema would result with the appropriate "CREATE MATERIALIZED VIEW"
+     * or "CREATE INDEX" depends on the type of index that schema describes (ie. Materialized View, Global
+     * Index or Local Index).
+     *
+     */
+    std::ostream& describe(std::ostream& os) const;
     friend bool operator==(const schema&, const schema&);
     const column_mapping& get_column_mapping() const;
     friend class schema_registry_entry;


### PR DESCRIPTION
To use a snapshot we need a schema file that is similar to the result of running cql DESCRIBE command.

The DESCRIBE is implemented in the cql driver so the functionality needs to be re-implemented inside scylla.

This series adds a describe method to the schema file and use it when doing a snapshot.

There are different approach of how to handle materialize views and secondary indexes. 

This implementation creates each schema.cql file in its own relevant directory, so the schema for materializing view, for example, will be placed in the snapshot directory of the table of that view.

Fixes #4192