### PR TITLE
scylla_raid_setup: fix incorrect block device path

### DIFF
--- a/dist/common/scripts/scylla_raid_setup
+++ b/dist/common/scripts/scylla_raid_setup
@@ -145,7 +145,7 @@ Before=scylla-server.service
 After=local-fs.target
 
 [Mount]
-What={uuid}
+What=UUID={uuid}
 Where={mount_at}
 Type=xfs
 Options=noatime


### PR DESCRIPTION
To use UUID, we need a tag "UUID=<uuid>".

reference: https://www.freedesktop.org/software/systemd/man/systemd.mount.html
reference: https://man7.org/linux/man-pages/man8/mount.8.html