### PR TITLE
installs.sh: Add seastar scripts to $PATH

### DIFF
--- a/dist/debian/debian/scylla-server.install
+++ b/dist/debian/debian/scylla-server.install
@@ -12,6 +12,7 @@ usr/bin/scyllatop
 usr/sbin/scylla*
 usr/sbin/node_exporter_install
 usr/sbin/node_health_check
+usr/sbin/seastar-cpu-map.sh
 opt/scylladb/scripts/*
 opt/scylladb/swagger-ui/dist/*
 opt/scylladb/api/api-doc/*

--- a/dist/redhat/scylla.spec
+++ b/dist/redhat/scylla.spec
@@ -111,6 +111,7 @@ rm -rf $RPM_BUILD_ROOT
 %{_sbindir}/scylla*
 %{_sbindir}/node_exporter_install
 %{_sbindir}/node_health_check
+%{_sbindir}/seastar-cpu-map.sh
 /opt/scylladb/scripts/*
 /opt/scylladb/swagger-ui/dist/*
 /opt/scylladb/api/api-doc/*

--- a/install.sh
+++ b/install.sh
@@ -287,6 +287,7 @@ cp -r dist/common/scripts/* "$rprefix"/scripts
 ln -srf "$rprefix/scyllatop/scyllatop.py" "$rprefix/bin/scyllatop"
 
 SBINFILES=$(cd dist/common/scripts/; ls scylla_*setup node_exporter_install node_health_check scylla_ec2_check scylla_kernel_check)
+SBINFILES+=" $(cd seastar/scripts; ls seastar-cpu-map.sh)"
 if ! $nonroot; then
     install -d -m755 "$retc"/systemd/system/scylla-server.service.d
     install -m644 dist/common/systemd/scylla-server.service.d/dependencies.conf -Dt "$retc"/systemd/system/scylla-server.service.d


### PR DESCRIPTION
Add seastar script to the SBINFILES variable, which is used to create
symbolic links to scripts so that they appear in $PATH.

Fixes #6731