### PR TITLE
utils: log_heap: relax check for clang's sanitizer

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -252,7 +252,7 @@ def find_headers(repodir, excluded_dirs):
 
 modes = {
     'debug': {
-        'cxxflags': '-DDEBUG -DDEBUG_LSA_SANITIZER -DSCYLLA_ENABLE_ERROR_INJECTION',
+        'cxxflags': '-DDEBUG -DSANITIZE -DDEBUG_LSA_SANITIZER -DSCYLLA_ENABLE_ERROR_INJECTION',
         'cxx_ld_flags': '',
         'stack-usage-threshold': 1024*40,
     },
@@ -267,7 +267,7 @@ modes = {
         'stack-usage-threshold': 1024*21,
     },
     'sanitize': {
-        'cxxflags': '-DDEBUG -DDEBUG_LSA_SANITIZER -DSCYLLA_ENABLE_ERROR_INJECTION',
+        'cxxflags': '-DDEBUG -DSANITIZE -DDEBUG_LSA_SANITIZER -DSCYLLA_ENABLE_ERROR_INJECTION',
         'cxx_ld_flags': '-Os',
         'stack-usage-threshold': 1024*50,
     }

--- a/utils/log_heap.hh
+++ b/utils/log_heap.hh
@@ -58,7 +58,8 @@ struct log_heap_options {
     }
 
     size_t bucket_of(size_t value) const {
-#ifdef __SANITIZE_ADDRESS__
+#ifdef SANITIZE
+        // ubsan will otherwise complain about pow2_rank(0)
         if (value < min_size) {
             return 0;
         }


### PR DESCRIPTION
b1e78313fe7ed58 added a check for ubsan to squelch a false positive,
but that check doesn't work with clang. Relax it to check for debug
mode, so clang doesn't hit the same false positive as gcc did.