### PR TITLE
CDC: use a single `cdc$time` value for a batch of changes

### DIFF
--- a/cdc/log.cc
+++ b/cdc/log.cc
@@ -938,9 +938,11 @@ cdc::cdc_service::impl::augment_mutation_call(lowres_clock::time_point timeout, 
                 auto& m = mutations[idx];
                 auto& s = m.schema();
                 if (should_split(m, *s)) {
-                    for (auto&& mm : split(m, s)) {
-                        mutations.push_back(trans.transform(mm, rs.get()));
-                    }
+                    std::vector<mutation> res;
+                    for_each_change(m, s, [&] (mutation mm) {
+                        res.push_back(trans.transform(std::move(mm), rs.get()));
+                    });
+                    mutations.insert(mutations.end(), std::make_move_iterator(res.begin()), std::make_move_iterator(res.end()));
                 } else {
                     mutations.push_back(trans.transform(m, rs.get()));
                 }

--- a/cdc/split.cc
+++ b/cdc/split.cc
@@ -375,13 +375,12 @@ bool should_split(const mutation& base_mutation, const schema& base_schema) {
     return false;
 }
 
-std::vector<mutation> split(const mutation& base_mutation, const schema_ptr& base_schema) {
+void for_each_change(const mutation& base_mutation, const schema_ptr& base_schema, std::function<void(mutation)> f) {
     auto changes = extract_changes(base_mutation, *base_schema);
-    std::vector<mutation> result;
+
     for (auto& [change_ts, btch] : changes) {
         for (auto& sr_update : btch.static_updates) {
-            result.emplace_back(base_schema, base_mutation.key());
-            auto& m = result.back();
+            mutation m(base_schema, base_mutation.key());
             for (auto& atomic_update : sr_update.atomic_entries) {
                 auto& cdef = base_schema->column_at(column_kind::static_column, atomic_update.id);
                 m.set_static_cell(cdef, std::move(atomic_update.cell));
@@ -394,12 +393,13 @@ std::vector<mutation> split(const mutation& base_mutation, const schema_ptr& bas
                 auto& cdef = base_schema->column_at(column_kind::static_column, nonatomic_update.id);
                 m.set_static_cell(cdef, collection_mutation_description{{}, std::move(nonatomic_update.cells)}.serialize(*cdef.type));
             }
+            f(std::move(m));
         }
 
         for (auto& cr_insert : btch.clustered_inserts) {
-            result.emplace_back(base_schema, base_mutation.key());
-            auto& row = result.back().partition().clustered_row(*base_schema, cr_insert.key);
+            mutation m(base_schema, base_mutation.key());
 
+            auto& row = m.partition().clustered_row(*base_schema, cr_insert.key);
             for (auto& atomic_update : cr_insert.atomic_entries) {
                 auto& cdef = base_schema->column_at(column_kind::regular_column, atomic_update.id);
                 row.cells().apply(cdef, std::move(atomic_update.cell));
@@ -408,14 +408,15 @@ std::vector<mutation> split(const mutation& base_mutation, const schema_ptr& bas
                 auto& cdef = base_schema->column_at(column_kind::regular_column, nonatomic_delete.id);
                 row.cells().apply(cdef, collection_mutation_description{nonatomic_delete.t, {}}.serialize(*cdef.type));
             }
-
             row.apply(cr_insert.marker);
+
+            f(std::move(m));
         }
 
         for (auto& cr_update : btch.clustered_updates) {
-            result.emplace_back(base_schema, base_mutation.key());
-            auto& row = result.back().partition().clustered_row(*base_schema, cr_update.key).cells();
+            mutation m(base_schema, base_mutation.key());
 
+            auto& row = m.partition().clustered_row(*base_schema, cr_update.key).cells();
             for (auto& atomic_update : cr_update.atomic_entries) {
                 auto& cdef = base_schema->column_at(column_kind::regular_column, atomic_update.id);
                 row.apply(cdef, std::move(atomic_update.cell));
@@ -428,24 +429,28 @@ std::vector<mutation> split(const mutation& base_mutation, const schema_ptr& bas
                 auto& cdef = base_schema->column_at(column_kind::static_column, nonatomic_update.id);
                 row.apply(cdef, collection_mutation_description{{}, std::move(nonatomic_update.cells)}.serialize(*cdef.type));
             }
+
+            f(std::move(m));
         }
 
         for (auto& cr_delete : btch.clustered_row_deletions) {
-            result.emplace_back(base_schema, base_mutation.key());
-            result.back().partition().apply_delete(*base_schema, cr_delete.key, cr_delete.t);
+            mutation m(base_schema, base_mutation.key());
+            m.partition().apply_delete(*base_schema, cr_delete.key, cr_delete.t);
+            f(std::move(m));
         }
 
         for (auto& crange_delete : btch.clustered_range_deletions) {
-            result.emplace_back(base_schema, base_mutation.key());
-            result.back().partition().apply_delete(*base_schema, crange_delete.rt);
+            mutation m(base_schema, base_mutation.key());
+            m.partition().apply_delete(*base_schema, crange_delete.rt);
+            f(std::move(m));
         }
 
         if (btch.partition_deletions) {
-            result.emplace_back(base_schema, base_mutation.key());
-            result.back().partition().apply(btch.partition_deletions->t);
+            mutation m(base_schema, base_mutation.key());
+            m.partition().apply(btch.partition_deletions->t);
+            f(std::move(m));
         }
     }
-    return result;
 }
 
 } // namespace cdc

--- a/cdc/split.hh
+++ b/cdc/split.hh
@@ -29,6 +29,6 @@ class mutation;
 namespace cdc {
 
 bool should_split(const mutation& base_mutation, const schema& base_schema);
-std::vector<mutation> split(const mutation& base_mutation, const schema_ptr& base_schema);
+void for_each_change(const mutation& base_mutation, const schema_ptr& base_schema, std::function<void(mutation)>);
 
 }

--- a/cdc/split.hh
+++ b/cdc/split.hh
@@ -29,6 +29,7 @@ class mutation;
 namespace cdc {
 
 bool should_split(const mutation& base_mutation, const schema& base_schema);
-void for_each_change(const mutation& base_mutation, const schema_ptr& base_schema, std::function<void(mutation)>);
+void for_each_change(const mutation& base_mutation, const schema_ptr& base_schema,
+        std::function<void(mutation, api::timestamp_type, bytes, int&)>);
 
 }

--- a/test/boost/cdc_test.cc
+++ b/test/boost/cdc_test.cc
@@ -1102,20 +1102,20 @@ SEASTAR_THREAD_TEST_CASE(test_change_splitting) {
 
         {
             auto result = get_result(
-                {int32_type, int32_type, int32_type, boolean_type, m_type, keys_type, long_type},
-                "select \"cdc$batch_seq_no\", v1, v2, \"cdc$deleted_v2\", m, \"cdc$deleted_elements_m\", \"cdc$ttl\""
+                {int32_type, int32_type, boolean_type, m_type, keys_type, long_type},
+                "select v1, v2, \"cdc$deleted_v2\", m, \"cdc$deleted_elements_m\", \"cdc$ttl\""
                 " from ks.t_scylla_cdc_log where pk = 0 and ck = 1 allow filtering");
             BOOST_REQUIRE_EQUAL(result.size(), 4);
 
             std::vector<std::vector<data_value>> expected = {
                 // The following represents the "v1 = 5" change. The "v2 = null" change gets merged with a different change, see below
-                {int32_t(0), int32_t(5), int_null, bool_null, map_null, keys_null, int64_t(5)},
-                {int32_t(0), int_null, int_null, bool_null, vmap({{0,6},{1,6}}), keys_null, long_null /*FIXME: ttl = 6*/},
+                {int32_t(5), int_null, bool_null, map_null, keys_null, int64_t(5)},
+                {int_null, int_null, bool_null, vmap({{0,6},{1,6}}), keys_null, long_null /*FIXME: ttl = 6*/},
                 // The following represents the "m[2] = 7" change. The "m[3] = null" change gets merged with a different change, see below
-                {int32_t(0), int_null, int_null, bool_null, vmap({{2,7}}), keys_null, long_null /*FIXME: ttl = 7*/},
+                {int_null, int_null, bool_null, vmap({{2,7}}), keys_null, long_null /*FIXME: ttl = 7*/},
                 // The "v2 = null" and "v[3] = null" changes get merged with the "m[4] = 0" change, because dead cells
                 // don't have a "ttl" concept; thus we put them together with alive cells which don't have a ttl (so ttl column = null).
-                {int32_t(0), int_null, int_null, true, vmap({{4,0}}), vkeys({3}), long_null},
+                {int_null, int_null, true, vmap({{4,0}}), vkeys({3}), long_null},
             };
 
             // These changes have the same timestamp, so their relative order in CDC log is arbitrary
@@ -1124,6 +1124,13 @@ SEASTAR_THREAD_TEST_CASE(test_change_splitting) {
                     return er == r;
                 }) != result.end());
             }
+        }
+
+        {
+            auto result = get_result({int32_type},
+                "select \"cdc$batch_seq_no\" from ks.t_scylla_cdc_log where pk = 0 and ck = 1 allow filtering");
+            std::vector<std::vector<data_value>> expected = {{int32_t(0)}, {int32_t(1)}, {int32_t(2)}, {int32_t(3)}};
+            BOOST_REQUIRE_EQUAL(expected, result);
         }
 
         cquery_nofail(e, format(
@@ -1140,16 +1147,16 @@ SEASTAR_THREAD_TEST_CASE(test_change_splitting) {
 
         {
             auto result = get_result(
-                {int32_type, int32_type, m_type, boolean_type, oper_type},
-                "select v1, v2, m, \"cdc$deleted_m\", \"cdc$operation\""
+                {int32_type, int32_type, int32_type, m_type, boolean_type, oper_type},
+                "select \"cdc$batch_seq_no\", v1, v2, m, \"cdc$deleted_m\", \"cdc$operation\""
                 " from ks.t_scylla_cdc_log where pk = 1 allow filtering");
             BOOST_REQUIRE_EQUAL(result.size(), 7);
 
             std::vector<std::vector<data_value>> expected = {
-                {int_null, int_null, map_null, bool_null, oper_ut(cdc::operation::partition_delete)},
-                {int_null, int_null, map_null, bool_null, oper_ut(cdc::operation::range_delete_start_inclusive)},
-                {int_null, int_null, map_null, bool_null, oper_ut(cdc::operation::range_delete_end_exclusive)},
-                {int_null, int_null, map_null, bool_null, oper_ut(cdc::operation::row_delete)},
+                {int32_t(0), int_null, int_null, map_null, bool_null, oper_ut(cdc::operation::partition_delete)},
+                {int32_t(0), int_null, int_null, map_null, bool_null, oper_ut(cdc::operation::range_delete_start_inclusive)},
+                {int32_t(1), int_null, int_null, map_null, bool_null, oper_ut(cdc::operation::range_delete_end_exclusive)},
+                {int32_t(0), int_null, int_null, map_null, bool_null, oper_ut(cdc::operation::row_delete)},
 
                 // The following sequence of operations:
                 //     insert into ks.t (pk,ck,v1) values (1,0,1) using timestamp T;
@@ -1166,21 +1173,12 @@ SEASTAR_THREAD_TEST_CASE(test_change_splitting) {
                 //        and a {3:3} cell with timestamp T + 1. Thus we merge the tombstone into the T update,
                 //        and we add a T + 1 update to express the addition of the {3:3} cell.
                 //
-                {int32_t(1), int32_t(2), map_null, true, oper_ut(cdc::operation::update)},
-                {int_null, int_null, map_null, bool_null, oper_ut(cdc::operation::insert)},
-                {int_null, int_null, vmap({{3,3}}), bool_null, oper_ut(cdc::operation::update)},
+                {int32_t(0), int32_t(1), int32_t(2), map_null, true, oper_ut(cdc::operation::update)},
+                {int32_t(0), int_null, int_null, map_null, bool_null, oper_ut(cdc::operation::insert)},
+                {int32_t(1), int_null, int_null, vmap({{3,3}}), bool_null, oper_ut(cdc::operation::update)},
             };
 
-            // The first 5 changes have different timestamps, so we can compare the order.
-            BOOST_REQUIRE(std::equal(expected.begin(), expected.begin() + 5, result.begin()));
-
-            // The last 2 changes have a higher timestamp than the other 5, but between the two the timestamp is the same.
-            // Thus their relative order in the CDC log is arbitrary.
-            for (auto it = expected.begin() + 5; it != expected.end(); ++it) {
-                BOOST_REQUIRE(std::find_if(result.begin() + 5, result.end(), [&] (const std::vector<data_value>& r) {
-                    return *it == r;
-                }) != result.end());
-            }
+            BOOST_REQUIRE_EQUAL(expected, result);
         }
     }, mk_cdc_test_config()).get();
 }


### PR DESCRIPTION
If a batch update is performed with a sequence of changes with a single timestamp, they will now show up in CDC with a single timeuuid in the `cdc$time` column, distinguished by different `cdc$batch_seq_no` values.

Fixes https://github.com/scylladb/scylla/issues/5953.