### PR TITLE
gossiper: Use dedicated gossip scheduling group

### DIFF
--- a/database.hh
+++ b/database.hh
@@ -1218,6 +1218,7 @@ struct database_config {
     seastar::scheduling_group memory_compaction_scheduling_group;
     seastar::scheduling_group statement_scheduling_group;
     seastar::scheduling_group streaming_scheduling_group;
+    seastar::scheduling_group gossip_scheduling_group;
     size_t available_memory;
 };
 


### PR DESCRIPTION
Gossip currently runs inside the default (main) scheduling group. It is
fine to run inside default scheduling group. From time to time, we see
many tasks in main scheduling group and we suspect gossip. It is best
we can move gossip to a dedicated scheduling group, so that we can catch
bugs that leak tasks to main group more easily.

After this patch, we can check:

scylla_scheduler_time_spent_on_task_quota_violations_ms{group="gossip",shard="0"}

Fixes #7154