### PR TITLE
Add debug context to views out of sync

### DIFF
--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -226,7 +226,7 @@ bool view_info::has_base_non_pk_columns_in_view_pk() const {
     // schema integrity problem as the creator of owning view schema
     // didn't make sure to initialize it with base information.
     if (!_base_info) {
-        on_internal_error(vlogger, "Tried to perform a view query which is base info dependant without initializing it");
+        on_internal_error(vlogger, "Tried to perform a view query which is base info dependent without initializing it");
     }
     return _base_info->has_base_non_pk_columns_in_view_pk;
 }

--- a/db/view/view.hh
+++ b/db/view/view.hh
@@ -53,6 +53,10 @@ private:
     // Id of a regular base table column included in the view's PK, if any.
     // Scylla views only allow one such column, alternator can have up to two.
     std::vector<column_id> _base_non_pk_columns_in_view_pk;
+    // For tracing purposes, if the view is out of sync with its base table
+    // and there exists a column which is not in base, its name is stored
+    // and added to debug messages.
+    std::optional<bytes> _column_missing_in_base = {};
 public:
     const std::vector<column_id>& base_non_pk_columns_in_view_pk() const;
     const schema_ptr& base_schema() const;
@@ -71,7 +75,7 @@ public:
     // A constructor for a base info that can facilitate reads and writes from the materialized view.
     base_dependent_view_info(schema_ptr base_schema, std::vector<column_id>&& base_non_pk_columns_in_view_pk);
     // A constructor for a base info that can facilitate only reads from the materialized view.
-    explicit base_dependent_view_info(bool has_base_non_pk_columns_in_view_pk);
+    base_dependent_view_info(bool has_base_non_pk_columns_in_view_pk, std::optional<bytes>&& column_missing_in_base);
 };
 
 // Immutable snapshot of view's base-schema-dependent part.

--- a/db/view/view.hh
+++ b/db/view/view.hh
@@ -71,7 +71,7 @@ public:
     // A constructor for a base info that can facilitate reads and writes from the materialized view.
     base_dependent_view_info(schema_ptr base_schema, std::vector<column_id>&& base_non_pk_columns_in_view_pk);
     // A constructor for a base info that can facilitate only reads from the materialized view.
-    base_dependent_view_info(bool has_base_non_pk_columns_in_view_pk);
+    explicit base_dependent_view_info(bool has_base_non_pk_columns_in_view_pk);
 };
 
 // Immutable snapshot of view's base-schema-dependent part.


### PR DESCRIPTION
This series adds more context to debugging information in case a view gets out of sync with its base table.
A test was conducted manually, by:
1. creating a table with a secondary index
2. manually deleting computed column information from system_schema.computed_columns
3. restarting the target node
4. trying to write to the index

Here's what's logged right after the index metadata is loaded from disk:
```
ERROR 2020-10-30 12:30:42,806 [shard 0] view - Column idx_token in view ks.t_c_idx_index was not found in the base table ks.t
ERROR 2020-10-30 12:30:42,806 [shard 0] view - Missing idx_token column is caused by an incorrect upgrade of a secondary index. Please recreate index ks.t_c_idx_index to avoid future issues.
```

And here's what's logged during the actual failure - when Scylla notices that there exists
a column which is not computed, but it's also not found in the base table:
```
ERROR 2020-10-30 12:31:25,709 [shard 0] storage_proxy - exception during mutation write to 127.0.0.1: seastar::internal::backtraced<std::runtime_error> (base_schema(): operation unsupported when initialized only for view reads. Missing column in the base table: idx_token Backtrace:    0x1d14513
   0x1d1468b
   0x1d1492b
   0x109bbad
   0x109bc97
   0x109bcf4
   0x1bc4370
   0x1381cd3
   0x1389c38
   0xaf89bf
   0xaf9b20
   0xaf1654
   0xaf1afe
   0xb10525
   0xb10ad8
   0xb10c3a
   0xaaefac
   0xabf525
   0xabf262
   0xac107f
   0x1ba8ede
   0x1bdf749
   0x1be338c
   0x1bfe984
   0x1ba73fa
   0x1ba77a4
   0x9ea2c8
   /lib64/libc.so.6+0x27041
   0x9d11cd
   --------
   seastar::lambda_task<seastar::execution_stage::flush()::{lambda()#1}>

```

Hopefully, this information will make it much easier to solve future problems with out-of-sync views.

Tests: unit(dev)
Fixes #7512