### PR TITLE
api: enable/disable auto compaction

### DIFF
--- a/api/api-doc/column_family.json
+++ b/api/api-doc/column_family.json
@@ -380,16 +380,54 @@
          "operations":[
             {
                "method":"GET",
-               "summary":"check if the auto compaction disabled",
+               "summary":"check if the auto_compaction property is enabled for a given table",
                "type":"boolean",
-               "nickname":"is_auto_compaction_disabled",
+               "nickname":"get_auto_compaction",
                "produces":[
                   "application/json"
                ],
                "parameters":[
                   {
                      "name":"name",
-                     "description":"The column family name in keyspace:name format",
+                     "description":"The table name in keyspace:name format",
+                     "required":true,
+                     "allowMultiple":false,
+                     "type":"string",
+                     "paramType":"path"
+                  }
+               ]
+            },
+            {
+               "method":"POST",
+               "summary":"Enable table auto compaction",
+               "type":"void",
+               "nickname":"enable_auto_compaction",
+               "produces":[
+                  "application/json"
+               ],
+               "parameters":[
+                  {
+                     "name":"name",
+                     "description":"The table name in keyspace:name format",
+                     "required":true,
+                     "allowMultiple":false,
+                     "type":"string",
+                     "paramType":"path"
+                  }
+               ]
+            },
+            {
+               "method":"DELETE",
+               "summary":"Disable table auto compaction",
+               "type":"void",
+               "nickname":"disable_auto_compaction",
+               "produces":[
+                  "application/json"
+               ],
+               "parameters":[
+                  {
+                     "name":"name",
+                     "description":"The table name in keyspace:name format",
                      "required":true,
                      "allowMultiple":false,
                      "type":"string",

--- a/api/column_family.cc
+++ b/api/column_family.cc
@@ -839,11 +839,26 @@ void set_column_family(http_context& ctx, routes& r) {
         return make_ready_future<json::json_return_type>(res);
     });
 
-    cf::is_auto_compaction_disabled.set(r, [] (const_req req) {
-        // FIXME
-        // currently auto compaction is disable
-        // it should be changed when it would have an API
-        return true;
+    cf::get_auto_compaction.set(r, [&ctx] (const_req req) {
+        const utils::UUID& uuid = get_uuid(req.param["name"], ctx.db.local());
+        column_family& cf = ctx.db.local().find_column_family(uuid);
+        return !cf.is_auto_compaction_disabled_by_user();
+    });
+
+    cf::enable_auto_compaction.set(r, [&ctx](std::unique_ptr<request> req) {
+        return foreach_column_family(ctx, req->param["name"], [](column_family &cf) {
+            cf.enable_auto_compaction();
+        }).then([] {
+            return make_ready_future<json::json_return_type>(json_void());
+        });
+    });
+
+    cf::disable_auto_compaction.set(r, [&ctx](std::unique_ptr<request> req) {
+        return foreach_column_family(ctx, req->param["name"], [](column_family &cf) {
+            cf.disable_auto_compaction();
+        }).then([] {
+            return make_ready_future<json::json_return_type>(json_void());
+        });
     });
 
     cf::get_built_indexes.set(r, [&ctx](std::unique_ptr<request> req) {

--- a/database.hh
+++ b/database.hh
@@ -504,6 +504,7 @@ private:
     compaction_manager& _compaction_manager;
     secondary_index::secondary_index_manager _index_manager;
     int _compaction_disabled = 0;
+    bool _compaction_disabled_by_user = false;
     utils::phased_barrier _flush_barrier;
     seastar::gate _streaming_flush_gate;
     std::vector<view_ptr> _views;
@@ -954,6 +955,12 @@ public:
     void drop_hit_rate(gms::inet_address addr);
 
     future<> run_with_compaction_disabled(std::function<future<> ()> func);
+
+    void enable_auto_compaction();
+    void disable_auto_compaction();
+    bool is_auto_compaction_disabled_by_user() const {
+      return _compaction_disabled_by_user;
+    }
 
     utils::phased_barrier::operation write_in_progress() {
         return _pending_writes_phaser.start();

--- a/sstables/compaction_manager.cc
+++ b/sstables/compaction_manager.cc
@@ -515,6 +515,10 @@ inline bool compaction_manager::maybe_stop_on_error(future<> f, stop_iteration w
 }
 
 void compaction_manager::submit(column_family* cf) {
+    if (cf->is_auto_compaction_disabled_by_user()) {
+        return;
+    }
+
     auto task = make_lw_shared<compaction_manager::task>();
     task->compacting_cf = cf;
     _tasks.push_back(task);
@@ -532,7 +536,7 @@ void compaction_manager::submit(column_family* cf) {
             sstables::compaction_descriptor descriptor = cs.get_sstables_for_compaction(cf, get_candidates(cf));
             int weight = trim_to_compact(&cf, descriptor);
 
-            if (descriptor.sstables.empty() || !can_proceed(task)) {
+            if (descriptor.sstables.empty() || !can_proceed(task) || cf.is_auto_compaction_disabled_by_user()) {
                 _stats.pending_tasks--;
                 return make_ready_future<stop_iteration>(stop_iteration::yes);
             }

--- a/table.cc
+++ b/table.cc
@@ -2432,6 +2432,44 @@ table::run_with_compaction_disabled(std::function<future<> ()> func) {
     });
 }
 
+void
+table::enable_auto_compaction() {
+    // XXX: unmute backlog. turn table backlog back on.
+    //      see table::disable_auto_compaction() notes.
+    _compaction_disabled_by_user = false;
+}
+
+void
+table::disable_auto_compaction() {
+    // XXX: mute backlog. When we disable background compactions
+    // for the table, we must also disable current backlog of the
+    // table compaction strategy that contributes to the scheduling
+    // group resources prioritization.
+    //
+    // There are 2 possibilities possible:
+    // - there are no ongoing background compaction, and we can freely
+    //   mute table backlog.
+    // - there are compactions happening. than we must decide either
+    //   we want to allow them to finish not allowing submitting new
+    //   compactions tasks, or we may "suspend" them until the bg
+    //   compactions will be enabled back. This is not a worst option
+    //   because it will allow bg compactions to finish if there are
+    //   unused resourced, it will not lose any writers/readers stats.
+    //
+    // Besides that:
+    // - there are major compactions that additionally uses constant
+    //   size backlog of shares,
+    // - sstables rewrites tasks that do the same.
+    // 
+    // Setting NullCompactionStrategy is not an option due to the
+    // following reasons:
+    // - it will 0 backlog if suspending current compactions is not an
+    //   option
+    // - it will break computation of major compaction descriptor
+    //   for new submissions
+    _compaction_disabled_by_user = true;
+}
+
 flat_mutation_reader
 table::make_reader_excluding_sstables(schema_ptr s,
         std::vector<sstables::shared_sstable>& excluded,


### PR DESCRIPTION
The patch implements:

- /storage_service/auto_compaction API endpoint
- /column_family/autocompaction/{name} API endpoint

Those APIs allow to control and request the status of background
compaction jobs for the existing tables.

The implementation introduces the table::_compaction_disabled_by_user.
Then the CompactionManager checks if it can push the background
compaction job for the corresponding table.

New members
===

    table::enable_auto_compaction();
    table::disable_auto_compaction();
    bool table::is_auto_compaction_disabled_by_user() const

Test
===
Tests: unit(sstable_datafile_test autocompaction_control_test), manual

    $ ninja build/dev/test/boost/sstable_datafile_test
    $ ./build/dev/test/boost/sstable_datafile_test --run_test=autocompaction_control_test -- -c1 -m2G --overprovisioned --unsafe-bypass-fsync 1 --blocked-reactor-notify-ms 2000000

The test tries to submit a compaction job after playing
with autocompaction control table switch. However, there is
no reliable way to hook pending compaction task. The code
assumed that with_scheduling_group() closure will never
preempt execution of the stats check.

Revert
===
Reverts commit c8247ac. In previous version the execution
sometimes resulted into the following error:

    test/boost/sstable_datafile_test.cc(1076): fatal error: in "autocompaction_control_test":
    critical check cm->get_stats().pending_tasks == 1 || cm->get_stats().active_tasks == 1 has failed

This version adds a few sstables to the cf, starts
the compaction and awaits until it is finished.

API change
===

- `/column_family/autocompaction/` always returned `true` while answering to the question: if the autocompaction disabled (see https://github.com/scylladb/scylla-jmx/blob/master/src/main/java/org/apache/cassandra/db/ColumnFamilyStore.java#L321). now it answers to the question: if the autocompaction for specific table is enabled. The question logic is inverted. The patch to the JMX is required. However, the change is decent because all old values were invalid (it always reported all compactions are disabled).
- `/column_family/autocompaction/` got support for POST/DELETE per table 

Fixes
===

Fixes #1488
Fixes #1808
Fixes #440
