### PR TITLE
docker: apply scylla-jmx sysconfig file on scylla-jmx service

### DIFF
--- a/dist/docker/redhat/scylla-jmx-service.sh
+++ b/dist/docker/redhat/scylla-jmx-service.sh
@@ -2,4 +2,4 @@
 
 source /etc/sysconfig/scylla-jmx
 
-exec /opt/scylladb/jmx/scylla-jmx -l /opt/scylladb/jmx
+exec /opt/scylladb/jmx/scylla-jmx $SCYLLA_JMX_PORT $SCYLLA_API_PORT $SCYLLA_API_ADDR $SCYLLA_JMX_ADDR $SCYLLA_JMX_FILE $SCYLLA_JMX_LOCAL $SCYLLA_JMX_REMOTE $SCYLLA_JMX_DEBUG


### PR DESCRIPTION
Apply scylla-jmx sysconfig file on scyla-jmx service, to allow customize
jmx parameter.

Fixes #5939