### PR TITLE
Reduce usage of global_partitioner()

### DIFF
--- a/cdc/log.cc
+++ b/cdc/log.cc
@@ -31,7 +31,6 @@
 #include "bytes.hh"
 #include "database.hh"
 #include "db/config.hh"
-#include "dht/murmur3_partitioner.hh"
 #include "partition_slice_builder.hh"
 #include "schema.hh"
 #include "schema_builder.hh"
@@ -265,11 +264,6 @@ db_context::builder& db_context::builder::with_token_metadata(locator::token_met
     return *this;
 }
 
-db_context::builder& db_context::builder::with_partitioner(dht::i_partitioner& partitioner) {
-    _partitioner = partitioner;
-    return *this;
-}
-
 db_context::builder& db_context::builder::with_cdc_metadata(cdc::metadata& cdc_metadata) {
     _cdc_metadata = cdc_metadata;
     return *this;
@@ -281,7 +275,6 @@ db_context db_context::builder::build() {
         _migration_notifier ? _migration_notifier->get() : service::get_local_storage_service().get_migration_notifier(),
         _token_metadata ? _token_metadata->get() : service::get_local_storage_service().get_token_metadata(),
         _cdc_metadata ? _cdc_metadata->get() : service::get_local_storage_service().get_cdc_metadata(),
-        _partitioner ? _partitioner->get() : dht::global_partitioner()
     };
 }
 

--- a/cdc/log.hh
+++ b/cdc/log.hh
@@ -59,12 +59,6 @@ class query_state;
 
 } // namespace service
 
-namespace dht {
-
-class i_partitioner;
-
-} // namespace dht
-
 class mutation;
 class partition_key;
 
