### PR TITLE
cdc: Stop storing CDC options in scylla tables

### DIFF
--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -1803,19 +1803,11 @@ mutation make_scylla_tables_mutation(schema_ptr table, api::timestamp_type times
     auto ckey = clustering_key::from_singular(*s, table->cf_name());
     mutation m(scylla_tables(), pkey);
     m.set_clustered_cell(ckey, "version", utils::UUID(table->version()), timestamp);
-    auto cdc_options = table->cdc_options().to_map();
-    if (!cdc_options.empty()) {
-        store_map(m, ckey, "cdc", timestamp, cdc_options);
-    } else {
-        // Avoid storing anything for cdc disabled, so we don't end up with
-        // different digests on different nodes due to the other node redacting
-        // the cdc column when the cdc cluster feature is disabled.
-        //
-        // Tombstones are not considered for schema digest, so this is okay (and
-        // needed in order for disabling of cdc to have effect).
-        auto& cdc_cdef = *scylla_tables()->get_column_definition("cdc");
-        m.set_clustered_cell(ckey, cdc_cdef, atomic_cell::make_dead(timestamp, gc_clock::now()));
-    }
+    // Since 4.0, we stopped using cdc column in scylla tables. Extensions are
+    // used instead. Since we stopped reading this column in commit 861c7b5, we
+    // can now keep it always empty.
+    auto& cdc_cdef = *scylla_tables()->get_column_definition("cdc");
+    m.set_clustered_cell(ckey, cdc_cdef, atomic_cell::make_dead(timestamp, gc_clock::now()));
     if (table->has_custom_partitioner()) {
         m.set_clustered_cell(ckey, "partitioner", table->get_partitioner().name(), timestamp);
     } else {


### PR DESCRIPTION
Initially we were storing CDC options in scylla tables but then we realized
that we can use schema extensions. Extensions are more flexible and cause less
problems with schema digest.

The transition was done in 4.0 and with that we stopped reading 'cdc' column
in scylla tables. Commit 861c7b5626baaab4ae316f4fc24369c033abab9f removed
the code that used to read 'cdc' column.

Since no Scylla node should be reading 'cdc' column, we can always keep
it empty now. This will allow removal of schema::cdc_options in the future.

Signed-off-by: Piotr Jastrzebski <piotr@scylladb.com>