### PR TITLE
Adding functionality to enforce optimal Linux clocksource setting.

### DIFF
--- a/dist/common/scripts/scylla_prepare
+++ b/dist/common/scripts/scylla_prepare
@@ -75,9 +75,5 @@ if __name__ == '__main__':
             run('hugeadm --create-mounts')
         fi
     else:
-        set_nic_and_disks = get_set_nic_and_disks_config_value(cfg)
-        ifname = cfg.get('IFNAME')
-        if set_nic_and_disks == 'yes':
-            create_perftune_conf(ifname)
+        if create_perftune_conf(cfg):
             run("{} --options-file /etc/scylla.d/perftune.yaml".format(perftune_base_command()))
-

--- a/dist/common/scripts/scylla_setup
+++ b/dist/common/scripts/scylla_setup
@@ -218,6 +218,7 @@ if __name__ == '__main__':
     cpuscaling_setup = not args.no_cpuscaling_setup
     fstrim_setup = not args.no_fstrim_setup
     selinux_reboot_required = False
+    set_clocksource = False
 
     umask = current_umask()
     # files have to be world-readable
@@ -376,11 +377,14 @@ if __name__ == '__main__':
         sysconfig_setup = interactive_ask_service('Do you want to setup a system-wide customized configuration for Scylla?', 'Yes - setup the sysconfig file. No - skips this step.', sysconfig_setup)
         args.no_sysconfig_setup = not sysconfig_setup
         if sysconfig_setup:
-            nic = interactive_choose_nic()
             set_nic_and_disks = interactive_ask_service('Do you want to enable Network Interface Card (NIC) and disk(s) optimization?', 'Yes - optimize the NIC queue and disks settings. Selecting Yes greatly improves performance. No - skip this step.', set_nic_and_disks)
-        if sysconfig_setup:
             setup_args = '--setup-nic-and-disks' if set_nic_and_disks else ''
-            run_setup_script('NIC queue', 'scylla_sysconfig_setup --nic {nic} {setup_args}'.format(nic=nic, setup_args=setup_args))
+            nic = interactive_choose_nic()
+
+            set_clocksource = interactive_ask_service('The clocksource is the physical device that Linux uses to take time measurements. In most cases Linux chooses the fastest available clocksource device as long as it is accurate. In some situations, however, Linux errs in the side of caution and does not choose the fastest available clocksource despite it being accurate enough. If you know your hardware''s fast clocksource is stable enough, choose "yes" here. The safest is the choose "no" (the default)', 'Yes - enforce clocksource setting. No - keep current configuration.', set_clocksource)
+            setup_args += ' --set-clocksource' if set_clocksource else ''
+
+            run_setup_script('Performance Tuning', 'scylla_sysconfig_setup --nic {nic} {setup_args}'.format(nic=nic, setup_args=setup_args))
 
     io_setup = interactive_ask_service('Do you want IOTune to study your disks IO profile and adapt Scylla to it? (*WARNING* Saying NO here means the node will not boot in production mode unless you configure the I/O Subsystem manually!)', 'Yes - let iotune study my disk(s). Note that this action will take a few minutes. No - skip this step.', io_setup)
     args.no_io_setup = not io_setup

--- a/dist/common/scripts/scylla_sysconfig_setup
+++ b/dist/common/scripts/scylla_sysconfig_setup
@@ -42,8 +42,12 @@ if __name__ == '__main__':
     else:
         cfg = sysconfig_parser('/etc/default/scylla-server')
     set_nic_and_disks = str2bool(get_set_nic_and_disks_config_value(cfg))
+    if cfg.has_option('SET_CLOCKSOURCE'):
+        set_clocksource = str2bool(cfg.get('SET_CLOCKSOURCE'))
+    else:
+        set_clocksource = 'no'
     ami = str2bool(cfg.get('AMI'))
-
+    
     parser = argparse.ArgumentParser(description='Setting parameters on Scylla sysconfig file.')
     parser.add_argument('--nic',
                         help='specify NIC')
@@ -61,6 +65,8 @@ if __name__ == '__main__':
                         help='scylla config directory')
     parser.add_argument('--setup-nic-and-disks', action='store_true', default=set_nic_and_disks,
                         help='setup NIC\'s and disks\' interrupts, RPS, XPS, nomerges and I/O scheduler')
