### PR TITLE
gossip: Introduce STATUS_PREPARE_REPLACE

### DIFF
--- a/gms/gossiper.cc
+++ b/gms/gossiper.cc
@@ -1508,6 +1508,13 @@ void gossiper::handle_major_state_change(inet_address ep, const endpoint_state& 
         });
     }
 
+    auto* eps_new = get_endpoint_state_for_endpoint_ptr(ep);
+    if (eps_new) {
+        _subscribers.for_each([ep, eps_new] (shared_ptr<i_endpoint_state_change_subscriber> subscriber) {
+            subscriber->on_join(ep, *eps_new);
+        });
+    }
+
     auto& ep_state = endpoint_state_map.at(ep);
     if (!is_dead_state(ep_state)) {
         mark_alive(ep, ep_state);
@@ -1516,12 +1523,6 @@ void gossiper::handle_major_state_change(inet_address ep, const endpoint_state& 
         mark_dead(ep, ep_state);
     }
 
-    auto* eps_new = get_endpoint_state_for_endpoint_ptr(ep);
-    if (eps_new) {
-        _subscribers.for_each([ep, eps_new] (shared_ptr<i_endpoint_state_change_subscriber> subscriber) {
-            subscriber->on_join(ep, *eps_new);
-        });
-    }
     // check this at the end so nodes will learn about the endpoint
     if (is_shutdown(ep)) {
         mark_as_shutdown(ep);

--- a/gms/versioned_value.hh
+++ b/gms/versioned_value.hh
@@ -81,6 +81,7 @@ public:
     static constexpr const char* REMOVING_TOKEN = "removing";
     static constexpr const char* REMOVED_TOKEN = "removed";
 
+    static constexpr const char* STATUS_PREPARE_REPLACE = "PREPARE_REPLACE";
     static constexpr const char* HIBERNATE = "hibernate";
     static constexpr const char* SHUTDOWN = "shutdown";
 
@@ -205,6 +206,10 @@ public:
 
     static versioned_value hibernate(bool value) {
         return versioned_value(sstring(HIBERNATE) + sstring(DELIMITER_STR) + (value ? "true" : "false"));
+    }
+
+    static versioned_value prepare_replacing(bool value) {
+        return versioned_value(sstring(STATUS_PREPARE_REPLACE) + sstring(DELIMITER_STR) + (value ? "true" : "false"));
     }
 
     static versioned_value shutdown(bool value) {

--- a/locator/token_metadata.hh
+++ b/locator/token_metadata.hh
@@ -240,7 +240,7 @@ public:
     // Is any node being replaced by another node
     bool is_any_node_being_replaced() const;
 
-    void add_replacing_endpoint(inet_address existing_node, inet_address replacing_node);
+    void add_replacing_endpoint(inet_address existing_node, inet_address replacing_node, bool is_prepare_state);
 
     void del_replacing_endpoint(inet_address existing_node);
 

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -599,7 +599,7 @@ private:
      *
      * @param endpoint node
      */
-    void handle_state_replacing(inet_address endpoint);
+    void handle_state_replacing(inet_address endpoint, bool is_prepare_state);
 
 private:
     void excise(std::unordered_set<token> tokens, inet_address endpoint);


### PR DESCRIPTION
Currently the replacing node sets the status as STATUS_UNKNOWN when it
starts gossip service for the first time before it sets the status to
HIBERNATE to start the replacing operation. This introduces the
following race:

1) Replacing node using the same IP address of the node to be replaced
   starts gossip service without setting the gossip STATUS (will be seen as
   STATUS_UNKNOWN by other nodes)

2) Replacing node waits for gossip to settle and learns status and
   tokens of existing nodes

3) Replacing node announces the HIBERNATE STATUS.

After Step 1 and before Step 3, existing nodes will mark the replacing
node as UP, but haven't marked the replacing node as doing replacing
yet. As a result, the replacing node will not be excluded from the read
replicas and will be considered a target node to serve CQL reads.

To fix, a new gossip status STATUS_PREPARE_REPLACE is introduced for the
replace operation. It is set as early as the replacing node starts
gossip service for the first time, so that when existing nodes in the
cluster know about this replacing node, existing nodes know the status
of the node is replacing.

Fixes #7312
