### PR TITLE
cdc: fix non-atomic updates in splitting

### DIFF
--- a/cdc/split.cc
+++ b/cdc/split.cc
@@ -433,7 +433,7 @@ void for_each_change(const mutation& base_mutation, const schema_ptr& base_schem
                 row.apply(cdef, collection_mutation_description{nonatomic_delete.t, {}}.serialize(*cdef.type));
             }
             for (auto& nonatomic_update : cr_update.nonatomic_updates) {
-                auto& cdef = base_schema->column_at(column_kind::static_column, nonatomic_update.id);
+                auto& cdef = base_schema->column_at(column_kind::regular_column, nonatomic_update.id);
                 row.apply(cdef, collection_mutation_description{{}, std::move(nonatomic_update.cells)}.serialize(*cdef.type));
             }
 


### PR DESCRIPTION
This patch fixes a bug in mutation splitting logic of CDC. In the part that handles updates of non-atomic clustering columns, the column definition was fetched from a static column of the same id instead of the actual definition of the clustering column. It could cause the value to be written to a wrong column.

Tests: unit(dev)
Fixes: #6050 