### PR TITLE
Enhance max concurrent requests code

### DIFF
--- a/transport/server.cc
+++ b/transport/server.cc
@@ -179,6 +179,9 @@ cql_server::cql_server(distributed<cql3::query_processor>& qp, auth::service& au
                         sm::description(
                             seastar::format("Holds an incrementing counter with the requests that ever blocked due to reaching the memory quota limit ({}B). "
                                             "The first derivative of this value shows how often we block due to memory exhaustion in the \"CQL transport\" component.", _max_request_size))),
+        sm::make_derive("requests_shed", _requests_shed,
+                        sm::description("Holds an incrementing counter with the requests that were shed due to overload (threshold configured via max_concurrent_requests_per_shard). "
+                                            "The first derivative of this value shows how often we shed requests due to overload in the \"CQL transport\" component.")),
        sm::make_gauge("requests_memory_available", [this] { return _memory_available.current(); },
                         sm::description(
                             seastar::format("Holds the amount of available memory for admitting new requests (max is {}B)."
@@ -619,6 +622,7 @@ future<> cql_server::connection::process_request() {
         }
 
         if (_server._requests_serving > _server._config.max_concurrent_requests) {
+            ++_server._requests_shed;
             return make_exception_future<>(
                     exceptions::overloaded_exception(format("too many in-flight requests: {}", _server._requests_serving)));
         }

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -624,7 +624,7 @@ future<> cql_server::connection::process_request() {
         if (_server._requests_serving > _server._config.max_concurrent_requests) {
             ++_server._requests_shed;
             return make_exception_future<>(
-                    exceptions::overloaded_exception(format("too many in-flight requests: {}", _server._requests_serving)));
+                    exceptions::overloaded_exception(format("too many in-flight requests (configured via max_concurrent_requests_per_shard): {}", _server._requests_serving)));
         }
 
         auto fut = get_units(_server._memory_available, mem_estimate);

--- a/transport/server.hh
+++ b/transport/server.hh
@@ -134,6 +134,7 @@ private:
     uint64_t _requests_served = 0;
     uint64_t _requests_serving = 0;
     uint64_t _requests_blocked_memory = 0;
+    uint64_t _requests_shed = 0;
     auth::service& _auth_service;
 public:
     cql_server(distributed<cql3::query_processor>& qp, auth::service&,

--- a/transport/server.hh
+++ b/transport/server.hh
@@ -132,7 +132,7 @@ private:
     uint64_t _connects = 0;
     uint64_t _connections = 0;
     uint64_t _requests_served = 0;
-    uint64_t _requests_serving = 0;
+    uint32_t _requests_serving = 0;
     uint64_t _requests_blocked_memory = 0;
     uint64_t _requests_shed = 0;
     auth::service& _auth_service;


### PR DESCRIPTION
This miniseries enhances the code from #7279 by:
 * adding metrics for shed requests, which will allow to pinpoint the problem if the max concurrent requests threshold is too low
 * making the error message more comprehensive by pointing at the variable used to set max concurrent requests threshold

Example of an ehanced error message:
```
ConnectionException('Failed to initialize new connection to 127.0.0.1: Error from server: code=1001 [Coordinator node overloaded] message="too many in-flight requests (configured via max_concurrent_requests_per_shard): 18"',)})
```

Note: this pull request is against /next, because #7279 is not merged yet.