### PR TITLE
Add postimage implementation

### DIFF
--- a/cdc/log.cc
+++ b/cdc/log.cc
@@ -623,7 +623,7 @@ public:
                                 // simply means "replace values"
                                 is_column_delete = true;
                             }
-                            auto process_cells = [&](auto value_callback) {
+                            auto process_collection = [&](auto value_callback) {
                                 for (auto& [key, value] : view.cells) {
                                     // note: we are assuming that all mutations coming here adhere to
                                     // / are created by the cql machinery or similar, i.e. if we have
@@ -649,7 +649,7 @@ public:
                                 // maps and lists are just flattened
                                 [&] (const collection_type_impl& type) -> bytes_opt {
                                     std::vector<std::pair<bytes_view, bytes_view>> result;
-                                    process_cells([&](const bytes_view& key, const bytes_view& value, bool live) {
+                                    process_collection([&](const bytes_view& key, const bytes_view& value, bool live) {
                                         if (live) {
                                             result.emplace_back(key, value);
                                         } else {
@@ -667,7 +667,7 @@ public:
                                 // set need to transform from mutation view
                                 [&] (const set_type_impl& type) -> bytes_opt  {
                                     std::vector<bytes_view> result;
-                                    process_cells([&](const bytes_view& key, const bytes_view& value, bool live) {
+                                    process_collection([&](const bytes_view& key, const bytes_view& value, bool live) {
                                         if (live) {
                                             result.emplace_back(key);
                                         } else {
@@ -687,7 +687,7 @@ public:
                                 // fields not in the mutation are null in the enclosing tuple, signifying "no info"
                                 [&](const user_type_impl& type) -> bytes_opt  {
                                     std::vector<bytes_opt> result(type.size());
-                                    process_cells([&](const bytes_view& key, const bytes_view& value, bool live) {
+                                    process_collection([&](const bytes_view& key, const bytes_view& value, bool live) {
                                         if (live) {
                                             auto idx = deserialize_field_index(key);
                                             result[idx].emplace(value);

--- a/cdc/log.hh
+++ b/cdc/log.hh
@@ -126,6 +126,7 @@ enum class operation : int8_t {
     // enum decl, so don't change the constant values (or the datatype).
     pre_image = 0, update = 1, insert = 2, row_delete = 3, partition_delete = 4,
     range_delete_start_inclusive = 5, range_delete_start_exclusive = 6, range_delete_end_inclusive = 7, range_delete_end_exclusive = 8,
+    post_image = 9,
 };
 
 bool is_log_for_some_table(const sstring& ks_name, const std::string_view& table_name);

--- a/cql3/untyped_result_set.hh
+++ b/cql3/untyped_result_set.hh
@@ -77,6 +77,12 @@ public:
     std::optional<T> get_opt(const sstring& name) const {
         return has(name) ? get_as<T>(name) : std::optional<T>{};
     }
+    bytes_view_opt get_view_opt(const sstring& name) const {
+        if (has(name)) {
+            return get_view(name);
+        }
+        return std::nullopt;
+    }
     template<typename T>
     T get_or(const sstring& name, T t) const {
         return has(name) ? get_as<T>(name) : t;

--- a/schema.cc
+++ b/schema.cc
@@ -1374,6 +1374,21 @@ schema::regular_columns() const {
             , _raw._columns.end());
 }
 
+schema::const_iterator_range_type
+schema::columns(column_kind kind) const {
+    switch (kind) {
+    case column_kind::partition_key:
+        return partition_key_columns();
+    case column_kind::clustering_key:
+        return clustering_key_columns();
+    case column_kind::static_column:
+        return static_columns();
+    case column_kind::regular_column:
+        return regular_columns();
+    }
+    throw std::invalid_argument(std::to_string(int(kind)));
+}
+
 schema::select_order_range schema::all_columns_in_select_order() const {
     auto is_static_compact_table = this->is_static_compact_table();
     auto no_non_pk_columns = is_compact_table()

--- a/schema.hh
+++ b/schema.hh
@@ -848,6 +848,8 @@ public:
     // Returns a range of column definitions
     const_iterator_range_type regular_columns() const;
     // Returns a range of column definitions
+    const_iterator_range_type columns(column_kind) const;
+    // Returns a range of column definitions
 
     typedef boost::range::joined_range<const_iterator_range_type, const_iterator_range_type>
         select_order_range;


### PR DESCRIPTION
Fixes #4992
    
Implements post-image support by synthesizing it from
pre-image + delta.
    
Post-image data differs from the delta data in two ways:
    
1.) It merges non-atomics into an actual result value
2.) It contains _all_ columns of the row, not just
     those affected by the update.
    
For a non-atomic field, the post-image value of a column
is either the pre-image or the delta (maybe null)
    
Tested by adding post-image checks to pre-image test
and collection/udt tests