### PR TITLE
idl: fix definition order related build failures with clang

### DIFF
--- a/frozen_schema.cc
+++ b/frozen_schema.cc
@@ -24,10 +24,14 @@
 #include "canonical_mutation.hh"
 #include "schema_mutations.hh"
 #include "idl/uuid.dist.hh"
+#include "idl/keys.dist.hh"
+#include "idl/mutation.dist.hh"
 #include "idl/frozen_schema.dist.hh"
 #include "serializer_impl.hh"
 #include "serialization_visitors.hh"
 #include "idl/uuid.dist.impl.hh"
+#include "idl/keys.dist.impl.hh"
+#include "idl/mutation.dist.impl.hh"
 #include "idl/frozen_schema.dist.impl.hh"
 
 frozen_schema::frozen_schema(const schema_ptr& s)

--- a/idl-compiler.py
+++ b/idl-compiler.py
@@ -1037,9 +1037,9 @@ def load_file(name):
     data = parse_file(name)
     if data:
         handle_types(data)
-    add_visitors(cout)
     if data:
         handle_objects(data, hout, cout)
+    add_visitors(cout)
     if config.ns != '':
         fprintln(cout, "}")
     cout.close()

--- a/query-result-reader.hh
+++ b/query-result-reader.hh
@@ -33,9 +33,9 @@
 #include "idl/query.dist.hh"
 #include "serializer_impl.hh"
 #include "serialization_visitors.hh"
-#include "idl/query.dist.impl.hh"
-#include "idl/keys.dist.impl.hh"
 #include "idl/uuid.dist.impl.hh"
+#include "idl/keys.dist.impl.hh"
+#include "idl/query.dist.impl.hh"
 
 namespace query {
 


### PR DESCRIPTION
Clang eagerly instantiates templates, apparently with the following algorithm:

 - if both the declaration and definition are seen at the time of instantiation, instantiate the template
 - if only the declaration is see at the time of instantiation, just emit a reference to the template; even if the definition is later seen, it is not instantiated

The "reference" in the second case is a relocation entry in the object file that is satisfied at link time by the linker, but if no other object file instantiated the needed template, a link error results.

These problems are hard to diagnose but easy to fix. This series fixes all known such issues in the code base. It was tested on gcc as well.