### PR TITLE
scylla-docker: fix default data_directories in scyllasetup.py

### DIFF
--- a/dist/docker/redhat/scyllasetup.py
+++ b/dist/docker/redhat/scyllasetup.py
@@ -42,6 +42,14 @@ class ScyllaSetup:
     def io(self):
         conf_dir = "/etc/scylla"
         cfg = yaml.safe_load(open(os.path.join(conf_dir, "scylla.yaml")))
+        if 'workdir' not in cfg or not cfg['workdir']:
+            cfg['workdir'] = '/var/lib/scylla'
+        if 'data_file_directories' not in cfg or \
+                not cfg['data_file_directories'] or \
+                not len(cfg['data_file_directories']) or \
+                not " ".join(cfg['data_file_directories']).strip():
+            cfg['data_file_directories'] = [os.path.join(cfg['workdir'], 'data')]
+
         data_dirs = cfg["data_file_directories"]
         if len(data_dirs) > 1:
             logging.warn("%d data directories found. scylla_io_setup currently lacks support for it, and only %s will be evaluated",


### PR DESCRIPTION
Use default data_file_directories if it's not assigned in scylla.yaml

Docker test of scylla master failed, this PR fixed that.
https://jenkins.scylladb.com/job/scylla-master/job/docker-test/label=muninn/82/console

Test: built a new image, and tested locally

/CC @penberg 