### PR TITLE
Reinstate [[nodiscard]] support

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1139,7 +1139,6 @@ warnings = [
     '-Wno-delete-non-abstract-non-virtual-dtor',
     '-Wno-unknown-attributes',
     '-Wno-braced-scalar-init',
-    '-Wno-unused-value',
     '-Wno-range-loop-construct',
     '-Wno-unused-function',
     '-Wno-implicit-int-float-conversion',

--- a/serializer_impl.hh
+++ b/serializer_impl.hh
@@ -724,7 +724,7 @@ void serialize(Output& out, const std::variant<T...>& v) {
 template<typename Input, typename T, size_t... I>
 T deserialize_std_variant(Input& in, boost::type<T> t,  size_t idx, std::index_sequence<I...>) {
     T v;
-    ((I == idx ? v = deserialize(in, boost::type<std::variant_alternative_t<I, T>>()), true : false) || ...);
+    (void)((I == idx ? v = deserialize(in, boost::type<std::variant_alternative_t<I, T>>()), true : false) || ...);
     return v;
 }
 

--- a/test/boost/mutation_test.cc
+++ b/test/boost/mutation_test.cc
@@ -2897,7 +2897,7 @@ void check_clustering_summaries(const schema& schema, const partition_summary& a
 void check_partition_summaries(const schema& schema, const std::vector<partition_summary>& actual, const std::vector<partition_summary>& expected) {
     BOOST_CHECK_EQUAL(actual.size(), expected.size());
 
-    for (auto actual_it = actual.cbegin(), expected_it = expected.cbegin(); actual_it != actual.cend(), expected_it != expected.cend();
+    for (auto actual_it = actual.cbegin(), expected_it = expected.cbegin(); actual_it != actual.cend() || expected_it != expected.cend();
             ++actual_it, ++expected_it) {
         BOOST_REQUIRE(actual_it->key.equal(schema, expected_it->key));
         BOOST_REQUIRE_EQUAL(actual_it->tomb.timestamp, expected_it->tomb.timestamp);

--- a/test/lib/mutation_source_test.cc
+++ b/test/lib/mutation_source_test.cc
@@ -2349,7 +2349,7 @@ void compare_readers(const schema& s, flat_mutation_reader authority, flat_mutat
     auto assertions = assert_that(std::move(tested));
     compare_readers(s, authority, assertions);
     for (auto& r: fwd_ranges) {
-        authority.fast_forward_to(r, db::no_timeout);
+        authority.fast_forward_to(r, db::no_timeout).get();
         assertions.fast_forward_to(r);
         compare_readers(s, authority, assertions);
     }


### PR DESCRIPTION
The switch to clang disabled the clang-specific -Wunused-value
since it generated some harmless warnings. Unfortunately, that also
prevent [[nodiscard]] violations from warning.
    
Fix by clearing all instances of the warning (including [[nodiscard]]
violations that crept in while it was disabled) and reinstating the warning.
