### PR TITLE
scylla_setup: check var-lib-scylla.mount existance before formatting RAID

### DIFF
--- a/dist/common/scripts/scylla_raid_setup
+++ b/dist/common/scripts/scylla_raid_setup
@@ -80,6 +80,12 @@ if __name__ == '__main__':
         print('{} is already mounted'.format(mount_at))
         sys.exit(1)
 
+    mntunit_bn = out('systemd-escape -p --suffix=mount {}'.format(mount_at))
+    mntunit = Path('/etc/systemd/system/{}'.format(mntunit_bn))
+    if mntunit.exists():
+        print('mount unit {} already exists'.format(mntunit))
+        sys.exit(1)
+
     if is_debian_variant():
         run('env DEBIAN_FRONTEND=noninteractive apt-get -y install mdadm xfsprogs')
     elif is_redhat_variant():
@@ -132,11 +138,6 @@ if __name__ == '__main__':
             f.write('\nMAILADDR root')
 
     makedirs(mount_at)
-    mntunit_bn = out('systemd-escape -p --suffix=mount {}'.format(mount_at))
-    mntunit = Path('/etc/systemd/system/{}'.format(mntunit_bn))
-    if mntunit.exists():
-        print('mount unit {} already exists'.format(mntunit))
-        sys.exit(1)
 
     uuid = out(f'blkid -s UUID -o value {fsdev}')
     after = 'local-fs.target'

--- a/dist/common/scripts/scylla_setup
+++ b/dist/common/scripts/scylla_setup
@@ -354,7 +354,10 @@ if __name__ == '__main__':
             raid_setup = interactive_ask_service('Are you sure you want to setup RAID0 and XFS?', 'If you choose Yes, the selected drive will be reformated, erasing all existing data in the process.', raid_setup)
         else:
             raid_setup = False
-        if res and raid_setup and not disks:
+        if res and raid_setup and os.path.exists('/etc/systemd/system/var-lib-scylla.mount'):
+            colorprint('{red}/etc/systemd/system/var-lib-scylla.mount already exists, skipping RAID setup.{nocolor}')
+            raid_setup = False
+        elif res and raid_setup and not disks:
             devices = get_unused_disks()
             if len(devices) == 0:
                 print('No free disks were detected, abort RAID/XFS setup. Disks must be unmounted before proceeding.\n')


### PR DESCRIPTION
We should run var-lib-scyllla.mount existance check before formatting RAID.