### PR TITLE
CDC: handle schema changes

### DIFF
--- a/cdc/cdc.cc
+++ b/cdc/cdc.cc
@@ -64,6 +64,24 @@ using namespace std::chrono_literals;
 
 static logging::logger cdc_log("cdc");
 
+class cdc::cdc_service::impl {
+    db_context _ctxt;
+public:
+    impl(db_context ctxt)
+        : _ctxt(std::move(ctxt))
+    {}
+};
+
+cdc::cdc_service::cdc_service(service::storage_proxy& proxy)
+    : cdc_service(db_context::builder(proxy).build())
+{}
+
+cdc::cdc_service::cdc_service(db_context ctxt)
+    : _impl(std::make_unique<impl>(std::move(ctxt)))
+{}
+
+cdc::cdc_service::~cdc_service() = default;
+
 cdc::options::options(const std::map<sstring, sstring>& map) {
     if (map.find("enabled") == std::end(map)) {
         throw exceptions::configuration_exception("Missing enabled CDC option");

--- a/cdc/cdc.cc
+++ b/cdc/cdc.cc
@@ -35,6 +35,7 @@
 #include "schema.hh"
 #include "schema_builder.hh"
 #include "service/migration_manager.hh"
+#include "service/migration_listener.hh"
 #include "service/storage_service.hh"
 #include "types/tuple.hh"
 #include "cql3/statements/select_statement.hh"
@@ -64,12 +65,119 @@ using namespace std::chrono_literals;
 
 static logging::logger cdc_log("cdc");
 
-class cdc::cdc_service::impl {
+namespace cdc {
+static schema_ptr create_log_schema(const schema&, std::optional<utils::UUID> = {});
+static schema_ptr create_stream_description_table_schema(const schema&, std::optional<utils::UUID> = {});
+static future<> populate_desc(db_context ctx, const schema& s);
+}
+
+class cdc::cdc_service::impl : service::migration_listener::empty_listener {
     db_context _ctxt;
 public:
     impl(db_context ctxt)
         : _ctxt(std::move(ctxt))
-    {}
+    {
+        if (engine().cpu_id() == 0) {
+            _ctxt._migration_manager.register_listener(this);
+        }
+    }
+    ~impl() {
+        if (engine().cpu_id() == 0) {
+            _ctxt._migration_manager.unregister_listener(this);
+        }
+    }
+
+    void on_before_create_column_family(const schema& schema, std::vector<mutation>& mutations, api::timestamp_type timestamp) override {
+        if (schema.cdc_options().enabled()) {
+            auto& db = _ctxt._proxy.get_db().local();
+            auto logname = log_name(schema.cf_name());
+            if (!db.has_schema(schema.ks_name(), logname)) {
+                // in seastar thread
+                auto log_schema = create_log_schema(schema);
+                auto stream_desc_schema = create_stream_description_table_schema(schema);
+                auto& keyspace = db.find_keyspace(schema.ks_name());
+
+                auto log_mut = db::schema_tables::make_create_table_mutations(keyspace.metadata(), log_schema, timestamp);
+                auto stream_mut = db::schema_tables::make_create_table_mutations(keyspace.metadata(), stream_desc_schema, timestamp);
+
+                mutations.insert(mutations.end(), std::make_move_iterator(log_mut.begin()), std::make_move_iterator(log_mut.end()));
+                mutations.insert(mutations.end(), std::make_move_iterator(stream_mut.begin()), std::make_move_iterator(stream_mut.end()));
+            }
+        }
+    }
+
+    void on_before_update_column_family(const schema& new_schema, const schema& old_schema, std::vector<mutation>& mutations, api::timestamp_type timestamp) override {
+        bool is_cdc = new_schema.cdc_options().enabled();
+        bool was_cdc = old_schema.cdc_options().enabled();
+
+        // we need to create or modify the log & stream schemas iff either we changed cdc status (was != is)
+        // or if cdc is on now unconditionally, since then any actual base schema changes will affect the column 
+        // etc.
+        if (was_cdc || is_cdc) {
+            auto logname = log_name(old_schema.cf_name());
+            auto descname = desc_name(old_schema.cf_name());
+            auto& db = _ctxt._proxy.get_db().local();
+            auto& keyspace = db.find_keyspace(old_schema.ks_name());
+            auto log_schema = was_cdc ? db.find_column_family(old_schema.ks_name(), logname).schema() : nullptr;
+            auto stream_desc_schema = was_cdc ? db.find_column_family(old_schema.ks_name(), descname).schema() : nullptr;
+
+            if (!is_cdc) {
+                auto log_mut = db::schema_tables::make_drop_table_mutations(keyspace.metadata(), log_schema, timestamp);
+                auto stream_mut = db::schema_tables::make_drop_table_mutations(keyspace.metadata(), stream_desc_schema, timestamp);
+
+                mutations.insert(mutations.end(), std::make_move_iterator(log_mut.begin()), std::make_move_iterator(log_mut.end()));
+                mutations.insert(mutations.end(), std::make_move_iterator(stream_mut.begin()), std::make_move_iterator(stream_mut.end()));
+                return;
+            }
+
+            auto new_log_schema = create_log_schema(new_schema, log_schema ? std::make_optional(log_schema->id()) : std::nullopt);
+            auto new_stream_desc_schema = create_stream_description_table_schema(new_schema, stream_desc_schema ? std::make_optional(stream_desc_schema->id()) : std::nullopt);
+
+            auto log_mut = log_schema 
+                ? db::schema_tables::make_update_table_mutations(keyspace.metadata(), log_schema, new_log_schema, timestamp, false)
+                : db::schema_tables::make_create_table_mutations(keyspace.metadata(), new_log_schema, timestamp)
+                ;
+            auto stream_mut = stream_desc_schema 
+                ? db::schema_tables::make_update_table_mutations(keyspace.metadata(), stream_desc_schema, new_stream_desc_schema, timestamp, false)
+                : db::schema_tables::make_create_table_mutations(keyspace.metadata(), new_stream_desc_schema, timestamp)
+                ;
+
+            mutations.insert(mutations.end(), std::make_move_iterator(log_mut.begin()), std::make_move_iterator(log_mut.end()));
+            mutations.insert(mutations.end(), std::make_move_iterator(stream_mut.begin()), std::make_move_iterator(stream_mut.end()));
+        }
+    }
+
+    void on_before_drop_column_family(const schema& schema, std::vector<mutation>& mutations, api::timestamp_type timestamp) override {
+        if (schema.cdc_options().enabled()) {
+            auto logname = log_name(schema.cf_name());
+            auto descname = desc_name(schema.cf_name());
+            auto& db = _ctxt._proxy.get_db().local();
+            auto& keyspace = db.find_keyspace(schema.ks_name());
+            auto log_schema = db.find_column_family(schema.ks_name(), logname).schema();
+            auto stream_desc_schema = db.find_column_family(schema.ks_name(), descname).schema();
+
+            auto log_mut = db::schema_tables::make_drop_table_mutations(keyspace.metadata(), log_schema, timestamp);
+            auto stream_mut = db::schema_tables::make_drop_table_mutations(keyspace.metadata(), stream_desc_schema, timestamp);
+
+            mutations.insert(mutations.end(), std::make_move_iterator(log_mut.begin()), std::make_move_iterator(log_mut.end()));
+            mutations.insert(mutations.end(), std::make_move_iterator(stream_mut.begin()), std::make_move_iterator(stream_mut.end()));
+        }
+    }
+
+    void on_create_column_family(const sstring& ks_name, const sstring& cf_name) override {
+        auto& db = _ctxt._proxy.get_db().local();
+        auto& cf = db.find_column_family(ks_name, cf_name);
+        auto schema = cf.schema();
+        if (schema->cdc_options().enabled()) {
+            populate_desc(_ctxt, *schema).get();
+        }
+    }
+
+    void on_update_column_family(const sstring& ks_name, const sstring& cf_name, bool columns_changed) override {
+        on_create_column_family(ks_name, cf_name);
+    }
+
+    void on_drop_column_family(const sstring& ks_name, const sstring& cf_name) override {}
 };
 
 cdc::cdc_service::cdc_service(service::storage_proxy& proxy)
@@ -137,39 +245,7 @@ sstring desc_name(const sstring& table_name) {
     return table_name + cdc_desc_suffix;
 }
 
-static future<>
-remove_log(db_context ctx, const sstring& ks_name, const sstring& table_name) {
-    try {
-        return ctx._migration_manager.announce_column_family_drop(
-                ks_name, log_name(table_name), false);
-    } catch (exceptions::configuration_exception& e) {
-        // It's fine if the table does not exist.
-        return make_ready_future<>();
-    } catch (...) {
-        return make_exception_future<>(std::current_exception());
-    }
-}
-
-static future<>
-remove_desc(db_context ctx, const sstring& ks_name, const sstring& table_name) {
-    try {
-        return ctx._migration_manager.announce_column_family_drop(
-                ks_name, desc_name(table_name), false);
-    } catch (exceptions::configuration_exception& e) {
-        // It's fine if the table does not exist.
-        return make_ready_future<>();
-    } catch (...) {
-        return make_exception_future<>(std::current_exception());
-    }
-}
-
-future<>
-remove(db_context ctx, const sstring& ks_name, const sstring& table_name) {
-    return when_all(remove_log(ctx, ks_name, table_name),
-                    remove_desc(ctx, ks_name, table_name)).discard_result();
-}
-
-static future<> setup_log(db_context ctx, const schema& s) {
+static schema_ptr create_log_schema(const schema& s, std::optional<utils::UUID> uuid) {
     schema_builder b(s.ks_name(), log_name(s.cf_name()));
     b.set_default_time_to_live(gc_clock::duration{s.cdc_options().ttl()});
     b.set_comment(sprint("CDC log for %s.%s", s.ks_name(), s.cf_name()));
@@ -191,17 +267,27 @@ static future<> setup_log(db_context ctx, const schema& s) {
     add_columns(s.clustering_key_columns());
     add_columns(s.static_columns(), true);
     add_columns(s.regular_columns(), true);
-    return ctx._migration_manager.announce_new_column_family(b.build(), false);
+
+    if (uuid) {
+        b.set_uuid(*uuid);
+    }
+    
+    return b.build();
 }
 
-static future<> setup_stream_description_table(db_context ctx, const schema& s) {
+static schema_ptr create_stream_description_table_schema(const schema& s, std::optional<utils::UUID> uuid) {
     schema_builder b(s.ks_name(), desc_name(s.cf_name()));
     b.set_comment(sprint("CDC description for %s.%s", s.ks_name(), s.cf_name()));
     b.with_column("node_ip", inet_addr_type, column_kind::partition_key);
     b.with_column("shard_id", int32_type, column_kind::partition_key);
     b.with_column("created_at", timestamp_type, column_kind::clustering_key);
     b.with_column("stream_id", uuid_type);
-    return ctx._migration_manager.announce_new_column_family(b.build(), false);
+
+    if (uuid) {
+        b.set_uuid(*uuid);
+    }
+
+    return b.build();
 }
 
 // This function assumes setup_stream_description_table was called on |s| before the call to this
@@ -259,18 +345,6 @@ static future<> populate_desc(db_context ctx, const schema& s) {
                              db::no_timeout,
                              nullptr,
                              empty_service_permit());
-}
-
-future<> setup(db_context ctx, schema_ptr s) {
-    return seastar::async([ctx = std::move(ctx), s = std::move(s)] {
-        setup_log(ctx, *s).get();
-        auto log_guard = seastar::defer([&] { remove_log(ctx, s->ks_name(), s->cf_name()).get(); });
-        setup_stream_description_table(ctx, *s).get();
-        auto desc_guard = seastar::defer([&] { remove_desc(ctx, s->ks_name(), s->cf_name()).get(); });
-        populate_desc(ctx, *s).get();
-        desc_guard.cancel();
-        log_guard.cancel();
-    });
 }
 
 db_context::builder::builder(service::storage_proxy& proxy) 

--- a/cdc/cdc.hh
+++ b/cdc/cdc.hh
@@ -34,6 +34,7 @@
 
 #include "exceptions/exceptions.hh"
 #include "timestamp.hh"
+#include "cdc_options.hh"
 
 class schema;
 using schema_ptr = seastar::lw_shared_ptr<const schema>;
@@ -63,27 +64,6 @@ class mutation;
 class partition_key;
 
 namespace cdc {
-
-class options final {
-    bool _enabled = false;
-    bool _preimage = false;
-    bool _postimage = false;
-    int _ttl = 86400; // 24h in seconds
-public:
-    options() = default;
-    options(const std::map<sstring, sstring>& map);
-
-    std::map<sstring, sstring> to_map() const;
-    sstring to_sstring() const;
-
-    bool enabled() const { return _enabled; }
-    bool preimage() const { return _preimage; }
-    bool postimage() const { return _postimage; }
-    int ttl() const { return _ttl; }
-
-    bool operator==(const options& o) const;
-    bool operator!=(const options& o) const;
-};
 
 struct db_context final {
     service::storage_proxy& _proxy;

--- a/cdc/cdc.hh
+++ b/cdc/cdc.hh
@@ -33,7 +33,6 @@
 #include <seastar/core/sstring.hh>
 
 #include "exceptions/exceptions.hh"
-#include "json.hh"
 #include "timestamp.hh"
 
 class schema;
@@ -72,49 +71,18 @@ class options final {
     int _ttl = 86400; // 24h in seconds
 public:
     options() = default;
-    options(const std::map<sstring, sstring>& map) {
-        if (map.find("enabled") == std::end(map)) {
-            throw exceptions::configuration_exception("Missing enabled CDC option");
-        }
+    options(const std::map<sstring, sstring>& map);
 
-        for (auto& p : map) {
-            if (p.first == "enabled") {
-                _enabled = p.second == "true";
-            } else if (p.first == "preimage") {
-                _preimage = p.second == "true";
-            } else if (p.first == "postimage") {
-                _postimage = p.second == "true";
-            } else if (p.first == "ttl") {
-                _ttl = std::stoi(p.second);
-            } else {
-                throw exceptions::configuration_exception("Invalid CDC option: " + p.first);
-            }
-        }
-    }
-    std::map<sstring, sstring> to_map() const {
-        return {
-            { "enabled", _enabled ? "true" : "false" },
-            { "preimage", _preimage ? "true" : "false" },
-            { "postimage", _postimage ? "true" : "false" },
-            { "ttl", std::to_string(_ttl) },
-        };
-    }
-
-    sstring to_sstring() const {
-        return json::to_json(to_map());
-    }
+    std::map<sstring, sstring> to_map() const;
+    sstring to_sstring() const;
 
     bool enabled() const { return _enabled; }
     bool preimage() const { return _preimage; }
     bool postimage() const { return _postimage; }
     int ttl() const { return _ttl; }
 
-    bool operator==(const options& o) const {
-        return _enabled == o._enabled && _preimage == o._preimage && _postimage == o._postimage && _ttl == o._ttl;
-    }
-    bool operator!=(const options& o) const {
-        return !(*this == o);
-    }
+    bool operator==(const options& o) const;
+    bool operator!=(const options& o) const;
 };
 
 struct db_context final {
@@ -131,27 +99,12 @@ struct db_context final {
         std::optional<std::reference_wrapper<locator::snitch_ptr>> _snitch;
         std::optional<std::reference_wrapper<dht::i_partitioner>> _partitioner;
     public:
-        builder(service::storage_proxy& proxy) : _proxy(proxy) { }
+        builder(service::storage_proxy& proxy);
 
-        builder& with_migration_manager(service::migration_manager& migration_manager) {
-            _migration_manager = migration_manager;
-            return *this;
-        }
-
-        builder& with_token_metadata(locator::token_metadata& token_metadata) {
-            _token_metadata = token_metadata;
-            return *this;
-        }
-
-        builder& with_snitch(locator::snitch_ptr& snitch) {
-            _snitch = snitch;
-            return *this;
-        }
-
-        builder& with_partitioner(dht::i_partitioner& partitioner) {
-            _partitioner = partitioner;
-            return *this;
-        }
+        builder& with_migration_manager(service::migration_manager& migration_manager);
+        builder& with_token_metadata(locator::token_metadata& token_metadata);
+        builder& with_snitch(locator::snitch_ptr& snitch);
+        builder& with_partitioner(dht::i_partitioner& partitioner);
 
         db_context build();
     };

--- a/cdc/cdc.hh
+++ b/cdc/cdc.hh
@@ -65,6 +65,17 @@ class partition_key;
 
 namespace cdc {
 
+class db_context;
+
+class cdc_service {
+    class impl;
+    std::unique_ptr<impl> _impl;
+public:
+    cdc_service(service::storage_proxy&);
+    cdc_service(db_context);
+    ~cdc_service();
+};
+
 struct db_context final {
     service::storage_proxy& _proxy;
     service::migration_manager& _migration_manager;

--- a/cdc/cdc.hh
+++ b/cdc/cdc.hh
@@ -67,6 +67,11 @@ namespace cdc {
 
 class db_context;
 
+/// \brief CDC service, responsible for schema listeners
+///
+/// CDC service will listen for schema changes and iff CDC is enabled/changed
+/// create/modify/delete corresponding log tables etc as part of the schema change. 
+///
 class cdc_service {
     class impl;
     std::unique_ptr<impl> _impl;
@@ -101,15 +106,6 @@ struct db_context final {
     };
 };
 
-/// \brief Sets up CDC related tables for a given table
-///
-/// This function not only creates CDC Log and CDC Description for a given table
-/// but also populates CDC Description with a list of change streams.
-///
-/// param[in] ctx object with references to database components
-/// param[in] schema schema of a table for which CDC tables are being created
-seastar::future<> setup(db_context ctx, schema_ptr schema);
-
 // cdc log table operation
 enum class operation : int8_t {
     // note: these values will eventually be read by a third party, probably not privvy to this
@@ -122,21 +118,6 @@ enum class column_op : int8_t {
     // same as "operation". Do not edit values or type/type unless you _really_ want to.
     set = 0, del = 1, add = 2,
 };
-
-/// \brief Deletes CDC Log and CDC Description tables for a given table
-///
-/// This function cleans up all CDC related tables created for a given table.
-/// At the moment, CDC Log and CDC Description are the only affected tables.
-/// It's ok if some/all of them don't exist.
-///
-/// \param[in] ctx object with references to database components
-/// \param[in] ks_name keyspace name of a table for which CDC tables are removed
-/// \param[in] table_name name of a table for which CDC tables are removed
-///
-/// \pre This function works correctly no matter if CDC Log and/or CDC Description
-///      exist.
-seastar::future<>
-remove(db_context ctx, const seastar::sstring& ks_name, const seastar::sstring& table_name);
 
 seastar::sstring log_name(const seastar::sstring& table_name);
 

--- a/cdc/cdc_options.hh
+++ b/cdc/cdc_options.hh
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2019 ScyllaDB
+ */
+
+/*
+ * This file is part of Scylla.
+ *
+ * Scylla is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Scylla is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <map>
+#include <seastar/core/sstring.hh>
+#include "seastarx.hh"
+
+namespace cdc {
+
+class options final {
+    bool _enabled = false;
+    bool _preimage = false;
+    bool _postimage = false;
+    int _ttl = 86400; // 24h in seconds
+public:
+    options() = default;
+    options(const std::map<sstring, sstring>& map);
+
+    std::map<sstring, sstring> to_map() const;
+    sstring to_sstring() const;
+
+    bool enabled() const { return _enabled; }
+    bool preimage() const { return _preimage; }
+    bool postimage() const { return _postimage; }
+    int ttl() const { return _ttl; }
+
+    bool operator==(const options& o) const;
+    bool operator!=(const options& o) const;
+};
+
+} // namespace cdc

--- a/cql3/statements/create_table_statement.cc
+++ b/cql3/statements/create_table_statement.cc
@@ -51,7 +51,6 @@
 
 #include "auth/resource.hh"
 #include "auth/service.hh"
-#include "cdc/cdc.hh"
 #include "schema_builder.hh"
 #include "service/storage_service.hh"
 #include "db/extensions.hh"
@@ -98,52 +97,26 @@ std::vector<column_definition> create_table_statement::get_columns() const
     return column_defs;
 }
 
-template <typename CreateTable>
-future<shared_ptr<cql_transport::event::schema_change>>
-create_table_statement::create_table_with_cdc(service::storage_proxy& proxy,
-                                              schema_ptr schema,
-                                              CreateTable&& create_table) const {
-    if (_if_not_exists) {
-        throw exceptions::invalid_request_exception(
-                "Can't create table with CDC support using IF NOT EXISTS");
-    }
-    cdc::db_context ctx = cdc::db_context::builder(proxy).build();
-    return cdc::setup(ctx, schema).then([ctx, create_table = std::move(create_table), schema = std::move(schema)] () mutable{
-        return create_table().handle_exception([ctx, schema = std::move(schema)](std::exception_ptr ep) mutable {
-            return cdc::remove(ctx, schema->ks_name(), schema->cf_name()).then([ep = std::move(ep)] () -> shared_ptr<cql_transport::event::schema_change> {
-                std::rethrow_exception(ep);
-            });
-        });
-    });
-}
-
 future<shared_ptr<cql_transport::event::schema_change>> create_table_statement::announce_migration(service::storage_proxy& proxy, bool is_local_only) const {
     auto schema = get_cf_meta_data(proxy.get_db().local());
-    auto create_table = [this, is_local_only, schema] () mutable {
-        return make_ready_future<>().then([this, is_local_only, schema = std::move(schema)] {
-            return service::get_local_migration_manager().announce_new_column_family(std::move(schema), is_local_only);
-        }).then_wrapped([this] (auto&& f) {
-            try {
-                f.get();
-                using namespace cql_transport;
-                return make_shared<event::schema_change>(
-                        event::schema_change::change_type::CREATED,
-                        event::schema_change::target_type::TABLE,
-                        this->keyspace(),
-                        this->column_family());
-            } catch (const exceptions::already_exists_exception& e) {
-                if (_if_not_exists) {
-                    return ::shared_ptr<cql_transport::event::schema_change>();
-                }
-                throw e;
+    return make_ready_future<>().then([this, is_local_only, schema = std::move(schema)] {
+        return service::get_local_migration_manager().announce_new_column_family(std::move(schema), is_local_only);
+    }).then_wrapped([this] (auto&& f) {
+        try {
+            f.get();
+            using namespace cql_transport;
+            return make_shared<event::schema_change>(
+                    event::schema_change::change_type::CREATED,
+                    event::schema_change::target_type::TABLE,
+                    this->keyspace(),
+                    this->column_family());
+        } catch (const exceptions::already_exists_exception& e) {
+            if (_if_not_exists) {
+                return ::shared_ptr<cql_transport::event::schema_change>();
             }
-        });
-    };
-    bool cdc_enabled = _properties->get_cdc_options() && cdc::options(*_properties->get_cdc_options()).enabled();
-    return cdc_enabled
-            ? create_table_with_cdc(
-                    proxy, std::move(schema), std::move(create_table))
-            : create_table();
+            throw e;
+        }
+    });
 }
 
 /**

--- a/cql3/statements/create_table_statement.hh
+++ b/cql3/statements/create_table_statement.hh
@@ -119,11 +119,6 @@ private:
     void apply_properties_to(schema_builder& builder, const database&) const;
 
     void add_column_metadata_from_aliases(schema_builder& builder, std::vector<bytes> aliases, const std::vector<data_type>& types, column_kind kind) const;
-
-    template <typename CreateTable>
-    future<shared_ptr<cql_transport::event::schema_change>> create_table_with_cdc(service::storage_proxy& proxy,
-                                                                                  schema_ptr,
-                                                                                  CreateTable&&) const;
 };
 
 class create_table_statement::raw_statement : public raw::cf_statement {

--- a/cql3/statements/drop_table_statement.cc
+++ b/cql3/statements/drop_table_statement.cc
@@ -39,12 +39,8 @@
  * along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "cdc/cdc.hh"
-
 #include "cql3/statements/drop_table_statement.hh"
 #include "cql3/statements/prepared_statement.hh"
-
-#include "database.hh"
 
 #include "service/migration_manager.hh"
 
@@ -80,20 +76,18 @@ future<shared_ptr<cql_transport::event::schema_change>> drop_table_statement::an
 {
     return make_ready_future<>().then([this, is_local_only] {
         return service::get_local_migration_manager().announce_column_family_drop(keyspace(), column_family(), is_local_only);
-    }).then_wrapped([this, &proxy] (auto&& f) {
+    }).then_wrapped([this] (auto&& f) {
         try {
             f.get();
             using namespace cql_transport;
-            return cdc::remove(cdc::db_context::builder(proxy).build(), keyspace(), column_family()).then([this] {
-                return make_shared<event::schema_change>(
-                        event::schema_change::change_type::DROPPED,
-                        event::schema_change::target_type::TABLE,
-                        this->keyspace(),
-                        this->column_family());
-            });
+            return make_shared<event::schema_change>(
+                    event::schema_change::change_type::DROPPED,
+                    event::schema_change::target_type::TABLE,
+                    this->keyspace(),
+                    this->column_family());
         } catch (const exceptions::configuration_exception& e) {
             if (_if_exists) {
-                return make_ready_future<::shared_ptr<cql_transport::event::schema_change>>(::shared_ptr<cql_transport::event::schema_change>());
+                return ::shared_ptr<cql_transport::event::schema_change>();
             }
             throw e;
         }

--- a/main.cc
+++ b/main.cc
@@ -71,6 +71,7 @@
 
 #include "alternator/server.hh"
 #include "redis/service.hh"
+#include "cdc/cdc.hh"
 
 namespace fs = std::filesystem;
 
@@ -890,6 +891,12 @@ int main(int ac, char** av) {
             supervisor::notify("loading system sstables");
 
             distributed_loader::ensure_system_table_directories(db).get();
+
+            static sharded<cdc::cdc_service> cdc;
+            cdc.start(std::ref(proxy)).get();
+            auto stop_cdc_service = defer_verbose_shutdown("cdc", [] {
+                cdc.stop().get();
+            });
 
             supervisor::notify("loading non-system sstables");
             distributed_loader::init_non_system_keyspaces(db, proxy).get();

--- a/schema.hh
+++ b/schema.hh
@@ -41,7 +41,7 @@
 #include "compaction_strategy.hh"
 #include "caching_options.hh"
 #include "column_computation.hh"
-#include "cdc/cdc.hh"
+#include "cdc/cdc_options.hh"
 
 using column_count_type = uint32_t;
 

--- a/tests/cql_test_env.cc
+++ b/tests/cql_test_env.cc
@@ -460,6 +460,13 @@ public:
                 return ks.make_directory_for_column_family(cfm->cf_name(), cfm->id());
             }).get();
             distributed_loader::init_non_system_keyspaces(*db, proxy).get();
+
+            sharded<cdc::cdc_service> cdc;
+            cdc.start(std::ref(proxy)).get();
+            auto stop_cdc_service = defer([&] {
+                cdc.stop().get();
+            });
+
             // In main.cc we call db::system_keyspace::setup which calls
             // minimal_setup and init_local_cache
             db::system_keyspace::minimal_setup(*db, qp);


### PR DESCRIPTION
Moves schema creation/alter/drop awareness to use new "before" callbacks from migration manager, and adds/modifies log and streams table as part of the base table modification. 

Makes schema changes semi-atomic per node. While this does not deal with updates coming in before a schema change has propagated cluster, it now falls into the same pit as when this happens without CDC. 

Added side effect is also that now schemas are transparent across all subsystems, not just cql. 

v2:
Pushed new version addressing the mis-squash for cdc.hh
v3:
Rebased on master
v4:
Added two asserts.
v5:
removed "use namespace seastar" and added include "seastarx.h"
v6: 
removed asserts again (gah), and simplified condition in favour of comment