### PR TITLE
dist/common/scripts: drop run() and out(), swtich to subprocess.run()

### DIFF
--- a/dist/common/scripts/node_exporter_install
+++ b/dist/common/scripts/node_exporter_install
@@ -26,6 +26,7 @@ import tempfile
 import tarfile
 from scylla_util import *
 import argparse
+from subprocess import run
 
 VERSION='1.0.1'
 INSTALL_DIR=scylladir()+'/Prometheus/node_exporter'
@@ -52,7 +53,7 @@ if __name__ == '__main__':
             sys.exit(1)
 
     if is_gentoo_variant():
-        run('emerge -uq app-metrics/node_exporter')
+        run('emerge -uq app-metrics/node_exporter', shell=True, check=True)
         print('app-metrics/node_exporter does not install systemd service files, please fill a bug if you need them.')
         sys.exit(1)
     else:

--- a/dist/common/scripts/scylla_bootparam_setup
+++ b/dist/common/scripts/scylla_bootparam_setup
@@ -24,8 +24,8 @@ import os
 import re
 import sys
 import argparse
-import subprocess
 from scylla_util import *
+from subprocess import run
 
 if __name__ == '__main__':
     if os.getuid() > 0:
@@ -58,9 +58,9 @@ if __name__ == '__main__':
             cfg.set(grub_key, cmdline_linux)
             cfg.commit()
             if is_debian_variant():
-                run('update-grub')
+                run('update-grub', shell=True, check=True)
             else:
-                run('grub2-mkconfig -o /boot/grub2/grub.cfg')
+                run('grub2-mkconfig -o /boot/grub2/grub.cfg', shell=True, check=True)
 
 #    if is_ec2() and os.path.exists('/boot/grub/menu.lst'):
     if os.path.exists('/boot/grub/menu.lst'):

--- a/dist/common/scripts/scylla_coredump_setup
+++ b/dist/common/scripts/scylla_coredump_setup
@@ -26,8 +26,8 @@ import argparse
 import subprocess
 import time
 import tempfile
-import subprocess
 from scylla_util import *
+from subprocess import run
 
 if __name__ == '__main__':
     if os.getuid() > 0:
@@ -42,7 +42,7 @@ if __name__ == '__main__':
 
 # Gentoo may uses OpenRC
     if is_gentoo_variant():
-        run('sysctl -p /etc/sysctl.d/99-scylla-coredump.conf')
+        run('sysctl -p /etc/sysctl.d/99-scylla-coredump.conf', shell=True, check=True)
 # Other distributions can use systemd-coredump, so setup it
     else:
         if is_debian_variant():
@@ -80,11 +80,11 @@ WantedBy=multi-user.target
             systemd_unit('var-lib-systemd-coredump.mount').enable()
             systemd_unit('var-lib-systemd-coredump.mount').start()
         if os.path.exists('/usr/lib/sysctl.d/50-coredump.conf'):
-            run('sysctl -p /usr/lib/sysctl.d/50-coredump.conf')
+            run('sysctl -p /usr/lib/sysctl.d/50-coredump.conf', shell=True, check=True)
         else:
             with open('/etc/sysctl.d/99-scylla-coredump.conf', 'w') as f:
                 f.write('kernel.core_pattern=|/usr/lib/systemd/systemd-coredump %p %u %g %s %t %e"')
-            run('sysctl -p /etc/sysctl.d/99-scylla-coredump.conf')
+            run('sysctl -p /etc/sysctl.d/99-scylla-coredump.conf', shell=True, check=True)
 
         fp = tempfile.NamedTemporaryFile()
         fp.write(b'kill -SEGV $$')
@@ -98,7 +98,7 @@ WantedBy=multi-user.target
         # need to wait for systemd-coredump to complete collecting coredump
         time.sleep(3)
         try:
-            coreinfo = out('coredumpctl --no-pager --no-legend info {}'.format(pid))
+            coreinfo = run('coredumpctl --no-pager --no-legend info {}'.format(pid), shell=True, check=True, capture_output=True, encoding='utf-8').stdout.strip()
         except subprocess.CalledProcessError:
             print('Does not able to detect coredump, failed to configure systemd-coredump.')
             sys.exit(1)

--- a/dist/common/scripts/scylla_ec2_check
+++ b/dist/common/scripts/scylla_ec2_check
@@ -24,6 +24,7 @@ import os
 import sys
 import argparse
 from scylla_util import *
