### PR TITLE
Allow repeated LIKE on same column

### DIFF
--- a/cql3/restrictions/single_column_restriction.hh
+++ b/cql3/restrictions/single_column_restriction.hh
@@ -398,9 +398,8 @@ public:
     { }
 
     virtual std::vector<bytes_opt> values(const query_options& options) const override {
-        std::vector<bytes_opt> v;
-        v.push_back(to_bytes_opt(_value->bind_and_get(options)));
-        return v;
+        // LIKE cannot provide the matching values without fetching the data first.
+        throw std::logic_error("LIKE::values() invoked");
     }
 
     virtual bool uses_function(const sstring& ks_name, const sstring& function_name) const override {

--- a/cql3/restrictions/single_column_restriction.hh
+++ b/cql3/restrictions/single_column_restriction.hh
@@ -391,7 +391,6 @@ private:
     /// constructor when the pattern is a bind marker.  Mutable because it is initialized on demand
     /// in is_satisfied_by().
     mutable std::optional<like_matcher> _matcher;
-    mutable bytes_opt _last_pattern; ///< Pattern from which _matcher was last initialized.
 public:
     LIKE(const column_definition& column_def, ::shared_ptr<term> value)
         : single_column_restriction(op::LIKE, column_def)
@@ -434,7 +433,7 @@ public:
     }
 
   private:
-    /// If necessary, reinitializes _matcher and _last_pattern.
+    /// If necessary, reinitializes _matcher.
     ///
     /// Invoked from is_satisfied_by(), so must be const.
     ///

--- a/cql3/restrictions/statement_restrictions.cc
+++ b/cql3/restrictions/statement_restrictions.cc
@@ -931,9 +931,10 @@ bool single_column_restriction::LIKE::init_matcher(const query_options& options)
     if (!pattern) {
         return false;
     }
-    if (!_matcher || pattern != _last_pattern) {
+    if (!_matcher) {
         _matcher.emplace(*pattern);
-        _last_pattern = std::move(pattern);
+    } else {
+        _matcher->reset(*pattern);
     }
     return true;
 }

--- a/cql3/restrictions/statement_restrictions.cc
+++ b/cql3/restrictions/statement_restrictions.cc
@@ -20,10 +20,12 @@
  * along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <algorithm>
+#include <boost/algorithm/cxx11/all_of.hpp>
+#include <boost/algorithm/cxx11/any_of.hpp>
 #include <boost/range/algorithm/transform.hpp>
 #include <boost/range/algorithm.hpp>
 #include <boost/range/adaptors.hpp>
-#include <boost/algorithm/cxx11/any_of.hpp>
 
 #include "statement_restrictions.hh"
 #include "single_column_primary_key_restrictions.hh"
@@ -926,15 +928,17 @@ bool token_restriction::slice::is_satisfied_by(const schema& schema,
     return satisfied;
 }
 
