### PR TITLE
Add product aware build

### DIFF
--- a/reloc/build_reloc.sh
+++ b/reloc/build_reloc.sh
@@ -59,6 +59,13 @@ done
 
 FLAGS="$FLAGS"
 
+# configure.py will run SCYLLA-VERSION-GEN prior to this case
+# but just in case...
+if [ ! -f build/SCYLLA-PRODUCT-FILE ]; then
+    ./SCYLLA-VERSION-GEN
+fi
+PRODUCT=`cat build/SCYLLA-PRODUCT-FILE`
+
 if [ ! -e reloc/build_reloc.sh ]; then
     echo "run build_reloc.sh in top of scylla dir"
     exit 1
@@ -68,8 +75,8 @@ if [ "$CLEAN" = "yes" ]; then
     rm -rf build
 fi
 
-if [ -f build/$MODE/scylla-package.tar.gz ]; then
-    rm build/$MODE/scylla-package.tar.gz
+if [ -f build/$MODE/$PRODUCT-package.tar.gz ]; then
+    rm build/$MODE/$PRODUCT-package.tar.gz
 fi
 
 NINJA=$(which ninja-build) &&:
@@ -91,7 +98,7 @@ fi
 echo "Configuring with flags: '$FLAGS' ..."
 ./configure.py $FLAGS
 python3 -m compileall ./dist/common/scripts/ ./seastar/scripts/perftune.py ./tools/scyllatop
-$NINJA $JOBS build/$MODE/scylla-package.tar.gz
+$NINJA $JOBS build/$MODE/$PRODUCT-package.tar.gz
 BUILD_ID_END=$(readelf -SW build/$MODE/scylla | perl -ne '/.note.gnu.build-id *NOTE *[a-f,0-9]* *([a-f,0-9]*) *([a-f,0-9]*)/ && print ((hex $1) + (hex $2))')
 if (($BUILD_ID_END > 4096))
 then

--- a/unified/build_unified.sh
+++ b/unified/build_unified.sh
@@ -27,8 +27,15 @@ print_usage() {
     exit 1
 }
 
+# configure.py will run SCYLLA-VERSION-GEN prior to this case
+# but just in case...
+if [ ! -f build/SCYLLA-PRODUCT-FILE ]; then
+    ./SCYLLA-VERSION-GEN
+fi
+PRODUCT=`cat build/SCYLLA-PRODUCT-FILE`
+
 MODE="release"
-UNIFIED_PKG="build/release/scylla-unified-package.tar.gz"
+UNIFIED_PKG="build/release/$PRODUCT-unified-package.tar.gz"
 while [ $# -gt 0 ]; do
     case "$1" in
         "--mode")
@@ -46,7 +53,7 @@ while [ $# -gt 0 ]; do
 done
 
 UNIFIED_PKG="$(realpath -s $UNIFIED_PKG)"
-PKGS="build/$MODE/dist/tar/scylla-package.tar.gz build/$MODE/dist/tar/scylla-python3-package.tar.gz build/$MODE/dist/tar/scylla-jmx-package.tar.gz build/$MODE/dist/tar/scylla-tools-package.tar.gz"
+PKGS="build/$MODE/dist/tar/$PRODUCT-package.tar.gz build/$MODE/dist/tar/$PRODUCT-python3-package.tar.gz build/$MODE/dist/tar/$PRODUCT-jmx-package.tar.gz build/$MODE/dist/tar/$PRODUCT-tools-package.tar.gz"
 
 rm -rf build/"$MODE"/unified/
 mkdir -p build/"$MODE"/unified/
@@ -59,6 +66,7 @@ for pkg in $PKGS; do
     pkg="$(readlink -f $pkg)"
     tar -C build/"$MODE"/unified/ -xpf "$pkg"
     dirname=$(basename "$pkg"| sed -e "s/-package.tar.gz//")
+    dirname=${dirname/#$PRODUCT/scylla}
     if [ ! -d build/"$MODE"/unified/"$dirname" ]; then
         echo "Directory $dirname not found in $pkg, the pacakge may corrupted."
         exit 1


### PR DESCRIPTION
This commit changes the build file generation and the package
creation scripts to be product aware. This will change the
relocatable package archives to be named after the product,
this commit deals with two main things:
1. Creting the actual scylla server relocatable with a product
prefixed name - which is independent of any other change
2. Expect all other packages to create product prefixed archive -
which is dependant uppon the actual submodules creating
product prefixed archives.

If the support is not introduced in the submodules first this
will break the package build.

Tests: scylla full build with the original product and a
different product names.