### PR TITLE
api: replace swagger definition to use long instead of int

### DIFF
--- a/api/api-doc/cache_service.json
+++ b/api/api-doc/cache_service.json
@@ -13,7 +13,7 @@
             {
                "method":"GET",
                "summary":"get row cache save period in seconds",
-               "type":"int",
+               "type": "long",
                "nickname":"get_row_cache_save_period_in_seconds",
                "produces":[
                   "application/json"
@@ -35,7 +35,7 @@
                      "description":"row cache save period in seconds",
                      "required":true,
                      "allowMultiple":false,
-                     "type":"int",
+                     "type": "long",
                      "paramType":"query"
                   }
                ]
@@ -48,7 +48,7 @@
             {
                "method":"GET",
                "summary":"get key cache save period in seconds",
-               "type":"int",
+               "type": "long",
                "nickname":"get_key_cache_save_period_in_seconds",
                "produces":[
                   "application/json"
@@ -70,7 +70,7 @@
                      "description":"key cache save period in seconds",
                      "required":true,
                      "allowMultiple":false,
-                     "type":"int",
+                     "type": "long",
                      "paramType":"query"
                   }
                ]
@@ -83,7 +83,7 @@
             {
                "method":"GET",
                "summary":"get counter cache save period in seconds",
-               "type":"int",
+               "type": "long",
                "nickname":"get_counter_cache_save_period_in_seconds",
                "produces":[
                   "application/json"
@@ -105,7 +105,7 @@
                      "description":"counter cache save period in seconds",
                      "required":true,
                      "allowMultiple":false,
-                     "type":"int",
+                     "type": "long",
                      "paramType":"query"
                   }
                ]
@@ -118,7 +118,7 @@
             {
                "method":"GET",
                "summary":"get row cache keys to save",
-               "type":"int",
+               "type": "long",
                "nickname":"get_row_cache_keys_to_save",
                "produces":[
                   "application/json"
@@ -140,7 +140,7 @@
                      "description":"row cache keys to save",
                      "required":true,
                      "allowMultiple":false,
-                     "type":"int",
+                     "type": "long",
                      "paramType":"query"
                   }
                ]
@@ -153,7 +153,7 @@
             {
                "method":"GET",
                "summary":"get key cache keys to save",
-               "type":"int",
+               "type": "long",
                "nickname":"get_key_cache_keys_to_save",
                "produces":[
                   "application/json"
@@ -175,7 +175,7 @@
                      "description":"key cache keys to save",
                      "required":true,
                      "allowMultiple":false,
-                     "type":"int",
+                     "type": "long",
                      "paramType":"query"
                   }
                ]
@@ -188,7 +188,7 @@
             {
                "method":"GET",
                "summary":"get counter cache keys to save",
-               "type":"int",
+               "type": "long",
                "nickname":"get_counter_cache_keys_to_save",
                "produces":[
                   "application/json"
@@ -210,7 +210,7 @@
                      "description":"counter cache keys to save",
                      "required":true,
                      "allowMultiple":false,
-                     "type":"int",
+                     "type": "long",
                      "paramType":"query"
                   }
                ]
@@ -448,7 +448,7 @@
         {
           "method": "GET",
           "summary": "Get key entries",
-          "type": "int",
+          "type": "long",
           "nickname": "get_key_entries",
           "produces": [
             "application/json"
@@ -568,7 +568,7 @@
         {
           "method": "GET",
           "summary": "Get row entries",
-          "type": "int",
+          "type": "long",
           "nickname": "get_row_entries",
           "produces": [
             "application/json"
@@ -688,7 +688,7 @@
         {
           "method": "GET",
           "summary": "Get counter entries",
-          "type": "int",
+          "type": "long",
           "nickname": "get_counter_entries",
           "produces": [
             "application/json"

--- a/api/api-doc/column_family.json
+++ b/api/api-doc/column_family.json
@@ -121,7 +121,7 @@
                      "description":"The minimum number of sstables in queue before compaction kicks off",
                      "required":true,
                      "allowMultiple":false,
-                     "type":"int",
+                     "type": "long",
                      "paramType":"query"
                   }
                ]
@@ -172,7 +172,7 @@
                      "description":"The maximum number of sstables in queue before compaction kicks off",
                      "required":true,
                      "allowMultiple":false,
-                     "type":"int",
+                     "type": "long",
                      "paramType":"query"
                   }
                ]
@@ -223,7 +223,7 @@
                      "description":"The maximum number of sstables in queue before compaction kicks off",
                      "required":true,
                      "allowMultiple":false,
-                     "type":"int",
+                     "type": "long",
                      "paramType":"query"
                   },
                   {
@@ -231,7 +231,7 @@
                      "description":"The minimum number of sstables in queue before compaction kicks off",
                      "required":true,
                      "allowMultiple":false,
-                     "type":"int",
+                     "type": "long",
                      "paramType":"query"
                   }
                ]
