### PR TITLE
reloc-pkg: move all files under project name directory

### DIFF
--- a/dist/redhat/python3/python.spec
+++ b/dist/redhat/python3/python.spec
@@ -23,7 +23,7 @@ functionality). All shared libraries needed for the interpreter to
 operate are shipped with it.
 
 %prep
-%setup -q -c
+%setup -n scylla-python3-package
 
 %install
 ./install.sh --root "$RPM_BUILD_ROOT"

--- a/dist/redhat/scylla.spec
+++ b/dist/redhat/scylla.spec
@@ -44,7 +44,7 @@ This package installs all required packages for ScyllaDB,  including
 %defattr(-,root,root)
 
 %prep
-%setup -c
+%setup -n scylla-package
 
 %package        server
 Group:          Applications/Databases

--- a/reloc/build_deb.sh
+++ b/reloc/build_deb.sh
@@ -36,7 +36,7 @@ RELOC_PKG=$(readlink -f $RELOC_PKG)
 if [[ ! $OPTS =~ --reloc-pkg ]]; then
     OPTS="$OPTS --reloc-pkg $RELOC_PKG"
 fi
-mkdir -p build/debian/scylla-package
-tar -C build/debian/scylla-package -xpf $RELOC_PKG
+mkdir -p build/debian/
+tar -C build/debian/ -xpf $RELOC_PKG
 cd build/debian/scylla-package
 exec ./dist/debian/build_deb.sh $OPTS

--- a/reloc/build_rpm.sh
+++ b/reloc/build_rpm.sh
@@ -52,8 +52,8 @@ RELOC_PKG=$(readlink -f $RELOC_PKG)
 if [[ ! $OPTS =~ --reloc-pkg ]]; then
     OPTS="$OPTS --reloc-pkg $RELOC_PKG"
 fi
-mkdir -p $BUILDDIR/scylla-package
-tar -C $BUILDDIR/scylla-package -xpf $RELOC_PKG SCYLLA-RELOCATABLE-FILE SCYLLA-RELEASE-FILE SCYLLA-VERSION-FILE SCYLLA-PRODUCT-FILE dist/redhat
+mkdir -p $BUILDDIR/
+tar -C $BUILDDIR/ -xpf $RELOC_PKG scylla-package/SCYLLA-RELOCATABLE-FILE scylla-package/SCYLLA-RELEASE-FILE scylla-package/SCYLLA-VERSION-FILE scylla-package/SCYLLA-PRODUCT-FILE scylla-package/dist/redhat
 cd $BUILDDIR/scylla-package
 echo "Running './dist/redhat/build_rpm.sh $OPTS' under $BUILDDIR/scylla-package directory"
 exec ./dist/redhat/build_rpm.sh $OPTS

--- a/reloc/python3/build_deb.sh
+++ b/reloc/python3/build_deb.sh
@@ -32,6 +32,6 @@ if [[ ! $OPTS =~ --reloc-pkg ]]; then
     OPTS="$OPTS --reloc-pkg $RELOC_PKG"
 fi
 mkdir -p build/debian/scylla-python3-package
-tar -C build/debian/scylla-python3-package -xpf $RELOC_PKG
+tar -C build/debian -xpf $RELOC_PKG
 cd build/debian/scylla-python3-package
 exec ./dist/debian/python3/build_deb.sh $OPTS

--- a/reloc/python3/build_rpm.sh
+++ b/reloc/python3/build_rpm.sh
@@ -37,6 +37,6 @@ if [[ ! $OPTS =~ --reloc-pkg ]]; then
     OPTS="$OPTS --reloc-pkg $RELOC_PKG"
 fi
 mkdir -p $BUILDDIR/scylla-python3-package
