### PR TITLE
cdc: introduce a ,,change visitor'' and ,,inspect mutation'' abstractions

### DIFF
--- a/cdc/change_visitor.hh
+++ b/cdc/change_visitor.hh
@@ -1,0 +1,283 @@
+/*
+ * Copyright (C) 2020 ScyllaDB
+ */
+
+/*
+ * This file is part of Scylla.
+ *
+ * Scylla is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Scylla is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "mutation.hh"
+
+/*
+ * This file contains a general abstraction for walking over mutations,
+ * deconstructing them into ``atomic'' pieces, and consuming these pieces.
+ *
+ * The pieces considered atomic are:
+ * - atomic_cells, either in collections or in atomic columns
+ *   (see `live_collection_cell`, `dead_collection_cell`, `live_atomic_cell`, `dead_atomic_cell`),
+ * - collection tombstones (see `collection_tombstone`)
+ * - row markers (see `marker`)
+ * - row tombstones (see `clustered_row_delete`),
+ * - range tombstones (see `range_delete`),
+ * - partition tombstones (see `partition_delete`).
+ * We use the term ``changes'' to refer to these atomic pieces, hence the name ``ChangeVisitor''.
+ *
+ * IMPORTANT: this doesn't understand all possible states that a mutation can have, e.g. it doesn't understand
+ * the concept of ``continuity''. However, it is sufficient for analyzing mutations created by a write coordinator,
+ * e.g. obtained by parsing a CQL statement.
+ *
+ * To analyze a mutation, create a visitor (described by the `ChangeVisitor` concept below) and pass it
+ * together with the mutation to `inspect_mutation`.
+ *
+ * To analyze certain fragments of the mutation, the inspecting code requires further visitors to be passed.
+ * For example, when it encounters a clustered row update, it calls `clustered_row_cells` on the visitor,
+ * passing it the row's key and the callback. The visitor can then decide:
+ * - if it's not interested in the row's cells, it can simply not call the callback,
+ * - otherwise, it can call the callback with a value of type that satisfies the ``RowCellsVisitor'' concept.
+ * If the callback is called, the inspector walks over the row and passes the changes into the ``row cells visitor''.
+ * In either case, it will then proceed to analyze further parts of the mutation, if any.
+ *
+ * Note that the type passed to the callbacks provided by the inspector (such as in the example above)
+ * can be decided at runtime. This can be especially useful with the callback passed to `collection_column`
+ * in RowCellsVisitor, if different collection types require different logic to handle.
+ *
+ * The dummy visitors below are there only to define the concepts.
+ * For example, in the RowCellsVisitor concept I wanted to express that `visit_collection` in RowCellsVisitor
+ * is a function that handles *any* type which satisfies CollectionVisitor. I didn't find a way to do that
+ * other than providing a ``most generic'' concrete type which satisfies the interface (`dummy_collection_visitor`).
+ * Unfortunately C++ is still not Haskell.
+ *
+ * The inspector calls `finished()` after visiting each change, and sometimes before (e.g. when it starts
+ * visiting a static row, but before it visits any of its cells). If it returns true, the inspector
+ * will stop the visitation. Thus, if at any point during the walk the visitor decides it's not interested
+ * in any more changes, it can inform the inspector by returning `true` from `finished()`.
+ *
+ * IMPORTANT: if the visitor returns `true` from `finished()`, it should keep returning `true`. This is because
+ * the inspector may call `finished()` multiple times when exiting some nested loops.
+ *
+ * The order of visitation is as follows:
+ * - First the static row is visited, if it has any cells.
+ *   Within the row, its columns are visited in order of increasing column IDs.
+ *
+ * - Then, for each clustering key, if a change (row marker, cell, or tombstone) exists for this key:
+ *   - The row marker is visited, if there is one.
+ *   - Columns are visited in order of increasing column IDs.
+ *   - The row tombstone is visited, if there is one.
+ *
+ * For both the static row and a clustering row, for each column:
+ * - If the column is atomic, a corresponding atomic_cell is visited (if there is one).
+ * - Otherwise (the column is non-atomic):
+ *   - The collection tombstone is visited first.
+ *   - Cells are visited in order of increasing keys
+ *     (assuming that the mutation was correctly constructed, i.e. it stores cells in key order).
+ *
+ * WARNING: visited collection tombstone and cells
+ * are guaranteed to live only for the duration of `collection_column` call.
+ *
+ * - Then range tombstones are visited. The order is unspecified
+ *   (more accurately: if it's specified, I don't know what it is)
+ *
+ * - Finally, the partition tombstone is visited, if it exists.
+ */
+
+namespace cdc {
+
+template <typename V>
+concept CollectionVisitor = requires(V v,
+        const tombstone& t,
+        bytes_view key,
+        const atomic_cell_view& cell) {
+
+    { v.collection_tombstone(t) }         -> std::same_as<void>;
+    { v.live_collection_cell(key, cell) } -> std::same_as<void>;
+    { v.dead_collection_cell(key, cell) } -> std::same_as<void>;
+    { v.finished() } -> std::same_as<bool>;
+};
+
+struct dummy_collection_visitor {
+    void collection_tombstone(const tombstone&) {}
+    void live_collection_cell(bytes_view, const atomic_cell_view&) {}
+    void dead_collection_cell(bytes_view, const atomic_cell_view&) {}
+    bool finished() { return false; }
+};
+
+template <typename V>
+concept RowCellsVisitor = requires(V v,
+        const column_definition& cdef,
+        const atomic_cell_view& cell,
+        noncopyable_function<void(dummy_collection_visitor&)> visit_collection) {
+
+    { v.live_atomic_cell(cdef, cell) }                         -> std::same_as<void>;
+    { v.dead_atomic_cell(cdef, cell) }                         -> std::same_as<void>;
+    { v.collection_column(cdef, std::move(visit_collection)) } -> std::same_as<void>;
+    { v.finished() }                                           -> std::same_as<bool>;
+};
+
+struct dummy_row_cells_visitor {
+    void live_atomic_cell(const column_definition&, const atomic_cell_view&) {}
+    void dead_atomic_cell(const column_definition&, const atomic_cell_view&) {}
+    void collection_column(const column_definition&, auto&& visit_collection) {
+        dummy_collection_visitor v;
+        visit_collection(v);
+    }
+    bool finished() { return false; }
+};
+
+template <typename V>
+concept ClusteredRowCellsVisitor = requires(V v,
+        const row_marker& rm) {
+    requires RowCellsVisitor<V>;
+    { v.marker(rm) } -> std::same_as<void>;
+};
+
+struct dummy_clustered_row_cells_visitor : public dummy_row_cells_visitor {
+    void marker(const row_marker&) {}
+};
+
+template <typename V>
+concept ChangeVisitor = requires(V v,
+        api::timestamp_type ts,
+        const clustering_key& ckey,
+        const range_tombstone& rt,
+        const tombstone& t,
+        noncopyable_function<void(dummy_clustered_row_cells_visitor&)> visit_clustered_row_cells,
+        noncopyable_function<void(dummy_row_cells_visitor&)> visit_row_cells) {
+
+    { v.static_row_cells(std::move(visit_row_cells)) }                    -> std::same_as<void>;
+    { v.clustered_row_cells(ckey, std::move(visit_clustered_row_cells)) } -> std::same_as<void>;
+    { v.clustered_row_delete(ckey, t) }                                   -> std::same_as<void>;
+    { v.range_delete(rt) }                                                -> std::same_as<void>;
+    { v.partition_delete(t) }                                             -> std::same_as<void>;
+    { v.finished() }                                                      -> std::same_as<bool>;
+};
+
+template <RowCellsVisitor V>
+void inspect_row_cells(const schema& s, column_kind ckind, const row& r, V& v) {
+    r.for_each_cell_until([&s, ckind, &v] (column_id id, const atomic_cell_or_collection& acoc) {
+        auto& cdef = s.column_at(ckind, id);
+
+        if (cdef.is_atomic()) {
+            auto cell = acoc.as_atomic_cell(cdef);
+            if (cell.is_live()) {
+                v.live_atomic_cell(cdef, cell);
+            } else {
+                v.dead_atomic_cell(cdef, cell);
+            }
+
+            return stop_iteration(v.finished());
+        }
+
+        acoc.as_collection_mutation().with_deserialized(*cdef.type, [&v, &cdef] (collection_mutation_view_description view) {
+            v.collection_column(cdef, [&view] (CollectionVisitor auto& cv) {
+                if (cv.finished()) {
+                    return;
+                }
+
+                if (view.tomb) {
+                    cv.collection_tombstone(view.tomb);
+                    if (cv.finished()) {
+                        return;
+                    }
+                }
+
+                for (auto& [key, cell]: view.cells) {
+                    if (cell.is_live()) {
+                        cv.live_collection_cell(key, cell);
+                    } else {
+                        cv.dead_collection_cell(key, cell);
+                    }
+
+                    if (cv.finished()) {
+                        return;
+                    }
+                }
+            });
+        });
+
+        return stop_iteration(v.finished());
+    });
+}
+
+template <ChangeVisitor V>
+void inspect_mutation(const mutation& m, V& v) {
+    auto& p = m.partition();
+    auto& s = *m.schema();
+
+    if (!p.static_row().empty()) {
+        v.static_row_cells([&s, &p] (RowCellsVisitor auto& srv) {
+            if (srv.finished()) {
+                return;
+            }
+            inspect_row_cells(s, column_kind::static_column, p.static_row().get(), srv);
+        });
+
+        if (v.finished()) {
+            return;
+        }
+    }
+
+    for (auto& cr: p.clustered_rows()) {
+        auto& r = cr.row();
+
+        if (r.marker().is_live() || !r.cells().empty()) {
+            v.clustered_row_cells(cr.key(), [&s, &r] (ClusteredRowCellsVisitor auto& crv) {
+                if (crv.finished()) {
+                    return;
+                }
+
+                auto& rm = r.marker();
+                if (rm.is_live()) {
+                    crv.marker(rm);
+
+                    if (crv.finished()) {
+                        return;
+                    }
+                }
+
+                inspect_row_cells(s, column_kind::regular_column, r.cells(), crv);
+            });
+
+            if (v.finished()) {
+                return;
+            }
+        }
+
+        if (r.deleted_at()) {
+            auto t = r.deleted_at().tomb();
+            assert(t.timestamp != api::missing_timestamp);
+            v.clustered_row_delete(cr.key(), t);
+            if (v.finished()) {
+                return;
+            }
+        }
+    }
+
+    for (auto& rt: p.row_tombstones()) {
+        assert(rt.tomb.timestamp != api::missing_timestamp);
+        v.range_delete(rt);
+        if (v.finished()) {
+            return;
+        }
+    }
+
+    if (p.partition_tombstone()) {
+        v.partition_delete(p.partition_tombstone());
+    }
+}
+
+} // namespace cdc

