### PR TITLE
configure.py: Drop unused var cassandra_interface

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -493,8 +493,6 @@ defines = ['XXH_PRIVATE_API',
 
 extra_cxxflags = {}
 
-cassandra_interface = Thrift(source='interface/cassandra.thrift', service='Cassandra')
-
 scylla_core = (['database.cc',
                 'absl-flat_hash_map.cc',
                 'table.cc',


### PR DESCRIPTION
The variable doesn't appear to be used anywhere.

Tests: manually run configure.py

Signed-off-by: Dejan Mircevski <dejan@scylladb.com>