### PR TITLE
Make replacing node take writes

### DIFF
--- a/locator/abstract_replication_strategy.cc
+++ b/locator/abstract_replication_strategy.cc
@@ -168,10 +168,15 @@ insert_token_range_to_sorted_container_while_unwrapping(
 
 dht::token_range_vector
 abstract_replication_strategy::get_ranges(inet_address ep) const {
+    return get_ranges(ep, _token_metadata);
+}
+
+dht::token_range_vector
+abstract_replication_strategy::get_ranges(inet_address ep, token_metadata& tm) const {
     dht::token_range_vector ret;
-    auto prev_tok = _token_metadata.sorted_tokens().back();
-    for (auto tok : _token_metadata.sorted_tokens()) {
-        for (inet_address a : calculate_natural_endpoints(tok, _token_metadata)) {
+    auto prev_tok = tm.sorted_tokens().back();
+    for (auto tok : tm.sorted_tokens()) {
+        for (inet_address a : calculate_natural_endpoints(tok, tm)) {
             if (a == ep) {
                 insert_token_range_to_sorted_container_while_unwrapping(prev_tok, tok, ret);
                 break;

--- a/locator/abstract_replication_strategy.hh
+++ b/locator/abstract_replication_strategy.hh
@@ -95,6 +95,7 @@ public:
                                               token_metadata& token_metadata,
                                               const std::map<sstring, sstring>& config_options);
     virtual std::vector<inet_address> get_natural_endpoints(const token& search_token);
+    virtual std::vector<inet_address> get_natural_endpoints_without_node_being_replaced(const token& search_token);
     virtual void validate_options() const = 0;
     virtual std::optional<std::set<sstring>> recognized_options() const = 0;
     virtual size_t get_replication_factor() const = 0;

--- a/locator/abstract_replication_strategy.hh
+++ b/locator/abstract_replication_strategy.hh
@@ -113,6 +113,10 @@ public:
     // It the analogue of Origin's getAddressRanges().get(endpoint).
     // This function is not efficient, and not meant for the fast path.
     dht::token_range_vector get_ranges(inet_address ep) const;
+
+    // Use the token_metadata provided by the caller instead of _token_metadata
+    dht::token_range_vector get_ranges(inet_address ep, token_metadata& tm) const;
+
     // get_primary_ranges() returns the list of "primary ranges" for the given
     // endpoint. "Primary ranges" are the ranges that the node is responsible
     // for storing replica primarily, which means this is the first node

--- a/locator/abstract_replication_strategy.hh
+++ b/locator/abstract_replication_strategy.hh
@@ -98,6 +98,12 @@ public:
     virtual void validate_options() const = 0;
     virtual std::optional<std::set<sstring>> recognized_options() const = 0;
     virtual size_t get_replication_factor() const = 0;
+    // Decide if the replication strategy allow removing the node being
+    // replaced from the natural endpoints when a node is being replaced in the
+    // cluster. LocalStrategy is the not allowed to do so because it always
+    // returns the node itself as the natural_endpoints and the node will not
+    // appear in the pending_endpoints.
+    virtual bool allow_remove_node_being_replaced_from_natural_endpoints() const = 0;
     uint64_t get_cache_hits_count() const { return _cache_hits_count; }
     replication_strategy_type get_type() const { return _my_type; }
 

--- a/locator/everywhere_replication_strategy.hh
+++ b/locator/everywhere_replication_strategy.hh
@@ -61,5 +61,9 @@ public:
     virtual size_t get_replication_factor() const override {
         return _token_metadata.get_all_endpoints_count();
     }
+
+    virtual bool allow_remove_node_being_replaced_from_natural_endpoints() const override {
+        return true;
+    }
 };
 }

--- a/locator/local_strategy.hh
+++ b/locator/local_strategy.hh
@@ -51,6 +51,11 @@ public:
     virtual void validate_options() const override;
 
     virtual std::optional<std::set<sstring>> recognized_options() const override;
+
+    virtual bool allow_remove_node_being_replaced_from_natural_endpoints() const override {
+        return false;
+    }
+
 };
 
 }

--- a/locator/network_topology_strategy.hh
+++ b/locator/network_topology_strategy.hh
@@ -66,6 +66,10 @@ public:
         return _datacenteres;
     }
 
+    virtual bool allow_remove_node_being_replaced_from_natural_endpoints() const override {
+        return true;
+    }
+
 protected:
     /**
      * calculate endpoints in one pass through the tokens by tracking our

--- a/locator/simple_strategy.hh
+++ b/locator/simple_strategy.hh
@@ -37,6 +37,9 @@ public:
     virtual size_t get_replication_factor() const override;
     virtual void validate_options() const override;
     virtual std::optional<std::set<sstring>> recognized_options() const override;
+    virtual bool allow_remove_node_being_replaced_from_natural_endpoints() const override {
+        return true;
+    }
 private:
     size_t _replication_factor = 1;
 };

--- a/locator/token_metadata.hh
+++ b/locator/token_metadata.hh
@@ -227,6 +227,16 @@ public:
 
     bool is_leaving(inet_address endpoint);
 
+    // Is this node being replaced by another node
+    bool is_being_replaced(inet_address endpoint);
+
+    // Is any node being replaced by another node
+    bool is_any_node_being_replaced();
+
+    void add_replacing_endpoint(inet_address existing_node, inet_address replacing_node);
+
+    void del_replacing_endpoint(inet_address existing_node);
+
     /**
      * Create a copy of TokenMetadata with only tokenToEndpointMap. That is, pending ranges,
      * bootstrap tokens and leaving endpoints are not included in the copy.
@@ -288,6 +298,9 @@ public:
         abstract_replication_strategy& strategy,
         lw_shared_ptr<std::unordered_multimap<range<token>, inet_address>> new_pending_ranges,
         lw_shared_ptr<token_metadata> all_left_metadata);
+    future<> calculate_pending_ranges_for_replacing(
+            abstract_replication_strategy& strategy,
+            lw_shared_ptr<std::unordered_multimap<range<token>, inet_address>> new_pending_ranges);
 
     token get_predecessor(token t);
 

--- a/repair/repair.hh
+++ b/repair/repair.hh
@@ -51,7 +51,7 @@ future<> bootstrap_with_repair(seastar::sharded<database>& db, locator::token_me
 future<> decommission_with_repair(seastar::sharded<database>& db, locator::token_metadata tm);
 future<> removenode_with_repair(seastar::sharded<database>& db, locator::token_metadata tm, gms::inet_address leaving_node);
 future<> rebuild_with_repair(seastar::sharded<database>& db, locator::token_metadata tm, sstring source_dc);
-future<> replace_with_repair(seastar::sharded<database>& db, locator::token_metadata tm);
+future<> replace_with_repair(seastar::sharded<database>& db, locator::token_metadata tm, std::unordered_set<dht::token> replacing_tokens);
 
 // NOTE: repair_start() can be run on any node, but starts a node-global
 // operation.

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -958,7 +958,7 @@ void storage_service::bootstrap() {
     set_mode(mode::JOINING, "Starting to bootstrap...", true);
     if (is_repair_based_node_ops_enabled()) {
         if (db().local().is_replacing()) {
-            replace_with_repair(_db, _token_metadata).get();
+            replace_with_repair(_db, _token_metadata, _bootstrap_tokens).get();
         } else {
             bootstrap_with_repair(_db, _token_metadata, _bootstrap_tokens).get();
         }

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -650,6 +650,13 @@ private:
      */
     void handle_state_removing(inet_address endpoint, std::vector<sstring> pieces);
 
+    /**
+     * Handle notification that a node is replacing another node.
+     *
+     * @param endpoint node
+     */
+    void handle_state_replacing(inet_address endpoint);
+
 private:
     void excise(std::unordered_set<token> tokens, inet_address endpoint);
     void excise(std::unordered_set<token> tokens, inet_address endpoint, long expire_time);


### PR DESCRIPTION

storage_service: Make replacing node take writes

Background:

Replace operation is used to replace a dead node in the cluster.
Currently during replace operation, the replacing node does not take any
writes. As a result, new writes to a range after the sync for that range
is done, e.g., after streaming for that range is finished, will not be
synced to the replacing node. Hinted hand off or repair after the
replacing operation will help. But it is better if we can make the
writes to the replacing node to avoid any post replacing operation
actions.

After this series and repair based node operation series, the replace
operation will guarantee the replacing node has all the latest copy of
data including the new writes during the replace operation. In short, no
more repairs before or after the replacing operation. Just replacing the
node is enough.

Implementation:

1) Filter the node being replaced out of the natural endpoints in
   storage_proxy, so that:

