### PR TITLE
Redis API:   Rename options related to Redis API, describe them clearly, and remove unnecessary one.

### DIFF
--- a/conf/scylla.yaml
+++ b/conf/scylla.yaml
@@ -264,24 +264,6 @@ batch_size_fail_threshold_in_kb: 50
 # created until it has been seen alive and gone down again.
 # max_hint_window_in_ms: 10800000 # 3 hours
 
-# Maximum throttle in KBs per second, per delivery thread.  This will be
-# reduced proportionally to the number of nodes in the cluster.  (If there
-# are two nodes in the cluster, each delivery thread will use the maximum
-# rate; if there are three, each will throttle to half of the maximum,
-# since we expect two nodes to be delivering hints simultaneously.)
-# hinted_handoff_throttle_in_kb: 1024
-# Number of threads with which to deliver hints;
-# Consider increasing this number when you have multi-dc deployments, since
-# cross-dc handoff tends to be slower
-# max_hints_delivery_threads: 2
-
-###################################################
-## Not currently supported, reserved for future use
-###################################################
-
-# Maximum throttle in KBs per second, total. This will be
-# reduced proportionally to the number of nodes in the cluster.
-# batchlog_replay_throttle_in_kb: 1024
 
 # Validity period for permissions cache (fetching permissions can be an
 # expensive operation depending on the authorizer, CassandraAuthorizer is
@@ -309,120 +291,6 @@ batch_size_fail_threshold_in_kb: 50
 #
 partitioner: org.apache.cassandra.dht.Murmur3Partitioner
 
-# Maximum size of the key cache in memory.
-#
-# Each key cache hit saves 1 seek and each row cache hit saves 2 seeks at the
-# minimum, sometimes more. The key cache is fairly tiny for the amount of
-# time it saves, so it's worthwhile to use it at large numbers.
-# The row cache saves even more time, but must contain the entire row,
-# so it is extremely space-intensive. It's best to only use the
-# row cache if you have hot rows or static rows.
-#
-# NOTE: if you reduce the size, you may not get you hottest keys loaded on startup.
-#
-# Default value is empty to make it "auto" (min(5% of Heap (in MB), 100MB)). Set to 0 to disable key cache.
-# key_cache_size_in_mb:
-
-# Duration in seconds after which Scylla should
-# save the key cache. Caches are saved to saved_caches_directory as
-# specified in this configuration file.
-#
-# Saved caches greatly improve cold-start speeds, and is relatively cheap in
-# terms of I/O for the key cache. Row cache saving is much more expensive and
-# has limited use.
-#
-# Default is 14400 or 4 hours.
-# key_cache_save_period: 14400
-
-# Number of keys from the key cache to save
-# Disabled by default, meaning all keys are going to be saved
-# key_cache_keys_to_save: 100
-
-# Maximum size of the row cache in memory.
-# NOTE: if you reduce the size, you may not get you hottest keys loaded on startup.
-#
-# Default value is 0, to disable row caching.
-# row_cache_size_in_mb: 0
-
-# Duration in seconds after which Scylla should
-# save the row cache. Caches are saved to saved_caches_directory as specified
-# in this configuration file.
-#
-# Saved caches greatly improve cold-start speeds, and is relatively cheap in
-# terms of I/O for the key cache. Row cache saving is much more expensive and
-# has limited use.
-#
-# Default is 0 to disable saving the row cache.
-# row_cache_save_period: 0
-
-# Number of keys from the row cache to save
-# Disabled by default, meaning all keys are going to be saved
-# row_cache_keys_to_save: 100
-
-# Maximum size of the counter cache in memory.
-#
-# Counter cache helps to reduce counter locks' contention for hot counter cells.
-# In case of RF = 1 a counter cache hit will cause Scylla to skip the read before
-# write entirely. With RF > 1 a counter cache hit will still help to reduce the duration
-# of the lock hold, helping with hot counter cell updates, but will not allow skipping
-# the read entirely. Only the local (clock, count) tuple of a counter cell is kept
-# in memory, not the whole counter, so it's relatively cheap.
-#
-# NOTE: if you reduce the size, you may not get you hottest keys loaded on startup.
-#
-# Default value is empty to make it "auto" (min(2.5% of Heap (in MB), 50MB)). Set to 0 to disable counter cache.
-# NOTE: if you perform counter deletes and rely on low gcgs, you should disable the counter cache.
-# counter_cache_size_in_mb:
-
-# Duration in seconds after which Scylla should
-# save the counter cache (keys only). Caches are saved to saved_caches_directory as
-# specified in this configuration file.
-#
-# Default is 7200 or 2 hours.
-# counter_cache_save_period: 7200
-
-# Number of keys from the counter cache to save
-# Disabled by default, meaning all keys are going to be saved
-# counter_cache_keys_to_save: 100
-
-# The off-heap memory allocator.  Affects storage engine metadata as
-# well as caches.  Experiments show that JEMAlloc saves some memory
-# than the native GCC allocator (i.e., JEMalloc is more
-# fragmentation-resistant).
-# 
-# Supported values are: NativeAllocator, JEMallocAllocator
-#
-# If you intend to use JEMallocAllocator you have to install JEMalloc as library and
-# modify cassandra-env.sh as directed in the file.
-#
-# Defaults to NativeAllocator
-# memory_allocator: NativeAllocator
-
-# saved caches
-# If not set, the default directory is /var/lib/scylla/saved_caches.
-# saved_caches_directory: /var/lib/scylla/saved_caches
-
-
-
-# For workloads with more data than can fit in memory, Scylla's
-# bottleneck will be reads that need to fetch data from
-# disk. "concurrent_reads" should be set to (16 * number_of_drives) in
-# order to allow the operations to enqueue low enough in the stack
-# that the OS and drives can reorder them. Same applies to
-# "concurrent_counter_writes", since counter writes read the current
-# values before incrementing and writing them back.
-#
-# On the other hand, since writes are almost never IO bound, the ideal
-# number of "concurrent_writes" is dependent on the number of cores in
-# your system; (8 * number_of_cores) is a good rule of thumb.
-# concurrent_reads: 32
-# concurrent_writes: 32
-# concurrent_counter_writes: 32
-
-# Total memory to use for sstable-reading buffers.  Defaults to
-# the smaller of 1/4 of heap or 512MB.
-# file_cache_size_in_mb: 512
-
 # Total space to use for commitlogs.
 #
 # If space gets above this value (it will round up to the next nearest
