### PR TITLE
gms::inet_address: Fix sign extension error in custom address formatting

### DIFF
--- a/gms/inet_address.cc
+++ b/gms/inet_address.cc
@@ -69,7 +69,8 @@ std::ostream& gms::operator<<(std::ostream& os, const inet_address& x) {
     auto&& bytes = x.bytes();
     auto i = 0u;
     auto acc = 0u;
-    for (auto b : bytes) {
+    // extra paranoid sign extension evasion - #5808
+    for (uint8_t b : bytes) {
         acc <<= 8;
         acc |= b;
         if ((++i & 1) == 0) {

--- a/test/boost/serialization_test.cc
+++ b/test/boost/serialization_test.cc
@@ -200,5 +200,16 @@ BOOST_AUTO_TEST_CASE(inet_address) {
         auto res = ser::deserialize_from_buffer(buf, boost::type<gms::inet_address>{});
         BOOST_CHECK_EQUAL(res, ip);
     }
+
+    // stringify tests
+    {
+        for (sstring s : { "2001:6b0:8:2::232", "2a05:d018:223:f00:97af:f4d9:eac2:6a0f", "fe80::8898:3e04:215b:2cd6" }) {
+            gms::inet_address ip(s);
+            BOOST_CHECK(ip.addr().is_ipv6());
+            auto s2 = boost::lexical_cast<std::string>(ip);
+            gms::inet_address ip2(s);
+            BOOST_CHECK_EQUAL(ip2, ip);
+        }
+    }
 }
 


### PR DESCRIPTION
Fixes #5808

Seems some gcc:s will generate the code as sign extending. Mine does not,
but this should be more correct anyhow.

Added small stringify test to serialization_test for inet_address