### PR TITLE
Repair use table id instead of table name

### DIFF
--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -1041,13 +1041,14 @@ static future<> repair_range(repair_info& ri, const dht::token_range& range) {
             neighbors.swap(live_neighbors);
       }
       return ::service::get_local_migration_manager().sync_schema(ri.db.local(), neighbors).then([&neighbors, &ri, range, id] {
-        return do_for_each(ri.cfs.begin(), ri.cfs.end(), [&ri, &neighbors, range] (auto&& cf) {
+        return do_for_each(ri.table_ids.begin(), ri.table_ids.end(), [&ri, &neighbors, range] (utils::UUID table_id) {
+            auto cf = ri.db.local().find_column_family(table_id).schema()->cf_name();
             ri._sub_ranges_nr++;
             if (ri.row_level_repair()) {
                 if (ri.dropped_tables.count(cf)) {
                     return make_ready_future<>();
                 }
-                return repair_cf_range_row_level(ri, cf, range, neighbors).handle_exception_type([&ri, cf] (no_such_column_family&) mutable {
+                return repair_cf_range_row_level(ri, cf, table_id, range, neighbors).handle_exception_type([&ri, cf] (no_such_column_family&) mutable {
                     ri.dropped_tables.insert(cf);
                     return make_ready_future<>();
                 }).handle_exception([&ri] (std::exception_ptr ep) mutable {

--- a/repair/repair.hh
+++ b/repair/repair.hh
@@ -177,6 +177,7 @@ public:
     sstring keyspace;
     dht::token_range_vector ranges;
     std::vector<sstring> cfs;
+    std::vector<utils::UUID> table_ids;
     int id;
     shard_id shard;
     std::vector<sstring> data_centers;
@@ -211,6 +212,7 @@ public:
             const sstring& keyspace_,
             const dht::token_range_vector& ranges_,
             const std::vector<sstring>& cfs_,
+            std::vector<utils::UUID> table_ids_,
             int id_,
             const std::vector<sstring>& data_centers_,
             const std::vector<sstring>& hosts_,

--- a/repair/repair.hh
+++ b/repair/repair.hh
@@ -211,7 +211,6 @@ public:
     repair_info(seastar::sharded<database>& db_,
             const sstring& keyspace_,
             const dht::token_range_vector& ranges_,
-            const std::vector<sstring>& cfs_,
             std::vector<utils::UUID> table_ids_,
             int id_,
             const std::vector<sstring>& data_centers_,
@@ -231,6 +230,9 @@ public:
     }
     bool row_level_repair() {
         return _row_level_repair;
+    }
+    const std::vector<sstring>& table_names() {
+        return cfs;
     }
 };
 

--- a/repair/repair.hh
+++ b/repair/repair.hh
@@ -278,7 +278,7 @@ public:
     void abort_all_repairs();
     named_semaphore& range_parallelism_semaphore();
     static size_t max_repair_memory_per_range() { return _max_repair_memory_per_range; }
-    future<> run(int id, std::function<future<> ()> func);
+    future<> run(int id, std::function<void ()> func);
 };
 
 future<uint64_t> estimate_partitions(seastar::sharded<database>& db, const sstring& keyspace,

--- a/repair/row_level.hh
+++ b/repair/row_level.hh
@@ -49,7 +49,7 @@ future<> repair_init_messaging_service_handler(repair_service& rs, distributed<d
 class repair_info;
 
 future<> repair_cf_range_row_level(repair_info& ri,
-        sstring cf_name, dht::token_range range,
+        sstring cf_name, utils::UUID table_id, dht::token_range range,
         const std::vector<gms::inet_address>& all_peer_nodes);
 
 future<> shutdown_all_row_level_repair();


### PR DESCRIPTION
Use table_id instead of table_name in row level repair to find a table. It
guarantees we repair the same table even if a table is dropped and a new
table is created with the same name.

Refs: #5942