### PR TITLE
Stop using dht::ring_position_view::max() in reader_selector

### DIFF
--- a/mutation_reader.cc
+++ b/mutation_reader.cc
@@ -291,7 +291,7 @@ public:
     list_reader_selector& operator=(list_reader_selector&&) = default;
 
     virtual std::vector<flat_mutation_reader> create_new_readers(const std::optional<dht::ring_position_view>&) override {
-        _selector_position = dht::ring_position_view::max();
+        set_position(dht::ring_position_view::max());
         return std::exchange(_readers, {});
     }
 

--- a/mutation_reader.cc
+++ b/mutation_reader.cc
@@ -291,7 +291,7 @@ public:
     list_reader_selector& operator=(list_reader_selector&&) = default;
 
     virtual std::vector<flat_mutation_reader> create_new_readers(const std::optional<dht::ring_position_view>&) override {
-        set_position(dht::ring_position_view::max());
+        mark_finished();
         return std::exchange(_readers, {});
     }
 

--- a/mutation_reader.hh
+++ b/mutation_reader.hh
@@ -35,6 +35,9 @@ class reader_selector {
 protected:
     schema_ptr _s;
     dht::ring_position_view _selector_position;
+    bool is_finished() const {
+        return _selector_position.is_max();
+    }
 public:
     reader_selector(schema_ptr s, dht::ring_position_view rpv) noexcept : _s(std::move(s)), _selector_position(std::move(rpv)) {}
 
@@ -46,7 +49,7 @@ public:
     // Can be false-positive but never false-negative!
     bool has_new_readers(const std::optional<dht::ring_position_view>& pos) const noexcept {
         dht::ring_position_comparator cmp(*_s);
-        return !_selector_position.is_max() && (!pos || cmp(*pos, _selector_position) >= 0);
+        return !is_finished() && (!pos || cmp(*pos, _selector_position) >= 0);
     }
 };
 

