### PR TITLE
scripts/pull_pr: don't pollute local branch namespace

### DIFF
--- a/scripts/pull_github_pr.sh
+++ b/scripts/pull_github_pr.sh
@@ -29,25 +29,23 @@ PR_PREFIX=https://api.github.com/repos/scylladb/scylla/pulls
 PR_DATA=$(curl -s $PR_PREFIX/$PR_NUM)
 PR_TITLE=$(jq -r .title <<< $PR_DATA)
 PR_DESCR=$(jq -r .body <<< $PR_DATA)
-PR_REF=$(jq -r .head.ref <<< $PR_DATA)
 PR_LOGIN=$(jq -r .head.user.login <<< $PR_DATA)
 PR_REPO=$(jq -r .head.repo.html_url <<< $PR_DATA)
-PR_LOCAL_BRANCH=$PR_LOGIN-$PR_REF
 
 USER_NAME=$(curl -s "https://api.github.com/users/$PR_LOGIN" | jq -r .name)
 
-git fetch origin pull/$PR_NUM/head:$PR_LOCAL_BRANCH
+git fetch origin pull/$PR_NUM/head
 
-nr_commits=$(git log --pretty=oneline HEAD..$PR_LOCAL_BRANCH | wc -l)
+nr_commits=$(git log --pretty=oneline HEAD..FETCH_HEAD | wc -l)
 
 closes="${NL}${NL}Closes #${PR_NUM}${NL}"
 
 if [[ $nr_commits == 1 ]]; then
-	commit=$(git log --pretty=oneline HEAD..$PR_LOCAL_BRANCH | awk '{print $1}')
+	commit=$(git log --pretty=oneline HEAD..FETCH_HEAD | awk '{print $1}')
 	message="$(git log -1 "$commit" --format="format:%s%n%n%b")"
 	git cherry-pick $commit
 	git commit --amend -m "${message}${closes}"
 else
-	git merge --no-ff --log $PR_LOCAL_BRANCH -m "Merge '$PR_TITLE' from $USER_NAME" -m "${PR_DESCR}${closes}"
+	git merge --no-ff --log FETCH_HEAD -m "Merge '$PR_TITLE' from $USER_NAME" -m "${PR_DESCR}${closes}"
 fi
 git commit --amend # for a manual double-check


### PR DESCRIPTION
Currently, scripts/pull_pr pollutes the local branch namespace
by creating a branch and never deleting it. This can be avoided
by using FETCH_HEAD, a temporary name automatically assigned by
git to fetches with no destination.