### PR TITLE
lsa: background reclaim

### DIFF
--- a/utils/logalloc.cc
+++ b/utils/logalloc.cc
@@ -1012,7 +1012,7 @@ void segment_pool::prime(size_t available_memory, size_t min_free_memory) {
     // We want to leave more free memory than just min_free_memory() in order to reduce
     // the frequency of expensive segment-migrating reclaim() called by the seastar allocator.
     size_t min_gap = 1 * 1024 * 1024;
-    size_t max_gap = 64 * 1024 * 1024;
+    size_t max_gap = 32 * 1024 * 1024;
     size_t gap = std::min(max_gap, std::max(available_memory / 16, min_gap));
     _store.non_lsa_reserve = min_free_memory + gap;
     // Since the reclaimer is not yet in place, free some low memory for general use

--- a/utils/logalloc.hh
+++ b/utils/logalloc.hh
@@ -449,9 +449,11 @@ public:
         bool defragment_on_idle;
         bool abort_on_lsa_bad_alloc;
         size_t lsa_reclamation_step;
+        scheduling_group background_reclaim_sched_group;
     };
 
     void configure(const config& cfg);
+    future<> stop();
 
 private:
     std::unique_ptr<impl> _impl;


### PR DESCRIPTION
This series adds background reclaim to lsa, with the goal
that most large allocations can be satisfied from available
free memory, and and reclaim work can be done from a preemptible
context.

If the workload has free cpu, then background reclaim will
utilize that free cpu, reducing latency for the main workload.
Otherwise, background reclaim will compete with the main
workload, but since that work needs to happen anyway,
throughput will not be reduced.

A unit test is added to verify it works.

Fixes #1634.
