### PR TITLE
alternator: unify error messages for existing tables/keyspaces

### DIFF
--- a/test/alternator/test_table.py
+++ b/test/alternator/test_table.py
@@ -200,7 +200,7 @@ def test_create_table_invalid_schema(dynamodb):
 # Test that trying to create a table that already exists fails in the
 # appropriate way (ResourceInUseException)
 def test_create_table_already_exists(dynamodb, test_table):
-    with pytest.raises(ClientError, match='ResourceInUseException'):
+    with pytest.raises(ClientError, match='ResourceInUseException.*Table.*already exists'):
         create_table(dynamodb, test_table.name)
 
 # Test that BillingMode error path works as expected - only the values


### PR DESCRIPTION
Since alternator is based on Scylla, two "already exists" error types
can appear when trying to create a table - that a table itself exists,
or that its keyspace does. That's however an implementation detail,
since alternator does not have a notion of keyspaces at all.
This patch unifies the error message to simply mention that a table
already exists, and comes with a more robust test case.
If the keyspace already exists, table creation will still be attempted.

Fixes #6340
Tests: alternator(local, remote)