### PR TITLE
cql3: remove linearizations in the write path

### DIFF
--- a/compound.hh
+++ b/compound.hh
@@ -125,6 +125,14 @@ public:
             return *bo;
         }));
     }
+    managed_bytes serialize_optionals(const std::vector<managed_bytes_opt>& values) const {
+        return serialize_value(values | boost::adaptors::transformed([] (const managed_bytes_opt& bo) -> managed_bytes_view {
+            if (!bo) {
+                throw std::logic_error("attempted to create key component from empty optional");
+            }
+            return managed_bytes_view(*bo);
+        }));
+    }
     managed_bytes serialize_value_deep(const std::vector<data_value>& values) const {
         // TODO: Optimize
         std::vector<bytes> partial;

--- a/configure.py
+++ b/configure.py
@@ -1130,7 +1130,7 @@ deps['test/boost/bytes_ostream_test'] = [
     "test/lib/log.cc",
 ]
 deps['test/boost/input_stream_test'] = ['test/boost/input_stream_test.cc']
-deps['test/boost/UUID_test'] = ['utils/UUID_gen.cc', 'test/boost/UUID_test.cc', 'utils/uuid.cc', 'utils/managed_bytes.cc', 'utils/logalloc.cc', 'utils/dynamic_bitset.cc', 'hashers.cc']
+deps['test/boost/UUID_test'] = ['utils/UUID_gen.cc', 'test/boost/UUID_test.cc', 'utils/uuid.cc', 'utils/dynamic_bitset.cc', 'hashers.cc']
 deps['test/boost/murmur_hash_test'] = ['bytes.cc', 'utils/murmur_hash.cc', 'test/boost/murmur_hash_test.cc']
 deps['test/boost/allocation_strategy_test'] = ['test/boost/allocation_strategy_test.cc', 'utils/logalloc.cc', 'utils/dynamic_bitset.cc']
 deps['test/boost/log_heap_test'] = ['test/boost/log_heap_test.cc']

--- a/configure.py
+++ b/configure.py
@@ -1124,6 +1124,7 @@ deps['test/boost/multishard_combining_reader_as_mutation_source_test'] += ['test
 
 deps['test/boost/bytes_ostream_test'] = [
     "test/boost/bytes_ostream_test.cc",
+    "bytes.cc",
     "utils/managed_bytes.cc",
     "utils/logalloc.cc",
     "utils/dynamic_bitset.cc",

--- a/cql3/attributes.cc
+++ b/cql3/attributes.cc
@@ -78,11 +78,10 @@ int64_t attributes::get_timestamp(int64_t now, const query_options& options) {
         return now;
     }
     try {
-        data_type_for<int64_t>()->validate(*tval, options.get_cql_serialization_format());
+        return tval.validate_and_deserialize<int64_t>(*long_type, options.get_cql_serialization_format());
     } catch (marshal_exception& e) {
         throw exceptions::invalid_request_exception("Invalid timestamp value");
     }
-    return value_cast<int64_t>(data_type_for<int64_t>()->deserialize(*tval));
 }
 
 int32_t attributes::get_time_to_live(const query_options& options) {
@@ -97,13 +96,13 @@ int32_t attributes::get_time_to_live(const query_options& options) {
         return 0;
     }
 
+    int32_t ttl;
     try {
-        data_type_for<int32_t>()->validate(*tval, options.get_cql_serialization_format());
+        ttl = tval.validate_and_deserialize<int32_t>(*int32_type, options.get_cql_serialization_format());
     }
     catch (marshal_exception& e) {
         throw exceptions::invalid_request_exception("Invalid TTL value");
     }
-    auto ttl = value_cast<int32_t>(data_type_for<int32_t>()->deserialize(*tval));
 
     if (ttl < 0) {
         throw exceptions::invalid_request_exception("A TTL must be greater or equal to 0");
@@ -123,7 +122,7 @@ db::timeout_clock::duration attributes::get_timeout(const query_options& options
     if (timeout.is_null() || timeout.is_unset_value()) {
         throw exceptions::invalid_request_exception("Timeout value cannot be unset/null");
     }
-    cql_duration duration = value_cast<cql_duration>(duration_type->deserialize(*timeout));
+    cql_duration duration = timeout.deserialize<cql_duration>(*duration_type);
     if (duration.months || duration.days) {
         throw exceptions::invalid_request_exception("Timeout values cannot be expressed in days/months");
     }

--- a/cql3/column_condition.cc
+++ b/cql3/column_condition.cc
@@ -176,7 +176,7 @@ bool column_condition::applies_to(const data_value* cell_value, const query_opti
             const std::vector<std::pair<data_value, data_value>>& map = map_type.from_value(*cell_value);
             if (column.type->is_map()) {
                 // We're working with a map *type*, not only map *representation*.
-                with_linearized(*key, [&map, &map_type, &cell_value] (bytes_view key) {
+                key.with_linearized([&map, &map_type, &cell_value] (bytes_view key) {
                     auto end = map.end();
                     const auto& map_key_type = *map_type.get_keys_type();
                     auto less = [&map_key_type](const std::pair<data_value, data_value>& value, bytes_view key) {

--- a/cql3/constants.cc
+++ b/cql3/constants.cc
@@ -171,7 +171,7 @@ void constants::deleter::execute(mutation& m, const clustering_key_prefix& prefi
 
         m.set_cell(prefix, column, coll_m.serialize(*column.type));
     } else {
-        m.set_cell(prefix, column, make_dead_cell(params));
+        m.set_cell(prefix, column, params.make_dead_cell());
     }
 }
 

--- a/cql3/constants.hh
+++ b/cql3/constants.hh
@@ -213,7 +213,7 @@ public:
 
         static void execute(mutation& m, const clustering_key_prefix& prefix, const update_parameters& params, const column_definition& column, cql3::raw_value_view value) {
             if (value.is_null()) {
-                m.set_cell(prefix, column, std::move(make_dead_cell(params)));
+                m.set_cell(prefix, column, params.make_dead_cell());
             } else if (value.is_value()) {
                 m.set_cell(prefix, column, params.make_cell(*column.type, value));
             }
@@ -231,7 +231,7 @@ public:
                 return;
             }
             auto increment = value.deserialize<int64_t>(*long_type);
-            m.set_cell(prefix, column, make_counter_update_cell(increment, params));
+            m.set_cell(prefix, column, params.make_counter_update_cell(increment));
         }
     };
 
@@ -249,7 +249,7 @@ public:
             if (increment == std::numeric_limits<int64_t>::min()) {
                 throw exceptions::invalid_request_exception(format("The negation of {:d} overflows supported counter precision (signed 8 bytes integer)", increment));
             }
-            m.set_cell(prefix, column, make_counter_update_cell(-increment, params));
+            m.set_cell(prefix, column, params.make_counter_update_cell(-increment));
         }
     };
 

--- a/cql3/constants.hh
+++ b/cql3/constants.hh
@@ -73,7 +73,7 @@ public:
         value(cql3::raw_value bytes_) : _bytes(std::move(bytes_)) {}
         virtual cql3::raw_value get(const query_options& options) override { return _bytes; }
         virtual cql3::raw_value_view bind_and_get(const query_options& options) override { return _bytes.to_view(); }
-        virtual sstring to_string() const override { return to_hex(*_bytes); }
+        virtual sstring to_string() const override { return _bytes.to_view().with_value([] (const FragmentedView auto& v) { return to_hex(v); }); }
     };
 
     static thread_local const ::shared_ptr<value> UNSET_VALUE;
@@ -181,7 +181,7 @@ public:
             try {
                 auto value = options.get_value_at(_bind_index);
                 if (value) {
-                    _receiver->type->validate(*value, options.get_cql_serialization_format());
+                    value.validate(*_receiver->type, options.get_cql_serialization_format());
                 }
                 return value;
             } catch (const marshal_exception& e) {
@@ -198,7 +198,7 @@ public:
             if (bytes.is_unset_value()) {
                 return UNSET_VALUE;
             }
-            return ::make_shared<constants::value>(std::move(cql3::raw_value::make_value(to_bytes(*bytes))));
+            return ::make_shared<constants::value>(std::move(cql3::raw_value::make_value(bytes)));
         }
     };
 
@@ -215,7 +215,7 @@ public:
             if (value.is_null()) {
                 m.set_cell(prefix, column, std::move(make_dead_cell(params)));
             } else if (value.is_value()) {
-                m.set_cell(prefix, column, std::move(make_cell(*column.type, *value, params)));
+                m.set_cell(prefix, column, params.make_cell(*column.type, value));
             }
         }
     };
@@ -230,7 +230,7 @@ public:
             } else if (value.is_unset_value()) {
                 return;
             }
-            auto increment = value_cast<int64_t>(long_type->deserialize_value(*value));
+            auto increment = value.deserialize<int64_t>(*long_type);
             m.set_cell(prefix, column, make_counter_update_cell(increment, params));
         }
     };
@@ -245,7 +245,7 @@ public:
             } else if (value.is_unset_value()) {
                 return;
             }
-            auto increment = value_cast<int64_t>(long_type->deserialize_value(*value));
+            auto increment = value.deserialize<int64_t>(*long_type);
             if (increment == std::numeric_limits<int64_t>::min()) {
                 throw exceptions::invalid_request_exception(format("The negation of {:d} overflows supported counter precision (signed 8 bytes integer)", increment));
             }

