### PR TITLE
dist/redhat: install specified version of scylla-enterprise-conf on meta package

### DIFF
--- a/dist/redhat/scylla.spec.mustache
+++ b/dist/redhat/scylla.spec.mustache
@@ -7,7 +7,7 @@ Group:          Applications/Databases
 License:        AGPLv3
 URL:            http://www.scylladb.com/
 Source0:        {{reloc_pkg}}
-Requires:       {{product}}-server = {{version}} {{product}}-jmx = {{version}} {{product}}-tools = {{version}} {{product}}-tools-core = {{version}} {{product}}-kernel-conf = {{version}}
+Requires:       {{product}}-server = {{version}} {{product}}-conf = {{version}} {{product}}-kernel-conf = {{version}} {{product}}-jmx = {{version}} {{product}}-tools = {{version}} {{product}}-tools-core = {{version}}
 Obsoletes:	scylla-server < 1.1
 
 %global _debugsource_template %{nil}


### PR DESCRIPTION
To install specified version of scylla-conf package, we need to add it on Requires.

See scylladb/scylla-enterprise#1203