### PR TITLE
cdc: Fix segfault when selecting stream ID by a too short key

### DIFF
--- a/cdc/cdc_partitioner.cc
+++ b/cdc/cdc_partitioner.cc
@@ -40,7 +40,8 @@ static dht::token to_token(int64_t value) {
 }
 
 static dht::token to_token(bytes_view key) {
-    if (key.empty()) {
+    // Key should be 16 B long, of which first 8 B are used for token calculation
+    if (key.size() != 2*sizeof(int64_t)) {
         return dht::minimum_token();
     }
     return to_token(stream_id::token_from_bytes(key));

--- a/test/cql/cdc_too_short_stream_id_test.cql
+++ b/test/cql/cdc_too_short_stream_id_test.cql
@@ -1,0 +1,7 @@
+create table tb (pk int primary key) with cdc = {'enabled': true};
+insert into tb (pk) VALUES (0);
+
+-- Key of length != 128 b should return empty result set (issue #6570)
+select * from tb_scylla_cdc_log where "cdc$stream_id" = 0x00;
+
+select * from tb_scylla_cdc_log where "cdc$stream_id" = 0x;

--- a/test/cql/cdc_too_short_stream_id_test.result
+++ b/test/cql/cdc_too_short_stream_id_test.result
@@ -1,0 +1,19 @@
+create table tb (pk int primary key) with cdc = {'enabled': true};
+{
+	"status" : "ok"
+}
+insert into tb (pk) VALUES (0);
+{
+	"status" : "ok"
+}
+
+-- Key of length != 128 b should return empty result set (issue #6570)
+select * from tb_scylla_cdc_log where "cdc$stream_id" = 0x00;
+{
+	"rows" : null
+}
+
+select * from tb_scylla_cdc_log where "cdc$stream_id" = 0x;
+{
+	"rows" : null
+}


### PR DESCRIPTION
When a token is calculated for stream_id, we check that the key is exactly 16 bytes long. If it's not - `minimum_token` is returned and client receives empty result.

This used to be the expected behavior for empty keys; now it's extended to keys of any incorrect length.

Fixes #6570