### PR TITLE
cdc: correct static row preimage for case with no clustering row

### DIFF
--- a/cdc/log.cc
+++ b/cdc/log.cc
@@ -116,6 +116,9 @@ public:
             if (!was_cdc) {
                 check_that_cdc_log_table_does_not_exist(db, new_schema, log_name(new_schema.cf_name()));
             }
+            if (is_cdc) {
+                check_for_attempt_to_create_nested_cdc_log(new_schema);
+            }
 
             auto logname = log_name(old_schema.cf_name());
             auto& keyspace = db.find_keyspace(old_schema.ks_name());
@@ -161,6 +164,15 @@ public:
     future<> append_mutations(Iter i, Iter e, schema_ptr s, lowres_clock::time_point, std::vector<mutation>&);
 
 private:
+    static void check_for_attempt_to_create_nested_cdc_log(const schema& schema) {
+        const auto& cf_name = schema.cf_name();
+        const auto cf_name_view = std::string_view(cf_name.data(), cf_name.size());
+        if (is_log_for_some_table(schema.ks_name(), cf_name_view)) {
+            throw exceptions::invalid_request_exception(format("Cannot create a CDC log for a table {}.{}, because creating nested CDC logs is not allowed",
+                    schema.ks_name(), schema.cf_name()));
+        }
+    }
+
     static void check_that_cdc_log_table_does_not_exist(database& db, const schema& schema, const sstring& logname) {
         if (db.has_schema(schema.ks_name(), logname)) {
             throw exceptions::invalid_request_exception(format("Cannot create CDC log table for table {}.{} because a table of name {}.{} already exists",

--- a/cdc/log.cc
+++ b/cdc/log.cc
@@ -908,6 +908,7 @@ public:
 
         auto opts = selection->get_query_options();
         opts.set(query::partition_slice::option::collections_as_maps);
+        opts.set_if<query::partition_slice::option::always_return_static_content>(!p.static_row().empty());
 
         auto partition_slice = query::partition_slice(std::move(bounds), std::move(static_columns), std::move(regular_columns), std::move(opts));
         auto command = ::make_lw_shared<query::read_command>(_schema->id(), _schema->version(), partition_slice, row_limit);

--- a/test/cql/cdc_disallow_nested_cdc_logs_test.cql
+++ b/test/cql/cdc_disallow_nested_cdc_logs_test.cql
@@ -1,0 +1,2 @@
+create table tbl (pk int primary key) with cdc = {'enabled': true};
+alter table tbl_scylla_cdc_log with cdc = {'enabled': true};

--- a/test/cql/cdc_disallow_nested_cdc_logs_test.result
+++ b/test/cql/cdc_disallow_nested_cdc_logs_test.result
@@ -1,0 +1,9 @@
+create table tbl (pk int primary key) with cdc = {'enabled': true};
+{
+	"status" : "ok"
+}
+alter table tbl_scylla_cdc_log with cdc = {'enabled': true};
+{
+	"message" : "exceptions::invalid_request_exception (Cannot create a CDC log for a table ks.tbl_scylla_cdc_log, because creating nested CDC logs is not allowed)",
+	"status" : "error"
+}

--- a/test/cql/cdc_static_and_clustered_rows_test.cql
+++ b/test/cql/cdc_static_and_clustered_rows_test.cql
@@ -1,0 +1,22 @@
+create table ks.t (pk int, ck int, vs int static, vc int, primary key (pk, ck)) with cdc = {'enabled': true, 'preimage': true};
+
+-- generates 1 row: delta(static)
+update ks.t set vs = 0 where pk = 0;
+-- generates 2 rows: preimage(static), delta(static)
+update ks.t set vs = 1 where pk = 0;
+select "cdc$batch_seq_no", "cdc$operation", ck, vs, vc from ks.t_scylla_cdc_log where pk = 0 allow filtering;
+
+-- generates 3 rows: preimage(static), delta(static), delta(clustering)
+update ks.t set vs = 2, vc = 2 where pk = 0 and ck = 0;
+-- generates 4 rows: preimage(static), preimage(clustering), delta(static), delta(clustering)
+update ks.t set vs = 3, vc = 3 where pk = 0 and ck = 0;
+select "cdc$batch_seq_no", "cdc$operation", ck, vs, vc from ks.t_scylla_cdc_log where pk = 0 and ck = 0 allow filtering;
+
+-- generates 1 row: delta(clustering)
+update ks.t set vc = 4 where pk = 1 and ck = 0;
+-- generates 2 rows: preimage(clustering), delta(clustering)
+update ks.t set vc = 5 where pk = 1 and ck = 0;
+select "cdc$batch_seq_no", "cdc$operation", ck, vs, vc from ks.t_scylla_cdc_log where pk = 1 and ck = 0 allow filtering;
+
+-- there should be 13 rows in total
+select count(*) from ks.t_scylla_cdc_log;

--- a/test/cql/cdc_static_and_clustered_rows_test.result
+++ b/test/cql/cdc_static_and_clustered_rows_test.result
@@ -1,0 +1,126 @@
+create table ks.t (pk int, ck int, vs int static, vc int, primary key (pk, ck)) with cdc = {'enabled': true, 'preimage': true};
+{
+	"status" : "ok"
+}
+
+-- generates 1 row: delta(static)
+update ks.t set vs = 0 where pk = 0;
+{
+	"status" : "ok"
+}
+-- generates 2 rows: preimage(static), delta(static)
+update ks.t set vs = 1 where pk = 0;
+{
+	"status" : "ok"
+}
+select "cdc$batch_seq_no", "cdc$operation", ck, vs, vc from ks.t_scylla_cdc_log where pk = 0 allow filtering;
+{
+	"rows" : 
+	[
+		{
+			"cdc$batch_seq_no" : "0",
+			"cdc$operation" : "1",
+			"pk" : "0",
+			"vs" : "0"
+		},
+		{
+			"cdc$batch_seq_no" : "0",
+			"cdc$operation" : "0",
+			"pk" : "0",
+			"vs" : "0"
+		},
+		{
+			"cdc$batch_seq_no" : "1",
+			"cdc$operation" : "1",
+			"pk" : "0",
+			"vs" : "1"
+		}
+	]
+}
+
+-- generates 3 rows: preimage(static), delta(static), delta(clustering)
+update ks.t set vs = 2, vc = 2 where pk = 0 and ck = 0;
+{
+	"status" : "ok"
+}
+-- generates 4 rows: preimage(static), preimage(clustering), delta(static), delta(clustering)
+update ks.t set vs = 3, vc = 3 where pk = 0 and ck = 0;
+{
+	"status" : "ok"
+}
+select "cdc$batch_seq_no", "cdc$operation", ck, vs, vc from ks.t_scylla_cdc_log where pk = 0 and ck = 0 allow filtering;
+{
+	"rows" : 
+	[
+		{
+			"cdc$batch_seq_no" : "2",
+			"cdc$operation" : "1",
+			"ck" : "0",
+			"pk" : "0",
+			"vc" : "2"
+		},
+		{
+			"cdc$batch_seq_no" : "2",
+			"cdc$operation" : "0",
+			"ck" : "0",
+			"pk" : "0",
+			"vc" : "2"
+		},
+		{
+			"cdc$batch_seq_no" : "3",
+			"cdc$operation" : "1",
+			"ck" : "0",
+			"pk" : "0",
+			"vc" : "3"
+		}
+	]
+}
+
+-- generates 1 row: delta(clustering)
+update ks.t set vc = 4 where pk = 1 and ck = 0;
+{
+	"status" : "ok"
+}
+-- generates 2 rows: preimage(clustering), delta(clustering)
+update ks.t set vc = 5 where pk = 1 and ck = 0;
+{
+	"status" : "ok"
+}
+select "cdc$batch_seq_no", "cdc$operation", ck, vs, vc from ks.t_scylla_cdc_log where pk = 1 and ck = 0 allow filtering;
+{
+	"rows" : 
+	[
+		{
+			"cdc$batch_seq_no" : "0",
+			"cdc$operation" : "1",
+			"ck" : "0",
+			"pk" : "1",
+			"vc" : "4"
+		},
+		{
+			"cdc$batch_seq_no" : "0",
+			"cdc$operation" : "0",
+			"ck" : "0",
+			"pk" : "1",
+			"vc" : "4"
+		},
+		{
+			"cdc$batch_seq_no" : "1",
+			"cdc$operation" : "1",
+			"ck" : "0",
+			"pk" : "1",
+			"vc" : "5"
+		}
+	]
+}
+
+-- there should be 13 rows in total
+select count(*) from ks.t_scylla_cdc_log;
+{
+	"rows" : 
+	[
+		{
+			"count" : "13"
+		}
+	]
+}

--- a/test/tools/cql_repl.cc
+++ b/test/tools/cql_repl.cc
@@ -37,6 +37,8 @@
 #include "cql3/cql_config.hh"
 #include "cql3/type_json.hh"
 #include "test/lib/exception_utils.hh"
+#include "alternator/tags_extension.hh"
+#include "cdc/cdc_extension.hh"
 
 static std::ofstream std_cout;
 
@@ -113,7 +115,10 @@ std::unique_ptr<cql3::query_options> repl_options() {
 
 // Read-evaluate-print-loop for CQL
 void repl(seastar::app_template& app) {
-    auto db_cfg = make_shared<db::config>();
+    auto ext = std::make_shared<db::extensions>();
+    ext->add_schema_extension<alternator::tags_extension>(alternator::tags_extension::NAME);
+    ext->add_schema_extension<cdc::cdc_extension>(cdc::cdc_extension::NAME);
+    auto db_cfg = ::make_shared<db::config>(std::move(ext));
     db_cfg->enable_user_defined_functions({true}, db::config::config_source::CommandLine);
     db_cfg->experimental_features(db::experimental_features_t::all(), db::config::config_source::CommandLine);
     do_with_cql_env_thread([] (cql_test_env& e) {


### PR DESCRIPTION
In case a static and a clustering row is written at the same time, but
a clustering row with given key was not present, the preimage query was
incorrectly configured and no rows were returned. This resulted in an
empty preimage, while a preimage for static row should be present.

This patch fixes this and now the static row is correctly written to cdc
log in the case above.

Tests: unit(dev)