### PR TITLE
Pretty print canonical_mutation objects

### DIFF
--- a/atomic_cell.cc
+++ b/atomic_cell.cc
@@ -233,6 +233,27 @@ operator<<(std::ostream& os, const atomic_cell& ac) {
     return os << atomic_cell_view(ac);
 }
 
+std::ostream&
+operator<<(std::ostream& os, const atomic_cell_view::printer& acvp) {
+    auto& type = acvp._type;
+    auto& acv = acvp._cell;
+    if (acv.is_live()) {
+        return fmt_print(os, "atomic_cell{{{};ts={:d};expiry={:d},ttl={:d}}}",
+            type.to_string(acv.value().linearize()),
+            acv.timestamp(),
+            acv.is_live_and_has_ttl() ? acv.expiry().time_since_epoch().count() : -1,
+            acv.is_live_and_has_ttl() ? acv.ttl().count() : 0);
+    } else {
+        return fmt_print(os, "atomic_cell{{DEAD;ts={:d};deletion_time={:d}}}",
+            acv.timestamp(), acv.deletion_time().time_since_epoch().count());
+    }
+}
+
+std::ostream&
+operator<<(std::ostream& os, const atomic_cell::printer& acp) {
+    return operator<<(os, static_cast<const atomic_cell_view::printer&>(acp));
+}
+
 std::ostream& operator<<(std::ostream& os, const atomic_cell_or_collection::printer& p) {
     if (!p._cell._data.get()) {
         return os << "{ null atomic_cell_or_collection }";

--- a/atomic_cell.cc
+++ b/atomic_cell.cc
@@ -214,6 +214,25 @@ size_t atomic_cell_or_collection::external_memory_usage(const abstract_type& t) 
         + imr_object_type::size_overhead + external_value_size;
 }
 
+std::ostream&
+operator<<(std::ostream& os, const atomic_cell_view& acv) {
+    if (acv.is_live()) {
+        return fmt_print(os, "atomic_cell{{{};ts={:d};expiry={:d},ttl={:d}}}",
+            to_hex(acv.value().linearize()),
+            acv.timestamp(),
+            acv.is_live_and_has_ttl() ? acv.expiry().time_since_epoch().count() : -1,
+            acv.is_live_and_has_ttl() ? acv.ttl().count() : 0);
+    } else {
+        return fmt_print(os, "atomic_cell{{DEAD;ts={:d};deletion_time={:d}}}",
+            acv.timestamp(), acv.deletion_time().time_since_epoch().count());
+    }
+}
+
+std::ostream&
+operator<<(std::ostream& os, const atomic_cell& ac) {
+    return os << atomic_cell_view(ac);
+}
+
 std::ostream& operator<<(std::ostream& os, const atomic_cell_or_collection::printer& p) {
     if (!p._cell._data.get()) {
         return os << "{ null atomic_cell_or_collection }";

--- a/atomic_cell.hh
+++ b/atomic_cell.hh
@@ -153,6 +153,14 @@ public:
     }
 
     friend std::ostream& operator<<(std::ostream& os, const atomic_cell_view& acv);
+
+    class printer {
+        const abstract_type& _type;
+        const atomic_cell_view& _cell;
+    public:
+        printer(const abstract_type& type, const atomic_cell_view& cell) : _type(type), _cell(cell) {}
+        friend std::ostream& operator<<(std::ostream& os, const printer& acvp);
+    };
 };
 
 class atomic_cell_mutable_view final : public basic_atomic_cell_view<mutable_view::yes> {
@@ -219,6 +227,12 @@ public:
     static atomic_cell make_live_uninitialized(const abstract_type& type, api::timestamp_type timestamp, size_t size);
     friend class atomic_cell_or_collection;
     friend std::ostream& operator<<(std::ostream& os, const atomic_cell& ac);
+
+    class printer : atomic_cell_view::printer {
+    public:
+        printer(const abstract_type& type, const atomic_cell_view& cell) : atomic_cell_view::printer(type, cell) {}
+        friend std::ostream& operator<<(std::ostream& os, const printer& acvp);
+    };
 };
 
 class column_definition;

--- a/canonical_mutation.hh
+++ b/canonical_mutation.hh
@@ -26,6 +26,7 @@
 #include "database_fwd.hh"
 #include "mutation_partition_visitor.hh"
 #include "mutation_partition_serializer.hh"
+#include <iosfwd>
 
 // Immutable mutation form which can be read using any schema version of the same table.
 // Safe to access from other shards via const&.
@@ -52,4 +53,5 @@ public:
 
     const bytes& representation() const { return _data; }
 
+    friend std::ostream& operator<<(std::ostream& os, const canonical_mutation& cm);
 };

