### PR TITLE
gossiper: Remove HIBERNATE status from dead state

### DIFF
--- a/gms/gossiper.hh
+++ b/gms/gossiper.hh
@@ -162,7 +162,6 @@ public:
         versioned_value::REMOVING_TOKEN,
         versioned_value::REMOVED_TOKEN,
         versioned_value::STATUS_LEFT,
-        versioned_value::HIBERNATE
     };
     const std::vector<sstring> SILENT_SHUTDOWN_STATES = {
         versioned_value::REMOVING_TOKEN,


### PR DESCRIPTION
In scylla, the replacing node is set as HIBERNATE status. It is the only
place we use HIBERNATE status. The replacing node is supposed to be
alive and updating its heartbeat, so it is not supposed to be in dead
state.

This patch fixes the following problem in replacing.

   1) start n1, n2
   2) n2 is down
   3) start n3 to replace n2, but kill n3 in the middle of the replace
   4) start n4 to replace n2

After step 3 and step 4, the old n3 will stay in gossip forever until a
full cluster shutdown. Note n3 will only stay in gossip but in
system.peers table. User will see the annoying and infinite logs like on
all the nodes

   rpc - client $ip_of_n3:7000: fail to connect: Connection refused

Fixes: #5449
Tests: replace_address_test.py + manual test