### PR TITLE
fix(scylla_prepare): missing platform import

### DIFF
--- a/dist/common/scripts/scylla_prepare
+++ b/dist/common/scripts/scylla_prepare
@@ -23,6 +23,8 @@
 import os
 import sys
 import glob
+import platform
+
 from scylla_util import *
 
 def verify_cpu():


### PR DESCRIPTION
as part of eabcb31503eb9896abeeaefe49cd548012dca001 `import platform`
was removed from scylla_utils.py

seem like we missed it's usage in scylla_prepare script