### PR TITLE
types: tighten digit count requirement on time nanoseconds components

### DIFF
--- a/types.cc
+++ b/types.cc
@@ -406,7 +406,11 @@ int64_t time_type_impl::from_sstring(sstring_view s) {
     int64_t nanoseconds = 0;
     if (seconds_end < s.length()) {
         nanoseconds = std::stol(sstring(s.substr(seconds_end + 1)));
-        nanoseconds *= std::pow(10, 9 - (s.length() - (seconds_end + 1)));
+        auto nano_digits = s.length() - (seconds_end + 1);
+        if (nano_digits > 9) {
+            throw marshal_exception(format("more than 9 nanosecond digits: {}", s));
+        }
+        nanoseconds *= std::pow(10, 9 - nano_digits);
         if (nanoseconds < 0 || nanoseconds >= 1000 * 1000 * 1000) {
             throw marshal_exception(format("Nanosecond out of bounds ({:d}).", nanoseconds));
         }


### PR DESCRIPTION
When the number of nanosecond digits is greater than 9, the std::pow()
expression that corrects the nanosecond value becomes infinite. This
is because sstring::length() is unsigned, and so negative values
underflow and become large.

Following Cassandra, fix by forbidding more than 9 digits of
nanosecond precision.

Found by clang's ubsan.