### PR TITLE
multishard_combining_reader: do not use `smp::count`

### DIFF
--- a/mutation_reader.cc
+++ b/mutation_reader.cc
@@ -1828,7 +1828,7 @@ void multishard_combining_reader::on_partition_range_change(const dht::partition
         boost::push_heap(_shard_selection_min_heap);
     };
 
-    for (auto shard = _current_shard + 1; shard < smp::count; ++shard) {
+    for (auto shard = _current_shard + 1; shard < _sharder.shard_count(); ++shard) {
         update_and_push_token_for_shard(shard);
     }
     for (auto shard = 0u; shard < _current_shard; ++shard) {


### PR DESCRIPTION
`multishard_combining_reader` currently only works under the assumption
that every table uses the same sharder configured using the node's number
of shards. But we could potentially specify a different sharder for a chosen table,
e.g. one that puts everything on shard 0.
Then this assumption will be broken and the reader causes a segfault.

Fixes #7945.