### PR TITLE
cdc: allow dropping manually created tables with cdc log suffix

### DIFF
--- a/cdc/log.cc
+++ b/cdc/log.cc
@@ -262,8 +262,12 @@ bool is_log_for_some_table(const sstring& ks_name, const std::string_view& table
         return false;
     }
     const auto base_name = sstring(table_name.data(), table_name.size() - cdc_log_suffix.size());
-    const auto base_schema = service::get_local_storage_proxy().get_db().local().find_schema(ks_name, base_name);
-    return bool(base_schema) && base_schema->cdc_options().enabled();
+    const auto& local_db = service::get_local_storage_proxy().get_db().local();
+    if (!local_db.has_schema(ks_name, base_name)) {
+        return false;
+    }
+    const auto base_schema = local_db.find_schema(ks_name, base_name);
+    return base_schema->cdc_options().enabled();
 }
 
 sstring log_name(const sstring& table_name) {

--- a/test/cql/cdc_allow_dropping_manually_created_log_test.cql
+++ b/test/cql/cdc_allow_dropping_manually_created_log_test.cql
@@ -1,0 +1,3 @@
+create table ks.test_scylla_cdc_log (pk int primary key);
+-- Should be possible to drop it
+drop table ks.test_scylla_cdc_log;

--- a/test/cql/cdc_allow_dropping_manually_created_log_test.result
+++ b/test/cql/cdc_allow_dropping_manually_created_log_test.result
@@ -1,0 +1,9 @@
+create table ks.test_scylla_cdc_log (pk int primary key);
+{
+	"status" : "ok"
+}
+-- Should be possible to drop it
+drop table ks.test_scylla_cdc_log;
+{
+	"status" : "ok"
+}


### PR DESCRIPTION
The is_log_for_some_table function incorrectly assumed that database::find_schema would return a null pointer in case the queried schema does not exist. This patch fixes that, and now this function checks for existence of the schema using database::has_schema.

Refs: https://github.com/scylladb/scylla/issues/5966
Tests: unit(dev)