### PR TITLE
Make handle_state_left more robust when tokens are empty

### DIFF
--- a/locator/token_metadata.cc
+++ b/locator/token_metadata.cc
@@ -1223,9 +1223,8 @@ void token_metadata_impl::add_bootstrap_tokens(std::unordered_set<token> tokens,
 
 void token_metadata_impl::remove_bootstrap_tokens(std::unordered_set<token> tokens) {
     if (tokens.empty()) {
-        auto msg = format("tokens is empty in remove_bootstrap_tokens!");
-        tlogger.error("{}", msg);
-        throw std::runtime_error(msg);
+        tlogger.warn("tokens is empty in remove_bootstrap_tokens!");
+        return;
     }
     for (auto t : tokens) {
         _bootstrap_tokens.erase(t);

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -1289,6 +1289,17 @@ void storage_service::handle_state_left(inet_address endpoint, std::vector<sstri
     }
     auto tokens = get_tokens_for(endpoint);
     slogger.debug("Node {} state left, tokens {}", endpoint, tokens);
+    if (tokens.empty()) {
+        auto eps = _gossiper.get_endpoint_state_for_endpoint_ptr(endpoint);
+        if (eps) {
+            slogger.warn("handle_state_left: Tokens for node={} are empty, endpoint_state={}", endpoint, *eps);
+        } else {
+            slogger.warn("handle_state_left: Couldn't find endpoint state for node={}", endpoint);
+        }
+        auto tokens_from_tm = _token_metadata.get_tokens(endpoint);
+        slogger.warn("handle_state_left: Get tokens from token_metadata, node={}, tokens={}", endpoint, tokens_from_tm);
+        tokens = std::unordered_set<dht::token>(tokens_from_tm.begin(), tokens_from_tm.end());
+    }
     excise(tokens, endpoint, extract_expire_time(pieces));
 }
 


### PR DESCRIPTION
1) storage_service: Make handle_state_left more robust when tokens are empty

In case the tokens for the node to be removed from the cluster are
empty, log the application_state of the leaving node to help understand
why the tokens are empty and try to get the tokens from token_metadata.

2) token_metadata: Do not throw if empty tokens are passed to remove_bootstrap_tokens

Gossip on_change callback calls storage_service::excise which calls
remove_bootstrap_tokens to remove the tokens of the leaving node from
bootstrap tokens. If empty tokens, e.g., due to gossip propagation issue
as we saw in https://github.com/scylladb/scylla/issues/6468, are passed
to remove_bootstrap_tokens, it will throw. Since the on_change callback
is marked as noexcept, such throw will cause the node to terminate which
is an overkill.

To avoid such error causing the whole cluster to down in worse cases,
just log the tokens are empty passed to remove_bootstrap_tokens.

Refs #6468