### PR TITLE
cdc: ensure that CDC generation write is flushed to commitlog before ack

### DIFF
--- a/db/system_distributed_keyspace.cc
+++ b/db/system_distributed_keyspace.cc
@@ -113,6 +113,10 @@ static std::vector<schema_ptr> all_tables() {
     };
 }
 
+bool system_distributed_keyspace::is_extra_durable(const sstring& cf_name) {
+    return cf_name == CDC_TOPOLOGY_DESCRIPTION;
+}
+
 system_distributed_keyspace::system_distributed_keyspace(cql3::query_processor& qp, service::migration_manager& mm)
         : _qp(qp)
         , _mm(mm) {

--- a/db/system_distributed_keyspace.hh
+++ b/db/system_distributed_keyspace.hh
@@ -64,6 +64,10 @@ private:
     service::migration_manager& _mm;
 
 public:
+    /* Should writes to the given table always be synchronized by commitlog (flushed to disk)
+     * before being acknowledged? */
+    static bool is_extra_durable(const sstring& cf_name);
+
     system_distributed_keyspace(cql3::query_processor&, service::migration_manager&);
 
     future<> start();


### PR DESCRIPTION
When a node bootstraps or upgrades from a pre-CDC version, it creates a
new CDC generation, writes it to a distributed table
(`system_distributed.cdc_generation_descriptions`), and starts gossiping
its timestamp. When other nodes see the timestamp being gossiped, they
retrieve the generation from the table.

The bootstrapping/upgrading node therefore assumes that the generation
is made durable and other nodes will be able to retrieve it from the
table. This assumption could be invalidated if periodic commitlog mode
was used: replicas would acknowledge the write and then immediately
crash, losing the write if they were unlucky (i.e. commitlog wasn't
synced to disk before the write was acknowledged).

This commit enforces all writes to the generations table to be
synced to commitlog immediately. It does not matter for performance as
these writes are very rare.

Fixes https://github.com/scylladb/scylla/issues/7610.

Tested by inserting a tactical sleep in commitlog code which allowed me to reproduce issue #7610 with each run of the `test_periodic_commitlog` test. With this commit the bug no longer occurred.