### PR TITLE
cql3: Move #include from .hh to .cc

### DIFF
--- a/cql3/restrictions/restriction.hh
+++ b/cql3/restrictions/restriction.hh
@@ -48,7 +48,7 @@
 #include <variant>
 #include <vector>
 
-#include <fmt/ostream.h>
+#include <fmt/core.h>
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/core/sstring.hh>
 #include "utils/overloaded_functor.hh"
@@ -252,31 +252,7 @@ public:
 }
 
 /// Required for fmt::join() to work on expression.
-template <>
-struct fmt::formatter<cql3::restrictions::expression> {
-    constexpr auto parse(format_parse_context& ctx) {
-        return ctx.end();
-    }
-
-    template <typename FormatContext>
-    auto format(const cql3::restrictions::expression& expr, FormatContext& ctx) {
-        std::ostringstream os;
-        os << expr;
-        return format_to(ctx.out(), "{}", os.str());
-    }
-};
+template <> struct fmt::formatter<cql3::restrictions::expression>;
 
 /// Required for fmt::join() to work on column_value.
-template <>
-struct fmt::formatter<cql3::restrictions::column_value> {
-    constexpr auto parse(format_parse_context& ctx) {
-        return ctx.end();
-    }
-
-    template <typename FormatContext>
-    auto format(const cql3::restrictions::column_value& col, FormatContext& ctx) {
-        std::ostringstream os;
-        os << col;
-        return format_to(ctx.out(), "{}", os.str());
-    }
-};
+template <> struct fmt::formatter<cql3::restrictions::column_value>;

--- a/cql3/restrictions/statement_restrictions.cc
+++ b/cql3/restrictions/statement_restrictions.cc
@@ -25,6 +25,7 @@
 #include <boost/algorithm/cxx11/any_of.hpp>
 #include <boost/range/adaptors.hpp>
 #include <boost/range/algorithm.hpp>
+#include <fmt/ostream.h>
 #include <functional>
 #include <ranges>
 #include <stdexcept>
@@ -1404,3 +1405,31 @@ expression replace_column_def(const expression& expr, const column_definition* n
 
 } // namespace restrictions
 } // namespace cql3
+
+template <>
+struct fmt::formatter<cql3::restrictions::expression> {
+    constexpr auto parse(format_parse_context& ctx) {
+        return ctx.end();
+    }
+
+    template <typename FormatContext>
+    auto format(const cql3::restrictions::expression& expr, FormatContext& ctx) {
+        std::ostringstream os;
+        os << expr;
+        return format_to(ctx.out(), "{}", os.str());
+    }
+};
+
+template <>
+struct fmt::formatter<cql3::restrictions::column_value> {
+    constexpr auto parse(format_parse_context& ctx) {
+        return ctx.end();
+    }
+
+    template <typename FormatContext>
+    auto format(const cql3::restrictions::column_value& col, FormatContext& ctx) {
+        std::ostringstream os;
+        os << col;
+        return format_to(ctx.out(), "{}", os.str());
+    }
+};


### PR DESCRIPTION
restrictions.hh included fmt/ostream.h, which is expensive due to its
transitive #includes.  Replace it with fmt/core.h, which transitively
includes only standard C++ headers.

As requested by #5763 feedback:
https://github.com/scylladb/scylla/pull/5763#discussion_r443210634

Tests: unit (dev)

Signed-off-by: Dejan Mircevski <dejan@scylladb.com>