### PR TITLE
repair: Ignore table removed in sync_data_using_repair

### DIFF
--- a/idl/partition_checksum.idl.hh
+++ b/idl/partition_checksum.idl.hh
@@ -94,3 +94,12 @@ struct repair_row_on_wire_with_cmd {
     repair_stream_cmd cmd;
     partition_key_and_mutation_fragments row;
 };
+
+enum class repair_row_level_start_status: uint8_t {
+    ok,
+    no_such_column_family,
+};
+
+struct repair_row_level_start_response {
+    repair_row_level_start_status status;
+};

--- a/message/messaging_service.cc
+++ b/message/messaging_service.cc
@@ -1193,14 +1193,14 @@ future<> messaging_service::send_repair_put_row_diff(msg_addr id, uint32_t repai
 }
 
 // Wrapper for REPAIR_ROW_LEVEL_START
-void messaging_service::register_repair_row_level_start(std::function<future<> (const rpc::client_info& cinfo, uint32_t repair_meta_id, sstring keyspace_name, sstring cf_name, dht::token_range range, row_level_diff_detect_algorithm algo, uint64_t max_row_buf_size, uint64_t seed, unsigned remote_shard, unsigned remote_shard_count, unsigned remote_ignore_msb, sstring remote_partitioner_name, table_schema_version schema_version, rpc::optional<streaming::stream_reason> reason)>&& func) {
+void messaging_service::register_repair_row_level_start(std::function<future<repair_row_level_start_response> (const rpc::client_info& cinfo, uint32_t repair_meta_id, sstring keyspace_name, sstring cf_name, dht::token_range range, row_level_diff_detect_algorithm algo, uint64_t max_row_buf_size, uint64_t seed, unsigned remote_shard, unsigned remote_shard_count, unsigned remote_ignore_msb, sstring remote_partitioner_name, table_schema_version schema_version, rpc::optional<streaming::stream_reason> reason)>&& func) {
     register_handler(this, messaging_verb::REPAIR_ROW_LEVEL_START, std::move(func));
 }
 future<> messaging_service::unregister_repair_row_level_start() {
     return unregister_handler(messaging_verb::REPAIR_ROW_LEVEL_START);
 }
-future<> messaging_service::send_repair_row_level_start(msg_addr id, uint32_t repair_meta_id, sstring keyspace_name, sstring cf_name, dht::token_range range, row_level_diff_detect_algorithm algo, uint64_t max_row_buf_size, uint64_t seed, unsigned remote_shard, unsigned remote_shard_count, unsigned remote_ignore_msb, sstring remote_partitioner_name, table_schema_version schema_version, streaming::stream_reason reason) {
-    return send_message<void>(this, messaging_verb::REPAIR_ROW_LEVEL_START, std::move(id), repair_meta_id, std::move(keyspace_name), std::move(cf_name), std::move(range), algo, max_row_buf_size, seed, remote_shard, remote_shard_count, remote_ignore_msb, std::move(remote_partitioner_name), std::move(schema_version), reason);
+future<rpc::optional<repair_row_level_start_response>> messaging_service::send_repair_row_level_start(msg_addr id, uint32_t repair_meta_id, sstring keyspace_name, sstring cf_name, dht::token_range range, row_level_diff_detect_algorithm algo, uint64_t max_row_buf_size, uint64_t seed, unsigned remote_shard, unsigned remote_shard_count, unsigned remote_ignore_msb, sstring remote_partitioner_name, table_schema_version schema_version, streaming::stream_reason reason) {
+    return send_message<rpc::optional<repair_row_level_start_response>>(this, messaging_verb::REPAIR_ROW_LEVEL_START, std::move(id), repair_meta_id, std::move(keyspace_name), std::move(cf_name), std::move(range), algo, max_row_buf_size, seed, remote_shard, remote_shard_count, remote_ignore_msb, std::move(remote_partitioner_name), std::move(schema_version), reason);
 }
 
 // Wrapper for REPAIR_ROW_LEVEL_STOP

--- a/message/messaging_service.hh
+++ b/message/messaging_service.hh
@@ -343,9 +343,9 @@ public:
     future<> send_repair_put_row_diff(msg_addr id, uint32_t repair_meta_id, repair_rows_on_wire row_diff);
 
     // Wrapper for REPAIR_ROW_LEVEL_START
-    void register_repair_row_level_start(std::function<future<> (const rpc::client_info& cinfo, uint32_t repair_meta_id, sstring keyspace_name, sstring cf_name, dht::token_range range, row_level_diff_detect_algorithm algo, uint64_t max_row_buf_size, uint64_t seed, unsigned remote_shard, unsigned remote_shard_count, unsigned remote_ignore_msb, sstring remote_partitioner_name, table_schema_version schema_version, rpc::optional<streaming::stream_reason> reason)>&& func);
+    void register_repair_row_level_start(std::function<future<repair_row_level_start_response> (const rpc::client_info& cinfo, uint32_t repair_meta_id, sstring keyspace_name, sstring cf_name, dht::token_range range, row_level_diff_detect_algorithm algo, uint64_t max_row_buf_size, uint64_t seed, unsigned remote_shard, unsigned remote_shard_count, unsigned remote_ignore_msb, sstring remote_partitioner_name, table_schema_version schema_version, rpc::optional<streaming::stream_reason> reason)>&& func);
     future<> unregister_repair_row_level_start();
-    future<> send_repair_row_level_start(msg_addr id, uint32_t repair_meta_id, sstring keyspace_name, sstring cf_name, dht::token_range range, row_level_diff_detect_algorithm algo, uint64_t max_row_buf_size, uint64_t seed, unsigned remote_shard, unsigned remote_shard_count, unsigned remote_ignore_msb, sstring remote_partitioner_name, table_schema_version schema_version, streaming::stream_reason reason);
+    future<rpc::optional<repair_row_level_start_response>> send_repair_row_level_start(msg_addr id, uint32_t repair_meta_id, sstring keyspace_name, sstring cf_name, dht::token_range range, row_level_diff_detect_algorithm algo, uint64_t max_row_buf_size, uint64_t seed, unsigned remote_shard, unsigned remote_shard_count, unsigned remote_ignore_msb, sstring remote_partitioner_name, table_schema_version schema_version, streaming::stream_reason reason);
 
     // Wrapper for REPAIR_ROW_LEVEL_STOP
     void register_repair_row_level_stop(std::function<future<> (const rpc::client_info& cinfo, uint32_t repair_meta_id, sstring keyspace_name, sstring cf_name, dht::token_range range)>&& func);

--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -740,7 +740,11 @@ void repair_info::check_failed_ranges() {
         rlogger.info("repair id {} on shard {} failed - {} ranges failed", id, shard, nr_failed_ranges);
         throw std::runtime_error(format("repair {:d} on shard {:d} failed to do checksum for {:d} sub ranges", id, shard, nr_failed_ranges));
     } else {
-        rlogger.info("repair id {} on shard {} completed successfully", id, shard);
+        if (dropped_tables.size()) {
+            rlogger.warn("repair id {} on shard {} completed successfully, keyspace={}, ignoring dropped tables={}", id, shard, keyspace, dropped_tables);
+        } else {
+            rlogger.info("repair id {} on shard {} completed successfully, keyspace={}", id, shard, keyspace);
+        }
     }
 }
 
@@ -1027,7 +1031,16 @@ static future<> repair_range(repair_info& ri, const dht::token_range& range) {
         return do_for_each(ri.cfs.begin(), ri.cfs.end(), [&ri, &neighbors, range] (auto&& cf) {
             ri._sub_ranges_nr++;
             if (ri.row_level_repair()) {
-                return repair_cf_range_row_level(ri, cf, range, neighbors);
+                if (ri.dropped_tables.count(cf)) {
+                    return make_ready_future<>();
+                }
+                return repair_cf_range_row_level(ri, cf, range, neighbors).handle_exception_type([&ri, cf] (no_such_column_family&) mutable {
+                    ri.dropped_tables.insert(cf);
+                    return make_ready_future<>();
+                }).handle_exception([&ri] (std::exception_ptr ep) mutable {
+                    ri.nr_failed_ranges++;
+                    return make_exception_future<>(std::move(ep));
+                });
             } else {
                 return repair_cf_range(ri, cf, range, neighbors);
             }

--- a/repair/repair.hh
+++ b/repair/repair.hh
@@ -205,6 +205,7 @@ public:
     repair_stats _stats;
     bool _row_level_repair;
     uint64_t _sub_ranges_nr = 0;
+    std::unordered_set<sstring> dropped_tables;
 public:
     repair_info(seastar::sharded<database>& db_,
             const sstring& keyspace_,
@@ -332,6 +333,15 @@ public:
     friend std::ostream& operator<<(std::ostream& os, const repair_hash& x) {
         return os << x.hash;
     }
+};
+
+enum class repair_row_level_start_status: uint8_t {
+    ok,
+    no_such_column_family,
+};
+
+struct repair_row_level_start_response {
+    repair_row_level_start_status status;
 };
 
 // Return value of the REPAIR_GET_SYNC_BOUNDARY RPC verb

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -1449,23 +1449,33 @@ public:
         // the time this change is introduced.
         sstring remote_partitioner_name = "org.apache.cassandra.dht.Murmur3Partitioner";
         return netw::get_local_messaging_service().send_repair_row_level_start(msg_addr(remote_node),
-                _repair_meta_id, std::move(ks_name), std::move(cf_name), std::move(range), _algo, _max_row_buf_size, _seed,
+                _repair_meta_id, ks_name, cf_name, std::move(range), _algo, _max_row_buf_size, _seed,
                 _master_node_shard_config.shard, _master_node_shard_config.shard_count, _master_node_shard_config.ignore_msb,
-                remote_partitioner_name, std::move(schema_version), reason);
+                remote_partitioner_name, std::move(schema_version), reason).then([ks_name, cf_name] (rpc::optional<repair_row_level_start_response> resp) {
+            if (resp && resp->status == repair_row_level_start_status::no_such_column_family) {
+                return make_exception_future<>(no_such_column_family(ks_name, cf_name));
+            } else {
+                return make_ready_future<>();
+            }
+        });
     }
 
     // RPC handler
-    static future<>
+    static future<repair_row_level_start_response>
     repair_row_level_start_handler(gms::inet_address from, uint32_t src_cpu_id, uint32_t repair_meta_id, sstring ks_name, sstring cf_name,
             dht::token_range range, row_level_diff_detect_algorithm algo, uint64_t max_row_buf_size,
             uint64_t seed, shard_config master_node_shard_config, table_schema_version schema_version, streaming::stream_reason reason) {
         if (!_sys_dist_ks->local_is_initialized() || !_view_update_generator->local_is_initialized()) {
-            return make_exception_future<>(std::runtime_error(format("Node {} is not fully initialized for repair, try again later",
+            return make_exception_future<repair_row_level_start_response>(std::runtime_error(format("Node {} is not fully initialized for repair, try again later",
                     utils::fb_utilities::get_broadcast_address())));
         }
         rlogger.debug(">>> Started Row Level Repair (Follower): local={}, peers={}, repair_meta_id={}, keyspace={}, cf={}, schema_version={}, range={}, seed={}, max_row_buf_siz={}",
             utils::fb_utilities::get_broadcast_address(), from, repair_meta_id, ks_name, cf_name, schema_version, range, seed, max_row_buf_size);
-        return insert_repair_meta(from, src_cpu_id, repair_meta_id, std::move(range), algo, max_row_buf_size, seed, std::move(master_node_shard_config), std::move(schema_version), reason);
+        return insert_repair_meta(from, src_cpu_id, repair_meta_id, std::move(range), algo, max_row_buf_size, seed, std::move(master_node_shard_config), std::move(schema_version), reason).then([] {
+            return repair_row_level_start_response{repair_row_level_start_status::ok};
+        }).handle_exception_type([] (no_such_column_family&) {
+            return repair_row_level_start_response{repair_row_level_start_status::no_such_column_family};
+        });
     }
 
     // RPC API
@@ -2464,6 +2474,7 @@ public:
             };
             auto s = _cf.schema();
             auto schema_version = s->version();
+            bool table_dropped = false;
 
             repair_meta master(_ri.db,
                     _cf,
@@ -2516,11 +2527,16 @@ public:
                     }
                     send_missing_rows_to_follower_nodes(master);
                 }
+            } catch (no_such_column_family& e) {
+                table_dropped = true;
+                rlogger.warn("repair id {} on shard {}, keyspace={}, cf={}, range={}, got error in row level repair: {}",
+                        _ri.id, this_shard_id(), _ri.keyspace, _cf_name, _range, e);
+                _failed = true;
             } catch (std::exception& e) {
-                rlogger.info("Got error in row level repair: {}", e);
+                rlogger.warn("repair id {} on shard {}, keyspace={}, cf={}, range={}, got error in row level repair: {}",
+                        _ri.id, this_shard_id(), _ri.keyspace, _cf_name, _range, e);
                 // In case the repair process fail, we need to call repair_row_level_stop to clean up repair followers
                 _failed = true;
-                _ri.nr_failed_ranges++;
             }
 
             parallel_for_each(nodes_to_stop, [&] (const gms::inet_address& node) {
@@ -2529,7 +2545,11 @@ public:
 
             _ri.update_statistics(master.stats());
             if (_failed) {
-                throw std::runtime_error(format("Failed to repair for keyspace={}, cf={}, range={}", _ri.keyspace, _cf_name, _range));
+                if (table_dropped) {
+                    throw no_such_column_family(_ri.keyspace,  _cf_name);
+                } else {
+                    throw std::runtime_error(format("Failed to repair for keyspace={}, cf={}, range={}", _ri.keyspace, _cf_name, _range));
+                }
             }
             rlogger.debug("<<< Finished Row Level Repair (Master): local={}, peers={}, repair_meta_id={}, keyspace={}, cf={}, range={}, tx_hashes_nr={}, rx_hashes_nr={}, tx_row_nr={}, rx_row_nr={}, row_from_disk_bytes={}, row_from_disk_nr={}",
                     master.myip(), _all_live_peer_nodes, master.repair_meta_id(), _ri.keyspace, _cf_name, _range, master.stats().tx_hashes_nr, master.stats().rx_hashes_nr, master.stats().tx_row_nr, master.stats().rx_row_nr, master.stats().row_from_disk_bytes, master.stats().row_from_disk_nr);
@@ -2540,8 +2560,11 @@ public:
 future<> repair_cf_range_row_level(repair_info& ri,
         sstring cf_name, dht::token_range range,
         const std::vector<gms::inet_address>& all_peer_nodes) {
-    return do_with(row_level_repair(ri, std::move(cf_name), std::move(range), all_peer_nodes), [] (row_level_repair& repair) {
-        return repair.run();
+    return seastar::futurize_invoke([&ri, cf_name = std::move(cf_name), range = std::move(range), &all_peer_nodes] () mutable {
+        auto repair = row_level_repair(ri, std::move(cf_name), std::move(range), all_peer_nodes);
+        return do_with(std::move(repair), [] (row_level_repair& repair) {
+            return repair.run();
+        });
     });
 }
 


### PR DESCRIPTION
Commit 75cf255c67641db7255286908c8b4f5a67590f9c (repair: Ignore keyspace
that is removed in sync_data_using_repair) is not enough to fix the
issue because when the repair master checks if the table is dropped, the
table might not be dropped yet on the repair master.

To fix, the repair master should check if the follower failed the repair
because the table is dropped by checking the error returned from
follower.

With this patch, we would see

WARN  2020-04-14 11:19:00,417 [shard 0] repair - repair id 1 on shard 0
completed successfully, keyspace=ks, ignoring dropped tables={cf}

when the table is dropped during bootstrap.

Tests: update_cluster_layout_tests.py:TestUpdateClusterLayout.simple_add_new_node_while_schema_changes_test

Fixes: #5942