### PR TITLE
tools: toolchain: dbuild: don't confine with seccomp

### DIFF
--- a/tools/toolchain/dbuild
+++ b/tools/toolchain/dbuild
@@ -164,6 +164,7 @@ fi
 tmpdir=$(mktemp -d)
 
 docker_common_args+=(
+       --security-opt seccomp=unconfined \
        --pids-limit -1 \
        --network host \
        --cap-add SYS_PTRACE \


### PR DESCRIPTION
Some systems (at least, Centos 7, aarch64) block the membarrier()
syscall via seccomp. This causes Scylla or unit tests to burn cpu
instead of sleeping when there is nothing to do.

Fix by instructing podman/docker not to block any syscalls. I
tested this with podman, and it appears [1] to be supported on
docker.

[1] https://docs.docker.com/engine/security/seccomp/#run-without-the-default-seccomp-profile