### PR TITLE
cdc: move (most of) CDC generation management to a new service

### DIFF
--- a/alternator/executor.hh
+++ b/alternator/executor.hh
@@ -53,6 +53,10 @@ namespace service {
     class storage_service;
 }
 
+namespace cdc {
+    class metadata;
+}
+
 namespace alternator {
 
 class rmw_operation;
@@ -140,6 +144,7 @@ class executor : public peering_sharded_service<executor> {
     service::migration_manager& _mm;
     db::system_distributed_keyspace& _sdks;
     service::storage_service& _ss;
+    cdc::metadata& _cdc_metadata;
     // An smp_service_group to be used for limiting the concurrency when
     // forwarding Alternator request between shards - if necessary for LWT.
     smp_service_group _ssg;
@@ -152,8 +157,8 @@ public:
     static constexpr auto KEYSPACE_NAME_PREFIX = "alternator_";
     static constexpr std::string_view INTERNAL_TABLE_PREFIX = ".scylla.alternator.";
 
-    executor(service::storage_proxy& proxy, service::migration_manager& mm, db::system_distributed_keyspace& sdks, service::storage_service& ss, smp_service_group ssg)
-        : _proxy(proxy), _mm(mm), _sdks(sdks), _ss(ss), _ssg(ssg) {}
+    executor(service::storage_proxy& proxy, service::migration_manager& mm, db::system_distributed_keyspace& sdks, service::storage_service& ss, cdc::metadata& cdc_metadata, smp_service_group ssg)
+        : _proxy(proxy), _mm(mm), _sdks(sdks), _ss(ss), _cdc_metadata(cdc_metadata), _ssg(ssg) {}
 
     future<request_return_type> create_table(client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value request);
     future<request_return_type> describe_table(client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value request);

--- a/alternator/streams.cc
+++ b/alternator/streams.cc
@@ -34,6 +34,7 @@
 #include "cdc/log.hh"
 #include "cdc/generation.hh"
 #include "cdc/cdc_options.hh"
+#include "cdc/metadata.hh"
 #include "db/system_distributed_keyspace.hh"
 #include "utils/UUID_gen.hh"
 #include "cql3/selection/selection.hh"
@@ -470,8 +471,7 @@ future<executor::request_return_type> executor::describe_stream(client_state& cl
     auto status = "DISABLED";
 
     if (opts.enabled()) {
-        auto& metadata = _ss.get_cdc_metadata();
-        if (!metadata.streams_available()) {
+        if (!_cdc_metadata.streams_available()) {
             status = "ENABLING";
         } else {
             status = "ENABLED";

--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -47,6 +47,7 @@
 #include "transport/controller.hh"
 #include "thrift/controller.hh"
 #include "locator/token_metadata.hh"
+#include "cdc/generation_service.hh"
 
 namespace api {
 
@@ -401,7 +402,7 @@ void set_storage_service(http_context& ctx, routes& r) {
     });
 
     ss::cdc_streams_check_and_repair.set(r, [&ctx] (std::unique_ptr<request> req) {
-        return service::get_local_storage_service().check_and_repair_cdc_streams().then([] {
+        return service::get_local_storage_service().get_cdc_generation_service().check_and_repair_cdc_streams().then([] {
             return make_ready_future<json::json_return_type>(json_void());
         });
     });

--- a/cdc/generation.hh
+++ b/cdc/generation.hh
@@ -190,10 +190,8 @@ std::optional<db_clock::time_point> get_streams_timestamp_for(const gms::inet_ad
  *
  * Returning from this function does not mean that the table update was successful: the function
  * might run an asynchronous task in the background.
- *
- * Run inside seastar::async context.
  */
-void update_streams_description(
+future<> update_streams_description(
         db_clock::time_point,
         shared_ptr<db::system_distributed_keyspace>,
         noncopyable_function<unsigned()> get_num_token_owners,

--- a/cdc/generation.hh
+++ b/cdc/generation.hh
@@ -167,7 +167,7 @@ future<db_clock::time_point> get_local_streams_timestamp();
  * (not guaranteed in the current implementation, but expected to be the common case;
  *  we assume that `ring_delay` is enough for other nodes to learn about the new generation).
  */
-db_clock::time_point make_new_cdc_generation(
+future<db_clock::time_point> make_new_cdc_generation(
         const db::config& cfg,
         const std::unordered_set<dht::token>& bootstrap_tokens,
         const locator::token_metadata_ptr tmptr,

--- a/cdc/generation_service.hh
+++ b/cdc/generation_service.hh
@@ -22,6 +22,7 @@
 
 #pragma once
 
+#include "cdc/metadata.hh"
 #include "gms/i_endpoint_state_change_subscriber.hh"
 
 namespace db {
@@ -40,12 +41,33 @@ class generation_service : public peering_sharded_service<generation_service>
 
     bool _stopped = false;
 
+    // The node has joined the token ring. Set to `true` on `after_join` call.
+    bool _joined = false;
+
     const db::config& _cfg;
     gms::gossiper& _gossiper;
     sharded<db::system_distributed_keyspace>& _sys_dist_ks;
     abort_source& _abort_src;
     const locator::shared_token_metadata& _token_metadata;
 
+    /* Maintains the set of known CDC generations used to pick streams for log writes (i.e., the partition keys of these log writes).
+     * Updated in response to certain gossip events (see the handle_cdc_generation function).
+     */
+    cdc::metadata _cdc_metadata;
+
+    /* The latest known generation timestamp and the timestamp that we're currently gossiping
+     * (as CDC_STREAMS_TIMESTAMP application state).
+     *
+     * Only shard 0 manages this, hence it will be std::nullopt on all shards other than 0.
+     * This timestamp is also persisted in the system.cdc_local table.
+     *
+     * On shard 0 this may be nullopt only in one special case: rolling upgrade, when we upgrade
+     * from an old version of Scylla that didn't support CDC. In that case one node in the cluster
+     * will create the first generation and start gossiping it; it may be us, or it may be some
+     * different node. In any case, eventually - after one of the nodes gossips the first timestamp
+     * - we'll catch on and this variable will be updated with that generation.
+     */
+    std::optional<db_clock::time_point> _gen_ts;
 public:
     generation_service(const db::config&, gms::gossiper&,
             sharded<db::system_distributed_keyspace>&, abort_source&, const locator::shared_token_metadata&);
@@ -53,7 +75,21 @@ public:
     future<> stop();
     ~generation_service();
 
-    future<> after_join();
+    /* After the node bootstraps and creates a new CDC generation, or restarts and loads the last
+     * known generation timestamp from persistent storage, this function should be called with
+     * that generation timestamp moved in as the `startup_gen_ts` parameter.
+     * This passes the responsibility of managing generations from the node startup code to this service;
+     * until then, the service remains dormant.
+     * At the time of writing this comment, the startup code is in `storage_service::join_token_ring`, hence
+     * `after_join` should be called at the end of that function.
+     * Precondition: the node has completed bootstrapping and system_distributed_keyspace is initialized.
+     * Must be called on shard 0 - that's where the generation management happens.
+     */
+    future<> after_join(std::optional<db_clock::time_point>&& startup_gen_ts);
+
+    cdc::metadata& get_cdc_metadata() {
+        return _cdc_metadata;
+    }
 
     virtual void before_change(gms::inet_address, gms::endpoint_state, gms::application_state, const gms::versioned_value&) override {}
     virtual void on_alive(gms::inet_address, gms::endpoint_state) override {}
@@ -63,6 +99,40 @@ public:
 
     virtual void on_join(gms::inet_address, gms::endpoint_state) override;
     virtual void on_change(gms::inet_address, gms::application_state, const gms::versioned_value&) override;
+
+    future<> check_and_repair_cdc_streams();
+
+private:
+    /* Retrieve the CDC generation which starts at the given timestamp (from a distributed table created for this purpose)
+     * and start using it for CDC log writes if it's not obsolete.
+     */
+    future<> handle_cdc_generation(std::optional<db_clock::time_point>);
+
+    /* If `handle_cdc_generation` fails, it schedules an asynchronous retry in the background
+     * using `async_handle_cdc_generation`.
+     */
+    void async_handle_cdc_generation(db_clock::time_point);
+
+    /* Wrapper around `do_handle_cdc_generation` which intercepts timeout/unavailability exceptions.
+     * Returns: do_handle_cdc_generation(ts). */
+    future<bool> do_handle_cdc_generation_intercept_nonfatal_errors(db_clock::time_point);
+
+    /* Returns `true` iff we started using the generation (it was not obsolete or already known),
+     * which means that this node might write some CDC log entries using streams from this generation. */
+    future<bool> do_handle_cdc_generation(db_clock::time_point);
+
+    /* Scan CDC generation timestamps gossiped by other nodes and retrieve the latest one.
+     * This function should be called once at the end of the node startup procedure
+     * (after the node is started and running normally, it will retrieve generations on gossip events instead).
+     */
+    future<> scan_cdc_generations();
+
+    /* generation_service code might be racing with system_distributed_keyspace deinitialization
+     * (the deinitialization order is broken).
+     * Therefore, whenever we want to access sys_dist_ks in a background task,
+     * we need to check if the instance is still there. Storing the shared pointer will keep it alive.
+     */
+    shared_ptr<db::system_distributed_keyspace> get_sys_dist_ks();
 };
 
 } // namespace cdc

--- a/cdc/generation_service.hh
+++ b/cdc/generation_service.hh
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Modified by ScyllaDB
+ * Copyright (C) 2021 ScyllaDB
+ *
+ */
+
+#pragma once
+
+#include "gms/i_endpoint_state_change_subscriber.hh"
+
+namespace db {
+class system_distributed_keyspace;
+}
+
+namespace gms {
+class gossiper;
+}
+
+namespace cdc {
+
+class generation_service : public peering_sharded_service<generation_service>
+                         , public async_sharded_service<generation_service>
+                         , public gms::i_endpoint_state_change_subscriber {
+
+    bool _stopped = false;
+
+    const db::config& _cfg;
+    gms::gossiper& _gossiper;
+    sharded<db::system_distributed_keyspace>& _sys_dist_ks;
+    abort_source& _abort_src;
+    const locator::shared_token_metadata& _token_metadata;
+
+public:
+    generation_service(const db::config&, gms::gossiper&,
+            sharded<db::system_distributed_keyspace>&, abort_source&, const locator::shared_token_metadata&);
+
+    future<> stop();
+    ~generation_service();
+
+    future<> after_join();
+
+    virtual void before_change(gms::inet_address, gms::endpoint_state, gms::application_state, const gms::versioned_value&) override {}
+    virtual void on_alive(gms::inet_address, gms::endpoint_state) override {}
+    virtual void on_dead(gms::inet_address, gms::endpoint_state) override {}
+    virtual void on_remove(gms::inet_address) override {}
+    virtual void on_restart(gms::inet_address, gms::endpoint_state) override {}
+
+    virtual void on_join(gms::inet_address, gms::endpoint_state) override;
+    virtual void on_change(gms::inet_address, gms::application_state, const gms::versioned_value&) override;
+};
+
+} // namespace cdc

--- a/cdc/log.cc
+++ b/cdc/log.cc
@@ -32,6 +32,7 @@
 #include "cdc/split.hh"
 #include "cdc/cdc_options.hh"
 #include "cdc/change_visitor.hh"
+#include "cdc/metadata.hh"
 #include "bytes.hh"
 #include "database.hh"
 #include "db/config.hh"
@@ -278,8 +279,8 @@ private:
     }
 };
 
-cdc::cdc_service::cdc_service(service::storage_proxy& proxy)
-    : cdc_service(db_context::builder(proxy).build())
+cdc::cdc_service::cdc_service(service::storage_proxy& proxy, cdc::metadata& cdc_metadata)
+    : cdc_service(db_context::builder(proxy, cdc_metadata).build())
 {}
 
 cdc::cdc_service::cdc_service(db_context ctxt)
@@ -571,8 +572,8 @@ static schema_ptr create_log_schema(const schema& s, std::optional<utils::UUID> 
     return b.build();
 }
 
-db_context::builder::builder(service::storage_proxy& proxy) 
-    : _proxy(proxy) 
+db_context::builder::builder(service::storage_proxy& proxy, cdc::metadata& cdc_metadata)
+    : _proxy(proxy), _cdc_metadata(cdc_metadata)
 {}
 
 db_context::builder& db_context::builder::with_migration_notifier(service::migration_notifier& migration_notifier) {
@@ -580,16 +581,11 @@ db_context::builder& db_context::builder::with_migration_notifier(service::migra
     return *this;
 }
 
-db_context::builder& db_context::builder::with_cdc_metadata(cdc::metadata& cdc_metadata) {
-    _cdc_metadata = cdc_metadata;
-    return *this;
-}
-
 db_context db_context::builder::build() {
     return db_context{
         _proxy,
         _migration_notifier ? _migration_notifier->get() : service::get_local_storage_service().get_migration_notifier(),
-        _cdc_metadata ? _cdc_metadata->get() : service::get_local_storage_service().get_cdc_metadata(),
+        _cdc_metadata,
     };
 }
 

--- a/cdc/log.hh
+++ b/cdc/log.hh
@@ -80,7 +80,7 @@ class cdc_service final : public async_sharded_service<cdc::cdc_service> {
     std::unique_ptr<impl> _impl;
 public:
     future<> stop();
-    cdc_service(service::storage_proxy&);
+    cdc_service(service::storage_proxy&, cdc::metadata&);
     cdc_service(db_context);
     ~cdc_service();
 
@@ -104,13 +104,12 @@ struct db_context final {
 
     class builder final {
         service::storage_proxy& _proxy;
+        cdc::metadata& _cdc_metadata;
         std::optional<std::reference_wrapper<service::migration_notifier>> _migration_notifier;
-        std::optional<std::reference_wrapper<cdc::metadata>> _cdc_metadata;
     public:
-        builder(service::storage_proxy& proxy);
+        builder(service::storage_proxy& proxy, cdc::metadata&);
 
         builder& with_migration_notifier(service::migration_notifier& migration_notifier);
-        builder& with_cdc_metadata(cdc::metadata&);
 
         db_context build();
     };

--- a/main.cc
+++ b/main.cc
@@ -82,6 +82,7 @@
 #include "redis/service.hh"
 #include "cdc/log.hh"
 #include "cdc/cdc_extension.hh"
+#include "cdc/generation_service.hh"
 #include "alternator/tags_extension.hh"
 #include "alternator/rmw_operation.hh"
 #include "db/paxos_grace_seconds_extension.hh"
@@ -787,6 +788,7 @@ int main(int ac, char** av) {
             static sharded<db::view::view_update_generator> view_update_generator;
             static sharded<cql3::cql_config> cql_config;
             static sharded<::cql_config_updater> cql_config_updater;
+            static sharded<cdc::generation_service> cdc_generation_service;
             cql_config.start().get();
             //FIXME: discarded future
             (void)cql_config_updater.start(std::ref(cql_config), std::ref(*cfg));
@@ -801,7 +803,7 @@ int main(int ac, char** av) {
             supervisor::notify("initializing storage service");
             service::storage_service_config sscfg;
             sscfg.available_memory = memory::stats().total_memory();
-            service::init_storage_service(stop_signal.as_sharded_abort_source(), db, gossiper, sys_dist_ks, view_update_generator, feature_service, sscfg, mm_notifier, token_metadata, messaging).get();
+            service::init_storage_service(stop_signal.as_sharded_abort_source(), db, gossiper, sys_dist_ks, view_update_generator, feature_service, sscfg, mm_notifier, token_metadata, messaging, cdc_generation_service).get();
             supervisor::notify("starting per-shard database core");
 
             sst_dir_semaphore.start(cfg->initial_sstable_loading_concurrency()).get();
@@ -1051,6 +1053,25 @@ int main(int ac, char** av) {
                 repair_uninit_messaging_service_handler().get();
             });
 
+            supervisor::notify("starting CDC Generation Management service");
+            /* This service uses the system distributed keyspace.
+             * It will only do that *after* the node has joined the token ring, and the token ring joining
+             * procedure (`storage_service::init_server`) is responsible for initializing sys_dist_ks.
+             * Hence the service will start using sys_dist_ks only after it was initialized.
+             *
+             * However, there is a problem with the service shutdown order: sys_dist_ks is stopped
+             * *before* CDC generation service is stopped (`storage_service::drain_on_shutdown` below),
+             * so CDC generation service takes sharded<db::sys_dist_ks> and must check local_is_initialized()
+             * every time it accesses it (because it may have been stopped already), then take local_shared()
+             * which will prevent sys_dist_ks from being destroyed while the service operates on it.
+             */
+            cdc_generation_service.start(std::ref(*cfg), std::ref(gossiper), std::ref(sys_dist_ks),
+                    std::ref(stop_signal.as_sharded_abort_source()), std::ref(token_metadata)).get();
+            auto stop_cdc_generation_service = defer_verbose_shutdown("CDC Generation Management service", [] {
+                cdc_generation_service.stop().get();
+            });
+
+            supervisor::notify("starting CDC log service");
             static sharded<cdc::cdc_service> cdc;
             cdc.start(std::ref(proxy)).get();
             auto stop_cdc_service = defer_verbose_shutdown("cdc log service", [] {

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -741,7 +741,7 @@ void storage_service::async_handle_cdc_generation(db_clock::time_point ts) {
                 const bool using_this_gen = ss->do_handle_cdc_generation_intercept_nonfatal_errors(ts);
                 if (using_this_gen) {
                     cdc::update_streams_description(ts, sys_dist_ks,
-                            [ss] { return ss->get_token_metadata().count_normal_token_owners(); }, ss->_abort_source);
+                            [ss] { return ss->get_token_metadata().count_normal_token_owners(); }, ss->_abort_source).get();
                 }
                 return;
             } catch (cdc_generation_handling_nonfatal_exception& e) {
@@ -792,7 +792,7 @@ void storage_service::handle_cdc_generation(std::optional<db_clock::time_point> 
 
     if (using_this_gen) {
         cdc::update_streams_description(*ts, _sys_dist_ks.local_shared(),
-               [ss = this->shared_from_this()] { return ss->get_token_metadata().count_normal_token_owners(); }, _abort_source);
+               [ss = this->shared_from_this()] { return ss->get_token_metadata().count_normal_token_owners(); }, _abort_source).get();
     }
 }
 

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -618,9 +618,7 @@ void storage_service::join_token_ring(int delay) {
         throw std::runtime_error(err);
     }
 
-    _cdc_gen_service.local().after_join().get();
-    // Retrieve the latest CDC generation seen in gossip (if any).
-    scan_cdc_generations();
+    _cdc_gen_service.local().after_join(std::move(_cdc_streams_ts)).get();
 
     // Ensure that the new CDC stream description table has all required streams.
     // See the function's comment for details.
@@ -628,7 +626,6 @@ void storage_service::join_token_ring(int delay) {
             _db.local(), _sys_dist_ks.local_shared(),
             [tm = get_token_metadata_ptr()] { return tm->count_normal_token_owners(); },
             _abort_source).get();
-
 }
 
 void storage_service::mark_existing_views_as_built() {
@@ -641,274 +638,6 @@ void storage_service::mark_existing_views_as_built() {
             });
         });
     }).get();
-}
-
-// Run inside seastar::async context.
-bool storage_service::do_handle_cdc_generation(db_clock::time_point ts) {
-
-    auto gen = _sys_dist_ks.local().read_cdc_topology_description(
-            ts, { get_token_metadata().count_normal_token_owners() }).get0();
-    if (!gen) {
-        throw std::runtime_error(format(
-            "Could not find CDC generation with timestamp {} in distributed system tables (current time: {}),"
-            " even though some node gossiped about it.",
-            ts, db_clock::now()));
-    }
-
-    // If we're not gossiping our own generation timestamp (because we've upgraded from a non-CDC/old version,
-    // or we somehow lost it due to a byzantine failure), start gossiping someone else's timestamp.
-    // This is to avoid the upgrade check on every restart (see `should_propose_first_cdc_generation`).
-    // And if we notice that `ts` is higher than our timestamp, we will start gossiping it instead,
-    // so if the node that initially gossiped `ts` leaves the cluster while `ts` is still the latest generation,
-    // the cluster will remember.
-    if (!_cdc_streams_ts || *_cdc_streams_ts < ts) {
-        _cdc_streams_ts = ts;
-        db::system_keyspace::update_cdc_streams_timestamp(ts).get();
-        _gossiper.add_local_application_state(
-                gms::application_state::CDC_STREAMS_TIMESTAMP, versioned_value::cdc_streams_timestamp(ts)).get();
-    }
-
-    class orer {
-    private:
-        bool _result = false;
-    public:
-        future<> operator()(bool value) {
-            _result = value || _result;
-            return make_ready_future<>();
-        }
-        bool get() {
-            return _result;
-        }
-    };
-
-    // Return `true` iff the generation was inserted on any of our shards.
-    return container().map_reduce(orer(), [ts, &gen] (storage_service& ss) {
-        auto gen_ = *gen;
-        return ss._cdc_metadata.insert(ts, std::move(gen_));
-    }).get0();
-}
-
-namespace {
-class cdc_generation_handling_nonfatal_exception : public std::runtime_error {
-    using std::runtime_error::runtime_error;
-};
-
-constexpr char could_not_retrieve_msg_template[]
-        = "Could not retrieve CDC streams with timestamp {} upon gossip event. Reason: \"{}\". Action: {}.";
-} // anon. namespace
-
-bool storage_service::do_handle_cdc_generation_intercept_nonfatal_errors(db_clock::time_point ts) {
-    try {
-        return do_handle_cdc_generation(ts);
-    } catch (exceptions::request_timeout_exception& e) {
-        throw cdc_generation_handling_nonfatal_exception(e.what());
-    } catch (exceptions::unavailable_exception& e) {
-        throw cdc_generation_handling_nonfatal_exception(e.what());
-    } catch (exceptions::read_failure_exception& e) {
-        throw cdc_generation_handling_nonfatal_exception(e.what());
-    } catch (...) {
-        const auto ep = std::current_exception();
-        if (is_timeout_exception(ep)) {
-            throw cdc_generation_handling_nonfatal_exception(format("{}", ep));
-        }
-        throw;
-    }
-}
-
-class ander {
-private:
-    bool _result = true;
-public:
-    future<> operator()(bool value) {
-        _result = value && _result;
-        return make_ready_future<>();
-    }
-    bool get() {
-        return _result;
-    }
-};
-
-void storage_service::async_handle_cdc_generation(db_clock::time_point ts) {
-
-    // It is safe to discard this future: we keep the storage_service, gossiper,
-    // and system distributed keyspace alive for the whole duration of this operation.
-    (void)seastar::async([this, ts,
-        g = _gossiper.shared_from_this(), ss = this->shared_from_this(), sys_dist_ks = _sys_dist_ks.local_shared()
-    ] {
-        while (true) {
-            sleep_abortable(std::chrono::seconds(5), ss->_abort_source).get();
-            try {
-                const bool using_this_gen = ss->do_handle_cdc_generation_intercept_nonfatal_errors(ts);
-                if (using_this_gen) {
-                    cdc::update_streams_description(ts, sys_dist_ks,
-                            [ss] { return ss->get_token_metadata().count_normal_token_owners(); }, ss->_abort_source).get();
-                }
-                return;
-            } catch (cdc_generation_handling_nonfatal_exception& e) {
-                if (container().map_reduce(ander(), [ts] (storage_service& ss) {
-                    return ss._cdc_metadata.known_or_obsolete(ts);
-                }).get0()) {
-                    return;
-                }
-                cdc_log.warn(could_not_retrieve_msg_template, ts, e.what(), "continuing to retry in the background");
-            } catch (...) {
-                cdc_log.error(could_not_retrieve_msg_template, ts, std::current_exception(), "not retrying anymore");
-                return; // Exotic ("fatal") exception => do not retry
-            }
-        }
-    });
-}
-
-// Run inside async
-void storage_service::handle_cdc_generation(std::optional<db_clock::time_point> ts) {
-    if (!ts) {
-        return;
-    }
-
-    if (!db::system_keyspace::bootstrap_complete() || !_sys_dist_ks.local_is_initialized()
-            || !_sys_dist_ks.local().started()) {
-        // We still haven't finished the startup process.
-        // We will handle this generation in `scan_cdc_generations` (unless there's a newer one).
-        return;
-    }
-
-    if (container().map_reduce(ander(), [ts = *ts] (storage_service& ss) {
-        return !ss._cdc_metadata.prepare(ts);
-    }).get0()) {
-        return;
-    }
-
-    bool using_this_gen = false;
-    try {
-        using_this_gen = do_handle_cdc_generation_intercept_nonfatal_errors(*ts);
-    } catch (cdc_generation_handling_nonfatal_exception& e) {
-        cdc_log.warn(could_not_retrieve_msg_template, ts, e.what(), "retrying in the background");
-        async_handle_cdc_generation(*ts);
-        return;
-    } catch(...) {
-        cdc_log.error(could_not_retrieve_msg_template, ts, std::current_exception(), "not retrying");
-        return; // Exotic ("fatal") exception => do not retry
-    }
-
-    if (using_this_gen) {
-        cdc::update_streams_description(*ts, _sys_dist_ks.local_shared(),
-               [ss = this->shared_from_this()] { return ss->get_token_metadata().count_normal_token_owners(); }, _abort_source).get();
-    }
-}
-
-// Runs inside seastar::async context.
-void storage_service::scan_cdc_generations() {
-    std::optional<db_clock::time_point> latest;
-    for (const auto& ep: _gossiper.get_endpoint_states()) {
-        auto ts = cdc::get_streams_timestamp_for(ep.first, _gossiper);
-        if (!latest || (ts && *ts > *latest)) {
-            latest = ts;
-        }
-    }
-
-    if (latest) {
-        cdc_log.info("Latest generation seen during startup: {}", *latest);
-        handle_cdc_generation(latest);
-    } else {
-        cdc_log.info("No generation seen during startup.");
-    }
-}
-
-future<> storage_service::check_and_repair_cdc_streams() {
-    return async([this] { 
-        auto latest = _cdc_streams_ts;
-        const auto& endpoint_states = _gossiper.get_endpoint_states();
-        for (const auto& [addr, state] : endpoint_states) {
-            if (!_gossiper.is_normal(addr))  {
-                throw std::runtime_error(format("All nodes must be in NORMAL state while performing check_and_repair_cdc_streams"
-                        " ({} is in state {})", addr, _gossiper.get_gossip_status(state)));
-            }
-
-            const auto ts = cdc::get_streams_timestamp_for(addr, _gossiper);
-            if (!latest || (ts && *ts > *latest)) {
-                latest = ts;
-            }
-        }
-
-        bool should_regenerate = false;
-        std::optional<cdc::topology_description> gen;
-
-        static const auto timeout_msg = "Timeout while fetching CDC topology description";
-        static const auto topology_read_error_note = "Note: this is likely caused by"
-                " node(s) being down or unreachable. It is recommended to check the network and"
-                " restart/remove the failed node(s), then retry checkAndRepairCdcStreams command";
-        static const auto exception_translating_msg = "Translating the exception to `request_execution_exception`";
-        const auto tmptr = get_token_metadata_ptr();
-        try {
-            gen = _sys_dist_ks.local().read_cdc_topology_description(
-                    *latest, { tmptr->count_normal_token_owners() }).get0();
-        } catch (exceptions::request_timeout_exception& e) {
-            cdc_log.error("{}: \"{}\". {}.", timeout_msg, e.what(), exception_translating_msg);
-            throw exceptions::request_execution_exception(exceptions::exception_code::READ_TIMEOUT,
-                    format("{}. {}.", timeout_msg, topology_read_error_note));
-        } catch (exceptions::unavailable_exception& e) {
-            static const auto unavailable_msg = "Node(s) unavailable while fetching CDC topology description";
-            cdc_log.error("{}: \"{}\". {}.", unavailable_msg, e.what(), exception_translating_msg);
-            throw exceptions::request_execution_exception(exceptions::exception_code::UNAVAILABLE,
-                    format("{}. {}.", unavailable_msg, topology_read_error_note));
-        } catch (...) {
-            const auto ep = std::current_exception();
-            if (is_timeout_exception(ep)) {
-                cdc_log.error("{}: \"{}\". {}.", timeout_msg, ep, exception_translating_msg);
-                throw exceptions::request_execution_exception(exceptions::exception_code::READ_TIMEOUT,
-                        format("{}. {}.", timeout_msg, topology_read_error_note));
-            }
-            // On exotic errors proceed with regeneration
-            cdc_log.error("Exception while reading CDC topology description: \"{}\". Regenerating streams anyway.", ep);
-            should_regenerate = true;
-        }
-
-        if (!gen) {
-            cdc_log.error(
-                "Could not find CDC generation with timestamp {} in distributed system tables (current time: {}),"
-                " even though some node gossiped about it.",
-                latest, db_clock::now());
-            should_regenerate = true;
-        } else {
-            std::unordered_set<dht::token> gen_ends;
-            for (const auto& entry : gen->entries()) {
-                gen_ends.insert(entry.token_range_end);
-            }
-            for (const auto& metadata_token : tmptr->sorted_tokens()) {
-                if (!gen_ends.contains(metadata_token)) {
-                    cdc_log.warn("CDC generation {} missing token {}. Regenerating.", latest, metadata_token);
-                    should_regenerate = true;
-                    break;
-                }
-            }
-        }
-
-        if (!should_regenerate) {
-            if (latest != _cdc_streams_ts) {
-                do_handle_cdc_generation(*latest);
-            }
-            cdc_log.info("CDC generation {} does not need repair", latest);
-            return;
-        }
-        const auto new_streams_ts = cdc::make_new_cdc_generation(db().local().get_config(),
-                {}, std::move(tmptr), _gossiper,
-                _sys_dist_ks.local(), get_ring_delay(), true /* add delay */).get0();
-        // Need to artificially update our STATUS so other nodes handle the timestamp change
-        auto status = _gossiper.get_application_state_ptr(get_broadcast_address(), application_state::STATUS);
-        if (!status) {
-            slogger.error("Our STATUS is missing");
-            cdc_log.error("Aborting CDC generation repair due to missing STATUS");
-            return;
-        }
-        // Update _cdc_streams_ts first, so that do_handle_cdc_generation (which will get called due to the status update)
-        // won't try to update the gossiper, which would result in a deadlock inside add_local_application_state
-        _cdc_streams_ts = new_streams_ts;
-        _gossiper.add_local_application_state({
-                { gms::application_state::CDC_STREAMS_TIMESTAMP, versioned_value::cdc_streams_timestamp(new_streams_ts) },
-                { gms::application_state::STATUS, *status }
-        }).get();
-        db::system_keyspace::update_cdc_streams_timestamp(new_streams_ts).get();
-    });
 }
 
 // Runs inside seastar::async context
@@ -1098,7 +827,6 @@ void storage_service::handle_state_bootstrap(inet_address endpoint) {
     slogger.debug("endpoint={} handle_state_bootstrap", endpoint);
     // explicitly check for TOKENS, because a bootstrapping node might be bootstrapping in legacy mode; that is, not using vnodes and no token specified
     auto tokens = get_tokens_for(endpoint);
-    auto cdc_streams_ts = cdc::get_streams_timestamp_for(endpoint, _gossiper);
 
     slogger.debug("Node {} state bootstrapping, token {}", endpoint, tokens);
 
@@ -1119,8 +847,6 @@ void storage_service::handle_state_bootstrap(inet_address endpoint) {
         tmptr->remove_endpoint(endpoint);
     }
 
-    handle_cdc_generation(cdc_streams_ts);
-
     tmptr->add_bootstrap_tokens(tokens, endpoint);
     if (_gossiper.uses_host_id(endpoint)) {
         tmptr->update_host_id(_gossiper.get_host_id(endpoint), endpoint);
@@ -1132,10 +858,8 @@ void storage_service::handle_state_bootstrap(inet_address endpoint) {
 void storage_service::handle_state_normal(inet_address endpoint) {
     slogger.debug("endpoint={} handle_state_normal", endpoint);
     auto tokens = get_tokens_for(endpoint);
-    auto cdc_streams_ts = cdc::get_streams_timestamp_for(endpoint, _gossiper);
 
     slogger.debug("Node {} state normal, token {}", endpoint, tokens);
-    cdc_log.debug("Node {} state normal, streams timestamp: {}", endpoint, cdc_streams_ts);
 
     auto tmlock = std::make_unique<token_metadata_lock>(get_token_metadata_lock().get0());
     auto tmptr = get_mutable_token_metadata_ptr().get0();
@@ -1213,8 +937,6 @@ void storage_service::handle_state_normal(inet_address endpoint) {
         }
     }
 
-    handle_cdc_generation(cdc_streams_ts);
-
     bool is_member = tmptr->is_member(endpoint);
     // Update pending ranges after update of normal tokens immediately to avoid
     // a race where natural endpoint was updated to contain node A, but A was
@@ -1257,10 +979,8 @@ void storage_service::handle_state_leaving(inet_address endpoint) {
     slogger.debug("endpoint={} handle_state_leaving", endpoint);
 
     auto tokens = get_tokens_for(endpoint);
-    auto cdc_streams_ts = cdc::get_streams_timestamp_for(endpoint, _gossiper);
 
     slogger.debug("Node {} state leaving, tokens {}", endpoint, tokens);
-    cdc_log.debug("Node {} state leaving, streams timestamp: {}", endpoint, cdc_streams_ts);
 
     // If the node is previously unknown or tokens do not match, update tokenmetadata to
     // have this node as 'normal' (it must have been using this token before the
@@ -1271,7 +991,6 @@ void storage_service::handle_state_leaving(inet_address endpoint) {
         // FIXME: this code should probably resolve token collisions too, like handle_state_normal
         slogger.info("Node {} state jump to leaving", endpoint);
 
-        handle_cdc_generation(cdc_streams_ts);
         tmptr->update_normal_tokens(tokens, endpoint).get();
     } else {
         auto tokens_ = tmptr->get_tokens(endpoint);
@@ -1280,7 +999,6 @@ void storage_service::handle_state_leaving(inet_address endpoint) {
             slogger.warn("Node {} 'leaving' token mismatch. Long network partition?", endpoint);
             slogger.debug("tokens_={}, tokens={}", tokens_, tmp);
 
-            handle_cdc_generation(cdc_streams_ts);
             tmptr->update_normal_tokens(tokens, endpoint).get();
         }
     }

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -589,7 +589,7 @@ void storage_service::join_token_ring(int delay) {
             try {
                 _cdc_streams_ts = cdc::make_new_cdc_generation(db().local().get_config(),
                         _bootstrap_tokens, get_token_metadata_ptr(), _gossiper,
-                        _sys_dist_ks.local(), get_ring_delay(), !_for_testing && !is_first_node());
+                        _sys_dist_ks.local(), get_ring_delay(), !_for_testing && !is_first_node()).get0();
             } catch (...) {
                 cdc_log.warn(
                     "Could not create a new CDC generation: {}. This may make it impossible to use CDC. Use nodetool checkAndRepairCdcStreams to fix CDC generation",
@@ -892,7 +892,7 @@ future<> storage_service::check_and_repair_cdc_streams() {
         }
         const auto new_streams_ts = cdc::make_new_cdc_generation(db().local().get_config(),
                 {}, std::move(tmptr), _gossiper,
-                _sys_dist_ks.local(), get_ring_delay(), true /* add delay */);
+                _sys_dist_ks.local(), get_ring_delay(), true /* add delay */).get0();
         // Need to artificially update our STATUS so other nodes handle the timestamp change
         auto status = _gossiper.get_application_state_ptr(get_broadcast_address(), application_state::STATUS);
         if (!status) {
@@ -938,7 +938,7 @@ void storage_service::bootstrap() {
 
         _cdc_streams_ts = cdc::make_new_cdc_generation(db().local().get_config(),
                 _bootstrap_tokens, get_token_metadata_ptr(), _gossiper,
-                _sys_dist_ks.local(), get_ring_delay(), !_for_testing && !is_first_node());
+                _sys_dist_ks.local(), get_ring_delay(), !_for_testing && !is_first_node()).get0();
 
         _gossiper.add_local_application_state({
             // Order is important: both the CDC streams timestamp and tokens must be known when a node handles our status.

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -63,7 +63,6 @@
 #include <seastar/core/rwlock.hh>
 #include "sstables/version.hh"
 #include "sstables/shared_sstable.hh"
-#include "cdc/metadata.hh"
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/core/lowres_clock.hh>
 #include "locator/snitch_base.hh"
@@ -248,10 +247,6 @@ public:
         return *_shared_token_metadata.get();
     }
 
-    cdc::metadata& get_cdc_metadata() {
-        return _cdc_metadata;
-    }
-
     const service::migration_notifier& get_migration_notifier() const {
         return _mnotifier.local();
     }
@@ -273,6 +268,14 @@ public:
         return _service_memory_limiter;
     }
 
+    cdc::generation_service& get_cdc_generation_service() {
+        if (!_cdc_gen_service.local_is_initialized()) {
+            throw std::runtime_error("get_cdc_generation_service: not initialized yet");
+        }
+
+        return _cdc_gen_service.local();
+    }
+
 private:
     bool is_auto_bootstrap() const;
     inet_address get_broadcast_address() const {
@@ -281,10 +284,6 @@ private:
     /* This abstraction maintains the token/endpoint metadata information */
     mutable_token_metadata_ptr _pending_token_metadata_ptr;
     shared_token_metadata& _shared_token_metadata;
-
-    // Maintains the set of known CDC generations used to pick streams for log writes (i.e., the partition keys of these log writes).
-    // Updated in response to certain gossip events (see the handle_cdc_generation function).
-    cdc::metadata _cdc_metadata;
 
     /* CDC generation management service.
      * It is sharded<>& and not simply a reference because the service will not yet be started
@@ -336,6 +335,13 @@ private:
      * 1. this node is being upgraded from a non-CDC version,
      * 2. this node is starting for the first time or restarting with CDC previously disabled,
      *    in which case the value should become populated before we leave the join_token_ring procedure.
+     *
+     * Important: this variable is using only during the startup procedure. It is moved out from
+     * at the end of `join_token_ring`; the responsibility handling of CDC generations is passed
+     * to cdc::generation_service.
+     *
+     * DO NOT use this variable after `join_token_ring` (i.e. after we call `generation_service::after_join`
+     * and pass it the ownership of the timestamp.
      */
     std::optional<db_clock::time_point> _cdc_streams_ts;
 
@@ -581,31 +587,6 @@ private:
     void do_update_system_peers_table(gms::inet_address endpoint, const application_state& state, const versioned_value& value);
 
     std::unordered_set<token> get_tokens_for(inet_address endpoint);
-
-    /* Retrieve the CDC generation which starts at the given timestamp (from a distributed table created for this purpose)
-     * and start using it for CDC log writes if it's not obsolete.
-     */
-    void handle_cdc_generation(std::optional<db_clock::time_point>);
-    /* Returns `true` iff we started using the generation (it was not obsolete),
-     * which means that this node might write some CDC log entries using streams from this generation. */
-    bool do_handle_cdc_generation(db_clock::time_point);
-    /* Wrapper around `do_handle_cdc_generation` which intercepts timeout/unavailability exceptions.
-     * Returns: do_handle_cdc_generation(ts). */
-    bool do_handle_cdc_generation_intercept_nonfatal_errors(db_clock::time_point ts);
-
-    /* If `handle_cdc_generation` fails, it schedules an asynchronous retry in the background
-     * using `async_handle_cdc_generation`.
-     */
-    void async_handle_cdc_generation(db_clock::time_point);
-
-    /* Scan CDC generation timestamps gossiped by other nodes and retrieve the latest one.
-     * This function should be called once at the end of the node startup procedure
-     * (after the node is started and running normally, it will retrieve generations on gossip events instead).
-     */
-    void scan_cdc_generations();
-
-public:
-    future<> check_and_repair_cdc_streams();
 private:
     // Should be serialized under token_metadata_lock.
     future<> replicate_to_all_cores(mutable_token_metadata_ptr tmptr) noexcept;

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -586,7 +586,8 @@ public:
             });
 
             sharded<cdc::cdc_service> cdc;
-            cdc.start(std::ref(proxy)).get();
+            auto get_cdc_metadata = [] (cdc::generation_service& svc) { return std::ref(svc.get_cdc_metadata()); };
+            cdc.start(std::ref(proxy), sharded_parameter(get_cdc_metadata, std::ref(cdc_generation_service))).get();
             auto stop_cdc_service = defer([&] {
                 cdc.stop().get();
             });

--- a/test/manual/gossip.cc
+++ b/test/manual/gossip.cc
@@ -80,6 +80,7 @@ int main(int ac, char ** av) {
             sharded<service::migration_notifier> mnotif;
             sharded<locator::shared_token_metadata> token_metadata;
             sharded<netw::messaging_service> messaging;
+            sharded<cdc::generation_service> cdc_generation_service;
 
             abort_sources.start().get();
             auto stop_abort_source = defer([&] { abort_sources.stop().get(); });
@@ -91,7 +92,7 @@ int main(int ac, char ** av) {
             sscfg.available_memory = memory::stats().total_memory();
             messaging.start(listen).get();
             gms::get_gossiper().start(std::ref(abort_sources), std::ref(feature_service), std::ref(token_metadata), std::ref(messaging), std::ref(*cfg)).get();
-            service::init_storage_service(std::ref(abort_sources), db, gms::get_gossiper(), sys_dist_ks, view_update_generator, feature_service, sscfg, mnotif, token_metadata, messaging).get();
+            service::init_storage_service(std::ref(abort_sources), db, gms::get_gossiper(), sys_dist_ks, view_update_generator, feature_service, sscfg, mnotif, token_metadata, messaging, std::ref(cdc_generation_service)).get();
             auto& server = messaging.local();
             auto port = server.port();
             auto msg_listen = server.listen_address();


### PR DESCRIPTION
Currently all management of CDC generations happens in storage_service,
which is a big ball of mud that does many unrelated things.

This PR introduces a new service crafted to handle CDC generation
management: listening and reacting to generation changes in the cluster.

We plug the service in, initializing it in main and test code,
passing a reference to storage_service and having storage_service call
the service (using the `after_join` method): the service only starts
doing its job after the node joins the token ring (either on bootstrap
or restart).

Some parts of generation management still remain in storage_service:
the bootstrap procedure, which happens inside storage_service,
must also do some initialization regarding CDC generations,
for example: on restart it must retrieve the latest known generation
timestamp from disk; on bootstrap it must create a new generation
and announce it to other nodes. The order of these operations w.r.t
the rest of the startup procedure is important, hence the startup
procedure is the only right place for them. We may try decoupling
these services even more in follow-up PRs, but that requires a bit
of careful reasoning. What this PR does is a low-hanging fruit.

Still, what remains in storage_service is a small part of the entire
CDC generation management logic; most of it has been moved to the
new service. This includes listening for generation changes and
updating the data structures for performing CDC log writes (cdc::metadata).
Furthermore these handling functions now return futures (and are internally
coroutines), where previously they required a seastar::async context.

This PR is a prerequisite to fixing #7985. The fact that all the CDC generation
management code was in storage_service is technical debt. It will be easier
to modify the management algorithms when they sit in their own module.

Tests: unit (dev) and cdc_tests.py dtest (dev), and local replication test using scylla-cdc-java