### PR TITLE
transport: Allow user to disable unencrypted native transport

### DIFF
--- a/conf/scylla.yaml
+++ b/conf/scylla.yaml
@@ -100,6 +100,7 @@ listen_address: localhost
 
 # port for the CQL native transport to listen for clients on
 # For security reasons, you should not expose this port to the internet.  Firewall it if needed.
+# To disable the CQL native transport, set this option to 0.
 native_transport_port: 9042
 
 # Like native_transport_port, but clients are forwarded to specific shards, based on the

--- a/docs/protocols.md
+++ b/docs/protocols.md
@@ -92,13 +92,17 @@ The CQL binary protocol is Cassandra's and Scylla's main client-facing
 protocol. Scylla supports several Scylla-only extensions to this protocol,
 described in [protocol-extensions.md](protocol-extensions.md).
 
-By default scylla listens to the CQL protocol on port 9042, which can be
-configured via the `native_transport_port` configuration option, or entirely
-disabled by setting the `start_native_transport` option to 0.
-Again these option names were chosen for backward-compatibility with Cassandra
-configuration files: They refers to CQL as the "native transport", to contrast
-with the older Thrift protocol (described below) which wasn't native to
-Cassandra.
+By default, Scylla listens to the CQL protocol on port 9042, which can be
+configured via the `native_transport_port` configuration option. Scylla also
+supports the CQL protocol via TLS/SSL encryption, which can be enabled via the
+`native_transport_port_ssl` configuration option (default port is 9142). Users
+that want to only support the encrypted CQL protocol can disable the
+unencrypted default CQL protocol by setting the `native_transport_port` to 0.
+The CQL protocol support can be disabled altogether by setting the
+`start_native_transport` option to `false`. These option names were chosen for
+backward-compatibility with Cassandra configuration files: They refers to CQL
+as the "native transport", to contrast with the older Thrift protocol
+(described below) which wasn't native to Cassandra.
 
 There is also a `rpc_address` configuration option to set the IP address
 (and therefore network interface) on which Scylla should listen for the

--- a/transport/controller.cc
+++ b/transport/controller.cc
@@ -92,7 +92,11 @@ future<> controller::do_start_server() {
             std::shared_ptr<seastar::tls::credentials_builder> cred;
         };
 
-        std::vector<listen_cfg> configs({{ socket_address{ip, cfg.native_transport_port()}, false }});
+        std::vector<listen_cfg> configs;
+
+        if (cfg.native_transport_port() != 0) {
+            configs.push_back(listen_cfg{ socket_address{ip, cfg.native_transport_port()}, false });
+        }
         if (cfg.native_shard_aware_transport_port.is_set()) {
             configs.push_back(listen_cfg{ socket_address{ip, cfg.native_shard_aware_transport_port()}, true });
         }


### PR DESCRIPTION
Let users disable the unencrypted native transport too by setting the port to
zero in the scylla.yaml configuration file.

Fixes #6997