### PR TITLE
Simplify sum overflow

### DIFF
--- a/cql3/functions/aggregate_fcts.cc
+++ b/cql3/functions/aggregate_fcts.cc
@@ -81,86 +81,33 @@ public:
 template <typename T>
 struct accumulator_for;
 
-template <typename NarrowType, typename AccType>
-static NarrowType checking_narrow(AccType acc) {
-    NarrowType ret = static_cast<NarrowType>(acc);
-    if (static_cast<AccType>(ret) != acc) {
-        throw exceptions::overflow_error_exception("Sum overflow. Values should be casted to a wider type.");
-    }
-    return ret;
-}
-
-template <>
-struct accumulator_for<int8_t> {
+template <typename T>
+struct int128_accumulator_for {
     using type = __int128;
 
-    static int8_t narrow(type acc) {
-        return checking_narrow<int8_t>(acc);
+    static T narrow(type acc) {
+        T ret = static_cast<T>(acc);
+        if (static_cast<type>(ret) != acc) {
+            throw exceptions::overflow_error_exception("Sum overflow. Values should be casted to a wider type.");
+        }
+        return ret;
     }
 };
 
-template <>
-struct accumulator_for<int16_t> {
-    using type = __int128;
+template <typename T>
+struct same_type_accumulator_for {
+    using type = T;
 
-    static int16_t narrow(type acc) {
-        return checking_narrow<int16_t>(acc);
-    }
-};
-
-template <>
-struct accumulator_for<int32_t> {
-    using type = __int128;
-
-    static int32_t narrow(type acc) {
-        return checking_narrow<int32_t>(acc);
-    }
-};
-
-template <>
-struct accumulator_for<int64_t> {
-    using type = __int128;
-
-    static int64_t narrow(type acc) {
-        return checking_narrow<int64_t>(acc);
-    }
-};
-
-template <>
-struct accumulator_for<float> {
-    using type = float;
-
-    static auto narrow(type acc) {
+    static T narrow(type acc) {
         return acc;
     }
 };
 
-template <>
-struct accumulator_for<double> {
-    using type = double;
-
-    static auto narrow(type acc) {
-        return acc;
-    }
-};
-
-template <>
-struct accumulator_for<boost::multiprecision::cpp_int> {
-    using type = boost::multiprecision::cpp_int;
-
-    static auto narrow(type acc) {
-        return acc;
-    }
-};
-
-template <>
-struct accumulator_for<big_decimal> {
-    using type = big_decimal;
-
-    static auto narrow(type acc) {
-        return acc;
-    }
-};
+template <typename T>
+struct accumulator_for : public std::conditional_t<std::is_integral_v<T>,
+                                                   int128_accumulator_for<T>,
+                                                   same_type_accumulator_for<T>>
+{ };
 
 template <typename Type>
 class impl_sum_function_for final : public aggregate_function::aggregate {

--- a/test/boost/cql_query_test.cc
+++ b/test/boost/cql_query_test.cc
@@ -4413,6 +4413,74 @@ SEASTAR_TEST_CASE(test_int_sum_with_cast) {
     });
 }
 
+SEASTAR_TEST_CASE(test_float_sum_overflow) {
+    return do_with_cql_env_thread([] (cql_test_env& e) {
+        cquery_nofail(e, "create table cf (pk text, val float, primary key(pk));");
+        BOOST_TEST_MESSAGE("make sure we can sum close to the max value");
+        cquery_nofail(e, "insert into cf (pk, val) values ('a', 3.4028234e+38);");
+        auto result = e.execute_cql("select sum(val) from cf;").get0();
+        assert_that(result)
+            .is_rows()
+            .with_size(1)
+            .with_row({serialized(3.4028234e+38f)});
+        BOOST_TEST_MESSAGE("cause overflow");
+        cquery_nofail(e, "insert into cf (pk, val) values ('b', 1e+38);");
+        result = e.execute_cql("select sum(val) from cf;").get0();
+        assert_that(result)
+            .is_rows()
+            .with_size(1)
+            .with_row({serialized(std::numeric_limits<float>::infinity())});
+        BOOST_TEST_MESSAGE("test maximum negative value");
+        cquery_nofail(e, "insert into cf (pk, val) values ('a', -3.4028234e+38);");
+        result = e.execute_cql("select sum(val) from cf;").get0();
+        assert_that(result)
+            .is_rows()
+            .with_size(1)
+            .with_row({serialized(-2.4028234e+38f)});
+        BOOST_TEST_MESSAGE("cause negative overflow");
+        cquery_nofail(e, "insert into cf (pk, val) values ('c', -2e+38);");
+        result = e.execute_cql("select sum(val) from cf;").get0();
+        assert_that(result)
+            .is_rows()
+            .with_size(1)
+            .with_row({serialized(-std::numeric_limits<float>::infinity())});
+    });
+}
+
+SEASTAR_TEST_CASE(test_double_sum_overflow) {
+    return do_with_cql_env_thread([] (cql_test_env& e) {
+        cquery_nofail(e, "create table cf (pk text, val double, primary key(pk));");
+        BOOST_TEST_MESSAGE("make sure we can sum close to the max value");
+        cquery_nofail(e, "insert into cf (pk, val) values ('a', 1.79769313486231570814527423732e+308);");
+        auto result = e.execute_cql("select sum(val) from cf;").get0();
+        assert_that(result)
+            .is_rows()
+            .with_size(1)
+            .with_row({serialized(1.79769313486231570814527423732E308)});
+        BOOST_TEST_MESSAGE("cause overflow");
+        cquery_nofail(e, "insert into cf (pk, val) values ('b', 0.5e+308);");
+        result = e.execute_cql("select sum(val) from cf;").get0();
+        assert_that(result)
+            .is_rows()
+            .with_size(1)
+            .with_row({serialized(std::numeric_limits<double>::infinity())});
+        BOOST_TEST_MESSAGE("test maximum negative value");
+        cquery_nofail(e, "insert into cf (pk, val) values ('a', -1.79769313486231570814527423732e+308);");
+        result = e.execute_cql("select sum(val) from cf;").get0();
+        assert_that(result)
+            .is_rows()
+            .with_size(1)
+            .with_row({serialized(-1.29769313486231570814527423732e+308)});
+        BOOST_TEST_MESSAGE("cause negative overflow");
+        cquery_nofail(e, "insert into cf (pk, val) values ('c', -1e+308);");
+        result = e.execute_cql("select sum(val) from cf;").get0();
+        assert_that(result)
+            .is_rows()
+            .with_size(1)
+            .with_row({serialized(-std::numeric_limits<double>::infinity())});
+    });
+}
+
 SEASTAR_TEST_CASE(test_int_avg) {
     return do_with_cql_env_thread([] (cql_test_env& e) {
         cquery_nofail(e, "create table cf (pk text, val int, primary key(pk));");


### PR DESCRIPTION
As a followup to 0bde5906b3337be7691a8fd62d3dfe98e07437e4
This series implements suggestions from @avikivity and @espindola 
It simplifies the template definitions for `accumulator_for`,
adds some debug logging for the overflow values,
and adds unit tests for float and double sum overflow.

Test: unit(dev),
paging_test:TestPagingWithIndexingAndAggregation.test_filter_{indexed,non_indexed,pk}_column(dev)