### PR TITLE
alternator::streams: Ensure shards are reported in string lexical order

### DIFF
--- a/test/alternator/test_streams.py
+++ b/test/alternator/test_streams.py
@@ -1028,6 +1028,11 @@ def test_streams_after_sequence_number(test_table_ss_keys_only, dynamodbstreams)
                 assert response['Records'][1]['dynamodb']['Keys'] == {'p': {'S': p}, 'c': {'S': c}}
                 sequence_number_1 = response['Records'][0]['dynamodb']['SequenceNumber']
                 sequence_number_2 = response['Records'][1]['dynamodb']['SequenceNumber']
+
+                # #7424 - AWS sdk assumes sequence numbers can be compared
+                # as bigints, and are monotonically growing.
+                assert int(sequence_number_1) < int(sequence_number_2)
+
                 # If we use the SequenceNumber of the first event to create an
                 # AFTER_SEQUENCE_NUMBER iterator, we can read the second event
                 # (only) again. We don't need a loop and a timeout, because this

--- a/utils/UUID_gen.hh
+++ b/utils/UUID_gen.hh
@@ -132,6 +132,14 @@ public:
         assert(uuid.is_timestamp());
         return uuid;
     }
+
+    static UUID get_time_UUID_raw(int64_t nanos, int64_t clock_seq_and_node)
+    {
+        auto uuid = UUID(create_time(nanos), clock_seq_and_node);
+        assert(uuid.is_timestamp());
+        return uuid;
+    }
+
     /**
      * Similar to get_time_UUID, but randomize the clock and sequence.
      * If you can guarantee that the when_in_micros() argument is unique for


### PR DESCRIPTION
Fixes #7409

AWS kinesis Java sdk requires/expects shards to be reported in
lexical order, and even worse, ignores lastevalshard. Thus not
upholding said order will break their stream intropection badly.

Added asserts to unit tests.

Also Fixes #7424 (added - since the basic problem is more or less the same)

Ensure sequencenumbers are bigint lexical.