### PR TITLE
cdc: add tracing

### DIFF
--- a/cdc/log.hh
+++ b/cdc/log.hh
@@ -40,6 +40,7 @@
 
 #include "exceptions/exceptions.hh"
 #include "timestamp.hh"
+#include "tracing/trace_state.hh"
 #include "cdc_options.hh"
 #include "utils/UUID.hh"
 
@@ -93,7 +94,8 @@ public:
     // returned to be invoked post the mutation query.
     future<std::tuple<std::vector<mutation>, result_callback>> augment_mutation_call(
         lowres_clock::time_point timeout,
-        std::vector<mutation>&& mutations
+        std::vector<mutation>&& mutations,
+        tracing::trace_state_ptr tr_state
         );
     bool needs_cdc_augmentation(const std::vector<mutation>&) const;
 };

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -1191,7 +1191,7 @@ future<> paxos_response_handler::learn_decision(paxos::proposal decision, bool a
         std::vector<mutation> update_mut_vec{std::move(update_mut)};
 
         if (_proxy->get_cdc_service()->needs_cdc_augmentation(update_mut_vec)) {
-            f_cdc = _proxy->get_cdc_service()->augment_mutation_call(_timeout, std::move(update_mut_vec))
+            f_cdc = _proxy->get_cdc_service()->augment_mutation_call(_timeout, std::move(update_mut_vec), tr_state)
                     .then([this, base_tbl_id] (std::tuple<std::vector<mutation>, cdc::result_callback>&& t) {
                 auto mutations = std::move(std::get<0>(t));
                 auto end_func = std::move(std::get<1>(t));
@@ -2151,7 +2151,7 @@ storage_proxy::get_paxos_participants(const sstring& ks_name, const dht::token &
  */
 future<> storage_proxy::mutate(std::vector<mutation> mutations, db::consistency_level cl, clock_type::time_point timeout, tracing::trace_state_ptr tr_state, service_permit permit, bool raw_counters) {
     if (_cdc && _cdc->needs_cdc_augmentation(mutations)) {
-        return _cdc->augment_mutation_call(timeout, std::move(mutations)).then([this, cl, timeout, tr_state = std::move(tr_state), permit = std::move(permit), raw_counters](std::tuple<std::vector<mutation>, cdc::result_callback>&& t) mutable {
+        return _cdc->augment_mutation_call(timeout, std::move(mutations), tr_state).then([this, cl, timeout, tr_state, permit = std::move(permit), raw_counters](std::tuple<std::vector<mutation>, cdc::result_callback>&& t) mutable {
             auto mutations = std::move(std::get<0>(t));
             auto end_func = std::move(std::get<1>(t));
             auto f = _mutate_stage(this, std::move(mutations), cl, timeout, std::move(tr_state), std::move(permit), raw_counters);
@@ -2325,12 +2325,12 @@ storage_proxy::mutate_atomically(std::vector<mutation> mutations, db::consistenc
           return make_exception_future<lw_shared_ptr<context>>(std::current_exception());
       }
     };
-    auto cleanup = [p = shared_from_this(), lc, tr_state = std::move(tr_state)] (future<> f) mutable {
+    auto cleanup = [p = shared_from_this(), lc, tr_state] (future<> f) mutable {
         return p->mutate_end(std::move(f), lc, p->get_stats(), std::move(tr_state));
     };
 
     if (_cdc && _cdc->needs_cdc_augmentation(mutations)) {
-        return _cdc->augment_mutation_call(timeout, std::move(mutations)).then([this, mk_ctxt = std::move(mk_ctxt), cleanup = std::move(cleanup)](std::tuple<std::vector<mutation>, cdc::result_callback>&& t) mutable {
+        return _cdc->augment_mutation_call(timeout, std::move(mutations), std::move(tr_state)).then([this, mk_ctxt = std::move(mk_ctxt), cleanup = std::move(cleanup)](std::tuple<std::vector<mutation>, cdc::result_callback>&& t) mutable {
             auto mutations = std::move(std::get<0>(t));
             auto end_func = std::get<1>(t);
             auto f = std::move(mk_ctxt)(std::move(mutations)).then([this] (lw_shared_ptr<context> ctxt) {


### PR DESCRIPTION
Adds information about the stages of CDC mutation augmentation to tracing sessions.

Fixes https://github.com/scylladb/scylla/issues/5912
Tests: unit(debug, dev)