### PR TITLE
scylla_coredump_setup: fix #6300 incorrect coredump directory mount

### DIFF
--- a/dist/common/scripts/scylla_coredump_setup
+++ b/dist/common/scripts/scylla_coredump_setup
@@ -65,8 +65,8 @@ Before=scylla-server.service
 After=local-fs.target
 
 [Mount]
-What=/var/lib/scylla/coredump
-Where=/var/lib/systemd/coredump
+What=/var/lib/systemd/coredump
+Where=/var/lib/scylla/coredump
 Type=none
 Options=bind
 


### PR DESCRIPTION
Fix to #6301 
The issue is that the mount is `/var/lib/scylla/coredump` -> `/var/lib/systemd/coredump`. But we need to do the opposite in order to save the coredump on the partition that Scylla is using:
 `/var/lib/systemd/coredump`-> `/var/lib/scylla/coredump` 