### PR TITLE
dist/debian: keep /etc/systemd .conf files on 'remove'

### DIFF
--- a/dist/debian/debian/scylla-server.postrm
+++ b/dist/debian/debian/scylla-server.postrm
@@ -6,8 +6,12 @@ case "$1" in
     purge|remove)
         rm -rf /etc/systemd/system/scylla-housekeeping-daily.service.d/
         rm -rf /etc/systemd/system/scylla-housekeeping-restart.service.d/
-        rm -rf /etc/systemd/system/scylla-server.service.d/
         rm -rf /etc/systemd/system/scylla-helper.slice.d/
+        # We need to keep dependencies.conf and sysconfdir.conf on 'remove',
+        # otherwise it will be missing after rollback.
+        if [ "$1" = "purge" ]; then
+            rm -rf /etc/systemd/system/scylla-server.service.d/
+        fi
         ;;
 esac
 


### PR DESCRIPTION
Since dpkg does not re-install conffiles when it removed by user,
currently we are missing dependencies.conf and sysconfdir.conf on rollback.
To prevent this, we need to stop running
'rm -rf /etc/systemd/system/scylla-server.service.d/' on 'remove'.

Fixes #5734