### PR TITLE
CDC: do mutation augmentation from storage proxy

### DIFF
--- a/cdc/cdc.cc
+++ b/cdc/cdc.cc
@@ -72,6 +72,7 @@ static future<> populate_desc(db_context ctx, const schema& s);
 }
 
 class cdc::cdc_service::impl : service::migration_listener::empty_listener {
+    friend cdc_service;
     db_context _ctxt;
 public:
     impl(db_context ctxt)
@@ -194,7 +195,9 @@ cdc::cdc_service::cdc_service(service::storage_proxy& proxy)
 
 cdc::cdc_service::cdc_service(db_context ctxt)
     : _impl(std::make_unique<impl>(std::move(ctxt)))
-{}
+{
+    _impl->_ctxt._proxy.set_cdc_service(this);
+}
 
 cdc::cdc_service::~cdc_service() = default;
 

--- a/cdc/cdc.hh
+++ b/cdc/cdc.hh
@@ -138,33 +138,4 @@ seastar::sstring log_name(const seastar::sstring& table_name);
 
 seastar::sstring desc_name(const seastar::sstring& table_name);
 
-/// \brief For each mutation in the set appends related CDC Log mutation
-///
-/// This function should be called with a set of mutations of a table
-/// with CDC enabled. Returned set of mutations contains all original mutations
-/// and for each original mutation appends a mutation to CDC Log that reflects
-/// the change.
-///
-/// \param[in] ctx object with references to database components
-/// \param[in] s schema of a CDC enabled table which is being modified
-/// \param[in] timeout period of time after which a request is considered timed out
-/// \param[in] qs the state of the query that's being executed
-/// \param[in] mutations set of changes of a CDC enabled table
-///
-/// \return set of mutations from input parameter with relevant CDC Log mutations appended
-///
-/// \pre CDC Log and CDC Description have to exist
-/// \pre CDC Description has to be in sync with cluster topology
-///
-/// \note At the moment, cluster topology changes are not supported
-//        so the assumption that CDC Description is in sync with cluster topology
-//        is easy to enforce. When support for cluster topology changes is added
-//        it has to make sure the assumption holds.
-seastar::future<std::vector<mutation>>append_log_mutations(
-        db_context ctx,
-        schema_ptr s,
-        lowres_clock::time_point timeout,
-        service::query_state& qs,
-        std::vector<mutation> mutations);
-
 } // namespace cdc

--- a/cql3/statements/modification_statement.cc
+++ b/cql3/statements/modification_statement.cc
@@ -39,7 +39,6 @@
  * along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "cdc/cdc.hh"
 #include "cql3/statements/modification_statement.hh"
 #include "cql3/statements/raw/modification_statement.hh"
 #include "cql3/statements/prepared_statement.hh"
@@ -327,23 +326,8 @@ modification_statement::execute_without_condition(service::storage_proxy& proxy,
         if (mutations.empty()) {
             return now();
         }
-
-        auto mutate = [&, cl, timeout] (std::vector<mutation> mutations) {
-            return proxy.mutate_with_triggers(std::move(mutations), cl, timeout, false, qs.get_trace_state(), qs.get_permit(), this->is_raw_counter_shard_write());
-        };
-
-        if (qs.get_client_state().is_internal() || qs.get_client_state().is_thrift() || !s->cdc_options().enabled()) {
-            return mutate(std::move(mutations));
-        }
-        return cdc::append_log_mutations(
-                cdc::db_context::builder(proxy).build(),
-                s,
-                timeout,
-                qs,
-                std::move(mutations))
-        .then([cl, timeout, &proxy, &qs, mutate = std::move(mutate)] (std::vector<mutation> mutations) {
-            return mutate(std::move(mutations));
-        });
+        
+        return proxy.mutate_with_triggers(std::move(mutations), cl, timeout, false, qs.get_trace_state(), qs.get_permit(), this->is_raw_counter_shard_write());
     });
 }
 

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -87,6 +87,7 @@
 #include "multishard_mutation_query.hh"
 #include "database.hh"
 #include "db/consistency_level_validations.hh"
+#include "cdc/cdc.hh"
 
 namespace bi = boost::intrusive;
 
@@ -2005,6 +2006,17 @@ storage_proxy::get_paxos_participants(const sstring& ks_name, const dht::token &
  * @param tr_state trace state handle
  */
 future<> storage_proxy::mutate(std::vector<mutation> mutations, db::consistency_level cl, clock_type::time_point timeout, tracing::trace_state_ptr tr_state, service_permit permit, bool raw_counters) {
+    if (_cdc && _cdc->needs_cdc_augmentation(mutations)) {
+        return _cdc->augment_mutation_call(timeout, std::move(mutations)).then([this, cl, timeout, tr_state = std::move(tr_state), permit = std::move(permit), raw_counters](std::tuple<std::vector<mutation>, cdc::result_callback>&& t) mutable {
+            auto mutations = std::move(std::get<0>(t));
+            auto end_func = std::move(std::get<1>(t));
+            auto f = _mutate_stage(this, std::move(mutations), cl, timeout, std::move(tr_state), std::move(permit), raw_counters);
+            if (end_func) {
+                f = f.then(std::move(end_func));
+            }
+            return f;
+        });
+    }
     return _mutate_stage(this, std::move(mutations), cl, timeout, std::move(tr_state), std::move(permit), raw_counters);
 }
 
@@ -2162,19 +2174,35 @@ storage_proxy::mutate_atomically(std::vector<mutation> mutations, db::consistenc
         }
     };
 
