### PR TITLE
cdc: Remove post-filterings for keys-only/off cdc delta generation

### DIFF
--- a/cdc/cdc_options.hh
+++ b/cdc/cdc_options.hh
@@ -28,7 +28,6 @@
 namespace cdc {
 
 enum class delta_mode : uint8_t {
-    off,
     keys,
     full,
 };

--- a/test/cql/cdc_delta_modes_test.cql
+++ b/test/cql/cdc_delta_modes_test.cql
@@ -1,11 +1,4 @@
-create table tb1 (pk int, ck int, i1 int, PRIMARY KEY (pk, ck)) with cdc = {'enabled': true, 'preimage': false, 'postimage': false, 'delta': 'off'};
-
-create table tb2 (pk int, ck int, i1 int, PRIMARY KEY (pk, ck)) with cdc = {'enabled': true, 'preimage': true, 'postimage': true, 'delta': 'off'};
--- Should add 1 row (postimage)
-insert into tb2 (pk, ck, i1) VALUES (1, 11, 111) USING TTL 1111;
-select "cdc$batch_seq_no", "cdc$operation", pk, ck, i1 from tb2_scylla_cdc_log where pk = 1 and ck = 11 allow filtering;
-
-alter table tb2 with cdc = {'enabled': true, 'preimage': true, 'postimage': true, 'delta': 'keys'};
+create table tb2 (pk int, ck int, i1 int, PRIMARY KEY (pk, ck)) with cdc = {'enabled': true, 'preimage': true, 'postimage': true, 'delta': 'keys'};
 -- Should add 3 rows (preimage + postimage + delta). Delta has only key columns and "pk" + "ck"
 insert into tb2 (pk, ck, i1) VALUES (2, 22, 222) USING TTL 2222;
 select "cdc$batch_seq_no", "cdc$operation", "cdc$ttl", pk, ck, i1 from tb2_scylla_cdc_log where pk = 2 and ck = 22 allow filtering;

--- a/test/cql/cdc_delta_modes_test.result
+++ b/test/cql/cdc_delta_modes_test.result
@@ -1,33 +1,4 @@
-create table tb1 (pk int, ck int, i1 int, PRIMARY KEY (pk, ck)) with cdc = {'enabled': true, 'preimage': false, 'postimage': false, 'delta': 'off'};
-{
-	"message" : "exceptions::configuration_exception (Invalid combination of CDC options: neither of {preimage, postimage, delta} is enabled)",
-	"status" : "error"
-}
-
-create table tb2 (pk int, ck int, i1 int, PRIMARY KEY (pk, ck)) with cdc = {'enabled': true, 'preimage': true, 'postimage': true, 'delta': 'off'};
-{
-	"status" : "ok"
-}
--- Should add 1 row (postimage)
-insert into tb2 (pk, ck, i1) VALUES (1, 11, 111) USING TTL 1111;
-{
-	"status" : "ok"
-}
-select "cdc$batch_seq_no", "cdc$operation", pk, ck, i1 from tb2_scylla_cdc_log where pk = 1 and ck = 11 allow filtering;
-{
-	"rows" : 
-	[
-		{
-			"cdc$batch_seq_no" : "0",
-			"cdc$operation" : "9",
-			"ck" : "11",
-			"i1" : "111",
-			"pk" : "1"
-		}
-	]
-}
-
-alter table tb2 with cdc = {'enabled': true, 'preimage': true, 'postimage': true, 'delta': 'keys'};
+create table tb2 (pk int, ck int, i1 int, PRIMARY KEY (pk, ck)) with cdc = {'enabled': true, 'preimage': true, 'postimage': true, 'delta': 'keys'};
 {
 	"status" : "ok"
 }


### PR DESCRIPTION
Refs #7095
Fixes #7128

CDC delta!=full both relied on post-filtering
to remove generated log row and/or cells. This is inefficient.
Instead, simply check if the data should be created in the
visitors.

v2:
    * Fixed delta logs rows created (empty) even when delta == off
v3:
    * Killed delta == off (patch in series)