### PR TITLE
cql3: Rewrite get_clustering_bounds() using expressions

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -394,6 +394,7 @@ scylla_tests = set([
     'test/boost/sstable_directory_test',
     'test/boost/sstable_test',
     'test/boost/sstable_move_test',
+    'test/boost/statement_restrictions_test',
     'test/boost/storage_proxy_test',
     'test/boost/top_k_test',
     'test/boost/transport_test',

--- a/cql3/expr/expression.cc
+++ b/cql3/expr/expression.cc
@@ -635,7 +635,7 @@ bool is_satisfied_by(
 std::vector<bytes_opt> first_multicolumn_bound(
         const expression& restr, const query_options& options, statements::bound bnd) {
     auto found = find_atom(restr, [bnd] (const binary_operator& oper) {
-        return matches(oper.op, bnd) && std::holds_alternative<std::vector<column_value>>(oper.lhs);
+        return matches(oper.op, bnd) && is_multi_column(oper);
     });
     if (found) {
         return static_pointer_cast<tuples::value>(found->rhs->bind(options))->get_elements();

--- a/cql3/expr/expression.hh
+++ b/cql3/expr/expression.hh
@@ -223,6 +223,10 @@ inline bool is_compare(oper_t op) {
     }
 }
 
+inline bool is_multi_column(const binary_operator& op) {
+    return holds_alternative<std::vector<column_value>>(op.lhs);
+}
+
 inline bool has_token(const expression& e) {
     return find_atom(e, [] (const binary_operator& o) { return std::holds_alternative<token>(o.lhs); });
 }

--- a/cql3/expr/expression.hh
+++ b/cql3/expr/expression.hh
@@ -193,7 +193,8 @@ inline const binary_operator* find(const expression& e, oper_t op) {
 }
 
 inline bool needs_filtering(oper_t op) {
-    return (op == oper_t::CONTAINS) || (op == oper_t::CONTAINS_KEY) || (op == oper_t::LIKE);
+    return (op == oper_t::CONTAINS) || (op == oper_t::CONTAINS_KEY) || (op == oper_t::LIKE) ||
+           (op == oper_t::IS_NOT) || (op == oper_t::NEQ) ;
 }
 
 inline auto find_needs_filtering(const expression& e) {

--- a/cql3/expr/expression.hh
+++ b/cql3/expr/expression.hh
@@ -131,6 +131,10 @@ extern value_set possible_lhs_values(const column_definition*, const expression&
 /// Turns value_set into a range, unless it's a multi-valued list (in which case this throws).
 extern nonwrapping_range<bytes> to_range(const value_set&);
 
+/// A range of all X such that X op val.
+template<typename T>
+nonwrapping_range<T> to_range(oper_t op, const T& val);
+
 /// True iff the index can support the entire expression.
 extern bool is_supported_by(const expression&, const secondary_index::index&);
 

--- a/cql3/multi_column_relation.hh
+++ b/cql3/multi_column_relation.hh
@@ -60,7 +60,7 @@ namespace cql3 {
  */
 class multi_column_relation final : public relation {
 public:
-    using mode = restrictions::multi_column_restriction::slice::mode;
+    using mode = expr::comparison_order;
 private:
     std::vector<shared_ptr<column_identifier::raw>> _entities;
     shared_ptr<term::multi_column_raw> _values_or_marker;
@@ -70,7 +70,7 @@ private:
 public:
     multi_column_relation(std::vector<shared_ptr<column_identifier::raw>> entities,
         expr::oper_t relation_type, shared_ptr<term::multi_column_raw> values_or_marker,
-        std::vector<shared_ptr<term::multi_column_raw>> in_values, shared_ptr<tuples::in_raw> in_marker, mode m = mode::normal)
+        std::vector<shared_ptr<term::multi_column_raw>> in_values, shared_ptr<tuples::in_raw> in_marker, mode m = mode::cql)
         : relation(relation_type)
         , _entities(std::move(entities))
         , _values_or_marker(std::move(values_or_marker))
@@ -82,7 +82,7 @@ public:
     static shared_ptr<multi_column_relation> create_multi_column_relation(
         std::vector<shared_ptr<column_identifier::raw>> entities, expr::oper_t relation_type,
         shared_ptr<term::multi_column_raw> values_or_marker, std::vector<shared_ptr<term::multi_column_raw>> in_values,
-        shared_ptr<tuples::in_raw> in_marker, mode m = mode::normal) {
+        shared_ptr<tuples::in_raw> in_marker, mode m = mode::cql) {
         return ::make_shared<multi_column_relation>(std::move(entities), relation_type, std::move(values_or_marker),
             std::move(in_values), std::move(in_marker), m);
     }
@@ -107,7 +107,7 @@ public:
     static shared_ptr<multi_column_relation> create_scylla_clustering_bound_non_in_relation(std::vector<shared_ptr<column_identifier::raw>> entities,
                                                                     expr::oper_t relation_type, shared_ptr<term::multi_column_raw> values_or_marker) {
         assert(relation_type != expr::oper_t::IN);
-        return create_multi_column_relation(std::move(entities), relation_type, std::move(values_or_marker), {}, {}, mode::scylla_clustering_bound);
+        return create_multi_column_relation(std::move(entities), relation_type, std::move(values_or_marker), {}, {}, mode::clustering);
     }
 
     /**

--- a/cql3/restrictions/multi_column_restriction.hh
+++ b/cql3/restrictions/multi_column_restriction.hh
@@ -376,26 +376,8 @@ protected:
 };
 
 class multi_column_restriction::slice final : public multi_column_restriction {
-public:
-    /**
-     * SCYLLA_CLUSTERING_BOUND support.
-     * 
-     * "normal" -   clustering bounds are interpreted as value bounds, 
-     *              based on column ordering. For tables with mixed sort order
-     *              clustering, this means we need to do clever reconstruction
-     *              of bounds into single column restrictions and switch bounds.
-     * 
-     * "scylla_clustering_bound" - simply bypasses this. sstableloader will create
-     *                             these, where the (a, b, c) bounds of the expression
-     *                             is actually raw clustering bounds. For us, it just
-     *                             means we can skip transforming things.
-     */
-    enum class mode : char {
-        normal,
-        scylla_clustering_bound,
-    };
-private:
     using restriction_shared_ptr = ::shared_ptr<clustering_key_restrictions>;
+    using mode = expr::comparison_order;
     term_slice _slice;
     mode _mode;
 
@@ -405,13 +387,14 @@ private:
         , _mode(m)
     { }
 public:
-    slice(schema_ptr schema, std::vector<const column_definition*> defs, statements::bound bound, bool inclusive, shared_ptr<term> term, mode m = mode::normal)
+    slice(schema_ptr schema, std::vector<const column_definition*> defs, statements::bound bound, bool inclusive, shared_ptr<term> term, mode m = mode::cql)
         : slice(schema, defs, term_slice::new_instance(bound, inclusive, term), m)
     {
         expression = expr::binary_operator{
             std::vector<expr::column_value>(defs.cbegin(), defs.cend()),
             expr::pick_operator(bound, inclusive),
-            std::move(term)};
+            std::move(term),
+            m};
     }
 
     virtual bool is_supported_by(const secondary_index::index& index) const override {
@@ -424,7 +407,7 @@ public:
     }
 
     virtual std::vector<bounds_range_type> bounds_ranges(const query_options& options) const override {
-        if (_mode == mode::scylla_clustering_bound || !is_mixed_order()) {
+        if (_mode == mode::clustering || !is_mixed_order()) {
             return bounds_ranges_unified_order(options);
         } else {
             return bounds_ranges_mixed_order(options);
@@ -460,7 +443,7 @@ public:
                    get_columns_in_commons(other));
         auto other_slice = static_pointer_cast<slice>(other);
 
-        static auto mode2str = [](auto m) { return m == mode::normal ? "plain" : "SCYLLA_CLUSTERING_BOUND"; };
+        static auto mode2str = [](auto m) { return m == mode::cql ? "plain" : "SCYLLA_CLUSTERING_BOUND"; };
         check_true(other_slice->_mode == this->_mode, 
                     "Invalid combination of restrictions (%s / %s)",
                     mode2str(this->_mode), mode2str(other_slice->_mode)
@@ -509,7 +492,7 @@ private:
             auto end_prefix = clustering_key_prefix::from_optional_exploded(*_schema, end_components);
             end_bound = bounds_range_type::bound(std::move(end_prefix), _slice.is_inclusive(statements::bound::END));
         }
-        if (_mode == mode::normal && !is_asc_order()) {
+        if (_mode == mode::cql && !is_asc_order()) {
             std::swap(start_bound, end_bound);
         }
         auto range = bounds_range_type(start_bound, end_bound);

--- a/cql3/restrictions/statement_restrictions.cc
+++ b/cql3/restrictions/statement_restrictions.cc
@@ -288,6 +288,7 @@ void statement_restrictions::add_restriction(::shared_ptr<restriction> restricti
     } else {
         add_single_column_restriction(::static_pointer_cast<single_column_restriction>(restriction), for_view, allow_filtering);
     }
+    _where = _where.has_value() ? make_conjunction(std::move(*_where), restriction->expression) : restriction->expression;
 }
 
 void statement_restrictions::add_single_column_restriction(::shared_ptr<single_column_restriction> restriction, bool for_view, bool allow_filtering) {

--- a/cql3/restrictions/statement_restrictions.cc
+++ b/cql3/restrictions/statement_restrictions.cc
@@ -34,6 +34,7 @@
 #include "multi_column_restriction.hh"
 #include "token_restriction.hh"
 #include "database.hh"
+#include "cartesian_product.hh"
 
 #include "cql3/constants.hh"
 #include "cql3/lists.hh"
@@ -224,13 +225,6 @@ statement_restrictions::statement_restrictions(database& db,
         bool allow_filtering)
     : statement_restrictions(schema, allow_filtering)
 {
-    /*
-     * WHERE clause. For a given entity, rules are: - EQ relation conflicts with anything else (including a 2nd EQ)
-     * - Can't have more than one LT(E) relation (resp. GT(E) relation) - IN relation are restricted to row keys
-     * (for now) and conflicts with anything else (we could allow two IN for the same entity but that doesn't seem
-     * very useful) - The value_alias cannot be restricted in any way (we don't support wide rows with indexed value
-     * in CQL so far)
-     */
     if (!where_clause.empty()) {
         for (auto&& relation : where_clause) {
             if (relation->get_operator() == cql3::expr::oper_t::IS_NOT) {
@@ -569,17 +563,497 @@ dht::partition_range_vector statement_restrictions::get_partition_key_ranges(con
     return _partition_key_restrictions->bounds_ranges(options);
 }
 
-std::vector<query::clustering_range> statement_restrictions::get_clustering_bounds(const query_options& options) const {
-    if (_clustering_columns_restrictions->empty()) {
-        return {query::clustering_range::make_open_ended_both_sides()};
-    }
-    if (_clustering_columns_restrictions->needs_filtering(*_schema)) {
-        if (auto single_ck_restrictions = dynamic_pointer_cast<single_column_clustering_key_restrictions>(_clustering_columns_restrictions)) {
-            return single_ck_restrictions->get_longest_prefix_restrictions()->bounds_ranges(options);
+namespace {
+
+using namespace expr;
+
+clustering_key_prefix::prefix_equal_tri_compare get_unreversed_tri_compare(const schema& schema) {
+    clustering_key_prefix::prefix_equal_tri_compare cmp(schema);
+    std::vector<data_type> types = cmp.prefix_type->types();
+    for (auto& t : types) {
+        if (t->is_reversed()) {
+            t = t->underlying_type();
         }
+    }
+    cmp.prefix_type = make_lw_shared<compound_type<allow_prefixes::yes>>(types);
+    return cmp;
+}
+
+/// True iff r1 start is strictly before r2 start.
+bool starts_before_start(
+        const query::clustering_range& r1,
+        const query::clustering_range& r2,
+        const clustering_key_prefix::prefix_equal_tri_compare& cmp) {
+    if (!r2.start()) {
+        return false; // r2 start is -inf, nothing is before that.
+    }
+    if (!r1.start()) {
+        return true; // r1 start is -inf, while r2 start is finite.
+    }
+    const auto diff = cmp(r1.start()->value(), r2.start()->value());
+    if (diff < 0) { // r1 start is strictly before r2 start.
+        return true;
+    }
+    if (diff > 0) { // r1 start is strictly after r2 start.
+        return false;
+    }
+    const auto len1 = r1.start()->value().representation().size();
+    const auto len2 = r2.start()->value().representation().size();
+    if (len1 == len2) { // The values truly are equal.
+        return r1.start()->is_inclusive() && !r2.start()->is_inclusive();
+    } else if (len1 < len2) { // r1 start is a prefix of r2 start.
+        // (a)>=(1) starts before (a,b)>=(1,1), but (a)>(1) doesn't.
+        return r1.start()->is_inclusive();
+    } else { // r2 start is a prefix of r1 start.
+        // (a,b)>=(1,1) starts before (a)>(1) but after (a)>=(1).
+        return r2.start()->is_inclusive();
+    }
+}
+
+/// True iff r1 start is before (or identical as) r2 end.
+bool starts_before_or_at_end(
+        const query::clustering_range& r1,
+        const query::clustering_range& r2,
+        const clustering_key_prefix::prefix_equal_tri_compare& cmp) {
+    if (!r1.start()) {
+        return true; // r1 start is -inf, must be before r2 end.
+    }
+    if (!r2.end()) {
+        return true; // r2 end is +inf, everything is before it.
+    }
+    const auto diff = cmp(r1.start()->value(), r2.end()->value());
+    if (diff < 0) { // r1 start is strictly before r2 end.
+        return true;
+    }
+    if (diff > 0) { // r1 start is strictly after r2 end.
+        return false;
+    }
+    const auto len1 = r1.start()->value().representation().size();
+    const auto len2 = r2.end()->value().representation().size();
+    if (len1 == len2) { // The values truly are equal.
+        return r1.start()->is_inclusive() && r2.end()->is_inclusive();
+    } else if (len1 < len2) { // r1 start is a prefix of r2 end.
+        // a>=(1) starts before (a,b)<=(1,1) ends, but (a)>(1) doesn't.
+        return r1.start()->is_inclusive();
+    } else { // r2 end is a prefix of r1 start.
+        // (a,b)>=(1,1) starts before (a)<=(1) ends but after (a)<(1) ends.
+        return r2.end()->is_inclusive();
+    }
+}
+
+/// True if r1 end is strictly before r2 end.
+bool ends_before_end(
+        const query::clustering_range& r1,
+        const query::clustering_range& r2,
+        const clustering_key_prefix::prefix_equal_tri_compare& cmp) {
+    if (!r1.end()) {
+        return false; // r1 end is +inf, which is after everything.
+    }
+    if (!r2.end()) {
+        return true; // r2 end is +inf, while r1 end is finite.
+    }
+    const auto diff = cmp(r1.end()->value(), r2.end()->value());
+    if (diff < 0) { // r1 end is strictly before r2 end.
+        return true;
+    }
+    if (diff > 0) { // r1 end is strictly after r2 end.
+        return false;
+    }
+    const auto len1 = r1.end()->value().representation().size();
+    const auto len2 = r2.end()->value().representation().size();
+    if (len1 == len2) { // The values truly are equal.
+        return !r1.end()->is_inclusive() && r2.end()->is_inclusive();
+    } else if (len1 < len2) { // r1 end is a prefix of r2 end.
+        // (a)<(1) ends before (a,b)<=(1,1), but (a)<=(1) doesn't.
+        return !r1.end()->is_inclusive();
+    } else { // r2 end is a prefix of r1 end.
+        // (a,b)<=(1,1) ends before (a)<=(1) but after (a)<(1).
+        return r2.end()->is_inclusive();
+    }
+}
+
+/// Correct clustering_range intersection.  See #8157.
+std::optional<query::clustering_range> intersection(
+        const query::clustering_range& r1,
+        const query::clustering_range& r2,
+        const clustering_key_prefix::prefix_equal_tri_compare& cmp) {
+    // Assume r1's start is to the left of r2's start.
+    if (starts_before_start(r2, r1, cmp)) {
+        return intersection(r2, r1, cmp);
+    }
+    if (!starts_before_or_at_end(r2, r1, cmp)) {
+        return {};
+    }
+    const auto& intersection_start = r2.start();
+    const auto& intersection_end = ends_before_end(r1, r2, cmp) ? r1.end() : r2.end();
+    if (intersection_start == intersection_end && intersection_end.has_value()) {
+        return query::clustering_range::make_singular(intersection_end->value());
+    }
+    return query::clustering_range(intersection_start, intersection_end);
+}
+
+struct range_less {
+    const class schema& s;
+    clustering_key_prefix::less_compare cmp = clustering_key_prefix::less_compare(s);
+    bool operator()(const query::clustering_range& x, const query::clustering_range& y) const {
+        if (!x.start() && !y.start()) {
+            return false;
+        }
+        if (!x.start()) {
+            return true;
+        }
+        if (!y.start()) {
+            return false;
+        }
+        return cmp(x.start()->value(), y.start()->value());
+    }
+};
+
+/// An expression visitor that translates multi-column atoms into clustering ranges.
+struct multi_column_range_accumulator {
+    const query_options& options;
+    const schema_ptr schema;
+    std::vector<query::clustering_range> ranges{query::clustering_range::make_open_ended_both_sides()};
+    const clustering_key_prefix::prefix_equal_tri_compare prefix3cmp = get_unreversed_tri_compare(*schema);
+
+    void operator()(const binary_operator& binop) {
+        if (is_compare(binop.op)) {
+            auto opt_values = dynamic_pointer_cast<tuples::value>(binop.rhs->bind(options))->get_elements();
+            auto& lhs = std::get<std::vector<column_value>>(binop.lhs);
+            std::vector<bytes> values(lhs.size());
+            for (size_t i = 0; i < lhs.size(); ++i) {
+                values[i] = *statements::request_validations::check_not_null(
+                        opt_values[i],
+                        "Invalid null value in condition for column %s", lhs.at(i).col->name_as_text());
+            }
+            intersect_all(to_range(binop.op, clustering_key_prefix(values)));
+        } else if (binop.op == oper_t::IN) {
+            if (auto dv = dynamic_pointer_cast<lists::delayed_value>(binop.rhs)) {
+                process_in_values(
+                        dv->get_elements() | transformed(
+                                [&] (const ::shared_ptr<term>& t) {
+                                    return static_pointer_cast<tuples::value>(t->bind(options))->get_elements();
+                                }));
+            } else if (auto mkr = dynamic_pointer_cast<tuples::in_marker>(binop.rhs)) {
+                // This is `(a,b) IN ?`.  RHS elements are themselves tuples, represented as vector<bytes_opt>.
+                process_in_values(
+                        static_pointer_cast<tuples::in_value>(mkr->bind(options))->get_split_values());
+            }
+            else {
+                on_internal_error(rlogger, format("multi_column_range_accumulator: unexpected atom {}", binop));
+            }
+        } else {
+            on_internal_error(rlogger, format("multi_column_range_accumulator: unexpected atom {}", binop));
+        }
+    }
+
+    void operator()(const conjunction& c) {
+        std::ranges::for_each(c.children, [this] (const expression& child) { std::visit(*this, child); });
+    }
+
+    void operator()(bool b) {
+        if (!b) {
+            ranges.clear();
+        }
+    }
+
+    /// Intersects each range with v.  If any intersection is empty, clears ranges.
+    void intersect_all(const query::clustering_range& v) {
+        for (auto& r : ranges) {
+            auto intrs = intersection(r, v, prefix3cmp);
+            if (!intrs) {
+                ranges.clear();
+                break;
+            }
+            r = *intrs;
+        }
+    }
+
+    template<std::ranges::range Range>
+    requires std::convertible_to<typename Range::value_type::value_type, bytes_opt>
+    void process_in_values(Range in_values) {
+        if (ranges.empty()) {
+            return; // Shortcircuit an easy case.
+        }
+        std::set<query::clustering_range, range_less> new_ranges(range_less{*schema});
+        for (const auto& current_tuple : in_values) {
+            // Each IN value is like a separate EQ restriction ANDed to the existing state.
+            auto current_range = to_range(
+                    oper_t::EQ, clustering_key_prefix::from_optional_exploded(*schema, current_tuple));
+            for (const auto& r : ranges) {
+                auto intrs = intersection(r, current_range, prefix3cmp);
+                if (intrs) {
+                    new_ranges.insert(*intrs);
+                }
+            }
+        }
+        ranges.assign(new_ranges.cbegin(), new_ranges.cend());
+    }
+};
+
+/// Calculates clustering bounds for the multi-column case.
+std::vector<query::clustering_range> get_multi_column_clustering_bounds(
+        const query_options& options,
+        schema_ptr schema,
+        const std::vector<expression>& multi_column_restrictions) {
+    multi_column_range_accumulator acc{options, schema};
+    for (const auto& restr : multi_column_restrictions) {
+        std::visit(acc, restr);
+    }
+    return acc.ranges;
+}
+
+/// Reverses the range if the type is reversed.  Why don't we have nonwrapping_interval::reverse()??
+query::clustering_range reverse_if_reqd(query::clustering_range r, const abstract_type& t) {
+    return t.is_reversed() ? query::clustering_range(r.end(), r.start()) : std::move(r);
+}
+
+void error_if_exceeds(size_t size, size_t limit) {
+    if (size > limit) {
+        throw std::runtime_error(
+                fmt::format("clustering-key cartesian product size {} is greater than maximum {}", size, limit));
+    }
+}
+
+constexpr bool inclusive = true;
+
+/// Calculates clustering bounds for the single-column case.
+std::vector<query::clustering_range> get_single_column_clustering_bounds(
+        const query_options& options,
+        schema_ptr schema,
+        const std::vector<expression>& single_column_restrictions) {
+    const size_t size_limit =
+            options.get_cql_config().restrictions.clustering_key_restrictions_max_cartesian_product_size;
+    size_t product_size = 1;
+    std::vector<std::vector<bytes>> prior_column_values; // Equality values of columns seen so far.
+    for (size_t i = 0; i < single_column_restrictions.size(); ++i) {
+        auto values = possible_lhs_values(
+                &schema->clustering_column_at(i), // This should be the LHS of restrictions[i].
+                single_column_restrictions[i],
+                options);
+        if (auto list = std::get_if<value_list>(&values)) {
+            if (list->empty()) { // Impossible condition -- no rows can possibly match.
+                return {};
+            }
+            prior_column_values.push_back(*list);
+            product_size *= list->size();
+            error_if_exceeds(product_size, size_limit);
+        } else if (auto last_range = std::get_if<nonwrapping_interval<bytes>>(&values)) {
+            // Must be the last column in the prefix, since it's neither EQ nor IN.
+            std::vector<query::clustering_range> ck_ranges;
+            if (prior_column_values.empty()) {
+                // This is the first and last range; just turn it into a clustering_key_prefix.
+                ck_ranges.push_back(
+                        reverse_if_reqd(
+                                last_range->transform([] (const bytes& val) { return clustering_key_prefix({val}); }),
+                                *schema->clustering_column_at(i).type));
+            } else {
+                // Prior clustering columns are equality-restricted (either via = or IN), producing one or more
+                // prior_column_values elements.  Now we will turn each such element into a CK range dictated by those
+                // equalities and this inequality represented by last_range.  Each CK range's upper/lower bound is
+                // formed by extending the Cartesian-product element with the corresponding last_range bound, if it
+                // exists; if it doesn't, the CK range bound is just the Cartesian-product element, inclusive.
+                //
+                // For example, the expression `c1=1 AND c2=2 AND c3>3` makes lower CK bound (1,2,3) exclusive and
+                // upper CK bound (1,2) inclusive.
+                ck_ranges.reserve(product_size);
+                const auto extra_lb = last_range->start(), extra_ub = last_range->end();
+                for (auto& b : cartesian_product(prior_column_values)) {
+                    auto new_lb = b, new_ub = b;
+                    if (extra_lb) {
+                        new_lb.push_back(extra_lb->value());
+                    }
+                    if (extra_ub) {
+                        new_ub.push_back(extra_ub->value());
+                    }
+                    query::clustering_range::bound new_start(new_lb, extra_lb ? extra_lb->is_inclusive() : inclusive);
+                    query::clustering_range::bound new_end  (new_ub, extra_ub ? extra_ub->is_inclusive() : inclusive);
+                    ck_ranges.push_back(reverse_if_reqd({new_start, new_end}, *schema->clustering_column_at(i).type));
+                }
+            }
+            sort(ck_ranges.begin(), ck_ranges.end(), range_less{*schema});
+            return ck_ranges;
+        }
+    }
+    // All prefix columns are restricted by EQ or IN.  The resulting CK ranges are just singular ranges of corresponding
+    // prior_column_values.
+    std::vector<query::clustering_range> ck_ranges(product_size);
+    cartesian_product cp(prior_column_values);
+    std::transform(cp.begin(), cp.end(), ck_ranges.begin(), std::bind_front(query::clustering_range::make_singular));
+    sort(ck_ranges.begin(), ck_ranges.end(), range_less{*schema});
+    return ck_ranges;
+}
+
+using opt_bound = std::optional<query::clustering_range::bound>;
+
+/// Makes a partial bound out of whole_bound's prefix.  If the partial bound is strictly shorter than the whole, it is
+/// exclusive.  Otherwise, it matches the whole_bound's inclusivity.
+opt_bound make_prefix_bound(
+        size_t prefix_len, const std::vector<bytes>& whole_bound, bool whole_bound_is_inclusive) {
+    if (whole_bound.empty()) {
+        return {};
+    }
+    // Couldn't get std::ranges::subrange(whole_bound, prefix_len) to compile :(
+    std::vector<bytes> partial_bound(
+            whole_bound.cbegin(), whole_bound.cbegin() + std::min(prefix_len, whole_bound.size()));
+    return query::clustering_range::bound(
+            clustering_key_prefix(move(partial_bound)),
+            prefix_len >= whole_bound.size() && whole_bound_is_inclusive);
+}
+
+/// Given a multi-column range in CQL order, breaks it into an equivalent union of clustering-order ranges.  Returns
+/// those ranges as vector elements.
+///
+/// A difference between CQL order and clustering order means that the right-hand side of a clustering-key comparison is
+/// not necessarily a single (lower or upper) bound on the clustering key in storage.  Eg, `WITH CLUSTERING ORDER BY (a
+/// ASC, b DESC)` indicates that "a less than 5" means "a comes before 5 in storage", but "b less than 5" means "b comes
+/// AFTER 5 in storage".  Therefore the CQL expression (a,b)<(5,5) cannot be executed by fetching a single range from
+/// the storage layer -- the right-hand side is not a single upper bound from the storage layer's perspective.
+///
+/// When translating the WHERE clause into clustering ranges to fetch, it's natural to first calculate the CQL-order
+/// ranges: comparisons define ranges, the AND operator intersects them, the IN operator makes a Cartesian product.  The
+/// result of this is a union of ranges in CQL order that define the clustering slice to fetch.  And if the clustering
+/// order is the same as the CQL order, these ranges can be sent to the storage proxy directly to fetch the correct
+/// result.  But if the two orders differ, there is some work to be done first.  This is simple enough for ranges that
+/// only vary a single column -- see reverse_if_reqd().  Multi-column ranges are more complicated; they are translated
+/// into an equivalent union of clustering-order ranges by get_equivalent_ranges().
+///
+/// Continuing the above example, we can translate the CQL expression (a,b)<(5,5) into a union of several ranges that
+/// are continuous in storage.  We begin by observing that (a,b)<(5,5) is the same as a<5 OR (a=5 AND b<5).  This is a
+/// union of two ranges: the range corresponding to a<5, plus the range corresponding to (a=5 AND b<5).  Note that both
+/// of these ranges are continuous in storage because they only vary a single column:
+///
+///  * a<5 is a range from -inf to clustering_key_prefix(5) exclusive
+///
+///  * (a=5 AND b<5) is a range from clustering_key_prefix(5,5) exclusive to clustering_key_prefix(5) inclusive; note
+///    the clustering order between those start/end bounds
+///
+/// Here is an illustration of those two ranges in storage, with rows represented vertically and clustering-ordered left
+/// to right:
+///
+///        a: 4 4 4 4 4 4 5 5 5 5 5 5 5 5 6 6 6 6 6
+///        b: 5 4 3 2 1 0 7 6 5 4 3 2 1 0 5 4 3 2 1
+/// 1st range ^^^^^^^^^^^       ^^^^^^^^^ 2nd range
+///
+/// For more examples of this range translation, please see the statement_restrictions unit tests.
+std::vector<query::clustering_range> get_equivalent_ranges(
+        const query::clustering_range& cql_order_range, const schema& schema) {
+    const auto& cql_lb = cql_order_range.start();
+    const auto& cql_ub = cql_order_range.end();
+    if (cql_lb == cql_ub && (!cql_lb || cql_lb->is_inclusive())) {
+        return {cql_order_range};
+    }
+    const auto cql_lb_bytes = cql_lb ? cql_lb->value().explode(schema) : std::vector<bytes>{};
+    const auto cql_ub_bytes = cql_ub ? cql_ub->value().explode(schema) : std::vector<bytes>{};
+    const bool cql_lb_is_inclusive = cql_lb ? cql_lb->is_inclusive() : false;
+    const bool cql_ub_is_inclusive = cql_ub ? cql_ub->is_inclusive() : false;
+
+    size_t common_prefix_len = 0;
+    // Skip equal values; they don't contribute to equivalent-range generation.
+    while (common_prefix_len < cql_lb_bytes.size() && common_prefix_len < cql_ub_bytes.size() &&
+           cql_lb_bytes[common_prefix_len] == cql_ub_bytes[common_prefix_len]) {
+        ++common_prefix_len;
+    }
+
+    std::vector<query::clustering_range> ranges;
+    // First range is special: it has both bounds.
+    opt_bound lb1 = make_prefix_bound(
+            common_prefix_len + 1, cql_lb_bytes, cql_lb_is_inclusive);
+    opt_bound ub1 = make_prefix_bound(
+            common_prefix_len + 1, cql_ub_bytes, cql_ub_is_inclusive);
+    auto range1 = schema.clustering_column_at(common_prefix_len).type->is_reversed() ?
+            query::clustering_range(ub1, lb1) : query::clustering_range(lb1, ub1);
+    ranges.push_back(std::move(range1));
+
+    for (size_t p = common_prefix_len + 2; p <= cql_lb_bytes.size(); ++p) {
+        opt_bound lb = make_prefix_bound(p, cql_lb_bytes, cql_lb_is_inclusive);
+        opt_bound ub = make_prefix_bound(p - 1, cql_lb_bytes, /*irrelevant:*/true);
+        if (ub) {
+            ub = query::clustering_range::bound(ub->value(), inclusive);
+        }
+        auto range = schema.clustering_column_at(p - 1).type->is_reversed() ?
+                query::clustering_range(ub, lb) : query::clustering_range(lb, ub);
+        ranges.push_back(std::move(range));
+    }
+
+    for (size_t p = common_prefix_len + 2; p <= cql_ub_bytes.size(); ++p) {
+        // Note the difference from the cql_lb_bytes case above!
+        opt_bound ub = make_prefix_bound(p, cql_ub_bytes, cql_ub_is_inclusive);
+        opt_bound lb = make_prefix_bound(p - 1, cql_ub_bytes, /*irrelevant:*/true);
+        if (lb) {
+            lb = query::clustering_range::bound(lb->value(), inclusive);
+        }
+        auto range = schema.clustering_column_at(p - 1).type->is_reversed() ?
+                query::clustering_range(ub, lb) : query::clustering_range(lb, ub);
+        ranges.push_back(std::move(range));
+    }
+
+    return ranges;
+}
+
+/// Extracts raw multi-column bounds from exprs; last one wins.
+query::clustering_range range_from_raw_bounds(
+        const std::vector<expression>& exprs, const query_options& options, const schema& schema) {
+    opt_bound lb, ub;
+    for (const auto& e : exprs) {
+        if (auto b = find_clustering_order(e)) {
+            const auto tup = dynamic_pointer_cast<tuples::value>(b->rhs->bind(options));
+            if (!tup) {
+                on_internal_error(rlogger, format("range_from_raw_bounds: unexpected atom {}", *b));
+            }
+            const auto r = to_range(
+                    b->op, clustering_key_prefix::from_optional_exploded(schema, tup->get_elements()));
+            if (r.start()) {
+                lb = r.start();
+            }
+            if (r.end()) {
+                ub = r.end();
+            }
+        }
+    }
+    return {lb, ub};
+}
+
+} // anonymous namespace
+
+std::vector<query::clustering_range> statement_restrictions::get_clustering_bounds(const query_options& options) const {
+    if (_clustering_prefix_restrictions.empty()) {
         return {query::clustering_range::make_open_ended_both_sides()};
     }
-    return _clustering_columns_restrictions->bounds_ranges(options);
+    if (count_if(_clustering_prefix_restrictions[0], expr::is_multi_column)) {
+        bool all_natural = true, all_reverse = true; ///< Whether column types are reversed or natural.
+        for (auto& r : _clustering_prefix_restrictions) { // TODO: move to constructor, do only once.
+            using namespace expr;
+            const auto& binop = std::get<binary_operator>(r);
+            if (is_clustering_order(binop)) {
+                return {range_from_raw_bounds(_clustering_prefix_restrictions, options, *_schema)};
+            }
+            for (auto& cv : std::get<std::vector<column_value>>(binop.lhs)) {
+                if (cv.col->type->is_reversed()) {
+                    all_natural = false;
+                } else {
+                    all_reverse = false;
+                }
+            }
+        }
+        auto bounds = get_multi_column_clustering_bounds(options, _schema, _clustering_prefix_restrictions);
+        if (!all_natural && !all_reverse) {
+            std::vector<query::clustering_range> bounds_in_clustering_order;
+            for (const auto& b : bounds) {
+                const auto eqv = get_equivalent_ranges(b, *_schema);
+                bounds_in_clustering_order.insert(bounds_in_clustering_order.end(), eqv.cbegin(), eqv.cend());
+            }
+            return bounds_in_clustering_order;
+        }
+        if (all_reverse) {
+            for (auto& crange : bounds) {
+                crange = query::clustering_range(crange.end(), crange.start());
+            }
+        }
+        return bounds;
+    } else {
+        return get_single_column_clustering_bounds(options, _schema, _clustering_prefix_restrictions);
+    }
 }
 
 namespace {

--- a/cql3/restrictions/statement_restrictions.hh
+++ b/cql3/restrictions/statement_restrictions.hh
@@ -104,6 +104,8 @@ private:
 
     bool _has_queriable_regular_index = false, _has_queriable_pk_index = false, _has_queriable_ck_index = false;
 
+    std::optional<expr::expression> _where; ///< The entire WHERE clause.
+
 public:
     /**
      * Creates a new empty <code>StatementRestrictions</code>.

--- a/cql3/restrictions/statement_restrictions.hh
+++ b/cql3/restrictions/statement_restrictions.hh
@@ -105,6 +105,7 @@ private:
     bool _has_queriable_regular_index = false, _has_queriable_pk_index = false, _has_queriable_ck_index = false;
 
     std::optional<expr::expression> _where; ///< The entire WHERE clause.
+    std::vector<expr::expression> _clustering_prefix_restrictions; ///< Parts of _where defining the clustering slice.
 
 public:
     /**

--- a/test/boost/statement_restrictions_test.cc
+++ b/test/boost/statement_restrictions_test.cc
@@ -1,0 +1,361 @@
+/*
+ * Copyright (C) 2021 ScyllaDB
+ */
+
+/*
+ * This file is part of Scylla.
+ *
+ * Scylla is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Scylla is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#include <seastar/testing/test_case.hh>
+
+#include <vector>
+
+#include "cql3/relation.hh"
+#include "cql3/restrictions/statement_restrictions.hh"
+#include "cql3/util.hh"
+#include "test/lib/cql_assertions.hh"
+#include "test/lib/cql_test_env.hh"
+
+using namespace cql3;
+
+namespace {
+
+/// Returns statement_restrictions::get_clustering_bounds() of where_clause, with reasonable defaults in
+/// boilerplate.
+query::clustering_row_ranges slice(
+        const std::vector<relation_ptr>& where_clause, cql_test_env& env,
+        const sstring& table_name = "t", const sstring& keyspace_name = "ks") {
+    variable_specifications bound_names;
+    return restrictions::statement_restrictions(
+            env.local_db(),
+            env.local_db().find_schema(keyspace_name, table_name),
+            statements::statement_type::SELECT,
+            where_clause,
+            bound_names,
+            /*contains_only_static_columns=*/false,
+            /*for_view=*/false,
+            /*allow_filtering=*/true)
+            .get_clustering_bounds(query_options({}));
+}
+
+/// Overload that parses the WHERE clause from string.  Named differently to disambiguate when where_clause is
+/// brace-initialized.
+query::clustering_row_ranges slice_parse(
+        sstring_view where_clause, cql_test_env& env,
+        const sstring& table_name = "t", const sstring& keyspace_name = "ks") {
+    return slice(cql3::util::where_clause_to_relations(where_clause), env, table_name, keyspace_name);
+}
+
+auto I(int32_t x) { return int32_type->decompose(x); }
+
+auto T(const char* t) { return utf8_type->decompose(t); }
+
+const auto open_ended = query::clustering_range::make_open_ended_both_sides();
+
+auto singular(std::vector<bytes> values) {
+    return query::clustering_range::make_singular(clustering_key_prefix(move(values)));
+}
+
+constexpr bool inclusive = true, exclusive = false;
+
+auto left_open(std::vector<bytes> lb) {
+    return query::clustering_range::make_starting_with({clustering_key_prefix(move(lb)), exclusive});
+}
+
+auto left_closed(std::vector<bytes> lb) {
+    return query::clustering_range::make_starting_with({clustering_key_prefix(move(lb)), inclusive});
+}
+
+auto right_open(std::vector<bytes> ub) {
+    return query::clustering_range::make_ending_with({clustering_key_prefix(move(ub)), exclusive});
+}
+
+auto right_closed(std::vector<bytes> ub) {
+    return query::clustering_range::make_ending_with({clustering_key_prefix(move(ub)), inclusive});
+}
+
+auto left_open_right_closed(std::vector<bytes> lb, std::vector<bytes> ub) {
+    clustering_key_prefix cklb(move(lb)), ckub(move(ub));
+    return query::clustering_range({{cklb, exclusive}}, {{ckub, inclusive}});
+}
+
+auto left_closed_right_open(std::vector<bytes> lb, std::vector<bytes> ub) {
+    clustering_key_prefix cklb(move(lb)), ckub(move(ub));
+    return query::clustering_range({{cklb, inclusive}}, {{ckub, exclusive}});
+}
+
+auto both_open(std::vector<bytes> lb, std::vector<bytes> ub) {
+    clustering_key_prefix cklb(move(lb)), ckub(move(ub));
+    return query::clustering_range({{cklb, exclusive}}, {{ckub, exclusive}});
+}
+
+auto both_closed(std::vector<bytes> lb, std::vector<bytes> ub) {
+    clustering_key_prefix cklb(move(lb)), ckub(move(ub));
+    return query::clustering_range({{cklb, inclusive}}, {{ckub, inclusive}});
+}
+
+} // anonymous namespace
+
+SEASTAR_TEST_CASE(slice_empty_restriction) {
+    return do_with_cql_env_thread([](cql_test_env& e) {
+        cquery_nofail(e, "create table ks.t(p int, c int, primary key(p,c))");
+        BOOST_CHECK_EQUAL(slice(/*where_clause=*/{}, e), std::vector{open_ended});
+    });
+}
+
+SEASTAR_TEST_CASE(slice_one_column) {
+    return do_with_cql_env_thread([](cql_test_env& e) {
+        cquery_nofail(e, "create table ks.t(p int, c text, primary key(p,c))");
+
+        BOOST_CHECK_EQUAL(slice_parse("p=1", e), std::vector{open_ended});
+
+        BOOST_CHECK_EQUAL(slice_parse("c='123'", e), std::vector{singular({T("123")})});
+        BOOST_CHECK_EQUAL(slice_parse("c='a' and c='a'", e), std::vector{singular({T("a")})});
+        BOOST_CHECK_EQUAL(slice_parse("c='a' and c='b'", e), query::clustering_row_ranges{});
+        BOOST_CHECK_EQUAL(slice_parse("c like '123'", e), std::vector{singular({})});
+
+        BOOST_CHECK_EQUAL(slice_parse("c in ('x','y','z')", e),
+                          (std::vector{singular({T("x")}), singular({T("y")}), singular({T("z")})}));
+        BOOST_CHECK_EQUAL(slice_parse("c in ('x')", e), std::vector{singular({T("x")})});
+        BOOST_CHECK_EQUAL(slice_parse("c in ()", e), query::clustering_row_ranges{});
+        BOOST_CHECK_EQUAL(slice_parse("c in ('x','y') and c in ('a','b')", e), query::clustering_row_ranges{});
+        BOOST_CHECK_EQUAL(slice_parse("c in ('x','y') and c='z'", e), query::clustering_row_ranges{});
+        BOOST_CHECK_EQUAL(slice_parse("c in ('x','y') and c='x'", e), std::vector{singular({T("x")})});
+        BOOST_CHECK_EQUAL(slice_parse("c in ('a','b','c','b','a')", e), std::vector({
+                    singular({T("a")}), singular({T("b")}), singular({T("c")})}));
+
+        BOOST_CHECK_EQUAL(slice_parse("c>'x'", e), std::vector{left_open({T("x")})});
+        BOOST_CHECK_EQUAL(slice_parse("c>='x'", e), std::vector{left_closed({T("x")})});
+        BOOST_CHECK_EQUAL(slice_parse("c<'x'", e), std::vector{right_open({T("x")})});
+        BOOST_CHECK_EQUAL(slice_parse("c<='x'", e), std::vector{right_closed({T("x")})});
+    });
+}
+
+SEASTAR_TEST_CASE(slice_two_columns) {
+    return do_with_cql_env_thread([](cql_test_env& e) {
+        cquery_nofail(e, "create table ks.t(p int, c1 int, c2 text, primary key(p,c1,c2))");
+
+        BOOST_CHECK_EQUAL(slice_parse("c1=123 and c2='321'", e), std::vector{singular({I(123), T("321")})});
+        BOOST_CHECK_EQUAL(slice_parse("c1=123", e), std::vector{singular({I(123)})});
+        BOOST_CHECK_EQUAL(slice_parse("c1=123 and c2 like '321'", e), std::vector{singular({I(123)})});
+        BOOST_CHECK_EQUAL(slice_parse("c1=123 and c1=123", e), std::vector{singular({I(123)})});
+        BOOST_CHECK_EQUAL(slice_parse("c2='abc'", e), std::vector{singular({})});
+        BOOST_CHECK_EQUAL(slice_parse("c1=0 and c1=1 and c2='a'", e), query::clustering_row_ranges{});
+        BOOST_CHECK_EQUAL(slice_parse("c1=0 and c2='a' and c1=0", e), std::vector{singular({I(0), T("a")})});
+
+        BOOST_CHECK_EQUAL(slice_parse("c2='abc' and c1 in (1,2,3)", e),
+                          (std::vector{
+                              singular({I(1), T("abc")}),
+                              singular({I(2), T("abc")}),
+                              singular({I(3), T("abc")})}));
+        BOOST_CHECK_EQUAL(slice_parse("c1 in (1,2) and c2='x'", e),
+                          (std::vector{
+                              singular({I(1), T("x")}),
+                              singular({I(2), T("x")})}));
+        BOOST_CHECK_EQUAL(slice_parse("c1 in (1,2) and c2 in ('x','y')", e),
+                          (std::vector{
+                              singular({I(1), T("x")}), singular({I(1), T("y")}),
+                              singular({I(2), T("x")}), singular({I(2), T("y")})}));
+        BOOST_CHECK_EQUAL(slice_parse("c1 in (1) and c1 in (1) and c2 in ('x', 'y')", e),
+                          (std::vector{singular({I(1), T("x")}), singular({I(1), T("y")})}));
+        BOOST_CHECK_EQUAL(slice_parse("c1 in (1) and c1 in (2) and c2 in ('x')", e), query::clustering_row_ranges{});
+        BOOST_CHECK_EQUAL(slice_parse("c1 in (1) and c2='x'", e), std::vector{singular({I(1), T("x")})});
+        BOOST_CHECK_EQUAL(slice_parse("c1 in () and c2='x'", e), query::clustering_row_ranges{});
+        BOOST_CHECK_EQUAL(slice_parse("c2 in ('x','y')", e), std::vector{singular({})});
+        BOOST_CHECK_EQUAL(slice_parse("c1 in (1,2,3)", e),
+                          (std::vector{singular({I(1)}), singular({I(2)}), singular({I(3)})}));
+        BOOST_CHECK_EQUAL(slice_parse("c1 in (1)", e), std::vector{singular({I(1)})});
+        BOOST_CHECK_EQUAL(slice_parse("c1 in ()", e), query::clustering_row_ranges{});
+        BOOST_CHECK_EQUAL(slice_parse("c2 like 'a' and c1 in (1,2)", e),
+                          (std::vector{singular({I(1)}), singular({I(2)})}));
+
+        BOOST_CHECK_EQUAL(slice_parse("c1=123 and c2>'321'", e), std::vector{
+                left_open_right_closed({I(123), T("321")}, {I(123)})});
+        BOOST_CHECK_EQUAL(slice_parse("c1<123 and c2>'321'", e), std::vector{right_open({I(123)})});
+        BOOST_CHECK_EQUAL(slice_parse("c1>=123 and c2='321'", e), std::vector{left_closed({I(123)})});
+    });
+}
+
+SEASTAR_TEST_CASE(slice_multi_column) {
+    return do_with_cql_env_thread([](cql_test_env& e) {
+        cquery_nofail(e, "create table ks.t(p int, c1 int, c2 int, c3 int, primary key(p,c1,c2,c3))");
+        BOOST_CHECK_EQUAL(slice_parse("(c1)=(1)", e), std::vector{singular({I(1)})});
+        BOOST_CHECK_EQUAL(slice_parse("(c1,c2)=(1,2)", e), std::vector{singular({I(1), I(2)})});
+        BOOST_CHECK_EQUAL(slice_parse("(c1,c2,c3)=(1,2,3)", e), std::vector{singular({I(1), I(2), I(3)})});
+        // TODO: Uncomment when supported:
+        // BOOST_CHECK_EQUAL(slice_parse("(c1)=(1) and (c1)=(2)", e), query::clustering_row_ranges{});
+        // BOOST_CHECK_EQUAL(slice_parse("(c1,c2)=(1,2) and (c1,c2)>(2)", e), query::clustering_row_ranges{});
+        // BOOST_CHECK_EQUAL(slice_parse("(c1,c2)=(1,2) and (c1,c2)=(1,2)", e),
+        //                   std::vector{singular({I(1), I(2)})});
+
+        BOOST_CHECK_EQUAL(slice_parse("(c1)<(1)", e), std::vector{right_open({I(1)})});
+        // TODO: Uncomment when supported:
+        // BOOST_CHECK_EQUAL(slice_parse("(c1)<(1) and (c1)<=(3)", e), std::vector{right_open({I(1)})});
+        BOOST_CHECK_EQUAL(slice_parse("(c1)>(0) and (c1)<=(1)", e), std::vector{
+                left_open_right_closed({I(0)}, {I(1)})});
+        BOOST_CHECK_EQUAL(slice_parse("(c1,c2)>=(1,2)", e), std::vector{left_closed({I(1), I(2)})});
+        BOOST_CHECK_EQUAL(slice_parse("(c1,c2)>=(1,2) and (c1)<(9)", e), std::vector{
+                left_closed_right_open({I(1), I(2)}, {I(9)})});
+        BOOST_CHECK_EQUAL(slice_parse("(c1,c2)>=(1,2) and (c1,c2)<=(11,12)", e),
+                          std::vector{both_closed({I(1), I(2)}, {I(11), I(12)})});
+        BOOST_CHECK_EQUAL(slice_parse("(c1,c2,c3)>(1,2,3)", e), std::vector{left_open({I(1), I(2), I(3)})});
+        BOOST_CHECK_EQUAL(slice_parse("(c1,c2,c3)>(1,2,3) and (c1,c2,c3)<(1,2,3)", e), query::clustering_row_ranges{});
+        BOOST_CHECK_EQUAL(slice_parse("(c1,c2,c3)>(1,2,3) and (c1,c2,c3)<(10,20,30)", e),
+                          std::vector{both_open({I(1), I(2), I(3)}, {I(10), I(20), I(30)})});
+        BOOST_CHECK_EQUAL(slice_parse("(c1,c2,c3)>(1,2,3) and (c1,c2)<(10,20)", e),
+                          std::vector{both_open({I(1), I(2), I(3)}, {I(10), I(20)})});
+        BOOST_CHECK_EQUAL(slice_parse("(c1,c2,c3)>=(1,2,3) and (c1,c2)<(1,2)", e), query::clustering_row_ranges{});
+        BOOST_CHECK_EQUAL(slice_parse("(c1,c2)>(1,2) and (c1,c2,c3)<=(1,2,3)", e), query::clustering_row_ranges{});
+
+        BOOST_CHECK_EQUAL(slice_parse("(c1) IN ((1))", e), std::vector{singular({I(1)})});
+        BOOST_CHECK_EQUAL(slice_parse("(c1) IN ((1),(10))", e), (std::vector{
+                    singular({I(1)}), singular({I(10)})}));
+        BOOST_CHECK_EQUAL(slice_parse("(c1,c2) IN ((1,2),(10,20))", e), (std::vector{
+                    singular({I(1), I(2)}), singular({I(10), I(20)})}));
+        BOOST_CHECK_EQUAL(slice_parse("(c1,c2) IN ((10,20),(1,2))", e), (std::vector{
+                    singular({I(1), I(2)}), singular({I(10), I(20)})}));
+        BOOST_CHECK_EQUAL(slice_parse("(c1,c2,c3) IN ((1,2,3),(10,20,30))", e), (std::vector{
+                    singular({I(1), I(2), I(3)}), singular({I(10), I(20), I(30)})}));
+    });
+}
+
+SEASTAR_TEST_CASE(slice_multi_column_mixed_order) {
+    return do_with_cql_env_thread([](cql_test_env& e) {
+        // First two columns ascending:
+        cquery_nofail(
+                e,
+                "create table t1(p int, c1 int, c2 int, c3 int, c4 int, primary key(p,c1,c2,c3,c4)) "
+                "with clustering order by (c1 asc, c2 asc, c3 desc, c4 desc)");
+
+        // Not mixed order:
+        BOOST_CHECK_EQUAL(slice_parse("(c1,c2)>(1,1) and (c1,c2)<(9,9)", e, "t1"), (std::vector{
+                    both_open({I(1), I(1)}, {I(9), I(9)})}));
+
+        // Same upper/lower bound lengths:
+        BOOST_CHECK_EQUAL(slice_parse("(c1,c2,c3)>(1,1,1) and (c1,c2,c3)<(9,9,9)", e, "t1"), (std::vector{
+                    // 1<c1<9
+                    both_open({I(1)}, {I(9)}),
+                    // or (c1=1 and c2>1)
+                    left_open_right_closed({I(1), I(1)}, {I(1)}),
+                    // or (c1=1 and c2=1 and c3>1)
+                    left_closed_right_open({I(1), I(1)}, {I(1), I(1), I(1)}),
+                    // or (c1=9 and c2<9)
+                    left_closed_right_open({I(9)}, {I(9), I(9)}),
+                    // or (c1=9 and c2=9 and c3<9)
+                    left_open_right_closed({I(9), I(9), I(9)}, {I(9), I(9)})}));
+
+        // Common initial values in lower/upper bound:
+        BOOST_CHECK_EQUAL(slice_parse("(c1,c2,c3)>(1,1,1) and (c1,c2,c3)<(1,9,9)", e, "t1"), (std::vector{
+                    // c1=1 and c2>1 and c2<9
+                    both_open({I(1), I(1)}, {I(1), I(9)}),
+                    // or c1=1 and c2=1 and c3>1
+                    left_closed_right_open({I(1), I(1)}, {I(1), I(1), I(1)}),
+                    // or c1=1 and c2=9 and c3<9
+                    left_open_right_closed({I(1), I(9), I(9)}, {I(1), I(9)})}));
+        BOOST_CHECK_EQUAL(slice_parse("(c1,c2,c3)>=(1,1,1) and (c1,c2,c3)<(1,9,9)", e, "t1"), (std::vector{
+                    // c1=1 and c2>1 and c2<9
+                    both_open({I(1), I(1)}, {I(1), I(9)}),
+                    // or c1=1 and c2=1 and c3>=1
+                    both_closed({I(1), I(1)}, {I(1), I(1), I(1)}),
+                    // or c1=1 and c2=9 and c3<9
+                    left_open_right_closed({I(1), I(9), I(9)}, {I(1), I(9)})}));
+        BOOST_CHECK_EQUAL(slice_parse("(c1,c2,c3)>(1,1,1) and (c1,c2,c3)<=(1,9,9)", e, "t1"), (std::vector{
+                    // c1=1 and c2>1 and c2<9
+                    both_open({I(1), I(1)}, {I(1), I(9)}),
+                    // or c1=1 and c2=1 and c3>1
+                    left_closed_right_open({I(1), I(1)}, {I(1), I(1), I(1)}),
+                    // or c1=1 and c2=9 and c3<=9
+                    both_closed({I(1), I(9), I(9)}, {I(1), I(9)})}));
+        BOOST_CHECK_EQUAL(slice_parse("(c1,c2,c3)>=(1,1,1) and (c1,c2,c3)<=(1,9,9)", e, "t1"), (std::vector{
+                    // c1=1 and c2>1 and c2<9
+                    both_open({I(1), I(1)}, {I(1), I(9)}),
+                    // or c1=1 and c2=1 and c3>=1
+                    both_closed({I(1), I(1)}, {I(1), I(1), I(1)}),
+                    // or c1=1 and c2=9 and c3<=9
+                    both_closed({I(1), I(9), I(9)}, {I(1), I(9)})}));
+        // Same result for same inequalities in different order:
+        BOOST_CHECK_EQUAL(slice_parse("(c1,c2,c3)<=(1,9,9) and (c1,c2,c3)>=(1,1,1)", e, "t1"), (std::vector{
+                    both_open({I(1), I(1)}, {I(1), I(9)}),
+                    both_closed({I(1), I(1)}, {I(1), I(1), I(1)}),
+                    both_closed({I(1), I(9), I(9)}, {I(1), I(9)})}));
+        BOOST_CHECK_EQUAL(slice_parse("(c1,c2,c3)>(1,1,1) and (c1,c2,c3)<(1,1,9)", e, "t1"), std::vector{
+                // c1=1 and c2=1 and 9>c3>1
+                both_open({I(1), I(1), I(9)}, {I(1), I(1), I(1)})});
+        BOOST_CHECK_EQUAL(slice_parse("(c1,c2,c3)>(1,1,1) and (c1,c2,c3)<(1,1,1)", e, "t1"),
+                          query::clustering_row_ranges{});
+        BOOST_CHECK_EQUAL(slice_parse("(c1,c2,c3)>(1,1,1) and (c1,c2,c3)<=(1,1,1)", e, "t1"),
+                          query::clustering_row_ranges{});
+        BOOST_CHECK_EQUAL(slice_parse("(c1,c2,c3)>=(1,1,1) and (c1,c2,c3)<(1,1,1)", e, "t1"),
+                          query::clustering_row_ranges{});
+        BOOST_CHECK_EQUAL(slice_parse("(c1,c2,c3)>=(1,1,1) and (c1,c2,c3)<=(1,1,1)", e, "t1"), std::vector{
+                singular({I(1), I(1), I(1)})});
+        BOOST_CHECK_EQUAL(slice_parse("(c1,c2,c3)>(1,1,1) and (c1,c2)<(1,1)", e, "t1"), query::clustering_row_ranges{});
+        BOOST_CHECK_EQUAL(slice_parse("(c1,c2,c3)>=(1,1,1) and (c1,c2)<(1,1)", e, "t1"), query::clustering_row_ranges{});
+        BOOST_CHECK_EQUAL(slice_parse("(c1,c2,c3)>(1,1,1) and (c1,c2)<=(1,1)", e, "t1"), std::vector{
+                // c1=1 and c2=1 and c3>1
+                left_closed_right_open({I(1), I(1)}, {I(1), I(1), I(1)})});
+
+        // Equality:
+        BOOST_CHECK_EQUAL(slice_parse("(c1,c2,c3)=(1,1,1)", e, "t1"), std::vector{singular({I(1), I(1), I(1)})});
+        // TODO: Uncomment when supported.
+        // BOOST_CHECK_EQUAL(slice_parse("(c1,c2,c3)=(1,1,1) and (c1,c2,c3)=(1,1,1)", e, "t1"), std::vector{
+        //         singular({I(1), I(1), I(1)})});
+        BOOST_CHECK_EQUAL(slice_parse("(c1,c2,c3)>=(1,1,1) and (c1,c2,c3)<=(1,1,1)", e, "t1"), std::vector{
+                singular({I(1), I(1), I(1)})});
+
+        // First two columns descending:
+        cquery_nofail(
+                e,
+                "create table t2(p int, c1 int, c2 int, c3 int, primary key(p,c1,c2,c3)) "
+                "with clustering order by (c1 desc, c2 desc, c3 asc)");
+        BOOST_CHECK_EQUAL(slice_parse("(c1,c2)>(1,1) and (c1,c2)<(9,9)", e, "t2"), std::vector{
+                both_open({I(9), I(9)}, {I(1), I(1)})});
+
+        // Alternating desc and asc:
+        cquery_nofail(
+                e,
+                "create table t3 (p int, a int, b int, c int, d int, PRIMARY KEY (p, a, b, c, d)) "
+                "with clustering order by (a desc, b asc, c desc, d asc);");
+        BOOST_CHECK_EQUAL(slice_parse("(a,b,c,d)>=(0,1,2,3) and (a,b)<=(0,1)", e, "t3"), (std::vector{
+                    // a=0 and b=1 and c>2
+                    left_closed_right_open({I(0), I(1)}, {I(0), I(1), I(2)}),
+                    // or a=0 and b=1 and c=2 and d>=3
+                    both_closed({I(0), I(1), I(2), I(3)}, {I(0), I(1), I(2)})}));
+        BOOST_CHECK_EQUAL(slice_parse("(a,b)>=(0,1)", e, "t3"), (std::vector{
+                    // a>0
+                    right_open({I(0)}),
+                    // or a=0 and b>=1
+                    both_closed({I(0), I(1)}, {I(0)})}));
+        BOOST_CHECK_EQUAL(slice_parse("(a,b)>=SCYLLA_CLUSTERING_BOUND(0,1)", e, "t3"), std::vector{
+                left_closed({I(0), I(1)})});
+    });
+}
+
+SEASTAR_TEST_CASE(slice_single_column_mixed_order) {
+    return do_with_cql_env_thread([](cql_test_env& e) {
+        cquery_nofail(
+                e,
+                "create table t (p int, a int, b int, c int, d int, PRIMARY KEY (p, a, b, c, d)) "
+                "with clustering order by (a desc, b asc, c desc, d asc);");
+        BOOST_CHECK_EQUAL(slice_parse("a in (1,2,3,2,1)", e), (std::vector{
+                    singular({I(3)}), singular({I(2)}), singular({I(1)})}));
+        BOOST_CHECK_EQUAL(slice_parse("a in (1,2,3,2,1) and b in (1,2,1)", e), (std::vector{
+                    singular({I(3), I(1)}), singular({I(3), I(2)}),
+                    singular({I(2), I(1)}), singular({I(2), I(2)}),
+                    singular({I(1), I(1)}), singular({I(1), I(2)})}));
+    });
+}

--- a/test/boost/statement_restrictions_test.cc
+++ b/test/boost/statement_restrictions_test.cc
@@ -126,7 +126,7 @@ SEASTAR_TEST_CASE(slice_one_column) {
         BOOST_CHECK_EQUAL(slice_parse("c='123'", e), std::vector{singular({T("123")})});
         BOOST_CHECK_EQUAL(slice_parse("c='a' and c='a'", e), std::vector{singular({T("a")})});
         BOOST_CHECK_EQUAL(slice_parse("c='a' and c='b'", e), query::clustering_row_ranges{});
-        BOOST_CHECK_EQUAL(slice_parse("c like '123'", e), std::vector{singular({})});
+        BOOST_CHECK_EQUAL(slice_parse("c like '123'", e), std::vector{open_ended});
 
         BOOST_CHECK_EQUAL(slice_parse("c in ('x','y','z')", e),
                           (std::vector{singular({T("x")}), singular({T("y")}), singular({T("z")})}));
@@ -153,7 +153,7 @@ SEASTAR_TEST_CASE(slice_two_columns) {
         BOOST_CHECK_EQUAL(slice_parse("c1=123", e), std::vector{singular({I(123)})});
         BOOST_CHECK_EQUAL(slice_parse("c1=123 and c2 like '321'", e), std::vector{singular({I(123)})});
         BOOST_CHECK_EQUAL(slice_parse("c1=123 and c1=123", e), std::vector{singular({I(123)})});
-        BOOST_CHECK_EQUAL(slice_parse("c2='abc'", e), std::vector{singular({})});
+        BOOST_CHECK_EQUAL(slice_parse("c2='abc'", e), std::vector{open_ended});
         BOOST_CHECK_EQUAL(slice_parse("c1=0 and c1=1 and c2='a'", e), query::clustering_row_ranges{});
         BOOST_CHECK_EQUAL(slice_parse("c1=0 and c2='a' and c1=0", e), std::vector{singular({I(0), T("a")})});
 
@@ -175,7 +175,7 @@ SEASTAR_TEST_CASE(slice_two_columns) {
         BOOST_CHECK_EQUAL(slice_parse("c1 in (1) and c1 in (2) and c2 in ('x')", e), query::clustering_row_ranges{});
         BOOST_CHECK_EQUAL(slice_parse("c1 in (1) and c2='x'", e), std::vector{singular({I(1), T("x")})});
         BOOST_CHECK_EQUAL(slice_parse("c1 in () and c2='x'", e), query::clustering_row_ranges{});
-        BOOST_CHECK_EQUAL(slice_parse("c2 in ('x','y')", e), std::vector{singular({})});
+        BOOST_CHECK_EQUAL(slice_parse("c2 in ('x','y')", e), std::vector{open_ended});
         BOOST_CHECK_EQUAL(slice_parse("c1 in (1,2,3)", e),
                           (std::vector{singular({I(1)}), singular({I(2)}), singular({I(3)})}));
         BOOST_CHECK_EQUAL(slice_parse("c1 in (1)", e), std::vector{singular({I(1)})});


### PR DESCRIPTION
Instead of using the `restrictions` class hierarchy, calculate the clustering slice using the `expr::expression` representation of the WHERE clause.  This will allow us to eventually drop the `restrictions` hierarchy altogether.

Tests: unit (dev, debug)