### PR TITLE
api: use a list instead of a vector to remove a large allocation in api handler

### DIFF
--- a/api/column_family.cc
+++ b/api/column_family.cc
@@ -311,7 +311,7 @@ void set_column_family(http_context& ctx, routes& r) {
     });
 
     cf::get_column_family.set(r, [&ctx] (std::unique_ptr<request> req){
-            vector<cf::column_family_info> res;
+            std::list<cf::column_family_info> res;
             for (auto i: ctx.db.local().get_column_families_mapping()) {
                 cf::column_family_info info;
                 info.ks = i.first.first;
@@ -319,7 +319,7 @@ void set_column_family(http_context& ctx, routes& r) {
                 info.type = "ColumnFamilies";
                 res.push_back(info);
             }
-            return make_ready_future<json::json_return_type>(json::stream_object(std::move(res)));
+            return make_ready_future<json::json_return_type>(json::stream_range_as_array(std::move(res), std::identity()));
         });
 
     cf::get_column_family_name_keyspace.set(r, [&ctx] (const_req req){


### PR DESCRIPTION
Follow-up to #7917

The size of an cf::column_family_info is 224 bytes, so an std::vector that
contains one for each column family may be very large, causing allocations
of over 1MB.
Considering the vector is used only for iteration, it can be changed to
a non-contiguous list instead. 

We aren't using utils::chunked_vector because it requires the class it's storing
to have a noexcept move constructor, which a cf::column_family_info doesn't have.