### PR TITLE
dbuild: Fix podman invocation

### DIFF
--- a/tools/toolchain/dbuild
+++ b/tools/toolchain/dbuild
@@ -107,7 +107,7 @@ MAVEN_LOCAL_REPO="$HOME/.m2"
 
 mkdir -p "$MAVEN_LOCAL_REPO"
 
-is_podman="$(docker --version | grep -o podman)"
+is_podman="$(docker --help | grep -o podman)"
 
 docker_common_args=()
 
@@ -152,7 +152,7 @@ if [[ -n "$interactive" || -n "$is_podman" ]]; then
     docker run --rm "${docker_common_args[@]}"
     ret=$?
     rm -rf "$tmpdir"
-    exit $?
+    exit $ret
 fi
 
 container=$(


### PR DESCRIPTION
The is_podman check was depending on `docker -v` printing "podman" in
the output, but that doesn't actually work, since podman prints $0.
Use `docker --help` instead, which will output "podman".

Also return podman's return status, which was previously being
dropped.