### PR TITLE
Alternator streams get_records - fix threshold/record

### DIFF
--- a/alternator/streams.cc
+++ b/alternator/streams.cc
@@ -839,7 +839,9 @@ future<executor::request_return_type> executor::get_records(client_state& client
             {
                 auto item = rjson::empty_object();
                 describe_single_item(*selection, row, attr_names, item, true);
-                rjson::set(dynamodb, op == cdc::operation::pre_image ? "OldImage" : "NewImage", std::move(item));
+                if (!item.ObjectEmpty()) {
+                    rjson::set(dynamodb, op == cdc::operation::pre_image ? "OldImage" : "NewImage", std::move(item));
+                }
                 break;
             }
             case cdc::operation::update:


### PR DESCRIPTION
Fixes #6942
Fixes #6926
Fixes #6933

We use clustering [lo:hi) range for iterator query.
To avoid encoding inclusive/exclusive range (depending on
init/last get_records call), instead just increment
the timeuuid threshold.

Also, dynamo result always contains a "records" entry. Include one for us as well. 

Also, if old (or new) image for a change set is empty, dynamo will not include
this key at all. Alternator did return an empty object. This changes it to be excluded 
on empty.

