### PR TITLE
reloc: don't build anything in build_reloc.sh

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1412,8 +1412,6 @@ with open(buildfile_tmp, 'w') as f:
         rule copy
             command = cp $in $out
             description = COPY $out
-        rule package
-            command = scripts/create-relocatable-package.py --mode $mode $out
         ''').format(**globals()))
     for mode in build_modes:
         modeval = modes[mode]
@@ -1654,9 +1652,6 @@ with open(buildfile_tmp, 'w') as f:
         f.write(textwrap.dedent('''\
             build build/{mode}/iotune: copy build/{mode}/seastar/apps/iotune/iotune
             ''').format(**locals()))
-        f.write('build build/{mode}/scylla-package.tar.gz: package build/{mode}/scylla build/{mode}/iotune build/SCYLLA-RELEASE-FILE build/SCYLLA-VERSION-FILE build/debian/debian | always\n'.format(**locals()))
-        f.write('  pool = submodule_pool\n')
-        f.write('  mode = {mode}\n'.format(**locals()))
         f.write('rule libdeflate.{mode}\n'.format(**locals()))
         f.write('  command = make -C libdeflate BUILD_DIR=../build/{mode}/libdeflate/ CFLAGS="{libdeflate_cflags}" CC={args.cc} ../build/{mode}/libdeflate//libdeflate.a\n'.format(**locals()))
         f.write('build build/{mode}/libdeflate/libdeflate.a: libdeflate.{mode}\n'.format(**locals()))
@@ -1697,12 +1692,6 @@ with open(buildfile_tmp, 'w') as f:
         ''').format(modes_list=' '.join(default_modes), **globals()))
     f.write(textwrap.dedent('''\
         build always: phony
-        rule scylla_version_gen
-            command = ./SCYLLA-VERSION-GEN
-        build build/SCYLLA-RELEASE-FILE build/SCYLLA-VERSION-FILE: scylla_version_gen
-        rule debian_files_gen
-            command = ./dist/debian/debian_files_gen.py
-        build build/debian/debian: debian_files_gen | always
         ''').format(modes_list=' '.join(build_modes), **globals()))
 
 os.rename(buildfile_tmp, buildfile)

--- a/reloc/build_reloc.sh
+++ b/reloc/build_reloc.sh
@@ -2,56 +2,21 @@
 
 . /etc/os-release
 
-COMMON_FLAGS="--enable-dpdk --cflags=-ffile-prefix-map=$PWD=."
-
 DEFAULT_MODE="release"
 
 print_usage() {
     echo "Usage: build_reloc.sh [OPTION]..."
     echo ""
-    echo "  --configure-flags FLAGS specify extra build flags passed to 'configure.py' (common: '$COMMON_FLAGS')"
     echo "  --mode MODE             specify build mode (default: '$DEFAULT_MODE')"
-    echo "  --jobs JOBS             specify number of jobs"
-    echo "  --clean                 clean build directory"
-    echo "  --compiler PATH         C++ compiler path"
-    echo "  --c-compiler PATH       C compiler path"
     exit 1
 }
 
-FLAGS=""
 MODE="$DEFAULT_MODE"
-JOBS=
-CLEAN=
-COMPILER=
-CCOMPILER=
 while [ $# -gt 0 ]; do
     case "$1" in
-        "--configure-flags")
-            FLAGS=$2
-            shift 2
-            ;;
         "--mode")
             MODE=$2
             shift 2
-            ;;
-        "--jobs")
-            JOBS="-j$2"
-            shift 2
-            ;;
-        "--clean")
-            CLEAN=yes
-            shift 1
-            ;;
-        "--compiler")
-            COMPILER=$2
-            shift 2
-            ;;
-        "--c-compiler")
-            CCOMPILER=$2
-            shift 2
-            ;;
-        "--nodeps")
-            shift 1
             ;;
         *)
             print_usage
@@ -59,44 +24,27 @@ while [ $# -gt 0 ]; do
     esac
 done
 
-FLAGS="$COMMON_FLAGS $FLAGS"
-
 if [ ! -e reloc/build_reloc.sh ]; then
     echo "run build_reloc.sh in top of scylla dir"
     exit 1
 fi
 
-if [ "$CLEAN" = "yes" ]; then
-    rm -rf build
-fi
-
-if [ -f build/$MODE/scylla-package.tar.gz ]; then
-    rm build/$MODE/scylla-package.tar.gz
-fi
-
-NINJA=$(which ninja-build) &&:
-if [ -z "$NINJA" ]; then
-    NINJA=$(which ninja) &&:
-fi
-if [ -z "$NINJA" ]; then
-    echo "ninja not found."
+if [ ! -e build/$MODE/scylla ] || [ ! -e build/$MODE/iotune ]; then
+    echo "run ./configure.py && ninja-build before running build_reloc.sh"
     exit 1
 fi
 
-FLAGS="$FLAGS --mode=$MODE"
-if [ -n "$COMPILER" ]; then
-    FLAGS="$FLAGS --compiler $COMPILER"
-fi
-if [ -n "$CCOMPILER" ]; then
-    FLAGS="$FLAGS --c-compiler $CCOMPILER"
-fi
-echo "Configuring with flags: '$FLAGS' ..."
-./configure.py $FLAGS
-python3 -m compileall ./dist/common/scripts/ ./seastar/scripts/perftune.py ./tools/scyllatop
-$NINJA $JOBS build/$MODE/scylla-package.tar.gz
 BUILD_ID_END=$(readelf -SW build/$MODE/scylla | perl -ne '/.note.gnu.build-id *NOTE *[a-f,0-9]* *([a-f,0-9]*) *([a-f,0-9]*)/ && print ((hex $1) + (hex $2))')
 if (($BUILD_ID_END > 4096))
 then
     echo "build-id is not in the first page. It ends at offset $BUILD_ID_END"
     exit 1
 fi
+
+if [ ! -e build/SCYLLA-RELEASE-FILE ] || [ ! -e build/SCYLLA-VERSION-FILE ]; then
+    ./SCYLLA-VERSION-GEN
+fi
+
+python3 -m compileall ./dist/common/scripts/ ./seastar/scripts/perftune.py ./tools/scyllatop
+./dist/debian/debian_files_gen.py
+./scripts/create-relocatable-package.py --mode $MODE build/$MODE/scylla-package.tar.gz


### PR DESCRIPTION
Remove configure.py and ninja from build_reloc.sh, let it done by user.

Fixes #6477

We require to run following commit after the commit:
```
./install-dependencies.sh
./configure.py --mode release
ninja-build
./reloc/build_reloc.sh
```
