### PR TITLE
cql3: Fix missing aggregate functions for counters

### DIFF
--- a/cql3/selection/selector.hh
+++ b/cql3/selection/selector.hh
@@ -45,6 +45,7 @@
 #include "cql3/assignment_testable.hh"
 #include "types.hh"
 #include "schema.hh"
+#include "counters.hh"
 
 namespace cql3 {
 
@@ -109,7 +110,11 @@ public:
     virtual assignment_testable::test_result test_assignment(database& db, const sstring& keyspace, ::shared_ptr<column_specification> receiver) override {
         auto t1 = receiver->type->underlying_type();
         auto t2 = get_type()->underlying_type();
-        if (t1 == t2) {
+        // We want columns of `counter_type' to be served by underlying type's overloads
+        // (here: `counter_cell_view::total_value_type()') with an `EXACT_MATCH'.
+        // Weak assignability between the two would lead to ambiguity because
+        // `WEAKLY_ASSIGNABLE' counter->blob conversion exists and would compete.
+        if (t1 == t2 || (t1 == counter_cell_view::total_value_type() && t2->is_counter())) {
             return assignment_testable::test_result::EXACT_MATCH;
         } else if (t1->is_value_compatible_with(*t2)) {
             return assignment_testable::test_result::WEAKLY_ASSIGNABLE;


### PR DESCRIPTION
Aggregate functions for counters do not exist. Until now counters could, at best, fall back to blob->blob overloads, e.g.:

```
cqlsh> select max(cnt) from ks.tbl;

 system.max(cnt)
----------------------
   0x000000000000000a
(1 rows)
cqlsh> select sum(cnt) from ks.tbl;
InvalidRequest: Error from server: code=2200 [Invalid query]
message="Invalid call to function sum, none of its type signatures match
[...]
```

Meanwhile, bigint (`long_type`) overloads (e.g. `sum(bigint)->bigint`) can be used on counters just fine. In this patch this is achieved by special rule in "overload resolution". `selector` now perceives counters as an `EXACT_MATCH` to their underlying type (bigint).

Fixes #3174 