### PR TITLE
types: Work around a clang thread-local code generation bug (user_type)

### DIFF
--- a/types.cc
+++ b/types.cc
@@ -2670,6 +2670,12 @@ user_type_impl::idx_of_field(const bytes& name) const {
     return {};
 }
 
+shared_ptr<const user_type_impl>
+user_type_impl::get_instance(sstring keyspace, bytes name,
+        std::vector<bytes> field_names, std::vector<data_type> field_types, bool multi_cell) {
+    return intern::get_instance(std::move(keyspace), std::move(name), std::move(field_names), std::move(field_types), multi_cell);
+}
+
 sstring
 tuple_type_impl::make_name(const std::vector<data_type>& types) {
     // To keep format compatibility with Origin we never wrap

--- a/types/user.hh
+++ b/types/user.hh
@@ -45,9 +45,7 @@ public:
             , _is_multi_cell(is_multi_cell) {
     }
     static shared_ptr<const user_type_impl> get_instance(sstring keyspace, bytes name,
-            std::vector<bytes> field_names, std::vector<data_type> field_types, bool multi_cell) {
-        return intern::get_instance(std::move(keyspace), std::move(name), std::move(field_names), std::move(field_types), multi_cell);
-    }
+            std::vector<bytes> field_names, std::vector<data_type> field_types, bool multi_cell);
     data_type field_type(size_t i) const { return type(i); }
     const std::vector<data_type>& field_types() const { return _types; }
     bytes_view field_name(size_t i) const { return _field_names[i]; }


### PR DESCRIPTION
Following 5d249a8e27ce5659ecc57c0bd63f79f2e0e4cbd2, apply the same
fix for user_type_impl.

This works around https://bugs.llvm.org/show_bug.cgi?id=47747

Depending on this might be unstable, as the bug bug can show up at any
corner, but this is sufficient right now to get
test_user_function_disabled to pass.
