### PR TITLE
cdc: Postimage must check iff we have (pre-)image row data for non-to…

### DIFF
--- a/cdc/log.cc
+++ b/cdc/log.cc
@@ -1042,10 +1042,10 @@ public:
                 });
 
                 // fill in all columns not already processed. Note that column nulls are also marked.
-                if (poikey) {
+                if (poikey && pirow) {
                     for (auto& cdef : _schema->columns(ckind)) {
                         if (!columns_assigned.count(cdef.id)) {
-                            auto v = pirow->get_view_opt(cdef.name_as_text());
+                            auto v = get_preimage_col_value(cdef, pirow);
                             if (v) {
                                 auto dst = _log_schema->get_column_definition(log_data_column_name_bytes(cdef.name()));
                                 res.set_cell(*poikey, *dst, atomic_cell::make_live(*dst->type, ts, *v, _cdc_ttl_opt));


### PR DESCRIPTION
…uched columns

Fixes #6143

When doing post-image generation, we also write values for columns not
in delta (actual update), based on data selected in pre-image row.

However, if we are doing initial update/insert with only a subset of
columns, when the pre-image result set is nil, this cannot be done.

Adds check to non-touched column post-image code. Also uses the
pre-image value extractor to handle non-atomic sets properly.

Tests updated.