### PR TITLE
schema_tables: fix secondary old indexes during their initialization

### DIFF
--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -3035,10 +3035,6 @@ future<> maybe_update_legacy_secondary_index_mv_schema(service::migration_manage
     // format, where "token" is not marked as computed. Once we're sure that all indexes have their
     // columns marked as computed (because they were either created on a node that supports computed
     // columns or were fixed by this utility function), it's safe to remove this function altogether.
-    if (!db.features().cluster_supports_computed_columns()) {
-        return make_ready_future<>();
-    }
-
     if (v->clustering_key_size() == 0) {
         return make_ready_future<>();
     }


### PR DESCRIPTION
Old secondary index schemas did not have their idx_token column
marked as computed, and there already exists code which updates
them. Unfortunately, the fix itself contains an error and doesn't
fire if computed columns are not yet supported by the whole cluster,
which is a very common situation during upgrades.

Fixes #7515
Tests: unit(dev), manual: adding an index, removing its schema info manually from `system_schema.computed_columns`, then restarting the node and trying to write to the index: it fails before the patch and succeeds after