### PR TITLE
cdc: disallow negative TTL values in CDC options

### DIFF
--- a/cdc/log.cc
+++ b/cdc/log.cc
@@ -180,6 +180,9 @@ cdc::options::options(const std::map<sstring, sstring>& map) {
             _postimage = p.second == "true";
         } else if (p.first == "ttl") {
             _ttl = std::stoi(p.second);
+            if (_ttl < 0) {
+                throw exceptions::configuration_exception("Invalid CDC option: ttl must be >= 0");
+            }
         } else {
             throw exceptions::configuration_exception("Invalid CDC option: " + p.first);
         }

--- a/test/boost/cdc_test.cc
+++ b/test/boost/cdc_test.cc
@@ -27,6 +27,7 @@
 #include "schema_builder.hh"
 #include "test/lib/cql_assertions.hh"
 #include "test/lib/cql_test_env.hh"
+#include "test/lib/exception_utils.hh"
 #include "transport/messages/result_message.hh"
 
 #include "types.hh"
@@ -428,5 +429,13 @@ SEASTAR_THREAD_TEST_CASE(test_cdc_across_shards) {
         auto rows = select_log(e, "tbl");
 
         BOOST_REQUIRE(!to_bytes_filtered(*rows, cdc::operation::update).empty());
+    }, mk_cdc_test_config()).get();
+}
+
+SEASTAR_THREAD_TEST_CASE(test_negative_ttl_fail) {
+    do_with_cql_env_thread([](cql_test_env& e) {
+        BOOST_REQUIRE_EXCEPTION(e.execute_cql("CREATE TABLE ks.fail (a int PRIMARY KEY, b int) WITH cdc = {'enabled':true,'ttl':'-1'}").get0(),
+                exceptions::configuration_exception,
+                exception_predicate::message_contains("ttl"));
     }, mk_cdc_test_config()).get();
 }


### PR DESCRIPTION
Setting TTL = -1 in `cdc_options` prevents any writes to CDC log. But enabling CDC and having unwritable log table makes no sense.

Notably, normal writes `USING TTL -1` are forbidden. This patch does the same to TTLs in CDC options.

Fixes #5747