### PR TITLE
scylla_cpuscaling_setup: move the unit file to /etc/systemd

### DIFF
--- a/dist/common/scripts/scylla_cpuscaling_setup
+++ b/dist/common/scripts/scylla_cpuscaling_setup
@@ -72,7 +72,7 @@ EnvironmentFile=/etc/sysconfig/scylla-cpupower
 ExecStart=/usr/bin/cpupower $CPUPOWER_START_OPTS
 ExecStop=/usr/bin/cpupower $CPUPOWER_STOP_OPTS
 '''[1:-1]
-        with open('/usr/lib/systemd/system/scylla-cpupower.service', 'w') as f:
+        with open('/etc/systemd/system/scylla-cpupower.service', 'w') as f:
             f.write(unit_data)
         systemd_unit.reload()
         cpupwr = systemd_unit('scylla-cpupower.service')

--- a/dist/redhat/scylla.spec
+++ b/dist/redhat/scylla.spec
@@ -134,7 +134,7 @@ rm -rf $RPM_BUILD_ROOT
 %ghost /etc/systemd/system/scylla-server.service.d/mounts.conf
 %ghost /etc/systemd/system/scylla-server.service.d/dependencies.conf
 %ghost /etc/systemd/system/var-lib-systemd-coredump.mount
-%ghost /usr/lib/systemd/system/scylla-cpupower.service
+%ghost /etc/systemd/system/scylla-cpupower.service
 
 %package conf
 Group:          Applications/Databases


### PR DESCRIPTION
Since scylla-cpupower.service isn't installed by .rpm package, but created
in the setup script, it's better to not use /usr/lib directory, use /etc.

We already doing same way for scylla-server.service.d/*.conf, *.mount, and
*.swap created by setup scripts.