### PR TITLE
table: fix race and exception handling in on_compaction_completion()

### DIFF
--- a/table.cc
+++ b/table.cc
@@ -1017,7 +1017,7 @@ table::on_compaction_completion(sstables::compaction_completion_desc& desc) {
 
     rebuild_statistics();
 
-    auto f = seastar::with_gate(_sstable_deletion_gate, [this, sstables_to_remove = desc.old_sstables] {
+    auto f = seastar::try_with_gate(_sstable_deletion_gate, [this, sstables_to_remove = desc.old_sstables] {
        return with_semaphore(_sstable_deletion_sem, 1, [sstables_to_remove = std::move(sstables_to_remove)] {
            return sstables::delete_atomically(std::move(sstables_to_remove));
        });


### PR DESCRIPTION
Fix a race condition in on_compaction_completion() that can prevent shutdown, as well as an exception handling error. See individual patches for details.

Fixes #7331.