### PR TITLE
repair: Add progress metrics for node ops

### DIFF
--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -60,12 +60,16 @@ public:
                 [this] { return bootstrap_finished_percentage(); }),
             sm::make_gauge("rebuild_finished_percentage", sm::description("Number of finished percentage for rebuild operation on this shard."),
                 [this] { return rebuild_finished_percentage(); }),
+            sm::make_gauge("repair_finished_percentage", sm::description("Number of finished percentage for repair operation on this shard."),
+                [this] { return repair_finished_percentage(); }),
         });
     }
     uint64_t bootstrap_total_ranges{0};
     uint64_t bootstrap_finished_ranges{0};
     uint64_t rebuild_total_ranges{0};
     uint64_t rebuild_finished_ranges{0};
+    uint64_t repair_total_ranges_sum{0};
+    uint64_t repair_finished_ranges_sum{0};
 private:
     seastar::metrics::metric_groups _metrics;
     float bootstrap_finished_percentage() {
@@ -74,6 +78,7 @@ private:
     float rebuild_finished_percentage() {
         return rebuild_total_ranges == 0 ? 1 : float(rebuild_finished_ranges) / float(rebuild_total_ranges);
     }
+    float repair_finished_percentage();
 };
 
 static thread_local node_ops_metrics _node_ops_metrics;
@@ -271,6 +276,13 @@ tracker& repair_tracker() {
     }
 }
 
+float node_ops_metrics::repair_finished_percentage() {
+    if (_the_tracker) {
+        return repair_tracker().report_progress(streaming::stream_reason::repair);
+    }
+    return 1;
+}
+
 tracker::tracker(size_t nr_shards, size_t max_repair_memory)
     : _shutdown(false)
     , _repairs(nr_shards) {
@@ -396,6 +408,19 @@ void tracker::abort_all_repairs() {
         ri->abort();
     }
     rlogger.info0("Aborted {} repair job(s)", count);
+}
+
+float tracker::report_progress(streaming::stream_reason reason) {
+    uint64_t nr_ranges_finished = 0;
+    uint64_t nr_ranges_total = 0;
+    for (auto& x : _repairs[this_shard_id()]) {
+        auto& ri = x.second;
+        if (ri->reason == reason) {
+            nr_ranges_total += ri->nr_ranges_total;
+            nr_ranges_finished += ri->nr_ranges_finished;
+        }
+    }
+    return nr_ranges_total == 0 ? 1 : float(nr_ranges_finished) / float(nr_ranges_total);
 }
 
 named_semaphore& tracker::range_parallelism_semaphore() {
@@ -762,6 +787,7 @@ repair_info::repair_info(seastar::sharded<database>& db_,
     , data_centers(data_centers_)
     , hosts(hosts_)
     , reason(reason_)
+    , nr_ranges_total(ranges.size())
     , _row_level_repair(db.local().features().cluster_supports_row_level_repair()) {
 }
 
@@ -1423,6 +1449,9 @@ static future<> do_repair_ranges(lw_shared_ptr<repair_info> ri) {
                         _node_ops_metrics.bootstrap_finished_ranges++;
                     } else if (ri->reason == streaming::stream_reason::rebuild) {
                         _node_ops_metrics.rebuild_finished_ranges++;
+                    } else if (ri->reason == streaming::stream_reason::repair) {
+                        _node_ops_metrics.repair_finished_ranges_sum++;
+                        ri->nr_ranges_finished++;
                     }
                 });
             });
@@ -1452,6 +1481,9 @@ static future<> do_repair_ranges(lw_shared_ptr<repair_info> ri) {
                     _node_ops_metrics.bootstrap_finished_ranges++;
                 } else if (ri->reason == streaming::stream_reason::rebuild) {
                     _node_ops_metrics.rebuild_finished_ranges++;
+                } else if (ri->reason == streaming::stream_reason::repair) {
+                    _node_ops_metrics.repair_finished_ranges_sum++;
+                    ri->nr_ranges_finished++;
                 }
             });
         }).then([ri] {
@@ -1562,6 +1594,11 @@ static int do_repair_start(seastar::sharded<database>& db, sstring keyspace,
         rlogger.info("repair id {} completed successfully: no tables to repair", id);
         return id.id;
     }
+
+    auto nr_ranges_total = ranges.size();
+    db.invoke_on_all([nr_ranges_total] (database&) {
+        _node_ops_metrics.repair_total_ranges_sum += nr_ranges_total;
+    }).get();
 
     // Do it in the background.
     (void)repair_tracker().run(id, [&db, id, keyspace = std::move(keyspace),

--- a/repair/repair.hh
+++ b/repair/repair.hh
@@ -202,6 +202,8 @@ public:
     std::vector<sstring> hosts;
     streaming::stream_reason reason;
     std::unordered_map<dht::token_range, repair_neighbors> neighbors;
+    uint64_t nr_ranges_finished = 0;
+    uint64_t nr_ranges_total;
     size_t nr_failed_ranges = 0;
     bool aborted = false;
     // Map of peer -> <cf, ranges>
@@ -303,6 +305,7 @@ public:
     static size_t max_repair_memory_per_range() { return _max_repair_memory_per_range; }
     future<> run(repair_uniq_id id, std::function<void ()> func);
     future<repair_status> repair_await_completion(int id, std::chrono::steady_clock::time_point timeout);
+    float report_progress(streaming::stream_reason reason);
 };
 
 future<uint64_t> estimate_partitions(seastar::sharded<database>& db, const sstring& keyspace,


### PR DESCRIPTION
This series adds progress metrics for the node operations. Metrics for bootstrap and rebuild progress are added as a starter. I will add more for the remaining operations after getting feedback.

With this the Scylla Monitor and Scylla Manager can know the progress of the bootstrap and other node operations. E.g.,
```
    scylla_node_ops_bootstrap_nr_ranges_finished{shard="0",type="derive"} 50
    scylla_node_ops_bootstrap_nr_ranges_total{shard="0",type="derive"} 1040
```

Fixes #1244, #6733