### PR TITLE
Backport avoid use-after-free of sstable writer

### DIFF
--- a/sstables/compaction.cc
+++ b/sstables/compaction.cc
@@ -253,6 +253,7 @@ public:
     }
 
     virtual void write_failed() override {
+        _cf.get_compaction_strategy().get_backlog_tracker().revert_charges(std::move(_sst));
     }
 
     virtual uint64_t written() const {

--- a/sstables/compaction.cc
+++ b/sstables/compaction.cc
@@ -252,6 +252,9 @@ public:
         }
     }
 
+    virtual void write_failed() override {
+    }
+
     virtual uint64_t written() const {
         if (_tracker) {
             return _tracker->offset;

--- a/sstables/mc/writer.cc
+++ b/sstables/mc/writer.cc
@@ -772,6 +772,9 @@ public:
 };
 
 writer::~writer() {
+    if (_data_writer != nullptr) {
+        _cfg.monitor->write_failed();
+    }
     auto close_writer = [](auto& writer) {
         if (writer) {
             try {

--- a/sstables/progress_monitor.hh
+++ b/sstables/progress_monitor.hh
@@ -39,6 +39,7 @@ public:
     virtual void on_data_write_completed() = 0;
     virtual void on_write_completed() = 0;
     virtual void on_flush_completed() = 0;
+    virtual void write_failed() = 0;
 };
 
 struct noop_write_monitor final : public write_monitor {
@@ -46,6 +47,7 @@ struct noop_write_monitor final : public write_monitor {
     virtual void on_data_write_completed() override { }
     virtual void on_write_completed() override { }
     virtual void on_flush_completed() override { }
+    virtual void write_failed() override { }
 };
 
 write_monitor& default_write_monitor();

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -2299,6 +2299,7 @@ void sstable_writer_k_l::finish_file_writer()
 
 sstable_writer_k_l::~sstable_writer_k_l() {
     if (_writer) {
+        _monitor->write_failed();
         try {
             _writer->close();
         } catch (...) {

--- a/table.cc
+++ b/table.cc
@@ -746,6 +746,7 @@ public:
     }
     virtual void on_write_completed() override { }
     virtual void on_flush_completed() override { }
+    virtual void write_failed() override { }
 };
 
 // Handles all tasks related to sstable writing: permit management, compaction backlog updates, etc
@@ -777,7 +778,7 @@ public:
         _tracker = nullptr;
     }
 
-    void write_failed() {
+    virtual void write_failed() override {
         _compaction_strategy.get_backlog_tracker().revert_charges(_sst);
     }
 

--- a/table.cc
+++ b/table.cc
@@ -767,6 +767,17 @@ public:
             , _maximum_timestamp(max_timestamp)
     {}
 
+    database_sstable_write_monitor(const database_sstable_write_monitor&) = delete;
+    database_sstable_write_monitor(database_sstable_write_monitor&& x) = default;
+
+    ~database_sstable_write_monitor() {
+        // We failed to finish handling this SSTable, so we have to update the backlog_tracker
+        // about it.
+        if (_sst) {
+            _compaction_strategy.get_backlog_tracker().revert_charges(_sst);
+        }
+    }
+
     virtual void on_write_started(const sstables::writer_offset_tracker& t) override {
         _tracker = &t;
         _compaction_strategy.get_backlog_tracker().register_partially_written_sstable(_sst, *this);
@@ -779,7 +790,9 @@ public:
     }
 
     virtual void write_failed() override {
-        _compaction_strategy.get_backlog_tracker().revert_charges(_sst);
+        if (_sst) {
+            _compaction_strategy.get_backlog_tracker().revert_charges(std::move(_sst));
+        }
     }
 
     virtual uint64_t written() const override {

--- a/table.cc
+++ b/table.cc
@@ -849,8 +849,7 @@ table::seal_active_streaming_memtable_immediate(flush_permit&& permit) {
                         return old->clear_gently();
                       }
                     });
-                }).handle_exception([old, permit = std::move(permit), &monitor, newtab] (auto ep) {
-                    monitor.write_failed();
+                }).handle_exception([old, permit = std::move(permit), newtab] (auto ep) {
                     newtab->mark_for_deletion();
                     tlogger.error("failed to write streamed sstable: {}", ep);
                     return make_exception_future<>(ep);
@@ -890,7 +889,6 @@ future<> table::seal_active_streaming_memtable_big(streaming_memtable_big& smb, 
                         smb.sstables.push_back(monitored_sstable{std::move(monitor), newtab});
                         return make_ready_future<>();
                     } else {
-                        monitor->write_failed();
                         newtab->mark_for_deletion();
                         auto ep = f.get_exception();
                         tlogger.error("failed to write streamed sstable: {}", ep);
@@ -986,8 +984,8 @@ table::try_flush_memtable_to_sstable(lw_shared_ptr<memtable> old, sstable_write_
         // Switch back to default scheduling group for post-flush actions, to avoid them being staved by the memtable flush
         // controller. Cache update does not affect the input of the memtable cpu controller, so it can be subject to
         // priority inversion.
-        return with_scheduling_group(default_scheduling_group(), [this, &monitor, old = std::move(old), newtab = std::move(newtab), f = std::move(f)] () mutable {
-            return f.then([this, newtab, old, &monitor] {
+        return with_scheduling_group(default_scheduling_group(), [this, old = std::move(old), newtab = std::move(newtab), f = std::move(f)] () mutable {
+            return f.then([this, newtab, old] {
                 return newtab->open_data().then([this, old, newtab] () {
                     tlogger.debug("Flushing to {} done", newtab->get_filename());
                     return with_scheduling_group(_config.memtable_to_cache_scheduling_group, [this, old, newtab] {
@@ -998,8 +996,7 @@ table::try_flush_memtable_to_sstable(lw_shared_ptr<memtable> old, sstable_write_
                     tlogger.debug("Memtable for {} replaced", newtab->get_filename());
                     return stop_iteration::yes;
                 });
-            }).handle_exception([this, old, newtab, &monitor] (auto e) {
-                monitor.write_failed();
+            }).handle_exception([this, old, newtab] (auto e) {
                 newtab->mark_for_deletion();
                 _config.cf_stats->failed_memtables_flushes_count++;
                 tlogger.error("failed to write sstable {}: {}", newtab->get_filename(), e);
@@ -1914,7 +1911,6 @@ future<> table::fail_streaming_mutations(utils::UUID plan_id) {
     _streaming_memtables_big.erase(it);
     return entry->flush_in_progress.close().then([this, entry] {
         for (auto&& sst : entry->sstables) {
-            sst.monitor->write_failed();
             sst.sstable->mark_for_deletion();
         }
     });


### PR DESCRIPTION
4.0 Backport of:
1. Rafael's series "Avoid use-after-free of sstable writer" that was merged to master in 280854ab46344e5db16f95ca6989d5763f2d928b
2. A follow-up patch to that series: b2f50224d9df33c5dfdce83d5ab057bb5b58d7f2

Required for fixing Scylla crash during shutdown with segfault in sstables::mc:~writer seen in release branch.

Test: unit(dev)