### PR TITLE
sstables: introduce HasPartitionTombstones sstable metadata

### DIFF
--- a/sstables/kl/writer.cc
+++ b/sstables/kl/writer.cc
@@ -663,7 +663,7 @@ void sstable_writer_k_l::consume_end_of_stream()
         features.disable(sstable_feature::NonCompoundRangeTombstones);
     }
     run_identifier identifier{_run_identifier};
-    _sst.write_scylla_metadata(_pc, _shard, std::move(features), std::move(identifier));
+    _sst.write_scylla_metadata(_pc, _shard, std::move(features), std::move(identifier), has_partition_tombstones::Unknown);
 
     if (!_leave_unsealed) {
         _sst.seal_sstable(_backup).get();

--- a/sstables/mx/writer.cc
+++ b/sstables/mx/writer.cc
@@ -608,6 +608,7 @@ private:
     } _pi_write_m;
     utils::UUID _run_identifier;
     bool _write_regular_as_static; // See #4139
+    has_partition_tombstones _has_partition_tombstones = has_partition_tombstones::No;
 
     void init_file_writers();
 
@@ -1003,6 +1004,7 @@ void writer::consume(tombstone t) {
 
     if (t) {
         _collector.update_min_max_components(clustering_key_prefix::make_empty(_schema));
+        _has_partition_tombstones = has_partition_tombstones::Yes;
     }
 }
 
@@ -1436,7 +1438,7 @@ void writer::consume_end_of_stream() {
         features.disable(sstable_feature::CorrectStaticCompact);
     }
     run_identifier identifier{_run_identifier};
-    _sst.write_scylla_metadata(_pc, _shard, std::move(features), std::move(identifier));
+    _sst.write_scylla_metadata(_pc, _shard, std::move(features), std::move(identifier), _has_partition_tombstones);
     if (!_cfg.leave_unsealed) {
         _sst.seal_sstable(_cfg.backup).get();
     }

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -1600,7 +1600,7 @@ sstable::read_scylla_metadata(const io_priority_class& pc) noexcept {
 }
 
 void
-sstable::write_scylla_metadata(const io_priority_class& pc, shard_id shard, sstable_enabled_features features, struct run_identifier identifier) {
+sstable::write_scylla_metadata(const io_priority_class& pc, shard_id shard, sstable_enabled_features features, struct run_identifier identifier, has_partition_tombstones hpt) {
     auto&& first_key = get_first_decorated_key();
     auto&& last_key = get_last_decorated_key();
     auto sm = create_sharding_metadata(_schema, first_key, last_key, shard);
@@ -1618,6 +1618,9 @@ sstable::write_scylla_metadata(const io_priority_class& pc, shard_id shard, ssta
     _components->scylla_metadata->data.set<scylla_metadata_type::Sharding>(std::move(sm));
     _components->scylla_metadata->data.set<scylla_metadata_type::Features>(std::move(features));
     _components->scylla_metadata->data.set<scylla_metadata_type::RunIdentifier>(std::move(identifier));
+    if (hpt != has_partition_tombstones::Unknown) {
+        _components->scylla_metadata->data.set<scylla_metadata_type::HasPartitionTombstones>(std::move(hpt));
+    }
 
     write_simple<component_type::Scylla>(*_components->scylla_metadata, pc);
 }

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -553,7 +553,7 @@ private:
     void write_compression(const io_priority_class& pc);
 
     future<> read_scylla_metadata(const io_priority_class& pc) noexcept;
-    void write_scylla_metadata(const io_priority_class& pc, shard_id shard, sstable_enabled_features features, run_identifier identifier);
+    void write_scylla_metadata(const io_priority_class& pc, shard_id shard, sstable_enabled_features features, run_identifier identifier, has_partition_tombstones);
 
     future<> read_filter(const io_priority_class& pc);
 
@@ -673,6 +673,11 @@ public:
 
     utils::UUID run_identifier() const {
         return _run_identifier;
+    }
+
+    // false => no partition tombstones, true => we don't know
+    bool may_have_partition_tombstones() const {
+        return _components->scylla_metadata->has_partition_tombstones() != has_partition_tombstones::No;
     }
 
     bool has_correct_max_deletion_time() const {

--- a/test/boost/sstable_datafile_test.cc
+++ b/test/boost/sstable_datafile_test.cc
@@ -6685,3 +6685,43 @@ SEASTAR_TEST_CASE(test_zero_estimated_partitions) {
         return make_ready_future<>();
     });
 }
+
+SEASTAR_TEST_CASE(test_partition_tombstones_metadata) {
+    return test_env::do_with_async([] (test_env& env) {
+        storage_service_for_tests ssft;
+        simple_schema ss;
+        auto s = ss.schema();
+        auto pks = ss.make_pkeys(2);
+
+        auto tmp = tmpdir();
+        unsigned gen = 0;
+        for (auto version : all_sstable_versions) {
+            if (version < sstable_version_types::mc) {
+                continue;
+            }
+
+            auto mut1 = mutation(s, pks[0]);
+            auto mut2 = mutation(s, pks[1]);
+            mut1.partition().apply_insert(*s, ss.make_ckey(0), ss.new_timestamp());
+            mut1.partition().apply_delete(*s, ss.make_ckey(1), ss.new_tombstone());
+            ss.add_row(mut1, ss.make_ckey(2), "val");
+            ss.delete_range(mut1, query::clustering_range::make({ss.make_ckey(3)}, {ss.make_ckey(5)}));
+            ss.add_row(mut2, ss.make_ckey(6), "val");
+
+            auto sst_gen = [&env, s, &tmp, &gen, version] () {
+                return env.make_sstable(s, tmp.path().string(), ++gen, version, big);
+            };
+
+            {
+                auto sst = make_sstable_containing(sst_gen, {mut1, mut2});
+                sst->load().get();
+                BOOST_REQUIRE(!sst->may_have_partition_tombstones());
+            }
+
+            mut2.partition().apply(ss.new_tombstone());
+            auto sst = make_sstable_containing(sst_gen, {mut1, mut2});
+            sst->load().get();
+            BOOST_REQUIRE(sst->may_have_partition_tombstones());
+        }
+    });
+}


### PR DESCRIPTION
This is a type with three possible values:
- `Yes` - there are partition tombstones in the sstable
- `No` - there are no partition tombstones
- `Unknown` - we don't know

The metadata is calculated and written for sstable versions greater
or equal to `mc`. For lower versions we don't write it.
When reading, if the metadata is not present, we interpret it as
`Unknown`.

Split from https://github.com/scylladb/scylla/pull/7437.