### PR TITLE
messagin service: fix execution order in messaging_service constructor

### DIFF
--- a/message/messaging_service.cc
+++ b/message/messaging_service.cc
@@ -396,17 +396,21 @@ messaging_service::messaging_service(gms::inet_address ip
     , _scheduling_info_for_connection_index(initial_scheduling_info())
 {
     _rpc->set_logger(&rpc_logger);
+
+    // this initialization should be done before any handler registration
+    // this is because register_handler calls to: scheduling_group_for_verb
+    // which in turn relies on _connection_index_for_tenant to be initialized.
+    _connection_index_for_tenant.reserve(_scheduling_config.statement_tenants.size());
+    for (unsigned i = 0; i <  _scheduling_config.statement_tenants.size(); ++i) {
+        _connection_index_for_tenant.push_back({_scheduling_config.statement_tenants[i].sched_group, i});
+    }
+
     register_handler(this, messaging_verb::CLIENT_ID, [] (rpc::client_info& ci, gms::inet_address broadcast_address, uint32_t src_cpu_id, rpc::optional<uint64_t> max_result_size) {
         ci.attach_auxiliary("baddr", broadcast_address);
         ci.attach_auxiliary("src_cpu_id", src_cpu_id);
         ci.attach_auxiliary("max_result_size", max_result_size.value_or(query::result_memory_limiter::maximum_result_size));
         return rpc::no_wait;
     });
-
-    _connection_index_for_tenant.reserve(_scheduling_config.statement_tenants.size());
-    for (unsigned i = 0; i <  _scheduling_config.statement_tenants.size(); ++i) {
-        _connection_index_for_tenant.push_back({_scheduling_config.statement_tenants[i].sched_group, i});
-    }
 }
 
 msg_addr messaging_service::get_source(const rpc::client_info& cinfo) {


### PR DESCRIPTION
The messaging service constructor's body does two main things in this
order:
1. it registers the CLIENT_ID verb with rpc.
2. it initializes the scheduling mechanism in charge of locating the
right scheduling group for each verb.

The registration function uses the scheduling mechanism to determine
the scheduling group for the verb.
This commit simply reverses the order of execution.

Fixes #6628