### PR TITLE
repair: Handle dropped table in repair_range

### DIFF
--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -1050,7 +1050,12 @@ static future<> repair_range(repair_info& ri, const dht::token_range& range) {
       }
       return ::service::get_local_migration_manager().sync_schema(ri.db.local(), neighbors).then([&neighbors, &ri, range, id] {
         return do_for_each(ri.table_ids.begin(), ri.table_ids.end(), [&ri, &neighbors, range] (utils::UUID table_id) {
-            auto cf = ri.db.local().find_column_family(table_id).schema()->cf_name();
+            sstring cf;
+            try {
+                cf = ri.db.local().find_column_family(table_id).schema()->cf_name();
+            } catch (no_such_column_family&) {
+                return make_ready_future<>();
+            }
             ri._sub_ranges_nr++;
             if (ri.row_level_repair()) {
                 if (ri.dropped_tables.count(cf)) {


### PR DESCRIPTION
In commit 12d929a5ae1f3166ec56e54239f40e6137f6d2c2 (repair: Add table_id
to row_level_repair), a call to find_column_family() was added in
repair_range. In case of the table is dropped, it will fail the
repair_range which in turn fails the bootstrap operation.

Tests: update_cluster_layout_tests.py:TestUpdateClusterLayout.simple_add_new_node_while_schema_changes_test
Fixes: #5942