### PR TITLE
cql3: Fix reverse-order collections

### DIFF
--- a/cql3/abstract_marker.cc
+++ b/cql3/abstract_marker.cc
@@ -74,7 +74,7 @@ abstract_marker::raw::raw(int32_t bind_index)
             return ::make_shared<lists::marker>(_bind_index, receiver);
         } else if (receiver->type->self_or_reversed(&abstract_type::is_set)) {
             return ::make_shared<sets::marker>(_bind_index, receiver);
-        } else if (receiver->type->get_kind() == abstract_type::kind::map) {
+        } else if (receiver->type->self_or_reversed(&abstract_type::is_map)) {
             return ::make_shared<maps::marker>(_bind_index, receiver);
         }
         assert(0);

--- a/cql3/abstract_marker.cc
+++ b/cql3/abstract_marker.cc
@@ -72,7 +72,7 @@ abstract_marker::raw::raw(int32_t bind_index)
     if (receiver->type->is_collection()) {
         if (receiver->type->get_kind() == abstract_type::kind::list) {
             return ::make_shared<lists::marker>(_bind_index, receiver);
-        } else if (receiver->type->get_kind() == abstract_type::kind::set) {
+        } else if (receiver->type->self_or_reversed(&abstract_type::is_set)) {
             return ::make_shared<sets::marker>(_bind_index, receiver);
         } else if (receiver->type->get_kind() == abstract_type::kind::map) {
             return ::make_shared<maps::marker>(_bind_index, receiver);

--- a/cql3/abstract_marker.cc
+++ b/cql3/abstract_marker.cc
@@ -70,7 +70,7 @@ abstract_marker::raw::raw(int32_t bind_index)
 ::shared_ptr<term> abstract_marker::raw::prepare(database& db, const sstring& keyspace, lw_shared_ptr<column_specification> receiver) const
 {
     if (receiver->type->is_collection()) {
-        if (receiver->type->get_kind() == abstract_type::kind::list) {
+        if (receiver->type->self_or_reversed(&abstract_type::is_list)) {
             return ::make_shared<lists::marker>(_bind_index, receiver);
         } else if (receiver->type->self_or_reversed(&abstract_type::is_set)) {
             return ::make_shared<sets::marker>(_bind_index, receiver);

--- a/cql3/maps.cc
+++ b/cql3/maps.cc
@@ -55,14 +55,14 @@ lw_shared_ptr<column_specification>
 maps::key_spec_of(const column_specification& column) {
     return make_lw_shared<column_specification>(column.ks_name, column.cf_name,
                 ::make_shared<column_identifier>(format("key({})", *column.name), true),
-                 dynamic_pointer_cast<const map_type_impl>(column.type)->get_keys_type());
+                 column.type->as<map_type_impl>().get_keys_type());
 }
 
 lw_shared_ptr<column_specification>
 maps::value_spec_of(const column_specification& column) {
     return make_lw_shared<column_specification>(column.ks_name, column.cf_name,
                 ::make_shared<column_identifier>(format("value({})", *column.name), true),
-                 dynamic_pointer_cast<const map_type_impl>(column.type)->get_values_type());
+                 column.type->as<map_type_impl>().get_values_type());
 }
 
 ::shared_ptr<term>
@@ -88,7 +88,7 @@ maps::literal::prepare(database& db, const sstring& keyspace, lw_shared_ptr<colu
 
         values.emplace(k, v);
     }
-    delayed_value value(static_pointer_cast<const map_type_impl>(receiver->type)->get_keys_type()->as_less_comparator(), values);
+    delayed_value value(receiver->type->as<map_type_impl>().get_keys_type()->as_less_comparator(), values);
     if (all_terminal) {
         return value.bind(query_options::DEFAULT);
     } else {
@@ -98,7 +98,7 @@ maps::literal::prepare(database& db, const sstring& keyspace, lw_shared_ptr<colu
 
 void
 maps::literal::validate_assignable_to(database& db, const sstring& keyspace, const column_specification& receiver) const {
-    if (!dynamic_pointer_cast<const map_type_impl>(receiver.type)) {
+    if (!receiver.type->self_or_reversed(&abstract_type::is_map)) {
         throw exceptions::invalid_request_exception(format("Invalid map literal for {} of type {}", *receiver.name, receiver.type->as_cql3_type()));
     }
     auto&& key_spec = maps::key_spec_of(receiver);
@@ -266,7 +266,8 @@ maps::marker::bind(const query_options& options) {
         throw exceptions::invalid_request_exception(
                 format("Exception while binding column {:s}: {:s}", _receiver->name->to_cql_string(), e.what()));
     }
-    return ::make_shared<maps::value>(maps::value::from_serialized(*val, static_cast<const map_type_impl&>(*_receiver->type), options.get_cql_serialization_format()));
+    return ::make_shared<maps::value>(
+            maps::value::from_serialized(*val, _receiver->type->as<map_type_impl>(), options.get_cql_serialization_format()));
 }
 
 void

--- a/cql3/sets.cc
+++ b/cql3/sets.cc
@@ -31,7 +31,7 @@ lw_shared_ptr<column_specification>
 sets::value_spec_of(const column_specification& column) {
     return make_lw_shared<column_specification>(column.ks_name, column.cf_name,
             ::make_shared<column_identifier>(format("value({})", *column.name), true),
-            dynamic_pointer_cast<const set_type_impl>(column.type)->get_elements_type());
+            column.type->as<set_type_impl>().get_elements_type());
 }
 
 shared_ptr<term>
@@ -74,7 +74,7 @@ sets::literal::prepare(database& db, const sstring& keyspace, lw_shared_ptr<colu
 
         values.push_back(std::move(t));
     }
-    auto compare = dynamic_pointer_cast<const set_type_impl>(receiver->type)->get_elements_type()->as_less_comparator();
+    auto compare = receiver->type->as<set_type_impl>().get_elements_type()->as_less_comparator();
 
     auto value = ::make_shared<delayed_value>(compare, std::move(values));
     if (all_terminal) {
@@ -86,7 +86,7 @@ sets::literal::prepare(database& db, const sstring& keyspace, lw_shared_ptr<colu
 
 void
 sets::literal::validate_assignable_to(database& db, const sstring& keyspace, const column_specification& receiver) const {
-    if (!dynamic_pointer_cast<const set_type_impl>(receiver.type)) {
+    if (!receiver.type->self_or_reversed(&abstract_type::is_set)) {
         // We've parsed empty maps as a set literal to break the ambiguity so
         // handle that case now
         if (dynamic_pointer_cast<const map_type_impl>(receiver.type) && _elements.empty()) {
@@ -106,7 +106,7 @@ sets::literal::validate_assignable_to(database& db, const sstring& keyspace, con
 
 assignment_testable::test_result
 sets::literal::test_assignment(database& db, const sstring& keyspace, const column_specification& receiver) const {
-    if (!dynamic_pointer_cast<const set_type_impl>(receiver.type)) {
+    if (!receiver.type->self_or_reversed(&abstract_type::is_set)) {
         // We've parsed empty maps as a set literal to break the ambiguity so handle that case now
         if (dynamic_pointer_cast<const map_type_impl>(receiver.type) && _elements.empty()) {
             return assignment_testable::test_result::WEAKLY_ASSIGNABLE;
@@ -224,7 +224,7 @@ sets::delayed_value::bind(const query_options& options) {
 
 sets::marker::marker(int32_t bind_index, lw_shared_ptr<column_specification> receiver)
     : abstract_marker{bind_index, std::move(receiver)} {
-        assert(dynamic_cast<const set_type_impl*>(_receiver->type.get()));
+        assert(_receiver->type->self_or_reversed(&abstract_type::is_set));
     }
 
 ::shared_ptr<terminal>
@@ -235,7 +235,7 @@ sets::marker::bind(const query_options& options) {
     } else if (value.is_unset_value()) {
         return constants::UNSET_VALUE;
     } else {
-        auto& type = static_cast<const set_type_impl&>(*_receiver->type);
+        auto& type = _receiver->type->as<set_type_impl>();
         try {
             type.validate(*value, options.get_cql_serialization_format());
         } catch (marshal_exception& e) {
@@ -280,8 +280,7 @@ void
 sets::adder::do_add(mutation& m, const clustering_key_prefix& row_key, const update_parameters& params,
         shared_ptr<term> value, const column_definition& column) {
     auto set_value = dynamic_pointer_cast<sets::value>(std::move(value));
-    auto set_type = dynamic_cast<const set_type_impl*>(column.type.get());
-    assert(set_type);
+    auto& set_type = column.type->as<set_type_impl>();
     if (column.type->is_multi_cell()) {
         if (!set_value || set_value->_elements.empty()) {
             return;
@@ -291,10 +290,10 @@ sets::adder::do_add(mutation& m, const clustering_key_prefix& row_key, const upd
         collection_mutation_description mut;
 
         for (auto&& e : set_value->_elements) {
-            mut.cells.emplace_back(e, params.make_cell(*set_type->value_comparator(), bytes_view(), atomic_cell::collection_member::yes));
+            mut.cells.emplace_back(e, params.make_cell(*set_type.value_comparator(), bytes_view(), atomic_cell::collection_member::yes));
         }
 
-        m.set_cell(row_key, column, mut.serialize(*set_type));
+        m.set_cell(row_key, column, mut.serialize(set_type));
     } else if (set_value != nullptr) {
         // for frozen sets, we're overwriting the whole cell
         auto v = set_type_impl::serialize_partially_deserialized_form(

--- a/types.hh
+++ b/types.hh
@@ -610,6 +610,21 @@ public:
     cql3::cql3_type as_cql3_type() const;
     const sstring& cql3_type_name() const;
     virtual shared_ptr<const abstract_type> freeze() const { return shared_from_this(); }
+
+    bool self_or_reversed(bool (abstract_type::*method)() const) const{
+        return (this->*method)() || (is_reversed() && (*underlying_type().*method)());
+    }
+
+    /// Casts *this (or underlying type, if this is reversed) to T.  Throws bad_cast if it cannot.
+    template<typename T> const T& as() const {
+        if (auto cast = dynamic_cast<const T*>(this)) {
+            return *cast;
+        }
+        if (is_reversed()) {
+            return underlying_type()->as<T>();
+        }
+        throw std::bad_cast();
+    }
     friend class list_type_impl;
 private:
     mutable sstring _cql3_type_name;


### PR DESCRIPTION
When a clustering order is reversed, the corresponding column type is set to reversed_type_impl.  This was not properly handled by collections code, which assumed the type is a regular collection implementation.  Fixed by getting the underlying type when appropriate.

Fixes #7868
Fixes #7875

Tests: unit (dev)