### PR TITLE
Two-phase truncate

### DIFF
--- a/db/config.cc
+++ b/db/config.cc
@@ -728,6 +728,7 @@ db::config::config(std::shared_ptr<db::extensions> exts)
         "Set to true if the cluster was initially installed from 3.1.0. If it was upgraded from an earlier version,"
         " or installed from a later version, leave this set to false. This adjusts the communication protocol to"
         " work around a bug in Scylla 3.1.0")
+    , enable_write_blocking_during_truncate(this, "enable_write_blocking_during_truncate", liveness::LiveUpdate, value_status::Used, true, "Enables waiting for ongoing writes before performing TRUNCATE operation, and rejecting new writes for the duration of the TRUNCATE operation")
     , enable_user_defined_functions(this, "enable_user_defined_functions", value_status::Used, false,  "Enable user defined functions. You must also set experimental-features=udf")
     , user_defined_function_time_limit_ms(this, "user_defined_function_time_limit_ms", value_status::Used, 10, "The time limit for each UDF invocation")
     , user_defined_function_allocation_limit_bytes(this, "user_defined_function_allocation_limit_bytes", value_status::Used, 1024*1024, "How much memory each UDF invocation can allocate")

--- a/db/config.hh
+++ b/db/config.hh
@@ -305,6 +305,7 @@ public:
     named_value<uint32_t> max_clustering_key_restrictions_per_query;
     named_value<uint64_t> max_memory_for_unlimited_query;
     named_value<bool> enable_3_1_0_compatibility_mode;
+    named_value<bool> enable_write_blocking_during_truncate;
     named_value<bool> enable_user_defined_functions;
     named_value<unsigned> user_defined_function_time_limit_ms;
     named_value<unsigned> user_defined_function_allocation_limit_bytes;

--- a/db/hints/manager.cc
+++ b/db/hints/manager.cc
@@ -187,6 +187,13 @@ bool manager::should_ignore_hints_during_replay_for_table(schema_ptr s) const {
     return _tables_to_ignore_hints_for.count(base_id);
 }
 
