### PR TITLE
storage_proxy: [RFC] intercept `rpc::closed_error` if counter leader is down

### DIFF
--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -1917,6 +1917,8 @@ future<> storage_proxy::mutate_counters(Range&& mutations, db::consistency_level
                 return make_exception_future<>(mutation_write_timeout_exception(s->ks_name(), s->cf_name(), cl, 0, db::block_for(ks, cl), db::write_type::COUNTER));
             } catch (timed_out_error&) {
                 return make_exception_future<>(mutation_write_timeout_exception(s->ks_name(), s->cf_name(), cl, 0, db::block_for(ks, cl), db::write_type::COUNTER));
+            } catch (rpc::closed_error&) {
+                return make_exception_future<>(mutation_write_failure_exception(s->ks_name(), s->cf_name(), cl, 0, 1, db::block_for(ks, cl), db::write_type::COUNTER));
             }
         };
 


### PR DESCRIPTION
When counter mutation is about to be sent, a leader is elected. If the leader node fails after election, we get `rpc::closed_error`. That exception propagated high up, causing all client connections to be dropped.

This patch intercepts `rpc::closed_error` in `storage_proxy::mutate_counters` and translates it to `mutation_write_failure_exception` (which is, in turn, translated to response with error code). I assume that hinted handoffs will eventually take over the unsent mutation.

RFC because critical code paths are affected and I'm new to counters.

References #2859