### PR TITLE
sstables: remove large allocations when parsing cells

### DIFF
--- a/sstables/index_reader.hh
+++ b/sstables/index_reader.hh
@@ -160,7 +160,7 @@ public:
             }
         case state::KEY_BYTES:
             sstlog.trace("{}: pos {} state {}", fmt::ptr(this), current_pos(), state::KEY_BYTES);
-            if (this->read_bytes(data, this->_u16, _key) != continuous_data_consumer::read_status::ready) {
+            if (this->read_bytes_contiguous(data, this->_u16, _key) != continuous_data_consumer::read_status::ready) {
                 _state = state::POSITION;
                 break;
             }

--- a/sstables/kl/reader.cc
+++ b/sstables/kl/reader.cc
@@ -467,7 +467,7 @@ public:
         return ret;
     }
 
-    virtual proceed consume_counter_cell(bytes_view col_name, bytes_view value, int64_t timestamp) override {
+    virtual proceed consume_counter_cell(bytes_view col_name, fragmented_temporary_buffer::view value, int64_t timestamp) override {
         return do_consume_cell(col_name, timestamp, 0, 0, [&] (auto&& col) {
             auto ac = make_counter_cell(timestamp, value);
 
@@ -483,7 +483,7 @@ public:
         });
     }
 
-    virtual proceed consume_cell(bytes_view col_name, bytes_view value, int64_t timestamp, int64_t ttl, int64_t expiration) override {
+    virtual proceed consume_cell(bytes_view col_name, fragmented_temporary_buffer::view value, int64_t timestamp, int64_t ttl, int64_t expiration) override {
         return do_consume_cell(col_name, timestamp, ttl, expiration, [&] (auto&& col) {
             bool is_multi_cell = col.collection_extra_data.size();
             if (is_multi_cell != col.cdef->is_multi_cell()) {

--- a/sstables/kl/reader_impl.hh
+++ b/sstables/kl/reader_impl.hh
@@ -334,7 +334,7 @@ private:
                 break;
             }
         case state::CELL_VALUE_BYTES:
-            if (read_bytes(data, _u32, _val) != read_status::ready) {
+            if (read_bytes_contiguous(data, _u32, _val) != read_status::ready) {
                 _state = state::CELL_VALUE_BYTES_2;
                 break;
             }

--- a/sstables/mx/parsers.hh
+++ b/sstables/mx/parsers.hh
@@ -44,10 +44,10 @@ class clustering_parser {
     bool _parsing_start_key;
     boost::iterator_range<column_values_fixed_lengths::const_iterator> ck_range;
 
-    std::vector<temporary_buffer<char>> clustering_key_values;
+    std::vector<fragmented_temporary_buffer> clustering_key_values;
     bound_kind_m kind{};
 
-    temporary_buffer<char> column_value;
+    fragmented_temporary_buffer column_value;
     uint64_t ck_blocks_header = 0;
     uint32_t ck_blocks_header_offset = 0;
     std::optional<position_in_partition> _pos;
@@ -91,7 +91,7 @@ class clustering_parser {
 
     position_in_partition make_position() {
         auto key = clustering_key_prefix::from_range(clustering_key_values | boost::adaptors::transformed(
-            [] (const temporary_buffer<char>& b) { return to_bytes_view(b); }));
+            [] (const fragmented_temporary_buffer& b) { return fragmented_temporary_buffer::view(b); }));
 
         if (kind == bound_kind_m::clustering) {
             return position_in_partition::for_key(std::move(key));
@@ -181,9 +181,9 @@ public:
             }
             read_status status = read_status::waiting;
             if (auto len = get_ck_block_value_length()) {
-                status = _primitive.read_bytes_contiguous(data, *len, column_value);
+                status = _primitive.read_bytes(data, *len, column_value);
             } else {
-                status = _primitive.read_unsigned_vint_length_bytes_contiguous(data, column_value);
+                status = _primitive.read_unsigned_vint_length_bytes(data, column_value);
             }
             if (status != read_status::ready) {
                 _state = state::CK_BLOCK_END;

--- a/sstables/mx/parsers.hh
+++ b/sstables/mx/parsers.hh
@@ -181,9 +181,9 @@ public:
             }
             read_status status = read_status::waiting;
             if (auto len = get_ck_block_value_length()) {
-                status = _primitive.read_bytes(data, *len, column_value);
+                status = _primitive.read_bytes_contiguous(data, *len, column_value);
             } else {
-                status = _primitive.read_unsigned_vint_length_bytes(data, column_value);
+                status = _primitive.read_unsigned_vint_length_bytes_contiguous(data, column_value);
             }
             if (status != read_status::ready) {
                 _state = state::CK_BLOCK_END;

--- a/sstables/mx/reader.cc
+++ b/sstables/mx/reader.cc
@@ -465,9 +465,9 @@ private:
             }
             read_status status = read_status::waiting;
             if (auto len = get_ck_block_value_length()) {
-                status = read_bytes(data, *len, _column_value);
+                status = read_bytes_contiguous(data, *len, _column_value);
             } else {
-                status = read_unsigned_vint_length_bytes(data, _column_value);
+                status = read_unsigned_vint_length_bytes_contiguous(data, _column_value);
             }
             if (status != read_status::ready) {
                 _state = state::CK_BLOCK_END;
@@ -671,7 +671,7 @@ private:
         case state::COLUMN_CELL_PATH:
         column_cell_path_label:
             if (!is_column_simple()) {
-                if (read_unsigned_vint_length_bytes(data, _cell_path) != read_status::ready) {
+                if (read_unsigned_vint_length_bytes_contiguous(data, _cell_path) != read_status::ready) {
                     _state = state::COLUMN_VALUE;
                     break;
                 }
@@ -687,9 +687,9 @@ private:
             }
             read_status status = read_status::waiting;
             if (auto len = get_column_value_length()) {
-                status = read_bytes(data, *len, _column_value);
+                status = read_bytes_contiguous(data, *len, _column_value);
             } else {
-                status = read_unsigned_vint_length_bytes(data, _column_value);
+                status = read_unsigned_vint_length_bytes_contiguous(data, _column_value);
             }
             if (status != read_status::ready) {
                 _state = state::COLUMN_END;

--- a/sstables/mx/reader.cc
+++ b/sstables/mx/reader.cc
@@ -68,7 +68,7 @@ public:
     // proceed consuming more data.
     virtual proceed consume_partition_end() = 0;
 
-    virtual row_processing_result consume_row_start(const std::vector<temporary_buffer<char>>& ecp) = 0;
+    virtual row_processing_result consume_row_start(const std::vector<fragmented_temporary_buffer>& ecp) = 0;
 
     virtual proceed consume_row_marker_and_tombstone(
             const sstables::liveness_info& info, tombstone tomb, tombstone shadowable_tomb) = 0;
@@ -77,7 +77,7 @@ public:
 
     virtual proceed consume_column(const sstables::column_translation::column_info& column_info,
                                    bytes_view cell_path,
-                                   bytes_view value,
+                                   fragmented_temporary_buffer::view value,
                                    api::timestamp_type timestamp,
                                    gc_clock::duration ttl,
                                    gc_clock::time_point local_deletion_time,
@@ -89,13 +89,13 @@ public:
     virtual proceed consume_complex_column_end(const sstables::column_translation::column_info& column_info) = 0;
 
     virtual proceed consume_counter_column(const sstables::column_translation::column_info& column_info,
-                                           bytes_view value, api::timestamp_type timestamp) = 0;
+                                           fragmented_temporary_buffer::view value, api::timestamp_type timestamp) = 0;
 
-    virtual proceed consume_range_tombstone(const std::vector<temporary_buffer<char>>& ecp,
+    virtual proceed consume_range_tombstone(const std::vector<fragmented_temporary_buffer>& ecp,
                                             bound_kind kind,
                                             tombstone tomb) = 0;
 
-    virtual proceed consume_range_tombstone(const std::vector<temporary_buffer<char>>& ecp,
+    virtual proceed consume_range_tombstone(const std::vector<fragmented_temporary_buffer>& ecp,
                                             sstables::bound_kind_m,
                                             tombstone end_tombstone,
                                             tombstone start_tombstone) = 0;
@@ -203,7 +203,7 @@ private:
     liveness_info _liveness;
     bool _is_first_unfiltered = true;
 
-    std::vector<temporary_buffer<char>> _row_key;
+    std::vector<fragmented_temporary_buffer> _row_key;
 
     struct row_schema {
         using column_range = boost::iterator_range<std::vector<column_translation::column_info>::const_iterator>;
@@ -234,7 +234,7 @@ private:
     gc_clock::time_point _column_local_deletion_time;
     gc_clock::duration _column_ttl;
     uint32_t _column_value_length;
-    temporary_buffer<char> _column_value;
+    fragmented_temporary_buffer _column_value;
     temporary_buffer<char> _cell_path;
     uint64_t _ck_blocks_header;
     uint32_t _ck_blocks_header_offset;
@@ -465,9 +465,9 @@ private:
             }
             read_status status = read_status::waiting;
             if (auto len = get_ck_block_value_length()) {
-                status = read_bytes_contiguous(data, *len, _column_value);
+                status = read_bytes(data, *len, _column_value);
             } else {
-                status = read_unsigned_vint_length_bytes_contiguous(data, _column_value);
+                status = read_unsigned_vint_length_bytes(data, _column_value);
             }
             if (status != read_status::ready) {
                 _state = state::CK_BLOCK_END;
@@ -681,15 +681,15 @@ private:
         case state::COLUMN_VALUE:
         {
             if (!_column_flags.has_value()) {
-                _column_value = temporary_buffer<char>(0);
+                _column_value = fragmented_temporary_buffer();
                 _state = state::COLUMN_END;
                 goto column_end_label;
             }
             read_status status = read_status::waiting;
             if (auto len = get_column_value_length()) {
-                status = read_bytes_contiguous(data, *len, _column_value);
+                status = read_bytes(data, *len, _column_value);
             } else {
-                status = read_unsigned_vint_length_bytes_contiguous(data, _column_value);
+                status = read_unsigned_vint_length_bytes(data, _column_value);
             }
             if (status != read_status::ready) {
                 _state = state::COLUMN_END;
@@ -701,14 +701,14 @@ private:
             _state = state::NEXT_COLUMN;
             if (is_column_counter() && !_column_flags.is_deleted()) {
                 if (_consumer.consume_counter_column(get_column_info(),
-                                                     to_bytes_view(_column_value),
+                                                     fragmented_temporary_buffer::view(_column_value),
                                                      _column_timestamp) == consumer_m::proceed::no) {
                     return consumer_m::proceed::no;
                 }
             } else {
                 if (_consumer.consume_column(get_column_info(),
                                              to_bytes_view(_cell_path),
-                                             to_bytes_view(_column_value),
+                                             fragmented_temporary_buffer::view(_column_value),
                                              _column_timestamp,
                                              _column_ttl,
                                              _column_local_deletion_time,
@@ -991,7 +991,7 @@ class mp_row_consumer_m : public consumer_m {
         }
     };
 
-    inline friend std::ostream& operator<<(std::ostream& o, const sstables::mx::mp_row_consumer_m::range_tombstone_start& rt_start) {
+    inline friend std::ostream& operator<<(std::ostream& o, const mp_row_consumer_m::range_tombstone_start& rt_start) {
         o << "{ clustering: " << rt_start.ck
           << ", kind: " << rt_start.kind
           << ", tombstone: " << rt_start.tomb << " }";
@@ -1224,9 +1224,9 @@ public:
         return proceed(!_reader->is_buffer_full() && !need_preempt());
     }
 
-    virtual consumer_m::row_processing_result consume_row_start(const std::vector<temporary_buffer<char>>& ecp) override {
+    virtual consumer_m::row_processing_result consume_row_start(const std::vector<fragmented_temporary_buffer>& ecp) override {
         auto key = clustering_key_prefix::from_range(ecp | boost::adaptors::transformed(
-            [] (const temporary_buffer<char>& b) { return to_bytes_view(b); }));
+            [] (const fragmented_temporary_buffer& b) { return fragmented_temporary_buffer::view(b); }));
 
         sstlog.trace("mp_row_consumer_m {}: consume_row_start({})", fmt::ptr(this), key);
 
@@ -1306,14 +1306,14 @@ public:
 
     virtual proceed consume_column(const column_translation::column_info& column_info,
                                    bytes_view cell_path,
-                                   bytes_view value,
+                                   fragmented_temporary_buffer::view value,
                                    api::timestamp_type timestamp,
                                    gc_clock::duration ttl,
                                    gc_clock::time_point local_deletion_time,
                                    bool is_deleted) override {
         const std::optional<column_id>& column_id = column_info.id;
         sstlog.trace("mp_row_consumer_m {}: consume_column(id={}, path={}, value={}, ts={}, ttl={}, del_time={}, deleted={})", fmt::ptr(this),
-            column_id, fmt_hex(cell_path), fmt_hex(value), timestamp, ttl.count(), local_deletion_time.time_since_epoch().count(), is_deleted);
+            column_id, fmt_hex(cell_path), value, timestamp, ttl.count(), local_deletion_time.time_since_epoch().count(), is_deleted);
         check_column_missing_in_current_schema(column_info, timestamp);
         if (!column_id) {
             return proceed::yes;
@@ -1388,10 +1388,10 @@ public:
     }
 
     virtual proceed consume_counter_column(const column_translation::column_info& column_info,
-                                           bytes_view value,
+                                           fragmented_temporary_buffer::view value,
                                            api::timestamp_type timestamp) override {
         const std::optional<column_id>& column_id = column_info.id;
-        sstlog.trace("mp_row_consumer_m {}: consume_counter_column({}, {}, {})", fmt::ptr(this), column_id, fmt_hex(value), timestamp);
+        sstlog.trace("mp_row_consumer_m {}: consume_counter_column({}, {}, {})", fmt::ptr(this), column_id, value, timestamp);
         check_column_missing_in_current_schema(column_info, timestamp);
         if (!column_id) {
             return proceed::yes;
@@ -1406,11 +1406,11 @@ public:
         return proceed::yes;
     }
 
-    virtual proceed consume_range_tombstone(const std::vector<temporary_buffer<char>>& ecp,
+    virtual proceed consume_range_tombstone(const std::vector<fragmented_temporary_buffer>& ecp,
                                             bound_kind kind,
                                             tombstone tomb) override {
         auto ck = clustering_key_prefix::from_range(ecp | boost::adaptors::transformed(
-            [] (const temporary_buffer<char>& b) { return to_bytes_view(b); }));
+            [] (const fragmented_temporary_buffer& b) { return fragmented_temporary_buffer::view(b); }));
         if (kind == bound_kind::incl_start || kind == bound_kind::excl_start) {
             consume_range_tombstone_start(std::move(ck), kind, std::move(tomb));
             return proceed(!_reader->is_buffer_full() && !need_preempt());
@@ -1419,13 +1419,13 @@ public:
         }
     }
 
-    virtual proceed consume_range_tombstone(const std::vector<temporary_buffer<char>>& ecp,
+    virtual proceed consume_range_tombstone(const std::vector<fragmented_temporary_buffer>& ecp,
                                             sstables::bound_kind_m kind,
                                             tombstone end_tombstone,
                                             tombstone start_tombstone) override {
         auto result = proceed::yes;
         auto ck = clustering_key_prefix::from_range(ecp | boost::adaptors::transformed(
-            [] (const temporary_buffer<char>& b) { return to_bytes_view(b); }));
+            [] (const fragmented_temporary_buffer& b) { return fragmented_temporary_buffer::view(b); }));
         switch (kind) {
         case bound_kind_m::incl_end_excl_start:
             result = consume_range_tombstone_end(ck, bound_kind::incl_end, std::move(end_tombstone));

--- a/sstables/promoted_index_blocks_reader.hh
+++ b/sstables/promoted_index_blocks_reader.hh
@@ -104,7 +104,7 @@ private:
                     return;
                 }
             case state_k_l::START_NAME_BYTES:
-                if (this->read_bytes(data, this->_u16, ctx.start) != continuous_data_consumer::read_status::ready) {
+                if (this->read_bytes_contiguous(data, this->_u16, ctx.start) != continuous_data_consumer::read_status::ready) {
                     ctx.state = state_k_l::END_NAME_LENGTH;
                     return;
                 }
@@ -114,7 +114,7 @@ private:
                     return;
                 }
             case state_k_l::END_NAME_BYTES:
-                if (this->read_bytes(data, this->_u16, ctx.end) != continuous_data_consumer::read_status::ready) {
+                if (this->read_bytes_contiguous(data, this->_u16, ctx.end) != continuous_data_consumer::read_status::ready) {
                     ctx.state = state_k_l::OFFSET;
                     return;
                 }

--- a/sstables/sstable_mutation_reader.hh
+++ b/sstables/sstable_mutation_reader.hh
@@ -83,7 +83,7 @@ public:
 
 inline atomic_cell make_atomic_cell(const abstract_type& type,
                                     api::timestamp_type timestamp,
-                                    bytes_view value,
+                                    fragmented_temporary_buffer::view value,
                                     gc_clock::duration ttl,
                                     gc_clock::time_point expiration,
                                     atomic_cell::collection_member cm) {
@@ -94,7 +94,7 @@ inline atomic_cell make_atomic_cell(const abstract_type& type,
     }
 }
 
-atomic_cell make_counter_cell(api::timestamp_type timestamp, bytes_view value);
+atomic_cell make_counter_cell(api::timestamp_type timestamp, fragmented_temporary_buffer::view value);
 
 position_in_partition_view get_slice_upper_bound(const schema& s, const query::partition_slice& slice, dht::ring_position_view key);
 

--- a/test/boost/sstable_test.cc
+++ b/test/boost/sstable_test.cc
@@ -350,7 +350,7 @@ public:
         return proceed::yes;
     }
 
-    virtual proceed consume_cell(bytes_view col_name, bytes_view value,
+    virtual proceed consume_cell(bytes_view col_name, fragmented_temporary_buffer::view value,
             int64_t timestamp, int64_t ttl, int64_t expiration) override {
         BOOST_REQUIRE(ttl == 0);
         BOOST_REQUIRE(expiration == 0);
@@ -358,7 +358,7 @@ public:
         case 0:
             // The silly "cql marker" column
             BOOST_REQUIRE(col_name.size() == 3 && col_name[0] == 0 && col_name[1] == 0 && col_name[2] == 0);
-            BOOST_REQUIRE(value.size() == 0);
+            BOOST_REQUIRE(value.size_bytes() == 0);
             BOOST_REQUIRE(timestamp == desired_timestamp);
             break;
         case 1:
@@ -366,7 +366,7 @@ public:
                     col_name[1] == 4 && col_name[2] == 'c' &&
                     col_name[3] == 'o' && col_name[4] == 'l' &&
                     col_name[5] == '1' && col_name[6] == '\0');
-            BOOST_REQUIRE(value == as_bytes("daughter"));
+            BOOST_REQUIRE(linearized(value) == as_bytes("daughter"));
             BOOST_REQUIRE(timestamp == desired_timestamp);
             break;
         case 2:
@@ -374,8 +374,7 @@ public:
                     col_name[1] == 4 && col_name[2] == 'c' &&
                     col_name[3] == 'o' && col_name[4] == 'l' &&
                     col_name[5] == '2' && col_name[6] == '\0');
-            BOOST_REQUIRE(value.size() == 4 && value[0] == 0 &&
-                    value[1] == 0 && value[2] == 0 && value[3] == 3);
+            BOOST_REQUIRE(linearized(value) == bytes({0, 0, 0, 3}));
             BOOST_REQUIRE(timestamp == desired_timestamp);
             break;
         }
@@ -383,7 +382,7 @@ public:
         return proceed::yes;
     }
 
-    virtual proceed consume_counter_cell(bytes_view col_name, bytes_view value, int64_t timestamp) override {
+    virtual proceed consume_counter_cell(bytes_view col_name, fragmented_temporary_buffer::view value, int64_t timestamp) override {
         BOOST_FAIL("counter cell wasn't expected");
         abort(); // BOOST_FAIL is not marked as [[noreturn]].
     }
@@ -470,12 +469,12 @@ public:
         count_row_start++;
         return proceed::yes;
     }
-    virtual proceed consume_cell(bytes_view col_name, bytes_view value,
+    virtual proceed consume_cell(bytes_view col_name, fragmented_temporary_buffer::view value,
             int64_t timestamp, int64_t ttl, int64_t expiration) override {
         count_cell++;
         return proceed::yes;
     }
-    virtual proceed consume_counter_cell(bytes_view col_name, bytes_view value, int64_t timestamp) override {
+    virtual proceed consume_counter_cell(bytes_view col_name, fragmented_temporary_buffer::view value, int64_t timestamp) override {
         count_cell++;
         return proceed::yes;
     }
@@ -625,13 +624,13 @@ public:
         return proceed::yes;
     }
 
-    virtual proceed consume_cell(bytes_view col_name, bytes_view value,
+    virtual proceed consume_cell(bytes_view col_name, fragmented_temporary_buffer::view value,
             int64_t timestamp, int64_t ttl, int64_t expiration) override {
         switch (count_cell) {
         case 0:
             // The silly "cql row marker" cell
             BOOST_REQUIRE(col_name.size() == 3 && col_name[0] == 0 && col_name[1] == 0 && col_name[2] == 0);
-            BOOST_REQUIRE(value.size() == 0);
+            BOOST_REQUIRE(value.size_bytes() == 0);
             BOOST_REQUIRE(timestamp == desired_timestamp);
             BOOST_REQUIRE(ttl == 3600);
             BOOST_REQUIRE(expiration == 1430154618);
@@ -641,8 +640,7 @@ public:
                     col_name[1] == 3 && col_name[2] == 'a' &&
                     col_name[3] == 'g' && col_name[4] == 'e' &&
                     col_name[5] == '\0');
-            BOOST_REQUIRE(value.size() == 4 && value[0] == 0 && value[1] == 0
-                    && value[2] == 0 && value[3] == 40);
+            BOOST_REQUIRE(linearized(value) == bytes({0, 0, 0, 40}));
             BOOST_REQUIRE(timestamp == desired_timestamp);
             BOOST_REQUIRE(ttl == 3600);
             BOOST_REQUIRE(expiration == 1430154618);

--- a/utils/fragmented_temporary_buffer.hh
+++ b/utils/fragmented_temporary_buffer.hh
@@ -489,3 +489,12 @@ public:
         });
     }
 };
+
+// The operator below is used only for logging
+
+inline std::ostream& operator<<(std::ostream& out, const fragmented_temporary_buffer::view& v) {
+    for (bytes_view frag : fragment_range(v)) {
+        out << to_hex(frag);
+    }
+    return out;
+}


### PR DESCRIPTION
sstable cells are parsed into temporary_buffers, which causes large contiguous allocations for some cells. 
This is fixed by storing fragments of the cell value in a fragmented_temporary_buffer instead. 
To achieve this, this patch also adds new methods to the fragmented_temporary_buffer(size(), ostream& operator<<()) and adds methods to the underlying parser(primitive_consumer) for parsing byte strings into fragmented buffers.

Fixes #7457, and (as the last of 4 patches) #6376