### PR TITLE
Use time window compaction strategy for CDC Log table

### DIFF
--- a/cdc/log.cc
+++ b/cdc/log.cc
@@ -393,6 +393,9 @@ static schema_ptr create_log_schema(const schema& s, std::optional<utils::UUID> 
     schema_builder b(s.ks_name(), log_name(s.cf_name()));
     b.with_partitioner("com.scylladb.dht.CDCPartitioner");
     b.set_comment(sprint("CDC log for %s.%s", s.ks_name(), s.cf_name()));
+    if (s.cdc_options().ttl() > 0) {
+        b.set_gc_grace_seconds(0);
+    }
     b.with_column(log_meta_column_name_bytes("stream_id"), bytes_type, column_kind::partition_key);
     b.with_column(log_meta_column_name_bytes("time"), timeuuid_type, column_kind::clustering_key);
     b.with_column(log_meta_column_name_bytes("batch_seq_no"), int32_type, column_kind::clustering_key);


### PR DESCRIPTION
CDC Log is a time series so it makes sense to use time window compaction strategy for it.
Our support for time series is limited so we make sure that we don't create more than 24 sstables.
If TTL is configured to 0, meaning data does not expire, we don't use time window compaction strategy.

This PR also sets gc_grace_seconds to 0 when TTL is not set to 0.