### PR TITLE
hinted handoff: send orphaned counter hints correctly

### DIFF
--- a/db/hints/manager.cc
+++ b/db/hints/manager.cc
@@ -405,11 +405,8 @@ future<> manager::end_point_hints_manager::sender::do_send_one_mutation(frozen_m
             return _proxy.send_hint_to_endpoint(std::move(m), end_point_key());
         } else {
             manager_logger.trace("Endpoints set has changed and {} is no longer a replica. Mutating from scratch...", end_point_key());
-            // FIXME: using 1h as infinite timeout. If a node is down, we should get an
-            // unavailable exception.
-            auto timeout = db::timeout_clock::now() + 1h;
             //FIXME: Add required frozen_mutation overloads
-            return _proxy.mutate({m.fm.unfreeze(m.s)}, consistency_level::ALL, timeout, nullptr, empty_service_permit());
+            return _proxy.mutate_hint_from_scratch(std::move(m));
         }
     });
 }

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -2319,6 +2319,14 @@ future<> storage_proxy::send_hint_to_endpoint(frozen_mutation_and_schema fm_a_s,
             allow_hints::no);
 }
 
+future<> storage_proxy::mutate_hint_from_scratch(frozen_mutation_and_schema fm_a_s) {
+    // FIXME: using 1h as infinite timeout. If a node is down, we should get an
+    // unavailable exception.
+    const auto timeout = db::timeout_clock::now() + 1h;
+    std::array<mutation, 1> ms{fm_a_s.fm.unfreeze(fm_a_s.s)};
+    return mutate_internal(std::move(ms), db::consistency_level::ALL, false, nullptr, empty_service_permit(), timeout);
+}
+
 /**
  * Send the mutations to the right targets, write it locally if it corresponds or writes a hint when the node
  * is not available.

--- a/service/storage_proxy.hh
+++ b/service/storage_proxy.hh
@@ -471,6 +471,8 @@ public:
     */
     future<> mutate_atomically(std::vector<mutation> mutations, db::consistency_level cl, clock_type::time_point timeout, tracing::trace_state_ptr tr_state, service_permit permit);
 
+    future<> mutate_hint_from_scratch(frozen_mutation_and_schema fm_a_s);
+
     // Send a mutation to one specific remote target.
     // Inspired by Cassandra's StorageProxy.sendToHintedEndpoints but without
     // hinted handoff support, and just one target. See also


### PR DESCRIPTION
This patch fixes a bug that appears because of an incorrect interaction between counters and hinted handoff.

When a counter is updated on the leader, it sends mutations to other replicas that contain all counter shards from the leader. If consistency level is achieved but some replicas are unavailable, a hint with mutation containing counter shards is stored.

When a hint's destination node is no longer its replica, it is attempted to be sent to all its current replicas. Previously, storage_proxy::mutate was used for that purpose. It was incorrect because that function treats mutations for counter tables as mutations containing only a delta (by how much to increase/decrease the counter). These two types of mutations have different serialization format, so in this case a "shards" mutation is reinterpreted as "delta" mutation, which can cause data corruption to occur.

This patch backports `storage_proxy::mutate_hint_from_scratch` function, which bypasses special handling of counter mutations and treats them as regular mutations - which is the correct behavior for "shards" mutations.

Refs #5833.
Tests: unit(dev), dtest(hintedhandoff_additional_test)