+from subprocess import run
 
 if __name__ == '__main__':
     if not is_ec2():
@@ -40,7 +41,7 @@ if __name__ == '__main__':
     aws = aws_instance()
     instance_class = aws.instance_class()
     en = aws.get_en_interface_type()
-    match = re.search(r'^driver: (\S+)$', out('ethtool -i {}'.format(args.nic)), flags=re.MULTILINE)
+    match = re.search(r'^driver: (\S+)$', run('ethtool -i {}'.format(args.nic), shell=True, check=True, capture_output=True, encoding='utf-8').stdout.strip(), flags=re.MULTILINE)
     driver = match.group(1)
 
     if not en:

--- a/dist/common/scripts/scylla_kernel_check
+++ b/dist/common/scripts/scylla_kernel_check
@@ -24,6 +24,7 @@ import os
 import sys
 import shutil
 from scylla_util import *
+from subprocess import run, DEVNULL
 
 if __name__ == '__main__':
     if os.getuid() > 0:
@@ -34,11 +35,11 @@ if __name__ == '__main__':
         pkg_install('xfsprogs')
 
     os.makedirs('/var/tmp/mnt', exist_ok=True)
-    run('dd if=/dev/zero of=/var/tmp/kernel-check.img bs=1M count=128', silent=True)
-    run('mkfs.xfs /var/tmp/kernel-check.img', silent=True)
-    run('mount /var/tmp/kernel-check.img /var/tmp/mnt -o loop', silent=True)
-    ret = run('iotune --fs-check --evaluation-directory /var/tmp/mnt', exception=False)
-    run('umount /var/tmp/mnt')
+    run('dd if=/dev/zero of=/var/tmp/kernel-check.img bs=1M count=128', shell=True, check=True, stdout=DEVNULL, stderr=DEVNULL)
+    run('mkfs.xfs /var/tmp/kernel-check.img', shell=True, check=True, stdout=DEVNULL, stderr=DEVNULL)
+    run('mount /var/tmp/kernel-check.img /var/tmp/mnt -o loop', shell=True, check=True, stdout=DEVNULL, stderr=DEVNULL)
+    ret = run('iotune --fs-check --evaluation-directory /var/tmp/mnt', shell=True).returncode
+    run('umount /var/tmp/mnt', shell=True, check=True)
     shutil.rmtree('/var/tmp/mnt')
     os.remove('/var/tmp/kernel-check.img')
     if ret == 0:

--- a/dist/common/scripts/scylla_ntp_setup
+++ b/dist/common/scripts/scylla_ntp_setup
@@ -29,6 +29,7 @@ import distro
 import shutil
 
 from scylla_util import *
+from subprocess import run
 
 if __name__ == '__main__':
     if os.getuid() > 0:
@@ -54,7 +55,7 @@ if __name__ == '__main__':
         ntp = systemd_unit('ntp.service')
         ntp.stop()
         # ignore error, ntpd may able to adjust clock later
-        run('ntpdate ntp.ubuntu.com', exception=False)
+        run('ntpdate ntp.ubuntu.com', shell=True)
         ntp.start()
 
     if is_gentoo_variant():
@@ -66,7 +67,7 @@ if __name__ == '__main__':
         server = match.group(1)
         ntpd = systemd_unit('ntpd.service')
         ntpd.stop()
-        run('ntpdate {}'.format(server))
+        run('ntpdate {}'.format(server), shell=True, check=True)
         ntpd.enable()
         ntpd.start()
 
@@ -84,7 +85,7 @@ if __name__ == '__main__':
             chronyd = systemd_unit('chronyd.service')
             chronyd.enable()
             chronyd.restart()
-            run('chronyc makestep')
+            run('chronyc makestep', shell=True, check=True)
         else:
             if not shutil.which('ntpd') or not shutil.which('ntpdate'):
                 yum_install('ntp ntpdate')
@@ -100,6 +101,6 @@ if __name__ == '__main__':
             ntpd = systemd_unit('ntpd.service')
             ntpd.stop()
             # ignore error, ntpd may able to adjust clock later
-            run('ntpdate {}'.format(server), exception=False)
+            run('ntpdate {}'.format(server), shell=True)
             ntpd.enable()
             ntpd.start()

--- a/dist/common/scripts/scylla_prepare
+++ b/dist/common/scripts/scylla_prepare
@@ -27,9 +27,10 @@ import platform
 import distro
 
 from scylla_util import *
