### PR TITLE
dist: increase fs.aio-max-nr value for other apps

### DIFF
--- a/dist/common/scripts/scylla_prepare
+++ b/dist/common/scripts/scylla_prepare
@@ -103,7 +103,9 @@ def verify_cpu():
 def configure_aio_slots():
     with open('/proc/sys/fs/aio-max-nr') as f:
         aio_max_nr = int(f.read())
-    required_aio_slots = cpu_count() * 11026
+    # (10000 + 1024 + 2) * ncpus for scylla,
+    # 65536 for other apps
+    required_aio_slots = cpu_count() * 11026 + 65536
     if aio_max_nr < required_aio_slots:
         with open('/proc/sys/fs/aio-max-nr', 'w') as f:
             f.write(str(required_aio_slots))


### PR DESCRIPTION
Current fs.aio-max-nr value cpu_count() * 11026 is exact size of scylla
uses, if other apps on the environment also try to use aio, aio slot
will be run out.
So increase value +65536 for other apps.

Related #8133