### PR TITLE
sstables: make sstable_manager control the lifetime of the sstables it manages

### DIFF
--- a/database.cc
+++ b/database.cc
@@ -1797,6 +1797,10 @@ database::stop() {
         return _streaming_dirty_memory_manager.shutdown();
     }).then([this] {
         return _memtable_controller.shutdown();
+    }).then([this] {
+        return _user_sstables_manager->close();
+    }).then([this] {
+        return _system_sstables_manager->close();
     });
 }
 

--- a/main.cc
+++ b/main.cc
@@ -818,9 +818,6 @@ int main(int ac, char** av) {
                     return db.invoke_on_all([](auto& db) {
                         return db.stop();
                     });
-                }).then([] {
-                    startlog.info("Shutting down database: waiting for background jobs...");
-                    return sstables::await_background_jobs_on_all_shards();
                 }).get();
             });
             api::set_server_config(ctx).get();

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -178,24 +178,6 @@ future<file> sstable::new_sstable_component_file(const io_error_handler& error_h
   }
 }
 
-utils::phased_barrier& background_jobs() {
-    static thread_local utils::phased_barrier gate;
-    return gate;
-}
-
-future<> await_background_jobs() {
-    sstlog.debug("Waiting for background jobs");
-    return background_jobs().advance_and_await().finally([] {
-        sstlog.debug("Waiting done");
-    });
-}
-
-future<> await_background_jobs_on_all_shards() {
-    return smp::invoke_on_all([] {
-        return await_background_jobs();
-    });
-}
-
 std::unordered_map<sstable::version_types, sstring, enum_hash<sstable::version_types>> sstable::_version_string = {
     { sstable::version_types::ka , "ka" },
     { sstable::version_types::la , "la" },

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -555,6 +555,8 @@ private:
 
 public:
     const bool has_component(component_type f) const;
+    sstables_manager& manager() { return _manager; }
+    const sstables_manager& manager() const { return _manager; }
 private:
     future<file> open_file(component_type, open_flags, file_open_options = {}) noexcept;
 

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -52,7 +52,6 @@
 #include "utils/disk-error-handler.hh"
 #include "sstables/progress_monitor.hh"
 #include "db/commitlog/replay_position.hh"
-#include "utils/phased_barrier.hh"
 #include "component_type.hh"
 #include "sstable_version.hh"
 #include "db/large_data_handler.hh"
@@ -877,16 +876,6 @@ public:
     friend void lw_shared_ptr_deleter<sstables::sstable>::dispose(sstable* s);
 };
 
-// Waits for all prior tasks started on current shard related to sstable management to finish.
-//
-// There may be asynchronous cleanup started from sstable destructor. Since we can't have blocking
-// destructors in seastar, that cleanup is not waited for. It can be waited for using this function.
-// It is also waited for when seastar exits.
-future<> await_background_jobs();
-
-// Invokes await_background_jobs() on all shards
-future<> await_background_jobs_on_all_shards();
-
 // When we compact sstables, we have to atomically instantiate the new
 // sstable and delete the old ones.  Otherwise, if we compact A+B into C,
 // and if A contained some data that was tombstoned by B, and if B was
@@ -936,8 +925,6 @@ public:
 };
 
 future<> init_metrics();
-
-utils::phased_barrier& background_jobs();
 
 class file_io_extension {
 public:

--- a/sstables/sstables_manager.cc
+++ b/sstables/sstables_manager.cc
@@ -60,4 +60,9 @@ sstable_writer_config sstables_manager::configure_writer() const {
     return cfg;
 }
 
+
+future<> sstables_manager::close() {
+    return make_ready_future<>();
+}
+
 }   // namespace sstables

