### PR TITLE
dist/common/scripts: skip internet access on offline installation

### DIFF
--- a/dist/common/scripts/scylla_coredump_setup
+++ b/dist/common/scripts/scylla_coredump_setup
@@ -46,7 +46,7 @@ if __name__ == '__main__':
 # Other distributions can use systemd-coredump, so setup it
     else:
         if is_debian_variant():
-            run('apt-get install -y systemd-coredump')
+            apt_install('systemd-coredump')
         conf_data = '''
 [Coredump]
 Storage=external

--- a/dist/common/scripts/scylla_cpuscaling_setup
+++ b/dist/common/scripts/scylla_cpuscaling_setup
@@ -33,7 +33,8 @@ if __name__ == '__main__':
         print('This computer doesn\'t supported CPU scaling configuration.')
         sys.exit(0)
     if is_debian_variant():
-        run('apt-get install -y cpufrequtils')
+        if not shutil.which('cpufreq-set'):
+            apt_install('cpufrequtils')
         cfg = sysconfig_parser('/etc/default/cpufrequtils')
         cfg.set('GOVERNOR', 'performance')
         cfg.commit()
@@ -41,7 +42,8 @@ if __name__ == '__main__':
         cpufreq.enable()
         cpufreq.restart()
     if is_gentoo_variant():
-        run('emerge -uq sys-power/cpupower')
+        if not shutil.which('cpupower'):
+            emerge_install('sys-power/cpupower')
         with open('/etc/conf.d/cpupower') as f:
             cur = f.read()
         new = re.sub(r'--governor ondemand', '--governor performance', cur, flags=re.MULTILINE)
@@ -55,7 +57,8 @@ if __name__ == '__main__':
             run('rc-update add cpupower default')
             run('rc-service cpupower start')
     if is_amzn2():
-        run('yum install -y cpupowerutils')
+        if not shutil.which('cpupower'):
+            yum_install('cpupowerutils')
         cfg = sysconfig_parser('/etc/sysconfig/scylla-cpupower')
         cfg.set('CPUPOWER_START_OPTS', 'frequency-set -g performance')
         cfg.set('CPUPOWER_STOP_OPTS', 'frequency-set -g ondemand')
@@ -79,7 +82,8 @@ ExecStop=/usr/bin/cpupower $CPUPOWER_STOP_OPTS
         cpupwr.enable()
         cpupwr.restart()
     elif is_redhat_variant():
-        run('yum install -y cpupowerutils')
+        if not shutil.which('cpupower'):
+            yum_install('cpupowerutils')
         cfg = sysconfig_parser('/etc/sysconfig/cpupower')
         cfg.set('CPUPOWER_START_OPTS', 'frequency-set -g performance')
         cfg.set('CPUPOWER_STOP_OPTS', 'frequency-set -g ondemand')

--- a/dist/common/scripts/scylla_kernel_check
+++ b/dist/common/scripts/scylla_kernel_check
@@ -31,12 +31,7 @@ if __name__ == '__main__':
         sys.exit(1)
 
     if not shutil.which('mkfs.xfs'):
-        if is_debian_variant():
-            run('apt-get install -y xfsprogs')
-        elif is_gentoo_variant():
-            run('emerge -uq sys-fs/xfsprogs')
-        elif is_redhat_variant():
-            run('yum install -y xfsprogs')
+        pkg_install('xfsprogs')
 
     makedirs('/var/tmp/mnt')
     run('dd if=/dev/zero of=/var/tmp/kernel-check.img bs=1M count=128', silent=True)

--- a/dist/common/scripts/scylla_ntp_setup
+++ b/dist/common/scripts/scylla_ntp_setup
@@ -43,7 +43,7 @@ if __name__ == '__main__':
 
     if is_debian_variant():
         if not shutil.which('ntpd') or not shutil.which('ntpdate'):
-            run('apt-get install -y ntp ntpdate')
+            apt_install('ntp ntpdate')
         with open('/etc/ntp.conf') as f:
             conf = f.read()
         if not re.match(r'^server ', conf, flags=re.MULTILINE):
@@ -59,7 +59,7 @@ if __name__ == '__main__':
 
     if is_gentoo_variant():
         if not shutil.which('ntpd'):
-            run('emerge -uq net-misc/ntp')
+            emerge_install('net-misc/ntp')
         with open('/etc/ntp.conf') as f:
             conf = f.read()
         match = re.search(r'^server\s+(\S*)(\s+\S+)?', conf, flags=re.MULTILINE)
@@ -80,7 +80,7 @@ if __name__ == '__main__':
     if is_redhat_variant():
         if int(distro.major_version()) >= 8:
             if not shutil.which('chronyd'):
-                run('dnf install -y chrony')
+                yum_install('chrony')
             with open('/etc/chrony.conf') as f:
                 conf = f.read()
             if args.subdomain:
@@ -94,7 +94,7 @@ if __name__ == '__main__':
             run('chronyc makestep')
         else:
             if not shutil.which('ntpd') or not shutil.which('ntpdate'):
-                run('yum install -y ntp ntpdate')
+                yum_install('ntp ntpdate')
             with open('/etc/ntp.conf') as f:
                 conf = f.read()
             if args.subdomain:

--- a/dist/common/scripts/scylla_ntp_setup
+++ b/dist/common/scripts/scylla_ntp_setup
@@ -26,6 +26,7 @@ import argparse
 import subprocess
 import re
 import distro
+import shutil
 
 from scylla_util import *
 
@@ -41,7 +42,7 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     if is_debian_variant():
-        if not os.path.exists('/usr/sbin/ntpd') or not os.path.exists('/usr/sbin/ntpdate'):
+        if not shutil.which('ntpd') or not shutil.which('ntpdate'):
             run('apt-get install -y ntp ntpdate')
         with open('/etc/ntp.conf') as f:
             conf = f.read()
@@ -57,7 +58,7 @@ if __name__ == '__main__':
         ntp.start()
 
     if is_gentoo_variant():
-        if not os.path.exists('/usr/sbin/ntpd'):
+        if not shutil.which('ntpd'):
             run('emerge -uq net-misc/ntp')
         with open('/etc/ntp.conf') as f:
             conf = f.read()
@@ -78,7 +79,7 @@ if __name__ == '__main__':
 
     if is_redhat_variant():
         if int(distro.major_version()) >= 8:
-            if not os.path.exists('/usr/sbin/chronyd'):
+            if not shutil.which('chronyd'):
                 run('dnf install -y chrony')
             with open('/etc/chrony.conf') as f:
                 conf = f.read()
@@ -92,7 +93,7 @@ if __name__ == '__main__':
             chronyd.restart()
             run('chronyc makestep')
         else:
-            if not os.path.exists('/usr/sbin/ntpd') or not os.path.exists('/usr/sbin/ntpdate'):
+            if not shutil.which('ntpd') or not shutil.which('ntpdate'):
                 run('yum install -y ntp ntpdate')
             with open('/etc/ntp.conf') as f:
                 conf = f.read()

--- a/dist/common/scripts/scylla_raid_setup
+++ b/dist/common/scripts/scylla_raid_setup
@@ -86,18 +86,12 @@ if __name__ == '__main__':
         print('mount unit {} already exists'.format(mntunit))
         sys.exit(1)
 
-    if is_debian_variant():
-        run('env DEBIAN_FRONTEND=noninteractive apt-get -y install mdadm xfsprogs')
-        try:
-            md_service = systemd_unit('mdmonitor.service')
-        except SystemdException:
-            md_service = systemd_unit('mdadm.service')
-    elif is_redhat_variant():
-        run('yum install -y mdadm xfsprogs')
+    if not shutil.which('mkfs.xfs') or not shutil.which('mdadm'):
+        pkg_install('xfsprogs mdadm')
+    try:
         md_service = systemd_unit('mdmonitor.service')
-    elif is_gentoo_variant():
-        run('emerge -uq sys-fs/mdadm sys-fs/xfsprogs')
-        md_service = systemd_unit('mdmonitor.service')
+    except SystemdException:
+        md_service = systemd_unit('mdadm.service')
 
     if len(disks) == 1 and not args.force_raid:
         raid = False

--- a/dist/common/scripts/scylla_setup
+++ b/dist/common/scripts/scylla_setup
@@ -165,15 +165,58 @@ def run_setup_script(name, script):
             sys.exit(1)
     return res
 
+def warn_offline(setup):
+    colorprint('{red}{setup} is disabled by default, since the installation is offline mode.{nocolor}', setup=setup)
+
+def warn_offline_missing_pkg(setup, pkg):
+    colorprint('{red}{setup} disabled by default, since {pkg} not available.{nocolor}', setup=setup, pkg=pkg)
+
 if __name__ == '__main__':
     if not is_nonroot() and os.getuid() > 0:
         print('Requires root permission.')
         sys.exit(1)
+
+    default_no_ntp_setup = False
+    default_no_node_exporter = False
+    default_no_kernel_check = False
+    default_no_raid_setup = False
+    default_no_coredump_setup = False
+    default_no_cpuscaling_setup = False
+
+    if is_offline():
+        default_no_ntp_setup = True
+        default_no_node_exporter = True
+        warn_offline('ntp setup')
+        warn_offline('node exporter setup')
+
+        if not shutil.which('mkfs.xfs'):
+            default_no_kernel_check = True
+            default_no_raid_setup = True
+            warn_offline_missing_pkg('kernel version check', 'xfsprogs')
+            warn_offline_missing_pkg('RAID setup', 'xfsprogs')
+
+        if not default_no_raid_setup and not shutil.which('mdadm'):
+            default_no_raid_setup = True
+            warn_offline_missing_pkg('RAID setup', 'mdadm')
+
+        if not shutil.which('coredumpctl'):
+            default_no_coredump_setup = True
+            warn_offline_missing_pkg('coredump setup', 'systemd-coredump')
+
+        if is_debian_variant() and not shutil.which('cpufreq-set'):
+            default_no_cpuscaling_setup = True
+            warn_offline_missing_pkg('cpuscaling setup', 'cpufrequtils')
+        elif not shutil.which('cpupower'):
+            default_no_cpuscaling_setup = True
+            warn_offline_missing_pkg('cpuscaling setup', 'cpupower')
+        print()
+
     parser = argparse.ArgumentParser(description='Configure environment for Scylla.')
     group = parser.add_mutually_exclusive_group(required=True)
     group.add_argument('--disks',
                         help='specify disks for RAID')
-    group.add_argument('--no-raid-setup', action='store_true', default=False,
+    group.add_argument('--no-raid-setup', action='store_true',
+                        default=default_no_raid_setup,
                         help='skip raid setup')
     parser.add_argument('--nic',
                         help='specify NIC')
@@ -191,7 +234,8 @@ if __name__ == '__main__':
                         help='enable developer mode')
     parser.add_argument('--no-ec2-check', action='store_true', default=False,
                         help='skip EC2 configuration check')
-    parser.add_argument('--no-kernel-check', action='store_true', default=False,
+    parser.add_argument('--no-kernel-check', action='store_true',
+                        default=default_no_kernel_check,
                         help='skip kernel version check')
     parser.add_argument('--no-verify-package', action='store_true', default=False,
                         help='skip verifying packages')
@@ -202,9 +246,11 @@ if __name__ == '__main__':
                             help='skip selinux setup')
     parser.add_argument('--no-bootparam-setup', action='store_true', default=False,
                         help='skip bootparam setup')
-    parser.add_argument('--no-ntp-setup', action='store_true', default=False,
+    parser.add_argument('--no-ntp-setup', action='store_true',
+                        default=default_no_ntp_setup,
                         help='skip ntp setup')
-    parser.add_argument('--no-coredump-setup', action='store_true', default=False,
+    parser.add_argument('--no-coredump-setup', action='store_true',
+                        default=default_no_coredump_setup,
                         help='skip coredump setup')
     parser.add_argument('--no-sysconfig-setup', action='store_true', default=False,
                         help='skip sysconfig setup')
@@ -214,9 +260,11 @@ if __name__ == '__main__':
                         help='skip IO configuration setup')
     parser.add_argument('--no-version-check', action='store_true', default=False,
                         help='skip daily version check')
-    parser.add_argument('--no-node-exporter', action='store_true', default=False,
+    parser.add_argument('--no-node-exporter', action='store_true',
+                        default=default_no_node_exporter,
                         help='do not install the node exporter')
-    parser.add_argument('--no-cpuscaling-setup', action='store_true', default=False,
+    parser.add_argument('--no-cpuscaling-setup', action='store_true',
+                        default=default_no_cpuscaling_setup,
                         help='skip cpu scaling setup')
     parser.add_argument('--no-fstrim-setup', action='store_true', default=False,
                         help='skip fstrim setup')


### PR DESCRIPTION
We need to skip internet access on offline installation.
To do this we need following changes:
 - prevent running yum/apt for each script
 - set default "NO" for scripts it requires package installation
 - set default "NO" for scripts it requires internet access, such as NTP

See #7153