### PR TITLE
Avoid scanning sstables in parallel for TWCS single-partition queries

### DIFF
--- a/mutation_reader.cc
+++ b/mutation_reader.cc
@@ -2565,6 +2565,11 @@ public:
             _all_readers.push_front(std::move(r));
             _unpeeked_readers.push_back(_all_readers.begin());
         }
+
+        if (rs.empty()) {
+            // No readers, no partition.
+            _should_emit_partition_end = false;
+        }
     }
 
     // We assume that operator() is called sequentially and that the caller doesn't use the batch

--- a/sstables/sstable_set.cc
+++ b/sstables/sstable_set.cc
@@ -530,7 +530,7 @@ filter_sstable_for_reader_by_ck(std::vector<shared_sstable>&& sstables, column_f
 }
 
 flat_mutation_reader
-sstable_set::create_single_key_sstable_reader(
+sstable_set_impl::create_single_key_sstable_reader(
         column_family* cf,
         schema_ptr schema,
         reader_permit permit,
@@ -569,6 +569,22 @@ sstable_set::create_single_key_sstable_reader(
     }
     sstable_histogram.add(num_readers);
     return make_combined_reader(schema, std::move(permit), std::move(readers), fwd, fwd_mr);
+}
+
+flat_mutation_reader
+sstable_set::create_single_key_sstable_reader(
+        column_family* cf,
+        schema_ptr schema,
+        reader_permit permit,
+        utils::estimated_histogram& sstable_histogram,
+        const dht::ring_position& pos,
+        const query::partition_slice& slice,
+        const io_priority_class& pc,
+        tracing::trace_state_ptr trace_state,
+        streamed_mutation::forwarding fwd,
+        mutation_reader::forwarding fwd_mr) const {
+    return _impl->create_single_key_sstable_reader(cf, std::move(schema),
+            std::move(permit), sstable_histogram, pos, slice, pc, std::move(trace_state), fwd, fwd_mr);
 }
 
 flat_mutation_reader

--- a/sstables/sstable_set.cc
+++ b/sstables/sstable_set.cc
@@ -25,6 +25,7 @@
 #include "compatible_ring_position.hh"
 #include "compaction_strategy_impl.hh"
 #include "leveled_compaction_strategy.hh"
+#include "time_window_compaction_strategy.hh"
 
 #include "sstable_set_impl.hh"
 
@@ -528,6 +529,10 @@ std::unique_ptr<sstable_set_impl> compaction_strategy_impl::make_sstable_set(sch
 
 std::unique_ptr<sstable_set_impl> leveled_compaction_strategy::make_sstable_set(schema_ptr schema) const {
     return std::make_unique<partitioned_sstable_set>(std::move(schema));
+}
+
+std::unique_ptr<sstable_set_impl> time_window_compaction_strategy::make_sstable_set(schema_ptr schema) const {
+    return std::make_unique<time_series_sstable_set>(std::move(schema));
 }
 
 sstable_set make_partitioned_sstable_set(schema_ptr schema, lw_shared_ptr<sstable_list> all, bool use_level_metadata) {

--- a/sstables/sstable_set_impl.hh
+++ b/sstables/sstable_set_impl.hh
@@ -107,4 +107,24 @@ public:
     class incremental_selector;
 };
 
+class time_series_sstable_set : public sstable_set_impl {
+public:
+    // s.min_position() -> s
+    using container_t = std::multimap<position_in_partition, shared_sstable, position_in_partition::less_compare>;
+
+private:
+    schema_ptr _schema;
+    lw_shared_ptr<container_t> _sstables;
+
+public:
+    time_series_sstable_set(schema_ptr schema);
+    time_series_sstable_set(const time_series_sstable_set& s);
+
+    virtual std::unique_ptr<sstable_set_impl> clone() const override;
+    virtual std::vector<shared_sstable> select(const dht::partition_range& range = query::full_partition_range) const override;
+    virtual void insert(shared_sstable sst) override;
+    virtual void erase(shared_sstable sst) override;
+    virtual std::unique_ptr<incremental_selector_impl> make_incremental_selector() const override;
+};
+
 } // namespace sstables

--- a/sstables/sstable_set_impl.hh
+++ b/sstables/sstable_set_impl.hh
@@ -125,6 +125,10 @@ public:
     virtual void insert(shared_sstable sst) override;
     virtual void erase(shared_sstable sst) override;
     virtual std::unique_ptr<incremental_selector_impl> make_incremental_selector() const override;
+
+    std::unique_ptr<position_reader_queue> make_min_position_reader_queue(
+        std::function<flat_mutation_reader(sstable&)> create_reader,
+        std::function<bool(const sstable&)> filter) const;
 };
 
 } // namespace sstables

--- a/sstables/sstable_set_impl.hh
+++ b/sstables/sstable_set_impl.hh
@@ -42,6 +42,18 @@ public:
     virtual void insert(shared_sstable sst) = 0;
     virtual void erase(shared_sstable sst) = 0;
     virtual std::unique_ptr<incremental_selector_impl> make_incremental_selector() const = 0;
