### PR TITLE
api/compaction_manager: add the compaction id in get_compaction

### DIFF
--- a/api/compaction_manager.cc
+++ b/api/compaction_manager.cc
@@ -58,6 +58,7 @@ void set_compaction_manager(http_context& ctx, routes& r) {
 
             for (const auto& c : cm.get_compactions()) {
                 cm::summary s;
+                s.id = c->compaction_uuid.to_sstring();
                 s.ks = c->ks_name;
                 s.cf = c->cf_name;
                 s.unit = "keys";


### PR DESCRIPTION
This patch adds the compaction id to the get_compaction structure.
While it was supported, it was not used and up until now wasn't needed.

After this patch a call to curl -X GET 'http://localhost:10000/compaction_manager/compactions'
will include the compaction id.

Relates to #7927

Signed-off-by: Amnon Heiman <amnon@scylladb.com>