@@ -433,28 +301,6 @@ partitioner: org.apache.cassandra.dht.Murmur3Partitioner
 # A value of -1 (default) will automatically equate it to the total amount of memory
 # available for Scylla.
 commitlog_total_space_in_mb: -1
-
-# A fixed memory pool size in MB for for SSTable index summaries. If left
-# empty, this will default to 5% of the heap size. If the memory usage of
-# all index summaries exceeds this limit, SSTables with low read rates will
-# shrink their index summaries in order to meet this limit.  However, this
-# is a best-effort process. In extreme conditions Scylla may need to use
-# more than this amount of memory.
-# index_summary_capacity_in_mb:
-
-# How frequently index summaries should be resampled.  This is done
-# periodically to redistribute memory from the fixed-size pool to sstables
-# proportional their recent read rates.  Setting to -1 will disable this
-# process, leaving existing index summaries at their current sampling level.
-# index_summary_resize_interval_in_minutes: 60
-
-# Whether to, when doing sequential writing, fsync() at intervals in
-# order to force the operating system to flush the dirty
-# buffers. Enable this to avoid sudden dirty buffer flushing from
-# impacting read latencies. Almost always a good idea on SSDs; not
-# necessarily on platters.
-# trickle_fsync: false
-# trickle_fsync_interval_in_kb: 10240
 
 # TCP port, for commands and data
 # For security reasons, you should not expose this port to the internet.  Firewall it if needed.
@@ -468,90 +314,20 @@ commitlog_total_space_in_mb: -1
 # listen_interface: eth0
 # listen_interface_prefer_ipv6: false
 
-# Internode authentication backend, implementing IInternodeAuthenticator;
-# used to allow/disallow connections from peer nodes.
-# internode_authenticator: org.apache.cassandra.auth.AllowAllInternodeAuthenticator
-
 # Whether to start the native transport server.
 # Please note that the address on which the native transport is bound is the
 # same as the rpc_address. The port however is different and specified below.
 # start_native_transport: true
 
-# The maximum threads for handling requests when the native transport is used.
-# This is similar to rpc_max_threads though the default differs slightly (and
-# there is no native_transport_min_threads, idle threads will always be stopped
-# after 30 seconds).
-# native_transport_max_threads: 128
-#
 # The maximum size of allowed frame. Frame (requests) larger than this will
 # be rejected as invalid. The default is 256MB.
 # native_transport_max_frame_size_in_mb: 256
