### PR TITLE
offline installation: fix default value of python3/sysconfdir and a small cleanup

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -42,8 +42,6 @@ EOF
 
 root=/
 housekeeping=false
-python3=/opt/scylladb/python3/bin/python3
-sysconfdir=/etc/sysconfig
 nonroot=false
 packaging=false
 upgrade=false
@@ -179,6 +177,20 @@ if [ -z "$prefix" ]; then
 fi
 
 rprefix=$(realpath -m "$root/$prefix")
+
+if [ -f "/etc/os-release" ]; then
+    . /etc/os-release
+fi
+
+if [ -z "$sysconfdir" ]; then
+    sysconfdir=/etc/sysconfig
+    if ! $nonroot; then
+        if [ "$ID" = "ubuntu" ] || [ "$ID" = "debian" ]; then
+            sysconfdir=/etc/default
+        fi
+    fi
+fi
+
 if [ -z "$python3" ]; then
     python3=$prefix/python3/bin/python3
 fi

--- a/install.sh
+++ b/install.sh
@@ -206,6 +206,7 @@ grep -v api_ui_dir conf/scylla.yaml | grep -v api_doc_dir > /tmp/scylla.yaml
 echo "api_ui_dir: /opt/scylladb/swagger-ui/dist/" >> /tmp/scylla.yaml
 echo "api_doc_dir: /opt/scylladb/api/api-doc/" >> /tmp/scylla.yaml
 installconfig 644 /tmp/scylla.yaml "$retc"/scylla
+rm -f /tmp/scylla.yaml
 installconfig 644 conf/cassandra-rackdc.properties "$retc"/scylla
 if $housekeeping; then
     installconfig 644 conf/housekeeping.cfg "$retc"/scylla.d

--- a/unified/install.sh
+++ b/unified/install.sh
@@ -40,8 +40,6 @@ EOF
 
 root=/
 housekeeping=false
-python3=/opt/scylladb/python3/bin/python3
-sysconfdir=/etc/sysconfig
 nonroot=false
 
 while [ $# -gt 0 ]; do
@@ -88,6 +86,23 @@ if [ -z "$prefix" ]; then
     fi
 fi
 rprefix=$(realpath -m "$root/$prefix")
+
+if [ -f "/etc/os-release" ]; then
+    . /etc/os-release
+fi
+
+if [ -z "$sysconfdir" ]; then
+    sysconfdir=/etc/sysconfig
+    if ! $nonroot; then
+        if [ "$ID" = "ubuntu" ] || [ "$ID" = "debian" ]; then
+            sysconfdir=/etc/default
+        fi
+    fi
+fi
+
+if [ -z "$python3" ]; then
+    python3=$prefix/python3/bin/python3
+fi
 
 scylla_args=()
 args=()


### PR DESCRIPTION
1. scylla setup scripts doesn't work, because python3 path isn't correct in creating relocatable packages if user doesn't set python3 path in running unified/install.sh. This PR fixed the problem by setting the default python3 value according to the install mode (root/nonroot).

2. another patch cleaned the tmp scylla.yaml after installation