### PR TITLE
dist/debian: fix "unable to open node-exporter.service.dpkg-new" error

### DIFF
--- a/dist/debian/debian/scylla-server.install
+++ b/dist/debian/debian/scylla-server.install
@@ -4,7 +4,6 @@ etc/security/limits.d/scylla.conf
 etc/scylla.d/*.conf
 opt/scylladb/share/doc/scylla/*
 opt/scylladb/share/doc/scylla/licenses/
-usr/lib/systemd/system/*.service
 usr/lib/systemd/system/*.timer
 usr/lib/systemd/system/*.slice
 usr/bin/scylla


### PR DESCRIPTION
It seems like *.service is conflicting on install time because the file
installed twice, both debian/*.service and debian/scylla-server.install.

We don't need to use *.install, so we can just drop the line.

Fixes #5640