### PR TITLE
treewide: don't capture structured bindings in lambdas

### DIFF
--- a/api/column_family.cc
+++ b/api/column_family.cc
@@ -865,7 +865,9 @@ void set_column_family(http_context& ctx, routes& r) {
     });
 
     cf::get_built_indexes.set(r, [&ctx](std::unique_ptr<request> req) {
-        auto [ks, cf_name] = parse_fully_qualified_cf_name(req->param["name"]);
+        auto ks_cf = parse_fully_qualified_cf_name(req->param["name"]);
+        auto&& ks = std::get<0>(ks_cf);
+        auto&& cf_name = std::get<1>(ks_cf);
         return db::system_keyspace::load_view_build_progress().then([ks, cf_name, &ctx](const std::vector<db::system_keyspace::view_build_progress>& vb) mutable {
             std::set<sstring> vp;
             for (auto b : vb) {

--- a/cdc/log.cc
+++ b/cdc/log.cc
@@ -1088,7 +1088,7 @@ struct process_row_visitor {
 
         // cdc$deleted_col, cdc$deleted_elements_col, col
         using result_t = std::tuple<bool, std::vector<bytes_view>, bytes_opt>;
-        auto [is_column_delete, deleted_keys, added_cells] = visit(*cdef.type, make_visitor(
+        auto result = visit(*cdef.type, make_visitor(
             [&] (const set_type_impl&) -> result_t {
                 _touched_parts.set<stats::part_type::SET>();
 
@@ -1178,6 +1178,9 @@ struct process_row_visitor {
                 throw std::runtime_error(format("cdc process_change: unknown type {}", o.name()));
             }
         ));
+        auto&& is_column_delete = std::get<0>(result);
+        auto&& deleted_keys = std::get<1>(result);
+        auto&& added_cells = std::get<2>(result);
 
         // FIXME: we're doing redundant work: first we serialize the set of deleted keys into a blob,
         // then we deserialize again when merging images below

--- a/cql3/restrictions/statement_restrictions.cc
+++ b/cql3/restrictions/statement_restrictions.cc
@@ -354,7 +354,7 @@ std::vector<const column_definition*> statement_restrictions::get_column_defs_fo
     std::vector<const column_definition*> column_defs_for_filtering;
     if (need_filtering()) {
         auto& sim = db.find_column_family(_schema).get_index_manager();
-        auto [opt_idx, _] = find_idx(sim);
+        auto opt_idx = std::get<0>(find_idx(sim));
         auto column_uses_indexing = [&opt_idx] (const column_definition* cdef, ::shared_ptr<single_column_restriction> restr) {
             return opt_idx && restr && is_supported_by(restr->expression, *opt_idx);
         };

--- a/db/commitlog/commitlog_replayer.cc
+++ b/db/commitlog/commitlog_replayer.cc
@@ -241,7 +241,8 @@ db::commitlog_replayer::impl::recover(sstring file, const sstring& fname_prefix)
 }
 
 future<> db::commitlog_replayer::impl::process(stats* s, commitlog::buffer_and_replay_position buf_rp) const {
-    auto&& [buf, rp] = buf_rp;
+    auto&& buf = buf_rp.buffer;
+    auto&& rp = buf_rp.position;
     try {
 
         commitlog_entry_reader cer(buf);

--- a/db/hints/manager.cc
+++ b/db/hints/manager.cc
@@ -759,7 +759,8 @@ bool manager::end_point_hints_manager::sender::send_one_file(const sstring& fnam
 
     try {
         commitlog::read_log_file(fname, manager::FILENAME_PREFIX, service::get_local_streaming_priority(), [this, secs_since_file_mod, &fname, ctx_ptr] (commitlog::buffer_and_replay_position buf_rp) mutable {
-            auto&& [buf, rp] = buf_rp;
+            auto& buf = buf_rp.buffer;
+            auto& rp = buf_rp.position;
             // Check that we can still send the next hint. Don't try to send it if the destination host
             // is DOWN or if we have already failed to send some of the previous hints.
             if (!draining() && ctx_ptr->segment_replay_failed) {

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -3960,7 +3960,8 @@ storage_proxy::query_singular(lw_shared_ptr<query::read_command> cmd,
 
     auto f = ::map_reduce(exec.begin(), exec.end(), [p = shared_from_this(), timeout = query_options.timeout(*this), used_replicas] (
                 std::pair<::shared_ptr<abstract_read_executor>, dht::token_range>& executor_and_token_range) {
-        auto& [rex, token_range] = executor_and_token_range;
+        auto& rex = std::get<0>(executor_and_token_range);
+        auto& token_range = std::get<1>(executor_and_token_range);
         utils::latency_counter lc;
         lc.start();
         return rex->execute(timeout).then_wrapped([p = std::move(p), lc, rex, used_replicas, token_range = std::move(token_range)] (

--- a/test/boost/mutation_test.cc
+++ b/test/boost/mutation_test.cc
@@ -1944,7 +1944,9 @@ SEASTAR_THREAD_TEST_CASE(test_external_memory_usage) {
     };
 
     for (auto i = 0; i < 16; i++) {
-        auto [ m, size ] = generate();
+        auto m_and_size = generate();
+        auto&& m = m_and_size.first;
+        auto&& size = m_and_size.second;
 
         with_allocator(alloc, [&] {
             auto before = alloc.allocated_bytes();

--- a/test/boost/querier_cache_test.cc
+++ b/test/boost/querier_cache_test.cc
@@ -213,8 +213,10 @@ public:
         const auto cache_key = make_cache_key(key);
 
         auto querier = make_querier<Querier>(range);
-        auto [dk, ck] = querier.consume_page(dummy_result_builder{}, row_limit, std::numeric_limits<uint32_t>::max(),
+        auto dk_ck = querier.consume_page(dummy_result_builder{}, row_limit, std::numeric_limits<uint32_t>::max(),
                 gc_clock::now(), db::no_timeout, query::max_result_size(std::numeric_limits<uint64_t>::max())).get0();
+        auto&& dk = dk_ck.first;
+        auto&& ck = dk_ck.second;
         const auto memory_usage = querier.memory_usage();
         _cache.insert(cache_key, std::move(querier), nullptr);
 

--- a/test/manual/partition_data_test.cc
+++ b/test/manual/partition_data_test.cc
@@ -61,7 +61,11 @@ BOOST_AUTO_TEST_CASE(test_atomic_cell) {
     };
 
     for (auto tc : cases) {
-        auto [live, fixed_size, value, expiring, counter_update] = tc;
+        auto& live = tc.live;
+        auto& fixed_size = tc.fixed_size;
+        auto& value = tc.value;
+        auto& expiring = tc.expiring;
+        auto& counter_update = tc.counter_update;
         auto timestamp = tests::random::get_int<api::timestamp_type>();
         auto ti = [&] {
             if (fixed_size) {

--- a/thrift/server.cc
+++ b/thrift/server.cc
@@ -232,7 +232,8 @@ thrift_server::do_accepts(int which, bool keepalive) {
     // Future is waited on indirectly in `stop()` (via `_stop_gate`).
     (void)with_gate(_stop_gate, [&, this] {
         return _listeners[which].accept().then([this, which, keepalive] (accept_result ar) {
-            auto&& [fd, addr] = ar;
+            auto&& fd = ar.connection;
+            auto&& addr = ar.remote_address;
             fd.set_nodelay(true);
             fd.set_keepalive(keepalive);
             // Future is waited on indirectly in `stop()` (via `_stop_gate`).


### PR DESCRIPTION
Clang does not yet implement p1091r3, which allows lambdas
to capture structured bindings. To accomodate it, don't
use structured bindings for variables that are later
captured.

Hopefully, most of these lambda captures will be replaces with
coroutines.