### PR TITLE
dist/debian/python3: drop dependency on pystache

### DIFF
--- a/dist/debian/python3/changelog.template
+++ b/dist/debian/python3/changelog.template
@@ -1,4 +1,4 @@
-{{product}}-python3 ({{version}}-{{release}}-{{revision}}) {{codename}}; urgency=medium
+%{product}-python3 (%{version}-%{release}-%{revision}) %{codename}; urgency=medium
 
   * Initial release.
 

--- a/dist/debian/python3/control.template
+++ b/dist/debian/python3/control.template
@@ -1,4 +1,4 @@
-Source: {{product}}-python3
+Source: %{product}-python3
 Maintainer: Takuya ASADA <syuu@scylladb.com>
 Homepage: http://scylladb.com
 Section: python
@@ -7,7 +7,7 @@ X-Python3-Version: >= 3.4
 Standards-Version: 3.9.5
 Rules-Requires-Root: no
 
-Package: {{product}}-python3
+Package: %{product}-python3
 Architecture: amd64
 Description: A standalone python3 interpreter that can be moved around different Linux machines
  This is a self-contained python interpreter that can be moved around

--- a/dist/debian/python3/debian/rules
+++ b/dist/debian/python3/debian/rules
@@ -1,6 +1,10 @@
 #!/usr/bin/make -f
 
+include /usr/share/dpkg/pkg-info.mk
+
 export PYBUILD_DISABLE=1
+
+product := $(subst -python3,,$(DEB_SOURCE))
 
 override_dh_auto_configure:
 
@@ -8,7 +12,7 @@ override_dh_auto_build:
 
 override_dh_auto_install:
 	dh_auto_install
-	cd scylla-python3; ./install.sh --root "$(CURDIR)/debian/{{product}}-python3"
+	cd scylla-python3; ./install.sh --root "$(CURDIR)/debian/${product}-python3"
 
 override_dh_strip:
 
@@ -18,7 +22,7 @@ override_dh_shlibdeps:
 
 override_dh_fixperms:
 	dh_fixperms
-	chmod 755 $(CURDIR)/debian/{{product}}-python3/opt/scylladb/python3/libexec/ld.so
+	chmod 755 $(CURDIR)/debian/${product}-python3/opt/scylladb/python3/libexec/ld.so
 
 override_dh_strip_nondeterminism:
 

--- a/dist/debian/python3/debian_files_gen.py
+++ b/dist/debian/python3/debian_files_gen.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2020 ScyllaDB
+#
+
+#
+# This file is part of Scylla.
+#
+# Scylla is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Scylla is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+import string
+import os
+import glob
+import shutil
+
+class DebianFilesTemplate(string.Template):
+    delimiter = '%'
+
+scriptdir = os.path.dirname(__file__)
+
+with open(os.path.join(scriptdir, 'changelog.template')) as f:
+    changelog_template = f.read()
+
+with open(os.path.join(scriptdir, 'control.template')) as f:
+    control_template = f.read()
+
+with open('build/SCYLLA-PRODUCT-FILE') as f:
+    product = f.read().strip()
+
+with open('build/python3/SCYLLA-VERSION-FILE') as f:
+    version = f.read().strip()
+
+with open('build/python3/SCYLLA-RELEASE-FILE') as f:
+    release = f.read().strip()
+
+shutil.rmtree('build/debian/python3/debian', ignore_errors=True)
+shutil.copytree('dist/debian/python3/debian', 'build/debian/python3/debian')
+
+if product != 'scylla':
+    for p in glob.glob('build/debian/python3/debian/scylla-*'):
+        shutil.move(p, p.replace('scylla-', '{}-'.format(product)))
+
+s = DebianFilesTemplate(changelog_template)
+changelog_applied = s.substitute(product=product, version=version, release=release, revision='1', codename='stable')
+
+s = DebianFilesTemplate(control_template)
+control_applied = s.substitute(product=product)
+
+with open('build/debian/python3/debian/changelog', 'w') as f:
+    f.write(changelog_applied)
+
+with open('build/debian/python3/debian/control', 'w') as f:
+    f.write(control_applied)
+

--- a/reloc/python3/build_reloc.sh
+++ b/reloc/python3/build_reloc.sh
@@ -31,6 +31,7 @@ mkdir -p build/python3
 PYVER=$(python3 -V | cut -d' ' -f2)
 echo "$PYVER" > build/python3/SCYLLA-VERSION-FILE
 ln -fv build/SCYLLA-RELEASE-FILE build/python3/SCYLLA-RELEASE-FILE
+./dist/debian/python3/debian_files_gen.py
 
 PACKAGES="python3-pyyaml python3-urwid python3-pyparsing python3-requests python3-pyudev python3-setuptools python3-psutil python3-distro"
 ./scripts/create-relocatable-package-python3.py --output "$TARGET" $PACKAGES

--- a/scripts/create-relocatable-package-python3.py
+++ b/scripts/create-relocatable-package-python3.py
@@ -267,6 +267,7 @@ ar.reloc_add('build/python3/SCYLLA-RELEASE-FILE', arcname='SCYLLA-RELEASE-FILE')
 ar.reloc_add('build/python3/SCYLLA-VERSION-FILE', arcname='SCYLLA-VERSION-FILE')
 ar.reloc_add('build/SCYLLA-PRODUCT-FILE', arcname='SCYLLA-PRODUCT-FILE')
 ar.reloc_add('python3/install.sh', arcname='install.sh')
+ar.reloc_add('build/debian/python3/debian', arcname='debian')
 for p in ['pyhton3-libs'] + packages:
     pdir = pathlib.Path('/usr/share/licenses/{}/'.format(p))
     if pdir.exists():


### PR DESCRIPTION
Same as 287d6e5, we need to drop pystache from package build script
since Fedora 32 dropped it.