### PR TITLE
tracked_file_impl: inherit disk and memory alignment from underlying file

### DIFF
--- a/reader_concurrency_semaphore.cc
+++ b/reader_concurrency_semaphore.cc
@@ -184,6 +184,9 @@ public:
     tracking_file_impl(file file, reader_permit permit)
         : _tracked_file(std::move(file))
         , _permit(std::move(permit)) {
+        _memory_dma_alignment = _tracked_file.memory_dma_alignment();
+        _disk_read_dma_alignment = _tracked_file.disk_read_dma_alignment();
+        _disk_write_dma_alignment = _tracked_file.disk_write_dma_alignment();
     }
 
     tracking_file_impl(const tracking_file_impl&) = delete;


### PR DESCRIPTION
tracked_file_impl is a wrapper around another file, that tracks
memory allocated for buffers in order to control memory consumption.

However, it neglects to inherit the disk and memory alignment settings
from the wrapped file, which can cause unnecessarily-large buffers
to be read from disk, reducing throughput.

Fix by copying the alignment parameters.

Fixes #6290.