### PR TITLE
Fix stream manager get progress

### DIFF
--- a/streaming/stream_manager.cc
+++ b/streaming/stream_manager.cc
@@ -164,13 +164,25 @@ void stream_manager::remove_progress(UUID plan_id) {
 }
 
 stream_bytes stream_manager::get_progress(UUID plan_id, gms::inet_address peer) const {
-    auto const& sbytes = _stream_bytes.at(plan_id);
-    return sbytes.at(peer);
+    auto it = _stream_bytes.find(plan_id);
+    if (it == _stream_bytes.end()) {
+        return stream_bytes();
+    }
+    auto const& sbytes = it->second;
+    auto i = sbytes.find(peer);
+    if (i == sbytes.end()) {
+        return stream_bytes();
+    }
+    return i->second;
 }
 
 stream_bytes stream_manager::get_progress(UUID plan_id) const {
+    auto it = _stream_bytes.find(plan_id);
+    if (it == _stream_bytes.end()) {
+        return stream_bytes();
+    }
     stream_bytes ret;
-    for (auto const& x : _stream_bytes.at(plan_id)) {
+    for (auto const& x : it->second) {
         ret += x.second;
     }
     return ret;

--- a/streaming/stream_result_future.cc
+++ b/streaming/stream_result_future.cc
@@ -131,7 +131,7 @@ void stream_result_future::maybe_complete() {
             }
             *stats = format("tx={:d} KiB, {} KiB/s, rx={:d} KiB, {} KiB/s", sbytes.bytes_sent / 1024, tx_bw, sbytes.bytes_received / 1024, rx_bw);
         }).handle_exception([plan_id] (auto ep) {
-            sslog.warn("[Stream #{}] Fail to get progess on all shards: {}", plan_id, ep);
+            sslog.warn("[Stream #{}] Fail to get progress on all shards: {}", plan_id, ep);
         }).finally([this, plan_id, stats, &sm] () {
             sm.remove_stream(plan_id);
             auto final_state = get_current_state();


### PR DESCRIPTION
 streaming: Fix map access in stream_manager::get_progress
 
 When the progress is queried, e.g., query from nodetool netstats
 the progress info might not be updated yet.
 
 Fix it by checking before access the map to avoid errors like:
 
 std::out_of_range (_Map_base::at)
 
 Fixes: #5437
 Tests: nodetool_additional_test.py:TestNodetool.netstats_test

