### PR TITLE
token_restriction: invalid_request_exception on SELECTs with both normal and token restrictions

### DIFF
--- a/cql3/restrictions/token_restriction.hh
+++ b/cql3/restrictions/token_restriction.hh
@@ -71,6 +71,11 @@ public:
     }
 
     void merge_with(::shared_ptr<restriction> restriction) override {
+        if (!has_token(restriction->expression)) {
+            throw exceptions::invalid_request_exception(
+                    format("Columns \"{}\" cannot be restricted by both a normal relation and a token relation",
+                            join(", ", get_column_defs())));
+        }
         expression = make_conjunction(std::move(expression), restriction->expression);
     }
 


### PR DESCRIPTION
Before this change, invalid query exception on selects with both normal and token restrictions was only thrown when token restriction was after normal restriction. 

This change adds proper validation when token restriction is before normal restriction.

**Before the change - does not return error in last query; returns wrong results:**
```
cqlsh> CREATE TABLE ks.t(pk int, PRIMARY KEY(pk));
cqlsh> INSERT INTO ks.t(pk) VALUES (1);
cqlsh> INSERT INTO ks.t(pk) VALUES (2);
cqlsh> INSERT INTO ks.t(pk) VALUES (3);
cqlsh> INSERT INTO ks.t(pk) VALUES (4);
cqlsh> SELECT pk, token(pk) FROM ks.t WHERE pk = 2 AND token(pk) > 0;
InvalidRequest: Error from server: code=2200 [Invalid query] message="Columns "ColumnDefinition{name=pk, type=org.apache.cassandra.db.marshal.Int32Type, kind=PARTITION_KEY, componentIndex=0, droppedAt=-9223372036854775808}" cannot be restricted by both a normal relation and a token relation"
cqlsh> SELECT pk, token(pk) FROM ks.t WHERE token(pk) > 0 AND pk = 2;

 pk | system.token(pk)
----+---------------------
  3 | 9010454139840013625

(1 rows)
```