### PR TITLE
When altering table, keep old values of unchanged extensions

### DIFF
--- a/cql3/statements/cf_prop_defs.cc
+++ b/cql3/statements/cf_prop_defs.cc
@@ -290,6 +290,10 @@ void cf_prop_defs::apply_to_builder(schema_builder& builder, schema::extensions_
         cfm.caching(cachingOptions);
 #endif
 
+    // for extensions that are not altered, keep the old ones
+    auto& old_exts = builder.get_extensions();
+    schema_extensions.insert(old_exts.begin(), old_exts.end());
+
     builder.set_extensions(std::move(schema_extensions));
 }
 

--- a/schema_builder.hh
+++ b/schema_builder.hh
@@ -193,6 +193,9 @@ public:
         _raw._extensions = std::move(exts);
         return *this;
     }
+    const schema::extensions_map& get_extensions() const {
+        return _raw._extensions;
+    }
     schema_builder& set_compaction_strategy(sstables::compaction_strategy_type type) {
         _raw._compaction_strategy = type;
         return *this;


### PR DESCRIPTION
When the user performed
```
alter ks.t with compaction = {...}
```
the values of most other options, which were not specified in the
statement, e.g. compression, were left unchanged. That wasn't true for
extension options however: for example, the "cdc" option was removed.

This commit fixes the behavior to keep the old values of extension
options not specified in the alter statement.

Fixes https://github.com/scylladb/scylla/issues/6015.