### PR TITLE
view,table: fix waiting for view updates during building

### DIFF
--- a/db/view/view.hh
+++ b/db/view/view.hh
@@ -116,13 +116,16 @@ query::clustering_row_ranges calculate_affected_clustering_ranges(
         const mutation_partition& mp,
         const std::vector<view_ptr>& views);
 
+struct wait_for_all_updates_tag {};
+using wait_for_all_updates = bool_class<wait_for_all_updates_tag>;
 future<> mutate_MV(
         const dht::token& base_token,
         std::vector<frozen_mutation_and_schema> view_updates,
         db::view::stats& stats,
         cf_stats& cf_stats,
         db::timeout_semaphore_units pending_view_updates,
-        service::allow_hints allow_hints);
+        service::allow_hints allow_hints,
+        wait_for_all_updates wait_for_all);
 
 /**
  * create_virtual_column() adds a "virtual column" to a schema builder.

--- a/table.cc
+++ b/table.cc
@@ -2107,7 +2107,8 @@ future<> table::generate_and_propagate_view_updates(const schema_ptr& base,
             flat_mutation_reader_from_mutations({std::move(m)}),
             std::move(existings)).then([this, base_token = std::move(base_token)] (std::vector<frozen_mutation_and_schema>&& updates) mutable {
         auto units = seastar::consume_units(*_config.view_update_concurrency_semaphore, memory_usage_of(updates));
-        return db::view::mutate_MV(std::move(base_token), std::move(updates), _view_stats, *_config.cf_stats, std::move(units), service::allow_hints::yes).handle_exception([] (auto ignored) { });
+        return db::view::mutate_MV(std::move(base_token), std::move(updates), _view_stats, *_config.cf_stats,
+                std::move(units), service::allow_hints::yes, db::view::wait_for_all_updates::no).handle_exception([] (auto ignored) { });
     });
 }
 
@@ -2221,7 +2222,8 @@ future<> table::populate_views(
                  units_to_consume = update_size - units_to_wait_for,
                  this] (db::timeout_semaphore_units&& units) mutable {
             units.adopt(seastar::consume_units(*_config.view_update_concurrency_semaphore, units_to_consume));
-            return db::view::mutate_MV(std::move(base_token), std::move(updates), _view_stats, *_config.cf_stats, std::move(units), service::allow_hints::no);
+            return db::view::mutate_MV(std::move(base_token), std::move(updates), _view_stats,
+                    *_config.cf_stats, std::move(units), service::allow_hints::no, db::view::wait_for_all_updates::yes);
         });
     });
 }


### PR DESCRIPTION
View updates sent as part of the view building process should never
be ignored, but fd49fd7 introduced a bug which may cause exactly that:
the updates are mistakenly sent to background, so the view builder
will not receive negative feedback if an update failed, which will
in turn not cause a retry. Consequently, view building may report
that it "finished" building a view, while some of the updates were
lost. A simple fix is to restore previous behaviour - all updates
triggered by view building are now waited for.

Fixes #6038
Tests: unit(dev),
dtest: interrupt_build_process_with_resharding_low_to_half_test