### PR TITLE
Add support passing python3 dependencies from main repo to scylla-python3 script

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -58,6 +58,7 @@ i18n_xlat = {
     },
 }
 
+python3_dependencies = subprocess.run('./install-dependencies.sh --print-python3-runtime-packages', shell=True, capture_output=True, encoding='utf-8').stdout.strip()
 
 def pkgname(name):
     if name in i18n_xlat:
@@ -1749,7 +1750,7 @@ with open(buildfile_tmp, 'w') as f:
         build dist-server: phony dist-server-tar dist-server-rpm dist-server-deb
 
         rule build-submodule-reloc
-          command = cd $reloc_dir && ./reloc/build_reloc.sh --nodeps
+          command = cd $reloc_dir && ./reloc/build_reloc.sh --nodeps $args
         rule build-submodule-rpm
           command = cd $dir && ./reloc/build_rpm.sh --reloc-pkg $artifact
         rule build-submodule-deb
@@ -1796,6 +1797,7 @@ with open(buildfile_tmp, 'w') as f:
 
         build tools/python3/build/scylla-python3-package.tar.gz: build-submodule-reloc
           reloc_dir = tools/python3
+          args = --packages "{python3_dependencies}"
         build dist-python3-rpm: build-submodule-rpm tools/python3/build/scylla-python3-package.tar.gz
           dir = tools/python3
           artifact = $builddir/scylla-python3-package.tar.gz

--- a/dist/common/scripts/scylla_ntp_setup
+++ b/dist/common/scripts/scylla_ntp_setup
@@ -41,7 +41,8 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     if is_debian_variant():
-        run('apt-get install -y ntp ntpdate')
+        if not os.file.exists('/usr/sbin/ntpd') or not os.file.exists('/usr/sbni/ntpdate'):
+            run('apt-get install -y ntp ntpdate')
         with open('/etc/ntp.conf') as f:
             conf = f.read()
         if not re.match(r'^server ', conf, flags=re.MULTILINE):
@@ -56,7 +57,8 @@ if __name__ == '__main__':
         ntp.start()
 
     if is_gentoo_variant():
-        run('emerge -uq net-misc/ntp')
+        if not os.file.exists('/usr/sbin/ntpd'):
+            run('emerge -uq net-misc/ntp')
         with open('/etc/ntp.conf') as f:
             conf = f.read()
         match = re.search(r'^server\s+(\S*)(\s+\S+)?', conf, flags=re.MULTILINE)
@@ -76,7 +78,8 @@ if __name__ == '__main__':
 
     if is_redhat_variant():
         if int(distro.major_version()) >= 8:
-            run('dnf install -y chrony')
+            if not os.file.exists('/usr/sbin/chronyd'):
+                run('dnf install -y chrony')
             with open('/etc/chrony.conf') as f:
                 conf = f.read()
             if args.subdomain:
@@ -89,7 +92,8 @@ if __name__ == '__main__':
             chronyd.restart()
             run('chronyc makestep')
         else:
-            run('yum install -y ntp ntpdate')
+            if not os.file.exists('/usr/sbin/ntpd') or not os.file.exists('/usr/sbin/ntpdate'):
+                run('yum install -y ntp ntpdate')
             with open('/etc/ntp.conf') as f:
                 conf = f.read()
             if args.subdomain:

--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -27,10 +27,6 @@ else
     exit 1
 fi
 
-bash seastar/install-dependencies.sh
-bash tools/jmx/install-dependencies.sh
-bash tools/java/install-dependencies.sh
-
 debian_base_packages=(
     liblua5.3-dev
     python3-pyparsing
@@ -67,21 +63,10 @@ fedora_packages=(
     patchelf
     python3
     python3-pip
-    python3-PyYAML
-    python3-pyudev
-    python3-setuptools
-    python3-urwid
-    python3-pyparsing
-    python3-requests
-    python3-pyudev
-    python3-setuptools
     python3-magic
-    python3-psutil
     python3-colorama
     python3-boto3
     python3-pytest
-    python3-distro
-    python3-psutil
     python3-redis
     dnf-utils
     pigz
@@ -103,6 +88,17 @@ fedora_packages=(
     fakeroot
     file
     dpkg-dev
+)
+
+fedora_python3_packages=(
+    python3-pyyaml
+    python3-urwid
+    python3-pyparsing
+    python3-requests
+    python3-pyudev
+    python3-setuptools
+    python3-psutil
+    python3-distro
 )
 
 centos_packages=(
@@ -141,6 +137,39 @@ arch_packages=(
     thrift
 )
 
+print_usage() {
+    echo "Usage: install-dependencies.sh [OPTION]..."
+    echo ""
+    echo "  --print-python3-runtime-packages Print required python3 packages for Scylla"
+    exit 1
+}
+
+PRINT_PYTHON3=false
+while [ $# -gt 0 ]; do
+    case "$1" in
+        "--print-python3-runtime-packages")
+            PRINT_PYTHON3=true
+            shift 1
+            ;;
+         *)
+            print_usage
+            ;;
+    esac
+done
+
+if $PRINT_PYTHON3; then
+    if [ "$ID" != "fedora" ]; then
+        echo "Unsupported Distribution: $ID"
+        exit 1
+    fi
+    echo "${fedora_python3_packages[@]}"
+    exit 0
+fi
+
+bash seastar/install-dependencies.sh
+bash tools/jmx/install-dependencies.sh
+bash tools/java/install-dependencies.sh
+
 if [ "$ID" = "ubuntu" ] || [ "$ID" = "debian" ]; then
     apt-get -y install "${debian_base_packages[@]}"
     if [ "$VERSION_ID" = "8" ]; then
@@ -160,7 +189,7 @@ elif [ "$ID" = "fedora" ]; then
         echo "Please remove the package and try to run this script again."
         exit 1
     fi
-    yum install -y "${fedora_packages[@]}"
+    yum install -y "${fedora_packages[@]}" "${fedora_python3_packages[@]}"
     pip3 install cassandra-driver
 elif [ "$ID" = "centos" ]; then
     yum install -y "${centos_packages[@]}"


### PR DESCRIPTION
We don't want to update scylla-python3 submodule for every python3 dependency
update, bring python3 package list to python3-dependencies.txt, pass it on
package building time.

See #6702
See scylladb/scylla-python3#6