### PR TITLE
api: Add cardinality to toppartitions results

### DIFF
--- a/api/api-doc/column_family.json
+++ b/api/api-doc/column_family.json
@@ -2925,12 +2925,20 @@
          "id":"toppartitions_query_results",
          "description":"nodetool toppartitions query results",
          "properties":{
+            "read_cardinality":{
+               "type":"long",
+               "description":"Number of the unique operations in the sample set"
+            },
             "read":{
                "type":"array",
                "items":{
                   "type":"toppartitions_record"
                },
                "description":"Read results"
+            },
+            "write_cardinality":{
+               "type":"long",
+               "description":"Number of the unique operations in the sample set"
             },
             "write":{
                "type":"array",

--- a/api/column_family.cc
+++ b/api/column_family.cc
@@ -991,6 +991,9 @@ void set_column_family(http_context& ctx, routes& r) {
                         apilog.debug("toppartitions query: processing results");
                         cf::toppartitions_query_results results;
 
+                        results.read_cardinality = topk_results.read.size();
+                        results.write_cardinality = topk_results.write.size();
+
                         for (auto& d: topk_results.read.top(q.list_size())) {
                             cf::toppartitions_record r;
                             r.partition = sstring(d.item);


### PR DESCRIPTION
This change enhances the toppartitions api to also return
the cardinality of the read and write sample sets. It now uses
the size() method of space_saving_top_k class, counting the unique
operations in the sampled set for up to the given capacity.

Fixes #4089