### PR TITLE
treewide: adjust for missing aggregate template type deduction and parenthesized aggregate construction

### DIFF
--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -1182,7 +1182,7 @@ static schema_diff diff_table_or_view(distributed<service::storage_proxy>& proxy
         auto s_before = create_schema(std::move(before.at(key)));
         auto s = create_schema(std::move(after.at(key)));
         slogger.info("Altering {}.{} id={} version={}", s->ks_name(), s->cf_name(), s->id(), s->version());
-        d.altered.emplace_back(s_before, s);
+        d.altered.emplace_back(schema_diff::altered_schema{s_before, s});
     }
     return d;
 }

--- a/reader_concurrency_semaphore.cc
+++ b/reader_concurrency_semaphore.cc
@@ -261,7 +261,7 @@ static permit_stats do_dump_reader_permit_diagnostics(std::ostream& os, const pe
     for (const auto& [k, v] : permits) {
         const auto& [s, op_name, k_state] = k;
         if (k_state == state) {
-            permit_summaries.emplace_back(s, op_name, v.memory, v.count);
+            permit_summaries.emplace_back(permit_summary{s, op_name, v.memory, v.count});
         }
     }
 

--- a/types.cc
+++ b/types.cc
@@ -1403,6 +1403,7 @@ struct validate_visitor {
     FragmentRangeView v;
 
     cql_serialization_format sf;
+
     void operator()(const reversed_type_impl& t) { return t.underlying_type()->validate(underlying, sf); }
     void operator()(const abstract_type&) {}
     template <typename T> void operator()(const integer_type_impl<T>& t) {
@@ -1572,11 +1573,11 @@ struct validate_visitor {
 }
 
 void abstract_type::validate(const fragmented_temporary_buffer::view& view, cql_serialization_format sf) const {
-    visit(*this, validate_visitor{view, view, sf});
+    visit(*this, validate_visitor<const fragmented_temporary_buffer::view&, const fragmented_temporary_buffer::view&>{view, view, sf});
 }
 
 void abstract_type::validate(bytes_view v, cql_serialization_format sf) const {
-    visit(*this, validate_visitor{v, single_fragment_range(v), sf});
+    visit(*this, validate_visitor<bytes_view, single_fragment_range<mutable_view::no>>{v, single_fragment_range(v), sf});
 }
 
 static void serialize_aux(const tuple_type_impl& type, const tuple_type_impl::native_type* val, bytes::iterator& out) {


### PR DESCRIPTION
Clang does not implement P0960R3 and P1816R0, so constructions
of aggregates (structs with no constructors) have to used braced initialization
and cannot use class template argument deduction. This series makes the
adjustments.