### PR TITLE
tests: move token_generation_for_shard to common code

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -975,6 +975,7 @@ for t in perf_tests:
 
 deps['test/boost/sstable_test'] += ['test/lib/sstable_utils.cc', 'test/lib/normalizing_reader.cc']
 deps['test/boost/sstable_datafile_test'] += ['test/lib/sstable_utils.cc', 'test/lib/normalizing_reader.cc']
+deps['test/boost/sstable_resharding_test'] += ['test/lib/sstable_utils.cc' ]
 deps['test/boost/mutation_reader_test'] += ['test/lib/sstable_utils.cc', 'test/lib/dummy_partitioner.cc' ]
 deps['test/boost/multishard_combining_reader_as_mutation_source_test'] += ['test/lib/sstable_utils.cc', 'test/lib/dummy_partitioner.cc' ]
 deps['test/boost/sstable_mutation_test'] += ['test/lib/sstable_utils.cc']

--- a/test/boost/sstable_datafile_test.cc
+++ b/test/boost/sstable_datafile_test.cc
@@ -1714,37 +1714,6 @@ SEASTAR_TEST_CASE(test_counter_write) {
 
 // Leveled compaction strategy tests
 
-static std::vector<std::pair<sstring, dht::token>> token_generation_for_shard(unsigned tokens_to_generate, unsigned shard,
-        unsigned ignore_msb = 0, unsigned smp_count = smp::count) {
-    unsigned tokens = 0;
-    unsigned key_id = 0;
-    std::vector<std::pair<sstring, dht::token>> key_and_token_pair;
-
-    key_and_token_pair.reserve(tokens_to_generate);
-    dht::murmur3_partitioner partitioner(smp_count, ignore_msb);
-
-    while (tokens < tokens_to_generate) {
-        sstring key = to_sstring(key_id++);
-        dht::token token = create_token_from_key(partitioner, key);
-        if (shard != partitioner.shard_of(token)) {
-            continue;
-        }
-        tokens++;
-        key_and_token_pair.emplace_back(key, token);
-    }
-    assert(key_and_token_pair.size() == tokens_to_generate);
-
-    std::sort(key_and_token_pair.begin(),key_and_token_pair.end(), [] (auto& i, auto& j) {
-        return i.second < j.second;
-    });
-
-    return key_and_token_pair;
-}
-
-static std::vector<std::pair<sstring, dht::token>> token_generation_for_current_shard(unsigned tokens_to_generate) {
-    return token_generation_for_shard(tokens_to_generate, engine().cpu_id());
-}
-
 static void add_sstable_for_leveled_test(test_env& env, lw_shared_ptr<column_family> cf, int64_t gen, uint64_t fake_data_size,
                                          uint32_t sstable_level, sstring first_key, sstring last_key, int64_t max_timestamp = 0) {
     auto sst = env.make_sstable(cf->schema(), "", gen, la, big);

--- a/test/lib/sstable_utils.hh
+++ b/test/lib/sstable_utils.hh
@@ -85,3 +85,10 @@ inline std::vector<sstring> make_keys(unsigned n, const schema_ptr& s, size_t mi
 
 shared_sstable make_sstable(sstables::test_env& env, schema_ptr s, sstring dir, std::vector<mutation> mutations,
         sstable_writer_config cfg, sstables::sstable::version_types version, gc_clock::time_point query_time = gc_clock::now());
+
+std::vector<std::pair<sstring, dht::token>>
+token_generation_for_shard(unsigned tokens_to_generate, unsigned shard,
+        unsigned ignore_msb = 0, unsigned smp_count = smp::count);
+
+std::vector<std::pair<sstring, dht::token>>
+token_generation_for_current_shard(unsigned tokens_to_generate);


### PR DESCRIPTION
We now have a utils file for SSTables. This is potentially useful for
other tests.

As a matter of fact, this function is repeated right now for the
resharding test. And to add insult to injury, the version in the
resharding test has the parameters shard and number of tokens flipped,
which although extremely confusing is the predictable outcome of
such repetition

Signed-off-by: Glauber Costa <glauber@scylladb.com>