### PR TITLE
query-result-writer: fix idl definition order related failures with clang

### DIFF
--- a/query-result-writer.hh
+++ b/query-result-writer.hh
@@ -32,9 +32,9 @@
 #include "idl/query.dist.hh"
 #include "serializer_impl.hh"
 #include "serialization_visitors.hh"
-#include "idl/query.dist.impl.hh"
-#include "idl/keys.dist.impl.hh"
 #include "idl/uuid.dist.impl.hh"
+#include "idl/keys.dist.impl.hh"
+#include "idl/query.dist.impl.hh"
 
 namespace query {
 


### PR DESCRIPTION
Following ad48d8b43cc28, fix a similar problem which popped up
with higher inlining thresholds in query-result-writer.hh. Since
idl/query depends on idl/keys, it must follow in definition order.