### PR TITLE
Allow setting partitioner per table

### DIFF
--- a/database.cc
+++ b/database.cc
@@ -1994,7 +1994,7 @@ std::ostream& operator<<(std::ostream& os, const keyspace_metadata& m) {
 template <typename T>
 using foreign_unique_ptr = foreign_ptr<std::unique_ptr<T>>;
 
-flat_mutation_reader make_multishard_streaming_reader(distributed<database>& db, const dht::i_partitioner& partitioner, schema_ptr schema,
+flat_mutation_reader make_multishard_streaming_reader(distributed<database>& db, schema_ptr schema,
         std::function<std::optional<dht::partition_range>()> range_generator) {
     class streaming_reader_lifecycle_policy
             : public reader_lifecycle_policy
@@ -2039,7 +2039,7 @@ flat_mutation_reader make_multishard_streaming_reader(distributed<database>& db,
             return *_contexts[engine().cpu_id()].semaphore;
         }
     };
-    auto ms = mutation_source([&db, &partitioner] (schema_ptr s,
+    auto ms = mutation_source([&db] (schema_ptr s,
             reader_permit,
             const dht::partition_range& pr,
             const query::partition_slice& ps,
@@ -2047,7 +2047,7 @@ flat_mutation_reader make_multishard_streaming_reader(distributed<database>& db,
             tracing::trace_state_ptr trace_state,
             streamed_mutation::forwarding,
             mutation_reader::forwarding fwd_mr) {
-        return make_multishard_combining_reader(make_shared<streaming_reader_lifecycle_policy>(db), partitioner, std::move(s), pr, ps, pc,
+        return make_multishard_combining_reader(make_shared<streaming_reader_lifecycle_policy>(db), std::move(s), pr, ps, pc,
                 std::move(trace_state), fwd_mr);
     });
     auto&& full_slice = schema->full_slice();

--- a/database.hh
+++ b/database.hh
@@ -1612,7 +1612,7 @@ future<> stop_database(sharded<database>& db);
 //
 // Shard readers are created via `table::make_streaming_reader()`.
 // Range generator must generate disjoint, monotonically increasing ranges.
-flat_mutation_reader make_multishard_streaming_reader(distributed<database>& db, const dht::i_partitioner& partitioner, schema_ptr schema,
+flat_mutation_reader make_multishard_streaming_reader(distributed<database>& db, schema_ptr schema,
         std::function<std::optional<dht::partition_range>()> range_generator);
 
 future<utils::UUID> update_schema_version(distributed<service::storage_proxy>& proxy, db::schema_features);

--- a/db/schema_features.hh
+++ b/db/schema_features.hh
@@ -34,13 +34,15 @@ enum class schema_feature {
     DIGEST_INSENSITIVE_TO_EXPIRY,
     COMPUTED_COLUMNS,
     CDC_OPTIONS,
+    PER_TABLE_PARTITIONERS,
 };
 
 using schema_features = enum_set<super_enum<schema_feature,
     schema_feature::VIEW_VIRTUAL_COLUMNS,
     schema_feature::DIGEST_INSENSITIVE_TO_EXPIRY,
     schema_feature::COMPUTED_COLUMNS,
-    schema_feature::CDC_OPTIONS
+    schema_feature::CDC_OPTIONS,
+    schema_feature::PER_TABLE_PARTITIONERS
     >>;
 
 }

--- a/db/schema_tables.hh
+++ b/db/schema_tables.hh
@@ -79,8 +79,13 @@ public:
     const db::extensions& extensions() const {
         return _extensions;
     }
+
+    const unsigned murmur3_partitioner_ignore_msb_bits() const {
+        return _murmur3_partitioner_ignore_msb_bits;
+    }
 private:
     const db::extensions& _extensions;
+    const unsigned _murmur3_partitioner_ignore_msb_bits;
 };
 
 namespace schema_tables {

--- a/dht/i_partitioner.cc
+++ b/dht/i_partitioner.cc
@@ -300,7 +300,8 @@ ring_position_range_vector_sharder::next(const schema& s) {
 }
 
 future<utils::chunked_vector<partition_range>>
-split_range_to_single_shard(const i_partitioner& partitioner, const schema& s, const partition_range& pr, shard_id shard) {
+split_range_to_single_shard(const schema& s, const partition_range& pr, shard_id shard) {
+    const i_partitioner& partitioner = s.get_partitioner();
     auto next_shard = shard + 1 == partitioner.shard_count() ? 0 : shard + 1;
     auto start_token = pr.start() ? pr.start()->value().token() : minimum_token();
     auto start_shard = partitioner.shard_of(start_token);
@@ -329,12 +330,6 @@ split_range_to_single_shard(const i_partitioner& partitioner, const schema& s, c
         return make_ready_future<std::optional<utils::chunked_vector<partition_range>>>(std::move(ret));
     });
 }
-
-future<utils::chunked_vector<partition_range>>
-split_range_to_single_shard(const schema& s, const partition_range& pr, shard_id shard) {
-    return split_range_to_single_shard(s.get_partitioner(), s, pr, shard);
-}
-
 
 int ring_position::tri_compare(const schema& s, const ring_position& o) const {
     return ring_position_comparator(s)(*this, o);

--- a/dht/i_partitioner.hh
+++ b/dht/i_partitioner.hh
@@ -660,9 +660,6 @@ public:
 };
 std::ostream& operator<<(std::ostream& out, partition_ranges_view v);
 
-void set_global_partitioner(const sstring& class_name, unsigned ignore_msb = 0);
-i_partitioner& global_partitioner();
-
 unsigned shard_of(const schema&, const token&);
 inline decorated_key decorate_key(const schema& s, const partition_key& key) {
     return s.get_partitioner().decorate_key(s, key);

--- a/dht/i_partitioner.hh
+++ b/dht/i_partitioner.hh
@@ -693,8 +693,6 @@ future<utils::chunked_vector<partition_range>> split_range_to_single_shard(const
 
 std::unique_ptr<dht::i_partitioner> make_partitioner(sstring name, unsigned shard_count, unsigned sharding_ignore_msb_bits);
 
-extern std::unique_ptr<i_partitioner> default_partitioner;
-
 } // dht
 
 namespace std {

--- a/gms/feature.hh
+++ b/gms/feature.hh
@@ -137,6 +137,7 @@ extern const std::string_view CDC;
 extern const std::string_view NONFROZEN_UDTS;
 extern const std::string_view HINTED_HANDOFF_SEPARATE_CONNECTION;
 extern const std::string_view LWT;
+extern const std::string_view PER_TABLE_PARTITIONERS;
 
 }
 

--- a/gms/feature_service.cc
+++ b/gms/feature_service.cc
@@ -53,6 +53,7 @@ constexpr std::string_view features::CDC = "CDC";
 constexpr std::string_view features::NONFROZEN_UDTS = "NONFROZEN_UDTS";
 constexpr std::string_view features::HINTED_HANDOFF_SEPARATE_CONNECTION = "HINTED_HANDOFF_SEPARATE_CONNECTION";
 constexpr std::string_view features::LWT = "LWT";
+constexpr std::string_view features::PER_TABLE_PARTITIONERS = "PER_TABLE_PARTITIONERS";
 
 static logging::logger logger("features");
 
@@ -83,7 +84,8 @@ feature_service::feature_service(feature_config cfg) : _config(cfg)
         , _cdc_feature(*this, features::CDC)
         , _nonfrozen_udts(*this, features::NONFROZEN_UDTS)
         , _hinted_handoff_separate_connection(*this, features::HINTED_HANDOFF_SEPARATE_CONNECTION)
-        , _lwt_feature(*this, features::LWT) {
+        , _lwt_feature(*this, features::LWT)
+        , _per_table_partitioners_feature(*this, features::PER_TABLE_PARTITIONERS) {
 }
 
 feature_config feature_config_from_db_config(db::config& cfg) {
@@ -161,6 +163,7 @@ std::set<std::string_view> feature_service::known_feature_set() {
         gms::features::NONFROZEN_UDTS,
         gms::features::UNBOUNDED_RANGE_TOMBSTONES,
         gms::features::HINTED_HANDOFF_SEPARATE_CONNECTION,
+        gms::features::PER_TABLE_PARTITIONERS,
     };
 
     if (_config.enable_sstables_mc_format) {
@@ -252,7 +255,8 @@ void feature_service::enable(const std::set<std::string_view>& list) {
         std::ref(_cdc_feature),
         std::ref(_nonfrozen_udts),
         std::ref(_hinted_handoff_separate_connection),
-        std::ref(_lwt_feature)
+        std::ref(_lwt_feature),
+        std::ref(_per_table_partitioners_feature),
     })
     {
         if (list.count(f.name())) {

--- a/gms/feature_service.cc
+++ b/gms/feature_service.cc
@@ -224,6 +224,7 @@ db::schema_features feature_service::cluster_schema_features() const {
     f.set_if<db::schema_feature::DIGEST_INSENSITIVE_TO_EXPIRY>(bool(_digest_insensitive_to_expiry));
     f.set_if<db::schema_feature::COMPUTED_COLUMNS>(bool(_computed_columns));
     f.set_if<db::schema_feature::CDC_OPTIONS>(bool(_cdc_feature));
+    f.set_if<db::schema_feature::PER_TABLE_PARTITIONERS>(bool(_per_table_partitioners_feature));
     return f;
 }
 

--- a/gms/feature_service.hh
+++ b/gms/feature_service.hh
@@ -97,6 +97,7 @@ private:
     gms::feature _nonfrozen_udts;
     gms::feature _hinted_handoff_separate_connection;
     gms::feature _lwt_feature;
+    gms::feature _per_table_partitioners_feature;
 
 public:
     bool cluster_supports_range_tombstones() const {
@@ -165,6 +166,10 @@ public:
 
     const feature& cluster_supports_cdc() const {
         return _cdc_feature;
+    }
+
+    const feature& cluster_supports_per_table_partitioners() const {
+        return _per_table_partitioners_feature;
     }
 
     bool cluster_supports_row_level_repair() const {

--- a/main.cc
+++ b/main.cc
@@ -550,7 +550,7 @@ int main(int ac, char** av) {
                 feature_service.stop().get();
             });
 
-            dht::set_global_partitioner(cfg->partitioner(), cfg->murmur3_partitioner_ignore_msb_bits());
+            schema::set_default_partitioner(cfg->partitioner(), cfg->murmur3_partitioner_ignore_msb_bits());
             auto make_sched_group = [&] (sstring name, unsigned shares) {
                 if (cfg->cpu_scheduler()) {
                     return seastar::create_scheduling_group(name, shares).get0();

--- a/multishard_mutation_query.cc
+++ b/multishard_mutation_query.cc
@@ -597,8 +597,7 @@ static future<reconcilable_result> do_query_mutations(
                     tracing::trace_state_ptr trace_state,
                     streamed_mutation::forwarding,
                     mutation_reader::forwarding fwd_mr) {
-                    auto& partitioner = s->get_partitioner();
-                return make_multishard_combining_reader(ctx, partitioner, std::move(s), pr, ps, pc, std::move(trace_state), fwd_mr);
+                return make_multishard_combining_reader(ctx, std::move(s), pr, ps, pc, std::move(trace_state), fwd_mr);
             });
             auto reader = make_flat_multi_range_reader(s, std::move(ms), ranges, cmd.slice,
                     service::get_local_sstable_query_read_priority(), trace_state, mutation_reader::forwarding::no);

--- a/mutation_reader.hh
+++ b/mutation_reader.hh
@@ -485,7 +485,6 @@ public:
 /// The readers' life-cycles are managed through the supplied lifecycle policy.
 flat_mutation_reader make_multishard_combining_reader(
         shared_ptr<reader_lifecycle_policy> lifecycle_policy,
-        const dht::i_partitioner& partitioner,
         schema_ptr schema,
         const dht::partition_range& pr,
         const query::partition_slice& ps,

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -392,19 +392,18 @@ public:
             , _sharder(remote_partitioner, range, remote_shard)
             , _seed(seed)
             , _local_read_op(local_reader ? std::optional(cf.read_in_progress()) : std::nullopt)
-            , _reader(make_reader(db, cf, local_partitioner, local_reader)) {
+            , _reader(make_reader(db, cf, local_reader)) {
     }
 
 private:
     flat_mutation_reader
     make_reader(seastar::sharded<database>& db,
             column_family& cf,
-            const dht::i_partitioner& local_partitioner,
             is_local_reader local_reader) {
         if (local_reader) {
             return cf.make_streaming_reader(_schema, _range);
         }
-        return make_multishard_streaming_reader(db, local_partitioner, _schema, [this] {
+        return make_multishard_streaming_reader(db, _schema, [this] {
             auto shard_range = _sharder.next();
             if (shard_range) {
                 return std::optional<dht::partition_range>(dht::to_partition_range(*shard_range));

--- a/schema.cc
+++ b/schema.cc
@@ -121,6 +121,10 @@ const dht::i_partitioner& schema::get_partitioner() const {
     return dht::global_partitioner();
 }
 
+bool schema::has_custom_partitioner() const {
+    return bool(_raw._partitioner);
+}
+
 ::shared_ptr<cql3::column_specification>
 schema::make_column_specification(const column_definition& def) {
     auto id = ::make_shared<cql3::column_identifier>(def.name(), column_name_type(def));

--- a/schema.cc
+++ b/schema.cc
@@ -122,14 +122,11 @@ void schema::set_default_partitioner(const sstring& class_name, unsigned ignore_
 }
 
 const dht::i_partitioner& schema::get_partitioner() const {
-    if (_raw._partitioner) {
-        return _raw._partitioner->get();
-    }
-    return ::get_partitioner(default_partitioner_name, smp::count, default_partitioner_ignore_msb);
+    return _raw._partitioner.get();
 }
 
 bool schema::has_custom_partitioner() const {
-    return bool(_raw._partitioner);
+    return _raw._partitioner.get().name() != default_partitioner_name;
 }
 
 ::shared_ptr<cql3::column_specification>
@@ -283,7 +280,7 @@ const column_mapping& schema::get_column_mapping() const {
 }
 
 schema::raw_schema::raw_schema(utils::UUID id)
-    : _id(id)
+    : _id(id), _partitioner(::get_partitioner(default_partitioner_name, smp::count, default_partitioner_ignore_msb))
 { }
 
 schema::schema(const raw_schema& raw, std::optional<raw_view_info> raw_view_info)

--- a/schema.cc
+++ b/schema.cc
@@ -870,6 +870,11 @@ schema_builder& schema_builder::with_partitioner(sstring name, unsigned shard_co
     _raw._partitioner = get_partitioner(name, shard_count, sharding_ignore_msb_bits);
     return *this;
 }
+// Use only for tests!!!
+schema_builder& schema_builder::with_partitioner_for_tests_only(const dht::i_partitioner& p) {
+    _raw._partitioner = p;
+    return *this;
+}
 
 schema_builder::schema_builder(std::string_view ks_name, std::string_view cf_name,
         std::optional<utils::UUID> id, data_type rct)

--- a/schema.hh
+++ b/schema.hh
@@ -817,6 +817,7 @@ public:
     }
 
     const dht::i_partitioner& get_partitioner() const;
+    bool has_custom_partitioner() const;
 
     const column_definition* get_column_definition(const bytes& name) const;
     const column_definition& column_at(column_kind, column_id) const;

--- a/schema.hh
+++ b/schema.hh
@@ -21,6 +21,7 @@
 
 #pragma once
 
+#include <functional>
 #include <optional>
 #include <unordered_map>
 #include <boost/range/iterator_range.hpp>
@@ -634,6 +635,9 @@ private:
         // The flag is not stored in the schema mutation and does not affects schema digest.
         // It is set locally on a system tables that should be extra durable
         bool _wait_for_sync = false; // true if all writes using this schema have to be synced immediately by commitlog
+        // Partitioner is not stored in the schema mutation and does not affect
+        // schema digest. It is also not set locally on a schema tables.
+        std::optional<std::reference_wrapper<const dht::i_partitioner>> _partitioner;
     };
     raw_schema _raw;
     thrift_schema _thrift;

--- a/schema.hh
+++ b/schema.hh
@@ -637,7 +637,7 @@ private:
         bool _wait_for_sync = false; // true if all writes using this schema have to be synced immediately by commitlog
         // Partitioner is not stored in the schema mutation and does not affect
         // schema digest. It is also not set locally on a schema tables.
-        std::optional<std::reference_wrapper<const dht::i_partitioner>> _partitioner;
+        std::reference_wrapper<const dht::i_partitioner> _partitioner;
     };
     raw_schema _raw;
     thrift_schema _thrift;

--- a/schema.hh
+++ b/schema.hh
@@ -816,6 +816,7 @@ public:
         return _raw._caching_options;
     }
 
+    static void set_default_partitioner(const sstring& class_name, unsigned ignore_msb = 0);
     const dht::i_partitioner& get_partitioner() const;
     bool has_custom_partitioner() const;
 

--- a/schema_builder.hh
+++ b/schema_builder.hh
@@ -24,6 +24,7 @@
 #include "schema.hh"
 #include "database_fwd.hh"
 #include "cdc/log.hh"
+#include "dht/i_partitioner.hh"
 
 struct schema_builder {
 public:
@@ -227,6 +228,7 @@ public:
         _raw._wait_for_sync = sync;
         return *this;
     }
+    schema_builder& with_partitioner(sstring name, unsigned shard_count, unsigned sharding_ignore_msb_bits);
     class default_names {
     public:
         default_names(const schema_builder&);

--- a/schema_builder.hh
+++ b/schema_builder.hh
@@ -229,6 +229,8 @@ public:
         return *this;
     }
     schema_builder& with_partitioner(sstring name, unsigned shard_count, unsigned sharding_ignore_msb_bits);
+    // Use only for tests!!!
+    schema_builder& with_partitioner_for_tests_only(const dht::i_partitioner&);
     class default_names {
     public:
         default_names(const schema_builder&);

--- a/schema_mutations.cc
+++ b/schema_mutations.cc
@@ -105,6 +105,16 @@ table_schema_version schema_mutations::digest() const {
     return utils::UUID_gen::get_name_UUID(h.finalize());
 }
 
+std::optional<sstring> schema_mutations::partitioner() const {
+    if (_scylla_tables) {
+        auto rs = query::result_set(*_scylla_tables);
+        if (!rs.empty()) {
+            return rs.row(0).get<sstring>("partitioner");
+        }
+    }
+    return { };
+}
+
 static mutation_opt compact(const mutation_opt& m) {
     if (!m) {
         return m;

--- a/schema_mutations.hh
+++ b/schema_mutations.hh
@@ -138,6 +138,7 @@ public:
     bool is_view() const;
 
     table_schema_version digest() const;
+    std::optional<sstring> partitioner() const;
 
     bool operator==(const schema_mutations&) const;
     bool operator!=(const schema_mutations&) const;

--- a/service/migration_manager.cc
+++ b/service/migration_manager.cc
@@ -100,6 +100,7 @@ void migration_manager::init_messaging_service()
         _feature_listeners.push_back(_feat.cluster_supports_view_virtual_columns().when_enabled(update_schema));
         _feature_listeners.push_back(_feat.cluster_supports_digest_insensitive_to_expiry().when_enabled(update_schema));
         _feature_listeners.push_back(_feat.cluster_supports_cdc().when_enabled(update_schema));
+        _feature_listeners.push_back(_feat.cluster_supports_per_table_partitioners().when_enabled(update_schema));
     }
     _feature_listeners.push_back(_feat.cluster_supports_schema_tables_v3().when_enabled([this] {
         _cluster_upgraded = true;

--- a/test/boost/network_topology_strategy_test.cc
+++ b/test/boost/network_topology_strategy_test.cc
@@ -23,7 +23,6 @@
 #include <boost/range/adaptor/map.hpp>
 #include "utils/fb_utilities.hh"
 #include "utils/sequenced_set.hh"
-#include "dht/murmur3_partitioner.hh"
 #include "locator/network_topology_strategy.hh"
 #include <seastar/testing/test_case.hh>
 #include <seastar/core/sstring.hh>

--- a/test/boost/partitioner_test.cc
+++ b/test/boost/partitioner_test.cc
@@ -469,8 +469,10 @@ test_something_with_some_interesting_ranges_and_partitioners(std::function<void 
             dht::partition_range(make_bound(dht::ring_position::ending_at(t1)), make_bound(dht::ring_position::starting_at(t4))),
     };
     for (auto&& part : some_murmur3_partitioners) {
+        auto schema = schema_builder(s)
+            .with_partitioner(part.name(), part.shard_count(), part.sharding_ignore_msb()).build();
         for (auto&& range : some_murmur3_ranges) {
-            func_to_test(part, *s, range);
+            func_to_test(part, *schema, range);
         }
     }
 }
@@ -483,7 +485,7 @@ static
 void
 do_test_split_range_to_single_shard(const dht::i_partitioner& part, const schema& s, const dht::partition_range& pr) {
     for (auto shard : boost::irange(0u, part.shard_count())) {
-        auto ranges = dht::split_range_to_single_shard(part, s, pr, shard).get0();
+        auto ranges = dht::split_range_to_single_shard(s, pr, shard).get0();
         auto sharder = dht::ring_position_range_sharder(part, pr);
         auto x = sharder.next(s);
         auto cmp = dht::ring_position_comparator(s);

--- a/test/lib/test_services.cc
+++ b/test/lib/test_services.cc
@@ -25,7 +25,6 @@
 #include "db/system_distributed_keyspace.hh"
 #include "db/view/view_update_generator.hh"
 #include "dht/i_partitioner.hh"
-#include "dht/murmur3_partitioner.hh"
 #include "gms/feature_service.hh"
 #include "gms/gossiper.hh"
 #include "message/messaging_service.hh"


### PR DESCRIPTION
This PR makes it possible to enable the usage of different partitioner for each table. If no table-specific partitioner is set for a given table then a default partitioner is used.

The PR is composed of the following parts:
1. Introduction of schema::get_partitioner that still returns dht::global_partitioner
2. Replacement of all the usage of dht::global_partitioner with schema::get_partitioner
3. Making it possible to set table-specific partitioner in a schema_builder
4. Remove all the places that were setting default partitioner except for main.cc (mostly tests)
5. Move default partitioner from i_partitioner to schema.cc and hide it from the rest of the codebase
6. Remove dht::global_partitioner

After this PR there's no such thing as global partitioner at all. There is only a default partitioner but it still has to be accessed through schema::get_partitioner.

There are some intermediate states in which i_partitioner is stored as shared_ptr in the schema but the final version keeps it by const&.

The PR does not enable per table partitioner end-to-end. Just the internals of the single node are covered. I still have to deal with:
1. Making sure a table has the same partitioner on each node
2. Allowing user to set up a table-specific partitioner on table
3. Signal driver about what partitioner is used by a given table
4. Persist partitioner info for each table that does not use default partitioner.

Fixes #5493 

Tests: unit(dev, release, debug), dtest(byo)