+from subprocess import run
 
 def get_mode_cpuset(nic, mode):
-    mode_cpu_mask = out('/opt/scylladb/scripts/perftune.py --tune net --nic {} --mode {} --get-cpu-mask-quiet'.format(nic, mode))
+    mode_cpu_mask = run('/opt/scylladb/scripts/perftune.py --tune net --nic {} --mode {} --get-cpu-mask-quiet'.format(nic, mode), shell=True, check=True, capture_output=True, encoding='utf-8').stdout.strip()
     return hex2list(mode_cpu_mask)
 
 def get_cur_cpuset():
@@ -78,7 +79,7 @@ def create_perftune_conf(cfg):
 
         mode = get_tune_mode(nic)
         params += ' --mode {mode} --dump-options-file'.format(mode=mode)
-        yaml = out('/opt/scylladb/scripts/perftune.py ' + params)
+        yaml = run('/opt/scylladb/scripts/perftune.py ' + params, shell=True, check=True, capture_output=True, encoding='utf-8').stdout.strip()
         with open('/etc/scylla.d/perftune.yaml', 'w') as f:
             f.write(yaml)
         return True
@@ -119,26 +120,26 @@ if __name__ == '__main__':
         user = cfg.get('USER')
         group = cfg.get('GROUP')
         bridge = cfg.get('BRIDGE')
-        run('ip tuntap del mode tap dev {TAP}'.format(TAP=tap))
-        run('ip tuntap add mode tap dev {TAP} user {USER} one_queue vnet_hdr'.format(TAP=tap, USER=user))
-        run('ip link set dev {TAP} up'.format(TAP=tap))
-        run('ip link set dev {TAP} master {BRIDGE}'.format(TAP=tap, BRIDGE=bridge))
-        run('chown {USER}.{GROUP} /dev/vhost-net'.format(USER=user, GROUP=group))
+        run('ip tuntap del mode tap dev {TAP}'.format(TAP=tap), shell=True, check=True)
+        run('ip tuntap add mode tap dev {TAP} user {USER} one_queue vnet_hdr'.format(TAP=tap, USER=user), shell=True, check=True)
+        run('ip link set dev {TAP} up'.format(TAP=tap), shell=True, check=True)
+        run('ip link set dev {TAP} master {BRIDGE}'.format(TAP=tap, BRIDGE=bridge), shell=True, check=True)
+        run('chown {USER}.{GROUP} /dev/vhost-net'.format(USER=user, GROUP=group), shell=True, check=True)
     elif mode == 'dpdk':
         ethpciid = cfg.get('ETHPCIID')
         nr_hugepages = cfg.get('NR_HUGEPAGES')
-        run('modprobe uio')
-        run('modprobe uio_pci_generic')
-        run('/opt/scylladb/scripts/dpdk-devbind.py --force --bind=uio_pci_generic {ETHPCIID}'.format(ETHPCIID=ethpciid))
+        run('modprobe uio', shell=True, check=True)
+        run('modprobe uio_pci_generic', shell=True, check=True)
+        run('/opt/scylladb/scripts/dpdk-devbind.py --force --bind=uio_pci_generic {ETHPCIID}'.format(ETHPCIID=ethpciid), shell=True, check=True)
         for n in glob.glob('/sys/devices/system/node/node?'):
             with open('{n}/hugepages/hugepages-2048kB/nr_hugepages'.format(n=n), 'w') as f:
                 f.write(nr_hugepages)
         if distro.name() == 'Ubuntu':
-            run('hugeadm --create-mounts')
+            run('hugeadm --create-mounts', shell=True, check=True)
     else:
         try:
             if create_perftune_conf(cfg):
-                run("{} --options-file /etc/scylla.d/perftune.yaml".format(perftune_base_command()))
+                run("{} --options-file /etc/scylla.d/perftune.yaml".format(perftune_base_command()), shell=True, check=True)
         except Exception as e:
             print(f'Exception occurred while creating perftune.yaml: {e}')
             print('To fix the error, please re-run scylla_setup.')

--- a/dist/common/scripts/scylla_raid_setup
+++ b/dist/common/scripts/scylla_raid_setup
@@ -28,6 +28,7 @@ import sys
 import stat
 import distro
 from scylla_util import *
+from subprocess import run
 
 if __name__ == '__main__':
     if os.getuid() > 0:
