### PR TITLE
fixing --experimental flag option from "on" to "1"

### DIFF
--- a/docs/alternator/alternator.md
+++ b/docs/alternator/alternator.md
@@ -23,7 +23,7 @@ Alternator on port 8000 - the traditional port used by DynamoDB.
 
 Alternator uses Scylla's LWT feature, which is currently considered
 experimental and needs to be seperately enabled as well, e.g. with the
-"`--experimental=on`" option.
+"`--experimental=1`" option.
 
 By default, Scylla listens on this port on all network interfaces.
 To listen only on a specific interface, pass also an "`alternator-address`"


### PR DESCRIPTION
When trying to run with "--experimental=on" I get:
File "/usr/lib64/python3.6/argparse.py", line 2318, in _check_value
   raise ArgumentError(action, msg % args)
argparse.ArgumentError: argument --experimental: invalid choice: 'on' (choose from '0', '1')