### PR TITLE
dist/redhat/python3: drop dependency on pystache

### DIFF
--- a/dist/redhat/python3/build_rpm.sh
+++ b/dist/redhat/python3/build_rpm.sh
@@ -74,13 +74,6 @@ fi
 if [ ! -f /usr/bin/git ]; then
     pkg_install git
 fi
-if [ ! -f /usr/bin/pystache ]; then
-    if is_redhat_variant; then
-        sudo yum install -y python2-pystache || sudo yum install -y pystache
-    elif is_debian_variant; then
-        sudo apt-get install -y python2-pystache
-    fi
-fi
 
 RELOC_PKG_BASENAME=$(basename "$RELOC_PKG")
 SCYLLA_VERSION=$(cat SCYLLA-VERSION-FILE)
@@ -89,6 +82,14 @@ SCYLLA_RELEASE=$(cat SCYLLA-RELEASE-FILE)
 RPMBUILD=$(readlink -f ../)
 mkdir -p "$RPMBUILD"/{BUILD,BUILDROOT,RPMS,SOURCES,SPECS,SRPMS}
 
+parameters=(
+    -D"name $PRODUCT-python3"
+    -D"version $SCYLLA_VERSION"
+    -D"release $SCYLLA_RELEASE"
+    -D"target /opt/scylladb/python3"
+    -D"reloc_pkg $RELOC_PKG_BASENAME"
+)
+
 ln -fv "$RELOC_PKG" "$RPMBUILD"/SOURCES/
-pystache dist/redhat/python3/python.spec.mustache "{ \"version\": \"${SCYLLA_VERSION}\", \"release\": \"${SCYLLA_RELEASE}\", \"reloc_pkg\": \"${RELOC_PKG_BASENAME}\", \"name\": \"$PRODUCT-python3\", \"target\": \"/opt/scylladb/python3\" }" > "$RPMBUILD"/SPECS/python.spec
-rpmbuild --nodebuginfo -ba --define '_binary_payload w2.xzdio' --define "_build_id_links none" --define "_topdir ${RPMBUILD}" "$RPMBUILD"/SPECS/python.spec
+cp dist/redhat/python3/python.spec "$RPMBUILD"/SPECS/
+rpmbuild "${parameters[@]}" --nodebuginfo -ba --define '_binary_payload w2.xzdio' --define "_build_id_links none" --define "_topdir ${RPMBUILD}" "$RPMBUILD"/SPECS/python.spec

--- a/dist/redhat/python3/python.spec
+++ b/dist/redhat/python3/python.spec
@@ -1,12 +1,12 @@
-Name: {{name}}
-Version: {{version}}
-Release: {{release}}
+Name: %{name}
+Version: %{version}
+Release: %{release}
 Summary: A standalone python3 interpreter that can be moved around different Linux machines
 AutoReqProv: no
-Provides: {{name}}
+Provides: %{name}
 
 License: Python
-Source0: {{reloc_pkg}}
+Source0: %{reloc_pkg}
 
 %global __brp_python_bytecompile %{nil}
 %global __brp_mangle_shebangs %{nil}
@@ -29,8 +29,8 @@ operate are shipped with it.
 ./install.sh --root "$RPM_BUILD_ROOT"
 
 %files
-%dir {{target}}
-{{target}}/*
+%dir %{target}
+%{target}/*
 
 %changelog
 


### PR DESCRIPTION
Same as dist/redhat, stop using mustache since pystache is no longer available
on Fedora 32.

see: https://github.com/scylladb/scylla/pull/6313