### PR TITLE
token_metadata: Fix incorrect log in update_normal_tokens

### DIFF
--- a/locator/token_metadata.cc
+++ b/locator/token_metadata.cc
@@ -1051,7 +1051,7 @@ void token_metadata_impl::update_normal_tokens(const std::unordered_map<inet_add
             auto prev = _token_to_endpoint_map.insert(std::pair<token, inet_address>(t, endpoint));
             should_sort_tokens |= prev.second; // new token inserted -> sort
             if (prev.first->second != endpoint) {
-                tlogger.warn("Token {} changing ownership from {} to {}", t, prev.first->second, endpoint);
+                tlogger.debug("Token {} changing ownership from {} to {}", t, prev.first->second, endpoint);
                 prev.first->second = endpoint;
             }
         }


### PR DESCRIPTION
Currently, when update_normal_tokens is called, a warning logged.

   Token X changing ownership from A to B

It is not correct to log so because we can call update_normal_tokens
against a temporary token_metadata object during topology calculation.

Refs: 6437