### PR TITLE
test: network_topology_strategy_test: fix overflow in d2t()

### DIFF
--- a/test/boost/network_topology_strategy_test.cc
+++ b/test/boost/network_topology_strategy_test.cc
@@ -133,7 +133,10 @@ void endpoints_check(
 }
 
 auto d2t = [](double d) -> int64_t {
-    return static_cast<unsigned long>(d*(std::numeric_limits<unsigned long>::max()));
+    // Double to unsigned long conversion will overflow if the
+    // input is greater than numeric_limits<long>::max(), so divide by two and
+    // multiply again later.
+    return static_cast<unsigned long>(d*(std::numeric_limits<unsigned long>::max() >> 1)) << 1;
 };
 
 /**


### PR DESCRIPTION
d2t() scales a fraction in the range [0, 1] to the range of
a biased token (same as unsigned long). But x86 doesn't support
conversion to unsigned, only signed, so this is a truncating
conversion. Clang's ubsan correctly warns about it.

Fix by reducing the range before converting, and expanding it
afterwards.