### PR TITLE
Add issue type selection to Scylla

### DIFF
--- a/.github/ISSUE_TEMPLATE/10-bug-issue.md
+++ b/.github/ISSUE_TEMPLATE/10-bug-issue.md
@@ -1,6 +1,6 @@
 ---
-name: "🐛 Bug Issue"
-about: Use this template for reporting a bug
+name: "🐛 Report a Scylla bug"
+about: Use this template for reporting a suspected bug or an issue
 title: ''
 labels: bug
 assignees: ''

--- a/.github/ISSUE_TEMPLATE/10-bug-issue.md
+++ b/.github/ISSUE_TEMPLATE/10-bug-issue.md
@@ -1,0 +1,23 @@
+---
+name: "🐛 Bug Issue"
+about: Use this template for reporting a bug
+title: ''
+labels: bug
+assignees: ''
+---
+
+This is Scylla's bug tracker, to be used for reporting bugs only.
+If you have a question about Scylla, and not a bug, please ask it in
+our mailing-list at scylladb-dev@googlegroups.com or in our  [slack channel](http://slack.scylladb.com/).
+
+- [] I have read the disclaimer above, and I am reporting a suspected malfunction in Scylla.
+
+*Installation details*
+Scylla version (or git commit hash):
+Cluster size:
+OS (RHEL/CentOS/Ubuntu/AWS AMI/ Docker):
+
+*Hardware details (for performance issues)*          Delete if unneeded
+Platform (physical/VM/cloud instance type/docker):
+Hardware: sockets= cores= hyperthreading= memory=
+Disks: (SSD/HDD, count)

--- a/.github/ISSUE_TEMPLATE/20-performance-issue.md
+++ b/.github/ISSUE_TEMPLATE/20-performance-issue.md
@@ -1,5 +1,5 @@
 ---
-name: "🏃 Scylla Performance are not what I expected"
+name: "🏃 Scylla Performance is not what I expected"
 about: Use this template for reporting a suspected performance issue.
 labels: performance
 ---

--- a/.github/ISSUE_TEMPLATE/20-performance-issue.md
+++ b/.github/ISSUE_TEMPLATE/20-performance-issue.md
@@ -1,8 +1,7 @@
 ---
-name: "🏃 Performance Issue"
-about: Use this template for reporting a performance issue
+name: "🏃 Scylla Performance are not what I expected"
+about: Use this template for reporting a suspected performance issue.
 labels: performance
-
 ---
 
 **Please make sure that this is an issue related to Scylla performance**

--- a/.github/ISSUE_TEMPLATE/20-performance-issue.md
+++ b/.github/ISSUE_TEMPLATE/20-performance-issue.md
@@ -1,0 +1,40 @@
+---
+name: "🏃 Performance Issue"
+about: Use this template for reporting a performance issue
+labels: performance
+
+---
+
+**Please make sure that this is an issue related to Scylla performance**
+
+This is Scylla's bug tracker, to be used for reporting bugs only.
+If you have a question about Scylla, and not a bug, please ask it in
+our mailing-list at scylladb-dev@googlegroups.com or in our [slack channel](http://slack.scylladb.com/).
+
+- [] I have read the disclaimer above, and I am reporting a suspected malfunction in Scylla.
+
+*Installation details*
+Scylla version (or git commit hash):
+Cluster size:
+OS (RHEL/CentOS/Ubuntu/AWS AMI/ Docker):
+
+*Hardware details (for performance issues)*          Delete if unneeded
+Platform (physical/VM/cloud instance type/docker):
+Hardware: sockets= cores= hyperthreading= memory=
+Disks: (SSD/HDD, count)
+
+Please follow [How To Report a Pefromance Issue](https://docs.scylladb.com/troubleshooting/report_scylla_problem/#report-a-performance-problem) procedure to collect and share relevant data
+
+**Describe the current behavior**
+
+**Describe the expected behavior**
+
+**Standalone code to reproduce the issue**
+If possible, provide a reproducible test case that is the bare minimum necessary to generate
+the problem. 
+
+**Other info / logs** Include any logs or source code that would be helpful to
+diagnose the problem. If including tracebacks, please include the full
+traceback. Large logs and files should be attached.
+
+* Collected info UUID: 

--- a/.github/ISSUE_TEMPLATE/30-feature-request.md
+++ b/.github/ISSUE_TEMPLATE/30-feature-request.md
@@ -1,0 +1,20 @@
+---
+name: "⭐ Feature Request"
+about: Use this template for raising a feature request
+labels: enhancement
+assignees: ''
+---
+
+Please make sure that this is a feature request. 
+
+**System information**
+- Scylla version (you are using):
+- Are you willing to contribute it (Yes/No):
+
+**Describe the feature and the current behavior/state.**
+
+**Will this change the current api? How?**
+
+**Who will benefit with this feature?**
+
+**Any Other info.**

--- a/.github/ISSUE_TEMPLATE/30-feature-request.md
+++ b/.github/ISSUE_TEMPLATE/30-feature-request.md
@@ -1,5 +1,5 @@
 ---
-name: "⭐ Feature Request"
+name: "⭐ Feature Request: I want Scylla to do X"
 about: Use this template for raising a feature request
 labels: enhancement
 assignees: ''

--- a/.github/ISSUE_TEMPLATE/50-installation-issue.md
+++ b/.github/ISSUE_TEMPLATE/50-installation-issue.md
@@ -1,5 +1,5 @@
 ---
-name: "𝄞 installation Issue"
+name: "𝄞 installation Issue: I fail to install Scylla"
 about: Use this template for instllation related issues
 labels: install
 ---

--- a/.github/ISSUE_TEMPLATE/50-installation-issue.md
+++ b/.github/ISSUE_TEMPLATE/50-installation-issue.md
@@ -1,0 +1,17 @@
+---
+name: "𝄞 installation Issue"
+about: Use this template for instllation related issues
+labels: install
+---
+
+Please make sure that this is a installation issue.
+
+**System information**
+- OS Platform and Distribution (e.g., Linux Ubuntu 16.04):
+
+**Describe the problem**
+
+**Provide the exact sequence of commands / steps that you executed before running into the problem**
+
+**Any other info / logs**
+Include any logs or source code that would be helpful to diagnose the problem. If including tracebacks, please include the full traceback. Large logs and files should be attached.

--- a/.github/ISSUE_TEMPLATE/70-build-issue.md
+++ b/.github/ISSUE_TEMPLATE/70-build-issue.md
@@ -1,5 +1,5 @@
 ---
-name: "☕ Build Issue: I want to build Scylla from source, but I cant!"
+name: "☕ Build Issue: I want to build Scylla from source, but I can't!"
 about: Use this template for build related issues
 labels: build
 ---

--- a/.github/ISSUE_TEMPLATE/70-build-issue.md
+++ b/.github/ISSUE_TEMPLATE/70-build-issue.md
@@ -1,6 +1,6 @@
 ---
-name: "☕ Build Issue"
-about: Use this template for build issues
+name: "☕ Build Issue: I want to build Scylla from source, but I cant!"
+about: Use this template for build related issues
 labels: build
 ---
 

--- a/.github/ISSUE_TEMPLATE/70-build-issue.md
+++ b/.github/ISSUE_TEMPLATE/70-build-issue.md
@@ -1,0 +1,19 @@
+---
+name: "☕ Build Issue"
+about: Use this template for build issues
+labels: build
+---
+
+Please make sure that this is a build issue.
+
+**System information**
+- OS Platform and Distribution (e.g., Linux Ubuntu 16.04):
+- GCC/Compiler version (if compiling from source):
+
+**Describe the problem**
+
+**Provide the exact sequence of commands / steps that you executed before running into the problem**
+
+
+**Any other info / logs**
+Include any logs or source code that would be helpful to diagnose the problem. If including tracebacks, please include the full traceback. Large logs and files should be attached.

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,3 @@
+The Scylla team and community take security bugs very seriously. We appreciate your efforts to disclose your findings responsibly and will acknowledge your contributions.
+To report a security issue, email security@scylladb.com. The Scylla team will send a response indicating the next steps in handling your report. 
+Thanks for helping make Scylla safe for everyone!


### PR DESCRIPTION
This PR adds issue type templates.
Five templates are introduced:

* bug-issue
* performance-issue
* feature-request
* installation-issue
* build-issue
* security

The last refer you the the new SECURITY.md file.
Each issue template include relevant information, where the first is a copy of the current template.
When opening a new issue via Github the user will be prompt with the 5 issues:

![image](https://user-images.githubusercontent.com/170200/80283182-73cffa80-871e-11ea-8d28-a644488df9e6.png)
See live demo: https://github.com/tzach/apiPlay/issues/new/choose

