### PR TITLE
gms: Return full schema_features from cluster_schema_features

### DIFF
--- a/gms/feature_service.cc
+++ b/gms/feature_service.cc
@@ -25,6 +25,7 @@
 #include "db/config.hh"
 #include "gms/feature.hh"
 #include "gms/feature_service.hh"
+#include "gms/gossiper.hh"
 
 namespace gms {
 constexpr std::string_view features::RANGE_TOMBSTONES = "RANGE_TOMBSTONES";
@@ -230,6 +231,9 @@ void feature::enable() {
 }
 
 db::schema_features feature_service::cluster_schema_features() const {
+    if (!get_local_gossiper().is_enabled()) {
+        return db::schema_features::full();
+    }
     db::schema_features f;
     f.set_if<db::schema_feature::VIEW_VIRTUAL_COLUMNS>(bool(_view_virtual_columns));
     f.set_if<db::schema_feature::DIGEST_INSENSITIVE_TO_EXPIRY>(bool(_digest_insensitive_to_expiry));


### PR DESCRIPTION
when it's called before gossip is enabled.

Without this change schemas loaded from disk at startup are stripped
from new fields guarded by feature flags.

Fixes #6893

Signed-off-by: Piotr Jastrzebski <piotr@scylladb.com>