### PR TITLE
Do not run out of memory if a large run of tombstones is encountered

### DIFF
--- a/database.cc
+++ b/database.cc
@@ -1413,6 +1413,13 @@ database::get_query_class_config(const query::read_command& cmd) {
     return query::query_class_config{
             .semaphore = semaphore,
             .max_memory_for_unlimited_query = *cmd.max_result_size,
+            .tombstone_thresholds = &semaphore == &_read_concurrency_sem
+                ? tombstone_thresholds{
+                    .tombstone_warn_threshold = _cfg.tombstone_warn_threshold(),
+                    .tombstone_fail_threshold = _cfg.tombstone_failure_threshold(),
+                    }
+                // system/streaming reads bypass the tombstone failure thresholds to avoid killing the system
+                : tombstone_thresholds{},
     };
 }
 

--- a/database.hh
+++ b/database.hh
@@ -1361,6 +1361,7 @@ private:
     Future update_write_metrics(Future&& f);
     void update_write_metrics_for_timed_out_write();
     future<> create_keyspace(const lw_shared_ptr<keyspace_metadata>&, bool is_bootstrap);
+    query::query_class_config get_query_class_config(const query::read_command& cmd);
 public:
     static utils::UUID empty_version;
 

--- a/db/config.cc
+++ b/db/config.cc
@@ -490,9 +490,9 @@ db::config::config(std::shared_ptr<db::extensions> exts)
     /* Tombstone settings */
     /* When executing a scan, within or across a partition, tombstones must be kept in memory to allow returning them to the coordinator. The coordinator uses them to ensure other replicas know about the deleted rows. Workloads that generate numerous tombstones may cause performance problems and exhaust the server heap. See Cassandra anti-patterns: Queues and queue-like datasets. Adjust these thresholds only if you understand the impact and want to scan more tombstones. Additionally, you can adjust these thresholds at runtime using the StorageServiceMBean. */
     /* Related information: Cassandra anti-patterns: Queues and queue-like datasets */
