### PR TITLE
Support unofficial distributions

### DIFF
--- a/dist/common/scripts/scylla_coredump_setup
+++ b/dist/common/scripts/scylla_coredump_setup
@@ -41,7 +41,7 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
 # Gentoo may uses OpenRC
-    if is_gentoo_variant():
+    if is_gentoo():
         run('sysctl -p /etc/sysctl.d/99-scylla-coredump.conf', shell=True, check=True)
 # Other distributions can use systemd-coredump, so setup it
     else:

--- a/dist/common/scripts/scylla_cpuscaling_setup
+++ b/dist/common/scripts/scylla_cpuscaling_setup
@@ -42,7 +42,7 @@ if __name__ == '__main__':
         cpufreq = systemd_unit('cpufrequtils.service')
         cpufreq.enable()
         cpufreq.restart()
-    if is_gentoo():
+    elif is_gentoo():
         if not shutil.which('cpupower'):
             emerge_install('sys-power/cpupower')
         with open('/etc/conf.d/cpupower') as f:
@@ -53,7 +53,7 @@ if __name__ == '__main__':
         cpufreq = systemd_unit('cpupower-frequency-set.service')
         cpufreq.enable()
         cpufreq.restart()
-    if is_arch():
+    elif is_arch():
         if not shutil.which('cpupower'):
             pkg_install('cpupower')
         cfg = sysconfig_parser('/etc/default/cpupower')
@@ -62,7 +62,7 @@ if __name__ == '__main__':
         cpupwr = systemd_unit('cpupower.service')
         cpupwr.enable()
         cpupwr.restart()
-    if is_amzn2():
+    elif is_amzn2():
         if not shutil.which('cpupower'):
             yum_install('cpupowerutils')
         cfg = sysconfig_parser('/etc/sysconfig/scylla-cpupower')
@@ -100,3 +100,6 @@ WantedBy=multi-user.target
         cpupwr = systemd_unit('cpupower.service')
         cpupwr.enable()
         cpupwr.restart()
+    else:
+        print("Unsupported distribution, skipping setup..")
+        sys.exit(0)

--- a/dist/common/scripts/scylla_cpuscaling_setup
+++ b/dist/common/scripts/scylla_cpuscaling_setup
@@ -56,6 +56,15 @@ if __name__ == '__main__':
         cpufreq = systemd_unit('cpupower-frequency-set.service')
         cpufreq.enable()
         cpufreq.restart()
+    if is_arch():
+        if not shutil.which('cpupower'):
+            pkg_install('cpupower')
+        cfg = sysconfig_parser('/etc/default/cpupower')
+        cfg.set('governor', 'performance')
+        cfg.commit()
+        cpupwr = systemd_unit('cpupower.service')
+        cpupwr.enable()
+        cpupwr.restart()
     if is_amzn2():
         if not shutil.which('cpupower'):
             yum_install('cpupowerutils')

--- a/dist/common/scripts/scylla_cpuscaling_setup
+++ b/dist/common/scripts/scylla_cpuscaling_setup
@@ -26,6 +26,22 @@ import shlex
 import distro
 from scylla_util import *
 
+UNIT_DATA= '''
+[Unit]
+Description=Scylla cpupower service
+After=syslog.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+EnvironmentFile=/etc/sysconfig/scylla-cpupower
+ExecStart=/usr/bin/cpupower $CPUPOWER_START_OPTS
+ExecStop=/usr/bin/cpupower $CPUPOWER_STOP_OPTS
+
+[Install]
+WantedBy=multi-user.target
+'''[1:-1]
+
 if __name__ == '__main__':
     if os.getuid() > 0:
         print('Requires root permission.')
@@ -69,23 +85,8 @@ if __name__ == '__main__':
         cfg.set('CPUPOWER_START_OPTS', 'frequency-set -g performance')
         cfg.set('CPUPOWER_STOP_OPTS', 'frequency-set -g ondemand')
         cfg.commit()
-        unit_data = '''
-[Unit]
-Description=Scylla cpupower service
-After=syslog.target
-
-[Service]
-Type=oneshot
-RemainAfterExit=yes
-EnvironmentFile=/etc/sysconfig/scylla-cpupower
-ExecStart=/usr/bin/cpupower $CPUPOWER_START_OPTS
-ExecStop=/usr/bin/cpupower $CPUPOWER_STOP_OPTS
-
-[Install]
-WantedBy=multi-user.target
-'''[1:-1]
         with open('/etc/systemd/system/scylla-cpupower.service', 'w') as f:
