### PR TITLE
docker: optimize build process

### DIFF
--- a/dist/docker/redhat/Dockerfile
+++ b/dist/docker/redhat/Dockerfile
@@ -4,10 +4,6 @@ MAINTAINER Avi Kivity <avi@cloudius-systems.com>
 
 ENV container docker
 
-# The SCYLLA_REPO_URL argument specifies the URL to the RPM repository this Docker image uses to install Scylla. The default value is the Scylla's unstable RPM repository, which contains the daily build.
-ARG SCYLLA_REPO_URL=http://downloads.scylladb.com/rpm/unstable/centos/master/latest/scylla.repo
-ARG VERSION=4.6.dev
-
 ADD scylla_bashrc /scylla_bashrc
 
 # Scylla configuration:
@@ -33,12 +29,22 @@ ADD scyllasetup.py /scyllasetup.py
 ADD commandlineparser.py /commandlineparser.py
 ADD docker-entrypoint.py /docker-entrypoint.py
 ADD node_exporter_install /node_exporter_install
-# Install Scylla:
-RUN curl $SCYLLA_REPO_URL -o /etc/yum.repos.d/scylla.repo && \
-    yum -y install epel-release && \
+
+# Prepare layer for actual software install
+RUN sed -i -e 's/enabled=1/enabled=0/' /etc/yum/pluginconf.d/fastestmirror.conf && \
+    yum -y install epel-release hostname supervisor openssh-server openssh-clients rsyslog && \
     yum -y clean expire-cache && \
     yum -y update && \
-    yum -y install scylla-$VERSION hostname supervisor openssh-server openssh-clients rsyslog && \
+    yum clean all
+
+# The SCYLLA_REPO_URL argument specifies the URL to the RPM repository this Docker image uses to install Scylla. The default value is the Scylla's unstable RPM repository, which contains the daily build.
+ARG SCYLLA_REPO_URL=http://downloads.scylladb.com/rpm/unstable/centos/master/latest/scylla.repo
+ARG VERSION
+
+# Install Scylla
+RUN if [[ -z "$VERSION" ]]; then SCYLLA_PACKAGE="scylla"; else SCYLLA_PACKAGE="scylla-$VERSION"; fi && \
+    curl $SCYLLA_REPO_URL -o /etc/yum.repos.d/scylla.repo && \
+    yum -y install $SCYLLA_PACKAGE && \
     yum clean all && \
     cat /scylla_bashrc >> /etc/bashrc && \
     mkdir -p /etc/supervisor.conf.d && \

--- a/dist/docker/redhat/README.md
+++ b/dist/docker/redhat/README.md
@@ -1,13 +1,17 @@
 # Building a CentOS-based Docker image
+
 Running
-```
-docker build -t <image-name> .
-```
+
+    $ docker build -t <image-name> .
+
+    or
+
+    $ docker build --build-arg VERSION=4.4.dev -t <image-name> .
+
 in this directory will build a Docker image of Scylla. You can then run
 it with, for example,
-```
-docker run --name scylla -d -p 9042:9042 -t <image name>
-```
+
+    $ docker run --name scylla -d -p 9042:9042 -t <image name>
 
 However, it is important to note that while the resulting image will contain
 some scripts taken from this directory, the actual Scylla executable will


### PR DESCRIPTION
fixes minor build script issues:

- make `docker build -t scylla .` to work by default by allowing
correct default version

- args must be used later so that when you change them it does not wipe
out all previously built image layers

- by default install `scylla` package instead of scylla-$VERSION package
to allow installing the latest version out of the repo by default. So
both commands will work:

    $ docker build -t scylla .
    $ docker build --build-arg VERSION=4.4.dev -t scylla .

- yum update to be cached as another prepare layer before actually
installing Scylla. that allows reusing cached layers when you will be
willing to change package version. useful especially for local builds.

- disable yum fastestmirror detect plugin to minimize scylla package
install time after full clean up.

Note. VERSION flag is used by the CI to build custom images.