### PR TITLE
transport: Fix abort on certain configurations of native_transport_port(_ssl)

### DIFF
--- a/conf/scylla.yaml
+++ b/conf/scylla.yaml
@@ -99,8 +99,8 @@ listen_address: localhost
 # listen_on_broadcast_address: false
 
 # port for the CQL native transport to listen for clients on
-# For security reasons, you should not expose this port to the internet.  Firewall it if needed.
-# To disable the CQL native transport, set this option to 0.
+# For security reasons, you should not expose this port to the internet. Firewall it if needed.
+# To disable the CQL native transport, remove this option and configure native_transport_port_ssl.
 native_transport_port: 9042
 
 # Like native_transport_port, but clients are forwarded to specific shards, based on the


### PR DESCRIPTION
The reason was accessing the table out of index. Also,
native_transport_port can no longer be disabled by setting it to 0.

Fixes #7783
Fixes #7866