### PR TITLE
canonical_mutation: make the data type non-contiguous

### DIFF
--- a/canonical_mutation.cc
+++ b/canonical_mutation.cc
@@ -37,7 +37,7 @@
 #include "idl/mutation.dist.impl.hh"
 #include <iostream>
 
-canonical_mutation::canonical_mutation(bytes data)
+canonical_mutation::canonical_mutation(bytes_ostream data)
         : _data(std::move(data))
 { }
 
@@ -45,8 +45,7 @@ canonical_mutation::canonical_mutation(const mutation& m)
 {
     mutation_partition_serializer part_ser(*m.schema(), m.partition());
 
-    bytes_ostream out;
-    ser::writer_of_canonical_mutation<bytes_ostream> wr(out);
+    ser::writer_of_canonical_mutation<bytes_ostream> wr(_data);
     std::move(wr).write_table_id(m.schema()->id())
                  .write_schema_version(m.schema()->version())
                  .write_key(m.key())
@@ -54,7 +53,6 @@ canonical_mutation::canonical_mutation(const mutation& m)
                  .partition([&] (auto wr) {
                      part_ser.write(std::move(wr));
                  }).end_canonical_mutation();
-    _data = to_bytes(out.linearize());
 }
 
 utils::UUID canonical_mutation::column_family_id() const {

--- a/canonical_mutation.hh
+++ b/canonical_mutation.hh
@@ -32,9 +32,9 @@
 // Safe to access from other shards via const&.
 // Safe to pass serialized across nodes.
 class canonical_mutation {
-    bytes _data;
+    bytes_ostream _data;
 public:
-    explicit canonical_mutation(bytes);
+    explicit canonical_mutation(bytes_ostream);
     explicit canonical_mutation(const mutation&);
 
     canonical_mutation(canonical_mutation&&) = default;
@@ -51,7 +51,7 @@ public:
 
     utils::UUID column_family_id() const;
 
-    const bytes& representation() const { return _data; }
+    const bytes_ostream& representation() const { return _data; }
 
     friend std::ostream& operator<<(std::ostream& os, const canonical_mutation& cm);
 };


### PR DESCRIPTION
The canonical_mutation type can contain a large mutation, particularly
when the mutation is a result of converting a big schema. Its data
was stored in a field of type 'bytes', which is non-contiguous and
may cause a large allocation.
This is fixed by simply changing the type to 'bytes_ostream', which is
fragmented. The change is compatible because the idl type 'bytes' is compatible
with 'bytes_ostream' as a result of dcf794b, and all canonical_mutations's
methods use the field as an input stream (ser::as_input_stream), which can
be used on 'bytes_ostream' too.

Fixes #8074

Tests: unit(dev) and migration dtest