### PR TITLE
CDC+LWT: fix missing CDC entries for successful LWTs

### DIFF
--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -1177,10 +1177,47 @@ future<bool> paxos_response_handler::accept_proposal(const paxos::proposal& prop
 future<> paxos_response_handler::learn_decision(paxos::proposal decision, bool allow_hints) {
     tracing::trace(tr_state, "learn_decision: committing {} with cl={}", decision, _cl_for_learn);
     paxos::paxos_state::logger.trace("CAS[{}] learn_decision: committing {} with cl={}", _id, decision, _cl_for_learn);
-    std::array<std::tuple<paxos::proposal, schema_ptr, dht::token>, 1> m{std::make_tuple(std::move(decision), _schema, _key.token())};
     // FIXME: allow_hints is ignored. Consider if we should follow it and remove if not.
     // Right now we do not store hints for when committing decisions.
-    return _proxy->mutate_internal(std::move(m), _cl_for_learn, false, tr_state, _permit, _timeout);
+
+    // `mutate_internal` behaves differently when its template parameter is a range of mutations and when it's
+    // a range of (decision, schema, token)-tuples. Both code paths diverge on `create_write_response_handler`.
+    // We use the first path for CDC mutations (if present) and the latter for "paxos mutations".
+    // Attempts to send both kinds of mutations in one shot caused an infinite loop.
+    future<> f_cdc = make_ready_future<>();
+    if (_schema->cdc_options().enabled()) {
+        auto update_mut = decision.update.unfreeze(_schema);
+        const auto base_tbl_id = update_mut.column_family_id();
+        std::vector<mutation> update_mut_vec{std::move(update_mut)};
+
+        if (_proxy->get_cdc_service()->needs_cdc_augmentation(update_mut_vec)) {
+            f_cdc = _proxy->get_cdc_service()->augment_mutation_call(_timeout, std::move(update_mut_vec))
+                    .then([this, base_tbl_id] (std::tuple<std::vector<mutation>, cdc::result_callback>&& t) {
+                auto mutations = std::move(std::get<0>(t));
+                auto end_func = std::move(std::get<1>(t));
+
+                // Pick only the CDC ("augmenting") mutations
+                mutations.erase(std::remove_if(mutations.begin(), mutations.end(), [base_tbl_id = std::move(base_tbl_id)] (const mutation& v) {
+                    return v.schema()->id() == base_tbl_id;
+                }), mutations.end());
+                if (mutations.empty()) {
+                    return make_ready_future<>();
+                }
+
+                auto f = _proxy->mutate_internal(std::move(mutations), _cl_for_learn, false, tr_state, _permit, _timeout);
+                if (end_func) {
+                    f = f.then(std::move(end_func));
+                }
+                return f;
+            });
+        }
+    }
+
+    // Path for the "base" mutations
+    std::array<std::tuple<paxos::proposal, schema_ptr, dht::token>, 1> m{std::make_tuple(std::move(decision), _schema, _key.token())};
+    future<> f_lwt = _proxy->mutate_internal(std::move(m), _cl_for_learn, false, tr_state, _permit, _timeout);
+
+    return when_all_succeed(std::move(f_cdc), std::move(f_lwt));
 }
 
 static std::vector<gms::inet_address>


### PR DESCRIPTION
Now, if CDC is enabled, `paxos_response_handler::learn_decision()`
augments the base table mutation. The differences in logic between:
(1) `mutate_internal<std::vector<mutation>>()`
and
(2) `mutate_internal<std::vector<std::tuple<paxos::proposal, schema_ptr, ...>>>()`
make it necessary to separate "CDC mutations" from "base mutation"
and send them, respectively, to (1) and (2).

Test will come in a separate PR, because LWT queries from test suite are not routed to correct shards (IIUC `bounce_to_shard` is not handled in test env).

Fixes #5869