### PR TITLE
[DRAFT v4] cdc+counters: make counters work in CDC

### DIFF
--- a/counters.hh
+++ b/counters.hh
@@ -440,6 +440,8 @@ struct counter_cell_mutable_view : basic_counter_cell_view<mutable_view::yes> {
     void set_timestamp(api::timestamp_type ts) { _cell.set_timestamp(ts); }
 };
 
+void nullify_dead_updates(mutation& update, const mutation* current_state);
+
 // Transforms mutation dst from counter updates to counter shards using state
 // stored in current_state.
 // If current_state is present it has to be in the same schema as dst.

--- a/database.hh
+++ b/database.hh
@@ -1404,8 +1404,8 @@ private:
     future<> apply_with_commitlog(schema_ptr, column_family&, utils::UUID, const frozen_mutation&, db::timeout_clock::time_point timeout, db::commitlog::force_sync sync);
     future<> apply_with_commitlog(column_family& cf, const mutation& m, db::timeout_clock::time_point timeout);
 
-    future<mutation> do_apply_counter_update(column_family& cf, const frozen_mutation& fm, schema_ptr m_schema, db::timeout_clock::time_point timeout,
-                                             tracing::trace_state_ptr trace_state);
+    future<std::tuple<mutation, mutation_opt>> do_apply_counter_update(column_family& cf, const frozen_mutation& fm, schema_ptr m_schema, db::timeout_clock::time_point timeout,
+                                             tracing::trace_state_ptr trace_state, bool get_sanitized_delta);
 
     template<typename Future>
     Future update_write_metrics(Future&& f);
@@ -1505,7 +1505,7 @@ public:
     future<> apply(schema_ptr, const frozen_mutation&, db::commitlog::force_sync sync, db::timeout_clock::time_point timeout);
     future<> apply_hint(schema_ptr, const frozen_mutation&, db::timeout_clock::time_point timeout);
     future<> apply_streaming_mutation(schema_ptr, utils::UUID plan_id, const frozen_mutation&, bool fragmented);
-    future<mutation> apply_counter_update(schema_ptr, const frozen_mutation& m, db::timeout_clock::time_point timeout, tracing::trace_state_ptr trace_state);
+    future<std::tuple<mutation, mutation_opt>> apply_counter_update(schema_ptr, const frozen_mutation& m, db::timeout_clock::time_point timeout, tracing::trace_state_ptr trace_state, bool get_sanitized_delta);
     keyspace::config make_keyspace_config(const keyspace_metadata& ksm);
     const sstring& get_snitch_name() const;
     /*!


### PR DESCRIPTION
[draft, because I left tests at home, unpushed]

This patch augments counter "deltas" on leader node. Before that,
"deltas" are "sanitized", which means that they are set to 0 if
they try to update a deleted counter, so CDC will not contain
spurious (ineffective) updates.

On the CDC side, counter columns are represented as `long_type`,
with unchanged logic behind pre-/postimage (preimage query returns
ordinary integer, postimage is calculated from delta and preimg).