### PR TITLE
Allow our users to shoot themselves in their feet.

### DIFF
--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -626,6 +626,19 @@ void storage_service::join_token_ring(int delay) {
         }
     }
 
+
+    if (!is_auto_bootstrap()) {
+        slogger.warn("auto_bootstrap set to \"off\". This causes UNDEFINED BEHAVIOR. YOU MAY LOSE DATA.");
+    }
+
+    if (!db::system_keyspace::bootstrap_complete() && _gossiper.get_seeds().count(get_broadcast_address())) {
+        slogger.warn("Bootstrapping node marked as seed (present in the seed list)."
+                     " This can only be done for the very first node in a new cluster."
+                     " If this is not the first node, YOU MAY LOSE DATA."
+                     " Bootstrapping new nodes into an existing cluster as seeds"
+                     " causes UNDEFINED BEHAVIOR. DO NOT EVER do that.");
+    }
+
     slogger.debug("Setting tokens to {}", _bootstrap_tokens);
     // This node must know about its chosen tokens before other nodes do
     // since they may start sending writes to this node after it gossips status = NORMAL.


### PR DESCRIPTION
Allow a node to join without bootstrapping, even if it couldn't contact other nodes.

Print a BIG WARNING saying that you should never join nodes without
bootstrapping (by marking it as a seed or using auto_bootstrap=off).

Only the very first node should (must) be joined as a seed.

If you want to have more seeds, first join them using the only supported
way (i.e. bootstrap them), and only AFTER they have bootstrapped, change
their configuration to include them in the seed list.

Does not fix, but closes https://github.com/scylladb/scylla/issues/6005. Read the discussion: it's enlightening.
See https://github.com/scylladb/scylla-docs/issues/2647 for the correct procedure of joining a node.

Reverts https://github.com/scylladb/scylla/commit/7cb6ac33f5f54cae665cecd3a90428eb52d424e3.