-tar -C $BUILDDIR/scylla-python3-package -xpf $RELOC_PKG SCYLLA-RELOCATABLE-FILE SCYLLA-RELEASE-FILE SCYLLA-VERSION-FILE SCYLLA-PRODUCT-FILE dist/redhat/python3
+tar -C $BUILDDIR -xpf $RELOC_PKG scylla-python3-package/SCYLLA-RELOCATABLE-FILE scylla-python3-package/SCYLLA-RELEASE-FILE scylla-python3-package/SCYLLA-VERSION-FILE scylla-python3-package/SCYLLA-PRODUCT-FILE scylla-python3-package/dist/redhat/python3
 cd $BUILDDIR/scylla-python3-package
 exec ./dist/redhat/python3/build_rpm.sh $OPTS

--- a/scripts/create-relocatable-package-python3.py
+++ b/scripts/create-relocatable-package-python3.py
@@ -34,6 +34,21 @@ import tarfile
 from tempfile import mkstemp
 import magic
 
+
+RELOC_PREFIX='scylla-python3-package'
+def reloc_add(self, name, arcname=None, recursive=True, *, filter=None):
+    if arcname:
+        return self.add(name, arcname="{}/{}".format(RELOC_PREFIX, arcname))
+    else:
+        return self.add(name, arcname="{}/{}".format(RELOC_PREFIX, name))
+
+def reloc_addfile(self, tarinfo, fileobj=None):
+    tarinfo.name = "{}/{}".format(RELOC_PREFIX, tarinfo.name)
+    return self.addfile(tarinfo, fileobj)
+
+tarfile.TarFile.reloc_add = reloc_add
+tarfile.TarFile.reloc_addfile = reloc_addfile
+
 def should_copy(f):
     '''Given a file, returns whether or not we are interested in copying this file.
     We want the actual python interepreter, and the files in /lib(64) and /usr/lib(64)
@@ -95,14 +110,14 @@ def fix_python_binary(ar, binpath):
     interpreter = subprocess.check_output(['patchelf',
                                            '--print-interpreter',
                                            patched_binary], universal_newlines=True).splitlines()[0]
-    ar.add(os.path.realpath(interpreter), arcname=os.path.join("libexec", "ld.so"))
-    ar.add(patched_binary, arcname=os.path.join("libexec", pyname + ".bin"))
+    ar.reloc_add(os.path.realpath(interpreter), arcname=os.path.join("libexec", "ld.so"))
+    ar.reloc_add(patched_binary, arcname=os.path.join("libexec", pyname + ".bin"))
     os.remove(patched_binary)
 
 def fix_sharedlib(ar, binpath, targetpath):
     relpath =  os.path.join(os.path.relpath("lib64", targetpath), "lib64")
     patched_binary = fix_binary(ar, binpath, '$ORIGIN/' + relpath)
-    ar.add(patched_binary, arcname=targetpath)
+    ar.reloc_add(patched_binary, arcname=targetpath)
     os.remove(patched_binary)
 
 def gen_python_thunk(ar, pybin):
@@ -124,12 +139,12 @@ PYTHONPATH="$d/{sitepackages}:$d/{sitepackages64}:$PYTHONPATH" exec -a "$0" "$ld
     ti = tarfile.TarInfo(name=os.path.join("bin", pybin))
     ti.size = len(thunk)
     ti.mode = 0o755
-    ar.addfile(ti, fileobj=io.BytesIO(thunk))
+    ar.reloc_addfile(ti, fileobj=io.BytesIO(thunk))
 
     ti = tarfile.TarInfo(name=os.path.join("bin", "python3"))
     ti.type = tarfile.SYMTYPE
     ti.linkname = pybin
-    ar.addfile(ti)
+    ar.reloc_addfile(ti)
 
 def copy_file_to_python_env(ar, f):
     if f.startswith("/usr/bin/python"):
@@ -154,7 +169,7 @@ def copy_file_to_python_env(ar, f):
         # links to the current directory are usually safe, but because we are manipulating
         # the directory structure, very likely links that transverse paths will break.
         if os.path.islink(f) and os.readlink(f) != os.path.basename(os.readlink(f)):
-            ar.add(os.path.realpath(f), arcname=libfile)
+            ar.reloc_add(os.path.realpath(f), arcname=libfile)
         else:
             m = magic.detect_from_filename(f)
             if m and (m.mime_type.startswith('application/x-sharedlib') or m.mime_type.startswith('application/x-pie-executable')):
@@ -163,7 +178,7 @@ def copy_file_to_python_env(ar, f):
                 # in case this is a directory that is listed, we don't want to include everything that is in that directory
                 # for instance, the python3 package will own site-packages, but other packages that we are not packaging could have
                 # filled it with stuff.
-                ar.add(f, arcname=libfile, recursive=False)
+                ar.reloc_add(f, arcname=libfile, recursive=False)
 
 def filter_basic_packages(package):
     '''Returns true if this package should be filtered out. We filter out packages that are too basic like the Fedora repos,
