### PR TITLE
cdc log: merge stream_id columns into a single column

### DIFF
--- a/cdc/generation.cc
+++ b/cdc/generation.cc
@@ -78,10 +78,9 @@ int64_t stream_id::second() const {
 }
 
 partition_key stream_id::to_partition_key(const schema& log_schema) const {
-    return partition_key::from_exploded(log_schema,
-            { long_type->decompose(_first), long_type->decompose(_second) });
+    return partition_key::from_single_value(log_schema,
+            long_type->decompose(_first) + long_type->decompose(_second));
 }
-
 
 bool token_range_description::operator==(const token_range_description& o) const {
     return token_range_end == o.token_range_end && streams == o.streams

--- a/cdc/log.cc
+++ b/cdc/log.cc
@@ -293,8 +293,7 @@ bytes log_data_column_deleted_elements_name_bytes(const bytes& column_name) {
 static schema_ptr create_log_schema(const schema& s, std::optional<utils::UUID> uuid) {
     schema_builder b(s.ks_name(), log_name(s.cf_name()));
     b.set_comment(sprint("CDC log for %s.%s", s.ks_name(), s.cf_name()));
-    b.with_column(log_meta_column_name_bytes("stream_id_1"), long_type, column_kind::partition_key);
-    b.with_column(log_meta_column_name_bytes("stream_id_2"), long_type, column_kind::partition_key);
+    b.with_column(log_meta_column_name_bytes("stream_id"), bytes_type, column_kind::partition_key);
     b.with_column(log_meta_column_name_bytes("time"), timeuuid_type, column_kind::clustering_key);
     b.with_column(log_meta_column_name_bytes("batch_seq_no"), int32_type, column_kind::clustering_key);
     b.with_column(log_meta_column_name_bytes("operation"), data_type_for<operation_native_type>());

--- a/test/boost/cdc_test.cc
+++ b/test/boost/cdc_test.cc
@@ -226,20 +226,19 @@ SEASTAR_THREAD_TEST_CASE(test_permissions_of_cdc_log_table) {
 
         // Allow MODIFY, SELECT, ALTER
         auto log_table = "ks." + cdc::log_name("tbl");
-        auto stream_id_1 = cdc::log_meta_column_name("stream_id_1");
-        auto stream_id_2 = cdc::log_meta_column_name("stream_id_2");
+        auto stream_id = cdc::log_meta_column_name("stream_id");
         auto time = cdc::log_meta_column_name("time");
         auto batch_seq_no = cdc::log_meta_column_name("batch_seq_no");
         auto ttl = cdc::log_meta_column_name("ttl");
 
-        e.execute_cql(format("INSERT INTO {} (\"{}\", \"{}\", \"{}\", \"{}\") VALUES (0, 0, now(), 0)",
-            log_table, stream_id_1, stream_id_2, time, batch_seq_no        
+        e.execute_cql(format("INSERT INTO {} (\"{}\", \"{}\", \"{}\") VALUES (0x00000000000000000000000000000000, now(), 0)",
+            log_table, stream_id, time, batch_seq_no
         )).get();
-        e.execute_cql(format("UPDATE {} SET \"{}\"= 100 WHERE \"{}\" = 0 AND \"{}\" = 0 AND \"{}\" = now() AND \"{}\" = 0",
-            log_table, ttl, stream_id_1, stream_id_2, time, batch_seq_no
+        e.execute_cql(format("UPDATE {} SET \"{}\"= 100 WHERE \"{}\" = 0x00000000000000000000000000000000 AND \"{}\" = now() AND \"{}\" = 0",
+            log_table, ttl, stream_id, time, batch_seq_no
         )).get();
-        e.execute_cql(format("DELETE FROM {} WHERE \"{}\" = 0 AND \"{}\" = 0 AND \"{}\" = now() AND \"{}\" = 0",
-            log_table, stream_id_1, stream_id_2, time, batch_seq_no
+        e.execute_cql(format("DELETE FROM {} WHERE \"{}\" = 0x00000000000000000000000000000000 AND \"{}\" = now() AND \"{}\" = 0",
+            log_table, stream_id, time, batch_seq_no
         )).get();
         e.execute_cql("SELECT * FROM " + log_table).get();
         e.execute_cql("ALTER TABLE " + log_table + " ALTER \"" + ttl + "\" TYPE blob").get();


### PR DESCRIPTION
Previously we had stream_id_1 and stream_id_2 columns
of type long each. They were forming a partition key.

In a new format we want a single stream_id column that
forms a partition key. To be able to still store two
longs, the new column will have type blob and its value
will be concatenated bytes of two longs that
partition key is composed of.

We still want partition key to logically be two longs
because those two values will be used by a custom partitioner
later once we implement it.

Signed-off-by: Piotr Jastrzebski <piotr@scylladb.com>