### PR TITLE
dist/common/scripts/scylla_setup: Optionally config rsyslog destination

### DIFF
--- a/dist/common/scripts/scylla_rsyslog_setup
+++ b/dist/common/scripts/scylla_rsyslog_setup
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright 2020 ScyllaDB
+#
+
+#
+# This file is part of Scylla.
+#
+# Scylla is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Scylla is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import argparse
+from scylla_util import *
+
+def update_rsysconf(rsyslog_server):
+    if ':' not in rsyslog_server:
+        rsyslog_server = rsyslog_server + ':1514'
+
+    with open('/etc/rsyslog.d/scylla.conf', 'w') as f:
+        f.write("if $programname ==  'scylla' then @@{};RSYSLOG_SyslogProtocol23Format\n".format(rsyslog_server))
+    systemd_unit('rsyslog.service').restart()
+
+if __name__ == '__main__':
+    if os.getuid() > 0:
+        print('Requires root permission.')
+        sys.exit(1)
+    parser = argparse.ArgumentParser(description='Updating rsyslog to send logs to a remote server.')
+    parser.add_argument('--remote-server', required=True,
+                        help='specify remote rsyslog server, use ip:port format. If not port is included, Scylla-Monitoring port will be used')
+    args = parser.parse_args()
+    update_rsysconf(args.remote_server)

--- a/dist/common/scripts/scylla_setup
+++ b/dist/common/scripts/scylla_setup
@@ -89,6 +89,10 @@ def interactive_choose_nic():
             if is_valid_nic(n):
                 return n
 
+def interactive_ask_rsyslog_server():
+    print("Please input rsyslog remote server, use ip:port format.")
+    return input('ip:port> ').strip()
+
 def interactive_choose_swap_directory():
     print('Please input swapfile directory:')
     while True:
@@ -278,6 +282,10 @@ if __name__ == '__main__':
                         help='skip memory setup')
     parser.add_argument('--no-swap-setup', action='store_true', default=False,
                         help='skip swap setup')
+    parser.add_argument('--no-rsyslog-setup', action='store_true', default=False,
+                        help='skip rsyslog setup')
+    parser.add_argument('--rsyslog-server',
+                        help='specify a remote rsyslog server to send Scylla logs to. Use ip:port format, if no port is given, Scylla-Monitoring rsyslog will be used')
     if len(sys.argv) == 1:
         interactive = True
         group.required = False # interactive mode: no option is required.
@@ -320,6 +328,8 @@ if __name__ == '__main__':
     fstrim_setup = not args.no_fstrim_setup
     memory_setup = not args.no_memory_setup
     swap_setup = not args.no_swap_setup
+    rsyslog_setup = not args.no_rsyslog_setup
+    rsyslog_server = args.rsyslog_server
     selinux_reboot_required = False
     set_clocksource = False
 
@@ -549,6 +559,15 @@ if __name__ == '__main__':
                     options += f' --swap-size {swap_size}'
 
                 run_setup_script('swap', 'scylla_swap_setup' + options)
+
+        if os.path.isdir('/etc/rsyslog.d'):
+            rsyslog_setup = interactive_ask_service('Do you want to configure rsyslog to send log to a remote repository?', 'Answer yes to setup rsyslog to a remote server, Answer no to do nothing.', rsyslog_setup)
+            args.no_rsyslog_setup = not rsyslog_setup
+            if rsyslog_setup:
+                if interactive:
+                    rsyslog_server = interactive_ask_rsyslog_server()
+                if rsyslog_server:
+                    run_setup_script('rsyslog', 'scylla_rsyslog_setup --remote-server ' + rsyslog_server)
 
     print('ScyllaDB setup finished.')
 


### PR DESCRIPTION
This patch adds an option to scylla_setup to configure an rsyslog destination.

The monitoring stack has an option to get information from rsyslog it
requires that rsyslog on the scylla machines will send the trace line to
it.

The configuration will be in a Scylla configuration file, so it is safe to run it multiple times.

Fixes #7589

Signed-off-by: Amnon Heiman <amnon@scylladb.com>