### PR TITLE
fix scylla_sysconfig_setup of setting clocksource

### DIFF
--- a/dist/common/scripts/scylla_util.py
+++ b/dist/common/scripts/scylla_util.py
@@ -661,7 +661,9 @@ class sysconfig_parser:
         self.__load()
 
     def get(self, key):
-        return self._cfg.get('global', key).strip('"')
+        if self.has_option(key):
+            return self._cfg.get('global', key).strip('"')
+        raise Exception("The key '%s' is not present" % key)
 
     def has_option(self, key):
         return self._cfg.has_option('global', key)

--- a/dist/common/scripts/scylla_util.py
+++ b/dist/common/scripts/scylla_util.py
@@ -553,7 +553,7 @@ def create_perftune_conf(cfg):
             nic = 'eth0'
         params += '--tune net --nic "{nic}"'.format(nic=nic)
 
-    if cfg.get('SET_CLOCKSOURCE') == 'yes':
+    if cfg.has_option('SET_CLOCKSOURCE') and cfg.get('SET_CLOCKSOURCE') == 'yes':
         params += ' --tune-clock'
 
     if len(params) > 0:

--- a/dist/common/sysconfig/scylla-server
+++ b/dist/common/sysconfig/scylla-server
@@ -42,3 +42,6 @@ SCYLLA_ARGS="--log-to-syslog 1 --log-to-stdout 0 --default-log-level info --netw
 
 # setup as AMI instance
 AMI=no
+
+# tune clocksource
+SET_CLOCKSOURCE=yes


### PR DESCRIPTION
This PR fixed a issue introduced by 4333b37f9e1087f7f0622a71d44ffeafbf7f6b2a

- scylla_setup would fail in setting clocksource
- after upgrading from 3.1 to master, we won't execute scylla_setup again, but scylla-server fails to start in scylla_prepare stage

Fixes #5478 

/CC @flucchese