### PR TITLE
dist/debian: fix node-exporter.service file name

### DIFF
--- a/dist/debian/debian_files_gen.py
+++ b/dist/debian/debian_files_gen.py
@@ -61,7 +61,7 @@ else:
 shutil.copy('dist/common/systemd/scylla-housekeeping-daily.service', 'build/debian/debian/{}-server.scylla-housekeeping-daily.service'.format(product))
 shutil.copy('dist/common/systemd/scylla-housekeeping-restart.service', 'build/debian/debian/{}-server.scylla-housekeeping-restart.service'.format(product))
 shutil.copy('dist/common/systemd/scylla-fstrim.service', 'build/debian/debian/{}-server.scylla-fstrim.service'.format(product))
-shutil.copy('dist/common/systemd/node-exporter.service', 'build/debian/debian/{}-server.scylla-node-exporter.service'.format(product))
+shutil.copy('dist/common/systemd/node-exporter.service', 'build/debian/debian/{}-server.node-exporter.service'.format(product))
 
 s = DebianFilesTemplate(changelog_template)
 changelog_applied = s.substitute(product=product, version=version, release=release, revision='1', codename='stable')


### PR DESCRIPTION
Since 287d6e5, we mistakenly packaging node-exporter.service in wrong name
on .deb, need to rename in correct name.

Fixes #6604