### PR TITLE
dist_util.py: use correct ID value to detect Amazon Linux 2

### DIFF
--- a/dist/common/scripts/scylla_util.py
+++ b/dist/common/scripts/scylla_util.py
@@ -362,7 +362,7 @@ def is_redhat_variant():
     return ('rhel' in d) or ('fedora' in d) or ('oracle') in d
 
 def is_amzn2():
-    return ('amazon' in distro.id()) and ('2' in distro.version())
+    return ('amzn' in distro.id()) and ('2' in distro.version())
 
 def is_gentoo_variant():
     return ('gentoo' in distro.id())


### PR DESCRIPTION
On 2d63acdd6aaf00c4c8bf979ad332776e532d2f56 we replaced 'ol' and 'amzn' to 'oracle' and 'amazon', but distro.id() actually returns 'amzn' for Amazon Linux 2,
so we need to revert the change.

Fixes #6882