### PR TITLE
build-deb.sh: fix rm to erase only python

### DIFF
--- a/reloc/python3/build_deb.sh
+++ b/reloc/python3/build_deb.sh
@@ -26,7 +26,7 @@ if [ ! -e $RELOC_PKG ]; then
     exit 1
 fi
 RELOC_PKG=$(readlink -f $RELOC_PKG)
-rm -rf build/debian
+rm -rf build/debian/scylla-python3-package
 mkdir -p build/debian/scylla-python3-package
 tar -C build/debian/scylla-python3-package -xpf $RELOC_PKG
 cd build/debian/scylla-python3-package


### PR DESCRIPTION
Fixes #6802 
While building unified-deb we first use scylla/reloc/build_deb.sh to create the scylla core package, and after that scylla/reloc/python3/build_deb.sh to create python3.

On 058da69#diff-4a42abbd0ed654a1257c623716804c82 a new rm -rf command was added.
It causes python3 process to erase Scylla-core process.

Set python3 to erase its own dir scylla-python3-package only.