### PR TITLE
install.sh: show warning nonroot mode when systemd does not support user mode

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -165,6 +165,11 @@ installconfig() {
     fi
 }
 
+check_usermode_support() {
+    user=$(systemctl --help|grep -e '--user')
+    [ -n "$user" ]
+}
+
 # change directory to the package's root directory
 cd "$(dirname "$0")"
 
@@ -377,7 +382,9 @@ if $nonroot; then
     # nonroot install is also 'offline install'
     touch $rprefix/SCYLLA-OFFLINE-FILE
     touch $rprefix/SCYLLA-NONROOT-FILE
-    systemctl --user daemon-reload
+    if check_usermode_support; then
+        systemctl --user daemon-reload
+    fi
     echo "Scylla non-root install completed."
 elif ! $packaging; then
     # run install.sh without --packaging is 'offline install'

--- a/unified/install.sh
+++ b/unified/install.sh
@@ -38,6 +38,11 @@ EOF
     exit 1
 }
 
+check_usermode_support() {
+    user=$(systemctl --help|grep -e '--user')
+    [ -n "$user" ]
+}
+
 root=/
 housekeeping=false
 nonroot=false
@@ -124,3 +129,7 @@ fi
 (cd $(readlink -f scylla-tools); ./install.sh --root "$root" --prefix "$prefix" ${args[@]})
 
 install -m755 uninstall.sh -Dt "$rprefix"
+
+if $nonroot && ! check_usermode_support; then
+    echo "WARNING: This distribution does not support systemd user mode, please configure and launch Scylla manually."
+fi


### PR DESCRIPTION
This is v2 of 7089, removed key press waiting since it likely breaked next build

----

On older distribution such as CentOS7, it does not support systemd user mode.
On such distribution nonroot mode does not work, show warning message and
skip running systemctl --user.

Fixes #7071