### PR TITLE
Fix alternator streams management regression

### DIFF
--- a/alternator/streams.cc
+++ b/alternator/streams.cc
@@ -1020,7 +1020,9 @@ future<executor::request_return_type> executor::get_records(client_state& client
         }
 
         // ugh. figure out if we are and end-of-shard
-        return cdc::get_local_streams_timestamp().then([this, iter, high_ts, start_time, ret = std::move(ret)](db_clock::time_point ts) mutable {
+        auto normal_token_owners = _proxy.get_token_metadata_ptr()->count_normal_token_owners();
+        
+        return _sdks.cdc_current_generation_timestamp({ normal_token_owners }).then([this, iter, high_ts, start_time, ret = std::move(ret)](db_clock::time_point ts) mutable {
             auto& shard = iter.shard;            
 
             if (shard.time < ts && ts < high_ts) {

--- a/db/system_distributed_keyspace.cc
+++ b/db/system_distributed_keyspace.cc
@@ -498,14 +498,14 @@ system_distributed_keyspace::cdc_get_versioned_streams(db_clock::time_point not_
     }
 
     // `time` is the table's clustering key, so the results are already sorted
-    auto first = std::lower_bound(timestamps.begin(), timestamps.end(), not_older_than);
+    auto first = std::lower_bound(timestamps.rbegin(), timestamps.rend(), not_older_than);
     // need first gen _intersecting_ the timestamp.
-    if (first != timestamps.begin()) {
+    if (first != timestamps.rbegin()) {
         --first;
     }
 
     std::map<db_clock::time_point, cdc::streams_version> result;
-    co_await max_concurrent_for_each(first, timestamps.end(), 5, [this, &ctx, &result] (db_clock::time_point ts) -> future<> {
+    co_await max_concurrent_for_each(first, timestamps.rend(), 5, [this, &ctx, &result] (db_clock::time_point ts) -> future<> {
         auto streams_cql = co_await _qp.execute_internal(
                 format("SELECT streams FROM {}.{} WHERE time = ?", NAME, CDC_DESC_V2),
                 quorum_if_many(ctx.num_token_owners),

--- a/db/system_distributed_keyspace.hh
+++ b/db/system_distributed_keyspace.hh
@@ -109,6 +109,9 @@ public:
     future<std::vector<db_clock::time_point>> get_cdc_desc_v1_timestamps(context);
 
     future<std::map<db_clock::time_point, cdc::streams_version>> cdc_get_versioned_streams(db_clock::time_point not_older_than, context);
+
+    future<db_clock::time_point> cdc_current_generation_timestamp(context);
+
 };
 
 }


### PR DESCRIPTION
Refs: #8012
Fixes: #8210

With the update to CDC generation management, the way we retrieve and process these changed. 
One very bad bug slipped through though; the code for getting versioned streams did not take into
account the late-in-pr change to make clustering of CDC gen timestamps reversed. So our alternator
shard info became quite rump-stumped, leading to more or less no data depending on when generations
changed w.r. data. 

Also, the way we track the above timestamps changed, so we should utilize this for our end-of-iterator check.