### PR TITLE
mutation_reader: introduce clustering_order_reader_merger

### DIFF
--- a/mutation_reader.hh
+++ b/mutation_reader.hh
@@ -609,3 +609,65 @@ std::pair<flat_mutation_reader, queue_reader_handle> make_queue_reader(schema_pt
 /// supported.
 flat_mutation_reader make_compacting_reader(flat_mutation_reader source, gc_clock::time_point compaction_time,
         std::function<api::timestamp_type(const dht::decorated_key&)> get_max_purgeable);
+
+// A mutation reader together with an upper bound on the set of positions of fragments
+// that the reader will return. The upper bound does not need to be exact.
+struct reader_and_upper_bound {
+    flat_mutation_reader reader;
+    position_in_partition upper_bound;
+
+    reader_and_upper_bound(flat_mutation_reader r, position_in_partition bound)
+        : reader(std::move(r)), upper_bound(std::move(bound)) {}
+};
+
+// A queue of mutation readers returning fragments with the same schema from the same single partition.
+//
+// Intuitively, the order of returned readers is such that the positions of the first fragments
+// returned by the readers inside the partition (after `partition_start`) are ``mostly increasing''.
+//
+// More formally:
+// 1. The queue contains a sequence of readers.
+//    Each call to `pop` consumes a batch of readers from the sequence.
+// 2. Each position-in-partition `b` corresponds to a prefix of the sequence of readers in the queue.
+//    Let's call it `pref(b)`.
+// 3. If `b1 <= b2`, then `pref(b1)` is a prefix of `pref(b2)`.
+// 4. `pref(position_in_partition::after_all_clustered_rows())` is the entire sequence.
+// 5. For each `b`, `pop(b)` returns only readers from `pref(b)`.
+// 6. For each `b`, all readers that lie in the sequence after `pref(b)`
+//    satisfy the following property:
+//        the first fragment returned by the reader has a position greater than `b`.
+//    In other words, if `pop(b)` returns no readers, then we can be sure that all readers
+//    returned later by the queue return fragments with positions greater than `b`.
+//
+// Considering the above properties, a simple legal implementation of this interface would
+// return all readers on the first call to `pop(after_all_clustered_rows())` and would not return
+// any readers on `pop(b)` for `b < after_all_clustered_rows()`.
+//
+// Better implementations may use information about positions returned by the readers
+// to return some readers earlier, but they must not break property 6.
+// For example, the following scenario is illegal:
+// 1. pop(for_key(10)) returns r1
+// 2. pop(for_key(10)) returns no readers => all readers from pref(for_key(10)) have been popped
+// 3. pop(for_key(20)) returns r2 => due to the previous step we know that r2 is not in pref(for_key(10))
+// 4. the first fragment (excluding partition_start) returned by r2 has position for_key(10)
+//        => illegal, because for_key(10) is not greater than for_key(10).
+//        The first position returned by r2 must be after_key(10) or higher.
+//
+// With each reader also comes an upper bound on the set of positions of fragments that the reader will return.
+class position_reader_queue {
+public:
+    virtual ~position_reader_queue() = 0;
+
+    // `empty(b)` <=>
+    //      we have popped all readers from `pref(b)` so `pop(b)`
+    //      will not return any more readers.
+    virtual bool empty(position_in_partition_view bound) const = 0;
+
+    // Return the next batch of readers from `pref(b)`.
+    virtual std::vector<reader_and_upper_bound> pop(position_in_partition_view bound) = 0;
+};
+
+flat_mutation_reader make_clustering_combined_reader(schema_ptr schema,
+        reader_permit,
+        streamed_mutation::forwarding,
+        std::unique_ptr<position_reader_queue>);

--- a/test/boost/mutation_reader_test.cc
+++ b/test/boost/mutation_reader_test.cc
@@ -27,6 +27,7 @@
 #include <seastar/core/sleep.hh>
 #include <seastar/core/do_with.hh>
 #include <seastar/core/thread.hh>
+#include <seastar/core/coroutine.hh>
 
 #include <seastar/testing/test_case.hh>
 #include <seastar/testing/thread_test_case.hh>

--- a/test/lib/mutation_source_test.hh
+++ b/test/lib/mutation_source_test.hh
@@ -73,3 +73,6 @@ bytes make_blob(size_t blob_size);
 
 void for_each_schema_change(std::function<void(schema_ptr, const std::vector<mutation>&,
                                                schema_ptr, const std::vector<mutation>&)>);
+
+void compare_readers(const schema&, flat_mutation_reader authority, flat_mutation_reader tested);
+void compare_readers(const schema&, flat_mutation_reader authority, flat_mutation_reader tested, const std::vector<position_range>& fwd_ranges);

--- a/test/lib/random_schema.cc
+++ b/test/lib/random_schema.cc
@@ -210,17 +210,6 @@ std::unique_ptr<random_schema_specification> make_random_schema_specification(
 
 namespace {
 
-// Picks a random subset of size `m` from the set {0, ..., `n` - 1}.
-std::vector<unsigned> random_subset(unsigned n, unsigned m, std::mt19937& engine) {
-    assert(m <= n);
-
-    std::vector<unsigned> the_set(n);
-    std::iota(the_set.begin(), the_set.end(), 0u);
-    std::shuffle(the_set.begin(), the_set.end(), engine);
-
-    return {the_set.begin(), the_set.begin() + m};
-}
-
 utils::multiprecision_int generate_multiprecision_integer_value(std::mt19937& engine, size_t max_size_in_bytes) {
     using utils::multiprecision_int;
 
@@ -280,7 +269,7 @@ data_model::mutation_description::collection generate_user_value(std::mt19937& e
 
     // Non-null fields.
     auto fields_num = std::uniform_int_distribution<size_t>(1, type.size())(engine);
-    auto field_idxs = random_subset(type.size(), fields_num, engine);
+    auto field_idxs = random::random_subset<unsigned>(type.size(), fields_num, engine);
     std::sort(field_idxs.begin(), field_idxs.end());
 
     md::collection collection;

--- a/test/lib/random_utils.hh
+++ b/test/lib/random_utils.hh
@@ -166,4 +166,22 @@ inline sstring get_sstring() {
     return get_sstring(get_int<unsigned>(1024));
 }
 
+// Picks a random subset of size `m` from the given vector.
+template <typename T>
+std::vector<T> random_subset(std::vector<T> v, unsigned m, std::mt19937& engine) {
+    assert(m <= v.size());
+    std::shuffle(v.begin(), v.end(), engine);
+    return {v.begin(), v.begin() + m};
+}
+
+// Picks a random subset of size `m` from the set {0, ..., `n` - 1}.
+template<typename T>
+std::vector<T> random_subset(unsigned n, unsigned m, std::mt19937& engine) {
+    assert(m <= n);
+
+    std::vector<T> the_set(n);
+    std::iota(the_set.begin(), the_set.end(), T{});
+    return random_subset(std::move(the_set), m, engine);
+}
+
 }

--- a/test/lib/simple_position_reader_queue.hh
+++ b/test/lib/simple_position_reader_queue.hh
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2020 ScyllaDB
+ */
+
+/*
+ * This file is part of Scylla.
+ *
+ * Scylla is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ *
+ * (at your option) any later version.
+ *
+ * Scylla is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "mutation_reader.hh"
+
+/*
+ * Single-partition reader, a lower bound and an upper bound for the set of positions
+ * of fragments returned by the reader. The bounds don't need to be exact.
+ */
+struct reader_bounds {
+    flat_mutation_reader r;
+    position_in_partition lower;
+    position_in_partition upper;
+};
+
+/*
+ * Returns readers from an a-priori prepared set of readers with determined lower and upper bounds
+ * on the positions of their fragments.
+ */
+struct simple_position_reader_queue : public position_reader_queue {
+    position_in_partition::tri_compare _cmp;
+
+    using container_t = std::vector<reader_bounds>;
+    container_t _rs;
+    container_t::iterator _it;
+
+    simple_position_reader_queue(const schema& s, std::vector<reader_bounds> rs)
+        // precondition: rs sorted w.r.t lower.
+        // `s` must be kept alive until the last call to `pop` or `empty`.
+        : _cmp(s), _rs(std::move(rs)), _it(_rs.begin())
+    { }
+
+    virtual ~simple_position_reader_queue() override = default;
+
+    virtual std::vector<reader_and_upper_bound> pop(position_in_partition_view bound) override {
+        if (empty(bound)) {
+            return {};
+        }
+
+        // !empty(bound) implies that _it->lower <= bound.
+
+        std::vector<reader_and_upper_bound> ret;
+        auto it = _it;
+        for (; it != _rs.end() && _cmp(_it->lower, it->lower) == 0; ++it) {
+            ret.emplace_back(std::move(it->r), std::move(it->upper));
+        }
+        _it = it;
+        return ret;
+    }
+
+    virtual bool empty(position_in_partition_view bound) const override {
+        return _it == _rs.end() || _cmp(bound, _it->lower) < 0;
+    }
+};


### PR DESCRIPTION
This abstraction is used to merge the output of multiple readers, each
opened for a single partition query, into a non-decreasing stream
of mutation_fragments.

It is similar to `mutation_reader_merger`,
but an important difference is that the new merger may select new readers
in the middle of a partition after it already returned some fragments
from that partition.  It uses the new `position_reader_queue` abstraction
to select new readers. It doesn't support multi-partition (ring range) queries.

The new merger will be later used when reading from sstable sets created
by TimeWindowCompactionStrategy. This strategy creates many sstables
that are mostly disjoint w.r.t the contained clustering keys, so we can
delay opening sstable readers when querying a partition until after we have
processed all mutation fragments with positions before the keys
contained by these sstables.

A microbenchmark was added that compares the existing combining reader
(which uses `mutation_reader_merger` underneath) with a new combining reader
built using the new `clustering_order_reader_merger` and a simple queue of readers
that returns readers from some supplied set. The used set of readers is built from the following
ranges of keys (each range corresponds to a single reader):
`[0, 31]`, `[30, 61]`, `[60, 91]`, `[90, 121]`, `[120, 151]`.
The microbenchmark runs the reader and divides the result by the number of mutation fragments.
The results on my laptop were:
```
$ build/release/test/perf/perf_mutation_readers -t clustering_combined.* -r 10
single run iterations:    0
single run duration:      1.000s
number of runs:           10

test                                      iterations      median         mad         min         max
clustering_combined.ranges_generic           2911678   117.598ns     0.685ns   116.175ns   119.482ns
clustering_combined.ranges_specialized       3005618   111.015ns     0.349ns   110.063ns   111.840ns
```
`ranges_generic` denotes the existing combining reader, `ranges_specialized` denotes the new reader.

Split from https://github.com/scylladb/scylla/pull/7437.