--- a/mutation_reader.hh
+++ b/mutation_reader.hh
@@ -38,10 +38,14 @@ private:
     dht::ring_position_view _selector_position;
 protected:
     void set_position(dht::ring_position_view pos) {
+        assert(!pos.is_max());
         _selector_position = pos;
     }
     dht::ring_position_view position() const {
         return _selector_position;
+    }
+    void mark_finished() {
+        _selector_position = dht::ring_position_view::max();
     }
     bool is_finished() const {
         return _selector_position.is_max();

--- a/mutation_reader.hh
+++ b/mutation_reader.hh
@@ -34,7 +34,15 @@
 class reader_selector {
 protected:
     schema_ptr _s;
+private:
     dht::ring_position_view _selector_position;
+protected:
+    void set_position(dht::ring_position_view pos) {
+        _selector_position = pos;
+    }
+    dht::ring_position_view position() const {
+        return _selector_position;
+    }
     bool is_finished() const {
         return _selector_position.is_max();
     }

--- a/sstables/sstable_set.cc
+++ b/sstables/sstable_set.cc
@@ -613,7 +613,7 @@ public:
 
         // prevents sstable_set::incremental_selector::_current_sstables from holding reference to
         // sstables when done selecting.
-        if (_selector_position.is_max()) {
+        if (is_finished()) {
             _selector.reset();
         }
 

--- a/sstables/sstable_set.cc
+++ b/sstables/sstable_set.cc
@@ -598,11 +598,11 @@ public:
         auto readers = std::vector<flat_mutation_reader>();
 
         do {
-            auto selection = _selector->select(_selector_position);
-            _selector_position = selection.next_position;
+            auto selection = _selector->select(position());
+            set_position(selection.next_position);
 
             irclogger.trace("{}: {} sstables to consider, advancing selector to {}", fmt::ptr(this), selection.sstables.size(),
-                    _selector_position);
+                    position());
 
             readers = boost::copy_range<std::vector<flat_mutation_reader>>(selection.sstables
                     | boost::adaptors::filtered([this] (auto& sst) { return _read_sstable_gens.emplace(sst->generation()).second; })

--- a/sstables/sstable_set.cc
+++ b/sstables/sstable_set.cc
@@ -607,7 +607,7 @@ public:
             readers = boost::copy_range<std::vector<flat_mutation_reader>>(selection.sstables
                     | boost::adaptors::filtered([this] (auto& sst) { return _read_sstable_gens.emplace(sst->generation()).second; })
                     | boost::adaptors::transformed([this] (auto& sst) { return this->create_reader(sst); }));
-        } while (!_selector_position.is_max() && readers.empty() && (!pos || dht::ring_position_tri_compare(*_s, *pos, _selector_position) >= 0));
+        } while (readers.empty() && has_new_readers(pos));
 
         irclogger.trace("{}: created {} new readers", fmt::ptr(this), readers.size());
 
@@ -624,7 +624,7 @@ public:
         _pr = &pr;
 
         auto pos = dht::ring_position_view::for_range_start(*_pr);
-        if (dht::ring_position_tri_compare(*_s, pos, _selector_position) >= 0) {
+        if (has_new_readers(pos)) {
             return create_new_readers(pos);
         }
 

--- a/sstables/sstable_set.cc
+++ b/sstables/sstable_set.cc
@@ -599,7 +599,11 @@ public:
 
         do {
             auto selection = _selector->select(position());
-            set_position(selection.next_position);
+            if (selection.next_position.is_max()) {
+                mark_finished();
+            } else {
+                set_position(selection.next_position);
+            }
 
             irclogger.trace("{}: {} sstables to consider, advancing selector to {}", fmt::ptr(this), selection.sstables.size(),
                     position());

--- a/sstables/sstable_set.hh
+++ b/sstables/sstable_set.hh
@@ -26,6 +26,7 @@
 #include "shared_sstable.hh"
 #include "dht/i_partitioner.hh"
 #include <seastar/core/shared_ptr.hh>
+#include <seastar/util/optimized_optional.hh>
 #include <vector>
 
 namespace utils {
@@ -78,7 +79,7 @@ public:
         mutable std::optional<dht::partition_range> _current_range;
         mutable std::optional<nonwrapping_range<dht::ring_position_view>> _current_range_view;
         mutable std::vector<shared_sstable> _current_sstables;
-        mutable dht::ring_position_view _current_next_position = dht::ring_position_view::min();
+        mutable optimized_optional<dht::ring_position_view> _current_next_position;
     public:
         ~incremental_selector();
         incremental_selector(std::unique_ptr<incremental_selector_impl> impl, const schema& s);
@@ -86,7 +87,8 @@ public:
 
         struct selection {
             const std::vector<shared_sstable>& sstables;
-            dht::ring_position_view next_position;
+            // Disengaged when there's no next position - we're finished
+            optimized_optional<dht::ring_position_view> next_position;
         };
 
         // Return the sstables that intersect with `pos` and the next

--- a/sstables/sstable_set_impl.hh
+++ b/sstables/sstable_set_impl.hh
@@ -31,7 +31,7 @@ namespace sstables {
 class incremental_selector_impl {
 public:
     virtual ~incremental_selector_impl() {}
-    virtual std::tuple<dht::partition_range, std::vector<shared_sstable>, dht::ring_position_view> select(const dht::ring_position_view&) = 0;
+    virtual std::tuple<dht::partition_range, std::vector<shared_sstable>, optimized_optional<dht::ring_position_view>> select(const dht::ring_position_view&) = 0;
 };
 
 class sstable_set_impl {

--- a/test/boost/mutation_reader_test.cc
+++ b/test/boost/mutation_reader_test.cc
@@ -730,7 +730,7 @@ public:
             return readers;
         }
 
-        while (!_readers_mutations.empty() && dht::ring_position_tri_compare(*_s, _selector_position, *pos) <= 0) {
+        while (!_readers_mutations.empty() && has_new_readers(pos)) {
             readers.emplace_back(pop_reader());
         }
         return readers;

--- a/test/boost/mutation_reader_test.cc
+++ b/test/boost/mutation_reader_test.cc
@@ -697,8 +697,12 @@ class dummy_incremental_selector : public reader_selector {
     flat_mutation_reader pop_reader() {
         auto muts = std::move(_readers_mutations.back());
         _readers_mutations.pop_back();
-        _position = _readers_mutations.empty() ? dht::ring_position::max() : _readers_mutations.back().front().decorated_key();
-        set_position(_position);
+        if (_readers_mutations.empty()) {
+            mark_finished();
+        } else {
+            _position = _readers_mutations.back().front().decorated_key();
+            set_position(_position);
+        }
         return flat_mutation_reader_from_mutations(tests::make_permit(), std::move(muts), _pr, _fwd);
     }
 public:

--- a/test/boost/mutation_reader_test.cc
+++ b/test/boost/mutation_reader_test.cc
@@ -698,7 +698,7 @@ class dummy_incremental_selector : public reader_selector {
         auto muts = std::move(_readers_mutations.back());
         _readers_mutations.pop_back();
         _position = _readers_mutations.empty() ? dht::ring_position::max() : _readers_mutations.back().front().decorated_key();
-        _selector_position = _position;
+        set_position(_position);
         return flat_mutation_reader_from_mutations(tests::make_permit(), std::move(muts), _pr, _fwd);
     }
 public:


### PR DESCRIPTION
This is a first baby step in a long voyage to remove special MIN and MAX tokens from our codebase.

To be able to remove them we have to make sure that our code does not depend on them at all.
This means that transitively the code can't depend on:
ring_position::is_min()
ring_position::is_max()
ring_position_view::is_min()
ring_position_view::is_max()
ring_position_ext::is_min()
ring_position_ext::is_max()

This PR makes reader_selector and its subclasses independent from is_max() functions. dht::ring_position_view::max() was used to mark that the selector is finished but this can be done more explicitly by using optimized_optional<dht::ring_position_view> and setting it to disengaged optional when the selector is done.

Refs #1580 

Tests: unit(dev, release, debug), dtest(dev)