### PR TITLE
docs: update url

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,8 +78,8 @@ and the current compatibility of this feature as well as Scylla-specific extensi
 
 ## Documentation
 
-Documentation can be found [here](http://scylladb.github.io/scylla).
-Seastar documentation can be found [here](http://docs.seastar.io/master/index.html.
+Documentation can be found [here](https://scylla.docs.scylladb.com).
+Seastar documentation can be found [here](http://docs.seastar.io/master/index.html).
 User documentation can be found [here](https://docs.scylladb.com/).
 
 ## Training 

--- a/docs/_utils/deploy.sh
+++ b/docs/_utils/deploy.sh
@@ -2,12 +2,11 @@
 
 # Copy contents
 mkdir gh-pages
-cp -r ./docs/_build/dirhtml/* gh-pages
+cp -r ./docs/_build/dirhtml/. gh-pages
 ./docs/_utils/redirect.sh > gh-pages/index.html
 
 # Create gh-pages branch
 cd gh-pages
-touch .nojekyll
 git init
 git config --local user.email "action@scylladb.com"
 git config --local user.name "GitHub Action"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -110,7 +110,7 @@ html_style = ''
 #
 html_theme_options = {
     'header_links': [
-    ('Scylla Developer Notes', 'https://scylladb.github.io/scylla'),
+    ('Scylla Developer Notes', 'https://scylla.docs.scylladb.com'),
     ('Scylla University', 'https://university.scylladb.com/'),
     ('ScyllaDB Home', 'https://www.scylladb.com/')],
     'github_issues_repository': 'scylladb/scylla',
@@ -133,7 +133,7 @@ html_sidebars = {'**': ['side-nav.html']}
 htmlhelp_basename = 'ScyllaDocumentationdoc'
 
 # URL which points to the root of the HTML documentation. 
-html_baseurl = 'https://scylladb.github.io/scylla'
+html_baseurl = 'https://scylla.docs.scylladb.com'
 
 # Dictionary of values to pass into the template engine’s context for all pages
 html_context = {'html_baseurl': html_baseurl}


### PR DESCRIPTION
Related issue https://github.com/scylladb/sphinx-scylladb-theme/issues/88

Once this commit is merged, the docs will be published under the new domain name https://scylla.docs.scylladb.com

## Frequently asked questions

> Should we change the links in the README/docs folder?

GitHub automatically handles the redirections. For example, https://scylladb.github.io/sphinx-scylladb-theme/stable/examples/index.html redirects to https://sphinx-theme.scylladb.com/stable/examples/index.html
Nevertheless, it would be great to change URLs progressively to avoid the 301 redirections.

> Do I need to add this new domain in the custom dns domain section on GitHub settings?

It is not necessary. We have already edited the DNS for this domain and the theme creates programmatically the required CNAME file. If everything goes well, GitHub should detect the new URL after this PR is merged.

> The DNS doesn't seem to have the right SSL certificates

GitHub handles the certificate provisioning but is not aware of the subdomain for this repo yet.  ``make multi-version`` will create a  new file "CNAME". This is published in `gh-pages` branch, therefore GitHub should create the missing cert.

## How to test this PR

1. Run ``make multiversion``.
2. You should see ``CNAME`` and ``.nojekyll`` files under the ``docs/_build/dirhtml`` folder.
3. The contents of the CNAME file should be ``scylla.docs.scylladb.com``