### PR TITLE
Synchronize snapshot and staging sstable deletion using sem

### DIFF
--- a/database.hh
+++ b/database.hh
@@ -533,7 +533,7 @@ private:
     utils::phased_barrier _pending_streams_phaser;
 public:
     future<> add_sstable_and_update_cache(sstables::shared_sstable sst);
-    void move_sstable_from_staging_in_thread(sstables::shared_sstable sst);
+    future<> move_sstables_from_staging(std::vector<sstables::shared_sstable>);
     sstables::shared_sstable get_staging_sstable(uint64_t generation) {
         auto it = _sstables_staging.find(generation);
         return it != _sstables_staging.end() ? it->second : nullptr;

--- a/db/view/view_update_generator.cc
+++ b/db/view/view_update_generator.cc
@@ -34,23 +34,23 @@ future<> view_update_generator::start() {
                 _pending_sstables.wait().get();
             }
             while (!_sstables_with_tables.empty()) {
-                auto& entry = _sstables_with_tables.front();
+                auto& [sst, t] = _sstables_with_tables.front();
                 try {
-                    schema_ptr s = entry.t->schema();
-                    flat_mutation_reader staging_sstable_reader = entry.sst->read_rows_flat(s);
-                    auto result = staging_sstable_reader.consume_in_thread(view_updating_consumer(s, _proxy, entry.sst, _as), db::no_timeout);
+                    schema_ptr s = t->schema();
+                    flat_mutation_reader staging_sstable_reader = sst->read_rows_flat(s);
+                    auto result = staging_sstable_reader.consume_in_thread(view_updating_consumer(s, _proxy, sst, _as), db::no_timeout);
                     if (result == stop_iteration::yes) {
                         break;
                     }
                 } catch (...) {
-                    vug_logger.warn("Processing {} failed: {}. Will retry...", entry.sst->get_filename(), std::current_exception());
+                    vug_logger.warn("Processing {} failed: {}. Will retry...", sst->get_filename(), std::current_exception());
                     break;
                 }
                 try {
-                    entry.t->move_sstable_from_staging_in_thread(entry.sst);
+                    t->move_sstable_from_staging_in_thread(sst);
                 } catch (...) {
                     // Move from staging will be retried upon restart.
-                    vug_logger.warn("Moving {} from staging failed: {}. Ignoring...", entry.sst->get_filename(), std::current_exception());
+                    vug_logger.warn("Moving {} from staging failed: {}. Ignoring...", sst->get_filename(), std::current_exception());
                 }
                 _registration_sem.signal();
                 _sstables_with_tables.pop_front();

--- a/db/view/view_update_generator.cc
+++ b/db/view/view_update_generator.cc
@@ -21,6 +21,8 @@
 
 #include "view_update_generator.hh"
 
+static logging::logger vug_logger("view_update_generator");
+
 namespace db::view {
 
 future<> view_update_generator::start() {
@@ -33,13 +35,23 @@ future<> view_update_generator::start() {
             }
             while (!_sstables_with_tables.empty()) {
                 auto& entry = _sstables_with_tables.front();
+              try {
                 schema_ptr s = entry.t->schema();
                 flat_mutation_reader staging_sstable_reader = entry.sst->read_rows_flat(s);
                 auto result = staging_sstable_reader.consume_in_thread(view_updating_consumer(s, _proxy, entry.sst, _as), db::no_timeout);
                 if (result == stop_iteration::yes) {
                     break;
                 }
+              } catch (...) {
+                vug_logger.warn("Processing {} failed: {}. Will retry...", entry.sst->get_filename(), std::current_exception());
+                break;
+              }
+              try {
                 entry.t->move_sstable_from_staging_in_thread(entry.sst);
+              } catch (...) {
+                // Move from staging will be retried upon restart.
+                vug_logger.warn("Moving {} from staging failed: {}. Ignoring...", entry.sst->get_filename(), std::current_exception());
+              }
                 _registration_sem.signal();
                 _sstables_with_tables.pop_front();
             }

--- a/db/view/view_update_generator.hh
+++ b/db/view/view_update_generator.hh
@@ -42,7 +42,7 @@ class view_update_generator {
     struct sstable_with_table {
         sstables::shared_sstable sst;
         lw_shared_ptr<table> t;
-        sstable_with_table(sstables::shared_sstable sst, lw_shared_ptr<table> t) : sst(sst), t(t) { }
+        sstable_with_table(sstables::shared_sstable sst, lw_shared_ptr<table> t) : sst(std::move(sst)), t(std::move(t)) { }
     };
     std::deque<sstable_with_table> _sstables_with_tables;
 public:

--- a/db/view/view_update_generator.hh
+++ b/db/view/view_update_generator.hh
@@ -45,6 +45,7 @@ class view_update_generator {
         sstable_with_table(sstables::shared_sstable sst, lw_shared_ptr<table> t) : sst(std::move(sst)), t(std::move(t)) { }
     };
     std::deque<sstable_with_table> _sstables_with_tables;
+    std::unordered_map<lw_shared_ptr<table>, std::vector<sstables::shared_sstable>> _sstables_to_move;
 public:
     view_update_generator(database& db, service::storage_proxy& proxy) : _db(db), _proxy(proxy) { }
 

--- a/distributed_loader.cc
+++ b/distributed_loader.cc
@@ -567,9 +567,7 @@ future<sstables::entry_descriptor> distributed_loader::probe_file(distributed<da
         cf.update_sstables_known_generation(comps.generation);
         if (shared_sstable sst = cf.get_staging_sstable(comps.generation)) {
             dblog.warn("SSTable {} is already present in staging/ directory. Moving from staging will be retried.", sst->get_filename());
-            return seastar::async([sst = std::move(sst), comps = std::move(comps)] () {
-                sst->move_to_new_dir_in_thread(comps.sstdir, comps.generation);
-            });
+            return sst->move_to_new_dir(comps.sstdir, comps.generation);
         }
         {
             auto i = boost::range::find_if(*cf._sstables->all(), [gen = comps.generation] (sstables::shared_sstable sst) { return sst->generation() == gen; });

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -193,7 +193,7 @@ public:
     future<> update_info_for_opened_data();
 
     future<> set_generation(int64_t generation);
-    future<> move_to_new_dir(sstring new_dir, int64_t generation);
+    future<> move_to_new_dir(sstring new_dir, int64_t generation, bool do_sync_dirs = true);
 
     int64_t generation() const {
         return _generation;

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -193,7 +193,7 @@ public:
     future<> update_info_for_opened_data();
 
     future<> set_generation(int64_t generation);
-    void move_to_new_dir_in_thread(sstring dir, int64_t generation);
+    future<> move_to_new_dir(sstring new_dir, int64_t generation);
 
     int64_t generation() const {
         return _generation;

--- a/table.cc
+++ b/table.cc
@@ -2472,15 +2472,29 @@ table::make_reader_excluding_sstable(schema_ptr s,
     return make_combined_reader(s, std::move(readers), fwd, fwd_mr);
 }
 
-void table::move_sstable_from_staging_in_thread(sstables::shared_sstable sst) {
-    try {
-        sst->move_to_new_dir(dir(), sst->generation()).get();
-    } catch (...) {
-        tlogger.warn("Failed to move sstable {} from staging: {}", sst->get_filename(), std::current_exception());
-        return;
-    }
-    _sstables_staging.erase(sst->generation());
-    _compaction_strategy.get_backlog_tracker().add_sstable(sst);
+future<> table::move_sstables_from_staging(std::vector<sstables::shared_sstable> sstables) {
+    return with_semaphore(_sstable_deletion_sem, 1, [this, sstables = std::move(sstables)] {
+        return do_with(std::set<sstring>({dir()}), [this, sstables = std::move(sstables)] (std::set<sstring>& dirs_to_sync) {
+            return do_for_each(std::move(sstables), [this, &dirs_to_sync] (sstables::shared_sstable sst) {
+                dirs_to_sync.emplace(sst->get_dir());
+                return sst->move_to_new_dir(dir(), sst->generation(), false).then_wrapped([this, sst, &dirs_to_sync] (future<> f) {
+                    if (!f.failed()) {
+                        _sstables_staging.erase(sst->generation());
+                        _compaction_strategy.get_backlog_tracker().add_sstable(sst);
+                        return make_ready_future<>();
+                    } else {
+                        auto ep = f.get_exception();
+                        tlogger.warn("Failed to move sstable {} from staging: {}", sst->get_filename(), ep);
+                        return make_exception_future<>(ep);
+                    }
+                });
+            }).finally([&dirs_to_sync] {
+                return parallel_for_each(dirs_to_sync, [] (sstring dir) {
+                    return sync_directory(dir);
+                });
+            });
+        });
+    });
 }
 
 /**

--- a/table.cc
+++ b/table.cc
@@ -2474,7 +2474,7 @@ table::make_reader_excluding_sstable(schema_ptr s,
 
 void table::move_sstable_from_staging_in_thread(sstables::shared_sstable sst) {
     try {
-        sst->move_to_new_dir_in_thread(dir(), sst->generation());
+        sst->move_to_new_dir(dir(), sst->generation()).get();
     } catch (...) {
         tlogger.warn("Failed to move sstable {} from staging: {}", sst->get_filename(), std::current_exception());
         return;


### PR DESCRIPTION
Fixes #5340
(instead of #5329 that was retracted)

Hold the sstable_deletion_sem table::move_sstables_from_subdirs to serialize access to the staging directory.  It now synchronizes snapshot, compaction deletion of sstables, and view_update_generator moving of sstables from staging.

Tests:
* unit (dev) [expect  test_user_function_timestamp_return that fails for me locally, but also on master]
* snapshot_test.py (dev)