### PR TITLE
types: get rid of linearization in deserialize()

### DIFF
--- a/cql3/constants.hh
+++ b/cql3/constants.hh
@@ -227,9 +227,7 @@ public:
             } else if (value.is_unset_value()) {
                 return;
             }
-            auto increment = with_linearized(*value, [] (bytes_view value_view) {
-                return value_cast<int64_t>(long_type->deserialize_value(value_view));
-            });
+            auto increment = value_cast<int64_t>(long_type->deserialize_value(*value));
             m.set_cell(prefix, column, make_counter_update_cell(increment, params));
         }
     };
@@ -244,9 +242,7 @@ public:
             } else if (value.is_unset_value()) {
                 return;
             }
-            auto increment = with_linearized(*value, [] (bytes_view value_view) {
-                return value_cast<int64_t>(long_type->deserialize_value(value_view));
-            });
+            auto increment = value_cast<int64_t>(long_type->deserialize_value(*value));
             if (increment == std::numeric_limits<int64_t>::min()) {
                 throw exceptions::invalid_request_exception(format("The negation of {:d} overflows supported counter precision (signed 8 bytes integer)", increment));
             }

--- a/cql3/expr/expression.cc
+++ b/cql3/expr/expression.cc
@@ -355,16 +355,12 @@ bytes_opt next_value(query::result_row_view::iterator_type& iter, const column_d
     if (cdef->type->is_multi_cell()) {
         auto cell = iter.next_collection_cell();
         if (cell) {
-            return cell->with_linearized([] (bytes_view data) {
-                return bytes(data.cbegin(), data.cend());
-            });
+            return linearized(*cell);
         }
     } else {
         auto cell = iter.next_atomic_cell();
         if (cell) {
-            return cell->value().with_linearized([] (bytes_view data) {
-                return bytes(data.cbegin(), data.cend());
-            });
+            return linearized(cell->value());
         }
     }
     return std::nullopt;

--- a/cql3/lists.cc
+++ b/cql3/lists.cc
@@ -125,18 +125,11 @@ lists::literal::to_string() const {
 
 lists::value
 lists::value::from_serialized(const fragmented_temporary_buffer::view& val, const list_type_impl& type, cql_serialization_format sf) {
-    return with_linearized(val, [&] (bytes_view v) {
-        return from_serialized(v, type, sf);
-    });
-}
-
-lists::value
-lists::value::from_serialized(bytes_view v, const list_type_impl& type, cql_serialization_format sf) {
     try {
         // Collections have this small hack that validate cannot be called on a serialized object,
         // but compose does the validation (so we're fine).
         // FIXME: deserializeForNativeProtocol()?!
-        auto l = value_cast<list_type_impl::native_type>(type.deserialize(v, sf));
+        auto l = value_cast<list_type_impl::native_type>(type.deserialize(val, sf));
         std::vector<bytes_opt> elements;
         elements.reserve(l.size());
         for (auto&& element : l) {
@@ -234,10 +227,10 @@ lists::marker::bind(const query_options& options) {
         return constants::UNSET_VALUE;
     } else {
         try {
-            return with_linearized(*value, [&] (bytes_view v) {
+            with_linearized(*value, [&] (bytes_view v) {
                 ltype.validate(v, options.get_cql_serialization_format());
-                return make_shared<lists::value>(value::from_serialized(v, ltype, options.get_cql_serialization_format()));
             });
+            return make_shared<lists::value>(value::from_serialized(*value, ltype, options.get_cql_serialization_format()));
         } catch (marshal_exception& e) {
             throw exceptions::invalid_request_exception(
                     format("Exception while binding column {:s}: {:s}", _receiver->name->to_cql_string(), e.what()));

--- a/cql3/lists.cc
+++ b/cql3/lists.cc
@@ -301,9 +301,7 @@ lists::setter_by_index::execute(mutation& m, const clustering_key_prefix& prefix
         return;
     }
 
-    auto idx = with_linearized(*index, [] (bytes_view v) {
-        return value_cast<int32_t>(data_type_for<int32_t>()->deserialize(v));
-    });
+    auto idx = value_cast<int32_t>(data_type_for<int32_t>()->deserialize(*index));
     auto&& existing_list_opt = params.get_prefetched_list(m.key(), prefix, column);
     if (!existing_list_opt) {
         throw exceptions::invalid_request_exception("Attempted to set an element on a list which is null");

--- a/cql3/lists.hh
+++ b/cql3/lists.hh
@@ -73,7 +73,6 @@ public:
     };
 
     class value : public multi_item_terminal, collection_terminal {
-        static value from_serialized(bytes_view v, const list_type_impl& type, cql_serialization_format sf);
     public:
         std::vector<bytes_opt> _elements;
     public:

--- a/cql3/maps.cc
+++ b/cql3/maps.cc
@@ -158,15 +158,13 @@ maps::value::from_serialized(const fragmented_temporary_buffer::view& fragmented
         // Collections have this small hack that validate cannot be called on a serialized object,
         // but compose does the validation (so we're fine).
         // FIXME: deserialize_for_native_protocol?!
-      return with_linearized(fragmented_value, [&] (bytes_view value) {
-        auto m = value_cast<map_type_impl::native_type>(type.deserialize(value, sf));
+        auto m = value_cast<map_type_impl::native_type>(type.deserialize(fragmented_value, sf));
         std::map<bytes, bytes, serialized_compare> map(type.get_keys_type()->as_less_comparator());
         for (auto&& e : m) {
             map.emplace(type.get_keys_type()->decompose(e.first),
                         type.get_values_type()->decompose(e.second));
         }
         return maps::value { std::move(map) };
-      });
     } catch (marshal_exception& e) {
         throw exceptions::invalid_request_exception(e.what());
     }

--- a/cql3/sets.cc
+++ b/cql3/sets.cc
@@ -137,14 +137,12 @@ sets::value::from_serialized(const fragmented_temporary_buffer::view& val, const
         // Collections have this small hack that validate cannot be called on a serialized object,
         // but compose does the validation (so we're fine).
         // FIXME: deserializeForNativeProtocol?!
-      return with_linearized(val, [&] (bytes_view v) {
-        auto s = value_cast<set_type_impl::native_type>(type.deserialize(v, sf));
+        auto s = value_cast<set_type_impl::native_type>(type.deserialize(val, sf));
         std::set<bytes, serialized_compare> elements(type.get_elements_type()->as_less_comparator());
         for (auto&& element : s) {
             elements.insert(elements.end(), type.get_elements_type()->decompose(element));
         }
         return value(std::move(elements));
-      });
     } catch (marshal_exception& e) {
         throw exceptions::invalid_request_exception(e.what());
     }

--- a/cql3/tuples.cc
+++ b/cql3/tuples.cc
@@ -85,8 +85,7 @@ tuples::in_value::from_serialized(const fragmented_temporary_buffer::view& value
     try {
         // Collections have this small hack that validate cannot be called on a serialized object,
         // but the deserialization does the validation (so we're fine).
-      return with_linearized(value_view, [&] (bytes_view value) {
-        auto l = value_cast<list_type_impl::native_type>(type.deserialize(value, options.get_cql_serialization_format()));
+        auto l = value_cast<list_type_impl::native_type>(type.deserialize(value_view, options.get_cql_serialization_format()));
         auto ttype = dynamic_pointer_cast<const tuple_type_impl>(type.get_elements_type());
         assert(ttype);
 
@@ -96,7 +95,6 @@ tuples::in_value::from_serialized(const fragmented_temporary_buffer::view& value
             elements.emplace_back(to_bytes_opt_vec(ttype->split(ttype->decompose(e))));
         }
         return tuples::in_value(elements);
-      });
     } catch (marshal_exception& e) {
         throw exceptions::invalid_request_exception(e.what());
     }

--- a/cql3/update_parameters.cc
+++ b/cql3/update_parameters.cc
@@ -133,9 +133,7 @@ class prefetch_data_builder {
             auto ctype = static_pointer_cast<const collection_type_impl>(type);
             type = map_type_impl::get_instance(ctype->name_comparator(), ctype->value_comparator(), true);
         }
-        cell->with_linearized([&] (bytes_view cell_view) {
-            cells.cells.emplace(def.ordinal_id, type->deserialize(cell_view));
-        });
+        cells.cells.emplace(def.ordinal_id, type->deserialize(*cell));
     };
 public:
     prefetch_data_builder(schema_ptr s, update_parameters::prefetch_data& data, const query::partition_slice& ps)

--- a/types.cc
+++ b/types.cc
@@ -1091,11 +1091,6 @@ map_type_impl::deserialize(View in, cql_serialization_format sf) const {
     return make_value(std::move(m));
 }
 
-data_value
-map_type_impl::deserialize(bytes_view in, cql_serialization_format sf) const {
-    return deserialize(single_fragmented_view(in), sf);
-}
-
 static void validate_aux(const map_type_impl& t, bytes_view v, cql_serialization_format sf) {
     auto size = read_collection_size(v, sf);
     for (int i = 0; i < size; ++i) {
@@ -1266,11 +1261,6 @@ set_type_impl::deserialize(View in, cql_serialization_format sf) const {
     return make_value(std::move(s));
 }
 
-data_value
-set_type_impl::deserialize(bytes_view in, cql_serialization_format sf) const {
-    return deserialize(single_fragmented_view(in), sf);
-}
-
 bytes
 set_type_impl::serialize_partially_deserialized_form(
         const std::vector<bytes_view>& v, cql_serialization_format sf) {
@@ -1371,11 +1361,6 @@ list_type_impl::deserialize(View in, cql_serialization_format sf) const {
         s.push_back(std::move(e));
     }
     return make_value(std::move(s));
-}
-
-data_value
-list_type_impl::deserialize(bytes_view in, cql_serialization_format sf) const {
-    return deserialize(single_fragmented_view(in), sf);
 }
 
 static sstring vector_to_string(const std::vector<data_value>& v, std::string_view sep) {

--- a/types.cc
+++ b/types.cc
@@ -1808,7 +1808,7 @@ static void serialize(const abstract_type& t, const void* value, bytes::iterator
 }
 
 template <FragmentedView View>
-data_value collection_type_impl::deserialize(View v, cql_serialization_format sf) const {
+data_value collection_type_impl::deserialize_impl(View v, cql_serialization_format sf) const {
     struct visitor {
         View v;
         cql_serialization_format sf;
@@ -1829,9 +1829,9 @@ data_value collection_type_impl::deserialize(View v, cql_serialization_format sf
 }
 // Explicit instantiation.
 // This should be repeated for every View type passed to collection_type_impl::deserialize.
-template data_value collection_type_impl::deserialize<>(ser::buffer_view<bytes_ostream::fragment_iterator>, cql_serialization_format) const;
-template data_value collection_type_impl::deserialize<>(fragmented_temporary_buffer::view, cql_serialization_format) const;
-template data_value collection_type_impl::deserialize<>(single_fragmented_view, cql_serialization_format) const;
+template data_value collection_type_impl::deserialize_impl<>(ser::buffer_view<bytes_ostream::fragment_iterator>, cql_serialization_format) const;
+template data_value collection_type_impl::deserialize_impl<>(fragmented_temporary_buffer::view, cql_serialization_format) const;
+template data_value collection_type_impl::deserialize_impl<>(single_fragmented_view, cql_serialization_format) const;
 
 template <FragmentedView View>
 data_value deserialize_aux(const tuple_type_impl& t, View v) {

--- a/types.cc
+++ b/types.cc
@@ -1347,19 +1347,28 @@ serialize_list(const list_type_impl& t, const void* value, bytes::iterator& out,
     }
 }
 
+template <FragmentedView View>
 data_value
-list_type_impl::deserialize(bytes_view in, cql_serialization_format sf) const {
+list_type_impl::deserialize(View in, cql_serialization_format sf) const {
     auto nr = read_collection_size(in, sf);
     native_type s;
     s.reserve(nr);
     for (int i = 0; i != nr; ++i) {
-        auto e = _elements->deserialize(read_collection_value(in, sf));
+        // FIXME: don't linearize
+        auto e = with_linearized(read_collection_value(in, sf), [&] (bytes_view bv) {
+            return _elements->deserialize(bv);
+        });
         if (e.is_null()) {
             throw marshal_exception("Cannot deserialize a list");
         }
         s.push_back(std::move(e));
     }
     return make_value(std::move(s));
+}
+
+data_value
+list_type_impl::deserialize(bytes_view in, cql_serialization_format sf) const {
+    return deserialize(single_fragmented_view(in), sf);
 }
 
 static sstring vector_to_string(const std::vector<data_value>& v, std::string_view sep) {

--- a/types.cc
+++ b/types.cc
@@ -1837,7 +1837,8 @@ template <typename T> static T deserialize_value(const floating_type_impl<T>&, b
     return d;
 }
 
-static big_decimal deserialize_value(const decimal_type_impl& , bytes_view v) {
+template<FragmentedView View>
+big_decimal deserialize_value(const decimal_type_impl&, View v) {
     auto scale = read_simple<int32_t>(v);
     auto unscaled = deserialize_value(static_cast<const varint_type_impl&>(*varint_type), v);
     return big_decimal(scale, unscaled);

--- a/types.cc
+++ b/types.cc
@@ -1887,11 +1887,12 @@ static int64_t deserialize_value(const time_type_impl&, bytes_view v) {
     return read_simple_exactly<int64_t>(v);
 }
 
-static bool deserialize_value(const boolean_type_impl&, bytes_view v) {
-    if (v.size() != 1) {
-        throw marshal_exception(format("cannot deserialize boolean, size mismatch ({:d})", v.size()));
+template<FragmentedView View>
+bool deserialize_value(const boolean_type_impl&, View v) {
+    if (v.size_bytes() != 1) {
+        throw marshal_exception(format("cannot deserialize boolean, size mismatch ({:d})", v.size_bytes()));
     }
-    return *v.begin() != 0;
+    return v.current_fragment().front() != 0;
 }
 
 template<typename T, FragmentedView View>

--- a/types.cc
+++ b/types.cc
@@ -2018,14 +2018,14 @@ struct deserialize_visitor {
 }
 
 template <FragmentedView View>
-data_value abstract_type::deserialize(View v) const {
+data_value abstract_type::deserialize_impl(View v) const {
     return visit(*this, deserialize_visitor<View>{v});
 }
 // Explicit instantiation.
 // This should be repeated for every type passed to deserialize().
-template data_value abstract_type::deserialize<>(fragmented_temporary_buffer::view) const;
-template data_value abstract_type::deserialize<>(single_fragmented_view) const;
-template data_value abstract_type::deserialize<>(ser::buffer_view<bytes_ostream::fragment_iterator>) const;
+template data_value abstract_type::deserialize_impl<>(fragmented_temporary_buffer::view) const;
+template data_value abstract_type::deserialize_impl<>(single_fragmented_view) const;
+template data_value abstract_type::deserialize_impl<>(ser::buffer_view<bytes_ostream::fragment_iterator>) const;
 
 int32_t compare_aux(const tuple_type_impl& t, bytes_view v1, bytes_view v2) {
     // This is a slight modification of lexicographical_tri_compare:

--- a/types.cc
+++ b/types.cc
@@ -1894,8 +1894,8 @@ static bool deserialize_value(const boolean_type_impl&, bytes_view v) {
     return *v.begin() != 0;
 }
 
-template<typename T>
-static T deserialize_value(const integer_type_impl<T>& t, bytes_view v) {
+template<typename T, FragmentedView View>
+T deserialize_value(const integer_type_impl<T>& t, View v) {
     return read_simple_exactly<T>(v);
 }
 

--- a/types.cc
+++ b/types.cc
@@ -1831,10 +1831,7 @@ data_value deserialize_aux(const tuple_type_impl& t, View v) {
         data_value obj = data_value::make_null(*ti);
         std::optional<View> e = read_tuple_element(v);
         if (e) {
-            // FIXME: don't linearize
-            with_linearized(*e, [&] (bytes_view bv) {
-                obj = (*ti)->deserialize(bv);
-            });
+            obj = (*ti)->deserialize(*e);
         }
         ret.push_back(std::move(obj));
         ++ti;

--- a/types.cc
+++ b/types.cc
@@ -1842,10 +1842,6 @@ data_value deserialize_aux(const tuple_type_impl& t, View v) {
     return data_value::make(t.shared_from_this(), std::make_unique<tuple_type_impl::native_type>(std::move(ret)));
 }
 
-data_value deserialize_aux(const tuple_type_impl& t, bytes_view v) {
-    return deserialize_aux(t, single_fragmented_view(v));
-}
-
 template<FragmentedView View>
 utils::multiprecision_int deserialize_value(const varint_type_impl&, View v) {
     bool negative = v.current_fragment().front() < 0;

--- a/types.cc
+++ b/types.cc
@@ -1874,7 +1874,8 @@ static utils::UUID deserialize_value(const timeuuid_type_impl&, bytes_view v) {
     return deserialize_value(static_cast<const uuid_type_impl&>(*uuid_type), v);
 }
 
-static db_clock::time_point deserialize_value(const timestamp_date_base_class&, bytes_view v) {
+template<FragmentedView View>
+db_clock::time_point deserialize_value(const timestamp_date_base_class&, View v) {
     auto v2 = read_simple_exactly<uint64_t>(v);
     return db_clock::time_point(db_clock::duration(v2));
 }

--- a/types.cc
+++ b/types.cc
@@ -1883,7 +1883,8 @@ static uint32_t deserialize_value(const simple_date_type_impl&, bytes_view v) {
     return read_simple_exactly<uint32_t>(v);
 }
 
-static int64_t deserialize_value(const time_type_impl&, bytes_view v) {
+template<FragmentedView View>
+int64_t deserialize_value(const time_type_impl&, View v) {
     return read_simple_exactly<int64_t>(v);
 }
 

--- a/types.cc
+++ b/types.cc
@@ -644,6 +644,15 @@ size_t collection_value_len(cql_serialization_format sf) {
 }
 
 
+template <FragmentedView View>
+int read_collection_size(View& in, cql_serialization_format sf) {
+    if (sf.using_32_bits_for_collections()) {
+        return read_simple<int32_t>(in);
+    } else {
+        return read_simple<uint16_t>(in);
+    }
+}
+
 int read_collection_size(bytes_view& in, cql_serialization_format sf) {
     if (sf.using_32_bits_for_collections()) {
         return read_simple<int32_t>(in);
@@ -658,6 +667,12 @@ void write_collection_size(bytes::iterator& out, int size, cql_serialization_for
     } else {
         serialize_int16(out, uint16_t(size));
     }
+}
+
+template <FragmentedView View>
+View read_collection_value(View& in, cql_serialization_format sf) {
+    auto size = sf.using_32_bits_for_collections() ? read_simple<int32_t>(in) : read_simple<uint16_t>(in);
+    return read_simple_bytes(in, size);
 }
 
 bytes_view read_collection_value(bytes_view& in, cql_serialization_format sf) {

--- a/types.cc
+++ b/types.cc
@@ -1843,9 +1843,12 @@ static big_decimal deserialize_value(const decimal_type_impl& , bytes_view v) {
     return big_decimal(scale, unscaled);
 }
 
-static cql_duration deserialize_value(const duration_type_impl& t, bytes_view v) {
+template<FragmentedView View>
+cql_duration deserialize_value(const duration_type_impl& t, View v) {
     common_counter_type months, days, nanoseconds;
-    std::tie(months, days, nanoseconds) = deserialize_counters(v);
+    std::tie(months, days, nanoseconds) = with_linearized(v, [] (bytes_view bv) {
+        return deserialize_counters(bv);
+    });
     return cql_duration(months_counter(months), days_counter(days), nanoseconds_counter(nanoseconds));
 }
 

--- a/types.cc
+++ b/types.cc
@@ -1861,16 +1861,18 @@ static inet_address deserialize_value(const inet_addr_type_impl&, bytes_view v) 
     }
 }
 
-static utils::UUID deserialize_value(const uuid_type_impl&, bytes_view v) {
+template<FragmentedView View>
+utils::UUID deserialize_value(const uuid_type_impl&, View v) {
     auto msb = read_simple<uint64_t>(v);
     auto lsb = read_simple<uint64_t>(v);
-    if (!v.empty()) {
-        throw marshal_exception(format("cannot deserialize uuid, {:d} bytes left", v.size()));
+    if (v.size_bytes()) {
+        throw marshal_exception(format("cannot deserialize uuid, {:d} bytes left", v.size_bytes()));
     }
     return utils::UUID(msb, lsb);
 }
 
-static utils::UUID deserialize_value(const timeuuid_type_impl&, bytes_view v) {
+template<FragmentedView View>
+utils::UUID deserialize_value(const timeuuid_type_impl&, View v) {
     return deserialize_value(static_cast<const uuid_type_impl&>(*uuid_type), v);
 }
 

--- a/types.cc
+++ b/types.cc
@@ -1084,13 +1084,8 @@ map_type_impl::deserialize(View in, cql_serialization_format sf) const {
     native_type m;
     auto size = read_collection_size(in, sf);
     for (int i = 0; i < size; ++i) {
-        // FIXME: don't linearize
-        auto k = with_linearized(read_collection_value(in, sf), [&] (bytes_view bv) {
-            return _keys->deserialize(bv);
-        });
-        auto v = with_linearized(read_collection_value(in, sf), [&] (bytes_view bv) {
-            return _values->deserialize(bv);
-        });
+        auto k = _keys->deserialize(read_collection_value(in, sf));
+        auto v = _values->deserialize(read_collection_value(in, sf));
         m.insert(m.end(), std::make_pair(std::move(k), std::move(v)));
     }
     return make_value(std::move(m));
@@ -1262,10 +1257,7 @@ set_type_impl::deserialize(View in, cql_serialization_format sf) const {
     native_type s;
     s.reserve(nr);
     for (int i = 0; i != nr; ++i) {
-        // FIXME: don't linearize
-        auto e = with_linearized(read_collection_value(in, sf), [&] (bytes_view bv) {
-            return _elements->deserialize(bv);
-        });
+        auto e = _elements->deserialize(read_collection_value(in, sf));
         if (e.is_null()) {
             throw marshal_exception("Cannot deserialize a set");
         }
@@ -1372,10 +1364,7 @@ list_type_impl::deserialize(View in, cql_serialization_format sf) const {
     native_type s;
     s.reserve(nr);
     for (int i = 0; i != nr; ++i) {
-        // FIXME: don't linearize
-        auto e = with_linearized(read_collection_value(in, sf), [&] (bytes_view bv) {
-            return _elements->deserialize(bv);
-        });
+        auto e = _elements->deserialize(read_collection_value(in, sf));
         if (e.is_null()) {
             throw marshal_exception("Cannot deserialize a list");
         }

--- a/types.cc
+++ b/types.cc
@@ -1879,7 +1879,8 @@ static db_clock::time_point deserialize_value(const timestamp_date_base_class&, 
     return db_clock::time_point(db_clock::duration(v2));
 }
 
-static uint32_t deserialize_value(const simple_date_type_impl&, bytes_view v) {
+template<FragmentedView View>
+uint32_t deserialize_value(const simple_date_type_impl&, View v) {
     return read_simple_exactly<uint32_t>(v);
 }
 

--- a/types.cc
+++ b/types.cc
@@ -1827,10 +1827,11 @@ static utils::multiprecision_int deserialize_value(const varint_type_impl&, byte
     return negative ? -num : num;
 }
 
-template <typename T> static T deserialize_value(const floating_type_impl<T>&, bytes_view v) {
+template<typename T, FragmentedView View>
+T deserialize_value(const floating_type_impl<T>&, View v) {
     typename int_of_size<T>::itype i = read_simple<typename int_of_size<T>::itype>(v);
-    if (!v.empty()) {
-        throw marshal_exception(format("cannot deserialize floating - {:d} bytes left", v.size()));
+    if (v.size_bytes()) {
+        throw marshal_exception(format("cannot deserialize floating - {:d} bytes left", v.size_bytes()));
     }
     T d;
     memcpy(&d, &i, sizeof(T));

--- a/types.hh
+++ b/types.hh
@@ -504,16 +504,26 @@ public:
     size_t hash(bytes_view v) const;
     bool equal(bytes_view v1, bytes_view v2) const;
     int32_t compare(bytes_view v1, bytes_view v2) const;
+
+private:
     // Explicitly instantiated in .cc
-    template <FragmentedView View> data_value deserialize(View v) const;
+    template <FragmentedView View> data_value deserialize_impl(View v) const;
+public:
+    template <FragmentedView View> data_value deserialize(View v) const {
+        if (v.size_bytes() == v.current_fragment().size()) [[likely]] {
+            return deserialize_impl(single_fragmented_view(v.current_fragment()));
+        } else {
+            return deserialize_impl(v);
+        }
+    }
     data_value deserialize(bytes_view v) const {
-        return deserialize(single_fragmented_view(v));
+        return deserialize_impl(single_fragmented_view(v));
     }
     template <FragmentedView View> data_value deserialize_value(View v) const {
         return deserialize(v);
     }
     data_value deserialize_value(bytes_view v) const {
-        return deserialize(single_fragmented_view(v));
+        return deserialize_impl(single_fragmented_view(v));
     };
     void validate(const fragmented_temporary_buffer::view& view, cql_serialization_format sf) const;
     void validate(bytes_view view, cql_serialization_format sf) const;

--- a/types.hh
+++ b/types.hh
@@ -1197,19 +1197,6 @@ View read_simple_bytes(View& v, size_t n) {
     return prefix;
 }
 
-template<typename T>
-std::optional<T> read_simple_opt(bytes_view& v) {
-    if (v.empty()) {
-        return {};
-    }
-    if (v.size() != sizeof(T)) {
-        throw_with_backtrace<marshal_exception>(format("read_simple_opt - size mismatch (expected {:d}, got {:d})", sizeof(T), v.size()));
-    }
-    auto p = v.begin();
-    v.remove_prefix(sizeof(T));
-    return { net::ntoh(*reinterpret_cast<const net::packed<T>*>(p)) };
-}
-
 inline sstring read_simple_short_string(bytes_view& v) {
     uint16_t len = read_simple<uint16_t>(v);
     if (v.size() < len) {

--- a/types.hh
+++ b/types.hh
@@ -504,9 +504,16 @@ public:
     size_t hash(bytes_view v) const;
     bool equal(bytes_view v1, bytes_view v2) const;
     int32_t compare(bytes_view v1, bytes_view v2) const;
-    data_value deserialize(bytes_view v) const;
-    data_value deserialize_value(bytes_view v) const {
+    // Explicitly instantiated in .cc
+    template <FragmentedView View> data_value deserialize(View v) const;
+    data_value deserialize(bytes_view v) const {
+        return deserialize(single_fragmented_view(v));
+    }
+    template <FragmentedView View> data_value deserialize_value(View v) const {
         return deserialize(v);
+    }
+    data_value deserialize_value(bytes_view v) const {
+        return deserialize(single_fragmented_view(v));
     };
     void validate(const fragmented_temporary_buffer::view& view, cql_serialization_format sf) const;
     void validate(bytes_view view, cql_serialization_format sf) const;

--- a/types/collection.hh
+++ b/types/collection.hh
@@ -54,9 +54,17 @@ public:
     virtual bool is_value_compatible_with_frozen(const collection_type_impl& previous) const = 0;
     template <typename BytesViewIterator>
     static bytes pack(BytesViewIterator start, BytesViewIterator finish, int elements, cql_serialization_format sf);
-    virtual data_value deserialize(bytes_view v, cql_serialization_format sf) const = 0;
-    data_value deserialize_value(bytes_view v, cql_serialization_format sf) const {
+
+    // Explicitly instantiated in types.cc
+    template <FragmentedView View> data_value deserialize(View v, cql_serialization_format sf) const;
+    template <FragmentedView View> data_value deserialize_value(View v, cql_serialization_format sf) const {
         return deserialize(v, sf);
+    }
+    data_value deserialize(bytes_view v, cql_serialization_format sf) const {
+        return deserialize(single_fragmented_view(v), sf);
+    }
+    data_value deserialize_value(bytes_view v, cql_serialization_format sf) const {
+        return deserialize(single_fragmented_view(v), sf);
     }
     bytes_opt reserialize(cql_serialization_format from, cql_serialization_format to, bytes_view_opt v) const;
 };

--- a/types/collection.hh
+++ b/types/collection.hh
@@ -55,16 +55,25 @@ public:
     template <typename BytesViewIterator>
     static bytes pack(BytesViewIterator start, BytesViewIterator finish, int elements, cql_serialization_format sf);
 
+private:
     // Explicitly instantiated in types.cc
-    template <FragmentedView View> data_value deserialize(View v, cql_serialization_format sf) const;
+    template <FragmentedView View> data_value deserialize_impl(View v, cql_serialization_format sf) const;
+public:
+    template <FragmentedView View> data_value deserialize(View v, cql_serialization_format sf) const {
+        if (v.size_bytes() == v.current_fragment().size()) [[likely]] {
+            return deserialize_impl(single_fragmented_view(v.current_fragment()), sf);
+        } else {
+            return deserialize_impl(v, sf);
+        }
+    }
     template <FragmentedView View> data_value deserialize_value(View v, cql_serialization_format sf) const {
         return deserialize(v, sf);
     }
     data_value deserialize(bytes_view v, cql_serialization_format sf) const {
-        return deserialize(single_fragmented_view(v), sf);
+        return deserialize_impl(single_fragmented_view(v), sf);
     }
     data_value deserialize_value(bytes_view v, cql_serialization_format sf) const {
-        return deserialize(single_fragmented_view(v), sf);
+        return deserialize_impl(single_fragmented_view(v), sf);
     }
     bytes_opt reserialize(cql_serialization_format from, cql_serialization_format to, bytes_view_opt v) const;
 };

--- a/types/list.hh
+++ b/types/list.hh
@@ -47,7 +47,7 @@ public:
     virtual bool is_compatible_with_frozen(const collection_type_impl& previous) const override;
     virtual bool is_value_compatible_with_frozen(const collection_type_impl& previous) const override;
     using abstract_type::deserialize;
-    virtual data_value deserialize(bytes_view v, cql_serialization_format sf) const override;
+    data_value deserialize(bytes_view v, cql_serialization_format sf) const;
     template <FragmentedView View> data_value deserialize(View v, cql_serialization_format sf) const;
 };
 

--- a/types/list.hh
+++ b/types/list.hh
@@ -47,7 +47,7 @@ public:
     virtual bool is_compatible_with_frozen(const collection_type_impl& previous) const override;
     virtual bool is_value_compatible_with_frozen(const collection_type_impl& previous) const override;
     using abstract_type::deserialize;
-    data_value deserialize(bytes_view v, cql_serialization_format sf) const;
+    using collection_type_impl::deserialize;
     template <FragmentedView View> data_value deserialize(View v, cql_serialization_format sf) const;
 };
 

--- a/types/list.hh
+++ b/types/list.hh
@@ -48,6 +48,7 @@ public:
     virtual bool is_value_compatible_with_frozen(const collection_type_impl& previous) const override;
     using abstract_type::deserialize;
     virtual data_value deserialize(bytes_view v, cql_serialization_format sf) const override;
+    template <FragmentedView View> data_value deserialize(View v, cql_serialization_format sf) const;
 };
 
 data_value make_list_value(data_type type, list_type_impl::native_type value);

--- a/types/map.hh
+++ b/types/map.hh
@@ -56,6 +56,7 @@ public:
                         bytes_view o1, bytes_view o2);
     using abstract_type::deserialize;
     virtual data_value deserialize(bytes_view v, cql_serialization_format sf) const override;
+    template <FragmentedView View> data_value deserialize(View v, cql_serialization_format sf) const;
     static bytes serialize_partially_deserialized_form(const std::vector<std::pair<bytes_view, bytes_view>>& v,
             cql_serialization_format sf);
 };

--- a/types/map.hh
+++ b/types/map.hh
@@ -55,7 +55,7 @@ public:
     static int32_t compare_maps(data_type keys_comparator, data_type values_comparator,
                         bytes_view o1, bytes_view o2);
     using abstract_type::deserialize;
-    data_value deserialize(bytes_view v, cql_serialization_format sf) const;
+    using collection_type_impl::deserialize;
     template <FragmentedView View> data_value deserialize(View v, cql_serialization_format sf) const;
     static bytes serialize_partially_deserialized_form(const std::vector<std::pair<bytes_view, bytes_view>>& v,
             cql_serialization_format sf);

--- a/types/map.hh
+++ b/types/map.hh
@@ -55,7 +55,7 @@ public:
     static int32_t compare_maps(data_type keys_comparator, data_type values_comparator,
                         bytes_view o1, bytes_view o2);
     using abstract_type::deserialize;
-    virtual data_value deserialize(bytes_view v, cql_serialization_format sf) const override;
+    data_value deserialize(bytes_view v, cql_serialization_format sf) const;
     template <FragmentedView View> data_value deserialize(View v, cql_serialization_format sf) const;
     static bytes serialize_partially_deserialized_form(const std::vector<std::pair<bytes_view, bytes_view>>& v,
             cql_serialization_format sf);

--- a/types/set.hh
+++ b/types/set.hh
@@ -47,7 +47,7 @@ public:
     virtual bool is_compatible_with_frozen(const collection_type_impl& previous) const override;
     virtual bool is_value_compatible_with_frozen(const collection_type_impl& previous) const override;
     using abstract_type::deserialize;
-    data_value deserialize(bytes_view v, cql_serialization_format sf) const;
+    using collection_type_impl::deserialize;
     template <FragmentedView View> data_value deserialize(View v, cql_serialization_format sf) const;
     static bytes serialize_partially_deserialized_form(
             const std::vector<bytes_view>& v, cql_serialization_format sf);

--- a/types/set.hh
+++ b/types/set.hh
@@ -48,6 +48,7 @@ public:
     virtual bool is_value_compatible_with_frozen(const collection_type_impl& previous) const override;
     using abstract_type::deserialize;
     virtual data_value deserialize(bytes_view v, cql_serialization_format sf) const override;
+    template <FragmentedView View> data_value deserialize(View v, cql_serialization_format sf) const;
     static bytes serialize_partially_deserialized_form(
             const std::vector<bytes_view>& v, cql_serialization_format sf);
 };

--- a/types/set.hh
+++ b/types/set.hh
@@ -47,7 +47,7 @@ public:
     virtual bool is_compatible_with_frozen(const collection_type_impl& previous) const override;
     virtual bool is_value_compatible_with_frozen(const collection_type_impl& previous) const override;
     using abstract_type::deserialize;
-    virtual data_value deserialize(bytes_view v, cql_serialization_format sf) const override;
+    data_value deserialize(bytes_view v, cql_serialization_format sf) const;
     template <FragmentedView View> data_value deserialize(View v, cql_serialization_format sf) const;
     static bytes serialize_partially_deserialized_form(
             const std::vector<bytes_view>& v, cql_serialization_format sf);

--- a/types/tuple.hh
+++ b/types/tuple.hh
@@ -93,6 +93,15 @@ private:
     }
 };
 
+template <FragmentedView View>
+std::optional<View> read_tuple_element(View& v) {
+    auto s = read_simple<int32_t>(v);
+    if (s < 0) {
+        return std::nullopt;
+    }
+    return read_simple_bytes(v, s);
+}
+
 class tuple_type_impl : public concrete_type<std::vector<data_value>> {
     using intern = type_interning_helper<tuple_type_impl, std::vector<data_type>>;
 protected:

--- a/utils/fragment_range.hh
+++ b/utils/fragment_range.hh
@@ -201,3 +201,16 @@ decltype(auto) with_linearized(const View& v, Function&& fn)
         return fn(linearized(v));
     }
 }
+
+class single_fragmented_view {
+    bytes_view _view;
+public:
+    using fragment_type = bytes_view;
+    explicit single_fragmented_view(bytes_view bv) : _view(bv) {}
+    size_t size_bytes() const { return _view.size(); }
+    void remove_prefix(size_t n) { _view.remove_prefix(n); }
+    void remove_current() { _view = bytes_view(); }
+    bytes_view current_fragment() const { return _view; }
+    single_fragmented_view prefix(size_t n) { return single_fragmented_view(_view.substr(0, n)); }
+};
+static_assert(FragmentedView<single_fragmented_view>);

--- a/utils/fragmented_temporary_buffer.hh
+++ b/utils/fragmented_temporary_buffer.hh
@@ -197,6 +197,29 @@ public:
         }
     }
 
+    void remove_current() noexcept {
+        _total_size -= _current_size;
+        ++_current;
+        if (_total_size) {
+            _current_size = std::min(_current->size(), _total_size);
+            _current_position = _current->get();
+        } else {
+            _current_size = 0;
+            _current_position = nullptr;
+        }
+    }
+
+    view prefix(size_t n) const {
+        auto tmp = *this;
+        tmp._total_size = std::min(tmp._total_size, n);
+        tmp._current_size = std::min(tmp._current_size, n);
+        return tmp;
+    }
+
+    bytes_view current_fragment() const noexcept {
+        return bytes_view(reinterpret_cast<const bytes_view::value_type*>(_current_position), _current_size);
+    }
+
     // Invalidates iterators
     void remove_suffix(size_t n) noexcept {
         _total_size -= n;
@@ -241,6 +264,7 @@ public:
     }
 };
 static_assert(FragmentRange<fragmented_temporary_buffer::view>);
+static_assert(FragmentedView<fragmented_temporary_buffer::view>);
 
 inline fragmented_temporary_buffer::operator view() const noexcept
 {

--- a/utils/fragmented_temporary_buffer.hh
+++ b/utils/fragmented_temporary_buffer.hh
@@ -185,10 +185,11 @@ public:
             n -= _current_size;
             ++_current;
             _current_size = std::min(_current->size(), _total_size);
+            _current_position = _current->get();
         }
         _total_size -= n;
         _current_size -= n;
-        _current_position = _current->get() + n;
+        _current_position += n;
         if (!_current_size && _total_size) {
             ++_current;
             _current_size = std::min(_current->size(), _total_size);


### PR DESCRIPTION
Citing #6138:
> In the past few years we have converted most of our codebase to work in terms of fragmented buffers, instead of linearised ones, to help avoid large allocations that put large pressure on the memory allocator.
> One prominent component that still works exclusively in terms of linearised buffers is the types hierarchy, more specifically the de/serialization code to/from CQL format. Note that for most types, this is the same as our internal format, notable exceptions are non-frozen collections and user types.
> 
> Most types are expected to contain reasonably small values, but texts, blobs and especially collections can get very large. Since the entire hierarchy shares a common interface we can either transition all or none to work with fragmented buffers.

This series gets rid of intermediate linearizations in deserialization. The next steps are removing linearizations from serialization, validation and comparison code.

Series summary:
- Fix a bug in `fragmented_temporary_buffer::view::remove_prefix`. (Discovered while testing. Since it wasn't discovered earlier, I guess it doesn't occur in any code path in master.)
- Add a `FragmentedView` concept to allow uniform handling of various types of fragmented buffers (`bytes_view`, `temporary_fragmented_buffer::view`, `ser::buffer_view` and likely `managed_bytes_view` in the future).
- Implement `FragmentedView` for relevant fragmented buffer types.
- Add helper functions for reading from `FragmentedView`.
- Switch `deserialize()` and all its helpers from `bytes_view` to `FragmentedView`.
- Remove `with_linearized()` calls which just became unnecessary.
- Add an optimization for single-fragment cases.

The addition of `FragmentedView` might be controversial, because another concept meant for the same purpose - `FragmentRange` - is already used. Unfortunately, it lacks the functionality we need. The main (only?) thing we want to do with a fragmented buffer is to extract a prefix from it and `FragmentRange` gives us no way to do that, because it's immutable by design. We can work around that by wrapping it into a mutable view which will track the offset into the immutable `FragmentRange`, and that's exactly what `linearizing_input_stream` is. But it's wasteful. `linearizing_input_stream` is a heavy type, unsuitable for passing around as a view - it stores a pair of fragment iterators, a fragment view and a size (11 words) to conform to the iterator-based design of `FragmentRange`, when one fragment iterator (4 words) already contains all needed state, just hidden.
I suggest we replace `FragmentRange` with `FragmentedView` (or something similar) altogether.

Refs: #6138 