-
-# The maximum number of concurrent client connections.
-# The default is -1, which means unlimited.
-# native_transport_max_concurrent_connections: -1
-
-# The maximum number of concurrent client connections per source ip.
-# The default is -1, which means unlimited.
-# native_transport_max_concurrent_connections_per_ip: -1
 
 # Whether to start the thrift rpc server.
 # start_rpc: true
 
 # enable or disable keepalive on rpc/native connections
 # rpc_keepalive: true
-
-# Scylla provides two out-of-the-box options for the RPC Server:
-#
-# sync  -> One thread per thrift connection. For a very large number of clients, memory
-#          will be your limiting factor. On a 64 bit JVM, 180KB is the minimum stack size
-#          per thread, and that will correspond to your use of virtual memory (but physical memory
-#          may be limited depending on use of stack space).
-#
-# hsha  -> Stands for "half synchronous, half asynchronous." All thrift clients are handled
-#          asynchronously using a small number of threads that does not vary with the amount
-#          of thrift clients (and thus scales well to many clients). The rpc requests are still
-#          synchronous (one thread per active request). If hsha is selected then it is essential
-#          that rpc_max_threads is changed from the default value of unlimited.
-#
-# The default is sync because on Windows hsha is about 30% slower.  On Linux,
-# sync/hsha performance is about the same, with hsha of course using less memory.
-#
-# Alternatively,  can provide your own RPC server by providing the fully-qualified class name
-# of an o.a.c.t.TServerFactory that can create an instance of it.
-# rpc_server_type: sync
-
-# Uncomment rpc_min|max_thread to set request pool size limits.
-#
-# Regardless of your choice of RPC server (see above), the number of maximum requests in the
-# RPC thread pool dictates how many concurrent requests are possible (but if you are using the sync
-# RPC server, it also dictates the number of clients that can be connected at all).
-#
-# The default is unlimited and thus provides no protection against clients overwhelming the server. You are
-# encouraged to set a maximum that makes sense for you in production, but do keep in mind that
-# rpc_max_threads represents the maximum number of client requests this server may execute concurrently.
-#
-# rpc_min_threads: 16
-# rpc_max_threads: 2048
-
-# uncomment to set socket buffer sizes on rpc connections
-# rpc_send_buff_size_in_bytes:
-# rpc_recv_buff_size_in_bytes:
-
-# Uncomment to set socket buffer size for internode communication
-# Note that when setting this, the buffer size is limited by net.core.wmem_max
-# and when not setting it it is defined by net.ipv4.tcp_wmem
-# See:
-# /proc/sys/net/core/wmem_max
-# /proc/sys/net/core/rmem_max
-# /proc/sys/net/ipv4/tcp_wmem
-# /proc/sys/net/ipv4/tcp_rmem
-# and: man tcp
-# internode_send_buff_size_in_bytes:
-# internode_recv_buff_size_in_bytes:
-
-# Frame size for thrift (maximum message length).
-# thrift_framed_transport_size_in_mb: 15
 
 # Set to true to have Scylla create a hard link to each sstable
 # flushed or streamed locally in a backups/ subdirectory of the
@@ -595,30 +371,6 @@ commitlog_total_space_in_mb: -1
 # column_index_size_in_kb: 64
 
 
-# Number of simultaneous compactions to allow, NOT including
-# validation "compactions" for anti-entropy repair.  Simultaneous
-# compactions can help preserve read performance in a mixed read/write
-# workload, by mitigating the tendency of small sstables to accumulate
-# during a single long running compactions. The default is usually
-# fine and if you experience problems with compaction running too
-# slowly or too fast, you should look at
-# compaction_throughput_mb_per_sec first.
-#
-# concurrent_compactors defaults to the smaller of (number of disks,
-# number of cores), with a minimum of 2 and a maximum of 8.
-# 
-# If your data directories are backed by SSD, you should increase this
-# to the number of cores.
-#concurrent_compactors: 1
-
-# Throttles compaction to the given total throughput across the entire
-# system. The faster you insert data, the faster you need to compact in
-# order to keep the sstable count down, but in general, setting this to
-# 16 to 32 times the rate you are inserting data is more than sufficient.
-# Setting this to 0 disables throttling. Note that this account for all types
-# of compaction, including validation compaction.
-# compaction_throughput_mb_per_sec: 16
-
 # Log a warning when writing partitions larger than this value
 # compaction_large_partition_warning_threshold_mb: 1000
 
