### PR TITLE
tools/toolchain: update maintainer instructions

### DIFF
--- a/tools/toolchain/README.md
+++ b/tools/toolchain/README.md
@@ -54,27 +54,40 @@ If you add dependencies (to `install-dependencies.sh` or
 
 Run the command
 
-    docker build --no-cache --pull -f tools/toolchain/Dockerfile .
+    podman build --no-cache --pull -f tools/toolchain/Dockerfile .
 
 and use the resulting image.
-
-Note: if using `podman build` instead of `docker build`, add
-`--format docker` so that old docker clients can understand the
-image manifest:
-
-    podman build --format docker --no-cache --pull -f tools/toolchain/Dockerfile .
 
 ## Publishing an image
 
 If you're a maintainer, you can tag the image and push it
-using `docker push`. Tags follow the format
-`scylladb/scylla-toolchain:fedora-29-[branch-3.0-]20181128`. After the
-image is pushed, update `tools/toolchain/image` so new
-builds can use it automatically.
+using `podman push`. Tags follow the format
+`scylladb/scylla-toolchain:fedora-29-[branch-3.0-]20181128`.
 
 For master toolchains, the branch designation is omitted. In a branch, if
 there is a need to update a toolchain, the branch designation is added to
 the tag to avoid ambiguity.
+
+To publish a new image, follow this procedure:
+
+1. Pick a new name for the image (in `tools/toolchain/image`) and
+   commit it. The commit updating install-dependencies.sh should
+   include the toolchain change, for atomicity. Do not push the commit
+   to `next` yet.
+2. Push the commit to a personal repository/branch.
+3. Perform the following on an x86 and an ARM machine:
+    1. check out the branch containing the new toolchain name
+    2. Run `git submodule update --init --recursive` to make sure
+       all the submodules are synchronized
+    3. Run `podman build --no-cache --pull --tag mytag-arch -f tools/toolchain/Dockerfile .`, where mytag-arch is a new, unique tag that is different for x86 and ARM.
+    4. Push the resulting images to a personal docker repository.
+4. Now, create a multiarch image with the following:
+    1. Pull the two images with `podman pull`. Let's call the two tags
+       `mytag-x86` and `mytag-arm`.
+    2. Create the new toolchain manifest with `podman manifest create $(<tools/toolchain/image)`
+    3. Add each image with `podman manifest add --all $(<tools/toolchain/image) mytag-x86` and `podman manifest add --all $(<tools/toolchain/image) mytag-arm`
+    4. Push the image with `podman manifest push --all $(<tools/toolchain/image) docker://$(<tools/toolchain/image)`
+5. Now push the commit that updated the toolchain with `git push`.
 
 ## Troubleshooting
 


### PR DESCRIPTION
The instructions are updated for multiarch images (images that
can be used on x86 and ARM machines).

Additionally,
 - docker is replaced with podman, since that is now used by
   developers. Docker is still supported for developers, but
   the image creation instructions are only tested with podman.
 - added instructions about updating submodules
 - `--format docker` is removed. It is not necessary with
   more recent versions of docker.