### PR TITLE
scylla_prepare: add --tune system when SET_CLOCKSOURCE=yes

### DIFF
--- a/dist/common/scripts/scylla_prepare
+++ b/dist/common/scripts/scylla_prepare
@@ -71,7 +71,7 @@ def create_perftune_conf(cfg):
         params += '--tune net --nic "{nic}"'.format(nic=nic)
 
     if cfg.has_option('SET_CLOCKSOURCE') and cfg.get('SET_CLOCKSOURCE') == 'yes':
-        params += ' --tune-clock'
+        params += ' --tune system --tune-clock'
 
     if len(params) > 0:
         if os.path.exists('/etc/scylla.d/perftune.yaml'):


### PR DESCRIPTION
perftune.py only run clocksource setup when --tune system specified,
so we need to add it on the parameter when SET_CLOCKSOURCE=yes.

Fixes #7672