### PR TITLE
.dockerignore: add testlog

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
 .git
 build
 seastar/build
+testlog


### PR DESCRIPTION
testlog files are not used when preparing the frozen toolchain,
and can be very large, so ignore them in order to speed up the
docker build.