### PR TITLE
transport/config: fix cross-shard use of updateable_value

### DIFF
--- a/transport/controller.cc
+++ b/transport/controller.cc
@@ -69,7 +69,9 @@ future<> controller::do_start_server() {
         cql_transport::cql_server_config cql_server_config;
         cql_server_config.timeout_config = make_timeout_config(cfg);
         cql_server_config.max_request_size = service::get_local_storage_service()._service_memory_total;
-        cql_server_config.max_concurrent_requests = cfg.max_concurrent_requests_per_shard;
+        cql_server_config.get_max_concurrent_requests_updateable_value = [ss = std::ref(service::get_storage_service())] () -> utils::updateable_value<uint32_t> {
+            return ss.get().local().db().local().get_config().max_concurrent_requests_per_shard;
+        };
         cql_server_config.get_service_memory_limiter_semaphore = [ss = std::ref(service::get_storage_service())] () -> semaphore& { return ss.get().local()._service_memory_limiter; };
         cql_server_config.allow_shard_aware_drivers = cfg.enable_shard_aware_drivers();
         cql_server_config.sharding_ignore_msb = cfg.murmur3_partitioner_ignore_msb_bits();

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -152,6 +152,7 @@ cql_server::cql_server(distributed<cql3::query_processor>& qp, auth::service& au
     : _query_processor(qp)
     , _config(config)
     , _max_request_size(config.max_request_size)
+    , _max_concurrent_requests(config.get_max_concurrent_requests_updateable_value())
     , _memory_available(config.get_service_memory_limiter_semaphore())
     , _notifier(std::make_unique<event_notifier>(mn))
     , _auth_service(auth_service)
@@ -618,7 +619,7 @@ future<> cql_server::connection::process_request() {
                     f.length, mem_estimate, _server._max_request_size)));
         }
 
-        if (_server._requests_serving > _server._config.max_concurrent_requests) {
+        if (_server._requests_serving > _server._max_concurrent_requests) {
             return make_exception_future<>(
                     exceptions::overloaded_exception(format("too many in-flight requests: {}", _server._requests_serving)));
         }

--- a/transport/server.hh
+++ b/transport/server.hh
@@ -105,7 +105,7 @@ struct cql_query_state {
 struct cql_server_config {
     ::timeout_config timeout_config;
     size_t max_request_size;
-    utils::updateable_value<uint32_t> max_concurrent_requests;
+    std::function<utils::updateable_value<uint32_t> ()> get_max_concurrent_requests_updateable_value;
     std::function<semaphore& ()> get_service_memory_limiter_semaphore;
     sstring partitioner_name;
     unsigned sharding_ignore_msb;
@@ -125,6 +125,7 @@ private:
     distributed<cql3::query_processor>& _query_processor;
     cql_server_config _config;
     size_t _max_request_size;
+    utils::updateable_value<uint32_t> _max_concurrent_requests;
     semaphore& _memory_available;
     seastar::metrics::metric_groups _metrics;
     std::unique_ptr<event_notifier> _notifier;


### PR DESCRIPTION
Recently, the cql_server_config::max_concurrent_requests field was
changed to be an updateable_value, so that it is updated when the
corresponding option in Scylla's configuration is live-reloaded.
Unfortunately, due to how cql_server is constructed, this caused
cql_server instances on all shards to store an updateable_value which
pointed to an updateable_value_source on shard 0. Unsynchronized
cross-shard memory operations ensue.

The fix changes the cql_server_config so that it holds a function which
creates an updateable_value appropriate for the given shard. This
pattern is similar to another, already existing option in the config:
get_service_memory_limiter_semaphore.

This fix can be reverted if updateable_value becomes safe to use across
shards.

Tests: unit(dev)

Fixes: #7310