### PR TITLE
repair: apply_rows_on_follower(): remove copy of repair_rows list

### DIFF
--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -1317,7 +1317,7 @@ private:
         if (rows.empty()) {
             return make_ready_future<>();
         }
-        return to_repair_rows_list(rows).then([this] (std::list<repair_row> row_diff) {
+        return to_repair_rows_list(std::move(rows)).then([this] (std::list<repair_row> row_diff) {
             unsigned node_idx = 0;
             return do_apply_rows(std::move(row_diff), node_idx, update_working_row_buf::no);
         });


### PR DESCRIPTION
We copy a list, which was reported to generate a 15ms stall.

This is easily fixed by moving it instead, which is safe since this is
the last use of the variable.

Fixes #7115.