### PR TITLE
db,view: fix checking for secondary index special columns

### DIFF
--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -311,7 +311,7 @@ deletable_row& view_updates::get_view_row(const partition_key& base_key, const c
             if (!cdef.is_computed()) {
                 //FIXME(sarna): this legacy code is here for backward compatibility and should be removed
                 // once "computed_columns feature" is supported by every node
-                if (!service::get_local_storage_service().db().local().find_column_family(_base->id()).get_index_manager().is_index(*_base)) {
+                if (!service::get_local_storage_service().db().local().find_column_family(_base->id()).get_index_manager().is_index(*_view)) {
                     throw std::logic_error(format("Column {} doesn't exist in base and this view is not backing a secondary index", cdef.name_as_text()));
                 }
                 computed_value = token_column_computation().compute_value(*_base, base_key, update);


### PR DESCRIPTION
A mistake in handling legacy checks for special 'idx_token' column
resulted in not recognizing materialized views backing secondary
indexes properly. The mistake is really a typo, but with bad
consequences - instead of checking the view schema for being an index,
we asked for the base schema, which is definitely not an index of
itself.

NOTE: I don't have PC access now, so I can only test it properly first thing tomorrow morning.

Branches 3.1,3.2 (asap)
Fixes #5621
Fixes #4744

/cc @scylladb/scylla-maint @tarzanek @nyh 