### PR TITLE
redis: implement parse error, reply error message correctly

### DIFF
--- a/redis/protocol_parser.rl
+++ b/redis/protocol_parser.rl
@@ -134,6 +134,10 @@ public:
         return _req._state == request_state::eof;
     }
     
+    bool failed() const {
+        return _req._state == request_state::error;
+    }
+
     redis::request& get_request() { 
         std::transform(_req._command.begin(), _req._command.end(), _req._command.begin(), ::tolower);
         return _req;


### PR DESCRIPTION
Since we haven't implemented parse error on redis protocol parser,
reply message is broken at parse error.
Implemented parse error, reply error message correctly.

Fixed #7861