### PR TITLE
scylla_util.py: properly parse GCP instances without size

### DIFF
--- a/dist/common/scripts/scylla_util.py
+++ b/dist/common/scripts/scylla_util.py
@@ -234,7 +234,8 @@ class gcp_instance:
 
     def instance_size(self):
         """Returns the size of the instance we are running in. i.e.: 2"""
-        return self.instancetype.split("-")[2]
+        instancetypesplit = self.instancetype.split("-")
+        return instancetypesplit[2] if len(instancetypesplit)>2 else 0
 
     def instance_class(self):
         """Returns the class of the instance we are running in. i.e.: n2"""
@@ -296,7 +297,7 @@ class gcp_instance:
         return self.__firstNvmeSize
 
     def is_recommended_instance(self):
-        if self.is_recommended_instance_size() and not self.is_unsupported_instance_class() and self.is_supported_instance_class():
+        if not self.is_unsupported_instance_class() and self.is_supported_instance_class() and self.is_recommended_instance_size():
             # at least 1:2GB cpu:ram ratio , GCP is at 1:4, so this should be fine
             if self.cpu/self.memoryGB < 0.5:
               # 30:1 Disk/RAM ratio must be kept at least(AWS), we relax this a little bit


### PR DESCRIPTION
fixes #7577