- The node being replaced will not be selected as the target for
  normal write or normal read.

- Do not depend on the gossip liveness to avoid selecting replacing node
  for normal write or normal read when the replacing node has the same
  ip address as the node being replaced. No more special handling for
  hibernate state in gossip which makes it is simpler and more robust.
  Replacing node will be marked as UP.

2) Put the replacing node in the pending list, so that:

- Replacing node will take writes but write to replacing will not be
  counted as CL.

- Replacing node will not take normal read.

Example:

For example, with RF = 3, n1, n2, n3 in the cluster, n3 is dead and
being replaced by node n4. When n4 starts:

- writes to nodes {n1, n2, n3} are changed to
  normal_replica_writes = {n1, n2} and pending_replica_writes= {n4}.

- reads to nodes {n1, n2, n3} are changed to
  normal_replica_reads = {n1, n2} only.

This way, the replacing node n4 now takes writes but does not take reads.

Tests:

1) Measure the number of writes during pending period that is the
   replacing starts and finishes the replace operation.

- Start 5 nodes, n1 to n5.
- Stop n5
- Start write in the background
- Start n6 to replace n5
- Get scylla_database_total_writes metrics when the replacing node announces HIBERNATE (replacing) and NORMAL status.

Before:
2020-02-06 08:35:35.921837 Get metrics when other knows replacing node = HIBERNATE
2020-02-06 08:35:35.939493 scylla_database_total_writes: node1={'scylla_database_total_writes': 15483}
2020-02-06 08:35:35.950614 scylla_database_total_writes: node2={'scylla_database_total_writes': 15857}
2020-02-06 08:35:35.961820 scylla_database_total_writes: node3={'scylla_database_total_writes': 16195}
2020-02-06 08:35:35.978427 scylla_database_total_writes: node4={'scylla_database_total_writes': 15764}
2020-02-06 08:35:35.992580 scylla_database_total_writes: node6={'scylla_database_total_writes': 331}
2020-02-06 08:36:49.794790 Get metrics when other knows replacing node = NORMAL
2020-02-06 08:36:49.809189 scylla_database_total_writes: node1={'scylla_database_total_writes': 267088}
2020-02-06 08:36:49.823302 scylla_database_total_writes: node2={'scylla_database_total_writes': 272352}
2020-02-06 08:36:49.837228 scylla_database_total_writes: node3={'scylla_database_total_writes': 274004}
2020-02-06 08:36:49.851104 scylla_database_total_writes: node4={'scylla_database_total_writes': 262972}
2020-02-06 08:36:49.862504 scylla_database_total_writes: node6={'scylla_database_total_writes': 513}

