### PR TITLE
5139 minmax bad printing

### DIFF
--- a/cql3/functions/functions.cc
+++ b/cql3/functions/functions.cc
@@ -154,6 +154,10 @@ functions::init() {
     declare(aggregate_fcts::make_max_function<timeuuid_native_type>());
     declare(aggregate_fcts::make_min_function<timeuuid_native_type>());
 
+    declare(aggregate_fcts::make_count_function<time_native_type>());
+    declare(aggregate_fcts::make_max_function<time_native_type>());
+    declare(aggregate_fcts::make_min_function<time_native_type>());
+
     declare(aggregate_fcts::make_count_function<utils::UUID>());
     declare(aggregate_fcts::make_max_function<utils::UUID>());
     declare(aggregate_fcts::make_min_function<utils::UUID>());
@@ -165,6 +169,10 @@ functions::init() {
     declare(aggregate_fcts::make_count_function<bool>());
     declare(aggregate_fcts::make_max_function<bool>());
     declare(aggregate_fcts::make_min_function<bool>());
+
+    declare(aggregate_fcts::make_count_function<net::inet_address>());
+    declare(aggregate_fcts::make_max_function<net::inet_address>());
+    declare(aggregate_fcts::make_min_function<net::inet_address>());
 
     // FIXME: more count/min/max
 

--- a/tests/cql_query_test.cc
+++ b/tests/cql_query_test.cc
@@ -1607,6 +1607,15 @@ SEASTAR_TEST_CASE(test_aggregate_functions) {
             timeuuid_native_type{utils::UUID("00000000-0000-1000-0000-000000000002")}
         ).test_min_max_count();
 
+        aggregate_function_test(e, time_type,
+            time_native_type{std::chrono::duration_cast<std::chrono::nanoseconds>(
+                    now.time_since_epoch() - std::chrono::seconds(1)).count()},
+            time_native_type{std::chrono::duration_cast<std::chrono::nanoseconds>(
+                    now.time_since_epoch()).count()},
+            time_native_type{std::chrono::duration_cast<std::chrono::nanoseconds>(
+                    now.time_since_epoch() + std::chrono::seconds(1)).count()}
+        ).test_min_max_count();
+
         aggregate_function_test(e, uuid_type,
             utils::UUID("00000000-0000-1000-0000-000000000000"),
             utils::UUID("00000000-0000-1000-0000-000000000001"),
@@ -1614,6 +1623,15 @@ SEASTAR_TEST_CASE(test_aggregate_functions) {
         ).test_min_max_count();
 
         aggregate_function_test(e, boolean_type, false, true).test_min_max_count();
+
+        aggregate_function_test(e, inet_addr_type,
+            net::inet_address("0.0.0.0"),
+            net::inet_address("::"),
+            net::inet_address("::1"),
+            net::inet_address("0.0.0.1"),
+            net::inet_address("1::1"),
+            net::inet_address("1.0.0.1")
+        ).test_min_max_count();
     });
 }
 


### PR DESCRIPTION
This is a partial solution to #5139 (only for two types) because of the above and because collections are much harder to do. They are coming in a separate PR.
What this PR does is simple: adds `system.min()` and `system.max()` fns for `time_type` and `inet_address`, so 'overload resolution' does not use `blob->blob` overload, which caused results to be printed as blobs.