### PR TITLE
alternator::streams: Report streams as not ready until CDC stream id:…

### DIFF
--- a/alternator/executor.hh
+++ b/alternator/executor.hh
@@ -49,6 +49,10 @@ namespace cql3::selection {
     class selection;
 }
 
+namespace service {
+    class storage_service;
+}
+
 namespace alternator {
 
 class rmw_operation;
@@ -70,6 +74,7 @@ class executor : public peering_sharded_service<executor> {
     service::storage_proxy& _proxy;
     service::migration_manager& _mm;
     db::system_distributed_keyspace& _sdks;
+    service::storage_service& _ss;
     // An smp_service_group to be used for limiting the concurrency when
     // forwarding Alternator request between shards - if necessary for LWT.
     smp_service_group _ssg;
@@ -82,8 +87,8 @@ public:
     static constexpr auto KEYSPACE_NAME_PREFIX = "alternator_";
     static constexpr std::string_view INTERNAL_TABLE_PREFIX = ".scylla.alternator.";
 
-    executor(service::storage_proxy& proxy, service::migration_manager& mm, db::system_distributed_keyspace& sdks, smp_service_group ssg)
-        : _proxy(proxy), _mm(mm), _sdks(sdks), _ssg(ssg) {}
+    executor(service::storage_proxy& proxy, service::migration_manager& mm, db::system_distributed_keyspace& sdks, service::storage_service& ss, smp_service_group ssg)
+        : _proxy(proxy), _mm(mm), _sdks(sdks), _ss(ss), _ssg(ssg) {}
 
     future<request_return_type> create_table(client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value request);
     future<request_return_type> describe_table(client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value request);

--- a/cdc/metadata.cc
+++ b/cdc/metadata.cc
@@ -77,6 +77,12 @@ cdc::metadata::container_t::const_iterator cdc::metadata::gen_used_at(api::times
     return std::prev(it);
 }
 
+bool cdc::metadata::streams_available() const {
+    auto now = api::new_timestamp();
+    auto it = gen_used_at(now);
+    return  it != _gens.end();
+}
+
 cdc::stream_id cdc::metadata::get_stream(api::timestamp_type ts, dht::token tok) {
     auto now = api::new_timestamp();
     if (ts > now + generation_leeway.count()) {

--- a/cdc/metadata.hh
+++ b/cdc/metadata.hh
@@ -57,6 +57,10 @@ public:
     /* Is a generation with the given timestamp already known or superseded by a newer generation? */
     bool known_or_obsolete(db_clock::time_point) const;
 
+    /* Are there streams available. I.e. valid for time == now. If this is false, any writes to 
+     * CDC logs will fail fast.
+     */
+    bool streams_available() const;
     /* Return the stream for the base partition whose token is `tok` to which a corresponding log write should go
      * according to the generation used at time `ts` (i.e, the latest generation whose timestamp is less or equal to `ts`).
      *

--- a/main.cc
+++ b/main.cc
@@ -1198,7 +1198,7 @@ int main(int ac, char** av) {
                 smp_service_group_config c;
                 c.max_nonlocal_requests = 5000;
                 smp_service_group ssg = create_smp_service_group(c).get0();
-                alternator_executor.start(std::ref(proxy), std::ref(mm), std::ref(sys_dist_ks), ssg).get();
+                alternator_executor.start(std::ref(proxy), std::ref(mm), std::ref(sys_dist_ks), std::ref(service::get_storage_service()), ssg).get();
                 alternator_server.start(std::ref(alternator_executor)).get();
                 std::optional<uint16_t> alternator_port;
                 if (cfg->alternator_port()) {


### PR DESCRIPTION
…s are available

Refs #6864

When booting a clean scylla, CDC stream ID:s will not be availble until
a n*ring delay time period has passed. Before this, writing to a CDC
enabled table will fail hard.
For alternator (and its tests), we can report the stream(s) for tables as not yet
available (ENABLING) until such time as id:s are
computed.