### PR TITLE
Fix row level repair uninitialized member

### DIFF
--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -2174,7 +2174,7 @@ class row_level_repair {
 
     // If the total size of the `_row_buf` on either of the nodes is zero,
     // we set this flag, which is an indication that rows are not synced.
-    bool _zero_rows;
+    bool _zero_rows = false;
 
     // Sum of estimated_partitions on all peers
     uint64_t _estimated_partitions = 0;

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -256,9 +256,9 @@ private:
     std::optional<inet_address> _removing_node;
 
     /* Are we starting this node in bootstrap mode? */
-    bool _is_bootstrap_mode;
+    bool _is_bootstrap_mode = false;
 
-    bool _initialized;
+    bool _initialized = false;
 
     bool _joined = false;
 


### PR DESCRIPTION
Initialize bool members in `row_level_repair` and _storage_service` causing ubsan errors. 

Fixes #5531 