### PR TITLE
Reduce #include bloat around cql3 internals from non-cql3 users

### DIFF
--- a/auth/standard_role_manager.cc
+++ b/auth/standard_role_manager.cc
@@ -35,6 +35,7 @@
 #include "auth/common.hh"
 #include "auth/roles-metadata.hh"
 #include "cql3/query_processor.hh"
+#include "cql3/untyped_result_set.hh"
 #include "db/consistency_level_type.hh"
 #include "exceptions/exceptions.hh"
 #include "log.hh"

--- a/cdc/log.cc
+++ b/cdc/log.cc
@@ -40,6 +40,7 @@
 #include "cql3/statements/select_statement.hh"
 #include "cql3/multi_column_relation.hh"
 #include "cql3/tuples.hh"
+#include "cql3/untyped_result_set.hh"
 #include "log.hh"
 #include "json.hh"
 

--- a/cql3/column_identifier.cc
+++ b/cql3/column_identifier.cc
@@ -23,6 +23,7 @@
 #include "exceptions/exceptions.hh"
 #include "cql3/selection/simple_selector.hh"
 #include "cql3/util.hh"
+#include "cql3/query_options.hh"
 
 #include <regex>
 

--- a/cql3/query_processor.cc
+++ b/cql3/query_processor.cc
@@ -47,6 +47,7 @@
 #include "cql3/error_collector.hh"
 #include "cql3/statements/batch_statement.hh"
 #include "cql3/util.hh"
+#include "cql3/untyped_result_set.hh"
 #include "db/config.hh"
 #include "database.hh"
 #include "hashers.hh"

--- a/cql3/query_processor.hh
+++ b/cql3/query_processor.hh
@@ -52,9 +52,6 @@
 #include "cql3/authorized_prepared_statements_cache.hh"
 #include "cql3/query_options.hh"
 #include "cql3/statements/prepared_statement.hh"
-#include "cql3/statements/raw/parsed_statement.hh"
-#include "cql3/statements/raw/cf_statement.hh"
-#include "cql3/untyped_result_set.hh"
 #include "exceptions/exceptions.hh"
 #include "log.hh"
 #include "service/migration_listener.hh"
