### PR TITLE
test: add missing #include <fstream>

### DIFF
--- a/test/perf/perf_fast_forward.cc
+++ b/test/perf/perf_fast_forward.cc
@@ -40,6 +40,7 @@
 #include "sstables/compaction_manager.hh"
 #include "transport/messages/result_message.hh"
 #include "sstables/shared_index_lists.hh"
+#include <fstream>
 
 using namespace std::chrono_literals;
 using namespace seastar;

--- a/test/perf/perf_simple_query.cc
+++ b/test/perf/perf_simple_query.cc
@@ -29,6 +29,7 @@
 #include <seastar/testing/test_runner.hh>
 #include "schema_builder.hh"
 #include "release.hh"
+#include <fstream>
 
 static const sstring table_name = "cf";
 

--- a/test/tools/cql_repl.cc
+++ b/test/tools/cql_repl.cc
@@ -19,6 +19,7 @@
  * along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
  */
 #include <filesystem>
+#include <fstream>
 // use boost::regex instead of std::regex due
 // to stack overflow in debug mode
 #include <boost/regex.hpp>


### PR DESCRIPTION
std::ofstream is used, but there is no direct include for it. This
fails the build with libstdc++ 11.