### PR TITLE
install.sh: allow --packaging with nonroot mode

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -390,8 +390,10 @@ if $nonroot; then
     # nonroot install is also 'offline install'
     touch $rprefix/SCYLLA-OFFLINE-FILE
     touch $rprefix/SCYLLA-NONROOT-FILE
-    systemctl --user daemon-reload
-    echo "Scylla non-root install completed."
+    if ! $packaging; then
+        systemctl --user daemon-reload
+        echo "Scylla non-root install completed."
+    fi
 elif ! $packaging; then
     # run install.sh without --packaging is 'offline install'
     touch $rprefix/SCYLLA-OFFLINE-FILE


### PR DESCRIPTION
Since scylla-ccm wants to skip systemctl, we need to support --packaging
in nonroot mode too.

Related: #7187