### PR TITLE
dist: redhat: reduce log spam from unpacking sources when building rpm

### DIFF
--- a/dist/redhat/scylla.spec
+++ b/dist/redhat/scylla.spec
@@ -44,7 +44,7 @@ This package installs all required packages for ScyllaDB,  including
 %defattr(-,root,root)
 
 %prep
-%setup -n scylla
+%setup -q -n scylla
 
 %package        server
 Group:          Applications/Databases


### PR DESCRIPTION
rpmbuild defaults to logging the name of every file it unpacks from
the archive.

Make it quiet with the %setup -q flag.