### PR TITLE
create_table_statement: Disallow default TTL on counter tables

### DIFF
--- a/cql3/statements/create_table_statement.cc
+++ b/cql3/statements/create_table_statement.cc
@@ -204,6 +204,7 @@ std::unique_ptr<prepared_statement> create_table_statement::raw_statement::prepa
     }
 
     _properties.validate(db, _properties.properties()->make_schema_extensions(db.extensions()));
+    const bool has_default_ttl = _properties.properties()->get_default_time_to_live() > 0;
 
     auto stmt = ::make_shared<create_table_statement>(_cf_name, _properties.properties(), _if_not_exists, _static_columns, _properties.properties()->get_id());
 
@@ -211,6 +212,11 @@ std::unique_ptr<prepared_statement> create_table_statement::raw_statement::prepa
     for (auto&& entry : _definitions) {
         ::shared_ptr<column_identifier> id = entry.first;
         cql3_type pt = entry.second->prepare(db, keyspace());
+
+        if (has_default_ttl && pt.is_counter()) {
+            throw exceptions::invalid_request_exception("Cannot set default_time_to_live on a table with counters");
+        }
+
         if (pt.get_type()->is_multi_cell()) {
             if (pt.get_type()->is_user_type()) {
                 // check for multi-cell types (non-frozen UDTs or collections) inside a non-frozen UDT

--- a/test/cql/counters_disallow_ttl_test.cql
+++ b/test/cql/counters_disallow_ttl_test.cql
@@ -1,0 +1,9 @@
+create table tb1 (pk int primary key, c1 counter) with default_time_to_live = 100;
+
+create table tb2 (pk int primary key, c1 counter);
+alter table tb2 with default_time_to_live = 100;
+
+create table tb3 (pk int primary key) with default_time_to_live = 100;
+alter table tb3 add (c1 counter);
+
+create table tb4 (pk int, ck int, cs counter static, primary KEY (pk, ck)) with default_time_to_live = 100;

--- a/test/cql/counters_disallow_ttl_test.result
+++ b/test/cql/counters_disallow_ttl_test.result
@@ -1,0 +1,31 @@
+create table tb1 (pk int primary key, c1 counter) with default_time_to_live = 100;
+{
+	"message" : "exceptions::invalid_request_exception (Cannot set default_time_to_live on a table with counters)",
+	"status" : "error"
+}
+
+create table tb2 (pk int primary key, c1 counter);
+{
+	"status" : "ok"
+}
+alter table tb2 with default_time_to_live = 100;
+{
+	"message" : "exceptions::invalid_request_exception (Cannot set default_time_to_live on a table with counters)",
+	"status" : "error"
+}
+
+create table tb3 (pk int primary key) with default_time_to_live = 100;
+{
+	"status" : "ok"
+}
+alter table tb3 add (c1 counter);
+{
+	"message" : "exceptions::configuration_exception (Cannot add a counter column (c1) in a non counter column family)",
+	"status" : "error"
+}
+
+create table tb4 (pk int, ck int, cs counter static, primary KEY (pk, ck)) with default_time_to_live = 100;
+{
+	"message" : "exceptions::invalid_request_exception (Cannot set default_time_to_live on a table with counters)",
+	"status" : "error"
+}


### PR DESCRIPTION
In such attempt `invalid_request_exception` is thrown.
Also, a simple CQL test is added.

Fixes #6879