### PR TITLE
scylla_ntp_setup: check redhat variant version by parse_version

### DIFF
--- a/dist/common/scripts/scylla_ntp_setup
+++ b/dist/common/scripts/scylla_ntp_setup
@@ -25,6 +25,9 @@ import sys
 import argparse
 import subprocess
 import re
+
+from pkg_resources import parse_version
+
 from scylla_util import *
 
 if __name__ == '__main__':
@@ -78,7 +81,7 @@ if __name__ == '__main__':
             run('rc-service ntpd start')
 
     if is_redhat_variant():
-        if redhat_version() >= 8:
+        if parse_version(redhat_version()) >= parse_version('8'):
             run('dnf install -y chrony')
             with open('/etc/chrony.conf') as f:
                 conf = f.read()

--- a/dist/common/scripts/scylla_util.py
+++ b/dist/common/scripts/scylla_util.py
@@ -367,7 +367,7 @@ def is_gentoo_variant():
     return ('gentoo' in os_release['ID'])
 
 def redhat_version():
-    return int(os_release['VERSION_ID'])
+    return os_release['VERSION_ID']
 
 def is_ec2():
     if os.path.exists('/sys/hypervisor/uuid'):


### PR DESCRIPTION
VERSION_ID of centos7 is "7", but VERSION_ID of oel7.7 is "7.7"
This patch fixed ValueError: invalid literal for int() with base 10: '7.7' 

Fixes #5433 

/CC @syuu1228 