### PR TITLE
dist/common/scripts/scylla_coredump_setup: don't create /etc/sysctl.d/99-scylla-coredump.conf on CentOS8

### DIFF
--- a/dist/common/scripts/scylla_coredump_setup
+++ b/dist/common/scripts/scylla_coredump_setup
@@ -66,7 +66,7 @@ ExternalSizeMax=1024G
             makedirs('/var/lib/scylla/coredump')
             os.symlink('/var/lib/scylla/coredump', '/var/lib/systemd/coredump')
         run('systemctl daemon-reload')
-        if is_debian_variant():
+        if os.path.exists('/usr/lib/sysctl.d/50-coredump.conf'):
             run('sysctl -p /usr/lib/sysctl.d/50-coredump.conf')
         else:
             with open('/etc/sysctl.d/99-scylla-coredump.conf', 'w') as f:


### PR DESCRIPTION
We don't need to create 99-scylla-coredump.conf on CentOS8, the file is only
needed for CentOS7.

Fixes #5818