### PR TITLE
Changing hints configuration followup

### DIFF
--- a/db/hints/resource_manager.cc
+++ b/db/hints/resource_manager.cc
@@ -223,10 +223,14 @@ future<> resource_manager::register_manager(manager& m) {
                 return make_ready_future<>();
             }
             if (!running()) {
+                // The hints manager will be started later by resource_manager::start()
                 return make_ready_future<>();
             }
 
+            // If the resource_manager was started, start the hints manager, too.
             return m.start(_proxy_ptr, _gossiper_ptr, _ss_ptr).then([this, &m] {
+                // Calculate device limits for this manager so that it is accounted for
+                // by the space_watchdog
                 return prepare_per_device_limits(m).then([this, &m] {
                     if (this->replay_allowed()) {
                         m.allow_replaying();

--- a/db/hints/resource_manager.hh
+++ b/db/hints/resource_manager.hh
@@ -186,8 +186,15 @@ public:
     size_t sending_queue_length() const;
 
     future<> start(shared_ptr<service::storage_proxy> proxy_ptr, shared_ptr<gms::gossiper> gossiper_ptr, shared_ptr<service::storage_service> ss_ptr);
-    void allow_replaying() noexcept;
     future<> stop() noexcept;
+
+    /// \brief Allows replaying hints for managers which are registered now or will be in the future.
+    void allow_replaying() noexcept;
+
+    /// \brief Registers the hints::manager in resource_manager, and starts it, if resource_manager is already running.
+    ///
+    /// The hints::managers can be added either before or after resource_manager starts.
+    /// If resource_manager is already started, the hints manager will also be started.
     future<> register_manager(manager& m);
 };
 

--- a/db/hints/resource_manager.hh
+++ b/db/hints/resource_manager.hh
@@ -159,6 +159,8 @@ class resource_manager {
         return _state.contains(state::replay_allowed);
     }
 
+    future<> prepare_per_device_limits(manager& shard_manager);
+
 public:
     static constexpr size_t hint_segment_size_in_mb = 32;
     static constexpr size_t max_hints_per_ep_size_mb = 128; // 4 files 32MB each
@@ -183,7 +185,6 @@ public:
     void allow_replaying() noexcept;
     future<> stop() noexcept;
     future<> register_manager(manager& m);
-    future<> prepare_per_device_limits();
 };
 
 }


### PR DESCRIPTION
Follow-up to https://github.com/scylladb/scylla/pull/6916.

- Fixes wrong usage of `resource_manager::prepare_per_device_limits`,
- Improves locking in `resource_manager` so that it is more safe to call its methods concurrently,
- Adds comments around `resource_manager::register_manager` so that it's more clear what this method does and why.