### PR TITLE
Docker: pass extra arguments to scylla

### DIFF
--- a/dist/docker/redhat/commandlineparser.py
+++ b/dist/docker/redhat/commandlineparser.py
@@ -28,4 +28,4 @@ def parse():
     parser.add_argument('--cluster-name', default=None, dest='clusterName', help="Set cluster name")
     parser.add_argument('--endpoint-snitch', default=None, dest='endpointSnitch', help="Set endpoint snitch")
     parser.add_argument('--replace-address-first-boot', default=None, dest='replaceAddressFirstBoot', help="IP address of a dead node to replace.")
-    return parser.parse_args()
+    return parser.parse_known_args()

--- a/dist/docker/redhat/docker-entrypoint.py
+++ b/dist/docker/redhat/docker-entrypoint.py
@@ -18,9 +18,10 @@ def signal_handler(signum, frame):
 
 signal.signal(signal.SIGINT, signal_handler)
 signal.signal(signal.SIGTERM, signal_handler)
+
 try:
-    arguments = commandlineparser.parse()
-    setup = scyllasetup.ScyllaSetup(arguments)
+    arguments, extra_arguments = commandlineparser.parse()
+    setup = scyllasetup.ScyllaSetup(arguments, extra_arguments=extra_arguments)
     setup.developerMode()
     setup.cpuSet()
     setup.io()

--- a/dist/docker/redhat/scyllasetup.py
+++ b/dist/docker/redhat/scyllasetup.py
@@ -5,7 +5,7 @@ import os
 
 
 class ScyllaSetup:
-    def __init__(self, arguments):
+    def __init__(self, arguments, extra_arguments):
         self._developerMode = arguments.developerMode
         self._seeds = arguments.seeds
         self._cpuset = arguments.cpuset
@@ -30,6 +30,7 @@ class ScyllaSetup:
         self._endpointSnitch = arguments.endpointSnitch
         self._replaceAddressFirstBoot = arguments.replaceAddressFirstBoot
         self._io_setup = arguments.io_setup
+        self._extra_args = extra_arguments
 
     def _run(self, *args, **kwargs):
         logging.info('running: {}'.format(args))
@@ -152,4 +153,4 @@ class ScyllaSetup:
         args += ["--blocked-reactor-notify-ms 999999999"]
 
         with open("/etc/scylla.d/docker.conf", "w") as cqlshrc:
-            cqlshrc.write("SCYLLA_DOCKER_ARGS=\"%s\"\n" % " ".join(args))
+            cqlshrc.write("SCYLLA_DOCKER_ARGS=\"%s\"\n" % (" ".join(args) + " " + " ".join(self._extra_args)))

--- a/docs/docker-hub.md
+++ b/docs/docker-hub.md
@@ -341,6 +341,13 @@ The `--authorizer` command lines option allows to provide the authorizer class S
 
 **Since: 2.3**
 
+### Additional scylla command argument
+
+You can provide any additional argument that is supported by scylla (https://github.com/scylladb/scylla/blob/master/conf/scylla.yaml)
+Example: `--commitlog_sync batch --commitlog_sync_batch_window_in_ms 2`
+
+**Since: 4.3**
+
 ## JMX parameters
 
 JMX Scylla service is initialized from the `/scylla-jmx-service.sh` on


### PR DESCRIPTION
Currently there is no way to pass scylla arguments from docker-entrypoint to scylla,
but time to time it is needed.
Example: https://github.com/scylladb/scylla-operator/issues/177