### PR TITLE
Fix mixed cluster schema sync

### DIFF
--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -783,6 +783,13 @@ future<std::vector<canonical_mutation>> convert_schema_to_mutations(distributed<
 
 std::vector<mutation>
 adjust_schema_for_schema_features(std::vector<mutation> schema, schema_features features) {
+    //Don't send the `computed_columns` table mutations to nodes that doesn't know it.
+    if (!features.contains(schema_feature::COMPUTED_COLUMNS)) {
+        schema.erase(std::remove_if(schema.begin(), schema.end(), [] (const mutation& m) {
+            return m.schema()->cf_name() == COMPUTED_COLUMNS;
+        }) , schema.end());
+    }
+
     for (auto& m : schema) {
         m = redact_columns_for_missing_features(m, features);
     }

--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -700,7 +700,9 @@ redact_columns_for_missing_features(mutation m, schema_features features) {
         return std::move(m);
     }
     slogger.debug("adjusting schema_tables mutation due to possible in-progress cluster upgrade");
-    m.upgrade(scylla_tables(features));
+    // The global schema ptr make sure it will be registered in the schema registry.
+    global_schema_ptr redacted_schema{scylla_tables(features)};
+    m.upgrade(redacted_schema);
     return std::move(m);
 }
 

--- a/gms/feature_service.hh
+++ b/gms/feature_service.hh
@@ -147,8 +147,8 @@ public:
         return _digest_insensitive_to_expiry;
     }
 
-    bool cluster_supports_computed_columns() const {
-        return bool(_computed_columns);
+    const feature& cluster_supports_computed_columns() const {
+        return _computed_columns;
     }
 
     bool cluster_supports_nonfrozen_udts() const {

--- a/service/migration_manager.cc
+++ b/service/migration_manager.cc
@@ -99,6 +99,7 @@ void migration_manager::init_messaging_service()
         _feature_listeners.push_back(_feat.cluster_supports_digest_insensitive_to_expiry().when_enabled(update_schema));
         _feature_listeners.push_back(_feat.cluster_supports_cdc().when_enabled(update_schema));
         _feature_listeners.push_back(_feat.cluster_supports_per_table_partitioners().when_enabled(update_schema));
+        _feature_listeners.push_back(_feat.cluster_supports_computed_columns().when_enabled(update_schema));
     }
 
     _messaging.register_definitions_update([this] (const rpc::client_info& cinfo, std::vector<frozen_mutation> fm, rpc::optional<std::vector<canonical_mutation>> cm) {


### PR DESCRIPTION
When a table is altered in a mixed cluster by a node with a more recent version, the request can
fail if there is a difference in schema_features between the two versions.
This miniset handles the two problems that prevents the sync.
