### PR TITLE
dist/debian: install scylla-node-exporter.service correctly

### DIFF
--- a/dist/debian/debian/rules
+++ b/dist/debian/debian/rules
@@ -33,7 +33,7 @@ endif
 	dh_installinit --no-start --name scylla-housekeeping-daily
 	dh_installinit --no-start --name scylla-housekeeping-restart
 	dh_installinit --no-start --name scylla-fstrim
-	dh_installinit --no-start --name node-exporter
+	dh_installinit --no-start --name scylla-node-exporter
 
 override_dh_strip:
 	# The binaries (ethtool...patchelf) don't pass dh_strip after going through patchelf. Since they are


### PR DESCRIPTION
node-exporter systemd unit name is "scylla-node-exporter.service", not
"node-exporter.service".

Fixes #8054