### PR TITLE
cdc: add metrics

### DIFF
--- a/cdc/log.cc
+++ b/cdc/log.cc
@@ -126,6 +126,28 @@ cdc::stats::stats() {
     register_counters(counters_failed, "failed");
 }
 
+cdc::operation_result_tracker::~operation_result_tracker() {
+    auto update_stats = [this] (stats::counters& counters) {
+        if (_details.was_split) {
+            counters.split_count++;
+        } else {
+            counters.unsplit_count++;
+        }
+        counters.touches.apply(_details.touched_parts);
+        if (_details.had_preimage) {
+            counters.with_preimage_count++;
+        }
+        if (_details.had_postimage) {
+            counters.with_postimage_count++;
+        }
+    };
+
+    update_stats(_stats.counters_total);
+    if (_failed) {
+        update_stats(_stats.counters_failed);
+    }
+}
+
 class cdc::cdc_service::impl : service::migration_listener::empty_listener {
     friend cdc_service;
     db_context _ctxt;

--- a/cdc/log.hh
+++ b/cdc/log.hh
@@ -66,6 +66,7 @@ class partition_key;
 
 namespace cdc {
 
+struct operation_result_tracker;
 class db_context;
 class metadata;
 
@@ -87,7 +88,7 @@ public:
     // appropriate augments to set the log entries.
     // Iff post-image is enabled for any of these, a non-empty callback is also
     // returned to be invoked post the mutation query.
-    future<std::vector<mutation>> augment_mutation_call(
+    future<std::tuple<std::vector<mutation>, lw_shared_ptr<operation_result_tracker>>> augment_mutation_call(
         lowres_clock::time_point timeout,
         std::vector<mutation>&& mutations,
         tracing::trace_state_ptr tr_state

--- a/cdc/split.cc
+++ b/cdc/split.cc
@@ -433,7 +433,7 @@ void for_each_change(const mutation& base_mutation, const schema_ptr& base_schem
                 row.apply(cdef, collection_mutation_description{nonatomic_delete.t, {}}.serialize(*cdef.type));
             }
             for (auto& nonatomic_update : cr_update.nonatomic_updates) {
-                auto& cdef = base_schema->column_at(column_kind::static_column, nonatomic_update.id);
+                auto& cdef = base_schema->column_at(column_kind::regular_column, nonatomic_update.id);
                 row.apply(cdef, collection_mutation_description{{}, std::move(nonatomic_update.cells)}.serialize(*cdef.type));
             }
 

--- a/cdc/stats.hh
+++ b/cdc/stats.hh
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2020 ScyllaDB
+ */
+
+/*
+ * This file is part of Scylla.
+ *
+ * Scylla is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Scylla is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <array>
+#include <cstdint>
+#include <string>
+#include <seastar/core/metrics_registration.hh>
+#include "enum_set.hh"
+#include "utils/histogram.hh"
+#include "utils/estimated_histogram.hh"
+
+namespace cdc {
+
+class stats final {
+    seastar::metrics::metric_groups _metrics;
+
+public:
+    enum class part_type {
+        STATIC_ROW,
+        CLUSTERING_ROW,
+        MAP,
+        SET,
+        LIST,
+        UDT,
+        RANGE_TOMBSTONE,
+        PARTITION_DELETE,
+        ROW_DELETE,
+
+        MAX
+    };
+
+    using part_type_set = enum_set<super_enum<part_type,
+        part_type::STATIC_ROW,
+        part_type::CLUSTERING_ROW,
+        part_type::MAP,
+        part_type::SET,
+        part_type::LIST,
+        part_type::UDT,
+        part_type::RANGE_TOMBSTONE,
+        part_type::PARTITION_DELETE,
+        part_type::ROW_DELETE
+    >>;
+
+    struct parts_touched_stats final {
+        std::array<uint64_t, (size_t)part_type::MAX> count = {};
+
+        inline void apply(part_type_set parts_set) {
+            for (part_type idx : parts_set) {
+                count[(size_t)idx]++;
+            }
+        }
+
+        void register_metrics(seastar::metrics::metric_groups& metrics, std::string_view suffix);
+    };
+
+    struct counters final {
+        uint64_t unsplit_count = 0;
+        uint64_t split_count = 0;
+        uint64_t preimage_selects = 0;
+        uint64_t with_preimage_count = 0;
+        uint64_t with_postimage_count = 0;
+
+        parts_touched_stats touches;
+    };
+
+    counters counters_total;
+    counters counters_failed;
+
+    stats();
+};
+
+}

--- a/cdc/stats.hh
+++ b/cdc/stats.hh
@@ -89,4 +89,32 @@ public:
     stats();
 };
 
+// Contains the details on what happened during a CDC operation.
+struct operation_details final {
+    stats::part_type_set touched_parts;
+    bool was_split = false;
+    bool had_preimage = false;
+    bool had_postimage = false;
+};
+
+// This object tracks the lifetime of write handlers related to one CDC operation. After all
+// write handlers for the operation finish, CDC metrics are updated.
+class operation_result_tracker final {
+    stats& _stats;
+    operation_details _details;
+    bool _failed;
+
+public:
+    operation_result_tracker(stats& stats, operation_details details)
+        : _stats(stats)
+        , _details(details)
+        , _failed(false)
+    {}
+    ~operation_result_tracker();
+
+    void on_mutation_failed() {
+        _failed = true;
+    }
+};
+
 }

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -2171,19 +2171,20 @@ future<> storage_proxy::mutate(std::vector<mutation> mutations, db::consistency_
     if (_cdc && _cdc->needs_cdc_augmentation(mutations)) {
         return _cdc->augment_mutation_call(timeout, std::move(mutations), tr_state).then([this, cl, timeout, tr_state, permit = std::move(permit), raw_counters](std::tuple<std::vector<mutation>, lw_shared_ptr<cdc::operation_result_tracker>>&& t) mutable {
             auto mutations = std::move(std::get<0>(t));
-            return _mutate_stage(this, std::move(mutations), cl, timeout, std::move(tr_state), std::move(permit), raw_counters);
+            auto tracker = std::move(std::get<1>(t));
+            return _mutate_stage(this, std::move(mutations), cl, timeout, std::move(tr_state), std::move(permit), raw_counters, std::move(tracker));
         });
     }
-    return _mutate_stage(this, std::move(mutations), cl, timeout, std::move(tr_state), std::move(permit), raw_counters);
+    return _mutate_stage(this, std::move(mutations), cl, timeout, std::move(tr_state), std::move(permit), raw_counters, nullptr);
 }
 
-future<> storage_proxy::do_mutate(std::vector<mutation> mutations, db::consistency_level cl, clock_type::time_point timeout, tracing::trace_state_ptr tr_state, service_permit permit, bool raw_counters) {
+future<> storage_proxy::do_mutate(std::vector<mutation> mutations, db::consistency_level cl, clock_type::time_point timeout, tracing::trace_state_ptr tr_state, service_permit permit, bool raw_counters, lw_shared_ptr<cdc::operation_result_tracker> cdc_tracker) {
     auto mid = raw_counters ? mutations.begin() : boost::range::partition(mutations, [] (auto&& m) {
         return m.schema()->is_counter();
     });
     return seastar::when_all_succeed(
         mutate_counters(boost::make_iterator_range(mutations.begin(), mid), cl, tr_state, permit, timeout),
-        mutate_internal(boost::make_iterator_range(mid, mutations.end()), cl, false, tr_state, permit, timeout)
+        mutate_internal(boost::make_iterator_range(mid, mutations.end()), cl, false, tr_state, permit, timeout, std::move(cdc_tracker))
     );
 }
 
@@ -2201,7 +2202,7 @@ future<> storage_proxy::replicate_counter_from_leader(mutation m, db::consistenc
 template<typename Range>
 future<>
 storage_proxy::mutate_internal(Range mutations, db::consistency_level cl, bool counters, tracing::trace_state_ptr tr_state, service_permit permit,
-                               std::optional<clock_type::time_point> timeout_opt) {
+                               std::optional<clock_type::time_point> timeout_opt, lw_shared_ptr<cdc::operation_result_tracker> cdc_tracker) {
     if (boost::empty(mutations)) {
         return make_ready_future<>();
     }
@@ -2218,7 +2219,8 @@ storage_proxy::mutate_internal(Range mutations, db::consistency_level cl, bool c
     utils::latency_counter lc;
     lc.start();
 
-    return mutate_prepare(mutations, cl, type, tr_state, std::move(permit)).then([this, cl, timeout_opt] (std::vector<storage_proxy::unique_response_handler> ids) {
+    return mutate_prepare(mutations, cl, type, tr_state, std::move(permit)).then([this, cl, timeout_opt, tracker = std::move(cdc_tracker)] (std::vector<storage_proxy::unique_response_handler> ids) {
+        register_cdc_operation_result_tracker(ids, tracker);
         return mutate_begin(std::move(ids), cl, timeout_opt);
     }).then_wrapped([this, p = shared_from_this(), lc, tr_state] (future<> f) mutable {
         return p->mutate_end(std::move(f), lc, get_stats(), std::move(tr_state));

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -88,6 +88,7 @@
 #include "database.hh"
 #include "db/consistency_level_validations.hh"
 #include "cdc/log.hh"
+#include "cdc/stats.hh"
 
 namespace bi = boost::intrusive;
 
@@ -1192,7 +1193,8 @@ future<> paxos_response_handler::learn_decision(paxos::proposal decision, bool a
 
         if (_proxy->get_cdc_service()->needs_cdc_augmentation(update_mut_vec)) {
             f_cdc = _proxy->get_cdc_service()->augment_mutation_call(_timeout, std::move(update_mut_vec), tr_state)
-                    .then([this, base_tbl_id] (std::vector<mutation>&& mutations) {
+                    .then([this, base_tbl_id] (std::tuple<std::vector<mutation>, lw_shared_ptr<cdc::operation_result_tracker>>&& t) {
+                auto mutations = std::move(std::get<0>(t));
                 // Pick only the CDC ("augmenting") mutations
                 mutations.erase(std::remove_if(mutations.begin(), mutations.end(), [base_tbl_id = std::move(base_tbl_id)] (const mutation& v) {
                     return v.schema()->id() == base_tbl_id;
@@ -2144,7 +2146,8 @@ storage_proxy::get_paxos_participants(const sstring& ks_name, const dht::token &
  */
 future<> storage_proxy::mutate(std::vector<mutation> mutations, db::consistency_level cl, clock_type::time_point timeout, tracing::trace_state_ptr tr_state, service_permit permit, bool raw_counters) {
     if (_cdc && _cdc->needs_cdc_augmentation(mutations)) {
-        return _cdc->augment_mutation_call(timeout, std::move(mutations), tr_state).then([this, cl, timeout, tr_state, permit = std::move(permit), raw_counters](std::vector<mutation>&& mutations) mutable {
+        return _cdc->augment_mutation_call(timeout, std::move(mutations), tr_state).then([this, cl, timeout, tr_state, permit = std::move(permit), raw_counters](std::tuple<std::vector<mutation>, lw_shared_ptr<cdc::operation_result_tracker>>&& t) mutable {
+            auto mutations = std::move(std::get<0>(t));
             return _mutate_stage(this, std::move(mutations), cl, timeout, std::move(tr_state), std::move(permit), raw_counters);
         });
     }
@@ -2317,7 +2320,8 @@ storage_proxy::mutate_atomically(std::vector<mutation> mutations, db::consistenc
     };
 
     if (_cdc && _cdc->needs_cdc_augmentation(mutations)) {
-        return _cdc->augment_mutation_call(timeout, std::move(mutations), std::move(tr_state)).then([this, mk_ctxt = std::move(mk_ctxt), cleanup = std::move(cleanup)](std::vector<mutation>&& mutations) mutable {
+        return _cdc->augment_mutation_call(timeout, std::move(mutations), std::move(tr_state)).then([this, mk_ctxt = std::move(mk_ctxt), cleanup = std::move(cleanup)](std::tuple<std::vector<mutation>, lw_shared_ptr<cdc::operation_result_tracker>>&& t) mutable {
+            auto mutations = std::move(std::get<0>(t));
             return std::move(mk_ctxt)(std::move(mutations)).then([this] (lw_shared_ptr<context> ctxt) {
                 return ctxt->run().finally([ctxt]{});
             }).then_wrapped(std::move(cleanup));

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -392,10 +392,12 @@ public:
                 _proxy->_global_stats.background_write_bytes -= _mutation_holder->size();
                 _proxy->unthrottle();
             }
-        } else if (_error == error::TIMEOUT) {
-            _ready.set_exception(mutation_write_timeout_exception(get_schema()->ks_name(), get_schema()->cf_name(), _cl, _cl_acks, _total_block_for, _type));
-        } else if (_error == error::FAILURE) {
-            _ready.set_exception(mutation_write_failure_exception(get_schema()->ks_name(), get_schema()->cf_name(), _cl, _cl_acks, _failed, _total_block_for, _type));
+        } else {
+            if (_error == error::TIMEOUT) {
+                _ready.set_exception(mutation_write_timeout_exception(get_schema()->ks_name(), get_schema()->cf_name(), _cl, _cl_acks, _total_block_for, _type));
+            } else if (_error == error::FAILURE) {
+                _ready.set_exception(mutation_write_failure_exception(get_schema()->ks_name(), get_schema()->cf_name(), _cl, _cl_acks, _failed, _total_block_for, _type));
+            }
         }
     }
     bool is_counter() const {

--- a/service/storage_proxy.hh
+++ b/service/storage_proxy.hh
@@ -66,6 +66,7 @@
 #include "service/paxos/proposal.hh"
 #include "service/client_state.hh"
 #include "service/paxos/prepare_summary.hh"
+#include "cdc/stats.hh"
 
 
 namespace seastar::rpc {
@@ -191,6 +192,7 @@ public:
     using write_stats = storage_proxy_stats::write_stats;
     using stats = storage_proxy_stats::stats;
     using global_stats = storage_proxy_stats::global_stats;
+    using cdc_stats = cdc::stats;
 
     class coordinator_query_options {
         clock_type::time_point _timeout;
@@ -292,6 +294,7 @@ private:
     std::unique_ptr<view_update_handlers_list> _view_update_handlers_list;
 
     cdc::cdc_service* _cdc = nullptr;
+    cdc_stats _cdc_stats;
 private:
     future<> uninit_messaging_service();
     future<coordinator_query_result> query_singular(lw_shared_ptr<query::read_command> cmd,
@@ -575,6 +578,12 @@ public:
     }
     global_stats& get_global_stats() {
         return _global_stats;
+    }
+    const cdc_stats& get_cdc_stats() const {
+        return _cdc_stats;
+    }
+    cdc_stats& get_cdc_stats() {
+        return _cdc_stats;
     }
 
     scheduling_group_key get_stats_key() const {

--- a/service/storage_proxy.hh
+++ b/service/storage_proxy.hh
@@ -320,6 +320,7 @@ private:
             db::consistency_level cl, db::write_type type, tracing::trace_state_ptr tr_state, service_permit permit);
     response_id_type create_write_response_handler(const std::tuple<paxos::proposal, schema_ptr, dht::token, std::unordered_set<gms::inet_address>>& meta,
             db::consistency_level cl, db::write_type type, tracing::trace_state_ptr tr_state, service_permit permit);
+    void register_cdc_operation_result_tracker(const std::vector<storage_proxy::unique_response_handler>& ids, lw_shared_ptr<cdc::operation_result_tracker> tracker);
     void send_to_live_endpoints(response_id_type response_id, clock_type::time_point timeout);
     template<typename Range>
     size_t hint_to_dead_endpoints(std::unique_ptr<mutation_holder>& mh, const Range& targets, db::write_type type, tracing::trace_state_ptr tr_state) noexcept;

--- a/service/storage_proxy.hh
+++ b/service/storage_proxy.hh
@@ -285,7 +285,8 @@ private:
             clock_type::time_point,
             tracing::trace_state_ptr,
             service_permit,
-            bool> _mutate_stage;
+            bool,
+            lw_shared_ptr<cdc::operation_result_tracker>> _mutate_stage;
     db::view::node_update_backlog& _max_view_update_backlog;
     std::unordered_map<gms::inet_address, view_update_backlog_timestamped> _view_update_backlogs;
 
@@ -390,7 +391,7 @@ private:
     void unthrottle();
     void handle_read_error(std::exception_ptr eptr, bool range);
     template<typename Range>
-    future<> mutate_internal(Range mutations, db::consistency_level cl, bool counter_write, tracing::trace_state_ptr tr_state, service_permit permit, std::optional<clock_type::time_point> timeout_opt = { });
+    future<> mutate_internal(Range mutations, db::consistency_level cl, bool counter_write, tracing::trace_state_ptr tr_state, service_permit permit, std::optional<clock_type::time_point> timeout_opt = { }, lw_shared_ptr<cdc::operation_result_tracker> cdc_tracker = { });
     future<rpc::tuple<foreign_ptr<lw_shared_ptr<reconcilable_result>>, cache_temperature>> query_nonsingular_mutations_locally(
             schema_ptr s, lw_shared_ptr<query::read_command> cmd, const dht::partition_range_vector&& pr, tracing::trace_state_ptr trace_state,
             uint64_t max_size, clock_type::time_point timeout);
@@ -402,7 +403,7 @@ private:
 
     gms::inet_address find_leader_for_counter_update(const mutation& m, db::consistency_level cl);
 
-    future<> do_mutate(std::vector<mutation> mutations, db::consistency_level cl, clock_type::time_point timeout, tracing::trace_state_ptr tr_state, service_permit permit, bool);
+    future<> do_mutate(std::vector<mutation> mutations, db::consistency_level cl, clock_type::time_point timeout, tracing::trace_state_ptr tr_state, service_permit permit, bool, lw_shared_ptr<cdc::operation_result_tracker> cdc_tracker);
 
     future<> send_to_endpoint(
             std::unique_ptr<mutation_holder> m,


### PR DESCRIPTION
Adds CDC-related metrics.

Following counters are added, both for total and failed operations:
- Total number of CDC operations that did/did not perform splitting,
- Total number of CDC operations  that touched a particular mutation part.
- Total number of preimage selects.

Fixes #6002.
Tests: unit(dev, debug)