### PR TITLE
CDC: implement new column format and naming

### DIFF
--- a/cdc/log.cc
+++ b/cdc/log.cc
@@ -234,10 +234,11 @@ bool cdc::options::operator!=(const options& o) const {
 namespace cdc {
 
 using operation_native_type = std::underlying_type_t<operation>;
-using column_op_native_type = std::underlying_type_t<column_op>;
 
 static const sstring cdc_log_suffix = "_scylla_cdc_log";
 static const sstring cdc_meta_column_prefix = "cdc$";
+static const sstring cdc_deleted_column_prefix = cdc_meta_column_prefix + "deleted_";
+static const sstring cdc_deleted_elements_column_prefix = cdc_meta_column_prefix + "deleted_elements_";
 
 static bool is_log_name(const std::string_view& table_name) {
     return boost::ends_with(table_name, cdc_log_suffix);
@@ -272,6 +273,22 @@ bytes log_meta_column_name_bytes(const bytes& column_name) {
     return to_bytes(cdc_meta_column_prefix) + column_name;
 }
 
+seastar::sstring log_data_column_deleted_name(std::string_view column_name) {
+    return cdc_deleted_column_prefix + sstring(column_name);
+}
+
+bytes log_data_column_deleted_name_bytes(const bytes& column_name) {
+    return to_bytes(cdc_deleted_column_prefix) + column_name;
+}
+
+seastar::sstring log_data_column_deleted_elements_name(std::string_view column_name) {
+    return cdc_deleted_elements_column_prefix + sstring(column_name);
+}
+
+bytes log_data_column_deleted_elements_name_bytes(const bytes& column_name) {
+    return to_bytes(cdc_deleted_elements_column_prefix) + column_name;
+}
+
 static schema_ptr create_log_schema(const schema& s, std::optional<utils::UUID> uuid) {
     schema_builder b(s.ks_name(), log_name(s.cf_name()));
     b.set_comment(sprint("CDC log for %s.%s", s.ks_name(), s.cf_name()));
@@ -287,29 +304,34 @@ static schema_ptr create_log_schema(const schema& s, std::optional<utils::UUID> 
             if (is_data_col) {
                 type = visit(*type, make_visitor(
                     // lists are represented as map<timeuuid, value_type>. Otherwise we cannot express delta
-                    [] (const list_type_impl& type) {
+                    [] (const list_type_impl& type) -> data_type {
                         return map_type_impl::get_instance(type.name_comparator(), type.value_comparator(), false);
-                    },
-                    // user types are expressed as tuple<tuple<field0>, tuple<field1>...>
-                    // the extra tuple allows us to distinguish null == <no info>
-                    // from <null> = set field to null
-                    [] (const user_type_impl& type) -> data_type {
-                        std::vector<data_type> types;
-                        types.reserve(type.size());
-                        for (auto& ft : type.field_types()) {
-                            types.emplace_back(tuple_type_impl::get_instance({ ft }));
-                        }
-                        return tuple_type_impl::get_instance(std::move(types));
                     },
                     // everything else is just frozen self
                     [] (const abstract_type& type) {
                         return type.freeze();
                     }
                 ));
-
-                type = tuple_type_impl::get_instance({ /* op */ data_type_for<column_op_native_type>(), /* value */ type->freeze()});
+                type = type->freeze();
             }
             b.with_column(log_data_column_name_bytes(column.name()), type);
+            b.with_column(log_data_column_deleted_name_bytes(column.name()), boolean_type);
+            if (column.type->is_multi_cell()) {
+                auto dtype = visit(*type, make_visitor(
+                    // all collection deletes are set<key_type> (i.e. timeuuid for lists)
+                    [] (const collection_type_impl& type) -> data_type {
+                        return set_type_impl::get_instance(type.name_comparator(), false);
+                    },
+                    // user types deletes are a set of the indices removed
+                    [] (const user_type_impl& type) -> data_type {
+                        return set_type_impl::get_instance(short_type, false);
+                    },
+                    [] (const abstract_type& type) -> data_type {
+                        throw std::invalid_argument("Should not reach");
+                    }
+                ));
+                b.with_column(log_data_column_deleted_elements_name_bytes(column.name()), dtype);
+            }
         }
     };
     add_columns(s.partition_key_columns());
@@ -604,7 +626,7 @@ public:
                     ++pos;
                 }
 
-                std::vector<bytes_opt> values(2);
+                bytes_opt value;
                 std::optional<gc_clock::duration> ttl;
 
                 auto process_cells = [&](const row& r, column_kind ckind) {
@@ -612,29 +634,30 @@ public:
                         auto& cdef = _schema->column_at(ckind, id);
                         auto* dst = _log_schema->get_column_definition(log_data_column_name_bytes(cdef.name()));
                         auto has_pirow = pirow && pirow->has(cdef.name_as_text());
-                        auto op = column_op::del;
+                        bool is_column_delete = true;
 
                         if (cdef.is_atomic()) {
-                            values[1] = std::nullopt;
+                            value = std::nullopt;
                             auto view = cell.as_atomic_cell(cdef);
                             if (view.is_live()) {
-                                op = column_op::set;
-                                values[1] = view.value().linearize();
+                                is_column_delete = false;
+                                value = view.value().linearize();
                                 if (view.is_live_and_has_ttl()) {
                                     ttl = view.ttl();
                                 }
                             } 
                         } else {
                             auto mv = cell.as_collection_mutation();
-                            std::optional<column_op> oop;
-                            op = column_op::add;
-
+                            is_column_delete = false;
+                            bytes_opt deleted_elements = std::nullopt;
                             std::vector<bytes> buf;
-                            values[1] = mv.with_deserialized(*cdef.type, [&](collection_mutation_view_description view) -> bytes_opt {
+                            value = mv.with_deserialized(*cdef.type, [&](collection_mutation_view_description view) -> bytes_opt {
                                 if (view.tomb) {
                                     // there is a tombstone with timestamp before this mutation.
                                     // this is how a assign collection = <value> is represented.
-                                    oop = column_op::set;
+                                    // for non-atomics, a column delete + values in data column
+                                    // simply means "replace values"
+                                    is_column_delete = true;
                                 }
                                 auto process_cells = [&](auto value_callback) {
                                     for (auto& [key, value] : view.cells) {
@@ -645,20 +668,6 @@ public:
                                         // dead cells, i.e. null markers. 
                                         auto live = value.is_live();
                                         if (!live) {
-                                            // technically mutations can express both add/set/delete
-                                            // even created by cql statements.
-                                            // But for now, assume we have homogeneous op, OR
-                                            // we're doing a full assign
-                                            // TODO: split into two log rows
-                                            if (oop == column_op::set) {
-                                                // dead cell in full assign? just don't include
-                                                continue;
-                                            }
-                                            if (oop.value_or(column_op::del) != column_op::del) {
-                                                cdc_log.warn("Unhandled case: mismatched set/add operations in multi cell type {}", cdef.type->name());
-                                                continue;
-                                            }
-                                            oop = oop.value_or(column_op::del);
                                             value_callback(key, bytes_view{}, live);
                                             continue;
                                         }
@@ -670,56 +679,89 @@ public:
                                     }
                                 };
 
+                                std::vector<bytes_view> deleted;
+
                                 return visit(*cdef.type, make_visitor(
                                     // maps and lists are just flattened
-                                    [&] (const collection_type_impl& type) {
+                                    [&] (const collection_type_impl& type) -> bytes_opt {
                                         std::vector<std::pair<bytes_view, bytes_view>> result;
                                         process_cells([&](const bytes_view& key, const bytes_view& value, bool live) {
-                                            result.emplace_back(key, value);
+                                            if (live) {
+                                                result.emplace_back(key, value);
+                                            } else {
+                                                deleted.emplace_back(key);
+                                            }
                                         });
+                                        if (!deleted.empty()) {
+                                            deleted_elements = set_type_impl::serialize_partially_deserialized_form(deleted, cql_serialization_format::internal());
+                                        }
+                                        if (result.empty()) {
+                                            return std::nullopt;
+                                        }
                                         return map_type_impl::serialize_partially_deserialized_form(result, cql_serialization_format::internal());
                                     },
                                     // set need to transform from mutation view
-                                    [&] (const set_type_impl& type) {
+                                    [&] (const set_type_impl& type) -> bytes_opt  {
                                         std::vector<bytes_view> result;
                                         process_cells([&](const bytes_view& key, const bytes_view& value, bool live) {
-                                            result.emplace_back(key);
+                                            if (live) {
+                                                result.emplace_back(key);
+                                            } else {
+                                                deleted.emplace_back(key);
+                                            }
                                         });
-                                        return type.serialize_partially_deserialized_form(result, cql_serialization_format::internal());
+                                        if (!deleted.empty()) {
+                                            deleted_elements = set_type_impl::serialize_partially_deserialized_form(deleted, cql_serialization_format::internal());
+                                        }
+                                        if (result.empty()) {
+                                            return std::nullopt;
+                                        }
+                                        return set_type_impl::serialize_partially_deserialized_form(result, cql_serialization_format::internal());
                                     },
                                     // for user type we collect the fields in the mutation and set to
                                     // tuple of value or tuple of null in case of delete.
                                     // fields not in the mutation are null in the enclosing tuple, signifying "no info"
-                                    [&](const user_type_impl& type) {
-                                        std::vector<bytes_opt> res(type.size());
-                                        std::array<bytes_view_opt, 1> tmp;
-                                        // type of the actual value in log column tuple.
-                                        auto res_type = static_pointer_cast<const tuple_type_impl>(dst->type)->type(1);
-                                        auto tt = static_pointer_cast<const tuple_type_impl>(res_type);
+                                    [&](const user_type_impl& type) -> bytes_opt  {
+                                        std::vector<bytes_opt> result(type.size());
                                         process_cells([&](const bytes_view& key, const bytes_view& value, bool live) {
-                                            auto idx = deserialize_field_index(key);
-                                            tmp[0] = live ? bytes_view_opt{value} : std::nullopt;
-                                            res[idx].emplace(static_pointer_cast<const tuple_type_impl>(tt->all_types()[idx])->build_value(tmp));
+                                            if (live) {
+                                                auto idx = deserialize_field_index(key);
+                                                result[idx].emplace(value);
+                                            } else {
+                                                deleted.emplace_back(key);
+                                            }
                                         });
-                                        return tt->build_value(res);
+                                        if (!deleted.empty()) {
+                                            deleted_elements = set_type_impl::serialize_partially_deserialized_form(deleted, cql_serialization_format::internal());
+                                        }
+                                        if (result.empty()) {
+                                            return std::nullopt;
+                                        }
+                                        return type.build_value(result);
                                     },
-                                    [&] (const abstract_type& o) -> bytes {
+                                    [&] (const abstract_type& o) -> bytes_opt {
                                         throw std::runtime_error(format("cdc transform: unknown type {}", o.name()));
                                     }
                                 ));
                             });
 
-                            op = oop.value_or(op);
+                            if (deleted_elements) {
+                                auto* dc = _log_schema->get_column_definition(log_data_column_deleted_elements_name_bytes(cdef.name()));
+                                res.set_cell(log_ck, *dc, atomic_cell::make_live(*dc->type, ts, *deleted_elements, _cdc_ttl_opt));
+                            }
                         }
 
-                        values[0] = data_type_for<column_op_native_type>()->decompose(data_value(static_cast<column_op_native_type>(op)));
-                        res.set_cell(log_ck, *dst, atomic_cell::make_live(*dst->type, ts, tuple_type_impl::build_value(values), _cdc_ttl_opt));
+                        if (is_column_delete) {
+                            res.set_cell(log_ck, log_data_column_deleted_name_bytes(cdef.name()), data_value(true), ts, _cdc_ttl_opt);
+                        }
+                        if (value) {
+                            res.set_cell(log_ck, *dst, atomic_cell::make_live(*dst->type, ts, *value, _cdc_ttl_opt));
+                        }
 
                         if (has_pirow) {
-                            values[0] = data_type_for<column_op_native_type>()->decompose(data_value(static_cast<column_op_native_type>(column_op::set)));
-                            values[1] = cdef.is_atomic()
+                            value = cdef.is_atomic()
                                 ? pirow->get_blob(cdef.name_as_text())
-                                : values[1] = visit(*cdef.type, make_visitor(
+                                : visit(*cdef.type, make_visitor(
                                     // flatten set
                                     [&] (const set_type_impl& type) {
                                         auto v = pirow->get_view(cdef.name_as_text());
@@ -731,24 +773,7 @@ public:
                                             tmp.emplace_back(read_collection_value(v, f)); // key
                                             read_collection_value(v, f); // value. ignore.
                                         }
-                                        return type.serialize_partially_deserialized_form(tmp, f);
-                                    },
-                                    // transform udt similarly to above
-                                    [&](const user_type_impl& type) {
-                                        std::vector<bytes_opt> res(type.size());
-                                        std::array<bytes_view_opt, 1> tmp;
-                                        // type of the actual value in log column tuple.
-                                        auto res_type = static_pointer_cast<const tuple_type_impl>(dst->type)->type(1);
-                                        auto tt = static_pointer_cast<const tuple_type_impl>(res_type);
-                                        size_t i = 0; 
-                                        for (auto& v : type.split(pirow->get_view(cdef.name_as_text()))) {
-                                            if (v) {
-                                                tmp[0] = v;
-                                                res[i] = static_pointer_cast<const tuple_type_impl>(tt->all_types()[i])->build_value(tmp);
-                                            }
-                                            ++i;
-                                        }
-                                        return tt->build_value(res);
+                                        return set_type_impl::serialize_partially_deserialized_form(tmp, f);
                                     },
                                     [&] (const abstract_type& o) -> bytes {
                                         return pirow->get_blob(cdef.name_as_text());
@@ -757,7 +782,7 @@ public:
 
                             assert(std::addressof(res.partition().clustered_row(*_log_schema, *pikey)) != std::addressof(res.partition().clustered_row(*_log_schema, log_ck)));
                             assert(pikey->explode() != log_ck.explode());
-                            res.set_cell(*pikey, *dst, atomic_cell::make_live(*dst->type, ts, tuple_type_impl::build_value(values), _cdc_ttl_opt));
+                            res.set_cell(*pikey, *dst, atomic_cell::make_live(*dst->type, ts, *value, _cdc_ttl_opt));
                         }
                     });
                 };

--- a/cdc/log.hh
+++ b/cdc/log.hh
@@ -127,17 +127,17 @@ enum class operation : int8_t {
     range_delete_start_inclusive = 5, range_delete_start_exclusive = 6, range_delete_end_inclusive = 7, range_delete_end_exclusive = 8,
 };
 
-// cdc log data column operation
-enum class column_op : int8_t {
-    // same as "operation". Do not edit values or type/type unless you _really_ want to.
-    set = 0, del = 1, add = 2,
-};
-
 bool is_log_for_some_table(const sstring& ks_name, const std::string_view& table_name);
 seastar::sstring log_name(const seastar::sstring& table_name);
 seastar::sstring log_data_column_name(std::string_view column_name);
 seastar::sstring log_meta_column_name(std::string_view column_name);
 bytes log_data_column_name_bytes(const bytes& column_name);
 bytes log_meta_column_name_bytes(const bytes& column_name);
+
+seastar::sstring log_data_column_deleted_name(std::string_view column_name);
+bytes log_data_column_deleted_name_bytes(const bytes& column_name);
+
+seastar::sstring log_data_column_deleted_elements_name(std::string_view column_name);
+bytes log_data_column_deleted_elements_name_bytes(const bytes& column_name);
 
 } // namespace cdc

--- a/cdc/log.hh
+++ b/cdc/log.hh
@@ -135,5 +135,9 @@ enum class column_op : int8_t {
 
 bool is_log_for_some_table(const sstring& ks_name, const std::string_view& table_name);
 seastar::sstring log_name(const seastar::sstring& table_name);
+seastar::sstring log_data_column_name(std::string_view column_name);
+seastar::sstring log_meta_column_name(std::string_view column_name);
+bytes log_data_column_name_bytes(const bytes& column_name);
+bytes log_meta_column_name_bytes(const bytes& column_name);
 
 } // namespace cdc

--- a/cql3/sets.cc
+++ b/cql3/sets.cc
@@ -300,7 +300,7 @@ sets::adder::do_add(mutation& m, const clustering_key_prefix& row_key, const upd
         m.set_cell(row_key, column, mut.serialize(*set_type));
     } else if (set_value != nullptr) {
         // for frozen sets, we're overwriting the whole cell
-        auto v = set_type->serialize_partially_deserialized_form(
+        auto v = set_type_impl::serialize_partially_deserialized_form(
                 {set_value->_elements.begin(), set_value->_elements.end()},
                 cql_serialization_format::internal());
         m.set_cell(row_key, column, params.make_cell(*column.type, fragmented_temporary_buffer::view(v)));

--- a/types.cc
+++ b/types.cc
@@ -1196,7 +1196,7 @@ set_type_impl::deserialize(bytes_view in, cql_serialization_format sf) const {
 
 bytes
 set_type_impl::serialize_partially_deserialized_form(
-        const std::vector<bytes_view>& v, cql_serialization_format sf) const {
+        const std::vector<bytes_view>& v, cql_serialization_format sf) {
     return pack(v.begin(), v.end(), v.size(), sf);
 }
 

--- a/types/set.hh
+++ b/types/set.hh
@@ -48,8 +48,8 @@ public:
     virtual bool is_value_compatible_with_frozen(const collection_type_impl& previous) const override;
     using abstract_type::deserialize;
     virtual data_value deserialize(bytes_view v, cql_serialization_format sf) const override;
-    bytes serialize_partially_deserialized_form(
-            const std::vector<bytes_view>& v, cql_serialization_format sf) const;
+    static bytes serialize_partially_deserialized_form(
+            const std::vector<bytes_view>& v, cql_serialization_format sf);
 };
 
 data_value make_set_value(data_type tuple_type, set_type_impl::native_type value);


### PR DESCRIPTION
Rename metadata and data columns according to new spec
    
Also use transformation methods for names in all code + tests
to make switching again easier

Break up data column tuple
    
Data column is now pure frozen original type. 

- If column is deleted (set to null), a metadata column cdc$deleted_<name> is set to true, to distinguish null column == not involved in row operation
- For non-atomic collections, a cdc$deleted_elements_<name> column is added, and when removing elements from collection this is where they are shown.
- For non-atomic assign, the "cdc$deleted_<name>" is true, and <name> is set to new value.
    
column_op removed.

v2:
Modified to use uniform "key" set semantics for all non-atomic types, i.e. udts put deleted fields as field index in `deleted_elements` set. 