### PR TITLE
db,view: remove duplicate entries from the list of target endpoints

### DIFF
--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -1240,6 +1240,14 @@ future<> mutate_MV(
                 }
             }
         }
+        // It's still possible that a target endpoint is dupliated in the remote endpoints list,
+        // so let's get rid of the duplicate if it exists
+        if (target_endpoint) {
+            auto remote_it = std::find(remote_endpoints.begin(), remote_endpoints.end(), *target_endpoint);
+            if (remote_it != remote_endpoints.end()) {
+                remote_endpoints.erase(remote_it);
+            }
+        }
 
         if (target_endpoint && *target_endpoint == my_address) {
             ++stats.view_updates_pushed_local;


### PR DESCRIPTION
If a list of target endpoints for sending view updates contains
duplicates, it results in benign (but annoying) broken promise
errors happening due to duplicated write response handlers being
instantiated for a single endpoint.
In order to avoid such errors, target remote endpoints are deduplicated
from the list of pending endpoints.
A similar issue (#5459) solved the case for duplicated local endpoints,
but that didn't solve the general case.

Fixes #7572
Tests: unit(dev),
manual:
 * I hardcoded duplicated remote endpoint values to be present in pending endpoints
 * the code before the fix experienced an identical failure as #7572 - a broken promise which doesn't really affect the state of the view, but is nonetheless annoying
 * after the patch, the broken promise is gone, because each endpoint has exactly one response handlers, no more than that