### PR TITLE
scylla_cpuscaling_setup: support Amazon Linux 2

### DIFF
--- a/dist/common/scripts/scylla_cpuscaling_setup
+++ b/dist/common/scripts/scylla_cpuscaling_setup
@@ -54,7 +54,31 @@ if __name__ == '__main__':
         else:
             run('rc-update add cpupower default')
             run('rc-service cpupower start')
-    if is_redhat_variant():
+    if is_amzn2():
+        run('yum install -y cpupowerutils')
+        cfg = sysconfig_parser('/etc/sysconfig/scylla-cpupower')
+        cfg.set('CPUPOWER_START_OPTS', 'frequency-set -g performance')
+        cfg.set('CPUPOWER_STOP_OPTS', 'frequency-set -g ondemand')
+        cfg.commit()
+        unit_data = '''
+[Unit]
+Description=Scylla cpupower service
+After=syslog.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+EnvironmentFile=/etc/sysconfig/scylla-cpupower
+ExecStart=/usr/bin/cpupower $CPUPOWER_START_OPTS
+ExecStop=/usr/bin/cpupower $CPUPOWER_STOP_OPTS
+'''[1:-1]
+        with open('/usr/lib/systemd/system/scylla-cpupower.service', 'w') as f:
+            f.write(unit_data)
+        systemd_unit.reload()
+        cpupwr = systemd_unit('scylla-cpupower.service')
+        cpupwr.enable()
+        cpupwr.restart()
+    elif is_redhat_variant():
         run('yum install -y cpupowerutils')
         cfg = sysconfig_parser('/etc/sysconfig/cpupower')
         cfg.set('CPUPOWER_START_OPTS', 'frequency-set -g performance')

--- a/dist/common/scripts/scylla_util.py
+++ b/dist/common/scripts/scylla_util.py
@@ -371,6 +371,9 @@ def is_redhat_variant():
     d = os_release['ID_LIKE'] if 'ID_LIKE' in os_release else os_release['ID']
     return ('rhel' in d) or ('fedora' in d) or ('ol') in d
 
+def is_amzn2():
+    return ('amzn' in os_release['ID']) and ('2' in os_release['VERSION_ID'])
+
 def is_gentoo_variant():
     return ('gentoo' in os_release['ID'])
 

--- a/dist/redhat/scylla.spec
+++ b/dist/redhat/scylla.spec
@@ -134,6 +134,7 @@ rm -rf $RPM_BUILD_ROOT
 %ghost /etc/systemd/system/scylla-server.service.d/mounts.conf
 %ghost /etc/systemd/system/scylla-server.service.d/dependencies.conf
 %ghost /etc/systemd/system/var-lib-systemd-coredump.mount
+%ghost /usr/lib/systemd/system/scylla-cpupower.service
 
 %package conf
 Group:          Applications/Databases


### PR DESCRIPTION
Amazon Linux 2 has /usr/bin/cpupower, but does not have cpupower.service
unlike CentOS7.
We need to provide the .service file when distribution is Amazon Linux 2.

Fixes #5977