### PR TITLE
dht: convert ring_position and decorated_key to std::strong_ordering

### DIFF
--- a/compatible_ring_position.hh
+++ b/compatible_ring_position.hh
@@ -43,7 +43,7 @@ public:
     const ::schema& schema() const {
         return *_schema;
     }
-    friend int tri_compare(const compatible_ring_position_view& x, const compatible_ring_position_view& y) {
+    friend std::strong_ordering tri_compare(const compatible_ring_position_view& x, const compatible_ring_position_view& y) {
         return dht::ring_position_tri_compare(*x._schema, *x._rpv, *y._rpv);
     }
     friend bool operator<(const compatible_ring_position_view& x, const compatible_ring_position_view& y) {
@@ -83,7 +83,7 @@ public:
     const ::schema& schema() const {
         return *_schema;
     }
-    friend int tri_compare(const compatible_ring_position& x, const compatible_ring_position& y) {
+    friend std::strong_ordering tri_compare(const compatible_ring_position& x, const compatible_ring_position& y) {
         return dht::ring_position_tri_compare(*x._schema, *x._rp, *y._rp);
     }
     friend bool operator<(const compatible_ring_position& x, const compatible_ring_position& y) {
@@ -133,7 +133,7 @@ public:
         };
         return std::visit(rpv_accessor{}, *_crp_or_view);
     }
-    friend int tri_compare(const compatible_ring_position_or_view& x, const compatible_ring_position_or_view& y) {
+    friend std::strong_ordering tri_compare(const compatible_ring_position_or_view& x, const compatible_ring_position_or_view& y) {
         struct schema_accessor {
             const ::schema& operator()(const compatible_ring_position& crp) {
                 return crp.schema();

--- a/repair/repair.hh
+++ b/repair/repair.hh
@@ -360,7 +360,11 @@ struct repair_sync_boundary {
     public:
         tri_compare(const schema& s) : _pk_cmp(s), _position_cmp(s) { }
         int operator()(const repair_sync_boundary& a, const repair_sync_boundary& b) const {
-            int ret = _pk_cmp(a.pk, b.pk);
+            auto tmp = _pk_cmp(a.pk, b.pk);
+            auto ret = 0;
+            if (tmp != 0) {
+                ret = tmp < 0 ? -1 : 1;
+            }
             if (ret == 0) {
                 ret = _position_cmp(a.position, b.position);
             }

--- a/service/pager/query_pagers.cc
+++ b/service/pager/query_pagers.cc
@@ -138,8 +138,8 @@ static bool has_clustering_keys(const schema& s, const query::read_command& cmd)
 
                     bool remove = !found
                             || (contains && !inclusive && (i->is_singular()
-                                || (reversed && i->start() && !cmp(i->start()->value(), lo))
-                                || (!reversed && i->end() && !cmp(i->end()->value(), lo))))
+                                || (reversed && i->start() && cmp(i->start()->value(), lo) == 0)
+                                || (!reversed && i->end() && cmp(i->end()->value(), lo) == 0)))
                             ;
 
                     if (remove) {

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -2968,7 +2968,7 @@ class data_read_resolver : public abstract_read_resolver {
 
             bool operator()(const primary_key& a, const primary_key& b) const {
                 auto pk_result = a.partition.tri_compare(_schema, b.partition);
-                if (pk_result) {
+                if (pk_result != 0) {
                     return pk_result < 0;
                 }
                 return _ck_cmp(a, b);

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -2257,7 +2257,7 @@ const dht::decorated_key& sstable::get_last_decorated_key() const {
     return *_last;
 }
 
-int sstable::compare_by_first_key(const sstable& other) const {
+std::strong_ordering sstable::compare_by_first_key(const sstable& other) const {
     return get_first_decorated_key().tri_compare(*_schema, other.get_first_decorated_key());
 }
 

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -311,8 +311,7 @@ public:
     const dht::decorated_key& get_last_decorated_key() const;
 
     // SSTable comparator using the first key (decorated key).
-    // Return values are those of a trichotomic comparison.
-    int compare_by_first_key(const sstable& other) const;
+    std::strong_ordering compare_by_first_key(const sstable& other) const;
 
     // SSTable comparator using the max timestamp.
     // Return values are those of a trichotomic comparison.

--- a/test/boost/total_order_check.hh
+++ b/test/boost/total_order_check.hh
@@ -22,10 +22,12 @@
 #pragma once
 
 #include <vector>
+#include <compare>
 #include <boost/test/unit_test.hpp>
 #include <seastar/util/variant_utils.hh>
 #include <variant>
 #include "test/lib/log.hh"
+#include "utils/collection-concepts.hh"
 
 template<typename Comparator, typename... T>
 class total_order_check {
@@ -33,12 +35,14 @@ class total_order_check {
     std::vector<std::vector<element>> _data;
     Comparator _cmp;
 private:
-    static int sgn(int x) {
+    static int sgn(std::strong_ordering x) {
         return (x > 0) - (x < 0);
     }
-
+    static int sgn(int x) {
+        return sgn(x <=> 0);
+    }
     // All in left are expect to compare with all in right with expected_order result
-    void check_order(const std::vector<element>& left, const std::vector<element>& right, int order) {
+    void check_order(const std::vector<element>& left, const std::vector<element>& right, int_or_strong_ordering auto order) {
         for (const element& left_e : left) {
             for (const element& right_e : right) {
                 seastar::visit(left_e, [&] (auto&& a) {

--- a/utils/collection-concepts.hh
+++ b/utils/collection-concepts.hh
@@ -22,6 +22,7 @@
 #pragma once
 #include <type_traits>
 #include <seastar/util/concepts.hh>
+#include <compare>
 
 template <typename Func, typename T>
 concept Disposer = requires (Func f, T* val) { 
@@ -37,11 +38,16 @@ concept LessComparable = requires (const Key1& a, const Key2& b, Less less) {
 template <typename Key1, typename Key2, typename Less>
 concept LessNothrowComparable = LessComparable<Key1, Key2, Less> && std::is_nothrow_invocable_v<Less, Key1, Key2>;
 
+// Temporary scaffolding for supporting trichotomic compares
+// that return either int or std::strong_ordering
+template <typename T>
+concept int_or_strong_ordering = std::same_as<T, int> || std::same_as<T, std::strong_ordering>;
+
 template <typename T1, typename T2, typename Compare>
 concept Comparable = requires (const T1& a, const T2& b, Compare cmp) {
     // The Comparable is trichotomic comparator that should return 
     //   negative value when a < b
     //   zero when a == b
     //   positive value when a > b
-    { cmp(a, b) } -> std::same_as<int>;
+    { cmp(a, b) } -> int_or_strong_ordering;
 };

--- a/utils/intrusive-array.hh
+++ b/utils/intrusive-array.hh
@@ -271,7 +271,7 @@ public:
         int i = 0;
 
         do {
-            int x = cmp(_data[i].object, val);
+            auto x = cmp(_data[i].object, val);
             if (x >= 0) {
                 match = (x == 0);
                 break;


### PR DESCRIPTION
As #1449 notes, trichotomic comparators returning int are dangerous as they
can be mistaken for less comparators. This series converts dht::ring_position
and dht::decorated_key, as well as a few closely related downstream types, to
return std::strong_ordering.