### PR TITLE
Remove std::iterator usage

### DIFF
--- a/bytes_ostream.hh
+++ b/bytes_ostream.hh
@@ -65,7 +65,14 @@ private:
     size_type _size;
     size_type _initial_chunk_size = default_chunk_size;
 public:
-    class fragment_iterator : public std::iterator<std::input_iterator_tag, bytes_view> {
+    class fragment_iterator {
+    public:
+        using iterator_category = std::input_iterator_tag;
+        using value_type = bytes_view;
+        using difference_type = std::ptrdiff_t;
+        using pointer = bytes_view*;
+        using reference = bytes_view&;
+    private:
         chunk* _current = nullptr;
     public:
         fragment_iterator() = default;

--- a/cartesian_product.hh
+++ b/cartesian_product.hh
@@ -33,9 +33,13 @@ template<typename T>
 struct cartesian_product {
     const std::vector<std::vector<T>>& _vec_of_vecs;
 public:
-    class iterator : public std::iterator<std::forward_iterator_tag, std::vector<T>> {
+    class iterator {
     public:
+        using iterator_category = std::forward_iterator_tag;
         using value_type = std::vector<T>;
+        using difference_type = std::ptrdiff_t;
+        using pointer = std::vector<T>*;
+        using reference = std::vector<T>&;
     private:
         size_t _pos;
         const std::vector<std::vector<T>>* _vec_of_vecs;

--- a/cdc/log.cc
+++ b/cdc/log.cc
@@ -600,7 +600,14 @@ db_context db_context::builder::build() {
 
 // iterators for collection merge
 template<typename T>
-class collection_iterator : public std::iterator<std::input_iterator_tag, const T> {
+class collection_iterator {
+public:
+    using iterator_category = std::input_iterator_tag;
+    using value_type = const T;
+    using difference_type = std::ptrdiff_t;
+    using pointer = const T*;
+    using reference = const T&;
+private:
     bytes_view _v, _next;
     size_t _rem = 0;
     T _current;

--- a/clustering_interval_set.hh
+++ b/clustering_interval_set.hh
@@ -72,7 +72,14 @@ public:
         }
         return result;
     }
-    class position_range_iterator : public std::iterator<std::input_iterator_tag, const position_range> {
+    class position_range_iterator {
+    public:
+        using iterator_category = std::input_iterator_tag;
+        using value_type = const position_range;
+        using difference_type = std::ptrdiff_t;
+        using pointer = const position_range*;
+        using reference = const position_range&;
+    private:
         set_type::iterator _i;
     public:
         position_range_iterator(set_type::iterator i) : _i(i) {}

--- a/compound.hh
+++ b/compound.hh
@@ -130,7 +130,13 @@ public:
     bytes decompose_value(const value_type& values) const {
         return serialize_value(values);
     }
-    class iterator : public std::iterator<std::input_iterator_tag, const bytes_view> {
+    class iterator {
+    public:
+        using iterator_category = std::input_iterator_tag;
+        using value_type = const bytes_view;
+        using difference_type = std::ptrdiff_t;
+        using pointer = const bytes_view*;
+        using reference = const bytes_view&;
     private:
         bytes_view _v;
         bytes_view _current;

--- a/compound_compat.hh
+++ b/compound_compat.hh
@@ -61,7 +61,14 @@ public:
         , _packed(packed)
     { }
 
-    class iterator : public std::iterator<std::input_iterator_tag, bytes::value_type> {
+    class iterator {
+    public:
+        using iterator_category = std::input_iterator_tag;
+        using value_type = bytes::value_type;
+        using difference_type = std::ptrdiff_t;
+        using pointer = bytes::value_type*;
+        using reference = bytes::value_type&;
+    private:
         bool _singular;
         // Offset within virtual output space of a component.
         //
@@ -339,7 +346,14 @@ public:
         return eoc_byte == 0 ? eoc::none : (eoc_byte < 0 ? eoc::start : eoc::end);
     }
 
-    class iterator : public std::iterator<std::input_iterator_tag, const component_view> {
+    class iterator {
+    public:
+        using iterator_category = std::input_iterator_tag;
+        using value_type = const component_view;
+        using difference_type = std::ptrdiff_t;
+        using pointer = const component_view*;
+        using reference = const component_view&;
+    private:
         bytes_view _v;
         component_view _current;
         bool _strict_mode = true;

--- a/counters.hh
+++ b/counters.hh
@@ -277,7 +277,14 @@ public:
         return ac;
     }
 
-    class inserter_iterator : public std::iterator<std::output_iterator_tag, counter_shard> {
+    class inserter_iterator {
+    public:
+        using iterator_category = std::output_iterator_tag;
+        using value_type = counter_shard;
+        using difference_type = std::ptrdiff_t;
+        using pointer = counter_shard*;
+        using reference = counter_shard&;
+    private:
         counter_cell_builder* _builder;
     public:
         explicit inserter_iterator(counter_cell_builder& b) : _builder(&b) { }
@@ -311,7 +318,14 @@ protected:
     basic_atomic_cell_view<is_mutable> _cell;
     linearized_value_view _value;
 private:
-    class shard_iterator : public std::iterator<std::input_iterator_tag, basic_counter_shard_view<is_mutable>> {
+    class shard_iterator {
+    public:
+        using iterator_category = std::input_iterator_tag;
+        using value_type = basic_counter_shard_view<is_mutable>;
+        using difference_type = std::ptrdiff_t;
+        using pointer = basic_counter_shard_view<is_mutable>*;
+        using reference = basic_counter_shard_view<is_mutable>&;
+    private:
         pointer_type _current;
         basic_counter_shard_view<is_mutable> _current_view;
     public:

--- a/db/size_estimates_virtual_reader.cc
+++ b/db/size_estimates_virtual_reader.cc
@@ -67,7 +67,14 @@ struct virtual_row_comparator {
 };
 
 // Iterating over the cartesian product of cf_names and token_ranges.
-class virtual_row_iterator : public std::iterator<std::input_iterator_tag, const virtual_row> {
+class virtual_row_iterator {
+public:
+    using iterator_category = std::input_iterator_tag;
+    using value_type = const virtual_row;
+    using difference_type = std::ptrdiff_t;
+    using pointer = const virtual_row*;
+    using reference = const virtual_row&;
+private:
     std::reference_wrapper<const std::vector<bytes>> _cf_names;
     std::reference_wrapper<const std::vector<token_range>> _ranges;
     size_t _cf_names_idx = 0;

--- a/locator/token_metadata.cc
+++ b/locator/token_metadata.cc
@@ -875,8 +875,13 @@ public:
     friend class token_metadata;
 };
 
-class tokens_iterator_impl :
-        public std::iterator<std::input_iterator_tag, token> {
+class tokens_iterator_impl {
+public:
+    using iterator_category = std::input_iterator_tag;
+    using value_type = token;
+    using difference_type = std::ptrdiff_t;
+    using pointer = token*;
+    using reference = token&;
 private:
     tokens_iterator_impl(std::vector<token>::const_iterator it, size_t pos)
     : _cur_it(it), _ring_pos(pos), _insert_min(false) {}

--- a/locator/token_metadata.hh
+++ b/locator/token_metadata.hh
@@ -148,7 +148,14 @@ public:
     using UUID = utils::UUID;
     using inet_address = gms::inet_address;
 private:
-    class tokens_iterator : public std::iterator<std::input_iterator_tag, token> {
+    class tokens_iterator {
+    public:
+        using iterator_category = std::input_iterator_tag;
+        using value_type = token;
+        using difference_type = std::ptrdiff_t;
+        using pointer = token*;
+        using reference = token&;
+    private:
         using impl_type = tokens_iterator_impl;
         std::unique_ptr<impl_type> _impl;
     public:

--- a/sstables/compress.hh
+++ b/sstables/compress.hh
@@ -155,7 +155,14 @@ struct compression {
         uint64_t at(std::size_t i, state& s) const;
         void push_back(uint64_t offset, state& s);
     public:
-        class const_iterator : public std::iterator<std::random_access_iterator_tag, const uint64_t> {
+        class const_iterator {
+        public:
+            using iterator_category = std::random_access_iterator_tag;
+            using value_type = const uint64_t;
+            using difference_type = std::ptrdiff_t;
+            using pointer = const uint64_t*;
+            using reference = const uint64_t&;
+        private:
             friend class segmented_offsets;
             struct end_tag {};
 

--- a/types/listlike_partial_deserializing_iterator.hh
+++ b/types/listlike_partial_deserializing_iterator.hh
@@ -30,8 +30,14 @@ bytes_view read_collection_value(bytes_view& in, cql_serialization_format sf);
 
 // iterator that takes a set or list in serialized form, and emits
 // each element, still in serialized form
-class listlike_partial_deserializing_iterator
-          : public std::iterator<std::input_iterator_tag, bytes_view> {
+class listlike_partial_deserializing_iterator {
+public:
+    using iterator_category = std::input_iterator_tag;
+    using value_type = bytes_view;
+    using difference_type = std::ptrdiff_t;
+    using pointer = bytes_view*;
+    using reference = bytes_view&;
+private:
     bytes_view* _in;
     int _remain;
     bytes_view _cur;

--- a/types/tuple.hh
+++ b/types/tuple.hh
@@ -27,7 +27,14 @@
 
 #include "types.hh"
 
-struct tuple_deserializing_iterator : public std::iterator<std::input_iterator_tag, const bytes_view_opt> {
+struct tuple_deserializing_iterator {
+public:
+    using iterator_category = std::input_iterator_tag;
+    using value_type = const bytes_view_opt;
+    using difference_type = std::ptrdiff_t;
+    using pointer = const bytes_view_opt*;
+    using reference = const bytes_view_opt&;
+private:
     bytes_view _v;
     bytes_view_opt _current;
 public:

--- a/utils/log_heap.hh
+++ b/utils/log_heap.hh
@@ -152,7 +152,14 @@ private:
     ssize_t _watermark = -1;
 public:
     template <bool IsConst>
-    class hist_iterator : public std::iterator<std::input_iterator_tag, std::conditional_t<IsConst, const T, T>> {
+    class hist_iterator {
+    public:
+        using iterator_category = std::input_iterator_tag;
+        using value_type = std::conditional_t<IsConst, const T, T>;
+        using difference_type = std::ptrdiff_t;
+        using pointer = std::conditional_t<IsConst, const T, T>*;
+        using reference = std::conditional_t<IsConst, const T, T>&;
+    private:
         using hist_type = std::conditional_t<IsConst, const log_heap, log_heap>;
         using iterator_type = std::conditional_t<IsConst, typename bucket::const_iterator, typename bucket::iterator>;
 


### PR DESCRIPTION
std::iterator is deprecated since C++17 so define all the required iterator_traits directly and stop using std::iterator at all.

More context: https://www.fluentcpp.com/2018/05/08/std-iterator-deprecated

Tests: unit(dev)