### PR TITLE
utils/array-search: document restrictions

### DIFF
--- a/utils/array-search.hh
+++ b/utils/array-search.hh
@@ -33,6 +33,12 @@ static constexpr int64_t simple_key_unused_value = std::numeric_limits<int64_t>:
  *
  * Returns the index of the first element in the array that's greater
  * than the given value.
+ *
+ * To accomodate the single-instruction-multiple-data variant, observe
+ * the following:
+ *  - capacity must be a multiple of 4
+ *  - any items with indexes in [size, capacity) must be initialized
+ *    to std::numeric_limits<int64_t>::min()
  */
 int array_search_gt(int64_t val, const int64_t* array, const int capacity, const int size);
 


### PR DESCRIPTION
Our AVX2 implementation cannot load a partial vector,
or mask unused elements (that can be done with AVX-512/SVE2),
so it has some restrictions. Document them.