### PR TITLE
Replace dht::global_partitioner() calls with schema::get_partitioner

### DIFF
--- a/database.cc
+++ b/database.cc
@@ -1994,7 +1994,7 @@ std::ostream& operator<<(std::ostream& os, const keyspace_metadata& m) {
 template <typename T>
 using foreign_unique_ptr = foreign_ptr<std::unique_ptr<T>>;
 
-flat_mutation_reader make_multishard_streaming_reader(distributed<database>& db, dht::i_partitioner& partitioner, schema_ptr schema,
+flat_mutation_reader make_multishard_streaming_reader(distributed<database>& db, const dht::i_partitioner& partitioner, schema_ptr schema,
         std::function<std::optional<dht::partition_range>()> range_generator) {
     class streaming_reader_lifecycle_policy
             : public reader_lifecycle_policy

--- a/database.hh
+++ b/database.hh
@@ -1612,7 +1612,7 @@ future<> stop_database(sharded<database>& db);
 //
 // Shard readers are created via `table::make_streaming_reader()`.
 // Range generator must generate disjoint, monotonically increasing ranges.
-flat_mutation_reader make_multishard_streaming_reader(distributed<database>& db, dht::i_partitioner& partitioner, schema_ptr schema,
+flat_mutation_reader make_multishard_streaming_reader(distributed<database>& db, const dht::i_partitioner& partitioner, schema_ptr schema,
         std::function<std::optional<dht::partition_range>()> range_generator);
 
 future<utils::UUID> update_schema_version(distributed<service::storage_proxy>& proxy, db::schema_features);

--- a/dht/i_partitioner.hh
+++ b/dht/i_partitioner.hh
@@ -162,7 +162,7 @@ public:
      * @param key the raw, client-facing key
      * @return decorated version of key
      */
-    decorated_key decorate_key(const schema& s, const partition_key& key) {
+    decorated_key decorate_key(const schema& s, const partition_key& key) const {
         return { get_token(s, key), key };
     }
 
@@ -172,7 +172,7 @@ public:
      * @param key the raw, client-facing key
      * @return decorated version of key
      */
-    decorated_key decorate_key(const schema& s, partition_key&& key) {
+    decorated_key decorate_key(const schema& s, partition_key&& key) const {
         auto token = get_token(s, key);
         return { std::move(token), std::move(key) };
     }
@@ -192,7 +192,7 @@ public:
      * @return True if the implementing class preserves key order in the tokens
      * it generates.
      */
-    virtual bool preserves_order() = 0;
+    virtual bool preserves_order() const = 0;
 
     /**
      * @return name of partitioner.

--- a/dht/murmur3_partitioner.hh
+++ b/dht/murmur3_partitioner.hh
@@ -34,7 +34,7 @@ public:
     virtual const sstring name() const { return "org.apache.cassandra.dht.Murmur3Partitioner"; }
     virtual token get_token(const schema& s, partition_key_view key) const override;
     virtual token get_token(const sstables::key_view& key) const override;
-    virtual bool preserves_order() override { return false; }
+    virtual bool preserves_order() const override { return false; }
 private:
     token get_token(bytes_view key) const;
     token get_token(uint64_t value) const;

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -29,7 +29,6 @@
 #include "dht/sharder.hh"
 #include "to_string.hh"
 #include "xx_hasher.hh"
-#include "dht/i_partitioner.hh"
 #include "utils/UUID.hh"
 #include "utils/hash.hh"
 #include "service/priority_manager.hh"
@@ -383,8 +382,8 @@ public:
             column_family& cf,
             schema_ptr s,
             dht::token_range range,
-            dht::i_partitioner& local_partitioner,
-            dht::i_partitioner& remote_partitioner,
+            const dht::i_partitioner& local_partitioner,
+            const dht::i_partitioner& remote_partitioner,
             unsigned remote_shard,
             uint64_t seed,
             is_local_reader local_reader)
@@ -400,7 +399,7 @@ private:
     flat_mutation_reader
     make_reader(seastar::sharded<database>& db,
             column_family& cf,
-            dht::i_partitioner& local_partitioner,
+            const dht::i_partitioner& local_partitioner,
             is_local_reader local_reader) {
         if (local_reader) {
             return cf.make_streaming_reader(_schema, _range);

--- a/schema.cc
+++ b/schema.cc
@@ -102,7 +102,7 @@ std::ostream& operator<<(std::ostream& os, ordinal_column_id id)
     return os << static_cast<column_count_type>(id);
 }
 
-dht::i_partitioner& schema::get_partitioner() const {
+const dht::i_partitioner& schema::get_partitioner() const {
     return dht::global_partitioner();
 }
 

--- a/schema.hh
+++ b/schema.hh
@@ -812,7 +812,7 @@ public:
         return _raw._caching_options;
     }
 
-    dht::i_partitioner& get_partitioner() const;
+    const dht::i_partitioner& get_partitioner() const;
 
     const column_definition* get_column_definition(const bytes& name) const;
     const column_definition& column_at(column_kind, column_id) const;

--- a/sstables/binary_search.hh
+++ b/sstables/binary_search.hh
@@ -49,7 +49,7 @@ namespace sstables {
  * a key view via get_key().
  */
 template <typename T>
-int binary_search(dht::i_partitioner& partitioner, const T& entries, const key& sk, const dht::token& token) {
+int binary_search(const dht::i_partitioner& partitioner, const T& entries, const key& sk, const dht::token& token) {
     int low = 0, mid = entries.size(), high = mid - 1, result = -1;
 
     while (low <= high) {
@@ -80,7 +80,7 @@ int binary_search(dht::i_partitioner& partitioner, const T& entries, const key& 
 }
 
 template <typename T>
-int binary_search(dht::i_partitioner& partitioner, const T& entries, const key& sk) {
+int binary_search(const dht::i_partitioner& partitioner, const T& entries, const key& sk) {
     return binary_search(partitioner, entries, sk, partitioner.get_token(key_view(sk)));
 }
 

--- a/sstables/compaction_manager.cc
+++ b/sstables/compaction_manager.cc
@@ -651,8 +651,8 @@ static bool needs_cleanup(const sstables::shared_sstable& sst,
                    schema_ptr s) {
     auto first = sst->get_first_partition_key();
     auto last = sst->get_last_partition_key();
-    auto first_token = dht::global_partitioner().get_token(*s, first);
-    auto last_token = dht::global_partitioner().get_token(*s, last);
+    auto first_token = dht::get_token(*s, first);
+    auto last_token = dht::get_token(*s, last);
     dht::token_range sst_token_range = dht::token_range::make(first_token, last_token);
 
     // return true iff sst partition range isn't fully contained in any of the owned ranges.

--- a/test/boost/mutation_reader_test.cc
+++ b/test/boost/mutation_reader_test.cc
@@ -1951,7 +1951,7 @@ SEASTAR_TEST_CASE(test_trim_clustering_row_ranges_to) {
 
 // Shards tokens such that tokens are owned by shards in a round-robin manner.
 class dummy_partitioner : public dht::i_partitioner {
-    dht::i_partitioner& _partitioner;
+    const dht::i_partitioner& _partitioner;
     std::vector<dht::token> _tokens;
 
 public:
@@ -1961,7 +1961,7 @@ public:
     // ordered associative container (std::map) that has dht::token as keys.
     // Values will be ignored.
     template <typename T>
-    dummy_partitioner(dht::i_partitioner& partitioner, const std::map<dht::token, T>& something_by_token)
+    dummy_partitioner(const dht::i_partitioner& partitioner, const std::map<dht::token, T>& something_by_token)
         : i_partitioner(smp::count)
         , _partitioner(partitioner)
         , _tokens(boost::copy_range<std::vector<dht::token>>(something_by_token | boost::adaptors::map_keys)) {
@@ -1969,7 +1969,7 @@ public:
 
     virtual dht::token get_token(const schema& s, partition_key_view key) const override { return _partitioner.get_token(s, key); }
     virtual dht::token get_token(const sstables::key_view& key) const override { return _partitioner.get_token(key); }
-    virtual bool preserves_order() override { return _partitioner.preserves_order(); }
+    virtual bool preserves_order() const override { return _partitioner.preserves_order(); }
     virtual const sstring name() const override { return _partitioner.name(); }
     virtual unsigned shard_of(const dht::token& t) const override;
     virtual dht::token token_for_next_shard(const dht::token& t, shard_id shard, unsigned spans = 1) const override;

--- a/test/boost/sstable_datafile_test.cc
+++ b/test/boost/sstable_datafile_test.cc
@@ -1772,7 +1772,7 @@ static shared_sstable sstable_for_overlapping_test(test_env& env, const schema_p
 // ranges: [a,b] and [c,d]
 // returns true if token ranges overlap.
 static bool key_range_overlaps(column_family_for_tests& cf, sstring a, sstring b, sstring c, sstring d) {
-    dht::i_partitioner& p = cf->schema()->get_partitioner();
+    const dht::i_partitioner& p = cf->schema()->get_partitioner();
     auto range1 = create_token_range_from_keys(p, a, b);
     auto range2 = create_token_range_from_keys(p, c, d);
     return range1.overlaps(range2, dht::token_comparator());

--- a/test/boost/sstable_datafile_test.cc
+++ b/test/boost/sstable_datafile_test.cc
@@ -4669,7 +4669,6 @@ SEASTAR_TEST_CASE(sstable_scrub_test) {
             testlog.info("Writing sstable {}", sst->get_filename());
 
             {
-                auto& partitioner = dht::global_partitioner();
                 const auto ts = api::timestamp_type{1};
 
                 auto local_keys = make_local_keys(3, schema);
@@ -4695,7 +4694,7 @@ SEASTAR_TEST_CASE(sstable_scrub_test) {
 
                 auto write_partition = [&, schema, ts] (int pk, bool write_to_scrubbed) {
                     auto pkey = partition_key::from_deeply_exploded(*schema, { local_keys.at(pk) });
-                    auto dkey = partitioner.decorate_key(*schema, pkey);
+                    auto dkey = dht::decorate_key(*schema, pkey);
 
                     testlog.trace("Writing partition {}", pkey.with_schema(*schema));
 
@@ -4817,13 +4816,12 @@ SEASTAR_THREAD_TEST_CASE(sstable_scrub_reader_test) {
     std::deque<mutation_fragment> corrupt_fragments;
     std::deque<mutation_fragment> scrubbed_fragments;
 
-    auto& partitioner = dht::global_partitioner();
     const auto ts = api::timestamp_type{1};
     auto local_keys = make_local_keys(5, schema);
 
     auto make_partition_start = [&, schema] (unsigned pk) {
         auto pkey = partition_key::from_deeply_exploded(*schema, { local_keys.at(pk) });
-        auto dkey = partitioner.decorate_key(*schema, pkey);
+        auto dkey = dht::decorate_key(*schema, pkey);
         return partition_start(std::move(dkey), {});
     };
 

--- a/test/boost/sstable_test.hh
+++ b/test/boost/sstable_test.hh
@@ -142,7 +142,7 @@ public:
     }
 
     template <typename T>
-    int binary_search(dht::i_partitioner& p, const T& entries, const key& sk) {
+    int binary_search(const dht::i_partitioner& p, const T& entries, const key& sk) {
         return sstables::binary_search(p, entries, sk);
     }
 

--- a/test/lib/test_services.cc
+++ b/test/lib/test_services.cc
@@ -84,14 +84,14 @@ storage_service_for_tests::storage_service_for_tests() : _impl(std::make_unique<
 
 storage_service_for_tests::~storage_service_for_tests() = default;
 
-dht::token create_token_from_key(dht::i_partitioner& partitioner, sstring key) {
+dht::token create_token_from_key(const dht::i_partitioner& partitioner, sstring key) {
     sstables::key_view key_view = sstables::key_view(bytes_view(reinterpret_cast<const signed char*>(key.c_str()), key.size()));
     dht::token token = partitioner.get_token(key_view);
     assert(token == partitioner.get_token(key_view));
     return token;
 }
 
-range<dht::token> create_token_range_from_keys(dht::i_partitioner& partitioner, sstring start_key, sstring end_key) {
+range<dht::token> create_token_range_from_keys(const dht::i_partitioner& partitioner, sstring start_key, sstring end_key) {
     dht::token start = create_token_from_key(partitioner, start_key);
     assert(engine().cpu_id() == partitioner.shard_of(start));
     dht::token end = create_token_from_key(partitioner, end_key);

--- a/test/lib/test_services.hh
+++ b/test/lib/test_services.hh
@@ -73,5 +73,5 @@ struct column_family_for_tests {
     column_family* operator->() { return _data->cf.get(); }
 };
 
-dht::token create_token_from_key(dht::i_partitioner&, sstring key);
-range<dht::token> create_token_range_from_keys(dht::i_partitioner&, sstring start_key, sstring end_key);
+dht::token create_token_from_key(const dht::i_partitioner&, sstring key);
+range<dht::token> create_token_range_from_keys(const dht::i_partitioner&, sstring start_key, sstring end_key);


### PR DESCRIPTION
and make schema::get_partitioner return const&.

Partitioners returned from get_partitioner are shared and not supposed to be changed so let's use the type system to enforce that.

dht::global_partitioner() is deprecated and will be removed as soon as custom partitioners are implemented so it's best to replace it with schema::get_partitioner.

Tests: unit(dev)