### PR TITLE
managed_bytes: switch to explicit linearization

### DIFF
--- a/bytes.hh
+++ b/bytes.hh
@@ -35,6 +35,10 @@ using bytes_mutable_view = basic_mutable_view<bytes_view::value_type>;
 using bytes_opt = std::optional<bytes>;
 using sstring_view = std::string_view;
 
+inline bytes to_bytes(bytes&& b) {
+    return std::move(b);
+}
+
 inline sstring_view to_sstring_view(bytes_view view) {
     return {reinterpret_cast<const char*>(view.data()), view.size()};
 }

--- a/clustering_bounds_comparator.hh
+++ b/clustering_bounds_comparator.hh
@@ -67,8 +67,8 @@ public:
         int operator()(const clustering_key_prefix& p1, int32_t w1, const clustering_key_prefix& p2, int32_t w2) const {
             auto type = _s.get().clustering_key_prefix_type();
             auto res = prefix_equality_tri_compare(type->types().begin(),
-                type->begin(p1), type->end(p1),
-                type->begin(p2), type->end(p2),
+                type->begin(p1.representation()), type->end(p1.representation()),
+                type->begin(p2.representation()), type->end(p2.representation()),
                 ::tri_compare);
             if (res) {
                 return res;

--- a/compound.hh
+++ b/compound.hh
@@ -165,6 +165,7 @@ public:
             read_current();
         }
         iterator(end_iterator_tag, const managed_bytes_view& v) : _v() {}
+        iterator() : iterator(end_iterator_tag()) {}
         iterator& operator++() {
             read_current();
             return *this;

--- a/compound_compat.hh
+++ b/compound_compat.hh
@@ -398,6 +398,7 @@ public:
         iterator(end_iterator_tag) : _v(nullptr, 0) {}
 
     public:
+        iterator() : iterator(end_iterator_tag()) {}
         iterator& operator++() {
             read_current();
             return *this;

--- a/cql3/expr/expression.cc
+++ b/cql3/expr/expression.cc
@@ -43,6 +43,7 @@ using boost::adaptors::transformed;
 
 namespace {
 
+static
 std::optional<atomic_cell_value_view> do_get_value(const schema& schema,
         const column_definition& cdef,
         const partition_key& key,

--- a/cql3/restrictions/single_column_primary_key_restrictions.hh
+++ b/cql3/restrictions/single_column_primary_key_restrictions.hh
@@ -324,7 +324,7 @@ public:
         std::vector<bytes_opt> res;
         for (const ValueType& r : src) {
             for (const auto& component : r.components()) {
-                res.emplace_back(component);
+                res.emplace_back(to_bytes(component));
             }
         }
         return res;

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -448,7 +448,7 @@ generate_base_key_from_index_pk(const partition_key& index_pk, const std::option
         return KeyType::make_empty();
     }
 
-    std::vector<bytes_view> exploded_base_key;
+    std::vector<managed_bytes_view> exploded_base_key;
     exploded_base_key.reserve(base_columns.size());
 
     for (const column_definition& base_col : base_columns) {
@@ -879,7 +879,7 @@ indexed_table_select_statement::indexed_table_select_statement(schema_ptr schema
 
 template<typename KeyType>
 requires (std::is_same_v<KeyType, partition_key> || std::is_same_v<KeyType, clustering_key_prefix>)
-static void append_base_key_to_index_ck(std::vector<bytes_view>& exploded_index_ck, const KeyType& base_key, const column_definition& index_cdef) {
+static void append_base_key_to_index_ck(std::vector<managed_bytes_view>& exploded_index_ck, const KeyType& base_key, const column_definition& index_cdef) {
     auto key_view = base_key.view();
     auto begin = key_view.begin();
     if ((std::is_same_v<KeyType, partition_key> && index_cdef.is_partition_key())
@@ -934,7 +934,7 @@ lw_shared_ptr<const service::pager::paging_state> indexed_table_select_statement
         }
     }();
 
-    std::vector<bytes_view> exploded_index_ck;
+    std::vector<managed_bytes_view> exploded_index_ck;
     exploded_index_ck.reserve(_view_schema->clustering_key_size());
 
     bytes token_bytes;

--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -427,9 +427,9 @@ deletable_row& view_updates::get_view_row(const partition_key& base_key, const c
         }
         switch (base_col->kind) {
         case column_kind::partition_key:
-            return base_key.get_component(*_base, base_col->position());
+            return to_bytes(base_key.get_component(*_base, base_col->position()));
         case column_kind::clustering_key:
-            return update.key().get_component(*_base, base_col->position());
+            return to_bytes(update.key().get_component(*_base, base_col->position()));
         default:
             auto& c = update.cells().cell_at(base_col->id);
             auto value_view = base_col->is_atomic() ? c.as_atomic_cell(cdef).value() : c.as_collection_mutation().data;

--- a/keys.cc
+++ b/keys.cc
@@ -28,7 +28,9 @@
 #include <boost/any.hpp>
 
 std::ostream& operator<<(std::ostream& out, const partition_key& pk) {
-    return out << "pk{" << to_hex(pk) << "}";
+    return pk.representation().with_linearized([&] (bytes_view v) {
+        return std::ref(out << "pk{" << to_hex(v) << "}");
+    });
 }
 
 template<typename T>
@@ -56,11 +58,15 @@ std::ostream& operator<<(std::ostream& out, const clustering_key_prefix::with_sc
 }
 
 std::ostream& operator<<(std::ostream& out, const partition_key_view& pk) {
-    return out << "pk{" << to_hex(pk.representation()) << "}";
+    return pk.representation().with_linearized([&] (bytes_view v) {
+        return std::ref(out << "pk{" << to_hex(v) << "}");
+    });
 }
 
 std::ostream& operator<<(std::ostream& out, const clustering_key_prefix& ckp) {
-    return out << "ckp{" << to_hex(ckp) << "}";
+    return ckp.representation().with_linearized([&] (bytes_view v) {
+        return std::ref(out << "ckp{" << to_hex(v) << "}");
+    });
 }
 
 const legacy_compound_view<partition_key_view::c_type>

--- a/keys.hh
+++ b/keys.hh
@@ -55,9 +55,9 @@
 template <typename TopLevelView>
 class compound_view_wrapper {
 protected:
-    bytes_view _bytes;
+    managed_bytes_view _bytes;
 protected:
-    compound_view_wrapper(bytes_view v)
+    compound_view_wrapper(managed_bytes_view v)
         : _bytes(v)
     { }
 
@@ -69,7 +69,7 @@ public:
         return get_compound_type(s)->deserialize_value(_bytes);
     }
 
-    bytes_view representation() const {
+    managed_bytes_view representation() const {
         return _bytes;
     }
 
@@ -241,7 +241,7 @@ public:
 
     std::vector<bytes> explode() const {
         std::vector<bytes> result;
-        for (bytes_view c : components()) {
+        for (managed_bytes_view c : components()) {
             result.emplace_back(to_bytes(c));
         }
         return result;
@@ -279,7 +279,7 @@ public:
         typename TopLevel::compound _t;
         hashing(const schema& s) : _t(get_compound_type(s)) {}
         size_t operator()(const TopLevel& o) const {
-            return _t->hash(o);
+            return _t->hash(o.representation());
         }
         size_t operator()(const TopLevelView& o) const {
             return _t->hash(o.representation());
@@ -308,7 +308,8 @@ public:
         return get_compound_type(s)->equal(representation(), other.representation());
     }
 
-    operator bytes_view() const {
+    operator managed_bytes_view() const
+    {
         return _bytes;
     }
 
@@ -350,7 +351,7 @@ public:
         return components();
     }
 
-    bytes_view get_component(const schema& s, size_t idx) const {
+    managed_bytes_view get_component(const schema& s, size_t idx) const {
         auto it = begin(s);
         std::advance(it, idx);
         return *it;
@@ -544,7 +545,7 @@ template <typename TopLevel, typename FullTopLevel>
 class prefix_compound_view_wrapper : public compound_view_wrapper<TopLevel> {
     using base = compound_view_wrapper<TopLevel>;
 protected:
-    prefix_compound_view_wrapper(bytes_view v)
+    prefix_compound_view_wrapper(managed_bytes_view v)
         : compound_view_wrapper<TopLevel>(v)
     { }
 
@@ -596,8 +597,8 @@ public:
 
         bool operator()(const TopLevel& k1, const TopLevel& k2) const {
             return prefix_equality_tri_compare(prefix_type->types().begin(),
-                prefix_type->begin(k1), prefix_type->end(k1),
-                prefix_type->begin(k2), prefix_type->end(k2),
+                prefix_type->begin(k1.representation()), prefix_type->end(k1.representation()),
+                prefix_type->begin(k2.representation()), prefix_type->end(k2.representation()),
                 tri_compare) < 0;
         }
     };
@@ -612,8 +613,8 @@ public:
 
         int operator()(const TopLevel& k1, const TopLevel& k2) const {
             return prefix_equality_tri_compare(prefix_type->types().begin(),
-                prefix_type->begin(k1), prefix_type->end(k1),
-                prefix_type->begin(k2), prefix_type->end(k2),
+                prefix_type->begin(k1.representation()), prefix_type->end(k1.representation()),
+                prefix_type->begin(k2.representation()), prefix_type->end(k2.representation()),
                 tri_compare);
         }
     };
@@ -623,13 +624,20 @@ class partition_key_view : public compound_view_wrapper<partition_key_view> {
 public:
     using c_type = compound_type<allow_prefixes::no>;
 private:
-    partition_key_view(bytes_view v)
+    partition_key_view(managed_bytes_view v)
         : compound_view_wrapper<partition_key_view>(v)
     { }
 public:
     using compound = lw_shared_ptr<c_type>;
 
     static partition_key_view from_bytes(bytes_view v) {
+        return { v };
+    }
+
+    static partition_key_view from_bytes(const managed_bytes& v) {
+        return { v };
+    }
+    static partition_key_view from_bytes(managed_bytes_view v) {
         return { v };
     }
 
@@ -697,6 +705,12 @@ public:
 
     using compound = lw_shared_ptr<c_type>;
 
+    static partition_key from_bytes(managed_bytes_view b) {
+        return partition_key(managed_bytes(b));
+    }
+    static partition_key from_bytes(managed_bytes&& b) {
+        return partition_key(std::move(b));
+    }
     static partition_key from_bytes(bytes_view b) {
         return partition_key(managed_bytes(b));
     }
@@ -751,10 +765,16 @@ public:
 };
 
 class clustering_key_prefix_view : public prefix_compound_view_wrapper<clustering_key_prefix_view, clustering_key> {
-    clustering_key_prefix_view(bytes_view v)
+    clustering_key_prefix_view(managed_bytes_view v)
         : prefix_compound_view_wrapper<clustering_key_prefix_view, clustering_key>(v)
     { }
 public:
+    static clustering_key_prefix_view from_bytes(const managed_bytes& v) {
+        return { v };
+    }
+    static clustering_key_prefix_view from_bytes(managed_bytes_view v) {
+        return { v };
+    }
     static clustering_key_prefix_view from_bytes(bytes_view v) {
         return { v };
     }
@@ -797,6 +817,9 @@ public:
 
     using compound = lw_shared_ptr<compound_type<allow_prefixes::yes>>;
 
+    static clustering_key_prefix from_bytes(const managed_bytes& b) { return clustering_key_prefix(managed_bytes(b)); }
+    static clustering_key_prefix from_bytes(managed_bytes&& b) { return clustering_key_prefix(std::move(b)); }
+    static clustering_key_prefix from_bytes(managed_bytes_view b) { return clustering_key_prefix(managed_bytes(b)); }
     static clustering_key_prefix from_bytes(bytes_view b) {
         return clustering_key_prefix(managed_bytes(b));
     }
@@ -835,7 +858,7 @@ template<>
 struct appending_hash<partition_key_view> {
     template<typename Hasher>
     void operator()(Hasher& h, const partition_key_view& pk, const schema& s) const {
-        for (bytes_view v : pk.components(s)) {
+        for (managed_bytes_view v : pk.components(s)) {
             ::feed_hash(h, v);
         }
     }
@@ -853,7 +876,7 @@ template<>
 struct appending_hash<clustering_key_prefix_view> {
     template<typename Hasher>
     void operator()(Hasher& h, const clustering_key_prefix_view& ck, const schema& s) const {
-        for (bytes_view v : ck.components(s)) {
+        for (managed_bytes_view v : ck.components(s)) {
             ::feed_hash(h, v);
         }
     }

--- a/memtable.cc
+++ b/memtable.cc
@@ -209,9 +209,7 @@ memtable::find_or_create_partition_slow(partition_key_view key) {
     return with_allocator(standard_allocator(), [&, this] () -> partition_entry& {
         auto dk = dht::decorate_key(*_schema, key);
         return with_allocator(outer, [&dk, this] () -> partition_entry& {
-          return with_linearized_managed_bytes([&] () -> partition_entry& {
             return find_or_create_partition(dk);
-          });
         });
     });
 }
@@ -430,8 +428,7 @@ public:
                 if (_delegate_range) {
                     _delegate = delegate_reader(_permit, *_delegate_range, _slice, _pc, streamed_mutation::forwarding::no, _fwd_mr);
                 } else {
-                    auto key_and_snp = read_section()(region(), [&] {
-                        return with_linearized_managed_bytes([&] () -> std::optional<std::pair<dht::decorated_key, partition_snapshot_ptr>> {
+                    auto key_and_snp = read_section()(region(), [&] () -> std::optional<std::pair<dht::decorated_key, partition_snapshot_ptr>> {
                             memtable_entry *e = fetch_entry();
                             if (!e) {
                                 return { };
@@ -444,7 +441,6 @@ public:
                                 advance_iterator();
                                 return std::pair(std::move(key), std::move(snp));
                             }
-                        });
                     });
                     if (key_and_snp) {
                         update_last(key_and_snp->first);
@@ -583,8 +579,7 @@ public:
 private:
     void get_next_partition() {
         uint64_t component_size = 0;
-        auto key_and_snp = read_section()(region(), [&] {
-            return with_linearized_managed_bytes([&] () -> std::optional<std::pair<dht::decorated_key, partition_snapshot_ptr>> {
+        auto key_and_snp = read_section()(region(), [&] () -> std::optional<std::pair<dht::decorated_key, partition_snapshot_ptr>> {
                 memtable_entry* e = fetch_entry();
                 if (e) {
                     auto dk = e->key();
@@ -594,7 +589,6 @@ private:
                     return std::pair(std::move(dk), std::move(snp));
                 }
                 return { };
-            });
         });
         if (key_and_snp) {
             _flushed_memory.update_bytes_read(component_size);
@@ -657,7 +651,6 @@ memtable::make_flat_reader(schema_ptr s,
     if (query::is_single_partition(range) && !fwd_mr) {
         const query::ring_position& pos = range.start()->value();
         auto snp = _read_section(*this, [&] () -> partition_snapshot_ptr {
-            managed_bytes::linearization_context_guard lcg;
             auto i = partitions.find(pos, dht::ring_position_comparator(*_schema));
             if (i != partitions.end()) {
                 upgrade_entry(*i);
@@ -722,11 +715,9 @@ void
 memtable::apply(const mutation& m, db::rp_handle&& h) {
     with_allocator(allocator(), [this, &m] {
         _allocating_section(*this, [&, this] {
-          with_linearized_managed_bytes([&] {
             auto& p = find_or_create_partition(m.decorated_key());
             _stats_collector.update(*m.schema(), m.partition());
             p.apply(*_schema, m.partition(), *m.schema(), _table_stats.memtable_app_stats);
-          });
         });
     });
     update(std::move(h));
@@ -736,14 +727,12 @@ void
 memtable::apply(const frozen_mutation& m, const schema_ptr& m_schema, db::rp_handle&& h) {
     with_allocator(allocator(), [this, &m, &m_schema] {
         _allocating_section(*this, [&, this] {
-          with_linearized_managed_bytes([&] {
             auto& p = find_or_create_partition_slow(m.key());
             mutation_partition mp(m_schema);
             partition_builder pb(*m_schema, mp);
             m.partition().accept(*m_schema, pb);
             _stats_collector.update(*m_schema, mp);
             p.apply(*_schema, std::move(mp), *m_schema, _table_stats.memtable_app_stats);
-          });
         });
     });
     update(std::move(h));
@@ -796,9 +785,7 @@ void memtable::upgrade_entry(memtable_entry& e) {
     if (e._schema != _schema) {
         assert(!reclaiming_enabled());
         with_allocator(allocator(), [this, &e] {
-          with_linearized_managed_bytes([&] {
             e.upgrade_schema(_schema, cleaner());
-          });
         });
     }
 }

--- a/memtable.cc
+++ b/memtable.cc
@@ -429,18 +429,18 @@ public:
                     _delegate = delegate_reader(_permit, *_delegate_range, _slice, _pc, streamed_mutation::forwarding::no, _fwd_mr);
                 } else {
                     auto key_and_snp = read_section()(region(), [&] () -> std::optional<std::pair<dht::decorated_key, partition_snapshot_ptr>> {
-                            memtable_entry *e = fetch_entry();
-                            if (!e) {
-                                return { };
-                            } else {
-                                // FIXME: Introduce a memtable specific reader that will be returned from
-                                // memtable_entry::read and will allow filling the buffer without the overhead of
-                                // virtual calls, intermediate buffers and futures.
-                                auto key = e->key();
-                                auto snp = e->snapshot(*mtbl());
-                                advance_iterator();
-                                return std::pair(std::move(key), std::move(snp));
-                            }
+                        memtable_entry *e = fetch_entry();
+                        if (!e) {
+                            return { };
+                        } else {
+                            // FIXME: Introduce a memtable specific reader that will be returned from
+                            // memtable_entry::read and will allow filling the buffer without the overhead of
+                            // virtual calls, intermediate buffers and futures.
+                            auto key = e->key();
+                            auto snp = e->snapshot(*mtbl());
+                            advance_iterator();
+                            return std::pair(std::move(key), std::move(snp));
+                        }
                     });
                     if (key_and_snp) {
                         update_last(key_and_snp->first);
@@ -580,15 +580,15 @@ private:
     void get_next_partition() {
         uint64_t component_size = 0;
         auto key_and_snp = read_section()(region(), [&] () -> std::optional<std::pair<dht::decorated_key, partition_snapshot_ptr>> {
-                memtable_entry* e = fetch_entry();
-                if (e) {
-                    auto dk = e->key();
-                    auto snp = e->snapshot(*mtbl());
-                    component_size = _flushed_memory.compute_size(*e, *snp);
-                    advance_iterator();
-                    return std::pair(std::move(dk), std::move(snp));
-                }
-                return { };
+            memtable_entry* e = fetch_entry();
+            if (e) {
+                auto dk = e->key();
+                auto snp = e->snapshot(*mtbl());
+                component_size = _flushed_memory.compute_size(*e, *snp);
+                advance_iterator();
+                return std::pair(std::move(dk), std::move(snp));
+            }
+            return { };
         });
         if (key_and_snp) {
             _flushed_memory.update_bytes_read(component_size);

--- a/mutation_partition.cc
+++ b/mutation_partition.cc
@@ -1219,8 +1219,6 @@ static
 void
 apply_monotonically(const column_definition& def, cell_and_hash& dst,
                     atomic_cell_or_collection& src, cell_hash_opt src_hash) {
-    // Must be run via with_linearized_managed_bytes() context, but assume it is
-    // provided via an upper layer
     if (def.is_atomic()) {
         if (def.is_counter()) {
             counter_cell_view::apply(def, dst.cell, src); // FIXME: Optimize
@@ -2699,9 +2697,7 @@ stop_iteration mutation_cleaner_impl::merge_some(partition_snapshot& snp) noexce
             }
             try {
                 return _worker_state->alloc_section(region, [&] {
-                  return with_linearized_managed_bytes([&] {
                     return snp.merge_partition_versions(_app_stats);
-                  });
                 });
             } catch (...) {
                 // Merging failed, give up as there is no guarantee of forward progress.

--- a/partition_snapshot_reader.hh
+++ b/partition_snapshot_reader.hh
@@ -73,9 +73,7 @@ class partition_snapshot_flat_reader : public flat_mutation_reader::impl, public
         template<typename Function>
         decltype(auto) in_alloc_section(Function&& fn) {
             return _read_section.with_reclaiming_disabled(_region, [&] {
-                return with_linearized_managed_bytes([&] {
                     return fn();
-                });
             });
         }
         void refresh_state(const query::clustering_range& ck_range,

--- a/partition_snapshot_reader.hh
+++ b/partition_snapshot_reader.hh
@@ -73,7 +73,7 @@ class partition_snapshot_flat_reader : public flat_mutation_reader::impl, public
         template<typename Function>
         decltype(auto) in_alloc_section(Function&& fn) {
             return _read_section.with_reclaiming_disabled(_region, [&] {
-                    return fn();
+                return fn();
             });
         }
         void refresh_state(const query::clustering_range& ck_range,

--- a/partition_version.cc
+++ b/partition_version.cc
@@ -417,7 +417,6 @@ coroutine partition_entry::apply_to_incomplete(const schema& s,
             static_done = false] () mutable {
         auto&& allocator = reg.allocator();
         return alloc(reg, [&] {
-            return with_linearized_managed_bytes([&] {
                 size_t dirty_size = 0;
 
                 if (!static_done) {
@@ -481,7 +480,6 @@ coroutine partition_entry::apply_to_incomplete(const schema& s,
                     }
                 } while (!preemptible || !need_preempt());
                 return stop_iteration::no;
-            });
         });
     });
 }

--- a/position_in_partition.hh
+++ b/position_in_partition.hh
@@ -384,7 +384,7 @@ public:
                 return 0;
             }
             auto&& types = _s.clustering_key_type()->types();
-            auto cmp = [&] (const data_type& t, bytes_view c1, bytes_view c2) { return t->compare(c1, c2); };
+            auto cmp = [&] (const data_type& t, managed_bytes_view c1, managed_bytes_view c2) { return t->compare(c1, c2); };
             return lexicographical_tri_compare(types.begin(), types.end(),
                 a._ck->begin(_s), a._ck->end(_s),
                 b._ck->begin(_s), b._ck->end(_s),
@@ -404,7 +404,7 @@ public:
             }
             auto&& types = _s.clustering_key_type()->types();
             auto b_values = b.values();
-            auto cmp = [&] (const data_type& t, bytes_view c1, bytes_view c2) { return t->compare(c1, c2); };
+            auto cmp = [&] (const data_type& t, managed_bytes_view c1, managed_bytes_view c2) { return t->compare(c1, c2); };
             return lexicographical_tri_compare(types.begin(), types.end(),
                 a._ck->begin(_s), a._ck->end(_s),
                 b_values.begin(), b_values.end(),

--- a/row_cache.cc
+++ b/row_cache.cc
@@ -65,7 +65,6 @@ cache_tracker::cache_tracker(mutation_application_stats& app_stats)
         return with_allocator(_region.allocator(), [this] {
           // Removing a partition may require reading large keys when we rebalance
           // the rbtree, so linearize anything we read
-          return with_linearized_managed_bytes([&] {
            try {
             if (!_garbage.empty()) {
                 _garbage.clear_some();
@@ -86,7 +85,6 @@ cache_tracker::cache_tracker(mutation_application_stats& app_stats)
             clear();
             return memory::reclaiming_result::reclaimed_something;
            }
-          });
         });
     });
 }
@@ -508,10 +506,8 @@ public:
             {
                 if (!mfopt) {
                     return _cache._read_section(_cache._tracker.region(), [&] {
-                        return with_linearized_managed_bytes([&] {
-                            this->handle_end_of_stream();
-                            return make_ready_future<read_result>(read_result(std::nullopt, std::nullopt));
-                        });
+                        this->handle_end_of_stream();
+                        return make_ready_future<read_result>(read_result(std::nullopt, std::nullopt));
                     });
                 }
                 _cache.on_partition_miss();
@@ -573,8 +569,7 @@ private:
     }
 
     flat_mutation_reader_opt do_read_from_primary(db::timeout_clock::time_point timeout) {
-        return _cache._read_section(_cache._tracker.region(), [this] {
-            return with_linearized_managed_bytes([&] () -> flat_mutation_reader_opt {
+        return _cache._read_section(_cache._tracker.region(), [this] () -> flat_mutation_reader_opt {
                 bool not_moved = true;
                 if (!_primary.valid()) {
                     not_moved = _primary.advance_to(as_ring_position_view(_lower_bound));
@@ -616,7 +611,6 @@ private:
                         return std::nullopt;
                     }
                 }
-            });
         });
     }
 
@@ -724,7 +718,6 @@ row_cache::make_reader(schema_ptr s,
         tracing::trace(trace_state, "Querying cache for range {} and slice {}",
                 range, seastar::value_of([&slice] { return slice.get_all_ranges(); }));
         auto mr = _read_section(_tracker.region(), [&] {
-            return with_linearized_managed_bytes([&] {
                 dht::ring_position_comparator cmp(*_schema);
                 auto&& pos = ctx->range().start()->value();
                 partitions_type::bound_hint hint;
@@ -741,7 +734,6 @@ row_cache::make_reader(schema_ptr s,
                     on_partition_miss();
                     return make_flat_mutation_reader<single_partition_populating_reader>(*this, std::move(ctx));
                 }
-            });
         });
 
         if (fwd == streamed_mutation::forwarding::yes) {
@@ -792,7 +784,6 @@ cache_entry& row_cache::do_find_or_create_entry(const dht::decorated_key& key,
     const previous_entry_pointer* previous, CreateEntry&& create_entry, VisitEntry&& visit_entry)
 {
     return with_allocator(_tracker.allocator(), [&] () -> cache_entry& {
-            return with_linearized_managed_bytes([&] () -> cache_entry& {
                 partitions_type::bound_hint hint;
                 dht::ring_position_comparator cmp(*_schema);
                 auto i = _partitions.lower_bound(key, cmp, hint);
@@ -815,7 +806,6 @@ cache_entry& row_cache::do_find_or_create_entry(const dht::decorated_key& key,
                 }
 
                 return *i;
-            });
     });
 }
 
@@ -897,21 +887,16 @@ void row_cache::invalidate_sync(memtable& m) noexcept {
     with_allocator(_tracker.allocator(), [&m, this] () {
         logalloc::reclaim_lock _(_tracker.region());
         bool blow_cache = false;
-        // Note: clear_and_dispose() ought not to look up any keys, so it doesn't require
-        // with_linearized_managed_bytes(), but invalidate() does.
         m.partitions.clear_and_dispose([this, &m, &blow_cache] (memtable_entry* entry) noexcept {
-            with_linearized_managed_bytes([&] () noexcept {
                 try {
                     invalidate_locked(entry->key());
                 } catch (...) {
                     blow_cache = true;
                 }
                 m.evict_entry(*entry, _tracker.memtable_cleaner());
-            });
         });
         if (blow_cache) {
-            // We failed to invalidate the key, presumably due to with_linearized_managed_bytes()
-            // running out of memory.  Recover using clear_now(), which doesn't throw.
+            // We failed to invalidate the key. Recover using clear_now(), which doesn't throw.
             clear_now();
         }
     });
@@ -963,13 +948,11 @@ future<> row_cache::do_update(external_updater eu, memtable& m, Updater updater)
                           {
                             if (!update) {
                                 _update_section(_tracker.region(), [&] {
-                                  with_linearized_managed_bytes([&] {
                                     memtable_entry& mem_e = *m.partitions.begin();
                                     size_entry = mem_e.size_in_allocator_without_rows(_tracker.allocator());
                                     partitions_type::bound_hint hint;
                                     auto cache_i = _partitions.lower_bound(mem_e.key(), cmp, hint);
                                     update = updater(_update_section, cache_i, mem_e, is_present, real_dirty_acc, hint);
-                                  });
                                 });
                             }
                             // We use cooperative deferring instead of futures so that
@@ -981,12 +964,10 @@ future<> row_cache::do_update(external_updater eu, memtable& m, Updater updater)
                             update = {};
                             real_dirty_acc.unpin_memory(size_entry);
                             _update_section(_tracker.region(), [&] {
-                              with_linearized_managed_bytes([&] {
                                 auto i = m.partitions.begin();
                                 i.erase_and_dispose(dht::raw_token_less_comparator{}, [&] (memtable_entry* e) noexcept {
                                     m.evict_entry(*e, _tracker.memtable_cleaner());
                                 });
-                              });
                             });
                             ++partition_count;
                           }
@@ -1070,7 +1051,6 @@ void row_cache::refresh_snapshot() {
 
 void row_cache::touch(const dht::decorated_key& dk) {
  _read_section(_tracker.region(), [&] {
-  with_linearized_managed_bytes([&] {
     auto i = _partitions.find(dk, dht::ring_position_comparator(*_schema));
     if (i != _partitions.end()) {
         for (partition_version& pv : i->partition().versions_from_oldest()) {
@@ -1079,13 +1059,11 @@ void row_cache::touch(const dht::decorated_key& dk) {
             }
         }
     }
-  });
  });
 }
 
 void row_cache::unlink_from_lru(const dht::decorated_key& dk) {
     _read_section(_tracker.region(), [&] {
-        with_linearized_managed_bytes([&] {
             auto i = _partitions.find(dk, dht::ring_position_comparator(*_schema));
             if (i != _partitions.end()) {
                 for (partition_version& pv : i->partition().versions_from_oldest()) {
@@ -1094,7 +1072,6 @@ void row_cache::unlink_from_lru(const dht::decorated_key& dk) {
                     }
                 }
             }
-        });
     });
 }
 
@@ -1135,7 +1112,6 @@ future<> row_cache::invalidate(external_updater eu, dht::partition_range_vector&
 
                 while (true) {
                     auto done = _update_section(_tracker.region(), [&] {
-                        return with_linearized_managed_bytes([&] {
                             auto cmp = dht::ring_position_comparator(*_schema);
                             auto it = _partitions.lower_bound(*_prev_snapshot_pos, cmp);
                             auto end = _partitions.lower_bound(dht::ring_position_view::for_range_end(range), cmp);
@@ -1159,7 +1135,6 @@ future<> row_cache::invalidate(external_updater eu, dht::partition_range_vector&
                                 _tracker.clear_continuity(*it);
                                 return stop_iteration(it == end);
                             });
-                        });
                     });
                     if (done == stop_iteration::yes) {
                         break;
@@ -1279,10 +1254,8 @@ void row_cache::upgrade_entry(cache_entry& e) {
         auto& r = _tracker.region();
         assert(!r.reclaiming_enabled());
         with_allocator(r.allocator(), [this, &e] {
-          with_linearized_managed_bytes([&] {
             e.partition().upgrade(e._schema, _schema, _tracker.cleaner(), &_tracker);
             e._schema = _schema;
-          });
         });
     }
 }

--- a/row_cache.hh
+++ b/row_cache.hh
@@ -558,28 +558,22 @@ public:
     template<typename Func>
     decltype(auto) run_in_read_section(const Func &func) {
         return _cache._read_section(_cache._tracker.region(), [&func]() {
-            return with_linearized_managed_bytes([&func]() {
-                return func();
-            });
+            return func();
         });
     }
 
     template<typename Func>
     decltype(auto) run_in_update_section(const Func &func) {
         return _cache._update_section(_cache._tracker.region(), [&func]() {
-            return with_linearized_managed_bytes([&func]() {
-                return func();
-            });
+            return func();
         });
     }
 
     template<typename Func>
     void run_in_update_section_with_allocator(Func &&func) {
         return _cache._update_section(_cache._tracker.region(), [this, &func]() {
-            return with_linearized_managed_bytes([this, &func]() {
-                return with_allocator(_cache._tracker.region().allocator(), [this, &func]() mutable {
-                    return func();
-                });
+            return with_allocator(_cache._tracker.region().allocator(), [this, &func]() mutable {
+                return func();
             });
         });
     }

--- a/sstables/metadata_collector.cc
+++ b/sstables/metadata_collector.cc
@@ -34,7 +34,7 @@ void metadata_collector::convert(disk_array<uint32_t, disk_string<uint16_t>>& to
     }
     mdclogger.trace("{}: convert: {}", _name, clustering_key_prefix::with_schema_wrapper(_schema, *from));
     for (auto& value : from->components()) {
-        to.elements.push_back(disk_string<uint16_t>{bytes(value.data(), value.size())});
+        to.elements.push_back(disk_string<uint16_t>{value.to_bytes()});
     }
 }
 

--- a/sstables/mx/writer.cc
+++ b/sstables/mx/writer.cc
@@ -173,7 +173,8 @@ public:
         while (_offset < limit) {
             auto shift = _offset % clustering_block::max_block_size;
             if (_offset < _prefix.size(_schema)) {
-                bytes_view value = _prefix.get_component(_schema, _offset);
+              managed_bytes_view mvalue = _prefix.get_component(_schema, _offset);
+              mvalue.with_linearized([&] (bytes_view value) {
                 if (value.empty()) {
                     _current_block.header |= (uint64_t(1) << (shift * 2));
                 } else {
@@ -193,6 +194,7 @@ public:
                         _current_block.header |= (uint64_t(1) << ((shift * 2) + 1));
                     }
                 }
+              });
             } else {
                 // This (and all subsequent) values of the prefix are missing (null)
                 // This branch is only ever taken for an ephemerally_full_prefix

--- a/test/boost/cache_flat_mutation_reader_test.cc
+++ b/test/boost/cache_flat_mutation_reader_test.cc
@@ -194,8 +194,8 @@ class cache_tester {
 public:
     static partition_snapshot_ptr snapshot_for_key(row_cache& rc, const dht::decorated_key& dk) {
         return rc._read_section(rc._tracker.region(), [&] {
-                cache_entry& e = rc.lookup(dk);
-                return e.partition().read(rc._tracker.region(), rc._tracker.cleaner(), e.schema(), &rc._tracker);
+            cache_entry& e = rc.lookup(dk);
+            return e.partition().read(rc._tracker.region(), rc._tracker.cleaner(), e.schema(), &rc._tracker);
         });
     }
 };

--- a/test/boost/cache_flat_mutation_reader_test.cc
+++ b/test/boost/cache_flat_mutation_reader_test.cc
@@ -194,10 +194,8 @@ class cache_tester {
 public:
     static partition_snapshot_ptr snapshot_for_key(row_cache& rc, const dht::decorated_key& dk) {
         return rc._read_section(rc._tracker.region(), [&] {
-            return with_linearized_managed_bytes([&] {
                 cache_entry& e = rc.lookup(dk);
                 return e.partition().read(rc._tracker.region(), rc._tracker.cleaner(), e.schema(), &rc._tracker);
-            });
         });
     }
 };

--- a/test/boost/keys_test.cc
+++ b/test/boost/keys_test.cc
@@ -133,7 +133,7 @@ BOOST_AUTO_TEST_CASE(test_conversions_between_view_and_wrapper) {
     BOOST_REQUIRE(key2.equal(s, key));
     BOOST_REQUIRE(key.equal(s, key2));
 
-    BOOST_REQUIRE(*key.begin(s) == bytes("value"));
+    BOOST_REQUIRE(*key.begin(s) == to_managed_bytes("value"));
 }
 
 template<typename T>

--- a/test/boost/logalloc_test.cc
+++ b/test/boost/logalloc_test.cc
@@ -303,11 +303,11 @@ SEASTAR_TEST_CASE(test_blob) {
             auto src = bytes("123456");
             managed_bytes b(src);
 
-            BOOST_REQUIRE(bytes_view(b) == src);
+            BOOST_REQUIRE(managed_bytes_view(b) == managed_bytes_view(src));
 
             reg.full_compaction();
 
-            BOOST_REQUIRE(bytes_view(b) == src);
+            BOOST_REQUIRE(managed_bytes_view(b) == managed_bytes_view(src));
         });
     });
 }

--- a/test/boost/sstable_mutation_test.cc
+++ b/test/boost/sstable_mutation_test.cc
@@ -75,7 +75,7 @@ future<> test_no_clustered(sstables::test_env& env, bytes&& key, std::unordered_
                 BOOST_REQUIRE(mutation);
                 auto& mp = mutation->partition();
                 for (auto&& e : mp.range(*s, nonwrapping_range<clustering_key_prefix>())) {
-                    BOOST_REQUIRE(to_bytes(e.key()) == to_bytes(""));
+                    BOOST_REQUIRE(to_bytes(e.key().representation()) == to_bytes(""));
                     BOOST_REQUIRE(e.row().cells().size() == map.size());
 
                     auto &row = e.row().cells();

--- a/test/boost/test_table.cc
+++ b/test/boost/test_table.cc
@@ -227,7 +227,7 @@ static size_t maybe_generate_static_row(cql_test_env& env, const schema& schema,
     const auto size = value.size();
 
     env.execute_prepared(static_insert_id, {{
-            cql3::raw_value::make_value(bytes(part_desc.dkey.key().get_component(schema, 0))),
+            cql3::raw_value::make_value(to_bytes(part_desc.dkey.key().get_component(schema, 0))),
             cql3::raw_value::make_value(serialized(std::move(value)))}}).get();
     return size;
 }
@@ -282,8 +282,8 @@ static clustering_row_generation_result generate_clustering_rows(
         written_bytes += value.size();
 
         env.execute_prepared(clustering_insert_id, {{
-                cql3::raw_value::make_value(bytes(part_desc.dkey.key().get_component(schema, 0))),
-                cql3::raw_value::make_value(bytes(key.get_component(schema, 0))),
+                cql3::raw_value::make_value(to_bytes(part_desc.dkey.key().get_component(schema, 0))),
+                cql3::raw_value::make_value(to_bytes(key.get_component(schema, 0))),
                 cql3::raw_value::make_value(serialized(std::move(value)))}}).get();
         written_rows.insert(std::move(key));
     }
@@ -296,9 +296,9 @@ static clustering_row_generation_result generate_clustering_rows(
     for (const auto& range : delete_ranges) {
         const auto delete_id = clustering_delete_id_mappings[range.start()->is_inclusive()][range.end()->is_inclusive()];
         env.execute_prepared(delete_id, {{
-                cql3::raw_value::make_value(bytes(part_desc.dkey.key().get_component(schema, 0))),
-                cql3::raw_value::make_value(bytes(range.start()->value().get_component(schema, 0))),
-                cql3::raw_value::make_value(bytes(range.end()->value().get_component(schema, 0)))}}).get();
+                cql3::raw_value::make_value(to_bytes(part_desc.dkey.key().get_component(schema, 0))),
+                cql3::raw_value::make_value(to_bytes(range.start()->value().get_component(schema, 0))),
+                cql3::raw_value::make_value(to_bytes(range.end()->value().get_component(schema, 0)))}}).get();
     }
 
     std::sort(delete_ranges.begin(), delete_ranges.end(), clustering_range_less_compare(schema));

--- a/thrift/handler.cc
+++ b/thrift/handler.cc
@@ -1589,7 +1589,7 @@ private:
         return counter_column_to_column_or_supercolumn(make_counter_column(col, cell));
     }
     static std::string partition_key_to_string(const schema& s, const partition_key& key) {
-        return bytes_to_string(to_legacy(*s.partition_key_type(), key));
+        return bytes_to_string(to_legacy(*s.partition_key_type(), key.representation()));
     }
 
     template<typename Aggregator, query_order QueryOrder>

--- a/types.hh
+++ b/types.hh
@@ -721,7 +721,7 @@ tri_compare_opt(data_type t, bytes_view_opt v1, bytes_view_opt v2) {
 }
 
 static inline
-bool equal(data_type t, bytes_view e1, bytes_view e2) {
+bool equal(data_type t, managed_bytes_view e1, managed_bytes_view e2) {
     return t->equal(e1, e2);
 }
 

--- a/types.hh
+++ b/types.hh
@@ -502,15 +502,21 @@ public:
     serialized_compare as_less_comparator() const ;
     serialized_tri_compare as_tri_comparator() const ;
     static data_type parse_type(const sstring& name);
+    size_t hash(managed_bytes_view v) const;
     size_t hash(bytes_view v) const;
     bool equal(bytes_view v1, bytes_view v2) const;
+    bool equal(managed_bytes_view v1, managed_bytes_view v2) const;
     int32_t compare(bytes_view v1, bytes_view v2) const;
+    int32_t compare(managed_bytes_view v1, managed_bytes_view v2) const;
+    data_value deserialize(managed_bytes_view v) const;
     data_value deserialize(bytes_view v) const;
+    data_value deserialize_value(managed_bytes_view v) const;
     data_value deserialize_value(bytes_view v) const {
         return deserialize(v);
     };
     void validate(const fragmented_temporary_buffer::view& view, cql_serialization_format sf) const;
     void validate(bytes_view view, cql_serialization_format sf) const;
+    void validate(managed_bytes_view view, cql_serialization_format sf) const;
     bool is_compatible_with(const abstract_type& previous) const;
     /*
      * Types which are wrappers over other types return the inner type.
@@ -700,7 +706,7 @@ bool less_compare(data_type t, bytes_view e1, bytes_view e2) {
 }
 
 static inline
-int tri_compare(data_type t, bytes_view e1, bytes_view e2) {
+int tri_compare(data_type t, managed_bytes_view e1, managed_bytes_view e2) {
     return t->compare(e1, e2);
 }
 

--- a/types.hh
+++ b/types.hh
@@ -26,6 +26,7 @@
 #include <iosfwd>
 #include "data/cell.hh"
 #include <sstream>
+#include <iterator>
 
 #include <seastar/core/sstring.hh>
 #include <seastar/core/shared_ptr.hh>
@@ -121,7 +122,10 @@ bool lexicographical_compare(TypesIterator types, InputIt1 first1, InputIt1 last
 // A trichotomic comparator returns an integer which is less, equal or greater
 // than zero when the first value is respectively smaller, equal or greater
 // than the second value.
-template <typename TypesIterator, typename InputIt1, typename InputIt2, typename Compare>
+template <std::input_iterator TypesIterator, std::input_iterator InputIt1, std::input_iterator InputIt2, typename Compare>
+requires requires (TypesIterator types, InputIt1 i1, InputIt2 i2, Compare cmp) {
+    { cmp(*types, *i1, *i2) } -> std::same_as<int>;
+}
 int lexicographical_tri_compare(TypesIterator types_first, TypesIterator types_last,
         InputIt1 first1, InputIt1 last1,
         InputIt2 first2, InputIt2 last2,

--- a/types.hh
+++ b/types.hh
@@ -30,6 +30,7 @@
 #include <seastar/core/sstring.hh>
 #include <seastar/core/shared_ptr.hh>
 #include "utils/UUID.hh"
+#include "utils/managed_bytes.hh"
 #include <seastar/net/byteorder.hh>
 #include "db_clock.hh"
 #include "bytes.hh"
@@ -1119,12 +1120,30 @@ T read_simple(bytes_view& v) {
 }
 
 template<typename T>
+T read_simple(managed_bytes_view& v) {
+    if (v.size() < sizeof(T)) {
+        throw_with_backtrace<marshal_exception>(format("read_simple - not enough bytes (expected {:d}, got {:d})", sizeof(T), v.size()));
+    }
+    // FIXME: implement
+    return T();
+}
+
+template<typename T>
 T read_simple_exactly(bytes_view v) {
     if (v.size() != sizeof(T)) {
         throw_with_backtrace<marshal_exception>(format("read_simple_exactly - size mismatch (expected {:d}, got {:d})", sizeof(T), v.size()));
     }
     auto p = v.begin();
     return net::ntoh(*reinterpret_cast<const net::packed<T>*>(p));
+}
+
+template<typename T>
+T read_simple_exactly(managed_bytes_view v) {
+    if (v.size() != sizeof(T)) {
+        throw_with_backtrace<marshal_exception>(format("read_simple_exactly - size mismatch (expected {:d}, got {:d})", sizeof(T), v.size()));
+    }
+    // FIXME: implement
+    return T();
 }
 
 inline
@@ -1136,6 +1155,16 @@ read_simple_bytes(bytes_view& v, size_t n) {
     bytes_view ret(v.begin(), n);
     v.remove_prefix(n);
     return ret;
+}
+
+inline
+managed_bytes_view
+read_simple_bytes(managed_bytes_view& v, size_t n) {
+    if (v.size() < n) {
+        throw_with_backtrace<marshal_exception>(format("read_simple_bytes - not enough bytes (requested {:d}, got {:d})", n, v.size()));
+    }
+    // FIXME: implement
+    return managed_bytes_view();
 }
 
 template<typename T>

--- a/types.hh
+++ b/types.hh
@@ -1055,6 +1055,13 @@ to_bytes(const sstring& x) {
     return bytes(reinterpret_cast<const int8_t*>(x.c_str()), x.size());
 }
 
+// FIXME: make more explicit
+inline
+managed_bytes
+to_managed_bytes(const sstring& x) {
+    return managed_bytes(reinterpret_cast<const int8_t*>(x.c_str()), x.size());
+}
+
 inline
 bytes_view
 to_bytes_view(const sstring& x) {

--- a/utils/allocation_strategy.hh
+++ b/utils/allocation_strategy.hh
@@ -185,6 +185,9 @@ public:
 
 class standard_allocation_strategy : public allocation_strategy {
 public:
+    constexpr standard_allocation_strategy() {
+        _preferred_max_contiguous_allocation = 128 * 1024;
+    }
     virtual void* alloc(migrate_fn, size_t size, size_t alignment) override {
         seastar::memory::on_alloc_point();
         // ASAN doesn't intercept aligned_alloc() and complains on free().

--- a/utils/managed_bytes.cc
+++ b/utils/managed_bytes.cc
@@ -31,6 +31,10 @@ managed_bytes::linearization_context::forget(const blob_storage* p) noexcept {
     _lc_state.erase(p);
 }
 
+managed_bytes::managed_bytes(managed_bytes_view o) : managed_bytes(initialized_later(), o.size()) {
+    // FIXME: implement
+}
+
 std::unique_ptr<bytes_view::value_type[]>
 managed_bytes::do_linearize_pure() const {
     auto b = _u.ptr;
@@ -57,3 +61,80 @@ managed_bytes::do_linearize() const {
     return i->second.get();
 }
 
+managed_bytes_view::managed_bytes_view(const managed_bytes& mb) {
+    if (mb._u.small.size != -1) {
+        _current_fragment = bytes_view(mb._u.small.data, mb._u.small.size);
+        _size = mb._u.small.size;
+    } else {
+        auto p = mb._u.ptr;
+        _current_fragment = bytes_view(p->data, p->frag_size);
+        _next_fragments = p->next;
+        _size = p->size;
+    }
+}
+
+bytes_view::value_type
+managed_bytes_view::operator[](size_t idx) const {
+    if (idx < _current_fragment.size()) {
+        return _current_fragment[idx];
+    }
+    idx -= _current_fragment.size();
+    auto f = _next_fragments;
+    while (idx >= f->frag_size) {
+        idx -= f->frag_size;
+        f = f->next;
+    }
+    return f->data[idx];
+}
+
+bytes
+managed_bytes_view::to_bytes() const {
+    // FIXME: implement
+    return bytes();
+}
+
+bytes
+to_bytes(managed_bytes_view v) {
+    return v.to_bytes();
+}
+
+bytes
+to_bytes(const managed_bytes& b) {
+    return managed_bytes_view(b).to_bytes();
+}
+
+void managed_bytes_view::remove_prefix(size_t n) {
+    // FIXME: implement
+}
+
+managed_bytes_view
+managed_bytes_view::substr(size_t offset, size_t len) const {
+    // FIXME: implement
+    return managed_bytes_view();
+}
+
+bool
+managed_bytes_view::operator==(const managed_bytes_view& x) const {
+    // FIXME: implement
+    return true;
+}
+
+bool
+managed_bytes_view::operator!=(const managed_bytes_view& x) const {
+    // FIXME: implement
+    return true;
+}
+
+int compare_unsigned(const managed_bytes_view v1, const managed_bytes_view v2) {
+    // FIXME: implement
+    return 0;
+}
+
+std::ostream& operator<<(std::ostream& os, const managed_bytes_view& v) {
+    // FIXME: implement
+    return os;
+}
+
+std::ostream& operator<<(std::ostream& os, const managed_bytes& b) {
+    return os << managed_bytes_view(b);
+}

--- a/utils/managed_bytes.hh
+++ b/utils/managed_bytes.hh
@@ -232,8 +232,8 @@ public:
     }
 
     managed_bytes(const managed_bytes& o) : managed_bytes(initialized_later(), o.size()) {
-        if (!external()) {
-            memcpy(data(), o.data(), size());
+        if (!o.external()) {
+            _u.small = o._u.small;
             return;
         }
         auto s = size();
@@ -299,7 +299,7 @@ public:
             return false;
         }
         if (!external()) {
-            return bytes_view(*this) == bytes_view(o);
+            return std::equal(_u.small.data, _u.small.data + _u.small.size, o._u.small.data);
         } else {
             auto a = _u.ptr;
             auto a_data = a->data;

--- a/utils/managed_bytes.hh
+++ b/utils/managed_bytes.hh
@@ -414,6 +414,25 @@ public:
         return 0;
     }
 
+    template <std::invocable<bytes_view> Func>
+    std::invoke_result_t<Func, bytes_view> with_linearized(Func&& func) const {
+        const bytes_view::value_type* start = nullptr;
+        size_t size = 0;
+        if (!external()) {
+            start = _u.small.data;
+            size = _u.small.size;
+        } else if (!_u.ptr->next) {
+            start = _u.ptr->data;
+            size = _u.ptr->size;
+        }
+        if (start) {
+            return func(bytes_view(start, size));
+        } else {
+            auto data = do_linearize_pure();
+            return func(bytes_view(data.get(), _u.ptr->size));
+        }
+    }
+
     template <std::invocable<> Func>
     friend std::result_of_t<Func()> with_linearized_managed_bytes(Func&& func);
 };

--- a/utils/managed_bytes.hh
+++ b/utils/managed_bytes.hh
@@ -414,13 +414,13 @@ public:
         return 0;
     }
 
-    template <typename Func>
+    template <std::invocable<> Func>
     friend std::result_of_t<Func()> with_linearized_managed_bytes(Func&& func);
 };
 
 // Run func() while ensuring that reads of managed_bytes objects are
 // temporarlily linearized
-template <typename Func>
+template <std::invocable<> Func>
 inline
 std::result_of_t<Func()>
 with_linearized_managed_bytes(Func&& func) {

--- a/utils/managed_bytes.hh
+++ b/utils/managed_bytes.hh
@@ -158,6 +158,7 @@ private:
         }
         return a->data[index];
     }
+    std::unique_ptr<bytes_view::value_type[]> do_linearize_pure() const;
     const bytes_view::value_type* do_linearize() const;
 public:
     using size_type = blob_storage::size_type;

--- a/utils/managed_bytes.hh
+++ b/utils/managed_bytes.hh
@@ -140,16 +140,6 @@ private:
             p = n;
         }
     }
-    const bytes_view::value_type* read_linearize() const {
-        seastar::memory::on_alloc_point();
-        if (!external()) {
-            return _u.small.data;
-        } else  if (!_u.ptr->next) {
-            return _u.ptr->data;
-        } else {
-            return do_linearize();
-        }
-    }
     bytes_view::value_type& value_at_index(blob_storage::size_type index) {
         if (!external()) {
             return _u.small.data[index];
@@ -342,18 +332,9 @@ public:
         return !(*this == o);
     }
 
-    operator bytes_view() const {
-        return { data(), size() };
-    }
-
     bool is_fragmented() const {
         return external() && _u.ptr->next;
     }
-
-    operator bytes_mutable_view() {
-        assert(!is_fragmented());
-        return { data(), size() };
-    };
 
     bytes_view::value_type& operator[](size_type index) {
         return value_at_index(index);
@@ -372,37 +353,8 @@ public:
         }
     }
 
-    const blob_storage::char_type* begin() const {
-        return data();
-    }
-
-    const blob_storage::char_type* end() const {
-        return data() + size();
-    }
-
-    blob_storage::char_type* begin() {
-        return data();
-    }
-
-    blob_storage::char_type* end() {
-        return data() + size();
-    }
-
     bool empty() const {
         return _u.small.size == 0;
-    }
-
-    blob_storage::char_type* data() {
-        if (external()) {
-            assert(!_u.ptr->next);  // must be linearized
-            return _u.ptr->data;
-        } else {
-            return _u.small.data;
-        }
-    }
-
-    const blob_storage::char_type* data() const {
-        return read_linearize();
     }
 
     // Returns the amount of external memory used.

--- a/utils/managed_bytes.hh
+++ b/utils/managed_bytes.hh
@@ -79,37 +79,6 @@ class managed_bytes_view;
 
 // A managed version of "bytes" (can be used with LSA).
 class managed_bytes {
-    static thread_local std::unordered_map<const blob_storage*, std::unique_ptr<bytes_view::value_type[]>> _lc_state;
-    struct linearization_context {
-        unsigned _nesting = 0;
-        // Map from first blob_storage address to linearized version
-        // We use the blob_storage address to be insentive to moving
-        // a managed_bytes object.
-        // linearization_context is entered often in the fast path, but it is
-        // actually used only in rare (slow) cases.
-        std::unordered_map<const blob_storage*, std::unique_ptr<bytes_view::value_type[]>>* _state_ptr = nullptr;
-        void enter() {
-            ++_nesting;
-        }
-        void leave() {
-            if (!--_nesting && _state_ptr) {
-                _state_ptr->clear();
-                _state_ptr = nullptr;
-            }
-        }
-        void forget(const blob_storage* p) noexcept;
-    };
-    static thread_local linearization_context _linearization_context;
-public:
-    struct linearization_context_guard {
-        linearization_context_guard() {
-            _linearization_context.enter();
-        }
-        ~linearization_context_guard() {
-            _linearization_context.leave();
-        }
-    };
-private:
     static constexpr size_t max_inline_size = 15;
     struct small_blob {
         bytes_view::value_type data[max_inline_size];
@@ -130,9 +99,6 @@ private:
         return alctr.preferred_max_contiguous_allocation() - sizeof(blob_storage);
     }
     void free_chain(blob_storage* p) noexcept {
-        if (p->next && _linearization_context._nesting) {
-            _linearization_context.forget(p);
-        }
         auto& alctr = current_allocator();
         while (p) {
             auto n = p->next;
@@ -152,7 +118,7 @@ private:
         return a->data[index];
     }
     std::unique_ptr<bytes_view::value_type[]> do_linearize_pure() const;
-    const bytes_view::value_type* do_linearize() const;
+
 public:
     using size_type = blob_storage::size_type;
     struct initialized_later {};
@@ -390,9 +356,6 @@ public:
         }
     }
 
-    template <std::invocable<> Func>
-    friend std::result_of_t<Func()> with_linearized_managed_bytes(Func&& func);
-
     friend class managed_bytes_view;
 };
 
@@ -469,16 +432,6 @@ managed_bytes_view::managed_bytes_view(const bytes& b)
 bytes to_bytes(const managed_bytes& b);
 bytes to_bytes(managed_bytes_view v);
 int compare_unsigned(const managed_bytes_view v1, const managed_bytes_view v2);
-
-// Run func() while ensuring that reads of managed_bytes objects are
-// temporarlily linearized
-template <std::invocable<> Func>
-inline
-std::result_of_t<Func()>
-with_linearized_managed_bytes(Func&& func) {
-    managed_bytes::linearization_context_guard g;
-    return func();
-}
 
 namespace std {
 


### PR DESCRIPTION
The managed_bytes class now uses implicit linearization: outside LSA, data is never fragmented, and within LSA, data is linearized on-demand, as long as the code is running within with_linearized_managed_bytes() scope.

We would like to stop linearizing managed_bytes and keep it fragmented at all times, since linearization can require large contiguous chunks. Large contiguous allocations are hard to satisfy and cause latency spikes.

As a first step towards that, we remove all implicitly linearizing accessors and replace them with an explicit linearization accessor, with_linearized().

Some of the linearization happens long before use, by creating a bytes_view of the managed_bytes object and passing it onwards, perhaps storing it for later use. This does not work with with_linearized(), which creates a temporary linearized view, and does not work towards the longer term goal of never linearizing. As a substitute a managed_bytes_view class is introduced that acts as a view for managed_bytes (for interoperability it can also be a view for bytes and is coimpatible with bytes_view).

By the end of the series, all linearizations are temporary, within the scope of a with_linearized() call and can be converted to fragmented consumption of the data at leisure.

This has limited practical value directly, as current uses of managed_bytes are limited to keys (which are limited to 64k). However, it enables converting the atomic_cell layer back to managed_bytes (so we can remove IMR) and the CQL layer to managed_bytes/managed_bytes_view, removing contiguous allocations from the coordinator.