### PR TITLE
Add per query timeout

### DIFF
--- a/cql3/Cql.g
+++ b/cql3/Cql.g
@@ -521,6 +521,7 @@ usingClause[std::unique_ptr<cql3::attributes::raw>& attrs]
 usingClauseObjective[std::unique_ptr<cql3::attributes::raw>& attrs]
     : K_TIMESTAMP ts=intValue { attrs->timestamp = ts; }
     | K_TTL t=intValue { attrs->time_to_live = t; }
+    | K_TIMEOUT to=term { attrs->timeout = to; }
     ;
 
 /**
@@ -1761,6 +1762,7 @@ basic_unreserved_keyword returns [sstring str]
         | K_PER
         | K_PARTITION
         | K_GROUP
+        | K_TIMEOUT
         ) { $str = $k.text; }
     ;
 
@@ -1915,6 +1917,8 @@ K_SCYLLA_COUNTER_SHARD_LIST: S C Y L L A '_' C O U N T E R '_' S H A R D '_' L I
 K_GROUP:       G R O U P;
 
 K_LIKE:        L I K E;
+
+K_TIMEOUT:     T I M E O U T;
 
 // Case-insensitive alpha characters
 fragment A: ('a'|'A');

--- a/cql3/Cql.g
+++ b/cql3/Cql.g
@@ -394,6 +394,7 @@ selectStatement returns [std::unique_ptr<raw::select_statement> expr]
         bool allow_filtering = false;
         bool is_json = false;
         bool bypass_cache = false;
+        auto attrs = std::make_unique<cql3::attributes::raw>();
     }
     : K_SELECT (
                 ( K_JSON { is_json = true; } )?
@@ -408,11 +409,12 @@ selectStatement returns [std::unique_ptr<raw::select_statement> expr]
       ( K_LIMIT rows=intValue { limit = rows; } )?
       ( K_ALLOW K_FILTERING  { allow_filtering = true; } )?
       ( K_BYPASS K_CACHE { bypass_cache = true; })?
+      ( usingClause[attrs] )?
       {
           auto params = make_lw_shared<raw::select_statement::parameters>(std::move(orderings), is_distinct, allow_filtering, is_json, bypass_cache);
           $expr = std::make_unique<raw::select_statement>(std::move(cf), std::move(params),
             std::move(sclause), std::move(wclause), std::move(limit), std::move(per_partition_limit),
-            std::move(gbcolumns), std::make_unique<cql3::attributes::raw>());
+            std::move(gbcolumns), std::move(attrs));
       }
     ;
 

--- a/cql3/Cql.g
+++ b/cql3/Cql.g
@@ -412,7 +412,7 @@ selectStatement returns [std::unique_ptr<raw::select_statement> expr]
           auto params = make_lw_shared<raw::select_statement::parameters>(std::move(orderings), is_distinct, allow_filtering, is_json, bypass_cache);
           $expr = std::make_unique<raw::select_statement>(std::move(cf), std::move(params),
             std::move(sclause), std::move(wclause), std::move(limit), std::move(per_partition_limit),
-            std::move(gbcolumns));
+            std::move(gbcolumns), std::make_unique<cql3::attributes::raw>());
       }
     ;
 

--- a/cql3/attributes.cc
+++ b/cql3/attributes.cc
@@ -44,12 +44,13 @@
 namespace cql3 {
 
 std::unique_ptr<attributes> attributes::none() {
-    return std::unique_ptr<attributes>{new attributes{{}, {}}};
+    return std::unique_ptr<attributes>{new attributes{{}, {}, {}}};
 }
 
-attributes::attributes(::shared_ptr<term>&& timestamp, ::shared_ptr<term>&& time_to_live)
+attributes::attributes(::shared_ptr<term>&& timestamp, ::shared_ptr<term>&& time_to_live, ::shared_ptr<term>&& timeout)
     : _timestamp{std::move(timestamp)}
     , _time_to_live{std::move(time_to_live)}
+    , _timeout{std::move(timeout)}
 { }
 
 bool attributes::is_timestamp_set() const {
@@ -58,6 +59,10 @@ bool attributes::is_timestamp_set() const {
 
 bool attributes::is_time_to_live_set() const {
     return bool(_time_to_live);
+}
+
+bool attributes::is_timeout_set() const {
+    return bool(_timeout);
 }
 
 int64_t attributes::get_timestamp(int64_t now, const query_options& options) {
@@ -112,6 +117,25 @@ int32_t attributes::get_time_to_live(const query_options& options) {
     return ttl;
 }
 
+
+db::timeout_clock::duration attributes::get_timeout(const query_options& options) const {
+    auto timeout = _timeout->bind_and_get(options);
+    if (timeout.is_null() || timeout.is_unset_value()) {
+        throw exceptions::invalid_request_exception("Timeout value cannot be unset/null");
+    }
+    cql_duration duration = value_cast<cql_duration>(duration_type->deserialize(*timeout));
+    if (duration.months || duration.days) {
+        throw exceptions::invalid_request_exception("Timeout values cannot be expressed in days/months");
+    }
+    if (duration.nanoseconds % 1'000'000 != 0) {
+        throw exceptions::invalid_request_exception("Timeout values cannot have granularity finer than milliseconds");
+    }
+    if (duration.nanoseconds < 0) {
+        throw exceptions::invalid_request_exception("Timeout values must be non-negative");
+    }
+    return std::chrono::duration_cast<db::timeout_clock::duration>(std::chrono::nanoseconds(duration.nanoseconds));
+}
+
 void attributes::collect_marker_specification(variable_specifications& bound_names) const {
     if (_timestamp) {
         _timestamp->collect_marker_specification(bound_names);
@@ -119,12 +143,16 @@ void attributes::collect_marker_specification(variable_specifications& bound_nam
     if (_time_to_live) {
         _time_to_live->collect_marker_specification(bound_names);
     }
+    if (_timeout) {
+        _timeout->collect_marker_specification(bound_names);
+    }
 }
 
 std::unique_ptr<attributes> attributes::raw::prepare(database& db, const sstring& ks_name, const sstring& cf_name) const {
     auto ts = !timestamp ? ::shared_ptr<term>{} : timestamp->prepare(db, ks_name, timestamp_receiver(ks_name, cf_name));
     auto ttl = !time_to_live ? ::shared_ptr<term>{} : time_to_live->prepare(db, ks_name, time_to_live_receiver(ks_name, cf_name));
-    return std::unique_ptr<attributes>{new attributes{std::move(ts), std::move(ttl)}};
+    auto to = !timeout ? ::shared_ptr<term>{} : timeout->prepare(db, ks_name, timeout_receiver(ks_name, cf_name));
+    return std::unique_ptr<attributes>{new attributes{std::move(ts), std::move(ttl), std::move(to)}};
 }
 
 lw_shared_ptr<column_specification> attributes::raw::timestamp_receiver(const sstring& ks_name, const sstring& cf_name) const {
@@ -133,6 +161,10 @@ lw_shared_ptr<column_specification> attributes::raw::timestamp_receiver(const ss
 
 lw_shared_ptr<column_specification> attributes::raw::time_to_live_receiver(const sstring& ks_name, const sstring& cf_name) const {
     return make_lw_shared<column_specification>(ks_name, cf_name, ::make_shared<column_identifier>("[ttl]", true), data_type_for<int32_t>());
+}
+
+lw_shared_ptr<column_specification> attributes::raw::timeout_receiver(const sstring& ks_name, const sstring& cf_name) const {
+    return make_lw_shared<column_specification>(ks_name, cf_name, ::make_shared<column_identifier>("[timeout]", true), duration_type);
 }
 
 }

--- a/cql3/attributes.hh
+++ b/cql3/attributes.hh
@@ -54,18 +54,23 @@ class attributes final {
 private:
     const ::shared_ptr<term> _timestamp;
     const ::shared_ptr<term> _time_to_live;
+    const ::shared_ptr<term> _timeout;
 public:
     static std::unique_ptr<attributes> none();
 private:
-    attributes(::shared_ptr<term>&& timestamp, ::shared_ptr<term>&& time_to_live);
+    attributes(::shared_ptr<term>&& timestamp, ::shared_ptr<term>&& time_to_live, ::shared_ptr<term>&& timeout);
 public:
     bool is_timestamp_set() const;
 
     bool is_time_to_live_set() const;
 
+    bool is_timeout_set() const;
+
     int64_t get_timestamp(int64_t now, const query_options& options);
 
     int32_t get_time_to_live(const query_options& options);
+
+    db::timeout_clock::duration get_timeout(const query_options& options) const;
 
     void collect_marker_specification(variable_specifications& bound_names) const;
 
@@ -73,12 +78,15 @@ public:
     public:
         ::shared_ptr<term::raw> timestamp;
         ::shared_ptr<term::raw> time_to_live;
+        ::shared_ptr<term::raw> timeout;
 
         std::unique_ptr<attributes> prepare(database& db, const sstring& ks_name, const sstring& cf_name) const;
     private:
         lw_shared_ptr<column_specification> timestamp_receiver(const sstring& ks_name, const sstring& cf_name) const;
 
         lw_shared_ptr<column_specification> time_to_live_receiver(const sstring& ks_name, const sstring& cf_name) const;
+
+        lw_shared_ptr<column_specification> timeout_receiver(const sstring& ks_name, const sstring& cf_name) const;
     };
 };
 

--- a/cql3/statements/batch_statement.hh
+++ b/cql3/statements/batch_statement.hh
@@ -170,6 +170,8 @@ private:
             service::storage_proxy& storage,
             const query_options& options,
             service::query_state& state) const;
+
+    db::timeout_clock::duration get_timeout(const query_options& options) const;
 public:
     // FIXME: no cql_statement::to_string() yet
 #if 0

--- a/cql3/statements/create_view_statement.cc
+++ b/cql3/statements/create_view_statement.cc
@@ -225,7 +225,7 @@ future<shared_ptr<cql_transport::event::schema_change>> create_view_statement::a
     }
 
     auto parameters = make_lw_shared<raw::select_statement::parameters>(raw::select_statement::parameters::orderings_type(), false, true);
-    raw::select_statement raw_select(_base_name, std::move(parameters), _select_clause, _where_clause, nullptr, nullptr, {});
+    raw::select_statement raw_select(_base_name, std::move(parameters), _select_clause, _where_clause, nullptr, nullptr, {}, std::make_unique<cql3::attributes::raw>());
     raw_select.prepare_keyspace(keyspace());
     raw_select.set_bound_variables({});
 

--- a/cql3/statements/modification_statement.cc
+++ b/cql3/statements/modification_statement.cc
@@ -74,6 +74,10 @@ modification_statement_timeout(const schema& s) {
     }
 }
 
+db::timeout_clock::duration modification_statement::get_timeout(const query_options& options) const {
+    return attrs->is_timeout_set() ? attrs->get_timeout(options) : options.get_timeout_config().*get_timeout_config_selector();
+}
+
 modification_statement::modification_statement(statement_type type_, uint32_t bound_terms, schema_ptr schema_, std::unique_ptr<attributes> attrs_, cql_stats& stats_)
     : cql_statement_opt_metadata(modification_statement_timeout(*schema_))
     , type{type_}
@@ -287,7 +291,7 @@ modification_statement::do_execute(service::storage_proxy& proxy, service::query
 future<>
 modification_statement::execute_without_condition(service::storage_proxy& proxy, service::query_state& qs, const query_options& options) const {
     auto cl = options.get_consistency();
-    auto timeout = db::timeout_clock::now() + options.get_timeout_config().*get_timeout_config_selector();
+    auto timeout = db::timeout_clock::now() + get_timeout(options);
     return get_mutations(proxy, options, timeout, false, options.get_timestamp(qs), qs).then([this, cl, timeout, &proxy, &qs] (auto mutations) {
         if (mutations.empty()) {
             return now();

--- a/cql3/statements/modification_statement.hh
+++ b/cql3/statements/modification_statement.hh
@@ -298,6 +298,9 @@ protected:
      * @throws InvalidRequestException
      */
     virtual void validate_where_clause_for_conditions() const;
