### PR TITLE
dist/common/scripts: move back get_set_nic_and_disks_config_value to scylla_util.py

### DIFF
--- a/dist/common/scripts/scylla_sysconfig_setup
+++ b/dist/common/scripts/scylla_sysconfig_setup
@@ -27,26 +27,6 @@ import subprocess
 import re
 from scylla_util import *
 
-# Remove this when we do not support SET_NIC configuration value anymore
-def get_set_nic_and_disks_config_value(cfg):
-    """
-    Get the SET_NIC_AND_DISKS configuration value.
-    Return the SET_NIC configuration value if SET_NIC_AND_DISKS is not found (old releases case).
-    :param cfg: sysconfig_parser object
-    :return configuration value
-    :except If the configuration value is not found
-    """
-
-    # Sanity check
-    if cfg.has_option('SET_NIC_AND_DISKS') and cfg.has_option('SET_NIC'):
-        raise Exception("Only one of 'SET_NIC_AND_DISKS' and 'SET_NIC' is allowed to be present")
-
-    try:
-        return cfg.get('SET_NIC_AND_DISKS')
-    except Exception:
-        # For backwards compatibility
-        return cfg.get('SET_NIC')
-
 def bool2str(val):
     return 'yes' if val else 'no'
 

--- a/dist/common/scripts/scylla_util.py
+++ b/dist/common/scripts/scylla_util.py
@@ -660,6 +660,27 @@ def is_valid_nic(nic):
     return os.path.exists('/sys/class/net/{}'.format(nic))
 
 
+# Remove this when we do not support SET_NIC configuration value anymore
+def get_set_nic_and_disks_config_value(cfg):
+    """
+    Get the SET_NIC_AND_DISKS configuration value.
+    Return the SET_NIC configuration value if SET_NIC_AND_DISKS is not found (old releases case).
+    :param cfg: sysconfig_parser object
+    :return configuration value
+    :except If the configuration value is not found
+    """
+
+    # Sanity check
+    if cfg.has_option('SET_NIC_AND_DISKS') and cfg.has_option('SET_NIC'):
+        raise Exception("Only one of 'SET_NIC_AND_DISKS' and 'SET_NIC' is allowed to be present")
+
+    try:
+        return cfg.get('SET_NIC_AND_DISKS')
+    except Exception:
+        # For backwards compatibility
+        return cfg.get('SET_NIC')
+
+
 def swap_exists():
     swaps = out('swapon --noheadings --raw')
     return True if swaps != '' else False


### PR DESCRIPTION
The function mistakenly moved to scylla_sysconfig_setup but it also referenced
from scylla_prepare, move back to scylla_util.py

Fixes #7276