### PR TITLE
atomic_cell: fix operator<< for atomic_cell_or_collection

### DIFF
--- a/atomic_cell.cc
+++ b/atomic_cell.cc
@@ -193,7 +193,7 @@ std::ostream& operator<<(std::ostream& os, const atomic_cell_or_collection::prin
         return os << "{ null atomic_cell_or_collection }";
     }
     os << "{ ";
-    if (p._cdef.type->is_collection()) {
+    if (p._cdef.type->is_multi_cell()) {
         os << "collection ";
         auto cmv = p._cell.as_collection_mutation();
         os << collection_mutation_view::printer(*p._cdef.type, cmv);


### PR DESCRIPTION
operator<< used the wrong criterium for deciding whether the data is
stored as atomic_cell or collection_mutation, resulting in
catastrophical failure if it was used with frozen collections or UDTs.
Since frozen collections and UDTs are stored as atomic_cell, not
collection_mutation, the correct criterium is not is_collection(),
but is_multi_cell().

Fixes #8127