### PR TITLE
CDC: use a single `cdc$time` value for a batch of changes 

### DIFF
--- a/cdc/log.cc
+++ b/cdc/log.cc
@@ -966,9 +966,9 @@ cdc::cdc_service::impl::augment_mutation_call(lowres_clock::time_point timeout, 
                 auto& m = mutations[idx];
                 auto& s = m.schema();
                 if (should_split(m, *s)) {
-                    for (auto&& mm : split(m, s)) {
-                        mutations.push_back(trans.transform(mm, rs.get()));
-                    }
+                    for_each_change(m, s, [&] (mutation mm) {
+                        mutations.push_back(trans.transform(std::move(mm), rs.get()));
+                    });
                 } else {
                     mutations.push_back(trans.transform(m, rs.get()));
                 }

--- a/cdc/log.hh
+++ b/cdc/log.hh
@@ -41,6 +41,7 @@
 #include "exceptions/exceptions.hh"
 #include "timestamp.hh"
 #include "cdc_options.hh"
+#include "utils/UUID.hh"
 
 class schema;
 using schema_ptr = seastar::lw_shared_ptr<const schema>;
@@ -139,5 +140,7 @@ bytes log_data_column_deleted_name_bytes(const bytes& column_name);
 
 seastar::sstring log_data_column_deleted_elements_name(std::string_view column_name);
 bytes log_data_column_deleted_elements_name_bytes(const bytes& column_name);
+
+utils::UUID generate_timeuuid(api::timestamp_type t);
 
 } // namespace cdc

--- a/cdc/split.cc
+++ b/cdc/split.cc
@@ -23,6 +23,7 @@
 #include "schema.hh"
 
 #include "split.hh"
+#include "log.hh"
 
 struct atomic_column_update {
     column_id id;
@@ -376,11 +377,15 @@ bool should_split(const mutation& base_mutation, const schema& base_schema) {
     return found_ts == api::missing_timestamp;
 }
 
-void for_each_change(const mutation& base_mutation, const schema_ptr& base_schema, seastar::noncopyable_function<void(mutation)> f) {
+void for_each_change(const mutation& base_mutation, const schema_ptr& base_schema,
+        seastar::noncopyable_function<void(mutation, api::timestamp_type, bytes, int&)> f) {
     auto changes = extract_changes(base_mutation, *base_schema);
     auto pk = base_mutation.key();
 
     for (auto& [change_ts, btch] : changes) {
+        auto tuuid = timeuuid_type->decompose(generate_timeuuid(change_ts));
+        int batch_no = 0;
+
         for (auto& sr_update : btch.static_updates) {
             mutation m(base_schema, pk);
             for (auto& atomic_update : sr_update.atomic_entries) {
@@ -395,7 +400,7 @@ void for_each_change(const mutation& base_mutation, const schema_ptr& base_schem
                 auto& cdef = base_schema->column_at(column_kind::static_column, nonatomic_update.id);
                 m.set_static_cell(cdef, collection_mutation_description{{}, std::move(nonatomic_update.cells)}.serialize(*cdef.type));
             }
-            f(std::move(m));
+            f(std::move(m), change_ts, tuuid, batch_no);
         }
 
         for (auto& cr_insert : btch.clustered_inserts) {
@@ -412,7 +417,7 @@ void for_each_change(const mutation& base_mutation, const schema_ptr& base_schem
             }
             row.apply(cr_insert.marker);
 
-            f(std::move(m));
+            f(std::move(m), change_ts, tuuid, batch_no);
         }
 
         for (auto& cr_update : btch.clustered_updates) {
@@ -432,25 +437,25 @@ void for_each_change(const mutation& base_mutation, const schema_ptr& base_schem
                 row.apply(cdef, collection_mutation_description{{}, std::move(nonatomic_update.cells)}.serialize(*cdef.type));
             }
 
-            f(std::move(m));
+            f(std::move(m), change_ts, tuuid, batch_no);
         }
 
         for (auto& cr_delete : btch.clustered_row_deletions) {
             mutation m(base_schema, pk);
             m.partition().apply_delete(*base_schema, cr_delete.key, cr_delete.t);
-            f(std::move(m));
+            f(std::move(m), change_ts, tuuid, batch_no);
         }
 
         for (auto& crange_delete : btch.clustered_range_deletions) {
             mutation m(base_schema, pk);
             m.partition().apply_delete(*base_schema, crange_delete.rt);
-            f(std::move(m));
+            f(std::move(m), change_ts, tuuid, batch_no);
         }
 
         if (btch.partition_deletions) {
             mutation m(base_schema, pk);
             m.partition().apply(btch.partition_deletions->t);
-            f(std::move(m));
+            f(std::move(m), change_ts, tuuid, batch_no);
         }
     }
 }

--- a/cdc/split.hh
+++ b/cdc/split.hh
@@ -23,12 +23,13 @@
 
 #include <vector>
 #include "schema_fwd.hh"
+#include <seastar/util/noncopyable_function.hh>
 
 class mutation;
 
 namespace cdc {
 
 bool should_split(const mutation& base_mutation, const schema& base_schema);
-std::vector<mutation> split(const mutation& base_mutation, const schema_ptr& base_schema);
+void for_each_change(const mutation& base_mutation, const schema_ptr& base_schema, seastar::noncopyable_function<void(mutation)>);
 
 }

--- a/cdc/split.hh
+++ b/cdc/split.hh
@@ -30,6 +30,7 @@ class mutation;
 namespace cdc {
 
 bool should_split(const mutation& base_mutation, const schema& base_schema);
-void for_each_change(const mutation& base_mutation, const schema_ptr& base_schema, seastar::noncopyable_function<void(mutation)>);
+void for_each_change(const mutation& base_mutation, const schema_ptr& base_schema,
+        seastar::noncopyable_function<void(mutation, api::timestamp_type, bytes, int&)>);
 
 }


### PR DESCRIPTION
If a batch update is performed with a sequence of changes with a single timestamp, they will now show up in CDC with a single timeuuid in the cdc$time column, distinguished by different cdc$batch_seq_no values.

Fixes #5953.

Tests: unit(dev)