### PR TITLE
Add missing shaded<>::stop in exceptional startup code for CQL/redis

### DIFF
--- a/redis/service.cc
+++ b/redis/service.cc
@@ -107,6 +107,10 @@ future<> redis_service::listen(distributed<auth::service>& auth_service, db::con
                 });
             });
         });
+    }).handle_exception([this](auto ep) {
+        return _server->stop().then([ep = std::move(ep)]() mutable {
+            return make_exception_future<>(std::move(ep));
+        });
     });
 }
 


### PR DESCRIPTION
Fixes #7211
    
If we start a sharded<> object, then proceed to do potentially
exceptional stuff, we should destroy it on said exception.
Otherwise, the exception propagation will abort on RAII
destruction of the sharded<>. And we get no exception logging.