### PR TITLE
redis: adding support read/write non-string type

### DIFF
--- a/redis/mutation_utils.hh
+++ b/redis/mutation_utils.hh
@@ -21,6 +21,8 @@
 
 #pragma once
 #include "types.hh"
+#include <vector>
+#include <map>
 
 class service_permit;
 
@@ -34,6 +36,10 @@ namespace redis {
 class redis_options;
 
 future<> write_strings(service::storage_proxy& proxy, redis::redis_options& options, bytes&& key, bytes&& data, long ttl, service_permit permit);
+future<> write_lists(service::storage_proxy& proxy, redis::redis_options& options, bytes&& key, std::vector<bytes>&& data, long ttl, service_permit permit);
+future<> write_hashes(service::storage_proxy& proxy, redis::redis_options& options, bytes&& key, std::map<bytes, bytes>&& data, long ttl, service_permit permit);
+future<> write_sets(service::storage_proxy& proxy, redis::redis_options& options, bytes&& key, std::vector<bytes>&& data, long ttl, service_permit permit);
+future<> write_zsets(service::storage_proxy& proxy, redis::redis_options& options, bytes&& key, std::vector<bytes>&& data, long ttl, service_permit permit);
 future<> delete_objects(service::storage_proxy& proxy, redis::redis_options& options, std::vector<bytes>&& keys, service_permit permit);
 
 }

--- a/redis/query_utils.hh
+++ b/redis/query_utils.hh
@@ -24,6 +24,8 @@
 #include "seastar/core/shared_ptr.hh"
 #include "seastar/core/future.hh"
 #include "bytes.hh"
+#include <vector>
+#include <map>
 
 using namespace seastar;
 
@@ -45,6 +47,24 @@ struct strings_result {
     bool has_result() const { return _has_result; }
 };
 
+struct lists_result {
+    std::vector<bytes> _result;
+    bool _has_result;
+    std::vector<bytes>& result() { return _result; }
+    bool has_result() const { return _has_result; }
+};
+
+struct hashes_result {
+    std::map<bytes, bytes> _result;
+    bool _has_result;
+    std::map<bytes, bytes>& result() { return _result; }
+    bool has_result() const { return _has_result; }
+};
+
 future<lw_shared_ptr<strings_result>> read_strings(service::storage_proxy&, const redis_options&, const bytes&, service_permit);
+future<lw_shared_ptr<lists_result>> read_lists(service::storage_proxy&, const redis_options&, const bytes&, service_permit);
+future<lw_shared_ptr<hashes_result>> read_hashes(service::storage_proxy&, const redis_options&, const bytes&, service_permit);
+future<lw_shared_ptr<lists_result>> read_sets(service::storage_proxy&, const redis_options&, const bytes&, service_permit);
+future<lw_shared_ptr<lists_result>> read_zsets(service::storage_proxy&, const redis_options&, const bytes&, service_permit);
 
 }


### PR DESCRIPTION
On Redis, there are non-string type support such as Lists, Hashes, Sets, ZSets.
This patch add functions to read/write such types on Scylla.