### PR TITLE
db: set gc grace period to 0 for local system tables

### DIFF
--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -203,6 +203,7 @@ schema_ptr batchlog() {
         // operations on resulting CFMetaData:
         //    .compactionStrategyClass(LeveledCompactionStrategy.class);
        )));
+       builder.set_gc_grace_seconds(0);
        builder.with_version(generate_schema_version(builder.uuid()));
        builder.set_wait_for_sync_to_commitlog(true);
        return builder.build(schema_builder::compact_storage::no);
@@ -226,6 +227,7 @@ schema_ptr built_indexes() {
         // comment
         "built column indexes"
        )));
+       builder.set_gc_grace_seconds(0);
        builder.with_version(generate_schema_version(builder.uuid()));
        return builder.build(schema_builder::compact_storage::yes);
     }();
@@ -272,6 +274,7 @@ schema_ptr built_indexes() {
         // comment
         "information about the local node"
        )));
+       builder.set_gc_grace_seconds(0);
        builder.with_version(generate_schema_version(builder.uuid()));
        builder.remove_column("scylla_cpu_sharding_algorithm");
        builder.remove_column("scylla_nr_shards");
@@ -307,6 +310,7 @@ schema_ptr built_indexes() {
         // comment
         "information about known peers in the cluster"
        )));
+       builder.set_gc_grace_seconds(0);
        builder.with_version(generate_schema_version(builder.uuid()));
        return builder.build(schema_builder::compact_storage::no);
     }();
@@ -331,6 +335,7 @@ schema_ptr built_indexes() {
         // comment
         "events related to peers"
        )));
+       builder.set_gc_grace_seconds(0);
        builder.with_version(generate_schema_version(builder.uuid()));
        return builder.build(schema_builder::compact_storage::no);
     }();
@@ -353,6 +358,7 @@ schema_ptr built_indexes() {
         // comment
         "ranges requested for transfer"
        )));
+       builder.set_gc_grace_seconds(0);
        builder.with_version(generate_schema_version(builder.uuid()));
        return builder.build(schema_builder::compact_storage::no);
     }();
@@ -490,6 +496,7 @@ schema_ptr size_estimates() {
         // comment
         "partitions larger than specified threshold"
         )));
+        builder.set_gc_grace_seconds(0);
         builder.with_version(generate_schema_version(builder.uuid()));
         return builder.build(schema_builder::compact_storage::no);
     }();
@@ -510,6 +517,7 @@ static schema_ptr large_rows() {
                 .with_column("compaction_time", timestamp_type)
                 .set_comment("rows larger than specified threshold")
                 .with_version(generate_schema_version(id))
+                .set_gc_grace_seconds(0)
                 .build();
     }();
     return large_rows;
@@ -530,6 +538,7 @@ static schema_ptr large_cells() {
                 .with_column("compaction_time", timestamp_type)
                 .set_comment("cells larger than specified threshold")
                 .with_version(generate_schema_version(id))
+                .set_gc_grace_seconds(0)
                 .build();
     }();
     return large_cells;
@@ -553,6 +562,7 @@ static schema_ptr large_cells() {
         // comment
         "Scylla specific information about the local node"
        )));
+       builder.set_gc_grace_seconds(0);
        builder.with_version(generate_schema_version(builder.uuid()));
        return builder.build(schema_builder::compact_storage::no);
     }();
@@ -666,6 +676,7 @@ schema_ptr local() {
         // comment
         "information about the local node"
        )));
+       builder.set_gc_grace_seconds(0);
        builder.with_version(generate_schema_version(builder.uuid()));
        return builder.build(schema_builder::compact_storage::no);
     }();
@@ -693,6 +704,7 @@ schema_ptr truncated() {
         // comment
         "information about table truncation"
        )));
+       builder.set_gc_grace_seconds(0);
        builder.with_version(generate_schema_version(builder.uuid()));
        return builder.build(schema_builder::compact_storage::no);
     }();
@@ -755,6 +767,7 @@ schema_ptr available_ranges() {
         // comment
         "available keyspace/ranges during bootstrap/replace that are ready to be served"
        )));
+       builder.set_gc_grace_seconds(0);
        builder.with_version(generate_schema_version(builder.uuid()));
        return builder.build();
     }();
@@ -777,6 +790,7 @@ schema_ptr views_builds_in_progress() {
         // comment
         "views builds current progress"
        )));
+       builder.set_gc_grace_seconds(0);
        builder.with_version(generate_schema_version(builder.uuid()));
        return builder.build();
     }();
@@ -799,6 +813,7 @@ schema_ptr built_views() {
         // comment
         "built views"
        )));
+       builder.set_gc_grace_seconds(0);
        builder.with_version(generate_schema_version(builder.uuid()));
        return builder.build();
     }();
@@ -842,6 +857,7 @@ schema_ptr scylla_views_builds_in_progress() {
         // comment
         "CDC-specific information that the local node stores"
        )));
+       builder.set_gc_grace_seconds(0);
        builder.with_version(generate_schema_version(builder.uuid()));
        return builder.build(schema_builder::compact_storage::no);
     }();


### PR DESCRIPTION
Local system tables from `system` namespace use LocalStrategy
replication, so they do not need to be concerned about gc grace
period. Some system tables already set gc grace period to 0,
but other ones, including system.large_partitions, did not.
That may result in millions of tombstones being needlessly
kept for these tables, which can cause read timeouts.

Fixes #6325
Tests: unit(dev), local(running cqlsh and playing with system tables)