### PR TITLE
Delete table from a snapshot

### DIFF
--- a/api/api-doc/storage_service.json
+++ b/api/api-doc/storage_service.json
@@ -582,7 +582,15 @@
                   },
                   {
                      "name":"kn",
-                     "description":"Comma seperated keyspaces name to snapshot",
+                     "description":"Comma seperated keyspaces name that their snapshot will be deleted",
+                     "required":false,
+                     "allowMultiple":false,
+                     "type":"string",
+                     "paramType":"query"
+                  },
+                  {
+                     "name":"cf",
+                     "description":"an optional table name that its snapshot will be deleted",
                      "required":false,
                      "allowMultiple":false,
                      "type":"string",

--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -1013,7 +1013,7 @@ void set_snapshot(http_context& ctx, routes& r) {
         auto tag = req->get_query_param("tag");
 
         std::vector<sstring> keynames = split(req->get_query_param("kn"), ",");
-        return service::get_local_storage_service().clear_snapshot(tag, keynames).then([] {
+        return service::get_local_storage_service().clear_snapshot(tag, keynames, "").then([] {
             return make_ready_future<json::json_return_type>(json_void());
         });
     });

--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -1011,9 +1011,10 @@ void set_snapshot(http_context& ctx, routes& r) {
 
     ss::del_snapshot.set(r, [](std::unique_ptr<request> req) {
         auto tag = req->get_query_param("tag");
+        auto column_family = req->get_query_param("cf");
 
         std::vector<sstring> keynames = split(req->get_query_param("kn"), ",");
-        return service::get_local_storage_service().clear_snapshot(tag, keynames, "").then([] {
+        return service::get_local_storage_service().clear_snapshot(tag, keynames, column_family).then([] {
             return make_ready_future<json::json_return_type>(json_void());
         });
     });

--- a/database.cc
+++ b/database.cc
@@ -1853,17 +1853,29 @@ const sstring& database::get_snitch_name() const {
     return _cfg.endpoint_snitch();
 }
 
+/*!
+ * \brief a helper function that gets a table name and returns a prefix
+ * of the directory name of the table.
+ */
+static sstring get_snapshot_table_dir_prefix(const sstring& table_name) {
+    return table_name + "-";
+}
+
 // For the filesystem operations, this code will assume that all keyspaces are visible in all shards
 // (as we have been doing for a lot of the other operations, like the snapshot itself).
-future<> database::clear_snapshot(sstring tag, std::vector<sstring> keyspace_names) {
+future<> database::clear_snapshot(sstring tag, std::vector<sstring> keyspace_names, const sstring& table_name) {
     std::vector<sstring> data_dirs = _cfg.data_file_directories();
     lw_shared_ptr<lister::dir_entry_types> dirs_only_entries_ptr = make_lw_shared<lister::dir_entry_types>({ directory_entry_type::directory });
     lw_shared_ptr<sstring> tag_ptr = make_lw_shared<sstring>(std::move(tag));
     std::unordered_set<sstring> ks_names_set(keyspace_names.begin(), keyspace_names.end());
 
-    return parallel_for_each(data_dirs, [this, tag_ptr, ks_names_set = std::move(ks_names_set), dirs_only_entries_ptr] (const sstring& parent_dir) {
+    return parallel_for_each(data_dirs, [this, tag_ptr, ks_names_set = std::move(ks_names_set), dirs_only_entries_ptr, table_name = table_name] (const sstring& parent_dir) {
         std::unique_ptr<lister::filter_type> filter = std::make_unique<lister::filter_type>([] (const fs::path& parent_dir, const directory_entry& dir_entry) { return true; });
 
+        lister::filter_type table_filter = (table_name.empty()) ? lister::filter_type([] (const fs::path& parent_dir, const directory_entry& dir_entry) mutable { return true; }) :
+                lister::filter_type([table_name = get_snapshot_table_dir_prefix(table_name)] (const fs::path& parent_dir, const directory_entry& dir_entry) mutable {
+                    return dir_entry.name.find(table_name) == 0;
+                });
         // if specific keyspaces names were given - filter only these keyspaces directories
         if (!ks_names_set.empty()) {
             filter = std::make_unique<lister::filter_type>([ks_names_set = std::move(ks_names_set)] (const fs::path& parent_dir, const directory_entry& dir_entry) {
@@ -1889,7 +1901,7 @@ future<> database::clear_snapshot(sstring tag, std::vector<sstring> keyspace_nam
         //  |- <keyspace name2>
         //  |- ...
         //
-        return lister::scan_dir(parent_dir, *dirs_only_entries_ptr, [this, tag_ptr, dirs_only_entries_ptr] (fs::path parent_dir, directory_entry de) {
+        return lister::scan_dir(parent_dir, *dirs_only_entries_ptr, [this, tag_ptr, dirs_only_entries_ptr, table_filter = std::move(table_filter)] (fs::path parent_dir, directory_entry de) mutable {
             // KS directory
             return lister::scan_dir(parent_dir / de.name, *dirs_only_entries_ptr, [this, tag_ptr, dirs_only_entries_ptr] (fs::path parent_dir, directory_entry de) mutable {
                 // CF directory
@@ -1908,7 +1920,7 @@ future<> database::clear_snapshot(sstring tag, std::vector<sstring> keyspace_nam
                         }, [tag_ptr] (const fs::path& parent_dir, const directory_entry& dir_entry) { return dir_entry.name == *tag_ptr; });
                     }
                  }, [] (const fs::path& parent_dir, const directory_entry& dir_entry) { return dir_entry.name == "snapshots"; });
-            });
+            }, table_filter);
         }, *filter);
     });
 }

--- a/database.hh
+++ b/database.hh
@@ -1482,7 +1482,17 @@ public:
     future<mutation> apply_counter_update(schema_ptr, const frozen_mutation& m, db::timeout_clock::time_point timeout, tracing::trace_state_ptr trace_state);
     keyspace::config make_keyspace_config(const keyspace_metadata& ksm);
     const sstring& get_snitch_name() const;
-    future<> clear_snapshot(sstring tag, std::vector<sstring> keyspace_names);
+    /*!
+     * \brief clear snapshot based on a tag
+     * The clear_snapshot method deletes specific or multiple snapshots
+     * You can specify:
+     * tag - The snapshot tag (the one that was used when creating the snapshot) if not specified
+     *       All snapshot will be deleted
+     * keyspace_names - a vector of keyspace names that will be deleted, if empty all keyspaces
+     *                  will be deleted.
+     * table_name - A name of a specific table inside the keyspace, if empty all tables will be deleted.
+     */
+    future<> clear_snapshot(sstring tag, std::vector<sstring> keyspace_names, const sstring& table_name);
 
     friend std::ostream& operator<<(std::ostream& out, const database& db);
     const std::unordered_map<sstring, keyspace>& get_keyspaces() const {

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -2213,9 +2213,9 @@ future<> storage_service::take_column_family_snapshot(sstring ks_name, sstring c
     });
 }
 
-future<> storage_service::clear_snapshot(sstring tag, std::vector<sstring> keyspace_names) {
-    return run_snapshot_modify_operation([this, tag = std::move(tag), keyspace_names = std::move(keyspace_names)] {
-        return _db.local().clear_snapshot(tag, keyspace_names);
+future<> storage_service::clear_snapshot(sstring tag, std::vector<sstring> keyspace_names, sstring cf_name) {
+    return run_snapshot_modify_operation([this, tag = std::move(tag), keyspace_names = std::move(keyspace_names), cf_name = std::move(cf_name)] {
+        return _db.local().clear_snapshot(tag, keyspace_names, cf_name);
     });
 }
 

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -1092,8 +1092,9 @@ public:
     /**
      * Remove the snapshot with the given name from the given keyspaces.
      * If no tag is specified we will remove all snapshots.
+     * If a cf_name is specified, only that table will be deleted
      */
-    future<> clear_snapshot(sstring tag, std::vector<sstring> keyspace_names);
+    future<> clear_snapshot(sstring tag, std::vector<sstring> keyspace_names, sstring cf_name);
 
     future<std::unordered_map<sstring, std::vector<snapshot_details>>> get_snapshot_details();
 


### PR DESCRIPTION
This series adds an option to the API that supports deleting a specific table from a snapshot.

The implementation works in a similar way to the option to specify specific keyspaces when deleting a snapshot.

The motivation is to allow reducing disk-space when using the snapshot for backup.

A dtest PR is sent to the dtest repository.

Fixes #5658