### PR TITLE
expr: give a name to a tuple of columns

### DIFF
--- a/cql3/restrictions/multi_column_restriction.hh
+++ b/cql3/restrictions/multi_column_restriction.hh
@@ -190,7 +190,7 @@ public:
     {
         using namespace expr;
         expression = binary_operator{
-            std::vector<column_value>(_column_defs.cbegin(), _column_defs.cend()), oper_t::EQ, _value};
+            column_value_tuple(_column_defs), oper_t::EQ, _value};
     }
 
     virtual bool is_supported_by(const secondary_index::index& index) const override {
@@ -332,7 +332,7 @@ public:
     {
         using namespace expr;
         expression = binary_operator{
-            std::vector<column_value>(_column_defs.cbegin(), _column_defs.cend()),
+            column_value_tuple(_column_defs),
             oper_t::IN,
             ::make_shared<lists::delayed_value>(_values)};
     }
@@ -361,7 +361,7 @@ public:
         : IN(schema, std::move(defs)), _marker(marker) {
         using namespace expr;
         expression = binary_operator{
-            std::vector<column_value>(_column_defs.cbegin(), _column_defs.cend()),
+            column_value_tuple(_column_defs),
             oper_t::IN,
             std::move(marker)};
     }
@@ -391,7 +391,7 @@ public:
         : slice(schema, defs, term_slice::new_instance(bound, inclusive, term), m)
     {
         expression = expr::binary_operator{
-            std::vector<expr::column_value>(defs.cbegin(), defs.cend()),
+            expr::column_value_tuple(defs),
             expr::pick_operator(bound, inclusive),
             std::move(term),
             m};

--- a/cql3/restrictions/single_column_primary_key_restrictions.hh
+++ b/cql3/restrictions/single_column_primary_key_restrictions.hh
@@ -171,7 +171,7 @@ public:
 
     virtual void merge_with(::shared_ptr<restriction> restriction) override {
         if (find_atom(restriction->expression, [] (const expr::binary_operator& b) {
-                    return std::holds_alternative<std::vector<expr::column_value>>(b.lhs);
+                    return std::holds_alternative<expr::column_value_tuple>(b.lhs);
                 })) {
             throw exceptions::invalid_request_exception(
                 "Mixing single column relations and multi column relations on clustering columns is not allowed");


### PR DESCRIPTION
Right now, binary_operator::lhs is a variant<column_value,
std::vector<column_value>, token>. The role of the second branch
(a vector of column values) is to represent a tuple of columns
e.g. "WHERE (a, b, c) = ?"), but this is not clear from the type
name.

Inroduce a wrapper type around the vector, column_value_tuple, to
make it clear we're dealing with tuples of CQL references (a
column_value is really a column_ref, since it doesn't actually
contain any value).