Writes = 513 - 331

After:
2020-02-06 08:28:56.548047 Get metrics when other knows replacing node = HIBERNATE
2020-02-06 08:28:56.560813 scylla_database_total_writes: node1={'scylla_database_total_writes': 290886}
2020-02-06 08:28:56.573925 scylla_database_total_writes: node2={'scylla_database_total_writes': 310304}
2020-02-06 08:28:56.586305 scylla_database_total_writes: node3={'scylla_database_total_writes': 304049}
2020-02-06 08:28:56.601464 scylla_database_total_writes: node4={'scylla_database_total_writes': 303770}
2020-02-06 08:28:56.615066 scylla_database_total_writes: node6={'scylla_database_total_writes': 604}
2020-02-06 08:29:10.537016 Get metrics when other knows replacing node = NORMAL
2020-02-06 08:29:10.553257 scylla_database_total_writes: node1={'scylla_database_total_writes': 336126}
2020-02-06 08:29:10.567181 scylla_database_total_writes: node2={'scylla_database_total_writes': 358549}
2020-02-06 08:29:10.581939 scylla_database_total_writes: node3={'scylla_database_total_writes': 351416}
2020-02-06 08:29:10.595567 scylla_database_total_writes: node4={'scylla_database_total_writes': 350580}
2020-02-06 08:29:10.610548 scylla_database_total_writes: node6={'scylla_database_total_writes': 45460}

Writes = 45460 - 604

As we can see the replacing node did not take write before and take write after the patch.

2) Check log of writer handler in storage_proxy

storage_proxy - creating write handler for token: -2642068240672386521,
keyspace_name=ks, original_natrual={127.0.0.1, 127.0.0.5, 127.0.0.2},
natural={127.0.0.1, 127.0.0.2}, pending={127.0.0.6}

The node being replaced, n5=127.0.0.5, is filtered out and the replacing
node, n6=127.0.0.6 is in the pending list.

TODO:
- Handle paxos writes

