### PR TITLE
alternator::streams: Do not allow enabling streams when CDC is off

### DIFF
--- a/alternator/executor.hh
+++ b/alternator/executor.hh
@@ -141,7 +141,7 @@ public:
 
 
 
-    static void add_stream_options(const rjson::value& stream_spec, schema_builder&);
+    void add_stream_options(const rjson::value& stream_spec, schema_builder&);
 };
 
 }

--- a/alternator/streams.cc
+++ b/alternator/streams.cc
@@ -36,6 +36,8 @@
 #include "cql3/result_set.hh"
 #include "cql3/type_json.hh"
 #include "schema_builder.hh"
+#include "gms/feature.hh"
+#include "gms/feature_service.hh"
 
 #include "executor.hh"
 #include "tags_extension.hh"
@@ -862,6 +864,12 @@ void executor::add_stream_options(const rjson::value& stream_specification, sche
     }
 
     if (stream_enabled->GetBool()) {
+        auto& db = _proxy.get_db().local();
+
+        if (!db.features().cluster_supports_cdc()) {
+            throw api_error::validation("StreamSpecification: streams (CDC) feature not enabled in cluster.");
+        }
+
         cdc::options opts;
         opts.enabled(true);
         auto type = rjson::get_opt<stream_view_type>(stream_specification, "StreamViewType").value_or(stream_view_type::KEYS_ONLY);


### PR DESCRIPTION
Fixes #6866

If we try to create/alter an Alternator table to include streams,
we must check that the cluster does in fact support CDC
(experimental still). If not, throw a hopefully somewhat descriptive
error.
(Normal CQL table create goes through a similar check in cql_prop_defs)

Note: no other operations are prohibited. The cluster could have had CDC
enabled before, so streams could exist to list and even read.
Any tables loaded from schema tables should be reposnsible for their
own validation.