### PR TITLE
cdc+counters: make counters work in CDC

### DIFF
--- a/cdc/log.hh
+++ b/cdc/log.hh
@@ -93,7 +93,13 @@ public:
         std::vector<mutation>&& mutations,
         tracing::trace_state_ptr tr_state
         );
+
+    future<std::tuple<std::vector<mutation>, lw_shared_ptr<cdc::operation_result_tracker>>> calc_counter_mutation_augmentation(
+            lowres_clock::time_point timeout, mutation&& delta,
+            mutation_opt&& counter_preimage, tracing::trace_state_ptr tr_state);
+
     bool needs_cdc_augmentation(const std::vector<mutation>&) const;
+    bool counter_needs_cdc_augmentation(const mutation& m) const;
 };
 
 struct db_context final {

--- a/database.hh
+++ b/database.hh
@@ -1399,8 +1399,9 @@ private:
     future<> apply_with_commitlog(schema_ptr, column_family&, utils::UUID, const frozen_mutation&, db::timeout_clock::time_point timeout, db::commitlog::force_sync sync);
     future<> apply_with_commitlog(column_family& cf, const mutation& m, db::timeout_clock::time_point timeout);
 
-    future<mutation> do_apply_counter_update(column_family& cf, const frozen_mutation& fm, schema_ptr m_schema, db::timeout_clock::time_point timeout,
-                                             tracing::trace_state_ptr trace_state);
+    future<std::tuple<mutation, mutation_opt>> do_apply_counter_update(
+            column_family& cf, const frozen_mutation& fm, schema_ptr m_schema, db::timeout_clock::time_point timeout,
+            tracing::trace_state_ptr trace_state, bool return_previous_state);
 
     template<typename Future>
     Future update_write_metrics(Future&& f);
@@ -1500,7 +1501,9 @@ public:
     future<> apply(schema_ptr, const frozen_mutation&, db::commitlog::force_sync sync, db::timeout_clock::time_point timeout);
     future<> apply_hint(schema_ptr, const frozen_mutation&, db::timeout_clock::time_point timeout);
     future<> apply_streaming_mutation(schema_ptr, utils::UUID plan_id, const frozen_mutation&, bool fragmented);
-    future<mutation> apply_counter_update(schema_ptr, const frozen_mutation& m, db::timeout_clock::time_point timeout, tracing::trace_state_ptr trace_state);
+    future<std::tuple<mutation, mutation_opt>> apply_counter_update(
+            schema_ptr, const frozen_mutation& m, db::timeout_clock::time_point timeout,
+            tracing::trace_state_ptr trace_state, bool return_previous_state);
     keyspace::config make_keyspace_config(const keyspace_metadata& ksm);
     const sstring& get_snitch_name() const;
     /*!

--- a/test/cql/cdc_with_counters_test.cql
+++ b/test/cql/cdc_with_counters_test.cql
@@ -1,0 +1,19 @@
+create table ks.t (pk int, ck int, cs counter static, c counter, primary key (pk, ck)) with cdc = {'enabled': true, 'preimage': true, 'postimage': true};
+
+-- generates 2 rows: delta(static) + postimage(static)
+update ks.t set cs = cs + 1 where pk = 0;
+-- generates 3 rows: preimage(static), delta(static) + postimage(static)
+update ks.t set cs = cs + 10 where pk = 0;
+select c, "cdc$batch_seq_no", "cdc$operation", ck, cs from ks.t_scylla_cdc_log where pk = 0 allow filtering;
+
+-- generates 5 rows: preimage(static), delta(static+clustered), postimage(static+clustered), but we only select ck==0
+update ks.t set cs = cs + 2, c = c + 20 where pk = 0 and ck = 0;
+select c, "cdc$batch_seq_no", "cdc$operation", ck, cs from ks.t_scylla_cdc_log where pk = 0 and ck = 0 allow filtering;
+
+-- update one counter at a new PK: delta(clustered) + postimage(clustered)
+update ks.t set c = c + 20 where pk = 1 and ck = 0;
+-- delete clustered column: preimage(clustered) and delta(clustered) with "cdc$deleted_c"
+delete c from ks.t where pk = 1 and ck = 0;
+-- update dead clustered counter: nothing should happen in CDC
+update ks.t set c = c + 20 where pk = 1 and ck = 0;
+select c, "cdc$batch_seq_no", "cdc$deleted_c", "cdc$operation" from ks.t_scylla_cdc_log where pk = 1 and ck = 0 allow filtering;

--- a/test/cql/cdc_with_counters_test.result
+++ b/test/cql/cdc_with_counters_test.result
@@ -1,0 +1,146 @@
+create table ks.t (pk int, ck int, cs counter static, c counter, primary key (pk, ck)) with cdc = {'enabled': true, 'preimage': true, 'postimage': true};
+{
+	"status" : "ok"
+}
+
+-- generates 2 rows: delta(static) + postimage(static)
+update ks.t set cs = cs + 1 where pk = 0;
+{
+	"status" : "ok"
+}
+-- generates 3 rows: preimage(static), delta(static) + postimage(static)
+update ks.t set cs = cs + 10 where pk = 0;
+{
+	"status" : "ok"
+}
+select c, "cdc$batch_seq_no", "cdc$operation", ck, cs from ks.t_scylla_cdc_log where pk = 0 allow filtering;
+{
+	"rows" : 
+	[
+		{
+			"cdc$batch_seq_no" : "0",
+			"cdc$operation" : "1",
+			"cs" : "1",
+			"pk" : "0"
+		},
+		{
+			"cdc$batch_seq_no" : "1",
+			"cdc$operation" : "9",
+			"cs" : "1",
+			"pk" : "0"
+		},
+		{
+			"cdc$batch_seq_no" : "0",
+			"cdc$operation" : "0",
+			"cs" : "1",
+			"pk" : "0"
+		},
+		{
+			"cdc$batch_seq_no" : "1",
+			"cdc$operation" : "1",
+			"cs" : "10",
+			"pk" : "0"
+		},
+		{
+			"cdc$batch_seq_no" : "2",
+			"cdc$operation" : "9",
+			"cs" : "11",
+			"pk" : "0"
+		}
+	]
+}
+
+-- generates 5 rows: preimage(static), delta(static+clustered), postimage(static+clustered), but we only select ck==0
+update ks.t set cs = cs + 2, c = c + 20 where pk = 0 and ck = 0;
+{
+	"status" : "ok"
+}
+select c, "cdc$batch_seq_no", "cdc$operation", ck, cs from ks.t_scylla_cdc_log where pk = 0 and ck = 0 allow filtering;
+{
+	"rows" : 
+	[
+		{
+			"c" : "20",
+			"cdc$batch_seq_no" : "3",
+			"cdc$operation" : "1",
+			"ck" : "0",
+			"pk" : "0"
+		},
+		{
+			"c" : "20",
+			"cdc$batch_seq_no" : "4",
+			"cdc$operation" : "9",
+			"ck" : "0",
+			"pk" : "0"
+		}
+	]
+}
+
+-- update one counter at a new PK: delta(clustered) + postimage(clustered)
+update ks.t set c = c + 20 where pk = 1 and ck = 0;
+{
+	"status" : "ok"
+}
+-- delete clustered column: preimage(clustered) and delta(clustered) with "cdc$deleted_c"
+delete c from ks.t where pk = 1 and ck = 0;
+{
+	"status" : "ok"
+}
+-- update dead clustered counter: nothing should happen in CDC
+update ks.t set c = c + 20 where pk = 1 and ck = 0;
+{
+	"status" : "ok"
+}
+select c, "cdc$batch_seq_no", "cdc$deleted_c", "cdc$operation" from ks.t_scylla_cdc_log where pk = 1 and ck = 0 allow filtering;
+{
+	"rows" : 
+	[
+		{
+			"c" : "20",
+			"cdc$batch_seq_no" : "0",
+			"cdc$operation" : "1",
+			"ck" : "0",
+			"pk" : "1"
+		},
+		{
+			"c" : "20",
+			"cdc$batch_seq_no" : "1",
+			"cdc$operation" : "9",
+			"ck" : "0",
+			"pk" : "1"
+		},
+		{
+			"c" : "20",
+			"cdc$batch_seq_no" : "0",
+			"cdc$operation" : "0",
+			"ck" : "0",
+			"pk" : "1"
+		},
+		{
+			"cdc$batch_seq_no" : "1",
+			"cdc$deleted_c" : "true",
+			"cdc$operation" : "1",
+			"ck" : "0",
+			"pk" : "1"
+		},
+		{
+			"cdc$batch_seq_no" : "2",
+			"cdc$operation" : "9",
+			"ck" : "0",
+			"pk" : "1"
+		},
+		{
+			"c" : "20",
+			"cdc$batch_seq_no" : "0",
+			"cdc$operation" : "1",
+			"ck" : "0",
+			"pk" : "1"
+		},
+		{
+			"cdc$batch_seq_no" : "1",
+			"cdc$operation" : "9",
+			"ck" : "0",
+			"pk" : "1"
+		}
+	]
+}


### PR DESCRIPTION
Introducing CDC log columns for counters as plain bigints (64-bit,
`long_type`). They cannot be of `counter_type` because counter
columns are mutually exclusive with other types (e.g. `bool`
in cdc$deleted_*).

Correct generation of CDC log requires knowledge about tombstones
because updating dead counter cell has no effect (and thus should
not trigger CDC). This is why counter shard mutations are
transferred from DB code to CDC code.

Preimage values for counters are calulated from counter-shards.
Postimage is queried from the DB, because when CDC is being
calculated, counter updates are already applied. What remains
unresolved is printing the full preimage (all columns) upon row
delete, beacuse CDC code for counters sees the DB in the state
of postimage.

Also, this assumes that counter mutations always have only 1 row.
It was intended to simplify the rewrite of `transformer::transform`.
The logic of splitting mutations and tracing is re-used.

EDIT: because this is a heavy change, I'm taking time to write more "basic" tests. They are about to appear here.
Anyway, I expect to see a lot of remarks here and rebasing 10x is... no pleasure.