### PR TITLE
Minor tweaks to the failure detector interface

### DIFF
--- a/gms/failure_detector.hh
+++ b/gms/failure_detector.hh
@@ -138,7 +138,7 @@ public:
             : _phi(phi), _initial(initial), _max_interval(max_interval) {
     }
 
-    std::map<inet_address, arrival_window> arrival_samples() const {
+    const std::map<inet_address, arrival_window>& arrival_samples() const {
         return _arrival_samples;
     }
 

--- a/gms/failure_detector.hh
+++ b/gms/failure_detector.hh
@@ -89,6 +89,8 @@ public:
 
     size_t size() { return _arrival_intervals.size(); }
 
+    clk::time_point last_update() const { return _tlast; }
+
     friend std::ostream& operator<<(std::ostream& os, const arrival_window& w);
 
 };

--- a/gms/failure_detector.hh
+++ b/gms/failure_detector.hh
@@ -171,8 +171,6 @@ public:
 
     double get_phi_convict_threshold();
 
-    bool is_alive(inet_address ep);
-
     void report(inet_address ep);
 
     void interpret(inet_address ep);


### PR DESCRIPTION
The interface of the failure detector service is cleaned up a little:
 - an unimplemented method is removed (is_alive)
 - a return type of another method is fixed (arrival_samples)
 - a getter for the most recent successful update is added (last_update)

This code was tested manually during various overload protection experiments, which check if the failure detector can be used to reject requests which have a very small chance of succeeding within their timeout.