### PR TITLE
gdb: change 'scylla thread' command to access fs_base register directly

### DIFF
--- a/scylla-gdb.py
+++ b/scylla-gdb.py
@@ -2016,15 +2016,7 @@ class seastar_thread_context(object):
             gdb.execute('set $%s = %s' % (reg, value))
 
     def get_fs_base(self):
-        holder_addr = get_seastar_memory_start_and_size()[0]
-        holder = gdb.Value(holder_addr).reinterpret_cast(self.ulong_type.pointer())
-        saved = holder.dereference()
-        gdb.execute('set *(void**)%s = 0' % holder_addr)
-        if gdb.parse_and_eval('arch_prctl(0x1003, %d)' % holder_addr) != 0:
-            raise Exception('arch_prctl() failed')
-        fs_base = holder.dereference()
-        gdb.execute('set *(void**)%s = %s' % (holder_addr, saved))
-        return fs_base
+        return gdb.parse_and_eval('$fs_base')
 
     def regs_from_jmpbuf(self, jmpbuf):
         canary = gdb.Value(self.get_fs_base()).reinterpret_cast(self.ulong_type.pointer())[6]


### PR DESCRIPTION
Currently, 'scylla thread' uses arch_prctl() to extract the value of
fsbase, used to reference thread local variables. gdb 8 added support
for directly accessing the value as $fs_base, so use that instead. This
works from core dumps as well as live processes, as you don't need to
execute inferior functions.

The patch is required for debugging threads in core dumps, but not
sufficient, as we still need to set $rip and $rsp, and gdb still[1]
doesn't allow this.

[1] https://sourceware.org/bugzilla/show_bug.cgi?id=9370