### PR TITLE
build: replace xxhash submodule with OS package

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,9 +6,6 @@
 	path = swagger-ui
 	url = ../scylla-swagger-ui
 	ignore = dirty
-[submodule "xxHash"]
-	path = xxHash
-	url = ../xxHash
 [submodule "libdeflate"]
 	path = libdeflate
 	url = ../libdeflate

--- a/configure.py
+++ b/configure.py
@@ -1289,10 +1289,12 @@ libs = ' '.join([maybe_static(args.staticyamlcpp, '-lyaml-cpp'), '-latomic', '-l
                  ' -lstdc++fs', ' -lcrypt', ' -lcryptopp', ' -lpthread',
                  maybe_static(args.staticboost, '-lboost_date_time -lboost_regex -licuuc'), ])
 
-xxhash_dir = 'xxHash'
+pkgconfig_libs = [
+    'libxxhash',
+]
 
-if not os.path.exists(xxhash_dir) or not os.listdir(xxhash_dir):
-    raise Exception(xxhash_dir + ' is empty. Run "git submodule update --init".')
+args.user_cflags += ' ' + ' '.join([pkg_config(lib, '--cflags') for lib in pkgconfig_libs])
+libs += ' ' + ' '.join([pkg_config(lib, '--libs') for lib in pkgconfig_libs])
 
 if not args.staticboost:
     args.user_cflags += ' -DBOOST_TEST_DYN_LINK'

--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -89,6 +89,7 @@ fedora_packages=(
     hwloc
     glibc-langpack-en
     lld
+    xxhash-devel
 )
 
 centos_packages=(

--- a/tools/toolchain/image
+++ b/tools/toolchain/image
@@ -1,1 +1,1 @@
-docker.io/scylladb/scylla-toolchain:fedora-31-20200402
+docker.io/scylladb/scylla-toolchain:fedora-31-20200427

--- a/xx_hasher.hh
+++ b/xx_hasher.hh
@@ -26,7 +26,7 @@
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Warray-bounds"
-#include <xxHash/xxhash.h>
+#include <xxhash.h>
 #pragma GCC diagnostic pop
 
 #include <array>


### PR DESCRIPTION
The xxhash library has been packaged by Fedora, so we can use it
instead of carrying the submodule. This reduces allows us to
receive updates as the OS packages are updated. Build time will
not be reduced since it is a header-only library.

xxhash preserves the hash results across versions so rolling
upgrades will still work.

The frozen toolchain is updated with the new package.

Tests: unit (dev)