### PR TITLE
compaction: use a larger min_threshold during bootstrap, replace

### DIFF
--- a/sstables/compaction_manager.cc
+++ b/sstables/compaction_manager.cc
@@ -153,7 +153,7 @@ int compaction_manager::trim_to_compact(column_family* cf, sstables::compaction_
     }
 
     uint64_t total_size = get_total_size(descriptor.sstables);
-    int min_threshold = cf->schema()->min_compaction_threshold();
+    int min_threshold = cf->min_compaction_threshold();
     auto compacting_run_identifiers = boost::copy_range<std::unordered_set<utils::UUID>>(descriptor.sstables
         | boost::adaptors::transformed(std::mem_fn(&sstables::sstable::run_identifier)));
 

--- a/sstables/size_tiered_compaction_strategy.cc
+++ b/sstables/size_tiered_compaction_strategy.cc
@@ -135,7 +135,7 @@ size_tiered_compaction_strategy::most_interesting_bucket(std::vector<std::vector
 compaction_descriptor
 size_tiered_compaction_strategy::get_sstables_for_compaction(column_family& cfs, std::vector<sstables::shared_sstable> candidates) {
     // make local copies so they can't be changed out from under us mid-method
-    int min_threshold = cfs.schema()->min_compaction_threshold();
+    int min_threshold = cfs.min_compaction_threshold();
     int max_threshold = cfs.schema()->max_compaction_threshold();
     auto gc_before = gc_clock::now() - cfs.schema()->gc_grace_seconds();
 
@@ -177,7 +177,7 @@ size_tiered_compaction_strategy::get_sstables_for_compaction(column_family& cfs,
 }
 
 int64_t size_tiered_compaction_strategy::estimated_pending_compactions(column_family& cf) const {
-    int min_threshold = cf.schema()->min_compaction_threshold();
+    int min_threshold = cf.min_compaction_threshold();
     int max_threshold = cf.schema()->max_compaction_threshold();
     std::vector<sstables::shared_sstable> sstables;
     int64_t n = 0;

--- a/sstables/time_window_compaction_strategy.hh
+++ b/sstables/time_window_compaction_strategy.hh
@@ -220,9 +220,9 @@ private:
         // Update the highest window seen, if necessary
         _highest_window_seen = std::max(_highest_window_seen, p.second);
 
-        update_estimated_compaction_by_tasks(p.first, cf.schema()->min_compaction_threshold());
+        update_estimated_compaction_by_tasks(p.first, cf.min_compaction_threshold());
 
-        return newest_bucket(std::move(p.first), cf.schema()->min_compaction_threshold(), cf.schema()->max_compaction_threshold(),
+        return newest_bucket(std::move(p.first), cf.min_compaction_threshold(), cf.schema()->max_compaction_threshold(),
             _options.sstable_window_size, _highest_window_seen, _stcs_options);
     }
 public:


### PR DESCRIPTION
During bootstrap and replace operations the node can't take reads and
we'd like to see the process ending ASAP. This is because until the
process ends, we keep having to duplicate writes to an extended set. Not
to mention, in the case of a cluster expansion users want to use the
added capacity sooner rather than later.

Streaming generates a lot of compaction activity, that competes with the
bootstrap itself, slowing it down.

Long term, we are moving to treat those compactions differently and
maybe postpone them altogether. However for now we can reduce the amount
of compactions by increasing the minimum threshold of SSTables that have
to accumulate before they are selected for compactions. The default is
2, meaning we will trigger a compaction every time 2 SSTables of about
the same size are found (for STCS, others follow a similar pattern).

Until we have offstrategy infrastructure we don't want the compactions
to stop happening altogether so the reads, when they start, don't suffer.
This patch sets the minimum threshold to 16, meaning we will generate a
lot less compaction activity during streaming. Once streaming is done we
revert it to its original.

Unfortunately there isn't much we can do at the moment about decommission.
During decommission the nodes receiving data are also taking reads and
we don't want SSTables to accumulate.

Signed-off-by: Glauber Costa <glauber@scylladb.com>