### PR TITLE
CDC: split mutations by timestamp and ttl

### DIFF
--- a/alternator-test/test_condition_expression.py
+++ b/alternator-test/test_condition_expression.py
@@ -1317,10 +1317,7 @@ def test_update_condition_unused_entries_succeeded(test_table_s):
 # i.e. LWT_ALWAYS, LWT_RMW_ONLY and UNSAFE_RMW.
 # These test cases make sense only for alternator, so they're skipped
 # when run on AWS
-def test_condition_expression_with_permissive_write_isolation(dynamodb, test_table_s):
-    url = dynamodb.meta.client._endpoint.host
-    if url.endswith('.amazonaws.com'):
-        pytest.skip('rmw isolation levels are applicable to alternator only')
+def test_condition_expression_with_permissive_write_isolation(scylla_only, dynamodb, test_table_s):
     def do_test_with_permissive_isolation_levels(test_case, table, *args):
         try:
             for isolation in ['a', 'o', 'u']:
@@ -1335,10 +1332,7 @@ def test_condition_expression_with_permissive_write_isolation(dynamodb, test_tab
 # Test that the forbid_rmw isolation level prevents read-modify-write requests
 # from working. These test cases make sense only for alternator, so they're skipped
 # when run on AWS
-def test_condition_expression_with_forbidden_rmw(dynamodb, test_table_s):
-    url = dynamodb.meta.client._endpoint.host
-    if url.endswith('.amazonaws.com'):
-        pytest.skip('rmw isolation levels are applicable to alternator only')
+def test_condition_expression_with_forbidden_rmw(scylla_only, dynamodb, test_table_s):
     def do_test_with_forbidden_rmw(test_case, table, *args):
         try:
             set_write_isolation(table, 'f')

--- a/alternator-test/test_table.py
+++ b/alternator-test/test_table.py
@@ -74,6 +74,11 @@ def create_and_delete_table(dynamodb, name, **kwargs):
 def test_create_and_delete_table(dynamodb):
     create_and_delete_table(dynamodb, 'alternator_test')
 
+# Test that recreating a table right after deleting it works without issues
+def test_recreate_table(dynamodb):
+    create_and_delete_table(dynamodb, 'alternator_recr_test')
+    create_and_delete_table(dynamodb, 'alternator_recr_test')
+
 # DynamoDB documentation specifies that table names must be 3-255 characters,
 # and match the regex [a-zA-Z0-9._-]+. Names not matching these rules should
 # be rejected, and no table be created.

--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -56,6 +56,7 @@
 #include "db/query_context.hh"
 #include "schema.hh"
 #include "alternator/tags_extension.hh"
+#include "alternator/rmw_operation.hh"
 
 #include <boost/range/adaptors.hpp>
 
@@ -537,6 +538,24 @@ static bool validate_legal_tag_chars(std::string_view tag) {
     return std::all_of(tag.begin(), tag.end(), &is_legal_tag_char);
 }
 
+static void validate_tags(const std::map<sstring, sstring>& tags) {
+    static const std::unordered_set<std::string_view> allowed_values = {
+        "f", "forbid", "forbid_rmw",
+        "a", "always", "always_use_lwt",
+        "o", "only_rmw_uses_lwt",
+        "u", "unsafe", "unsafe_rmw",
+    };
+    auto it = tags.find(rmw_operation::WRITE_ISOLATION_TAG_KEY);
+    if (it != tags.end()) {
+        std::string_view value = it->second;
+        elogger.warn("Allowed values count {} {}", value, allowed_values.count(value));
+        if (allowed_values.count(value) == 0) {
+            throw api_error("ValidationException",
+                    format("Incorrect write isolation tag {}. Allowed values: {}", value, allowed_values));
+        }
+    }
+}
+
 // FIXME: Updating tags currently relies on updating schema, which may be subject
 // to races during concurrent updates of the same table. Once Scylla schema updates
 // are fixed, this issue will automatically get fixed as well.
@@ -566,6 +585,7 @@ static future<> update_tags(const rjson::value& tags, schema_ptr schema, std::ma
     if (tags_map.size() > 50) {
         return make_exception_future<>(api_error("ValidationException", "Number of Tags exceed the current limit for the provided ResourceArn"));
     }
+    validate_tags(tags_map);
 
     std::stringstream serialized_tags;
     serialized_tags << '{';
@@ -1044,111 +1064,46 @@ static dht::partition_range_vector to_partition_ranges(const dht::decorated_key&
     return dht::partition_range_vector{dht::partition_range(pk)};
 }
 
+rmw_operation::rmw_operation(service::storage_proxy& proxy, rjson::value&& request)
+    : _request(std::move(request))
+    , _schema(get_table(proxy, _request))
+    , _write_isolation(get_write_isolation_for_schema(_schema)) {
+    // _pk and _ck will be assigned later, by the subclass's constructor
+    // (each operation puts the key in a slightly different location in
+    // the request).
+}
 
-// An rmw_operation encapsulates the common logic of all the item update
-// operations which may involve a read of the item before the write
-// (so-called Read-Modify-Write operations). These operations include PutItem,
-// UpdateItem and DeleteItem: All of these may be conditional operations (the
-// "Expected" parameter) which requir a read before the write, and UpdateItem
-// may also have an update expression which refers to the item's old value.
-//
-// The code below supports running the read and the write together as one
-// transaction using LWT (this is why rmw_operation is a subclass of
-// cas_request, as required by storage_proxy::cas()), but also has optional
-// modes not using LWT.
-class rmw_operation : public service::cas_request, public enable_shared_from_this<rmw_operation> {
-public:
-    // The following options choose which mechanism to use for isolating
-    // parallel write operations:
-    // * The FORBID_RMW option forbids RMW (read-modify-write) operations
-    //   such as conditional updates. For the remaining write-only
-    //   operations, ordinary quorum writes are isolated enough.
-    // * The LWT_ALWAYS option always uses LWT (lightweight transactions)
-    //   for any write operation - whether or not it also has a read.
-    // * The LWT_RMW_ONLY option uses LWT only for RMW operations, and uses
-    //   ordinary quorum writes for write-only operations.
-    //   This option is not safe if the user may send both RMW and write-only
-    //   operations on the same item.
-    // * The UNSAFE_RMW option does read-modify-write operations as separate
-    //   read and write. It is unsafe - concurrent RMW operations are not
-    //   isolated at all. This option will likely be removed in the future.
-    enum class write_isolation {
-        FORBID_RMW, LWT_ALWAYS, LWT_RMW_ONLY, UNSAFE_RMW
-    };
-    static constexpr auto WRITE_ISOLATION_TAG_KEY = "system:write_isolation";
+std::optional<mutation> rmw_operation::apply(query::result& qr, const query::partition_slice& slice, api::timestamp_type ts) {
+    if (qr.row_count()) {
+        auto selection = cql3::selection::selection::wildcard(_schema);
+        auto previous_item = describe_item(_schema, slice, *selection, qr, {});
+        return apply(std::make_unique<rjson::value>(std::move(previous_item)), ts);
+    } else {
+        return apply(std::unique_ptr<rjson::value>(), ts);
+    }
+}
 
-    static write_isolation get_write_isolation_for_schema(schema_ptr schema) {
-        const auto& tags = get_tags_of_table(schema);
-        auto it = tags.find(WRITE_ISOLATION_TAG_KEY);
-        if (it == tags.end() || it->second.empty()) {
-            // By default, fall back to always enforcing LWT
-            return write_isolation::LWT_ALWAYS;
-        }
-        switch (it->second[0]) {
-        case 'f':
-            return write_isolation::FORBID_RMW;
-        case 'a':
-            return write_isolation::LWT_ALWAYS;
-        case 'o':
-            return write_isolation::LWT_RMW_ONLY;
-        case 'u':
-            return write_isolation::UNSAFE_RMW;
-        default:
-            // In case of an incorrect tag, fall back to the safest option: LWT_ALWAYS
-            return write_isolation::LWT_ALWAYS;
-        }
+rmw_operation::write_isolation rmw_operation::get_write_isolation_for_schema(schema_ptr schema) {
+    const auto& tags = get_tags_of_table(schema);
+    auto it = tags.find(WRITE_ISOLATION_TAG_KEY);
+    if (it == tags.end() || it->second.empty()) {
+        // By default, fall back to always enforcing LWT
+        return write_isolation::LWT_ALWAYS;
     }
-
-protected:
-    // The full request JSON
-    rjson::value _request;
-    // All RMW operations involve a single item with a specific partition
-    // and optional clustering key, in a single table, so the following
-    // information is common to all of them:
-    schema_ptr _schema;
-    partition_key _pk = partition_key::make_empty();
-    clustering_key _ck = clustering_key::make_empty();
-    write_isolation _write_isolation;
-public:
-    // The constructor of a rmw_operation subclass should parse the request
-    // and try to discover as many input errors as it can before really
-    // attempting the read or write operations.
-    rmw_operation(service::storage_proxy& proxy, rjson::value&& request)
-        : _request(std::move(request))
-        , _schema(get_table(proxy, _request))
-        , _write_isolation(get_write_isolation_for_schema(_schema)) {
-        // _pk and _ck will be assigned later, by the subclass's constructor
-        // (each operation puts the key in a slightly different location in
-        // the request).
+    switch (it->second[0]) {
+    case 'f':
+        return write_isolation::FORBID_RMW;
+    case 'a':
+        return write_isolation::LWT_ALWAYS;
+    case 'o':
+        return write_isolation::LWT_RMW_ONLY;
+    case 'u':
+        return write_isolation::UNSAFE_RMW;
+    default:
+        // In case of an incorrect tag, fall back to the safest option: LWT_ALWAYS
+        return write_isolation::LWT_ALWAYS;
     }
-    // rmw_operation subclasses (update_item_operation, put_item_operation
-    // and delete_item_operation) shall implement an apply() function which
-    // takes the previous value of the item (if it was read) and creates the
-    // write mutation. If the previous value of item does not pass the needed
-    // conditional expression, apply() should return an empty optional.
-    // apply() may throw if it encounters input errors not discovered during
-    // the constructor.
-    virtual std::optional<mutation> apply(const std::unique_ptr<rjson::value>& previous_item, api::timestamp_type ts) = 0;
-    // Convert the above apply() into the signature needed by cas_request:
-    virtual std::optional<mutation> apply(query::result& qr, const query::partition_slice& slice, api::timestamp_type ts) override {
-        if (qr.row_count()) {
-            auto selection = cql3::selection::selection::wildcard(_schema);
-            auto previous_item = describe_item(_schema, slice, *selection, qr, {});
-            return apply(std::make_unique<rjson::value>(std::move(previous_item)), ts);
-        } else {
-            return apply(std::unique_ptr<rjson::value>(), ts);
-        }
-    }
-    virtual ~rmw_operation() = default;
-    schema_ptr schema() const { return _schema; }
-    const rjson::value& request() const { return _request; }
-    future<executor::request_return_type> execute(service::storage_proxy& proxy,
-            service::client_state& client_state,
-            tracing::trace_state_ptr trace_state,
-            bool needs_read_before_write,
-            stats& stats);
-    std::optional<shard_id> shard_for_execute(bool needs_read_before_write);
-};
+}
 
 // shard_for_execute() checks whether execute() must be called on a specific
 // other shard. Running execute() on a specific shard is necessary only if it

--- a/alternator/executor.hh
+++ b/alternator/executor.hh
@@ -45,7 +45,7 @@ public:
     using request_return_type = std::variant<json::json_return_type, api_error>;
     stats _stats;
     static constexpr auto ATTRS_COLUMN_NAME = ":attrs";
-    static constexpr auto KEYSPACE_NAME = "alternator";
+    static constexpr auto KEYSPACE_NAME_PREFIX = "a#";
 
     executor(service::storage_proxy& proxy, service::migration_manager& mm) : _proxy(proxy), _mm(mm) {}
 
@@ -69,7 +69,7 @@ public:
     future<> start();
     future<> stop() { return make_ready_future<>(); }
 
-    future<> maybe_create_keyspace();
+    future<> create_keyspace(std::string_view keyspace_name);
 
     static tracing::trace_state_ptr maybe_trace_query(client_state& client_state, sstring_view op, sstring_view query);
 };

--- a/alternator/rmw_operation.hh
+++ b/alternator/rmw_operation.hh
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2020 ScyllaDB
+ */
+
+/*
+ * This file is part of Scylla.
+ *
+ * Scylla is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Scylla is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <seastarx.hh>
+#include <service/storage_proxy.hh>
+
+namespace alternator {
+
+// An rmw_operation encapsulates the common logic of all the item update
+// operations which may involve a read of the item before the write
+// (so-called Read-Modify-Write operations). These operations include PutItem,
+// UpdateItem and DeleteItem: All of these may be conditional operations (the
+// "Expected" parameter) which requir a read before the write, and UpdateItem
+// may also have an update expression which refers to the item's old value.
+//
+// The code below supports running the read and the write together as one
+// transaction using LWT (this is why rmw_operation is a subclass of
+// cas_request, as required by storage_proxy::cas()), but also has optional
+// modes not using LWT.
+class rmw_operation : public service::cas_request, public enable_shared_from_this<rmw_operation> {
+public:
+    // The following options choose which mechanism to use for isolating
+    // parallel write operations:
+    // * The FORBID_RMW option forbids RMW (read-modify-write) operations
+    //   such as conditional updates. For the remaining write-only
+    //   operations, ordinary quorum writes are isolated enough.
+    // * The LWT_ALWAYS option always uses LWT (lightweight transactions)
+    //   for any write operation - whether or not it also has a read.
+    // * The LWT_RMW_ONLY option uses LWT only for RMW operations, and uses
+    //   ordinary quorum writes for write-only operations.
+    //   This option is not safe if the user may send both RMW and write-only
+    //   operations on the same item.
+    // * The UNSAFE_RMW option does read-modify-write operations as separate
+    //   read and write. It is unsafe - concurrent RMW operations are not
+    //   isolated at all. This option will likely be removed in the future.
+    enum class write_isolation {
+        FORBID_RMW, LWT_ALWAYS, LWT_RMW_ONLY, UNSAFE_RMW
+    };
+    static constexpr auto WRITE_ISOLATION_TAG_KEY = "system:write_isolation";
+
+    static write_isolation get_write_isolation_for_schema(schema_ptr schema);
+
+protected:
+    // The full request JSON
+    rjson::value _request;
+    // All RMW operations involve a single item with a specific partition
+    // and optional clustering key, in a single table, so the following
+    // information is common to all of them:
+    schema_ptr _schema;
+    partition_key _pk = partition_key::make_empty();
+    clustering_key _ck = clustering_key::make_empty();
+    write_isolation _write_isolation;
+public:
+    // The constructor of a rmw_operation subclass should parse the request
+    // and try to discover as many input errors as it can before really
+    // attempting the read or write operations.
+    rmw_operation(service::storage_proxy& proxy, rjson::value&& request);
+    // rmw_operation subclasses (update_item_operation, put_item_operation
+    // and delete_item_operation) shall implement an apply() function which
+    // takes the previous value of the item (if it was read) and creates the
+    // write mutation. If the previous value of item does not pass the needed
+    // conditional expression, apply() should return an empty optional.
+    // apply() may throw if it encounters input errors not discovered during
+    // the constructor.
+    virtual std::optional<mutation> apply(const std::unique_ptr<rjson::value>& previous_item, api::timestamp_type ts) = 0;
+    // Convert the above apply() into the signature needed by cas_request:
+    virtual std::optional<mutation> apply(query::result& qr, const query::partition_slice& slice, api::timestamp_type ts) override;
+    virtual ~rmw_operation() = default;
+    schema_ptr schema() const { return _schema; }
+    const rjson::value& request() const { return _request; }
+    future<executor::request_return_type> execute(service::storage_proxy& proxy,
+            service::client_state& client_state,
+            tracing::trace_state_ptr trace_state,
+            bool needs_read_before_write,
+            stats& stats);
+    std::optional<shard_id> shard_for_execute(bool needs_read_before_write);
+};
+
+} // namespace alternator

--- a/cdc/log.cc
+++ b/cdc/log.cc
@@ -416,6 +416,200 @@ utils::UUID generate_timeuuid(api::timestamp_type t) {
     return utils::UUID_gen::get_random_time_UUID_from_micros(t);
 }
 
+struct atomic_column_update {
+    column_id id;
+    atomic_cell cell;
+};
+
+struct nonatomic_column_deletion {
+    column_id id;
+};
+
+struct nonatomic_column_update {
+    column_id id;
+    std::vector<std::pair<bytes, atomic_cell>> cells;
+};
+
+struct static_row_update {
+    gc_clock::duration ttl;
+    std::vector<atomic_column_update> atomic_entries;
+    std::vector<nonatomic_column_deletion> nonatomic_deletions;
+    std::vector<nonatomic_column_update> nonatomic_updates;
+};
+
+struct clustered_row_insert {
+    gc_clock::duration ttl;
+    clustering_key key;
+    std::vector<atomic_column_update> atomic_entries;
+    std::vector<nonatomic_column_deletion> nonatomic_deletions;
+    // INSERTs can't express updates of individual cells inside a non-atomic
+    // (without deleting the entire field first), so no `nonatomic_updates` field
+    // overwriting a nonatomic column inside an INSERT will be split into two changes:
+    // one with a nonatomic deletion, and one with a nonatomic update
+};
+
+struct clustered_row_update {
+    gc_clock::duration ttl;
+    clustering_key key;
+    std::vector<atomic_column_update> atomic_entries;
+    std::vector<nonatomic_column_deletion> nonatomic_deletions;
+    std::vector<nonatomic_column_update> nonatomic_updates;
+};
+
+struct clustered_row_deletion {
+    clustering_key key;
+};
+
+struct clustered_range_deletion {
+    clustering_key_prefix start;
+    bound_kind start_kind;
+    clustering_key_prefix end;
+    bound_kind end_kind;
+};
+
+struct batch {
+    std::vector<static_row_update> static_updates;
+    std::vector<clustered_row_insert> clustered_inserts;
+    std::vector<clustered_row_update> clustered_updates;
+    std::vector<clustered_row_deletion> clustered_row_deletions;
+    std::vector<clustered_range_deletion> clustered_range_deletions;
+    bool has_partition_deletion = false;
+};
+
+using set_of_changes = std::map<api::timestamp_type, batch>;
+
+struct row_update {
+    std::vector<atomic_column_update> atomic_entries;
+    std::vector<nonatomic_column_deletion> nonatomic_deletions;
+    std::vector<nonatomic_column_update> nonatomic_updates;
+};
+
+std::map<std::pair<api::timestamp_type, gc_clock::duration>, row_update>
+extract_row_updates(const row& r, column_kind ckind, const schema& schema) {
+    std::map<std::pair<api::timestamp_type, gc_clock::duration>, row_update> result;
+    r.for_each_cell([&] (column_id id, const atomic_cell_or_collection& cell) {
+        auto& cdef = schema.column_at(ckind, id);
+        if (cdef.is_atomic()) {
+            auto view = cell.as_atomic_cell(cdef);
+            auto timestamp_and_ttl = std::pair(
+                    view.timestamp(),
+                    view.is_live_and_has_ttl() ? view.ttl() : gc_clock::duration(0)
+                );
+            result[timestamp_and_ttl].atomic_entries.push_back({id, atomic_cell(*cdef.type, view)});
+            return;
+        }
+
+        cell.as_collection_mutation().with_deserialized(*cdef.type, [&] (collection_mutation_view_description mview) {
+            auto desc = mview.materialize(*cdef.type);
+            for (auto& [k, v]: desc.cells) {
+                auto timestamp_and_ttl = std::pair(
+                        v.timestamp(),
+                        v.is_live_and_has_ttl() ? v.ttl() : gc_clock::duration(0)
+                    );
+                auto& updates = result[timestamp_and_ttl].nonatomic_updates;
+                if (updates.empty() || updates.back().id != id) {
+                    updates.push_back({id, {}});
+                }
+                updates.back().cells.push_back({std::move(k), std::move(v)});
+            }
+
+            if (desc.tomb) {
+                auto timestamp_and_ttl = std::pair(desc.tomb.timestamp, gc_clock::duration(0));
+                result[timestamp_and_ttl].nonatomic_deletions.push_back({id});
+            }
+        });
+    });
+    return result;
+};
+
+set_of_changes extract_changes(const mutation& base_mutation, const schema& base_schema) {
+    set_of_changes res;
+    auto& p = base_mutation.partition();
+
+    auto sr_updates = extract_row_updates(p.static_row().get(), column_kind::static_column, base_schema);
+    for (auto& [k, up]: sr_updates) {
+        auto [timestamp, ttl] = k;
+        res[timestamp].static_updates.push_back({
+                ttl,
+                std::move(up.atomic_entries),
+                std::move(up.nonatomic_deletions),
+                std::move(up.nonatomic_updates)
+            });
+    }
+
+    for (const rows_entry& cr : p.clustered_rows()) {
+        auto cr_updates = extract_row_updates(cr.row().cells(), column_kind::regular_column, base_schema);
+
+        const auto& marker = cr.row().marker();
+        auto marker_timestamp = marker.timestamp();
+        auto marker_ttl = marker.is_expiring() ? marker.ttl() : gc_clock::duration(0);
+        if (marker.is_live()) {
+            // make sure that an entry corresponding to the row marker's timestamp and ttl is in the map
+            (void)cr_updates[std::pair(marker_timestamp, marker_ttl)];
+        }
+
+        auto is_insert = [&] (api::timestamp_type timestamp, gc_clock::duration ttl) {
+            if (!marker.is_live()) {
+                return false;
+            }
+
+            return timestamp == marker_timestamp && ttl == marker_ttl;
+        };
+
+        for (auto& [k, up]: cr_updates) {
+            auto [timestamp, ttl] = k;
+
+            if (is_insert(timestamp, ttl)) {
+                res[timestamp].clustered_inserts.push_back({
+                        ttl,
+                        cr.key(),
+                        std::move(up.atomic_entries),
+                        std::move(up.nonatomic_deletions)
+                    });
+                if (!up.nonatomic_updates.empty()) {
+                    // nonatomic updates cannot be expressed with an INSERT.
+                    res[timestamp].clustered_updates.push_back({
+                            ttl,
+                            cr.key(),
+                            {},
+                            {},
+                            std::move(up.nonatomic_updates)
+                        });
+                }
+            } else {
+                res[timestamp].clustered_updates.push_back({
+                        ttl,
+                        cr.key(),
+                        std::move(up.atomic_entries),
+                        std::move(up.nonatomic_deletions),
+                        std::move(up.nonatomic_updates)
+                    });
+            }
+        }
+
+        auto row_tomb = cr.row().deleted_at().regular();
+        if (row_tomb) {
+            res[row_tomb.timestamp].clustered_row_deletions.push_back({cr.key()});
+        }
+    }
+
+    for (const auto& rt: p.row_tombstones()) {
+        if (rt.tomb.timestamp != api::missing_timestamp) {
+            res[rt.tomb.timestamp].clustered_range_deletions.push_back({
+                rt.start, rt.start_kind,
+                rt.end, rt.end_kind
+            });
+        }
+    }
+
+    auto partition_tomb_timestamp = p.partition_tombstone().timestamp;
+    if (partition_tomb_timestamp != api::missing_timestamp) {
+        res[partition_tomb_timestamp].has_partition_deletion = true;
+    }
+
+    return res;
+}
+
 class transformer final {
 private:
     db_context _ctx;

--- a/cdc/log.cc
+++ b/cdc/log.cc
@@ -31,6 +31,7 @@
 #include "bytes.hh"
 #include "database.hh"
 #include "db/config.hh"
+#include "db/schema_tables.hh"
 #include "partition_slice_builder.hh"
 #include "schema.hh"
 #include "schema_builder.hh"

--- a/cdc/log.hh
+++ b/cdc/log.hh
@@ -123,7 +123,7 @@ struct db_context final {
 enum class operation : int8_t {
     // note: these values will eventually be read by a third party, probably not privvy to this
     // enum decl, so don't change the constant values (or the datatype).
-    pre_image = 0, update = 1, row_delete = 2, range_delete_start = 3, range_delete_end = 4, partition_delete = 5
+    pre_image = 0, insert = 1, update = 2, row_delete = 3, range_delete_start = 4, range_delete_end = 5, partition_delete = 6
 };
 
 // cdc log data column operation

--- a/cql3/abstract_marker.cc
+++ b/cql3/abstract_marker.cc
@@ -55,7 +55,7 @@ abstract_marker::abstract_marker(int32_t bind_index, ::shared_ptr<column_specifi
     , _receiver{std::move(receiver)}
 { }
 
-void abstract_marker::collect_marker_specification(variable_specifications& bound_names) {
+void abstract_marker::collect_marker_specification(variable_specifications& bound_names) const {
     bound_names.add(_bind_index, _receiver);
 }
 

--- a/cql3/abstract_marker.hh
+++ b/cql3/abstract_marker.hh
@@ -57,7 +57,7 @@ protected:
 public:
     abstract_marker(int32_t bind_index, ::shared_ptr<column_specification>&& receiver);
 
-    virtual void collect_marker_specification(variable_specifications& bound_names) override;
+    virtual void collect_marker_specification(variable_specifications& bound_names) const override;
 
     virtual bool contains_bind_marker() const override;
 

--- a/cql3/attributes.cc
+++ b/cql3/attributes.cc
@@ -120,7 +120,7 @@ int32_t attributes::get_time_to_live(const query_options& options) {
     return ttl;
 }
 
-void attributes::collect_marker_specification(variable_specifications& bound_names) {
+void attributes::collect_marker_specification(variable_specifications& bound_names) const {
     if (_timestamp) {
         _timestamp->collect_marker_specification(bound_names);
     }

--- a/cql3/attributes.hh
+++ b/cql3/attributes.hh
@@ -69,7 +69,7 @@ public:
 
     int32_t get_time_to_live(const query_options& options);
 
-    void collect_marker_specification(variable_specifications& bound_names);
+    void collect_marker_specification(variable_specifications& bound_names) const;
 
     class raw {
     public:

--- a/cql3/column_condition.cc
+++ b/cql3/column_condition.cc
@@ -131,7 +131,7 @@ column_condition::uses_function(const sstring& ks_name, const sstring& function_
     return false;
 }
 
-void column_condition::collect_marker_specificaton(variable_specifications& bound_names) {
+void column_condition::collect_marker_specificaton(variable_specifications& bound_names) const {
     if (_collection_element) {
         _collection_element->collect_marker_specification(bound_names);
     }

--- a/cql3/column_condition.hh
+++ b/cql3/column_condition.hh
@@ -85,7 +85,7 @@ public:
      * @param boundNames the list of column specification where to collect the
      * bind variables of this term in.
      */
-    void collect_marker_specificaton(variable_specifications& bound_names);
+    void collect_marker_specificaton(variable_specifications& bound_names) const;
 
     bool uses_function(const sstring& ks_name, const sstring& function_name) const;
 

--- a/cql3/functions/function_call.hh
+++ b/cql3/functions/function_call.hh
@@ -57,7 +57,7 @@ public:
             : _fun(std::move(fun)), _terms(std::move(terms)) {
     }
     virtual bool uses_function(const sstring& ks_name, const sstring& function_name) const override;
-    virtual void collect_marker_specification(variable_specifications& bound_names) override;
+    virtual void collect_marker_specification(variable_specifications& bound_names) const override;
     virtual shared_ptr<terminal> bind(const query_options& options) override;
     virtual cql3::raw_value_view bind_and_get(const query_options& options) override;
 private:

--- a/cql3/functions/functions.cc
+++ b/cql3/functions/functions.cc
@@ -419,7 +419,7 @@ function_call::uses_function(const sstring& ks_name, const sstring& function_nam
 }
 
 void
-function_call::collect_marker_specification(variable_specifications& bound_names) {
+function_call::collect_marker_specification(variable_specifications& bound_names) const {
     for (auto&& t : _terms) {
         t->collect_marker_specification(bound_names);
     }

--- a/cql3/lists.cc
+++ b/cql3/lists.cc
@@ -175,7 +175,7 @@ lists::value::equals(shared_ptr<list_type_impl> lt, const value& v) {
 }
 
 const std::vector<bytes_opt>&
-lists::value::get_elements() {
+lists::value::get_elements() const {
     return _elements;
 }
 
@@ -202,7 +202,7 @@ lists::delayed_value::contains_bind_marker() const {
 }
 
 void
-lists::delayed_value::collect_marker_specification(variable_specifications& bound_names) {
+lists::delayed_value::collect_marker_specification(variable_specifications& bound_names) const {
 }
 
 shared_ptr<terminal>
@@ -285,7 +285,7 @@ lists::setter_by_index::requires_read() const {
 }
 
 void
-lists::setter_by_index::collect_marker_specification(variable_specifications& bound_names) {
+lists::setter_by_index::collect_marker_specification(variable_specifications& bound_names) const {
     operation::collect_marker_specification(bound_names);
     _idx->collect_marker_specification(bound_names);
 }

--- a/cql3/lists.hh
+++ b/cql3/lists.hh
@@ -84,7 +84,7 @@ public:
         virtual cql3::raw_value get(const query_options& options) override;
         virtual bytes get_with_protocol_version(cql_serialization_format sf) override;
         bool equals(shared_ptr<list_type_impl> lt, const value& v);
-        virtual const std::vector<bytes_opt>& get_elements() override;
+        virtual const std::vector<bytes_opt>& get_elements() const override;
         virtual sstring to_string() const;
         friend class lists;
     };
@@ -104,7 +104,7 @@ public:
                 : _elements(std::move(elements)) {
         }
         virtual bool contains_bind_marker() const override;
-        virtual void collect_marker_specification(variable_specifications& bound_names);
+        virtual void collect_marker_specification(variable_specifications& bound_names) const override;
         virtual shared_ptr<terminal> bind(const query_options& options) override;
     };
 
@@ -159,7 +159,7 @@ public:
             : operation(column, std::move(t)), _idx(std::move(idx)) {
         }
         virtual bool requires_read() const override;
-        virtual void collect_marker_specification(variable_specifications& bound_names);
+        virtual void collect_marker_specification(variable_specifications& bound_names) const;
         virtual void execute(mutation& m, const clustering_key_prefix& prefix, const update_parameters& params) override;
     };
 

--- a/cql3/maps.cc
+++ b/cql3/maps.cc
@@ -218,7 +218,7 @@ maps::delayed_value::contains_bind_marker() const {
 }
 
 void
-maps::delayed_value::collect_marker_specification(variable_specifications& bound_names) {
+maps::delayed_value::collect_marker_specification(variable_specifications& bound_names) const {
 }
 
 shared_ptr<terminal>
@@ -293,7 +293,7 @@ maps::setter::execute(mutation& m, const clustering_key_prefix& row_key, const u
 }
 
 void
-maps::setter_by_key::collect_marker_specification(variable_specifications& bound_names) {
+maps::setter_by_key::collect_marker_specification(variable_specifications& bound_names) const {
     operation::collect_marker_specification(bound_names);
     _k->collect_marker_specification(bound_names);
 }

--- a/cql3/maps.hh
+++ b/cql3/maps.hh
@@ -98,7 +98,7 @@ public:
                 : _comparator(std::move(comparator)), _elements(std::move(elements)) {
         }
         virtual bool contains_bind_marker() const override;
-        virtual void collect_marker_specification(variable_specifications& bound_names) override;
+        virtual void collect_marker_specification(variable_specifications& bound_names) const override;
         shared_ptr<terminal> bind(const query_options& options);
     };
 
@@ -126,7 +126,7 @@ public:
         setter_by_key(const column_definition& column, shared_ptr<term> k, shared_ptr<term> t)
             : operation(column, std::move(t)), _k(std::move(k)) {
         }
-        virtual void collect_marker_specification(variable_specifications& bound_names) override;
+        virtual void collect_marker_specification(variable_specifications& bound_names) const override;
         virtual void execute(mutation& m, const clustering_key_prefix& prefix, const update_parameters& params) override;
     };
 

--- a/cql3/multi_column_relation.hh
+++ b/cql3/multi_column_relation.hh
@@ -202,7 +202,7 @@ protected:
 
     virtual shared_ptr<term> to_term(const std::vector<shared_ptr<column_specification>>& receivers,
                                      ::shared_ptr<term::raw> raw, database& db, const sstring& keyspace,
-                                     variable_specifications& bound_names) override {
+                                     variable_specifications& bound_names) const override {
         auto as_multi_column_raw = dynamic_pointer_cast<term::multi_column_raw>(raw);
         auto t = as_multi_column_raw->prepare(db, keyspace, receivers);
         t->collect_marker_specification(bound_names);

--- a/cql3/operation.cc
+++ b/cql3/operation.cc
@@ -87,7 +87,7 @@ operation::set_element::prepare(database& db, const sstring& keyspace, const col
 }
 
 bool
-operation::set_element::is_compatible_with(shared_ptr<raw_update> other) {
+operation::set_element::is_compatible_with(shared_ptr<raw_update> other) const {
     // TODO: we could check that the other operation is not setting the same element
     // too (but since the index/key set may be a bind variables we can't always do it at this point)
     return !dynamic_pointer_cast<set_value>(std::move(other));
@@ -120,7 +120,7 @@ operation::set_field::prepare(database& db, const sstring& keyspace, const colum
 }
 
 bool
-operation::set_field::is_compatible_with(shared_ptr<raw_update> other) {
+operation::set_field::is_compatible_with(shared_ptr<raw_update> other) const {
     auto x = dynamic_pointer_cast<set_field>(other);
     if (x) {
         return _field != x->_field;
@@ -185,7 +185,7 @@ operation::addition::prepare(database& db, const sstring& keyspace, const column
 }
 
 bool
-operation::addition::is_compatible_with(shared_ptr<raw_update> other) {
+operation::addition::is_compatible_with(shared_ptr<raw_update> other) const {
     return !dynamic_pointer_cast<set_value>(other);
 }
 
@@ -227,7 +227,7 @@ operation::subtraction::prepare(database& db, const sstring& keyspace, const col
 }
 
 bool
-operation::subtraction::is_compatible_with(shared_ptr<raw_update> other) {
+operation::subtraction::is_compatible_with(shared_ptr<raw_update> other) const {
     return !dynamic_pointer_cast<set_value>(other);
 }
 
@@ -250,7 +250,7 @@ operation::prepend::prepare(database& db, const sstring& keyspace, const column_
 }
 
 bool
-operation::prepend::is_compatible_with(shared_ptr<raw_update> other) {
+operation::prepend::is_compatible_with(shared_ptr<raw_update> other) const {
     return !dynamic_pointer_cast<set_value>(other);
 }
 
@@ -356,7 +356,7 @@ operation::set_counter_value_from_tuple_list::prepare(database& db, const sstrin
 };
 
 bool
-operation::set_value::is_compatible_with(::shared_ptr <raw_update> other) {
+operation::set_value::is_compatible_with(::shared_ptr <raw_update> other) const {
     // We don't allow setting multiple time the same column, because 1)
     // it's stupid and 2) the result would seem random to the user.
     return false;

--- a/cql3/operation.hh
+++ b/cql3/operation.hh
@@ -125,7 +125,7 @@ public:
      * @param bound_names the list of column specification where to collect the
      * bind variables of this term in.
      */
-    virtual void collect_marker_specification(variable_specifications& bound_names) {
+    virtual void collect_marker_specification(variable_specifications& bound_names) const {
         if (_t) {
             _t->collect_marker_specification(bound_names);
         }
@@ -168,7 +168,7 @@ public:
          * @return whether this operation can be applied alongside the {@code
          * other} update (in the same UPDATE statement for the same column).
          */
-        virtual bool is_compatible_with(::shared_ptr<raw_update> other) = 0;
+        virtual bool is_compatible_with(::shared_ptr<raw_update> other) const = 0;
     };
 
     /**
@@ -218,7 +218,7 @@ public:
 
         virtual shared_ptr<operation> prepare(database& db, const sstring& keyspace, const column_definition& receiver) override;
 
-        virtual bool is_compatible_with(shared_ptr<raw_update> other) override;
+        virtual bool is_compatible_with(shared_ptr<raw_update> other) const override;
     };
 
     // Set a single field inside a user-defined type.
@@ -234,7 +234,7 @@ public:
 
         virtual shared_ptr<operation> prepare(database& db, const sstring& keyspace, const column_definition& receiver) override;
 
-        virtual bool is_compatible_with(shared_ptr<raw_update> other) override;
+        virtual bool is_compatible_with(shared_ptr<raw_update> other) const override;
     };
 
     // Delete a single field inside a user-defined type.
@@ -263,7 +263,7 @@ public:
 
         virtual shared_ptr<operation> prepare(database& db, const sstring& keyspace, const column_definition& receiver) override;
 
-        virtual bool is_compatible_with(shared_ptr<raw_update> other) override;
+        virtual bool is_compatible_with(shared_ptr<raw_update> other) const override;
     };
 
     class subtraction : public raw_update {
@@ -277,7 +277,7 @@ public:
 
         virtual shared_ptr<operation> prepare(database& db, const sstring& keyspace, const column_definition& receiver) override;
 
-        virtual bool is_compatible_with(shared_ptr<raw_update> other) override;
+        virtual bool is_compatible_with(shared_ptr<raw_update> other) const override;
     };
 
     class prepend : public raw_update {
@@ -291,7 +291,7 @@ public:
 
         virtual shared_ptr<operation> prepare(database& db, const sstring& keyspace, const column_definition& receiver) override;
 
-        virtual bool is_compatible_with(shared_ptr<raw_update> other) override;
+        virtual bool is_compatible_with(shared_ptr<raw_update> other) const override;
     };
 
     class column_deletion;

--- a/cql3/operation_impl.hh
+++ b/cql3/operation_impl.hh
@@ -65,7 +65,7 @@ public:
         }
 #endif
 
-    virtual bool is_compatible_with(::shared_ptr <raw_update> other) override;
+    virtual bool is_compatible_with(::shared_ptr <raw_update> other) const override;
 };
 
 class operation::set_counter_value_from_tuple_list : public set_value {

--- a/cql3/relation.hh
+++ b/cql3/relation.hh
@@ -253,7 +253,7 @@ protected:
                                        ::shared_ptr<term::raw> raw,
                                        database& db,
                                        const sstring& keyspace,
-                                       variable_specifications& boundNames) = 0;
+                                       variable_specifications& boundNames) const = 0;
 
     /**
      * Converts the specified <code>Raw</code> terms into a <code>Term</code>s.
@@ -269,7 +269,7 @@ protected:
                                              const std::vector<::shared_ptr<term::raw>>& raws,
                                              database& db,
                                              const sstring& keyspace,
-                                             variable_specifications& boundNames) {
+                                             variable_specifications& boundNames) const {
         std::vector<::shared_ptr<term>> terms;
         for (auto&& r : raws) {
             terms.emplace_back(to_term(receivers, r, db, keyspace, boundNames));

--- a/cql3/sets.cc
+++ b/cql3/sets.cc
@@ -196,7 +196,7 @@ sets::delayed_value::contains_bind_marker() const {
 }
 
 void
-sets::delayed_value::collect_marker_specification(variable_specifications& bound_names) {
+sets::delayed_value::collect_marker_specification(variable_specifications& bound_names) const {
 }
 
 shared_ptr<terminal>

--- a/cql3/sets.hh
+++ b/cql3/sets.hh
@@ -94,7 +94,7 @@ public:
             : _comparator(std::move(comparator)), _elements(std::move(elements)) {
         }
         virtual bool contains_bind_marker() const override;
-        virtual void collect_marker_specification(variable_specifications& bound_names) override;
+        virtual void collect_marker_specification(variable_specifications& bound_names) const override;
         virtual shared_ptr<terminal> bind(const query_options& options);
     };
 

--- a/cql3/single_column_relation.cc
+++ b/cql3/single_column_relation.cc
@@ -57,7 +57,7 @@ single_column_relation::to_term(const std::vector<::shared_ptr<column_specificat
                                 ::shared_ptr<term::raw> raw,
                                 database& db,
                                 const sstring& keyspace,
-                                variable_specifications& bound_names) {
+                                variable_specifications& bound_names) const {
     // TODO: optimize vector away, accept single column_specification
     assert(receivers.size() == 1);
     auto term = raw->prepare(db, keyspace, receivers[0]);
@@ -108,7 +108,7 @@ single_column_relation::new_LIKE_restriction(
 }
 
 std::vector<::shared_ptr<column_specification>>
-single_column_relation::to_receivers(schema_ptr schema, const column_definition& column_def)
+single_column_relation::to_receivers(schema_ptr schema, const column_definition& column_def) const
 {
     using namespace statements::request_validations;
     auto receiver = column_def.column_specification;

--- a/cql3/single_column_relation.hh
+++ b/cql3/single_column_relation.hh
@@ -119,7 +119,7 @@ public:
 protected:
     virtual ::shared_ptr<term> to_term(const std::vector<::shared_ptr<column_specification>>& receivers,
                           ::shared_ptr<term::raw> raw, database& db, const sstring& keyspace,
-                          variable_specifications& bound_names) override;
+                          variable_specifications& bound_names) const override;
 
 #if 0
     public SingleColumnRelation withNonStrictOperator()
@@ -202,7 +202,7 @@ private:
      * @return the receivers for the specified relation.
      * @throws exceptions::invalid_request_exception if the relation is invalid
      */
-    std::vector<::shared_ptr<column_specification>> to_receivers(schema_ptr schema, const column_definition& column_def);
+    std::vector<::shared_ptr<column_specification>> to_receivers(schema_ptr schema, const column_definition& column_def) const;
 
     static shared_ptr<column_specification> make_collection_receiver(shared_ptr<column_specification> receiver, bool for_key) {
         return static_cast<const collection_type_impl*>(receiver->type.get())->make_collection_receiver(receiver, for_key);

--- a/cql3/statements/modification_statement.cc
+++ b/cql3/statements/modification_statement.cc
@@ -39,6 +39,7 @@
  * along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "types/map.hh"
 #include "cql3/statements/modification_statement.hh"
 #include "cql3/statements/raw/modification_statement.hh"
 #include "cql3/statements/prepared_statement.hh"
@@ -52,6 +53,7 @@
 #include "db/config.hh"
 #include "dht/murmur3_partitioner.hh"
 #include "service/storage_service.hh"
+#include "transport/messages/result_message.hh"
 #include "database.hh"
 #include <seastar/core/execution_stage.hh>
 #include "utils/UUID_gen.hh"

--- a/cql3/statements/role-management-statements.cc
+++ b/cql3/statements/role-management-statements.cc
@@ -41,6 +41,7 @@
 
 #include <algorithm>
 
+#include "types/map.hh"
 #include "auth/authentication_options.hh"
 #include "auth/common.hh"
 #include "auth/role_manager.hh"
@@ -54,7 +55,8 @@
 #include "cql3/statements/revoke_role_statement.hh"
 #include "cql3/statements/request_validations.hh"
 #include "exceptions/exceptions.hh"
-#include "service/storage_service.hh"
+#include "service/storage_proxy.hh"
+#include "gms/feature_service.hh"
 #include "transport/messages/result_message.hh"
 #include "unimplemented.hh"
 

--- a/cql3/term.hh
+++ b/cql3/term.hh
@@ -72,7 +72,7 @@ public:
      * @param boundNames the variables specification where to collect the
      * bind variables of this term in.
      */
-    virtual void collect_marker_specification(variable_specifications& bound_names) = 0;
+    virtual void collect_marker_specification(variable_specifications& bound_names) const = 0;
 
     /**
      * Bind the values in this term to the values contained in {@code values}.
@@ -167,7 +167,7 @@ public:
  */
 class terminal : public term {
 public:
-    virtual void collect_marker_specification(variable_specifications& bound_names) {
+    virtual void collect_marker_specification(variable_specifications& bound_names) const {
     }
 
     virtual ::shared_ptr<terminal> bind(const query_options& options) override {
@@ -198,7 +198,7 @@ public:
 
 class multi_item_terminal : public terminal {
 public:
-    virtual const std::vector<bytes_opt>& get_elements() = 0;
+    virtual const std::vector<bytes_opt>& get_elements() const = 0;
 };
 
 class collection_terminal {

--- a/cql3/token_relation.cc
+++ b/cql3/token_relation.cc
@@ -55,7 +55,7 @@ std::vector<const column_definition*> cql3::token_relation::get_column_definitio
 
 std::vector<::shared_ptr<cql3::column_specification>> cql3::token_relation::to_receivers(
         schema_ptr schema,
-        const std::vector<const column_definition*>& column_defs) {
+        const std::vector<const column_definition*>& column_defs) const {
     auto pk = schema->partition_key_columns();
     if (!std::equal(column_defs.begin(), column_defs.end(), pk.begin(),
             pk.end(), [](auto* c1, auto& c2) {
@@ -128,7 +128,7 @@ sstring cql3::token_relation::to_string() const {
 ::shared_ptr<cql3::term> cql3::token_relation::to_term(
         const std::vector<::shared_ptr<column_specification>>& receivers,
         ::shared_ptr<term::raw> raw, database& db, const sstring& keyspace,
-        variable_specifications& bound_names) {
+        variable_specifications& bound_names) const {
     auto term = raw->prepare(db, keyspace, receivers.front());
     term->collect_marker_specification(bound_names);
     return term;

--- a/cql3/token_relation.hh
+++ b/cql3/token_relation.hh
@@ -82,7 +82,7 @@ private:
      * @return the receivers for the specified relation.
      * @throws InvalidRequestException if the relation is invalid
      */
-    std::vector<::shared_ptr<column_specification>> to_receivers(schema_ptr schema, const std::vector<const column_definition*>& column_defs);
+    std::vector<::shared_ptr<column_specification>> to_receivers(schema_ptr schema, const std::vector<const column_definition*>& column_defs) const;
 
 public:
     token_relation(std::vector<::shared_ptr<column_identifier::raw>> entities,
@@ -126,7 +126,7 @@ protected:
                                        ::shared_ptr<term::raw> raw,
                                        database& db,
                                        const sstring& keyspace,
-                                       variable_specifications& bound_names) override;
+                                       variable_specifications& bound_names) const override;
 };
 
 }

--- a/cql3/tuples.hh
+++ b/cql3/tuples.hh
@@ -124,7 +124,7 @@ public:
             return cql3::raw_value::make_value(tuple_type_impl::build_value(_elements));
         }
 
-        virtual const std::vector<bytes_opt>& get_elements() override {
+        virtual const std::vector<bytes_opt>& get_elements() const override {
             return _elements;
         }
         virtual sstring to_string() const override {
@@ -147,7 +147,7 @@ public:
             return std::all_of(_elements.begin(), _elements.end(), std::mem_fn(&term::contains_bind_marker));
         }
 
-        virtual void collect_marker_specification(variable_specifications& bound_names) override {
+        virtual void collect_marker_specification(variable_specifications& bound_names) const override {
             for (auto&& term : _elements) {
                 term->collect_marker_specification(bound_names);
             }

--- a/cql3/user_types.cc
+++ b/cql3/user_types.cc
@@ -170,7 +170,7 @@ cql3::raw_value user_types::value::get(const query_options&) {
     return cql3::raw_value::make_value(tuple_type_impl::build_value(_elements));
 }
 
-const std::vector<bytes_opt>& user_types::value::get_elements() {
+const std::vector<bytes_opt>& user_types::value::get_elements() const {
     return _elements;
 }
 
@@ -189,7 +189,7 @@ bool user_types::delayed_value::contains_bind_marker() const {
     return boost::algorithm::any_of(_values, std::mem_fn(&term::contains_bind_marker));
 }
 
-void user_types::delayed_value::collect_marker_specification(variable_specifications& bound_names) {
+void user_types::delayed_value::collect_marker_specification(variable_specifications& bound_names) const {
     for (auto&& v : _values) {
         v->collect_marker_specification(bound_names);
     }

--- a/cql3/user_types.hh
+++ b/cql3/user_types.hh
@@ -81,7 +81,7 @@ public:
         static value from_serialized(const fragmented_temporary_buffer::view&, const user_type_impl&);
 
         virtual cql3::raw_value get(const query_options&) override;
-        virtual const std::vector<bytes_opt>& get_elements() override;
+        virtual const std::vector<bytes_opt>& get_elements() const override;
         virtual sstring to_string() const override;
     };
 
@@ -93,7 +93,7 @@ public:
         delayed_value(user_type type, std::vector<shared_ptr<term>> values);
         virtual bool uses_function(const sstring& ks_name, const sstring& function_name) const override;
         virtual bool contains_bind_marker() const override;
-        virtual void collect_marker_specification(variable_specifications& bound_names);
+        virtual void collect_marker_specification(variable_specifications& bound_names) const;
     private:
         std::vector<bytes_opt> bind_internal(const query_options& options);
     public:

--- a/db/system_distributed_keyspace.cc
+++ b/db/system_distributed_keyspace.cc
@@ -31,6 +31,7 @@
 #include "types/tuple.hh"
 #include "types/set.hh"
 #include "cdc/generation.hh"
+#include "cql3/query_processor.hh"
 
 #include <seastar/core/reactor.hh>
 #include <seastar/core/shared_ptr.hh>

--- a/db/system_distributed_keyspace.hh
+++ b/db/system_distributed_keyspace.hh
@@ -22,7 +22,6 @@
 #pragma once
 
 #include "bytes.hh"
-#include "cql3/query_processor.hh"
 #include "schema.hh"
 #include "service/migration_manager.hh"
 #include "utils/UUID.hh"
@@ -31,6 +30,10 @@
 #include <seastar/core/sstring.hh>
 
 #include <unordered_map>
+
+namespace cql3 {
+class query_processor;
+}
 
 namespace cdc {
     class stream_id;

--- a/docs/alternator/alternator.md
+++ b/docs/alternator/alternator.md
@@ -155,11 +155,11 @@ implemented, with the following limitations:
 ### Write isolation policies
  * By default, alternator will use LWT for all writes. It can, however, be configured
    per table by tagging it with a 'system:write_isolation' key and one of the following values:
-    * 'a' - always use LWT
-    * 'o' - use LWT only for requests that require read-before-write
-    * 'f' - forbid statements that need read-before-write. Using such statements
+    * 'a', 'always', 'always_use_lwt' - always use LWT
+    * 'o', 'only_rmw_uses_lwt' - use LWT only for requests that require read-before-write
+    * 'f', 'forbid', 'forbid_rmw' - forbid statements that need read-before-write. Using such statements
       (e.g. UpdateItem with ConditionExpression) will result in an error
-    * 'u' - (unsafe) perform read-modify-write without any consistency guarantees
+    * 'u', 'unsafe', 'unsafe_rmw' - (unsafe) perform read-modify-write without any consistency guarantees
 ### Accounting and capping
 * Not yet supported. Mainly for multi-tenant cloud use, we need to track
   resource use of individual requests (the API should also optionally

--- a/mutation_partition_serializer.cc
+++ b/mutation_partition_serializer.cc
@@ -35,6 +35,7 @@
 #include "idl/keys.dist.impl.hh"
 #include "idl/mutation.dist.impl.hh"
 #include "service/storage_service.hh"
+#include "frozen_mutation.hh"
 
 using namespace db;
 

--- a/redis/mutation_utils.cc
+++ b/redis/mutation_utils.cc
@@ -21,7 +21,7 @@
 
 #include "redis/mutation_utils.hh"
 #include "types.hh"
-#include "service/storage_service.hh"
+#include "service/storage_proxy.hh"
 #include "schema.hh"
 #include "database.hh"
 #include <seastar/core/print.hh>

--- a/service/client_state.cc
+++ b/service/client_state.cc
@@ -50,6 +50,7 @@
 #include "db/schema_tables.hh"
 #include "tracing/trace_keyspace_helper.hh"
 #include "storage_service.hh"
+#include "db/system_distributed_keyspace.hh"
 #include "database.hh"
 #include "cdc/log.hh"
 

--- a/service/misc_services.cc
+++ b/service/misc_services.cc
@@ -44,6 +44,7 @@
 #include "db/system_keyspace.hh"
 #include "gms/application_state.hh"
 #include "service/storage_service.hh"
+#include "service/storage_proxy.hh"
 #include "service/view_update_backlog_broker.hh"
 #include "database.hh"
 

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -50,7 +50,6 @@
 #include "dht/token_range_endpoints.hh"
 #include <seastar/core/sleep.hh>
 #include "gms/application_state.hh"
-#include "db/system_distributed_keyspace.hh"
 #include <seastar/core/semaphore.hh>
 #include <seastar/core/gate.hh>
 #include "utils/fb_utilities.hh"
@@ -58,15 +57,26 @@
 #include "database_fwd.hh"
 #include "db/schema_features.hh"
 #include "streaming/stream_state.hh"
-#include "streaming/stream_plan.hh"
 #include <seastar/core/distributed.hh>
 #include "utils/disk-error-handler.hh"
 #include "gms/feature.hh"
+#include "service/migration_listener.hh"
 #include "gms/feature_service.hh"
 #include <seastar/core/metrics_registration.hh>
 #include <seastar/core/rwlock.hh>
 #include "sstables/version.hh"
 #include "cdc/metadata.hh"
+
+namespace db {
+class system_distributed_keyspace;
+namespace view {
+class view_update_generator;
+}
+}
+
+namespace cql3 {
+class cql_config;
+}
 
 namespace cql_transport {
     class cql_server;

--- a/sstables/writer.hh
+++ b/sstables/writer.hh
@@ -30,6 +30,7 @@
 #include <seastar/core/byteorder.hh>
 #include "version.hh"
 #include "data/value_view.hh"
+#include "counters.hh"
 #include "service/storage_service.hh"
 
 namespace sstables {

--- a/streaming/stream_plan.hh
+++ b/streaming/stream_plan.hh
@@ -45,7 +45,6 @@
 #include "query-request.hh"
 #include "dht/i_partitioner.hh"
 #include "streaming/stream_coordinator.hh"
-#include "streaming/stream_event_handler.hh"
 #include "streaming/stream_detail.hh"
 #include "streaming/stream_reason.hh"
 #include <vector>
@@ -53,6 +52,7 @@
 namespace streaming {
 
 class stream_state;
+class stream_event_handler;
 
 /**
  * {@link StreamPlan} is a helper class that builds StreamOperation of given configuration.

--- a/streaming/stream_session.hh
+++ b/streaming/stream_session.hh
@@ -40,7 +40,6 @@
 
 #include "gms/i_endpoint_state_change_subscriber.hh"
 #include <seastar/core/distributed.hh>
-#include "cql3/query_processor.hh"
 #include "message/messaging_service_fwd.hh"
 #include "utils/UUID.hh"
 #include "streaming/stream_session_state.hh"

--- a/table.cc
+++ b/table.cc
@@ -24,6 +24,7 @@
 #include "sstables/sstables_manager.hh"
 #include "service/priority_manager.hh"
 #include "db/view/view_updating_consumer.hh"
+#include "db/schema_tables.hh"
 #include "cell_locking.hh"
 #include "mutation_fragment.hh"
 #include "mutation_partition.hh"

--- a/table_helper.cc
+++ b/table_helper.cc
@@ -21,6 +21,7 @@
  */
 
 #include "table_helper.hh"
+#include "cql3/query_processor.hh"
 #include "cql3/statements/create_table_statement.hh"
 #include "cql3/statements/modification_statement.hh"
 #include "database.hh"

--- a/table_helper.hh
+++ b/table_helper.hh
@@ -25,7 +25,6 @@
 #include <seastar/util/gcc6-concepts.hh>
 #include <seastar/core/apply.hh>
 #include "cql3/statements/prepared_statement.hh"
-#include "cql3/query_processor.hh"
 #include "service/migration_manager.hh"
 
 

--- a/test.py
+++ b/test.py
@@ -389,7 +389,10 @@ async def run_test(test, options):
             stdout, _ = await asyncio.wait_for(process.communicate(), options.timeout)
             if process.returncode != 0:
                 report_error('Test exited with code {code}\n'.format(code=process.returncode))
-            return process.returncode == 0
+                return False
+            if not options.save_log_on_success:
+                pathlib.Path(test.log_filename).unlink()
+            return True
         except (asyncio.TimeoutError, asyncio.CancelledError) as e:
             if process is not None:
                 process.kill()
@@ -458,6 +461,9 @@ def parse_cmd_line():
                         help='Verbose reporting')
     parser.add_argument('--jobs', '-j', action="store", default=default_num_jobs, type=int,
                         help="Number of jobs to use for running the tests")
+    parser.add_argument('--save-log-on-success', "-s", default=False,
+                        dest="save_log_on_success", action="store_true",
+                        help="Save test log output on success.")
     args = parser.parse_args()
 
     if not sys.stdout.isatty():

--- a/test.py
+++ b/test.py
@@ -597,8 +597,10 @@ def write_junit_report(tmpdir, mode):
                 continue
             failed += 1
             xml_fail = ET.SubElement(xml_res, 'failure')
-            xml_fail.text = "Test {} {} failed:\n".format(test.path, " ".join(test.args))
-            xml_fail.text += read_log(test.log_filename)
+            xml_fail.text = "Test {} {} failed, check the log at {}".format(
+                test.path,
+                " ".join(test.args),
+                test.log_filename)
     if total == 0:
         return
     xml_results.set("tests", str(total))

--- a/test.py
+++ b/test.py
@@ -486,7 +486,8 @@ def parse_cmd_line():
     prepare_dir(args.tmpdir, "*.log")
 
     for mode in args.modes:
-        prepare_dir(os.path.join(args.tmpdir, mode), "*.{log,reject}")
+        prepare_dir(os.path.join(args.tmpdir, mode), "*.log")
+        prepare_dir(os.path.join(args.tmpdir, mode), "*.reject")
         prepare_dir(os.path.join(args.tmpdir, mode, "xml"), "*.xml")
 
     return args

--- a/test.py
+++ b/test.py
@@ -325,6 +325,7 @@ class TabularConsoleOutput:
     def __init__(self, verbose, test_count):
         self.verbose = verbose
         self.test_count = test_count
+        self.print_newline = False
         self.last_test_no = 0
         self.last_line_len = 1
 
@@ -334,8 +335,8 @@ class TabularConsoleOutput:
         print("-"*78)
 
     def print_end_blurb(self):
-        if not self.verbose:
-            sys.stdout.write('\n')
+        if self.print_newline:
+            print("")
         print("-"*78)
 
     def print_progress(self, test):
@@ -346,9 +347,16 @@ class TabularConsoleOutput:
             palette.ok("[ PASS ]") if test.success else palette.fail("[ FAIL ]")
         )
         if self.verbose is False:
-            print('\r' + ' ' * self.last_line_len, end='')
-            self.last_line_len = len(msg)
-            print('\r' + msg, end='')
+            if test.success:
+                print("\r" + " " * self.last_line_len, end="")
+                self.last_line_len = len(msg)
+                print("\r" + msg, end="")
+                self.print_newline = True
+            else:
+                if self.print_newline:
+                    print("")
+                print(msg)
+                self.print_newline = False
         else:
             print(msg)
 

--- a/test/boost/sstable_resharding_test.cc
+++ b/test/boost/sstable_resharding_test.cc
@@ -7,6 +7,7 @@
 #include <seastar/core/future-util.hh>
 #include <seastar/core/do_with.hh>
 #include <seastar/core/distributed.hh>
+#include "types/map.hh"
 #include "sstables/sstables.hh"
 #include <seastar/testing/test_case.hh>
 #include "schema.hh"

--- a/test/boost/sstable_test.hh
+++ b/test/boost/sstable_test.hh
@@ -22,6 +22,7 @@
 
 #pragma once
 
+#include "types/map.hh"
 #include "sstables/writer.hh"
 #include "sstables/sstables.hh"
 #include "sstables/binary_search.hh"

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -193,7 +193,14 @@ public:
         auto stmt = prepared->statement;
         assert(stmt->get_bound_terms() == values.size());
 
-        auto options = ::make_shared<cql3::query_options>(cl, infinite_timeout_config, std::move(values));
+        const auto& so = cql3::query_options::specific_options::DEFAULT;
+        auto options = ::make_shared<cql3::query_options>(cl, infinite_timeout_config,
+                std::move(values), cql3::query_options::specific_options{
+                            so.page_size,
+                            so.state,
+                            db::consistency_level::SERIAL,
+                            so.timestamp,
+                        });
         options->prepare(prepared->bound_names);
 
         auto qs = make_query_state();

--- a/tracing/trace_keyspace_helper.cc
+++ b/tracing/trace_keyspace_helper.cc
@@ -44,6 +44,7 @@
 #include "tracing/tracing_backend_registry.hh"
 #include "cql3/statements/batch_statement.hh"
 #include "cql3/statements/modification_statement.hh"
+#include "cql3/query_processor.hh"
 #include "cql3/cql_config.hh"
 #include "types/set.hh"
 

--- a/tracing/trace_keyspace_helper.hh
+++ b/tracing/trace_keyspace_helper.hh
@@ -45,7 +45,6 @@
 #include <seastar/core/apply.hh>
 #include <seastar/core/metrics_registration.hh>
 #include "tracing/tracing.hh"
-#include "cql3/query_processor.hh"
 #include "table_helper.hh"
 
 namespace tracing {

--- a/types.cc
+++ b/types.cc
@@ -1345,17 +1345,26 @@ struct validate_visitor {
     void operator()(const reversed_type_impl& t) { return t.underlying_type()->validate(v, sf); }
     void operator()(const abstract_type&) {}
     template <typename T> void operator()(const integer_type_impl<T>& t) {
-        if (v.size() != 0 && v.size() != sizeof(T)) {
+        if (v.empty()) {
+            return;
+        }
+        if (v.size() != sizeof(T)) {
             throw marshal_exception(format("Validation failed for type {}: got {:d} bytes", t.name(), v.size()));
         }
     }
     void operator()(const byte_type_impl& t) {
-        if (v.size() != 0 && v.size() != 1) {
+        if (v.empty()) {
+            return;
+        }
+        if (v.size() != 1) {
             throw marshal_exception(format("Expected 1 byte for a tinyint ({:d})", v.size()));
         }
     }
     void operator()(const short_type_impl& t) {
-        if (v.size() != 0 && v.size() != 2) {
+        if (v.empty()) {
+            return;
+        }
+        if (v.size() != 2) {
             throw marshal_exception(format("Expected 2 bytes for a smallint ({:d})", v.size()));
         }
     }
@@ -1371,12 +1380,18 @@ struct validate_visitor {
     }
     void operator()(const bytes_type_impl& t) {}
     void operator()(const boolean_type_impl& t) {
-        if (v.size() != 0 && v.size() != 1) {
+        if (v.empty()) {
+            return;
+        }
+        if (v.size() != 1) {
             throw marshal_exception(format("Validation failed for boolean, got {:d} bytes", v.size()));
         }
     }
     void operator()(const timeuuid_type_impl& t) {
-        if (v.size() != 0 && v.size() != 16) {
+        if (v.empty()) {
+            return;
+        }
+        if (v.size() != 16) {
             throw marshal_exception(format("Validation failed for timeuuid - got {:d} bytes", v.size()));
         }
         auto msb = read_simple<uint64_t>(v);
@@ -1387,7 +1402,10 @@ struct validate_visitor {
         }
     }
     void operator()(const timestamp_date_base_class& t) {
-        if (v.size() != 0 && v.size() != sizeof(uint64_t)) {
+        if (v.empty()) {
+            return;
+        }
+        if (v.size() != sizeof(uint64_t)) {
             throw marshal_exception(format("Validation failed for timestamp - got {:d} bytes", v.size()));
         }
     }
@@ -1421,27 +1439,42 @@ struct validate_visitor {
         }
     }
     template <typename T> void operator()(const floating_type_impl<T>& t) {
-        if (v.size() != 0 && v.size() != sizeof(T)) {
+        if (v.empty()) {
+            return;
+        }
+        if (v.size() != sizeof(T)) {
             throw marshal_exception(format("Expected {:d} bytes for a floating type, got {:d}", sizeof(T), v.size()));
         }
     }
     void operator()(const simple_date_type_impl& t) {
-        if (v.size() != 0 && v.size() != 4) {
+        if (v.empty()) {
+            return;
+        }
+        if (v.size() != 4) {
             throw marshal_exception(format("Expected 4 byte long for date ({:d})", v.size()));
         }
     }
     void operator()(const time_type_impl& t) {
-        if (v.size() != 0 && v.size() != 8) {
+        if (v.empty()) {
+            return;
+        }
+        if (v.size() != 8) {
             throw marshal_exception(format("Expected 8 byte long for time ({:d})", v.size()));
         }
     }
     void operator()(const uuid_type_impl& t) {
-        if (v.size() != 0 && v.size() != 16) {
+        if (v.empty()) {
+            return;
+        }
+        if (v.size() != 16) {
             throw marshal_exception(format("Validation failed for uuid - got {:d} bytes", v.size()));
         }
     }
     void operator()(const inet_addr_type_impl& t) {
-        if (v.size() != 0 && v.size() != sizeof(uint32_t) && v.size() != 16) {
+        if (v.empty()) {
+            return;
+        }
+        if (v.size() != sizeof(uint32_t) && v.size() != 16) {
             throw marshal_exception(format("Validation failed for inet_addr - got {:d} bytes", v.size()));
         }
     }
@@ -1575,6 +1608,10 @@ struct serialize_visitor {
     }
     void operator()(const empty_type_impl& t, const void*) {}
     void operator()(const uuid_type_impl& t, const uuid_type_impl::native_type* value) {
+        if (value->empty()) {
+            return;
+        }
+
         value->get().serialize(out);
     }
     void operator()(const inet_addr_type_impl& t, const inet_addr_type_impl::native_type* ipv) {
@@ -1597,6 +1634,10 @@ struct serialize_visitor {
     }
     template <typename T>
     void operator()(const floating_type_impl<T>& t, const typename floating_type_impl<T>::native_type* value) {
+        if (value->empty()) {
+            return;
+        }
+
         T d = *value;
         if (std::isnan(d)) {
             // Java's Double.doubleToLongBits() documentation specifies that


### PR DESCRIPTION
Add a bunch of new structs describing a change made
to a table, and an `extract_changes` function which takes a mutation and
returns the set of changes contained in this mutation, separated by
timestamp and ttl.

Add a separate "insert" operation to distinguish inserts (which create a row marker)
from updates (which don't).

Refactor the `transform` function.
It doesn't inspect the mutation manually now. Instead, it calls
`extract_changes` which returns an easily accesible (structured) set of
changes, split by timestamp and ttl.

It then adds a CDC log table row for each of those changes.

As a byproduct:
1. the CDC log now distinguishes between inserts, updates, and row deletes.
2. static row changes appear even if no clustering rows were affected by
   the base mutation (the static row change is always a separate
   change).

Fixes https://github.com/scylladb/scylla/issues/5719.
Fixes https://github.com/scylladb/scylla/issues/5723.
Fixes https://github.com/scylladb/scylla/issues/5744.
Ref: https://github.com/scylladb/scylla/issues/5709: we distinguish row deletes now as separate operations, but preimages for row deletes do not appear yet.

Tests: unit (dev)
