### PR TITLE
storage_service.cc: get_natural_endpoints should translate key

### DIFF
--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -2985,8 +2985,9 @@ storage_service::get_all_ranges(const std::vector<token>& sorted_tokens) const {
 std::vector<gms::inet_address>
 storage_service::get_natural_endpoints(const sstring& keyspace,
         const sstring& cf, const sstring& key) const {
-    sstables::key_view key_view = sstables::key_view(bytes_view(reinterpret_cast<const signed char*>(key.c_str()), key.size()));
-    dht::token token = _db.local().find_schema(keyspace, cf)->get_partitioner().get_token(key_view);
+    auto schema = _db.local().find_schema(keyspace, cf);
+    partition_key pk = partition_key::from_nodetool_style_string(schema, key);
+    dht::token token = schema->get_partitioner().get_token(*schema, pk.view());
     return get_natural_endpoints(keyspace, token);
 }
 


### PR DESCRIPTION
The get_natural_endpoints returns the list of nodes holding a key.

There is a variation of the method that gets the key as string, the
current implementation just cast the string to bytes_view, which will
not work. Instead, this patch changes the implementation to use
from_nodetool_style_string to translate the key (in a nodetool like
format) to a token.
    
Fixes #7134

Signed-off-by: Amnon Heiman <amnon@scylladb.com>