### PR TITLE
fix scylla setup of processing default scylla directories

### DIFF
--- a/dist/common/scripts/scylla_blocktune.py
+++ b/dist/common/scripts/scylla_blocktune.py
@@ -23,6 +23,8 @@
 
 import os
 
+from scylla_util import parse_scylla_dirs_with_default
+
 
 # try to write data to a sysfs path, expect problems
 def try_write(path, data):
@@ -93,8 +95,7 @@ def tune_fs(path, nomerges):
 
 # tunes all filesystems referenced from a scylla.yaml
 def tune_yaml(path, nomerges):
-    import yaml
-    y = yaml.safe_load(open(path))
+    y = parse_scylla_dirs_with_default(conf=path)
     for fs in y['data_file_directories']:
         tune_fs(fs, nomerges)
     tune_fs(y['commitlog_directory'], nomerges)

--- a/dist/common/scripts/scylla_fstrim
+++ b/dist/common/scripts/scylla_fstrim
@@ -26,6 +26,9 @@ import yaml
 import argparse
 import subprocess
 
+from scylla_util import parse_scylla_dirs_with_default
+
+
 def find_mount_point(path):
     path = os.path.abspath(path)
     while not os.path.ismount(path):
@@ -38,8 +41,7 @@ def main():
                         default='/etc/scylla/scylla.yaml',
                         help='path to scylla.yaml')
     args = parser.parse_args()
-    s = open(args.config).read()
-    cfg = yaml.safe_load(s)
+    cfg = parse_scylla_dirs_with_default(conf=args.config)
     mountpoints = set()
     for d in cfg['data_file_directories']:
         mountpoints.add(find_mount_point(d))

--- a/dist/common/scripts/scylla_io_setup
+++ b/dist/common/scripts/scylla_io_setup
@@ -101,8 +101,8 @@ if __name__ == "__main__":
                 key = "%s_directory" % t
                 if key in cfg:
                     data_dirs += [ cfg[key] ]
-                elif os.path.isdir(default_path + key):
-                    data_dirs += [ default_path + key ]
+                elif os.path.isdir(os.path.join(default_path, t)):
+                    data_dirs += [ os.path.join(default_path, t) ]
 
             iotune_args = []
             for data_dir in data_dirs:

--- a/dist/common/scripts/scylla_io_setup
+++ b/dist/common/scripts/scylla_io_setup
@@ -91,12 +91,11 @@ if __name__ == "__main__":
             else:
                 conf_dir = etcdir() + "/scylla"
             cfg = yaml.safe_load(open(os.path.join(conf_dir, "scylla.yaml")))
+            default_path = cfg.get('workdir') or datadir()
             if not "data_file_directories" in cfg:
-                logging.error("No data directories found. Please check the configuration and run scylla_io_setup again.\n")
-                sys.exit(1)
+                cfg["data_file_directories"] = [os.path.join(default_path, 'data')]
             data_dirs = cfg["data_file_directories"]
 
-            default_path = datadir()
             for t in [ "commitlog", "hints", "view_hints", "saved_caches" ]:
                 key = "%s_directory" % t
                 if key in cfg:

--- a/dist/common/scripts/scylla_util.py
+++ b/dist/common/scripts/scylla_util.py
@@ -462,6 +462,22 @@ def get_mode_cpuset(nic, mode):
         return '-1'
 
 
+def parse_scylla_dirs_with_default(conf='/etc/scylla/scylla.yaml'):
+    y = yaml.safe_load(open(conf))
+    if 'workdir' not in y or not y['workdir']:
+        y['workdir'] = datadir()
+    if 'data_file_directories' not in y or \
+            not y['data_file_directories'] or \
+            not len(y['data_file_directories']) or \
+            not " ".join(y['data_file_directories']).strip():
+        y['data_file_directories'] = [os.path.join(y['workdir'], 'data')]
+    for t in [ "commitlog", "hints", "view_hints", "saved_caches" ]:
+        key = "%s_directory" % t
+        if key not in y or not y[k]:
+            y[k] = os.path.join(y['workdir'], t)
+    return y
+
+
 def get_scylla_dirs():
     """
     Returns a list of scylla directories configured in /etc/scylla/scylla.yaml.

--- a/dist/common/scripts/scylla_util.py
+++ b/dist/common/scripts/scylla_util.py
@@ -472,7 +472,7 @@ def get_scylla_dirs():
 
     # Check that mandatory fields are set
     if 'workdir' not in y or not y['workdir']:
-        y['workdir'] = '/var/lib/scylla'
+        y['workdir'] = datadir()
     if 'data_file_directories' not in y or \
             not y['data_file_directories'] or \
             not len(y['data_file_directories']) or \


### PR DESCRIPTION
Fixed two problem in scylla_io_setup
- Problem 1: paths of default directories is invalid, introduced by commit 5ec191536e  /CC @bhalevy 
- Problem 2: wrong path join, introduced by commit 31ddb2145a /CC @syuu1228 

scylla_io_setup, scylla_fstrim and scylla_blocktune.py:
- Fixed default scylla directories when they aren't assigned in scylla.yaml 
