### PR TITLE
database: remove variadic future from query() and query_mutations()

### DIFF
--- a/database.hh
+++ b/database.hh
@@ -1493,10 +1493,10 @@ public:
     future<> stop_large_data_handler();
     unsigned shard_of(const mutation& m);
     unsigned shard_of(const frozen_mutation& m);
-    future<lw_shared_ptr<query::result>, cache_temperature> query(schema_ptr, const query::read_command& cmd, query::result_options opts,
+    future<std::tuple<lw_shared_ptr<query::result>, cache_temperature>> query(schema_ptr, const query::read_command& cmd, query::result_options opts,
                                                                   const dht::partition_range_vector& ranges, tracing::trace_state_ptr trace_state,
                                                                   uint64_t max_result_size, db::timeout_clock::time_point timeout);
-    future<reconcilable_result, cache_temperature> query_mutations(schema_ptr, const query::read_command& cmd, const dht::partition_range& range,
+    future<std::tuple<reconcilable_result, cache_temperature>> query_mutations(schema_ptr, const query::read_command& cmd, const dht::partition_range& range,
                                                 query::result_memory_accounter&& accounter, tracing::trace_state_ptr trace_state,
                                                 db::timeout_clock::time_point timeout);
     // Apply the mutation atomically.

--- a/service/paxos/paxos_state.cc
+++ b/service/paxos/paxos_state.cc
@@ -92,7 +92,7 @@ future<prepare_response> paxos_state::prepare(tracing::trace_state_ptr tr_state,
                     // Silently ignore any errors querying the current value as the caller is prepared to fall back
                     // on querying it by itself in case it's missing in the response.
                     if (!f2.failed()) {
-                        auto&& [result, hit_rate] = f2.get();
+                        auto&& [result, hit_rate] = f2.get0();
                         if (only_digest) {
                             data_or_digest = *result->digest();
                         } else {

--- a/test/boost/database_test.cc
+++ b/test/boost/database_test.cc
@@ -62,7 +62,7 @@ SEASTAR_TEST_CASE(test_safety_after_truncate) {
         auto assert_query_result = [&] (size_t expected_size) {
             auto max_size = std::numeric_limits<size_t>::max();
             auto cmd = query::read_command(s->id(), s->version(), partition_slice_builder(*s).build(), 1000);
-            auto result = db.query(s, cmd, query::result_options::only_result(), pranges, nullptr, max_size, db::no_timeout).get0();
+            auto&& [result, cache_tempature] = db.query(s, cmd, query::result_options::only_result(), pranges, nullptr, max_size, db::no_timeout).get0();
             assert_that(query::result_set::from_raw_result(s, cmd.slice, *result)).has_size(expected_size);
         };
         assert_query_result(1000);
@@ -105,21 +105,21 @@ SEASTAR_TEST_CASE(test_querying_with_limits) {
             auto max_size = std::numeric_limits<size_t>::max();
             {
                 auto cmd = query::read_command(s->id(), s->version(), partition_slice_builder(*s).build(), 3);
-                auto result = db.query(s, cmd, query::result_options::only_result(), pranges, nullptr, max_size, db::no_timeout).get0();
+                auto result = std::get<0>(db.query(s, cmd, query::result_options::only_result(), pranges, nullptr, max_size, db::no_timeout).get0());
                 assert_that(query::result_set::from_raw_result(s, cmd.slice, *result)).has_size(3);
             }
 
             {
                 auto cmd = query::read_command(s->id(), s->version(), partition_slice_builder(*s).build(),
                         query::max_rows, gc_clock::now(), std::nullopt, 5);
-                auto result = db.query(s, cmd, query::result_options::only_result(), pranges, nullptr, max_size, db::no_timeout).get0();
+                auto result = std::get<0>(db.query(s, cmd, query::result_options::only_result(), pranges, nullptr, max_size, db::no_timeout).get0());
                 assert_that(query::result_set::from_raw_result(s, cmd.slice, *result)).has_size(5);
             }
 
             {
                 auto cmd = query::read_command(s->id(), s->version(), partition_slice_builder(*s).build(),
                         query::max_rows, gc_clock::now(), std::nullopt, 3);
-                auto result = db.query(s, cmd, query::result_options::only_result(), pranges, nullptr, max_size, db::no_timeout).get0();
+                auto result = std::get<0>(db.query(s, cmd, query::result_options::only_result(), pranges, nullptr, max_size, db::no_timeout).get0());
                 assert_that(query::result_set::from_raw_result(s, cmd.slice, *result)).has_size(3);
             }
         });

--- a/test/boost/multishard_mutation_query_test.cc
+++ b/test/boost/multishard_mutation_query_test.cc
@@ -107,7 +107,7 @@ static std::vector<mutation> read_all_partitions_one_by_one(distributed<database
                 const auto cmd = query::read_command(s->id(), s->version(), s->full_slice(), query::max_rows);
                 const auto range = dht::partition_range::make_singular(pkey);
                 return make_foreign(std::make_unique<reconcilable_result>(
-                    db.query_mutations(std::move(s), cmd, range, std::move(accounter), nullptr, db::no_timeout).get0()));
+                    std::get<0>(db.query_mutations(std::move(s), cmd, range, std::move(accounter), nullptr, db::no_timeout).get0())));
             });
         }).get0();
 


### PR DESCRIPTION
Variadic futures are deprecated; replace with future<std::tuple<...>>.

Tests: unit (dev)