### PR TITLE
database, streaming, messaging: drop streaming memtables

### DIFF
--- a/api/api-doc/messaging_service.json
+++ b/api/api-doc/messaging_service.json
@@ -249,7 +249,7 @@
                  "MIGRATION_REQUEST",
                  "PREPARE_MESSAGE",
                  "PREPARE_DONE_MESSAGE",
-                 "STREAM_MUTATION",
+                 "UNUSED__STREAM_MUTATION",
                  "STREAM_MUTATION_DONE",
                  "COMPLETE_MESSAGE",
                  "REPAIR_CHECKSUM_RANGE",

--- a/message/messaging_service.cc
+++ b/message/messaging_service.cc
@@ -476,7 +476,7 @@ static constexpr unsigned do_get_rpc_client_idx(messaging_verb verb) {
         return 0;
     case messaging_verb::PREPARE_MESSAGE:
     case messaging_verb::PREPARE_DONE_MESSAGE:
-    case messaging_verb::STREAM_MUTATION:
+    case messaging_verb::UNUSED__STREAM_MUTATION:
     case messaging_verb::STREAM_MUTATION_DONE:
     case messaging_verb::COMPLETE_MESSAGE:
     case messaging_verb::REPLICATION_FINISHED:
@@ -951,15 +951,6 @@ void messaging_service::register_prepare_done_message(std::function<future<> (co
 future<> messaging_service::send_prepare_done_message(msg_addr id, UUID plan_id, unsigned dst_cpu_id) {
     return send_message<void>(this, messaging_verb::PREPARE_DONE_MESSAGE, id,
         plan_id, dst_cpu_id);
-}
-
-// STREAM_MUTATION
-void messaging_service::register_stream_mutation(std::function<future<> (const rpc::client_info& cinfo, UUID plan_id, frozen_mutation fm, unsigned dst_cpu_id, rpc::optional<bool> fragmented, rpc::optional<streaming::stream_reason> reason)>&& func) {
-    register_handler(this, messaging_verb::STREAM_MUTATION, std::move(func));
-}
-future<> messaging_service::send_stream_mutation(msg_addr id, UUID plan_id, frozen_mutation fm, unsigned dst_cpu_id, bool fragmented, streaming::stream_reason reason) {
-    return send_message<void>(this, messaging_verb::STREAM_MUTATION, id,
-        plan_id, std::move(fm), dst_cpu_id, fragmented, reason);
 }
 
 // STREAM_MUTATION_DONE

--- a/message/messaging_service.hh
+++ b/message/messaging_service.hh
@@ -112,7 +112,7 @@ enum class messaging_verb : int32_t {
     // Used by streaming
     PREPARE_MESSAGE = 15,
     PREPARE_DONE_MESSAGE = 16,
-    STREAM_MUTATION = 17,
+    UNUSED__STREAM_MUTATION = 17,
     STREAM_MUTATION_DONE = 18,
     COMPLETE_MESSAGE = 19,
     // end of streaming verbs
@@ -301,10 +301,6 @@ public:
     // Wrapper for PREPARE_DONE_MESSAGE verb
     void register_prepare_done_message(std::function<future<> (const rpc::client_info& cinfo, UUID plan_id, unsigned dst_cpu_id)>&& func);
     future<> send_prepare_done_message(msg_addr id, UUID plan_id, unsigned dst_cpu_id);
-
-    // Wrapper for STREAM_MUTATION verb
-    void register_stream_mutation(std::function<future<> (const rpc::client_info& cinfo, UUID plan_id, frozen_mutation fm, unsigned dst_cpu_id, rpc::optional<bool>, rpc::optional<streaming::stream_reason>)>&& func);
-    future<> send_stream_mutation(msg_addr id, UUID plan_id, frozen_mutation fm, unsigned dst_cpu_id, bool fragmented, streaming::stream_reason reason);
 
     // Wrapper for STREAM_MUTATION_FRAGMENTS
     // The receiver of STREAM_MUTATION_FRAGMENTS sends status code to the sender to notify any error on the receiver side. The status code is of type int32_t. 0 means successful, -1 means error, other status code value are reserved for future use.

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -1866,18 +1866,6 @@ storage_proxy::mutate_counter_on_leader_and_replicate(const schema_ptr& s, froze
     });
 }
 
-future<>
-storage_proxy::mutate_streaming_mutation(const schema_ptr& s, utils::UUID plan_id, const frozen_mutation& m, bool fragmented) {
-    auto shard = _db.local().shard_of(m);
-    get_stats().replica_cross_shard_ops += shard != this_shard_id();
-    // In theory streaming writes should have their own smp_service_group, but this is only used during upgrades from old versions; new
-    // versions use rpc streaming.
-    return _db.invoke_on(shard, _write_smp_service_group, [&m, plan_id, fragmented, gs = global_schema_ptr(s)] (database& db) mutable -> future<> {
-        return db.apply_streaming_mutation(gs, plan_id, m, fragmented);
-    });
-}
-
-
 storage_proxy::response_id_type
 storage_proxy::create_write_response_handler_helper(schema_ptr s, const dht::token& token, std::unique_ptr<mutation_holder> mh,
         db::consistency_level cl, db::write_type type, tracing::trace_state_ptr tr_state, service_permit permit) {

--- a/service/storage_proxy.hh
+++ b/service/storage_proxy.hh
@@ -481,7 +481,6 @@ public:
     future<> mutate_locally(std::vector<mutation> mutation, tracing::trace_state_ptr tr_state, clock_type::time_point timeout = clock_type::time_point::max());
 
     future<> mutate_hint(const schema_ptr&, const frozen_mutation& m, tracing::trace_state_ptr tr_state, clock_type::time_point timeout = clock_type::time_point::max());
-    future<> mutate_streaming_mutation(const schema_ptr&, utils::UUID plan_id, const frozen_mutation& m, bool fragmented);
 
     /**
     * Use this method to have these Mutations applied


### PR DESCRIPTION
Before Scylla 3.0, we used to send streaming mutations using
individual RPC requests and flush them together using dedicated
streaming memtables. This mechanism is no longer in use and all
versions that use it have long reached end-of-life.

Remove this code.