### PR TITLE
Make it possible to turn caching off per table and stop caching CDC Log

### DIFF
--- a/caching_options.hh
+++ b/caching_options.hh
@@ -79,6 +79,10 @@ public:
         return json::to_json(to_map());
     }
 
+    static caching_options get_disabled_caching_options() {
+        return caching_options("NONE", "NONE", false);
+    }
+
     template<typename Map>
     static caching_options from_map(const Map & map) {
         sstring k = default_key;

--- a/caching_options.hh
+++ b/caching_options.hh
@@ -39,7 +39,10 @@ class caching_options {
 
     sstring _key_cache;
     sstring _row_cache;
-    caching_options(sstring k, sstring r) : _key_cache(k), _row_cache(r) {
+    bool _enabled = true;
+    caching_options(sstring k, sstring r, bool enabled)
+        : _key_cache(k), _row_cache(r), _enabled(enabled)
+    {
         if ((k != "ALL") && (k != "NONE")) {
             throw exceptions::configuration_exception("Invalid key value: " + k); 
         }
@@ -59,8 +62,17 @@ class caching_options {
     caching_options() : _key_cache(default_key), _row_cache(default_row) {}
 public:
 
+    bool enabled() const {
+        return _enabled;
+    }
+
     std::map<sstring, sstring> to_map() const {
-        return {{ "keys", _key_cache }, { "rows_per_partition", _row_cache }};
+        std::map<sstring, sstring> res = {{ "keys", _key_cache },
+                { "rows_per_partition", _row_cache }};
+        if (!_enabled) {
+            res.insert({"enabled", "false"});
+        }
+        return res;
     }
 
     sstring to_sstring() const {
@@ -71,24 +83,28 @@ public:
     static caching_options from_map(const Map & map) {
         sstring k = default_key;
         sstring r = default_row;
+        bool e = true;
 
         for (auto& p : map) {
             if (p.first == "keys") {
                 k = p.second;
             } else if (p.first == "rows_per_partition") {
                 r = p.second;
+            } else if (p.first == "enabled") {
+                e = p.second == "true";
             } else {
                 throw exceptions::configuration_exception("Invalid caching option: " + p.first);
             }
         }
-        return caching_options(k, r);
+        return caching_options(k, r, e);
     }
     static caching_options from_sstring(const sstring& str) {
         return from_map(json::to_map(str));
     }
 
     bool operator==(const caching_options& other) const {
-        return _key_cache == other._key_cache && _row_cache == other._row_cache;
+        return _key_cache == other._key_cache && _row_cache == other._row_cache
+            && _enabled == other._enabled;
     }
     bool operator!=(const caching_options& other) const {
         return !(*this == other);

--- a/cdc/log.cc
+++ b/cdc/log.cc
@@ -397,6 +397,7 @@ static schema_ptr create_log_schema(const schema& s, std::optional<utils::UUID> 
     b.with_column(log_meta_column_name_bytes("batch_seq_no"), int32_type, column_kind::clustering_key);
     b.with_column(log_meta_column_name_bytes("operation"), data_type_for<operation_native_type>());
     b.with_column(log_meta_column_name_bytes("ttl"), long_type);
+    b.set_caching_options(caching_options::get_disabled_caching_options());
     auto add_columns = [&] (const schema::const_iterator_range_type& columns, bool is_data_col = false) {
         for (const auto& column : columns) {
             auto type = column.type;

--- a/cql3/statements/cf_prop_defs.hh
+++ b/cql3/statements/cf_prop_defs.hh
@@ -95,6 +95,7 @@ public:
     std::map<sstring, sstring> get_compaction_options() const;
     std::optional<std::map<sstring, sstring>> get_compression_options() const;
     const cdc::options* get_cdc_options(const schema::extensions_map&) const;
+    std::optional<caching_options> get_caching_options() const;
 #if 0
     public CachingOptions getCachingOptions() throws SyntaxException, ConfigurationException
     {

--- a/cql3/statements/property_definitions.cc
+++ b/cql3/statements/property_definitions.cc
@@ -109,6 +109,13 @@ bool property_definitions::has_property(const sstring& name) const {
     return _properties.find(name) != _properties.end();
 }
 
+std::optional<property_definitions::value_type> property_definitions::get(const sstring& name) const {
+    if (auto it = _properties.find(name); it != _properties.end()) {
+        return it->second;
+    }
+    return std::nullopt;
+}
+
 sstring property_definitions::get_string(sstring key, sstring default_value) const {
     auto value = get_simple(key);
     if (value) {

--- a/cql3/statements/property_definitions.hh
+++ b/cql3/statements/property_definitions.hh
@@ -86,6 +86,8 @@ protected:
 public:
     bool has_property(const sstring& name) const;
 
+    std::optional<value_type> get(const sstring& name) const;
+
     sstring get_string(sstring key, sstring default_value) const;
 
     // Return a property value, typed as a Boolean

--- a/database.hh
+++ b/database.hh
@@ -574,6 +574,9 @@ public:
         _is_bootstrap_or_replace = false;
     }
 private:
+    bool cache_enabled() const {
+        return _config.enable_cache && _schema->caching_options().enabled();
+    }
     void update_stats_for_new_sstable(uint64_t disk_space_used_by_sstable, const std::vector<unsigned>& shards_for_the_sstable) noexcept;
     // Adds new sstable to the set of sstables
     // Doesn't update the cache. The cache must be synchronized in order for reads to see

--- a/gms/feature.hh
+++ b/gms/feature.hh
@@ -140,6 +140,7 @@ extern const std::string_view NONFROZEN_UDTS;
 extern const std::string_view HINTED_HANDOFF_SEPARATE_CONNECTION;
 extern const std::string_view LWT;
 extern const std::string_view PER_TABLE_PARTITIONERS;
+extern const std::string_view PER_TABLE_CACHING;
 
 }
 

--- a/gms/feature_service.cc
+++ b/gms/feature_service.cc
@@ -55,6 +55,7 @@ constexpr std::string_view features::NONFROZEN_UDTS = "NONFROZEN_UDTS";
 constexpr std::string_view features::HINTED_HANDOFF_SEPARATE_CONNECTION = "HINTED_HANDOFF_SEPARATE_CONNECTION";
 constexpr std::string_view features::LWT = "LWT";
 constexpr std::string_view features::PER_TABLE_PARTITIONERS = "PER_TABLE_PARTITIONERS";
+constexpr std::string_view features::PER_TABLE_CACHING = "PER_TABLE_CACHING";
 
 static logging::logger logger("features");
 
@@ -88,7 +89,8 @@ feature_service::feature_service(feature_config cfg) : _config(cfg)
         , _nonfrozen_udts(*this, features::NONFROZEN_UDTS)
         , _hinted_handoff_separate_connection(*this, features::HINTED_HANDOFF_SEPARATE_CONNECTION)
         , _lwt_feature(*this, features::LWT)
-        , _per_table_partitioners_feature(*this, features::PER_TABLE_PARTITIONERS) {
+        , _per_table_partitioners_feature(*this, features::PER_TABLE_PARTITIONERS)
+        , _per_table_caching_feature(*this, features::PER_TABLE_CACHING) {
 }
 
 feature_config feature_config_from_db_config(db::config& cfg) {
@@ -163,6 +165,7 @@ std::set<std::string_view> feature_service::known_feature_set() {
         gms::features::UNBOUNDED_RANGE_TOMBSTONES,
         gms::features::HINTED_HANDOFF_SEPARATE_CONNECTION,
         gms::features::PER_TABLE_PARTITIONERS,
+        gms::features::PER_TABLE_CACHING,
     };
 
     if (_config.enable_sstables_mc_format) {
@@ -254,6 +257,7 @@ void feature_service::enable(const std::set<std::string_view>& list) {
         std::ref(_hinted_handoff_separate_connection),
         std::ref(_lwt_feature),
         std::ref(_per_table_partitioners_feature),
+        std::ref(_per_table_caching_feature),
     })
     {
         if (list.count(f.name())) {

--- a/gms/feature_service.hh
+++ b/gms/feature_service.hh
@@ -96,6 +96,7 @@ private:
     gms::feature _hinted_handoff_separate_connection;
     gms::feature _lwt_feature;
     gms::feature _per_table_partitioners_feature;
+    gms::feature _per_table_caching_feature;
 
 public:
     bool cluster_supports_range_tombstones() const {
@@ -164,6 +165,10 @@ public:
 
     const feature& cluster_supports_per_table_partitioners() const {
         return _per_table_partitioners_feature;
+    }
+
+    const feature& cluster_supports_per_table_caching() const {
+        return _per_table_caching_feature;
     }
 
     bool cluster_supports_row_level_repair() const {

--- a/table.cc
+++ b/table.cc
@@ -469,7 +469,7 @@ table::make_reader(schema_ptr s,
         readers.emplace_back(mt->make_flat_reader(s, range, slice, pc, trace_state, fwd, fwd_mr));
     }
 
-    if (_config.enable_cache && !slice.options.contains(query::partition_slice::option::bypass_cache)) {
+    if (cache_enabled() && !slice.options.contains(query::partition_slice::option::bypass_cache)) {
         readers.emplace_back(_cache.make_reader(s, range, slice, pc, std::move(trace_state), fwd, fwd_mr));
     } else {
         readers.emplace_back(make_sstable_reader(s, _sstables, range, slice, pc, std::move(trace_state), fwd, fwd_mr));
@@ -720,7 +720,7 @@ table::update_cache(lw_shared_ptr<memtable> m, sstables::shared_sstable sst) {
         m->mark_flushed(std::move(newtab_ms));
         try_trigger_compaction();
     };
-    if (_config.enable_cache) {
+    if (cache_enabled()) {
         return _cache.update(adder, *m);
     } else {
         adder();
@@ -841,7 +841,7 @@ table::seal_active_streaming_memtable_immediate(flush_permit&& permit) {
                           try_trigger_compaction();
                           tlogger.debug("Flushing to {} done", newtab->get_filename());
                       };
-                      if (_config.enable_cache) {
+                      if (cache_enabled()) {
                         return _cache.update_invalidating(adder, *old);
                       } else {
                         adder();


### PR DESCRIPTION
We inherited from Origin a `caching` table parameter. It's a map of named caching parameters. Before this PR two caching parameters were expected: `keys` and `rows_per_partition`. So far we have been ignoring them. This PR adds a new caching parameter called `enabled` which can be set to `true` or `false` and controls the usage of the cache for the table. By default, it's set to `true` which reflects Scylla behavior before this PR.

This new capability is used to disable caching for CDC Log table. It is desirable because CDC Log entries are not expected to be read often. They also put much more pressure on memory than entries in Base Table. This is caused by the fact that some writes to Base Table can override previous writes. Every write to CDC Log is unique and does not invalidate any previous entry.

Fixes #6098
Fixes #6146

Tests: unit(dev, release), manual