### PR TITLE
alternator: Use vnode token ranges for shards instead of 1:1 stream I…

### DIFF
--- a/alternator/error.hh
+++ b/alternator/error.hh
@@ -71,6 +71,12 @@ public:
     static api_error conditional_check_failed(std::string msg) {
         return api_error("ConditionalCheckFailedException", std::move(msg));
     }
+    static api_error expired_iterator(std::string msg) {
+        return api_error("ExpiredIteratorException", std::move(msg));
+    }
+    static api_error trimmed_data_access_exception(std::string msg) {
+        return api_error("TrimmedDataAccessException", std::move(msg));
+    }
     static api_error internal(std::string msg) {
         return api_error("InternalServerError", std::move(msg), reply::status_type::internal_server_error);
     }

--- a/alternator/executor.hh
+++ b/alternator/executor.hh
@@ -56,6 +56,7 @@ namespace service {
 namespace alternator {
 
 class rmw_operation;
+class shard_iterator;
 
 struct make_jsonable : public json::jsonable {
     rjson::value _value;
@@ -131,6 +132,8 @@ private:
     static void describe_key_schema(rjson::value& parent, const schema&, std::unordered_map<std::string,std::string> * = nullptr);
     static void describe_key_schema(rjson::value& parent, const schema& schema, std::unordered_map<std::string,std::string>&);
     
+    future<request_return_type> do_get_records(client_state&, service_permit permit, schema_ptr, schema_ptr, size_t, shard_iterator);
+
 public:    
     static std::optional<rjson::value> describe_single_item(schema_ptr,
         const query::partition_slice&,

--- a/cdc/generation.hh
+++ b/cdc/generation.hh
@@ -124,24 +124,16 @@ public:
  * I.e. the stream ids at a given time. 
  */ 
 class streams_version {
-    std::vector<stream_id> _streams;
-    db_clock::time_point _timestamp;
-    std::optional<db_clock::time_point> _expired;
 public:
-    streams_version(std::vector<stream_id> streams, db_clock::time_point ts, std::optional<db_clock::time_point> expired)
-        : _streams(std::move(streams))
-        , _timestamp(ts)
-        , _expired(std::move(expired))
+    std::vector<stream_id> streams;
+    db_clock::time_point timestamp;
+    std::optional<db_clock::time_point> expired;
+
+    streams_version(std::vector<stream_id> s, db_clock::time_point ts, std::optional<db_clock::time_point> exp)
+        : streams(std::move(s))
+        , timestamp(ts)
+        , expired(std::move(exp))
     {}
-    const db_clock::time_point& timestamp() const {
-        return _timestamp;
-    }
-    const std::optional<db_clock::time_point>& expired() const {
-        return _expired;
-    }
-    const std::vector<stream_id>& streams() const {
-        return _streams;
-    }
 };
 
 /* Should be called when we're restarting and we noticed that we didn't save any streams timestamp in our local tables,

--- a/db/system_distributed_keyspace.cc
+++ b/db/system_distributed_keyspace.cc
@@ -371,7 +371,7 @@ system_distributed_keyspace::cdc_desc_exists(
     });
 }
 
-future<std::map<db_clock::time_point, cdc::streams_version>> 
+future<std::map<db_clock::time_point, cdc::streams_version>>
 system_distributed_keyspace::cdc_get_versioned_streams(context ctx) {
     return _qp.execute_internal(
             format("SELECT * FROM {}.{}", NAME, CDC_DESC),
@@ -394,5 +394,27 @@ system_distributed_keyspace::cdc_get_versioned_streams(context ctx) {
     });
 }
 
+future<db_clock::time_point>
+system_distributed_keyspace::get_next_stream_timestamp(context ctx, db_clock::time_point low) {
+    // I love that you cannot order by pk.
+    return _qp.execute_internal(
+            format("SELECT time FROM {}.{}", NAME, CDC_DESC),
+            quorum_if_many(ctx.num_token_owners),
+            internal_distributed_timeout_config,
+            {},
+            false
+    ).then([low] (::shared_ptr<cql3::untyped_result_set> cql_result) {
+        std::optional<db_clock::time_point> high;
+        db_clock::time_point res = low;
+        for (auto& row : *cql_result) {
+            auto ts = row.get_as<db_clock::time_point>("time");
+            if (ts > low && (!high || ts < *high)) {
+                high = ts;
+                res = ts;
+            }
+        }
+        return res;
+    });
+}
 
 }

--- a/db/system_distributed_keyspace.hh
+++ b/db/system_distributed_keyspace.hh
@@ -83,6 +83,12 @@ public:
     future<bool> cdc_desc_exists(db_clock::time_point streams_ts, context);
 
     future<std::map<db_clock::time_point, cdc::streams_version>> cdc_get_versioned_streams(context);
+
+    /**
+     * Gets the next higher generation timestamp from descriptions table, or 
+     * the input if none exists
+     */
+    future<db_clock::time_point> get_next_stream_timestamp(context, db_clock::time_point);
 };
 
 }

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -198,6 +198,12 @@ public:
     distributed<database>& db() {
         return _db;
     }
+    gms::gossiper& gossiper() {
+        return _gossiper;
+    }
+    const gms::gossiper& gossiper() const {
+        return _gossiper;
+    }
 
     gms::feature_service& features() { return _feature_service; }
     const gms::feature_service& features() const { return _feature_service; }


### PR DESCRIPTION
…D mapping

CDC stream ids are tied to (scylla) shards per vnode. This means very
many ids per cluster, even with a low number of nodes.

Dynamodb typically expects the number of "shards" in a stream to be much lower.

This patch makes each stream shard a vnode (using the embedded "index" classifier
of cdc stream id), and uses token range query instead of id = <value> (or id in
{ ...values }). This means we can still keep alternator streams stateless (all
info is encoded in the various json identifiers).

There are caveats though: To avoid querying into an old generation, we also
need to make the timestamp restrictions for query adjust according to a shards
creation and ev. expiry time. This is a little problematic for an iterator
with a shards from the latest generation, if a new generation is created
right in the middle of operations.

We assume this is rare, and (mis-)use the local gossip app state for cdc
generation timestamp to check if it seems we expired. If so, we simply
throw. It should be rare enough.

For old shard iterators, we simply adjust the high threshold for query.
This in turn means that we can include writes made to a new generation
in a new generation query, since we ignore confidence overlap. However,
this is not a problem since we similarly filter out this data from the
new generation query.

Queries to an old generation might be slower though, since they might
hit more than one current vnode. But again, this should be rare, and
adjust itself quickly (catching up).

An added benefit is that we can more easily say that iterators have
hit end-of-data, since end timestamp is now embedded.

Also fixes string length restrictions on ShardId:s. Dynamo define them
as max 65 chars, which we broke even before.

Note that the magic string markers for ShardId and ShardIterator
remain the same, since alternator streams are not GA yet, thus
a format change is ok.