### PR TITLE
Allow empty nonwrapping ranges

### DIFF
--- a/cql3/expr/expression.cc
+++ b/cql3/expr/expression.cc
@@ -483,7 +483,7 @@ struct intersection_visitor {
 
     value_set operator()(const nonwrapping_range<bytes>& a, const nonwrapping_range<bytes>& b) const {
         const auto common_range = a.intersection(b, type->as_tri_comparator());
-        return common_range ? *common_range : empty_value_set;
+        return !common_range.empty(type->as_tri_comparator()) ? std::move(common_range) : empty_value_set;
     }
 };
 

--- a/dht/i_partitioner.cc
+++ b/dht/i_partitioner.cc
@@ -191,8 +191,8 @@ selective_token_range_sharder::next() {
         auto intersection = _range.intersection(std::move(candidate), dht::token_comparator());
         _start_token = _sharder.token_for_next_shard(end_token, _shard);
         _start_boundary = range_bound<dht::token>(_start_token);
-        if (intersection) {
-            return *intersection;
+        if (!intersection.empty(dht::token_comparator())) {
+            return intersection;
         }
     }
 
@@ -268,8 +268,8 @@ split_range_to_single_shard(const schema& s, const partition_range& pr, shard_id
             auto end_token = sharder.token_for_next_shard(start_token, next_shard);
             auto candidate = partition_range(std::move(start_boundary), range_bound<ring_position>(ring_position::starting_at(end_token), false));
             auto intersection = pr.intersection(std::move(candidate), cmp);
-            if (intersection) {
-                ret.push_back(std::move(*intersection));
+            if (!intersection.empty(cmp)) {
+                ret.push_back(std::move(intersection));
             }
             start_token = sharder.token_for_next_shard(end_token, shard);
             start_boundary = range_bound<ring_position>(ring_position::starting_at(start_token));

--- a/read_context.hh
+++ b/read_context.hh
@@ -55,11 +55,11 @@ public:
             if (_last_key) {
                 auto cmp = dht::ring_position_comparator(*_cache._schema);
                 auto&& new_range = _range.split_after(*_last_key, cmp);
-                if (!new_range) {
+                if (new_range.empty(cmp)) {
                     _reader = {};
                     return make_ready_future<mutation_fragment_opt>();
                 }
-                _range = std::move(*new_range);
+                _range = std::move(new_range);
                 _last_key = {};
             }
             if (_reader) {

--- a/row_cache.cc
+++ b/row_cache.cc
@@ -607,11 +607,11 @@ private:
                     } else {
                         dht::ring_position_comparator cmp(*_read_context->schema());
                         auto range = _pr->trim_front(std::optional<dht::partition_range::bound>(_lower_bound), cmp);
-                        if (!range) {
+                        if (range.empty(cmp)) {
                             return std::nullopt;
                         }
                         _lower_bound = dht::partition_range::bound{dht::ring_position::max()};
-                        _secondary_range = std::move(*range);
+                        _secondary_range = std::move(range);
                         _secondary_in_progress = true;
                         return std::nullopt;
                     }

--- a/test/boost/nonwrapping_range_test.cc
+++ b/test/boost/nonwrapping_range_test.cc
@@ -174,17 +174,17 @@ BOOST_AUTO_TEST_CASE(test_range_subtract) {
     BOOST_REQUIRE_EQUAL(r({4}, {}).subtract(r({1}, {3}), cmp), vec({r({4}, {})}));
     BOOST_REQUIRE_EQUAL(r({4}, {}).subtract(r({}, {3}), cmp), vec({r({4}, {})}));
 
-    BOOST_REQUIRE_EQUAL(r({5}, {1}).subtract(r({6}, {}), cmp), vec({r({}, {1}), r({5}, {{6, false}})}));
-    BOOST_REQUIRE_EQUAL(r({5}, {1}).subtract(r({6}, {1}), cmp), vec({r({5}, {{6, false}})}));
-    BOOST_REQUIRE_EQUAL(r({5}, {1}).subtract(r({6}, {2}), cmp), vec({r({5}, {{6, false}})}));
+    BOOST_REQUIRE_EQUAL(r({5}, {1}).subtract(r({6}, {}), cmp), vec());
+    BOOST_REQUIRE_EQUAL(r({5}, {1}).subtract(r({6}, {1}), cmp), vec());
+    BOOST_REQUIRE_EQUAL(r({5}, {1}).subtract(r({6}, {2}), cmp), vec());
 
     // FIXME: Also accept adjacent ranges merged
-    BOOST_REQUIRE_EQUAL(r({5}, {1}).subtract(r({4}, {7}), cmp), vec({r({}, {1}), r({{7, false}}, {})}));
+    BOOST_REQUIRE_EQUAL(r({5}, {1}).subtract(r({4}, {7}), cmp), vec());
 
     // FIXME: Also accept adjacent ranges merged
-    BOOST_REQUIRE_EQUAL(r({5}, {1}).subtract(r({6}, {7}), cmp), vec({r({}, {1}), r({5}, {{6, false}}), r({{7, false}}, {})}));
+    BOOST_REQUIRE_EQUAL(r({5}, {1}).subtract(r({6}, {7}), cmp), vec());
 
-    BOOST_REQUIRE_EQUAL(r({5}, {1}).subtract(r({}, {0}), cmp), vec({r({{0, false}}, {1}), r({5}, {})}));
+    BOOST_REQUIRE_EQUAL(r({5}, {1}).subtract(r({}, {0}), cmp), vec());
 }
 
 struct unsigned_comparator {

--- a/test/boost/range_test.cc
+++ b/test/boost/range_test.cc
@@ -343,22 +343,22 @@ BOOST_AUTO_TEST_CASE(test_split_after) {
     BOOST_REQUIRE_EQUAL(nwr1.split_after(2, cmp), nwr1);
     BOOST_REQUIRE_EQUAL(nwr1.split_after(5, cmp), nwr(b(5, false), b(8)));
     BOOST_REQUIRE_EQUAL(nwr1.split_after(6, cmp), nwr(b(6, false), b(8)));
-    BOOST_REQUIRE_EQUAL(nwr1.split_after(8, cmp), std::nullopt);
-    BOOST_REQUIRE_EQUAL(nwr1.split_after(9, cmp), std::nullopt);
+    BOOST_REQUIRE(nwr1.split_after(8, cmp).empty(cmp));
+    BOOST_REQUIRE(nwr1.split_after(9, cmp).empty(cmp));
     auto nwr2 = nwr(b(5, false), b(8, false));
     BOOST_REQUIRE_EQUAL(nwr2.split_after(2, cmp), nwr2);
     BOOST_REQUIRE_EQUAL(nwr2.split_after(5, cmp), nwr(b(5, false), b(8, false)));
     BOOST_REQUIRE_EQUAL(nwr2.split_after(6, cmp), nwr(b(6, false), b(8, false)));
-    BOOST_REQUIRE_EQUAL(nwr2.split_after(8, cmp), std::nullopt);
-    BOOST_REQUIRE_EQUAL(nwr2.split_after(9, cmp), std::nullopt);
+    BOOST_REQUIRE(nwr2.split_after(8, cmp).empty(cmp));
+    BOOST_REQUIRE(nwr2.split_after(9, cmp).empty(cmp));
     auto nwr3 = nwr(b(5, false), std::nullopt);
     BOOST_REQUIRE_EQUAL(nwr3.split_after(2, cmp), nwr3);
     BOOST_REQUIRE_EQUAL(nwr3.split_after(5, cmp), nwr3);
     BOOST_REQUIRE_EQUAL(nwr3.split_after(6, cmp), nwr(b(6, false), std::nullopt));
     auto nwr4 = nwr(std::nullopt, b(5, false));
     BOOST_REQUIRE_EQUAL(nwr4.split_after(2, cmp), nwr(b(2, false), b(5, false)));
-    BOOST_REQUIRE_EQUAL(nwr4.split_after(5, cmp), std::nullopt);
-    BOOST_REQUIRE_EQUAL(nwr4.split_after(6, cmp), std::nullopt);
+    BOOST_REQUIRE(nwr4.split_after(5, cmp).empty(cmp));
+    BOOST_REQUIRE(nwr4.split_after(6, cmp).empty(cmp));
     auto nwr5 = nwr(std::nullopt, std::nullopt);
     BOOST_REQUIRE_EQUAL(nwr5.split_after(2, cmp), nwr(b(2, false), std::nullopt));
 
@@ -399,7 +399,7 @@ BOOST_AUTO_TEST_CASE(test_intersection) {
 
     auto r1 = nwr(b(5), b(10));
     auto r2 = nwr(b(1), b(4));
-    BOOST_REQUIRE_EQUAL(r1.intersection(r2, cmp), std::nullopt);
+    BOOST_REQUIRE(r1.intersection(r2, cmp).empty(cmp));
     auto r3 = nwr(b(1), b(5));
     BOOST_REQUIRE_EQUAL(r1.intersection(r3, cmp), nwr(b(5), b(5)));
     auto r4 = nwr(b(2), b(7));
@@ -415,27 +415,27 @@ BOOST_AUTO_TEST_CASE(test_intersection) {
     auto r9 = nwr(b(10), b(12));
     BOOST_REQUIRE_EQUAL(r1.intersection(r9, cmp), nwr(b(10), b(10)));
     auto r10 = nwr(b(12), b(20));
-    BOOST_REQUIRE_EQUAL(r1.intersection(r10, cmp), std::nullopt);
+    BOOST_REQUIRE(r1.intersection(r10, cmp).empty(cmp));
     auto r11 = nwr(b(1), b(20));
     BOOST_REQUIRE_EQUAL(r1.intersection(r11, cmp), nwr(b(5), b(10)));
 
     auto r12 = nwr(b(1), b(3, false));
-    BOOST_REQUIRE_EQUAL(r12.intersection(nwr(b(3, false), b(5)), cmp), std::nullopt);
-    BOOST_REQUIRE_EQUAL(r12.intersection(nwr(b(3, false), b(5)), cmp), std::nullopt);
+    BOOST_REQUIRE(r12.intersection(nwr(b(3, false), b(5)), cmp).empty(cmp));
+    BOOST_REQUIRE(r12.intersection(nwr(b(3, false), b(5)), cmp).empty(cmp));
     BOOST_REQUIRE_EQUAL(r12.intersection(nwr(b(2), { }), cmp), nwr(b(2), b(3, false)));
     BOOST_REQUIRE_EQUAL(r12.intersection(nwr({ }, b(2)), cmp), nwr(b(1), b(2)));
-    BOOST_REQUIRE_EQUAL(r12.intersection(nwr::make_singular(4), cmp), std::nullopt);
-    BOOST_REQUIRE_EQUAL(r12.intersection(nwr::make_singular(3), cmp), std::nullopt);
+    BOOST_REQUIRE(r12.intersection(nwr::make_singular(4), cmp).empty(cmp));
+    BOOST_REQUIRE(r12.intersection(nwr::make_singular(3), cmp).empty(cmp));
     BOOST_REQUIRE_EQUAL(r12.intersection(nwr::make_singular(2), cmp), nwr(b(2), b(2)));
     BOOST_REQUIRE_EQUAL(r12.intersection(nwr::make_singular(1), cmp), nwr(b(1), b(1)));
-    BOOST_REQUIRE_EQUAL(r12.intersection(nwr::make_singular(0), cmp), std::nullopt);
+    BOOST_REQUIRE(r12.intersection(nwr::make_singular(0), cmp).empty(cmp));
 
     const auto r13 = nwr::make_singular(123);
     BOOST_REQUIRE_EQUAL(r13.intersection(r13, cmp), nwr(b(123), b(123)));
-    BOOST_REQUIRE_EQUAL(r13.intersection(nwr::make_singular(321), cmp), std::nullopt);
+    BOOST_REQUIRE(r13.intersection(nwr::make_singular(321), cmp).empty(cmp));
     BOOST_REQUIRE_EQUAL(r13.intersection(nwr(b(123), b(123)), cmp), nwr(b(123), b(123)));
     BOOST_REQUIRE_EQUAL(r13.intersection(nwr(b(123), b(124, false)), cmp), nwr(b(123), b(123)));
-    BOOST_REQUIRE_EQUAL(r13.intersection(nwr(b(123, false), b(124, false)), cmp), std::nullopt);
-    BOOST_REQUIRE_EQUAL(r13.intersection(nwr(b(0), b(123, false)), cmp), std::nullopt);
+    BOOST_REQUIRE(r13.intersection(nwr(b(123, false), b(124, false)), cmp).empty(cmp));
+    BOOST_REQUIRE(r13.intersection(nwr(b(0), b(123, false)), cmp).empty(cmp));
     BOOST_REQUIRE_EQUAL(r13.intersection(nwr(b(0), b(1000)), cmp), nwr(b(123), b(123)));
 }


### PR DESCRIPTION
Previous implementation of `nonwrapping_interval` (a.k.a. `nonwrapping_range`) did not handle empty intervals, which results in an unobvious interface - it's illegal(UB) to create an empty interval, e.g. `[0, 0)` or `[5, 1]`, and various functions return  `optional<nonwrapping_interval>` when the result might be empty - e.g. `intersection`. This miniseries adds support for empty intervals. It's RFC because the interface is still not pretty, but perhaps it's a step in the right direction.

Notes:
 * some of the tests operated on undefined ranges and even asserted certain results: e.g. `test_range_subtract`
 * `wrapping_interval` implements both `operator==` and `equal()`, where equal is the function that should be used for comparing intervals, since it accepts a comparator. `operator==` is quite useless, especially for now implemented empty ranges - `[5,1) == [6, 3)`, but it won't be so with current `operator==` implementation.
 * due to how intervals are implemented underneath, creating an empty `nonwrapping_interval<T>` needs a dummy value, since it's not always possible to create a default object of type `T`. In general, `empty` should be a bit field, but then we'd need to serialize it when sending it via network, which is not done now, otherwise the IDL layer won't be able to deduce if the interval is empty or not when it creates one. That's a bigger change though.

/cc @avikivity @dekimir