### PR TITLE
scylla_coredump_setup: fix coredump directory mount

### DIFF
--- a/dist/common/scripts/scylla_coredump_setup
+++ b/dist/common/scripts/scylla_coredump_setup
@@ -78,6 +78,7 @@ WantedBy=multi-user.target
             makedirs('/var/lib/scylla/coredump')
             systemd_unit.reload()
             systemd_unit('var-lib-systemd-coredump.mount').enable()
+            systemd_unit('var-lib-systemd-coredump.mount').start()
         if os.path.exists('/usr/lib/sysctl.d/50-coredump.conf'):
             run('sysctl -p /usr/lib/sysctl.d/50-coredump.conf')
         else:

--- a/dist/common/scripts/scylla_util.py
+++ b/dist/common/scripts/scylla_util.py
@@ -618,7 +618,7 @@ class systemd_unit:
         try:
             run('systemctl {} cat {}'.format(self.ctlparam, unit), silent=True)
         except subprocess.CalledProcessError:
-            raise SystemdException('unit {} not found'.format(unit))
+            raise SystemdException('unit {} is not found or invalid'.format(unit))
         self._unit = unit
 
     def start(self):


### PR DESCRIPTION
Currently in coredump setup, we enabled a systemd mount to mount default coredump directory to /var/lib/scylla/coredump, but we didn't start it. So the coredump will still be saved to default coredump directory before a system reboot, it might touch enospc problem.

One patch started the systemd mount during coredump setup, and make the mount effect.
Another patch improved the error message of systemd unit, it's confused when the unit config is invalid.