### PR TITLE
test: index_reader_assertions: fix misuse of trichotomic comparator in has_monotonic_positions

### DIFF
--- a/test/lib/index_reader_assertions.hh
+++ b/test/lib/index_reader_assertions.hh
@@ -45,7 +45,7 @@ public:
             auto token = dht::token(k.token());
             auto rp = dht::ring_position(token, k.key().to_partition_key(s));
 
-            if (!rp_cmp(prev, rp)) {
+            if (rp_cmp(prev, rp) >= 0) {
                 BOOST_FAIL(format("Partitions have invalid order: {} >= {}", prev, rp));
             }
 


### PR DESCRIPTION
has_monotonic_positions() wants to check for a greater-than-or-equal-to
relation, but actually tests for not-equal, since it treats a
trichotomic comparator as a less-than comparator. This is clearly seen
in the BOOST_FAIL message just below.

Fix by aligning the test with the intended invariant. Luckily, the tests
still pass.

Ref #1449.