### PR TITLE
add fix_system_distributed_tables.py to the package, add cassandra-driver to relocatable python3

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -59,6 +59,7 @@ i18n_xlat = {
 }
 
 python3_dependencies = subprocess.run('./install-dependencies.sh --print-python3-runtime-packages', shell=True, capture_output=True, encoding='utf-8').stdout.strip()
+pip_dependencies = subprocess.run('./install-dependencies.sh --print-pip-runtime-packages', shell=True, capture_output=True, encoding='utf-8').stdout.strip()
 node_exporter_filename = subprocess.run('./install-dependencies.sh --print-node-exporter-filename', shell=True, capture_output=True, encoding='utf-8').stdout.strip()
 node_exporter_dirname = os.path.basename(node_exporter_filename).rstrip('.tar.gz')
 
@@ -1940,7 +1941,7 @@ with open(buildfile_tmp, 'w') as f:
 
         build tools/python3/build/{scylla_product}-python3-package.tar.gz: build-submodule-reloc
           reloc_dir = tools/python3
-          args = --packages "{python3_dependencies}"
+          args = --packages "{python3_dependencies}" --pip-packages "{pip_dependencies}"
         build dist-python3-rpm: build-submodule-rpm tools/python3/build/{scylla_product}-python3-package.tar.gz
           dir = tools/python3
           artifact = $builddir/{scylla_product}-python3-package.tar.gz

--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -103,6 +103,12 @@ fedora_python3_packages=(
     python3-setuptools
     python3-psutil
     python3-distro
+    python3-six
+    python3-geomet-0.2.1-5.fc33
+)
+
+pip_packages=(
+    cassandra-driver
 )
 
 centos_packages=(
@@ -175,16 +181,22 @@ print_usage() {
     echo "Usage: install-dependencies.sh [OPTION]..."
     echo ""
     echo "  --print-python3-runtime-packages Print required python3 packages for Scylla"
+    echo "  --print-pip-runtime-packages Print required pip packages for Scylla"
     echo "  --print-node-exporter-filename Print node_exporter filename"
     exit 1
 }
 
 PRINT_PYTHON3=false
+PRINT_PIP=false
 PRINT_NODE_EXPORTER=false
 while [ $# -gt 0 ]; do
     case "$1" in
         "--print-python3-runtime-packages")
             PRINT_PYTHON3=true
+            shift 1
+            ;;
+        "--print-pip-runtime-packages")
+            PRINT_PIP=true
             shift 1
             ;;
         "--print-node-exporter-filename")
@@ -203,6 +215,11 @@ if $PRINT_PYTHON3; then
         exit 1
     fi
     echo "${fedora_python3_packages[@]}"
+    exit 0
+fi
+
+if $PRINT_PIP; then
+    echo "${pip_packages[@]}"
     exit 0
 fi
 
@@ -235,7 +252,8 @@ elif [ "$ID" = "fedora" ]; then
         exit 1
     fi
     yum install -y "${fedora_packages[@]}" "${fedora_python3_packages[@]}"
-    pip3 install cassandra-driver
+    # Disable C extensions
+    pip3 install cassandra-driver --install-option="--no-murmur3" --install-option="--no-libev" --install-option="--no-cython"
 
     if [ -f "$(node_exporter_fullpath)" ] && node_exporter_checksum; then
         echo "$(node_exporter_filename) already exists, skipping download"

--- a/install.sh
+++ b/install.sh
@@ -426,6 +426,7 @@ for i in seastar/scripts/perftune.py seastar/scripts/seastar-addr2line; do
     relocate_python3 "$rprefix"/scripts "$i"
 done
 relocate_python3 "$rprefix"/scyllatop tools/scyllatop/scyllatop.py
+relocate_python3 "$rprefix"/scripts fix_system_distributed_tables.py
 
 if $nonroot; then
     sed -i -e "s#/var/lib/scylla#$rprefix#g" $rsysconfdir/scylla-server

--- a/scripts/create-relocatable-package.py
+++ b/scripts/create-relocatable-package.py
@@ -164,6 +164,7 @@ ar.reloc_add('scylla-gdb.py')
 ar.reloc_add('build/debian/debian', arcname='debian')
 ar.reloc_add('build/node_exporter', arcname='node_exporter')
 ar.reloc_add('ubsan-suppressions.supp')
+ar.reloc_add('fix_system_distributed_tables.py')
 
 # Complete the tar output, and wait for the gzip process to complete
 ar.close()


### PR DESCRIPTION
Add fix_system_distributed_tables.py to the package.
Since the script requires cassandra-driver, add it to relocatable python3.

But python cassandra-driver rpm does not available, and our relocatable python3 requires rpm to solve dependencies,
the PR do some trick:
install by pip -> convert pip to rpm -> convert to relocatable python3