-    , tombstone_warn_threshold(this, "tombstone_warn_threshold", value_status::Unused, 1000,
+    , tombstone_warn_threshold(this, "tombstone_warn_threshold", liveness::LiveUpdate, value_status::Used, 1000,
         "The maximum number of tombstones a query can scan before warning.")
-    , tombstone_failure_threshold(this, "tombstone_failure_threshold", value_status::Unused, 100000,
+    , tombstone_failure_threshold(this, "tombstone_failure_threshold", liveness::LiveUpdate, value_status::Used, 100000,
         "The maximum number of tombstones a query can scan before aborting.")
     /* Network timeout settings */
     , range_request_timeout_in_ms(this, "range_request_timeout_in_ms", value_status::Used, 10000,

--- a/frozen_mutation.cc
+++ b/frozen_mutation.cc
@@ -177,6 +177,18 @@ frozen_mutation streamed_mutation_freezer::consume_end_of_stream() {
     return frozen_mutation(std::move(out), std::move(_key));
 }
 
+streamed_mutation_freezer::primary_key
+streamed_mutation_freezer::current_position_for_debug() const {
+    std::optional<clustering_key_prefix> ck;
+    if (!_crs.empty()) {
+        ck.emplace(_crs.back().key());
+    }
+    return {
+        .pk = _key,
+        .ck = std::move(ck),
+    };
+}
+
 class fragmenting_mutation_freezer {
     const schema& _schema;
     std::optional<partition_key> _key;

--- a/frozen_mutation.hh
+++ b/frozen_mutation.hh
@@ -112,6 +112,13 @@ public:
     stop_iteration consume(range_tombstone&& rt);
 
     frozen_mutation consume_end_of_stream();
+
+    struct primary_key {
+        partition_key pk;
+        std::optional<clustering_key_prefix> ck;
+    };
+
+    primary_key current_position_for_debug() const;
 };
 
 static constexpr size_t default_frozen_fragment_size = 128 * 1024;

--- a/multishard_mutation_query.cc
+++ b/multishard_mutation_query.cc
@@ -617,11 +617,12 @@ static future<reconcilable_result> do_query_mutations(
         const dht::partition_range_vector& ranges,
         tracing::trace_state_ptr trace_state,
         db::timeout_clock::time_point timeout,
-        query::result_memory_accounter&& accounter) {
+        query::result_memory_accounter&& accounter,
+        multishard_mutation_query_config cfg) {
     return do_with(seastar::make_shared<read_context>(db, s, cmd, ranges, trace_state), [&db, s, &cmd, &ranges, trace_state, timeout,
-            accounter = std::move(accounter)] (shared_ptr<read_context>& ctx) mutable {
+            accounter = std::move(accounter), cfg] (shared_ptr<read_context>& ctx) mutable {
         return ctx->lookup_readers().then([&ctx, s = std::move(s), &cmd, &ranges, trace_state, timeout,
-                accounter = std::move(accounter)] () mutable {
+                accounter = std::move(accounter), cfg] () mutable {
             auto ms = mutation_source([&] (schema_ptr s,
                     reader_permit permit,
                     const dht::partition_range& pr,
@@ -638,9 +639,12 @@ static future<reconcilable_result> do_query_mutations(
             auto compaction_state = make_lw_shared<compact_for_mutation_query_state>(*s, cmd.timestamp, cmd.slice, cmd.get_row_limit(),
                     cmd.partition_limit);
 
-            return do_with(std::move(reader), std::move(compaction_state), [&, accounter = std::move(accounter), timeout] (
+            return do_with(std::move(reader), std::move(compaction_state), [&, accounter = std::move(accounter), timeout, cfg] (
                         flat_mutation_reader& reader, lw_shared_ptr<compact_for_mutation_query_state>& compaction_state) mutable {
-                auto rrb = reconcilable_result_builder(*reader.schema(), cmd.slice, std::move(accounter));
+                auto rrb_cfg = reconcilable_result_builder_config{
+                    .tombstone_thresholds = cfg.tombstone_thresholds,
+                };
+                auto rrb = reconcilable_result_builder(*reader.schema(), cmd.slice, std::move(accounter), rrb_cfg);
                 return query::consume_page(reader, compaction_state, cmd.slice, std::move(rrb), cmd.get_row_limit(), cmd.partition_limit, cmd.timestamp,
                         timeout, *cmd.max_result_size).then([&] (consume_result&& result) mutable {
                     return make_ready_future<page_consume_result>(page_consume_result(std::move(result), reader.detach_buffer(), std::move(compaction_state)));
@@ -672,7 +676,8 @@ future<std::tuple<foreign_ptr<lw_shared_ptr<reconcilable_result>>, cache_tempera
         const query::read_command& cmd,
         const dht::partition_range_vector& ranges,
         tracing::trace_state_ptr trace_state,
-        db::timeout_clock::time_point timeout) {
+        db::timeout_clock::time_point timeout,
+        multishard_mutation_query_config cfg) {
     if (cmd.get_row_limit() == 0 || cmd.slice.partition_row_limit() == 0 || cmd.partition_limit == 0) {
         return make_ready_future<std::tuple<foreign_ptr<lw_shared_ptr<reconcilable_result>>, cache_temperature>>(
             std::tuple(
@@ -682,8 +687,8 @@ future<std::tuple<foreign_ptr<lw_shared_ptr<reconcilable_result>>, cache_tempera
 
     const auto short_read_allowed = query::short_read(cmd.slice.options.contains<query::partition_slice::option::allow_short_read>());
     return db.local().get_result_memory_limiter().new_mutation_read(*cmd.max_result_size, short_read_allowed).then([&, s = std::move(s),
-            trace_state = std::move(trace_state), timeout] (query::result_memory_accounter accounter) mutable {
-        return do_query_mutations(db, s, cmd, ranges, std::move(trace_state), timeout, std::move(accounter)).then_wrapped(
+            trace_state = std::move(trace_state), timeout, cfg] (query::result_memory_accounter accounter) mutable {
+        return do_query_mutations(db, s, cmd, ranges, std::move(trace_state), timeout, std::move(accounter), cfg).then_wrapped(
                     [&db, s = std::move(s)] (future<reconcilable_result>&& f) {
             auto& local_db = db.local();
             auto& stats = local_db.get_stats();

--- a/multishard_mutation_query.hh
+++ b/multishard_mutation_query.hh
@@ -28,6 +28,10 @@
 
 #include <seastar/core/distributed.hh>
 
+struct multishard_mutation_query_config {
+    ::tombstone_thresholds tombstone_thresholds;
+};
+
 /// Run the mutation query on all shards.
 ///
 /// Under the hood it uses a multishard_combining_reader for reading the
@@ -67,4 +71,5 @@ future<std::tuple<foreign_ptr<lw_shared_ptr<reconcilable_result>>, cache_tempera
         const query::read_command& cmd,
         const dht::partition_range_vector& ranges,
         tracing::trace_state_ptr trace_state,
-        db::timeout_clock::time_point timeout);
+        db::timeout_clock::time_point timeout,
+        multishard_mutation_query_config cfg);

--- a/mutation_partition.cc
+++ b/mutation_partition.cc
@@ -2386,7 +2386,10 @@ static do_mutation_query(schema_ptr s,
 
     return do_with(std::move(q), [=, &slice, accounter = std::move(accounter), trace_ptr = std::move(trace_ptr), cache_ctx = std::move(cache_ctx)] (
                 query::mutation_querier& q) mutable {
-        auto rrb = reconcilable_result_builder(*s, slice, std::move(accounter));
+        auto rrb = reconcilable_result_builder(*s, slice, std::move(accounter),
+                reconcilable_result_builder_config{
+                    .tombstone_thresholds = class_config.tombstone_thresholds,
+                });
         return q.consume_page(std::move(rrb), row_limit, partition_limit, query_time, timeout, class_config.max_memory_for_unlimited_query).then(
                 [=, &q, trace_ptr = std::move(trace_ptr), cache_ctx = std::move(cache_ctx)] (reconcilable_result r) mutable {
             if (q.are_limits_reached() || r.is_short_read()) {

--- a/mutation_query.hh
+++ b/mutation_query.hh
@@ -161,7 +161,7 @@ class reconcilable_result_builder {
 public:
     reconcilable_result_builder(const schema& s, const query::partition_slice& slice,
                                 query::result_memory_accounter&& accounter,
-                                reconcilable_result_builder_config cfg = {})
+                                reconcilable_result_builder_config cfg)
         : _schema(s), _slice(slice)
         , _memory_accounter(std::move(accounter))
         , _cfg(cfg)

--- a/query_class_config.hh
+++ b/query_class_config.hh
@@ -22,6 +22,7 @@
 #pragma once
 
 #include <cinttypes>
+#include "tombstone_thresholds.hh"
 
 class reader_concurrency_semaphore;
 
@@ -39,6 +40,7 @@ struct max_result_size {
 struct query_class_config {
     reader_concurrency_semaphore& semaphore;
     max_result_size max_memory_for_unlimited_query;
+    ::tombstone_thresholds tombstone_thresholds;
 };
 
 }

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -5188,7 +5188,13 @@ storage_proxy::query_nonsingular_mutations_locally(schema_ptr s,
                                                    storage_proxy::clock_type::time_point timeout) {
     return do_with(cmd, std::move(prs), [this, timeout, s = std::move(s), trace_state = std::move(trace_state)] (lw_shared_ptr<query::read_command>& cmd,
                 const dht::partition_range_vector& prs) mutable {
-        return query_mutations_on_all_shards(_db, std::move(s), *cmd, prs, std::move(trace_state), timeout).then([] (std::tuple<foreign_ptr<lw_shared_ptr<reconcilable_result>>, cache_temperature> t) {
+        multishard_mutation_query_config mmq_cfg = {
+            .tombstone_thresholds = {
+                .tombstone_warn_threshold = _db.local().get_config().tombstone_warn_threshold(),
+                .tombstone_fail_threshold = _db.local().get_config().tombstone_failure_threshold(),
+            },
+        };
+        return query_mutations_on_all_shards(_db, std::move(s), *cmd, prs, std::move(trace_state), timeout, mmq_cfg).then([] (std::tuple<foreign_ptr<lw_shared_ptr<reconcilable_result>>, cache_temperature> t) {
             return make_ready_future<rpc::tuple<foreign_ptr<lw_shared_ptr<reconcilable_result>>, cache_temperature>>(std::move(t));
         });
     });

--- a/test/boost/database_test.cc
+++ b/test/boost/database_test.cc
@@ -510,7 +510,7 @@ SEASTAR_THREAD_TEST_CASE(read_max_size) {
                     });
                 }},
                 {"query_mutations_on_all_shards()", [&e, &partition_ranges] (schema_ptr s, const query::read_command& cmd) -> future<size_t> {
-                    return query_mutations_on_all_shards(e.db(), s, cmd, partition_ranges, {}, db::no_timeout).then(
+                    return query_mutations_on_all_shards(e.db(), s, cmd, partition_ranges, {}, db::no_timeout, {}).then(
                             [] (const std::tuple<foreign_ptr<lw_shared_ptr<reconcilable_result>>, cache_temperature>& res) {
                         return std::get<0>(res)->memory_usage();
                     });

--- a/tombstone_thresholds.hh
+++ b/tombstone_thresholds.hh
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2020 ScyllaDB
+ */
+
+/*
+ * This file is part of Scylla.
+ *
+ * Scylla is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Scylla is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <cinttypes>
+#include <numeric>
+
+struct tombstone_thresholds {
+    uint32_t tombstone_warn_threshold = std::numeric_limits<uint32_t>::max();
+    uint32_t tombstone_fail_threshold = std::numeric_limits<uint32_t>::max();
+};
+


### PR DESCRIPTION
Currently, our paging system requires that we return at least one live row (if the page contains any data at all). This results in partitions composed solely of tombstones (or just a long prefix of tombstones) requiring unbounded memory to store mutation query results. This leads to running out of memory.

Fix this by enabling the `tombstone_failure_threshold` and `tombstone_warn_threshold` configuration parameters, for user queries. If a tombstone run larger than the thresholds is encountered, we warn/fail the query.

Note that data queries are unchanged. They don't cause OOM, but also they don't fail early - they will continue to read tombstones until they time out. This is a smaller problem and can be addressed later.

Fixes #7689 
Ref #3672 (partial fix)