### PR TITLE
prepare the view building generator to work through a compaction

### DIFF
--- a/database.hh
+++ b/database.hh
@@ -707,8 +707,8 @@ public:
             tracing::trace_state_ptr trace_state = nullptr,
             streamed_mutation::forwarding fwd = streamed_mutation::forwarding::no,
             mutation_reader::forwarding fwd_mr = mutation_reader::forwarding::yes) const;
-    flat_mutation_reader make_reader_excluding_sstable(schema_ptr schema,
-            sstables::shared_sstable sst,
+    flat_mutation_reader make_reader_excluding_sstables(schema_ptr schema,
+            std::vector<sstables::shared_sstable>& sst,
             const dht::partition_range& range,
             const query::partition_slice& slice,
             const io_priority_class& pc = default_priority_class(),
@@ -744,7 +744,7 @@ public:
     }
 
     mutation_source as_mutation_source() const;
-    mutation_source as_mutation_source_excluding(sstables::shared_sstable sst) const;
+    mutation_source as_mutation_source_excluding(std::vector<sstables::shared_sstable>& sst) const;
 
     void set_virtual_reader(mutation_source virtual_reader) {
         _virtual_reader = std::move(virtual_reader);
@@ -992,7 +992,10 @@ public:
     const std::vector<view_ptr>& views() const;
     future<row_locker::lock_holder> push_view_replica_updates(const schema_ptr& s, const frozen_mutation& fm, db::timeout_clock::time_point timeout) const;
     future<row_locker::lock_holder> push_view_replica_updates(const schema_ptr& s, mutation&& m, db::timeout_clock::time_point timeout) const;
-    future<row_locker::lock_holder> stream_view_replica_updates(const schema_ptr& s, mutation&& m, db::timeout_clock::time_point timeout, sstables::shared_sstable excluded_sstable) const;
+    future<row_locker::lock_holder>
+    stream_view_replica_updates(const schema_ptr& s, mutation&& m, db::timeout_clock::time_point timeout,
+            std::vector<sstables::shared_sstable>& excluded_sstables) const;
+
     void add_coordinator_read_latency(utils::estimated_histogram::duration latency);
     std::chrono::milliseconds get_coordinator_read_latency_percentile(double percentile);
 

--- a/db/view/view_update_generator.hh
+++ b/db/view/view_update_generator.hh
@@ -43,7 +43,7 @@ class view_update_generator {
         lw_shared_ptr<table> t;
         sstable_with_table(sstables::shared_sstable sst, lw_shared_ptr<table> t) : sst(std::move(sst)), t(std::move(t)) { }
     };
-    std::deque<sstable_with_table> _sstables_with_tables;
+    std::unordered_map<lw_shared_ptr<table>, std::vector<sstables::shared_sstable>> _sstables_with_tables;
     std::unordered_map<lw_shared_ptr<table>, std::vector<sstables::shared_sstable>> _sstables_to_move;
 public:
     view_update_generator(database& db) : _db(db) { }

--- a/db/view/view_updating_consumer.hh
+++ b/db/view/view_updating_consumer.hh
@@ -36,14 +36,14 @@ namespace db::view {
 class view_updating_consumer {
     schema_ptr _schema;
     lw_shared_ptr<table> _table;
-    sstables::shared_sstable _excluded_sstable;
+    std::vector<sstables::shared_sstable> _excluded_sstables;
     const seastar::abort_source& _as;
     std::optional<mutation> _m;
 public:
-    view_updating_consumer(schema_ptr schema, database& db, sstables::shared_sstable excluded_sstable, const seastar::abort_source& as)
+    view_updating_consumer(schema_ptr schema, table& table, std::vector<sstables::shared_sstable> excluded_sstables, const seastar::abort_source& as)
             : _schema(std::move(schema))
-            , _table(db.find_column_family(_schema->id()).shared_from_this())
-            , _excluded_sstable(excluded_sstable)
+            , _table(table.shared_from_this())
+            , _excluded_sstables(std::move(excluded_sstables))
             , _as(as)
             , _m()
     { }


### PR DESCRIPTION
There is no reason to read a single SSTable at a time from the staging
directory. Moving SSTables from staging directory essentially involves
scanning input SSTables and creating new SSTables (albeit in a different
directory).
    
We have a mechanism that does that: compactions. In a follow up patch, I
will introduce a new specialization of compaction that moves SSTables
from staging (potentially compacting them if there are plenty).
    
In preparation for that, some signatures have to be changed and the
view_updating_consumer has to be more compaction friendly. Meaning:
    - Operating with an sstable vector
    - taking a table reference, not a database
    
Because this code is a bit fragile and the reviewer set is fundamentally
different from anything compaction related, I am sending this separately
