### PR TITLE
build: remove pystache from install-dependencies

### DIFF
--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -157,7 +157,7 @@ elif [ "$ID" = "fedora" ]; then
         exit 1
     fi
     yum install -y "${fedora_packages[@]}"
-    pip3 install pystache cassandra-driver
+    pip3 install cassandra-driver
 elif [ "$ID" = "centos" ]; then
     yum install -y "${centos_packages[@]}"
     echo -e "Configure example:\n\tpython3.4 ./configure.py --enable-dpdk --mode=release --static-boost --compiler=/opt/scylladb/bin/g++-7.3 --python python3.4 --ldflag=-Wl,-rpath=/opt/scylladb/lib64 --cflags=-I/opt/scylladb/include --with-antlr3=/opt/scylladb/bin/antlr3"


### PR DESCRIPTION
As of d6165bc1c348f0c38231a6e6ab85b259b0c4143a we do not
depend on pystache, so don't install it.