### PR TITLE
tests: avoid exhausting random_device entropy

### DIFF
--- a/test/boost/dynamic_bitset_test.cc
+++ b/test/boost/dynamic_bitset_test.cc
@@ -117,7 +117,7 @@ BOOST_AUTO_TEST_CASE(test_find_last_prev) {
     BOOST_REQUIRE_EQUAL(i, 174);
 }
 
-static void test_random_ops(size_t size, std::random_device& rd ) {
+static void test_random_ops(size_t size, std::default_random_engine& re ) {
     // BOOST_REQUIRE and friends are very slow, just use regular throws instead.
     auto require = [] (bool b) {
         if (!b) {
@@ -139,9 +139,9 @@ static void test_random_ops(size_t size, std::random_device& rd ) {
     };
     size_t limit = std::log(size) * 1000;
     for (size_t i = 0; i != limit; ++i) {
-        if (global_op_dist(rd) == 0) {
+        if (global_op_dist(re) == 0) {
             // perform a global operation
-            switch (global_op_selection_dist(rd)) {
+            switch (global_op_selection_dist(re)) {
             case 0:
                 for (size_t j = 0; j != size; ++j) {
                     db.clear(j);
@@ -157,28 +157,28 @@ static void test_random_ops(size_t size, std::random_device& rd ) {
             }
         } else {
             // perform a single-bit operation
-            switch (single_op_selection_dist(rd)) {
+            switch (single_op_selection_dist(re)) {
             case 0: {
-                auto bit = bit_dist(rd);
+                auto bit = bit_dist(re);
                 db.set(bit);
                 bv[bit] = true;
                 break;
             }
             case 1: {
-                auto bit = bit_dist(rd);
+                auto bit = bit_dist(re);
                 db.clear(bit);
                 bv[bit] = false;
                 break;
             }
             case 2: {
-                auto bit = bit_dist(rd);
+                auto bit = bit_dist(re);
                 bool dbb = db.test(bit);
                 bool bvb = bv[bit];
                 require_equal(dbb, bvb);
                 break;
             }
             case 3: {
-                auto bit = bit_dist(rd);
+                auto bit = bit_dist(re);
                 auto next = db.find_next_set(bit);
                 if (next == db.npos) {
                     require(!boost::algorithm::any_of(boost::irange<size_t>(bit+1, size), is_set));
@@ -215,7 +215,8 @@ static void test_random_ops(size_t size, std::random_device& rd ) {
 
 BOOST_AUTO_TEST_CASE(test_random_operations) {
     std::random_device rd;
+    std::default_random_engine re(rd());
     for (auto size : { 1, 63, 64, 65, 2000, 4096-65, 4096-64, 4096-63, 4096-1, 4096, 4096+1, 262144-1, 262144, 262144+1}) {
-        BOOST_CHECK_NO_THROW(test_random_ops(size, rd));
+        BOOST_CHECK_NO_THROW(test_random_ops(size, re));
     }
 }

--- a/test/boost/loading_cache_test.cc
+++ b/test/boost/loading_cache_test.cc
@@ -46,8 +46,8 @@
 /// \param upper bound of the random value range
 /// \return The uniformly distributed random integer from the [0, \ref max) range.
 static int rand_int(int max) {
-    std::random_device rd;     // only used once to initialise (seed) engine
-    std::mt19937 rng(rd());    // random-number engine used (Mersenne-Twister in this case)
+    static thread_local std::random_device rd;     // only used once to initialise (seed) engine
+    static thread_local std::mt19937 rng(rd());    // random-number engine used (Mersenne-Twister in this case)
     std::uniform_int_distribution<int> uni(0, max - 1); // guaranteed unbiased
     return uni(rng);
 }

--- a/test/boost/querier_cache_test.cc
+++ b/test/boost/querier_cache_test.cc
@@ -572,14 +572,15 @@ SEASTAR_THREAD_TEST_CASE(test_time_based_cache_eviction) {
 
 sstring make_string_blob(size_t size) {
     const char* const letters = "abcdefghijklmnoqprsuvwxyz";
-    std::random_device rd;
+    static thread_local std::random_device rd;
+    static thread_local std::default_random_engine re(rd());
     std::uniform_int_distribution<size_t> dist(0, 25);
 
     sstring s;
     s.resize(size);
 
     for (size_t i = 0; i < size; ++i) {
-        s[i] = letters[dist(rd)];
+        s[i] = letters[dist(re)];
     }
 
     return s;

--- a/test/unit/lsa_sync_eviction_test.cc
+++ b/test/unit/lsa_sync_eviction_test.cc
@@ -67,7 +67,8 @@ int main(int argc, char** argv) {
                 }
 
                 // Evict in random order to stress more
-                std::shuffle(refs.begin(), refs.end(), std::random_device());
+                std::random_device rd;
+                std::shuffle(refs.begin(), refs.end(), std::default_random_engine(rd()));
                 r.make_evictable([&] {
                     return with_allocator(r.allocator(), [&] {
                         if (refs.empty()) {


### PR DESCRIPTION
In several tests we were calling random_device::operator() in a tight loop. This is a slow operation, and in gcc 10 can fail if called too frequently due to a bug [1].

Change to use a random_engine instead, seeded once from the random_device.

Tests: unit (dev)

[1] https://gcc.gnu.org/bugzilla/show_bug.cgi?id=94087