-bool single_column_restriction::LIKE::init_matcher(const query_options& options) const {
-    auto pattern = to_bytes_opt(_value->bind_and_get(options));
-    if (!pattern) {
-        return false;
-    }
-    if (!_matcher) {
-        _matcher.emplace(*pattern);
-    } else {
-        _matcher->reset(*pattern);
+bool single_column_restriction::LIKE::init_matchers(const query_options& options) const {
+    for (size_t i = 0; i < _values.size(); ++i) {
+        auto pattern = to_bytes_opt(_values[i]->bind_and_get(options));
+        if (!pattern) {
+            return false;
+        }
+        if (i < _matchers.size()) {
+            _matchers[i].reset(*pattern);
+        } else {
+            _matchers.emplace_back(*pattern);
+        }
     }
     return true;
 }
@@ -952,11 +956,11 @@ bool single_column_restriction::LIKE::is_satisfied_by(const schema& schema,
     if (!cell_value) {
         return false;
     }
-    if (!init_matcher(options)) {
+    if (!init_matchers(options)) {
         return false;
     }
     return cell_value->with_linearized([&] (bytes_view data) {
-        return (*_matcher)(data);
+        return boost::algorithm::all_of(_matchers, [&] (auto& m) { return m(data); });
     });
 }
 
@@ -964,11 +968,34 @@ bool single_column_restriction::LIKE::is_satisfied_by(bytes_view data, const que
     if (!_column_def.type->is_string()) {
         throw exceptions::invalid_request_exception("LIKE is allowed only on string types");
     }
-    if (!init_matcher(options)) {
+    if (!init_matchers(options)) {
         return false;
     }
-    return (*_matcher)(data);
+    return boost::algorithm::all_of(_matchers, [&] (auto& m) { return m(data); });
 }
 
+sstring single_column_restriction::LIKE::to_string() const {
+    std::vector<sstring> vs(_values.size());
+    for (size_t i = 0; i < _values.size(); ++i) {
+        vs[i] = _values[i]->to_string();
+    }
+    return join(" AND ", vs);
 }
+
+void single_column_restriction::LIKE::merge_with(::shared_ptr<restriction> rest) {
+    if (auto other = dynamic_pointer_cast<LIKE>(rest)) {
+        boost::copy(other->_values, back_inserter(_values));
+    } else {
+        throw exceptions::invalid_request_exception(
+                format("{} cannot be restricted by both LIKE and non-LIKE restrictions", _column_def.name_as_text()));
+    }
 }
+
+::shared_ptr<single_column_restriction> single_column_restriction::LIKE::apply_to(const column_definition& cdef) {
+    auto r = ::make_shared<LIKE>(cdef, _values[0]);
+    std::copy(_values.cbegin() + 1, _values.cend(), back_inserter(r->_values));
+    return r;
+}
+
+} // namespace restrictions
+} // namespace cql3

--- a/test/boost/cql_query_test.cc
+++ b/test/boost/cql_query_test.cc
@@ -4137,10 +4137,15 @@ SEASTAR_TEST_CASE(test_like_operator_conjunction) {
         cquery_nofail(e, "insert into t (s1, s2) values ('a', 'A')");
         require_rows(e, "select * from t where s1 like 'a%' and s2 like '__C' allow filtering",
                      {{T("abc"), T("ABC")}});
+        require_rows(e, "select * from t where s1 like 'a%' and s1 like '__C' allow filtering", {});
+        require_rows(e, "select s1 from t where s1 like 'a%' and s1 like '_' allow filtering", {{T("a")}});
+        require_rows(e, "select s1 from t where s1 like 'a%' and s1 like '%' allow filtering", {{T("a")}, {T("abc")}});
+        require_rows(e, "select s1 from t where s1 like 'a%' and s1 like '_b_' and s1 like '%c' allow filtering",
+                     {{T("abc")}});
         BOOST_REQUIRE_EXCEPTION(
                 e.execute_cql("select * from t where s1 like 'a%' and s1 = 'abc' allow filtering").get(),
                 exceptions::invalid_request_exception,
-                exception_predicate::message_contains("more than one relation"));
+                exception_predicate::message_contains("LIKE and non-LIKE"));
     });
 }
 

--- a/test/boost/like_matcher_test.cc
+++ b/test/boost/like_matcher_test.cc
@@ -434,3 +434,17 @@ BOOST_AUTO_TEST_CASE(test_dollar) {
     BOOST_TEST(matches(matcher(u8"a$bc"), u8"a$bc"));
     BOOST_TEST(matches(matcher(u8R"(a\$bc)"), u8"a$bc"));
 }
+
+BOOST_AUTO_TEST_CASE(test_reset) {
+    auto m = matcher(u8"alpha");
+    BOOST_TEST(matches(m, u8"alpha"));
+    m.reset(bytes(u8"omega"));
+    BOOST_TEST(!matches(m, u8"alpha"));
+    BOOST_TEST(matches(m, u8"omega"));
+    m.reset(bytes(u8"omega"));
+    BOOST_TEST(!matches(m, u8"alpha"));
+    BOOST_TEST(matches(m, u8"omega"));
+    m.reset(bytes(u8"alpha"));
+    BOOST_TEST(matches(m, u8"alpha"));
+    BOOST_TEST(!matches(m, u8"omega"));
+}

--- a/utils/like_matcher.cc
+++ b/utils/like_matcher.cc
@@ -124,6 +124,8 @@ like_matcher::like_matcher(bytes_view pattern)
 
 like_matcher::~like_matcher() = default;
 
+like_matcher::like_matcher(like_matcher&& that) noexcept = default;
+
 bool like_matcher::operator()(bytes_view text) const {
     return _impl->operator()(text);
 }

--- a/utils/like_matcher.hh
+++ b/utils/like_matcher.hh
@@ -49,4 +49,7 @@ public:
     ///
     /// \return true iff text matches constructor's pattern.
     bool operator()(bytes_view text) const;
+
+    /// Resets pattern if different from the current one.
+    void reset(bytes_view pattern);
 };

--- a/utils/like_matcher.hh
+++ b/utils/like_matcher.hh
@@ -43,6 +43,8 @@ public:
     /// \param pattern UTF-8 encoded pattern with wildcards '_' and '%'.
     explicit like_matcher(bytes_view pattern);
 
+    like_matcher(like_matcher&&) noexcept; // Must be defined in .cc, where class impl is known.
+
     ~like_matcher();
 
     /// Runs the compiled pattern on \c text.


### PR DESCRIPTION
Fixes #5902 by making the LIKE restriction keep a vector of matchers and apply them all to the column value.

Tests: unit (dev)