### PR TITLE
Switch Estimated histogram to time_estimated_histogram latency

### DIFF
--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -1451,7 +1451,7 @@ future<executor::request_return_type> executor::put_item(client_state& client_st
         });
     }
     return op->execute(_proxy, client_state, trace_state, std::move(permit), needs_read_before_write, _stats).finally([op, start_time, this] {
-        _stats.api_operations.put_item_latency.add(std::chrono::steady_clock::now() - start_time, _stats.api_operations.put_item_latency._count + 1);
+        _stats.api_operations.put_item_latency.add(std::chrono::steady_clock::now() - start_time);
     });
 }
 
@@ -1534,7 +1534,7 @@ future<executor::request_return_type> executor::delete_item(client_state& client
         });
     }
     return op->execute(_proxy, client_state, trace_state, std::move(permit), needs_read_before_write, _stats).finally([op, start_time, this] {
-        _stats.api_operations.delete_item_latency.add(std::chrono::steady_clock::now() - start_time, _stats.api_operations.delete_item_latency._count + 1);
+        _stats.api_operations.delete_item_latency.add(std::chrono::steady_clock::now() - start_time);
     });
 }
 
@@ -2220,7 +2220,7 @@ future<executor::request_return_type> executor::update_item(client_state& client
         });
     }
     return op->execute(_proxy, client_state, trace_state, std::move(permit), needs_read_before_write, _stats).finally([op, start_time, this] {
-        _stats.api_operations.update_item_latency.add(std::chrono::steady_clock::now() - start_time, _stats.api_operations.update_item_latency._count + 1);
+        _stats.api_operations.update_item_latency.add(std::chrono::steady_clock::now() - start_time);
     });
 }
 
@@ -2301,7 +2301,7 @@ future<executor::request_return_type> executor::get_item(client_state& client_st
 
     return _proxy.query(schema, std::move(command), std::move(partition_ranges), cl, service::storage_proxy::coordinator_query_options(default_timeout(), std::move(permit), client_state)).then(
             [this, schema, partition_slice = std::move(partition_slice), selection = std::move(selection), attrs_to_get = std::move(attrs_to_get), start_time = std::move(start_time)] (service::storage_proxy::coordinator_query_result qr) mutable {
-        _stats.api_operations.get_item_latency.add(std::chrono::steady_clock::now() - start_time, _stats.api_operations.get_item_latency._count + 1);
+        _stats.api_operations.get_item_latency.add(std::chrono::steady_clock::now() - start_time);
         return make_ready_future<executor::request_return_type>(make_jsonable(describe_item(schema, partition_slice, *selection, *qr.query_result, std::move(attrs_to_get))));
     });
 }

--- a/alternator/stats.cc
+++ b/alternator/stats.cc
@@ -20,7 +20,7 @@
  */
 
 #include "stats.hh"
-
+#include "utils/histogram_metrics_helper.hh"
 #include <seastar/core/metrics.hh>
 
 namespace alternator {
@@ -37,7 +37,7 @@ stats::stats() : api_operations{} {
                         seastar::metrics::description("number of operations via Alternator API"), {op(CamelCaseName)}),
 #define OPERATION_LATENCY(name, CamelCaseName) \
                 seastar::metrics::make_histogram("op_latency", \
-                        seastar::metrics::description("Latency histogram of an operation via Alternator API"), {op(CamelCaseName)}, [this]{return api_operations.name.get_histogram(1,20);}),
+                        seastar::metrics::description("Latency histogram of an operation via Alternator API"), {op(CamelCaseName)}, [this]{return to_metrics_histogram(api_operations.name);}),
             OPERATION(batch_write_item, "BatchWriteItem")
             OPERATION(create_backup, "CreateBackup")
             OPERATION(create_global_table, "CreateGlobalTable")

--- a/alternator/stats.hh
+++ b/alternator/stats.hh
@@ -75,10 +75,10 @@ public:
         uint64_t update_table = 0;
         uint64_t update_time_to_live = 0;
 
-        utils::estimated_histogram put_item_latency;
-        utils::estimated_histogram get_item_latency;
-        utils::estimated_histogram delete_item_latency;
-        utils::estimated_histogram update_item_latency;
+        utils::time_estimated_histogram put_item_latency;
+        utils::time_estimated_histogram get_item_latency;
+        utils::time_estimated_histogram delete_item_latency;
+        utils::time_estimated_histogram update_item_latency;
     } api_operations;
     // Miscellaneous event counters
     uint64_t total_operations = 0;

--- a/api/api.hh
+++ b/api/api.hh
@@ -256,4 +256,6 @@ public:
     operator T() const { return value; }
 };
 
+utils_json::estimated_histogram time_to_json_histogram(const utils::time_estimated_histogram& val);
+
 }

--- a/api/column_family.hh
+++ b/api/column_family.hh
@@ -68,6 +68,8 @@ future<json::json_return_type> map_reduce_cf(http_context& ctx, const sstring& n
     });
 }
 
