### PR TITLE
Don't add delay to the timestamp of the first CDC generation

### DIFF
--- a/cdc/generation.cc
+++ b/cdc/generation.cc
@@ -302,13 +302,13 @@ db_clock::time_point make_new_cdc_generation(
         const gms::gossiper& g,
         db::system_distributed_keyspace& sys_dist_ks,
         std::chrono::milliseconds ring_delay,
-        bool for_testing) {
+        bool add_delay) {
     using namespace std::chrono;
     auto gen = topology_description_generator(cfg, bootstrap_tokens, tmptr, g).generate();
 
     // Begin the race.
     auto ts = db_clock::now() + (
-            (for_testing || ring_delay == milliseconds(0)) ? milliseconds(0) : (
+            (!add_delay || ring_delay == milliseconds(0)) ? milliseconds(0) : (
                 2 * ring_delay + duration_cast<milliseconds>(generation_leeway)));
     sys_dist_ks.insert_cdc_topology_description(ts, std::move(gen), { tmptr->count_normal_token_owners() }).get();
 

--- a/cdc/generation.hh
+++ b/cdc/generation.hh
@@ -169,7 +169,7 @@ db_clock::time_point make_new_cdc_generation(
         const gms::gossiper& g,
         db::system_distributed_keyspace& sys_dist_ks,
         std::chrono::milliseconds ring_delay,
-        bool for_testing);
+        bool add_delay);
 
 /* Retrieves CDC streams generation timestamp from the given endpoint's application state (broadcasted through gossip).
  * We might be during a rolling upgrade, so the timestamp might not be there (if the other node didn't upgrade yet),

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -570,7 +570,7 @@ void storage_service::join_token_ring(int delay) {
             try {
                 _cdc_streams_ts = cdc::make_new_cdc_generation(db().local().get_config(),
                         _bootstrap_tokens, get_token_metadata_ptr(), _gossiper,
-                        _sys_dist_ks.local(), get_ring_delay(), _for_testing);
+                        _sys_dist_ks.local(), get_ring_delay(), !_for_testing);
             } catch (...) {
                 cdc_log.warn(
                     "Could not create a new CDC generation: {}. This may make it impossible to use CDC. Use nodetool checkAndRepairCdcStreams to fix CDC generation",
@@ -863,7 +863,7 @@ future<> storage_service::check_and_repair_cdc_streams() {
         }
         const auto new_streams_ts = cdc::make_new_cdc_generation(db().local().get_config(),
                 {}, std::move(tmptr), _gossiper,
-                _sys_dist_ks.local(), get_ring_delay(), false /* for_testing */);
+                _sys_dist_ks.local(), get_ring_delay(), true /* add delay */);
         // Need to artificially update our STATUS so other nodes handle the timestamp change
         auto status = _gossiper.get_application_state_ptr(get_broadcast_address(), application_state::STATUS);
         if (!status) {
@@ -909,7 +909,7 @@ void storage_service::bootstrap() {
 
         _cdc_streams_ts = cdc::make_new_cdc_generation(db().local().get_config(),
                 _bootstrap_tokens, get_token_metadata_ptr(), _gossiper,
-                _sys_dist_ks.local(), get_ring_delay(), _for_testing);
+                _sys_dist_ks.local(), get_ring_delay(), !_for_testing);
 
         _gossiper.add_local_application_state({
             // Order is important: both the CDC streams timestamp and tokens must be known when a node handles our status.

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -570,7 +570,7 @@ void storage_service::join_token_ring(int delay) {
             try {
                 _cdc_streams_ts = cdc::make_new_cdc_generation(db().local().get_config(),
                         _bootstrap_tokens, get_token_metadata_ptr(), _gossiper,
-                        _sys_dist_ks.local(), get_ring_delay(), !_for_testing);
+                        _sys_dist_ks.local(), get_ring_delay(), !_for_testing && !is_first_node());
             } catch (...) {
                 cdc_log.warn(
                     "Could not create a new CDC generation: {}. This may make it impossible to use CDC. Use nodetool checkAndRepairCdcStreams to fix CDC generation",
@@ -909,7 +909,7 @@ void storage_service::bootstrap() {
 
         _cdc_streams_ts = cdc::make_new_cdc_generation(db().local().get_config(),
                 _bootstrap_tokens, get_token_metadata_ptr(), _gossiper,
-                _sys_dist_ks.local(), get_ring_delay(), !_for_testing);
+                _sys_dist_ks.local(), get_ring_delay(), !_for_testing && !is_first_node());
 
         _gossiper.add_local_application_state({
             // Order is important: both the CDC streams timestamp and tokens must be known when a node handles our status.


### PR DESCRIPTION
After the concept of the seed nodes was removed we can distinguish
whether the node is the first node in the cluster or not.

Thanks to this we can avoid adding delay to the timestamp of the first
CDC generation.

The delay is added to the timestamp to make sure that all the nodes
in the cluster manage to learn about it before the timestamp becomes in the past.
It is safe to not add the delay for the first node because we know it's the only node
in the cluster and no one else has to learn about the timestamp.

Fixes #7645

Tests: unit(dev)