### PR TITLE
utf8: Print invalid UTF-8 character position

### DIFF
--- a/bytes.hh
+++ b/bytes.hh
@@ -39,6 +39,10 @@ inline sstring_view to_sstring_view(bytes_view view) {
     return {reinterpret_cast<const char*>(view.data()), view.size()};
 }
 
+inline bytes_view to_bytes_view(sstring_view view) {
+    return {reinterpret_cast<const int8_t*>(view.data()), view.size()};
+}
+
 namespace std {
 
 template <>

--- a/lua.cc
+++ b/lua.cc
@@ -793,10 +793,11 @@ struct from_lua_visitor {
 
     data_value operator()(const utf8_type_impl& t) {
         sstring s = get_string(l, -1);
-        if (utils::utf8::validate(reinterpret_cast<uint8_t*>(s.data()), s.size())) {
-            return std::move(s);
+        auto error_pos = utils::utf8::validate_with_error_position(reinterpret_cast<uint8_t*>(s.data()), s.size());
+        if (error_pos) {
+            throw exceptions::invalid_request_exception(format("value is not valid utf8, invalid character at byte offset {}", *error_pos));
         }
-        throw exceptions::invalid_request_exception("value is not valid utf8");
+        return std::move(s);
     }
 
     data_value operator()(const ascii_type_impl& t) {

--- a/test/boost/user_function_test.cc
+++ b/test/boost/user_function_test.cc
@@ -574,7 +574,7 @@ SEASTAR_TEST_CASE(test_user_function_utf8_return) {
 
         e.execute_cql("CREATE FUNCTION my_func3(val varint) CALLED ON NULL INPUT RETURNS text LANGUAGE Lua AS 'return \"\\xFF\"';").get();
         auto fut = e.execute_cql("SELECT my_func3(val) FROM my_table;");
-        BOOST_REQUIRE_EXCEPTION(fut.get(), ire, message_equals("value is not valid utf8"));
+        BOOST_REQUIRE_EXCEPTION(fut.get(), ire, message_equals("value is not valid utf8, invalid character at byte offset 0"));
 
         e.execute_cql("CREATE TABLE my_table2 (key text PRIMARY KEY, val decimal);").get();
         e.execute_cql("INSERT INTO my_table2 (key, val) VALUES ('foo', 4.2);").get();

--- a/test/boost/utf8_test.cc
+++ b/test/boost/utf8_test.cc
@@ -163,3 +163,15 @@ BOOST_AUTO_TEST_CASE(test_utf8_negative) {
         }
     }
 }
+
+BOOST_AUTO_TEST_CASE(test_utf8_position) {
+    auto test_string = [](const char* str, std::optional<size_t> expected) {
+        BOOST_CHECK(utils::utf8::validate_with_error_position(reinterpret_cast<const uint8_t*>(str), strlen(str)) == expected);
+    };
+
+    test_string("valid string", std::nullopt);
+    test_string("ab\xc3\x28 xx", 2);
+    test_string("abc\xe2\x82\x28", 3);
+    test_string("abcd\xf0\x28\x8c\x28", 4);
+    test_string("abcd\xc3\x28", 4);
+}

--- a/types.cc
+++ b/types.cc
@@ -1422,8 +1422,9 @@ struct validate_visitor {
         }
     }
     void operator()(const utf8_type_impl&) {
-        if (!utils::utf8::validate(v)) {
-            throw marshal_exception("Validation failed - non-UTF8 character in a UTF8 string");
+        auto error_pos = utils::utf8::validate_with_error_position(v);
+        if (error_pos) {
+            throw marshal_exception(format("Validation failed - non-UTF8 character in a UTF8 string, at byte offset {}", *error_pos));
         }
     }
     void operator()(const bytes_type_impl& t) {}

--- a/utils/utf8.hh
+++ b/utils/utf8.hh
@@ -40,6 +40,17 @@ inline bool validate(bytes_view string) {
     return validate(data, len);
 }
 
+// If data represents a correct UTF-8 string, return std::nullopt,
+// otherwise return a position of first error byte.
+std::optional<size_t> validate_with_error_position(const uint8_t *data, size_t len);
+
+inline std::optional<size_t> validate_with_error_position(bytes_view string) {
+    const uint8_t *data = reinterpret_cast<const uint8_t*>(string.data());
+    size_t len = string.size();
+
+    return validate_with_error_position(data, len);	
+}
+
 } // namespace utf8
 
 } // namespace utils


### PR DESCRIPTION
#### Summary
Before this change, if there was a UTF-8 validation error, Scylla provided no further information about location of invalid character inside the offending string.

Added new `validate_with_error_position` function, which returns a position of invalid UTF-8 byte in a string. Modified all "invalid UTF-8" exception messages to present a location information to user (below - in bold highlighted added new text):

- Invalid UTF-8 string inside prepared statement argument:
`exceptions::invalid_request_exception: Exception while binding column b: marshaling error: Validation failed - non-UTF8 character in a UTF8 string,` **`at byte offset 0`**
- Server-side message returned to the Java Cassandra client:
`Exception in thread "main" com.datastax.oss.driver.api.core.servererrors.ProtocolError: Cannot decode string as UTF8` **`, invalid character at byte offset 45`**

Fixes #3016 

#### Why `validate_with_error_position` is done in two passes?
At first I considered changing existing functions to return a error position instead of bool error/no error. One of the existing implementations is a SIMD branchfree (in the main loop) method, which goes through the entire string accumulating state in `error` vector (no short-circuit!). In order to return a position I would have to:

a) change the loop to short-circuit, eliminating the branchfree aspect of the implementation
or
b) somehow accumulate the position alongside/in the `error` vector, adding additional operations which might make it slower
https://github.com/scylladb/scylla/blob/6fadba56cc18bebe6648e6aec09be1b0b93f4817/utils/utf8.cc#L461-L462 

As (probably) most strings are valid UTF-8, in those cases only a one (SIMD optimized) pass is performed. If there is an UTF8 error, in current implementation a slower naive pass is performed to find the error position - I think a good tradeoff. 