### PR TITLE
locator: Check DC names in NetworkTopologyStrategy

### DIFF
--- a/locator/network_topology_strategy.cc
+++ b/locator/network_topology_strategy.cc
@@ -273,8 +273,12 @@ void network_topology_strategy::validate_options() const {
 }
 
 std::optional<std::set<sstring>> network_topology_strategy::recognized_options() const {
-    // We explicitely allow all options
-    return std::nullopt;
+    std::set<sstring> datacenters;
+    for (const auto& [dc_name, endpoints] : _shared_token_metadata.get()->get_topology().get_datacenter_endpoints()) {
+        datacenters.insert(dc_name);
+    }
+    // We only allow datacenter names as options
+    return datacenters;
 }
 
 using registry = class_registrator<abstract_replication_strategy, network_topology_strategy, const sstring&, const shared_token_metadata&, snitch_ptr&, const std::map<sstring, sstring>&>;

--- a/test/boost/cql_query_test.cc
+++ b/test/boost/cql_query_test.cc
@@ -3658,19 +3658,9 @@ SEASTAR_TEST_CASE(test_rf_expand) {
             {"datacenter1", "3"}
         });
 
-        e.execute_cql("CREATE KEYSPACE rf_expand_3 WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 3}").get();
-        assert_replication_contains("rf_expand_3", {
-            {"class", simple},
-            {"replication_factor", "3"}
-        });
-
-        // Should not auto-expand when switching to NetworkTopologyStrategy with additional options.
-        e.execute_cql("ALTER KEYSPACE rf_expand_3 WITH replication = {'class': 'NetworkTopologyStrategy', 'datacenter2': 2}").get();
-        assert_replication_not_contains("rf_expand_3", {"datacenter1"});
-
         // Respect factors specified manually.
