### PR TITLE
dist/common/scripts/scylla_io_setup: raise error when unsupported instance type

### DIFF
--- a/dist/common/scripts/scylla_io_setup
+++ b/dist/common/scripts/scylla_io_setup
@@ -41,6 +41,9 @@ if __name__ == "__main__":
         if args.ami:
             idata = aws_instance()
 
+            if not idata.is_supported_instance_class():
+                logging.error('{} is not supported instance type, run "scylla_io_setup" again without --ami option.'.format(idata.instance()))
+                sys.exit(1)
             disk_properties = {}
             disk_properties["mountpoint"] = datadir()
             nr_disks = len(idata.ephemeral_disks())


### PR DESCRIPTION
Currently --ami does not check instance types, creates invalid io_properties.yaml on unsupported instance types.
It actually won't occur on AMI startup, since scylla_ami_setup only invoke scylla_io_setup --ami when the instance is supported, so we don't get the issue on startup, but we still get when we run scylla_io_setup manually.

It's better to check instance type on scylla_io_setup, too.

Related #5438