### PR TITLE
install.sh: run post-install script just like .rpm/.deb package

### DIFF
--- a/dist/debian/rules.mustache
+++ b/dist/debian/rules.mustache
@@ -17,7 +17,7 @@ override_dh_auto_clean:
 
 override_dh_auto_install:
 	dh_auto_install
-	./install.sh --root "$(CURDIR)/debian/tmp" $(install_arg) --sysconfdir "/etc/default"
+	./install.sh --packaging --root "$(CURDIR)/debian/tmp" $(install_arg) --sysconfdir "/etc/default"
 	# don't use default sysconfig file, use Debian version
 	cp dist/debian/sysconfig/scylla-housekeeping $(CURDIR)/debian/tmp/etc/default/
 

--- a/dist/redhat/scylla.spec.mustache
+++ b/dist/redhat/scylla.spec.mustache
@@ -68,7 +68,7 @@ defines=()
 {{#housekeeping}}
 install_arg="--housekeeping"
 {{/housekeeping}}
-./install.sh --root "$RPM_BUILD_ROOT" $install_arg
+./install.sh --packaging --root "$RPM_BUILD_ROOT" $install_arg
 
 %pre server
 getent group scylla || /usr/sbin/groupadd scylla 2> /dev/null || :


### PR DESCRIPTION
To install scylla using install.sh easily, we need to run following things:
 - add scylla user/group
 - configure scylla.yaml
 - run scylla_post_install.sh

But we don't want to run them when we build .rpm/.deb package,
we also need to add --packaging option to skip them.

Fixes #5830