### PR TITLE
build: silence gcc ABI interoperability warning on arm

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1152,6 +1152,8 @@ warnings = [
     '-Wno-implicit-int-float-conversion',
     '-Wno-delete-abstract-non-virtual-dtor',
     '-Wno-uninitialized-const-reference',
+    # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=77728
+    '-Wno-psabi',
 ]
 
 warnings = [w


### PR DESCRIPTION
A gcc bug [1] caused objects built by different versions of gcc
not to interoperate. Gcc helpfully warns when it encounters code that
could be affected.

Since we build everything with one version, and as that versions is far
newer than the last version generating incorrect code, we can silence
that warning without issue.

[1] https://gcc.gnu.org/bugzilla/show_bug.cgi?id=77728