### PR TITLE
hinted handoff: improve segment replay logic

### DIFF
--- a/db/hints/manager.cc
+++ b/db/hints/manager.cc
@@ -686,15 +686,6 @@ future<> manager::end_point_hints_manager::sender::send_one_hint(lw_shared_ptr<s
         // Future is waited on indirectly in `send_one_file()` (via `ctx_ptr->file_send_gate`).
         (void)with_gate(ctx_ptr->file_send_gate, [this, secs_since_file_mod, &fname, buf = std::move(buf), rp, ctx_ptr] () mutable {
             try {
-                try {
-                    ctx_ptr->rps_set.emplace(rp);
-                } catch (...) {
-                    // if we failed to insert the rp into the set then its contents can't be trusted and we have to re-send the current file from the beginning
-                    ctx_ptr->state.set(send_state::restart_segment);
-                    ctx_ptr->state.set(send_state::segment_replay_failed);
-                    return make_ready_future<>();
-                }
-
                 auto m = this->get_mutation(ctx_ptr, buf);
                 gc_clock::duration gc_grace_sec = m.s->gc_grace_seconds();
 
@@ -703,16 +694,14 @@ future<> manager::end_point_hints_manager::sender::send_one_hint(lw_shared_ptr<s
                 // Files are aggregated for at most manager::hints_timer_period therefore the oldest hint there is
                 // (last_modification - manager::hints_timer_period) old.
                 if (gc_clock::now().time_since_epoch() - secs_since_file_mod > gc_grace_sec - manager::hints_flush_period) {
-                    ctx_ptr->rps_set.erase(rp);
                     return make_ready_future<>();
                 }
 
                 return this->send_one_mutation(std::move(m)).then([this, rp, ctx_ptr] {
-                    ctx_ptr->rps_set.erase(rp);
                     ++this->shard_stats().sent;
-                }).handle_exception([this, ctx_ptr] (auto eptr) {
+                }).handle_exception([this, ctx_ptr, rp] (auto eptr) {
                     manager_logger.trace("send_one_hint(): failed to send to {}: {}", end_point_key(), eptr);
-                    ctx_ptr->state.set(send_state::segment_replay_failed);
+                    ctx_ptr->on_hint_send_failure(rp);
                 });
 
             // ignore these errors and move on - probably this hint is too old and the KS/CF has been deleted...
@@ -725,14 +714,23 @@ future<> manager::end_point_hints_manager::sender::send_one_hint(lw_shared_ptr<s
             } catch (no_column_mapping& e) {
                 manager_logger.debug("send_hints(): {} at {}: {}", fname, rp, e.what());
                 ++this->shard_stats().discarded;
+            } catch (...) {
+                manager_logger.debug("send_hints(): unexpected error in file {} at {}: {}", fname, rp, std::current_exception());
+                ctx_ptr->on_hint_send_failure(rp);
             }
-            ctx_ptr->rps_set.erase(rp);
             return make_ready_future<>();
         }).finally([units = std::move(units), ctx_ptr] {});
-    }).handle_exception([this, ctx_ptr] (auto eptr) {
+    }).handle_exception([this, ctx_ptr, rp] (auto eptr) {
         manager_logger.trace("send_one_file(): Hmmm. Something bad had happend: {}", eptr);
-        ctx_ptr->state.set(send_state::segment_replay_failed);
+        ctx_ptr->on_hint_send_failure(rp);
     });
+}
+
+void manager::end_point_hints_manager::sender::send_one_file_ctx::on_hint_send_failure(db::replay_position rp) noexcept {
+    state.set(send_state::segment_replay_failed);
+    if (!first_failed_rp || rp < *first_failed_rp) {
+        first_failed_rp = rp;
+    }
 }
 
 // runs in a seastar::async context