--- a/cdc/log.cc
+++ b/cdc/log.cc
@@ -31,6 +31,7 @@
 #include "cdc/generation.hh"
 #include "cdc/split.hh"
 #include "cdc/cdc_options.hh"
+#include "cdc/change_visitor.hh"
 #include "bytes.hh"
 #include "database.hh"
 #include "db/config.hh"
@@ -931,7 +932,7 @@ public:
     }
 
     // Each regular and static column in the base schema has a corresponding column in the log schema
-    // with boolean type and the name constructed by prefixing the original name with ,,cdc$deleted_''
+    // with boolean type and the name constructed by prefixing the original name with ``cdc$deleted_''
     // Given a reference to such a column from the base schema, this function sets the corresponding column
     // in the log to `true` for the given row. If not called, the column will be `null`.
     void set_deleted(const clustering_key& log_ck, const column_definition& base_cdef) {
@@ -940,7 +941,7 @@ public:
 
     // Each regular and static non-atomic column in the base schema has a corresponding column in the log schema
     // whose type is a frozen `set` of keys (the types of which depend on the base type) and whose name is constructed
-    // by prefixing the original name with ,,cdc$deleted_elements_''.
+    // by prefixing the original name with ``cdc$deleted_elements_''.
     // Given a reference to such a column from the base schema, this function sets the corresponding column
     // in the log to the given set of keys for the given row.
     void set_deleted_elements(const clustering_key& log_ck, const column_definition& base_cdef, bytes deleted_elements) {
@@ -960,6 +961,350 @@ private:
             ++pos;
         }
     }
