### PR TITLE
db, view: remove duplicate entries from pending endpoints

### DIFF
--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -1101,6 +1101,8 @@ future<> mutate_MV(
             }
         };
         if (paired_endpoint) {
+            // If paired endpoint is present, remove it from the list of pending endpoints to avoid duplicates
+            pending_endpoints.erase(std::remove(pending_endpoints.begin(), pending_endpoints.end(), *paired_endpoint), pending_endpoints.end());
             // When paired endpoint is the local node, we can just apply
             // the mutation locally, unless there are pending endpoints, in
             // which case we want to do an ordinary write so the view mutation


### PR DESCRIPTION
When generating view updates, an endpoint can appear both
as a primary paired endpoint for the view update, and as a pending
endpoint (due to range movements). In order not to generate
the same update twice for the same endpoint, the paired endpoint
is removed from the list of pending endpoints if present.

Fixes #5459
Tests: unit(dev),
       dtest(TestMaterializedViews.add_dc_during_mv_insert_test)