### PR TITLE
toolchain: update to Fedora 31

### DIFF
--- a/dist/redhat/build_rpm.sh
+++ b/dist/redhat/build_rpm.sh
@@ -110,7 +110,7 @@ mkdir -p $RPMBUILD/{BUILD,BUILDROOT,RPMS,SOURCES,SPECS,SRPMS}
 ln -fv $RELOC_PKG $RPMBUILD/SOURCES/
 pystache dist/redhat/scylla.spec.mustache "{ \"version\": \"$SCYLLA_VERSION\", \"release\": \"$SCYLLA_RELEASE\", \"housekeeping\": $DIST, \"product\": \"$PRODUCT\", \"$PRODUCT\": true, \"reloc_pkg\": \"$RELOC_PKG_BASENAME\", $MUSTACHE_DIST }" > $RPMBUILD/SPECS/scylla.spec
 if [ "$TARGET" = "centos7" ]; then
-    rpmbuild -ba --define "_topdir $RPMBUILD" --define "dist .el7" $RPMBUILD/SPECS/scylla.spec
+    rpmbuild -ba --define '_binary_payload w2.xzdio' --define "_topdir $RPMBUILD" --define "dist .el7" $RPMBUILD/SPECS/scylla.spec
 else
-    rpmbuild -ba --define "_topdir $RPMBUILD" $RPMBUILD/SPECS/scylla.spec
+    rpmbuild -ba --define '_binary_payload w2.xzdio' --define "_topdir $RPMBUILD" $RPMBUILD/SPECS/scylla.spec
 fi

--- a/dist/redhat/python3/build_rpm.sh
+++ b/dist/redhat/python3/build_rpm.sh
@@ -91,4 +91,4 @@ mkdir -p "$RPMBUILD"/{BUILD,BUILDROOT,RPMS,SOURCES,SPECS,SRPMS}
 
 ln -fv "$RELOC_PKG" "$RPMBUILD"/SOURCES/
 pystache dist/redhat/python3/python.spec.mustache "{ \"version\": \"${SCYLLA_VERSION}\", \"release\": \"${SCYLLA_RELEASE}\", \"reloc_pkg\": \"${RELOC_PKG_BASENAME}\", \"name\": \"$PRODUCT-python3\", \"target\": \"/opt/scylladb/python3\" }" > "$RPMBUILD"/SPECS/python.spec
-rpmbuild --nodebuginfo -ba --define "_build_id_links none" --define "_topdir ${RPMBUILD}" --define "dist .el7" "$RPMBUILD"/SPECS/python.spec
+rpmbuild --nodebuginfo -ba --define '_binary_payload w2.xzdio' --define "_build_id_links none" --define "_topdir ${RPMBUILD}" --define "dist .el7" "$RPMBUILD"/SPECS/python.spec

--- a/dist/redhat/scylla.spec.mustache
+++ b/dist/redhat/scylla.spec.mustache
@@ -87,7 +87,7 @@ fi
 %systemd_preun scylla-server.service
 
 %postun server
-%systemd_postun
+%systemd_postun scylla-server.service
 
 %posttrans server
 if  [ -d /tmp/%{name}-%{version}-%{release} ]; then

--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -75,6 +75,7 @@ fedora_packages=(
     util-linux
     ethtool
     hwloc
+    glibc-langpack-en
 )
 
 centos_packages=(

--- a/tools/toolchain/Dockerfile
+++ b/tools/toolchain/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:30
+FROM fedora:31
 ADD ./install-dependencies.sh ./
 ADD ./seastar/install-dependencies.sh ./seastar/
 ADD ./tools/toolchain/system-auth ./

--- a/tools/toolchain/image
+++ b/tools/toolchain/image
@@ -1,1 +1,1 @@
-docker.io/scylladb/scylla-toolchain:fedora-30-20191022
+docker.io/scylladb/scylla-toolchain:fedora-31-20191119


### PR DESCRIPTION
This is a minor update as gcc and boost versions did not change. A noteable update is patchelf 0.10, which adds support to large binaries.

A few minor issues exposed by the update are fixed in preparatory patches.