### PR TITLE
Add waiting for flushes on table drops

### DIFF
--- a/database.cc
+++ b/database.cc
@@ -1000,7 +1000,7 @@ future<> database::drop_column_family(const sstring& ks_name, const sstring& cf_
     remove(*cf);
     cf->clear_views();
     auto& ks = find_keyspace(ks_name);
-    return when_all_succeed(cf->await_pending_writes(), cf->await_pending_reads()).then_unpack([this, &ks, cf, tsf = std::move(tsf), snapshot] {
+    return when_all_succeed(cf->await_pending_writes(), cf->await_pending_reads(), cf->await_pending_streams()).then_unpack([this, &ks, cf, tsf = std::move(tsf), snapshot] {
         return truncate(ks, *cf, std::move(tsf), snapshot).finally([this, cf] {
             return cf->stop();
         });

--- a/database.cc
+++ b/database.cc
@@ -1000,7 +1000,7 @@ future<> database::drop_column_family(const sstring& ks_name, const sstring& cf_
     remove(*cf);
     cf->clear_views();
     auto& ks = find_keyspace(ks_name);
-    return when_all_succeed(cf->await_pending_writes(), cf->await_pending_reads(), cf->await_pending_streams()).then_unpack([this, &ks, cf, tsf = std::move(tsf), snapshot] {
+    return cf->await_pending_ops().then([this, &ks, cf, tsf = std::move(tsf), snapshot] {
         return truncate(ks, *cf, std::move(tsf), snapshot).finally([this, cf] {
             return cf->stop();
         });

--- a/database.hh
+++ b/database.hh
@@ -490,6 +490,8 @@ private:
     utils::phased_barrier _pending_reads_phaser;
     // Corresponding phaser for in-progress streams
     utils::phased_barrier _pending_streams_phaser;
+    // Corresponding phaser for in-progress flushes
+    utils::phased_barrier _pending_flushes_phaser;
 
     // This field cashes the last truncation time for the table.
     // The master resides in system.truncated table
@@ -918,6 +920,10 @@ public:
 
     size_t streams_in_progress() const {
         return _pending_streams_phaser.operations_in_progress();
+    }
+
+    future<> await_pending_flushes() {
+        return _pending_flushes_phaser.advance_and_await();
     }
 
     void add_or_update_view(view_ptr v);

--- a/database.hh
+++ b/database.hh
@@ -927,7 +927,7 @@ public:
     }
 
     future<> await_pending_ops() {
-        return when_all(await_pending_reads(), await_pending_writes(), await_pending_streams()).discard_result();
+        return when_all(await_pending_reads(), await_pending_writes(), await_pending_streams(), await_pending_flushes()).discard_result();
     }
 
     void add_or_update_view(view_ptr v);

--- a/database.hh
+++ b/database.hh
@@ -926,6 +926,10 @@ public:
         return _pending_flushes_phaser.advance_and_await();
     }
 
+    future<> await_pending_ops() {
+        return when_all(await_pending_reads(), await_pending_writes(), await_pending_streams()).discard_result();
+    }
+
     void add_or_update_view(view_ptr v);
     void remove_view(view_ptr v);
     void clear_views();

--- a/table.cc
+++ b/table.cc
@@ -1246,7 +1246,8 @@ future<std::unordered_map<sstring, table::snapshot_details>> table::get_snapshot
 }
 
 future<> table::flush() {
-    return _memtables->request_flush();
+    auto op = _pending_flushes_phaser.start();
+    return _memtables->request_flush().then([op = std::move(op)] {});
 }
 
 future<> table::clear() {

--- a/table.cc
+++ b/table.cc
@@ -575,7 +575,7 @@ table::stop() {
         return make_ready_future<>();
     }
     return _async_gate.close().then([this] {
-        return when_all(await_pending_writes(), await_pending_reads(), await_pending_streams()).discard_result().finally([this] {
+        return await_pending_ops().finally([this] {
             return _memtables->request_flush().finally([this] {
                 return _compaction_manager.remove(this).then([this] {
                     return _sstable_deletion_gate.close().then([this] {


### PR DESCRIPTION
This series makes sure that before the table is dropped, all pending memtable flushes related to its memtables would finish.
Normally, flushes are not problematic in Scylla, because all tables are by default `auto_snapshot=true`, which also implies that a table is flushed before being dropped. However, with `auto_snapshot=false` the flush is not attempted at all. It leads to the following race:
1. Run a node with `auto_snapshot=false`
2. Schedule a memtable flush  (e.g. via nodetool)
3. Get preempted in the middle of the flush
4. Drop the table
5. The flush that already started wakes up and starts operating on freed memory, which causes a segfault

Tests: manual(artificially preempting for a long time in bullet point 2. to ensure that the race occurs; segfaults were 100% reproducible before the series and do not happen anymore after the series is applied)

Fixes #7792
