### PR TITLE
memory_footprint_test: Make it clear it has to run with -c1

### DIFF
--- a/test/unit/memory_footprint_test.cc
+++ b/test/unit/memory_footprint_test.cc
@@ -213,6 +213,9 @@ int main(int argc, char** argv) {
         ("data-size", bpo::value<size_t>()->default_value(32), "cell data size");
 
     return app.run(argc, argv, [&] {
+        if (smp::count != 1) {
+            throw std::runtime_error("This test has to be run with -c1");
+        }
         return seastar::async([&] {
             storage_service_for_tests ssft;
 


### PR DESCRIPTION
The test fails when run on number of cores different than 1.

Signed-off-by: Piotr Jastrzebski <piotr@scylladb.com>