### PR TITLE
docker: Make I/O configuration setup configurable

### DIFF
--- a/dist/common/scripts/scylla_setup
+++ b/dist/common/scripts/scylla_setup
@@ -70,7 +70,7 @@ def print_non_interactive_suggestion_message(args):
         outlines[-1] += x
 
     print(' \\\n'.join(outlines))
-    if args.no_io_setup == False:
+    if args.io_setup:
         print('\nAlso, to avoid the time-consuming I/O tuning you can add --no-io-setup and copy the contents of /etc/scylla.d/io*')
         print('Only do that if you are moving the files into machines with the exact same hardware')
 
@@ -191,7 +191,9 @@ if __name__ == '__main__':
                         help='skip coredump setup')
     parser.add_argument('--no-sysconfig-setup', action='store_true', default=False,
                         help='skip sysconfig setup')
-    parser.add_argument('--no-io-setup', action='store_true', default=False,
+    parser.add_argument('--io-setup', default='1', choices=['0', '1'], dest='io_setup',
+                        help='Run I/O configuration setup (i.e. iotune). Defaults to 1.')
+    parser.add_argument('--no-io-setup', dest='io_setup', action='store_const', const='0',
                         help='skip IO configuration setup')
     parser.add_argument('--no-version-check', action='store_true', default=False,
                         help='skip daily version check')
@@ -239,7 +241,7 @@ if __name__ == '__main__':
     raid_setup = not args.no_raid_setup
     coredump_setup = not args.no_coredump_setup
     sysconfig_setup = not args.no_sysconfig_setup
-    io_setup = not args.no_io_setup
+    io_setup = args.io_setup == "1"
     version_check = not args.no_version_check
     node_exporter = not args.no_node_exporter
     cpuscaling_setup = not args.no_cpuscaling_setup
@@ -420,7 +422,7 @@ if __name__ == '__main__':
             run_setup_script('Performance Tuning', 'scylla_sysconfig_setup --nic {nic} {setup_args}'.format(nic=nic, setup_args=setup_args))
 
     io_setup = interactive_ask_service('Do you want IOTune to study your disks IO profile and adapt Scylla to it? (*WARNING* Saying NO here means the node will not boot in production mode unless you configure the I/O Subsystem manually!)', 'Yes - let iotune study my disk(s). Note that this action will take a few minutes. No - skip this step.', io_setup)
-    args.no_io_setup = not io_setup
+    args.io_setup = io_setup
     if io_setup:
         run_setup_script('IO configuration', 'scylla_io_setup')
 

--- a/dist/docker/redhat/commandlineparser.py
+++ b/dist/docker/redhat/commandlineparser.py
@@ -12,6 +12,7 @@ def parse():
     parser.add_argument('--reserve-memory', default=None, dest='reserveMemory', help="e.g. --reserve-memory 1G to reserve 1 GB of RAM")
     parser.add_argument('--overprovisioned', default=None, choices=['0', '1'],
                         help="run in overprovisioned environment. By default it will run in overprovisioned mode unless --cpuset is specified")
+    parser.add_argument('--io-setup', default='1', choices=['0', '1'], dest='io_setup', help='Run I/O setup (i.e. iotune) at container startup. Defaults to 1.')
     parser.add_argument('--listen-address', default=None, dest='listenAddress')
     parser.add_argument('--rpc-address', default=None, dest='rpcAddress')
     parser.add_argument('--broadcast-address', default=None, dest='broadcastAddress')

--- a/dist/docker/redhat/scyllasetup.py
+++ b/dist/docker/redhat/scyllasetup.py
@@ -29,6 +29,7 @@ class ScyllaSetup:
         self._clusterName = arguments.clusterName
         self._endpointSnitch = arguments.endpointSnitch
         self._replaceAddressFirstBoot = arguments.replaceAddressFirstBoot
+        self._io_setup = arguments.io_setup
 
     def _run(self, *args, **kwargs):
         logging.info('running: {}'.format(args))
@@ -61,7 +62,8 @@ class ScyllaSetup:
         if not os.path.exists(data_dir):
             os.makedirs(data_dir)
 
-        self._run(['/opt/scylladb/scripts/scylla_io_setup'])
+        if self._io_setup == "1":
+            self._run(['/opt/scylladb/scripts/scylla_io_setup'])
 
     def cqlshrc(self):
         home = os.environ['HOME']

--- a/docs/docker-hub.md
+++ b/docs/docker-hub.md
@@ -243,6 +243,20 @@ For example, to enable optimizations for running in an statically partitioned en
 $ docker run --name some-scylla -d scylladb/scylla --overprovisioned 0
 ```
 
+### `--io-setup ENABLE`
+
+The `--io-setup` command line option specifies if the `scylla_io_setup` script is run when the container is started for the first time.
+This is useful if users want to specify I/O settings themselves in environments such as Kubernetes, where running `iotune` is problematic.
+The default of `--io-setup` is `1`, which means I/O setup is run.
+
+For example, to skip running I/O setup:
+
+```console
+$ docker run --name some-scylla -d scylladb/scylla --io-setup 0
+```
+
+**Since: 4.3**
+
 ### `--cpuset CPUSET`
 
 The `--cpuset` command line option restricts Scylla to run on only on CPUs specified by `CPUSET`.


### PR DESCRIPTION
This adds a '--io-setup N' command line option, which users can pass to
specify whether they want to run the "scylla_io_setup" script or not.
This is useful if users want to specify I/O settings themselves in
environments such as Kubernetes, where running "iotune" is problematic.

While at it, add the same option to "scylla_setup" to keep the interface
between that script and Docker consistent.

Fixes #6587