### PR TITLE
Get rid of seed concept in gossip

### DIFF
--- a/gms/gossiper.cc
+++ b/gms/gossiper.cc
@@ -1763,38 +1763,86 @@ future<> gossiper::start_gossiping(int generation_nbr, std::map<application_stat
     });
 }
 
-future<> gossiper::do_shadow_round() {
-    return seastar::async([this, g = this->shared_from_this()] {
-        build_seeds_list();
-        _in_shadow_round = true;
-        auto t = clk::now();
-
-        // When peer node receives a syn message, it will send back a ack message.
-        // So, we need to register gossip message handlers before sending syn message.
+future<> gossiper::do_shadow_round(std::unordered_set<gms::inet_address> nodes) {
+    return seastar::async([this, g = this->shared_from_this(), nodes = std::move(nodes)] () mutable {
         get_gossiper().invoke_on_all([] (gossiper& g) {
             return g.init_messaging_service_handler();
         }).get();
-
-        while (this->_in_shadow_round) {
-            // send a completely empty syn
-            for (inet_address seed : _seeds) {
-                utils::chunked_vector<gossip_digest> digests;
-                gossip_digest_syn message(get_cluster_name(), get_partitioner_name(), digests);
-                auto id = get_msg_addr(seed);
-                logger.trace("Sending a GossipDigestSyn (ShadowRound) to {} ...", id);
-                // Do it in the background.
-                (void)ms().send_gossip_digest_syn(id, std::move(message)).handle_exception([id] (auto ep) {
-                    logger.trace("Fail to send GossipDigestSyn (ShadowRound) to {}: {}", id, ep);
+        nodes.erase(get_broadcast_address());
+        gossip_get_endpoint_states_request request{{
+            gms::application_state::STATUS,
+            gms::application_state::HOST_ID,
+            gms::application_state::TOKENS,
+            gms::application_state::SUPPORTED_FEATURES}};
+        logger.info("Gossip shadow round started with nodes={}", nodes);
+        std::unordered_set<gms::inet_address> nodes_talked;
+        size_t nodes_down = 0;
+        auto start_time = clk::now();
+        bool fall_back_to_syn_msg = false;
+        std::list<gms::gossip_get_endpoint_states_response> responses;
+        for (;;) {
+            parallel_for_each(nodes.begin(), nodes.end(), [this, &request, &responses, &nodes_talked, &nodes_down, &fall_back_to_syn_msg] (gms::inet_address node) {
+                logger.debug("Sent get_endpoint_states request to {}, request={}", node, request.application_states);
+                return ms().send_gossip_get_endpoint_states(msg_addr(node), std::chrono::milliseconds(5000), request).then(
+                        [node, &nodes_talked, &responses] (gms::gossip_get_endpoint_states_response response) {
+                    logger.debug("Got get_endpoint_states response from {}, response={}", node, response.endpoint_state_map);
+                    responses.push_back(std::move(response));
+                    nodes_talked.insert(node);
+                }).handle_exception_type([node, &fall_back_to_syn_msg] (seastar::rpc::unknown_verb_error&) {
+                    logger.warn("Node {} does not support get_endpoint_states verb", node);
+                    fall_back_to_syn_msg = true;
+                }).handle_exception_type([node, &nodes_down] (seastar::rpc::closed_error&) {
+                    nodes_down++;
+                    logger.warn("Node {} is down for get_endpoint_states verb", node);
                 });
+            }).get();
+            for (auto& response : responses) {
+                apply_state_locally_without_listener_notification(response.endpoint_state_map);
+            }
+            if (!nodes_talked.empty()) {
+                break;
+            }
+            if (nodes_down == nodes.size()) {
+                logger.warn("All nodes={} are down for get_endpoint_states verb. Skip ShadowRound.", nodes);
+                break;
+            }
+            if (fall_back_to_syn_msg) {
+                break;
+            }
+            if (clk::now() > start_time + std::chrono::milliseconds(_cfg.shadow_round_ms())) {
+                throw std::runtime_error(format("Unable to gossip with any nodes={} (ShadowRound).", nodes));
             }
             sleep_abortable(std::chrono::seconds(1), _abort_source).get();
-            if (this->_in_shadow_round) {
-                if (clk::now() > t + std::chrono::milliseconds(_cfg.shadow_round_ms())) {
-                    throw std::runtime_error(format("Unable to gossip with any seeds (ShadowRound)"));
+            logger.info("Connect nodes={} again ... ({} seconds passed)",
+                    nodes, std::chrono::duration_cast<std::chrono::seconds>(clk::now() - start_time).count());
+        }
+        if (fall_back_to_syn_msg) {
+            logger.info("Fallback to old method for ShadowRound");
+            auto t = clk::now();
+            _in_shadow_round = true;
+            while (this->_in_shadow_round) {
+                // send a completely empty syn
+                for (const auto& node : nodes) {
+                    utils::chunked_vector<gossip_digest> digests;
+                    gossip_digest_syn message(get_cluster_name(), get_partitioner_name(), digests);
+                    auto id = get_msg_addr(node);
+                    logger.trace("Sending a GossipDigestSyn (ShadowRound) to {} ...", id);
+                    // Do it in the background.
+                    (void)ms().send_gossip_digest_syn(id, std::move(message)).handle_exception([id] (auto ep) {
+                        logger.trace("Fail to send GossipDigestSyn (ShadowRound) to {}: {}", id, ep);
+                    });
                 }
-                logger.info("Connect seeds again ... ({} seconds passed)", std::chrono::duration_cast<std::chrono::seconds>(clk::now() - t).count());
+                sleep_abortable(std::chrono::seconds(1), _abort_source).get();
+                if (this->_in_shadow_round) {
+                    if (clk::now() > t + std::chrono::milliseconds(_cfg.shadow_round_ms())) {
+                        throw std::runtime_error(format("Unable to gossip with any nodes={} (ShadowRound),", nodes));
+                    }
+                    logger.info("Connect nodes={} again ... ({} seconds passed)",
+                            nodes, std::chrono::duration_cast<std::chrono::seconds>(clk::now() - t).count());
+                }
             }
         }
+        logger.info("Gossip shadow round finisehd with nodes_talked={}", nodes_talked);
     });
 }
 

--- a/gms/gossiper.hh
+++ b/gms/gossiper.hh
@@ -195,9 +195,10 @@ private:
      */
     atomic_vector<shared_ptr<i_endpoint_state_change_subscriber>> _subscribers;
 
+    std::list<std::vector<inet_address>> _endpoints_to_talk_with;
+
     /* live member set */
     utils::chunked_vector<inet_address> _live_endpoints;
-    std::list<inet_address> _live_endpoints_just_added;
 
     /* nodes are being marked as alive */
     std::unordered_set<inet_address> _pending_mark_alive_endpoints;

--- a/gms/gossiper.hh
+++ b/gms/gossiper.hh
@@ -485,7 +485,7 @@ public:
      *  Do a single 'shadow' round of gossip, where we do not modify any state
      *  Only used when replacing a node, to get and assume its states
      */
-    future<> do_shadow_round();
+    future<> do_shadow_round(std::unordered_set<gms::inet_address> nodes = {});
 
 private:
     void build_seeds_list();

--- a/gms/gossiper.hh
+++ b/gms/gossiper.hh
@@ -382,9 +382,6 @@ private:
     /* Sends a Gossip message to an unreachable member */
     future<> do_gossip_to_unreachable_member(gossip_digest_syn message);
 
-    /* Gossip to a seed for facilitating partition healing */
-    future<> do_gossip_to_seed(gossip_digest_syn prod);
-
     void do_status_check();
 
 public:
@@ -549,7 +546,6 @@ private:
     uint64_t _nr_run = 0;
     uint64_t _msg_processing = 0;
     bool _ms_registered = false;
-    bool _gossiped_to_seed = false;
     bool _gossip_settled = false;
 
     class msg_proc_guard;

--- a/gms/gossiper.hh
+++ b/gms/gossiper.hh
@@ -81,6 +81,8 @@ class gossip_digest_ack2;
 class gossip_digest;
 class inet_address;
 class i_endpoint_state_change_subscriber;
+class gossip_get_endpoint_states_request;
+class gossip_get_endpoint_states_response;
 
 class feature_service;
 
@@ -129,6 +131,7 @@ private:
     future<> handle_shutdown_msg(inet_address from);
     future<> do_send_ack_msg(msg_addr from, gossip_digest_syn syn_msg);
     future<> do_send_ack2_msg(msg_addr from, utils::chunked_vector<gossip_digest> ack_msg_digest);
+    future<gossip_get_endpoint_states_response> handle_get_endpoint_states_msg(gossip_get_endpoint_states_request request);
     static constexpr uint32_t _default_cpuid = 0;
     msg_addr get_msg_addr(inet_address to);
     void do_sort(utils::chunked_vector<gossip_digest>& g_digest_list);
@@ -441,7 +444,8 @@ public:
     future<> apply_state_locally(std::map<inet_address, endpoint_state> map);
 
 private:
-    void do_apply_state_locally(gms::inet_address node, const endpoint_state& remote_state);
+    void do_apply_state_locally(gms::inet_address node, const endpoint_state& remote_state, bool listener_notification);
+    void apply_state_locally_without_listener_notification(std::unordered_map<inet_address, endpoint_state> map);
 
     void apply_new_states(inet_address addr, endpoint_state& local_state, const endpoint_state& remote_state);
 
@@ -646,5 +650,13 @@ inline future<std::map<inet_address, arrival_window>> get_arrival_samples() {
     });
 }
 
+struct gossip_get_endpoint_states_request {
+    // Application states the sender requested
+    std::unordered_set<gms::application_state> application_states;
+};
+
+struct gossip_get_endpoint_states_response {
+    std::unordered_map<gms::inet_address, gms::endpoint_state> endpoint_state_map;
+};
 
 } // namespace gms

--- a/gms/gossiper.hh
+++ b/gms/gossiper.hh
@@ -441,6 +441,8 @@ public:
     future<> apply_state_locally(std::map<inet_address, endpoint_state> map);
 
 private:
+    void do_apply_state_locally(gms::inet_address node, const endpoint_state& remote_state);
+
     void apply_new_states(inet_address addr, endpoint_state& local_state, const endpoint_state& remote_state);
 
     // notify that a local application state is going to change (doesn't get triggered for remote changes)

--- a/idl/gossip_digest.idl.hh
+++ b/idl/gossip_digest.idl.hh
@@ -74,4 +74,12 @@ class gossip_digest_ack2 {
     std::map<gms::inet_address, gms::endpoint_state> get_endpoint_state_map();
 };
 
+struct gossip_get_endpoint_states_request {
+    std::unordered_set<gms::application_state> application_states;
+};
+
+struct gossip_get_endpoint_states_response {
+    std::unordered_map<gms::inet_address, gms::endpoint_state> endpoint_state_map;
+};
+
 }

--- a/message/messaging_service.cc
+++ b/message/messaging_service.cc
@@ -475,6 +475,7 @@ static constexpr unsigned do_get_rpc_client_idx(messaging_verb verb) {
     case messaging_verb::GOSSIP_DIGEST_ACK2:
     case messaging_verb::GOSSIP_SHUTDOWN:
     case messaging_verb::GOSSIP_ECHO:
+    case messaging_verb::GOSSIP_GET_ENDPOINT_STATES:
     case messaging_verb::GET_SCHEMA_VERSION:
         return 0;
     case messaging_verb::PREPARE_MESSAGE:
@@ -1033,6 +1034,16 @@ future<> messaging_service::unregister_gossip_digest_ack2() {
 }
 future<> messaging_service::send_gossip_digest_ack2(msg_addr id, gossip_digest_ack2 msg) {
     return send_message_oneway(this, messaging_verb::GOSSIP_DIGEST_ACK2, std::move(id), std::move(msg));
+}
+
+void messaging_service::register_gossip_get_endpoint_states(std::function<future<gms::gossip_get_endpoint_states_response> (const rpc::client_info& cinfo, gms::gossip_get_endpoint_states_request request)>&& func) {
+    register_handler(this, messaging_verb::GOSSIP_GET_ENDPOINT_STATES, std::move(func));
+}
+future<> messaging_service::unregister_gossip_get_endpoint_states() {
+    return unregister_handler(messaging_verb::GOSSIP_GET_ENDPOINT_STATES);
+}
+future<gms::gossip_get_endpoint_states_response> messaging_service::send_gossip_get_endpoint_states(msg_addr id, std::chrono::milliseconds timeout, gms::gossip_get_endpoint_states_request request) {
+    return send_message_timeout<future<gms::gossip_get_endpoint_states_response>>(this, messaging_verb::GOSSIP_GET_ENDPOINT_STATES, std::move(id), std::move(timeout), std::move(request));
 }
 
 void messaging_service::register_definitions_update(std::function<rpc::no_wait_type (const rpc::client_info& cinfo, std::vector<frozen_mutation> fm,

--- a/message/messaging_service.hh
+++ b/message/messaging_service.hh
@@ -54,6 +54,8 @@ namespace gms {
     class gossip_digest_syn;
     class gossip_digest_ack;
     class gossip_digest_ack2;
+    class gossip_get_endpoint_states_request;
+    class gossip_get_endpoint_states_response;
 }
 
 namespace utils {
@@ -140,7 +142,8 @@ enum class messaging_verb : int32_t {
     PAXOS_LEARN = 41,
     HINT_MUTATION = 42,
     PAXOS_PRUNE = 43,
-    LAST = 44,
+    GOSSIP_GET_ENDPOINT_STATES = 44,
+    LAST = 45,
 };
 
 } // namespace netw
@@ -408,6 +411,11 @@ public:
     void register_gossip_digest_ack2(std::function<rpc::no_wait_type (gms::gossip_digest_ack2)>&& func);
     future<> unregister_gossip_digest_ack2();
     future<> send_gossip_digest_ack2(msg_addr id, gms::gossip_digest_ack2 msg);
+
+    // Wrapper for GOSSIP_GET_ENDPOINT_STATES
+    void register_gossip_get_endpoint_states(std::function<future<gms::gossip_get_endpoint_states_response> (const rpc::client_info& cinfo, gms::gossip_get_endpoint_states_request request)>&& func);
+    future<> unregister_gossip_get_endpoint_states();
+    future<gms::gossip_get_endpoint_states_response> send_gossip_get_endpoint_states(msg_addr id, std::chrono::milliseconds timeout, gms::gossip_get_endpoint_states_request request);
 
     // Wrapper for DEFINITIONS_UPDATE
     void register_definitions_update(std::function<rpc::no_wait_type (const rpc::client_info& cinfo, std::vector<frozen_mutation> fm,

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -206,12 +206,36 @@ bool get_property_load_ring_state() {
     return get_local_storage_service().db().local().get_config().load_ring_state();
 }
 
-bool storage_service::should_bootstrap() const {
-    return is_auto_bootstrap() && !db::system_keyspace::bootstrap_complete() && !_gossiper.get_seeds().count(get_broadcast_address());
+bool storage_service::is_first_node() {
+    if (db().local().is_replacing()) {
+        return false;
+    }
+    auto seeds = _gossiper.get_seeds();
+    if (seeds.empty()) {
+        return false;
+    }
+    // Node with the smallest IP address is chosen as the very first node
+    // in the cluster. The first node is the only node that does not
+    // bootstrap in the cluser. All other nodes will bootstrap.
+    std::vector<gms::inet_address> sorted_seeds(seeds.begin(), seeds.end());
+    std::sort(sorted_seeds.begin(), sorted_seeds.end());
+    if (sorted_seeds.front() == get_broadcast_address()) {
+        slogger.info("I am the first node in the cluster. Skip bootstrap. Node={}", get_broadcast_address());
+        return true;
+    }
+    return false;
+}
+
+bool storage_service::should_bootstrap() {
+    return !db::system_keyspace::bootstrap_complete() && !is_first_node();
 }
 
 // Runs inside seastar::async context
-void storage_service::prepare_to_join(std::vector<inet_address> loaded_endpoints, const std::unordered_map<gms::inet_address, sstring>& loaded_peer_features, bind_messaging_port do_bind) {
+void storage_service::prepare_to_join(
+        std::unordered_set<gms::inet_address> initial_contact_nodes,
+        std::unordered_set<gms::inet_address> loaded_endpoints,
+        std::unordered_map<gms::inet_address, sstring> loaded_peer_features,
+        bind_messaging_port do_bind) {
     std::map<gms::application_state, gms::versioned_value> app_states;
     if (db::system_keyspace::was_decommissioned()) {
         if (db().local().get_config().override_decommission()) {
@@ -233,62 +257,20 @@ void storage_service::prepare_to_join(std::vector<inet_address> loaded_endpoints
         if (db::system_keyspace::bootstrap_complete()) {
             throw std::runtime_error("Cannot replace address with a node that is already bootstrapped");
         }
-        if (!is_auto_bootstrap()) {
-            throw std::runtime_error("Trying to replace_address with auto_bootstrap disabled will not work, check your configuration");
-        }
-
-        std::tie(_bootstrap_tokens, _cdc_streams_ts) = prepare_replacement_info(loaded_peer_features).get0();
+        std::tie(_bootstrap_tokens, _cdc_streams_ts) = prepare_replacement_info(initial_contact_nodes, loaded_peer_features).get0();
         auto replace_address = db().local().get_replace_address();
         replacing_a_node_with_same_ip = replace_address && *replace_address == get_broadcast_address();
         replacing_a_node_with_diff_ip = replace_address && *replace_address != get_broadcast_address();
     } else if (should_bootstrap()) {
-        check_for_endpoint_collision(loaded_peer_features).get();
+        check_for_endpoint_collision(initial_contact_nodes, loaded_peer_features).get();
     } else {
-        auto seeds = _gossiper.get_seeds();
-        auto my_ep = get_broadcast_address();
         auto local_features = _feature_service.known_feature_set();
-
-        if (seeds.count(my_ep)) {
-            // This node is a seed node
-            if (loaded_peer_features.empty()) {
-                // This is a competely new seed node, skip the check
-                slogger.info("Checking remote features skipped, since this node is a new seed node which knows nothing about the cluster");
-            } else {
-                // This is a existing seed node
-                if (seeds.size() == 1) {
-                    // This node is the only seed node, check features with system table
-                    slogger.info("Checking remote features with system table, since this node is the only seed node");
-                    _gossiper.check_knows_remote_features(local_features, loaded_peer_features);
-                } else {
-                    // More than one seed node in the seed list, do shadow round with other seed nodes
-                    try {
-                        slogger.info("Checking remote features with gossip and system tables");
-                        _gossiper.do_shadow_round().get();
-                    } catch (...) {
-                        slogger.info("Shadow round failed with {}, checking remote features with system tables only",
-                                std::current_exception());
-                        _gossiper.finish_shadow_round();
-                    }
-
-                    _gossiper.check_knows_remote_features(local_features, loaded_peer_features);
-                    _gossiper.reset_endpoint_state_map().get();
-                    for (auto ep : loaded_endpoints) {
-                        _gossiper.add_saved_endpoint(ep);
-                    }
-                }
-            }
-        } else {
-            // This node is a non-seed node
-            // Do shadow round to check if this node knows all the features
-            // advertised by all other nodes, otherwise this node is too old
-            // (missing features) to join the cluser.
-            slogger.info("Checking remote features with gossip");
-            _gossiper.do_shadow_round().get();
-            _gossiper.check_knows_remote_features(local_features, loaded_peer_features);
-            _gossiper.reset_endpoint_state_map().get();
-            for (auto ep : loaded_endpoints) {
-                _gossiper.add_saved_endpoint(ep);
-            }
+        slogger.info("Checking remote features with gossip, initial_contact_nodes={}", initial_contact_nodes);
+        _gossiper.do_shadow_round(initial_contact_nodes).get();
+        _gossiper.check_knows_remote_features(local_features, loaded_peer_features);
+        _gossiper.reset_endpoint_state_map().get();
+        for (auto ep : loaded_endpoints) {
+            _gossiper.add_saved_endpoint(ep);
         }
     }
 
@@ -412,14 +394,6 @@ void storage_service::join_token_ring(int delay) {
     // We attempted to replace this with a schema-presence check, but you need a meaningful sleep
     // to get schema info from gossip which defeats the purpose.  See CASSANDRA-4427 for the gory details.
     std::unordered_set<inet_address> current;
-    slogger.debug("Bootstrap variables: {} {} {} {}",
-                 is_auto_bootstrap(),
-                 db::system_keyspace::bootstrap_in_progress(),
-                 db::system_keyspace::bootstrap_complete(),
-                 _gossiper.get_seeds().count(get_broadcast_address()));
-    if (is_auto_bootstrap() && !db::system_keyspace::bootstrap_complete() && _gossiper.get_seeds().count(get_broadcast_address())) {
-        slogger.info("This node will not auto bootstrap because it is configured to be a seed node.");
-    }
     if (should_bootstrap()) {
         bool resume_bootstrap = db::system_keyspace::bootstrap_in_progress();
         if (resume_bootstrap) {
@@ -545,19 +519,6 @@ void storage_service::join_token_ring(int delay) {
                 slogger.info("Using saved tokens {}", _bootstrap_tokens);
             }
         }
-    }
-
-
-    if (!is_auto_bootstrap()) {
-        slogger.warn("auto_bootstrap set to \"off\". This causes UNDEFINED BEHAVIOR. YOU MAY LOSE DATA.");
-    }
-
-    if (!db::system_keyspace::bootstrap_complete() && _gossiper.get_seeds().count(get_broadcast_address())) {
-        slogger.warn("Bootstrapping node marked as seed (present in the seed list)."
-                     " This can only be done for the very first node in a new cluster."
-                     " If this is not the first node, YOU MAY LOSE DATA."
-                     " Bootstrapping new nodes into an existing cluster as seeds"
-                     " causes UNDEFINED BEHAVIOR. DO NOT EVER do that.");
     }
 
     slogger.debug("Setting tokens to {}", _bootstrap_tokens);
@@ -961,8 +922,6 @@ void storage_service::bootstrap() {
             db::system_keyspace::remove_endpoint(*replace_addr).get();
         }
     }
-
-    _gossiper.check_seen_seeds();
 
     _db.invoke_on_all([this] (database& db) {
         for (auto& cf : db.get_non_system_column_families()) {
@@ -1643,7 +1602,7 @@ future<> storage_service::init_server(bind_messaging_port do_bind) {
         // pending ranges when keyspace is chagned
         _mnotifier.local().register_listener(this);
 
-        std::vector<inet_address> loaded_endpoints;
+        std::unordered_set<inet_address> loaded_endpoints;
         if (get_property_load_ring_state()) {
             slogger.info("Loading persisted ring state");
             auto loaded_tokens = db::system_keyspace::load_tokens().get0();
@@ -1668,19 +1627,27 @@ future<> storage_service::init_server(bind_messaging_port do_bind) {
                     if (loaded_host_ids.count(ep)) {
                         _token_metadata.update_host_id(loaded_host_ids.at(ep), ep);
                     }
-                    loaded_endpoints.push_back(ep);
+                    loaded_endpoints.insert(ep);
                     _gossiper.add_saved_endpoint(ep);
                 }
             }
         }
 
+        // Seeds are now only used as the initial contact point nodes. If the
+        // loaded_endpoints are empty which means this node is a completely new
+        // node, we use the nodes specified in seeds as the initial contact
+        // point nodes, otherwise use the peer nodes persisted in system table.
+        auto seeds = _gossiper.get_seeds();
+        auto initial_contact_nodes = loaded_endpoints.empty() ?
+            std::unordered_set<gms::inet_address>(seeds.begin(), seeds.end()) :
+            loaded_endpoints;
         auto loaded_peer_features = db::system_keyspace::load_peer_features().get0();
-        slogger.info("loaded_peer_features: peer_features size={}", loaded_peer_features.size());
+        slogger.info("initial_contact_nodes={}, loaded_endpoints={}, loaded_peer_features={}",
+                initial_contact_nodes, loaded_endpoints, loaded_peer_features.size());
         for (auto& x : loaded_peer_features) {
-            slogger.info("loaded_peer_features: peer={}, supported_features={}", x.first, x.second);
+            slogger.info("peer={}, supported_features={}", x.first, x.second);
         }
-
-        prepare_to_join(std::move(loaded_endpoints), loaded_peer_features, do_bind);
+        prepare_to_join(std::move(initial_contact_nodes), std::move(loaded_endpoints), std::move(loaded_peer_features), do_bind);
     });
 }
 
@@ -1745,16 +1712,16 @@ future<> storage_service::stop() {
     });
 }
 
-future<> storage_service::check_for_endpoint_collision(const std::unordered_map<gms::inet_address, sstring>& loaded_peer_features) {
+future<> storage_service::check_for_endpoint_collision(std::unordered_set<gms::inet_address> initial_contact_nodes, const std::unordered_map<gms::inet_address, sstring>& loaded_peer_features) {
     slogger.debug("Starting shadow gossip round to check for endpoint collision");
 
-    return seastar::async([this, loaded_peer_features] {
+    return seastar::async([this, initial_contact_nodes, loaded_peer_features] {
         auto t = gms::gossiper::clk::now();
         bool found_bootstrapping_node = false;
         auto local_features = _feature_service.known_feature_set();
         do {
             slogger.info("Checking remote features with gossip");
-            _gossiper.do_shadow_round().get();
+            _gossiper.do_shadow_round(initial_contact_nodes).get();
             _gossiper.check_knows_remote_features(local_features, loaded_peer_features);
             auto addr = get_broadcast_address();
             if (!_gossiper.is_safe_for_bootstrap(addr)) {
@@ -1807,7 +1774,7 @@ void storage_service::remove_endpoint(inet_address endpoint) {
 }
 
 future<storage_service::replacement_info>
-storage_service::prepare_replacement_info(const std::unordered_map<gms::inet_address, sstring>& loaded_peer_features) {
+storage_service::prepare_replacement_info(std::unordered_set<gms::inet_address> initial_contact_nodes, const std::unordered_map<gms::inet_address, sstring>& loaded_peer_features) {
     if (!db().local().get_replace_address()) {
         throw std::runtime_error(format("replace_address is empty"));
     }
@@ -1823,7 +1790,7 @@ storage_service::prepare_replacement_info(const std::unordered_map<gms::inet_add
 
     // make magic happen
     slogger.info("Checking remote features with gossip");
-    return _gossiper.do_shadow_round().then([this, loaded_peer_features, replace_address] {
+    return _gossiper.do_shadow_round(initial_contact_nodes).then([this, loaded_peer_features, replace_address] {
         auto local_features = _feature_service.known_feature_set();
         _gossiper.check_knows_remote_features(local_features, loaded_peer_features);
 

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -303,12 +303,14 @@ private:
 
     // Tokens and the CDC streams timestamp of the replaced node.
     using replacement_info = std::pair<std::unordered_set<token>, std::optional<db_clock::time_point>>;
-    future<replacement_info> prepare_replacement_info(const std::unordered_map<gms::inet_address, sstring>& loaded_peer_features);
+    future<replacement_info> prepare_replacement_info(std::unordered_set<gms::inet_address> initial_contact_nodes,
+            const std::unordered_map<gms::inet_address, sstring>& loaded_peer_features);
 
 public:
     future<bool> is_initialized();
 
-    future<> check_for_endpoint_collision(const std::unordered_map<gms::inet_address, sstring>& loaded_peer_features);
+    future<> check_for_endpoint_collision(std::unordered_set<gms::inet_address> initial_contact_nodes,
+            const std::unordered_map<gms::inet_address, sstring>& loaded_peer_features);
 
     /*!
      * \brief Init the messaging service part of the service.
@@ -345,8 +347,13 @@ public:
     void flush_column_families();
 
 private:
-    bool should_bootstrap() const;
-    void prepare_to_join(std::vector<inet_address> loaded_endpoints, const std::unordered_map<gms::inet_address, sstring>& loaded_peer_features, bind_messaging_port do_bind = bind_messaging_port::yes);
+    bool should_bootstrap();
+    bool is_first_node();
+    void prepare_to_join(
+            std::unordered_set<gms::inet_address> initial_contact_nodes,
+            std::unordered_set<gms::inet_address> loaded_endpoints,
+            std::unordered_map<gms::inet_address, sstring> loaded_peer_features,
+            bind_messaging_port do_bind = bind_messaging_port::yes);
     void join_token_ring(int delay);
     void maybe_start_sys_dist_ks();
 public:


### PR DESCRIPTION
 gossip: Get rid of seed concept
 
 The concept of seed and the different behaviour between seed nodes and
 non seed nodes generate a lot of confusion, complication and error for
 users. For example, how to add a seed node into into a cluster, how to
 promote a non seed node to a seed node, how to choose seeds node in
 multiple DC setup, edit config files for seeds, why seed node does not
 bootstrap.
 
 If we remove the concept of seed, it will get much easier for users.
 After this series, seed config option is only used once when a new node
 joins a cluster.
 
 Major changes:
 
 - Seed nodes are only used as the initial contact point nodes.
 
 - Seed nodes now perform bootstrap. The only exception is the first node
   in the cluster.
 
 - The unsafe auto_bootstrap option is now ignored.
 
 - Gossip shadow round now talks to all nodes instead of just seed nodes.
 
 Refs: #6845
 Tests: update_cluster_layout_tests.py + manual test
