### PR TITLE
column_family: Make toppartitions queries more generic

### DIFF
--- a/api/api-doc/storage_service.json
+++ b/api/api-doc/storage_service.json
@@ -105,6 +105,68 @@
          ]
       },
       {
+         "path":"/storage_service/toppartitions/",
+         "operations":[
+            {
+               "method":"GET",
+               "summary":"Toppartitions query",
+               "type":"toppartitions_query_results",
+               "nickname":"toppartitions_generic",
+               "produces":[
+                  "application/json"
+               ],
+               "parameters":[
+                  {
+                     "name":"table_filters",
+                     "description":"Optional list of table name filters in keyspace:name format",
+                     "required":false,
+                     "allowMultiple":false,
+                     "type":"array",
+                     "items":{
+                        "type":"string"
+                     },
+                     "paramType":"query"
+                  },
+                  {
+                     "name":"keyspace_filters",
+                     "description":"Optional list of keyspace filters",
+                     "required":false,
+                     "allowMultiple":false,
+                     "type":"array",
+                     "items":{
+                        "type":"string"
+                     },
+                     "paramType":"query"
+                  },
+                  {
+                     "name":"duration",
+                     "description":"Duration (in milliseconds) of monitoring operation",
+                     "required":true,
+                     "allowMultiple":false,
+                     "type": "long",
+                     "paramType":"query"
+                  },
+                  {
+                    "name":"list_size",
+                    "description":"number of the top partitions to list",
+                    "required":false,
+                    "allowMultiple":false,
+                    "type": "long",
+                    "paramType":"query"
+                 },
+                 {
+                    "name":"capacity",
+                    "description":"capacity of stream summary: determines amount of resources used in query processing",
+                    "required":false,
+                    "allowMultiple":false,
+                    "type": "long",
+                    "paramType":"query"
+                 }
+              ]
+            }
+         ]
+      },
+      {
          "path":"/storage_service/nodes/leaving",
          "operations":[
             {

--- a/api/column_family.cc
+++ b/api/column_family.cc
@@ -28,6 +28,7 @@
 #include <algorithm>
 #include "db/system_keyspace_view_types.hh"
 #include "db/data_listeners.hh"
+#include "storage_service.hh"
 
 extern logging::logger apilog;
 
@@ -973,45 +974,20 @@ void set_column_family(http_context& ctx, routes& r) {
         });
     });
 
+
     cf::toppartitions.set(r, [&ctx] (std::unique_ptr<request> req) {
-        auto name_param = req->param["name"];
-        auto [ks, cf] = parse_fully_qualified_cf_name(name_param);
+        auto name = req->param["name"];
+        auto [ks, cf] = parse_fully_qualified_cf_name(name);
 
         api::req_param<std::chrono::milliseconds, unsigned> duration{*req, "duration", 1000ms};
         api::req_param<unsigned> capacity(*req, "capacity", 256);
         api::req_param<unsigned> list_size(*req, "list_size", 10);
 
         apilog.info("toppartitions query: name={} duration={} list_size={} capacity={}",
-            name_param, duration.param, list_size.param, capacity.param);
+            name, duration.param, list_size.param, capacity.param);
 
-        return seastar::do_with(db::toppartitions_query(ctx.db, ks, cf, duration.value, list_size, capacity), [&ctx](auto& q) {
-            return q.scatter().then([&q] {
-                return sleep(q.duration()).then([&q] {
-                    return q.gather(q.capacity()).then([&q] (auto topk_results) {
-                        apilog.debug("toppartitions query: processing results");
-                        cf::toppartitions_query_results results;
-
-                        results.read_cardinality = topk_results.read.size();
-                        results.write_cardinality = topk_results.write.size();
-
-                        for (auto& d: topk_results.read.top(q.list_size())) {
-                            cf::toppartitions_record r;
-                            r.partition = sstring(d.item);
-                            r.count = d.count;
-                            r.error = d.error;
-                            results.read.push(r);
-                        }
-                        for (auto& d: topk_results.write.top(q.list_size())) {
-                            cf::toppartitions_record r;
-                            r.partition = sstring(d.item);
-                            r.count = d.count;
-                            r.error = d.error;
-                            results.write.push(r);
-                        }
-                        return make_ready_future<json::json_return_type>(results);
-                    });
-                });
-            });
+        return seastar::do_with(db::toppartitions_query(ctx.db, {{ks, cf}}, {}, duration.value, list_size, capacity), [&ctx] (db::toppartitions_query& q) {
+            return run_toppartitions_query(q, ctx, true);
         });
     });
 

--- a/api/column_family.hh
+++ b/api/column_family.hh
@@ -116,4 +116,7 @@ future<json::json_return_type>  get_cf_stats(http_context& ctx, const sstring& n
 future<json::json_return_type>  get_cf_stats(http_context& ctx,
         int64_t column_family_stats::*f);
 
+
+std::tuple<sstring, sstring> parse_fully_qualified_cf_name(sstring name);
+
 }

--- a/api/storage_service.hh
+++ b/api/storage_service.hh
@@ -23,6 +23,7 @@
 
 #include <seastar/core/sharded.hh>
 #include "api.hh"
+#include "db/data_listeners.hh"
 
 namespace cql_transport { class controller; }
 class thrift_controller;
@@ -40,5 +41,6 @@ void set_rpc_controller(http_context& ctx, routes& r, thrift_controller& ctl);
 void unset_rpc_controller(http_context& ctx, routes& r);
 void set_snapshot(http_context& ctx, routes& r, sharded<db::snapshot_ctl>& snap_ctl);
 void unset_snapshot(http_context& ctx, routes& r);
+seastar::future<json::json_return_type> run_toppartitions_query(db::toppartitions_query& q, http_context &ctx, bool legacy_request = false);
 
 }

--- a/test/boost/database_test.cc
+++ b/test/boost/database_test.cc
@@ -458,7 +458,7 @@ SEASTAR_TEST_CASE(clear_nonexistent_snapshot) {
 SEASTAR_TEST_CASE(toppartitions_cross_shard_schema_ptr) {
     return do_with_cql_env_thread([] (cql_test_env& e) {
         e.execute_cql("CREATE TABLE ks.tab (id int PRIMARY KEY)").get();
-        db::toppartitions_query tq(e.db(), "ks", "tab", 1s, 100, 100);
+        db::toppartitions_query tq(e.db(), {{"ks", "tab"}}, {}, 1s, 100, 100);
         tq.scatter().get();
         auto q = e.prepare("INSERT INTO ks.tab(id) VALUES(?)").get0();
         // Generate many values to ensure crossing shards


### PR DESCRIPTION
Right now toppartitions can only be invoked on one column family at a time.
This change introduces a natural extension to this functionality,
allowing to specify a list of families.

We provide three ways for filtering in the query parameter "name_list":
      1. A specific column family to include in the form "ks:cf"
      2. A keyspace, telling the server to include all column families in it.
          Specified by omitting the cf name, i.e. "ks:"
      3. All column families, which is represented by an empty list
The list can include any amount of one or both of the 1. and 2. option.

Fixes #4520