### PR TITLE
cql3::restrictions: Add SCYLLA_CLUSTERING_BOUND keyword for sstablelo…

### DIFF
--- a/cql3/Cql.g
+++ b/cql3/Cql.g
@@ -1549,6 +1549,10 @@ relation[std::vector<cql3::relation_ptr>& clauses]
           {
               $clauses.emplace_back(cql3::multi_column_relation::create_non_in_relation(ids, type, literal));
           }
+      | type=relationType K_SCYLLA_CLUSTERING_BOUND literal=tupleLiteral /* (a, b, c) > (1, 2, 3) or (a, b, c) > (?, ?, ?) */
+          {
+              $clauses.emplace_back(cql3::multi_column_relation::create_scylla_clustering_bound_non_in_relation(ids, type, literal));
+          }
       | type=relationType tupleMarker=markerForTuple /* (a, b, c) >= ? */
           { $clauses.emplace_back(cql3::multi_column_relation::create_non_in_relation(ids, type, tupleMarker)); }
       )
@@ -1915,6 +1919,8 @@ K_PARTITION:   P A R T I T I O N;
 
 K_SCYLLA_TIMEUUID_LIST_INDEX: S C Y L L A '_' T I M E U U I D '_' L I S T '_' I N D E X;
 K_SCYLLA_COUNTER_SHARD_LIST: S C Y L L A '_' C O U N T E R '_' S H A R D '_' L I S T; 
+K_SCYLLA_CLUSTERING_BOUND: S C Y L L A '_' C L U S T E R I N G '_' B O U N D;
+
 
 K_GROUP:       G R O U P;
 

--- a/docs/design-notes/cql-extensions-internal.md
+++ b/docs/design-notes/cql-extensions-internal.md
@@ -1,0 +1,39 @@
+# Scylla CQL extensions
+
+Scylla extends the CQL language to provide a few extra features. This document
+lists those extensions.
+
+## SCYLLA_TIMEUUID_LIST_INDEX function
+
+The `SCYLLA_TIMEUUID_LIST_INDEX` function allows using the raw (sstable) collection
+key for lists, which is a timeuuid, as "index" when performing a modification.
+
+The function is used to wrap the index part of a list assignment:
+
+    UPDATE ... SET list_column[SCYLLA_TIMEUUID_LIST_INDEX(:v1)] = :v2 ... 
+
+It is only used by sstableloader.
+
+## SCYLLA_COUNTER_SHARD_LIST function
+
+The `SCYLLA_COUNTER_SHARD_LIST` function allows setting a counter column value by 
+its internal representation.
+
+The function is used to wrap the value part of a counter assignment:
+
+    UPDATE ... SET counter_column = SCYLLA_COUNTER_SHARD_LIST(:v1) ... 
+
+It is only used by sstableloader.
+
+## SCYLLA_CLUSTERING_BOUND function
+
+The `SCYLLA_CLUSTERING_BOUND` function marks a query bound as being 
+a CQL clustering boundary, not a value range bound as in normal CQL.
+
+This function can be used on the right-hand side of a `WHERE` statement multicolumn 
+comparison, excluding the IN and LIKE operators. Its parameters are values corresponding 
+to the clustering prefix specified on the left-hand side of that comparison.
+
+    UPDATE ... WHERE (c1, c2) < SCYLLA_CLUSTERING_BOUND(:v1, :v2) AND (c1, c2) > SCYLLA_CLUSTERING_BOUND(:v3, :v4) ...
+
+It is only used by sstableloader.

