### PR TITLE
Do verify package for offline

### DIFF
--- a/dist/common/scripts/scylla_setup
+++ b/dist/common/scripts/scylla_setup
@@ -107,8 +107,14 @@ def interactive_choose_swap_size():
         except Exception as e:
             print(f'"{s}" is not valid number, input again')
 
+pkg_files = {
+        'scylla-jmx': scylladir_p() / 'jmx/scylla-jmx',
+        'scylla-tools': scylladir_p() / 'share/cassandra/bin/cqlsh'
+        }
 def do_verify_package(pkg):
-    if is_debian_variant():
+    if is_offline():
+        res = 0 if pkg_files[pkg].exists() else 1
+    elif is_debian_variant():
         res = run('dpkg -s {}'.format(pkg), silent=True, exception=False)
     elif is_redhat_variant():
         res = run('rpm -q {}'.format(pkg), silent=True, exception=False)

--- a/dist/common/scripts/scylla_util.py
+++ b/dist/common/scripts/scylla_util.py
@@ -48,6 +48,9 @@ def scylladir_p():
 def is_nonroot():
     return Path(scylladir_p() / 'SCYLLA-NONROOT-FILE').exists()
 
+def is_offline():
+    return Path(scylladir_p() / 'SCYLLA-OFFLINE-FILE').exists()
+
 def bindir_p():
     if is_nonroot():
         return scylladir_p() / 'bin'

--- a/install.sh
+++ b/install.sh
@@ -361,10 +361,14 @@ if $nonroot; then
     sed -i -e "s#/var/lib/scylla#$rprefix#g" $rsysconfdir/scylla-server
     sed -i -e "s#/etc/scylla#$retc/scylla#g" $rsysconfdir/scylla-server
     sed -i -e "s#^SCYLLA_ARGS=\"#SCYLLA_ARGS=\"--workdir $rprefix #g" $rsysconfdir/scylla-server
+    # nonroot install is also 'offline install'
+    touch $rprefix/SCYLLA-OFFLINE-FILE
     touch $rprefix/SCYLLA-NONROOT-FILE
     systemctl --user daemon-reload
     echo "Scylla non-root install completed."
 elif ! $packaging; then
+    # run install.sh without --packaging is 'offline install'
+    touch $rprefix/SCYLLA-OFFLINE-FILE
     nousr=
     nogrp=
     getent passwd scylla || nousr=1
@@ -382,4 +386,5 @@ elif ! $packaging; then
     chown -R scylla:scylla $rhkdata
 
     $rprefix/scripts/scylla_post_install.sh
+    echo "Scylla offline install completed."
 fi


### PR DESCRIPTION
To verify offline installed image with do_verify_package() in scylla_setup, we introduce is_offline() function works just like is_nonroot() but the install not with --nonroot.