### PR TITLE
build: fix --enable-dpdk/--disable-dpdk configure switch

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -454,7 +454,7 @@ arg_parser.add_argument('--c-compiler', action='store', dest='cc', default='gcc'
                         help='C compiler path')
 arg_parser.add_argument('--with-osv', action='store', dest='with_osv', default='',
                         help='Shortcut for compile for OSv')
-add_tristate(arg_parser, name='enable-dpdk', dest='dpdk',
+add_tristate(arg_parser, name='dpdk', dest='dpdk',
                         help='Use dpdk (from seastar dpdk sources) (default=True for release builds)')
 arg_parser.add_argument('--dpdk-target', action='store', dest='dpdk_target', default='',
                         help='Path to DPDK SDK target location (e.g. <DPDK SDK dir>/x86_64-native-linuxapp-gcc)')


### PR DESCRIPTION
5ceb20c43992e2cb5292e7e7ad929c6798dfc560 switched --enable-dpdk
to a tristate switch, but forgot that add_tristate() prepends
--enable and --disable itself; so now the switch looks like
--enable-enable-dpdk and --disable-enable-dpdk.

Fix by removing the "enable-" prefix.