### PR TITLE
reloc-pkg: move all files under project name directory

### DIFF
--- a/dist/debian/build_deb.sh
+++ b/dist/debian/build_deb.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-PRODUCT=$(cat SCYLLA-PRODUCT-FILE)
+PRODUCT=$(cat scylla/SCYLLA-PRODUCT-FILE)
 
 . /etc/os-release
 print_usage() {
@@ -45,7 +45,7 @@ pkg_install() {
     fi
 }
 
-if [ ! -e SCYLLA-RELOCATABLE-FILE ]; then
+if [ ! -e scylla/SCYLLA-RELOCATABLE-FILE ]; then
     echo "do not directly execute build_deb.sh, use reloc/build_deb.sh instead."
     exit 1
 fi
@@ -103,11 +103,12 @@ fi
 
 RELOC_PKG_FULLPATH=$(readlink -f $RELOC_PKG)
 RELOC_PKG_BASENAME=$(basename $RELOC_PKG)
-SCYLLA_VERSION=$(cat SCYLLA-VERSION-FILE | sed 's/\.rc/~rc/')
-SCYLLA_RELEASE=$(cat SCYLLA-RELEASE-FILE)
+SCYLLA_VERSION=$(cat scylla/SCYLLA-VERSION-FILE | sed 's/\.rc/~rc/')
+SCYLLA_RELEASE=$(cat scylla/SCYLLA-RELEASE-FILE)
 
 ln -fv $RELOC_PKG_FULLPATH ../$PRODUCT-server_$SCYLLA_VERSION-$SCYLLA_RELEASE.orig.tar.gz
 
+cp -al scylla/debian debian
 if $DIST; then
     export DEB_BUILD_OPTIONS="housekeeping"
 fi

--- a/dist/debian/debian/rules
+++ b/dist/debian/debian/rules
@@ -20,9 +20,9 @@ override_dh_auto_clean:
 
 override_dh_auto_install:
 	dh_auto_install
-	./install.sh --packaging --root "$(CURDIR)/debian/tmp" $(install_arg) --sysconfdir "/etc/default"
+	cd scylla; ./install.sh --packaging --root "$(CURDIR)/debian/tmp" $(install_arg) --sysconfdir "/etc/default"
 	# don't use default sysconfig file, use Debian version
-	cp dist/debian/sysconfig/scylla-housekeeping $(CURDIR)/debian/tmp/etc/default/
+	cp scylla/dist/debian/sysconfig/scylla-housekeeping $(CURDIR)/debian/tmp/etc/default/
 
 override_dh_installinit:
 ifeq ($(product),scylla)

--- a/dist/debian/python3/build_deb.sh
+++ b/dist/debian/python3/build_deb.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-PRODUCT=$(cat SCYLLA-PRODUCT-FILE)
+PRODUCT=$(cat scylla-python3/SCYLLA-PRODUCT-FILE)
 
 . /etc/os-release
 print_usage() {
@@ -40,7 +40,7 @@ pkg_install() {
     fi
 }
 
-if [ ! -e SCYLLA-RELOCATABLE-FILE ]; then
+if [ ! -e scylla-python3/SCYLLA-RELOCATABLE-FILE ]; then
     echo "do not directly execute build_deb.sh, use reloc/build_deb.sh instead."
     exit 1
 fi
@@ -119,12 +119,12 @@ if [ -z "$TARGET" ]; then
 fi
 RELOC_PKG_FULLPATH=$(readlink -f $RELOC_PKG)
 RELOC_PKG_BASENAME=$(basename $RELOC_PKG)
-SCYLLA_VERSION=$(cat SCYLLA-VERSION-FILE)
-SCYLLA_RELEASE=$(cat SCYLLA-RELEASE-FILE)
+SCYLLA_VERSION=$(cat scylla-python3/SCYLLA-VERSION-FILE)
+SCYLLA_RELEASE=$(cat scylla-python3/SCYLLA-RELEASE-FILE)
 
 ln -fv $RELOC_PKG_FULLPATH ../$PRODUCT-python3_$SCYLLA_VERSION-$SCYLLA_RELEASE.orig.tar.gz
 
-cp -al dist/debian/python3/debian debian
+cp -al scylla-python3/dist/debian/python3/debian debian
 if [ "$PRODUCT" != "scylla" ]; then
     # rename all 'scylla-' prefixed artifacts in the debian folder to have the 
     # product name as a prefix
@@ -132,9 +132,9 @@ if [ "$PRODUCT" != "scylla" ]; then
 fi
 REVISION="1"
 MUSTACHE_DIST="\"debian\": true, \"product\": \"$PRODUCT\", \"$PRODUCT\": true"
-pystache dist/debian/python3/changelog.mustache "{ $MUSTACHE_DIST, \"version\": \"$SCYLLA_VERSION\", \"release\": \"$SCYLLA_RELEASE\", \"revision\": \"$REVISION\", \"codename\": \"$TARGET\" }" > debian/changelog
-pystache dist/debian/python3/rules.mustache "{ $MUSTACHE_DIST }" > debian/rules
-pystache dist/debian/python3/control.mustache "{ $MUSTACHE_DIST }" > debian/control
+pystache scylla-python3/dist/debian/python3/changelog.mustache "{ $MUSTACHE_DIST, \"version\": \"$SCYLLA_VERSION\", \"release\": \"$SCYLLA_RELEASE\", \"revision\": \"$REVISION\", \"codename\": \"$TARGET\" }" > debian/changelog
+pystache scylla-python3/dist/debian/python3/rules.mustache "{ $MUSTACHE_DIST }" > debian/rules
+pystache scylla-python3/dist/debian/python3/control.mustache "{ $MUSTACHE_DIST }" > debian/control
 chmod a+rx debian/rules
 
 debuild -rfakeroot -us -uc

--- a/dist/debian/python3/rules.mustache
+++ b/dist/debian/python3/rules.mustache
@@ -8,7 +8,7 @@ override_dh_auto_build:
 
 override_dh_auto_install:
 	dh_auto_install
-	./install.sh --root "$(CURDIR)/debian/{{product}}-python3"
+	cd scylla-python3; ./install.sh --root "$(CURDIR)/debian/{{product}}-python3"
 
 override_dh_strip:
 

--- a/dist/redhat/python3/python.spec
+++ b/dist/redhat/python3/python.spec
@@ -23,7 +23,7 @@ functionality). All shared libraries needed for the interpreter to
 operate are shipped with it.
 
 %prep
-%setup -q -c
+%setup -n scylla-python3
 
 %install
 ./install.sh --root "$RPM_BUILD_ROOT"

--- a/dist/redhat/scylla.spec
+++ b/dist/redhat/scylla.spec
@@ -44,7 +44,7 @@ This package installs all required packages for ScyllaDB,  including
 %defattr(-,root,root)
 
 %prep
-%setup -c
+%setup -n scylla
 
 %package        server
 Group:          Applications/Databases

--- a/reloc/build_deb.sh
+++ b/reloc/build_deb.sh
@@ -39,4 +39,4 @@ fi
 mkdir -p build/debian/scylla-package
 tar -C build/debian/scylla-package -xpf $RELOC_PKG
 cd build/debian/scylla-package
-exec ./dist/debian/build_deb.sh $OPTS
+exec ./scylla/dist/debian/build_deb.sh $OPTS

--- a/reloc/build_rpm.sh
+++ b/reloc/build_rpm.sh
@@ -52,8 +52,8 @@ RELOC_PKG=$(readlink -f $RELOC_PKG)
 if [[ ! $OPTS =~ --reloc-pkg ]]; then
     OPTS="$OPTS --reloc-pkg $RELOC_PKG"
 fi
-mkdir -p $BUILDDIR/scylla-package
-tar -C $BUILDDIR/scylla-package -xpf $RELOC_PKG SCYLLA-RELOCATABLE-FILE SCYLLA-RELEASE-FILE SCYLLA-VERSION-FILE SCYLLA-PRODUCT-FILE dist/redhat
-cd $BUILDDIR/scylla-package
-echo "Running './dist/redhat/build_rpm.sh $OPTS' under $BUILDDIR/scylla-package directory"
+mkdir -p $BUILDDIR/
+tar -C $BUILDDIR/ -xpf $RELOC_PKG scylla/SCYLLA-RELOCATABLE-FILE scylla/SCYLLA-RELEASE-FILE scylla/SCYLLA-VERSION-FILE scylla/SCYLLA-PRODUCT-FILE scylla/dist/redhat
+cd $BUILDDIR/scylla
+echo "Running './dist/redhat/build_rpm.sh $OPTS' under $BUILDDIR/scylla directory"
 exec ./dist/redhat/build_rpm.sh $OPTS

--- a/reloc/python3/build_deb.sh
+++ b/reloc/python3/build_deb.sh
@@ -34,4 +34,4 @@ fi
 mkdir -p build/debian/scylla-python3-package
 tar -C build/debian/scylla-python3-package -xpf $RELOC_PKG
 cd build/debian/scylla-python3-package
-exec ./dist/debian/python3/build_deb.sh $OPTS
+exec ./scylla-python3/dist/debian/python3/build_deb.sh $OPTS

--- a/reloc/python3/build_rpm.sh
+++ b/reloc/python3/build_rpm.sh
@@ -36,7 +36,7 @@ RELOC_PKG=$(readlink -f $RELOC_PKG)
 if [[ ! $OPTS =~ --reloc-pkg ]]; then
     OPTS="$OPTS --reloc-pkg $RELOC_PKG"
 fi
-mkdir -p $BUILDDIR/scylla-python3-package
-tar -C $BUILDDIR/scylla-python3-package -xpf $RELOC_PKG SCYLLA-RELOCATABLE-FILE SCYLLA-RELEASE-FILE SCYLLA-VERSION-FILE SCYLLA-PRODUCT-FILE dist/redhat/python3
-cd $BUILDDIR/scylla-python3-package
+mkdir -p $BUILDDIR/scylla-python3
+tar -C $BUILDDIR -xpf $RELOC_PKG scylla-python3/SCYLLA-RELOCATABLE-FILE scylla-python3/SCYLLA-RELEASE-FILE scylla-python3/SCYLLA-VERSION-FILE scylla-python3/SCYLLA-PRODUCT-FILE scylla-python3/dist/redhat/python3
+cd $BUILDDIR/scylla-python3
 exec ./dist/redhat/python3/build_rpm.sh $OPTS


### PR DESCRIPTION
*This is reopened version of  https://github.com/scylladb/scylla/pull/6327, since it dequeued*

To make unified relocatable package easily, we may want to merge tarballs to single tarball like this:
zcat *.tar.gz | gzip -c > scylla-unified.tar.xz
But it's not possible with current relocatable package format, since there are multiple files conflicts, install.sh, SCYLLA-*-FILE, dist/, README.md, etc..

To support this, we need to archive everything in the directory when building relocatable package.

This is modifying relocatable package format, we need to provide a way to
detect the format version.
To do this, we added a new file ".relocatable_package_version" on the top of the
archive, and set version number "2" to the file.

This also requires scylla-ccm change, here is a PR to do this:
https://github.com/scylladb/scylla-ccm/pull/236

Fixes #6315