### PR TITLE
cql3: Drop unneeded filtering when continuous clustering-key is selected

### DIFF
--- a/cql3/restrictions/statement_restrictions.cc
+++ b/cql3/restrictions/statement_restrictions.cc
@@ -504,7 +504,6 @@ bool statement_restrictions::need_filtering() const {
         number_of_filtering_restrictions += _clustering_columns_restrictions->size() - _clustering_columns_restrictions->prefix_size();
     }
     return number_of_restricted_columns_for_indexing > 1
-            || (number_of_restricted_columns_for_indexing == 0 && _partition_key_restrictions->empty() && !_clustering_columns_restrictions->empty())
             || (number_of_restricted_columns_for_indexing != 0 && _nonprimary_key_restrictions->has_multiple_contains())
             || (number_of_restricted_columns_for_indexing != 0 && !_uses_secondary_indexing)
             || (_uses_secondary_indexing && number_of_filtering_restrictions > 1);

--- a/test/boost/cql_query_group_test.cc
+++ b/test/boost/cql_query_group_test.cc
@@ -226,7 +226,7 @@ SEASTAR_TEST_CASE(test_group_by_text_key) {
         require_rows(e, "select avg(v) from t2 group by p", {{I(25), T(" ")}});
         require_rows(e, "select avg(v) from t2 group by p, c1", {{I(15), T(" "), T("")}, {I(35), T(" "), T("a")}});
         require_rows(e, "select sum(v) from t2 where c1='' group by p, c2 allow filtering",
-                     {{I(10), T(""), T(" "), T("")}, {I(20), T(""), T(" "), T("b")}});
+                     {{I(10), T(" "), T("")}, {I(20), T(" "), T("b")}});
         return make_ready_future<>();
     });
 }

