### PR TITLE
schema.cc/describe: fix invalid compaction options in schema

### DIFF
--- a/schema.cc
+++ b/schema.cc
@@ -859,7 +859,7 @@ std::ostream& schema::describe(database& db, std::ostream& os) const {
     os << "}";
     os << "\n    AND comment = '" << comment()<< "'";
     os << "\n    AND compaction = {'class': '" <<  sstables::compaction_strategy::name(compaction_strategy()) << "'";
-    map_as_cql_param(os, compaction_strategy_options()) << "}";
+    map_as_cql_param(os, compaction_strategy_options(), false) << "}";
     os << "\n    AND compression = {";
     map_as_cql_param(os,  get_compressor_params().get_options());
     os << "}";


### PR DESCRIPTION
There is a typo in schema.cql of snapshot, lack of comma after
compaction strategy.

    AND compaction = {'class': 'SizeTieredCompactionStrategy''max_compaction_threshold': '32'}

map_as_cql_param() function has a `first` parameter to smartly add
comma, the compaction_strategy_options is always not the first.

Fixes #7741

Signed-off-by: Amos Kong <amos@scylladb.com>

/CC @amnonh @raphaelsc 