### PR TITLE
cdc: Tune expired sstables check frequency

### DIFF
--- a/cdc/log.cc
+++ b/cdc/log.cc
@@ -410,7 +410,12 @@ static schema_ptr create_log_schema(const schema& s, std::optional<utils::UUID> 
         auto window_minutes = seconds_to_minutes(window_seconds);
         b.set_compaction_strategy_options({
                 {"compaction_window_unit", "MINUTES"},
-                {"compaction_window_size", std::to_string(window_minutes)}
+                {"compaction_window_size", std::to_string(window_minutes)},
+                // A new SSTable will become fully expired every
+                // `window_seconds` seconds so we shouldn't check for expired
+                // sstables too often.
+                {"expired_sstable_check_frequency_seconds",
+                        std::to_string(std::max(1, window_seconds / 2))},
         });
     }
     b.with_column(log_meta_column_name_bytes("stream_id"), bytes_type, column_kind::partition_key);


### PR DESCRIPTION
CDC Log is a time series which uses time window compaction with some
time window. Data is TTLed with the same value. This means that sstable
won't become fully expired more often than once per time window
duration.

This patch sets expired_sstable_check_frequency_seconds compaction
strategy parameter to half of the time window. Default value of this
parameter is 10 minutes which in most cases won't be a good fit.
By default, we set TTL to 24h and time window to 1h. This means that
with a default value of the parameter we would be checking every 10
minutes but new expired sstable would appear only every 60 minutes.

The parameter is set to half of the time window duration because it's
the expected time we have to wait for sstable to become fully expired.
Half of the time we will wait longer and half of the time we will wait
shorter.

Signed-off-by: Piotr Jastrzebski <piotr@scylladb.com>