### PR TITLE
scylla_swap_setup: fix systemd-escape path

### DIFF
--- a/dist/common/scripts/scylla_swap_setup
+++ b/dist/common/scripts/scylla_swap_setup
@@ -57,7 +57,7 @@ if __name__ == '__main__':
     run('dd if=/dev/zero of={} bs=1G count={}'.format(swapfile, swapsize))
     swapfile.chmod(0o600)
     run('mkswap -f {}'.format(swapfile))
-    swapunit_bn = out('/usr/bin/systemd-escape -p --suffix=swap {}'.format(swapfile))
+    swapunit_bn = out('systemd-escape -p --suffix=swap {}'.format(swapfile))
     swapunit = Path('/etc/systemd/system/{}'.format(swapunit_bn))
     if swapunit.exists():
         print('swap unit {} already exists'.format(swapunit))


### PR DESCRIPTION
On Ubuntu 18.04 and ealier & Deiban 10 and ealier, /usr merge is not done, so
/usr/bin/systemd-escape and /bin/systemd-escape is different place, and we call
/usr/bin but Debian variants tries to install the command in /bin.
Drop full path, just call command name and resolve by default PATH.

Fixes: #6650