### PR TITLE
test: gossip_test: configure database memory allocation correctly

### DIFF
--- a/test/boost/gossip_test.cc
+++ b/test/boost/gossip_test.cc
@@ -47,6 +47,7 @@ SEASTAR_TEST_CASE(test_boot_shutdown){
     return seastar::async([] {
         distributed<database> db;
         database_config dbcfg;
+        dbcfg.available_memory = memory::stats().total_memory();
         auto cfg = std::make_unique<db::config>();
         sharded<service::migration_notifier> mm_notif;
         sharded<abort_source> abort_sources;


### PR DESCRIPTION
The memory configuration for the database object was left at zero.
This can cause the following chain of failures:
 - the test is a little slow due to the machine being overloaded,
   and debug mode
 - this causes the memtable flush_controller timer to fire before
   the test completes
 - the backlog computation callback is called
 - this calculates the backlog as dirty_memory / total_memory; this
   is 0.0/0.0, which resolves to NaN
 - eventually this gets converted to an integer
 - UBSAN dooesn't like the convertion from NaN to integer, and complains

Fix by initializing dbcfg.available_memory.

Test: gossip_test(debug), 1000 repetitions with concurrency 6