### PR TITLE
alternator: fix combination of filter and projection

### DIFF
--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -1881,7 +1881,8 @@ static std::string get_item_type_string(const rjson::value& v) {
 
 // calculate_attrs_to_get() takes either AttributesToGet or
 // ProjectionExpression parameters (having both is *not* allowed),
-// and returns the list of cells we need to read.
+// and returns the list of cells we need to read, or an empty set when
+// *all* attributes are to be returned.
 // In our current implementation, only top-level attributes are stored
 // as cells, and nested documents are stored serialized as JSON.
 // So this function currently returns only the the top-level attributes
@@ -2571,6 +2572,10 @@ public:
             std::unordered_set<std::string>& used_attribute_values);
     bool check(const rjson::value& item) const;
     bool filters_on(std::string_view attribute) const;
+    // for_filters_on() runs the given function on the attributes that the
+    // filter works on. It may run for the same attribute more than once if
+    // used more than once in the filter.
+    void for_filters_on(const noncopyable_function<void(std::string_view)>& func) const;
     operator bool() const { return bool(_imp); }
 };
 
@@ -2651,10 +2656,26 @@ bool filter::filters_on(std::string_view attribute) const {
     }, *_imp);
 }
 
+void filter::for_filters_on(const noncopyable_function<void(std::string_view)>& func) const {
+    if (_imp) {
+        std::visit(overloaded_functor {
+            [&] (const conditions_filter& f) -> void {
+                for (auto it = f.conditions.MemberBegin(); it != f.conditions.MemberEnd(); ++it) {
+                    func(rjson::to_string_view(it->name));
+                }
+            },
+            [&] (const expression_filter& f) -> void {
+                return for_condition_expression_on(f.expression, func);
+            }
+        }, *_imp);
+    }
+}
+
 class describe_items_visitor {
     typedef std::vector<const column_definition*> columns_t;
     const columns_t& _columns;
     const std::unordered_set<std::string>& _attrs_to_get;
+    std::unordered_set<std::string> _extra_filter_attrs;
     const filter& _filter;
     typename columns_t::const_iterator _column_it;
     rjson::value _item;
@@ -2670,7 +2691,20 @@ public:
             , _item(rjson::empty_object())
             , _items(rjson::empty_array())
             , _scanned_count(0)
-    { }
+    {
+        // _filter.check() may need additional attributes not listed in
+        // _attrs_to_get (i.e., not requested as part of the output).
+        // We list those in _extra_filter_attrs. We will include them in
+        // the JSON but take them out before finally returning the JSON.
+        if (!_attrs_to_get.empty()) {
+            _filter.for_filters_on([&] (std::string_view attr) {
+                std::string a(attr); // no heterogenous maps searches :-(
+                if (!_attrs_to_get.contains(a)) {
+                    _extra_filter_attrs.emplace(std::move(a));
+                }
+            });
+        }
+    }
 
     void start_row() {
         _column_it = _columns.begin();
@@ -2684,7 +2718,7 @@ public:
         result_bytes_view->with_linearized([this] (bytes_view bv) {
             std::string column_name = (*_column_it)->name_as_text();
             if (column_name != executor::ATTRS_COLUMN_NAME) {
-                if (_attrs_to_get.empty() || _attrs_to_get.contains(column_name)) {
+                if (_attrs_to_get.empty() || _attrs_to_get.contains(column_name) || _extra_filter_attrs.contains(column_name)) {
                     if (!_item.HasMember(column_name.c_str())) {
                         rjson::set_with_string_name(_item, column_name, rjson::empty_object());
                     }
@@ -2696,7 +2730,7 @@ public:
                 auto keys_and_values = value_cast<map_type_impl::native_type>(deserialized);
                 for (auto entry : keys_and_values) {
                     std::string attr_name = value_cast<sstring>(entry.first);
-                    if (_attrs_to_get.empty() || _attrs_to_get.contains(attr_name)) {
+                    if (_attrs_to_get.empty() || _attrs_to_get.contains(attr_name) || _extra_filter_attrs.contains(attr_name)) {
                         bytes value = value_cast<bytes>(entry.second);
                         rjson::set_with_string_name(_item, attr_name, deserialize_item(value));
                     }
@@ -2708,6 +2742,11 @@ public:
 
     void end_row() {
         if (_filter.check(_item)) {
+            // Remove the extra attributes _extra_filter_attrs which we had
+            // to add just for the filter, and not requested to be returned:
+            for (const auto& attr : _extra_filter_attrs) {
+                rjson::remove_member(_item, attr);
+            }
             rjson::push_back(_items, std::move(_item));
         }
         _item = rjson::empty_object();

--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -2603,6 +2603,9 @@ filter::filter(const rjson::value& request, request_type rt,
         if (expression->GetStringLength() == 0) {
             throw api_error::validation("FilterExpression must not be empty");
         }
+        if (rjson::find(request, "AttributesToGet")) {
+            throw api_error::validation("Cannot use both old-style and new-style parameters in same request: FilterExpression and AttributesToGet");
+        }
         try {
             // FIXME: make parse_condition_expression take string_view, get
             // rid of the silly conversion to std::string.
@@ -2618,6 +2621,9 @@ filter::filter(const rjson::value& request, request_type rt,
         }
     }
     if (conditions) {
+        if (rjson::find(request, "ProjectionExpression")) {
+            throw api_error::validation(format("Cannot use both old-style and new-style parameters in same request: {} and ProjectionExpression", conditions_attribute));
+        }
         bool require_all = conditional_operator != conditional_operator_type::OR;
         _imp = conditions_filter { require_all, rjson::copy(*conditions) };
     }

--- a/alternator/expressions.hh
+++ b/alternator/expressions.hh
@@ -27,6 +27,8 @@
 #include <unordered_set>
 #include <string_view>
 
+#include <seastar/util/noncopyable_function.hh>
+
 #include "expressions_types.hh"
 #include "utils/rjson.hh"
 
@@ -58,6 +60,11 @@ void resolve_condition_expression(parsed::condition_expression& ce,
 void validate_value(const rjson::value& v, const char* caller);
 
 bool condition_expression_on(const parsed::condition_expression& ce, std::string_view attribute);
+
+// for_condition_expression_on() runs the given function on the attributes
+// that the expression uses. It may run for the same attribute more than once
+// if the same attribute is used more than once in the expression.
+void for_condition_expression_on(const parsed::condition_expression& ce, const noncopyable_function<void(std::string_view)>& func);
 
 // calculate_value() behaves slightly different (especially, different
 // functions supported) when used in different types of expressions, as

--- a/test/alternator/test_filter_expression.py
+++ b/test/alternator/test_filter_expression.py
@@ -680,7 +680,6 @@ def test_filter_expression_and_projection_expression(test_table):
 # It is not allowed to combine the new-style FilterExpression with the
 # old-style AttributesToGet. You must use ProjectionExpression instead
 # (tested in test_filter_expression_and_projection_expression() above).
-@pytest.mark.xfail(reason="missing check for expression and non-expression query parameters")
 def test_filter_expression_and_attributes_to_get(test_table):
     p = random_string()
     # DynamoDB complains: "Can not use both expression and non-expression

--- a/test/alternator/test_filter_expression.py
+++ b/test/alternator/test_filter_expression.py
@@ -658,7 +658,6 @@ def test_filter_expression_and_sort_key_condition(test_table_sn_with_data):
 # In particular, test that FilterExpression may inspect attributes which will
 # not be returned by the query, because of the ProjectionExpression.
 # This test reproduces issue #6951.
-@pytest.mark.xfail(reason="issue #6951: cannot filter on non-returned attributes")
 def test_filter_expression_and_projection_expression(test_table):
     p = random_string()
     test_table.put_item(Item={'p': p, 'c': 'hi', 'x': 'dog', 'y': 'cat'})

--- a/test/alternator/test_lsi.py
+++ b/test/alternator/test_lsi.py
@@ -125,8 +125,9 @@ def test_lsi_wrong(dynamodb):
             ])
         table.delete()
 
-# A simple scenario for LSI. Base table has just hash key, Index has an
-# additional sort key - one of the non-key attributes from the base table.
+# A simple scenario for LSI. Base table has a partition key and a sort key,
+# index has the same partition key key but a different sort key - one of
+# the non-key attributes from the base table.
 @pytest.fixture(scope="session")
 def test_table_lsi_1(dynamodb):
     table = create_test_table(dynamodb,

--- a/test/alternator/test_query_filter.py
+++ b/test/alternator/test_query_filter.py
@@ -560,7 +560,6 @@ def test_query_filter_and_attributes_to_get(test_table):
 # It is not allowed to combine the old-style QueryFilter with the
 # new-style ProjectionExpression. You must use AttributesToGet instead
 # (tested in test_query_filter_and_attributes_to_get() above).
-@pytest.mark.xfail(reason="missing check for expression and non-expression query parameters")
 def test_query_filter_and_projection_expression(test_table):
     p = random_string()
     # DynamoDB complains: "Can not use both expression and non-expression

--- a/test/alternator/test_query_filter.py
+++ b/test/alternator/test_query_filter.py
@@ -539,7 +539,6 @@ def test_query_filter_paging(test_table_sn_with_data):
 # In particular, test that QueryFilter may inspect attributes which will
 # not be returned by the query, because the AttributesToGet.
 # This test reproduces issue #6951.
-@pytest.mark.xfail(reason="issue #6951: cannot filter on non-returned attributes")
 def test_query_filter_and_attributes_to_get(test_table):
     p = random_string()
     test_table.put_item(Item={'p': p, 'c': 'hi', 'x': 'dog', 'y': 'cat'})


### PR DESCRIPTION
The main goal of this this series is to fix issue #6951 - a Query (or Scan) with a combination of filtering and projection parameters produced wrong results if the filter needs some attributes which weren't projected.

This series also adds new tests for various corner cases of this issue. These new tests also pass after this fix, or still fail because some other missing feature (namely, nested attributes). These additional tests will be important if we ever want to refactor or optimize this code, because they exercise some rare corner code paths at the intersection of filtering and projection.

This series also fixes some additional problems related to this issue, like combining old and new filtering/projection syntaxes (should be forbidden), and even one fix to a wrong comment.