### PR TITLE
Add a timeout for housekeeping when using scylla with no external connectivity

### DIFF
--- a/dist/common/scripts/scylla_setup
+++ b/dist/common/scripts/scylla_setup
@@ -30,7 +30,7 @@ import stat
 from scylla_util import *
 
 interactive = False
-
+HOUSEKEEPING_TIMEOUT = 60
 def when_interactive_ask_service(interactive, msg1, msg2, default = None):
     if not interactive:
         return default
@@ -283,16 +283,16 @@ if __name__ == '__main__':
         cur_version=out('scylla --version', exception=False)
         if len(cur_version) > 0:
             if is_debian_variant():
-                new_version=out('sudo -u scylla {}/scylla-housekeeping --uuid-file /var/lib/scylla-housekeeping/housekeeping.uuid --repo-files \'/etc/apt/sources.list.d/scylla*.list\' version --version {} --mode i'.format(scriptsdir(), cur_version), shell=True, exception=False)
+                new_version=out('sudo -u scylla {}/scylla-housekeeping --uuid-file /var/lib/scylla-housekeeping/housekeeping.uuid --repo-files \'/etc/apt/sources.list.d/scylla*.list\' version --version {} --mode i'.format(scriptsdir(), cur_version), shell=True, exception=False, timeout=HOUSEKEEPING_TIMEOUT)
             else:
-                new_version=out('sudo -u scylla {}/scylla-housekeeping --uuid-file /var/lib/scylla-housekeeping/housekeeping.uuid --repo-files \'/etc/yum.repos.d/scylla*.repo\' version --version {} --mode i'.format(scriptsdir(), cur_version), shell=True, exception=False)
+                new_version=out('sudo -u scylla {}/scylla-housekeeping --uuid-file /var/lib/scylla-housekeeping/housekeeping.uuid --repo-files \'/etc/yum.repos.d/scylla*.repo\' version --version {} --mode i'.format(scriptsdir(), cur_version), shell=True, exception=False, timeout=HOUSEKEEPING_TIMEOUT)
             if len(new_version) > 0:
                 print(new_version)
         else:
             if is_debian_variant():
-                new_version=out('sudo -u scylla {}/scylla-housekeeping --uuid-file /var/lib/scylla-housekeeping/housekeeping.uuid --repo-files \'/etc/apt/sources.list.d/scylla*.list\' version --version unknown --mode u'.format(scriptsdir()), shell=True, exception=False)
+                new_version=out('sudo -u scylla {}/scylla-housekeeping --uuid-file /var/lib/scylla-housekeeping/housekeeping.uuid --repo-files \'/etc/apt/sources.list.d/scylla*.list\' version --version unknown --mode u'.format(scriptsdir()), shell=True, exception=False, timeout=HOUSEKEEPING_TIMEOUT)
             else:
-                new_version=out('sudo -u scylla {}/scylla-housekeeping --uuid-file /var/lib/scylla-housekeeping/housekeeping.uuid --repo-files \'/etc/yum.repos.d/scylla*.repo\' version --version unknown --mode u'.format(scriptsdir()), shell=True, exception=False)
+                new_version=out('sudo -u scylla {}/scylla-housekeeping --uuid-file /var/lib/scylla-housekeeping/housekeeping.uuid --repo-files \'/etc/yum.repos.d/scylla*.repo\' version --version unknown --mode u'.format(scriptsdir()), shell=True, exception=False, timeout=HOUSEKEEPING_TIMEOUT)
             print('A Scylla executable was not found, please check your installation {}'.format(new_version))
 
         if is_redhat_variant():

--- a/dist/common/scripts/scylla_util.py
+++ b/dist/common/scripts/scylla_util.py
@@ -337,11 +337,11 @@ def run(cmd, shell=False, silent=False, exception=True):
         return p.wait()
 
 
-def out(cmd, shell=False, exception=True):
+def out(cmd, shell=False, exception=True, timeout=None):
     if not shell:
         cmd = shlex.split(cmd)
     if exception:
-        return subprocess.check_output(cmd, shell=shell, env=scylla_env).strip().decode('utf-8')
+        return subprocess.check_output(cmd, shell=shell, env=scylla_env, timeout=timeout).strip().decode('utf-8')
     else:
         p = subprocess.Popen(cmd, shell=shell, stdout=subprocess.PIPE, env=scylla_env)
         return p.communicate()[0].strip().decode('utf-8')


### PR DESCRIPTION
These series solves an issue with scylla_setup and prevent it from waiting forever if housekeeping cannot look for the new Scylla version.

Fixes  #5302
It should be backported to versions that support offline installations.