### PR TITLE
api: support table auto compaction control

### DIFF
--- a/api/api-doc/column_family.json
+++ b/api/api-doc/column_family.json
@@ -380,9 +380,9 @@
          "operations":[
             {
                "method":"GET",
-               "summary":"check if the auto compaction disabled",
+               "summary":"check if the auto compaction enabled",
                "type":"boolean",
-               "nickname":"is_auto_compaction_disabled",
+               "nickname":"get_auto_compaction",
                "produces":[
                   "application/json"
                ],
@@ -394,6 +394,33 @@
                      "allowMultiple":false,
                      "type":"string",
                      "paramType":"path"
+                  }
+               ]
+            },
+            {
+               "method":"POST",
+               "summary":"Enable or disable column family auto compaction",
+               "type":"boolean",
+               "nickname":"set_auto_compaction",
+               "produces":[
+                  "application/json"
+               ],
+               "parameters":[
+                  {
+                     "name":"name",
+                     "description":"The column family name in keyspace:name format",
+                     "required":true,
+                     "allowMultiple":false,
+                     "type":"string",
+                     "paramType":"path"
+                  },
+                  {
+                     "name":"enabled",
+                     "description":"Enable or disable auto compaction",
+                     "required":true,
+                     "allowMultiple":false,
+                     "type":"boolean",
+                     "paramType":"query"
                   }
                ]
             }

--- a/database.hh
+++ b/database.hh
@@ -502,6 +502,7 @@ private:
     compaction_manager& _compaction_manager;
     secondary_index::secondary_index_manager _index_manager;
     int _compaction_disabled = 0;
+    bool _compaction_disabled_by_user = false;
     utils::phased_barrier _flush_barrier;
     seastar::gate _streaming_flush_gate;
     std::vector<view_ptr> _views;
@@ -932,6 +933,11 @@ public:
     void drop_hit_rate(gms::inet_address addr);
 
     future<> run_with_compaction_disabled(std::function<future<> ()> func);
+
+    bool set_auto_compaction(bool enabled);
+    bool is_auto_compaction_disabled_by_user() const {
+      return _compaction_disabled_by_user;
+    }
 
     utils::phased_barrier::operation write_in_progress() {
         return _pending_writes_phaser.start();


### PR DESCRIPTION
This patch adds an API point /column_family/autocompaction/{name}
that supports GET and POST methods to read and control column
family minor compaction.

To implement that the patch introduces "_compaction_disabled_by_user"
variable into the "table" class along the "_compaction_disabled" var.

Then it introduces:

    bool table::set_auto_compaction(bool enabled);
    bool table::is_auto_compaction_disabled_by_user() const

to control auto compaction state.

https://github.com/scylladb/scylla/issues/1488
https://github.com/scylladb/scylla/issues/1808
https://github.com/scylladb/scylla/issues/440

Signed-off-by: Ivan Prisyazhnyy <ivan@scylladb.com>