--- a/test/cql/query_bounds_test.cql
+++ b/test/cql/query_bounds_test.cql
@@ -1,0 +1,95 @@
+create table foo (a int, b int, c int, PRIMARY KEY (a, b, c)) WITH CLUSTERING ORDER BY (b DESC, c ASC);
+
+INSERT INTO foo (a, b, c) VALUES (0, 2, 0);
+INSERT INTO foo (a, b, c) VALUES (0, 1, 0);
+INSERT INTO foo (a, b, c) VALUES (0, 1, 1);
+INSERT INTO foo (a, b, c) VALUES (0, 0, 0);
+
+SELECT * FROM foo WHERE a=0 AND (b, c) > (1, 0);
+
+SELECT * FROM foo WHERE a=0 AND (b, c) > SCYLLA_CLUSTERING_BOUND (1, 0);
+
+SELECT * FROM foo WHERE a=0 AND (b, c) > (2, 0);
+
+SELECT * FROM foo WHERE a=0 AND (b, c) > SCYLLA_CLUSTERING_BOUND (2, 0);
+
+SELECT * FROM foo WHERE a=0 AND (b, c) >= (2, 0);
+
+SELECT * FROM foo WHERE a=0 AND (b, c) >= SCYLLA_CLUSTERING_BOUND (2, 0);
+
+SELECT * FROM foo WHERE a=0 AND (b, c) < (1, 0);
+
+SELECT * FROM foo WHERE a=0 AND (b, c) < SCYLLA_CLUSTERING_BOUND (1, 0);
+
+SELECT * FROM foo WHERE a=0 AND (b, c) < (2, 0);
+
+SELECT * FROM foo WHERE a=0 AND (b, c) < SCYLLA_CLUSTERING_BOUND (2, 0);
+
+SELECT * FROM foo WHERE a=0 AND (b, c) <= (2, 0);
+
+SELECT * FROM foo WHERE a=0 AND (b, c) <= SCYLLA_CLUSTERING_BOUND (2, 0);
+
+
+SELECT * FROM foo WHERE a=0 AND (b) > (1);
+
+SELECT * FROM foo WHERE a=0 AND (b) > SCYLLA_CLUSTERING_BOUND (1);
+
+SELECT * FROM foo WHERE a=0 AND (b) > (2);
+
+SELECT * FROM foo WHERE a=0 AND (b) > SCYLLA_CLUSTERING_BOUND (2);
+
+SELECT * FROM foo WHERE a=0 AND (b) >= (2);
+
+SELECT * FROM foo WHERE a=0 AND (b) >= SCYLLA_CLUSTERING_BOUND (2);
+
+SELECT * FROM foo WHERE a=0 AND (b) < (1);
+
+SELECT * FROM foo WHERE a=0 AND (b) < SCYLLA_CLUSTERING_BOUND (1);
+
+SELECT * FROM foo WHERE a=0 AND (b) < (2);
+
+SELECT * FROM foo WHERE a=0 AND (b) < SCYLLA_CLUSTERING_BOUND (2);
+
+SELECT * FROM foo WHERE a=0 AND (b) <= (2);
+
+SELECT * FROM foo WHERE a=0 AND (b) <= SCYLLA_CLUSTERING_BOUND (2);
+
+
+
+
+SELECT * FROM foo WHERE a=0 AND (b) > (1) AND (b, c) <= (2, 0);
+
+SELECT * FROM foo WHERE a=0 AND (b) > SCYLLA_CLUSTERING_BOUND (1) AND (b, c) <= SCYLLA_CLUSTERING_BOUND (0, 0);
+
+SELECT * FROM foo WHERE a=0 AND (b) > (2) AND (b, c) <= (2, 1);
+
+SELECT * FROM foo WHERE a=0 AND (b) > SCYLLA_CLUSTERING_BOUND (2) AND (b, c) <= SCYLLA_CLUSTERING_BOUND(1, 1);
+
+-- error checks --
+
+-- wrong side of condition
+SELECT * FROM foo WHERE a=0 AND SCYLLA_CLUSTERING_BOUND(b) > (2);
+
+-- both sides of condition
+SELECT * FROM foo WHERE a=0 AND SCYLLA_CLUSTERING_BOUND(b) > SCYLLA_CLUSTERING_BOUND(2);
+
+-- too many values --
+SELECT * FROM foo WHERE a=0 AND (b, c) > SCYLLA_CLUSTERING_BOUND (1, 0, 5);
+
+-- too few values --
+SELECT * FROM foo WHERE a=0 AND (b, c) > SCYLLA_CLUSTERING_BOUND (1);
+
+-- missing values --
+SELECT * FROM foo WHERE a=0 AND (b, c) > SCYLLA_CLUSTERING_BOUND;
+
+-- not tuple  --
+SELECT * FROM foo WHERE a=0 AND (b, c) > SCYLLA_CLUSTERING_BOUND 45;
+
+-- just wrong  --
+SELECT * FROM foo WHERE a=0 SCYLLA_CLUSTERING_BOUND AND (b, c) > (0, 1);
+SELECT * FROM foo WHERE a=0 AND (b, c) > (0, 1) SCYLLA_CLUSTERING_BOUND;
+
+-- mixing apples and make_count_rows_function
+SELECT * FROM foo WHERE a=0 AND (b, c) > SCYLLA_CLUSTERING_BOUND(2, 0)  AND (b, c) < (1, 1);
+-- and again --
+SELECT * FROM foo WHERE a=0 AND (b, c) > SCYLLA_CLUSTERING_BOUND(2, 0)  AND (b, c) < (2, 0);

