### PR TITLE
gossip: Added CLUSTER_INFO to `application_state`

### DIFF
--- a/gms/application_state.cc
+++ b/gms/application_state.cc
@@ -68,6 +68,7 @@ static const std::map<application_state, sstring> application_state_names = {
     {application_state::SHARD_COUNT,            "SHARD_COUNT"},
     {application_state::IGNORE_MSB_BITS,        "IGNOR_MSB_BITS"},
     {application_state::CDC_STREAMS_TIMESTAMP,  "CDC_STREAMS_TIMESTAMP"},
+    {application_state::CLUSTER_INFO,           "CLUSTER_INFO"},
 };
 
 std::ostream& operator<<(std::ostream& os, const application_state& m) {

--- a/gms/application_state.hh
+++ b/gms/application_state.hh
@@ -65,8 +65,8 @@ enum class application_state {
     SHARD_COUNT,
     IGNORE_MSB_BITS,
     CDC_STREAMS_TIMESTAMP,
+    CLUSTER_INFO,
     // pad to allow adding new states to existing cluster
-    X9,
     X10,
 };
 

--- a/gms/gossiper.hh
+++ b/gms/gossiper.hh
@@ -571,6 +571,7 @@ private:
     std::set<sstring> get_supported_features(const std::unordered_map<gms::inet_address, sstring>& loaded_peer_features, ignore_features_of_local_node ignore_local_node) const;
 public:
     void check_knows_remote_features(std::set<std::string_view>& local_features, const std::unordered_map<inet_address, sstring>& loaded_peer_features) const;
+    void check_cluster_info_matches(const std::unordered_set<gms::inet_address>& initial_contact_nodes);
     void maybe_enable_features();
 private:
     seastar::metrics::metric_groups _metrics;

--- a/gms/versioned_value.cc
+++ b/gms/versioned_value.cc
@@ -56,6 +56,8 @@ constexpr const char* versioned_value::REMOVED_TOKEN;
 constexpr const char* versioned_value::HIBERNATE;
 constexpr const char* versioned_value::SHUTDOWN;
 constexpr const char* versioned_value::REMOVAL_COORDINATOR;
+constexpr const char* versioned_value::SNITCH_NAME;
+constexpr const char* versioned_value::CLUSTER_NAME;
 
 versioned_value versioned_value::network_version() {
     return versioned_value(format("{}", netw::messaging_service::current_version));

--- a/gms/versioned_value.hh
+++ b/gms/versioned_value.hh
@@ -87,6 +87,9 @@ public:
     // values for ApplicationState.REMOVAL_COORDINATOR
     static constexpr const char* REMOVAL_COORDINATOR = "REMOVER";
 
+    static constexpr const char* SNITCH_NAME = "SNITCH_NAME";
+    static constexpr const char* CLUSTER_NAME = "CLUSTER_NAME";
+
     int version;
     sstring value;
 public:
@@ -217,6 +220,12 @@ public:
 
     static versioned_value rack(const sstring& rack_id) {
         return versioned_value(rack_id);
+    }
+
+    static versioned_value cluster_info(const sstring& snitch_name, const sstring& cluster_name) {
+        return versioned_value(version_string({
+                sstring(SNITCH_NAME)  + ":" + snitch_name,
+                sstring(CLUSTER_NAME) + ":" + cluster_name}));
     }
 
     static versioned_value shard_count(int shard_count) {


### PR DESCRIPTION
CLUSTER_INFO is a map of unchangeable parameters that need to be
exchanged within cluster once, on shadow round.

Here it's mainly used to exchange snitch name, so joining nodes
cannot use wrong snitch. I also dropped cluster name into the map.

Fixes #6832