### PR TITLE
UUID: Stop caching clock_seq_and_node

### DIFF
--- a/utils/UUID_gen.cc
+++ b/utils/UUID_gen.cc
@@ -57,14 +57,15 @@ static int64_t make_node()
 }
 
 
-static int64_t make_clock_seq_and_node()
+int64_t make_clock_seq_and_node()
 {
+    thread_local std::mt19937_64 engine(std::random_device().operator()());
+    thread_local std::uniform_int_distribution<int> dist;
     // The original Java code did this, shuffling the number of millis
     // since the epoch, and taking 14 bits of it. We don't do exactly
     // the same, but the idea is the same.
     //long clock = new Random(System.currentTimeMillis()).nextLong();
-    unsigned int seed = std::chrono::system_clock::now().time_since_epoch().count();
-    int clock = rand_r(&seed);
+    int clock = dist(engine);
 
     long lsb = 0;
     lsb |= 0x8000000000000000L;                 // variant (2 bits)
@@ -96,7 +97,6 @@ UUID UUID_gen::get_name_UUID(const unsigned char *s, size_t len) {
     return get_UUID(digest);
 }
 
-const thread_local int64_t UUID_gen::clock_seq_and_node = make_clock_seq_and_node();
 thread_local const std::unique_ptr<UUID_gen> UUID_gen::instance (new UUID_gen());
 
 


### PR DESCRIPTION
Previously, clock_seq_and_node was generated once at startup and was used for
generation of TimeUUIDs. This is problematic because as a result creating
TimeUUID at the same time on the same node always creates exactly the same
value. It's bad because the whole purpose of using TimeUUID is to create
unique identifier for a timestamp. Not a duplicate. Otherwise a timestamp
alone could be used as well.

This patch drops the cache of clock_seq_and_node and calls
make_clock_seq_and_node() every time TimeUUID is generated. This creates new
unique clock_seq_and_node for each generation and reduces the chance for
collision.

Fixes #6208

Tests: unit(dev)

Signed-off-by: Piotr Jastrzebski <piotr@scylladb.com>