### PR TITLE
 types: add constraint on lexicographical_tri_compare()

### DIFF
--- a/compound.hh
+++ b/compound.hh
@@ -156,6 +156,7 @@ public:
             read_current();
         }
         iterator(end_iterator_tag, const bytes_view& v) : _v(nullptr, 0) {}
+        iterator() {}
         iterator& operator++() {
             read_current();
             return *this;

--- a/compound_compat.hh
+++ b/compound_compat.hh
@@ -391,6 +391,7 @@ public:
         iterator(end_iterator_tag) : _v(nullptr, 0) {}
 
     public:
+        iterator() : iterator(end_iterator_tag()) {}
         iterator& operator++() {
             read_current();
             return *this;

--- a/types.hh
+++ b/types.hh
@@ -26,6 +26,7 @@
 #include <iosfwd>
 #include "data/cell.hh"
 #include <sstream>
+#include <iterator>
 
 #include <seastar/core/sstring.hh>
 #include <seastar/core/shared_ptr.hh>
@@ -120,7 +121,10 @@ bool lexicographical_compare(TypesIterator types, InputIt1 first1, InputIt1 last
 // A trichotomic comparator returns an integer which is less, equal or greater
 // than zero when the first value is respectively smaller, equal or greater
 // than the second value.
-template <typename TypesIterator, typename InputIt1, typename InputIt2, typename Compare>
+template <std::input_iterator TypesIterator, std::input_iterator InputIt1, std::input_iterator InputIt2, typename Compare>
+requires requires (TypesIterator types, InputIt1 i1, InputIt2 i2, Compare cmp) {
+    { cmp(*types, *i1, *i2) } -> std::same_as<int>;
+}
 int lexicographical_tri_compare(TypesIterator types_first, TypesIterator types_last,
         InputIt1 first1, InputIt1 last1,
         InputIt2 first2, InputIt2 last2,


### PR DESCRIPTION
Verify that the input types are iterators and their value types are compatible with the compare function.

Because some of the inputs were not actually valid iterators, they are adjusted too.
