### PR TITLE
redis: create all redis keyspaces as configured

### DIFF
--- a/redis-test/test_strings.py
+++ b/redis-test/test_strings.py
@@ -21,6 +21,7 @@
 import pytest
 import redis
 import logging
+import requests
 from util import random_string, connect
 
 logger = logging.getLogger('redis-test')
@@ -100,9 +101,15 @@ def test_select():
     r.delete(key)
     assert r.get(key) == None
 
-    logger.debug('Try to switch to invalid database 16')
+def test_select_invalid_db():
+    r = connect()
+    logger.debug('Assume that user will not set redis_database_count to be bigger as 100')
+    invalid_db_idx = 100
+
+    logger.debug('Try to switch to invalid database %d' % invalid_db_idx)
     try:
-        r.execute_command('SELECT 16')
-        raise Exception('Expect that `SELECT 16` does not work')
+        query = 'SELECT %d' % invalid_db_idx
+        r.execute_command(query)
+        raise Exception('Expect that `%s` does not work' % query)
     except redis.exceptions.ResponseError as ex:
         assert str(ex) == 'invalid DB index'

--- a/redis-test/test_strings.py
+++ b/redis-test/test_strings.py
@@ -113,3 +113,23 @@ def test_select_invalid_db():
         raise Exception('Expect that `%s` does not work' % query)
     except redis.exceptions.ResponseError as ex:
         assert str(ex) == 'invalid DB index'
+
+def test_redis_database_count():
+    """
+    Test enough keyspaces can be prepared if redis_database_count is set to be larger than default 16.
+    Test will fail if redis_database_count isn't set correctly.
+    """
+    logger.info('Make sure redis_database_count is set to be larger than default 16')
+
+    r = connect()
+
+    try:
+        r.execute_command('SELECT 16')  # Use the select to verify the redis_database_count configuration
+        key = random_string(10)
+        r.get(key)
+    except redis.exceptions.ResponseError as ex:
+        if str(ex) == 'invalid DB index':
+            raise Exception('Make sure redis_database_count is set to be larger than default 16')
+    finally:
+        logger.debug('Switch back to default database 0')
+        assert r.execute_command('SELECT 0') == 'OK'

--- a/redis/keyspace_utils.cc
+++ b/redis/keyspace_utils.cc
@@ -179,8 +179,9 @@ future<> create_keyspace_if_not_exists_impl(db::config& config, int default_repl
         logger.info("Create keyspace: {}, table: {} for redis.", ks_name, cf_name);
         return service::get_local_migration_manager().announce_new_column_family(schema, false);
     };
-    // create 16 default database for redis.
-    return parallel_for_each(boost::irange<unsigned>(0, 16), [keyspace_gen = std::move(keyspace_gen), table_gen = std::move(table_gen)] (auto c) {
+    // Create keyspaces as configured by redis_database_count, which are used as redis databases.
+    return parallel_for_each(boost::irange<unsigned>(0, config.redis_database_count()),
+                             [keyspace_gen = std::move(keyspace_gen), table_gen = std::move(table_gen)] (auto c) {
         auto ks_name = sprint("REDIS_%d", c);
         return keyspace_gen(ks_name).then([ks_name, table_gen] {
             return when_all_succeed(


### PR DESCRIPTION
Note: this PR is v2 of https://github.com/scylladb/scylla/pull/5405

Currently we always try to create 16 keyspaces for Redis, the config
redis_database_count doesn't effect.

SELECT command is supported, it would switch between keyspaces. The limitation
is got from configuration. So if we config redis_database_count to be larger
than 16, SELECT allows to switch to unexisting keyspace, and it will fail in
read/write data.

Example:
| # scylla --developer-mode 1 --workdir ./ --enable-redis-protocol 1  --redis-database-count 20
| # redis-cli
| 127.0.0.1:6379> select 18
| OK
| 127.0.0.1:6379[18]> set a 1 
| (error) ERR Can't find a column family STRINGs in keyspace REDIS_18
| 127.0.0.1:6379[18]> get a
| (error) ERR Can't find a column family STRINGs in keyspace REDIS_18

v2: rename of redis_database_count
