### PR TITLE
scylla_swap_setup improvement

### DIFF
--- a/dist/common/scripts/scylla_setup
+++ b/dist/common/scripts/scylla_setup
@@ -98,6 +98,15 @@ def interactive_choose_swap_directory():
         else:
             return d
 
+def interactive_choose_swap_size():
+    print('Please input swap size in GB:')
+    while True:
+        s = input('> ')
+        try:
+            return int(s)
+        except Exception as e:
+            print(f'"{s}" is not valid number, input again')
+
 def do_verify_package(pkg):
     if is_debian_variant():
         res = run('dpkg -s {}'.format(pkg), silent=True, exception=False)
@@ -166,6 +175,8 @@ if __name__ == '__main__':
                         help='specify subdomain of pool.ntp.org (ex: centos, fedora or amazon)')
     parser.add_argument('--swap-directory',
                         help='specify swapfile directory (ex: /)')
+    parser.add_argument('--swap-size', type=int,
+                        help='specify swapfile size in GB')
     parser.add_argument('--ami', action='store_true', default=False,
                         help='setup AMI instance')
     parser.add_argument('--setup-nic-and-disks', action='store_true', default=False,
@@ -230,6 +241,7 @@ if __name__ == '__main__':
     nic = args.nic
     set_nic_and_disks = args.setup_nic_and_disks
     swap_directory = args.swap_directory
+    swap_size = args.swap_size
     ec2_check = not args.no_ec2_check
     kernel_check = not args.no_kernel_check
     verify_package = not args.no_verify_package
@@ -458,14 +470,22 @@ if __name__ == '__main__':
             swap_setup = interactive_ask_service('Do you want to configure swapfile?', 'Answer yes to setup swapfile to Scylla, Answer no to do nothing.', swap_setup)
             args.no_swap_setup = not swap_setup
             if swap_setup:
+                options = ""
                 if interactive:
                     skip_choose_swap_directory = interactive_ask_service('Do you want to create swapfile on root directory?', 'Anser yes to create swapfile on /, no to choose swap directory.', True)
                     if not skip_choose_swap_directory:
                         swap_directory = interactive_choose_swap_directory()
+
+                    skip_choose_swap_size = interactive_ask_service('Do you want to auto configure swap size?', 'Anser yes to auto configure, no to manually configure swap size.', True)
+                    if not skip_choose_swap_size:
+                        swap_size = interactive_choose_swap_size()
+
                 if swap_directory:
-                    run_setup_script('swap', 'scylla_swap_setup --swap-directory {}'.format(swap_directory))
-                else:
-                    run_setup_script('swap', 'scylla_swap_setup')
+                    options += f' --swap-directory {swap_directory}'
+                if swap_size:
+                    options += f' --swap-size {swap_size}'
+
+                run_setup_script('swap', 'scylla_swap_setup' + options)
 
     print('ScyllaDB setup finished.')
 

--- a/dist/common/scripts/scylla_swap_setup
+++ b/dist/common/scripts/scylla_swap_setup
@@ -23,6 +23,7 @@
 import os
 import sys
 import argparse
+import psutil
 from pathlib import Path
 from scylla_util import *
 
@@ -39,9 +40,10 @@ if __name__ == '__main__':
         print('swap already configured, exiting setup')
         sys.exit(1)
 
-    memtotal = get_memtotal_gb()
+    memtotal_kb = int(psutil.virtual_memory().total / 1024)
+    memtotal = int(memtotal_kb / 1024 / 1024)
     if memtotal == 0:
-        print('memory too small: {} KB'.format(get_memtotal()))
+        print('memory too small: {} KB'.format(memtotal_kb))
         sys.exit(1)
 
     # Scylla document says 'swap size should be set to either total_mem/3 or
@@ -49,7 +51,7 @@ if __name__ == '__main__':
     # choose lower one
     # see: https://docs.scylladb.com/faq/#do-i-need-to-configure-swap-on-a-scylla-node
     swapsize = 16 if 16 < int(memtotal / 3) else int(memtotal / 3)
-    diskfree = get_disk_free_gb(args.swap_directory)
+    diskfree = int(psutil.disk_usage(args.swap_directory).free / 1024 / 1024 / 1024)
     if swapsize > diskfree:
         print('swap directory {} does not have enough disk space. {}GB space required.'.format(args.swap_directory, swapsize))
         sys.exit(1)

--- a/dist/common/scripts/scylla_swap_setup
+++ b/dist/common/scripts/scylla_swap_setup
@@ -27,6 +27,12 @@ import psutil
 from pathlib import Path
 from scylla_util import *
 
+def GB(n):
+    return n * 1024 * 1024 * 1024
+
+def to_GB(n):
+    return '{:.2f}'.format(n / 1024 / 1024 / 1024)
+
 if __name__ == '__main__':
     if os.getuid() > 0:
         print('Requires root permission.')
@@ -40,27 +46,24 @@ if __name__ == '__main__':
         print('swap already configured, exiting setup')
         sys.exit(1)
 
-    memtotal_kb = int(psutil.virtual_memory().total / 1024)
-    memtotal = int(memtotal_kb / 1024 / 1024)
-    if memtotal == 0:
-        print('memory too small: {} KB'.format(memtotal_kb))
-        sys.exit(1)
+    memtotal = psutil.virtual_memory().total
 
     # Scylla document says 'swap size should be set to either total_mem/3 or
     # 16GB - lower of the two', so we need to compare 16g vs memtotal/3 and
     # choose lower one
     # see: https://docs.scylladb.com/faq/#do-i-need-to-configure-swap-on-a-scylla-node
-    swapsize = 16 if 16 < int(memtotal / 3) else int(memtotal / 3)
-    diskfree = int(psutil.disk_usage(args.swap_directory).free / 1024 / 1024 / 1024)
+    swapsize = GB(16) if GB(16) < int(memtotal / 3) else int(memtotal / 3)
+    diskfree = psutil.disk_usage(args.swap_directory).free
     if swapsize > diskfree:
-        print('swap directory {} does not have enough disk space. {}GB space required.'.format(args.swap_directory, swapsize))
+        print('swap directory {} does not have enough disk space. {}GB space required.'.format(args.swap_directory, to_GB(swapsize)))
         sys.exit(1)
 
+    swapsize_mb = int(swapsize / 1024 / 1024)
     swapfile = Path(args.swap_directory) / 'swapfile'
     if swapfile.exists():
         print('swapfile {} already exists'.format(swapfile))
         sys.exit(1)
-    run('dd if=/dev/zero of={} bs=1G count={}'.format(swapfile, swapsize))
+    run('dd if=/dev/zero of={} bs=1M count={}'.format(swapfile, swapsize_mb))
     swapfile.chmod(0o600)
     run('mkswap -f {}'.format(swapfile))
     swapunit_bn = out('systemd-escape -p --suffix=swap {}'.format(swapfile))

--- a/dist/common/scripts/scylla_swap_setup
+++ b/dist/common/scripts/scylla_swap_setup
@@ -40,30 +40,38 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Configure swap for Scylla.')
     parser.add_argument('--swap-directory',
                         help='specify swapfile directory', default='/')
+    parser.add_argument('--swap-size', type=int,
+                        help='specify swapfile size in GB')
     args = parser.parse_args()
 
     if swap_exists():
         print('swap already configured, exiting setup')
         sys.exit(1)
 
-    memtotal = psutil.virtual_memory().total
-
-    # Scylla document says 'swap size should be set to either total_mem/3 or
-    # 16GB - lower of the two', so we need to compare 16g vs memtotal/3 and
-    # choose lower one
-    # see: https://docs.scylladb.com/faq/#do-i-need-to-configure-swap-on-a-scylla-node
-    swapsize = GB(16) if GB(16) < int(memtotal / 3) else int(memtotal / 3)
-
-    # We should not fill entire disk space with swapfile, it's safer to limit
-    # swap size 50% of diskfree
     diskfree = psutil.disk_usage(args.swap_directory).free
-    half_of_diskfree = int(diskfree / 2)
-    if swapsize > half_of_diskfree:
-        # out of disk space, abort setup
-        if half_of_diskfree <= GB(1):
-            print('swap directory {} does not have enough disk space.')
+    if args.swap_size:
+        swapsize = GB(args.swap_size)
+        if swapsize > diskfree:
+            print('swap directory {} does not have enough disk space. {}GB space required.'.format(args.swap_directory, to_GB(swapsize)))
             sys.exit(1)
-        swapsize = half_of_diskfree
+    else:
+        memtotal = psutil.virtual_memory().total
+
+        # Scylla document says 'swap size should be set to either total_mem/3 or
+        # 16GB - lower of the two', so we need to compare 16g vs memtotal/3 and
+        # choose lower one
+        # see: https://docs.scylladb.com/faq/#do-i-need-to-configure-swap-on-a-scylla-node
+        swapsize = GB(16) if GB(16) < int(memtotal / 3) else int(memtotal / 3)
+
+        # We should not fill entire disk space with swapfile, it's safer to limit
+        # swap size 50% of diskfree
+        half_of_diskfree = int(diskfree / 2)
+        if swapsize > half_of_diskfree:
+            # out of disk space, abort setup
+            if half_of_diskfree <= GB(1):
+                print('swap directory {} does not have enough disk space.')
+                sys.exit(1)
+            swapsize = half_of_diskfree
 
     swapsize_mb = int(swapsize / 1024 / 1024)
     swapfile = Path(args.swap_directory) / 'swapfile'

--- a/dist/common/scripts/scylla_swap_setup
+++ b/dist/common/scripts/scylla_swap_setup
@@ -53,10 +53,17 @@ if __name__ == '__main__':
     # choose lower one
     # see: https://docs.scylladb.com/faq/#do-i-need-to-configure-swap-on-a-scylla-node
     swapsize = GB(16) if GB(16) < int(memtotal / 3) else int(memtotal / 3)
+
+    # We should not fill entire disk space with swapfile, it's safer to limit
+    # swap size 50% of diskfree
     diskfree = psutil.disk_usage(args.swap_directory).free
-    if swapsize > diskfree:
-        print('swap directory {} does not have enough disk space. {}GB space required.'.format(args.swap_directory, to_GB(swapsize)))
-        sys.exit(1)
+    half_of_diskfree = int(diskfree / 2)
+    if swapsize > half_of_diskfree:
+        # out of disk space, abort setup
+        if half_of_diskfree <= GB(1):
+            print('swap directory {} does not have enough disk space.')
+            sys.exit(1)
+        swapsize = half_of_diskfree
 
     swapsize_mb = int(swapsize / 1024 / 1024)
     swapfile = Path(args.swap_directory) / 'swapfile'

--- a/dist/common/scripts/scylla_util.py
+++ b/dist/common/scripts/scylla_util.py
@@ -615,21 +615,6 @@ def swap_exists():
     swaps = out('swapon --noheadings --raw')
     return True if swaps != '' else False
 
-def get_memtotal():
-    with open('/proc/meminfo') as f:
-        meminfo = f.read()
-    matched = re.search(r'^MemTotal:\s+(\d+)', meminfo)
-    return int(matched.groups()[0])
-
-def get_memtotal_gb():
-    return int(get_memtotal() / 1024 / 1024)
-
-def get_disk_free(path):
-    return shutil.disk_usage(path)[2]
-
-def get_disk_free_gb(path):
-    return int(get_disk_free(path) / 1024 / 1024 / 1024)
-
 class SystemdException(Exception):
     pass
 

--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -81,6 +81,7 @@ fedora_packages=(
     python3-boto3
     python3-pytest
     python3-distro
+    python3-psutil
     dnf-utils
     pigz
     net-tools

--- a/reloc/python3/build_reloc.sh
+++ b/reloc/python3/build_reloc.sh
@@ -33,5 +33,5 @@ echo "$PYVER" > build/python3/SCYLLA-VERSION-FILE
 ln -fv build/SCYLLA-RELEASE-FILE build/python3/SCYLLA-RELEASE-FILE
 ./dist/debian/python3/debian_files_gen.py
 
-PACKAGES="python3-pyyaml python3-urwid python3-pyparsing python3-requests python3-pyudev python3-setuptools python3-psutil python3-distro"
+PACKAGES="python3-pyyaml python3-urwid python3-pyparsing python3-requests python3-pyudev python3-setuptools python3-psutil python3-distro python3-psutil"
 ./scripts/create-relocatable-package-python3.py --output "$TARGET" $PACKAGES


### PR DESCRIPTION
As I described at https://github.com/scylladb/scylla/issues/6973#issuecomment-669705374,
we need to avoid disk full on scylla_swap_setup, also we should provide manual configuration of swap size.

This PR provides following things:
 - use psutil to get memtotal and disk free, since it provides better APIs
 - calculate swap size in bytes to avoid causing error on low-memory environment
 - prevent to use more than 50% of disk space when auto-configured swap size, abort setup when almost no disk space available (less than 2GB)
 - add --swap-size option to specify swap size both on scylla_swap_setup and scylla_setup
 - add interactive swap size prompt on scylla_setup

Fixes #6947 
Related #6973
Related scylladb/scylla-machine-image#48