### PR TITLE
allocation_strategy: set preferred max contiguous allocation to 128k …

### DIFF
--- a/utils/allocation_strategy.hh
+++ b/utils/allocation_strategy.hh
@@ -185,6 +185,9 @@ public:
 
 class standard_allocation_strategy : public allocation_strategy {
 public:
+    constexpr standard_allocation_strategy() {
+        _preferred_max_contiguous_allocation = 128 * 1024;
+    }
     virtual void* alloc(migrate_fn, size_t size, size_t alignment) override {
         seastar::memory::on_alloc_point();
         // ASAN doesn't intercept aligned_alloc() and complains on free().


### PR DESCRIPTION
…for standard allocations

Now that managed_bytes and its users do not assume that a managed_bytes
instance allocated using standard_allocation_strategy is non-fragmented,
we can set the preferred max contiguous allocation to 128k. This causes
managed_bytes to fragment instances that are larger than this size.

Note that managed_bytes is the only user.