### PR TITLE
dist/redhat: override systemd macros to CentOS7 version

### DIFF
--- a/dist/redhat/build_rpm.sh
+++ b/dist/redhat/build_rpm.sh
@@ -93,5 +93,6 @@ fi
 rpm_payload_opts=(--define "_binary_payload w2${xz_thread_param}.xzdio")
 
 ln -fv $RELOC_PKG $RPMBUILD/SOURCES/
+ln -fv dist/redhat/systemd.inc $RPMBUILD/SOURCES/
 pystache dist/redhat/scylla.spec.mustache "{ \"version\": \"$SCYLLA_VERSION\", \"release\": \"$SCYLLA_RELEASE\", \"housekeeping\": $DIST, \"product\": \"$PRODUCT\", \"$PRODUCT\": true, \"reloc_pkg\": \"$RELOC_PKG_BASENAME\" }" > $RPMBUILD/SPECS/scylla.spec
 rpmbuild -ba "${rpm_payload_opts[@]}" --define "_topdir $RPMBUILD" $RPMBUILD/SPECS/scylla.spec

--- a/dist/redhat/scylla.spec.mustache
+++ b/dist/redhat/scylla.spec.mustache
@@ -7,8 +7,11 @@ Group:          Applications/Databases
 License:        AGPLv3
 URL:            http://www.scylladb.com/
 Source0:        {{reloc_pkg}}
+Source1:        systemd.inc
 Requires:       {{product}}-server = {{version}} {{product}}-jmx = {{version}} {{product}}-tools = {{version}} {{product}}-tools-core = {{version}} {{product}}-kernel-conf = {{version}}
 Obsoletes:	scylla-server < 1.1
+
+%include %{SOURCE1}
 
 %global _debugsource_template %{nil}
 %global _debuginfo_subpackages %{nil}

--- a/dist/redhat/systemd.inc
+++ b/dist/redhat/systemd.inc
@@ -1,0 +1,19 @@
+%define systemd_daemon_reload \
+if [ -x /usr/bin/systemctl ]; then \
+    /usr/bin/systemctl daemon-reload ||: \
+fi \
+%{nil}
+
+%undefine systemd_post
+%define systemd_post() %{expand:%systemd_daemon_reload}
+
+%undefine systemd_preun
+%define systemd_preun() \
+if [ $1 -eq 0 ] && [ -x /usr/bin/systemctl ]; then \
+    /usr/bin/systemctl disable %1 ||: \
+    /usr/bin/systemctl stop %1 ||: \
+fi \
+%{nil}
+
+%undefine systemd_postun
+%define systemd_postun() %{expand:%systemd_daemon_reload}


### PR DESCRIPTION
Fedora 31 version of systemd macros does not work correctly on CentOS7,
since CentOS7 does not support "file trigger" feature.
To fix the issue we need to override macros with CentOS7 version.

See scylladb/scylla-jmx#94