### PR TITLE
[RFC] Make updateable value cross shard safe again

### DIFF
--- a/transport/controller.cc
+++ b/transport/controller.cc
@@ -69,9 +69,7 @@ future<> controller::do_start_server() {
         cql_transport::cql_server_config cql_server_config;
         cql_server_config.timeout_config = make_timeout_config(cfg);
         cql_server_config.max_request_size = service::get_local_storage_service()._service_memory_total;
-        cql_server_config.get_max_concurrent_requests_updateable_value = [ss = std::ref(service::get_storage_service())] () -> utils::updateable_value<uint32_t> {
-            return ss.get().local().db().local().get_config().max_concurrent_requests_per_shard;
-        };
+        cql_server_config.max_concurrent_requests = cfg.max_concurrent_requests_per_shard;
         cql_server_config.get_service_memory_limiter_semaphore = [ss = std::ref(service::get_storage_service())] () -> semaphore& { return ss.get().local()._service_memory_limiter; };
         cql_server_config.allow_shard_aware_drivers = cfg.enable_shard_aware_drivers();
         cql_server_config.sharding_ignore_msb = cfg.murmur3_partitioner_ignore_msb_bits();

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -152,7 +152,6 @@ cql_server::cql_server(distributed<cql3::query_processor>& qp, auth::service& au
     : _query_processor(qp)
     , _config(config)
     , _max_request_size(config.max_request_size)
-    , _max_concurrent_requests(config.get_max_concurrent_requests_updateable_value())
     , _memory_available(config.get_service_memory_limiter_semaphore())
     , _notifier(std::make_unique<event_notifier>(mn))
     , _auth_service(auth_service)
@@ -622,7 +621,7 @@ future<> cql_server::connection::process_request() {
                     f.length, mem_estimate, _server._max_request_size)));
         }
 
-        if (_server._requests_serving > _server._max_concurrent_requests) {
+        if (_server._requests_serving > _server._config.max_concurrent_requests) {
             ++_server._requests_shed;
             return make_exception_future<>(
                     exceptions::overloaded_exception(format("too many in-flight requests (configured via max_concurrent_requests_per_shard): {}", _server._requests_serving)));

--- a/transport/server.hh
+++ b/transport/server.hh
@@ -105,7 +105,7 @@ struct cql_query_state {
 struct cql_server_config {
     ::timeout_config timeout_config;
     size_t max_request_size;
-    std::function<utils::updateable_value<uint32_t> ()> get_max_concurrent_requests_updateable_value;
+    utils::updateable_value<uint32_t> max_concurrent_requests;
     std::function<semaphore& ()> get_service_memory_limiter_semaphore;
     sstring partitioner_name;
     unsigned sharding_ignore_msb;
@@ -125,7 +125,6 @@ private:
     distributed<cql3::query_processor>& _query_processor;
     cql_server_config _config;
     size_t _max_request_size;
-    utils::updateable_value<uint32_t> _max_concurrent_requests;
     semaphore& _memory_available;
     seastar::metrics::metric_groups _metrics;
     std::unique_ptr<event_notifier> _notifier;


### PR DESCRIPTION
This miniseries makes `updateable_value` safe for cross-shard use for a far larger number of cases than before.
A proper™ solution would be to make the interface future-based and serialize the modifications to the vector of observers
via submit_to, but there exists a simpler idea, especially if we assume that a classic use case is to
create a source on a single shard and then craete a single instance of an updateable_value for all shards:
1. The updateable value source, instead of having a single vector of observers, has a vector per shard.
2. Each observer tracks its owner shard.
3. When an observer is going to be removed, it knows which shard it came from and this information
   can be used to find it in the vector of observers per shard.
   
This mechanism prevents a most obvious race where multiple shards try to read and write to a single vector
residing on a single source (e.g. shard0). It's still possible to abuse the interface by reading from a value
from one shard and trying to remove it from another, but that would have to be explicitly coded,
which is rather unlikely to pass review. The second quite unlikely race would be updating the value at the same
time as adding/removing an observer, which requires a SIGHUP sent very carefully during startup or shutdown.

I'm temporarily marking this as RFC, because I really want to hear some feedback if these assumptions above make sense and are feasible enough to call updateable value "cross-shard safe" again. Making this interface future-based will effectively also make it rather ugly, so it would be nice to avoid it. On the other hand, I guess that since most of these races happen during startup/shutdown, it's also likely they run in seastar::threads or coroutines already, so perhaps making updateable_value future-based would not be that ugly after all.

Fixes #7316