--- a/test/boost/cql_query_group_test.cc
+++ b/test/boost/cql_query_group_test.cc
@@ -105,7 +105,7 @@ SEASTAR_TEST_CASE(test_group_by_syntax) {
         BOOST_REQUIRE_EXCEPTION(
                 e.execute_cql("select * from t1 where p1 > 0 group by p2 allow filtering").get(), ire, order);
         BOOST_REQUIRE_EXCEPTION(
-                e.execute_cql("select * from t1 where (c1,c2) > (0,0) group by p1, p2, c3 allow filtering").get(),
+                e.execute_cql("select * from t1 where (c1,c2) > (0,0) group by p1, p2, c3").get(),
                 ire, order);
         BOOST_REQUIRE_EXCEPTION(
                 e.execute_cql("select * from t1 where p1>0 and p2=0 group by c1 allow filtering").get(), ire, order);
@@ -225,7 +225,7 @@ SEASTAR_TEST_CASE(test_group_by_text_key) {
         cquery_nofail(e, "insert into t2 (p, c1, c2, v) values (' ', 'a', 'b', 40)");
         require_rows(e, "select avg(v) from t2 group by p", {{I(25), T(" ")}});
         require_rows(e, "select avg(v) from t2 group by p, c1", {{I(15), T(" "), T("")}, {I(35), T(" "), T("a")}});
-        require_rows(e, "select sum(v) from t2 where c1='' group by p, c2 allow filtering",
+        require_rows(e, "select sum(v) from t2 where c1='' group by p, c2",
                      {{I(10), T(" "), T("")}, {I(20), T(" "), T("b")}});
         return make_ready_future<>();
     });

--- a/test/boost/cql_query_group_test.cc
+++ b/test/boost/cql_query_group_test.cc
@@ -105,8 +105,7 @@ SEASTAR_TEST_CASE(test_group_by_syntax) {
         BOOST_REQUIRE_EXCEPTION(
                 e.execute_cql("select * from t1 where p1 > 0 group by p2 allow filtering").get(), ire, order);
         BOOST_REQUIRE_EXCEPTION(
-                e.execute_cql("select * from t1 where (c1,c2) > (0,0) group by p1, p2, c3").get(),
-                ire, order);
+                e.execute_cql("select * from t1 where (c1,c2) > (0,0) group by p1, p2, c3").get(), ire, order);
         BOOST_REQUIRE_EXCEPTION(
                 e.execute_cql("select * from t1 where p1>0 and p2=0 group by c1 allow filtering").get(), ire, order);
         // Even when GROUP BY lists all primary-key columns:

--- a/test/boost/cql_query_test.cc
+++ b/test/boost/cql_query_test.cc
@@ -2397,8 +2397,8 @@ SEASTAR_TEST_CASE(test_in_restriction) {
         {
             auto msg = e.execute_cql("select r1 from tir2 where (c1,r1) in ((0, 1),(1,2),(0,1),(1,2),(3,3)) ALLOW FILTERING;").get0();
             assert_that(msg).is_rows().with_rows({
-                {int32_type->decompose(1), int32_type->decompose(0)},
-                {int32_type->decompose(2), int32_type->decompose(1)},
+                {int32_type->decompose(1)},
+                {int32_type->decompose(2)},
             });
         }
         {
@@ -2422,8 +2422,8 @@ SEASTAR_TEST_CASE(test_in_restriction) {
             raw_values.emplace_back(cql3::raw_value::make_value(in_values_list));
             auto msg = e.execute_prepared(prepared_id,raw_values).get0();
             assert_that(msg).is_rows().with_rows({
-                {int32_type->decompose(1), int32_type->decompose(0)},
-                {int32_type->decompose(2), int32_type->decompose(1)},
+                {int32_type->decompose(1)},
+                {int32_type->decompose(2)},
             });
         }
     });

--- a/test/boost/cql_query_test.cc
+++ b/test/boost/cql_query_test.cc
@@ -247,7 +247,7 @@ SEASTAR_TEST_CASE(test_map_elements_validation) {
 SEASTAR_TEST_CASE(test_in_clause_validation) {
     return do_with_cql_env_thread([](cql_test_env& e) {
         auto test_inline = [&] (sstring value, bool should_throw) {
-            auto cql = sprint("SELECT r1 FROM tbl WHERE (c1,r1) IN ((1, '%s')) ALLOW FILTERING", value);
+            auto cql = sprint("SELECT r1 FROM tbl WHERE (c1,r1) IN ((1, '%s'))", value);
             if (should_throw) {
                 BOOST_REQUIRE_THROW(e.execute_cql(cql).get(), exceptions::invalid_request_exception);
             } else {
@@ -258,7 +258,7 @@ SEASTAR_TEST_CASE(test_in_clause_validation) {
         test_inline("definietly not a date value", true);
         test_inline("2015-05-03", false);
         e.execute_cql("CREATE TABLE tbl2 (p1 int, c1 int, r1 text, PRIMARY KEY (p1, c1,r1))").get();
-        auto id = e.prepare("SELECT r1 FROM tbl2 WHERE (c1,r1) IN ? ALLOW FILTERING").get0();
+        auto id = e.prepare("SELECT r1 FROM tbl2 WHERE (c1,r1) IN ?").get0();
         auto test_bind = [&] (sstring value, bool should_throw) {
             auto my_tuple_type = tuple_type_impl::get_instance({int32_type, utf8_type});
             auto my_list_type = list_type_impl::get_instance(my_tuple_type, true);
@@ -424,7 +424,7 @@ SEASTAR_TEST_CASE(test_select_statement) {
             });
         }).then([&e] {
             // Test full partition range, singular clustering range
-            return e.execute_cql("select * from cf where c1 = 1 and c2 = 2 allow filtering;").then([] (shared_ptr<cql_transport::messages::result_message> msg) {
+            return e.execute_cql("select * from cf where c1 = 1 and c2 = 2;").then([] (shared_ptr<cql_transport::messages::result_message> msg) {
                 assert_that(msg).is_rows()
                     .with_size(3)
                     .with_row({
@@ -2395,14 +2395,14 @@ SEASTAR_TEST_CASE(test_in_restriction) {
         e.execute_cql("insert into tir2 (p1, c1, r1) values (1, 2, 3);").get();
         e.execute_cql("insert into tir2 (p1, c1, r1) values (2, 3, 4);").get();
         {
-            auto msg = e.execute_cql("select r1 from tir2 where (c1,r1) in ((0, 1),(1,2),(0,1),(1,2),(3,3)) ALLOW FILTERING;").get0();
+            auto msg = e.execute_cql("select r1 from tir2 where (c1,r1) in ((0, 1),(1,2),(0,1),(1,2),(3,3));").get0();
             assert_that(msg).is_rows().with_rows({
                 {int32_type->decompose(1)},
                 {int32_type->decompose(2)},
             });
         }
         {
-            auto prepared_id = e.prepare("select r1 from tir2 where (c1,r1) in ? ALLOW FILTERING;").get0();
+            auto prepared_id = e.prepare("select r1 from tir2 where (c1,r1) in ?;").get0();
             auto my_tuple_type = tuple_type_impl::get_instance({int32_type,int32_type});
             auto my_list_type = list_type_impl::get_instance(my_tuple_type, true);
             std::vector<tuple_type_impl::native_type> native_tuples = {
@@ -4525,7 +4525,7 @@ SEASTAR_TEST_CASE(test_select_serial_consistency) {
             }
         };
         check_fails("select * from t allow filtering");
-        check_fails("select * from t where  b > 0 allow filtering");
+        check_fails("select * from t where  b > 0");
         check_fails("select * from t where  a in (1, 3)");
         prepared_on_shard(e, "select * from t where a = 1", {}, {{I(1), I(1)}, {I(1), I(2)}}, db::consistency_level::SERIAL);
     });
@@ -4582,8 +4582,8 @@ SEASTAR_TEST_CASE(test_impossible_where) {
         cquery_nofail(e, "INSERT INTO  t2(p,c) VALUES (0, 0)");
         cquery_nofail(e, "INSERT INTO  t2(p,c) VALUES (1, 10)");
         cquery_nofail(e, "INSERT INTO  t2(p,c) VALUES (2, 20)");
-        require_rows(e, "SELECT * FROM t2 WHERE c>10 AND c<10 ALLOW FILTERING", {});
-        require_rows(e, "SELECT * FROM t2 WHERE c>=10 AND c<=0 ALLOW FILTERING", {});
+        require_rows(e, "SELECT * FROM t2 WHERE c>10 AND c<10", {});
+        require_rows(e, "SELECT * FROM t2 WHERE c>=10 AND c<=0", {});
     });
 }
 

--- a/test/boost/filtering_test.cc
+++ b/test/boost/filtering_test.cc
@@ -198,7 +198,7 @@ SEASTAR_TEST_CASE(test_allow_filtering_multi_column) {
         e.execute_cql("INSERT INTO t (a,b,c,d,e) VALUES (1, 2, 1, 2, 25)").get();
         e.execute_cql("INSERT INTO t (a,b,c,d,e) VALUES (1, 2, 1, 3, 35)").get();
 
-        auto msg = e.execute_cql("SELECT * FROM t WHERE (c, d) = (1, 2) ALLOW FILTERING").get0();
+        auto msg = e.execute_cql("SELECT * FROM t WHERE (c, d) = (1, 2)").get0();
         assert_that(msg).is_rows().with_rows_ignore_order({
             {
                 int32_type->decompose(1),
@@ -216,7 +216,7 @@ SEASTAR_TEST_CASE(test_allow_filtering_multi_column) {
             },
         });
 
-        msg = e.execute_cql("SELECT * FROM t WHERE (c, d) IN ((1, 2), (1,3), (1,4)) ALLOW FILTERING").get0();
+        msg = e.execute_cql("SELECT * FROM t WHERE (c, d) IN ((1, 2), (1,3), (1,4))").get0();
         assert_that(msg).is_rows().with_rows_ignore_order({
             {
                 int32_type->decompose(1),
@@ -241,7 +241,7 @@ SEASTAR_TEST_CASE(test_allow_filtering_multi_column) {
             },
         });
 
-        msg = e.execute_cql("SELECT * FROM t WHERE (c, d) < (1, 3) ALLOW FILTERING").get0();
+        msg = e.execute_cql("SELECT * FROM t WHERE (c, d) < (1, 3)").get0();
         assert_that(msg).is_rows().with_rows_ignore_order({
             {
                 int32_type->decompose(1),
@@ -266,7 +266,7 @@ SEASTAR_TEST_CASE(test_allow_filtering_multi_column) {
             },
         });
 
-        msg = e.execute_cql("SELECT * FROM t WHERE (c, d) < (1, 3) AND (c, d) > (1, 1) ALLOW FILTERING").get0();
+        msg = e.execute_cql("SELECT * FROM t WHERE (c, d) < (1, 3) AND (c, d) > (1, 1)").get0();
         assert_that(msg).is_rows().with_rows_ignore_order({
             {
                 int32_type->decompose(1),
@@ -348,7 +348,7 @@ SEASTAR_TEST_CASE(test_allow_filtering_clustering_column) {
            }
         });
 
-        msg = e.execute_cql("SELECT * FROM t WHERE c > 2 AND c <= 4 ALLOW FILTERING").get0();
+        msg = e.execute_cql("SELECT * FROM t WHERE c > 2 AND c <= 4").get0();
         assert_that(msg).is_rows().with_rows({{
             int32_type->decompose(1),
             int32_type->decompose(3),
@@ -601,7 +601,7 @@ SEASTAR_TEST_CASE(test_allow_filtering_desc) {
         e.execute_cql("INSERT INTO t (a, b, c, d, e) VALUES (1, 2, 5, 1, 9)").get();
         e.execute_cql("INSERT INTO t (a, b, c, d, e) VALUES (1, 2, 6, 7, 5)").get();
 
-        auto msg = e.execute_cql("SELECT a, b, c, d, e FROM t WHERE c > 3 ALLOW FILTERING").get0();
+        auto msg = e.execute_cql("SELECT a, b, c, d, e FROM t WHERE c > 3").get0();
         assert_that(msg).is_rows().with_rows({
             {
                 int32_type->decompose(1),
@@ -619,7 +619,7 @@ SEASTAR_TEST_CASE(test_allow_filtering_desc) {
             }
         });
 
-        msg = e.execute_cql("SELECT a, b, c, d, e FROM t WHERE c < 4 ALLOW FILTERING").get0();
+        msg = e.execute_cql("SELECT a, b, c, d, e FROM t WHERE c < 4").get0();
         assert_that(msg).is_rows().with_rows({
             {
                 int32_type->decompose(1),
@@ -637,7 +637,7 @@ SEASTAR_TEST_CASE(test_allow_filtering_desc) {
             }
         });
 
-        msg = e.execute_cql("SELECT a, b, c, d, e FROM t WHERE c = 4 ALLOW FILTERING").get0();
+        msg = e.execute_cql("SELECT a, b, c, d, e FROM t WHERE c = 4").get0();
         assert_that(msg).is_rows().with_size(0);
     });
 }
@@ -1076,7 +1076,7 @@ SEASTAR_TEST_CASE(test_filtering_on_empty_partition_with_a_static_row) {
         cquery_nofail(e, "INSERT INTO t (p, s) VALUES (1, 1);");
         auto msg = cquery_nofail(e, "SELECT * FROM t WHERE s = 2 ALLOW FILTERING;");
         assert_that(msg).is_rows().is_empty();
-        msg = cquery_nofail(e, "SELECT * FROM t WHERE c = 1 ALLOW FILTERING");
+        msg = cquery_nofail(e, "SELECT * FROM t WHERE c = 1");
         assert_that(msg).is_rows().is_empty();
         cquery_nofail(e, "INSERT INTO t (p, c, s) VALUES (2, 2, 2);");
         msg = cquery_nofail(e, "SELECT * FROM t WHERE s = 1 ALLOW FILTERING");

--- a/test/boost/filtering_test.cc
+++ b/test/boost/filtering_test.cc
@@ -65,16 +65,6 @@ SEASTAR_TEST_CASE(test_allow_filtering_check) {
             e.execute_cql(q + " ALLOW FILTERING").get();
         }
 
-        queries = {
-            "SELECT * FROM t WHERE c = 2",
-            "SELECT * FROM t WHERE c <= 4"
-        };
-
-        for (const sstring& q : queries) {
-            BOOST_CHECK_THROW(e.execute_cql(q).get(), exceptions::invalid_request_exception);
-            e.execute_cql(q + " ALLOW FILTERING").get();
-        }
-
         e.execute_cql("CREATE TABLE t2 (p int PRIMARY KEY, a int, b int);").get();
         e.require_table_exists("ks", "t2").get();
         e.execute_cql("CREATE INDEX ON t2(a)").get();
@@ -344,10 +334,7 @@ SEASTAR_TEST_CASE(test_allow_filtering_clustering_column) {
             int32_type->decompose(1)
         }});
 
-        BOOST_CHECK_THROW(e.execute_cql("SELECT * FROM t WHERE c = 2").get(), exceptions::invalid_request_exception);
-        BOOST_CHECK_THROW(e.execute_cql("SELECT * FROM t WHERE c > 2 AND c <= 4").get(), exceptions::invalid_request_exception);
-
-        msg = e.execute_cql("SELECT * FROM t WHERE c = 2 ALLOW FILTERING").get0();
+        msg = e.execute_cql("SELECT * FROM t WHERE c = 2").get0();
         assert_that(msg).is_rows().with_rows({
             {
                 int32_type->decompose(1),

--- a/test/boost/large_paging_state_test.cc
+++ b/test/boost/large_paging_state_test.cc
@@ -103,7 +103,7 @@ SEASTAR_TEST_CASE(test_use_high_bits_of_remaining_rows_in_paging_state_filtering
 
         auto qo = std::make_unique<cql3::query_options>(db::consistency_level::LOCAL_ONE, infinite_timeout_config, std::vector<cql3::raw_value>{},
                     cql3::query_options::specific_options{5, nullptr, {}, api::new_timestamp()});
-        auto msg = e.execute_cql("select * from test where ck > 10 allow filtering;", std::move(qo)).get0();
+        auto msg = e.execute_cql("select * from test where ck > 10;", std::move(qo)).get0();
         auto paging_state = extract_paging_state(msg);
         uint64_t rows_fetched = count_rows_fetched(msg);
         BOOST_REQUIRE_EQUAL(paging_state->get_remaining() + rows_fetched, query::max_rows);
@@ -115,7 +115,7 @@ SEASTAR_TEST_CASE(test_use_high_bits_of_remaining_rows_in_paging_state_filtering
         while (has_more_pages(msg)) {
             qo = std::make_unique<cql3::query_options>(db::consistency_level::LOCAL_ONE, infinite_timeout_config, std::vector<cql3::raw_value>{},
                     cql3::query_options::specific_options{5, paging_state, {}, api::new_timestamp()});
-            msg = e.execute_cql("SELECT * FROM test where ck > 10 allow filtering;", std::move(qo)).get0();
+            msg = e.execute_cql("SELECT * FROM test where ck > 10;", std::move(qo)).get0();
             rows_fetched = count_rows_fetched(msg);
             test_remaining = test_remaining - rows_fetched;
             if (has_more_pages(msg)) {

--- a/test/boost/query_processor_test.cc
+++ b/test/boost/query_processor_test.cc
@@ -342,7 +342,7 @@ SEASTAR_TEST_CASE(test_select_full_scan_metrics) {
 
         // Filtered by ck but not filtered by pk
         auto stat_ps4 = qp.get_cql_stats().select_partition_range_scan;
-        qp.execute_internal("select * from ks.fsm where ck = 1 allow filtering;").get();
+        qp.execute_internal("select * from ks.fsm where ck = 1;").get();
         BOOST_CHECK_EQUAL(stat_ps4 + 1, qp.get_cql_stats().select_partition_range_scan);
 
         // Filtered by unindexed non-cluster column

--- a/test/boost/restrictions_test.cc
+++ b/test/boost/restrictions_test.cc
@@ -184,10 +184,8 @@ SEASTAR_THREAD_TEST_CASE(tuple_of_list) {
         cquery_nofail(e, "insert into t (p, l1, l2) values (2, [21,22], [201,202])");
         require_rows(e, "select * from t where (l1,l2)<([],[])", {});
         require_rows(e, "select l1 from t where (l1,l2)<([20],[200])", {{LI({11, 12})}});
-        require_rows(e, "select l1 from t where (l1,l2)>=([11,12],[101,102])",
-                     {{LI({11, 12})}, {LI({21, 22})}});
-        require_rows(e, "select l1 from t where (l1,l2)<([11,12],[101,103])",
-                     {{LI({11, 12})}});
+        require_rows(e, "select l1 from t where (l1,l2)>=([11,12],[101,102])", {{LI({11, 12})}, {LI({21, 22})}});
+        require_rows(e, "select l1 from t where (l1,l2)<([11,12],[101,103])", {{LI({11, 12})}});
     }).get();
 }
 
@@ -351,8 +349,7 @@ SEASTAR_THREAD_TEST_CASE(multi_col_eq) {
         require_rows(e, "select c1 from t where (c1)=('one')", {{T("one")}});
         require_rows(e, "select c1 from t where (c1)=('x')", {});
         auto stmt = e.prepare("select p from t where (c1,c2)=:t").get0();
-        require_rows(e, stmt, {{"t"}}, {make_tuple({utf8_type, float_type}, {sstring("two"), 12.f})},
-                         {{I(2)}});
+        require_rows(e, stmt, {{"t"}}, {make_tuple({utf8_type, float_type}, {sstring("two"), 12.f})}, {{I(2)}});
         require_rows(e, stmt, {{"t"}}, {make_tuple({utf8_type, float_type}, {sstring("x"), 12.f})}, {});
         stmt = e.prepare("select p from t where (c1,c2)=('two',?)").get0();
         require_rows(e, stmt, {}, {F(12)}, {{I(2)}});
@@ -375,15 +372,12 @@ SEASTAR_THREAD_TEST_CASE(multi_col_slice) {
         cquery_nofail(e, "insert into t (p, c1, c2) values (2, 'b', 2);");
         cquery_nofail(e, "insert into t (p, c1, c2) values (3, 'c', 13);");
         require_rows(e, "select c2 from t where (c1,c2)>('a',20)", {{F(2)}, {F(13)}});
-        require_rows(e, "select p from t where (c1,c2)>=('a',20) and (c1,c2)<('b',3)",
-                     {{I(2)}});
+        require_rows(e, "select p from t where (c1,c2)>=('a',20) and (c1,c2)<('b',3)", {{I(2)}});
         require_rows(e, "select * from t where (c1,c2)<('a',11)", {});
         require_rows(e, "select c1 from t where (c1,c2)<('a',12)", {{T("a")}});
         require_rows(e, "select c1 from t where (c1)>=('c')", {{T("c")}});
-        require_rows(e, "select c1 from t where (c1,c2)<=('c',13)",
-                     {{T("a")}, {T("b")}, {T("c")}});
-        require_rows(e, "select c1 from t where (c1,c2)>=('b',2) and (c1,c2)<=('b',2)",
-                     {{T("b")}});
+        require_rows(e, "select c1 from t where (c1,c2)<=('c',13)", {{T("a")}, {T("b")}, {T("c")}});
+        require_rows(e, "select c1 from t where (c1,c2)>=('b',2) and (c1,c2)<=('b',2)", {{T("b")}});
         auto stmt = e.prepare("select c1 from t where (c1,c2)<?").get0();
         require_rows(e, stmt, {}, {make_tuple({utf8_type, float_type}, {sstring("a"), 12.f})}, {{T("a")}});
         require_rows(e, stmt, {}, {make_tuple({utf8_type, float_type}, {sstring("a"), 11.f})}, {});
@@ -406,8 +400,7 @@ SEASTAR_THREAD_TEST_CASE(multi_col_slice_reversed) {
         cquery_nofail(e, "insert into t(p,c1,c2) values (1,11,21)");
         cquery_nofail(e, "insert into t(p,c1,c2) values (1,12,22)");
         cquery_nofail(e, "insert into t(p,c1,c2) values (1,12,23)");
-        require_rows(e, "select c1 from t where (c1,c2)>(10,99)",
-                         {{I(11)}, {I(12)}, {I(12)}});
+        require_rows(e, "select c1 from t where (c1,c2)>(10,99)", {{I(11)}, {I(12)}, {I(12)}});
         require_rows(e, "select c1 from t where (c1,c2)<(12,0)", {{I(11)}});
         require_rows(e, "select c1 from t where (c1,c2)>(12,22)", {{I(12)}});
         require_rows(e, "select c1 from t where (c1)>(12)", {});
@@ -687,8 +680,7 @@ SEASTAR_THREAD_TEST_CASE(list_in) {
         cquery_nofail(e, "insert into t (p, c) values ([4], [])");
         cquery_nofail(e, "insert into t (p, c) values ([5], [51,52,53])");
         require_rows(e, "select c from t where c in ([11,12],[11,13])", {});
-        require_rows(e, "select c from t where c in ([11,12,13],[11,13,12])",
-                         {{LI({11,12,13})}});
+        require_rows(e, "select c from t where c in ([11,12,13],[11,13,12])", {{LI({11,12,13})}});
         require_rows(e, "select c from t where c in ([11,12,13],[11,13,12],[41,42,43])",
                          {{LI({11,12,13})}, {LI({41,42,43})}});
         require_rows(e, "select c from t where p in ([1],[2],[4]) and c in ([11,12,13], [41,42,43])",
@@ -705,8 +697,7 @@ SEASTAR_THREAD_TEST_CASE(set_in) {
         cquery_nofail(e, "insert into t (p, c, r) values ({1,11}, {22,202}, '2')");
         require_rows(e, "select * from t where c in ({222}, {21})", {});
         require_rows(e, "select c from t where c in ({222}, {21,201})", {{SI({21, 201})}});
-        require_rows(e, "select c from t where c in ({22,202}, {21,201})",
-                         {{SI({21, 201})}, {SI({22, 202})}});
+        require_rows(e, "select c from t where c in ({22,202}, {21,201})", {{SI({21, 201})}, {SI({22, 202})}});
         require_rows(e, "select c from t where c in ({222}, {21,201}) and r='' allow filtering", {});
         require_rows(e, "select c from t where c in ({222}, {21,201}) and r='x' allow filtering", {});
         require_rows(e, "select c from t where c in ({22,202}, {21,201}) and r='2' allow filtering",
@@ -733,8 +724,8 @@ SEASTAR_THREAD_TEST_CASE(map_in) {
                          {{c1b, I(12)}});
         require_rows(e, "select c from t where c in ({10:11}, {10:10}, {10:10,11:11}) and r in (12,null) "
                          "allow filtering", {{c1b, I(12)}});
-        require_rows(e, "select c from t where c in ({10:11}, {10:10}, {10:10,11:11}) and p in ({1:1},{2:2})"
-                         , {{c1a}, {c1b}});
+        require_rows(e, "select c from t where c in ({10:11}, {10:10}, {10:10,11:11}) and p in ({1:1},{2:2})",
+                     {{c1a}, {c1b}});
     }).get();
 }
 
@@ -746,17 +737,13 @@ SEASTAR_THREAD_TEST_CASE(multi_col_in) {
         require_rows(e, "select ck1 from t where (ck1,ck2) in ((11,21),(12,22))", {{I(11)}});
         require_rows(e, "select ck1 from t where (ck1,ck2) in ((11,21))", {{I(11)}});
         cquery_nofail(e, "insert into t(pk,ck1,ck2) values (2,12,22)");
-        require_rows(e, "select ck1 from t where (ck1,ck2) in ((11,21),(12,22))",
-                         {{I(11)}, {I(12)}});
+        require_rows(e, "select ck1 from t where (ck1,ck2) in ((11,21),(12,22))", {{I(11)}, {I(12)}});
         cquery_nofail(e, "insert into t(pk,ck1,ck2) values (3,13,23)");
-        require_rows(e, "select ck1 from t where (ck1,ck2) in ((11,21),(12,22))",
-                         {{I(11)}, {I(12)}});
+        require_rows(e, "select ck1 from t where (ck1,ck2) in ((11,21),(12,22))", {{I(11)}, {I(12)}});
         require_rows(e, "select ck1 from t where (ck1,ck2) in ((13,23))", {{I(13)}});
         cquery_nofail(e, "insert into t(pk,ck1,ck2,r) values (4,13,23,'a')");
-        require_rows(e, "select pk from t where (ck1,ck2) in ((13,23))",
-                         {{I(3)}, {I(4)}});
-        require_rows(e, "select pk from t where (ck1) in ((13),(33),(44))",
-                         {{I(3)}, {I(4)}});
+        require_rows(e, "select pk from t where (ck1,ck2) in ((13,23))", {{I(3)}, {I(4)}});
+        require_rows(e, "select pk from t where (ck1) in ((13),(33),(44))", {{I(3)}, {I(4)}});
         // TODO: uncomment when #6200 is fixed.
         // require_rows(e, "select pk from t where (ck1,ck2) in ((13,23)) and r='a' allow filtering",
         //                  {{I(4), I(13), F(23), T("a")}});

--- a/test/boost/restrictions_test.cc
+++ b/test/boost/restrictions_test.cc
@@ -182,11 +182,11 @@ SEASTAR_THREAD_TEST_CASE(tuple_of_list) {
         cquery_nofail(e, "create table t (p int, l1 frozen<list<int>>, l2 frozen<list<int>>, primary key(p,l1,l2))");
         cquery_nofail(e, "insert into t (p, l1, l2) values (1, [11,12], [101,102])");
         cquery_nofail(e, "insert into t (p, l1, l2) values (2, [21,22], [201,202])");
-        require_rows(e, "select * from t where (l1,l2)<([],[]) allow filtering", {});
-        require_rows(e, "select l1 from t where (l1,l2)<([20],[200]) allow filtering", {{LI({11, 12})}});
-        require_rows(e, "select l1 from t where (l1,l2)>=([11,12],[101,102]) allow filtering",
+        require_rows(e, "select * from t where (l1,l2)<([],[])", {});
+        require_rows(e, "select l1 from t where (l1,l2)<([20],[200])", {{LI({11, 12})}});
+        require_rows(e, "select l1 from t where (l1,l2)>=([11,12],[101,102])",
                      {{LI({11, 12})}, {LI({21, 22})}});
-        require_rows(e, "select l1 from t where (l1,l2)<([11,12],[101,103]) allow filtering",
+        require_rows(e, "select l1 from t where (l1,l2)<([11,12],[101,103])",
                      {{LI({11, 12})}});
     }).get();
 }
@@ -244,10 +244,10 @@ SEASTAR_THREAD_TEST_CASE(regular_col_slice_reversed) {
     do_with_cql_env_thread([](cql_test_env& e) {
         cquery_nofail(e, "create table t (p int, c int, primary key(p, c)) with clustering order by (c desc)");
         cquery_nofail(e, "insert into t(p,c) values (1,11)");
-        require_rows(e, "select c from t where c>10 allow filtering", {{I(11)}});
+        require_rows(e, "select c from t where c>10", {{I(11)}});
         cquery_nofail(e, "insert into t(p,c) values (1,12)");
-        require_rows(e, "select c from t where c>10 allow filtering", {{I(11)}, {I(12)}});
-        require_rows(e, "select c from t where c<100 allow filtering", {{I(11)}, {I(12)}});
+        require_rows(e, "select c from t where c>10", {{I(11)}, {I(12)}});
+        require_rows(e, "select c from t where c<100", {{I(11)}, {I(12)}});
     }).get();
 }
 
@@ -313,7 +313,7 @@ SEASTAR_THREAD_TEST_CASE(null_rhs) {
         BOOST_REQUIRE_EXCEPTION(q("select * from t where pk1=0 and pk2=null"), ire, message_contains(expect));
         BOOST_REQUIRE_EXCEPTION(q("select * from t where pk1=0 and pk2=0 and (ck1,ck2)>=(0,null)"),
                                 ire, message_contains(expect));
-        BOOST_REQUIRE_EXCEPTION(q("select * from t where ck1=null allow filtering"), ire, message_contains(expect));
+        BOOST_REQUIRE_EXCEPTION(q("select * from t where ck1=null"), ire, message_contains(expect));
         BOOST_REQUIRE_EXCEPTION(q("select * from t where r=null and ck1=null allow filtering"),
                                 ire, message_contains(expect));
         require_rows(e, "select * from t where pk1=0 and pk2=0 and ck1<null", {});
@@ -345,23 +345,23 @@ SEASTAR_THREAD_TEST_CASE(multi_col_eq) {
         require_rows(e, "select c2 from t where p=1 and (c1,c2)=('one',11)", {{F(11)}});
         require_rows(e, "select c1 from t where p=1 and (c1)=('one')", {{T("one")}});
         require_rows(e, "select c2 from t where p=2 and (c1,c2)=('one',11)", {});
-        require_rows(e, "select p from t where (c1,c2)=('two',12) allow filtering", {{I(2)}});
-        require_rows(e, "select c2 from t where (c1,c2)=('one',12) allow filtering", {});
-        require_rows(e, "select c2 from t where (c1,c2)=('two',11) allow filtering", {});
-        require_rows(e, "select c1 from t where (c1)=('one') allow filtering", {{T("one")}});
-        require_rows(e, "select c1 from t where (c1)=('x') allow filtering", {});
-        auto stmt = e.prepare("select p from t where (c1,c2)=:t allow filtering").get0();
+        require_rows(e, "select p from t where (c1,c2)=('two',12)", {{I(2)}});
+        require_rows(e, "select c2 from t where (c1,c2)=('one',12)", {});
+        require_rows(e, "select c2 from t where (c1,c2)=('two',11)", {});
+        require_rows(e, "select c1 from t where (c1)=('one')", {{T("one")}});
+        require_rows(e, "select c1 from t where (c1)=('x')", {});
+        auto stmt = e.prepare("select p from t where (c1,c2)=:t").get0();
         require_rows(e, stmt, {{"t"}}, {make_tuple({utf8_type, float_type}, {sstring("two"), 12.f})},
                          {{I(2)}});
         require_rows(e, stmt, {{"t"}}, {make_tuple({utf8_type, float_type}, {sstring("x"), 12.f})}, {});
-        stmt = e.prepare("select p from t where (c1,c2)=('two',?) allow filtering").get0();
+        stmt = e.prepare("select p from t where (c1,c2)=('two',?)").get0();
         require_rows(e, stmt, {}, {F(12)}, {{I(2)}});
         require_rows(e, stmt, {}, {F(99)}, {});
-        stmt = e.prepare("select c1 from t where (c1)=? allow filtering").get0();
+        stmt = e.prepare("select c1 from t where (c1)=?").get0();
         require_rows(e, stmt, {}, {make_tuple({utf8_type}, {sstring("one")})}, {{T("one")}});
         require_rows(e, stmt, {}, {make_tuple({utf8_type}, {sstring("two")})}, {{T("two")}});
         require_rows(e, stmt, {}, {make_tuple({utf8_type}, {sstring("three")})}, {});
-        stmt = e.prepare("select c1 from t where (c1)=(:c1) allow filtering").get0();
+        stmt = e.prepare("select c1 from t where (c1)=(:c1)").get0();
         require_rows(e, stmt, {{"c1"}}, {T("one")}, {{T("one")}});
         require_rows(e, stmt, {{"c1"}}, {T("two")}, {{T("two")}});
         require_rows(e, stmt, {{"c1"}}, {T("three")}, {});
@@ -374,26 +374,26 @@ SEASTAR_THREAD_TEST_CASE(multi_col_slice) {
         cquery_nofail(e, "insert into t (p, c1, c2) values (1, 'a', 11);");
         cquery_nofail(e, "insert into t (p, c1, c2) values (2, 'b', 2);");
         cquery_nofail(e, "insert into t (p, c1, c2) values (3, 'c', 13);");
-        require_rows(e, "select c2 from t where (c1,c2)>('a',20) allow filtering", {{F(2)}, {F(13)}});
-        require_rows(e, "select p from t where (c1,c2)>=('a',20) and (c1,c2)<('b',3) allow filtering",
+        require_rows(e, "select c2 from t where (c1,c2)>('a',20)", {{F(2)}, {F(13)}});
+        require_rows(e, "select p from t where (c1,c2)>=('a',20) and (c1,c2)<('b',3)",
                      {{I(2)}});
-        require_rows(e, "select * from t where (c1,c2)<('a',11) allow filtering", {});
-        require_rows(e, "select c1 from t where (c1,c2)<('a',12) allow filtering", {{T("a")}});
-        require_rows(e, "select c1 from t where (c1)>=('c') allow filtering", {{T("c")}});
-        require_rows(e, "select c1 from t where (c1,c2)<=('c',13) allow filtering",
+        require_rows(e, "select * from t where (c1,c2)<('a',11)", {});
+        require_rows(e, "select c1 from t where (c1,c2)<('a',12)", {{T("a")}});
+        require_rows(e, "select c1 from t where (c1)>=('c')", {{T("c")}});
+        require_rows(e, "select c1 from t where (c1,c2)<=('c',13)",
                      {{T("a")}, {T("b")}, {T("c")}});
-        require_rows(e, "select c1 from t where (c1,c2)>=('b',2) and (c1,c2)<=('b',2) allow filtering",
+        require_rows(e, "select c1 from t where (c1,c2)>=('b',2) and (c1,c2)<=('b',2)",
                      {{T("b")}});
-        auto stmt = e.prepare("select c1 from t where (c1,c2)<? allow filtering").get0();
+        auto stmt = e.prepare("select c1 from t where (c1,c2)<?").get0();
         require_rows(e, stmt, {}, {make_tuple({utf8_type, float_type}, {sstring("a"), 12.f})}, {{T("a")}});
         require_rows(e, stmt, {}, {make_tuple({utf8_type, float_type}, {sstring("a"), 11.f})}, {});
-        stmt = e.prepare("select c1 from t where (c1,c2)<('a',:c2) allow filtering").get0();
+        stmt = e.prepare("select c1 from t where (c1,c2)<('a',:c2)").get0();
         require_rows(e, stmt, {{"c2"}}, {F(12)}, {{T("a")}});
         require_rows(e, stmt, {{"c2"}}, {F(11)}, {});
-        stmt = e.prepare("select c1 from t where (c1)>=? allow filtering").get0();
+        stmt = e.prepare("select c1 from t where (c1)>=?").get0();
         require_rows(e, stmt, {}, {make_tuple({utf8_type}, {sstring("c")})}, {{T("c")}});
         require_rows(e, stmt, {}, {make_tuple({utf8_type}, {sstring("x")})}, {});
-        stmt = e.prepare("select c1 from t where (c1)>=(:c1) allow filtering").get0();
+        stmt = e.prepare("select c1 from t where (c1)>=(:c1)").get0();
         require_rows(e, stmt, {{"c1"}}, {T("c")}, {{T("c")}});
         require_rows(e, stmt, {{"c1"}}, {T("x")}, {});
     }).get();
@@ -406,12 +406,12 @@ SEASTAR_THREAD_TEST_CASE(multi_col_slice_reversed) {
         cquery_nofail(e, "insert into t(p,c1,c2) values (1,11,21)");
         cquery_nofail(e, "insert into t(p,c1,c2) values (1,12,22)");
         cquery_nofail(e, "insert into t(p,c1,c2) values (1,12,23)");
-        require_rows(e, "select c1 from t where (c1,c2)>(10,99) allow filtering",
+        require_rows(e, "select c1 from t where (c1,c2)>(10,99)",
                          {{I(11)}, {I(12)}, {I(12)}});
-        require_rows(e, "select c1 from t where (c1,c2)<(12,0) allow filtering", {{I(11)}});
-        require_rows(e, "select c1 from t where (c1,c2)>(12,22) allow filtering", {{I(12)}});
-        require_rows(e, "select c1 from t where (c1)>(12) allow filtering", {});
-        require_rows(e, "select c1 from t where (c1)<=(12) allow filtering", {{I(11)}, {I(12)}, {I(12)}});
+        require_rows(e, "select c1 from t where (c1,c2)<(12,0)", {{I(11)}});
+        require_rows(e, "select c1 from t where (c1,c2)>(12,22)", {{I(12)}});
+        require_rows(e, "select c1 from t where (c1)>(12)", {});
+        require_rows(e, "select c1 from t where (c1)<=(12)", {{I(11)}, {I(12)}, {I(12)}});
     }).get();
 }
 
@@ -636,17 +636,17 @@ SEASTAR_THREAD_TEST_CASE(scalar_in) {
         cquery_nofail(e, "create table t (p int, c int, r float, s text static, primary key (p, c))");
         require_rows(e, "select c from t where c in (11,12,13) allow filtering", {});
         cquery_nofail(e, "insert into t(p,c) values (1,11)");
-        require_rows(e, "select c from t where c in (11,12,13) allow filtering", {{I(11)}});
+        require_rows(e, "select c from t where c in (11,12,13)", {{I(11)}});
         cquery_nofail(e, "insert into t(p,c,r) values (1,11,21)");
         cquery_nofail(e, "insert into t(p,c,r) values (2,12,22)");
         cquery_nofail(e, "insert into t(p,c,r) values (3,13,23)");
         cquery_nofail(e, "insert into t(p,c,r) values (4,14,24)");
         cquery_nofail(e, "insert into t(p,c,r,s) values (4,15,24,'34')");
         cquery_nofail(e, "insert into t(p,c,r,s) values (5,15,25,'35')");
-        require_rows(e, "select c from t where c in (11,12,13) allow filtering", {{I(11)}, {I(12)}, {I(13)}});
-        require_rows(e, "select c from t where c in (11) allow filtering", {{I(11)}});
-        require_rows(e, "select c from t where c in (999) allow filtering", {});
-        require_rows(e, "select c from t where c in (11,999) allow filtering", {{I(11)}});
+        require_rows(e, "select c from t where c in (11,12,13)", {{I(11)}, {I(12)}, {I(13)}});
+        require_rows(e, "select c from t where c in (11)", {{I(11)}});
+        require_rows(e, "select c from t where c in (999)", {});
+        require_rows(e, "select c from t where c in (11,999)", {{I(11)}});
         require_rows(e, "select c from t where c in (11,12,13) and r in (21,24) allow filtering", {{I(11), F(21)}});
         require_rows(e, "select c from t where c in (11,12,13) and r in (21,22) allow filtering",
                          {{I(11), F(21)}, {I(12), F(22)}});
@@ -686,32 +686,32 @@ SEASTAR_THREAD_TEST_CASE(list_in) {
         cquery_nofail(e, "insert into t (p, c) values ([4], [41,42,43])");
         cquery_nofail(e, "insert into t (p, c) values ([4], [])");
         cquery_nofail(e, "insert into t (p, c) values ([5], [51,52,53])");
-        require_rows(e, "select c from t where c in ([11,12],[11,13]) allow filtering", {});
-        require_rows(e, "select c from t where c in ([11,12,13],[11,13,12]) allow filtering",
+        require_rows(e, "select c from t where c in ([11,12],[11,13])", {});
+        require_rows(e, "select c from t where c in ([11,12,13],[11,13,12])",
                          {{LI({11,12,13})}});
-        require_rows(e, "select c from t where c in ([11,12,13],[11,13,12],[41,42,43]) allow filtering",
+        require_rows(e, "select c from t where c in ([11,12,13],[11,13,12],[41,42,43])",
                          {{LI({11,12,13})}, {LI({41,42,43})}});
-        require_rows(e, "select c from t where p in ([1],[2],[4]) and c in ([11,12,13], [41,42,43]) allow filtering",
+        require_rows(e, "select c from t where p in ([1],[2],[4]) and c in ([11,12,13], [41,42,43])",
                          {{LI({11,12,13})}, {LI({41,42,43})}});
-        require_rows(e, "select c from t where c in ([],[11,13,12]) allow filtering", {{LI({})}});
+        require_rows(e, "select c from t where c in ([],[11,13,12])", {{LI({})}});
     }).get();
 }
 
 SEASTAR_THREAD_TEST_CASE(set_in) {
     do_with_cql_env_thread([](cql_test_env& e) {
         cquery_nofail(e, "create table t (p frozen<set<int>>, c frozen<set<int>>, r text, primary key (p, c))");
-        require_rows(e, "select * from t where c in ({222}) allow filtering", {});
+        require_rows(e, "select * from t where c in ({222})", {});
         cquery_nofail(e, "insert into t (p, c) values ({1,11}, {21,201})");
         cquery_nofail(e, "insert into t (p, c, r) values ({1,11}, {22,202}, '2')");
-        require_rows(e, "select * from t where c in ({222}, {21}) allow filtering", {});
-        require_rows(e, "select c from t where c in ({222}, {21,201}) allow filtering", {{SI({21, 201})}});
-        require_rows(e, "select c from t where c in ({22,202}, {21,201}) allow filtering",
+        require_rows(e, "select * from t where c in ({222}, {21})", {});
+        require_rows(e, "select c from t where c in ({222}, {21,201})", {{SI({21, 201})}});
+        require_rows(e, "select c from t where c in ({22,202}, {21,201})",
                          {{SI({21, 201})}, {SI({22, 202})}});
         require_rows(e, "select c from t where c in ({222}, {21,201}) and r='' allow filtering", {});
         require_rows(e, "select c from t where c in ({222}, {21,201}) and r='x' allow filtering", {});
         require_rows(e, "select c from t where c in ({22,202}, {21,201}) and r='2' allow filtering",
                          {{SI({22, 202}), T("2")}});
-        require_rows(e, "select c from t where c in ({22,202}, {21,201}) and p in ({1,11}, {222}) allow filtering",
+        require_rows(e, "select c from t where c in ({22,202}, {21,201}) and p in ({1,11}, {222})",
                          {{SI({21, 201})}, {SI({22, 202})}});
     }).get();
 }
@@ -721,48 +721,48 @@ SEASTAR_THREAD_TEST_CASE(map_in) {
         cquery_nofail(e, "create table t (p frozen<map<int,int>>, c frozen<map<int,int>>, r int, primary key(p, c))");
         cquery_nofail(e, "insert into t (p, c) values ({1:1}, {10:10})");
         cquery_nofail(e, "insert into t (p, c, r) values ({1:1}, {10:10,11:11}, 12)");
-        require_rows(e, "select * from t where c in ({10:11},{10:11},{11:11}) allow filtering", {});
+        require_rows(e, "select * from t where c in ({10:11},{10:11},{11:11})", {});
         const auto my_map_type = map_type_impl::get_instance(int32_type, int32_type, true);
         const auto c1a = my_map_type->decompose(make_map_value(my_map_type, map_type_impl::native_type({{10, 10}})));
-        require_rows(e, "select c from t where c in ({10:11}, {10:10}, {11:11}) allow filtering", {{c1a}});
+        require_rows(e, "select c from t where c in ({10:11}, {10:10}, {11:11})", {{c1a}});
         const auto c1b = my_map_type->decompose(
                 make_map_value(my_map_type, map_type_impl::native_type({{10, 10}, {11, 11}})));
-        require_rows(e, "select c from t where c in ({10:11}, {10:10}, {10:10,11:11}) allow filtering",
+        require_rows(e, "select c from t where c in ({10:11}, {10:10}, {10:10,11:11})",
                          {{c1a}, {c1b}});
         require_rows(e, "select c from t where c in ({10:11}, {10:10}, {10:10,11:11}) and r=12 allow filtering",
                          {{c1b, I(12)}});
         require_rows(e, "select c from t where c in ({10:11}, {10:10}, {10:10,11:11}) and r in (12,null) "
                          "allow filtering", {{c1b, I(12)}});
-        require_rows(e, "select c from t where c in ({10:11}, {10:10}, {10:10,11:11}) and p in ({1:1},{2:2}) "
-                         "allow filtering", {{c1a}, {c1b}});
+        require_rows(e, "select c from t where c in ({10:11}, {10:10}, {10:10,11:11}) and p in ({1:1},{2:2})"
+                         , {{c1a}, {c1b}});
     }).get();
 }
 
 SEASTAR_THREAD_TEST_CASE(multi_col_in) {
     do_with_cql_env_thread([](cql_test_env& e) {
         cquery_nofail(e, "create table t (pk int, ck1 int, ck2 float, r text, primary key (pk, ck1, ck2))");
-        require_rows(e, "select ck1 from t where (ck1,ck2) in ((11,21),(12,22)) allow filtering", {});
+        require_rows(e, "select ck1 from t where (ck1,ck2) in ((11,21),(12,22))", {});
         cquery_nofail(e, "insert into t(pk,ck1,ck2) values (1,11,21)");
-        require_rows(e, "select ck1 from t where (ck1,ck2) in ((11,21),(12,22)) allow filtering", {{I(11)}});
-        require_rows(e, "select ck1 from t where (ck1,ck2) in ((11,21)) allow filtering", {{I(11)}});
+        require_rows(e, "select ck1 from t where (ck1,ck2) in ((11,21),(12,22))", {{I(11)}});
+        require_rows(e, "select ck1 from t where (ck1,ck2) in ((11,21))", {{I(11)}});
         cquery_nofail(e, "insert into t(pk,ck1,ck2) values (2,12,22)");
-        require_rows(e, "select ck1 from t where (ck1,ck2) in ((11,21),(12,22)) allow filtering",
+        require_rows(e, "select ck1 from t where (ck1,ck2) in ((11,21),(12,22))",
                          {{I(11)}, {I(12)}});
         cquery_nofail(e, "insert into t(pk,ck1,ck2) values (3,13,23)");
-        require_rows(e, "select ck1 from t where (ck1,ck2) in ((11,21),(12,22)) allow filtering",
+        require_rows(e, "select ck1 from t where (ck1,ck2) in ((11,21),(12,22))",
                          {{I(11)}, {I(12)}});
-        require_rows(e, "select ck1 from t where (ck1,ck2) in ((13,23)) allow filtering", {{I(13)}});
+        require_rows(e, "select ck1 from t where (ck1,ck2) in ((13,23))", {{I(13)}});
         cquery_nofail(e, "insert into t(pk,ck1,ck2,r) values (4,13,23,'a')");
-        require_rows(e, "select pk from t where (ck1,ck2) in ((13,23)) allow filtering",
+        require_rows(e, "select pk from t where (ck1,ck2) in ((13,23))",
                          {{I(3)}, {I(4)}});
-        require_rows(e, "select pk from t where (ck1) in ((13),(33),(44)) allow filtering",
+        require_rows(e, "select pk from t where (ck1) in ((13),(33),(44))",
                          {{I(3)}, {I(4)}});
         // TODO: uncomment when #6200 is fixed.
         // require_rows(e, "select pk from t where (ck1,ck2) in ((13,23)) and r='a' allow filtering",
         //                  {{I(4), I(13), F(23), T("a")}});
         cquery_nofail(e, "delete from t where pk=4");
-        require_rows(e, "select pk from t where (ck1,ck2) in ((13,23)) allow filtering", {{I(3)}});
-        auto stmt = e.prepare("select ck1 from t where (ck1,ck2) in ? allow filtering").get0();
+        require_rows(e, "select pk from t where (ck1,ck2) in ((13,23))", {{I(3)}});
+        auto stmt = e.prepare("select ck1 from t where (ck1,ck2) in ?").get0();
         auto bound_tuples = [] (std::vector<std::tuple<int32_t, float>> tuples) {
             const auto tuple_type = tuple_type_impl::get_instance({int32_type, float_type});
             const auto list_type = list_type_impl::get_instance(tuple_type, true);
@@ -778,21 +778,21 @@ SEASTAR_THREAD_TEST_CASE(multi_col_in) {
         require_rows(e, stmt, {}, {bound_tuples({{13, 13}, {12, 22}})}, {{I(12)}});
         require_rows(e, stmt, {}, {bound_tuples({{12, 21}})}, {});
         require_rows(e, stmt, {}, {bound_tuples({{12, 21}, {12, 21}, {13, 21}, {14, 21}})}, {});
-        stmt = e.prepare("select ck1 from t where (ck1,ck2) in (?) allow filtering").get0();
+        stmt = e.prepare("select ck1 from t where (ck1,ck2) in (?)").get0();
         auto tpl = [] (int32_t e1, float e2) {
             return make_tuple({int32_type, float_type}, {e1, e2});
         };
         require_rows(e, stmt, {}, {tpl(11, 21)}, {{I(11)}});
         require_rows(e, stmt, {}, {tpl(12, 22)}, {{I(12)}});
         require_rows(e, stmt, {}, {tpl(12, 21)}, {});
-        stmt = e.prepare("select ck1 from t where (ck1,ck2) in (:t1,:t2) allow filtering").get0();
+        stmt = e.prepare("select ck1 from t where (ck1,ck2) in (:t1,:t2)").get0();
         require_rows(e, stmt, {{"t1", "t2"}}, {tpl(11, 21), tpl(12, 22)}, {{I(11)}, {I(12)}});
         require_rows(e, stmt, {{"t1", "t2"}}, {tpl(11, 21), tpl(11, 21)}, {{I(11)}});
         require_rows(e, stmt, {{"t1", "t2"}}, {tpl(11, 21), tpl(99, 99)}, {{I(11)}});
         require_rows(e, stmt, {{"t1", "t2"}}, {tpl(9, 9), tpl(99, 99)}, {});
         // Parsing error:
-        // stmt = e.prepare("select ck1 from t where (ck1,ck2) in ((13,23),:p1) allow filtering").get0();
-        stmt = e.prepare("select ck1 from t where (ck1,ck2) in ((13,23),(?,?)) allow filtering").get0();
+        // stmt = e.prepare("select ck1 from t where (ck1,ck2) in ((13,23),:p1)").get0();
+        stmt = e.prepare("select ck1 from t where (ck1,ck2) in ((13,23),(?,?))").get0();
         require_rows(e, stmt, {}, {I(0), F(0)}, {{I(13)}});
         require_rows(e, stmt, {}, {I(11), F(21)}, {{I(11)}, {I(13)}});
     }).get();

--- a/test/boost/secondary_index_test.cc
+++ b/test/boost/secondary_index_test.cc
@@ -1271,7 +1271,7 @@ SEASTAR_TEST_CASE(test_filtering_indexed_column) {
             });
         });
         eventually([&] {
-            auto msg = cquery_nofail(e, "select d from ks.test_index where c > 25 ALLOW FILTERING;");
+            auto msg = cquery_nofail(e, "select d from ks.test_index where c > 25;");
             assert_that(msg).is_rows().with_rows({
                 {int32_type->decompose(44)}
             });

--- a/test/boost/secondary_index_test.cc
+++ b/test/boost/secondary_index_test.cc
@@ -1273,7 +1273,7 @@ SEASTAR_TEST_CASE(test_filtering_indexed_column) {
         eventually([&] {
             auto msg = cquery_nofail(e, "select d from ks.test_index where c > 25 ALLOW FILTERING;");
             assert_that(msg).is_rows().with_rows({
-                {int32_type->decompose(44), int32_type->decompose(33)}
+                {int32_type->decompose(44)}
             });
         });
     });

--- a/test/boost/secondary_index_test.cc
+++ b/test/boost/secondary_index_test.cc
@@ -1272,9 +1272,7 @@ SEASTAR_TEST_CASE(test_filtering_indexed_column) {
         });
         eventually([&] {
             auto msg = cquery_nofail(e, "select d from ks.test_index where c > 25;");
-            assert_that(msg).is_rows().with_rows({
-                {int32_type->decompose(44)}
-            });
+            assert_that(msg).is_rows().with_rows({{int32_type->decompose(44)}});
         });
     });
 }


### PR DESCRIPTION
I noticed that we require filtering for continuous clustering key, which is not necessary.  I dropped the requirement and made sure the correct data is read from the storage proxy.

The corresponding dtest PR: https://github.com/scylladb/scylla-dtest/pull/1727

Tests: unit (dev,debug), dtest (next-gating, cql*py)