### PR TITLE
api: remove potential large allocation in /column_family/ GET request…

### DIFF
--- a/api/column_family.cc
+++ b/api/column_family.cc
@@ -310,7 +310,7 @@ void set_column_family(http_context& ctx, routes& r) {
         return res;
     });
 
-    cf::get_column_family.set(r, [&ctx] (const_req req){
+    cf::get_column_family.set(r, [&ctx] (std::unique_ptr<request> req){
             vector<cf::column_family_info> res;
             for (auto i: ctx.db.local().get_column_families_mapping()) {
                 cf::column_family_info info;
@@ -319,7 +319,7 @@ void set_column_family(http_context& ctx, routes& r) {
                 info.type = "ColumnFamilies";
                 res.push_back(info);
             }
-            return res;
+            return make_ready_future<json::json_return_type>(json::stream_object(std::move(res)));
         });
 
     cf::get_column_family_name_keyspace.set(r, [&ctx] (const_req req){


### PR DESCRIPTION
… handler

The reply to a /column_family/ GET request contains info about all
column families. Currently, all this info is stored in a single
string when replying, and this string may require a big allocation
when there are many column families.
To avoid that allocation, instead of a single string, use a
body_writer function, which writes chunks of the message content
to the output stream.

Fixes #7916

Signed-off-by: Wojciech Mitros <wojciech.mitros@scylladb.com>