### PR TITLE
Protect CDC-related tables from being modified by the user

### DIFF
--- a/cdc/log.cc
+++ b/cdc/log.cc
@@ -85,15 +85,15 @@ public:
         if (schema.cdc_options().enabled()) {
             auto& db = _ctxt._proxy.get_db().local();
             auto logname = log_name(schema.cf_name());
-            if (!db.has_schema(schema.ks_name(), logname)) {
-                // in seastar thread
-                auto log_schema = create_log_schema(schema);
-                auto& keyspace = db.find_keyspace(schema.ks_name());
+            check_that_cdc_log_table_does_not_exist(db, schema, logname);
 
-                auto log_mut = db::schema_tables::make_create_table_mutations(keyspace.metadata(), log_schema, timestamp);
+            // in seastar thread
+            auto log_schema = create_log_schema(schema);
+            auto& keyspace = db.find_keyspace(schema.ks_name());
 
-                mutations.insert(mutations.end(), std::make_move_iterator(log_mut.begin()), std::make_move_iterator(log_mut.end()));
-            }
+            auto log_mut = db::schema_tables::make_create_table_mutations(keyspace.metadata(), log_schema, timestamp);
+
+            mutations.insert(mutations.end(), std::make_move_iterator(log_mut.begin()), std::make_move_iterator(log_mut.end()));
         }
     }
 
@@ -105,8 +105,13 @@ public:
         // or if cdc is on now unconditionally, since then any actual base schema changes will affect the column 
         // etc.
         if (was_cdc || is_cdc) {
-            auto logname = log_name(old_schema.cf_name());
             auto& db = _ctxt._proxy.get_db().local();
+
+            if (!was_cdc) {
+                check_that_cdc_log_table_does_not_exist(db, new_schema, log_name(new_schema.cf_name()));
+            }
+
+            auto logname = log_name(old_schema.cf_name());
             auto& keyspace = db.find_keyspace(old_schema.ks_name());
             auto log_schema = was_cdc ? db.find_column_family(old_schema.ks_name(), logname).schema() : nullptr;
 
@@ -148,6 +153,15 @@ public:
 
     template<typename Iter>
     future<> append_mutations(Iter i, Iter e, schema_ptr s, lowres_clock::time_point, std::vector<mutation>&);
+
+private:
+    void check_that_cdc_log_table_does_not_exist(database& db, const schema& schema, const sstring& logname) {
+        if (db.has_schema(schema.ks_name(), logname)) {
+            throw exceptions::invalid_request_exception(format("Cannot create CDC log table for table {}.{} because a table of name {}.{} already exists",
+                    schema.ks_name(), schema.cf_name(),
+                    schema.ks_name(), logname));
+        }
+    }
 };
 
 cdc::cdc_service::cdc_service(service::storage_proxy& proxy)

--- a/cdc/log.hh
+++ b/cdc/log.hh
@@ -132,6 +132,7 @@ enum class column_op : int8_t {
     set = 0, del = 1, add = 2,
 };
 
+bool is_log_for_some_table(const sstring& ks_name, const std::string_view& table_name);
 seastar::sstring log_name(const seastar::sstring& table_name);
 
 } // namespace cdc

--- a/cql3/statements/create_view_statement.cc
+++ b/cql3/statements/create_view_statement.cc
@@ -158,6 +158,10 @@ future<shared_ptr<cql_transport::event::schema_change>> create_view_statement::a
         throw exceptions::invalid_request_exception(format("Cannot use 'COMPACT STORAGE' when defining a materialized view"));
     }
 
+    if (_properties.properties()->get_cdc_options().has_value()) {
+        throw exceptions::invalid_request_exception("Cannot enable CDC for a materialized view");
+    }
+
     // View and base tables must be in the same keyspace, to ensure that RF
     // is the same (because we assign a view replica to each base replica).
     // If a keyspace was not specified for the base table name, it is assumed

--- a/service/client_state.cc
+++ b/service/client_state.cc
@@ -192,7 +192,7 @@ future<> service::client_state::has_access(const sstring& ks, auth::permission p
         }
     }
 
-    if (resource.kind() == auth::resource_kind::data && service::get_local_storage_service().cluster_supports_cdc()) {
+    if (service::get_local_storage_service().db().local().features().cluster_supports_cdc() && resource.kind() == auth::resource_kind::data) {
         const auto resource_view = auth::data_resource_view(resource);
         if (resource_view.table()) {
             if (p == auth::permission::DROP) {

--- a/service/client_state.cc
+++ b/service/client_state.cc
@@ -200,6 +200,17 @@ future<> service::client_state::has_access(const sstring& ks, auth::permission p
                     throw exceptions::unauthorized_exception(format("Cannot {} cdc log table {}", auth::permissions::to_string(p), resource));
                 }
             }
+
+            static constexpr auto cdc_topology_description_forbidden_permissions = auth::permission_set::of<
+                    auth::permission::ALTER, auth::permission::DROP>();
+
+            if (cdc_topology_description_forbidden_permissions.contains(p)) {
+                if (ks == db::system_distributed_keyspace::NAME
+                        && (resource_view.table() == db::system_distributed_keyspace::CDC_DESC
+                        || resource_view.table() == db::system_distributed_keyspace::CDC_TOPOLOGY_DESCRIPTION)) {
+                    throw exceptions::unauthorized_exception(format("Cannot {} {}", auth::permissions::to_string(p), resource));
+                }
+            }
         }
     }
 


### PR DESCRIPTION
This patch introduces following modifications:

- Disallows enabling cdc for table `X` when `X_scylla_cdc_log` already exists,
- Restricts DROP permissions for `X_scylla_cdc_log` tables,
- Restricts ALTER and DROP permissions for `cdc_description` and `cdc_topology_description`,
- Disallows `cdc` option when creating materialized views.

Refs #4991.
Tests: unit(dev).