### PR TITLE
RFC: alternator CDC/streams initial metadata support

### DIFF
--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -75,22 +75,19 @@ static const column_definition& attrs_column(const schema& schema) {
     return *cdef;
 }
 
-struct make_jsonable : public json::jsonable {
-    rjson::value _value;
-public:
-    explicit make_jsonable(rjson::value&& value) : _value(std::move(value)) {}
-    virtual std::string to_json() const override {
-        return rjson::print(_value);
-    }
-};
-struct json_string : public json::jsonable {
-    std::string _value;
-public:
-    explicit json_string(std::string&& value) : _value(std::move(value)) {}
-    virtual std::string to_json() const override {
-        return _value;
-    }
-};
+make_jsonable::make_jsonable(rjson::value&& value)
+    : _value(std::move(value))
+{}
+std::string make_jsonable::to_json() const {
+    return rjson::print(_value);
+}
+
+json_string::json_string(std::string&& value)
+    : _value(std::move(value))
+{}
+std::string json_string::to_json() const {
+    return _value;
+}
 
 static void supplement_table_info(rjson::value& descr, const schema& schema) {
     rjson::set(descr, "CreationDateTime", rjson::value(std::chrono::duration_cast<std::chrono::seconds>(gc_clock::now().time_since_epoch()).count()));
@@ -159,15 +156,22 @@ static std::string lsi_name(const std::string& table_name, const std::string& in
  *  and api_error in case the table name is missing or not a string, or
  *  doesn't pass validate_table_name().
  */
-static std::string get_table_name(const rjson::value& request) {
-    const rjson::value& table_name_value = rjson::get(request, "TableName");
-    if (!table_name_value.IsString()) {
+std::optional<std::string> executor::get_table_name(const rjson::value& request, bool required) {
+    const rjson::value* table_name_value = rjson::find(request, "TableName");
+    if (!table_name_value && !required) {
+        return std::nullopt;
+    }
+    if (!table_name_value || !table_name_value->IsString()) {
         throw api_error("ValidationException",
                 "Missing or non-string TableName field in request");
     }
-    std::string table_name = table_name_value.GetString();
+    std::string table_name = table_name_value->GetString();
     validate_table_name(table_name);
     return table_name;
+}
+
+std::string executor::get_table_name(const rjson::value& request) {
+    return *get_table_name(request, true);
 }
 
 /** Extract table schema from a request.
@@ -177,13 +181,16 @@ static std::string get_table_name(const rjson::value& request) {
  *  name is missing, invalid or the table doesn't exist. If everything is
  *  successful, it returns the table's schema.
  */
-static schema_ptr get_table(service::storage_proxy& proxy, const rjson::value& request) {
-    std::string table_name = get_table_name(request);
+schema_ptr executor::get_table(service::storage_proxy& proxy, const rjson::value& request, bool required) {
+    auto table_name = get_table_name(request, required);
+    if (!table_name) {
+        return nullptr;
+    }
     try {
-        return proxy.get_db().local().find_schema(sstring(executor::KEYSPACE_NAME_PREFIX) + sstring(table_name), table_name);
+        return proxy.get_db().local().find_schema(sstring(executor::KEYSPACE_NAME_PREFIX) + sstring(*table_name), *table_name);
     } catch(no_such_column_family&) {
         throw api_error("ResourceNotFoundException",
-                format("Requested resource not found: Table: {} not found", table_name));
+                format("Requested resource not found: Table: {} not found", *table_name));
     }
 }
 
@@ -214,7 +221,7 @@ enum class table_or_view_type { base, lsi, gsi };
 static std::pair<schema_ptr, table_or_view_type>
 get_table_or_view(service::storage_proxy& proxy, const rjson::value& request) {
     table_or_view_type type = table_or_view_type::base;
-    std::string table_name = get_table_name(request);
+    std::string table_name = executor::get_table_name(request);
 
     auto [is_internal_table, internal_ks_name, internal_table_name] = try_get_internal_table(table_name);
     if (is_internal_table) {
@@ -313,22 +320,25 @@ static std::optional<int> get_int_attribute(const rjson::value& value, std::stri
 // attributes of the the given schema as being either HASH or RANGE keys.
 // Additionally, adds to a given map mappings between the key attribute
 // names and their type (as a DynamoDB type string).
-static void describe_key_schema(rjson::value& parent, const schema& schema, std::unordered_map<std::string,std::string>& attribute_types) {
+void executor::describe_key_schema(rjson::value& parent, const schema& schema, std::unordered_map<std::string,std::string>* attribute_types) {
     rjson::value key_schema = rjson::empty_array();
     for (const column_definition& cdef : schema.partition_key_columns()) {
         rjson::value key = rjson::empty_object();
         rjson::set(key, "AttributeName", rjson::from_string(cdef.name_as_text()));
         rjson::set(key, "KeyType", "HASH");
         rjson::push_back(key_schema, std::move(key));
-        attribute_types[cdef.name_as_text()] = type_to_string(cdef.type);
-
+        if (attribute_types) {
+            (*attribute_types)[cdef.name_as_text()] = type_to_string(cdef.type);
+        }
     }
     for (const column_definition& cdef : schema.clustering_key_columns()) {
         rjson::value key = rjson::empty_object();
         rjson::set(key, "AttributeName", rjson::from_string(cdef.name_as_text()));
         rjson::set(key, "KeyType", "RANGE");
         rjson::push_back(key_schema, std::move(key));
-        attribute_types[cdef.name_as_text()] = type_to_string(cdef.type);
+        if (attribute_types) {
+            (*attribute_types)[cdef.name_as_text()] = type_to_string(cdef.type);
+        }
         // FIXME: this "break" can avoid listing some clustering key columns
         // we added for GSIs just because they existed in the base table -
         // but not in all cases. We still have issue #5320. See also
@@ -339,8 +349,24 @@ static void describe_key_schema(rjson::value& parent, const schema& schema, std:
 
 }
 
+void executor::describe_key_schema(rjson::value& parent, const schema& schema, std::unordered_map<std::string,std::string>& attribute_types) {
+    describe_key_schema(parent, schema, &attribute_types);
+}
+
 static rjson::value generate_arn_for_table(const schema& schema) {
     return rjson::from_string(format("arn:scylla:alternator:{}:scylla:table/{}", schema.ks_name(), schema.cf_name()));
+}
+
+bool executor::is_alternator_keyspace(const sstring& ks_name) {
+    return ks_name.find(KEYSPACE_NAME_PREFIX) == 0;
+}
+
+sstring executor::table_name(const schema& s) {
+    return s.cf_name();
+}
+
+sstring executor::make_keyspace_name(const sstring& table_name) {
+    return sstring(KEYSPACE_NAME_PREFIX) + table_name;
 }
 
 future<executor::request_return_type> executor::describe_table(client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value request) {

--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -1198,7 +1198,7 @@ rmw_operation::returnvalues rmw_operation::parse_returnvalues(const rjson::value
 
 rmw_operation::rmw_operation(service::storage_proxy& proxy, rjson::value&& request)
     : _request(std::move(request))
-    , _schema(get_table(proxy, _request))
+    , _schema(executor::get_table(proxy, _request))
     , _write_isolation(get_write_isolation_for_schema(_schema))
     , _returnvalues(parse_returnvalues(_request))
 {

--- a/alternator/executor.hh
+++ b/alternator/executor.hh
@@ -114,6 +114,7 @@ private:
     static schema_ptr get_table(service::storage_proxy&, const rjson::value& request, bool required = true);
     static void describe_key_schema(rjson::value& parent, const schema&, std::unordered_map<std::string,std::string> * = nullptr);
     static void describe_key_schema(rjson::value& parent, const schema& schema, std::unordered_map<std::string,std::string>&);
+    static void add_stream_options(const rjson::value& stream_spec, schema_builder&);
 };
 
 }

--- a/alternator/executor.hh
+++ b/alternator/executor.hh
@@ -93,6 +93,7 @@ public:
     future<request_return_type> list_tags_of_resource(client_state& client_state, service_permit permit, rjson::value request);
     future<request_return_type> list_streams(client_state& client_state, service_permit permit, rjson::value request);
     future<request_return_type> describe_stream(client_state& client_state, service_permit permit, rjson::value request);
+    future<request_return_type> get_shard_iterator(client_state& client_state, service_permit permit, rjson::value request);
 
     future<> start();
     future<> stop() { return make_ready_future<>(); }

--- a/alternator/executor.hh
+++ b/alternator/executor.hh
@@ -94,6 +94,7 @@ public:
     future<request_return_type> list_streams(client_state& client_state, service_permit permit, rjson::value request);
     future<request_return_type> describe_stream(client_state& client_state, service_permit permit, rjson::value request);
     future<request_return_type> get_shard_iterator(client_state& client_state, service_permit permit, rjson::value request);
+    future<request_return_type> get_records(client_state& client_state, service_permit permit, rjson::value request);
 
     future<> start();
     future<> stop() { return make_ready_future<>(); }

--- a/alternator/executor.hh
+++ b/alternator/executor.hh
@@ -37,6 +37,21 @@
 
 namespace alternator {
 
+class rmw_operation;
+
+struct make_jsonable : public json::jsonable {
+    rjson::value _value;
+public:
+    explicit make_jsonable(rjson::value&& value);
+    std::string to_json() const override;
+};
+struct json_string : public json::jsonable {
+    std::string _value;
+public:
+    explicit json_string(std::string&& value);
+    std::string to_json() const override;
+};
+
 class executor : public peering_sharded_service<executor> {
     service::storage_proxy& _proxy;
     service::migration_manager& _mm;
@@ -78,6 +93,18 @@ public:
     future<> create_keyspace(std::string_view keyspace_name);
 
     static tracing::trace_state_ptr maybe_trace_query(client_state& client_state, sstring_view op, sstring_view query);
+
+    static sstring table_name(const schema&);
+    static std::string get_table_name(const rjson::value& request);
+private:
+    friend class rmw_operation;
+
+    static bool is_alternator_keyspace(const sstring& ks_name);
+    static sstring make_keyspace_name(const sstring& table_name);
+    static std::optional<std::string> get_table_name(const rjson::value& request, bool required);
+    static schema_ptr get_table(service::storage_proxy&, const rjson::value& request, bool required = true);
+    static void describe_key_schema(rjson::value& parent, const schema&, std::unordered_map<std::string,std::string> * = nullptr);
+    static void describe_key_schema(rjson::value& parent, const schema& schema, std::unordered_map<std::string,std::string>&);
 };
 
 }

--- a/alternator/executor.hh
+++ b/alternator/executor.hh
@@ -91,6 +91,7 @@ public:
     future<request_return_type> tag_resource(client_state& client_state, service_permit permit, rjson::value request);
     future<request_return_type> untag_resource(client_state& client_state, service_permit permit, rjson::value request);
     future<request_return_type> list_tags_of_resource(client_state& client_state, service_permit permit, rjson::value request);
+    future<request_return_type> list_streams(client_state& client_state, service_permit permit, rjson::value request);
 
     future<> start();
     future<> stop() { return make_ready_future<>(); }

--- a/alternator/executor.hh
+++ b/alternator/executor.hh
@@ -92,6 +92,7 @@ public:
     future<request_return_type> untag_resource(client_state& client_state, service_permit permit, rjson::value request);
     future<request_return_type> list_tags_of_resource(client_state& client_state, service_permit permit, rjson::value request);
     future<request_return_type> list_streams(client_state& client_state, service_permit permit, rjson::value request);
+    future<request_return_type> describe_stream(client_state& client_state, service_permit permit, rjson::value request);
 
     future<> start();
     future<> stop() { return make_ready_future<>(); }

--- a/alternator/executor.hh
+++ b/alternator/executor.hh
@@ -35,6 +35,10 @@
 #include "stats.hh"
 #include "rjson.hh"
 
+namespace db {
+    class system_distributed_keyspace;
+}
+
 namespace alternator {
 
 class rmw_operation;
@@ -55,6 +59,7 @@ public:
 class executor : public peering_sharded_service<executor> {
     service::storage_proxy& _proxy;
     service::migration_manager& _mm;
+    db::system_distributed_keyspace& _sdks;
     // An smp_service_group to be used for limiting the concurrency when
     // forwarding Alternator request between shards - if necessary for LWT.
     smp_service_group _ssg;
@@ -67,8 +72,8 @@ public:
     static constexpr auto KEYSPACE_NAME_PREFIX = "alternator_";
     static constexpr std::string_view INTERNAL_TABLE_PREFIX = ".scylla.alternator.";
 
-    executor(service::storage_proxy& proxy, service::migration_manager& mm, smp_service_group ssg)
-        : _proxy(proxy), _mm(mm), _ssg(ssg) {}
+    executor(service::storage_proxy& proxy, service::migration_manager& mm, db::system_distributed_keyspace& sdks, smp_service_group ssg)
+        : _proxy(proxy), _mm(mm), _sdks(sdks), _ssg(ssg) {}
 
     future<request_return_type> create_table(client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value request);
     future<request_return_type> describe_table(client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value request);

--- a/alternator/rjson.cc
+++ b/alternator/rjson.cc
@@ -128,6 +128,14 @@ std::string print(const rjson::value& value) {
     return std::string(buffer.GetString());
 }
 
+rjson::invalid_parameter::invalid_parameter(std::string_view name, const rjson::value& value)
+    : error(format("Invalid JSON parameter {} : {}", name, print(value)))
+{}
+
+rjson::missing_parameter::missing_parameter(std::string_view name) 
+    : error(format("JSON parameter {} not found", name))
+{}
+
 rjson::value copy(const rjson::value& value) {
     return rjson::value(value, the_allocator);
 }
@@ -158,20 +166,18 @@ rjson::value& get(rjson::value& value, std::string_view name) {
     // Luckily, the variant taking a GenericValue doesn't share this bug,
     // and we can create a string GenericValue without copying the string.
     auto member_it = value.FindMember(rjson::value(name.data(), name.size()));
-    if (member_it != value.MemberEnd())
+    if (member_it != value.MemberEnd()) {
         return member_it->value;
-    else {
-        throw rjson::error(format("JSON parameter {} not found", name));
     }
+    throw missing_parameter(name);
 }
 
 const rjson::value& get(const rjson::value& value, std::string_view name) {
     auto member_it = value.FindMember(rjson::value(name.data(), name.size()));
-    if (member_it != value.MemberEnd())
+    if (member_it != value.MemberEnd()) {
         return member_it->value;
-    else {
-        throw rjson::error(format("JSON parameter {} not found", name));
     }
+    throw missing_parameter(name);
 }
 
 rjson::value from_string(const std::string& str) {

--- a/alternator/rjson.cc
+++ b/alternator/rjson.cc
@@ -26,7 +26,7 @@
 
 namespace rjson {
 
-static allocator the_allocator;
+allocator the_allocator;
 
 /*
  * This wrapper class adds nested level checks to rapidjson's handlers.

--- a/alternator/rjson.hh
+++ b/alternator/rjson.hh
@@ -80,6 +80,15 @@ using string_buffer = rapidjson::GenericStringBuffer<encoding>;
 using writer = rapidjson::Writer<string_buffer, encoding>;
 using type = rapidjson::Type;
 
+class invalid_parameter : public error {
+public:
+    invalid_parameter(std::string_view name, const rjson::value& value);
+};
+class missing_parameter : public error {
+public:
+    missing_parameter(std::string_view name);
+};
+
 // Returns an object representing JSON's null
 inline rjson::value null_value() {
     return rjson::value(rapidjson::kNullType);

--- a/alternator/server.cc
+++ b/alternator/server.cc
@@ -393,6 +393,9 @@ server::server(executor& exec)
         {"ListTagsOfResource", [] (executor& e, executor::client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value json_request, std::unique_ptr<request> req) {
             return e.list_tags_of_resource(client_state, std::move(permit), std::move(json_request));
         }},
+        {"ListStreams", [] (executor& e, executor::client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value json_request, std::unique_ptr<request> req) {
+            return e.list_streams(client_state, std::move(permit), std::move(json_request));
+        }},
     } {
 }
 

--- a/alternator/server.cc
+++ b/alternator/server.cc
@@ -396,6 +396,9 @@ server::server(executor& exec)
         {"ListStreams", [] (executor& e, executor::client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value json_request, std::unique_ptr<request> req) {
             return e.list_streams(client_state, std::move(permit), std::move(json_request));
         }},
+        {"DescribeStream", [] (executor& e, executor::client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value json_request, std::unique_ptr<request> req) {
+            return e.describe_stream(client_state, std::move(permit), std::move(json_request));
+        }},
     } {
 }
 

--- a/alternator/server.cc
+++ b/alternator/server.cc
@@ -399,6 +399,9 @@ server::server(executor& exec)
         {"DescribeStream", [] (executor& e, executor::client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value json_request, std::unique_ptr<request> req) {
             return e.describe_stream(client_state, std::move(permit), std::move(json_request));
         }},
+        {"GetShardIterator", [] (executor& e, executor::client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value json_request, std::unique_ptr<request> req) {
+            return e.get_shard_iterator(client_state, std::move(permit), std::move(json_request));
+        }},
     } {
 }
 

--- a/alternator/server.cc
+++ b/alternator/server.cc
@@ -80,6 +80,10 @@ public:
                      resf.get();
                  } catch (api_error &ae) {
                      ret = ae;
+                 } catch (rjson::invalid_parameter& ivp) {
+                     ret = api_error("InvalidParameterValue", ivp.what());
+                 } catch (rjson::missing_parameter& mp) {
+                     ret = api_error("MissingParameter", mp.what());
                  } catch (rjson::error & re) {
                      ret = api_error("ValidationException", re.what());
                  } catch (...) {

--- a/alternator/server.cc
+++ b/alternator/server.cc
@@ -402,6 +402,9 @@ server::server(executor& exec)
         {"GetShardIterator", [] (executor& e, executor::client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value json_request, std::unique_ptr<request> req) {
             return e.get_shard_iterator(client_state, std::move(permit), std::move(json_request));
         }},
+        {"GetRecords", [] (executor& e, executor::client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value json_request, std::unique_ptr<request> req) {
+            return e.get_records(client_state, std::move(permit), std::move(json_request));
+        }},
     } {
 }
 

--- a/alternator/stats.cc
+++ b/alternator/stats.cc
@@ -78,6 +78,7 @@ stats::stats() : api_operations{} {
             OPERATION_LATENCY(delete_item_latency, "DeleteItem")
             OPERATION_LATENCY(update_item_latency, "UpdateItem")
             OPERATION(list_streams, "ListStreams")
+            OPERATION(describe_stream, "DescribeStream")
     });
     _metrics.add_group("alternator", {
             seastar::metrics::make_total_operations("unsupported_operations", unsupported_operations,

--- a/alternator/stats.cc
+++ b/alternator/stats.cc
@@ -77,6 +77,7 @@ stats::stats() : api_operations{} {
             OPERATION_LATENCY(get_item_latency, "GetItem")
             OPERATION_LATENCY(delete_item_latency, "DeleteItem")
             OPERATION_LATENCY(update_item_latency, "UpdateItem")
+            OPERATION(list_streams, "ListStreams")
     });
     _metrics.add_group("alternator", {
             seastar::metrics::make_total_operations("unsupported_operations", unsupported_operations,

--- a/alternator/stats.cc
+++ b/alternator/stats.cc
@@ -80,6 +80,7 @@ stats::stats() : api_operations{} {
             OPERATION(list_streams, "ListStreams")
             OPERATION(describe_stream, "DescribeStream")
             OPERATION(get_shard_iterator, "GetShardIterator")
+            OPERATION(get_records, "GetRecords")
     });
     _metrics.add_group("alternator", {
             seastar::metrics::make_total_operations("unsupported_operations", unsupported_operations,

--- a/alternator/stats.cc
+++ b/alternator/stats.cc
@@ -79,6 +79,7 @@ stats::stats() : api_operations{} {
             OPERATION_LATENCY(update_item_latency, "UpdateItem")
             OPERATION(list_streams, "ListStreams")
             OPERATION(describe_stream, "DescribeStream")
+            OPERATION(get_shard_iterator, "GetShardIterator")
     });
     _metrics.add_group("alternator", {
             seastar::metrics::make_total_operations("unsupported_operations", unsupported_operations,

--- a/alternator/stats.hh
+++ b/alternator/stats.hh
@@ -77,6 +77,7 @@ public:
         uint64_t list_streams = 0;
         uint64_t describe_stream = 0;
         uint64_t get_shard_iterator = 0;
+        uint64_t get_records = 0;
 
         utils::estimated_histogram put_item_latency;
         utils::estimated_histogram get_item_latency;

--- a/alternator/stats.hh
+++ b/alternator/stats.hh
@@ -75,6 +75,7 @@ public:
         uint64_t update_table = 0;
         uint64_t update_time_to_live = 0;
         uint64_t list_streams = 0;
+        uint64_t describe_stream = 0;
 
         utils::estimated_histogram put_item_latency;
         utils::estimated_histogram get_item_latency;

--- a/alternator/stats.hh
+++ b/alternator/stats.hh
@@ -76,6 +76,7 @@ public:
         uint64_t update_time_to_live = 0;
         uint64_t list_streams = 0;
         uint64_t describe_stream = 0;
+        uint64_t get_shard_iterator = 0;
 
         utils::estimated_histogram put_item_latency;
         utils::estimated_histogram get_item_latency;

--- a/alternator/stats.hh
+++ b/alternator/stats.hh
@@ -74,6 +74,7 @@ public:
         uint64_t update_item = 0;
         uint64_t update_table = 0;
         uint64_t update_time_to_live = 0;
+        uint64_t list_streams = 0;
 
         utils::estimated_histogram put_item_latency;
         utils::estimated_histogram get_item_latency;

--- a/alternator/streams.cc
+++ b/alternator/streams.cc
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2019 ScyllaDB
+ */
+
+/*
+ * This file is part of Scylla.
+ *
+ * Scylla is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Scylla is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <type_traits>
+#include <boost/lexical_cast.hpp>
+
+#include "base64.hh"
+#include "log.hh"
+#include "database.hh"
+
+#include "cdc/log.hh"
+#include "cdc/generation.hh"
+#include "db/system_distributed_keyspace.hh"
+#include "utils/UUID_gen.hh"
+
+#include "executor.hh"
+#include "tags_extension.hh"
+#include "rmw_operation.hh"
+
+template<typename ValueType, typename T>
+struct from_string_helper {
+    static bool Is(const ValueType& v) {
+        try {
+            Get(v);
+            return true;
+        } catch (...) {
+            return false;
+        }
+    }
+    static T Get(const ValueType& v) {
+        auto s = rjson::to_string_view(v);
+        if constexpr (std::is_constructible_v<T, std::string_view>) {
+            return T(s);
+        } else if constexpr (std::is_constructible_v<T, sstring>) {
+            return T(sstring(s));
+        } else {
+            return boost::lexical_cast<T>(s.data(), s.size());
+        }
+    }
+    static ValueType& Set(ValueType&, T) = delete;
+    static ValueType& Set(ValueType& v, T data, typename ValueType::AllocatorType& a) {
+        std::ostringstream ss;
+        ss << data;
+#if __cplusplus >= 202002L
+        auto s = ss.view();
+#else
+        auto s = ss.str();
+#endif
+        return v.SetString(s.data(), s.size(), a);
+    }
+};
+
+template<typename ValueType>
+struct rapidjson::internal::TypeHelper<ValueType, utils::UUID>
+    : public from_string_helper<ValueType, utils::UUID>
+{};
+
+namespace alternator {
+
+// stream arn _has_ to be 37 or more characters long. ugh...
+class stream_arn : public utils::UUID {
+public:
+    using UUID = utils::UUID;
+    static constexpr char marker = 'S';
+
+    stream_arn() = default;
+    stream_arn(const UUID& uuid)
+        : UUID(uuid)
+    {}
+    stream_arn(std::string_view v)
+        : UUID(v.substr(1))
+    {
+        if (v[0] != marker) {
+            throw std::invalid_argument(std::string(v));
+        }
+    }
+    friend std::ostream& operator<<(std::ostream& os, const stream_arn& arn) {
+        const UUID& uuid = arn;
+        return os << marker << uuid;
+    }
+    friend std::istream& operator>>(std::istream& is, stream_arn& arn) {
+        std::string s;
+        is >> s;
+        arn = stream_arn(s);
+        return is;
+    }
+};
+
+}
+
+template<typename ValueType>
+struct rapidjson::internal::TypeHelper<ValueType, alternator::stream_arn>
+    : public from_string_helper<ValueType, alternator::stream_arn>
+{};
+
+namespace alternator {
+
+future<alternator::executor::request_return_type> alternator::executor::list_streams(client_state& client_state, service_permit permit, rjson::value request) {
+    _stats.api_operations.list_streams++;
+
+    auto streams_start = rjson::get_opt<stream_arn>(request, "ExclusiveStartStreamArn");
+    auto limit = rjson::get_opt<int>(request, "Limit").value_or(std::numeric_limits<int>::max());
+    auto table = get_table(_proxy, request, false);
+
+    auto& db = _proxy.get_db().local();
+    auto& cfs = db.get_column_families();
+    auto i = cfs.begin();
+    auto e = cfs.end();
+
+    // TODO: the unordered_map here is not really well suited for partial
+    // querying - we're sorting on local hash order, and creating a table
+    // between queries may or may not miss info. But that should be rate,
+    // and we can probably expect this to be a single call.
+    if (streams_start) {
+        i = std::find_if(i, e, [&](const std::pair<utils::UUID, lw_shared_ptr<column_family>>& p) {
+            return p.first == *streams_start;
+        });
+        if (i != e) {
+            ++i;
+        }
+    }
+
+    auto ret = rjson::empty_object();
+    auto streams = rjson::empty_array();
+
+    std::optional<stream_arn> last;
+
+    for (;limit > 0 && i != e; ++i) {
+        auto s = i->second->schema();
+        auto& ks_name = s->ks_name();
+        auto& cf_name = s->cf_name();
+
+        if (!is_alternator_keyspace(ks_name)) {
+            continue;
+        }
+        if (table && ks_name != table->ks_name()) {
+            continue;
+        }
+        if (cdc::is_log_for_some_table(ks_name, cf_name)) {
+            if (table && table != cdc::get_base_table(db, *s)) {
+                continue;
+            }
+
+            rjson::value new_entry = rjson::empty_object();
+
+            last = i->first;
+            rjson::set(new_entry, "StreamArn", *last);
+            rjson::set(new_entry, "StreamLabel", rjson::from_string(ks_name + "." + cf_name));
+            rjson::set(new_entry, "TableName", rjson::from_string(table_name(*s)));
+            rjson::push_back(streams, std::move(new_entry));
+
+            --limit;
+        }
+    }
+
+    rjson::set(ret, "Streams", std::move(streams));
+
+    if (last) {
+        rjson::set(ret, "LastEvaluatedStreamArn", *last);
+    }
+
+    return make_ready_future<executor::request_return_type>(make_jsonable(std::move(ret)));
+}
+
+
+}

--- a/alternator/streams.cc
+++ b/alternator/streams.cc
@@ -546,5 +546,10 @@ future<executor::request_return_type> executor::get_shard_iterator(client_state&
     return make_ready_future<executor::request_return_type>(make_jsonable(std::move(ret)));
 }
 
+future<executor::request_return_type> executor::get_records(client_state& client_state, service_permit permit, rjson::value request) {
+    auto ret = rjson::empty_object();
+    return make_ready_future<executor::request_return_type>(make_jsonable(std::move(ret)));
+}
+
 
 }

--- a/cdc/cdc_extension.hh
+++ b/cdc/cdc_extension.hh
@@ -33,6 +33,7 @@ public:
     static constexpr auto NAME = "cdc";
 
     cdc_extension() = default;
+    cdc_extension(const options& opts) : _cdc_options(opts) {}
     explicit cdc_extension(std::map<sstring, sstring> tags) : _cdc_options(std::move(tags)) {}
     explicit cdc_extension(const bytes& b) : _cdc_options(cdc_extension::deserialize(b)) {}
     explicit cdc_extension(const sstring& s) {

--- a/cdc/cdc_options.hh
+++ b/cdc/cdc_options.hh
@@ -44,6 +44,11 @@ public:
     bool postimage() const { return _postimage; }
     int ttl() const { return _ttl; }
 
+    void enabled(bool b) { _enabled = b; }
+    void preimage(bool b) { _preimage = b; }
+    void postimage(bool b) { _postimage = b; }
+    void ttl(int v) { _ttl = v; }
+
     bool operator==(const options& o) const;
     bool operator!=(const options& o) const;
 };

--- a/cdc/generation.cc
+++ b/cdc/generation.cc
@@ -76,6 +76,10 @@ bool stream_id::operator==(const stream_id& o) const {
     return _value == o._value;
 }
 
+bool stream_id::operator!=(const stream_id& o) const {
+    return !(*this == o);
+}
+
 bool stream_id::operator<(const stream_id& o) const {
     return _value < o._value;
 }
@@ -122,6 +126,14 @@ bool topology_description::operator==(const topology_description& o) const {
 const std::vector<token_range_description>& topology_description::entries() const {
     return _entries;
 }
+
+topology_description_version::topology_description_version(std::vector<token_range_description> entries
+    , db_clock::time_point timestamp
+    , std::optional<db_clock::time_point> expired)
+    : topology_description(std::move(entries))
+    , _timestamp(timestamp)
+    , _expired(expired)
+{}
 
 static stream_id create_stream_id(dht::token t) {
     static thread_local std::mt19937_64 rand_gen(std::random_device().operator()());

--- a/cdc/generation.hh
+++ b/cdc/generation.hh
@@ -69,6 +69,7 @@ public:
     stream_id(bytes);
     bool is_set() const;
     bool operator==(const stream_id&) const;
+    bool operator!=(const stream_id&) const;
     bool operator<(const stream_id&) const;
 
     int64_t first() const;
@@ -111,6 +112,20 @@ public:
     bool operator==(const topology_description&) const;
 
     const std::vector<token_range_description>& entries() const;
+};
+
+class topology_description_version : public topology_description {
+    db_clock::time_point _timestamp;
+    std::optional<db_clock::time_point> _expired;
+public:
+    topology_description_version(std::vector<token_range_description> entries, db_clock::time_point, std::optional<db_clock::time_point> = {});
+
+    auto expired() const {
+        return _expired;
+    }
+    db_clock::time_point timestamp() const {
+        return _timestamp;
+    }
 };
 
 /* Should be called when we're restarting and we noticed that we didn't save any streams timestamp in our local tables,

--- a/cdc/log.hh
+++ b/cdc/log.hh
@@ -129,6 +129,9 @@ enum class operation : int8_t {
 };
 
 bool is_log_for_some_table(const sstring& ks_name, const std::string_view& table_name);
+schema_ptr get_base_table(const database&, const sstring& ks_name, const std::string_view& table_name);
+schema_ptr get_base_table(const database&, const schema&);
+
 seastar::sstring log_name(const seastar::sstring& table_name);
 seastar::sstring log_data_column_name(std::string_view column_name);
 seastar::sstring log_meta_column_name(std::string_view column_name);

--- a/configure.py
+++ b/configure.py
@@ -841,6 +841,7 @@ alternator = [
        'alternator/conditions.cc',
        'alternator/rjson.cc',
        'alternator/auth.cc',
+       'alternator/streams.cc',
 ]
 
 redis = [

--- a/db/system_distributed_keyspace.hh
+++ b/db/system_distributed_keyspace.hh
@@ -38,6 +38,7 @@ class query_processor;
 namespace cdc {
     class stream_id;
     class topology_description;
+    class topology_description_version;
 } // namespace cdc
 
 namespace db {
@@ -80,6 +81,8 @@ public:
     future<> create_cdc_desc(db_clock::time_point streams_ts, const std::vector<cdc::stream_id>&, context);
     future<> expire_cdc_desc(db_clock::time_point streams_ts, db_clock::time_point expiration_time, context);
     future<bool> cdc_desc_exists(db_clock::time_point streams_ts, context);
+
+    future<std::vector<cdc::topology_description_version>> cdc_get_topology_descriptions(context);
 };
 
 }

--- a/main.cc
+++ b/main.cc
@@ -1096,7 +1096,7 @@ int main(int ac, char** av) {
                 smp_service_group_config c;
                 c.max_nonlocal_requests = 5000;
                 smp_service_group ssg = create_smp_service_group(c).get0();
-                alternator_executor.start(std::ref(proxy), std::ref(mm), ssg).get();
+                alternator_executor.start(std::ref(proxy), std::ref(mm), std::ref(sys_dist_ks), ssg).get();
                 alternator_server.start(std::ref(alternator_executor)).get();
                 std::optional<uint16_t> alternator_port;
                 if (cfg->alternator_port()) {

--- a/schema.cc
+++ b/schema.cc
@@ -1174,6 +1174,11 @@ const cdc::options& schema::cdc_options() const {
     return default_cdc_options;
 }
 
+schema_builder& schema_builder::with_cdc_options(const cdc::options& opts) {
+    add_extension(cdc::cdc_extension::NAME, ::make_shared<cdc::cdc_extension>(opts));
+    return *this;
+}
+
 schema_ptr schema_builder::build(compact_storage cp) {
     return with(cp).build();
 }

--- a/schema_builder.hh
+++ b/schema_builder.hh
@@ -194,6 +194,10 @@ public:
         _raw._extensions = std::move(exts);
         return *this;
     }
+    schema_builder& add_extension(const sstring& name, ::shared_ptr<schema_extension> ext) {
+        _raw._extensions[name] = std::move(ext);
+        return *this;
+    }
     const schema::extensions_map& get_extensions() const {
         return _raw._extensions;
     }
@@ -275,6 +279,8 @@ public:
     schema_builder& without_index(const sstring& name);
     schema_builder& without_indexes();
 
+    schema_builder& with_cdc_options(const cdc::options&);
+    
     default_names get_default_names() const {
         return default_names(_raw);
     }

--- a/test/alternator/conftest.py
+++ b/test/alternator/conftest.py
@@ -82,6 +82,25 @@ def dynamodb(request):
             region_name='us-east-1', aws_access_key_id='alternator', aws_secret_access_key='secret_pass',
             config=botocore.client.Config(retries={"max_attempts": 3}))
 
+@pytest.fixture(scope="session")
+def dynamostreams(request):
+    if request.config.getoption('aws'):
+        return boto3.client('dynamodbstreams')
+    else:
+        # Even though we connect to the local installation, Boto3 still
+        # requires us to specify dummy region and credential parameters,
+        # otherwise the user is forced to properly configure ~/.aws even
+        # for local runs.
+        if request.config.getoption('url') != None:
+            local_url = request.config.getoption('url')
+        else:
+            local_url = 'https://localhost:8043' if request.config.getoption('https') else 'http://localhost:8000'
+        # Disable verifying in order to be able to use self-signed TLS certificates
+        verify = not request.config.getoption('https')
+        return boto3.client('dynamodbstreams', endpoint_url=local_url, verify=verify,
+            region_name='us-east-1', aws_access_key_id='alternator', aws_secret_access_key='secret_pass',
+            config=botocore.client.Config(retries={"max_attempts": 3}))
+
 # "test_table" fixture: Create and return a temporary table to be used in tests
 # that need a table to work on. The table is automatically deleted at the end.
 # We use scope="session" so that all tests will reuse the same client object.

--- a/test/alternator/test_streams.py
+++ b/test/alternator/test_streams.py
@@ -1,0 +1,82 @@
+# Copyright 2019 ScyllaDB
+#
+# This file is part of Scylla.
+#
+# Scylla is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Scylla is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
+
+# Tests for stream operations: ListStreams, DescribeStream, GetShardIterator.
+
+import pytest
+from botocore.exceptions import ClientError
+from util import list_tables, test_table_name, create_test_table, random_string
+
+stream_types = [ 'OLD_IMAGE', 'NEW_IMAGE', 'KEYS_ONLY', 'NEW_AND_OLD_IMAGES']
+
+def test_list_streams(dynamodb, dynamostreams):
+    for type in stream_types:
+        table = create_test_table(dynamodb,
+            StreamSpecification={'StreamEnabled': True, 'StreamViewType': type},
+            KeySchema=[{ 'AttributeName': 'p', 'KeyType': 'HASH' }],
+            AttributeDefinitions=[{ 'AttributeName': 'p', 'AttributeType': 'S' }]);
+
+        streams = dynamostreams.list_streams(TableName=table.name)
+
+        assert streams
+        assert streams.get('LastEvaluatedStreamArn')
+        assert streams.get('Streams')
+                    
+        table.delete();
+
+def test_describe_stream(dynamodb, dynamostreams):
+    table = create_test_table(dynamodb,
+        StreamSpecification={'StreamEnabled': True, 'StreamViewType': 'KEYS_ONLY'},
+        KeySchema=[{ 'AttributeName': 'p', 'KeyType': 'HASH' }],
+        AttributeDefinitions=[{ 'AttributeName': 'p', 'AttributeType': 'S' }]);
+
+    streams = dynamostreams.list_streams(TableName=table.name)
+    arn = streams['Streams'][0]['StreamArn'];
+
+    desc = dynamostreams.describe_stream(StreamArn=arn)
+
+    print(desc)
+
+    assert desc;
+    assert desc.get('StreamDescription')
+    assert desc['StreamDescription']['StreamArn'] == arn
+    assert desc['StreamDescription']['StreamStatus'] != 'DISABLED'
+    assert desc['StreamDescription']['StreamViewType'] == 'KEYS_ONLY'
+    assert desc['StreamDescription']['TableName'] == table.name
+    assert desc['StreamDescription'].get('Shards')
+    assert desc['StreamDescription']['Shards'][0].get('ShardId')
+    assert desc['StreamDescription']['Shards'][0].get('SequenceNumberRange')
+    assert desc['StreamDescription']['Shards'][0]['SequenceNumberRange'].get('StartingSequenceNumber')
+
+def test_get_shard_iterator(dynamodb, dynamostreams):
+    table = create_test_table(dynamodb,
+        StreamSpecification={'StreamEnabled': True, 'StreamViewType': 'KEYS_ONLY'},
+        KeySchema=[{ 'AttributeName': 'p', 'KeyType': 'HASH' }],
+        AttributeDefinitions=[{ 'AttributeName': 'p', 'AttributeType': 'S' }]);
+
+    streams = dynamostreams.list_streams(TableName=table.name)
+    arn = streams['Streams'][0]['StreamArn'];
+    desc = dynamostreams.describe_stream(StreamArn=arn)
+
+    shard_id = desc['StreamDescription']['Shards'][0]['ShardId'];
+    seq = desc['StreamDescription']['Shards'][0]['SequenceNumberRange']['StartingSequenceNumber'];
+
+    for type in ['AT_SEQUENCE_NUMBER', 'AFTER_SEQUENCE_NUMBER', 'TRIM_HORIZON', 'LATEST']: 
+        iter = dynamostreams.get_shard_iterator(
+            StreamArn=arn, ShardId=shard_id, ShardIteratorType=type, SequenceNumber=seq
+        )
+        assert iter.get('ShardIterator')

--- a/test/alternator/test_table.py
+++ b/test/alternator/test_table.py
@@ -253,13 +253,13 @@ def test_table_streams_off(dynamodb):
     # Unfortunately, boto3 doesn't allow us to pass StreamSpecification=None.
     # This is what we had in issue #5796.
 
-@pytest.mark.xfail(reason="streams not yet implemented")
 def test_table_streams_on(dynamodb):
-    table = create_test_table(dynamodb,
-        StreamSpecification={'StreamEnabled': True, 'StreamViewType': 'OLD_IMAGE'},
-        KeySchema=[{ 'AttributeName': 'p', 'KeyType': 'HASH' }],
-        AttributeDefinitions=[{ 'AttributeName': 'p', 'AttributeType': 'S' }]);
-    table.delete();
+    for type in [ 'OLD_IMAGE', 'NEW_IMAGE', 'KEYS_ONLY', 'NEW_AND_OLD_IMAGES']:
+        table = create_test_table(dynamodb,
+            StreamSpecification={'StreamEnabled': True, 'StreamViewType': type},
+            KeySchema=[{ 'AttributeName': 'p', 'KeyType': 'HASH' }],
+            AttributeDefinitions=[{ 'AttributeName': 'p', 'AttributeType': 'S' }]);
+        table.delete();
 
 # Our first implementation had a special column name called "attrs" where
 # we stored a map for all non-key columns. If the user tried to name one


### PR DESCRIPTION
Posted for comments and initial review. Probably don't merge.

Implementation of `ListStreams` `DescribeStream` and `GetShardIterator` + empty `GetRecords`. I.e. does not actual get any CDC data out, but...

Note that this uses "naive" mapping cdc stream to dynamo "shard", i.e. 1:1. See comment on `describe_stream` for some musings on possible way to reduce the amount of shards reported. 