### PR TITLE
alternator: change keyspace prefix to alternator_

### DIFF
--- a/alternator/executor.hh
+++ b/alternator/executor.hh
@@ -45,7 +45,7 @@ public:
     using request_return_type = std::variant<json::json_return_type, api_error>;
     stats _stats;
     static constexpr auto ATTRS_COLUMN_NAME = ":attrs";
-    static constexpr auto KEYSPACE_NAME_PREFIX = "a#";
+    static constexpr auto KEYSPACE_NAME_PREFIX = "alternator_";
 
     executor(service::storage_proxy& proxy, service::migration_manager& mm) : _proxy(proxy), _mm(mm) {}
 


### PR DESCRIPTION
The original idea of prefixing alternator keyspace names with 'a#'
leveraged the fact that '#' is not a legal CQL character for keyspace
names. The idea is flawed though, since '#' proved to confuse
existing Scylla tools (e.g. nodetool).
Thus, the prefix is changed to more orthodox 'alternator_'.
It is possible to create such keyspaces with CQL as well, but then
the alternator CreateTable request would simply fail, because
the keyspace already exists, which is graceful enough.
Hiding alternator keyspaces and tables from CQL is another issue,
but there are other ways to distinguish them than a non-standard
prefix, e.g. tags.

Fixes #5883