### PR TITLE
scylla_swap_setup: when swap already configured, exit with return code 0

### DIFF
--- a/dist/common/scripts/scylla_swap_setup
+++ b/dist/common/scripts/scylla_swap_setup
@@ -46,7 +46,7 @@ if __name__ == '__main__':
 
     if swap_exists():
         print('swap already configured, exiting setup')
-        sys.exit(1)
+        sys.exit(0)
 
     diskfree = psutil.disk_usage(args.swap_directory).free
     if args.swap_size:


### PR DESCRIPTION
Fixes: https://github.com/scylladb/scylla/issues/7522
If scylla_swap_setup is run when the swap already exists the scripts exits with error code 1. We shouldn't fail the script in such case.

@penberg @yaronkaikov 
