### PR TITLE
Use large_data_counters in scylla_metadata to decide when to delete large_data records

### DIFF
--- a/db/large_data_handler.cc
+++ b/db/large_data_handler.cc
@@ -25,6 +25,8 @@
 #include "db/large_data_handler.hh"
 #include "sstables/sstables.hh"
 
+static logging::logger large_data_logger("large_data");
+
 namespace db {
 
 nop_large_data_handler::nop_large_data_handler()
@@ -32,6 +34,16 @@ nop_large_data_handler::nop_large_data_handler()
           std::numeric_limits<uint64_t>::max(), std::numeric_limits<uint64_t>::max()) {
     // Don't require start() to be called on nop large_data_handler.
     start();
+}
+
+large_data_handler::large_data_handler(uint64_t partition_threshold_bytes, uint64_t row_threshold_bytes, uint64_t cell_threshold_bytes, uint64_t rows_count_threshold)
+        : _partition_threshold_bytes(partition_threshold_bytes)
+        , _row_threshold_bytes(row_threshold_bytes)
+        , _cell_threshold_bytes(cell_threshold_bytes)
+        , _rows_count_threshold(rows_count_threshold)
+{
+    large_data_logger.debug("partition_threshold_bytes={} row_threshold_bytes={} cell_threshold_bytes={} rows_count_threshold={}",
+        partition_threshold_bytes, row_threshold_bytes, cell_threshold_bytes, rows_count_threshold);
 }
 
 future<> large_data_handler::maybe_record_large_partitions(const sstables::sstable& sst, const sstables::key& key, uint64_t partition_size) {
@@ -56,8 +68,6 @@ future<> large_data_handler::stop() {
     _running = false;
     return _sem.wait(max_concurrency);
 }
-
-static logging::logger large_data_logger("large_data");
 
 template <typename T> static std::string key_to_str(const T& key, const schema& s) {
     std::ostringstream oss;

--- a/db/large_data_handler.cc
+++ b/db/large_data_handler.cc
@@ -84,19 +84,22 @@ future<> large_data_handler::maybe_delete_large_data_entries(sstables::shared_ss
     auto data_size = sst->data_size();
 
     future<> large_partitions = make_ready_future<>();
-    if (__builtin_expect(data_size > _partition_threshold_bytes, false)) {
+    auto entry = sst->get_large_data_stat(sstables::large_data_type::partition_size);
+    if (entry ? entry->above_threshold : (data_size > _partition_threshold_bytes)) {
         large_partitions = with_sem([schema, filename, this] () mutable {
             return delete_large_data_entries(*schema, std::move(filename), db::system_keyspace::LARGE_PARTITIONS);
         });
     }
     future<> large_rows = make_ready_future<>();
-    if (__builtin_expect(data_size > _row_threshold_bytes, false)) {
+    entry = sst->get_large_data_stat(sstables::large_data_type::row_size);
+    if (entry ? entry->above_threshold : (data_size > _row_threshold_bytes)) {
         large_rows = with_sem([schema, filename, this] () mutable {
             return delete_large_data_entries(*schema, std::move(filename), db::system_keyspace::LARGE_ROWS);
         });
     }
     future<> large_cells = make_ready_future<>();
-    if (__builtin_expect(data_size > _cell_threshold_bytes, false)) {
+    entry = sst->get_large_data_stat(sstables::large_data_type::cell_size);
+    if (entry ? entry->above_threshold : (data_size > _cell_threshold_bytes)) {
         large_cells = with_sem([schema, filename, this] () mutable {
             return delete_large_data_entries(*schema, std::move(filename), db::system_keyspace::LARGE_CELLS);
         });

--- a/db/large_data_handler.hh
+++ b/db/large_data_handler.hh
@@ -24,6 +24,7 @@
 #include <cstdint>
 #include "schema_fwd.hh"
 #include "system_keyspace.hh"
+#include "sstables/shared_sstable.hh"
 
 namespace sstables {
 class sstable;
@@ -113,7 +114,7 @@ public:
         return make_ready_future<bool>(false);
     }
 
-    future<> maybe_delete_large_data_entries(const schema& s, sstring filename, uint64_t data_size);
+    future<> maybe_delete_large_data_entries(sstables::shared_sstable sst);
 
     const large_data_handler::stats& stats() const { return _stats; }
 

--- a/db/large_data_handler.hh
+++ b/db/large_data_handler.hh
@@ -113,28 +113,7 @@ public:
         return make_ready_future<bool>(false);
     }
 
-    future<> maybe_delete_large_data_entries(const schema& s, sstring filename, uint64_t data_size) {
-        assert(running());
-        future<> large_partitions = make_ready_future<>();
-        if (__builtin_expect(data_size > _partition_threshold_bytes, false)) {
-            large_partitions = with_sem([&s, filename, this] () mutable {
-                return delete_large_data_entries(s, std::move(filename), db::system_keyspace::LARGE_PARTITIONS);
-            });
-        }
-        future<> large_rows = make_ready_future<>();
-        if (__builtin_expect(data_size > _row_threshold_bytes, false)) {
-            large_rows = with_sem([&s, filename, this] () mutable {
-                return delete_large_data_entries(s, std::move(filename), db::system_keyspace::LARGE_ROWS);
-            });
-        }
-        future<> large_cells = make_ready_future<>();
-        if (__builtin_expect(data_size > _cell_threshold_bytes, false)) {
-            large_cells = with_sem([&s, filename, this] () mutable {
-                return delete_large_data_entries(s, std::move(filename), db::system_keyspace::LARGE_CELLS);
-            });
-        }
-        return when_all(std::move(large_partitions), std::move(large_rows), std::move(large_cells)).discard_result();
-    }
+    future<> maybe_delete_large_data_entries(const schema& s, sstring filename, uint64_t data_size);
 
     const large_data_handler::stats& stats() const { return _stats; }
 

--- a/db/large_data_handler.hh
+++ b/db/large_data_handler.hh
@@ -69,11 +69,7 @@ private:
     mutable large_data_handler::stats _stats;
 
 public:
-    explicit large_data_handler(uint64_t partition_threshold_bytes, uint64_t row_threshold_bytes, uint64_t cell_threshold_bytes, uint64_t rows_count_threshold)
-        : _partition_threshold_bytes(partition_threshold_bytes)
-        , _row_threshold_bytes(row_threshold_bytes)
-        , _cell_threshold_bytes(cell_threshold_bytes)
-        , _rows_count_threshold(rows_count_threshold) {}
+    explicit large_data_handler(uint64_t partition_threshold_bytes, uint64_t row_threshold_bytes, uint64_t cell_threshold_bytes, uint64_t rows_count_threshold);
     virtual ~large_data_handler() {}
 
     // Once large_data_handler is stopped no further updates will be accepted.

--- a/db/large_data_handler.hh
+++ b/db/large_data_handler.hh
@@ -138,6 +138,19 @@ public:
 
     const large_data_handler::stats& stats() const { return _stats; }
 
+    uint64_t get_partition_threshold_bytes() const noexcept {
+        return _partition_threshold_bytes;
+    }
+    uint64_t get_row_threshold_bytes() const noexcept {
+        return _row_threshold_bytes;
+    }
+    uint64_t get_cell_threshold_bytes() const noexcept {
+        return _cell_threshold_bytes;
+    }
+    uint64_t get_rows_count_threshold() const noexcept {
+        return _rows_count_threshold;
+    }
+
 protected:
     virtual void log_too_many_rows(const sstables::sstable& sst, const sstables::key& partition_key, uint64_t rows_count) const = 0;
     virtual future<> record_large_cells(const sstables::sstable& sst, const sstables::key& partition_key,

--- a/docs/sstable-scylla-format.md
+++ b/docs/sstable-scylla-format.md
@@ -26,6 +26,7 @@ in individual sections
         | features
         | extension_attributes
         | run_identifier
+        | large_data_stats
 
 `sharding_metadata` (tag 1): describes what token sub-ranges are included in this
 sstable. This is used, when loading the sstable, to determine which shard(s)
@@ -37,6 +38,9 @@ it occupies.
 
 `run_identifier` (tag 4): a uuid that is the same for all sstables in the same run
 (and different for sstables in different runs).
+
+`large_data_stats`: a map<large_data_type, large_data_stats_entry> with statistics
+about large data entities in the sstable.
 
 ## sharding_metadata subcomponent
 
@@ -101,3 +105,20 @@ There are currently no defined attributes.
 If the run_identifier subcomponent is present, the sstable is part of a run.
 All sstables with the same run_identifier belong to the same run. They are
 guaranteed to be disjoint (non-overlapping) in their partition keys.
+
+## large_data_stats subcomponent
+
+    large_data_stats = large_data_count large_data_pair*
+    large_data_count = be32
+    large_data_pair = large_data_type large_data_stats_entry
+    large_data_type = be32
+    large_data_stats_entry = max_value threshold above_threshold
+    max_value = be64
+    threshold = be64
+    above_threshold = be32
+
+The large_data_stats component holds statistics about partition,
+row, and cell sizes and about number of rows in partition.
+For each entry, it keeps the largest value for the entry type,
+the respective large_data threshold and the number of entities
+that are above the threshold.

--- a/sstables/kl/writer.cc
+++ b/sstables/kl/writer.cc
@@ -613,7 +613,6 @@ stop_iteration sstable_writer_k_l::consume_end_of_partition() {
     _c_stats.partition_size = _writer->offset() - _c_stats.start_offset;
 
     _sst.get_large_data_handler().maybe_record_large_partitions(_sst, *_partition_key, _c_stats.partition_size).get();
-    _sst.get_large_data_handler().maybe_log_too_many_rows(_sst, *_partition_key, _c_stats.rows_count);
 
     // update is about merging column_stats with the data being stored by collector.
     _collector.update(std::move(_c_stats));

--- a/sstables/kl/writer.cc
+++ b/sstables/kl/writer.cc
@@ -662,7 +662,7 @@ void sstable_writer_k_l::consume_end_of_stream()
         features.disable(sstable_feature::NonCompoundRangeTombstones);
     }
     run_identifier identifier{_run_identifier};
-    _sst.write_scylla_metadata(_pc, _shard, std::move(features), std::move(identifier));
+    _sst.write_scylla_metadata(_pc, _shard, std::move(features), std::move(identifier), {});
 
     if (!_leave_unsealed) {
         _sst.seal_sstable(_backup).get();

--- a/sstables/mx/writer.cc
+++ b/sstables/mx/writer.cc
@@ -1512,7 +1512,8 @@ void writer::consume_end_of_stream() {
         features.disable(sstable_feature::CorrectStaticCompact);
     }
     run_identifier identifier{_run_identifier};
-    _sst.write_scylla_metadata(_pc, _shard, std::move(features), std::move(identifier));
+    std::optional<scylla_metadata::large_data_stats> ld_stats(std::move(_large_data_stats));
+    _sst.write_scylla_metadata(_pc, _shard, std::move(features), std::move(identifier), std::move(ld_stats));
     if (!_cfg.leave_unsealed) {
         _sst.seal_sstable(_cfg.backup).get();
     }

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -2947,6 +2947,16 @@ std::ostream& operator<<(std::ostream& out, const sstables::component_type& comp
     return out;
 }
 
+std::optional<large_data_stats_entry> sstable::get_large_data_stat(large_data_type t) const noexcept {
+    if (_large_data_stats) {
+        auto it = _large_data_stats->map.find(t);
+        if (it != _large_data_stats->map.end()) {
+            return std::make_optional<large_data_stats_entry>(it->second);
+        }
+    }
+    return std::make_optional<large_data_stats_entry>();
+}
+
 }
 
 namespace seastar {

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -2661,7 +2661,7 @@ sstable::unlink()
     });
 
     name = get_filename();
-    fut = get_large_data_handler().maybe_delete_large_data_entries(*get_schema(), name, data_size());
+    fut = get_large_data_handler().maybe_delete_large_data_entries(shared_from_this());
     auto update_large_data_fut = fut.then_wrapped([name = std::move(name)] (future<> f) {
         if (f.failed()) {
             // Just log and ignore failures to delete large data entries.

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -1600,7 +1600,8 @@ sstable::read_scylla_metadata(const io_priority_class& pc) noexcept {
 }
 
 void
-sstable::write_scylla_metadata(const io_priority_class& pc, shard_id shard, sstable_enabled_features features, struct run_identifier identifier) {
+sstable::write_scylla_metadata(const io_priority_class& pc, shard_id shard, sstable_enabled_features features, struct run_identifier identifier,
+        std::optional<scylla_metadata::large_data_stats> ld_stats) {
     auto&& first_key = get_first_decorated_key();
     auto&& last_key = get_last_decorated_key();
     auto sm = create_sharding_metadata(_schema, first_key, last_key, shard);
@@ -1618,6 +1619,9 @@ sstable::write_scylla_metadata(const io_priority_class& pc, shard_id shard, ssta
     _components->scylla_metadata->data.set<scylla_metadata_type::Sharding>(std::move(sm));
     _components->scylla_metadata->data.set<scylla_metadata_type::Features>(std::move(features));
     _components->scylla_metadata->data.set<scylla_metadata_type::RunIdentifier>(std::move(identifier));
+    if (ld_stats) {
+        _components->scylla_metadata->data.set<scylla_metadata_type::LargeDataStats>(std::move(*ld_stats));
+    }
 
     write_simple<component_type::Scylla>(*_components->scylla_metadata, pc);
 }

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -1327,6 +1327,11 @@ future<> sstable::open_data() noexcept {
             _open = true;
             return make_ready_future<>();
         });
+    }).then([this] {
+        auto* ld_stats = _components->scylla_metadata->data.get<scylla_metadata_type::LargeDataStats, scylla_metadata::large_data_stats>();
+        if (ld_stats) {
+            _large_data_stats.emplace(*ld_stats);
+        }
     });
 }
 

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -517,6 +517,13 @@ private:
     sstables_stats _stats;
     tracker_link_type _tracker_link;
     manager_link_type _manager_link;
+
+    // The _large_data_stats map stores e.g. largest partitions, rows, cells sizes,
+    // and max number of rows in a partition.
+    //
+    // It can be disengaged normally when loading legacy sstables that do not have this
+    // information in their scylla metadata.
+    std::optional<scylla_metadata::large_data_stats> _large_data_stats;
 public:
     const bool has_component(component_type f) const;
     sstables_manager& manager() { return _manager; }

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -811,6 +811,11 @@ public:
             || _position_range.is_all_clustered_rows(*_schema);
     }
 
+    // Return the large_data_stats_entry identified by large_data_type
+    // iff _large_data_stats is available and the requested entry is in
+    // the map.  Otherwise, return a disengaged optional.
+    std::optional<large_data_stats_entry> get_large_data_stat(large_data_type t) const noexcept;
+
     // Allow the test cases from sstable_test.cc to test private methods. We use
     // a placeholder to avoid cluttering this class too much. The sstable_test class
     // will then re-export as public every method it needs.

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -553,7 +553,8 @@ private:
     void write_compression(const io_priority_class& pc);
 
     future<> read_scylla_metadata(const io_priority_class& pc) noexcept;
-    void write_scylla_metadata(const io_priority_class& pc, shard_id shard, sstable_enabled_features features, run_identifier identifier);
+    void write_scylla_metadata(const io_priority_class& pc, shard_id shard, sstable_enabled_features features, run_identifier identifier,
+            std::optional<scylla_metadata::large_data_stats> ld_stats);
 
     future<> read_filter(const io_priority_class& pc);
 

--- a/sstables/types.hh
+++ b/sstables/types.hh
@@ -509,8 +509,29 @@ struct run_identifier {
     auto describe_type(sstable_version_types v, Describer f) { return f(id); }
 };
 
+// Types of large data statistics.
+//
+// Note: For extensibility, never reuse an identifier,
+// only add new ones, since these are stored on stable storage.
+enum class large_data_type : uint32_t {
+    partition_size = 1,     // partition size, in bytes
+    row_size = 2,           // row size, in bytes
+    cell_size = 3,          // cell size, in bytes
+    rows_in_partition = 4,  // number of rows in a partition
+};
+
+struct large_data_stats_entry {
+    uint64_t max_value;
+    uint64_t threshold;
+    uint32_t above_threshold;
+
+    template <typename Describer>
+    auto describe_type(sstable_version_types v, Describer f) { return f(max_value, threshold, above_threshold); }
+};
+
 struct scylla_metadata {
     using extension_attributes = disk_hash<uint32_t, disk_string<uint32_t>, disk_string<uint32_t>>;
+    using large_data_stats = disk_hash<uint32_t, large_data_type, large_data_stats_entry>;
 
     disk_set_of_tagged_union<scylla_metadata_type,
             disk_tagged_union_member<scylla_metadata_type, scylla_metadata_type::Sharding, sharding_metadata>,

--- a/sstables/types.hh
+++ b/sstables/types.hh
@@ -498,6 +498,7 @@ enum class scylla_metadata_type : uint32_t {
     Features = 2,
     ExtensionAttributes = 3,
     RunIdentifier = 4,
+    LargeDataStats = 5,
 };
 
 struct run_identifier {
@@ -537,7 +538,8 @@ struct scylla_metadata {
             disk_tagged_union_member<scylla_metadata_type, scylla_metadata_type::Sharding, sharding_metadata>,
             disk_tagged_union_member<scylla_metadata_type, scylla_metadata_type::Features, sstable_enabled_features>,
             disk_tagged_union_member<scylla_metadata_type, scylla_metadata_type::ExtensionAttributes, extension_attributes>,
-            disk_tagged_union_member<scylla_metadata_type, scylla_metadata_type::RunIdentifier, run_identifier>
+            disk_tagged_union_member<scylla_metadata_type, scylla_metadata_type::RunIdentifier, run_identifier>,
+            disk_tagged_union_member<scylla_metadata_type, scylla_metadata_type::LargeDataStats, large_data_stats>
             > data;
 
     sstable_enabled_features get_features() const {


### PR DESCRIPTION
This series introduces a `large_data_counters` element to `scylla_metadata` component to explicitly count the number of `large_{partitions,rows,cells}` and `too_many_rows` in the sstable.  These are accounted for in the sstable writer whenever the respective large data entry is encountered.

It is taken into account in `large_data_handler::maybe_delete_large_data_entries`, when engaged.
Otherwise, if deleting a legacy sstable that has no such entry in `scylla_metadata`, just revert to using the current method of comparing the sstable's `data_size` to the various thresholds.

Fixes #7668

Test: unit(dev)
Dtest: wide_rows_test.py (in progress)