### PR TITLE
gossip: Allow deferring advertise of local node

### DIFF
--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -369,7 +369,8 @@ void storage_service::prepare_to_join(
     slogger.info("Starting up server gossip");
 
     auto generation_number = db::system_keyspace::increment_and_get_generation().get0();
-    _gossiper.start_gossiping(generation_number, app_states, gms::bind_messaging_port(bool(do_bind))).get();
+    auto advertise = gms::advertise_myself(!replacing_a_node_with_same_ip);
+    _gossiper.start_gossiping(generation_number, app_states, gms::bind_messaging_port(bool(do_bind)), advertise).get();
 
     install_schema_version_change_listener();
 
@@ -935,6 +936,7 @@ void storage_service::bootstrap() {
             { gms::application_state::CDC_STREAMS_TIMESTAMP, versioned_value::cdc_streams_timestamp(_cdc_streams_ts) },
             { gms::application_state::STATUS, versioned_value::hibernate(true) },
         }).get();
+        _gossiper.advertise_myself().get();
         set_mode(mode::JOINING, format("Wait until peer nodes know the bootstrap tokens of local node"), true);
         _gossiper.wait_for_range_setup().get();
         auto replace_addr = db().local().get_replace_address();


### PR DESCRIPTION
Currently the replacing node sets the status as STATUS_UNKNOWN when it
starts gossip service for the first time before it sets the status to
HIBERNATE to start the replacing operation. This introduces the
following race:

1) Replacing node using the same IP address of the node to be replaced
starts gossip service without setting the gossip STATUS (will be seen as
STATUS_UNKNOWN by other nodes)

2) Replacing node waits for gossip to settle and learns status and
tokens of existing nodes

3) Replacing node announces the HIBERNATE STATUS.

After Step 1 and before Step 3, existing nodes will mark the replacing
node as UP, but haven't marked the replacing node as doing replacing
yet. As a result, the replacing node will not be excluded from the read
replicas and will be considered a target node to serve CQL reads.

To fix, we start gossip service on the replacing node with a gossip generation
zero so that existing nodes will ignore the replacing node because
they have bigger generation number.

When the replacing node can advertise HIBERNATE status, it sets the generation
number to normal so other nodes can learn it from gossip.

Fixes #7312