### PR TITLE
Repair improve logging with uuid for repair job and more accurate error messages

### DIFF
--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -759,7 +759,7 @@ void repair_info::check_failed_ranges() {
         id, shard, ranges.size(), _sub_ranges_nr, _stats.get_stats());
     if (nr_failed_ranges) {
         rlogger.warn("repair id {} on shard {} failed - {} ranges failed", id, shard, nr_failed_ranges);
-        throw std::runtime_error(format("repair {:d} on shard {:d} failed to do checksum for {:d} sub ranges", id, shard, nr_failed_ranges));
+        throw std::runtime_error(format("repair id {:d} on shard {:d} failed to repair {:d} sub ranges", id, shard, nr_failed_ranges));
     } else {
         if (dropped_tables.size()) {
             rlogger.warn("repair id {} on shard {} completed successfully, keyspace={}, ignoring dropped tables={}", id, shard, keyspace, dropped_tables);

--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -352,7 +352,7 @@ future<> tracker::run(int id, std::function<void ()> func) {
             rlogger.info("repair id {} completed successfully", id);
             done(id, true);
         }).handle_exception([this, id] (std::exception_ptr ep) {
-            rlogger.info("repair id {} failed: {}", id, ep);
+            rlogger.warn("repair id {} failed: {}", id, ep);
             done(id, false);
             return make_exception_future(std::move(ep));
         });
@@ -758,7 +758,7 @@ void repair_info::check_failed_ranges() {
     rlogger.info("repair id {} on shard {} stats: ranges_nr={}, sub_ranges_nr={}, {}",
         id, shard, ranges.size(), _sub_ranges_nr, _stats.get_stats());
     if (nr_failed_ranges) {
-        rlogger.info("repair id {} on shard {} failed - {} ranges failed", id, shard, nr_failed_ranges);
+        rlogger.warn("repair id {} on shard {} failed - {} ranges failed", id, shard, nr_failed_ranges);
         throw std::runtime_error(format("repair {:d} on shard {:d} failed to do checksum for {:d} sub ranges", id, shard, nr_failed_ranges));
     } else {
         if (dropped_tables.size()) {
@@ -1400,7 +1400,7 @@ static future<> repair_ranges(lw_shared_ptr<repair_info> ri) {
         repair_tracker().remove_repair_info(ri->id);
         return make_ready_future<>();
     }).handle_exception([ri] (std::exception_ptr eptr) {
-        rlogger.info("repair id {} on shard {} failed: {}", ri->id, this_shard_id(), eptr);
+        rlogger.warn("repair id {} on shard {} failed: {}", ri->id, this_shard_id(), eptr);
         repair_tracker().remove_repair_info(ri->id);
         return make_exception_future<>(std::move(eptr));
     });
@@ -1520,7 +1520,7 @@ static int do_repair_start(seastar::sharded<database>& db, sstring keyspace,
             return make_ready_future<>();
         }).get();
     }).handle_exception([id] (std::exception_ptr ep) {
-        rlogger.info("repair_tracker run for repair id {} failed: {}", id, ep);
+        rlogger.warn("repair_tracker run for repair id {} failed: {}", id, ep);
     });
 
     return id;
@@ -1612,7 +1612,7 @@ future<> sync_data_using_repair(seastar::sharded<database>& db,
                 rlogger.warn("repair id {} to sync data for keyspace={}, status=failed: keyspace does not exist any more, ignoring it, {}", id, keyspace, ep);
                 return make_ready_future<>();
             }
-            rlogger.info("repair id {} to sync data for keyspace={}, status=failed: {}", id, keyspace,  ep);
+            rlogger.warn("repair id {} to sync data for keyspace={}, status=failed: {}", id, keyspace,  ep);
             return make_exception_future<>(ep);
         });
     });

--- a/repair/repair.hh
+++ b/repair/repair.hh
@@ -46,6 +46,14 @@ public:
     repair_stopped_exception() : repair_exception("Repair stopped") { }
 };
 
+struct repair_uniq_id {
+    int id;
+    utils::UUID uuid;
+    friend std::ostream& operator<<(std::ostream& os, const repair_uniq_id& x) {
+        return os << format("[id={}, uuid={}]", x.id, x.uuid);
+    }
+};
+
 // The tokens are the tokens assigned to the bootstrap node.
 future<> bootstrap_with_repair(seastar::sharded<database>& db, locator::token_metadata tm, std::unordered_set<dht::token> bootstrap_tokens);
 future<> decommission_with_repair(seastar::sharded<database>& db, locator::token_metadata tm);
@@ -178,7 +186,7 @@ public:
     dht::token_range_vector ranges;
     std::vector<sstring> cfs;
     std::vector<utils::UUID> table_ids;
