### PR TITLE
storage_service: Improve log on removing pending replacing node

### DIFF
--- a/locator/token_metadata.cc
+++ b/locator/token_metadata.cc
@@ -1248,7 +1248,7 @@ void token_metadata_impl::remove_endpoint(inet_address endpoint) {
     remove_by_value(_token_to_endpoint_map, endpoint);
     _topology.remove_endpoint(endpoint);
     _leaving_endpoints.erase(endpoint);
-    _replacing_endpoints.erase(endpoint);
+    del_replacing_endpoint(endpoint);
     _endpoint_to_host_id_map.erase(endpoint);
     _sorted_tokens = sort_tokens();
     invalidate_cached_rings();
@@ -1540,10 +1540,16 @@ void token_metadata_impl::add_leaving_endpoint(inet_address endpoint) {
 }
 
 void token_metadata_impl::add_replacing_endpoint(inet_address existing_node, inet_address replacing_node) {
+    tlogger.info("Added node {} as pending replacing endpoint which replaces existing node {}",
+            replacing_node, existing_node);
     _replacing_endpoints[existing_node] = replacing_node;
 }
 
 void token_metadata_impl::del_replacing_endpoint(inet_address existing_node) {
+    if (_replacing_endpoints.count(existing_node)) {
+        tlogger.info("Removed node {} as pending replacing endpoint which replaces existing node {}",
+                _replacing_endpoints[existing_node], existing_node);
+    }
     _replacing_endpoints.erase(existing_node);
 }
 

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -1150,14 +1150,11 @@ void storage_service::handle_state_normal(inet_address endpoint) {
                 do_remove_node(*existing);
                 slogger.info("Set host_id={} to be owned by node={}, existing={}", host_id, endpoint, *existing);
                 _token_metadata.update_host_id(host_id, endpoint);
-                slogger.info("Remove node {} from pending replacing endpoint", endpoint);
-                _token_metadata.del_replacing_endpoint(endpoint);
             } else {
                 slogger.warn("Host ID collision for {} between {} and {}; ignored {}", host_id, *existing, endpoint, endpoint);
                 do_remove_node(endpoint);
             }
         } else if (existing && *existing == endpoint) {
-            slogger.info("Remove node {} from pending replacing endpoint", endpoint);
             _token_metadata.del_replacing_endpoint(endpoint);
         } else {
             slogger.info("Set host_id={} to be owned by node={}", host_id, endpoint);


### PR DESCRIPTION
The log "removing pending replacing node" is printed whenever a node
jumps to normal status including a normal restart. For example, on
node1, we saw the following when node2 restarts.

[shard 0] storage_service - Node 127.0.0.2 state jump to normal
[shard 0] storage_service - Remove node 127.0.0.2 from pending replacing endpoint

This is confusing since no node is really being replaced.

To fix, log only if a node is really removed from the pending replacing
nodes.

In addition, since do_remove_node will call del_replacing_endpoint,
there is no need to call del_replacing_endpoint again in
storage_service::handle_state_normal after do_remove_node.

Fixes #6936