### PR TITLE
sstables: add `may_have_partition_tombstones` method

### DIFF
--- a/position_in_partition.hh
+++ b/position_in_partition.hh
@@ -593,6 +593,7 @@ public:
     position_in_partition&& end() && { return std::move(_end); }
     bool contains(const schema& s, position_in_partition_view pos) const;
     bool overlaps(const schema& s, position_in_partition_view start, position_in_partition_view end) const;
+    bool is_all_clustered_rows(const schema&) const;
 
     friend std::ostream& operator<<(std::ostream&, const position_range&);
 };
@@ -609,4 +610,9 @@ inline
 bool position_range::overlaps(const schema& s, position_in_partition_view start, position_in_partition_view end) const {
     position_in_partition::less_compare less(s);
     return !less(end, _start) && less(start, _end);
+}
+
+inline
+bool position_range::is_all_clustered_rows(const schema& s) const {
+    return _start.is_before_all_clustered_rows(s) && _end.is_after_all_clustered_rows(s);
 }

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -797,6 +797,12 @@ public:
     // Return true if this sstable possibly stores clustering row(s) specified by ranges.
     bool may_contain_rows(const query::clustering_row_ranges& ranges) const;
 
+    // false => there are no partition tombstones, true => we don't know
+    bool may_have_partition_tombstones() const {
+        return !has_correct_min_max_column_names()
+            || _position_range.is_all_clustered_rows(*_schema);
+    }
+
     // Allow the test cases from sstable_test.cc to test private methods. We use
     // a placeholder to avoid cluttering this class too much. The sstable_test class
     // will then re-export as public every method it needs.

--- a/test/boost/sstable_datafile_test.cc
+++ b/test/boost/sstable_datafile_test.cc
@@ -6685,3 +6685,43 @@ SEASTAR_TEST_CASE(test_zero_estimated_partitions) {
         return make_ready_future<>();
     });
 }
+
+SEASTAR_TEST_CASE(test_may_have_partition_tombstones) {
+    return test_env::do_with_async([] (test_env& env) {
+        storage_service_for_tests ssft;
+        simple_schema ss;
+        auto s = ss.schema();
+        auto pks = ss.make_pkeys(2);
+
+        auto tmp = tmpdir();
+        unsigned gen = 0;
+        for (auto version : all_sstable_versions) {
+            if (version < sstable_version_types::md) {
+                continue;
+            }
+
+            auto mut1 = mutation(s, pks[0]);
+            auto mut2 = mutation(s, pks[1]);
+            mut1.partition().apply_insert(*s, ss.make_ckey(0), ss.new_timestamp());
+            mut1.partition().apply_delete(*s, ss.make_ckey(1), ss.new_tombstone());
+            ss.add_row(mut1, ss.make_ckey(2), "val");
+            ss.delete_range(mut1, query::clustering_range::make({ss.make_ckey(3)}, {ss.make_ckey(5)}));
+            ss.add_row(mut2, ss.make_ckey(6), "val");
+
+            auto sst_gen = [&env, s, &tmp, &gen, version] () {
+                return env.make_sstable(s, tmp.path().string(), ++gen, version, big);
+            };
+
+            {
+                auto sst = make_sstable_containing(sst_gen, {mut1, mut2});
+                sst->load().get();
+                BOOST_REQUIRE(!sst->may_have_partition_tombstones());
+            }
+
+            mut2.partition().apply(ss.new_tombstone());
+            auto sst = make_sstable_containing(sst_gen, {mut1, mut2});
+            sst->load().get();
+            BOOST_REQUIRE(sst->may_have_partition_tombstones());
+        }
+    });
+}


### PR DESCRIPTION
For sstable versions greater or equal than md, the `min_max_column_names`
sstable metadata gives a range of position-in-partitions such that all
clustering rows stored in this sstable have positions in this range.

Partition tombstones in this context are understood as covering the
entire range of clustering keys; thus, if the sstable contains at least
one partition tombstone, the sstable position range is set to be the
range of all clustered rows.

Therefore, by checking that the position range is *not* the range of all
clustered rows we know that the sstable cannot have any partition tombstones.

Manually tested that it works with Cassandra md sstables as well.

Refs: https://github.com/scylladb/scylla/pull/7646, https://github.com/scylladb/scylla/pull/7437