### PR TITLE
Allow ALTERing the properties of system_auth tables

### DIFF
--- a/auth/service.cc
+++ b/auth/service.cc
@@ -372,6 +372,9 @@ bool is_enforcing(const service& ser)  {
 }
 
 bool is_protected(const service& ser, command_desc cmd) noexcept {
+    if (cmd.type_ == command_desc::type::ALTER_WITH_OPTS) {
+        return false; // Table attributes are OK to modify; see #7057.
+    }
     return ser.underlying_role_manager().protected_resources().contains(cmd.resource)
             || ser.underlying_authenticator().protected_resources().contains(cmd.resource)
             || ser.underlying_authorizer().protected_resources().contains(cmd.resource);

--- a/auth/service.cc
+++ b/auth/service.cc
@@ -371,10 +371,10 @@ bool is_enforcing(const service& ser)  {
     return enforcing_authorizer || enforcing_authenticator;
 }
 
-bool is_protected(const service& ser, const resource& r) noexcept {
-    return ser.underlying_role_manager().protected_resources().contains(r)
-            || ser.underlying_authenticator().protected_resources().contains(r)
-            || ser.underlying_authorizer().protected_resources().contains(r);
+bool is_protected(const service& ser, command_desc cmd) noexcept {
+    return ser.underlying_role_manager().protected_resources().contains(cmd.resource)
+            || ser.underlying_authenticator().protected_resources().contains(cmd.resource)
+            || ser.underlying_authorizer().protected_resources().contains(cmd.resource);
 }
 
 static void validate_authentication_options_are_supported(

--- a/auth/service.hh
+++ b/auth/service.hh
@@ -181,10 +181,17 @@ future<permission_set> get_permissions(const service&, const authenticated_user&
 ///
 bool is_enforcing(const service&);
 
+/// A description of a CQL command from which auth::service can tell whether or not this command could endanger
+/// internal data on which auth::service depends.
+struct command_desc {
+    auth::permission permission; ///< Nature of the command's alteration.
+    const resource& resource; ///< Resource impacted by this command.
+};
+
 ///
 /// Protected resources cannot be modified even if the performer has permissions to do so.
 ///
-bool is_protected(const service&, const resource&) noexcept;
+bool is_protected(const service&, command_desc) noexcept;
 
 ///
 /// Create a role with optional authentication information.

--- a/auth/service.hh
+++ b/auth/service.hh
@@ -186,6 +186,10 @@ bool is_enforcing(const service&);
 struct command_desc {
     auth::permission permission; ///< Nature of the command's alteration.
     const resource& resource; ///< Resource impacted by this command.
+    enum class type {
+        ALTER_WITH_OPTS, ///< Command is ALTER ... WITH ...
+        OTHER
+    } type_ = type::OTHER;
 };
 
 ///

--- a/cql3/statements/alter_table_statement.cc
+++ b/cql3/statements/alter_table_statement.cc
@@ -70,7 +70,9 @@ alter_table_statement::alter_table_statement(shared_ptr<cf_name> name,
 }
 
 future<> alter_table_statement::check_access(service::storage_proxy& proxy, const service::client_state& state) const {
-    return state.has_column_family_access(keyspace(), column_family(), auth::permission::ALTER);
+    using cdt = auth::command_desc::type;
+    return state.has_column_family_access(keyspace(), column_family(), auth::permission::ALTER,
+                                          _type == type::opts ? cdt::ALTER_WITH_OPTS : cdt::OTHER);
 }
 
 void alter_table_statement::validate(service::storage_proxy& proxy, const service::client_state& state) const

--- a/cql3/statements/permission_altering_statement.cc
+++ b/cql3/statements/permission_altering_statement.cc
@@ -78,11 +78,11 @@ future<> cql3::statements::permission_altering_statement::check_access(service::
     return state.ensure_exists(_resource).then([this, &state] {
         // check that the user has AUTHORIZE permission on the resource or its parents, otherwise reject
         // GRANT/REVOKE.
-        return state.ensure_has_permission(auth::permission::AUTHORIZE, _resource).then([this, &state] {
+        return state.ensure_has_permission({auth::permission::AUTHORIZE, _resource}).then([this, &state] {
             return do_for_each(_permissions, [this, &state](auth::permission p) {
                 // TODO: how about we re-write the access check to check a set
                 // right away.
-                return state.ensure_has_permission(p, _resource);
+                return state.ensure_has_permission({p, _resource});
             });
         });
     });

--- a/cql3/statements/role-management-statements.cc
+++ b/cql3/statements/role-management-statements.cc
@@ -113,7 +113,7 @@ future<> create_role_statement::check_access(service::storage_proxy& proxy, cons
     state.ensure_not_anonymous();
 
     return async([this, &state] {
-        state.ensure_has_permission(auth::permission::CREATE, auth::root_role_resource()).get0();
+        state.ensure_has_permission({auth::permission::CREATE, auth::root_role_resource()}).get0();
 
         if (*_options.is_superuser) {
             if (!auth::has_superuser(*state.get_auth_service(), *state.user()).get0()) {
@@ -192,7 +192,7 @@ future<> alter_role_statement::check_access(service::storage_proxy& proxy, const
         }
 
         if (*user.name != _role) {
-            state.ensure_has_permission(auth::permission::ALTER, auth::make_role_resource(_role)).get0();
+            state.ensure_has_permission({auth::permission::ALTER, auth::make_role_resource(_role)}).get0();
         } else {
             const auto alterable_options = state.get_auth_service()->underlying_authenticator().alterable_options();
 
@@ -256,7 +256,7 @@ future<> drop_role_statement::check_access(service::storage_proxy& proxy, const 
     state.ensure_not_anonymous();
 
     return async([this, &state] {
-        state.ensure_has_permission(auth::permission::DROP, auth::make_role_resource(_role)).get0();
+        state.ensure_has_permission({auth::permission::DROP, auth::make_role_resource(_role)}).get0();
 
         auto& as = *state.get_auth_service();
 
@@ -305,7 +305,7 @@ future<> list_roles_statement::check_access(service::storage_proxy& proxy, const
     state.ensure_not_anonymous();
 
     return async([this, &state] {
-        if (state.check_has_permission(auth::permission::DESCRIBE, auth::root_role_resource()).get0()) {
+        if (state.check_has_permission({auth::permission::DESCRIBE, auth::root_role_resource()}).get0()) {
             return;
         }
 
@@ -404,9 +404,9 @@ list_roles_statement::execute(service::storage_proxy&, service::query_state& sta
         if (!_grantee) {
             // A user with DESCRIBE on the root role resource lists all roles in the system. A user without it lists
             // only the roles granted to them.
-            return cs.check_has_permission(
+            return cs.check_has_permission({
                     auth::permission::DESCRIBE,
-                    auth::root_role_resource()).then([&cs, &rm, &a, query_mode](bool has_describe) {
+                    auth::root_role_resource()}).then([&cs, &rm, &a, query_mode](bool has_describe) {
                 if (has_describe) {
                     return rm.query_all().then([&rm, &a](auto&& roles) {
                         return make_results(rm, a, std::move(roles));
@@ -440,7 +440,7 @@ future<> grant_role_statement::check_access(service::storage_proxy& proxy, const
     state.ensure_not_anonymous();
 
     return do_with(auth::make_role_resource(_role), [this, &state](const auto& r) {
-        return state.ensure_has_permission(auth::permission::AUTHORIZE, r);
+        return state.ensure_has_permission({auth::permission::AUTHORIZE, r});
     });
 }
 
@@ -468,7 +468,7 @@ future<> revoke_role_statement::check_access(service::storage_proxy& proxy, cons
     state.ensure_not_anonymous();
 
     return do_with(auth::make_role_resource(_role), [this, &state](const auto& r) {
-        return state.ensure_has_permission(auth::permission::AUTHORIZE, r);
+        return state.ensure_has_permission({auth::permission::AUTHORIZE, r});
     });
 }
 

--- a/service/client_state.cc
+++ b/service/client_state.cc
@@ -118,11 +118,11 @@ future<> service::client_state::has_keyspace_access(const sstring& ks,
 }
 
 future<> service::client_state::has_column_family_access(const sstring& ks,
-                const sstring& cf, auth::permission p) const {
+                const sstring& cf, auth::permission p, auth::command_desc::type t) const {
     validation::validate_column_family(ks, cf);
 
-    return do_with(ks, auth::make_data_resource(ks, cf), [this, p](const auto& ks, const auto& r) {
-        return has_access(ks, {p, r});
+    return do_with(ks, auth::make_data_resource(ks, cf), [this, p, t](const auto& ks, const auto& r) {
+        return has_access(ks, {p, r, t});
     });
 }
 

--- a/service/client_state.hh
+++ b/service/client_state.hh
@@ -311,7 +311,8 @@ public:
 
     future<> has_all_keyspaces_access(auth::permission) const;
     future<> has_keyspace_access(const sstring&, auth::permission) const;
-    future<> has_column_family_access(const sstring&, const sstring&, auth::permission) const;
+    future<> has_column_family_access(const sstring&, const sstring&, auth::permission,
+                                      auth::command_desc::type = auth::command_desc::type::OTHER) const;
     future<> has_schema_access(const schema& s, auth::permission p) const;
 
 private:

--- a/service/client_state.hh
+++ b/service/client_state.hh
@@ -315,11 +315,11 @@ public:
     future<> has_schema_access(const schema& s, auth::permission p) const;
 
 private:
-    future<> has_access(const sstring&, auth::permission, const auth::resource&) const;
+    future<> has_access(const sstring& keyspace, auth::command_desc) const;
 
 public:
-    future<bool> check_has_permission(auth::permission, const auth::resource&) const;
-    future<> ensure_has_permission(auth::permission, const auth::resource&) const;
+    future<bool> check_has_permission(auth::command_desc) const;
+    future<> ensure_has_permission(auth::command_desc) const;
 
     /**
      * Returns an exceptional future with \ref exceptions::invalid_request_exception if the resource does not exist.

--- a/test/boost/auth_test.cc
+++ b/test/boost/auth_test.cc
@@ -208,3 +208,11 @@ SEASTAR_TEST_CASE(role_permissions_table_is_protected) {
         require_table_protected(env, "system_auth.role_permissions");
     }, auth_on());
 }
+
+SEASTAR_TEST_CASE(alter_opts_on_system_auth_tables) {
+    return do_with_cql_env_thread([] (cql_test_env& env) {
+        cquery_nofail(env, "ALTER TABLE system_auth.roles WITH speculative_retry = 'NONE'");
+        cquery_nofail(env, "ALTER TABLE system_auth.role_members WITH gc_grace_seconds = 123");
+        cquery_nofail(env, "ALTER TABLE system_auth.role_permissions WITH min_index_interval = 456");
+    }, auth_on());
+}

--- a/test/boost/auth_test.cc
+++ b/test/boost/auth_test.cc
@@ -33,6 +33,7 @@
 #include <seastar/testing/test_case.hh>
 #include "test/lib/cql_test_env.hh"
 #include "test/lib/cql_assertions.hh"
+#include "test/lib/exception_utils.hh"
 
 #include "auth/allow_all_authenticator.hh"
 #include "auth/authenticator.hh"
@@ -165,4 +166,45 @@ SEASTAR_TEST_CASE(test_password_authenticator_operations) {
             });
         });
     }, cfg);
+}
+
+namespace {
+
+/// Asserts that table is protected from alterations that can brick a node.
+void require_table_protected(cql_test_env& env, const char* table) {
+    using exception_predicate::message_contains;
+    using unauth = exceptions::unauthorized_exception;
+    const auto q = [&] (const char* stmt) { return env.execute_cql(fmt::format(stmt, table)).get(); };
+    BOOST_TEST_INFO(table);
+    BOOST_REQUIRE_EXCEPTION(q("ALTER TABLE {} ALTER role TYPE blob"), unauth, message_contains("is protected"));
+    BOOST_REQUIRE_EXCEPTION(q("ALTER TABLE {} RENAME role TO user"), unauth, message_contains("is protected"));
+    BOOST_REQUIRE_EXCEPTION(q("ALTER TABLE {} DROP role"), unauth, message_contains("is protected"));
+    BOOST_REQUIRE_EXCEPTION(q("DROP TABLE {}"), unauth, message_contains("is protected"));
+}
+
+cql_test_config auth_on() {
+    cql_test_config cfg;
+    cfg.db_config->authorizer("CassandraAuthorizer");
+    cfg.db_config->authenticator("PasswordAuthenticator");
+    return cfg;
+}
+
+} // anonymous namespace
+
+SEASTAR_TEST_CASE(roles_table_is_protected) {
+    return do_with_cql_env_thread([] (cql_test_env& env) {
+        require_table_protected(env, "system_auth.roles");
+    }, auth_on());
+}
+
+SEASTAR_TEST_CASE(role_members_table_is_protected) {
+    return do_with_cql_env_thread([] (cql_test_env& env) {
+        require_table_protected(env, "system_auth.role_members");
+    }, auth_on());
+}
+
+SEASTAR_TEST_CASE(role_permissions_table_is_protected) {
+    return do_with_cql_env_thread([] (cql_test_env& env) {
+        require_table_protected(env, "system_auth.role_permissions");
+    }, auth_on());
 }


### PR DESCRIPTION
As requested in #7057, allow certain alterations of system_auth tables. Potentially destructive alterations are still rejected.

Tests: unit (dev)