### PR TITLE
Introduce load and stream feature

### DIFF
--- a/api/api-doc/storage_service.json
+++ b/api/api-doc/storage_service.json
@@ -1764,6 +1764,22 @@
                      "allowMultiple":false,
                      "type":"string",
                      "paramType":"query"
+                  },
+                  {
+                     "name":"load_and_stream",
+                     "description":"Load the sstables and stream to all replica nodes that owns the data",
+                     "required":false,
+                     "allowMultiple":false,
+                     "type":"string",
+                     "paramType":"query"
+                  },
+                  {
+                     "name":"primary_replica_only",
+                     "description":"Load the sstables and stream to primary replica node that owns the data. Repair is needed after the load and stream process",
+                     "required":false,
+                     "allowMultiple":false,
+                     "type":"string",
+                     "paramType":"query"
                   }
                ]
             }

--- a/database.hh
+++ b/database.hh
@@ -688,6 +688,10 @@ public:
         return make_streaming_reader(schema, range, schema->full_slice());
     }
 
+    // Stream reader from the given sstables
+    flat_mutation_reader make_streaming_reader(schema_ptr schema, const dht::partition_range& range,
+            lw_shared_ptr<sstables::sstable_set> sstables) const;
+
     sstables::shared_sstable make_streaming_sstable_for_write(std::optional<sstring> subdir = {});
     sstables::shared_sstable make_streaming_staging_sstable() {
         return make_streaming_sstable_for_write("staging");

--- a/distributed_loader.cc
+++ b/distributed_loader.cc
@@ -152,14 +152,14 @@ future<> distributed_loader::verify_owner_and_mode(fs::path path) {
 };
 
 future<>
-distributed_loader::process_sstable_dir(sharded<sstables::sstable_directory>& dir) {
+distributed_loader::process_sstable_dir(sharded<sstables::sstable_directory>& dir, bool sort_sstables_according_to_owner) {
     return dir.invoke_on(0, [] (const sstables::sstable_directory& d) {
         return distributed_loader::verify_owner_and_mode(d.sstable_dir());
-    }).then([&dir] {
-      return dir.invoke_on_all([&dir] (sstables::sstable_directory& d) {
+    }).then([&dir, sort_sstables_according_to_owner] {
+      return dir.invoke_on_all([&dir, sort_sstables_according_to_owner] (sstables::sstable_directory& d) {
         // Supposed to be called with the node either down or on behalf of maintenance tasks
         // like nodetool refresh
-        return d.process_sstable_dir(service::get_local_streaming_priority()).then([&dir, &d] {
+        return d.process_sstable_dir(service::get_local_streaming_priority(), sort_sstables_according_to_owner).then([&dir, &d] {
             return d.move_foreign_sstables(dir);
         });
       });
@@ -447,6 +447,40 @@ distributed_loader::process_upload_dir(distributed<database>& db, distributed<db
         }, size_t(0), std::plus<size_t>()).get0();
 
         dblog.info("Loaded {} SSTables into {}", loaded, datadir.native());
+    });
+}
+
+future<std::tuple<utils::UUID, std::vector<std::vector<sstables::shared_sstable>>>>
+distributed_loader::get_sstables_from_upload_dir(distributed<database>& db, sstring ks, sstring cf) {
+    return seastar::async([&db, ks = std::move(ks), cf = std::move(cf)] {
+        global_column_family_ptr global_table(db, ks, cf);
+        sharded<sstables::sstable_directory> directory;
+        auto table_id = global_table->schema()->id();
+        auto upload = fs::path(global_table->dir()) / "upload";
+
+        directory.start(upload, db.local().get_config().initial_sstable_loading_concurrency(), std::ref(db.local().get_sharded_sst_dir_semaphore()),
+            sstables::sstable_directory::need_mutate_level::yes,
+            sstables::sstable_directory::lack_of_toc_fatal::no,
+            sstables::sstable_directory::enable_dangerous_direct_import_of_cassandra_counters(db.local().get_config().enable_dangerous_direct_import_of_cassandra_counters()),
+            sstables::sstable_directory::allow_loading_materialized_view::no,
+            [&global_table] (fs::path dir, int64_t gen, sstables::sstable_version_types v, sstables::sstable_format_types f) {
+                return global_table->make_sstable(dir.native(), gen, v, f, &error_handler_gen_for_upload_dir);
+
+        }).get();
+
+        auto stop = defer([&directory] {
+            directory.stop().get();
+        });
+
+        std::vector<std::vector<sstables::shared_sstable>> sstables_on_shards(smp::count);
+        lock_table(directory, db, ks, cf).get();
+        bool sort_sstables_according_to_owner = false;
+        process_sstable_dir(directory, sort_sstables_according_to_owner).get();
+        directory.invoke_on_all([&sstables_on_shards] (sstables::sstable_directory& d) mutable {
+            sstables_on_shards[this_shard_id()] = d.get_unsorted_sstables();
+        }).get();
+
+        return std::make_tuple(table_id, sstables_on_shards);
     });
 }
 

--- a/distributed_loader.hh
+++ b/distributed_loader.hh
@@ -62,7 +62,7 @@ public:
     static future<> reshape(sharded<sstables::sstable_directory>& dir, sharded<database>& db, sstables::reshape_mode mode,
             sstring ks_name, sstring table_name, sstables::compaction_sstable_creator_fn creator);
     static future<> reshard(sharded<sstables::sstable_directory>& dir, sharded<database>& db, sstring ks_name, sstring table_name, sstables::compaction_sstable_creator_fn creator);
-    static future<> process_sstable_dir(sharded<sstables::sstable_directory>& dir);
+    static future<> process_sstable_dir(sharded<sstables::sstable_directory>& dir, bool sort_sstables_according_to_owner = true);
     static future<> lock_table(sharded<sstables::sstable_directory>& dir, sharded<database>& db, sstring ks_name, sstring cf_name);
 
     static future<> verify_owner_and_mode(std::filesystem::path path);
@@ -72,6 +72,12 @@ public:
             std::filesystem::path datadir, sstring ks, sstring cf);
     static future<> process_upload_dir(distributed<database>& db, distributed<db::system_distributed_keyspace>& sys_dist_ks,
             distributed<db::view::view_update_generator>& view_update_generator, sstring ks_name, sstring cf_name);
+    // Scan sstables under upload directory. Return a vector with smp::count entries.
+    // Each entry with index of idx should be accessed on shard idx only.
+    // Each entry contains a vector of sstables for this shard.
+    // The table UUID is returned too.
+    static future<std::tuple<utils::UUID, std::vector<std::vector<sstables::shared_sstable>>>>
+            get_sstables_from_upload_dir(distributed<database>& db, sstring ks, sstring cf);
     static future<> populate_column_family(distributed<database>& db, sstring sstdir, sstring ks, sstring cf);
     static future<> populate_keyspace(distributed<database>& db, sstring datadir, sstring ks_name);
     static future<> init_system_keyspace(distributed<database>& db);

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -82,6 +82,7 @@
 #include "repair/repair.hh"
 #include "service/priority_manager.hh"
 #include "utils/generation-number.hh"
+#include <seastar/core/coroutine.hh>
 
 using token = dht::token;
 using UUID = utils::UUID;
@@ -2773,22 +2774,245 @@ void storage_service::add_expire_time_if_found(inet_address endpoint, int64_t ex
     }
 }
 
+class send_meta_data {
+    gms::inet_address _node;
+    rpc::sink<frozen_mutation_fragment, streaming::stream_mutation_fragments_cmd> _sink;
+    rpc::source<int32_t> _source;
+    bool _error_from_peer = false;
+    size_t _num_partitions_sent = 0;
+    size_t _num_bytes_sent = 0;
+    future<> _receive_done;
+private:
+    future<> do_receive() {
+        int32_t status = 0;
+        while (auto status_opt = co_await _source()) {
+            status = std::get<0>(*status_opt);
+            slogger.debug("send_meta_data: got error code={}, from node={}, status={}", status, _node);
+            if (status == -1) {
+                _error_from_peer = true;
+            }
+        }
+        slogger.debug("send_meta_data: finished reading source from node={}", _node);
+        if (_error_from_peer) {
+            throw std::runtime_error(format("send_meta_data: got error code={} from node={}", status, _node));
+        }
+        co_return;
+    }
+public:
+    send_meta_data(gms::inet_address node,
+            rpc::sink<frozen_mutation_fragment, streaming::stream_mutation_fragments_cmd> sink,
+            rpc::source<int32_t> source)
+        : _node(std::move(node))
+        , _sink(std::move(sink))
+        , _source(std::move(source))
+        , _receive_done(make_ready_future<>()) {
+    }
+    void receive() {
+        _receive_done = do_receive();
+    }
+    future<> send(const frozen_mutation_fragment& fmf, bool is_partition_start) {
+        if (_error_from_peer) {
+            throw std::runtime_error(format("send_meta_data: got error from peer node={}", _node));
+        }
+        auto size = fmf.representation().size();
+        if (is_partition_start) {
+            ++_num_partitions_sent;
+        }
+        _num_bytes_sent += size;
+        slogger.trace("send_meta_data: send mf to node={}, size={}", _node, size);
+        co_return co_await _sink(fmf, streaming::stream_mutation_fragments_cmd::mutation_fragment_data);
+    }
+    future<> finish(bool failed) {
+        std::exception_ptr eptr;
+        try {
+            if (failed) {
+                co_await _sink(frozen_mutation_fragment(bytes_ostream()), streaming::stream_mutation_fragments_cmd::error);
+            } else {
+                co_await _sink(frozen_mutation_fragment(bytes_ostream()), streaming::stream_mutation_fragments_cmd::end_of_stream);
+            }
+        } catch (...) {
+            eptr = std::current_exception();
+            slogger.warn("send_meta_data: failed to send {} to node={}, err={}",
+                    failed ? "stream_mutation_fragments_cmd::error" : "stream_mutation_fragments_cmd::end_of_stream", _node, eptr);
+        }
+        try {
+            co_await _sink.close();
+        } catch (...)  {
+            eptr = std::current_exception();
+            slogger.warn("send_meta_data: failed to close sink to node={}, err={}", _node, eptr);
+        }
+        try {
+            co_await std::move(_receive_done);
+        } catch (...)  {
+            eptr = std::current_exception();
+            slogger.warn("send_meta_data: failed to process source from node={}, err={}", _node, eptr);
+        }
+        if (eptr) {
+            std::rethrow_exception(eptr);
+        }
+        co_return;
+    }
+    size_t num_partitions_sent() {
+        return _num_partitions_sent;
+    }
+    size_t num_bytes_sent() {
+        return _num_bytes_sent;
+    }
+};
+
+future<> storage_service::load_and_stream(sstring ks_name, sstring cf_name,
+        utils::UUID table_id, std::vector<sstables::shared_sstable> sstables, bool primary_replica_only) {
+    const auto full_partition_range = dht::partition_range::make_open_ended_both_sides();
+    const auto full_token_range = dht::token_range::make_open_ended_both_sides();
+    auto& table = _db.local().find_column_family(table_id);
+    auto s = table.schema();
+    const auto cf_id = s->id();
+    const auto reason = streaming::stream_reason::rebuild;
+    auto& rs = _db.local().find_keyspace(ks_name).get_replication_strategy();
+
+    size_t nr_sst_total = sstables.size();
+    size_t nr_sst_current = 0;
+    while (!sstables.empty()) {
+        auto ops_uuid = utils::make_random_uuid();
+        auto sst_set = make_lw_shared<sstables::sstable_set>(sstables::make_partitioned_sstable_set(s,
+                make_lw_shared<sstable_list>(sstable_list{}), false));
+        size_t batch_sst_nr = 16;
+        std::vector<sstring> sst_names;
+        std::vector<sstables::shared_sstable> sst_processed;
+        size_t estimated_partitions = 0;
+        while (batch_sst_nr-- && !sstables.empty()) {
+            auto sst = sstables.back();
+            estimated_partitions += sst->estimated_keys_for_range(full_token_range);
+            sst_names.push_back(sst->get_filename());
+            sst_set->insert(sst);
+            sst_processed.push_back(sst);
+            sstables.pop_back();
+        }
+
+        slogger.info("load_and_stream: started ops_uuid={}, process [{}-{}] out of {} sstables={}",
+                ops_uuid, nr_sst_current, nr_sst_current + sst_processed.size(), nr_sst_total, sst_names);
+
+        auto start_time = std::chrono::steady_clock::now();
+        std::vector<gms::inet_address> current_targets;
+        std::unordered_map<gms::inet_address, send_meta_data> metas;
+        size_t num_partitions_processed = 0;
+        size_t num_bytes_read = 0;
+        nr_sst_current += sst_processed.size();
+        auto reader = table.make_streaming_reader(s, full_partition_range, sst_set);
+        std::exception_ptr eptr;
+        bool failed = false;
+        try {
+            netw::messaging_service& ms = _messaging.local();
+            while (auto mf = co_await reader(db::no_timeout)) {
+                bool is_partition_start = mf->is_partition_start();
+                if (is_partition_start) {
+                    ++num_partitions_processed;
+                    auto& start = mf->as_partition_start();
+                    const auto& current_dk = start.key();
+
+                    current_targets = rs.get_natural_endpoints(current_dk.token());
+                    if (primary_replica_only && current_targets.size() > 1) {
+                        current_targets.resize(1);
+                    }
+                    slogger.trace("load_and_stream: ops_uuid={}, current_dk={}, current_targets={}", ops_uuid,
+                            current_dk.token(), current_targets);
+                    for (auto& node : current_targets) {
+                        if (!metas.contains(node)) {
+                            auto [sink, source] = co_await ms.make_sink_and_source_for_stream_mutation_fragments(reader.schema()->version(),
+                                    ops_uuid, cf_id, estimated_partitions, reason, netw::messaging_service::msg_addr(node));
+                            slogger.debug("load_and_stream: ops_uuid={}, make sink and source for node={}", ops_uuid, node);
+                            metas.emplace(node, send_meta_data(node, std::move(sink), std::move(source)));
+                            metas.at(node).receive();
+                        }
+                    }
+                }
+                frozen_mutation_fragment fmf = freeze(*s, *mf);
+                num_bytes_read += fmf.representation().size();
+                co_await parallel_for_each(current_targets, [&metas, &fmf, is_partition_start] (const gms::inet_address& node) {
+                    return metas.at(node).send(fmf, is_partition_start);
+                });
+            }
+        } catch (...) {
+            failed = true;
+            eptr = std::current_exception();
+            slogger.warn("load_and_stream: ops_uuid={}, ks={}, table={}, send_phase, err={}",
+                    ops_uuid, ks_name, cf_name, eptr);
+        }
+        try {
+            co_await parallel_for_each(metas.begin(), metas.end(), [failed] (std::pair<const gms::inet_address, send_meta_data>& pair) {
+                auto& meta = pair.second;
+                return meta.finish(failed);
+            });
+        } catch (...) {
+            failed = true;
+            eptr = std::current_exception();
+            slogger.warn("load_and_stream: ops_uuid={}, ks={}, table={}, finish_phase, err={}",
+                    ops_uuid, ks_name, cf_name, eptr);
+        }
+        if (!failed) {
+            try {
+                co_await parallel_for_each(sst_processed, [&] (sstables::shared_sstable& sst) {
+                    slogger.debug("load_and_stream: ops_uuid={}, ks={}, table={}, remove sst={}",
+                            ops_uuid, ks_name, cf_name, sst->component_filenames());
+                    return sst->unlink();
+                });
+            } catch (...) {
+                failed = true;
+                eptr = std::current_exception();
+                slogger.warn("load_and_stream: ops_uuid={}, ks={}, table={}, del_sst_phase, err={}",
+                        ops_uuid, ks_name, cf_name, eptr);
+            }
+        }
+        auto duration = std::chrono::duration_cast<std::chrono::duration<float>>(std::chrono::steady_clock::now() - start_time).count();
+        for (auto& [node, meta] : metas) {
+            slogger.info("load_and_stream: ops_uuid={}, ks={}, table={}, target_node={}, num_partitions_sent={}, num_bytes_sent={}",
+                    ops_uuid, ks_name, cf_name, node, meta.num_partitions_sent(), meta.num_bytes_sent());
+        }
+        auto partition_rate = std::fabs(duration) > FLT_EPSILON ? num_partitions_processed / duration : 0;
+        auto bytes_rate = std::fabs(duration) > FLT_EPSILON ? num_bytes_read / duration / 1024 / 1024 : 0;
+        auto status = failed ? "failed" : "succeeded";
+        slogger.info("load_and_stream: finished ops_uuid={}, ks={}, table={}, partitions_processed={} partitions, bytes_processed={} bytes, partitions_per_second={} partitions/s, bytes_per_second={} MiB/s, duration={} s, status={}",
+                ops_uuid, ks_name, cf_name, num_partitions_processed, num_bytes_read, partition_rate, bytes_rate, duration, status);
+        if (failed) {
+            std::rethrow_exception(eptr);
+        }
+    }
+    co_return;
+}
+
 // For more details, see the commends on column_family::load_new_sstables
 // All the global operations are going to happen here, and just the reloading happens
 // in there.
-future<> storage_service::load_new_sstables(sstring ks_name, sstring cf_name) {
+future<> storage_service::load_new_sstables(sstring ks_name, sstring cf_name,
+    bool load_and_stream, bool primary_replica_only) {
     if (_loading_new_sstables) {
         throw std::runtime_error("Already loading SSTables. Try again later");
     } else {
         _loading_new_sstables = true;
     }
-
-    slogger.info("Loading new SSTables for {}.{}...", ks_name, cf_name);
-
-    return distributed_loader::process_upload_dir(_db, _sys_dist_ks, _view_update_generator, ks_name, cf_name).finally([this, ks_name, cf_name] {
-        slogger.info("Done loading new SSTables for {}.{}", ks_name, cf_name);
+    slogger.info("Loading new SSTables for keyspace={}, table={}, load_and_stream={}, primary_replica_only={}",
+            ks_name, cf_name, load_and_stream, primary_replica_only);
+    try {
+        if (load_and_stream) {
+            utils::UUID table_id;
+            std::vector<std::vector<sstables::shared_sstable>> sstables_on_shards;
+            std::tie(table_id, sstables_on_shards) = co_await distributed_loader::get_sstables_from_upload_dir(_db, ks_name, cf_name);
+            co_await container().invoke_on_all([&sstables_on_shards, ks_name, cf_name, table_id, primary_replica_only] (storage_service& ss) mutable -> future<> {
+                co_await ss.load_and_stream(ks_name, cf_name, table_id, std::move(sstables_on_shards[this_shard_id()]), primary_replica_only);
+            });
+        } else {
+            co_await distributed_loader::process_upload_dir(_db, _sys_dist_ks, _view_update_generator, ks_name, cf_name);
+        }
+    } catch (...) {
+        slogger.warn("Done loading new SSTables for keyspace={}, table={}, load_and_stream={}, primary_replica_only={}, status=failed: {}",
+                ks_name, cf_name, load_and_stream, primary_replica_only, std::current_exception());
         _loading_new_sstables = false;
-    });
+        throw;
+    }
+    slogger.warn("Done loading new SSTables for keyspace={}, table={}, load_and_stream={}, primary_replica_only={}, status=succeeded",
+            ks_name, cf_name, load_and_stream, primary_replica_only);
+    _loading_new_sstables = false;
+    co_return;
 }
 
 void storage_service::shutdown_client_servers() {

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -62,6 +62,7 @@
 #include <seastar/core/metrics_registration.hh>
 #include <seastar/core/rwlock.hh>
 #include "sstables/version.hh"
+#include "sstables/shared_sstable.hh"
 #include "cdc/metadata.hh"
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/core/lowres_clock.hh>
@@ -859,7 +860,11 @@ public:
      * @param cf_name the column family in which to search for new SSTables.
      * @return a future<> when the operation finishes.
      */
-    future<> load_new_sstables(sstring ks_name, sstring cf_name);
+    future<> load_new_sstables(sstring ks_name, sstring cf_name,
+            bool load_and_stream, bool primary_replica_only);
+    future<> load_and_stream(sstring ks_name, sstring cf_name,
+            utils::UUID table_id, std::vector<sstables::shared_sstable> sstables,
+            bool primary_replica_only);
 
     future<> set_tables_autocompaction(const sstring &keyspace, std::vector<sstring> tables, bool enabled);
 

--- a/table.cc
+++ b/table.cc
@@ -250,6 +250,17 @@ flat_mutation_reader table::make_streaming_reader(schema_ptr schema, const dht::
     return make_combined_reader(std::move(schema), std::move(permit), std::move(readers), fwd, fwd_mr);
 }
 
+flat_mutation_reader table::make_streaming_reader(schema_ptr schema, const dht::partition_range& range,
+        lw_shared_ptr<sstables::sstable_set> sstables) const {
+    auto permit = _config.streaming_read_concurrency_semaphore->make_permit(schema.get(), "load-and-stream");
+    auto& slice = schema->full_slice();
+    const auto& pc = service::get_local_streaming_priority();
+    auto trace_state = tracing::trace_state_ptr();
+    const auto fwd = streamed_mutation::forwarding::no;
+    const auto fwd_mr = mutation_reader::forwarding::no;
+    return make_sstable_reader(schema, permit, sstables, range, slice, pc, std::move(trace_state), fwd, fwd_mr);
+}
+
 future<std::vector<locked_cell>> table::lock_counter_cells(const mutation& m, db::timeout_clock::time_point timeout) {
     assert(m.schema() == _counter_cell_locks->schema());
     return _counter_cell_locks->lock_cells(m.decorated_key(), partition_cells_range(m.partition()), timeout);


### PR DESCRIPTION
storage_service: Introduce load_and_stream

=== Introduction ===

This feature extends the nodetool refresh to allow loading arbitrary sstables
that do not belong to a node into the cluster. It loads the sstables from disk
and calculates the owning nodes of the data and streams to the owners
automatically.

From example, say the old cluster has 6 nodes and the new cluster has 3 nodes.
We can copy the sstables from the old cluster to any of the new nodes and
trigger the load and stream process.

This can make restores and migrations much easier.

=== Performance ===

I managed to get 40MB/s per shard on my build machine.
CPU: AMD Ryzen 7 1800X Eight-Core Processor
DISK: Samsung SSD 970 PRO 512GB

Assume 1TB sstables per node, each shard can do 40MB/s, each node has 32
shards, we can finish the load and stream 1TB of data in 13 mins on each
node.

1TB / 40 MB per shard * 32 shard / 60 s = 13 mins

=== Tests ===

backup_restore_tests.py:TestBackupRestore.load_and_stream_to_new_cluster_test
which creates a cluster with 4 nodes and inserts data, then use
load_and_stream to restore to a 2 nodes cluster.

=== Usage ===

curl -X POST "http://{ip}:10000/storage_service/sstables/{keyspace}?cf={table}&load_and_stream=true

=== Notes ===

Btw, with the old nodetool refresh, the node will not pick up the data
that does not belong to this node but it will not delete it either. One
has to run nodetool cleanup to remove those data manually which is a
surprise to me and probably to users as well. With load and stream, the
process will delete the sstables once it finishes stream, so no nodetool
cleanup is needed.

The name of this feature load and stream follows load and store in CPU world.

Fixes #7831
