### PR TITLE
cql3: Fix detection of bound variables in tuples

### DIFF
--- a/cql3/tuples.hh
+++ b/cql3/tuples.hh
@@ -144,7 +144,7 @@ public:
         }
 
         virtual bool contains_bind_marker() const override {
-            return std::all_of(_elements.begin(), _elements.end(), std::mem_fn(&term::contains_bind_marker));
+            return std::any_of(_elements.begin(), _elements.end(), std::mem_fn(&term::contains_bind_marker));
         }
 
         virtual void collect_marker_specification(variable_specifications& bound_names) const override {

--- a/test/boost/cql_query_test.cc
+++ b/test/boost/cql_query_test.cc
@@ -360,6 +360,14 @@ SEASTAR_TEST_CASE(test_tuple_elements_validation) {
     });
 }
 
+/// Reproduces #4209
+SEASTAR_TEST_CASE(test_list_of_tuples_with_bound_var) {
+    return do_with_cql_env_thread([](cql_test_env& e) {
+        e.execute_cql("create table cf (pk int PRIMARY KEY, c1 list<frozen<tuple<int,int>>>);").get();
+        BOOST_REQUIRE_THROW(e.prepare("update cf SET c1 = c1 + [(?,9999)] where pk = 999;").get0(), exceptions::invalid_request_exception);
+    });
+}
+
 SEASTAR_TEST_CASE(test_insert_statement) {
     return do_with_cql_env([] (cql_test_env& e) {
         return e.execute_cql("create table cf (p1 varchar, c1 int, r1 int, PRIMARY KEY (p1, c1));").discard_result().then([&e] {


### PR DESCRIPTION
This is unrelated to counters, but happens to fix #4209 

`tuple::delayed_value::contains_bind_marker` used to check that
ALL terms are bound (not that ANY of them is bound). As a result,
scylla would crash in prepare codepath for collections of tuples.
After this fix `invalid_request_exception` is thrown instead.