### PR TITLE
row_cache: Make fill_buffer() preemptable when cursor leads with dummy rows

### DIFF
--- a/cache_flat_mutation_reader.hh
+++ b/cache_flat_mutation_reader.hh
@@ -619,6 +619,8 @@ void cache_flat_mutation_reader::add_to_buffer(const partition_snapshot_row_curs
     if (!row.dummy()) {
         _read_context->cache().on_row_hit();
         add_clustering_row_to_buffer(mutation_fragment(*_schema, _permit, row.row(_read_context->digest_requested())));
+    } else {
+        _read_context->cache()._tracker.on_dummy_row_hit();
     }
 }
 

--- a/cache_flat_mutation_reader.hh
+++ b/cache_flat_mutation_reader.hh
@@ -620,6 +620,11 @@ void cache_flat_mutation_reader::add_to_buffer(const partition_snapshot_row_curs
         _read_context->cache().on_row_hit();
         add_clustering_row_to_buffer(mutation_fragment(*_schema, _permit, row.row(_read_context->digest_requested())));
     } else {
+        position_in_partition::less_compare less(*_schema);
+        if (less(_lower_bound, row.position())) {
+            _lower_bound = row.position();
+            _lower_bound_changed = true;
+        }
         _read_context->cache()._tracker.on_dummy_row_hit();
     }
 }

