### PR TITLE
cql3: Drop all uses_function methods

### DIFF
--- a/cql3/attributes.cc
+++ b/cql3/attributes.cc
@@ -52,11 +52,6 @@ attributes::attributes(::shared_ptr<term>&& timestamp, ::shared_ptr<term>&& time
     , _time_to_live{std::move(time_to_live)}
 { }
 
-bool attributes::uses_function(const sstring& ks_name, const sstring& function_name) const {
-    return (_timestamp && _timestamp->uses_function(ks_name, function_name))
-        || (_time_to_live && _time_to_live->uses_function(ks_name, function_name));
-}
-
 bool attributes::is_timestamp_set() const {
     return bool(_timestamp);
 }

--- a/cql3/attributes.hh
+++ b/cql3/attributes.hh
@@ -59,8 +59,6 @@ public:
 private:
     attributes(::shared_ptr<term>&& timestamp, ::shared_ptr<term>&& time_to_live);
 public:
-    bool uses_function(const sstring& ks_name, const sstring& function_name) const;
-
     bool is_timestamp_set() const;
 
     bool is_time_to_live_set() const;

--- a/cql3/column_condition.cc
+++ b/cql3/column_condition.cc
@@ -118,24 +118,6 @@ uint32_t read_and_check_list_index(const cql3::raw_value_view& key) {
 
 namespace cql3 {
 
-bool
-column_condition::uses_function(const sstring& ks_name, const sstring& function_name) const {
-    if (bool(_collection_element) && _collection_element->uses_function(ks_name, function_name)) {
-        return true;
-    }
-    if (bool(_value) && _value->uses_function(ks_name, function_name)) {
-        return true;
-    }
-    if (!_in_values.empty()) {
-        for (auto&& value : _in_values) {
-            if (bool(value) && value->uses_function(ks_name, function_name)) {
-                return true;
-            }
-        }
-    }
-    return false;
-}
-
 void column_condition::collect_marker_specificaton(variable_specifications& bound_names) const {
     if (_collection_element) {
         _collection_element->collect_marker_specification(bound_names);

--- a/cql3/column_condition.hh
+++ b/cql3/column_condition.hh
@@ -91,8 +91,6 @@ public:
      */
     void collect_marker_specificaton(variable_specifications& bound_names) const;
 
-    bool uses_function(const sstring& ks_name, const sstring& function_name) const;
-
     // Retrieve parameter marker values, if any, find the appropriate collection
     // element if the cell is a collection and an element access is used in the expression,
     // and evaluate the condition.

--- a/cql3/cql_statement.hh
+++ b/cql3/cql_statement.hh
@@ -101,8 +101,6 @@ public:
     virtual future<::shared_ptr<cql_transport::messages::result_message>>
         execute(service::storage_proxy& proxy, service::query_state& state, const query_options& options) const = 0;
 
-    virtual bool uses_function(const sstring& ks_name, const sstring& function_name) const = 0;
-
     virtual bool depends_on_keyspace(const sstring& ks_name) const = 0;
 
     virtual bool depends_on_column_family(const sstring& cf_name) const = 0;

--- a/cql3/expr/expression.cc
+++ b/cql3/expr/expression.cc
@@ -766,26 +766,6 @@ nonwrapping_range<bytes> to_range(const value_set& s) {
         }, s);
 }
 
-bool uses_function(const expression& expr, const sstring& ks_name, const sstring& function_name) {
-    return std::visit(overloaded_functor{
-            [&] (const conjunction& conj) {
-                using std::placeholders::_1;
-                return boost::algorithm::any_of(conj.children, std::bind(uses_function, _1, ks_name, function_name));
-            },
-            [&] (const binary_operator& oper) {
-                if (oper.rhs && oper.rhs->uses_function(ks_name, function_name)) {
-                    return true;
-                } else if (auto columns = std::get_if<std::vector<column_value>>(&oper.lhs)) {
-                    return boost::algorithm::any_of(*columns, [&] (const column_value& cv) {
-                        return cv.sub && cv.sub->uses_function(ks_name, function_name);
-                    });
-                }
-                return false;
-            },
-            [&] (const auto& default_case) { return false; },
-        }, expr);
-}
-
 bool is_supported_by(const expression& expr, const secondary_index::index& idx) {
     using std::placeholders::_1;
     return std::visit(overloaded_functor{

--- a/cql3/expr/expression.hh
+++ b/cql3/expr/expression.hh
@@ -131,9 +131,6 @@ extern value_set possible_lhs_values(const column_definition*, const expression&
 /// Turns value_set into a range, unless it's a multi-valued list (in which case this throws).
 extern nonwrapping_range<bytes> to_range(const value_set&);
 
-/// True iff expr references the function.
-extern bool uses_function(const expression& expr, const sstring& ks_name, const sstring& function_name);
-
 /// True iff the index can support the entire expression.
 extern bool is_supported_by(const expression&, const secondary_index::index&);
 

--- a/cql3/functions/abstract_function.hh
+++ b/cql3/functions/abstract_function.hh
@@ -91,10 +91,6 @@ public:
             && _return_type == x._return_type;
     }
 
-    virtual bool uses_function(const sstring& ks_name, const sstring& function_name) const override {
-        return _name.keyspace == ks_name && _name.name == function_name;
-    }
-
     virtual sstring column_name(const std::vector<sstring>& column_names) const override {
         return format("{}({})", _name, join(", ", column_names));
     }

--- a/cql3/functions/as_json_function.hh
+++ b/cql3/functions/as_json_function.hh
@@ -140,10 +140,6 @@ public:
         os << ") -> " << utf8_type->as_cql3_type().to_string();
     }
 
-    virtual bool uses_function(const sstring& ks_name, const sstring& function_name) const override {
-        return false;
-    }
-
     virtual sstring column_name(const std::vector<sstring>& column_names) const override {
         return "[json]";
     }

--- a/cql3/functions/function.hh
+++ b/cql3/functions/function.hh
@@ -81,7 +81,6 @@ public:
     virtual bool is_aggregate() const = 0;
 
     virtual void print(std::ostream& os) const = 0;
-    virtual bool uses_function(const sstring& ks_name, const sstring& function_name) const = 0;
 
     /**
      * Returns the name of the function to use within a ResultSet.

--- a/cql3/functions/function_call.hh
+++ b/cql3/functions/function_call.hh
@@ -56,7 +56,6 @@ public:
     function_call(shared_ptr<scalar_function> fun, std::vector<shared_ptr<term>> terms)
             : _fun(std::move(fun)), _terms(std::move(terms)) {
     }
-    virtual bool uses_function(const sstring& ks_name, const sstring& function_name) const override;
     virtual void collect_marker_specification(variable_specifications& bound_names) const override;
     virtual shared_ptr<terminal> bind(const query_options& options) override;
     virtual cql3::raw_value_view bind_and_get(const query_options& options) override;

--- a/cql3/functions/functions.cc
+++ b/cql3/functions/functions.cc
@@ -424,11 +424,6 @@ functions::type_equals(const std::vector<data_type>& t1, const std::vector<data_
     return t1 == t2;
 }
 
-bool
-function_call::uses_function(const sstring& ks_name, const sstring& function_name) const {
-    return _fun->uses_function(ks_name, function_name);
-}
-
 void
 function_call::collect_marker_specification(variable_specifications& bound_names) const {
     for (auto&& t : _terms) {

--- a/cql3/operation.hh
+++ b/cql3/operation.hh
@@ -103,10 +103,6 @@ public:
         return params.make_counter_update_cell(delta);
     }
 
-    virtual bool uses_function(const sstring& ks_name, const sstring& function_name) const {
-        return _t && _t->uses_function(ks_name, function_name);
-    }
-
     virtual bool is_raw_counter_shard_write() const {
         return false;
     }

--- a/cql3/restrictions/multi_column_restriction.hh
+++ b/cql3/restrictions/multi_column_restriction.hh
@@ -83,10 +83,6 @@ public:
         expression = make_conjunction(std::move(expression), other->expression);
     }
 
-    virtual bool uses_function(const sstring& ks_name, const sstring& function_name) const override {
-        return expr::uses_function(expression, ks_name, function_name);
-    }
-
 protected:
     virtual void do_merge_with(::shared_ptr<clustering_key_restrictions> other) = 0;
 

--- a/cql3/restrictions/primary_key_restrictions.hh
+++ b/cql3/restrictions/primary_key_restrictions.hh
@@ -78,7 +78,6 @@ public:
 
     virtual std::vector<bounds_range_type> bounds_ranges(const query_options& options) const = 0;
 
-    using restrictions::uses_function;
     using restrictions::has_supporting_index;
 
     bool empty() const override {
@@ -131,7 +130,6 @@ public:
 
     virtual std::vector<bounds_range_type> bounds_ranges(const query_options& options) const = 0;
 
-    using restrictions::uses_function;
     using restrictions::has_supporting_index;
 
     bool empty() const override {

--- a/cql3/restrictions/restrictions.hh
+++ b/cql3/restrictions/restrictions.hh
@@ -72,15 +72,6 @@ public:
     }
 
     /**
-     * Returns <code>true</code> if one of the restrictions use the specified function.
-     *
-     * @param ks_name the keyspace name
-     * @param function_name the function name
-     * @return <code>true</code> if one of the restrictions use the specified function, <code>false</code> otherwise.
-     */
-    virtual bool uses_function(const sstring& ks_name, const sstring& function_name) const = 0;
-
-    /**
      * Check if the restriction is on indexed columns.
      *
      * @param index_manager the index manager

--- a/cql3/restrictions/single_column_primary_key_restrictions.hh
+++ b/cql3/restrictions/single_column_primary_key_restrictions.hh
@@ -129,10 +129,6 @@ public:
         return _restrictions->is_all_eq();
     }
 
-    virtual bool uses_function(const sstring& ks_name, const sstring& function_name) const override {
-        return _restrictions->uses_function(ks_name, function_name);
-    }
-
     void do_merge_with(::shared_ptr<single_column_restriction> restriction) {
         if (!_restrictions->empty() && !_allow_filtering) {
             auto last_column = *_restrictions->last_column();

--- a/cql3/restrictions/single_column_restrictions.hh
+++ b/cql3/restrictions/single_column_restrictions.hh
@@ -127,15 +127,6 @@ public:
         return i->second;
     }
 
-    virtual bool uses_function(const sstring& ks_name, const sstring& function_name) const override {
-        for (auto&& e : _restrictions) {
-            if (expr::uses_function(e.second->expression, ks_name, function_name)) {
-                return true;
-            }
-        }
-        return false;
-    }
-
     virtual bool empty() const override {
         return _restrictions.empty();
     }

--- a/cql3/restrictions/statement_restrictions.cc
+++ b/cql3/restrictions/statement_restrictions.cc
@@ -85,9 +85,6 @@ public:
         // throw? should not reach?
         return {};
     }
-    bool uses_function(const sstring&, const sstring&) const override {
-        return false;
-    }
     bool empty() const override {
         return true;
     }
@@ -328,12 +325,6 @@ void statement_restrictions::add_single_column_restriction(::shared_ptr<single_c
     } else {
         _nonprimary_key_restrictions->add_restriction(restriction);
     }
-}
-
-bool statement_restrictions::uses_function(const sstring& ks_name, const sstring& function_name) const {
-    return  _partition_key_restrictions->uses_function(ks_name, function_name)
-            || _clustering_columns_restrictions->uses_function(ks_name, function_name)
-            || _nonprimary_key_restrictions->uses_function(ks_name, function_name);
 }
 
 const std::vector<::shared_ptr<restrictions>>& statement_restrictions::index_restrictions() const {

--- a/cql3/restrictions/statement_restrictions.hh
+++ b/cql3/restrictions/statement_restrictions.hh
@@ -124,8 +124,6 @@ public:
     void add_restriction(::shared_ptr<restriction> restriction, bool for_view, bool allow_filtering);
     void add_single_column_restriction(::shared_ptr<single_column_restriction> restriction, bool for_view, bool allow_filtering);
 public:
-    bool uses_function(const sstring& ks_name, const sstring& function_name) const;
-
     const std::vector<::shared_ptr<restrictions>>& index_restrictions() const;
 
     /**

--- a/cql3/restrictions/token_restriction.hh
+++ b/cql3/restrictions/token_restriction.hh
@@ -74,10 +74,6 @@ public:
         expression = make_conjunction(std::move(expression), restriction->expression);
     }
 
-    bool uses_function(const sstring& ks_name, const sstring& function_name) const override {
-        return expr::uses_function(expression, ks_name, function_name);
-    }
-
     virtual bool has_supporting_index(const secondary_index::secondary_index_manager& index_manager,
                                       expr::allow_local_index allow_local) const override {
         return false;

--- a/cql3/selection/abstract_function_selector.cc
+++ b/cql3/selection/abstract_function_selector.cc
@@ -80,10 +80,6 @@ abstract_function_selector::new_factory(shared_ptr<functions::function> fun, sha
             return _fun->return_type();
         }
 
-        virtual bool uses_function(const sstring& ks_name, const sstring& function_name) const override {
-            return _fun->uses_function(ks_name, function_name);
-        }
-
         virtual shared_ptr<selector> new_instance() const override {
             using ret_type = shared_ptr<selector>;
             return _fun->is_aggregate() ? ret_type(::make_shared<aggregate_function_selector>(_fun, _factories->new_instances()))

--- a/cql3/selection/selection.cc
+++ b/cql3/selection/selection.cc
@@ -162,10 +162,6 @@ public:
         , _factories(std::move(factories))
     { }
 
-    virtual bool uses_function(const sstring& ks_name, const sstring& function_name) const override {
-        return _factories->uses_function(ks_name, function_name);
-    }
-
     virtual uint32_t add_column_for_post_processing(const column_definition& c) override {
         uint32_t index = selection::add_column_for_post_processing(c);
         _factories->add_selector_for_post_processing(c, index);

--- a/cql3/selection/selection.hh
+++ b/cql3/selection/selection.hh
@@ -186,10 +186,6 @@ public:
 
     virtual uint32_t add_column_for_post_processing(const column_definition& c);
 
-    virtual bool uses_function(const sstring &ks_name, const sstring& function_name) const {
-        return false;
-    }
-
     query::partition_slice::option_set get_query_options();
 private:
     static bool processes_selection(const std::vector<::shared_ptr<raw_selector>>& raw_selectors) {

--- a/cql3/selection/selector.hh
+++ b/cql3/selection/selector.hh
@@ -131,10 +131,6 @@ class selector::factory {
 public:
     virtual ~factory() {}
 
-    virtual bool uses_function(const sstring& ks_name, const sstring& function_name) const {
-        return false;
-    }
-
     /**
      * Returns the column specification corresponding to the output value of the selector instances created by
      * this factory.

--- a/cql3/selection/selector_factories.cc
+++ b/cql3/selection/selector_factories.cc
@@ -69,15 +69,6 @@ selector_factories::selector_factories(std::vector<::shared_ptr<selectable>> sel
     }
 }
 
-bool selector_factories::uses_function(const sstring& ks_name, const sstring& function_name) const {
-    for (auto&& f : _factories) {
-        if (f && f->uses_function(ks_name, function_name)) {
-            return true;
-        }
-    }
-    return false;
-}
-
 void selector_factories::add_selector_for_post_processing(const column_definition& def, uint32_t index) {
     _factories.emplace_back(simple_selector::new_factory(def.name_as_text(), index, def.type));
     ++_number_of_factories_for_post_processing;

--- a/cql3/selection/selector_factories.hh
+++ b/cql3/selection/selector_factories.hh
@@ -99,8 +99,6 @@ public:
     selector_factories(std::vector<::shared_ptr<selectable>> selectables,
             database& db, schema_ptr schema, std::vector<const column_definition*>& defs);
 public:
-    bool uses_function(const sstring& ks_name, const sstring& function_name) const;
-
     /**
      * Adds a new <code>Selector.Factory</code> for a column that is needed only for ORDER BY or post
      * processing purposes.

--- a/cql3/statements/authentication_statement.cc
+++ b/cql3/statements/authentication_statement.cc
@@ -46,11 +46,6 @@ uint32_t cql3::statements::authentication_statement::get_bound_terms() const {
     return 0;
 }
 
-bool cql3::statements::authentication_statement::uses_function(
-                const sstring& ks_name, const sstring& function_name) const {
-    return parsed_statement::uses_function(ks_name, function_name);
-}
-
 bool cql3::statements::authentication_statement::depends_on_keyspace(
                 const sstring& ks_name) const {
     return false;

--- a/cql3/statements/authentication_statement.hh
+++ b/cql3/statements/authentication_statement.hh
@@ -56,8 +56,6 @@ public:
 
     uint32_t get_bound_terms() const override;
 
-    bool uses_function(const sstring& ks_name, const sstring& function_name) const override;
-
     bool depends_on_keyspace(const sstring& ks_name) const override;
 
     bool depends_on_column_family(const sstring& cf_name) const override;

--- a/cql3/statements/authorization_statement.cc
+++ b/cql3/statements/authorization_statement.cc
@@ -46,11 +46,6 @@ uint32_t cql3::statements::authorization_statement::get_bound_terms() const {
     return 0;
 }
 
-bool cql3::statements::authorization_statement::uses_function(
-                const sstring& ks_name, const sstring& function_name) const {
-    return parsed_statement::uses_function(ks_name, function_name);
-}
-
 bool cql3::statements::authorization_statement::depends_on_keyspace(
                 const sstring& ks_name) const {
     return false;

--- a/cql3/statements/authorization_statement.hh
+++ b/cql3/statements/authorization_statement.hh
@@ -60,8 +60,6 @@ public:
 
     uint32_t get_bound_terms() const override;
 
-    bool uses_function(const sstring& ks_name, const sstring& function_name) const override;
-
     bool depends_on_keyspace(const sstring& ks_name) const override;
 
     bool depends_on_column_family(const sstring& cf_name) const override;

--- a/cql3/statements/batch_statement.cc
+++ b/cql3/statements/batch_statement.cc
@@ -87,12 +87,6 @@ batch_statement::batch_statement(type type_,
 {
 }
 
-bool batch_statement::uses_function(const sstring& ks_name, const sstring& function_name) const
-{
-    return _attrs->uses_function(ks_name, function_name)
-            || boost::algorithm::any_of(_statements, [&] (auto&& s) { return s.statement->uses_function(ks_name, function_name); });
-}
-
 bool batch_statement::depends_on_keyspace(const sstring& ks_name) const
 {
     return false;

--- a/cql3/statements/batch_statement.hh
+++ b/cql3/statements/batch_statement.hh
@@ -118,8 +118,6 @@ public:
                     std::unique_ptr<attributes> attrs,
                     cql_stats& stats);
 
-    virtual bool uses_function(const sstring& ks_name, const sstring& function_name) const override;
-
     virtual bool depends_on_keyspace(const sstring& ks_name) const override;
 
     virtual bool depends_on_column_family(const sstring& cf_name) const override;

--- a/cql3/statements/modification_statement.cc
+++ b/cql3/statements/modification_statement.cc
@@ -86,31 +86,6 @@ modification_statement::modification_statement(statement_type type_, uint32_t bo
     , _ks_sel(::is_system_keyspace(schema_->ks_name()) ? ks_selector::SYSTEM : ks_selector::NONSYSTEM)
 { }
 
-bool modification_statement::uses_function(const sstring& ks_name, const sstring& function_name) const {
-    if (attrs->uses_function(ks_name, function_name)) {
-        return true;
-    }
-    if (_restrictions->uses_function(ks_name, function_name)) {
-        return true;
-    }
-    for (auto&& operation : _column_operations) {
-        if (operation && operation->uses_function(ks_name, function_name)) {
-            return true;
-        }
-    }
-    for (auto&& condition : _regular_conditions) {
-        if (condition && condition->uses_function(ks_name, function_name)) {
-            return true;
-        }
-    }
-    for (auto&& condition : _static_conditions) {
-        if (condition && condition->uses_function(ks_name, function_name)) {
-            return true;
-        }
-    }
-    return false;
-}
-
 uint32_t modification_statement::get_bound_terms() const {
     return _bound_terms;
 }

--- a/cql3/statements/modification_statement.hh
+++ b/cql3/statements/modification_statement.hh
@@ -144,8 +144,6 @@ public:
             std::unique_ptr<attributes> attrs_,
             cql_stats& stats_);
 
-    virtual bool uses_function(const sstring& ks_name, const sstring& function_name) const override;
-
     virtual bool require_full_clustering_key() const = 0;
 
     virtual bool allow_clustering_key_slices() const = 0;

--- a/cql3/statements/raw/parsed_statement.cc
+++ b/cql3/statements/raw/parsed_statement.cc
@@ -65,10 +65,6 @@ void parsed_statement::set_bound_variables(const std::vector<::shared_ptr<column
     _variables.set_bound_variables(bound_names);
 }
 
-bool parsed_statement::uses_function(const sstring& ks_name, const sstring& function_name) const {
-    return false;
-}
-
 }
 
 prepared_statement::prepared_statement(::shared_ptr<cql_statement> statement_, std::vector<lw_shared_ptr<column_specification>> bound_names_, std::vector<uint16_t> partition_key_bind_indices)

--- a/cql3/statements/raw/parsed_statement.hh
+++ b/cql3/statements/raw/parsed_statement.hh
@@ -71,8 +71,6 @@ public:
     void set_bound_variables(const std::vector<::shared_ptr<column_identifier>>& bound_names);
 
     virtual std::unique_ptr<prepared_statement> prepare(database& db, cql_stats& stats) = 0;
-
-    virtual bool uses_function(const sstring& ks_name, const sstring& function_name) const;
 };
 
 }

--- a/cql3/statements/schema_altering_statement.cc
+++ b/cql3/statements/schema_altering_statement.cc
@@ -67,11 +67,6 @@ future<> schema_altering_statement::grant_permissions_to_creator(const service::
     return make_ready_future<>();
 }
 
-bool schema_altering_statement::uses_function(const sstring& ks_name, const sstring& function_name) const
-{
-    return cf_statement::uses_function(ks_name, function_name);
-}
-
 bool schema_altering_statement::depends_on_keyspace(const sstring& ks_name) const
 {
     return false;

--- a/cql3/statements/schema_altering_statement.hh
+++ b/cql3/statements/schema_altering_statement.hh
@@ -79,8 +79,6 @@ protected:
      */
     virtual future<> grant_permissions_to_creator(const service::client_state&) const;
 
-    virtual bool uses_function(const sstring& ks_name, const sstring& function_name) const override;
-
     virtual bool depends_on_keyspace(const sstring& ks_name) const override;
 
     virtual bool depends_on_column_family(const sstring& cf_name) const override;

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -156,12 +156,6 @@ select_statement::select_statement(schema_ptr schema,
     _opts.set_if<query::partition_slice::option::reversed>(_is_reversed);
 }
 
-bool select_statement::uses_function(const sstring& ks_name, const sstring& function_name) const {
-    return _selection->uses_function(ks_name, function_name)
-        || _restrictions->uses_function(ks_name, function_name)
-        || (_limit && _limit->uses_function(ks_name, function_name));
-}
-
 ::shared_ptr<const cql3::metadata> select_statement::get_result_metadata() const {
     // FIXME: COUNT needs special result metadata handling.
     return _selection->get_result_metadata();

--- a/cql3/statements/select_statement.hh
+++ b/cql3/statements/select_statement.hh
@@ -113,8 +113,6 @@ public:
             ::shared_ptr<term> per_partition_limit,
             cql_stats& stats);
 
-    virtual bool uses_function(const sstring& ks_name, const sstring& function_name) const override;
-
     virtual ::shared_ptr<const cql3::metadata> get_result_metadata() const override;
     virtual uint32_t get_bound_terms() const override;
     virtual future<> check_access(service::storage_proxy& proxy, const service::client_state& state) const override;

--- a/cql3/statements/truncate_statement.cc
+++ b/cql3/statements/truncate_statement.cc
@@ -66,11 +66,6 @@ std::unique_ptr<prepared_statement> truncate_statement::prepare(database& db,cql
     return std::make_unique<prepared_statement>(::make_shared<truncate_statement>(*this));
 }
 
-bool truncate_statement::uses_function(const sstring& ks_name, const sstring& function_name) const
-{
-    return parsed_statement::uses_function(ks_name, function_name);
-}
-
 bool truncate_statement::depends_on_keyspace(const sstring& ks_name) const
 {
     return false;

--- a/cql3/statements/truncate_statement.hh
+++ b/cql3/statements/truncate_statement.hh
@@ -58,8 +58,6 @@ public:
 
     virtual std::unique_ptr<prepared_statement> prepare(database& db, cql_stats& stats) override;
 
-    virtual bool uses_function(const sstring& ks_name, const sstring& function_name) const override;
-
     virtual bool depends_on_keyspace(const sstring& ks_name) const override;
 
     virtual bool depends_on_column_family(const sstring& cf_name) const override;

--- a/cql3/statements/use_statement.cc
+++ b/cql3/statements/use_statement.cc
@@ -73,11 +73,6 @@ std::unique_ptr<prepared_statement> use_statement::prepare(database& db, cql_sta
 
 }
 
-bool use_statement::uses_function(const sstring& ks_name, const sstring& function_name) const
-{
-    return false;
-}
-
 bool use_statement::depends_on_keyspace(const sstring& ks_name) const
 {
     return false;

--- a/cql3/statements/use_statement.hh
+++ b/cql3/statements/use_statement.hh
@@ -59,8 +59,6 @@ public:
 
     virtual uint32_t get_bound_terms() const override;
 
-    virtual bool uses_function(const sstring& ks_name, const sstring& function_name) const override;
-
     virtual bool depends_on_keyspace(const sstring& ks_name) const override;
 
     virtual bool depends_on_column_family(const sstring& cf_name) const override;

--- a/cql3/term.hh
+++ b/cql3/term.hh
@@ -101,8 +101,6 @@ public:
      */
     virtual bool contains_bind_marker() const = 0;
 
-    virtual bool uses_function(const sstring& ks_name, const sstring& function_name) const = 0;
-
     virtual sstring to_string() const {
         return format("term@{:p}", static_cast<const void*>(this));
     }
@@ -174,10 +172,6 @@ public:
         return static_pointer_cast<terminal>(this->shared_from_this());
     }
 
-    virtual bool uses_function(const sstring& ks_name, const sstring& function_name) const override {
-        return false;
-    }
-
     // While some NonTerminal may not have bind markers, no Term can be Terminal
     // with a bind marker
     virtual bool contains_bind_marker() const override {
@@ -220,10 +214,6 @@ public:
  */
 class non_terminal : public term {
 public:
-    virtual bool uses_function(const sstring& ks_name, const sstring& function_name) const override {
-        return false;
-    }
-
     virtual cql3::raw_value_view bind_and_get(const query_options& options) override {
         auto t = bind(options);
         if (t) {

--- a/cql3/user_types.cc
+++ b/cql3/user_types.cc
@@ -181,10 +181,6 @@ sstring user_types::value::to_string() const {
 user_types::delayed_value::delayed_value(user_type type, std::vector<shared_ptr<term>> values)
         : _type(std::move(type)), _values(std::move(values)) {
 }
-bool user_types::delayed_value::uses_function(const sstring& ks_name, const sstring& function_name) const {
-    return boost::algorithm::any_of(_values,
-                std::bind(&term::uses_function, std::placeholders::_1, std::cref(ks_name), std::cref(function_name)));
-}
 bool user_types::delayed_value::contains_bind_marker() const {
     return boost::algorithm::any_of(_values, std::mem_fn(&term::contains_bind_marker));
 }

--- a/cql3/user_types.hh
+++ b/cql3/user_types.hh
@@ -91,7 +91,6 @@ public:
         std::vector<shared_ptr<term>> _values;
     public:
         delayed_value(user_type type, std::vector<shared_ptr<term>> values);
-        virtual bool uses_function(const sstring& ks_name, const sstring& function_name) const override;
         virtual bool contains_bind_marker() const override;
         virtual void collect_marker_specification(variable_specifications& bound_names) const;
     private:


### PR DESCRIPTION
No one seems to call them except for other uses_function methods.

Tests: unit (dev)

Signed-off-by: Dejan Mircevski <dejan@scylladb.com>