### PR TITLE
Add max concurrent requests configuration option to coordinator

### DIFF
--- a/db/config.cc
+++ b/db/config.cc
@@ -745,6 +745,8 @@ db::config::config(std::shared_ptr<db::extensions> exts)
     , user_defined_function_contiguous_allocation_limit_bytes(this, "user_defined_function_contiguous_allocation_limit_bytes", value_status::Used, 1024*1024, "How much memory each UDF invocation can allocate in one chunk")
     , schema_registry_grace_period(this, "schema_registry_grace_period", value_status::Used, 1,
         "Time period in seconds after which unused schema versions will be evicted from the local schema registry cache. Default is 1 second.")
+    , max_concurrent_requests_per_shard(this, "max_concurrent_requests_per_shard", value_status::Used, std::numeric_limits<uint32_t>::max(),
+        "Maximum number of concurrent requests a single shard can handle before it starts shedding extra load. By default, no requests will be shed.")
     , alternator_port(this, "alternator_port", value_status::Used, 0, "Alternator API port")
     , alternator_https_port(this, "alternator_https_port", value_status::Used, 0, "Alternator API HTTPS port")
     , alternator_address(this, "alternator_address", value_status::Used, "0.0.0.0", "Alternator API listening address")

--- a/db/config.cc
+++ b/db/config.cc
@@ -745,7 +745,7 @@ db::config::config(std::shared_ptr<db::extensions> exts)
     , user_defined_function_contiguous_allocation_limit_bytes(this, "user_defined_function_contiguous_allocation_limit_bytes", value_status::Used, 1024*1024, "How much memory each UDF invocation can allocate in one chunk")
     , schema_registry_grace_period(this, "schema_registry_grace_period", value_status::Used, 1,
         "Time period in seconds after which unused schema versions will be evicted from the local schema registry cache. Default is 1 second.")
