### PR TITLE
cdc: do not attempt to log empty mutations

### DIFF
--- a/cdc/split.cc
+++ b/cdc/split.cc
@@ -372,7 +372,8 @@ bool should_split(const mutation& base_mutation, const schema& base_schema) {
         return true;
     }
 
-    return false;
+    // A mutation with no timestamp will be split into 0 mutations
+    return found_ts == api::missing_timestamp;
 }
 
 std::vector<mutation> split(const mutation& base_mutation, const schema_ptr& base_schema) {

--- a/test/boost/cdc_test.cc
+++ b/test/boost/cdc_test.cc
@@ -1182,5 +1182,17 @@ SEASTAR_THREAD_TEST_CASE(test_change_splitting) {
                 }) != result.end());
             }
         }
+
+        cquery_nofail(e, "delete from ks.t where pk = 2 and ck < 1 and ck > 2;");
+
+        {
+            auto result = get_result(
+                {int32_type, int32_type, m_type, boolean_type, oper_type},
+                "select v1, v2, m, \"cdc$deleted_m\", \"cdc$operation\""
+                " from ks.t_scylla_cdc_log where pk = 2 allow filtering");
+
+            // A delete from a degenerate row range should produce no rows in CDC log
+            BOOST_REQUIRE_EQUAL(result.size(), 0);
+        }
     }, mk_cdc_test_config()).get();
 }


### PR DESCRIPTION
It is possible to produce an empty mutation using CQL. For example, the following query:

```cql
DELETE FROM ks.tbl WHERE pk = 0 AND ck < 1 AND ck > 2;
```

will attempt to delete from an empty range of rows. This is translated to the following mutation:

```
{ks.tbl {key: pk{000400000000}, token:-3485513579396041028}
 {mutation_partition:
  static: cont=1 {row: },
  clustered: {}}}
```

Such mutation does not contain any timestamp, therefore it is difficult to determine what timestamp was used while making the query. This is problematic for CDC, because an entry in CDC log should be written with the same timestamp as the original mutation.

Because an empty mutation does not modify the table in any way, we can safely skip logging such mutations in CDC and still preserve the ability to reconstruct the current state of the base table from full CDC log.

Tests: unit(dev)
Fixes:  #5920