### PR TITLE
dht: filter out empty ranges from selective_token_range_sharder

### DIFF
--- a/dht/sharder.hh
+++ b/dht/sharder.hh
@@ -129,6 +129,7 @@ public:
 
 // Incrementally divides a `partition_range` into sub-ranges wholly owned by a single shard.
 // Unlike ring_position_range_sharder, it only returns result for a shard number provided by the caller.
+// Skips ranges which contain no tokens.
 class selective_token_range_sharder {
     const sharder& _sharder;
     dht::token_range _range;


### PR DESCRIPTION
Sometimes selective_token_range_sharder generated ranges such as
(x, x+1). They contain no tokens and generating them was a waste
of resources (for example, repair would start an instance on the
empty range).
This patch filters out ranges of the form (x, x+1).

Fixes #5374