### PR TITLE
gossip: make sleeps react to shutdown signal

### DIFF
--- a/gms/gossiper.hh
+++ b/gms/gossiper.hh
@@ -62,6 +62,7 @@
 #include <set>
 #include <seastar/core/condition-variable.hh>
 #include <seastar/core/metrics_registration.hh>
+#include <seastar/core/abort_source.hh>
 
 namespace db {
 class config;
@@ -259,7 +260,7 @@ private:
     // The value must be kept alive until completes and not change.
     future<> replicate(inet_address, application_state key, const versioned_value& value);
 public:
-    explicit gossiper(feature_service& features, db::config& cfg);
+    explicit gossiper(abort_source& as, feature_service& features, db::config& cfg);
 
     void set_last_processed_message_at();
     void set_last_processed_message_at(clk::time_point tp);
@@ -592,6 +593,7 @@ private:
 
     class msg_proc_guard;
 private:
+    abort_source& _abort_source;
     condition_variable _features_condvar;
     feature_service& _feature_service;
     db::config& _cfg;

--- a/main.cc
+++ b/main.cc
@@ -668,7 +668,7 @@ int main(int ac, char** av) {
             (void)cql_config_updater.start(std::ref(cql_config), std::ref(*cfg));
             auto stop_cql_config_updater = defer([&] { cql_config_updater.stop().get(); });
             auto& gossiper = gms::get_gossiper();
-            gossiper.start(std::ref(feature_service), std::ref(*cfg)).get();
+            gossiper.start(std::ref(stop_signal.as_sharded_abort_source()), std::ref(feature_service), std::ref(*cfg)).get();
             // #293 - do not stop anything
             //engine().at_exit([]{ return gms::get_gossiper().stop(); });
             supervisor::notify("initializing storage service");

--- a/test/boost/gossip_test.cc
+++ b/test/boost/gossip_test.cc
@@ -67,7 +67,7 @@ SEASTAR_TEST_CASE(test_boot_shutdown){
         netw::get_messaging_service().start(gms::inet_address("127.0.0.1"), 7000, false /* don't bind */).get();
         auto stop_messaging_service = defer([&] { netw::get_messaging_service().stop().get(); });
 
-        gms::get_gossiper().start(std::ref(feature_service), std::ref(cfg)).get();
+        gms::get_gossiper().start(std::ref(abort_sources), std::ref(feature_service), std::ref(cfg)).get();
         auto stop_gossiper = defer([&] { gms::get_gossiper().stop().get(); });
 
         service::storage_service_config sscfg;

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -85,7 +85,8 @@ future<> await_background_jobs_on_all_shards();
 
 static const sstring testing_superuser = "tester";
 
-static future<> tst_init_ms_fd_gossiper(sharded<gms::feature_service>& features, db::config& cfg, db::seed_provider_type seed_provider, sstring cluster_name = "Test Cluster") {
+static future<> tst_init_ms_fd_gossiper(sharded<gms::feature_service>& features, db::config& cfg, db::seed_provider_type seed_provider,
+            sharded<abort_source>& abort_sources, sstring cluster_name = "Test Cluster") {
         // Init gossiper
         std::set<gms::inet_address> seeds;
         if (seed_provider.parameters.count("seeds") > 0) {
@@ -100,7 +101,7 @@ static future<> tst_init_ms_fd_gossiper(sharded<gms::feature_service>& features,
         if (seeds.empty()) {
             seeds.emplace(gms::inet_address("127.0.0.1"));
         }
-        return gms::get_gossiper().start(std::ref(features), std::ref(cfg)).then([seeds, cluster_name] {
+        return gms::get_gossiper().start(std::ref(abort_sources), std::ref(features), std::ref(cfg)).then([seeds, cluster_name] {
             auto& gossiper = gms::get_local_gossiper();
             gossiper.set_seeds(seeds);
             gossiper.set_cluster_name(cluster_name);
@@ -391,7 +392,7 @@ public:
             auto stop_feature_service = defer([&] { feature_service->stop().get(); });
 
             // FIXME: split
-            tst_init_ms_fd_gossiper(*feature_service, *cfg, db::config::seed_provider_type()).get();
+            tst_init_ms_fd_gossiper(*feature_service, *cfg, db::config::seed_provider_type(), abort_sources).get();
 
             distributed<service::storage_proxy>& proxy = service::get_storage_proxy();
             distributed<service::migration_manager>& mm = service::get_migration_manager();

--- a/test/lib/test_services.cc
+++ b/test/lib/test_services.cc
@@ -52,7 +52,7 @@ public:
         utils::fb_utilities::set_broadcast_rpc_address(gms::inet_address("localhost"));
         _abort_source.start().get();
         _feature_service.start().get();
-        _gossiper.start(std::ref(_feature_service), std::ref(_cfg)).get();
+        _gossiper.start(std::ref(_abort_source), std::ref(_feature_service), std::ref(_cfg)).get();
         netw::get_messaging_service().start(gms::inet_address("127.0.0.1"), 7000, false).get();
         service::storage_service_config sscfg;
         sscfg.available_memory = memory::stats().total_memory();

--- a/test/manual/gossip.cc
+++ b/test/manual/gossip.cc
@@ -92,7 +92,7 @@ int main(int ac, char ** av) {
             auto port = server.port();
             auto listen = server.listen_address();
             fmt::print("Messaging server listening on ip {} port {:d} ...\n", listen, port);
-            gms::get_gossiper().start(std::ref(feature_service), std::ref(cfg)).get();
+            gms::get_gossiper().start(std::ref(abort_sources), std::ref(feature_service), std::ref(cfg)).get();
             std::set<gms::inet_address> seeds;
             for (auto s : config["seed"].as<std::vector<std::string>>()) {
                 seeds.emplace(std::move(s));


### PR DESCRIPTION
This change makes most sleeps in gossip.cc abortable. It is now possible to quickly shut down a node during startup, most notably during the phase while it waits for gossip to settle.

Fixes #3749.

Tests: unit(dev)