### PR TITLE
install.sh: stop using symlinks for systemd units on nonroot mode

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -206,7 +206,7 @@ if ! $nonroot; then
 else
     retc="$rprefix/etc"
     rsysconfdir="$rprefix/$sysconfdir"
-    rsystemd="$retc/systemd"
+    rsystemd="$HOME/.config/systemd/user"
     rdoc="$rprefix/share/doc"
     rdata="$rprefix"
 fi
@@ -323,8 +323,8 @@ EOS
     done
 else
     install -m755 -d "$rdata"/saved_caches
-    install -d -m755 "$retc"/systemd/system/scylla-server.service.d
-    cat << EOS > "$retc"/systemd/system/scylla-server.service.d/nonroot.conf
+    install -d -m755 "$rsystemd"/scylla-server.service.d
+    cat << EOS > "$rsystemd"/scylla-server.service.d/nonroot.conf
 [Service]
 EnvironmentFile=
 EnvironmentFile=$rsysconfdir/scylla-server
@@ -335,8 +335,8 @@ ExecStart=$rprefix/bin/scylla \$SCYLLA_ARGS \$SEASTAR_IO \$DEV_MODE \$CPUSET
 ExecStopPost=
 User=
 EOS
-     install -d -m755 "$retc"/systemd/system/node-exporter.service.d
-     cat << EOS > "$retc"/systemd/system/node-exporter.service.d/nonroot.conf
+     install -d -m755 "$rsystemd"/node-exporter.service.d
+     cat << EOS > "$rsystemd"/node-exporter.service.d/nonroot.conf
 [Service]
 ExecStart=
 ExecStart=$rprefix/bin/node_exporter  --collector.interrupts
@@ -347,16 +347,6 @@ EOS
     for i in $SBINFILES; do
         ln -srf "$rprefix/scripts/$i" "$rprefix/sbin/$i"
     done
-    if [ ! -d ~/.config/systemd/user/scylla-server.service.d ]; then
-        mkdir -p ~/.config/systemd/user/scylla-server.service.d
-    fi
-    ln -srf $rsystemd/scylla-server.service ~/.config/systemd/user/
-    ln -srf "$retc"/systemd/system/scylla-server.service.d/nonroot.conf ~/.config/systemd/user/scylla-server.service.d
-    if [ ! -d ~/.config/systemd/user/node-exporter.service.d ]; then
-        mkdir -p ~/.config/systemd/user/node-exporter.service.d
-    fi
-    ln -srf $rsystemd/node-exporter.service ~/.config/systemd/user/
-    ln -srf "$retc"/systemd/system/node-exporter.service.d/nonroot.conf ~/.config/systemd/user/node-exporter.service.d
 fi
 
 install -m755 scylla-gdb.py -Dt "$rprefix"/scripts/

--- a/unified/uninstall.sh
+++ b/unified/uninstall.sh
@@ -59,7 +59,7 @@ else
     sysconfdir=/etc/sysconfig
     retc="$rprefix/etc"
     rsysconfdir="$rprefix/$sysconfdir"
-    rsystemd="$retc/systemd"
+    rsystemd="$HOME/.config/systemd/user"
     rdoc="$rprefix/share/doc"
     rdata="$rprefix"
 fi
@@ -77,8 +77,8 @@ rm -rfv "$rprefix"/api
 rm -rfv "$rprefix"/scyllatop
 rm -rfv "$rprefix"/scripts
 rm -rfv "$rprefix"/bin
-rm -rfv "$retc"/systemd/system/scylla-server.service.d
 if ! $nonroot; then
+    rm -rfv "$retc"/systemd/system/scylla-server.service.d
     rm -rfv "$retc"/systemd/system/scylla-housekeeping-*.service.d
     rm -fv "$retc"/security/limits.d/scylla.conf
     rm -fv "$rusr"/bin/scylla
@@ -88,10 +88,9 @@ if ! $nonroot; then
     find "$rusr"/lib/scylla -type l -exec rm -fv {} \;
     rm -rfv "$rusr"/lib/scylla/scyllatop
 else
-    rm -rfv "$retc"/systemd/system/node-exporter.service.d
     rm -rfv "$rprefix"/sbin
-    rm -rfv ~/.config/systemd/user/scylla-server.service.d
-    rm -fv ~/.config/systemd/user/{scylla-server.service,node-exporter.service}
+    rm -rfv "$rsystemd"/scylla-server.service.d
+    rm -rfv "$rsystemd"/node-exporter.service.d
 fi
 
 # scylla-python3
@@ -99,10 +98,10 @@ rm -rfv "$rprefix"/python3
 
 # scylla-jmx
 rm -fv "$rsystemd"/scylla-jmx.service
-rm -rfv "$retc"/systemd/system/scylla-jmx.service.d
-if $nonroot; then
-    rm -fv ~/.config/systemd/user/scylla-jmx.service
-    rm -rfv ~/.config/systemd/user/scylla-jmx.service.d
+if ! $nonroot; then
+    rm -rfv "$retc"/systemd/system/scylla-jmx.service.d
+else
+    rm -rfv "$rsystemd"/scylla-jmx.service.d
 fi
 rm -rfv "$rprefix"/jmx
 if ! $nonroot; then


### PR DESCRIPTION
On some environment, systemctl enable <service> fails when we use symlink.
So just directly copy systemd units to ~/.config/systemd/user, instead of
creating symlink.

Fixes #7288