### PR TITLE
RFC: use direct RPC streams to exchange CDC generations between nodes. 

### DIFF
--- a/cdc/generation.cc
+++ b/cdc/generation.cc
@@ -37,6 +37,7 @@
 #include "gms/application_state.hh"
 #include "gms/inet_address.hh"
 #include "gms/gossiper.hh"
+#include "message/messaging_service.hh"
 
 #include "cdc/generation.hh"
 #include "cdc/cdc_options.hh"
@@ -644,8 +645,8 @@ constexpr char could_not_retrieve_msg_template[]
 
 generation_service::generation_service(
             const db::config& cfg, gms::gossiper& g, sharded<db::system_distributed_keyspace>& sys_dist_ks,
-            abort_source& abort_src, const locator::shared_token_metadata& stm)
-        : _cfg(cfg), _gossiper(g), _sys_dist_ks(sys_dist_ks), _abort_src(abort_src), _token_metadata(stm) {
+            abort_source& abort_src, const locator::shared_token_metadata& stm, netw::messaging_service& ms)
+        : _cfg(cfg), _gossiper(g), _sys_dist_ks(sys_dist_ks), _abort_src(abort_src), _token_metadata(stm), _ms(ms) {
 }
 
 future<> generation_service::stop() {

--- a/cdc/generation.hh
+++ b/cdc/generation.hh
@@ -172,7 +172,6 @@ future<db_clock::time_point> make_new_cdc_generation(
         const std::unordered_set<dht::token>& bootstrap_tokens,
         const locator::token_metadata_ptr tmptr,
         const gms::gossiper& g,
-        db::system_distributed_keyspace& sys_dist_ks,
         std::chrono::milliseconds ring_delay,
         bool add_delay);
 

--- a/cdc/generation_service.hh
+++ b/cdc/generation_service.hh
@@ -74,6 +74,11 @@ public:
             sharded<db::system_distributed_keyspace>&, abort_source&, const locator::shared_token_metadata&,
             netw::messaging_service&);
 
+    /* This function initializes RPC handlers for calls that may start arriving as soon as we join
+     * the token ring (or in the middle of it). Hence the function must be called before we join
+     * the token ring. */
+    void initialize();
+
     future<> stop();
     ~generation_service();
 
@@ -81,7 +86,7 @@ public:
      * known generation timestamp from persistent storage, this function should be called with
      * that generation timestamp moved in as the `startup_gen_ts` parameter.
      * This passes the responsibility of managing generations from the node startup code to this service;
-     * until then, the service remains dormant.
+     * until then, the service remains dormant (except for answering generation fetch requests).
      * At the time of writing this comment, the startup code is in `storage_service::join_token_ring`, hence
      * `after_join` should be called at the end of that function.
      * Precondition: the node has completed bootstrapping and system_distributed_keyspace is initialized.

--- a/cdc/generation_service.hh
+++ b/cdc/generation_service.hh
@@ -113,20 +113,20 @@ private:
     /* Retrieve the CDC generation which starts at the given timestamp (from a distributed table created for this purpose)
      * and start using it for CDC log writes if it's not obsolete.
      */
-    future<> handle_cdc_generation(std::optional<db_clock::time_point>);
+    future<> handle_cdc_generation(std::optional<db_clock::time_point>, gms::inet_address source);
 
     /* If `handle_cdc_generation` fails, it schedules an asynchronous retry in the background
      * using `async_handle_cdc_generation`.
      */
-    void async_handle_cdc_generation(db_clock::time_point);
+    void async_handle_cdc_generation(db_clock::time_point, gms::inet_address source);
 
     /* Wrapper around `do_handle_cdc_generation` which intercepts timeout/unavailability exceptions.
      * Returns: do_handle_cdc_generation(ts). */
-    future<bool> do_handle_cdc_generation_intercept_nonfatal_errors(db_clock::time_point);
+    future<bool> do_handle_cdc_generation_intercept_nonfatal_errors(db_clock::time_point, gms::inet_address source);
 
     /* Returns `true` iff we started using the generation (it was not obsolete or already known),
      * which means that this node might write some CDC log entries using streams from this generation. */
