### PR TITLE
Follow-up to CQL restrictions rewrite

### DIFF
--- a/cql3/restrictions/statement_restrictions.cc
+++ b/cql3/restrictions/statement_restrictions.cc
@@ -58,7 +58,7 @@ class statement_restrictions::initial_key_restrictions : public primary_key_rest
 public:
     initial_key_restrictions(bool allow_filtering)
         : _allow_filtering(allow_filtering) {
-        this->expression = conjunction{};
+        this->expression = true;
     }
     using bounds_range_type = typename primary_key_restrictions<T>::bounds_range_type;
 

--- a/cql3/statements/delete_statement.cc
+++ b/cql3/statements/delete_statement.cc
@@ -100,7 +100,7 @@ const column_definition* single_column(const binary_operator& oper) {
 /// See #6493.
 bool bounded_ck(const expression& expr) {
     return std::visit(overloaded_functor{
-            [] (bool b) { return !b; },
+            [] (bool b) { return true; }, // false means empty, true means no bounds at all; both fit the condition.
             [] (const binary_operator& oper) {
                 return *oper.op == operator_type::EQ; // Without EQ, one side must be unbounded.
             },


### PR DESCRIPTION
This takes care of some follow-up requests from the #5763 review.

Use concepts to explicitly state some interface constraints, and rename `find_if` to `find_atom`.

Tests: unit (dev)