--- a/configure.py
+++ b/configure.py
@@ -433,6 +433,7 @@ scylla_tests = set([
     'test/perf/perf_mutation',
     'test/perf/perf_collection',
     'test/perf/perf_row_cache_update',
+    'test/perf/perf_row_cache_reads',
     'test/perf/perf_simple_query',
     'test/perf/perf_sstable',
     'test/unit/lsa_async_eviction_test',

--- a/row_cache.cc
+++ b/row_cache.cc
@@ -108,6 +108,7 @@ cache_tracker::setup_metrics() {
         sm::make_derive("partition_misses", sm::description("number of partitions needed by reads and missing in cache"), _stats.partition_misses),
         sm::make_derive("partition_insertions", sm::description("total number of partitions added to cache"), _stats.partition_insertions),
         sm::make_derive("row_hits", sm::description("total number of rows needed by reads and found in cache"), _stats.row_hits),
+        sm::make_derive("dummy_row_hits", sm::description("total number of dummy rows touched by reads in cache"), _stats.dummy_row_hits),
         sm::make_derive("row_misses", sm::description("total number of rows needed by reads and missing in cache"), _stats.row_misses),
         sm::make_derive("row_insertions", sm::description("total number of rows added to cache"), _stats.row_insertions),
         sm::make_derive("row_evictions", sm::description("total number of rows evicted from cache"), _stats.row_evictions),
@@ -198,6 +199,10 @@ void cache_tracker::on_row_eviction() noexcept {
 
 void cache_tracker::on_row_hit() noexcept {
     ++_stats.row_hits;
+}
+
+void cache_tracker::on_dummy_row_hit() noexcept {
+    ++_stats.dummy_row_hits;
 }
 
 void cache_tracker::on_row_miss() noexcept {

--- a/row_cache.hh
+++ b/row_cache.hh
@@ -165,6 +165,7 @@ public:
         uint64_t partition_hits;
         uint64_t partition_misses;
         uint64_t row_hits;
+        uint64_t dummy_row_hits;
         uint64_t row_misses;
         uint64_t partition_insertions;
         uint64_t row_insertions;
@@ -221,6 +222,7 @@ public:
     void on_partition_eviction() noexcept;
     void on_row_eviction() noexcept;
     void on_row_hit() noexcept;
+    void on_dummy_row_hit() noexcept;
     void on_row_miss() noexcept;
     void on_miss_already_populated() noexcept;
     void on_mispopulate() noexcept;

--- a/test/perf/perf_row_cache_reads.cc
+++ b/test/perf/perf_row_cache_reads.cc
@@ -1,0 +1,156 @@
+/*
+ * Copyright (C) 2021 ScyllaDB
+ */
+
+/*
+ * This file is part of Scylla.
+ *
+ * Scylla is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Scylla is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <seastar/core/distributed.hh>
+#include <seastar/core/app-template.hh>
+#include <seastar/core/sstring.hh>
+#include <seastar/core/thread.hh>
+#include <seastar/core/reactor.hh>
+
+#include "utils/managed_bytes.hh"
+#include "utils/logalloc.hh"
+#include "utils/UUID_gen.hh"
+#include "row_cache.hh"
+#include "partition_slice_builder.hh"
+#include "schema_builder.hh"
+#include "memtable.hh"
+#include "test/lib/memtable_snapshot_source.hh"
+#include "test/perf/perf.hh"
+#include "test/lib/reader_permit.hh"
+
+/// Tests read scenarios from cache.
+///
+/// Watch out for max preemption period growing above 0.5 ms.
+///
+/// Example run:
+///
+///    $ build/release/test/perf/perf_row_cache_reads_g  -c1 -m200M
+///    Filling memtable
+///    rows in cache: 0
+///    Populating with dummy rows
+///    rows in cache: 373929
+///    Scanning
+///    read: 156.288986 [ms], preemption: {count: 702, 99%: 0.545791 [ms], max: 0.537537 [ms]}, cache: 99/100 [MB]
+///    read: 106.480766 [ms], preemption: {count: 6, 99%: 0.006866 [ms], max: 106.496168 [ms]}, cache: 99/100 [MB]
+///
+/// The second row which starts with "read:" has high max latency (106 ms),
+/// which is an indication of the following bug: https://github.com/scylladb/scylla/issues/8153
+///
+
+static const int cell_size = 128;
+static bool cancelled = false;
+static const auto MB = 1024 * 1024;
+
+void test_scans_with_dummy_entries() {
+    auto s = schema_builder("ks", "cf")
+            .with_column("pk", uuid_type, column_kind::partition_key)
+            .with_column("st", bytes_type, column_kind::static_column)
+            .with_column("ck", reversed_type_impl::get_instance(uuid_type), column_kind::clustering_key)
+            .with_column("v1", bytes_type, column_kind::regular_column)
+            .build();
+
+    auto pk = dht::decorate_key(*s, partition_key::from_single_value(*s,
+                                            serialized(utils::UUID_gen::get_time_UUID())));
+
+    cache_tracker tracker;
+    memtable_snapshot_source mss(s);
+
+    auto make_random_ck = [&] {
+        return clustering_key::from_single_value(*s, serialized(utils::make_random_uuid()));
+    };
+
+    auto val = data_value(bytes(bytes::initialized_later(), cell_size));
+
+    // Make the partition non-empty so that it's not marked as continuous by the first read
+    // on population.
+    mutation m(s, pk);
+    m.set_static_cell("st", val, api::new_timestamp());
+    mss.apply(m);
+
+    row_cache cache(s, snapshot_source([&] { return mss(); }), tracker, is_continuous::no);
+
+    std::cout << "Rows in cache: " << tracker.get_stats().rows << std::endl;
+    std::cout << "Populating with dummy rows" << std::endl;
+
+    const size_t cache_size = seastar::memory::stats().total_memory() / 2;
+    auto pr = dht::partition_range::make_singular(pk);
+    while (tracker.region().occupancy().total_space() < cache_size) {
+        auto slice = partition_slice_builder(*s)
+                .with_range(query::clustering_range::make_starting_with(make_random_ck()))
+                .build();
+
+        auto rd = cache.make_reader(s, tests::make_permit(), pr, slice);
+        rd.set_max_buffer_size(1);
+        rd.fill_buffer(db::no_timeout).get();
+        seastar::thread::maybe_yield();
+
+        if (cancelled) {
+            return;
+        }
+    }
+
+    std::cout << "Rows in cache: " << tracker.get_stats().rows << std::endl;
+    std::cout << "Scanning" << std::endl;
+
+    auto test_read = [&] {
+        auto rd = cache.make_reader(s, tests::make_permit(), pr);
+        scheduling_latency_measurer slm;
+        slm.start();
+        auto d = duration_in_seconds([&] {
+            rd.consume_pausable([](mutation_fragment) {
+                return stop_iteration(cancelled);
+            }, db::no_timeout).get();
+        });
+        slm.stop();
+
+        std::cout << format("read: {:.6f} [ms], preemption: {}, cache: {:d}/{:d} [MB]\n",
+                            d.count() * 1000,
+                            slm,
+                            tracker.region().occupancy().used_space() / MB,
+                            tracker.region().occupancy().total_space() / MB);
+    };
+
+    // The first scan populates the cache with continuity
+    // It reads from underlying so will be preemptible.
+    test_read();
+
+    // If dummy entries are not removed by the first scan, the second scan will hit
+    // https://github.com/scylladb/scylla/issues/8153
+    test_read();
+
+    // Clean gently to avoid reactor stalls in destructors
+    cache.invalidate(row_cache::external_updater([]{})).get();
+    tracker.cleaner().drain().get();
+}
+
+int main(int argc, char** argv) {
+    app_template app;
+    return app.run(argc, argv, [&app] {
+        return seastar::async([&] {
+            engine().at_exit([] {
+                cancelled = true;
+                return make_ready_future();
+            });
+            logalloc::prime_segment_pool(memory::stats().total_memory(), memory::min_free_memory()).get();
+            test_scans_with_dummy_entries();
+        });
+    });
+}


### PR DESCRIPTION

fill_buffer() will keep scanning until _lower_bound_changed is true,
even if preemption is signaled, so that the reader makes forward
progress.

Before the patch, we did not update _lower_bound on touching a dummy
entry. The read will not respect preemption until we hit a non-dummy
row. If there is a lot of dummy rows, that can cause reactor stalls.

Fix that by updating _lower_bound on dummy entries as well.

Refs #8153.

Tested with perf_row_cache_reads:

```
$ build/release/test/perf/perf_row_cache_reads -c1 -m200M
Rows in cache: 0
Populating with dummy rows
Rows in cache: 373929
Scanning
read: 183.658966 [ms], preemption: {count: 848, 99%: 0.545791 [ms], max: 0.519343 [ms]}, cache: 99/100 [MB]
read: 120.951515 [ms], preemption: {count: 257, 99%: 0.545791 [ms], max: 0.518795 [ms]}, cache: 99/100 [MB]
```

Notice that max preemption latency is low in the second "read:" line.
