### PR TITLE
Alternator: support nested attribute paths in all expressions

### DIFF
--- a/alternator/conditions.cc
+++ b/alternator/conditions.cc
@@ -159,23 +159,40 @@ static bool check_NE(const rjson::value* v1, const rjson::value& v2) {
 }
 
 // Check if two JSON-encoded values match with the BEGINS_WITH relation
-static bool check_BEGINS_WITH(const rjson::value* v1, const rjson::value& v2) {
-    // BEGINS_WITH requires that its single operand (v2) be a string or
-    // binary - otherwise it's a validation error. However, problems with
-    // the stored attribute (v1) will just return false (no match).
-    if (!v2.IsObject() || v2.MemberCount() != 1) {
-        throw api_error::validation(format("BEGINS_WITH operator encountered malformed AttributeValue: {}", v2));
-    }
-    auto it2 = v2.MemberBegin();
-    if (it2->name != "S" && it2->name != "B") {
-        throw api_error::validation(format("BEGINS_WITH operator requires String or Binary type in AttributeValue, got {}", it2->name));
-    }
-
-
+bool check_BEGINS_WITH(const rjson::value* v1, const rjson::value& v2,
+                       bool v1_from_query, bool v2_from_query) {
+    bool bad = false;
     if (!v1 || !v1->IsObject() || v1->MemberCount() != 1) {
+        if (v1_from_query) {
+            throw api_error::validation("begins_with() encountered malformed argument");
+        } else {
+            bad = true;
+        }
+    } else if (v1->MemberBegin()->name != "S" && v1->MemberBegin()->name != "B") {
+        if (v1_from_query) {
+            throw api_error::validation(format("begins_with supports only string or binary type, got: {}", *v1));
+        } else {
+            bad = true;
+        }
+    }
+    if (!v2.IsObject() || v2.MemberCount() != 1) {
+        if (v2_from_query) {
+            throw api_error::validation("begins_with() encountered malformed argument");
+        } else {
+            bad = true;
+        }
+    } else if (v2.MemberBegin()->name != "S" && v2.MemberBegin()->name != "B") {
+        if (v2_from_query) {
+            throw api_error::validation(format("begins_with() supports only string or binary type, got: {}", v2));
+        } else {
+            bad = true;
+        }
+    }
+    if (bad) {
         return false;
     }
     auto it1 = v1->MemberBegin();
+    auto it2 = v2.MemberBegin();
     if (it1->name != it2->name) {
         return false;
     }
@@ -279,24 +296,38 @@ static bool check_NOT_NULL(const rjson::value* val) {
     return val != nullptr;
 }
 
+// Only types S, N or B (string, number or bytes) may be compared by the
+// various comparion operators - lt, le, gt, ge, and between.
+static bool check_comparable_type(const rjson::value& v) {
+    if (!v.IsObject() || v.MemberCount() != 1) {
+        return false;
+    }
+    const rjson::value& type = v.MemberBegin()->name;
+    return type == "S" || type == "N" || type == "B";
+}
+
 // Check if two JSON-encoded values match with cmp.
 template <typename Comparator>
-bool check_compare(const rjson::value* v1, const rjson::value& v2, const Comparator& cmp) {
-    if (!v2.IsObject() || v2.MemberCount() != 1) {
-        throw api_error::validation(
-                        format("{} requires a single AttributeValue of type String, Number, or Binary",
-                               cmp.diagnostic));
+bool check_compare(const rjson::value* v1, const rjson::value& v2, const Comparator& cmp,
+                   bool v1_from_query, bool v2_from_query) {
+    bool bad = false;
+    if (!v1 || !check_comparable_type(*v1)) {
+        if (v1_from_query) {
+            throw api_error::validation(format("{} allow only the types String, Number, or Binary", cmp.diagnostic));
+        }
+        bad = true;
     }
-    const auto& kv2 = *v2.MemberBegin();
-    if (kv2.name != "S" && kv2.name != "N" && kv2.name != "B") {
-        throw api_error::validation(
-                        format("{} requires a single AttributeValue of type String, Number, or Binary",
-                               cmp.diagnostic));
+    if (!check_comparable_type(v2)) {
+        if (v2_from_query) {
+            throw api_error::validation(format("{} allow only the types String, Number, or Binary", cmp.diagnostic));
+        }
+        bad = true;
     }
-    if (!v1 || !v1->IsObject() || v1->MemberCount() != 1) {
+    if (bad) {
         return false;
     }
     const auto& kv1 = *v1->MemberBegin();
+    const auto& kv2 = *v2.MemberBegin();
     if (kv1.name != kv2.name) {
         return false;
     }
@@ -310,7 +341,8 @@ bool check_compare(const rjson::value* v1, const rjson::value& v2, const Compara
     if (kv1.name == "B") {
         return cmp(base64_decode(kv1.value), base64_decode(kv2.value));
     }
-    clogger.error("check_compare panic: LHS type equals RHS type, but one is in {N,S,B} while the other isn't");
+    // cannot reach here, as check_comparable_type() verifies the type is one
+    // of the above options.
     return false;
 }
 
@@ -341,56 +373,71 @@ struct cmp_gt {
     static constexpr const char* diagnostic = "GT operator";
 };
 
-// True if v is between lb and ub, inclusive.  Throws if lb > ub.
+// True if v is between lb and ub, inclusive.  Throws or returns false
+// (depending on bounds_from_query parameter) if lb > ub.
 template <typename T>
-static bool check_BETWEEN(const T& v, const T& lb, const T& ub) {
+static bool check_BETWEEN(const T& v, const T& lb, const T& ub, bool bounds_from_query) {
     if (cmp_lt()(ub, lb)) {
-        throw api_error::validation(
-                        format("BETWEEN operator requires lower_bound <= upper_bound, but {} > {}", lb, ub));
+        if (bounds_from_query) {
+            throw api_error::validation(
+                format("BETWEEN operator requires lower_bound <= upper_bound, but {} > {}", lb, ub));
+        } else {
+            return false;
+        }
     }
     return cmp_ge()(v, lb) && cmp_le()(v, ub);
 }
 
-static bool check_BETWEEN(const rjson::value* v, const rjson::value& lb, const rjson::value& ub) {
-    if (!v) {
+static bool check_BETWEEN(const rjson::value* v, const rjson::value& lb, const rjson::value& ub,
+                          bool v_from_query, bool lb_from_query, bool ub_from_query) {
+    if ((v && v_from_query && !check_comparable_type(*v)) ||
+        (lb_from_query && !check_comparable_type(lb)) ||
+        (ub_from_query && !check_comparable_type(ub))) {
+        throw api_error::validation("between allow only the types String, Number, or Binary");
+
+    }
+    if (!v || !v->IsObject() || v->MemberCount() != 1 ||
+        !lb.IsObject() || lb.MemberCount() != 1 ||
+        !ub.IsObject() || ub.MemberCount() != 1) {
         return false;
-    }
-    if (!v->IsObject() || v->MemberCount() != 1) {
-        throw api_error::validation(format("BETWEEN operator encountered malformed AttributeValue: {}", *v));
-    }
-    if (!lb.IsObject() || lb.MemberCount() != 1) {
-        throw api_error::validation(format("BETWEEN operator encountered malformed AttributeValue: {}", lb));
-    }
-    if (!ub.IsObject() || ub.MemberCount() != 1) {
-        throw api_error::validation(format("BETWEEN operator encountered malformed AttributeValue: {}", ub));
     }
 
     const auto& kv_v = *v->MemberBegin();
     const auto& kv_lb = *lb.MemberBegin();
     const auto& kv_ub = *ub.MemberBegin();
+    bool bounds_from_query = lb_from_query && ub_from_query;
     if (kv_lb.name != kv_ub.name) {
-        throw api_error::validation(
+        if (bounds_from_query) {
+           throw api_error::validation(
                 format("BETWEEN operator requires the same type for lower and upper bound; instead got {} and {}",
                        kv_lb.name, kv_ub.name));
+        } else {
+            return false;
+        }
     }
     if (kv_v.name != kv_lb.name) { // Cannot compare different types, so v is NOT between lb and ub.
         return false;
     }
     if (kv_v.name == "N") {
         const char* diag = "BETWEEN operator";
-        return check_BETWEEN(unwrap_number(*v, diag), unwrap_number(lb, diag), unwrap_number(ub, diag));
+        return check_BETWEEN(unwrap_number(*v, diag), unwrap_number(lb, diag), unwrap_number(ub, diag), bounds_from_query);
     }
     if (kv_v.name == "S") {
         return check_BETWEEN(std::string_view(kv_v.value.GetString(), kv_v.value.GetStringLength()),
                              std::string_view(kv_lb.value.GetString(), kv_lb.value.GetStringLength()),
-                             std::string_view(kv_ub.value.GetString(), kv_ub.value.GetStringLength()));
+                             std::string_view(kv_ub.value.GetString(), kv_ub.value.GetStringLength()),
+                             bounds_from_query);
     }
     if (kv_v.name == "B") {
-        return check_BETWEEN(base64_decode(kv_v.value), base64_decode(kv_lb.value), base64_decode(kv_ub.value));
+        return check_BETWEEN(base64_decode(kv_v.value), base64_decode(kv_lb.value), base64_decode(kv_ub.value), bounds_from_query);
     }
-    throw api_error::validation(
-        format("BETWEEN operator requires AttributeValueList elements to be of type String, Number, or Binary; instead got {}",
+    if (v_from_query) {
+        throw api_error::validation(
+            format("BETWEEN operator requires AttributeValueList elements to be of type String, Number, or Binary; instead got {}",
                kv_lb.name));
+    } else {
+        return false;
+    }
 }
 
 // Verify one Expect condition on one attribute (whose content is "got")
@@ -437,19 +484,19 @@ static bool verify_expected_one(const rjson::value& condition, const rjson::valu
             return check_NE(got, (*attribute_value_list)[0]);
         case comparison_operator_type::LT:
             verify_operand_count(attribute_value_list, exact_size(1), *comparison_operator);
-            return check_compare(got, (*attribute_value_list)[0], cmp_lt{});
+            return check_compare(got, (*attribute_value_list)[0], cmp_lt{}, false, true);
         case comparison_operator_type::LE:
             verify_operand_count(attribute_value_list, exact_size(1), *comparison_operator);
-            return check_compare(got, (*attribute_value_list)[0], cmp_le{});
+            return check_compare(got, (*attribute_value_list)[0], cmp_le{}, false, true);
         case comparison_operator_type::GT:
             verify_operand_count(attribute_value_list, exact_size(1), *comparison_operator);
-            return check_compare(got, (*attribute_value_list)[0], cmp_gt{});
+            return check_compare(got, (*attribute_value_list)[0], cmp_gt{}, false, true);
         case comparison_operator_type::GE:
             verify_operand_count(attribute_value_list, exact_size(1), *comparison_operator);
-            return check_compare(got, (*attribute_value_list)[0], cmp_ge{});
+            return check_compare(got, (*attribute_value_list)[0], cmp_ge{}, false, true);
         case comparison_operator_type::BEGINS_WITH:
             verify_operand_count(attribute_value_list, exact_size(1), *comparison_operator);
-            return check_BEGINS_WITH(got, (*attribute_value_list)[0]);
+            return check_BEGINS_WITH(got, (*attribute_value_list)[0], false, true);
         case comparison_operator_type::IN:
             verify_operand_count(attribute_value_list, nonempty(), *comparison_operator);
             return check_IN(got, *attribute_value_list);
@@ -461,7 +508,8 @@ static bool verify_expected_one(const rjson::value& condition, const rjson::valu
             return check_NOT_NULL(got);
         case comparison_operator_type::BETWEEN:
             verify_operand_count(attribute_value_list, exact_size(2), *comparison_operator);
-            return check_BETWEEN(got, (*attribute_value_list)[0], (*attribute_value_list)[1]);
+            return check_BETWEEN(got, (*attribute_value_list)[0], (*attribute_value_list)[1],
+                                 false, true, true);
         case comparison_operator_type::CONTAINS:
             {
                 verify_operand_count(attribute_value_list, exact_size(1), *comparison_operator);
@@ -573,7 +621,8 @@ static bool calculate_primitive_condition(const parsed::primitive_condition& con
             // Shouldn't happen unless we have a bug in the parser
             throw std::logic_error(format("Wrong number of values {} in BETWEEN primitive_condition", cond._values.size()));
         }
-        return check_BETWEEN(&calculated_values[0], calculated_values[1], calculated_values[2]);
+        return check_BETWEEN(&calculated_values[0], calculated_values[1], calculated_values[2],
+                             cond._values[0].is_constant(), cond._values[1].is_constant(), cond._values[2].is_constant());
     case parsed::primitive_condition::type::IN:
         return check_IN(calculated_values);
     case parsed::primitive_condition::type::VALUE:
@@ -604,13 +653,17 @@ static bool calculate_primitive_condition(const parsed::primitive_condition& con
     case parsed::primitive_condition::type::NE:
         return check_NE(&calculated_values[0], calculated_values[1]);
     case parsed::primitive_condition::type::GT:
-        return check_compare(&calculated_values[0], calculated_values[1], cmp_gt{});
+        return check_compare(&calculated_values[0], calculated_values[1], cmp_gt{},
+            cond._values[0].is_constant(), cond._values[1].is_constant());
     case parsed::primitive_condition::type::GE:
-        return check_compare(&calculated_values[0], calculated_values[1], cmp_ge{});
+        return check_compare(&calculated_values[0], calculated_values[1], cmp_ge{},
+            cond._values[0].is_constant(), cond._values[1].is_constant());
     case parsed::primitive_condition::type::LT:
-        return check_compare(&calculated_values[0], calculated_values[1], cmp_lt{});
+        return check_compare(&calculated_values[0], calculated_values[1], cmp_lt{},
+            cond._values[0].is_constant(), cond._values[1].is_constant());
     case parsed::primitive_condition::type::LE:
-        return check_compare(&calculated_values[0], calculated_values[1], cmp_le{});
+        return check_compare(&calculated_values[0], calculated_values[1], cmp_le{},
+            cond._values[0].is_constant(), cond._values[1].is_constant());
     default:
         // Shouldn't happen unless we have a bug in the parser
         throw std::logic_error(format("Unknown type {} in primitive_condition object", (int)(cond._op)));

--- a/alternator/conditions.hh
+++ b/alternator/conditions.hh
@@ -52,6 +52,7 @@ bool verify_expected(const rjson::value& req, const rjson::value* previous_item)
 bool verify_condition(const rjson::value& condition, bool require_all, const rjson::value* previous_item);
 
 bool check_CONTAINS(const rjson::value* v1, const rjson::value& v2);
+bool check_BEGINS_WITH(const rjson::value* v1, const rjson::value& v2, bool v1_from_query, bool v2_from_query);
 
 bool verify_condition_expression(
         const parsed::condition_expression& condition_expression,

--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -2556,7 +2556,7 @@ update_item_operation::apply(std::unique_ptr<rjson::value> previous_item, api::t
     // can just move previous_item later, when we don't need it any more.
     if (_returnvalues == returnvalues::ALL_NEW) {
         if (previous_item) {
-            _return_attributes = std::move(*previous_item);
+            _return_attributes = rjson::copy(*previous_item);
         } else {
             // If there is no previous item, usually a new item is created
             // and contains they given key. This may be cancelled at the end

--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -1882,6 +1882,70 @@ static std::string get_item_type_string(const rjson::value& v) {
     return it->name.GetString();
 }
 
+bool hierarchy_filter::filter(rjson::value& val) {
+    // Importantly, val is a DynamoDB-encoded JSON object - it's a map whose
+    // key is the type, and the value is the actual object.
+    if (!val.IsObject() || val.MemberCount() != 1) {
+        // This shouldn't happen. We shouldn't have stored malformed objects.
+        // But today Alternator does not validate the structure of nested
+        // documents before storing them, so this can happen on read.
+        throw api_error::validation(format("Malformed value object for filtering: {}", val));
+    }
+    const char* type = val.MemberBegin()->name.GetString();
+    rjson::value& v = val.MemberBegin()->value;
+    if (!members.empty()) {
+        if (type[0] != 'M' || !v.IsObject()) {
+            // If v is not an object (dictionary, map), none of the members
+            // can match. We return immediately because we assume that either
+            // members or indexes are set, but not both.
+            return false;
+        }
+        rjson::value newv = rjson::empty_object();
+        for (auto it = v.MemberBegin(); it != v.MemberEnd(); ++it) {
+            std::string attr = it->name.GetString();
+            auto h = members.find(attr);
+            if (h != members.end()) {
+                if (h->second) {
+                    // Only a part of this attribute is to be filtered, do it.
+                    if (h->second->filter(it->value)) {
+                        rjson::set_with_string_name(newv, attr, std::move(it->value));
+                    }
+                } else {
+                    // The entire attribute is to be kept
+                    rjson::set_with_string_name(newv, attr, std::move(it->value));
+                }
+            }
+        }
+        if (newv.MemberCount() == 0) {
+            return false;
+        }
+        v = newv;
+    } else if (!indexes.empty()) {
+        if (type[0] != 'L' || !v.IsArray()) {
+            return false;
+        }
+        rjson::value newv = rjson::empty_array();
+        const auto& a = v.GetArray();
+        for (unsigned i = 0; i < v.Size(); i++) {
+            auto h = indexes.find(i);
+            if (h != indexes.end()) {
+                if (h->second) {
+                    if (h->second->filter(a[i])) {
+                        rjson::push_back(newv, std::move(a[i]));
+                    }
+                } else {
+                    // The entire attribute is to be kept
+                    rjson::push_back(newv, std::move(a[i]));
+                }
+            }
+        }
+        if (newv.Size() == 0) {
+            return false;
+        }
+        v = newv;
+    }
+    return true;
+}
 void hierarchy_filter::add(const parsed::path& p) {
     hierarchy_filter* h = this;
     // new_level is false if the previous iteration of the loop below found
@@ -2058,7 +2122,16 @@ void executor::describe_single_item(const cql3::selection::selection& selection,
                 std::string attr_name = value_cast<sstring>(entry.first);
                 if (include_all_embedded_attributes || attrs_to_get.empty() || attrs_to_get.contains(attr_name)) {
                     bytes value = value_cast<bytes>(entry.second);
-                    rjson::set_with_string_name(item, attr_name, deserialize_item(value));
+                    rjson::value v = deserialize_item(value);
+                    auto it = attrs_to_get.find(attr_name);
+                    if (it != attrs_to_get.end() && it->second) {
+                        // attrs_to_get asked for only part of this attribute:
+                        if (it->second->filter(v)) {
+                            rjson::set_with_string_name(item, attr_name, std::move(v));
+                        }
+                    } else {
+                        rjson::set_with_string_name(item, attr_name, std::move(v));
+                    }
                 }
             }
         }
@@ -2834,6 +2907,12 @@ public:
                     std::string attr_name = value_cast<sstring>(entry.first);
                     if (_attrs_to_get.empty() || _attrs_to_get.contains(attr_name) || _extra_filter_attrs.contains(attr_name)) {
                         bytes value = value_cast<bytes>(entry.second);
+                        // Even if _attrs_to_get asked to keep only a part of a
+                        // top-level attribute, we keep the entire attribute
+                        // at this stage, because the item filter might still
+                        // need the other parts (it was easier for us to keep
+                        // extra_filter_attrs at top-level granularity). We'll
+                        // filter the unneeded parts after item filtering.
                         rjson::set_with_string_name(_item, attr_name, deserialize_item(value));
                     }
                 }
@@ -2844,11 +2923,24 @@ public:
 
     void end_row() {
         if (_filter.check(_item)) {
+            // As noted above, we kept entire top-level attributes listed in
+            // _attrs_to_get. We may need to only keep parts of them.
+            for (const auto& attr: _attrs_to_get) {
+                if (attr.second) {
+                    rjson::value* toplevel= rjson::find(_item, attr.first);
+                    // filter() either modifies toplevel_attr directly, or
+                    // asks us to delete it:
+                    if (toplevel && !attr.second->filter(*toplevel)) {
+                        rjson::remove_member(_item, attr.first);
+                    }
+                }
+            }
             // Remove the extra attributes _extra_filter_attrs which we had
             // to add just for the filter, and not requested to be returned:
             for (const auto& attr : _extra_filter_attrs) {
                 rjson::remove_member(_item, attr);
             }
+
             rjson::push_back(_items, std::move(_item));
         }
         _item = rjson::empty_object();

--- a/alternator/executor.hh
+++ b/alternator/executor.hh
@@ -90,7 +90,14 @@ struct hierarchy_filter {
     // "overlaps" with one already in the filter (one is a sub-path
     // of the other) or "conflicts" with it (both a member and index is
     // requested).
-    void add(const parsed::path& p);
+    void add(const parsed::path&);
+    // Run the filter on a given JSON object, dropping its parts which
+    // weren't asked to be kept. Modifies the given JSON object, or
+    // returns false to signify the entire object should be dropped.
+    // Important note: The JSON object is assumed to be using the DynamoDB
+    // conventions, i.e., it is really a map whose key has a type string,
+    // and the value is the real object.
+    bool filter(rjson::value&);
 };
 
 // We use lw_shared_ptr<hierarchy_filter>  allows us to efficiently represent

--- a/alternator/executor.hh
+++ b/alternator/executor.hh
@@ -111,8 +111,11 @@ public:
     // std::unique_ptr<> because it makes the entire object uncopyable. We
     // don't often need to copy such a map, but we do have some code that
     // copies an attrs_to_get object, and is hard to find and remove.
+    // The shared_ptr should never be null.
     using members_t =  std::unordered_map<std::string, seastar::shared_ptr<attribute_path_map_node<T>>>;
-    using indexes_t = std::unordered_map<unsigned, seastar::shared_ptr<attribute_path_map_node<T>>>;
+    // The indexes list is sorted because DynamoDB requires handling writes
+    // beyond the end of a list in index order.
+    using indexes_t = std::map<unsigned, seastar::shared_ptr<attribute_path_map_node<T>>>;
     // The prohibition on "overlap" and "conflict" explained above means
     // That only one of data, members or indexes is non-empty.
     std::optional<std::variant<data_t, members_t, indexes_t>> _content;

--- a/alternator/executor.hh
+++ b/alternator/executor.hh
@@ -126,6 +126,8 @@ public:
     const members_t& get_members() const { return std::get<members_t>(*_content); }
     indexes_t& get_indexes() { return std::get<indexes_t>(*_content); }
     const indexes_t& get_indexes() const { return std::get<indexes_t>(*_content); }
+    T& get_value() { return std::get<T>(*_content); }
+    const T& get_value() const { return std::get<T>(*_content); }
 };
 
 template<typename T>

--- a/alternator/expressions.cc
+++ b/alternator/expressions.cc
@@ -130,6 +130,12 @@ void condition_expression::append(condition_expression&& a, char op) {
     }, _expression);
 }
 
+void path::check_depth_limit() {
+    if (1 + _operators.size() > depth_limit) {
+        throw expressions_syntax_error(format("Document path exceeded {} nesting levels", depth_limit));
+    }
+}
+
 std::ostream& operator<<(std::ostream& os, const path& p) {
     os << p.root();
     for (const auto& op : p.operators()) {

--- a/alternator/expressions.cc
+++ b/alternator/expressions.cc
@@ -130,6 +130,21 @@ void condition_expression::append(condition_expression&& a, char op) {
     }, _expression);
 }
 
+std::ostream& operator<<(std::ostream& os, const path& p) {
+    os << p.root();
+    for (const auto& op : p.operators()) {
+        std::visit(overloaded_functor {
+            [&] (const std::string& member) {
+                os << '.' << member;
+            },
+            [&] (unsigned index) {
+                os << '[' << index << ']';
+            }
+        }, op);
+    }
+    return os;
+}
+
 } // namespace parsed
 
 // The following resolve_*() functions resolve references in parsed

--- a/alternator/expressions.cc
+++ b/alternator/expressions.cc
@@ -603,52 +603,8 @@ std::unordered_map<std::string_view, function_handler_type*> function_handlers {
             }
             rjson::value v1 = calculate_value(f._parameters[0], caller, previous_item);
             rjson::value v2 = calculate_value(f._parameters[1], caller, previous_item);
-            // TODO: There's duplication here with check_BEGINS_WITH().
-            // But unfortunately, the two functions differ a bit.
-
-            // If one of v1 or v2 is malformed or has an unsupported type
-            // (not B or S), what we do depends on whether it came from
-            // the user's query (is_constant()), or the item. Unsupported
-            // values in the query result in an error, but if they are in
-            // the item, we silently return false (no match).
-            bool bad = false;
-            if (!v1.IsObject() || v1.MemberCount() != 1) {
-                bad = true;
-                if (f._parameters[0].is_constant()) {
-                    throw api_error::validation(format("{}: begins_with() encountered malformed AttributeValue: {}", caller, v1));
-                }
-            } else if (v1.MemberBegin()->name != "S" && v1.MemberBegin()->name != "B") {
-                bad = true;
-                if (f._parameters[0].is_constant()) {
-                    throw api_error::validation(format("{}: begins_with() supports only string or binary in AttributeValue: {}", caller, v1));
-                }
-            }
-            if (!v2.IsObject() || v2.MemberCount() != 1) {
-                bad = true;
-                if (f._parameters[1].is_constant()) {
-                    throw api_error::validation(format("{}: begins_with() encountered malformed AttributeValue: {}", caller, v2));
-                }
-            } else if (v2.MemberBegin()->name != "S" && v2.MemberBegin()->name != "B") {
-                bad = true;
-                if (f._parameters[1].is_constant()) {
-                    throw api_error::validation(format("{}: begins_with() supports only string or binary in AttributeValue: {}", caller, v2));
-                }
-            }
-            bool ret = false;
-            if (!bad) {
-                auto it1 = v1.MemberBegin();
-                auto it2 = v2.MemberBegin();
-                if (it1->name == it2->name) {
-                    if (it2->name == "S") {
-                        std::string_view val1 = rjson::to_string_view(it1->value);
-                        std::string_view val2 = rjson::to_string_view(it2->value);
-                        ret = val1.starts_with(val2);
-                    } else /* it2->name == "B" */ {
-                        ret = base64_begins_with(rjson::to_string_view(it1->value), rjson::to_string_view(it2->value));
-                    }
-                }
-            }
-            return to_bool_json(ret);
+            return to_bool_json(check_BEGINS_WITH(v1.IsNull() ? nullptr : &v1,  v2,
+                                    f._parameters[0].is_constant(), f._parameters[1].is_constant()));
         }
     },
     {"contains", [] (calculate_value_caller caller, const rjson::value* previous_item, const parsed::value::function_call& f) {

--- a/alternator/expressions_types.hh
+++ b/alternator/expressions_types.hh
@@ -71,6 +71,7 @@ public:
     std::vector<std::variant<std::string, unsigned>>& operators() {
         return _operators;
     }
+    friend std::ostream& operator<<(std::ostream&, const path&);
 };
 
 // When an expression is first parsed, all constants are references, like

--- a/alternator/expressions_types.hh
+++ b/alternator/expressions_types.hh
@@ -68,6 +68,9 @@ public:
     const std::vector<std::variant<std::string, unsigned>>& operators() const {
         return _operators;
     }
+    std::vector<std::variant<std::string, unsigned>>& operators() {
+        return _operators;
+    }
 };
 
 // When an expression is first parsed, all constants are references, like

--- a/alternator/expressions_types.hh
+++ b/alternator/expressions_types.hh
@@ -65,6 +65,9 @@ public:
     bool has_operators() const {
         return !_operators.empty();
     }
+    const std::vector<std::variant<std::string, unsigned>>& operators() const {
+        return _operators;
+    }
 };
 
 // When an expression is first parsed, all constants are references, like

--- a/alternator/expressions_types.hh
+++ b/alternator/expressions_types.hh
@@ -49,15 +49,23 @@ class path {
     // dot (e.g., ".xyz").
     std::string _root;
     std::vector<std::variant<std::string, unsigned>> _operators;
+    // It is useful to limit the depth of a user-specified path, because is
+    // allows us to use recursive algorithms without worrying about recursion
+    // depth. DynamoDB officially limits the length of paths to 32 components
+    // (including the root) so let's use the same limit.
+    static constexpr unsigned depth_limit = 32;
+    void check_depth_limit();
 public:
     void set_root(std::string root) {
         _root = std::move(root);
     }
     void add_index(unsigned i) {
         _operators.emplace_back(i);
+        check_depth_limit();
     }
     void add_dot(std::string(name)) {
         _operators.emplace_back(std::move(name));
+        check_depth_limit();
     }
     const std::string& root() const {
         return _root;

--- a/alternator/streams.cc
+++ b/alternator/streams.cc
@@ -858,7 +858,7 @@ future<executor::request_return_type> executor::get_records(client_state& client
     auto key_names = boost::copy_range<attrs_to_get>(
         boost::range::join(std::move(base->partition_key_columns()), std::move(base->clustering_key_columns()))
         | boost::adaptors::transformed([&] (const column_definition& cdef) {
-            return std::make_pair<std::string, lw_shared_ptr<hierarchy_filter>>(cdef.name_as_text(), nullptr); })
+            return std::make_pair<std::string, attrs_to_get_node>(cdef.name_as_text(), {}); })
     );
     // Include all base table columns as values (in case pre or post is enabled).
     // This will include attributes not stored in the frozen map column
@@ -866,7 +866,7 @@ future<executor::request_return_type> executor::get_records(client_state& client
         // this will include the :attrs column, which we will also force evaluating. 
         // But not having this set empty forces out any cdc columns from actual result 
         | boost::adaptors::transformed([] (const column_definition& cdef) {
-            return std::make_pair<std::string, lw_shared_ptr<hierarchy_filter>>(cdef.name_as_text(), nullptr); })
+            return std::make_pair<std::string, attrs_to_get_node>(cdef.name_as_text(), {}); })
     );
 
     std::vector<const column_definition*> columns;

--- a/docs/alternator/alternator.md
+++ b/docs/alternator/alternator.md
@@ -87,25 +87,13 @@ progresses and compatibility continues to improve.
 * UpdateTable: Not supported.
 * ListTables: Supported.
 ### Item Operations
-* GetItem: Support almost complete except that projection expressions can
-  only ask for top-level attributes.
-* PutItem: Support almost complete except that condition expressions can
-  only refer to to-level attributes.
-* UpdateItem: Nested documents are supported but updates to nested attributes
-  are not (e.g., `SET a.b[3].c=val`), and neither are nested attributes in
-  condition expressions.
-* DeleteItem: Mostly works, but again does not support nested attributes
-  in condition expressions.
+* GetItem, PutItem, UpdateItem, DeleteItem fully supported.
 ### Batch Operations
-* BatchGetItem: Almost complete except that projection expressions can only
-  ask for top-level attributes.
-* BatchWriteItem: Supported. Doesn't limit the number of items (DynamoDB
-  limits to 25) or size of items (400 KB) or total request size (16 MB).
+* BatchGetItem, BatchWriteItem fully supported.
+  Doesn't limit the number of items (DynamoDB limits to 25) or size of items
+  (400 KB) or total request size (16 MB).
 ### Scans
 Scan and Query are mostly supported, with the following limitations:
-* As above, projection expressions only support top-level attributes.
-* The ScanFilter/QueryFilter parameter for filtering results is fully
-  supported, but the newer FilterExpression syntax is not yet supported.
 * The "Select" options which allows to count items instead of returning them
   is not yet supported.
 ### Secondary Indexes
@@ -297,11 +285,10 @@ policies" section.
 DynamoDB allows attributes to be **nested** - a top-level attribute may
 be a list or a map, and each of its elements may further be lists or
 maps, etc. Alternator currently stores the entire content of a top-level
-attribute as one JSON object. This is good enough for most needs, except
-one DynamoDB feature which we cannot support safely: we cannot modify
-a non-top-level attribute (e.g., a.b[3].c) directly without RMW. We plan
-to fix this in a future version by rethinking the data model we use for
-attributes, or rethinking our implementation of RMW (as explained above).
+attribute as one JSON object. This means that UpdateItem requests which
+want modify a non-top-level attribute directly (e.g., a.b[3].c) need RMW:
+Alternator implements such requests by reading the entire top-level
+attribute a, modifying only a.b[3].c, and then writing back a.
 
 ```eval_rst
 .. toctree::

--- a/docs/alternator/compatibility.md
+++ b/docs/alternator/compatibility.md
@@ -61,12 +61,6 @@ behave the same in Alternator. However, there are a few features which we have
 not implemented yet. Unimplemented features return an error when used, so
 they should be easy to detect. Here is a list of these unimplemented features:
 
-* Missing support for **atribute paths** like `a.b[3].c`.
-  Nested attributes _are_ supported, but Alternator does not yet allow reading
-  or writing directly a piece of a nested attributes using an attribute path -
-  only top-level attributes can be read or written directly.
-  https://github.com/scylladb/scylla/issues/5024
-
 * Currently in Alternator, a GSI (Global Secondary Index) can only be added
   to a table at table creation time. Unlike DynamoDB which also allows adding
   a GSI (but not an LSI) to an existing table using an UpdateTable operation.

--- a/test/alternator/test_condition_expression.py
+++ b/test/alternator/test_condition_expression.py
@@ -1262,7 +1262,6 @@ def test_update_condition_other_funcs(test_table_s):
 # ConditionExpressions also allows reading nested attributes, and we should
 # support that too. This test just checks a few random operators - we don't
 # test all the different operators here.
-@pytest.mark.xfail(reason="nested attributes not yet implemented in ConditionExpression")
 def test_update_condition_nested_attributes(test_table_s):
     p = random_string()
     test_table_s.update_item(Key={'p': p},
@@ -1308,7 +1307,6 @@ def test_update_condition_attribute_reference(test_table_s):
             ExpressionAttributeValues={':val': 1})
     assert test_table_s.get_item(Key={'p': p}, ConsistentRead=True)['Item']['c'] == 1
 
-@pytest.mark.xfail(reason="nested attributes not yet implemented in ConditionExpression")
 def test_update_condition_nested_attribute_reference(test_table_s):
     p = random_string()
     test_table_s.update_item(Key={'p': p},

--- a/test/alternator/test_filter_expression.py
+++ b/test/alternator/test_filter_expression.py
@@ -743,7 +743,6 @@ def test_filter_expression_and_attributes_to_get(test_table):
 # support that too. This test just checks one operators - we don't
 # test all the different operators again here, we will assume the same
 # code is used internally so if one operator worked, all will work.
-@pytest.mark.xfail(reason="nested attributes not yet implemented in FilterExpression")
 def test_filter_expression_nested_attribute(test_table):
     p = random_string()
     test_table.put_item(Item={'p': p, 'c': 'hi', 'x': {'a': 'dog', 'b': 3}})
@@ -754,7 +753,6 @@ def test_filter_expression_nested_attribute(test_table):
         ExpressionAttributeValues={':p': p, ':a': 'mouse'})
     assert(got_items == [{'p': p, 'c': 'yo', 'x': {'a': 'mouse', 'b': 4}}])
 
-@pytest.mark.xfail(reason="nested attributes not yet implemented in FilterExpression")
 # This test is a version of test_filter_expression_and_projection_expression
 # involving nested attributes. In that test, we had a filter and projection
 # involving different attributes. Nested attributes open new corner cases:

--- a/test/alternator/test_item.py
+++ b/test/alternator/test_item.py
@@ -367,6 +367,13 @@ def test_getitem_attributes_to_get(dynamodb, test_table):
         expected_item = {k: item[k] for k in wanted if k in item}
         assert expected_item == got_item
 
+# Verify that it is forbidden to ask for the same attribute multiple times
+def test_getitem_attributes_to_get_duplicate(dynamodb, test_table):
+    p = random_string()
+    c = random_string()
+    with pytest.raises(ClientError, match='ValidationException.*Duplicate'):
+        test_table.get_item(Key={'p': p, 'c': c}, AttributesToGet=['a', 'a'], ConsistentRead=True)
+
 # Basic test for DeleteItem, with hash key only
 def test_delete_item_hash(test_table_s):
     p = random_string()

--- a/test/alternator/test_projection_expression.py
+++ b/test/alternator/test_projection_expression.py
@@ -202,7 +202,6 @@ def test_projection_expression_path_dot(test_table_s):
 # ProjectionExpression. This includes both identical paths, and paths where
 # one is a sub-path of the other - e.g. "a.b" and "a.b.c". As we already saw
 # above, paths with just a common *prefix* - e.g., "a.b, a.c" - are fine.
-@pytest.mark.xfail(reason="ProjectionExpression does not yet support attribute paths")
 def test_projection_expression_path_overlap(test_table_s):
     # The overlap is tested symbolically, on the given paths, without any
     # relation to what the item contains, or whether it even exists. So we
@@ -245,7 +244,6 @@ def test_projection_expression_path_overlap(test_table_s):
 #   [a, [1]]".
 # The reasoning is that asking for both in one request makes no sense because
 # no item will ever be able to fulfill both.
-@pytest.mark.xfail(reason="ProjectionExpression does not yet support attribute paths")
 def test_projection_expression_path_conflict(test_table_s):
     # The conflict is tested symbolically, on the given paths, without any
     # relation to what the item contains, or whether it even exists. So we

--- a/test/alternator/test_projection_expression.py
+++ b/test/alternator/test_projection_expression.py
@@ -248,6 +248,9 @@ def test_projection_expression_path_conflict(test_table_s):
     # key for the GetItem call :-)
     p = random_string()
     for expr in ['a.b, a[1]',
+                 'a[1], a.b',
+                 'a.b[1], a.b.c',
+                 'a.b.c, a.b[1]',
                 ]:
         with pytest.raises(ClientError, match='ValidationException.* conflict'):
             test_table_s.get_item(Key={'p': p}, ConsistentRead=True, ProjectionExpression=expr)

--- a/test/alternator/test_projection_expression.py
+++ b/test/alternator/test_projection_expression.py
@@ -169,6 +169,14 @@ def test_projection_expression_path(test_table_s):
     with pytest.raises(ClientError, match='ValidationException'):
         test_table_s.get_item(Key={'p': p}, ConsistentRead=True, ProjectionExpression='a,a.b[0]')['Item']
 
+    # Above we noted that asking for to project a non-existent attribute in an
+    # existing item yields an empty Item object. However, if the item does not
+    # exist at all, the Item object will be missing entirely:
+    p = random_string()
+    assert not 'Item' in test_table_s.get_item(Key={'p': p}, ConsistentRead=True, ProjectionExpression='x')
+    assert not 'Item' in test_table_s.get_item(Key={'p': p}, ConsistentRead=True, ProjectionExpression='a.x')
+    assert not 'Item' in test_table_s.get_item(Key={'p': p}, ConsistentRead=True, ProjectionExpression='a[0]')
+
 # Above in test_projection_expression_toplevel_syntax() we tested how
 # name references (#name) work in top-level attributes. In the following
 # two tests we test how they work in more elaborate paths:

--- a/test/alternator/test_projection_expression.py
+++ b/test/alternator/test_projection_expression.py
@@ -116,7 +116,6 @@ def test_projection_expression_query(test_table):
 # but the previous test checked that the alternative syntax works correctly.
 # The following test checks fetching more elaborate attribute paths from
 # nested documents.
-@pytest.mark.xfail(reason="ProjectionExpression does not yet support attribute paths")
 def test_projection_expression_path(test_table_s):
     p = random_string()
     test_table_s.put_item(Item={
@@ -177,7 +176,6 @@ def test_projection_expression_path(test_table_s):
 # 2. Conversely, a single reference, e.g., "#a", is always a single path
 #    component. Even if "#a" is "a.b", this refers to the literal attribute
 #    "a.b" - with a dot in its name - and not to the b element in a.
-@pytest.mark.xfail(reason="ProjectionExpression does not yet support attribute paths")
 def test_projection_expression_path_references(test_table_s):
     p = random_string()
     test_table_s.put_item(Item={'p': p, 'a': {'b': 1, 'c': 2}, 'b': 'hi'})
@@ -191,7 +189,6 @@ def test_projection_expression_path_references(test_table_s):
     with pytest.raises(ClientError, match='ValidationException'):
         test_table_s.get_item(Key={'p': p}, ConsistentRead=True, ProjectionExpression='a.#n2', ExpressionAttributeNames={'#n2': 'b', '#unused': 'x'})
 
-@pytest.mark.xfail(reason="ProjectionExpression does not yet support attribute paths")
 def test_projection_expression_path_dot(test_table_s):
     p = random_string()
     test_table_s.put_item(Item={'p': p, 'a.b': 'hi', 'a': {'b': 'yo', 'c': 'jo'}})
@@ -264,7 +261,6 @@ def test_projection_expression_path_conflict(test_table_s):
 
 # Above we nested paths in ProjectionExpression, but just for the GetItem
 # request. Let's verify they also work in Query and Scan requests:
-@pytest.mark.xfail(reason="ProjectionExpression does not yet support attribute paths")
 def test_query_projection_expression_path(test_table):
     p = random_string()
     items = [{'p': p, 'c': str(i), 'a': {'x': str(i*10), 'y': 'hi'}, 'b': 'hello' } for i in range(10)]
@@ -275,7 +271,6 @@ def test_query_projection_expression_path(test_table):
     expected_items = [{'a': {'x': x['a']['x']}} for x in items]
     assert multiset(expected_items) == multiset(got_items)
 
-@pytest.mark.xfail(reason="ProjectionExpression does not yet support attribute paths")
 def test_scan_projection_expression_path(test_table):
     # This test is similar to test_query_projection_expression_path above,
     # but uses a scan instead of a query. The scan will generate unrelated
@@ -292,7 +287,6 @@ def test_scan_projection_expression_path(test_table):
 
 # BatchGetItem also supports ProjectionExpression, let's test that it
 # applies to all items, and that it correctly suports document paths as well.
-@pytest.mark.xfail(reason="ProjectionExpression does not yet support attribute paths")
 def test_batch_get_item_projection_expression_path(test_table_s):
     items = [{'p': random_string(), 'a': {'b': random_string(), 'x': 'hi'}, 'c': random_string()} for i in range(3)]
     with test_table_s.batch_writer() as batch:

--- a/test/alternator/test_update_expression.py
+++ b/test/alternator/test_update_expression.py
@@ -265,7 +265,6 @@ def test_update_expression_multi_overlap(test_table_s):
 
 # The problem isn't just with identical paths - we can't modify two paths that
 # "overlap" in the sense that one is the ancestor of the other.
-@pytest.mark.xfail(reason="nested updates not yet implemented")
 def test_update_expression_multi_overlap_nested(test_table_s):
     p = random_string()
     # Note that the overlap checks happen before checking the actual content
@@ -301,7 +300,6 @@ def test_update_expression_multi_overlap_nested(test_table_s):
 # Besides the concept of "overlapping" paths tested above, DynamoDB also has
 # the concept of "conflicting" paths - e.g., attempting to set both a.b and
 # a[1] together doesn't make sense.
-@pytest.mark.xfail(reason="nested updates not yet implemented")
 def test_update_expression_multi_conflict_nested(test_table_s):
     p = random_string()
     for expr in ['SET a.b = :val1, a[1] = :val2',
@@ -831,7 +829,6 @@ def test_update_expression_dot_in_name(test_table_s):
 # Below we have several tests of what happens when a nested attribute is
 # on the left-hand side of an assignment, but an every simpler case of
 # nested attributes is having one on the right hand side of an assignment:
-@pytest.mark.xfail(reason="nested updates not yet implemented")
 def test_update_expression_nested_attribute_rhs(test_table_s):
     p = random_string()
     test_table_s.put_item(Item={'p': p, 'a': {'b': 3, 'c': {'x': 7, 'y': 8}}, 'd': 5})


### PR DESCRIPTION
This series fixes #5024 - which is about adding support for nested attribute paths (e.g., a.b.c[2]) to Alternator.
The series adds complete support for this feature in ProjectionExpression, ConditionExpression, FilterExpression and UpdateExpression - and also its combination with ReturnValues. Many relevant tests - and also some new tests added in this series - now pass.

The first patch in the series fixes #8043 a bug in some error cases in conditions, which was discovered while working in this series, and is conceptually separate from the rest of the series.