### PR TITLE
tools: toolchain: add simplified procedure for creating dbuild images

### DIFF
--- a/tools/toolchain/README.md
+++ b/tools/toolchain/README.md
@@ -68,7 +68,22 @@ For master toolchains, the branch designation is omitted. In a branch, if
 there is a need to update a toolchain, the branch designation is added to
 the tag to avoid ambiguity.
 
-To publish a new image, follow this procedure:
+Publishing an image is complicated since multiple architectures are supported.
+There are two procedures, one using emulation (can run on any x86 machine) and
+another using native systems, which requires access to aarch64 and s390x machines.
+
+## Emulated publishing procedure (slow)
+
+1. Pick a new name for the image (in `tools/toolchain/image`) and
+   commit it. The commit updating install-dependencies.sh should
+   include the toolchain change, for atomicity. Do not push the commit
+   to `next` yet.
+2. Run `tools/toolchain/prepare` and wait. It requires `buildah` and
+   `qemu-user-static` to be installed (and will complain if they are not).
+3. Publish the image using the instructions printed by the previous step.
+4. Push the `next` branch that refers to the new toolchain.
+
+## Native publishing procedure (complicated)
 
 1. Pick a new name for the image (in `tools/toolchain/image`) and
    commit it. The commit updating install-dependencies.sh should

--- a/tools/toolchain/prepare
+++ b/tools/toolchain/prepare
@@ -1,0 +1,44 @@
+#!/bin/bash -e
+
+bv=$(buildah --version)
+if (( $? != 0 )); then
+    echo install buildah 1.19.3 or later
+    exit 1
+fi
+
+# translate to array of version components
+bv="${bv#buildah version }"
+bv="${bv% (*}"
+bv=(${bv//./ })
+
+maj=${bv[0]}
+min=${bv[1]}
+patch=${bv[2]}
+
+ok=$(( maj > 1 || ( maj == 1 && min > 19 ) || ( maj == 1 && min == 19 && patch >= 3 ) ))
+
+if (( ! ok )); then 
+    echo install buildah 1.19.3 or later
+    exit 1
+fi
+
+archs=(amd64 arm64 s390x)
+
+if [[ ! -f  /proc/sys/fs/binfmt_misc/qemu-aarch64 || ! -f /proc/sys/fs/binfmt_misc/qemu-s390x ]]; then
+    echo install qemu-user-static
+    exit 1
+fi
+
+podman manifest create "$(<tools/toolchain/image)"
+
+
+for arch in "${archs[@]}"; do
+    image_id_file="$(mktemp)"
+    buildah bud --arch="$arch" --no-cache --pull -f tools/toolchain/Dockerfile --iidfile "$image_id_file"
+    podman manifest add --all "$(<tools/toolchain/image)" "containers-storage:$(<$image_id_file)"
+    rm "$image_id_file"
+done
+
+echo "Done building $(<tools/toolchain/image). You can now test it, and push with"
+echo ""
+echo "    podman manifest push --all $(<tools/toolchain/image) docker://$(<tools/toolchain/image)"


### PR DESCRIPTION
The current procedure for building images is complicated, as it
requires access to x86_64, aarch64, and s390x machines. Add an alternative
procedure that is fully automated, as it relies on emulation on a single
machine.

It is slow, but requires less attention.