### PR TITLE
[RFC] Speculatively disqualify a node which seems to be down or overloaded from read operations

### DIFF
--- a/docs/design-notes/qualifying-replicas-for-reads.md
+++ b/docs/design-notes/qualifying-replicas-for-reads.md
@@ -1,0 +1,79 @@
+# Qualifying replicas for read operations
+
+## Intro
+
+When a read request arrives at the coordinator node, it is later
+forwarded to one or more replicas in order to read the actual data
+and return it back to the client. Each request has an associated
+timeout, which indicates how long the client is willing to wait
+for the query results.
+This timeout information can be leveraged to lift some pressure off
+a replica which is overloaded or dead.
+
+## Gathering last seen information
+
+The coordinator should be able to predict whether a replica is likely
+to respond to a request in time or not. This prediction should be as
+precise as possible, but at the same time have minimal overhead, because
+performing read requests is on the hot path. A simple estimation
+of how responsive a replica is likely to be is implemented as follows:
+ * each time a read request is sent to a replica, a timestamp is recorded
+ * each time a response is received from a replica, a timestamp is recorded
+ * each time a response is received from a replica, the request round trip time
+   is recorded
+
+The difference between the two above timestamps is a cheap, rough implementation
+of a failure detector - if the node hasn't responded for more than X milliseconds since
+the previous request and the current request is going to time out in X milliseconds,
+it gets more and more likely to be dead.
+The last recorded round trip time is, in turn, a cheap, rough estimate of how long
+it may take the replica to respond to the next request - assuming that the conditions
+haven't changed and the requests are identical, which might be a good enough estimate
+for homogenous workloads.
+
+Finally, when a replica was not contacted in a long while (e.g. 5s),
+its previous last seen information is considered stale and dropped to avoid
+reporting incorrect long periods of time without response.
+
+## Omitting replicas not likely to respond in time
+
+Based on the last seen information, the coordinator is now allowed
+to make an educated guess whether a replica is going to respond in time.
+A simple, probabilistic approach is implemented as follows.
+At first, we compute how much time left (`TL`) the request still has until
+it reaches its deadline and times out. From the last seen information
+we fetch the last time without a response, estimated by subtracting
+the last sent timestamp from the last responded timestamp - `TWR`,
+as well as the last round trip time for a successful request - `RTT`.
+These two are used to estimate the time it will take for a replica
+to respond to the next query - `EST = max(TWR, RTT)`. Maximum is used
+in order to prefer `TWR` in cases when a node is dead, and `RTT` in cases when
+the node regularly responds, but latency of a single request remains large.
+If `TL` is larger than `EST`, then the node is likely to still respond
+in time, so the request is let through. If, however, `TL < EST`,
+it suggests that the replica might not respond within the deadline,
+so it may be probabilistically omitted as a potential target. The chance of
+omitting a replica is `(EST-TL)/TL`, which means that the chance increases
+linearly along with `EST`, i.e. the longer the replica is expected to spend
+on responding, the higher its chances for being qualified as unreliable.
+Once the estimation reaches `2*TL`, the chance reaches almost 100% - but there
+always exist a small chance (`>=0.01%`) for letting a request through in case
+the replica started responding.
+
+## So, it's a dynamic snitch?
+
+Kind of, but it's only expected to work once the replica is likely
+to not be able to handle its requests within their deadline. Ideally,
+it would have no influence over how the requests are distributed
+as long as replicas regularly respond to their requests in time.
+A scenario in which this mechanism is expected to be particularly
+effective is when a replica dies suddenly without broadcasting
+that it's going to die. In this case, the failure detector can take
+tens of seconds to figure out that this replica is dead, which
+also means that coordinators would try to send data to it,
+which results in a sharp increase of background reads, which in turn
+lack a proper backpressure mechanism (at least at the time of writing
+this doc). With the qualification mechanism in place, the node
+is qualified as not likely to respond potentially much quicker,
+especially if its requests have short timeout values (e.g. 500ms).
+ 

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -1528,7 +1528,8 @@ storage_proxy_stats::stats::stats()
         , digest_read_errors(COORDINATOR_STATS_CATEGORY, "read_errors", "number of digest read requests that failed", "digest")
         , mutation_data_read_attempts(COORDINATOR_STATS_CATEGORY, "reads", "number of mutation data read requests", "mutation_data")
         , mutation_data_read_completed(COORDINATOR_STATS_CATEGORY, "completed_reads", "number of mutation data read requests that completed", "mutation_data")
