### PR TITLE
dist/redhat: drop Conflicts with older kernel

### DIFF
--- a/dist/redhat/scylla.spec
+++ b/dist/redhat/scylla.spec
@@ -51,7 +51,6 @@ Group:          Applications/Databases
 Summary:        The Scylla database server
 License:        AGPLv3
 URL:            http://www.scylladb.com/
-Conflicts: kernel < 3.10.0-514
 Requires:       %{product}-conf %{product}-python3
 Conflicts:      abrt
 AutoReqProv:    no


### PR DESCRIPTION
We have "Conflicts: kernel < 3.10.0-514" on rpm package to make sure
the environment is running newer kernel.
However, user may use non-standard kernel which has different package name,
like kernel-ml or kernel-uek.
On such environment Conflicts tag does not works correctly.
Even the system running with newer kernel, rpm only checks "kernel" package
version number.

To avoid such issue, we need to drop Conflicts tag, need to check kernel version
in scylla_setup script instead.

Fixes #7675