### PR TITLE
cf_prop_defs: don't override default_time_to_live when it's not set

### DIFF
--- a/cql3/statements/cf_prop_defs.cc
+++ b/cql3/statements/cf_prop_defs.cc
@@ -255,7 +255,9 @@ void cf_prop_defs::apply_to_builder(schema_builder& builder, schema::extensions_
         }
     }
 
-    builder.set_default_time_to_live(gc_clock::duration(get_int(KW_DEFAULT_TIME_TO_LIVE, DEFAULT_DEFAULT_TIME_TO_LIVE)));
+    if (has_property(KW_DEFAULT_TIME_TO_LIVE)) {
+        builder.set_default_time_to_live(gc_clock::duration(get_int(KW_DEFAULT_TIME_TO_LIVE, DEFAULT_DEFAULT_TIME_TO_LIVE)));
+    }
 
     if (has_property(KW_SPECULATIVE_RETRY)) {
         builder.set_speculative_retry(get_string(KW_SPECULATIVE_RETRY, builder.get_speculative_retry().to_sstring()));


### PR DESCRIPTION
Previously altering any table property would set default ttl to 0
if this alter statement wasn't specifying ttl.

Fixes #5048

Tests: unit(dev)

Signed-off-by: Piotr Jastrzebski <piotr@scylladb.com>