### PR TITLE
scylla_setup: enable node_exporter for offline installation

### DIFF
--- a/dist/common/scripts/scylla_setup
+++ b/dist/common/scripts/scylla_setup
@@ -193,30 +193,30 @@ if __name__ == '__main__':
     default_no_coredump_setup = False
     default_no_cpuscaling_setup = False
 
-    if is_offline():
-        if not is_nonroot():
-            default_no_ntp_setup = True
-            warn_offline('ntp setup')
-            if not shutil.which('mkfs.xfs'):
-                default_no_kernel_check = True
-                default_no_raid_setup = True
-                warn_offline_missing_pkg('kernel version check', 'xfsprogs')
-                warn_offline_missing_pkg('RAID setup', 'xfsprogs')
+    if is_offline() and not is_nonroot():
+        default_no_ntp_setup = True
+        warn_offline('ntp setup')
+        if not shutil.which('mkfs.xfs'):
+            default_no_kernel_check = True
+            default_no_raid_setup = True
+            warn_offline_missing_pkg('kernel version check', 'xfsprogs')
+            warn_offline_missing_pkg('RAID setup', 'xfsprogs')
 
-            if not default_no_raid_setup and not shutil.which('mdadm'):
-                default_no_raid_setup = True
-                warn_offline_missing_pkg('RAID setup', 'mdadm')
+        if not default_no_raid_setup and not shutil.which('mdadm'):
+            default_no_raid_setup = True
+            warn_offline_missing_pkg('RAID setup', 'mdadm')
 
-            if not shutil.which('coredumpctl'):
-                default_no_coredump_setup = True
-                warn_offline_missing_pkg('coredump setup', 'systemd-coredump')
+        if not shutil.which('coredumpctl'):
+            default_no_coredump_setup = True
+            warn_offline_missing_pkg('coredump setup', 'systemd-coredump')
 
-            if is_debian_variant() and not shutil.which('cpufreq-set'):
-                default_no_cpuscaling_setup = True
-                warn_offline_missing_pkg('cpuscaling setup', 'cpufrequtils')
-            elif not shutil.which('cpupower'):
-                default_no_cpuscaling_setup = True
-                warn_offline_missing_pkg('cpuscaling setup', 'cpupower')
+        if is_debian_variant() and not shutil.which('cpufreq-set'):
+            default_no_cpuscaling_setup = True
+            warn_offline_missing_pkg('cpuscaling setup', 'cpufrequtils')
+        elif not shutil.which('cpupower'):
+            default_no_cpuscaling_setup = True
+            warn_offline_missing_pkg('cpuscaling setup', 'cpupower')
+
         print()
 
     parser = argparse.ArgumentParser(description='Configure environment for Scylla.')

--- a/dist/common/scripts/scylla_setup
+++ b/dist/common/scripts/scylla_setup
@@ -194,9 +194,6 @@ if __name__ == '__main__':
     default_no_cpuscaling_setup = False
 
     if is_offline():
-        default_no_node_exporter = True
-        warn_offline('node exporter setup')
-
         if not is_nonroot():
             default_no_ntp_setup = True
             warn_offline('ntp setup')


### PR DESCRIPTION
node_exporter had been added to scylla-server package by commit
95197a09c91eb719c252abed847b8c035f5f9600.
    
So we can enable it by default for offline installation.

/CC @tzach @slivne @eyalgutkind @syuu1228 