### PR TITLE
cql3: Drop restrictions::values() method

### DIFF
--- a/cql3/restrictions/primary_key_restrictions.hh
+++ b/cql3/restrictions/primary_key_restrictions.hh
@@ -80,7 +80,6 @@ public:
 
     using restrictions::uses_function;
     using restrictions::has_supporting_index;
-    using restrictions::values;
 
     bool empty() const override {
         return get_column_defs().empty();
@@ -134,7 +133,6 @@ public:
 
     using restrictions::uses_function;
     using restrictions::has_supporting_index;
-    using restrictions::values;
 
     bool empty() const override {
         return get_column_defs().empty();

--- a/cql3/restrictions/restrictions.hh
+++ b/cql3/restrictions/restrictions.hh
@@ -70,8 +70,6 @@ public:
      */
     virtual std::vector<const column_definition*> get_column_defs() const = 0;
 
-    virtual std::vector<bytes_opt> values(const query_options& options) const = 0;
-
     virtual bytes_opt value_for(const column_definition& cdef, const query_options& options) const {
         throw exceptions::invalid_request_exception("Single value can be obtained from single-column restrictions only");
     }

--- a/cql3/restrictions/single_column_restrictions.hh
+++ b/cql3/restrictions/single_column_restrictions.hh
@@ -102,15 +102,6 @@ public:
         return r;
     }
 
-    virtual std::vector<bytes_opt> values(const query_options& options) const override {
-        std::vector<bytes_opt> r;
-        for (auto&& e : _restrictions) {
-            auto&& value = e.second->value(options);
-            r.emplace_back(value);
-        }
-        return r;
-    }
-
     virtual bytes_opt value_for(const column_definition& cdef, const query_options& options) const override {
         auto it = _restrictions.find(std::addressof(cdef));
         return (it != _restrictions.end()) ? it->second->value(options) : bytes_opt{};


### PR DESCRIPTION
No-one seems to invoke this method.  Instead, clients invoke
`restriction::values` (note singular "restriction").  Most subclasses of
`restrictions` also inherit from `restriction`, so `values()` still exists
in their public interface.

Tests: unit (dev)

Signed-off-by: Dejan Mircevski <dejan@scylladb.com>