### PR TITLE
API: column_family per_level, add max per level

### DIFF
--- a/api/api-doc/column_family.json
+++ b/api/api-doc/column_family.json
@@ -596,6 +596,14 @@
                      "allowMultiple":false,
                      "type":"string",
                      "paramType":"path"
+                  },
+                  {
+                     "name": "add_max",
+                     "description":"if set to true, the result array, will have twice the number of cells and would contain the max per level",
+                     "required":false,
+                     "allowMultiple":false,
+                     "type": "string",
+                     "paramType":"query"
                   }
                ]
             }


### PR DESCRIPTION
Sometimes it's useful not to know the maximum sstable per level not only
the number of sstable per level.

Specifically, it is useful for nodetool tablestats

This patch adds an optional parameter to GET
/column_family/sstables/per_level/ API.

If add_max is set to true, the returned array would contain an
additional entry per level with the maximum value.

Following changes are required in the JMX to support it.

Relates to #3612

Signed-off-by: Amnon Heiman <amnon@scylladb.com>