### PR TITLE
test: cql_repl: use boost::regex instead of std::regex to avoid stack overflow

### DIFF
--- a/test/tools/cql_repl.cc
+++ b/test/tools/cql_repl.cc
@@ -19,7 +19,9 @@
  * along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
  */
 #include <filesystem>
-#include <regex>
+// use boost::regex instead of std::regex due
+// to stack overflow in debug mode
+#include <boost/regex.hpp>
 
 #include "test/lib/cql_test_env.hh"
 #include "test/lib/cql_assertions.hh"
@@ -127,9 +129,9 @@ void repl(seastar::app_template& app) {
     do_with_cql_env_thread([] (cql_test_env& e) {
 
         // Comments allowed by CQL - -- and //
-        const std::regex comment_re("^[[:space:]]*((--|//).*)?$");
+        const boost::regex comment_re("^[[:space:]]*((--|//).*)?$");
         // A comment is not a delimiter even if ends with one
-        const std::regex delimiter_re("^(?![[:space:]]*(--|//)).*;[[:space:]]*$");
+        const boost::regex delimiter_re("^(?![[:space:]]*(--|//)).*;[[:space:]]*$");
 
         while (std::cin) {
             std::string line;
@@ -138,12 +140,12 @@ void repl(seastar::app_template& app) {
                 break;
             }
             // Handle multiline input and comments
-            if (std::regex_match(line.begin(), line.end(), comment_re)) {
+            if (boost::regex_match(line.begin(), line.end(), comment_re)) {
                 std_cout << line << std::endl;
                 continue;
             }
             stmt << line << std::endl;
-            while (!std::regex_match(line.begin(), line.end(), delimiter_re)) {
+            while (!boost::regex_match(line.begin(), line.end(), delimiter_re)) {
                 // Read the rest of input until delimiter or EOF
                 if (!std::getline(std::cin, line)) {
                     break;


### PR DESCRIPTION
libstdc++'s std::regex uses recursion[1], with a depth controlled by the
input. Together with clang's debug mode, this overflows the stack.

Use boost::regex instead, which is immune to the problem.

[1] https://gcc.gnu.org/bugzilla/show_bug.cgi?id=86164