### PR TITLE
install.sh: apply sysctl.d files on non-packaging installation

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -423,6 +423,10 @@ elif ! $packaging; then
     chown -R scylla:scylla $rdata
     chown -R scylla:scylla $rhkdata
 
+    for file in dist/common/sysctl.d/*.conf; do
+        bn=$(basename "$file")
+        sysctl -p "$rusr"/lib/sysctl.d/"$bn"
+    done
     $rprefix/scripts/scylla_post_install.sh
     echo "Scylla offline install completed."
 fi


### PR DESCRIPTION
We don't apply sysctl.d files on non-packaging installation, apply them
just like rpm/deb taking care of that.

Fixes #7702