@@ -630,18 +382,6 @@ commitlog_total_space_in_mb: -1
 
 # Log a warning when row number is larger than this value
 # compaction_rows_count_warning_threshold: 100000
-
-# When compacting, the replacement sstable(s) can be opened before they
-# are completely written, and used in place of the prior sstables for
-# any range that has been written. This helps to smoothly transfer reads 
-# between the sstables, reducing page cache churn and keeping hot rows hot
-# sstable_preemptive_open_interval_in_mb: 50
-
-# Throttles all streaming file transfer between the datacenters,
-# this setting allows users to throttle inter dc stream throughput in addition
-# to throttling all network stream traffic as configured with
-# stream_throughput_outbound_megabits_per_sec
-# inter_dc_stream_throughput_outbound_megabits_per_sec:
 
 # How long the coordinator should wait for seq or index scans to complete
 # range_request_timeout_in_ms: 10000
@@ -656,80 +396,6 @@ commitlog_total_space_in_mb: -1
 # truncate_request_timeout_in_ms: 60000
 # The default timeout for other, miscellaneous operations
 # request_timeout_in_ms: 10000
-
-# Enable operation timeout information exchange between nodes to accurately
-# measure request timeouts.  If disabled, replicas will assume that requests
-# were forwarded to them instantly by the coordinator, which means that
-# under overload conditions we will waste that much extra time processing 
-# already-timed-out requests.
-#
-# Warning: before enabling this property make sure to ntp is installed
-# and the times are synchronized between the nodes.
-# cross_node_timeout: false
-
-# Enable socket timeout for streaming operation.
-# When a timeout occurs during streaming, streaming is retried from the start
-# of the current file. This _can_ involve re-streaming an important amount of
-# data, so you should avoid setting the value too low.
-# Default value is 0, which never timeout streams.
-# streaming_socket_timeout_in_ms: 0
-
-# controls how often to perform the more expensive part of host score
-# calculation
-# dynamic_snitch_update_interval_in_ms: 100 
-
-# controls how often to reset all host scores, allowing a bad host to
-# possibly recover
-# dynamic_snitch_reset_interval_in_ms: 600000
-
-# if set greater than zero and read_repair_chance is < 1.0, this will allow
-# 'pinning' of replicas to hosts in order to increase cache capacity.
-# The badness threshold will control how much worse the pinned host has to be
-# before the dynamic snitch will prefer other replicas over it.  This is
-# expressed as a double which represents a percentage.  Thus, a value of
-# 0.2 means Scylla would continue to prefer the static snitch values
-# until the pinned host was 20% worse than the fastest.
-# dynamic_snitch_badness_threshold: 0.1
-
-# request_scheduler -- Set this to a class that implements
-# RequestScheduler, which will schedule incoming client requests
-# according to the specific policy. This is useful for multi-tenancy
-# with a single Scylla cluster.
-# NOTE: This is specifically for requests from the client and does
-# not affect inter node communication.
-# org.apache.cassandra.scheduler.NoScheduler - No scheduling takes place
-# org.apache.cassandra.scheduler.RoundRobinScheduler - Round robin of
-# client requests to a node with a separate queue for each
-# request_scheduler_id. The scheduler is further customized by
-# request_scheduler_options as described below.
-# request_scheduler: org.apache.cassandra.scheduler.NoScheduler
-
-# Scheduler Options vary based on the type of scheduler
-# NoScheduler - Has no options
-# RoundRobin
-#  - throttle_limit -- The throttle_limit is the number of in-flight
-#                      requests per client.  Requests beyond 
-#                      that limit are queued up until
-#                      running requests can complete.
-#                      The value of 80 here is twice the number of
-#                      concurrent_reads + concurrent_writes.
-#  - default_weight -- default_weight is optional and allows for
-#                      overriding the default which is 1.
-#  - weights -- Weights are optional and will default to 1 or the
-#               overridden default_weight. The weight translates into how
-#               many requests are handled during each turn of the
-#               RoundRobin, based on the scheduler id.
-#
-# request_scheduler_options:
-#    throttle_limit: 80
-#    default_weight: 5
-#    weights:
-#      Keyspace1: 1
-#      Keyspace2: 5
-
-# request_scheduler_id -- An identifier based on which to perform
-# the request scheduling. Currently the only valid option is keyspace.
-# request_scheduler_id: keyspace
 
 # Enable or disable inter-node encryption. 
 # You must also generate keys and provide the appropriate key and trust store locations and passwords. 

