### PR TITLE
draft: transport: Drop overdue requests from the admission queue

### DIFF
--- a/transport/server.cc
+++ b/transport/server.cc
@@ -613,6 +613,10 @@ cql_server::connection::connection(cql_server& server, socket_address server_add
     ++_server._total_connections;
     ++_server._current_connections;
     _server._connections_list.push_back(*this);
+    _shedding_timer.set_callback([this] {
+        clogger.debug("Shedding all incoming requests due to overload");
+        _shed_incoming_requests = true;
+    });
 }
 
 cql_server::connection::~connection() {
@@ -699,6 +703,12 @@ future<> cql_server::connection::process_request() {
         }
 
         auto& f = *maybe_frame;
+
+        if (_shed_incoming_requests) {
+            ++_server._stats.requests_shed;
+            return _read_buf.skip(f.length);
+        }
+
         tracing_request_type tracing_requested = tracing_request_type::not_requested;
         if (f.flags & cql_frame_flags::tracing) {
             // If tracing is requested for a specific CQL command - flush
@@ -711,7 +721,6 @@ future<> cql_server::connection::process_request() {
         auto op = f.opcode;
         auto stream = f.stream;
         auto mem_estimate = f.length * 2 + 8000; // Allow for extra copies and bookkeeping
-
         if (mem_estimate > _server._max_request_size) {
             return make_exception_future<>(exceptions::invalid_request_exception(format("request size too large (frame size {:d}; estimate {:d}; allowed {:d}",
                     f.length, mem_estimate, _server._max_request_size)));
@@ -723,8 +732,12 @@ future<> cql_server::connection::process_request() {
                     exceptions::overloaded_exception(format("too many in-flight requests (configured via max_concurrent_requests_per_shard): {}", _server._stats.requests_serving)));
         }
 
-        auto fut = get_units(_server._memory_available, mem_estimate);
+        const auto shedding_timeout = std::chrono::milliseconds(50);
+        auto fut = get_units(_server._memory_available, mem_estimate, shedding_timeout);
         if (_server._memory_available.waiters()) {
+            if (!_shedding_timer.armed()) {
+                _shedding_timer.arm(shedding_timeout);
+            }
             ++_server._stats.requests_blocked_memory;
         }
 
@@ -735,7 +748,11 @@ future<> cql_server::connection::process_request() {
             ++_server._stats.requests_serving;
 
             _pending_requests_gate.enter();
-            auto leave = defer([this] { _pending_requests_gate.leave(); });
+            auto leave = defer([this] {
+                _shedding_timer.cancel();
+                _shed_incoming_requests = false;
+                _pending_requests_gate.leave();
+            });
             auto istream = buf.get_istream();
             (void)_process_request_stage(this, istream, op, stream, seastar::ref(_client_state), tracing_requested, mem_permit)
                     .then_wrapped([this, buf = std::move(buf), mem_permit, leave = std::move(leave)] (future<foreign_ptr<std::unique_ptr<cql_server::response>>> response_f) mutable {
@@ -749,6 +766,12 @@ future<> cql_server::connection::process_request() {
 
             return make_ready_future<>();
           });
+        }).handle_exception([this, length = f.length] (const std::exception_ptr&) {
+            // Cancel shedding in case no more requests are going to do that on completion
+            if (_pending_requests_gate.get_count() == 0) {
+                _shed_incoming_requests = false;
+            }
+            return _read_buf.skip(length);
         });
     });
 }

--- a/transport/server.hh
+++ b/transport/server.hh
@@ -182,6 +182,8 @@ private:
         cql_serialization_format _cql_serialization_format = cql_serialization_format::latest();
         service::client_state _client_state;
         std::unordered_map<uint16_t, cql_query_state> _query_states;
+        timer<lowres_clock> _shedding_timer;
+        bool _shed_incoming_requests = false;
         unsigned _request_cpu = 0;
 
         enum class tracing_request_type : uint8_t {


### PR DESCRIPTION
This draft shows a stub implementation of how the admission queue
could start getting rid of long-overdue requests.
The idea is that if requests stay in the admission queue (or,
indirectly, on the socket) for more than their timeout, we might
just as well drop these requests and try to make room for
new ones, which still have a real chance of succeeding.

This draft does not make sense on its own, but it's supposed
to be used as foundation for a discussion on how to make it workable.

Refs #1823