-            f.write(unit_data)
+            f.write(UNIT_DATA)
         systemd_unit.reload()
         cpupwr = systemd_unit('scylla-cpupower.service')
         cpupwr.enable()
@@ -98,6 +99,19 @@ WantedBy=multi-user.target
         cfg.set('CPUPOWER_STOP_OPTS', 'frequency-set -g ondemand')
         cfg.commit()
         cpupwr = systemd_unit('cpupower.service')
+        cpupwr.enable()
+        cpupwr.restart()
+    elif is_suse_variant():
+        if not shutil.which('cpupower'):
+            pkg_install('cpupower')
+        cfg = sysconfig_parser('/etc/sysconfig/scylla-cpupower')
+        cfg.set('CPUPOWER_START_OPTS', 'frequency-set -g performance')
+        cfg.set('CPUPOWER_STOP_OPTS', 'frequency-set -g ondemand')
+        cfg.commit()
+        with open('/etc/systemd/system/scylla-cpupower.service', 'w') as f:
+            f.write(UNIT_DATA)
+        systemd_unit.reload()
+        cpupwr = systemd_unit('scylla-cpupower.service')
         cpupwr.enable()
         cpupwr.restart()
     else:

--- a/dist/common/scripts/scylla_cpuscaling_setup
+++ b/dist/common/scripts/scylla_cpuscaling_setup
@@ -63,11 +63,10 @@ if __name__ == '__main__':
         cpufreq.enable()
         cpufreq.restart()
     elif is_gentoo():
-        with open('/etc/conf.d/cpupower') as f:
-            cur = f.read()
-        new = re.sub(r'--governor ondemand', '--governor performance', cur, flags=re.MULTILINE)
-        with open('/etc/conf.d/cpupower', 'w') as f:
-            f.write(new)
+        cfg = sysconfig_parser('/etc/conf.d/cpupower')
+        cfg.set('START_OPTS', '-g performance')
+        cfg.set('STOP_OPTS', '-g ondemand')
+        cfg.commit()
         cpufreq = systemd_unit('cpupower-frequency-set.service')
         cpufreq.enable()
         cpufreq.restart()

--- a/dist/common/scripts/scylla_cpuscaling_setup
+++ b/dist/common/scripts/scylla_cpuscaling_setup
@@ -45,7 +45,7 @@ if __name__ == '__main__':
         cpufreq = systemd_unit('cpufrequtils.service')
         cpufreq.enable()
         cpufreq.restart()
-    if is_gentoo_variant():
+    if is_gentoo():
         if not shutil.which('cpupower'):
             emerge_install('sys-power/cpupower')
         with open('/etc/conf.d/cpupower') as f:

--- a/dist/common/scripts/scylla_cpuscaling_setup
+++ b/dist/common/scripts/scylla_cpuscaling_setup
@@ -49,9 +49,13 @@ if __name__ == '__main__':
     if not os.path.exists('/sys/devices/system/cpu/cpufreq/policy0/scaling_governor'):
         print('This computer doesn\'t supported CPU scaling configuration.')
         sys.exit(0)
-    if is_debian_variant():
+    if not is_debian_variant():
+        if not shutil.which('cpupower'):
+            pkg_install('cpupowerutils')
+    else:
         if not shutil.which('cpufreq-set'):
-            apt_install('cpufrequtils')
+            pkg_install('cpufrequtils')
+    if is_debian_variant():
         cfg = sysconfig_parser('/etc/default/cpufrequtils')
         cfg.set('GOVERNOR', 'performance')
         cfg.commit()
@@ -59,8 +63,6 @@ if __name__ == '__main__':
         cpufreq.enable()
         cpufreq.restart()
     elif is_gentoo():
-        if not shutil.which('cpupower'):
-            emerge_install('sys-power/cpupower')
         with open('/etc/conf.d/cpupower') as f:
             cur = f.read()
         new = re.sub(r'--governor ondemand', '--governor performance', cur, flags=re.MULTILINE)
@@ -70,17 +72,13 @@ if __name__ == '__main__':
         cpufreq.enable()
         cpufreq.restart()
     elif is_arch():