@@ -65,6 +62,12 @@ namespace cql3 {
 
 namespace statements {
 class batch_statement;
+
+namespace raw {
+
+class parsed_statement;
+
+}
 }
 
 class untyped_result_set;

--- a/cql3/selection/selectable.cc
+++ b/cql3/selection/selectable.cc
@@ -24,6 +24,7 @@
 #include "field_selector.hh"
 #include "writetime_or_ttl.hh"
 #include "selector_factories.hh"
+#include "cql3/query_options.hh"
 #include "cql3/functions/functions.hh"
 #include "cql3/functions/castas_fcts.hh"
 #include "cql3/functions/aggregate_fcts.hh"

--- a/cql3/selection/selection.cc
+++ b/cql3/selection/selection.cc
@@ -46,7 +46,9 @@
 #include "cql3/selection/selection.hh"
 #include "cql3/selection/selector_factories.hh"
 #include "cql3/result_set.hh"
+#include "cql3/query_options.hh"
 #include "cql3/restrictions/multi_column_restriction.hh"
+#include "cql3/restrictions/statement_restrictions.hh"
 
 namespace cql3 {
 

--- a/cql3/selection/selection.cc
+++ b/cql3/selection/selection.cc
@@ -384,6 +384,25 @@ std::unique_ptr<result_set> result_set_builder::build() {
     return std::move(_result_set);
 }
 
+result_set_builder::restrictions_filter::restrictions_filter(::shared_ptr<restrictions::statement_restrictions> restrictions,
+        const query_options& options,
+        uint32_t remaining,
+        schema_ptr schema,
+        uint32_t per_partition_limit,
+        std::optional<partition_key> last_pkey,
+        uint32_t rows_fetched_for_last_partition)
+    : _restrictions(restrictions)
+    , _options(options)
+    , _skip_pk_restrictions(!_restrictions->pk_restrictions_need_filtering())
+    , _skip_ck_restrictions(!_restrictions->ck_restrictions_need_filtering())
+    , _remaining(remaining)
+    , _schema(schema)
+    , _per_partition_limit(per_partition_limit)
+    , _per_partition_remaining(_per_partition_limit)
+    , _rows_fetched_for_last_partition(rows_fetched_for_last_partition)
+    , _last_pkey(std::move(last_pkey))
+{ }
+
 bool result_set_builder::restrictions_filter::do_filter(const selection& selection,
                                                          const std::vector<bytes>& partition_key,
                                                          const std::vector<bytes>& clustering_key,

--- a/cql3/selection/selection.hh
+++ b/cql3/selection/selection.hh
@@ -47,7 +47,6 @@
 #include "cql3/column_specification.hh"
 #include "exceptions/exceptions.hh"
 #include "cql3/selection/raw_selector.hh"
-#include "cql3/selection/selector_factories.hh"
 #include "cql3/restrictions/statement_restrictions.hh"
 #include "unimplemented.hh"
 #include <seastar/core/thread.hh>
@@ -58,6 +57,8 @@ class result_set;
 class metadata;
 
 namespace selection {
+
+class selector_factories;
 
 class selectors {
 public:

--- a/cql3/selection/selection.hh
+++ b/cql3/selection/selection.hh
@@ -47,7 +47,6 @@
 #include "cql3/column_specification.hh"
 #include "exceptions/exceptions.hh"
 #include "cql3/selection/raw_selector.hh"
-#include "cql3/restrictions/statement_restrictions.hh"
 #include "unimplemented.hh"
 #include <seastar/core/thread.hh>
 
@@ -55,6 +54,11 @@ namespace cql3 {
 
 class result_set;
 class metadata;
+class query_options;
+
+namespace restrictions {
+class statement_restrictions;
+}
 
 namespace selection {
 

--- a/cql3/selection/selection.hh
+++ b/cql3/selection/selection.hh
@@ -301,18 +301,7 @@ public:
                 schema_ptr schema,
                 uint32_t per_partition_limit,
                 std::optional<partition_key> last_pkey = {},
-                uint32_t rows_fetched_for_last_partition = 0)
-            : _restrictions(restrictions)
-            , _options(options)
-            , _skip_pk_restrictions(!_restrictions->pk_restrictions_need_filtering())
-            , _skip_ck_restrictions(!_restrictions->ck_restrictions_need_filtering())
-            , _remaining(remaining)
-            , _schema(schema)
-            , _per_partition_limit(per_partition_limit)
-            , _per_partition_remaining(_per_partition_limit)
-            , _rows_fetched_for_last_partition(rows_fetched_for_last_partition)
-            , _last_pkey(std::move(last_pkey))
-        { }
+                uint32_t rows_fetched_for_last_partition = 0);
         bool operator()(const selection& selection, const std::vector<bytes>& pk, const std::vector<bytes>& ck, const query::result_row_view& static_row, const query::result_row_view* row) const;
         void reset(const partition_key* key = nullptr);
         uint32_t get_rows_dropped() const {

--- a/cql3/selection/selector_factories.cc
+++ b/cql3/selection/selector_factories.cc
@@ -42,6 +42,7 @@
 #include "cql3/selection/selector_factories.hh"
 #include "cql3/selection/simple_selector.hh"
 #include "cql3/selection/selectable.hh"
+#include "cql3/query_options.hh"
 
 namespace cql3 {
 

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -47,6 +47,7 @@
 #include "cql3/selection/selection.hh"
 #include "cql3/util.hh"
 #include "cql3/restrictions/single_column_primary_key_restrictions.hh"
+#include "cql3/selection/selector_factories.hh"
 #include <seastar/core/shared_ptr.hh>
 #include "query-result-reader.hh"
 #include "query_result_merger.hh"

--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -63,6 +63,8 @@
 #include "cdc/log.hh"
 #include "cql3/functions/functions.hh"
 #include "cql3/util.hh"
+#include "types/list.hh"
+#include "types/set.hh"
 
 #include "db/marshal/type_parser.hh"
 #include "db/config.hh"

--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -71,6 +71,7 @@
 #include "view_info.hh"
 #include "view_update_checks.hh"
 #include "types/user.hh"
+#include "types/list.hh"
 
 using namespace std::chrono_literals;
 

--- a/service/pager/query_pagers.cc
+++ b/service/pager/query_pagers.cc
@@ -42,6 +42,8 @@
 #include "query_pagers.hh"
 #include "query_pager.hh"
 #include "cql3/selection/selection.hh"
+#include "cql3/query_options.hh"
+#include "cql3/restrictions/statement_restrictions.hh"
 #include "log.hh"
 #include "service/storage_proxy.hh"
 #include "to_string.hh"

--- a/table_helper.cc
+++ b/table_helper.cc
@@ -22,6 +22,7 @@
 
 #include "table_helper.hh"
 #include "cql3/statements/create_table_statement.hh"
+#include "cql3/statements/modification_statement.hh"
 #include "database.hh"
 
 future<> table_helper::setup_table() const {

--- a/table_helper.hh
+++ b/table_helper.hh
@@ -24,10 +24,14 @@
 
 #include <seastar/util/gcc6-concepts.hh>
 #include <seastar/core/apply.hh>
-#include "cql3/statements/modification_statement.hh"
 #include "cql3/statements/prepared_statement.hh"
 #include "cql3/query_processor.hh"
 #include "service/migration_manager.hh"
+
+
+namespace cql3::statements {
+class modification_statement;
+}
 
 /**
  * \class table_helper

--- a/test/boost/sstable_test.hh
+++ b/test/boost/sstable_test.hh
@@ -28,6 +28,8 @@
 #include "database.hh"
 #include "schema.hh"
 #include "schema_builder.hh"
+#include "types/set.hh"
+#include "types/list.hh"
 #include <seastar/core/thread.hh>
 #include "sstables/index_reader.hh"
 #include "test/lib/test_services.hh"

--- a/test/boost/view_schema_test.cc
+++ b/test/boost/view_schema_test.cc
@@ -34,6 +34,8 @@
 #include "test/lib/cql_assertions.hh"
 #include "exceptions/unrecognized_entity_exception.hh"
 #include "db/config.hh"
+#include "types/set.hh"
+#include "types/list.hh"
 
 using namespace std::literals::chrono_literals;
 

--- a/tracing/trace_keyspace_helper.cc
+++ b/tracing/trace_keyspace_helper.cc
@@ -45,6 +45,7 @@
 #include "cql3/statements/batch_statement.hh"
 #include "cql3/statements/modification_statement.hh"
 #include "cql3/cql_config.hh"
+#include "types/set.hh"
 
 namespace tracing {
 

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -28,6 +28,10 @@
 #include <boost/range/adaptor/sliced.hpp>
 
 #include "cql3/statements/batch_statement.hh"
+#include "types/collection.hh"
+#include "types/list.hh"
+#include "types/set.hh"
+#include "types/map.hh"
 #include "dht/token-sharding.hh"
 #include "service/migration_manager.hh"
 #include "service/storage_service.hh"

--- a/view_info.hh
+++ b/view_info.hh
@@ -21,10 +21,13 @@
 
 #pragma once
 
-#include "cql3/statements/select_statement.hh"
 #include "dht/i_partitioner.hh"
 #include "query-request.hh"
 #include "schema.hh"
+
+namespace cql3::statements {
+class select_statement;
+}
 
 class view_info final {
     const schema& _schema;


### PR DESCRIPTION
This series removes some #include dependencies around cql3. It results in 30k line (6.6%) reduction in the preprocessed size of database.i, mainly due to elimination of boost::regex (which was brought in in turn by like_matcher). This should result in fewer and faster recompiles.