--- a/cql3/expr/expression.cc
+++ b/cql3/expr/expression.cc
@@ -117,7 +117,7 @@ bytes_opt get_value_from_partition_slice(
         const auto& data_map = value_cast<map_type_impl::native_type>(deserialized);
         const auto key = col.sub->bind_and_get(options);
         auto&& key_type = col_type->name_comparator();
-        const auto found = with_linearized(*key, [&] (bytes_view key_bv) {
+        const auto found = key.with_linearized([&] (bytes_view key_bv) {
             using entry = std::pair<data_value, data_value>;
             return std::find_if(data_map.cbegin(), data_map.cend(), [&] (const entry& element) {
                 return key_type->compare(element.first.serialize_nonnull(), key_bv) == 0;
@@ -294,7 +294,7 @@ bool contains(const data_value& collection, const raw_value_view& value) {
     }
     auto col_type = static_pointer_cast<const collection_type_impl>(collection.type());
     auto&& element_type = col_type->is_set() ? col_type->name_comparator() : col_type->value_comparator();
-    return with_linearized(*value, [&] (bytes_view val) {
+    return value.with_linearized([&] (bytes_view val) {
         auto exists_in = [&](auto&& range) {
             auto found = std::find_if(range.begin(), range.end(), [&] (auto&& element) {
                 return element_type->compare(element.serialize_nonnull(), val) == 0;
@@ -343,7 +343,7 @@ bool contains_key(const column_value& col, cql3::raw_value_view key, const colum
     }
     const auto data_map = value_cast<map_type_impl::native_type>(type->deserialize(*collection));
     auto key_type = static_pointer_cast<const collection_type_impl>(type)->name_comparator();
-    auto found = with_linearized(*key, [&] (bytes_view k_bv) {
+    auto found = key.with_linearized([&] (bytes_view k_bv) {
         using entry = std::pair<data_value, data_value>;
         return std::find_if(data_map.begin(), data_map.end(), [&] (const entry& element) {
             return key_type->compare(element.first.serialize_nonnull(), k_bv) == 0;

--- a/cql3/expr/expression.cc
+++ b/cql3/expr/expression.cc
@@ -37,14 +37,6 @@
 #include "types/set.hh"
 #include "utils/like_matcher.hh"
 
-static bytes_opt to_bytes_opt(const managed_bytes_opt& b) {
-    if (b) {
-        return to_bytes(*b);
-    } else {
-        return std::nullopt;
-    }
-}
-
 namespace cql3 {
 namespace expr {
 
@@ -54,7 +46,7 @@ using boost::adaptors::transformed;
 namespace {
 
 static
-bytes_opt do_get_value(const schema& schema,
+managed_bytes_opt do_get_value(const schema& schema,
         const column_definition& cdef,
         const partition_key& key,
         const clustering_key_prefix& ckey,
@@ -62,9 +54,9 @@ bytes_opt do_get_value(const schema& schema,
         gc_clock::time_point now) {
     switch (cdef.kind) {
         case column_kind::partition_key:
-            return to_bytes(key.get_component(schema, cdef.component_index()));
+            return managed_bytes(key.get_component(schema, cdef.component_index()));
         case column_kind::clustering_key:
-            return to_bytes(ckey.get_component(schema, cdef.component_index()));
+            return managed_bytes(ckey.get_component(schema, cdef.component_index()));
         default:
             auto cell = cells.find_cell(cdef.id);
             if (!cell) {
@@ -72,7 +64,7 @@ bytes_opt do_get_value(const schema& schema,
             }
             assert(cdef.is_atomic());
             auto c = cell->as_atomic_cell(cdef);
-            return c.is_dead(now) ? std::nullopt : bytes_opt(to_bytes(c.value()));
+            return c.is_dead(now) ? std::nullopt : managed_bytes_opt(c.value());
     }
 }
 
@@ -92,7 +84,7 @@ using cql3::selection::selection;
 struct row_data_from_partition_slice {
     const std::vector<bytes>& partition_key;
     const std::vector<bytes>& clustering_key;
-    const std::vector<bytes_opt>& other_columns;
+    const std::vector<managed_bytes_opt>& other_columns;
     const selection& sel;
 };
 
@@ -113,7 +105,7 @@ struct column_value_eval_bag {
 };
 
 /// Returns col's value from queried data.
-bytes_opt get_value_from_partition_slice(
+managed_bytes_opt get_value_from_partition_slice(
         const column_value& col, row_data_from_partition_slice data, const query_options& options) {
     auto cdef = col.col;
     if (col.sub) {
@@ -121,7 +113,7 @@ bytes_opt get_value_from_partition_slice(
         if (!col_type->is_map()) {
             throw exceptions::invalid_request_exception(format("subscripting non-map column {}", cdef->name_as_text()));
         }
-        const auto deserialized = cdef->type->deserialize(*data.other_columns[data.sel.index_of(*cdef)]);
+        const auto deserialized = cdef->type->deserialize(managed_bytes_view(*data.other_columns[data.sel.index_of(*cdef)]));
         const auto& data_map = value_cast<map_type_impl::native_type>(deserialized);
         const auto key = col.sub->bind_and_get(options);
         auto&& key_type = col_type->name_comparator();
@@ -131,16 +123,16 @@ bytes_opt get_value_from_partition_slice(
                 return key_type->compare(element.first.serialize_nonnull(), key_bv) == 0;
             });
         });
-        return found == data_map.cend() ? bytes_opt() : bytes_opt(found->second.serialize_nonnull());
+        return found == data_map.cend() ? std::nullopt : managed_bytes_opt(found->second.serialize_nonnull());
     } else {
         switch (cdef->kind) {
         case column_kind::partition_key:
-            return data.partition_key[cdef->id];
+            return managed_bytes(data.partition_key[cdef->id]);
         case column_kind::clustering_key:
-            return data.clustering_key[cdef->id];
+            return managed_bytes(data.clustering_key[cdef->id]);
         case column_kind::static_column:
         case column_kind::regular_column:
-            return data.other_columns[data.sel.index_of(*cdef)];
+            return managed_bytes_opt(data.other_columns[data.sel.index_of(*cdef)]);
         default:
             throw exceptions::unsupported_operation_exception("Unknown column kind");
         }
@@ -148,13 +140,13 @@ bytes_opt get_value_from_partition_slice(
 }
 
 /// Returns col's value from a mutation.
-bytes_opt get_value_from_mutation(const column_value& col, row_data_from_mutation data) {
+managed_bytes_opt get_value_from_mutation(const column_value& col, row_data_from_mutation data) {
     return do_get_value(
             data.schema_, *col.col, data.partition_key_, data.clustering_key_, data.other_columns, data.now);
 }
 
 /// Returns col's value from the fetched data.
-bytes_opt get_value(const column_value& col, const column_value_eval_bag& bag) {
+managed_bytes_opt get_value(const column_value& col, const column_value_eval_bag& bag) {
     using std::placeholders::_1;
     return std::visit(overloaded_functor{
             std::bind(get_value_from_mutation, col, _1),
@@ -182,18 +174,6 @@ const abstract_type* get_value_comparator(const column_value& cv) {
 }
 
 /// True iff lhs's value equals rhs.
-bool equal(const bytes_opt& rhs, const column_value& lhs, const column_value_eval_bag& bag) {
-    if (!rhs) {
-        return false;
-    }
-    const auto value = get_value(lhs, bag);
-    if (!value) {
-        return false;
-    }
-    return get_value_comparator(lhs)->equal(*value, *rhs);
-}
-
-/// True iff lhs's value equals rhs.
 bool equal(const managed_bytes_opt& rhs, const column_value& lhs, const column_value_eval_bag& bag) {
     if (!rhs) {
         return false;
@@ -202,12 +182,12 @@ bool equal(const managed_bytes_opt& rhs, const column_value& lhs, const column_v
     if (!value) {
         return false;
     }
-    return get_value_comparator(lhs)->equal(managed_bytes_view(bytes_view(*value)), managed_bytes_view(*rhs));
+    return get_value_comparator(lhs)->equal(managed_bytes_view(*value), managed_bytes_view(*rhs));
 }
 
 /// Convenience overload for term.
 bool equal(term& rhs, const column_value& lhs, const column_value_eval_bag& bag) {
-    return equal(to_bytes_opt(rhs.bind_and_get(bag.options)), lhs, bag);
+    return equal(to_managed_bytes_opt(rhs.bind_and_get(bag.options)), lhs, bag);
 }
 
 /// True iff columns' values equal t.
@@ -228,7 +208,7 @@ bool equal(term& t, const std::vector<column_value>& columns, const column_value
 }
 
 /// True iff lhs is limited by rhs in the manner prescribed by op.
-bool limits(bytes_view lhs, oper_t op, bytes_view rhs, const abstract_type& type) {
+bool limits(managed_bytes_view lhs, oper_t op, managed_bytes_view rhs, const abstract_type& type) {
     const auto cmp = type.compare(lhs, rhs);
     switch (op) {
     case oper_t::LT:
@@ -257,7 +237,7 @@ bool limits(const column_value& col, oper_t op, term& rhs, const column_value_ev
     if (!lhs) {
         return false;
     }
-    const auto b = to_bytes_opt(rhs.bind_and_get(bag.options));
+    const auto b = to_managed_bytes_opt(rhs.bind_and_get(bag.options));
     return b ? limits(*lhs, op, *b, *get_value_comparator(col)) : false;
 }
 
@@ -281,7 +261,7 @@ bool limits(const std::vector<column_value>& columns, const oper_t op, term& t,
     for (size_t i = 0; i < rhs.size(); ++i) {
         const auto cmp = get_value_comparator(columns[i])->compare(
                 // CQL dictates that columns[i] is a clustering column and non-null.
-                managed_bytes_view(*get_value(columns[i], bag)),
+                *get_value(columns[i], bag),
                 *rhs[i]);
         // If the components aren't equal, then we just learned the LHS/RHS order.
         if (cmp < 0) {
@@ -342,7 +322,7 @@ bool contains(const column_value& col, const raw_value_view& value, const column
     }
     const auto collection = get_value(col, bag);
     if (collection) {
-        return contains(col.col->type->deserialize(*collection), value);
+        return contains(col.col->type->deserialize(managed_bytes_view(*collection)), value);
     } else {
         return false;
     }
@@ -361,7 +341,7 @@ bool contains_key(const column_value& col, cql3::raw_value_view key, const colum
     if (!collection) {
         return false;
     }
-    const auto data_map = value_cast<map_type_impl::native_type>(type->deserialize(*collection));
+    const auto data_map = value_cast<map_type_impl::native_type>(type->deserialize(managed_bytes_view(*collection)));
     auto key_type = static_pointer_cast<const collection_type_impl>(type)->name_comparator();
     auto found = key.with_linearized([&] (bytes_view k_bv) {
         using entry = std::pair<data_value, data_value>;
@@ -373,16 +353,16 @@ bool contains_key(const column_value& col, cql3::raw_value_view key, const colum
 }
 
 /// Fetches the next cell value from iter and returns its (possibly null) value.
-bytes_opt next_value(query::result_row_view::iterator_type& iter, const column_definition* cdef) {
+managed_bytes_opt next_value(query::result_row_view::iterator_type& iter, const column_definition* cdef) {
     if (cdef->type->is_multi_cell()) {
         auto cell = iter.next_collection_cell();
         if (cell) {
-            return linearized(*cell);
+            return managed_bytes(*cell);
         }
     } else {
         auto cell = iter.next_atomic_cell();
         if (cell) {
-            return linearized(cell->value());
+            return managed_bytes(cell->value());
         }
     }
     return std::nullopt;
@@ -390,10 +370,10 @@ bytes_opt next_value(query::result_row_view::iterator_type& iter, const column_d
 
 /// Returns values of non-primary-key columns from selection.  The kth element of the result
 /// corresponds to the kth column in selection.
-std::vector<bytes_opt> get_non_pk_values(const selection& selection, const query::result_row_view& static_row,
+std::vector<managed_bytes_opt> get_non_pk_values(const selection& selection, const query::result_row_view& static_row,
                                          const query::result_row_view* row) {
     const auto& cols = selection.get_columns();
-    std::vector<bytes_opt> vals(cols.size());
+    std::vector<managed_bytes_opt> vals(cols.size());
     auto static_row_iterator = static_row.iterator();
     auto row_iterator = row ? std::optional<query::result_row_view::iterator_type>(row->iterator()) : std::nullopt;
     for (size_t i = 0; i < cols.size(); ++i) {
@@ -414,14 +394,22 @@ std::vector<bytes_opt> get_non_pk_values(const selection& selection, const query
 }
 
 /// True iff cv matches the CQL LIKE pattern.
-bool like(const column_value& cv, const bytes_opt& pattern, const column_value_eval_bag& bag) {
+bool like(const column_value& cv, const raw_value_view& pattern, const column_value_eval_bag& bag) {
     if (!cv.col->type->is_string()) {
         throw exceptions::invalid_request_exception(
                 format("LIKE is allowed only on string types, which {} is not", cv.col->name_as_text()));
     }
     auto value = get_value(cv, bag);
     // TODO: reuse matchers.
-    return (pattern && value) ? like_matcher(*pattern)(*value) : false;
+    if (pattern && value) {
+        return value->with_linearized([&pattern] (bytes_view linearized_value) {
+            return pattern.with_linearized([linearized_value] (bytes_view linearized_pattern) {
+                return like_matcher(linearized_pattern)(linearized_value);
+            });
+        });
+    } else {
+        return false;
+    }
 }
 
 /// True iff the column value is in the set defined by rhs.
@@ -453,7 +441,7 @@ bool is_one_of(const std::vector<column_value>& cvs, term& rhs, const column_val
                 return equal(*t, cvs, bag);
             });
     } else if (auto mkr = dynamic_cast<tuples::in_marker*>(&rhs)) {
-        // This is `(a,b) IN ?`.  RHS elements are themselves tuples, represented as vector<bytes_opt>.
+        // This is `(a,b) IN ?`.  RHS elements are themselves tuples, represented as vector<managed_bytes_opt>.
         const auto marker_value = static_pointer_cast<tuples::in_value>(mkr->bind(bag.options));
         return boost::algorithm::any_of(marker_value->get_split_values(), [&] (const std::vector<managed_bytes_opt>& el) {
                 return boost::equal(cvs, el, [&] (const column_value& c, const managed_bytes_opt& b) {
@@ -481,7 +469,7 @@ bool matches(oper_t op, statements::bound bnd) {
 }
 
 const value_set empty_value_set = value_list{};
-const value_set unbounded_value_set = nonwrapping_range<bytes>::make_open_ended_both_sides();
+const value_set unbounded_value_set = nonwrapping_range<managed_bytes>::make_open_ended_both_sides();
 
 struct intersection_visitor {
     const abstract_type* type;
@@ -492,16 +480,16 @@ struct intersection_visitor {
         return std::move(common);
     }
 
-    value_set operator()(const nonwrapping_range<bytes>& a, const value_list& b) const {
-        const auto common = b | filtered([&] (const bytes& el) { return a.contains(el, type->as_tri_comparator()); });
+    value_set operator()(const nonwrapping_range<managed_bytes>& a, const value_list& b) const {
+        const auto common = b | filtered([&] (const managed_bytes& el) { return a.contains(el, type->as_tri_comparator()); });
         return value_list(common.begin(), common.end());
     }
 
-    value_set operator()(const value_list& a, const nonwrapping_range<bytes>& b) const {
+    value_set operator()(const value_list& a, const nonwrapping_range<managed_bytes>& b) const {
         return (*this)(b, a);
     }
 
-    value_set operator()(const nonwrapping_range<bytes>& a, const nonwrapping_range<bytes>& b) const {
+    value_set operator()(const nonwrapping_range<managed_bytes>& a, const nonwrapping_range<managed_bytes>& b) const {
         const auto common_range = a.intersection(b, type->as_tri_comparator());
         return common_range ? *common_range : empty_value_set;
     }
@@ -525,7 +513,7 @@ bool is_satisfied_by(const binary_operator& opr, const column_value_eval_bag& ba
                 } else if (opr.op == oper_t::CONTAINS_KEY) {
                     return contains_key(col, opr.rhs->bind_and_get(bag.options), bag);
                 } else if (opr.op == oper_t::LIKE) {
-                    return like(col, to_bytes_opt(opr.rhs->bind_and_get(bag.options)), bag);
+                    return like(col, opr.rhs->bind_and_get(bag.options), bag);
                 } else if (opr.op == oper_t::IN) {
                     return is_one_of(col, *opr.rhs, bag);
                 } else {
@@ -565,10 +553,10 @@ bool is_satisfied_by(const expression& restr, const column_value_eval_bag& bag) 
 }
 
 /// If t is a tuple, binds and gets its k-th element.  Otherwise, binds and gets t's whole value.
-bytes_opt get_kth(size_t k, const query_options& options, const ::shared_ptr<term>& t) {
+managed_bytes_opt get_kth(size_t k, const query_options& options, const ::shared_ptr<term>& t) {
     auto bound = t->bind(options);
     if (auto tup = dynamic_pointer_cast<tuples::value>(bound)) {
-        return to_bytes_opt(tup->get_elements()[k]);
+        return tup->get_elements()[k];
     } else {
         throw std::logic_error("non-tuple RHS for multi-column IN");
     }
@@ -582,11 +570,9 @@ value_list to_sorted_vector(Range r, const serialized_compare& comparator) {
     return value_list(unique.begin(), unique.end());
 }
 
-const auto non_null = boost::adaptors::filtered([] (const bytes_opt& b) { return b.has_value(); });
+const auto non_null = boost::adaptors::filtered([] (const managed_bytes_opt& b) { return b.has_value(); });
 
-const auto deref = boost::adaptors::transformed([] (const bytes_opt& b) { return b.value(); });
-
-const auto to_bytes_opt_adapt = boost::adaptors::transformed([] (const managed_bytes_opt& b) { return to_bytes_opt(b); });
+const auto deref = boost::adaptors::transformed([] (const managed_bytes_opt& b) { return b.value(); });
 
 /// Returns possible values from t, which must be RHS of IN.
 value_list get_IN_values(
@@ -596,10 +582,8 @@ value_list get_IN_values(
     if (auto dv = dynamic_pointer_cast<lists::delayed_value>(t)) {
         // Case `a IN (1,2,3)`.
         const auto result_range = dv->get_elements()
-                | boost::adaptors::transformed([&] (const ::shared_ptr<term>& t) { return to_bytes_opt(t->bind_and_get(options)); })
+                | boost::adaptors::transformed([&] (const ::shared_ptr<term>& t) { return to_managed_bytes_opt(t->bind_and_get(options)); })
                 | non_null | deref;
-        static_assert(std::same_as<decltype(*result_range.begin()), bytes>);
-        static_assert(std::same_as<decltype(*result_range.end()), bytes>);
         return to_sorted_vector(std::move(result_range), comparator);
     } else if (auto mkr = dynamic_pointer_cast<lists::marker>(t)) {
         // Case `a IN ?`.  Collect all list-element values.
@@ -608,7 +592,7 @@ value_list get_IN_values(
             throw exceptions::invalid_request_exception(format("Invalid unset value for column {}", column_name));
         }
         statements::request_validations::check_not_null(val, "Invalid null value for column %s", column_name);
-        return to_sorted_vector(static_pointer_cast<lists::value>(val)->get_elements() | to_bytes_opt_adapt | non_null | deref, comparator);
+        return to_sorted_vector(static_pointer_cast<lists::value>(val)->get_elements() | non_null | deref, comparator);
     }
     throw std::logic_error(format("get_IN_values(single column) on invalid term {}", *t));
 }
@@ -627,7 +611,7 @@ value_list get_IN_values(const ::shared_ptr<term>& t, size_t k, const query_opti
         const auto val = static_pointer_cast<tuples::in_value>(mkr->bind(options));
         const auto split_values = val->get_split_values(); // Need lvalue from which to make std::view.
         const auto result_range = split_values
-                | boost::adaptors::transformed([k] (const std::vector<managed_bytes_opt>& v) { return to_bytes_opt(v[k]); }) | non_null | deref;
+                | boost::adaptors::transformed([k] (const std::vector<managed_bytes_opt>& v) { return v[k]; }) | non_null | deref;
         return to_sorted_vector(std::move(result_range), comparator);
     }
     throw std::logic_error(format("get_IN_values(multi-column) on invalid term {}", *t));
@@ -716,12 +700,12 @@ value_set possible_lhs_values(const column_definition* cdef, const expression& e
                                 return unbounded_value_set;
                             }
                             if (is_compare(oper.op)) {
-                                const auto val = to_bytes_opt(oper.rhs->bind_and_get(options));
+                                managed_bytes_opt val = to_managed_bytes_opt(oper.rhs->bind_and_get(options));
                                 if (!val) {
                                     return empty_value_set; // All NULL comparisons fail; no column values match.
                                 }
                                 return oper.op == oper_t::EQ ? value_set(value_list{*val})
-                                        : to_range(oper.op, *val);
+                                        : to_range(oper.op, std::move(*val));
                             } else if (oper.op == oper_t::IN) {
                                 return get_IN_values(oper.rhs, options, type->as_less_comparator(), cdef->name_as_text());
                             }
@@ -739,19 +723,19 @@ value_set possible_lhs_values(const column_definition* cdef, const expression& e
                             const auto column_index_on_lhs = std::distance(cvs.begin(), found);
                             if (is_compare(oper.op)) {
                                 // RHS must be a tuple due to upstream checks.
-                                bytes_opt val = to_bytes_opt(get_tuple(*oper.rhs, options)->get_elements()[column_index_on_lhs]);
+                                managed_bytes_opt val = get_tuple(*oper.rhs, options)->get_elements()[column_index_on_lhs];
                                 if (!val) {
                                     return empty_value_set; // All NULL comparisons fail; no column values match.
                                 }
                                 if (oper.op == oper_t::EQ) {
-                                    return value_list{*val};
+                                    return value_list{std::move(*val)};
                                 }
                                 if (column_index_on_lhs > 0) {
                                     // A multi-column comparison restricts only the first column, because
                                     // comparison is lexicographical.
                                     return unbounded_value_set;
                                 }
-                                return to_range(oper.op, *val);
+                                return to_range(oper.op, std::move(*val));
                             } else if (oper.op == oper_t::IN) {
                                 return get_IN_values(oper.rhs, column_index_on_lhs, options, type->as_less_comparator());
                             }
@@ -761,26 +745,26 @@ value_set possible_lhs_values(const column_definition* cdef, const expression& e
                             if (cdef) {
                                 return unbounded_value_set;
                             }
-                            const auto val = to_bytes_opt(oper.rhs->bind_and_get(options));
+                            const auto val = to_managed_bytes_opt(oper.rhs->bind_and_get(options));
                             if (!val) {
                                 return empty_value_set; // All NULL comparisons fail; no token values match.
                             }
                             if (oper.op == oper_t::EQ) {
                                 return value_list{*val};
                             } else if (oper.op == oper_t::GT) {
-                                return nonwrapping_range<bytes>::make_starting_with(interval_bound(*val, exclusive));
+                                return nonwrapping_range<managed_bytes>::make_starting_with(interval_bound(std::move(*val), exclusive));
                             } else if (oper.op == oper_t::GTE) {
-                                return nonwrapping_range<bytes>::make_starting_with(interval_bound(*val, inclusive));
+                                return nonwrapping_range<managed_bytes>::make_starting_with(interval_bound(std::move(*val), inclusive));
                             }
-                            static const bytes MININT = serialized(std::numeric_limits<int64_t>::min()),
-                                    MAXINT = serialized(std::numeric_limits<int64_t>::max());
+                            static const managed_bytes MININT = managed_bytes(serialized(std::numeric_limits<int64_t>::min())),
+                                    MAXINT = managed_bytes(serialized(std::numeric_limits<int64_t>::max()));
                             // Undocumented feature: when the user types `token(...) < MININT`, we interpret
                             // that as MAXINT for some reason.
-                            const auto adjusted_val = (*val == MININT) ? serialized(MAXINT) : *val;
+                            const auto adjusted_val = (*val == MININT) ? MAXINT : *val;
                             if (oper.op == oper_t::LT) {
-                                return nonwrapping_range<bytes>::make_ending_with(interval_bound(adjusted_val, exclusive));
+                                return nonwrapping_range<managed_bytes>::make_ending_with(interval_bound(std::move(adjusted_val), exclusive));
                             } else if (oper.op == oper_t::LTE) {
-                                return nonwrapping_range<bytes>::make_ending_with(interval_bound(adjusted_val, inclusive));
+                                return nonwrapping_range<managed_bytes>::make_ending_with(interval_bound(std::move(adjusted_val), inclusive));
                             }
                             throw std::logic_error(format("get_token_interval invalid operator {}", oper.op));
                         },
@@ -789,14 +773,14 @@ value_set possible_lhs_values(const column_definition* cdef, const expression& e
         }, expr);
 }
 
-nonwrapping_range<bytes> to_range(const value_set& s) {
+nonwrapping_range<managed_bytes> to_range(const value_set& s) {
     return std::visit(overloaded_functor{
-            [] (const nonwrapping_range<bytes>& r) { return r; },
+            [] (const nonwrapping_range<managed_bytes>& r) { return r; },
             [] (const value_list& lst) {
                 if (lst.size() != 1) {
                     throw std::logic_error(format("to_range called on list of size {}", lst.size()));
                 }
-                return nonwrapping_range<bytes>::make_singular(lst[0]);
+                return nonwrapping_range<managed_bytes>::make_singular(lst[0]);
             },
         }, s);
 }

--- a/cql3/expr/expression.hh
+++ b/cql3/expr/expression.hh
@@ -113,7 +113,7 @@ extern bool is_satisfied_by(
 
 /// Finds the first binary_operator in restr that represents a bound and returns its RHS as a tuple.  If no
 /// such binary_operator exists, returns an empty vector.  The search is depth first.
-extern std::vector<bytes_opt> first_multicolumn_bound(const expression&, const query_options&, statements::bound);
+extern std::vector<managed_bytes_opt> first_multicolumn_bound(const expression&, const query_options&, statements::bound);
 
 /// A set of discrete values.
 using value_list = std::vector<bytes>; // Sorted and deduped using value comparator.

--- a/cql3/expr/expression.hh
+++ b/cql3/expr/expression.hh
@@ -116,11 +116,11 @@ extern bool is_satisfied_by(
 extern std::vector<managed_bytes_opt> first_multicolumn_bound(const expression&, const query_options&, statements::bound);
 
 /// A set of discrete values.
-using value_list = std::vector<bytes>; // Sorted and deduped using value comparator.
+using value_list = std::vector<managed_bytes>; // Sorted and deduped using value comparator.
 
 /// General set of values.  Empty set and single-element sets are always value_list.  nonwrapping_range is
 /// never singular and never has start > end.  Universal set is a nonwrapping_range with both bounds null.
-using value_set = std::variant<value_list, nonwrapping_range<bytes>>;
+using value_set = std::variant<value_list, nonwrapping_range<managed_bytes>>;
 
 /// A set of all column values that would satisfy an expression.  If column is null, a set of all token values
 /// that satisfy.
@@ -136,7 +136,7 @@ using value_set = std::variant<value_list, nonwrapping_range<bytes>>;
 extern value_set possible_lhs_values(const column_definition*, const expression&, const query_options&);
 
 /// Turns value_set into a range, unless it's a multi-valued list (in which case this throws).
-extern nonwrapping_range<bytes> to_range(const value_set&);
+extern nonwrapping_range<managed_bytes> to_range(const value_set&);
 
 /// A range of all X such that X op val.
 nonwrapping_range<clustering_key_prefix> to_range(oper_t op, const clustering_key_prefix& val);

--- a/cql3/expr/expression.hh
+++ b/cql3/expr/expression.hh
@@ -139,8 +139,7 @@ extern value_set possible_lhs_values(const column_definition*, const expression&
 extern nonwrapping_range<bytes> to_range(const value_set&);
 
 /// A range of all X such that X op val.
-template<typename T>
-nonwrapping_range<T> to_range(oper_t op, const T& val);
+nonwrapping_range<clustering_key_prefix> to_range(oper_t op, const clustering_key_prefix& val);
 
 /// True iff the index can support the entire expression.
 extern bool is_supported_by(const expression&, const secondary_index::index&);

--- a/cql3/lists.cc
+++ b/cql3/lists.cc
@@ -147,11 +147,11 @@ lists::value::get(const query_options& options) {
     return cql3::raw_value::make_value(get_with_protocol_version(options.get_cql_serialization_format()));
 }
 
-bytes
+managed_bytes
 lists::value::get_with_protocol_version(cql_serialization_format sf) {
     // Can't use boost::indirect_iterator, because optional is not an iterator
     auto deref = [] (bytes_opt& x) { return *x; };
-    return collection_type_impl::pack(
+    return collection_type_impl::pack_fragmented(
             boost::make_transform_iterator(_elements.begin(), deref),
             boost::make_transform_iterator( _elements.end(), deref),
             _elements.size(), sf);
@@ -393,7 +393,7 @@ lists::do_append(shared_ptr<term> value,
             m.set_cell(prefix, column, params.make_dead_cell());
         } else {
             auto newv = list_value->get_with_protocol_version(cql_serialization_format::internal());
-            m.set_cell(prefix, column, params.make_cell(*column.type, std::move(newv)));
+            m.set_cell(prefix, column, params.make_cell(*column.type, newv));
         }
     }
 }

--- a/cql3/lists.hh
+++ b/cql3/lists.hh
@@ -73,16 +73,16 @@ public:
 
     class value : public multi_item_terminal, collection_terminal {
     public:
-        std::vector<bytes_opt> _elements;
+        std::vector<managed_bytes_opt> _elements;
     public:
-        explicit value(std::vector<bytes_opt> elements)
+        explicit value(std::vector<managed_bytes_opt> elements)
             : _elements(std::move(elements)) {
         }
         static value from_serialized(const raw_value_view& v, const list_type_impl& type, cql_serialization_format sf);
         virtual cql3::raw_value get(const query_options& options) override;
         virtual managed_bytes get_with_protocol_version(cql_serialization_format sf) override;
         bool equals(const list_type_impl& lt, const value& v);
-        virtual const std::vector<bytes_opt>& get_elements() const override;
+        virtual const std::vector<managed_bytes_opt>& get_elements() const override;
         virtual sstring to_string() const;
         friend class lists;
     };

--- a/cql3/lists.hh
+++ b/cql3/lists.hh
@@ -80,7 +80,7 @@ public:
         }
         static value from_serialized(const raw_value_view& v, const list_type_impl& type, cql_serialization_format sf);
         virtual cql3::raw_value get(const query_options& options) override;
-        virtual bytes get_with_protocol_version(cql_serialization_format sf) override;
+        virtual managed_bytes get_with_protocol_version(cql_serialization_format sf) override;
         bool equals(const list_type_impl& lt, const value& v);
         virtual const std::vector<bytes_opt>& get_elements() const override;
         virtual sstring to_string() const;

--- a/cql3/lists.hh
+++ b/cql3/lists.hh
@@ -78,7 +78,7 @@ public:
         explicit value(std::vector<bytes_opt> elements)
             : _elements(std::move(elements)) {
         }
-        static value from_serialized(const fragmented_temporary_buffer::view& v, const list_type_impl& type, cql_serialization_format sf);
+        static value from_serialized(const raw_value_view& v, const list_type_impl& type, cql_serialization_format sf);
         virtual cql3::raw_value get(const query_options& options) override;
         virtual bytes get_with_protocol_version(cql_serialization_format sf) override;
         bool equals(const list_type_impl& lt, const value& v);

--- a/cql3/maps.cc
+++ b/cql3/maps.cc
@@ -177,15 +177,15 @@ maps::value::get(const query_options& options) {
     return cql3::raw_value::make_value(get_with_protocol_version(options.get_cql_serialization_format()));
 }
 
-bytes
+managed_bytes
 maps::value::get_with_protocol_version(cql_serialization_format sf) {
     //FIXME: share code with serialize_partially_deserialized_form
     size_t len = collection_value_len(sf) * map.size() * 2 + collection_size_len(sf);
     for (auto&& e : map) {
         len += e.first.size() + e.second.size();
     }
-    bytes b(bytes::initialized_later(), len);
-    bytes::iterator out = b.begin();
+    managed_bytes b(managed_bytes::initialized_later(), len);
+    managed_bytes_mutable_view out(b);
 
     write_collection_size(out, map.size(), sf);
     for (auto&& e : map) {

--- a/cql3/maps.cc
+++ b/cql3/maps.cc
@@ -346,7 +346,7 @@ maps::do_put(mutation& m, const clustering_key_prefix& prefix, const update_para
 
         auto ctype = static_cast<const map_type_impl*>(column.type.get());
         for (auto&& e : map_value->map) {
-            mut.cells.emplace_back(e.first, params.make_cell(*ctype->get_values_type(), fragmented_temporary_buffer::view(e.second), atomic_cell::collection_member::yes));
+            mut.cells.emplace_back(e.first, params.make_cell(*ctype->get_values_type(), e.second, atomic_cell::collection_member::yes));
         }
 
         m.set_cell(prefix, column, mut.serialize(*ctype));
@@ -357,7 +357,7 @@ maps::do_put(mutation& m, const clustering_key_prefix& prefix, const update_para
         } else {
             auto v = map_type_impl::serialize_partially_deserialized_form({map_value->map.begin(), map_value->map.end()},
                     cql_serialization_format::internal());
-            m.set_cell(prefix, column, params.make_cell(*column.type, fragmented_temporary_buffer::view(std::move(v))));
+            m.set_cell(prefix, column, params.make_cell(*column.type, v));
         }
     }
 }

--- a/cql3/maps.hh
+++ b/cql3/maps.hh
@@ -76,9 +76,9 @@ public:
 
     class value : public terminal, collection_terminal {
     public:
-        std::map<bytes, bytes, serialized_compare> map;
+        std::map<managed_bytes, managed_bytes, serialized_compare> map;
 
-        value(std::map<bytes, bytes, serialized_compare> map)
+        value(std::map<managed_bytes, managed_bytes, serialized_compare> map)
             : map(std::move(map)) {
         }
         static value from_serialized(const raw_value_view& value, const map_type_impl& type, cql_serialization_format sf);

--- a/cql3/maps.hh
+++ b/cql3/maps.hh
@@ -83,7 +83,7 @@ public:
         }
         static value from_serialized(const raw_value_view& value, const map_type_impl& type, cql_serialization_format sf);
         virtual cql3::raw_value get(const query_options& options) override;
-        virtual bytes get_with_protocol_version(cql_serialization_format sf);
+        virtual managed_bytes get_with_protocol_version(cql_serialization_format sf);
         bool equals(const map_type_impl& mt, const value& v);
         virtual sstring to_string() const;
     };

--- a/cql3/maps.hh
+++ b/cql3/maps.hh
@@ -81,7 +81,7 @@ public:
         value(std::map<bytes, bytes, serialized_compare> map)
             : map(std::move(map)) {
         }
-        static value from_serialized(const fragmented_temporary_buffer::view& value, const map_type_impl& type, cql_serialization_format sf);
+        static value from_serialized(const raw_value_view& value, const map_type_impl& type, cql_serialization_format sf);
         virtual cql3::raw_value get(const query_options& options) override;
         virtual bytes get_with_protocol_version(cql_serialization_format sf);
         bool equals(const map_type_impl& mt, const value& v);

--- a/cql3/operation.cc
+++ b/cql3/operation.cc
@@ -317,7 +317,7 @@ operation::set_counter_value_from_tuple_list::prepare(database& db, const sstrin
             counter_cell_builder ccb(list_value->_elements.size());
             for (auto& bo : list_value->_elements) {
                 // lexical etc cast fails should be enough type checking here.
-                auto tuple = value_cast<tuple_type_impl::native_type>(counter_tuple_type->deserialize(*bo));
+                auto tuple = value_cast<tuple_type_impl::native_type>(counter_tuple_type->deserialize(managed_bytes_view(*bo)));
                 auto shard = value_cast<int>(tuple[0]);
                 auto id = counter_id(value_cast<utils::UUID>(tuple[1]));
                 auto clock = value_cast<int64_t>(tuple[2]);

--- a/cql3/operation.hh
+++ b/cql3/operation.hh
@@ -87,22 +87,6 @@ public:
 
     virtual ~operation() {}
 
-    static atomic_cell make_dead_cell(const update_parameters& params) {
-        return params.make_dead_cell();
-    }
-
-    static atomic_cell make_cell(const abstract_type& type, bytes_view value, const update_parameters& params) {
-        return params.make_cell(type, fragmented_temporary_buffer::view(value));
-    }
-
-    static atomic_cell make_cell(const abstract_type& type, const fragmented_temporary_buffer::view& value, const update_parameters& params) {
-        return params.make_cell(type, value);
-    }
-
-    static atomic_cell make_counter_update_cell(int64_t delta, const update_parameters& params) {
-        return params.make_counter_update_cell(delta);
-    }
-
     virtual bool is_raw_counter_shard_write() const {
         return false;
     }

--- a/cql3/restrictions/multi_column_restriction.hh
+++ b/cql3/restrictions/multi_column_restriction.hh
@@ -222,7 +222,7 @@ public:
     clustering_key_prefix composite_value(const query_options& options) const {
         auto t = static_pointer_cast<tuples::value>(_value->bind(options));
         auto values = t->get_elements();
-        std::vector<bytes> components;
+        std::vector<managed_bytes> components;
         for (unsigned i = 0; i < values.size(); i++) {
             auto component = statements::request_validations::check_not_null(values[i],
                 "Invalid null value in condition for column %s",
@@ -315,7 +315,7 @@ public:
     }
 #endif
 protected:
-    virtual std::vector<std::vector<bytes_opt>> split_values(const query_options& options) const = 0;
+    virtual std::vector<std::vector<managed_bytes_opt>> split_values(const query_options& options) const = 0;
 };
 
 /**
@@ -338,8 +338,8 @@ public:
     }
 
 protected:
-    virtual std::vector<std::vector<bytes_opt>> split_values(const query_options& options) const override {
-        std::vector<std::vector<bytes_opt>> buffers(_values.size());
+    virtual std::vector<std::vector<managed_bytes_opt>> split_values(const query_options& options) const override {
+        std::vector<std::vector<managed_bytes_opt>> buffers(_values.size());
         std::transform(_values.begin(), _values.end(), buffers.begin(), [&] (const ::shared_ptr<term>& value) {
             auto term = static_pointer_cast<multi_item_terminal>(value->bind(options));
             return term->get_elements();
@@ -367,7 +367,7 @@ public:
     }
 
 protected:
-    virtual std::vector<std::vector<bytes_opt>> split_values(const query_options& options) const override {
+    virtual std::vector<std::vector<managed_bytes_opt>> split_values(const query_options& options) const override {
         auto in_marker = static_pointer_cast<tuples::in_marker>(_marker);
         auto in_value = static_pointer_cast<tuples::in_value>(in_marker->bind(options));
         statements::request_validations::check_not_null(in_value, "Invalid null value for IN restriction");
@@ -462,7 +462,7 @@ public:
     }
 
 private:
-    std::vector<bytes_opt> read_bound_components(const query_options& options, statements::bound b) const {
+    std::vector<managed_bytes_opt> read_bound_components(const query_options& options, statements::bound b) const {
         if (!_slice.has_bound(b)) {
             return {};
         }
@@ -564,7 +564,7 @@ private:
      * @return a shared pointer to the just created restriction.
      */
     ::shared_ptr<restriction> make_single_column_restriction(std::optional<cql3::statements::bound> bound, bool inclusive,
-                                                             std::size_t column_pos,const bytes_opt& value) const {
+                                                             std::size_t column_pos, const managed_bytes_opt& value) const {
         ::shared_ptr<cql3::term> term = ::make_shared<cql3::constants::value>(cql3::raw_value::make_value(value));
         using namespace expr;
         if (!bound){
@@ -597,7 +597,7 @@ private:
      * @return the single column restriction set built according to the above parameters.
      */
     std::vector<restriction_shared_ptr> make_single_bound_restrictions(statements::bound bound, bool bound_inclusive,
-                                                                       std::vector<bytes_opt>& bound_values,
+                                                                       std::vector<managed_bytes_opt>& bound_values,
                                                                        std::size_t first_neq_component) const{
         std::vector<restriction_shared_ptr> ret;
         std::size_t num_of_restrictions = bound_values.size() - first_neq_component;

--- a/cql3/restrictions/single_column_restrictions.hh
+++ b/cql3/restrictions/single_column_restrictions.hh
@@ -112,7 +112,7 @@ public:
                 return bytes_opt{};
             }
             assert(values.size() == 1);
-            return values.front();
+            return to_bytes(values.front());
         }
     }
 

--- a/cql3/restrictions/token_restriction.hh
+++ b/cql3/restrictions/token_restriction.hh
@@ -97,9 +97,10 @@ public:
             return {};
         }
         const auto bounds = expr::to_range(values);
-        const auto start_token = bounds.start() ? dht::token::from_bytes(bounds.start()->value())
+        const auto start_token = bounds.start() ? bounds.start()->value().with_linearized([] (bytes_view bv) { return dht::token::from_bytes(bv); })
                 : dht::minimum_token();
-        auto end_token = bounds.end() ? dht::token::from_bytes(bounds.end()->value()) : dht::maximum_token();
+        auto end_token = bounds.end() ? bounds.end()->value().with_linearized([] (bytes_view bv) { return dht::token::from_bytes(bv); })
+                : dht::maximum_token();
         const bool include_start = bounds.start() && bounds.start()->is_inclusive();
         const auto include_end = bounds.end() && bounds.end()->is_inclusive();
 

--- a/cql3/selection/field_selector.hh
+++ b/cql3/selection/field_selector.hh
@@ -97,12 +97,7 @@ public:
         if (!value) {
             return std::nullopt;
         }
-        auto&& buffers = _type->split(single_fragmented_view(*value));
-        bytes_opt ret;
-        if (_field < buffers.size() && buffers[_field]) {
-            ret = to_bytes(*buffers[_field]);
-        }
-        return ret;
+        return get_nth_tuple_element(single_fragmented_view(*value), _field);
     }
 
     virtual data_type get_type() const override {

--- a/cql3/sets.cc
+++ b/cql3/sets.cc
@@ -154,9 +154,9 @@ sets::value::get(const query_options& options) {
     return cql3::raw_value::make_value(get_with_protocol_version(options.get_cql_serialization_format()));
 }
 
-bytes
+managed_bytes
 sets::value::get_with_protocol_version(cql_serialization_format sf) {
-    return collection_type_impl::pack(_elements.begin(), _elements.end(),
+    return collection_type_impl::pack_fragmented(_elements.begin(), _elements.end(),
             _elements.size(), sf);
 }
 

--- a/cql3/sets.cc
+++ b/cql3/sets.cc
@@ -302,7 +302,7 @@ sets::adder::do_add(mutation& m, const clustering_key_prefix& row_key, const upd
         auto v = set_type_impl::serialize_partially_deserialized_form(
                 {set_value->_elements.begin(), set_value->_elements.end()},
                 cql_serialization_format::internal());
-        m.set_cell(row_key, column, params.make_cell(*column.type, fragmented_temporary_buffer::view(v)));
+        m.set_cell(row_key, column, params.make_cell(*column.type, v));
     } else {
         m.set_cell(row_key, column, params.make_dead_cell());
     }

--- a/cql3/sets.hh
+++ b/cql3/sets.hh
@@ -73,9 +73,9 @@ public:
 
     class value : public terminal, collection_terminal {
     public:
-        std::set<bytes, serialized_compare> _elements;
+        std::set<managed_bytes, serialized_compare> _elements;
     public:
-        value(std::set<bytes, serialized_compare> elements)
+        value(std::set<managed_bytes, serialized_compare> elements)
                 : _elements(std::move(elements)) {
         }
         static value from_serialized(const raw_value_view& v, const set_type_impl& type, cql_serialization_format sf);

--- a/cql3/sets.hh
+++ b/cql3/sets.hh
@@ -78,7 +78,7 @@ public:
         value(std::set<bytes, serialized_compare> elements)
                 : _elements(std::move(elements)) {
         }
-        static value from_serialized(const fragmented_temporary_buffer::view& v, const set_type_impl& type, cql_serialization_format sf);
+        static value from_serialized(const raw_value_view& v, const set_type_impl& type, cql_serialization_format sf);
         virtual cql3::raw_value get(const query_options& options) override;
         virtual bytes get_with_protocol_version(cql_serialization_format sf) override;
         bool equals(const set_type_impl& st, const value& v);

--- a/cql3/sets.hh
+++ b/cql3/sets.hh
@@ -80,7 +80,7 @@ public:
         }
         static value from_serialized(const raw_value_view& v, const set_type_impl& type, cql_serialization_format sf);
         virtual cql3::raw_value get(const query_options& options) override;
-        virtual bytes get_with_protocol_version(cql_serialization_format sf) override;
+        virtual managed_bytes get_with_protocol_version(cql_serialization_format sf) override;
         bool equals(const set_type_impl& st, const value& v);
         virtual sstring to_string() const override;
     };

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -260,8 +260,7 @@ uint64_t select_statement::do_get_limit(const query_options& options, ::shared_p
         return default_limit;
     }
     try {
-        int32_type->validate(*val, options.get_cql_serialization_format());
-        auto l = value_cast<int32_t>(int32_type->deserialize(*val));
+        auto l = val.validate_and_deserialize<int32_t>(*int32_type, options.get_cql_serialization_format());
         if (l <= 0) {
             throw exceptions::invalid_request_exception("LIMIT must be strictly positive");
         }

--- a/cql3/statements/update_statement.cc
+++ b/cql3/statements/update_statement.cc
@@ -205,7 +205,7 @@ insert_prepared_json_statement::execute_set_value(mutation& m, const clustering_
             if (type.is_collection()) {
                 throw std::runtime_error(format("insert_prepared_json_statement::execute_set_value: unhandled collection type {}", type.name()));
             }
-            m.set_cell(prefix, column, operation::make_dead_cell(params));
+            m.set_cell(prefix, column, params.make_dead_cell());
         }
         ));
         return;

--- a/cql3/statements/update_statement.cc
+++ b/cql3/statements/update_statement.cc
@@ -179,9 +179,7 @@ void update_statement::add_update_for_key(mutation& m, const query::clustering_r
 }
 
 modification_statement::json_cache_opt insert_prepared_json_statement::maybe_prepare_json_cache(const query_options& options) const {
-    sstring json_string = with_linearized(_term->bind_and_get(options).data().value(), [&] (bytes_view value) {
-        return utf8_type->to_string(bytes(value));
-    });
+    sstring json_string = utf8_type->to_string(to_bytes(_term->bind_and_get(options)));
     return json_helpers::parse(std::move(json_string), s->all_columns(), options.get_cql_serialization_format());
 }
 
@@ -217,25 +215,25 @@ insert_prepared_json_statement::execute_set_value(mutation& m, const clustering_
     visit(*column.type, make_visitor(
     [&] (const list_type_impl& ltype) {
         lists::setter::execute(m, prefix, params, column,
-                ::make_shared<lists::value>(lists::value::from_serialized(fragmented_temporary_buffer::view(*value), ltype, sf)));
+                ::make_shared<lists::value>(lists::value::from_serialized(raw_value_view::make_value(*value), ltype, sf)));
     },
     [&] (const set_type_impl& stype) {
         sets::setter::execute(m, prefix, params, column,
-                ::make_shared<sets::value>(sets::value::from_serialized(fragmented_temporary_buffer::view(*value), stype, sf)));
+                ::make_shared<sets::value>(sets::value::from_serialized(raw_value_view::make_value(*value), stype, sf)));
     },
     [&] (const map_type_impl& mtype) {
         maps::setter::execute(m, prefix, params, column,
-                ::make_shared<maps::value>(maps::value::from_serialized(fragmented_temporary_buffer::view(*value), mtype, sf)));
+                ::make_shared<maps::value>(maps::value::from_serialized(raw_value_view::make_value(*value), mtype, sf)));
     },
     [&] (const user_type_impl& utype) {
         user_types::setter::execute(m, prefix, params, column,
-                ::make_shared<user_types::value>(user_types::value::from_serialized(fragmented_temporary_buffer::view(*value), utype)));
+                ::make_shared<user_types::value>(user_types::value::from_serialized(raw_value_view::make_value(*value), utype)));
     },
     [&] (const abstract_type& type) {
         if (type.is_collection()) {
             throw std::runtime_error(format("insert_prepared_json_statement::execute_set_value: unhandled collection type {}", type.name()));
         }
-        constants::setter::execute(m, prefix, params, column, raw_value_view::make_value(fragmented_temporary_buffer::view(*value)));
+        constants::setter::execute(m, prefix, params, column, raw_value_view::make_value(*value));
     }
     ));
 }

--- a/cql3/term.hh
+++ b/cql3/term.hh
@@ -199,7 +199,7 @@ class collection_terminal {
 public:
     virtual ~collection_terminal() {}
     /** Gets the value of the collection when serialized with the given protocol version format */
-    virtual bytes get_with_protocol_version(cql_serialization_format sf) = 0;
+    virtual managed_bytes get_with_protocol_version(cql_serialization_format sf) = 0;
 };
 
 /**

--- a/cql3/term.hh
+++ b/cql3/term.hh
@@ -192,7 +192,7 @@ public:
 
 class multi_item_terminal : public terminal {
 public:
-    virtual const std::vector<bytes_opt>& get_elements() const = 0;
+    virtual const std::vector<managed_bytes_opt>& get_elements() const = 0;
 };
 
 class collection_terminal {

--- a/cql3/tuples.cc
+++ b/cql3/tuples.cc
@@ -81,11 +81,11 @@ tuples::literal::prepare(database& db, const sstring& keyspace, const std::vecto
 }
 
 tuples::in_value
-tuples::in_value::from_serialized(const fragmented_temporary_buffer::view& value_view, const list_type_impl& type, const query_options& options) {
+tuples::in_value::from_serialized(const raw_value_view& value_view, const list_type_impl& type, const query_options& options) {
     try {
         // Collections have this small hack that validate cannot be called on a serialized object,
         // but the deserialization does the validation (so we're fine).
-        auto l = value_cast<list_type_impl::native_type>(type.deserialize(value_view, options.get_cql_serialization_format()));
+        auto l = value_view.deserialize<list_type_impl::native_type>(type, options.get_cql_serialization_format());
         auto ttype = dynamic_pointer_cast<const tuple_type_impl>(type.get_elements_type());
         assert(ttype);
 
@@ -140,16 +140,14 @@ shared_ptr<terminal> tuples::in_marker::bind(const query_options& options) {
         auto& type = static_cast<const list_type_impl&>(*_receiver->type);
         auto& elem_type = static_cast<const tuple_type_impl&>(*type.get_elements_type());
         try {
-            type.validate(*value, options.get_cql_serialization_format());
-            auto l = value_cast<list_type_impl::native_type>(type.deserialize(*value, options.get_cql_serialization_format()));
-
+            auto l = value.validate_and_deserialize<list_type_impl::native_type>(type, options.get_cql_serialization_format());
             for (auto&& element : l) {
                 elem_type.validate(elem_type.decompose(element), options.get_cql_serialization_format());
             }
         } catch (marshal_exception& e) {
             throw exceptions::invalid_request_exception(e.what());
         }
-        return make_shared<tuples::in_value>(tuples::in_value::from_serialized(*value, type, options));
+        return make_shared<tuples::in_value>(tuples::in_value::from_serialized(value, type, options));
     }
 }
 

--- a/cql3/tuples.cc
+++ b/cql3/tuples.cc
@@ -89,10 +89,11 @@ tuples::in_value::from_serialized(const raw_value_view& value_view, const list_t
         auto ttype = dynamic_pointer_cast<const tuple_type_impl>(type.get_elements_type());
         assert(ttype);
 
-        std::vector<std::vector<bytes_opt>> elements;
+        std::vector<std::vector<managed_bytes_opt>> elements;
         elements.reserve(l.size());
         for (auto&& e : l) {
-            elements.emplace_back(ttype->split(single_fragmented_view(ttype->decompose(e))));
+            // FIXME: Avoid useless copies.
+            elements.emplace_back(ttype->split_fragmented(single_fragmented_view(ttype->decompose(e))));
         }
         return tuples::in_value(elements);
     } catch (marshal_exception& e) {

--- a/cql3/tuples.hh
+++ b/cql3/tuples.hh
@@ -108,24 +108,21 @@ public:
      */
     class value : public multi_item_terminal {
     public:
-        std::vector<bytes_opt> _elements;
+        std::vector<managed_bytes_opt> _elements;
     public:
-        value(std::vector<bytes_opt> elements)
+        value(std::vector<managed_bytes_opt> elements)
                 : _elements(std::move(elements)) {
-        }
-        value(std::vector<bytes_view_opt> elements)
-            : value(to_bytes_opt_vec(std::move(elements))) {
         }
         static value from_serialized(const raw_value_view& buffer, const tuple_type_impl& type) {
           return buffer.with_value([&] (const FragmentedView auto& view) {
-              return value(type.split(view));
+              return value(type.split_fragmented(view));
           });
         }
         virtual cql3::raw_value get(const query_options& options) override {
             return cql3::raw_value::make_value(tuple_type_impl::build_value_fragmented(_elements));
         }
 
-        virtual const std::vector<bytes_opt>& get_elements() const override {
+        virtual const std::vector<managed_bytes_opt>& get_elements() const override {
             return _elements;
         }
         size_t size() const {
@@ -157,15 +154,15 @@ public:
             }
         }
     private:
-        std::vector<bytes_opt> bind_internal(const query_options& options) {
-            std::vector<bytes_opt> buffers;
+        std::vector<managed_bytes_opt> bind_internal(const query_options& options) {
+            std::vector<managed_bytes_opt> buffers;
             buffers.resize(_elements.size());
             for (size_t i = 0; i < _elements.size(); ++i) {
                 const auto& value = _elements[i]->bind_and_get(options);
                 if (value.is_unset_value()) {
                     throw exceptions::invalid_request_exception(format("Invalid unset value for tuple field number {:d}", i));
                 }
-                buffers[i] = to_bytes_opt(value);
+                buffers[i] = to_managed_bytes_opt(value);
                 // Inside tuples, we must force the serialization of collections to v3 whatever protocol
                 // version is in use since we're going to store directly that serialized value.
                 if (options.get_cql_serialization_format() != cql_serialization_format::internal()
@@ -174,7 +171,7 @@ public:
                         buffers[i] = static_pointer_cast<const collection_type_impl>(_type->type(i))->reserialize(
                                 options.get_cql_serialization_format(),
                                 cql_serialization_format::internal(),
-                                bytes_view(*buffers[i]));
+                                managed_bytes_view(*buffers[i]));
                     }
                 }
             }
@@ -198,20 +195,9 @@ public:
      */
     class in_value : public terminal {
     private:
-        std::vector<std::vector<bytes_opt>> _elements;
+        std::vector<std::vector<managed_bytes_opt>> _elements;
     public:
-        in_value(std::vector<std::vector<bytes_opt>> items) : _elements(std::move(items)) { }
-        in_value(std::vector<std::vector<bytes_view_opt>> items) {
-            _elements.reserve(items.size());
-            for (auto&& tuple : items) {
-                std::vector<bytes_opt> elems;
-                elems.reserve(tuple.size());
-                for (auto&& e : tuple) {
-                    elems.emplace_back(e ? bytes_opt(bytes(e->begin(), e->end())) : bytes_opt());
-                }
-                _elements.emplace_back(std::move(elems));
-            }
-        }
+        in_value(std::vector<std::vector<managed_bytes_opt>> items) : _elements(std::move(items)) { }
 
         static in_value from_serialized(const raw_value_view& value_view, const list_type_impl& type, const query_options& options);
 
@@ -219,13 +205,13 @@ public:
             throw exceptions::unsupported_operation_exception();
         }
 
-        std::vector<std::vector<bytes_opt>> get_split_values() const {
+        std::vector<std::vector<managed_bytes_opt>> get_split_values() const {
             return _elements;
         }
 
         virtual sstring to_string() const override {
             std::vector<sstring> tuples(_elements.size());
-            std::transform(_elements.begin(), _elements.end(), tuples.begin(), &tuples::tuple_to_string<bytes_opt>);
+            std::transform(_elements.begin(), _elements.end(), tuples.begin(), &tuples::tuple_to_string<managed_bytes_opt>);
             return tuple_to_string(tuples);
         }
     };

--- a/cql3/tuples.hh
+++ b/cql3/tuples.hh
@@ -117,12 +117,12 @@ public:
             : value(to_bytes_opt_vec(std::move(elements))) {
         }
         static value from_serialized(const raw_value_view& buffer, const tuple_type_impl& type) {
-          return buffer.with_linearized([&] (bytes_view view) {
+          return buffer.with_value([&] (const FragmentedView auto& view) {
               return value(type.split(view));
           });
         }
         virtual cql3::raw_value get(const query_options& options) override {
-            return cql3::raw_value::make_value(tuple_type_impl::build_value(_elements));
+            return cql3::raw_value::make_value(tuple_type_impl::build_value_fragmented(_elements));
         }
 
         virtual const std::vector<bytes_opt>& get_elements() const override {
@@ -188,7 +188,7 @@ public:
 
         virtual cql3::raw_value_view bind_and_get(const query_options& options) override {
             // We don't "need" that override but it saves us the allocation of a Value object if used
-            return cql3::raw_value_view::make_temporary(cql3::raw_value::make_value(_type->build_value(bind_internal(options))));
+            return cql3::raw_value_view::make_temporary(cql3::raw_value::make_value(_type->build_value_fragmented(bind_internal(options))));
         }
     };
 

--- a/cql3/update_parameters.hh
+++ b/cql3/update_parameters.hh
@@ -187,20 +187,6 @@ public:
         }
     };
 
-    atomic_cell make_cell(const abstract_type& type, const bytes_view& value, atomic_cell::collection_member cm = atomic_cell::collection_member::no) const {
-        auto ttl = _ttl;
-
-        if (ttl.count() <= 0) {
-            ttl = _schema->default_time_to_live();
-        }
-
-        if (ttl.count() > 0) {
-            return atomic_cell::make_live(type, _timestamp, value, _local_deletion_time + ttl, ttl, cm);
-        } else {
-            return atomic_cell::make_live(type, _timestamp, value, cm);
-        }
-    };
-
     atomic_cell make_counter_update_cell(int64_t delta) const {
         return atomic_cell::make_live_counter_update(_timestamp, delta);
     }

--- a/cql3/update_parameters.hh
+++ b/cql3/update_parameters.hh
@@ -157,6 +157,22 @@ public:
         return atomic_cell::make_dead(_timestamp, _local_deletion_time);
     }
 
+    atomic_cell make_cell(const abstract_type& type, const raw_value_view& value, atomic_cell::collection_member cm = atomic_cell::collection_member::no) const {
+        auto ttl = _ttl;
+
+        if (ttl.count() <= 0) {
+            ttl = _schema->default_time_to_live();
+        }
+
+        return value.with_value([&] (const FragmentedView auto& v) {
+            if (ttl.count() > 0) {
+                return atomic_cell::make_live(type, _timestamp, v, _local_deletion_time + ttl, ttl, cm);
+            } else {
+                return atomic_cell::make_live(type, _timestamp, v, cm);
+            }
+        });
+    };
+
     atomic_cell make_cell(const abstract_type& type, const fragmented_temporary_buffer::view& value, atomic_cell::collection_member cm = atomic_cell::collection_member::no) const {
         auto ttl = _ttl;
 

--- a/cql3/update_parameters.hh
+++ b/cql3/update_parameters.hh
@@ -173,7 +173,7 @@ public:
         });
     };
 
-    atomic_cell make_cell(const abstract_type& type, const fragmented_temporary_buffer::view& value, atomic_cell::collection_member cm = atomic_cell::collection_member::no) const {
+    atomic_cell make_cell(const abstract_type& type, const bytes_view& value, atomic_cell::collection_member cm = atomic_cell::collection_member::no) const {
         auto ttl = _ttl;
 
         if (ttl.count() <= 0) {
@@ -186,10 +186,6 @@ public:
             return atomic_cell::make_live(type, _timestamp, value, cm);
         }
     };
-
-    atomic_cell make_cell(const abstract_type& type, bytes_view value, atomic_cell::collection_member cm = atomic_cell::collection_member::no) const {
-        return make_cell(type, fragmented_temporary_buffer::view(value), cm);
-    }
 
     atomic_cell make_counter_update_cell(int64_t delta) const {
         return atomic_cell::make_live_counter_update(_timestamp, delta);

--- a/cql3/update_parameters.hh
+++ b/cql3/update_parameters.hh
@@ -173,6 +173,20 @@ public:
         });
     };
 
+    atomic_cell make_cell(const abstract_type& type, const managed_bytes_view& value, atomic_cell::collection_member cm = atomic_cell::collection_member::no) const {
+        auto ttl = _ttl;
+
+        if (ttl.count() <= 0) {
+            ttl = _schema->default_time_to_live();
+        }
+
+        if (ttl.count() > 0) {
+            return atomic_cell::make_live(type, _timestamp, value, _local_deletion_time + ttl, ttl, cm);
+        } else {
+            return atomic_cell::make_live(type, _timestamp, value, cm);
+        }
+    };
+
     atomic_cell make_cell(const abstract_type& type, const bytes_view& value, atomic_cell::collection_member cm = atomic_cell::collection_member::no) const {
         auto ttl = _ttl;
 

--- a/cql3/user_types.cc
+++ b/cql3/user_types.cc
@@ -154,13 +154,16 @@ user_types::value::value(std::vector<bytes_view_opt> elements)
     : value(to_bytes_opt_vec(std::move(elements))) {
 }
 
-user_types::value user_types::value::from_serialized(const fragmented_temporary_buffer::view& v, const user_type_impl& type) {
-    auto elements = type.split(v);
-    if (elements.size() > type.size()) {
-        throw exceptions::invalid_request_exception(
-                format("User Defined Type value contained too many fields (expected {}, got {})", type.size(), elements.size()));
-    }
-    return value(elements);
+user_types::value user_types::value::from_serialized(const raw_value_view& v, const user_type_impl& type) {
+    return v.with_linearized([&] (bytes_view val) {
+        auto elements = type.split(val);
+        if (elements.size() > type.size()) {
+            throw exceptions::invalid_request_exception(
+                    format("User Defined Type value contained too many fields (expected {}, got {})", type.size(), elements.size()));
+        }
+
+        return value(elements);
+    });
 }
 
 cql3::raw_value user_types::value::get(const query_options&) {
@@ -231,7 +234,7 @@ shared_ptr<terminal> user_types::marker::bind(const query_options& options) {
     if (value.is_unset_value()) {
         return constants::UNSET_VALUE;
     }
-    return make_shared<user_types::value>(value::from_serialized(*value, static_cast<const user_type_impl&>(*_receiver->type)));
+    return make_shared<user_types::value>(value::from_serialized(value, static_cast<const user_type_impl&>(*_receiver->type)));
 }
 
 void user_types::setter::execute(mutation& m, const clustering_key_prefix& row_key, const update_parameters& params) {
@@ -285,7 +288,7 @@ void user_types::setter::execute(mutation& m, const clustering_key_prefix& row_k
         m.set_cell(row_key, column, mut.serialize(type));
     } else {
         if (value) {
-            m.set_cell(row_key, column, make_cell(type, *value->get(params._options), params));
+            m.set_cell(row_key, column, params.make_cell(type, value->get(params._options).to_view()));
         } else {
             m.set_cell(row_key, column, make_dead_cell(params));
         }
@@ -304,7 +307,7 @@ void user_types::setter_by_field::execute(mutation& m, const clustering_key_pref
 
     collection_mutation_description mut;
     mut.cells.emplace_back(serialize_field_index(_field_idx), value
-                ? params.make_cell(*type.type(_field_idx), *value, atomic_cell::collection_member::yes)
+                ? params.make_cell(*type.type(_field_idx), value, atomic_cell::collection_member::yes)
                 : make_dead_cell(params));
 
     m.set_cell(row_key, column, mut.serialize(type));

--- a/cql3/user_types.cc
+++ b/cql3/user_types.cc
@@ -290,7 +290,7 @@ void user_types::setter::execute(mutation& m, const clustering_key_prefix& row_k
         if (value) {
             m.set_cell(row_key, column, params.make_cell(type, value->get(params._options).to_view()));
         } else {
-            m.set_cell(row_key, column, make_dead_cell(params));
+            m.set_cell(row_key, column, params.make_dead_cell());
         }
     }
 }
@@ -308,7 +308,7 @@ void user_types::setter_by_field::execute(mutation& m, const clustering_key_pref
     collection_mutation_description mut;
     mut.cells.emplace_back(serialize_field_index(_field_idx), value
                 ? params.make_cell(*type.type(_field_idx), value, atomic_cell::collection_member::yes)
-                : make_dead_cell(params));
+                : params.make_dead_cell());
 
     m.set_cell(row_key, column, mut.serialize(type));
 }
@@ -317,7 +317,7 @@ void user_types::deleter_by_field::execute(mutation& m, const clustering_key_pre
     assert(column.type->is_user_type() && column.type->is_multi_cell());
 
     collection_mutation_description mut;
-    mut.cells.emplace_back(serialize_field_index(_field_idx), make_dead_cell(params));
+    mut.cells.emplace_back(serialize_field_index(_field_idx), params.make_dead_cell());
 
     m.set_cell(row_key, column, mut.serialize(*column.type));
 }

--- a/cql3/user_types.cc
+++ b/cql3/user_types.cc
@@ -146,17 +146,13 @@ sstring user_types::literal::to_string() const {
     return format("{{{}}}", ::join(", ", _entries | boost::adaptors::transformed(kv_to_str)));
 }
 
-user_types::value::value(std::vector<bytes_opt> elements)
+user_types::value::value(std::vector<managed_bytes_opt> elements)
         : _elements(std::move(elements)) {
-}
-
-user_types::value::value(std::vector<bytes_view_opt> elements)
-    : value(to_bytes_opt_vec(std::move(elements))) {
 }
 
 user_types::value user_types::value::from_serialized(const raw_value_view& v, const user_type_impl& type) {
     return v.with_value([&] (const FragmentedView auto& val) {
-        std::vector<bytes_opt> elements = type.split(val);
+        std::vector<managed_bytes_opt> elements = type.split_fragmented(val);
         if (elements.size() > type.size()) {
             throw exceptions::invalid_request_exception(
                     format("User Defined Type value contained too many fields (expected {}, got {})", type.size(), elements.size()));
@@ -170,7 +166,7 @@ cql3::raw_value user_types::value::get(const query_options&) {
     return cql3::raw_value::make_value(tuple_type_impl::build_value_fragmented(_elements));
 }
 
-const std::vector<bytes_opt>& user_types::value::get_elements() const {
+const std::vector<managed_bytes_opt>& user_types::value::get_elements() const {
     return _elements;
 }
 
@@ -191,14 +187,14 @@ void user_types::delayed_value::collect_marker_specification(variable_specificat
     }
 }
 
-std::vector<bytes_opt> user_types::delayed_value::bind_internal(const query_options& options) {
+std::vector<managed_bytes_opt> user_types::delayed_value::bind_internal(const query_options& options) {
     auto sf = options.get_cql_serialization_format();
 
     // user_types::literal::prepare makes sure that every field gets a corresponding value.
     // For missing fields the values become nullopts.
     assert(_type->size() == _values.size());
 
-    std::vector<bytes_opt> buffers;
+    std::vector<managed_bytes_opt> buffers;
     for (size_t i = 0; i < _type->size(); ++i) {
         const auto& value = _values[i]->bind_and_get(options);
         if (!_type->is_multi_cell() && value.is_unset_value()) {
@@ -206,13 +202,13 @@ std::vector<bytes_opt> user_types::delayed_value::bind_internal(const query_opti
                         _type->field_name_as_string(i), _type->get_name_as_string()));
         }
 
-        buffers.push_back(to_bytes_opt(value));
+        buffers.push_back(to_managed_bytes_opt(value));
 
         // Inside UDT values, we must force the serialization of collections to v3 whatever protocol
         // version is in use since we're going to store directly that serialized value.
         if (!sf.collection_format_unchanged() && _type->field_type(i)->is_collection() && buffers.back()) {
             auto&& ctype = static_pointer_cast<const collection_type_impl>(_type->field_type(i));
-            buffers.back() = ctype->reserialize(sf, cql_serialization_format::latest(), bytes_view(*buffers.back()));
+            buffers.back() = ctype->reserialize(sf, cql_serialization_format::latest(), managed_bytes_view(*buffers.back()));
         }
     }
     return buffers;

--- a/cql3/user_types.hh
+++ b/cql3/user_types.hh
@@ -73,15 +73,15 @@ public:
     };
 
     class value : public multi_item_terminal {
-        std::vector<bytes_opt> _elements;
+        std::vector<managed_bytes_opt> _elements;
     public:
-        explicit value(std::vector<bytes_opt>);
-        explicit value(std::vector<bytes_view_opt>);
+        explicit value(std::vector<managed_bytes_opt>);
+        explicit value(std::vector<managed_bytes_view_opt>);
 
         static value from_serialized(const raw_value_view&, const user_type_impl&);
 
         virtual cql3::raw_value get(const query_options&) override;
-        virtual const std::vector<bytes_opt>& get_elements() const override;
+        virtual const std::vector<managed_bytes_opt>& get_elements() const override;
         virtual sstring to_string() const override;
     };
 
@@ -94,7 +94,7 @@ public:
         virtual bool contains_bind_marker() const override;
         virtual void collect_marker_specification(variable_specifications& bound_names) const;
     private:
-        std::vector<bytes_opt> bind_internal(const query_options& options);
+        std::vector<managed_bytes_opt> bind_internal(const query_options& options);
     public:
         virtual shared_ptr<terminal> bind(const query_options& options) override;
         virtual cql3::raw_value_view bind_and_get(const query_options& options) override;

--- a/cql3/user_types.hh
+++ b/cql3/user_types.hh
@@ -78,7 +78,7 @@ public:
         explicit value(std::vector<bytes_opt>);
         explicit value(std::vector<bytes_view_opt>);
 
-        static value from_serialized(const fragmented_temporary_buffer::view&, const user_type_impl&);
+        static value from_serialized(const raw_value_view&, const user_type_impl&);
 
         virtual cql3::raw_value get(const query_options&) override;
         virtual const std::vector<bytes_opt>& get_elements() const override;

--- a/cql3/values.hh
+++ b/cql3/values.hh
@@ -108,19 +108,6 @@ public:
         return std::get<fragmented_temporary_buffer::view>(_data);
     }
 
-    bool operator==(const raw_value_view& other) const {
-        if (_data.index() != other._data.index()) {
-            return false;
-        }
-        if (is_value() && **this != *other) {
-            return false;
-        }
-        return true;
-    }
-    bool operator!=(const raw_value_view& other) const {
-        return !(*this == other);
-    }
-
     template <typename Func>
     requires std::invocable<Func, const managed_bytes_view&> && std::invocable<Func, const fragmented_temporary_buffer::view&>
     decltype(auto) with_value(Func f) const {

--- a/cql3/values.hh
+++ b/cql3/values.hh
@@ -44,8 +44,8 @@ class raw_value;
 /// \brief View to a raw CQL protocol value.
 ///
 /// \see raw_value
-struct raw_value_view {
-    std::variant<fragmented_temporary_buffer::view, null_value, unset_value> _data;
+class raw_value_view {
+    std::variant<fragmented_temporary_buffer::view, managed_bytes_view, null_value, unset_value> _data;
     // Temporary storage is only useful if a raw_value_view needs to be instantiated
     // with a value which lifetime is bounded only to the view itself.
     // This hack is introduced in order to avoid storing temporary storage
@@ -55,32 +55,38 @@ struct raw_value_view {
     // - pointers are cheap to copy
     // - it makes the view keep its semantics - it's safe to copy a view multiple times
     //   and all copies still refer to the same underlying data.
-    lw_shared_ptr<bytes> _temporary_storage = nullptr;
+    lw_shared_ptr<managed_bytes> _temporary_storage = nullptr;
 
-    raw_value_view(null_value&& data)
+    raw_value_view(null_value data)
         : _data{std::move(data)}
     {}
-    raw_value_view(unset_value&& data)
+    raw_value_view(unset_value data)
         : _data{std::move(data)}
     {}
     raw_value_view(fragmented_temporary_buffer::view data)
         : _data{data}
     {}
+    raw_value_view(managed_bytes_view data)
+        : _data{data}
+    {}
     // This constructor is only used by make_temporary() and it acquires ownership
     // of the given buffer. The view created that way refers to its own temporary storage.
-    explicit raw_value_view(bytes&& temporary_storage);
+    explicit raw_value_view(managed_bytes&& temporary_storage);
 public:
     static raw_value_view make_null() {
-        return raw_value_view{std::move(null_value{})};
+        return raw_value_view{null_value{}};
     }
     static raw_value_view make_unset_value() {
-        return raw_value_view{std::move(unset_value{})};
+        return raw_value_view{unset_value{}};
     }
     static raw_value_view make_value(fragmented_temporary_buffer::view view) {
         return raw_value_view{view};
     }
+    static raw_value_view make_value(managed_bytes_view view) {
+        return raw_value_view{view};
+    }
     static raw_value_view make_value(bytes_view view) {
-        return raw_value_view{fragmented_temporary_buffer::view(view)};
+        return raw_value_view{managed_bytes_view(view)};
     }
     static raw_value_view make_temporary(raw_value&& value);
     bool is_null() const {
@@ -90,28 +96,19 @@ public:
         return std::holds_alternative<unset_value>(_data);
     }
     bool is_value() const {
-        return std::holds_alternative<fragmented_temporary_buffer::view>(_data);
-    }
-    std::optional<fragmented_temporary_buffer::view> data() const {
-        if (auto pdata = std::get_if<fragmented_temporary_buffer::view>(&_data)) {
-            return *pdata;
-        }
-        return {};
+        return _data.index() <= 1;
     }
     explicit operator bool() const {
         return is_value();
-    }
-    const fragmented_temporary_buffer::view* operator->() const {
-        return &std::get<fragmented_temporary_buffer::view>(_data);
-    }
-    const fragmented_temporary_buffer::view& operator*() const {
-        return std::get<fragmented_temporary_buffer::view>(_data);
     }
 
     template <typename Func>
     requires std::invocable<Func, const managed_bytes_view&> && std::invocable<Func, const fragmented_temporary_buffer::view&>
     decltype(auto) with_value(Func f) const {
-        return f(std::get<fragmented_temporary_buffer::view>(_data));
+        switch (_data.index()) {
+        case 0: return f(std::get<fragmented_temporary_buffer::view>(_data));
+        default: return f(std::get<managed_bytes_view>(_data));
+        }
     }
 
     template <typename Func>
@@ -159,6 +156,7 @@ public:
     }
 
     friend std::ostream& operator<<(std::ostream& os, const raw_value_view& value);
+    friend class raw_value;
 };
 
 /// \brief Raw CQL protocol value.
@@ -167,7 +165,7 @@ public:
 /// protocol. A raw value can hold either a null value, an unset value, or a byte
 /// blob that represents the value.
 class raw_value {
-    std::variant<bytes, null_value, unset_value> _data;
+    std::variant<bytes, managed_bytes, null_value, unset_value> _data;
 
     raw_value(null_value&& data)
         : _data{std::move(data)}
@@ -181,6 +179,9 @@ class raw_value {
     raw_value(const bytes& data)
         : _data{data}
     {}
+    raw_value(managed_bytes&& data)
+        : _data{std::move(data)}
+    {}
 public:
     static raw_value make_null() {
         return raw_value{std::move(null_value{})};
@@ -189,6 +190,9 @@ public:
         return raw_value{std::move(unset_value{})};
     }
     static raw_value make_value(const raw_value_view& view);
+    static raw_value make_value(managed_bytes&& bytes) {
+        return raw_value{std::move(bytes)};
+    }
     static raw_value make_value(bytes&& bytes) {
         return raw_value{std::move(bytes)};
     }
@@ -208,45 +212,33 @@ public:
         return std::holds_alternative<unset_value>(_data);
     }
     bool is_value() const {
-        return std::holds_alternative<bytes>(_data);
-    }
-    bytes_opt data() const {
-        if (auto pdata = std::get_if<bytes>(&_data)) {
-            return *pdata;
-        }
-        return {};
+        return _data.index() <= 1;
     }
     explicit operator bool() const {
         return is_value();
     }
-    const bytes* operator->() const {
-        return &std::get<bytes>(_data);
-    }
-    const bytes& operator*() const {
-        return std::get<bytes>(_data);
-    }
-    bytes&& extract_value() && {
-        auto b = std::get_if<bytes>(&_data);
-        assert(b);
-        return std::move(*b);
-    }
     bytes to_bytes() && {
-        return std::move(std::get<bytes>(_data));
+        switch (_data.index()) {
+        case 0:  return std::move(std::get<bytes>(_data));
+        default: return ::to_bytes(std::get<managed_bytes>(_data));
+        }
     }
     raw_value_view to_view() const;
+    friend class raw_value_view;
 };
 
 }
 
 inline bytes to_bytes(const cql3::raw_value_view& view)
 {
-    return linearized(*view);
+    return view.with_value([] (const FragmentedView auto& v) {
+        return linearized(v);
+    });
 }
 
 inline bytes_opt to_bytes_opt(const cql3::raw_value_view& view) {
-    auto buffer_view = view.data();
-    if (buffer_view) {
-        return bytes_opt(linearized(*buffer_view));
+    if (view.is_value()) {
+        return to_bytes(view);
     }
     return bytes_opt();
 }

--- a/keys.hh
+++ b/keys.hh
@@ -193,12 +193,18 @@ public:
     static TopLevel from_exploded(const schema& s, const std::vector<bytes>& v) {
         return from_exploded(v);
     }
+    static TopLevel from_exploded(const schema& s, const std::vector<managed_bytes>& v) {
+        return from_exploded(v);
+    }
     static TopLevel from_exploded_view(const std::vector<bytes_view>& v) {
         return from_exploded(v);
     }
 
     // We don't allow optional values, but provide this method as an efficient adaptor
     static TopLevel from_optional_exploded(const schema& s, const std::vector<bytes_opt>& v) {
+        return TopLevel::from_bytes(get_compound_type(s)->serialize_optionals(v));
+    }
+    static TopLevel from_optional_exploded(const schema& s, const std::vector<managed_bytes_opt>& v) {
         return TopLevel::from_bytes(get_compound_type(s)->serialize_optionals(v));
     }
 
@@ -793,6 +799,9 @@ public:
     }
 
     clustering_key_prefix(std::vector<bytes> v)
+        : prefix_compound_wrapper(compound::element_type::serialize_value(std::move(v)))
+    { }
+    clustering_key_prefix(std::vector<managed_bytes> v)
         : prefix_compound_wrapper(compound::element_type::serialize_value(std::move(v)))
     { }
 

--- a/keys.hh
+++ b/keys.hh
@@ -216,6 +216,10 @@ public:
         return TopLevel::from_bytes(get_compound_type(s)->serialize_single(std::move(v)));
     }
 
+    static TopLevel from_single_value(const schema& s, managed_bytes v) {
+        return TopLevel::from_bytes(get_compound_type(s)->serialize_single(std::move(v)));
+    }
+
     template <typename T>
     static
     TopLevel from_singular(const schema& s, const T& v) {

--- a/test/boost/managed_bytes_test.cc
+++ b/test/boost/managed_bytes_test.cc
@@ -389,3 +389,14 @@ BOOST_AUTO_TEST_CASE(test_appending_hash) {
     });
 }
 
+BOOST_AUTO_TEST_CASE(test_to_hex) {
+    fragmenting_allocation_strategy fragmenting_allocator(alloc_size);
+    with_allocator(fragmenting_allocator, [&] {
+        for (size_t size : sizes) {
+            auto b = tests::random::get_bytes(size);
+            managed_bytes m(b);
+            BOOST_CHECK_EQUAL(to_hex(b), to_hex(m));
+        }
+    });
+}
+

--- a/test/boost/transport_test.cc
+++ b/test/boost/transport_test.cc
@@ -99,7 +99,7 @@ SEASTAR_THREAD_TEST_CASE(test_response_request_reader) {
 
     BOOST_CHECK(req.read_value_view(version).is_null());
     BOOST_CHECK(req.read_value_view(version).is_unset_value());
-    BOOST_CHECK_EQUAL(linearized(*req.read_value_view(version)), value);
+    BOOST_CHECK_EQUAL(to_bytes(req.read_value_view(version)), value);
 
     std::vector<sstring_view> names;
     std::vector<cql3::raw_value_view> values;

--- a/test/boost/transport_test.cc
+++ b/test/boost/transport_test.cc
@@ -26,6 +26,22 @@
 
 #include "test/lib/random_utils.hh"
 
+namespace cql3 {
+
+bool operator==(const cql3::raw_value_view& a, const cql3::raw_value_view& b) {
+    if (a.is_value()) {
+        return b.is_value() && b.with_value([&] (const FragmentedView auto& v2) {
+            return a.with_value([&] (const FragmentedView auto& v1) {
+                return equal_unsigned(v1, v2);
+            });
+        });
+    } else {
+        return a.is_null() == b.is_null();
+    }
+}
+
+} // namespace cql3
+
 SEASTAR_THREAD_TEST_CASE(test_response_request_reader) {
     auto stream_id = tests::random::get_int<int16_t>();
     auto opcode = tests::random::get_int<uint8_t>(uint8_t(cql_transport::cql_binary_opcode::AUTH_SUCCESS));

--- a/tracing/trace_state.cc
+++ b/tracing/trace_state.cc
@@ -315,7 +315,7 @@ sstring trace_state::raw_value_to_sstring(const cql3::raw_value_view& v, const d
     } else if (v.is_unset_value()) {
         return "unset value";
     } else {
-      return with_linearized(*v, [&] (bytes_view val) {
+      return v.with_linearized([&] (bytes_view val) {
         sstring str_rep;
 
         if (t) {

--- a/types.cc
+++ b/types.cc
@@ -115,15 +115,6 @@ sstring inet_addr_type_impl::to_sstring(const seastar::net::inet_address& addr) 
     return out.str();
 }
 
-std::vector<bytes_opt> to_bytes_opt_vec(const std::vector<bytes_view_opt>& v) {
-    std::vector<bytes_opt> r;
-    r.reserve(v.size());
-    for (auto& e: v) {
-        r.push_back(to_bytes_opt(e));
-    }
-    return r;
-}
-
 static const char* byte_type_name      = "org.apache.cassandra.db.marshal.ByteType";
 static const char* short_type_name     = "org.apache.cassandra.db.marshal.ShortType";
 static const char* int32_type_name     = "org.apache.cassandra.db.marshal.Int32Type";
@@ -1219,8 +1210,8 @@ static std::optional<data_type> update_user_type_aux(
 
 static void serialize(const abstract_type& t, const void* value, bytes::iterator& out, cql_serialization_format sf);
 
-bytes_opt
-collection_type_impl::reserialize(cql_serialization_format from, cql_serialization_format to, bytes_view_opt v) const {
+managed_bytes_opt
+collection_type_impl::reserialize(cql_serialization_format from, cql_serialization_format to, managed_bytes_view_opt v) const {
     if (!v) {
         return std::nullopt;
     }
@@ -1228,7 +1219,8 @@ collection_type_impl::reserialize(cql_serialization_format from, cql_serializati
     bytes ret(bytes::initialized_later(), val.serialized_size());  // FIXME: serialized_size want @to
     auto out = ret.begin();
     ::serialize(*this, get_value_ptr(val), out, to);
-    return ret;
+    // FIXME: serialize directly to managed_bytes.
+    return managed_bytes(ret);
 }
 
 set_type

--- a/types.hh
+++ b/types.hh
@@ -869,6 +869,9 @@ public:
     bool operator()(const bytes& v1, const bytes& v2) const {
         return _type->less(v1, v2);
     }
+    bool operator()(const managed_bytes& v1, const managed_bytes& v2) const {
+        return _type->compare(v1, v2) < 0;
+    }
 };
 
 inline
@@ -882,6 +885,9 @@ class serialized_tri_compare {
 public:
     serialized_tri_compare(data_type type) : _type(type) {}
     int operator()(const bytes_view& v1, const bytes_view& v2) const {
+        return _type->compare(v1, v2);
+    }
+    int operator()(const managed_bytes_view& v1, const managed_bytes_view& v2) const {
         return _type->compare(v1, v2);
     }
 };

--- a/types.hh
+++ b/types.hh
@@ -1214,8 +1214,11 @@ inline sstring read_simple_short_string(bytes_view& v) {
 size_t collection_size_len(cql_serialization_format sf);
 size_t collection_value_len(cql_serialization_format sf);
 void write_collection_size(bytes::iterator& out, int size, cql_serialization_format sf);
+void write_collection_size(managed_bytes_mutable_view&, int size, cql_serialization_format sf);
 void write_collection_value(bytes::iterator& out, cql_serialization_format sf, bytes_view val_bytes);
 void write_collection_value(bytes::iterator& out, cql_serialization_format sf, data_type type, const data_value& value);
+void write_collection_value(managed_bytes_mutable_view&, cql_serialization_format sf, bytes_view val_bytes);
+void write_collection_value(managed_bytes_mutable_view&, cql_serialization_format sf, const managed_bytes_view& val_bytes);
 
 using user_type = shared_ptr<const user_type_impl>;
 using tuple_type = shared_ptr<const tuple_type_impl>;

--- a/types.hh
+++ b/types.hh
@@ -1223,6 +1223,13 @@ void write_collection_value(bytes::iterator& out, cql_serialization_format sf, b
 void write_collection_value(managed_bytes_mutable_view&, cql_serialization_format sf, bytes_view val_bytes);
 void write_collection_value(managed_bytes_mutable_view&, cql_serialization_format sf, const managed_bytes_view& val_bytes);
 
+// Splits a serialized collection into a vector of elements, but does not recursively deserialize the elements.
+// Does not perform validation.
+template <FragmentedView View>
+std::vector<managed_bytes> partially_deserialize_listlike(View in, cql_serialization_format sf);
+template <FragmentedView View>
+std::vector<std::pair<managed_bytes, managed_bytes>> partially_deserialize_map(View in, cql_serialization_format sf);
+
 using user_type = shared_ptr<const user_type_impl>;
 using tuple_type = shared_ptr<const tuple_type_impl>;
 

--- a/types.hh
+++ b/types.hh
@@ -1075,8 +1075,6 @@ to_bytes_opt(bytes_view_opt bv) {
     return std::nullopt;
 }
 
-std::vector<bytes_opt> to_bytes_opt_vec(const std::vector<bytes_view_opt>&);
-
 inline
 bytes_view_opt
 as_bytes_view_opt(const bytes_opt& bv) {
@@ -1216,7 +1214,6 @@ size_t collection_value_len(cql_serialization_format sf);
 void write_collection_size(bytes::iterator& out, int size, cql_serialization_format sf);
 void write_collection_size(managed_bytes_mutable_view&, int size, cql_serialization_format sf);
 void write_collection_value(bytes::iterator& out, cql_serialization_format sf, bytes_view val_bytes);
-void write_collection_value(bytes::iterator& out, cql_serialization_format sf, data_type type, const data_value& value);
 void write_collection_value(managed_bytes_mutable_view&, cql_serialization_format sf, bytes_view val_bytes);
 void write_collection_value(managed_bytes_mutable_view&, cql_serialization_format sf, const managed_bytes_view& val_bytes);
 

--- a/types/collection.hh
+++ b/types/collection.hh
@@ -58,10 +58,6 @@ public:
     static bytes pack(Iterator start, Iterator finish, int elements, cql_serialization_format sf);
 
     template <typename Iterator>
-    requires requires (Iterator it) { {*it} -> std::convertible_to<bytes_view>; }
-    static managed_bytes pack_fragmented(Iterator start, Iterator finish, int elements, cql_serialization_format sf);
-
-    template <typename Iterator>
     requires requires (Iterator it) { {*it} -> std::convertible_to<managed_bytes_view>; }
     static managed_bytes pack_fragmented(Iterator start, Iterator finish, int elements, cql_serialization_format sf);
 
@@ -128,25 +124,6 @@ collection_type_impl::pack(Iterator start, Iterator finish, int elements, cql_se
     write_collection_size(i, elements, sf);
     while (start != finish) {
         write_collection_value(i, sf, *start++);
-    }
-    return out;
-}
-
-// TODO: remove after all collections types in cql3/ are converted to managed_bytes
-template <typename Iterator>
-requires requires (Iterator it) { {*it} -> std::convertible_to<bytes_view>; }
-managed_bytes
-collection_type_impl::pack_fragmented(Iterator start, Iterator finish, int elements, cql_serialization_format sf) {
-    size_t len = collection_size_len(sf);
-    size_t psz = collection_value_len(sf);
-    for (auto j = start; j != finish; j++) {
-        len += j->size() + psz;
-    }
-    managed_bytes out(managed_bytes::initialized_later(), len);
-    managed_bytes_mutable_view v(out);
-    write_collection_size(v, elements, sf);
-    while (start != finish) {
-        write_collection_value(v, sf, *start++);
     }
     return out;
 }

--- a/types/collection.hh
+++ b/types/collection.hh
@@ -85,7 +85,7 @@ public:
     data_value deserialize_value(bytes_view v, cql_serialization_format sf) const {
         return deserialize_impl(single_fragmented_view(v), sf);
     }
-    bytes_opt reserialize(cql_serialization_format from, cql_serialization_format to, bytes_view_opt v) const;
+    managed_bytes_opt reserialize(cql_serialization_format from, cql_serialization_format to, managed_bytes_view_opt v) const;
 };
 
 // a list or a set

--- a/utils/fragment_range.hh
+++ b/utils/fragment_range.hh
@@ -410,3 +410,23 @@ void write_native(Out& out, std::type_identity_t<T> v) {
         write_fragmented(out, single_fragmented_view(bytes_view(p, sizeof(v))));
     }
 }
+
+inline sstring::iterator fragment_to_hex(sstring::iterator out, bytes_view frag) {
+    static constexpr char digits[] = "0123456789abcdef";
+    for (auto byte : frag) {
+        uint8_t x = static_cast<uint8_t>(byte);
+        *out++ = digits[x >> 4];
+        *out++ = digits[x & 0xf];
+    }
+    return out;
+}
+
+template<FragmentedView View>
+sstring to_hex(const View& b) {
+    sstring out = uninitialized_string(b.size_bytes() * 2);
+    auto it = out.begin();
+    for (auto frag : fragment_range(b)) {
+        it = fragment_to_hex(it, frag);
+    }
+    return out;
+}

--- a/utils/managed_bytes.cc
+++ b/utils/managed_bytes.cc
@@ -35,3 +35,17 @@ managed_bytes::do_linearize_pure() const {
     return data;
 }
 
+sstring to_hex(const managed_bytes& b) {
+    return to_hex(managed_bytes_view(b));
+}
+
+sstring to_hex(const managed_bytes_opt& b) {
+    return !b ? "null" : to_hex(*b);
+}
+
+std::ostream& operator<<(std::ostream& os, const managed_bytes_opt& b) {
+    if (b) {
+        return os << *b;
+    }
+    return os << "null";
+}

--- a/utils/managed_bytes.hh
+++ b/utils/managed_bytes.hh
@@ -469,6 +469,9 @@ public:
 static_assert(FragmentedView<managed_bytes_view>);
 static_assert(FragmentedMutableView<managed_bytes_mutable_view>);
 
+using managed_bytes_opt = std::optional<managed_bytes>;
+using managed_bytes_view_opt = std::optional<managed_bytes_view>;
+
 inline bytes to_bytes(const managed_bytes& v) {
     return linearized(managed_bytes_view(v));
 }
@@ -509,6 +512,9 @@ struct hash<managed_bytes> {
 };
 } // namespace std
 
+sstring to_hex(const managed_bytes& b);
+sstring to_hex(const managed_bytes_opt& b);
+
 // The operators below are used only by tests.
 
 inline bool operator==(const managed_bytes_view& a, const managed_bytes_view& b) {
@@ -524,3 +530,4 @@ inline std::ostream& operator<<(std::ostream& os, const managed_bytes_view& v) {
 inline std::ostream& operator<<(std::ostream& os, const managed_bytes& b) {
     return (os << managed_bytes_view(b));
 }
+std::ostream& operator<<(std::ostream& os, const managed_bytes_opt& b);

--- a/utils/managed_bytes.hh
+++ b/utils/managed_bytes.hh
@@ -134,7 +134,8 @@ public:
 
     explicit managed_bytes(const bytes& b) : managed_bytes(static_cast<bytes_view>(b)) {}
 
-    explicit managed_bytes(managed_bytes_view v);
+    template <FragmentedView View>
+    explicit managed_bytes(View v);
 
     managed_bytes(initialized_later, size_type size) {
         memory::on_alloc_point();
@@ -479,7 +480,8 @@ inline bytes to_bytes(managed_bytes_view v) {
     return linearized(v);
 }
 
-inline managed_bytes::managed_bytes(managed_bytes_view v) : managed_bytes(initialized_later(), v.size_bytes()) {
+template<FragmentedView View>
+inline managed_bytes::managed_bytes(View v) : managed_bytes(initialized_later(), v.size_bytes()) {
     managed_bytes_mutable_view self(*this);
     write_fragmented(self, v);
 }


### PR DESCRIPTION
As a part of the effort of removing big, contiguous buffers from the codebase,
cql3::raw_value should be made fragmented. Unfortunately a straightforward
rewrite to a fragmented buffer type is not possible, because we want
cql3::raw_value to be compatible with cql3::raw_value_view, and we want that
view to be based on fragmented_temporary_buffer::view, so that it can be
used to view data coming directly from seastar without copying.

This patch makes cql3::raw_value fragmented by making cql3::raw_value_view
a `variant` of managed_bytes_view and fragmented_temporary_buffer::view.

Code users which depended on `cql3::raw_value` being `bytes`,
and cql::raw_value_view being `fragmented_temporary_buffer::view` underneath
were adjusted to the new, dual representation, mainly through the
`cql3::raw_value_view::with_value` visitor and deserialization/validation
helpers added to `cql3::raw_value_view`.

The second part of this series gets rid of linearizations occuring when processing
compound types in the CQL layer. This is achieved by storing their elements in
`managed_bytes` instead of `bytes` in the partially deserialized form (`lists::value`
`tuples::value`, etc.) outputting `managed_bytes` instead of `bytes` in functions
which go from the partially deserialized form to the atomic cell format (for frozen
types), and avoiding calling deserialize/serialize on individual elements when
it's not necessary. (It's only necessary for CQLv2, because since CQLv3 the format
on the wire is the same as our internal one).

The above also forces some changes to `expression.cc`, and `restrictions`, mainly because
`IN` clauses store their arguments as `lists` and `tuples`, and the code which handled
this clause expected `bytes`.

After this series, the path from prepared CQL statements to `atomic_cell_or_collection`
is almost completely linearization-free. The last remaining place is `collection_mutation_description`,
where map keys are linearized to `bytes`.