### PR TITLE
abstract_type: Rework unreversal methods

### DIFF
--- a/cql3/abstract_marker.cc
+++ b/cql3/abstract_marker.cc
@@ -70,11 +70,11 @@ abstract_marker::raw::raw(int32_t bind_index)
 ::shared_ptr<term> abstract_marker::raw::prepare(database& db, const sstring& keyspace, lw_shared_ptr<column_specification> receiver) const
 {
     if (receiver->type->is_collection()) {
-        if (receiver->type->self_or_reversed(&abstract_type::is_list)) {
+        if (receiver->type->without_reversed().is_list()) {
             return ::make_shared<lists::marker>(_bind_index, receiver);
-        } else if (receiver->type->self_or_reversed(&abstract_type::is_set)) {
+        } else if (receiver->type->without_reversed().is_set()) {
             return ::make_shared<sets::marker>(_bind_index, receiver);
-        } else if (receiver->type->self_or_reversed(&abstract_type::is_map)) {
+        } else if (receiver->type->without_reversed().is_map()) {
             return ::make_shared<maps::marker>(_bind_index, receiver);
         }
         assert(0);

--- a/cql3/expr/expression.cc
+++ b/cql3/expr/expression.cc
@@ -155,7 +155,7 @@ bytes_opt get_value(const column_value& col, const column_value_eval_bag& bag) {
 
 /// Type for comparing results of get_value().
 const abstract_type* get_value_comparator(const column_definition* cdef) {
-    return cdef->type->is_reversed() ? cdef->type->underlying_type().get() : cdef->type.get();
+    return &cdef->type->without_reversed();
 }
 
 /// Type for comparing results of get_value().

--- a/cql3/lists.cc
+++ b/cql3/lists.cc
@@ -40,7 +40,7 @@ lw_shared_ptr<column_specification>
 lists::value_spec_of(const column_specification& column) {
     return make_lw_shared<column_specification>(column.ks_name, column.cf_name,
             ::make_shared<column_identifier>(format("value({})", *column.name), true),
-                column.type->as<list_type_impl>().get_elements_type());
+                dynamic_cast<const list_type_impl&>(column.type->without_reversed()).get_elements_type());
 }
 
 lw_shared_ptr<column_specification>
@@ -87,7 +87,7 @@ lists::literal::prepare(database& db, const sstring& keyspace, lw_shared_ptr<col
 
 void
 lists::literal::validate_assignable_to(database& db, const sstring keyspace, const column_specification& receiver) const {
-    if (!receiver.type->self_or_reversed(&abstract_type::is_list)) {
+    if (!receiver.type->without_reversed().is_list()) {
         throw exceptions::invalid_request_exception(format("Invalid list literal for {} of type {}",
                 *receiver.name, receiver.type->as_cql3_type()));
     }
@@ -220,7 +220,7 @@ lists::delayed_value::bind(const query_options& options) {
 ::shared_ptr<terminal>
 lists::marker::bind(const query_options& options) {
     const auto& value = options.get_value_at(_bind_index);
-    auto& ltype = _receiver->type->as<list_type_impl>();
+    auto& ltype = dynamic_cast<const list_type_impl&>(_receiver->type->without_reversed());
     if (value.is_null()) {
         return nullptr;
     } else if (value.is_unset_value()) {

--- a/types.hh
+++ b/types.hh
@@ -611,20 +611,10 @@ public:
     const sstring& cql3_type_name() const;
     virtual shared_ptr<const abstract_type> freeze() const { return shared_from_this(); }
 
-    bool self_or_reversed(bool (abstract_type::*method)() const) const{
-        return (this->*method)() || (is_reversed() && (*underlying_type().*method)());
+    const abstract_type& without_reversed() const {
+        return is_reversed() ? *underlying_type() : *this;
     }
 
-    /// Casts *this (or underlying type, if this is reversed) to T.  Throws bad_cast if it cannot.
-    template<typename T> const T& as() const {
-        if (auto cast = dynamic_cast<const T*>(this)) {
-            return *cast;
-        }
-        if (is_reversed()) {
-            return underlying_type()->as<T>();
-        }
-        throw std::bad_cast();
-    }
     friend class list_type_impl;
 private:
     mutable sstring _cql3_type_name;


### PR DESCRIPTION
Replace two methods for unreversal (`as` and `self_or_reversed`) with
a new one (`without_reversed`).  More flexible and better named.

Tests: unit (dev)

Signed-off-by: Dejan Mircevski <dejan@scylladb.com>