### PR TITLE
scylla_ntp_setup: don't install ntpd package when it's already exists

### DIFF
--- a/dist/common/scripts/scylla_ntp_setup
+++ b/dist/common/scripts/scylla_ntp_setup
@@ -41,7 +41,8 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     if is_debian_variant():
-        run('apt-get install -y ntp ntpdate')
+        if not os.path.exists('/usr/sbin/ntpd') or not os.path.exists('/usr/sbin/ntpdate'):
+            run('apt-get install -y ntp ntpdate')
         with open('/etc/ntp.conf') as f:
             conf = f.read()
         if not re.match(r'^server ', conf, flags=re.MULTILINE):
@@ -56,7 +57,8 @@ if __name__ == '__main__':
         ntp.start()
 
     if is_gentoo_variant():
-        run('emerge -uq net-misc/ntp')
+        if not os.path.exists('/usr/sbin/ntpd'):
+            run('emerge -uq net-misc/ntp')
         with open('/etc/ntp.conf') as f:
             conf = f.read()
         match = re.search(r'^server\s+(\S*)(\s+\S+)?', conf, flags=re.MULTILINE)
@@ -76,7 +78,8 @@ if __name__ == '__main__':
 
     if is_redhat_variant():
         if int(distro.major_version()) >= 8:
-            run('dnf install -y chrony')
+            if not os.path.exists('/usr/sbin/chronyd'):
+                run('dnf install -y chrony')
             with open('/etc/chrony.conf') as f:
                 conf = f.read()
             if args.subdomain:
@@ -89,7 +92,8 @@ if __name__ == '__main__':
             chronyd.restart()
             run('chronyc makestep')
         else:
-            run('yum install -y ntp ntpdate')
+            if not os.path.exists('/usr/sbin/ntpd') or not os.path.exists('/usr/sbin/ntpdate'):
+                run('yum install -y ntp ntpdate')
             with open('/etc/ntp.conf') as f:
                 conf = f.read()
             if args.subdomain:


### PR DESCRIPTION
Don't install ntpd package when it's already exists.
Related with #7153