### PR TITLE
table: Do not trigger compaction in add_sstable_and_update_cache

### DIFF
--- a/database.hh
+++ b/database.hh
@@ -546,7 +546,7 @@ private:
     db_clock::time_point _truncated_at = db_clock::time_point::min();
 
 public:
-    future<> add_sstable_and_update_cache(sstables::shared_sstable sst);
+    future<> add_sstable_and_update_cache(sstables::shared_sstable sst, bool trigger_compaction = true);
     future<> move_sstables_from_staging(std::vector<sstables::shared_sstable>);
     sstables::shared_sstable get_staging_sstable(uint64_t generation) {
         auto it = _sstables_staging.find(generation);

--- a/dht/range_streamer.hh
+++ b/dht/range_streamer.hh
@@ -173,6 +173,7 @@ private:
     streaming::stream_reason _reason;
     std::unordered_multimap<sstring, std::unordered_map<inet_address, dht::token_range_vector>> _to_stream;
     std::unordered_set<std::unique_ptr<i_source_filter>> _source_filters;
+    std::unordered_map<sstring, std::unordered_set<inet_address>> _trigger_compaction;
     stream_plan _stream_plan;
     // Retry the stream plan _nr_max_retry times
     unsigned _nr_retried = 0;

--- a/message/messaging_service.cc
+++ b/message/messaging_service.cc
@@ -890,17 +890,17 @@ future<> messaging_service::send_stream_mutation(msg_addr id, UUID plan_id, froz
 
 // STREAM_MUTATION_DONE
 void messaging_service::register_stream_mutation_done(std::function<future<> (const rpc::client_info& cinfo,
-        UUID plan_id, dht::token_range_vector ranges, UUID cf_id, unsigned dst_cpu_id)>&& func) {
+        UUID plan_id, dht::token_range_vector ranges, UUID cf_id, unsigned dst_cpu_id, rpc::optional<sstring> trigger_compaction)>&& func) {
     register_handler(this, messaging_verb::STREAM_MUTATION_DONE,
             [func = std::move(func)] (const rpc::client_info& cinfo,
                     UUID plan_id, std::vector<wrapping_range<dht::token>> ranges,
-                    UUID cf_id, unsigned dst_cpu_id) mutable {
-        return func(cinfo, plan_id, ::compat::unwrap(std::move(ranges)), cf_id, dst_cpu_id);
+                    UUID cf_id, unsigned dst_cpu_id, rpc::optional<sstring> trigger_compaction) mutable {
+        return func(cinfo, plan_id, ::compat::unwrap(std::move(ranges)), cf_id, dst_cpu_id, trigger_compaction);
     });
 }
-future<> messaging_service::send_stream_mutation_done(msg_addr id, UUID plan_id, dht::token_range_vector ranges, UUID cf_id, unsigned dst_cpu_id) {
+future<> messaging_service::send_stream_mutation_done(msg_addr id, UUID plan_id, dht::token_range_vector ranges, UUID cf_id, unsigned dst_cpu_id, sstring trigger_compaction) {
     return send_message<void>(this, messaging_verb::STREAM_MUTATION_DONE, id,
-        plan_id, std::move(ranges), cf_id, dst_cpu_id);
+        plan_id, std::move(ranges), cf_id, dst_cpu_id, std::move(trigger_compaction));
 }
 
 // COMPLETE_MESSAGE

--- a/message/messaging_service.hh
+++ b/message/messaging_service.hh
@@ -304,8 +304,8 @@ public:
     rpc::sink<repair_hash_with_cmd> make_sink_for_repair_get_full_row_hashes_with_rpc_stream(rpc::source<repair_stream_cmd>& source);
     void register_repair_get_full_row_hashes_with_rpc_stream(std::function<future<rpc::sink<repair_hash_with_cmd>> (const rpc::client_info& cinfo, uint32_t repair_meta_id, rpc::source<repair_stream_cmd> source)>&& func);
 
-    void register_stream_mutation_done(std::function<future<> (const rpc::client_info& cinfo, UUID plan_id, dht::token_range_vector ranges, UUID cf_id, unsigned dst_cpu_id)>&& func);
-    future<> send_stream_mutation_done(msg_addr id, UUID plan_id, dht::token_range_vector ranges, UUID cf_id, unsigned dst_cpu_id);
+    void register_stream_mutation_done(std::function<future<> (const rpc::client_info& cinfo, UUID plan_id, dht::token_range_vector ranges, UUID cf_id, unsigned dst_cpu_id, rpc::optional<sstring> trigger_compaction)>&& func);
+    future<> send_stream_mutation_done(msg_addr id, UUID plan_id, dht::token_range_vector ranges, UUID cf_id, unsigned dst_cpu_id, sstring trigger_compaction = {});
 
     void register_complete_message(std::function<future<> (const rpc::client_info& cinfo, UUID plan_id, unsigned dst_cpu_id, rpc::optional<bool> failed)>&& func);
     future<> send_complete_message(msg_addr id, UUID plan_id, unsigned dst_cpu_id, bool failed = false);

--- a/table.cc
+++ b/table.cc
@@ -703,12 +703,14 @@ void table::add_sstable(sstables::shared_sstable sstable, const std::vector<unsi
 }
 
 future<>
-table::add_sstable_and_update_cache(sstables::shared_sstable sst) {
-    return get_row_cache().invalidate([this, sst] () noexcept {
+table::add_sstable_and_update_cache(sstables::shared_sstable sst, bool trigger_compaction) {
+    return get_row_cache().invalidate([this, sst, trigger_compaction] () noexcept {
         // FIXME: this is not really noexcept, but we need to provide strong exception guarantees.
         // atomically load all opened sstables into column family.
         add_sstable(sst, {engine().cpu_id()});
-        trigger_compaction();
+        if (trigger_compaction) {
+            this->trigger_compaction();
+        }
     }, dht::partition_range::make({sst->get_first_decorated_key(), true}, {sst->get_last_decorated_key(), true}));
 }
 


### PR DESCRIPTION
The table::add_sstable_and_update_cache is used by streaming and repair to
add sstables generated during the operation.

When we run a node maintenance operation, e.g., bootstrap, repair, a set
of new sstables will be created. For a given token range for a given
table, typically a vnode token range, streaming will create 1 new
sstables per shard, repair will create 1 new sstables per shard on
repair followers and RF - 1 new sstables per shard on repair master.

Currently, we add those new sstables to the main sstables set directly
and let the normal compaction to compact and "reshape" those sstables.
As a result, we effectively push the maintenance work to the compaction
scheduling group, not running under maintenance scheduling group, having
impact on the user read performance. In addition, those sstables without
the invariant properties defined by the compaction strategy may cause
bad read performance.

Before we have the Off-Strategy Compaction which will take a while to be
there, we can mitigate the problem by not triggering a compaction
every time we add a stream/repair generated sstable.

Refs: #5495 #5226 #5199 #5109 #4884