-        e.execute_cql("CREATE KEYSPACE rf_expand_4 WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3, 'datacenter1': 2}").get();
-        assert_replication_contains("rf_expand_4", {
+        e.execute_cql("CREATE KEYSPACE rf_expand_3 WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3, 'datacenter1': 2}").get();
+        assert_replication_contains("rf_expand_3", {
             {"class", network_topology},
             {"datacenter1", "2"}
         });

--- a/test/cql/locator_test.cql
+++ b/test/cql/locator_test.cql
@@ -1,25 +1,9 @@
 --
--- https://github.com/scylladb/scylla/issues/5935
--- crash if all_replicas is empty test we work well when the list of
--- natural endpoints is empty
+-- https://github.com/scylladb/scylla/issues/7595
+-- Fail on wrong DC name
 --
-CREATE KEYSPACE t WITH REPLICATION = { 'class' : 'NetworkTopologyStrategy', 'nosuchdc' : 3 } AND DURABLE_WRITES =  true;
-CREATE TABLE t.t (a INT PRIMARY KEY, b int);
-INSERT INTO t.t (a, b) VALUES (1, 1);
-INSERT INTO t.t (a, b) VALUES (2, 2);
-SELECT * FROM t.t ALLOW FILTERING;
--- This statement used to trigger a crash
-SELECT a FROM t.t WHERE a IN (1, 2);
-DELETE FROM t.t WHERE a = 1;
-DELETE FROM t.t WHERE a = 2;
-CREATE INDEX b ON t.t (b);
-SELECT * FROM t.t WHERE b=2;
-INSERT INTO t.t (a) VALUES (1) IF NOT EXISTS;
-DELETE FROM t.t WHERE a=1 IF EXISTS;
-CREATE MATERIALIZED VIEW t.mv AS SELECT a, b FROM t.t WHERE b > 1 PRIMARY KEY (b, a);
-SELECT * FROM t.mv WHERE b IN (2, 1);
-DROP MATERIALIZED VIEW t.mv;
-DROP TABLE t.t;
+CREATE KEYSPACE t WITH REPLICATION = { 'class' : 'NetworkTopologyStrategy', 'nosuchdc' : 3 } AND DURABLE_WRITES = true;
+CREATE KEYSPACE t WITH REPLICATION = { 'class' : 'NetworkTopologyStrategy', 'datacenter1' : 3 } AND DURABLE_WRITES = true;
 DROP KEYSPACE t;
 --
 -- https://github.com/scylladb/scylla/issues/5962

--- a/test/cql/locator_test.result
+++ b/test/cql/locator_test.result
@@ -1,80 +1,13 @@
 --
--- https://github.com/scylladb/scylla/issues/5935
--- crash if all_replicas is empty test we work well when the list of
--- natural endpoints is empty
+-- https://github.com/scylladb/scylla/issues/7595
+-- Fail on wrong DC name
 --
-CREATE KEYSPACE t WITH REPLICATION = { 'class' : 'NetworkTopologyStrategy', 'nosuchdc' : 3 } AND DURABLE_WRITES =  true;
+CREATE KEYSPACE t WITH REPLICATION = { 'class' : 'NetworkTopologyStrategy', 'nosuchdc' : 3 } AND DURABLE_WRITES = true;
 {
-	"status" : "ok"
-}
-CREATE TABLE t.t (a INT PRIMARY KEY, b int);
-{
-	"status" : "ok"
-}
-INSERT INTO t.t (a, b) VALUES (1, 1);
-{
-	"message" : "exceptions::unavailable_exception (Cannot achieve consistency level for cl ONE. Requires 1, alive 0)",
+	"message" : "exceptions::configuration_exception (Unrecognized strategy option {nosuchdc} passed to org.apache.cassandra.locator.NetworkTopologyStrategy for keyspace t)",
 	"status" : "error"
 }
-INSERT INTO t.t (a, b) VALUES (2, 2);
-{
-	"message" : "exceptions::unavailable_exception (Cannot achieve consistency level for cl ONE. Requires 1, alive 0)",
-	"status" : "error"
-}
-SELECT * FROM t.t ALLOW FILTERING;
-{
-	"message" : "exceptions::unavailable_exception (Cannot achieve consistency level for cl ONE. Requires 1, alive 0)",
-	"status" : "error"
-}
--- This statement used to trigger a crash
-SELECT a FROM t.t WHERE a IN (1, 2);
-{
-	"message" : "exceptions::unavailable_exception (Cannot achieve consistency level for cl ONE. Requires 1, alive 0)",
-	"status" : "error"
-}
-DELETE FROM t.t WHERE a = 1;
-{
-	"message" : "exceptions::unavailable_exception (Cannot achieve consistency level for cl ONE. Requires 1, alive 0)",
-	"status" : "error"
-}
-DELETE FROM t.t WHERE a = 2;
-{
-	"message" : "exceptions::unavailable_exception (Cannot achieve consistency level for cl ONE. Requires 1, alive 0)",
-	"status" : "error"
-}
-CREATE INDEX b ON t.t (b);
-{
-	"status" : "ok"
-}
-SELECT * FROM t.t WHERE b=2;
-{
-	"message" : "exceptions::unavailable_exception (Cannot achieve consistency level for cl ONE. Requires 1, alive 0)",
-	"status" : "error"
-}
-INSERT INTO t.t (a) VALUES (1) IF NOT EXISTS;
-{
-	"message" : "exceptions::unavailable_exception (Cannot achieve consistency level for cl SERIAL. Requires 1, alive 0)",
-	"status" : "error"
-}
-DELETE FROM t.t WHERE a=1 IF EXISTS;
-{
-	"message" : "exceptions::unavailable_exception (Cannot achieve consistency level for cl SERIAL. Requires 1, alive 0)",
-	"status" : "error"
-}
-CREATE MATERIALIZED VIEW t.mv AS SELECT a, b FROM t.t WHERE b > 1 PRIMARY KEY (b, a);
-{
-	"status" : "ok"
-}
-SELECT * FROM t.mv WHERE b IN (2, 1);
-{
-	"message" : "exceptions::unavailable_exception (Cannot achieve consistency level for cl ONE. Requires 1, alive 0)",
-	"status" : "error"
-}
-DROP MATERIALIZED VIEW t.mv;
-{
-	"status" : "ok"
-}
-DROP TABLE t.t;
+CREATE KEYSPACE t WITH REPLICATION = { 'class' : 'NetworkTopologyStrategy', 'datacenter1' : 3 } AND DURABLE_WRITES = true;
 {
 	"status" : "ok"
 }


### PR DESCRIPTION
The same trick is used as in C*:
https://github.com/apache/cassandra/blob/79e693e16e2152097c5b27d2d7aaa1763e34f594/src/java/org/apache/cassandra/locator/NetworkTopologyStrategy.java#L241

The edited CQL test relied on quietly accepting non-existing DCs, so it had to be removed. Also, one boost-test referred to nonexistent `datacenter2` and had to be removed.

Fixes #7595