### PR TITLE
Add propagating overloaded from replicas

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -946,6 +946,7 @@ idls = ['idl/gossip_digest.idl.hh',
         'idl/view.idl.hh',
         'idl/messaging_service.idl.hh',
         'idl/paxos.idl.hh',
+        'idl/status.idl.hh',
         ]
 
 headers = find_headers('.', excluded_dirs=['idl', 'build', 'seastar', '.git'])

--- a/exceptions/exceptions.hh
+++ b/exceptions/exceptions.hh
@@ -228,6 +228,7 @@ struct read_failure_exception : public request_failure_exception {
 };
 
 struct overloaded_exception : public cassandra_exception {
+    overloaded_exception() noexcept : cassandra_exception(exception_code::OVERLOADED, "") {};
     explicit overloaded_exception(size_t c) noexcept :
         cassandra_exception(exception_code::OVERLOADED, prepare_message("Too many in flight hints: %lu", c)) {}
     explicit overloaded_exception(sstring msg) noexcept :

--- a/gms/feature.hh
+++ b/gms/feature.hh
@@ -145,6 +145,7 @@ extern const std::string_view PER_TABLE_CACHING;
 extern const std::string_view DIGEST_FOR_NULL_VALUES;
 extern const std::string_view CORRECT_IDX_TOKEN_IN_SECONDARY_INDEX;
 extern const std::string_view ALTERNATOR_STREAMS;
+extern const std::string_view QUERY_STATUS_FOR_READS;
 
 }
 

--- a/gms/feature_service.cc
+++ b/gms/feature_service.cc
@@ -64,6 +64,7 @@ constexpr std::string_view features::PER_TABLE_CACHING = "PER_TABLE_CACHING";
 constexpr std::string_view features::DIGEST_FOR_NULL_VALUES = "DIGEST_FOR_NULL_VALUES";
 constexpr std::string_view features::CORRECT_IDX_TOKEN_IN_SECONDARY_INDEX = "CORRECT_IDX_TOKEN_IN_SECONDARY_INDEX";
 constexpr std::string_view features::ALTERNATOR_STREAMS = "ALTERNATOR_STREAMS";
+constexpr std::string_view features::QUERY_STATUS_FOR_READS = "QUERY_STATUS_FOR_READS";
 
 static logging::logger logger("features");
 
@@ -90,6 +91,7 @@ feature_service::feature_service(feature_config cfg) : _config(cfg)
         , _digest_for_null_values_feature(*this, features::DIGEST_FOR_NULL_VALUES)
         , _correct_idx_token_in_secondary_index_feature(*this, features::CORRECT_IDX_TOKEN_IN_SECONDARY_INDEX)
         , _alternator_streams_feature(*this, features::ALTERNATOR_STREAMS)
