### PR TITLE
api: export system uptime via REST

### DIFF
--- a/api/api-doc/system.json
+++ b/api/api-doc/system.json
@@ -53,6 +53,24 @@
          ]
       },
       {
+         "path":"/system/uptime_ms",
+         "operations":[
+            {
+               "method":"GET",
+               "summary":"Get system uptime, in milliseconds",
+               "type":"array",
+               "items":{
+                  "type":"long"
+               },
+               "nickname":"get_system_uptime",
+               "produces":[
+                  "application/json"
+               ],
+               "parameters":[]
+            }
+         ]
+      },
+      {
          "path":"/system/logger/{name}",
          "operations":[
             {

--- a/api/system.cc
+++ b/api/system.cc
@@ -30,6 +30,10 @@ namespace api {
 namespace hs = httpd::system_json;
 
 void set_system(http_context& ctx, routes& r) {
+    hs::get_system_uptime.set(r, [](const_req req) {
+        return std::chrono::duration_cast<std::chrono::milliseconds>(engine().uptime()).count();
+    });
+
     hs::get_all_logger_names.set(r, [](const_req req) {
         return logging::logger_registry().get_all_logger_names();
     });


### PR DESCRIPTION
This will be useful for tools like nodetool that want to query the uptime
of the system.

Signed-off-by: Glauber Costa <glauber@scylladb.com>