### PR TITLE
schema: store and use the index type internally

### DIFF
--- a/schema.cc
+++ b/schema.cc
@@ -667,22 +667,14 @@ std::ostream& column_definition_as_cql_key(std::ostream& os, const column_defini
     return os;
 }
 
-static bool is_global_index(const utils::UUID& id, const schema& s) {
-    return  service::get_local_storage_service().db().local().find_column_family(id).get_index_manager().is_global_index(s);
-}
-
-static bool is_index(const utils::UUID& id, const schema& s) {
-    return  service::get_local_storage_service().db().local().find_column_family(id).get_index_manager().is_index(s);
-}
-
 
 std::ostream& schema::describe(std::ostream& os) const {
     os << "CREATE ";
     int n = 0;
 
     if (is_view()) {
-        if (is_index(view_info()->base_id(), *this)) {
-            auto is_local = !is_global_index(view_info()->base_id(), *this);
+        if (is_index()) {
+            auto is_local = !is_global_index();
 
             os << "INDEX " << cql3::util::maybe_quote(secondary_index::index_name_from_table_name(cf_name())) << " ON "
                     << cql3::util::maybe_quote(ks_name()) << "." << cql3::util::maybe_quote(view_info()->base_name()) << "(";

--- a/schema.hh
+++ b/schema.hh
@@ -635,6 +635,8 @@ private:
     v3_columns _v3_columns;
     mutable schema_registry_entry* _registry_entry = nullptr;
     std::unique_ptr<::view_info> _view_info;
+    bool _is_global_index = false;
+    bool _is_index = false;
 
     const std::array<column_count_type, 3> _offsets;
 
@@ -676,7 +678,7 @@ public:
 private:
     ::shared_ptr<cql3::column_specification> make_column_specification(const column_definition& def);
     void rebuild();
-    schema(const raw_schema&, std::optional<raw_view_info>);
+    schema(const raw_schema&, std::optional<raw_view_info>, bool is_index, bool is_global_index);
 public:
     // deprecated, use schema_builder.
     schema(std::optional<utils::UUID> id,
@@ -899,6 +901,14 @@ public:
     bool is_view() const {
         return bool(_view_info);
     }
+    bool is_global_index() const {
+        return  _is_global_index;
+    }
+
+    bool is_index() const {
+        return _is_index;
+    }
+
     const query::partition_slice& full_slice() const {
         return *_full_slice;
     }

--- a/schema_builder.hh
+++ b/schema_builder.hh
@@ -33,6 +33,8 @@ private:
     std::optional<compact_storage> _compact_storage;
     std::optional<table_schema_version> _version;
     std::optional<raw_view_info> _view_info;
+    bool _is_index = false;
+    bool _is_global_index = false;
     schema_builder(const schema::raw_schema&);
 public:
     schema_builder(const sstring& ks_name, const sstring& cf_name,


### PR DESCRIPTION
This series changes how a view schema decides if it's an index and what kind of an index it is.

Specifically, when running the `describe` method of a view it needs to know if it's an index and if so, what type of index it is.

Instead of taking it from the base table, the index type will be stored as part of the schema and will be deduced when the schema is created.
This will solve the race condition when deleting a table (and implicitly its views) where a view needs to know if it is an index but the base table is already deleted.

