### PR TITLE
build: relocatable package: exclude tools/python3

### DIFF
--- a/scripts/create-relocatable-package.py
+++ b/scripts/create-relocatable-package.py
@@ -154,7 +154,9 @@ ar.reloc_add('licenses')
 ar.reloc_add('swagger-ui')
 ar.reloc_add('api')
 def exclude_submodules(tarinfo):
-    if tarinfo.name in ('scylla/tools/jmx', 'scylla/tools/java'):
+    if tarinfo.name in ('scylla/tools/jmx',
+                        'scylla/tools/java',
+                        'scylla/tools/python3'):
         return None
     return tarinfo
 ar.reloc_add('tools', filter=exclude_submodules)


### PR DESCRIPTION
python3 has its own relocatable package, no need to include it
in scylla-package.tar.gz.

Python has its own relocatable package, so packaging it in scylla-package.ta