### PR TITLE
dist/ami: switch AMI distribution to Amazon Linux 2

### DIFF
--- a/dist/ami/build_ami.sh
+++ b/dist/ami/build_ami.sh
@@ -62,9 +62,8 @@ pkg_install() {
     fi
 }
 
-AMI=ami-ae7bfdb8
 REGION=us-east-1
-SSH_USERNAME=centos
+SSH_USERNAME=ec2-user
 
 if [ $LOCALRPM -eq 1 ]; then
     REPO=`./scripts/scylla_current_repo --target centos`
@@ -207,4 +206,4 @@ if [ ! -d packer ]; then
     cd -
 fi
 
-env PACKER_LOG=1 PACKER_LOG_PATH=../../build/ami.log packer/packer build -var-file=variables.json -var install_args="$INSTALL_ARGS" -var region="$REGION" -var source_ami="$AMI" -var ssh_username="$SSH_USERNAME" -var scylla_version="$SCYLLA_VERSION" -var scylla_ami_version="$SCYLLA_AMI_VERSION" -var scylla_jmx_version="$SCYLLA_JMX_VERSION" -var scylla_tools_version="$SCYLLA_TOOLS_VERSION" -var scylla_python3_version="$SCYLLA_PYTHON3_VERSION" -var scylla_ami_description="${SCYLLA_AMI_DESCRIPTION:0:255}" scylla.json
+env PACKER_LOG=1 PACKER_LOG_PATH=../../build/ami.log packer/packer build -var-file=variables.json -var install_args="$INSTALL_ARGS" -var region="$REGION" -var ssh_username="$SSH_USERNAME" -var scylla_version="$SCYLLA_VERSION" -var scylla_ami_version="$SCYLLA_AMI_VERSION" -var scylla_jmx_version="$SCYLLA_JMX_VERSION" -var scylla_tools_version="$SCYLLA_TOOLS_VERSION" -var scylla_python3_version="$SCYLLA_PYTHON3_VERSION" -var scylla_ami_description="${SCYLLA_AMI_DESCRIPTION:0:255}" scylla.json

--- a/dist/ami/files/99_user_alias.cfg
+++ b/dist/ami/files/99_user_alias.cfg
@@ -1,0 +1,4 @@
+runcmd:
+  - /sbin/userdel -r ec2-user
+  - /sbin/groupdel ec2-user
+  - /sbin/useradd -o -u 1001 -g scyllaadm -d /home/scyllaadm centos

--- a/dist/ami/files/scylla_install_ami
+++ b/dist/ami/files/scylla_install_ami
@@ -29,6 +29,7 @@ import shlex
 import tarfile
 import argparse
 import subprocess
+import os.path
 
 def run(cmd, shell=False):
     if not shell:
@@ -43,6 +44,9 @@ if __name__ == '__main__':
     if os.getuid() > 0:
         print('Requires root permission.')
         sys.exit(1)
+
+    homedir = os.path.abspath(os.path.join(__file__, os.pardir))
+
     parser = argparse.ArgumentParser(description='Construct AMI')
     parser.add_argument('--localrpm', action='store_true', default=False,
                         help='deploy locally built rpms')
@@ -63,12 +67,11 @@ if __name__ == '__main__':
 
     run('yum update -y')
 
-    run('curl -L -o /etc/yum.repos.d/scylla-ami-drivers.repo https://copr.fedorainfracloud.org/coprs/scylladb/scylla-ami-drivers/repo/epel-7/scylladb-scylla-ami-drivers-epel-7.repo')
     if args.repo_for_install:
         run('curl -L -o /etc/yum.repos.d/scylla_install.repo {REPO_FOR_INSTALL}'.format(REPO_FOR_INSTALL=args.repo_for_install))
 
     if args.localrpm:
-        rpms = glob.glob('/home/centos/scylla*.*.rpm')
+        rpms = glob.glob('{}/scylla*.*.rpm'.format(homedir))
         run('yum install -y {}'.format(' '.join(rpms)))
     else:
         run('yum install -y scylla-ami scylla-debuginfo')
@@ -84,38 +87,20 @@ if __name__ == '__main__':
         lines = f.readlines()
     with open('/etc/cloud/cloud.cfg', 'w') as f:
         for l in lines:
+            if re.match(r'^    name: ec2-user\n$', l):
+                f.write('    name: scyllaadm\n')
+                continue
             if not re.match(r'^ - mounts\n$', l):
                 f.write(l)
     run('/opt/scylladb/scripts/scylla_setup --ntp-domain amazon --no-coredump-setup --no-sysconfig-setup --no-raid-setup --no-io-setup --no-bootparam-setup --no-ec2-check')
     run('/opt/scylladb/scripts/scylla_sysconfig_setup --ami')
     run('/opt/scylladb/scripts/scylla_bootparam_setup --ami')
