### PR TITLE
Restrict default access to system keyspace

### DIFF
--- a/auth/default_authorizer.cc
+++ b/auth/default_authorizer.cc
@@ -334,7 +334,7 @@ future<> default_authorizer::revoke_all(const resource& resource) const {
 }
 
 const resource_set& default_authorizer::protected_resources() const {
-    static const resource_set resources({ make_data_resource(meta::AUTH_KS, PERMISSIONS_CF) });
+    static const resource_set resources({ make_data_resource(meta::AUTH_KS, PERMISSIONS_CF), make_data_resource(db::system_keyspace_name()) });
     return resources;
 }
 


### PR DESCRIPTION
This change marks the whole system keyspace as a restricted resource
in the default authorizer so that it can only be accessed by the superuser.
Later, permissions can still be granted to other users if the need arises.

Fixes #3607