### PR TITLE
Use default values for reader forwarding explicitly

### DIFF
--- a/multishard_mutation_query.cc
+++ b/multishard_mutation_query.cc
@@ -264,7 +264,7 @@ flat_mutation_reader read_context::create_reader(
         const query::partition_slice& ps,
         const io_priority_class& pc,
         tracing::trace_state_ptr trace_state,
-        mutation_reader::forwarding) {
+        mutation_reader::forwarding fwd_mr) {
     const auto shard = engine().cpu_id();
     auto& rm = _readers[shard];
 
@@ -295,7 +295,7 @@ flat_mutation_reader read_context::create_reader(
     rm.rparts->read_operation = table.read_in_progress();
     rm.state = reader_state::used;
 
-    return table.as_mutation_source().make_reader(std::move(schema), *rm.rparts->range, *rm.rparts->slice, pc, std::move(trace_state));
+    return table.as_mutation_source().make_reader(std::move(schema), *rm.rparts->range, *rm.rparts->slice, pc, std::move(trace_state), streamed_mutation::forwarding::no, fwd_mr);
 }
 
 void read_context::destroy_reader(shard_id shard, future<stopped_reader> reader_fut) noexcept {

--- a/mutation_reader.cc
+++ b/mutation_reader.cc
@@ -807,13 +807,14 @@ mutation_source make_combined_mutation_source(std::vector<mutation_source> adden
             const query::partition_slice& slice,
             const io_priority_class& pc,
             tracing::trace_state_ptr tr,
-            streamed_mutation::forwarding fwd) {
+            streamed_mutation::forwarding fwd,
+            mutation_reader::forwarding fwd_mr) {
         std::vector<flat_mutation_reader> rd;
         rd.reserve(addends.size());
         for (auto&& ms : addends) {
-            rd.emplace_back(ms.make_reader(s, pr, slice, pc, tr, fwd));
+            rd.emplace_back(ms.make_reader(s, pr, slice, pc, tr, fwd, fwd_mr));
         }
-        return make_combined_reader(s, std::move(rd), fwd);
+        return make_combined_reader(s, std::move(rd), fwd, fwd_mr);
     });
 }
 

--- a/row_cache.cc
+++ b/row_cache.cc
@@ -47,7 +47,8 @@ using namespace cache;
 flat_mutation_reader
 row_cache::create_underlying_reader(read_context& ctx, mutation_source& src, const dht::partition_range& pr) {
     ctx.on_underlying_created();
-    return src.make_reader(_schema, pr, ctx.slice(), ctx.pc(), ctx.trace_state(), streamed_mutation::forwarding::yes);
+    return src.make_reader(_schema, pr, ctx.slice(), ctx.pc(), ctx.trace_state(), streamed_mutation::forwarding::yes,
+            mutation_reader::forwarding(ctx.is_range_query() || ctx.fwd_mr()));
 }
 
 static thread_local mutation_application_stats dummy_app_stats;

--- a/table.cc
+++ b/table.cc
@@ -399,7 +399,7 @@ table::make_sstable_reader(schema_ptr s,
 future<table::const_mutation_partition_ptr>
 table::find_partition(schema_ptr s, const dht::decorated_key& key) const {
     return do_with(dht::partition_range::make_singular(key), [s = std::move(s), this] (auto& range) {
-        return do_with(this->make_reader(s, range), [s] (flat_mutation_reader& reader) {
+        return do_with(this->make_reader(s, range, s->full_slice(), default_priority_class(), nullptr, streamed_mutation::forwarding::no, mutation_reader::forwarding::no), [s] (flat_mutation_reader& reader) {
             return read_mutation_from_flat_mutation_reader(reader, db::no_timeout).then([] (mutation_opt&& mo) -> std::unique_ptr<const mutation_partition> {
                 if (!mo) {
                     return {};
@@ -545,7 +545,7 @@ table::for_all_partitions_slow(schema_ptr s, std::function<bool (const dht::deco
     public:
         bool done() const { return !ok || empty; }
         iteration_state(schema_ptr s, const column_family& cf, std::function<bool (const dht::decorated_key&, const mutation_partition&)>&& func)
-            : reader(cf.make_reader(std::move(s)))
+            : reader(cf.make_reader(s, query::full_partition_range, s->full_slice(), default_priority_class(), nullptr, streamed_mutation::forwarding::no, mutation_reader::forwarding::no))
             , func(std::move(func))
         { }
     };


### PR DESCRIPTION
As a first step towards fixing issue 5441, which states that
mutation_reader::forwarding parameter should not have a default value
due to performance reasons, all core code (i.e. everything but tests)
usages of this parameter are now made explicit.
Default values are still preserved, because tests are a very heavy
user of this API.

Refs #5441

Related: #5452