### PR TITLE
improvements for GCE image

### DIFF
--- a/dist/common/scripts/scylla_util.py
+++ b/dist/common/scripts/scylla_util.py
@@ -398,7 +398,7 @@ class aws_instance:
     def is_aws_instance(cls):
         """Check if it's AWS instance via query to metadata server."""
         try:
-            curl(cls.META_DATA_BASE_URL, max_retries=2)
+            curl(cls.META_DATA_BASE_URL, max_retries=2, retry_interval=1)
             return True
         except (urllib.error.URLError, urllib.error.HTTPError):
             return False

--- a/dist/common/scripts/scylla_util.py
+++ b/dist/common/scripts/scylla_util.py
@@ -17,7 +17,6 @@
 
 import configparser
 import io
-import logging
 import os
 import re
 import shlex
@@ -103,7 +102,6 @@ def curl(url, headers=None, byte=False, timeout=3, max_retries=5, retry_interval
                 else:
                     return res.read().decode('utf-8')
         except urllib.error.HTTPError:
-            logging.warning("Failed to grab %s..." % url)
             time.sleep(retry_interval)
             retries += 1
             if retries >= max_retries:

--- a/dist/common/scripts/scylla_util.py
+++ b/dist/common/scripts/scylla_util.py
@@ -92,7 +92,7 @@ def scyllabindir():
 
 
 # @param headers dict of k:v
-def curl(url, headers=None, byte=False, timeout=3, max_retries=5):
+def curl(url, headers=None, byte=False, timeout=3, max_retries=5, retry_interval=5):
     retries = 0
     while True:
         try:
@@ -104,7 +104,7 @@ def curl(url, headers=None, byte=False, timeout=3, max_retries=5):
                     return res.read().decode('utf-8')
         except urllib.error.HTTPError:
             logging.warning("Failed to grab %s..." % url)
-            time.sleep(5)
+            time.sleep(retry_interval)
             retries += 1
             if retries >= max_retries:
                 raise


### PR DESCRIPTION
when logging in to the GCE instance that is created from the GCE image it takes 10 seconds to understand that we are not running on AWS. Also, some unnecessary debug logging messages are printed:
```
bentsi@bentsi-G3-3590:~/devel/scylladb$ ssh -i ~/.ssh/scylla-qa-ec2 bentsi@35.196.8.86
Warning: Permanently added '35.196.8.86' (ECDSA) to the list of known hosts.
Last login: Sun Nov  1 22:14:57 2020 from 108.128.125.4

   _____            _ _       _____  ____  
  / ____|          | | |     |  __ \|  _ \ 
 | (___   ___ _   _| | | __ _| |  | | |_) |
  \___ \ / __| | | | | |/ _` | |  | |  _ < 
  ____) | (__| |_| | | | (_| | |__| | |_) |
 |_____/ \___|\__, |_|_|\__,_|_____/|____/ 
               __/ |                       
              |___/                        

Version:
       666.development-0.20201101.6be9f4938
Nodetool:
	nodetool help
CQL Shell:
	cqlsh
More documentation available at: 
	http://www.scylladb.com/doc/
By default, Scylla sends certain information about this node to a data collection server. For information, see http://www.scylladb.com/privacy/

WARNING:root:Failed to grab http://169.254.169.254/latest/...
WARNING:root:Failed to grab http://169.254.169.254/latest/...
    Initial image configuration failed!

To see status, run 
 'systemctl status scylla-image-setup'


[bentsi@artifacts-gce-image-jenkins-db-node-aa57409d-0-1 ~]$ 

```
this PR fixes this