### PR TITLE
api: support table auto compaction control

### DIFF
--- a/api/api-doc/column_family.json
+++ b/api/api-doc/column_family.json
@@ -380,16 +380,54 @@
          "operations":[
             {
                "method":"GET",
-               "summary":"check if the auto compaction disabled",
+               "summary":"check if the auto_compaction property is enabled for a given table",
                "type":"boolean",
-               "nickname":"is_auto_compaction_disabled",
+               "nickname":"get_auto_compaction",
                "produces":[
                   "application/json"
                ],
                "parameters":[
                   {
                      "name":"name",
-                     "description":"The column family name in keyspace:name format",
+                     "description":"The table name in keyspace:name format",
+                     "required":true,
+                     "allowMultiple":false,
+                     "type":"string",
+                     "paramType":"path"
+                  }
+               ]
+            },
+            {
+               "method":"POST",
+               "summary":"Enable table auto compaction",
+               "type":"void",
+               "nickname":"enable_auto_compaction",
+               "produces":[
+                  "application/json"
+               ],
+               "parameters":[
+                  {
+                     "name":"name",
+                     "description":"The table name in keyspace:name format",
+                     "required":true,
+                     "allowMultiple":false,
+                     "type":"string",
+                     "paramType":"path"
+                  }
+               ]
+            },
+            {
+               "method":"DELETE",
+               "summary":"Disable table auto compaction",
+               "type":"void",
+               "nickname":"disable_auto_compaction",
+               "produces":[
+                  "application/json"
+               ],
+               "parameters":[
+                  {
+                     "name":"name",
+                     "description":"The table name in keyspace:name format",
                      "required":true,
                      "allowMultiple":false,
                      "type":"string",

--- a/api/column_family.cc
+++ b/api/column_family.cc
@@ -839,11 +839,26 @@ void set_column_family(http_context& ctx, routes& r) {
         return make_ready_future<json::json_return_type>(res);
     });
 
-    cf::is_auto_compaction_disabled.set(r, [] (const_req req) {
-        // FIXME
-        // currently auto compaction is disable
-        // it should be changed when it would have an API
-        return true;
+    cf::get_auto_compaction.set(r, [&ctx] (const_req req) {
+        const utils::UUID& uuid = get_uuid(req.param["name"], ctx.db.local());
+        column_family& cf = ctx.db.local().find_column_family(uuid);
+        return !cf.is_auto_compaction_disabled_by_user();
+    });
+
+    cf::enable_auto_compaction.set(r, [&ctx](std::unique_ptr<request> req) {
+        return foreach_column_family(ctx, req->param["name"], [](column_family &cf) {
+            cf.enable_auto_compaction();
+        }).then([] {
+            return make_ready_future<json::json_return_type>(json_void());
+        });
+    });
+
+    cf::disable_auto_compaction.set(r, [&ctx](std::unique_ptr<request> req) {
+        return foreach_column_family(ctx, req->param["name"], [](column_family &cf) {
+            cf.disable_auto_compaction();
+        }).then([] {
+            return make_ready_future<json::json_return_type>(json_void());
+        });
     });
 
     cf::get_built_indexes.set(r, [&ctx](std::unique_ptr<request> req) {

--- a/database.hh
+++ b/database.hh
@@ -504,6 +504,7 @@ private:
     compaction_manager& _compaction_manager;
     secondary_index::secondary_index_manager _index_manager;
     int _compaction_disabled = 0;
+    bool _compaction_disabled_by_user = false;
     utils::phased_barrier _flush_barrier;
     seastar::gate _streaming_flush_gate;
     std::vector<view_ptr> _views;
@@ -959,6 +960,12 @@ public:
     void drop_hit_rate(gms::inet_address addr);
 
     future<> run_with_compaction_disabled(std::function<future<> ()> func);
+
+    void enable_auto_compaction();
+    void disable_auto_compaction();
+    bool is_auto_compaction_disabled_by_user() const {
+      return _compaction_disabled_by_user;
+    }
 
     utils::phased_barrier::operation write_in_progress() {
         return _pending_writes_phaser.start();

--- a/sstables/compaction_manager.cc
+++ b/sstables/compaction_manager.cc
@@ -515,6 +515,10 @@ inline bool compaction_manager::maybe_stop_on_error(future<> f, stop_iteration w
 }
 
 void compaction_manager::submit(column_family* cf) {
+    if (cf->is_auto_compaction_disabled_by_user()) {
+        return;
+    }
+
     auto task = make_lw_shared<compaction_manager::task>();
     task->compacting_cf = cf;
     _tasks.push_back(task);
@@ -532,7 +536,7 @@ void compaction_manager::submit(column_family* cf) {
             sstables::compaction_descriptor descriptor = cs.get_sstables_for_compaction(cf, get_candidates(cf));
             int weight = trim_to_compact(&cf, descriptor);
 
-            if (descriptor.sstables.empty() || !can_proceed(task)) {
+            if (descriptor.sstables.empty() || !can_proceed(task) || cf.is_auto_compaction_disabled_by_user()) {
                 _stats.pending_tasks--;
                 return make_ready_future<stop_iteration>(stop_iteration::yes);
             }

--- a/table.cc
+++ b/table.cc
@@ -2458,6 +2458,44 @@ table::run_with_compaction_disabled(std::function<future<> ()> func) {
     });
 }
 
+void
+table::enable_auto_compaction() {
+    // XXX: unmute backlog. turn table backlog back on.
+    //      see table::disable_auto_compaction() notes.
+    _compaction_disabled_by_user = false;
+}
+
+void
+table::disable_auto_compaction() {
+    // XXX: mute backlog. When we disable background compactions
+    // for the table, we must also disable current backlog of the
+    // table compaction strategy that contributes to the scheduling
+    // group resources prioritization.
+    //
+    // There are 2 possibilities possible:
+    // - there are no ongoing background compaction, and we can freely
+    //   mute table backlog.
+    // - there are compactions happening. than we must decide either
+    //   we want to allow them to finish not allowing submitting new
+    //   compactions tasks, or we may "suspend" them until the bg
+    //   compactions will be enabled back. This is not a worst option
+    //   because it will allow bg compactions to finish if there are
+    //   unused resourced, it will not lose any writers/readers stats.
+    //
+    // Besides that:
+    // - there are major compactions that additionally uses constant
+    //   size backlog of shares,
+    // - sstables rewrites tasks that do the same.
+    // 
+    // Setting NullCompactionStrategy is not an option due to the
+    // following reasons:
+    // - it will 0 backlog if suspending current compactions is not an
+    //   option
+    // - it will break computation of major compaction descriptor
+    //   for new submissions
+    _compaction_disabled_by_user = true;
+}
+
 flat_mutation_reader
 table::make_reader_excluding_sstable(schema_ptr s,
         sstables::shared_sstable sst,

--- a/test/boost/sstable_datafile_test.cc
+++ b/test/boost/sstable_datafile_test.cc
@@ -1036,6 +1036,51 @@ static flat_mutation_reader make_normalizing_sstable_reader(shared_sstable sst, 
     return make_normalizing_sstable_reader(sst, s, query::full_partition_range);
 }
 
+SEASTAR_TEST_CASE(autocompaction_control_test) {
+    return test_env::do_with_async([] (test_env& env) {
+        storage_service_for_tests ssft;
+        BOOST_REQUIRE(smp::count == 1);
+        auto s = make_lw_shared(schema({}, some_keyspace, some_column_family, {{"p1", utf8_type}}, {{"c1", utf8_type}}, {}, {}, utf8_type));
+
+        auto cm = make_lw_shared<compaction_manager>();
+        cm->start();
+
+        auto tmp = tmpdir();
+        column_family::config cfg = column_family_test_config();
+        cfg.datadir = tmp.path().string();
+        cfg.enable_commitlog = false;
+        cfg.enable_incremental_backups = false;
+        auto cl_stats = make_lw_shared<cell_locker_stats>();
+        auto tracker = make_lw_shared<cache_tracker>();
+        auto cf = make_lw_shared<column_family>(s, cfg, column_family::no_commitlog(), *cm, *cl_stats, *tracker);
+        cf->start();
+        cf->set_compaction_strategy(sstables::compaction_strategy_type::null);
+
+        // auto compaction is enabled by default
+        BOOST_REQUIRE(!cf->is_auto_compaction_disabled_by_user());
+        // disable auto compaction by user
+        cf->disable_auto_compaction();
+        // check it is disabled
+        BOOST_REQUIRE(cf->is_auto_compaction_disabled_by_user());
+        // check CompactionManager does not receive background compaction submissions
+        cf->trigger_compaction();
+        BOOST_REQUIRE(cm->get_stats().pending_tasks == 0 && cm->get_stats().active_tasks == 0);
+        cf->get_compaction_manager().submit(cf.get());
+        BOOST_REQUIRE(cm->get_stats().pending_tasks == 0 && cm->get_stats().active_tasks == 0);
+        // enable auto compaction
+        cf->enable_auto_compaction();
+        // check enabled
+        BOOST_REQUIRE(!cf->is_auto_compaction_disabled_by_user());
+        // trigger background compaction
+        cf->trigger_compaction();
+        BOOST_REQUIRE(cm->get_stats().pending_tasks == 1 || cm->get_stats().active_tasks == 1);
+
+        // XXX: test backlog state
+
+        cm->stop().wait();
+    });
+}
+
 SEASTAR_TEST_CASE(compaction_manager_test) {
   return test_env::do_with_async([] (test_env& env) {
     storage_service_for_tests ssft;


### PR DESCRIPTION
This patch adds an API point /column_family/autocompaction/{name}
that supports GET and POST methods to read and control column
family minor compaction.

To implement that the patch introduces "_compaction_disabled_by_user"
variable into the "table" class.

Then it introduces:

    bool table::{enable,disable}_auto_compaction();
    bool table::is_auto_compaction_disabled_by_user() const

to control auto compaction state.

https://github.com/scylladb/scylla/issues/1488
https://github.com/scylladb/scylla/issues/1808
https://github.com/scylladb/scylla/issues/440

Signed-off-by: Ivan Prisyazhnyy <ivan@scylladb.com>

Test
===

```
./test.py sstable_datafile_test autocompaction_control_test
```

Manual qa
===

```
$ ninja
$ env SCYLLA_HOME=$(pwd) ./build/dev/scylla --log-to-syslog 0 --log-to-stdout 1 --default-log-level info --network-stack posix --developer-mode=1 --cpuset 0 --listen-address 127.0.0.1 --rpc-address 127.0.0.1 --seed-provider-parameters seeds=127.0.0.1 --blocked-reactor-notify-ms 999999999 --workdir $SCYLLA_HOME/build/data

CREATE KEYSPACE kr1 WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND durable_writes = false;
USE kr1;
CREATE TABLE standard1 (id int PRIMARY KEY);

$ curl http://127.0.0.1:10000/storage_service/auto_compaction/kr1\?cf\=standard1
$ curl -X DELETE http://127.0.0.1:10000/storage_service/auto_compaction/kr1\?cf\=standard1
$ curl http://127.0.0.1:10000/storage_service/auto_compaction/kr1\?cf\=standard1
$ curl -X POST http://127.0.0.1:10000/storage_service/auto_compaction/kr1\?cf\=standard1
$ curl http://127.0.0.1:10000/storage_service/auto_compaction/kr1\?cf\=standard1

$ curl http://127.0.0.1:10000/column_family/autocompaction/kr1:standard1
$ curl -X DELETE http://127.0.0.1:10000/column_family/autocompaction/kr1:standard1
$ curl http://127.0.0.1:10000/column_family/autocompaction/kr1:standard1
$ curl -X POST http://127.0.0.1:10000/column_family/autocompaction/kr1:standard1
$ curl http://127.0.0.1:10000/column_family/autocompaction/kr1:standard1
```
