### PR TITLE
install.sh: set LC_ALL=en_US.UTF-8 on python3 thunk

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -130,6 +130,7 @@ relocate_python3() {
     cp "$script" "$relocateddir"
     cat > "$install"<<EOF
 #!/usr/bin/env bash
+export LC_ALL=en_US.UTF-8
 x="\$(readlink -f "\$0")"
 b="\$(basename "\$x")"
 d="\$(dirname "\$x")"


### PR DESCRIPTION
scylla-python3 causes segfault when non-default locale specified.
As workaround for this, we need to set LC_ALL=en_US.UTF_8 on python3 thunk.

Fixes #7408