### PR TITLE
hinted handoff: log message after removing hints directory

### DIFF
--- a/db/hints/manager.cc
+++ b/db/hints/manager.cc
@@ -571,6 +571,8 @@ void manager::drain_for(gms::inet_address endpoint) {
                 manager_logger.error("Exception when draining {}: {}", endpoint, eptr);
             });
         });
+    }).finally([endpoint] {
+        manager_logger.trace("drain_for: finished draining {}", endpoint);
     });
 }
 


### PR DESCRIPTION
To be used by dtest as an indicator that endpoint's hints
were drained and hints directory is removed.

Refs #5354

Signed-off-by: Benny Halevy <bhalevy@scylladb.com>