### PR TITLE
thrift: switch csharp backend to netstd

### DIFF
--- a/interface/cassandra.thrift
+++ b/interface/cassandra.thrift
@@ -35,7 +35,7 @@
 
 namespace java org.apache.cassandra.thrift
 namespace cpp cassandra
-namespace csharp Apache.Cassandra
+namespace netstd Apache.Cassandra
 namespace py cassandra
 namespace php cassandra
 namespace perl Cassandra


### PR DESCRIPTION
The thrift compiler (since 0.13 at least) complains that
the csharp target is deprecated and recommend replacing it
with netstd. Since we don't use either, humor it.

I suspect that this warning caused some spurious rebuilds,
but have not proven it.