--- a/database.hh
+++ b/database.hh
@@ -479,7 +479,7 @@ private:
     // sstables deleted by compaction in parallel, a race condition which could
     // easily result in failure.
     // Locking order: must be acquired either independently or after _sstables_lock
-    seastar::semaphore _sstable_deletion_sem = {1};
+    seastar::named_semaphore _sstable_deletion_sem = {1, named_semaphore_exception_factory{"sstable deletion"}};
     // There are situations in which we need to stop writing sstables. Flushers will take
     // the read lock, and the ones that wish to stop that process will take the write lock.
     rwlock _sstables_lock;
@@ -1267,7 +1267,7 @@ private:
     reader_concurrency_semaphore _streaming_concurrency_sem;
     reader_concurrency_semaphore _system_read_concurrency_sem;
 
-    semaphore _sstable_load_concurrency_sem{max_concurrent_sstable_loads()};
+    named_semaphore _sstable_load_concurrency_sem{max_concurrent_sstable_loads(), named_semaphore_exception_factory{"sstable load concurrency"}};
 
     db::timeout_semaphore _view_update_concurrency_sem{max_memory_pending_view_updates()};
 
@@ -1504,7 +1504,7 @@ public:
     std::unordered_set<sstring> get_initial_tokens();
     std::optional<gms::inet_address> get_replace_address();
     bool is_replacing();
