### PR TITLE
dbuild: export $HOME seen by dbuild, not by $tool

### DIFF
--- a/tools/toolchain/dbuild
+++ b/tools/toolchain/dbuild
@@ -172,7 +172,7 @@ docker_common_args+=(
        -v "$MAVEN_LOCAL_REPO:$MAVEN_LOCAL_REPO:z" \
        -v /etc/localtime:/etc/localtime:ro \
        -w "$PWD" \
-       -e HOME \
+       -e HOME="$HOME" \
        "${docker_args[@]}" \
        "$image" \
        "${args[@]}"


### PR DESCRIPTION
The default of DBUILD_TOOL=docker requires passwordless access to docker
by the user of dbuild. This is insecure, as any user with unconstrained
access to docker is root equivalent. Therefore, users might prefer to
run docker as root (e.g. by setting DBUILD_TOOL="sudo docker").

However, `$tool -e HOME` exports HOME as seen by $tool.
This breaks dbuild when `$tool` runs docker as a another user.
`$tool -e HOME="$HOME"` exports HOME as seen by dbuild, which is
the intended behaviour.