### PR TITLE
config: Remove UDF from experimental_features_t in 3.2

### DIFF
--- a/conf/scylla.yaml
+++ b/conf/scylla.yaml
@@ -244,7 +244,6 @@ batch_size_fail_threshold_in_kb: 50
 # experimental_features:
 #     - cdc
 #     - lwt
-#     - udf
 
 # The directory where hints files are stored if hinted handoff is enabled.
 # hints_directory: /var/lib/scylla/hints

--- a/db/config.cc
+++ b/db/config.cc
@@ -692,7 +692,7 @@ db::config::config(std::shared_ptr<db::extensions> exts)
     , developer_mode(this, "developer_mode", value_status::Used, false, "Relax environment checks. Setting to true can reduce performance and reliability significantly.")
     , skip_wait_for_gossip_to_settle(this, "skip_wait_for_gossip_to_settle", value_status::Used, -1, "An integer to configure the wait for gossip to settle. -1: wait normally, 0: do not wait at all, n: wait for at most n polls. Same as -Dcassandra.skip_wait_for_gossip_to_settle in cassandra.")
     , experimental(this, "experimental", value_status::Used, false, "Set to true to unlock all experimental features.")
-    , experimental_features(this, "experimental_features", value_status::Used, {}, "Unlock experimental features provided as the option arguments (possible values: 'lwt', 'cdc', 'udf'). Can be repeated.")
+    , experimental_features(this, "experimental_features", value_status::Used, {}, "Unlock experimental features provided as the option arguments (possible values: 'lwt' and 'cdc'). Can be repeated.")
     , lsa_reclamation_step(this, "lsa_reclamation_step", value_status::Used, 1, "Minimum number of segments to reclaim in a single step")
     , prometheus_port(this, "prometheus_port", value_status::Used, 9180, "Prometheus port, set to zero to disable")
     , prometheus_address(this, "prometheus_address", value_status::Used, "0.0.0.0", "Prometheus listening address")
@@ -855,7 +855,7 @@ const db::extensions& db::config::extensions() const {
 std::unordered_map<sstring, db::experimental_features_t::feature> db::experimental_features_t::map() {
     // We decided against using the construct-on-first-use idiom here:
     // https://github.com/scylladb/scylla/pull/5369#discussion_r353614807
-    return {{"lwt", LWT}, {"udf", UDF}, {"cdc", CDC}};
+    return {{"lwt", LWT}, {"cdc", CDC}};
 }
 
 template struct utils::config_file::named_value<seastar::log_level>;

--- a/db/config.hh
+++ b/db/config.hh
@@ -78,7 +78,7 @@ namespace db {
 
 /// Enumeration of all valid values for the `experimental` config entry.
 struct experimental_features_t {
-    enum feature { LWT, UDF, CDC };
+    enum feature { LWT, CDC };
     static std::unordered_map<sstring, feature> map(); // See enum_option.
 };
 

--- a/tests/config_test.cc
+++ b/tests/config_test.cc
@@ -933,7 +933,6 @@ SEASTAR_TEST_CASE(test_parse_experimental_features_cdc) {
     BOOST_CHECK_EQUAL(cfg.experimental_features(), features{ef::CDC});
     BOOST_CHECK(cfg.check_experimental(ef::CDC));
     BOOST_CHECK(!cfg.check_experimental(ef::LWT));
-    BOOST_CHECK(!cfg.check_experimental(ef::UDF));
     return make_ready_future();
 }
 
@@ -943,17 +942,6 @@ SEASTAR_TEST_CASE(test_parse_experimental_features_lwt) {
     BOOST_CHECK_EQUAL(cfg.experimental_features(), features{ef::LWT});
     BOOST_CHECK(!cfg.check_experimental(ef::CDC));
     BOOST_CHECK(cfg.check_experimental(ef::LWT));
-    BOOST_CHECK(!cfg.check_experimental(ef::UDF));
-    return make_ready_future();
-}
-
-SEASTAR_TEST_CASE(test_parse_experimental_features_udf) {
-    config cfg;
-    cfg.read_from_yaml("experimental_features:\n    - udf\n", throw_on_error);
-    BOOST_CHECK_EQUAL(cfg.experimental_features(), features{ef::UDF});
-    BOOST_CHECK(!cfg.check_experimental(ef::CDC));
-    BOOST_CHECK(!cfg.check_experimental(ef::LWT));
-    BOOST_CHECK(cfg.check_experimental(ef::UDF));
     return make_ready_future();
 }
 
@@ -963,7 +951,6 @@ SEASTAR_TEST_CASE(test_parse_experimental_features_multiple) {
     BOOST_CHECK_EQUAL(cfg.experimental_features(), (features{ef::CDC, ef::LWT, ef::CDC}));
     BOOST_CHECK(cfg.check_experimental(ef::CDC));
     BOOST_CHECK(cfg.check_experimental(ef::LWT));
-    BOOST_CHECK(!cfg.check_experimental(ef::UDF));
     return make_ready_future();
 }
 
@@ -976,7 +963,6 @@ SEASTAR_TEST_CASE(test_parse_experimental_features_invalid) {
                            BOOST_REQUIRE_NE(msg.find("line 2, column 7"), msg.npos);
                            BOOST_CHECK(!cfg.check_experimental(ef::CDC));
                            BOOST_CHECK(!cfg.check_experimental(ef::LWT));
-                           BOOST_CHECK(!cfg.check_experimental(ef::UDF));
                        });
     return make_ready_future();
 }
@@ -986,7 +972,6 @@ SEASTAR_TEST_CASE(test_parse_experimental_true) {
     cfg.read_from_yaml("experimental: true", throw_on_error);
     BOOST_CHECK(cfg.check_experimental(ef::CDC));
     BOOST_CHECK(cfg.check_experimental(ef::LWT));
-    BOOST_CHECK(cfg.check_experimental(ef::UDF));
     return make_ready_future();
 }
 
@@ -995,6 +980,5 @@ SEASTAR_TEST_CASE(test_parse_experimental_false) {
     cfg.read_from_yaml("experimental: false", throw_on_error);
     BOOST_CHECK(!cfg.check_experimental(ef::CDC));
     BOOST_CHECK(!cfg.check_experimental(ef::LWT));
-    BOOST_CHECK(!cfg.check_experimental(ef::UDF));
     return make_ready_future();
 }

--- a/tests/schema_change_test.cc
+++ b/tests/schema_change_test.cc
@@ -586,7 +586,6 @@ future<> test_schema_digest_does_not_change_with_disabled_features(sstring data_
 
     auto db_cfg_ptr = make_shared<db::config>();
     auto& db_cfg = *db_cfg_ptr;
-    db_cfg.experimental_features({experimental_features_t::UDF}, db::config::config_source::CommandLine);
     if (regenerate) {
         db_cfg.data_file_directories({data_dir}, db::config::config_source::CommandLine);
     } else {


### PR DESCRIPTION
Scylla 3.2 doesn't support UDF, so do not accept UDF as a valid option
to experimental_features.

Fixes #5645.

No fix is needed on master, which does support UDF.

Tests: unit (dev)