### PR TITLE
cql3: Check for timestamp correctness in USING TIMESTAMP statements 

### DIFF
--- a/cql3/statements/batch_statement.cc
+++ b/cql3/statements/batch_statement.cc
@@ -38,6 +38,7 @@
  */
 
 #include "batch_statement.hh"
+#include "cql3/util.hh"
 #include "raw/batch_statement.hh"
 #include "db/config.hh"
 #include "db/consistency_level_validations.hh"
@@ -259,6 +260,7 @@ static thread_local inheriting_concrete_execution_stage<
 
 future<shared_ptr<cql_transport::messages::result_message>> batch_statement::execute(
         service::storage_proxy& storage, service::query_state& state, const query_options& options) const {
+    cql3::util::validate_timestamp(options, _attrs);
     return batch_stage(this, seastar::ref(storage), seastar::ref(state),
                        seastar::cref(options), false, options.get_timestamp(state));
 }

--- a/cql3/statements/modification_statement.cc
+++ b/cql3/statements/modification_statement.cc
@@ -44,6 +44,7 @@
 #include "cql3/statements/raw/modification_statement.hh"
 #include "cql3/statements/prepared_statement.hh"
 #include "cql3/restrictions/single_column_restriction.hh"
+#include "cql3/util.hh"
 #include "validation.hh"
 #include "db/consistency_level_validations.hh"
 #include <seastar/core/shared_ptr.hh>
@@ -258,6 +259,7 @@ static thread_local inheriting_concrete_execution_stage<
 
 future<::shared_ptr<cql_transport::messages::result_message>>
 modification_statement::execute(service::storage_proxy& proxy, service::query_state& qs, const query_options& options) const {
+    cql3::util::validate_timestamp(options, attrs);
     return modify_stage(this, seastar::ref(proxy), seastar::ref(qs), seastar::cref(options));
 }
 

--- a/cql3/util.cc
+++ b/cql3/util.cc
@@ -119,5 +119,19 @@ void do_with_parser_impl(const sstring_view& cql, noncopyable_function<void (cql
 
 #endif
 
+void validate_timestamp(const query_options& options, const std::unique_ptr<attributes>& attrs) {
+    if (attrs->is_timestamp_set()) {
+        static constexpr int64_t MAX_DIFFERENCE = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::days(3)).count();
+        auto now = std::chrono::duration_cast<std::chrono::microseconds>(db_clock::now().time_since_epoch()).count();
+
+        auto timestamp = attrs->get_timestamp(now, options);
+
+        if (timestamp - now > MAX_DIFFERENCE) {
+            throw exceptions::invalid_request_exception("Cannot provide a timestamp more than 3 days into the future. If this was not intended, "
+            "make sure the timestamp is in microseconds");
+        }
+    }
+}
+
 
 }

--- a/cql3/util.hh
+++ b/cql3/util.hh
@@ -89,6 +89,10 @@ std::unique_ptr<cql3::statements::raw::select_statement> build_select_statement(
 /// character itself is quoted by doubling it.
 sstring maybe_quote(const sstring& s);
 
+// Check whether timestamp is not too far in the future as this probably
+// indicates its incorrectness (for example using other units than microseconds).
+void validate_timestamp(const query_options& options, const std::unique_ptr<attributes>& attrs);
+
 } // namespace util
 
 } // namespace cql3


### PR DESCRIPTION
In certain CQL statements it's possible to provide a custom timestamp via the USING TIMESTAMP clause. Those values are accepted in microseconds, however, there's no limit on the timestamp (apart from type size constraint) and providing a timestamp in a different unit like nanoseconds can lead to creating an entry with a timestamp way ahead in the future, thus compromising the table. To avoid this, this change introduces a sanity check for modification and batch statements that raises an error when a timestamp of more than 3 days into the future is provided.

Test: unit (dev)

Fixes #5619 