### PR TITLE
alternator_streams: Include keys in OldImage/NewImage

### DIFF
--- a/alternator/streams.cc
+++ b/alternator/streams.cc
@@ -840,9 +840,8 @@ future<executor::request_return_type> executor::get_records(client_state& client
             {
                 auto item = rjson::empty_object();
                 describe_single_item(*selection, row, attr_names, item, true);
-                if (!item.ObjectEmpty()) {
-                    rjson::set(dynamodb, op == cdc::operation::pre_image ? "OldImage" : "NewImage", std::move(item));
-                }
+                describe_single_item(*selection, row, key_names, item);
+                rjson::set(dynamodb, op == cdc::operation::pre_image ? "OldImage" : "NewImage", std::move(item));
                 break;
             }
             case cdc::operation::update:

--- a/test/alternator/test_streams.py
+++ b/test/alternator/test_streams.py
@@ -677,8 +677,7 @@ def test_streams_updateitem_keys_only_2(test_table_ss_keys_only, dynamodbstreams
 
 # Test OLD_IMAGE using UpdateItem. Verify that the OLD_IMAGE indeed includes,
 # as needed, the entire old item and not just the modified columns.
-# Currently fails in Alternator because the item's key is missing in OldImage (#6935).
-@pytest.mark.xfail(reason="Currently fails - see issue #6935")
+# Reproduces issue #6935
 def test_streams_updateitem_old_image(test_table_ss_old_image, dynamodbstreams):
     def do_updates(table, p, c):
         events = []
@@ -703,7 +702,6 @@ def test_streams_updateitem_old_image(test_table_ss_old_image, dynamodbstreams):
 # key - in this case since the item did exist, OLD_IMAGE should be returned -
 # and include just the key. This is a special case of reproducing #6935 -
 # the first patch for this issue failed in this special case.
-@pytest.mark.xfail(reason="Currently fails - see issue #6935")
 def test_streams_updateitem_old_image_empty_item(test_table_ss_old_image, dynamodbstreams):
     def do_updates(table, p, c):
         events = []
@@ -751,7 +749,6 @@ def test_table_ss_old_image_and_lsi(dynamodb, dynamodbstreams):
     yield table, arn
     table.delete()
 
-@pytest.mark.xfail(reason="Currently fails - see issue #6935, #7030")
 def test_streams_updateitem_old_image_lsi(test_table_ss_old_image_and_lsi, dynamodbstreams):
     def do_updates(table, p, c):
         events = []
@@ -774,7 +771,6 @@ def test_streams_updateitem_old_image_lsi(test_table_ss_old_image_and_lsi, dynam
 # that deleting the item results in a missing NEW_IMAGE, and that setting the
 # item to be empty has a different result - a NEW_IMAGE with just a key.
 # Reproduces issue #7107.
-@pytest.mark.xfail(reason="issue #7107")
 def test_streams_new_image(test_table_ss_new_image, dynamodbstreams):
     def do_updates(table, p, c):
         events = []

--- a/test/cql/cdc_delta_modes_test.cql
+++ b/test/cql/cdc_delta_modes_test.cql
@@ -1,7 +1,7 @@
 create table tb1 (pk int, ck int, i1 int, PRIMARY KEY (pk, ck)) with cdc = {'enabled': true, 'preimage': false, 'postimage': false, 'delta': 'off'};
 
 create table tb2 (pk int, ck int, i1 int, PRIMARY KEY (pk, ck)) with cdc = {'enabled': true, 'preimage': true, 'postimage': true, 'delta': 'off'};
--- Should add 2 rows (preimage + postimage)
+-- Should add 1 row (postimage)
 insert into tb2 (pk, ck, i1) VALUES (1, 11, 111) USING TTL 1111;
 select "cdc$batch_seq_no", "cdc$operation", pk, ck, i1 from tb2_scylla_cdc_log where pk = 1 and ck = 11 allow filtering;
 

--- a/test/cql/cdc_delta_modes_test.result
+++ b/test/cql/cdc_delta_modes_test.result
@@ -8,7 +8,7 @@ create table tb2 (pk int, ck int, i1 int, PRIMARY KEY (pk, ck)) with cdc = {'ena
 {
 	"status" : "ok"
 }
--- Should add 2 rows (preimage + postimage)
+-- Should add 1 row (postimage)
 insert into tb2 (pk, ck, i1) VALUES (1, 11, 111) USING TTL 1111;
 {
 	"status" : "ok"
@@ -19,12 +19,6 @@ select "cdc$batch_seq_no", "cdc$operation", pk, ck, i1 from tb2_scylla_cdc_log w
 	[
 		{
 			"cdc$batch_seq_no" : "0",
-			"cdc$operation" : "0",
-			"ck" : "11",
-			"pk" : "1"
-		},
-		{
-			"cdc$batch_seq_no" : "1",
 			"cdc$operation" : "9",
 			"ck" : "11",
 			"i1" : "111",
@@ -48,19 +42,13 @@ select "cdc$batch_seq_no", "cdc$operation", "cdc$ttl", pk, ck, i1 from tb2_scyll
 	[
 		{
 			"cdc$batch_seq_no" : "0",
-			"cdc$operation" : "0",
-			"ck" : "22",
-			"pk" : "2"
-		},
-		{
-			"cdc$batch_seq_no" : "1",
 			"cdc$operation" : "2",
 			"cdc$ttl" : "2222",
 			"ck" : "22",
 			"pk" : "2"
 		},
 		{
-			"cdc$batch_seq_no" : "2",
+			"cdc$batch_seq_no" : "1",
 			"cdc$operation" : "9",
 			"ck" : "22",
 			"i1" : "222",
@@ -84,12 +72,6 @@ select "cdc$batch_seq_no", "cdc$operation", "cdc$ttl", pk, ck, i1 from tb2_scyll
 	[
 		{
 			"cdc$batch_seq_no" : "0",
-			"cdc$operation" : "0",
-			"ck" : "33",
-			"pk" : "3"
-		},
-		{
-			"cdc$batch_seq_no" : "1",
 			"cdc$operation" : "2",
 			"cdc$ttl" : "3333",
 			"ck" : "33",
@@ -97,7 +79,7 @@ select "cdc$batch_seq_no", "cdc$operation", "cdc$ttl", pk, ck, i1 from tb2_scyll
 			"pk" : "3"
 		},
 		{
-			"cdc$batch_seq_no" : "2",
+			"cdc$batch_seq_no" : "1",
 			"cdc$operation" : "9",
 			"ck" : "33",
 			"i1" : "333",

--- a/test/cql/cdc_static_and_clustered_rows_test.result
+++ b/test/cql/cdc_static_and_clustered_rows_test.result
@@ -30,11 +30,6 @@ select "cdc$batch_seq_no", "cdc$operation", ck, vs, vc from ks.t_scylla_cdc_log 
 	[
 		{
 			"cdc$batch_seq_no" : "0",
-			"cdc$operation" : "0",
-			"pk" : "0"
-		},
-		{
-			"cdc$batch_seq_no" : "1",
 			"cdc$operation" : "1",
 			"pk" : "0",
 			"vs" : "0"
@@ -59,18 +54,12 @@ select "cdc$batch_seq_no", "cdc$operation", ck, vs, vc from ks.t_scylla_cdc_log 
 		},
 		{
 			"cdc$batch_seq_no" : "1",
-			"cdc$operation" : "0",
-			"ck" : "0",
-			"pk" : "0"
-		},
-		{
-			"cdc$batch_seq_no" : "2",
 			"cdc$operation" : "1",
 			"pk" : "0",
 			"vs" : "2"
 		},
 		{
-			"cdc$batch_seq_no" : "3",
+			"cdc$batch_seq_no" : "2",
 			"cdc$operation" : "1",
 			"ck" : "0",
 			"pk" : "0",
@@ -121,12 +110,6 @@ select "cdc$batch_seq_no", "cdc$operation", ck, vs, vc from ks.t_scylla_cdc_log 
 	[
 		{
 			"cdc$batch_seq_no" : "0",
-			"cdc$operation" : "0",
-			"ck" : "0",
-			"pk" : "1"
-		},
-		{
-			"cdc$batch_seq_no" : "1",
 			"cdc$operation" : "1",
 			"ck" : "0",
 			"pk" : "1",
@@ -155,7 +138,7 @@ select count(*) from ks.t_scylla_cdc_log;
 	"rows" : 
 	[
 		{
-			"count" : "16"
+			"count" : "13"
 		}
 	]
 }

--- a/test/cql/cdc_with_lwt_test.result
+++ b/test/cql/cdc_with_lwt_test.result
@@ -79,12 +79,6 @@ SELECT "cdc$batch_seq_no", "cdc$operation", ck, pk, val FROM ks.tbl_cdc_lwt_scyl
 	[
 		{
 			"cdc$batch_seq_no" : "0",
-			"cdc$operation" : "0",
-			"ck" : "1",
-			"pk" : "1"
-		},
-		{
-			"cdc$batch_seq_no" : "1",
 			"cdc$operation" : "2",
 			"ck" : "1",
 			"pk" : "1",
@@ -126,7 +120,7 @@ SELECT count(*) FROM ks.tbl_cdc_lwt_scylla_cdc_log;
 	"rows" : 
 	[
 		{
-			"count" : "6"
+			"count" : "5"
 		}
 	]
 }


### PR DESCRIPTION
Fixes #6935

DynamoDB streams for some reason duplicate the record keys
into both the "Keys" and "OldImage"/"NewImage" sub-objects
when doing GetRecords. But only if there is other data
to include.

This patch appends the pk/ck parts into old/new image
iff we had any record data.

Updated to handle keys-only updates, and distinguish creating vs. updating rows. Changes cdc to not generate preimage 
for non-existent/deleted rows, and also fixes missing operations/ttls in keys-only delta mode.  