### PR TITLE
api: Command to check and repair cdc streams

### DIFF
--- a/api/api-doc/storage_service.json
+++ b/api/api-doc/storage_service.json
@@ -512,6 +512,21 @@
          ]
       },
       {
+         "path":"/storage_service/cdc_streams_check_and_repair",
+         "operations":[
+            {
+               "method":"POST",
+               "summary":"Checks that CDC streams reflect current cluster topology and regenerates them if not.",
+               "type":"void",
+               "nickname":"cdc_streams_check_and_repair",
+               "produces":[
+                  "application/json"
+               ],
+               "parameters":[]
+            }
+         ]
+      },
+      {
          "path":"/storage_service/snapshots",
          "operations":[
             {

--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -42,6 +42,8 @@
 #include "database.hh"
 #include "db/extensions.hh"
 
+extern logging::logger apilog;
+
 namespace api {
 
 namespace ss = httpd::storage_service_json;
@@ -230,6 +232,11 @@ void set_storage_service(http_context& ctx, routes& r) {
         auto keyspace = validate_keyspace(ctx, req.param);
         return container_to_vec(service::get_local_storage_service().get_natural_endpoints(keyspace, req.get_query_param("cf"),
                 req.get_query_param("key")));
+    });
+
+    ss::cdc_streams_check_and_repair.set(r, [&ctx] (std::unique_ptr<request> req) {
+        // TODO(JS): regenerate streams
+        return make_ready_future<json::json_return_type>(json_void());
     });
 
     ss::force_keyspace_compaction.set(r, [&ctx](std::unique_ptr<request> req) {

--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -42,8 +42,6 @@
 #include "database.hh"
 #include "db/extensions.hh"
 
-extern logging::logger apilog;
-
 namespace api {
 
 namespace ss = httpd::storage_service_json;
@@ -235,8 +233,9 @@ void set_storage_service(http_context& ctx, routes& r) {
     });
 
     ss::cdc_streams_check_and_repair.set(r, [&ctx] (std::unique_ptr<request> req) {
-        // TODO(JS): regenerate streams
-        return make_ready_future<json::json_return_type>(json_void());
+        return service::get_local_storage_service().check_and_repair_cdc_streams().then([] {
+            return make_ready_future<json::json_return_type>(json_void());
+        });
     });
 
     ss::force_keyspace_compaction.set(r, [&ctx](std::unique_ptr<request> req) {

--- a/cdc/generation.cc
+++ b/cdc/generation.cc
@@ -190,12 +190,7 @@ public:
         , _bootstrap_tokens(bootstrap_tokens)
         , _token_metadata(token_metadata)
         , _gossiper(gossiper)
-    {
-        if (_bootstrap_tokens.empty()) {
-            throw std::runtime_error(
-                    "cdc: bootstrap tokens is empty in generate_topology_description");
-        }
-    }
+    {}
 
     /*
      * Generate a set of CDC stream identifiers such that for each shard
@@ -257,8 +252,6 @@ db_clock::time_point make_new_cdc_generation(
         db::system_distributed_keyspace& sys_dist_ks,
         std::chrono::milliseconds ring_delay,
         bool for_testing) {
-    assert(!bootstrap_tokens.empty());
-
     auto gen = topology_description_generator(cfg, bootstrap_tokens, tm, g).generate();
 
     // Begin the race.

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -558,6 +558,9 @@ private:
      */
     void scan_cdc_generations();
 
+public:
+    future<> check_and_repair_cdc_streams();
+private:
     future<> replicate_to_all_cores();
     future<> do_replicate_to_all_cores();
     serialized_action _replicate_action;


### PR DESCRIPTION
The command regenerates streams when:
- generations corresponding to a gossiped timestamp cannot be
fetched from `system_distributed` table,
- or when generation token ranges do not align with token metadata.

In such case the streams are regenerated and new timestamp is
gossiped around. The returned JSON is always empty, regardless of
whether streams needed regeneration or not.

Fixes #6498
Accompanied by: scylladb/scylla-jmx#109, scylladb/scylla-tools-java#172