### PR TITLE
cql3/maps: Drop redundant if condition

### DIFF
--- a/cql3/maps.cc
+++ b/cql3/maps.cc
@@ -310,7 +310,7 @@ maps::setter_by_key::execute(mutation& m, const clustering_key_prefix& prefix, c
     if (value.is_unset_value()) {
         return;
     }
-    if (key.is_unset_value() || value.is_unset_value()) {
+    if (key.is_unset_value()) {
         throw invalid_request_exception("Invalid unset map key");
     }
     if (!key) {


### PR DESCRIPTION
Accidentally introduced in 9eed26ca3d, it can never be true due to
code above it.

Tests: unit (dev)

Signed-off-by: Dejan Mircevski <dejan@scylladb.com>