### PR TITLE
dist/common/scripts:  abort scylla_prepare with better error message

### DIFF
--- a/dist/common/scripts/scylla_prepare
+++ b/dist/common/scripts/scylla_prepare
@@ -78,5 +78,11 @@ if __name__ == '__main__':
         if dist_name() == 'Ubuntu':
             run('hugeadm --create-mounts')
     else:
-        if create_perftune_conf(cfg):
-            run("{} --options-file /etc/scylla.d/perftune.yaml".format(perftune_base_command()))
+        try:
+            if create_perftune_conf(cfg):
+                run("{} --options-file /etc/scylla.d/perftune.yaml".format(perftune_base_command()))
+        except Exception as e:
+            print(f'Exception occurred while creating perftune.yaml: {e}')
+            print('To fix the error, please re-run scylla_setup.')
+            sys.exit(1)
+

--- a/dist/common/scripts/scylla_util.py
+++ b/dist/common/scripts/scylla_util.py
@@ -679,11 +679,8 @@ def colorprint(msg, **kwargs):
 
 
 def get_mode_cpuset(nic, mode):
-    try:
-        mode_cpu_mask = out('/opt/scylladb/scripts/perftune.py --tune net --nic {} --mode {} --get-cpu-mask-quiet'.format(nic, mode))
-        return hex2list(mode_cpu_mask)
-    except subprocess.CalledProcessError:
-        return '-1'
+    mode_cpu_mask = out('/opt/scylladb/scripts/perftune.py --tune net --nic {} --mode {} --get-cpu-mask-quiet'.format(nic, mode))
+    return hex2list(mode_cpu_mask)
 
 
 def parse_scylla_dirs_with_default(conf='/etc/scylla/scylla.yaml'):
@@ -746,7 +743,7 @@ def get_cur_cpuset():
 
 def get_tune_mode(nic):
     if not os.path.exists('/etc/scylla.d/cpuset.conf'):
-        return
+        raise Exception('/etc/scylla.d/cpuset.conf not found')
     cur_cpuset = get_cur_cpuset()
     mq_cpuset = get_mode_cpuset(nic, 'mq')
     sq_cpuset = get_mode_cpuset(nic, 'sq')
@@ -758,6 +755,8 @@ def get_tune_mode(nic):
         return 'sq'
     elif cur_cpuset == sq_split_cpuset:
         return 'sq_split'
+    else:
+        raise Exception('tune mode not found')
 
 
 def create_perftune_conf(cfg):


### PR DESCRIPTION
When configuration files for perftune contain invalid parameter, scylla_prepare
may cause traceback because error handling is not eough.

Throw all errors from create_perftune_conf(), catch them on scylla_prepare,
proceed running scylla w/o using perftune.

Fixes #6847