@@ -82,7 +83,7 @@ if __name__ == '__main__':
         print('{} is already mounted'.format(mount_at))
         sys.exit(1)
 
-    mntunit_bn = out('systemd-escape -p --suffix=mount {}'.format(mount_at))
+    mntunit_bn = run('systemd-escape -p --suffix=mount {}'.format(mount_at), shell=True, check=True, capture_output=True, encoding='utf-8').stdout.strip()
     mntunit = Path('/etc/systemd/system/{}'.format(mntunit_bn))
     if mntunit.exists():
         print('mount unit {} already exists'.format(mntunit))
@@ -105,10 +106,10 @@ if __name__ == '__main__':
     print('Creating {type} for scylla using {nr_disk} disk(s): {disks}'.format(type='RAID0' if raid else 'XFS volume', nr_disk=len(disks), disks=args.disks))
     if distro.name() == 'Ubuntu' and distro.version() == '14.04':
         if raid:
-            run('udevadm settle')
-            run('mdadm --create --verbose --force --run {raid} --level=0 -c1024 --raid-devices={nr_disk} {disks}'.format(raid=fsdev, nr_disk=len(disks), disks=args.disks.replace(',', ' ')))
-            run('udevadm settle')
-        run('mkfs.xfs {} -f'.format(fsdev))
+            run('udevadm settle', shell=True, check=True)
+            run('mdadm --create --verbose --force --run {raid} --level=0 -c1024 --raid-devices={nr_disk} {disks}'.format(raid=fsdev, nr_disk=len(disks), disks=args.disks.replace(',', ' ')), shell=True, check=True)
+            run('udevadm settle', shell=True, check=True)
+        run('mkfs.xfs {} -f'.format(fsdev), shell=True, check=True)
     else:
         procs=[]
         for disk in disks:
@@ -123,10 +124,10 @@ if __name__ == '__main__':
         for proc in procs:
             proc.wait()
         if raid:
-            run('udevadm settle')
-            run('mdadm --create --verbose --force --run {raid} --level=0 -c1024 --raid-devices={nr_disk} {disks}'.format(raid=fsdev, nr_disk=len(disks), disks=args.disks.replace(',', ' ')))
-            run('udevadm settle')
-        run('mkfs.xfs {} -f -K'.format(fsdev))
+            run('udevadm settle', shell=True, check=True)
+            run('mdadm --create --verbose --force --run {raid} --level=0 -c1024 --raid-devices={nr_disk} {disks}'.format(raid=fsdev, nr_disk=len(disks), disks=args.disks.replace(',', ' ')), shell=True, check=True)
+            run('udevadm settle', shell=True, check=True)
+        run('mkfs.xfs {} -f -K'.format(fsdev), shell=True, check=True)
 
     if is_debian_variant():
         confpath = '/etc/mdadm/mdadm.conf'
@@ -134,14 +135,14 @@ if __name__ == '__main__':
         confpath = '/etc/mdadm.conf'
 
     if raid:
-        res = out('mdadm --detail --scan')
+        res = run('mdadm --detail --scan', shell=True, check=True, capture_output=True, encoding='utf-8').stdout.strip()
         with open(confpath, 'w') as f:
             f.write(res)
             f.write('\nMAILADDR root')
 
     os.makedirs(mount_at, exist_ok=True)
 
-    uuid = out(f'blkid -s UUID -o value {fsdev}')
+    uuid = run(f'blkid -s UUID -o value {fsdev}', shell=True, check=True, capture_output=True, encoding='utf-8').stdout.strip()
     after = 'local-fs.target'
     if raid:
         after += f' {md_service}'
@@ -188,4 +189,4 @@ WantedBy=multi-user.target
         os.chown(dpath, uid, gid)
 
     if is_debian_variant():
-        run('update-initramfs -u')
+        run('update-initramfs -u', shell=True, check=True)

--- a/dist/common/scripts/scylla_selinux_setup
+++ b/dist/common/scripts/scylla_selinux_setup
@@ -24,6 +24,7 @@ import os
 import sys
 import subprocess
 from scylla_util import *
+from subprocess import run
 
 if __name__ == '__main__':
     if os.getuid() > 0:
@@ -34,9 +35,9 @@ if __name__ == '__main__':
         print("scylla_selinux_setup only supports Red Hat variants")
         sys.exit(0)
 
-    res = out('sestatus')
+    res = run('sestatus', shell=True, check=True, capture_output=True, encoding='utf-8').stdout.strip()
     if res.split(None)[2] != 'disabled':
