### PR TITLE
schema_tables: put schema tables on shard 0

### DIFF
--- a/schema.cc
+++ b/schema.cc
@@ -934,6 +934,11 @@ schema_builder& schema_builder::with_sharder(unsigned shard_count, unsigned shar
     return *this;
 }
 
+schema_builder& schema_builder::with_null_sharder() {
+    _raw._sharder = get_sharder(1, 0);
+    return *this;
+}
+
 schema_builder::schema_builder(std::string_view ks_name, std::string_view cf_name,
         std::optional<utils::UUID> id, data_type rct)
         : _raw(id ? *id : utils::UUID_gen::get_time_UUID())

--- a/schema_builder.hh
+++ b/schema_builder.hh
@@ -236,6 +236,7 @@ public:
     }
     schema_builder& with_partitioner(sstring name);
     schema_builder& with_sharder(unsigned shard_count, unsigned sharding_ignore_msb_bits);
+    schema_builder& with_null_sharder(); // a sharder that puts everything on shard 0
     class default_names {
     public:
         default_names(const schema_builder&);


### PR DESCRIPTION
We use a custom sharder for all schema tables: every table under
the `system_schema` keyspace, plus `system.scylla_table_schema_history`.
This sharder puts all data on shard 0.

To achieve this, we hardcode the sharder in initial schema object
definitions. Furthermore - since the sharder is not stored inside schema
mutations yet - whenever we deserialize schema objects from mutations,
we modify the sharder based on the schema's keyspace and table names.

A regression test is added to ensure no one forgets to set the special
sharder for newly added schema tables. This test assumes that all newly
added schema tables will end up in the `system_schema` keyspace (other
tables may go unnoticed, unfortunately).

---

Everything seems to magically work:
1. tracing confirms that each desired table (everything under `system_schema` + `system.scylla_table_schema_history`) has data only under shard 0 (performing `select * from`). I opened a bunch of `cqlsh` sessions which were connected to different shards - each routed the query to shard 0, as desired.
```
                                                       Execute CQL3 query | 2021-01-21 16:43:13.878000 | 127.0.0.1 |              0 | 127.0.0.1
                                            Parsing a statement [shard 1] | 2021-01-21 16:43:13.878038 | 127.0.0.1 |              3 | 127.0.0.1
                                         Processing a statement [shard 1] | 2021-01-21 16:43:13.878386 | 127.0.0.1 |            351 | 127.0.0.1
                                    read_data: querying locally [shard 1] | 2021-01-21 16:43:13.878685 | 127.0.0.1 |            650 | 127.0.0.1
                        Start querying token range (-inf, +inf) [shard 1] | 2021-01-21 16:43:13.878704 | 127.0.0.1 |            670 | 127.0.0.1
                              Creating shard reader on shard: 0 [shard 0] | 2021-01-21 16:43:13.879179 | 127.0.0.1 |              8 | 127.0.0.1
 Scanning cache for range (-inf, +inf) and slice {(-inf, +inf)} [shard 0] | 2021-01-21 16:43:13.879589 | 127.0.0.1 |            430 | 127.0.0.1
                                               Querying is done [shard 1] | 2021-01-21 16:43:13.902964 | 127.0.0.1 |          24929 | 127.0.0.1
                           Done processing - preparing a result [shard 1] | 2021-01-21 16:43:13.916814 | 127.0.0.1 |          38780 | 127.0.0.1
                                                         Request complete | 2021-01-21 16:43:13.918379 | 127.0.0.1 |          40379 | 127.0.0.1
```
2. rolling upgrade works, even downgrade
3. data in these tables is not lost between upgrades/downgrades (created bunch of keyspaces and tables - they still show up in the schema tables after such upgrade/downgrade and I can normally use them)

Does not require fixing https://github.com/scylladb/scylla/issues/7642 (mutations don't have info about the sharder - we simply "fix" the schema after deserializing it, same trick as with "extra durability")