+
+    db::timeout_clock::duration get_timeout(const query_options& options) const;
+
     friend class raw::modification_statement;
 };
 

--- a/cql3/statements/raw/select_statement.hh
+++ b/cql3/statements/raw/select_statement.hh
@@ -48,6 +48,7 @@
 #include "cql3/selection/raw_selector.hh"
 #include "cql3/restrictions/statement_restrictions.hh"
 #include "cql3/result_set.hh"
+#include "cql3/attributes.hh"
 #include "exceptions/unrecognized_entity_exception.hh"
 #include "service/client_state.hh"
 #include <seastar/core/shared_ptr.hh>
@@ -105,6 +106,7 @@ private:
     ::shared_ptr<term::raw> _limit;
     ::shared_ptr<term::raw> _per_partition_limit;
     std::vector<::shared_ptr<cql3::column_identifier::raw>> _group_by_columns;
+    std::unique_ptr<cql3::attributes::raw> _attrs;
 public:
     select_statement(::shared_ptr<cf_name> cf_name,
             lw_shared_ptr<const parameters> parameters,
@@ -112,7 +114,8 @@ public:
             std::vector<::shared_ptr<relation>> where_clause,
             ::shared_ptr<term::raw> limit,
             ::shared_ptr<term::raw> per_partition_limit,
-            std::vector<::shared_ptr<cql3::column_identifier::raw>> group_by_columns);
+            std::vector<::shared_ptr<cql3::column_identifier::raw>> group_by_columns,
+            std::unique_ptr<cql3::attributes::raw> attrs);
 
     virtual std::unique_ptr<prepared_statement> prepare(database& db, cql_stats& stats) override {
         return prepare(db, stats, false);

--- a/cql3/statements/select_statement.hh
+++ b/cql3/statements/select_statement.hh
@@ -96,6 +96,7 @@ protected:
     const ks_selector _ks_sel;
     bool _range_scan = false;
     bool _range_scan_no_bypass_cache = false;
+    std::unique_ptr<cql3::attributes> _attrs;
 protected :
     virtual future<::shared_ptr<cql_transport::messages::result_message>> do_execute(service::storage_proxy& proxy,
         service::query_state& state, const query_options& options) const;
@@ -111,7 +112,8 @@ public:
             ordering_comparator_type ordering_comparator,
             ::shared_ptr<term> limit,
             ::shared_ptr<term> per_partition_limit,
-            cql_stats& stats);
+            cql_stats& stats,
+            std::unique_ptr<cql3::attributes> attrs);
 
     virtual ::shared_ptr<const cql3::metadata> get_result_metadata() const override;
     virtual uint32_t get_bound_terms() const override;
