### PR TITLE
approx_exponential_histogram: Makes the implementation clearer

### DIFF
--- a/test/boost/estimated_histogram_test.cc
+++ b/test/boost/estimated_histogram_test.cc
@@ -60,10 +60,10 @@ std::string validate_histogram(seastar::metrics::histogram& h, const std::vector
 
 BOOST_AUTO_TEST_CASE(test_histogram_bucket_limits) {
     std::vector<size_t> limits{128, 160, 192, 224, 256, 320, 384, 448, 512, 640, 768, 896, 1024};
-    utils::approx_exponential_histogram<128, 1024, 13> hist;
-    BOOST_CHECK_EQUAL(hist.RANGES, 3);
-    BOOST_CHECK_EQUAL(hist.RESOLUTION, 4);
-    BOOST_CHECK_EQUAL(hist.RESOLUTION_BITS, 2);
+    utils::approx_exponential_histogram<128, 1024, 4> hist;
+    BOOST_CHECK_EQUAL(hist.NUM_EXP_RANGES, 3);
+    BOOST_CHECK_EQUAL(hist.NUM_BUCKETS, 13);
+    BOOST_CHECK_EQUAL(hist.PRECISION_BITS, 2);
     BOOST_CHECK_EQUAL(hist.LOWER_BITS_MASK, 3);
 
     BOOST_CHECK_EQUAL(hist.BASESHIFT, 7);
@@ -73,7 +73,7 @@ BOOST_AUTO_TEST_CASE(test_histogram_bucket_limits) {
 }
 
 BOOST_AUTO_TEST_CASE(test_basic_estimated) {
-    utils::approx_exponential_histogram<128, 1024, 13> hist;
+    utils::approx_exponential_histogram<128, 1024, 4> hist;
     hist.add(1);
     validate_histogram(hist, {1});
     hist.add(100);
@@ -111,7 +111,7 @@ BOOST_AUTO_TEST_CASE(test_basic_estimated) {
 }
 
 BOOST_AUTO_TEST_CASE(test_estimated_statistics) {
-    utils::approx_exponential_histogram<128, 1024, 13> hist;
+    utils::approx_exponential_histogram<128, 1024, 4> hist;
     hist.add(1);
     hist.add(160);
     BOOST_CHECK_EQUAL(hist.min(), 128);

--- a/utils/histogram_metrics_helper.hh
+++ b/utils/histogram_metrics_helper.hh
@@ -28,14 +28,14 @@
 #include "estimated_histogram.hh"
 
 
-template<uint64_t Min, uint64_t Max, size_t NumBuckets>
-seastar::metrics::histogram to_metrics_histogram(const utils::approx_exponential_histogram<Min, Max, NumBuckets>& hist) {
+template<uint64_t Min, uint64_t Max, size_t Precision>
+seastar::metrics::histogram to_metrics_histogram(const utils::approx_exponential_histogram<Min, Max, Precision>& hist) {
     seastar::metrics::histogram res;
     res.buckets.resize(hist.size() - 1);
     uint64_t cummulative_count = 0;
     res.sample_sum = 0;
 
-    for (size_t i = 0; i < NumBuckets - 1; i++) {
+    for (size_t i = 0; i < hist.NUM_BUCKETS - 1; i++) {
         auto& v = res.buckets[i];
         v.upper_bound = hist.get_bucket_lower_limit(i + 1);
         cummulative_count += hist.get(i);
@@ -43,7 +43,7 @@ seastar::metrics::histogram to_metrics_histogram(const utils::approx_exponential
         res.sample_sum += hist.get(i) * v.upper_bound;
     }
     // The count serves as the infinite bucket
-    res.sample_count = cummulative_count + hist.get(NumBuckets - 1);
-    res.sample_sum += hist.get(NumBuckets - 1) * hist.get_bucket_lower_limit(NumBuckets - 1);
+    res.sample_count = cummulative_count + hist.get(hist.NUM_BUCKETS - 1);
+    res.sample_sum += hist.get(hist.NUM_BUCKETS - 1) * hist.get_bucket_lower_limit(hist.NUM_BUCKETS - 1);
     return res;
 }


### PR DESCRIPTION
This patch aim to make the implementation and usage of the
approx_exponential_histogram clearer.

The approx_exponential_histogram Uses a combination of Min, Max,
Precision and number of buckets where the user needs to pick 3.

Most of the changes in the patch are about documenting the class and
method, but following the review there are two functionality changes:

1. The user would pick: Min, Max and Precision and the number of buckets
   will be calculated from these values.
2. The template restrictions are now state in a requires so voiolation
   will be stop at compile time.