### PR TITLE
cdc: New delta modes: `off`, `keys`, `fulll`

### DIFF
--- a/cdc/cdc_options.hh
+++ b/cdc/cdc_options.hh
@@ -27,10 +27,17 @@
 
 namespace cdc {
 
+enum class delta_mode {
+    off,
+    keys,
+    full,
+};
+
 class options final {
     bool _enabled = false;
     bool _preimage = false;
     bool _postimage = false;
+    delta_mode _delta_mode = delta_mode::full;
     int _ttl = 86400; // 24h in seconds
 public:
     options() = default;
@@ -42,6 +49,7 @@ public:
     bool enabled() const { return _enabled; }
     bool preimage() const { return _preimage; }
     bool postimage() const { return _postimage; }
+    delta_mode get_delta_mode() const { return _delta_mode; }
     int ttl() const { return _ttl; }
 
     void enabled(bool b) { _enabled = b; }

--- a/mutation_partition.hh
+++ b/mutation_partition.hh
@@ -192,7 +192,7 @@ public:
     const atomic_cell_or_collection* find_cell(column_id id) const;
     // Returns a pointer to cell's value and hash or nullptr if column is not set.
     const cell_and_hash* find_cell_and_hash(column_id id) const;
-private:
+
     template<typename Func>
     void remove_if(Func&& func) {
         if (_type == storage_type::vector) {

--- a/test/cql/cdc_delta_modes_test.cql
+++ b/test/cql/cdc_delta_modes_test.cql
@@ -1,0 +1,16 @@
+create table tb1 (pk int, ck int, i1 int, PRIMARY KEY (pk, ck)) with cdc = {'enabled': true, 'preimage': false, 'postimage': false, 'delta': 'off'};
+
+create table tb2 (pk int, ck int, i1 int, PRIMARY KEY (pk, ck)) with cdc = {'enabled': true, 'preimage': true, 'postimage': true, 'delta': 'off'};
+-- Should add 2 rows (preimage + postimage)
+insert into tb2 (pk, ck, i1) VALUES (1, 11, 111) USING TTL 1111;
+select "cdc$batch_seq_no", "cdc$operation", pk, ck, i1 from tb2_scylla_cdc_log where pk = 1 and ck = 11 allow filtering;
+
+alter table tb2 with cdc = {'enabled': true, 'preimage': true, 'postimage': true, 'delta': 'keys'};
+-- Should add 3 rows (preimage + postimage + delta). Delta has only key columns and "pk" + "ck"
+insert into tb2 (pk, ck, i1) VALUES (2, 22, 222) USING TTL 2222;
+select "cdc$batch_seq_no", "cdc$operation", "cdc$ttl", pk, ck, i1 from tb2_scylla_cdc_log where pk = 2 and ck = 22 allow filtering;
+
+alter table tb2 with cdc = {'enabled': true, 'preimage': true, 'postimage': true, 'delta': 'full'};
+-- Should add 3 rows (preimage + postimage + delta)
+insert into tb2 (pk, ck, i1) VALUES (3, 33, 333) USING TTL 3333;
+select "cdc$batch_seq_no", "cdc$operation", "cdc$ttl", pk, ck, i1 from tb2_scylla_cdc_log where pk = 3 and ck = 33 allow filtering;

--- a/test/cql/cdc_delta_modes_test.result
+++ b/test/cql/cdc_delta_modes_test.result
@@ -1,0 +1,105 @@
+create table tb1 (pk int, ck int, i1 int, PRIMARY KEY (pk, ck)) with cdc = {'enabled': true, 'preimage': false, 'postimage': false, 'delta': 'off'};
+{
+	"message" : "exceptions::configuration_exception (Invalid combination of CDC options: neither of {preimage, postimage, delta} is enabled)",
+	"status" : "error"
+}
+
+create table tb2 (pk int, ck int, i1 int, PRIMARY KEY (pk, ck)) with cdc = {'enabled': true, 'preimage': true, 'postimage': true, 'delta': 'off'};
+{
+	"status" : "ok"
+}
+-- Should add 2 rows (preimage + postimage)
+insert into tb2 (pk, ck, i1) VALUES (1, 11, 111) USING TTL 1111;
+{
+	"status" : "ok"
+}
+select "cdc$batch_seq_no", "cdc$operation", pk, ck, i1 from tb2_scylla_cdc_log where pk = 1 and ck = 11 allow filtering;
+{
+	"rows" : 
+	[
+		{
+			"cdc$batch_seq_no" : "0",
+			"cdc$operation" : "0",
+			"ck" : "11",
+			"pk" : "1"
+		},
+		{
+			"cdc$batch_seq_no" : "1",
+			"cdc$operation" : "9",
+			"ck" : "11",
+			"i1" : "111",
+			"pk" : "1"
+		}
+	]
+}
+
+alter table tb2 with cdc = {'enabled': true, 'preimage': true, 'postimage': true, 'delta': 'keys'};
+{
+	"status" : "ok"
+}
+-- Should add 3 rows (preimage + postimage + delta). Delta has only key columns and "pk" + "ck"
+insert into tb2 (pk, ck, i1) VALUES (2, 22, 222) USING TTL 2222;
+{
+	"status" : "ok"
+}
+select "cdc$batch_seq_no", "cdc$operation", "cdc$ttl", pk, ck, i1 from tb2_scylla_cdc_log where pk = 2 and ck = 22 allow filtering;
+{
+	"rows" : 
+	[
+		{
+			"cdc$batch_seq_no" : "0",
+			"cdc$operation" : "0",
+			"ck" : "22",
+			"pk" : "2"
+		},
+		{
+			"cdc$batch_seq_no" : "1",
+			"ck" : "22",
+			"pk" : "2"
+		},
+		{
+			"cdc$batch_seq_no" : "2",
+			"cdc$operation" : "9",
+			"ck" : "22",
+			"i1" : "222",
+			"pk" : "2"
+		}
+	]
+}
+
+alter table tb2 with cdc = {'enabled': true, 'preimage': true, 'postimage': true, 'delta': 'full'};
+{
+	"status" : "ok"
+}
+-- Should add 3 rows (preimage + postimage + delta)
+insert into tb2 (pk, ck, i1) VALUES (3, 33, 333) USING TTL 3333;
+{
+	"status" : "ok"
+}
+select "cdc$batch_seq_no", "cdc$operation", "cdc$ttl", pk, ck, i1 from tb2_scylla_cdc_log where pk = 3 and ck = 33 allow filtering;
+{
+	"rows" : 
+	[
+		{
+			"cdc$batch_seq_no" : "0",
+			"cdc$operation" : "0",
+			"ck" : "33",
+			"pk" : "3"
+		},
+		{
+			"cdc$batch_seq_no" : "1",
+			"cdc$operation" : "2",
+			"cdc$ttl" : "3333",
+			"ck" : "33",
+			"i1" : "333",
+			"pk" : "3"
+		},
+		{
+			"cdc$batch_seq_no" : "2",
+			"cdc$operation" : "9",
+			"ck" : "33",
+			"i1" : "333",
+			"pk" : "3"
+		}
+	]
+}


### PR DESCRIPTION
The goal is to have finer control over CDC "delta" rows, i.e.:
- disable them totally (mode `off`);
- record only base PK+CK columns (mode `keys`);
- make them behave as usual (mode `full`, default).

The editing of log rows is performed at the stage of `finish`ing CDC mutation.

Fixes #6838