### PR TITLE
Clean up Redis transport layer

### DIFF
--- a/redis/server.cc
+++ b/redis/server.cc
@@ -20,21 +20,25 @@
  */
 
 #include "redis/server.hh"
-#include "service/storage_service.hh"
-#include "db/consistency_level_type.hh"
+
+#include "redis/request.hh"
+#include "redis/reply.hh"
+
+#include "auth/authenticator.hh"
 #include "db/config.hh"
+#include "db/consistency_level_type.hh"
 #include "db/write_type.hh"
+#include "exceptions/exceptions.hh"
+#include "service/query_state.hh"
+#include "service/storage_service.hh"
+
 #include <seastar/core/future-util.hh>
 #include <seastar/core/seastar.hh>
 #include <seastar/net/byteorder.hh>
 #include <seastar/core/execution_stage.hh>
-#include "service/query_state.hh"
-#include "exceptions/exceptions.hh"
-#include "auth/authenticator.hh"
+
 #include <cassert>
 #include <string>
-#include "redis/request.hh"
-#include "redis/reply.hh"
 #include <unordered_map>
 
 namespace redis_transport {

--- a/redis/server.cc
+++ b/redis/server.cc
@@ -41,7 +41,7 @@ namespace redis_transport {
 
 static logging::logger logging("redis_server");
 
-redis_server::redis_server(distributed<service::storage_proxy>& proxy, distributed<redis::query_processor>& qp, auth::service& auth_service, redis_server_config config)
+redis_server::redis_server(seastar::sharded<service::storage_proxy>& proxy, seastar::sharded<redis::query_processor>& qp, auth::service& auth_service, redis_server_config config)
     : _proxy(proxy)
     , _query_processor(qp)
     , _config(config)

--- a/redis/server.cc
+++ b/redis/server.cc
@@ -265,12 +265,6 @@ future<> redis_server::connection::process_request() {
     });
 }
 
-static inline bytes_view to_bytes_view(temporary_buffer<char>& b)
-{
-    using byte = bytes_view::value_type;
-    return bytes_view(reinterpret_cast<const byte*>(b.get()), b.size());
-}
-
 }
 
 db::consistency_level make_consistency_level(const sstring& level)

--- a/redis/server.hh
+++ b/redis/server.hh
@@ -97,12 +97,6 @@ private:
         seastar::gate _pending_requests_gate;
         redis::redis_options _options;
         future<> _ready_to_respond = make_ready_future<>();
-    private:
-        enum class tracing_request_type : uint8_t {
-            not_requested,
-            no_write_on_close,
-            write_on_close
-        };  
 
         using execution_stage_type = inheriting_concrete_execution_stage<
                 future<redis_server::result>,

--- a/redis/server.hh
+++ b/redis/server.hh
@@ -26,7 +26,6 @@
 #include "redis/query_processor.hh"
 #include "redis/reply.hh"
 #include "redis/request.hh"
-#include "redis/request.hh"
 #include "redis/stats.hh"
 
 #include "auth/authenticator.hh"

