### PR TITLE
Shard aware: Support of source port based load balancing

### DIFF
--- a/db/config.cc
+++ b/db/config.cc
@@ -714,6 +714,7 @@ db::config::config(std::shared_ptr<db::extensions> exts)
     , enable_dangerous_direct_import_of_cassandra_counters(this, "enable_dangerous_direct_import_of_cassandra_counters", value_status::Used, false, "Only turn this option on if you want to import tables from Cassandra containing counters, and you are SURE that no counters in that table were created in a version earlier than Cassandra 2.1."
         " It is not enough to have ever since upgraded to newer versions of Cassandra. If you EVER used a version earlier than 2.1 in the cluster where these SSTables come from, DO NOT TURN ON THIS OPTION! You will corrupt your data. You have been warned.")
     , enable_shard_aware_drivers(this, "enable_shard_aware_drivers", value_status::Used, true, "Enable native transport drivers to use connection-per-shard for better performance")
+    , cpu_sharding_algorithm_name(this, "cpu_sharding_algorithm_name", value_status::Used, "biased-token-round-robin", "Select the type of connection-per-shard algorithm")
     , enable_ipv6_dns_lookup(this, "enable_ipv6_dns_lookup", value_status::Used, false, "Use IPv6 address resolution")
     , abort_on_internal_error(this, "abort_on_internal_error", liveness::LiveUpdate, value_status::Used, false, "Abort the server instead of throwing exception when internal invariants are violated")
     , max_partition_key_restrictions_per_query(this, "max_partition_key_restrictions_per_query", liveness::LiveUpdate, value_status::Used, 100,

--- a/db/config.hh
+++ b/db/config.hh
@@ -299,6 +299,7 @@ public:
     named_value<bool> enable_sstables_mc_format;
     named_value<bool> enable_dangerous_direct_import_of_cassandra_counters;
     named_value<bool> enable_shard_aware_drivers;
+    named_value<sstring> cpu_sharding_algorithm_name;
     named_value<bool> enable_ipv6_dns_lookup;
     named_value<bool> abort_on_internal_error;
     named_value<uint32_t> max_partition_key_restrictions_per_query;

--- a/dht/token-sharding.hh
+++ b/dht/token-sharding.hh
@@ -25,10 +25,6 @@
 
 namespace dht {
 
-inline sstring cpu_sharding_algorithm_name() {
-    return "biased-token-round-robin";
-}
-
 std::vector<uint64_t> init_zero_based_shard_start(unsigned shards, unsigned sharding_ignore_msb_bits);
 
 unsigned shard_of(unsigned shard_count, unsigned sharding_ignore_msb_bits, const token& t);

--- a/transport/controller.cc
+++ b/transport/controller.cc
@@ -71,6 +71,7 @@ future<> controller::do_start_server() {
         cql_server_config.max_request_size = service::get_local_storage_service()._service_memory_total;
         cql_server_config.get_service_memory_limiter_semaphore = [ss = std::ref(service::get_storage_service())] () -> semaphore& { return ss.get().local()._service_memory_limiter; };
         cql_server_config.allow_shard_aware_drivers = cfg.enable_shard_aware_drivers();
+        cql_server_config.cpu_sharding_algorithm_name = cfg.cpu_sharding_algorithm_name();
         cql_server_config.sharding_ignore_msb = cfg.murmur3_partitioner_ignore_msb_bits();
         cql_server_config.partitioner_name = cfg.partitioner();
         smp_service_group_config cql_server_smp_service_group_config;

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -224,6 +224,9 @@ cql_server::listen(socket_address addr, std::shared_ptr<seastar::tls::credential
     }
     return f.then([this, addr, keepalive](shared_ptr<seastar::tls::server_credentials> creds) {
         listen_options lo;
+        if (_config.cpu_sharding_algorithm_name == "biased-token-source-port"){
+            lo.lba = server_socket::load_balancing_algorithm::port;
+        }
         lo.reuse_address = true;
         server_socket ss;
         try {
@@ -1226,7 +1229,7 @@ std::unique_ptr<cql_server::response> cql_server::connection::make_supported(int
     if (_server._config.allow_shard_aware_drivers) {
         opts.insert({"SCYLLA_SHARD", format("{:d}", this_shard_id())});
         opts.insert({"SCYLLA_NR_SHARDS", format("{:d}", smp::count)});
-        opts.insert({"SCYLLA_SHARDING_ALGORITHM", dht::cpu_sharding_algorithm_name()});
+        opts.insert({"SCYLLA_SHARDING_ALGORITHM",  _server._config.cpu_sharding_algorithm_name});
         opts.insert({"SCYLLA_SHARDING_IGNORE_MSB", format("{:d}", _server._config.sharding_ignore_msb)});
         opts.insert({"SCYLLA_PARTITIONER", _server._config.partitioner_name});
     }

--- a/transport/server.hh
+++ b/transport/server.hh
@@ -108,6 +108,7 @@ struct cql_server_config {
     sstring partitioner_name;
     unsigned sharding_ignore_msb;
     bool allow_shard_aware_drivers = true;
+    sstring cpu_sharding_algorithm_name;
     smp_service_group bounce_request_smp_service_group = default_smp_service_group();
 };
 


### PR DESCRIPTION
new configuration `cpu_sharding_algorithm_name` that support one of the two:

* `biased-token-round-robin` (default) -
  seastar `load_balancing_algorithm::connection_distribution` would be used
  for CQL connections

* `biased-token-source-port` -
  seastar `load_balancing_algorithm::port` would be used for CQL connections

example in scylla-driver (python): scylladb/python-driver#54