### PR TITLE
api/storage_service: use stream in get_snapshots

### DIFF
--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -956,26 +956,38 @@ void set_storage_service(http_context& ctx, routes& r) {
 
 void set_snapshot(http_context& ctx, routes& r) {
     ss::get_snapshot_details.set(r, [](std::unique_ptr<request> req) {
-        return service::get_local_storage_service().get_snapshot_details().then([] (auto result) {
-            std::vector<ss::snapshots> res;
-            for (auto& map: result) {
-                ss::snapshots all_snapshots;
-                all_snapshots.key = map.first;
-
-                std::vector<ss::snapshot> snapshot;
-                for (auto& cf: map.second) {
-                    ss::snapshot s;
-                    s.ks = cf.ks;
-                    s.cf = cf.cf;
-                    s.live = cf.live;
-                    s.total = cf.total;
-                    snapshot.push_back(std::move(s));
-                }
-                all_snapshots.value = std::move(snapshot);
-                res.push_back(std::move(all_snapshots));
-            }
-            return make_ready_future<json::json_return_type>(std::move(res));
-        });
+        std::function<future<>(output_stream<char>&&)> f = [](output_stream<char>&& s) {
+            return do_with(output_stream<char>(std::move(s)), true, [] (output_stream<char>& s, bool& first){
+                return s.write("[").then([&s, &first] {
+                    return service::get_local_storage_service().get_snapshot_details().then([&s, &first] (std::unordered_map<sstring, std::vector<service::storage_service::snapshot_details>>&& result) {
+                        return do_for_each(result, [&s, &first](std::tuple<sstring, std::vector<service::storage_service::snapshot_details>>&& map){
+                            ss::snapshots all_snapshots;
+                            all_snapshots.key = std::get<0>(map);
+                            future<> f = first ? make_ready_future<>() : s.write(", ");
+                            first = false;
+                            std::vector<ss::snapshot> snapshot;
+                            for (auto& cf: std::get<1>(map)) {
+                                ss::snapshot snp;
+                                snp.ks = cf.ks;
+                                snp.cf = cf.cf;
+                                snp.live = cf.live;
+                                snp.total = cf.total;
+                                snapshot.push_back(std::move(snp));
+                            }
+                            all_snapshots.value = std::move(snapshot);
+                            return f.then([&s, all_snapshots = std::move(all_snapshots)] {
+                                return all_snapshots.write(s);
+                            });
+                        });
+                    }).then([&s] {
+                        return s.write("]").then([&s] {
+                            return s.close();
+                        });
+                    });
+                });
+            });
+        };
+        return make_ready_future<json::json_return_type>(std::move(f));
     });
 
     ss::take_snapshot.set(r, [](std::unique_ptr<request> req) {


### PR DESCRIPTION
get_snapshot should use http stream to reduce memory allocation and
stalls.

This patch chage the implementation so it would stream each of the
snapshot object instead of creating a single response and return it.

Fixes #5468

Depends on scylladb/seastar#723