### PR TITLE
compaction: allow _max_sstable_size = 0

### DIFF
--- a/sstables/compaction.cc
+++ b/sstables/compaction.cc
@@ -477,7 +477,9 @@ protected:
     }
 
     uint64_t partitions_per_sstable() const {
-        uint64_t estimated_sstables = std::max(1UL, uint64_t(ceil(double(_info->start_size) / _max_sstable_size)));
+        // some tests use _max_sstable_size == 0 for force many one partition per sstable
+        auto max_sstable_size = std::max<uint64_t>(_max_sstable_size, 1);
+        uint64_t estimated_sstables = std::max(1UL, uint64_t(ceil(double(_info->start_size) / max_sstable_size)));
         return std::min(uint64_t(ceil(double(_estimated_partitions) / estimated_sstables)),
                         _cf.get_compaction_strategy().adjust_partition_estimate(_ms_metadata, _estimated_partitions));
     }


### PR DESCRIPTION
Some test (run_based_compaction_test at least) use _max_sstable_size = 0
in order to force one partition per sstable. That triggers an overflow
when calculating the expected bloom filter size. The overflow doesn't
matter for normal operation, because the result later appears on a
divisor, but does trigger a ubsan error.

Squelch the error by bot dividing by zero here.

I tried using _max_sstable_size = 1, but the test failed for other
reasons.