### PR TITLE
secondary_index: Fix TOKEN() handling when combined with index-supported restriction

### DIFF
--- a/cql3/expr/expression.hh
+++ b/cql3/expr/expression.hh
@@ -226,6 +226,9 @@ extern bool is_on_collection(const binary_operator&);
 /// column_value.
 extern expression replace_column_def(const expression&, const column_definition*);
 
+/// Replaces every token in an expression with the given column_definition.
+extern expression replace_token(const expression&, const column_definition*);
+
 inline oper_t pick_operator(statements::bound b, bool inclusive) {
     return is_start(b) ?
             (inclusive ? oper_t::GTE : oper_t::GT) :

--- a/cql3/statements/select_statement.hh
+++ b/cql3/statements/select_statement.hh
@@ -175,9 +175,19 @@ public:
 };
 
 class indexed_table_select_statement : public select_statement {
+public:
+    // Struct which stores data related to global index,
+    // computed on the prepare stage
+    struct global_index_prepare_data {
+        // Column definition of computed token column in global index view
+        const column_definition& _token_cdef;
+    };
+
+private:
     secondary_index::index _index;
     ::shared_ptr<restrictions::restrictions> _used_index_restrictions;
     schema_ptr _view_schema;
+    std::optional<global_index_prepare_data> _global_index_prepare_data;
     noncopyable_function<dht::partition_range_vector(const query_options&)> _get_partition_ranges_for_posting_list;
     noncopyable_function<query::partition_slice(const query_options&)> _get_partition_slice_for_posting_list;
 public:
@@ -207,7 +217,8 @@ public:
                                    cql_stats &stats,
                                    const secondary_index::index& index,
                                    ::shared_ptr<restrictions::restrictions> used_index_restrictions,
-                                   schema_ptr view_schema);
+                                   schema_ptr view_schema,
+                                   std::optional<global_index_prepare_data> global_index_prepare_data);
 
 private:
     virtual future<::shared_ptr<cql_transport::messages::result_message>> do_execute(service::storage_proxy& proxy,

--- a/cql3/statements/select_statement.hh
+++ b/cql3/statements/select_statement.hh
@@ -54,6 +54,7 @@
 #include <seastar/core/distributed.hh>
 #include "validation.hh"
 #include "transport/messages/result_message.hh"
+#include "cql3/restrictions/single_column_primary_key_restrictions.hh"
 
 namespace cql3 {
 
@@ -181,6 +182,12 @@ public:
     struct global_index_prepare_data {
         // Column definition of computed token column in global index view
         const column_definition& _token_cdef;
+
+        // Will global posting list partition be sliced according to base query TOKEN restriction
+        bool _is_token_partition_slice;
+
+        // Clustering restrictions of global posting list precomputed at prepare stage
+        shared_ptr<restrictions::single_column_clustering_key_restrictions> _posting_list_clustering_restrictions;
     };
 
 private:


### PR DESCRIPTION
Fixes `TOKEN(...)` restrictions handling in `SELECTs` when combined with global secondary index supported restriction, for example:
```
CREATE TABLE t(pk int, ck int, v int, PRIMARY KEY(pk, ck));
CREATE INDEX ON t(v);
SELECT * FROM t WHERE v = 5 AND token(pk) < 0 ALLOW FILTERING;
```

This PR does not change when `ALLOW FILTERING` clause is required, because there are multiple opinions on when it should be required. 

This functionality is only supported on new indexes (those with `token_v2` column computation). In case of running on a old index, the old behaviour is not changed (returning the same invalid data).

Adds unit tests to validate various `SELECT`s with `TOKEN` restrictions.

Adds new `global_index_prepare_data` structure which stores data related to global index that was computed on `prepare` stage.

Fixes #7043.