### PR TITLE
repair: Do not return working_row_buf_nr in get combined row hash verb

### DIFF
--- a/idl/partition_checksum.idl.hh
+++ b/idl/partition_checksum.idl.hh
@@ -69,11 +69,6 @@ struct get_sync_boundary_response {
     uint64_t new_rows_nr;
 };
 
-struct get_combined_row_hash_response {
-    repair_hash working_row_buf_combined_csum;
-    uint64_t working_row_buf_nr;
-};
-
 enum class row_level_diff_detect_algorithm : uint8_t {
     send_full_set,
     send_full_set_rpc_stream,

--- a/repair/repair.hh
+++ b/repair/repair.hh
@@ -321,11 +321,7 @@ struct get_sync_boundary_response {
 };
 
 // Return value of the REPAIR_GET_COMBINED_ROW_HASH RPC verb
-struct get_combined_row_hash_response {
-    repair_hash working_row_buf_combined_csum;
-    // The number of rows in the working row buf
-    uint64_t working_row_buf_nr;
-};
+using get_combined_row_hash_response = repair_hash;
 
 struct node_repair_meta_id {
     gms::inet_address ip;

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -1098,14 +1098,14 @@ private:
         _working_row_buf_combined_hash.clear();
 
         if (_row_buf.empty()) {
-            return make_ready_future<get_combined_row_hash_response>(get_combined_row_hash_response{repair_hash(), 0});
+            return make_ready_future<get_combined_row_hash_response>(get_combined_row_hash_response());
         }
         return move_row_buf_to_working_row_buf().then([this] {
             return do_for_each(_working_row_buf, [this] (repair_row& r) {
                 _working_row_buf_combined_hash.add(r.hash());
                 return make_ready_future<>();
             }).then([this] {
-                return get_combined_row_hash_response{_working_row_buf_combined_hash, _working_row_buf.size()};
+                return get_combined_row_hash_response{_working_row_buf_combined_hash};
             });
         });
     }
@@ -2296,8 +2296,8 @@ private:
             // are identical, there is no need to transfer each and every
             // row hashes to the repair master.
             return master.get_combined_row_hash(_common_sync_boundary, _all_nodes[idx]).then([&, this, idx] (get_combined_row_hash_response resp) {
-                rlogger.debug("Calling master.get_combined_row_hash for node {}, got combined_hash={}, rows_nr={}", _all_nodes[idx], resp.working_row_buf_combined_csum, resp.working_row_buf_nr);
-                combined_hashes[idx]= std::move(resp.working_row_buf_combined_csum);
+                rlogger.debug("Calling master.get_combined_row_hash for node {}, got combined_hash={}", _all_nodes[idx], resp);
+                combined_hashes[idx]= std::move(resp);
             });
         }).get();
 


### PR DESCRIPTION
In commit b463d7039cd20445a52191bb94770d87a025e78a (repair: Introduce
get_combined_row_hash_response), working_row_buf_nr is returned in
REPAIR_GET_COMBINED_ROW_HASH in addition to the combined hash. It is
scheduled to be part of 3.1 release. However it is not backported to 3.1
by accident.

In order to be compatible between 3.1 and 3.2 repair. We need to drop
the working_row_buf_nr in 3.2 release.

Fixes: #5490
Backports: 3.1 and 3.2
Tests: Run repair in a mixed 3.1 and 3.2 cluster