### PR TITLE
redis: don't include storage_proxy.hh in commands.cc

### DIFF
--- a/redis/abstract_command.hh
+++ b/redis/abstract_command.hh
@@ -28,12 +28,15 @@
 #include "db/consistency_level_type.hh"
 #include "db/timeout_clock.hh"
 #include "db/system_keyspace.hh"
-#include "service/storage_proxy.hh"
 #include "keys.hh"
 #include "timestamp.hh"
 #include <unordered_map>
 
 class service_permit;
+
+namespace service {
+class storage_proxy;
+}
 
 namespace redis {
 

--- a/redis/commands.cc
+++ b/redis/commands.cc
@@ -25,7 +25,6 @@
 #include "redis/reply.hh"
 #include "types.hh"
 #include "service_permit.hh"
-#include "service/storage_proxy.hh"
 #include "service/client_state.hh"
 #include "redis/options.hh"
 #include "redis/query_utils.hh"


### PR DESCRIPTION
Use a forward declaration instead.

Tracker issue: https://github.com/scylladb/scylla/issues/6523.