### PR TITLE
cdc: distinguish open and closed ranges for range delete

### DIFF
--- a/cdc/log.cc
+++ b/cdc/log.cc
@@ -500,15 +500,19 @@ public:
                 {
                     auto log_ck = set_pk_columns(m.key(), ts, tuuid, batch_no, res);
                     set_bound(log_ck, rt.start);
-                    // TODO: separate inclusive/exclusive range
-                    set_operation(log_ck, ts, operation::range_delete_start, res);
+                    const auto start_operation = rt.start_kind == bound_kind::incl_start
+                            ? operation::range_delete_start_inclusive
+                            : operation::range_delete_start_exclusive;
+                    set_operation(log_ck, ts, start_operation, res);
                     ++batch_no;
                 }
                 {
                     auto log_ck = set_pk_columns(m.key(), ts, tuuid, batch_no, res);
                     set_bound(log_ck, rt.end);
-                    // TODO: separate inclusive/exclusive range
-                    set_operation(log_ck, ts, operation::range_delete_end, res);
+                    const auto end_operation = rt.end_kind == bound_kind::incl_end
+                            ? operation::range_delete_end_inclusive
+                            : operation::range_delete_end_exclusive;
+                    set_operation(log_ck, ts, end_operation, res);
                     ++batch_no;
                 }
             }

--- a/cdc/log.hh
+++ b/cdc/log.hh
@@ -123,7 +123,8 @@ struct db_context final {
 enum class operation : int8_t {
     // note: these values will eventually be read by a third party, probably not privvy to this
     // enum decl, so don't change the constant values (or the datatype).
-    pre_image = 0, update = 1, row_delete = 2, range_delete_start = 3, range_delete_end = 4, partition_delete = 5
+    pre_image = 0, update = 1, row_delete = 2, partition_delete = 3,
+    range_delete_start_inclusive = 4, range_delete_start_exclusive = 5, range_delete_end_inclusive = 6, range_delete_end_exclusive = 7
 };
 
 // cdc log data column operation


### PR DESCRIPTION
This patch causes inclusive and exclusive range deletes to be distinguished in cdc log. Previously, operations `range_delete_start` and `range_delete_end` were used for both inclusive and exclusive bounds in range deletes. Now, old operations were renamed to `range_delete_*_inclusive`, and for exclusive deletes, new operations `range_delete_*_exclusive` are used.

Tests: unit(dev)