### PR TITLE
cql3/expr: Drop make_column_op()

### DIFF
--- a/cql3/expr/expression.hh
+++ b/cql3/expr/expression.hh
@@ -229,11 +229,6 @@ extern bool is_on_collection(const binary_operator&);
 /// column_value.
 extern expression replace_column_def(const expression&, const column_definition*);
 
-/// Makes a binary_operator on a column_definition.
-inline expression make_column_op(const column_definition* cdef, oper_t op, ::shared_ptr<term> value) {
-    return binary_operator{column_value(cdef), op, std::move(value)};
-}
-
 inline oper_t pick_operator(statements::bound b, bool inclusive) {
     return is_start(b) ?
             (inclusive ? oper_t::GTE : oper_t::GT) :

--- a/cql3/restrictions/multi_column_restriction.hh
+++ b/cql3/restrictions/multi_column_restriction.hh
@@ -565,7 +565,7 @@ private:
         using namespace expr;
         if (!bound){
             auto r = ::make_shared<cql3::restrictions::single_column_restriction>(*_column_defs[column_pos]);
-            r->expression = make_column_op(_column_defs[column_pos], expr::oper_t::EQ, std::move(term));
+            r->expression = binary_operator{_column_defs[column_pos], expr::oper_t::EQ, std::move(term)};
             return r;
         } else {
             auto r = ::make_shared<cql3::restrictions::single_column_restriction>(*_column_defs[column_pos]);

--- a/cql3/single_column_relation.cc
+++ b/cql3/single_column_relation.cc
@@ -71,7 +71,7 @@ single_column_relation::new_EQ_restriction(database& db, schema_ptr schema, vari
     if (!_map_key) {
         auto r = ::make_shared<restrictions::single_column_restriction>(column_def);
         auto term = to_term(to_receivers(*schema, column_def), *_value, db, schema->ks_name(), bound_names);
-        r->expression = make_column_op(&column_def, expr::oper_t::EQ, std::move(term));
+        r->expression = binary_operator{&column_def, expr::oper_t::EQ, std::move(term)};
         return r;
     }
     auto&& receivers = to_receivers(*schema, column_def);
@@ -92,19 +92,19 @@ single_column_relation::new_IN_restriction(database& db, schema_ptr schema, vari
     if (_value) {
         auto term = to_term(receivers, *_value, db, schema->ks_name(), bound_names);
         auto r = ::make_shared<single_column_restriction>(column_def);
-        r->expression = make_column_op(&column_def, expr::oper_t::IN, std::move(term));
+        r->expression = binary_operator{&column_def, expr::oper_t::IN, std::move(term)};
         return r;
     }
     auto terms = to_terms(receivers, _in_values, db, schema->ks_name(), bound_names);
     // Convert a single-item IN restriction to an EQ restriction
     if (terms.size() == 1) {
         auto r = ::make_shared<single_column_restriction>(column_def);
-        r->expression = make_column_op(&column_def, expr::oper_t::EQ, std::move(terms[0]));
+        r->expression = binary_operator{&column_def, expr::oper_t::EQ, std::move(terms[0])};
         return r;
     }
     auto r = ::make_shared<single_column_restriction>(column_def);
-    r->expression = make_column_op(
-            &column_def, expr::oper_t::IN, ::make_shared<lists::delayed_value>(std::move(terms)));
+    r->expression = binary_operator{
+            &column_def, expr::oper_t::IN, ::make_shared<lists::delayed_value>(std::move(terms))};
     return r;
 }
 
@@ -118,7 +118,7 @@ single_column_relation::new_LIKE_restriction(
     }
     auto term = to_term(to_receivers(*schema, column_def), *_value, db, schema->ks_name(), bound_names);
     auto r = ::make_shared<restrictions::single_column_restriction>(column_def);
-    r->expression = make_column_op(&column_def, expr::oper_t::LIKE, std::move(term));
+    r->expression = binary_operator{&column_def, expr::oper_t::LIKE, std::move(term)};
     return r;
 }
 

--- a/cql3/single_column_relation.hh
+++ b/cql3/single_column_relation.hh
@@ -171,7 +171,7 @@ protected:
 
         auto term = to_term(to_receivers(*schema, column_def), *_value, db, schema->ks_name(), bound_names);
         auto r = ::make_shared<restrictions::single_column_restriction>(column_def);
-        r->expression = expr::make_column_op(&column_def, _relation_type, std::move(term));
+        r->expression = expr::binary_operator{&column_def, _relation_type, std::move(term)};
         return r;
     }
 
@@ -181,8 +181,8 @@ protected:
         auto&& column_def = to_column_definition(*schema, *_entity);
         auto term = to_term(to_receivers(*schema, column_def), *_value, db, schema->ks_name(), bound_names);
         auto r = ::make_shared<restrictions::single_column_restriction>(column_def);
-        r->expression = expr::make_column_op(
-                &column_def, is_key ? expr::oper_t::CONTAINS_KEY : expr::oper_t::CONTAINS, std::move(term));
+        r->expression = expr::binary_operator{
+                &column_def, is_key ? expr::oper_t::CONTAINS_KEY : expr::oper_t::CONTAINS, std::move(term)};
         return r;
     }
 

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -1085,9 +1085,9 @@ query::partition_slice indexed_table_select_statement::get_partition_slice_for_g
             auto base_pk = partition_key::from_optional_exploded(*_schema, single_pk_restrictions->values(options));
             bytes token_value = dht::get_token(*_schema, base_pk).data();
             auto token_restriction = ::make_shared<restrictions::single_column_restriction>(token_cdef);
-            token_restriction->expression = expr::make_column_op(
+            token_restriction->expression = expr::binary_operator{
                     &token_cdef, expr::oper_t::EQ,
-                    ::make_shared<cql3::constants::value>(cql3::raw_value::make_value(token_value)));
+                    ::make_shared<cql3::constants::value>(cql3::raw_value::make_value(token_value))};
             clustering_restrictions->merge_with(token_restriction);
 
             if (_restrictions->get_clustering_columns_restrictions()->prefix_size() > 0) {
@@ -1120,8 +1120,8 @@ query::partition_slice indexed_table_select_statement::get_partition_slice_for_l
     if (value) {
         const column_definition* view_cdef = _view_schema->get_column_definition(to_bytes(_index.target_column()));
         auto index_eq_restriction = ::make_shared<restrictions::single_column_restriction>(*view_cdef);
-        index_eq_restriction->expression = expr::make_column_op(
-                view_cdef, expr::oper_t::EQ, ::make_shared<cql3::constants::value>(cql3::raw_value::make_value(*value)));
+        index_eq_restriction->expression = expr::binary_operator{
+                view_cdef, expr::oper_t::EQ, ::make_shared<cql3::constants::value>(cql3::raw_value::make_value(*value))};
         clustering_restrictions->merge_with(index_eq_restriction);
     }
 


### PR DESCRIPTION
Instantiating binary_operator directly is more readable.

Tests: unit (dev)

Signed-off-by: Dejan Mircevski <dejan@scylladb.com>