### PR TITLE
repair: Reject repair with wrong startToken and endToken

### DIFF
--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -1624,6 +1624,9 @@ static int do_repair_start(seastar::sharded<database>& db, seastar::sharded<netw
                     dht::token_comparator());
             intersections.insert(intersections.end(), rs.begin(), rs.end());
         }
+        if (intersections.empty()) {
+            throw std::runtime_error("The range specified by startToken and endToken does not intersect with any ranges owned by this node");
+        }
         ranges = std::move(intersections);
     }
 


### PR DESCRIPTION
If user provides a range using startToken and endToken that does not
intersect with any of the ranges owned by the node to be repaired,
repair will choose to repair empty ranges.

This can be confusing. Instead, reject the repair request and tell the
user the reason.

$ curl -X POST 'http://127.0.0.1:10000/storage_service/repair_async/myks1?startToken=9006814998760595684&endToken=9006814998760595684'

{"message": "std::runtime_error (The range specified by startToken and endToken does not intersect with any ranges owned by this node)", "code": 500}

Refs #8132