### PR TITLE
cdc:stream_id: Encode format version + vnode grouping/index in id

### DIFF
--- a/alternator/streams.cc
+++ b/alternator/streams.cc
@@ -449,10 +449,10 @@ future<executor::request_return_type> executor::describe_stream(client_state& cl
                 auto shard = rjson::empty_object();
 
                 if (prev != e) {
-                    auto token = dht::token::from_int64(id.first());
+                    auto token = id.token();
                     auto& pids = prev->second.streams();
                     auto pid = std::upper_bound(pids.begin(), pids.end(), token, [](const dht::token& t, const cdc::stream_id& id) {
-                        return t < dht::token::from_int64(id.first());
+                        return t < id.token();
                     });
                     if (pid != pids.end()) {
                         rjson::set(shard, "ParentShardId", shard_id(schema->id(), prev->first, *pid));

--- a/cdc/generation.hh
+++ b/cdc/generation.hh
@@ -64,21 +64,26 @@ namespace cdc {
 class stream_id final {
     bytes _value;
 public:
+    static constexpr uint8_t version_1 = 1;
+
     stream_id() = default;
-    stream_id(int64_t, int64_t);
     stream_id(bytes);
+
     bool is_set() const;
     bool operator==(const stream_id&) const;
     bool operator!=(const stream_id&) const;
     bool operator<(const stream_id&) const;
 
-    int64_t first() const;
-    int64_t second() const;
-
+    uint8_t version() const;
+    size_t index() const;
     const bytes& to_bytes() const;
+    dht::token token() const;
 
     partition_key to_partition_key(const schema& log_schema) const;
     static int64_t token_from_bytes(bytes_view);
+private:
+    friend class topology_description_generator;
+    stream_id(dht::token, size_t);
 };
 
 /* Describes a mapping of tokens to CDC streams in a token range.


### PR DESCRIPTION
Fixes #6948

Changes the stream_id format from
 `<token:64>:<rand:64>`
to
 `<token:64>:<rand:38>:<index:22>:<version:4>`

The code will attempt to assert version match when
presented with a stored id (i.e. construct from bytes).
This means that ID:s created by previous (experimental)
versions will break.

Moves the ID encoding fully into the ID class, and makes
the code path private for the topology generation code
path.

Removes some superflous accessors but adds accessors for
token, version and index. (For alternator etc).