### PR TITLE
Adding Optimized pseudo floating point estimated histogram

### DIFF
--- a/api/storage_proxy.cc
+++ b/api/storage_proxy.cc
@@ -116,6 +116,23 @@ static future<json::json_return_type>  sum_timed_rate_as_long(distributed<proxy>
     });
 }
 
+utils_json::estimated_histogram time_to_json_histogram(const utils::time_estimated_histogram& val) {
+    utils_json::estimated_histogram res;
+    for (size_t i = 0; i < val.size(); i++) {
+        res.buckets.push(val.get(i));
+        res.bucket_offsets.push(val.get_bucket_lower_limit(i));
+    }
+    return res;
+}
+
+static future<json::json_return_type>  sum_estimated_histogram(http_context& ctx, utils::time_estimated_histogram service::storage_proxy_stats::stats::*f) {
+
+    return two_dimensional_map_reduce(ctx.sp, f, utils::time_estimated_histogram_merge,
+            utils::time_estimated_histogram()).then([](const utils::time_estimated_histogram& val) {
+        return make_ready_future<json::json_return_type>(time_to_json_histogram(val));
+    });
+}
+
 static future<json::json_return_type>  sum_estimated_histogram(http_context& ctx, utils::estimated_histogram service::storage_proxy_stats::stats::*f) {
 
     return two_dimensional_map_reduce(ctx.sp, f, utils::estimated_histogram_merge,

--- a/configure.py
+++ b/configure.py
@@ -326,6 +326,7 @@ scylla_tests = set([
     'test/boost/linearizing_input_stream_test',
     'test/boost/loading_cache_test',
     'test/boost/log_heap_test',
+    'test/boost/estimated_histogram_test',
     'test/boost/logalloc_test',
     'test/boost/managed_vector_test',
     'test/boost/map_difference_test',
@@ -1003,6 +1004,7 @@ deps['test/boost/UUID_test'] = ['utils/UUID_gen.cc', 'test/boost/UUID_test.cc', 
 deps['test/boost/murmur_hash_test'] = ['bytes.cc', 'utils/murmur_hash.cc', 'test/boost/murmur_hash_test.cc']
 deps['test/boost/allocation_strategy_test'] = ['test/boost/allocation_strategy_test.cc', 'utils/logalloc.cc', 'utils/dynamic_bitset.cc']
 deps['test/boost/log_heap_test'] = ['test/boost/log_heap_test.cc']
+deps['test/boost/estimated_histogram_test'] = ['test/boost/estimated_histogram_test.cc']
 deps['test/boost/anchorless_list_test'] = ['test/boost/anchorless_list_test.cc']
 deps['test/perf/perf_fast_forward'] += ['release.cc']
 deps['test/perf/perf_simple_query'] += ['release.cc']

--- a/service/storage_proxy_stats.hh
+++ b/service/storage_proxy_stats.hh
@@ -90,13 +90,13 @@ struct write_stats {
     utils::timed_rate_moving_average write_timeouts;
 
     utils::timed_rate_moving_average_and_histogram write;
-    utils::estimated_histogram estimated_write;
+    utils::time_estimated_histogram estimated_write;
 
     utils::timed_rate_moving_average cas_write_unavailables;
     utils::timed_rate_moving_average cas_write_timeouts;
 
     utils::timed_rate_moving_average_and_histogram cas_write;
-    utils::estimated_histogram estimated_cas_write;
+    utils::time_estimated_histogram estimated_cas_write;
 
     utils::estimated_histogram cas_write_contention;
 
@@ -169,11 +169,11 @@ struct stats : public write_stats {
 
     utils::timed_rate_moving_average_and_histogram read;
     utils::timed_rate_moving_average_and_histogram range;
-    utils::estimated_histogram estimated_read;
-    utils::estimated_histogram estimated_range;
+    utils::time_estimated_histogram estimated_read;
+    utils::time_estimated_histogram estimated_range;
 
     utils::timed_rate_moving_average_and_histogram cas_read;
-    utils::estimated_histogram estimated_cas_read;
+    utils::time_estimated_histogram estimated_cas_read;
 
     uint64_t reads = 0;
     uint64_t foreground_reads = 0; // client still waits for the read

--- a/test/boost/estimated_histogram_test.cc
+++ b/test/boost/estimated_histogram_test.cc
@@ -1,0 +1,124 @@
+/*
+ * Copyright (C) 2020 ScyllaDB
+ */
+
+/*
+ * This file is part of Scylla.
+ *
+ * Scylla is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Scylla is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#define BOOST_TEST_MODULE core
+
+#include <boost/test/unit_test.hpp>
+#include <iostream>
+#include "utils/estimated_histogram.hh"
+#include "utils/histogram_metrics_helper.hh"
+
+template<uint64_t MIN, uint64_t MAX, std::vector<uint64_t>::size_type NUM_BUCKETS>
+std::string validate_histogram(utils::approx_exponential_histogram<MIN, MAX, NUM_BUCKETS>& h, const std::vector<uint64_t>& r) {
+    size_t i = 0;
+    for (; i < r.size(); i++) {
+        if (r[i] != h.get(i)) {
+            return format("{:d} != {:d}", r[i], h.get(i)) ;
+        }
+    }
+    for (; i < h.size(); i++) {
+        if (h.get(i)) {
+            return format("{:d} != 0", h.get(i)) ;
+        }
+    }
+    return "";
+}
+
+std::string validate_histogram(seastar::metrics::histogram& h, const std::vector<uint64_t>& counts, const std::vector<uint64_t>& limits) {
+    size_t i = 0;
+    for (; i < counts.size(); i++) {
+        if (counts[i] != h.buckets[i].count) {
+            return format("Bucket {} limit {}  count {} !=  limit {} count {}", i, limits[i], counts[i], h.buckets[i].upper_bound, h.buckets[i].count);
+        }
+    }
+    for (; i < h.buckets.size(); i++) {
+        if (h.buckets[i].count != counts[counts.size() - 1]) {
+            return format("Bucket {} limit {}  count {} !=  limit {} count {}", i, limits[i], counts[counts.size() - 1], h.buckets[i].upper_bound, h.buckets[i].count);
+        }
+    }
+    return "";
+}
+
+BOOST_AUTO_TEST_CASE(test_histogram_bucket_limits) {
+    std::vector<size_t> limits{128, 160, 192, 224, 256, 320, 384, 448, 512, 640, 768, 896, 1024};
+    utils::approx_exponential_histogram<128, 1024, 13> hist;
+    BOOST_CHECK_EQUAL(hist.RANGES, 3);
+    BOOST_CHECK_EQUAL(hist.RESOLUTION, 4);
+    BOOST_CHECK_EQUAL(hist.RESOLUTION_BITS, 2);
+    BOOST_CHECK_EQUAL(hist.LOWER_BITS_MASK, 3);
+
+    BOOST_CHECK_EQUAL(hist.BASESHIFT, 7);
+    for (size_t i = 0; i < limits.size(); i++) {
+        BOOST_CHECK_EQUAL(hist.get_bucket_lower_limit(i), limits[i]);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(test_basic_estimated) {
+    utils::approx_exponential_histogram<128, 1024, 13> hist;
+    hist.add(1);
+    validate_histogram(hist, {1});
+    hist.add(100);
+    hist.add(128);
+    hist.add(129);
+    hist.add(159);
+    BOOST_CHECK_EQUAL(validate_histogram(hist, {5}), "");
+    hist.add(160);
+    hist.add(161);
+    hist.add(191);
+    hist.add(192);
+    BOOST_CHECK_EQUAL(validate_histogram(hist, {5, 3, 1}), "");
+    hist.add(223);
+    BOOST_CHECK_EQUAL(validate_histogram(hist, {5, 3, 2}), "");
+    hist.add(224);
+    hist.add(225);
+    hist.add(255);
+    hist.add(253);
+    BOOST_CHECK_EQUAL(validate_histogram(hist, {5, 3, 2, 4}), "");
+    hist.add(256);
+    hist.add(260);
+    hist.add(258);
+    hist.add(258);
+    hist.add(260);
+    hist.add(319);
+    BOOST_CHECK_EQUAL(validate_histogram(hist, {5, 3, 2, 4, 6}), "");
+    hist.add(1023);
+    hist.add(1024);
+    hist.add(1025);
+    BOOST_CHECK_EQUAL(validate_histogram(hist, {5, 3, 2, 4, 6, 0, 0, 0, 0, 0, 0, 1, 2}), "");
+    auto res = to_metrics_histogram(hist);
+    BOOST_CHECK_EQUAL(res.sample_count, 23);
+    BOOST_CHECK_EQUAL(res.sample_sum, 7840);
+    BOOST_CHECK_EQUAL(validate_histogram(res, {5, 8, 10, 14, 20, 20, 20, 20, 20, 20, 20, 21}, {160, 192, 224, 256, 320, 384, 448, 512, 640, 768, 896, 1024}), "");
+}
+
+BOOST_AUTO_TEST_CASE(test_estimated_statistics) {
+    utils::approx_exponential_histogram<128, 1024, 13> hist;
+    hist.add(1);
+    hist.add(160);
+    BOOST_CHECK_EQUAL(hist.min(), 128);
+    BOOST_CHECK_EQUAL(hist.max(), 192);
+    hist.add(160);
+    hist.add(160);
+    BOOST_CHECK_EQUAL(hist.mean(), (128 + 160 + 160 + 3 + 160)/4);
+    hist *= 0.5;
+    BOOST_CHECK_EQUAL(hist.get(1), 1);
+}

--- a/utils/histogram_metrics_helper.hh
+++ b/utils/histogram_metrics_helper.hh
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2020 ScyllaDB
+ *
+ * Modified by ScyllaDB
+ */
+
+/*
+ * This file is part of Scylla.
+ *
+ * Scylla is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Scylla is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <seastar/core/metrics_types.hh>
+#include "seastarx.hh"
+#include "estimated_histogram.hh"
+
+
+template<uint64_t Min, uint64_t Max, size_t NumBuckets>
+seastar::metrics::histogram to_metrics_histogram(const utils::approx_exponential_histogram<Min, Max, NumBuckets>& hist) {
+    seastar::metrics::histogram res;
+    res.buckets.resize(hist.size() - 1);
+    uint64_t cummulative_count = 0;
+    res.sample_sum = 0;
+
+    for (size_t i = 0; i < NumBuckets - 1; i++) {
+        auto& v = res.buckets[i];
+        v.upper_bound = hist.get_bucket_lower_limit(i + 1);
+        cummulative_count += hist.get(i);
+        v.count = cummulative_count;
+        res.sample_sum += hist.get(i) * v.upper_bound;
+    }
+    // The count serves as the infinite bucket
+    res.sample_count = cummulative_count + hist.get(NumBuckets - 1);
+    res.sample_sum += hist.get(NumBuckets - 1) * hist.get_bucket_lower_limit(NumBuckets - 1);
+    return res;
+}


### PR DESCRIPTION
This series Adds a pseudo-floating-point histogram implementation.
The histogram is used for time_estimated_histogram a histogram for latency tracking and then used in storage_proxy as a more efficient with a higher resolution histogram.

Follow up series would use the new histogram in other places in the system and will add an implementation that supports lower values.
Fixes #5815
Fixes #4746