+future<json::json_return_type> map_reduce_cf_time_histogram(http_context& ctx, const sstring& name, std::function<utils::time_estimated_histogram(const column_family&)> f);
+
 struct map_reduce_column_families_locally {
     std::any init;
     std::function<std::unique_ptr<std::any>(column_family&)> mapper;

--- a/database.hh
+++ b/database.hh
@@ -352,11 +352,11 @@ struct table_stats {
     utils::timed_rate_moving_average_and_histogram cas_prepare{256};
     utils::timed_rate_moving_average_and_histogram cas_accept{256};
     utils::timed_rate_moving_average_and_histogram cas_learn{256};
-    utils::estimated_histogram estimated_read;
-    utils::estimated_histogram estimated_write;
-    utils::estimated_histogram estimated_cas_prepare;
-    utils::estimated_histogram estimated_cas_accept;
-    utils::estimated_histogram estimated_cas_learn;
+    utils::time_estimated_histogram estimated_read;
+    utils::time_estimated_histogram estimated_write;
+    utils::time_estimated_histogram estimated_cas_prepare;
+    utils::time_estimated_histogram estimated_cas_accept;
+    utils::time_estimated_histogram estimated_cas_learn;
     utils::estimated_histogram estimated_sstable_per_read{35};
     utils::timed_rate_moving_average_and_histogram tombstone_scanned;
     utils::timed_rate_moving_average_and_histogram live_scanned;

--- a/db/view/row_locking.cc
+++ b/db/view/row_locking.cc
@@ -80,7 +80,7 @@ row_locker::lock_pk(const dht::decorated_key& pk, bool exclusive, db::timeout_cl
     // even in the case of rehashing.
     return f.then([this, pk = &i->first, exclusive, &single_lock_stats, waiting_latency = std::move(waiting_latency)] () mutable {
         waiting_latency.stop();
-        single_lock_stats.estimated_waiting_for_lock.add(waiting_latency.latency(), single_lock_stats.operations_currently_waiting_for_lock);
+        single_lock_stats.estimated_waiting_for_lock.add(waiting_latency.latency());
         single_lock_stats.lock_acquisitions++;
         single_lock_stats.operations_currently_waiting_for_lock--;
         return lock_holder(this, pk, exclusive);
@@ -126,7 +126,7 @@ row_locker::lock_ck(const dht::decorated_key& pk, const clustering_key_prefix& c
         lock1.release();
         lock2.release();
         waiting_latency.stop();
-        single_lock_stats.estimated_waiting_for_lock.add(waiting_latency.latency(), single_lock_stats.operations_currently_waiting_for_lock);
+        single_lock_stats.estimated_waiting_for_lock.add(waiting_latency.latency());
         single_lock_stats.lock_acquisitions++;
         single_lock_stats.operations_currently_waiting_for_lock--;
         return lock_holder(this, pk, cpk, exclusive);

--- a/db/view/row_locking.hh
+++ b/db/view/row_locking.hh
@@ -51,7 +51,7 @@ public:
     struct single_lock_stats {
         uint64_t lock_acquisitions = 0;
         uint64_t operations_currently_waiting_for_lock = 0;
-        utils::estimated_histogram estimated_waiting_for_lock;
+        utils::time_estimated_histogram estimated_waiting_for_lock;
     };
     struct stats {
         single_lock_stats exclusive_row;

--- a/service/paxos/paxos_state.cc
+++ b/service/paxos/paxos_state.cc
@@ -120,9 +120,7 @@ future<prepare_response> paxos_state::prepare(tracing::trace_state_ptr tr_state,
         }).finally([schema, lc] () mutable {
             auto& stats = get_local_storage_proxy().get_db().local().find_column_family(schema).get_stats();
             stats.cas_prepare.mark(lc.stop().latency());
-            if (lc.is_start()) {
-                stats.estimated_cas_prepare.add(lc.latency(), stats.cas_prepare.hist.count);
-            }
+            stats.estimated_cas_prepare.add(lc.latency());
         });
     });
 }
@@ -162,9 +160,7 @@ future<bool> paxos_state::accept(tracing::trace_state_ptr tr_state, schema_ptr s
         }).finally([schema, lc] () mutable {
             auto& stats = get_local_storage_proxy().get_db().local().find_column_family(schema).get_stats();
             stats.cas_accept.mark(lc.stop().latency());
-            if (lc.is_start()) {
-                stats.estimated_cas_accept.add(lc.latency(), stats.cas_accept.hist.count);
-            }
+            stats.estimated_cas_accept.add(lc.latency());
         });
     });
 }
@@ -214,9 +210,7 @@ future<> paxos_state::learn(schema_ptr schema, proposal decision, clock_type::ti
     }).finally([schema, lc] () mutable {
         auto& stats = get_local_storage_proxy().get_db().local().find_column_family(schema).get_stats();
         stats.cas_learn.mark(lc.stop().latency());
-        if (lc.is_start()) {
-            stats.estimated_cas_learn.add(lc.latency(), stats.cas_learn.hist.count);
-        }
+        stats.estimated_cas_learn.add(lc.latency());
     });
 }
 

