### PR TITLE
db: degrade view building progress loading error to warning

### DIFF
--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -2051,7 +2051,7 @@ future<std::vector<view_build_progress>> load_view_build_progress() {
         }
         return progress;
     }).handle_exception([] (const std::exception_ptr& eptr) {
-        slogger.error("Failed to load view build progress: {}", eptr);
+        slogger.warn("Failed to load view build progress: {}", eptr);
         return std::vector<view_build_progress>();
     });
 }


### PR DESCRIPTION
When the view builder cannot read view building progress from an
internal CQL table it produces an error message, but that only confuses
the user and the test suite -- this situation is entirely recoverable,
because the builder simply assumes that there is no progress and the
view building should start from scratch.

Fixes #7527