### PR TITLE
[DONOTMERGE] install.sh: show warning nonroot mode when systemd does not support user mode

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -390,7 +390,9 @@ if $nonroot; then
     # nonroot install is also 'offline install'
     touch $rprefix/SCYLLA-OFFLINE-FILE
     touch $rprefix/SCYLLA-NONROOT-FILE
-    systemctl --user daemon-reload
+    if ! $packaging; then
+        systemctl --user daemon-reload
+    fi
     echo "Scylla non-root install completed."
 elif ! $packaging; then
     # run install.sh without --packaging is 'offline install'

--- a/install.sh
+++ b/install.sh
@@ -165,6 +165,11 @@ installconfig() {
     fi
 }
 
+check_usermode_support() {
+    user=$(systemctl --help|grep -e '--user')
+    [ -n "$user" ]
+}
+
 # change directory to the package's root directory
 cd "$(dirname "$0")"
 
@@ -390,7 +395,7 @@ if $nonroot; then
     # nonroot install is also 'offline install'
     touch $rprefix/SCYLLA-OFFLINE-FILE
     touch $rprefix/SCYLLA-NONROOT-FILE
-    if ! $packaging; then
+    if ! $packaging || check_usermode_support; then
         systemctl --user daemon-reload
     fi
     echo "Scylla non-root install completed."

--- a/unified/install.sh
+++ b/unified/install.sh
@@ -38,6 +38,11 @@ EOF
     exit 1
 }
 
+check_usermode_support() {
+    user=$(systemctl --help|grep -e '--user')
+    [ -n "$user" ]
+}
+
 root=/
 housekeeping=false
 nonroot=false
@@ -136,3 +141,7 @@ fi
 (cd $(readlink -f scylla-tools); ./install.sh --root "$root" --prefix "$prefix" ${args[@]})
 
 install -m755 uninstall.sh -Dt "$rprefix"
+
+if $nonroot && ! check_usermode_support; then
+    echo "WARNING: This distribution does not support systemd user mode, please configure and launch Scylla manually."
+fi


### PR DESCRIPTION
This is v3 of 7089, added fixes for shell syntax error on scylla-ccm.
We need merge https://github.com/scylladb/scylla-ccm/pull/250 first.

----

On older distribution such as CentOS7, it does not support systemd user mode.
On such distribution nonroot mode does not work, show warning message and
skip running systemctl --user.

Fixes #7071