### PR TITLE
sysctl: reduce kernel tendency to swap anonymous pages relative to page cache

### DIFF
--- a/dist/common/sysctl.d/99-scylla-vm.conf
+++ b/dist/common/sysctl.d/99-scylla-vm.conf
@@ -1,0 +1,8 @@
+# Prefer swapping page cache to anonymous memory. Scylla doesn't
+# use page cache, so if there is any significant amount, it's the
+# result of some side process like backup.
+#
+# Reduce swappiness to the bare minimum (0 is too low, as it won't
+# swap anonymous memory any more, which puts the server at the risk
+# of OOM).
+vm.swappiness = 1

--- a/dist/debian/debian/scylla-kernel-conf.postinst
+++ b/dist/debian/debian/scylla-kernel-conf.postinst
@@ -10,6 +10,7 @@ else
     # expect failures in virtualized environments
     sysctl -p/usr/lib/sysctl.d/99-scylla-sched.conf || :
     sysctl -p/usr/lib/sysctl.d/99-scylla-aio.conf || :
+    sysctl -p/usr/lib/sysctl.d/99-scylla-vm.conf || :
 fi
 
 #DEBHELPER#

--- a/dist/redhat/scylla.spec.mustache
+++ b/dist/redhat/scylla.spec.mustache
@@ -215,6 +215,7 @@ if Scylla is the main application on your server and you wish to optimize its la
 # following is a "manual" expansion
 /usr/lib/systemd/systemd-sysctl 99-scylla-sched.conf >/dev/null 2>&1 || :
 /usr/lib/systemd/systemd-sysctl 99-scylla-aio.conf >/dev/null 2>&1 || :
+/usr/lib/systemd/systemd-sysctl 99-scylla-vm.conf >/dev/null 2>&1 || :
 
 %files kernel-conf
 %defattr(-,root,root)


### PR DESCRIPTION
The vm.swappiness sysctl controls the kernel's prefernce for swapping
anonymous memory vs page cache. Since Scylla uses very large amounts
of anonymous memory, and tiny amounts of page cache, the correct setting
is to prefer swapping page cache. If the kernel swaps anonymous memory
the reactor will stall until the page fault is satisfied. On the other
hand, page cache pages usually belong to other applications, usually
backup processes that read Scylla files.

This setting has been used in production in Scylla Cloud for a while
with good results.

Users can opt out by not installing the scylla-kernel-conf package
(same as with the other kernel tunables).