### PR TITLE
utf8: don't linearize cells for validation

### DIFF
--- a/types.cc
+++ b/types.cc
@@ -1438,9 +1438,7 @@ struct validate_visitor {
         }
     }
     void operator()(const utf8_type_impl&) {
-        auto error_pos = with_linearized(v, [this] (bytes_view bv) {
-            return utils::utf8::validate_with_error_position(bv);
-        });
+        auto error_pos = utils::utf8::validate_with_error_position_fragmented(v);
         if (error_pos) {
             throw marshal_exception(format("Validation failed - non-UTF8 character in a UTF8 string, at byte offset {}", *error_pos));
         }

--- a/utils/utf8.cc
+++ b/utils/utf8.cc
@@ -56,6 +56,8 @@ namespace utils {
 
 namespace utf8 {
 
+using namespace internal;
+
 struct codepoint_status {
     size_t bytes_validated;
     bool error;
@@ -136,12 +138,6 @@ static inline std::optional<size_t> validate_naive(const uint8_t *data, size_t l
 
     return std::nullopt;
 }
-
-struct partial_validation_results {
-    bool error;
-    size_t unvalidated_tail;
-    size_t bytes_needed_for_tail;
-};
 
 static
 partial_validation_results
@@ -235,9 +231,8 @@ alignas(16) static const uint8_t s_range_adjust_tbl[] = {
 };
 
 // 2x ~ 4x faster than naive method
-static
 partial_validation_results
-validate_partial(const uint8_t *data, size_t len) {
+internal::validate_partial(const uint8_t *data, size_t len) {
     if (len >= 16) {
         uint8x16_t prev_input = vdupq_n_u8(0);
         uint8x16_t prev_first_len = vdupq_n_u8(0);
@@ -415,9 +410,8 @@ alignas(16) static const int8_t s_ef_fe_tbl[] = {
 };
 
 // 5x faster than naive method
-static
 partial_validation_results
-validate_partial(const uint8_t *data, size_t len) {
+internal::validate_partial(const uint8_t *data, size_t len) {
     if (len >= 16) {
         __m128i prev_input = _mm_set1_epi8(0);
         __m128i prev_first_len = _mm_set1_epi8(0);
@@ -545,7 +539,6 @@ validate_partial(const uint8_t *data, size_t len) {
 
 #else
 // No SIMD implementation for this arch, fallback to naive method
-static
 partial_validation_results
 validate_partial(const uint8_t *data, size_t len) {
     return validate_partial_naive(data, len);

--- a/utils/utf8.cc
+++ b/utils/utf8.cc
@@ -137,6 +137,29 @@ static inline std::optional<size_t> validate_naive(const uint8_t *data, size_t l
     return std::nullopt;
 }
 
+struct partial_validation_results {
+    bool error;
+    size_t unvalidated_tail;
+    size_t bytes_needed_for_tail;
+};
+
+static
+partial_validation_results
+validate_partial_naive(const uint8_t *data, size_t len) {
+    while (len) {
+        auto cs = evaluate_codepoint(data, len);
+        data += cs.bytes_validated;
+        len -= cs.bytes_validated;
+        if (cs.error) {
+            return partial_validation_results{.error = true};
+        }
+        if (cs.more_bytes_needed) {
+            return partial_validation_results{.unvalidated_tail = len, .bytes_needed_for_tail = cs.more_bytes_needed};
+        }
+    }
+    return partial_validation_results{};
+}
+
 #if defined(__aarch64__)
 #include <arm_neon.h>
 
@@ -212,7 +235,9 @@ alignas(16) static const uint8_t s_range_adjust_tbl[] = {
 };
 
 // 2x ~ 4x faster than naive method
-bool validate(const uint8_t *data, size_t len) {
+static
+partial_validation_results
+validate_partial(const uint8_t *data, size_t len) {
     if (len >= 16) {
         uint8x16_t prev_input = vdupq_n_u8(0);
         uint8x16_t prev_first_len = vdupq_n_u8(0);
@@ -308,7 +333,7 @@ bool validate(const uint8_t *data, size_t len) {
 
         // Delay error check till loop ends
         if (vmaxvq_u8(error)) {
-            return false;
+            return partial_validation_results{.error = true};
         }
 
         // Find previous token (not 80~BF)
@@ -328,8 +353,8 @@ bool validate(const uint8_t *data, size_t len) {
         len += lookahead;
     }
 
-    // Check for no error position in remaining bytes with naive method
-    return !validate_naive(data, len);
+    // Continue with remaining bytes with naive method
+    return validate_partial_naive(data, len);
 }
 
 #elif defined(__x86_64__)
@@ -390,7 +415,9 @@ alignas(16) static const int8_t s_ef_fe_tbl[] = {
 };
 
 // 5x faster than naive method
-bool validate(const uint8_t *data, size_t len) {
+static
+partial_validation_results
+validate_partial(const uint8_t *data, size_t len) {
     if (len >= 16) {
         __m128i prev_input = _mm_set1_epi8(0);
         __m128i prev_first_len = _mm_set1_epi8(0);
@@ -494,7 +521,7 @@ bool validate(const uint8_t *data, size_t len) {
         int error_reduced =
             _mm_movemask_epi8(_mm_cmpeq_epi8(error, _mm_set1_epi8(0)));
         if (error_reduced != 0xFFFF) {
-            return false;
+            return partial_validation_results{.error = true};
         }
 
         // Find previous token (not 80~BF)
@@ -512,17 +539,23 @@ bool validate(const uint8_t *data, size_t len) {
         len += lookahead;
     }
 
-    // Check for no error position in remaining bytes with naive method
-    return !validate_naive(data, len);
+    // Continue with remaining bytes with naive method
+    return validate_partial_naive(data, len);
 }
 
 #else
 // No SIMD implementation for this arch, fallback to naive method
-bool validate(const uint8_t *data, size_t len) {
-    // Check for no error position
-    return !validate_naive(data, len);
+static
+partial_validation_results
+validate_partial(const uint8_t *data, size_t len) {
+    return validate_partial_naive(data, len);
 }
 #endif
+
+bool validate(const uint8_t* data, size_t len) {
+    auto pvr = validate_partial(data, len);
+    return !pvr.error && !pvr.unvalidated_tail;
+}
 
 std::optional<size_t> validate_with_error_position(const uint8_t *data, size_t len) {
     // First pass - validate data (using optimized code)

--- a/utils/utf8.hh
+++ b/utils/utf8.hh
@@ -26,6 +26,7 @@
 
 #include <cstdint>
 #include "bytes.hh"
+#include "fragment_range.hh"
 
 namespace utils {
 
@@ -62,6 +63,54 @@ inline std::optional<size_t> validate_with_error_position(bytes_view string) {
     size_t len = string.size();
 
     return validate_with_error_position(data, len);	
+}
+
+std::optional<size_t> validate_with_error_position_fragmented(const FragmentRange auto& fr) {
+    uint8_t partial_codepoint[4];
+    size_t partial_filled = 0;
+    size_t partial_more_needed = 0;
+    size_t bytes_validated = 0;
+    for (auto&& frag : fr) {
+        auto data = reinterpret_cast<const uint8_t*>(frag.data());
+        auto len = frag.size();
+        if (partial_more_needed) {
+            // Tiny loop (often zero iterations), don't call memcpy
+            while (partial_more_needed && len) {
+                partial_codepoint[partial_filled++] = *data++;
+                --partial_more_needed;
+                --len;
+            }
+            if (!partial_more_needed) {
+                // We accumulated a codepoint that straddled two or more fragments,
+                // validate it now.
+                auto pvr = internal::validate_partial(partial_codepoint, partial_filled);
+                if (pvr.error) {
+                    return {bytes_validated};
+                }
+                bytes_validated += partial_filled;
+                partial_filled = partial_more_needed = 0;
+            }
+            if (!len) {
+                continue;
+            }
+        }
+        auto pvr = internal::validate_partial(data, len);
+        if (pvr.error) {
+            return bytes_validated + *validate_with_error_position(data, len);
+        }
+        bytes_validated += len - pvr.unvalidated_tail;
+        data += len - pvr.unvalidated_tail;
+        len = pvr.unvalidated_tail;
+        while (len) {
+            partial_codepoint[partial_filled++] = *data++;
+            --len;
+        }
+        partial_more_needed = pvr.bytes_needed_for_tail;
+    }
+    if (partial_more_needed) {
+        return bytes_validated;
+    }
+    return std::nullopt;
 }
 
 } // namespace utf8

--- a/utils/utf8.hh
+++ b/utils/utf8.hh
@@ -31,6 +31,19 @@ namespace utils {
 
 namespace utf8 {
 
+namespace internal {
+
+struct partial_validation_results {
+    bool error;
+    size_t unvalidated_tail;
+    size_t bytes_needed_for_tail;
+};
+
+partial_validation_results validate_partial(const uint8_t* data, size_t len);
+
+}
+
+
 bool validate(const uint8_t *data, size_t len);
 
 inline bool validate(bytes_view string) {


### PR DESCRIPTION
Currently, we linearize large UTF8 cells in order to validate them. This can cause large latency spikes if the cell is large.

This series changes UTF8 validation to work on fragmented buffers. This is somewhat tricky since the validation routines are optimized for single-instruction-multiple-data (SIMD) architectures.

The unit tests are expanded to cover the new functionality.

Fixes #7448.