+    parser.add_argument('--set-clocksource', action='store_true', default=set_clocksource,
+                        help='Set enforcing fastest available Linux clocksource')
     parser.add_argument('--ami', action='store_true', default=ami,
                         help='AMI instance mode')
     args = parser.parse_args()
@@ -112,6 +118,9 @@ if __name__ == '__main__':
         else:
             cfg.set('SET_NIC_AND_DISKS', bool2str(args.setup_nic_and_disks))
 
+    if cfg.has_option('SET_CLOCKSOURCE') and str2bool(cfg.get('SET_CLOCKSOURCE')) != args.set_clocksource:
+        cfg.set('SET_CLOCKSOURCE', bool2str(args.set_clocksource))
+        
     if str2bool(cfg.get('AMI')) != args.ami:
         cfg.set('AMI', bool2str(args.ami))
     cfg.commit()

--- a/dist/common/scripts/scylla_util.py
+++ b/dist/common/scripts/scylla_util.py
@@ -520,14 +520,36 @@ def get_tune_mode(nic):
         return 'sq_split'
 
 
-def create_perftune_conf(nic='eth0'):
-    if os.path.exists('/etc/scylla.d/perftune.yaml'):
-        return
-    mode = get_tune_mode(nic)
-    yaml = out('/opt/scylladb/scripts/perftune.py --tune net --nic "{nic}" --mode {mode} --dump-options-file'.format(nic=nic, mode=mode))
-    with open('/etc/scylla.d/perftune.yaml', 'w') as f:
-        f.write(yaml)
+def create_perftune_conf(cfg):
+    """
+    This function checks if a perftune configuration file should be created and
+    creates it if so is the case, returning a boolean accordingly. It returns False
+    if none of the perftune options are enabled in scylla_server file. If the perftune
+    configuration file already exists, none is created.
+    :return boolean indicating if perftune.py should be executed
+    """
+    params = ''
+    if get_set_nic_and_disks_config_value(cfg) == 'yes':
+        nic = cfg.get('IFNAME')
+        if not nic:
+            nic = 'eth0'
+        params += '--tune net --nic "{nic}"'.format(nic=nic)
 
+    if cfg.has_option('SET_CLOCKSOURCE') and cfg.get('SET_CLOCKSOURCE') == 'yes':
+        params += ' --tune-clock'
+
+    if len(params) > 0:
+        if os.path.exists('/etc/scylla.d/perftune.yaml'):
+            return True
+        
+        mode = get_tune_mode(nic)
+        params += ' --mode {mode} --dump-options-file'.format(mode=mode)
+        yaml = out('/opt/scylladb/scripts/perftune.py ' + params)
+        with open('/etc/scylla.d/perftune.yaml', 'w') as f:
+            f.write(yaml)
+        return True
+    else:
+        return False
 
 def is_valid_nic(nic):
     if len(nic) == 0:

--- a/dist/common/sysconfig/scylla-server
+++ b/dist/common/sysconfig/scylla-server
@@ -13,6 +13,9 @@ IFNAME=eth0
 # setup NIC's and disks' interrupts, RPS, XPS, nomerges and I/O scheduler (posix)
 SET_NIC_AND_DISKS=no
 
+# tune clocksource
+SET_CLOCKSOURCE=no
+
 # ethernet device driver (dpdk)
 ETHDRV=
 


### PR DESCRIPTION
A Linux machine typically has multiple clocksources with distinct
performances. Setting a high-performant clocksource might result in
better performance for ScyllaDB, so this should be considered whenever
starting it up.

This patch introduces the possibility of enforcing optimized Linux
clocksource to Scylla's setup/start-up processes. It does so by adding
an interactive question about enforcing clocksource setting to scylla_setup,
which modifies the parameter "CLOCKSOURCE" in scylla_server configuration
file. This parameter is read by perftune.py which, if set to "yes", proceeds
to (non persistently) setting the clocksource. On x86, TSC clocksource is used.

Fixes #4474
Fixes #5474
Fixes #5480