### PR TITLE
cdc: disallow creating nested cdc logs

### DIFF
--- a/cdc/log.cc
+++ b/cdc/log.cc
@@ -116,6 +116,9 @@ public:
             if (!was_cdc) {
                 check_that_cdc_log_table_does_not_exist(db, new_schema, log_name(new_schema.cf_name()));
             }
+            if (is_cdc) {
+                check_for_attempt_to_create_nested_cdc_log(new_schema);
+            }
 
             auto logname = log_name(old_schema.cf_name());
             auto& keyspace = db.find_keyspace(old_schema.ks_name());
@@ -161,6 +164,15 @@ public:
     future<> append_mutations(Iter i, Iter e, schema_ptr s, lowres_clock::time_point, std::vector<mutation>&);
 
 private:
+    static void check_for_attempt_to_create_nested_cdc_log(const schema& schema) {
+        const auto& cf_name = schema.cf_name();
+        const auto cf_name_view = std::string_view(cf_name.data(), cf_name.size());
+        if (is_log_for_some_table(schema.ks_name(), cf_name_view)) {
+            throw exceptions::invalid_request_exception(format("Cannot create a CDC log for a table {}.{}, because creating nested CDC logs is not allowed",
+                    schema.ks_name(), schema.cf_name()));
+        }
+    }
+
     static void check_that_cdc_log_table_does_not_exist(database& db, const schema& schema, const sstring& logname) {
         if (db.has_schema(schema.ks_name(), logname)) {
             throw exceptions::invalid_request_exception(format("Cannot create CDC log table for table {}.{} because a table of name {}.{} already exists",

--- a/test/cql/cdc_disallow_nested_cdc_logs_test.cql
+++ b/test/cql/cdc_disallow_nested_cdc_logs_test.cql
@@ -1,0 +1,2 @@
+create table tbl (pk int primary key) with cdc = {'enabled': true};
+alter table tbl_scylla_cdc_log with cdc = {'enabled': true};

--- a/test/cql/cdc_disallow_nested_cdc_logs_test.result
+++ b/test/cql/cdc_disallow_nested_cdc_logs_test.result
@@ -1,0 +1,9 @@
+create table tbl (pk int primary key) with cdc = {'enabled': true};
+{
+	"status" : "ok"
+}
+alter table tbl_scylla_cdc_log with cdc = {'enabled': true};
+{
+	"message" : "exceptions::invalid_request_exception (Cannot create a CDC log for a table ks.tbl_scylla_cdc_log, because creating nested CDC logs is not allowed)",
+	"status" : "error"
+}

--- a/test/tools/cql_repl.cc
+++ b/test/tools/cql_repl.cc
@@ -37,6 +37,8 @@
 #include "cql3/cql_config.hh"
 #include "cql3/type_json.hh"
 #include "test/lib/exception_utils.hh"
+#include "alternator/tags_extension.hh"
+#include "cdc/cdc_extension.hh"
 
 static std::ofstream std_cout;
 
@@ -113,7 +115,10 @@ std::unique_ptr<cql3::query_options> repl_options() {
 
 // Read-evaluate-print-loop for CQL
 void repl(seastar::app_template& app) {
-    auto db_cfg = make_shared<db::config>();
+    auto ext = std::make_shared<db::extensions>();
+    ext->add_schema_extension<alternator::tags_extension>(alternator::tags_extension::NAME);
+    ext->add_schema_extension<cdc::cdc_extension>(cdc::cdc_extension::NAME);
+    auto db_cfg = ::make_shared<db::config>(std::move(ext));
     db_cfg->enable_user_defined_functions({true}, db::config::config_source::CommandLine);
     db_cfg->experimental_features(db::experimental_features_t::all(), db::config::config_source::CommandLine);
     do_with_cql_env_thread([] (cql_test_env& e) {


### PR DESCRIPTION
This change disallows creating CDC log tables for already existing CDC log tables. CDC logs nested in that way are not really useful and do not work at the moment, therefore disallowing their creation prevents confusion.

Fixes #5967
Tests: unit(dev)