### PR TITLE
tracing: one_session_records: keep local tracing ptr

### DIFF
--- a/tracing/tracing.cc
+++ b/tracing/tracing.cc
@@ -206,8 +206,9 @@ void tracing::set_trace_probability(double p) {
 }
 
 one_session_records::one_session_records()
-    : backend_state_ptr(tracing::get_local_tracing_instance().allocate_backend_session_state())
-    , budget_ptr(tracing::get_local_tracing_instance().get_cached_records_ptr()) {}
+    : _local_tracing_ptr(tracing::get_local_tracing_instance().shared_from_this())
+    , backend_state_ptr(_local_tracing_ptr->allocate_backend_session_state())
+    , budget_ptr(_local_tracing_ptr->get_cached_records_ptr()) {}
 
 std::ostream& operator<<(std::ostream& os, const span_id& id) {
     return os << id.get_id();

--- a/tracing/tracing.hh
+++ b/tracing/tracing.hh
@@ -240,6 +240,8 @@ public:
 };
 
 class one_session_records {
+private:
+    shared_ptr<tracing> _local_tracing_ptr;
 public:
     utils::UUID session_id;
     session_record session_rec;
@@ -665,7 +667,7 @@ private:
 
 void one_session_records::set_pending_for_write() {
     _is_pending_for_write = true;
-    budget_ptr = tracing::get_local_tracing_instance().get_pending_records_ptr();
+    budget_ptr = _local_tracing_ptr->get_pending_records_ptr();
 }
 
 void one_session_records::data_consumed() {
@@ -674,7 +676,7 @@ void one_session_records::data_consumed() {
     }
 
     _is_pending_for_write = false;
-    budget_ptr = tracing::get_local_tracing_instance().get_cached_records_ptr();
+    budget_ptr = _local_tracing_ptr->get_cached_records_ptr();
 }
 
 inline span_id span_id::make_span_id() {


### PR DESCRIPTION
Fixes #5243

cql_tracing_test:TestCqlTracing.tracing_shutdown_test hits the following assert:
scylla: /local/home/bhalevy/dev/scylla/seastar/include/seastar/core/sharded.hh:712: Service& seastar::sharded<T>::local() [with Service = tracing::tracing]: Assertion `local_is_initialized()' failed.

Similar to trace_state keep shared_ptr<tracing> _local_tracing_ptr
in one_session_records when constructed so it can be used
during shutdown.

Signed-off-by: Benny Halevy <bhalevy@scylladb.com>

Test: unit(dev), cql_tracing_test:TestCqlTracing.tracing_shutdown_test (dev)