### PR TITLE
build: remove zstd submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,6 +9,3 @@
 [submodule "libdeflate"]
 	path = libdeflate
 	url = ../libdeflate
-[submodule "zstd"]
-	path = zstd
-	url = ../zstd

--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -42,6 +42,7 @@ debian_base_packages=(
     git
     pigz
     libunistring-dev
+    libzstd-dev
 )
 
 fedora_packages=(
@@ -91,6 +92,7 @@ fedora_packages=(
     lld
     xxhash-devel
     makeself
+    libzstd-static libzstd-devel
 )
 
 centos_packages=(

--- a/tools/toolchain/image
+++ b/tools/toolchain/image
@@ -1,1 +1,1 @@
-docker.io/scylladb/scylla-toolchain:fedora-32-20200608
+docker.io/scylladb/scylla-toolchain:fedora-32-20200610

--- a/zstd.cc
+++ b/zstd.cc
@@ -24,7 +24,7 @@
 // We need to use experimental features of the zstd library (to allocate compression/decompression context),
 // which are available only when the library is linked statically.
 #define ZSTD_STATIC_LINKING_ONLY
-#include "zstd/lib/zstd.h"
+#include "zstd.h"
 
 #include "compress.hh"
 #include "utils/class_registrator.hh"


### PR DESCRIPTION
Now that Fedora provides the zstd static library, we can remove the
submodule.

The frozen toolchain is regenerated to include the new package.