### PR TITLE
dist: fix debian generated files for non-default PRODUCT setting

### DIFF
--- a/dist/debian/debian_files_gen.py
+++ b/dist/debian/debian_files_gen.py
@@ -51,8 +51,8 @@ shutil.rmtree('build/debian/debian', ignore_errors=True)
 shutil.copytree('dist/debian/debian', 'build/debian/debian')
 
 if product != 'scylla':
-    for p in Path.glob('build/debian/debian/scylla-*'):
-        if p.endswith('scylla-server.service'):
+    for p in Path('build/debian/debian').glob('scylla-*'):
+        if str(p).endswith('scylla-server.service'):
             p.rename(p.parent / '{}-server.'.format(product, p.name))
         else:
             p.rename(p.parent / p.name.replace('scylla-', f'{product}-'))


### PR DESCRIPTION
There are a bunch of renames that are done if PRODUCT is not the
default, but the Python code for them is incorrect. Path.glob()
is not a static method, and Path does not support .endswith().

Fix by constructing a Path object, and later casting to str.