### PR TITLE
view_info: Drop partition_ranges()

### DIFF
--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -118,13 +118,6 @@ const query::partition_slice& view_info::partition_slice() const {
     return *_partition_slice;
 }
 
-const dht::partition_range_vector& view_info::partition_ranges() const {
-    if (!_partition_ranges) {
-        _partition_ranges = select_statement().get_restrictions()->get_partition_key_ranges(cql3::query_options({ }));
-    }
-    return *_partition_ranges;
-}
-
 const column_definition* view_info::view_column(const schema& base, column_id base_id) const {
     // FIXME: Map base column_ids to view_column_ids, which can be something like
     // a boost::small_vector where the position is the base column_id, and the

--- a/view_info.hh
+++ b/view_info.hh
@@ -32,7 +32,6 @@ class view_info final {
     // The following fields are used to select base table rows.
     mutable shared_ptr<cql3::statements::select_statement> _select_statement;
     mutable std::optional<query::partition_slice> _partition_slice;
-    mutable std::optional<dht::partition_range_vector> _partition_ranges;
     // Id of a regular base table column included in the view's PK, if any.
     // Scylla views only allow one such column, alternator can have up to two.
     mutable std::vector<column_id> _base_non_pk_columns_in_view_pk;
@@ -61,7 +60,6 @@ public:
 
     cql3::statements::select_statement& select_statement() const;
     const query::partition_slice& partition_slice() const;
-    const dht::partition_range_vector& partition_ranges() const;
     const column_definition* view_column(const schema& base, column_id base_id) const;
     const column_definition* view_column(const column_definition& base_def) const;
     const std::vector<column_id>& base_non_pk_columns_in_view_pk() const;


### PR DESCRIPTION
The method view_info::partition_ranges() is unused.

Tests: unit (dev)