### PR TITLE
everywhere: Insert space after `switch`

### DIFF
--- a/alternator/expressions.cc
+++ b/alternator/expressions.cc
@@ -674,7 +674,7 @@ rjson::value calculate_value(const parsed::value& v,
 // either a single value, or v1+v2 or v1-v2.
 rjson::value calculate_value(const parsed::set_rhs& rhs,
         const rjson::value* previous_item) {
-    switch(rhs._op) {
+    switch (rhs._op) {
     case 'v':
         return calculate_value(rhs._v1, calculate_value_caller::UpdateExpression, previous_item);
     case '+': {

--- a/cql3/expr/expression.cc
+++ b/cql3/expr/expression.cc
@@ -48,7 +48,7 @@ std::optional<atomic_cell_value_view> do_get_value(const schema& schema,
         const clustering_key_prefix& ckey,
         const row& cells,
         gc_clock::time_point now) {
-    switch(cdef.kind) {
+    switch (cdef.kind) {
         case column_kind::partition_key:
             return atomic_cell_value_view(key.get_component(schema, cdef.component_index()));
         case column_kind::clustering_key:

--- a/cql3/functions/castas_fcts.cc
+++ b/cql3/functions/castas_fcts.cc
@@ -207,7 +207,7 @@ castas_fctn get_castas_fctn(data_type to_type, data_type from_type) {
     }
 
     using kind = abstract_type::kind;
-    switch(cast_switch_case_val(to_type->get_kind(), from_type->get_kind())) {
+    switch (cast_switch_case_val(to_type->get_kind(), from_type->get_kind())) {
     case cast_switch_case_val(kind::byte, kind::short_kind):
         return castas_fctn_simple<int8_t, int16_t>;
     case cast_switch_case_val(kind::byte, kind::int32):

--- a/database.cc
+++ b/database.cc
@@ -1669,7 +1669,7 @@ database::make_keyspace_config(const keyspace_metadata& ksm) {
 namespace db {
 
 std::ostream& operator<<(std::ostream& os, const write_type& t) {
-    switch(t) {
+    switch (t) {
         case write_type::SIMPLE: return os << "SIMPLE";
         case write_type::BATCH: return os << "BATCH";
         case write_type::UNLOGGED_BATCH: return os << "UNLOGGED_BATCH";

--- a/keys.cc
+++ b/keys.cc
@@ -101,7 +101,7 @@ partition_key partition_key::from_nodetool_style_string(const schema_ptr s, cons
 }
 
 std::ostream& operator<<(std::ostream& out, const bound_kind k) {
-    switch(k) {
+    switch (k) {
     case bound_kind::excl_end:
         return out << "excl end";
     case bound_kind::incl_start:
@@ -115,7 +115,7 @@ std::ostream& operator<<(std::ostream& out, const bound_kind k) {
 }
 
 bound_kind invert_kind(bound_kind k) {
-    switch(k) {
+    switch (k) {
     case bound_kind::excl_start: return bound_kind::incl_end;
     case bound_kind::incl_start: return bound_kind::excl_end;
     case bound_kind::excl_end:   return bound_kind::incl_start;
@@ -125,7 +125,7 @@ bound_kind invert_kind(bound_kind k) {
 }
 
 int32_t weight(bound_kind k) {
-    switch(k) {
+    switch (k) {
     case bound_kind::excl_end:
         return -2;
     case bound_kind::incl_start:

--- a/mutation_fragment.hh
+++ b/mutation_fragment.hh
@@ -336,7 +336,7 @@ public:
 
     mutation_fragment(const schema& s, const mutation_fragment& o)
         : _kind(o._kind), _data(std::make_unique<data>()) {
-        switch(_kind) {
+        switch (_kind) {
             case kind::static_row:
                 new (&_data->_static_row) static_row(s, o._data->_static_row);
                 break;
@@ -476,7 +476,7 @@ public:
         if (other._kind != _kind) {
             return false;
         }
-        switch(_kind) {
+        switch (_kind) {
         case kind::static_row:
             return as_static_row().equal(s, other.as_static_row());
         case kind::clustering_row:

--- a/position_in_partition.hh
+++ b/position_in_partition.hh
@@ -61,7 +61,7 @@ enum class bound_weight : int8_t {
 
 inline
 bound_weight position_weight(bound_kind k) {
-    switch(k) {
+    switch (k) {
     case bound_kind::excl_end:
     case bound_kind::incl_start:
         return bound_weight::before_all_prefixed;

--- a/sstables/compaction_strategy.cc
+++ b/sstables/compaction_strategy.cc
@@ -1020,7 +1020,7 @@ bool compaction_strategy::use_interposer_consumer() const {
 compaction_strategy make_compaction_strategy(compaction_strategy_type strategy, const std::map<sstring, sstring>& options) {
     ::shared_ptr<compaction_strategy_impl> impl;
 
-    switch(strategy) {
+    switch (strategy) {
     case compaction_strategy_type::null:
         impl = ::make_shared<null_compaction_strategy>();
         break;

--- a/test/boost/view_complex_test.cc
+++ b/test/boost/view_complex_test.cc
@@ -1428,7 +1428,7 @@ SEASTAR_TEST_CASE(test_3362_with_ttls) {
 enum class collection_kind { set, list, map };
 void do_test_3362_no_ttls_with_collections(cql_test_env& e, collection_kind t) {
     sstring type, pref, suf;
-    switch(t) {
+    switch (t) {
     case collection_kind::set:
         type = "set<int>";
         pref = "{";
@@ -1501,7 +1501,7 @@ SEASTAR_TEST_CASE(test_3362_no_ttls_with_map) {
 
 void do_test_3362_with_ttls_with_collections(cql_test_env& e, collection_kind t) {
     sstring type, pref, suf;
-    switch(t) {
+    switch (t) {
     case collection_kind::set:
         type = "set<int>";
         pref = "{";

--- a/thrift/handler.cc
+++ b/thrift/handler.cc
@@ -1365,7 +1365,7 @@ private:
         return partition_key::from_exploded(composite.values());
     }
     static db::consistency_level cl_from_thrift(const ConsistencyLevel::type consistency_level) {
-        switch(consistency_level) {
+        switch (consistency_level) {
         case ConsistencyLevel::type::ONE: return db::consistency_level::ONE;
         case ConsistencyLevel::type::QUORUM: return db::consistency_level::QUORUM;
         case ConsistencyLevel::type::LOCAL_QUORUM: return db::consistency_level::LOCAL_QUORUM;

--- a/unimplemented.cc
+++ b/unimplemented.cc
@@ -33,7 +33,7 @@ static thread_local std::unordered_map<cause, bool> _warnings;
 static logging::logger ulogger("unimplemented");
 
 std::ostream& operator<<(std::ostream& out, cause c) {
-    switch(c) {
+    switch (c) {
         case cause::INDEXES: return out << "INDEXES";
         case cause::LWT: return out << "LWT";
         case cause::PAGING: return out << "PAGING";

--- a/utils/murmur_hash.cc
+++ b/utils/murmur_hash.cc
@@ -207,7 +207,7 @@ void hash3_x64_128(bytes_view key, uint64_t seed, std::array<uint64_t,2> &result
     uint64_t k1 = 0;
     uint64_t k2 = 0;
 
-    switch(length & 15)
+    switch (length & 15)
     {
     case 15: k2 ^= ((uint64_t) key[14]) << 48;
     case 14: k2 ^= ((uint64_t) key[13]) << 40;

--- a/utils/murmur_hash.hh
+++ b/utils/murmur_hash.hh
@@ -125,7 +125,7 @@ void hash3_x64_128(InputIterator in, uint32_t length, uint64_t seed, std::array<
     typename std::iterator_traits<InputIterator>::value_type tmp[15];
     std::copy_n(in, length & 15, tmp);
 
-    switch(length & 15)
+    switch (length & 15)
     {
         case 15: k2 ^= ((uint64_t) tmp[14]) << 48;
         case 14: k2 ^= ((uint64_t) tmp[13]) << 40;


### PR DESCRIPTION
Quoth @avikivity: "switch is not a function, and we celebrate that by
putting a space after it like other control-flow keywords."

https://github.com/scylladb/scylla/pull/7052#discussion_r471932710

Tests: unit (dev)

Signed-off-by: Dejan Mircevski <dejan@scylladb.com>