### PR TITLE
scylla_swap_setup: don't create sparse file

### DIFF
--- a/dist/common/scripts/scylla_swap_setup
+++ b/dist/common/scripts/scylla_swap_setup
@@ -54,7 +54,7 @@ if __name__ == '__main__':
     if swapfile.exists():
         print('swapfile {} already exists'.format(swapfile))
         sys.exit(1)
-    run('fallocate -v -l {}GB {}'.format(swapsize, swapfile))
+    run('dd if=/dev/zero of={} bs=1G count={}'.format(swapfile, swapsize))
     swapfile.chmod(0o600)
     run('mkswap -f {}'.format(swapfile))
     swapunit_bn = out('/usr/bin/systemd-escape -p --suffix=swap {}'.format(swapfile))


### PR DESCRIPTION
fallocate creates sparse file, XFS rejects such file for swapfile:
https://bugzilla.redhat.com/show_bug.cgi?id=1129205

Use dd instead.

Fixes #6650