-    , max_concurrent_requests_per_shard(this, "max_concurrent_requests_per_shard", value_status::Used, std::numeric_limits<uint32_t>::max(),
+    , max_concurrent_requests_per_shard(this, "max_concurrent_requests_per_shard",liveness::LiveUpdate, value_status::Used, std::numeric_limits<uint32_t>::max(),
         "Maximum number of concurrent requests a single shard can handle before it starts shedding extra load. By default, no requests will be shed.")
     , alternator_port(this, "alternator_port", value_status::Used, 0, "Alternator API port")
     , alternator_https_port(this, "alternator_https_port", value_status::Used, 0, "Alternator API HTTPS port")

--- a/db/config.hh
+++ b/db/config.hh
@@ -315,6 +315,7 @@ public:
     named_value<unsigned> user_defined_function_allocation_limit_bytes;
     named_value<unsigned> user_defined_function_contiguous_allocation_limit_bytes;
     named_value<uint32_t> schema_registry_grace_period;
+    named_value<uint32_t> max_concurrent_requests_per_shard;
 
     named_value<uint16_t> alternator_port;
     named_value<uint16_t> alternator_https_port;

--- a/exceptions/exceptions.hh
+++ b/exceptions/exceptions.hh
@@ -228,6 +228,8 @@ struct read_failure_exception : public request_failure_exception {
 struct overloaded_exception : public cassandra_exception {
     overloaded_exception(size_t c) noexcept :
         cassandra_exception(exception_code::OVERLOADED, prepare_message("Too many in flight hints: %lu", c)) {}
+    explicit overloaded_exception(sstring msg) noexcept :
+        cassandra_exception(exception_code::OVERLOADED, std::move(msg)) {}
 };
 
 class request_validation_exception : public cassandra_exception {

--- a/exceptions/exceptions.hh
+++ b/exceptions/exceptions.hh
@@ -226,7 +226,7 @@ struct read_failure_exception : public request_failure_exception {
 };
 
 struct overloaded_exception : public cassandra_exception {
-    overloaded_exception(size_t c) noexcept :
+    explicit overloaded_exception(size_t c) noexcept :
         cassandra_exception(exception_code::OVERLOADED, prepare_message("Too many in flight hints: %lu", c)) {}
     explicit overloaded_exception(sstring msg) noexcept :
         cassandra_exception(exception_code::OVERLOADED, std::move(msg)) {}

--- a/transport/controller.cc
+++ b/transport/controller.cc
@@ -69,6 +69,7 @@ future<> controller::do_start_server() {
         cql_transport::cql_server_config cql_server_config;
         cql_server_config.timeout_config = make_timeout_config(cfg);
         cql_server_config.max_request_size = service::get_local_storage_service()._service_memory_total;
+        cql_server_config.max_concurrent_requests = cfg.max_concurrent_requests_per_shard();
         cql_server_config.get_service_memory_limiter_semaphore = [ss = std::ref(service::get_storage_service())] () -> semaphore& { return ss.get().local()._service_memory_limiter; };
         cql_server_config.allow_shard_aware_drivers = cfg.enable_shard_aware_drivers();
         cql_server_config.sharding_ignore_msb = cfg.murmur3_partitioner_ignore_msb_bits();

--- a/transport/controller.cc
+++ b/transport/controller.cc
@@ -69,7 +69,7 @@ future<> controller::do_start_server() {
         cql_transport::cql_server_config cql_server_config;
         cql_server_config.timeout_config = make_timeout_config(cfg);
         cql_server_config.max_request_size = service::get_local_storage_service()._service_memory_total;
-        cql_server_config.max_concurrent_requests = cfg.max_concurrent_requests_per_shard();
+        cql_server_config.max_concurrent_requests = cfg.max_concurrent_requests_per_shard;
         cql_server_config.get_service_memory_limiter_semaphore = [ss = std::ref(service::get_storage_service())] () -> semaphore& { return ss.get().local()._service_memory_limiter; };
         cql_server_config.allow_shard_aware_drivers = cfg.enable_shard_aware_drivers();
         cql_server_config.sharding_ignore_msb = cfg.murmur3_partitioner_ignore_msb_bits();

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -614,8 +614,8 @@ future<> cql_server::connection::process_request() {
         auto mem_estimate = f.length * 2 + 8000; // Allow for extra copies and bookkeeping
 
         if (mem_estimate > _server._max_request_size) {
-            throw exceptions::invalid_request_exception(format("request size too large (frame size {:d}; estimate {:d}; allowed {:d}",
-                    f.length, mem_estimate, _server._max_request_size));
+            return make_exception_future<>(exceptions::invalid_request_exception(format("request size too large (frame size {:d}; estimate {:d}; allowed {:d}",
+                    f.length, mem_estimate, _server._max_request_size)));
         }
 
         if (_server._requests_serving > _server._config.max_concurrent_requests) {

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -618,6 +618,11 @@ future<> cql_server::connection::process_request() {
                     f.length, mem_estimate, _server._max_request_size));
         }
 
+        if (_server._requests_serving > _server._config.max_concurrent_requests) {
+            return make_exception_future<>(
+                    exceptions::overloaded_exception(format("too many in-flight requests: {}", _server._requests_serving)));
+        }
+
         auto fut = get_units(_server._memory_available, mem_estimate);
         if (_server._memory_available.waiters()) {
             ++_server._requests_blocked_memory;

--- a/transport/server.hh
+++ b/transport/server.hh
@@ -104,6 +104,7 @@ struct cql_query_state {
 struct cql_server_config {
     ::timeout_config timeout_config;
     size_t max_request_size;
+    uint32_t max_concurrent_requests;
     std::function<semaphore& ()> get_service_memory_limiter_semaphore;
     sstring partitioner_name;
     unsigned sharding_ignore_msb;

--- a/transport/server.hh
+++ b/transport/server.hh
@@ -39,6 +39,7 @@
 #include "utils/fragmented_temporary_buffer.hh"
 #include "service_permit.hh"
 #include <seastar/core/sharded.hh>
+#include "utils/updateable_value.hh"
 
 namespace scollectd {
 
@@ -104,7 +105,7 @@ struct cql_query_state {
 struct cql_server_config {
     ::timeout_config timeout_config;
     size_t max_request_size;
-    uint32_t max_concurrent_requests;
+    utils::updateable_value<uint32_t> max_concurrent_requests;
     std::function<semaphore& ()> get_service_memory_limiter_semaphore;
     sstring partitioner_name;
     unsigned sharding_ignore_msb;


### PR DESCRIPTION
This series approaches issue #7072 and provides a very simple mechanism for limiting the number of concurrent CQL requests being served on a shard. Once the limit is hit, new requests will be instantly refused and OverloadedException will be returned to the client.
This mechanism has many improvement opportunities:
 * shedding requests gradually instead of having one hard limit,
 * having more than one limit per different types of queries (reads, writes, schema changes, ...),
 * not using a preconfigured value at all, and instead figuring out the limit dynamically,
 * etc.

... and none of these are taken into account in this series, which only adds a very basic configuration variable. The variable can be updated live without a restart - it can be done by updating the .yaml file and triggering a configuration re-read via sending the SIGHUP signal to Scylla.

The default value for this parameter is a very large number, which translates to effectively not shedding any requests at all.

Refs #7072
