### PR TITLE
main: Run init_server and join_cluster inside maintenance scheduling group

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -1088,9 +1088,15 @@ int main(int ac, char** av) {
 
             sys_dist_ks.start(std::ref(qp), std::ref(mm), std::ref(proxy)).get();
 
-            ss.init_server().get();
+            with_scheduling_group(maintenance_scheduling_group, [&] {
+                return ss.init_server();
+            }).get();
+
             sst_format_selector.sync();
-            ss.join_cluster().get();
+
+            with_scheduling_group(maintenance_scheduling_group, [&] {
+                return ss.join_cluster();
+            }).get();
 
             supervisor::notify("starting tracing");
             tracing::tracing::start_tracing(qp).get();


### PR DESCRIPTION
Currently, init_server and join_cluster which initiate the bootstrap and
replace operations on the new node run inside the main scheduling group.
We should run them inside the maintenance scheduling group to reduce the
impact on the user workload.

This patch fixes a scheduling group leak for bootstrap and replace operation.

Before:
[shard 0] storage_service - storage_service::bootstrap sg=main
[shard 0] repair - bootstrap_with_repair sg=main

After:
[shard 0] storage_service - storage_service::bootstrap sg=streaming
[shard 0] repair - bootstrap_with_repair sg=streaming

Fixes #8130