### PR TITLE
cql3: detect and handle int overflow in aggregate functions

### DIFF
--- a/cql3/functions/aggregate_fcts.cc
+++ b/cql3/functions/aggregate_fcts.cc
@@ -165,7 +165,7 @@ make_sum_function() {
 template <typename Type>
 class impl_div_for_avg {
 public:
-    static Type div(const Type& x, const int64_t y) {
+    static Type div(const typename accumulator_for<Type>::type& x, const int64_t y) {
         return x/y;
     }
 };

--- a/exceptions/exceptions.hh
+++ b/exceptions/exceptions.hh
@@ -65,6 +65,8 @@ enum class exception_code : int32_t {
     WRITE_FAILURE   = 0x1500,
     READ_TIMEOUT    = 0x1200,
     READ_FAILURE    = 0x1300,
+    FUNCTION_FAILURE= 0x1400,
+    CDC_WRITE_FAILURE = 0x1600,
 
     // 2xx: problem validating the request
     SYNTAX_ERROR    = 0x2000,

--- a/exceptions/exceptions.hh
+++ b/exceptions/exceptions.hh
@@ -68,6 +68,10 @@ enum class exception_code : int32_t {
     WRITE_FAILURE   = 0x1500,
     CDC_WRITE_FAILURE = 0x1600,
 
+    // Scylla-specific codes
+    // Allocated backwards from 0x1aff-0x1a01 to minimize the chance of collision with Cassandra.
+    OVERFLOW_ERROR  = 0x1aff,
+
     // 2xx: problem validating the request
     SYNTAX_ERROR    = 0x2000,
     UNAUTHORIZED    = 0x2100,
@@ -203,6 +207,12 @@ struct read_failure_exception : public request_failure_exception {
         : request_failure_exception{exception_code::READ_FAILURE, ks, cf, consistency_, received_, failures_, block_for_}
         , data_present{data_present_}
     { }
+};
+
+class overflow_error_exception: public cassandra_exception {
+public:
+    overflow_error_exception(sstring msg) noexcept
+        : cassandra_exception(exception_code::OVERFLOW_ERROR, std::move(msg)) {}
 };
 
 struct overloaded_exception : public cassandra_exception {

--- a/exceptions/exceptions.hh
+++ b/exceptions/exceptions.hh
@@ -62,10 +62,10 @@ enum class exception_code : int32_t {
     IS_BOOTSTRAPPING= 0x1002,
     TRUNCATE_ERROR  = 0x1003,
     WRITE_TIMEOUT   = 0x1100,
-    WRITE_FAILURE   = 0x1500,
     READ_TIMEOUT    = 0x1200,
     READ_FAILURE    = 0x1300,
     FUNCTION_FAILURE= 0x1400,
+    WRITE_FAILURE   = 0x1500,
     CDC_WRITE_FAILURE = 0x1600,
 
     // 2xx: problem validating the request


### PR DESCRIPTION
Fix overflow handling in sum() and avg().

sum:
- aggregated into __int128
- detect overflow when computing result
  - and log a warning if found

avg:
- fix division function to divide the accumulator type _sum (__int128 for integers) by _count

- Add unit tests for both cases

Test:
- manual test against Cassandra 3.11.3 to make sure the results in the scylla unit test agree with it.
- unit(dev), cql_query_test(debug)

Fixes #5536
