### PR TITLE
dist: rename coredump .mount to var-lib-scylla-coredump.mount

### DIFF
--- a/dist/common/scripts/scylla_coredump_setup
+++ b/dist/common/scripts/scylla_coredump_setup
@@ -73,11 +73,11 @@ Options=bind
 [Install]
 WantedBy=multi-user.target
 '''[1:-1]
-            with open('/etc/systemd/system/var-lib-systemd-coredump.mount', 'w') as f:
+            with open('/etc/systemd/system/var-lib-scylla-coredump.mount', 'w') as f:
                 f.write(dot_mount)
             makedirs('/var/lib/scylla/coredump')
             systemd_unit.reload()
-            systemd_unit('var-lib-systemd-coredump.mount').enable()
+            systemd_unit('var-lib-scylla-coredump.mount').enable()
         if os.path.exists('/usr/lib/sysctl.d/50-coredump.conf'):
             run('sysctl -p /usr/lib/sysctl.d/50-coredump.conf')
         else:


### PR DESCRIPTION
Since we change bind-mount opposite way, .mount file should be renamed too.

Fixes #6402