### PR TITLE
treewide: drop some uses of <ranges> for clang

### DIFF
--- a/cql3/expr/expression.cc
+++ b/cql3/expr/expression.cc
@@ -555,28 +555,28 @@ bytes_opt get_kth(size_t k, const query_options& options, const ::shared_ptr<ter
 }
 
 template<typename Range>
-requires std::ranges::forward_range<Range>
+// Clang doesn't compile this, and boost ranges aren't std::ranges
+// requires std::ranges::forward_range<Range>
 value_list to_sorted_vector(Range r, const serialized_compare& comparator) {
     value_list tmp(r.begin(), r.end()); // Need random-access range to sort (r is not necessarily random-access).
     const auto unique = boost::unique(boost::sort(tmp, comparator));
     return value_list(unique.begin(), unique.end());
 }
 
-const auto non_null = std::views::filter([] (const bytes_opt& b) { return b.has_value(); });
+const auto non_null = boost::adaptors::filtered([] (const bytes_opt& b) { return b.has_value(); });
 
-const auto deref = std::views::transform([] (const bytes_opt& b) { return b.value(); });
+const auto deref = boost::adaptors::transformed([] (const bytes_opt& b) { return b.value(); });
 
 /// Returns possible values from t, which must be RHS of IN.
 value_list get_IN_values(
         const ::shared_ptr<term>& t, const query_options& options, const serialized_compare& comparator) {
-    using std::views::transform;
     // RHS is prepared differently for different CQL cases.  Cast it dynamically to discern which case this is.
     if (auto dv = dynamic_pointer_cast<lists::delayed_value>(t)) {
         // Case `a IN (1,2,3)`.
         const auto result_range = dv->get_elements()
-                | transform([&] (const ::shared_ptr<term>& t) { return to_bytes_opt(t->bind_and_get(options)); })
+                | boost::adaptors::transformed([&] (const ::shared_ptr<term>& t) { return to_bytes_opt(t->bind_and_get(options)); })
                 | non_null | deref;
-        return to_sorted_vector(move(result_range), comparator);
+        return to_sorted_vector(std::move(result_range), comparator);
     } else if (auto mkr = dynamic_pointer_cast<lists::marker>(t)) {
         // Case `a IN ?`.  Collect all list-element values.
         const auto val = static_pointer_cast<lists::value>(mkr->bind(options));
@@ -588,20 +588,19 @@ value_list get_IN_values(
 /// Returns possible values for k-th column from t, which must be RHS of IN.
 value_list get_IN_values(const ::shared_ptr<term>& t, size_t k, const query_options& options,
                          const serialized_compare& comparator) {
-    using std::views::transform;
     // RHS is prepared differently for different CQL cases.  Cast it dynamically to discern which case this is.
     if (auto dv = dynamic_pointer_cast<lists::delayed_value>(t)) {
         // Case `(a,b) in ((1,1),(2,2),(3,3))`.  Get kth value from each term element.
         const auto result_range = dv->get_elements()
-                | transform(std::bind_front(get_kth, k, options)) | non_null | deref;
-        return to_sorted_vector(move(result_range), comparator);
+                | boost::adaptors::transformed(std::bind_front(get_kth, k, options)) | non_null | deref;
+        return to_sorted_vector(std::move(result_range), comparator);
     } else if (auto mkr = dynamic_pointer_cast<tuples::in_marker>(t)) {
         // Case `(a,b) IN ?`.  Get kth value from each vector<bytes> element.
         const auto val = static_pointer_cast<tuples::in_value>(mkr->bind(options));
         const auto split_values = val->get_split_values(); // Need lvalue from which to make std::view.
         const auto result_range = split_values
-                | transform([k] (const std::vector<bytes_opt>& v) { return v[k]; }) | non_null | deref;
-        return to_sorted_vector(move(result_range), comparator);
+                | boost::adaptors::transformed([k] (const std::vector<bytes_opt>& v) { return v[k]; }) | non_null | deref;
+        return to_sorted_vector(std::move(result_range), comparator);
     }
     throw std::logic_error(format("get_IN_values(multi-column) on invalid term {}", *t));
 }

--- a/sstables/leveled_compaction_strategy.cc
+++ b/sstables/leveled_compaction_strategy.cc
@@ -168,7 +168,9 @@ leveled_compaction_strategy::get_reshaping_job(std::vector<shared_sstable> input
         level_info[sst_level].push_back(sst);
     }
 
-    for (auto& level : level_info | std::ranges::views::drop(1)) {
+    // Can't use std::ranges::views::drop due to https://bugs.llvm.org/show_bug.cgi?id=47509
+    for (auto i = level_info.begin() + 1; i != level_info.end(); ++i) {
+        auto& level = *i;
         std::sort(level.begin(), level.end(), [&schema] (const shared_sstable& a, const shared_sstable& b) {
             return dht::ring_position(a->get_first_decorated_key()).less_compare(*schema, dht::ring_position(b->get_first_decorated_key()));
         });

--- a/test/boost/view_build_test.cc
+++ b/test/boost/view_build_test.cc
@@ -805,7 +805,7 @@ SEASTAR_THREAD_TEST_CASE(test_view_update_generator_buffering) {
 
     const auto partition_size_sets = std::vector<std::vector<int>>{{12}, {8, 4}, {8, 16}, {22}, {8, 8, 8, 8}, {8, 8, 8, 16, 8}, {8, 20, 16, 16}, {50}, {21}, {21, 2}};
     const auto max_partition_set_size = std::ranges::max_element(partition_size_sets, [] (const std::vector<int>& a, const std::vector<int>& b) { return a.size() < b.size(); })->size();
-    auto pkeys = ranges::to<std::vector<dht::decorated_key>>(std::views::iota(size_t{0}, max_partition_set_size) | std::views::transform([schema] (int i) {
+    auto pkeys = ranges::to<std::vector<dht::decorated_key>>(boost::irange(size_t{0}, max_partition_set_size) | boost::adaptors::transformed([schema] (int i) {
         return dht::decorate_key(*schema, partition_key::from_single_value(*schema, int32_type->decompose(data_value(i))));
     }));
     std::ranges::sort(pkeys, dht::ring_position_less_comparator(*schema));

--- a/utils/ranges.hh
+++ b/utils/ranges.hh
@@ -25,7 +25,13 @@
 
 namespace ranges {
 
+#ifndef __clang__
 template <std::ranges::range Container, std::ranges::range Range>
+#else
+// 'Range' should be constrained to std::ranges::range, but due to
+// problems between clang and <ranges>, it cannot be
+template <std::ranges::range Container, typename Range>
+#endif
 Container to(const Range& range) {
     return Container(range.begin(), range.end());
 }


### PR DESCRIPTION
Clang has trouble compiling libstdc++'s `<ranges>`. It is not known whether
the problem is in clang or in libstdc++; I filed bugs for both [1] [2].

Meanwhile, we wish to use clang to gain working coroutine support,
so drop the failing uses of `<ranges>`. Luckily the changes are simple.

[1] https://bugs.llvm.org/show_bug.cgi?id=47509
[2] https://gcc.gnu.org/bugzilla/show_bug.cgi?id=97120