### PR TITLE
forbid tmpdir().path()

### DIFF
--- a/test/lib/tmpdir.hh
+++ b/test/lib/tmpdir.hh
@@ -42,9 +42,7 @@ private:
     }
 
 public:
-    tmpdir()
-     : _path(fs::temp_directory_path() /
-             fs::path(fmt::format(FMT_STRING("scylla-{}"), utils::make_random_uuid()))) {
+    tmpdir() : _path(tmpdir::temp_directory_path()) {
         fs::create_directories(_path);
     }
 
@@ -60,5 +58,12 @@ public:
         remove();
     }
 
-    const fs::path& path() const noexcept { return _path; }
+    const fs::path& path() const & noexcept { return _path; }
+    // tmpdir().path() must not be allowed, use tmpdir::temp_directory_path() for this.
+    const fs::path& path() const && = delete;
+
+    static const fs::path temp_directory_path() {
+      return fs::temp_directory_path() /
+             fs::path(fmt::format(FMT_STRING("scylla-{}"), utils::make_random_uuid()));
+    }
 };


### PR DESCRIPTION
tmpdir is an object that exploits RAII for providing the user
with the temporary directory. however, it is very easy to miss
that it is must not be used as an rvalue for the path() call.

Implementation
==============

I wanted to forbid `tmpdir` to be an rvalue, but there are a lot
of places that use rvalue to lvalue materialization to the future
with `do_with(tmpdir(), [](){...})`.

The implementation deletes `path() &&` leaving only `path() &`.
It also extracts path generation logic to the separate static
method `tmpdir::temp_directory_path()`.