### PR TITLE
dist/common/scripts/scylla_setup: force developer mode on nonroot when NOFILE is too low

### DIFF
--- a/dist/common/scripts/scylla_setup
+++ b/dist/common/scripts/scylla_setup
@@ -501,6 +501,12 @@ if __name__ == '__main__':
     if node_exporter:
         run_setup_script('node exporter', 'node_exporter_install')
 
+    if is_nonroot():
+        params = out('systemctl --no-pager show user@1000.service')
+        res = re.findall(r'^LimitNOFILE=(.*)$', params, flags=re.MULTILINE)
+        if res and int(res[0]) < 10000:
+            colorprint('{red}NOFILE hard limit is too low, enabling developer mode{nocolor}')
+            args.developer_mode = True
     if args.developer_mode:
         run_setup_script('developer mode', 'scylla_dev_mode_setup --developer-mode 1')
 


### PR DESCRIPTION
On Ubuntu 16/18 and Debian 9, LimitNOFILE is set to 4096 and not able to override from
user unit.
To run scylla-server in such environment, we need to turn on developer mode and show
warnings.

Fixes #7133