### PR TITLE
mutation_reader: generalize `combined_mutation_reader`

### DIFF
--- a/flat_mutation_reader.hh
+++ b/flat_mutation_reader.hh
@@ -392,8 +392,14 @@ public:
     // Skips to the next partition.
     //
     // Skips over the remaining fragments of the current partitions. If the
-    // reader is currently positioned at a partition boundary (partition
-    // start) nothing is done.
+    // reader is currently positioned at a partition start nothing is done.
+    //
+    // If the last produced fragment comes from partition `P`, then the reader
+    // is considered to still be in partition `P`, which means that `next_partition`
+    // will move the reader to the partition immediately following `P`.
+    // This case happens in particular when the last produced fragment was
+    // `partition_end` for `P`.
+    //
     // Only skips within the current partition range, i.e. if the current
     // partition is the last in the range the reader will be at EOS.
     //

--- a/mutation_reader.cc
+++ b/mutation_reader.cc
@@ -54,14 +54,25 @@ concept FragmentProducer = requires(Producer p, dht::partition_range part_range,
 /**
  * Merge mutation-fragments produced by producer.
  *
- * Merge a non-decreasing stream of mutation-fragments into strictly
- * increasing stream. The merger is stateful, it's intended to be kept
+ * Merge a non-decreasing stream of mutation fragment batches into
+ * a non-decreasing stream of mutation fragments.
+ *
+ * A batch is a sequence of fragments. For each such batch we merge
+ * the maximal mergeable subsequences of fragments and emit them
+ * as single fragments.
+ *
+ * For example, a batch <f1, f2, f3, f4, f5>, where f1 and f2 are mergeable,
+ * f2 is not mergeable with f3, f3 is not mergeable with f4, and f4 and f5
+ * are mergeable, will result in the following sequence:
+ * merge(f1, f2), f3, merge(f4, f5).
+ *
+ * The merger is stateful, it's intended to be kept
  * around *at least* for merging an entire partition. That is, creating
  * a new instance for each batch of fragments will produce incorrect
  * results.
  *
  * Call operator() to get the next mutation fragment. operator() will
- * consume fragments from the producer using operator().
+ * consume batches from the producer using operator().
  * Any fast-forwarding has to be communicated to the merger object using
  * fast_forward_to() and next_partition(), as appropriate.
  */


### PR DESCRIPTION
It is now called `merging_reader`, and is used to change a `FragmentProducer`
that produces a non-decreasing stream of mutation fragments batches into
a `flat_mutation_reader` producing a non-decreasing stream of fragments.

The resulting stream of fragments is increasing except for places where
we encounter range tombstones (multiple range tombstones may be produced
with the same position_in_partition)

`merging_reader` is a simple adapter over `mutation_fragment_merger`.

The old `combined_mutation_reader` is simply a specialization of `merging_reader`
where the used `FragmentProducer` is `mutation_reader_merger`, an abstraction that
merges the output of multiple readers into one non-decreasing stream of fragment
batches.

There is no separate class for `combined_mutation_reader` now. Instead,
`make_combined_reader` works directly with `merging_reader`.

The PR also improves some comments.

Split from https://github.com/scylladb/scylla/pull/7437.