### PR TITLE
More Redis cleanups

### DIFF
--- a/redis/command_factory.hh
+++ b/redis/command_factory.hh
@@ -21,8 +21,6 @@
 
 #pragma once
 
-#include "bytes.hh"
-#include "seastar/core/shared_ptr.hh"
 #include "abstract_command.hh"
 #include "redis/options.hh"
 

--- a/redis/command_factory.hh
+++ b/redis/command_factory.hh
@@ -21,7 +21,7 @@
 
 #pragma once
 
-#include "abstract_command.hh"
+#include "redis/abstract_command.hh"
 #include "redis/options.hh"
 
 namespace service {

--- a/redis/command_factory.hh
+++ b/redis/command_factory.hh
@@ -29,12 +29,11 @@ namespace service {
 }
 
 namespace redis {
-using namespace seastar;
 class request;
 class command_factory {
 public:
     command_factory() {}
     ~command_factory() {}
-    static future<redis_message> create_execute(service::storage_proxy&, request&, redis::redis_options&, service_permit);
+    static seastar::future<redis_message> create_execute(service::storage_proxy&, request&, redis::redis_options&, service_permit);
 };
 }

--- a/redis/keyspace_utils.hh
+++ b/redis/keyspace_utils.hh
@@ -25,8 +25,6 @@
 #include "seastar/core/future.hh"
 #include "seastar/core/sstring.hh"
 
-using namespace seastar;
-
 namespace redis {
 
 static constexpr auto DATA_COLUMN_NAME = "data";
@@ -36,6 +34,6 @@ static constexpr auto HASHes          = "HASHes";
 static constexpr auto SETs            = "SETs";
 static constexpr auto ZSETs           = "ZSETs";
 
-future<> maybe_create_keyspace(db::config& cfg);
+seastar::future<> maybe_create_keyspace(db::config& cfg);
 
 }

--- a/redis/keyspace_utils.hh
+++ b/redis/keyspace_utils.hh
@@ -23,7 +23,6 @@
 
 #include  "db/config.hh"
 #include "seastar/core/future.hh"
-#include "seastar/core/sstring.hh"
 
 namespace redis {
 

--- a/redis/options.hh
+++ b/redis/options.hh
@@ -30,8 +30,6 @@
 #include "service/client_state.hh"
 #include "auth/service.hh"
 
-using namespace seastar;
-
 namespace service {
 class storage_proxy;
 }

--- a/redis/options.hh
+++ b/redis/options.hh
@@ -44,10 +44,6 @@ class redis_options {
     service::client_state _client_state;
     size_t _total_redis_db_count;
 public:
-    //redis_options(redis_options&&) = default;
-    
-    //explicit redis_options(const redis_options&) = default;
-   
     explicit redis_options(const db::consistency_level rcl,
         const db::consistency_level wcl,
         const timeout_config& tc,

--- a/redis/query_processor.hh
+++ b/redis/query_processor.hh
@@ -26,9 +26,6 @@
 #include <seastar/core/gate.hh>
 #include <seastar/core/metrics_registration.hh>
 
-
-using namespace seastar;
-
 class database;
 class service_permit;
 
@@ -61,10 +58,10 @@ public:
         return _proxy;
     }
 
-    future<redis_message> process(request&&, redis_options&, service_permit);
+    seastar::future<redis_message> process(request&&, redis_options&, service_permit);
 
-    future<> start();
-    future<> stop();
+    seastar::future<> start();
+    seastar::future<> stop();
 };
 
 }

--- a/redis/query_processor.hh
+++ b/redis/query_processor.hh
@@ -21,7 +21,7 @@
 
 #pragma once
 
-#include <seastar/core/distributed.hh>
+#include <seastar/core/sharded.hh>
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/core/gate.hh>
 #include <seastar/core/metrics_registration.hh>
@@ -45,15 +45,15 @@ class redis_message;
 
 class query_processor {
     service::storage_proxy& _proxy;
-    distributed<database>& _db;
+    seastar::sharded<database>& _db;
     seastar::metrics::metric_groups _metrics;
     seastar::gate _pending_command_gate;
 public:
-    query_processor(service::storage_proxy& proxy, distributed<database>& db);
+    query_processor(service::storage_proxy& proxy, seastar::sharded<database>& db);
 
     ~query_processor();
 
-    distributed<database>& db() {
+    seastar::sharded<database>& db() {
         return _db;
     }
 

--- a/redis/query_utils.hh
+++ b/redis/query_utils.hh
@@ -27,8 +27,6 @@
 #include "gc_clock.hh"
 #include "query-request.hh"
 
-using namespace seastar;
-
 namespace service {
 class storage_proxy;
 class client_state;
@@ -50,11 +48,11 @@ struct strings_result {
     bool has_ttl() { return _ttl.has_value(); }
 };
 
-future<lw_shared_ptr<strings_result>> read_strings(service::storage_proxy&, const redis_options&, const bytes&, service_permit);
-future<lw_shared_ptr<strings_result>> query_strings(service::storage_proxy&, const redis_options&, const bytes&, service_permit, schema_ptr, query::partition_slice);
+seastar::future<seastar::lw_shared_ptr<strings_result>> read_strings(service::storage_proxy&, const redis_options&, const bytes&, service_permit);
+seastar::future<seastar::lw_shared_ptr<strings_result>> query_strings(service::storage_proxy&, const redis_options&, const bytes&, service_permit, schema_ptr, query::partition_slice);
 
-future<lw_shared_ptr<std::map<bytes, bytes>>> read_hashes(service::storage_proxy&, const redis_options&, const bytes&, service_permit);
-future<lw_shared_ptr<std::map<bytes, bytes>>> read_hashes(service::storage_proxy&, const redis_options&, const bytes&, const bytes&, service_permit);
-future<lw_shared_ptr<std::map<bytes, bytes>>> query_hashes(service::storage_proxy&, const redis_options&, const bytes&, service_permit, schema_ptr, query::partition_slice);
+seastar::future<seastar::lw_shared_ptr<std::map<bytes, bytes>>> read_hashes(service::storage_proxy&, const redis_options&, const bytes&, service_permit);
+seastar::future<seastar::lw_shared_ptr<std::map<bytes, bytes>>> read_hashes(service::storage_proxy&, const redis_options&, const bytes&, const bytes&, service_permit);
+seastar::future<seastar::lw_shared_ptr<std::map<bytes, bytes>>> query_hashes(service::storage_proxy&, const redis_options&, const bytes&, service_permit, schema_ptr, query::partition_slice);
 
 }

--- a/redis/reply.hh
+++ b/redis/reply.hh
@@ -28,8 +28,6 @@
 #include "seastar/core/scattered_message.hh"
 #include "redis/exceptions.hh"
 
-using namespace seastar;
-
 namespace redis {
 
 class redis_message final {
@@ -40,40 +38,40 @@ public:
     redis_message& operator=(const redis_message&) = delete;
     redis_message(redis_message&& o) noexcept : _message(std::move(o._message)) {}
     redis_message(lw_shared_ptr<scattered_message<char>> m) noexcept : _message(m) {}
-    static future<redis_message> ok() {
+    static seastar::future<redis_message> ok() {
         auto m = make_lw_shared<scattered_message<char>> ();
         m->append_static("+OK\r\n");
         return make_ready_future<redis_message>(m);
     }
-    static future<redis_message> pong() {
+    static seastar::future<redis_message> pong() {
         auto m = make_lw_shared<scattered_message<char>> ();
         m->append_static("+PONG\r\n");
         return make_ready_future<redis_message>(m);
     }
-    static future<redis_message> zero() {
+    static seastar::future<redis_message> zero() {
         auto m = make_lw_shared<scattered_message<char>> ();
         m->append_static(":0\r\n");
         return make_ready_future<redis_message>(m);
     }
-    static future<redis_message> one() {
+    static seastar::future<redis_message> one() {
         auto m = make_lw_shared<scattered_message<char>> ();
         m->append_static(":1\r\n");
         return make_ready_future<redis_message>(m);
     }
-    static future<redis_message> nil() {
+    static seastar::future<redis_message> nil() {
         auto m = make_lw_shared<scattered_message<char>> ();
         m->append_static("$-1\r\n");
         return make_ready_future<redis_message>(m);
     }
-    static future<redis_message> err() {
+    static seastar::future<redis_message> err() {
         return zero();
     }
-    static future<redis_message> number(size_t n) {
+    static seastar::future<redis_message> number(size_t n) {
         auto m = make_lw_shared<scattered_message<char>> ();
         m->append(sprint(":%zu\r\n", n));
         return make_ready_future<redis_message>(m);
     }
-    static future<redis_message> make_list_result(std::map<bytes, bytes>& list_result) {
+    static seastar::future<redis_message> make_list_result(std::map<bytes, bytes>& list_result) {
         auto m = make_lw_shared<scattered_message<char>> ();
         m->append(sprint("*%u\r\n", list_result.size() * 2));
         for (auto r : list_result) {
@@ -82,25 +80,25 @@ public:
         }
         return make_ready_future<redis_message>(m);
     }
-    static future<redis_message> make_strings_result(bytes result) {
+    static seastar::future<redis_message> make_strings_result(bytes result) {
         auto m = make_lw_shared<scattered_message<char>> ();
         write_bytes(m, result);
         return make_ready_future<redis_message>(m);
     }
-    static future<redis_message> unknown(const bytes& name) {
+    static seastar::future<redis_message> unknown(const bytes& name) {
         return from_exception(make_message("-ERR unknown command '%s'\r\n", to_sstring(name)));
     }
-    static future<redis_message> exception(const sstring& em) {
+    static seastar::future<redis_message> exception(const sstring& em) {
         auto m = make_lw_shared<scattered_message<char>> ();
         m->append(make_message("-ERR %s\r\n", em));
         return make_ready_future<redis_message>(m);
     }
-    static future<redis_message> exception(const redis_exception& e) {
+    static seastar::future<redis_message> exception(const redis_exception& e) {
         return exception(e.what_message());
     }
     inline lw_shared_ptr<scattered_message<char>> message() { return _message; }
 private:
-    static future<redis_message> from_exception(sstring data) {
+    static seastar::future<redis_message> from_exception(sstring data) {
          auto m = make_lw_shared<scattered_message<char>> (); 
          m->append(data);
          return make_ready_future<redis_message>(m);

--- a/redis/service.cc
+++ b/redis/service.cc
@@ -38,12 +38,12 @@ redis_service::~redis_service()
 {
 }
 
-future<> redis_service::listen(distributed<auth::service>& auth_service, db::config& cfg)
+future<> redis_service::listen(seastar::sharded<auth::service>& auth_service, db::config& cfg)
 {
     if (_server) {
         return make_ready_future<>();
     }
-    auto server = make_shared<distributed<redis_transport::redis_server>>();
+    auto server = make_shared<seastar::sharded<redis_transport::redis_server>>();
     _server = server;
 
     auto addr = cfg.rpc_address();
@@ -114,7 +114,7 @@ future<> redis_service::listen(distributed<auth::service>& auth_service, db::con
     });
 }
 
-future<> redis_service::init(distributed<service::storage_proxy>& proxy, distributed<database>& db, distributed<auth::service>& auth_service, db::config& cfg)
+future<> redis_service::init(seastar::sharded<service::storage_proxy>& proxy, seastar::sharded<database>& db, seastar::sharded<auth::service>& auth_service, db::config& cfg)
 {
     // 1. Create keyspace/tables used by redis API if not exists.
     // 2. Initialize the redis query processor.

--- a/redis/service.hh
+++ b/redis/service.hh
@@ -25,8 +25,6 @@
 #include "seastar/core/shared_ptr.hh"
 #include "seastar/core/sharded.hh"
 
-using namespace seastar;
-
 namespace db {
 class config;
 };
@@ -51,12 +49,12 @@ class database;
 
 class redis_service {
     seastar::sharded<redis::query_processor> _query_processor;
-    shared_ptr<seastar::sharded<redis_transport::redis_server>> _server;
+    seastar::shared_ptr<seastar::sharded<redis_transport::redis_server>> _server;
 private:
-    future<> listen(seastar::sharded<auth::service>& auth_service, db::config& cfg);
+    seastar::future<> listen(seastar::sharded<auth::service>& auth_service, db::config& cfg);
 public:
     redis_service();
     ~redis_service();
-    future<> init(seastar::sharded<service::storage_proxy>& proxy, seastar::sharded<database>& db, seastar::sharded<auth::service>& auth_service, db::config& cfg);
-    future<> stop();
+    seastar::future<> init(seastar::sharded<service::storage_proxy>& proxy, seastar::sharded<database>& db, seastar::sharded<auth::service>& auth_service, db::config& cfg);
+    seastar::future<> stop();
 };

--- a/redis/service.hh
+++ b/redis/service.hh
@@ -23,7 +23,7 @@
 
 #include "seastar/core/future.hh"
 #include "seastar/core/shared_ptr.hh"
-#include "seastar/core/distributed.hh"
+#include "seastar/core/sharded.hh"
 
 using namespace seastar;
 
@@ -50,13 +50,13 @@ class storage_proxy;
 class database;
 
 class redis_service {
-    distributed<redis::query_processor> _query_processor;
-    shared_ptr<distributed<redis_transport::redis_server>> _server;
+    seastar::sharded<redis::query_processor> _query_processor;
+    shared_ptr<seastar::sharded<redis_transport::redis_server>> _server;
 private:
-    future<> listen(distributed<auth::service>& auth_service, db::config& cfg);
+    future<> listen(seastar::sharded<auth::service>& auth_service, db::config& cfg);
 public:
     redis_service();
     ~redis_service();
-    future<> init(distributed<service::storage_proxy>& proxy, distributed<database>& db, distributed<auth::service>& auth_service, db::config& cfg);
+    future<> init(seastar::sharded<service::storage_proxy>& proxy, seastar::sharded<database>& db, seastar::sharded<auth::service>& auth_service, db::config& cfg);
     future<> stop();
 };


### PR DESCRIPTION
This pull request removes seastar namespace imports from the header 
files. There are some additional cleanups to make that easier and to 
remove some commented out code.