### PR TITLE
alternator: Fix EQ operator for sets

### DIFF
--- a/alternator-test/test_expected.py
+++ b/alternator-test/test_expected.py
@@ -86,7 +86,6 @@ def test_update_expected_1_eq_true(test_table_s):
 # Check that set equality is checked correctly. Unlike string equality (for
 # example), it cannot be done with just naive string comparison of the JSON
 # representation, and we need to allow for any order.
-@pytest.mark.xfail(reason="bug in EQ test of sets")
 def test_update_expected_1_eq_set(test_table_s):
     p = random_string()
     # Because boto3 sorts the set values we give it, in order to generate a

--- a/alternator/conditions.cc
+++ b/alternator/conditions.cc
@@ -143,9 +143,44 @@ static void verify_operand_count(const rjson::value* array, const size_check& ex
     }
 }
 
+struct rjson_engaged_ptr_comp {
+    bool operator()(const rjson::value* p1, const rjson::value* p2) const {
+        return rjson::single_value_comp()(*p1, *p2);
+    }
+};
+
+// It's not enough to compare underlying JSON objects when comparing sets,
+// as internally they're stored in an array, and the order of elements is
+// not important in set equality. See issue #5021
+static bool check_EQ_for_sets(const rjson::value& set1, const rjson::value& set2) {
+    if (set1.Size() != set2.Size()) {
+        return false;
+    }
+    std::set<const rjson::value*, rjson_engaged_ptr_comp> set1_raw;
+    for (auto it = set1.Begin(); it != set1.End(); ++it) {
+        set1_raw.insert(&*it);
+    }
+    for (const auto& a : set2.GetArray()) {
+        if (set1_raw.count(&a) == 0) {
+            return false;
+        }
+    }
+    return true;
+}
+
 // Check if two JSON-encoded values match with the EQ relation
 static bool check_EQ(const rjson::value* v1, const rjson::value& v2) {
-    return v1 && *v1 == v2;
+    if (!v1) {
+        return false;
+    }
+    if (v1->IsObject() && v1->MemberCount() == 1 && v2.IsObject() && v2.MemberCount() == 1) {
+        auto it1 = v1->MemberBegin();
+        auto it2 = v2.MemberBegin();
+        if ((it1->name == "SS" && it2->name == "SS") || (it1->name == "NS" && it2->name == "NS") || (it1->name == "BS" && it2->name == "BS")) {
+            return check_EQ_for_sets(it1->value, it2->value);
+        }
+    }
+    return *v1 == v2;
 }
 
 // Check if two JSON-encoded values match with the NE relation

--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -991,50 +991,6 @@ static rjson::value list_concatenate(const rjson::value& v1, const rjson::value&
     return ret;
 }
 
