### PR TITLE
sstables: file_writer: close output_stream on exception during write

### DIFF
--- a/sstables/mc/writer.cc
+++ b/sstables/mc/writer.cc
@@ -832,16 +832,16 @@ void writer::init_file_writers() {
     options.write_behind = 10;
 
     if (!_compression_enabled) {
-        _data_writer = std::make_unique<crc32_checksummed_file_writer>(std::move(_sst._data_file), options);
+        _data_writer = std::make_unique<crc32_checksummed_file_writer>(std::move(_sst._data_file), options, _sst.filename(component_type::Data));
     } else {
-        _data_writer = std::make_unique<file_writer>(
-            make_compressed_file_m_format_output_stream(
+        auto out = make_compressed_file_m_format_output_stream(
                 std::move(_sst._data_file),
                 options,
                 &_sst._components->compression,
-                _schema.get_compressor_params()));
+                _schema.get_compressor_params());
+        _data_writer = std::make_unique<file_writer>(std::move(out), _sst.filename(component_type::Data));
     }
-    _index_writer = std::make_unique<file_writer>(std::move(_sst._index_file), options);
+    _index_writer = std::make_unique<file_writer>(std::move(_sst._index_file), std::move(options), _sst.filename(component_type::Index));
 }
 
 std::unique_ptr<file_writer> writer::close_writer(std::unique_ptr<file_writer>& w) {

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -567,6 +567,10 @@ private:
     future<file> rename_new_sstable_component_file(sstring from_file, sstring to_file, file fd);
     future<file> new_sstable_component_file(const io_error_handler& error_handler, component_type f, open_flags flags, file_open_options options = {});
 
+    // must be called from seastar thread
+    file_writer make_component_file_writer(component_type c, file_output_stream_options options,
+            open_flags oflags = open_flags::wo | open_flags::create | open_flags::exclusive);
+
     future<> touch_temp_dir();
     future<> remove_temp_dir();
 

--- a/sstables/writer.hh
+++ b/sstables/writer.hh
@@ -43,6 +43,7 @@ class file_writer {
     output_stream<char> _out;
     writer_offset_tracker _offset;
     std::string _filename;
+    bool _closed = false;
 public:
     // It is the responsiblity of the caller to close file f
     // if the constructor throws
@@ -63,7 +64,7 @@ public:
         , _filename("output_stream")
     {}
 
-    virtual ~file_writer() = default;
+    virtual ~file_writer();
     file_writer(file_writer&&) = default;
     // Must be called in a seastar thread.
     void write(const char* buf, size_t n) {
@@ -80,9 +81,8 @@ public:
         _out.flush().get();
     }
     // Must be called in a seastar thread.
-    void close() {
-        _out.close().get();
-    }
+    void close();
+
     uint64_t offset() const {
         return _offset.offset;
     }

--- a/sstables/writer.hh
+++ b/sstables/writer.hh
@@ -44,11 +44,15 @@ class file_writer {
     writer_offset_tracker _offset;
     std::string _filename;
 public:
+    // It is the responsiblity of the caller to close file f
+    // if the constructor throws
     file_writer(file f, file_output_stream_options options, std::string filename)
         : _out(make_file_output_stream(std::move(f), std::move(options)))
         , _filename(std::move(filename))
     {}
 
+    // It is the responsiblity of the caller to close output_stream out
+    // if the constructor throws
     file_writer(output_stream<char>&& out, std::string filename)
         : _out(std::move(out))
         , _filename(std::move(filename))


### PR DESCRIPTION
Otherwise we may trip the following
    assert(_closing_state == state::closed);
in ~append_challenged_posix_file_impl
when the output_stream is destructed.

Example stack trace:
    non-virtual thunk to seastar::append_challenged_posix_file_impl::~append_challenged_posix_file_impl() at /jenkins/slave/workspace/scylla-3.2/build/scylla/seastar/include/seastar/core/future.hh:944
    seastar::shared_ptr_count_for<checked_file_impl>::~shared_ptr_count_for() at crtstuff.c:?
    seastar::shared_ptr<seastar::file_impl>::~shared_ptr() at /jenkins/slave/workspace/scylla-3.2/build/scylla/seastar/include/seastar/core/future.hh:944
     (inlined by) seastar::file::~file() at /jenkins/slave/workspace/scylla-3.2/build/scylla/seastar/include/seastar/core/file.hh:155
     (inlined by) seastar::file_data_sink_impl::~file_data_sink_impl() at /jenkins/slave/workspace/scylla-3.2/build/scylla/seastar/src/core/fstream.cc:312
     (inlined by) seastar::file_data_sink_impl::~file_data_sink_impl() at /jenkins/slave/workspace/scylla-3.2/build/scylla/seastar/src/core/fstream.cc:312
    seastar::output_stream<char>::~output_stream() at crtstuff.c:?
    sstables::sstable::write_crc(sstables::checksum const&) [clone .cold] at sstables.cc:?
    sstables::mc::writer::close_data_writer() at crtstuff.c:?
    sstables::mc::writer::consume_end_of_stream() at crtstuff.c:?
    sstables::sstable::write_components(flat_mutation_reader, unsigned long, seastar::lw_shared_ptr<schema const>, sstables::sstable_writer_config const&, encoding_stats, seastar::io_priority_class const&)::{lambda()#1}::operator()() at sstables.cc:?

Refs #5506

Signed-off-by: Benny Halevy <bhalevy@scylladb.com>

Test: unit(dev)