### PR TITLE
table: switch to correct io_priority for streaming view updates

### DIFF
--- a/table.cc
+++ b/table.cc
@@ -2556,7 +2556,7 @@ future<row_locker::lock_holder> table::push_view_replica_updates(const schema_pt
 future<row_locker::lock_holder>
 table::stream_view_replica_updates(const schema_ptr& s, mutation&& m, db::timeout_clock::time_point timeout,
         std::vector<sstables::shared_sstable>& excluded_sstables) const {
-    return do_push_view_replica_updates(s, std::move(m), timeout, as_mutation_source_excluding(excluded_sstables), service::get_local_streaming_write_priority());
+    return do_push_view_replica_updates(s, std::move(m), timeout, as_mutation_source_excluding(excluded_sstables), service::get_local_streaming_read_priority());
 }
 
 mutation_source


### PR DESCRIPTION
The io_priority parameter used when generating view updates from
streaming is used by the sstable reader, so it should use the I/O priority
for streaming *read* operations, not streaming *write* operations.

Fixes #6231
Tests: unit(dev)