-        , mutation_data_read_errors(COORDINATOR_STATS_CATEGORY, "read_errors", "number of mutation data read requests that failed", "mutation_data") { }
+        , mutation_data_read_errors(COORDINATOR_STATS_CATEGORY, "read_errors", "number of mutation data read requests that failed", "mutation_data")
+        , read_requests_speculatively_refused(COORDINATOR_STATS_CATEGORY, "read_requests_speculatively_refused", "number of requests which were destined for this endpoint, but speculatively refused", "data") { }
 
 void storage_proxy_stats::stats::register_split_metrics_local() {
     write_stats::register_split_metrics_local();
@@ -4628,6 +4629,7 @@ bool storage_proxy::is_likely_to_respond_in_time(const gms::inet_address& ep, cl
             int fail_chance = std::min<long>((rtt_estimate.count() - time_left.count()) * granularity / time_left.count(), granularity - 1);
             int roll = dice(_urandom);
             if (roll < fail_chance) {
+                ++get_stats().read_requests_speculatively_refused.get_ep_stat(ep);
                 slogger.debug("Overload protection: speculatively disqualifying {} as a candidate for a read request with {}ms left until timeout, "
                         "since it hasn't responded for at least {}ms", ep, time_left.count(), rtt_estimate.count());
                 return false;

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -3822,13 +3822,14 @@ db::read_repair_decision storage_proxy::new_read_repair_decision(const schema& s
         tracing::trace_state_ptr trace_state,
         const std::vector<gms::inet_address>& preferred_endpoints,
         bool& is_read_non_local,
-        service_permit permit) {
+        service_permit permit,
+        clock_type::time_point timeout) {
     const dht::token& token = pr.start()->value().token();
     keyspace& ks = _db.local().find_keyspace(schema->ks_name());
     speculative_retry::type retry_type = schema->speculative_retry().get_type();
     gms::inet_address extra_replica;
 
-    std::vector<gms::inet_address> all_replicas = get_live_sorted_endpoints(ks, token);
+    std::vector<gms::inet_address> all_replicas = get_live_sorted_endpoints_for_read(ks, token, timeout);
     // Check for a non-local read before heat-weighted load balancing
     // reordering of endpoints happens. The local endpoint, if
     // present, is always first in the list, as get_live_sorted_endpoints()
@@ -3958,6 +3959,7 @@ storage_proxy::query_singular(lw_shared_ptr<query::read_command> cmd,
     bool is_read_non_local = false;
 
     const auto tmptr = get_token_metadata_ptr();
+    auto timeout = query_options.timeout(*this);
     for (auto&& pr: partition_ranges) {
         if (!pr.is_singular()) {
             throw std::runtime_error("mixed singular and non singular range are not supported");
@@ -3970,7 +3972,7 @@ storage_proxy::query_singular(lw_shared_ptr<query::read_command> cmd,
 
         auto read_executor = get_read_executor(cmd, schema, std::move(pr), cl, repair_decision,
                                                query_options.trace_state, replicas, is_read_non_local,
-                                               query_options.permit);
+                                               query_options.permit, timeout);
 
         exec.emplace_back(read_executor, std::move(token_range));
     }
@@ -3983,7 +3985,7 @@ storage_proxy::query_singular(lw_shared_ptr<query::read_command> cmd,
 
     auto used_replicas = make_lw_shared<replicas_per_token_range>();
 
-    auto f = ::map_reduce(exec.begin(), exec.end(), [p = shared_from_this(), timeout = query_options.timeout(*this), used_replicas, tmptr] (
+    auto f = ::map_reduce(exec.begin(), exec.end(), [p = shared_from_this(), timeout, used_replicas, tmptr] (
                 std::pair<::shared_ptr<abstract_read_executor>, dht::token_range>& executor_and_token_range) {
         auto& rex = std::get<0>(executor_and_token_range);
         auto& token_range = std::get<1>(executor_and_token_range);
@@ -4057,7 +4059,7 @@ storage_proxy::query_partition_key_range_concurrent(storage_proxy::clock_type::t
 
     while (i != ranges.end()) {
         dht::partition_range& range = *i;
-        std::vector<gms::inet_address> live_endpoints = get_live_sorted_endpoints(ks, end_token(range));
+        std::vector<gms::inet_address> live_endpoints = get_live_sorted_endpoints_for_read(ks, end_token(range), timeout);
         std::vector<gms::inet_address> merged_preferred_replicas = preferred_replicas_for_range(*i);
         std::vector<gms::inet_address> filtered_endpoints = filter_for_query(cl, ks, live_endpoints, merged_preferred_replicas, pcf);
         std::vector<dht::token_range> merged_ranges{to_token_range(range)};
@@ -4070,7 +4072,7 @@ storage_proxy::query_partition_key_range_concurrent(storage_proxy::clock_type::t
         {
             const auto current_range_preferred_replicas = preferred_replicas_for_range(*i);
             dht::partition_range& next_range = *i;
-            std::vector<gms::inet_address> next_endpoints = get_live_sorted_endpoints(ks, end_token(next_range));
+            std::vector<gms::inet_address> next_endpoints = get_live_sorted_endpoints_for_read(ks, end_token(next_range), timeout);
             std::vector<gms::inet_address> next_filtered_endpoints = filter_for_query(cl, ks, next_endpoints, current_range_preferred_replicas, pcf);
 
             // Origin has this to say here:
@@ -4597,10 +4599,58 @@ future<bool> storage_proxy::cas(schema_ptr schema, shared_ptr<cas_request> reque
     co_return condition_met;
 }
 
+bool storage_proxy::is_likely_to_respond_in_time(const gms::inet_address& ep, clock_type::time_point timeout) {
+    clock_type::time_point now = clock_type::now();
+    if (timeout <= now) {
+        return false;
+    }
+    if (fbu::is_me(ep)) {
+        return true;
+    }
+    if (auto last_seen_ep = last_seen(ep)) {
+        auto time_left = timeout - now;
+        auto last_attempt = now - last_seen_ep->last_sent;
+        // If the node has never responded yet or there was no communication attempt for a long while,
+        // the node should be probed in case it becomes responsive
+        if (last_seen_ep->last_responded == last_seen_info::unknown || last_attempt > time_left) {
+            return true;
+        }
+        auto time_without_response = last_seen_ep->last_sent - last_seen_ep->last_responded;
+        // When the target node is dead/unresponsive, time_without_response would very quickly
+        // start dominating. Otherwise, if the node constantly responds at a high rate, but with a considerable
+        // lag, it's better to estimate based on a response time of a single request.
+        slogger.trace("Overload protection: Last rtt: {}ms; time without response: {}ms", last_seen_ep->last_rtt.count(), time_without_response.count());
+        auto rtt_estimate = std::max(last_seen_ep->last_rtt, time_without_response);
+        if (rtt_estimate > time_left) {
+            static constexpr int granularity = 10'000;
+            static thread_local std::uniform_int_distribution dice(0, granularity);
+            // There's always a small chance of probing the replica in case it came back to life.
+            int fail_chance = std::min<long>((rtt_estimate.count() - time_left.count()) * granularity / time_left.count(), granularity - 1);
+            int roll = dice(_urandom);
+            if (roll < fail_chance) {
+                slogger.debug("Overload protection: speculatively disqualifying {} as a candidate for a read request with {}ms left until timeout, "
+                        "since it hasn't responded for at least {}ms", ep, time_left.count(), rtt_estimate.count());
+                return false;
+            }
+        }
+    }
+    return true;
+}
+
 std::vector<gms::inet_address> storage_proxy::get_live_endpoints(keyspace& ks, const dht::token& token) const {
     auto& rs = ks.get_replication_strategy();
     std::vector<gms::inet_address> eps = rs.get_natural_endpoints_without_node_being_replaced(token);
     auto itend = boost::range::remove_if(eps, std::not1(std::bind1st(std::mem_fn(&gms::gossiper::is_alive), &gms::get_local_gossiper())));
+    eps.erase(itend, eps.end());
+    return eps;
+}
+
+std::vector<gms::inet_address> storage_proxy::get_live_endpoints_for_read(keyspace& ks, const dht::token& token, clock_type::time_point timeout) {
+    auto& rs = ks.get_replication_strategy();
+    std::vector<gms::inet_address> eps = rs.get_natural_endpoints_without_node_being_replaced(token);
+    auto itend = boost::range::remove_if(eps, [this, timeout, &gossiper = gms::get_local_gossiper()] (const gms::inet_address& ep) {
+        return !gossiper.is_alive(ep) || !is_likely_to_respond_in_time(ep, timeout);
+    });
     eps.erase(itend, eps.end());
     return eps;
 }
@@ -4614,8 +4664,8 @@ void storage_proxy::sort_endpoints_by_proximity(std::vector<gms::inet_address>& 
     }
 }
 
-std::vector<gms::inet_address> storage_proxy::get_live_sorted_endpoints(keyspace& ks, const dht::token& token) const {
-    auto eps = get_live_endpoints(ks, token);
+std::vector<gms::inet_address> storage_proxy::get_live_sorted_endpoints_for_read(keyspace& ks, const dht::token& token, clock_type::time_point timeout) {
+    auto eps = get_live_endpoints_for_read(ks, token, timeout);
     sort_endpoints_by_proximity(eps);
     return eps;
 }
@@ -5287,11 +5337,17 @@ std::optional<storage_proxy::last_seen_info> storage_proxy::last_seen(const gms:
     return it != _last_seen.end() ? std::make_optional(it->second) : std::nullopt;
 }
 
-void storage_proxy::on_join_cluster(const gms::inet_address& endpoint) {};
+void storage_proxy::on_join_cluster(const gms::inet_address& endpoint) {
+    _last_seen.erase(endpoint);
+};
 
-void storage_proxy::on_leave_cluster(const gms::inet_address& endpoint) {};
+void storage_proxy::on_leave_cluster(const gms::inet_address& endpoint) {
+    _last_seen.erase(endpoint);
+};
 
-void storage_proxy::on_up(const gms::inet_address& endpoint) {};
+void storage_proxy::on_up(const gms::inet_address& endpoint) {
+    _last_seen.erase(endpoint);
+};
 
 void storage_proxy::retire_view_response_handlers(noncopyable_function<bool(const abstract_write_response_handler&)> filter_fun) {
     assert(thread::running_in_thread());

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -3443,9 +3443,12 @@ protected:
             return _proxy->query_mutations_locally(_schema, cmd, _partition_range, timeout, _trace_state);
         } else {
             tracing::trace(_trace_state, "read_mutation_data: sending a message to /{}", ep);
-            return _proxy->_messaging.send_read_mutation_data(netw::messaging_service::msg_addr{ep, 0}, timeout, *cmd, _partition_range).then([this, ep](rpc::tuple<reconcilable_result, rpc::optional<cache_temperature>> result_and_hit_rate) {
+            clock_type::time_point req_time = clock_type::now();
+            _proxy->mark_sent(ep, req_time);
+            return _proxy->_messaging.send_read_mutation_data(netw::messaging_service::msg_addr{ep, 0}, timeout, *cmd, _partition_range).then([this, ep, req_time](rpc::tuple<reconcilable_result, rpc::optional<cache_temperature>> result_and_hit_rate) {
                 auto&& [result, hit_rate] = result_and_hit_rate;
                 tracing::trace(_trace_state, "read_mutation_data: got response from /{}", ep);
+                _proxy->mark_responded(ep, req_time, clock_type::now());
                 return make_ready_future<rpc::tuple<foreign_ptr<lw_shared_ptr<reconcilable_result>>, cache_temperature>>(rpc::tuple(make_foreign(::make_lw_shared<reconcilable_result>(std::move(result))), hit_rate.value_or(cache_temperature::invalid())));
             });
         }
@@ -3460,9 +3463,12 @@ protected:
             return _proxy->query_result_local(_schema, _cmd, _partition_range, opts, _trace_state, timeout);
         } else {
             tracing::trace(_trace_state, "read_data: sending a message to /{}", ep);
-            return _proxy->_messaging.send_read_data(netw::messaging_service::msg_addr{ep, 0}, timeout, *_cmd, _partition_range, opts.digest_algo).then([this, ep](rpc::tuple<query::result, rpc::optional<cache_temperature>> result_hit_rate) {
+            clock_type::time_point req_time = clock_type::now();
+            _proxy->mark_sent(ep, req_time);
+            return _proxy->_messaging.send_read_data(netw::messaging_service::msg_addr{ep, 0}, timeout, *_cmd, _partition_range, opts.digest_algo).then([this, ep, req_time](rpc::tuple<query::result, rpc::optional<cache_temperature>> result_hit_rate) {
                 auto&& [result, hit_rate] = result_hit_rate;
                 tracing::trace(_trace_state, "read_data: got response from /{}", ep);
+                _proxy->mark_responded(ep, req_time, clock_type::now());
                 return make_ready_future<rpc::tuple<foreign_ptr<lw_shared_ptr<query::result>>, cache_temperature>>(rpc::tuple(make_foreign(::make_lw_shared<query::result>(std::move(result))), hit_rate.value_or(cache_temperature::invalid())));
             });
         }
@@ -3475,20 +3481,26 @@ protected:
                         timeout, digest_algorithm(*_proxy));
         } else {
             tracing::trace(_trace_state, "read_digest: sending a message to /{}", ep);
+            clock_type::time_point req_time = clock_type::now();
+            _proxy->mark_sent(ep, req_time);
             return _proxy->_messaging.send_read_digest(netw::messaging_service::msg_addr{ep, 0}, timeout, *_cmd,
-                        _partition_range, digest_algorithm(*_proxy)).then([this, ep] (
+                        _partition_range, digest_algorithm(*_proxy)).then([this, ep, req_time] (
                     rpc::tuple<query::result_digest, rpc::optional<api::timestamp_type>, rpc::optional<cache_temperature>> digest_timestamp_hit_rate) {
                 auto&& [d, t, hit_rate] = digest_timestamp_hit_rate;
                 tracing::trace(_trace_state, "read_digest: got response from /{}", ep);
+                _proxy->mark_responded(ep, req_time, clock_type::now());
                 return make_ready_future<rpc::tuple<query::result_digest, api::timestamp_type, cache_temperature>>(rpc::tuple(d, t ? t.value() : api::missing_timestamp, hit_rate.value_or(cache_temperature::invalid())));
             });
         }
     }
     future<> make_mutation_data_requests(lw_shared_ptr<query::read_command> cmd, data_resolver_ptr resolver, targets_iterator begin, targets_iterator end, clock_type::time_point timeout) {
         return parallel_for_each(begin, end, [this, &cmd, resolver = std::move(resolver), timeout] (gms::inet_address ep) {
-            return make_mutation_data_request(cmd, ep, timeout).then_wrapped([this, resolver, ep] (future<rpc::tuple<foreign_ptr<lw_shared_ptr<reconcilable_result>>, cache_temperature>> f) {
+            clock_type::time_point req_time = clock_type::now();
+            _proxy->mark_sent(ep, req_time);
+            return make_mutation_data_request(cmd, ep, timeout).then_wrapped([this, resolver, ep, req_time] (future<rpc::tuple<foreign_ptr<lw_shared_ptr<reconcilable_result>>, cache_temperature>> f) {
                 try {
                     auto v = f.get0();
+                    _proxy->mark_responded(ep, req_time, clock_type::now());
                     _cf->set_hit_rate(ep, std::get<1>(v));
                     resolver->add_mutate_data(ep, std::get<0>(std::move(v)));
                     ++_proxy->get_stats().mutation_data_read_completed.get_ep_stat(ep);
@@ -5254,6 +5266,27 @@ const db::hints::host_filter& storage_proxy::get_hints_host_filter() const {
     return _hints_manager.get_host_filter();
 }
 
+void storage_proxy::mark_responded(const gms::inet_address& ep, clock_type::time_point req_time, clock_type::time_point response_time) {
+    last_seen_info& info = _last_seen[ep];
+    info.last_rtt = response_time - req_time;
+    info.last_responded = response_time;
+}
+
+void storage_proxy::mark_sent(const gms::inet_address& ep, clock_type::time_point req_time) {
+    last_seen_info& info = _last_seen[ep];
+    // If last sending attempt was sufficiently old, the response
+    // info should be reset in order to avoid having stale records.
+    if (info.last_sent + 5s < req_time) {
+        info.last_responded = last_seen_info::unknown;
+    }
+    info.last_sent = req_time;
+}
+
+std::optional<storage_proxy::last_seen_info> storage_proxy::last_seen(const gms::inet_address& ep) const {
+    auto it = _last_seen.find(ep);
+    return it != _last_seen.end() ? std::make_optional(it->second) : std::nullopt;
+}
+
 void storage_proxy::on_join_cluster(const gms::inet_address& endpoint) {};
 
 void storage_proxy::on_leave_cluster(const gms::inet_address& endpoint) {};
@@ -5277,6 +5310,7 @@ void storage_proxy::retire_view_response_handlers(noncopyable_function<bool(cons
 }
 
 void storage_proxy::on_down(const gms::inet_address& endpoint) {
+    _last_seen.erase(endpoint);
     return retire_view_response_handlers([endpoint] (const abstract_write_response_handler& handler) {
         return handler.get_targets().contains(endpoint);
     });

--- a/service/storage_proxy.hh
+++ b/service/storage_proxy.hh
@@ -358,9 +358,11 @@ private:
     bool cannot_hint(const Range& targets, db::write_type type) const;
     bool hints_enabled(db::write_type type) const noexcept;
     db::hints::manager& hints_manager_for(db::write_type type);
+    bool is_likely_to_respond_in_time(const gms::inet_address& ep, clock_type::time_point timeout);
     std::vector<gms::inet_address> get_live_endpoints(keyspace& ks, const dht::token& token) const;
+    std::vector<gms::inet_address> get_live_endpoints_for_read(keyspace& ks, const dht::token& token, clock_type::time_point timeout);
     static void sort_endpoints_by_proximity(std::vector<gms::inet_address>& eps);
-    std::vector<gms::inet_address> get_live_sorted_endpoints(keyspace& ks, const dht::token& token) const;
+    std::vector<gms::inet_address> get_live_sorted_endpoints_for_read(keyspace& ks, const dht::token& token, clock_type::time_point timeout);
     db::read_repair_decision new_read_repair_decision(const schema& s);
     ::shared_ptr<abstract_read_executor> get_read_executor(lw_shared_ptr<query::read_command> cmd,
             schema_ptr schema,
@@ -370,7 +372,8 @@ private:
             tracing::trace_state_ptr trace_state,
             const std::vector<gms::inet_address>& preferred_endpoints,
             bool& is_bounced_read,
-            service_permit permit);
+            service_permit permit,
+            clock_type::time_point timeout);
     future<rpc::tuple<foreign_ptr<lw_shared_ptr<query::result>>, cache_temperature>> query_result_local(schema_ptr, lw_shared_ptr<query::read_command> cmd, const dht::partition_range& pr,
                                                                            query::result_options opts,
                                                                            tracing::trace_state_ptr trace_state,

--- a/service/storage_proxy.hh
+++ b/service/storage_proxy.hh
@@ -480,6 +480,11 @@ public:
         }
         return next;
     }
+
+    std::default_random_engine& get_urandom() {
+        return _urandom;
+    }
+
     void init_messaging_service();
     future<> uninit_messaging_service();
 

--- a/service/storage_proxy_stats.hh
+++ b/service/storage_proxy_stats.hh
@@ -202,6 +202,11 @@ struct stats : public write_stats {
     split_stats mutation_data_read_completed;
     split_stats mutation_data_read_errors;
 
+    // number of requests which were destined for this endpoint, but speculatively
+    // directed to other replicas or dropped, because this endpoint was not likely
+    // to respond within deadline
+    split_stats read_requests_speculatively_refused;
+
 public:
     stats();
     void register_stats();


### PR DESCRIPTION
This series presents a mechanism of disqualifying a node from read operations if it looks overloaded/down. It's based on estimating how long ago the target node was still responsive - an as that time gets longer than request's timeout, the chance for dropping the request increases.

Things to consider:
 1. Perhaps this mechanism should fire depending on the workload type (#8096, #8097)
 2. While I successfully tested an early version of this solution on AWS, I don't yet have any cool grafana screenshots for this specific version of the source code.
 3. The heuristics for qualifying requests for getting dropped should be subject to debate
 4. I haven't measured the performance penalty for looking up endpoints in a flat map for each sent request, but I strongly suspect it's not going to be noticeable, given that the number of entries is expected to be very small (roughly the number of live nodes in the cluster) and a flat map is used to take advantage of this fact.

/cc @avikivity @gleb-cloudius 