### PR TITLE
Use sstring_view in execute_cql and assertions

### DIFF
--- a/test/lib/cql_assertions.cc
+++ b/test/lib/cql_assertions.cc
@@ -198,7 +198,7 @@ rows_assertions rows_assertions::with_serialized_columns_count(size_t columns_co
 }
 
 shared_ptr<cql_transport::messages::result_message> cquery_nofail(
-        cql_test_env& env, const seastar::sstring& query, std::unique_ptr<cql3::query_options>&& qo, const std::experimental::source_location& loc) {
+        cql_test_env& env, sstring_view query, std::unique_ptr<cql3::query_options>&& qo, const std::experimental::source_location& loc) {
     try {
         if (qo) {
             return env.execute_cql(query, std::move(qo)).get0();
@@ -213,7 +213,7 @@ shared_ptr<cql_transport::messages::result_message> cquery_nofail(
 }
 
 void require_rows(cql_test_env& e,
-                  const char* qstr,
+                  sstring_view qstr,
                   const std::vector<std::vector<bytes_opt>>& expected,
                   const std::experimental::source_location& loc) {
     try {

--- a/test/lib/cql_assertions.hh
+++ b/test/lib/cql_assertions.hh
@@ -86,13 +86,13 @@ void assert_that_failed(future<T...>&& f)
 /// \note Should be called from a seastar::thread context, as it awaits the CQL result.
 shared_ptr<cql_transport::messages::result_message> cquery_nofail(
         cql_test_env& env,
-        const seastar::sstring& query,
+        sstring_view query,
         std::unique_ptr<cql3::query_options>&& qo = nullptr,
         const std::experimental::source_location& loc = std::experimental::source_location::current());
 
 /// Asserts that cquery_nofail(e, qstr) contains expected rows, in any order.
 void require_rows(cql_test_env& e,
-                  const char* qstr,
+                  sstring_view qstr,
                   const std::vector<std::vector<bytes_opt>>& expected,
                   const std::experimental::source_location& loc = std::experimental::source_location::current());
 

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -159,13 +159,13 @@ public:
             , _mnotifier(mnotifier)
     { }
 
-    virtual future<::shared_ptr<cql_transport::messages::result_message>> execute_cql(const sstring& text) override {
+    virtual future<::shared_ptr<cql_transport::messages::result_message>> execute_cql(sstring_view text) override {
         auto qs = make_query_state();
         return local_qp().execute_direct(text, *qs, cql3::query_options::DEFAULT).finally([qs] {});
     }
 
     virtual future<::shared_ptr<cql_transport::messages::result_message>> execute_cql(
-        const sstring& text,
+        sstring_view text,
         std::unique_ptr<cql3::query_options> qo) override
     {
         auto qs = make_query_state();

--- a/test/lib/cql_test_env.hh
+++ b/test/lib/cql_test_env.hh
@@ -76,10 +76,10 @@ class cql_test_env {
 public:
     virtual ~cql_test_env() {};
 
-    virtual future<::shared_ptr<cql_transport::messages::result_message>> execute_cql(const sstring& text) = 0;
+    virtual future<::shared_ptr<cql_transport::messages::result_message>> execute_cql(sstring_view text) = 0;
 
     virtual future<::shared_ptr<cql_transport::messages::result_message>> execute_cql(
-        const sstring& text, std::unique_ptr<cql3::query_options> qo) = 0;
+            sstring_view text, std::unique_ptr<cql3::query_options> qo) = 0;
 
     /// Processes queries (which must be modifying queries) as a batch.
     virtual future<::shared_ptr<cql_transport::messages::result_message>> execute_batch(


### PR DESCRIPTION
This lets the functions operate on a wider variety of arguments and
may also be faster.

Tests: unit (dev)