### PR TITLE
cdc: distinguishing inserts from updates

### DIFF
--- a/cdc/log.hh
+++ b/cdc/log.hh
@@ -124,7 +124,8 @@ enum class operation : int8_t {
     // note: these values will eventually be read by a third party, probably not privvy to this
     // enum decl, so don't change the constant values (or the datatype).
     pre_image = 0, update = 1, row_delete = 2, partition_delete = 3,
-    range_delete_start_inclusive = 4, range_delete_start_exclusive = 5, range_delete_end_inclusive = 6, range_delete_end_exclusive = 7
+    range_delete_start_inclusive = 4, range_delete_start_exclusive = 5, range_delete_end_inclusive = 6, range_delete_end_exclusive = 7,
+    insert = 8,
 };
 
 // cdc log data column operation


### PR DESCRIPTION
New kind of `operation` is introduced: "insert". It is reported in CDC log whenever the incoming mutation has a live row marker.

Fixes #5723