### PR TITLE
sstables: move component_type formatter to namespace sstables

### DIFF
--- a/sstables/component_type.hh
+++ b/sstables/component_type.hh
@@ -42,8 +42,8 @@ enum class component_type {
     Unknown,
 };
 
+std::ostream& operator<<(std::ostream&, const sstables::component_type&);
+
 }
 
 using component_type = ::sstables::component_type;
-
-std::ostream& operator<<(std::ostream&, const sstables::component_type&);

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -3599,8 +3599,6 @@ std::ostream& operator<<(std::ostream& out, const deletion_time& dt) {
     return out << "{timestamp=" << dt.marked_for_delete_at << ", deletion_time=" << dt.marked_for_delete_at << "}";
 }
 
-}
-
 std::ostream& operator<<(std::ostream& out, const sstables::component_type& comp_type) {
     using ct = sstables::component_type;
     switch (comp_type) {
@@ -3619,6 +3617,8 @@ std::ostream& operator<<(std::ostream& out, const sstables::component_type& comp
     case ct::Unknown: out << "Unknown"; break;
     }
     return out;
+}
+
 }
 
 namespace seastar {


### PR DESCRIPTION
Without this, clang complains that we violate argument dependent
lookup rules:

  note: 'operator<<' should be declared prior to the call site or in namespace 'sstables'
  std::ostream& operator<<(std::ostream&, const sstables::component_type&);

we can't enforce the #include order, but we can easily move it it
to namespace sstables (where it belongs anyway), so let's do that.

gcc is happy either way.