+        , _query_status_for_reads_feature(*this, features::QUERY_STATUS_FOR_READS)
 {}
 
 feature_config feature_config_from_db_config(db::config& cfg, std::set<sstring> disabled) {
@@ -193,6 +195,7 @@ std::set<std::string_view> feature_service::known_feature_set() {
         gms::features::DIGEST_FOR_NULL_VALUES,
         gms::features::CORRECT_IDX_TOKEN_IN_SECONDARY_INDEX,
         gms::features::ALTERNATOR_STREAMS,
+        gms::features::QUERY_STATUS_FOR_READS,
     };
 
     for (const sstring& s : _config._disabled_features) {
@@ -274,6 +277,7 @@ void feature_service::enable(const std::set<std::string_view>& list) {
         std::ref(_digest_for_null_values_feature),
         std::ref(_correct_idx_token_in_secondary_index_feature),
         std::ref(_alternator_streams_feature),
+        std::ref(_query_status_for_reads_feature),
     })
     {
         if (list.contains(f.name())) {

--- a/gms/feature_service.hh
+++ b/gms/feature_service.hh
@@ -94,6 +94,7 @@ private:
     gms::feature _digest_for_null_values_feature;
     gms::feature _correct_idx_token_in_secondary_index_feature;
     gms::feature _alternator_streams_feature;
+    gms::feature _query_status_for_reads_feature;
 
 public:
     bool cluster_supports_user_defined_functions() const {
@@ -169,6 +170,10 @@ public:
 
     bool cluster_supports_alternator_streams() const {
         return bool(_alternator_streams_feature);
+    }
+
+    bool cluster_supports_query_status_for_reads() const {
+        return bool(_query_status_for_reads_feature);
     }
 };
 

--- a/idl/status.idl.hh
+++ b/idl/status.idl.hh
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2020 ScyllaDB
+ */
+
+/*
+ * This file is part of Scylla.
+ *
+ * Scylla is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Scylla is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace query {
+
+class status {
+    uint8_t get_status();
+}
+}
+

--- a/message/messaging_service.hh
+++ b/message/messaging_service.hh
@@ -30,6 +30,7 @@
 #include <seastar/rpc/rpc_types.hh>
 #include <unordered_map>
 #include "query-request.hh"
+#include "query-status.hh"
 #include "mutation_query.hh"
 #include "range.hh"
 #include "repair/repair.hh"
@@ -469,9 +470,9 @@ public:
 
     // Wrapper for READ_DATA
     // Note: WTH is future<foreign_ptr<lw_shared_ptr<query::result>>
-    void register_read_data(std::function<future<rpc::tuple<foreign_ptr<lw_shared_ptr<query::result>>, cache_temperature>> (const rpc::client_info&, rpc::opt_time_point timeout, query::read_command cmd, ::compat::wrapping_partition_range pr, rpc::optional<query::digest_algorithm> digest)>&& func);
+    void register_read_data(std::function<future<rpc::tuple<foreign_ptr<lw_shared_ptr<query::result>>, cache_temperature, query::status>> (const rpc::client_info&, rpc::opt_time_point timeout, query::read_command cmd, ::compat::wrapping_partition_range pr, rpc::optional<query::digest_algorithm> digest)>&& func);
     future<> unregister_read_data();
-    future<rpc::tuple<query::result, rpc::optional<cache_temperature>>> send_read_data(msg_addr id, clock_type::time_point timeout, const query::read_command& cmd, const dht::partition_range& pr, query::digest_algorithm da);
+    future<rpc::tuple<query::result, rpc::optional<cache_temperature>, rpc::optional<query::status>>> send_read_data(msg_addr id, clock_type::time_point timeout, const query::read_command& cmd, const dht::partition_range& pr, query::digest_algorithm da);
 
     // Wrapper for GET_SCHEMA_VERSION
     void register_get_schema_version(std::function<future<frozen_schema>(unsigned, table_schema_version)>&& func);
@@ -484,14 +485,14 @@ public:
     future<utils::UUID> send_schema_check(msg_addr);
 
     // Wrapper for READ_MUTATION_DATA
-    void register_read_mutation_data(std::function<future<rpc::tuple<foreign_ptr<lw_shared_ptr<reconcilable_result>>, cache_temperature>> (const rpc::client_info&, rpc::opt_time_point timeout, query::read_command cmd, ::compat::wrapping_partition_range pr)>&& func);
+    void register_read_mutation_data(std::function<future<rpc::tuple<foreign_ptr<lw_shared_ptr<reconcilable_result>>, cache_temperature, query::status>> (const rpc::client_info&, rpc::opt_time_point timeout, query::read_command cmd, ::compat::wrapping_partition_range pr)>&& func);
     future<> unregister_read_mutation_data();
-    future<rpc::tuple<reconcilable_result, rpc::optional<cache_temperature>>> send_read_mutation_data(msg_addr id, clock_type::time_point timeout, const query::read_command& cmd, const dht::partition_range& pr);
+    future<rpc::tuple<reconcilable_result, rpc::optional<cache_temperature>, rpc::optional<query::status>>> send_read_mutation_data(msg_addr id, clock_type::time_point timeout, const query::read_command& cmd, const dht::partition_range& pr);
 
     // Wrapper for READ_DIGEST
-    void register_read_digest(std::function<future<rpc::tuple<query::result_digest, api::timestamp_type, cache_temperature>> (const rpc::client_info&, rpc::opt_time_point timeout, query::read_command cmd, ::compat::wrapping_partition_range pr, rpc::optional<query::digest_algorithm> digest)>&& func);
+    void register_read_digest(std::function<future<rpc::tuple<query::result_digest, api::timestamp_type, cache_temperature, query::status>> (const rpc::client_info&, rpc::opt_time_point timeout, query::read_command cmd, ::compat::wrapping_partition_range pr, rpc::optional<query::digest_algorithm> digest)>&& func);
     future<> unregister_read_digest();
-    future<rpc::tuple<query::result_digest, rpc::optional<api::timestamp_type>, rpc::optional<cache_temperature>>> send_read_digest(msg_addr id, clock_type::time_point timeout, const query::read_command& cmd, const dht::partition_range& pr, query::digest_algorithm da);
+    future<rpc::tuple<query::result_digest, rpc::optional<api::timestamp_type>, rpc::optional<cache_temperature>, rpc::optional<query::status>>> send_read_digest(msg_addr id, clock_type::time_point timeout, const query::read_command& cmd, const dht::partition_range& pr, query::digest_algorithm da);
 
     // Wrapper for TRUNCATE
     void register_truncate(std::function<future<>(sstring, sstring)>&& func);

--- a/query-status.hh
+++ b/query-status.hh
@@ -57,7 +57,7 @@ public:
         return static_cast<uint8_t>(_value);
     }
     friend struct ser::serializer<status>;
-
+    bool operator==(const status& other) const = default;
 };
 
 }

--- a/query-status.hh
+++ b/query-status.hh
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2020 ScyllaDB
+ */
+
+/*
+ * This file is part of Scylla.
+ *
+ * Scylla is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Scylla is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+#include <cinttypes>
+
+namespace ser {
+template <typename T>
+class serializer;
+}
+
+namespace query {
+
+// The query status can be used to provide more context for a particular
+// query. The status is propagated from a replica to its coordinator
+// via RPC.
+//
+// Main motivation for introducing this class is that returning an error
+// via RPC layer lacks context - the coordinator does not know why the query
+// failed, only  that it did. In order to remedy that, an additional status
+// field is sent.
+//
+// Status values and their meanings:
+// * OK
+//     The query succeeded without issues and the response contains valid data.
+// * OVERLOADED
+//     The query was rejected due to target replica being overloaded.
+//     Results returned by the response should be ignored, and a proper
+//     exception should be propagated to the client instead.
+class status {
+public:
+    enum value { OK, OVERLOADED };
+private:
+    value _value;
+public:
+    status(value value) : _value(value) {}
+    explicit status(uint8_t v) : _value(static_cast<value>(v)) {}
+    uint8_t get_status() const {
+        return static_cast<uint8_t>(_value);
+    }
+    friend struct ser::serializer<status>;
+
+};
+
+}

--- a/reader_concurrency_semaphore.cc
+++ b/reader_concurrency_semaphore.cc
@@ -443,8 +443,7 @@ future<reader_permit::resource_units> reader_concurrency_semaphore::do_wait_admi
         }
         maybe_dump_reader_permit_diagnostics(*this, *_permit_list, "wait queue overloaded");
         return make_exception_future<reader_permit::resource_units>(
-                std::make_exception_ptr(std::runtime_error(
-                        format("{}: restricted mutation reader queue overload", _name))));
+                exceptions::overloaded_exception(format("{}: restricted mutation reader queue overload", _name)));
     }
     auto r = resources(1, static_cast<ssize_t>(memory));
     auto it = _inactive_reads.begin();

--- a/service/storage_proxy.hh
+++ b/service/storage_proxy.hh
@@ -154,11 +154,11 @@ public:
 class storage_proxy : public seastar::async_sharded_service<storage_proxy>, public peering_sharded_service<storage_proxy>, public service::endpoint_lifecycle_subscriber  {
 public:
     enum class error : uint8_t {
-        NONE,
-        TIMEOUT,
-        FAILURE,
-        DISCONNECTED,
-        OVERLOADED,
+        NONE,         // no error
+        TIMEOUT,      // operation timed out (locally, or no response arrived from a replica before the deadline)
+        FAILURE,      // operation failed (locally or on a remote replica)
+        DISCONNECTED, // RPC session was disconnected
+        OVERLOADED,   // a replica (possibly local) was overloaded and thus unable to perform a request
     };
     using clock_type = lowres_clock;
     struct config {

--- a/service/storage_proxy.hh
+++ b/service/storage_proxy.hh
@@ -157,6 +157,8 @@ public:
         NONE,
         TIMEOUT,
         FAILURE,
+        DISCONNECTED,
+        OVERLOADED,
     };
     using clock_type = lowres_clock;
     struct config {


### PR DESCRIPTION
This series adds propagating overloaded exceptions from replicas to the coordinator, which in turn allows propagating them to the users. The motivation behind it is that drivers are capable of applying retry policies for specific kinds of errors, so it's better to provide as much context as possible.

The way of propagating more context is via a new `query::status` field returned from read operations. The field contains additional information what happened - currently, the status can be either `OK` or `OVERLOADED`. `OK` simply means that the query succeeded, while `OVERLOADED` hints that the result should not be returned to the user at all, but instead discarded and translated to `OverloadedException`. That way, when a replica gets overloaded, Scylla will be able to return a more meaningful error type than a generic read failure.

Note that in C* world, `OverloadedException` is currently understood as `this coordinator got overloaded`, and this series makes this meaning more generic, since it's a replica (or multiple replicas) that failed. Retry policies picked by the drivers should consider that distinction, since some policies may make less sense if the overloaded exception was actually propagated from a replica. One of such policies is "try on next coordinator", which is not guaranteed to help if it's a remote replica that got overloaded. Still, other policies (e.g. reduce the load) may be very effective.