@@ -108,20 +102,17 @@ struct db_context final {
     service::migration_notifier& _migration_notifier;
     locator::token_metadata& _token_metadata;
     cdc::metadata& _cdc_metadata;
-    dht::i_partitioner& _partitioner;
 
     class builder final {
         service::storage_proxy& _proxy;
         std::optional<std::reference_wrapper<service::migration_notifier>> _migration_notifier;
         std::optional<std::reference_wrapper<locator::token_metadata>> _token_metadata;
         std::optional<std::reference_wrapper<cdc::metadata>> _cdc_metadata;
-        std::optional<std::reference_wrapper<dht::i_partitioner>> _partitioner;
     public:
         builder(service::storage_proxy& proxy);
 
         builder& with_migration_notifier(service::migration_notifier& migration_notifier);
         builder& with_token_metadata(locator::token_metadata& token_metadata);
-        builder& with_partitioner(dht::i_partitioner& partitioner);
         builder& with_cdc_metadata(cdc::metadata&);
 
         db_context build();

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -54,7 +54,6 @@
 #include "cql3/untyped_result_set.hh"
 #include "utils/fb_utilities.hh"
 #include "utils/hash.hh"
-#include "dht/i_partitioner.hh"
 #include "version.hh"
 #include "thrift/server.hh"
 #include "exceptions/exceptions.hh"
@@ -1154,7 +1153,7 @@ static future<> setup_version() {
                              to_sstring(cql_serialization_format::latest_version),
                              snitch->get_datacenter(utils::fb_utilities::get_broadcast_address()),
                              snitch->get_rack(utils::fb_utilities::get_broadcast_address()),
-                             sstring(dht::global_partitioner().name()),
+                             sstring(qctx->db().get_config().partitioner()),
                              a.addr(),
                              utils::fb_utilities::get_broadcast_address().addr(),
                              netw::get_local_messaging_service().listen_address().addr(),

--- a/dht/i_partitioner.hh
+++ b/dht/i_partitioner.hh
@@ -224,10 +224,6 @@ public:
         return _shard_count;
     }
 
-    sstring cpu_sharding_algorithm_name() const {
-        return "biased-token-round-robin";
-    }
-
     unsigned sharding_ignore_msb() const {
         return _sharding_ignore_msb_bits;
     }

--- a/dht/token-sharding.hh
+++ b/dht/token-sharding.hh
@@ -25,6 +25,10 @@
 
 namespace dht {
 
+inline sstring cpu_sharding_algorithm_name() {
+    return "biased-token-round-robin";
+}
+
 std::vector<uint64_t> init_zero_based_shard_start(unsigned shards, unsigned sharding_ignore_msb_bits);
 
 unsigned shard_of(unsigned shard_count, unsigned sharding_ignore_msb_bits, const token& t);

--- a/gms/gossiper.cc
+++ b/gms/gossiper.cc
@@ -51,7 +51,6 @@
 #include "gms/i_endpoint_state_change_subscriber.hh"
 #include "service/storage_service.hh"
 #include "message/messaging_service.hh"
-#include "dht/i_partitioner.hh"
 #include "database.hh"
 #include "log.hh"
 #include "db/system_keyspace.hh"
@@ -60,7 +59,6 @@
 #include <seastar/core/metrics.hh>
 #include <seastar/util/defer.hh>
 #include <chrono>
-#include "dht/i_partitioner.hh"
 #include "db/config.hh"
 #include <boost/range/algorithm/set_algorithm.hpp>
 #include <boost/range/adaptors.hpp>
@@ -90,7 +88,7 @@ void gossiper::set_cluster_name(sstring name) {
 }
 
 sstring gossiper::get_partitioner_name() {
-    return dht::global_partitioner().name();
+    return _cfg.partitioner();
 }
 
 std::set<inet_address> gossiper::get_seeds() {

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -2539,6 +2539,8 @@ future<> storage_service::start_native_transport() {
             cql_server_config.max_request_size = ss._service_memory_total;
             cql_server_config.get_service_memory_limiter_semaphore = [ss = std::ref(get_storage_service())] () -> semaphore& { return ss.get().local()._service_memory_limiter; };
             cql_server_config.allow_shard_aware_drivers = cfg.enable_shard_aware_drivers();
+            cql_server_config.sharding_ignore_msb = cfg.murmur3_partitioner_ignore_msb_bits();
+            cql_server_config.partitioner_name = cfg.partitioner();
             smp_service_group_config cql_server_smp_service_group_config;
             cql_server_smp_service_group_config.max_nonlocal_requests = 5000;
             cql_server_config.bounce_request_smp_service_group = create_smp_service_group(cql_server_smp_service_group_config).get0();

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -1934,7 +1934,7 @@ future<> storage_service::gossip_snitch_info() {
 future<> storage_service::gossip_sharding_info() {
     return _gossiper.add_local_application_state({
         { gms::application_state::SHARD_COUNT, value_factory.shard_count(smp::count) },
-        { gms::application_state::IGNORE_MSB_BITS, value_factory.ignore_msb_bits(dht::global_partitioner().sharding_ignore_msb()) },
+        { gms::application_state::IGNORE_MSB_BITS, value_factory.ignore_msb_bits(_db.local().get_config().murmur3_partitioner_ignore_msb_bits()) },
     });
 }
 

--- a/thrift/handler.cc
+++ b/thrift/handler.cc
@@ -767,7 +767,7 @@ public:
     }
 
     void describe_partitioner(thrift_fn::function<void(std::string const& _return)> cob) {
-        cob(dht::global_partitioner().name());
+        cob(_db.local().get_config().partitioner());
     }
 
     void describe_snitch(thrift_fn::function<void(std::string const& _return)> cob) {

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -28,6 +28,7 @@
 #include <boost/range/adaptor/sliced.hpp>
 
 #include "cql3/statements/batch_statement.hh"
+#include "dht/token-sharding.hh"
 #include "service/migration_manager.hh"
 #include "service/storage_service.hh"
 #include "db/consistency_level_type.hh"
@@ -1190,7 +1191,7 @@ std::unique_ptr<cql_server::response> cql_server::connection::make_supported(int
         auto const& part = dht::global_partitioner();
         opts.insert({"SCYLLA_SHARD", format("{:d}", engine().cpu_id())});
         opts.insert({"SCYLLA_NR_SHARDS", format("{:d}", smp::count)});
-        opts.insert({"SCYLLA_SHARDING_ALGORITHM", part.cpu_sharding_algorithm_name()});
+        opts.insert({"SCYLLA_SHARDING_ALGORITHM", dht::cpu_sharding_algorithm_name()});
         opts.insert({"SCYLLA_SHARDING_IGNORE_MSB", format("{:d}", part.sharding_ignore_msb())});
         opts.insert({"SCYLLA_PARTITIONER", part.name()});
     }

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -1188,12 +1188,11 @@ std::unique_ptr<cql_server::response> cql_server::connection::make_supported(int
     opts.insert({"COMPRESSION", "lz4"});
     opts.insert({"COMPRESSION", "snappy"});
     if (_server._config.allow_shard_aware_drivers) {
-        auto const& part = dht::global_partitioner();
         opts.insert({"SCYLLA_SHARD", format("{:d}", engine().cpu_id())});
         opts.insert({"SCYLLA_NR_SHARDS", format("{:d}", smp::count)});
         opts.insert({"SCYLLA_SHARDING_ALGORITHM", dht::cpu_sharding_algorithm_name()});
-        opts.insert({"SCYLLA_SHARDING_IGNORE_MSB", format("{:d}", part.sharding_ignore_msb())});
-        opts.insert({"SCYLLA_PARTITIONER", part.name()});
+        opts.insert({"SCYLLA_SHARDING_IGNORE_MSB", format("{:d}", _server._config.sharding_ignore_msb)});
+        opts.insert({"SCYLLA_PARTITIONER", _server._config.partitioner_name});
     }
     auto response = std::make_unique<cql_server::response>(stream, cql_binary_opcode::SUPPORTED, tr_state);
     response->write_string_multimap(opts);

--- a/transport/server.hh
+++ b/transport/server.hh
@@ -108,6 +108,8 @@ struct cql_server_config {
     ::timeout_config timeout_config;
     size_t max_request_size;
     std::function<semaphore& ()> get_service_memory_limiter_semaphore;
+    sstring partitioner_name;
+    unsigned sharding_ignore_msb;
     bool allow_shard_aware_drivers = true;
     smp_service_group bounce_request_smp_service_group = default_smp_service_group();
 };


### PR DESCRIPTION
In many places we use global_partitioner() to obtain parameters that are available in config. This PR replaces number of global_partitioner() calls with equivalent non-global ways.

tests: unit(dev)