### PR TITLE
index: Ensure restriction is supported in find_idx

### DIFF
--- a/cql3/restrictions/single_column_restrictions.hh
+++ b/cql3/restrictions/single_column_restrictions.hh
@@ -119,7 +119,7 @@ public:
      * @param column_def the column definition
      * @return the restriction associated to the specified column
      */
-    ::shared_ptr<restriction> get_restriction(const column_definition& column_def) const {
+    ::shared_ptr<single_column_restriction> get_restriction(const column_definition& column_def) const {
         auto i = _restrictions.find(&column_def);
         if (i == _restrictions.end()) {
             return {};

--- a/cql3/restrictions/statement_restrictions.cc
+++ b/cql3/restrictions/statement_restrictions.cc
@@ -330,20 +330,39 @@ int statement_restrictions::score(const secondary_index::index& index) const {
     return 1;
 }
 
+namespace {
+
+using namespace cql3::restrictions;
+
+/// If rs contains a restrictions_map of individual columns to their restrictions, returns it.  Otherwise, returns null.
+const single_column_restrictions::restrictions_map* get_individual_restrictions_map(const restrictions* rs) {
+    if (auto regular = dynamic_cast<const single_column_restrictions*>(rs)) {
+        return &regular->restrictions();
+    } else if (auto partition = dynamic_cast<const single_column_partition_key_restrictions*>(rs)) {
+        return &partition->restrictions();
+    } else if (auto clustering = dynamic_cast<const single_column_clustering_key_restrictions*>(rs)) {
+        return &clustering->restrictions();
+    }
+    return nullptr;
+}
+
+} // anonymous namespace
+
 std::pair<std::optional<secondary_index::index>, ::shared_ptr<cql3::restrictions::restrictions>> statement_restrictions::find_idx(secondary_index::secondary_index_manager& sim) const {
     std::optional<secondary_index::index> chosen_index;
     int chosen_index_score = 0;
     ::shared_ptr<cql3::restrictions::restrictions> chosen_index_restrictions;
 
     for (const auto& index : sim.list_indexes()) {
+        auto cdef = _schema->get_column_definition(to_bytes(index.target_column()));
         for (::shared_ptr<cql3::restrictions::restrictions> restriction : index_restrictions()) {
-            for (const auto& cdef : restriction->get_column_defs()) {
-                if (index.depends_on(*cdef)) {
-                    if (score(index) > chosen_index_score) {
-                        chosen_index = index;
-                        chosen_index_score = score(index);
-                        chosen_index_restrictions = restriction;
-                    }
+            if (auto rmap = get_individual_restrictions_map(restriction.get())) {
+                const auto found = rmap->find(cdef);
+                if (found != rmap->end() && is_supported_by(found->second->expression, index)
+                    && score(index) > chosen_index_score) {
+                    chosen_index = index;
+                    chosen_index_score = score(index);
+                    chosen_index_restrictions = restriction;
                 }
             }
         }

--- a/test/boost/secondary_index_test.cc
+++ b/test/boost/secondary_index_test.cc
@@ -323,6 +323,13 @@ SEASTAR_TEST_CASE(test_many_columns) {
                 {{int32_type->decompose(1)}, {int32_type->decompose(2)}, {int32_type->decompose(3)}, {int32_type->decompose(4)}, {int32_type->decompose(5)}, {int32_type->decompose(6)}},
             });
         });
+        BOOST_TEST_PASSPOINT();
+        eventually([&] {
+            // #7659
+            cquery_nofail(e, "SELECT * FROM tab WHERE d=0 AND f>0 ALLOW FILTERING");
+            cquery_nofail(e, "SELECT * FROM tab WHERE f=0 AND d>0 ALLOW FILTERING");
+            cquery_nofail(e, "SELECT * FROM tab WHERE f=0 AND f>0 ALLOW FILTERING");
+        });
     });
 }
 


### PR DESCRIPTION
Previously, statement_restrictions::find_idx() would happily return an
index for a non-EQ restriction (because it checked only the column
name, not the operator).  This is incorrect: when the selected index
is for a non-EQ restriction, it is impossible to query that index
table.

Fixes #7659.

Tests: unit (dev)