### PR TITLE
gossiper: Introduce gossip STATUS_UNKNOWN

### DIFF
--- a/db/hints/manager.cc
+++ b/db/hints/manager.cc
@@ -437,7 +437,7 @@ bool manager::end_point_hints_manager::sender::can_send() noexcept {
                     !ep_state_ptr ||
                     (ep_gossip_state_val != gms::versioned_value::STATUS_NORMAL &&
                     ep_gossip_state_val != gms::versioned_value::SHUTDOWN &&
-                    ep_gossip_state_val != "")
+                    ep_gossip_state_val != gms::versioned_value::STATUS_UNKNOWN)
                 );
             }
             // send the hints out if the destination Node is part of the ring - we will send to all new replicas in this case

--- a/gms/gossiper.cc
+++ b/gms/gossiper.cc
@@ -2081,13 +2081,13 @@ void gossiper::force_newer_generation() {
 
 static sstring do_get_gossip_status(const gms::versioned_value* app_state) {
     if (!app_state) {
-        return "";
+        return gms::versioned_value::STATUS_UNKNOWN;
     }
     auto value = app_state->value;
     std::vector<sstring> pieces;
     boost::split(pieces, value, boost::is_any_of(","));
     if (pieces.empty()) {
-        return "";
+        return gms::versioned_value::STATUS_UNKNOWN;
     }
     return pieces[0];
 }
@@ -2178,7 +2178,7 @@ bool gossiper::is_safe_for_bootstrap(inet_address endpoint) {
 
     // these states are not allowed to join the cluster as it would not be safe
     std::unordered_set<sstring> unsafe_statuses{
-        sstring(""), // failed bootstrap but we did start gossiping
+        sstring(versioned_value::STATUS_UNKNOWN), // failed bootstrap but we did start gossiping
         sstring(versioned_value::STATUS_NORMAL), // node is legit in the cluster or it was stopped with kill -9
         sstring(versioned_value::SHUTDOWN) // node was shutdown
     };

--- a/gms/versioned_value.cc
+++ b/gms/versioned_value.cc
@@ -42,6 +42,7 @@ namespace gms {
 
 constexpr char versioned_value::DELIMITER;
 constexpr const char versioned_value::DELIMITER_STR[];
+constexpr const char* versioned_value::STATUS_UNKNOWN;
 constexpr const char* versioned_value::STATUS_BOOTSTRAPPING;
 constexpr const char* versioned_value::STATUS_NORMAL;
 constexpr const char* versioned_value::STATUS_LEAVING;

--- a/gms/versioned_value.hh
+++ b/gms/versioned_value.hh
@@ -71,6 +71,7 @@ public:
     static constexpr const char DELIMITER_STR[] = { DELIMITER, 0 };
 
     // values for ApplicationState.STATUS
+    static constexpr const char* STATUS_UNKNOWN = "UNKNOWN";
     static constexpr const char* STATUS_BOOTSTRAPPING = "BOOT";
     static constexpr const char* STATUS_NORMAL = "NORMAL";
     static constexpr const char* STATUS_LEAVING = "LEAVING";

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -1670,7 +1670,7 @@ future<> storage_service::check_for_endpoint_collision(const std::unordered_map<
                 found_bootstrapping_node = false;
                 for (auto& x : _gossiper.get_endpoint_states()) {
                     auto state = _gossiper.get_gossip_status(x.second);
-                    if (state.empty()) {
+                    if (state == sstring(versioned_value::STATUS_UNKNOWN)) {
                         continue;
                     }
                     auto addr = x.first;


### PR DESCRIPTION
When a node does not have gossip STATUS application_state, we currently
use an empty string to present such state in get_gossip_status.

It is better to use an explicit "UNKNOWN" to present it. It makes the
log easier to understand when the status is unknown.

 Before:

   'gossip - InetAddress n2 is now UP, status ='

 After:

   'gossip - InetAddress n2 is now UP, status = UNKNOWN'

This patch is safe because the STATUS_UNKNOWN is never sent over the
cluster. So the presentation is only internal to the node.

Fixes #5520