### PR TITLE
node_exporter_install: upgrade to latest release

### DIFF
--- a/dist/common/scripts/node_exporter_install
+++ b/dist/common/scripts/node_exporter_install
@@ -27,7 +27,7 @@ import tarfile
 from scylla_util import *
 import argparse
 
-VERSION='0.17.0'
+VERSION='1.0.1'
 INSTALL_DIR=scylladir()+'/Prometheus/node_exporter'
 
 if __name__ == '__main__':


### PR DESCRIPTION
We currently uses outdated version of node_exporter, let's upgrade to latest
version.

Fixes #7427