### PR TITLE
alternator: deduplicate logs on boot

### DIFF
--- a/alternator/server.cc
+++ b/alternator/server.cc
@@ -409,7 +409,6 @@ future<> server::init(net::inet_address addr, std::optional<uint16_t> port, std:
                 _http_server.set_content_length_limit(server::content_length_limit);
                 _http_server.listen(socket_address{addr, *port}).get();
                 _enabled_servers.push_back(std::ref(_http_server));
-                slogger.info("Alternator HTTP server listening on {} port {}", addr, *port);
             }
             if (https_port) {
                 set_routes(_https_server._routes);
@@ -423,7 +422,6 @@ future<> server::init(net::inet_address addr, std::optional<uint16_t> port, std:
                 }).get0());
                 _https_server.listen(socket_address{addr, *https_port}).get();
                 _enabled_servers.push_back(std::ref(_https_server));
-                slogger.info("Alternator HTTPS server listening on {} port {}", addr, *https_port);
             }
         } catch (...) {
             slogger.error("Failed to set up Alternator HTTP server on {} port {}, TLS port {}: {}",

--- a/main.cc
+++ b/main.cc
@@ -1129,6 +1129,9 @@ int main(int ac, char** av) {
                             [addr, alternator_port, alternator_https_port, creds = std::move(creds), alternator_enforce_authorization] (alternator::server& server) mutable {
                         auto& ss = service::get_local_storage_service();
                         return server.init(addr, alternator_port, alternator_https_port, creds, alternator_enforce_authorization, &ss.service_memory_limiter());
+                    }).then([addr, alternator_port, alternator_https_port] {
+                        startlog.info("Alternator server listening on {}, HTTP port {}, HTTPS port {}",
+                                addr, alternator_port ? std::to_string(*alternator_port) : "OFF", alternator_https_port ? std::to_string(*alternator_https_port) : "OFF");
                     });
                 }).get();
                 auto stop_alternator = [ssg] {


### PR DESCRIPTION
Alternator server used to print a startup log line for each shard,
which is redundant and creates churn for nodes with many cores.
Instead of all that, a single line is now printed once alternator
server properly boots.

Fixes #6347
Tests: manual(boot), unit(dev)