### PR TITLE
configure.py: $mode-test targets depend on scylla

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1608,7 +1608,7 @@ with open(buildfile_tmp, 'w') as f:
         )
 
         f.write(
-            'build {mode}-test: test.{mode} {test_executables} $builddir/{mode}/test/tools/cql_repl\n'.format(
+            'build {mode}-test: test.{mode} {test_executables} $builddir/{mode}/test/tools/cql_repl $builddir/{mode}/scylla\n'.format(
                 mode=mode,
                 test_executables=' '.join(['$builddir/{}/{}'.format(mode, binary) for binary in tests]),
             )


### PR DESCRIPTION
The targets {dev|debug|release}-test run all unit tests, including
alternator/run.  But this test requires the Scylla executable, which
wasn't among the dependencies.  Fix it by adding build/$mode/scylla to
the dependency list.

Fixes #6855.

Tests: `ninja dev-test` after removing build/dev/scylla

Signed-off-by: Dejan Mircevski <dejan@scylladb.com>