### PR TITLE
sstable: reader: preempt after every fragment

### DIFF
--- a/clustering_ranges_walker.hh
+++ b/clustering_ranges_walker.hh
@@ -65,6 +65,11 @@ private:
                 _current_start = position_in_partition_view::for_range_start(_current_range.front());
                 _current_end = position_in_partition_view::for_range_end(_current_range.front());
             }
+        } else {
+             // If the first range is contiguous with the static row, then advance _current_end as much as we can
+             if (_current_range && !_current_range.front().start()) {
+                 _current_end = position_in_partition_view::for_range_end(_current_range.front());
+             }
         }
     }
 


### PR DESCRIPTION
Whenever we push a fragment, we check whether the buffer is
full and return proceed::no if so, so that the state machine pauses
and lets the consumer continue. This patch adds an additional
condition - if preemption is needed, we also return proceed::no.
This drops us back to the outer loop
(in sstable_mutation_reader::fill_buffer), which will yield to
the reactor as part of seastar::do_until().

Two cases (partition_start and partition_end) did not have the
check for is_buffer_full(); it is added now. This can trigger
is the partition has no rows.

Unlike the previous attempt, push_ready_fragments() is not touched.

The extra preemption opportunities triggered a preexisting bug in
clustering_ranges_walker; it is fixed in the first patch of the series.

I tested this by reading from a large partition with a simple
schema (pk int, ck int, primary key(pk, ck)) with BYPASS CACHE.
However, even without the patch I only got sporadic stalls
with the detector set to 1ms, so it's possible I'm not testing
correctly.

Test: unit (dev, debug, release)

Fixes #7883.