### PR TITLE
Use inline variables to reduce code duplication and complexity

### DIFF
--- a/auth/common.cc
+++ b/auth/common.cc
@@ -32,15 +32,6 @@
 
 namespace auth {
 
-namespace meta {
-
-const sstring DEFAULT_SUPERUSER_NAME("cassandra");
-const sstring AUTH_KS("system_auth");
-const sstring USERS_CF("users");
-const sstring AUTH_PACKAGE_NAME("org.apache.cassandra.auth.");
-
-}
-
 static logging::logger auth_log("auth");
 
 // Func must support being invoked more than once.

--- a/auth/common.hh
+++ b/auth/common.hh
@@ -52,10 +52,10 @@ namespace auth {
 
 namespace meta {
 
-extern const sstring DEFAULT_SUPERUSER_NAME;
-extern const sstring AUTH_KS;
-extern const sstring USERS_CF;
-extern const sstring AUTH_PACKAGE_NAME;
+inline const sstring DEFAULT_SUPERUSER_NAME("cassandra");
+inline const sstring AUTH_KS("system_auth");
+inline const sstring USERS_CF("users");
+inline const sstring AUTH_PACKAGE_NAME("org.apache.cassandra.auth.");
 
 }
 

--- a/auth/permission.cc
+++ b/auth/permission.cc
@@ -45,17 +45,6 @@
 
 #include <unordered_map>
 
-const auth::permission_set auth::permissions::ALL = auth::permission_set::of<
-        auth::permission::CREATE,
-        auth::permission::ALTER,
-        auth::permission::DROP,
-        auth::permission::SELECT,
-        auth::permission::MODIFY,
-        auth::permission::AUTHORIZE,
-        auth::permission::DESCRIBE>();
-
-const auth::permission_set auth::permissions::NONE;
-
 static const std::unordered_map<sstring, auth::permission> permission_names({
         {"READ", auth::permission::READ},
         {"WRITE", auth::permission::WRITE},

--- a/auth/permission.hh
+++ b/auth/permission.hh
@@ -88,8 +88,16 @@ bool operator<(const permission_set&, const permission_set&);
 
 namespace permissions {
 
-extern const permission_set ALL;
-extern const permission_set NONE;
+inline const permission_set ALL = auth::permission_set::of<
+        auth::permission::CREATE,
+        auth::permission::ALTER,
+        auth::permission::DROP,
+        auth::permission::SELECT,
+        auth::permission::MODIFY,
+        auth::permission::AUTHORIZE,
+        auth::permission::DESCRIBE>();
+
+inline const permission_set NONE;
 
 const sstring& to_string(permission);
 permission from_string(const sstring&);

--- a/clocks-impl.cc
+++ b/clocks-impl.cc
@@ -26,8 +26,6 @@
 
 #include "clocks-impl.hh"
 
-std::atomic<int64_t> clocks_offset;
-
 std::ostream& operator<<(std::ostream& os, db_clock::time_point tp) {
     auto t = db_clock::to_time_t(tp);
     return os << std::put_time(std::gmtime(&t), "%Y/%m/%d %T");

--- a/clocks-impl.hh
+++ b/clocks-impl.hh
@@ -26,7 +26,7 @@
 #include <chrono>
 #include <cstdint>
 
-extern std::atomic<int64_t> clocks_offset;
+inline std::atomic<int64_t> clocks_offset;
 
 template<typename Duration>
 static inline void forward_jump_clocks(Duration delta)

--- a/cql3/cql_config.hh
+++ b/cql3/cql_config.hh
@@ -31,6 +31,6 @@ struct cql_config {
     restrictions::restrictions_config restrictions;
 };
 
-extern const cql_config default_cql_config;
+inline const cql_config default_cql_config;
 
 }

--- a/cql3/query_options.cc
+++ b/cql3/query_options.cc
@@ -45,8 +45,6 @@
 
 namespace cql3 {
 
-const cql_config default_cql_config;
-
 thread_local const query_options::specific_options query_options::specific_options::DEFAULT{-1, {}, {}, api::missing_timestamp};
 
 thread_local query_options query_options::DEFAULT{default_cql_config,

--- a/cql3/query_options.hh
+++ b/cql3/query_options.hh
@@ -56,7 +56,6 @@
 namespace cql3 {
 
 class cql_config;
-extern const cql_config default_cql_config;
 
 /**
  * Options for a query.

--- a/cql3/query_processor.cc
+++ b/cql3/query_processor.cc
@@ -61,8 +61,6 @@ logging::logger log("query_processor");
 logging::logger prep_cache_log("prepared_statements_cache");
 logging::logger authorized_prepared_statements_cache_log("authorized_prepared_statements_cache");
 
-distributed<query_processor> _the_query_processor;
-
 const sstring query_processor::CQL_VERSION = "3.3.1";
 
 const std::chrono::minutes prepared_statements_cache::entry_expiry = std::chrono::minutes(60);

--- a/cql3/query_processor.hh
+++ b/cql3/query_processor.hh
@@ -474,7 +474,7 @@ private:
             ::shared_ptr<cql_statement> statement);
 };
 
-extern seastar::sharded<query_processor> _the_query_processor;
+inline seastar::sharded<query_processor> _the_query_processor;
 
 inline seastar::sharded<query_processor>& get_query_processor() {
     return _the_query_processor;

--- a/database.cc
+++ b/database.cc
@@ -92,7 +92,6 @@
 
 #include "schema_builder.hh"
 
-using namespace std::chrono_literals;
 using namespace db;
 
 logging::logger dblog("database");
@@ -2057,8 +2056,3 @@ std::ostream& operator<<(std::ostream& os, gc_clock::time_point tp) {
     tmp << std::setw(12) << sec;
     return os;
 }
-
-const timeout_config infinite_timeout_config = {
-        // not really infinite, but long enough
-        1h, 1h, 1h, 1h, 1h, 1h, 1h,
-};

--- a/database.cc
+++ b/database.cc
@@ -97,10 +97,6 @@ using namespace db;
 
 logging::logger dblog("database");
 
-// Used for tests where the CF exists without a database object. We need to pass a valid
-// dirty_memory manager in that case.
-thread_local dirty_memory_manager default_dirty_memory_manager;
-
 inline
 flush_controller
 make_flush_controller(const db::config& cfg, seastar::scheduling_group sg, const ::io_priority_class& iop, std::function<double()> fn) {

--- a/db/batchlog_manager.cc
+++ b/db/batchlog_manager.cc
@@ -405,6 +405,3 @@ std::unordered_set<gms::inet_address> db::batchlog_manager::endpoint_filter(cons
 
     return result;
 }
-
-
-distributed<db::batchlog_manager> db::_the_batchlog_manager;

--- a/db/batchlog_manager.hh
+++ b/db/batchlog_manager.hh
@@ -112,7 +112,7 @@ public:
     std::unordered_set<gms::inet_address> endpoint_filter(const sstring&, const std::unordered_map<sstring, std::unordered_set<gms::inet_address>>&);
 };
 
-extern distributed<batchlog_manager> _the_batchlog_manager;
+inline distributed<batchlog_manager> _the_batchlog_manager;
 
 inline distributed<batchlog_manager>& get_batchlog_manager() {
     return _the_batchlog_manager;

--- a/db/consistency_level.cc
+++ b/db/consistency_level.cc
@@ -58,8 +58,6 @@
 
 namespace db {
 
-logging::logger cl_logger("consistency");
-
 size_t quorum_for(const keyspace& ks) {
     return (ks.get_replication_strategy().get_replication_factor() / 2) + 1;
 }

--- a/db/consistency_level.hh
+++ b/db/consistency_level.hh
@@ -54,7 +54,7 @@
 
 namespace db {
 
-extern logging::logger cl_logger;
+inline logging::logger cl_logger("consistency");
 
 size_t quorum_for(const keyspace& ks);
 

--- a/db/heat_load_balance.cc
+++ b/db/heat_load_balance.cc
@@ -23,8 +23,6 @@
 #include <random>
 #include "heat_load_balance.hh"
 
-logging::logger hr_logger("heat_load_balance");
-
 // Return a uniformly-distributed random number in [0,1)
 // We use per-thread state for thread safety.  We seed the random number generator
 // once with a real random value, if available,

--- a/db/heat_load_balance.hh
+++ b/db/heat_load_balance.hh
@@ -43,7 +43,7 @@
 #include <boost/range/adaptor/map.hpp>
 #include "log.hh"
 
-extern logging::logger hr_logger;
+inline logging::logger hr_logger("heat_load_balance");
 
 class rand_exception {};
 

--- a/db/query_context.hh
+++ b/db/query_context.hh
@@ -81,7 +81,8 @@ struct query_context {
 };
 
 // This does not have to be thread local, because all cores will share the same context.
-extern std::unique_ptr<query_context> qctx;
+inline std::unique_ptr<query_context> qctx = {};
+
 
 template <typename... Args>
 static future<::shared_ptr<cql3::untyped_result_set>> execute_cql(sstring text, Args&&... args) {

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -90,8 +90,6 @@ using days = std::chrono::duration<int, std::ratio<24 * 3600>>;
 
 namespace db {
 
-std::unique_ptr<query_context> qctx = {};
-
 namespace system_keyspace {
 
 static logging::logger slogger("system_keyspace");

--- a/dirty_memory_manager.hh
+++ b/dirty_memory_manager.hh
@@ -236,5 +236,7 @@ private:
     friend class flush_permit;
 };
 
-extern thread_local dirty_memory_manager default_dirty_memory_manager;
+// Used for tests where the CF exists without a database object. We need to pass a valid
+// dirty_memory manager in that case.
+inline thread_local dirty_memory_manager default_dirty_memory_manager;
 

--- a/gms/feature.hh
+++ b/gms/feature.hh
@@ -110,34 +110,34 @@ public:
 
 namespace features {
 
-extern const std::string_view RANGE_TOMBSTONES;
-extern const std::string_view LARGE_PARTITIONS;
-extern const std::string_view MATERIALIZED_VIEWS;
-extern const std::string_view COUNTERS;
-extern const std::string_view INDEXES;
-extern const std::string_view DIGEST_MULTIPARTITION_READ;
-extern const std::string_view CORRECT_COUNTER_ORDER;
-extern const std::string_view SCHEMA_TABLES_V3;
-extern const std::string_view CORRECT_NON_COMPOUND_RANGE_TOMBSTONES;
-extern const std::string_view WRITE_FAILURE_REPLY;
-extern const std::string_view XXHASH;
-extern const std::string_view UDF;
-extern const std::string_view ROLES;
-extern const std::string_view LA_SSTABLE;
-extern const std::string_view STREAM_WITH_RPC_STREAM;
-extern const std::string_view MC_SSTABLE;
-extern const std::string_view ROW_LEVEL_REPAIR;
-extern const std::string_view TRUNCATION_TABLE;
-extern const std::string_view CORRECT_STATIC_COMPACT_IN_MC;
-extern const std::string_view UNBOUNDED_RANGE_TOMBSTONES;
-extern const std::string_view VIEW_VIRTUAL_COLUMNS;
-extern const std::string_view DIGEST_INSENSITIVE_TO_EXPIRY;
-extern const std::string_view COMPUTED_COLUMNS;
-extern const std::string_view CDC;
-extern const std::string_view NONFROZEN_UDTS;
-extern const std::string_view HINTED_HANDOFF_SEPARATE_CONNECTION;
-extern const std::string_view LWT;
-extern const std::string_view PER_TABLE_PARTITIONERS;
+inline const std::string_view RANGE_TOMBSTONES = "RANGE_TOMBSTONES";
+inline const std::string_view LARGE_PARTITIONS = "LARGE_PARTITIONS";
+inline const std::string_view MATERIALIZED_VIEWS = "MATERIALIZED_VIEWS";
+inline const std::string_view COUNTERS = "COUNTERS";
+inline const std::string_view INDEXES = "INDEXES";
+inline const std::string_view DIGEST_MULTIPARTITION_READ = "DIGEST_MULTIPARTITION_READ";
+inline const std::string_view CORRECT_COUNTER_ORDER = "CORRECT_COUNTER_ORDER";
+inline const std::string_view SCHEMA_TABLES_V3 = "SCHEMA_TABLES_V3";
+inline const std::string_view CORRECT_NON_COMPOUND_RANGE_TOMBSTONES = "CORRECT_NON_COMPOUND_RANGE_TOMBSTONES";
+inline const std::string_view WRITE_FAILURE_REPLY = "WRITE_FAILURE_REPLY";
+inline const std::string_view XXHASH = "XXHASH";
+inline const std::string_view UDF = "UDF";
+inline const std::string_view ROLES = "ROLES";
+inline const std::string_view LA_SSTABLE = "LA_SSTABLE_FORMAT";
+inline const std::string_view STREAM_WITH_RPC_STREAM = "STREAM_WITH_RPC_STREAM";
+inline const std::string_view MC_SSTABLE = "MC_SSTABLE_FORMAT";
+inline const std::string_view ROW_LEVEL_REPAIR = "ROW_LEVEL_REPAIR";
+inline const std::string_view TRUNCATION_TABLE = "TRUNCATION_TABLE";
+inline const std::string_view CORRECT_STATIC_COMPACT_IN_MC = "CORRECT_STATIC_COMPACT_IN_MC";
+inline const std::string_view UNBOUNDED_RANGE_TOMBSTONES = "UNBOUNDED_RANGE_TOMBSTONES";
+inline const std::string_view VIEW_VIRTUAL_COLUMNS = "VIEW_VIRTUAL_COLUMNS";
+inline const std::string_view DIGEST_INSENSITIVE_TO_EXPIRY = "DIGEST_INSENSITIVE_TO_EXPIRY";
+inline const std::string_view COMPUTED_COLUMNS = "COMPUTED_COLUMNS";
+inline const std::string_view CDC = "CDC";
+inline const std::string_view NONFROZEN_UDTS = "NONFROZEN_UDTS";
+inline const std::string_view HINTED_HANDOFF_SEPARATE_CONNECTION = "HINTED_HANDOFF_SEPARATE_CONNECTION";
+inline const std::string_view LWT = "LWT";
+inline const std::string_view PER_TABLE_PARTITIONERS = "PER_TABLE_PARTITIONERS";
 
 }
 

--- a/gms/feature.hh
+++ b/gms/feature.hh
@@ -21,6 +21,8 @@
 
 #pragma once
 
+#include <any>
+
 #include <boost/signals2.hpp>
 #include <boost/signals2/dummy_mutex.hpp>
 

--- a/gms/feature_service.cc
+++ b/gms/feature_service.cc
@@ -26,34 +26,6 @@
 #include "gms/feature_service.hh"
 
 namespace gms {
-constexpr std::string_view features::RANGE_TOMBSTONES = "RANGE_TOMBSTONES";
-constexpr std::string_view features::LARGE_PARTITIONS = "LARGE_PARTITIONS";
-constexpr std::string_view features::MATERIALIZED_VIEWS = "MATERIALIZED_VIEWS";
-constexpr std::string_view features::COUNTERS = "COUNTERS";
-constexpr std::string_view features::INDEXES = "INDEXES";
-constexpr std::string_view features::DIGEST_MULTIPARTITION_READ = "DIGEST_MULTIPARTITION_READ";
-constexpr std::string_view features::CORRECT_COUNTER_ORDER = "CORRECT_COUNTER_ORDER";
-constexpr std::string_view features::SCHEMA_TABLES_V3 = "SCHEMA_TABLES_V3";
-constexpr std::string_view features::CORRECT_NON_COMPOUND_RANGE_TOMBSTONES = "CORRECT_NON_COMPOUND_RANGE_TOMBSTONES";
-constexpr std::string_view features::WRITE_FAILURE_REPLY = "WRITE_FAILURE_REPLY";
-constexpr std::string_view features::XXHASH = "XXHASH";
-constexpr std::string_view features::UDF = "UDF";
-constexpr std::string_view features::ROLES = "ROLES";
-constexpr std::string_view features::LA_SSTABLE = "LA_SSTABLE_FORMAT";
-constexpr std::string_view features::STREAM_WITH_RPC_STREAM = "STREAM_WITH_RPC_STREAM";
-constexpr std::string_view features::MC_SSTABLE = "MC_SSTABLE_FORMAT";
-constexpr std::string_view features::ROW_LEVEL_REPAIR = "ROW_LEVEL_REPAIR";
-constexpr std::string_view features::TRUNCATION_TABLE = "TRUNCATION_TABLE";
-constexpr std::string_view features::CORRECT_STATIC_COMPACT_IN_MC = "CORRECT_STATIC_COMPACT_IN_MC";
-constexpr std::string_view features::UNBOUNDED_RANGE_TOMBSTONES = "UNBOUNDED_RANGE_TOMBSTONES";
-constexpr std::string_view features::VIEW_VIRTUAL_COLUMNS = "VIEW_VIRTUAL_COLUMNS";
-constexpr std::string_view features::DIGEST_INSENSITIVE_TO_EXPIRY = "DIGEST_INSENSITIVE_TO_EXPIRY";
-constexpr std::string_view features::COMPUTED_COLUMNS = "COMPUTED_COLUMNS";
-constexpr std::string_view features::CDC = "CDC";
-constexpr std::string_view features::NONFROZEN_UDTS = "NONFROZEN_UDTS";
-constexpr std::string_view features::HINTED_HANDOFF_SEPARATE_CONNECTION = "HINTED_HANDOFF_SEPARATE_CONNECTION";
-constexpr std::string_view features::LWT = "LWT";
-constexpr std::string_view features::PER_TABLE_PARTITIONERS = "PER_TABLE_PARTITIONERS";
 
 static logging::logger logger("features");
 

--- a/gms/feature_service.hh
+++ b/gms/feature_service.hh
@@ -28,13 +28,12 @@
 #include <functional>
 #include "seastarx.hh"
 #include "db/schema_features.hh"
+#include "gms/feature.hh"
 
 namespace db { class config; }
 namespace service { class storage_service; }
 
 namespace gms {
-
-class feature;
 
 struct feature_config {
     bool enable_sstables_mc_format = false;

--- a/gms/gossiper.cc
+++ b/gms/gossiper.cc
@@ -73,8 +73,6 @@ constexpr std::chrono::milliseconds gossiper::INTERVAL;
 constexpr std::chrono::hours gossiper::A_VERY_LONG_TIME;
 constexpr int64_t gossiper::MAX_GENERATION_DIFFERENCE;
 
-distributed<gossiper> _the_gossiper;
-
 netw::msg_addr gossiper::get_msg_addr(inet_address to) {
     return msg_addr{to, _default_cpuid};
 }

--- a/gms/gossiper.hh
+++ b/gms/gossiper.hh
@@ -595,7 +595,7 @@ public:
     failure_detector& fd() { return _fd; }
 };
 
-extern distributed<gossiper> _the_gossiper;
+inline distributed<gossiper> _the_gossiper;
 
 inline gossiper& get_local_gossiper() {
     return _the_gossiper.local();

--- a/init.cc
+++ b/init.cc
@@ -30,8 +30,6 @@
 #include "seastarx.hh"
 #include "db/config.hh"
 
-logging::logger startlog("init");
-
 void init_ms_fd_gossiper(sharded<gms::gossiper>& gossiper
                 , sharded<gms::feature_service>& features
                 , db::config& cfg

--- a/init.hh
+++ b/init.hh
@@ -43,7 +43,7 @@ class feature_service;
 class gossiper;
 }
 
-extern logging::logger startlog;
+inline logging::logger startlog("init");
 
 class bad_configuration_error : public std::exception {};
 

--- a/message/messaging_service.cc
+++ b/message/messaging_service.cc
@@ -185,8 +185,6 @@ struct messaging_service::rpc_protocol_server_wrapper : public rpc_protocol::ser
 
 constexpr int32_t messaging_service::current_version;
 
-distributed<messaging_service> _the_messaging_service;
-
 bool operator==(const msg_addr& x, const msg_addr& y) {
     // Ignore cpu id for now since we do not really support shard to shard connections
     return x.addr == y.addr;

--- a/message/messaging_service.hh
+++ b/message/messaging_service.hh
@@ -515,7 +515,7 @@ public:
     scheduling_group scheduling_group_for_verb(messaging_verb verb) const;
 };
 
-extern distributed<messaging_service> _the_messaging_service;
+inline distributed<messaging_service> _the_messaging_service;
 
 inline distributed<messaging_service>& get_messaging_service() {
     return _the_messaging_service;

--- a/partition_snapshot_reader.hh
+++ b/partition_snapshot_reader.hh
@@ -31,8 +31,6 @@ struct partition_snapshot_reader_dummy_accounter {
    void operator()(const partition_start& ph) {}
    void operator()(const partition_end& eop) {}
 };
-extern partition_snapshot_reader_dummy_accounter no_accounter;
-
 template <typename MemoryAccounter = partition_snapshot_reader_dummy_accounter>
 class partition_snapshot_flat_reader : public flat_mutation_reader::impl, public MemoryAccounter {
     struct rows_position {

--- a/query-request.hh
+++ b/query-request.hh
@@ -43,8 +43,9 @@ using range = wrapping_range<T>;
 using ring_position = dht::ring_position;
 using clustering_range = nonwrapping_range<clustering_key_prefix>;
 
-extern const dht::partition_range full_partition_range;
-extern const clustering_range full_clustering_range;
+inline const dht::partition_range full_partition_range = dht::partition_range::make_open_ended_both_sides();
+inline const clustering_range full_clustering_range = clustering_range::make_open_ended_both_sides();
+
 
 inline
 bool is_single_partition(const dht::partition_range& range) {

--- a/query.cc
+++ b/query.cc
@@ -37,9 +37,6 @@ constexpr size_t result_memory_limiter::maximum_result_size;
 
 thread_local semaphore result_memory_tracker::_dummy { 0 };
 
-const dht::partition_range full_partition_range = dht::partition_range::make_open_ended_both_sides();
-const clustering_range full_clustering_range = clustering_range::make_open_ended_both_sides();
-
 std::ostream& operator<<(std::ostream& out, const specific_ranges& s);
 
 std::ostream& operator<<(std::ostream& out, const partition_slice& ps) {

--- a/service/migration_manager.cc
+++ b/service/migration_manager.cc
@@ -57,8 +57,6 @@ namespace service {
 
 static logging::logger mlogger("migration_manager");
 
-distributed<service::migration_manager> _the_migration_manager;
-
 using namespace std::chrono_literals;
 
 const std::chrono::milliseconds migration_manager::migration_delay = 60000ms;

--- a/service/migration_manager.hh
+++ b/service/migration_manager.hh
@@ -178,7 +178,7 @@ private:
     static future<> do_announce_new_type(user_type new_type, bool announce_locally);
 };
 
-extern distributed<migration_manager> _the_migration_manager;
+inline distributed<migration_manager> _the_migration_manager;
 
 inline distributed<migration_manager>& get_migration_manager() {
     return _the_migration_manager;

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -111,8 +111,6 @@ seastar::metrics::label_instance current_scheduling_group_label() {
 
 thread_local uint64_t paxos_response_handler::next_id = 0;
 
-distributed<service::storage_proxy> _the_storage_proxy;
-
 using namespace exceptions;
 using fbu = utils::fb_utilities;
 

--- a/service/storage_proxy.hh
+++ b/service/storage_proxy.hh
@@ -688,7 +688,7 @@ public:
     }
 };
 
-extern distributed<storage_proxy> _the_storage_proxy;
+inline distributed<storage_proxy> _the_storage_proxy;
 
 inline distributed<storage_proxy>& get_storage_proxy() {
     return _the_storage_proxy;

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -94,9 +94,6 @@ static logging::logger slogger("storage_service");
 
 static const sstring SSTABLE_FORMAT_PARAM_NAME = "sstable_format";
 
-distributed<storage_service> _the_storage_service;
-
-
 int get_generation_number() {
     using namespace std::chrono;
     auto now = high_resolution_clock::now().time_since_epoch();

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -92,7 +92,7 @@ namespace service {
 
 class storage_service;
 
-extern distributed<storage_service> _the_storage_service;
+inline distributed<storage_service> _the_storage_service;
 inline distributed<storage_service>& get_storage_service() {
     return _the_storage_service;
 }

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -79,9 +79,6 @@
 #include <boost/algorithm/string/predicate.hpp>
 #include "tracing/traced_file.hh"
 
-thread_local disk_error_signal_type sstable_read_error;
-thread_local disk_error_signal_type sstable_write_error;
-
 namespace sstables {
 
 logging::logger sstlog("sstable");

--- a/streaming/stream_manager.cc
+++ b/streaming/stream_manager.cc
@@ -47,9 +47,6 @@ namespace streaming {
 
 extern logging::logger sslog;
 
-distributed<stream_manager> _the_stream_manager;
-
-
 stream_manager::stream_manager() {
     namespace sm = seastar::metrics;
 

--- a/streaming/stream_manager.hh
+++ b/streaming/stream_manager.hh
@@ -168,7 +168,7 @@ private:
     bool has_peer(inet_address endpoint) const;
 };
 
-extern distributed<stream_manager> _the_stream_manager;
+inline distributed<stream_manager> _the_stream_manager;
 
 inline distributed<stream_manager>& get_stream_manager() {
     return _the_stream_manager;

--- a/supervisor.cc
+++ b/supervisor.cc
@@ -21,6 +21,7 @@
 
 #include "supervisor.hh"
 #include "log.hh"
+#include "init.hh"
 #include <seastar/core/print.hh>
 #include <csignal>
 #include <cstdlib>
@@ -28,8 +29,6 @@
 #ifdef HAVE_LIBSYSTEMD
 #include <systemd/sd-daemon.h>
 #endif
-
-extern logger startlog;
 
 const sstring supervisor::scylla_upstart_job_str("scylla-server");
 const sstring supervisor::upstart_job_env("UPSTART_JOB");

--- a/test/boost/cql_query_large_test.cc
+++ b/test/boost/cql_query_large_test.cc
@@ -33,6 +33,7 @@
 #include "test/lib/cql_assertions.hh"
 
 #include <seastar/core/future-util.hh>
+#include "cql3/cql_config.hh"
 #include "transport/messages/result_message.hh"
 #include "utils/big_decimal.hh"
 #include "types/user.hh"

--- a/test/lib/test_services.cc
+++ b/test/lib/test_services.cc
@@ -21,11 +21,9 @@
 
 #include "test/lib/test_services.hh"
 #include "auth/service.hh"
-#include "db/config.hh"
 #include "db/system_distributed_keyspace.hh"
 #include "db/view/view_update_generator.hh"
 #include "dht/i_partitioner.hh"
-#include "gms/feature_service.hh"
 #include "gms/gossiper.hh"
 #include "message/messaging_service.hh"
 #include "service/storage_service.hh"
@@ -97,11 +95,6 @@ range<dht::token> create_token_range_from_keys(const dht::i_partitioner& partiti
 
 static const sstring some_keyspace("ks");
 static const sstring some_column_family("cf");
-
-db::nop_large_data_handler nop_lp_handler;
-db::config test_db_config;
-gms::feature_service test_feature_service(gms::feature_config_from_db_config(test_db_config));
-thread_local sstables::sstables_manager test_sstables_manager(nop_lp_handler, test_db_config, test_feature_service);
 
 column_family::config column_family_test_config() {
     column_family::config cfg;

--- a/test/lib/test_services.hh
+++ b/test/lib/test_services.hh
@@ -25,6 +25,8 @@
 #include <memory>
 #include <seastar/core/reactor.hh>
 
+#include "db/config.hh"
+#include "gms/feature_service.hh"
 #include "schema.hh"
 #include "schema_builder.hh"
 #include "row_cache.hh"
@@ -43,10 +45,11 @@ public:
     ~storage_service_for_tests();
 };
 
-extern db::nop_large_data_handler nop_lp_handler;
-extern db::config test_db_config;
-extern gms::feature_service test_feature_service;
-extern thread_local sstables::sstables_manager test_sstables_manager;
+inline db::nop_large_data_handler nop_lp_handler;
+inline db::config test_db_config;
+inline gms::feature_service test_feature_service(gms::feature_config_from_db_config(test_db_config));
+inline thread_local sstables::sstables_manager test_sstables_manager(nop_lp_handler, test_db_config, test_feature_service);
+
 
 column_family::config column_family_test_config();
 

--- a/timeout_config.hh
+++ b/timeout_config.hh
@@ -35,8 +35,12 @@ struct timeout_config {
 };
 
 using timeout_config_selector = db::timeout_clock::duration (timeout_config::*);
+using namespace std::chrono_literals;
 
-extern const timeout_config infinite_timeout_config;
+inline const timeout_config infinite_timeout_config = {
+        // not really infinite, but long enough
+        1h, 1h, 1h, 1h, 1h, 1h, 1h,
+};
 
 namespace db { class config; }
 timeout_config make_timeout_config(const db::config& cfg);

--- a/tracing/tracing.cc
+++ b/tracing/tracing.cc
@@ -50,12 +50,6 @@ const gc_clock::duration tracing::tracing::write_period = std::chrono::seconds(2
 const std::chrono::seconds tracing::tracing::default_slow_query_record_ttl = std::chrono::seconds(86400);
 const std::chrono::microseconds tracing::tracing::default_slow_query_duraion_threshold = std::chrono::milliseconds(500);
 
-std::vector<sstring> trace_type_names = {
-    "NONE",
-    "QUERY",
-    "REPAIR"
-};
-
 tracing::tracing(const backend_registry& br, sstring tracing_backend_helper_class_name)
         : _write_timer([this] { write_timer_callback(); })
         , _thread_name(seastar::format("shard {:d}", engine().cpu_id()))

--- a/tracing/tracing.hh
+++ b/tracing/tracing.hh
@@ -69,7 +69,12 @@ enum class trace_type : uint8_t {
     REPAIR,
 };
 
-extern std::vector<sstring> trace_type_names;
+inline const std::vector<sstring> trace_type_names = {
+    "NONE",
+    "QUERY",
+    "REPAIR"
+};
+
 
 inline const sstring& type_to_string(trace_type t) {
     return trace_type_names.at(static_cast<int>(t));

--- a/utils/allocation_strategy.hh
+++ b/utils/allocation_strategy.hh
@@ -212,7 +212,7 @@ public:
     }
 };
 
-extern standard_allocation_strategy standard_allocation_strategy_instance;
+inline standard_allocation_strategy standard_allocation_strategy_instance;
 
 inline
 standard_allocation_strategy& standard_allocator() {

--- a/utils/disk-error-handler.cc
+++ b/utils/disk-error-handler.cc
@@ -20,13 +20,6 @@
 
 #include "utils/disk-error-handler.hh"
 
-thread_local disk_error_signal_type commit_error;
-thread_local disk_error_signal_type general_disk_error;
-
-thread_local io_error_handler commit_error_handler = default_io_error_handler(commit_error);
-thread_local io_error_handler general_disk_error_handler = default_io_error_handler(general_disk_error);
-thread_local io_error_handler sstable_write_error_handler = default_io_error_handler(sstable_write_error);
-
 io_error_handler default_io_error_handler(disk_error_signal_type& signal) {
     return [&signal] (std::exception_ptr eptr) {
         try {

--- a/utils/disk-error-handler.hh
+++ b/utils/disk-error-handler.hh
@@ -33,10 +33,10 @@ namespace bs2 = boost::signals2;
 
 using disk_error_signal_type = bs2::signal_type<void (), bs2::keywords::mutex_type<bs2::dummy_mutex>>::type;
 
-extern thread_local disk_error_signal_type commit_error;
-extern thread_local disk_error_signal_type sstable_read_error;
-extern thread_local disk_error_signal_type sstable_write_error;
-extern thread_local disk_error_signal_type general_disk_error;
+inline thread_local disk_error_signal_type commit_error;
+inline thread_local disk_error_signal_type sstable_read_error;
+inline thread_local disk_error_signal_type sstable_write_error;
+inline thread_local disk_error_signal_type general_disk_error;
 
 bool should_stop_on_system_error(const std::system_error& e);
 
@@ -48,9 +48,10 @@ io_error_handler default_io_error_handler(disk_error_signal_type& signal);
 // generates handler that handles exception for a given signal
 io_error_handler_gen default_io_error_handler_gen();
 
-extern thread_local io_error_handler commit_error_handler;
-extern thread_local io_error_handler sstable_write_error_handler;
-extern thread_local io_error_handler general_disk_error_handler;
+inline const thread_local io_error_handler commit_error_handler = default_io_error_handler(commit_error);
+inline const thread_local io_error_handler general_disk_error_handler = default_io_error_handler(general_disk_error);
+inline const thread_local io_error_handler sstable_write_error_handler = default_io_error_handler(sstable_write_error);
+
 
 template<typename Func, typename... Args>
 std::enable_if_t<!is_future<std::result_of_t<Func(Args&&...)>>::value,

--- a/utils/logalloc.cc
+++ b/utils/logalloc.cc
@@ -92,8 +92,6 @@ void unpoison(const char *addr, size_t size) { }
 
 namespace bi = boost::intrusive;
 
-standard_allocation_strategy standard_allocation_strategy_instance;
-
 namespace {
 
 class migrators_base {


### PR DESCRIPTION
C++17 introduced inline variables and now we don't have to declare a global extern in a header and then define it in .cc file. It is better to use inline variables because it reduces code duplication and complexity. Defining a variable in a single place is simpler and more maintainable.

This PR switches multiple places to use inline variables.

Tests: unit (dev)