### PR TITLE
Introduce schema::get_partitioner

### DIFF
--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -1131,7 +1131,7 @@ std::optional<shard_id> rmw_operation::shard_for_execute(bool needs_read_before_
     }
     // If we're still here, cas() *will* be called by execute(), so let's
     // find the appropriate shard to run it on:
-    auto token = dht::global_partitioner().get_token(*_schema, _pk);
+    auto token = dht::get_token(*_schema, _pk);
     auto desired_shard = service::storage_proxy::cas_shard(*_schema, token);
     if (desired_shard == engine().cpu_id()) {
         return {};

--- a/cdc/generation.cc
+++ b/cdc/generation.cc
@@ -26,9 +26,9 @@
 
 #include "keys.hh"
 #include "schema_builder.hh"
+#include "db/config.hh"
 #include "db/system_keyspace.hh"
 #include "db/system_distributed_keyspace.hh"
-#include "dht/i_partitioner.hh"
 #include "dht/token-sharding.hh"
 #include "locator/token_metadata.hh"
 #include "gms/application_state.hh"
@@ -119,9 +119,9 @@ static stream_id make_random_stream_id() {
  */
 // Run in seastar::async context.
 topology_description generate_topology_description(
+        const db::config& cfg,
         const std::unordered_set<dht::token>& bootstrap_tokens,
         const locator::token_metadata& token_metadata,
-        const dht::i_partitioner& partitioner,
         const gms::gossiper& gossiper) {
     if (bootstrap_tokens.empty()) {
         throw std::runtime_error(
@@ -142,7 +142,7 @@ topology_description generate_topology_description(
 
         if (bootstrap_tokens.count(entry.token_range_end) > 0) {
             entry.streams.resize(smp::count);
-            entry.sharding_ignore_msb = partitioner.sharding_ignore_msb();
+            entry.sharding_ignore_msb = cfg.murmur3_partitioner_ignore_msb_bits();
         } else {
             auto endpoint = token_metadata.get_endpoint(entry.token_range_end);
             if (!endpoint) {
@@ -293,6 +293,7 @@ future<db_clock::time_point> get_local_streams_timestamp() {
 
 // Run inside seastar::async context.
 db_clock::time_point make_new_cdc_generation(
+        const db::config& cfg,
         const std::unordered_set<dht::token>& bootstrap_tokens,
         const locator::token_metadata& tm,
         const gms::gossiper& g,
@@ -301,8 +302,7 @@ db_clock::time_point make_new_cdc_generation(
         bool for_testing) {
     assert(!bootstrap_tokens.empty());
 
-    auto gen = generate_topology_description(
-            bootstrap_tokens, tm, dht::global_partitioner(), g);
+    auto gen = generate_topology_description(cfg, bootstrap_tokens, tm, g);
 
     // Begin the race.
     auto ts = db_clock::now() + (

--- a/cdc/generation.cc
+++ b/cdc/generation.cc
@@ -172,7 +172,7 @@ topology_description generate_topology_description(
     repeat([&] {
         for (int i = 0; i < 500; ++i) {
             auto stream_id = make_random_stream_id();
-            auto token = partitioner.get_token(*schema, stream_id.to_partition_key(*schema));
+            auto token = dht::get_token(*schema, stream_id.to_partition_key(*schema));
 
             // Find the token range into which our stream_id's token landed.
             auto it = std::lower_bound(tokens.begin(), tokens.end(), token);

--- a/cdc/generation.hh
+++ b/cdc/generation.hh
@@ -39,13 +39,14 @@
 
 #include "database_fwd.hh"
 #include "db_clock.hh"
-#include "dht/i_partitioner.hh"
+#include "dht/token.hh"
 
 namespace seastar {
     class abort_source;
 } // namespace seastar
 
 namespace db {
+    class config;
     class system_distributed_keyspace;
 } // namespace db
 
@@ -142,6 +143,7 @@ future<db_clock::time_point> get_local_streams_timestamp();
  *  we assume that `ring_delay` is enough for other nodes to learn about the new generation).
  */
 db_clock::time_point make_new_cdc_generation(
+        const db::config& cfg,
         const std::unordered_set<dht::token>& bootstrap_tokens,
         const locator::token_metadata& tm,
         const gms::gossiper& g,

--- a/cdc/metadata.cc
+++ b/cdc/metadata.cc
@@ -21,6 +21,7 @@
 
 #include "dht/token-sharding.hh"
 #include "utils/exceptions.hh"
+#include "exceptions/exceptions.hh"
 
 #include "cdc/generation.hh"
 #include "cdc/metadata.hh"

--- a/cql3/functions/token_fct.hh
+++ b/cql3/functions/token_fct.hh
@@ -63,7 +63,7 @@ public:
 
     bytes_opt execute(cql_serialization_format sf, const std::vector<bytes_opt>& parameters) override {
         auto key = partition_key::from_optional_exploded(*_schema, parameters);
-        auto tok = dht::global_partitioner().get_token(*_schema, key);
+        auto tok = dht::get_token(*_schema, key);
         warn(unimplemented::cause::VALIDATION);
         return tok.data();
     }

--- a/cql3/restrictions/single_column_primary_key_restrictions.hh
+++ b/cql3/restrictions/single_column_primary_key_restrictions.hh
@@ -421,7 +421,7 @@ single_column_primary_key_restrictions<partition_key>::bounds_ranges(const query
         }
         ranges.emplace_back(std::move(r).transform(
             [this] (partition_key&& k) -> query::ring_position {
-                auto token = dht::global_partitioner().get_token(*_schema, k);
+                auto token = dht::get_token(*_schema, k);
                 return { std::move(token), std::move(k) };
             }));
     }

--- a/cql3/statements/batch_statement.cc
+++ b/cql3/statements/batch_statement.cc
@@ -377,7 +377,7 @@ future<shared_ptr<cql_transport::messages::result_message>> batch_statement::exe
         throw exceptions::invalid_request_exception(format("Unrestricted partition key in a conditional BATCH"));
     }
 
-    auto shard = service::storage_proxy::cas_shard(request->key()[0].start()->value().as_decorated_key().token());
+    auto shard = service::storage_proxy::cas_shard(*_statements[0].statement->s, request->key()[0].start()->value().as_decorated_key().token());
     if (shard != engine().cpu_id()) {
         proxy.get_stats().replica_cross_shard_ops++;
         return make_ready_future<shared_ptr<cql_transport::messages::result_message>>(

--- a/cql3/statements/modification_statement.cc
+++ b/cql3/statements/modification_statement.cc
@@ -51,7 +51,6 @@
 #include <boost/range/adaptor/map.hpp>
 #include <boost/range/adaptor/indirected.hpp>
 #include "db/config.hh"
-#include "dht/murmur3_partitioner.hh"
 #include "service/storage_service.hh"
 #include "transport/messages/result_message.hh"
 #include "database.hh"
@@ -359,7 +358,7 @@ modification_statement::execute_with_condition(service::storage_proxy& proxy, se
     // modification in the list of CAS commands, since we're handling single-statement execution.
     request->add_row_update(*this, std::move(ranges), std::move(json_cache), options);
 
-    auto shard = service::storage_proxy::cas_shard(request->key()[0].start()->value().as_decorated_key().token());
+    auto shard = service::storage_proxy::cas_shard(*s, request->key()[0].start()->value().as_decorated_key().token());
     if (shard != engine().cpu_id()) {
         proxy.get_stats().replica_cross_shard_ops++;
         return make_ready_future<shared_ptr<cql_transport::messages::result_message>>(

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -340,7 +340,7 @@ select_statement::do_execute(service::storage_proxy& proxy,
     auto key_ranges = _restrictions->get_partition_key_ranges(options);
 
     if (db::is_serial_consistency(options.get_consistency())) {
-        unsigned shard = dht::shard_of(key_ranges[0].start()->value().as_decorated_key().token());
+        unsigned shard = dht::shard_of(*_schema, key_ranges[0].start()->value().as_decorated_key().token());
         if (engine().cpu_id() != shard) {
             proxy.get_stats().replica_cross_shard_ops++;
             return make_ready_future<shared_ptr<cql_transport::messages::result_message>>(

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -1041,7 +1041,7 @@ query::partition_slice indexed_table_select_statement::get_partition_slice_for_g
             // Computed token column needs to be added to index view restrictions
             const column_definition& token_cdef = *_view_schema->clustering_key_columns().begin();
             auto base_pk = partition_key::from_optional_exploded(*_schema, _restrictions->get_partition_key_restrictions()->values(options));
-            bytes token_value = dht::global_partitioner().get_token(*_schema, base_pk).data();
+            bytes token_value = dht::get_token(*_schema, base_pk).data();
             auto token_restriction = ::make_shared<restrictions::single_column_restriction::EQ>(token_cdef, ::make_shared<cql3::constants::value>(cql3::raw_value::make_value(token_value)));
             clustering_restrictions->merge_with(token_restriction);
 

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -1022,7 +1022,7 @@ dht::partition_range_vector indexed_table_select_statement::get_partition_ranges
     bytes_opt value = _used_index_restrictions->value_for(*cdef, options);
     if (value) {
         auto pk = partition_key::from_single_value(*_view_schema, *value);
-        auto dk = dht::global_partitioner().decorate_key(*_view_schema, pk);
+        auto dk = dht::decorate_key(*_view_schema, pk);
         auto range = dht::partition_range::make_singular(dk);
         partition_ranges.emplace_back(range);
     }
@@ -1178,7 +1178,7 @@ indexed_table_select_statement::find_index_partition_ranges(service::storage_pro
                 pk_columns.push_back(row.get_blob(column->name->to_string()));
             }
             auto pk = partition_key::from_exploded(*_schema, pk_columns);
-            auto dk = dht::global_partitioner().decorate_key(*_schema, pk);
+            auto dk = dht::decorate_key(*_schema, pk);
             if (last_dk && last_dk->equal(*_schema, dk)) {
                 // Another row of the same partition, no need to output the
                 // same partition key again.
@@ -1212,7 +1212,7 @@ indexed_table_select_statement::find_index_clustering_rows(service::storage_prox
                 return row.get_blob(cdef.name_as_text());
             });
             auto pk = partition_key::from_range(pk_columns);
-            auto dk = dht::global_partitioner().decorate_key(*_schema, pk);
+            auto dk = dht::decorate_key(*_schema, pk);
             auto ck_columns = _schema->clustering_key_columns() | boost::adaptors::transformed([&] (auto& cdef) {
                 return row.get_blob(cdef.name_as_text());
             });

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -861,8 +861,7 @@ static void append_base_key_to_index_ck(std::vector<bytes_view>& exploded_index_
     if (_index.metadata().local()) {
         exploded_index_ck.push_back(bytes_view(*indexed_column_value));
     } else {
-        dht::i_partitioner& partitioner = dht::global_partitioner();
-        token_bytes = partitioner.get_token(*_schema, last_base_pk).data();
+        token_bytes = dht::get_token(*_schema, last_base_pk).data();
         exploded_index_ck.push_back(bytes_view(token_bytes));
         append_base_key_to_index_ck<partition_key>(exploded_index_ck, last_base_pk, *cdef);
     }

--- a/cql3/statements/update_statement.cc
+++ b/cql3/statements/update_statement.cc
@@ -258,7 +258,7 @@ insert_prepared_json_statement::build_partition_keys(const query_options& option
         exploded.emplace_back(json_value->second);
     }
     auto pkey = partition_key::from_optional_exploded(*s, std::move(exploded));
-    auto k = query::range<query::ring_position>::make_singular(dht::global_partitioner().decorate_key(*s, std::move(pkey)));
+    auto k = query::range<query::ring_position>::make_singular(dht::decorate_key(*s, std::move(pkey)));
     ranges.emplace_back(std::move(k));
     return ranges;
 }

--- a/database.cc
+++ b/database.cc
@@ -651,7 +651,7 @@ database::shard_of(const frozen_mutation& m) {
     // sent the partition key in legacy form or together
     // with token.
     schema_ptr schema = find_schema(m.column_family_id());
-    return dht::shard_of(*schema, dht::global_partitioner().get_token(*schema, m.key(*schema)));
+    return dht::shard_of(*schema, dht::get_token(*schema, m.key(*schema)));
 }
 
 void database::add_keyspace(sstring name, keyspace k) {

--- a/database.cc
+++ b/database.cc
@@ -641,13 +641,8 @@ database::init_commitlog() {
 }
 
 unsigned
-database::shard_of(const dht::token& t) {
-    return dht::shard_of(t);
-}
-
-unsigned
 database::shard_of(const mutation& m) {
-    return shard_of(m.token());
+    return dht::shard_of(*m.schema(), m.token());
 }
 
 unsigned
@@ -656,7 +651,7 @@ database::shard_of(const frozen_mutation& m) {
     // sent the partition key in legacy form or together
     // with token.
     schema_ptr schema = find_schema(m.column_family_id());
-    return shard_of(dht::global_partitioner().get_token(*schema, m.key(*schema)));
+    return dht::shard_of(*schema, dht::global_partitioner().get_token(*schema, m.key(*schema)));
 }
 
 void database::add_keyspace(sstring name, keyspace k) {

--- a/database.hh
+++ b/database.hh
@@ -1466,7 +1466,6 @@ public:
     future<> close_tables(table_kind kind_to_close);
 
     future<> stop_large_data_handler();
-    unsigned shard_of(const dht::token& t);
     unsigned shard_of(const mutation& m);
     unsigned shard_of(const frozen_mutation& m);
     future<lw_shared_ptr<query::result>, cache_temperature> query(schema_ptr, const query::read_command& cmd, query::result_options opts,

--- a/db/hints/manager.cc
+++ b/db/hints/manager.cc
@@ -679,7 +679,7 @@ void manager::end_point_hints_manager::sender::start() {
 future<> manager::end_point_hints_manager::sender::send_one_mutation(frozen_mutation_and_schema m) {
     keyspace& ks = _db.find_keyspace(m.s->ks_name());
     auto& rs = ks.get_replication_strategy();
-    auto token = dht::global_partitioner().get_token(*m.s, m.fm.key(*m.s));
+    auto token = dht::get_token(*m.s, m.fm.key(*m.s));
     std::vector<gms::inet_address> natural_endpoints = rs.get_natural_endpoints(std::move(token));
 
     return do_send_one_mutation(std::move(m), natural_endpoints);

--- a/db/size_estimates_virtual_reader.cc
+++ b/db/size_estimates_virtual_reader.cc
@@ -123,7 +123,7 @@ static std::vector<sstring> get_keyspaces(const schema& s, const database& db, d
         keyspace_less_comparator(const schema& s) : _s(s) { }
         dht::ring_position as_ring_position(const sstring& ks) {
             auto pkey = partition_key::from_single_value(_s, utf8_type->decompose(ks));
-            return dht::global_partitioner().decorate_key(_s, std::move(pkey));
+            return dht::decorate_key(_s, std::move(pkey));
         }
         bool operator()(const sstring& ks1, const sstring& ks2) {
             return as_ring_position(ks1).less_compare(_s, as_ring_position(ks2));

--- a/db/size_estimates_virtual_reader.cc
+++ b/db/size_estimates_virtual_reader.cc
@@ -141,7 +141,7 @@ static std::vector<sstring> get_keyspaces(const schema& s, const database& db, d
     return boost::copy_range<std::vector<sstring>>(
         range.slice(keyspaces, std::move(cmp)) | boost::adaptors::filtered([&s] (const auto& ks) {
             // If this is a range query, results are divided between shards by the partition key (keyspace_name).
-            return shard_of(s, dht::global_partitioner().get_token(s,
+            return shard_of(s, dht::get_token(s,
                         partition_key::from_single_value(s, utf8_type->decompose(ks))))
                 == engine().cpu_id();
         })

--- a/db/size_estimates_virtual_reader.cc
+++ b/db/size_estimates_virtual_reader.cc
@@ -141,7 +141,7 @@ static std::vector<sstring> get_keyspaces(const schema& s, const database& db, d
     return boost::copy_range<std::vector<sstring>>(
         range.slice(keyspaces, std::move(cmp)) | boost::adaptors::filtered([&s] (const auto& ks) {
             // If this is a range query, results are divided between shards by the partition key (keyspace_name).
-            return shard_of(dht::global_partitioner().get_token(s,
+            return shard_of(s, dht::global_partitioner().get_token(s,
                         partition_key::from_single_value(s, utf8_type->decompose(ks))))
                 == engine().cpu_id();
         })

--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -249,9 +249,8 @@ public:
     }
 
     void move_to(std::vector<frozen_mutation_and_schema>& mutations) && {
-        auto& partitioner = dht::global_partitioner();
         std::transform(_updates.begin(), _updates.end(), std::back_inserter(mutations), [&, this] (auto&& m) {
-            auto mut = mutation(_view, partitioner.decorate_key(*_view, std::move(m.first)), std::move(m.second));
+            auto mut = mutation(_view, dht::decorate_key(*_view, std::move(m.first)), std::move(m.second));
             return frozen_mutation_and_schema{freeze(mut), std::move(_view)};
         });
     }
@@ -1069,9 +1068,8 @@ future<> mutate_MV(
 {
     auto fs = std::make_unique<std::vector<future<>>>();
     fs->reserve(view_updates.size());
-    auto& partitioner = dht::global_partitioner();
     for (frozen_mutation_and_schema& mut : view_updates) {
-        auto view_token = partitioner.get_token(*mut.s, mut.fm.key(*mut.s));
+        auto view_token = dht::get_token(*mut.s, mut.fm.key(*mut.s));
         auto& keyspace_name = mut.s->ks_name();
         auto paired_endpoint = get_view_natural_endpoint(keyspace_name, base_token, view_token);
         auto pending_endpoints = service::get_local_storage_service().get_token_metadata().pending_endpoints_for(view_token, keyspace_name);

--- a/dht/i_partitioner.cc
+++ b/dht/i_partitioner.cc
@@ -184,6 +184,12 @@ std::ostream& operator<<(std::ostream& out, ring_position_view pos) {
     return out << "}";
 }
 
+std::ostream& operator<<(std::ostream& out, const i_partitioner& p) {
+    out << "{partitioner name = " << p.name();
+    out << ", sharding_ignore_msb = " << p.sharding_ignore_msb();
+    return out << "}";
+}
+
 unsigned shard_of(const token& t) {
     return global_partitioner().shard_of(t);
 }

--- a/dht/i_partitioner.cc
+++ b/dht/i_partitioner.cc
@@ -20,6 +20,7 @@
  */
 
 #include "i_partitioner.hh"
+#include "sharder.hh"
 #include <seastar/core/reactor.hh>
 #include "dht/murmur3_partitioner.hh"
 #include "dht/token-sharding.hh"

--- a/dht/i_partitioner.cc
+++ b/dht/i_partitioner.cc
@@ -190,8 +190,8 @@ std::ostream& operator<<(std::ostream& out, const i_partitioner& p) {
     return out << "}";
 }
 
-unsigned shard_of(const token& t) {
-    return global_partitioner().shard_of(t);
+unsigned shard_of(const schema& s, const token& t) {
+    return s.get_partitioner().shard_of(t);
 }
 
 std::optional<dht::token_range>

--- a/dht/i_partitioner.cc
+++ b/dht/i_partitioner.cc
@@ -290,8 +290,9 @@ ring_position_exponential_sharder::next(const schema& s) {
     return std::make_optional(std::move(ret));
 }
 
-ring_position_range_vector_sharder::ring_position_range_vector_sharder(dht::partition_range_vector ranges)
+ring_position_range_vector_sharder::ring_position_range_vector_sharder(const dht::i_partitioner& p, dht::partition_range_vector ranges)
         : _ranges(std::move(ranges))
+        , _partitioner(p)
         , _current_range(_ranges.begin()) {
     next_range();
 }
@@ -432,7 +433,7 @@ to_partition_range(dht::token_range r) {
 std::map<unsigned, dht::partition_range_vector>
 split_range_to_shards(dht::partition_range pr, const schema& s) {
     std::map<unsigned, dht::partition_range_vector> ret;
-    auto sharder = dht::ring_position_range_sharder(std::move(pr));
+    auto sharder = dht::ring_position_range_sharder(s.get_partitioner(), std::move(pr));
     auto rprs = sharder.next(s);
     while (rprs) {
         ret[rprs->shard].emplace_back(rprs->ring_range);
@@ -446,7 +447,7 @@ split_ranges_to_shards(const dht::token_range_vector& ranges, const schema& s) {
     std::map<unsigned, dht::partition_range_vector> ret;
     for (const auto& range : ranges) {
         auto pr = dht::to_partition_range(range);
-        auto sharder = dht::ring_position_range_sharder(std::move(pr));
+        auto sharder = dht::ring_position_range_sharder(s.get_partitioner(), std::move(pr));
         auto rprs = sharder.next(s);
         while (rprs) {
             ret[rprs->shard].emplace_back(rprs->ring_range);

--- a/dht/i_partitioner.cc
+++ b/dht/i_partitioner.cc
@@ -349,7 +349,7 @@ split_range_to_single_shard(const i_partitioner& partitioner, const schema& s, c
 
 future<utils::chunked_vector<partition_range>>
 split_range_to_single_shard(const schema& s, const partition_range& pr, shard_id shard) {
-    return split_range_to_single_shard(global_partitioner(), s, pr, shard);
+    return split_range_to_single_shard(s.get_partitioner(), s, pr, shard);
 }
 
 

--- a/dht/i_partitioner.cc
+++ b/dht/i_partitioner.cc
@@ -289,38 +289,6 @@ ring_position_exponential_sharder::next(const schema& s) {
     return std::make_optional(std::move(ret));
 }
 
-
-ring_position_exponential_vector_sharder::ring_position_exponential_vector_sharder(const std::vector<nonwrapping_range<ring_position>>&& ranges) {
-    std::move(ranges.begin(), ranges.end(), std::back_inserter(_ranges));
-    if (!_ranges.empty()) {
-        _current_sharder.emplace(_ranges.front());
-        _ranges.pop_front();
-        ++_element;
-    }
-}
-
-std::optional<ring_position_exponential_vector_sharder_result>
-ring_position_exponential_vector_sharder::next(const schema& s) {
-    if (!_current_sharder) {
-        return std::nullopt;
-    }
-    while (true) {  // yuch
-        auto ret = _current_sharder->next(s);
-        if (ret) {
-            auto augmented = ring_position_exponential_vector_sharder_result{std::move(*ret), _element};
-            return std::make_optional(std::move(augmented));
-        }
-        if (_ranges.empty()) {
-            _current_sharder = std::nullopt;
-            return std::nullopt;
-        }
-        _current_sharder.emplace(_ranges.front());
-        _ranges.pop_front();
-        ++_element;
-    }
-}
-
-
 ring_position_range_vector_sharder::ring_position_range_vector_sharder(dht::partition_range_vector ranges)
         : _ranges(std::move(ranges))
         , _current_range(_ranges.begin()) {

--- a/dht/i_partitioner.cc
+++ b/dht/i_partitioner.cc
@@ -248,10 +248,6 @@ ring_position_exponential_sharder::ring_position_exponential_sharder(const i_par
     }
 }
 
-ring_position_exponential_sharder::ring_position_exponential_sharder(partition_range pr)
-        : ring_position_exponential_sharder(global_partitioner(), std::move(pr)) {
-}
-
 std::optional<ring_position_exponential_sharder_result>
 ring_position_exponential_sharder::next(const schema& s) {
     auto ret = ring_position_exponential_sharder_result{};

--- a/dht/i_partitioner.hh
+++ b/dht/i_partitioner.hh
@@ -700,24 +700,6 @@ public:
     std::optional<ring_position_exponential_sharder_result> next(const schema& s);
 };
 
-struct ring_position_exponential_vector_sharder_result : ring_position_exponential_sharder_result {
-    ring_position_exponential_vector_sharder_result(ring_position_exponential_sharder_result rpesr, unsigned element)
-            : ring_position_exponential_sharder_result(std::move(rpesr)), element(element) {}
-    unsigned element; // range within vector from which this result came
-};
-
-
-// given a vector of sorted, disjoint ring_position ranges, generates exponentially increasing
-// sets per-shard sub-ranges.  May be non-exponential when moving from one ring position range to another.
-class ring_position_exponential_vector_sharder {
-    std::deque<nonwrapping_range<ring_position>> _ranges;
-    std::optional<ring_position_exponential_sharder> _current_sharder;
-    unsigned _element = 0;
-public:
-    explicit ring_position_exponential_vector_sharder(const std::vector<nonwrapping_range<ring_position>>&& ranges);
-    std::optional<ring_position_exponential_vector_sharder_result> next(const schema& s);
-};
-
 class ring_position_range_vector_sharder {
     using vec_type = dht::partition_range_vector;
     vec_type _ranges;

--- a/dht/i_partitioner.hh
+++ b/dht/i_partitioner.hh
@@ -671,6 +671,10 @@ inline decorated_key decorate_key(const schema& s, partition_key&& key) {
     return s.get_partitioner().decorate_key(s, std::move(key));
 }
 
+inline token get_token(const schema& s, partition_key_view key) {
+    return s.get_partitioner().get_token(s, key);
+}
+
 dht::partition_range to_partition_range(dht::token_range);
 
 // Each shard gets a sorted, disjoint vector of ranges

--- a/dht/i_partitioner.hh
+++ b/dht/i_partitioner.hh
@@ -656,67 +656,6 @@ i_partitioner& global_partitioner();
 
 unsigned shard_of(const token&);
 
-struct ring_position_range_and_shard {
-    dht::partition_range ring_range;
-    unsigned shard;
-};
-
-class ring_position_range_sharder {
-    const i_partitioner& _partitioner;
-    dht::partition_range _range;
-    bool _done = false;
-public:
-    explicit ring_position_range_sharder(nonwrapping_range<ring_position> rrp)
-            : ring_position_range_sharder(global_partitioner(), std::move(rrp)) {}
-    ring_position_range_sharder(const i_partitioner& partitioner, nonwrapping_range<ring_position> rrp)
-            : _partitioner(partitioner), _range(std::move(rrp)) {}
-    std::optional<ring_position_range_and_shard> next(const schema& s);
-};
-
-struct ring_position_range_and_shard_and_element : ring_position_range_and_shard {
-    ring_position_range_and_shard_and_element(ring_position_range_and_shard&& rpras, unsigned element)
-            : ring_position_range_and_shard(std::move(rpras)), element(element) {
-    }
-    unsigned element;
-};
-
-struct ring_position_exponential_sharder_result {
-    std::vector<ring_position_range_and_shard> per_shard_ranges;
-    bool inorder = true;
-};
-
-// given a ring_position range, generates exponentially increasing
-// sets per-shard sub-ranges
-class ring_position_exponential_sharder {
-    const i_partitioner& _partitioner;
-    partition_range _range;
-    unsigned _spans_per_iteration = 1;
-    unsigned _first_shard = 0;
-    unsigned _next_shard = 0;
-    std::vector<std::optional<token>> _last_ends; // index = shard
-public:
-    explicit ring_position_exponential_sharder(partition_range pr);
-    explicit ring_position_exponential_sharder(const i_partitioner& partitioner, partition_range pr);
-    std::optional<ring_position_exponential_sharder_result> next(const schema& s);
-};
-
-class ring_position_range_vector_sharder {
-    using vec_type = dht::partition_range_vector;
-    vec_type _ranges;
-    vec_type::iterator _current_range;
-    std::optional<ring_position_range_sharder> _current_sharder;
-private:
-    void next_range() {
-        if (_current_range != _ranges.end()) {
-            _current_sharder.emplace(std::move(*_current_range++));
-        }
-    }
-public:
-    explicit ring_position_range_vector_sharder(dht::partition_range_vector ranges);
-    // results are returned sorted by index within the vector first, then within each vector item
-    std::optional<ring_position_range_and_shard_and_element> next(const schema& s);
-};
-
 dht::partition_range to_partition_range(dht::token_range);
 
 // Each shard gets a sorted, disjoint vector of ranges
@@ -731,29 +670,6 @@ split_ranges_to_shards(const dht::token_range_vector& ranges, const schema& s);
 // Intersect a partition_range with a shard and return the the resulting sub-ranges, in sorted order
 future<utils::chunked_vector<partition_range>> split_range_to_single_shard(const schema& s, const dht::partition_range& pr, shard_id shard);
 future<utils::chunked_vector<partition_range>> split_range_to_single_shard(const i_partitioner& partitioner, const schema& s, const dht::partition_range& pr, shard_id shard);
-
-class selective_token_range_sharder {
-    const i_partitioner& _partitioner;
-    dht::token_range _range;
-    shard_id _shard;
-    bool _done = false;
-    shard_id _next_shard;
-    dht::token _start_token;
-    std::optional<range_bound<dht::token>> _start_boundary;
-public:
-    explicit selective_token_range_sharder(dht::token_range range, shard_id shard)
-            : selective_token_range_sharder(global_partitioner(), std::move(range), shard) {}
-    selective_token_range_sharder(const i_partitioner& partitioner, dht::token_range range, shard_id shard)
-            : _partitioner(partitioner)
-            , _range(std::move(range))
-            , _shard(shard)
-            , _next_shard(_shard + 1 == _partitioner.shard_count() ? 0 : _shard + 1)
-            , _start_token(_range.start() ? _range.start()->value() : minimum_token())
-            , _start_boundary(_partitioner.shard_of(_start_token) == shard ?
-                _range.start() : range_bound<dht::token>(_partitioner.token_for_next_shard(_start_token, shard))) {
-    }
-    std::optional<dht::token_range> next();
-};
 
 std::unique_ptr<dht::i_partitioner> make_partitioner(sstring name, unsigned shard_count, unsigned sharding_ignore_msb_bits);
 

--- a/dht/i_partitioner.hh
+++ b/dht/i_partitioner.hh
@@ -663,7 +663,7 @@ std::ostream& operator<<(std::ostream& out, partition_ranges_view v);
 void set_global_partitioner(const sstring& class_name, unsigned ignore_msb = 0);
 i_partitioner& global_partitioner();
 
-unsigned shard_of(const token&);
+unsigned shard_of(const schema&, const token&);
 
 dht::partition_range to_partition_range(dht::token_range);
 

--- a/dht/i_partitioner.hh
+++ b/dht/i_partitioner.hh
@@ -664,6 +664,12 @@ void set_global_partitioner(const sstring& class_name, unsigned ignore_msb = 0);
 i_partitioner& global_partitioner();
 
 unsigned shard_of(const schema&, const token&);
+inline decorated_key decorate_key(const schema& s, const partition_key& key) {
+    return s.get_partitioner().decorate_key(s, key);
+}
+inline decorated_key decorate_key(const schema& s, partition_key&& key) {
+    return s.get_partitioner().decorate_key(s, std::move(key));
+}
 
 dht::partition_range to_partition_range(dht::token_range);
 

--- a/dht/i_partitioner.hh
+++ b/dht/i_partitioner.hh
@@ -641,6 +641,8 @@ std::ostream& operator<<(std::ostream& out, const token& t);
 
 std::ostream& operator<<(std::ostream& out, const decorated_key& t);
 
+std::ostream& operator<<(std::ostream& out, const i_partitioner& p);
+
 class partition_ranges_view {
     const dht::partition_range* _data = nullptr;
     size_t _size = 0;

--- a/dht/i_partitioner.hh
+++ b/dht/i_partitioner.hh
@@ -227,6 +227,13 @@ public:
     unsigned sharding_ignore_msb() const {
         return _sharding_ignore_msb_bits;
     }
+    bool operator==(const i_partitioner& o) const {
+        return name() == o.name()
+                && sharding_ignore_msb() == o.sharding_ignore_msb();
+    }
+    bool operator!=(const i_partitioner& o) const {
+        return !(*this == o);
+    }
 };
 
 //

--- a/dht/sharder.hh
+++ b/dht/sharder.hh
@@ -1,0 +1,115 @@
+/*
+ * Copyright (C) 2015 ScyllaDB
+ */
+
+/*
+ * This file is part of Scylla.
+ *
+ * Scylla is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Scylla is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "i_partitioner.hh"
+#include "range.hh"
+
+#include <vector>
+
+namespace dht {
+
+struct ring_position_range_and_shard {
+    dht::partition_range ring_range;
+    unsigned shard;
+};
+
+class ring_position_range_sharder {
+    const i_partitioner& _partitioner;
+    dht::partition_range _range;
+    bool _done = false;
+public:
+    explicit ring_position_range_sharder(nonwrapping_range<ring_position> rrp)
+            : ring_position_range_sharder(global_partitioner(), std::move(rrp)) {}
+    ring_position_range_sharder(const i_partitioner& partitioner, nonwrapping_range<ring_position> rrp)
+            : _partitioner(partitioner), _range(std::move(rrp)) {}
+    std::optional<ring_position_range_and_shard> next(const schema& s);
+};
+
+struct ring_position_range_and_shard_and_element : ring_position_range_and_shard {
+    ring_position_range_and_shard_and_element(ring_position_range_and_shard&& rpras, unsigned element)
+            : ring_position_range_and_shard(std::move(rpras)), element(element) {
+    }
+    unsigned element;
+};
+
+struct ring_position_exponential_sharder_result {
+    std::vector<ring_position_range_and_shard> per_shard_ranges;
+    bool inorder = true;
+};
+
+// given a ring_position range, generates exponentially increasing
+// sets per-shard sub-ranges
+class ring_position_exponential_sharder {
+    const i_partitioner& _partitioner;
+    partition_range _range;
+    unsigned _spans_per_iteration = 1;
+    unsigned _first_shard = 0;
+    unsigned _next_shard = 0;
+    std::vector<std::optional<token>> _last_ends; // index = shard
+public:
+    explicit ring_position_exponential_sharder(partition_range pr);
+    explicit ring_position_exponential_sharder(const i_partitioner& partitioner, partition_range pr);
+    std::optional<ring_position_exponential_sharder_result> next(const schema& s);
+};
+
+class ring_position_range_vector_sharder {
+    using vec_type = dht::partition_range_vector;
+    vec_type _ranges;
+    vec_type::iterator _current_range;
+    std::optional<ring_position_range_sharder> _current_sharder;
+private:
+    void next_range() {
+        if (_current_range != _ranges.end()) {
+            _current_sharder.emplace(std::move(*_current_range++));
+        }
+    }
+public:
+    explicit ring_position_range_vector_sharder(dht::partition_range_vector ranges);
+    // results are returned sorted by index within the vector first, then within each vector item
+    std::optional<ring_position_range_and_shard_and_element> next(const schema& s);
+};
+
+class selective_token_range_sharder {
+    const i_partitioner& _partitioner;
+    dht::token_range _range;
+    shard_id _shard;
+    bool _done = false;
+    shard_id _next_shard;
+    dht::token _start_token;
+    std::optional<range_bound<dht::token>> _start_boundary;
+public:
+    explicit selective_token_range_sharder(dht::token_range range, shard_id shard)
+            : selective_token_range_sharder(global_partitioner(), std::move(range), shard) {}
+    selective_token_range_sharder(const i_partitioner& partitioner, dht::token_range range, shard_id shard)
+            : _partitioner(partitioner)
+            , _range(std::move(range))
+            , _shard(shard)
+            , _next_shard(_shard + 1 == _partitioner.shard_count() ? 0 : _shard + 1)
+            , _start_token(_range.start() ? _range.start()->value() : minimum_token())
+            , _start_boundary(_partitioner.shard_of(_start_token) == shard ?
+                _range.start() : range_bound<dht::token>(_partitioner.token_for_next_shard(_start_token, shard))) {
+    }
+    std::optional<dht::token_range> next();
+};
+
+} // dht

--- a/dht/sharder.hh
+++ b/dht/sharder.hh
@@ -97,8 +97,6 @@ class selective_token_range_sharder {
     dht::token _start_token;
     std::optional<range_bound<dht::token>> _start_boundary;
 public:
-    explicit selective_token_range_sharder(dht::token_range range, shard_id shard)
-            : selective_token_range_sharder(global_partitioner(), std::move(range), shard) {}
     selective_token_range_sharder(const i_partitioner& partitioner, dht::token_range range, shard_id shard)
             : _partitioner(partitioner)
             , _range(std::move(range))

--- a/frozen_mutation.cc
+++ b/frozen_mutation.cc
@@ -69,7 +69,7 @@ frozen_mutation::key(const schema& s) const {
 
 dht::decorated_key
 frozen_mutation::decorated_key(const schema& s) const {
-    return dht::global_partitioner().decorate_key(s, key(s));
+    return dht::decorate_key(s, key(s));
 }
 
 partition_key frozen_mutation::deserialize_key() const {

--- a/keys.cc
+++ b/keys.cc
@@ -76,8 +76,8 @@ partition_key_view::legacy_tri_compare(const schema& s, partition_key_view o) co
 
 int
 partition_key_view::ring_order_tri_compare(const schema& s, partition_key_view k2) const {
-    auto t1 = dht::global_partitioner().get_token(s, *this);
-    auto t2 = dht::global_partitioner().get_token(s, k2);
+    auto t1 = dht::get_token(s, *this);
+    auto t2 = dht::get_token(s, k2);
     if (t1 != t2) {
         return t1 < t2 ? -1 : 1;
     }

--- a/memtable.cc
+++ b/memtable.cc
@@ -191,7 +191,7 @@ memtable::find_or_create_partition_slow(partition_key_view key) {
     // We could switch to boost::intrusive_map<> similar to what we have for row keys.
     auto& outer = current_allocator();
     return with_allocator(standard_allocator(), [&, this] () -> partition_entry& {
-        auto dk = dht::global_partitioner().decorate_key(*_schema, key);
+        auto dk = dht::decorate_key(*_schema, key);
         return with_allocator(outer, [&dk, this] () -> partition_entry& {
           return with_linearized_managed_bytes([&] () -> partition_entry& {
             return find_or_create_partition(dk);

--- a/multishard_mutation_query.cc
+++ b/multishard_mutation_query.cc
@@ -353,7 +353,7 @@ future<> read_context::stop() {
 
 read_context::dismantle_buffer_stats read_context::dismantle_combined_buffer(circular_buffer<mutation_fragment> combined_buffer,
         const dht::decorated_key& pkey) {
-    auto& partitioner = dht::global_partitioner();
+    auto& partitioner = _schema->get_partitioner();
 
     std::vector<mutation_fragment> tmp_buffer;
     dismantle_buffer_stats stats;
@@ -401,7 +401,7 @@ read_context::dismantle_buffer_stats read_context::dismantle_combined_buffer(cir
 
 read_context::dismantle_buffer_stats read_context::dismantle_compaction_state(detached_compaction_state compaction_state) {
     auto stats = dismantle_buffer_stats();
-    auto& partitioner = dht::global_partitioner();
+    auto& partitioner = _schema->get_partitioner();
     const auto shard = partitioner.shard_of(compaction_state.partition_start.key().token());
 
     // It is possible that the reader this partition originates from does not
@@ -592,7 +592,8 @@ static future<reconcilable_result> do_query_mutations(
                     tracing::trace_state_ptr trace_state,
                     streamed_mutation::forwarding,
                     mutation_reader::forwarding fwd_mr) {
-                return make_multishard_combining_reader(ctx, dht::global_partitioner(), std::move(s), pr, ps, pc, std::move(trace_state), fwd_mr);
+                    auto& partitioner = s->get_partitioner();
+                return make_multishard_combining_reader(ctx, partitioner, std::move(s), pr, ps, pc, std::move(trace_state), fwd_mr);
             });
             auto reader = make_flat_multi_range_reader(s, std::move(ms), ranges, cmd.slice,
                     service::get_local_sstable_query_read_priority(), trace_state, mutation_reader::forwarding::no);

--- a/mutation.cc
+++ b/mutation.cc
@@ -32,7 +32,7 @@ mutation::data::data(dht::decorated_key&& key, schema_ptr&& schema)
 
 mutation::data::data(partition_key&& key_, schema_ptr&& schema)
     : _schema(std::move(schema))
-    , _dk(dht::global_partitioner().decorate_key(*_schema, std::move(key_)))
+    , _dk(dht::decorate_key(*_schema, std::move(key_)))
     , _p(_schema)
 { }
 

--- a/mutation_partition_view.cc
+++ b/mutation_partition_view.cc
@@ -338,7 +338,7 @@ mutation_fragment frozen_mutation_fragment::unfreeze(const schema& s)
             return mutation_fragment(range_tombstone(rt));
         },
         [&] (ser::partition_start_view ps) {
-            auto dkey = dht::global_partitioner().decorate_key(s, ps.key());
+            auto dkey = dht::decorate_key(s, ps.key());
             return mutation_fragment(partition_start(std::move(dkey), ps.partition_tombstone()));
         },
         [] (partition_end) {

--- a/mutation_writer/multishard_writer.hh
+++ b/mutation_writer/multishard_writer.hh
@@ -32,7 +32,6 @@ namespace mutation_writer {
 // producer to the correct shard and consume with the consumer.
 // It returns number of partitions consumed.
 future<uint64_t> distribute_reader_and_consume_on_shards(schema_ptr s,
-    dht::i_partitioner& partitioner,
     flat_mutation_reader producer,
     std::function<future<> (flat_mutation_reader)> consumer,
     utils::phased_barrier::operation&& op = {});

--- a/redis/query_utils.cc
+++ b/redis/query_utils.cc
@@ -74,7 +74,7 @@ future<lw_shared_ptr<strings_result>> read_strings(service::storage_proxy& proxy
     auto ps = partition_slice_builder(*schema).build();
     query::read_command cmd(schema->id(), schema->version(), ps, 1, gc_clock::now(), std::nullopt, 1); 
     auto pkey = partition_key::from_single_value(*schema, key);
-    auto partition_range = dht::partition_range::make_singular(dht::global_partitioner().decorate_key(*schema, std::move(pkey)));
+    auto partition_range = dht::partition_range::make_singular(dht::decorate_key(*schema, std::move(pkey)));
     dht::partition_range_vector partition_ranges;
     partition_ranges.emplace_back(std::move(partition_range));
     auto read_consistency_level = options.get_read_consistency_level();

--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -24,6 +24,7 @@
 #include "range_split.hh"
 
 #include "atomic_cell_hash.hh"
+#include "dht/sharder.hh"
 #include "streaming/stream_plan.hh"
 #include "streaming/stream_state.hh"
 #include "streaming/stream_reason.hh"

--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -637,6 +637,29 @@ future<uint64_t> estimate_partitions(seastar::sharded<database>& db, const sstri
     );
 }
 
+static
+const dht::i_partitioner&
+get_partitioner_for_tables(seastar::sharded<database>& db, const sstring& keyspace, const std::vector<sstring>& names) {
+    schema_ptr last_s;
+    for (auto& name : names) {
+        schema_ptr s;
+        try {
+            s = db.local().find_column_family(keyspace, name).schema();
+        } catch(...) {
+            throw std::runtime_error(format("No column family '{}' in keyspace '{}'", name, keyspace));
+        }
+        if (last_s && last_s->get_partitioner() != s->get_partitioner()) {
+            throw std::runtime_error(
+                    format("All tables repaired together have to have the same partitioner. "
+                        "Different partitioners found: {} (for table {}) and {} (for table {})",
+                        last_s->get_partitioner(), last_s->cf_name(),
+                        s->get_partitioner(), s->cf_name()));
+        }
+        last_s = std::move(s);
+    }
+    return last_s->get_partitioner();
+}
+
 repair_info::repair_info(seastar::sharded<database>& db_,
     const sstring& keyspace_,
     const dht::token_range_vector& ranges_,
@@ -645,6 +668,7 @@ repair_info::repair_info(seastar::sharded<database>& db_,
     const std::vector<sstring>& data_centers_,
     const std::vector<sstring>& hosts_)
     : db(db_)
+    , partitioner(get_partitioner_for_tables(db_, keyspace_, cfs_))
     , keyspace(keyspace_)
     , ranges(ranges_)
     , cfs(cfs_)
@@ -1280,7 +1304,7 @@ static future<> do_repair_ranges(lw_shared_ptr<repair_info> ri) {
             ri->ranges_index++;
             rlogger.info("Repair {} out of {} ranges, id={}, shard={}, keyspace={}, table={}, range={}",
                 ri->ranges_index, ri->ranges.size(), ri->id, ri->shard, ri->keyspace, ri->cfs, range);
-            return do_with(dht::selective_token_range_sharder(range, ri->shard), [ri] (auto& sharder) {
+            return do_with(dht::selective_token_range_sharder(ri->partitioner, range, ri->shard), [ri] (auto& sharder) {
                 return repeat([ri, &sharder] () {
                     check_in_shutdown();
                     ri->check_in_abort();
@@ -1396,18 +1420,11 @@ static int do_repair_start(seastar::sharded<database>& db, sstring keyspace,
         ranges = std::move(intersections);
     }
 
-    std::vector<sstring> cfs;
-    if (options.column_families.size()) {
-        cfs = options.column_families;
-        for (auto& cf : cfs) {
-            try {
-                db.local().find_column_family(keyspace, cf);
-            } catch(...) {
-                throw std::runtime_error(format("No column family '{}' in keyspace '{}'", cf, keyspace));
-            }
-        }
-    } else {
-        cfs = list_column_families(db.local(), keyspace);
+    std::vector<sstring> cfs =
+        options.column_families.size() ? options.column_families : list_column_families(db.local(), keyspace);
+    if (cfs.empty()) {
+        rlogger.info("repair id {} completed successfully: no tables to repair", id);
+        return id;
     }
 
     // Do it in the background.

--- a/repair/repair.hh
+++ b/repair/repair.hh
@@ -152,6 +152,7 @@ public:
 class repair_info {
 public:
     seastar::sharded<database>& db;
+    const dht::i_partitioner& partitioner;
     sstring keyspace;
     dht::token_range_vector ranges;
     std::vector<sstring> cfs;

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -496,7 +496,7 @@ public:
         };
         auto& db = service::get_local_storage_service().db();
         table& t = db.local().find_column_family(_schema->id());
-        _writer_done[node_idx] = mutation_writer::distribute_reader_and_consume_on_shards(_schema, dht::global_partitioner(),
+        _writer_done[node_idx] = mutation_writer::distribute_reader_and_consume_on_shards(_schema,
                 make_generating_reader(_schema, std::move(get_next_mutation_fragment)),
                 [&db, estimated_partitions = this->_estimated_partitions] (flat_mutation_reader reader) {
             auto& t = db.local().find_column_family(reader.schema());

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -25,6 +25,7 @@
 #include "mutation_fragment.hh"
 #include "mutation_writer/multishard_writer.hh"
 #include "dht/i_partitioner.hh"
+#include "dht/sharder.hh"
 #include "to_string.hh"
 #include "xx_hasher.hh"
 #include "dht/i_partitioner.hh"

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -1257,7 +1257,7 @@ private:
         return do_with(std::move(rows), std::list<repair_row>(), lw_shared_ptr<const decorated_key_with_hash>(), lw_shared_ptr<mutation_fragment>(), position_in_partition::tri_compare(*_schema),
           [this] (repair_rows_on_wire& rows, std::list<repair_row>& row_list, lw_shared_ptr<const decorated_key_with_hash>& dk_ptr, lw_shared_ptr<mutation_fragment>& last_mf, position_in_partition::tri_compare& cmp) mutable {
             return do_for_each(rows, [this, &dk_ptr, &row_list, &last_mf, &cmp] (partition_key_and_mutation_fragments& x) mutable {
-                dht::decorated_key dk = dht::global_partitioner().decorate_key(*_schema, x.get_key());
+                dht::decorated_key dk = dht::decorate_key(*_schema, x.get_key());
                 if (!(dk_ptr && dk_ptr->dk.equal(*_schema, dk))) {
                     dk_ptr = make_lw_shared<const decorated_key_with_hash>(*_schema, dk, _seed);
                 }

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -677,7 +677,7 @@ public:
                     _cf,
                     _schema,
                     _range,
-                    dht::global_partitioner(),
+                    _schema->get_partitioner(),
                     *_remote_partitioner,
                     _master_node_shard_config.shard,
                     _seed,
@@ -944,9 +944,9 @@ private:
     bool is_same_sharding_config() {
         rlogger.debug("is_same_sharding_config: remote_partitioner_name={}, remote_shard={}, remote_shard_count={}, remote_ignore_msb={}",
                 _master_node_shard_config.partitioner_name, _master_node_shard_config.shard, _master_node_shard_config.shard_count, _master_node_shard_config.ignore_msb);
-        return dht::global_partitioner().name() == _master_node_shard_config.partitioner_name
-               && dht::global_partitioner().shard_count() == _master_node_shard_config.shard_count
-               && dht::global_partitioner().sharding_ignore_msb() == _master_node_shard_config.ignore_msb
+        return _schema->get_partitioner().name() == _master_node_shard_config.partitioner_name
+               && _schema->get_partitioner().shard_count() == _master_node_shard_config.shard_count
+               && _schema->get_partitioner().sharding_ignore_msb() == _master_node_shard_config.ignore_msb
                && engine().cpu_id() == _master_node_shard_config.shard;
     }
 
@@ -2437,9 +2437,9 @@ public:
             auto max_row_buf_size = get_max_row_buf_size(algorithm);
             auto master_node_shard_config = shard_config {
                     engine().cpu_id(),
-                    dht::global_partitioner().shard_count(),
-                    dht::global_partitioner().sharding_ignore_msb(),
-                    dht::global_partitioner().name()
+                    _ri.partitioner.shard_count(),
+                    _ri.partitioner.sharding_ignore_msb(),
+                    _ri.partitioner.name()
             };
             auto s = _cf.schema();
             auto schema_version = s->version();

--- a/schema.cc
+++ b/schema.cc
@@ -36,6 +36,7 @@
 #include "partition_slice_builder.hh"
 #include "database.hh"
 #include "service/storage_service.hh"
+#include "dht/i_partitioner.hh"
 
 constexpr int32_t schema::NAME_LENGTH;
 
@@ -98,6 +99,10 @@ std::ostream& operator<<(std::ostream& out, const column_mapping& cm) {
 std::ostream& operator<<(std::ostream& os, ordinal_column_id id)
 {
     return os << static_cast<column_count_type>(id);
+}
+
+dht::i_partitioner& schema::get_partitioner() const {
+    return dht::global_partitioner();
 }
 
 ::shared_ptr<cql3::column_specification>

--- a/schema.cc
+++ b/schema.cc
@@ -1461,8 +1461,7 @@ bytes token_column_computation::serialize() const {
 }
 
 bytes_opt token_column_computation::compute_value(const schema& schema, const partition_key& key, const clustering_row& row) const {
-    dht::i_partitioner& partitioner = dht::global_partitioner();
-    return partitioner.get_token(schema, key).data();
+    return dht::get_token(schema, key).data();
 }
 
 bool operator==(const raw_view_info& x, const raw_view_info& y) {

--- a/schema.hh
+++ b/schema.hh
@@ -43,6 +43,12 @@
 #include "column_computation.hh"
 #include "cdc/cdc_options.hh"
 
+namespace dht {
+
+class i_partitioner;
+
+}
+
 using column_count_type = uint32_t;
 
 // Column ID, unique within column_kind
@@ -808,6 +814,8 @@ public:
     const ::caching_options& caching_options() const {
         return _raw._caching_options;
     }
+
+    dht::i_partitioner& get_partitioner() const;
 
     const column_definition* get_column_definition(const bytes& name) const;
     const column_definition& column_at(column_kind, column_id) const;

--- a/service/pager/query_pagers.cc
+++ b/service/pager/query_pagers.cc
@@ -100,7 +100,7 @@ static bool has_clustering_keys(const schema& s, const query::read_command& cmd)
         qlogger.trace("fetch_page query id {}", _cmd->query_uuid);
 
         if (_last_pkey) {
-            auto dpk = dht::global_partitioner().decorate_key(*_schema, *_last_pkey);
+            auto dpk = dht::decorate_key(*_schema, *_last_pkey);
             dht::ring_position lo(dpk);
 
             auto reversed = _cmd->slice.options.contains<query::partition_slice::option::reversed>();

--- a/service/paxos/paxos_state.cc
+++ b/service/paxos/paxos_state.cc
@@ -50,7 +50,7 @@ void paxos_state::key_lock_map::release_semaphore_for_key(const dht::token& key)
 future<prepare_response> paxos_state::prepare(tracing::trace_state_ptr tr_state, schema_ptr schema,
         const query::read_command& cmd, const partition_key& key, utils::UUID ballot,
         bool only_digest, query::digest_algorithm da, clock_type::time_point timeout) {
-    dht::token token = dht::global_partitioner().get_token(*schema, key);
+    dht::token token = dht::get_token(*schema, key);
     utils::latency_counter lc;
     lc.start();
     return with_locked_key(token, timeout, [&cmd, token, &key, ballot, tr_state, schema, only_digest, da, timeout] () mutable {

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -4819,7 +4819,7 @@ void storage_proxy::init_messaging_service() {
 
         return get_schema_for_read(cmd.schema_version, src_addr).then([this, cmd = std::move(cmd), key = std::move(key), ballot,
                          only_digest, da, timeout, tr_state = std::move(tr_state), src_ip] (schema_ptr schema) mutable {
-            dht::token token = dht::global_partitioner().get_token(*schema, key);
+            dht::token token = dht::get_token(*schema, key);
             unsigned shard = dht::shard_of(*schema, token);
             bool local = shard == engine().cpu_id();
             get_stats().replica_cross_shard_ops += !local;

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -147,8 +147,8 @@ sstring get_local_dc() {
     return get_dc(local_addr);
 }
 
-unsigned storage_proxy::cas_shard(dht::token token) {
-    return dht::shard_of(token);
+unsigned storage_proxy::cas_shard(const schema& s, dht::token token) {
+    return dht::shard_of(s, token);
 }
 
 class mutation_holder {
@@ -3689,7 +3689,7 @@ storage_proxy::query_result_local(schema_ptr s, lw_shared_ptr<query::read_comman
                                   tracing::trace_state_ptr trace_state, storage_proxy::clock_type::time_point timeout, uint64_t max_size) {
     cmd->slice.options.set_if<query::partition_slice::option::with_digest>(opts.request != query::result_request::only_result);
     if (pr.is_singular()) {
-        unsigned shard = _db.local().shard_of(pr.start()->value().token());
+        unsigned shard = dht::shard_of(*s, pr.start()->value().token());
         get_stats().replica_cross_shard_ops += shard != engine().cpu_id();
         return _db.invoke_on(shard, _read_smp_service_group, [max_size, gs = global_schema_ptr(s), prv = dht::partition_range_vector({pr}) /* FIXME: pr is copied */, cmd, opts, timeout, gt = tracing::global_trace_state_ptr(std::move(trace_state))] (database& db) mutable {
             auto trace_state = gt.get();
@@ -4122,7 +4122,7 @@ storage_proxy::do_query_with_paxos(schema_ptr s,
     auto cl_for_learn = cl == db::consistency_level::LOCAL_SERIAL ? db::consistency_level::LOCAL_QUORUM :
             db::consistency_level::QUORUM;
 
-    if (cas_shard(partition_ranges[0].start()->value().as_decorated_key().token()) != engine().cpu_id()) {
+    if (cas_shard(*s, partition_ranges[0].start()->value().as_decorated_key().token()) != engine().cpu_id()) {
         throw std::logic_error("storage_proxy::do_query_with_paxos called on a wrong shard");
     }
     // All cas networking operations run with query provided timeout
@@ -4242,7 +4242,7 @@ future<bool> storage_proxy::cas(schema_ptr schema, shared_ptr<cas_request> reque
     db::validate_for_cas(cl_for_paxos);
     db::validate_for_cas_commit(cl_for_commit, schema->ks_name());
 
-    if (cas_shard(partition_ranges[0].start()->value().as_decorated_key().token()) != engine().cpu_id()) {
+    if (cas_shard(*schema, partition_ranges[0].start()->value().as_decorated_key().token()) != engine().cpu_id()) {
         throw std::logic_error("storage_proxy::cas called on a wrong shard");
     }
 
@@ -4820,7 +4820,7 @@ void storage_proxy::init_messaging_service() {
         return get_schema_for_read(cmd.schema_version, src_addr).then([this, cmd = std::move(cmd), key = std::move(key), ballot,
                          only_digest, da, timeout, tr_state = std::move(tr_state), src_ip] (schema_ptr schema) mutable {
             dht::token token = dht::global_partitioner().get_token(*schema, key);
-            unsigned shard = _db.local().shard_of(token);
+            unsigned shard = dht::shard_of(*schema, token);
             bool local = shard == engine().cpu_id();
             get_stats().replica_cross_shard_ops += !local;
             return smp::submit_to(shard, _write_smp_service_group, [gs = global_schema_ptr(schema), gt = tracing::global_trace_state_ptr(std::move(tr_state)),
@@ -4848,7 +4848,7 @@ void storage_proxy::init_messaging_service() {
         auto f = get_schema_for_read(proposal.update.schema_version(), src_addr).then([this, tr_state = std::move(tr_state),
                                                               proposal = std::move(proposal), timeout] (schema_ptr schema) mutable {
             dht::token token = proposal.update.decorated_key(*schema).token();
-            unsigned shard = _db.local().shard_of(token);
+            unsigned shard = dht::shard_of(*schema, token);
             bool local = shard == engine().cpu_id();
             get_stats().replica_cross_shard_ops += !local;
             return smp::submit_to(shard, _write_smp_service_group, [gs = global_schema_ptr(schema), gt = tracing::global_trace_state_ptr(std::move(tr_state)),
@@ -4888,7 +4888,7 @@ storage_proxy::query_mutations_locally(schema_ptr s, lw_shared_ptr<query::read_c
                                        storage_proxy::clock_type::time_point timeout,
                                        tracing::trace_state_ptr trace_state, uint64_t max_size) {
     if (pr.is_singular()) {
-        unsigned shard = _db.local().shard_of(pr.start()->value().token());
+        unsigned shard = dht::shard_of(*s, pr.start()->value().token());
         get_stats().replica_cross_shard_ops += shard != engine().cpu_id();
         return _db.invoke_on(shard, _read_smp_service_group, [max_size, cmd, &pr, gs=global_schema_ptr(s), timeout, gt = tracing::global_trace_state_ptr(std::move(trace_state))] (database& db) mutable {
           return db.get_result_memory_limiter().new_mutation_read(max_size).then([&] (query::result_memory_accounter ma) {

--- a/service/storage_proxy.hh
+++ b/service/storage_proxy.hh
@@ -568,7 +568,7 @@ public:
         return _stats_key;
     }
 
-    static unsigned cas_shard(dht::token token);
+    static unsigned cas_shard(const schema& s, dht::token token);
 
     virtual void on_join_cluster(const gms::inet_address& endpoint) override;
     virtual void on_leave_cluster(const gms::inet_address& endpoint) override;

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -718,7 +718,7 @@ void storage_service::join_token_ring(int delay) {
                 && (!db::system_keyspace::bootstrap_complete()
                     || cdc::should_propose_first_generation(get_broadcast_address(), _gossiper))) {
 
-            _cdc_streams_ts = cdc::make_new_cdc_generation(
+            _cdc_streams_ts = cdc::make_new_cdc_generation(db().local().get_config(),
                     _bootstrap_tokens, _token_metadata, _gossiper,
                     _sys_dist_ks.local(), get_ring_delay(), _for_testing);
         }
@@ -942,7 +942,7 @@ void storage_service::bootstrap() {
             // We don't do any other generation switches (unless we crash before complecting bootstrap).
             assert(!_cdc_streams_ts);
 
-            _cdc_streams_ts = cdc::make_new_cdc_generation(
+            _cdc_streams_ts = cdc::make_new_cdc_generation(db().local().get_config(),
                     _bootstrap_tokens, _token_metadata, _gossiper,
                     _sys_dist_ks.local(), get_ring_delay(), _for_testing);
         } else {

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -3450,7 +3450,7 @@ std::vector<gms::inet_address>
 storage_service::get_natural_endpoints(const sstring& keyspace,
         const sstring& cf, const sstring& key) const {
     sstables::key_view key_view = sstables::key_view(bytes_view(reinterpret_cast<const signed char*>(key.c_str()), key.size()));
-    dht::token token = dht::global_partitioner().get_token(key_view);
+    dht::token token = _db.local().find_schema(keyspace, cf)->get_partitioner().get_token(key_view);
     return get_natural_endpoints(keyspace, token);
 }
 

--- a/sstables/binary_search.hh
+++ b/sstables/binary_search.hh
@@ -49,10 +49,8 @@ namespace sstables {
  * a key view via get_key().
  */
 template <typename T>
-int binary_search(const T& entries, const key& sk, const dht::token& token) {
+int binary_search(dht::i_partitioner& partitioner, const T& entries, const key& sk, const dht::token& token) {
     int low = 0, mid = entries.size(), high = mid - 1, result = -1;
-
-    auto& partitioner = dht::global_partitioner();
 
     while (low <= high) {
         // The token comparison should yield the right result most of the time.
@@ -82,8 +80,8 @@ int binary_search(const T& entries, const key& sk, const dht::token& token) {
 }
 
 template <typename T>
-int binary_search(const T& entries, const key& sk) {
-    return binary_search(entries, sk, dht::global_partitioner().get_token(key_view(sk)));
+int binary_search(dht::i_partitioner& partitioner, const T& entries, const key& sk) {
+    return binary_search(partitioner, entries, sk, partitioner.get_token(key_view(sk)));
 }
 
 }

--- a/sstables/compaction.cc
+++ b/sstables/compaction.cc
@@ -744,8 +744,8 @@ public:
     }
 
     virtual flat_mutation_reader::filter make_partition_filter() const override {
-        return [] (const dht::decorated_key& dk){
-            return dht::shard_of(dk.token()) == engine().cpu_id();
+        return [&s = *_schema] (const dht::decorated_key& dk){
+            return dht::shard_of(s, dk.token()) == engine().cpu_id();
         };
     }
 
@@ -889,7 +889,7 @@ public:
         dht::token_range_vector owned_ranges = service::get_local_storage_service().get_local_ranges(_schema->ks_name());
 
         return [this, owned_ranges = std::move(owned_ranges)] (const dht::decorated_key& dk) {
-            if (dht::shard_of(dk.token()) != engine().cpu_id()) {
+            if (dht::shard_of(*_schema, dk.token()) != engine().cpu_id()) {
                 clogger.trace("Token {} does not belong to CPU {}, skipping", dk.token(), engine().cpu_id());
                 return false;
             }
@@ -993,7 +993,7 @@ public:
     }
 
     sstable_writer* select_sstable_writer(const dht::decorated_key& dk) override {
-        _shard = dht::shard_of(dk.token());
+        _shard = dht::shard_of(*_schema, dk.token());
         auto& sst = _output_sstables[_shard].first;
         auto& writer = _output_sstables[_shard].second;
 

--- a/sstables/index_reader.hh
+++ b/sstables/index_reader.hh
@@ -425,7 +425,7 @@ private:
             if (sstlog.is_enabled(seastar::log_level::trace)) {
                 sstlog.trace("index {} bound {}: page:", this, &bound);
                 for (const index_entry& e : *bound.current_list) {
-                    auto dk = dht::global_partitioner().decorate_key(*_sstable->_schema,
+                    auto dk = dht::decorate_key(*_sstable->_schema,
                         e.get_key().to_partition_key(*_sstable->_schema));
                     sstlog.trace("  {} -> {}", dk, e.position());
                 }

--- a/sstables/index_reader.hh
+++ b/sstables/index_reader.hh
@@ -217,7 +217,7 @@ public:
                                    promoted_index_size, _num_pi_blocks);
                 }
             }
-            _consumer.consume_entry(index_entry{std::move(_key), _position, std::move(index)}, _entry_offset);
+            _consumer.consume_entry(index_entry{_s, std::move(_key), _position, std::move(index)}, _entry_offset);
             _deletion_time = std::nullopt;
             _num_pi_blocks = 0;
             _state = state::START;

--- a/sstables/mc/writer.cc
+++ b/sstables/mc/writer.cc
@@ -1401,7 +1401,7 @@ void writer::consume_end_of_stream() {
 
     _sst._components->statistics.contents[metadata_type::Serialization] = std::make_unique<serialization_header>(std::move(_sst_schema.header));
     seal_statistics(_sst.get_version(), _sst._components->statistics, _sst.get_metadata_collector(),
-        dht::global_partitioner().name(), _schema.bloom_filter_fp_chance(),
+        _sst._schema->get_partitioner().name(), _schema.bloom_filter_fp_chance(),
         _sst._schema, _sst.get_first_decorated_key(), _sst.get_last_decorated_key(), _enc_stats);
     close_data_writer();
     _sst.write_summary(_pc);

--- a/sstables/mp_row_consumer.hh
+++ b/sstables/mp_row_consumer.hh
@@ -411,7 +411,7 @@ public:
         }
         auto pk = partition_key::from_exploded(key.explode(*_schema));
         setup_for_partition(pk);
-        auto dk = dht::global_partitioner().decorate_key(*_schema, pk);
+        auto dk = dht::decorate_key(*_schema, pk);
         _reader->on_next_partition(std::move(dk), tombstone(deltime));
         return proceed::yes;
     }
@@ -1105,7 +1105,7 @@ public:
         }
         auto pk = partition_key::from_exploded(key.explode(*_schema));
         setup_for_partition(pk);
-        auto dk = dht::global_partitioner().decorate_key(*_schema, pk);
+        auto dk = dht::decorate_key(*_schema, pk);
         _reader->on_next_partition(std::move(dk), tombstone(deltime));
         return proceed::yes;
     }

--- a/sstables/partition.cc
+++ b/sstables/partition.cc
@@ -276,7 +276,7 @@ private:
             return read_from_datafile();
         }
         auto pk = _index_reader->partition_key().to_partition_key(*_schema);
-        auto key = dht::global_partitioner().decorate_key(*_schema, std::move(pk));
+        auto key = dht::decorate_key(*_schema, std::move(pk));
         _consumer.setup_for_partition(key.key());
         on_next_partition(std::move(key), tombstone(*tomb));
         return make_ready_future<>();

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -3097,7 +3097,7 @@ std::optional<std::pair<uint64_t, uint64_t>> sstable::get_sample_indexes_for_ran
         auto kind = before ? key::kind::before_all_keys : key::kind::after_all_keys;
         key k(kind);
         // Binary search will never returns positive values.
-        return uint64_t((binary_search(_components->summary.entries, k, token) + 1) * -1);
+        return uint64_t((binary_search(_schema->get_partitioner(), _components->summary.entries, k, token) + 1) * -1);
     };
     uint64_t left = 0;
     if (range.start()) {

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -2833,7 +2833,7 @@ void sstable::set_first_and_last_keys() {
             throw std::runtime_error(format("{} key of summary of {} is empty", m, get_filename()));
         }
         auto pk = key::from_bytes(value).to_partition_key(*_schema);
-        return dht::global_partitioner().decorate_key(*_schema, std::move(pk));
+        return dht::decorate_key(*_schema, std::move(pk));
     };
     _first = decorate_key("first", _components->summary.first_key.value);
     _last = decorate_key("last", _components->summary.last_key.value);
@@ -3176,7 +3176,7 @@ std::vector<dht::decorated_key> sstable::get_key_samples(const schema& s, const 
     if (index_range) {
         for (auto idx = index_range->first; idx < index_range->second; ++idx) {
             auto pkey = _components->summary.entries[idx].get_key().to_partition_key(s);
-            res.push_back(dht::global_partitioner().decorate_key(s, std::move(pkey)));
+            res.push_back(dht::decorate_key(s, std::move(pkey)));
         }
     }
     return res;

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -3218,7 +3218,7 @@ sstable::compute_shards_for_this_sstable() const {
                 sm->token_ranges.elements
                 | boost::adaptors::transformed(disk_token_range_to_ring_position_range));
     }
-    auto sharder = dht::ring_position_range_vector_sharder(std::move(token_ranges));
+    auto sharder = dht::ring_position_range_vector_sharder(_schema->get_partitioner(), std::move(token_ranges));
     auto rpras = sharder.next(*_schema);
     while (rpras) {
         shards.insert(rpras->shard);

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -229,7 +229,7 @@ read_integer(temporary_buffer<char>& buf, T& i) {
 
 template <typename T>
 typename std::enable_if_t<std::is_integral<T>::value, future<>>
-parse(sstable_version_types v, random_access_reader& in, T& i) {
+parse(const schema&, sstable_version_types v, random_access_reader& in, T& i) {
     return in.read_exactly(sizeof(T)).then([&i] (auto buf) {
         check_buf_size(buf, sizeof(T));
 
@@ -241,12 +241,12 @@ parse(sstable_version_types v, random_access_reader& in, T& i) {
 
 template <typename T>
 typename std::enable_if_t<std::is_enum<T>::value, future<>>
-parse(sstable_version_types v, random_access_reader& in, T& i) {
-    return parse(v, in, reinterpret_cast<typename std::underlying_type<T>::type&>(i));
+parse(const schema& s, sstable_version_types v, random_access_reader& in, T& i) {
+    return parse(s, v, in, reinterpret_cast<typename std::underlying_type<T>::type&>(i));
 }
 
-future<> parse(sstable_version_types v, random_access_reader& in, bool& i) {
-    return parse(v, in, reinterpret_cast<uint8_t&>(i));
+future<> parse(const schema& s, sstable_version_types v, random_access_reader& in, bool& i) {
+    return parse(s, v, in, reinterpret_cast<uint8_t&>(i));
 }
 
 template <typename To, typename From>
@@ -261,7 +261,7 @@ static inline To convert(From f) {
     return conv.to;
 }
 
-future<> parse(sstable_version_types, random_access_reader& in, double& d) {
+future<> parse(const schema&, sstable_version_types, random_access_reader& in, double& d) {
     return in.read_exactly(sizeof(double)).then([&d] (auto buf) {
         check_buf_size(buf, sizeof(double));
 
@@ -272,7 +272,7 @@ future<> parse(sstable_version_types, random_access_reader& in, double& d) {
 }
 
 template <typename T>
-future<> parse(sstable_version_types, random_access_reader& in, T& len, bytes& s) {
+future<> parse(const schema&, sstable_version_types, random_access_reader& in, T& len, bytes& s) {
     return in.read_exactly(len).then([&s, len] (auto buf) {
         check_buf_size(buf, len);
         // Likely a different type of char. Most bufs are unsigned, whereas the bytes type is signed.
@@ -282,27 +282,27 @@ future<> parse(sstable_version_types, random_access_reader& in, T& len, bytes& s
 
 // All composite parsers must come after this
 template<typename First, typename... Rest>
-future<> parse(sstable_version_types v, random_access_reader& in, First& first, Rest&&... rest) {
-    return parse(v, in, first).then([v, &in, &rest...] {
-        return parse(v, in, std::forward<Rest>(rest)...);
+future<> parse(const schema& s, sstable_version_types v, random_access_reader& in, First& first, Rest&&... rest) {
+    return parse(s, v, in, first).then([v, &s, &in, &rest...] {
+        return parse(s, v, in, std::forward<Rest>(rest)...);
     });
 }
 
 // Intended to be used for a type that describes itself through describe_type().
 template <class T>
 typename std::enable_if_t<!std::is_integral<T>::value && !std::is_enum<T>::value, future<>>
-parse(sstable_version_types v, random_access_reader& in, T& t) {
-    return t.describe_type(v, [v, &in] (auto&&... what) -> future<> {
-        return parse(v, in, what...);
+parse(const schema& s, sstable_version_types v, random_access_reader& in, T& t) {
+    return t.describe_type(v, [v, &s, &in] (auto&&... what) -> future<> {
+        return parse(s, v, in, what...);
     });
 }
 
 template <class T>
-future<> parse(sstable_version_types v, random_access_reader& in, vint<T>& t) {
+future<> parse(const schema&, sstable_version_types v, random_access_reader& in, vint<T>& t) {
     return read_vint(in, t.value);
 }
 
-future<> parse(sstable_version_types, random_access_reader& in, utils::UUID& uuid) {
+future<> parse(const schema&, sstable_version_types, random_access_reader& in, utils::UUID& uuid) {
     return in.read_exactly(uuid.serialized_size()).then([&uuid] (temporary_buffer<char> buf) {
         check_buf_size(buf, utils::UUID::serialized_size());
 
@@ -320,28 +320,28 @@ inline void write(sstable_version_types v, file_writer& out, const utils::UUID& 
 // are contiguous, it is not always the case. So we want to have the
 // flexibility of parsing them separately.
 template <typename Size>
-future<> parse(sstable_version_types v, random_access_reader& in, disk_string<Size>& s) {
+future<> parse(const schema& schema, sstable_version_types v, random_access_reader& in, disk_string<Size>& s) {
     auto len = std::make_unique<Size>();
-    auto f = parse(v, in, *len);
-    return f.then([v, &in, &s, len = std::move(len)] {
-        return parse(v, in, *len, s.value);
+    auto f = parse(schema, v, in, *len);
+    return f.then([v, &schema, &in, &s, len = std::move(len)] {
+        return parse(schema, v, in, *len, s.value);
     });
 }
 
-future<> parse(sstable_version_types v, random_access_reader& in, disk_string_vint_size& s) {
+future<> parse(const schema& schema, sstable_version_types v, random_access_reader& in, disk_string_vint_size& s) {
     auto len = std::make_unique<uint64_t>();
     auto f = read_vint(in, *len);
-    return f.then([v, &in, &s, len = std::move(len)] {
-        return parse(v, in, *len, s.value);
+    return f.then([v, &schema, &in, &s, len = std::move(len)] {
+        return parse(schema, v, in, *len, s.value);
     });
 }
 
 template <typename Members>
-future<> parse(sstable_version_types v, random_access_reader& in, disk_array_vint_size<Members>& arr) {
+future<> parse(const schema& s, sstable_version_types v, random_access_reader& in, disk_array_vint_size<Members>& arr) {
     auto len = std::make_unique<uint64_t>();
     auto f = read_vint(in, *len);
-    return f.then([v, &in, &arr, len = std::move(len)] {
-        return parse(v, in, *len, arr.elements);
+    return f.then([v, &s, &in, &arr, len = std::move(len)] {
+        return parse(s, v, in, *len, arr.elements);
     });
 }
 
@@ -355,21 +355,21 @@ future<> parse(sstable_version_types v, random_access_reader& in, disk_array_vin
 // We'll offer a specialization for that case below.
 template <typename Size, typename Members>
 typename std::enable_if_t<!std::is_integral<Members>::value, future<>>
-parse(sstable_version_types v, random_access_reader& in, Size& len, utils::chunked_vector<Members>& arr) {
+parse(const schema& s, sstable_version_types v, random_access_reader& in, Size& len, utils::chunked_vector<Members>& arr) {
 
     auto count = make_lw_shared<size_t>(0);
     auto eoarr = [count, len] { return *count == len; };
 
-    return do_until(eoarr, [v, count, &in, &arr] {
+    return do_until(eoarr, [v, &s, count, &in, &arr] {
         arr.emplace_back();
         (*count)++;
-        return parse(v, in, arr.back());
+        return parse(s, v, in, arr.back());
     });
 }
 
 template <typename Size, typename Members>
 typename std::enable_if_t<std::is_integral<Members>::value, future<>>
-parse(sstable_version_types, random_access_reader& in, Size& len, utils::chunked_vector<Members>& arr) {
+parse(const schema&, sstable_version_types, random_access_reader& in, Size& len, utils::chunked_vector<Members>& arr) {
     auto done = make_lw_shared<size_t>(0);
     return repeat([&in, &len, &arr, done]  {
         auto now = std::min(len - *done, 100000 / sizeof(Members));
@@ -389,27 +389,27 @@ parse(sstable_version_types, random_access_reader& in, Size& len, utils::chunked
 // We resize the array here, before we pass it to the integer / non-integer
 // specializations
 template <typename Size, typename Members>
-future<> parse(sstable_version_types v, random_access_reader& in, disk_array<Size, Members>& arr) {
+future<> parse(const schema& s, sstable_version_types v, random_access_reader& in, disk_array<Size, Members>& arr) {
     auto len = make_lw_shared<Size>();
-    auto f = parse(v, in, *len);
-    return f.then([v, &in, &arr, len] {
+    auto f = parse(s, v, in, *len);
+    return f.then([v, &s, &in, &arr, len] {
         arr.elements.reserve(*len);
-        return parse(v, in, *len, arr.elements);
+        return parse(s, v, in, *len, arr.elements);
     }).finally([len] {});
 }
 
 template <typename Size, typename Key, typename Value>
-future<> parse(sstable_version_types v, random_access_reader& in, Size& len, std::unordered_map<Key, Value>& map) {
-    return do_with(Size(), [v, &in, len, &map] (Size& count) {
+future<> parse(const schema& s, sstable_version_types v, random_access_reader& in, Size& len, std::unordered_map<Key, Value>& map) {
+    return do_with(Size(), [v, &s, &in, len, &map] (Size& count) {
         auto eos = [len, &count] { return len == count++; };
-        return do_until(eos, [v, len, &in, &map] {
+        return do_until(eos, [v, &s, len, &in, &map] {
             struct kv {
                 Key key;
                 Value value;
             };
 
-            return do_with(kv(), [v, &in, &map] (auto& el) {
-                return parse(v, in, el.key, el.value).then([&el, &map] {
+            return do_with(kv(), [v, &s, &in, &map] (auto& el) {
+                return parse(s, v, in, el.key, el.value).then([&el, &map] {
                     map.emplace(el.key, el.value);
                 });
             });
@@ -418,16 +418,16 @@ future<> parse(sstable_version_types v, random_access_reader& in, Size& len, std
 }
 
 template <typename First, typename Second>
-future<> parse(sstable_version_types v, random_access_reader& in, std::pair<First, Second>& p) {
-    return parse(v, in, p.first, p.second);
+future<> parse(const schema& s, sstable_version_types v, random_access_reader& in, std::pair<First, Second>& p) {
+    return parse(s, v, in, p.first, p.second);
 }
 
 template <typename Size, typename Key, typename Value>
-future<> parse(sstable_version_types v, random_access_reader& in, disk_hash<Size, Key, Value>& h) {
+future<> parse(const schema& s, sstable_version_types v, random_access_reader& in, disk_hash<Size, Key, Value>& h) {
     auto w = std::make_unique<Size>();
-    auto f = parse(v, in, *w);
-    return f.then([v, &in, &h, w = std::move(w)] {
-        return parse(v, in, *w, h.map);
+    auto f = parse(s, v, in, *w);
+    return f.then([v, &s, &in, &h, w = std::move(w)] {
+        return parse(s, v, in, *w, h.map);
     });
 }
 
@@ -436,7 +436,7 @@ template <typename DiskSetOfTaggedUnion>
 struct single_tagged_union_member_serdes {
     using value_type = typename DiskSetOfTaggedUnion::value_type;
     virtual ~single_tagged_union_member_serdes() {}
-    virtual future<> do_parse(sstable_version_types version, random_access_reader& in, value_type& v) const = 0;
+    virtual future<> do_parse(const schema& s, sstable_version_types version, random_access_reader& in, value_type& v) const = 0;
     virtual uint32_t do_size(sstable_version_types version, const value_type& v) const = 0;
     virtual void do_write(sstable_version_types version, file_writer& out, const value_type& v) const = 0;
 };
@@ -446,9 +446,9 @@ template <typename DiskSetOfTaggedUnion, typename Member>
 struct single_tagged_union_member_serdes_for final : single_tagged_union_member_serdes<DiskSetOfTaggedUnion> {
     using base = single_tagged_union_member_serdes<DiskSetOfTaggedUnion>;
     using value_type = typename base::value_type;
-    virtual future<> do_parse(sstable_version_types version, random_access_reader& in, value_type& v) const {
+    virtual future<> do_parse(const schema& s, sstable_version_types version, random_access_reader& in, value_type& v) const {
         v = Member();
-        return parse(version, in, boost::get<Member>(v).value);
+        return parse(s, version, in, boost::get<Member>(v).value);
     }
     virtual uint32_t do_size(sstable_version_types version, const value_type& v) const override {
         return serialized_size(version, boost::get<Member>(v).value);
@@ -467,12 +467,12 @@ struct disk_set_of_tagged_union<TagType, Members...>::serdes {
     serdes_map_type map = {
         {Members::tag(), make_shared<single_tagged_union_member_serdes_for<disk_set, Members>>()}...
     };
-    future<> lookup_and_parse(sstable_version_types v, random_access_reader& in, TagType tag, uint32_t& size, disk_set& s, value_type& value) const {
+    future<> lookup_and_parse(const schema& schema, sstable_version_types v, random_access_reader& in, TagType tag, uint32_t& size, disk_set& s, value_type& value) const {
         auto i = map.find(tag);
         if (i == map.end()) {
             return in.read_exactly(size).discard_result();
         } else {
-            return i->second->do_parse(v, in, value).then([tag, &s, &value] () mutable {
+            return i->second->do_parse(schema, v, in, value).then([tag, &s, &value] () mutable {
                 s.data.emplace(tag, std::move(value));
             });
         }
@@ -490,17 +490,17 @@ typename disk_set_of_tagged_union<TagType, Members...>::serdes disk_set_of_tagge
 
 template <typename TagType, typename... Members>
 future<>
-parse(sstable_version_types v, random_access_reader& in, disk_set_of_tagged_union<TagType, Members...>& s) {
+parse(const schema& schema, sstable_version_types v, random_access_reader& in, disk_set_of_tagged_union<TagType, Members...>& s) {
     using disk_set = disk_set_of_tagged_union<TagType, Members...>;
     using key_type = typename disk_set::key_type;
     using value_type = typename disk_set::value_type;
     return do_with(0u, 0u, 0u, value_type{}, [&] (key_type& nr_elements, key_type& new_key, unsigned& new_size, value_type& new_value) {
-        return parse(v, in, nr_elements).then([&, v] {
+        return parse(schema, v, in, nr_elements).then([&, v] {
             auto rng = boost::irange<key_type>(0, nr_elements); // do_for_each doesn't like an rvalue range
             return do_for_each(rng.begin(), rng.end(), [&, v] (key_type ignore) {
-                return parse(v, in, new_key).then([&, v] {
-                    return parse(v, in, new_size).then([&, v] {
-                        return disk_set::s_serdes.lookup_and_parse(v, in, TagType(new_key), new_size, s, new_value);
+                return parse(schema, v, in, new_key).then([&, v] {
+                    return parse(schema, v, in, new_size).then([&, v] {
+                        return disk_set::s_serdes.lookup_and_parse(schema, v, in, TagType(new_key), new_size, s, new_value);
                     });
                 });
             });
@@ -521,14 +521,14 @@ void write(sstable_version_types v, file_writer& out, const disk_set_of_tagged_u
     }
 }
 
-future<> parse(sstable_version_types v, random_access_reader& in, summary& s) {
+future<> parse(const schema& schema, sstable_version_types v, random_access_reader& in, summary& s) {
     using pos_type = typename decltype(summary::positions)::value_type;
 
-    return parse(v, in, s.header.min_index_interval,
+    return parse(schema, v, in, s.header.min_index_interval,
                      s.header.size,
                      s.header.memory_size,
                      s.header.sampling_level,
-                     s.header.size_at_full_sampling).then([v, &in, &s] {
+                     s.header.size_at_full_sampling).then([v, &schema, &in, &s] {
         return in.read_exactly(s.header.size * sizeof(pos_type)).then([&in, &s] (auto buf) {
             auto len = s.header.size * sizeof(pos_type);
             check_buf_size(buf, len);
@@ -550,20 +550,20 @@ future<> parse(sstable_version_types v, random_access_reader& in, summary& s) {
                 s.positions.push_back(s.header.memory_size);
                 return make_ready_future<>();
             });
-        }).then([v, &in, &s] {
+        }).then([v, &schema, &in, &s] {
             in.seek(sizeof(summary::header) + s.header.memory_size);
-            return parse(v, in, s.first_key, s.last_key);
-        }).then([&in, &s] {
+            return parse(schema, v, in, s.first_key, s.last_key);
+        }).then([&schema, &in, &s] {
             in.seek(s.positions[0] + sizeof(summary::header));
             s.entries.reserve(s.header.size);
 
-            return do_with(int(0), [&in, &s] (int& idx) mutable {
-                return do_until([&s] { return s.entries.size() == s.header.size; }, [&s, &in, &idx] () mutable {
+            return do_with(int(0), [&schema, &in, &s] (int& idx) mutable {
+                return do_until([&s] { return s.entries.size() == s.header.size; }, [&schema, &s, &in, &idx] () mutable {
                     auto pos = s.positions[idx++];
                     auto next = s.positions[idx];
 
                     auto entrysize = next - pos;
-                    return in.read_exactly(entrysize).then([&s, entrysize] (auto buf) mutable {
+                    return in.read_exactly(entrysize).then([&schema, &s, entrysize] (auto buf) mutable {
                         check_buf_size(buf, entrysize);
 
                         auto keysize = entrysize - 8;
@@ -572,7 +572,7 @@ future<> parse(sstable_version_types v, random_access_reader& in, summary& s) {
 
                         // position is little-endian encoded
                         auto position = seastar::read_le<uint64_t>(buf.get());
-                        auto token = dht::global_partitioner().get_token(key_view(key_data));
+                        auto token = schema.get_partitioner().get_token(key_view(key_data));
                         s.add_summary_data(token.data());
                         s.entries.push_back({ token, key_data, position });
                         return make_ready_future<>();
@@ -619,14 +619,14 @@ future<summary_entry&> sstable::read_summary_entry(size_t i) {
     return make_ready_future<summary_entry&>(_components->summary.entries[i]);
 }
 
-future<> parse(sstable_version_types v, random_access_reader& in, deletion_time& d) {
-    return parse(v, in, d.local_deletion_time, d.marked_for_delete_at);
+future<> parse(const schema& s, sstable_version_types v, random_access_reader& in, deletion_time& d) {
+    return parse(s, v, in, d.local_deletion_time, d.marked_for_delete_at);
 }
 
 template <typename Child>
-future<> parse(sstable_version_types v, random_access_reader& in, std::unique_ptr<metadata>& p) {
+future<> parse(const schema& s, sstable_version_types v, random_access_reader& in, std::unique_ptr<metadata>& p) {
     p.reset(new Child);
-    return parse(v, in, *static_cast<Child *>(p.get()));
+    return parse(s, v, in, *static_cast<Child *>(p.get()));
 }
 
 template <typename Child>
@@ -634,27 +634,27 @@ inline void write(sstable_version_types v, file_writer& out, const std::unique_p
     write(v, out, *static_cast<Child *>(p.get()));
 }
 
-future<> parse(sstable_version_types v, random_access_reader& in, statistics& s) {
-    return parse(v, in, s.offsets).then([v, &in, &s] {
+future<> parse(const schema& schema, sstable_version_types v, random_access_reader& in, statistics& s) {
+    return parse(schema, v, in, s.offsets).then([v, &schema, &in, &s] {
         // Old versions of Scylla do not respect the order.
         // See https://github.com/scylladb/scylla/issues/3937
         boost::sort(s.offsets.elements, [] (auto&& e1, auto&& e2) { return e1.first < e2.first; });
-        return do_for_each(s.offsets.elements.begin(), s.offsets.elements.end(), [v, &in, &s] (auto val) mutable {
+        return do_for_each(s.offsets.elements.begin(), s.offsets.elements.end(), [v, &schema, &in, &s] (auto val) mutable {
             in.seek(val.second);
 
             switch (val.first) {
                 case metadata_type::Validation:
-                    return parse<validation_metadata>(v, in, s.contents[val.first]);
+                    return parse<validation_metadata>(schema, v, in, s.contents[val.first]);
                 case metadata_type::Compaction:
-                    return parse<compaction_metadata>(v, in, s.contents[val.first]);
+                    return parse<compaction_metadata>(schema, v, in, s.contents[val.first]);
                 case metadata_type::Stats:
-                    return parse<stats_metadata>(v, in, s.contents[val.first]);
+                    return parse<stats_metadata>(schema, v, in, s.contents[val.first]);
                 case metadata_type::Serialization:
                     if (v != sstable_version_types::mc) {
                         throw std::runtime_error(
                             "Statistics is malformed: SSTable is in 2.x format but contains serialization header.");
                     } else {
-                        return parse<serialization_header>(v, in, s.contents[val.first]);
+                        return parse<serialization_header>(schema, v, in, s.contents[val.first]);
                     }
                     return make_ready_future<>();
                 default:
@@ -672,10 +672,10 @@ inline void write(sstable_version_types v, file_writer& out, const statistics& s
     }
 }
 
-future<> parse(sstable_version_types v, random_access_reader& in, utils::estimated_histogram& eh) {
+future<> parse(const schema& s, sstable_version_types v, random_access_reader& in, utils::estimated_histogram& eh) {
     auto len = std::make_unique<uint32_t>();
 
-    auto f = parse(v, in, *len);
+    auto f = parse(s, v, in, *len);
     return f.then([&in, &eh, len = std::move(len)] {
         uint32_t length = *len;
 
@@ -748,10 +748,10 @@ struct streaming_histogram_element {
     auto describe_type(sstable_version_types v, Describer f) { return f(key, value); }
 };
 
-future<> parse(sstable_version_types v, random_access_reader& in, utils::streaming_histogram& sh) {
+future<> parse(const schema& s, sstable_version_types v, random_access_reader& in, utils::streaming_histogram& sh) {
     auto a = std::make_unique<disk_array<uint32_t, streaming_histogram_element>>();
 
-    auto f = parse(v, in, sh.max_bin_size, *a);
+    auto f = parse(s, v, in, sh.max_bin_size, *a);
     return f.then([&sh, a = std::move(a)] {
         auto length = a->elements.size();
         if (length > sh.max_bin_size) {
@@ -789,9 +789,9 @@ void write(sstable_version_types v, file_writer& out, const utils::streaming_his
     write(v, out, max_bin_size, a);
 }
 
-future<> parse(sstable_version_types v, random_access_reader& in, commitlog_interval& ci) {
-    return parse(v, in, ci.start).then([&ci, v, &in] {
-        return parse(v, in, ci.end);
+future<> parse(const schema& s, sstable_version_types v, random_access_reader& in, commitlog_interval& ci) {
+    return parse(s, v, in, ci.start).then([&ci, v, &s, &in] {
+        return parse(s, v, in, ci.end);
     });
 }
 
@@ -800,16 +800,16 @@ void write(sstable_version_types v, file_writer& out, const commitlog_interval& 
     write(v, out, ci.end);
 }
 
-future<> parse(sstable_version_types v, random_access_reader& in, compression& c) {
+future<> parse(const schema& s, sstable_version_types v, random_access_reader& in, compression& c) {
     auto data_len_ptr = make_lw_shared<uint64_t>(0);
     auto chunk_len_ptr = make_lw_shared<uint32_t>(0);
 
-    return parse(v, in, c.name, c.options, *chunk_len_ptr, *data_len_ptr).then([v, &in, &c, chunk_len_ptr, data_len_ptr] {
+    return parse(s, v, in, c.name, c.options, *chunk_len_ptr, *data_len_ptr).then([v, &s, &in, &c, chunk_len_ptr, data_len_ptr] {
         c.set_uncompressed_chunk_length(*chunk_len_ptr);
         c.set_uncompressed_file_length(*data_len_ptr);
 
-      return do_with(uint32_t(), c.offsets.get_writer(), [v, &in, &c] (uint32_t& len, compression::segmented_offsets::writer& offsets) {
-        return parse(v, in, len).then([&in, &c, &len, &offsets] {
+      return do_with(uint32_t(), c.offsets.get_writer(), [v, &s, &in, &c] (uint32_t& len, compression::segmented_offsets::writer& offsets) {
+        return parse(s, v, in, len).then([&in, &c, &len, &offsets] {
             auto eoarr = [&c, &len] { return c.offsets.size() == len; };
 
             return do_until(eoarr, [&in, &c, &len, &offsets] () {
@@ -1043,7 +1043,7 @@ future<> sstable::read_simple(T& component, const io_priority_class& pc) {
         auto fut = fi.size();
         return fut.then([this, &component, fi = std::move(fi)] (uint64_t size) {
             auto r = make_lw_shared<file_random_access_reader>(std::move(fi), size, sstable_buffer_size);
-            auto fut = parse(_version, *r, component);
+            auto fut = parse(*_schema, _version, *r, component);
             return fut.finally([r] {
                 return r->close();
             }).then([r] {});
@@ -1134,12 +1134,12 @@ void sstable::validate_partitioner() {
     }
 
     validation_metadata& v = *static_cast<validation_metadata *>(p.get());
-    if (v.partitioner.value != to_bytes(dht::global_partitioner().name())) {
+    if (v.partitioner.value != to_bytes(_schema->get_partitioner().name())) {
         throw std::runtime_error(
                 fmt::format(FMT_STRING("SSTable {} uses {} partitioner which is different than {} partitioner used by the database"),
                             get_filename(),
                             sstring(reinterpret_cast<char*>(v.partitioner.value.data()), v.partitioner.value.size()),
-                            dht::global_partitioner().name()));
+                            _schema->get_partitioner().name()));
     }
 
 }
@@ -2190,7 +2190,7 @@ void components_writer::consume_end_of_stream() {
     }
 
     _sst.set_first_and_last_keys();
-    seal_statistics(_sst.get_version(), _sst._components->statistics, _sst._collector, dht::global_partitioner().name(), _schema.bloom_filter_fp_chance(),
+    seal_statistics(_sst.get_version(), _sst._components->statistics, _sst._collector, _schema.get_partitioner().name(), _schema.bloom_filter_fp_chance(),
             _sst._schema, _sst.get_first_decorated_key(), _sst.get_last_decorated_key());
 }
 
@@ -2488,19 +2488,20 @@ future<> sstable::generate_summary(const io_priority_class& pc) {
 
     sstlog.info("Summary file {} not found. Generating Summary...", filename(component_type::Summary));
     class summary_generator {
+        const dht::i_partitioner& _partitioner;
         summary& _summary;
         index_sampling_state _state;
     public:
         std::optional<key> first_key, last_key;
 
-        summary_generator(summary& s) : _summary(s) {
+        summary_generator(const dht::i_partitioner& p, summary& s) : _partitioner(p), _summary(s) {
             _state.summary_byte_cost = summary_byte_cost();
         }
         bool should_continue() {
             return true;
         }
         void consume_entry(index_entry&& ie, uint64_t index_offset) {
-            auto token = dht::global_partitioner().get_token(ie.get_key());
+            auto token = _partitioner.get_token(ie.get_key());
             maybe_add_summary_entry(_summary, token, ie.get_key_bytes(), ie.position(), index_offset, _state);
             if (!first_key) {
                 first_key = key(to_bytes(ie.get_key_bytes()));
@@ -2523,7 +2524,7 @@ future<> sstable::generate_summary(const io_priority_class& pc) {
                 file_input_stream_options options;
                 options.buffer_size = sstable_buffer_size;
                 options.io_priority_class = pc;
-                return do_with(summary_generator(_components->summary),
+                return do_with(summary_generator(_schema->get_partitioner(), _components->summary),
                         [this, &pc, options = std::move(options), index_file, index_size] (summary_generator& s) mutable {
                     auto ctx = make_lw_shared<index_consume_entry_context<summary_generator>>(
                             no_reader_permit(), s, trust_promoted_index::yes, *_schema, index_file, std::move(options), 0, index_size,

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -35,6 +35,7 @@
 #include <seastar/core/byteorder.hh>
 #include <iterator>
 
+#include "dht/sharder.hh"
 #include "types.hh"
 #include "mc/writer.hh"
 #include "writer.hh"

--- a/streaming/stream_session.cc
+++ b/streaming/stream_session.cc
@@ -214,7 +214,7 @@ void stream_session::init_messaging_service_handler() {
                         });
                     };
                     //FIXME: discarded future.
-                    (void)mutation_writer::distribute_reader_and_consume_on_shards(s, dht::global_partitioner(),
+                    (void)mutation_writer::distribute_reader_and_consume_on_shards(s,
                         make_generating_reader(s, std::move(get_next_mutation_fragment)),
                         [plan_id, estimated_partitions, reason] (flat_mutation_reader reader) {
                             auto& cf = get_local_db().find_column_family(reader.schema());

--- a/streaming/stream_transfer_task.cc
+++ b/streaming/stream_transfer_task.cc
@@ -111,7 +111,7 @@ struct send_info {
         return do_with(false, [this] (bool& found_relevant_range) {
             return do_for_each(ranges, [this, &found_relevant_range] (dht::token_range range) {
                 if (!found_relevant_range) {
-                    auto sharder = dht::selective_token_range_sharder(range, engine().cpu_id());
+                    auto sharder = dht::selective_token_range_sharder(cf.schema()->get_partitioner(), range, engine().cpu_id());
                     auto range_shard = sharder.next();
                     if (range_shard) {
                         found_relevant_range = true;

--- a/streaming/stream_transfer_task.cc
+++ b/streaming/stream_transfer_task.cc
@@ -49,6 +49,7 @@
 #include "message/messaging_service.hh"
 #include "range.hh"
 #include "dht/i_partitioner.hh"
+#include "dht/sharder.hh"
 #include "service/priority_manager.hh"
 #include <boost/range/irange.hpp>
 #include "service/storage_service.hh"

--- a/table.cc
+++ b/table.cc
@@ -53,11 +53,6 @@ using namespace std::chrono_literals;
 
 sstables::sstable::version_types get_highest_supported_format();
 
-static
-bool belongs_to_current_shard(const dht::decorated_key& dk) {
-    return dht::shard_of(dk.token()) == engine().cpu_id();
-}
-
 // Stores ranges for all components of the same clustering key, index 0 referring to component
 // range 0, and so on.
 using ck_filter_clustering_key_components = std::vector<nonwrapping_range<bytes_view>>;
@@ -350,7 +345,7 @@ table::make_sstable_reader(schema_ptr s,
     auto ms = [&] () -> mutation_source {
         if (pr.is_singular() && pr.start()->value().has_key()) {
             const dht::ring_position& pos = pr.start()->value();
-            if (dht::shard_of(pos.token()) != engine().cpu_id()) {
+            if (dht::shard_of(*s, pos.token()) != engine().cpu_id()) {
                 return mutation_source([] (
                         schema_ptr s,
                         reader_permit permit,
@@ -593,8 +588,10 @@ flat_mutation_reader make_local_shard_sstable_reader(schema_ptr s,
         flat_mutation_reader reader = sst->read_range_rows_flat(s, permit, pr, slice, pc,
                 trace_state, fwd, fwd_mr, monitor_generator(sst));
         if (sst->is_shared()) {
-            using sig = bool (&)(const dht::decorated_key&);
-            reader = make_filtering_reader(std::move(reader), sig(belongs_to_current_shard));
+            auto filter = [&s = *s](const dht::decorated_key& dk) -> bool {
+                return dht::shard_of(s, dk.token()) == engine().cpu_id();
+            };
+            reader = make_filtering_reader(std::move(reader), std::move(filter));
         }
         return reader;
     };

--- a/table.cc
+++ b/table.cc
@@ -411,7 +411,7 @@ table::find_partition(schema_ptr s, const dht::decorated_key& key) const {
 
 future<table::const_mutation_partition_ptr>
 table::find_partition_slow(schema_ptr s, const partition_key& key) const {
-    return find_partition(s, dht::global_partitioner().decorate_key(*s, key));
+    return find_partition(s, dht::decorate_key(*s, key));
 }
 
 future<table::const_row_ptr>
@@ -1453,7 +1453,7 @@ future<std::unordered_set<sstring>> table::get_sstables_by_partition_key(const s
     return do_with(std::unordered_set<sstring>(), lw_shared_ptr<sstables::sstable_set::incremental_selector>(make_lw_shared(get_sstable_set().make_incremental_selector())),
             partition_key(partition_key::from_nodetool_style_string(_schema, key)),
             [this] (std::unordered_set<sstring>& filenames, lw_shared_ptr<sstables::sstable_set::incremental_selector>& sel, partition_key& pk) {
-        return do_with(dht::decorated_key(dht::global_partitioner().decorate_key(*_schema, pk)),
+        return do_with(dht::decorated_key(dht::decorate_key(*_schema, pk)),
                 [this, &filenames, &sel, &pk](dht::decorated_key& dk) mutable {
             auto sst = sel->select(dk).sstables;
             auto hk = sstables::sstable::make_hashed_key(*_schema, dk.key());

--- a/table.cc
+++ b/table.cc
@@ -1322,8 +1322,8 @@ static bool needs_cleanup(const sstables::shared_sstable& sst,
                    schema_ptr s) {
     auto first = sst->get_first_partition_key();
     auto last = sst->get_last_partition_key();
-    auto first_token = dht::global_partitioner().get_token(*s, first);
-    auto last_token = dht::global_partitioner().get_token(*s, last);
+    auto first_token = dht::get_token(*s, first);
+    auto last_token = dht::get_token(*s, last);
     dht::token_range sst_token_range = dht::token_range::make(first_token, last_token);
 
     // return true iff sst partition range isn't fully contained in any of the owned ranges.

--- a/test/boost/cache_flat_mutation_reader_test.cc
+++ b/test/boost/cache_flat_mutation_reader_test.cc
@@ -61,7 +61,7 @@ static partition_key make_pk(int value) {
 
 static const thread_local partition_key PK = make_pk(0);
 static const thread_local dht::decorated_key DK =
-    dht::global_partitioner().decorate_key(*SCHEMA, PK);
+    dht::decorate_key(*SCHEMA, PK);
 
 static clustering_key make_ck(int value) {
     return clustering_key_prefix::from_single_value(*SCHEMA, int32_type->decompose(value));

--- a/test/boost/database_test.cc
+++ b/test/boost/database_test.cc
@@ -55,7 +55,7 @@ SEASTAR_TEST_CASE(test_safety_after_truncate) {
             auto pkey = partition_key::from_single_value(*s, to_bytes(sprint("key%d", i)));
             mutation m(s, pkey);
             m.set_clustered_cell(clustering_key_prefix::make_empty(), "v", int32_t(42), {});
-            pranges.emplace_back(dht::partition_range::make_singular(dht::global_partitioner().decorate_key(*s, std::move(pkey))));
+            pranges.emplace_back(dht::partition_range::make_singular(dht::decorate_key(*s, std::move(pkey))));
             db.apply(s, freeze(m), db::commitlog::force_sync::no).get();
         }
 
@@ -99,7 +99,7 @@ SEASTAR_TEST_CASE(test_querying_with_limits) {
                 mutation m(s, pkey);
                 m.set_clustered_cell(clustering_key_prefix::make_empty(), "v", int32_t(42), 1);
                 db.apply(s, freeze(m), db::commitlog::force_sync::no).get();
-                pranges.emplace_back(dht::partition_range::make_singular(dht::global_partitioner().decorate_key(*s, std::move(pkey))));
+                pranges.emplace_back(dht::partition_range::make_singular(dht::decorate_key(*s, std::move(pkey))));
             }
 
             auto max_size = std::numeric_limits<size_t>::max();

--- a/test/boost/multishard_mutation_query_test.cc
+++ b/test/boost/multishard_mutation_query_test.cc
@@ -97,7 +97,7 @@ SEASTAR_THREAD_TEST_CASE(test_abandoned_read) {
 }
 
 static std::vector<mutation> read_all_partitions_one_by_one(distributed<database>& db, schema_ptr s, std::vector<dht::decorated_key> pkeys) {
-    const auto& partitioner = dht::global_partitioner();
+    const auto& partitioner = s->get_partitioner();
     std::vector<mutation> results;
     results.reserve(pkeys.size());
 

--- a/test/boost/mutation_reader_test.cc
+++ b/test/boost/mutation_reader_test.cc
@@ -216,7 +216,7 @@ static mutation make_mutation_with_key(schema_ptr s, dht::decorated_key dk) {
 }
 
 static mutation make_mutation_with_key(schema_ptr s, const char* key) {
-    return make_mutation_with_key(s, dht::global_partitioner().decorate_key(*s, partition_key::from_single_value(*s, bytes(key))));
+    return make_mutation_with_key(s, dht::decorate_key(*s, partition_key::from_single_value(*s, bytes(key))));
 }
 
 SEASTAR_TEST_CASE(test_filtering) {
@@ -320,7 +320,7 @@ std::vector<dht::decorated_key> generate_keys(schema_ptr s, int count) {
     auto keys = boost::copy_range<std::vector<dht::decorated_key>>(
         boost::irange(0, count) | boost::adaptors::transformed([s] (int key) {
             auto pk = partition_key::from_single_value(*s, int32_type->decompose(data_value(key)));
-            return dht::global_partitioner().decorate_key(*s, std::move(pk));
+            return dht::decorate_key(*s, std::move(pk));
         }));
     return std::move(boost::range::sort(keys, dht::decorated_key::less_comparator(s)));
 }

--- a/test/boost/mutation_reader_test.cc
+++ b/test/boost/mutation_reader_test.cc
@@ -2089,7 +2089,7 @@ SEASTAR_THREAD_TEST_CASE(test_multishard_combining_reader_as_mutation_source) {
                     mutations_by_token[mut.token()].push_back(freeze(mut));
                 }
 
-                auto partitioner = make_lw_shared<dummy_partitioner>(dht::global_partitioner(), mutations_by_token);
+                auto partitioner = make_lw_shared<dummy_partitioner>(s->get_partitioner(), mutations_by_token);
 
                 auto merged_mutations = boost::copy_range<std::vector<std::vector<frozen_mutation>>>(mutations_by_token | boost::adaptors::map_values);
 
@@ -2179,7 +2179,7 @@ SEASTAR_THREAD_TEST_CASE(test_multishard_combining_reader_reading_empty_table) {
 
         assert_that(make_multishard_combining_reader(
                     seastar::make_shared<test_reader_lifecycle_policy>(std::move(factory)),
-                    dht::global_partitioner(),
+                    s.schema()->get_partitioner(),
                     s.schema(),
                     query::full_partition_range,
                     s.schema()->full_slice(),
@@ -2410,7 +2410,7 @@ SEASTAR_THREAD_TEST_CASE(test_multishard_combining_reader_destroyed_with_pending
             shard_pkeys[i++ % smp::count].push_back(pkey);
         }
 
-        auto partitioner = dummy_partitioner(dht::global_partitioner(), std::move(pkeys_by_tokens));
+        auto partitioner = dummy_partitioner(s.schema()->get_partitioner(), std::move(pkeys_by_tokens));
 
         auto factory = [gs = global_simple_schema(s), &remote_controls, &shard_pkeys] (
                 schema_ptr,
@@ -2468,7 +2468,7 @@ SEASTAR_THREAD_TEST_CASE(test_multishard_combining_reader_next_partition) {
         }
 
         auto schema = env.local_db().find_column_family("multishard_combining_reader_next_partition_ks", "test").schema();
-        auto& partitioner = dht::global_partitioner();
+        auto& partitioner = schema->get_partitioner();
 
         auto pkeys = boost::copy_range<std::vector<dht::decorated_key>>(
                 boost::irange(0, partition_count) |
@@ -2616,7 +2616,7 @@ SEASTAR_THREAD_TEST_CASE(test_multishard_combining_reader_non_strictly_monotonic
                 mutation_reader::forwarding fwd_mr) {
             auto s = gs.get();
             auto pkey = s.make_pkey(pk);
-            if (dht::global_partitioner().shard_of(pkey.token()) != engine().cpu_id()) {
+            if (s.schema()->get_partitioner().shard_of(pkey.token()) != engine().cpu_id()) {
                 return make_empty_flat_reader(s.schema());
             }
             auto fragments = make_fragments_with_non_monotonic_positions(s, std::move(pkey), max_buffer_size, tombstone_deletion_time);
@@ -2632,7 +2632,7 @@ SEASTAR_THREAD_TEST_CASE(test_multishard_combining_reader_non_strictly_monotonic
 
         assert_that(make_multishard_combining_reader(
                     seastar::make_shared<test_reader_lifecycle_policy>(std::move(factory), true),
-                    dht::global_partitioner(),
+                    s.schema()->get_partitioner(),
                     s.schema(),
                     query::full_partition_range,
                     s.schema()->full_slice(),
@@ -2672,7 +2672,7 @@ SEASTAR_THREAD_TEST_CASE(test_multishard_streaming_reader) {
         auto token_range = dht::token_range::make_open_ended_both_sides();
         auto partition_range = dht::to_partition_range(token_range);
 
-        auto& local_partitioner = dht::global_partitioner();
+        auto& local_partitioner = schema->get_partitioner();
         auto remote_partitioner_ptr = create_object<dht::i_partitioner, const unsigned&, const unsigned&>(local_partitioner.name(),
                 local_partitioner.shard_count() - 1, local_partitioner.sharding_ignore_msb());
         auto& remote_partitioner = *remote_partitioner_ptr;

--- a/test/boost/mutation_reader_test.cc
+++ b/test/boost/mutation_reader_test.cc
@@ -43,6 +43,7 @@
 #include "test/lib/cql_test_env.hh"
 #include "test/lib/make_random_string.hh"
 
+#include "dht/sharder.hh"
 #include "mutation_reader.hh"
 #include "schema_builder.hh"
 #include "cell_locking.hh"

--- a/test/boost/mutation_test.cc
+++ b/test/boost/mutation_test.cc
@@ -2942,10 +2942,9 @@ void run_compaction_data_stream_split_test(const schema& schema, gc_clock::time_
 } // anonymous namespace
 
 SEASTAR_THREAD_TEST_CASE(test_compaction_data_stream_split) {
-    auto& partitioner = dht::global_partitioner();
     auto spec = tests::make_random_schema_specification(get_name());
 
-    tests::random_schema random_schema(tests::random::get_int<uint32_t>(), *spec, partitioner);
+    tests::random_schema random_schema(tests::random::get_int<uint32_t>(), *spec);
     const auto& schema = *random_schema.schema();
 
     tlog.info("Random schema:\n{}", random_schema.cql());

--- a/test/boost/mutation_test.cc
+++ b/test/boost/mutation_test.cc
@@ -89,7 +89,7 @@ static atomic_cell make_collection_member(data_type dt, T value) {
 };
 
 static mutation_partition get_partition(memtable& mt, const partition_key& key) {
-    auto dk = dht::global_partitioner().decorate_key(*mt.schema(), key);
+    auto dk = dht::decorate_key(*mt.schema(), key);
     auto range = dht::partition_range::make_singular(dk);
     auto reader = mt.make_flat_reader(mt.schema(), range);
     auto mo = read_mutation_from_flat_mutation_reader(reader, db::no_timeout).get0();
@@ -515,7 +515,7 @@ SEASTAR_TEST_CASE(test_multiple_memtables_one_partition) {
         {
             auto verify_row = [&] (int32_t c1, int32_t r1) {
                 auto c_key = clustering_key::from_exploded(*s, {int32_type->decompose(c1)});
-                auto p_key = dht::global_partitioner().decorate_key(*s, key);
+                auto p_key = dht::decorate_key(*s, key);
                 auto r = cf.find_row(cf.schema(), p_key, c_key).get0();
                 {
                     BOOST_REQUIRE(r);
@@ -556,7 +556,7 @@ SEASTAR_TEST_CASE(test_flush_in_the_middle_of_a_scan) {
             // populate
             auto new_key = [&] {
                 static thread_local int next = 0;
-                return dht::global_partitioner().decorate_key(*s,
+                return dht::decorate_key(*s,
                     partition_key::from_single_value(*s, to_bytes(format("key{:d}", next++))));
             };
             auto make_mutation = [&] {
@@ -1765,7 +1765,7 @@ SEASTAR_TEST_CASE(test_collection_cell_diff) {
             {{"p", utf8_type}}, {}, {{"v", list_type_impl::get_instance(bytes_type, true)}}, {}, utf8_type));
 
         auto& col = s->column_at(column_kind::regular_column, 0);
-        auto k = dht::global_partitioner().decorate_key(*s, partition_key::from_single_value(*s, to_bytes("key")));
+        auto k = dht::decorate_key(*s, partition_key::from_single_value(*s, to_bytes("key")));
         mutation m1(s, k);
         auto uuid = utils::UUID_gen::get_time_UUID_bytes();
         collection_mutation_description mcol1;

--- a/test/boost/mutation_writer_test.cc
+++ b/test/boost/mutation_writer_test.cc
@@ -60,24 +60,25 @@ SEASTAR_TEST_CASE(test_multishard_writer) {
                 auto muts = gen(partition_nr);
                 std::vector<size_t> shards_before(smp::count, 0);
                 std::vector<size_t> shards_after(smp::count, 0);
+                schema_ptr s = gen.schema();
 
                 for (auto& m : muts) {
-                    auto shard = dht::global_partitioner().shard_of(m.token());
+                    auto shard = s->get_partitioner().shard_of(m.token());
                     shards_before[shard]++;
                 }
-                schema_ptr s = gen.schema();
                 auto source_reader = partition_nr > 0 ? flat_mutation_reader_from_mutations(muts) : make_empty_flat_reader(s);
+                auto& partitioner = s->get_partitioner();
                 size_t partitions_received = distribute_reader_and_consume_on_shards(s,
                     std::move(source_reader),
-                    [&shards_after, error] (flat_mutation_reader reader) mutable {
+                    [&partitioner, &shards_after, error] (flat_mutation_reader reader) mutable {
                         if (error) {
                             return make_exception_future<>(std::runtime_error("Failed to write"));
                         }
-                        return repeat([&shards_after, reader = std::move(reader), error] () mutable {
-                            return reader(db::no_timeout).then([&shards_after, error] (mutation_fragment_opt mf_opt) mutable {
+                        return repeat([&partitioner, &shards_after, reader = std::move(reader), error] () mutable {
+                            return reader(db::no_timeout).then([&partitioner, &shards_after, error] (mutation_fragment_opt mf_opt) mutable {
                                 if (mf_opt) {
                                     if (mf_opt->is_partition_start()) {
-                                        auto shard = dht::global_partitioner().shard_of(mf_opt->as_partition_start().key().token());
+                                        auto shard = partitioner.shard_of(mf_opt->as_partition_start().key().token());
                                         BOOST_REQUIRE_EQUAL(shard, engine().cpu_id());
                                         shards_after[shard]++;
                                     }

--- a/test/boost/mutation_writer_test.cc
+++ b/test/boost/mutation_writer_test.cc
@@ -237,7 +237,7 @@ SEASTAR_THREAD_TEST_CASE(test_timestamp_based_splitting_mutation_writer) {
             std::uniform_int_distribution<size_t>(2, 4),
             std::uniform_int_distribution<size_t>(2, 8),
             std::uniform_int_distribution<size_t>(2, 8));
-    auto random_schema = tests::random_schema{tests::random::get_int<uint32_t>(), *random_spec, dht::global_partitioner()};
+    auto random_schema = tests::random_schema{tests::random::get_int<uint32_t>(), *random_spec};
 
     tlog.info("Random schema:\n{}", random_schema.cql());
 

--- a/test/boost/mutation_writer_test.cc
+++ b/test/boost/mutation_writer_test.cc
@@ -68,7 +68,6 @@ SEASTAR_TEST_CASE(test_multishard_writer) {
                 schema_ptr s = gen.schema();
                 auto source_reader = partition_nr > 0 ? flat_mutation_reader_from_mutations(muts) : make_empty_flat_reader(s);
                 size_t partitions_received = distribute_reader_and_consume_on_shards(s,
-                    dht::global_partitioner(),
                     std::move(source_reader),
                     [&shards_after, error] (flat_mutation_reader reader) mutable {
                         if (error) {

--- a/test/boost/partitioner_test.cc
+++ b/test/boost/partitioner_test.cc
@@ -97,9 +97,9 @@ SEASTAR_THREAD_TEST_CASE(test_ring_position_is_comparable_with_decorated_key) {
         .build();
 
     std::vector<dht::decorated_key> keys = {
-        dht::global_partitioner().decorate_key(*s,
+        dht::decorate_key(*s,
             partition_key::from_single_value(*s, "key1")),
-        dht::global_partitioner().decorate_key(*s,
+        dht::decorate_key(*s,
             partition_key::from_single_value(*s, "key2")),
     };
 

--- a/test/boost/partitioner_test.cc
+++ b/test/boost/partitioner_test.cc
@@ -23,6 +23,7 @@
 #include <seastar/testing/thread_test_case.hh>
 
 #include "dht/i_partitioner.hh"
+#include "dht/sharder.hh"
 #include "dht/murmur3_partitioner.hh"
 #include "schema.hh"
 #include "types.hh"

--- a/test/boost/partitioner_test.cc
+++ b/test/boost/partitioner_test.cc
@@ -327,8 +327,6 @@ static
 void
 test_exponential_sharder(const dht::i_partitioner& part, const schema& s, const dht::partition_range& pr) {
 
-    dht::set_global_partitioner(part.name()); // so we can print tokens, also ring_position_comparator is not global_partitioner() clean
-
     // Step 1: run the exponential sharder fully, and collect all results
 
     debug("input range: %s\n", pr);
@@ -483,8 +481,6 @@ SEASTAR_THREAD_TEST_CASE(test_exponential_sharders) {
 static
 void
 do_test_split_range_to_single_shard(const dht::i_partitioner& part, const schema& s, const dht::partition_range& pr) {
-    dht::set_global_partitioner(part.name()); // so we can print tokens, also ring_position_comparator is not global_partitioner() clean
-
     for (auto shard : boost::irange(0u, part.shard_count())) {
         auto ranges = dht::split_range_to_single_shard(part, s, pr, shard).get0();
         auto sharder = dht::ring_position_range_sharder(part, pr);
@@ -588,7 +584,6 @@ test_something_with_some_interesting_ranges_and_partitioners_with_token_range(st
 static
 void
 do_test_selective_token_range_sharder(const dht::i_partitioner& part, const schema& s, const dht::token_range& range) {
-    dht::set_global_partitioner(part.name());
     bool debug = false;
     for (auto shard : boost::irange(0u, part.shard_count())) {
         auto sharder = dht::selective_token_range_sharder(part, range, shard);

--- a/test/boost/row_cache_test.cc
+++ b/test/boost/row_cache_test.cc
@@ -232,7 +232,7 @@ SEASTAR_TEST_CASE(test_cache_delegates_to_underlying_only_once_empty_full_range)
 
 dht::partition_range make_single_partition_range(schema_ptr& s, int pkey) {
     auto pk = partition_key::from_exploded(*s, { int32_type->decompose(pkey) });
-    auto dk = dht::global_partitioner().decorate_key(*s, pk);
+    auto dk = dht::decorate_key(*s, pk);
     return dht::partition_range::make_singular(dk);
 }
 
@@ -893,7 +893,7 @@ SEASTAR_TEST_CASE(test_eviction_from_invalidated) {
 
         std::vector<dht::decorated_key> keys;
         while (tracker.get_stats().partition_evictions == prev_evictions) {
-            auto dk = dht::global_partitioner().decorate_key(*gen.schema(), new_key(gen.schema()));
+            auto dk = dht::decorate_key(*gen.schema(), new_key(gen.schema()));
             auto m = mutation(gen.schema(), dk, make_fully_continuous(gen()).partition());
             keys.emplace_back(dk);
             cache.populate(m);
@@ -980,7 +980,7 @@ SEASTAR_TEST_CASE(test_single_partition_update) {
             .with_column("v", int32_type)
             .build();
         auto pk = partition_key::from_exploded(*s, { int32_type->decompose(100) });
-        auto dk = dht::global_partitioner().decorate_key(*s, pk);
+        auto dk = dht::decorate_key(*s, pk);
         auto range = dht::partition_range::make_singular(dk);
         auto make_ck = [&s] (int v) {
             return clustering_key_prefix::from_single_value(*s, int32_type->decompose(v));
@@ -1663,7 +1663,7 @@ SEASTAR_TEST_CASE(test_slicing_mutation_reader) {
             reader = cache.make_reader(s, query::full_partition_range, ps);
             test_sliced_read_row_presence(std::move(reader), s, expected);
 
-            auto dk = dht::global_partitioner().decorate_key(*s, pk);
+            auto dk = dht::decorate_key(*s, pk);
             auto singular_range = dht::partition_range::make_singular(dk);
 
             reader = cache.make_reader(s, singular_range, ps);
@@ -2893,7 +2893,7 @@ SEASTAR_TEST_CASE(test_continuity_population_with_multicolumn_clustering_key) {
         cache_tracker tracker;
         memtable_snapshot_source underlying(s);
 
-        auto pk = dht::global_partitioner().decorate_key(*s,
+        auto pk = dht::decorate_key(*s,
             partition_key::from_single_value(*s, serialized(3)));
         auto pr = dht::partition_range::make_singular(pk);
 

--- a/test/boost/sstable_3_x_test.cc
+++ b/test/boost/sstable_3_x_test.cc
@@ -186,7 +186,7 @@ SEASTAR_THREAD_TEST_CASE(test_uncompressed_filtering_and_forwarding_read) {
     auto to_key = [] (int key) {
         auto bytes = int32_type->decompose(int32_t(key));
         auto pk = partition_key::from_single_value(*UNCOMPRESSED_FILTERING_AND_FORWARDING_SCHEMA, bytes);
-        return dht::global_partitioner().decorate_key(*UNCOMPRESSED_FILTERING_AND_FORWARDING_SCHEMA, pk);
+        return dht::decorate_key(*UNCOMPRESSED_FILTERING_AND_FORWARDING_SCHEMA, pk);
     };
 
     auto to_ck = [] (int ck) {
@@ -433,7 +433,7 @@ SEASTAR_THREAD_TEST_CASE(test_uncompressed_skip_using_index_rows) {
     auto to_key = [] (int key) {
         auto bytes = int32_type->decompose(int32_t(key));
         auto pk = partition_key::from_single_value(*UNCOMPRESSED_SKIP_USING_INDEX_ROWS_SCHEMA, bytes);
-        return dht::global_partitioner().decorate_key(*UNCOMPRESSED_SKIP_USING_INDEX_ROWS_SCHEMA, pk);
+        return dht::decorate_key(*UNCOMPRESSED_SKIP_USING_INDEX_ROWS_SCHEMA, pk);
     };
 
     auto to_ck = [] (int ck) {
@@ -677,7 +677,7 @@ SEASTAR_THREAD_TEST_CASE(test_uncompressed_filtering_and_forwarding_range_tombst
     auto to_pkey = [] (int key) {
         auto bytes = int32_type->decompose(int32_t(key));
         auto pk = partition_key::from_single_value(*UNCOMPRESSED_FILTERING_AND_FORWARDING_RANGE_TOMBSTONES_SCHEMA, bytes);
-        return dht::global_partitioner().decorate_key(*UNCOMPRESSED_FILTERING_AND_FORWARDING_RANGE_TOMBSTONES_SCHEMA, pk);
+        return dht::decorate_key(*UNCOMPRESSED_FILTERING_AND_FORWARDING_RANGE_TOMBSTONES_SCHEMA, pk);
     };
     auto to_non_full_ck = [] (int ck) {
         return clustering_key_prefix::from_single_value(
@@ -1005,7 +1005,7 @@ SEASTAR_THREAD_TEST_CASE(test_uncompressed_slicing_interleaved_rows_and_rts_read
     auto to_pkey = [] (int key) {
         auto bytes = int32_type->decompose(int32_t(key));
         auto pk = partition_key::from_single_value(*UNCOMPRESSED_SLICING_INTERLEAVED_ROWS_AND_RTS_SCHEMA, bytes);
-        return dht::global_partitioner().decorate_key(*UNCOMPRESSED_SLICING_INTERLEAVED_ROWS_AND_RTS_SCHEMA, pk);
+        return dht::decorate_key(*UNCOMPRESSED_SLICING_INTERLEAVED_ROWS_AND_RTS_SCHEMA, pk);
     };
     auto to_non_full_ck = [] (int ck) {
         return clustering_key_prefix::from_single_value(
@@ -1207,7 +1207,7 @@ SEASTAR_THREAD_TEST_CASE(test_uncompressed_static_row_read) {
     auto to_key = [] (int key) {
         auto bytes = int32_type->decompose(int32_t(key));
         auto pk = partition_key::from_single_value(*UNCOMPRESSED_STATIC_ROW_SCHEMA, bytes);
-        return dht::global_partitioner().decorate_key(*UNCOMPRESSED_STATIC_ROW_SCHEMA, pk);
+        return dht::decorate_key(*UNCOMPRESSED_STATIC_ROW_SCHEMA, pk);
     };
 
     auto s_cdef = UNCOMPRESSED_STATIC_ROW_SCHEMA->get_column_definition(to_bytes("s"));
@@ -1331,7 +1331,7 @@ SEASTAR_THREAD_TEST_CASE(test_uncompressed_compound_static_row_read) {
     auto to_key = [] (int key) {
         auto bytes = int32_type->decompose(int32_t(key));
         auto pk = partition_key::from_single_value(*UNCOMPRESSED_COMPOUND_STATIC_ROW_SCHEMA, bytes);
-        return dht::global_partitioner().decorate_key(*UNCOMPRESSED_COMPOUND_STATIC_ROW_SCHEMA, pk);
+        return dht::decorate_key(*UNCOMPRESSED_COMPOUND_STATIC_ROW_SCHEMA, pk);
     };
 
     auto s_int_cdef = UNCOMPRESSED_COMPOUND_STATIC_ROW_SCHEMA->get_column_definition(to_bytes("s_int"));
@@ -1422,7 +1422,7 @@ SEASTAR_THREAD_TEST_CASE(test_uncompressed_partition_key_only_read) {
     auto to_key = [] (int key) {
         auto bytes = int32_type->decompose(int32_t(key));
         auto pk = partition_key::from_single_value(*UNCOMPRESSED_PARTITION_KEY_ONLY_SCHEMA, bytes);
-        return dht::global_partitioner().decorate_key(*UNCOMPRESSED_PARTITION_KEY_ONLY_SCHEMA, pk);
+        return dht::decorate_key(*UNCOMPRESSED_PARTITION_KEY_ONLY_SCHEMA, pk);
     };
     assert_that(sst.read_rows_flat())
         .produces_partition_start(to_key(5))
@@ -1474,7 +1474,7 @@ SEASTAR_THREAD_TEST_CASE(test_uncompressed_partition_key_with_value_read) {
     auto to_key = [] (int key) {
         auto bytes = int32_type->decompose(int32_t(key));
         auto pk = partition_key::from_single_value(*UNCOMPRESSED_PARTITION_KEY_WITH_VALUE_SCHEMA, bytes);
-        return dht::global_partitioner().decorate_key(*UNCOMPRESSED_PARTITION_KEY_WITH_VALUE_SCHEMA, pk);
+        return dht::decorate_key(*UNCOMPRESSED_PARTITION_KEY_WITH_VALUE_SCHEMA, pk);
     };
 
     auto cdef = UNCOMPRESSED_PARTITION_KEY_WITH_VALUE_SCHEMA->get_column_definition(to_bytes("val"));
@@ -1538,7 +1538,7 @@ SEASTAR_THREAD_TEST_CASE(test_uncompressed_counters_read) {
     auto to_key = [] (int key) {
         auto bytes = int32_type->decompose(int32_t(key));
         auto pk = partition_key::from_single_value(*UNCOMPRESSED_COUNTERS_SCHEMA, bytes);
-        return dht::global_partitioner().decorate_key(*UNCOMPRESSED_COUNTERS_SCHEMA, pk);
+        return dht::decorate_key(*UNCOMPRESSED_COUNTERS_SCHEMA, pk);
     };
 
     auto cdef = UNCOMPRESSED_COUNTERS_SCHEMA->get_column_definition(to_bytes("val"));
@@ -1704,7 +1704,7 @@ static void test_partition_key_with_values_of_different_types_read(const sstring
     auto to_key = [&s] (int key) {
         auto bytes = int32_type->decompose(int32_t(key));
         auto pk = partition_key::from_single_value(*s, bytes);
-        return dht::global_partitioner().decorate_key(*s, pk);
+        return dht::decorate_key(*s, pk);
     };
 
     assert_that(sst.read_rows_flat())
@@ -1808,7 +1808,7 @@ SEASTAR_THREAD_TEST_CASE(test_zstd_compression) {
     auto to_key = [] (int key) {
         auto bytes = int32_type->decompose(int32_t(key));
         auto pk = partition_key::from_single_value(*ZSTD_MULTIPLE_CHUNKS_SCHEMA, bytes);
-        return dht::global_partitioner().decorate_key(*ZSTD_MULTIPLE_CHUNKS_SCHEMA, pk);
+        return dht::decorate_key(*ZSTD_MULTIPLE_CHUNKS_SCHEMA, pk);
     };
 
     flat_reader_assertions assertions(sst.read_rows_flat());
@@ -1879,7 +1879,7 @@ SEASTAR_THREAD_TEST_CASE(test_uncompressed_subset_of_columns_read) {
     auto to_key = [] (int key) {
         auto bytes = int32_type->decompose(int32_t(key));
         auto pk = partition_key::from_single_value(*UNCOMPRESSED_SUBSET_OF_COLUMNS_SCHEMA, bytes);
-        return dht::global_partitioner().decorate_key(*UNCOMPRESSED_SUBSET_OF_COLUMNS_SCHEMA, pk);
+        return dht::decorate_key(*UNCOMPRESSED_SUBSET_OF_COLUMNS_SCHEMA, pk);
     };
 
     auto bool_cdef =
@@ -2105,7 +2105,7 @@ SEASTAR_THREAD_TEST_CASE(test_uncompressed_large_subset_of_columns_sparse_read) 
     auto to_key = [] (int key) {
         auto bytes = int32_type->decompose(int32_t(key));
         auto pk = partition_key::from_single_value(*UNCOMPRESSED_LARGE_SUBSET_OF_COLUMNS_SPARSE_SCHEMA, bytes);
-        return dht::global_partitioner().decorate_key(*UNCOMPRESSED_LARGE_SUBSET_OF_COLUMNS_SPARSE_SCHEMA, pk);
+        return dht::decorate_key(*UNCOMPRESSED_LARGE_SUBSET_OF_COLUMNS_SPARSE_SCHEMA, pk);
     };
 
     std::vector<const column_definition*> column_defs(64);
@@ -2317,7 +2317,7 @@ SEASTAR_THREAD_TEST_CASE(test_uncompressed_large_subset_of_columns_dense_read) {
     auto to_key = [] (int key) {
         auto bytes = int32_type->decompose(int32_t(key));
         auto pk = partition_key::from_single_value(*UNCOMPRESSED_LARGE_SUBSET_OF_COLUMNS_DENSE_SCHEMA, bytes);
-        return dht::global_partitioner().decorate_key(*UNCOMPRESSED_LARGE_SUBSET_OF_COLUMNS_DENSE_SCHEMA, pk);
+        return dht::decorate_key(*UNCOMPRESSED_LARGE_SUBSET_OF_COLUMNS_DENSE_SCHEMA, pk);
     };
 
     std::vector<const column_definition*> column_defs(64);
@@ -2419,7 +2419,7 @@ SEASTAR_THREAD_TEST_CASE(test_uncompressed_deleted_cells_read) {
     auto to_key = [] (int key) {
         auto bytes = int32_type->decompose(int32_t(key));
         auto pk = partition_key::from_single_value(*UNCOMPRESSED_DELETED_CELLS_SCHEMA, bytes);
-        return dht::global_partitioner().decorate_key(*UNCOMPRESSED_DELETED_CELLS_SCHEMA, pk);
+        return dht::decorate_key(*UNCOMPRESSED_DELETED_CELLS_SCHEMA, pk);
     };
 
     auto int_cdef =
@@ -2502,7 +2502,7 @@ SEASTAR_THREAD_TEST_CASE(test_uncompressed_range_tombstones_simple_read) {
     auto to_key = [] (int key) {
         auto bytes = int32_type->decompose(int32_t(key));
         auto pk = partition_key::from_single_value(*UNCOMPRESSED_RANGE_TOMBSTONES_SIMPLE_SCHEMA, bytes);
-        return dht::global_partitioner().decorate_key(*UNCOMPRESSED_RANGE_TOMBSTONES_SIMPLE_SCHEMA, pk);
+        return dht::decorate_key(*UNCOMPRESSED_RANGE_TOMBSTONES_SIMPLE_SCHEMA, pk);
     };
 
     auto to_ck = [] (int ck) {
@@ -2573,7 +2573,7 @@ SEASTAR_THREAD_TEST_CASE(test_uncompressed_range_tombstones_partial_read) {
     auto to_key = [] (int key) {
         auto bytes = int32_type->decompose(int32_t(key));
         auto pk = partition_key::from_single_value(*UNCOMPRESSED_RANGE_TOMBSTONES_PARTIAL_SCHEMA, bytes);
-        return dht::global_partitioner().decorate_key(*UNCOMPRESSED_RANGE_TOMBSTONES_PARTIAL_SCHEMA, pk);
+        return dht::decorate_key(*UNCOMPRESSED_RANGE_TOMBSTONES_PARTIAL_SCHEMA, pk);
     };
 
     auto to_ck = [] (int ck) {
@@ -2695,7 +2695,7 @@ SEASTAR_THREAD_TEST_CASE(test_uncompressed_simple_read) {
     auto to_key = [] (int key) {
         auto bytes = int32_type->decompose(int32_t(key));
         auto pk = partition_key::from_single_value(*UNCOMPRESSED_SIMPLE_SCHEMA, bytes);
-        return dht::global_partitioner().decorate_key(*UNCOMPRESSED_SIMPLE_SCHEMA, pk);
+        return dht::decorate_key(*UNCOMPRESSED_SIMPLE_SCHEMA, pk);
     };
 
     auto int_cdef =
@@ -2777,7 +2777,7 @@ SEASTAR_THREAD_TEST_CASE(test_uncompressed_compound_ck_read) {
     auto to_key = [] (int key) {
         auto bytes = int32_type->decompose(int32_t(key));
         auto pk = partition_key::from_single_value(*UNCOMPRESSED_COMPOUND_CK_SCHEMA, bytes);
-        return dht::global_partitioner().decorate_key(*UNCOMPRESSED_COMPOUND_CK_SCHEMA, pk);
+        return dht::decorate_key(*UNCOMPRESSED_COMPOUND_CK_SCHEMA, pk);
     };
 
     auto int_cdef =
@@ -2871,7 +2871,7 @@ SEASTAR_THREAD_TEST_CASE(test_uncompressed_collections_read) {
     auto to_key = [] (int key) {
         auto bytes = int32_type->decompose(int32_t(key));
         auto pk = partition_key::from_single_value(*UNCOMPRESSED_COLLECTIONS_SCHEMA, bytes);
-        return dht::global_partitioner().decorate_key(*UNCOMPRESSED_COLLECTIONS_SCHEMA, pk);
+        return dht::decorate_key(*UNCOMPRESSED_COLLECTIONS_SCHEMA, pk);
     };
 
     auto set_cdef = UNCOMPRESSED_COLLECTIONS_SCHEMA->get_column_definition(to_bytes("set_val"));
@@ -4657,7 +4657,7 @@ SEASTAR_THREAD_TEST_CASE(test_read_table_empty_clustering_key) {
     std::vector<dht::decorated_key> keys;
     for (int i = 0; i < 10; i++) {
         auto pk = partition_key::from_single_value(*s, int32_type->decompose(i));
-        keys.emplace_back(dht::global_partitioner().decorate_key(*s, std::move(pk)));
+        keys.emplace_back(dht::decorate_key(*s, std::move(pk)));
     }
     dht::decorated_key::less_comparator cmp(s);
     std::sort(keys.begin(), keys.end(), cmp);
@@ -4691,7 +4691,7 @@ SEASTAR_THREAD_TEST_CASE(test_complex_column_zero_subcolumns_read) {
     auto to_pkey = [&s] (const UUID& key) {
         auto bytes = uuid_type->decompose(key);
         auto pk = partition_key::from_single_value(*s, bytes);
-        return dht::global_partitioner().decorate_key(*s, pk);
+        return dht::decorate_key(*s, pk);
     };
 
     std::vector<UUID> keys {
@@ -4738,7 +4738,7 @@ SEASTAR_THREAD_TEST_CASE(test_uncompressed_read_two_rows_fast_forwarding) {
     auto to_pkey = [&] (int key) {
         auto bytes = int32_type->decompose(int32_t(key));
         auto pk = partition_key::from_single_value(*s, bytes);
-        return dht::global_partitioner().decorate_key(*s, pk);
+        return dht::decorate_key(*s, pk);
     };
 
     auto to_ckey = [&] (int key) {
@@ -5079,7 +5079,7 @@ SEASTAR_THREAD_TEST_CASE(test_sstable_reader_on_unknown_column) {
     };
     auto bytes = int32_type->decompose(int32_t(0));
     auto pk = partition_key::from_single_value(*write_schema, bytes);
-    auto dk = dht::global_partitioner().decorate_key(*write_schema, pk);
+    auto dk = dht::decorate_key(*write_schema, pk);
     mutation partition(write_schema, pk);
     for (int i = 0; i < 3; ++i) {
         clustering_key ckey = to_ck(i);

--- a/test/boost/sstable_datafile_test.cc
+++ b/test/boost/sstable_datafile_test.cc
@@ -2706,7 +2706,7 @@ SEASTAR_TEST_CASE(test_wrong_range_tombstone_order) {
             .build();
         clustering_key::equality ck_eq(*s);
         auto pkey = partition_key::from_exploded(*s, { int32_type->decompose(0) });
-        auto dkey = dht::global_partitioner().decorate_key(*s, std::move(pkey));
+        auto dkey = dht::decorate_key(*s, std::move(pkey));
 
         auto sst = env.make_sstable(s, get_test_dir("wrong_range_tombstone_order", s), 1, version, big);
         sst->load().get0();
@@ -3304,7 +3304,7 @@ SEASTAR_TEST_CASE(test_promoted_index_read) {
         sst->load().get0();
 
         auto pkey = partition_key::from_exploded(*s, { int32_type->decompose(0) });
-        auto dkey = dht::global_partitioner().decorate_key(*s, std::move(pkey));
+        auto dkey = dht::decorate_key(*s, std::move(pkey));
 
         auto rd = make_normalizing_sstable_reader(sst, s);
         using kind = mutation_fragment::kind;
@@ -3587,7 +3587,7 @@ SEASTAR_TEST_CASE(test_partition_skipping) {
         std::vector<dht::decorated_key> keys;
         for (int i = 0; i < 10; i++) {
             auto pk = partition_key::from_single_value(*s, int32_type->decompose(i));
-            keys.emplace_back(dht::global_partitioner().decorate_key(*s, std::move(pk)));
+            keys.emplace_back(dht::decorate_key(*s, std::move(pk)));
         }
         dht::decorated_key::less_comparator cmp(s);
         std::sort(keys.begin(), keys.end(), cmp);
@@ -3887,7 +3887,7 @@ SEASTAR_TEST_CASE(sstable_set_incremental_selector) {
             key_and_token_pair | boost::adaptors::transformed([&s] (const std::pair<sstring, dht::token>& key_and_token) {
                 auto value = bytes(reinterpret_cast<const signed char*>(key_and_token.first.data()), key_and_token.first.size());
                 auto pk = sstables::key::from_bytes(value).to_partition_key(*s);
-                return dht::global_partitioner().decorate_key(*s, std::move(pk));
+                return dht::decorate_key(*s, std::move(pk));
             }));
 
     auto check = [] (sstable_set::incremental_selector& selector, const dht::decorated_key& key, std::unordered_set<int64_t> expected_gens) {
@@ -4525,7 +4525,7 @@ SEASTAR_TEST_CASE(test_old_format_non_compound_range_tombstone_is_read) {
                 sst->load().get0();
 
                 auto pk = partition_key::from_exploded(*s, { int32_type->decompose(1) });
-                auto dk = dht::global_partitioner().decorate_key(*s, pk);
+                auto dk = dht::decorate_key(*s, pk);
                 auto ck = clustering_key::from_exploded(*s, {int32_type->decompose(2)});
                 mutation m(s, dk);
                 m.set_clustered_cell(ck, *s->get_column_definition("v"), atomic_cell::make_live(*int32_type, 1511270919978349, int32_type->decompose(1), { }));
@@ -4934,7 +4934,7 @@ SEASTAR_TEST_CASE(test_reads_cassandra_static_compact) {
         sst->load().get0();
 
         auto pkey = partition_key::from_exploded(*s, { utf8_type->decompose("a") });
-        auto dkey = dht::global_partitioner().decorate_key(*s, std::move(pkey));
+        auto dkey = dht::decorate_key(*s, std::move(pkey));
         mutation m(s, dkey);
         m.set_clustered_cell(clustering_key::make_empty(), *s->get_column_definition("c1"),
                     atomic_cell::make_live(*utf8_type, 1551785032379079, utf8_type->decompose("abc"), {}));

--- a/test/boost/sstable_datafile_test.cc
+++ b/test/boost/sstable_datafile_test.cc
@@ -1719,11 +1719,12 @@ static std::vector<std::pair<sstring, dht::token>> token_generation_for_shard(un
 
     key_and_token_pair.reserve(tokens_to_generate);
     dht::default_partitioner = std::make_unique<dht::murmur3_partitioner>(smp_count, ignore_msb);
+    dht::murmur3_partitioner partitioner(smp_count, ignore_msb);
 
     while (tokens < tokens_to_generate) {
         sstring key = to_sstring(key_id++);
         dht::token token = create_token_from_key(key);
-        if (shard != dht::global_partitioner().shard_of(token)) {
+        if (shard != partitioner.shard_of(token)) {
             continue;
         }
         tokens++;

--- a/test/boost/sstable_mutation_test.cc
+++ b/test/boost/sstable_mutation_test.cc
@@ -380,7 +380,7 @@ SEASTAR_THREAD_TEST_CASE(read_partial_range) {
     auto wait_bg = seastar::defer([] { sstables::await_background_jobs().get(); });
     std::vector<bytes> expected = { to_bytes("finna"), to_bytes("isak") };
     do_with(sstables::test_env(), std::move(expected), [] (auto& env, auto& expected) {
-        return test_range_reads(env, dht::global_partitioner().get_token(key_view(bytes_view(expected.back()))), dht::maximum_token(), expected);
+        return test_range_reads(env, uncompressed_schema()->get_partitioner().get_token(key_view(bytes_view(expected.back()))), dht::maximum_token(), expected);
     }).get();
 }
 
@@ -388,7 +388,7 @@ SEASTAR_THREAD_TEST_CASE(read_partial_range_2) {
     auto wait_bg = seastar::defer([] { sstables::await_background_jobs().get(); });
     std::vector<bytes> expected = { to_bytes("gustaf"), to_bytes("vinna") };
     do_with(sstables::test_env(), std::move(expected), [] (auto& env, auto& expected) {
-        return test_range_reads(env, dht::minimum_token(), dht::global_partitioner().get_token(key_view(bytes_view(expected.front()))), expected);
+        return test_range_reads(env, dht::minimum_token(), uncompressed_schema()->get_partitioner().get_token(key_view(bytes_view(expected.front()))), expected);
     }).get();
 }
 

--- a/test/boost/sstable_resharding_test.cc
+++ b/test/boost/sstable_resharding_test.cc
@@ -12,6 +12,7 @@
 #include <seastar/testing/test_case.hh>
 #include "schema.hh"
 #include "database.hh"
+#include "dht/murmur3_partitioner.hh"
 #include "sstables/compaction_manager.hh"
 #include "mutation_reader.hh"
 #include "test/boost/sstable_test.hh"
@@ -30,12 +31,12 @@ static inline std::vector<std::pair<sstring, dht::token>> token_generation_for_s
     std::vector<std::pair<sstring, dht::token>> key_and_token_pair;
 
     key_and_token_pair.reserve(tokens_to_generate);
-    dht::set_global_partitioner(to_sstring("org.apache.cassandra.dht.Murmur3Partitioner"));
+    dht::murmur3_partitioner partitioner(smp::count, 12);
 
     while (tokens < tokens_to_generate) {
         sstring key = to_sstring(key_id++);
         dht::token token = create_token_from_key(key);
-        if (shard != dht::global_partitioner().shard_of(token)) {
+        if (shard != partitioner.shard_of(token)) {
             continue;
         }
         tokens++;

--- a/test/boost/sstable_resharding_test.cc
+++ b/test/boost/sstable_resharding_test.cc
@@ -35,7 +35,7 @@ static inline std::vector<std::pair<sstring, dht::token>> token_generation_for_s
 
     while (tokens < tokens_to_generate) {
         sstring key = to_sstring(key_id++);
-        dht::token token = create_token_from_key(key);
+        dht::token token = create_token_from_key(partitioner, key);
         if (shard != partitioner.shard_of(token)) {
             continue;
         }

--- a/test/boost/sstable_test.cc
+++ b/test/boost/sstable_test.cc
@@ -721,7 +721,7 @@ SEASTAR_TEST_CASE(find_key_map) {
         kk.push_back(make_map_value(map_type, map));
 
         auto key = sstables::key::from_deeply_exploded(*s, kk);
-        BOOST_REQUIRE(sstables::test(sstp).binary_search(summary.entries, key) == 0);
+        BOOST_REQUIRE(sstables::test(sstp).binary_search(s->get_partitioner(), summary.entries, key) == 0);
         return make_ready_future<>();
     });
 }
@@ -743,7 +743,7 @@ SEASTAR_TEST_CASE(find_key_set) {
         kk.push_back(make_set_value(set_type, set));
 
         auto key = sstables::key::from_deeply_exploded(*s, kk);
-        BOOST_REQUIRE(sstables::test(sstp).binary_search(summary.entries, key) == 0);
+        BOOST_REQUIRE(sstables::test(sstp).binary_search(s->get_partitioner(), summary.entries, key) == 0);
         return make_ready_future<>();
     });
 }
@@ -765,7 +765,7 @@ SEASTAR_TEST_CASE(find_key_list) {
         kk.push_back(make_list_value(list_type, list));
 
         auto key = sstables::key::from_deeply_exploded(*s, kk);
-        BOOST_REQUIRE(sstables::test(sstp).binary_search(summary.entries, key) == 0);
+        BOOST_REQUIRE(sstables::test(sstp).binary_search(s->get_partitioner(), summary.entries, key) == 0);
         return make_ready_future<>();
     });
 }
@@ -784,7 +784,7 @@ SEASTAR_TEST_CASE(find_key_composite) {
         kk.push_back(data_value(b2));
 
         auto key = sstables::key::from_deeply_exploded(*s, kk);
-        BOOST_REQUIRE(sstables::test(sstp).binary_search(summary.entries, key) == 0);
+        BOOST_REQUIRE(sstables::test(sstp).binary_search(s->get_partitioner(), summary.entries, key) == 0);
         return make_ready_future<>();
     });
 }
@@ -796,7 +796,7 @@ SEASTAR_TEST_CASE(all_in_place) {
         int idx = 0;
         for (auto& e: summary.entries) {
             auto key = sstables::key::from_bytes(bytes(e.key));
-            BOOST_REQUIRE(sstables::test(sstp).binary_search(summary.entries, key) == idx++);
+            BOOST_REQUIRE(sstables::test(sstp).binary_search(sstp->get_schema()->get_partitioner(), summary.entries, key) == idx++);
         }
         return make_ready_future<>();
     });
@@ -808,7 +808,7 @@ SEASTAR_TEST_CASE(full_index_search) {
             int idx = 0;
             for (auto& ie: index_list) {
                 auto key = key::from_bytes(to_bytes(ie.get_key_bytes()));
-                BOOST_REQUIRE(sstables::test(sstp).binary_search(index_list, key) == idx++);
+                BOOST_REQUIRE(sstables::test(sstp).binary_search(sstp->get_schema()->get_partitioner(), index_list, key) == idx++);
             }
         });
     });
@@ -828,7 +828,7 @@ SEASTAR_TEST_CASE(not_find_key_composite_bucket0) {
 
         auto key = sstables::key::from_deeply_exploded(*s, kk);
         // (result + 1) * -1 -1 = 0
-        BOOST_REQUIRE(sstables::test(sstp).binary_search(summary.entries, key) == -2);
+        BOOST_REQUIRE(sstables::test(sstp).binary_search(s->get_partitioner(), summary.entries, key) == -2);
         return make_ready_future<>();
     });
 }

--- a/test/boost/sstable_test.hh
+++ b/test/boost/sstable_test.hh
@@ -142,8 +142,8 @@ public:
     }
 
     template <typename T>
-    int binary_search(const T& entries, const key& sk) {
-        return sstables::binary_search(entries, sk);
+    int binary_search(dht::i_partitioner& p, const T& entries, const key& sk) {
+        return sstables::binary_search(p, entries, sk);
     }
 
     void change_generation_number(int64_t generation) {

--- a/test/boost/sstable_test.hh
+++ b/test/boost/sstable_test.hh
@@ -716,5 +716,5 @@ inline
 inline dht::decorated_key make_dkey(schema_ptr s, bytes b)
 {
     auto sst_key = sstables::key::from_bytes(b);
-    return dht::global_partitioner().decorate_key(*s, sst_key.to_partition_key(*s));
+    return dht::decorate_key(*s, sst_key.to_partition_key(*s));
 }

--- a/test/boost/storage_proxy_test.cc
+++ b/test/boost/storage_proxy_test.cc
@@ -37,7 +37,7 @@ static std::vector<dht::ring_position> make_ring(schema_ptr s, int n_keys) {
     std::vector<dht::ring_position> ring;
     for (int i = 0; i < 10; ++i) {
         auto pk = partition_key::from_single_value(*s, to_bytes(format("key{:d}", i)));
-        ring.emplace_back(dht::global_partitioner().decorate_key(*s, pk));
+        ring.emplace_back(dht::decorate_key(*s, pk));
     }
     std::sort(ring.begin(), ring.end(), dht::ring_position_less_comparator(*s));
     return ring;

--- a/test/boost/test_table.cc
+++ b/test/boost/test_table.cc
@@ -377,7 +377,7 @@ static partition_generation_result generate_partitions(
     const auto part_count = pop_gen.partition_count();
     for (size_t i = 0; i < part_count; ++i) {
         auto part_gen = pop_gen.make_partition_content_generator();
-        partition_description part_desc(dht::global_partitioner().decorate_key(schema, part_gen->generate_partition_key(schema)));
+        partition_description part_desc(dht::decorate_key(schema, part_gen->generate_partition_key(schema)));
         written_bytes += part_desc.dkey.key().external_memory_usage();
 
         {

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -259,7 +259,7 @@ public:
         auto pkey = partition_key::from_deeply_exploded(*schema, pk);
         auto ckey = clustering_key::from_deeply_exploded(*schema, ck);
         auto exp = expected.type()->decompose(expected);
-        auto dk = dht::global_partitioner().decorate_key(*schema, pkey);
+        auto dk = dht::decorate_key(*schema, pkey);
         auto shard = dht::shard_of(*schema, dk._token);
         return _db->invoke_on(shard, [pkey = std::move(pkey),
                                       ckey = std::move(ckey),

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -260,7 +260,7 @@ public:
         auto ckey = clustering_key::from_deeply_exploded(*schema, ck);
         auto exp = expected.type()->decompose(expected);
         auto dk = dht::global_partitioner().decorate_key(*schema, pkey);
-        auto shard = db.shard_of(dk._token);
+        auto shard = dht::shard_of(*schema, dk._token);
         return _db->invoke_on(shard, [pkey = std::move(pkey),
                                       ckey = std::move(ckey),
                                       ks_name = std::move(ks_name),

--- a/test/lib/mutation_source_test.cc
+++ b/test/lib/mutation_source_test.cc
@@ -1050,7 +1050,7 @@ static void test_clustering_slices(populate_fn_ex populate) {
     };
 
     auto make_pk = [&] (sstring key) {
-        return dht::global_partitioner().decorate_key(*s, partition_key::from_single_value(*s, to_bytes(key)));
+        return dht::decorate_key(*s, partition_key::from_single_value(*s, to_bytes(key)));
     };
 
     auto partition_count = 3;
@@ -1959,7 +1959,7 @@ public:
         auto local_keys = _local_shard_only ? make_local_keys(n, _schema) : make_keys(n, _schema);
         return boost::copy_range<std::vector<dht::decorated_key>>(local_keys | boost::adaptors::transformed([this] (sstring& key) {
             auto pkey = partition_key::from_single_value(*_schema, to_bytes(key));
-            return dht::global_partitioner().decorate_key(*_schema, std::move(pkey));
+            return dht::decorate_key(*_schema, std::move(pkey));
         }));
     }
 

--- a/test/lib/random_schema.cc
+++ b/test/lib/random_schema.cc
@@ -933,9 +933,8 @@ data_model::mutation_description::key random_schema::make_clustering_key(uint32_
     return make_key(n, gen, _schema->clustering_key_columns(), std::numeric_limits<clustering_key::compound::element_type::size_type>::max());
 }
 
-random_schema::random_schema(uint32_t seed, random_schema_specification& spec, dht::i_partitioner& partitioner)
-    : _schema(build_random_schema(seed, spec))
-    , _partitioner(partitioner) {
+random_schema::random_schema(uint32_t seed, random_schema_specification& spec)
+    : _schema(build_random_schema(seed, spec)) {
 }
 
 sstring random_schema::cql() const {
@@ -981,7 +980,7 @@ std::vector<data_model::mutation_description::key> random_schema::make_pkeys(siz
 
     uint32_t i{0};
     while (keys.size() < n) {
-        keys.emplace(_partitioner.decorate_key(*_schema, partition_key::from_exploded(make_partition_key(i, val_gen))));
+        keys.emplace(dht::decorate_key(*_schema, partition_key::from_exploded(make_partition_key(i, val_gen))));
         ++i;
     }
 

--- a/test/lib/random_schema.hh
+++ b/test/lib/random_schema.hh
@@ -162,7 +162,6 @@ expiry_generator no_expiry_expiry_generator();
 /// The generation is deterministic, the same seed will generate the same schema.
 class random_schema {
     schema_ptr _schema;
-    dht::i_partitioner& _partitioner;
 
 private:
     static data_model::mutation_description::key make_key(uint32_t n, value_generator& gen, schema::const_iterator_range_type columns,
@@ -176,7 +175,7 @@ public:
     /// Passing the same seed and spec will yield the same schema. Part of this
     /// guarantee rests on the spec, which, if a custom one is used, should
     /// make sure to honor this guarantee.
-    random_schema(uint32_t seed, random_schema_specification& spec, dht::i_partitioner& partitioner);
+    random_schema(uint32_t seed, random_schema_specification& spec);
 
     schema_ptr schema() const {
         return _schema;

--- a/test/lib/simple_schema.hh
+++ b/test/lib/simple_schema.hh
@@ -102,7 +102,7 @@ public:
 
     dht::decorated_key make_pkey(sstring pk) {
         auto key = partition_key::from_single_value(*_s, serialized(pk));
-        return dht::global_partitioner().decorate_key(*_s, key);
+        return dht::decorate_key(*_s, key);
     }
 
     api::timestamp_type add_row(mutation& m, const clustering_key& key, const sstring& v, api::timestamp_type t = api::missing_timestamp) {

--- a/test/lib/sstable_utils.hh
+++ b/test/lib/sstable_utils.hh
@@ -51,7 +51,7 @@ static std::vector<sstring> do_make_keys(unsigned n, const schema_ptr& s, size_t
         auto dk = dht::decorate_key(*s, partition_key::from_single_value(*s, to_bytes(raw_key)));
         key_id++;
         if (lso) {
-            if (engine_is_ready() && engine().cpu_id() != dht::global_partitioner().shard_of(dk.token())) {
+            if (engine_is_ready() && engine().cpu_id() != shard_of(*s, dk.token())) {
                 continue;
             }
         }

--- a/test/lib/sstable_utils.hh
+++ b/test/lib/sstable_utils.hh
@@ -48,7 +48,7 @@ static std::vector<sstring> do_make_keys(unsigned n, const schema_ptr& s, size_t
     while (generated < n) {
         auto raw_key = sstring(std::max(min_key_size, sizeof(key_id)), int8_t(0));
         std::copy_n(reinterpret_cast<int8_t*>(&key_id), sizeof(key_id), raw_key.begin());
-        auto dk = dht::global_partitioner().decorate_key(*s, partition_key::from_single_value(*s, to_bytes(raw_key)));
+        auto dk = dht::decorate_key(*s, partition_key::from_single_value(*s, to_bytes(raw_key)));
         key_id++;
         if (lso) {
             if (engine_is_ready() && engine().cpu_id() != dht::global_partitioner().shard_of(dk.token())) {

--- a/test/lib/test_services.cc
+++ b/test/lib/test_services.cc
@@ -84,18 +84,18 @@ storage_service_for_tests::storage_service_for_tests() : _impl(std::make_unique<
 
 storage_service_for_tests::~storage_service_for_tests() = default;
 
-dht::token create_token_from_key(sstring key) {
+dht::token create_token_from_key(dht::i_partitioner& partitioner, sstring key) {
     sstables::key_view key_view = sstables::key_view(bytes_view(reinterpret_cast<const signed char*>(key.c_str()), key.size()));
-    dht::token token = dht::global_partitioner().get_token(key_view);
-    assert(token == dht::global_partitioner().get_token(key_view));
+    dht::token token = partitioner.get_token(key_view);
+    assert(token == partitioner.get_token(key_view));
     return token;
 }
 
-range<dht::token> create_token_range_from_keys(sstring start_key, sstring end_key) {
-    dht::token start = create_token_from_key(start_key);
-    assert(engine().cpu_id() == dht::global_partitioner().shard_of(start));
-    dht::token end = create_token_from_key(end_key);
-    assert(engine().cpu_id() == dht::global_partitioner().shard_of(end));
+range<dht::token> create_token_range_from_keys(dht::i_partitioner& partitioner, sstring start_key, sstring end_key) {
+    dht::token start = create_token_from_key(partitioner, start_key);
+    assert(engine().cpu_id() == partitioner.shard_of(start));
+    dht::token end = create_token_from_key(partitioner, end_key);
+    assert(engine().cpu_id() == partitioner.shard_of(end));
     assert(end >= start);
     return range<dht::token>::make(start, end);
 }

--- a/test/lib/test_services.hh
+++ b/test/lib/test_services.hh
@@ -70,5 +70,5 @@ struct column_family_for_tests {
     column_family* operator->() { return _data->cf.get(); }
 };
 
-dht::token create_token_from_key(sstring key);
-range<dht::token> create_token_range_from_keys(sstring start_key, sstring end_key);
+dht::token create_token_from_key(dht::i_partitioner&, sstring key);
+range<dht::token> create_token_range_from_keys(dht::i_partitioner&, sstring start_key, sstring end_key);

--- a/test/manual/row_locker_test.cc
+++ b/test/manual/row_locker_test.cc
@@ -39,7 +39,7 @@ static schema_ptr make_schema()
 }
 
 dht::decorated_key make_pk(const schema_ptr& s, const sstring& pk) {
-    return dht::global_partitioner().decorate_key(*s,
+    return dht::decorate_key(*s,
             partition_key::from_single_value(*s, to_bytes(pk)));
 }
 

--- a/test/perf/perf_cache_eviction.cc
+++ b/test/perf/perf_cache_eviction.cc
@@ -142,7 +142,7 @@ int main(int argc, char** argv) {
 
             auto make_pkey = [s] (sstring pk) {
                 auto key = partition_key::from_single_value(*s, serialized(pk));
-                return dht::global_partitioner().decorate_key(*s, key);
+                return dht::decorate_key(*s, key);
             };
 
             auto pkey = make_pkey("key1");

--- a/test/perf/perf_fast_forward.cc
+++ b/test/perf/perf_fast_forward.cc
@@ -773,7 +773,7 @@ static test_result scan_rows_with_stride(column_family& cf, int n_rows, int n_re
 }
 
 static dht::decorated_key make_pkey(const schema& s, int n) {
-    return dht::global_partitioner().decorate_key(s, partition_key::from_singular(s, n));
+    return dht::decorate_key(s, partition_key::from_singular(s, n));
 }
 
 std::vector<dht::decorated_key> make_pkeys(schema_ptr s, int n) {

--- a/test/perf/perf_row_cache_update.cc
+++ b/test/perf/perf_row_cache_update.cc
@@ -123,7 +123,7 @@ void run_test(const sstring& name, schema_ptr s, MutationGenerator&& gen) {
 
         auto mt = make_lw_shared<memtable>(s);
         while (mt->occupancy().total_space() < memtable_size) {
-            auto pk = dht::global_partitioner().decorate_key(*s, partition_key::from_single_value(*s,
+            auto pk = dht::decorate_key(*s, partition_key::from_single_value(*s,
                 serialized(utils::UUID_gen::get_time_UUID())));
             mutation m = gen();
             mt->apply(m);
@@ -204,7 +204,7 @@ void test_small_partitions() {
         .build();
 
     run_test("Small partitions, no overwrites", s, [&] {
-        auto pk = dht::global_partitioner().decorate_key(*s, partition_key::from_single_value(*s,
+        auto pk = dht::decorate_key(*s, partition_key::from_single_value(*s,
             serialized(utils::UUID_gen::get_time_UUID())));
         mutation m(s, pk);
         auto val = data_value(bytes(bytes::initialized_later(), cell_size));
@@ -224,7 +224,7 @@ void test_partition_with_lots_of_small_rows() {
         .with_column("v3", bytes_type, column_kind::regular_column)
         .build();
 
-    auto pk = dht::global_partitioner().decorate_key(*s, partition_key::from_single_value(*s,
+    auto pk = dht::decorate_key(*s, partition_key::from_single_value(*s,
         serialized(utils::UUID_gen::get_time_UUID())));
     int ck_idx = 0;
 
@@ -249,7 +249,7 @@ void test_partition_with_few_small_rows() {
         .build();
 
     run_test("Small partition with a few rows", s, [&] {
-        auto pk = dht::global_partitioner().decorate_key(*s, partition_key::from_single_value(*s,
+        auto pk = dht::decorate_key(*s, partition_key::from_single_value(*s,
             serialized(utils::UUID_gen::get_time_UUID())));
 
         mutation m(s, pk);
@@ -274,7 +274,7 @@ void test_partition_with_lots_of_range_tombstones() {
         .with_column("v3", bytes_type, column_kind::regular_column)
         .build();
 
-    auto pk = dht::global_partitioner().decorate_key(*s, partition_key::from_single_value(*s,
+    auto pk = dht::decorate_key(*s, partition_key::from_single_value(*s,
         serialized(utils::UUID_gen::get_time_UUID())));
     int ck_idx = 0;
 

--- a/test/unit/row_cache_alloc_stress_test.cc
+++ b/test/unit/row_cache_alloc_stress_test.cc
@@ -91,7 +91,7 @@ int main(int argc, char** argv) {
             std::default_random_engine random_engine(random());
 
             for (int i = 0; i < 10; i++) {
-                auto key = dht::global_partitioner().decorate_key(*s, new_key(s));
+                auto key = dht::decorate_key(*s, new_key(s));
 
                 mutation m1(s, key);
                 m1.set_clustered_cell(new_ckey(s), "v", data_value(bytes(bytes::initialized_later(), cell_size)), 1);

--- a/thrift/handler.cc
+++ b/thrift/handler.cc
@@ -443,7 +443,7 @@ public:
             } else {
                 start_key = key_from_thrift(*schema, to_bytes_view(output.back().key));
             }
-            auto start = dht::global_partitioner().decorate_key(*schema, std::move(*start_key));
+            auto start = dht::decorate_key(*schema, std::move(*start_key));
             range[0] = dht::partition_range(dht::partition_range::bound(std::move(start), false), std::move(end));
             return do_get_paged_slice(schema, column_limit - columns, std::move(range), nullptr, consistency_level, timeout_config, output, qs);
         });
@@ -631,7 +631,7 @@ public:
             }
             auto& s = *schema;
             auto pk = key_from_thrift(s, to_bytes(request.key));
-            auto dk = dht::global_partitioner().decorate_key(s, pk);
+            auto dk = dht::decorate_key(s, pk);
             query::column_id_vector regular_columns;
             std::vector<query::clustering_range> clustering_ranges;
             auto opts = query_opts(s);
@@ -1534,7 +1534,7 @@ private:
         dht::partition_range_vector ranges;
         for (auto&& key : keys) {
             auto pk = key_from_thrift(s, to_bytes_view(key));
-            auto dk = dht::global_partitioner().decorate_key(s, pk);
+            auto dk = dht::decorate_key(s, pk);
             ranges.emplace_back(dht::partition_range::make_singular(std::move(dk)));
         }
         return ranges;

--- a/thrift/handler.cc
+++ b/thrift/handler.cc
@@ -1687,7 +1687,7 @@ private:
             throw make_exception<InvalidRequestException>("Start token + end key is not a supported key range");
         }
 
-        auto&& partitioner = dht::global_partitioner();
+        auto&& partitioner = s.get_partitioner();
 
         if (range.__isset.start_key && range.__isset.end_key) {
             auto start = range.start_key.empty()


### PR DESCRIPTION
Introduce schema::get_partitioner and use it instead of dht::global_partitioner.

The motivation for this change is a desire to have the ability to set a special partitioner for a selected table. To be able to do this, we need to be able to tell for each table what partitioner it uses. The most convenient way for this is to obtain such a partitioner from the schema. Even though a table can have multiple schemas over time, they all have to use the same partitioner. That would mean column_family is a better place for storing partitioner but the schema is much easier to access from all the places in the code.

The first step is to introduce schema::get_partitioner that still calls dht::global_partitioner internally and use this new function everywhere instead of dht::global_partitioner. Thanks to this, when later we change the implementation of schema::get_partitioner to something that allows setting different partitioners for different tables, it will already be used in all the places that depend on partitioner.

Fixes #5493

Tests: unit(dev, release, debug)