### PR TITLE
transport: Added listener with port-based load balancing

### DIFF
--- a/conf/scylla.yaml
+++ b/conf/scylla.yaml
@@ -102,6 +102,10 @@ listen_address: localhost
 # For security reasons, you should not expose this port to the internet.  Firewall it if needed.
 native_transport_port: 9042
 
+# Like native_transport_port, but clients are forwarded to specific shards, based on the
+# client-side port numbers.
+native_shard_aware_transport_port: 19042
+
 # Enabling native transport encryption in client_encryption_options allows you to either use
 # encryption for the standard port or to use a dedicated, additional port along with the unencrypted
 # standard native_transport_port.
@@ -110,6 +114,10 @@ native_transport_port: 9042
 # from native_transport_port will use encryption for native_transport_port_ssl while
 # keeping native_transport_port unencrypted.
 #native_transport_port_ssl: 9142
+
+# Like native_transport_port_ssl, but clients are forwarded to specific shards, based on the
+# client-side port numbers.
+#native_shard_aware_transport_port_ssl: 19142
 
 # How long the coordinator should wait for read operations to complete
 read_request_timeout_in_ms: 5000

--- a/db/config.cc
+++ b/db/config.cc
@@ -525,6 +525,10 @@ db::config::config(std::shared_ptr<db::extensions> exts)
         "for native_transport_port. Setting native_transport_port_ssl to a different value"
         "from native_transport_port will use encryption for native_transport_port_ssl while"
         "keeping native_transport_port unencrypted")
+    , native_shard_aware_transport_port(this, "native_shard_aware_transport_port", value_status::Used, 19042,
+        "Like native_transport_port, but clients-side port number (modulo smp) is used to route the connection to the specific shard.")
+    , native_shard_aware_transport_port_ssl(this, "native_shard_aware_transport_port_ssl", value_status::Used, 19142,
+        "Like native_transport_port_ssl, but clients-side port number (modulo smp) is used to route the connection to the specific shard.")
     , native_transport_max_threads(this, "native_transport_max_threads", value_status::Invalid, 128,
         "The maximum number of thread handling requests. The meaning is the same as rpc_max_threads.\n"
         "Default is different (128 versus unlimited).\n"

--- a/db/config.hh
+++ b/db/config.hh
@@ -218,6 +218,8 @@ public:
     named_value<bool> start_native_transport;
     named_value<uint16_t> native_transport_port;
     named_value<uint16_t> native_transport_port_ssl;
+    named_value<uint16_t> native_shard_aware_transport_port;
+    named_value<uint16_t> native_shard_aware_transport_port_ssl;
     named_value<uint32_t> native_transport_max_threads;
     named_value<uint32_t> native_transport_max_frame_size_in_mb;
     named_value<sstring> broadcast_rpc_address;

--- a/docs/protocol-extensions.md
+++ b/docs/protocol-extensions.md
@@ -63,6 +63,18 @@ The keys and values are:
     partitions are mapped into shards (described below)
   - `SCYLLA_SHARDING_IGNORE_MSB` is an integer parameter to the algorithm (also
     described below)
+  - `SCYLLA_SHARD_AWARE_PORT` is an additional port number where Scylla is listening
+    for CQL connections. If present, it works almost the same way as port 9042 typically
+    does; the difference is that client-side port number is used as an indicator to which
+    shard client wants to connect. The desired shard number is calculated as:
+    `desired_shard_no = client_port % SCYLLA_NR_SHARDS`. Its value is a decimal
+    representation of type `uint16_t`, by default `19042`.
+  - `SCYLLA_SHARD_AWARE_PORT_SSL` is an additional port number where Scylla is
+    listening for encrypted CQL connections. If present, it works almost the same way
+    as port 9142 typically does; the difference is that client-side port number is used
+    as an indicator to which shard client wants to connect. The desired shard number
+    is calculated as: `desired_shard_no = client_port % SCYLLA_NR_SHARDS`.
+    Its value is a decimal representation of type `uint16_t`, by default `19142`.
 
 Currently, one `SCYLLA_SHARDING_ALGORITHM` is defined,
 `biased-token-round-robin`. To apply the algorithm,

--- a/transport/server.hh
+++ b/transport/server.hh
@@ -107,6 +107,8 @@ struct cql_server_config {
     std::function<semaphore& ()> get_service_memory_limiter_semaphore;
     sstring partitioner_name;
     unsigned sharding_ignore_msb;
+    std::optional<uint16_t> shard_aware_transport_port;
+    std::optional<uint16_t> shard_aware_transport_port_ssl;
     bool allow_shard_aware_drivers = true;
     smp_service_group bounce_request_smp_service_group = default_smp_service_group();
 };
@@ -135,7 +137,7 @@ public:
     cql_server(distributed<cql3::query_processor>& qp, auth::service&,
             service::migration_notifier& mn,
             cql_server_config config);
-    future<> listen(socket_address addr, std::shared_ptr<seastar::tls::credentials_builder> = {}, bool keepalive = false);
+    future<> listen(socket_address addr, std::shared_ptr<seastar::tls::credentials_builder> = {}, bool is_shard_aware = false, bool keepalive = false);
     future<> do_accepts(int which, bool keepalive, socket_address server_addr);
     future<> stop();
 public:


### PR DESCRIPTION
This is inspired by #6781. The idea is to make Scylla listen for CQL connections on port 9042 (where both old shard-aware and shard-unaware clients can still connect the traditional way). On top of that I added a new port, where everything works the same way, only the port from client's socket used to determine the shard No. to connect to. Desired shard No. is the result of `clientside_port % num_shards`.

The new port is configurable from scylla.yaml and defaults to 19042 (unencrypted, unless user configures encryption options and omits `native_shard_aware_transport_port_ssl` in DB config).

Two "SUPPORTED" tags are added: "SCYLLA_SHARD_AWARE_PORT" and "SCYLLA_SHARD_AWARE_PORT_SSL". For compatibility, "SCYLLA_SHARDING_ALGORITHM" is still kept.

Fixes #5239