-    future<bool> do_handle_cdc_generation(db_clock::time_point);
+    future<bool> do_handle_cdc_generation(db_clock::time_point, gms::inet_address source);
 
     /* Scan CDC generation timestamps gossiped by other nodes and retrieve the latest one.
      * This function should be called once at the end of the node startup procedure

--- a/cdc/generation_service.hh
+++ b/cdc/generation_service.hh
@@ -49,6 +49,7 @@ class generation_service : public peering_sharded_service<generation_service>
     sharded<db::system_distributed_keyspace>& _sys_dist_ks;
     abort_source& _abort_src;
     const locator::shared_token_metadata& _token_metadata;
+    netw::messaging_service& _ms;
 
     /* Maintains the set of known CDC generations used to pick streams for log writes (i.e., the partition keys of these log writes).
      * Updated in response to certain gossip events (see the handle_cdc_generation function).
@@ -70,7 +71,8 @@ class generation_service : public peering_sharded_service<generation_service>
     std::optional<db_clock::time_point> _gen_ts;
 public:
     generation_service(const db::config&, gms::gossiper&,
-            sharded<db::system_distributed_keyspace>&, abort_source&, const locator::shared_token_metadata&);
+            sharded<db::system_distributed_keyspace>&, abort_source&, const locator::shared_token_metadata&,
+            netw::messaging_service&);
 
     future<> stop();
     ~generation_service();

--- a/configure.py
+++ b/configure.py
@@ -978,6 +978,7 @@ idls = ['idl/gossip_digest.idl.hh',
         'idl/messaging_service.idl.hh',
         'idl/paxos.idl.hh',
         'idl/raft.idl.hh',
+        'idl/cdc_generation.idl.hh',
         ]
 
 headers = find_headers('.', excluded_dirs=['idl', 'build', 'seastar', '.git'])

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -76,6 +76,10 @@ namespace gms {
     class feature_service;
 }
 
+namespace cdc {
+    class topology_description;
+}
+
 bool is_system_keyspace(std::string_view ks_name);
 
 namespace db {
@@ -122,6 +126,7 @@ static constexpr auto VIEWS_BUILDS_IN_PROGRESS = "views_builds_in_progress";
 static constexpr auto BUILT_VIEWS = "built_views";
 static constexpr auto SCYLLA_VIEWS_BUILDS_IN_PROGRESS = "scylla_views_builds_in_progress";
 static constexpr auto CDC_LOCAL = "cdc_local";
+static constexpr auto CDC_GENERATIONS = "cdc_generations";
 }
 
 namespace legacy {
@@ -640,6 +645,9 @@ future<> delete_paxos_decision(const schema& s, const partition_key& key, const 
 
 future<bool> cdc_is_rewritten();
 future<> cdc_set_rewritten(std::optional<db_clock::time_point>);
+
+future<> store_cdc_generation(db_clock::time_point, const cdc::topology_description&);
+future<std::optional<cdc::topology_description>> load_cdc_generation(db_clock::time_point);
 
 } // namespace system_keyspace
 } // namespace db

--- a/idl/cdc_generation.idl.hh
+++ b/idl/cdc_generation.idl.hh
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2021 ScyllaDB
+ */
+
+/*
+ * This file is part of Scylla.
+ *
+ * Scylla is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Scylla is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace cdc {
+
+class stream_id {
+    bytes to_bytes();
+};
+
+class token_range_description {
+    dht::token token_range_end;
+    std::vector<cdc::stream_id> streams;
+    uint8_t sharding_ignore_msb;
+};
+
+} // namespace cdc

--- a/main.cc
+++ b/main.cc
@@ -1066,7 +1066,7 @@ int main(int ac, char** av) {
              * which will prevent sys_dist_ks from being destroyed while the service operates on it.
              */
             cdc_generation_service.start(std::ref(*cfg), std::ref(gossiper), std::ref(sys_dist_ks),
-                    std::ref(stop_signal.as_sharded_abort_source()), std::ref(token_metadata)).get();
+                    std::ref(stop_signal.as_sharded_abort_source()), std::ref(token_metadata), std::ref(messaging)).get();
             auto stop_cdc_generation_service = defer_verbose_shutdown("CDC Generation Management service", [] {
                 cdc_generation_service.stop().get();
             });

--- a/main.cc
+++ b/main.cc
@@ -1071,6 +1071,10 @@ int main(int ac, char** av) {
                 cdc_generation_service.stop().get();
             });
 
+            // This must be called before `init_server` because during/after `init_server` this node may be called
+            // using RPC verbs that are registered in generation_service::initialize.
+            cdc_generation_service.local().initialize();
+
             auto get_cdc_metadata = [] (cdc::generation_service& svc) { return std::ref(svc.get_cdc_metadata()); };
 
             supervisor::notify("starting CDC log service");

