### PR TITLE
transport: Delay NEW_NODE until CQL listen started

### DIFF
--- a/transport/server.hh
+++ b/transport/server.hh
@@ -273,6 +273,12 @@ class cql_server::event_notifier : public service::migration_listener,
     std::unordered_map<gms::inet_address, event::status_change::status_type> _last_status_change;
     service::migration_notifier& _mnotifier;
     bool _stopped = false;
+
+    // We want to delay sending NEW_NODE CQL event to clients until the new node
+    // has started listening for CQL requests.
+    std::unordered_set<gms::inet_address> _endpoints_pending_joined_notification;
+
+    void send_join_cluster(const gms::inet_address& endpoint);
 public:
     future<> stop();
     event_notifier(service::migration_notifier& mn);


### PR DESCRIPTION
After adding a new node to the cluster, Scylla sends a `NEW_NODE` event to CQL clients. Some clients immediately try to connect to the new node, however they fail as the node has not yet started listening to CQL requests.

In contrast, Apache Cassandra waits for the new node to start its CQL server before sending `NEW_NODE` event. In practice this means that `NEW_NODE` and `UP` events will be sent "jointly" after new node is `UP`.

This change is implemented in the same manner as in Apache Cassandra code:

- [`endpointsPendingJoinedNotification` field in `EventNotifier`](https://github.com/apache/cassandra/blob/79e693e16e2152097c5b27d2d7aaa1763e34f594/src/java/org/apache/cassandra/transport/Server.java#L589-L591)
- [`onUp`](https://github.com/apache/cassandra/blob/79e693e16e2152097c5b27d2d7aaa1763e34f594/src/java/org/apache/cassandra/transport/Server.java#L653-L659)
- [`onJoinCluster`](https://github.com/apache/cassandra/blob/79e693e16e2152097c5b27d2d7aaa1763e34f594/src/java/org/apache/cassandra/transport/Server.java#L635-L641)

Fixes #7301.