### PR TITLE
install.sh: show warning when systemd does not support user mode

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -167,6 +167,11 @@ installconfig() {
     fi
 }
 
+check_usermode_support() {
+    user=$(systemctl --help|grep -e '--user')
+    [ -n "$user" ]
+}
+
 # change directory to the package's root directory
 cd "$(dirname "$0")"
 
@@ -364,7 +369,9 @@ if $nonroot; then
     # nonroot install is also 'offline install'
     touch $rprefix/SCYLLA-OFFLINE-FILE
     touch $rprefix/SCYLLA-NONROOT-FILE
-    systemctl --user daemon-reload
+    if check_usermode_support; then
+        systemctl --user daemon-reload
+    fi
     echo "Scylla non-root install completed."
 elif ! $packaging; then
     # run install.sh without --packaging is 'offline install'

--- a/unified/install.sh
+++ b/unified/install.sh
@@ -38,6 +38,11 @@ EOF
     exit 1
 }
 
+check_usermode_support() {
+    user=$(systemctl --help|grep -e '--user')
+    [ -n "$user" ]
+}
+
 root=/
 housekeeping=false
 python3=/opt/scylladb/python3/bin/python3
@@ -79,6 +84,12 @@ while [ $# -gt 0 ]; do
             ;;
     esac
 done
+
+if $nonroot && ! check_usermode_support; then
+    echo "WARNING: This distribution does not support systemd user mode, please configure and launch Scylla manually."
+    echo "Press any key to continue..."
+    read
+fi
 
 if [ -z "$prefix" ]; then
     if $nonroot; then


### PR DESCRIPTION
On older distribution such as CentOS7, it does not support systemd user mode.
On such distribution nonroot mode does not work, show error message and
reject installing before copying files.

Fixes #7071