@@ -780,11 +778,8 @@ bool manager::end_point_hints_manager::sender::send_one_file(const sstring& fnam
 
     // update the next iteration replay position if needed
     if (ctx_ptr->state.contains(send_state::segment_replay_failed)) {
-        if (ctx_ptr->state.contains(send_state::restart_segment)) {
-            // if _rps_set contents is inconsistent simply re-start the current file from the beginning
-            _last_not_complete_rp = replay_position();
-        } else if (!ctx_ptr->rps_set.empty()) {
-            _last_not_complete_rp = *std::min_element(ctx_ptr->rps_set.begin(), ctx_ptr->rps_set.end());
+        if (ctx_ptr->first_failed_rp) {
+            _last_not_complete_rp = *ctx_ptr->first_failed_rp;
         }
 
         manager_logger.trace("send_one_file(): error while sending hints from {}, last RP is {}", fname, _last_not_complete_rp);

--- a/db/hints/manager.hh
+++ b/db/hints/manager.hh
@@ -110,6 +110,7 @@ public:
                 std::unordered_map<table_schema_version, column_mapping>& schema_ver_to_column_mapping;
                 seastar::gate file_send_gate;
                 std::optional<db::replay_position> first_failed_rp;
+                std::optional<db::replay_position> last_attempted_rp;
                 send_state_set state;
 
                 void on_hint_send_failure(db::replay_position rp) noexcept;

--- a/db/hints/manager.hh
+++ b/db/hints/manager.hh
@@ -96,13 +96,6 @@ public:
                 state::ep_state_left_the_ring,
                 state::draining>>;
 
-            enum class send_state {
-                segment_replay_failed,  // current segment sending failed
-            };
-
-            using send_state_set = enum_set<super_enum<send_state,
-                send_state::segment_replay_failed>>;
-
             struct send_one_file_ctx {
                 send_one_file_ctx(std::unordered_map<table_schema_version, column_mapping>& last_schema_ver_to_column_mapping)
                     : schema_ver_to_column_mapping(last_schema_ver_to_column_mapping)
@@ -111,7 +104,7 @@ public:
                 seastar::gate file_send_gate;
                 std::optional<db::replay_position> first_failed_rp;
                 std::optional<db::replay_position> last_attempted_rp;
-                send_state_set state;
+                bool segment_replay_failed = false;
 
                 void on_hint_send_failure(db::replay_position rp) noexcept;
             };

--- a/db/hints/manager.hh
+++ b/db/hints/manager.hh
@@ -26,6 +26,7 @@
 #include <vector>
 #include <list>
 #include <chrono>
+#include <optional>
 #include <seastar/core/gate.hh>
 #include <seastar/core/sharded.hh>
 #include <seastar/core/timer.hh>
@@ -97,12 +98,10 @@ public:
 
             enum class send_state {
                 segment_replay_failed,  // current segment sending failed
-                restart_segment,        // segment sending failed and it has to be restarted from the beginning since we failed to store one or more RPs
             };
 
             using send_state_set = enum_set<super_enum<send_state,
-                send_state::segment_replay_failed,
-                send_state::restart_segment>>;
+                send_state::segment_replay_failed>>;
 
             struct send_one_file_ctx {
                 send_one_file_ctx(std::unordered_map<table_schema_version, column_mapping>& last_schema_ver_to_column_mapping)
@@ -110,8 +109,10 @@ public:
                 {}
                 std::unordered_map<table_schema_version, column_mapping>& schema_ver_to_column_mapping;
                 seastar::gate file_send_gate;
-                std::unordered_set<db::replay_position> rps_set; // number of elements in this set is never going to be greater than the maximum send queue length
+                std::optional<db::replay_position> first_failed_rp;
                 send_state_set state;
+
+                void on_hint_send_failure(db::replay_position rp) noexcept;
             };
 
         private:
@@ -197,8 +198,7 @@ public:
             ///  - Limit the maximum memory size of hints "in the air" and the maximum total number of hints "in the air".
             ///  - Discard the hints that are older than the grace seconds value of the corresponding table.
             ///
-            /// If sending fails we are going to clear the state::segment_replay_ok in the _state and \ref rp is going to be stored in the _rps_set.
-            /// If sending is successful then \ref rp is going to be removed from the _rps_set.
+            /// If sending fails we are going to set the state::segment_replay_failed in the _state and _first_failed_rp will be updated to min(_first_failed_rp, \ref rp).
             ///
             /// \param ctx_ptr shared pointer to the file sending context
             /// \param buf buffer representing the hint


### PR DESCRIPTION
This series contains two improvements to hint file replay logic in hints manager:

- During replay of a hint file, keeping track of the first hint that fails to be sent is now done via a simple std::optional variable instead of an unordered_set. This slightly reduces complexity of next replay position calculation.
- A corner case is handled: if reading commitlog fails, but there won't be an error related to sending hints, starting position wouldn't be updated. This could cause us to replay more hints than necessary.

Tests:

- unit(dev)
- dtest(hintedhandoff_additional_test, dev)