### PR TITLE
Sstables: limit snapshot dirs

### DIFF
--- a/sstables/entry_descriptor.hh
+++ b/sstables/entry_descriptor.hh
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2019 ScyllaDB
+ */
+
+/*
+ * This file is part of Scylla.
+ *
+ * Scylla is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Scylla is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <seastar/core/sstring.hh>
+
+#include "sstables/component_type.hh"
+#include "sstables/version.hh"
+
+using namespace seastar;
+
+namespace sstables {
+
+struct entry_descriptor {
+    sstring sstdir;
+    sstring ks;
+    sstring cf;
+    int64_t generation;
+    sstable_version_types version;
+    sstable_format_types format;
+    component_type component;
+
+    static entry_descriptor make_descriptor(sstring sstdir, sstring fname);
+
+    entry_descriptor(sstring sstdir, sstring ks, sstring cf, int64_t generation,
+                     sstable_version_types version, sstable_format_types format,
+                     component_type component)
+        : sstdir(sstdir), ks(ks), cf(cf), generation(generation), version(version), format(format), component(component) {}
+};
+
+}

--- a/sstables/entry_descriptor.hh
+++ b/sstables/entry_descriptor.hh
@@ -21,6 +21,8 @@
 
 #pragma once
 
+#include <regex>
+
 #include <seastar/core/sstring.hh>
 
 #include "sstables/component_type.hh"
@@ -30,7 +32,10 @@ using namespace seastar;
 
 namespace sstables {
 
-struct entry_descriptor {
+class sstable;
+
+class entry_descriptor {
+public:
     sstring sstdir;
     sstring ks;
     sstring cf;
@@ -45,6 +50,12 @@ struct entry_descriptor {
                      sstable_version_types version, sstable_format_types format,
                      component_type component)
         : sstdir(sstdir), ks(ks), cf(cf), generation(generation), version(version), format(format), component(component) {}
+private:
+    friend class sstable;
+
+    static std::regex la_mc_filename_pattern;
+    static std::regex ka_filename_pattern;
+    static std::regex sst_dir_pattern;
 };
 
 }

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -2608,7 +2608,7 @@ sstable::location_types sstable::sstable_location(const sstring& dir) {
 }
 
 bool sstable::requires_view_building() const {
-    return boost::algorithm::ends_with(_dir, "staging");
+    return get_location() == sstable::location_types::staging;
 }
 
 sstring sstable::component_basename(const sstring& ks, const sstring& cf, version_types version, int64_t generation,

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -62,6 +62,7 @@
 #include "stats.hh"
 #include "utils/observable.hh"
 #include "sstables/shareable_components.hh"
+#include "sstables/entry_descriptor.hh"
 
 #include <seastar/util/optimized_optional.hh>
 #include <boost/intrusive/list.hpp>
@@ -847,23 +848,6 @@ public:
     template <typename DataConsumeRowsContext>
     friend data_consume_context<DataConsumeRowsContext>
     data_consume_rows(const schema&, shared_sstable, typename DataConsumeRowsContext::consumer&);
-};
-
-struct entry_descriptor {
-    sstring sstdir;
-    sstring ks;
-    sstring cf;
-    int64_t generation;
-    sstable::version_types version;
-    sstable::format_types format;
-    component_type component;
-
-    static entry_descriptor make_descriptor(sstring sstdir, sstring fname);
-
-    entry_descriptor(sstring sstdir, sstring ks, sstring cf, int64_t generation,
-                     sstable::version_types version, sstable::format_types format,
-                     component_type component)
-        : sstdir(sstdir), ks(ks), cf(cf), generation(generation), version(version), format(format), component(component) {}
 };
 
 // Waits for all prior tasks started on current shard related to sstable management to finish.

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -134,6 +134,7 @@ public:
     using version_types = sstable_version_types;
     using format_types = sstable_format_types;
     using tracker_link_type = bi::list_member_hook<bi::link_mode<bi::auto_unlink>>;
+    using location_types = sstable_location_types;
 public:
     sstable(schema_ptr schema,
             sstring dir,
@@ -411,6 +412,11 @@ public:
         return temp_sst_dir(_dir, _generation);
     }
 
+    static location_types sstable_location(const sstring& dir);
+    location_types get_location() const {
+        return _location;
+    }
+
     bool requires_view_building() const;
 
     metadata_collector& get_metadata_collector() {
@@ -523,6 +529,7 @@ private:
 
     schema_ptr _schema;
     sstring _dir;
+    location_types _location = location_types::unknown;
     std::optional<sstring> _temp_dir; // Valid while the sstable is being created, until sealed
     unsigned long _generation = 0;
     version_types _version;

--- a/sstables/types.hh
+++ b/sstables/types.hh
@@ -49,6 +49,14 @@ static inline bytes_view to_bytes_view(const temporary_buffer<char>& b) {
 
 namespace sstables {
 
+enum class sstable_location_types {
+    unknown,
+    base,
+    staging,
+    upload,
+    snapshots,
+};
+
 GCC6_CONCEPT(
 template<typename T>
 concept bool Writer() {


### PR DESCRIPTION
Fixes #5324

We've hit a case where snapshot failed since an sstable in staging got removed while taking its snapshot. We need to snapshot only sstables located in the base table directory, not in "staging" or "uploads".

The patchset introduces an enum class sstable::location_types that indicates where the sstable is in the data hierarchy: base, staging, upload, or snapshots.

The sstable location is determined when the sstable object is constructed using the sstable directory using a regular expression shared with `make_descriptor`.  `sstable::get_location()` retrieves the location.

The sstable location is used by `table::snapshot` to filter `_sstables->all()` and ignore any sstable that is not in the base directory.

A unit test for sstable location has been added to `sstable_test`.
