### PR TITLE
dist/docker: Remove 'epel-release' from Docker image

### DIFF
--- a/dist/docker/redhat/Dockerfile
+++ b/dist/docker/redhat/Dockerfile
@@ -35,7 +35,6 @@ ADD docker-entrypoint.py /docker-entrypoint.py
 ADD node_exporter_install /node_exporter_install
 # Install Scylla:
 RUN curl $SCYLLA_REPO_URL -o /etc/yum.repos.d/scylla.repo && \
-    yum -y install epel-release && \
     yum -y clean expire-cache && \
     yum -y update && \
     yum -y install scylla-$VERSION hostname supervisor openssh-server openssh-clients rsyslog && \


### PR DESCRIPTION
We no longer need the 'epel-release' package for anything as our
scylla-server package bundles all the necessary dependencies.