### PR TITLE
Add max concurrent requests to alternator

### DIFF
--- a/alternator/error.hh
+++ b/alternator/error.hh
@@ -80,6 +80,9 @@ public:
     static api_error trimmed_data_access_exception(std::string msg) {
         return api_error("TrimmedDataAccessException", std::move(msg));
     }
+    static api_error request_limit_exceeded(std::string msg) {
+        return api_error("RequestLimitExceeded", std::move(msg));
+    }
     static api_error internal(std::string msg) {
         return api_error("InternalServerError", std::move(msg), reply::status_type::internal_server_error);
     }

--- a/alternator/server.cc
+++ b/alternator/server.cc
@@ -276,7 +276,7 @@ future<executor::request_return_type> server::handle_api_request(std::unique_ptr
         auto callback_it = _callbacks.find(op);
         if (callback_it == _callbacks.end()) {
             _executor._stats.unsupported_operations++;
-            throw api_error::unknown_operation(format("Unsupported operation {}", op));
+            return make_ready_future<executor::request_return_type>(api_error::unknown_operation(format("Unsupported operation {}", op)));
         }
         if (_pending_requests.get_count() >= _max_concurrent_requests) {
             _executor._stats.requests_shed++;

--- a/alternator/server.cc
+++ b/alternator/server.cc
@@ -279,6 +279,7 @@ future<executor::request_return_type> server::handle_api_request(std::unique_ptr
             throw api_error::unknown_operation(format("Unsupported operation {}", op));
         }
         if (_pending_requests.get_count() >= _max_concurrent_requests) {
+            _executor._stats.requests_shed++;
             return make_ready_future<executor::request_return_type>(
                     api_error::request_limit_exceeded(format("too many in-flight requests (configured via max_concurrent_requests_per_shard): {}", _pending_requests.get_count())));
         }

--- a/alternator/server.cc
+++ b/alternator/server.cc
@@ -278,6 +278,10 @@ future<executor::request_return_type> server::handle_api_request(std::unique_ptr
             _executor._stats.unsupported_operations++;
             throw api_error::unknown_operation(format("Unsupported operation {}", op));
         }
+        if (_pending_requests.get_count() >= _max_concurrent_requests) {
+            return make_ready_future<executor::request_return_type>(
+                    api_error::request_limit_exceeded(format("too many in-flight requests (configured via max_concurrent_requests_per_shard): {}", _pending_requests.get_count())));
+        }
         return with_gate(_pending_requests, [this, callback_it = std::move(callback_it), op = std::move(op), req = std::move(req)] () mutable {
             //FIXME: Client state can provide more context, e.g. client's endpoint address
             // We use unique_ptr because client_state cannot be moved or copied
@@ -405,9 +409,10 @@ server::server(executor& exec, cql3::query_processor& qp)
 }
 
 future<> server::init(net::inet_address addr, std::optional<uint16_t> port, std::optional<uint16_t> https_port, std::optional<tls::credentials_builder> creds,
-        bool enforce_authorization, semaphore* memory_limiter) {
+        bool enforce_authorization, semaphore* memory_limiter, utils::updateable_value<uint32_t> max_concurrent_requests) {
     _memory_limiter = memory_limiter;
     _enforce_authorization = enforce_authorization;
+    _max_concurrent_requests = std::move(max_concurrent_requests);
     if (!port && !https_port) {
         return make_exception_future<>(std::runtime_error("Either regular port or TLS port"
                 " must be specified in order to init an alternator HTTP server instance"));

--- a/alternator/server.hh
+++ b/alternator/server.hh
@@ -28,6 +28,7 @@
 #include <optional>
 #include "alternator/auth.hh"
 #include "utils/small_vector.hh"
+#include "utils/updateable_value.hh"
 #include <seastar/core/units.hh>
 
 namespace alternator {
@@ -50,6 +51,7 @@ class server {
     alternator_callbacks_map _callbacks;
 
     semaphore* _memory_limiter;
+    utils::updateable_value<uint32_t> _max_concurrent_requests;
 
     class json_parser {
         static constexpr size_t yieldable_parsing_threshold = 16*KB;
@@ -72,7 +74,7 @@ public:
     server(executor& executor, cql3::query_processor& qp);
 
     future<> init(net::inet_address addr, std::optional<uint16_t> port, std::optional<uint16_t> https_port, std::optional<tls::credentials_builder> creds,
-            bool enforce_authorization, semaphore* memory_limiter);
+            bool enforce_authorization, semaphore* memory_limiter, utils::updateable_value<uint32_t> max_concurrent_requests);
     future<> stop();
 private:
     void set_routes(seastar::httpd::routes& r);

--- a/alternator/stats.cc
+++ b/alternator/stats.cc
@@ -96,6 +96,8 @@ stats::stats() : api_operations{} {
                     seastar::metrics::description("number writes that had to be bounced from this shard because of LWT requirements")),
             seastar::metrics::make_total_operations("requests_blocked_memory", requests_blocked_memory,
                     seastar::metrics::description("Counts a number of requests blocked due to memory pressure.")),
+            seastar::metrics::make_total_operations("requests_shed", requests_shed,
+                    seastar::metrics::description("Counts a number of requests shed due to overload.")),
             seastar::metrics::make_total_operations("filtered_rows_read_total", cql_stats.filtered_rows_read_total,
                     seastar::metrics::description("number of rows read during filtering operations")),
             seastar::metrics::make_total_operations("filtered_rows_matched_total", cql_stats.filtered_rows_matched_total,

--- a/alternator/stats.hh
+++ b/alternator/stats.hh
@@ -92,6 +92,7 @@ public:
     uint64_t write_using_lwt = 0;
     uint64_t shard_bounce_for_lwt = 0;
     uint64_t requests_blocked_memory = 0;
+    uint64_t requests_shed = 0;
     // CQL-derived stats
     cql3::cql_stats cql_stats;
 private:

--- a/main.cc
+++ b/main.cc
@@ -1284,11 +1284,12 @@ int main(int ac, char** av) {
                 }
                 bool alternator_enforce_authorization = cfg->alternator_enforce_authorization();
                 with_scheduling_group(dbcfg.statement_scheduling_group,
-                        [addr, alternator_port, alternator_https_port, creds = std::move(creds), alternator_enforce_authorization] () mutable {
+                        [addr, alternator_port, alternator_https_port, creds = std::move(creds), alternator_enforce_authorization, cfg] () mutable {
                     return alternator_server.invoke_on_all(
-                            [addr, alternator_port, alternator_https_port, creds = std::move(creds), alternator_enforce_authorization] (alternator::server& server) mutable {
+                            [addr, alternator_port, alternator_https_port, creds = std::move(creds), alternator_enforce_authorization, cfg] (alternator::server& server) mutable {
                         auto& ss = service::get_local_storage_service();
-                        return server.init(addr, alternator_port, alternator_https_port, creds, alternator_enforce_authorization, &ss.service_memory_limiter());
+                        return server.init(addr, alternator_port, alternator_https_port, creds, alternator_enforce_authorization, &ss.service_memory_limiter(),
+                                ss.db().local().get_config().max_concurrent_requests_per_shard);
                     }).then([addr, alternator_port, alternator_https_port] {
                         startlog.info("Alternator server listening on {}, HTTP port {}, HTTPS port {}",
                                 addr, alternator_port ? std::to_string(*alternator_port) : "OFF", alternator_https_port ? std::to_string(*alternator_https_port) : "OFF");


### PR DESCRIPTION
Previous version, merged and dequeued due to a dependency bug: https://github.com/scylladb/scylla/pull/7297

Note: this pull request is temporarily created against /next, because it depends on https://github.com/scylladb/scylla/pull/7279.

This series adds support for `max_concurrent_requests_per_shard` config variable to alternator. Excessive requests are shed and RequestLimitExceeded is sent back to the client.

Tested manually by reloading Scylla multiple times and editing the config, while bombarding alternator with many concurrent requests. Observed excepted failures are:
`botocore.errorfactory.RequestLimitExceeded: An error occurred (RequestLimitExceeded) when calling the CreateTable operation: too many in-flight requests: 17
`

Fixes #7294