### PR TITLE
types: don't linearize in serialize_for_cql()

### DIFF
--- a/collection_mutation.hh
+++ b/collection_mutation.hh
@@ -136,4 +136,4 @@ collection_mutation merge(const abstract_type&, collection_mutation_view, collec
 collection_mutation difference(const abstract_type&, collection_mutation_view, collection_mutation_view);
 
 // Serializes the given collection of cells to a sequence of bytes ready to be sent over the CQL protocol.
-bytes serialize_for_cql(const abstract_type&, collection_mutation_view, cql_serialization_format);
+bytes_ostream serialize_for_cql(const abstract_type&, collection_mutation_view, cql_serialization_format);

--- a/mutation_partition.cc
+++ b/mutation_partition.cc
@@ -704,7 +704,7 @@ void write_cell(RowWriter& w, const query::partition_slice& slice, data_type typ
 
     w.add().write().skip_timestamp()
         .skip_expiry()
-        .write_value(serialize_for_cql(*type, std::move(v), slice.cql_format()))
+        .write_fragmented_value(serialize_for_cql(*type, std::move(v), slice.cql_format()))
         .skip_ttl()
         .end_qr_cell();
 }

--- a/serializer_impl.hh
+++ b/serializer_impl.hh
@@ -543,10 +543,9 @@ struct serializer<bytes> {
     requires FragmentRange<FragmentedBuffer>
     static void write_fragmented(Output& out, FragmentedBuffer&& fragments) {
         safe_serialize_as_uint32(out, uint32_t(fragments.size_bytes()));
-        using boost::range::for_each;
-        for_each(fragments, [&out] (bytes_view frag) {
+        for (bytes_view frag : fragments) {
             out.write(reinterpret_cast<const char*>(frag.begin()), frag.size());
-        });
+        }
     }
     template<typename Input>
     static void skip(Input& in) {

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -296,8 +296,8 @@ public:
                 assert(c.is_live());
                 actual = c.value().linearize();
             } else {
-                actual = serialize_for_cql(*col_def->type,
-                        cell->as_collection_mutation(), cql_serialization_format::internal());
+                actual = linearized(serialize_for_cql(*col_def->type,
+                        cell->as_collection_mutation(), cql_serialization_format::internal()));
             }
             assert(col_def->type->equal(actual, exp));
           });

--- a/types.cc
+++ b/types.cc
@@ -3123,10 +3123,10 @@ static bytes_ostream serialize_for_cql_aux(const user_type_impl& type, collectio
     return out;
 }
 
-bytes serialize_for_cql(const abstract_type& type, collection_mutation_view v, cql_serialization_format sf) {
+bytes_ostream serialize_for_cql(const abstract_type& type, collection_mutation_view v, cql_serialization_format sf) {
     assert(type.is_multi_cell());
 
-    return linearized(v.with_deserialized(type, [&] (collection_mutation_view_description mv) {
+    return v.with_deserialized(type, [&] (collection_mutation_view_description mv) {
         return visit(type, make_visitor(
             [&] (const map_type_impl& ctype) { return serialize_for_cql_aux(ctype, std::move(mv), sf); },
             [&] (const set_type_impl& ctype) { return serialize_for_cql_aux(ctype, std::move(mv), sf); },
@@ -3136,7 +3136,7 @@ bytes serialize_for_cql(const abstract_type& type, collection_mutation_view v, c
                 throw std::runtime_error(format("attempted to serialize a collection of cells with type: {}", o.name()));
             }
         ));
-    }));
+    });
 }
 
 bytes serialize_field_index(size_t idx) {

--- a/types.cc
+++ b/types.cc
@@ -3072,15 +3072,17 @@ static bytes serialize_for_cql_aux(const set_type_impl&, collection_mutation_vie
 }
 
 static bytes serialize_for_cql_aux(const list_type_impl&, collection_mutation_view_description mut, cql_serialization_format sf) {
-    std::vector<bytes> linearized_values;
-    std::vector<bytes_view> tmp;
-    tmp.reserve(mut.cells.size());
+    bytes_ostream out;
+    auto len_slot = out.write_place_holder(collection_size_len(sf));
+    int elements = 0;
     for (auto&& e : mut.cells) {
         if (e.second.is_live(mut.tomb, false)) {
-            tmp.push_back(linearized(e.second.value(), linearized_values));
+            write_collection_value(out, sf, e.second.value());
+            elements += 1;
         }
     }
-    return collection_type_impl::pack(tmp.begin(), tmp.end(), tmp.size(), sf);
+    write_collection_size(len_slot, elements, sf);
+    return linearized(out);
 }
 
 static bytes serialize_for_cql_aux(const user_type_impl& type, collection_mutation_view_description mut, cql_serialization_format) {

--- a/types.cc
+++ b/types.cc
@@ -3058,14 +3058,17 @@ static bytes serialize_for_cql_aux(const map_type_impl&, collection_mutation_vie
 }
 
 static bytes serialize_for_cql_aux(const set_type_impl&, collection_mutation_view_description mut, cql_serialization_format sf) {
-    std::vector<bytes_view> tmp;
-    tmp.reserve(mut.cells.size());
+    bytes_ostream out;
+    auto len_slot = out.write_place_holder(collection_size_len(sf));
+    int elements = 0;
     for (auto&& e : mut.cells) {
         if (e.second.is_live(mut.tomb, false)) {
-            tmp.emplace_back(e.first);
+            write_collection_value(out, sf, data::value_view(e.first));
+            elements += 1;
         }
     }
-    return collection_type_impl::pack(tmp.begin(), tmp.end(), tmp.size(), sf);
+    write_collection_size(len_slot, elements, sf);
+    return linearized(out);
 }
 
 static bytes serialize_for_cql_aux(const list_type_impl&, collection_mutation_view_description mut, cql_serialization_format sf) {

--- a/utils/fragment_range.hh
+++ b/utils/fragment_range.hh
@@ -131,10 +131,9 @@ bytes linearized(const FragmentedBuffer& buffer)
 {
     bytes b(bytes::initialized_later(), buffer.size_bytes());
     auto dst = b.begin();
-    using boost::range::for_each;
-    for_each(buffer, [&] (bytes_view fragment) {
+    for (bytes_view fragment : buffer) {
         dst = boost::copy(fragment, dst);
-    });
+    }
     return b;
 }
 


### PR DESCRIPTION
A sequel to #7692.

This series gets rid of linearization in `serialize_for_cql`, which serializes collections and user types from `collection_mutation_view` to CQL. We switch from `bytes` to `bytes_ostream` as the intermediate buffer type.

The only user of of `serialize_for_cql` immediately copies the result to another `bytes_ostream`. We could avoid some copies and allocations by writing to the final `bytes_ostream` directly, but it's currently hidden behind a template.

Before this series, `serialize_for_cql_aux()` delegated the actual writing to `collection_type_impl::pack` and `tuple_type_impl::build_value`, by passing them an intermediate `vector`. After this patch, the writing is done directly in `serialize_for_cql_aux()`. Pros: we avoid the overhead of creating an intermediate vector, without bloating the source code (because creating that intermediate vector requires just as much code as serializing the values right away). Cons: we duplicate the CQL collection format knowledge contained in `collection_type_impl::pack` and `tuple_type_impl::build_value`.

Refs: #6138