--- a/message/messaging_service.hh
+++ b/message/messaging_service.hh
@@ -301,6 +301,9 @@ public:
 
     future<> unregister_handler(messaging_verb verb);
 
+    template <typename... Ret, typename... Args>
+    rpc::sink<Ret...> make_sink(rpc::source<Args...>&);
+
     // Wrapper for PREPARE_MESSAGE verb
     void register_prepare_message(std::function<future<streaming::prepare_message> (const rpc::client_info& cinfo,
             streaming::prepare_message msg, UUID plan_id, sstring description, rpc::optional<streaming::stream_reason> reason)>&& func);
@@ -317,24 +320,20 @@ public:
     // The receiver of STREAM_MUTATION_FRAGMENTS sends status code to the sender to notify any error on the receiver side. The status code is of type int32_t. 0 means successful, -1 means error, other status code value are reserved for future use.
     void register_stream_mutation_fragments(std::function<future<rpc::sink<int32_t>> (const rpc::client_info& cinfo, UUID plan_id, UUID schema_id, UUID cf_id, uint64_t estimated_partitions, rpc::optional<streaming::stream_reason> reason_opt, rpc::source<frozen_mutation_fragment, rpc::optional<streaming::stream_mutation_fragments_cmd>> source)>&& func);
     future<> unregister_stream_mutation_fragments();
-    rpc::sink<int32_t> make_sink_for_stream_mutation_fragments(rpc::source<frozen_mutation_fragment, rpc::optional<streaming::stream_mutation_fragments_cmd>>& source);
     future<std::tuple<rpc::sink<frozen_mutation_fragment, streaming::stream_mutation_fragments_cmd>, rpc::source<int32_t>>> make_sink_and_source_for_stream_mutation_fragments(utils::UUID schema_id, utils::UUID plan_id, utils::UUID cf_id, uint64_t estimated_partitions, streaming::stream_reason reason, msg_addr id);
 
     // Wrapper for REPAIR_GET_ROW_DIFF_WITH_RPC_STREAM
     future<std::tuple<rpc::sink<repair_hash_with_cmd>, rpc::source<repair_row_on_wire_with_cmd>>> make_sink_and_source_for_repair_get_row_diff_with_rpc_stream(uint32_t repair_meta_id, msg_addr id);
-    rpc::sink<repair_row_on_wire_with_cmd> make_sink_for_repair_get_row_diff_with_rpc_stream(rpc::source<repair_hash_with_cmd>& source);
     void register_repair_get_row_diff_with_rpc_stream(std::function<future<rpc::sink<repair_row_on_wire_with_cmd>> (const rpc::client_info& cinfo, uint32_t repair_meta_id, rpc::source<repair_hash_with_cmd> source)>&& func);
     future<> unregister_repair_get_row_diff_with_rpc_stream();
 
     // Wrapper for REPAIR_PUT_ROW_DIFF_WITH_RPC_STREAM
     future<std::tuple<rpc::sink<repair_row_on_wire_with_cmd>, rpc::source<repair_stream_cmd>>> make_sink_and_source_for_repair_put_row_diff_with_rpc_stream(uint32_t repair_meta_id, msg_addr id);
-    rpc::sink<repair_stream_cmd> make_sink_for_repair_put_row_diff_with_rpc_stream(rpc::source<repair_row_on_wire_with_cmd>& source);
     void register_repair_put_row_diff_with_rpc_stream(std::function<future<rpc::sink<repair_stream_cmd>> (const rpc::client_info& cinfo, uint32_t repair_meta_id, rpc::source<repair_row_on_wire_with_cmd> source)>&& func);
     future<> unregister_repair_put_row_diff_with_rpc_stream();
 
     // Wrapper for REPAIR_GET_FULL_ROW_HASHES_WITH_RPC_STREAM
     future<std::tuple<rpc::sink<repair_stream_cmd>, rpc::source<repair_hash_with_cmd>>> make_sink_and_source_for_repair_get_full_row_hashes_with_rpc_stream(uint32_t repair_meta_id, msg_addr id);
