### PR TITLE
install.sh: support calling install.sh from other directory

### DIFF
--- a/dist/debian/debian/rules
+++ b/dist/debian/debian/rules
@@ -20,7 +20,7 @@ override_dh_auto_clean:
 
 override_dh_auto_install:
 	dh_auto_install
-	cd scylla; ./install.sh --packaging --root "$(CURDIR)/debian/tmp" $(install_arg) --sysconfdir "/etc/default"
+	./scylla/install.sh --packaging --root "$(CURDIR)/debian/tmp" $(install_arg) --sysconfdir "/etc/default"
 	# don't use default sysconfig file, use Debian version
 	cp scylla/dist/debian/sysconfig/scylla-housekeeping $(CURDIR)/debian/tmp/etc/default/
 

--- a/install.sh
+++ b/install.sh
@@ -51,7 +51,7 @@ upgrade=false
 while [ $# -gt 0 ]; do
     case "$1" in
         "--root")
-            root="$2"
+            root="$(realpath "$2")"
             shift 2
             ;;
         "--prefix")
@@ -166,6 +166,9 @@ installconfig() {
         install "-m$perm" "$src" -Dt "$dest"
     fi
 }
+
+# change directory to the package's root directory
+cd "$(dirname "$0")"
 
 if [ -z "$prefix" ]; then
     if $nonroot; then


### PR DESCRIPTION
On .deb package with new relocatable package format, all files moved to
under scylla/ directory.
So we need to call ./scylla/install.sh on debian/rules, but it does not work
correctly, since install.sh does not support calling from other directory.

To support this, we need to changedir to scylla top directory before
copying files.