### PR TITLE
locator::ec2_multi_region_snitch: Handle ipv6 broadcast/public ip

### DIFF
--- a/locator/ec2_multi_region_snitch.cc
+++ b/locator/ec2_multi_region_snitch.cc
@@ -41,6 +41,12 @@
 #include "gms/gossiper.hh"
 #include "service/storage_service.hh"
 
+static constexpr const char* PUBLIC_IP_QUERY_REQ  = "/latest/meta-data/public-ipv4";
+static constexpr const char* PRIVATE_IP_QUERY_REQ = "/latest/meta-data/local-ipv4";
+
+static constexpr const char* PUBLIC_IPV6_QUERY_REQ  = "/latest/meta-data/network/interfaces/macs/{}/ipv6s";
+static constexpr const char* PRIVATE_MAC_QUERY = "/latest/meta-data/network/interfaces/macs";
+
 namespace locator {
 ec2_multi_region_snitch::ec2_multi_region_snitch(const sstring& fname, unsigned io_cpu_id)
     : ec2_snitch(fname, io_cpu_id) {}
@@ -51,12 +57,27 @@ future<> ec2_multi_region_snitch::start() {
     return seastar::async([this] {
         ec2_snitch::load_config().get();
         if (this_shard_id() == io_cpu_id()) {
-            sstring pub_addr;
             inet_address local_public_address;
 
             try {
-                pub_addr = aws_api_call(AWS_QUERY_SERVER_ADDR, AWS_QUERY_SERVER_PORT, PUBLIC_IP_QUERY_REQ).get0();
-                local_public_address = inet_address(pub_addr);
+                auto broadcast = utils::fb_utilities::get_broadcast_address();
+                if (broadcast.addr().is_ipv6()) {
+                    auto macs = aws_api_call(AWS_QUERY_SERVER_ADDR, AWS_QUERY_SERVER_PORT, PRIVATE_MAC_QUERY).get0();
+                    // we should just get a single line, ending in '/'. If there are more than one mac, we should
+                    // maybe try to loop the addresses and exclude local/link-local etc, but these addresses typically 
+                    // are already filtered by aws, so probably does not help. For now, just warn and pick first address.
+                    auto i = macs.find('/');
+                    auto mac = macs.substr(0, i);
+                    if (i != std::string::npos && ++i != macs.size()) {
+                        logger().warn("Ec2MultiRegionSnitch (ipv6): more than one MAC address listed ({}). Will use first.", macs);
+                    }
+                    auto ipv6 = aws_api_call(AWS_QUERY_SERVER_ADDR, AWS_QUERY_SERVER_PORT, format(PUBLIC_IPV6_QUERY_REQ, mac)).get0();
+                    local_public_address = inet_address(ipv6);
+                    _local_private_address = ipv6;
+                } else {
+                    auto pub_addr = aws_api_call(AWS_QUERY_SERVER_ADDR, AWS_QUERY_SERVER_PORT, PUBLIC_IP_QUERY_REQ).get0();
+                    local_public_address = inet_address(pub_addr);
+                }
             } catch (...) {
                 std::throw_with_nested(exceptions::configuration_exception("Failed to get a Public IP. Public IP is a requirement for Ec2MultiRegionSnitch. Consider using a different snitch if your instance doesn't have it"));
             }
@@ -71,8 +92,10 @@ future<> ec2_multi_region_snitch::start() {
             utils::fb_utilities::set_broadcast_address(local_public_address);
             utils::fb_utilities::set_broadcast_rpc_address(local_public_address);
 
-            sstring priv_addr = aws_api_call(AWS_QUERY_SERVER_ADDR, AWS_QUERY_SERVER_PORT, PRIVATE_IP_QUERY_REQ).get0();
-            _local_private_address = priv_addr;
+            if (!local_public_address.addr().is_ipv6()) {
+                sstring priv_addr = aws_api_call(AWS_QUERY_SERVER_ADDR, AWS_QUERY_SERVER_PORT, PRIVATE_IP_QUERY_REQ).get0();
+                _local_private_address = priv_addr;
+            }
 
             //
             // Gossiper main instance is currently running on CPU0 -

--- a/locator/ec2_multi_region_snitch.hh
+++ b/locator/ec2_multi_region_snitch.hh
@@ -51,8 +51,6 @@ public:
         return "org.apache.cassandra.locator.Ec2MultiRegionSnitch";
     }
 private:
-    static constexpr const char* PUBLIC_IP_QUERY_REQ  = "/latest/meta-data/public-ipv4";
-    static constexpr const char* PRIVATE_IP_QUERY_REQ = "/latest/meta-data/local-ipv4";
     sstring _local_private_address;
 };
 } // namespace locator


### PR DESCRIPTION
Fixes #7064

Iff broadcast address is set to ipv6 from main (meaning prefer
ipv6), determine the "public" ipv6 address (which should be
the same, but might not be), via aws metadata query.