### PR TITLE
debian: use symlink copying files to build/debian/debian/

### DIFF
--- a/dist/debian/debian/scylla-server.default
+++ b/dist/debian/debian/scylla-server.default
@@ -1,0 +1,1 @@
+../../common/sysconfig/scylla-server

--- a/dist/debian/debian/scylla-server.node-exporter.service
+++ b/dist/debian/debian/scylla-server.node-exporter.service
@@ -1,0 +1,1 @@
+../../common/systemd/node-exporter.service

--- a/dist/debian/debian/scylla-server.scylla-fstrim.service
+++ b/dist/debian/debian/scylla-server.scylla-fstrim.service
@@ -1,0 +1,1 @@
+../../common/systemd/scylla-fstrim.service

--- a/dist/debian/debian/scylla-server.scylla-housekeeping-daily.service
+++ b/dist/debian/debian/scylla-server.scylla-housekeeping-daily.service
@@ -1,0 +1,1 @@
+../../common/systemd/scylla-housekeeping-daily.service

--- a/dist/debian/debian/scylla-server.scylla-housekeeping-restart.service
+++ b/dist/debian/debian/scylla-server.scylla-housekeeping-restart.service
@@ -1,0 +1,1 @@
+../../common/systemd/scylla-housekeeping-restart.service

--- a/dist/debian/debian/scylla-server.service
+++ b/dist/debian/debian/scylla-server.service
@@ -1,0 +1,1 @@
+../../common/systemd/scylla-server.service


### PR DESCRIPTION
Instead of running shutil.copy() for each *.{service,default},
create symlink for these files.
Python will copy original file when copying debian directory.