### PR TITLE
cql3: Drop get_partition_key_unrestricted_components

### DIFF
--- a/cql3/restrictions/statement_restrictions.cc
+++ b/cql3/restrictions/statement_restrictions.cc
@@ -130,20 +130,6 @@ statement_restrictions::initial_key_restrictions<clustering_key_prefix>::merge_t
     return allow_filtering ? initial_kr_true : initial_kr_false;
 }
 
-std::vector<::shared_ptr<column_identifier>>
-statement_restrictions::get_partition_key_unrestricted_components() const {
-    std::vector<::shared_ptr<column_identifier>> r;
-
-    auto restricted = _partition_key_restrictions->get_column_defs();
-    auto is_not_restricted = [&restricted] (const column_definition& def) {
-        return !boost::count(restricted, &def);
-    };
-
-    boost::copy(_schema->partition_key_columns() | filtered(is_not_restricted) | transformed(to_identifier),
-        std::back_inserter(r));
-    return r;
-}
-
 statement_restrictions::statement_restrictions(schema_ptr schema, bool allow_filtering)
     : _schema(schema)
     , _partition_key_restrictions(get_initial_partition_key_restrictions(allow_filtering))

--- a/cql3/restrictions/statement_restrictions.hh
+++ b/cql3/restrictions/statement_restrictions.hh
@@ -214,12 +214,6 @@ private:
     void process_partition_key_restrictions(bool has_queriable_index, bool for_view, bool allow_filtering);
 
     /**
-     * Returns the partition key components that are not restricted.
-     * @return the partition key components that are not restricted.
-     */
-    std::vector<::shared_ptr<column_identifier>> get_partition_key_unrestricted_components() const;
-
-    /**
      * Processes the clustering column restrictions.
      *
      * @param has_queriable_index <code>true</code> if some of the queried data are indexed, <code>false</code> otherwise


### PR DESCRIPTION
Not used anywhere.

Tests: unit (dev)

Signed-off-by: Dejan Mircevski <dejan@scylladb.com>