### PR TITLE
clustering_order_reader_merger: fix the 0 readers case

### DIFF
--- a/mutation_reader.cc
+++ b/mutation_reader.cc
@@ -2565,6 +2565,11 @@ public:
             _all_readers.push_front(std::move(r));
             _unpeeked_readers.push_back(_all_readers.begin());
         }
+
+        if (rs.empty()) {
+            // No readers, no partition.
+            _should_emit_partition_end = false;
+        }
     }
 
     // We assume that operator() is called sequentially and that the caller doesn't use the batch

--- a/test/boost/mutation_reader_test.cc
+++ b/test/boost/mutation_reader_test.cc
@@ -3657,6 +3657,13 @@ SEASTAR_THREAD_TEST_CASE(test_clustering_order_merger_in_memory) {
         compare_readers(*g._s, make_authority(std::move(merged), fwd),
                 make_tested(std::move(scenario.readers_data), fwd), scenario.fwd_ranges);
     }
+
+    // Test case with 0 readers
+    for (auto fwd: {streamed_mutation::forwarding::no, streamed_mutation::forwarding::yes}) {
+        auto r = make_clustering_combined_reader(g._s, tests::make_permit(), fwd,
+                std::make_unique<simple_position_reader_queue>(*g._s, std::vector<reader_bounds>{}));
+        assert_that(std::move(r)).produces_end_of_stream();
+    }
 }
 
 SEASTAR_THREAD_TEST_CASE(clustering_combined_reader_mutation_source_test) {


### PR DESCRIPTION
With 0 readers the merger would produce a `partition_end` fragment
when it should immediately return `end_of_stream` instead.