### PR TITLE
alternator: Implement CONTAINS and NOT_CONTAINS in Expected

### DIFF
--- a/alternator-test/test_expected.py
+++ b/alternator-test/test_expected.py
@@ -524,7 +524,6 @@ def test_update_expected_1_null(test_table_s):
         )
 
 # Tests for Expected with ComparisonOperator = "CONTAINS":
-@pytest.mark.xfail(reason="ComparisonOperator=CONTAINS in Expected not yet implemented")
 def test_update_expected_1_contains(test_table_s):
     # true cases. CONTAINS can be used for two unrelated things: check substrings
     # (in string or binary) and membership (in set or list).

--- a/alternator-test/test_expected.py
+++ b/alternator-test/test_expected.py
@@ -606,7 +606,6 @@ def test_update_expected_1_contains(test_table_s):
         )
 
 # Tests for Expected with ComparisonOperator = "NOT_CONTAINS":
-@pytest.mark.xfail(reason="ComparisonOperator=NOT_CONTAINS in Expected not yet implemented")
 def test_update_expected_1_not_contains(test_table_s):
     # true cases. NOT_CONTAINS can be used for two unrelated things: check substrings
     # (in string or binary) and membership (in set or list).

--- a/alternator/conditions.hh
+++ b/alternator/conditions.hh
@@ -37,7 +37,7 @@
 namespace alternator {
 
 enum class comparison_operator_type {
-    EQ, NE, LE, LT, GE, GT, IN, BETWEEN, CONTAINS, IS_NULL, NOT_NULL, BEGINS_WITH
+    EQ, NE, LE, LT, GE, GT, IN, BETWEEN, CONTAINS, NOT_CONTAINS, IS_NULL, NOT_NULL, BEGINS_WITH
 };
 
 comparison_operator_type get_comparison_operator(const rjson::value& comparison_operator);


### PR DESCRIPTION
Add the last missing operators and re-enable their tests.

Fixes #5034.