### PR TITLE
Mount RAID volume correctly beyond reboot

### DIFF
--- a/dist/common/scripts/scylla_raid_setup
+++ b/dist/common/scripts/scylla_raid_setup
@@ -129,6 +129,7 @@ if __name__ == '__main__':
         res = out('mdadm --detail --scan')
         with open(confpath, 'w') as f:
             f.write(res)
+            f.write('\nMAILADDR root')
 
     makedirs(mount_at)
     mntunit_bn = out('systemd-escape -p --suffix=mount {}'.format(mount_at))
@@ -138,11 +139,14 @@ if __name__ == '__main__':
         sys.exit(1)
 
     uuid = out(f'blkid -s UUID -o value {fsdev}')
+    after = 'local-fs.target'
+    if raid:
+        after += ' mdmonitor.service'
     unit_data = f'''
 [Unit]
 Description=Scylla data directory
 Before=scylla-server.service
-After=local-fs.target
+After={after}
 
 [Mount]
 What=UUID={uuid}
@@ -165,6 +169,9 @@ WantedBy=multi-user.target
             f.write(f'RequiresMountsFor={mount_at}\n')
 
     systemd_unit.reload()
+    mdmonitor = systemd_unit('mdmonitor.service')
+    mdmonitor.enable()
+    mdmonitor.start()
     mount = systemd_unit(mntunit_bn)
     mount.start()
     if args.enable_on_nextboot:

--- a/dist/common/scripts/scylla_util.py
+++ b/dist/common/scripts/scylla_util.py
@@ -331,7 +331,7 @@ class scylla_cpuinfo:
 
 # When a CLI tool is not installed, use relocatable CLI tool provided by Scylla
 scylla_env = os.environ.copy()
-scylla_env['PATH'] =  '{}:{}'.format(scylla_env['PATH'], scyllabindir())
+scylla_env['PATH'] =  '{}:{}'.format(scyllabindir(), scylla_env['PATH'])
 
 def run(cmd, shell=False, silent=False, exception=True):
     stdout = subprocess.DEVNULL if silent else None

--- a/scripts/create-relocatable-package.py
+++ b/scripts/create-relocatable-package.py
@@ -94,7 +94,8 @@ executables = ['build/{}/scylla'.format(args.mode),
                '/usr/sbin/ethtool',
                '/usr/bin/netstat',
                '/usr/bin/hwloc-distrib',
-               '/usr/bin/hwloc-calc']
+               '/usr/bin/hwloc-calc',
+               '/usr/bin/lsblk']
 
 output = args.dest
 


### PR DESCRIPTION
To mount RAID volume correctly (#6876), we need to wait for MDRAID initialization.
To do so we need to add After=mdmonitor.service on var-lib-scylla.mount.
Also, `lsblk -n -oPARTTYPE {dev}` does not work for CentOS7, since older lsblk does not supported PARTTYPE column (#6954).
We need to provide relocatable lsblk and run it on out() / run() function instead of distribution provided version.