### PR TITLE
cql_metrics: Add metrics for CQL errors

### DIFF
--- a/exceptions/exceptions.cc
+++ b/exceptions/exceptions.cc
@@ -44,6 +44,35 @@
 #include "exceptions.hh"
 #include "log.hh"
 
-exceptions::truncate_exception::truncate_exception(std::exception_ptr ep)
+namespace exceptions {
+
+truncate_exception::truncate_exception(std::exception_ptr ep)
     : request_execution_exception(exceptions::exception_code::TRUNCATE_ERROR, format("Error during truncate: {}", ep))
 {}
+
+const std::unordered_map<exception_code, sstring>& exception_map() {
+    static const std::unordered_map<exception_code, sstring> map {
+        {exception_code::SERVER_ERROR, "server_error"},
+        {exception_code::PROTOCOL_ERROR, "protocol_error"},
+        {exception_code::BAD_CREDENTIALS, "authentication"},
+        {exception_code::UNAVAILABLE, "unavailable"},
+        {exception_code::OVERLOADED, "overloaded"},
+        {exception_code::IS_BOOTSTRAPPING, "is_bootstrapping"},
+        {exception_code::TRUNCATE_ERROR, "truncate_error"},
+        {exception_code::WRITE_TIMEOUT, "write_timeout"},
+        {exception_code::READ_TIMEOUT, "read_timeout"},
+        {exception_code::READ_FAILURE, "read_failure"},
+        {exception_code::FUNCTION_FAILURE, "function_failure"},
+        {exception_code::WRITE_FAILURE, "write_failure"},
+        {exception_code::CDC_WRITE_FAILURE, "cdc_write_failure"},
+        {exception_code::SYNTAX_ERROR, "syntax_error"},
+        {exception_code::UNAUTHORIZED, "unathorized"},
+        {exception_code::INVALID, "invalid"},
+        {exception_code::CONFIG_ERROR, "config_error"},
+        {exception_code::ALREADY_EXISTS, "already_exists"},
+        {exception_code::UNPREPARED, "unprepared"}
+    };
+    return map;
+}
+
+}

--- a/exceptions/exceptions.hh
+++ b/exceptions/exceptions.hh
@@ -77,6 +77,8 @@ enum class exception_code : int32_t {
     UNPREPARED      = 0x2500
 };
 
+const std::unordered_map<exception_code, sstring>& exception_map();
+
 class cassandra_exception : public std::exception {
 private:
     exception_code _code;

--- a/transport/server.hh
+++ b/transport/server.hh
@@ -136,6 +136,8 @@ private:
         uint64_t execute_requests;
         uint64_t batch_requests;
         uint64_t register_requests;
+
+        std::unordered_map<exceptions::exception_code, uint64_t> errors;
     };
 private:
     class event_notifier;


### PR DESCRIPTION
This change adds tracking of all the CQL errors that can be
raised in response to a CQL message from a client, as described
in the CQL v4 protocol and with Scylla's CDC_WRITE_FAILUREs
included.

Fixes #5859