### PR TITLE
test: suppress ubsan true-positive on rapidjson

### DIFF
--- a/test.py
+++ b/test.py
@@ -428,6 +428,7 @@ async def run_test(test, options, gentle_kill=False, env=dict()):
         UBSAN_OPTIONS = [
             "halt_on_error=1",
             "abort_on_error=1",
+            f"suppressions={os.getcwd()}/ubsan-suppressions.supp",
             os.getenv("UBSAN_OPTIONS"),
         ]
         ASAN_OPTIONS = [

--- a/ubsan-suppressions.supp
+++ b/ubsan-suppressions.supp
@@ -1,0 +1,2 @@
+# https://github.com/Tencent/rapidjson/commit/16872af88915176f49e389defb167f899e2c230a
+pointer-overflow:rapidjson/internal/stack.h


### PR DESCRIPTION
rapidjson has a harmless (but true) ubsan violation. It was fixed
in https://github.com/Tencent/rapidjson/commit/16872af88915176f49e389defb167f899e2c230a.

Since rapidjson has't released since 2016, we're unlikely to see
the fix, so suppress it to prevent the tests failing. In any case
the violation is harmless.

gcc's ubsan doesn't object to the addition.