### PR TITLE
test: sstable_datafile_test: sstable_run_based_compaction_test: prevent use of uninitialized variable observer

### DIFF
--- a/test/boost/sstable_datafile_test.cc
+++ b/test/boost/sstable_datafile_test.cc
@@ -5742,7 +5742,7 @@ SEASTAR_TEST_CASE(sstable_run_based_compaction_test) {
             };
 
             auto result = compact(std::move(desc.sstables), replacer);
-            observer->disconnect();
+            observer.reset();
             BOOST_REQUIRE_EQUAL(expected_output, result.size());
             BOOST_REQUIRE(expected_sst == sstable_run.end());
             return result;


### PR DESCRIPTION
The variable 'observer' (an std::optional) may be left uninitialized
if 'incremental_enabled' is false. However, it is used afterwards
with a call to disconnect, accessing garbage.

Fix by accessing it via the optional wrapper. A call to optional::reset()
destroys the observable, which in turn calls disconnect().