-    semaphore& sstable_load_concurrency_sem() {
+    named_semaphore& sstable_load_concurrency_sem() {
         return _sstable_load_concurrency_sem;
     }
     void register_connection_drop_notifier(netw::messaging_service& ms);

--- a/db/config.cc
+++ b/db/config.cc
@@ -715,21 +715,20 @@ db::config::config(std::shared_ptr<db::extensions> exts)
     , alternator_address(this, "alternator_address", value_status::Used, "0.0.0.0", "Alternator API listening address")
     , alternator_enforce_authorization(this, "alternator_enforce_authorization", value_status::Used, false, "Enforce checking the authorization header for every request in Alternator")
     , abort_on_ebadf(this, "abort_on_ebadf", value_status::Used, true, "Abort the server on incorrect file descriptor access. Throws exception when disabled.")
-    , redis_transport_port(this, "redis_transport_port", value_status::Used, 6379, "Port on which the REDIS transport listens for clients.")
-    // FIXME: 9142 has been used by native_transport_port_ssl
-    , redis_transport_port_ssl(this, "redis_transport_port_ssl", value_status::Used, 9142, "Port on which the REDIS TLS native transport listens for clients.")
-    , enable_redis_protocol(this, "enable_redis_protocol", value_status::Used, false, "Enable redis protocol; Scylla will process redis protocol as a redis cluster if enable.")
-    , redis_read_consistency_level(this, "redis_read_consistency_level", value_status::Used, "ONE", "Consistency level for read operations for redis.")
-    , redis_write_consistency_level(this, "redis_write_consistency_level", value_status::Used, "ANY", "Consistency level for write operations for redis.")
-    , redis_default_database_count(this, "redis_default_database_count", value_status::Used, 16, "Default database count for the redis cluster.")
-    , redis_keyspace_options(this, "redis_keyspace_options", value_status::Used, {}, 
-            "Enable redis protocol, list of properties of replication of redis keyspace. The available options are:\n"
-            "\n"
-            "\tclass : (Default: SimpleStrategy ).\n"
-            "\treplication_factor: (Default: 1) If the class is SimpleStrategy, set the replication factor for the strategy.\n"
-            "\tdatacenter_i: (Default: 1) If the class is NetworkTopologyStrategy, set the replication factor per datacenter.\n"
-            "\n"
-            "The properties of replication for redis keyspace.")
+    , redis_port(this, "redis_port", value_status::Used, 6379, "Port on which the REDIS transport listens for clients.")
+    , redis_ssl_port(this, "redis_ssl_port", value_status::Used, 9142, "Port on which the REDIS TLS native transport listens for clients.")
+    , redis_read_consistency_level(this, "redis_read_consistency_level", value_status::Used, "LOCAL_QUORUM", "Consistency level for read operations for redis.")
+    , redis_write_consistency_level(this, "redis_write_consistency_level", value_status::Used, "LOCAL_QUORUM", "Consistency level for write operations for redis.")
+    , redis_database_count(this, "redis_database_count", value_status::Used, 16, "Database count for the redis. You can use the default settings (16).")
+    , redis_keyspace_replication_strategy_options(this, "redis_keyspace_replication_strategy", value_status::Used, {}, 
+        "Set the replication strategy for the redis keyspace. The setting is used by the first node in the boot phase when the keyspace is not exists to create keyspace for redis.\n"
+        "The replication strategy determines how many copies of the data are kept in a given data center. This setting impacts consistency, availability and request speed.\n"
+        "Two strategies are available: SimpleStrategy and NetworkTopologyStrategy.\n\n"
+        "\tclass: (Default: SimpleStrategy ). Set the replication strategy for redis keyspace.\n"
+        "\t'replication_factor':N, (Default: 'replication_factor':1) IFF the class is SimpleStrategy, assign the same replication factor to the entire cluster.\n"
+        "\t'datacenter_name':N [,...], (Default: 'dc1:1') IFF the class is NetworkTopologyStrategy, assign replication factors to each data center in a comma separated list.\n"
+        "\n"
+        "Related information: About replication strategy.")
 
     , default_log_level(this, "default_log_level", value_status::Used)
     , logger_log_level(this, "logger_log_level", value_status::Used)

--- a/db/config.hh
+++ b/db/config.hh
@@ -299,13 +299,12 @@ public:
     named_value<bool> alternator_enforce_authorization;
     named_value<bool> abort_on_ebadf;
 
-    named_value<uint16_t> redis_transport_port;
-    named_value<uint16_t> redis_transport_port_ssl;
-    named_value<bool> enable_redis_protocol;
+    named_value<uint16_t> redis_port;
+    named_value<uint16_t> redis_ssl_port;
     named_value<sstring> redis_read_consistency_level;
     named_value<sstring> redis_write_consistency_level;
-    named_value<uint16_t> redis_default_database_count;
-    named_value<string_map> redis_keyspace_options;
+    named_value<uint16_t> redis_database_count;
+    named_value<string_map> redis_keyspace_replication_strategy_options;
 
     seastar::logging_settings logging_settings(const boost::program_options::variables_map&) const;
 

--- a/db/hints/manager.hh
+++ b/db/hints/manager.hh
@@ -471,7 +471,7 @@ private:
     stats _stats;
     seastar::metrics::metric_groups _metrics;
     std::unordered_set<ep_key_type> _eps_with_pending_hints;
-    seastar::semaphore _drain_lock = {1};
+    seastar::named_semaphore _drain_lock = {1, named_semaphore_exception_factory{"drain lock"}};
 
 public:
     manager(sstring hints_directory, std::vector<sstring> hinted_dcs, int64_t max_hint_window_ms, resource_manager&res_manager, distributed<database>& db);
@@ -550,7 +550,7 @@ public:
         return _hints_dir_device_id;
     }
 
-    seastar::semaphore& drain_lock() noexcept {
+    seastar::named_semaphore& drain_lock() noexcept {
         return _drain_lock;
     }
 

--- a/db/hints/resource_manager.cc
+++ b/db/hints/resource_manager.cc
@@ -51,7 +51,7 @@ future<bool> is_mountpoint(const fs::path& path) {
     });
 }
 