-        if not shutil.which('cpupower'):
-            pkg_install('cpupower')
         cfg = sysconfig_parser('/etc/default/cpupower')
         cfg.set('governor', 'performance')
         cfg.commit()
         cpupwr = systemd_unit('cpupower.service')
         cpupwr.enable()
         cpupwr.restart()
-    elif is_amzn2():
-        if not shutil.which('cpupower'):
-            yum_install('cpupowerutils')
+    elif is_amzn2() or is_suse_variant():
         cfg = sysconfig_parser('/etc/sysconfig/scylla-cpupower')
         cfg.set('CPUPOWER_START_OPTS', 'frequency-set -g performance')
         cfg.set('CPUPOWER_STOP_OPTS', 'frequency-set -g ondemand')
@@ -92,26 +90,11 @@ if __name__ == '__main__':
         cpupwr.enable()
         cpupwr.restart()
     elif is_redhat_variant():
-        if not shutil.which('cpupower'):
-            yum_install('cpupowerutils')
         cfg = sysconfig_parser('/etc/sysconfig/cpupower')
         cfg.set('CPUPOWER_START_OPTS', 'frequency-set -g performance')
         cfg.set('CPUPOWER_STOP_OPTS', 'frequency-set -g ondemand')
         cfg.commit()
         cpupwr = systemd_unit('cpupower.service')
-        cpupwr.enable()
-        cpupwr.restart()
-    elif is_suse_variant():
-        if not shutil.which('cpupower'):
-            pkg_install('cpupower')
-        cfg = sysconfig_parser('/etc/sysconfig/scylla-cpupower')
-        cfg.set('CPUPOWER_START_OPTS', 'frequency-set -g performance')
-        cfg.set('CPUPOWER_STOP_OPTS', 'frequency-set -g ondemand')
-        cfg.commit()
-        with open('/etc/systemd/system/scylla-cpupower.service', 'w') as f:
-            f.write(UNIT_DATA)
-        systemd_unit.reload()
-        cpupwr = systemd_unit('scylla-cpupower.service')
         cpupwr.enable()
         cpupwr.restart()
     else:

--- a/dist/common/scripts/scylla_cpuscaling_setup
+++ b/dist/common/scripts/scylla_cpuscaling_setup
@@ -26,9 +26,6 @@ import shlex
 import distro
 from scylla_util import *
 
-def is_amzn2():
-    return ('amzn' in distro.id()) and ('2' in distro.version())
-
 if __name__ == '__main__':
     if os.getuid() > 0:
         print('Requires root permission.')

--- a/dist/common/scripts/scylla_fstrim_setup
+++ b/dist/common/scripts/scylla_fstrim_setup
@@ -31,5 +31,5 @@ if __name__ == '__main__':
         sys.exit(1)
     systemd_unit('scylla-fstrim.timer').unmask()
     systemd_unit('scylla-fstrim.timer').enable()
-    if is_redhat_variant() or is_arch():
+    if is_redhat_variant() or is_arch() or is_suse_variant():
         systemd_unit('fstrim.timer').disable()

--- a/dist/common/scripts/scylla_fstrim_setup
+++ b/dist/common/scripts/scylla_fstrim_setup
@@ -31,5 +31,5 @@ if __name__ == '__main__':
         sys.exit(1)
     systemd_unit('scylla-fstrim.timer').unmask()
     systemd_unit('scylla-fstrim.timer').enable()
-    if is_redhat_variant():
+    if is_redhat_variant() or is_arch():
         systemd_unit('fstrim.timer').disable()

--- a/dist/common/scripts/scylla_ntp_setup
+++ b/dist/common/scripts/scylla_ntp_setup
@@ -57,8 +57,7 @@ if __name__ == '__main__':
         # ignore error, ntpd may able to adjust clock later
         run('ntpdate ntp.ubuntu.com', shell=True)
         ntp.start()
-
-    if is_gentoo() or is_arch():
+    elif is_gentoo() or is_arch():
         if not shutil.which('ntpd'):
             pkg_install('ntp')
         with open('/etc/ntp.conf') as f:
@@ -70,8 +69,7 @@ if __name__ == '__main__':
         run('ntpdate {}'.format(server), shell=True, check=True)
         ntpd.enable()
         ntpd.start()
