### PR TITLE
CDC: Disallowed CDC for tables with counter column(s)

### DIFF
--- a/test/cql/cdc_disallow_cdc_for_counters_test.cql
+++ b/test/cql/cdc_disallow_cdc_for_counters_test.cql
@@ -1,0 +1,7 @@
+create table tb1 (pk int primary key, c1 counter) with cdc = {'enabled': true};
+
+create table tb2 (pk int primary key, c1 counter);
+alter table tb2 with cdc = {'enabled': true};
+
+create table tb3 (pk int primary key) with cdc = {'enabled': true};
+alter table tb3 add (c1 counter);

--- a/test/cql/cdc_disallow_cdc_for_counters_test.result
+++ b/test/cql/cdc_disallow_cdc_for_counters_test.result
@@ -1,0 +1,25 @@
+create table tb1 (pk int primary key, c1 counter) with cdc = {'enabled': true};
+{
+	"message" : "exceptions::invalid_request_exception (Cannot create CDC log for table ks.tb1. Counter support not implemented)",
+	"status" : "error"
+}
+
+create table tb2 (pk int primary key, c1 counter);
+{
+	"status" : "ok"
+}
+alter table tb2 with cdc = {'enabled': true};
+{
+	"message" : "exceptions::invalid_request_exception (Cannot create CDC log for table ks.tb2. Counter support not implemented)",
+	"status" : "error"
+}
+
+create table tb3 (pk int primary key) with cdc = {'enabled': true};
+{
+	"status" : "ok"
+}
+alter table tb3 add (c1 counter);
+{
+	"message" : "exceptions::invalid_request_exception (Cannot create CDC log for table ks.tb3. Counter support not implemented)",
+	"status" : "error"
+}


### PR DESCRIPTION
CDC for counters is unimplemented as of now, therefore any attempt to enable CDC log on counter table needs to be clearly disallowed. This patch does exactly this.

The check whether schema has counter columns is performed in `cdc_service::impl` in:
- `on_before_create_column_family`,
- `on_before_update_column_family`
and, if so, results in `invalid_request_exception` thrown.

Fixes #6553