### PR TITLE
A bunch of refactors in versioned_value and gossiper

### DIFF
--- a/cdc/generation.cc
+++ b/cdc/generation.cc
@@ -335,12 +335,7 @@ db_clock::time_point make_new_cdc_generation(
 std::optional<db_clock::time_point> get_streams_timestamp_for(const gms::inet_address& endpoint, const gms::gossiper& g) {
     auto streams_ts_string = g.get_application_state_value(endpoint, gms::application_state::CDC_STREAMS_TIMESTAMP);
     cdc_log.trace("endpoint={}, streams_ts_string={}", endpoint, streams_ts_string);
-
-    if (streams_ts_string.empty()) {
-        return {};
-    }
-
-    return db_clock::time_point(db_clock::duration(std::stoll(streams_ts_string)));
+    return gms::versioned_value::cdc_streams_timestamp_from_string(streams_ts_string);
 }
 
 // Run inside seastar::async context.

--- a/docs/cdc.md
+++ b/docs/cdc.md
@@ -125,9 +125,9 @@ Future patches will make the solution safe by using a two-phase-commit approach.
 Next, the node starts gossiping the timestamp of the new generation together with its set of chosen tokens and status:
 ```
         _gossiper.add_local_application_state({
-            { gms::application_state::TOKENS, value_factory.tokens(_bootstrap_tokens) },
-            { gms::application_state::CDC_STREAMS_TIMESTAMP, value_factory.cdc_streams_timestamp(_cdc_streams_ts) },
-            { gms::application_state::STATUS, value_factory.bootstrapping(_bootstrap_tokens) },
+            { gms::application_state::TOKENS, versioned_value::tokens(_bootstrap_tokens) },
+            { gms::application_state::CDC_STREAMS_TIMESTAMP, versioned_value::cdc_streams_timestamp(_cdc_streams_ts) },
+            { gms::application_state::STATUS, versioned_value::bootstrapping(_bootstrap_tokens) },
         }).get();
 ```
 

--- a/gms/gossiper.cc
+++ b/gms/gossiper.cc
@@ -91,7 +91,7 @@ sstring gossiper::get_partitioner_name() {
     return _cfg.partitioner();
 }
 
-std::set<inet_address> gossiper::get_seeds() {
+const std::set<inet_address>& gossiper::get_seeds() const {
     return _seeds_from_config;
 }
 

--- a/gms/gossiper.hh
+++ b/gms/gossiper.hh
@@ -147,7 +147,7 @@ public:
         return utils::fb_utilities::get_broadcast_address();
     }
     void set_cluster_name(sstring name);
-    std::set<inet_address> get_seeds();
+    const std::set<inet_address>& get_seeds() const;
     void set_seeds(std::set<inet_address> _seeds);
 public:
     static clk::time_point inline now() { return clk::now(); }

--- a/gms/gossiper.hh
+++ b/gms/gossiper.hh
@@ -583,7 +583,6 @@ public:
     void maybe_enable_features();
 private:
     seastar::metrics::metric_groups _metrics;
-    gms::versioned_value::factory _value_factory;
 public:
     void append_endpoint_state(std::stringstream& ss, const endpoint_state& state);
 public:

--- a/gms/versioned_value.cc
+++ b/gms/versioned_value.cc
@@ -58,4 +58,45 @@ versioned_value versioned_value::factory::network_version() {
     return versioned_value(format("{}", netw::messaging_service::current_version));
 }
 
+sstring versioned_value::make_full_token_string(const std::unordered_set<dht::token>& tokens) {
+    return ::join(";", tokens | boost::adaptors::transformed([] (const dht::token& t) {
+        return t.to_sstring(); })
+    );
+}
+
+sstring versioned_value::make_token_string(const std::unordered_set<dht::token>& tokens) {
+    if (tokens.empty()) {
+        return "";
+    }
+    return tokens.begin()->to_sstring();
+}
+
+sstring versioned_value::make_cdc_streams_timestamp_string(std::optional<db_clock::time_point> t) {
+    // We assume that the db_clock epoch is the same on all receiving nodes.
+    if (!t) {
+        return "";
+    }
+    return std::to_string(t->time_since_epoch().count());
+}
+
+std::unordered_set<dht::token> versioned_value::tokens_from_string(const sstring& s) {
+    if (s.size() == 0) {
+        return {}; // boost::split produces one element for empty string
+    }
+    std::vector<sstring> tokens;
+    boost::split(tokens, s, boost::is_any_of(";"));
+    std::unordered_set<dht::token> ret;
+    for (auto str : tokens) {
+        ret.emplace(dht::token::from_sstring(str));
+    }
+    return ret;
+}
+
+std::optional<db_clock::time_point> versioned_value::cdc_streams_timestamp_from_string(const sstring& s) {
+    if (s.empty()) {
+        return {};
+    }
+    return db_clock::time_point(db_clock::duration(std::stoll(s)));
+}
+
 }

