### PR TITLE
scylla_coredump_setup: don't run apt-get when systemd-coredump is already installed

### DIFF
--- a/dist/common/scripts/scylla_coredump_setup
+++ b/dist/common/scripts/scylla_coredump_setup
@@ -45,7 +45,7 @@ if __name__ == '__main__':
         run('sysctl -p /etc/sysctl.d/99-scylla-coredump.conf', shell=True, check=True)
 # Other distributions can use systemd-coredump, so setup it
     else:
-        if is_debian_variant():
+        if is_debian_variant() and not shutil.which('coredumpctl'):
             apt_install('systemd-coredump')
         conf_data = '''
 [Coredump]


### PR DESCRIPTION
Check systemd-coredump existance before running apt-get install
systemd-coredump.