### PR TITLE
transport/system_ks: Add more info to `system.clients`

### DIFF
--- a/connection_notifier.hh
+++ b/connection_notifier.hh
@@ -20,9 +20,17 @@
  */
 #pragma once
 
-#include "gms/inet_address.hh"
+#include "db/query_context.hh"
+
+#include <seastar/net/inet_address.hh>
 #include <seastar/core/sstring.hh>
+#include "seastarx.hh"
+
 #include <optional>
+
+namespace db::system_keyspace {
+extern const char *const CLIENTS;
+}
 
 enum class client_type {
     cql = 0,
@@ -30,9 +38,28 @@ enum class client_type {
     alternator,
 };
 
+sstring to_string(client_type ct);
+
+enum class changed_column {
+    username = 0,
+    connection_stage,
+    driver_name,
+    driver_version,
+    hostname,
+    protocol_version,
+};
+
+template <changed_column column> constexpr const char* column_literal = "";
+template <> constexpr const char* column_literal<changed_column::username> = "username";
+template <> constexpr const char* column_literal<changed_column::connection_stage> = "connection_stage";
+template <> constexpr const char* column_literal<changed_column::driver_name> = "driver_name";
+template <> constexpr const char* column_literal<changed_column::driver_version> = "driver_version";
+template <> constexpr const char* column_literal<changed_column::hostname> = "hostname";
+template <> constexpr const char* column_literal<changed_column::protocol_version> = "protocol_version";
+
 // Representation of a row in `system.clients'. std::optionals are for nullable cells.
 struct client_data {
-    gms::inet_address ip;
+    net::inet_address ip;
     int32_t port;
     client_type ct;
     int32_t shard_id;  /// ID of server-side shard which is processing the connection.
@@ -52,6 +79,17 @@ struct client_data {
 };
 
 future<> notify_new_client(client_data cd);
-future<> notify_disconnected_client(gms::inet_address addr, client_type ct, int port);
-
+future<> notify_disconnected_client(net::inet_address addr, int port, client_type ct);
 future<> clear_clientlist();
+
+template <changed_column column_enum_val>
+struct notify_client_change {
+    template <typename T>
+    future<> operator()(net::inet_address addr, int port, client_type ct, T&& value) {
+        const static sstring req
+                = format("UPDATE system.{} SET {}=? WHERE address=? AND port=? AND client_type=?;",
+                        db::system_keyspace::CLIENTS, column_literal<column_enum_val>);
+
+        return db::execute_cql(req, std::forward<T>(value), std::move(addr), port, to_string(ct)).discard_result();
+    }
+};

--- a/connection_notifier.hh
+++ b/connection_notifier.hh
@@ -57,17 +57,28 @@ template <> constexpr const char* column_literal<changed_column::driver_version>
 template <> constexpr const char* column_literal<changed_column::hostname> = "hostname";
 template <> constexpr const char* column_literal<changed_column::protocol_version> = "protocol_version";
 
+enum class client_connection_stage {
+    established = 0,
+    authenticating,
+    ready,
+};
+
+template <client_connection_stage ccs> constexpr const char* connection_stage_literal = "";
+template <> constexpr const char* connection_stage_literal<client_connection_stage::established> = "ESTABLISHED";
+template <> constexpr const char* connection_stage_literal<client_connection_stage::authenticating> = "AUTHENTICATING";
+template <> constexpr const char* connection_stage_literal<client_connection_stage::ready> = "READY";
+
 // Representation of a row in `system.clients'. std::optionals are for nullable cells.
 struct client_data {
     net::inet_address ip;
     int32_t port;
     client_type ct;
+    client_connection_stage connection_stage = client_connection_stage::established;
     int32_t shard_id;  /// ID of server-side shard which is processing the connection.
 
     // `optional' column means that it's nullable (possibly because it's
     // unimplemented yet). If you want to fill ("implement") any of them,
     // remember to update the query in `notify_new_client()'.
-    std::optional<sstring> connection_stage;
     std::optional<sstring> driver_name;
     std::optional<sstring> driver_version;
     std::optional<sstring> hostname;

--- a/service/client_state.hh
+++ b/service/client_state.hh
@@ -118,6 +118,7 @@ private:
     private volatile String keyspace;
 #endif
     std::optional<auth::authenticated_user> _user;
+    std::optional<sstring> _driver_name, _driver_version;
 
     auth_state _auth_state = auth_state::UNINITIALIZED;
 
@@ -145,6 +146,20 @@ public:
 
     void set_auth_state(auth_state new_state) noexcept {
         _auth_state = new_state;
+    }
+
+    std::optional<sstring> get_driver_name() const {
+        return _driver_name;
+    }
+    void set_driver_name(sstring driver_name) {
+        _driver_name = std::move(driver_name);
+    }
+
+    std::optional<sstring> get_driver_version() const {
+        return _driver_version;
+    }
+    void set_driver_version(sstring driver_version) {
+        _driver_version = std::move(driver_version);
     }
 
     client_state(external_tag, auth::service& auth_service, const socket_address& remote_address = socket_address(), bool thrift = false)

--- a/transport/server.hh
+++ b/transport/server.hh
@@ -48,6 +48,7 @@ class registrations;
 }
 
 class database;
+enum class client_type;
 struct client_data;
 
 namespace cql_transport {
@@ -189,6 +190,7 @@ private:
         future<> process();
         future<> process_request();
         future<> shutdown();
+        static std::tuple<net::inet_address, int, client_type> make_client_key(const service::client_state& cli_state);
         client_data make_client_data() const;
         const service::client_state& get_client_state() const { return _client_state; }
     private:


### PR DESCRIPTION
This patch fills the following columns in `system.clients` table:
* `connection_stage`
* `driver_name`
* `driver_version`
* `protocol_version`

It also improves:
* `client_type` - distinguishes cql from thrift just in case
* `username` - now it displays correct username iff `PasswordAuthenticator` is configured.

What is still missing:
* SSL params (I'll happily get some advice here)
* `hostname` - I didn't find it in tested drivers

Refs #6946