### PR TITLE
dist: scylla_util: prevent IndexError when no ephemeral_disks were found

### DIFF
--- a/dist/common/scripts/scylla_util.py
+++ b/dist/common/scripts/scylla_util.py
@@ -315,9 +315,10 @@ class gcp_instance:
                     logging.warning(
                         "This machine doesn't have enough CPUs for allocated number of NVMEs (at least 32 cpus for >=16 disks). Performance will suffer.")
                     return False
-                diskSize = self.firstNvmeSize
                 if diskCount < 1:
+                    logging.warning("No ephemeral disks were found.")
                     return False
+                diskSize = self.firstNvmeSize
                 max_disktoramratio = 105
                 # 30:1 Disk/RAM ratio must be kept at least(AWS), we relax this a little bit
                 # on GCP we are OK with {max_disktoramratio}:1 , n1-standard-2 can cope with 1 disk, not more


### PR DESCRIPTION
Currently we call firstNvmeSize before checking that we have enough
(at least 1) ephemeral disks.  When none are found, we hit the following
error (see #7971):
```
File "/opt/scylladb/scripts/libexec/scylla_io_setup", line 239, in
if idata.is_recommended_instance():
File "/opt/scylladb/scripts/scylla_util.py", line 311, in is_recommended_instance
diskSize = self.firstNvmeSize
File "/opt/scylladb/scripts/scylla_util.py", line 291, in firstNvmeSize
firstDisk = ephemeral_disks[0]
IndexError: list index out of range
```

This change reverses the order and first checks that we found
enough disks before getting the fist disk size.

Fixes #7971

Signed-off-by: Benny Halevy <bhalevy@scylladb.com>