### PR TITLE
build: default enable dpdk in release mode

### DIFF
--- a/reloc/build_reloc.sh
+++ b/reloc/build_reloc.sh
@@ -2,7 +2,7 @@
 
 . /etc/os-release
 
-COMMON_FLAGS="--enable-dpdk --cflags=-ffile-prefix-map=$PWD=."
+COMMON_FLAGS="--cflags=-ffile-prefix-map=$PWD=."
 
 DEFAULT_MODE="release"
 


### PR DESCRIPTION
To reduce special cases for the build bots, default dpdk to enabled
in release mode, keeping it disabled for debug and dev.

To allow release modes without dpdk to be build, the --enable-dpdk
switch is converted to a tri-state. When disabled, dpdk is disabled
across all modes. Similarly when enabled the effect is global. When
unspecified, dpdk is enabled for release mode only.