### PR TITLE
gossiper: Run echo message handler on all shards

### DIFF
--- a/gms/gossiper.cc
+++ b/gms/gossiper.cc
@@ -418,7 +418,6 @@ future<> gossiper::handle_ack2_msg(gossip_digest_ack2 msg) {
 }
 
 future<> gossiper::handle_echo_msg() {
-    set_last_processed_message_at();
     return make_ready_future<>();
 }
 
@@ -491,9 +490,7 @@ future<> gossiper::init_messaging_service_handler(bind_messaging_port do_bind) {
         return messaging_service::no_wait();
     });
     _messaging.register_gossip_echo([] {
-        return smp::submit_to(0, [] {
-            return gms::get_local_gossiper().handle_echo_msg();
-        });
+        return gms::get_local_gossiper().handle_echo_msg();
     });
     _messaging.register_gossip_shutdown([] (inet_address from) {
         // In a new fiber.

--- a/gms/gossiper.cc
+++ b/gms/gossiper.cc
@@ -159,14 +159,6 @@ gossiper::gossiper(abort_source& as, feature_service& features, const locator::t
     });
 }
 
-void gossiper::set_last_processed_message_at() {
-    set_last_processed_message_at(now());
-}
-
-void gossiper::set_last_processed_message_at(clk::time_point tp) {
-    _last_processed_message_at = tp;
-}
-
 /*
  * First construct a map whose key is the endpoint in the GossipDigest and the value is the
  * GossipDigest itself. Then build a list of version differences i.e difference between the
@@ -211,7 +203,6 @@ void gossiper::do_sort(utils::chunked_vector<gossip_digest>& g_digest_list) {
 future<> gossiper::handle_syn_msg(msg_addr from, gossip_digest_syn syn_msg) {
     logger.trace("handle_syn_msg():from={},cluster_name:peer={},local={},partitioner_name:peer={},local={}",
         from, syn_msg.cluster_id(), get_cluster_name(), syn_msg.partioner(), get_partitioner_name());
-    this->set_last_processed_message_at();
     if (!this->is_enabled()) {
         return make_ready_future<>();
     }
@@ -306,7 +297,6 @@ private:
 future<> gossiper::handle_ack_msg(msg_addr id, gossip_digest_ack ack_msg) {
     logger.trace("handle_ack_msg():from={},msg={}", id, ack_msg);
 
-    this->set_last_processed_message_at();
     if (!this->is_enabled() && !this->is_in_shadow_round()) {
         return make_ready_future<>();
     }
@@ -404,7 +394,6 @@ future<> gossiper::do_send_ack2_msg(msg_addr from, utils::chunked_vector<gossip_
 // - on_alive callbacks
 future<> gossiper::handle_ack2_msg(gossip_digest_ack2 msg) {
     logger.trace("handle_ack2_msg():msg={}", msg);
-    set_last_processed_message_at();
     if (!is_enabled()) {
         return make_ready_future<>();
     }
@@ -422,7 +411,6 @@ future<> gossiper::handle_echo_msg() {
 }
 
 future<> gossiper::handle_shutdown_msg(inet_address from) {
-    set_last_processed_message_at();
     if (!is_enabled()) {
         logger.debug("Ignoring shutdown message from {} because gossip is disabled", from);
         return make_ready_future<>();
@@ -1415,7 +1403,6 @@ void gossiper::mark_alive(inet_address addr, endpoint_state& local_state) {
     // Do it in the background.
     (void)_messaging.send_gossip_echo(id).then([this, addr] {
         logger.trace("Got EchoMessage Reply");
-        set_last_processed_message_at();
         return seastar::async([this, addr] {
             // After sending echo message, the Node might not be in the
             // endpoint_state_map anymore, use the reference of local_state

--- a/gms/gossiper.hh
+++ b/gms/gossiper.hh
@@ -222,8 +222,6 @@ private:
 
     bool _in_shadow_round = false;
 
-    clk::time_point _last_processed_message_at = now();
-
     std::unordered_map<inet_address, clk::time_point> _shadow_unreachable_endpoints;
     utils::chunked_vector<inet_address> _shadow_live_endpoints;
 
@@ -239,9 +237,6 @@ private:
     future<> replicate(inet_address, application_state key, const versioned_value& value);
 public:
     explicit gossiper(abort_source& as, feature_service& features, const locator::token_metadata& tokens, netw::messaging_service& ms, db::config& cfg);
-
-    void set_last_processed_message_at();
-    void set_last_processed_message_at(clk::time_point tp);
 
     void check_seen_seeds();
 


### PR DESCRIPTION
Echo message does not need to access gossip internal states. 
Yes, set_last_processed_message_at() is called but it is not really used. 
So we can run it on all shards and avoid forwarding to shard zero.

This makes gossip marking node up more robust when shard zero is loaded.

Refs: #7197
