### PR TITLE
database: detect misconfigured unit tests that don't set available_memory

### DIFF
--- a/database.cc
+++ b/database.cc
@@ -222,6 +222,8 @@ database::database(const db::config& cfg, database_config dbcfg, service::migrat
     , _shared_token_metadata(stm)
     , _sst_dir_semaphore(sst_dir_sem)
 {
+    assert(dbcfg.available_memory != 0); // Detect misconfigured unit tests, see #7544
+
     local_schema_registry().init(*this); // TODO: we're never unbound.
     setup_metrics();
 


### PR DESCRIPTION
available_memory is used to seed many caches and controllers. Usually
it's detected from the environment, but unit tests configure it
on their own with fake values. If they forget, then the undefined
behavior sanitizer will kick in in random places (see 8aa842614a11
("test: gossip_test: configure database memory allocation correctly")
for an example.

Prevent this early by asserting that available_memory is nonzero.