### PR TITLE
dist/debian/python3: apply version number fixup on scylla-python3

### DIFF
--- a/dist/debian/python3/build_deb.sh
+++ b/dist/debian/python3/build_deb.sh
@@ -101,7 +101,12 @@ RELOC_PKG_BASENAME=$(basename $RELOC_PKG)
 SCYLLA_VERSION=$(cat scylla-python3/SCYLLA-VERSION-FILE)
 SCYLLA_RELEASE=$(cat scylla-python3/SCYLLA-RELEASE-FILE)
 
-ln -fv $RELOC_PKG_FULLPATH ../$PRODUCT-python3_$SCYLLA_VERSION-$SCYLLA_RELEASE.orig.tar.gz
 
 cp -al scylla-python3/debian debian
+PKG_NAME=$(dpkg-parsechangelog --show-field Source)
+# XXX: Drop revision number from version string.
+#      Since it always '1', this should be okay for now.
+PKG_VERSION=$(dpkg-parsechangelog --show-field Version |sed -e 's/-1$//')
+ln -fv $RELOC_PKG_FULLPATH ../"$PKG_NAME"_"$PKG_VERSION".orig.tar.gz
+
 debuild -rfakeroot -us -uc

--- a/dist/debian/python3/debian_files_gen.py
+++ b/dist/debian/python3/debian_files_gen.py
@@ -41,7 +41,7 @@ with open('build/SCYLLA-PRODUCT-FILE') as f:
     product = f.read().strip()
 
 with open('build/python3/SCYLLA-VERSION-FILE') as f:
-    version = f.read().strip()
+    version = f.read().strip().replace('.rc', '~rc').replace('_', '-')
 
 with open('build/python3/SCYLLA-RELEASE-FILE') as f:
     release = f.read().strip()


### PR DESCRIPTION
Sync version number fixup from main package, contains #6546 and #6752 fixes.

Note that scylla-python3 likely does not affect this versioning issue,
since it uses python3 version, which normally does not contain 'rcX'.