### PR TITLE
Allow ALTERing the properties of system_auth tables

### DIFF
--- a/auth/authenticator.hh
+++ b/auth/authenticator.hh
@@ -64,6 +64,8 @@ namespace db {
     class config;
 }
 
+namespace cql3::statements { class schema_altering_statement; }
+
 namespace auth {
 
 class authenticated_user;
@@ -149,6 +151,9 @@ public:
     /// System resources used internally as part of the implementation. These are made inaccessible to users.
     ///
     virtual const resource_set& protected_resources() const = 0;
+
+    /// True iff alteration is safe for continuous functioning of this authenticator.
+    virtual bool safe(const cql3::statements::schema_altering_statement&) const { return true; }
 
     virtual ::shared_ptr<sasl_challenge> new_sasl_challenge() const = 0;
 };

--- a/auth/authorizer.hh
+++ b/auth/authorizer.hh
@@ -55,6 +55,8 @@
 #include "auth/resource.hh"
 #include "seastarx.hh"
 
+namespace cql3::statements { class schema_altering_statement; }
+
 namespace auth {
 
 class role_or_anonymous;
@@ -150,6 +152,9 @@ public:
     /// System resources used internally as part of the implementation. These are made inaccessible to users.
     ///
     virtual const resource_set& protected_resources() const = 0;
+
+    /// True iff alteration is safe for continuous functioning of this authorizer.
+    virtual bool safe(const cql3::statements::schema_altering_statement&) const { return true; }
 };
 
 }