-        run('setenforce 0')
+        run('setenforce 0', shell=True, check=True)
         cfg = sysconfig_parser('/etc/sysconfig/selinux')
         cfg.set('SELINUX', 'disabled')
         cfg.commit()

--- a/dist/common/scripts/scylla_setup
+++ b/dist/common/scripts/scylla_setup
@@ -29,6 +29,7 @@ import io
 import stat
 import distro
 from scylla_util import *
+from subprocess import run, DEVNULL
 
 interactive = False
 HOUSEKEEPING_TIMEOUT = 60
@@ -115,9 +116,9 @@ def do_verify_package(pkg):
     if is_offline():
         res = 0 if pkg_files[pkg].exists() else 1
     elif is_debian_variant():
-        res = run('dpkg -s {}'.format(pkg), silent=True, exception=False)
+        res = run('dpkg -s {}'.format(pkg), shell=True, stdout=DEVNULL, stderr=DEVNULL).returncode
     elif is_redhat_variant():
-        res = run('rpm -q {}'.format(pkg), silent=True, exception=False)
+        res = run('rpm -q {}'.format(pkg), shell=True, stdout=DEVNULL, stderr=DEVNULL).returncode
     elif is_gentoo_variant():
         res = 0 if len(glob.glob('/var/db/pkg/*/{}-*'.format(pkg))) else 1
     else:
@@ -129,9 +130,9 @@ def do_verify_package(pkg):
 
 def list_block_devices():
     devices = []
-    s = out('lsblk --help')
+    s = run('lsblk --help', shell=True, check=True, capture_output=True, encoding='utf-8').stdout.strip()
     if re.search(r'\s*-p', s, flags=re.MULTILINE):
-        s = out('lsblk -pnr')
+        s = run('lsblk -pnr', shell=True, check=True, capture_output=True, encoding='utf-8').stdout.strip()
         res = re.findall(r'^(\S+) \S+ \S+ \S+ \S+ (\S+)', s, flags=re.MULTILINE)
         for r in res:
             if r[1] != 'rom' and r[1] != 'loop':
@@ -155,7 +156,7 @@ def get_unused_disks():
 
 def run_setup_script(name, script):
     global interactive
-    res = run('{}/{}'.format(scriptsdir(), script), exception=False)
+    res = run('{}/{}'.format(scriptsdir(), script), shell=True).returncode
     if res != 0:
         if interactive:
             colorprint('{red}{name} setup failed. Press any key to continue...{nocolor}', name=name)
@@ -341,13 +342,13 @@ if __name__ == '__main__':
         if ec2_check:
             if interactive:
                 nic = interactive_choose_nic()
-            run('{}/scylla_ec2_check --nic {}'.format(scriptsdir(), nic))
+            run('{}/scylla_ec2_check --nic {}'.format(scriptsdir(), nic), shell=True, check=True)
 
     if not is_nonroot():
         kernel_check = interactive_ask_service('Do you want to run check your kernel version?', 'Yes - runs a  script to verify that the kernel for this instance qualifies to run Scylla. No - skips the kernel check.', kernel_check)
         args.no_kernel_check = not kernel_check
         if kernel_check:
-            run('{}/scylla_kernel_check'.format(scriptsdir()))
+            run('{}/scylla_kernel_check'.format(scriptsdir()), shell=True, check=True)
 
         verify_package = interactive_ask_service('Do you want to verify the ScyllaDB packages are installed?', 'Yes - runs a script to confirm that ScyllaDB is installed. No - skips the installation check.', verify_package)
         args.no_verify_package = not verify_package
@@ -379,19 +380,19 @@ if __name__ == '__main__':
                 hk_restart.mask()
                 hk_restart.stop()
 
-        cur_version=out('scylla --version', exception=False)
+        cur_version=run('scylla --version', shell=True, capture_output=True, encoding='utf-8').stdout.strip()
         if len(cur_version) > 0:
             if is_debian_variant():
-                new_version=out('sudo -u scylla {}/scylla-housekeeping --uuid-file /var/lib/scylla-housekeeping/housekeeping.uuid --repo-files \'/etc/apt/sources.list.d/scylla*.list\' version --version {} --mode i'.format(scriptsdir(), cur_version), shell=True, exception=False, timeout=HOUSEKEEPING_TIMEOUT)
+                new_version=run('sudo -u scylla {}/scylla-housekeeping --uuid-file /var/lib/scylla-housekeeping/housekeeping.uuid --repo-files \'/etc/apt/sources.list.d/scylla*.list\' version --version {} --mode i'.format(scriptsdir(), cur_version), shell=True, capture_output=True, encoding='utf-8', timeout=HOUSEKEEPING_TIMEOUT).stdout.strip()
             else:
