### PR TITLE
table: add bypassing cache when generating view updates

### DIFF
--- a/table.cc
+++ b/table.cc
@@ -2531,6 +2531,7 @@ future<row_locker::lock_holder> table::do_push_view_replica_updates(const schema
     opts.set(query::partition_slice::option::send_clustering_key);
     opts.set(query::partition_slice::option::send_timestamp);
     opts.set(query::partition_slice::option::send_ttl);
+    opts.set(query::partition_slice::option::bypass_cache);
     auto slice = query::partition_slice(
             std::move(cr_ranges), { }, std::move(columns), std::move(opts), { }, cql_serialization_format::internal(), query::max_rows);
     // Take the shard-local lock on the base-table row or partition as needed.


### PR DESCRIPTION
Generating view updates can be a source of high read amplification,
since updates may need to perform read-before-write.
After ensuring that readers participating in this read-before-write
process use `bypass_cache`, the read amplification from a test case:

1. Creating an index
  CREATE INDEX index1  ON myks2.standard1 ("C1")
2. Running cassandra-stress in order to generate view updates
cassandra-stress write no-warmup n=1000000 cl=ONE -schema \
  'replication(factor=2) compaction(strategy=LeveledCompactionStrategy)' \
  keyspace=myks2 -pop seq=4000000..8000000 -rate threads=100 -errors
  skip-read-validation -node 127.0.0.1

... dropped to 1.5GB, down from quite astonishing 36GB (sic!)
from before the change.

Fixes #4615