+};
+
+static bytes get_bytes(const atomic_cell_view& acv) {
+    return acv.value().linearize();
+}
+
+static bytes_view get_bytes_view(const atomic_cell_view& acv, std::vector<bytes>& buf) {
+    return acv.value().is_fragmented()
+        ? bytes_view{buf.emplace_back(acv.value().linearize())}
+        : acv.value().first_fragment();
+}
+
+static ttl_opt get_ttl(const atomic_cell_view& acv) {
+    return acv.is_live_and_has_ttl() ? std::optional{acv.ttl()} : std::nullopt;
+}
+
+static ttl_opt get_ttl(const row_marker& rm) {
+    return rm.is_expiring() ? std::optional{rm.ttl()} : std::nullopt;
+}
+
+/* Visits the cells and tombstones of a single base mutation row and constructs corresponding delta-row cells
+ * for the corresponding log mutation.
+ *
+ * Additionally updates state required to produce pre/post-image if configured to do so (`enable_updating_state`).
+ */
+struct process_row_visitor {
+    const clustering_key& _log_ck;
+
+    stats::part_type_set& _touched_parts;
+
+    // The base row being visited gets a single corresponding log delta row.
+    // This is the value of the "cdc$ttl" column for that delta row.
+    ttl_opt _ttl_column = std::nullopt;
+
+    // Used to create cells in the corresponding delta row in the log mutation.
+    log_mutation_builder& _builder;
+
+    /* Images-related state */
+    const bool _enable_updating_state = false;
+
+    // Null for the static row, non-null for clustered rows.
+    const clustering_key* const _base_ck;
+
+    // The state required to produce pre/post-image for the row being visited.
+    // Might be null if the preimage query didn't return a result for this row.
+    cell_map* _row_state;
+
+    // The state required to produce pre/post-image for all rows.
+    // We need to keep a reference to it since we might insert new row_states during the visitation.
+    row_states_map& _clustering_row_states;
+
+    process_row_visitor(
+            const clustering_key& log_ck, stats::part_type_set& touched_parts, log_mutation_builder& builder,
+            bool enable_updating_state, const clustering_key* base_ck, cell_map* row_state,
+            row_states_map& clustering_row_states)
+        : _log_ck(log_ck), _touched_parts(touched_parts), _builder(builder),
+          _enable_updating_state(enable_updating_state), _base_ck(base_ck), _row_state(row_state),
+          _clustering_row_states(clustering_row_states)
+    {}
+
+    void update_row_state(const column_definition& cdef, bytes_opt value) {
+        if (!_row_state) {
+            // static row always has a valid state, so this must be a clustering row missing
+            assert(_base_ck);
+            auto [it, _] = _clustering_row_states.try_emplace(*_base_ck);
+            _row_state = &it->second;
+        }
+        (*_row_state)[&cdef] = std::move(value);
+    }
+
+    void live_atomic_cell(const column_definition& cdef, const atomic_cell_view& cell) {
+        _ttl_column = get_ttl(cell);
+        bytes value = get_bytes(cell);
+
+        // delta
+        _builder.set_value(_log_ck, cdef, value);
+
+        // images
+        if (_enable_updating_state) {
+            update_row_state(cdef, std::move(value));
+        }
+    }
+
+    void dead_atomic_cell(const column_definition& cdef, const atomic_cell_view&) {
+        // delta
+        _builder.set_deleted(_log_ck, cdef);
+
+        // images
+        if (_enable_updating_state) {
+            update_row_state(cdef, std::nullopt);
+        }
+    }
+
+    void collection_column(const column_definition& cdef, auto&& visit_collection) {
+        // The handling of dead cells and the tombstone is common for all collection types,
+        // but we need separate visitors for different collection types to handle the live cells.
+        // See `set_visitor`, `udt_visitior`, and `map_or_list_visitor` below.
+        struct collection_visitor {
+            bool _is_column_delete = false;
+            std::vector<bytes_view> _deleted_keys;
+
+            ttl_opt& _ttl_column;
+
+            collection_visitor(ttl_opt& ttl_column) : _ttl_column(ttl_column) {}
+
+            void collection_tombstone(const tombstone&) {
+                _is_column_delete = true;
+            }
+
+            void dead_collection_cell(bytes_view key, const atomic_cell_view&) {
+                _deleted_keys.push_back(key);
+            }
+
+            constexpr bool finished() const { return false; }
+        };
+
+
+        // cdc$deleted_col, cdc$deleted_elements_col, col
+        using result_t = std::tuple<bool, std::vector<bytes_view>, bytes_opt>;
+        auto [is_column_delete, deleted_keys, added_cells] = visit(*cdef.type, make_visitor(
+            [&] (const set_type_impl&) -> result_t {
+                _touched_parts.set<stats::part_type::SET>();
+
+                struct set_visitor : public collection_visitor {
+                    std::vector<bytes_view> _added_keys;
+
+                    set_visitor(ttl_opt& ttl_column) : collection_visitor(ttl_column) {}
+
+                    void live_collection_cell(bytes_view key, const atomic_cell_view& cell) {
+                        this->_ttl_column = get_ttl(cell);
+                        _added_keys.push_back(key);
+                    }
+                } v(_ttl_column);
+
+                visit_collection(v);
+
+                bytes_opt added_keys = v._added_keys.empty() ? std::nullopt :
+                    std::optional{set_type_impl::serialize_partially_deserialized_form(v._added_keys, cql_serialization_format::internal())};
+
+                return {
+                    v._is_column_delete,
+                    std::move(v._deleted_keys),
+                    std::move(added_keys)
+                };
+            },
+            [&] (const user_type_impl& type) -> result_t  {
+                _touched_parts.set<stats::part_type::UDT>();
+
+                struct udt_visitor : public collection_visitor {
+                    std::vector<bytes_opt> _added_cells;
+                    std::vector<bytes>& _buf;
+
+                    udt_visitor(ttl_opt& ttl_column, size_t num_keys, std::vector<bytes>& buf)
+                        : collection_visitor(ttl_column), _added_cells(num_keys), _buf(buf) {}
+
+                    void live_collection_cell(bytes_view key, const atomic_cell_view& cell) {
+                        this->_ttl_column = get_ttl(cell);
+                        _added_cells[deserialize_field_index(key)].emplace(get_bytes_view(cell, _buf));
+                    }
+                };
+
+                std::vector<bytes> buf;
+                udt_visitor v(_ttl_column, type.size(), buf);
+
+                visit_collection(v);
+
+                bytes_opt added_cells = v._added_cells.empty() ? std::nullopt :
+                    std::optional{type.build_value(v._added_cells)};
+
+                return {
+                    v._is_column_delete,
+                    std::move(v._deleted_keys),
+                    std::move(added_cells)
+                };
+            },
+            [&] (const collection_type_impl& type) -> result_t {
+                _touched_parts.set(type.is_list() ? stats::part_type::LIST : stats::part_type::MAP);
+
+                struct map_or_list_visitor : public collection_visitor {
+                    std::vector<std::pair<bytes_view, bytes_view>> _added_cells;
+                    std::vector<bytes>& _buf;
+
+                    map_or_list_visitor(ttl_opt& ttl_column, std::vector<bytes>& buf)
+                        : collection_visitor(ttl_column), _buf(buf) {}
+
+                    void live_collection_cell(bytes_view key, const atomic_cell_view& cell) {
+                        this->_ttl_column = get_ttl(cell);
+                        _added_cells.emplace_back(key, get_bytes_view(cell, _buf));
+                    }
+                };
+
+                std::vector<bytes> buf;
+                map_or_list_visitor v(_ttl_column, buf);
+
+                visit_collection(v);
+
+                bytes_opt added_cells = v._added_cells.empty() ? std::nullopt :
+                    std::optional{map_type_impl::serialize_partially_deserialized_form(v._added_cells, cql_serialization_format::internal())};
+
+                return {
+                    v._is_column_delete,
+                    std::move(v._deleted_keys),
+                    std::move(added_cells)
+                };
+            },
+            [&] (const abstract_type& o) -> result_t {
+                throw std::runtime_error(format("cdc process_change: unknown type {}", o.name()));
+            }
+        ));
+
+        // FIXME: we're doing redundant work: first we serialize the set of deleted keys into a blob,
+        // then we deserialize again when merging images below
+        bytes_opt deleted_elements = std::nullopt;
+        if (!deleted_keys.empty()) {
+            deleted_elements = set_type_impl::serialize_partially_deserialized_form(deleted_keys, cql_serialization_format::internal());
+        }
+
+        // delta
+        if (is_column_delete) {
+            _builder.set_deleted(_log_ck, cdef);
+        }
+
+        if (deleted_elements) {
+            _builder.set_deleted_elements(_log_ck, cdef, *deleted_elements);
+        }
+
+        if (added_cells) {
+            _builder.set_value(_log_ck, cdef, *added_cells);
+        }
+
+        // images
+        if (_enable_updating_state) {
+            // A column delete overwrites any data we gathered until now.
+            bytes_opt prev = is_column_delete ? std::nullopt : get_col_from_row_state(_row_state, cdef);
+
+            bytes_opt next;
+            if (added_cells || (deleted_elements && prev)) {
+                next = visit(*cdef.type, [&] (const auto& type) -> bytes {
+                    return merge(type, prev, added_cells, deleted_elements);
+                });
+            }
+
+            update_row_state(cdef, std::move(next));
+        }
+    }
+
+    constexpr bool finished() const { return false; }
+};
+
+struct process_change_visitor {
+    stats::part_type_set& _touched_parts;
+
+    log_mutation_builder& _builder;
+
+    /* Images-related state */
+    const bool _enable_updating_state = false;
+
+    row_states_map& _clustering_row_states;
+    cell_map& _static_row_state;
+
+    void static_row_cells(auto&& visit_row_cells) {
+        _touched_parts.set<stats::part_type::STATIC_ROW>();
+
+        auto log_ck = _builder.allocate_new_log_row(operation::update);
+
+        process_row_visitor v(
+                log_ck, _touched_parts, _builder,
+                _enable_updating_state, nullptr, &_static_row_state, _clustering_row_states);
+        visit_row_cells(v);
+
+        _builder.set_ttl(log_ck, v._ttl_column);
+    }
+
+    void clustered_row_cells(const clustering_key& ckey, auto&& visit_row_cells) {
+        _touched_parts.set<stats::part_type::CLUSTERING_ROW>();
+
+        auto log_ck = _builder.allocate_new_log_row();
+
+        _builder.set_clustering_columns(log_ck, ckey);
+
+        struct clustering_row_cells_visitor : public process_row_visitor {
+            operation _cdc_op = operation::update;
+
+            clustering_row_cells_visitor(
+                    const clustering_key& log_ck, stats::part_type_set& touched_parts, log_mutation_builder& builder,
+                    bool enable_updating_state, const clustering_key* base_ck, cell_map* row_state,
+                    row_states_map& clustering_row_states)
+                : process_row_visitor(
+                        log_ck, touched_parts, builder,
+                        enable_updating_state, base_ck, row_state, clustering_row_states)
+            {}
+
+            void marker(const row_marker& rm) {
+                _ttl_column = get_ttl(rm);
+                _cdc_op = operation::insert;
+            }
+        };
+
+        clustering_row_cells_visitor v(
+                log_ck, _touched_parts, _builder,
+                _enable_updating_state, &ckey, get_row_state(_clustering_row_states, ckey),
+                _clustering_row_states);
+        visit_row_cells(v);
+
+        _builder.set_operation(log_ck, v._cdc_op);
+        _builder.set_ttl(log_ck, v._ttl_column);
+    }
+
+    void clustered_row_delete(const clustering_key& ckey, const tombstone&) {
+        _touched_parts.set<stats::part_type::ROW_DELETE>();
+
+        auto log_ck = _builder.allocate_new_log_row(operation::row_delete);
+        _builder.set_clustering_columns(log_ck, ckey);
+
+        if (_enable_updating_state && get_row_state(_clustering_row_states, ckey)) {
+            _clustering_row_states.erase(ckey);
+        }
+    }
+
+    void range_delete(const range_tombstone& rt) {
+        _touched_parts.set<stats::part_type::RANGE_TOMBSTONE>();
+        {
+            const auto start_operation = rt.start_kind == bound_kind::incl_start
+                    ? operation::range_delete_start_inclusive
+                    : operation::range_delete_start_exclusive;
+            auto log_ck = _builder.allocate_new_log_row(start_operation);
+            _builder.set_clustering_columns(log_ck, rt.start);
+        }
+        {
+            const auto end_operation = rt.end_kind == bound_kind::incl_end
+                    ? operation::range_delete_end_inclusive
+                    : operation::range_delete_end_exclusive;
+            auto log_ck = _builder.allocate_new_log_row(end_operation);
+            _builder.set_clustering_columns(log_ck, rt.end);
+        }
+    }
+
+    void partition_delete(const tombstone&) {
+        _touched_parts.set<stats::part_type::PARTITION_DELETE>();
+
+        auto log_ck = _builder.allocate_new_log_row(operation::partition_delete);
+    }
+
+    constexpr bool finished() const { return false; }
 };
 
 class transformer final : public change_processor {
@@ -1179,231 +1524,14 @@ public:
     // more details like tombstones/ttl? Probably not but keep in mind.
     void process_change(const mutation& m) override {
         assert(_builder);
-        auto& p = m.partition();
-        if (p.partition_tombstone()) {
-            // Partition deletion
-            _touched_parts.set<stats::part_type::PARTITION_DELETE>();
-            _builder->allocate_new_log_row(operation::partition_delete);
-        } else if (!p.row_tombstones().empty()) {
-            // range deletion
-            _touched_parts.set<stats::part_type::RANGE_TOMBSTONE>();
-            for (auto& rt : p.row_tombstones()) {
-                {
-                    const auto start_operation = rt.start_kind == bound_kind::incl_start
-                            ? operation::range_delete_start_inclusive
-                            : operation::range_delete_start_exclusive;
-                    auto log_ck = _builder->allocate_new_log_row(start_operation);
-                    _builder->set_clustering_columns(log_ck, rt.start);
-                }
-                {
-                    const auto end_operation = rt.end_kind == bound_kind::incl_end
-                            ? operation::range_delete_end_inclusive
-                            : operation::range_delete_end_exclusive;
-                    auto log_ck = _builder->allocate_new_log_row(end_operation);
-                    _builder->set_clustering_columns(log_ck, rt.end);
-                }
-            }
-        } else {
-            // should be insert, update or deletion
-            auto process_cells = [&](const row& r, column_kind ckind, const clustering_key& log_ck, const clustering_key* base_ck, cell_map* row_state) -> std::optional<gc_clock::duration> {
-                std::optional<gc_clock::duration> ttl;
-                std::unordered_set<column_id> columns_assigned;
-                r.for_each_cell([&](column_id id, const atomic_cell_or_collection& cell) {
-                    auto& cdef = _schema->column_at(ckind, id);
-                    bool is_column_delete = true;
-                    bytes_opt value;
-                    bytes_opt deleted_elements = std::nullopt;
-                    if (cdef.is_atomic()) {
-                        value = std::nullopt;
-                        auto view = cell.as_atomic_cell(cdef);
-                        if (view.is_live()) {
-                            is_column_delete = false;
-                            value = view.value().linearize();
-                            if (view.is_live_and_has_ttl()) {
-                                ttl = view.ttl();
-                            }
-                        }
-                    } else {
-                        auto mv = cell.as_collection_mutation();
-                        is_column_delete = false;
-                        std::vector<bytes> buf;
-                        value = mv.with_deserialized(*cdef.type, [&](collection_mutation_view_description view) -> bytes_opt {
-                            if (view.tomb) {
-                                // there is a tombstone with timestamp before this mutation.
-                                // this is how a assign collection = <value> is represented.
-                                // for non-atomics, a column delete + values in data column
-                                // simply means "replace values"
-                                is_column_delete = true;
-                            }
-                            auto process_collection = [&](auto value_callback) {
-                                for (auto& [key, value] : view.cells) {
-                                    // note: we are assuming that all mutations coming here adhere to
-                                    // / are created by the cql machinery or similar, i.e. if we have
-                                    // the tombstone above, it preceeds the actual cells, and is in
-                                    // fact an "assign" marker. So we only check for explicitly
-                                    // dead cells, i.e. null markers.
-                                    auto live = value.is_live();
-                                    if (!live) {
-                                        value_callback(key, bytes_view{}, live);
-                                        continue;
-                                    }
-                                    auto val = value.value().is_fragmented()
-                                        ? bytes_view{buf.emplace_back(value.value().linearize())}
-                                        : value.value().first_fragment()
-                                        ;
-                                    value_callback(key, val, live);
-                                    if (value.is_live_and_has_ttl()) {
-                                        ttl = value.ttl();
-                                    }
-                                }
-                            };
-
-                            std::vector<bytes_view> deleted;
-
-                            return visit(*cdef.type, make_visitor(
-                                // maps and lists are just flattened
-                                [&] (const collection_type_impl& type) -> bytes_opt {
-                                    _touched_parts.set(type.is_list() ? stats::part_type::LIST : stats::part_type::MAP);
-                                    std::vector<std::pair<bytes_view, bytes_view>> result;
-                                    process_collection([&](const bytes_view& key, const bytes_view& value, bool live) {
-                                        if (live) {
-                                            result.emplace_back(key, value);
-                                        } else {
-                                            deleted.emplace_back(key);
-                                        }
-                                    });
-                                    if (!deleted.empty()) {
-                                        deleted_elements = set_type_impl::serialize_partially_deserialized_form(deleted, cql_serialization_format::internal());
-                                    }
-                                    if (result.empty()) {
-                                        return std::nullopt;
-                                    }
-                                    return map_type_impl::serialize_partially_deserialized_form(result, cql_serialization_format::internal());
-                                },
-                                // set need to transform from mutation view
-                                [&] (const set_type_impl& type) -> bytes_opt  {
-                                    _touched_parts.set<stats::part_type::SET>();
-                                    std::vector<bytes_view> result;
-                                    process_collection([&](const bytes_view& key, const bytes_view& value, bool live) {
-                                        if (live) {
-                                            result.emplace_back(key);
-                                        } else {
-                                            deleted.emplace_back(key);
-                                        }
-                                    });
-                                    if (!deleted.empty()) {
-                                        deleted_elements = set_type_impl::serialize_partially_deserialized_form(deleted, cql_serialization_format::internal());
-                                    }
-                                    if (result.empty()) {
-                                        return std::nullopt;
-                                    }
-                                    return set_type_impl::serialize_partially_deserialized_form(result, cql_serialization_format::internal());
-                                },
-                                // for user type we collect the fields in the mutation and set to
-                                // tuple of value or tuple of null in case of delete.
-                                // fields not in the mutation are null in the enclosing tuple, signifying "no info"
-                                [&](const user_type_impl& type) -> bytes_opt  {
-                                    _touched_parts.set<stats::part_type::UDT>();
-                                    std::vector<bytes_opt> result(type.size());
-                                    process_collection([&](const bytes_view& key, const bytes_view& value, bool live) {
-                                        if (live) {
-                                            auto idx = deserialize_field_index(key);
-                                            result[idx].emplace(value);
-                                        } else {
-                                            deleted.emplace_back(key);
-                                        }
-                                    });
-                                    if (!deleted.empty()) {
-                                        deleted_elements = set_type_impl::serialize_partially_deserialized_form(deleted, cql_serialization_format::internal());
-                                    }
-                                    if (result.empty()) {
-                                        return std::nullopt;
-                                    }
-                                    return type.build_value(result);
-                                },
-                                [&] (const abstract_type& o) -> bytes_opt {
-                                    throw std::runtime_error(format("cdc transform: unknown type {}", o.name()));
-                                }
-                            ));
-                        });
-
-                        if (deleted_elements) {
-                            _builder->set_deleted_elements(log_ck, cdef, *deleted_elements);
-                        }
-                    }
-
-                    if (is_column_delete) {
-                        _builder->set_deleted(log_ck, cdef);
-                    }
-
-                    if (value) {
-                        _builder->set_value(log_ck, cdef, *value);
-                    }
-
-                    if (_enable_updating_state) {
-                        // don't merge with pre-image iff column delete
-                        bytes_opt prev = is_column_delete ? std::nullopt : get_col_from_row_state(row_state, cdef);
-
-                        bytes_opt next;
-                        if (cdef.is_atomic() && !is_column_delete && value) {
-                            next = std::move(value);
-                        } else if (!cdef.is_atomic() && (value || (deleted_elements && prev))) {
-                            next = visit(*cdef.type, [&] (const auto& type) -> bytes {
-                                return merge(type, prev, value, deleted_elements);
-                            });
-                        }
-                        if (!row_state) {
-                            // static row always has a valid state, so this must be
-                            // a clustering row missing
-                            assert(base_ck);
-                            auto [it, inserted] = _clustering_row_states.try_emplace(*base_ck);
-                            row_state = &it->second;
-                        }
-                        (*row_state)[&cdef] = std::move(next);
-                    }
-                });
-
-                return ttl;
-            };
-
-            if (!p.static_row().empty()) {
-                _touched_parts.set<stats::part_type::STATIC_ROW>();
-
-                auto log_ck = _builder->allocate_new_log_row(operation::update);
-                auto ttl = process_cells(p.static_row().get(), column_kind::static_column, log_ck, nullptr, &_static_row_state);
-                _builder->set_ttl(log_ck, ttl);
-            } else {
-                _touched_parts.set_if<stats::part_type::CLUSTERING_ROW>(!p.clustered_rows().empty());
-                for (const rows_entry& r : p.clustered_rows()) {
-                    auto* row_state = get_row_state(_clustering_row_states, r.key());
-
-                    auto log_ck = _builder->allocate_new_log_row();
-                    _builder->set_clustering_columns(log_ck, r.key());
-                    
-                    operation cdc_op;
-                    if (r.row().deleted_at()) {
-                        _touched_parts.set<stats::part_type::ROW_DELETE>();
-                        cdc_op = operation::row_delete;
-
-                        if (_enable_updating_state && row_state) {
-                            // Erase so that postimage will be empty
-                            _clustering_row_states.erase(r.key());
-                        }
-                    } else {
-                        auto ttl = process_cells(r.row().cells(), column_kind::regular_column, log_ck, &r.key(), row_state);
-                        const auto& marker = r.row().marker();
-                        if (marker.is_live() && marker.is_expiring()) {
-                            ttl = marker.ttl();
-                        }
-
-                        cdc_op = marker.is_live() ? operation::insert : operation::update;
-
-                        _builder->set_ttl(log_ck, ttl);
-                    }
-                    _builder->set_operation(log_ck, cdc_op);
-                }
-            }
-        }
+        process_change_visitor v {
+            ._touched_parts = _touched_parts,
+            ._builder = *_builder,
+            ._enable_updating_state = _enable_updating_state,
+            ._clustering_row_states = _clustering_row_states,
+            ._static_row_state = _static_row_state
+        };
+        cdc::inspect_mutation(m, v);
     }
 
     // Takes and returns generated cdc log mutations and associated statistics about parts touched during transformer's lifetime.


### PR DESCRIPTION
These abstractions are used for walking over mutations created by a write
coordinator, deconstructing them into ``atomic'' pieces (``changes''),
and consuming these pieces.

Read the big comment in cdc/change_visitor.hh for more details.

4 big functions were rewritten to use the new abstractions.

tests: 
- unit (dev build)
- all dtests from cdc_tests.py, except `cdc_tests.py:TestCdc.cluster_reduction_with_cdc_test`, have passed (on a dev build). The test that fails also fails on master.

Part of https://github.com/scylladb/scylla/issues/5945.