### PR TITLE
Add more overload-related metrics

### DIFF
--- a/database.cc
+++ b/database.cc
@@ -456,6 +456,11 @@ database::setup_metrics() {
                                        " to be able to admit new ones, if there is a shortage of permits."),
                        {user_label_instance}),
 
+        sm::make_derive("reads_shed_due_to_overload", _read_concurrency_sem.get_stats().total_reads_shed_due_to_overload,
+                       sm::description("The number of reads shed because the admission queue reached its max capacity."
+                                       " When the queue is full, excessive reads are shed to avoid overload."),
+                       {user_label_instance}),
+
         sm::make_gauge("active_reads", [this] { return max_count_streaming_concurrent_reads - _streaming_concurrency_sem.available_resources().count; },
                        sm::description("Holds the number of currently active read operations issued on behalf of streaming "),
                        {streaming_label_instance}),
@@ -481,6 +486,11 @@ database::setup_metrics() {
                                        " to be able to admit new ones, if there is a shortage of permits."),
                        {streaming_label_instance}),
 
+        sm::make_derive("reads_shed_due_to_overload", _streaming_concurrency_sem.get_stats().total_reads_shed_due_to_overload,
+                       sm::description("The number of reads shed because the admission queue reached its max capacity."
+                                       " When the queue is full, excessive reads are shed to avoid overload."),
+                       {streaming_label_instance}),
+
         sm::make_gauge("active_reads", [this] { return max_count_system_concurrent_reads - _system_read_concurrency_sem.available_resources().count; },
                        sm::description("Holds the number of currently active read operations from \"system\" keyspace tables. "),
                        {system_label_instance}),
@@ -503,6 +513,11 @@ database::setup_metrics() {
                        sm::description("The number of paused system reads evicted to free up permits"
                                        " Permits are required for new reads to start, and the database will evict inactive reads (if any)"
                                        " to be able to admit new ones, if there is a shortage of permits."),
+                       {system_label_instance}),
+
+        sm::make_derive("reads_shed_due_to_overload", _system_read_concurrency_sem.get_stats().total_reads_shed_due_to_overload,
+                       sm::description("The number of reads shed because the admission queue reached its max capacity."
+                                       " When the queue is full, excessive reads are shed to avoid overload."),
                        {system_label_instance}),
 
         sm::make_gauge("total_result_bytes", [this] { return get_result_memory_limiter().total_used_memory(); },

--- a/reader_concurrency_semaphore.cc
+++ b/reader_concurrency_semaphore.cc
@@ -436,6 +436,7 @@ bool reader_concurrency_semaphore::may_proceed(const resources& r) const {
 future<reader_permit::resource_units> reader_concurrency_semaphore::do_wait_admission(reader_permit permit, size_t memory,
         db::timeout_clock::time_point timeout) {
     if (_wait_list.size() >= _max_queue_length) {
+        _stats.total_reads_shed_due_to_overload++;
         if (_prethrow_action) {
             _prethrow_action();
         }

--- a/reader_concurrency_semaphore.hh
+++ b/reader_concurrency_semaphore.hh
@@ -91,6 +91,8 @@ public:
         uint64_t total_successful_reads = 0;
         // Total number of failed reads executed through this semaphore.
         uint64_t total_failed_reads = 0;
+        // Total number of reads rejected because the admission queue reached its max capacity
+        uint64_t total_reads_shed_due_to_overload = 0;
     };
 
     struct permit_list;

--- a/service/storage_proxy_stats.hh
+++ b/service/storage_proxy_stats.hh
@@ -111,6 +111,7 @@ struct write_stats {
     uint64_t throttled_writes = 0; // total number of writes ever delayed due to throttling
     uint64_t throttled_base_writes = 0; // current number of base writes delayed due to view update backlog
     uint64_t background_writes_failed = 0;
+    uint64_t writes_failed_due_to_too_many_in_flight_hints = 0;
 
     uint64_t cas_write_unfinished_commit = 0;
     uint64_t cas_write_condition_not_met = 0;


### PR DESCRIPTION
This miniseries adds metrics which can help the users detect potential overloads:
 * due to having too many in-flight hints
 * due to exceeding the capacity of the read admission queue, on replica side