### PR TITLE
Coroutinize alternator tagging requests

### DIFF
--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -55,7 +55,7 @@
 #include "schema.hh"
 #include "alternator/tags_extension.hh"
 #include "alternator/rmw_operation.hh"
-
+#include <seastar/core/coroutine.hh>
 #include <boost/range/adaptors.hpp>
 
 logging::logger elogger("alternator-executor");
@@ -710,24 +710,22 @@ static future<> update_tags(service::migration_manager& mm, schema_ptr schema, s
 future<executor::request_return_type> executor::tag_resource(client_state& client_state, service_permit permit, rjson::value request) {
     _stats.api_operations.tag_resource++;
 
-    return seastar::async([this, &client_state, request = std::move(request)] () mutable -> request_return_type {
-        const rjson::value* arn = rjson::find(request, "ResourceArn");
-        if (!arn || !arn->IsString()) {
-            return api_error::access_denied("Incorrect resource identifier");
-        }
-        schema_ptr schema = get_table_from_arn(_proxy, rjson::to_string_view(*arn));
-        std::map<sstring, sstring> tags_map = get_tags_of_table(schema);
-        const rjson::value* tags = rjson::find(request, "Tags");
-        if (!tags || !tags->IsArray()) {
-            return api_error::validation("Cannot parse tags");
-        }
-        if (tags->Size() < 1) {
-            return api_error::validation("The number of tags must be at least 1") ;
-        }
-        update_tags_map(*tags, tags_map,  update_tags_action::add_tags);
-        update_tags(_mm, schema, std::move(tags_map)).get();
-        return json_string("");
-    });
+    const rjson::value* arn = rjson::find(request, "ResourceArn");
+    if (!arn || !arn->IsString()) {
+        co_return api_error::access_denied("Incorrect resource identifier");
+    }
+    schema_ptr schema = get_table_from_arn(_proxy, rjson::to_string_view(*arn));
+    std::map<sstring, sstring> tags_map = get_tags_of_table(schema);
+    const rjson::value* tags = rjson::find(request, "Tags");
+    if (!tags || !tags->IsArray()) {
+        co_return api_error::validation("Cannot parse tags");
+    }
+    if (tags->Size() < 1) {
+        co_return api_error::validation("The number of tags must be at least 1") ;
+    }
+    update_tags_map(*tags, tags_map,  update_tags_action::add_tags);
+    co_await update_tags(_mm, schema, std::move(tags_map));
+    co_return json_string("");
 }
 
 future<executor::request_return_type> executor::untag_resource(client_state& client_state, service_permit permit, rjson::value request) {


### PR DESCRIPTION
This miniseries rewrites two alternator request handlers from seastar threads to coroutines - since these handlers are not on a hot path and using seastar threads is way too heavy for such a simple routine.

NOTE: this pull request obviously has to wait until coroutines are fully supported in Seastar/Scylla.