-struct single_value_rjson_comp {
-    bool operator()(const rjson::value& r1, const rjson::value& r2) const {
-        auto r1_type = r1.GetType();
-        auto r2_type = r2.GetType();
-        switch (r1_type) {
-        case rjson::type::kNullType:
-            return r1_type < r2_type;
-        case rjson::type::kFalseType:
-            return r1_type < r2_type;
-        case rjson::type::kTrueType:
-            return r1_type < r2_type;
-        case rjson::type::kObjectType:
-            throw rjson::error("Object type comparison is not supported");
-        case rjson::type::kArrayType:
-            throw rjson::error("Array type comparison is not supported");
-        case rjson::type::kStringType: {
-            const size_t r1_len = r1.GetStringLength();
-            const size_t r2_len = r2.GetStringLength();
-            size_t len = std::min(r1_len, r2_len);
-            int result = std::strncmp(r1.GetString(), r2.GetString(), len);
-            return result < 0 || (result == 0 && r1_len < r2_len);
-        }
-        case rjson::type::kNumberType: {
-            if (r1_type != r2_type) {
-                throw rjson::error("All numbers in a set should have the same type");
-            }
-            if (r1.IsDouble()) {
-                return r1.GetDouble() < r2.GetDouble();
-            } else if (r1.IsInt()) {
-                return r1.GetInt() < r2.GetInt();
-            } else if (r1.IsUint()) {
-                return r1.GetUint() < r2.GetUint();
-            } else if (r1.IsInt64()) {
-                return r1.GetInt64() < r2.GetInt64();
-            } else {
-                return r1.GetUint64() < r2.GetUint64();
-            }
-        }
-        default:
-            return false;
-        }
-    }
-};
-
 // Take two JSON-encoded set values (e.g. {"SS": [...the actual set]}) and return the sum of both sets,
 // again as a set value.
 static rjson::value set_sum(const rjson::value& v1, const rjson::value& v2) {
@@ -1047,7 +1003,7 @@ static rjson::value set_sum(const rjson::value& v1, const rjson::value& v2) {
         throw api_error("ValidationException", "UpdateExpression: ADD operation for sets must be given sets as arguments");
     }
     rjson::value sum = rjson::copy(*set1);
-    std::set<rjson::value, single_value_rjson_comp> set1_raw;
+    std::set<rjson::value, rjson::single_value_comp> set1_raw;
     for (auto it = sum.Begin(); it != sum.End(); ++it) {
         set1_raw.insert(rjson::copy(*it));
     }
@@ -1072,7 +1028,7 @@ static rjson::value set_diff(const rjson::value& v1, const rjson::value& v2) {
     if (!set1 || !set2) {
         throw api_error("ValidationException", "UpdateExpression: DELETE operation can only be performed on a set");
     }
-    std::set<rjson::value, single_value_rjson_comp> set1_raw;
+    std::set<rjson::value, rjson::single_value_comp> set1_raw;
     for (auto it = set1->Begin(); it != set1->End(); ++it) {
         set1_raw.insert(rjson::copy(*it));
     }

--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -958,21 +958,6 @@ static std::string get_item_type_string(const rjson::value& v) {
     return it->name.GetString();
 }
 
-// Check if a given JSON object encodes a set (i.e., it is a {"SS": [...]}, or "NS", "BS"
-// and returns set's type and a pointer to that set. If the object does not encode a set,
-// returned value is {"", nullptr}
-static const std::pair<std::string, const rjson::value*> unwrap_set(const rjson::value& v) {
-    if (!v.IsObject() || v.MemberCount() != 1) {
-        return {"", nullptr};
-    }
-    auto it = v.MemberBegin();
-    const std::string it_key = it->name.GetString();
-    if (it_key != "SS" && it_key != "BS" && it_key != "NS") {
-        return {"", nullptr};
-    }
-    return std::make_pair(it_key, &(it->value));
-}
-
 // Take two JSON-encoded list values (remember that a list value is
 // {"L": [...the actual list]}) and return the concatenation, again as
 // a list value.

--- a/alternator/rjson.cc
+++ b/alternator/rjson.cc
@@ -113,6 +113,48 @@ void push_back(rjson::value& base_array, rjson::value&& item) {
 
 }
 
+bool single_value_comp::operator()(const rjson::value& r1, const rjson::value& r2) const {
+       auto r1_type = r1.GetType();
+       auto r2_type = r2.GetType();
+       switch (r1_type) {
+       case rjson::type::kNullType:
+           return r1_type < r2_type;
+       case rjson::type::kFalseType:
+           return r1_type < r2_type;
+       case rjson::type::kTrueType:
+           return r1_type < r2_type;
+       case rjson::type::kObjectType:
+           throw rjson::error("Object type comparison is not supported");
+       case rjson::type::kArrayType:
+           throw rjson::error("Array type comparison is not supported");
+       case rjson::type::kStringType: {
+           const size_t r1_len = r1.GetStringLength();
+           const size_t r2_len = r2.GetStringLength();
+           size_t len = std::min(r1_len, r2_len);
+           int result = std::strncmp(r1.GetString(), r2.GetString(), len);
+           return result < 0 || (result == 0 && r1_len < r2_len);
+       }
+       case rjson::type::kNumberType: {
+           if (r1_type != r2_type) {
+               throw rjson::error("All numbers in a set should have the same type");
+           }
+           if (r1.IsDouble()) {
+               return r1.GetDouble() < r2.GetDouble();
+           } else if (r1.IsInt()) {
+               return r1.GetInt() < r2.GetInt();
+           } else if (r1.IsUint()) {
+               return r1.GetUint() < r2.GetUint();
+           } else if (r1.IsInt64()) {
+               return r1.GetInt64() < r2.GetInt64();
+           } else {
+               return r1.GetUint64() < r2.GetUint64();
+           }
+       }
+       default:
+           return false;
+       }
+   }
+
 } // end namespace rjson
 
 std::ostream& std::operator<<(std::ostream& os, const rjson::value& v) {

--- a/alternator/rjson.hh
+++ b/alternator/rjson.hh
@@ -152,6 +152,10 @@ void set(rjson::value& base, rjson::string_ref_type name, rjson::string_ref_type
 // Throws if base_array is not a JSON array.
 void push_back(rjson::value& base_array, rjson::value&& item);
 
+struct single_value_comp {
+    bool operator()(const rjson::value& r1, const rjson::value& r2) const;
+};
+
 } // end namespace rjson
 
 namespace std {

--- a/alternator/serialization.cc
+++ b/alternator/serialization.cc
@@ -246,4 +246,16 @@ big_decimal unwrap_number(const rjson::value& v, std::string_view diagnostic) {
     return big_decimal(it->value.GetString());
 }
 
+const std::pair<std::string, const rjson::value*> unwrap_set(const rjson::value& v) {
+    if (!v.IsObject() || v.MemberCount() != 1) {
+        return {"", nullptr};
+    }
+    auto it = v.MemberBegin();
+    const std::string it_key = it->name.GetString();
+    if (it_key != "SS" && it_key != "BS" && it_key != "NS") {
+        return {"", nullptr};
+    }
+    return std::make_pair(it_key, &(it->value));
+}
+
 }

--- a/alternator/serialization.hh
+++ b/alternator/serialization.hh
@@ -63,4 +63,10 @@ clustering_key ck_from_json(const rjson::value& item, schema_ptr schema);
 // If v encodes a number (i.e., it is a {"N": [...]}, returns an object representing it.  Otherwise,
 // raises ValidationException with diagnostic.
 big_decimal unwrap_number(const rjson::value& v, std::string_view diagnostic);
+
+// Check if a given JSON object encodes a set (i.e., it is a {"SS": [...]}, or "NS", "BS"
+// and returns set's type and a pointer to that set. If the object does not encode a set,
+// returned value is {"", nullptr}
+const std::pair<std::string, const rjson::value*> unwrap_set(const rjson::value& v);
+
 }


### PR DESCRIPTION
Checking the EQ relation for alternator attributes is usually performed
simply by comparing underlying JSON objects, but sets (SS, BS, NS types)
need a special routine, as we need to make sure that sets stored in
a different order underneath are still equal, e.g:
```python
[1, 3, 2] == [1, 2, 3]
```

Fixes #5021