### PR TITLE
cql: Add test for invalid unbounded DELETE

### DIFF
--- a/test/boost/cql_query_test.cc
+++ b/test/boost/cql_query_test.cc
@@ -52,6 +52,7 @@
 #include "schema_builder.hh"
 #include "service/migration_manager.hh"
 #include <regex>
+#include "gms/feature.hh"
 
 using namespace std::literals::chrono_literals;
 
@@ -1089,6 +1090,32 @@ SEASTAR_TEST_CASE(test_range_deletion_scenarios_with_compact_storage) {
             BOOST_FAIL("should've thrown");
         } catch (...) { }
     });
+}
+
+SEASTAR_TEST_CASE(test_invalid_range_deletion) {
+    cql_test_config cfg;
+    cfg.disabled_features.insert(sstring(gms::features::UNBOUNDED_RANGE_TOMBSTONES));
+    return do_with_cql_env_thread([] (cql_test_env& e) {
+        cquery_nofail(e, "create table cf (p int, c1 int, c2 int, c3 int, primary key (p, c1, c2, c3));");
+        const auto q = [&] (const char* stmt) { return e.execute_cql(stmt).get(); };
+        using ire = exceptions::invalid_request_exception;
+        const auto expected = exception_predicate::message_contains("specify both bounds");
+        cquery_nofail(e, "delete from cf where p = 1");
+        cquery_nofail(e, "delete from cf where p = 1 and c1 = 2");
+        BOOST_REQUIRE_EXCEPTION(q("delete from cf where p = 1 and c1 < 2"), ire, expected);
+        BOOST_REQUIRE_EXCEPTION(q("delete from cf where p = 1 and c1 >= 0"), ire, expected);
+        cquery_nofail(e, "delete from cf where p = 1 and c1 < 2 and c1 >= 0");
+        // TODO: enable when supported:
+        // cquery_nofail(e, "delete from cf where p = 1 and c1 = 2 and c1 < 2");
+        BOOST_REQUIRE_EXCEPTION(q("delete from cf where p = 1 and c1 = 2 and c2 >= 0"), ire, expected);
+        cquery_nofail(e, "delete from cf where p = 1 and c1 = 2 and c2 >= 0 and c2 < 2");
+        BOOST_REQUIRE_EXCEPTION(q("delete from cf where p = 1 and (c1)>(0)"), ire, expected);
+        BOOST_REQUIRE_EXCEPTION(q("delete from cf where p = 1 and (c1,c2)>(0,0)"), ire, expected);
+        BOOST_REQUIRE_EXCEPTION(q("delete from cf where p = 1 and (c1,c2,c3)<=(5,5,5)"), ire, expected);
+        cquery_nofail(e, "delete from cf where p = 1 and (c1,c2)>(0,0) and (c1,c2)<=(5,5)");
+        cquery_nofail(e, "delete from cf where p = 1 and (c1,c2)>(0,0) and (c1)<=(5)");
+        cquery_nofail(e, "delete from cf where p = 1 and (c1,c2)=(1,1)");
+    }, cfg);
 }
 
 SEASTAR_TEST_CASE(test_map_insert_update) {


### PR DESCRIPTION
In add40d4e59, we relaxed the prohibition of unbounded DELETE and
stopped testing the failure message.  But there are still scenarios
when unbounded DELETE is prohibited, so add a test to ensure we
continue to catch it where appropriate.

Signed-off-by: Dejan Mircevski <dejan@scylladb.com>