### PR TITLE
scylla_raid_setup: daemon-reload after mounts.conf installed

### DIFF
--- a/dist/common/scripts/scylla_raid_setup
+++ b/dist/common/scripts/scylla_raid_setup
@@ -155,6 +155,7 @@ if __name__ == '__main__':
         else:
             with open(mounts_conf, 'a') as f:
                 f.write('RequiresMountsFor={mount_at}\n'.format(mount_at=mount_at))
+        systemd_unit.reload()
 
     if is_debian_variant():
         run('update-initramfs -u')


### PR DESCRIPTION
systemd requires daemon-reload after adding drop-in file, so we need to
do that after writing mounts.conf.

Fixes #6674