--- a/collection_mutation.hh
+++ b/collection_mutation.hh
@@ -28,6 +28,7 @@
 #include "cql_serialization_format.hh"
 #include "marshal_exception.hh"
 #include "utils/linearizing_input_stream.hh"
+#include <iosfwd>
 
 class abstract_type;
 class bytes_ostream;
@@ -99,6 +100,15 @@ public:
         auto stream = collection_mutation_input_stream(data);
         return f(deserialize_collection_mutation(type, stream));
     }
+
+    class printer {
+        const abstract_type& _type;
+        const collection_mutation_view& _cmv;
+    public:
+        printer(const abstract_type& type, const collection_mutation_view& cmv)
+                : _type(type), _cmv(cmv) {}
+        friend std::ostream& operator<<(std::ostream& os, const printer& cmvp);
+    };
 };
 
 // A serialized mutation of a collection of cells.

--- a/database.cc
+++ b/database.cc
@@ -1625,25 +1625,6 @@ operator<<(std::ostream& os, const exploded_clustering_prefix& ecp) {
     return fmt_print(os, "prefix{{{}}}", ::join(":", ecp._v | boost::adaptors::transformed(enhex)));
 }
 
-std::ostream&
-operator<<(std::ostream& os, const atomic_cell_view& acv) {
-    if (acv.is_live()) {
-        return fmt_print(os, "atomic_cell{{{};ts={:d};expiry={:d},ttl={:d}}}",
-            to_hex(acv.value().linearize()),
-            acv.timestamp(),
-            acv.is_live_and_has_ttl() ? acv.expiry().time_since_epoch().count() : -1,
-            acv.is_live_and_has_ttl() ? acv.ttl().count() : 0);
-    } else {
-        return fmt_print(os, "atomic_cell{{DEAD;ts={:d};deletion_time={:d}}}",
-            acv.timestamp(), acv.deletion_time().time_since_epoch().count());
-    }
-}
-
-std::ostream&
-operator<<(std::ostream& os, const atomic_cell& ac) {
-    return os << atomic_cell_view(ac);
-}
-
 sstring database::get_available_index_name(const sstring &ks_name, const sstring &cf_name,
                                            std::optional<sstring> index_name_root) const
 {

--- a/mutation_partition_view.cc
+++ b/mutation_partition_view.cc
@@ -45,6 +45,10 @@
 
 using namespace db;
 
+GCC6_CONCEPT(static_assert(MutationViewVisitor<mutation_partition_view_virtual_visitor>);)
+
+mutation_partition_view_virtual_visitor::~mutation_partition_view_virtual_visitor() = default;
+
 namespace {
 
 using atomic_cell_variant = boost::variant<ser::live_cell_view,
@@ -250,6 +254,10 @@ void mutation_partition_view::accept(const schema& s, partition_builder& visitor
 
 void mutation_partition_view::accept(const column_mapping& cm, converting_mutation_partition_applier& visitor) const
 {
+    do_accept(cm, visitor);
+}
+
+void mutation_partition_view::accept(const column_mapping& cm, mutation_partition_view_virtual_visitor& visitor) const {
     do_accept(cm, visitor);
 }
 


### PR DESCRIPTION
canonical_mutation objects are used for schema reconciliation, which is a fragile area and thus deserves some debugging help.

This series makes canonical_mutation objects printable. The end result looks something like

```
INFO  2019-12-30 17:00:40,935 [shard 1] migration_manager - received definitions update from 127.0.0.1:62937: {{{canonical_mutation: table_id afddfb9d-bc1e-3068-8056-eed6c302ba09 schema_version c179c1d7-9503-3f66-a5b3-70e72af3392a partition_key pk{00026b73} partition_tombstone {tombstone: none}{row {position: clustered,ckp{0003746162},0} tombstone {row_tombstone: none} marker {row_marker: }, column bloom_filter_fp_chance atomic_cell{0.01;ts=1577718040933619;expiry=-1,ttl=0}, column caching atomic_cell{({keys : ALL}, {rows_per_partition : ALL});ts=1577718040933619;expiry=-1,ttl=0}, column comment atomic_cell{;ts=1577718040933619;expiry=-1,ttl=0}, column compaction atomic_cell{({class : SizeTieredCompactionStrategy});ts=1577718040933619;expiry=-1,ttl=0}, column compression atomic_cell{({sstable_compression : org.apache.cassandra.io.compress.LZ4Compressor});ts=1577718040933619;expiry=-1,ttl=0}, column crc_check_chance atomic_cell{1;ts=1577718040933619;expiry=-1,ttl=0}, column dclocal_read_repair_chance atomic_cell{0.1;ts=1577718040933619;expiry=-1,ttl=0}, column default_time_to_live atomic_cell{0;ts=1577718040933619;expiry=-1,ttl=0}, column extensions atomic_cell{;ts=1577718040933619;expiry=-1,ttl=0}, column flags atomic_cell{compound;ts=1577718040933619;expiry=-1,ttl=0}, column gc_grace_seconds atomic_cell{864000;ts=1577718040933619;expiry=-1,ttl=0}, column id atomic_cell{255c3950-2b15-11ea-b830-000000000001;ts=1577718040933619;expiry=-1,ttl=0}, column max_index_interval atomic_cell{2048;ts=1577718040933619;expiry=-1,ttl=0}, column memtable_flush_period_in_ms atomic_cell{0;ts=1577718040933619;expiry=-1,ttl=0}, column min_index_interval atomic_cell{128;ts=1577718040933619;expiry=-1,ttl=0}, column read_repair_chance atomic_cell{0;ts=1577718040933619;expiry=-1,ttl=0}, column speculative_retry atomic_cell{99.0PERCENTILE;ts=1577718040933619;expiry=-1,ttl=0}}}, {canonical_mutation: table_id 24101c25-a2ae-3af7-87c1-b40ee1aca33f schema_version a4fe505b-053c-3486-9d6a-bd283d568c10 partition_key pk{00026b73} partition_tombstone {tombstone: none}{row {position: clustered,ckp{000374616200026964},0} tombstone {row_tombstone: none} marker {row_marker: }, column clustering_order atomic_cell{NONE;ts=1577718040933619;expiry=-1,ttl=0}, column column_name_bytes atomic_cell{6964;ts=1577718040933619;expiry=-1,ttl=0}, column kind atomic_cell{partition_key;ts=1577718040933619;expiry=-1,ttl=0}, column position atomic_cell{0;ts=1577718040933619;expiry=-1,ttl=0}, column type atomic_cell{int;ts=1577718040933619;expiry=-1,ttl=0}}}, {canonical_mutation: table_id cc7c7069-3740-33c1-92a4-c3de78dbd2c4 schema_version 723420b4-8501-3ecd-92dd-b01de2e227f6 partition_key pk{00026b73} partition_tombstone {tombstone: none}}, {canonical_mutation: table_id 0feb57ac-311f-382f-ba6d-9024d305702f schema_version a7860a8c-d89c-30b0-98ba-279ae67fae1e partition_key pk{00026b73} partition_tombstone {tombstone: none}}, {canonical_mutation: table_id 5e7583b5-f3f4-3af1-9a39-b7e1d6f5f11f schema_version d4e2a352-3e28-3297-b746-461236df0a1e partition_key pk{00026b73} partition_tombstone {tombstone: none}}, {canonical_mutation: table_id 5d912ff1-f759-3665-b2c8-8042ab5103dd schema_version d15e4b38-4294-3cf3-b7e2-5485bd5c9367 partition_key pk{00026b73} partition_tombstone {tombstone: none}{row {position: clustered,ckp{0003746162},0} tombstone {row_tombstone: none} marker {row_marker: }, column cdc atomic_cell{({enabled : false}, {postimage : false}, {preimage : false}, {ttl : 86400});ts=1577718040933619;expiry=-1,ttl=0}, column version atomic_cell{255c3951-2b15-11ea-b830-000000000001;ts=1577718040933619;expiry=-1,ttl=0}}}, {canonical_mutation: table_id abac5682-dea6-31c5-b535-b3d6cffd0fb6 schema_version 546e75bd-58af-3eb4-8017-5f7c54bad49c partition_key pk{00026b73} partition_tombstone {tombstone: none}{row {position: clustered,ckp{},0} tombstone {row_tombstone: none} marker {row_marker: }, column durable_writes atomic_cell{true;ts=1577718037239063;expiry=-1,ttl=0}, column replication atomic_cell{({class : org.apache.cassandra.locator.SimpleStrategy}, {replication_factor : 3});ts=1577718037239063;expiry=-1,ttl=0}}}}}
```

(this is a vector<canonical_mutation> object, so the word "canonical_mutation" appears multiple times).