--- a/gms/versioned_value.cc
+++ b/gms/versioned_value.cc
@@ -54,7 +54,7 @@ constexpr const char* versioned_value::HIBERNATE;
 constexpr const char* versioned_value::SHUTDOWN;
 constexpr const char* versioned_value::REMOVAL_COORDINATOR;
 
-versioned_value versioned_value::factory::network_version() {
+versioned_value versioned_value::network_version() {
     return versioned_value(format("{}", netw::messaging_service::current_version));
 }
 

--- a/gms/versioned_value.hh
+++ b/gms/versioned_value.hh
@@ -137,129 +137,124 @@ public:
     // Reverse of `make_cdc_streams_timestamp_string`.
     static std::optional<db_clock::time_point> cdc_streams_timestamp_from_string(const sstring&);
 
-public:
-    class factory {
-        using token = dht::token;
-    public:
-        versioned_value clone_with_higher_version(const versioned_value& value) {
-            return versioned_value(value.value);
-        }
+    static versioned_value clone_with_higher_version(const versioned_value& value) {
+        return versioned_value(value.value);
+    }
 
-        versioned_value bootstrapping(const std::unordered_set<token>& tokens) {
-            return versioned_value(version_string({sstring(versioned_value::STATUS_BOOTSTRAPPING),
-                                                   make_token_string(tokens)}));
-        }
+    static versioned_value bootstrapping(const std::unordered_set<dht::token>& tokens) {
+        return versioned_value(version_string({sstring(versioned_value::STATUS_BOOTSTRAPPING),
+                                               make_token_string(tokens)}));
+    }
 
-        versioned_value normal(const std::unordered_set<token>& tokens) {
-            return versioned_value(version_string({sstring(versioned_value::STATUS_NORMAL),
-                                                   make_token_string(tokens)}));
-        }
+    static versioned_value normal(const std::unordered_set<dht::token>& tokens) {
+        return versioned_value(version_string({sstring(versioned_value::STATUS_NORMAL),
+                                               make_token_string(tokens)}));
+    }
 
-        versioned_value load(double load) {
-            return versioned_value(to_sstring(load));
-        }
+    static versioned_value load(double load) {
+        return versioned_value(to_sstring(load));
+    }
 
-        versioned_value schema(const utils::UUID &new_version) {
-            return versioned_value(new_version.to_sstring());
-        }
+    static versioned_value schema(const utils::UUID &new_version) {
+        return versioned_value(new_version.to_sstring());
+    }
 
-        versioned_value leaving(const std::unordered_set<token>& tokens) {
-            return versioned_value(version_string({sstring(versioned_value::STATUS_LEAVING),
-                                                   make_token_string(tokens)}));
-        }
+    static versioned_value leaving(const std::unordered_set<dht::token>& tokens) {
+        return versioned_value(version_string({sstring(versioned_value::STATUS_LEAVING),
+                                               make_token_string(tokens)}));
+    }
 
-        versioned_value left(const std::unordered_set<token>& tokens, int64_t expire_time) {
-            return versioned_value(version_string({sstring(versioned_value::STATUS_LEFT),
-                                                   make_token_string(tokens),
-                                                   std::to_string(expire_time)}));
-        }
+    static versioned_value left(const std::unordered_set<dht::token>& tokens, int64_t expire_time) {
+        return versioned_value(version_string({sstring(versioned_value::STATUS_LEFT),
+                                               make_token_string(tokens),
+                                               std::to_string(expire_time)}));
+    }
 
-        versioned_value moving(token t) {
-            std::unordered_set<token> tokens = {t};
-            return versioned_value(version_string({sstring(versioned_value::STATUS_MOVING),
-                                                   make_token_string(tokens)}));
-        }
+    static versioned_value moving(dht::token t) {
+        std::unordered_set<dht::token> tokens = {t};
+        return versioned_value(version_string({sstring(versioned_value::STATUS_MOVING),
+                                               make_token_string(tokens)}));
+    }
 
-        versioned_value host_id(const utils::UUID& host_id) {
-            return versioned_value(host_id.to_sstring());
-        }
+    static versioned_value host_id(const utils::UUID& host_id) {
+        return versioned_value(host_id.to_sstring());
+    }
 
-        versioned_value tokens(const std::unordered_set<token>& tokens) {
-            return versioned_value(make_full_token_string(tokens));
-        }
+    static versioned_value tokens(const std::unordered_set<dht::token>& tokens) {
+        return versioned_value(make_full_token_string(tokens));
+    }
 
-        versioned_value cdc_streams_timestamp(std::optional<db_clock::time_point> t) {
-            return versioned_value(make_cdc_streams_timestamp_string(t));
-        }
+    static versioned_value cdc_streams_timestamp(std::optional<db_clock::time_point> t) {
+        return versioned_value(make_cdc_streams_timestamp_string(t));
+    }
 
-        versioned_value removing_nonlocal(const utils::UUID& host_id) {
-            return versioned_value(sstring(REMOVING_TOKEN) +
-                sstring(DELIMITER_STR) + host_id.to_sstring());
-        }
+    static versioned_value removing_nonlocal(const utils::UUID& host_id) {
+        return versioned_value(sstring(REMOVING_TOKEN) +
+            sstring(DELIMITER_STR) + host_id.to_sstring());
+    }
 
-        versioned_value removed_nonlocal(const utils::UUID& host_id, int64_t expire_time) {
-            return versioned_value(sstring(REMOVED_TOKEN) + sstring(DELIMITER_STR) +
-                host_id.to_sstring() + sstring(DELIMITER_STR) + to_sstring(expire_time));
-        }
+    static versioned_value removed_nonlocal(const utils::UUID& host_id, int64_t expire_time) {
+        return versioned_value(sstring(REMOVED_TOKEN) + sstring(DELIMITER_STR) +
+            host_id.to_sstring() + sstring(DELIMITER_STR) + to_sstring(expire_time));
+    }
 
-        versioned_value removal_coordinator(const utils::UUID& host_id) {
-            return versioned_value(sstring(REMOVAL_COORDINATOR) +
-                sstring(DELIMITER_STR) + host_id.to_sstring());
-        }
+    static versioned_value removal_coordinator(const utils::UUID& host_id) {
+        return versioned_value(sstring(REMOVAL_COORDINATOR) +
+            sstring(DELIMITER_STR) + host_id.to_sstring());
+    }
 
-        versioned_value hibernate(bool value) {
-            return versioned_value(sstring(HIBERNATE) + sstring(DELIMITER_STR) + (value ? "true" : "false"));
-        }
+    static versioned_value hibernate(bool value) {
+        return versioned_value(sstring(HIBERNATE) + sstring(DELIMITER_STR) + (value ? "true" : "false"));
+    }
 
-        versioned_value shutdown(bool value) {
-            return versioned_value(sstring(SHUTDOWN) + sstring(DELIMITER_STR) + (value ? "true" : "false"));
-        }
+    static versioned_value shutdown(bool value) {
+        return versioned_value(sstring(SHUTDOWN) + sstring(DELIMITER_STR) + (value ? "true" : "false"));
+    }
 
-        versioned_value datacenter(const sstring& dc_id) {
-            return versioned_value(dc_id);
-        }
+    static versioned_value datacenter(const sstring& dc_id) {
+        return versioned_value(dc_id);
+    }
 
-        versioned_value rack(const sstring& rack_id) {
-            return versioned_value(rack_id);
-        }
+    static versioned_value rack(const sstring& rack_id) {
+        return versioned_value(rack_id);
+    }
 
-        versioned_value shard_count(int shard_count) {
-            return versioned_value(format("{}", shard_count));
-        }
+    static versioned_value shard_count(int shard_count) {
+        return versioned_value(format("{}", shard_count));
+    }
 
-        versioned_value ignore_msb_bits(unsigned ignore_msb_bits) {
-            return versioned_value(format("{}", ignore_msb_bits));
-        }
+    static versioned_value ignore_msb_bits(unsigned ignore_msb_bits) {
+        return versioned_value(format("{}", ignore_msb_bits));
+    }
 
-        versioned_value rpcaddress(gms::inet_address endpoint) {
-            return versioned_value(format("{}", endpoint));
-        }
+    static versioned_value rpcaddress(gms::inet_address endpoint) {
+        return versioned_value(format("{}", endpoint));
+    }
 
-        versioned_value release_version() {
-            return versioned_value(version::release());
-        }
+    static versioned_value release_version() {
+        return versioned_value(version::release());
+    }
 
-        versioned_value network_version();
+    static versioned_value network_version();
 
-        versioned_value internal_ip(const sstring &private_ip) {
-            return versioned_value(private_ip);
-        }
+    static versioned_value internal_ip(const sstring &private_ip) {
+        return versioned_value(private_ip);
+    }
 
-        versioned_value severity(double value) {
-            return versioned_value(to_sstring(value));
-        }
+    static versioned_value severity(double value) {
+        return versioned_value(to_sstring(value));
+    }
 
-        versioned_value supported_features(const sstring& features) {
-            return versioned_value(features);
-        }
+    static versioned_value supported_features(const sstring& features) {
+        return versioned_value(features);
+    }
 
-        versioned_value cache_hitrates(const sstring& hitrates) {
-            return versioned_value(hitrates);
-        }
+    static versioned_value cache_hitrates(const sstring& hitrates) {
+        return versioned_value(hitrates);
+    }
 
-        versioned_value cql_ready(bool value) {
-            return versioned_value(to_sstring(int(value)));
-        }
+    static versioned_value cql_ready(bool value) {
+        return versioned_value(to_sstring(int(value)));
     };
 }; // class versioned_value
 

--- a/gms/versioned_value.hh
+++ b/gms/versioned_value.hh
@@ -127,30 +127,20 @@ public:
         return ::join(sstring(versioned_value::DELIMITER_STR), args);
     }
 
