### PR TITLE
dist: drop /etc/security/limits.d/scylla.conf

### DIFF
--- a/dist/common/limits.d/scylla.conf
+++ b/dist/common/limits.d/scylla.conf
@@ -1,5 +1,0 @@
-scylla  -  core     unlimited
-scylla  -  memlock  unlimited
-scylla  -  nofile   200000
-scylla  -  as       unlimited
-scylla  -  nproc    8096

--- a/dist/common/systemd/scylla-server.service
+++ b/dist/common/systemd/scylla-server.service
@@ -7,6 +7,7 @@ Wants=scylla-housekeeping-daily.timer
 [Service]
 PermissionsStartOnly=true
 Type=notify
+LimitCORE=infinity
 LimitMEMLOCK=infinity
 LimitNOFILE=800000
 LimitAS=infinity

--- a/dist/debian/debian/scylla-server.install
+++ b/dist/debian/debian/scylla-server.install
@@ -1,6 +1,5 @@
 etc/default/scylla-server
 etc/default/scylla-housekeeping
-etc/security/limits.d/scylla.conf
 etc/scylla.d/*.conf
 opt/scylladb/share/doc/scylla/*
 opt/scylladb/share/doc/scylla/licenses/

--- a/dist/redhat/scylla.spec
+++ b/dist/redhat/scylla.spec
@@ -101,7 +101,6 @@ rm -rf $RPM_BUILD_ROOT
 
 %config(noreplace) %{_sysconfdir}/sysconfig/scylla-server
 %config(noreplace) %{_sysconfdir}/sysconfig/scylla-housekeeping
-%{_sysconfdir}/security/limits.d/scylla.conf
 %attr(0755,root,root) %dir %{_sysconfdir}/scylla.d
 %config(noreplace) %{_sysconfdir}/scylla.d/*.conf
 /opt/scylladb/share/doc/scylla/*

--- a/install.sh
+++ b/install.sh
@@ -350,10 +350,8 @@ EOS
 SYSCONFDIR="$sysconfdir"
 EOS
     fi
-    install -m755 -d "$retc/security/limits.d"
     install -m755 -d "$rusr/bin"
     install -m755 -d "$rhkdata"
-    install -m644 dist/common/limits.d/scylla.conf -Dt "$retc"/security/limits.d
     ln -srf "$rprefix/bin/scylla" "$rusr/bin/scylla"
     ln -srf "$rprefix/bin/iotune" "$rusr/bin/iotune"
     ln -srf "$rprefix/bin/scyllatop" "$rusr/bin/scyllatop"


### PR DESCRIPTION
Drop limits.d conf file, since we don't use it.
We set these parameters via systemd unit file instead.

Fixes #7925