### PR TITLE
dbuild: Replace stray use of `docker` with `$tool`

### DIFF
--- a/tools/toolchain/dbuild
+++ b/tools/toolchain/dbuild
@@ -205,7 +205,7 @@ container=$(
 
 kill_it() {
     if [[ -n "$container" ]]; then
-        docker rm -f "$container" > /dev/null
+        $tool rm -f "$container" > /dev/null
         container=
     fi
     cleanup


### PR DESCRIPTION
Instead of invoking `$tool`, as is done everywhere else in dbuild,
kill_it() invoked `docker` explicitly. This was slightly breaking the
script for DBUILD_TOOL other than `docker`.