### PR TITLE
cql3: Permit views sync when a table is modified

### DIFF
--- a/cql3/statements/modification_statement.cc
+++ b/cql3/statements/modification_statement.cc
@@ -151,19 +151,6 @@ future<> modification_statement::check_access(const service::client_state& state
            return state.has_column_family_access(keyspace(), column_family(), auth::permission::SELECT);
         });
     }
-    // MV updates need to get the current state from the table, and might update the views
-    // Require Permission.SELECT on the base table, and Permission.MODIFY on the views
-    auto& db = service::get_local_storage_service().db().local();
-    auto&& views = db.find_column_family(keyspace(), column_family()).views();
-    if (!views.empty()) {
-        f = f.then([this, &state] {
-            return state.has_column_family_access(keyspace(), column_family(), auth::permission::SELECT);
-        }).then([this, &state, views = std::move(views)] {
-            return parallel_for_each(views, [this, &state] (auto&& view) {
-                return state.has_column_family_access(this->keyspace(), view->cf_name(), auth::permission::MODIFY);
-            });
-        });
-    }
     return f;
 }
 


### PR DESCRIPTION
Previously we required MODIFY permissions on all materialized views in
order to modify a table.  This is wrong, because the views should be
synced to the table unconditionally.  For the same reason,
users *shouldn't* be granted MODIFY on views, to prevent them manually
changing (and breaking) a view.

This patch removes an explicit permissions check in
modification_statement introduced by 65535b3.  It also tests that a
user can indeed modify a table they are allowed to modify, regardless
of lacking permissions on the table's views and indices.

Fixes #5205.

Tests: unit (dev)