### PR TITLE
storage proxy: rename mutate_hint_from_scratch

### DIFF
--- a/db/hints/manager.cc
+++ b/db/hints/manager.cc
@@ -405,7 +405,7 @@ future<> manager::end_point_hints_manager::sender::do_send_one_mutation(frozen_m
             return _proxy.send_hint_to_endpoint(std::move(m), end_point_key());
         } else {
             manager_logger.trace("Endpoints set has changed and {} is no longer a replica. Mutating from scratch...", end_point_key());
-            return _proxy.mutate_hint_from_scratch(std::move(m));
+            return _proxy.send_hint_to_all_replicas(std::move(m));
         }
     });
 }

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -2416,7 +2416,7 @@ future<> storage_proxy::send_hint_to_endpoint(frozen_mutation_and_schema fm_a_s,
             allow_hints::no);
 }
 
-future<> storage_proxy::mutate_hint_from_scratch(frozen_mutation_and_schema fm_a_s) {
+future<> storage_proxy::send_hint_to_all_replicas(frozen_mutation_and_schema fm_a_s) {
     const auto timeout = db::timeout_clock::now() + 1h;
     if (!_features.cluster_supports_hinted_handoff_separate_connection()) {
         std::array<mutation, 1> ms{fm_a_s.fm.unfreeze(fm_a_s.s)};

--- a/service/storage_proxy.hh
+++ b/service/storage_proxy.hh
@@ -493,7 +493,7 @@ public:
     */
     future<> mutate_atomically(std::vector<mutation> mutations, db::consistency_level cl, clock_type::time_point timeout, tracing::trace_state_ptr tr_state, service_permit permit);
 
-    future<> mutate_hint_from_scratch(frozen_mutation_and_schema fm_a_s);
+    future<> send_hint_to_all_replicas(frozen_mutation_and_schema fm_a_s);
 
     // Send a mutation to one specific remote target.
     // Inspired by Cassandra's StorageProxy.sendToHintedEndpoints but without


### PR DESCRIPTION
Changes the name of `storage_proxy::mutate_hint_from_scratch` function to another name, whose meaning is more clear: `send_hint_to_all_replicas`.

Tests: unit(dev)