### PR TITLE
Allow Major compactions for TWCS

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -784,6 +784,7 @@ scylla_core = (['database.cc',
                 'utils/ascii.cc',
                 'utils/like_matcher.cc',
                 'mutation_writer/timestamp_based_splitting_writer.cc',
+                'mutation_writer/shard_based_splitting_writer.cc',
                 'lua.cc',
                 ] + [Antlr3Grammar('cql3/Cql.g')] + [Thrift('interface/cassandra.thrift', 'Cassandra')]
                )

--- a/mutation_writer/feed_writers.hh
+++ b/mutation_writer/feed_writers.hh
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2020 ScyllaDB
+ */
+
+/*
+ * This file is part of Scylla.
+ *
+ * Scylla is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Scylla is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "flat_mutation_reader.hh"
+
+namespace mutation_writer {
+using reader_consumer = noncopyable_function<future<> (flat_mutation_reader)>;
+
+template <typename Writer>
+GCC6_CONCEPT(
+    requires MutationFragmentConsumer<Writer, future<>>()
+)
+future<> feed_writer(flat_mutation_reader&& rd, Writer&& wr) {
+    return do_with(std::move(rd), std::move(wr), [] (flat_mutation_reader& rd, Writer& wr) {
+        return rd.fill_buffer(db::no_timeout).then([&rd, &wr] {
+            return do_until([&rd] { return rd.is_buffer_empty() && rd.is_end_of_stream(); }, [&rd, &wr] {
+                auto f1 = rd.pop_mutation_fragment().consume(wr);
+                auto f2 = rd.is_buffer_empty() ? rd.fill_buffer(db::no_timeout) : make_ready_future<>();
+                return when_all_succeed(std::move(f1), std::move(f2));
+            });
+        }).finally([&wr] {
+            return wr.consume_end_of_stream();
+        });
+    });
+}
+
+}

--- a/mutation_writer/shard_based_splitting_writer.cc
+++ b/mutation_writer/shard_based_splitting_writer.cc
@@ -1,0 +1,113 @@
+/*
+ * Copyright (C) 2020 ScyllaDB
+ */
+
+/*
+ * This file is part of Scylla.
+ *
+ * Scylla is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Scylla is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "mutation_writer/shard_based_splitting_writer.hh"
+
+#include <cinttypes>
+#include <boost/range/adaptor/transformed.hpp>
+#include <boost/range/algorithm/min_element.hpp>
+#include <seastar/core/shared_mutex.hh>
+
+#include "mutation_reader.hh"
+
+namespace mutation_writer {
+
+class shard_based_splitting_mutation_writer {
+    class shard_writer {
+        queue_reader_handle _handle;
+        future<> _consume_fut;
+    private:
+        shard_writer(schema_ptr schema, std::pair<flat_mutation_reader, queue_reader_handle> queue_reader, reader_consumer& consumer)
+            : _handle(std::move(queue_reader.second))
+            , _consume_fut(consumer(std::move(queue_reader.first))) {
+        }
+
+    public:
+        shard_writer(schema_ptr schema, reader_consumer& consumer)
+            : shard_writer(schema, make_queue_reader(schema), consumer) {
+        }
+        future<> consume(mutation_fragment mf) {
+            return _handle.push(std::move(mf));
+        }
+        future<> consume_end_of_stream() {
+            _handle.push_end_of_stream();
+            return std::move(_consume_fut);
+        }
+    };
+
+private:
+    schema_ptr _schema;
+    reader_consumer _consumer;
+    unsigned _current_shard;
+    std::vector<std::optional<shard_writer>> _shards;
+
+    future<> write_to_shard(mutation_fragment&& mf) {
+        auto& writer = *_shards[_current_shard];
+        return writer.consume(std::move(mf));
+    }
+public:
+    shard_based_splitting_mutation_writer(schema_ptr schema, reader_consumer consumer)
+        : _schema(std::move(schema))
+        , _consumer(std::move(consumer))
+        , _shards(smp::count)
+    {}
+
+    future<> consume(partition_start&& ps) {
+        _current_shard = _schema->get_partitioner().shard_of(ps.key().token());
+        if (!_shards[_current_shard]) {
+            _shards[_current_shard] = shard_writer(_schema, _consumer);
+        }
+        return write_to_shard(std::move(ps));
+    }
+
+    future<> consume(static_row&& sr) {
+        return write_to_shard(std::move(sr));
+    }
+
+    future<> consume(clustering_row&& cr) {
+        return write_to_shard(std::move(cr));
+    }
+
+    future<> consume(range_tombstone&& rt) {
+        return write_to_shard(std::move(rt));
+    }
+
+    future<> consume(partition_end&& pe) {
+        return write_to_shard(std::move(pe));
+    }
+
+    future<> consume_end_of_stream() {
+        return parallel_for_each(_shards, [] (std::optional<shard_writer>& shard) {
+            if (!shard) {
+                return make_ready_future<>();
+            }
+            return shard->consume_end_of_stream();
+        });
+    }
+};
+
+future<> segregate_by_shard(flat_mutation_reader producer, reader_consumer consumer) {
+    auto schema = producer.schema();
+    return feed_writer(
+        std::move(producer),
+        shard_based_splitting_mutation_writer(std::move(schema), std::move(consumer)));
+}
+} // namespace mutation_writer

--- a/mutation_writer/shard_based_splitting_writer.hh
+++ b/mutation_writer/shard_based_splitting_writer.hh
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2020 ScyllaDB
+ */
+
+/*
+ * This file is part of Scylla.
+ *
+ * Scylla is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Scylla is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <seastar/util/noncopyable_function.hh>
+
+#include "feed_writers.hh"
+
+namespace mutation_writer {
+
+// Given a producer that may contain data for all shards, consume it in a per-shard
+// manner. This is useful, for instance, in the resharding process where a user changes
+// the amount of CPU assigned to Scylla and we have to rewrite the SSTables to their new
+// owners.
+future<> segregate_by_shard(flat_mutation_reader producer, reader_consumer consumer);
+
+} // namespace mutation_writer

--- a/mutation_writer/timestamp_based_splitting_writer.hh
+++ b/mutation_writer/timestamp_based_splitting_writer.hh
@@ -23,13 +23,11 @@
 
 #include <seastar/util/noncopyable_function.hh>
 
-#include "flat_mutation_reader.hh"
+#include "feed_writers.hh"
 
 namespace mutation_writer {
 
 using classify_by_timestamp = noncopyable_function<int64_t(api::timestamp_type)>;
-using reader_consumer = noncopyable_function<future<> (flat_mutation_reader)>;
-
 future<> segregate_by_timestamp(flat_mutation_reader producer, classify_by_timestamp classifier, reader_consumer consumer);
 
 } // namespace mutation_writer

--- a/sstables/compaction.cc
+++ b/sstables/compaction.cc
@@ -68,6 +68,7 @@
 #include "leveled_manifest.hh"
 #include "utils/observable.hh"
 #include "dht/token.hh"
+#include "mutation_writer/shard_based_splitting_writer.hh"
 
 namespace sstables {
 
@@ -124,18 +125,22 @@ static std::vector<shared_sstable> get_uncompacting_sstables(column_family& cf, 
 
 class compaction;
 
+struct compaction_writer {
+    sstable_writer writer;
+    shared_sstable sst;
+};
+
 class compacting_sstable_writer {
     compaction& _c;
-    sstable_writer* _writer = nullptr;
+    std::optional<compaction_writer> _writer = {};
 public:
-    explicit compacting_sstable_writer(compaction& c) : _c(c) {}
-
+    explicit compacting_sstable_writer(compaction& c) : _c(c) { }
     void consume_new_partition(const dht::decorated_key& dk);
 
-    void consume(tombstone t) { _writer->consume(t); }
-    stop_iteration consume(static_row&& sr, tombstone, bool) { return _writer->consume(std::move(sr)); }
-    stop_iteration consume(clustering_row&& cr, row_tombstone, bool) { return _writer->consume(std::move(cr)); }
-    stop_iteration consume(range_tombstone&& rt) { return _writer->consume(std::move(rt)); }
+    void consume(tombstone t) { _writer->writer.consume(t); }
+    stop_iteration consume(static_row&& sr, tombstone, bool) { return _writer->writer.consume(std::move(sr)); }
+    stop_iteration consume(clustering_row&& cr, row_tombstone, bool) { return _writer->writer.consume(std::move(cr)); }
+    stop_iteration consume(range_tombstone&& rt) { return _writer->writer.consume(std::move(rt)); }
 
     stop_iteration consume_end_of_partition();
     void consume_end_of_stream();
@@ -429,11 +434,10 @@ protected:
         }
     }
 
-    void finish_new_sstable(std::optional<sstable_writer>& writer, shared_sstable& sst) {
-        writer->consume_end_of_stream();
-        writer = std::nullopt;
-        sst->open_data().get0();
-        _info->end_size += sst->bytes_on_disk();
+    void finish_new_sstable(compaction_writer* writer) {
+        writer->writer.consume_end_of_stream();
+        writer->sst->open_data().get0();
+        _info->end_size += writer->sst->bytes_on_disk();
         // Notify GC'ed-data sstable writer's handler that an output sstable has just been sealed.
         // The handler is responsible for making sure that deleting an input sstable will not
         // result in resurrection on failure.
@@ -472,7 +476,11 @@ private:
     // Default range sstable reader that will only return mutation that belongs to current shard.
     virtual flat_mutation_reader make_sstable_reader() const = 0;
 
-    flat_mutation_reader setup() {
+    template <typename GCConsumer>
+    GCC6_CONCEPT(
+        requires CompactedFragmentsConsumer<GCConsumer>
+    )
+    future<> setup(GCConsumer gc_consumer) {
         auto ssts = make_lw_shared<sstables::sstable_set>(_cf.get_compaction_strategy().make_sstable_set(_schema));
         sstring formatted_msg = "[";
         auto fully_expired = get_fully_expired_sstables(_cf, _sstables, gc_clock::now() - _schema->gc_grace_seconds());
@@ -512,8 +520,24 @@ private:
         report_start(formatted_msg);
 
         _compacting = std::move(ssts);
-        return make_sstable_reader();
+
+        auto now = gc_clock::now();
+        auto consumer = make_interposer_consumer([this, gc_consumer = std::move(gc_consumer), now] (flat_mutation_reader reader) mutable
+        {
+            using compact_mutations = compact_for_compaction<compacting_sstable_writer, GCConsumer>;
+            auto cfc = make_stable_flattened_mutations_consumer<compact_mutations>(*schema(), now,
+                                         max_purgeable_func(),
+                                         get_compacting_sstable_writer(),
+                                         std::move(gc_consumer));
+
+            return seastar::async([cfc = std::move(cfc), reader = std::move(reader), this] () mutable {
+                reader.consume_in_thread(std::move(cfc), make_partition_filter(), db::no_timeout);
+            });
+        });
+        return consumer(make_sstable_reader());
     }
+
+    virtual reader_consumer make_interposer_consumer(reader_consumer end_consumer) = 0;
 
     compaction_info finish(std::chrono::time_point<db_clock> started_at, std::chrono::time_point<db_clock> ended_at) {
         _info->ended_at = std::chrono::duration_cast<std::chrono::milliseconds>(ended_at.time_since_epoch()).count();
@@ -562,14 +586,16 @@ private:
         };
     }
 
+    virtual void on_new_partition() = 0;
+
     virtual shared_sstable create_new_sstable() const = 0;
 
-    // select a sstable writer based on decorated key.
-    virtual sstable_writer* select_sstable_writer(const dht::decorated_key& dk) = 0;
+    // create a writer based on decorated key.
+    virtual compaction_writer create_compaction_writer(const dht::decorated_key& dk) = 0;
     // stop current writer
-    virtual void stop_sstable_writer() = 0;
+    virtual void stop_sstable_writer(compaction_writer* writer) = 0;
     // finish all writers.
-    virtual void finish_sstable_writer() = 0;
+    virtual void finish_sstable_writer(compaction_writer* writer) = 0;
 
     compacting_sstable_writer get_compacting_sstable_writer() {
         return compacting_sstable_writer(*this);
@@ -623,23 +649,30 @@ void compacting_sstable_writer::consume_new_partition(const dht::decorated_key& 
         // Compaction manager will catch this exception and re-schedule the compaction.
         throw compaction_stop_exception(_c._info->ks_name, _c._info->cf_name, _c._info->stop_requested);
     }
-    _writer = _c.select_sstable_writer(dk);
-    _writer->consume_new_partition(dk);
+    if (!_writer) {
+        _writer = _c.create_compaction_writer(dk);
+    }
+
+    _c.on_new_partition();
+    _writer->writer.consume_new_partition(dk);
     _c._info->total_keys_written++;
 }
 
 stop_iteration compacting_sstable_writer::consume_end_of_partition() {
-    auto ret = _writer->consume_end_of_partition();
+    auto ret = _writer->writer.consume_end_of_partition();
     if (ret == stop_iteration::yes) {
         // stop sstable writer being currently used.
-        _c.stop_sstable_writer();
+        _c.stop_sstable_writer(&*_writer);
+        _writer = std::nullopt;
     }
     return ret;
 }
 
 void compacting_sstable_writer::consume_end_of_stream() {
-    // this will stop any writer opened by compaction.
-    _c.finish_sstable_writer();
+    // this will stop any writer opened by compaction. It still needs to be called
+    // even if we don't have a current writer, so that the compaction can do its
+    // final cleanups like replacements, etc.
+    _c.finish_sstable_writer(_writer ? &*_writer : nullptr);
 }
 
 void garbage_collected_sstable_writer::setup_on_new_sstable_sealed_handler() {
@@ -694,8 +727,6 @@ class regular_compaction : public compaction {
     // used to incrementally calculate max purgeable timestamp, as we iterate through decorated keys.
     std::optional<sstable_set::incremental_selector> _selector;
     // sstable being currently written.
-    shared_sstable _sst;
-    std::optional<sstable_writer> _writer;
     std::optional<compaction_weight_registration> _weight_registration;
     mutable compaction_read_monitor_generator _monitor_generator;
     std::deque<compaction_write_monitor> _active_write_monitors = {};
@@ -726,6 +757,10 @@ public:
                 ::streamed_mutation::forwarding::no,
                 ::mutation_reader::forwarding::no,
                 _monitor_generator);
+    }
+
+    reader_consumer make_interposer_consumer(reader_consumer end_consumer) override {
+        return std::move(end_consumer);
     }
 
     void report_start(const sstring& formatted_msg) const override {
@@ -759,34 +794,34 @@ public:
         return _creator();
     }
 
-    virtual sstable_writer* select_sstable_writer(const dht::decorated_key& dk) override {
-        if (!_writer) {
-            _sst = _creator();
-            setup_new_sstable(_sst);
+    virtual compaction_writer create_compaction_writer(const dht::decorated_key& dk) override {
+        auto sst = _creator();
+        setup_new_sstable(sst);
 
-            _active_write_monitors.emplace_back(_sst, _cf, maximum_timestamp(), _sstable_level);
-            auto&& priority = service::get_local_compaction_priority();
-            sstable_writer_config cfg = _cf.get_sstables_manager().configure_writer();
-            cfg.max_sstable_size = _max_sstable_size;
-            cfg.monitor = &_active_write_monitors.back();
-            cfg.run_identifier = _run_identifier;
-            _writer.emplace(_sst->get_writer(*_schema, partitions_per_sstable(), cfg, get_encoding_stats(), priority));
+        _active_write_monitors.emplace_back(sst, _cf, maximum_timestamp(), _sstable_level);
+        auto&& priority = service::get_local_compaction_priority();
+        sstable_writer_config cfg = _cf.get_sstables_manager().configure_writer();
+        cfg.max_sstable_size = _max_sstable_size;
+        cfg.monitor = &_active_write_monitors.back();
+        cfg.run_identifier = _run_identifier;
+        return compaction_writer{sst->get_writer(*_schema, partitions_per_sstable(), cfg, get_encoding_stats(), priority), sst};
+    }
+
+    virtual void stop_sstable_writer(compaction_writer* writer) override {
+        if (writer) {
+            finish_new_sstable(writer);
+            maybe_replace_exhausted_sstables_by_sst(writer->sst);
         }
-        do_pending_replacements();
-        return &*_writer;
     }
 
-    virtual void stop_sstable_writer() override {
-        finish_new_sstable(_writer, _sst);
-        maybe_replace_exhausted_sstables();
-    }
-
-    virtual void finish_sstable_writer() override {
+    virtual void finish_sstable_writer(compaction_writer* writer) override {
         on_end_of_stream();
-        if (_writer) {
-            stop_sstable_writer();
-        }
+        stop_sstable_writer(writer);
         replace_remaining_exhausted_sstables();
+    }
+
+    void on_new_partition() override {
+        update_pending_ranges();
     }
 private:
     void on_end_of_stream() {
@@ -814,14 +849,14 @@ private:
         _active_write_monitors.clear();
     }
 
-    void maybe_replace_exhausted_sstables() {
+    void maybe_replace_exhausted_sstables_by_sst(shared_sstable sst) {
         // Skip earlier replacement of exhausted sstables if compaction works with only single-fragment runs,
         // meaning incremental compaction is disabled for this compaction.
         if (!_contains_multi_fragment_runs) {
             return;
         }
         // Replace exhausted sstable(s), if any, by new one(s) in the column family.
-        auto not_exhausted = [s = _schema, &dk = _sst->get_last_decorated_key()] (shared_sstable& sst) {
+        auto not_exhausted = [s = _schema, &dk = sst->get_last_decorated_key()] (shared_sstable& sst) {
             return sst->get_last_decorated_key().tri_compare(*s, dk) > 0;
         };
         auto exhausted = std::partition(_sstables.begin(), _sstables.end(), not_exhausted);
@@ -849,7 +884,7 @@ private:
         }
     }
 
-    void do_pending_replacements() {
+    void update_pending_ranges() {
         if (_set.all()->empty() || _info->pending_replacements.empty()) { // set can be empty for testing scenario.
             return;
         }
@@ -1141,8 +1176,6 @@ flat_mutation_reader make_scrubbing_reader(flat_mutation_reader rd, bool skip_co
 }
 
 class resharding_compaction final : public compaction {
-    std::vector<std::pair<shared_sstable, std::optional<sstable_writer>>> _output_sstables;
-    shard_id _shard; // shard of current sstable writer
     std::function<shared_sstable(shard_id)> _sstable_creator;
     compaction_backlog_tracker _resharding_backlog_tracker;
 
@@ -1171,7 +1204,6 @@ public:
     resharding_compaction(std::vector<shared_sstable> sstables, column_family& cf, std::function<shared_sstable(shard_id)> creator,
             uint64_t max_sstable_size, uint32_t sstable_level)
         : compaction(cf, std::move(sstables), max_sstable_size, sstable_level)
-        , _output_sstables(smp::count)
         , _sstable_creator(std::move(creator))
         , _resharding_backlog_tracker(std::make_unique<resharding_backlog_tracker>())
         , _estimation_per_shard(smp::count)
@@ -1212,6 +1244,13 @@ public:
                 nullptr,
                 ::streamed_mutation::forwarding::no,
                 ::mutation_reader::forwarding::no);
+
+    }
+
+    reader_consumer make_interposer_consumer(reader_consumer end_consumer) override {
+        return [this, end_consumer = std::move(end_consumer)] (flat_mutation_reader reader) mutable -> future<> {
+            return mutation_writer::segregate_by_shard(std::move(reader), std::move(end_consumer));
+        };
     }
 
     void report_start(const sstring& formatted_msg) const override {
@@ -1230,38 +1269,29 @@ public:
         abort();
     }
 
-    sstable_writer* select_sstable_writer(const dht::decorated_key& dk) override {
-        _shard = dht::shard_of(*_schema, dk.token());
-        auto& sst = _output_sstables[_shard].first;
-        auto& writer = _output_sstables[_shard].second;
+    compaction_writer create_compaction_writer(const dht::decorated_key& dk) override {
+        auto shard = dht::shard_of(*_schema, dk.token());
+        auto sst = _sstable_creator(shard);
+        setup_new_sstable(sst);
 
-        if (!writer) {
-            sst = _sstable_creator(_shard);
-            setup_new_sstable(sst);
-
-            sstable_writer_config cfg = _cf.get_sstables_manager().configure_writer();
-            cfg.max_sstable_size = _max_sstable_size;
-            // sstables generated for a given shard will share the same run identifier.
-            cfg.run_identifier = _run_identifiers.at(_shard);
-            auto&& priority = service::get_local_compaction_priority();
-            writer.emplace(sst->get_writer(*_schema, partitions_per_sstable(_shard), cfg, get_encoding_stats(), priority, _shard));
-        }
-        return &*writer;
+        sstable_writer_config cfg = _cf.get_sstables_manager().configure_writer();
+        cfg.max_sstable_size = _max_sstable_size;
+        // sstables generated for a given shard will share the same run identifier.
+        cfg.run_identifier = _run_identifiers.at(shard);
+        auto&& priority = service::get_local_compaction_priority();
+        return compaction_writer{sst->get_writer(*_schema, partitions_per_sstable(shard), cfg, get_encoding_stats(), priority, shard), sst};
     }
 
-    void stop_sstable_writer() override {
-        auto& sst = _output_sstables[_shard].first;
-        auto& writer = _output_sstables[_shard].second;
+    void on_new_partition() override {}
 
-        finish_new_sstable(writer, sst);
+    void stop_sstable_writer(compaction_writer* writer) override {
+        if (writer) {
+            finish_new_sstable(writer);
+        }
     }
 
-    void finish_sstable_writer() override {
-        for (auto& p : _output_sstables) {
-            if (p.second) {
-                finish_new_sstable(p.second, p.first);
-            }
-        }
+    void finish_sstable_writer(compaction_writer* writer) override {
+        stop_sstable_writer(writer);
     }
 };
 
@@ -1271,22 +1301,13 @@ GCC6_CONCEPT(
 )
 future<compaction_info> compaction::run(std::unique_ptr<compaction> c, GCConsumer gc_consumer) {
     return seastar::async([c = std::move(c), gc_consumer = std::move(gc_consumer)] () mutable {
-        auto reader = c->setup();
-
-        auto cr = c->get_compacting_sstable_writer();
-        auto cfc = make_stable_flattened_mutations_consumer<compact_for_compaction<compacting_sstable_writer, GCConsumer>>(
-                    *c->schema(), gc_clock::now(), c->max_purgeable_func(), std::move(cr), std::move(gc_consumer));
-
+        auto consumer = c->setup(std::move(gc_consumer));
         auto start_time = db_clock::now();
         try {
-            // make sure the readers are all gone before the compaction object is gone. We will
-            // leave this block either successfully or exceptionally with the reader object
-            // destroyed.
-            auto r = std::move(reader);
-            r.consume_in_thread(std::move(cfc), c->make_partition_filter(), db::no_timeout);
+           consumer.get();
         } catch (...) {
             c->delete_sstables_for_interrupted_compaction();
-            c = nullptr; // make sure writers are stopped while running in thread context
+            c = nullptr; // make sure writers are stopped while running in thread context. This is because of calls to file.close().get();
             throw;
         }
 

--- a/sstables/compaction.cc
+++ b/sstables/compaction.cc
@@ -1225,7 +1225,9 @@ public:
     void backlog_tracker_adjust_charges() override { }
 
     shared_sstable create_new_sstable() const override {
-        return _sstable_creator(_shard);
+        // create_new_sstables is used only from the garbage_collected writer.
+        // It it not supposed to work with resharding compactions
+        abort();
     }
 
     sstable_writer* select_sstable_writer(const dht::decorated_key& dk) override {

--- a/sstables/compaction.cc
+++ b/sstables/compaction.cc
@@ -69,6 +69,7 @@
 #include "utils/observable.hh"
 #include "dht/token.hh"
 #include "mutation_writer/shard_based_splitting_writer.hh"
+#include "mutation_source_metadata.hh"
 
 namespace sstables {
 
@@ -400,6 +401,7 @@ protected:
     encoding_stats_collector _stats_collector;
     utils::observable<> _on_new_sstable_sealed;
     bool _contains_multi_fragment_runs = false;
+    mutation_source_metadata _ms_metadata = {};
 protected:
     compaction(column_family& cf, std::vector<shared_sstable> sstables, uint64_t max_sstable_size, uint32_t sstable_level)
         : _cf(cf)
@@ -421,7 +423,8 @@ protected:
 
     uint64_t partitions_per_sstable() const {
         uint64_t estimated_sstables = std::max(1UL, uint64_t(ceil(double(_info->start_size) / _max_sstable_size)));
-        return ceil(double(_estimated_partitions) / estimated_sstables);
+        return std::min(uint64_t(ceil(double(_estimated_partitions) / estimated_sstables)),
+                        _cf.get_compaction_strategy().adjust_partition_estimate(_ms_metadata, _estimated_partitions));
     }
 
     void setup_new_sstable(shared_sstable& sst) {
@@ -760,7 +763,7 @@ public:
     }
 
     reader_consumer make_interposer_consumer(reader_consumer end_consumer) override {
-        return std::move(end_consumer);
+        return _cf.get_compaction_strategy().make_interposer_consumer(_ms_metadata, std::move(end_consumer));
     }
 
     void report_start(const sstring& formatted_msg) const override {
@@ -1198,7 +1201,11 @@ private:
     // return estimated partitions per sstable for a given shard
     uint64_t partitions_per_sstable(shard_id s) const {
         uint64_t estimated_sstables = std::max(uint64_t(1), uint64_t(ceil(double(_estimation_per_shard[s].estimated_size) / _max_sstable_size)));
-        return ceil(double(_estimation_per_shard[s].estimated_partitions) / estimated_sstables);
+        // As we adjust this estimate downwards from the compaction strategy, it can get to 0 so
+        // make sure we're returning at least 1.
+        return std::max(uint64_t(1),
+                std::min(uint64_t(ceil(double(_estimation_per_shard[s].estimated_partitions) / estimated_sstables)),
+                _cf.get_compaction_strategy().adjust_partition_estimate(_ms_metadata, _estimation_per_shard[s].estimated_partitions)));
     }
 public:
     resharding_compaction(std::vector<shared_sstable> sstables, column_family& cf, std::function<shared_sstable(shard_id)> creator,

--- a/test/boost/sstable_datafile_test.cc
+++ b/test/boost/sstable_datafile_test.cc
@@ -5657,3 +5657,78 @@ SEASTAR_TEST_CASE(incremental_compaction_data_resurrection_test) {
         BOOST_REQUIRE(is_partition_dead(alpha));
     });
 }
+
+SEASTAR_TEST_CASE(twcs_major_compaction_test) {
+    // Tests that two mutations that were written a month apart are compacted
+    // to two different SSTables, whereas two mutations that were written 1ms apart
+    // are compacted to the same SSTable.
+    return test_env::do_with_async([] (test_env& env) {
+        storage_service_for_tests ssft;
+        cell_locker_stats cl_stats;
+
+        // In a column family with gc_grace_seconds set to 0, check that a tombstone
+        // is purged after compaction.
+        auto builder = schema_builder("tests", "twcs_major")
+                .with_column("id", utf8_type, column_kind::partition_key)
+                .with_column("cl", int32_type, column_kind::clustering_key)
+                .with_column("value", int32_type);
+        auto s = builder.build();
+
+        auto tmp = tmpdir();
+        auto sst_gen = [&env, s, &tmp, gen = make_lw_shared<unsigned>(1)] () mutable {
+            return env.make_sstable(s, tmp.path().string(), (*gen)++, la, big);
+        };
+
+        auto next_timestamp = [] (auto step) {
+            using namespace std::chrono;
+            return (api::timestamp_clock::now().time_since_epoch() - duration_cast<microseconds>(step)).count();
+        };
+
+        auto make_insert = [&] (api::timestamp_clock::duration step) {
+            static thread_local int32_t value = 1;
+
+            auto key_and_token_pair = token_generation_for_current_shard(1);
+            auto key_str = key_and_token_pair[0].first;
+            auto key = partition_key::from_exploded(*s, {to_bytes(key_str)});
+
+            mutation m(s, key);
+            auto c_key = clustering_key::from_exploded(*s, {int32_type->decompose(value++)});
+            m.set_clustered_cell(c_key, bytes("value"), data_value(int32_t(value)), next_timestamp(step));
+            return m;
+        };
+
+
+        // Two mutations, one of them 30 days ago. Should be split when
+        // compacting
+        auto mut1 = make_insert(0ms);
+        auto mut2 = make_insert(720h);
+
+        // Two mutations, close together. Should end up in the same SSTable
+        auto mut3 = make_insert(0ms);
+        auto mut4 = make_insert(1ms);
+
+        auto cm = make_lw_shared<compaction_manager>();
+        column_family::config cfg = column_family_test_config();
+        cfg.datadir = tmp.path().string();
+        cfg.enable_disk_writes = true;
+        cfg.enable_commitlog = false;
+        cfg.enable_cache = false;
+        cfg.enable_incremental_backups = false;
+            reader_concurrency_semaphore sem = reader_concurrency_semaphore(reader_concurrency_semaphore::no_limits{});
+            cfg.read_concurrency_semaphore = &sem;
+        auto tracker = make_lw_shared<cache_tracker>();
+        auto cf = make_lw_shared<column_family>(s, cfg, column_family::no_commitlog(), *cm, cl_stats, *tracker);
+        cf->mark_ready_for_writes();
+        cf->start();
+        cf->set_compaction_strategy(sstables::compaction_strategy_type::time_window);
+
+        auto original_together = make_sstable_containing(sst_gen, {mut3, mut4});
+
+        auto ret = sstables::compact_sstables(sstables::compaction_descriptor({original_together}), *cf, sst_gen, replacer_fn_no_op()).get0();
+        BOOST_REQUIRE(ret.new_sstables.size() == 1);
+
+        auto original_apart = make_sstable_containing(sst_gen, {mut1, mut2});
+        ret = sstables::compact_sstables(sstables::compaction_descriptor({original_apart}), *cf, sst_gen, replacer_fn_no_op()).get0();
+        BOOST_REQUIRE(ret.new_sstables.size() == 2);
+    });
+}


### PR DESCRIPTION
This patch makes makes major compaction aware of time buckets
for TWCS. That means that calling a major compaction with TWCS
will not bundle all SSTables together, but rather split them
based on their timestamps.
    
There are two motivations for this work:
1. Telling users not to ever major compact is easier said than
    done: in practice due to a variety of circumstances it might
    end up being done in which case data will have a hard time
    expiring later.
    
2. We are about to start working with offstrategy compactions,
    which are compactions that work in parallel with the main
    compactions. In those cases we may be converting SSTables from
    one format to another and it might be necessary to split a single
    big STCS SSTable into something that TWCS expects
    
In order to achieve that, we start by changing the way resharding works:
it will now work with a read interposer, similar to the one TWCS uses for
streaming data. Once we do that, a lot of assumptions that exist in the
compaction code can be simplified and supporting TWCS major
compactions become a matter of simply enabling its interposer in the
compaction code as well.

There are many further simplifications that this work exposes:
* The compaction method create_new_sstable seems out of place. It is not
   used by resharding, and it seems duplicated for normal compactions. We
   could clean it up with more refactoring in a later patch.
* The whole logic of the feed_writer could be part of the consumer code.

Testing details:
- scylla unit tests (dev, release)
- sstable_datafile_test (debug)
- dtests (resharding_test.py)
- manual scylla resharding