### PR TITLE
cql3: Fix handling of impossible restrictions on a primary-key column

### DIFF
--- a/cql3/restrictions/single_column_restrictions.hh
+++ b/cql3/restrictions/single_column_restrictions.hh
@@ -108,6 +108,9 @@ public:
             return bytes_opt{};
         } else {
             const auto values = std::get<expr::value_list>(possible_lhs_values(&cdef, it->second->expression, options));
+            if (values.empty()) {
+                return bytes_opt{};
+            }
             assert(values.size() == 1);
             return values.front();
         }

--- a/test/boost/secondary_index_test.cc
+++ b/test/boost/secondary_index_test.cc
@@ -76,6 +76,14 @@ SEASTAR_TEST_CASE(test_secondary_index_clustering_key_query) {
                 { utf8_type->decompose(sstring("dcurrorw@techcrunch.com")) },
                 { utf8_type->decompose(sstring("beassebyv@house.gov")) },
             });
+        }).then([&e] {
+            return e.execute_cql("select country from users where country='France' and country='Denmark'"); // #7772
+        }).then([&e] (shared_ptr<cql_transport::messages::result_message> msg) {
+            assert_that(msg).is_rows().is_empty();
+        }).then([&e] {
+            return e.execute_cql("select country from users where country='Denmark' and country='Denmark'");
+        }).then([&e] (shared_ptr<cql_transport::messages::result_message> msg) {
+            assert_that(msg).is_rows().with_rows({{utf8_type->decompose(sstring("Denmark"))}});
         });
     });
 }


### PR DESCRIPTION
There were two problems with handling conflicting equalities on the same PK column (eg, c=1 AND c=0):
1. When the column is indexed, Scylla crashed (#7772)
2. Computing ranges and slices was throwing an exception

This series fixes them both; it also happens to resolve some old TODOs from restriction_test.

Tests: unit (dev, debug)