### PR TITLE
sstables: prepare bound_kind_m formatter for clang

### DIFF
--- a/sstables/m_format_read_helpers.cc
+++ b/sstables/m_format_read_helpers.cc
@@ -58,8 +58,6 @@ future<int64_t> read_signed_vint(random_access_reader& in) {
     return read_vint_impl<int64_t>(in);
 }
 
-}  // namespace sstables
-
 std::ostream& operator<<(std::ostream& out, sstables::bound_kind_m kind) {
     switch (kind) {
     case sstables::bound_kind_m::excl_end:
@@ -91,3 +89,5 @@ std::ostream& operator<<(std::ostream& out, sstables::bound_kind_m kind) {
     }
     return out;
 }
+
+}  // namespace sstables

--- a/sstables/m_format_read_helpers.cc
+++ b/sstables/m_format_read_helpers.cc
@@ -59,3 +59,35 @@ future<int64_t> read_signed_vint(random_access_reader& in) {
 }
 
 }  // namespace sstables
+
+std::ostream& operator<<(std::ostream& out, sstables::bound_kind_m kind) {
+    switch (kind) {
+    case sstables::bound_kind_m::excl_end:
+        out << "excl_end";
+        break;
+    case sstables::bound_kind_m::incl_start:
+        out << "incl_start";
+        break;
+    case sstables::bound_kind_m::excl_end_incl_start:
+        out << "excl_end_incl_start";
+        break;
+    case sstables::bound_kind_m::static_clustering:
+        out << "static_clustering";
+        break;
+    case sstables::bound_kind_m::clustering:
+        out << "clustering";
+        break;
+    case sstables::bound_kind_m::incl_end_excl_start:
+        out << "incl_end_excl_start";
+        break;
+    case sstables::bound_kind_m::incl_end:
+        out << "incl_end";
+        break;
+    case sstables::bound_kind_m::excl_start:
+        out << "excl_start";
+        break;
+    default:
+        out << static_cast<unsigned>(kind);
+    }
+    return out;
+}

--- a/sstables/m_format_read_helpers.hh
+++ b/sstables/m_format_read_helpers.hh
@@ -99,34 +99,4 @@ inline gc_clock::time_point parse_expiry(const serialization_header& header,
 
 };   // namespace sstables
 
-inline std::ostream& operator<<(std::ostream& out, sstables::bound_kind_m kind) {
-    switch (kind) {
-    case sstables::bound_kind_m::excl_end:
-        out << "excl_end";
-        break;
-    case sstables::bound_kind_m::incl_start:
-        out << "incl_start";
-        break;
-    case sstables::bound_kind_m::excl_end_incl_start:
-        out << "excl_end_incl_start";
-        break;
-    case sstables::bound_kind_m::static_clustering:
-        out << "static_clustering";
-        break;
-    case sstables::bound_kind_m::clustering:
-        out << "clustering";
-        break;
-    case sstables::bound_kind_m::incl_end_excl_start:
-        out << "incl_end_excl_start";
-        break;
-    case sstables::bound_kind_m::incl_end:
-        out << "incl_end";
-        break;
-    case sstables::bound_kind_m::excl_start:
-        out << "excl_start";
-        break;
-    default:
-        out << static_cast<unsigned>(kind);
-    }
-    return out;
-}
+std::ostream& operator<<(std::ostream& out, sstables::bound_kind_m kind);

--- a/sstables/m_format_read_helpers.hh
+++ b/sstables/m_format_read_helpers.hh
@@ -98,5 +98,3 @@ inline gc_clock::time_point parse_expiry(const serialization_header& header,
 }
 
 };   // namespace sstables
-
-std::ostream& operator<<(std::ostream& out, sstables::bound_kind_m kind);

--- a/sstables/mx/types.hh
+++ b/sstables/mx/types.hh
@@ -22,6 +22,7 @@
 #pragma once
 
 #include "clustering_bounds_comparator.hh"
+#include <iosfwd>
 
 namespace sstables {
 
@@ -95,3 +96,5 @@ inline bound_kind boundary_to_end_bound(bound_kind_m kind) {
 }
 
 }
+
+std::ostream& operator<<(std::ostream& out, sstables::bound_kind_m kind);

--- a/sstables/mx/types.hh
+++ b/sstables/mx/types.hh
@@ -95,6 +95,6 @@ inline bound_kind boundary_to_end_bound(bound_kind_m kind) {
     return (kind == bound_kind_m::incl_end_excl_start) ? bound_kind::incl_end : bound_kind::excl_end;
 }
 
-}
-
 std::ostream& operator<<(std::ostream& out, sstables::bound_kind_m kind);
+
+}


### PR DESCRIPTION
bound_kind_m's formatter violates argument dependent lookup rules according to clang, so fix that. Along the way improve the formatter a little.