### PR TITLE
gossip: Apply state for local node in shadow round

### DIFF
--- a/gms/gossiper.cc
+++ b/gms/gossiper.cc
@@ -656,9 +656,6 @@ void gossiper::apply_state_locally_without_listener_notification(std::unordered_
     for (auto& x : map) {
         const inet_address& node = x.first;
         const endpoint_state& remote_state = x.second;
-        if (node == this->get_broadcast_address()) {
-            continue;
-        }
         do_apply_state_locally(node, remote_state, false);
     }
 }


### PR DESCRIPTION
We saw errors in killed_wiped_node_cannot_join_test dtest:

  Aug 2020 10:30:43 [node4] Missing: ['A node with address 127.0.76.4 already exists, cancelling join']:

The test does:
  n1, n2, n3, n4
  wipe data on n4
  start n4 again with the same ip address

Without this patch, n4 will bootstrap into the cluster new tokens. We
should prevent n4 to bootstrap because there is an existing
node in the cluster.

In shadow round, the local node should apply the application state of
the node with the same ip address. This is useful to detect a node
trying to bootstrap with the same IP address of an existing node.

Tests: bootstrap_test.py
Fixes: #7073