### PR TITLE
Resharding through compact sstables

### DIFF
--- a/sstables/compaction.hh
+++ b/sstables/compaction.hh
@@ -84,6 +84,18 @@ namespace sstables {
         compaction_type type() const;
     };
 
+    struct compaction_completion_desc {
+        std::vector<shared_sstable> input_sstables;
+        std::vector<shared_sstable> output_sstables;
+        // Set of compacted partition ranges that should be invalidated in the cache.
+        dht::partition_range_vector ranges_for_cache_invalidation;
+    };
+
+    // creates a new SSTable for a given shard
+    using creator_fn = std::function<shared_sstable(shard_id shard)>;
+    // Replaces old sstable(s) by new one(s) which contain all non-expired data.
+    using replacer_fn = std::function<void(compaction_completion_desc)>;
+
     struct compaction_descriptor {
         // List of sstables to be compacted.
         std::vector<sstables::shared_sstable> sstables;
@@ -100,6 +112,9 @@ namespace sstables {
         // The options passed down to the compaction code.
         // This also selects the kind of compaction to do.
         compaction_options options = compaction_options::make_regular();
+
+        creator_fn creator;
+        replacer_fn replacer;
 
         compaction_descriptor() = default;
 
@@ -190,16 +205,6 @@ namespace sstables {
         }
     };
 
-    struct compaction_completion_desc {
-        std::vector<shared_sstable> input_sstables;
-        std::vector<shared_sstable> output_sstables;
-        // Set of compacted partition ranges that should be invalidated in the cache.
-        dht::partition_range_vector ranges_for_cache_invalidation;
-    };
-
-    // Replaces old sstable(s) by new one(s) which contain all non-expired data.
-    using replacer_fn = std::function<void(compaction_completion_desc)>;
-
     // Compact a list of N sstables into M sstables.
     // Returns info about the finished compaction, which includes vector to new sstables.
     //
@@ -212,8 +217,7 @@ namespace sstables {
     // If descriptor.cleanup is true, mutation that doesn't belong to current node will be
     // cleaned up, log messages will inform the user that compact_sstables runs for
     // cleaning operation, and compaction history will not be updated.
-    future<compaction_info> compact_sstables(sstables::compaction_descriptor descriptor, column_family& cf,
-        std::function<shared_sstable()> creator, replacer_fn replacer);
+    future<compaction_info> compact_sstables(sstables::compaction_descriptor descriptor, column_family& cf);
 
     // Compacts a set of N shared sstables into M sstables. For every shard involved,
     // i.e. which owns any of the sstables, a new unshared sstable is created.

--- a/sstables/compaction.hh
+++ b/sstables/compaction.hh
@@ -48,9 +48,11 @@ namespace sstables {
         struct scrub {
             bool skip_corrupted;
         };
+        struct reshard {
+        };
 
     private:
-        using options_variant = std::variant<regular, cleanup, upgrade, scrub>;
+        using options_variant = std::variant<regular, cleanup, upgrade, scrub, reshard>;
 
     private:
         options_variant _options;
@@ -60,6 +62,10 @@ namespace sstables {
         }
 
     public:
+        static compaction_options make_reshard() {
+            return compaction_options(reshard{});
+        }
+
         static compaction_options make_regular() {
             return compaction_options(regular{});
         }
@@ -218,12 +224,6 @@ namespace sstables {
     // cleaned up, log messages will inform the user that compact_sstables runs for
     // cleaning operation, and compaction history will not be updated.
     future<compaction_info> compact_sstables(sstables::compaction_descriptor descriptor, column_family& cf);
-
-    // Compacts a set of N shared sstables into M sstables. For every shard involved,
-    // i.e. which owns any of the sstables, a new unshared sstable is created.
-    future<std::vector<shared_sstable>> reshard_sstables(std::vector<shared_sstable> sstables,
-            column_family& cf, std::function<shared_sstable(shard_id)> creator,
-        uint64_t max_sstable_size, uint32_t sstable_level);
 
     // Return list of expired sstables for column family cf.
     // A sstable is fully expired *iff* its max_local_deletion_time precedes gc_before and its

--- a/test/lib/sstable_utils.cc
+++ b/test/lib/sstable_utils.cc
@@ -121,6 +121,14 @@ token_generation_for_shard(unsigned tokens_to_generate, unsigned shard,
     return key_and_token_pair;
 }
 
+future<compaction_info> compact_sstables(sstables::compaction_descriptor descriptor, column_family& cf, std::function<shared_sstable()> creator, replacer_fn replacer) {
+    descriptor.creator = [creator = std::move(creator)] (shard_id dummy) mutable {
+        return creator();
+    };
+    descriptor.replacer = std::move(replacer);
+    return sstables::compact_sstables(std::move(descriptor), cf);
+}
+
 std::vector<std::pair<sstring, dht::token>> token_generation_for_current_shard(unsigned tokens_to_generate) {
     return token_generation_for_shard(tokens_to_generate, this_shard_id());
 }

--- a/test/lib/sstable_utils.hh
+++ b/test/lib/sstable_utils.hh
@@ -355,5 +355,7 @@ public:
     }
 };
 
-
 } // namespace sstables
+
+future<compaction_info> compact_sstables(sstables::compaction_descriptor descriptor, column_family& cf,
+        std::function<shared_sstable()> creator, replacer_fn replacer = sstables::replacer_fn_no_op());


### PR DESCRIPTION
This patchseries is part of my effort to make resharding less special - and hopefully less problematic.
The next steps are a bit heavy, so I'd like to, if possible, get this out of the way.

After these two patches, there is no more need to ever call reshard_sstables: compact_sstables will
do, and it will be able to recognize resharding compactions.

To do that we need to unify the creator function, which is trivially done by adding a shard parameter
to regular compactions as well: they can just ignore it. I have considered just making the compaction_descriptor have a virtual create() function and specializing it, but because we have to store the creator in the compaction object I decided to keep the virtual function for now. 

In a later cleanup step, if we can for instance store the entire compaction_descriptor object in the compaction object we could do that.

Tests: unit tests (dev), dtest (resharding.py)