### PR TITLE
types: don't linearize in validate()

### DIFF
--- a/cql3/attributes.cc
+++ b/cql3/attributes.cc
@@ -72,14 +72,12 @@ int64_t attributes::get_timestamp(int64_t now, const query_options& options) {
     if (tval.is_unset_value()) {
         return now;
     }
-  return with_linearized(*tval, [&] (bytes_view val) {
     try {
-        data_type_for<int64_t>()->validate(val, options.get_cql_serialization_format());
+        data_type_for<int64_t>()->validate(*tval, options.get_cql_serialization_format());
     } catch (marshal_exception& e) {
         throw exceptions::invalid_request_exception("Invalid timestamp value");
     }
-    return value_cast<int64_t>(data_type_for<int64_t>()->deserialize(val));
-  });
+    return value_cast<int64_t>(data_type_for<int64_t>()->deserialize(*tval));
 }
 
 int32_t attributes::get_time_to_live(const query_options& options) {
@@ -93,16 +91,15 @@ int32_t attributes::get_time_to_live(const query_options& options) {
     if (tval.is_unset_value()) {
         return 0;
     }
-  auto ttl = with_linearized(*tval, [&] (bytes_view val) {
+
     try {
-        data_type_for<int32_t>()->validate(val, options.get_cql_serialization_format());
+        data_type_for<int32_t>()->validate(*tval, options.get_cql_serialization_format());
     }
     catch (marshal_exception& e) {
         throw exceptions::invalid_request_exception("Invalid TTL value");
     }
+    auto ttl = value_cast<int32_t>(data_type_for<int32_t>()->deserialize(*tval));
 
-    return value_cast<int32_t>(data_type_for<int32_t>()->deserialize(val));
-  });
     if (ttl < 0) {
         throw exceptions::invalid_request_exception("A TTL must be greater or equal to 0");
     }

--- a/cql3/lists.cc
+++ b/cql3/lists.cc
@@ -227,9 +227,7 @@ lists::marker::bind(const query_options& options) {
         return constants::UNSET_VALUE;
     } else {
         try {
-            with_linearized(*value, [&] (bytes_view v) {
-                ltype.validate(v, options.get_cql_serialization_format());
-            });
+            ltype.validate(*value, options.get_cql_serialization_format());
             return make_shared<lists::value>(value::from_serialized(*value, ltype, options.get_cql_serialization_format()));
         } catch (marshal_exception& e) {
             throw exceptions::invalid_request_exception(

--- a/cql3/maps.cc
+++ b/cql3/maps.cc
@@ -261,9 +261,7 @@ maps::marker::bind(const query_options& options) {
         return constants::UNSET_VALUE;
     }
     try {
-        with_linearized(*val, [&] (bytes_view value) {
-            _receiver->type->validate(value, options.get_cql_serialization_format());
-        });
+        _receiver->type->validate(*val, options.get_cql_serialization_format());
     } catch (marshal_exception& e) {
         throw exceptions::invalid_request_exception(
                 format("Exception while binding column {:s}: {:s}", _receiver->name->to_cql_string(), e.what()));

--- a/cql3/sets.cc
+++ b/cql3/sets.cc
@@ -237,9 +237,7 @@ sets::marker::bind(const query_options& options) {
     } else {
         auto& type = static_cast<const set_type_impl&>(*_receiver->type);
         try {
-            with_linearized(*value, [&] (bytes_view v) {
-                type.validate(v, options.get_cql_serialization_format());
-            });
+            type.validate(*value, options.get_cql_serialization_format());
         } catch (marshal_exception& e) {
             throw exceptions::invalid_request_exception(
                     format("Exception while binding column {:s}: {:s}", _receiver->name->to_cql_string(), e.what()));

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -252,10 +252,9 @@ uint64_t select_statement::do_get_limit(const query_options& options, ::shared_p
     if (val.is_unset_value()) {
         return default_limit;
     }
-  return with_linearized(*val, [&] (bytes_view bv) {
     try {
-        int32_type->validate(bv, options.get_cql_serialization_format());
-        auto l = value_cast<int32_t>(int32_type->deserialize(bv));
+        int32_type->validate(*val, options.get_cql_serialization_format());
+        auto l = value_cast<int32_t>(int32_type->deserialize(*val));
         if (l <= 0) {
             throw exceptions::invalid_request_exception("LIMIT must be strictly positive");
         }
@@ -263,7 +262,6 @@ uint64_t select_statement::do_get_limit(const query_options& options, ::shared_p
     } catch (const marshal_exception& e) {
         throw exceptions::invalid_request_exception("Invalid limit value");
     }
-  });
 }
 
 bool select_statement::needs_post_query_ordering() const {

--- a/cql3/tuples.cc
+++ b/cql3/tuples.cc
@@ -140,14 +140,12 @@ shared_ptr<terminal> tuples::in_marker::bind(const query_options& options) {
         auto& type = static_cast<const list_type_impl&>(*_receiver->type);
         auto& elem_type = static_cast<const tuple_type_impl&>(*type.get_elements_type());
         try {
-            with_linearized(*value, [&] (bytes_view v) {
-                type.validate(v, options.get_cql_serialization_format());
-                auto l = value_cast<list_type_impl::native_type>(type.deserialize(v, options.get_cql_serialization_format()));
+            type.validate(*value, options.get_cql_serialization_format());
+            auto l = value_cast<list_type_impl::native_type>(type.deserialize(*value, options.get_cql_serialization_format()));
 
-                for (auto&& element : l) {
-                    elem_type.validate(elem_type.decompose(element), options.get_cql_serialization_format());
-                }
-            });
+            for (auto&& element : l) {
+                elem_type.validate(elem_type.decompose(element), options.get_cql_serialization_format());
+            }
         } catch (marshal_exception& e) {
             throw exceptions::invalid_request_exception(e.what());
         }

--- a/cql3/tuples.hh
+++ b/cql3/tuples.hh
@@ -317,9 +317,7 @@ public:
             } else {
                 auto& type = static_cast<const tuple_type_impl&>(*_receiver->type);
                 try {
-                    with_linearized(*value, [&] (bytes_view v) {
-                        type.validate(v, options.get_cql_serialization_format());
-                    });
+                    type.validate(*value, options.get_cql_serialization_format());
                 } catch (marshal_exception& e) {
                     throw exceptions::invalid_request_exception(
                             format("Exception while binding column {:s}: {:s}", _receiver->name->to_cql_string(), e.what()));

--- a/types.cc
+++ b/types.cc
@@ -1586,9 +1586,13 @@ struct validate_visitor {
 };
 }
 
-void abstract_type::validate(const fragmented_temporary_buffer::view& view, cql_serialization_format sf) const {
-    visit(*this, validate_visitor<fragmented_temporary_buffer::view>{view, sf});
+template <FragmentedView View>
+void abstract_type::validate(const View& view, cql_serialization_format sf) const {
+    visit(*this, validate_visitor<View>{view, sf});
 }
+// Explicit instantiation.
+template void abstract_type::validate<>(const single_fragmented_view&, cql_serialization_format) const;
+template void abstract_type::validate<>(const fragmented_temporary_buffer::view&, cql_serialization_format) const;
 
 void abstract_type::validate(bytes_view v, cql_serialization_format sf) const {
     visit(*this, validate_visitor<single_fragmented_view>{single_fragmented_view(v), sf});

--- a/types.cc
+++ b/types.cc
@@ -1091,7 +1091,8 @@ map_type_impl::deserialize(View in, cql_serialization_format sf) const {
     return make_value(std::move(m));
 }
 
-static void validate_aux(const map_type_impl& t, bytes_view v, cql_serialization_format sf) {
+template <FragmentedView View>
+static void validate_aux(const map_type_impl& t, View v, cql_serialization_format sf) {
     auto size = read_collection_size(v, sf);
     for (int i = 0; i < size; ++i) {
         t.get_keys_type()->validate(read_collection_value(v, sf), sf);
@@ -1564,9 +1565,7 @@ struct validate_visitor {
         }
     }
     void operator()(const map_type_impl& t) {
-        with_linearized(v, [this, &t] (bytes_view bv) {
-            validate_aux(t, bv, sf);
-        });
+        validate_aux(t, v, sf);
     }
     void operator()(const set_type_impl& t) {
         with_linearized(v, [this, &t] (bytes_view bv) {

--- a/types.cc
+++ b/types.cc
@@ -1221,7 +1221,8 @@ set_type_impl::is_value_compatible_with_frozen(const collection_type_impl& previ
     return is_compatible_with(previous);
 }
 
-static void validate_aux(const set_type_impl& t, bytes_view v, cql_serialization_format sf) {
+template <FragmentedView View>
+static void validate_aux(const set_type_impl& t, View v, cql_serialization_format sf) {
     auto nr = read_collection_size(v, sf);
     for (int i = 0; i != nr; ++i) {
         t.get_elements_type()->validate(read_collection_value(v, sf), sf);
@@ -1568,9 +1569,7 @@ struct validate_visitor {
         validate_aux(t, v, sf);
     }
     void operator()(const set_type_impl& t) {
-        with_linearized(v, [this, &t] (bytes_view bv) {
-            validate_aux(t, bv, sf);
-        });
+        validate_aux(t, v, sf);
     }
     void operator()(const list_type_impl& t) {
         with_linearized(v, [this, &t] (bytes_view bv) {

--- a/types.cc
+++ b/types.cc
@@ -1458,7 +1458,9 @@ struct validate_visitor {
         }
     }
     void operator()(const utf8_type_impl&) {
-        auto error_pos = utils::utf8::validate_with_error_position_fragmented(v);
+        auto error_pos = with_simplified(v, [] (FragmentedView auto v) {
+            return utils::utf8::validate_with_error_position_fragmented(v);
+        });
         if (error_pos) {
             throw marshal_exception(format("Validation failed - non-UTF8 character in a UTF8 string, at byte offset {}", *error_pos));
         }
@@ -1567,16 +1569,24 @@ struct validate_visitor {
         }
     }
     void operator()(const map_type_impl& t) {
-        validate_aux(t, v, sf);
+        with_simplified(v, [&] (FragmentedView auto v) {
+            validate_aux(t, v, sf);
+        });
     }
     void operator()(const set_type_impl& t) {
-        validate_aux(t, v, sf);
+        with_simplified(v, [&] (FragmentedView auto v) {
+            validate_aux(t, v, sf);
+        });
     }
     void operator()(const list_type_impl& t) {
-        validate_aux(t, v, sf);
+        with_simplified(v, [&] (FragmentedView auto v) {
+            validate_aux(t, v, sf);
+        });
     }
     void operator()(const tuple_type_impl& t) {
-        validate_aux(t, v, sf);
+        with_simplified(v, [&] (FragmentedView auto v) {
+            validate_aux(t, v, sf);
+        });
     }
 };
 }

--- a/types.hh
+++ b/types.hh
@@ -525,7 +525,8 @@ public:
     data_value deserialize_value(bytes_view v) const {
         return deserialize_impl(single_fragmented_view(v));
     };
-    void validate(const fragmented_temporary_buffer::view& view, cql_serialization_format sf) const;
+    // Explicitly instantiated in .cc
+    template <FragmentedView View> void validate(const View& v, cql_serialization_format sf) const;
     void validate(bytes_view view, cql_serialization_format sf) const;
     bool is_compatible_with(const abstract_type& previous) const;
     /*

--- a/utils/fragment_range.hh
+++ b/utils/fragment_range.hh
@@ -217,3 +217,14 @@ public:
     single_fragmented_view prefix(size_t n) { return single_fragmented_view(_view.substr(0, n)); }
 };
 static_assert(FragmentedView<single_fragmented_view>);
+
+template<FragmentedView View, typename Function>
+requires std::invocable<Function, View> && std::invocable<Function, single_fragmented_view>
+decltype(auto) with_simplified(const View& v, Function&& fn)
+{
+    if (v.size_bytes() == v.current_fragment().size()) [[likely]] {
+        return fn(single_fragmented_view(v.current_fragment()));
+    } else {
+        return fn(v);
+    }
+}

--- a/utils/fragment_range.hh
+++ b/utils/fragment_range.hh
@@ -163,6 +163,8 @@ concept FragmentedView = requires (T view, size_t n) {
     // No preconditions.
     { view.current_fragment() } -> std::convertible_to<const typename T::fragment_type&>;
     // No preconditions.
+    { view.empty() } -> std::same_as<bool>;
+    // No preconditions.
     { view.size_bytes() } -> std::convertible_to<size_t>;
     // Precondition: n <= size_bytes()
     { view.prefix(n) } -> std::same_as<T>;
@@ -208,6 +210,7 @@ public:
     using fragment_type = bytes_view;
     explicit single_fragmented_view(bytes_view bv) : _view(bv) {}
     size_t size_bytes() const { return _view.size(); }
+    bool empty() const { return _view.empty(); }
     void remove_prefix(size_t n) { _view.remove_prefix(n); }
     void remove_current() { _view = bytes_view(); }
     bytes_view current_fragment() const { return _view; }

--- a/utils/fragmented_temporary_buffer.hh
+++ b/utils/fragmented_temporary_buffer.hh
@@ -199,8 +199,8 @@ public:
 
     void remove_current() noexcept {
         _total_size -= _current_size;
-        ++_current;
         if (_total_size) {
+            ++_current;
             _current_size = std::min(_current->size(), _total_size);
             _current_position = _current->get();
         } else {

--- a/utils/utf8.hh
+++ b/utils/utf8.hh
@@ -65,12 +65,13 @@ inline std::optional<size_t> validate_with_error_position(bytes_view string) {
     return validate_with_error_position(data, len);	
 }
 
-std::optional<size_t> validate_with_error_position_fragmented(const FragmentRange auto& fr) {
+std::optional<size_t> validate_with_error_position_fragmented(FragmentedView auto fv) {
     uint8_t partial_codepoint[4];
     size_t partial_filled = 0;
     size_t partial_more_needed = 0;
     size_t bytes_validated = 0;
-    for (auto&& frag : fr) {
+    for (; fv.size_bytes(); fv.remove_current()) {
+        bytes_view frag = fv.current_fragment();
         auto data = reinterpret_cast<const uint8_t*>(frag.data());
         auto len = frag.size();
         if (partial_more_needed) {

--- a/utils/utf8.hh
+++ b/utils/utf8.hh
@@ -65,6 +65,10 @@ inline std::optional<size_t> validate_with_error_position(bytes_view string) {
     return validate_with_error_position(data, len);	
 }
 
+inline std::optional<size_t> validate_with_error_position_fragmented(single_fragmented_view fv) {
+    return validate_with_error_position(fv.current_fragment());
+}
+
 std::optional<size_t> validate_with_error_position_fragmented(FragmentedView auto fv) {
     uint8_t partial_codepoint[4];
     size_t partial_filled = 0;


### PR DESCRIPTION
A sequel to #7692.

This series gets rid of linearization when validating collections and tuple types. (Other types were already validated without linearizing).
The necessary helpers for reading from fragmented buffers were introduced in #7692. All this series does is put them to use in `validate()`.

Refs: #6138