### PR TITLE
dist/common/scripts/scylla_coredump_setup: bind-mount coredump directory, add coredump test

### DIFF
--- a/dist/common/scripts/scylla_coredump_setup
+++ b/dist/common/scripts/scylla_coredump_setup
@@ -24,6 +24,9 @@ import os
 import sys
 import argparse
 import subprocess
+import time
+import tempfile
+import subprocess
 from scylla_util import *
 
 if __name__ == '__main__':
@@ -54,13 +57,45 @@ ExternalSizeMax=1024G
         with open('/etc/systemd/coredump.conf', 'w') as f:
             conf = f.write(conf_data)
         if args.dump_to_raiddir:
-            rmtree('/var/lib/systemd/coredump')
+            dot_mount = '''
+[Unit]
+Description=Save coredump to scylla data directory
+Conflicts=umount.target
+Before=scylla-server.service
+After=local-fs.target
+
+[Mount]
+What=/var/lib/scylla/coredump
+Where=/var/lib/systemd/coredump
+Type=none
+Options=bind
+
+[Install]
+WantedBy=multi-user.target
+'''[1:-1]
+            with open('/etc/systemd/system/var-lib-systemd-coredump.mount', 'w') as f:
+                f.write(dot_mount)
             makedirs('/var/lib/scylla/coredump')
-            os.symlink('/var/lib/scylla/coredump', '/var/lib/systemd/coredump')
-        run('systemctl daemon-reload')
+            systemd_unit.reload()
+            systemd_unit('var-lib-systemd-coredump.mount').enable()
         if os.path.exists('/usr/lib/sysctl.d/50-coredump.conf'):
             run('sysctl -p /usr/lib/sysctl.d/50-coredump.conf')
         else:
             with open('/etc/sysctl.d/99-scylla-coredump.conf', 'w') as f:
                 f.write('kernel.core_pattern=|/usr/lib/systemd/systemd-coredump %p %u %g %s %t %e"')
             run('sysctl -p /etc/sysctl.d/99-scylla-coredump.conf')
+
+        fp = tempfile.NamedTemporaryFile()
+        fp.write(b'kill -SEGV $$')
+        fp.flush()
+        p = subprocess.Popen(['/bin/bash', fp.name], stdout=subprocess.PIPE)
+        pid = p.pid
+        p.wait()
+        fp.close()
+        # need to wait for systemd-coredump to complete collecting coredump
+        time.sleep(3)
+        try:
+            run('coredumpctl --no-pager --no-legend info {}'.format(pid))
+        except subprocess.CalledProcessError as e:
+            print('Does not able to detect coredump, failed to configure systemd-coredump.')
+            sys.exit(1)

--- a/dist/common/scripts/scylla_util.py
+++ b/dist/common/scripts/scylla_util.py
@@ -643,6 +643,9 @@ class systemd_unit:
     def unmask(self):
         return run('systemctl {} unmask {}'.format(self.ctlparam, self._unit))
 
+    @classmethod
+    def reload(cls):
+        run('systemctl daemon-reload')
 
 class sysconfig_parser:
     def __load(self):

--- a/dist/debian/debian/scylla-server.postrm
+++ b/dist/debian/debian/scylla-server.postrm
@@ -12,6 +12,7 @@ case "$1" in
         if [ "$1" = "purge" ]; then
             rm -rf /etc/systemd/system/scylla-server.service.d/
         fi
+        rm -f /etc/systemd/system/var-lib-systemd-coredump.mount
         ;;
 esac
 

--- a/dist/redhat/scylla.spec.mustache
+++ b/dist/redhat/scylla.spec.mustache
@@ -141,6 +141,7 @@ rm -rf $RPM_BUILD_ROOT
 %ghost /etc/systemd/system/scylla-server.service.d/capabilities.conf
 %ghost /etc/systemd/system/scylla-server.service.d/mounts.conf
 %ghost /etc/systemd/system/scylla-server.service.d/dependencies.conf
+%ghost /etc/systemd/system/var-lib-systemd-coredump.mount
 
 %package conf
 Group:          Applications/Databases


### PR DESCRIPTION
On some environment systemd-coredump does not work with symlink directory,
we can use bind-mount instead.
Also, it's better to check systemd-coredump is working by generating coredump.

Fixes #5753