### PR TITLE
cql: Forbid adding new fields to UDTs used in partition key columns

### DIFF
--- a/test/cql/forbid_adding_to_udt_used_in_partkey_test.cql
+++ b/test/cql/forbid_adding_to_udt_used_in_partkey_test.cql
@@ -1,0 +1,7 @@
+create type ut (a int);
+create table t (pk frozen<ut> primary key);
+alter type ut add b int;
+drop table t;
+alter type ut add c int;
+create table t2 (pk frozen<list<frozen<ut>>> primary key);
+alter type ut add d int;

--- a/test/cql/forbid_adding_to_udt_used_in_partkey_test.result
+++ b/test/cql/forbid_adding_to_udt_used_in_partkey_test.result
@@ -1,0 +1,30 @@
+create type ut (a int);
+{
+	"status" : "ok"
+}
+create table t (pk frozen<ut> primary key);
+{
+	"status" : "ok"
+}
+alter type ut add b int;
+{
+	"message" : "exceptions::invalid_request_exception (Cannot add new field to type ks.ut because it is used in the partition key column pk of table ks.t)",
+	"status" : "error"
+}
+drop table t;
+{
+	"status" : "ok"
+}
+alter type ut add c int;
+{
+	"status" : "ok"
+}
+create table t2 (pk frozen<list<frozen<ut>>> primary key);
+{
+	"status" : "ok"
+}
+alter type ut add d int;
+{
+	"message" : "exceptions::invalid_request_exception (Cannot add new field to type ks.ut because it is used in the partition key column pk of table ks.t2)",
+	"status" : "error"
+}


### PR DESCRIPTION
Changing a user type may allow adding duplicate rows to tables where
this type is used in a partitioning key. Fix by checking all types
of existing partitioning columns before allowing to add new fields to
the type.

Fixes #6941