### PR TITLE
db,view: degrade helper message from error to warn

### DIFF
--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -193,7 +193,7 @@ db::view::base_info_ptr view_info::make_base_dependent_view_info(const schema& b
             vlogger.error("Column {} in view {}.{} was not found in the base table {}.{}",
                     to_sstring_view(view_col_name), _schema.ks_name(), _schema.cf_name(), base.ks_name(), base.cf_name());
             if (to_sstring_view(view_col_name) == "idx_token") {
-                vlogger.error("Missing idx_token column is caused by an incorrect upgrade of a secondary index. "
+                vlogger.warn("Missing idx_token column is caused by an incorrect upgrade of a secondary index. "
                         "Please recreate index {}.{} to avoid future issues.", _schema.ks_name(), _schema.cf_name());
             }
             // If we didn't find the column in the base column then it must have been deleted


### PR DESCRIPTION
When a missing base column happens to be named `idx_token`,
an additional helper message is printed in logs.
This additional message does not need to have `error` severity,
since the previous, generic message is already marked as `error`.
This patch simply makes it easier to write tests, because in case
this error is expected, only one message needs to be explicitly
ignored instead of two.