### PR TITLE
db,views: unify time points used for update generation

### DIFF
--- a/database.hh
+++ b/database.hh
@@ -1017,7 +1017,8 @@ public:
     future<> populate_views(
             std::vector<view_ptr>,
             dht::token base_token,
-            flat_mutation_reader&&);
+            flat_mutation_reader&&,
+            gc_clock::time_point);
 
     reader_concurrency_semaphore& read_concurrency_semaphore() {
         return *_config.read_concurrency_semaphore;
@@ -1030,12 +1031,13 @@ public:
 private:
     future<row_locker::lock_holder> do_push_view_replica_updates(const schema_ptr& s, mutation&& m, db::timeout_clock::time_point timeout, mutation_source&& source,
             tracing::trace_state_ptr tr_state, const io_priority_class& io_priority, query::partition_slice::option_set custom_opts) const;
-    std::vector<view_ptr> affected_views(const schema_ptr& base, const mutation& update) const;
+    std::vector<view_ptr> affected_views(const schema_ptr& base, const mutation& update, gc_clock::time_point now) const;
     future<> generate_and_propagate_view_updates(const schema_ptr& base,
             std::vector<view_ptr>&& views,
             mutation&& m,
             flat_mutation_reader_opt existings,
-            tracing::trace_state_ptr tr_state) const;
+            tracing::trace_state_ptr tr_state,
+            gc_clock::time_point now) const;
 
     mutable row_locker _row_locker;
     future<row_locker::lock_holder> local_base_lock(


### PR DESCRIPTION
Until now, view updates were generated with a bunch of random
time points, because the interface was not adjusted for passing
a single time point. The time points were used to determine
whether cells were alive (e.g. because of TTL), so it's better
to unify the process:
1. when generating view updates from user writes, a single time point
   is used for the whole operation
2. when generating view updates via the view building process,
   a single time point is used for each build step

NOTE: I don't see any reliable and deterministic way of writing
      test scenarios which trigger problems with the old code.
      After #6488 is resolved and error injection is integrated
      into view.cc, tests can be added.

Fixes #6429
Tests: unit(dev)