### PR TITLE
cdc: Remove stored (postimage) data when doing row delete

### DIFF
--- a/test/cql/cdc_batch_delete_postimage.cql
+++ b/test/cql/cdc_batch_delete_postimage.cql
@@ -1,0 +1,21 @@
+-- do range delete in batch
+create table ks.t (pk int, ck int, v int, primary key(pk, ck)) with cdc = {'enabled': true, 'preimage': true, 'postimage': true};
+
+begin batch insert into ks.t (pk, ck, v) values (1, 1, 100); delete from t where pk = 1 and ck >= 1 and ck <= 2; apply batch;
+
+select "cdc$batch_seq_no", "cdc$operation", pk, ck, v from t_scylla_cdc_log;
+
+-- do pk delete in batch
+create table ks.t2 (pk int, ck int, v int, primary key(pk, ck)) with cdc = {'enabled': true, 'preimage': true, 'postimage': true};
+
+begin batch insert into ks.t2 (pk, ck, v) values (1, 1, 100); delete from t2 where pk = 1; apply batch;
+
+select "cdc$batch_seq_no", "cdc$operation", pk, ck, v from t2_scylla_cdc_log;
+
+-- do range delete in batch, but not matcing ck
+create table ks.t3 (pk int, ck int, v int, primary key(pk, ck)) with cdc = {'enabled': true, 'preimage': true, 'postimage': true};
+
+-- do range delete in batch
+begin batch insert into ks.t3 (pk, ck, v) values (1, 1, 100); delete from t3 where pk = 1 and ck >= 2 and ck <= 3; apply batch;
+
+select "cdc$batch_seq_no", "cdc$operation", pk, ck, v from t3_scylla_cdc_log;

--- a/test/cql/cdc_batch_delete_postimage.result
+++ b/test/cql/cdc_batch_delete_postimage.result
@@ -1,0 +1,141 @@
+-- do range delete in batch
+create table ks.t (pk int, ck int, v int, primary key(pk, ck)) with cdc = {'enabled': true, 'preimage': true, 'postimage': true};
+{
+	"status" : "ok"
+}
+
+begin batch insert into ks.t (pk, ck, v) values (1, 1, 100); delete from t where pk = 1 and ck >= 1 and ck <= 2; apply batch;
+{
+	"status" : "ok"
+}
+
+select "cdc$batch_seq_no", "cdc$operation", pk, ck, v from t_scylla_cdc_log;
+{
+	"rows" : 
+	[
+		{
+			"cdc$batch_seq_no" : "0",
+			"cdc$operation" : "0",
+			"ck" : "1",
+			"pk" : "1"
+		},
+		{
+			"cdc$batch_seq_no" : "1",
+			"cdc$operation" : "2",
+			"ck" : "1",
+			"pk" : "1",
+			"v" : "100"
+		},
+		{
+			"cdc$batch_seq_no" : "2",
+			"cdc$operation" : "5",
+			"ck" : "1",
+			"pk" : "1"
+		},
+		{
+			"cdc$batch_seq_no" : "3",
+			"cdc$operation" : "7",
+			"ck" : "2",
+			"pk" : "1"
+		},
+		{
+			"cdc$batch_seq_no" : "4",
+			"cdc$operation" : "9",
+			"ck" : "1",
+			"pk" : "1"
+		}
+	]
+}
+
+-- do pk delete in batch
+create table ks.t2 (pk int, ck int, v int, primary key(pk, ck)) with cdc = {'enabled': true, 'preimage': true, 'postimage': true};
+{
+	"status" : "ok"
+}
+
+begin batch insert into ks.t2 (pk, ck, v) values (1, 1, 100); delete from t2 where pk = 1; apply batch;
+{
+	"status" : "ok"
+}
+
+select "cdc$batch_seq_no", "cdc$operation", pk, ck, v from t2_scylla_cdc_log;
+{
+	"rows" : 
+	[
+		{
+			"cdc$batch_seq_no" : "0",
+			"cdc$operation" : "0",
+			"ck" : "1",
+			"pk" : "1"
+		},
+		{
+			"cdc$batch_seq_no" : "1",
+			"cdc$operation" : "2",
+			"ck" : "1",
+			"pk" : "1",
+			"v" : "100"
+		},
+		{
+			"cdc$batch_seq_no" : "2",
+			"cdc$operation" : "4",
+			"pk" : "1"
+		},
+		{
+			"cdc$batch_seq_no" : "3",
+			"cdc$operation" : "9",
+			"ck" : "1",
+			"pk" : "1"
+		}
+	]
+}
+
+-- do range delete in batch, but not matcing ck
+create table ks.t3 (pk int, ck int, v int, primary key(pk, ck)) with cdc = {'enabled': true, 'preimage': true, 'postimage': true};
+{
+	"status" : "ok"
+}
+
+-- do range delete in batch
+begin batch insert into ks.t3 (pk, ck, v) values (1, 1, 100); delete from t3 where pk = 1 and ck >= 2 and ck <= 3; apply batch;
+{
+	"status" : "ok"
+}
+
+select "cdc$batch_seq_no", "cdc$operation", pk, ck, v from t3_scylla_cdc_log;
+{
+	"rows" : 
+	[
+		{
+			"cdc$batch_seq_no" : "0",
+			"cdc$operation" : "0",
+			"ck" : "1",
+			"pk" : "1"
+		},
+		{
+			"cdc$batch_seq_no" : "1",
+			"cdc$operation" : "2",
+			"ck" : "1",
+			"pk" : "1",
+			"v" : "100"
+		},
+		{
+			"cdc$batch_seq_no" : "2",
+			"cdc$operation" : "5",
+			"ck" : "2",
+			"pk" : "1"
+		},
+		{
+			"cdc$batch_seq_no" : "3",
+			"cdc$operation" : "7",
+			"ck" : "3",
+			"pk" : "1"
+		},
+		{
+			"cdc$batch_seq_no" : "4",
+			"cdc$operation" : "9",
+			"ck" : "1",
+			"pk" : "1",
+			"v" : "100"
+		}
+	]
+}


### PR DESCRIPTION
Fixes #6900

Clustered range deletes did not clear out the "row_states" data associated
with affected rows (might be many).

Adds a sweep through and erases relevant data. Since we do pre- and
postimage in "order", this should only affect postimage.