### PR TITLE
install.sh: allow --packaging with nonroot mode

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -393,7 +393,9 @@ if $nonroot; then
     # nonroot install is also 'offline install'
     touch $rprefix/SCYLLA-OFFLINE-FILE
     touch $rprefix/SCYLLA-NONROOT-FILE
-    systemctl --user daemon-reload
+    if ! $packaging; then
+        systemctl --user daemon-reload
+    fi
     echo "Scylla non-root install completed."
 elif ! $packaging; then
     # run install.sh without --packaging is 'offline install'

--- a/scripts/create-relocatable-package.py
+++ b/scripts/create-relocatable-package.py
@@ -120,9 +120,9 @@ have_gnutls = any([lib.startswith('libgnutls.so')
 gzip_process = subprocess.Popen("pigz > "+output, shell=True, stdin=subprocess.PIPE)
 
 ar = tarfile.open(fileobj=gzip_process.stdin, mode='w|')
-# relocatable package format version = 2
+# relocatable package format version = 2.1
 with open('build/.relocatable_package_version', 'w') as f:
-    f.write('2\n')
+    f.write('2.1\n')
 ar.add('build/.relocatable_package_version', arcname='.relocatable_package_version')
 
 for exe in executables:


### PR DESCRIPTION
Since scylla-ccm wants to skip systemctl, we need to support --packaging
in nonroot mode too.

Related: https://github.com/scylladb/scylla-ccm/pull/250
Related: scylladb/scylla-ccm#249
Related: #7187