### PR TITLE
build: reduce release mode inline tuning on aarch64

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1172,9 +1172,16 @@ warnings = [w
 
 warnings = ' '.join(warnings + ['-Wno-error=deprecated-declarations'])
 
+def clang_inline_threshold():
+    if platform.machine() == 'aarch64':
+        # we see miscompiles with 1200 and above with format("{}", uuid)
+        return 600
+    else:
+        return 2500
+
 optimization_flags = [
     '--param inline-unit-growth=300', # gcc
-    '-mllvm -inline-threshold=2500',  # clang
+    f'-mllvm -inline-threshold={clang_inline_threshold()}',  # clang
 ]
 optimization_flags = [o
                       for o in optimization_flags


### PR DESCRIPTION
I see a miscompile on aarch64 where a call to format("{}", uuid)
translates a function pointer to -1. When called, this crashes.

Reduce the inline threshold from 2500 to 600. This doesn't guarantee
no miscompiles but all the tests pass with this parameter.