### PR TITLE
alternator: fix integer overflow warning in token generation

### DIFF
--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -2989,7 +2989,7 @@ static future<executor::request_return_type> do_query(schema_ptr schema,
 
 static dht::token token_for_segment(int segment, int total_segments) {
     assert(total_segments > 1 && segment >= 0 && segment < total_segments);
-    int64_t delta = std::numeric_limits<int64_t>::max() / total_segments * 2;
+    uint64_t delta = std::numeric_limits<uint64_t>::max() / total_segments;
     return dht::token::from_int64(std::numeric_limits<int64_t>::min() + delta * segment);
 }
 


### PR DESCRIPTION
When generating tokens for parallel scan, debug mode undefined behavior
sanitizer complained that integer overflow sometimes happens when
multiplying two big values - delta and segment number.
In order to mitigate this warning, the multiplication is now split
into two smaller ones, and the generated machine code remains
identical (verified on gcc and clang via compiler explorer).

Fixes #6280
Tests: unit(dev)