### PR TITLE
[DONOTMERGE] scylla_cpuscaling_setup: use scylla-cpupower.service on all distributions

### DIFF
--- a/dist/common/scripts/scylla_coredump_setup
+++ b/dist/common/scripts/scylla_coredump_setup
@@ -46,7 +46,7 @@ if __name__ == '__main__':
 # Other distributions can use systemd-coredump, so setup it
     else:
         if is_debian_variant():
-            run('apt-get install -y systemd-coredump')
+            apt_install('systemd-coredump')
         conf_data = '''
 [Coredump]
 Storage=external

--- a/dist/common/scripts/scylla_cpuscaling_setup
+++ b/dist/common/scripts/scylla_cpuscaling_setup
@@ -58,6 +58,9 @@ RemainAfterExit=yes
 EnvironmentFile=/etc/sysconfig/scylla-cpupower
 ExecStart=/usr/bin/cpupower $CPUPOWER_START_OPTS
 ExecStop=/usr/bin/cpupower $CPUPOWER_STOP_OPTS
+
+[Install]
+WantedBy=multi-user.target
 '''[1:-1]
     with open('/etc/systemd/system/scylla-cpupower.service', 'w') as f:
         f.write(unit_data)

--- a/dist/common/scripts/scylla_cpuscaling_setup
+++ b/dist/common/scripts/scylla_cpuscaling_setup
@@ -23,6 +23,7 @@
 import os
 import sys
 import shlex
+import shutil
 from scylla_util import *
 
 if __name__ == '__main__':
@@ -33,37 +34,20 @@ if __name__ == '__main__':
         print('This computer doesn\'t supported CPU scaling configuration.')
         sys.exit(0)
     if is_debian_variant():
-        if not shutil.which('cpufreq-set'):
-            apt_install('cpufrequtils')
-        cfg = sysconfig_parser('/etc/default/cpufrequtils')
-        cfg.set('GOVERNOR', 'performance')
-        cfg.commit()
-        cpufreq = systemd_unit('cpufrequtils.service')
-        cpufreq.enable()
-        cpufreq.restart()
-    if is_gentoo_variant():
+        if not shutil.which('cpupower'):
+            apt_install('linux-cpupower')
+    elif is_gentoo_variant():
         if not shutil.which('cpupower'):
             emerge_install('sys-power/cpupower')
-        with open('/etc/conf.d/cpupower') as f:
-            cur = f.read()
-        new = re.sub(r'--governor ondemand', '--governor performance', cur, flags=re.MULTILINE)
-        with open('/etc/conf.d/cpupower', 'w') as f:
-            f.write(new)
-        if is_systemd():
-            cpufreq = systemd_unit('cpupower-frequency-set.service')
-            cpufreq.enable()
-            cpufreq.restart()
-        else:
-            run('rc-update add cpupower default')
-            run('rc-service cpupower start')
-    if is_amzn2():
+    elif is_redhat_variant():
         if not shutil.which('cpupower'):
             yum_install('cpupowerutils')
-        cfg = sysconfig_parser('/etc/sysconfig/scylla-cpupower')
-        cfg.set('CPUPOWER_START_OPTS', 'frequency-set -g performance')
-        cfg.set('CPUPOWER_STOP_OPTS', 'frequency-set -g ondemand')
-        cfg.commit()
-        unit_data = '''
+
+    cfg = sysconfig_parser('/etc/sysconfig/scylla-cpupower')
+    cfg.set('CPUPOWER_START_OPTS', 'frequency-set -g performance')
+    cfg.set('CPUPOWER_STOP_OPTS', 'frequency-set -g ondemand')
+    cfg.commit()
+    unit_data = '''
 [Unit]
 Description=Scylla cpupower service
 After=syslog.target
