### PR TITLE
dist: stop replacing /usr/lib/scylla with symlink

### DIFF
--- a/dist/debian/debian/scylla-server.install
+++ b/dist/debian/debian/scylla-server.install
@@ -21,6 +21,7 @@ opt/scylladb/scripts/libexec/*
 opt/scylladb/bin/*
 opt/scylladb/libreloc/*
 opt/scylladb/libexec/*
+usr/lib/scylla/*
 var/lib/scylla/data
 var/lib/scylla/commitlog
 var/lib/scylla/hints

--- a/dist/debian/debian/scylla-server.postinst
+++ b/dist/debian/debian/scylla-server.postinst
@@ -24,10 +24,6 @@ if [ "$1" = configure ]; then
 fi
 
 ln -sfT /etc/scylla /var/lib/scylla/conf
-if [ -d /usr/lib/scylla ]; then
-    mv /usr/lib/scylla /usr/lib/scylla.old
-fi
-ln -sfT /opt/scylladb/scripts /usr/lib/scylla
 
 grep -v api_ui_dir /etc/scylla/scylla.yaml | grep -v api_doc_dir > /tmp/scylla.yaml
 echo "api_ui_dir: /opt/scylladb/swagger-ui/dist/" >> /tmp/scylla.yaml

--- a/dist/redhat/scylla.spec.mustache
+++ b/dist/redhat/scylla.spec.mustache
@@ -77,9 +77,6 @@ getent passwd scylla || /usr/sbin/useradd -g scylla -s /sbin/nologin -r -d %{_sh
 if [ -f /etc/systemd/coredump.conf ];then
     /opt/scylladb/scripts/scylla_coredump_setup
 fi
-if [ -d /usr/lib/scylla ]; then
-    mv /usr/lib/scylla /usr/lib/scylla.old
-fi
 
 /opt/scylladb/scripts/scylla_post_install.sh
 
@@ -97,10 +94,6 @@ if  [ -d /tmp/%{name}-%{version}-%{release} ]; then
     rm -rf /tmp/%{name}-%{version}-%{release}/
 fi
 ln -sfT /etc/scylla /var/lib/scylla/conf
-if [ -d /usr/lib/scylla ]; then
-    mv /usr/lib/scylla /usr/lib/scylla.old
-fi
-ln -sfT /opt/scylladb/scripts /usr/lib/scylla
 
 %clean
 rm -rf $RPM_BUILD_ROOT
@@ -132,6 +125,7 @@ rm -rf $RPM_BUILD_ROOT
 /opt/scylladb/bin/*
 /opt/scylladb/libreloc/*
 /opt/scylladb/libexec/*
+%{_prefix}/lib/scylla/*
 %attr(0755,scylla,scylla) %dir %{_sharedstatedir}/scylla/
 %attr(0755,scylla,scylla) %dir %{_sharedstatedir}/scylla/data
 %attr(0755,scylla,scylla) %dir %{_sharedstatedir}/scylla/commitlog

--- a/install.sh
+++ b/install.sh
@@ -218,6 +218,20 @@ EOS
     for i in $SBINFILES; do
         ln -srf "$rprefix/scripts/$i" "$rusr/sbin/$i"
     done
+
+    # we need keep /usr/lib/scylla directory to support upgrade/downgrade
+    # without error, so we need to create symlink for each script on the
+    # directory
+    install -m755 -d "$rusr"/lib/scylla/scyllatop/views
+    for i in $(find "$rprefix"/scripts/ -maxdepth 1 -type f); do
+        ln -srf $i "$rusr"/lib/scylla/
+    done
+    for i in $(find "$rprefix"/scyllatop/ -maxdepth 1 -type f); do
+        ln -srf $i "$rusr"/lib/scylla/scyllatop
+    done
+    for i in $(find "$rprefix"/scyllatop/views -maxdepth 1 -type f); do
+        ln -srf $i "$rusr"/lib/scylla/scyllatop/views
+    done
 else
     install -m755 -d "$rdata"/saved_caches
     install -d -m755 "$retc"/systemd/system/scylla-server.service.d


### PR DESCRIPTION
Since we merged /usr/lib/scylla with /opt/scylladb, we removed
/usr/lib/scylla and replace it with the symlink point to /opt/scylladb.
However, RPM does not support replacing a directory with a symlink,
we are doing some dirty hack using RPM scriptlet, but it causes
multiple issues on upgrade/downgrade.
(See: https://docs.fedoraproject.org/en-US/packaging-guidelines/Directory_Replacement/)

To minimize Scylla upgrading/downgrade issues on user side, it's better
to keep /usr/lib/scylla directory.
Instead of creating single symlink /usr/lib/scylla -> /opt/scylladb,
we can create symlinks for each setup scripts like
/usr/lib/scylla/<script> -> /opt/scylladb/scripts/<script>.

Fixes #5522
Fixes #4585
Fixes #4611