### PR TITLE
Remove default values for reader forwarding

### DIFF
--- a/database.hh
+++ b/database.hh
@@ -673,22 +673,26 @@ public:
     flat_mutation_reader make_reader(schema_ptr schema,
             const dht::partition_range& range,
             const query::partition_slice& slice,
-            const io_priority_class& pc = default_priority_class(),
-            tracing::trace_state_ptr trace_state = nullptr,
-            streamed_mutation::forwarding fwd = streamed_mutation::forwarding::no,
-            mutation_reader::forwarding fwd_mr = mutation_reader::forwarding::yes) const;
+            const io_priority_class& pc,
+            tracing::trace_state_ptr trace_state,
+            streamed_mutation::forwarding fwd,
+            mutation_reader::forwarding fwd_mr) const;
     flat_mutation_reader make_reader_excluding_sstable(schema_ptr schema,
             sstables::shared_sstable sst,
             const dht::partition_range& range,
             const query::partition_slice& slice,
-            const io_priority_class& pc = default_priority_class(),
-            tracing::trace_state_ptr trace_state = nullptr,
-            streamed_mutation::forwarding fwd = streamed_mutation::forwarding::no,
-            mutation_reader::forwarding fwd_mr = mutation_reader::forwarding::yes) const;
+            const io_priority_class& pc,
+            tracing::trace_state_ptr trace_state,
+            streamed_mutation::forwarding fwd,
+            mutation_reader::forwarding fwd_mr) const;
 
-    flat_mutation_reader make_reader(schema_ptr schema, const dht::partition_range& range = query::full_partition_range) const {
+    flat_mutation_reader make_reader_for_tests(schema_ptr schema, const dht::partition_range& range, const query::partition_slice& slice) const {
+        return make_reader(std::move(schema), range, slice, default_priority_class(), nullptr, streamed_mutation::forwarding::no, mutation_reader::forwarding::yes);
+    }
+
+    flat_mutation_reader make_reader_for_tests(schema_ptr schema, const dht::partition_range& range = query::full_partition_range) const {
         auto& full_slice = schema->full_slice();
-        return make_reader(std::move(schema), range, full_slice);
+        return make_reader_for_tests(std::move(schema), range, full_slice);
     }
 
     // The streaming mutation reader differs from the regular mutation reader in that:
@@ -702,10 +706,10 @@ public:
     // Single range overload.
     flat_mutation_reader make_streaming_reader(schema_ptr schema, const dht::partition_range& range,
             const query::partition_slice& slice,
-            mutation_reader::forwarding fwd_mr = mutation_reader::forwarding::no) const;
+            mutation_reader::forwarding fwd_mr) const;
 
     flat_mutation_reader make_streaming_reader(schema_ptr schema, const dht::partition_range& range) {
-        return make_streaming_reader(schema, range, schema->full_slice());
+        return make_streaming_reader(schema, range, schema->full_slice(), mutation_reader::forwarding::no);
     }
 
     sstables::shared_sstable make_streaming_sstable_for_write(std::optional<sstring> subdir = {});

