### PR TITLE
cql3: Fix unset values in collection operations

### DIFF
--- a/cql3/constants.hh
+++ b/cql3/constants.hh
@@ -192,8 +192,11 @@ public:
 
         virtual ::shared_ptr<terminal> bind(const query_options& options) override {
             auto bytes = bind_and_get(options);
-            if (!bytes) {
+            if (bytes.is_null()) {
                 return ::shared_ptr<terminal>{};
+            }
+            if (bytes.is_unset_value()) {
+                return UNSET_VALUE;
             }
             return ::make_shared<constants::value>(std::move(cql3::raw_value::make_value(to_bytes(*bytes))));
         }

--- a/cql3/expr/expression.cc
+++ b/cql3/expr/expression.cc
@@ -27,6 +27,7 @@
 #include <fmt/ostream.h>
 #include <unordered_map>
 
+#include "cql3/constants.hh"
 #include "cql3/lists.hh"
 #include "cql3/tuples.hh"
 #include "index/secondary_index_manager.hh"
@@ -564,7 +565,8 @@ const auto deref = boost::adaptors::transformed([] (const bytes_opt& b) { return
 
 /// Returns possible values from t, which must be RHS of IN.
 value_list get_IN_values(
-        const ::shared_ptr<term>& t, const query_options& options, const serialized_compare& comparator) {
+        const ::shared_ptr<term>& t, const query_options& options, const serialized_compare& comparator,
+        sstring_view column_name) {
     // RHS is prepared differently for different CQL cases.  Cast it dynamically to discern which case this is.
     if (auto dv = dynamic_pointer_cast<lists::delayed_value>(t)) {
         // Case `a IN (1,2,3)`.
@@ -574,8 +576,11 @@ value_list get_IN_values(
         return to_sorted_vector(std::move(result_range), comparator);
     } else if (auto mkr = dynamic_pointer_cast<lists::marker>(t)) {
         // Case `a IN ?`.  Collect all list-element values.
-        const auto val = static_pointer_cast<lists::value>(mkr->bind(options));
-        return to_sorted_vector(val->get_elements() | non_null | deref, comparator);
+        const auto val = mkr->bind(options);
+        if (val == constants::UNSET_VALUE) {
+            throw exceptions::invalid_request_exception(format("Invalid unset value for column {}", column_name));
+        }
+        return to_sorted_vector(static_pointer_cast<lists::value>(val)->get_elements() | non_null | deref, comparator);
     }
     throw std::logic_error(format("get_IN_values(single column) on invalid term {}", *t));
 }
@@ -682,7 +687,7 @@ value_set possible_lhs_values(const column_definition* cdef, const expression& e
                                 return oper.op == oper_t::EQ ? value_set(value_list{*val})
                                         : to_range(oper.op, *val);
                             } else if (oper.op == oper_t::IN) {
-                                return get_IN_values(oper.rhs, options, type->as_less_comparator());
+                                return get_IN_values(oper.rhs, options, type->as_less_comparator(), cdef->name_as_text());
                             }
                             throw std::logic_error(format("possible_lhs_values: unhandled operator {}", oper));
                         },

--- a/cql3/maps.cc
+++ b/cql3/maps.cc
@@ -301,6 +301,12 @@ maps::setter_by_key::execute(mutation& m, const clustering_key_prefix& prefix, c
     assert(column.type->is_multi_cell()); // "Attempted to set a value for a single key on a frozen map"m
     auto key = _k->bind_and_get(params._options);
     auto value = _t->bind_and_get(params._options);
+    if (value.is_unset_value()) {
+        return;
+    }
+    if (key.is_unset_value() || value.is_unset_value()) {
+        throw invalid_request_exception("Invalid unset map key");
+    }
     if (!key) {
         throw invalid_request_exception("Invalid null map key");
     }

--- a/cql3/sets.cc
+++ b/cql3/sets.cc
@@ -311,7 +311,7 @@ sets::discarder::execute(mutation& m, const clustering_key_prefix& row_key, cons
     assert(column.type->is_multi_cell()); // "Attempted to remove items from a frozen set";
 
     auto&& value = _t->bind(params._options);
-    if (!value) {
+    if (!value || value == constants::UNSET_VALUE) {
         return;
     }
 

--- a/test/cql-pytest/cassandra_tests/validation/entities/collections_test.py
+++ b/test/cql-pytest/cassandra_tests/validation/entities/collections_test.py
@@ -326,10 +326,6 @@ def testListWithUnsetValues(cql, test_keyspace):
         # captures this case before sending it to the server.
         #assert_invalid_message(cql, table, "Invalid unset value for column k", "SELECT * FROM %s WHERE k IN (?)", UNSET_VALUE)
 
-# Note: I have to use skip instead of xfail here because this test, not only
-# fails, it crashes: the last command UPDATE %s SET s = s - ? WHERE k = 10",
-# bound with UNSET_VALUE, crashes with an assertion failure. See #7740.
-@pytest.mark.skip(reason="Cassandra 2.2.0's 'unset' values not yet supported. Issue #7740")
 def testSetWithUnsetValues(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(k int PRIMARY KEY, s set<text>)") as table:
         s = {"bar", "baz", "foo"}

--- a/test/cql-pytest/cassandra_tests/validation/entities/collections_test.py
+++ b/test/cql-pytest/cassandra_tests/validation/entities/collections_test.py
@@ -274,7 +274,6 @@ def testLists(cql, test_keyspace):
         execute(cql, table, "UPDATE %s SET l = l - ? WHERE k=0", ["v1", "v2"])
         assert_rows(execute(cql, table, "SELECT l FROM %s WHERE k = 0"), [None]);
 
-@pytest.mark.xfail(reason="Cassandra 2.2.0's 'unset' values not yet supported. Issue #7740")
 def testMapWithUnsetValues(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(k int PRIMARY KEY, m map<text, text>)") as table:
         # set up
@@ -285,7 +284,7 @@ def testMapWithUnsetValues(cql, test_keyspace):
         # test putting an unset map, should not delete the contents
         execute(cql, table, "INSERT INTO %s (k, m) VALUES (10, ?)", UNSET_VALUE)
         assert_rows(execute(cql, table, "SELECT m FROM %s WHERE k = 10"), [m])
-        # test unset variables in a map update operaiotn, should not delete the contents
+        # test unset variables in a map update operation, should not delete the contents
         execute(cql, table, "UPDATE %s SET m['k'] = ? WHERE k = 10", UNSET_VALUE)
         assert_rows(execute(cql, table, "SELECT m FROM %s WHERE k = 10"), [m])
         assert_invalid_message(cql, table, "Invalid unset map key", "UPDATE %s SET m[?] = 'foo' WHERE k = 10", UNSET_VALUE)

--- a/test/cql-pytest/cassandra_tests/validation/entities/collections_test.py
+++ b/test/cql-pytest/cassandra_tests/validation/entities/collections_test.py
@@ -293,7 +293,6 @@ def testMapWithUnsetValues(cql, test_keyspace):
         # test unset value for map key
         assert_invalid_message(cql, table, "Invalid unset map key", "DELETE m[?] FROM %s WHERE k = 10", UNSET_VALUE)
 
-@pytest.mark.xfail(reason="Cassandra 2.2.0's 'unset' values not yet supported. Issue #7740")
 def testListWithUnsetValues(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(k int PRIMARY KEY, l list<text>)") as table:
         # set up


### PR DESCRIPTION
Fix handling of unset values so ported Cassandra tests can pass.

Fixes #7740.

Tests: unit (dev)

Signed-off-by: Dejan Mircevski <dejan@scylladb.com>