### PR TITLE
cql3/expr: Use Boost concept assert

### DIFF
--- a/cql3/expr/expression.cc
+++ b/cql3/expr/expression.cc
@@ -555,9 +555,8 @@ bytes_opt get_kth(size_t k, const query_options& options, const ::shared_ptr<ter
 }
 
 template<typename Range>
-// Clang doesn't compile this, and boost ranges aren't std::ranges
-// requires std::ranges::forward_range<Range>
 value_list to_sorted_vector(Range r, const serialized_compare& comparator) {
+    BOOST_CONCEPT_ASSERT((boost::ForwardRangeConcept<Range>));
     value_list tmp(r.begin(), r.end()); // Need random-access range to sort (r is not necessarily random-access).
     const auto unique = boost::unique(boost::sort(tmp, comparator));
     return value_list(unique.begin(), unique.end());


### PR DESCRIPTION
In bd6855e, we reverted to Boost ranges and commented out the concept
check.  But Boost has its own concept check, which this patch enables.

Tests: unit (dev)

Signed-off-by: Dejan Mircevski <dejan@scylladb.com>