-    auto mk_ctxt = [this, tr_state, timeout, permit = std::move(permit)] (std::vector<mutation> mutations, db::consistency_level cl) mutable {
+    auto mk_ctxt = [this, tr_state, timeout, permit = std::move(permit), cl] (std::vector<mutation> mutations) mutable {
       try {
           return make_ready_future<lw_shared_ptr<context>>(make_lw_shared<context>(*this, std::move(mutations), cl, timeout, std::move(tr_state), std::move(permit)));
       } catch(...) {
           return make_exception_future<lw_shared_ptr<context>>(std::current_exception());
       }
     };
-
-    return mk_ctxt(std::move(mutations), cl).then([this] (lw_shared_ptr<context> ctxt) {
-        return ctxt->run().finally([ctxt]{});
-    }).then_wrapped([p = shared_from_this(), lc, tr_state = std::move(tr_state)] (future<> f) mutable {
+    auto cleanup = [p = shared_from_this(), lc, tr_state = std::move(tr_state)] (future<> f) mutable {
         return p->mutate_end(std::move(f), lc, p->_stats, std::move(tr_state));
-    });
+    };
+
+    if (_cdc && _cdc->needs_cdc_augmentation(mutations)) {
+        return _cdc->augment_mutation_call(timeout, std::move(mutations)).then([this, mk_ctxt = std::move(mk_ctxt), cleanup = std::move(cleanup)](std::tuple<std::vector<mutation>, cdc::result_callback>&& t) mutable {
+            auto mutations = std::move(std::get<0>(t));
+            auto end_func = std::get<1>(t);
+            auto f = std::move(mk_ctxt)(std::move(mutations)).then([this] (lw_shared_ptr<context> ctxt) {
+                return ctxt->run().finally([ctxt]{});
+            }).then_wrapped(std::move(cleanup));
+
+            if (end_func) {
+                f = f.then(std::move(end_func));                
+            }
+            return f;
+        });
+    }
+
+    return mk_ctxt(std::move(mutations)).then([this] (lw_shared_ptr<context> ctxt) {
+        return ctxt->run().finally([ctxt]{});
+    }).then_wrapped(std::move(cleanup));
 }
 
 template<typename Range>

--- a/service/storage_proxy.hh
+++ b/service/storage_proxy.hh
@@ -86,6 +86,10 @@ class one_or_two_partition_ranges;
 
 }
 
+namespace cdc {
+    class cdc_service;    
+}
+
 namespace service {
 
 class abstract_write_response_handler;
@@ -268,6 +272,7 @@ private:
     class view_update_handlers_list;
     std::unique_ptr<view_update_handlers_list> _view_update_handlers_list;
 
+    cdc::cdc_service* _cdc = nullptr;
 private:
     future<> uninit_messaging_service();
     future<coordinator_query_result> query_singular(lw_shared_ptr<query::read_command> cmd,
@@ -399,6 +404,13 @@ public:
     }
     distributed<database>& get_db() {
         return _db;
+    }
+
+    void set_cdc_service(cdc::cdc_service* cdc) {
+        _cdc = cdc;
+    }
+    cdc::cdc_service* get_cdc_service() const {
+        return _cdc;
     }
 
     view_update_handlers_list& get_view_update_handlers_list() {

--- a/service/storage_proxy.hh
+++ b/service/storage_proxy.hh
@@ -388,6 +388,9 @@ private:
     void maybe_update_view_backlog_of(gms::inet_address, std::optional<db::view::update_backlog>);
 
     db::view::update_backlog get_backlog_of(gms::inet_address) const;
+
+    template<typename Range>
+    future<> mutate_counters(Range&& mutations, db::consistency_level cl, tracing::trace_state_ptr tr_state, service_permit permit, clock_type::time_point timeout);
 public:
     storage_proxy(distributed<database>& db, config cfg, db::view::node_update_backlog& max_view_update_backlog);
     ~storage_proxy();
@@ -440,9 +443,6 @@ public:
 
     future<> replicate_counter_from_leader(mutation m, db::consistency_level cl, tracing::trace_state_ptr tr_state,
                                            clock_type::time_point timeout, service_permit permit);
-
-    template<typename Range>
-    future<> mutate_counters(Range&& mutations, db::consistency_level cl, tracing::trace_state_ptr tr_state, service_permit permit, clock_type::time_point timeout);
 
     future<> mutate_with_triggers(std::vector<mutation> mutations, db::consistency_level cl, clock_type::time_point timeout,
                                   bool should_mutate_atomically, tracing::trace_state_ptr tr_state, service_permit permit, bool raw_counters = false);


### PR DESCRIPTION
Fixes #5314

Instead of tying CDC handling into cql statement objects, this patch set moves it to storage proxy, i.e. shared code for mutating stuff. This means we automatically handle cdc for code paths outside cql (i.e. alternator). 

It also adds api handling (though initially inefficient) for batch statements. 

CDC is tied into storage proxy by giving the former a ref to the latter (per shard). Initially this is _not_ a constructor parameter, because right now we have chicken and egg issues here. Hopefully, Pavels refactoring of migration manager and notifications will untie these and this relationship can become nicer. 

The actual augmentation can (as stated above) be made much more efficient. Hopefully, the stream management refactoring will deal with expensive stream lookup, and eventually, we can maybe coalesce pre-image selects for batches. However, that is left as an exercise for when deemed needed. 

The augmentation API has an optional return value for a "post-image handler" to be used iff returned after mutation call is finished (and successful). It is not yet actually invoked from storage_proxy, but it is at least in the call chain. 

v2:
- Changed storage proxy batch mutation augment to run outside context object
- Added code in storage proxy to actually handle (currently unimplemented) post image hooks. 