### PR TITLE
gossiper: Drop unused replaced_endpoint

### DIFF
--- a/gms/gossiper.cc
+++ b/gms/gossiper.cc
@@ -996,12 +996,6 @@ void gossiper::quarantine_endpoint(inet_address endpoint, clk::time_point quaran
     _just_removed_endpoints[endpoint] = quarantine_start;
 }
 
-void gossiper::replacement_quarantine(inet_address endpoint) {
-    // remember, quarantine_endpoint will effectively already add QUARANTINE_DELAY, so this is 2x
-    // logger.debug("");
-    quarantine_endpoint(endpoint, now() + quarantine_delay());
-}
-
 void gossiper::make_random_gossip_digest(utils::chunked_vector<gossip_digest>& g_digests) {
     int generation = 0;
     int max_version = 0;

--- a/gms/gossiper.cc
+++ b/gms/gossiper.cc
@@ -1002,13 +1002,6 @@ void gossiper::replacement_quarantine(inet_address endpoint) {
     quarantine_endpoint(endpoint, now() + quarantine_delay());
 }
 
-// Runs inside seastar::async context
-void gossiper::replaced_endpoint(inet_address endpoint) {
-    remove_endpoint(endpoint);
-    evict_from_membership(endpoint);
-    replacement_quarantine(endpoint);
-}
-
 void gossiper::make_random_gossip_digest(utils::chunked_vector<gossip_digest>& g_digests) {
     int generation = 0;
     int max_version = 0;

--- a/gms/gossiper.hh
+++ b/gms/gossiper.hh
@@ -316,13 +316,6 @@ private:
      */
     void quarantine_endpoint(inet_address endpoint, clk::time_point quarantine_start);
 
-public:
-    /**
-     * Quarantine endpoint specifically for replacement purposes.
-     * @param endpoint
-     */
-    void replacement_quarantine(inet_address endpoint);
-
 private:
     /**
      * The gossip digest is built based on randomization

--- a/gms/gossiper.hh
+++ b/gms/gossiper.hh
@@ -323,14 +323,6 @@ public:
      */
     void replacement_quarantine(inet_address endpoint);
 
-    /**
-     * Remove the Endpoint and evict immediately, to avoid gossiping about this node.
-     * This should only be called when a token is taken over by a new IP address.
-     *
-     * @param endpoint The endpoint that has been replaced
-     */
-    void replaced_endpoint(inet_address endpoint);
-
 private:
     /**
      * The gossip digest is built based on randomization


### PR DESCRIPTION
  
It is not used any more after 75cf1d18b512baeadb3445a7db7d63c90eafb322
(storage_service: Unify handling of replaced node removal from gossip)
in the "Make replacing node take writes" series.
    
Refs #5482
