### PR TITLE
treewide: deprecate passing explicit order in schema building

### DIFF
--- a/cql3/statements/create_table_statement.cc
+++ b/cql3/statements/create_table_statement.cc
@@ -135,7 +135,7 @@ schema_ptr create_table_statement::get_cf_meta_data(const database& db) const {
 void create_table_statement::apply_properties_to(schema_builder& builder, const database& db) const {
     auto&& columns = get_columns();
     for (auto&& column : columns) {
-        builder.with_column(column);
+        builder.with_column_ordered(column);
     }
 #if 0
     cfmd.defaultValidator(defaultValidator)

--- a/db/legacy_schema_migrator.cc
+++ b/db/legacy_schema_migrator.cc
@@ -379,7 +379,7 @@ public:
                         return to_bytes(name);
                     }
                 }();
-                builder.with_column(std::move(column_name), std::move(validator), kind, component_index);
+                builder.with_column_ordered(column_definition(std::move(column_name), std::move(validator), kind, component_index));
             }
 
             if (is_static_compact) {

--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -2572,12 +2572,12 @@ view_ptr create_view_from_mutations(const schema_ctxt& ctxt, schema_mutations sm
     auto computed_columns = get_computed_columns(sm);
     auto column_defs = create_columns_from_column_rows(query::result_set(sm.columns_mutation()), ks_name, cf_name, false, column_view_virtual::no, computed_columns);
     for (auto&& cdef : column_defs) {
-        builder.with_column(cdef);
+        builder.with_column_ordered(cdef);
     }
     if (sm.view_virtual_columns_mutation()) {
         column_defs = create_columns_from_column_rows(query::result_set(*sm.view_virtual_columns_mutation()), ks_name, cf_name, false, column_view_virtual::yes, computed_columns);
         for (auto&& cdef : column_defs) {
-            builder.with_column(cdef);
+            builder.with_column_ordered(cdef);
         }
     }
 

--- a/schema.cc
+++ b/schema.cc
@@ -208,11 +208,11 @@ void v3_columns::apply_to(schema_builder& builder) const {
             } else if (c.kind == column_kind::static_column) {
                 auto new_def = c;
                 new_def.kind = column_kind::regular_column;
-                builder.with_column(new_def);
+                builder.with_column_ordered(new_def);
             } else if (c.kind == column_kind::clustering_key) {
                 builder.set_regular_column_name_type(c.type);
             } else {
-                builder.with_column(c);
+                builder.with_column_ordered(c);
             }
         }
     } else {
@@ -220,7 +220,7 @@ void v3_columns::apply_to(schema_builder& builder) const {
             if (is_compact() && c.kind == column_kind::regular_column) {
                 builder.set_default_validation_class(c.type);
             }
-            builder.with_column(c);
+            builder.with_column_ordered(c);
         }
     }
 }
@@ -929,7 +929,7 @@ column_definition& schema_builder::find_column(const cql3::column_identifier& c)
     throw std::invalid_argument(format("No such column {}", c.name()));
 }
 
-schema_builder& schema_builder::with_column(const column_definition& c) {
+schema_builder& schema_builder::with_column_ordered(const column_definition& c) {
     return with_column(bytes(c.name()), data_type(c.type), column_kind(c.kind), c.position(), c.view_virtual(), c.get_computation_ptr());
 }
 
@@ -988,7 +988,7 @@ schema_builder& schema_builder::rename_column(bytes from, bytes to)
     auto& def = *it;
     column_definition new_def(to, def.type, def.kind, def.component_index());
     _raw._columns.erase(it);
-    return with_column(new_def);
+    return with_column_ordered(new_def);
 }
 
 schema_builder& schema_builder::alter_column_type(bytes name, data_type new_type)

--- a/schema_builder.hh
+++ b/schema_builder.hh
@@ -248,9 +248,8 @@ public:
     };
 
     column_definition& find_column(const cql3::column_identifier&);
-    schema_builder& with_column(const column_definition& c);
+    schema_builder& with_column_ordered(const column_definition& c);
     schema_builder& with_column(bytes name, data_type type, column_kind kind = column_kind::regular_column, column_view_virtual view_virtual = column_view_virtual::no);
-    schema_builder& with_column(bytes name, data_type type, column_kind kind, column_id component_index, column_view_virtual view_virtual = column_view_virtual::no, column_computation_ptr computation = nullptr);
     schema_builder& with_computed_column(bytes name, data_type type, column_kind kind, column_computation_ptr computation);
     schema_builder& remove_column(bytes name);
     schema_builder& without_column(sstring name, api::timestamp_type timestamp);
@@ -287,4 +286,6 @@ public:
 private:
     friend class default_names;
     void prepare_dense_schema(schema::raw_schema& raw);
+
+    schema_builder& with_column(bytes name, data_type type, column_kind kind, column_id component_index, column_view_virtual view_virtual = column_view_virtual::no, column_computation_ptr computation = nullptr);
 };


### PR DESCRIPTION
In order to avoid confusion with regard to whose responsibility
it is to sort the key columns (see #5856), the interface which allows
adding columns to the builder with explicit column id
is moved to a private function. An internal with_column_ordered()
overload is maintained to be used for internal operations,
but it's encouraged to use simpler with_column() in new code.

Fixes #6235
Tests: unit(dev)