### PR TITLE
config_file: read_from_yaml support flag shorthands

### DIFF
--- a/utils/config_file.cc
+++ b/utils/config_file.cc
@@ -221,6 +221,16 @@ sstring utils::hyphenate(const std::string_view& v) {
     return result;
 }
 
+sstring utils::trim_to_first_comma(const std::string_view& v) {
+    auto idx = v.find(',');
+    if (idx == 0) {
+        return v.data();
+    } else {
+        sstring result(v.substr(0, idx));
+        return result;
+    }
+}
+
 utils::config_file::config_file(std::initializer_list<cfg_ref> cfgs)
     : _cfgs(cfgs)
 {}
@@ -291,7 +301,9 @@ void utils::config_file::read_from_yaml(const char* yaml, error_handler h) {
     for (auto node : doc) {
         auto label = node.first.as<sstring>();
 
-        auto i = std::find_if(_cfgs.begin(), _cfgs.end(), [&label](const config_src& cfg) { return cfg.name() == label; });
+        auto i = std::find_if(_cfgs.begin(), _cfgs.end(), [&label](const config_src& cfg) {
+            return trim_to_first_comma(cfg.name()) == label;
+        });
         if (i == _cfgs.end()) {
             h(label, "Unknown option", std::nullopt);
             continue;

--- a/utils/config_file_impl.hh
+++ b/utils/config_file_impl.hh
@@ -189,6 +189,8 @@ inline typed_value_ex<T>* value_ex() {
 
 sstring hyphenate(const std::string_view&);
 
+sstring trim_to_first_comma(const std::string_view&);
+
 }
 
 template<typename T>


### PR DESCRIPTION
This patch adds support for long_flag_name,short_flag_name syntax used in workdir,W.

Without this patch workdir option specified in config file results in

```
WARN  2020-10-22 15:25:45,067 [shard 0] init - Unknown option : workdir
```

Fixes #7478