### PR TITLE
Futurize get_changed_ranges_for_leaving

### DIFF
--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -2600,6 +2600,7 @@ future<bool> storage_service::is_initialized() {
     });
 }
 
+// Runs inside seastar::async context
 std::unordered_multimap<dht::token_range, inet_address> storage_service::get_changed_ranges_for_leaving(sstring keyspace_name, inet_address endpoint) {
     // First get all ranges the leaving endpoint is responsible for
     auto ranges = get_ranges_for_endpoint(keyspace_name, endpoint);
@@ -2611,6 +2612,7 @@ std::unordered_multimap<dht::token_range, inet_address> storage_service::get_cha
     // Find (for each range) all nodes that store replicas for these ranges as well
     auto metadata = _token_metadata.clone_only_token_map(); // don't do this in the loop! #7758
     for (auto& r : ranges) {
+        seastar::thread::maybe_yield();
         auto& ks = _db.local().find_keyspace(keyspace_name);
         auto end_token = r.end() ? r.end()->value() : dht::maximum_token();
         auto eps = ks.get_replication_strategy().calculate_natural_endpoints(end_token, metadata);
@@ -2633,6 +2635,7 @@ std::unordered_multimap<dht::token_range, inet_address> storage_service::get_cha
     // not in the currentReplicaEndpoints list, will be needing the
     // range.
     for (auto& r : ranges) {
+        seastar::thread::maybe_yield();
         auto& ks = _db.local().find_keyspace(keyspace_name);
         auto end_token = r.end() ? r.end()->value() : dht::maximum_token();
         auto new_replica_endpoints = ks.get_replication_strategy().calculate_natural_endpoints(end_token, temp);


### PR DESCRIPTION
Futurize get_changed_ranges_for_leaving to fix stalls like:

```
   2019-12-17T15:18:33+00:00 ip-10-0-116-62 !INFO | scylla: Reactor stalled
   for 4609 ms on shard 0.

   0x0000000002accbd2
   0x0000000002a4579b
   0x0000000002a45cc2
   0x0000000002a45ff7
   0x00007ff0a609be7f
   0x0000000001b0b500
   0x0000000001b03185
   0x0000000001af0d41
   0x0000000001af027a
   0x0000000001f7e89a
   0x0000000001f9f55a
   0x0000000001fc9c09
   0x0000000001fcac08
   0x00000000007dfee3

   /jenkins/slave/workspace/scylla-3.2/build/scylla/seastar/src/core/reactor.cc:1041
   (inlined by) seastar::reactor::block_notifier(int) at
   /jenkins/slave/workspace/scylla-3.2/build/scylla/seastar/src/core/reactor.cc:1164
   ?? ??:0 __gnu_cxx::__normal_iterator<dht::token const*,
   std::vector<dht::token, std::allocator<dht::token> > >
   std::__lower_bound<__gnu_cxx::__normal_iterator<dht::token const*,
   std::vector<dht::token, std::allocator<dht::token> > >, dht::token,
   __gnu_cxx::__ops::_Iter_less_val>(__gnu_cxx::__normal_iterator<dht::token
   const*, std::vector<dht::token, std::allocator<dht::token> > >,
   __gnu_cxx::__normal_iterator<dht::token const*, std::vector<dht::token,
   std::allocator<dht::token> > >, dht::token const&,
   __gnu_cxx::__ops::_Iter_less_val) at crtstuff.c:?
   locator::token_metadata::first_token_index(dht::token const&) const at
   crtstuff.c:? locator::token_metadata::ring_range(dht::token const&, bool) const at crtstuff.c:?
   locator::simple_strategy::calculate_natural_endpoints(dht::token const&,
   locator::token_metadata&) const at crtstuff.c:?
   service::storage_service::get_changed_ranges_for_leaving(seastar::basic_sstring<char,
   unsigned int, 15u, true>, gms::inet_address) at crtstuff.c:?
   service::storage_service::unbootstrap() at crtstuff.c:?
   service::storage_service::decommission()::{lambda(service::storage_service&)#1}::operator()(service::storage_service&)
   const::{lambda()#1}::operator()() const [clone .isra.0] at
   storage_service.cc:?
```
Refs: #5495
