### PR TITLE
test: increase timeout to 12000 seconds to account for slow ARM cores

### DIFF
--- a/test.py
+++ b/test.py
@@ -538,7 +538,7 @@ def parse_cmd_line():
                         help="Run only tests for given build mode(s)")
     parser.add_argument('--repeat', action="store", default="1", type=int,
                         help="number of times to repeat test execution")
-    parser.add_argument('--timeout', action="store", default="3000", type=int,
+    parser.add_argument('--timeout', action="store", default="12000", type=int,
                         help="timeout value for test execution")
     parser.add_argument('--verbose', '-v', action='store_true', default=False,
                         help='Verbose reporting')


### PR DESCRIPTION
Some ARM cores are slow, and trip our current timeout of 3000
seconds in debug mode. Quadrupling the timeout is enough to make
debug-mode tests pass on those machines.

Since the timeout's role is to catch rare infinite loops in unsupervised
testing, increasing the timeout has no ill effect (other than to
delay the report of the failure).