### PR TITLE
scylla_util.py: replace platform.dist() with distro package

### DIFF
--- a/dist/common/scripts/scylla_util.py
+++ b/dist/common/scripts/scylla_util.py
@@ -19,7 +19,6 @@ import configparser
 import io
 import logging
 import os
-import platform
 import re
 import shlex
 import shutil
@@ -32,6 +31,9 @@ import yaml
 import psutil
 import sys
 from pathlib import Path
+
+import distro
+
 
 def scriptsdir_p():
     p = Path(sys.argv[0]).resolve()
@@ -434,11 +436,11 @@ def current_umask():
     return current
 
 def dist_name():
-    return platform.dist()[0]
+    return distro.name()
 
 
 def dist_ver():
-    return platform.dist()[1]
+    return distro.version()
 
 
 def is_unused_disk(dev):

--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -77,6 +77,7 @@ fedora_packages=(
     python3-colorama
     python3-boto3
     python3-pytest
+    python3-distro
     dnf-utils
     pigz
     net-tools

--- a/reloc/python3/build_reloc.sh
+++ b/reloc/python3/build_reloc.sh
@@ -32,5 +32,5 @@ PYVER=$(python3 -V | cut -d' ' -f2)
 echo "$PYVER" > build/python3/SCYLLA-VERSION-FILE
 ln -fv build/SCYLLA-RELEASE-FILE build/python3/SCYLLA-RELEASE-FILE
 
-PACKAGES="python3-pyyaml python3-urwid python3-pyparsing python3-requests python3-pyudev python3-setuptools python3-psutil"
+PACKAGES="python3-pyyaml python3-urwid python3-pyparsing python3-requests python3-pyudev python3-setuptools python3-psutil python3-distro"
 ./scripts/create-relocatable-package-python3.py --output "$TARGET" $PACKAGES


### PR DESCRIPTION
since dbuild was updated to fedora-32, hence to python3.8
`platform.dist()` is deprecated, and need to be replaced

Fixes: #6501