### PR TITLE
utils: fragmented_temporary_buffer: don't add to null pointer

### DIFF
--- a/utils/fragmented_temporary_buffer.hh
+++ b/utils/fragmented_temporary_buffer.hh
@@ -199,8 +199,8 @@ public:
 
     void remove_current() noexcept {
         _total_size -= _current_size;
-        ++_current;
         if (_total_size) {
+            ++_current;
             _current_size = std::min(_current->size(), _total_size);
             _current_position = _current->get();
         } else {


### PR DESCRIPTION
When fragmented_temporary_buffer::view is created from a bytes_view,
_current is null. In that case, in remove_current(), null pointer offset
happens, and ubsan complains. Fix that.