--- a/auth/default_authorizer.cc
+++ b/auth/default_authorizer.cc
@@ -58,6 +58,7 @@ extern "C" {
 #include "auth/permission.hh"
 #include "auth/role_or_anonymous.hh"
 #include "cql3/query_processor.hh"
+#include "cql3/statements/schema_altering_statement.hh"
 #include "cql3/untyped_result_set.hh"
 #include "exceptions/exceptions.hh"
 #include "log.hh"
@@ -336,6 +337,10 @@ future<> default_authorizer::revoke_all(const resource& resource) const {
 const resource_set& default_authorizer::protected_resources() const {
     static const resource_set resources({ make_data_resource(meta::AUTH_KS, PERMISSIONS_CF) });
     return resources;
+}
+
+bool default_authorizer::safe(const cql3::statements::schema_altering_statement& stmt) const {
+    return !protected_resources().contains(make_data_resource(stmt.keyspace(), stmt.column_family()));
 }
 
 }

--- a/auth/default_authorizer.hh
+++ b/auth/default_authorizer.hh
@@ -85,6 +85,8 @@ public:
 
     virtual const resource_set& protected_resources() const override;
 
+    bool safe(const cql3::statements::schema_altering_statement&) const override;
+
 private:
     bool legacy_metadata_exists() const;
 

--- a/auth/password_authenticator.cc
+++ b/auth/password_authenticator.cc
@@ -54,6 +54,7 @@
 #include "auth/common.hh"
 #include "auth/passwords.hh"
 #include "auth/roles-metadata.hh"
+#include "cql3/statements/schema_altering_statement.hh"
 #include "cql3/untyped_result_set.hh"
 #include "log.hh"
 #include "service/migration_manager.hh"
@@ -310,6 +311,10 @@ future<custom_options> password_authenticator::query_custom_options(std::string_
 const resource_set& password_authenticator::protected_resources() const {
     static const resource_set resources({make_data_resource(meta::AUTH_KS, meta::roles_table::name)});
     return resources;
+}
+
+bool password_authenticator::safe(const cql3::statements::schema_altering_statement& stmt) const {
+    return !protected_resources().contains(make_data_resource(stmt.keyspace(), stmt.column_family()));
 }
 
 ::shared_ptr<sasl_challenge> password_authenticator::new_sasl_challenge() const {

--- a/auth/password_authenticator.hh
+++ b/auth/password_authenticator.hh
@@ -91,6 +91,8 @@ public:
 
     virtual const resource_set& protected_resources() const override;
 
+    bool safe(const cql3::statements::schema_altering_statement&) const override;
+
     virtual ::shared_ptr<sasl_challenge> new_sasl_challenge() const override;
 
 private:

--- a/auth/role_manager.hh
+++ b/auth/role_manager.hh
@@ -35,6 +35,8 @@
 #include "seastarx.hh"
 #include "exceptions/exceptions.hh"
 
+namespace cql3::statements { class schema_altering_statement; }
+
 namespace auth {
 
 struct role_config final {
@@ -107,6 +109,9 @@ public:
     virtual std::string_view qualified_java_name() const noexcept = 0;
 
     virtual const resource_set& protected_resources() const = 0;
+
+    /// True iff alteration is safe for continuous functioning of this role manager.
+    virtual bool safe(const cql3::statements::schema_altering_statement&) const { return true; }
 
     virtual future<> start() = 0;
 

--- a/auth/service.cc
+++ b/auth/service.cc
@@ -371,12 +371,6 @@ bool is_enforcing(const service& ser)  {
     return enforcing_authorizer || enforcing_authenticator;
 }
 
-bool is_protected(const service& ser, const resource& r) noexcept {
-    return ser.underlying_role_manager().protected_resources().contains(r)
-            || ser.underlying_authenticator().protected_resources().contains(r)
-            || ser.underlying_authorizer().protected_resources().contains(r);
-}
-
 static void validate_authentication_options_are_supported(
         const authentication_options& options,
         const authentication_option_set& supported) {

--- a/auth/service.hh
+++ b/auth/service.hh
@@ -182,11 +182,6 @@ future<permission_set> get_permissions(const service&, const authenticated_user&
 bool is_enforcing(const service&);
 
 ///
-/// Protected resources cannot be modified even if the performer has permissions to do so.
-///
-bool is_protected(const service&, const resource&) noexcept;
-
-///
 /// Create a role with optional authentication information.
 ///
 /// \returns an exceptional future with \ref role_already_exists if the user or role exists.

--- a/auth/standard_role_manager.cc
+++ b/auth/standard_role_manager.cc
@@ -35,6 +35,7 @@
 #include "auth/common.hh"
 #include "auth/roles-metadata.hh"
 #include "cql3/query_processor.hh"
+#include "cql3/statements/schema_altering_statement.hh"
 #include "cql3/untyped_result_set.hh"
 #include "db/consistency_level_type.hh"
 #include "exceptions/exceptions.hh"
@@ -130,6 +131,10 @@ const resource_set& standard_role_manager::protected_resources() const {
             make_data_resource(meta::AUTH_KS, meta::role_members_table::name)});
 
     return resources;
+}
+
+bool standard_role_manager::safe(const cql3::statements::schema_altering_statement& stmt) const {
+    return !protected_resources().contains(make_data_resource(stmt.keyspace(), stmt.column_family()));
 }
 
 future<> standard_role_manager::create_metadata_tables_if_missing() const {

--- a/auth/standard_role_manager.hh
+++ b/auth/standard_role_manager.hh
@@ -59,6 +59,8 @@ public:
 
     virtual const resource_set& protected_resources() const override;
 
+    bool safe(const cql3::statements::schema_altering_statement&) const override;
+
     virtual future<> start() override;
 
     virtual future<> stop() override;

--- a/auth/transitional.cc
+++ b/auth/transitional.cc
@@ -137,6 +137,10 @@ public:
         return _authenticator->protected_resources();
     }
 
+    bool safe(const cql3::statements::schema_altering_statement& s) const override {
+        return _authenticator->safe(s);
+    }
+
     virtual ::shared_ptr<sasl_challenge> new_sasl_challenge() const override {
         class sasl_wrapper : public sasl_challenge {
         public:

--- a/cql3/statements/alter_table_statement.hh
+++ b/cql3/statements/alter_table_statement.hh
@@ -78,6 +78,7 @@ public:
                           shared_ptr<cf_prop_defs> properties,
                           renames_type renames);
 
+    type get_type() const { return _type; }
     virtual future<> check_access(service::storage_proxy& proxy, const service::client_state& state) const override;
     virtual void validate(service::storage_proxy& proxy, const service::client_state& state) const override;
     virtual future<shared_ptr<cql_transport::event::schema_change>> announce_migration(service::storage_proxy& proxy, bool is_local_only) const override;

--- a/cql3/statements/drop_table_statement.cc
+++ b/cql3/statements/drop_table_statement.cc
@@ -58,7 +58,15 @@ future<> drop_table_statement::check_access(service::storage_proxy& proxy, const
 {
     // invalid_request_exception is only thrown synchronously.
     try {
-        return state.has_column_family_access(keyspace(), column_family(), auth::permission::DROP);
+        return state.has_column_family_access(keyspace(), column_family(), auth::permission::DROP).then([this, &state] {
+            const auto table = column_family();
+            if (!state.get_auth_service()->underlying_role_manager().safe(*this) ||
+                !state.get_auth_service()->underlying_authenticator().safe(*this) ||
+                !state.get_auth_service()->underlying_authorizer().safe(*this)) {
+                throw exceptions::unauthorized_exception(format("{} is protected", table));
+            }
+            return make_ready_future();
+        });
     } catch (exceptions::invalid_request_exception&) {
         if (!_if_exists) {
             throw;

--- a/service/client_state.cc
+++ b/service/client_state.cc
@@ -187,11 +187,6 @@ future<> service::client_state::has_access(const sstring& ks, auth::permission p
     if (p == auth::permission::SELECT && readable_system_resources.contains(resource)) {
         return make_ready_future();
     }
-    if (alteration_permissions.contains(p)) {
-        if (auth::is_protected(*_auth_service, resource)) {
-            throw exceptions::unauthorized_exception(format("{} is protected", resource));
-        }
-    }
 
     if (service::get_local_storage_service().db().local().features().cluster_supports_cdc() && resource.kind() == auth::resource_kind::data) {
         const auto resource_view = auth::data_resource_view(resource);

--- a/test/boost/auth_test.cc
+++ b/test/boost/auth_test.cc
@@ -203,3 +203,13 @@ SEASTAR_TEST_CASE(role_permissions_table_is_protected) {
         require_table_protected(env, "system_auth.role_permissions");
     }, cfg);
 }
+
+SEASTAR_TEST_CASE(alter_opts_on_system_auth_tables) {
+    cql_test_config cfg;
+    cfg.db_config->authorizer("CassandraAuthorizer");
+    return do_with_cql_env_thread([] (cql_test_env& env) {
+        cquery_nofail(env, "ALTER TABLE system_auth.roles WITH speculative_retry = 'NONE'");
+        cquery_nofail(env, "ALTER TABLE system_auth.role_members WITH gc_grace_seconds = 123");
+        cquery_nofail(env, "ALTER TABLE system_auth.role_permissions WITH min_index_interval = 456");
+    }, cfg);
+}

--- a/test/boost/auth_test.cc
+++ b/test/boost/auth_test.cc
@@ -33,6 +33,7 @@
 #include <seastar/testing/test_case.hh>
 #include "test/lib/cql_test_env.hh"
 #include "test/lib/cql_assertions.hh"
+#include "test/lib/exception_utils.hh"
 
 #include "auth/allow_all_authenticator.hh"
 #include "auth/authenticator.hh"
@@ -164,5 +165,41 @@ SEASTAR_TEST_CASE(test_password_authenticator_operations) {
                 return require_throws<exceptions::authentication_exception>(authenticate(env, username, password));
             });
         });
+    }, cfg);
+}
+
+namespace {
+
+/// Asserts that table is protected from alterations that can brick a node.
+void require_table_protected(cql_test_env& env, const char* table) {
+    using exception_predicate::message_contains;
+    using unauth = exceptions::unauthorized_exception;
+    const auto q = [&] (const char* stmt) { return env.execute_cql(fmt::format(stmt, table)).get(); };
+    BOOST_TEST_INFO(table);
+    BOOST_REQUIRE_EXCEPTION(q("ALTER TABLE {} ALTER role TYPE blob"), unauth, message_contains("is protected"));
+    BOOST_REQUIRE_EXCEPTION(q("ALTER TABLE {} RENAME role TO user"), unauth, message_contains("is protected"));
+    BOOST_REQUIRE_EXCEPTION(q("ALTER TABLE {} DROP role"), unauth, message_contains("is protected"));
+    BOOST_REQUIRE_EXCEPTION(q("DROP TABLE {}"), unauth, message_contains("is protected"));
+}
+
+} // anonymous namespace
+
+SEASTAR_TEST_CASE(roles_table_is_protected) {
+    return do_with_cql_env_thread([] (cql_test_env& env) {
+        require_table_protected(env, "system_auth.roles");
+    });
+}
+
+SEASTAR_TEST_CASE(role_members_table_is_protected) {
+    return do_with_cql_env_thread([] (cql_test_env& env) {
+        require_table_protected(env, "system_auth.role_members");
+    });
+}
+
+SEASTAR_TEST_CASE(role_permissions_table_is_protected) {
+    cql_test_config cfg;
+    cfg.db_config->authorizer("CassandraAuthorizer");
+    return do_with_cql_env_thread([] (cql_test_env& env) {
+        require_table_protected(env, "system_auth.role_permissions");
     }, cfg);
 }


### PR DESCRIPTION
As requested in #7057, allow certain alterations of system_auth tables.  Potentially destructive alterations are still rejected.

Tests: unit (dev)