### PR TITLE
hinted handoff: handle counter update hints correctly

### DIFF
--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -2419,7 +2419,8 @@ future<> storage_proxy::send_hint_to_endpoint(frozen_mutation_and_schema fm_a_s,
 future<> storage_proxy::mutate_hint_from_scratch(frozen_mutation_and_schema fm_a_s) {
     const auto timeout = db::timeout_clock::now() + 1h;
     if (!_features.cluster_supports_hinted_handoff_separate_connection()) {
-        return mutate({fm_a_s.fm.unfreeze(fm_a_s.s)}, db::consistency_level::ALL, timeout, nullptr, empty_service_permit());
+        std::array<mutation, 1> ms{fm_a_s.fm.unfreeze(fm_a_s.s)};
+        return mutate_internal(std::move(ms), db::consistency_level::ALL, false, nullptr, empty_service_permit(), timeout);
     }
 
     std::array<hint_wrapper, 1> ms{hint_wrapper { std::move(fm_a_s.fm.unfreeze(fm_a_s.s)) }};


### PR DESCRIPTION
This patch fixes a bug that appears because of an incorrect interaction between counters and hinted handoff.

When a counter is updated on the leader, it sends mutations to other replicas that contain all counter shards from the leader. If consistency level is achieved but some replicas are unavailable, a hint with mutation containing counter shards is stored.

When a hint's destination node is no longer its replica, it is attempted to be sent to all its current replicas. Previously, if the cluster did not have the feature HINTED_HANDOFF_SEPARATE_CONNECTION enabled, storage_proxy::mutate function would be used for the purpose of sending the hint. It was incorrect because that function treats mutations for counter tables as mutations containing only a delta (by how much to increase/decrease the counter). These two types of mutations have different serialization format, so in this case a "shards" mutation is reinterpreted as "delta" mutation, which can cause data corruption to occur.

This patch fixes the case when HINTED_HANDOFF_SEPARATE_CONNECTION is disabled, and uses storage_proxy::mutate_internal, which treats "shards" mutation as regular mutations - which is the correct behavior.

Refs #5833.
Tests:
- unit(dev),
- dtest(hintedhandoff_additional_test, with HINTED_HANDOFF_SEPARATE_CONNECTION artificially disabled in source code)