### PR TITLE
dist/debian: fix typo for scylla-server.service filename

### DIFF
--- a/dist/debian/debian_files_gen.py
+++ b/dist/debian/debian_files_gen.py
@@ -54,7 +54,7 @@ shutil.copytree('dist/debian/debian', 'build/debian/debian')
 if product != 'scylla':
     for p in Path('build/debian/debian').glob('scylla-*'):
         if str(p).endswith('scylla-server.service'):
-            p.rename(p.parent / '{}-server.'.format(product, p.name))
+            p.rename(p.parent / '{}-server.{}'.format(product, p.name))
         else:
             p.rename(p.parent / p.name.replace('scylla-', f'{product}-'))
 


### PR DESCRIPTION
Currently debian_files_gen.py mistakenly renames scylla-server.service to
"scylla-server." on non-standard product name environment such as
scylla-enterprise, it should be fix to correct filename.

Fixes #7423 