-    os.remove('/home/centos/.ssh/authorized_keys')
+    os.remove('{}/.ssh/authorized_keys'.format(homedir))
     os.remove('/var/lib/scylla-housekeeping/housekeeping.uuid')
-
-    run('yum -y update kernel')
-    run('yum -y install dkms git grubby kernel-devel')
-    run('rpm -e kernel-$(uname -r)', shell=True)
-    run('rpm --import https://www.elrepo.org/RPM-GPG-KEY-elrepo.org')
-    run('rpm -Uvh http://www.elrepo.org/elrepo-release-7.0-3.el7.elrepo.noarch.rpm')
-    run('yum -y --enablerepo=elrepo-kernel install kernel-ml kernel-ml-devel')
-    os.remove('/etc/udev/rules.d/80-net-name-slot.rules')
-    with open('/etc/default/grub') as f:
-        grub = f.read()
-    grub = re.sub(r'^GRUB_CMDLINE_LINUX="(.+)"$', r'GRUB_CMDLINE_LINUX="\1 net.ifnames=0"', grub, flags=re.MULTILINE)
-    with open('/etc/default/grub', 'w') as f:
-        f.write(grub)
-    run('grub2-mkconfig -o /boot/grub2/grub.cfg')
-    c7kver = get_kver('/boot/vmlinuz-*el7.x86_64')
-    mlkver = get_kver('/boot/vmlinuz-*el7.elrepo.x86_64')
-    run('grubby --grub2 --set-default /boot/vmlinuz-{mlkver}'.format(mlkver=mlkver))
-    with open('/etc/yum.conf', 'a') as f:
-        f.write(u'exclude=kernel kernel-devel')
-
-    run('dracut --verbose --add-drivers "ixgbevf nvme ena" --force --kver {c7kver}'.format(c7kver=c7kver))
-    run('dracut --verbose --add-drivers "ixgbevf nvme ena" --force --kver {mlkver}'.format(mlkver=mlkver))
 
     with open('/etc/cloud/cloud.cfg') as f:
         cfg = f.read()
-    cfg2 = re.sub('^ssh_deletekeys:   0', 'ssh_deletekeys:   1', cfg, flags=re.MULTILINE)
+    cfg2 = re.sub('^ssh_deletekeys:   false', 'ssh_deletekeys:   true', cfg, flags=re.MULTILINE)
     with open('/etc/cloud/cloud.cfg', 'w') as f:
         f.write(cfg2)
+    shutil.move('{}/99_user_alias.cfg'.format(homedir), '/etc/cloud/cloud.cfg.d')

--- a/dist/ami/scylla.json
+++ b/dist/ami/scylla.json
@@ -44,14 +44,20 @@
       "launch_block_device_mappings": [
         {
           "delete_on_termination": true,
-          "device_name": "/dev/sda1",
+          "device_name": "/dev/xvda",
           "volume_size": 10
         }
       ],
       "region": "{{user `region`}}",
       "secret_key": "{{user `secret_key`}}",
       "security_group_id": "{{user `security_group_id`}}",
-      "source_ami": "{{user `source_ami`}}",
+      "source_ami_filter": {
+          "filters": {
+              "name": "amzn2-ami-hvm-*-x86_64-gp2"
+          },
+          "owners": ["137112412989"],
+          "most_recent": true
+      },
       "ssh_timeout": "5m",
       "ssh_username": "{{user `ssh_username`}}",
       "subnet_id": "{{user `subnet_id`}}",
@@ -89,7 +95,6 @@
     "region": "",
     "secret_key": "",
     "security_group_id": "",
-    "source_ami": "",
     "ssh_username": "",
     "subnet_id": ""
   }

--- a/dist/common/scripts/scylla_bootparam_setup
+++ b/dist/common/scripts/scylla_bootparam_setup
@@ -44,10 +44,10 @@ if __name__ == '__main__':
 
     if os.path.exists('/etc/default/grub'):
         cfg = sysconfig_parser('/etc/default/grub')
-        cmdline_linux = cfg.get('GRUB_CMDLINE_LINUX')
+        cmdline_linux = cfg.get('GRUB_CMDLINE_LINUX_DEFAULT')
         if len(re.findall(r'.*clocksource', cmdline_linux)) == 0:
             cmdline_linux += ' clocksource=tsc tsc=reliable'
-            cfg.set('GRUB_CMDLINE_LINUX', cmdline_linux)
+            cfg.set('GRUB_CMDLINE_LINUX_DEFAULT', cmdline_linux)
             cfg.commit()
             if is_debian_variant():
                 run('update-grub')


### PR DESCRIPTION
On Amazon Linux 2, we can get more recent version kernel by default,
with EC2 device driver support.