### PR TITLE
Don't use secondary indices for multi-column restrictions

### DIFF
--- a/cql3/expr/expression.cc
+++ b/cql3/expr/expression.cc
@@ -776,9 +776,11 @@ bool is_supported_by(const expression& expr, const secondary_index::index& idx) 
                             return idx.supports_expression(*col.col, oper.op);
                         },
                         [&] (const std::vector<column_value>& cvs) {
-                            return boost::algorithm::any_of(cvs, [&] (const column_value& c) {
-                                return idx.supports_expression(*c.col, oper.op);
-                            });
+                            if (cvs.size() == 1) {
+                                return idx.supports_expression(*cvs[0].col, oper.op);
+                            }
+                            // We don't use index table for multi-column restrictions, as it cannot avoid filtering.
+                            return false;
                         },
                         [&] (const token&) { return false; },
                     }, oper.lhs);

--- a/cql3/restrictions/statement_restrictions.cc
+++ b/cql3/restrictions/statement_restrictions.cc
@@ -230,7 +230,8 @@ statement_restrictions::statement_restrictions(database& db,
     process_clustering_columns_restrictions(select_a_collection, for_view, allow_filtering);
 
     // Covers indexes on the first clustering column (among others).
-    if (_is_key_range && _has_queriable_ck_index) {
+    if (_is_key_range && _has_queriable_ck_index &&
+        !dynamic_pointer_cast<multi_column_restriction>(_clustering_columns_restrictions)) {
         _uses_secondary_indexing = true;
     }
 

--- a/test/lib/cql_assertions.cc
+++ b/test/lib/cql_assertions.cc
@@ -225,6 +225,18 @@ void require_rows(cql_test_env& e,
     }
 }
 
+void eventually_require_rows(cql_test_env& e, sstring_view qstr, const std::vector<std::vector<bytes_opt>>& expected,
+                             const std::experimental::source_location& loc) {
+    try {
+        eventually([&] {
+            assert_that(cquery_nofail(e, qstr, nullptr, loc)).is_rows().with_rows_ignore_order(expected);
+        });
+    } catch (const std::exception& e) {
+        BOOST_FAIL(format("query '{}' failed: {}\n{}:{}: originally from here",
+                          qstr, e.what(), loc.file_name(), loc.line()));
+    }
+}
+
 void require_rows(cql_test_env& e,
                   cql3::prepared_cache_key_type id,
                   const std::vector<cql3::raw_value>& values,

--- a/test/lib/cql_assertions.hh
+++ b/test/lib/cql_assertions.hh
@@ -96,6 +96,11 @@ void require_rows(cql_test_env& e,
                   const std::vector<std::vector<bytes_opt>>& expected,
                   const std::experimental::source_location& loc = std::experimental::source_location::current());
 
+/// Like require_rows, but wraps assertions in \c eventually.
+void eventually_require_rows(
+        cql_test_env& e, sstring_view qstr, const std::vector<std::vector<bytes_opt>>& expected,
+        const std::experimental::source_location& loc = std::experimental::source_location::current());
+
 /// Asserts that e.execute_prepared(id, values) contains expected rows, in any order.
 void require_rows(cql_test_env& e,
                   cql3::prepared_cache_key_type id,


### PR DESCRIPTION
Fix #7680 by never using secondary index for multi-column restrictions.

Modify expr::is_supported_by() to handle multi-column correctly.

Tests: unit (dev)