### PR TITLE
docker: rsyslog configuration fixes

### DIFF
--- a/dist/docker/redhat/etc/rsyslog.conf
+++ b/dist/docker/redhat/etc/rsyslog.conf
@@ -13,7 +13,7 @@ global(workDirectory="/var/lib/rsyslog")
 module(load="builtin:omfile" Template="RSYSLOG_TraditionalFileFormat")
 
 # Include all config files in /etc/rsyslog.d/
-include(file="/etc/rsyslog.d/*.conf" mode="optional")
+$IncludeConfig "/etc/rsyslog.d/*.conf"
 
 #### MODULES ####
 

--- a/dist/docker/redhat/etc/supervisord.conf.d/rsyslog.conf
+++ b/dist/docker/redhat/etc/supervisord.conf.d/rsyslog.conf
@@ -1,5 +1,5 @@
 [program:rsyslog]
-command=rsyslogd
+command=rsyslogd -n
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr


### PR DESCRIPTION
The introduction of rsyslog had two errors in it.
Both errors are non fatal and the docker still works,
however, the system is left in a wrong state in which
supervisord marks rsyslogd service as failed (after several
failed retry attempts). Another bug in the configuration
causes rsyslog to output an error.

1) An inclusion command from a newer version was used
in rsyslogs main configuration file. This caused to rsyslog
to complain during startup but it didn't do much damage since
rsyslog converts every unrecognised command to a message command.
2) in the supervisord definition of the service, rsyslogd is ran
without the -n option which means it defaults to automatically
switch to the background. Supervisord interpret this as an unexpected
process termination and retries to start the process (unsuccessfully
because rsyslog protects itself from having multiple processes of
itself) and eventually marks it as down although it is fully up and
running.
This commit fixes both configuration problems.

Tests: Build and run docker and validate the errors are gone.
Fixes #5937