### PR TITLE
event_notifier: send pending NEW_NODE event before shutdown

### DIFF
--- a/transport/event_notifier.cc
+++ b/transport/event_notifier.cc
@@ -296,6 +296,9 @@ void cql_server::event_notifier::on_up(const gms::inet_address& endpoint)
 
 void cql_server::event_notifier::on_down(const gms::inet_address& endpoint)
 {
+    if (_endpoints_pending_joined_notification.erase(endpoint)) {
+        send_join_cluster(endpoint);
+    }
     bool was_down = _last_status_change.contains(endpoint) && _last_status_change.at(endpoint) == event::status_change::status_type::DOWN;
     _last_status_change[endpoint] = event::status_change::status_type::DOWN;
     if (!was_down) {


### PR DESCRIPTION
If we restart a node after joining in a cluster, the pending NEW_NODE event
might be delayed after restart.

This patch changed to send the pending NEW_NODE event before shutdown.

Signed-off-by: Amos Kong <amos@scylladb.com>