### PR TITLE
Untyped_result_set: make non-copying and fragment retaining

### DIFF
--- a/cql3/result_generator.hh
+++ b/cql3/result_generator.hh
@@ -82,7 +82,7 @@ private:
                     if (_clustering_key.size() > def->component_index()) {
                         _visitor.accept_value(query::result_bytes_view(bytes_view(_clustering_key[def->component_index()])));
                     } else {
-                        _visitor.accept_value({});
+                        _visitor.accept_value(std::nullopt);
                     }
                     break;
                 case column_kind::regular_column:
@@ -107,7 +107,7 @@ private:
                     } else if (def->is_static()) {
                         accept_cell_value(*def, static_row_iterator);
                     } else {
-                        _visitor.accept_value({});
+                        _visitor.accept_value(std::nullopt);
                     }
                 }
                 _visitor.end_row();

--- a/cql3/result_generator.hh
+++ b/cql3/result_generator.hh
@@ -25,6 +25,7 @@
 #include "stats.hh"
 
 namespace cql3 {
+class untyped_result_set;
 
 class result_generator {
     schema_ptr _schema;
@@ -33,6 +34,7 @@ class result_generator {
     shared_ptr<const selection::selection> _selection;
     cql_stats* _stats;
 private:
+    friend class untyped_result_set;
     template<typename Visitor>
     class query_result_visitor {
         const schema& _schema;

--- a/cql3/untyped_result_set.cc
+++ b/cql3/untyped_result_set.cc
@@ -47,58 +47,118 @@
 #include "result_set.hh"
 #include "transport/messages/result_message.hh"
 
-cql3::untyped_result_set_row::untyped_result_set_row(const map_t& data)
-    : _data(data)
+cql3::untyped_result_set_row::untyped_result_set_row(const index_map& index, const cql3::metadata& metadata, data_views data)
+    : _name_to_index(index)
+    , _metadata(metadata)
+    , _data(std::move(data))
 {}
 
-cql3::untyped_result_set_row::untyped_result_set_row(const std::vector<lw_shared_ptr<column_specification>>& columns, std::vector<bytes_opt> data)
-: _columns(columns)
-, _data([&columns, data = std::move(data)] () mutable {
-    map_t tmp;
-    std::transform(columns.begin(), columns.end(), data.begin(), std::inserter(tmp, tmp.end()), [](lw_shared_ptr<column_specification> c, bytes_opt& d) {
-       return std::make_pair<sstring, bytes_opt>(c->name->to_string(), std::move(d));
-    });
-    return tmp;
-}())
-{}
+size_t cql3::untyped_result_set_row::index(const std::string_view& name) const {
+    auto i = _name_to_index.find(name);
+    return i != _name_to_index.end() ? i->second : std::numeric_limits<size_t>::max();
+}
 
 bool cql3::untyped_result_set_row::has(std::string_view name) const {
-    auto i = _data.find(name);
-    return i != _data.end() && i->second;
+    auto i = index(name);
+    if (i < _data.size()) {
+        return !std::holds_alternative<std::monostate>(_data.at(i));
+    }
+    return false;
+}
+
+cql3::untyped_result_set_row::view_type cql3::untyped_result_set_row::get_view(std::string_view name) const {
+    return std::visit(make_visitor(
+        [](std::monostate) -> view_type { throw std::bad_variant_access(); },
+        [](const view_type& v) -> view_type { return v; },
+        [](const bytes& b) -> view_type { return view_type(b); }
+    ), _data.at(index(name)));
+}
+
+const std::vector<lw_shared_ptr<cql3::column_specification>>& cql3::untyped_result_set_row::get_columns() const {
+    return _metadata.get_names();
 }
 
 using cql_transport::messages::result_message;
 
-cql3::untyped_result_set::untyped_result_set(const cql3::result_set& rs) {
-    auto& cn = rs.get_metadata().get_names();
-    for (auto& r : rs.rows()) {
-        // r is const ref. TODO: make this more efficient by either wrapping result set
-        // or adding modifying accessors to it.
-        _rows.emplace_back(cn, r);
-    }
+cql3::untyped_result_set::index_map_ptr cql3::untyped_result_set::make_index(const cql3::metadata& metadata) {
+    auto map = std::make_unique<untyped_result_set_row::index_map>();
+    auto& names = metadata.get_names();
+    size_t i = 0;
+    std::transform(names.begin(), names.end(), std::inserter(*map, map->end()), [&](const lw_shared_ptr<column_specification>& c) mutable {
+        return std::make_pair<std::string_view, size_t>(c->name->text(), i++);
+    });
+    return map;
 }
 
+struct cql3::untyped_result_set::visitor {
+    rows_type& rows;
+    const cql3::metadata& meta;
+    const untyped_result_set_row::index_map& index;
+    untyped_result_set_row::data_views tmp;
+
+    visitor(rows_type& r, const cql3::metadata& m, const untyped_result_set_row::index_map& i)
+        : rows(r)
+        , meta(m)
+        , index(i)
+    {}
+
+    void start_row() {
+        tmp.reserve(index.size());
+    }
+    void accept_value(std::optional<query::result_bytes_view>&& v) {
+        if (v) {
+            tmp.emplace_back(std::move(*v));
+        } else {
+            tmp.emplace_back(std::monostate{});
+        } 
+    }
+    // somewhat weird dispatch, but when visiting directly via
+    // result_generator, pk:s will be temporary - and sent 
+    // as views, not opt_views. So we can dispatch on this and 
+    // simply copy the temporaries.
+    void accept_value(const query::result_bytes_view& v) {
+        tmp.emplace_back(v.linearize());
+    }
+    void end_row() {
+        rows.emplace_back(untyped_result_set_row(index, meta, std::exchange(tmp, {})));
+    }
+};
+
 cql3::untyped_result_set::untyped_result_set(::shared_ptr<result_message> msg)
-    : _rows([msg]{
-    class visitor : public result_message::visitor_base {
+    : _storage(msg)
+{
+    class msg_visitor : public result_message::visitor_base {
     public:
-        std::optional<untyped_result_set> res;
+        const cql3::result* res = nullptr;
         void visit(const result_message::rows& rmrs) override {
-            const auto& rs = rmrs.rs();
-            const auto& set = rs.result_set();
-            res.emplace(set); // construct untyped_result_set by const ref.
+            res = &rmrs.rs();
         }
     };
-    visitor v;
+    msg_visitor v;
     if (msg != nullptr) {
         msg->accept(v);
     }
     if (v.res) {
-        return std::move(v.res->_rows);
+        auto& metadata = v.res->get_metadata();
+        _index = make_index(metadata);
+        v.res->visit(visitor{_rows, metadata, *_index});
     }
-    return rows_type{};
-}())
-{}
+}
+
+cql3::untyped_result_set::untyped_result_set(const schema& s, foreign_ptr<lw_shared_ptr<query::result>> qr, const cql3::selection::selection& selection, const query::partition_slice& slice)
+    : _storage(std::make_tuple(std::move(qr), selection.get_result_metadata()))
+{
+    auto& qt = std::get<qr_tuple>(_storage);
+    auto& qres = std::get<0>(qt);
+    auto& metadata = *std::get<1>(qt);
+
+    _index = make_index(metadata);
+    visitor v{_rows, metadata, *_index};
+    result_generator::query_result_visitor<visitor> vv(s, v, selection);
+    query::result_view::consume(*qres, slice, vv);
+}
+
+cql3::untyped_result_set::~untyped_result_set() = default;
 
 const cql3::untyped_result_set_row& cql3::untyped_result_set::one() const {
     if (_rows.size() != 1) {

--- a/service/raft/raft_sys_table_storage.cc
+++ b/service/raft/raft_sys_table_storage.cc
@@ -75,7 +75,7 @@ future<raft::log_entries> raft_sys_table_storage::load_log() {
     for (const cql3::untyped_result_set_row& row : *rs) {
         raft::term_t term = raft::term_t(row.get_as<int64_t>("term"));
         raft::index_t idx = raft::index_t(row.get_as<int64_t>("index"));
-        bytes_view raw_data = row.get_view("data");
+        auto raw_data = row.get_blob("data");
         auto in = ser::as_input_stream(raw_data);
         using data_variant_type = decltype(raft::log_entry::data);
         data_variant_type data = ser::deserialize(in, boost::type<data_variant_type>());
@@ -98,7 +98,7 @@ future<raft::snapshot> raft_sys_table_storage::load_snapshot() {
         db::system_keyspace::RAFT_SNAPSHOTS);
     ::shared_ptr<cql3::untyped_result_set> snp_rs = co_await _qp.execute_internal(load_snp_info_cql, {int64_t(_group_id), snapshot_id});
     const auto& snp_row = snp_rs->one(); // should be only one matching row for a given snapshot id
-    bytes_view snp_cfg = snp_row.get_view("config");
+    auto snp_cfg = snp_row.get_blob("config");
     auto in = ser::as_input_stream(snp_cfg);
 
     raft::snapshot s{

--- a/types.cc
+++ b/types.cc
@@ -1854,6 +1854,9 @@ template data_value collection_type_impl::deserialize_impl<>(fragmented_temporar
 template data_value collection_type_impl::deserialize_impl<>(single_fragmented_view, cql_serialization_format) const;
 template data_value collection_type_impl::deserialize_impl<>(managed_bytes_view, cql_serialization_format) const;
 
+template int read_collection_size(ser::buffer_view<bytes_ostream::fragment_iterator>& in, cql_serialization_format);
+template ser::buffer_view<bytes_ostream::fragment_iterator> read_collection_value(ser::buffer_view<bytes_ostream::fragment_iterator>& in, cql_serialization_format);
+
 template <FragmentedView View>
 data_value deserialize_aux(const tuple_type_impl& t, View v) {
     tuple_type_impl::native_type ret;

--- a/types/listlike_partial_deserializing_iterator.hh
+++ b/types/listlike_partial_deserializing_iterator.hh
@@ -28,6 +28,12 @@
 int read_collection_size(bytes_view& in, cql_serialization_format sf);
 bytes_view read_collection_value(bytes_view& in, cql_serialization_format sf);
 
+template <FragmentedView View>
+int read_collection_size(View& in, cql_serialization_format);
+
+template <FragmentedView View>
+View read_collection_value(View& in, cql_serialization_format);
+
 // iterator that takes a set or list in serialized form, and emits
 // each element, still in serialized form
 class listlike_partial_deserializing_iterator {


### PR DESCRIPTION
Refs #7961
Fixes #8014

The "untyped_result_set" object was created for small, internal access to cql-stored metadata.
It is nowadays used for rather more than that (cdc). 
This has the potential of mixing badly with the fact that the type does deep copying of data
and linearizes all (not to mention handles multiple rows rather inefficiently).

Instead of doing a deep copy of input, we keep assume ownership and build
rows of the views therein, potentially retaining fragmented data as-is
avoiding premature linearization.

Note that this is not all sugar and flowers though. Any data access will
by nature be more expensive, and the view collections we create are
potentially just as expensive as copying for small cells.

Otoh, it allows writing code using this that avoids data copying,
depending on destination.

v2:
* Fixed wrong collection reserved in visitor
* Changed row index from shared ptr to ref
* Moved typedef
* Removed non-existing constructors
* Added const ref to index build
* Fixed raft usage after rebase

v3:
* Changed shared_ptr to unique