### PR TITLE
install.sh: logging to scylla-server.log when journalctl --user does not work

### DIFF
--- a/dist/common/scripts/scylla_logrotate
+++ b/dist/common/scripts/scylla_logrotate
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2020 ScyllaDB
+#
+
+#
+# This file is part of Scylla.
+#
+# Scylla is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Scylla is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
+
+from pathlib import Path
+from datetime import datetime
+from scylla_util import *
+
+if __name__ == '__main__':
+    log = scylladir_p() / 'scylla-server.log'
+    if log.exists() and log.stat().st_size > 0:
+        dt = datetime.today().isoformat()
+        log.rename(scylladir_p() / f'scylla-server.log.{dt}')


### PR DESCRIPTION
On some environment such as CentOS8, journalctl --user -xe does not work
since journald is running in volatile mode.
The issue cannnot fix in non-root mode, as a workaround we should logging to
a file instead of journal.

Also added scylla_logrotate to ExecStartPre which rename previous log file,
since StandardOutput=file:/path/to/file will erase existing file when service
restarted.

Fixes #7131