### PR TITLE
CDC: allow "full" preimage in logs

### DIFF
--- a/alternator/streams.cc
+++ b/alternator/streams.cc
@@ -908,10 +908,10 @@ void executor::add_stream_options(const rjson::value& stream_specification, sche
                 break;
             case stream_view_type::NEW_AND_OLD_IMAGES: 
                 opts.postimage(true);
-                opts.preimage(true);
+                opts.preimage(cdc::image_mode::full);
                 break;
             case stream_view_type::OLD_IMAGE: 
-                opts.preimage(true);
+                opts.preimage(cdc::image_mode::full);
                 break;
             case stream_view_type::NEW_IMAGE: 
                 opts.postimage(true);

--- a/cdc/cdc_options.hh
+++ b/cdc/cdc_options.hh
@@ -27,15 +27,31 @@
 
 namespace cdc {
 
-enum class delta_mode {
+enum class delta_mode : uint8_t {
     off,
     keys,
     full,
 };
 
+/**
+ * (for now only pre-) image collection mode.
+ * Stating how much info to record.
+ * off == none
+ * on == changed columns
+ * full == all (changed and unmodified columns)
+ */
+enum class image_mode : uint8_t {
+    off, 
+    on,
+    full,
+};
+
+std::ostream& operator<<(std::ostream& os, delta_mode);
+std::ostream& operator<<(std::ostream& os, image_mode);
+
 class options final {
     bool _enabled = false;
-    bool _preimage = false;
+    image_mode _preimage = image_mode::off;
     bool _postimage = false;
     delta_mode _delta_mode = delta_mode::full;
     int _ttl = 86400; // 24h in seconds
@@ -47,13 +63,15 @@ public:
     sstring to_sstring() const;
 
     bool enabled() const { return _enabled; }
-    bool preimage() const { return _preimage; }
+    bool preimage() const { return _preimage != image_mode::off; }
+    bool full_preimage() const { return _preimage == image_mode::full; }
     bool postimage() const { return _postimage; }
     delta_mode get_delta_mode() const { return _delta_mode; }
     int ttl() const { return _ttl; }
 
     void enabled(bool b) { _enabled = b; }
-    void preimage(bool b) { _preimage = b; }
+    void preimage(bool b) { preimage(b ? image_mode::on : image_mode::off); }
+    void preimage(image_mode m) { _preimage = m; }
     void postimage(bool b) { _postimage = b; }
     void ttl(int v) { _ttl = v; }
 


### PR DESCRIPTION
Changes the "preimage" option from binary true/false to on/off/full (accepting true/false, and using old style notation for normal to string - for upgrade reasons), where "full" will force us to include all columns in pre image log rows. 

Adds small test (just adding the case to preimage test). 
Uses the feature in alternator

Fixes #7030