### PR TITLE
Make dht::token tri_compare safer

### DIFF
--- a/dht/i_partitioner.hh
+++ b/dht/i_partitioner.hh
@@ -620,7 +620,7 @@ struct ring_position_less_comparator {
 
 struct token_comparator {
     // Return values are those of a trichotomic comparison.
-    int operator()(const token& t1, const token& t2) const;
+    std::strong_ordering operator()(const token& t1, const token& t2) const;
 };
 
 std::ostream& operator<<(std::ostream& out, const token& t);

--- a/dht/token.cc
+++ b/dht/token.cc
@@ -53,15 +53,15 @@ maximum_token() noexcept {
     return max_token;
 }
 
-int tri_compare(const token& t1, const token& t2) {
+std::strong_ordering tri_compare(const token& t1, const token& t2) {
     if (t1._kind < t2._kind) {
-            return -1;
+            return std::strong_ordering::less;
     } else if (t1._kind > t2._kind) {
-            return 1;
+            return std::strong_ordering::greater;
     } else if (t1._kind == token_kind::key) {
         return tri_compare_raw(long_token(t1), long_token(t2));
     }
-    return 0;
+    return std::strong_ordering::equal;
 }
 
 std::ostream& operator<<(std::ostream& out, const token& t) {

--- a/dht/token.hh
+++ b/dht/token.hh
@@ -30,6 +30,7 @@
 #include <array>
 #include <functional>
 #include <utility>
+#include <compare>
 
 namespace dht {
 
@@ -172,11 +173,11 @@ public:
     }
 };
 
-static inline int tri_compare_raw(const int64_t l1, const int64_t l2) noexcept {
+static inline std::strong_ordering tri_compare_raw(const int64_t l1, const int64_t l2) noexcept {
     if (l1 == l2) {
-        return 0;
+        return std::strong_ordering::equal;
     } else {
-        return l1 < l2 ? -1 : 1;
+        return l1 < l2 ? std::strong_ordering::less : std::strong_ordering::greater;
     }
 }
 
@@ -215,7 +216,7 @@ struct raw_token_less_comparator {
 
 const token& minimum_token() noexcept;
 const token& maximum_token() noexcept;
-int tri_compare(const token& t1, const token& t2);
+std::strong_ordering tri_compare(const token& t1, const token& t2);
 inline bool operator==(const token& t1, const token& t2) { return tri_compare(t1, t2) == 0; }
 inline bool operator<(const token& t1, const token& t2) { return tri_compare(t1, t2) < 0; }
 


### PR DESCRIPTION
tri_compare() returns an int, which is dangerous as a tri_compare can be misused
where a less_compare is expected. To prevent such misuse, convert the interval<>
template to accept comparators that return std::strong_ordering, and then convert
dht::token's comparator to do the same.

Ref #1449.