-    rpc::sink<repair_hash_with_cmd> make_sink_for_repair_get_full_row_hashes_with_rpc_stream(rpc::source<repair_stream_cmd>& source);
     void register_repair_get_full_row_hashes_with_rpc_stream(std::function<future<rpc::sink<repair_hash_with_cmd>> (const rpc::client_info& cinfo, uint32_t repair_meta_id, rpc::source<repair_stream_cmd> source)>&& func);
     future<> unregister_repair_get_full_row_hashes_with_rpc_stream();
 

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -2276,7 +2276,7 @@ future<> row_level_repair_init_messaging_service_handler(repair_service& rs, dis
         ms.register_repair_get_row_diff_with_rpc_stream([&ms] (const rpc::client_info& cinfo, uint64_t repair_meta_id, rpc::source<repair_hash_with_cmd> source) {
             auto src_cpu_id = cinfo.retrieve_auxiliary<uint32_t>("src_cpu_id");
             auto from = cinfo.retrieve_auxiliary<gms::inet_address>("baddr");
-            auto sink = ms.make_sink_for_repair_get_row_diff_with_rpc_stream(source);
+            auto sink = ms.make_sink(source);
             // Start a new fiber.
             (void)repair_get_row_diff_with_rpc_stream_handler(from, src_cpu_id, repair_meta_id, sink, source).handle_exception(
                     [from, repair_meta_id, sink, source] (std::exception_ptr ep) {
@@ -2287,7 +2287,7 @@ future<> row_level_repair_init_messaging_service_handler(repair_service& rs, dis
         ms.register_repair_put_row_diff_with_rpc_stream([&ms] (const rpc::client_info& cinfo, uint64_t repair_meta_id, rpc::source<repair_row_on_wire_with_cmd> source) {
             auto src_cpu_id = cinfo.retrieve_auxiliary<uint32_t>("src_cpu_id");
             auto from = cinfo.retrieve_auxiliary<gms::inet_address>("baddr");
-            auto sink = ms.make_sink_for_repair_put_row_diff_with_rpc_stream(source);
+            auto sink = ms.make_sink(source);
             // Start a new fiber.
             (void)repair_put_row_diff_with_rpc_stream_handler(from, src_cpu_id, repair_meta_id, sink, source).handle_exception(
                     [from, repair_meta_id, sink, source] (std::exception_ptr ep) {
@@ -2298,7 +2298,7 @@ future<> row_level_repair_init_messaging_service_handler(repair_service& rs, dis
         ms.register_repair_get_full_row_hashes_with_rpc_stream([&ms] (const rpc::client_info& cinfo, uint64_t repair_meta_id, rpc::source<repair_stream_cmd> source) {
             auto src_cpu_id = cinfo.retrieve_auxiliary<uint32_t>("src_cpu_id");
             auto from = cinfo.retrieve_auxiliary<gms::inet_address>("baddr");
-            auto sink = ms.make_sink_for_repair_get_full_row_hashes_with_rpc_stream(source);
+            auto sink = ms.make_sink(source);
             // Start a new fiber.
             (void)repair_get_full_row_hashes_with_rpc_stream_handler(from, src_cpu_id, repair_meta_id, sink, source).handle_exception(
                     [from, repair_meta_id, sink, source] (std::exception_ptr ep) {

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -589,7 +589,7 @@ void storage_service::join_token_ring(int delay) {
             try {
                 _cdc_streams_ts = cdc::make_new_cdc_generation(db().local().get_config(),
                         _bootstrap_tokens, get_token_metadata_ptr(), _gossiper,
-                        _sys_dist_ks.local(), get_ring_delay(), !_for_testing && !is_first_node()).get0();
+                        get_ring_delay(), !_for_testing && !is_first_node()).get0();
             } catch (...) {
                 cdc_log.warn(
                     "Could not create a new CDC generation: {}. This may make it impossible to use CDC. Use nodetool checkAndRepairCdcStreams to fix CDC generation",
@@ -667,7 +667,7 @@ void storage_service::bootstrap() {
 
         _cdc_streams_ts = cdc::make_new_cdc_generation(db().local().get_config(),
                 _bootstrap_tokens, get_token_metadata_ptr(), _gossiper,
-                _sys_dist_ks.local(), get_ring_delay(), !_for_testing && !is_first_node()).get0();
+                get_ring_delay(), !_for_testing && !is_first_node()).get0();
 
         _gossiper.add_local_application_state({
             // Order is important: both the CDC streams timestamp and tokens must be known when a node handles our status.

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -382,7 +382,7 @@ private:
     void shutdown_client_servers();
 
     // Tokens and the CDC streams timestamp of the replaced node.
-    using replacement_info = std::pair<std::unordered_set<token>, std::optional<db_clock::time_point>>;
+    using replacement_info = std::tuple<std::unordered_set<token>>;
     future<replacement_info> prepare_replacement_info(std::unordered_set<gms::inet_address> initial_contact_nodes,
             const std::unordered_map<gms::inet_address, sstring>& loaded_peer_features, bind_messaging_port do_bind = bind_messaging_port::yes);
 

--- a/streaming/stream_session.cc
+++ b/streaming/stream_session.cc
@@ -136,7 +136,7 @@ void stream_session::init_messaging_service_handler(netw::messaging_service& ms)
         }
 
         return service::get_schema_for_write(schema_id, from, ms).then([from, estimated_partitions, plan_id, schema_id, &cf, source, reason] (schema_ptr s) mutable {
-            auto sink = stream_session::ms().make_sink_for_stream_mutation_fragments(source);
+            auto sink = stream_session::ms().make_sink(source);
             struct stream_mutation_fragments_cmd_status {
                 bool got_cmd = false;
                 bool got_end_of_stream = false;

--- a/test/boost/gossip_test.cc
+++ b/test/boost/gossip_test.cc
@@ -103,7 +103,7 @@ SEASTAR_TEST_CASE(test_boot_shutdown){
             stop_database(db).get();
         });
 
-        cdc_generation_service.start(std::ref(*cfg), std::ref(gms::get_gossiper()), std::ref(sys_dist_ks), std::ref(abort_sources), std::ref(token_metadata)).get();
+        cdc_generation_service.start(std::ref(*cfg), std::ref(gms::get_gossiper()), std::ref(sys_dist_ks), std::ref(abort_sources), std::ref(token_metadata), std::ref(_messaging)).get();
         auto stop_cdc_generation_service = defer([&cdc_generation_service] {
             cdc_generation_service.stop().get();
         });

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -580,7 +580,7 @@ public:
 
             sys_dist_ks.start(std::ref(qp), std::ref(mm), std::ref(proxy)).get();
 
-            cdc_generation_service.start(std::ref(*cfg), std::ref(gms::get_gossiper()), std::ref(sys_dist_ks), std::ref(abort_sources), std::ref(token_metadata)).get();
+            cdc_generation_service.start(std::ref(*cfg), std::ref(gms::get_gossiper()), std::ref(sys_dist_ks), std::ref(abort_sources), std::ref(token_metadata), std::ref(ms)).get();
             auto stop_cdc_generation_service = defer([&cdc_generation_service] {
                 cdc_generation_service.stop().get();
             });

--- a/test/lib/test_services.cc
+++ b/test/lib/test_services.cc
@@ -63,7 +63,7 @@ public:
         service::get_storage_service().invoke_on_all([] (auto& ss) {
             ss.enable_all_features();
         }).get();
-        _cdc_generation_service.start(std::ref(_cfg), std::ref(_gossiper), std::ref(_sys_dist_ks), std::ref(_abort_source), std::ref(_token_metadata)).get();
+        _cdc_generation_service.start(std::ref(_cfg), std::ref(_gossiper), std::ref(_sys_dist_ks), std::ref(_abort_source), std::ref(_token_metadata), std::ref(_messaging)).get();
     }
     ~impl() {
         _cdc_generation_service.stop().get();


### PR DESCRIPTION
Issue: #7985

@avikivity: I'm creating this RFC in order to show how nice and elegant this solution is - at least in my opinion.
But if it doesn't convince you, I guess we'll go with tables. I'm also planning to sketch a table-based solution as well so we can compare.

NOTE: upgrading from the old method is not implemented yet, i.e. this only completely works for clusters bootstrapped using this method.
The upgrade handling code (a cluster feature and so on) is pretty much independent from the method we'll choose in the end. The algorithm will be similarly ugly and complex :(

A few TODOs are left but they don't change the shape of the solution

---

A new local table is introduced for persisting the CDC generations.

IDL definitions are added for sending generations over RPC streams.
It will be sent in parts; each part describes a single token range.

messaging_service is passed to the generation service. The generation
service registers an RPC handler for responding to generation fetch
requests.

When a node notices a new generation timestamp in gossip, it uses
an RPC call to fetch the generation data instead of retrieving
it from a distributed table like before. The data is then stored
in the new local table before the node starts gossiping the timestamp,
so it can also answer fetch requests coming from other nodes.

The RPC call itself has two sides: the puller (of the generation) and the pusher.
The puller begins by sending the pusher its generation serialization format version.
The pusher compares the version with its own; if the versions don't match,
there will be no exchange, otherwise sinks and sources are exchanged in order
to stream the generation data.