-
-    if is_redhat_variant():
+    elif is_redhat_variant():
         if int(distro.major_version()) >= 8:
             if not shutil.which('chronyd'):
                 yum_install('chrony')
@@ -104,3 +102,6 @@ if __name__ == '__main__':
             run('ntpdate {}'.format(server), shell=True)
             ntpd.enable()
             ntpd.start()
+    else:
+        print("Unsupported distribution, skipping setup..")
+        sys.exit(0)

--- a/dist/common/scripts/scylla_ntp_setup
+++ b/dist/common/scripts/scylla_ntp_setup
@@ -58,9 +58,9 @@ if __name__ == '__main__':
         run('ntpdate ntp.ubuntu.com', shell=True)
         ntp.start()
 
-    if is_gentoo_variant():
+    if is_gentoo_variant() or is_arch():
         if not shutil.which('ntpd'):
-            emerge_install('net-misc/ntp')
+            pkg_install('ntp')
         with open('/etc/ntp.conf') as f:
             conf = f.read()
         match = re.search(r'^server\s+(\S*)(\s+\S+)?', conf, flags=re.MULTILINE)

--- a/dist/common/scripts/scylla_ntp_setup
+++ b/dist/common/scripts/scylla_ntp_setup
@@ -102,6 +102,13 @@ if __name__ == '__main__':
             run('ntpdate {}'.format(server), shell=True)
             ntpd.enable()
             ntpd.start()
+    elif is_suse_variant() and int(distro.major_version()) >= 15:
+        if not shutil.which('chronyd'):
+            pkg_install('chrony')
+        chronyd = systemd_unit('chronyd.service')
+        chronyd.enable()
+        chronyd.restart()
+        run('chronyc makestep', shell=True, check=True)
     else:
         print("Unsupported distribution, skipping setup..")
         sys.exit(0)

--- a/dist/common/scripts/scylla_ntp_setup
+++ b/dist/common/scripts/scylla_ntp_setup
@@ -58,7 +58,7 @@ if __name__ == '__main__':
         run('ntpdate ntp.ubuntu.com', shell=True)
         ntp.start()
 
-    if is_gentoo_variant() or is_arch():
+    if is_gentoo() or is_arch():
         if not shutil.which('ntpd'):
             pkg_install('ntp')
         with open('/etc/ntp.conf') as f:

--- a/dist/common/scripts/scylla_prepare
+++ b/dist/common/scripts/scylla_prepare
@@ -104,10 +104,7 @@ if __name__ == '__main__':
     if os.getuid() > 0:
         print('Requires root permission.')
         sys.exit(1)
-    if is_redhat_variant():
-        cfg = sysconfig_parser('/etc/sysconfig/scylla-server')
-    else:
-        cfg = sysconfig_parser('/etc/default/scylla-server')
+    cfg = sysconfig_parser(sysconfdir_p() / 'scylla-server')
     ami = cfg.get('AMI')
     mode = cfg.get('NETWORK_MODE')
 

--- a/dist/common/scripts/scylla_raid_setup
+++ b/dist/common/scripts/scylla_raid_setup
@@ -104,8 +104,10 @@ if __name__ == '__main__':
         print('mount unit {} already exists'.format(mntunit))
         sys.exit(1)
 
-    if not shutil.which('mkfs.xfs') or not shutil.which('mdadm'):
-        pkg_install('xfsprogs mdadm')
+    if not shutil.which('mkfs.xfs'):
+        pkg_install('xfsprogs')
+    if not shutil.which('mdadm'):
+        pkg_install('mdadm')
     try:
         md_service = systemd_unit('mdmonitor.service')
     except SystemdException:

--- a/dist/common/scripts/scylla_raid_setup
+++ b/dist/common/scripts/scylla_raid_setup
@@ -114,30 +114,23 @@ if __name__ == '__main__':
         md_service = systemd_unit('mdadm.service')
 
     print('Creating {type} for scylla using {nr_disk} disk(s): {disks}'.format(type='RAID0' if raid else 'XFS volume', nr_disk=len(disks), disks=args.disks))
