### PR TITLE
Alternator streams - fix table description and sequence number

### DIFF
--- a/alternator/executor.hh
+++ b/alternator/executor.hh
@@ -146,7 +146,9 @@ public:
 
 
 
-    void add_stream_options(const rjson::value& stream_spec, schema_builder&);
+    void add_stream_options(const rjson::value& stream_spec, schema_builder&) const;
+    void supplement_table_info(rjson::value& descr, const schema& schema) const;
+    void supplement_table_stream_info(rjson::value& descr, const schema& schema) const;
 };
 
 }

--- a/alternator/streams.cc
+++ b/alternator/streams.cc
@@ -993,6 +993,8 @@ void executor::supplement_table_stream_info(rjson::value& descr, const schema& s
         auto& cf = db.find_column_family(schema.ks_name(), cdc::log_name(schema.cf_name()));
         stream_arn arn(cf.schema()->id());
         rjson::set(descr, "LatestStreamArn", arn);
+        rjson::set(descr, "LatestStreamLabel", rjson::from_string(stream_label(*cf.schema())));
+
     }
 }
 

--- a/alternator/streams.cc
+++ b/alternator/streams.cc
@@ -964,6 +964,8 @@ void executor::add_stream_options(const rjson::value& stream_specification, sche
 
         cdc::options opts;
         opts.enabled(true);
+        opts.set_delta_mode(cdc::delta_mode::keys);
+
         auto type = rjson::get_opt<stream_view_type>(stream_specification, "StreamViewType").value_or(stream_view_type::KEYS_ONLY);
         switch (type) {
             default: 

--- a/cdc/cdc_options.hh
+++ b/cdc/cdc_options.hh
@@ -66,6 +66,7 @@ public:
     bool full_preimage() const { return _preimage == image_mode::full; }
     bool postimage() const { return _postimage; }
     delta_mode get_delta_mode() const { return _delta_mode; }
+    void set_delta_mode(delta_mode m) { _delta_mode = m; }
     int ttl() const { return _ttl; }
 
     void enabled(bool b) { _enabled = b; }


### PR DESCRIPTION
Stream descriptions, as returned from create, update and describe stream was missing "latest" stream arn. 

Shard descriptions sequence number (for us timeuuid:s) were formatted wrongly. The spec states they should be numeric only. 

Both these defects break Kinesis operations. 

v2: 
* Fixed sequence number in getrecords