+
+    virtual flat_mutation_reader create_single_key_sstable_reader(
+        column_family*,
+        schema_ptr,
+        reader_permit,
+        utils::estimated_histogram&,
+        const dht::ring_position&,
+        const query::partition_slice&,
+        const io_priority_class&,
+        tracing::trace_state_ptr,
+        streamed_mutation::forwarding,
+        mutation_reader::forwarding) const;
 };
 
 // default sstable_set, not specialized for anything

--- a/sstables/sstable_set_impl.hh
+++ b/sstables/sstable_set_impl.hh
@@ -129,6 +129,18 @@ public:
     std::unique_ptr<position_reader_queue> make_min_position_reader_queue(
         std::function<flat_mutation_reader(sstable&)> create_reader,
         std::function<bool(const sstable&)> filter) const;
+
+    virtual flat_mutation_reader create_single_key_sstable_reader(
+        column_family*,
+        schema_ptr,
+        reader_permit,
+        utils::estimated_histogram&,
+        const dht::ring_position&,
+        const query::partition_slice&,
+        const io_priority_class&,
+        tracing::trace_state_ptr,
+        streamed_mutation::forwarding,
+        mutation_reader::forwarding) const override;
 };
 
 } // namespace sstables

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -457,6 +457,32 @@ public:
         });
     }
     future<> close_files();
+
+    /* Returns a lower-bound for the set of `position_in_partition`s appearing in the sstable across all partitions.
+     *
+     * Might be `before_all_keys` if, for example, the sstable comes from outside Scylla and lacks sufficient metadata,
+     * or the sstable's schema does not have clustering columns.
+     *
+     * But if the schema has clustering columns and the sstable is sufficiently ``modern'',
+     * the returned value should be equal to the smallest clustering key occuring in the sstable (across all partitions).
+     *
+     * The lower bound is inclusive: there might be a clustering row with position equal to min_position.
+     */
+    const position_in_partition& min_position() const {
+        return _position_range.start();
+    }
+
+    /* Similar to min_position, but returns an upper-bound.
+     * However, the upper-bound is exclusive: all positions are smaller than max_position.
+     *
+     * If certain conditions are satisfied (the same as for `min_position`, see above),
+     * the returned value should be equal to after_key(ck), where ck is the greatest clustering key
+     * occuring in the sstable (across all partitions).
+     */
+    const position_in_partition& max_position() const {
+        return _position_range.end();
+    }
+
 private:
     size_t sstable_buffer_size;
 

--- a/sstables/time_window_compaction_strategy.hh
+++ b/sstables/time_window_compaction_strategy.hh
@@ -184,6 +184,8 @@ public:
         return compaction_strategy_type::time_window;
     }
 
+    virtual std::unique_ptr<sstable_set_impl> make_sstable_set(schema_ptr schema) const override;
+
     virtual compaction_backlog_tracker& get_backlog_tracker() override {
         return _backlog_tracker;
     }

--- a/test/boost/mutation_reader_test.cc
+++ b/test/boost/mutation_reader_test.cc
@@ -3657,6 +3657,13 @@ SEASTAR_THREAD_TEST_CASE(test_clustering_order_merger_in_memory) {
         compare_readers(*g._s, make_authority(std::move(merged), fwd),
                 make_tested(std::move(scenario.readers_data), fwd), scenario.fwd_ranges);
     }
+
+    // Test case with 0 readers
+    for (auto fwd: {streamed_mutation::forwarding::no, streamed_mutation::forwarding::yes}) {
+        auto r = make_clustering_combined_reader(g._s, tests::make_permit(), fwd,
+                std::make_unique<simple_position_reader_queue>(*g._s, std::vector<reader_bounds>{}));
+        assert_that(std::move(r)).produces_end_of_stream();
+    }
 }
 
 SEASTAR_THREAD_TEST_CASE(clustering_combined_reader_mutation_source_test) {


### PR DESCRIPTION
We introduce a new single-key sstable reader for sstables created by `TimeWindowCompactionStrategy`.

The reader uses the fact that sstables created by TWCS are mostly disjoint with respect to the contained `position_in_partition`s in order to avoid having multiple sstable readers opened at the same time unnecessarily. In case there are overlapping ranges (for example, in the current time-window), it performs the necessary merging (it uses `clustering_order_reader_merger`, introduced recently).

The reader uses min/max clustering key metadata present in `md` sstables in order to decide when to open or close a sstable reader.

The following experiment was performed:
1. create a TWCS table with 1 minute windows
2. fill the table with 8 equal windows of data
   (each window flushed to a separate sstable)
3. perform `select * from ks.t where pk = 0 limit 1` query
   with and without the change

The expectation is that with the commit, only one sstable will be opened
to fetch that one row; without the commit all 8 sstables would be opened at once.
The difference in the value of `scylla_reactor_aio_bytes_read` was measured
(value after the query minus value before the query), both with and without the commit.

With the commit, the difference was 67584.
Without the commit, the difference was 528384.
528384 / 67584 ~= 7.8.

Fixes https://github.com/scylladb/scylla/issues/6418.