--- a/sstables/sstables_manager.cc
+++ b/sstables/sstables_manager.cc
@@ -35,6 +35,12 @@ sstables_manager::sstables_manager(
     : _large_data_handler(large_data_handler), _db_config(dbcfg), _features(feat) {
 }
 
+sstables_manager::~sstables_manager() {
+    assert(_closing);
+    assert(_active.empty());
+    assert(_undergoing_close.empty());
+}
+
 shared_sstable sstables_manager::make_sstable(schema_ptr schema,
         sstring dir,
         int64_t generation,
@@ -60,9 +66,39 @@ sstable_writer_config sstables_manager::configure_writer() const {
     return cfg;
 }
 
+void sstables_manager::add(sstable* sst) {
+    _active.push_back(*sst);
+}
+
+void sstables_manager::deactivate(sstable* sst) {
+    // At this point, sst has a reference count of zero, since we got here from
+    // lw_shared_ptr_deleter<sstables::sstable>::dispose().
+    _active.erase(_active.iterator_to(*sst));
+    _undergoing_close.push_back(*sst);
+    // guard against sstable::close_files() calling shared_from_this() and immediately destroying
+    // the result, which will dispose of the sstable recursively
+    auto ptr = sst->shared_from_this();
+    (void)sst->close_files().finally([ptr] {
+        // destruction of ptr will call maybe_done() and release close()
+    });
+}
+
+void sstables_manager::remove(sstable* sst) {
+    _undergoing_close.erase(_undergoing_close.iterator_to(*sst));
+    delete sst;
+    maybe_done();
+}
+
+void sstables_manager::maybe_done() {
+    if (_closing && _active.empty() && _undergoing_close.empty()) {
+        _done.set_value();
+    }
+}
 
 future<> sstables_manager::close() {
-    return make_ready_future<>();
+    _closing = true;
+    maybe_done();
+    return _done.get_future();
 }
 
 }   // namespace sstables

--- a/sstables/sstables_manager.hh
+++ b/sstables/sstables_manager.hh
@@ -80,6 +80,17 @@ public:
     void set_format(sstable_version_types format) { _format = format; }
     sstables::sstable::version_types get_highest_supported_format() const { return _format; }
 
+    // Wait until all sstables managed by this sstables_manager instance
+    // (previously created by make_sstable()) have been disposed of:
+    //   - if they were marked for deletion, the files are deleted
+    //   - in any case, the open file handles are closed
+    //   - all memory resources are freed
+    //
+    // Note that close() will not complete until all references to all
+    // sstables have been destroyed.
+    //
+    // Note: just a stub at this point.
+    future<> close();
 private:
     db::large_data_handler& get_large_data_handler() const {
         return _large_data_handler;

--- a/test/boost/mutation_test.cc
+++ b/test/boost/mutation_test.cc
@@ -479,13 +479,13 @@ SEASTAR_THREAD_TEST_CASE(test_large_collection_serialization_exception_safety) {
 }
 
 SEASTAR_TEST_CASE(test_multiple_memtables_one_partition) {
-    return seastar::async([] {
+    return sstables::test_env::do_with_async([] (sstables::test_env& env) {
     storage_service_for_tests ssft;
     auto s = make_shared_schema({}, some_keyspace, some_column_family,
         {{"p1", utf8_type}}, {{"c1", int32_type}}, {{"r1", int32_type}}, {}, utf8_type);
 
     auto cf_stats = make_lw_shared<::cf_stats>();
-    column_family::config cfg = column_family_test_config();
+    column_family::config cfg = column_family_test_config(env.manager());
     cfg.enable_disk_reads = false;
     cfg.enable_disk_writes = false;
     cfg.enable_incremental_backups = false;
@@ -529,6 +529,7 @@ SEASTAR_TEST_CASE(test_multiple_memtables_one_partition) {
 }
 
 SEASTAR_TEST_CASE(test_flush_in_the_middle_of_a_scan) {
+  return sstables::test_env::do_with([] (sstables::test_env& env) {
     auto s = schema_builder("ks", "cf")
         .with_column("pk", bytes_type, column_kind::partition_key)
         .with_column("v", bytes_type)
@@ -536,7 +537,7 @@ SEASTAR_TEST_CASE(test_flush_in_the_middle_of_a_scan) {
 
     auto cf_stats = make_lw_shared<::cf_stats>();
 
-    column_family::config cfg = column_family_test_config();
+    column_family::config cfg = column_family_test_config(env.manager());
     cfg.enable_disk_reads = true;
     cfg.enable_disk_writes = true;
     cfg.enable_cache = true;
@@ -606,16 +607,17 @@ SEASTAR_TEST_CASE(test_flush_in_the_middle_of_a_scan) {
             flushed.get();
         });
     }).then([cf_stats] {});
+  });
 }
 
 SEASTAR_TEST_CASE(test_multiple_memtables_multiple_partitions) {
-    return seastar::async([] {
+    return sstables::test_env::do_with_async([] (sstables::test_env& env) {
     auto s = make_shared_schema({}, some_keyspace, some_column_family,
             {{"p1", int32_type}}, {{"c1", int32_type}}, {{"r1", int32_type}}, {}, utf8_type);
 
     auto cf_stats = make_lw_shared<::cf_stats>();
 
-    column_family::config cfg = column_family_test_config();
+    column_family::config cfg = column_family_test_config(env.manager());
     cfg.enable_disk_reads = false;
     cfg.enable_disk_writes = false;
     cfg.enable_incremental_backups = false;

--- a/test/boost/schema_changes_test.cc
+++ b/test/boost/schema_changes_test.cc
@@ -37,9 +37,9 @@ using namespace sstables;
 using namespace std::chrono_literals;
 
 SEASTAR_THREAD_TEST_CASE(test_schema_changes) {
+  sstables::test_env::do_with_async([] (sstables::test_env& env) {
     auto dir = tmpdir();
     storage_service_for_tests ssft;
-    auto wait_bg = seastar::defer([] { sstables::await_background_jobs().get(); });
     int gen = 1;
 
     std::map<std::tuple<sstables::sstable::version_types, schema_ptr>, std::tuple<shared_sstable, int>> cache;
@@ -50,7 +50,6 @@ SEASTAR_THREAD_TEST_CASE(test_schema_changes) {
 
             shared_sstable created_with_base_schema;
             shared_sstable created_with_changed_schema;
-            sstables::test_env env;
             if (it == cache.end()) {
                 auto mt = make_lw_shared<memtable>(base);
                 for (auto& m : base_mutations) {
@@ -88,4 +87,5 @@ SEASTAR_THREAD_TEST_CASE(test_schema_changes) {
             mr.produces_end_of_stream();
         }
     });
+  }).get();
 }

--- a/test/boost/schema_changes_test.cc
+++ b/test/boost/schema_changes_test.cc
@@ -57,7 +57,7 @@ SEASTAR_THREAD_TEST_CASE(test_schema_changes) {
                 }
                 created_with_base_schema = env.make_sstable(base, dir.path().string(), gen, version, sstables::sstable::format_types::big);
                 created_with_base_schema->write_components(mt->make_flat_reader(base, tests::make_permit()), base_mutations.size(), base,
-                        test_sstables_manager.configure_writer(), mt->get_encoding_stats()).get();
+                        env.manager().configure_writer(), mt->get_encoding_stats()).get();
                 created_with_base_schema->load().get();
 
                 created_with_changed_schema = env.make_sstable(changed, dir.path().string(), gen, version, sstables::sstable::format_types::big);

--- a/test/boost/sstable_3_x_test.cc
+++ b/test/boost/sstable_3_x_test.cc
@@ -58,11 +58,11 @@
 using namespace sstables;
 
 class sstable_assertions final {
-    test_env _env;
+    test_env& _env;
     shared_sstable _sst;
 public:
-    sstable_assertions(schema_ptr schema, const sstring& path, sstable_version_types version = sstable_version_types::mc, int generation = 1)
-        : _env()
+    sstable_assertions(test_env& env, schema_ptr schema, const sstring& path, sstable_version_types version = sstable_version_types::mc, int generation = 1)
+        : _env(env)
         , _sst(_env.make_sstable(std::move(schema),
                             path,
                             generation,
@@ -185,8 +185,8 @@ static thread_local const schema_ptr UNCOMPRESSED_FILTERING_AND_FORWARDING_SCHEM
         .build();
 
 SEASTAR_THREAD_TEST_CASE(test_uncompressed_filtering_and_forwarding_read) {
-    auto abj = defer([] { await_background_jobs().get(); });
-    sstable_assertions sst(UNCOMPRESSED_FILTERING_AND_FORWARDING_SCHEMA,
+  test_env::do_with_async([] (test_env& env) {
+    sstable_assertions sst(env, UNCOMPRESSED_FILTERING_AND_FORWARDING_SCHEMA,
                            UNCOMPRESSED_FILTERING_AND_FORWARDING_PATH);
     sst.load();
     auto to_key = [] (int key) {
@@ -348,6 +348,7 @@ SEASTAR_THREAD_TEST_CASE(test_uncompressed_filtering_and_forwarding_read) {
             .produces_row(to_ck(110), to_expected(1010))
             .produces_end_of_stream();
     }
+  }).get();
 }
 
 /*
@@ -432,8 +433,8 @@ static thread_local const schema_ptr UNCOMPRESSED_SKIP_USING_INDEX_ROWS_SCHEMA =
         .build();
 
 SEASTAR_THREAD_TEST_CASE(test_uncompressed_skip_using_index_rows) {
-    auto abj = defer([] { await_background_jobs().get(); });
-    sstable_assertions sst(UNCOMPRESSED_SKIP_USING_INDEX_ROWS_SCHEMA,
+  test_env::do_with_async([] (test_env& env) {
+    sstable_assertions sst(env, UNCOMPRESSED_SKIP_USING_INDEX_ROWS_SCHEMA,
                            UNCOMPRESSED_SKIP_USING_INDEX_ROWS_PATH);
     sst.load();
     auto to_key = [] (int key) {
@@ -608,6 +609,7 @@ SEASTAR_THREAD_TEST_CASE(test_uncompressed_skip_using_index_rows) {
         r.produces_end_of_stream();
         BOOST_REQUIRE(aio_reads_tracker() < max_reads);
     }
+  }).get();
 }
 
 /*
@@ -675,8 +677,8 @@ static thread_local const schema_ptr UNCOMPRESSED_FILTERING_AND_FORWARDING_RANGE
         .build();
 
 SEASTAR_THREAD_TEST_CASE(test_uncompressed_filtering_and_forwarding_range_tombstones_read) {
-    auto abj = defer([] { await_background_jobs().get(); });
-    sstable_assertions sst(UNCOMPRESSED_FILTERING_AND_FORWARDING_RANGE_TOMBSTONES_SCHEMA,
+  test_env::do_with_async([] (test_env& env) {
+    sstable_assertions sst(env, UNCOMPRESSED_FILTERING_AND_FORWARDING_RANGE_TOMBSTONES_SCHEMA,
                            UNCOMPRESSED_FILTERING_AND_FORWARDING_RANGE_TOMBSTONES_PATH);
     sst.load();
 
@@ -942,6 +944,7 @@ SEASTAR_THREAD_TEST_CASE(test_uncompressed_filtering_and_forwarding_range_tombst
         }
         r.produces_end_of_stream();
     }
+  }).get();
 }
 
 /*
@@ -1003,8 +1006,8 @@ static thread_local const schema_ptr UNCOMPRESSED_SLICING_INTERLEAVED_ROWS_AND_R
         .build();
 
 SEASTAR_THREAD_TEST_CASE(test_uncompressed_slicing_interleaved_rows_and_rts_read) {
-    auto abj = defer([] { await_background_jobs().get(); });
-    sstable_assertions sst(UNCOMPRESSED_SLICING_INTERLEAVED_ROWS_AND_RTS_SCHEMA,
+  test_env::do_with_async([] (test_env& env) {
+    sstable_assertions sst(env, UNCOMPRESSED_SLICING_INTERLEAVED_ROWS_AND_RTS_SCHEMA,
                            UNCOMPRESSED_SLICING_INTERLEAVED_ROWS_AND_RTS_PATH);
     sst.load();
 
@@ -1178,6 +1181,7 @@ SEASTAR_THREAD_TEST_CASE(test_uncompressed_slicing_interleaved_rows_and_rts_read
         }
         r.produces_end_of_stream();
     }
+  }).get();
 }
 
 // Following tests run on files in test/resource/sstables/3.x/uncompressed/static_row
@@ -1206,8 +1210,8 @@ static thread_local const schema_ptr UNCOMPRESSED_STATIC_ROW_SCHEMA =
         .build();
 
 SEASTAR_THREAD_TEST_CASE(test_uncompressed_static_row_read) {
-    auto abj = defer([] { await_background_jobs().get(); });
-    sstable_assertions sst(UNCOMPRESSED_STATIC_ROW_SCHEMA,
+  test_env::do_with_async([] (test_env& env) {
+    sstable_assertions sst(env, UNCOMPRESSED_STATIC_ROW_SCHEMA,
                            UNCOMPRESSED_STATIC_ROW_PATH);
     sst.load();
     auto to_key = [] (int key) {
@@ -1253,6 +1257,7 @@ SEASTAR_THREAD_TEST_CASE(test_uncompressed_static_row_read) {
                       {{val_cdef, int32_type->decompose(int32_t(1003))}})
         .produces_partition_end()
         .produces_end_of_stream();
+  }).get();
 }
 
 // Following tests run on files in test/resource/sstables/3.x/uncompressed/random_partitioner
@@ -1272,7 +1277,7 @@ SEASTAR_THREAD_TEST_CASE(test_uncompressed_static_row_read) {
 using exception_predicate::message_equals;
 
 SEASTAR_THREAD_TEST_CASE(test_uncompressed_random_partitioner) {
-    auto abj = defer([] { await_background_jobs().get(); });
+  test_env::do_with_async([] (test_env& env) {
     const sstring uncompressed_random_partitioner_path =
             "test/resource/sstables/3.x/uncompressed/random_partitioner";
     const schema_ptr uncompressed_random_partitioner_schema =
@@ -1283,13 +1288,14 @@ SEASTAR_THREAD_TEST_CASE(test_uncompressed_random_partitioner) {
                 .set_compressor_params(compression_parameters::no_compression())
                 .build();
 
-    sstable_assertions sst(uncompressed_random_partitioner_schema,
+    sstable_assertions sst(env, uncompressed_random_partitioner_schema,
                            uncompressed_random_partitioner_path);
     using namespace std::string_literals;
     BOOST_REQUIRE_EXCEPTION(sst.load(), std::runtime_error,
         message_equals("SSTable test/resource/sstables/3.x/uncompressed/random_partitioner/mc-1-big-Data.db uses "
                        "org.apache.cassandra.dht.RandomPartitioner partitioner which is different than "
                        "org.apache.cassandra.dht.Murmur3Partitioner partitioner used by the database"s));
+  }).get();
 }
 // Following tests run on files in test/resource/sstables/3.x/uncompressed/compound_static_row
 // They were created using following CQL statements:
@@ -1330,8 +1336,8 @@ static thread_local const schema_ptr UNCOMPRESSED_COMPOUND_STATIC_ROW_SCHEMA =
         .build();
 
 SEASTAR_THREAD_TEST_CASE(test_uncompressed_compound_static_row_read) {
-    auto abj = defer([] { await_background_jobs().get(); });
-    sstable_assertions sst(UNCOMPRESSED_COMPOUND_STATIC_ROW_SCHEMA,
+  test_env::do_with_async([] (test_env& env) {
+    sstable_assertions sst(env, UNCOMPRESSED_COMPOUND_STATIC_ROW_SCHEMA,
                            UNCOMPRESSED_COMPOUND_STATIC_ROW_PATH);
     sst.load();
     auto to_key = [] (int key) {
@@ -1391,6 +1397,7 @@ SEASTAR_THREAD_TEST_CASE(test_uncompressed_compound_static_row_read) {
                       {{val_cdef, int32_type->decompose(int32_t(1003))}})
         .produces_partition_end()
         .produces_end_of_stream();
+  }).get();
 }
 
 // Following tests run on files in test/resource/sstables/3.x/uncompressed/partition_key_only
@@ -1416,14 +1423,15 @@ static thread_local const schema_ptr UNCOMPRESSED_PARTITION_KEY_ONLY_SCHEMA =
         .build();
 
 SEASTAR_THREAD_TEST_CASE(test_uncompressed_partition_key_only_load) {
-    auto abj = defer([] { await_background_jobs().get(); });
-    sstable_assertions sst(UNCOMPRESSED_PARTITION_KEY_ONLY_SCHEMA, UNCOMPRESSED_PARTITION_KEY_ONLY_PATH);
+  test_env::do_with_async([] (test_env& env) {
+    sstable_assertions sst(env, UNCOMPRESSED_PARTITION_KEY_ONLY_SCHEMA, UNCOMPRESSED_PARTITION_KEY_ONLY_PATH);
     sst.load();
+  }).get();
 }
 
 SEASTAR_THREAD_TEST_CASE(test_uncompressed_partition_key_only_read) {
-    auto abj = defer([] { await_background_jobs().get(); });
-    sstable_assertions sst(UNCOMPRESSED_PARTITION_KEY_ONLY_SCHEMA, UNCOMPRESSED_PARTITION_KEY_ONLY_PATH);
+  test_env::do_with_async([] (test_env& env) {
+    sstable_assertions sst(env, UNCOMPRESSED_PARTITION_KEY_ONLY_SCHEMA, UNCOMPRESSED_PARTITION_KEY_ONLY_PATH);
     sst.load();
     auto to_key = [] (int key) {
         auto bytes = int32_type->decompose(int32_t(key));
@@ -1447,6 +1455,7 @@ SEASTAR_THREAD_TEST_CASE(test_uncompressed_partition_key_only_read) {
         .produces_row_with_key(clustering_key_prefix::make_empty())
         .produces_partition_end()
         .produces_end_of_stream();
+  }).get();
 }
 
 // Following tests run on files in test/resource/sstables/3.x/uncompressed/partition_key_with_value
@@ -1473,8 +1482,8 @@ static thread_local const schema_ptr UNCOMPRESSED_PARTITION_KEY_WITH_VALUE_SCHEM
         .build();
 
 SEASTAR_THREAD_TEST_CASE(test_uncompressed_partition_key_with_value_read) {
-    auto abj = defer([] { await_background_jobs().get(); });
-    sstable_assertions sst(UNCOMPRESSED_PARTITION_KEY_WITH_VALUE_SCHEMA,
+  test_env::do_with_async([] (test_env& env) {
+    sstable_assertions sst(env, UNCOMPRESSED_PARTITION_KEY_WITH_VALUE_SCHEMA,
                            UNCOMPRESSED_PARTITION_KEY_WITH_VALUE_PATH);
     sst.load();
     auto to_key = [] (int key) {
@@ -1503,6 +1512,7 @@ SEASTAR_THREAD_TEST_CASE(test_uncompressed_partition_key_with_value_read) {
         .produces_row(clustering_key_prefix::make_empty(), {{cdef, int32_type->decompose(int32_t(103))}})
         .produces_partition_end()
         .produces_end_of_stream();
+  }).get();
 }
 
 // Following tests run on files in test/resource/sstables/3.x/uncompressed/counters
@@ -1537,8 +1547,8 @@ static thread_local const schema_ptr UNCOMPRESSED_COUNTERS_SCHEMA =
 static thread_local const counter_id HOST_ID = counter_id(utils::UUID("59b82720-99b0-4033-885c-e94d62106a35"));
 
 SEASTAR_THREAD_TEST_CASE(test_uncompressed_counters_read) {
-    auto abj = defer([] { await_background_jobs().get(); });
-    sstable_assertions sst(UNCOMPRESSED_COUNTERS_SCHEMA,
+  test_env::do_with_async([] (test_env& env) {
+    sstable_assertions sst(env, UNCOMPRESSED_COUNTERS_SCHEMA,
                            UNCOMPRESSED_COUNTERS_PATH);
     sst.load();
     auto to_key = [] (int key) {
@@ -1580,6 +1590,7 @@ SEASTAR_THREAD_TEST_CASE(test_uncompressed_counters_read) {
     .produces_row(clustering_key_prefix::make_empty(), {cdef->id}, generate(1528799885105152, 6, 1528799885107000))
     .produces_partition_end()
     .produces_end_of_stream();
+  }).get();
 }
 
 // Following tests run on files in test/resource/sstables/3.x/{uncompressed,lz4,snappy,deflate,zstd}/partition_key_with_value_of_different_types
@@ -1657,6 +1668,7 @@ static thread_local const schema_builder PARTITION_KEY_WITH_VALUES_OF_DIFFERENT_
         .with_column("text_val", utf8_type);
 
 static void test_partition_key_with_values_of_different_types_read(const sstring& path, compression_parameters cp) {
+  test_env::do_with_async([path, cp] (test_env& env) {
     auto s = schema_builder(PARTITION_KEY_WITH_VALUES_OF_DIFFERENT_TYPES_SCHEMA_BUILDER).set_compressor_params(cp).build();
 
     auto bool_cdef = s->get_column_definition(to_bytes("bool_val"));
@@ -1704,7 +1716,7 @@ static void test_partition_key_with_values_of_different_types_read(const sstring
         return columns;
     };
 
-    sstable_assertions sst(s, path);
+    sstable_assertions sst(env, s, path);
     sst.load();
 
     auto to_key = [&s] (int key) {
@@ -1745,34 +1757,30 @@ static void test_partition_key_with_values_of_different_types_read(const sstring
                                "variable length text 3"))
         .produces_partition_end()
         .produces_end_of_stream();
+  }).get();
 }
 
 SEASTAR_THREAD_TEST_CASE(test_uncompressed_partition_key_with_values_of_different_types_read) {
-    auto abj = defer([] { await_background_jobs().get(); });
     test_partition_key_with_values_of_different_types_read(
         UNCOMPRESSED_PARTITION_KEY_WITH_VALUES_OF_DIFFERENT_TYPES_PATH, compression_parameters::no_compression());
 }
 
 SEASTAR_THREAD_TEST_CASE(test_lz4_partition_key_with_values_of_different_types_read) {
-    auto abj = defer([] { await_background_jobs().get(); });
     test_partition_key_with_values_of_different_types_read(
         LZ4_PARTITION_KEY_WITH_VALUES_OF_DIFFERENT_TYPES_PATH, compressor::lz4);
 }
 
 SEASTAR_THREAD_TEST_CASE(test_snappy_partition_key_with_values_of_different_types_read) {
-    auto abj = defer([] { await_background_jobs().get(); });
     test_partition_key_with_values_of_different_types_read(
         SNAPPY_PARTITION_KEY_WITH_VALUES_OF_DIFFERENT_TYPES_PATH, compressor::snappy);
 }
 
 SEASTAR_THREAD_TEST_CASE(test_deflate_partition_key_with_values_of_different_types_read) {
-    auto abj = defer([] { await_background_jobs().get(); });
     test_partition_key_with_values_of_different_types_read(
         DEFLATE_PARTITION_KEY_WITH_VALUES_OF_DIFFERENT_TYPES_PATH, compressor::deflate);
 }
 
 SEASTAR_THREAD_TEST_CASE(test_zstd_partition_key_with_values_of_different_types_read) {
-    auto abj = defer([] { await_background_jobs().get(); });
     test_partition_key_with_values_of_different_types_read(
         ZSTD_PARTITION_KEY_WITH_VALUES_OF_DIFFERENT_TYPES_PATH, compressor::create({
             {"sstable_compression", "org.apache.cassandra.io.compress.ZstdCompressor"},
@@ -1806,9 +1814,8 @@ static thread_local const schema_ptr ZSTD_MULTIPLE_CHUNKS_SCHEMA =
         .build();
 
 SEASTAR_THREAD_TEST_CASE(test_zstd_compression) {
-    auto abj = defer([] { await_background_jobs().get(); });
-
-    sstable_assertions sst(ZSTD_MULTIPLE_CHUNKS_SCHEMA, ZSTD_MULTIPLE_CHUNKS_PATH);
+  test_env::do_with_async([] (test_env& env) {
+    sstable_assertions sst(env, ZSTD_MULTIPLE_CHUNKS_SCHEMA, ZSTD_MULTIPLE_CHUNKS_PATH);
     sst.load();
 
     auto to_key = [] (int key) {
@@ -1823,6 +1830,7 @@ SEASTAR_THREAD_TEST_CASE(test_zstd_compression) {
         assertions.produces_row_with_key(clustering_key::from_exploded(*ZSTD_MULTIPLE_CHUNKS_SCHEMA, {int32_type->decompose(i)}));
     }
     assertions.produces_partition_end().produces_end_of_stream();
+  }).get();
 }
 
 // Following tests run on files in test/resource/sstables/3.x/uncompressed/subset_of_columns
@@ -1878,8 +1886,8 @@ static thread_local const schema_ptr UNCOMPRESSED_SUBSET_OF_COLUMNS_SCHEMA =
         .build();
 
 SEASTAR_THREAD_TEST_CASE(test_uncompressed_subset_of_columns_read) {
-    auto abj = defer([] { await_background_jobs().get(); });
-    sstable_assertions sst(UNCOMPRESSED_SUBSET_OF_COLUMNS_SCHEMA,
+  test_env::do_with_async([] (test_env& env) {
+    sstable_assertions sst(env, UNCOMPRESSED_SUBSET_OF_COLUMNS_SCHEMA,
                            UNCOMPRESSED_SUBSET_OF_COLUMNS_PATH);
     sst.load();
     auto to_key = [] (int key) {
@@ -1985,6 +1993,7 @@ SEASTAR_THREAD_TEST_CASE(test_uncompressed_subset_of_columns_read) {
                                "variable length text 3"))
         .produces_partition_end()
         .produces_end_of_stream();
+  }).get();
 }
 
 // Following tests run on files in test/resource/sstables/3.x/uncompressed/large_subset_of_columns_sparse
@@ -2104,8 +2113,8 @@ static thread_local const schema_ptr UNCOMPRESSED_LARGE_SUBSET_OF_COLUMNS_SPARSE
         .build();
 
 SEASTAR_THREAD_TEST_CASE(test_uncompressed_large_subset_of_columns_sparse_read) {
-    auto abj = defer([] { await_background_jobs().get(); });
-    sstable_assertions sst(UNCOMPRESSED_LARGE_SUBSET_OF_COLUMNS_SPARSE_SCHEMA,
+  test_env::do_with_async([] (test_env& env) {
+    sstable_assertions sst(env, UNCOMPRESSED_LARGE_SUBSET_OF_COLUMNS_SPARSE_SCHEMA,
                            UNCOMPRESSED_LARGE_SUBSET_OF_COLUMNS_SPARSE_PATH);
     sst.load();
     auto to_key = [] (int key) {
@@ -2158,6 +2167,7 @@ SEASTAR_THREAD_TEST_CASE(test_uncompressed_large_subset_of_columns_sparse_read) 
                       generate({{32, 33}, {33, 333}}))
         .produces_partition_end()
         .produces_end_of_stream();
+  }).get();
 }
 
 // Following tests run on files in test/resource/sstables/3.x/uncompressed/large_subset_of_columns_dense
@@ -2316,8 +2326,8 @@ static thread_local const schema_ptr UNCOMPRESSED_LARGE_SUBSET_OF_COLUMNS_DENSE_
         .build();
 
 SEASTAR_THREAD_TEST_CASE(test_uncompressed_large_subset_of_columns_dense_read) {
-    auto abj = defer([] { await_background_jobs().get(); });
-    sstable_assertions sst(UNCOMPRESSED_LARGE_SUBSET_OF_COLUMNS_DENSE_SCHEMA,
+  test_env::do_with_async([] (test_env& env) {
+    sstable_assertions sst(env, UNCOMPRESSED_LARGE_SUBSET_OF_COLUMNS_DENSE_SCHEMA,
                            UNCOMPRESSED_LARGE_SUBSET_OF_COLUMNS_DENSE_PATH);
     sst.load();
     auto to_key = [] (int key) {
@@ -2391,6 +2401,7 @@ SEASTAR_THREAD_TEST_CASE(test_uncompressed_large_subset_of_columns_dense_read) {
                                 {58, 58}, {59, 59}, {60, 60}, {61, 61}, {62, 62}, {63, 63}}))
         .produces_partition_end()
         .produces_end_of_stream();
+  }).get();
 }
 
 // Following tests run on files in test/resource/sstables/3.x/uncompressed/deleted_cells
@@ -2419,8 +2430,8 @@ static thread_local const schema_ptr UNCOMPRESSED_DELETED_CELLS_SCHEMA =
         .build();
 
 SEASTAR_THREAD_TEST_CASE(test_uncompressed_deleted_cells_read) {
-    auto abj = defer([] { await_background_jobs().get(); });
-    sstable_assertions sst(UNCOMPRESSED_DELETED_CELLS_SCHEMA, UNCOMPRESSED_DELETED_CELLS_PATH);
+  test_env::do_with_async([] (test_env& env) {
+    sstable_assertions sst(env, UNCOMPRESSED_DELETED_CELLS_SCHEMA, UNCOMPRESSED_DELETED_CELLS_PATH);
     sst.load();
     auto to_key = [] (int key) {
         auto bytes = int32_type->decompose(int32_t(key));
@@ -2467,6 +2478,7 @@ SEASTAR_THREAD_TEST_CASE(test_uncompressed_deleted_cells_read) {
                   {{int_cdef, int32_type->decompose(1005)}})
     .produces_partition_end()
     .produces_end_of_stream();
+  }).get();
 }
 
 // Following tests run on files in test/resource/sstables/3.x/uncompressed/range_tombstones_simple
@@ -2501,8 +2513,8 @@ static thread_local const schema_ptr UNCOMPRESSED_RANGE_TOMBSTONES_SIMPLE_SCHEMA
         .build();
 
 SEASTAR_THREAD_TEST_CASE(test_uncompressed_range_tombstones_simple_read) {
-    auto abj = defer([] { await_background_jobs().get(); });
-    sstable_assertions sst(UNCOMPRESSED_RANGE_TOMBSTONES_SIMPLE_SCHEMA,
+  test_env::do_with_async([] (test_env& env) {
+    sstable_assertions sst(env, UNCOMPRESSED_RANGE_TOMBSTONES_SIMPLE_SCHEMA,
                            UNCOMPRESSED_RANGE_TOMBSTONES_SIMPLE_PATH);
     sst.load();
     auto to_key = [] (int key) {
@@ -2548,6 +2560,7 @@ SEASTAR_THREAD_TEST_CASE(test_uncompressed_range_tombstones_simple_read) {
                                                         gc_clock::time_point(gc_clock::duration(1529519643)))))
     .produces_partition_end()
     .produces_end_of_stream();
+  }).get();
 }
 
 // Following tests run on files in test/resource/sstables/3.x/uncompressed/range_tombstones_partial
@@ -2572,8 +2585,8 @@ static thread_local const schema_ptr UNCOMPRESSED_RANGE_TOMBSTONES_PARTIAL_SCHEM
         .build();
 
 SEASTAR_THREAD_TEST_CASE(test_uncompressed_range_tombstones_partial_read) {
-    auto abj = defer([] { await_background_jobs().get(); });
-    sstable_assertions sst(UNCOMPRESSED_RANGE_TOMBSTONES_PARTIAL_SCHEMA,
+  test_env::do_with_async([] (test_env& env) {
+    sstable_assertions sst(env, UNCOMPRESSED_RANGE_TOMBSTONES_PARTIAL_SCHEMA,
                            UNCOMPRESSED_RANGE_TOMBSTONES_PARTIAL_PATH);
     sst.load();
     auto to_key = [] (int key) {
@@ -2619,6 +2632,7 @@ SEASTAR_THREAD_TEST_CASE(test_uncompressed_range_tombstones_partial_read) {
                               gc_clock::time_point(gc_clock::duration(1530543761)))))
     .produces_partition_end()
     .produces_end_of_stream();
+  }).get();
 }
 
 // Following tests run on files in test/resource/sstables/3.x/uncompressed/simple
@@ -2645,8 +2659,8 @@ static thread_local const schema_ptr UNCOMPRESSED_SIMPLE_SCHEMA =
         .build();
 
 SEASTAR_THREAD_TEST_CASE(test_uncompressed_simple_read_toc) {
-    auto abj = defer([] { await_background_jobs().get(); });
-    sstable_assertions sst(UNCOMPRESSED_SIMPLE_SCHEMA, UNCOMPRESSED_SIMPLE_PATH);
+  test_env::do_with_async([] (test_env& env) {
+    sstable_assertions sst(env, UNCOMPRESSED_SIMPLE_SCHEMA, UNCOMPRESSED_SIMPLE_PATH);
     sst.read_toc();
     using ct = component_type;
     sst.assert_toc({ct::Index,
@@ -2657,45 +2671,51 @@ SEASTAR_THREAD_TEST_CASE(test_uncompressed_simple_read_toc) {
                     ct::CRC,
                     ct::Filter,
                     ct::Statistics});
+  }).get();
 }
 
 SEASTAR_THREAD_TEST_CASE(test_uncompressed_simple_read_summary) {
-    auto abj = defer([] { await_background_jobs().get(); });
-    sstable_assertions sst(UNCOMPRESSED_SIMPLE_SCHEMA, UNCOMPRESSED_SIMPLE_PATH);
+  test_env::do_with_async([] (test_env& env) {
+    sstable_assertions sst(env, UNCOMPRESSED_SIMPLE_SCHEMA, UNCOMPRESSED_SIMPLE_PATH);
     sst.read_toc();
     sst.read_summary();
+  }).get();
 }
 
 SEASTAR_THREAD_TEST_CASE(test_uncompressed_simple_read_filter) {
-    auto abj = defer([] { await_background_jobs().get(); });
-    sstable_assertions sst(UNCOMPRESSED_SIMPLE_SCHEMA, UNCOMPRESSED_SIMPLE_PATH);
+  test_env::do_with_async([] (test_env& env) {
+    sstable_assertions sst(env, UNCOMPRESSED_SIMPLE_SCHEMA, UNCOMPRESSED_SIMPLE_PATH);
     sst.read_toc();
     sst.read_filter();
+  }).get();
 }
 
 SEASTAR_THREAD_TEST_CASE(test_uncompressed_simple_read_statistics) {
-    auto abj = defer([] { await_background_jobs().get(); });
-    sstable_assertions sst(UNCOMPRESSED_SIMPLE_SCHEMA, UNCOMPRESSED_SIMPLE_PATH);
+  test_env::do_with_async([] (test_env& env) {
+    sstable_assertions sst(env, UNCOMPRESSED_SIMPLE_SCHEMA, UNCOMPRESSED_SIMPLE_PATH);
     sst.read_toc();
     sst.read_statistics();
+  }).get();
 }
 
 SEASTAR_THREAD_TEST_CASE(test_uncompressed_simple_load) {
-    auto abj = defer([] { await_background_jobs().get(); });
-    sstable_assertions sst(UNCOMPRESSED_SIMPLE_SCHEMA, UNCOMPRESSED_SIMPLE_PATH);
+  test_env::do_with_async([] (test_env& env) {
+    sstable_assertions sst(env, UNCOMPRESSED_SIMPLE_SCHEMA, UNCOMPRESSED_SIMPLE_PATH);
     sst.load();
+  }).get();
 }
 
 SEASTAR_THREAD_TEST_CASE(test_uncompressed_simple_read_index) {
-    auto abj = defer([] { await_background_jobs().get(); });
-    sstable_assertions sst(UNCOMPRESSED_SIMPLE_SCHEMA, UNCOMPRESSED_SIMPLE_PATH);
+  test_env::do_with_async([] (test_env& env) {
+    sstable_assertions sst(env, UNCOMPRESSED_SIMPLE_SCHEMA, UNCOMPRESSED_SIMPLE_PATH);
     auto vec = sst.read_index().get0();
     BOOST_REQUIRE_EQUAL(5, vec.size());
+  }).get();
 }
 
 SEASTAR_THREAD_TEST_CASE(test_uncompressed_simple_read) {
-    auto abj = defer([] { await_background_jobs().get(); });
-    sstable_assertions sst(UNCOMPRESSED_SIMPLE_SCHEMA,
+  test_env::do_with_async([] (test_env& env) {
+    sstable_assertions sst(env, UNCOMPRESSED_SIMPLE_SCHEMA,
                            UNCOMPRESSED_SIMPLE_PATH);
     sst.load();
     auto to_key = [] (int key) {
@@ -2736,6 +2756,7 @@ SEASTAR_THREAD_TEST_CASE(test_uncompressed_simple_read) {
                       {{int_cdef, int32_type->decompose(1003)}})
         .produces_partition_end()
         .produces_end_of_stream();
+  }).get();
 }
 
 // Following tests run on files in test/resource/sstables/3.x/uncompressed/compound_ck
@@ -2776,8 +2797,8 @@ static thread_local const schema_ptr UNCOMPRESSED_COMPOUND_CK_SCHEMA =
         .build();
 
 SEASTAR_THREAD_TEST_CASE(test_uncompressed_compound_ck_read) {
-    auto abj = defer([] { await_background_jobs().get(); });
-    sstable_assertions sst(UNCOMPRESSED_COMPOUND_CK_SCHEMA,
+  test_env::do_with_async([] (test_env& env) {
+    sstable_assertions sst(env, UNCOMPRESSED_COMPOUND_CK_SCHEMA,
                            UNCOMPRESSED_COMPOUND_CK_PATH);
     sst.load();
     auto to_key = [] (int key) {
@@ -2838,6 +2859,7 @@ SEASTAR_THREAD_TEST_CASE(test_uncompressed_compound_ck_read) {
                       {{int_cdef, int32_type->decompose(1003)}})
         .produces_partition_end()
         .produces_end_of_stream();
+  }).get();
 }
 
 // Following tests run on files in test/resource/sstables/3.x/uncompressed/collections
@@ -2871,8 +2893,8 @@ static thread_local const schema_ptr UNCOMPRESSED_COLLECTIONS_SCHEMA =
         .build();
 
 SEASTAR_THREAD_TEST_CASE(test_uncompressed_collections_read) {
-    auto abj = defer([] { await_background_jobs().get(); });
-    sstable_assertions sst(UNCOMPRESSED_COLLECTIONS_SCHEMA, UNCOMPRESSED_COLLECTIONS_PATH);
+  test_env::do_with_async([] (test_env& env) {
+    sstable_assertions sst(env, UNCOMPRESSED_COLLECTIONS_SCHEMA, UNCOMPRESSED_COLLECTIONS_PATH);
     sst.load();
     auto to_key = [] (int key) {
         auto bytes = int32_type->decompose(int32_t(key));
@@ -2977,6 +2999,7 @@ SEASTAR_THREAD_TEST_CASE(test_uncompressed_collections_read) {
             generate({7, 8, 9}, {"Text 7", "Text 8", "Text 9"}, {{7,"Text 7"}, {8,"Text 8"}, {9,"Text 9"}}))
     .produces_partition_end()
     .produces_end_of_stream();
+  }).get();
 }
 
 static sstables::shared_sstable open_sstable(test_env& env, schema_ptr schema, sstring dir, unsigned long generation) {
@@ -3019,7 +3042,7 @@ static flat_mutation_reader compacted_sstable_reader(test_env& env, schema_ptr s
 }
 
 SEASTAR_THREAD_TEST_CASE(compact_deleted_row) {
-    auto abj = defer([] { await_background_jobs().get(); });
+  test_env::do_with_async([] (test_env& env) {
     BOOST_REQUIRE(smp::count == 1);
     sstring table_name = "compact_deleted_row";
     // CREATE TABLE test_deleted_row (pk text, ck text, rc1 text, rc2 text, PRIMARY KEY (pk, ck)) WITH compression = {'sstable_compression': ''};
@@ -3071,7 +3094,6 @@ SEASTAR_THREAD_TEST_CASE(compact_deleted_row) {
      *   }
      * ]
      */
-    test_env env;
     auto reader = compacted_sstable_reader(env, s, table_name, {1, 2});
     mutation_opt m = read_mutation_from_flat_mutation_reader(reader, db::no_timeout).get0();
     BOOST_REQUIRE(m);
@@ -3086,10 +3108,11 @@ SEASTAR_THREAD_TEST_CASE(compact_deleted_row) {
     auto& rc2 = *s->get_column_definition("rc2");
     BOOST_REQUIRE(cells.find_cell(rc1.id) == nullptr);
     BOOST_REQUIRE(cells.find_cell(rc2.id) != nullptr);
+  }).get();
 }
 
 SEASTAR_THREAD_TEST_CASE(compact_deleted_cell) {
-    auto abj = defer([] { await_background_jobs().get(); });
+  test_env::do_with_async([] (test_env& env) {
     BOOST_REQUIRE(smp::count == 1);
     sstring table_name = "compact_deleted_cell";
     //  CREATE TABLE compact_deleted_cell (pk text, ck text, rc text, PRIMARY KEY (pk, ck)) WITH compression = {'sstable_compression': ''};
@@ -3142,7 +3165,6 @@ SEASTAR_THREAD_TEST_CASE(compact_deleted_cell) {
      *]
      *
      */
-    test_env env;
     auto reader = compacted_sstable_reader(env, s, table_name, {1, 2});
     mutation_opt m = read_mutation_from_flat_mutation_reader(reader, db::no_timeout).get0();
     BOOST_REQUIRE(m);
@@ -3154,6 +3176,7 @@ SEASTAR_THREAD_TEST_CASE(compact_deleted_cell) {
     BOOST_REQUIRE(row.is_live(*s));
     auto& cells = row.cells();
     BOOST_REQUIRE(cells.size() == 1);
+  }).get();
 }
 
 static void compare_files(sstring filename1, sstring filename2) {
@@ -3203,9 +3226,8 @@ static tmpdir write_sstables(test_env& env, schema_ptr s, lw_shared_ptr<memtable
 
 // Can be useful if we want, e.g., to avoid range tombstones de-overlapping
 // that otherwise takes place for RTs put into one and the same memtable
-static tmpdir write_and_compare_sstables(schema_ptr s, lw_shared_ptr<memtable> mt1, lw_shared_ptr<memtable> mt2,
+static tmpdir write_and_compare_sstables(test_env& env, schema_ptr s, lw_shared_ptr<memtable> mt1, lw_shared_ptr<memtable> mt2,
                                          sstring table_name, sstable_version_types version) {
-    test_env env;
     auto tmp = write_sstables(env, std::move(s), std::move(mt1), std::move(mt2), version);
     compare_sstables(tmp.path(), table_name, version);
     return tmp;
@@ -3219,15 +3241,14 @@ static tmpdir write_sstables(test_env& env, schema_ptr s, lw_shared_ptr<memtable
     return tmp;
 }
 
-static tmpdir write_and_compare_sstables(schema_ptr s, lw_shared_ptr<memtable> mt, sstring table_name, sstable_version_types version) {
-    test_env env;
+static tmpdir write_and_compare_sstables(test_env& env, schema_ptr s, lw_shared_ptr<memtable> mt, sstring table_name, sstable_version_types version) {
     auto tmp = write_sstables(env, std::move(s), std::move(mt), version);
     compare_sstables(tmp.path(), table_name, version);
     return tmp;
 }
 
-static sstable_assertions validate_read(schema_ptr s, const std::filesystem::path& path, std::vector<mutation> mutations, sstable_version_types version) {
-    sstable_assertions sst(s, path.string(), version);
+static sstable_assertions validate_read(test_env& env, schema_ptr s, const std::filesystem::path& path, std::vector<mutation> mutations, sstable_version_types version) {
+    sstable_assertions sst(env, s, path.string(), version, 1);
     sst.load();
 
     auto assertions = assert_that(sst.read_rows_flat());
@@ -3244,33 +3265,33 @@ constexpr std::array<sstable_version_types, 2> test_sstable_versions = {
     sstable_version_types::md,
 };
 
-static void write_mut_and_compare_sstables_version(schema_ptr s, mutation& mut, const sstring& table_name,
+static void write_mut_and_compare_sstables_version(test_env& env, schema_ptr s, mutation& mut, const sstring& table_name,
         sstable_version_types version) {
     lw_shared_ptr<memtable> mt = make_lw_shared<memtable>(s);
     mt->apply(mut);
 
-    (void)write_and_compare_sstables(s, mt, table_name, version);
+    (void)write_and_compare_sstables(env, s, mt, table_name, version);
 }
 
-static void write_mut_and_compare_sstables(schema_ptr s, mutation& mut, const sstring& table_name) {
+static void write_mut_and_compare_sstables(test_env& env, schema_ptr s, mutation& mut, const sstring& table_name) {
     for (auto version : test_sstable_versions) {
-        write_mut_and_compare_sstables_version(s, mut, table_name, version);
+        write_mut_and_compare_sstables_version(env, s, mut, table_name, version);
     }
 }
 
-static void write_muts_and_compare_sstables_version(schema_ptr s, mutation& mut1, mutation& mut2, const sstring& table_name,
+static void write_muts_and_compare_sstables_version(test_env& env, schema_ptr s, mutation& mut1, mutation& mut2, const sstring& table_name,
         sstable_version_types version) {
     lw_shared_ptr<memtable> mt1 = make_lw_shared<memtable>(s);
     lw_shared_ptr<memtable> mt2 = make_lw_shared<memtable>(s);
     mt1->apply(mut1);
     mt2->apply(mut2);
 
-    (void)write_and_compare_sstables(s, mt1, mt2, table_name, version);
+    (void)write_and_compare_sstables(env, s, mt1, mt2, table_name, version);
 }
 
-static void write_muts_and_compare_sstables(schema_ptr s, mutation& mut1, mutation& mut2, const sstring& table_name) {
+static void write_muts_and_compare_sstables(test_env& env, schema_ptr s, mutation& mut1, mutation& mut2, const sstring& table_name) {
     for (auto version : test_sstable_versions) {
-        write_muts_and_compare_sstables_version(s, mut1, mut2, table_name, version);
+        write_muts_and_compare_sstables_version(env, s, mut1, mut2, table_name, version);
     }
 }
 
@@ -3322,66 +3343,66 @@ static void check_min_max_column_names(sstable_assertions& written_sst, std::vec
 struct validate_stats_metadata_tag { };
 using validate_stats_metadata = bool_class<validate_stats_metadata_tag>;
 
-static void write_mut_and_validate_version(schema_ptr s, const sstring& table_name, mutation& mut,
+static void write_mut_and_validate_version(test_env& env, schema_ptr s, const sstring& table_name, mutation& mut,
         sstable_version_types version, validate_stats_metadata validate_flag) {
     lw_shared_ptr<memtable> mt = make_lw_shared<memtable>(s);
     mt->apply(mut);
 
-    tmpdir tmp = write_and_compare_sstables(s, mt, table_name, version);
-    auto written_sst = validate_read(s, tmp.path(), {mut}, version);
+    tmpdir tmp = write_and_compare_sstables(env, s, mt, table_name, version);
+    auto written_sst = validate_read(env, s, tmp.path(), {mut}, version);
     if (validate_flag) {
         do_validate_stats_metadata(s, written_sst, table_name);
     }
 }
 
-static void write_mut_and_validate(schema_ptr s, const sstring& table_name, mutation& mut,
+static void write_mut_and_validate(test_env& env, schema_ptr s, const sstring& table_name, mutation& mut,
         validate_stats_metadata validate_flag = validate_stats_metadata::no) {
     for (auto version : test_sstable_versions) {
-        write_mut_and_validate_version(s, table_name, mut, version, validate_flag);
+        write_mut_and_validate_version(env, s, table_name, mut, version, validate_flag);
     }
 }
 
-static void write_mut_and_validate_version(schema_ptr s, const sstring& table_name, mutation& mut,
+static void write_mut_and_validate_version(test_env& env, schema_ptr s, const sstring& table_name, mutation& mut,
         sstable_version_types version, std::vector<bytes> min_components, std::vector<bytes> max_components) {
     lw_shared_ptr<memtable> mt = make_lw_shared<memtable>(s);
     mt->apply(mut);
 
-    tmpdir tmp = write_and_compare_sstables(s, mt, table_name, version);
-    auto written_sst = validate_read(s, tmp.path(), {mut}, version);
+    tmpdir tmp = write_and_compare_sstables(env, s, mt, table_name, version);
+    auto written_sst = validate_read(env, s, tmp.path(), {mut}, version);
     do_validate_stats_metadata(s, written_sst, table_name);
     check_min_max_column_names(written_sst, std::move(min_components), std::move(max_components));
 }
 
-static void write_mut_and_validate(schema_ptr s, const sstring& table_name, mutation& mut,
+static void write_mut_and_validate(test_env& env, schema_ptr s, const sstring& table_name, mutation& mut,
         std::vector<bytes> min_components, std::vector<bytes> max_components) {
     for (auto version : test_sstable_versions) {
-        write_mut_and_validate_version(s, table_name, mut, version, min_components, max_components);
+        write_mut_and_validate_version(env, s, table_name, mut, version, min_components, max_components);
     }
 }
 
-static void write_mut_and_validate_version(schema_ptr s, const sstring& table_name, std::vector<mutation> muts,
+static void write_mut_and_validate_version(test_env& env, schema_ptr s, const sstring& table_name, std::vector<mutation> muts,
         sstable_version_types version, validate_stats_metadata validate_flag) {
     lw_shared_ptr<memtable> mt = make_lw_shared<memtable>(s);
     for (auto& mut : muts) {
         mt->apply(mut);
     }
 
-    tmpdir tmp = write_and_compare_sstables(s, mt, table_name, version);
-    auto written_sst = validate_read(s, tmp.path(), muts, version);
+    tmpdir tmp = write_and_compare_sstables(env, s, mt, table_name, version);
+    auto written_sst = validate_read(env, s, tmp.path(), muts, version);
     if (validate_flag) {
         do_validate_stats_metadata(s, written_sst, table_name);
     }
 }
 
-static void write_mut_and_validate(schema_ptr s, const sstring& table_name, std::vector<mutation> muts,
+static void write_mut_and_validate(test_env& env, schema_ptr s, const sstring& table_name, std::vector<mutation> muts,
         validate_stats_metadata validate_flag = validate_stats_metadata::no) {
     for (auto version : test_sstable_versions) {
-        write_mut_and_validate_version(s, table_name, muts, version, validate_flag);
+        write_mut_and_validate_version(env, s, table_name, muts, version, validate_flag);
     }
 }
 
 SEASTAR_THREAD_TEST_CASE(test_write_static_row) {
-    auto abj = defer([] { await_background_jobs().get(); });
+  test_env::do_with_async([] (test_env& env) {
     sstring table_name = "static_row";
     // CREATE TABLE static_row (pk text, ck int, st1 int static, st2 text static, PRIMARY KEY (pk, ck)) WITH compression = {'sstable_compression': ''};
     schema_builder builder("sst3", table_name);
@@ -3398,11 +3419,12 @@ SEASTAR_THREAD_TEST_CASE(test_write_static_row) {
     mut.set_static_cell("st1", data_value{1135}, write_timestamp);
     mut.set_static_cell("st2", data_value{"hello"}, write_timestamp);
 
-    write_mut_and_validate(s, table_name, mut);
+    write_mut_and_validate(env, s, table_name, mut);
+  }).get();
 }
 
 SEASTAR_THREAD_TEST_CASE(test_write_composite_partition_key) {
-    auto abj = defer([] { await_background_jobs().get(); });
+  test_env::do_with_async([] (test_env& env) {
     sstring table_name = "composite_partition_key";
     // CREATE TABLE composite_partition_key (a int , b text, c boolean, d int, e text, f int, g text, PRIMARY KEY ((a, b, c), d, e)) WITH compression = {'sstable_compression': ''};
     schema_builder builder("sst3", table_name);
@@ -3424,11 +3446,12 @@ SEASTAR_THREAD_TEST_CASE(test_write_composite_partition_key) {
     mut.set_cell(ckey, "f", data_value{3}, write_timestamp);
     mut.set_cell(ckey, "g", data_value{"world"}, write_timestamp);
 
-    write_mut_and_validate(s, table_name, mut);
+    write_mut_and_validate(env, s, table_name, mut);
+  }).get();
 }
 
 SEASTAR_THREAD_TEST_CASE(test_write_composite_clustering_key) {
-    auto abj = defer([] { await_background_jobs().get(); });
+  test_env::do_with_async([] (test_env& env) {
     sstring table_name = "composite_clustering_key";
     // CREATE TABLE composite_clustering_key (a int , b text, c int, d text, e int, f text, PRIMARY KEY (a, b, c, d)) WITH compression = {'sstable_compression': ''};
     schema_builder builder("sst3", table_name);
@@ -3449,11 +3472,12 @@ SEASTAR_THREAD_TEST_CASE(test_write_composite_clustering_key) {
     mut.set_cell(ckey, "e", data_value{3}, write_timestamp);
     mut.set_cell(ckey, "f", data_value{"world"}, write_timestamp);
 
-    write_mut_and_validate(s, table_name, mut);
+    write_mut_and_validate(env, s, table_name, mut);
+  }).get();
 }
 
 SEASTAR_THREAD_TEST_CASE(test_write_wide_partitions) {
-    auto abj = defer([] { await_background_jobs().get(); });
+  test_env::do_with_async([] (test_env& env) {
     sstring table_name = "wide_partitions";
     // CREATE TABLE wide_partitions (pk text, ck text, st text, rc text, PRIMARY KEY (pk, ck) WITH compression = {'sstable_compression': ''};
     schema_builder builder("sst3", table_name);
@@ -3491,11 +3515,12 @@ SEASTAR_THREAD_TEST_CASE(test_write_wide_partitions) {
         }
     }
 
-    write_mut_and_validate(s, table_name, {mut1, mut2});
+    write_mut_and_validate(env, s, table_name, {mut1, mut2});
+  }).get();
 }
 
 SEASTAR_THREAD_TEST_CASE(test_write_ttled_row) {
-    auto abj = defer([] { await_background_jobs().get(); });
+  test_env::do_with_async([] (test_env& env) {
     sstring table_name = "ttled_row";
     // CREATE TABLE ttled_row (pk int, ck int, rc int, PRIMARY KEY (pk, ck)) WITH compression = {'sstable_compression': ''};
     schema_builder builder("sst3", table_name);
@@ -3521,11 +3546,12 @@ SEASTAR_THREAD_TEST_CASE(test_write_ttled_row) {
     auto cell = atomic_cell::make_live(*column_def->type, write_timestamp, value, tp + ttl, ttl);
     mut.set_clustered_cell(ckey, *column_def, std::move(cell));
 
-    write_mut_and_validate(s, table_name, mut);
+    write_mut_and_validate(env, s, table_name, mut);
+  }).get();
 }
 
 SEASTAR_THREAD_TEST_CASE(test_write_ttled_column) {
-    auto abj = defer([] { await_background_jobs().get(); });
+  test_env::do_with_async([] (test_env& env) {
     sstring table_name = "ttled_column";
     // CREATE TABLE ttled_column (pk text, rc int, PRIMARY KEY (pk)) WITH compression = {'sstable_compression': ''};
     schema_builder builder("sst3", table_name);
@@ -3548,11 +3574,12 @@ SEASTAR_THREAD_TEST_CASE(test_write_ttled_column) {
     auto cell = atomic_cell::make_live(*column_def->type, write_timestamp, value, tp + ttl, ttl);
     mut.set_clustered_cell(clustering_key::make_empty(), *column_def, std::move(cell));
 
-    write_mut_and_validate(s, table_name, mut);
+    write_mut_and_validate(env, s, table_name, mut);
+  }).get();
 }
 
 SEASTAR_THREAD_TEST_CASE(test_write_deleted_column) {
-    auto abj = defer([] { await_background_jobs().get(); });
+  test_env::do_with_async([] (test_env& env) {
     sstring table_name = "deleted_column";
     // CREATE TABLE deleted_column (pk int, rc int, PRIMARY KEY (pk)) WITH compression = {'sstable_compression': ''};
     schema_builder builder("sst3", table_name);
@@ -3571,11 +3598,12 @@ SEASTAR_THREAD_TEST_CASE(test_write_deleted_column) {
     }
     mut.set_cell(clustering_key::make_empty(), *column_def, atomic_cell::make_dead(write_timestamp, tp));
 
-    write_mut_and_validate(s, table_name, mut);
+    write_mut_and_validate(env, s, table_name, mut);
+  }).get();
 }
 
 SEASTAR_THREAD_TEST_CASE(test_write_deleted_row) {
-    auto abj = defer([] { await_background_jobs().get(); });
+  test_env::do_with_async([] (test_env& env) {
     sstring table_name = "deleted_row";
     // CREATE TABLE deleted_row (pk int, ck int, PRIMARY KEY (pk, ck)) WITH compression = {'sstable_compression': ''};
     schema_builder builder("sst3", table_name);
@@ -3591,11 +3619,12 @@ SEASTAR_THREAD_TEST_CASE(test_write_deleted_row) {
     clustering_key ckey = clustering_key::from_deeply_exploded(*s, { 2 });
     mut.partition().apply_delete(*s, ckey, tombstone{write_timestamp, tp});
 
-    write_mut_and_validate(s, table_name, mut);
+    write_mut_and_validate(env, s, table_name, mut);
+  }).get();
 }
 
 SEASTAR_THREAD_TEST_CASE(test_write_collection_wide_update) {
-    auto abj = defer([] { await_background_jobs().get(); });
+  test_env::do_with_async([] (test_env& env) {
     sstring table_name = "collection_wide_update";
     auto set_of_ints_type = set_type_impl::get_instance(int32_type, true);
     // CREATE TABLE collection_wide_update (pk int, col set<int>, PRIMARY KEY (pk)) with compression = {'sstable_compression': ''};
@@ -3618,11 +3647,12 @@ SEASTAR_THREAD_TEST_CASE(test_write_collection_wide_update) {
 
     mut.set_clustered_cell(clustering_key::make_empty(), *s->get_column_definition("col"), set_values.serialize(*set_of_ints_type));
 
-    write_mut_and_validate(s, table_name, mut);
+    write_mut_and_validate(env, s, table_name, mut);
+  }).get();
 }
 
 SEASTAR_THREAD_TEST_CASE(test_write_collection_incremental_update) {
-    auto abj = defer([] { await_background_jobs().get(); });
+  test_env::do_with_async([] (test_env& env) {
     sstring table_name = "collection_incremental_update";
     auto set_of_ints_type = set_type_impl::get_instance(int32_type, true);
     // CREATE TABLE collection_incremental_update (pk int, col set<int>, PRIMARY KEY (pk)) with compression = {'sstable_compression': ''};
@@ -3641,11 +3671,12 @@ SEASTAR_THREAD_TEST_CASE(test_write_collection_incremental_update) {
 
     mut.set_clustered_cell(clustering_key::make_empty(), *s->get_column_definition("col"), set_values.serialize(*set_of_ints_type));
 
-    write_mut_and_validate(s, table_name, mut);
+    write_mut_and_validate(env, s, table_name, mut);
+  }).get();
 }
 
 SEASTAR_THREAD_TEST_CASE(test_write_multiple_partitions) {
-    auto abj = defer([] { await_background_jobs().get(); });
+  test_env::do_with_async([] (test_env& env) {
     sstring table_name = "multiple_partitions";
     // CREATE TABLE multiple_partitions (pk int, rc1 int, rc2 int, rc3 int, PRIMARY KEY (pk)) WITH compression = {'sstable_compression': ''};
     schema_builder builder("sst3", table_name);
@@ -3671,10 +3702,12 @@ SEASTAR_THREAD_TEST_CASE(test_write_multiple_partitions) {
         ts += 10;
     }
 
-    write_mut_and_validate(s, table_name, muts);
+    write_mut_and_validate(env, s, table_name, muts);
+  }).get();
 }
 
 static void test_write_many_partitions(sstring table_name, tombstone partition_tomb, compression_parameters cp) {
+  test_env::do_with_async([table_name, partition_tomb, cp] (test_env& env) {
     // CREATE TABLE <table_name> (pk int, PRIMARY KEY (pk)) WITH compression = {'sstable_compression': ''};
     schema_builder builder("sst3", table_name);
     builder.with_column("pk", int32_type, column_kind::partition_key);
@@ -3697,15 +3730,14 @@ static void test_write_many_partitions(sstring table_name, tombstone partition_t
             mt->apply(mut);
         }
 
-        test_env env;
-        tmpdir tmp = compressed ? write_sstables(env, s, mt, version) : write_and_compare_sstables(s, mt, table_name, version);
+        tmpdir tmp = compressed ? write_sstables(env, s, mt, version) : write_and_compare_sstables(env, s, mt, table_name, version);
         boost::sort(muts, mutation_decorated_key_less_comparator());
-        validate_read(s, tmp.path(), muts, version);
+        validate_read(env, s, tmp.path(), muts, version);
     }
+  }).get();
 }
 
 SEASTAR_THREAD_TEST_CASE(test_write_many_live_partitions) {
-    auto abj = defer([] { await_background_jobs().get(); });
     test_write_many_partitions(
             "many_live_partitions",
             tombstone{},
@@ -3713,7 +3745,6 @@ SEASTAR_THREAD_TEST_CASE(test_write_many_live_partitions) {
 }
 
 SEASTAR_THREAD_TEST_CASE(test_write_many_deleted_partitions) {
-    auto abj = defer([] { await_background_jobs().get(); });
     test_write_many_partitions(
             "many_deleted_partitions",
             tombstone{write_timestamp, write_time_point},
@@ -3721,7 +3752,6 @@ SEASTAR_THREAD_TEST_CASE(test_write_many_deleted_partitions) {
 }
 
 SEASTAR_THREAD_TEST_CASE(test_write_many_partitions_lz4) {
-    auto abj = defer([] { await_background_jobs().get(); });
     test_write_many_partitions(
             "many_partitions_lz4",
             tombstone{},
@@ -3729,7 +3759,6 @@ SEASTAR_THREAD_TEST_CASE(test_write_many_partitions_lz4) {
 }
 
 SEASTAR_THREAD_TEST_CASE(test_write_many_partitions_snappy) {
-    auto abj = defer([] { await_background_jobs().get(); });
     test_write_many_partitions(
             "many_partitions_snappy",
             tombstone{},
@@ -3737,7 +3766,6 @@ SEASTAR_THREAD_TEST_CASE(test_write_many_partitions_snappy) {
 }
 
 SEASTAR_THREAD_TEST_CASE(test_write_many_partitions_deflate) {
-    auto abj = defer([] { await_background_jobs().get(); });
     test_write_many_partitions(
             "many_partitions_deflate",
             tombstone{},
@@ -3745,7 +3773,6 @@ SEASTAR_THREAD_TEST_CASE(test_write_many_partitions_deflate) {
 }
 
 SEASTAR_THREAD_TEST_CASE(test_write_many_partitions_zstd) {
-    auto abj = defer([] { await_background_jobs().get(); });
     test_write_many_partitions(
             "many_partitions_zstd",
             tombstone{},
@@ -3755,7 +3782,7 @@ SEASTAR_THREAD_TEST_CASE(test_write_many_partitions_zstd) {
 }
 
 SEASTAR_THREAD_TEST_CASE(test_write_multiple_rows) {
-    auto abj = defer([] { await_background_jobs().get(); });
+  test_env::do_with_async([] (test_env& env) {
     sstring table_name = "multiple_rows";
     // CREATE TABLE multiple_rows (pk int, ck int, rc1 int, rc2 int, rc3 int, PRIMARY KEY (pk, ck)) WITH compression = {'sstable_compression': ''};
     schema_builder builder("sst3", table_name);
@@ -3781,13 +3808,14 @@ SEASTAR_THREAD_TEST_CASE(test_write_multiple_rows) {
         ts += 10;
     }
 
-    write_mut_and_validate(s, table_name, mut);
+    write_mut_and_validate(env, s, table_name, mut);
+  }).get();
 }
 
 // Information on missing columns is serialized differently when the number of columns is > 64.
 // This test checks that this information is encoded correctly.
 SEASTAR_THREAD_TEST_CASE(test_write_missing_columns_large_set) {
-    auto abj = defer([] { await_background_jobs().get(); });
+  test_env::do_with_async([] (test_env& env) {
     sstring table_name = "missing_columns_large_set";
     // CREATE TABLE missing_columns_large_set (pk int, ck int, rc1 int, ..., rc64 int, PRIMARY KEY (pk, ck)) WITH compression = {'sstable_compression': ''};
     schema_builder builder("sst3", table_name);
@@ -3823,11 +3851,12 @@ SEASTAR_THREAD_TEST_CASE(test_write_missing_columns_large_set) {
         mut.set_cell(ckey, to_bytes("rc64"), data_value{64}, ts);
     }
 
-    write_mut_and_validate(s, table_name, mut);
+    write_mut_and_validate(env, s, table_name, mut);
+  }).get();
 }
 
 SEASTAR_THREAD_TEST_CASE(test_write_empty_counter) {
-    auto abj = defer([] { await_background_jobs().get(); });
+  test_env::do_with_async([] (test_env& env) {
     sstring table_name = "empty_counter";
     // CREATE TABLE empty_counter (pk text, ck text, val counter, PRIMARY KEY (pk, ck)) WITH compression = {'sstable_compression': ''};
     schema_builder builder("sst3", table_name);
@@ -3846,11 +3875,12 @@ SEASTAR_THREAD_TEST_CASE(test_write_empty_counter) {
     counter_cell_builder b;
     mut.set_clustered_cell(ckey, cdef, b.build(write_timestamp));
 
-    write_mut_and_validate(s, table_name, mut);
+    write_mut_and_validate(env, s, table_name, mut);
+  }).get();
 }
 
 SEASTAR_THREAD_TEST_CASE(test_write_counter_table) {
-    auto abj = defer([] { await_background_jobs().get(); });
+  test_env::do_with_async([] (test_env& env) {
     sstring table_name = "counter_table";
     // CREATE TABLE counter_table (pk text, ck text, rc1 counter, rc2 counter, PRIMARY KEY (pk, ck)) WITH compression = {'sstable_compression': ''};
     schema_builder builder("sst3", table_name);
@@ -3891,11 +3921,12 @@ SEASTAR_THREAD_TEST_CASE(test_write_counter_table) {
     auto ckey2 = clustering_key::from_exploded(*s, {to_bytes("ck2")});
     mut.set_clustered_cell(ckey2, cdef1, atomic_cell::make_dead(write_timestamp, write_time_point));
 
-    write_mut_and_validate(s, table_name, mut, validate_stats_metadata::no);
+    write_mut_and_validate(env, s, table_name, mut, validate_stats_metadata::no);
+  }).get();
 }
 
 SEASTAR_THREAD_TEST_CASE(test_write_different_types) {
-    auto abj = defer([] { await_background_jobs().get(); });
+  test_env::do_with_async([] (test_env& env) {
     sstring table_name = "different_types";
     // CREATE TABLE different_types (pk text, asciival ascii, bigintval bigint,
     // blobval blob, boolval boolean, dateval date, decimalval decimal,
@@ -3959,11 +3990,12 @@ SEASTAR_THREAD_TEST_CASE(test_write_different_types) {
     mut.set_cell(ckey, "varintval", varint_type->deserialize(varint_type->from_string("123")), write_timestamp);
     mut.set_cell(ckey, "durationval", duration_type->deserialize(duration_type->from_string("1h4m48s20ms")), write_timestamp);
 
-    write_mut_and_validate(s, table_name, mut);
+    write_mut_and_validate(env, s, table_name, mut);
+  }).get();
 }
 
 SEASTAR_THREAD_TEST_CASE(test_write_empty_clustering_values) {
-    auto abj = defer([] { await_background_jobs().get(); });
+  test_env::do_with_async([] (test_env& env) {
     sstring table_name = "empty_clustering_values";
     // CREATE TABLE empty_clustering_values (pk int, ck1 text, ck2 int, ck3 text, rc int, PRIMARY KEY (pk, ck1, ck2, ck3)) WITH compression = {'sstable_compression': ''};
     schema_builder builder("sst3", table_name);
@@ -3983,11 +4015,12 @@ SEASTAR_THREAD_TEST_CASE(test_write_empty_clustering_values) {
     mut.partition().apply_insert(*s, ckey, write_timestamp);
     mut.set_cell(ckey, "rc", data_value{2}, write_timestamp);
 
-    write_mut_and_validate(s, table_name, mut);
+    write_mut_and_validate(env, s, table_name, mut);
+  }).get();
 }
 
 SEASTAR_THREAD_TEST_CASE(test_write_large_clustering_key) {
-    auto abj = defer([] { await_background_jobs().get(); });
+  test_env::do_with_async([] (test_env& env) {
     sstring table_name = "large_clustering_key";
     // CREATE TABLE large_clustering_key (pk int, ck1 text, ck2 text, ..., ck35 text, rc int, PRIMARY KEY (pk, ck1, ck2, ..., ck35)) WITH compression = {'sstable_compression': ''};
     schema_builder builder("sst3", table_name);
@@ -4014,11 +4047,12 @@ SEASTAR_THREAD_TEST_CASE(test_write_large_clustering_key) {
     mut.partition().apply_insert(*s, ckey, write_timestamp);
     mut.set_cell(ckey, "rc", data_value{1}, write_timestamp);
 
-    write_mut_and_validate(s, table_name, mut);
+    write_mut_and_validate(env, s, table_name, mut);
+  }).get();
 }
 
 SEASTAR_THREAD_TEST_CASE(test_write_compact_table) {
-    auto abj = defer([] { await_background_jobs().get(); });
+  test_env::do_with_async([] (test_env& env) {
     sstring table_name = "compact_table";
     // CREATE TABLE compact_table (pk int, ck1 int, ck2 int, rc int, PRIMARY KEY (pk, ck1, ck2)) WITH compression = {'sstable_compression': ''} AND COMPACT STORAGE;
     schema_builder builder("sst3", table_name);
@@ -4036,11 +4070,12 @@ SEASTAR_THREAD_TEST_CASE(test_write_compact_table) {
     clustering_key ckey = clustering_key::from_deeply_exploded(*s, { 1 });
     mut.set_cell(ckey, "rc", data_value{1}, write_timestamp);
 
-    write_mut_and_validate(s, table_name, mut);
+    write_mut_and_validate(env, s, table_name, mut);
+  }).get();
 }
 
 SEASTAR_THREAD_TEST_CASE(test_write_user_defined_type_table) {
-    auto abj = defer([] { await_background_jobs().get(); });
+  test_env::do_with_async([] (test_env& env) {
     // CREATE TYPE ut (my_int int, my_boolean boolean, my_text text);
     auto ut = user_type_impl::get_instance("sst3", to_bytes("ut"),
             {to_bytes("my_int"), to_bytes("my_boolean"), to_bytes("my_text")},
@@ -4063,11 +4098,12 @@ SEASTAR_THREAD_TEST_CASE(test_write_user_defined_type_table) {
     auto ut_val = make_user_value(ut, user_type_impl::native_type({int32_t(1703), true, sstring("Санкт-Петербург")}));
     mut.set_cell(ckey, "rc", ut_val, write_timestamp);
 
-    write_mut_and_validate(s, table_name, mut);
+    write_mut_and_validate(env, s, table_name, mut);
+  }).get();
 }
 
 SEASTAR_THREAD_TEST_CASE(test_write_simple_range_tombstone) {
-    auto abj = defer([] { await_background_jobs().get(); });
+  test_env::do_with_async([] (test_env& env) {
     sstring table_name = "simple_range_tombstone";
     // CREATE TABLE simple_range_tombstone (pk int, ck1 text, ck2 text, rc text, PRIMARY KEY (pk, ck1, ck2)) WITH compression = {'sstable_compression': ''};
     schema_builder builder("sst3", table_name);
@@ -4086,12 +4122,13 @@ SEASTAR_THREAD_TEST_CASE(test_write_simple_range_tombstone) {
     range_tombstone rt{clustering_key_prefix::from_single_value(*s, bytes("aaa")), clustering_key_prefix::from_single_value(*s, bytes("aaa")), tomb};
     mut.partition().apply_delete(*s, std::move(rt));
 
-    write_mut_and_validate(s, table_name, mut);
+    write_mut_and_validate(env, s, table_name, mut);
+  }).get();
 }
 
 // Test the case when for RTs their adjacent bounds are written as boundary RT markers.
 SEASTAR_THREAD_TEST_CASE(test_write_adjacent_range_tombstones) {
-    auto abj = defer([] { await_background_jobs().get(); });
+  test_env::do_with_async([] (test_env& env) {
     sstring table_name = "adjacent_range_tombstones";
     // CREATE TABLE adjacent_range_tombstones (pk text, ck1 text, ck2 text, ck3 text, PRIMARY KEY (pk, ck1, ck2, ck3)) WITH compression = {'sstable_compression': ''};
     schema_builder builder("sst3", table_name);
@@ -4125,13 +4162,14 @@ SEASTAR_THREAD_TEST_CASE(test_write_adjacent_range_tombstones) {
         mut.partition().apply_delete(*s, std::move(rt));
     }
 
-    write_mut_and_validate(s, table_name, mut, {"aaa"}, {"aaa"});
+    write_mut_and_validate(env, s, table_name, mut, {"aaa"}, {"aaa"});
+  }).get();
 }
 
 // Test the case when subsequent RTs have a common clustering but those bounds are both exclusive
 // so cannot be merged into a single boundary RT marker.
 SEASTAR_THREAD_TEST_CASE(test_write_non_adjacent_range_tombstones) {
-    auto abj = defer([] { await_background_jobs().get(); });
+  test_env::do_with_async([] (test_env& env) {
     sstring table_name = "non_adjacent_range_tombstones";
     // CREATE TABLE non_adjacent_range_tombstones (pk text, ck1 text, ck2 text, ck3 text, PRIMARY KEY (pk, ck1, ck2, ck3)) WITH compression = {'sstable_compression': ''};
     schema_builder builder("sst3", table_name);
@@ -4165,11 +4203,12 @@ SEASTAR_THREAD_TEST_CASE(test_write_non_adjacent_range_tombstones) {
         mut.partition().apply_delete(*s, std::move(rt));
     }
 
-    write_mut_and_validate(s, table_name, mut);
+    write_mut_and_validate(env, s, table_name, mut);
+  }).get();
 }
 
 SEASTAR_THREAD_TEST_CASE(test_write_mixed_rows_and_range_tombstones) {
-    auto abj = defer([] { await_background_jobs().get(); });
+  test_env::do_with_async([] (test_env& env) {
     sstring table_name = "mixed_rows_and_range_tombstones";
     // CREATE TABLE mixed_rows_and_range_tombstones (pk text, ck1 text, ck2 text, PRIMARY KEY (pk, ck1, ck2)) WITH compression = {'sstable_compression': ''};
     schema_builder builder("sst3", table_name);
@@ -4233,11 +4272,12 @@ SEASTAR_THREAD_TEST_CASE(test_write_mixed_rows_and_range_tombstones) {
         mut.partition().apply_insert(*s, ckey, ts);
     }
 
-    write_mut_and_validate(s, table_name, mut, {"aaa"}, {"ddd"});
+    write_mut_and_validate(env, s, table_name, mut, {"aaa"}, {"ddd"});
+  }).get();
 }
 
 SEASTAR_THREAD_TEST_CASE(test_write_many_range_tombstones) {
-    auto abj = defer([] { await_background_jobs().get(); });
+  test_env::do_with_async([] (test_env& env) {
     sstring table_name = "many_range_tombstones";
     // CREATE TABLE many_range_tombstones (pk text, ck1 text, ck2 text, PRIMARY KEY (pk, ck1, ck2) WITH compression = {'sstable_compression': ''};
     schema_builder builder("sst3", table_name);
@@ -4262,11 +4302,12 @@ SEASTAR_THREAD_TEST_CASE(test_write_many_range_tombstones) {
         seastar::thread::yield();
     }
 
-    write_mut_and_validate(s, table_name, mut, validate_stats_metadata::no);
+    write_mut_and_validate(env, s, table_name, mut, validate_stats_metadata::no);
+  }).get();
 }
 
 SEASTAR_THREAD_TEST_CASE(test_write_adjacent_range_tombstones_with_rows) {
-    auto abj = defer([] { await_background_jobs().get(); });
+  test_env::do_with_async([] (test_env& env) {
     sstring table_name = "adjacent_range_tombstones_with_rows";
     // CREATE TABLE adjacent_range_tombstones_with_rows (pk text, ck1 text, ck2 text, ck3 text, PRIMARY KEY (pk, ck1, ck2, ck3)) WITH compression = {'sstable_compression': ''};
     schema_builder builder("sst3", table_name);
@@ -4314,11 +4355,12 @@ SEASTAR_THREAD_TEST_CASE(test_write_adjacent_range_tombstones_with_rows) {
         mut.partition().apply_insert(*s, ckey, ts);
     }
 
-    write_mut_and_validate(s, table_name, mut, {"aaa"}, {"aaa"});
+    write_mut_and_validate(env, s, table_name, mut, {"aaa"}, {"aaa"});
+  }).get();
 }
 
 SEASTAR_THREAD_TEST_CASE(test_write_range_tombstone_same_start_with_row) {
-    auto abj = defer([] { await_background_jobs().get(); });
+  test_env::do_with_async([] (test_env& env) {
     sstring table_name = "range_tombstone_same_start_with_row";
     // CREATE TABLE range_tombstone_same_start_with_row (pk int, ck1 text, ck2 text, PRIMARY KEY (pk, ck1, ck2)) WITH compression = {'sstable_compression': ''};
     schema_builder builder("sst3", table_name);
@@ -4348,11 +4390,12 @@ SEASTAR_THREAD_TEST_CASE(test_write_range_tombstone_same_start_with_row) {
         mut.partition().apply_insert(*s, ckey, ts);
     }
 
-    write_mut_and_validate(s, table_name, mut, {"aaa", "bbb"}, {"aaa"});
+    write_mut_and_validate(env, s, table_name, mut, {"aaa", "bbb"}, {"aaa"});
+  }).get();
 }
 
 SEASTAR_THREAD_TEST_CASE(test_write_range_tombstone_same_end_with_row) {
-    auto abj = defer([] { await_background_jobs().get(); });
+  test_env::do_with_async([] (test_env& env) {
     sstring table_name = "range_tombstone_same_end_with_row";
     // CREATE TABLE range_tombstone_same_end_with_row (pk int, ck1 text, ck2 text, PRIMARY KEY (pk, ck1, ck2)) WITH compression = {'sstable_compression': ''};
     schema_builder builder("sst3", table_name);
@@ -4382,11 +4425,12 @@ SEASTAR_THREAD_TEST_CASE(test_write_range_tombstone_same_end_with_row) {
         mut.partition().apply_insert(*s, ckey, ts);
     }
 
-    write_mut_and_validate(s, table_name, mut, {"aaa"}, {"aaa", "bbb"});
+    write_mut_and_validate(env, s, table_name, mut, {"aaa"}, {"aaa", "bbb"});
+  }).get();
 }
 
 SEASTAR_THREAD_TEST_CASE(test_write_overlapped_start_range_tombstones) {
-    auto abj = defer([] { await_background_jobs().get(); });
+  test_env::do_with_async([] (test_env& env) {
     sstring table_name = "overlapped_start_range_tombstones";
     // CREATE TABLE overlapped_start_range_tombstones (pk int, ck1 text, ck2 text, PRIMARY KEY (pk, ck1, ck2)) WITH compression = {'sstable_compression': ''};
     schema_builder builder("sst3", table_name);
@@ -4430,11 +4474,12 @@ SEASTAR_THREAD_TEST_CASE(test_write_overlapped_start_range_tombstones) {
         mut2.partition().apply_delete(*s, std::move(rt));
     }
 
-    write_muts_and_compare_sstables(s, mut1, mut2, table_name);
+    write_muts_and_compare_sstables(env, s, mut1, mut2, table_name);
+  }).get();
 }
 
 SEASTAR_THREAD_TEST_CASE(test_write_two_non_adjacent_range_tombstones) {
-    auto abj = defer([] { await_background_jobs().get(); });
+  test_env::do_with_async([] (test_env& env) {
     sstring table_name = "two_non_adjacent_range_tombstones";
     // CREATE TABLE two_non_adjacent_range_tombstones (pk int, ck1 text, ck2 text, PRIMARY KEY (pk, ck1, ck2)) WITH compression = {'sstable_compression': ''};
     schema_builder builder("sst3", table_name);
@@ -4471,13 +4516,14 @@ SEASTAR_THREAD_TEST_CASE(test_write_two_non_adjacent_range_tombstones) {
         mut.partition().apply_delete(*s, std::move(rt));
     }
 
-    write_mut_and_validate(s, table_name, mut, {"aaa"}, {"aaa"});
+    write_mut_and_validate(env, s, table_name, mut, {"aaa"}, {"aaa"});
+  }).get();
 }
 
 // The resulting files are supposed to be identical to the files
 // from test_write_adjacent_range_tombstones
 SEASTAR_THREAD_TEST_CASE(test_write_overlapped_range_tombstones) {
-    auto abj = defer([] { await_background_jobs().get(); });
+  test_env::do_with_async([] (test_env& env) {
     sstring table_name = "overlapped_range_tombstones";
     // CREATE TABLE overlapped_range_tombstones (pk text, ck1 text, ck2 text, ck3 text, PRIMARY KEY (pk, ck1, ck2, ck3)) WITH compression = {'sstable_compression': ''};
     schema_builder builder("sst3", table_name);
@@ -4513,7 +4559,8 @@ SEASTAR_THREAD_TEST_CASE(test_write_overlapped_range_tombstones) {
         mut2.partition().apply_delete(*s, std::move(rt));
     }
 
-    write_muts_and_compare_sstables(s, mut1, mut2, table_name);
+    write_muts_and_compare_sstables(env, s, mut1, mut2, table_name);
+  }).get();
 }
 
 static sstring get_read_index_test_path(sstring table_name) {
@@ -4536,23 +4583,23 @@ shared_sstable make_test_sstable(test_env& env, schema_ptr schema, const sstring
 */
 
 SEASTAR_THREAD_TEST_CASE(test_read_empty_index) {
-    auto abj = defer([] { await_background_jobs().get(); });
+  test_env::do_with_async([] (test_env& env) {
     sstring table_name = "empty_index";
     schema_builder builder("sst3", table_name);
     builder.with_column("pk", utf8_type, column_kind::partition_key);
     builder.set_compressor_params(compression_parameters::no_compression());
     schema_ptr s = builder.build(schema_builder::compact_storage::no);
 
-    test_env env;
     auto sst = make_test_sstable(env, s, table_name);
     assert_that(get_index_reader(sst)).is_empty(*s);
+  }).get();
 }
 
 /*
  * Test files taken from write_wide_partitions test
  */
 SEASTAR_THREAD_TEST_CASE(test_read_rows_only_index) {
-    auto abj = defer([] { await_background_jobs().get(); });
+  test_env::do_with_async([] (test_env& env) {
     sstring table_name = "rows_only_index";
     // CREATE TABLE rows_only_index (pk text, ck text, st text, rc text, PRIMARY KEY (pk, ck) WITH compression = {'sstable_compression': ''};
     schema_builder builder("sst3", table_name);
@@ -4563,16 +4610,16 @@ SEASTAR_THREAD_TEST_CASE(test_read_rows_only_index) {
     builder.set_compressor_params(compression_parameters::no_compression());
     schema_ptr s = builder.build(schema_builder::compact_storage::no);
 
-    test_env env;
     auto sst = make_test_sstable(env, s, table_name);
     assert_that(get_index_reader(sst)).has_monotonic_positions(*s);
+  }).get();
 }
 
 /*
  * Test files taken from write_many_range_tombstones test
  */
 SEASTAR_THREAD_TEST_CASE(test_read_range_tombstones_only_index) {
-    auto abj = defer([] { await_background_jobs().get(); });
+  test_env::do_with_async([] (test_env& env) {
     sstring table_name = "range_tombstones_only_index";
     // CREATE TABLE range_tombstones_only_index (pk text, ck1 text, ck2 text, PRIMARY KEY (pk, ck1, ck2) WITH compression = {'sstable_compression': ''};
     schema_builder builder("sst3", table_name);
@@ -4582,9 +4629,9 @@ SEASTAR_THREAD_TEST_CASE(test_read_range_tombstones_only_index) {
     builder.set_compressor_params(compression_parameters::no_compression());
     schema_ptr s = builder.build(schema_builder::compact_storage::no);
 
-    test_env env;
     auto sst = make_test_sstable(env, s, table_name);
     assert_that(get_index_reader(sst)).has_monotonic_positions(*s);
+  }).get();
 }
 
 /*
@@ -4599,7 +4646,7 @@ SEASTAR_THREAD_TEST_CASE(test_read_range_tombstones_only_index) {
 
  */
 SEASTAR_THREAD_TEST_CASE(test_read_range_tombstone_boundaries_index) {
-    auto abj = defer([] { await_background_jobs().get(); });
+  test_env::do_with_async([] (test_env& env) {
     sstring table_name = "range_tombstone_boundaries_index";
     // CREATE TABLE range_tombstone_boundaries_index (pk text, ck1 text, ck2 text, PRIMARY KEY (pk, ck1, ck2) WITH compression = {'sstable_compression': ''};
     schema_builder builder("sst3", table_name);
@@ -4609,13 +4656,13 @@ SEASTAR_THREAD_TEST_CASE(test_read_range_tombstone_boundaries_index) {
     builder.set_compressor_params(compression_parameters::no_compression());
     schema_ptr s = builder.build(schema_builder::compact_storage::no);
 
-    test_env env;
     auto sst = make_test_sstable(env, s, table_name);
     assert_that(get_index_reader(sst)).has_monotonic_positions(*s);
+  }).get();
 }
 
 SEASTAR_THREAD_TEST_CASE(test_read_table_empty_clustering_key) {
-    auto abj = defer([] { await_background_jobs().get(); });
+  test_env::do_with_async([] (test_env& env) {
     // CREATE TABLE empty_clustering_key (pk int, v int, PRIMARY KEY (pk)) with compression = {'sstable_compression': ''};
     schema_builder builder("sst3", "empty_clustering_key");
     builder.with_column("pk", int32_type, column_kind::partition_key);
@@ -4623,7 +4670,7 @@ SEASTAR_THREAD_TEST_CASE(test_read_table_empty_clustering_key) {
     builder.set_compressor_params(compression_parameters::no_compression());
     schema_ptr s = builder.build(schema_builder::compact_storage::no);
 
-    sstable_assertions sst(s, "test/resource/sstables/3.x/uncompressed/empty_clustering_key");
+    sstable_assertions sst(env, s, "test/resource/sstables/3.x/uncompressed/empty_clustering_key");
     sst.load();
 
     std::vector<dht::decorated_key> keys;
@@ -4635,6 +4682,7 @@ SEASTAR_THREAD_TEST_CASE(test_read_table_empty_clustering_key) {
     std::sort(keys.begin(), keys.end(), cmp);
 
     assert_that(sst.read_rows_flat()).produces(keys);
+  }).get();
 }
 
 /*
@@ -4642,7 +4690,7 @@ SEASTAR_THREAD_TEST_CASE(test_read_table_empty_clustering_key) {
  * containing complex columns with zero subcolumns.
  */
 SEASTAR_THREAD_TEST_CASE(test_complex_column_zero_subcolumns_read) {
-    auto abj = defer([] { await_background_jobs().get(); });
+  test_env::do_with_async([] (test_env& env) {
     using utils::UUID;
     const sstring path =
         "test/resource/sstables/3.x/uncompressed/complex_column_zero_subcolumns";
@@ -4658,7 +4706,7 @@ SEASTAR_THREAD_TEST_CASE(test_complex_column_zero_subcolumns_read) {
         .set_compressor_params(compression_parameters::no_compression())
         .build();
 
-    sstable_assertions sst(s, path);
+    sstable_assertions sst(env, s, path);
     sst.load();
 
     auto to_pkey = [&s] (const UUID& key) {
@@ -4686,10 +4734,11 @@ SEASTAR_THREAD_TEST_CASE(test_complex_column_zero_subcolumns_read) {
         .produces_partition_end();
     }
     r.produces_end_of_stream();
+  }).get();
 }
 
 SEASTAR_THREAD_TEST_CASE(test_uncompressed_read_two_rows_fast_forwarding) {
-    auto abj = defer([] { await_background_jobs().get(); });
+  test_env::do_with_async([] (test_env& env) {
     // Following tests run on files in test/resource/sstables/3.x/uncompressed/read_two_rows_fast_forwarding
     // They were created using following CQL statements:
     //
@@ -4705,7 +4754,7 @@ SEASTAR_THREAD_TEST_CASE(test_uncompressed_read_two_rows_fast_forwarding) {
             .with_column("rc", int32_type)
             .set_compressor_params(compression_parameters::no_compression())
             .build();
-    sstable_assertions sst(s, path);
+    sstable_assertions sst(env, s, path);
     sst.load();
 
     auto to_pkey = [&] (int key) {
@@ -4744,10 +4793,11 @@ SEASTAR_THREAD_TEST_CASE(test_uncompressed_read_two_rows_fast_forwarding) {
     r.produces_row(to_ckey(7), to_expected(7))
         .produces_row(to_ckey(8), to_expected(8))
         .produces_end_of_stream();
+  }).get();
 }
 
 SEASTAR_THREAD_TEST_CASE(test_dead_row_marker) {
-    auto abj = defer([] { await_background_jobs().get(); });
+  test_env::do_with_async([] (test_env& env) {
     api::timestamp_type ts = 1543494402386839;
     gc_clock::time_point tp = gc_clock::time_point{} + gc_clock::duration{1543494402};
     sstring table_name = "dead_row_marker";
@@ -4770,11 +4820,12 @@ SEASTAR_THREAD_TEST_CASE(test_dead_row_marker) {
 
     mut.set_cell(ckey, "rc", data_value{7777}, ts);
 
-    write_mut_and_compare_sstables(s, mut, table_name);
+    write_mut_and_compare_sstables(env, s, mut, table_name);
+  }).get();
 }
 
 SEASTAR_THREAD_TEST_CASE(test_shadowable_deletion) {
-    auto abj = defer([] { await_background_jobs().get(); });
+  test_env::do_with_async([] (test_env& env) {
     /* The created SSTables content should match that of
      * an MV filled with the following queries:
      *
@@ -4806,11 +4857,12 @@ SEASTAR_THREAD_TEST_CASE(test_shadowable_deletion) {
         clustered_row.apply(shadowable_tombstone(ts, tp));
     }
 
-    write_mut_and_validate(s, table_name, {mut1, mut2}, validate_stats_metadata::no);
+    write_mut_and_validate(env, s, table_name, {mut1, mut2}, validate_stats_metadata::no);
+  }).get();
 }
 
 SEASTAR_THREAD_TEST_CASE(test_regular_and_shadowable_deletion) {
-    auto abj = defer([] { await_background_jobs().get(); });
+  test_env::do_with_async([] (test_env& env) {
     /* The created SSTables content should match that of
      * an MV filled with the following queries:
      *
@@ -4854,11 +4906,12 @@ SEASTAR_THREAD_TEST_CASE(test_regular_and_shadowable_deletion) {
         mt->apply(mut2);
     }
 
-    write_mut_and_validate(s, table_name, {mut1, mut2}, validate_stats_metadata::no);
+    write_mut_and_validate(env, s, table_name, {mut1, mut2}, validate_stats_metadata::no);
+  }).get();
 }
 
 SEASTAR_THREAD_TEST_CASE(test_write_static_row_with_missing_columns) {
-    auto abj = defer([] { await_background_jobs().get(); });
+  test_env::do_with_async([] (test_env& env) {
     sstring table_name = "static_row_with_missing_columns";
     // CREATE TABLE static_row (pk int, ck int, st1 int static, st2 int static, rc int, PRIMARY KEY (pk, ck)) WITH compression = {'sstable_compression': ''};
     schema_builder builder("sst3", table_name);
@@ -4878,11 +4931,12 @@ SEASTAR_THREAD_TEST_CASE(test_write_static_row_with_missing_columns) {
     mut.set_static_cell("st1", data_value{2}, write_timestamp);
     mut.set_cell(ckey, "rc", data_value{3}, write_timestamp);
 
-    write_mut_and_validate(s, table_name, mut, validate_stats_metadata::no);
+    write_mut_and_validate(env, s, table_name, mut, validate_stats_metadata::no);
+  }).get();
 }
 
 SEASTAR_THREAD_TEST_CASE(test_write_interleaved_atomic_and_collection_columns) {
-    auto abj = defer([] { await_background_jobs().get(); });
+  test_env::do_with_async([] (test_env& env) {
     sstring table_name = "interleaved_atomic_and_collection_columns";
     // CREATE TABLE interleaved_atomic_and_collection_columns ( pk int, ck int, rc1 int, rc2 set<int>, rc3 int, rc4 set<int>,
     //     rc5 int, rc6 set<int>, PRIMARY KEY (pk, ck)) WITH compression = {'sstable_compression': ''};
@@ -4915,11 +4969,12 @@ SEASTAR_THREAD_TEST_CASE(test_write_interleaved_atomic_and_collection_columns) {
 
     mut.set_cell(ckey, "rc5", data_value{5}, write_timestamp);
 
-    write_mut_and_validate(s, table_name, mut, validate_stats_metadata::no);
+    write_mut_and_validate(env, s, table_name, mut, validate_stats_metadata::no);
+  }).get();
 }
 
 SEASTAR_THREAD_TEST_CASE(test_write_static_interleaved_atomic_and_collection_columns) {
-    auto abj = defer([] { await_background_jobs().get(); });
+  test_env::do_with_async([] (test_env& env) {
     sstring table_name = "static_interleaved_atomic_and_collection_columns";
     // CREATE TABLE static_interleaved_atomic_and_collection_columns ( pk int, ck int, st1 int static,
     //     st2 set<int> static, st3 int static, st4 set<int> static, st5 int static, st6 set<int> static,
@@ -4953,11 +5008,12 @@ SEASTAR_THREAD_TEST_CASE(test_write_static_interleaved_atomic_and_collection_col
 
     mut.set_static_cell("st5", data_value{5}, write_timestamp);
 
-    write_mut_and_validate(s, table_name, mut, validate_stats_metadata::no);
+    write_mut_and_validate(env, s, table_name, mut, validate_stats_metadata::no);
+  }).get();
 }
 
 SEASTAR_THREAD_TEST_CASE(test_write_empty_static_row) {
-    auto abj = defer([] { await_background_jobs().get(); });
+  test_env::do_with_async([] (test_env& env) {
     sstring table_name = "empty_static_row";
     // CREATE TABLE empty_static_row (pk int, ck int, st int static, rc int, PRIMARY KEY (pk, ck)) WITH compression = {'sstable_compression': ''};
     schema_builder builder("sst3", table_name);
@@ -4991,13 +5047,14 @@ SEASTAR_THREAD_TEST_CASE(test_write_empty_static_row) {
         mt->apply(mut1);
         mt->apply(mut2);
 
-        tmpdir tmp = write_and_compare_sstables(s, mt, table_name, version);
-        validate_read(s, tmp.path(), {mut2, mut1}, version); // Mutations are re-ordered according to decorated_key order
+        tmpdir tmp = write_and_compare_sstables(env, s, mt, table_name, version);
+        validate_read(env, s, tmp.path(), {mut2, mut1}, version); // Mutations are re-ordered according to decorated_key order
     }
+  }).get();
 }
 
 SEASTAR_THREAD_TEST_CASE(test_read_missing_summary) {
-    auto abj = defer([] { await_background_jobs().get(); });
+  test_env::do_with_async([] (test_env& env) {
     const sstring path = "test/resource/sstables/3.x/uncompressed/read_missing_summary";
     const schema_ptr s =
         schema_builder("test_ks", "test_table")
@@ -5007,12 +5064,13 @@ SEASTAR_THREAD_TEST_CASE(test_read_missing_summary) {
             .set_compressor_params(compression_parameters::no_compression())
             .build();
 
-    sstable_assertions sst(s, path);
+    sstable_assertions sst(env, s, path);
     sst.load();
+  }).get();
 }
 
 SEASTAR_THREAD_TEST_CASE(test_sstable_reader_on_unknown_column) {
-    auto abj = defer([] { await_background_jobs().get(); });
+ test_env::do_with_async([] (test_env& env) {
     api::timestamp_type write_timestamp = 1525385507816568;
     storage_service_for_tests ssft;
     auto get_builder = [&] (bool has_missing_column) {
@@ -5048,7 +5106,6 @@ SEASTAR_THREAD_TEST_CASE(test_sstable_reader_on_unknown_column) {
         tmpdir dir;
         sstable_writer_config cfg = test_sstables_manager.configure_writer();
         cfg.promoted_index_block_size = index_block_size;
-        test_env env;
         auto sst = env.make_sstable(write_schema,
             dir.path().string(),
             1 /* generation */,
@@ -5069,6 +5126,7 @@ SEASTAR_THREAD_TEST_CASE(test_sstable_reader_on_unknown_column) {
             message_equals("Column val1 missing in current schema in sstable " + sst->get_filename()));
     }
   }
+ }).get();
 }
 
 namespace {
@@ -5251,8 +5309,7 @@ static const sstring LEGACY_UDT_IN_COLLECTION_PATH =
     "test/resource/sstables/3.x/uncompressed/legacy_udt_in_collection";
 
 SEASTAR_THREAD_TEST_CASE(test_legacy_udt_in_collection_table) {
-    auto abj = defer([] { await_background_jobs().get(); });
-
+  test_env::do_with_async([] (test_env& env) {
     auto ut = user_type_impl::get_instance("ks", to_bytes("ut"),
             {to_bytes("a"), to_bytes("b")},
             {int32_type, int32_type}, false);
@@ -5341,7 +5398,8 @@ SEASTAR_THREAD_TEST_CASE(test_legacy_udt_in_collection_table) {
     // fl = [{a: 0, b: 0}]
     mut.set_clustered_cell(ckey, *fl_cdef, atomic_cell::make_live(*fl_type, write_timestamp, fl_type->decompose(fl_val)));
 
-    sstable_assertions sst(s, LEGACY_UDT_IN_COLLECTION_PATH);
+    sstable_assertions sst(env, s, LEGACY_UDT_IN_COLLECTION_PATH);
     sst.load();
     assert_that(sst.read_rows_flat()).produces(mut).produces_end_of_stream();
+  }).get();
 }

--- a/test/boost/sstable_conforms_to_mutation_source_test.cc
+++ b/test/boost/sstable_conforms_to_mutation_source_test.cc
@@ -51,13 +51,11 @@ void test_mutation_source(sstables::test_env& env, sstable_writer_config cfg, ss
 
 
 SEASTAR_TEST_CASE(test_sstable_conforms_to_mutation_source) {
-    return seastar::async([] {
-        auto wait_bg = seastar::defer([] { sstables::await_background_jobs().get(); });
+    return sstables::test_env::do_with_async([] (sstables::test_env& env) {
         storage_service_for_tests ssft;
-        sstables::test_env env;
         for (auto version : all_sstable_versions) {
             for (auto index_block_size : {1, 128, 64*1024}) {
-                sstable_writer_config cfg = test_sstables_manager.configure_writer();
+                sstable_writer_config cfg = env.manager().configure_writer();
                 cfg.promoted_index_block_size = index_block_size;
                 test_mutation_source(env, cfg, version);
             }

--- a/test/boost/sstable_datafile_test.cc
+++ b/test/boost/sstable_datafile_test.cc
@@ -2414,7 +2414,7 @@ SEASTAR_TEST_CASE(check_multi_schema) {
     //        e blob
     //);
     return test_env::do_with_async([] (test_env& env) {
-        return for_each_sstable_version([&env] (const sstables::sstable::version_types version) {
+        for_each_sstable_version([&env] (const sstables::sstable::version_types version) {
             auto set_of_ints_type = set_type_impl::get_instance(int32_type, true);
             auto builder = schema_builder("test", "test_multi_schema")
                 .with_column("a", int32_type, column_kind::partition_key)

--- a/test/boost/sstable_datafile_test.cc
+++ b/test/boost/sstable_datafile_test.cc
@@ -1097,11 +1097,10 @@ SEASTAR_TEST_CASE(compaction_manager_test) {
     BOOST_REQUIRE(cm->get_stats().completed_tasks == 1);
     BOOST_REQUIRE(cm->get_stats().errors == 0);
 
-    // remove cf from compaction manager; this will wait for the
-    // ongoing compaction to finish.
-    cf->stop().get();
     // expect sstables of cf to be compacted.
     BOOST_REQUIRE(cf->sstables_count() == 1);
+
+    cf->stop().get();
   });
 }
 

--- a/test/boost/sstable_directory_test.cc
+++ b/test/boost/sstable_directory_test.cc
@@ -95,12 +95,21 @@ make_sstable_for_all_shards(database& db, table& table, fs::path sstdir, int64_t
     return sst;
 }
 
-sstables::shared_sstable sstable_from_existing_file(fs::path dir, int64_t gen, sstables::sstable_version_types v, sstables::sstable_format_types f) {
-    return test_sstables_manager.make_sstable(test_table_schema(), dir.native(), gen, v, f, gc_clock::now(), default_io_error_handler_gen(), default_sstable_buffer_size);
-}
+class sstable_from_existing_file {
+    std::function<sstables::sstables_manager* ()> _get_mgr;
+public:
+    explicit sstable_from_existing_file(sstables::test_env& env) : _get_mgr([m = &env.manager()] { return m; }) {}
+    // This variant this transportable across shards
+    explicit sstable_from_existing_file(sharded<sstables::test_env>& env) : _get_mgr([s = &env] { return &s->local().manager(); }) {}
+    // This variant this transportable across shards
+    explicit sstable_from_existing_file(cql_test_env& env) : _get_mgr([&env] { return &env.db().local().get_user_sstables_manager(); }) {}
+    sstables::shared_sstable operator()(fs::path dir, int64_t gen, sstables::sstable_version_types v, sstables::sstable_format_types f) const {
+        return _get_mgr()->make_sstable(test_table_schema(), dir.native(), gen, v, f, gc_clock::now(), default_io_error_handler_gen(), default_sstable_buffer_size);
+    }
+};
 
-sstables::shared_sstable new_sstable(fs::path dir, int64_t gen) {
-    return test_sstables_manager.make_sstable(test_table_schema(), dir.native(), gen,
+sstables::shared_sstable new_sstable(sstables::test_env& env, fs::path dir, int64_t gen) {
+    return env.manager().make_sstable(test_table_schema(), dir.native(), gen,
                 sstables::sstable_version_types::mc, sstables::sstable_format_types::big,
                 gc_clock::now(), default_io_error_handler_gen(), default_sstable_buffer_size);
 }
@@ -115,6 +124,7 @@ highest_generation_seen(sharded<sstables::sstable_directory>& dir) {
 }
 
 SEASTAR_THREAD_TEST_CASE(sstable_directory_test_table_simple_empty_directory_scan) {
+  sstables::test_env::do_with_async([] (test_env& env) {
     auto dir = tmpdir();
 
     // Write a manifest file to make sure it's ignored
@@ -128,7 +138,7 @@ SEASTAR_THREAD_TEST_CASE(sstable_directory_test_table_simple_empty_directory_sca
             sstable_directory::lack_of_toc_fatal::no,
             sstable_directory::enable_dangerous_direct_import_of_cassandra_counters::no,
             sstable_directory::allow_loading_materialized_view::no,
-            &sstable_from_existing_file).get();
+            sstable_from_existing_file(env)).get();
 
     auto stop = defer([&sstdir] {
         sstdir.stop().get();
@@ -138,12 +148,14 @@ SEASTAR_THREAD_TEST_CASE(sstable_directory_test_table_simple_empty_directory_sca
     int64_t max_generation_seen = highest_generation_seen(sstdir).get0();
     // No generation found on empty directory.
     BOOST_REQUIRE_EQUAL(max_generation_seen, 0);
+  }).get();
 }
 
 // Test unrecoverable SSTable: missing a file that is expected in the TOC.
 SEASTAR_THREAD_TEST_CASE(sstable_directory_test_table_scan_incomplete_sstables) {
+  sstables::test_env::do_with_async([] (test_env& env) {
     auto dir = tmpdir();
-    auto sst = make_sstable_for_this_shard(std::bind(new_sstable, dir.path(), 1));
+    auto sst = make_sstable_for_this_shard(std::bind(new_sstable, std::ref(env), dir.path(), 1));
 
     // Now there is one sstable to the upload directory, but it is incomplete and one component is missing.
     // We should fail validation and leave the directory untouched
@@ -155,7 +167,7 @@ SEASTAR_THREAD_TEST_CASE(sstable_directory_test_table_scan_incomplete_sstables) 
             sstable_directory::lack_of_toc_fatal::no,
             sstable_directory::enable_dangerous_direct_import_of_cassandra_counters::no,
             sstable_directory::allow_loading_materialized_view::no,
-            &sstable_from_existing_file).get();
+            sstable_from_existing_file(env)).get();
 
     auto stop = defer([&sstdir] {
         sstdir.stop().get();
@@ -163,12 +175,14 @@ SEASTAR_THREAD_TEST_CASE(sstable_directory_test_table_scan_incomplete_sstables) 
 
     auto expect_malformed_sstable = distributed_loader::process_sstable_dir(sstdir);
     BOOST_REQUIRE_THROW(expect_malformed_sstable.get(), sstables::malformed_sstable_exception);
+  }).get();
 }
 
 // Test always-benign incomplete SSTable: temporaryTOC found
 SEASTAR_THREAD_TEST_CASE(sstable_directory_test_table_temporary_toc) {
+  sstables::test_env::do_with_async([] (test_env& env) {
     auto dir = tmpdir();
-    auto sst = make_sstable_for_this_shard(std::bind(new_sstable, dir.path(), 1));
+    auto sst = make_sstable_for_this_shard(std::bind(new_sstable, std::ref(env), dir.path(), 1));
     rename_file(sst->filename(sstables::component_type::TOC), sst->filename(sstables::component_type::TemporaryTOC)).get();
 
     sharded<sstable_directory> sstdir;
@@ -177,7 +191,7 @@ SEASTAR_THREAD_TEST_CASE(sstable_directory_test_table_temporary_toc) {
             sstable_directory::lack_of_toc_fatal::yes,
             sstable_directory::enable_dangerous_direct_import_of_cassandra_counters::no,
             sstable_directory::allow_loading_materialized_view::no,
-            &sstable_from_existing_file).get();
+            sstable_from_existing_file(env)).get();
 
     auto stop = defer([&sstdir] {
         sstdir.stop().get();
@@ -185,13 +199,15 @@ SEASTAR_THREAD_TEST_CASE(sstable_directory_test_table_temporary_toc) {
 
     auto expect_ok = distributed_loader::process_sstable_dir(sstdir);
     BOOST_REQUIRE_NO_THROW(expect_ok.get());
+  }).get();
 }
 
 // Test the absence of TOC. Behavior is controllable by a flag
 SEASTAR_THREAD_TEST_CASE(sstable_directory_test_table_missing_toc) {
+  sstables::test_env::do_with_async([] (test_env& env) {
     auto dir = tmpdir();
 
-    auto sst = make_sstable_for_this_shard(std::bind(new_sstable, dir.path(), 1));
+    auto sst = make_sstable_for_this_shard(std::bind(new_sstable, std::ref(env), dir.path(), 1));
     remove_file(sst->filename(sstables::component_type::TOC)).get();
 
     sharded<sstable_directory> sstdir_fatal;
@@ -200,7 +216,7 @@ SEASTAR_THREAD_TEST_CASE(sstable_directory_test_table_missing_toc) {
             sstable_directory::lack_of_toc_fatal::yes,
             sstable_directory::enable_dangerous_direct_import_of_cassandra_counters::no,
             sstable_directory::allow_loading_materialized_view::no,
-            &sstable_from_existing_file).get();
+            sstable_from_existing_file(env)).get();
 
     auto stop_fatal = defer([&sstdir_fatal] {
         sstdir_fatal.stop().get();
@@ -215,7 +231,7 @@ SEASTAR_THREAD_TEST_CASE(sstable_directory_test_table_missing_toc) {
             sstable_directory::lack_of_toc_fatal::no,
             sstable_directory::enable_dangerous_direct_import_of_cassandra_counters::no,
             sstable_directory::allow_loading_materialized_view::no,
-            &sstable_from_existing_file).get();
+            sstable_from_existing_file(env)).get();
 
     auto stop_ok = defer([&sstdir_ok] {
         sstdir_ok.stop().get();
@@ -223,15 +239,17 @@ SEASTAR_THREAD_TEST_CASE(sstable_directory_test_table_missing_toc) {
 
     auto expect_ok = distributed_loader::process_sstable_dir(sstdir_ok);
     BOOST_REQUIRE_NO_THROW(expect_ok.get());
+  }).get();
 }
 
 // Test the presence of TemporaryStatistics. If the old Statistics file is around
 // this is benign and we'll just delete it and move on. If the old Statistics file
 // is not around (but mentioned in the TOC), then this is an error.
 SEASTAR_THREAD_TEST_CASE(sstable_directory_test_temporary_statistics) {
+  sstables::test_env::do_with_sharded_async([] (sharded<test_env>& env) {
     auto dir = tmpdir();
 
-    auto sst = make_sstable_for_this_shard(std::bind(new_sstable, dir.path(), 1));
+    auto sst = make_sstable_for_this_shard(std::bind(new_sstable, std::ref(env.local()), dir.path(), 1));
     auto tempstr = sst->filename(dir.path().native(), component_type::TemporaryStatistics);
     auto f = open_file_dma(tempstr, open_flags::rw | open_flags::create | open_flags::truncate).get0();
     f.close().get();
@@ -243,7 +261,7 @@ SEASTAR_THREAD_TEST_CASE(sstable_directory_test_temporary_statistics) {
             sstable_directory::lack_of_toc_fatal::no,
             sstable_directory::enable_dangerous_direct_import_of_cassandra_counters::no,
             sstable_directory::allow_loading_materialized_view::no,
-            &sstable_from_existing_file).get();
+            sstable_from_existing_file(env)).get();
 
     auto stop_ok= defer([&sstdir_ok] {
         sstdir_ok.stop().get();
@@ -264,7 +282,7 @@ SEASTAR_THREAD_TEST_CASE(sstable_directory_test_temporary_statistics) {
             sstable_directory::lack_of_toc_fatal::no,
             sstable_directory::enable_dangerous_direct_import_of_cassandra_counters::no,
             sstable_directory::allow_loading_materialized_view::no,
-            &sstable_from_existing_file).get();
+            sstable_from_existing_file(env)).get();
 
     auto stop_fatal = defer([&sstdir_fatal] {
         sstdir_fatal.stop().get();
@@ -272,13 +290,15 @@ SEASTAR_THREAD_TEST_CASE(sstable_directory_test_temporary_statistics) {
 
     auto expect_malformed_sstable  = distributed_loader::process_sstable_dir(sstdir_fatal);
     BOOST_REQUIRE_THROW(expect_malformed_sstable.get(), sstables::malformed_sstable_exception);
+  }).get();
 }
 
 // Test that we see the right generation during the scan. Temporary files are skipped
 SEASTAR_THREAD_TEST_CASE(sstable_directory_test_generation_sanity) {
+  sstables::test_env::do_with_sharded_async([] (sharded<test_env>& env) {
     auto dir = tmpdir();
-    make_sstable_for_this_shard(std::bind(new_sstable, dir.path(), 3333));
-    auto sst = make_sstable_for_this_shard(std::bind(new_sstable, dir.path(), 6666));
+    make_sstable_for_this_shard(std::bind(new_sstable, std::ref(env.local()), dir.path(), 3333));
+    auto sst = make_sstable_for_this_shard(std::bind(new_sstable, std::ref(env.local()), dir.path(), 6666));
     rename_file(sst->filename(sstables::component_type::TOC), sst->filename(sstables::component_type::TemporaryTOC)).get();
 
     sharded<sstable_directory> sstdir;
@@ -287,7 +307,7 @@ SEASTAR_THREAD_TEST_CASE(sstable_directory_test_generation_sanity) {
             sstable_directory::lack_of_toc_fatal::yes,
             sstable_directory::enable_dangerous_direct_import_of_cassandra_counters::no,
             sstable_directory::allow_loading_materialized_view::no,
-            &sstable_from_existing_file).get();
+            sstable_from_existing_file(env)).get();
 
     auto stop = defer([&sstdir] {
         sstdir.stop().get();
@@ -296,6 +316,7 @@ SEASTAR_THREAD_TEST_CASE(sstable_directory_test_generation_sanity) {
     distributed_loader::process_sstable_dir(sstdir).get();
     int64_t max_generation_seen = highest_generation_seen(sstdir).get0();
     BOOST_REQUIRE_EQUAL(max_generation_seen, 3333);
+  }).get();
 }
 
 future<> verify_that_all_sstables_are_local(sharded<sstable_directory>& sstdir, unsigned expected_sstables) {
@@ -318,13 +339,14 @@ future<> verify_that_all_sstables_are_local(sharded<sstable_directory>& sstdir, 
 // Test that all SSTables are seen as unshared, if the generation numbers match what their
 // shard-assignments expect
 SEASTAR_THREAD_TEST_CASE(sstable_directory_unshared_sstables_sanity_matched_generations) {
+  sstables::test_env::do_with_sharded_async([] (sharded<test_env>& env) {
     auto dir = tmpdir();
     for (shard_id i = 0; i < smp::count; ++i) {
-        smp::submit_to(i, [dir = dir.path(), i] {
+        env.invoke_on(i, [dir = dir.path(), i] (sstables::test_env& env) {
             // this is why it is annoying for the internal functions in the test infrastructure to
             // assume threaded execution
-            return seastar::async([dir, i] {
-                make_sstable_for_this_shard(std::bind(new_sstable, dir, i));
+            return seastar::async([dir, i, &env] {
+                make_sstable_for_this_shard(std::bind(new_sstable, std::ref(env), dir, i));
             });
         }).get();
     }
@@ -335,7 +357,7 @@ SEASTAR_THREAD_TEST_CASE(sstable_directory_unshared_sstables_sanity_matched_gene
             sstable_directory::lack_of_toc_fatal::yes,
             sstable_directory::enable_dangerous_direct_import_of_cassandra_counters::no,
             sstable_directory::allow_loading_materialized_view::no,
-            &sstable_from_existing_file).get();
+            sstable_from_existing_file(env)).get();
 
     auto stop = defer([&sstdir] {
         sstdir.stop().get();
@@ -343,18 +365,20 @@ SEASTAR_THREAD_TEST_CASE(sstable_directory_unshared_sstables_sanity_matched_gene
 
     distributed_loader::process_sstable_dir(sstdir).get();
     verify_that_all_sstables_are_local(sstdir, smp::count).get();
+  }).get();
 }
 
 // Test that all SSTables are seen as unshared, even if the generation numbers do not match what their
 // shard-assignments expect
 SEASTAR_THREAD_TEST_CASE(sstable_directory_unshared_sstables_sanity_unmatched_generations) {
+  sstables::test_env::do_with_sharded_async([] (sharded<test_env>& env) {
     auto dir = tmpdir();
     for (shard_id i = 0; i < smp::count; ++i) {
-        smp::submit_to(i, [dir = dir.path(), i] {
+        env.invoke_on(i, [dir = dir.path(), i] (sstables::test_env& env) {
             // this is why it is annoying for the internal functions in the test infrastructure to
             // assume threaded execution
-            return seastar::async([dir, i] {
-                make_sstable_for_this_shard(std::bind(new_sstable, dir, i + 1));
+            return seastar::async([dir, i, &env] {
+                make_sstable_for_this_shard(std::bind(new_sstable, std::ref(env), dir, i + 1));
             });
         }).get();
     }
@@ -365,7 +389,7 @@ SEASTAR_THREAD_TEST_CASE(sstable_directory_unshared_sstables_sanity_unmatched_ge
             sstable_directory::lack_of_toc_fatal::yes,
             sstable_directory::enable_dangerous_direct_import_of_cassandra_counters::no,
             sstable_directory::allow_loading_materialized_view::no,
-            &sstable_from_existing_file).get();
+            sstable_from_existing_file(env)).get();
 
     auto stop = defer([&sstdir] {
         sstdir.stop().get();
@@ -373,6 +397,7 @@ SEASTAR_THREAD_TEST_CASE(sstable_directory_unshared_sstables_sanity_unmatched_ge
 
     distributed_loader::process_sstable_dir(sstdir).get();
     verify_that_all_sstables_are_local(sstdir, smp::count).get();
+  }).get();
 }
 
 // Test that the sstable_dir object can keep the table alive against a drop
@@ -390,7 +415,7 @@ SEASTAR_TEST_CASE(sstable_directory_test_table_lock_works) {
                 sstable_directory::lack_of_toc_fatal::no,
                 sstable_directory::enable_dangerous_direct_import_of_cassandra_counters::no,
                 sstable_directory::allow_loading_materialized_view::no,
-                &sstable_from_existing_file).get();
+                sstable_from_existing_file(e)).get();
 
         // stop cleanly in case we fail early for unexpected reasons
         auto stop = defer([&sstdir] {

--- a/test/boost/sstable_mutation_test.cc
+++ b/test/boost/sstable_mutation_test.cc
@@ -52,8 +52,7 @@ using namespace sstables;
 using namespace std::chrono_literals;
 
 SEASTAR_THREAD_TEST_CASE(nonexistent_key) {
-    auto wait_bg = seastar::defer([] { sstables::await_background_jobs().get(); });
-    sstables::test_env env;
+  test_env::do_with_async([] (test_env& env) {
     env.reusable_sst(uncompressed_schema(), uncompressed_dir(), 1).then([] (auto sstp) {
         return do_with(make_dkey(uncompressed_schema(), "invalid_key"), [sstp] (auto& key) {
             auto s = uncompressed_schema();
@@ -64,6 +63,7 @@ SEASTAR_THREAD_TEST_CASE(nonexistent_key) {
             });
         });
     }).get();
+  }).get();
 }
 
 future<> test_no_clustered(sstables::test_env& env, bytes&& key, std::unordered_map<bytes, data_value> &&map) {
@@ -90,27 +90,27 @@ future<> test_no_clustered(sstables::test_env& env, bytes&& key, std::unordered_
 }
 
 SEASTAR_THREAD_TEST_CASE(uncompressed_1) {
-    auto wait_bg = seastar::defer([] { sstables::await_background_jobs().get(); });
-    sstables::test_env env;
+  test_env::do_with_async([] (test_env& env) {
     test_no_clustered(env, "vinna", {{ "col1", to_sstring("daughter") }, { "col2", 3 }}).get();
+  }).get();
 }
 
 SEASTAR_THREAD_TEST_CASE(uncompressed_2) {
-    auto wait_bg = seastar::defer([] { sstables::await_background_jobs().get(); });
-    sstables::test_env env;
+  test_env::do_with_async([] (test_env& env) {
     test_no_clustered(env, "gustaf", {{ "col1", to_sstring("son") }, { "col2", 0 }}).get();
+  }).get();
 }
 
 SEASTAR_THREAD_TEST_CASE(uncompressed_3) {
-    auto wait_bg = seastar::defer([] { sstables::await_background_jobs().get(); });
-    sstables::test_env env;
+  test_env::do_with_async([] (test_env& env) {
     test_no_clustered(env, "isak", {{ "col1", to_sstring("son") }, { "col2", 1 }}).get();
+  }).get();
 }
 
 SEASTAR_THREAD_TEST_CASE(uncompressed_4) {
-    auto wait_bg = seastar::defer([] { sstables::await_background_jobs().get(); });
-    sstables::test_env env;
+  test_env::do_with_async([] (test_env& env) {
     test_no_clustered(env, "finna", {{ "col1", to_sstring("daughter") }, { "col2", 2 }}).get();
+  }).get();
 }
 
 /*
@@ -161,8 +161,7 @@ inline auto clustered_row(mutation& mutation, const schema& s, std::vector<bytes
 }
 
 SEASTAR_THREAD_TEST_CASE(complex_sst1_k1) {
-    auto wait_bg = seastar::defer([] { sstables::await_background_jobs().get(); });
-    sstables::test_env env;
+  test_env::do_with_async([] (test_env& env) {
     generate_clustered<1>(env, "key1").then([] (auto&& mutation) {
         auto s = complex_schema();
 
@@ -189,11 +188,11 @@ SEASTAR_THREAD_TEST_CASE(complex_sst1_k1) {
 
         return make_ready_future<>();
     }).get();
+  }).get();
 }
 
 SEASTAR_THREAD_TEST_CASE(complex_sst1_k2) {
-    auto wait_bg = seastar::defer([] { sstables::await_background_jobs().get(); });
-    sstables::test_env env;
+  test_env::do_with_async([] (test_env& env) {
     generate_clustered<1>(env, "key2").then([] (auto&& mutation) {
         auto s = complex_schema();
 
@@ -222,11 +221,11 @@ SEASTAR_THREAD_TEST_CASE(complex_sst1_k2) {
 
         return make_ready_future<>();
     }).get();
+  }).get();
 }
 
 SEASTAR_THREAD_TEST_CASE(complex_sst2_k1) {
-    auto wait_bg = seastar::defer([] { sstables::await_background_jobs().get(); });
-    sstables::test_env env;
+  test_env::do_with_async([] (test_env& env) {
     generate_clustered<2>(env, "key1").then([] (auto&& mutation) {
         auto s = complex_schema();
 
@@ -242,11 +241,11 @@ SEASTAR_THREAD_TEST_CASE(complex_sst2_k1) {
         match_collection_element<status::dead>(reg_list.cells[0], bytes_opt{}, bytes_opt{});
         return make_ready_future<>();
     }).get();
+  }).get();
 }
 
 SEASTAR_THREAD_TEST_CASE(complex_sst2_k2) {
-    auto wait_bg = seastar::defer([] { sstables::await_background_jobs().get(); });
-    sstables::test_env env;
+  test_env::do_with_async([] (test_env& env) {
     generate_clustered<2>(env, "key2").then([] (auto&& mutation) {
         auto s = complex_schema();
 
@@ -273,11 +272,11 @@ SEASTAR_THREAD_TEST_CASE(complex_sst2_k2) {
 
         return make_ready_future<>();
     }).get();
+  }).get();
 }
 
 SEASTAR_THREAD_TEST_CASE(complex_sst2_k3) {
-    auto wait_bg = seastar::defer([] { sstables::await_background_jobs().get(); });
-    sstables::test_env env;
+  test_env::do_with_async([] (test_env& env) {
     generate_clustered<2>(env, "key3").then([] (auto&& mutation) {
         auto s = complex_schema();
 
@@ -293,11 +292,11 @@ SEASTAR_THREAD_TEST_CASE(complex_sst2_k3) {
         match_absent(row1.cells(), *s, "reg_fset");
         return make_ready_future<>();
     }).get();
+  }).get();
 }
 
 SEASTAR_THREAD_TEST_CASE(complex_sst3_k1) {
-    auto wait_bg = seastar::defer([] { sstables::await_background_jobs().get(); });
-    sstables::test_env env;
+  test_env::do_with_async([] (test_env& env) {
     generate_clustered<3>(env, "key1").then([] (auto&& mutation) {
         auto s = complex_schema();
 
@@ -315,11 +314,11 @@ SEASTAR_THREAD_TEST_CASE(complex_sst3_k1) {
         match_absent(row.cells(), *s, "reg_fset");
         return make_ready_future<>();
     }).get();
+  }).get();
 }
 
 SEASTAR_THREAD_TEST_CASE(complex_sst3_k2) {
-    auto wait_bg = seastar::defer([] { sstables::await_background_jobs().get(); });
-    sstables::test_env env;
+  test_env::do_with_async([] (test_env& env) {
     generate_clustered<3>(env, "key2").then([] (auto&& mutation) {
         auto s = complex_schema();
 
@@ -335,6 +334,7 @@ SEASTAR_THREAD_TEST_CASE(complex_sst3_k2) {
         match_absent(row.cells(), *s, "reg_fset");
         return make_ready_future<>();
     }).get();
+  }).get();
 }
 
 future<> test_range_reads(sstables::test_env& env, const dht::token& min, const dht::token& max, std::vector<bytes>& expected) {
@@ -371,27 +371,30 @@ future<> test_range_reads(sstables::test_env& env, const dht::token& min, const 
 }
 
 SEASTAR_THREAD_TEST_CASE(read_range) {
-    auto wait_bg = seastar::defer([] { sstables::await_background_jobs().get(); });
+  test_env::do_with_async([] (test_env& env) {
     std::vector<bytes> expected = { to_bytes("finna"), to_bytes("isak"), to_bytes("gustaf"), to_bytes("vinna") };
-    do_with(sstables::test_env(), std::move(expected), [] (auto& env, auto& expected) {
+    do_with(std::move(expected), [&env] (auto& expected) {
         return test_range_reads(env, dht::minimum_token(), dht::maximum_token(), expected);
     }).get();
+  }).get();
 }
 
 SEASTAR_THREAD_TEST_CASE(read_partial_range) {
-    auto wait_bg = seastar::defer([] { sstables::await_background_jobs().get(); });
+  test_env::do_with_async([] (test_env& env) {
     std::vector<bytes> expected = { to_bytes("finna"), to_bytes("isak") };
-    do_with(sstables::test_env(), std::move(expected), [] (auto& env, auto& expected) {
+    do_with(std::move(expected), [&env] (auto& expected) {
         return test_range_reads(env, uncompressed_schema()->get_partitioner().get_token(key_view(bytes_view(expected.back()))), dht::maximum_token(), expected);
     }).get();
+  }).get();
 }
 
 SEASTAR_THREAD_TEST_CASE(read_partial_range_2) {
-    auto wait_bg = seastar::defer([] { sstables::await_background_jobs().get(); });
+  test_env::do_with_async([] (test_env& env) {
     std::vector<bytes> expected = { to_bytes("gustaf"), to_bytes("vinna") };
-    do_with(sstables::test_env(), std::move(expected), [] (auto& env, auto& expected) {
+    do_with(std::move(expected), [&env] (auto& expected) {
         return test_range_reads(env, dht::minimum_token(), uncompressed_schema()->get_partitioner().get_token(key_view(bytes_view(expected.front()))), expected);
     }).get();
+  }).get();
 }
 
 static
@@ -402,7 +405,7 @@ mutation_source make_sstable_mutation_source(sstables::test_env& env, schema_ptr
 
 SEASTAR_TEST_CASE(test_sstable_can_write_and_read_range_tombstone) {
     return seastar::async([] {
-        auto wait_bg = seastar::defer([] { sstables::await_background_jobs().get(); });
+      test_env::do_with_async([] (test_env& env) {
         storage_service_for_tests ssft;
         auto dir = tmpdir();
         auto s = make_shared_schema({}, "ks", "cf",
@@ -419,7 +422,6 @@ SEASTAR_TEST_CASE(test_sstable_can_write_and_read_range_tombstone) {
         auto mt = make_lw_shared<memtable>(s);
         mt->apply(std::move(m));
 
-        sstables::test_env env;
         auto sst = env.make_sstable(s,
                 dir.path().string(),
                 1 /* generation */,
@@ -439,12 +441,12 @@ SEASTAR_TEST_CASE(test_sstable_can_write_and_read_range_tombstone) {
                         c_key_end,
                         bound_kind::excl_end,
                         tombstone(9, ttl))));
+      }).get();
     });
 }
 
 SEASTAR_THREAD_TEST_CASE(compact_storage_sparse_read) {
-    auto wait_bg = seastar::defer([] { sstables::await_background_jobs().get(); });
-    sstables::test_env env;
+  test_env::do_with_async([] (test_env& env) {
     env.reusable_sst(compact_sparse_schema(), "test/resource/sstables/compact_sparse", 1).then([] (auto sstp) {
         return do_with(make_dkey(compact_sparse_schema(), "first_row"), [sstp] (auto& key) {
             auto s = compact_sparse_schema();
@@ -459,11 +461,11 @@ SEASTAR_THREAD_TEST_CASE(compact_storage_sparse_read) {
             });
         });
     }).get();
+  }).get();
 }
 
 SEASTAR_THREAD_TEST_CASE(compact_storage_simple_dense_read) {
-    auto wait_bg = seastar::defer([] { sstables::await_background_jobs().get(); });
-    sstables::test_env env;
+  test_env::do_with_async([] (test_env& env) {
     env.reusable_sst(compact_simple_dense_schema(), "test/resource/sstables/compact_simple_dense", 1).then([] (auto sstp) {
         return do_with(make_dkey(compact_simple_dense_schema(), "first_row"), [sstp] (auto& key) {
             auto s = compact_simple_dense_schema();
@@ -480,11 +482,11 @@ SEASTAR_THREAD_TEST_CASE(compact_storage_simple_dense_read) {
             });
         });
     }).get();
+  }).get();
 }
 
 SEASTAR_THREAD_TEST_CASE(compact_storage_dense_read) {
-    auto wait_bg = seastar::defer([] { sstables::await_background_jobs().get(); });
-    sstables::test_env env;
+  test_env::do_with_async([] (test_env& env) {
     env.reusable_sst(compact_dense_schema(), "test/resource/sstables/compact_dense", 1).then([] (auto sstp) {
         return do_with(make_dkey(compact_dense_schema(), "first_row"), [sstp] (auto& key) {
             auto s = compact_dense_schema();
@@ -501,6 +503,7 @@ SEASTAR_THREAD_TEST_CASE(compact_storage_dense_read) {
             });
         });
     }).get();
+  }).get();
 }
 
 // We recently had an issue, documented at #188, where range-reading from an
@@ -508,8 +511,7 @@ SEASTAR_THREAD_TEST_CASE(compact_storage_dense_read) {
 //
 // Make sure we don't regress on that.
 SEASTAR_THREAD_TEST_CASE(broken_ranges_collection) {
-    auto wait_bg = seastar::defer([] { sstables::await_background_jobs().get(); });
-    sstables::test_env env;
+  test_env::do_with_async([] (test_env& env) {
     env.reusable_sst(peers_schema(), "test/resource/sstables/broken_ranges", 2).then([] (auto sstp) {
         auto s = peers_schema();
         auto reader = make_lw_shared<flat_mutation_reader>(sstp->as_mutation_source().make_reader(s, tests::make_permit(), query::full_partition_range));
@@ -537,6 +539,7 @@ SEASTAR_THREAD_TEST_CASE(broken_ranges_collection) {
             });
         });
     }).get();
+  }).get();
 }
 
 static schema_ptr tombstone_overlap_schema() {
@@ -561,8 +564,7 @@ static schema_ptr tombstone_overlap_schema() {
 }
 
 
-static future<sstable_ptr> ka_sst(schema_ptr schema, sstring dir, unsigned long generation) {
-    sstables::test_env env;
+static future<sstable_ptr> ka_sst(sstables::test_env& env, schema_ptr schema, sstring dir, unsigned long generation) {
     auto sst = env.make_sstable(std::move(schema), dir, generation, sstables::sstable::version_types::ka, big);
     auto fut = sst->load();
     return std::move(fut).then([sst = std::move(sst)] {
@@ -577,8 +579,8 @@ static future<sstable_ptr> ka_sst(schema_ptr schema, sstring dir, unsigned long 
 //                ["aaa:bbb:!","aaa:!",1459334681228103,"t",1459334681]]}
 //               ]
 SEASTAR_THREAD_TEST_CASE(tombstone_in_tombstone) {
-    auto wait_bg = seastar::defer([] { sstables::await_background_jobs().get(); });
-    ka_sst(tombstone_overlap_schema(), "test/resource/sstables/tombstone_overlap", 1).then([] (auto sstp) {
+  test_env::do_with_async([] (test_env& env) {
+    ka_sst(env, tombstone_overlap_schema(), "test/resource/sstables/tombstone_overlap", 1).then([] (auto sstp) {
         auto s = tombstone_overlap_schema();
         return do_with(sstp->read_rows_flat(s, tests::make_permit()), [sstp, s] (auto& reader) {
             return repeat([sstp, s, &reader] {
@@ -629,6 +631,7 @@ SEASTAR_THREAD_TEST_CASE(tombstone_in_tombstone) {
             });
         });
     }).get();
+  }).get();
 }
 
 //  Same schema as above, the sstable looks like:
@@ -641,8 +644,8 @@ SEASTAR_THREAD_TEST_CASE(tombstone_in_tombstone) {
 // We're not sure how this sort of sstable can be generated with Cassandra 2's
 // CQL, but we saw a similar thing is a real use case.
 SEASTAR_THREAD_TEST_CASE(range_tombstone_reading) {
-    auto wait_bg = seastar::defer([] { sstables::await_background_jobs().get(); });
-    ka_sst(tombstone_overlap_schema(), "test/resource/sstables/tombstone_overlap", 4).then([] (auto sstp) {
+  test_env::do_with_async([] (test_env& env) {
+    ka_sst(env, tombstone_overlap_schema(), "test/resource/sstables/tombstone_overlap", 4).then([] (auto sstp) {
         auto s = tombstone_overlap_schema();
         return do_with(sstp->read_rows_flat(s, tests::make_permit()), [sstp, s] (auto& reader) {
             return repeat([sstp, s, &reader] {
@@ -678,6 +681,7 @@ SEASTAR_THREAD_TEST_CASE(range_tombstone_reading) {
             });
         });
     }).get();
+  }).get();
 }
 
 // In this test case we have *three* levels of of tombstones:
@@ -719,8 +723,8 @@ static schema_ptr tombstone_overlap_schema2() {
     return s;
 }
 SEASTAR_THREAD_TEST_CASE(tombstone_in_tombstone2) {
-    auto wait_bg = seastar::defer([] { sstables::await_background_jobs().get(); });
-    ka_sst(tombstone_overlap_schema2(), "test/resource/sstables/tombstone_overlap", 3).then([] (auto sstp) {
+  test_env::do_with_async([] (test_env& env) {
+    ka_sst(env, tombstone_overlap_schema2(), "test/resource/sstables/tombstone_overlap", 3).then([] (auto sstp) {
         auto s = tombstone_overlap_schema2();
         return do_with(sstp->read_rows_flat(s, tests::make_permit()), [sstp, s] (auto& reader) {
             return repeat([sstp, s, &reader] {
@@ -776,6 +780,7 @@ SEASTAR_THREAD_TEST_CASE(tombstone_in_tombstone2) {
             });
         });
     }).get();
+  }).get();
 }
 
 // Reproducer for #4783
@@ -800,8 +805,9 @@ static schema_ptr buffer_overflow_schema() {
     return s;
 }
 SEASTAR_THREAD_TEST_CASE(buffer_overflow) {
+  test_env::do_with_async([] (test_env& env) {
     auto s = buffer_overflow_schema();
-    auto sstp = ka_sst(s, "test/resource/sstables/buffer_overflow", 5).get0();
+    auto sstp = ka_sst(env, s, "test/resource/sstables/buffer_overflow", 5).get0();
     auto r = sstp->read_rows_flat(s, tests::make_permit());
     auto pk1 = partition_key::from_exploded(*s, { int32_type->decompose(4) });
     auto dk1 = dht::decorate_key(*s, pk1);
@@ -830,11 +836,12 @@ SEASTAR_THREAD_TEST_CASE(buffer_overflow) {
         .produces_row_with_key(ck2)
         .produces_partition_end()
         .produces_end_of_stream();
+  }).get();
 }
 
 SEASTAR_TEST_CASE(test_non_compound_table_row_is_not_marked_as_static) {
     return seastar::async([] {
-      auto wait_bg = seastar::defer([] { sstables::await_background_jobs().get(); });
+     test_env::do_with_async([] (test_env& env) {
       for (const auto version : all_sstable_versions) {
         storage_service_for_tests ssft;
         auto dir = tmpdir();
@@ -854,7 +861,6 @@ SEASTAR_TEST_CASE(test_non_compound_table_row_is_not_marked_as_static) {
         auto mt = make_lw_shared<memtable>(s);
         mt->apply(std::move(m));
 
-        sstables::test_env env;
         auto sst = env.make_sstable(s,
                                 dir.path().string(),
                                 1 /* generation */,
@@ -866,12 +872,13 @@ SEASTAR_TEST_CASE(test_non_compound_table_row_is_not_marked_as_static) {
         auto mut = read_mutation_from_flat_mutation_reader(mr, db::no_timeout).get0();
         BOOST_REQUIRE(bool(mut));
       }
+     }).get();
     });
 }
 
 SEASTAR_TEST_CASE(test_has_partition_key) {
     return seastar::async([] {
-        auto wait_bg = seastar::defer([] { sstables::await_background_jobs().get(); });
+      test_env::do_with_async([] (test_env& env) {
         for (const auto version : all_sstable_versions) {
             storage_service_for_tests ssft;
             auto dir = tmpdir();
@@ -891,7 +898,6 @@ SEASTAR_TEST_CASE(test_has_partition_key) {
             auto mt = make_lw_shared<memtable>(s);
             mt->apply(std::move(m));
 
-            sstables::test_env env;
             auto sst = env.make_sstable(s,
                                     dir.path().string(),
                                     1 /* generation */,
@@ -910,6 +916,7 @@ SEASTAR_TEST_CASE(test_has_partition_key) {
             res =  sst->has_partition_key(hk2, dk2).get0();
             BOOST_REQUIRE(! bool(res));
         }
+      }).get();
     });
 }
 
@@ -919,7 +926,7 @@ static std::unique_ptr<index_reader> get_index_reader(shared_sstable sst) {
 
 SEASTAR_TEST_CASE(test_promoted_index_blocks_are_monotonic) {
     return seastar::async([] {
-        auto wait_bg = seastar::defer([] { sstables::await_background_jobs().get(); });
+      test_env::do_with_async([] (test_env& env) {
         storage_service_for_tests ssft;
         auto dir = tmpdir();
         schema_builder builder("ks", "cf");
@@ -955,7 +962,6 @@ SEASTAR_TEST_CASE(test_promoted_index_blocks_are_monotonic) {
         auto mt = make_lw_shared<memtable>(s);
         mt->apply(std::move(m));
 
-        sstables::test_env env;
         auto sst = env.make_sstable(s,
                                 dir.path().string(),
                                 1 /* generation */,
@@ -966,12 +972,13 @@ SEASTAR_TEST_CASE(test_promoted_index_blocks_are_monotonic) {
         sst->write_components(mt->make_flat_reader(s, tests::make_permit()), 1, s, cfg, mt->get_encoding_stats()).get();
         sst->load().get();
         assert_that(get_index_reader(sst)).has_monotonic_positions(*s);
+      }).get();
     });
 }
 
 SEASTAR_TEST_CASE(test_promoted_index_blocks_are_monotonic_compound_dense) {
     return seastar::async([] {
-      auto wait_bg = seastar::defer([] { sstables::await_background_jobs().get(); });
+     test_env::do_with_async([] (test_env& env) {
       for (const auto version : all_sstable_versions) {
         storage_service_for_tests ssft;
         auto dir = tmpdir();
@@ -1008,7 +1015,6 @@ SEASTAR_TEST_CASE(test_promoted_index_blocks_are_monotonic_compound_dense) {
         auto mt = make_lw_shared<memtable>(s);
         mt->apply(std::move(m));
 
-        sstables::test_env env;
         auto sst = env.make_sstable(s,
                                           dir.path().string(),
                                           1 /* generation */,
@@ -1030,12 +1036,13 @@ SEASTAR_TEST_CASE(test_promoted_index_blocks_are_monotonic_compound_dense) {
                     .produces_end_of_stream();
         }
       }
+     }).get();
     });
 }
 
 SEASTAR_TEST_CASE(test_promoted_index_blocks_are_monotonic_non_compound_dense) {
     return seastar::async([] {
-      auto wait_bg = seastar::defer([] { sstables::await_background_jobs().get(); });
+     test_env::do_with_async([] (test_env& env) {
       for (const auto version : all_sstable_versions) {
         storage_service_for_tests ssft;
         auto dir = tmpdir();
@@ -1068,7 +1075,6 @@ SEASTAR_TEST_CASE(test_promoted_index_blocks_are_monotonic_non_compound_dense) {
         auto mt = make_lw_shared<memtable>(s);
         mt->apply(std::move(m));
 
-        sstables::test_env env;
         auto sst = env.make_sstable(s,
                                           dir.path().string(),
                                           1 /* generation */,
@@ -1090,12 +1096,13 @@ SEASTAR_TEST_CASE(test_promoted_index_blocks_are_monotonic_non_compound_dense) {
                     .produces_end_of_stream();
         }
       }
+     }).get();
     });
 }
 
 SEASTAR_TEST_CASE(test_promoted_index_repeats_open_tombstones) {
     return seastar::async([] {
-      auto wait_bg = seastar::defer([] { sstables::await_background_jobs().get(); });
+     test_env::do_with_async([] (test_env& env) {
       for (const auto version : all_sstable_versions) {
         storage_service_for_tests ssft;
         auto dir = tmpdir();
@@ -1125,7 +1132,6 @@ SEASTAR_TEST_CASE(test_promoted_index_repeats_open_tombstones) {
             auto mt = make_lw_shared<memtable>(s);
             mt->apply(m);
 
-            sstables::test_env env;
             auto sst = env.make_sstable(s,
                                               dir.path().string(),
                                               generation,
@@ -1144,12 +1150,13 @@ SEASTAR_TEST_CASE(test_promoted_index_repeats_open_tombstones) {
             }
         }
       }
+     }).get();
     });
 }
 
 SEASTAR_TEST_CASE(test_range_tombstones_are_correctly_seralized_for_non_compound_dense_schemas) {
     return seastar::async([] {
-      auto wait_bg = seastar::defer([] { sstables::await_background_jobs().get(); });
+     test_env::do_with_async([] (test_env& env) {
       for (const auto version : all_sstable_versions) {
         storage_service_for_tests ssft;
         auto dir = tmpdir();
@@ -1172,7 +1179,6 @@ SEASTAR_TEST_CASE(test_range_tombstones_are_correctly_seralized_for_non_compound
         auto mt = make_lw_shared<memtable>(s);
         mt->apply(m);
 
-        sstables::test_env env;
         auto sst = env.make_sstable(s,
                                           dir.path().string(),
                                           1 /* generation */,
@@ -1188,12 +1194,13 @@ SEASTAR_TEST_CASE(test_range_tombstones_are_correctly_seralized_for_non_compound
                     .produces_end_of_stream();
         }
       }
+     }).get();
     });
 }
 
 SEASTAR_TEST_CASE(test_promoted_index_is_absent_for_schemas_without_clustering_key) {
     return seastar::async([] {
-      auto wait_bg = seastar::defer([] { sstables::await_background_jobs().get(); });
+     test_env::do_with_async([] (test_env& env) {
       for (const auto version : all_sstable_versions) {
         storage_service_for_tests ssft;
         auto dir = tmpdir();
@@ -1211,7 +1218,6 @@ SEASTAR_TEST_CASE(test_promoted_index_is_absent_for_schemas_without_clustering_k
         auto mt = make_lw_shared<memtable>(s);
         mt->apply(m);
 
-        sstables::test_env env;
         auto sst = env.make_sstable(s,
                                           dir.path().string(),
                                           1 /* generation */,
@@ -1224,12 +1230,13 @@ SEASTAR_TEST_CASE(test_promoted_index_is_absent_for_schemas_without_clustering_k
 
         assert_that(get_index_reader(sst)).is_empty(*s);
       }
+     }).get();
     });
 }
 
 SEASTAR_TEST_CASE(test_can_write_and_read_non_compound_range_tombstone_as_compound) {
     return seastar::async([] {
-      auto wait_bg = seastar::defer([] { sstables::await_background_jobs().get(); });
+     test_env::do_with_async([] (test_env& env) {
       for (const auto version : all_sstable_versions) {
         storage_service_for_tests ssft;
         auto dir = tmpdir();
@@ -1270,12 +1277,13 @@ SEASTAR_TEST_CASE(test_can_write_and_read_non_compound_range_tombstone_as_compou
                     .produces_end_of_stream();
         }
       }
+     }).get();
     });
 }
 
 SEASTAR_TEST_CASE(test_writing_combined_stream_with_tombstones_at_the_same_position) {
     return seastar::async([] {
-      auto wait_bg = seastar::defer([] { sstables::await_background_jobs().get(); });
+     test_env::do_with_async([] (test_env& env) {
       for (const auto version : all_sstable_versions) {
         storage_service_for_tests ssft;
         auto dir = tmpdir();
@@ -1306,7 +1314,6 @@ SEASTAR_TEST_CASE(test_writing_combined_stream_with_tombstones_at_the_same_posit
         auto mt2 = make_lw_shared<memtable>(s);
         mt2->apply(m2);
 
-        sstables::test_env env;
         auto sst = env.make_sstable(s,
                                           dir.path().string(),
                                           1 /* generation */,
@@ -1321,12 +1328,13 @@ SEASTAR_TEST_CASE(test_writing_combined_stream_with_tombstones_at_the_same_posit
             .produces(m1 + m2)
             .produces_end_of_stream();
       }
+     }).get();
     });
 }
 
 SEASTAR_TEST_CASE(test_no_index_reads_when_rows_fall_into_range_boundaries) {
     return seastar::async([] {
-        auto wait_bg = seastar::defer([] { sstables::await_background_jobs().get(); });
+      test_env::do_with_async([] (test_env& env) {
         for (const auto version : all_sstable_versions) {
             storage_service_for_tests ssft;
             simple_schema ss(simple_schema::with_static::yes);
@@ -1347,7 +1355,6 @@ SEASTAR_TEST_CASE(test_no_index_reads_when_rows_fall_into_range_boundaries) {
             ss.add_row(m2, ss.make_ckey(6), "v");
 
             tmpdir dir;
-            sstables::test_env env;
             auto ms = make_sstable_mutation_source(env, s, dir.path().string(), {m1, m2}, test_sstables_manager.configure_writer(), version);
 
             auto index_accesses = [] {
@@ -1366,12 +1373,13 @@ SEASTAR_TEST_CASE(test_no_index_reads_when_rows_fall_into_range_boundaries) {
                 BOOST_REQUIRE_EQUAL(index_accesses(), before);
             }
       }
+      }).get();
     });
 }
 
 SEASTAR_TEST_CASE(test_key_count_estimation) {
     return seastar::async([] {
-        auto wait_bg = seastar::defer([] { sstables::await_background_jobs().get(); });
+      test_env::do_with_async([] (test_env& env) {
         for (const auto version : all_sstable_versions) {
             storage_service_for_tests ssft;
             simple_schema ss;
@@ -1388,7 +1396,6 @@ SEASTAR_TEST_CASE(test_key_count_estimation) {
             }
 
             tmpdir dir;
-            sstables::test_env env;
             shared_sstable sst = make_sstable(env, s, dir.path().string(), muts, test_sstables_manager.configure_writer(), version);
 
             auto max_est = sst->get_estimated_key_count();
@@ -1433,12 +1440,12 @@ SEASTAR_TEST_CASE(test_key_count_estimation) {
                 BOOST_REQUIRE_EQUAL(est, 0);
             }
         }
+      }).get();
     });
 }
 
 SEASTAR_THREAD_TEST_CASE(test_large_index_pages_do_not_cause_large_allocations) {
-    auto wait_bg = seastar::defer([] { sstables::await_background_jobs().get(); });
-
+  test_env::do_with_async([] (test_env& env) {
     // We create a sequence of partitions such that first we have a partition with a very long key, then
     // series of partitions with small keys. This should result in large index page.
 
@@ -1492,7 +1499,6 @@ SEASTAR_THREAD_TEST_CASE(test_large_index_pages_do_not_cause_large_allocations) 
         mt->apply(m);
     }
 
-    sstables::test_env env;
     auto sst = env.make_sstable(s,
                                       dir.path().string(),
                                       1 /* generation */,
@@ -1517,12 +1523,13 @@ SEASTAR_THREAD_TEST_CASE(test_large_index_pages_do_not_cause_large_allocations) 
 
     assert_that(actual).is_equal_to(expected);
     BOOST_REQUIRE_EQUAL(large_allocs_after - large_allocs_before, 0);
+  }).get();
 }
 
 SEASTAR_THREAD_TEST_CASE(test_reading_serialization_header) {
+  test_env::do_with_async([] (test_env& env) {
     auto dir = tmpdir();
     storage_service_for_tests ssft;
-    auto wait_bg = seastar::defer([] { sstables::await_background_jobs().get(); });
 
     auto random_int32_value = [] {
         return int32_type->decompose(tests::random::get_int<int32_t>());
@@ -1560,7 +1567,6 @@ SEASTAR_THREAD_TEST_CASE(test_reading_serialization_header) {
     auto m1ow = md1_overwrite.build(s);
     mt->apply(m1ow);
 
-    sstables::test_env env;
     {
         // SSTable class has way too many responsibilities. In particular, it mixes the reading and
         // writting parts. Let's use a separate objects for writing and reading to ensure that nothing
@@ -1589,6 +1595,7 @@ SEASTAR_THREAD_TEST_CASE(test_reading_serialization_header) {
     // Like Cassandra even if a row marker is not expiring we update the metadata with NO_TTL value
     // which is 0.
     BOOST_CHECK(stats.min_ttl == gc_clock::duration(0));
+  }).get();
 }
 
 SEASTAR_THREAD_TEST_CASE(test_merging_encoding_stats) {
@@ -1627,6 +1634,7 @@ SEASTAR_THREAD_TEST_CASE(test_merging_encoding_stats) {
 
 // Reproducer for #4206
 SEASTAR_THREAD_TEST_CASE(test_counter_header_size) {
+  test_env::do_with_async([] (test_env& env) {
     auto dir = tmpdir();
     storage_service_for_tests ssft;
     auto wait_bg = seastar::defer([] { sstables::await_background_jobs().get(); });
@@ -1658,7 +1666,6 @@ SEASTAR_THREAD_TEST_CASE(test_counter_header_size) {
     auto mt = make_lw_shared<memtable>(s);
     mt->apply(m);
 
-    sstables::test_env env;
     for (const auto version : all_sstable_versions) {
         auto sst = env.make_sstable(s, dir.path().string(), 1, version, sstables::sstable::format_types::big);
         sst->write_components(mt->make_flat_reader(s, tests::make_permit()), 1, s, test_sstables_manager.configure_writer(), mt->get_encoding_stats()).get();
@@ -1668,6 +1675,7 @@ SEASTAR_THREAD_TEST_CASE(test_counter_header_size) {
             .produces(m)
             .produces_end_of_stream();
     }
+  }).get();
 }
 
 SEASTAR_TEST_CASE(test_static_compact_tables_are_read) {

--- a/test/boost/sstable_resharding_test.cc
+++ b/test/boost/sstable_resharding_test.cc
@@ -42,6 +42,7 @@ static schema_ptr get_schema(unsigned shard_count, unsigned sharding_ignore_msb_
 
 void run_sstable_resharding_test() {
     test_env env;
+    auto close_env = defer([&] { env.stop().get(); });
     cache_tracker tracker;
   for (const auto version : all_sstable_versions) {
     storage_service_for_tests ssft;
@@ -49,7 +50,7 @@ void run_sstable_resharding_test() {
     auto s = get_schema();
     auto cm = make_lw_shared<compaction_manager>();
     auto cl_stats = make_lw_shared<cell_locker_stats>();
-    auto cf = make_lw_shared<column_family>(s, column_family_test_config(), column_family::no_commitlog(), *cm, *cl_stats, tracker);
+    auto cf = make_lw_shared<column_family>(s, column_family_test_config(env.manager()), column_family::no_commitlog(), *cm, *cl_stats, tracker);
     cf->mark_ready_for_writes();
     std::unordered_map<shard_id, std::vector<mutation>> muts;
     static constexpr auto keys_per_shard = 1000u;

--- a/test/boost/sstable_test.cc
+++ b/test/boost/sstable_test.cc
@@ -245,10 +245,9 @@ SEASTAR_TEST_CASE(check_compressed_info_func) {
     return check_component_integrity(component_type::CompressionInfo);
 }
 
-template <typename Func>
-inline auto
-write_and_validate_sst(schema_ptr s, sstring dir, Func&& func) {
-    return test_env::do_with(tmpdir(), [s = std::move(s), dir = std::move(dir), func = std::move(func)] (test_env& env, tmpdir& tmp) {
+future<>
+write_and_validate_sst(schema_ptr s, sstring dir, noncopyable_function<future<> (shared_sstable sst1, shared_sstable sst2)> func) {
+    return test_env::do_with(tmpdir(), [s = std::move(s), dir = std::move(dir), func = std::move(func)] (test_env& env, tmpdir& tmp) mutable {
         return do_write_sst(env, s, dir, tmp.path().string(), 1).then([&env, &tmp, s = std::move(s), func = std::move(func)] (auto sst1) {
             auto sst2 = env.make_sstable(s, tmp.path().string(), 2, la, big);
             return func(std::move(sst1), std::move(sst2));

--- a/test/boost/sstable_test.cc
+++ b/test/boost/sstable_test.cc
@@ -183,14 +183,10 @@ static future<sstable_ptr> do_write_sst(test_env& env, schema_ptr schema, sstrin
     });
 }
 
-static future<sstable_ptr> do_write_sst(schema_ptr schema, sstring load_dir, sstring write_dir, unsigned long generation) {
-  return test_env::do_with([schema = std::move(schema), load_dir = std::move(load_dir), write_dir = std::move(write_dir), generation] (test_env& env) {
-      return do_write_sst(env, std::move(schema), std::move(load_dir), std::move(write_dir), generation);
-  });
-}
-
 static future<> write_sst_info(schema_ptr schema, sstring load_dir, sstring write_dir, unsigned long generation) {
-    return do_write_sst(std::move(schema), load_dir, write_dir, generation).then([] (auto ptr) { return make_ready_future<>(); });
+    return test_env::do_with([schema = std::move(schema), load_dir = std::move(load_dir), write_dir = std::move(write_dir), generation] (test_env& env) {
+        return do_write_sst(env, std::move(schema), load_dir, write_dir, generation).then([] (auto ptr) { return make_ready_future<>(); });
+    });
 }
 
 using bufptr_t = std::unique_ptr<char [], free_deleter>;

--- a/test/boost/view_build_test.cc
+++ b/test/boost/view_build_test.cc
@@ -433,7 +433,7 @@ SEASTAR_TEST_CASE(test_view_update_generator) {
 
         auto write_to_sstable = [&] (mutation m) {
             auto sst = t->make_streaming_staging_sstable();
-            sstables::sstable_writer_config sst_cfg = test_sstables_manager.configure_writer();
+            sstables::sstable_writer_config sst_cfg = e.db().local().get_user_sstables_manager().configure_writer();
             auto& pc = service::get_local_streaming_priority();
 
             sst->write_components(flat_mutation_reader_from_mutations({m}), 1ul, s, sst_cfg, {}, pc).get();
@@ -547,7 +547,7 @@ SEASTAR_THREAD_TEST_CASE(test_view_update_generator_deadlock) {
         }
 
         auto sst = t->make_streaming_staging_sstable();
-        sstables::sstable_writer_config sst_cfg = test_sstables_manager.configure_writer();
+        sstables::sstable_writer_config sst_cfg = e.local_db().get_user_sstables_manager().configure_writer();
         auto& pc = service::get_local_streaming_priority();
 
         sst->write_components(flat_mutation_reader_from_mutations({m}), 1ul, s, sst_cfg, {}, pc).get();
@@ -619,7 +619,7 @@ SEASTAR_THREAD_TEST_CASE(test_view_update_generator_register_semaphore_unit_leak
             }
 
             auto sst = t->make_streaming_staging_sstable();
-            sstables::sstable_writer_config sst_cfg = test_sstables_manager.configure_writer();
+            sstables::sstable_writer_config sst_cfg = e.local_db().get_user_sstables_manager().configure_writer();
             auto& pc = service::get_local_streaming_priority();
 
             sst->write_components(flat_mutation_reader_from_mutations({m}), 1ul, s, sst_cfg, {}, pc).get();

--- a/test/boost/view_build_test.cc
+++ b/test/boost/view_build_test.cc
@@ -584,7 +584,7 @@ SEASTAR_THREAD_TEST_CASE(test_view_update_generator_register_semaphore_unit_leak
     db_cfg.enable_cache(false);
     db_cfg.enable_commitlog(false);
 
-    do_with_cql_env([] (cql_test_env& e) -> future<> {
+    do_with_cql_env_thread([] (cql_test_env& e) {
         e.execute_cql("create table t (p text, c text, v text, primary key (p, c))").get();
         e.execute_cql("create materialized view tv as select * from t "
                       "where p is not null and c is not null and v is not null "
@@ -682,7 +682,6 @@ SEASTAR_THREAD_TEST_CASE(test_view_update_generator_register_semaphore_unit_leak
 
         watchdog_timer.cancel();
 
-        return make_ready_future<>();
 
     }, std::move(test_cfg)).get();
 }

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -80,12 +80,6 @@ cql_test_config::cql_test_config(shared_ptr<db::config> cfg)
 cql_test_config::cql_test_config(const cql_test_config&) = default;
 cql_test_config::~cql_test_config() = default;
 
-namespace sstables {
-
-future<> await_background_jobs_on_all_shards();
-
-}
-
 static const sstring testing_superuser = "tester";
 
 static future<> tst_init_ms_fd_gossiper(sharded<gms::feature_service>& features, sharded<locator::token_metadata>& tm, sharded<netw::messaging_service>& ms, db::config& cfg, db::seed_provider_type seed_provider,
@@ -380,8 +374,6 @@ public:
             utils::fb_utilities::set_broadcast_rpc_address(gms::inet_address("localhost"));
             locator::i_endpoint_snitch::create_snitch("SimpleSnitch").get();
             auto stop_snitch = defer([] { locator::i_endpoint_snitch::stop_snitch().get(); });
-
-            auto wait_for_background_jobs = defer([] { sstables::await_background_jobs_on_all_shards().get(); });
 
             sharded<abort_source> abort_sources;
             abort_sources.start().get();

--- a/test/lib/sstable_test_env.hh
+++ b/test/lib/sstable_test_env.hh
@@ -50,6 +50,8 @@ public:
         });
     }
 
+    sstables_manager& manager() { return _mgr; }
+
     future<> working_sst(schema_ptr schema, sstring dir, unsigned long generation) {
         return reusable_sst(std::move(schema), dir, generation).then([] (auto ptr) { return make_ready_future<>(); });
     }

--- a/test/lib/sstable_test_env.hh
+++ b/test/lib/sstable_test_env.hh
@@ -82,7 +82,6 @@ public:
 
     static inline future<> do_with_async(noncopyable_function<void (test_env&)> func) {
         return seastar::async([func = std::move(func)] {
-            auto wait_for_background_jobs = defer([] { sstables::await_background_jobs_on_all_shards().get(); });
             test_env env;
             auto close_env = defer([&] { env.stop().get(); });
             func(env);
@@ -91,7 +90,6 @@ public:
 
     static inline future<> do_with_sharded_async(noncopyable_function<void (sharded<test_env>&)> func) {
         return seastar::async([func = std::move(func)] {
-            auto wait_for_background_jobs = defer([] { sstables::await_background_jobs_on_all_shards().get(); });
             sharded<test_env> env;
             env.start().get();
             auto stop = defer([&] { env.stop().get(); });
@@ -102,7 +100,6 @@ public:
     template <typename T>
     static future<T> do_with_async_returning(noncopyable_function<T (test_env&)> func) {
         return seastar::async([func = std::move(func)] {
-            auto wait_for_background_jobs = defer([] { sstables::await_background_jobs_on_all_shards().get(); });
             test_env env;
             auto stop = defer([&] { env.stop().get(); });
             return func(env);

--- a/test/lib/sstable_test_env.hh
+++ b/test/lib/sstable_test_env.hh
@@ -81,6 +81,16 @@ public:
             func(env);
         });
     }
+
+    template <typename T>
+    static future<T> do_with_async_returning(noncopyable_function<T (test_env&)> func) {
+        return seastar::async([func = std::move(func)] {
+            auto wait_for_background_jobs = defer([] { sstables::await_background_jobs_on_all_shards().get(); });
+            test_env env;
+            auto stop = defer([&] { env.stop().get(); });
+            return func(env);
+        });
+    }
 };
 
 }   // namespace sstables

--- a/test/lib/sstable_test_env.hh
+++ b/test/lib/sstable_test_env.hh
@@ -22,6 +22,7 @@
 #pragma once
 
 #include <seastar/core/do_with.hh>
+#include <seastar/util/noncopyable_function.hh>
 
 #include "sstables/sstables.hh"
 #include "test/lib/tmpdir.hh"
@@ -67,8 +68,7 @@ public:
         });
     }
 
-    template <typename Func>
-    static inline auto do_with_async(Func&& func) {
+    static inline future<> do_with_async(noncopyable_function<void (test_env&)> func) {
         return seastar::async([func = std::move(func)] {
             auto wait_for_background_jobs = defer([] { sstables::await_background_jobs_on_all_shards().get(); });
             test_env env;

--- a/test/lib/sstable_test_env.hh
+++ b/test/lib/sstable_test_env.hh
@@ -36,6 +36,10 @@ public:
     explicit test_env() : _mgr(test_sstables_manager) { }
     explicit test_env(sstables_manager& mgr) : _mgr(mgr) { }
 
+    future<> stop() {
+        return make_ready_future<>();
+    }
+
     shared_sstable make_sstable(schema_ptr schema, sstring dir, unsigned long generation,
             sstable::version_types v, sstable::format_types f = sstable::format_types::big,
             size_t buffer_size = default_sstable_buffer_size, gc_clock::time_point now = gc_clock::now()) {

--- a/test/lib/sstable_test_env.hh
+++ b/test/lib/sstable_test_env.hh
@@ -33,13 +33,12 @@
 namespace sstables {
 
 class test_env {
-    sstables_manager& _mgr;
+    sstables_manager _mgr;
 public:
-    explicit test_env() : _mgr(test_sstables_manager) { }
-    explicit test_env(sstables_manager& mgr) : _mgr(mgr) { }
+    explicit test_env() : _mgr(nop_lp_handler, test_db_config, test_feature_service) { }
 
     future<> stop() {
-        return make_ready_future<>();
+        return _mgr.close();
     }
 
     shared_sstable make_sstable(schema_ptr schema, sstring dir, unsigned long generation,

--- a/test/lib/sstable_utils.hh
+++ b/test/lib/sstable_utils.hh
@@ -316,6 +316,7 @@ public:
             storage_service_for_tests ssft;
             auto tmp = tmpdir();
             test_env env;
+            auto close_env = defer([&] { env.stop().get(); });
             fut(env, tmp.path().string()).get();
         });
     }
@@ -331,6 +332,7 @@ public:
             auto dest_path = dest_dir.path() / src.c_str();
             std::filesystem::create_directories(dest_path);
             test_env env;
+            auto close_env = defer([&] { env.stop().get(); });
             fut(env, src_dir.path().string(), dest_path.string()).get();
         });
     }

--- a/test/lib/sstable_utils.hh
+++ b/test/lib/sstable_utils.hh
@@ -44,7 +44,7 @@ using local_shard_only = bool_class<local_shard_only_tag>;
 sstables::shared_sstable make_sstable_containing(std::function<sstables::shared_sstable()> sst_factory, std::vector<mutation> muts);
 
 inline future<> write_memtable_to_sstable_for_test(memtable& mt, sstables::shared_sstable sst) {
-    return write_memtable_to_sstable(mt, sst, test_sstables_manager.configure_writer());
+    return write_memtable_to_sstable(mt, sst, sst->manager().configure_writer());
 }
 
 //

--- a/test/lib/test_services.cc
+++ b/test/lib/test_services.cc
@@ -101,17 +101,12 @@ static const sstring some_column_family("cf");
 db::nop_large_data_handler nop_lp_handler;
 db::config test_db_config;
 gms::feature_service test_feature_service(gms::feature_config_from_db_config(test_db_config));
-thread_local sstables::sstables_manager test_sstables_manager(nop_lp_handler, test_db_config, test_feature_service);
 
 column_family::config column_family_test_config(sstables::sstables_manager& sstables_manager) {
     column_family::config cfg;
     cfg.sstables_manager = &sstables_manager;
     cfg.compaction_concurrency_semaphore = &tests::semaphore();
     return cfg;
-}
-
-column_family::config column_family_test_config() {
-    return column_family_test_config(test_sstables_manager);
 }
 
 column_family_for_tests::column_family_for_tests(sstables::sstables_manager& sstables_manager)
@@ -132,12 +127,4 @@ column_family_for_tests::column_family_for_tests(sstables::sstables_manager& sst
     _data->cfg.enable_commitlog = false;
     _data->cf = make_lw_shared<column_family>(_data->s, _data->cfg, column_family::no_commitlog(), _data->cm, _data->cl_stats, _data->tracker);
     _data->cf->mark_ready_for_writes();
-}
-
-column_family_for_tests::column_family_for_tests()
-        : column_family_for_tests(test_sstables_manager) {
-}
-
-column_family_for_tests::column_family_for_tests(schema_ptr s)
-        : column_family_for_tests(test_sstables_manager, std::move(s)) {
 }

--- a/test/lib/test_services.cc
+++ b/test/lib/test_services.cc
@@ -103,28 +103,41 @@ db::config test_db_config;
 gms::feature_service test_feature_service(gms::feature_config_from_db_config(test_db_config));
 thread_local sstables::sstables_manager test_sstables_manager(nop_lp_handler, test_db_config, test_feature_service);
 
-column_family::config column_family_test_config() {
+column_family::config column_family_test_config(sstables::sstables_manager& sstables_manager) {
     column_family::config cfg;
-    cfg.sstables_manager = &test_sstables_manager;
+    cfg.sstables_manager = &sstables_manager;
     cfg.compaction_concurrency_semaphore = &tests::semaphore();
     return cfg;
 }
 
-column_family_for_tests::column_family_for_tests()
+column_family::config column_family_test_config() {
+    return column_family_test_config(test_sstables_manager);
+}
+
+column_family_for_tests::column_family_for_tests(sstables::sstables_manager& sstables_manager)
     : column_family_for_tests(
+        sstables_manager,
         schema_builder(some_keyspace, some_column_family)
             .with_column(utf8_type->decompose("p1"), utf8_type, column_kind::partition_key)
             .build()
     )
 { }
 
-column_family_for_tests::column_family_for_tests(schema_ptr s)
+column_family_for_tests::column_family_for_tests(sstables::sstables_manager& sstables_manager, schema_ptr s)
     : _data(make_lw_shared<data>())
 {
     _data->s = s;
-    _data->cfg = column_family_test_config();
+    _data->cfg = column_family_test_config(sstables_manager);
     _data->cfg.enable_disk_writes = false;
     _data->cfg.enable_commitlog = false;
     _data->cf = make_lw_shared<column_family>(_data->s, _data->cfg, column_family::no_commitlog(), _data->cm, _data->cl_stats, _data->tracker);
     _data->cf->mark_ready_for_writes();
+}
+
+column_family_for_tests::column_family_for_tests()
+        : column_family_for_tests(test_sstables_manager) {
+}
+
+column_family_for_tests::column_family_for_tests(schema_ptr s)
+        : column_family_for_tests(test_sstables_manager, std::move(s)) {
 }

--- a/test/lib/test_services.hh
+++ b/test/lib/test_services.hh
@@ -48,6 +48,7 @@ extern db::config test_db_config;
 extern gms::feature_service test_feature_service;
 extern thread_local sstables::sstables_manager test_sstables_manager;
 
+column_family::config column_family_test_config(sstables::sstables_manager& sstables_manager);
 column_family::config column_family_test_config();
 
 struct column_family_for_tests {
@@ -61,7 +62,11 @@ struct column_family_for_tests {
     };
     lw_shared_ptr<data> _data;
 
-    column_family_for_tests();
+    explicit column_family_for_tests(sstables::sstables_manager& sstables_manager);
+
+    explicit column_family_for_tests(sstables::sstables_manager& sstables_manager, schema_ptr s);
+
+    explicit column_family_for_tests();
 
     explicit column_family_for_tests(schema_ptr s);
 

--- a/test/lib/test_services.hh
+++ b/test/lib/test_services.hh
@@ -46,10 +46,8 @@ public:
 extern db::nop_large_data_handler nop_lp_handler;
 extern db::config test_db_config;
 extern gms::feature_service test_feature_service;
-extern thread_local sstables::sstables_manager test_sstables_manager;
 
 column_family::config column_family_test_config(sstables::sstables_manager& sstables_manager);
-column_family::config column_family_test_config();
 
 struct column_family_for_tests {
     struct data {
@@ -65,10 +63,6 @@ struct column_family_for_tests {
     explicit column_family_for_tests(sstables::sstables_manager& sstables_manager);
 
     explicit column_family_for_tests(sstables::sstables_manager& sstables_manager, schema_ptr s);
-
-    explicit column_family_for_tests();
-
-    explicit column_family_for_tests(schema_ptr s);
 
     schema_ptr schema() { return _data->s; }
 

--- a/test/perf/perf_sstable.hh
+++ b/test/perf/perf_sstable.hh
@@ -153,7 +153,7 @@ public:
 
     future<double> compaction(int idx) {
         return test_setup::create_empty_test_dir(dir()).then([this, idx] {
-            return seastar::async([this, idx] {
+            return sstables::test_env::do_with_async_returning<double>([this, idx] (sstables::test_env& env) {
                 auto sst_gen = [this, gen = make_lw_shared<unsigned>(idx)] () mutable {
                     return _env.make_sstable(s, dir(), (*gen)++, sstable::version_types::ka, sstable::format_types::big, _cfg.buffer_size);
                 };
@@ -170,7 +170,7 @@ public:
                 cache_tracker tracker;
                 cell_locker_stats cl_stats;
                 auto cm = make_lw_shared<compaction_manager>();
-                auto cf = make_lw_shared<column_family>(s, column_family_test_config(), column_family::no_commitlog(), *cm, cl_stats, tracker);
+                auto cf = make_lw_shared<column_family>(s, column_family_test_config(env.manager()), column_family::no_commitlog(), *cm, cl_stats, tracker);
 
                 auto start = perf_sstable_test_env::now();
 


### PR DESCRIPTION
Currently, sstable_manager is used to create sstables, but it loses track
of them immediately afterwards. This series makes an sstable's life fully
contained within its sstable_manager.

The first practical impact (implemented in this series) is that file removal
stops being a background job; instead it is tracked by the sstable_manager,
so when the sstable_manager is stopped, you know that all of its sstable
activity is complete.

Later, we can make use of this to track the data size on disk, but this is not
implemented here.