+future<> manager::flush_current_hints() {
+    manager_logger.debug("Flushing hints on all endpoint managers");
+    return parallel_for_each(_ep_managers, [] (auto& ep) {
+        return ep.second.flush_current_hints();
+    });
+}
+
 future<> manager::await_in_flight_hints() {
     return parallel_for_each(_ep_managers, [] (auto& ep) {
         return ep.second.await_in_flight_hints();

--- a/db/hints/manager.hh
+++ b/db/hints/manager.hh
@@ -472,6 +472,7 @@ private:
     std::unordered_set<ep_key_type> _eps_with_pending_hints;
     seastar::named_semaphore _drain_lock = {1, named_semaphore_exception_factory{"drain lock"}};
     std::unordered_set<utils::UUID> _tables_blocked_from_generating_hints;
+    std::unordered_set<utils::UUID> _tables_to_ignore_hints_for;
 
 public:
     manager(sstring hints_directory, std::vector<sstring> hinted_dcs, int64_t max_hint_window_ms, resource_manager&res_manager, distributed<database>& db);
@@ -702,6 +703,11 @@ private:
     void forbid_generating_hints_for_table_and_its_views(utils::UUID cf_id);
     void allow_generating_hints_for_table_and_its_views(utils::UUID cf_id);
     bool is_generating_hints_for_schema_allowed(schema_ptr s) const;
+
+    /// \brief When called, hints to the specified table and its views won't be sent, only silently dropped.
+    void start_ignoring_hints_during_replay_for_table_and_its_views(utils::UUID cf_id);
+    void stop_ignoring_hints_during_replay_for_table_and_its_views(utils::UUID cf_id);
+    bool should_ignore_hints_during_replay_for_table(schema_ptr s) const;
 
 public:
     ep_managers_map_type::iterator find_ep_manager(ep_key_type ep_key) noexcept {

--- a/db/hints/manager.hh
+++ b/db/hints/manager.hh
@@ -575,6 +575,12 @@ public:
         _state.set(state::replay_allowed);
     }
 
+    /// \brief Blocks all hint traffic for a given table and its views.
+    ///
+    /// Stops generating and sending hints, flushes currrent hints and waits for in-progress hints.
+    future<> block_hints_for_table_and_its_views(utils::UUID cf_id);
+    void unblock_hints_for_table_and_its_views(utils::UUID cf_id);
+
     /// \brief Rebalance hints segments among all present shards.
     ///
     /// The difference between the number of segments on every two shard will be not greater than 1 after the

--- a/db/hints/manager.hh
+++ b/db/hints/manager.hh
@@ -409,6 +409,12 @@ public:
             return _sender.await_in_flight_hints();
         }
 
+        /// \brief Flushes all hints written so far to the disk.
+        ///  - Repopulates the _segments_to_replay list if needed.
+        ///
+        /// \return Ready future when the procedure above completes.
+        future<> flush_current_hints() noexcept;
+
     private:
         seastar::shared_mutex& file_update_mutex() noexcept {
             return _file_update_mutex;
@@ -422,12 +428,6 @@ public:
         ///
         /// \return A new hints store object.
         future<commitlog> add_store() noexcept;
-
-        /// \brief Flushes all hints written so far to the disk.
-        ///  - Repopulates the _segments_to_replay list if needed.
-        ///
-        /// \return Ready future when the procedure above completes.
-        future<> flush_current_hints() noexcept;
 
         struct stats& shard_stats() {
             return _shard_manager._stats;

--- a/db/hints/manager.hh
+++ b/db/hints/manager.hh
@@ -710,6 +710,9 @@ private:
         return _state.contains(state::replay_allowed);
     }
 
+    /// \brief Flushes all hints written so far on all endpoint managers to the disk.
+    future<> flush_current_hints();
+
     /// \brief Waits until all hints being currently sent are finished.
     future<> await_in_flight_hints();
 

--- a/message/messaging_service.hh
+++ b/message/messaging_service.hh
@@ -140,7 +140,9 @@ enum class messaging_verb : int32_t {
     PAXOS_LEARN = 41,
     HINT_MUTATION = 42,
     PAXOS_PRUNE = 43,
-    LAST = 44,
+    TRUNCATE_PREPARE = 44,
+    TRUNCATE_ACCEPT = 45,
+    LAST = 46,
 };
 
 } // namespace netw
@@ -529,6 +531,16 @@ public:
     future<> unregister_hint_mutation();
     future<> send_hint_mutation(msg_addr id, clock_type::time_point timeout, const frozen_mutation& fm, std::vector<inet_address> forward,
         inet_address reply_to, unsigned shard, response_id_type response_id, std::optional<tracing::trace_info> trace_info = std::nullopt);
+
+    // Wrappers for TRUNCATE_PREPARE
+    void register_truncate_prepare(std::function<future<>(sstring, sstring, bool)>&& func);
+    future<> unregister_truncate_prepare();
+    future<> send_truncate_prepare(msg_addr, std::chrono::milliseconds, sstring ks, sstring cf, bool wait_for_writes_and_reject_new);
+
+    // Wrappers for TRUNCATE_ACCEPT
+    void register_truncate_accept(std::function<future<>(sstring, sstring)>&& func);
+    future<> unregister_truncate_accept();
+    future<> send_truncate_accept(msg_addr, std::chrono::milliseconds, sstring ks, sstring cf);
 
     void foreach_server_connection_stats(std::function<void(const rpc::client_info&, const rpc::stats&)>&& f) const;
 private:

--- a/service/storage_proxy.hh
+++ b/service/storage_proxy.hh
@@ -246,6 +246,17 @@ public:
         bool has_dead_endpoints;
     };
 
+    struct write_admitter {
+    private:
+        bool _truncation_in_progress = false;
+        utils::phased_barrier _write_barrier;
+
+    public:
+        utils::phased_barrier::operation try_admit();
+        future<> notify_start_truncation();
+        void notify_end_truncation();
+    };
+
     const gms::feature_service& features() const { return _features; }
 
     const locator::token_metadata& get_token_metadata() const { return _token_metadata; }
@@ -291,6 +302,7 @@ private:
             lw_shared_ptr<cdc::operation_result_tracker>> _mutate_stage;
     db::view::node_update_backlog& _max_view_update_backlog;
     std::unordered_map<gms::inet_address, view_update_backlog_timestamped> _view_update_backlogs;
+    std::unordered_map<utils::UUID, write_admitter> _write_operation_admitters;
 
     //NOTICE(sarna): This opaque pointer is here just to avoid moving write handler class definitions from .cc to .hh. It's slow path.
     class view_update_handlers_list;

--- a/service/storage_proxy.hh
+++ b/service/storage_proxy.hh
@@ -424,6 +424,8 @@ private:
 
     template<typename Range>
     future<> mutate_counters(Range&& mutations, db::consistency_level cl, tracing::trace_state_ptr tr_state, service_permit permit, clock_type::time_point timeout);
+
+    future<> truncate_on_all_shards(sstring ks_name, sstring cf_name);
 public:
     storage_proxy(distributed<database>& db, config cfg, db::view::node_update_backlog& max_view_update_backlog,
             scheduling_group_key stats_key, gms::feature_service& feat, locator::token_metadata& tokens);

--- a/utils/expiring_session_manager.hh
+++ b/utils/expiring_session_manager.hh
@@ -1,0 +1,214 @@
+/*
+ * Copyright (C) 2020 ScyllaDB
+ */
+
+/*
+ * This file is part of Scylla.
+ *
+ * Scylla is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Scylla is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <seastar/core/future.hh>
+#include <seastar/core/lowres_clock.hh>
+#include <seastar/core/seastar.hh>
+#include <seastar/core/shared_ptr.hh>
+#include <seastar/core/sleep.hh>
+#include <seastar/core/smp.hh>
+#include <seastar/util/noncopyable_function.hh>
+#include "seastarx.hh"
+
+#include <map>
+#include <chrono>
+#include <optional>
+#include <exception>
+
+namespace utils {
+
+
+// Manages sessions, which are indexed by Key.
+// In this context, a session is an object that holds some state (SessionData)
+// which can be manipulated under lock. Session state may be initialized or not,
+// and can be scheduled to be disposed after a specified timeout.
+
+template<typename Key, typename SessionData>
+class expiring_session_manager {
+private:
+    class session_container;
+
+    // session_map must be a collection that does not invalidate other iterators
+    // when inserting/erasing
+    using session_map = std::map<Key, lw_shared_ptr<session_container>>;
+    using session_iterator = typename session_map::iterator;
+    using clock_type = lowres_clock;
+
+public:
+    class session_ref;
+
+    using disposer = noncopyable_function<future<>(SessionData&)>;
+    using operation = noncopyable_function<future<>(session_ref)>;
+
+private:
+    class session_container final : public enable_lw_shared_from_this<session_container> {
+    private:
+        session_map& _map;
+        session_iterator _it;
+        semaphore _operation_semaphore = {1};
+        uint64_t _generation = 0;
+        timer<clock_type> _timeout;
+
+        std::optional<SessionData> _data;
+
+    public:
+        session_container(session_map& map, session_iterator it) : _map(map), _it(it) {}
+
+        session_container(const session_container&) = delete;
+        session_container(session_container&&) = delete;
+        session_container& operator=(const session_container&) = delete;
+        session_container& operator=(session_container&&) = delete;
+
+        template<typename F>
+        future<> serialized(F&& f) {
+            return with_semaphore(_operation_semaphore, 1, std::forward<F>(f));
+        }
+
+        void remove_from_map_if_unused() {
+            if (_it != _map.end() && _operation_semaphore.available_units() == 1 && !bool(_data)) {
+                _map.erase(_it);
+                _it = _map.end();
+            }
+        }
+
+        const Key& get_key() const { return _it->first; }
+        SessionData* get_data() { return &*_data; }
+        bool is_initialized() const { return bool(_data); }
+
+        template<typename... Ts>
+        void initialize_session_data(Ts&&... args) {
+            _data.emplace(std::forward<Ts>(args)...);
+        }
+
+        void dispose_session_data() {
+            if (_timeout.armed()) {
+                _timeout.cancel();
+            }
+            _generation++;
+            _data.reset();
+        }
+
+        void dispose_after_timeout(clock_type::duration d, disposer dispose) {
+            if (!_data) {
+                return;
+            }
+            _generation++;
+            _timeout.set_callback([this, callback_generation = _generation, dispose = std::move(dispose)] () mutable {
+                (void)serialized([this, callback_generation, dispose = std::move(dispose)] () mutable {
+                    if (callback_generation != _generation || !_data) {
+                        return make_ready_future<>();
+                    }
+                    return futurize_apply(std::move(dispose), std::ref(*_data)).then([this] {
+                        dispose_session_data();
+                    });
+                }).finally([this, keep_alive = this->shared_from_this()] {
+                    remove_from_map_if_unused();
+                });
+            });
+            _timeout.rearm(clock_type::now() + d);
+        }
+    };
+
+public:
+    // A reference to a session.
+    //
+    // This proxy structure exists because some of the methods related
+    // to the session_container need to be public, but are unwanted
+    // in the public interface:
+    //    make_lw_shared requires a public constructor,
+    //    enable_lw_shared_from_this requires public inheritance.
+    //
+    // Because constructing session_container or obtaining a shared
+    // pointer to it is undesirable outside expiring_session_manager,
+    // session_ref is introduced which holds a reference to the container
+    // and forwards only some of the methods.
+    class session_ref {
+    private:
+        session_container& _cont;
+
+    private:
+        session_ref(session_container& cont) : _cont(cont) {}
+
+    public:
+        const Key& get_key() const { return _cont.get_key(); }
+        SessionData* get_data() { return _cont.get_data(); }
+        bool is_initialized() const { return _cont.is_initialized(); }
+
+        // Constructs the session data object, using given arguments.
+        template<typename... Ts>
+        void initialize_session_data(Ts&&... args) {
+            _cont.initialize_session_data(std::forward<Ts>(args)...);
+        }
+
+        // Destroys session data object associated with this session.
+        // If dispose after timeout was scheduled, it is canceled.
+        void dispose_session_data() {
+            _cont.dispose_session_data();
+        }
+
+        // Schedules a dispose operation to be run after timeout expires.
+        // Session data is disposed under session lock, therefore it does
+        // not race with do_with_session.
+        // If session data is disposed before timeout is reached, dispose
+        // after timeout is canceled.
+        // If another dispose was scheduled before, it is canceled and the
+        // newer dispose operation is scheduled.
+        // `Dispose` can be a future.
+        void dispose_after_timeout(clock_type::duration d, disposer dispose) {
+            _cont.dispose_after_timeout(d, std::move(dispose));
+        }
+
+        friend class expiring_session_manager<Key, SessionData>;
+    };
+
+private:
+    session_map _sessions;
+
+public:
+    // Performs an operation on a session under lock.
+    // Function f obtains a session_ref object which can be used to manipulate
+    // the session data - create, destroy, modify it, or schedule disposal
+    // after timeout.
+    future<> do_with_session(const Key& key, operation op) {
+        auto it = _sessions.find(key);
+        if (it == _sessions.end()) {
+            it = _sessions.emplace(key, nullptr).first;
+            try {
+                it->second = make_lw_shared<session_container>(_sessions, it);
+            } catch (...) {
+                // make_lw_shared can OOM
+                _sessions.erase(it);
+                throw;
+            }
+        }
+        auto sess = it->second;
+
+        return sess->serialized([this, sess, op = std::move(op)] () mutable {
+            return futurize_invoke(std::move(op), session_ref(*sess));
+        }).finally([this, sess] {
+            sess->remove_from_map_if_unused();
+        });
+    }
+};
+
+}


### PR DESCRIPTION
Currently, TRUNCATE is a single-phase operation: the coordinator checks if all nodes in the cluster are alive, and sends a command to each of them, telling them to get rid of their local data for the subject table (and its materialized views). Truncate commands may arrive at different points in time on each node, therefore they may race with replica writes, and a write operation might leave data that has lower consistency than requested after truncation finishes.

Hinted handoff writes suffer from a similar problem. First, hints older than the truncation time are not prevented from being sent out. While this is easily fixed (also in this PR), the local truncation time might differ on each node, and a node which performs truncation later might send a hint to another node which has already performed the truncation.

To mitigate the problems described above, the old, single phase of TRUNCATE (now called ACCEPT) is preceded by another phase, PREPARE. PREPARE makes sure that nothing is being written to the subject table by waiting for the writes that have already started, and by rejecting new writes. As for hints, ongoing hints are waited on, and more hints to that table won't be attempted to be sent.

After all nodes acknowledge the PREPARE phase, the ACCEPT phase starts. All nodes are instructed to remove their local data, and unblock writes/hints for that table.

In case something goes wrong and the ACCEPT phase won't be started on some of the nodes, writes and hints will become unblocked after the truncation timeout.

If somebody wishes not to block writes during truncation, there is an enable_write_blocking_during_truncate configuration option that allows to disable this feature. TRUNCATE will still use two phases, and will block hint traffic for the duration of truncation.

Fixes #6096
