### PR TITLE
CDC: Don't split collection tombstone away from base update

### DIFF
--- a/cdc/log.cc
+++ b/cdc/log.cc
@@ -547,6 +547,12 @@ api::timestamp_type find_timestamp(const schema& s, const mutation& m) {
                     [&] (collection_mutation_view_description mview) {
                 t = mview.tomb.timestamp;
                 if (t != api::missing_timestamp) {
+                    // A collection tombstone with timestamp T can be created with:
+                    // UPDATE ks.t USING TIMESTAMP T + 1 SET X = null WHERE ...
+                    // where X is a non-atomic column.
+                    // This is, among others, the reason why we show it in the CDC log
+                    // with cdc$time using timestamp T + 1 instead of T.
+                    t += 1;
                     return stop_iteration::yes;
                 }
 
@@ -742,17 +748,79 @@ private:
     const column_definition& _op_col;
     const column_definition& _ttl_col;
     ttl_opt _cdc_ttl_opt;
+
     /**
-     * #6070
-     * When mutation splitting was added, non-atomic column assignments were broken
-     * into two invocation of transform. This means the second (actual data assignment)
-     * does not know about the tombstone in first one -> postimage is created as if 
-     * we were _adding_ to the collection, not replacing it. 
+     * #6070, #6084
+     * Non-atomic column assignments which use a TTL are broken into two invocations
+     * of `transform`, such as in the following example:
+     * CREATE TABLE t (a int PRIMARY KEY, b map<int, int>) WITH cdc = {'enabled':true};
+     * UPDATE t USING TTL 5 SET b = {0:0} WHERE a = 0;
+     *
+     * The above UPDATE creates a tombstone and a (0, 0) cell; because tombstones don't have the notion
+     * of a TTL, we split the UPDATE into two separate changes (represented as two separate delta rows in the log,
+     * resulting in two invocations of `transform`): one change for the deletion with no TTL,
+     * and one change for adding cells with TTL = 5.
+     *
+     * In other words, we use the fact that
+     * UPDATE t USING TTL 5 SET b = {0:0} WHERE a = 0;
+     * is equivalent to
+     * BEGIN UNLOGGED BATCH
+     *  UPDATE t SET b = null WHERE a = 0;
+     *  UPDATE t USING TTL 5 SET b = b + {0:0} WHERE a = 0;
+     * APPLY BATCH;
+     * (the mutations are the same in both cases),
+     * and perform a separate `transform` call for each statement in the batch.
+     *
+     * An assignment also happens when an INSERT statement is used as follows:
+     * INSERT INTO t (a, b) VALUES (0, {0:0}) USING TTL 5;
      * 
-     * Not pretty, but to handle this we use the knowledge that we always get 
-     * invoked in timestamp order -> tombstone first, then assign.
-     * So we simply keep track of non-atomic columns deleted across calls 
-     * and filter out preimage data post this.
+     * This will be split into three separate changes (three invocations of `transform`):
+     * 1. One with TTL = 5 for the row marker (introduces by the INSERT), indicating that a row was inserted.
+     * 2. One without a TTL for the tombstone, indicating that the collection was cleared.
+     * 3. One with TTL = 5 for the addition of cell (0, 0), indicating that the collection
+     *    was extended by a new key/value.
+     *
+     * Why do we need three changes and not two, like in the UPDATE case?
+     * The tombstone needs to be a separate change because it doesn't have a TTL,
+     * so only the row marker change could potentially be merged with the cell change (1 and 3 above).
+     * However, we cannot do that: the row marker change is of INSERT type (cdc$operation == cdc::operation::insert),
+     * but there is no way to create a statement that
+     * - has a row marker,
+     * - adds cells to a collection,
+     * - but *doesn't* add a tombstone for this collection.
+     * INSERT statements that modify collections *always* add tombstones.
+     *
+     * Merging the row marker with the cell addition would result in such an impossible statement.
+     *
+     * Instead, we observe that
+     * INSERT INTO t (a, b) VALUES (0, {0:0}) USING TTL 5;
+     * is equivalent to
+     * BEGIN UNLOGGED BATCH
+     *  INSERT INTO t (a) VALUES (0) USING TTL 5;
+     *  UPDATE t SET b = null WHERE a = 0;
+     *  UPDATE t USING TTL 5 SET b = b + {0:0} WHERE a = 0;
+     * APPLY BATCH;
+     * and perform a separate `transform` call for each statement in the batch.
+     *
+     * Unfortunately, due to splitting, the cell addition call (b + b {0:0}) does not know about the tombstone.
+     * If it was performed independently from the tombstone call, it would create a wrong post-image:
+     * the post-image would look as if the previous cells still existed.
+     * For example, suppose that b was equal to {1:1} before the above statement was performed.
+     * Then the final post-image for b for above statement/batch would be {0:0, 1:1}, when instead it should be {0:0}.
+     *
+     * To handle this we use the fact that
+     * 1. changes without a TTL are treated as if TTL = 0,
+     * 2. `transform` is invoked in order of increasing TTLs,
+     * and we maintain state between `transform` invocations (`_non_atomic_column_deletes`).
+     *
+     * Thus, the tombstone call will happen *before* the cell addition call,
+     * so the cell addition call will know that there previously was a tombstone
+     * and create a correct post-image.
+     *
+     * Furthermore, `transform` calls for INSERT changes (i.e. with a row marker)
+     * happen before `transform` calls for UPDATE changes, so in the case of an INSERT
+     * which modifies a collection column as above, the row marker call will happen first;
+     * its post-image will still show {1:1} for the collection column. Good.
      */
     std::unordered_set<const column_definition*> _non_atomic_column_deletes;
 

--- a/test/boost/cdc_test.cc
+++ b/test/boost/cdc_test.cc
@@ -913,16 +913,11 @@ SEASTAR_THREAD_TEST_CASE(test_map_logging) {
             { 
                 "UPDATE ks.tbl set val = { 'apa':'ko' } where pk=1 and pk2=11 and ck=111",
                 data_value::make_null(map_type), // no previous value
-                { // two deltas: one sets the column to null, the other adds cells
-                    {
-                        data_value::make_null(map_type), // no added cells
-                        data_value::make_null(map_keys_type), // no deleted cells
-                        true // setting entire column to null -> expect delete marker
-                    },
+                {
                     {
                         ::make_map_value(map_type, { { "apa", "ko" } }), // one added cell
                         data_value::make_null(map_keys_type), // no deleted cells
-                        // just adding cells -> no delete marker
+                        true // setting entire column to null -> expect delete marker
                     }
                 },
                 ::make_map_value(map_type, { { "apa", "ko" } })
@@ -974,15 +969,11 @@ SEASTAR_THREAD_TEST_CASE(test_map_logging) {
             { 
                 "UPDATE ks.tbl set val = { 'bolla':'trolla', 'kork':'skruv' } where pk=1 and pk2=11 and ck=111",
                 ::make_map_value(map_type, { { "ola", "kokos" } }), 
-                { // two deltas: one sets the column to null, the other adds cells
-                    {
-                        data_value::make_null(map_type), // no added cells
-                        data_value::make_null(map_keys_type), // no deleted cells
-                        true // setting entire column to null -> expect delete marker
-                    },
+                {
                     {
                         ::make_map_value(map_type, { { "bolla", "trolla" }, { "kork", "skruv" } }),
                         data_value::make_null(map_keys_type),
+                        true // setting entire column to null -> expect delete marker
                     }
                 },
                 ::make_map_value(map_type, { { "bolla", "trolla" }, { "kork", "skruv" } })
@@ -1005,16 +996,11 @@ SEASTAR_THREAD_TEST_CASE(test_set_logging) {
             {
                 "UPDATE ks.tbl set val = { 'apa', 'ko' } where pk=1 and pk2=11 and ck=111",
                 data_value::make_null(set_type), // no previous value
-                { // two deltas: one sets the column to null, the other adds cells
-                    {
-                        data_value::make_null(set_type), // no added cells
-                        data_value::make_null(set_type), // no deleted cells
-                        true // setting entire column to null -> expect delete marker
-                    },
+                {
                     {
                         ::make_set_value(set_type, { "apa", "ko" }),
-                        data_value::make_null(set_type), // no deleted cells
-                        // just adding cells -> no delete marker
+                        data_value::make_null(set_type),
+                        true // setting entire column to null -> expect delete marker
                     }
                 },
                 ::make_set_value(set_type, { "apa", "ko" })
@@ -1055,14 +1041,11 @@ SEASTAR_THREAD_TEST_CASE(test_set_logging) {
             {
                 "UPDATE ks.tbl set val = { 'bolla', 'trolla' } where pk=1 and pk2=11 and ck=111",
                 ::make_set_value(set_type, { "ko", "nils", "ninja" }),
-                { // two deltas: one sets the column to null, the other adds cells
+                {
                     {
-                        data_value::make_null(set_type), // no added cells
-                        data_value::make_null(set_type), // no deleted cells
-                        true // setting entire column to null -> expect delete marker
-                    },                    {
                         ::make_set_value(set_type, { "bolla", "trolla" }),
-                        data_value::make_null(set_type), // no deleted cells
+                        data_value::make_null(set_type),
+                        true // setting entire column to null -> expect delete marker
                     }
                 },
                 ::make_set_value(set_type, { "bolla", "trolla" })
@@ -1086,16 +1069,11 @@ SEASTAR_THREAD_TEST_CASE(test_list_logging) {
             {
                 "UPDATE ks.tbl set val = [ 'apa', 'ko' ] where pk=1 and pk2=11 and ck=111",
                 data_value::make_null(list_type), 
-                { // two deltas: one sets the column to null, the other adds cells
-                    {
-                        data_value::make_null(list_type), // no added cells
-                        data_value::make_null(uuids_type), // no deleted cells
-                        true // setting entire column to null -> expect delete marker
-                    },
+                {
                     {
                         ::make_list_value(list_type, { "apa", "ko" }),
-                        data_value::make_null(uuids_type), // no added cells
-                        // just adding cells -> no delete marker
+                        data_value::make_null(uuids_type),
+                        true // setting entire column to null -> expect delete marker
                     }
                 },
                 ::make_list_value(list_type, { "apa", "ko" })
@@ -1147,15 +1125,11 @@ SEASTAR_THREAD_TEST_CASE(test_list_logging) {
             {
                 "UPDATE ks.tbl set val = ['bolla', 'trolla'] where pk=1 and pk2=11 and ck=111",
                 ::make_list_value(list_type, { "babar", "ko", "ninja", "mission" }),
-                { // two deltas: one sets the column to null, the other adds cells
-                    {
-                        data_value::make_null(list_type), // no added cells
-                        data_value::make_null(uuids_type), // no deleted cells
-                        true // setting entire column to null -> expect delete marker
-                    },
+                {
                     {
                         ::make_list_value(list_type, { "bolla", "trolla" }),
                         data_value::make_null(uuids_type),
+                        true // setting entire column to null -> expect delete marker
                     }
                 },
                 ::make_list_value(list_type, { "bolla", "trolla" })
@@ -1201,16 +1175,11 @@ SEASTAR_THREAD_TEST_CASE(test_udt_logging) {
             {
                 "UPDATE ks.tbl set val = { field0: 12, field1: 'ko' } where pk=1 and pk2=11 and ck=111",
                 data_value::make_null(udt_type), 
-                { // two deltas: one sets the column to null, the other adds cells
-                    {
-                        data_value::make_null(udt_type), // no added cells
-                        data_value::make_null(index_set_type), // no deleted cells
-                        true // setting entire column to null -> expect delete marker
-                    },
+                {
                     {
                         make_tuple(12, "ko"),
                         data_value::make_null(index_set_type), // no deleted cells
-                        // just adding cells -> no delete marker
+                        true // setting entire column to null -> expect delete marker
                     }
                 },
                 make_tuple(12, "ko")
@@ -1251,16 +1220,11 @@ SEASTAR_THREAD_TEST_CASE(test_udt_logging) {
             {
                 "UPDATE ks.tbl set val = { field0: 1, field1: 'bolla' } where pk=1 and pk2=11 and ck=111",
                 make_tuple(13, std::nullopt),
-                { // two deltas: one sets the column to null, the other adds cells
-                    {
-                        data_value::make_null(udt_type), // no added cells
-                        data_value::make_null(index_set_type), // no deleted cells
-                        true // setting entire column to null -> expect delete marker
-                    },
+                {
                     {
                         make_tuple(1, "bolla"),
-                        data_value::make_null(index_set_type), // no deleted cells
-                        // just adding cells -> no delete marker
+                        data_value::make_null(index_set_type),
+                        true // setting entire column to null -> expect delete marker
                     }
                 },
                 make_tuple(1, "bolla")
@@ -1425,6 +1389,38 @@ SEASTAR_THREAD_TEST_CASE(test_change_splitting) {
             BOOST_REQUIRE_EQUAL(expected, result);
         }
 
+        cquery_nofail(e, format("update ks.t using timestamp {} set m = null where pk = 0 and ck = 2;", now));
+        {
+            auto result = get_result(
+                {m_type, boolean_type, keys_type, timeuuid_type},
+                "select m, \"cdc$deleted_m\", \"cdc$deleted_elements_m\", \"cdc$time\""
+                " from ks.t_scylla_cdc_log where pk = 0 and ck = 2 allow filtering");
+            BOOST_REQUIRE_EQUAL(result.size(), 1);
+            BOOST_REQUIRE_EQUAL(result[0].size(), 4);
+
+            result[0][3] = utils::UUID_gen::micros_timestamp(value_cast<utils::UUID>(result[0][3]));
+            std::vector<std::vector<data_value>> expected = {
+                {map_null, true, keys_null, now}
+            };
+            BOOST_REQUIRE_EQUAL(expected, result);
+        }
+
+        cquery_nofail(e, format("update ks.t using timestamp {} set m = {{1:1}} where pk = 0 and ck = 3;", now));
+        {
+            auto result = get_result(
+                {m_type, boolean_type, keys_type, timeuuid_type},
+                "select m, \"cdc$deleted_m\", \"cdc$deleted_elements_m\", \"cdc$time\""
+                " from ks.t_scylla_cdc_log where pk = 0 and ck = 3 allow filtering");
+            BOOST_REQUIRE_EQUAL(result.size(), 1);
+            BOOST_REQUIRE_EQUAL(result[0].size(), 4);
+
+            result[0][3] = utils::UUID_gen::micros_timestamp(value_cast<utils::UUID>(result[0][3]));
+            std::vector<std::vector<data_value>> expected = {
+                {vmap({{1,1}}), true, keys_null, now}
+            };
+            BOOST_REQUIRE_EQUAL(expected, result);
+        }
+
         cquery_nofail(e, format(
             "begin unlogged batch"
             " update ks.t using timestamp {} and ttl 5 set v1 = 5, v2 = null where pk = 0 and ck = 1;"
@@ -1475,41 +1471,30 @@ SEASTAR_THREAD_TEST_CASE(test_change_splitting) {
             " insert into ks.t (pk,ck,v1) values (1,0,1) using timestamp {};"
             " update ks.t using timestamp {} set v2 = 2 where pk = 1 and ck = 0;"
             " insert into ks.t (pk,ck,m) values (1,0,{{3:3}}) using timestamp {};"
+            " insert into ks.t (pk,ck,m) values (1,1,{{4:4}}) using timestamp {} and ttl 5;"
 
             " apply batch;",
-            now, now + 1, now + 2, now + 3, now + 3, now + 4));
+            now, now + 1, now + 2, now + 3, now + 3, now + 4, now + 5));
 
         {
             auto result = get_result(
                 {int32_type, int32_type, int32_type, m_type, boolean_type, oper_type},
                 "select \"cdc$batch_seq_no\", v1, v2, m, \"cdc$deleted_m\", \"cdc$operation\""
                 " from ks.t_scylla_cdc_log where pk = 1 allow filtering");
-            BOOST_REQUIRE_EQUAL(result.size(), 7);
+            BOOST_REQUIRE_EQUAL(result.size(), 9);
+
+            // TODO: It would be nice to check how these things work together with pre/post-images, but maybe in a separate test.
 
             std::vector<std::vector<data_value>> expected = {
                 {int32_t(0), int_null, int_null, map_null, bool_null, oper_ut(cdc::operation::partition_delete)},
                 {int32_t(0), int_null, int_null, map_null, bool_null, oper_ut(cdc::operation::range_delete_start_inclusive)},
                 {int32_t(1), int_null, int_null, map_null, bool_null, oper_ut(cdc::operation::range_delete_end_exclusive)},
                 {int32_t(0), int_null, int_null, map_null, bool_null, oper_ut(cdc::operation::row_delete)},
-
-                // The following sequence of operations:
-                //     insert into ks.t (pk,ck,v1) values (1,0,1) using timestamp T;
-                //     update ks.t using timestamp T set v2 = 2 where pk = 1 and ck = 0;
-                //     insert into ks.t (pk,ck,m) values (1,0,{{3:3}}) using timestamp T + 1;"
-                // is equivalent to the following sequence of operations:
-                //     update ks.t using timestamp T set v1 = 1, v2 = 2, m = null where pk = 1 and ck = 0;
-                //     insert into ks.t (pk,ck) values (1,0) using timestamp T + 1;
-                //     update ks.t using timestamp T + 1 set m = m + {3:3} where pk = 1 and ck = 0;
-                // Explanation:
-                //     1. there are two row markers from the two inserts, but the one with T + 1 timestamp wins;
-                //        therefore we end up with a single T + 1 insert
-                //     2. the second insert (which changes the `m` column) generates a tombstone with timestamp T
-                //        and a {3:3} cell with timestamp T + 1. Thus we merge the tombstone into the T update,
-                //        and we add a T + 1 update to express the addition of the {3:3} cell.
-                //
-                {int32_t(0), int32_t(1), int32_t(2), map_null, true, oper_ut(cdc::operation::update)},
-                {int32_t(0), int_null, int_null, map_null, bool_null, oper_ut(cdc::operation::insert)},
-                {int32_t(1), int_null, int_null, vmap({{3,3}}), bool_null, oper_ut(cdc::operation::update)},
+                {int32_t(0), int32_t(1), int32_t(2), map_null, bool_null, oper_ut(cdc::operation::update)},
+                {int32_t(0), int_null, int_null, vmap({{3,3}}), true, oper_ut(cdc::operation::insert)},
+                {int32_t(0), int_null, int_null, map_null, bool_null, oper_ut(cdc::operation::insert)}, // for ck == 1
+                {int32_t(1), int_null, int_null, map_null, true, oper_ut(cdc::operation::update)},
+                {int32_t(2), int_null, int_null, vmap({{4,4}}), bool_null, oper_ut(cdc::operation::update)},
             };
 
             BOOST_REQUIRE_EQUAL(expected, result);
@@ -1547,14 +1532,31 @@ SEASTAR_THREAD_TEST_CASE(test_change_splitting) {
                 "where pk = 1 allow filtering"
             );
 
-            BOOST_REQUIRE_EQUAL(result.size(), 4);
+            BOOST_REQUIRE_EQUAL(result.size(), 2);
 
             std::vector<std::vector<data_value>> expected = {
-                {int32_t(0), int_null, cs_null, cm_null, true, true, oper_ut(cdc::operation::update)},
-                {int32_t(0), int32_t(3), cs_null, cm_null, bool_null, bool_null, oper_ut(cdc::operation::update)},
-                {int32_t(1), int_null, cs_null, cm_null, bool_null, bool_null, oper_ut(cdc::operation::insert)},
-                {int32_t(2), int_null, cs_value, cm_value, bool_null, bool_null, oper_ut(cdc::operation::update)}
+                {int32_t(0), int_null, cs_null, cm_null, true, true, oper_ut(cdc::operation::insert)},
+                {int32_t(0), int32_t(3), cs_value, cm_value, bool_null, bool_null, oper_ut(cdc::operation::update)},
             };
+        }
+
+        // Splitting cells from INSERT with TTL and multiple collection columns
+        cquery_nofail(e, "create table ks.t3 (pk int primary key, m1 map<int, int>, m2 map<int, int>) with cdc = {'enabled':true}");
+        cquery_nofail(e, format(
+            "insert into ks.t3 (pk, m1, m2) VALUES (0, {{1:1}}, {{2:2}}) using timestamp {} and ttl 5;", now));
+        {
+            auto result = get_result(
+                {m_type, boolean_type, m_type, boolean_type, long_type, oper_type},
+                "select m1, \"cdc$deleted_m1\", m2, \"cdc$deleted_m2\", \"cdc$ttl\", \"cdc$operation\""
+                " from ks.t3_scylla_cdc_log where pk = 0 allow filtering");
+            BOOST_REQUIRE_EQUAL(result.size(), 3);
+
+            std::vector<std::vector<data_value>> expected = {
+                { map_null, bool_null, map_null, bool_null, int64_t(5), oper_ut(cdc::operation::insert) }, // row marker
+                { map_null, true, map_null, true, long_null, oper_ut(cdc::operation::update) }, // deletion of maps
+                { vmap({{1,1}}), bool_null, vmap({{2,2}}), bool_null, int64_t(5), oper_ut(cdc::operation::update) } // addition of cells
+            };
+            BOOST_REQUIRE_EQUAL(expected, result);
         }
     }, mk_cdc_test_config()).get();
 }
@@ -1612,7 +1614,7 @@ SEASTAR_THREAD_TEST_CASE(test_batch_with_row_delete) {
 
         for (size_t idx = 0; idx < expected.size(); ++idx) {
             const auto& er = expected[idx];
-            const auto& r = results[idx + 3]; // We skip first 3 log records because they represent initial insert.
+            const auto& r = results[idx + 1]; // We skip first log record because it represents initial insert.
             BOOST_REQUIRE_EQUAL(deser(int32_type, r[0]), er[0]);
             BOOST_REQUIRE_EQUAL(deser(udt_type, r[1]), er[1]);
             BOOST_REQUIRE_EQUAL(deser(m_type, r[2]), er[2]);


### PR DESCRIPTION
This patch reduces the number of rows in CDC log when collections are inserted or updated.

Suppose we have a table `ks.t` with non-frozen collection column `X`.
The following statement:
`update ks.t using timestamp T set X = null where ...`
creates a tombstone for column `X` **with timestamp `T-1`**.
The following statement:
`update ks.t using timestamp T set X = {cell} where ...`
creates a tombstone for column `X` **with timestamp `T-1`** (same as above) and a cell for column `X` with timestamp `T`.

Because we don't want to split the second update into two log rows, then for any timestamp `T`, **we put collection tombstones with timestamp `T` into the `T+1` bucket** (they will show up in the log with timestamp `T+1`). In particular, if we have both a tombstone and a bunch of cells, such that the timestamps of these cells are the tombstone's timestamp + 1, they end up being put into a single log row (unless cells have TTLs, but that's a different story).
The user can then replay this log entry using an `update` statement with this timestamp.

Unfortunately, there is a small inconsistency. While:
`update ks.t using timestamp T set X = null where ...`
uses timestamp `T-1` for the tombstone,
`delete from ks.t using timestamp T where ...`
**uses timestamp `T`** :(
So if we're given a mutation with collection tombstone with timestamp `T`, what timestamp should we use for the `time` column? If we use `T`, it will be consistent with `delete`, but won't be consistent with `update`. If we use `T+1`, it will be consistent with `update`, but won't be consistent with `delete`. But **we have to choose something**. And the best thing to do is to use `T+1` to be consistent with `update`, because it causes less splitting.
We simply need to document the following for the user: when replaying the log, don't use `delete` statement, use `update` and then `cdc$time` provides you the correct timestamp. If you really want to use `delete` for some reason (you don't need to), you need to adjust the timestamp from `cdc$time` by +1.

Also, `cdc_test` had to be updated in places that relied on former splitting strategy. More tests will come in a separate PR.

Patch co-authored by @kbr- and @jul-stas.
Fixes #6084