### PR TITLE
utils: build_id: fix ubsan false positive on pointer arithmetic

### DIFF
--- a/utils/build_id.cc
+++ b/utils/build_id.cc
@@ -20,7 +20,7 @@ static const Elf64_Nhdr* get_nt_build_id(dl_phdr_info* info) {
             continue;
         }
 
-        auto* p = reinterpret_cast<const char*>(base) + h->p_vaddr;
+        auto* p = reinterpret_cast<const char*>(base + h->p_vaddr);
         auto* e = p + h->p_memsz;
         while (p != e) {
             const auto* n = reinterpret_cast<const Elf64_Nhdr*>(p);


### PR DESCRIPTION
get_nt_build_id() constructs a pointer by adding a base and an
offset, but if the base happens to be zero, that is undefined
under C++ rules (altough legal ELF).

Fix by performing the addition on integers, and only then
casting to a pointer.