### PR TITLE
idl: remove the large allocation in mutation_partition_view::rows()

### DIFF
--- a/idl-compiler.py
+++ b/idl-compiler.py
@@ -623,7 +623,7 @@ def get_template_name(lst):
 
 
 def is_vector(t):
-    return isinstance(t, TemplateType) and t.name == "std::vector"
+    return isinstance(t, TemplateType) and (t.name == "std::vector" or t.name == "utils::chunked_vector")
 
 
 def is_variant(t):

--- a/idl/mutation.idl.hh
+++ b/idl/mutation.idl.hh
@@ -125,7 +125,7 @@ class mutation_partition stub [[writable]] {
     tombstone tomb;
     row static_row;
     std::vector<range_tombstone> range_tombstones; // sorted by key
-    std::vector<deletable_row> rows; // sorted by key
+    utils::chunked_vector<deletable_row> rows; // sorted by key
 
 };
 


### PR DESCRIPTION
After these changes the generated code deserializes the stream into a chunked vector, instead of an contiguous one, so even if there are many fields in it, there won't be any big allocations.

I haven't run the scylla cluster test with it yet but it passes the unit tests.