### PR TITLE
Add metrics for tracking latency of successful operations

### DIFF
--- a/database.hh
+++ b/database.hh
@@ -357,6 +357,7 @@ struct table_stats {
     utils::time_estimated_histogram estimated_read;
     utils::time_estimated_histogram estimated_successful_read;
     utils::time_estimated_histogram estimated_write;
+    utils::time_estimated_histogram estimated_successful_write;
     utils::time_estimated_histogram estimated_cas_prepare;
     utils::time_estimated_histogram estimated_cas_accept;
     utils::time_estimated_histogram estimated_cas_learn;

--- a/database.hh
+++ b/database.hh
@@ -355,6 +355,7 @@ struct table_stats {
     utils::timed_rate_moving_average_and_histogram cas_accept{256};
     utils::timed_rate_moving_average_and_histogram cas_learn{256};
     utils::time_estimated_histogram estimated_read;
+    utils::time_estimated_histogram estimated_successful_read;
     utils::time_estimated_histogram estimated_write;
     utils::time_estimated_histogram estimated_cas_prepare;
     utils::time_estimated_histogram estimated_cas_accept;

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -1550,6 +1550,10 @@ void storage_proxy_stats::stats::register_stats() {
                 {storage_proxy_stats::current_scheduling_group_label()},
                 [this]{ return to_metrics_histogram(estimated_successful_read);}),
 
+        sm::make_histogram("range_read_latency", sm::description("The read latency histogram for partition range reads"),
+                {storage_proxy_stats::current_scheduling_group_label()},
+                [this]{ return to_metrics_histogram(estimated_range);}),
+
         sm::make_queue_length("foreground_reads", foreground_reads,
                 sm::description("number of currently pending foreground read requests"),
                 {storage_proxy_stats::current_scheduling_group_label()}),

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -1554,6 +1554,10 @@ void storage_proxy_stats::stats::register_stats() {
                 {storage_proxy_stats::current_scheduling_group_label()},
                 [this]{ return to_metrics_histogram(estimated_range);}),
 
+        sm::make_histogram("successful_range_read_latency", sm::description("The read latency histogram for successful range reads only"),
+                {storage_proxy_stats::current_scheduling_group_label()},
+                [this]{ return to_metrics_histogram(estimated_successful_range);}),
+
         sm::make_queue_length("foreground_reads", foreground_reads,
                 sm::description("number of currently pending foreground read requests"),
                 {storage_proxy_stats::current_scheduling_group_label()}),
@@ -4308,11 +4312,15 @@ storage_proxy::do_query(schema_ptr s,
         return query_partition_key_range(cmd,
                 std::move(partition_ranges),
                 cl,
-                std::move(query_options)).finally([lc, p] () mutable {
+                std::move(query_options)).then_wrapped([lc, p] (future<coordinator_query_result>&& f) mutable {
             p->get_stats().range.mark(lc.stop().latency());
             if (lc.is_start()) {
+                if (!f.failed()) {
+                    p->get_stats().estimated_successful_range.add(lc.latency());
+                }
                 p->get_stats().estimated_range.add(lc.latency());
             }
+            return std::move(f);
         });
     }
 }

--- a/service/storage_proxy_stats.hh
+++ b/service/storage_proxy_stats.hh
@@ -171,6 +171,7 @@ struct stats : public write_stats {
     utils::timed_rate_moving_average_and_histogram read;
     utils::timed_rate_moving_average_and_histogram range;
     utils::time_estimated_histogram estimated_read;
+    utils::time_estimated_histogram estimated_successful_read;
     utils::time_estimated_histogram estimated_range;
 
     utils::timed_rate_moving_average_and_histogram cas_read;

--- a/service/storage_proxy_stats.hh
+++ b/service/storage_proxy_stats.hh
@@ -91,6 +91,7 @@ struct write_stats {
 
     utils::timed_rate_moving_average_and_histogram write;
     utils::time_estimated_histogram estimated_write;
+    utils::time_estimated_histogram estimated_successful_write;
 
     utils::timed_rate_moving_average cas_write_unavailables;
     utils::timed_rate_moving_average cas_write_timeouts;

--- a/service/storage_proxy_stats.hh
+++ b/service/storage_proxy_stats.hh
@@ -173,6 +173,7 @@ struct stats : public write_stats {
     utils::time_estimated_histogram estimated_read;
     utils::time_estimated_histogram estimated_successful_read;
     utils::time_estimated_histogram estimated_range;
+    utils::time_estimated_histogram estimated_successful_range;
 
     utils::timed_rate_moving_average_and_histogram cas_read;
     utils::time_estimated_histogram estimated_cas_read;


### PR DESCRIPTION
This series is inspired by the following AWS blog on latency and load shedding: https://aws.amazon.com/builders-library/using-load-shedding-to-avoid-overload/.

In order to be able to track the latency of successful requests (e.g. without counting in timeouts and other errors), a mirrored set of histograms is added. The new set of histograms tracks only the latency of requests which result in sending a non-error reply to the user.

Attached, an example screenshot from a modified Grafana dashboard - orange lines indicate the latencies of successful writes only, while green lines represent the original histograms. The metrics were recorded in a modified environment, where every 5th request was delayed for 123ms, and every 10th request is delayed to the point when it's already too late and a TIMEOUT error is returned to the client - which was usually 2 seconds. It's easy to correlate the difference between orange and green lines and the rise of timeouts metrics.
![latencies_successful](https://user-images.githubusercontent.com/10433047/90149335-aa408c80-dd84-11ea-885e-7fb4236142c1.png)