### PR TITLE
build: install jmx and tools-java submodule dependencies

### DIFF
--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -28,6 +28,8 @@ else
 fi
 
 bash seastar/install-dependencies.sh
+bash tools/jmx/install-dependencies.sh
+bash tools/java/install-dependencies.sh
 
 debian_base_packages=(
     liblua5.3-dev


### PR DESCRIPTION
Let each submodule be responsible for its own dependencies, and
call the submodule's dependency installation script.