-    if distro.name() == 'Ubuntu' and distro.version() == '14.04':
-        if raid:
-            run('udevadm settle', shell=True, check=True)
-            run('mdadm --create --verbose --force --run {raid} --level=0 -c1024 --raid-devices={nr_disk} {disks}'.format(raid=fsdev, nr_disk=len(disks), disks=args.disks.replace(',', ' ')), shell=True, check=True)
-            run('udevadm settle', shell=True, check=True)
-        run('mkfs.xfs {} -f'.format(fsdev), shell=True, check=True)
-    else:
-        procs=[]
-        for disk in disks:
-            d = disk.replace('/dev/', '')
-            discard_path = '/sys/block/{}/queue/discard_granularity'.format(d)
-            if os.path.exists(discard_path):
-                with open(discard_path) as f:
-                    discard = f.read().strip()
-                if discard != '0':
-                    proc = subprocess.Popen(['blkdiscard', disk])
-                    procs.append(proc)
-        for proc in procs:
-            proc.wait()
-        if raid:
-            run('udevadm settle', shell=True, check=True)
-            run('mdadm --create --verbose --force --run {raid} --level=0 -c1024 --raid-devices={nr_disk} {disks}'.format(raid=fsdev, nr_disk=len(disks), disks=args.disks.replace(',', ' ')), shell=True, check=True)
-            run('udevadm settle', shell=True, check=True)
-        run('mkfs.xfs {} -f -K'.format(fsdev), shell=True, check=True)
+    procs=[]
+    for disk in disks:
+        d = disk.replace('/dev/', '')
+        discard_path = '/sys/block/{}/queue/discard_granularity'.format(d)
+        if os.path.exists(discard_path):
+            with open(discard_path) as f:
+                discard = f.read().strip()
+            if discard != '0':
+                proc = subprocess.Popen(['blkdiscard', disk])
+                procs.append(proc)
+    for proc in procs:
+        proc.wait()
+    if raid:
+        run('udevadm settle', shell=True, check=True)
+        run('mdadm --create --verbose --force --run {raid} --level=0 -c1024 --raid-devices={nr_disk} {disks}'.format(raid=fsdev, nr_disk=len(disks), disks=args.disks.replace(',', ' ')), shell=True, check=True)
+        run('udevadm settle', shell=True, check=True)
+    run('mkfs.xfs {} -f -K'.format(fsdev), shell=True, check=True)
 
     if is_debian_variant():
         confpath = '/etc/mdadm/mdadm.conf'

--- a/dist/common/scripts/scylla_selinux_setup
+++ b/dist/common/scripts/scylla_selinux_setup
@@ -31,7 +31,7 @@ if __name__ == '__main__':
         print('Requires root permission.')
         sys.exit(1)
 
-    if is_debian_variant() or is_gentoo_variant():
+    if not is_redhat_variant():
         print("scylla_selinux_setup only supports Red Hat variants")
         sys.exit(0)
 

--- a/dist/common/scripts/scylla_setup
+++ b/dist/common/scripts/scylla_setup
@@ -123,7 +123,7 @@ def do_verify_package(pkg):
         res = run('dpkg -s {}'.format(pkg), shell=True, stdout=DEVNULL, stderr=DEVNULL).returncode
     elif is_redhat_variant():
         res = run('rpm -q {}'.format(pkg), shell=True, stdout=DEVNULL, stderr=DEVNULL).returncode
-    elif is_gentoo_variant():
+    elif is_gentoo():
         res = 0 if len(glob.glob('/var/db/pkg/*/{}-*'.format(pkg))) else 1
     else:
         print("OS variant not recognized")

--- a/dist/common/scripts/scylla_stop
+++ b/dist/common/scripts/scylla_stop
@@ -29,11 +29,7 @@ if __name__ == '__main__':
     if os.getuid() > 0:
         print('Requires root permission.')
         sys.exit(1)
-    if is_redhat_variant():
-        cfg = sysconfig_parser('/etc/sysconfig/scylla-server')
-    else:
-        cfg = sysconfig_parser('/etc/default/scylla-server')
-
+    cfg = sysconfig_parser(sysconfdir_p() / 'scylla-server')
 
     if cfg.get('NETWORK_MODE') == 'virtio':
         run('ip tuntap del mode tap dev {TAP}'.format(TAP=cfg.get('TAP')), shell=True, check=True)

--- a/dist/common/scripts/scylla_sysconfdir.py
+++ b/dist/common/scripts/scylla_sysconfdir.py
@@ -1,0 +1,1 @@
+SYSCONFDIR="/etc/sysconfig"

