### PR TITLE
scylla: Add "--build-mode" command line option

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -533,7 +533,12 @@ defines = ['XXH_PRIVATE_API',
            'SEASTAR_TESTING_MAIN',
 ]
 
-extra_cxxflags = {}
+extra_cxxflags = {
+    'debug': {},
+    'dev': {},
+    'release': {},
+    'sanitize': {}
+}
 
 scylla_core = (['database.cc',
                 'absl-flat_hash_map.cc',
@@ -1289,7 +1294,9 @@ scylla_release = file.read().strip()
 file = open(f'{outdir}/SCYLLA-PRODUCT-FILE', 'r')
 scylla_product = file.read().strip()
 
-extra_cxxflags["release.cc"] = "-DSCYLLA_VERSION=\"\\\"" + scylla_version + "\\\"\" -DSCYLLA_RELEASE=\"\\\"" + scylla_release + "\\\"\""
+for m in ['debug', 'release', 'sanitize', 'dev']:
+    cxxflags = "-DSCYLLA_VERSION=\"\\\"" + scylla_version + "\\\"\" -DSCYLLA_RELEASE=\"\\\"" + scylla_release + "\\\"\" -DSCYLLA_BUILD_MODE=\"\\\"" + m + "\\\"\""
+    extra_cxxflags[m]["release.cc"] = cxxflags
 
 for m in ['debug', 'release', 'sanitize']:
     modes[m]['cxxflags'] += ' ' + dbgflag
@@ -1746,8 +1753,8 @@ with open(buildfile_tmp, 'w') as f:
         for obj in compiles:
             src = compiles[obj]
             f.write('build {}: cxx.{} {} || {} {}\n'.format(obj, mode, src, seastar_dep, gen_headers_dep))
-            if src in extra_cxxflags:
-                f.write('    cxxflags = {seastar_cflags} $cxxflags $cxxflags_{mode} {extra_cxxflags}\n'.format(mode=mode, extra_cxxflags=extra_cxxflags[src], **modeval))
+            if src in extra_cxxflags[mode]:
+                f.write('    cxxflags = {seastar_cflags} $cxxflags $cxxflags_{mode} {extra_cxxflags}\n'.format(mode=mode, extra_cxxflags=extra_cxxflags[mode][src], **modeval))
         for swagger in swaggers:
             hh = swagger.headers(gen_dir)[0]
             cc = swagger.sources(gen_dir)[0]

--- a/main.cc
+++ b/main.cc
@@ -433,6 +433,7 @@ int main(int ac, char** av) {
 
     init("version", bpo::bool_switch(), "print version number and exit");
     init("build-id", bpo::bool_switch(), "print build-id and exit");
+    init("build-mode", bpo::bool_switch(), "print build mode and exit");
 
     bpo::options_description deprecated("Deprecated options - ignored");
     deprecated.add_options()
@@ -455,9 +456,12 @@ int main(int ac, char** av) {
         fmt::print("{}\n", scylla_version());
         return 0;
     }
-
     if (vm["build-id"].as<bool>()) {
         fmt::print("{}\n", get_build_id());
+        return 0;
+    }
+    if (vm["build-mode"].as<bool>()) {
+        fmt::print("{}\n", scylla_build_mode());
         return 0;
     }
 

--- a/release.cc
+++ b/release.cc
@@ -25,10 +25,20 @@
 
 static const char scylla_version_str[] = SCYLLA_VERSION;
 static const char scylla_release_str[] = SCYLLA_RELEASE;
+static const char scylla_build_mode_str[] = SCYLLA_BUILD_MODE;
 
 std::string scylla_version()
 {
-    return format("{}-{}", scylla_version_str, scylla_release_str);
+    if (std::string{scylla_build_mode_str} == std::string{"release"}) {
+        return format("{}-{}", scylla_version_str, scylla_release_str);
+    } else {
+       return format("{}-{} ({})", scylla_version_str, scylla_release_str, scylla_build_mode_str);
+    }
+}
+
+std::string scylla_build_mode()
+{
+    return format("{}", scylla_build_mode_str);
 }
 
 // get the version number into writeable memory, so we can grep for it if we get a core dump

--- a/release.hh
+++ b/release.hh
@@ -24,3 +24,5 @@
 #include <string>
 
 std::string scylla_version();
+
+std::string scylla_build_mode();


### PR DESCRIPTION
This adds a "--build-mode" command line option to "scylla" executable:

$ ./build/dev/scylla --build-mode
dev

This allows you to discover the build mode of a "scylla" executable
without resorting to "readelf", for example, to verify that you are
looking at the correct executable while debugging packaging issues.