### PR TITLE
cql3: Use one expression in restrictions_filter

### DIFF
--- a/cql3/expr/expression.cc
+++ b/cql3/expr/expression.cc
@@ -28,6 +28,7 @@
 #include <unordered_map>
 
 #include "cql3/lists.hh"
+#include "cql3/selection/selection.hh"
 #include "cql3/tuples.hh"
 #include "index/secondary_index_manager.hh"
 #include "types/list.hh"

--- a/cql3/expr/expression.hh
+++ b/cql3/expr/expression.hh
@@ -28,7 +28,6 @@
 
 #include "bytes.hh"
 #include "cql3/query_options.hh"
-#include "cql3/selection/selection.hh"
 #include "cql3/statements/bound.hh"
 #include "cql3/term.hh"
 #include "database_fwd.hh"
@@ -45,6 +44,10 @@ class secondary_index_manager;
 } // namespace secondary_index
 
 namespace cql3 {
+
+namespace selection {
+class selection;
+} // namespace selection
 
 namespace expr {
 

--- a/cql3/selection/selection.hh
+++ b/cql3/selection/selection.hh
@@ -49,6 +49,7 @@
 #include "cql3/selection/raw_selector.hh"
 #include "unimplemented.hh"
 #include <seastar/core/thread.hh>
+#include "cql3/expr/expression.hh"
 
 namespace cql3 {
 
@@ -284,10 +285,8 @@ public:
         }
     };
     class restrictions_filter {
-        ::shared_ptr<restrictions::statement_restrictions> _restrictions;
+        const expr::expression _expression;
         const query_options& _options;
-        const bool _skip_pk_restrictions;
-        const bool _skip_ck_restrictions;
         mutable bool _current_partition_key_does_not_match = false;
         mutable bool _current_static_row_does_not_match = false;
         mutable uint64_t _rows_dropped = 0;
@@ -299,11 +298,12 @@ public:
         mutable std::optional<partition_key> _last_pkey;
         mutable bool _is_first_partition_on_page = true;
     public:
-        explicit restrictions_filter(::shared_ptr<restrictions::statement_restrictions> restrictions,
+        explicit restrictions_filter(const restrictions::statement_restrictions& restrictions,
                 const query_options& options,
                 uint64_t remaining,
                 schema_ptr schema,
                 uint64_t per_partition_limit,
+                const selection& sel,
                 std::optional<partition_key> last_pkey = {},
                 uint64_t rows_fetched_for_last_partition = 0);
         bool operator()(const selection& selection, const std::vector<bytes>& pk, const std::vector<bytes>& ck, const query::result_row_view& static_row, const query::result_row_view* row) const;

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -740,7 +740,9 @@ select_statement::process_results(foreign_ptr<lw_shared_ptr<query::result>> resu
                 _stats.filtered_rows_read_total += *results->row_count();
                 query::result_view::consume(*results, cmd->slice,
                         cql3::selection::result_set_builder::visitor(builder, *_schema,
-                                *_selection, cql3::selection::result_set_builder::restrictions_filter(_restrictions, options, cmd->get_row_limit(), _schema, cmd->slice.partition_row_limit())));
+                                *_selection, cql3::selection::result_set_builder::restrictions_filter(
+                                        *_restrictions, options, cmd->get_row_limit(), _schema,
+                                        cmd->slice.partition_row_limit(), *_selection)));
             } else {
                 query::result_view::consume(*results, cmd->slice,
                         cql3::selection::result_set_builder::visitor(builder, *_schema,
@@ -999,7 +1001,9 @@ indexed_table_select_statement::do_execute(service::storage_proxy& proxy,
                     if (restrictions_need_filtering) {
                         _stats.filtered_rows_read_total += *results->row_count();
                         query::result_view::consume(*results, cmd->slice, cql3::selection::result_set_builder::visitor(builder, *_schema, *_selection,
-                                cql3::selection::result_set_builder::restrictions_filter(_restrictions, options, cmd->get_row_limit(), _schema, cmd->slice.partition_row_limit())));
+                                cql3::selection::result_set_builder::restrictions_filter(
+                                        *_restrictions, options, cmd->get_row_limit(), _schema,
+                                        cmd->slice.partition_row_limit(), *_selection)));
                     } else {
                         query::result_view::consume(*results, cmd->slice, cql3::selection::result_set_builder::visitor(builder, *_schema, *_selection));
                     }

--- a/service/pager/query_pagers.cc
+++ b/service/pager/query_pagers.cc
@@ -256,7 +256,9 @@ public:
             qr.query_result->ensure_counts();
             _stats.rows_read_total += *qr.query_result->row_count();
             handle_result(cql3::selection::result_set_builder::visitor(builder, *_schema, *_selection,
-                          cql3::selection::result_set_builder::restrictions_filter(_filtering_restrictions, _options, _max, _schema, _per_partition_limit, _last_pkey, _rows_fetched_for_last_partition)),
+                          cql3::selection::result_set_builder::restrictions_filter(
+                                  *_filtering_restrictions, _options, _max, _schema, _per_partition_limit,
+                                  *_selection, _last_pkey, _rows_fetched_for_last_partition)),
                           std::move(qr.query_result), page_size, now);
         });
     }


### PR DESCRIPTION
Replace complex logic in restrictions_filter::do_filter with a simple
evaluation of a single expression compiled from the restrictions.

This approach separates compilation from evaluation, allowing us to
easily add optimizations (eg, binding markers, compiling LIKE patterns
into regular expressions, constant folding) in the future.

Tests: unit (dev)

Signed-off-by: Dejan Mircevski <dejan@scylladb.com>