@@ -145,6 +147,8 @@ public:
 
     bool has_group_by() const { return _group_by_cell_indices && !_group_by_cell_indices->empty(); }
 
+    db::timeout_clock::duration get_timeout(const query_options& options) const;
+
 protected:
     uint64_t do_get_limit(const query_options& options, ::shared_ptr<term> limit, uint64_t default_limit) const;
     uint64_t get_limit(const query_options& options) const {
@@ -171,7 +175,8 @@ public:
                      ordering_comparator_type ordering_comparator,
                      ::shared_ptr<term> limit,
                      ::shared_ptr<term> per_partition_limit,
-                     cql_stats &stats);
+                     cql_stats &stats,
+                     std::unique_ptr<cql3::attributes> attrs);
 };
 
 class indexed_table_select_statement : public select_statement {
@@ -192,7 +197,8 @@ public:
                                                                     ordering_comparator_type ordering_comparator,
                                                                     ::shared_ptr<term> limit,
                                                                      ::shared_ptr<term> per_partition_limit,
-                                                                    cql_stats &stats);
+                                                                    cql_stats &stats,
+                                                                    std::unique_ptr<cql3::attributes> attrs);
 
     indexed_table_select_statement(schema_ptr schema,
                                    uint32_t bound_terms,
@@ -207,7 +213,8 @@ public:
                                    cql_stats &stats,
                                    const secondary_index::index& index,
                                    ::shared_ptr<restrictions::restrictions> used_index_restrictions,
-                                   schema_ptr view_schema);
+                                   schema_ptr view_schema,
+                                   std::unique_ptr<cql3::attributes> attrs);
 
 private:
     virtual future<::shared_ptr<cql_transport::messages::result_message>> do_execute(service::storage_proxy& proxy,

--- a/docs/cql-extensions.md
+++ b/docs/cql-extensions.md
@@ -42,3 +42,31 @@ way as other options by using `WITH` clause:
 
     CREATE TABLE tbl ...
     WITH paxos_grace_seconds=1234
+
+## USING TIMEOUT
+
+TIMEOUT extension allows specifying per-query timeouts. This parameter accepts a single
+duration and applies it as a timeout specific to a single particular query.
+The parameter is supported for prepared statements as well.
+The parameter acts as part of the USING clause, and thus can be combined with other
+parameters - like timestamps and time-to-live.
+In order for this parameter to be effective for read operations as well, it's possible
+to attach USING clause to SELECT statements.
+
+Examples:
+```cql
+	SELECT * FROM t USING TIMEOUT 200ms;
+```
+```cql
+	INSERT INTO t(a,b,c) VALUES (1,2,3) USING TIMESTAMP 42 AND TIMEOUT 50ms;
+```
+
+Working with prepared statements works as usual - the timeout parameter can be
+explicitly defined or provided as a marker:
+
+```cql
+	SELECT * FROM t USING TIMEOUT ?;
+```
+```cql
+	INSERT INTO t(a,b,c) VALUES (?,?,?) USING TIMESTAMP 42 AND TIMEOUT 50ms;
+```

--- a/service/storage_proxy.hh
+++ b/service/storage_proxy.hh
@@ -153,6 +153,11 @@ public:
 
 class storage_proxy : public seastar::async_sharded_service<storage_proxy>, public peering_sharded_service<storage_proxy>, public service::endpoint_lifecycle_subscriber  {
 public:
+    enum class error : uint8_t {
+        NONE,
+        TIMEOUT,
+        FAILURE,
+    };
     using clock_type = lowres_clock;
     struct config {
         db::config::hinted_handoff_enabled_type hinted_handoff_enabled = {};
@@ -321,7 +326,7 @@ private:
     void remove_response_handler(response_id_type id);
     void remove_response_handler_entry(response_handlers_map::iterator entry);
     void got_response(response_id_type id, gms::inet_address from, std::optional<db::view::update_backlog> backlog);
-    void got_failure_response(response_id_type id, gms::inet_address from, size_t count, std::optional<db::view::update_backlog> backlog);
+    void got_failure_response(response_id_type id, gms::inet_address from, size_t count, std::optional<db::view::update_backlog> backlog, error err);
     future<> response_wait(response_id_type id, clock_type::time_point timeout);
     ::shared_ptr<abstract_write_response_handler>& get_write_response_handler(storage_proxy::response_id_type id);
     response_id_type create_write_response_handler_helper(schema_ptr s, const dht::token& token,

--- a/test/cql-pytest/test_using_timeout.py
+++ b/test/cql-pytest/test_using_timeout.py
@@ -1,0 +1,87 @@
+# Copyright 2020 ScyllaDB
+#
+# This file is part of Scylla.
+#
+# Scylla is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Scylla is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
+
+# Tests for USING TIMEOUT extension
+
+from util import new_test_keyspace, unique_name
+import pytest
+from cassandra.protocol import SyntaxException, AlreadyExists, InvalidRequest, ConfigurationException, ReadTimeout, WriteTimeout
+
+def r(regex):
+    return re.compile(regex, re.IGNORECASE)
+
+@pytest.fixture(scope="session")
+def table1(cql, test_keyspace):
+    table = test_keyspace + "." + unique_name()
+    cql.execute("CREATE TABLE " + table +
+        "(p int, c int, v int, PRIMARY KEY (p,c))")
+    for i in range(0, 3):
+        for j in range(0, 3):
+            cql.execute(f'INSERT INTO {table} (p, c, v) VALUES ({i}, {j}, {j})')
+    everything = list(cql.execute('SELECT * FROM ' + table))
+    yield (table, everything)
+    cql.execute("DROP TABLE " + table)
+
+# Performing operations with a small enough timeout is guaranteed to fail
+def test_per_query_timeout_effective(scylla_only, cql, table1):
+    table, everything = table1
+    with pytest.raises(ReadTimeout):
+        cql.execute(f"SELECT * FROM {table} USING TIMEOUT 0ms")
+    with pytest.raises(WriteTimeout):
+        cql.execute(f"INSERT INTO {table} (p,c,v) VALUES (9,1,1) USING TIMEOUT 0ms")
+    with pytest.raises(WriteTimeout):
+        cql.execute(f"UPDATE {table} USING TIMEOUT 0ms SET v = 5 WHERE p = 9 AND c = 1")
+
+# Performing operations with large enough timeout should succeed
+def test_per_query_timeout_large_enough(scylla_only, cql, table1):
+    table, everything = table1
+    res = list(cql.execute(f"SELECT * FROM {table} USING TIMEOUT 24h"))
+    assert res == everything
+    cql.execute(f"INSERT INTO {table} (p,c,v) VALUES (9,1,1) USING TIMEOUT 60m")
+    cql.execute(f"UPDATE {table} USING TIMEOUT 48h SET v = 5 WHERE p = 9 AND c = 1")
+    res = list(cql.execute(f"SELECT * FROM {table} USING TIMEOUT 24h"))
+    assert res == list(cql.execute(f"SELECT * FROM {table}"))
+
+# Mixing TIMEOUT parameter with other params from the USING clause is legal
+def test_mix_per_query_timeout_with_other_params(scylla_only, cql, table1):
+    table, everything = table1
+    cql.execute(f"INSERT INTO {table} (p,c,v) VALUES (42,1,1) USING TIMEOUT 60m AND TTL 1000000 AND TIMESTAMP 321")
+    cql.execute(f"INSERT INTO {table} (p,c,v) VALUES (42,2,1) USING TIMESTAMP 42 AND TIMEOUT 30m")
+    res = list(cql.execute(f"SELECT ttl(v), writetime(v) FROM {table} WHERE p = 42 and c = 1"))
+    assert len(res) == 1 and res[0].ttl_v == 1000000 and res[0].writetime_v == 321
+    res = list(cql.execute(f"SELECT ttl(v), writetime(v) FROM {table} WHERE p = 42 and c = 2"))
+    assert len(res) == 1 and not res[0].ttl_v and res[0].writetime_v == 42
+
+# Only valid timeout durations are allowed to be specified
+def test_invalid_timeout(scylla_only, cql, table1):
+    table, everything = table1
+    def invalid(stmt):
+        with pytest.raises(InvalidRequest):
+            cql.execute(stmt)
+    invalid(f"SELECT * FROM {table} USING TIMEOUT 'hey'")
+    invalid(f"SELECT * FROM {table} USING TIMEOUT 3mo")
+    invalid(f"SELECT * FROM {table} USING TIMEOUT 40y")
+    invalid(f"SELECT * FROM {table} USING TIMEOUT 917")
+    invalid(f"SELECT * FROM {table} USING TIMEOUT null")
+    # Scylla only supports ms granularity for timeouts
+    invalid(f"SELECT * FROM {table} USING TIMEOUT 60s5ns")
+    invalid(f"SELECT * FROM {table} USING TIMEOUT -10ms")
+    # For select statements, it's not allowed to specify timestamp or ttl,
+    # since they bear no meaning
+    invalid(f"SELECT * FROM {table} USING TIMEOUT 60s AND TIMESTAMP 42")
+    invalid(f"SELECT * FROM {table} USING TIMEOUT 60s AND TTL 10000")
+    invalid(f"SELECT * FROM {table} USING TIMEOUT 60s AND TTL 123 AND TIMESTAMP 911")


### PR DESCRIPTION
This series allows setting per-query timeout via CQL. It's possible via the existing `USING` clause, which is extended to be available for `SELECT` statement as well. This parameter accepts a duration and can also be provided as a marker.
The parameter acts as a regular part of the `USING` clause, which means that it can be used along with `USING TIMESTAMP` and `USING TTL` without issues.
The series comes with a pytest test suite.

Examples:
```cql
        SELECT * FROM t USING TIMEOUT 200ms;
```
```cql
        INSERT INTO t(a,b,c) VALUES (1,2,3) USING TIMESTAMP 42 AND TIMEOUT 50ms;
```

Working with prepared statements works as usual - the timeout parameter can be
explicitly defined or provided as a marker:

```cql
        SELECT * FROM t USING TIMEOUT ?;
```
```cql
        INSERT INTO t(a,b,c) VALUES (?,?,?) USING TIMESTAMP 42 AND TIMEOUT 50ms;
```

Tests: unit(dev)
Fixes #7777 
