### PR TITLE
redis: implement echo command

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -825,6 +825,7 @@ redis = [
         'redis/commands/get.cc',
         'redis/commands/del.cc',
         'redis/commands/select.cc',
+        'redis/commands/echo.cc',
         ]
 
 idls = ['idl/gossip_digest.idl.hh',

--- a/redis-test/test_strings.py
+++ b/redis-test/test_strings.py
@@ -78,6 +78,10 @@ def test_ping():
     r = connect()
     assert r.ping() == True
 
+def test_echo():
+    r = connect()
+    assert r.echo('hello world') == 'hello world'
+
 def test_select():
     r = connect()
     key = random_string(10)

--- a/redis/command_factory.cc
+++ b/redis/command_factory.cc
@@ -27,6 +27,7 @@
 #include "redis/commands/set.hh"
 #include "redis/commands/del.hh"
 #include "redis/commands/select.hh"
+#include "redis/commands/echo.hh"
 #include "log.hh"
 
 namespace redis {
@@ -42,6 +43,7 @@ shared_ptr<abstract_command> command_factory::create(service::storage_proxy& pro
         { "get",  [] (service::storage_proxy& proxy, request&& req) { return commands::get::prepare(proxy, std::move(req)); } }, 
         { "set",  [] (service::storage_proxy& proxy, request&& req) { return commands::set::prepare(proxy, std::move(req)); } }, 
         { "del",  [] (service::storage_proxy& proxy, request&& req) { return commands::del::prepare(proxy, std::move(req)); } }, 
+        { "echo",  [] (service::storage_proxy& proxy, request&& req) { return commands::echo::prepare(proxy, std::move(req)); } },
     };
     auto&& command = _commands.find(req._command);
     if (command != _commands.end()) {

--- a/redis/commands/echo.cc
+++ b/redis/commands/echo.cc
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2019 ScyllaDB
+ */
+
+/*
+ * This file is part of Scylla.
+ *
+ * Scylla is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Scylla is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "redis/commands/echo.hh"
+#include "seastar/core/shared_ptr.hh"
+#include "redis/request.hh"
+#include "redis/reply.hh"
+#include "types.hh"
+#include "service/storage_proxy.hh"
+#include "redis/options.hh"
+#include "service_permit.hh"
+
+namespace redis {
+namespace commands {
+
+shared_ptr<abstract_command> echo::prepare(service::storage_proxy& proxy, request&& req) {
+    if (req.arguments_size() != 1) {
+        throw wrong_arguments_exception(1, req.arguments_size(), req._command);
+    }
+    return seastar::make_shared<echo> (std::move(req._command), std::move(req._args[0]));
+}
+
+future<redis_message> echo::execute(service::storage_proxy&, redis::redis_options&, service_permit) {
+    return redis_message::make_strings_result(std::move(_str));
+}
+
+}
+}

--- a/redis/commands/echo.hh
+++ b/redis/commands/echo.hh
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2019 ScyllaDB
+ */
+
+/*
+ * This file is part of Scylla.
+ *
+ * Scylla is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Scylla is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "redis/request.hh"
+#include "redis/abstract_command.hh"
+
+namespace redis {
+
+namespace commands {
+
+class echo : public abstract_command {
+    bytes _str;
+public:
+    static shared_ptr<abstract_command> prepare(service::storage_proxy& proxy, request&& req);
+    echo(bytes&& name, bytes&& str) : abstract_command(std::move(name)) , _str(std::move(str)) {}
+    virtual future<redis_message> execute(service::storage_proxy&, redis_options&, service_permit) override;
+};
+
+}
+
+}


### PR DESCRIPTION
This patch implemented echo command, which return the string back to client.

Reference:
- https://redis.io/commands/echo

/CC @fastio @nyh 