### PR TITLE
tools: toolchain: support podman as a replacement to docker

### DIFF
--- a/tools/toolchain/dbuild
+++ b/tools/toolchain/dbuild
@@ -144,9 +144,12 @@ docker_common_args=(
        "${args[@]}"
 )
 
-if [[ -n "$interactive" ]]; then
+if [[ -n "$interactive" || -n "$is_podman" ]]; then
     # If --interactive was given on the command line, we can't run in detached mode
     # as it will be impossible to interact with the container.
+
+    # We also avoid detached mode with podman, which doesn't need it
+    # (it does not proxy SIGTERM) and doesn't work well with it.
     exec docker run --rm "${docker_common_args[@]}"
 fi
 

--- a/tools/toolchain/dbuild
+++ b/tools/toolchain/dbuild
@@ -107,13 +107,18 @@ MAVEN_LOCAL_REPO="$HOME/.m2"
 
 mkdir -p "$MAVEN_LOCAL_REPO"
 
+docker_common_args=()
+
+if [ "$PWD" != "$toplevel" ]; then
+     docker_common_args+=(-v "$toplevel:$toplevel:z")
+fi
+
 docker_common_args=(
        --network host \
        -u "$(id -u):$(id -g)" \
        "${group_args[@]}" \
        --cap-add SYS_PTRACE \
        -v "$PWD:$PWD:z" \
-       -v "$toplevel:$toplevel:z" \
        -v /tmp:/tmp:z \
        -v "$MAVEN_LOCAL_REPO:$MAVEN_LOCAL_REPO:z" \
        -v /etc/passwd:/etc/passwd:ro \

--- a/tools/toolchain/dbuild
+++ b/tools/toolchain/dbuild
@@ -107,24 +107,38 @@ MAVEN_LOCAL_REPO="$HOME/.m2"
 
 mkdir -p "$MAVEN_LOCAL_REPO"
 
+is_podman="$(docker --version | grep -o podman)"
+
 docker_common_args=()
 
+z=":z"
+
+if [ -z "$is_podman" ]; then
+    docker_common_args+=(
+       -u "$(id -u):$(id -g)"
+       "${group_args[@]}"
+       -v /etc/passwd:/etc/passwd:ro
+       -v /etc/group:/etc/group:ro
+       )
+else
+    # podman accesses filesystem as the calling user, so selinux relabeling
+    # is not needed; moreover it objects to relabeling /tmp
+    z=""
+fi
+
 if [ "$PWD" != "$toplevel" ]; then
-     docker_common_args+=(-v "$toplevel:$toplevel:z")
+     docker_common_args+=(-v "$toplevel:$toplevel$z")
 fi
 
 docker_common_args=(
        --network host \
-       -u "$(id -u):$(id -g)" \
-       "${group_args[@]}" \
        --cap-add SYS_PTRACE \
-       -v "$PWD:$PWD:z" \
-       -v /tmp:/tmp:z \
-       -v "$MAVEN_LOCAL_REPO:$MAVEN_LOCAL_REPO:z" \
-       -v /etc/passwd:/etc/passwd:ro \
-       -v /etc/group:/etc/group:ro \
+       -v "$PWD:$PWD$z" \
+       -v /tmp:/tmp$z \
+       -v "$MAVEN_LOCAL_REPO:$MAVEN_LOCAL_REPO$z" \
        -v /etc/localtime:/etc/localtime:ro \
        -w "$PWD" \
+       -e HOME \
        "${docker_args[@]}" \
        "$image" \
        "${args[@]}"


### PR DESCRIPTION
Docker on Fedora 31 is flakey, and is not supported at all on RHEL 8. Podman is a drop-in replacement for docker; this series adds support for using podman in dbuild.

Apart from actually working on Fedora 31 hosts, podman is nicer in being more secure and not requiring a daemon.

Fixes #5332.