### PR TITLE
gossip: Added SNITCH_NAME to `application_state`

### DIFF
--- a/gms/application_state.cc
+++ b/gms/application_state.cc
@@ -68,6 +68,7 @@ static const std::map<application_state, sstring> application_state_names = {
     {application_state::SHARD_COUNT,            "SHARD_COUNT"},
     {application_state::IGNORE_MSB_BITS,        "IGNOR_MSB_BITS"},
     {application_state::CDC_STREAMS_TIMESTAMP,  "CDC_STREAMS_TIMESTAMP"},
+    {application_state::SNITCH_NAME,            "SNITCH_NAME"},
 };
 
 std::ostream& operator<<(std::ostream& os, const application_state& m) {

--- a/gms/application_state.hh
+++ b/gms/application_state.hh
@@ -65,8 +65,8 @@ enum class application_state {
     SHARD_COUNT,
     IGNORE_MSB_BITS,
     CDC_STREAMS_TIMESTAMP,
+    SNITCH_NAME,
     // pad to allow adding new states to existing cluster
-    X9,
     X10,
 };
 

--- a/gms/gossiper.hh
+++ b/gms/gossiper.hh
@@ -577,6 +577,7 @@ private:
 public:
     void append_endpoint_state(std::stringstream& ss, const endpoint_state& state);
 public:
+    void check_snitch_name_matches() const;
     sstring get_all_endpoint_states();
     std::map<sstring, sstring> get_simple_states();
     int get_down_endpoint_count() const noexcept;

--- a/gms/versioned_value.hh
+++ b/gms/versioned_value.hh
@@ -219,6 +219,10 @@ public:
         return versioned_value(rack_id);
     }
 
+    static versioned_value snitch_name(const sstring& snitch_name) {
+        return versioned_value(snitch_name);
+    }
+
     static versioned_value shard_count(int shard_count) {
         return versioned_value(format("{}", shard_count));
     }


### PR DESCRIPTION
Snitch name needs to be exchanged within cluster once, on shadow
round, so joining nodes cannot use wrong snitch. The snitch names
are compared on bootstrap and on normal node start.

If the cluster already used mixed snitches, the upgrade to this
version will fail. In this case customer needs to add a node with
correct snitch for every node with the wrong snitch, then put
down the nodes with the wrong snitch and only then do the upgrade.

Fixes #6832