### PR TITLE
flat_mutation_reader: document assumption about fast_forward_to

### DIFF
--- a/flat_mutation_reader.hh
+++ b/flat_mutation_reader.hh
@@ -433,6 +433,11 @@ public:
     //
     // When forwarding mode is not enabled, fast_forward_to()
     // cannot be used.
+    //
+    // `fast_forward_to` can be called only when the reader is within a partition
+    // and it affects the set of fragments returned from that partition.
+    // In particular one must first enter a partition by fetching a `partition_start`
+    // fragment before calling `fast_forward_to`.
     future<> fast_forward_to(position_range cr, db::timeout_clock::time_point timeout) {
         return _impl->fast_forward_to(std::move(cr), timeout);
     }


### PR DESCRIPTION
It is not legal to fast forward a reader before it enters a partition.
One must ensure that there even is a partition in the first place. For
this one must fetch a `partition_start` fragment.

This PR is a follow-up to a discussion on Slack.