### PR TITLE
dist/docker: make docker-entrypoint.py pass signals to supervisord

### DIFF
--- a/dist/docker/redhat/docker-entrypoint.py
+++ b/dist/docker/redhat/docker-entrypoint.py
@@ -3,12 +3,21 @@
 
 import os
 import sys
+import signal
+import subprocess
 import scyllasetup
 import logging
 import commandlineparser
 
 logging.basicConfig(stream=sys.stdout, level=logging.DEBUG, format="%(message)s")
 
+supervisord = None
+
+def signal_handler(signum, frame):
+    supervisord.send_signal(signum)
+
+signal.signal(signal.SIGINT, signal_handler)
+signal.signal(signal.SIGTERM, signal_handler)
 try:
     arguments = commandlineparser.parse()
     setup = scyllasetup.ScyllaSetup(arguments)
@@ -18,6 +27,7 @@ try:
     setup.cqlshrc()
     setup.arguments()
     setup.set_housekeeping()
-    os.system("/usr/bin/supervisord -c /etc/supervisord.conf")
+    supervisord = subprocess.Popen(["/usr/bin/supervisord", "-c",  "/etc/supervisord.conf"])
+    supervisord.wait()
 except Exception:
     logging.exception('failed!')


### PR DESCRIPTION
Stopping docker currently didn't pass the signals to supervisord,
hence scylla wasn't gracefully shutdown.

Fixes #6150