### PR TITLE
scylla_setup: strip spaces of comma separated list

### DIFF
--- a/dist/common/scripts/scylla_setup
+++ b/dist/common/scripts/scylla_setup
@@ -449,7 +449,7 @@ if __name__ == '__main__':
                 if dsk == '':
                     continue
                 if dsk.find(',') > 0:
-                    dsklist = dsk.split(',')
+                    dsklist = [i.strip() for i in dsk.split(',')]
                     continue
                 if not os.path.exists(dsk):
                     print('{} not found'.format(dsk))


### PR DESCRIPTION
On RAID prompt, we can type disk list something like this:
 /dev/sda1,/dev/sdb1,/dev/sdc1,/dev/sdd1

However, if the list has spaces in the list, it doesn't work:
 /dev/sda1, /dev/sdb1, /dev/sdc1, /dev/sdd1

Because the script mistakenly recognize the space part of a device path.
So we need strip() the input for each item.

Fixes #8174