### PR TITLE
build: compress unified package faster

### DIFF
--- a/unified/build_unified.sh
+++ b/unified/build_unified.sh
@@ -75,4 +75,4 @@ done
 ln -f unified/install.sh build/"$MODE"/unified/
 ln -f unified/uninstall.sh build/"$MODE"/unified/
 cd build/"$MODE"/unified
-tar czpf "$UNIFIED_PKG" * .relocatable_package_version
+tar cpf "$UNIFIED_PKG" --use-compress-program=pigz * .relocatable_package_version


### PR DESCRIPTION
The unified package is quite large (1GB compressed), and it
is the last step in the build so its build time cannot be
parallized with other tasks. Compress it with pigz to take
advantage of multiple cores and speed up the build a little.