### PR TITLE
redis: add exists command

### DIFF
--- a/redis-test/test_strings.py
+++ b/redis-test/test_strings.py
@@ -106,3 +106,38 @@ def test_select():
         raise Exception('Expect that `SELECT 16` does not work')
     except redis.exceptions.ResponseError as ex:
         assert str(ex) == 'DB index is out of range'
+
+def test_exists_existent_key():
+    r = connect()
+    key = random_string(10)
+    val = random_string(10)
+
+    r.set(key, val)
+    assert r.get(key) == val
+    assert r.exists(key) == 1
+
+def test_exists_non_existent_key():
+    r = connect()
+    key = random_string(10)
+    r.delete(key)
+    assert r.exists(key) == 0
+
+def test_exists_multiple_existent_key():
+    r = connect()
+    key1 = random_string(10)
+    val1 = random_string(10)
+    key2 = random_string(10)
+    val2 = random_string(10)
+    key3 = random_string(10)
+    val3 = random_string(10)
+    key4 = random_string(10)
+
+    r.set(key1, val1)
+    r.set(key2, val2)
+    r.set(key3, val3)
+    r.delete(key4)
+    assert r.get(key1) == val1
+    assert r.get(key2) == val2
+    assert r.get(key3) == val3
+    assert r.get(key4) == None
+    assert r.exists(key1, key2, key3, key4) == 3

--- a/redis/command_factory.cc
+++ b/redis/command_factory.cc
@@ -35,6 +35,7 @@ shared_ptr<abstract_command> command_factory::create(service::storage_proxy& pro
         { "ping",  [] (service::storage_proxy& proxy, request&& req) { return commands::ping::prepare(proxy, std::move(req)); } }, 
         { "select",  [] (service::storage_proxy& proxy, request&& req) { return commands::select::prepare(proxy, std::move(req)); } }, 
         { "get",  [] (service::storage_proxy& proxy, request&& req) { return commands::get::prepare(proxy, std::move(req)); } }, 
+        { "exists", [] (service::storage_proxy& proxy, request&& req) { return commands::exists::prepare(proxy, std::move(req)); } },
         { "set",  [] (service::storage_proxy& proxy, request&& req) { return commands::set::prepare(proxy, std::move(req)); } }, 
         { "del",  [] (service::storage_proxy& proxy, request&& req) { return commands::del::prepare(proxy, std::move(req)); } }, 
         { "echo",  [] (service::storage_proxy& proxy, request&& req) { return commands::echo::prepare(proxy, std::move(req)); } },

--- a/redis/commands.hh
+++ b/redis/commands.hh
@@ -39,6 +39,15 @@ public:
     virtual future<redis_message> execute(service::storage_proxy&, redis_options&, service_permit) override;
 };
 
+class exists : public abstract_command {
+    std::vector<bytes> _keys;
+    size_t _count = 0;
+public:
+    static shared_ptr<abstract_command> prepare(service::storage_proxy& proxy, request&& req);
+    exists(bytes&& name, std::vector<bytes>&& keys);
+    virtual future<redis_message> execute(service::storage_proxy&, redis_options&, service_permit) override;
+};
+
 class set : public abstract_command {
     bytes _key;
     bytes _data;


### PR DESCRIPTION
Add exists command that returns key availablitiy.
We only support single argument for now, but upstream
does support multiple keys since Redis 3.0.3.

see: https://redis.io/commands/exists