### PR TITLE
cql3: Fix needs_filtering() for clustering columns

### DIFF
--- a/cql3/restrictions/single_column_primary_key_restrictions.hh
+++ b/cql3/restrictions/single_column_primary_key_restrictions.hh
@@ -478,7 +478,7 @@ inline bool single_column_primary_key_restrictions<clustering_key>::needs_filter
     // 3. a SLICE restriction isn't on a last place
     column_id position = 0;
     for (const auto& restriction : _restrictions->restrictions() | boost::adaptors::map_values) {
-        if (restriction->is_contains() || position != restriction->get_column_def().id) {
+        if (restriction->is_contains() || restriction->is_LIKE() || position != restriction->get_column_def().id) {
             return true;
         }
         if (!restriction->is_slice()) {

--- a/tests/cql_query_test.cc
+++ b/tests/cql_query_test.cc
@@ -4120,6 +4120,8 @@ SEASTAR_TEST_CASE(test_like_operator_on_clustering_key) {
         require_rows(e, "select s from t where s like '%c' allow filtering", {{T("abc")}});
         cquery_nofail(e, "insert into t (p, s) values (2, 'acc')");
         require_rows(e, "select s from t where s like '%c' allow filtering", {{T("abc")}, {T("acc")}});
+        cquery_nofail(e, "insert into t (p, s) values (2, 'acd')");
+        require_rows(e, "select s from t where p = 2 and s like '%c' allow filtering", {{T("acc")}});
     });
 }
 


### PR DESCRIPTION
The LIKE operator requires filtering, so needs_filtering() must check is_LIKE().  This already happens for partition columns, but it was overlooked for clustering columns in the initial implementation of LIKE.

Fixes #5400.

Tests: unit(dev)
