### PR TITLE
Include semaphore name in reader_concurrency_semaphore exception

### DIFF
--- a/database.cc
+++ b/database.cc
@@ -206,8 +206,12 @@ database::database(const db::config& cfg, database_config dbcfg)
         })
     // No timeouts or queue length limits - a failure here can kill an entire repair.
     // Trust the caller to limit concurrency.
-    , _streaming_concurrency_sem(max_count_streaming_concurrent_reads, max_memory_streaming_concurrent_reads())
-    , _system_read_concurrency_sem(max_count_system_concurrent_reads, max_memory_system_concurrent_reads())
+    , _streaming_concurrency_sem(
+            max_count_streaming_concurrent_reads,
+            max_memory_streaming_concurrent_reads())
+    , _system_read_concurrency_sem(
+            max_count_system_concurrent_reads,
+            max_memory_system_concurrent_reads())
     , _data_query_stage("data_query", &column_family::query)
     , _mutation_query_stage()
     , _apply_stage("db_apply", &database::do_apply)

--- a/reader_concurrency_semaphore.hh
+++ b/reader_concurrency_semaphore.hh
@@ -24,10 +24,8 @@
 #include <map>
 #include <seastar/core/file.hh>
 #include <seastar/core/future.hh>
-#include <seastar/core/semaphore.hh>
 #include "db/timeout_clock.hh"
-
-using namespace seastar;
+#include "seastarx.hh"
 
 /// Specific semaphore for controlling reader concurrency
 ///


### PR DESCRIPTION
Semaphore names are now explicitly contained in runtime_error message. Thrown from lambda (the last parameter of `reader_concurrency_semaphore` ctor).