--- a/dist/common/scripts/scylla_sysconfig_setup
+++ b/dist/common/scripts/scylla_sysconfig_setup
@@ -38,10 +38,7 @@ if __name__ == '__main__':
     if os.getuid() > 0:
         print('Requires root permission.')
         sys.exit(1)
-    if is_redhat_variant():
-        cfg = sysconfig_parser('/etc/sysconfig/scylla-server')
-    else:
-        cfg = sysconfig_parser('/etc/default/scylla-server')
+    cfg = sysconfig_parser(sysconfdir_p() / 'scylla-server')
     set_nic_and_disks = str2bool(get_set_nic_and_disks_config_value(cfg))
     if cfg.has_option('SET_CLOCKSOURCE'):
         set_clocksource = str2bool(cfg.get('SET_CLOCKSOURCE'))

--- a/dist/common/scripts/scylla_util.py
+++ b/dist/common/scripts/scylla_util.py
@@ -522,6 +522,8 @@ def is_redhat_variant():
 def is_gentoo_variant():
     return ('gentoo' in distro.id())
 
+def is_arch():
+    return ('arch' in distro.id())
 
 def get_text_from_path(fpath):
     board_vendor_path = Path(fpath)

--- a/dist/common/scripts/scylla_util.py
+++ b/dist/common/scripts/scylla_util.py
@@ -710,7 +710,20 @@ def emerge_install(pkg):
         pkg_error_exit(pkg)
     return run(f'emerge -uq {pkg}', shell=True, check=True)
 
+def pkg_distro():
+    if is_debian_variant():
+        return 'debian'
+    if is_suse_variant():
+        return 'suse'
+    elif is_amzn2():
+        return 'amzn2'
+    else:
+        return distro.id()
+
+pkg_xlat = {'cpupowerutils': {'debian': 'linux-cpupower', 'gentoo':'sys-power/cpupower', 'arch':'cpupower', 'suse': 'cpupower'}}
 def pkg_install(pkg):
+    if pkg in pkg_xlat and pkg_distro() in pkg_xlat[pkg]:
+        pkg = pkg_xlat[pkg][pkg_distro()]
     if is_redhat_variant():
         return yum_install(pkg)
     elif is_debian_variant():

--- a/dist/common/scripts/scylla_util.py
+++ b/dist/common/scripts/scylla_util.py
@@ -528,6 +528,10 @@ def is_arch():
 def is_amzn2():
     return ('amzn' in distro.id()) and ('2' in distro.version())
 
+def is_suse_variant():
+    d = get_id_like() if get_id_like() else distro.id()
+    return ('suse' in d)
+
 def get_text_from_path(fpath):
     board_vendor_path = Path(fpath)
     if board_vendor_path.exists():

--- a/dist/common/scripts/scylla_util.py
+++ b/dist/common/scripts/scylla_util.py
@@ -519,7 +519,7 @@ def is_redhat_variant():
     d = get_id_like() if get_id_like() else distro.id()
     return ('rhel' in d) or ('fedora' in d) or ('oracle') in d
 
-def is_gentoo_variant():
+def is_gentoo():
     return ('gentoo' in distro.id())
 
 def is_arch():
@@ -708,7 +708,7 @@ def pkg_install(pkg):
         return yum_install(pkg)
     elif is_debian_variant():
         return apt_install(pkg)
-    elif is_gentoo_variant():
+    elif is_gentoo():
         return emerge_install(pkg)
     else:
         pkg_error_exit(pkg)
@@ -729,7 +729,7 @@ def pkg_uninstall(pkg):
         return yum_uninstall(pkg)
     elif is_debian_variant():
         return apt_uninstall(pkg)
-    elif is_gentoo_variant():
+    elif is_gentoo():
         return emerge_uninstall(pkg)
     else:
         print(f'WARNING: Package "{pkg}" should be removed.')

--- a/dist/common/scripts/scylla_util.py
+++ b/dist/common/scripts/scylla_util.py
@@ -30,10 +30,11 @@ import urllib.request
 import yaml
 import psutil
 import sys
-from pathlib import Path
+from pathlib import Path, PurePath
 from subprocess import run, DEVNULL
 
 import distro