--- a/redis/server.hh
+++ b/redis/server.hh
@@ -89,7 +89,6 @@ public:
 private:
     friend class connection;
     class connection : public boost::intrusive::list_base_hook<> {
-       // using result = redis_server::result;
         redis_server& _server;
         socket_address _server_addr;
         connected_socket _fd;
@@ -97,7 +96,6 @@ private:
         output_stream<char> _write_buf;
         redis_protocol_parser _parser;
         seastar::gate _pending_requests_gate;
-        //service::client_state _client_state;
         redis::redis_options _options;
         future<> _ready_to_respond = make_ready_future<>();
         unsigned _request_cpu = 0;

--- a/redis/server.hh
+++ b/redis/server.hh
@@ -91,7 +91,6 @@ public:
     using response_type = result;
 
 private:
-    class fmt_visitor;
     friend class connection;
     class connection : public boost::intrusive::list_base_hook<> {
        // using result = redis_server::result;

--- a/redis/server.hh
+++ b/redis/server.hh
@@ -10,7 +10,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * Scylla is distributed in the hope that it will be useful,
+ * Scylla is seastar::sharded in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
@@ -32,7 +32,7 @@
 #include <memory>
 #include <seastar/net/tls.hh>
 #include <seastar/core/semaphore.hh>
-#include "seastar/core/distributed.hh"
+#include "seastar/core/sharded.hh"
 #include "seastar/core/seastar.hh"
 #include "utils/fragmented_temporary_buffer.hh"
 #include "utils/estimated_histogram.hh"
@@ -62,8 +62,8 @@ struct redis_server_config {
 
 class redis_server {
     std::vector<server_socket> _listeners;
-    distributed<service::storage_proxy>& _proxy;
-    distributed<redis::query_processor>& _query_processor;
+    seastar::sharded<service::storage_proxy>& _proxy;
+    seastar::sharded<redis::query_processor>& _query_processor;
     redis_server_config _config;
     size_t _max_request_size;
     semaphore _memory_available;
@@ -73,7 +73,7 @@ class redis_server {
     size_t _total_redis_db_count;
 
 public:
-    redis_server(distributed<service::storage_proxy>& proxy, distributed<redis::query_processor>& qp, auth::service& auth_service, redis_server_config config);
+    redis_server(seastar::sharded<service::storage_proxy>& proxy, seastar::sharded<redis::query_processor>& qp, auth::service& auth_service, redis_server_config config);
     future<> listen(socket_address addr, std::shared_ptr<seastar::tls::credentials_builder> = {}, bool keepalive = false);
     future<> do_accepts(int which, bool keepalive, socket_address server_addr);
     future<> stop();

--- a/redis/server.hh
+++ b/redis/server.hh
@@ -123,7 +123,6 @@ private:
         future<> shutdown();
     private:
         const ::timeout_config& timeout_config() { return _server.timeout_config(); }
-        friend class process_request_executor;
         future<result> process_request_one(redis::request&& request, redis::redis_options&, service_permit permit);
         future<result> process_request_internal();
     };

--- a/redis/server.hh
+++ b/redis/server.hh
@@ -87,7 +87,6 @@ public:
     using response_type = result;
 
 private:
-    friend class connection;
     class connection : public boost::intrusive::list_base_hook<> {
         redis_server& _server;
         socket_address _server_addr;

--- a/redis/server.hh
+++ b/redis/server.hh
@@ -68,16 +68,16 @@ class redis_server {
     size_t _max_request_size;
     semaphore _memory_available;
     redis::stats _stats;
-private:
     uint64_t _requests_blocked_memory = 0;
     auth::service& _auth_service;
     size_t _total_redis_db_count;
+
 public:
     redis_server(distributed<service::storage_proxy>& proxy, distributed<redis::query_processor>& qp, auth::service& auth_service, redis_server_config config);
     future<> listen(socket_address addr, std::shared_ptr<seastar::tls::credentials_builder> = {}, bool keepalive = false);
     future<> do_accepts(int which, bool keepalive, socket_address server_addr);
     future<> stop();
-public:
+
     struct result {
         result(redis::redis_message&& m) : _data(make_foreign(std::make_unique<redis::redis_message>(std::move(m)))) {}
         foreign_ptr<std::unique_ptr<redis::redis_message>> _data;
@@ -86,6 +86,7 @@ public:
         }
     };
     using response_type = result;
+
 private:
     class fmt_visitor;
     friend class connection;
@@ -132,12 +133,11 @@ private:
         future<result> process_request_internal();
     };
 
-private:
     bool _stopping = false;
     promise<> _all_connections_stopped;
     future<> _stopped = _all_connections_stopped.get_future();
     boost::intrusive::list<connection> _connections_list;
-private:
+
     void maybe_idle() {
         if (_stopping && !_stats._connections_being_accepted && !_stats._current_connections) {
             _all_connections_stopped.set_value();

--- a/redis/server.hh
+++ b/redis/server.hh
@@ -21,27 +21,30 @@
 
 #pragma once
 
+#include "redis/options.hh"
+#include "redis/protocol_parser.hh"
+#include "redis/query_processor.hh"
+#include "redis/reply.hh"
+#include "redis/request.hh"
+#include "redis/request.hh"
+#include "redis/stats.hh"
+
+#include "auth/authenticator.hh"
 #include "auth/service.hh"
+#include "cql3/values.hh"
+#include "service/client_state.hh"
 #include "service/storage_proxy.hh"
 #include "service_permit.hh"
-#include "redis/query_processor.hh"
-#include "redis/request.hh"
-#include "cql3/values.hh"
-#include "auth/authenticator.hh"
 #include "timeout_config.hh"
-#include <memory>
-#include <seastar/net/tls.hh>
-#include <seastar/core/semaphore.hh>
-#include "seastar/core/sharded.hh"
-#include "seastar/core/seastar.hh"
-#include "utils/fragmented_temporary_buffer.hh"
 #include "utils/estimated_histogram.hh"
-#include "redis/protocol_parser.hh"
-#include "redis/request.hh"
-#include "redis/reply.hh"
-#include "redis/options.hh"
-#include  "service/client_state.hh"
-#include "redis/stats.hh"
+#include "utils/fragmented_temporary_buffer.hh"
+
+#include <seastar/core/seastar.hh>
+#include <seastar/core/semaphore.hh>
+#include <seastar/core/sharded.hh>
+#include <seastar/net/tls.hh>
+
+#include <memory>
 
 db::consistency_level make_consistency_level(const sstring&);
 

--- a/redis/server.hh
+++ b/redis/server.hh
@@ -48,9 +48,6 @@
 
 db::consistency_level make_consistency_level(const sstring&);
 
-namespace db {
-class config;
-};
 class redis_exception;
 
 namespace redis_transport {

--- a/redis/server.hh
+++ b/redis/server.hh
@@ -98,7 +98,6 @@ private:
         seastar::gate _pending_requests_gate;
         redis::redis_options _options;
         future<> _ready_to_respond = make_ready_future<>();
-        unsigned _request_cpu = 0;
     private:
         enum class tracing_request_type : uint8_t {
             not_requested,


### PR DESCRIPTION
The Redis transport layer seems to have originated as a copy-paste of 
the CQL transport layer. This pull request removes bunch of unused
and commented out bits of code, and also does some minor cleanups
like organizing includes, to make the code more readable.