### PR TITLE
cdc: distinguishing update from insert

### DIFF
--- a/cdc/log.hh
+++ b/cdc/log.hh
@@ -123,8 +123,8 @@ struct db_context final {
 enum class operation : int8_t {
     // note: these values will eventually be read by a third party, probably not privvy to this
     // enum decl, so don't change the constant values (or the datatype).
-    pre_image = 0, update = 1, row_delete = 2, partition_delete = 3,
-    range_delete_start_inclusive = 4, range_delete_start_exclusive = 5, range_delete_end_inclusive = 6, range_delete_end_exclusive = 7
+    pre_image = 0, update = 1, insert = 2, row_delete = 3, partition_delete = 4,
+    range_delete_start_inclusive = 5, range_delete_start_exclusive = 6, range_delete_end_inclusive = 7, range_delete_end_exclusive = 8,
 };
 
 // cdc log data column operation


### PR DESCRIPTION
When incoming mutation contains live row marker the `operation` is
described as "insert", not as an "update".

Test cases that relied on "update" being the same as "insert" are
updated accordingly (`test_pre_image_logging`, `test_cdc_across_shards`,
`test_add_columns`). **It had to be done in one commit to avoid test-breaking
revision**. Also, I extended the test case "test_row_delete" with one insert,
which is expected to log different value of `operation` than update
or delete. Renamed the test case accordingly.

Fixes #5723