### PR TITLE
RFC: Add `experimental_features` option

### DIFF
--- a/conf/scylla.yaml
+++ b/conf/scylla.yaml
@@ -245,7 +245,10 @@ batch_size_fail_threshold_in_kb: 50
 # broadcast_rpc_address: 1.2.3.4
 
 # Uncomment to enable experimental features
-# experimental: true
+# experimental_features:
+#     - cdc
+#     - lwt
+#     - udf
 
 # The directory where hints files are stored if hinted handoff is enabled.
 # hints_directory: /var/lib/scylla/hints

--- a/configure.py
+++ b/configure.py
@@ -387,6 +387,7 @@ scylla_tests = [
     'tests/truncation_migration_test',
     'tests/like_matcher_test',
     'tests/linearizing_input_stream_test',
+    'tests/enum_option_test',
 ]
 
 perf_tests = [
@@ -909,6 +910,7 @@ pure_boost_tests = set([
     'tests/small_vector_test',
     'tests/like_matcher_test',
     'tests/linearizing_input_stream_test',
+    'tests/enum_option_test',
 ])
 
 tests_not_using_seastar_test_framework = set([

--- a/cql3/statements/function_statement.cc
+++ b/cql3/statements/function_statement.cc
@@ -68,7 +68,7 @@ data_type function_statement::prepare_type(service::storage_proxy& proxy, cql3_t
 
 void function_statement::create_arg_types(service::storage_proxy& proxy) const {
     if (!service::get_local_storage_service().cluster_supports_user_defined_functions()) {
-        throw exceptions::invalid_request_exception("User defined functions are disabled. Set enable_user_defined_functions to enable them");
+        throw exceptions::invalid_request_exception("User defined functions are disabled. Set enable_user_defined_functions and experimental_features:udf to enable them");
     }
 
     if (_arg_types.empty()) {

--- a/db/config.hh
+++ b/db/config.hh
@@ -32,6 +32,7 @@
 
 #include "seastarx.hh"
 #include "utils/config_file.hh"
+#include "utils/enum_option.hh"
 
 namespace seastar { class file; struct logging_settings; }
 
@@ -74,14 +75,21 @@ sstring config_value_as_json(const std::unordered_map<sstring, log_level>& v);
 
 namespace db {
 
+/// Enumeration of all valid values for the `experimental` config entry.
+struct experimental_features_t {
+    enum feature { LWT, UDF, CDC };
+    static std::unordered_map<sstring, feature> map(); // See enum_option.
+};
+
 class config : public utils::config_file {
 public:
     config();
     config(std::shared_ptr<db::extensions>);
     ~config();
 
-    // Throws exception if experimental feature is disabled.
-    void check_experimental(const sstring& what) const;
+    /// True iff the feature is enabled.
+    bool check_experimental(experimental_features_t::feature f) const;
+
     void setup_directories();
 
     /**
@@ -265,6 +273,7 @@ public:
     named_value<bool> developer_mode;
     named_value<int32_t> skip_wait_for_gossip_to_settle;
     named_value<bool> experimental;
+    named_value<std::vector<enum_option<experimental_features_t>>> experimental_features;
     named_value<size_t> lsa_reclamation_step;
     named_value<uint16_t> prometheus_port;
     named_value<sstring> prometheus_address;

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -737,7 +737,9 @@ static future<std::optional<paxos_response_handler::ballot_and_data>> sleep_and_
  */
 future<paxos_response_handler::ballot_and_data>
 paxos_response_handler::begin_and_repair_paxos(client_state& cs, unsigned& contentions, bool is_write) {
-    _proxy->get_db().local().get_config().check_experimental("Paxos");
+    if (!_proxy->get_db().local().get_config().check_experimental(db::experimental_features_t::LWT)) {
+        throw std::runtime_error("Paxos is currently disabled. Start Scylla with --experimental_features=lwt to enable.");
+    }
     return do_with(api::timestamp_type(0), shared_from_this(), [this, &cs, &contentions, is_write]
             (api::timestamp_type& min_timestamp_micros_to_use, shared_ptr<paxos_response_handler>& prh) {
         return repeat_until_value([this, &contentions, &cs, &min_timestamp_micros_to_use, is_write] {

--- a/test.py
+++ b/test.py
@@ -134,6 +134,7 @@ boost_tests = [
     'truncation_migration_test',
     'like_matcher_test',
     'linearizing_input_stream_test',
+    'enum_option_test',
 ]
 
 other_tests = [

--- a/tests/cql_test_env.cc
+++ b/tests/cql_test_env.cc
@@ -360,7 +360,10 @@ public:
             cfg->view_hints_directory.set(data_dir_path + "/view_hints.dir");
             cfg->num_tokens.set(256);
             cfg->ring_delay_ms.set(500);
-            cfg->experimental.set(true);
+            auto features = cfg->experimental_features();
+            features.emplace_back(db::experimental_features_t::CDC);
+            features.emplace_back(db::experimental_features_t::LWT);
+            cfg->experimental_features(features);
             cfg->shutdown_announce_in_ms.set(0);
             cfg->broadcast_to_all_shards().get();
             create_directories((data_dir_path + "/system").c_str());

--- a/tests/enum_option_test.cc
+++ b/tests/enum_option_test.cc
@@ -1,0 +1,175 @@
+/*
+ * Copyright (C) 2019 ScyllaDB
+ */
+
+/*
+ * This file is part of Scylla.
+ *
+ * Scylla is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Scylla is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#define BOOST_TEST_MODULE core
+
+#include <boost/test/unit_test.hpp>
+
+#include <array>
+#include <boost/program_options.hpp>
+#include <map>
+#include <set>
+#include <sstream>
+#include <string>
+#include <unordered_map>
+
+#include "utils/enum_option.hh"
+
+namespace po = boost::program_options;
+
+namespace {
+
+struct days {
+    enum enumeration { Mo, Tu, We, Th, Fr, Sa, Su };
+    static std::unordered_map<std::string, enumeration> map() {
+        return {{"Mon", Mo}, {"Tue", Tu}, {"Wed", We}, {"Thu", Th}, {"Fri", Fr}, {"Sat", Sa}, {"Sun", Su}};
+    }
+};
+
+template <typename T>
+enum_option<T> parse(const char* value) {
+    po::options_description desc("Allowed options");
+    desc.add_options()("opt", po::value<enum_option<T>>(), "Option");
+    po::variables_map vm;
+    const char* argv[] = {"$0", "--opt", value};
+    po::store(po::parse_command_line(3, argv, desc), vm);
+    return vm["opt"].as<enum_option<T>>();
+}
+
+template <typename T>
+std::string format(typename T::enumeration d) {
+    std::ostringstream os;
+    os << enum_option<T>(d);
+    return os.str();
+}
+
+} // anonymous namespace
+
+BOOST_AUTO_TEST_CASE(test_parsing) {
+    BOOST_CHECK_EQUAL(parse<days>("Sun"), days::Su);
+    BOOST_CHECK_EQUAL(parse<days>("Mon"), days::Mo);
+    BOOST_CHECK_EQUAL(parse<days>("Tue"), days::Tu);
+    BOOST_CHECK_EQUAL(parse<days>("Wed"), days::We);
+    BOOST_CHECK_EQUAL(parse<days>("Thu"), days::Th);
+    BOOST_CHECK_EQUAL(parse<days>("Fri"), days::Fr);
+    BOOST_CHECK_EQUAL(parse<days>("Sat"), days::Sa);
+}
+
+BOOST_AUTO_TEST_CASE(test_parsing_error) {
+    BOOST_REQUIRE_THROW(parse<days>("Sunday"), po::invalid_option_value);
+    BOOST_REQUIRE_THROW(parse<days>(""), po::invalid_option_value);
+    BOOST_REQUIRE_THROW(parse<days>(" "), po::invalid_option_value);
+    BOOST_REQUIRE_THROW(parse<days>(" Sun"), po::invalid_option_value);
+}
+
+BOOST_AUTO_TEST_CASE(test_formatting) {
+    BOOST_CHECK_EQUAL(format<days>(days::Mo), "Mon");
+    BOOST_CHECK_EQUAL(format<days>(days::Tu), "Tue");
+    BOOST_CHECK_EQUAL(format<days>(days::We), "Wed");
+    BOOST_CHECK_EQUAL(format<days>(days::Th), "Thu");
+    BOOST_CHECK_EQUAL(format<days>(days::Fr), "Fri");
+    BOOST_CHECK_EQUAL(format<days>(days::Sa), "Sat");
+    BOOST_CHECK_EQUAL(format<days>(days::Su), "Sun");
+}
+
+BOOST_AUTO_TEST_CASE(test_formatting_unknown) {
+    BOOST_CHECK_EQUAL(format<days>(static_cast<days::enumeration>(77)), "?unknown");
+}
+
+namespace {
+
+struct names {
+    enum enumeration { John, Jane, Jim };
+    static std::map<std::string, enumeration> map() {
+        return {{"John", John}, {"Jane", Jane}, {"James", Jim}};
+    }
+};
+
+} // anonymous namespace
+
+BOOST_AUTO_TEST_CASE(test_ordered_map) {
+    BOOST_CHECK_EQUAL(parse<names>("James"), names::Jim);
+    BOOST_CHECK_EQUAL(format<names>(names::Jim), "James");
+    BOOST_CHECK_EQUAL(parse<names>("John"), names::John);
+    BOOST_CHECK_EQUAL(format<names>(names::John), "John");
+    BOOST_CHECK_EQUAL(parse<names>("Jane"), names::Jane);
+    BOOST_CHECK_EQUAL(format<names>(names::Jane), "Jane");
+    BOOST_CHECK_THROW(parse<names>("Jimbo"), po::invalid_option_value);
+    BOOST_CHECK_EQUAL(format<names>(static_cast<names::enumeration>(77)), "?unknown");
+}
+
+namespace {
+
+struct cities {
+    enum enumeration { SF, TO, NY };
+    static std::unordered_map<std::string, enumeration> map() {
+        return {
+            {"SanFrancisco", SF}, {"SF", SF}, {"SFO", SF}, {"Frisco", SF},
+            {"Toronto", TO}, {"TO", TO}, {"YYZ", TO}, {"TheSix", TO},
+            {"NewYork", NY}, {"NY", NY}, {"NYC", NY}, {"BigApple", NY},
+        };
+    }
+};
+
+} // anonymous namespace
+
+BOOST_AUTO_TEST_CASE(test_multiple_parse) {
+    BOOST_CHECK_EQUAL(parse<cities>("SanFrancisco"), cities::SF);
+    BOOST_CHECK_EQUAL(parse<cities>("SF"), cities::SF);
+    BOOST_CHECK_EQUAL(parse<cities>("SFO"), cities::SF);
+    BOOST_CHECK_EQUAL(parse<cities>("Frisco"), cities::SF);
+    BOOST_CHECK_EQUAL(parse<cities>("Toronto"), cities::TO);
+    BOOST_CHECK_EQUAL(parse<cities>("TO"), cities::TO);
+    BOOST_CHECK_EQUAL(parse<cities>("YYZ"), cities::TO);
+    BOOST_CHECK_EQUAL(parse<cities>("TheSix"), cities::TO);
+    BOOST_CHECK_EQUAL(parse<cities>("NewYork"), cities::NY);
+    BOOST_CHECK_EQUAL(parse<cities>("NY"), cities::NY);
+    BOOST_CHECK_EQUAL(parse<cities>("NYC"), cities::NY);
+    BOOST_CHECK_EQUAL(parse<cities>("BigApple"), cities::NY);
+}
+
+BOOST_AUTO_TEST_CASE(test_multiple_format) {
+    BOOST_CHECK((std::set<std::string>{"SanFrancisco", "SF", "SFO", "Frisco"}).count(format<cities>(cities::SF)));
+    BOOST_CHECK((std::set<std::string>{"Toronto", "TO", "YYZ", "TheSix"}).count(format<cities>(cities::TO)));
+    BOOST_CHECK((std::set<std::string>{"NewYork", "NY", "NYC", "BigApple"}).count(format<cities>(cities::NY)));
+}
+
+namespace {
+
+struct numbers {
+    enum enumeration { ONE, TWO };
+    static std::unordered_map<int, enumeration> map() {
+        return {{1, ONE}, {2, TWO}};
+    }
+};
+
+} // anonymous namespace
+
+BOOST_AUTO_TEST_CASE(test_non_string) {
+    BOOST_CHECK_EQUAL(parse<numbers>("1"), numbers::ONE);
+    BOOST_CHECK_EQUAL(parse<numbers>("2"), numbers::TWO);
+    BOOST_CHECK_THROW(parse<numbers>("3"), po::invalid_option_value);
+    BOOST_CHECK_THROW(parse<numbers>("xx"), po::invalid_option_value);
+    BOOST_CHECK_THROW(parse<numbers>(""), po::invalid_option_value);
+    BOOST_CHECK_EQUAL(format<numbers>(numbers::ONE), "1");
+    BOOST_CHECK_EQUAL(format<numbers>(numbers::TWO), "2");
+    BOOST_CHECK_EQUAL(format<numbers>(static_cast<numbers::enumeration>(77)), "?unknown");
+}

--- a/tests/schema_change_test.cc
+++ b/tests/schema_change_test.cc
@@ -589,6 +589,7 @@ future<> test_schema_digest_does_not_change_with_disabled_features(sstring data_
     auto db_cfg_ptr = make_shared<db::config>();
     auto& db_cfg = *db_cfg_ptr;
     db_cfg.enable_user_defined_functions({true}, db::config::config_source::CommandLine);
+    db_cfg.experimental_features({experimental_features_t::UDF}, db::config::config_source::CommandLine);
     if (regenerate) {
         db_cfg.data_file_directories({data_dir}, db::config::config_source::CommandLine);
     } else {

--- a/utils/enum_option.hh
+++ b/utils/enum_option.hh
@@ -1,0 +1,125 @@
+
+/*
+ * Copyright (C) 2015 ScyllaDB
+ */
+
+/*
+ * This file is part of Scylla.
+ *
+ * Scylla is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Scylla is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// TODO: upstream this to Boost.
+
+#pragma once
+
+#include <boost/program_options/errors.hpp>
+#include <iostream>
+#include <seastar/util/gcc6-concepts.hh>
+#include <sstream>
+#include <type_traits>
+
+GCC6_CONCEPT(
+template<typename T>
+concept bool HasMapInterface = requires(T t) {
+    typename std::remove_reference<T>::type::mapped_type;
+    typename std::remove_reference<T>::type::key_type;
+    typename std::remove_reference<T>::type::value_type;
+    t.find(typename std::remove_reference<T>::type::key_type());
+    t.begin();
+    t.end();
+    t.cbegin();
+    t.cend();
+};
+)
+
+/// A Boost program option holding an enum value.
+///
+/// The options parser will parse enum values with the help of the Mapper class, which provides a mapping
+/// between some parsable form (eg, string) and the enum value.  For example, it may map the word "January" to
+/// the enum value JANUARY.
+///
+/// Mapper must have a static method `map()` that returns a map from a streamable key type (eg, string) to the
+/// enum in question.  In fact, enum_option knows which enum it represents only by referencing
+/// Mapper::map().mapped_type.
+///
+/// \note one enum_option holds only one enum value.  When multiple choices are allowed, use
+/// vector<enum_option>.
+///
+/// Example:
+///
+/// struct Type {
+///   enum ty { a1, a2, b1 };
+///   static unordered_map<string, ty> map();
+/// };
+/// unordered_map<string, Type::ty> Type::map() {
+///   return {{"a1", Type::a1}, {"a2", Type::a2}, {"b1", Type::b1}};
+/// }
+/// int main(int ac, char* av[]) {
+///   namespace po = boost::program_options;
+///   po::options_description desc("Allowed options");
+///   desc.add_options()
+///     ("val", po::value<enum_option<Type>>(), "Single Type")
+///     ("vec", po::value<vector<enum_option<Type>>>()->multitoken(), "Type vector");
+/// }
+template<typename Mapper>
+GCC6_CONCEPT(requires HasMapInterface<decltype(Mapper::map())>)
+class enum_option {
+    using map_t = typename std::remove_reference<decltype(Mapper::map())>::type;
+    typename map_t::mapped_type _value;
+    map_t _map;
+  public:
+    // For smooth conversion from enum values:
+    enum_option(const typename map_t::mapped_type& v) : _value(v), _map(Mapper::map()) {}
+
+    // So values can be default-constructed before streaming into them:
+    enum_option() : _map(Mapper::map()) {}
+
+    bool operator==(const enum_option<Mapper>& that) const {
+        return _value == that._value;
+    }
+
+    // For program_options parser:
+    friend std::istream& operator>>(std::istream& s, enum_option<Mapper>& opt) {
+        typename map_t::key_type key;
+        s >> key;
+        const auto found = opt._map.find(key);
+        if (found == opt._map.end()) {
+            std::string text;
+            if (s.rdstate() & s.failbit) {
+                // key wasn't read successfully.
+                s >> text;
+            } else {
+                // Turn key into text.
+                std::ostringstream temp;
+                temp << key;
+                text = temp.str();
+            }
+            throw boost::program_options::invalid_option_value(text);
+        }
+        opt._value = found->second;
+        return s;
+    }
+
+    // For various printers and formatters:
+    friend std::ostream& operator<<(std::ostream& s, const enum_option<Mapper>& opt) {
+        auto found = find_if(opt._map.cbegin(), opt._map.cend(),
+                             [&opt](const typename map_t::value_type& e) { return e.second == opt._value; });
+        if (found == opt._map.cend()) {
+            return s << "?unknown";
+        } else {
+            return s << found->first;
+        }
+    }
+};


### PR DESCRIPTION
Add `--experimental-features` -- a vector of features to unlock.  Make corresponding changes in the YAML parser.

Fixes #5338 