### PR TITLE
cql3: Simplify pk test in statement_restrictions

### DIFF
--- a/cql3/restrictions/statement_restrictions.cc
+++ b/cql3/restrictions/statement_restrictions.cc
@@ -419,7 +419,7 @@ void statement_restrictions::process_partition_key_restrictions(bool has_queriab
     // components must have a EQ. Only the last partition key component can be in IN relation.
     if (has_token(_partition_key_restrictions->expression)) {
         _is_key_range = true;
-    } else if (_partition_key_restrictions->has_unrestricted_components(*_schema)) {
+    } else if (_partition_key_restrictions->empty()) {
         _is_key_range = true;
         _uses_secondary_indexing = has_queriable_index;
     }


### PR DESCRIPTION
statement_restrictions::process_partition_key_restrictions() was
checking has_unrestricted_components(), whereas just an empty() check
suffices there, because has_unrestricted_components() is implicitly
checked five lines down by needs_filtering().

The replacement check is cheaper and simpler to understand.

Tests: unit (dev)

Signed-off-by: Dejan Mircevski <dejan@scylladb.com>