### PR TITLE
dist: redhat: don't pull in kernel package

### DIFF
--- a/dist/redhat/scylla.spec
+++ b/dist/redhat/scylla.spec
@@ -51,7 +51,7 @@ Group:          Applications/Databases
 Summary:        The Scylla database server
 License:        AGPLv3
 URL:            http://www.scylladb.com/
-Requires: kernel >= 3.10.0-514
+Conflicts: kernel < 3.10.0-514
 Requires:       %{product}-conf %{product}-python3
 Conflicts:      abrt
 AutoReqProv:    no


### PR DESCRIPTION
We require a kernel that is at least 3.10.0-514, because older
kernel have an XFS related bug that causes data corruption. However
this Requires: clause pulls in a kernel even in Docker installation,
where it (and especially the associated firmware) occupies a lot of
space.

Change to a Conflicts: instead. This prevents installation when
the really old kernel is present, but doesn't pull it in for the
Docker image.