### PR TITLE
debian pkg: Make deb packages explicitly depend on versioned components

### DIFF
--- a/dist/debian/control.template
+++ b/dist/debian/control.template
@@ -17,7 +17,7 @@ Conflicts: %{product}-server (<< 1.1)
 
 Package: %{product}-server
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, %{product}-conf, %{product}-python3
+Depends: ${shlibs:Depends}, ${misc:Depends}, %{product}-conf (= ${binary:Version}), %{product}-python3 (= ${binary:Version})
 Description: Scylla database server binaries 
  Scylla is a highly scalable, eventually consistent, distributed,
  partitioned row DB.
@@ -42,7 +42,11 @@ Description: Scylla kernel tuning configuration
 Package: %{product}
 Section: metapackages
 Architecture: any
-Depends: %{product}-server, %{product}-jmx, %{product}-tools, %{product}-tools-core, %{product}-kernel-conf
+Depends: %{product}-server (= ${binary:Version})
+ , %{product}-jmx (= ${binary:Version})
+ , %{product}-tools (= ${binary:Version})
+ , %{product}-tools-core (= ${binary:Version})
+ , %{product}-kernel-conf (= ${binary:Version})
 Description: Scylla database metapackage
  Scylla is a highly scalable, eventually consistent, distributed,
  partitioned row DB.


### PR DESCRIPTION
Up until now, Scylla's debian packages dependencies versions were
unspecified. This was due to a technical difficulty to determine
the version of the dependent upon packages (such as scylla-python3
or scylla-jmx). Now, when those packages are also built as part of
this repo and are built with a version identical to the server package
itself we can depend all of our packages with explicit versions.
The motivation for this change is that if a user tries to install
a specific Scylla version by installing a specific meta package,
it will silently drag in the latest components instead of the ones
of the requested versions.
The expected change in behavior is that after this change an attempt
to install a metapackage with version which is not the latest will fail
with an explicit error hinting the user what other packages of the same
version should be explicitly included in the command line.

Fixes #5514