### PR TITLE
configure.py: Use variables for product, version, and release

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1845,7 +1845,7 @@ with open(buildfile_tmp, 'w') as f:
         build dist-server: phony dist-server-tar dist-server-rpm dist-server-deb
 
         rule build-submodule-reloc
-          command = cd $reloc_dir && ./reloc/build_reloc.sh --version $$(<../../build/SCYLLA-PRODUCT-FILE)-$$(<../../build/SCYLLA-VERSION-FILE)-$$(<../../build/SCYLLA-RELEASE-FILE) --nodeps $args
+          command = cd $reloc_dir && ./reloc/build_reloc.sh --version {scylla_product}-{scylla_version}-{scylla_release} --nodeps $args
         rule build-submodule-rpm
           command = cd $dir && ./reloc/build_rpm.sh --reloc-pkg $artifact
         rule build-submodule-deb


### PR DESCRIPTION
The configure.py script has variables for Scylla product, version, and
release. Use them instead of reading the
SCYLLA-{PRODUCT,VERSION,RELEASE} files.