### PR TITLE
Fix repair stalls in get_sync_boundary and apply_rows_on_master_in_thread

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -393,6 +393,7 @@ scylla_tests = set([
     'test/boost/virtual_reader_test',
     'test/boost/bptree_test',
     'test/boost/double_decker_test',
+    'test/boost/stall_free_test',
     'test/manual/ec2_snitch_test',
     'test/manual/enormous_table_scan_test',
     'test/manual/gce_snitch_test',

--- a/test/boost/stall_free_test.cc
+++ b/test/boost/stall_free_test.cc
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2020 ScyllaDB
+ */
+
+/*
+ * This file is part of Scylla.
+ *
+ * Scylla is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Scylla is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <seastar/testing/thread_test_case.hh>
+#include "utils/stall_free.hh"
+
+SEASTAR_THREAD_TEST_CASE(test_merge1) {
+    std::list<int> l1{1, 2, 5, 8};
+    std::list<int> l2{3};
+    std::list<int> expected{1,2,3,5,8};
+    utils::merge_to_gently(l1, l2, std::less<int>());
+    BOOST_CHECK(l1 == expected);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_merge2) {
+    std::list<int> l1{1};
+    std::list<int> l2{3, 5, 6};
+    std::list<int> expected{1,3,5,6};
+    utils::merge_to_gently(l1, l2, std::less<int>());
+    BOOST_CHECK(l1 == expected);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_merge3) {
+    std::list<int> l1{};
+    std::list<int> l2{3, 5, 6};
+    std::list<int> expected{3,5,6};
+    utils::merge_to_gently(l1, l2, std::less<int>());
+    BOOST_CHECK(l1 == expected);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_merge4) {
+    std::list<int> l1{1};
+    std::list<int> l2{};
+    std::list<int> expected{1};
+    utils::merge_to_gently(l1, l2, std::less<int>());
+    BOOST_CHECK(l1 == expected);
+}

--- a/utils/stall_free.hh
+++ b/utils/stall_free.hh
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2020 ScyllaDB
+ */
+
+/*
+ * This file is part of Scylla.
+ *
+ * Scylla is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Scylla is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <list>
+#include <algorithm>
+#include <seastar/core/thread.hh>
+#include "utils/collection-concepts.hh"
+
+namespace utils {
+
+
+// Similar to std::merge but it does not stall. Must run inside a seastar
+// thread. It merges items from list2 into list1. Items from list2 can only be copied.
+template<class T, class Compare>
+SEASTAR_CONCEPT(requires LessComparable<T, T, Compare>)
+void merge_to_gently(std::list<T>& list1, const std::list<T>& list2, Compare comp) {
+    auto first1 = list1.begin();
+    auto first2 = list2.begin();
+    auto last1 = list1.end();
+    auto last2 = list2.end();
+    while (first2 != last2) {
+        seastar::thread::maybe_yield();
+        if (first1 == last1) {
+            // Copy remaining items of list2 into list1
+            std::copy_if(first2, last2, std::back_inserter(list1), [] (const auto&) { return true; });
+            return;
+        }
+        if (comp(*first2, *first1)) {
+            first1 = list1.insert(first1, *first2);
+            ++first2;
+        } else {
+            ++first1;
+        }
+    }
+}
+
+}
+

--- a/utils/stall_free.hh
+++ b/utils/stall_free.hh
@@ -54,5 +54,16 @@ void merge_to_gently(std::list<T>& list1, const std::list<T>& list2, Compare com
     }
 }
 
+template<class T>
+future<> clear_gently(std::list<T>& list) {
+    return repeat([&list] () mutable {
+        if (list.empty()) {
+            return stop_iteration::yes;
+        }
+        list.pop_back();
+        return stop_iteration::no;
+    });
+}
+
 }
 


### PR DESCRIPTION
This path set fixes stalls in repair that are caused by std::list merge and clear operations during test_latency_read_with_nemesis test. 

Fixes #6940
Fixes #6975
Fixes #6976