### PR TITLE
install.sh: suppoprt --upgrade

### DIFF
--- a/dist/debian/debian/scylla-server.postinst
+++ b/dist/debian/debian/scylla-server.postinst
@@ -25,11 +25,6 @@ fi
 
 ln -sfT /etc/scylla /var/lib/scylla/conf
 
-grep -v api_ui_dir /etc/scylla/scylla.yaml | grep -v api_doc_dir > /tmp/scylla.yaml
-echo "api_ui_dir: /opt/scylladb/swagger-ui/dist/" >> /tmp/scylla.yaml
-echo "api_doc_dir: /opt/scylladb/api/api-doc/" >> /tmp/scylla.yaml
-mv /tmp/scylla.yaml /etc/scylla/scylla.yaml
-
 /opt/scylladb/scripts/scylla_post_install.sh
 
 #DEBHELPER#

--- a/dist/redhat/scylla.spec.mustache
+++ b/dist/redhat/scylla.spec.mustache
@@ -150,12 +150,6 @@ Obsoletes:	scylla-server < 1.1
 %description conf
 This package contains the main scylla configuration file.
 
-%post conf
-grep -v api_ui_dir /etc/scylla/scylla.yaml | grep -v api_doc_dir > /tmp/scylla.yaml
-echo "api_ui_dir: /opt/scylladb/swagger-ui/dist/" >> /tmp/scylla.yaml
-echo "api_doc_dir: /opt/scylladb/api/api-doc/" >> /tmp/scylla.yaml
-mv /tmp/scylla.yaml /etc/scylla/scylla.yaml
-
 # we need to refuse upgrade if current scylla < 1.7.3 && commitlog remains
 %pretrans conf
 ver=$(rpm -qi scylla-server | grep Version | awk '{print $3}')


### PR DESCRIPTION
To use install.sh as Scylla install script w/o using .rpm/.deb package,
we need to provide a way to upgrade Scylla version, not just install.

With --upgrade option, install.sh does not overwrite config files.
It will install <filename>.new file on same directory, when old config file and
new config file does not contain same data.
If old one and new one is exactly same, it will nothing.

To implement this, rewriting api_ui_dir/api_doc_dir path on scylla.yaml
moved from .rpm/.deb scriptlet to install.sh.

Fixes #5874