--- a/test/cql/query_bounds_test.result
+++ b/test/cql/query_bounds_test.result
@@ -1,0 +1,510 @@
+create table foo (a int, b int, c int, PRIMARY KEY (a, b, c)) WITH CLUSTERING ORDER BY (b DESC, c ASC);
+{
+	"status" : "ok"
+}
+
+INSERT INTO foo (a, b, c) VALUES (0, 2, 0);
+{
+	"status" : "ok"
+}
+INSERT INTO foo (a, b, c) VALUES (0, 1, 0);
+{
+	"status" : "ok"
+}
+INSERT INTO foo (a, b, c) VALUES (0, 1, 1);
+{
+	"status" : "ok"
+}
+INSERT INTO foo (a, b, c) VALUES (0, 0, 0);
+{
+	"status" : "ok"
+}
+
+SELECT * FROM foo WHERE a=0 AND (b, c) > (1, 0);
+{
+	"rows" : 
+	[
+		{
+			"a" : "0",
+			"b" : "2",
+			"c" : "0"
+		},
+		{
+			"a" : "0",
+			"b" : "1",
+			"c" : "1"
+		}
+	]
+}
+
+SELECT * FROM foo WHERE a=0 AND (b, c) > SCYLLA_CLUSTERING_BOUND (1, 0);
+{
+	"rows" : 
+	[
+		{
+			"a" : "0",
+			"b" : "1",
+			"c" : "1"
+		},
+		{
+			"a" : "0",
+			"b" : "0",
+			"c" : "0"
+		}
+	]
+}
+
+SELECT * FROM foo WHERE a=0 AND (b, c) > (2, 0);
+{
+	"rows" : null
+}
+
+SELECT * FROM foo WHERE a=0 AND (b, c) > SCYLLA_CLUSTERING_BOUND (2, 0);
+{
+	"rows" : 
+	[
+		{
+			"a" : "0",
+			"b" : "1",
+			"c" : "0"
+		},
+		{
+			"a" : "0",
+			"b" : "1",
+			"c" : "1"
+		},
+		{
+			"a" : "0",
+			"b" : "0",
+			"c" : "0"
+		}
+	]
+}
+
+SELECT * FROM foo WHERE a=0 AND (b, c) >= (2, 0);
+{
+	"rows" : 
+	[
+		{
+			"a" : "0",
+			"b" : "2",
+			"c" : "0"
+		}
+	]
+}
+
+SELECT * FROM foo WHERE a=0 AND (b, c) >= SCYLLA_CLUSTERING_BOUND (2, 0);
+{
+	"rows" : 
+	[
+		{
+			"a" : "0",
+			"b" : "2",
+			"c" : "0"
+		},
+		{
+			"a" : "0",
+			"b" : "1",
+			"c" : "0"
+		},
+		{
+			"a" : "0",
+			"b" : "1",
+			"c" : "1"
+		},
+		{
+			"a" : "0",
+			"b" : "0",
+			"c" : "0"
+		}
+	]
+}
+
+SELECT * FROM foo WHERE a=0 AND (b, c) < (1, 0);
+{
+	"rows" : 
+	[
+		{
+			"a" : "0",
+			"b" : "0",
+			"c" : "0"
+		}
+	]
+}
+
+SELECT * FROM foo WHERE a=0 AND (b, c) < SCYLLA_CLUSTERING_BOUND (1, 0);
+{
+	"rows" : 
+	[
+		{
+			"a" : "0",
+			"b" : "2",
+			"c" : "0"
+		}
+	]
+}
+
+SELECT * FROM foo WHERE a=0 AND (b, c) < (2, 0);
+{
+	"rows" : 
+	[
+		{
+			"a" : "0",
+			"b" : "1",
+			"c" : "0"
+		},
+		{
+			"a" : "0",
+			"b" : "1",
+			"c" : "1"
+		},
+		{
+			"a" : "0",
+			"b" : "0",
+			"c" : "0"
+		}
+	]
+}
+
+SELECT * FROM foo WHERE a=0 AND (b, c) < SCYLLA_CLUSTERING_BOUND (2, 0);
+{
+	"rows" : null
+}
+
+SELECT * FROM foo WHERE a=0 AND (b, c) <= (2, 0);
+{
+	"rows" : 
+	[
+		{
+			"a" : "0",
+			"b" : "2",
+			"c" : "0"
+		},
+		{
+			"a" : "0",
+			"b" : "1",
+			"c" : "0"
+		},
+		{
+			"a" : "0",
+			"b" : "1",
+			"c" : "1"
+		},
+		{
+			"a" : "0",
+			"b" : "0",
+			"c" : "0"
+		}
+	]
+}
+
+SELECT * FROM foo WHERE a=0 AND (b, c) <= SCYLLA_CLUSTERING_BOUND (2, 0);
+{
+	"rows" : 
+	[
+		{
+			"a" : "0",
+			"b" : "2",
+			"c" : "0"
+		}
+	]
+}
+
+
+SELECT * FROM foo WHERE a=0 AND (b) > (1);
+{
+	"rows" : 
+	[
+		{
+			"a" : "0",
+			"b" : "2",
+			"c" : "0"
+		}
+	]
+}
+
+SELECT * FROM foo WHERE a=0 AND (b) > SCYLLA_CLUSTERING_BOUND (1);
+{
+	"rows" : 
+	[
+		{
+			"a" : "0",
+			"b" : "0",
+			"c" : "0"
+		}
+	]
+}
+
+SELECT * FROM foo WHERE a=0 AND (b) > (2);
+{
+	"rows" : null
+}
+
+SELECT * FROM foo WHERE a=0 AND (b) > SCYLLA_CLUSTERING_BOUND (2);
+{
+	"rows" : 
+	[
+		{
+			"a" : "0",
+			"b" : "1",
+			"c" : "0"
+		},
+		{
+			"a" : "0",
+			"b" : "1",
+			"c" : "1"
+		},
+		{
+			"a" : "0",
+			"b" : "0",
+			"c" : "0"
+		}
+	]
+}
+
+SELECT * FROM foo WHERE a=0 AND (b) >= (2);
+{
+	"rows" : 
+	[
+		{
+			"a" : "0",
+			"b" : "2",
+			"c" : "0"
+		}
+	]
+}
+
+SELECT * FROM foo WHERE a=0 AND (b) >= SCYLLA_CLUSTERING_BOUND (2);
+{
+	"rows" : 
+	[
+		{
+			"a" : "0",
+			"b" : "2",
+			"c" : "0"
+		},
+		{
+			"a" : "0",
+			"b" : "1",
+			"c" : "0"
+		},
+		{
+			"a" : "0",
+			"b" : "1",
+			"c" : "1"
+		},
+		{
+			"a" : "0",
+			"b" : "0",
+			"c" : "0"
+		}
+	]
+}
+
+SELECT * FROM foo WHERE a=0 AND (b) < (1);
+{
+	"rows" : 
+	[
+		{
+			"a" : "0",
+			"b" : "0",
+			"c" : "0"
+		}
+	]
+}
+
+SELECT * FROM foo WHERE a=0 AND (b) < SCYLLA_CLUSTERING_BOUND (1);
+{
+	"rows" : 
+	[
+		{
+			"a" : "0",
+			"b" : "2",
+			"c" : "0"
+		}
+	]
+}
+
+SELECT * FROM foo WHERE a=0 AND (b) < (2);
+{
+	"rows" : 
+	[
+		{
+			"a" : "0",
+			"b" : "1",
+			"c" : "0"
+		},
+		{
+			"a" : "0",
+			"b" : "1",
+			"c" : "1"
+		},
+		{
+			"a" : "0",
+			"b" : "0",
+			"c" : "0"
+		}
+	]
+}
+
+SELECT * FROM foo WHERE a=0 AND (b) < SCYLLA_CLUSTERING_BOUND (2);
+{
+	"rows" : null
+}
+
+SELECT * FROM foo WHERE a=0 AND (b) <= (2);
+{
+	"rows" : 
+	[
+		{
+			"a" : "0",
+			"b" : "2",
+			"c" : "0"
+		},
+		{
+			"a" : "0",
+			"b" : "1",
+			"c" : "0"
+		},
+		{
+			"a" : "0",
+			"b" : "1",
+			"c" : "1"
+		},
+		{
+			"a" : "0",
+			"b" : "0",
+			"c" : "0"
+		}
+	]
+}
+
+SELECT * FROM foo WHERE a=0 AND (b) <= SCYLLA_CLUSTERING_BOUND (2);
+{
+	"rows" : 
+	[
+		{
+			"a" : "0",
+			"b" : "2",
+			"c" : "0"
+		}
+	]
+}
+
+
+
+
+SELECT * FROM foo WHERE a=0 AND (b) > (1) AND (b, c) <= (2, 0);
+{
+	"rows" : 
+	[
+		{
+			"a" : "0",
+			"b" : "2",
+			"c" : "0"
+		}
+	]
+}
+
+SELECT * FROM foo WHERE a=0 AND (b) > SCYLLA_CLUSTERING_BOUND (1) AND (b, c) <= SCYLLA_CLUSTERING_BOUND (0, 0);
+{
+	"rows" : 
+	[
+		{
+			"a" : "0",
+			"b" : "0",
+			"c" : "0"
+		}
+	]
+}
+
+SELECT * FROM foo WHERE a=0 AND (b) > (2) AND (b, c) <= (2, 1);
+{
+	"rows" : null
+}
+
+SELECT * FROM foo WHERE a=0 AND (b) > SCYLLA_CLUSTERING_BOUND (2) AND (b, c) <= SCYLLA_CLUSTERING_BOUND(1, 1);
+{
+	"rows" : 
+	[
+		{
+			"a" : "0",
+			"b" : "1",
+			"c" : "0"
+		},
+		{
+			"a" : "0",
+			"b" : "1",
+			"c" : "1"
+		}
+	]
+}
+
+-- error checks --
+
+-- wrong side of condition
+SELECT * FROM foo WHERE a=0 AND SCYLLA_CLUSTERING_BOUND(b) > (2);
+{
+	"message" : "exceptions::syntax_exception (line 1:32 no viable alternative at input 'SCYLLA_CLUSTERING_BOUND')",
+	"status" : "error"
+}
+
+-- both sides of condition
+SELECT * FROM foo WHERE a=0 AND SCYLLA_CLUSTERING_BOUND(b) > SCYLLA_CLUSTERING_BOUND(2);
+{
+	"message" : "exceptions::syntax_exception (line 1:32 no viable alternative at input 'SCYLLA_CLUSTERING_BOUND')",
+	"status" : "error"
+}
+
+-- too many values --
+SELECT * FROM foo WHERE a=0 AND (b, c) > SCYLLA_CLUSTERING_BOUND (1, 0, 5);
+{
+	"message" : "exceptions::invalid_request_exception (Expected 2 elements in value tuple, but got 3: (1, 0, 5))",
+	"status" : "error"
+}
+
+-- too few values --
+SELECT * FROM foo WHERE a=0 AND (b, c) > SCYLLA_CLUSTERING_BOUND (1);
+{
+	"message" : "exceptions::invalid_request_exception (Expected 2 elements in value tuple, but got 1: (1))",
+	"status" : "error"
+}
+
+-- missing values --
+SELECT * FROM foo WHERE a=0 AND (b, c) > SCYLLA_CLUSTERING_BOUND;
+{
+	"message" : "exceptions::syntax_exception (line 1:64  : syntax error...\n)",
+	"status" : "error"
+}
+
+-- not tuple  --
+SELECT * FROM foo WHERE a=0 AND (b, c) > SCYLLA_CLUSTERING_BOUND 45;
+{
+	"message" : "exceptions::syntax_exception (line 1:65 missing '(' at '<missing ')",
+	"status" : "error"
+}
+
+-- just wrong  --
+SELECT * FROM foo WHERE a=0 SCYLLA_CLUSTERING_BOUND AND (b, c) > (0, 1);
+{
+	"message" : "exceptions::syntax_exception (line 1:28  : syntax error...\n)",
+	"status" : "error"
+}
+SELECT * FROM foo WHERE a=0 AND (b, c) > (0, 1) SCYLLA_CLUSTERING_BOUND;
+{
+	"message" : "exceptions::syntax_exception (line 1:48  : syntax error...\n)",
+	"status" : "error"
+}
+
+-- mixing apples and make_count_rows_function
+SELECT * FROM foo WHERE a=0 AND (b, c) > SCYLLA_CLUSTERING_BOUND(2, 0)  AND (b, c) < (1, 1);
+{
+	"message" : "exceptions::invalid_request_exception (Invalid combination of restrictions (SCYLLA_CLUSTERING_BOUND / plain))",
+	"status" : "error"
+}
+-- and again --
+SELECT * FROM foo WHERE a=0 AND (b, c) > SCYLLA_CLUSTERING_BOUND(2, 0)  AND (b, c) < (2, 0);
+{
+	"message" : "exceptions::invalid_request_exception (Invalid combination of restrictions (SCYLLA_CLUSTERING_BOUND / plain))",
+	"status" : "error"
+}


### PR DESCRIPTION
…ader

Refs #8093
Refs /scylladb/scylla-tools-java#218

Adds keyword that can preface value tuples in (a, b, c) > (1, 2, 3)
expressions, forcing the restriction to bypass column sort order
treatment, and instead just create the raw ck bounds accordningly.

This is a very limited, and simple version, but since we only need
to cover this above exact syntax, this should be sufficient.