### PR TITLE
migration_manager: Make sync_schema return error when node is down

### DIFF
--- a/service/migration_manager.hh
+++ b/service/migration_manager.hh
@@ -82,7 +82,7 @@ public:
 
     future<> maybe_schedule_schema_pull(const utils::UUID& their_version, const gms::inet_address& endpoint);
 
-    future<> submit_migration_task(const gms::inet_address& endpoint);
+    future<> submit_migration_task(const gms::inet_address& endpoint, bool can_ignore_down_node = true);
 
     // Makes sure that this node knows about all schema changes known by "nodes" that were made prior to this call.
     future<> sync_schema(const database& db, const std::vector<gms::inet_address>& nodes);

--- a/service/migration_task.cc
+++ b/service/migration_task.cc
@@ -64,6 +64,7 @@ future<> migration_task::run_may_throw(const gms::inet_address& endpoint, bool c
             std::rethrow_exception(e);
         } catch (const exceptions::configuration_exception& e) {
             mlogger.error("Configuration exception merging remote schema: {}", e.what());
+            return make_exception_future<>(e);
         }
     });
 }

--- a/service/migration_task.hh
+++ b/service/migration_task.hh
@@ -47,7 +47,7 @@ namespace service {
 
 class migration_task {
 public:
-    static future<> run_may_throw(const gms::inet_address& endpoint);
+    static future<> run_may_throw(const gms::inet_address& endpoint, bool can_ignore_down_node);
 };
 
 }


### PR DESCRIPTION
sync_schema is supposed to make sure that this node knows about all
schema changes known by "nodes" that were made prior to this call.

Currently, when a node is down, the sync is sliently skipped.

To fix, add a flag to migration_task::run_may_throw to indicate that it
should fail if a node is down.

Fixes #4791