### PR TITLE
messaging_service: Enforce dc/rack membership iff required for non-tl…

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -772,6 +772,13 @@ int main(int ac, char** av) {
                 mscfg.encrypt = netw::messaging_service::encrypt_what::rack;
             }
 
+            if (clauth && (mscfg.encrypt == netw::messaging_service::encrypt_what::dc || mscfg.encrypt == netw::messaging_service::encrypt_what::dc)) {
+                startlog.warn("Setting require_client_auth is incompatible with 'rack' and 'dc' internode_encryption values."
+                    " To ensure that mutual TLS authentication is enforced, please set internode_encryption to 'all'. Continuing with"
+                    " potentially insecure configuration."
+                );
+            }
+
             sstring compress_what = cfg->internode_compression();
             if (compress_what == "all") {
                 mscfg.compress = netw::messaging_service::compress_what::all;


### PR DESCRIPTION
…s connections

When internode_encryption is "rack" or "dc", we should enforce incoming
connections are from the appropriate address spaces iff answering on
non-tls socket.

This is implemented by having two protocol handlers. One for tls/full notls,
and one for mixed (needs checking) connections. The latter will ask
snitch if remote address is kosher, and refuse the connection otherwise.

Note: requires seastar patches:
"rpc: Make is possible for rpc server instance to refuse connection"
"RPC: (client) retain local address and use on stream creation"

Note that ip-level checks are not exhaustive. If a user is also using
"require_client_auth" with dc/rack tls setting we should warn him that
there is a possibility that someone could spoof himself pass the
authentication.

v2:
* Use options filter callback
v3:
* Force gossip to always use TLS in mixed mode, to work around
  mismatched knowlegde on which rack/dc client/server is in
* Fix streams not binding to broadcast
* Fix rack rule to also check dc, since racks can have same
  name in several dc:s