@@ -229,18 +244,18 @@ packages= ["python3"] + args.modules
 file_list = generate_file_list(dependencies(packages))
 ar = tarfile.open(args.output, mode='w|gz')
 pathlib.Path('build/SCYLLA-RELOCATABLE-FILE').touch()
-ar.add('build/SCYLLA-RELOCATABLE-FILE', arcname='SCYLLA-RELOCATABLE-FILE')
-ar.add('dist/redhat/python3')
-ar.add('dist/debian/python3')
-ar.add('build/python3/SCYLLA-RELEASE-FILE', arcname='SCYLLA-RELEASE-FILE')
-ar.add('build/python3/SCYLLA-VERSION-FILE', arcname='SCYLLA-VERSION-FILE')
-ar.add('build/SCYLLA-PRODUCT-FILE', arcname='SCYLLA-PRODUCT-FILE')
-ar.add('python3/install.sh', arcname='install.sh')
+ar.reloc_add('build/SCYLLA-RELOCATABLE-FILE', arcname='SCYLLA-RELOCATABLE-FILE')
+ar.reloc_add('dist/redhat/python3')
+ar.reloc_add('dist/debian/python3')
+ar.reloc_add('build/python3/SCYLLA-RELEASE-FILE', arcname='SCYLLA-RELEASE-FILE')
+ar.reloc_add('build/python3/SCYLLA-VERSION-FILE', arcname='SCYLLA-VERSION-FILE')
+ar.reloc_add('build/SCYLLA-PRODUCT-FILE', arcname='SCYLLA-PRODUCT-FILE')
+ar.reloc_add('python3/install.sh', arcname='install.sh')
 for p in ['pyhton3-libs'] + packages:
     pdir = pathlib.Path('/usr/share/licenses/{}/'.format(p))
     if pdir.exists():
         for f in pdir.glob('*'):
-            ar.add(f, arcname='licenses/{}/{}'.format(p, f.name))
+            ar.reloc_add(f, arcname='licenses/{}/{}'.format(p, f.name))
 
 for f in file_list:
     copy_file_to_python_env(ar, f)

--- a/scripts/create-relocatable-package.py
+++ b/scripts/create-relocatable-package.py
@@ -29,6 +29,15 @@ import tarfile
 import pathlib
 
 
