### PR TITLE
dist/debian: fix renaming debian/scylla-* files rule

### DIFF
--- a/dist/debian/debian_files_gen.py
+++ b/dist/debian/debian_files_gen.py
@@ -23,8 +23,8 @@
 
 import string
 import os
-import glob
 import shutil
+import re
 from pathlib import Path
 
 class DebianFilesTemplate(string.Template):
@@ -53,12 +53,19 @@ shutil.copytree('dist/debian/debian', 'build/debian/debian')
 
 if product != 'scylla':
     for p in Path('build/debian/debian').glob('scylla-*'):
-        if str(p).endswith('scylla-server.service'):
-            p.rename(p.parent / '{}-server.{}'.format(product, p.name))
-        elif str(p).endswith('scylla-node-exporter.service'):
-            p.rename(p.parent / '{}-node-exporter.{}'.format(product, p.name))
+        # pat1: scylla-server.service
+        #    -> scylla-enterprise-server.scylla-server.service
+        # pat2: scylla-server.scylla-fstrim.service
+        #    -> scylla-enterprise-server.scylla-fstrim.service
+        # pat3: scylla-conf.install
+        #    -> scylla-enterprise-conf.install
+
+        if m := re.match(r'^scylla(-[^.]+)\.service$', p.name):
+            p.rename(p.parent / f'{product}{m.group(1)}.{p.name}')
+        elif m := re.match(r'^scylla(-[^.]+\.scylla-[^.]+\.[^.]+)$', p.name):
+            p.rename(p.parent / f'{product}{m.group(1)}')
         else:
-            p.rename(p.parent / p.name.replace('scylla-', f'{product}-'))
+            p.rename(p.parent / p.name.replace('scylla', product, 1))
 
 s = DebianFilesTemplate(changelog_template)
 changelog_applied = s.substitute(product=product, version=version, release=release, revision='1', codename='stable')


### PR DESCRIPTION
Current renaming rule of debian/scylla-* files is buggy, it fails to
install some .service files when custom product name specified.

Introduce regex based rewriting instead of adhoc renaming, and fixed
wrong renaming rule.

Fixes #8113