@@ -544,7 +544,7 @@
                "summary":"sstable count for each level. empty unless leveled compaction is used",
                "type":"array",
                "items":{
-                  "type":"int"
+                  "type": "long"
                },
                "nickname":"get_sstable_count_per_level",
                "produces":[
@@ -636,7 +636,7 @@
                      "description":"Duration (in milliseconds) of monitoring operation",
                      "required":true,
                      "allowMultiple":false,
-                     "type":"int",
+                     "type": "long",
                      "paramType":"query"
                   },
                   {
@@ -644,7 +644,7 @@
                     "description":"number of the top partitions to list",
                     "required":false,
                     "allowMultiple":false,
-                    "type":"int",
+                    "type": "long",
                     "paramType":"query"
                  },
                  {
@@ -652,7 +652,7 @@
                     "description":"capacity of stream summary: determines amount of resources used in query processing",
                     "required":false,
                     "allowMultiple":false,
-                    "type":"int",
+                    "type": "long",
                     "paramType":"query"
                  }
               ]
@@ -921,7 +921,7 @@
             {
                "method":"GET",
                "summary":"Get memtable switch count",
-               "type":"int",
+               "type": "long",
                "nickname":"get_memtable_switch_count",
                "produces":[
                   "application/json"
@@ -945,7 +945,7 @@
             {
                "method":"GET",
                "summary":"Get all memtable switch count",
-               "type":"int",
+               "type": "long",
                "nickname":"get_all_memtable_switch_count",
                "produces":[
                   "application/json"
@@ -1082,7 +1082,7 @@
             {
                "method":"GET",
                "summary":"Get read latency",
-               "type":"int",
+               "type": "long",
                "nickname":"get_read_latency",
                "produces":[
                   "application/json"
@@ -1235,7 +1235,7 @@
             {
                "method":"GET",
                "summary":"Get all read latency",
-               "type":"int",
+               "type": "long",
                "nickname":"get_all_read_latency",
                "produces":[
                   "application/json"
@@ -1251,7 +1251,7 @@
             {
                "method":"GET",
                "summary":"Get range latency",
-               "type":"int",
+               "type": "long",
                "nickname":"get_range_latency",
                "produces":[
                   "application/json"
@@ -1275,7 +1275,7 @@
             {
                "method":"GET",
                "summary":"Get all range latency",
-               "type":"int",
+               "type": "long",
                "nickname":"get_all_range_latency",
                "produces":[
                   "application/json"
@@ -1291,7 +1291,7 @@
             {
                "method":"GET",
                "summary":"Get write latency",
-               "type":"int",
+               "type": "long",
                "nickname":"get_write_latency",
                "produces":[
                   "application/json"
@@ -1444,7 +1444,7 @@
             {
                "method":"GET",
                "summary":"Get all write latency",
-               "type":"int",
+               "type": "long",
                "nickname":"get_all_write_latency",
                "produces":[
                   "application/json"
@@ -1460,7 +1460,7 @@
             {
                "method":"GET",
                "summary":"Get pending flushes",
-               "type":"int",
+               "type": "long",
                "nickname":"get_pending_flushes",
                "produces":[
                   "application/json"
@@ -1484,7 +1484,7 @@
             {
                "method":"GET",
                "summary":"Get all pending flushes",
-               "type":"int",
+               "type": "long",
                "nickname":"get_all_pending_flushes",
                "produces":[
                   "application/json"
@@ -1500,7 +1500,7 @@
             {
                "method":"GET",
                "summary":"Get pending compactions",
-               "type":"int",
+               "type": "long",
                "nickname":"get_pending_compactions",
                "produces":[
                   "application/json"
@@ -1524,7 +1524,7 @@
             {
                "method":"GET",
                "summary":"Get all pending compactions",
-               "type":"int",
+               "type": "long",
                "nickname":"get_all_pending_compactions",
                "produces":[
                   "application/json"
@@ -1540,7 +1540,7 @@
             {
                "method":"GET",
                "summary":"Get live ss table count",
-               "type":"int",
+               "type": "long",
                "nickname":"get_live_ss_table_count",
                "produces":[
                   "application/json"
@@ -1564,7 +1564,7 @@
             {
                "method":"GET",
                "summary":"Get all live ss table count",
-               "type":"int",
+               "type": "long",
                "nickname":"get_all_live_ss_table_count",
                "produces":[
                   "application/json"
@@ -1580,7 +1580,7 @@
             {
                "method":"GET",
                "summary":"Get live disk space used",
-               "type":"int",
+               "type": "long",
                "nickname":"get_live_disk_space_used",
                "produces":[
                   "application/json"
@@ -1604,7 +1604,7 @@
             {
                "method":"GET",
                "summary":"Get all live disk space used",
-               "type":"int",
+               "type": "long",
                "nickname":"get_all_live_disk_space_used",
                "produces":[
                   "application/json"
@@ -1620,7 +1620,7 @@
             {
                "method":"GET",
                "summary":"Get total disk space used",
-               "type":"int",
+               "type": "long",
                "nickname":"get_total_disk_space_used",
                "produces":[
                   "application/json"
@@ -1644,7 +1644,7 @@
             {
                "method":"GET",
                "summary":"Get all total disk space used",
-               "type":"int",
+               "type": "long",
                "nickname":"get_all_total_disk_space_used",
                "produces":[
                   "application/json"
@@ -2100,7 +2100,7 @@
             {
                "method":"GET",
                "summary":"Get speculative retries",
-               "type":"int",
+               "type": "long",
                "nickname":"get_speculative_retries",
                "produces":[
                   "application/json"
@@ -2124,7 +2124,7 @@
             {
                "method":"GET",
                "summary":"Get all speculative retries",
-               "type":"int",
+               "type": "long",
                "nickname":"get_all_speculative_retries",
                "produces":[
                   "application/json"
@@ -2204,7 +2204,7 @@
             {
                "method":"GET",
                "summary":"Get row cache hit out of range",
-               "type":"int",
+               "type": "long",
                "nickname":"get_row_cache_hit_out_of_range",
                "produces":[
                   "application/json"
@@ -2228,7 +2228,7 @@
             {
                "method":"GET",
                "summary":"Get all row cache hit out of range",
-               "type":"int",
+               "type": "long",
                "nickname":"get_all_row_cache_hit_out_of_range",
                "produces":[
                   "application/json"
@@ -2244,7 +2244,7 @@
             {
                "method":"GET",
                "summary":"Get row cache hit",
-               "type":"int",
+               "type": "long",
                "nickname":"get_row_cache_hit",
                "produces":[
                   "application/json"
@@ -2268,7 +2268,7 @@
             {
                "method":"GET",
                "summary":"Get all row cache hit",
-               "type":"int",
+               "type": "long",
                "nickname":"get_all_row_cache_hit",
                "produces":[
                   "application/json"
@@ -2284,7 +2284,7 @@
             {
                "method":"GET",
                "summary":"Get row cache miss",
-               "type":"int",
+               "type": "long",
                "nickname":"get_row_cache_miss",
                "produces":[
                   "application/json"
@@ -2308,7 +2308,7 @@
             {
                "method":"GET",
                "summary":"Get all row cache miss",
-               "type":"int",
+               "type": "long",
                "nickname":"get_all_row_cache_miss",
                "produces":[
                   "application/json"
@@ -2324,7 +2324,7 @@
             {
                "method":"GET",
                "summary":"Get cas prepare",
-               "type":"int",
+               "type": "long",
                "nickname":"get_cas_prepare",
                "produces":[
                   "application/json"
@@ -2348,7 +2348,7 @@
             {
                "method":"GET",
                "summary":"Get cas propose",
-               "type":"int",
+               "type": "long",
                "nickname":"get_cas_propose",
                "produces":[
                   "application/json"
@@ -2372,7 +2372,7 @@
             {
                "method":"GET",
                "summary":"Get cas commit",
-               "type":"int",
+               "type": "long",
                "nickname":"get_cas_commit",
                "produces":[
                   "application/json"

--- a/api/api-doc/compaction_manager.json
+++ b/api/api-doc/compaction_manager.json
@@ -118,7 +118,7 @@
         {
           "method": "GET",
           "summary": "Get pending tasks",
-          "type": "int",
+          "type": "long",
           "nickname": "get_pending_tasks",
           "produces": [
             "application/json"
@@ -181,7 +181,7 @@
         {
           "method": "GET",
           "summary": "Get bytes compacted",
-          "type": "int",
+          "type": "long",
           "nickname": "get_bytes_compacted",
           "produces": [
             "application/json"
@@ -197,7 +197,7 @@
          "description":"A row merged information",
          "properties":{
             "key":{
-               "type":"int",
+               "type": "long",
                "description":"The number of sstable"
             },
             "value":{

--- a/api/api-doc/failure_detector.json
+++ b/api/api-doc/failure_detector.json
@@ -110,7 +110,7 @@
             {
                "method":"GET",
                "summary":"Get count down endpoint",
-               "type":"int",
+               "type": "long",
                "nickname":"get_down_endpoint_count",
                "produces":[
                   "application/json"
@@ -126,7 +126,7 @@
             {
                "method":"GET",
                "summary":"Get count up endpoint",
-               "type":"int",
+               "type": "long",
                "nickname":"get_up_endpoint_count",
                "produces":[
                   "application/json"
@@ -180,11 +180,11 @@
                     "description": "The endpoint address"
                 },
                 "generation": {
-                    "type": "int",
+                    "type": "long",
                     "description": "The heart beat generation"
                 },
                 "version": {
-                    "type": "int",
+                    "type": "long",
                     "description": "The heart beat version"
                 },
                 "update_time": {
@@ -209,7 +209,7 @@
            "description": "Holds a version value for an application state",
                "properties": {
                 "application_state": {
-                    "type": "int",
+                    "type": "long",
                     "description": "The application state enum index"
                 },
                 "value": {
@@ -217,7 +217,7 @@
                     "description": "The version value"
                 },
                 "version": {
-                    "type": "int",
+                    "type": "long",
                     "description": "The application state version"
                 }
             }

--- a/api/api-doc/gossiper.json
+++ b/api/api-doc/gossiper.json
@@ -75,7 +75,7 @@
             {
                "method":"GET",
                "summary":"Returns files which are pending for archival attempt. Does NOT include failed archive attempts",
-               "type":"int",
+               "type": "long",
                "nickname":"get_current_generation_number",
                "produces":[
                   "application/json"
@@ -99,7 +99,7 @@
             {
                "method":"GET",
                "summary":"Get heart beat version for a node",
-               "type":"int",
+               "type": "long",
                "nickname":"get_current_heart_beat_version",
                "produces":[
                   "application/json"

--- a/api/api-doc/hinted_handoff.json
+++ b/api/api-doc/hinted_handoff.json
@@ -99,7 +99,7 @@
         {
           "method": "GET",
           "summary": "Get create hint count",
-          "type": "int",
+          "type": "long",
           "nickname": "get_create_hint_count",
           "produces": [
             "application/json"
@@ -123,7 +123,7 @@
         {
           "method": "GET",
           "summary": "Get not stored hints count",
-          "type": "int",
+          "type": "long",
           "nickname": "get_not_stored_hints_count",
           "produces": [
             "application/json"

--- a/api/api-doc/messaging_service.json
+++ b/api/api-doc/messaging_service.json
@@ -191,7 +191,7 @@
             {
                "method":"GET",
                "summary":"Get the version number",
-               "type":"int",
+               "type": "long",
                "nickname":"get_version",
                "produces":[
                   "application/json"

--- a/api/api-doc/storage_proxy.json
+++ b/api/api-doc/storage_proxy.json
@@ -105,7 +105,7 @@
             {
                "method":"GET",
                "summary":"Get the max hint window",
-               "type":"int",
+               "type": "long",
                "nickname":"get_max_hint_window",
                "produces":[
                   "application/json"
@@ -128,7 +128,7 @@
                      "description":"max hint window in ms",
                      "required":true,
                      "allowMultiple":false,
-                     "type":"int",
+                     "type": "long",
                      "paramType":"query"
                   }
                ]
@@ -141,7 +141,7 @@
             {
                "method":"GET",
                "summary":"Get max hints in progress",
-               "type":"int",
+               "type": "long",
                "nickname":"get_max_hints_in_progress",
                "produces":[
                   "application/json"
@@ -164,7 +164,7 @@
                      "description":"max hints in progress",
                      "required":true,
                      "allowMultiple":false,
-                     "type":"int",
+                     "type": "long",
                      "paramType":"query"
                   }
                ]
@@ -177,7 +177,7 @@
             {
                "method":"GET",
                "summary":"get hints in progress",
-               "type":"int",
+               "type": "long",
                "nickname":"get_hints_in_progress",
                "produces":[
                   "application/json"
@@ -602,7 +602,7 @@
         {
           "method": "GET",
           "summary": "Get cas write metrics",
-          "type": "int",
+          "type": "long",
           "nickname": "get_cas_write_metrics_unfinished_commit",
           "produces": [
             "application/json"
@@ -632,7 +632,7 @@
         {
           "method": "GET",
           "summary": "Get cas write metrics",
-          "type": "int",
+          "type": "long",
           "nickname": "get_cas_write_metrics_condition_not_met",
           "produces": [
             "application/json"
@@ -647,7 +647,7 @@
         {
           "method": "GET",
           "summary": "Get cas read metrics",
-          "type": "int",
+          "type": "long",
           "nickname": "get_cas_read_metrics_unfinished_commit",
           "produces": [
             "application/json"
@@ -677,7 +677,7 @@
         {
           "method": "GET",
           "summary": "Get read metrics",
-          "type": "int",
+          "type": "long",
           "nickname": "get_read_metrics_timeouts",
           "produces": [
             "application/json"
@@ -692,7 +692,7 @@
         {
           "method": "GET",
           "summary": "Get read metrics",
-          "type": "int",
+          "type": "long",
           "nickname": "get_read_metrics_unavailables",
           "produces": [
             "application/json"
@@ -827,7 +827,7 @@
         {
           "method": "GET",
           "summary": "Get range metrics",
-          "type": "int",
+          "type": "long",
           "nickname": "get_range_metrics_timeouts",
           "produces": [
             "application/json"
@@ -842,7 +842,7 @@
         {
           "method": "GET",
           "summary": "Get range metrics",
-          "type": "int",
+          "type": "long",
           "nickname": "get_range_metrics_unavailables",
           "produces": [
             "application/json"
@@ -887,7 +887,7 @@
         {
           "method": "GET",
           "summary": "Get write metrics",
-          "type": "int",
+          "type": "long",
           "nickname": "get_write_metrics_timeouts",
           "produces": [
             "application/json"
@@ -902,7 +902,7 @@
         {
           "method": "GET",
           "summary": "Get write metrics",
-          "type": "int",
+          "type": "long",
           "nickname": "get_write_metrics_unavailables",
           "produces": [
             "application/json"
@@ -1008,7 +1008,7 @@
             {
                "method":"GET",
                "summary":"Get read latency",
-               "type":"int",
+               "type": "long",
                "nickname":"get_read_latency",
                "produces":[
                   "application/json"
@@ -1040,7 +1040,7 @@
             {
                "method":"GET",
                "summary":"Get write latency",
-               "type":"int",
+               "type": "long",
                "nickname":"get_write_latency",
                "produces":[
                   "application/json"
@@ -1072,7 +1072,7 @@
             {
                "method":"GET",
                "summary":"Get range latency",
-               "type":"int",
+               "type": "long",
                "nickname":"get_range_latency",
                "produces":[
                   "application/json"

--- a/api/api-doc/storage_service.json
+++ b/api/api-doc/storage_service.json
@@ -458,7 +458,7 @@
             {
                "method":"GET",
                "summary":"Return the generation value for this node.",
-               "type":"int",
+               "type": "long",
                "nickname":"get_current_generation_number",
                "produces":[
                   "application/json"
@@ -646,7 +646,7 @@
             {
                "method":"POST",
                "summary":"Trigger a cleanup of keys on a single keyspace",
-               "type":"int",
+               "type": "long",
                "nickname":"force_keyspace_cleanup",
                "produces":[
                   "application/json"
@@ -678,7 +678,7 @@
             {
                "method":"GET",
                "summary":"Scrub (deserialize + reserialize at the latest version, skipping bad rows if any) the given keyspace. If columnFamilies array is empty, all CFs are scrubbed. Scrubbed CFs will be snapshotted first, if disableSnapshot is false",
-               "type":"int",
+               "type": "long",
                "nickname":"scrub",
                "produces":[
                   "application/json"
@@ -726,7 +726,7 @@
             {
                "method":"GET",
                "summary":"Rewrite all sstables to the latest version. Unlike scrub, it doesn't skip bad rows and do not snapshot sstables first.",
-               "type":"int",
+               "type": "long",
                "nickname":"upgrade_sstables",
                "produces":[
                   "application/json"
@@ -800,7 +800,7 @@
                "summary":"Return an array with the ids of the currently active repairs",
                "type":"array",
                "items":{
-                  "type":"int"
+                  "type": "long"
                },
                "nickname":"get_active_repair_async",
                "produces":[
@@ -816,7 +816,7 @@
             {
                "method":"POST",
                "summary":"Invoke repair asynchronously. You can track repair progress by using the get supplying id",
-               "type":"int",
+               "type": "long",
                "nickname":"repair_async",
                "produces":[
                   "application/json"
@@ -947,7 +947,7 @@
                      "description":"The repair ID to check for status",
                      "required":true,
                      "allowMultiple":false,
-                     "type":"int",
+                     "type": "long",
                      "paramType":"query"
                   }
                ]
@@ -1277,18 +1277,18 @@
                   },
                   {
                      "name":"dynamic_update_interval",
-                     "description":"integer, in ms (default 100)",
+                     "description":"interval in ms (default 100)",
                      "required":false,
                      "allowMultiple":false,
-                     "type":"integer",
+                     "type":"long",
                      "paramType":"query"
                   },
                   {
                      "name":"dynamic_reset_interval",
-                     "description":"integer, in ms (default 600,000)",
+                     "description":"interval in ms (default 600,000)",
                      "required":false,
                      "allowMultiple":false,
-                     "type":"integer",
+                     "type":"long",
                      "paramType":"query"
                   },
                   {
@@ -1493,7 +1493,7 @@
                      "description":"Stream throughput",
                      "required":true,
                      "allowMultiple":false,
-                     "type":"int",
+                     "type": "long",
                      "paramType":"query"
                   }
                ]
@@ -1501,7 +1501,7 @@
             {
                "method":"GET",
                "summary":"Get stream throughput mb per sec",
-               "type":"int",
+               "type": "long",
                "nickname":"get_stream_throughput_mb_per_sec",
                "produces":[
                   "application/json"
@@ -1517,7 +1517,7 @@
             {
                "method":"GET",
                "summary":"get compaction throughput mb per sec",
-               "type":"int",
+               "type": "long",
                "nickname":"get_compaction_throughput_mb_per_sec",
                "produces":[
                   "application/json"
@@ -1539,7 +1539,7 @@
                      "description":"compaction throughput",
                      "required":true,
                      "allowMultiple":false,
-                     "type":"int",
+                     "type": "long",
                      "paramType":"query"
                   }
                ]
@@ -1943,7 +1943,7 @@
             {
                "method":"GET",
                "summary":"Returns the threshold for warning of queries with many tombstones",
-               "type":"int",
+               "type": "long",
                "nickname":"get_tombstone_warn_threshold",
                "produces":[
                   "application/json"
@@ -1965,7 +1965,7 @@
                      "description":"tombstone debug threshold",
                      "required":true,
                      "allowMultiple":false,
-                     "type":"int",
+                     "type": "long",
                      "paramType":"query"
                   }
                ]
@@ -1978,7 +1978,7 @@
             {
                "method":"GET",
                "summary":"",
-               "type":"int",
+               "type": "long",
                "nickname":"get_tombstone_failure_threshold",
                "produces":[
                   "application/json"
@@ -2000,7 +2000,7 @@
                      "description":"tombstone debug threshold",
                      "required":true,
                      "allowMultiple":false,
-                     "type":"int",
+                     "type": "long",
                      "paramType":"query"
                   }
                ]
@@ -2013,7 +2013,7 @@
             {
                "method":"GET",
                "summary":"Returns the threshold for rejecting queries due to a large batch size",
-               "type":"int",
+               "type": "long",
                "nickname":"get_batch_size_failure_threshold",
                "produces":[
                   "application/json"
@@ -2035,7 +2035,7 @@
                      "description":"batch size debug threshold",
                      "required":true,
                      "allowMultiple":false,
-                     "type":"int",
+                     "type": "long",
                      "paramType":"query"
                   }
                ]
@@ -2059,7 +2059,7 @@
                      "description":"throttle in kb",
                      "required":true,
                      "allowMultiple":false,
-                     "type":"int",
+                     "type": "long",
                      "paramType":"query"
                   }
                ]
@@ -2072,7 +2072,7 @@
             {
                "method":"GET",
                "summary":"Get load",
-               "type":"int",
+               "type": "long",
                "nickname":"get_metrics_load",
                "produces":[
                   "application/json"
@@ -2088,7 +2088,7 @@
             {
                "method":"GET",
                "summary":"Get exceptions",
-               "type":"int",
+               "type": "long",
                "nickname":"get_exceptions",
                "produces":[
                   "application/json"
@@ -2104,7 +2104,7 @@
             {
                "method":"GET",
                "summary":"Get total hints in progress",
-               "type":"int",
+               "type": "long",
                "nickname":"get_total_hints_in_progress",
                "produces":[
                   "application/json"
@@ -2120,7 +2120,7 @@
             {
                "method":"GET",
                "summary":"Get total hints",
-               "type":"int",
+               "type": "long",
                "nickname":"get_total_hints",
                "produces":[
                   "application/json"

--- a/api/api-doc/stream_manager.json
+++ b/api/api-doc/stream_manager.json
@@ -32,7 +32,7 @@
             {
                "method":"GET",
                "summary":"Get number of active outbound streams",
-               "type":"int",
+               "type": "long",
                "nickname":"get_all_active_streams_outbound",
                "produces":[
                   "application/json"
@@ -48,7 +48,7 @@
             {
                "method":"GET",
                "summary":"Get total incoming bytes",
-               "type":"int",
+               "type": "long",
                "nickname":"get_total_incoming_bytes",
                "produces":[
                   "application/json"
@@ -72,7 +72,7 @@
             {
                "method":"GET",
                "summary":"Get all total incoming bytes",
-               "type":"int",
+               "type": "long",
                "nickname":"get_all_total_incoming_bytes",
                "produces":[
                   "application/json"
@@ -88,7 +88,7 @@
             {
                "method":"GET",
                "summary":"Get total outgoing bytes",
-               "type":"int",
+               "type": "long",
                "nickname":"get_total_outgoing_bytes",
                "produces":[
                   "application/json"
@@ -112,7 +112,7 @@
             {
                "method":"GET",
                "summary":"Get all total outgoing bytes",
-               "type":"int",
+               "type": "long",
                "nickname":"get_all_total_outgoing_bytes",
                "produces":[
                   "application/json"
@@ -154,7 +154,7 @@
                "description":"The peer"
             },
             "session_index":{
-               "type":"int",
+               "type": "long",
                "description":"The session index"
             },
             "connecting":{
@@ -211,7 +211,7 @@
                "description":"The ID"
             },
             "files":{
-               "type":"int",
+               "type": "long",
                "description":"Number of files to transfer. Can be 0 if nothing to transfer for some streaming request."
             },
             "total_size":{
@@ -242,7 +242,7 @@
                "description":"The peer address"
             },
             "session_index":{
-               "type":"int",
+               "type": "long",
                "description":"The session index"
             },
             "file_name":{


### PR DESCRIPTION
In swagger 1.2 int is defined as int32.

We originally used int following the jmx definition, in practice
internally we use uint and int64 in many places.

While the API format the type correctly, an external system that uses
swagger-based code generator can face a type issue problem.

This patch replace all use of int in a return type with long that is defined as int64.

Changing the return type, have no impact on the system, but it does help
external systems that use code generator from swagger.

Fixes #5347

Signed-off-by: Amnon Heiman <amnon@scylladb.com>