+from scylla_sysconfdir import SYSCONFDIR
 
 
 def scriptsdir_p():
@@ -73,6 +74,9 @@ def datadir_p():
 def scyllabindir_p():
     return scylladir_p() / 'bin'
 
+def sysconfdir_p():
+    return Path(SYSCONFDIR)
+
 def scriptsdir():
     return str(scriptsdir_p())
 
@@ -91,6 +95,8 @@ def datadir():
 def scyllabindir():
     return str(scyllabindir_p())
 
+def sysconfdir():
+    return str(sysconfdir_p())
 
 # @param headers dict of k:v
 def curl(url, headers=None, byte=False, timeout=3, max_retries=5, retry_interval=5):
@@ -788,7 +794,10 @@ class sysconfig_parser:
         self.__load()
 
     def __init__(self, filename):
-        self._filename = filename
+        if isinstance(filename, PurePath):
+            self._filename = str(filename)
+        else:
+            self._filename = filename
         if not os.path.exists(filename):
             open(filename, 'a').close()
         with open(filename) as f:

--- a/dist/common/scripts/scylla_util.py
+++ b/dist/common/scripts/scylla_util.py
@@ -525,6 +525,9 @@ def is_gentoo():
 def is_arch():
     return ('arch' in distro.id())
 
+def is_amzn2():
+    return ('amzn' in distro.id()) and ('2' in distro.version())
+
 def get_text_from_path(fpath):
     board_vendor_path = Path(fpath)
     if board_vendor_path.exists():

--- a/install.sh
+++ b/install.sh
@@ -459,7 +459,8 @@ elif ! $packaging; then
 
     for file in dist/common/sysctl.d/*.conf; do
         bn=$(basename "$file")
-        sysctl -p "$rusr"/lib/sysctl.d/"$bn"
+        # ignore error since some kernel may not have specified parameter
+        sysctl -p "$rusr"/lib/sysctl.d/"$bn" || :
     done
     $rprefix/scripts/scylla_post_install.sh
     echo "Scylla offline install completed."

--- a/install.sh
+++ b/install.sh
@@ -272,6 +272,7 @@ EOS
 fi
 
 # scylla-server
+install -m755 -d "$rprefix"
 install -m755 -d "$rsysconfdir"
 install -m755 -d "$retc/scylla.d"
 installconfig 644 dist/common/sysconfig/scylla-housekeeping "$rsysconfdir"
@@ -340,6 +341,9 @@ EnvironmentFile=
 EnvironmentFile=$sysconfdir/scylla-housekeeping
 EOS
     done
+        cat << EOS > "$rprefix"/scripts/scylla_sysconfdir.py
+SYSCONFDIR="$sysconfdir"
+EOS
     fi
     install -m755 -d "$retc/security/limits.d"
     install -m755 -d "$rusr/bin"
@@ -397,6 +401,9 @@ StandardOutput=
 StandardOutput=file:$rprefix/scylla-server.log
 StandardError=
 StandardError=inherit
+EOS
+        cat << EOS > "$rprefix"/scripts/scylla_sysconfdir.py
+SYSCONFDIR="$sysconfdir"
 EOS
     fi
 

--- a/install.sh
+++ b/install.sh
@@ -174,6 +174,11 @@ check_usermode_support() {
     [ -n "$user" ]
 }
 
+if ! $packaging && [ ! -d /run/systemd/system/ ]; then
+    echo "systemd is not detected, unsupported distribution."
+    exit 1
+fi
+
 # change directory to the package's root directory
 cd "$(dirname "$0")"
 

--- a/unified/install.sh
+++ b/unified/install.sh
@@ -83,6 +83,11 @@ while [ $# -gt 0 ]; do
     esac
 done
 
+if [ ! -d /run/systemd/system/ ]; then
+    echo "systemd is not detected, unsupported distribution."
+    exit 1
+fi
+
 has_java=false
 if [ -x /usr/bin/java ]; then
     javaver=$(/usr/bin/java -version 2>&1|head -n1|cut -f 3 -d " ")


### PR DESCRIPTION
Since we introduced relocatable package and offline installer, scylla binary itself can run almost any distributions.
However, setup scripts are not designed to run in unsupported distributions, it causes error on such environment.
This PR adds minimal support to run offline installation on unsupported distributions, tested on SLES, Arch Linux and Gentoo.