### PR TITLE
tools: toolchain: dbuild: keep original user's groups

### DIFF
--- a/tools/toolchain/dbuild
+++ b/tools/toolchain/dbuild
@@ -157,7 +157,10 @@ else
     # detection code from
     #   https://unix.stackexchange.com/questions/617764/how-do-i-check-if-system-is-using-cgroupv1
     if grep -q 'cgroup2.*/sys/fs/cgroup' /proc/mounts; then
-        docker_common_args+=(--pids-limit -1)
+        docker_common_args+=(
+            --pids-limit -1
+            --annotation run.oci.keep_original_groups=1
+        )
     fi
     # if --pids-limit is not supported, add
     #    [containers]


### PR DESCRIPTION
The supplementary groups are removed by default, so add them back.
Supplementary groups are useful for group-shared directories like
ccache.

I added them to the podman-only branch since I don't know if this
works for docker. If a docker user verifies it works there too,
we can move it to the generic code.