--- a/table.cc
+++ b/table.cc
@@ -968,11 +968,11 @@ void table::set_metrics() {
 
         if (_schema->ks_name() != db::system_keyspace::NAME && _schema->ks_name() != db::schema_tables::v3::NAME && _schema->ks_name() != "system_traces") {
             _metrics.add_group("column_family", {
-                    ms::make_histogram("read_latency", ms::description("Read latency histogram"), [this] {return _stats.estimated_read.get_histogram(std::chrono::microseconds(100));})(cf)(ks),
-                    ms::make_histogram("write_latency", ms::description("Write latency histogram"), [this] {return _stats.estimated_write.get_histogram(std::chrono::microseconds(100));})(cf)(ks),
-                    ms::make_histogram("cas_prepare_latency", ms::description("CAS prepare round latency histogram"), [this] {return _stats.estimated_cas_prepare.get_histogram(std::chrono::microseconds(100));})(cf)(ks),
-                    ms::make_histogram("cas_propose_latency", ms::description("CAS accept round latency histogram"), [this] {return _stats.estimated_cas_accept.get_histogram(std::chrono::microseconds(100));})(cf)(ks),
-                    ms::make_histogram("cas_commit_latency", ms::description("CAS learn round latency histogram"), [this] {return _stats.estimated_cas_learn.get_histogram(std::chrono::microseconds(100));})(cf)(ks),
+                    ms::make_histogram("read_latency", ms::description("Read latency histogram"), [this] {return to_metrics_histogram(_stats.estimated_read);})(cf)(ks),
+                    ms::make_histogram("write_latency", ms::description("Write latency histogram"), [this] {return to_metrics_histogram(_stats.estimated_write);})(cf)(ks),
+                    ms::make_histogram("cas_prepare_latency", ms::description("CAS prepare round latency histogram"), [this] {return to_metrics_histogram(_stats.estimated_cas_prepare);})(cf)(ks),
+                    ms::make_histogram("cas_propose_latency", ms::description("CAS accept round latency histogram"), [this] {return to_metrics_histogram(_stats.estimated_cas_accept);})(cf)(ks),
+                    ms::make_histogram("cas_commit_latency", ms::description("CAS learn round latency histogram"), [this] {return to_metrics_histogram(_stats.estimated_cas_learn);})(cf)(ks),
                     ms::make_gauge("cache_hit_rate", ms::description("Cache hit rate"), [this] {return float(_global_cache_hit_rate);})(cf)(ks)
             });
         }
@@ -1938,7 +1938,7 @@ void table::do_apply(db::rp_handle&& h, Args&&... args) {
     }
     _stats.writes.mark(lc);
     if (lc.is_start()) {
-        _stats.estimated_write.add(lc.latency(), _stats.writes.hist.count);
+        _stats.estimated_write.add(lc.latency());
     }
 }
 
@@ -2033,7 +2033,7 @@ table::query(schema_ptr s,
         }).finally([lc, this]() mutable {
             _stats.reads.mark(lc);
             if (lc.is_start()) {
-                _stats.estimated_read.add(lc.latency(), _stats.reads.hist.count);
+                _stats.estimated_read.add(lc.latency());
             }
         });
     });

--- a/table.cc
+++ b/table.cc
@@ -46,6 +46,7 @@
 #include <boost/range/adaptor/transformed.hpp>
 #include <boost/range/adaptor/map.hpp>
 #include "utils/error_injection.hh"
+#include "utils/histogram_metrics_helper.hh"
 
 static logging::logger tlogger("table");
 static seastar::metrics::label column_family_label("cf");
@@ -952,7 +953,7 @@ void table::set_metrics() {
                 ms::make_total_operations(format("row_lock_{}_acquisitions", stat_name), stats.lock_acquisitions, ms::description(format("Row lock acquisitions for {} lock", stat_name)))(cf)(ks),
                 ms::make_queue_length(format("row_lock_{}_operations_currently_waiting_for_lock", stat_name), stats.operations_currently_waiting_for_lock, ms::description(format("Operations currently waiting for {} lock", stat_name)))(cf)(ks),
                 ms::make_histogram(format("row_lock_{}_waiting_time", stat_name), ms::description(format("Histogram representing time that operations spent on waiting for {} lock", stat_name)),
-                        [&stats] {return stats.estimated_waiting_for_lock.get_histogram(std::chrono::microseconds(100));})(cf)(ks)
+                        [&stats] {return to_metrics_histogram(stats.estimated_waiting_for_lock);})(cf)(ks)
             });
         };
         add_row_lock_metrics(_row_locker_stats.exclusive_row, "exclusive_row");


### PR DESCRIPTION
This series is a continuation of the series that introduced the time_estimated_histogram.

time_estimated_histogram is more efficient and uses a higher reporting resolution.

See  #5815 and  #4746