### PR TITLE
cdc: Retry generation fetching after `read_failure_exception`

### DIFF
--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -698,6 +698,8 @@ bool storage_service::do_handle_cdc_generation_intercept_nonfatal_errors(db_cloc
         throw cdc_generation_handling_nonfatal_exception(e.what());
     } catch (exceptions::unavailable_exception& e) {
         throw cdc_generation_handling_nonfatal_exception(e.what());
+    } catch (exceptions::read_failure_exception& e) {
+        throw cdc_generation_handling_nonfatal_exception(e.what());
     } catch (...) {
         const auto ep = std::current_exception();
         if (is_timeout_exception(ep)) {


### PR DESCRIPTION
While fetching CDC generations, various exceptions can occur. They are divided into "fatal" and "nonfatal", where "fatal" ones prevent retrying of the fetch operation.

This patch makes `read_failure_exception` "non-fatal", because such error may appear during restart. In general this type of error can mean a few different things (e.g. an error code in a response from replica, but also a broken connection) so retrying seems reasonable.

Fixes #6804