-                new_version=out('sudo -u scylla {}/scylla-housekeeping --uuid-file /var/lib/scylla-housekeeping/housekeeping.uuid --repo-files \'/etc/yum.repos.d/scylla*.repo\' version --version {} --mode i'.format(scriptsdir(), cur_version), shell=True, exception=False, timeout=HOUSEKEEPING_TIMEOUT)
+                new_version=run('sudo -u scylla {}/scylla-housekeeping --uuid-file /var/lib/scylla-housekeeping/housekeeping.uuid --repo-files \'/etc/yum.repos.d/scylla*.repo\' version --version {} --mode i'.format(scriptsdir(), cur_version), shell=True, capture_output=True, encoding='utf-8', timeout=HOUSEKEEPING_TIMEOUT).stdout.strip()
             if len(new_version) > 0:
                 print(new_version)
         else:
             if is_debian_variant():
-                new_version=out('sudo -u scylla {}/scylla-housekeeping --uuid-file /var/lib/scylla-housekeeping/housekeeping.uuid --repo-files \'/etc/apt/sources.list.d/scylla*.list\' version --version unknown --mode u'.format(scriptsdir()), shell=True, exception=False, timeout=HOUSEKEEPING_TIMEOUT)
+                new_version=run('sudo -u scylla {}/scylla-housekeeping --uuid-file /var/lib/scylla-housekeeping/housekeeping.uuid --repo-files \'/etc/apt/sources.list.d/scylla*.list\' version --version unknown --mode u'.format(scriptsdir()), shell=True, capture_output=True, encoding='utf-8', timeout=HOUSEKEEPING_TIMEOUT).stdout.strip()
             else:
-                new_version=out('sudo -u scylla {}/scylla-housekeeping --uuid-file /var/lib/scylla-housekeeping/housekeeping.uuid --repo-files \'/etc/yum.repos.d/scylla*.repo\' version --version unknown --mode u'.format(scriptsdir()), shell=True, exception=False, timeout=HOUSEKEEPING_TIMEOUT)
+                new_version=run('sudo -u scylla {}/scylla-housekeeping --uuid-file /var/lib/scylla-housekeeping/housekeeping.uuid --repo-files \'/etc/yum.repos.d/scylla*.repo\' version --version unknown --mode u'.format(scriptsdir()), shell=True, capture_output=True, encoding='utf-8', timeout=HOUSEKEEPING_TIMEOUT)
             print('A Scylla executable was not found, please check your installation {}'.format(new_version))
 
         if is_redhat_variant():
@@ -492,7 +493,7 @@ if __name__ == '__main__':
             run_setup_script('Performance Tuning', 'scylla_sysconfig_setup --nic {nic} {setup_args}'.format(nic=nic, setup_args=setup_args))
 
     if is_nonroot():
-        params = out('systemctl --no-pager show user@1000.service')
+        params = run('systemctl --no-pager show user@1000.service', shell=True, check=True, capture_output=True, encoding='utf-8').stdout.strip()
         res = re.findall(r'^LimitNOFILE=(.*)$', params, flags=re.MULTILINE)
         if res and int(res[0]) < 10000:
             colorprint('{red}NOFILE hard limit is too low, enabling developer mode{nocolor}')

--- a/dist/common/scripts/scylla_stop
+++ b/dist/common/scripts/scylla_stop
@@ -23,6 +23,7 @@
 import os
 import sys
 from scylla_util import *
+from subprocess import run
 
 if __name__ == '__main__':
     if os.getuid() > 0:
@@ -35,7 +36,7 @@ if __name__ == '__main__':
 
 
     if cfg.get('NETWORK_MODE') == 'virtio':
-        run('ip tuntap del mode tap dev {TAP}'.format(TAP=cfg.get('TAP')))
+        run('ip tuntap del mode tap dev {TAP}'.format(TAP=cfg.get('TAP')), shell=True, check=True)
     elif cfg.get('NETWORK_MODE') == 'dpdk':