@@ -75,19 +59,15 @@ EnvironmentFile=/etc/sysconfig/scylla-cpupower
 ExecStart=/usr/bin/cpupower $CPUPOWER_START_OPTS
 ExecStop=/usr/bin/cpupower $CPUPOWER_STOP_OPTS
 '''[1:-1]
-        with open('/etc/systemd/system/scylla-cpupower.service', 'w') as f:
-            f.write(unit_data)
-        systemd_unit.reload()
-        cpupwr = systemd_unit('scylla-cpupower.service')
-        cpupwr.enable()
-        cpupwr.restart()
-    elif is_redhat_variant():
-        if not shutil.which('cpupower'):
-            yum_install('cpupowerutils')
-        cfg = sysconfig_parser('/etc/sysconfig/cpupower')
-        cfg.set('CPUPOWER_START_OPTS', 'frequency-set -g performance')
-        cfg.set('CPUPOWER_STOP_OPTS', 'frequency-set -g ondemand')
-        cfg.commit()
+    with open('/etc/systemd/system/scylla-cpupower.service', 'w') as f:
+        f.write(unit_data)
+    systemd_unit.reload()
+    # disable distro default service if it exists
+    try:
         cpupwr = systemd_unit('cpupower.service')
-        cpupwr.enable()
-        cpupwr.restart()
+        cpupwr.disable()
+    except:
+        pass
+    cpupwr = systemd_unit('scylla-cpupower.service')
+    cpupwr.enable()
+    cpupwr.restart()

--- a/dist/common/scripts/scylla_cpuscaling_setup
+++ b/dist/common/scripts/scylla_cpuscaling_setup
@@ -33,7 +33,8 @@ if __name__ == '__main__':
         print('This computer doesn\'t supported CPU scaling configuration.')
         sys.exit(0)
     if is_debian_variant():
-        run('apt-get install -y cpufrequtils')
+        if not shutil.which('cpufreq-set'):
+            apt_install('cpufrequtils')
         cfg = sysconfig_parser('/etc/default/cpufrequtils')
         cfg.set('GOVERNOR', 'performance')
         cfg.commit()
@@ -41,7 +42,8 @@ if __name__ == '__main__':
         cpufreq.enable()
         cpufreq.restart()
     if is_gentoo_variant():
-        run('emerge -uq sys-power/cpupower')
+        if not shutil.which('cpupower'):
+            emerge_install('sys-power/cpupower')
         with open('/etc/conf.d/cpupower') as f:
             cur = f.read()
         new = re.sub(r'--governor ondemand', '--governor performance', cur, flags=re.MULTILINE)
@@ -55,7 +57,8 @@ if __name__ == '__main__':
             run('rc-update add cpupower default')
             run('rc-service cpupower start')
     if is_amzn2():
-        run('yum install -y cpupowerutils')
+        if not shutil.which('cpupower'):
+            yum_install('cpupowerutils')
         cfg = sysconfig_parser('/etc/sysconfig/scylla-cpupower')
         cfg.set('CPUPOWER_START_OPTS', 'frequency-set -g performance')
         cfg.set('CPUPOWER_STOP_OPTS', 'frequency-set -g ondemand')
@@ -79,7 +82,8 @@ ExecStop=/usr/bin/cpupower $CPUPOWER_STOP_OPTS
         cpupwr.enable()
         cpupwr.restart()
     elif is_redhat_variant():
-        run('yum install -y cpupowerutils')
+        if not shutil.which('cpupower'):
+            yum_install('cpupowerutils')
         cfg = sysconfig_parser('/etc/sysconfig/cpupower')
         cfg.set('CPUPOWER_START_OPTS', 'frequency-set -g performance')
         cfg.set('CPUPOWER_STOP_OPTS', 'frequency-set -g ondemand')

--- a/dist/common/scripts/scylla_kernel_check
+++ b/dist/common/scripts/scylla_kernel_check
@@ -31,12 +31,7 @@ if __name__ == '__main__':
         sys.exit(1)
 
     if not shutil.which('mkfs.xfs'):
-        if is_debian_variant():
-            run('apt-get install -y xfsprogs')
-        elif is_gentoo_variant():
-            run('emerge -uq sys-fs/xfsprogs')
-        elif is_redhat_variant():
-            run('yum install -y xfsprogs')
+        pkg_install('xfsprogs')
 
     makedirs('/var/tmp/mnt')
     run('dd if=/dev/zero of=/var/tmp/kernel-check.img bs=1M count=128', silent=True)

--- a/dist/common/scripts/scylla_ntp_setup
+++ b/dist/common/scripts/scylla_ntp_setup
@@ -43,7 +43,7 @@ if __name__ == '__main__':
 
     if is_debian_variant():
         if not shutil.which('ntpd') or not shutil.which('ntpdate'):
-            run('apt-get install -y ntp ntpdate')
+            apt_install('ntp ntpdate')
         with open('/etc/ntp.conf') as f:
             conf = f.read()
         if not re.match(r'^server ', conf, flags=re.MULTILINE):
@@ -59,7 +59,7 @@ if __name__ == '__main__':
 
     if is_gentoo_variant():
         if not shutil.which('ntpd'):
-            run('emerge -uq net-misc/ntp')
+            emerge_install('net-misc/ntp')
         with open('/etc/ntp.conf') as f:
             conf = f.read()
         match = re.search(r'^server\s+(\S*)(\s+\S+)?', conf, flags=re.MULTILINE)
@@ -80,7 +80,7 @@ if __name__ == '__main__':
     if is_redhat_variant():
         if int(distro.major_version()) >= 8:
             if not shutil.which('chronyd'):
-                run('dnf install -y chrony')
+                yum_install('chrony')
             with open('/etc/chrony.conf') as f:
                 conf = f.read()
             if args.subdomain:
@@ -94,7 +94,7 @@ if __name__ == '__main__':
             run('chronyc makestep')
         else:
             if not shutil.which('ntpd') or not shutil.which('ntpdate'):
-                run('yum install -y ntp ntpdate')
+                yum_install('ntp ntpdate')
             with open('/etc/ntp.conf') as f:
                 conf = f.read()
             if args.subdomain:

--- a/dist/common/scripts/scylla_ntp_setup
+++ b/dist/common/scripts/scylla_ntp_setup
@@ -26,6 +26,7 @@ import argparse
 import subprocess
 import re
 import distro
+import shutil
 
 from scylla_util import *
 
@@ -41,7 +42,7 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     if is_debian_variant():
-        if not os.path.exists('/usr/sbin/ntpd') or not os.path.exists('/usr/sbin/ntpdate'):
+        if not shutil.which('ntpd') or not shutil.which('ntpdate'):
             run('apt-get install -y ntp ntpdate')
         with open('/etc/ntp.conf') as f:
             conf = f.read()
@@ -57,7 +58,7 @@ if __name__ == '__main__':
         ntp.start()
 
     if is_gentoo_variant():
-        if not os.path.exists('/usr/sbin/ntpd'):
+        if not shutil.which('ntpd'):
             run('emerge -uq net-misc/ntp')
         with open('/etc/ntp.conf') as f:
             conf = f.read()
@@ -78,7 +79,7 @@ if __name__ == '__main__':
 
     if is_redhat_variant():
         if int(distro.major_version()) >= 8:
-            if not os.path.exists('/usr/sbin/chronyd'):
+            if not shutil.which('chronyd'):
                 run('dnf install -y chrony')
             with open('/etc/chrony.conf') as f:
                 conf = f.read()
@@ -92,7 +93,7 @@ if __name__ == '__main__':
             chronyd.restart()
             run('chronyc makestep')
         else:
-            if not os.path.exists('/usr/sbin/ntpd') or not os.path.exists('/usr/sbin/ntpdate'):
+            if not shutil.which('ntpd') or not shutil.which('ntpdate'):
                 run('yum install -y ntp ntpdate')
             with open('/etc/ntp.conf') as f:
                 conf = f.read()

--- a/dist/common/scripts/scylla_raid_setup
+++ b/dist/common/scripts/scylla_raid_setup
@@ -86,18 +86,12 @@ if __name__ == '__main__':
         print('mount unit {} already exists'.format(mntunit))
         sys.exit(1)
 
-    if is_debian_variant():
-        run('env DEBIAN_FRONTEND=noninteractive apt-get -y install mdadm xfsprogs')
-        try:
-            md_service = systemd_unit('mdmonitor.service')
-        except SystemdException:
-            md_service = systemd_unit('mdadm.service')
-    elif is_redhat_variant():
-        run('yum install -y mdadm xfsprogs')
+    if not shutil.which('mkfs.xfs') or not shutil.which('mdadm'):
+        pkg_install('xfsprogs mdadm')
+    try:
         md_service = systemd_unit('mdmonitor.service')
-    elif is_gentoo_variant():
-        run('emerge -uq sys-fs/mdadm sys-fs/xfsprogs')
-        md_service = systemd_unit('mdmonitor.service')
+    except SystemdException:
+        md_service = systemd_unit('mdadm.service')
 
     if len(disks) == 1 and not args.force_raid:
         raid = False

--- a/dist/common/scripts/scylla_setup
+++ b/dist/common/scripts/scylla_setup
@@ -188,9 +188,7 @@ if __name__ == '__main__':
         if not shutil.which('coredumpctl'):
             default_no_coredump_setup = True
 
-        if is_debian_variant() and not shutil.which('cpufreq-set'):
-            default_no_cpuscaling_setup = True
-        elif not shutil.which('cpupower'):
+        if not shutil.which('cpupower'):
             default_no_cpuscaling_setup = True
 
     parser = argparse.ArgumentParser(description='Configure environment for Scylla.')

--- a/dist/common/scripts/scylla_setup
+++ b/dist/common/scripts/scylla_setup
@@ -169,11 +169,36 @@ if __name__ == '__main__':
     if not is_nonroot() and os.getuid() > 0:
         print('Requires root permission.')
         sys.exit(1)
+
+    if is_offline():
+        default_no_ntp_setup = True
+        default_no_node_exporter = True
+        default_no_kernel_check = False
+        default_no_raid_setup = False
+        default_no_coredump_setup = False
+        default_no_cpuscaling_setup = False
+
+        if not shutil.which('mkfs.xfs'):
+            default_no_kernel_check = True
+            default_no_raid_setup = True
+
+        if not shutil.which('mdadm'):
+            default_no_raid_setup = True
+
+        if not shutil.which('coredumpctl'):
+            default_no_coredump_setup = True
+
+        if is_debian_variant() and not shutil.which('cpufreq-set'):
+            default_no_cpuscaling_setup = True
+        elif not shutil.which('cpupower'):
+            default_no_cpuscaling_setup = True
+
     parser = argparse.ArgumentParser(description='Configure environment for Scylla.')
     group = parser.add_mutually_exclusive_group(required=True)
     group.add_argument('--disks',
                         help='specify disks for RAID')
-    group.add_argument('--no-raid-setup', action='store_true', default=False,
+    group.add_argument('--no-raid-setup', action='store_true',
+                        default=default_no_raid_setup,
                         help='skip raid setup')
     parser.add_argument('--nic',
                         help='specify NIC')
@@ -191,7 +216,8 @@ if __name__ == '__main__':
                         help='enable developer mode')
     parser.add_argument('--no-ec2-check', action='store_true', default=False,
                         help='skip EC2 configuration check')
-    parser.add_argument('--no-kernel-check', action='store_true', default=False,
+    parser.add_argument('--no-kernel-check', action='store_true',
+                        default=default_no_kernel_check,
                         help='skip kernel version check')
     parser.add_argument('--no-verify-package', action='store_true', default=False,
                         help='skip verifying packages')
@@ -202,9 +228,11 @@ if __name__ == '__main__':
                             help='skip selinux setup')
     parser.add_argument('--no-bootparam-setup', action='store_true', default=False,
                         help='skip bootparam setup')
-    parser.add_argument('--no-ntp-setup', action='store_true', default=False,
+    parser.add_argument('--no-ntp-setup', action='store_true',
+                        default=default_no_ntp_setup,
                         help='skip ntp setup')
-    parser.add_argument('--no-coredump-setup', action='store_true', default=False,
+    parser.add_argument('--no-coredump-setup', action='store_true',
+                        default=default_no_coredump_setup,
                         help='skip coredump setup')
     parser.add_argument('--no-sysconfig-setup', action='store_true', default=False,
                         help='skip sysconfig setup')
@@ -214,9 +242,11 @@ if __name__ == '__main__':
                         help='skip IO configuration setup')
     parser.add_argument('--no-version-check', action='store_true', default=False,
                         help='skip daily version check')
-    parser.add_argument('--no-node-exporter', action='store_true', default=False,
+    parser.add_argument('--no-node-exporter', action='store_true',
+                        default=default_no_node_exporter,
                         help='do not install the node exporter')
-    parser.add_argument('--no-cpuscaling-setup', action='store_true', default=False,
+    parser.add_argument('--no-cpuscaling-setup', action='store_true',
+                        default=default_no_cpuscaling_setup,
                         help='skip cpu scaling setup')
     parser.add_argument('--no-fstrim-setup', action='store_true', default=False,
                         help='skip fstrim setup')
@@ -503,10 +533,10 @@ if __name__ == '__main__':
             print('Please restart your machine before using ScyllaDB, as you have disabled')
             print(' SELinux.')
 
-        if distro.id() == 'ubuntu':
+        if distro.id() == 'ubuntu' and not is_offline():
             # Ubuntu version is 20.04 or later
             if int(distro.major_version()) >= 20:
                 hugepkg = 'libhugetlbfs-bin'
             else:
                 hugepkg = 'hugepages'
-            run(f'apt-get install -y {hugepkg}')
+            apt_install(hugepkg)


### PR DESCRIPTION
This PR requires to merge #7224, do not merge now.

----

Use scylla-cpupower.service on all distributions, to simplify the setup script
and also to minimize difference of Scylla running environment between distributions.

Also contain 'add Install section' patch to fix #7230 