### PR TITLE
row_marker: correct row expiry condition

### DIFF
--- a/mutation_partition.cc
+++ b/mutation_partition.cc
@@ -1876,7 +1876,7 @@ bool row_marker::compact_and_expire(tombstone tomb, gc_clock::time_point now,
         _timestamp = api::missing_timestamp;
         return false;
     }
-    if (_ttl > no_ttl && _expiry < now) {
+    if (_ttl > no_ttl && _expiry <= now) {
         _expiry -= _ttl;
         _ttl = dead;
     }

--- a/mutation_partition.hh
+++ b/mutation_partition.hh
@@ -679,7 +679,7 @@ public:
         if (is_missing() || _ttl == dead) {
             return false;
         }
-        if (_ttl != no_ttl && _expiry < now) {
+        if (_ttl != no_ttl && _expiry <= now) {
             return false;
         }
         return _timestamp > t.timestamp;
@@ -689,7 +689,7 @@ public:
         if (_ttl == dead) {
             return true;
         }
-        return _ttl != no_ttl && _expiry < now;
+        return _ttl != no_ttl && _expiry <= now;
     }
     // Can be called only when is_live().
     bool is_expiring() const {


### PR DESCRIPTION
This change corrects condition on which a row was considered expired by its TTL.

The logic that decides when a row becomes expired was inconsistent with the logic that decides if a single cell is expired. A single cell becomes expired when `expiry_timestamp <= now`, while a row became expired when `expiry_timestamp < now` (notice the strict inequality). For rows inserted with TTL, this caused non-key cells to expire (change their values to null) one second before the row disappeared. Now, row expiry logic uses non-strict inequality.

Fixes: #4263, #5290.

Tests:
- unit(dev)
- python test described in issue #5290
