### PR TITLE
scylla_util.py: switch to subprocess.run()

### DIFF
--- a/dist/common/scripts/scylla_util.py
+++ b/dist/common/scripts/scylla_util.py
@@ -338,21 +338,13 @@ def run(cmd, shell=False, silent=False, exception=True):
     stderr = subprocess.DEVNULL if silent else None
     if not shell:
         cmd = shlex.split(cmd)
-    if exception:
-        return subprocess.check_call(cmd, shell=shell, stdout=stdout, stderr=stderr, env=scylla_env)
-    else:
-        p = subprocess.Popen(cmd, shell=shell, stdout=stdout, stderr=stderr, env=scylla_env)
-        return p.wait()
+    return subprocess.run(cmd, stdout=stdout, stderr=stderr, shell=shell, check=exception, env=scylla_env).returncode
 
 
 def out(cmd, shell=False, exception=True, timeout=None):
     if not shell:
         cmd = shlex.split(cmd)
-    if exception:
-        return subprocess.check_output(cmd, shell=shell, env=scylla_env, timeout=timeout).strip().decode('utf-8')
-    else:
-        p = subprocess.Popen(cmd, shell=shell, stdout=subprocess.PIPE, env=scylla_env)
-        return p.communicate()[0].strip().decode('utf-8')
+    return subprocess.run(cmd, capture_output=True, shell=shell, timeout=timeout, check=exception, encoding='utf-8', env=scylla_env).stdout.strip()
 
 
 def parse_os_release_line(line):


### PR DESCRIPTION
When we started to porting bash script to python script, we are not able to use
subprocess.run() since EPEL only provides python 3.4, but now we have
relocatable python, so we can switch to it.