### PR TITLE
table: bypass cache when generating view updates

### DIFF
--- a/table.cc
+++ b/table.cc
@@ -2526,6 +2526,7 @@ future<row_locker::lock_holder> table::do_push_view_replica_updates(const schema
     opts.set(query::partition_slice::option::send_clustering_key);
     opts.set(query::partition_slice::option::send_timestamp);
     opts.set(query::partition_slice::option::send_ttl);
+    opts.set(query::partition_slice::option::bypass_cache);
     auto slice = query::partition_slice(
             std::move(cr_ranges), { }, std::move(columns), std::move(opts), { }, cql_serialization_format::internal(), query::max_rows);
     // Take the shard-local lock on the base-table row or partition as needed.


### PR DESCRIPTION
User writes may trigger read-before-write in order to generate
view updates, but it does not indicate that the data is going
to be immediately useful for the user - on the contrary, the data
is going to be overwritten by the write request that just arrived,
so it's by definition cold and should not be put into cache.
Same goes for view updates generated from staging sstables -
there's no indication that data needed for generating view updates
from staging sstables is going to be immediately useful for the
user, and a large amount of it can push hot rows out of the cache,
thus deteriorating performance.

Fixes #6233
Tests: unit(dev)