### PR TITLE
docker: fix typo of scylla-jmx script path

### DIFF
--- a/dist/docker/redhat/scylla-jmx-service.sh
+++ b/dist/docker/redhat/scylla-jmx-service.sh
@@ -2,4 +2,4 @@
 
 source /etc/sysconfig/scylla-jmx
 
-exec /opt/scylladb/scripts/jmx/scylla-jmx -l /opt/scylladb/scripts/jmx
+exec /opt/scylladb/jmx/scylla-jmx -l /opt/scylladb/jmx


### PR DESCRIPTION
The path should /opt/scylladb/jmx, not /opt/scylladb/scripts/jmx.

Fixes #5542