### PR TITLE
Clean up stream_id representation

### DIFF
--- a/cdc/generation.cc
+++ b/cdc/generation.cc
@@ -70,6 +70,10 @@ bool stream_id::operator==(const stream_id& o) const {
     return _value == o._value;
 }
 
+bool stream_id::operator<(const stream_id& o) const {
+    return _value < o._value;
+}
+
 int64_t stream_id::first() const {
     assert(_value.size() == 2 * sizeof(int64_t));
     return seastar::read_le<int64_t>(reinterpret_cast<const char*>(_value.begin()));
@@ -342,11 +346,7 @@ static void do_update_streams_description(
         throw std::runtime_error(format("could not find streams data for timestamp {}", streams_ts));
     }
 
-    auto streams_less = [] (cdc::stream_id s1, cdc::stream_id s2) {
-        return s1.first() < s2.first() || (s1.first() == s2.first() && s1.second() < s2.second());
-    };
-
-    std::set<cdc::stream_id, decltype(streams_less)> streams_set(streams_less);
+    std::set<cdc::stream_id> streams_set;
     for (auto& entry: topo->entries()) {
         for (auto& s: entry.streams) {
             streams_set.insert(s);

--- a/cdc/generation.cc
+++ b/cdc/generation.cc
@@ -162,8 +162,7 @@ topology_description generate_topology_description(
     }
 
     auto schema = schema_builder("fake_ks", "fake_table")
-        .with_column("stream_id_1", long_type, column_kind::partition_key)
-        .with_column("stream_id_2", long_type, column_kind::partition_key)
+        .with_column("stream_id", bytes_type, column_kind::partition_key)
         .build();
 
     auto quota = std::chrono::seconds(spots_to_fill / 2000 + 1);

--- a/cdc/generation.cc
+++ b/cdc/generation.cc
@@ -347,9 +347,7 @@ static void do_update_streams_description(
 
     std::set<cdc::stream_id> streams_set;
     for (auto& entry: topo->entries()) {
-        for (auto& s: entry.streams) {
-            streams_set.insert(s);
-        }
+        streams_set.insert(entry.streams.begin(), entry.streams.end());
     }
 
     std::vector<cdc::stream_id> streams_vec(streams_set.begin(), streams_set.end());

--- a/cdc/generation.cc
+++ b/cdc/generation.cc
@@ -62,6 +62,8 @@ stream_id::stream_id(int64_t first, int64_t second)
     seastar::write_le(reinterpret_cast<char*>(_value.begin()) + sizeof(int64_t), second);
 }
 
+stream_id::stream_id(bytes b) : _value(std::move(b)) { }
+
 bool stream_id::is_set() const {
     return !_value.empty();
 }
@@ -82,6 +84,10 @@ int64_t stream_id::first() const {
 int64_t stream_id::second() const {
     assert(_value.size() == 2 * sizeof(int64_t));
     return seastar::read_le<int64_t>(reinterpret_cast<const char*>(_value.begin()) + sizeof(int64_t));
+}
+
+const bytes& stream_id::to_bytes() const {
+    return _value;
 }
 
 partition_key stream_id::to_partition_key(const schema& log_schema) const {

--- a/cdc/generation.hh
+++ b/cdc/generation.hh
@@ -68,6 +68,7 @@ public:
     stream_id(int64_t, int64_t);
     bool is_set() const;
     bool operator==(const stream_id&) const;
+    bool operator<(const stream_id&) const;
 
     int64_t first() const;
     int64_t second() const;

--- a/cdc/generation.hh
+++ b/cdc/generation.hh
@@ -62,14 +62,9 @@ namespace locator {
 namespace cdc {
 
 class stream_id final {
-    /* Currently stream IDs are just pairs of ints without any particular meaning given to these ints.
-     * After per-table partitioners are implemented, the first int will be the token
-     * (using a "take-the-first-int" partitioner) and the second int will be there to guarantee uniqueness
-     * of streams across different CDC generations. */
-    int64_t _first;
-    int64_t _second;
+    bytes _value;
 public:
-    stream_id();
+    stream_id() = default;
     stream_id(int64_t, int64_t);
     bool is_set() const;
     bool operator==(const stream_id&) const;

--- a/cdc/generation.hh
+++ b/cdc/generation.hh
@@ -66,12 +66,15 @@ class stream_id final {
 public:
     stream_id() = default;
     stream_id(int64_t, int64_t);
+    stream_id(bytes);
     bool is_set() const;
     bool operator==(const stream_id&) const;
     bool operator<(const stream_id&) const;
 
     int64_t first() const;
     int64_t second() const;
+
+    const bytes& to_bytes() const;
 
     partition_key to_partition_key(const schema& log_schema) const;
 };


### PR DESCRIPTION
With https://github.com/scylladb/scylla/pull/5950 we changed the representation of stream_id in CDC Log from two int columns to a single blob column.

This PR cleans up stream_id representation internally. Now stream_id is stored as blob both in-memory and in internal CDC tables.

Tests: unit(dev)