### PR TITLE
database: make changes to durable_writes effective immediately

### DIFF
--- a/database.cc
+++ b/database.cc
@@ -717,6 +717,16 @@ future<> database::update_keyspace(const sstring& name) {
         auto tmp_ksm = db::schema_tables::create_keyspace_from_schema_partition(v);
         auto new_ksm = ::make_lw_shared<keyspace_metadata>(tmp_ksm->name(), tmp_ksm->strategy_name(), tmp_ksm->strategy_options(), tmp_ksm->durable_writes(),
                         boost::copy_range<std::vector<schema_ptr>>(ks.metadata()->cf_meta_data() | boost::adaptors::map_values), std::move(ks.metadata()->user_types()));
+
+        bool old_durable_writes = ks.metadata()->durable_writes();
+        bool new_durable_writes = new_ksm->durable_writes();
+        if (old_durable_writes != new_durable_writes) {
+            for (auto& [cf_name, cf_schema] : new_ksm->cf_meta_data()) {
+                auto& cf = find_column_family(cf_schema);
+                cf.set_durable_writes(new_durable_writes);
+            }
+        }
+
         ks.update_from(get_token_metadata(), std::move(new_ksm));
         return get_notifier().update_keyspace(ks.metadata());
     });
@@ -736,6 +746,7 @@ void database::add_column_family(keyspace& ks, schema_ptr schema, column_family:
     } else {
        cf = make_lw_shared<column_family>(schema, std::move(cfg), column_family::no_commitlog(), *_compaction_manager, *_cl_stats, _row_cache_tracker);
     }
+    cf->set_durable_writes(ks.metadata()->durable_writes());
 
     auto uuid = schema->id();
     if (_column_families.contains(uuid)) {
@@ -1558,7 +1569,7 @@ static future<> maybe_handle_reorder(std::exception_ptr exp) {
 }
 
 future<> database::apply_with_commitlog(column_family& cf, const mutation& m, db::timeout_clock::time_point timeout) {
-    if (cf.commitlog() != nullptr) {
+    if (cf.commitlog() != nullptr && cf.durable_writes()) {
         return do_with(freeze(m), [this, &m, &cf, timeout] (frozen_mutation& fm) {
             commitlog_entry_writer cew(m.schema(), fm, db::commitlog::force_sync::no);
             return cf.commitlog()->add_entry(m.schema()->id(), cew, timeout);
@@ -1572,7 +1583,7 @@ future<> database::apply_with_commitlog(column_family& cf, const mutation& m, db
 future<> database::apply_with_commitlog(schema_ptr s, column_family& cf, utils::UUID uuid, const frozen_mutation& m, db::timeout_clock::time_point timeout,
         db::commitlog::force_sync sync) {
     auto cl = cf.commitlog();
-    if (cl != nullptr) {
+    if (cl != nullptr && cf.durable_writes()) {
         commitlog_entry_writer cew(s, m, sync);
         return cf.commitlog()->add_entry(uuid, cew, timeout).then([&m, this, s, timeout, cl](db::rp_handle h) {
             return this->apply_in_memory(m, s, std::move(h), timeout).handle_exception(maybe_handle_reorder);
@@ -1663,7 +1674,7 @@ database::make_keyspace_config(const keyspace_metadata& ksm) {
         }
         cfg.enable_disk_writes = !_cfg.enable_in_memory_data_store();
         cfg.enable_disk_reads = true; // we allways read from disk
-        cfg.enable_commitlog = ksm.durable_writes() && _cfg.enable_commitlog() && !_cfg.enable_in_memory_data_store();
+        cfg.enable_commitlog = _cfg.enable_commitlog() && !_cfg.enable_in_memory_data_store();
         cfg.enable_cache = _cfg.enable_cache();
 
     } else {

--- a/database.hh
+++ b/database.hh
@@ -464,6 +464,7 @@ private:
 
     // Provided by the database that owns this commitlog
     db::commitlog* _commitlog;
+    bool _durable_writes;
     compaction_manager& _compaction_manager;
     secondary_index::secondary_index_manager _index_manager;
     int _compaction_disabled = 0;
@@ -875,6 +876,14 @@ public:
 
     cache_temperature get_global_cache_hit_rate() const {
         return _global_cache_hit_rate;
+    }
+
+    bool durable_writes() const {
+        return _durable_writes;
+    }
+
+    void set_durable_writes(bool dw) {
+        _durable_writes = dw;
     }
 
     void set_global_cache_hit_rate(cache_temperature rate) {

--- a/table.cc
+++ b/table.cc
@@ -1217,6 +1217,7 @@ table::table(schema_ptr schema, config config, db::commitlog* cl, compaction_man
     , _sstables(make_lw_shared<sstables::sstable_set>(_compaction_strategy.make_sstable_set(_schema)))
     , _cache(_schema, sstables_as_snapshot_source(), row_cache_tracker, is_continuous::yes)
     , _commitlog(cl)
+    , _durable_writes(true)
     , _compaction_manager(compaction_manager)
     , _index_manager(*this)
     , _counter_cell_locks(_schema->is_counter() ? std::make_unique<cell_locker>(_schema, cl_stats) : nullptr)


### PR DESCRIPTION
Users can change `durable_writes` anytime with ALTER KEYSPACE.
Cassandra reads the value of `durable_writes` every time when applying
a mutation, so changes to that setting take effect immediately. That is,
mutations are added to the commitlog only when `durable_writes` is `true`
at the moment of their application.
Scylla reads the value of `durable_writes` only at `keyspace` construction time,
so changes to that setting take effect only after Scylla is restarted.
This patch fixes the inconsistency.

Fixes #3034