+RELOC_PREFIX='scylla-package'
+def reloc_add(self, name, arcname=None, recursive=True, *, filter=None):
+    if arcname:
+        return self.add(name, arcname="{}/{}".format(RELOC_PREFIX, arcname))
+    else:
+        return self.add(name, arcname="{}/{}".format(RELOC_PREFIX, name))
+
+tarfile.TarFile.reloc_add = reloc_add
+
 def ldd(executable):
     '''Given an executable file, return a dictionary with the keys
     containing its shared library dependencies and the values pointing
@@ -60,6 +69,10 @@ def filter_dist(info):
         if info.name.startswith(x):
             return None
     return info
+
+SCYLLA_DIR='scylla-package'
+def reloc_add(ar, name, arcname=None):
+    ar.add(name, arcname="{}/{}".format(SCYLLA_DIR, arcname if arcname else name))
 
 ap = argparse.ArgumentParser(description='Create a relocatable scylla package.')
 ap.add_argument('dest',
@@ -105,36 +118,36 @@ gzip_process = subprocess.Popen("pigz > "+output, shell=True, stdin=subprocess.P
 
 ar = tarfile.open(fileobj=gzip_process.stdin, mode='w|')
 pathlib.Path('build/SCYLLA-RELOCATABLE-FILE').touch()
-ar.add('build/SCYLLA-RELOCATABLE-FILE', arcname='SCYLLA-RELOCATABLE-FILE')
+ar.reloc_add('build/SCYLLA-RELOCATABLE-FILE', arcname='SCYLLA-RELOCATABLE-FILE')
 
 for exe in executables:
     basename = os.path.basename(exe)
-    ar.add(exe, arcname='libexec/' + basename)
+    ar.reloc_add(exe, arcname='libexec/' + basename)
 for lib, libfile in libs.items():
-    ar.add(libfile, arcname='libreloc/' + lib)
+    ar.reloc_add(libfile, arcname='libreloc/' + lib)
 if have_gnutls:
     gnutls_config_nolink = os.path.realpath('/etc/crypto-policies/back-ends/gnutls.config')
-    ar.add(gnutls_config_nolink, arcname='libreloc/gnutls.config')
-ar.add('conf')
-ar.add('dist', filter=filter_dist)
-ar.add('build/SCYLLA-RELEASE-FILE', arcname='SCYLLA-RELEASE-FILE')
-ar.add('build/SCYLLA-VERSION-FILE', arcname='SCYLLA-VERSION-FILE')
-ar.add('build/SCYLLA-PRODUCT-FILE', arcname='SCYLLA-PRODUCT-FILE')
-ar.add('seastar/scripts')
-ar.add('seastar/dpdk/usertools')
-ar.add('install.sh')
+    ar.reloc_add(gnutls_config_nolink, arcname='libreloc/gnutls.config')
+    ar.reloc_add('conf')
+ar.reloc_add('dist', filter=filter_dist)
+ar.reloc_add('build/SCYLLA-RELEASE-FILE', arcname='SCYLLA-RELEASE-FILE')
+ar.reloc_add('build/SCYLLA-VERSION-FILE', arcname='SCYLLA-VERSION-FILE')
+ar.reloc_add('build/SCYLLA-PRODUCT-FILE', arcname='SCYLLA-PRODUCT-FILE')
+ar.reloc_add('seastar/scripts')
+ar.reloc_add('seastar/dpdk/usertools')
+ar.reloc_add('install.sh')
 # scylla_post_install.sh lives at the top level together with install.sh in the src tree, but while install.sh is
 # not distributed in the .rpm and .deb packages, scylla_post_install is, so we'll add it in the package
 # together with the other scripts that will end up in /usr/lib/scylla
-ar.add('scylla_post_install.sh', arcname="dist/common/scripts/scylla_post_install.sh")
-ar.add('README.md')
-ar.add('NOTICE.txt')
-ar.add('ORIGIN')
-ar.add('licenses')
-ar.add('swagger-ui')
-ar.add('api')
-ar.add('tools')
-ar.add('scylla-gdb.py')
+ar.reloc_add('scylla_post_install.sh', arcname="dist/common/scripts/scylla_post_install.sh")
+ar.reloc_add('README.md')
+ar.reloc_add('NOTICE.txt')
+ar.reloc_add('ORIGIN')
+ar.reloc_add('licenses')
+ar.reloc_add('swagger-ui')
+ar.reloc_add('api')
+ar.reloc_add('tools')
+ar.reloc_add('scylla-gdb.py')
 
 # Complete the tar output, and wait for the gzip process to complete
 ar.close()


### PR DESCRIPTION
To make unified relocatable package easily, we may want to merge tarballs to single tarball like this:
zcat *.tar.gz | gzip -c > scylla-unified.tar.xz
But it's not possible with current relocatable package format, since there are multiple files conflicts, install.sh, SCYLLA-*-FILE, dist/, README.md, etc..

To support this, we need to archive everything in the directory when building relocatable package.

Fixes #6315