### PR TITLE
Materialized Views: drop materialized views before it's table

### DIFF
--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -1084,7 +1084,13 @@ static void merge_tables_and_views(distributed<service::storage_proxy>& proxy,
                 auto& s = *dt.schema.get();
                 return db.drop_column_family(s.ks_name(), s.cf_name(), [&] { return dt.jp.value(); });
             }).get();
-            parallel_for_each(boost::range::join(tables_diff.created, views_diff.created), [&] (global_schema_ptr& gs) {
+            
+            // In order to avoid possible races we first create the tables and only then the views.
+            // That way if a view seeks information about its base table it's guarantied to find it.
+            parallel_for_each(tables_diff.created, [&] (global_schema_ptr& gs) {
+                return db.add_column_family_and_make_directory(gs);
+            }).get();
+            parallel_for_each(views_diff.created, [&] (global_schema_ptr& gs) {
                 return db.add_column_family_and_make_directory(gs);
             }).get();
             for (auto&& gs : boost::range::join(tables_diff.created, views_diff.created)) {


### PR DESCRIPTION
When dropping a table, the table and its views are dropped
in parallel, this is not a problem as for itself but we
have mechanism to snapshot a deleted table before the
actual delete. When a secondary index is removed, in the
snapshot process it looks for it's schema for creating the
schema part of the snapshot but if the main table is already
gone it will not find it.
This commit serializes views and main table removals and
removes the views prior to the tables.

See discussion on https://github.com/scylladb/scylla/pull/5713

Tests:
Unit tests (dev)
dtest - A test that failed on "can't find schema" error

Fixes #5614