### PR TITLE
scylla_raid_setup: use mdadm.service on older Debian variants

### DIFF
--- a/dist/common/scripts/scylla_raid_setup
+++ b/dist/common/scripts/scylla_raid_setup
@@ -88,10 +88,16 @@ if __name__ == '__main__':
 
     if is_debian_variant():
         run('env DEBIAN_FRONTEND=noninteractive apt-get -y install mdadm xfsprogs')
+        try:
+            md_service = systemd_unit('mdmonitor.service')
+        except SystemdException:
+            md_service = systemd_unit('mdadm.service')
     elif is_redhat_variant():
         run('yum install -y mdadm xfsprogs')
+        md_service = systemd_unit('mdmonitor.service')
     elif is_gentoo_variant():
         run('emerge -uq sys-fs/mdadm sys-fs/xfsprogs')
+        md_service = systemd_unit('mdmonitor.service')
 
     if len(disks) == 1 and not args.force_raid:
         raid = False
@@ -142,7 +148,7 @@ if __name__ == '__main__':
     uuid = out(f'blkid -s UUID -o value {fsdev}')
     after = 'local-fs.target'
     if raid:
-        after += ' mdmonitor.service'
+        after += f' {md_service}'
     unit_data = f'''
 [Unit]
 Description=Scylla data directory
@@ -170,9 +176,8 @@ WantedBy=multi-user.target
             f.write(f'RequiresMountsFor={mount_at}\n')
 
     systemd_unit.reload()
-    mdmonitor = systemd_unit('mdmonitor.service')
-    mdmonitor.enable()
-    mdmonitor.start()
+    md_service.enable()
+    md_service.start()
     mount = systemd_unit(mntunit_bn)
     mount.start()
     if args.enable_on_nextboot:

--- a/dist/common/scripts/scylla_util.py
+++ b/dist/common/scripts/scylla_util.py
@@ -835,6 +835,9 @@ class systemd_unit:
             raise SystemdException('unit {} is not found or invalid'.format(unit))
         self._unit = unit
 
+    def __str__(self):
+        return self._unit
+
     def start(self):
         return run('systemctl {} start {}'.format(self.ctlparam, self._unit))
 


### PR DESCRIPTION
On older Debian variants does not have mdmonitor.service, we should use
mdadm.service instead.

Fixes #7000