### PR TITLE
redis: skip processing request of EOF

### DIFF
--- a/redis-test/test_raw_cmd.py
+++ b/redis-test/test_raw_cmd.py
@@ -1,0 +1,74 @@
+#
+# Copyright (C) 2019 ScyllaDB
+#
+#
+# This file is part of Scylla.
+#
+# Scylla is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Scylla is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+import socket
+import logging
+
+logger = logging.getLogger('redis-test')
+
+
+class RedisSocket:
+
+    def __init__(self, host='localhost', port=6379):
+        self.socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self.connect(host, port)
+
+    def connect(self, host, port):
+        self.socket.connect((host, port))
+
+    def send(self, content=''):
+        self.socket.send(content)
+
+    def recv(self, buf_len=1024):
+        return self.socket.recv(buf_len)
+
+    def shutdown(self):
+        self.socket.shutdown(socket.SHUT_WR)
+
+    def close(self):
+        self.socket.close()
+
+def verify_cmd_response(cmd, expect_ret, shutdown=False):
+    rs = RedisSocket()
+    rs.send(cmd.encode())
+    if shutdown:
+        rs.shutdown()
+    ret = rs.recv().decode()
+    logger.debug('Received content size: %s' % len(ret))
+    logger.debug(ret)
+    assert ret == expect_ret
+    rs.close()
+
+def test_ping():
+    verify_cmd_response('*1\r\n$4\r\nping\r\n', '+PONG\r\n')
+
+def test_eof():
+    # shutdown socket, and read nothing
+    verify_cmd_response("", "", shutdown=True)
+
+    # a EOF char `\x04` should be triggered parse error
+    verify_cmd_response("\x04", "-ERR unknown command ''\r\n", shutdown=True)
+
+def test_ping_and_eof():
+    # regular ping with shutdown
+    verify_cmd_response('*1\r\n$4\r\nping\r\n', '+PONG\r\n', shutdown=True)
+
+    # a EOF char `\x04` should be triggered parse error
+    verify_cmd_response("*1\r\n$4\r\nping\r\n\x04", "+PONG\r\n-ERR unknown command ''\r\n", shutdown=True)

--- a/redis/protocol_parser.rl
+++ b/redis/protocol_parser.rl
@@ -81,7 +81,7 @@ blob := any+ >start_blob $advance_blob;
 command := any+ >start_command $advance_command;
 arg = '$' u32 crlf ${ _arg_size = _u32;};
 
-main := (args_count (arg @{fcall command; } crlf) (arg @{fcall blob; } crlf)+) ${_req._state = request_state::ok;};
+main := (args_count (arg @{fcall command; } crlf) (arg @{fcall blob; } crlf)+) ${_req._state = request_state::ok;} >eof{_req._state = request_state::eof;};
 
 prepush {
     prepush();

--- a/redis/server.cc
+++ b/redis/server.cc
@@ -220,6 +220,9 @@ void redis_server::connection::write_reply(redis_server::result result)
 future<> redis_server::connection::process_request() {
     _parser.init();
     return _read_buf.consume(_parser).then([this] {
+        if (_parser.eof()) {
+            return make_ready_future<>();
+        }
         ++_server._stats._requests_serving;
         _pending_requests_gate.enter();
         utils::latency_counter lc;


### PR DESCRIPTION
    When I test the redis cmd by echo and nc, there is a redundant error in the end.
    I checked by strace, currently if client read nothing from stdin, it will
    shutdown the socket, redis server will read nothing (0 byte) from socket. But
    it tries to process the empty command and returns an error.
    
    $ echo -n -e '*1\r\n$4\r\nping\r\n' |strace nc localhost 6379
    | ...
    |    read(0, "*1\r\n$4\r\nping\r\n", 8192)   = 14
    |    select(5, [4], [4], [], NULL)           = 1 (out [4])
    |>>> sendto(4, "*1\r\n$4\r\nping\r\n", 14, 0, NULL, 0) = 14
    |    select(5, [0 4], [], [], NULL)          = 1 (in [0])
    |    recvfrom(0, 0x7ffe4d5b6c70, 8192, 0, 0x7ffe4d5b6bf0, 0x7ffe4d5b6bec) = -1 ENOTSOCK (Socket operation on non-socket)
    |    read(0, "", 8192)                       = 0
    |>>> shutdown(4, SHUT_WR)                    = 0
    |    select(5, [4], [], [], NULL)            = 1 (in [4])
    |    recvfrom(4, "+PONG\r\n-ERR unknown command ''\r\n", 8192, 0, 0x7ffe4d5b6bf0, [0]) = 32
    |    write(1, "+PONG\r\n-ERR unknown command ''\r\n", 32+PONG
    |    -ERR unknown command ''
    |    ) = 32
    |    select(5, [4], [], [], NULL)            = 1 (in [4])
    |    recvfrom(4, "", 8192, 0, 0x7ffe4d5b6bf0, [0]) = 0
    |    close(1)                                = 0
    |    close(4)                                = 0
    
    Current result:
      $ echo -n -e '' |nc localhost 6379
      -ERR unknown command ''
      $ echo -n -e '*1\r\n$4\r\nping\r\n' |nc localhost 6379
      +PONG
      -ERR unknown command ''
    
    Expected:
      $ echo -n -e '' |nc localhost 6379
      $ echo -n -e '*1\r\n$4\r\nping\r\n' |nc localhost 6379
      +PONG


/CC @fastio 