--- a/memtable.cc
+++ b/memtable.cc
@@ -697,7 +697,8 @@ memtable::update(db::rp_handle&& h) {
 
 future<>
 memtable::apply(memtable& mt) {
-    return do_with(mt.make_flat_reader(_schema), [this] (auto&& rd) mutable {
+    return do_with(mt.make_flat_reader(_schema, query::full_partition_range, _schema->full_slice(),
+            default_priority_class(), nullptr, streamed_mutation::forwarding::no, mutation_reader::forwarding::yes), [this] (auto&& rd) mutable {
         return consume_partitions(rd, [self = this->shared_from_this(), &rd] (mutation&& m) {
             self->apply(m);
             return stop_iteration::no;

--- a/memtable.hh
+++ b/memtable.hh
@@ -250,15 +250,21 @@ public:
     flat_mutation_reader make_flat_reader(schema_ptr,
                                           const dht::partition_range& range,
                                           const query::partition_slice& slice,
-                                          const io_priority_class& pc = default_priority_class(),
-                                          tracing::trace_state_ptr trace_state_ptr = nullptr,
-                                          streamed_mutation::forwarding fwd = streamed_mutation::forwarding::no,
-                                          mutation_reader::forwarding fwd_mr = mutation_reader::forwarding::yes);
+                                          const io_priority_class& pc,
+                                          tracing::trace_state_ptr trace_state_ptr,
+                                          streamed_mutation::forwarding fwd,
+                                          mutation_reader::forwarding fwd_mr);
 
-    flat_mutation_reader make_flat_reader(schema_ptr s,
+    flat_mutation_reader make_flat_reader_for_tests(schema_ptr s,
+                                          const dht::partition_range& range,
+                                          const query::partition_slice& slice) {
+        return make_flat_reader(s, range, slice, default_priority_class(), nullptr, streamed_mutation::forwarding::no, mutation_reader::forwarding::yes);
+    }
+
+    flat_mutation_reader make_flat_reader_for_tests(schema_ptr s,
                                           const dht::partition_range& range = query::full_partition_range) {
         auto& full_slice = s->full_slice();
-        return make_flat_reader(s, range, full_slice);
+        return make_flat_reader_for_tests(s, range, full_slice);
     }
 
     flat_mutation_reader make_flush_reader(schema_ptr, const io_priority_class& pc);

--- a/multishard_mutation_query.cc
+++ b/multishard_mutation_query.cc
@@ -264,7 +264,7 @@ flat_mutation_reader read_context::create_reader(
         const query::partition_slice& ps,
         const io_priority_class& pc,
         tracing::trace_state_ptr trace_state,
-        mutation_reader::forwarding) {
+        mutation_reader::forwarding fwd_mr) {
     const auto shard = engine().cpu_id();
     auto& rm = _readers[shard];
 
@@ -295,7 +295,7 @@ flat_mutation_reader read_context::create_reader(
     rm.rparts->read_operation = table.read_in_progress();
     rm.state = reader_state::used;
 
-    return table.as_mutation_source().make_reader(std::move(schema), *rm.rparts->range, *rm.rparts->slice, pc, std::move(trace_state));
+    return table.as_mutation_source().make_reader(std::move(schema), *rm.rparts->range, *rm.rparts->slice, pc, std::move(trace_state), streamed_mutation::forwarding::no, fwd_mr);
 }
 
 void read_context::destroy_reader(shard_id shard, future<stopped_reader> reader_fut) noexcept {

--- a/mutation_reader.cc
+++ b/mutation_reader.cc
@@ -811,9 +811,9 @@ mutation_source make_combined_mutation_source(std::vector<mutation_source> adden
         std::vector<flat_mutation_reader> rd;
         rd.reserve(addends.size());
         for (auto&& ms : addends) {
-            rd.emplace_back(ms.make_reader(s, pr, slice, pc, tr, fwd));
+            rd.emplace_back(ms.make_reader(s, pr, slice, pc, tr, fwd, mutation_reader::forwarding::yes));
         }
-        return make_combined_reader(s, std::move(rd), fwd);
+        return make_combined_reader(s, std::move(rd), fwd, mutation_reader::forwarding::yes);
     });
 }
 

--- a/row_cache.cc
+++ b/row_cache.cc
@@ -47,7 +47,7 @@ using namespace cache;
 flat_mutation_reader
 row_cache::create_underlying_reader(read_context& ctx, mutation_source& src, const dht::partition_range& pr) {
     ctx.on_underlying_created();
-    return src.make_reader(_schema, pr, ctx.slice(), ctx.pc(), ctx.trace_state(), streamed_mutation::forwarding::yes);
+    return src.make_reader(_schema, pr, ctx.slice(), ctx.pc(), ctx.trace_state(), streamed_mutation::forwarding::yes, mutation_reader::forwarding::yes);
 }
 
 static thread_local mutation_application_stats dummy_app_stats;

--- a/row_cache.hh
+++ b/row_cache.hh
@@ -493,14 +493,18 @@ public:
     flat_mutation_reader make_reader(schema_ptr,
                                      const dht::partition_range&,
                                      const query::partition_slice&,
-                                     const io_priority_class& = default_priority_class(),
-                                     tracing::trace_state_ptr trace_state = nullptr,
-                                     streamed_mutation::forwarding fwd = streamed_mutation::forwarding::no,
-                                     mutation_reader::forwarding fwd_mr = mutation_reader::forwarding::no);
+                                     const io_priority_class&,
+                                     tracing::trace_state_ptr trace_state,
+                                     streamed_mutation::forwarding fwd,
+                                     mutation_reader::forwarding fwd_mr);
 
-    flat_mutation_reader make_reader(schema_ptr s, const dht::partition_range& range = query::full_partition_range) {
+    flat_mutation_reader make_reader_for_tests(schema_ptr s, const dht::partition_range& range, const query::partition_slice& slice) {
+        return make_reader(std::move(s), range, slice, default_priority_class(), nullptr, streamed_mutation::forwarding::no, mutation_reader::forwarding::no);
+    }
+
+    flat_mutation_reader make_reader_for_tests(schema_ptr s, const dht::partition_range& range = query::full_partition_range) {
         auto& full_slice = s->full_slice();
-        return make_reader(std::move(s), range, full_slice);
+        return make_reader_for_tests(std::move(s), range, full_slice);
     }
 
     const stats& stats() const { return _stats; }

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -224,16 +224,23 @@ public:
         schema_ptr schema,
         const dht::partition_range& range,
         const query::partition_slice& slice,
-        const io_priority_class& pc = default_priority_class(),
-        reader_resource_tracker resource_tracker = no_resource_tracking(),
-        tracing::trace_state_ptr trace_state = {},
-        streamed_mutation::forwarding fwd = streamed_mutation::forwarding::no,
-        mutation_reader::forwarding fwd_mr = mutation_reader::forwarding::yes,
+        const io_priority_class& pc,
+        reader_resource_tracker resource_tracker,
+        tracing::trace_state_ptr trace_state,
+        streamed_mutation::forwarding fwd,
+        mutation_reader::forwarding fwd_mr,
         read_monitor& monitor = default_read_monitor());
 
-    flat_mutation_reader read_range_rows_flat(schema_ptr schema, const dht::partition_range& range) {
+    flat_mutation_reader read_range_rows_flat_for_tests(
+        schema_ptr schema,
+        const dht::partition_range& range,
+        const query::partition_slice& slice) {
+        return read_range_rows_flat(std::move(schema), range, slice, default_priority_class(), no_resource_tracking(), nullptr, streamed_mutation::forwarding::no, mutation_reader::forwarding::yes);
+    }
+
+    flat_mutation_reader read_range_rows_flat_for_tests(schema_ptr schema, const dht::partition_range& range) {
         auto& full_slice = schema->full_slice();
-        return read_range_rows_flat(std::move(schema), range, full_slice);
+        return read_range_rows_flat_for_tests(std::move(schema), range, full_slice);
     }
 
     // read_rows_flat() returns each of the rows in the sstable, in sequence,

--- a/table.cc
+++ b/table.cc
@@ -399,7 +399,7 @@ table::make_sstable_reader(schema_ptr s,
 future<table::const_mutation_partition_ptr>
 table::find_partition(schema_ptr s, const dht::decorated_key& key) const {
     return do_with(dht::partition_range::make_singular(key), [s = std::move(s), this] (auto& range) {
-        return do_with(this->make_reader(s, range), [s] (flat_mutation_reader& reader) {
+        return do_with(this->make_reader_for_tests(s, range), [s] (flat_mutation_reader& reader) {
             return read_mutation_from_flat_mutation_reader(reader, db::no_timeout).then([] (mutation_opt&& mo) -> std::unique_ptr<const mutation_partition> {
                 if (!mo) {
                     return {};
@@ -545,7 +545,7 @@ table::for_all_partitions_slow(schema_ptr s, std::function<bool (const dht::deco
     public:
         bool done() const { return !ok || empty; }
         iteration_state(schema_ptr s, const column_family& cf, std::function<bool (const dht::decorated_key&, const mutation_partition&)>&& func)
-            : reader(cf.make_reader(std::move(s)))
+            : reader(cf.make_reader_for_tests(std::move(s)))
             , func(std::move(func))
         { }
     };

--- a/tests/cache_flat_mutation_reader_test.cc
+++ b/tests/cache_flat_mutation_reader_test.cc
@@ -230,7 +230,7 @@ void test_slice_single_version(mutation& underlying,
 
     try {
         auto range = dht::partition_range::make_singular(DK);
-        auto reader = cache.make_reader(SCHEMA, range, slice);
+        auto reader = cache.make_reader_for_tests(SCHEMA, range, slice);
 
         check_produces_only(DK, std::move(reader), expected_sm_fragments, slice.row_ranges(*SCHEMA, DK.key()));
 

--- a/tests/memtable_snapshot_source.hh
+++ b/tests/memtable_snapshot_source.hh
@@ -74,7 +74,7 @@ private:
                  mutation_reader::forwarding::yes));
         }
         _memtables.push_back(new_memtable());
-        auto&& rd = make_combined_reader(new_mt->schema(), std::move(readers));
+        auto&& rd = make_combined_reader(new_mt->schema(), std::move(readers), streamed_mutation::forwarding::no, mutation_reader::forwarding::yes);
         consume_partitions(rd, [&] (mutation&& m) {
             new_mt->apply(std::move(m));
             return stop_iteration::no;

--- a/tests/memtable_test.cc
+++ b/tests/memtable_test.cc
@@ -95,7 +95,7 @@ SEASTAR_TEST_CASE(test_memtable_with_many_versions_conforms_to_mutation_source) 
             for (auto&& m : muts) {
                 mt->apply(m);
                 // Create reader so that each mutation is in a separate version
-                flat_mutation_reader rd = mt->make_flat_reader(s, ranges_storage.emplace_back(dht::partition_range::make_singular(m.decorated_key())));
+                flat_mutation_reader rd = mt->make_flat_reader_for_tests(s, ranges_storage.emplace_back(dht::partition_range::make_singular(m.decorated_key())));
                 rd.set_max_buffer_size(1);
                 rd.fill_buffer(db::no_timeout).get();
                 readers.push_back(std::move(rd));
@@ -198,8 +198,8 @@ SEASTAR_TEST_CASE(test_adding_a_column_during_reading_doesnt_affect_read_result)
             mt->apply(m);
         }
 
-        auto check_rd_s1 = assert_that(mt->make_flat_reader(s1));
-        auto check_rd_s2 = assert_that(mt->make_flat_reader(s2));
+        auto check_rd_s1 = assert_that(mt->make_flat_reader_for_tests(s1));
+        auto check_rd_s2 = assert_that(mt->make_flat_reader_for_tests(s2));
         check_rd_s1.next_mutation().has_schema(s1).is_equal_to(ring[0]);
         check_rd_s2.next_mutation().has_schema(s2).is_equal_to(ring[0]);
         mt->set_schema(s2);
@@ -210,13 +210,13 @@ SEASTAR_TEST_CASE(test_adding_a_column_during_reading_doesnt_affect_read_result)
         check_rd_s1.produces_end_of_stream();
         check_rd_s2.produces_end_of_stream();
 
-        assert_that(mt->make_flat_reader(s1))
+        assert_that(mt->make_flat_reader_for_tests(s1))
             .produces(ring[0])
             .produces(ring[1])
             .produces(ring[2])
             .produces_end_of_stream();
 
-        assert_that(mt->make_flat_reader(s2))
+        assert_that(mt->make_flat_reader_for_tests(s2))
             .produces(ring[0])
             .produces(ring[1])
             .produces(ring[2])
@@ -248,7 +248,7 @@ SEASTAR_TEST_CASE(test_virtual_dirty_accounting_on_flush) {
         }
 
         // Create a reader which will cause many partition versions to be created
-        flat_mutation_reader_opt rd1 = mt->make_flat_reader(s);
+        flat_mutation_reader_opt rd1 = mt->make_flat_reader_for_tests(s);
         rd1->set_max_buffer_size(1);
         rd1->fill_buffer(db::no_timeout).get();
 
@@ -311,29 +311,29 @@ SEASTAR_TEST_CASE(test_partition_version_consistency_after_lsa_compaction_happen
         m3.set_clustered_cell(ck3, to_bytes("col"), data_value(bytes(bytes::initialized_later(), 8)), next_timestamp());
 
         mt->apply(m1);
-        std::optional<flat_reader_assertions> rd1 = assert_that(mt->make_flat_reader(s));
+        std::optional<flat_reader_assertions> rd1 = assert_that(mt->make_flat_reader_for_tests(s));
         rd1->set_max_buffer_size(1);
         rd1->fill_buffer().get();
 
         mt->apply(m2);
-        std::optional<flat_reader_assertions> rd2 = assert_that(mt->make_flat_reader(s));
+        std::optional<flat_reader_assertions> rd2 = assert_that(mt->make_flat_reader_for_tests(s));
         rd2->set_max_buffer_size(1);
         rd2->fill_buffer().get();
 
         mt->apply(m3);
-        std::optional<flat_reader_assertions> rd3 = assert_that(mt->make_flat_reader(s));
+        std::optional<flat_reader_assertions> rd3 = assert_that(mt->make_flat_reader_for_tests(s));
         rd3->set_max_buffer_size(1);
         rd3->fill_buffer().get();
 
         logalloc::shard_tracker().full_compaction();
 
-        auto rd4 = assert_that(mt->make_flat_reader(s));
+        auto rd4 = assert_that(mt->make_flat_reader_for_tests(s));
         rd4.set_max_buffer_size(1);
         rd4.fill_buffer().get();
-        auto rd5 = assert_that(mt->make_flat_reader(s));
+        auto rd5 = assert_that(mt->make_flat_reader_for_tests(s));
         rd5.set_max_buffer_size(1);
         rd5.fill_buffer().get();
-        auto rd6 = assert_that(mt->make_flat_reader(s));
+        auto rd6 = assert_that(mt->make_flat_reader_for_tests(s));
         rd6.set_max_buffer_size(1);
         rd6.fill_buffer().get();
 
@@ -420,7 +420,7 @@ SEASTAR_TEST_CASE(test_fast_forward_to_after_memtable_is_flushed) {
             mt2->apply(m);
         }
 
-        auto rd = assert_that(mt->make_flat_reader(s));
+        auto rd = assert_that(mt->make_flat_reader_for_tests(s));
         rd.produces(ring[0]);
         mt->mark_flushed(mt2->as_data_source());
         rd.produces(ring[1]);
@@ -446,7 +446,7 @@ SEASTAR_TEST_CASE(test_exception_safety_of_partition_range_reads) {
         do {
             try {
                 injector.fail_after(i++);
-                assert_that(mt->make_flat_reader(s, query::full_partition_range))
+                assert_that(mt->make_flat_reader_for_tests(s, query::full_partition_range))
                     .produces(ms);
                 injector.cancel();
             } catch (const std::bad_alloc&) {
@@ -499,7 +499,7 @@ SEASTAR_TEST_CASE(test_exception_safety_of_single_partition_reads) {
         do {
             try {
                 injector.fail_after(i++);
-                assert_that(mt->make_flat_reader(s, dht::partition_range::make_singular(ms[1].decorated_key())))
+                assert_that(mt->make_flat_reader_for_tests(s, dht::partition_range::make_singular(ms[1].decorated_key())))
                     .produces(ms[1]);
                 injector.cancel();
             } catch (const std::bad_alloc&) {
@@ -523,7 +523,7 @@ SEASTAR_TEST_CASE(test_hash_is_cached) {
         mt->apply(m);
 
         {
-            auto rd = mt->make_flat_reader(s);
+            auto rd = mt->make_flat_reader_for_tests(s);
             rd(db::no_timeout).get0()->as_partition_start();
             clustering_row row = std::move(rd(db::no_timeout).get0()->as_mutable_clustering_row());
             BOOST_REQUIRE(!row.cells().cell_hash_for(0));
@@ -532,14 +532,14 @@ SEASTAR_TEST_CASE(test_hash_is_cached) {
         {
             auto slice = s->full_slice();
             slice.options.set<query::partition_slice::option::with_digest>();
-            auto rd = mt->make_flat_reader(s, query::full_partition_range, slice);
+            auto rd = mt->make_flat_reader_for_tests(s, query::full_partition_range, slice);
             rd(db::no_timeout).get0()->as_partition_start();
             clustering_row row = std::move(rd(db::no_timeout).get0()->as_mutable_clustering_row());
             BOOST_REQUIRE(row.cells().cell_hash_for(0));
         }
 
         {
-            auto rd = mt->make_flat_reader(s);
+            auto rd = mt->make_flat_reader_for_tests(s);
             rd(db::no_timeout).get0()->as_partition_start();
             clustering_row row = std::move(rd(db::no_timeout).get0()->as_mutable_clustering_row());
             BOOST_REQUIRE(row.cells().cell_hash_for(0));
@@ -549,7 +549,7 @@ SEASTAR_TEST_CASE(test_hash_is_cached) {
         mt->apply(m);
 
         {
-            auto rd = mt->make_flat_reader(s);
+            auto rd = mt->make_flat_reader_for_tests(s);
             rd(db::no_timeout).get0()->as_partition_start();
             clustering_row row = std::move(rd(db::no_timeout).get0()->as_mutable_clustering_row());
             BOOST_REQUIRE(!row.cells().cell_hash_for(0));
@@ -558,14 +558,14 @@ SEASTAR_TEST_CASE(test_hash_is_cached) {
         {
             auto slice = s->full_slice();
             slice.options.set<query::partition_slice::option::with_digest>();
-            auto rd = mt->make_flat_reader(s, query::full_partition_range, slice);
+            auto rd = mt->make_flat_reader_for_tests(s, query::full_partition_range, slice);
             rd(db::no_timeout).get0()->as_partition_start();
             clustering_row row = std::move(rd(db::no_timeout).get0()->as_mutable_clustering_row());
             BOOST_REQUIRE(row.cells().cell_hash_for(0));
         }
 
         {
-            auto rd = mt->make_flat_reader(s);
+            auto rd = mt->make_flat_reader_for_tests(s);
             rd(db::no_timeout).get0()->as_partition_start();
             clustering_row row = std::move(rd(db::no_timeout).get0()->as_mutable_clustering_row());
             BOOST_REQUIRE(row.cells().cell_hash_for(0));

--- a/tests/perf/perf_fast_forward.cc
+++ b/tests/perf/perf_fast_forward.cc
@@ -751,7 +751,8 @@ static test_result scan_rows_with_stride(column_family& cf, int n_rows, int n_re
         cf.schema()->full_slice(),
         default_priority_class(),
         nullptr,
-        n_skip ? streamed_mutation::forwarding::yes : streamed_mutation::forwarding::no);
+        n_skip ? streamed_mutation::forwarding::yes : streamed_mutation::forwarding::no,
+        mutation_reader::forwarding::yes);
 
     metrics_snapshot before;
     assert_partition_start(rd);
@@ -791,7 +792,7 @@ static test_result scan_with_stride_partitions(column_family& cf, int n, int n_r
     int pk = 0;
     auto pr = n_skip ? dht::partition_range::make_ending_with(dht::partition_range::bound(keys[0], false)) // covering none
                      : query::full_partition_range;
-    auto rd = cf.make_reader(cf.schema(), pr, cf.schema()->full_slice());
+    auto rd = cf.make_reader_for_tests(cf.schema(), pr, cf.schema()->full_slice());
 
     metrics_snapshot before;
 
@@ -817,7 +818,8 @@ static test_result slice_rows(column_family& cf, int offset = 0, int n_read = 1)
         cf.schema()->full_slice(),
         default_priority_class(),
         nullptr,
-        streamed_mutation::forwarding::yes);
+        streamed_mutation::forwarding::yes,
+        mutation_reader::forwarding::yes);
 
     metrics_snapshot before;
     assert_partition_start(rd);
@@ -842,7 +844,7 @@ static test_result slice_rows_by_ck(column_family& cf, int offset = 0, int n_rea
             clustering_key::from_singular(*cf.schema(), offset + n_read - 1)))
         .build();
     auto pr = dht::partition_range::make_singular(make_pkey(*cf.schema(), 0));
-    auto rd = cf.make_reader(cf.schema(), pr, slice);
+    auto rd = cf.make_reader_for_tests(cf.schema(), pr, slice);
     return test_reading_all(rd);
 }
 
@@ -853,7 +855,7 @@ static test_result select_spread_rows(column_family& cf, int stride = 0, int n_r
     }
 
     auto slice = sb.build();
-    auto rd = cf.make_reader(cf.schema(),
+    auto rd = cf.make_reader_for_tests(cf.schema(),
         query::full_partition_range,
         slice);
 
@@ -893,7 +895,7 @@ static test_result slice_partitions(column_family& cf, const std::vector<dht::de
         dht::partition_range::bound(keys[std::min<size_t>(keys.size(), offset + n_read) - 1], true)
     );
 
-    auto rd = cf.make_reader(cf.schema(), pr, cf.schema()->full_slice());
+    auto rd = cf.make_reader_for_tests(cf.schema(), pr, cf.schema()->full_slice());
     metrics_snapshot before;
 
     uint64_t fragments = consume_all_with_next_partition(rd);
@@ -1000,7 +1002,8 @@ static test_result test_forwarding_with_restriction(column_family& cf, clustered
         slice,
         default_priority_class(),
         nullptr,
-        streamed_mutation::forwarding::yes, mutation_reader::forwarding::no);
+        streamed_mutation::forwarding::yes,
+        mutation_reader::forwarding::no);
 
     uint64_t fragments = 0;
     metrics_snapshot before;

--- a/tests/perf/perf_mutation_readers.cc
+++ b/tests/perf/perf_mutation_readers.cc
@@ -159,7 +159,7 @@ PERF_TEST_F(combined, one_row)
 {
     std::vector<flat_mutation_reader> mrs;
     mrs.emplace_back(flat_mutation_reader_from_mutations(one_row_stream()));
-    return consume_all(make_combined_reader(schema().schema(), std::move(mrs)));
+    return consume_all(make_combined_reader_for_tests(schema().schema(), std::move(mrs)));
 }
 
 PERF_TEST_F(combined, single_active)
@@ -170,7 +170,7 @@ PERF_TEST_F(combined, single_active)
     for (auto i = 0; i < 3; i++) {
         mrs.emplace_back(make_empty_flat_reader(schema().schema()));
     }
-    return consume_all(make_combined_reader(schema().schema(), std::move(mrs)));
+    return consume_all(make_combined_reader_for_tests(schema().schema(), std::move(mrs)));
 }
 
 PERF_TEST_F(combined, many_overlapping)
@@ -180,12 +180,12 @@ PERF_TEST_F(combined, many_overlapping)
     for (auto i = 0; i < 4; i++) {
         mrs.emplace_back(flat_mutation_reader_from_mutations(single_stream()));
     }
-    return consume_all(make_combined_reader(schema().schema(), std::move(mrs)));
+    return consume_all(make_combined_reader_for_tests(schema().schema(), std::move(mrs)));
 }
 
 PERF_TEST_F(combined, disjoint_interleaved)
 {
-    return consume_all(make_combined_reader(schema().schema(),
+    return consume_all(make_combined_reader_for_tests(schema().schema(),
         boost::copy_range<std::vector<flat_mutation_reader>>(
             disjoint_interleaved_streams()
             | boost::adaptors::transformed([] (auto&& ms) {
@@ -197,7 +197,7 @@ PERF_TEST_F(combined, disjoint_interleaved)
 
 PERF_TEST_F(combined, disjoint_ranges)
 {
-    return consume_all(make_combined_reader(schema().schema(),
+    return consume_all(make_combined_reader_for_tests(schema().schema(),
         boost::copy_range<std::vector<flat_mutation_reader>>(
             disjoint_ranges_streams()
             | boost::adaptors::transformed([] (auto&& ms) {
@@ -209,7 +209,7 @@ PERF_TEST_F(combined, disjoint_ranges)
 
 PERF_TEST_F(combined, overlapping_partitions_disjoint_rows)
 {
-    return consume_all(make_combined_reader(schema().schema(),
+    return consume_all(make_combined_reader_for_tests(schema().schema(),
         boost::copy_range<std::vector<flat_mutation_reader>>(
             overlapping_partitions_disjoint_rows_streams()
             | boost::adaptors::transformed([] (auto&& ms) {
@@ -291,22 +291,22 @@ protected:
 
 PERF_TEST_F(memtable, one_partition_one_row)
 {
-    return consume_all(single_row_mt().make_flat_reader(schema(), single_partition_range()));
+    return consume_all(single_row_mt().make_flat_reader_for_tests(schema(), single_partition_range()));
 }
 
 PERF_TEST_F(memtable, one_partition_many_rows)
 {
-    return consume_all(multi_row_mt().make_flat_reader(schema(), single_partition_range()));
+    return consume_all(multi_row_mt().make_flat_reader_for_tests(schema(), single_partition_range()));
 }
 
 PERF_TEST_F(memtable, many_partitions_one_row)
 {
-    return consume_all(single_row_mt().make_flat_reader(schema(), multi_partition_range(25)));
+    return consume_all(single_row_mt().make_flat_reader_for_tests(schema(), multi_partition_range(25)));
 }
 
 PERF_TEST_F(memtable, many_partitions_many_rows)
 {
-    return consume_all(multi_row_mt().make_flat_reader(schema(), multi_partition_range(25)));
+    return consume_all(multi_row_mt().make_flat_reader_for_tests(schema(), multi_partition_range(25)));
 }
 
 }

--- a/tests/perf_row_cache_update.cc
+++ b/tests/perf_row_cache_update.cc
@@ -151,7 +151,7 @@ void run_test(const sstring& name, schema_ptr s, MutationGenerator&& gen) {
         // Create a reader which tests the case of memtable snapshots
         // going away after memtable was merged to cache.
         auto rd = std::make_unique<flat_mutation_reader>(
-            make_combined_reader(s, cache.make_reader(s), mt->make_flat_reader(s)));
+            make_combined_reader(s, cache.make_reader_for_tests(s), mt->make_flat_reader_for_tests(s), streamed_mutation::forwarding::no, mutation_reader::forwarding::yes));
         rd->set_max_buffer_size(1);
         rd->fill_buffer(db::no_timeout).get();
 

--- a/tests/row_cache_alloc_stress.cc
+++ b/tests/row_cache_alloc_stress.cc
@@ -184,7 +184,7 @@ int main(int argc, char** argv) {
             // Verify that all mutations from memtable went through
             for (auto&& key : keys) {
                 auto range = dht::partition_range::make_singular(key);
-                auto reader = cache.make_reader(s, range);
+                auto reader = cache.make_reader_for_tests(s, range);
                 auto mo = read_mutation_from_flat_mutation_reader(reader, db::no_timeout).get0();
                 assert(mo);
                 assert(mo->partition().live_row_count(*s) ==
@@ -201,7 +201,7 @@ int main(int argc, char** argv) {
 
             for (auto&& key : keys) {
                 auto range = dht::partition_range::make_singular(key);
-                auto reader = cache.make_reader(s, range);
+                auto reader = cache.make_reader_for_tests(s, range);
                 auto mfopt = reader(db::no_timeout).get0();
                 assert(mfopt);
                 assert(mfopt->is_partition_start());
@@ -239,7 +239,7 @@ int main(int argc, char** argv) {
                 }
 
                 try {
-                    auto reader = cache.make_reader(s, range);
+                    auto reader = cache.make_reader_for_tests(s, range);
                     assert(!reader(db::no_timeout).get0());
                     auto evicted_from_cache = logalloc::segment_size + large_cell_size;
                     new char[evicted_from_cache + logalloc::segment_size];

--- a/tests/row_cache_stress_test.cc
+++ b/tests/row_cache_stress_test.cc
@@ -156,7 +156,7 @@ struct table {
             streamed_mutation::forwarding::no, mutation_reader::forwarding::no));
         rd.push_back(cache.make_reader(s.schema(), r->pr, r->slice, default_priority_class(), nullptr,
             streamed_mutation::forwarding::no, mutation_reader::forwarding::no));
-        r->rd = make_combined_reader(s.schema(), std::move(rd), streamed_mutation::forwarding::no, mutation_reader::forwarding::no);
+        r->rd = make_combined_reader_for_tests(s.schema(), std::move(rd), streamed_mutation::forwarding::no, mutation_reader::forwarding::no);
         return r;
     }
 

--- a/tests/sstable_datafile_test.cc
+++ b/tests/sstable_datafile_test.cc
@@ -1008,19 +1008,19 @@ static future<std::vector<sstables::shared_sstable>> open_sstables(test_env& env
 
 // mutation_reader for sstable keeping all the required objects alive.
 static flat_mutation_reader sstable_reader(shared_sstable sst, schema_ptr s) {
-    return sst->as_mutation_source().make_reader(s, query::full_partition_range, s->full_slice());
+    return sst->as_mutation_source().make_reader_for_tests(s, query::full_partition_range, s->full_slice());
 
 }
 
 static flat_mutation_reader sstable_reader(shared_sstable sst, schema_ptr s, const dht::partition_range& pr) {
-    return sst->as_mutation_source().make_reader(s, pr, s->full_slice());
+    return sst->as_mutation_source().make_reader_for_tests(s, pr, s->full_slice());
 }
 
 // We don't need to normalize the sstable reader for 'mc' format
 // because it is naturally normalized now.
 static flat_mutation_reader make_normalizing_sstable_reader(
         shared_sstable sst, schema_ptr s, const dht::partition_range& pr) {
-    auto sstable_reader = sst->as_mutation_source().make_reader(s, pr, s->full_slice());
+    auto sstable_reader = sst->as_mutation_source().make_reader_for_tests(s, pr, s->full_slice());
     if (sst->get_version() == sstables::sstable::version_types::mc) {
         return sstable_reader;
     }
@@ -2546,7 +2546,7 @@ SEASTAR_TEST_CASE(sstable_rewrite) {
 void test_sliced_read_row_presence(shared_sstable sst, schema_ptr s, const query::partition_slice& ps,
     std::vector<std::pair<partition_key, std::vector<clustering_key>>> expected)
 {
-    auto reader = sst->as_mutation_source().make_reader(s, query::full_partition_range, ps);
+    auto reader = sst->as_mutation_source().make_reader_for_tests(s, query::full_partition_range, ps);
 
     partition_key::equality pk_eq(*s);
     clustering_key::equality ck_eq(*s);
@@ -3698,7 +3698,7 @@ SEASTAR_TEST_CASE(test_repeated_tombstone_skipping) {
                 .with_range(query::clustering_range::make_singular(ck2))
                 .with_range(query::clustering_range::make_singular(ck3))
                 .build();
-            flat_mutation_reader rd = ms.make_reader(table.schema(), query::full_partition_range, slice);
+            flat_mutation_reader rd = ms.make_reader_for_tests(table.schema(), query::full_partition_range, slice);
             assert_that(std::move(rd)).has_monotonic_positions();
         }
       }
@@ -4260,7 +4260,7 @@ SEASTAR_TEST_CASE(test_summary_entry_spanning_more_keys_than_min_interval) {
 
         std::set<mutation, mutation_decorated_key_less_comparator> merged;
         merged.insert(mutations.begin(), mutations.end());
-        auto rd = assert_that(sst->as_mutation_source().make_reader(s, query::full_partition_range));
+        auto rd = assert_that(sst->as_mutation_source().make_reader_for_tests(s, query::full_partition_range));
         auto keys_read = 0;
         for (auto&& m : merged) {
             keys_read++;
@@ -4270,7 +4270,7 @@ SEASTAR_TEST_CASE(test_summary_entry_spanning_more_keys_than_min_interval) {
         BOOST_REQUIRE(keys_read == keys_written);
 
         auto r = dht::partition_range::make({mutations.back().decorated_key(), true}, {mutations.back().decorated_key(), true});
-        assert_that(sst->as_mutation_source().make_reader(s, r))
+        assert_that(sst->as_mutation_source().make_reader_for_tests(s, r))
             .produces(slice(mutations, r))
             .produces_end_of_stream();
     });
@@ -4532,7 +4532,7 @@ SEASTAR_TEST_CASE(test_old_format_non_compound_range_tombstone_is_read) {
 
                 {
                     auto slice = partition_slice_builder(*s).with_range(query::clustering_range::make_singular({ck})).build();
-                    assert_that(sst->as_mutation_source().make_reader(s, dht::partition_range::make_singular(dk), slice))
+                    assert_that(sst->as_mutation_source().make_reader_for_tests(s, dht::partition_range::make_singular(dk), slice))
                             .produces(m)
                             .produces_end_of_stream();
                 }
@@ -4940,7 +4940,7 @@ SEASTAR_TEST_CASE(test_reads_cassandra_static_compact) {
         m.set_clustered_cell(clustering_key::make_empty(), *s->get_column_definition("c2"),
                     atomic_cell::make_live(*utf8_type, 1551785032379079, utf8_type->decompose("cde"), {}));
 
-        assert_that(sst->as_mutation_source().make_reader(s))
+        assert_that(sst->as_mutation_source().make_reader_for_tests(s))
             .produces(m)
             .produces_end_of_stream();
     });

--- a/tests/sstable_resharding_test.cc
+++ b/tests/sstable_resharding_test.cc
@@ -132,7 +132,7 @@ void run_sstable_resharding_test() {
         auto shard = shards.front();
         BOOST_REQUIRE(column_family_test::calculate_shard_from_sstable_generation(new_sst->generation()) == shard);
 
-        auto rd = assert_that(new_sst->as_mutation_source().make_reader(s));
+        auto rd = assert_that(new_sst->as_mutation_source().make_reader_for_tests(s));
         BOOST_REQUIRE(muts[shard].size() == keys_per_shard);
         for (auto k : boost::irange(0u, keys_per_shard)) {
             rd.produces(muts[shard][k]);

--- a/tests/sstable_test.cc
+++ b/tests/sstable_test.cc
@@ -1060,7 +1060,7 @@ static future<int> count_rows(sstable_ptr sstp, schema_ptr s, sstring key) {
 static future<int> count_rows(sstable_ptr sstp, schema_ptr s, sstring ck1, sstring ck2) {
     return seastar::async([sstp, s, ck1, ck2] () mutable {
         auto ps = make_partition_slice(*s, ck1, ck2);
-        auto reader = sstp->read_range_rows_flat(s, query::full_partition_range, ps);
+        auto reader = sstp->read_range_rows_flat_for_tests(s, query::full_partition_range, ps);
         int nrows = 0;
         auto mfopt = reader(db::no_timeout).get0();
         while (mfopt) {

--- a/tests/sstable_utils.cc
+++ b/tests/sstable_utils.cc
@@ -58,7 +58,7 @@ sstables::shared_sstable make_sstable_containing(std::function<sstables::shared_
     }
 
     // validate the sstable
-    auto rd = assert_that(sst->as_mutation_source().make_reader(s));
+    auto rd = assert_that(sst->as_mutation_source().make_reader_for_tests(s));
     for (auto&& m : merged) {
         rd.produces(m);
     }


### PR DESCRIPTION
In order to prevent performance degratation, forwarding parameters
for mutation readers must now be declared explicitly, unless
special versions of these functions are used specifically for tests:
  make_reader_for_tests()
  make_flat_reader_for_tests()
  read_range_rows_flat_for_tests()

The intention is that using default parameter for tests is fine in order
to reduce churn, but using make_reader_for_tests() in non-test code
should immediately look suspicious during review.

Fixes https://github.com/scylladb/scylla/issues/5441

/cc @nyh @denesb 