+    static sstring make_full_token_string(const std::unordered_set<dht::token>& tokens);
+    static sstring make_token_string(const std::unordered_set<dht::token>& tokens);
+    static sstring make_cdc_streams_timestamp_string(std::optional<db_clock::time_point> t);
+
+    // Reverse of `make_full_token_string`.
+    static std::unordered_set<dht::token> tokens_from_string(const sstring&);
+
+    // Reverse of `make_cdc_streams_timestamp_string`.
+    static std::optional<db_clock::time_point> cdc_streams_timestamp_from_string(const sstring&);
+
 public:
     class factory {
         using token = dht::token;
     public:
-        sstring make_full_token_string(const std::unordered_set<token>& tokens) {
-            return ::join(";", tokens | boost::adaptors::transformed([] (const token& t) {
-                return t.to_sstring(); })
-            );
-        }
-        sstring make_token_string(const std::unordered_set<token>& tokens) {
-            if (tokens.empty()) {
-                return "";
-            }
-            return tokens.begin()->to_sstring();
-        }
-
-        sstring make_cdc_streams_timestamp_string(std::optional<db_clock::time_point> t) {
-            // We assume that the db_clock epoch is the same on all receiving nodes.
-            if (!t) {
-                return "";
-            }
-            return std::to_string(t->time_since_epoch().count());
-        }
-
         versioned_value clone_with_higher_version(const versioned_value& value) {
             return versioned_value(value.value);
         }

--- a/locator/ec2_multi_region_snitch.cc
+++ b/locator/ec2_multi_region_snitch.cc
@@ -106,10 +106,9 @@ future<> ec2_multi_region_snitch::gossiper_starting() {
 
     using namespace gms;
     auto& g = get_local_gossiper();
-    auto& ss = service::get_local_storage_service();
 
     return g.add_local_application_state(application_state::INTERNAL_IP,
-        ss.value_factory.internal_ip(_local_private_address)).then([this] {
+        versioned_value::internal_ip(_local_private_address)).then([this] {
         if (!_gossip_started) {
             gms::get_local_gossiper().register_(::make_shared<reconnectable_snitch_helper>(_my_dc));
             _gossip_started = true;

--- a/locator/gossiping_property_file_snitch.cc
+++ b/locator/gossiping_property_file_snitch.cc
@@ -137,7 +137,6 @@ future<> gossiping_property_file_snitch::gossiper_starting() {
     // this function will be executed on CPU0 only.
     //
     auto& g = get_local_gossiper();
-    auto& ss = get_local_storage_service();
 
     auto local_internal_addr = netw::get_local_messaging_service().listen_address();
     std::ostringstream ostrm;
@@ -145,7 +144,7 @@ future<> gossiping_property_file_snitch::gossiper_starting() {
     ostrm<<local_internal_addr<<std::flush;
 
     return g.add_local_application_state(application_state::INTERNAL_IP,
-        ss.value_factory.internal_ip(ostrm.str())).then([this] {
+        versioned_value::internal_ip(ostrm.str())).then([this] {
         _gossip_started = true;
         return reload_gossiper_state();
     });

--- a/service/migration_manager.cc
+++ b/service/migration_manager.cc
@@ -996,9 +996,8 @@ future<> migration_manager::announce(std::vector<mutation> schema) {
  */
 future<> migration_manager::passive_announce(utils::UUID version) {
     return gms::get_gossiper().invoke_on(0, [version] (auto&& gossiper) {
-        gms::versioned_value::factory value_factory;
         mlogger.debug("Gossiping my schema version {}", version);
-        return gossiper.add_local_application_state(gms::application_state::SCHEMA, value_factory.schema(version));
+        return gossiper.add_local_application_state(gms::application_state::SCHEMA, gms::versioned_value::schema(version));
     });
 }
 

--- a/service/misc_services.cc
+++ b/service/misc_services.cc
@@ -117,9 +117,8 @@ void load_broadcaster::start_broadcasting() {
             }
             return res;
         }, int64_t(0), std::plus<int64_t>()).then([this] (int64_t size) {
-            gms::versioned_value::factory value_factory;
             return _gossiper.add_local_application_state(gms::application_state::LOAD,
-                value_factory.load(size)).then([this] {
+                gms::versioned_value::load(size)).then([this] {
                 _timer.arm(BROADCAST_INTERVAL);
                 return make_ready_future<>();
             });
@@ -213,9 +212,8 @@ future<lowres_clock::duration> cache_hitrate_calculator::recalculate_hitrates() 
         });
     }).then([this] {
         auto& g = gms::get_local_gossiper();
-        auto& ss = get_local_storage_service();
         _slen = _gstate.size();
-        return g.add_local_application_state(gms::application_state::CACHE_HITRATES, ss.value_factory.cache_hitrates(_gstate)).then([this] {
+        return g.add_local_application_state(gms::application_state::CACHE_HITRATES, gms::versioned_value::cache_hitrates(_gstate)).then([this] {
             // if max difference during this round is big schedule next recalculate earlier
             if (_diff < 0.01) {
                 return std::chrono::milliseconds(2000);

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -1469,17 +1469,8 @@ void storage_service::update_peer_info(gms::inet_address endpoint) {
 std::unordered_set<locator::token> storage_service::get_tokens_for(inet_address endpoint) {
     auto tokens_string = _gossiper.get_application_state_value(endpoint, application_state::TOKENS);
     slogger.trace("endpoint={}, tokens_string={}", endpoint, tokens_string);
-    if (tokens_string.size() == 0) {
-        return {}; // boost::split produces one element for emty string
-    }
-    std::vector<sstring> tokens;
-    std::unordered_set<token> ret;
-    boost::split(tokens, tokens_string, boost::is_any_of(";"));
-    for (auto str : tokens) {
-        auto t = dht::token::from_sstring(str);
-        slogger.trace("endpoint={}, token_str={} token={}", endpoint, str, t);
-        ret.emplace(std::move(t));
-    }
+    auto ret = versioned_value::tokens_from_string(tokens_string);
+    slogger.trace("endpoint={}, tokens={}", endpoint, ret);
     return ret;
 }
 

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -288,9 +288,9 @@ void storage_service::prepare_to_join(std::vector<inet_address> loaded_endpoints
         std::tie(_bootstrap_tokens, _cdc_streams_ts) = prepare_replacement_info(loaded_peer_features).get0();
         // kbraun: I think we don't have to gossip tokens nor streams timestmap when HIBERNATEd
         // (any state for this node will be ignored by other nodes anyway), but since TOKENS was already there, I added CDC_STREAMS_TIMESTAMP too.
-        app_states.emplace(gms::application_state::TOKENS, value_factory.tokens(_bootstrap_tokens));
-        app_states.emplace(gms::application_state::CDC_STREAMS_TIMESTAMP, value_factory.cdc_streams_timestamp(_cdc_streams_ts));
-        app_states.emplace(gms::application_state::STATUS, value_factory.hibernate(true));
+        app_states.emplace(gms::application_state::TOKENS, versioned_value::tokens(_bootstrap_tokens));
+        app_states.emplace(gms::application_state::CDC_STREAMS_TIMESTAMP, versioned_value::cdc_streams_timestamp(_cdc_streams_ts));
+        app_states.emplace(gms::application_state::STATUS, versioned_value::hibernate(true));
     } else if (should_bootstrap()) {
         check_for_endpoint_collision(loaded_peer_features).get();
     } else {
@@ -384,22 +384,22 @@ void storage_service::prepare_to_join(std::vector<inet_address> loaded_endpoints
     auto& proxy = service::get_storage_proxy();
     // Ensure we know our own actual Schema UUID in preparation for updates
     auto schema_version = update_schema_version(proxy, _feature_service.cluster_schema_features()).get0();
-    app_states.emplace(gms::application_state::NET_VERSION, value_factory.network_version());
-    app_states.emplace(gms::application_state::HOST_ID, value_factory.host_id(local_host_id));
-    app_states.emplace(gms::application_state::RPC_ADDRESS, value_factory.rpcaddress(broadcast_rpc_address));
-    app_states.emplace(gms::application_state::RELEASE_VERSION, value_factory.release_version());
-    app_states.emplace(gms::application_state::SUPPORTED_FEATURES, value_factory.supported_features(features));
-    app_states.emplace(gms::application_state::CACHE_HITRATES, value_factory.cache_hitrates(""));
+    app_states.emplace(gms::application_state::NET_VERSION, versioned_value::network_version());
+    app_states.emplace(gms::application_state::HOST_ID, versioned_value::host_id(local_host_id));
+    app_states.emplace(gms::application_state::RPC_ADDRESS, versioned_value::rpcaddress(broadcast_rpc_address));
+    app_states.emplace(gms::application_state::RELEASE_VERSION, versioned_value::release_version());
+    app_states.emplace(gms::application_state::SUPPORTED_FEATURES, versioned_value::supported_features(features));
+    app_states.emplace(gms::application_state::CACHE_HITRATES, versioned_value::cache_hitrates(""));
     app_states.emplace(gms::application_state::SCHEMA_TABLES_VERSION, versioned_value(db::schema_tables::version));
-    app_states.emplace(gms::application_state::RPC_READY, value_factory.cql_ready(false));
+    app_states.emplace(gms::application_state::RPC_READY, versioned_value::cql_ready(false));
     app_states.emplace(gms::application_state::VIEW_BACKLOG, versioned_value(""));
-    app_states.emplace(gms::application_state::SCHEMA, value_factory.schema(schema_version));
+    app_states.emplace(gms::application_state::SCHEMA, versioned_value::schema(schema_version));
     if (restarting_normal_node) {
         // Order is important: both the CDC streams timestamp and tokens must be known when a node handles our status.
         // Exception: there might be no CDC streams timestamp proposed by us if we're upgrading from a non-CDC version.
-        app_states.emplace(gms::application_state::TOKENS, value_factory.tokens(my_tokens));
-        app_states.emplace(gms::application_state::CDC_STREAMS_TIMESTAMP, value_factory.cdc_streams_timestamp(_cdc_streams_ts));
-        app_states.emplace(gms::application_state::STATUS, value_factory.normal(my_tokens));
+        app_states.emplace(gms::application_state::TOKENS, versioned_value::tokens(my_tokens));
+        app_states.emplace(gms::application_state::CDC_STREAMS_TIMESTAMP, versioned_value::cdc_streams_timestamp(_cdc_streams_ts));
+        app_states.emplace(gms::application_state::STATUS, versioned_value::normal(my_tokens));
     }
     slogger.info("Starting up server gossip");
 
@@ -764,7 +764,7 @@ bool storage_service::do_handle_cdc_generation(db_clock::time_point ts) {
         _cdc_streams_ts = ts;
         db::system_keyspace::update_cdc_streams_timestamp(ts).get();
         _gossiper.add_local_application_state(
-                gms::application_state::CDC_STREAMS_TIMESTAMP, value_factory.cdc_streams_timestamp(ts)).get();
+                gms::application_state::CDC_STREAMS_TIMESTAMP, versioned_value::cdc_streams_timestamp(ts)).get();
     }
 
     class orer {
@@ -916,9 +916,9 @@ void storage_service::bootstrap() {
 
         _gossiper.add_local_application_state({
             // Order is important: both the CDC streams timestamp and tokens must be known when a node handles our status.
-            { gms::application_state::TOKENS, value_factory.tokens(_bootstrap_tokens) },
-            { gms::application_state::CDC_STREAMS_TIMESTAMP, value_factory.cdc_streams_timestamp(_cdc_streams_ts) },
-            { gms::application_state::STATUS, value_factory.bootstrapping(_bootstrap_tokens) },
+            { gms::application_state::TOKENS, versioned_value::tokens(_bootstrap_tokens) },
+            { gms::application_state::CDC_STREAMS_TIMESTAMP, versioned_value::cdc_streams_timestamp(_cdc_streams_ts) },
+            { gms::application_state::STATUS, versioned_value::bootstrapping(_bootstrap_tokens) },
         }).get();
 
         set_mode(mode::JOINING, format("sleeping {} ms for pending range setup", get_ring_delay().count()), true);
@@ -1483,9 +1483,9 @@ void storage_service::set_gossip_tokens(
 
     // Order is important: both the CDC streams timestamp and tokens must be known when a node handles our status.
     _gossiper.add_local_application_state({
-        { gms::application_state::TOKENS, value_factory.tokens(tokens) },
-        { gms::application_state::CDC_STREAMS_TIMESTAMP, value_factory.cdc_streams_timestamp(cdc_streams_ts) },
-        { gms::application_state::STATUS, value_factory.normal(tokens) }
+        { gms::application_state::TOKENS, versioned_value::tokens(tokens) },
+        { gms::application_state::CDC_STREAMS_TIMESTAMP, versioned_value::cdc_streams_timestamp(cdc_streams_ts) },
+        { gms::application_state::STATUS, versioned_value::normal(tokens) }
     }).get();
 }
 
@@ -1667,15 +1667,15 @@ future<> storage_service::gossip_snitch_info() {
     auto dc = snitch->get_datacenter(addr);
     auto rack = snitch->get_rack(addr);
     return _gossiper.add_local_application_state({
-        { gms::application_state::DC, value_factory.datacenter(dc) },
-        { gms::application_state::RACK, value_factory.rack(rack) },
+        { gms::application_state::DC, versioned_value::datacenter(dc) },
+        { gms::application_state::RACK, versioned_value::rack(rack) },
     });
 }
 
 future<> storage_service::gossip_sharder() {
     return _gossiper.add_local_application_state({
-        { gms::application_state::SHARD_COUNT, value_factory.shard_count(smp::count) },
-        { gms::application_state::IGNORE_MSB_BITS, value_factory.ignore_msb_bits(_db.local().get_config().murmur3_partitioner_ignore_msb_bits()) },
+        { gms::application_state::SHARD_COUNT, versioned_value::shard_count(smp::count) },
+        { gms::application_state::IGNORE_MSB_BITS, versioned_value::ignore_msb_bits(_db.local().get_config().murmur3_partitioner_ignore_msb_bits()) },
     });
 }
 
@@ -2847,7 +2847,7 @@ void storage_service::leave_ring() {
 
     auto expire_time = _gossiper.compute_expire_time().time_since_epoch().count();
     _gossiper.add_local_application_state(gms::application_state::STATUS,
-            value_factory.left(db::system_keyspace::get_local_tokens().get0(), expire_time)).get();
+            versioned_value::left(db::system_keyspace::get_local_tokens().get0(), expire_time)).get();
     auto delay = std::max(get_ring_delay(), gms::gossiper::INTERVAL);
     slogger.info("Announcing that I have left the ring for {}ms", delay.count());
     sleep_abortable(delay, _abort_source).get();
@@ -2881,7 +2881,7 @@ storage_service::stream_ranges(std::unordered_map<sstring, std::unordered_multim
 }
 
 future<> storage_service::start_leaving() {
-    return _gossiper.add_local_application_state(application_state::STATUS, value_factory.leaving(db::system_keyspace::get_local_tokens().get0())).then([this] {
+    return _gossiper.add_local_application_state(application_state::STATUS, versioned_value::leaving(db::system_keyspace::get_local_tokens().get0())).then([this] {
         _token_metadata.add_leaving_endpoint(get_broadcast_address());
         return update_pending_ranges();
     });
@@ -3406,7 +3406,7 @@ void feature_enabled_listener::on_enabled() {
             return make_ready_future<>();
         }
         return gms::get_local_gossiper().add_local_application_state(gms::application_state::SUPPORTED_FEATURES,
-                                                                     _s.value_factory.supported_features(_s.get_config_supported_features()));
+                                                                     gms::versioned_value::supported_features(_s.get_config_supported_features()));
     });
 }
 
@@ -3423,7 +3423,7 @@ future<> read_sstables_format(distributed<storage_service>& ss) {
 }
 
 future<> storage_service::set_cql_ready(bool ready) {
-    return _gossiper.add_local_application_state(application_state::RPC_READY, value_factory.cql_ready(ready));
+    return _gossiper.add_local_application_state(application_state::RPC_READY, versioned_value::cql_ready(ready));
 }
 
 void storage_service::notify_down(inet_address endpoint) {

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -247,7 +247,6 @@ private:
     cdc::metadata _cdc_metadata;
 public:
     std::chrono::milliseconds get_ring_delay();
-    gms::versioned_value::factory value_factory;
     dht::token_range_vector get_local_ranges(const sstring& keyspace_name) const {
         return get_ranges_for_endpoint(keyspace_name, get_broadcast_address());
     }

--- a/test/manual/gossip.cc
+++ b/test/manual/gossip.cc
@@ -71,7 +71,6 @@ int main(int ac, char ** av) {
             const gms::inet_address listen = gms::inet_address(config["listen-address"].as<std::string>());
             utils::fb_utilities::set_broadcast_address(listen);
             utils::fb_utilities::set_broadcast_rpc_address(listen);
-            gms::versioned_value::factory vv;
             auto cfg = std::make_unique<db::config>();
             locator::i_endpoint_snitch::create_snitch("SimpleSnitch").get();
             sharded<gms::feature_service> feature_service;
@@ -108,7 +107,7 @@ int main(int ac, char ** av) {
             gossiper.set_cluster_name("Test Cluster");
 
             std::map<gms::application_state, gms::versioned_value> app_states = {
-                { gms::application_state::LOAD, vv.load(0.5) },
+                { gms::application_state::LOAD, gms::versioned_value::load(0.5) },
             };
 
             using namespace std::chrono;
@@ -117,7 +116,7 @@ int main(int ac, char ** av) {
             gossiper.start_gossiping(generation_number, app_states).get();
             static double load = 0.5;
             for (;;) {
-                auto value = vv.load(load);
+                auto value = gms::versioned_value::load(load);
                 load += 0.0001;
                 gms::get_local_gossiper().add_local_application_state(gms::application_state::LOAD, value).get();
                 sleep(std::chrono::seconds(1)).get();


### PR DESCRIPTION
1. Remove the `versioned_value::factory` class, it didn't add any value. It just forced us to create an object for making `versioned_value`s, for no sensible reason.
2. Move some `versioned_value` deserialization code (string -> internal data structures) into the versioned_value module. Previously, it was scattered all around the place.
3. Make `gossiper::get_seeds` const and return a const reference.

I needed these refactors for a PR I was preparing to fix an issue with CDC. The attempt of fixing the issue failed (I'm trying something different now), but the refactors might be useful anyway.