### PR TITLE
cql3: Use correct comparator in timeuuid min/max

### DIFF
--- a/cql3/functions/aggregate_fcts.cc
+++ b/cql3/functions/aggregate_fcts.cc
@@ -219,7 +219,7 @@ struct aggregate_type_for<simple_date_native_type> {
 
 template<>
 struct aggregate_type_for<timeuuid_native_type> {
-    using type = timeuuid_native_type::primary_type;
+    using type = timeuuid_native_type;
 };
 
 template<>
@@ -227,6 +227,7 @@ struct aggregate_type_for<time_native_type> {
     using type = time_native_type::primary_type;
 };
 
+// WARNING: never invoke this on temporary values; it will return a dangling reference.
 template <typename Type>
 const Type& max_wrapper(const Type& t1, const Type& t2) {
     using std::max;
@@ -239,6 +240,10 @@ inline const net::inet_address& max_wrapper(const net::inet_address& t1, const n
             (t1.in_family() == family::INET || t2.in_family() == family::INET)
             ? sizeof(::in_addr) : sizeof(::in6_addr);
     return std::memcmp(t1.data(), t2.data(), len) >= 0 ? t1 : t2;
+}
+
+inline const timeuuid_native_type& max_wrapper(const timeuuid_native_type& t1, const timeuuid_native_type& t2) {
+    return t1.uuid.timestamp() > t2.uuid.timestamp() ? t1 : t2;
 }
 
 template <typename Type>
@@ -323,6 +328,7 @@ make_max_function() {
     return make_shared<max_function_for<Type>>();
 }
 
+// WARNING: never invoke this on temporary values; it will return a dangling reference.
 template <typename Type>
 const Type& min_wrapper(const Type& t1, const Type& t2) {
     using std::min;
@@ -335,6 +341,10 @@ inline const net::inet_address& min_wrapper(const net::inet_address& t1, const n
             (t1.in_family() == family::INET || t2.in_family() == family::INET)
             ? sizeof(::in_addr) : sizeof(::in6_addr);
     return std::memcmp(t1.data(), t2.data(), len) <= 0 ? t1 : t2;
+}
+
+inline timeuuid_native_type min_wrapper(timeuuid_native_type t1, timeuuid_native_type t2) {
+    return t1.uuid.timestamp() < t2.uuid.timestamp() ? t1 : t2;
 }
 
 template <typename Type>

--- a/test/boost/aggregate_fcts_test.cc
+++ b/test/boost/aggregate_fcts_test.cc
@@ -148,7 +148,7 @@ SEASTAR_TEST_CASE(test_aggregate_max) {
                                                           {utf8_type->from_string("b")},
                                                           {simple_date_type->from_string("2017-12-02")},
                                                           {timestamp_type->from_string("2017-12-02t03:00:00")},
-                                                          {timeuuid_type->from_string("D2177dD0-EAa2-11de-a572-001B779C76e3")},
+                                                          {timeuuid_type->from_string("b650cbe0-f914-11e7-8892-000000000004")},
                                                           {bytes_type->from_string("0101")},
                                                           {boolean_type->from_string("true")},
         });
@@ -187,7 +187,7 @@ SEASTAR_TEST_CASE(test_aggregate_min) {
                                                           {utf8_type->from_string("a")},
                                                           {simple_date_type->from_string("2016-12-02")},
                                                           {timestamp_type->from_string("2016-12-02t06:00:00")},
-                                                          {timeuuid_type->from_string("b650cbe0-f914-11e7-8892-000000000004")},
+                                                          {timeuuid_type->from_string("D2177dD0-EAa2-11de-a572-001B779C76e3")},
                                                           {bytes_type->from_string("01")},
                                                           {boolean_type->from_string("false")},
         });

--- a/test/boost/cql_functions_test.cc
+++ b/test/boost/cql_functions_test.cc
@@ -268,7 +268,7 @@ SEASTAR_TEST_CASE(test_aggregate_functions) {
             timeuuid_native_type{utils::UUID("00000000-0000-1000-0000-000000000000")},
             timeuuid_native_type{utils::UUID("00000000-0000-1000-0000-000000000001")},
             timeuuid_native_type{utils::UUID("00000000-0000-1000-0000-000000000002")}
-        ).test_min_max_count();
+        ).test_count(); // min and max will fail, because we assert using UUID order, not timestamp order.
 
         aggregate_function_test(e, time_type,
             time_native_type{std::chrono::duration_cast<std::chrono::nanoseconds>(

--- a/test/cql-pytest/test_minmax.py
+++ b/test/cql-pytest/test_minmax.py
@@ -1,0 +1,36 @@
+# Copyright 2021 ScyllaDB
+#
+# This file is part of Scylla.
+#
+# Scylla is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Scylla is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
+
+#############################################################################
+# Tests for min/max aggregate functions
+#############################################################################
+
+import pytest
+from cassandra.protocol import SyntaxException, AlreadyExists, InvalidRequest, ConfigurationException, ReadFailure
+from cassandra.util import Date
+from util import unique_name, random_string, new_test_table, project
+
+# Regression-test for #7729.
+def test_timeuuid(cql, test_keyspace):
+    schema = "a int, b timeuuid, primary key (a,b)"
+    with new_test_table(cql, test_keyspace, schema) as table:
+        cql.execute(f'insert into {table} (a, b) values (0, 13814000-1dd2-11ff-8080-808080808080)')
+        cql.execute(f'insert into {table} (a, b) values (0, 6b1b3620-33fd-11eb-8080-808080808080)')
+        assert project('system_todate_system_min_b',
+                       cql.execute(f'select todate(min(b)) from {table} where a = 0')) == [Date('2020-12-01')]
+        assert project('system_todate_system_max_b',
+                       cql.execute(f'select todate(max(b)) from {table} where a = 0')) == [Date('2038-09-06')]

--- a/test/cql-pytest/util.py
+++ b/test/cql-pytest/util.py
@@ -67,3 +67,7 @@ def new_test_table(cql, keyspace, schema):
     cql.execute("CREATE TABLE " + table + "(" + schema + ")")
     yield table
     cql.execute("DROP TABLE " + table)
+
+def project(column_name_string, rows):
+    """Returns a list of column values from each of the rows."""
+    return [getattr(r, column_name_string) for r in rows]

--- a/types.hh
+++ b/types.hh
@@ -675,6 +675,14 @@ T&& value_cast(data_value&& value) {
     return std::move(*reinterpret_cast<maybe_empty<T>*>(value._value));
 }
 
+/// Special case: sometimes we cast uuid to timeuuid so we can correctly compare timestamps.  See #7729.
+template <>
+inline timeuuid_native_type&& value_cast<timeuuid_native_type>(data_value&& value) {
+    static thread_local timeuuid_native_type value_holder; // Static so it survives return from this function.
+    value_holder.uuid = value_cast<utils::UUID>(value);
+    return std::move(value_holder);
+}
+
 // CRTP: implements translation between a native_type (C++ type) to abstract_type
 // AbstractType is parametrized because we want a
 //    abstract_type -> collection_type_impl -> map_type


### PR DESCRIPTION
The min/max aggregators use aggregate_type_for comparators, and the
aggregate_type_for<timeuuid> is regular uuid.  But that yields wrong
results; timeuuids should be compared as timestamps.

Fix it by changing aggregate_type_for<timeuuid> from uuid to timeuuid,
so aggregators can distinguish betwen the two.  Then specialize the
aggregation utilities for timeuuid.

Add a cql-pytest and change some unit tests, which relied on naive
uuid comparators.

Fixes #7729.

Tests: unit (dev, debug)

Signed-off-by: Dejan Mircevski <dejan@scylladb.com>