### PR TITLE
priority_manager: merge streaming_read and streaming_write classes to one class

### DIFF
--- a/database.cc
+++ b/database.cc
@@ -2047,7 +2047,7 @@ flat_mutation_reader make_multishard_streaming_reader(distributed<database>& db,
     });
     auto&& full_slice = schema->full_slice();
     return make_flat_multi_range_reader(std::move(schema), std::move(ms), std::move(range_generator), std::move(full_slice),
-            service::get_local_streaming_read_priority(), {}, mutation_reader::forwarding::no);
+            service::get_local_streaming_priority(), {}, mutation_reader::forwarding::no);
 }
 
 std::ostream& operator<<(std::ostream& os, gc_clock::time_point tp) {

--- a/db/hints/manager.cc
+++ b/db/hints/manager.cc
@@ -742,7 +742,7 @@ bool manager::end_point_hints_manager::sender::send_one_file(const sstring& fnam
     lw_shared_ptr<send_one_file_ctx> ctx_ptr = make_lw_shared<send_one_file_ctx>(_last_schema_ver_to_column_mapping);
 
     try {
-        commitlog::read_log_file(fname, manager::FILENAME_PREFIX, service::get_local_streaming_read_priority(), [this, secs_since_file_mod, &fname, ctx_ptr] (commitlog::buffer_and_replay_position buf_rp) mutable {
+        commitlog::read_log_file(fname, manager::FILENAME_PREFIX, service::get_local_streaming_priority(), [this, secs_since_file_mod, &fname, ctx_ptr] (commitlog::buffer_and_replay_position buf_rp) mutable {
             auto&& [buf, rp] = buf_rp;
             // Check that we can still send the next hint. Don't try to send it if the destination host
             // is DOWN or if we have already failed to send some of the previous hints.

--- a/db/view/view_update_generator.cc
+++ b/db/view/view_update_generator.cc
@@ -58,7 +58,7 @@ future<> view_update_generator::start() {
                             std::move(ssts),
                             query::full_partition_range,
                             s->full_slice(),
-                            service::get_local_streaming_read_priority(),
+                            service::get_local_streaming_priority(),
                             nullptr,
                             ::streamed_mutation::forwarding::no,
                             ::mutation_reader::forwarding::no);

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -505,7 +505,7 @@ public:
                         [t = std::move(t), use_view_update_path, adjusted_estimated_partitions] (flat_mutation_reader reader) {
                     sstables::shared_sstable sst = use_view_update_path ? t->make_streaming_staging_sstable() : t->make_streaming_sstable_for_write();
                     schema_ptr s = reader.schema();
-                    auto& pc = service::get_local_streaming_write_priority();
+                    auto& pc = service::get_local_streaming_priority();
                     return sst->write_components(std::move(reader), std::max(1ul, adjusted_estimated_partitions), s,
                                                  t->get_sstables_manager().configure_writer(),
                                                  encoding_stats{}, pc).then([sst] {

--- a/service/priority_manager.cc
+++ b/service/priority_manager.cc
@@ -29,8 +29,7 @@ priority_manager& get_local_priority_manager() {
 priority_manager::priority_manager()
     : _commitlog_priority(engine().register_one_priority_class("commitlog", 1000))
     , _mt_flush_priority(engine().register_one_priority_class("memtable_flush", 1000))
-    , _stream_read_priority(engine().register_one_priority_class("streaming_read", 200))
-    , _stream_write_priority(engine().register_one_priority_class("streaming_write", 200))
+    , _streaming_priority(engine().register_one_priority_class("streaming", 200))
     , _sstable_query_read(engine().register_one_priority_class("query", 1000))
     , _compaction_priority(engine().register_one_priority_class("compaction", 1000))
 {}

--- a/service/priority_manager.hh
+++ b/service/priority_manager.hh
@@ -28,8 +28,7 @@ namespace service {
 class priority_manager {
     ::io_priority_class _commitlog_priority;
     ::io_priority_class _mt_flush_priority;
-    ::io_priority_class _stream_read_priority;
-    ::io_priority_class _stream_write_priority;
+    ::io_priority_class _streaming_priority;
     ::io_priority_class _sstable_query_read;
     ::io_priority_class _compaction_priority;
 
@@ -45,13 +44,8 @@ public:
     }
 
     const ::io_priority_class&
-    streaming_read_priority() const {
-        return _stream_read_priority;
-    }
-
-    const ::io_priority_class&
-    streaming_write_priority() const {
-        return _stream_write_priority;
+    streaming_priority() const {
+        return _streaming_priority;
     }
 
     const ::io_priority_class&
@@ -79,13 +73,8 @@ get_local_memtable_flush_priority() {
 }
 
 const inline ::io_priority_class&
-get_local_streaming_read_priority() {
-    return get_local_priority_manager().streaming_read_priority();
-}
-
-const inline ::io_priority_class&
-get_local_streaming_write_priority() {
-    return get_local_priority_manager().streaming_write_priority();
+get_local_streaming_priority() {
+    return get_local_priority_manager().streaming_priority();
 }
 
 const inline ::io_priority_class&

--- a/streaming/stream_session.cc
+++ b/streaming/stream_session.cc
@@ -228,7 +228,7 @@ void stream_session::init_messaging_service_handler() {
                                         [cf = std::move(cf), adjusted_estimated_partitions, use_view_update_path] (flat_mutation_reader reader) {
                                     sstables::shared_sstable sst = use_view_update_path ? cf->make_streaming_staging_sstable() : cf->make_streaming_sstable_for_write();
                                     schema_ptr s = reader.schema();
-                                    auto& pc = service::get_local_streaming_write_priority();
+                                    auto& pc = service::get_local_streaming_priority();
 
                                     return sst->write_components(std::move(reader), std::max(1ul, adjusted_estimated_partitions), s,
                                                                  cf->get_sstables_manager().configure_writer(),

--- a/test/boost/view_build_test.cc
+++ b/test/boost/view_build_test.cc
@@ -432,7 +432,7 @@ SEASTAR_TEST_CASE(test_view_update_generator) {
 
         auto sst = t->make_streaming_staging_sstable();
         sstables::sstable_writer_config sst_cfg = test_sstables_manager.configure_writer();
-        auto& pc = service::get_local_streaming_write_priority();
+        auto& pc = service::get_local_streaming_priority();
 
         sst->write_components(flat_mutation_reader_from_mutations({m}), 1ul, s, sst_cfg, {}, pc).get();
         sst->open_data().get();


### PR DESCRIPTION

Streaming is handled by just once group for CPU scheduling, so
separating it into read and write classes for I/O is artificial, and
inflates the resources we allow for streaming if both reads and writes
happen at the same time.

Merge both classes into one class ("streaming") and adjust callers. The
merged class has 200 shares, so it reduces streaming bandwidth if both
directions are active at the same time (which is rare; I think it only
happens in view building).