### PR TITLE
Make compaction cancellation easier.

### DIFF
--- a/sstables/compaction_manager.hh
+++ b/sstables/compaction_manager.hh
@@ -54,7 +54,7 @@ public:
         uint64_t active_tasks = 0; // Number of compaction going on.
         int64_t errors = 0;
     };
-private:
+
     struct task {
         column_family* compacting_cf = nullptr;
         shared_future<> compaction_done = make_ready_future<>();
@@ -63,6 +63,7 @@ private:
         sstables::compaction_type type = sstables::compaction_type::Compaction;
         bool compaction_running = false;
     };
+private:
 
     // compaction manager may have N fibers to allow parallel compaction per shard.
     std::list<lw_shared_ptr<task>> _tasks;
@@ -184,7 +185,7 @@ public:
     future<> perform_sstable_scrub(column_family* cf, bool skip_corrupted);
 
     // Submit a column family for major compaction.
-    future<> submit_major_compaction(column_family* cf);
+    lw_shared_ptr<task> submit_major_compaction(column_family* cf);
 
     // Run a resharding job for a given column family.
     // it completes when future returned by job is ready or returns immediately

--- a/table.cc
+++ b/table.cc
@@ -1352,7 +1352,8 @@ future<> table::rewrite_sstables(sstables::compaction_descriptor descriptor) {
 // Note: We assume that the column_family does not get destroyed during compaction.
 future<>
 table::compact_all_sstables() {
-    return _compaction_manager.submit_major_compaction(this);
+    auto task = _compaction_manager.submit_major_compaction(this);
+    return task->compaction_done.get_future().then([task] {});
 }
 
 void table::start_compaction() {

--- a/test/boost/cql_query_test.cc
+++ b/test/boost/cql_query_test.cc
@@ -132,7 +132,8 @@ SEASTAR_THREAD_TEST_CASE(test_large_data) {
         flush(e);
         e.db().invoke_on_all([] (database& dbi) {
             return parallel_for_each(dbi.get_column_families(), [&dbi] (auto& table) {
-                return dbi.get_compaction_manager().submit_major_compaction(&*table.second);
+                auto task = dbi.get_compaction_manager().submit_major_compaction(&*table.second);
+                return task->compaction_done.get_future().then([task] {});
             });
         }).get();
 

--- a/test/boost/view_complex_test.cc
+++ b/test/boost/view_complex_test.cc
@@ -853,7 +853,8 @@ void test_commutative_row_deletion(cql_test_env& e, std::function<void()>&& mayb
         }});
     });
 
-    e.local_db().get_compaction_manager().submit_major_compaction(&e.local_db().find_column_family("ks", "vcf")).get();
+    auto task = e.local_db().get_compaction_manager().submit_major_compaction(&e.local_db().find_column_family("ks", "vcf"));
+    task->compaction_done.get_future().get();
 }
 
 SEASTAR_TEST_CASE(test_commutative_row_deletion_without_flush) {
@@ -1089,7 +1090,9 @@ void test_update_with_column_timestamp_bigger_than_pk(cql_test_env& e, std::func
         }});
     });
 
-    e.local_db().get_compaction_manager().submit_major_compaction(&e.local_db().find_column_family("ks", "vcf")).get();
+    auto task = e.local_db().get_compaction_manager().submit_major_compaction(&e.local_db().find_column_family("ks", "vcf"));
+    task->compaction_done.get_future().get();
+
     eventually([&] {
         auto msg = e.execute_cql("select * from vcf limit 1").get0();
         assert_that(msg).is_rows().with_rows({{


### PR DESCRIPTION
Right now we can cancel all compactions of a specific type (cleanup,
regular, etc). This is not good enough, as in some situations we may
want to cancel a specific compaction.

One example is the upcoming offstrategy compactions that are fired
when the compaction strategy changes. If the user changes the compaction
strategy and then changes it again we will want to cancel just the
compaction that we started. Not all compactions on the column family,
not all compactions of a specific type.

There is already a mechanism to cancel a compaction given a task
pointer, so all we have to do is expose the task pointer to the
caller.

At this moment I don't see the need to cancel regular minor compactions
so that is deferred until and if we need that.

For now we will return the task to major compaction callers.

Note that there is no need to do anything with repect to the management
of the _tasks list. If the task is not added to the list the future will
be ready immediately. If it is, the compaction will have started already
for sure and will stop with an exception - removing itself from the
list, when it sees the stop notification

Signed-off-by: Glauber Costa <glauber@scylladb.com>