-        run('/opt/scylladb/scripts/dpdk-devbind.py -u {ETHPCIID}'.format(ETHPCIID=cfg.get('ETHPCIID')))
-        run('/opt/scylladb/scripts/dpdk-devbind.py -b {ETHDRV} {ETHPCIID}'.format(ETHDRV=cfg.get('ETHDRV'), ETHPCIID=cfg.get('ETHPCIID')))
+        run('/opt/scylladb/scripts/dpdk-devbind.py -u {ETHPCIID}'.format(ETHPCIID=cfg.get('ETHPCIID')), shell=True, check=True)
+        run('/opt/scylladb/scripts/dpdk-devbind.py -b {ETHDRV} {ETHPCIID}'.format(ETHDRV=cfg.get('ETHDRV'), ETHPCIID=cfg.get('ETHPCIID')), shell=True, check=True)

--- a/dist/common/scripts/scylla_swap_setup
+++ b/dist/common/scripts/scylla_swap_setup
@@ -26,6 +26,7 @@ import argparse
 import psutil
 from pathlib import Path
 from scylla_util import *
+from subprocess import run
 
 def GB(n):
     return n * 1024 * 1024 * 1024
@@ -78,10 +79,10 @@ if __name__ == '__main__':
     if swapfile.exists():
         print('swapfile {} already exists'.format(swapfile))
         sys.exit(1)
-    run('dd if=/dev/zero of={} bs=1M count={}'.format(swapfile, swapsize_mb))
+    run('dd if=/dev/zero of={} bs=1M count={}'.format(swapfile, swapsize_mb), shell=True, check=True)
     swapfile.chmod(0o600)
-    run('mkswap -f {}'.format(swapfile))
-    swapunit_bn = out('systemd-escape -p --suffix=swap {}'.format(swapfile))
+    run('mkswap -f {}'.format(swapfile), shell=True, check=True)
+    swapunit_bn = run('systemd-escape -p --suffix=swap {}'.format(swapfile), shell=True, check=True, capture_output=True, encoding='utf-8').stdout.strip()
     swapunit = Path('/etc/systemd/system/{}'.format(swapunit_bn))
     if swapunit.exists():
         print('swap unit {} already exists'.format(swapunit))

--- a/dist/common/scripts/scylla_sysconfig_setup
+++ b/dist/common/scripts/scylla_sysconfig_setup
@@ -26,6 +26,7 @@ import argparse
 import subprocess
 import re
 from scylla_util import *
+from subprocess import run
 
 def bool2str(val):
     return 'yes' if val else 'no'
@@ -79,15 +80,15 @@ if __name__ == '__main__':
     network_mode = args.mode if args.mode else cfg.get('NETWORK_MODE')
 
     if args.setup_nic_and_disks:
-        rps_cpus = out('{} --tune net --nic {} --get-cpu-mask'.format(perftune_base_command(), ifname))
+        rps_cpus = run('{} --tune net --nic {} --get-cpu-mask'.format(perftune_base_command(), ifname), shell=True, check=True, capture_output=True, encoding='utf-8').stdout.strip()
         if len(rps_cpus) > 0:
             cpuset = hex2list(rps_cpus)
-            run('/opt/scylladb/scripts/scylla_cpuset_setup --cpuset {}'.format(cpuset))
+            run('/opt/scylladb/scripts/scylla_cpuset_setup --cpuset {}'.format(cpuset), shell=True, check=True)
 
     ethdrv = ''
     ethpciid = ''
     if network_mode == 'dpdk':
-        dpdk_status = out('/opt/scylladb/scripts/dpdk-devbind.py --status')
+        dpdk_status = run('/opt/scylladb/scripts/dpdk-devbind.py --status', shell=True, check=True, capture_output=True, encoding='utf-8').stdout.strip()
         match = re.search('if={} drv=(\S+)'.format(ifname), dpdk_status, flags=re.MULTILINE)
         ethdrv = match.group(1)
         match = re.search('^(\\S+:\\S+:\\S+\.\\S+) [^\n]+ if={} '.format(ifname), dpdk_status, flags=re.MULTILINE)


### PR DESCRIPTION
We initially implemented run() and out() functions because we couldn't use
subprocess.run() since we were on Python 3.4.
But since we moved to relocatable python3, we don't need to implement it ourselves.
Why we keep using these functions are, because we needed to set environemnt variable to set PATH.
Since we recently moved away these codes to python thunk, we finally able to
drop run() and out(), switch to subprocess.run().