-    int id;
+    repair_uniq_id id;
     shard_id shard;
     std::vector<sstring> data_centers;
     std::vector<sstring> hosts;
@@ -212,7 +220,7 @@ public:
             const sstring& keyspace_,
             const dht::token_range_vector& ranges_,
             std::vector<utils::UUID> table_ids_,
-            int id_,
+            repair_uniq_id id_,
             const std::vector<sstring>& data_centers_,
             const std::vector<sstring>& hosts_,
             streaming::stream_reason reason_);
@@ -265,13 +273,13 @@ private:
     // by one shared.
     std::vector<named_semaphore> _range_parallelism_semaphores;
     static constexpr size_t _max_repair_memory_per_range = 32 * 1024 * 1024;
-    void start(int id);
-    void done(int id, bool succeeded);
+    void start(repair_uniq_id id);
+    void done(repair_uniq_id id, bool succeeded);
 public:
     explicit tracker(size_t nr_shards, size_t max_repair_memory);
     ~tracker();
     repair_status get(int id);
-    int next_repair_command();
+    repair_uniq_id next_repair_command();
     future<> shutdown();
     void check_in_shutdown();
     void add_repair_info(int id, lw_shared_ptr<repair_info> ri);
@@ -282,7 +290,7 @@ public:
     void abort_all_repairs();
     named_semaphore& range_parallelism_semaphore();
     static size_t max_repair_memory_per_range() { return _max_repair_memory_per_range; }
-    future<> run(int id, std::function<void ()> func);
+    future<> run(repair_uniq_id id, std::function<void ()> func);
 };
 
 future<uint64_t> estimate_partitions(seastar::sharded<database>& db, const sstring& keyspace,

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -2078,7 +2078,7 @@ future<> repair_init_messaging_service_handler(repair_service& rs, distributed<d
             // Start a new fiber.
             (void)repair_get_row_diff_with_rpc_stream_handler(from, src_cpu_id, repair_meta_id, sink, source).handle_exception(
                     [from, repair_meta_id, sink, source] (std::exception_ptr ep) {
-                rlogger.info("Failed to process get_row_diff_with_rpc_stream_handler from={}, repair_meta_id={}: {}", from, repair_meta_id, ep);
+                rlogger.warn("Failed to process get_row_diff_with_rpc_stream_handler from={}, repair_meta_id={}: {}", from, repair_meta_id, ep);
             });
             return make_ready_future<rpc::sink<repair_row_on_wire_with_cmd>>(sink);
         });
@@ -2089,7 +2089,7 @@ future<> repair_init_messaging_service_handler(repair_service& rs, distributed<d
             // Start a new fiber.
             (void)repair_put_row_diff_with_rpc_stream_handler(from, src_cpu_id, repair_meta_id, sink, source).handle_exception(
                     [from, repair_meta_id, sink, source] (std::exception_ptr ep) {
-                rlogger.info("Failed to process put_row_diff_with_rpc_stream_handler from={}, repair_meta_id={}: {}", from, repair_meta_id, ep);
+                rlogger.warn("Failed to process put_row_diff_with_rpc_stream_handler from={}, repair_meta_id={}: {}", from, repair_meta_id, ep);
             });
             return make_ready_future<rpc::sink<repair_stream_cmd>>(sink);
         });
@@ -2100,7 +2100,7 @@ future<> repair_init_messaging_service_handler(repair_service& rs, distributed<d
             // Start a new fiber.
             (void)repair_get_full_row_hashes_with_rpc_stream_handler(from, src_cpu_id, repair_meta_id, sink, source).handle_exception(
                     [from, repair_meta_id, sink, source] (std::exception_ptr ep) {
-                rlogger.info("Failed to process get_full_row_hashes_with_rpc_stream_handler from={}, repair_meta_id={}: {}", from, repair_meta_id, ep);
+                rlogger.warn("Failed to process get_full_row_hashes_with_rpc_stream_handler from={}, repair_meta_id={}: {}", from, repair_meta_id, ep);
             });
             return make_ready_future<rpc::sink<repair_hash_with_cmd>>(sink);
         });


### PR DESCRIPTION
This series contains patches to improve repair logging.

1) repair: Add uuid to a repair job

Currently, repair uses an integer to identify a repair job. The repair
id starts from 1 since node restart. As a result, different repair jobs
will have same id across restart.

To make the id more unique across restart, we can use an uuid in
addition to the integer id. We can not drop the use of the integer id
completely since the http api and nodetool use it.

Fixes #6786


2) repair: Fix inaccurate in check_failed_ranges

The reason for the failure can be other reasons than failure of
checksum.

Fixes #6785

3)  repair: Use warn level for logs with recoverable failures

Those logs are not fatal and recoverable. We should make them warn level
instead of info level.

Fixes #5612

 