-future<semaphore_units<semaphore_default_exception_factory>> resource_manager::get_send_units_for(size_t buf_size) {
+future<semaphore_units<named_semaphore::exception_factory>> resource_manager::get_send_units_for(size_t buf_size) {
     // Let's approximate the memory size the mutation is going to consume by the size of its serialized form
     size_t hint_memory_budget = std::max(_min_send_hint_budget, buf_size);
     // Allow a very big mutation to be sent out by consuming the whole shard budget

--- a/db/view/view_builder.hh
+++ b/db/view/view_builder.hh
@@ -153,7 +153,7 @@ class view_builder final : public service::migration_listener::only_view_notific
     // Ensures bookkeeping operations are serialized, meaning that while we execute
     // a build step we don't consider newly added or removed views. This simplifies
     // the algorithms. Also synchronizes an operation wrt. a call to stop().
-    seastar::semaphore _sem{1};
+    seastar::named_semaphore _sem{1, named_semaphore_exception_factory{"view builder"}};
     seastar::abort_source _as;
     future<> _started = make_ready_future<>();
     // Used to coordinate between shards the conclusion of the build process for a particular view.

--- a/db/view/view_update_generator.hh
+++ b/db/view/view_update_generator.hh
@@ -38,7 +38,7 @@ class view_update_generator {
     seastar::abort_source _as;
     future<> _started = make_ready_future<>();
     seastar::condition_variable _pending_sstables;
-    semaphore _registration_sem{registration_queue_size};
+    named_semaphore _registration_sem{registration_queue_size, named_semaphore_exception_factory{"view update generator"}};
     struct sstable_with_table {
         sstables::shared_sstable sst;
         lw_shared_ptr<table> t;

--- a/dist/common/scripts/scylla_util.py
+++ b/dist/common/scripts/scylla_util.py
@@ -167,7 +167,7 @@ class aws_instance:
         return self._type.split(".")[0]
 
     def is_supported_instance_class(self):
-        if self.instance_class() in ['i2', 'i3', 'i3en']:
+        if self.instance_class() in ['i2', 'i3', 'i3en', 'c5d', 'm5d', 'm5ad', 'r5d', 'z1d']:
             return True
         return False
 

--- a/main.cc
+++ b/main.cc
@@ -1108,9 +1108,9 @@ int main(int ac, char** av) {
             }
 
             static redis_service redis;
-            if (cfg->enable_redis_protocol()) {
+            if (cfg->redis_port()) {
                 redis.init(std::ref(proxy), std::ref(db), std::ref(auth_service), *cfg).get();
-                startlog.info("Redis server listening on port {}", cfg->redis_transport_port());
+                startlog.info("Redis server listening on port {}", cfg->redis_port());
             }
 
             if (cfg->defragment_memory_on_idle()) {
@@ -1158,7 +1158,7 @@ int main(int ac, char** av) {
             });
 
             auto stop_redis_service = defer_verbose_shutdown("redis service", [&cfg] {
-                if (cfg->enable_redis_protocol()) {
+                if (cfg->redis_port()) {
                     redis.stop().get();
                 }
             });

--- a/redis/service.cc
+++ b/redis/service.cc
@@ -67,7 +67,7 @@ future<> redis_service::listen(distributed<auth::service>& auth_service, db::con
     redis_cfg._read_consistency_level = make_consistency_level(cfg.redis_read_consistency_level());
     redis_cfg._write_consistency_level = make_consistency_level(cfg.redis_write_consistency_level());
     redis_cfg._max_request_size = memory::stats().total_memory() / 10;
-    redis_cfg._total_redis_db_count = cfg.redis_default_database_count();
+    redis_cfg._total_redis_db_count = cfg.redis_database_count();
     return gms::inet_address::lookup(addr, family, preferred).then([this, server, addr, &cfg, keepalive, ceo = std::move(ceo), redis_cfg, &auth_service] (seastar::net::inet_address ip) {
         return server->start(std::ref(service::get_storage_proxy()), std::ref(_query_processor), std::ref(auth_service), redis_cfg).then([server, &cfg, addr, ip, ceo, keepalive]() {
             auto f = make_ready_future();
@@ -76,7 +76,7 @@ future<> redis_service::listen(distributed<auth::service>& auth_service, db::con
                 std::shared_ptr<seastar::tls::credentials_builder> cred;
             };
 
-            std::vector<listen_cfg> configs({ { socket_address{ip, cfg.redis_transport_port()} }});
+            std::vector<listen_cfg> configs({ { socket_address{ip, cfg.redis_port()} }});
 
             // main should have made sure values are clean and neatish
             if (ceo.at("enabled") == "true") {
@@ -100,8 +100,8 @@ future<> redis_service::listen(distributed<auth::service>& auth_service, db::con
 
                 slogger.info("Enabling encrypted REDIS connections between client and server");
 
-                if (cfg.redis_transport_port_ssl.is_set() && cfg.redis_transport_port_ssl() != cfg.redis_transport_port()) {
-                    configs.emplace_back(listen_cfg{{ip, cfg.redis_transport_port_ssl()}, std::move(cred)});
+                if (cfg.redis_ssl_port() && cfg.redis_ssl_port() != cfg.redis_port()) {
+                    configs.emplace_back(listen_cfg{{ip, cfg.redis_ssl_port()}, std::move(cred)});
                 } else {
                     configs.back().cred = std::move(cred);
                 }
@@ -137,7 +137,7 @@ future<> redis_service::init(distributed<service::storage_proxy>& proxy, distrib
 
 future<> redis_service::stop()
 {
-    // If the `enable_redis_protocol disable, the redis_service::init is not
+    // If the redis protocol disable, the redis_service::init is not
     // invoked at all. Do nothing if `_server is null.
     if (_server) {
         return _server->stop().then([this] {

--- a/repair/repair.hh
+++ b/repair/repair.hh
@@ -175,7 +175,7 @@ public:
     size_t current_sub_ranges_nr_out = 0;
     int ranges_index = 0;
     // Only allow one stream_plan in flight
-    semaphore sp_parallelism_semaphore{1};
+    named_semaphore sp_parallelism_semaphore{1, named_semaphore_exception_factory{"repair sp parallelism"}};
     lw_shared_ptr<streaming::stream_plan> _sp_in;
     lw_shared_ptr<streaming::stream_plan> _sp_out;
     repair_stats _stats;
@@ -232,7 +232,7 @@ private:
     // Each element in the vector is the semaphore used to control the maximum
     // ranges that can be repaired in parallel. Each element will be accessed
     // by one shared.
-    std::vector<semaphore> _range_parallelism_semaphores;
+    std::vector<named_semaphore> _range_parallelism_semaphores;
     static const size_t _max_repair_memory_per_range = 32 * 1024 * 1024;
     void start(int id);
     void done(int id, bool succeeded);
@@ -249,7 +249,7 @@ public:
     std::vector<int> get_active() const;
     size_t nr_running_repair_jobs();
     void abort_all_repairs();
-    semaphore& range_parallelism_semaphore();
+    named_semaphore& range_parallelism_semaphore();
     static size_t max_repair_memory_per_range() { return _max_repair_memory_per_range; }
     future<> run(int id, std::function<future<> ()> func);
 };

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -101,10 +101,10 @@ using bind_messaging_port = bool_class<bind_messaging_port_tag>;
 
 class feature_enabled_listener : public gms::feature::listener {
     storage_service& _s;
-    seastar::semaphore& _sem;
+    seastar::named_semaphore& _sem;
     sstables::sstable_version_types _format;
 public:
-    feature_enabled_listener(storage_service& s, seastar::semaphore& sem, sstables::sstable_version_types format)
+    feature_enabled_listener(storage_service& s, seastar::named_semaphore& sem, sstables::sstable_version_types format)
         : _s(s)
         , _sem(sem)
         , _format(format)
@@ -342,7 +342,7 @@ private:
     gms::feature _nonfrozen_udts;
 
     sstables::sstable_version_types _sstables_format = sstables::sstable_version_types::ka;
-    seastar::semaphore _feature_listeners_sem = {1};
+    seastar::named_semaphore _feature_listeners_sem = {1, named_semaphore_exception_factory{"feature listeners"}};
     feature_enabled_listener _la_feature_listener;
     feature_enabled_listener _mc_feature_listener;
 public:

--- a/tests/user_function_test.cc
+++ b/tests/user_function_test.cc
@@ -605,7 +605,7 @@ SEASTAR_TEST_CASE(test_user_function_timestamp_return) {
             {serialized(db_clock::time_point(db_clock::duration(int64_t(0x12de9b1e550))))}
         });
 
-        e.execute_cql("CREATE FUNCTION my_func6(val varint) CALLED ON NULL INPUT RETURNS timestamp LANGUAGE Lua AS 'return {year = 10000, month = 2, day = 3, hour = 4, min = 5, sec = 6 }';").get();
+        e.execute_cql("CREATE FUNCTION my_func6(val varint) CALLED ON NULL INPUT RETURNS timestamp LANGUAGE Lua AS 'return {year = 10001, month = 2, day = 3, hour = 4, min = 5, sec = 6 }';").get();
         auto fut = e.execute_cql("SELECT my_func6(val) FROM my_table;");
         BOOST_REQUIRE_EXCEPTION(fut.get(), boost::gregorian::bad_year, message_equals("Year is out of valid range: 1400..9999"));
 


### PR DESCRIPTION
Rename redis_port, which the redis transport listens on for clients.

Rename redis_ssl_port, which the redis TLS transport listens on for clients.

Rename redis_database_count. Set the redis database count.

Rename redis_keyspace_replication_strategy_options.
Set the replication strategy for redis keyspace.

Remove unecessary option named .

#5335 

Signed-off-by: Peng Jian <pengjian.uestc@gmail.com>