### PR TITLE
Fix ignoring cells after null in appending hash

### DIFF
--- a/digest_algorithm.hh
+++ b/digest_algorithm.hh
@@ -28,7 +28,8 @@ namespace query {
 enum class digest_algorithm : uint8_t {
     none = 0,  // digest not required
     MD5 = 1,
-    xxHash = 2,// default algorithm
+    legacy_xxHash_without_null_digest = 2,
+    xxHash = 3, // default algorithm
 };
 
 }

--- a/digester.hh
+++ b/digester.hh
@@ -36,7 +36,7 @@ struct noop_hasher {
 };
 
 class digester final {
-    std::variant<noop_hasher, md5_hasher, xx_hasher> _impl;
+    std::variant<noop_hasher, md5_hasher, xx_hasher, legacy_xx_hasher_without_null_digest> _impl;
 
 public:
     explicit digester(digest_algorithm algo) {
@@ -46,6 +46,9 @@ public:
             break;
         case digest_algorithm::xxHash:
             _impl = xx_hasher();
+            break;
+        case digest_algorithm::legacy_xxHash_without_null_digest:
+            _impl = legacy_xx_hasher_without_null_digest();
             break;
         case digest_algorithm ::none:
             _impl = noop_hasher();

--- a/gms/feature.hh
+++ b/gms/feature.hh
@@ -142,6 +142,7 @@ extern const std::string_view HINTED_HANDOFF_SEPARATE_CONNECTION;
 extern const std::string_view LWT;
 extern const std::string_view PER_TABLE_PARTITIONERS;
 extern const std::string_view PER_TABLE_CACHING;
+extern const std::string_view DIGEST_FOR_NULL_VALUES;
 
 }
 

--- a/gms/feature_service.cc
+++ b/gms/feature_service.cc
@@ -57,6 +57,7 @@ constexpr std::string_view features::HINTED_HANDOFF_SEPARATE_CONNECTION = "HINTE
 constexpr std::string_view features::LWT = "LWT";
 constexpr std::string_view features::PER_TABLE_PARTITIONERS = "PER_TABLE_PARTITIONERS";
 constexpr std::string_view features::PER_TABLE_CACHING = "PER_TABLE_CACHING";
+constexpr std::string_view features::DIGEST_FOR_NULL_VALUES = "DIGEST_FOR_NULL_VALUES";
 
 static logging::logger logger("features");
 
@@ -92,8 +93,9 @@ feature_service::feature_service(feature_config cfg) : _config(cfg)
         , _hinted_handoff_separate_connection(*this, features::HINTED_HANDOFF_SEPARATE_CONNECTION)
         , _lwt_feature(*this, features::LWT)
         , _per_table_partitioners_feature(*this, features::PER_TABLE_PARTITIONERS)
-        , _per_table_caching_feature(*this, features::PER_TABLE_CACHING) {
-}
+        , _per_table_caching_feature(*this, features::PER_TABLE_CACHING)
+        , _digest_for_null_values_feature(*this, features::DIGEST_FOR_NULL_VALUES)
+{}
 
 feature_config feature_config_from_db_config(db::config& cfg, std::set<sstring> disabled) {
     feature_config fcfg;
@@ -190,6 +192,7 @@ std::set<std::string_view> feature_service::known_feature_set() {
         gms::features::MD_SSTABLE,
         gms::features::UDF,
         gms::features::CDC,
+        gms::features::DIGEST_FOR_NULL_VALUES,
     };
 
     for (const sstring& s : _config._disabled_features) {
@@ -281,6 +284,7 @@ void feature_service::enable(const std::set<std::string_view>& list) {
         std::ref(_lwt_feature),
         std::ref(_per_table_partitioners_feature),
         std::ref(_per_table_caching_feature),
+        std::ref(_digest_for_null_values_feature),
     })
     {
         if (list.contains(f.name())) {

--- a/gms/feature_service.hh
+++ b/gms/feature_service.hh
@@ -104,6 +104,7 @@ private:
     gms::feature _lwt_feature;
     gms::feature _per_table_partitioners_feature;
     gms::feature _per_table_caching_feature;
+    gms::feature _digest_for_null_values_feature;
 
 public:
     bool cluster_supports_range_tombstones() const {
@@ -180,6 +181,10 @@ public:
 
     const feature& cluster_supports_per_table_caching() const {
         return _per_table_caching_feature;
+    }
+
+    const feature& cluster_supports_digest_for_null_values() const {
+        return _digest_for_null_values_feature;
     }
 
     bool cluster_supports_row_level_repair() const {

--- a/mutation_partition.cc
+++ b/mutation_partition.cc
@@ -728,19 +728,8 @@ void write_counter_cell(RowWriter& w, const query::partition_slice& slice, ::ato
   });
 }
 
-// Used to return the timestamp of the latest update to the row
-struct max_timestamp {
-    api::timestamp_type max = api::missing_timestamp;
-
-    void update(api::timestamp_type ts) {
-        max = std::max(max, ts);
-    }
-};
-
-template<>
-struct appending_hash<row> {
     template<typename Hasher>
-    void operator()(Hasher& h, const row& cells, const schema& s, column_kind kind, const query::column_id_vector& columns, max_timestamp& max_ts) const {
+    void appending_hash<row>::operator()(Hasher& h, const row& cells, const schema& s, column_kind kind, const query::column_id_vector& columns, max_timestamp& max_ts) const {
         for (auto id : columns) {
             const cell_and_hash* cell_and_hash = cells.find_cell_and_hash(id);
             if (!cell_and_hash) {
@@ -777,7 +766,6 @@ struct appending_hash<row> {
             }
         }
     }
-};
 
 cell_hash_opt row::cell_hash_for(column_id id) const {
     if (_type == storage_type::vector) {

--- a/mutation_partition.cc
+++ b/mutation_partition.cc
@@ -728,44 +728,44 @@ void write_counter_cell(RowWriter& w, const query::partition_slice& slice, ::ato
   });
 }
 
-    template<typename Hasher>
-    void appending_hash<row>::operator()(Hasher& h, const row& cells, const schema& s, column_kind kind, const query::column_id_vector& columns, max_timestamp& max_ts) const {
-        for (auto id : columns) {
-            const cell_and_hash* cell_and_hash = cells.find_cell_and_hash(id);
-            if (!cell_and_hash) {
-                return;
-            }
-            auto&& def = s.column_at(kind, id);
-            if (def.is_atomic()) {
-                max_ts.update(cell_and_hash->cell.as_atomic_cell(def).timestamp());
-                if constexpr (query::using_hash_of_hash_v<Hasher>) {
-                    if (cell_and_hash->hash) {
-                        feed_hash(h, *cell_and_hash->hash);
-                    } else {
-                        query::default_hasher cellh;
-                        feed_hash(cellh, cell_and_hash->cell.as_atomic_cell(def), def);
-                        feed_hash(h, cellh.finalize_uint64());
-                    }
+template<typename Hasher>
+void appending_hash<row>::operator()(Hasher& h, const row& cells, const schema& s, column_kind kind, const query::column_id_vector& columns, max_timestamp& max_ts) const {
+    for (auto id : columns) {
+        const cell_and_hash* cell_and_hash = cells.find_cell_and_hash(id);
+        if (!cell_and_hash) {
+            return;
+        }
+        auto&& def = s.column_at(kind, id);
+        if (def.is_atomic()) {
+            max_ts.update(cell_and_hash->cell.as_atomic_cell(def).timestamp());
+            if constexpr (query::using_hash_of_hash_v<Hasher>) {
+                if (cell_and_hash->hash) {
+                    feed_hash(h, *cell_and_hash->hash);
                 } else {
-                    feed_hash(h, cell_and_hash->cell.as_atomic_cell(def), def);
+                    query::default_hasher cellh;
+                    feed_hash(cellh, cell_and_hash->cell.as_atomic_cell(def), def);
+                    feed_hash(h, cellh.finalize_uint64());
                 }
             } else {
-                auto cm = cell_and_hash->cell.as_collection_mutation();
-                max_ts.update(cm.last_update(*def.type));
-                if constexpr (query::using_hash_of_hash_v<Hasher>) {
-                    if (cell_and_hash->hash) {
-                        feed_hash(h, *cell_and_hash->hash);
-                    } else {
-                        query::default_hasher cellh;
-                        feed_hash(cellh, cm, def);
-                        feed_hash(h, cellh.finalize_uint64());
-                    }
+                feed_hash(h, cell_and_hash->cell.as_atomic_cell(def), def);
+            }
+        } else {
+            auto cm = cell_and_hash->cell.as_collection_mutation();
+            max_ts.update(cm.last_update(*def.type));
+            if constexpr (query::using_hash_of_hash_v<Hasher>) {
+                if (cell_and_hash->hash) {
+                    feed_hash(h, *cell_and_hash->hash);
                 } else {
-                    feed_hash(h, cm, def);
+                    query::default_hasher cellh;
+                    feed_hash(cellh, cm, def);
+                    feed_hash(h, cellh.finalize_uint64());
                 }
+            } else {
+                feed_hash(h, cm, def);
             }
         }
     }
+}
 
 cell_hash_opt row::cell_hash_for(column_id id) const {
     if (_type == storage_type::vector) {

--- a/mutation_partition.cc
+++ b/mutation_partition.cc
@@ -733,7 +733,8 @@ void appending_hash<row>::operator()(Hasher& h, const row& cells, const schema& 
     for (auto id : columns) {
         const cell_and_hash* cell_and_hash = cells.find_cell_and_hash(id);
         if (!cell_and_hash) {
-            return;
+            feed_hash(h, appending_hash<row>::null_hash_value);
+            continue;
         }
         auto&& def = s.column_at(kind, id);
         if (def.is_atomic()) {
@@ -762,6 +763,39 @@ void appending_hash<row>::operator()(Hasher& h, const row& cells, const schema& 
                 }
             } else {
                 feed_hash(h, cm, def);
+            }
+        }
+    }
+}
+// Instantiation for mutation_test.cc
+template void appending_hash<row>::operator()<xx_hasher>(xx_hasher& h, const row& cells, const schema& s, column_kind kind, const query::column_id_vector& columns, max_timestamp& max_ts) const;
+
+template<>
+void appending_hash<row>::operator()<legacy_xx_hasher_without_null_digest>(legacy_xx_hasher_without_null_digest& h, const row& cells, const schema& s, column_kind kind, const query::column_id_vector& columns, max_timestamp& max_ts) const {
+    for (auto id : columns) {
+        const cell_and_hash* cell_and_hash = cells.find_cell_and_hash(id);
+        if (!cell_and_hash) {
+            return;
+        }
+        auto&& def = s.column_at(kind, id);
+        if (def.is_atomic()) {
+            max_ts.update(cell_and_hash->cell.as_atomic_cell(def).timestamp());
+            if (cell_and_hash->hash) {
+                feed_hash(h, *cell_and_hash->hash);
+            } else {
+                query::default_hasher cellh;
+                feed_hash(cellh, cell_and_hash->cell.as_atomic_cell(def), def);
+                feed_hash(h, cellh.finalize_uint64());
+            }
+        } else {
+            auto cm = cell_and_hash->cell.as_collection_mutation();
+            max_ts.update(cm.last_update(*def.type));
+            if (cell_and_hash->hash) {
+                feed_hash(h, *cell_and_hash->hash);
+            } else {
+                query::default_hasher cellh;
+                feed_hash(cellh, cm, def);
+                feed_hash(h, cellh.finalize_uint64());
             }
         }
     }

--- a/mutation_partition.hh
+++ b/mutation_partition.hh
@@ -659,6 +659,7 @@ struct max_timestamp {
 
 template<>
 struct appending_hash<row> {
+    static constexpr int null_hash_value = 0xbeefcafe;
     template<typename Hasher>
     void operator()(Hasher& h, const row& cells, const schema& s, column_kind kind, const query::column_id_vector& columns, max_timestamp& max_ts) const;
 };

--- a/mutation_partition.hh
+++ b/mutation_partition.hh
@@ -648,6 +648,21 @@ public:
     };
 };
 
+// Used to return the timestamp of the latest update to the row
+struct max_timestamp {
+    api::timestamp_type max = api::missing_timestamp;
+
+    void update(api::timestamp_type ts) {
+        max = std::max(max, ts);
+    }
+};
+
+template<>
+struct appending_hash<row> {
+    template<typename Hasher>
+    void operator()(Hasher& h, const row& cells, const schema& s, column_kind kind, const query::column_id_vector& columns, max_timestamp& max_ts) const;
+};
+
 class row_marker;
 int compare_row_marker_for_merge(const row_marker& left, const row_marker& right) noexcept;
 

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -125,7 +125,7 @@ using fbu = utils::fb_utilities;
 static inline
 query::digest_algorithm digest_algorithm(service::storage_proxy& proxy) {
     return proxy.features().cluster_supports_xxhash_digest_algorithm()
-         ? query::digest_algorithm::xxHash
+         ? query::digest_algorithm::legacy_xxHash_without_null_digest
          : query::digest_algorithm::MD5;
 }
 

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -124,9 +124,11 @@ using fbu = utils::fb_utilities;
 
 static inline
 query::digest_algorithm digest_algorithm(service::storage_proxy& proxy) {
-    return proxy.features().cluster_supports_xxhash_digest_algorithm()
-         ? query::digest_algorithm::legacy_xxHash_without_null_digest
-         : query::digest_algorithm::MD5;
+    return proxy.features().cluster_supports_digest_for_null_values()
+            ? query::digest_algorithm::xxHash
+            : proxy.features().cluster_supports_xxhash_digest_algorithm()
+                    ? query::digest_algorithm::legacy_xxHash_without_null_digest
+                    : query::digest_algorithm::MD5;
 }
 
 static inline

--- a/test/boost/mutation_test.cc
+++ b/test/boost/mutation_test.cc
@@ -3038,3 +3038,36 @@ SEASTAR_THREAD_TEST_CASE(test_compaction_data_stream_split) {
         run_compaction_data_stream_split_test(schema, query_time, mutations);
     }
 }
+
+// Reproducer for #4567: "appending_hash<row> ignores cells after first null"
+SEASTAR_THREAD_TEST_CASE(test_appending_hash_row_4567) {
+    auto s = schema_builder("ks", "cf")
+        .with_column("pk", bytes_type, column_kind::partition_key)
+        .with_column("ck", bytes_type, column_kind::clustering_key)
+        .with_column("r1", bytes_type)
+        .with_column("r2", bytes_type)
+        .with_column("r3", bytes_type)
+        .build();
+
+    auto r1 = row();
+    r1.append_cell(0, atomic_cell::make_live(*bytes_type, 1, bytes{}));
+    r1.append_cell(2, atomic_cell::make_live(*bytes_type, 1, to_bytes("aaa")));
+
+    auto r2 = row();
+    r2.append_cell(0, atomic_cell::make_live(*bytes_type, 1, bytes{}));
+    r2.append_cell(2, atomic_cell::make_live(*bytes_type, 1, to_bytes("bbb")));
+
+    BOOST_CHECK(!r1.equal(column_kind::regular_column, *s, r2, *s));
+
+    auto compute_hash = [&] (const row& r, const query::column_id_vector& columns) {
+        auto hasher = xx_hasher{};
+        max_timestamp ts;
+        appending_hash<row>{}(hasher, r, *s, column_kind::regular_column, columns, ts);
+        return hasher.finalize_uint64();
+    };
+
+    BOOST_CHECK_EQUAL(compute_hash(r1, { 1 }), compute_hash(r2, { 1 }));
+    BOOST_CHECK_EQUAL(compute_hash(r1, { 0, 1 }), compute_hash(r2, { 0, 1 }));
+    BOOST_CHECK_NE(compute_hash(r1, { 0, 2 }), compute_hash(r2, { 0, 2 }));
+    BOOST_CHECK_NE(compute_hash(r1, { 0, 1, 2 }), compute_hash(r2, { 0, 1, 2 }));
+}

--- a/test/boost/mutation_test.cc
+++ b/test/boost/mutation_test.cc
@@ -3057,8 +3057,18 @@ SEASTAR_THREAD_TEST_CASE(test_appending_hash_row_4567) {
     r2.append_cell(0, atomic_cell::make_live(*bytes_type, 1, bytes{}));
     r2.append_cell(2, atomic_cell::make_live(*bytes_type, 1, to_bytes("bbb")));
 
+    auto r3 = row();
+    r3.append_cell(0, atomic_cell::make_live(*bytes_type, 1, bytes{}));
+    r3.append_cell(1, atomic_cell::make_live(*bytes_type, 1, to_bytes("bbb")));
+
     BOOST_CHECK(!r1.equal(column_kind::regular_column, *s, r2, *s));
 
+    auto compute_legacy_hash = [&] (const row& r, const query::column_id_vector& columns) {
+        auto hasher = legacy_xx_hasher_without_null_digest{};
+        max_timestamp ts;
+        appending_hash<row>{}(hasher, r, *s, column_kind::regular_column, columns, ts);
+        return hasher.finalize_uint64();
+    };
     auto compute_hash = [&] (const row& r, const query::column_id_vector& columns) {
         auto hasher = xx_hasher{};
         max_timestamp ts;
@@ -3070,4 +3080,10 @@ SEASTAR_THREAD_TEST_CASE(test_appending_hash_row_4567) {
     BOOST_CHECK_EQUAL(compute_hash(r1, { 0, 1 }), compute_hash(r2, { 0, 1 }));
     BOOST_CHECK_NE(compute_hash(r1, { 0, 2 }), compute_hash(r2, { 0, 2 }));
     BOOST_CHECK_NE(compute_hash(r1, { 0, 1, 2 }), compute_hash(r2, { 0, 1, 2 }));
+    // Additional test for making sure that {"", NULL, "bbb"} is not equal to {"", "bbb", NULL}
+    // due to ignoring NULL in a hash
+    BOOST_CHECK_NE(compute_hash(r2, { 0, 1, 2 }), compute_hash(r3, { 0, 1, 2 }));
+    // Legacy check which shows incorrect handling of NULL values.
+    // These checks are meaningful because legacy hashing is still used for old nodes.
+    BOOST_CHECK_EQUAL(compute_legacy_hash(r1, { 0, 1, 2 }), compute_legacy_hash(r2, { 0, 1, 2 }));
 }

--- a/xx_hasher.hh
+++ b/xx_hasher.hh
@@ -67,3 +67,10 @@ private:
         serialize_int64(out, finalize_uint64());
     }
 };
+
+// Used to specialize templates in order to fix a bug
+// in handling null values: #4567
+class legacy_xx_hasher_without_null_digest : public xx_hasher {
+public:
+    explicit legacy_xx_hasher_without_null_digest(uint64_t seed = 0) noexcept : xx_hasher(seed) {}
+};


### PR DESCRIPTION
This series fixes a bug in `appending_hash<row>` that caused it to ignore any cells after the first NULL. It also adds a cluster feature which starts using the new hashing only after the whole cluster is aware of it. The series comes with tests, which reproduce the issue.

Fixes #4567
Based on #4574
