### PR TITLE
scylla_raid_setup: use sysfs to detect existing RAID volume

### DIFF
--- a/dist/common/scripts/scylla_raid_setup
+++ b/dist/common/scripts/scylla_raid_setup
@@ -73,7 +73,8 @@ if __name__ == '__main__':
             print('{} is busy'.format(disk))
             sys.exit(1)
 
-    if os.path.exists(args.raiddev):
+    raiddevname = os.path.basename(args.raiddev)
+    if os.path.exists(f'/sys/block/{raiddevname}/md/array_state'):
         print('{} is already using'.format(args.raiddev))
         sys.exit(1)
 


### PR DESCRIPTION
We may not able to detect existing RAID volume by device file existance,
we should use sysfs instead to make sure it's running.

Fixes #7383