### PR TITLE
test: perf_fast_forward: Quiesce sstable readers between test cases

### DIFF
--- a/database.cc
+++ b/database.cc
@@ -28,6 +28,7 @@
 #include "db/system_keyspace.hh"
 #include "db/commitlog/commitlog.hh"
 #include "db/config.hh"
+#include "db/background.hh"
 #include "to_string.hh"
 #include "query-result-writer.hh"
 #include "cql3/column_identifier.hh"
@@ -98,6 +99,12 @@
 
 using namespace std::chrono_literals;
 using namespace db;
+
+namespace db {
+
+thread_local utils::phased_barrier background_jobs;
+
+}
 
 logging::logger dblog("database");
 

--- a/db/background.hh
+++ b/db/background.hh
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2020 ScyllaDB
+ *
+ */
+
+/*
+ * This file is part of Scylla.
+ *
+ * Scylla is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Scylla is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "utils/phased_barrier.hh"
+
+namespace db {
+
+extern thread_local utils::phased_barrier background_jobs;
+
+/// Those functions are used for tracking background tasks initiated by
+/// requests coming into the system.
+
+// Starts tracking a new background operation.
+// The operation ends when the returned object is destroyed.
+inline
+utils::phased_barrier::operation start_background_job() noexcept { return background_jobs.start(); }
+
+// Waits for all background jobs started before this call.
+// Background jobs are started with start_background_job().
+// Jobs started after this call but before the future resolves will not be waited for.
+inline
+future<> await_background_jobs() { return background_jobs.advance_and_await(); }
+
+}

--- a/sstables/data_consume_context.hh
+++ b/sstables/data_consume_context.hh
@@ -27,6 +27,7 @@
 #include <seastar/core/future.hh>
 #include <seastar/util/optimized_optional.hh>
 
+#include "db/background.hh"
 #include "shared_sstable.hh"
 #include "row.hh"
 #include "sstables.hh"
@@ -124,8 +125,7 @@ public:
     ~data_consume_context() {
         if (_ctx) {
             auto f = _ctx->close();
-            //FIXME: discarded future.
-            (void)f.handle_exception([ctx = std::move(_ctx), sst = std::move(_sst)](auto) {});
+            (void)f.handle_exception([ctx = std::move(_ctx), sst = std::move(_sst), op = db::start_background_job()](auto) {});
         }
     }
 

--- a/sstables/partition.cc
+++ b/sstables/partition.cc
@@ -20,6 +20,7 @@
  */
 #include "mutation.hh"
 #include "sstables.hh"
+#include "db/background.hh"
 #include "types.hh"
 #include <seastar/core/future-util.hh>
 #include "key.hh"
@@ -225,8 +226,7 @@ public:
         auto close = [this] (std::unique_ptr<index_reader>& ptr) {
             if (ptr) {
                 auto f = ptr->close();
-                // FIXME: discarded future.
-                (void)f.handle_exception([index = std::move(ptr)] (auto&&) { });
+                (void)f.handle_exception([index = std::move(ptr), op = db::start_background_job()] (auto&&) { });
             }
         };
         close(_index_reader);


### PR DESCRIPTION
Currently, sstable readers which go out of scope close file readers in the background.
This can leave, for example, file read-aheads active after the read is done. Those will interfere
with the next test case and be reported under the next test case, incorrectly.

Fix by joining with those background operations between test cases.

Tests: [dev] perf_fast_forward