### PR TITLE
Remove unnecessary schema copies

### DIFF
--- a/sstables/index_reader.hh
+++ b/sstables/index_reader.hh
@@ -597,7 +597,7 @@ private:
         }
 
         const schema& s = *_sstable->_schema;
-        auto cmp_with_start = [pos_cmp = promoted_index_block_compare(s), s]
+        auto cmp_with_start = [pos_cmp = promoted_index_block_compare(s), &s]
                 (position_in_partition_view pos, const promoted_index_block& info) -> bool {
             return pos_cmp(pos, info.start(s));
         };

--- a/test/boost/multishard_mutation_query_test.cc
+++ b/test/boost/multishard_mutation_query_test.cc
@@ -646,7 +646,7 @@ generate_clustering_ranges(RandomEngine& rnd_engine, const schema& schema, const
             start = end;
         }
 
-        clustering_key_ranges.emplace_back(clustering_index_range.transform([schema, &all_cks] (int i) {
+        clustering_key_ranges.emplace_back(clustering_index_range.transform([&all_cks] (int i) {
             return all_cks.at(i);
         }));
     } while (start < end);


### PR DESCRIPTION
Most of the time schema does not have to be copied and sometimes it's not even used.

tests: unit(dev)