### PR TITLE
tools: toolchain: prepare: adjust manifest manipulations

### DIFF
--- a/tools/toolchain/prepare
+++ b/tools/toolchain/prepare
@@ -29,13 +29,13 @@ if [[ ! -f  /proc/sys/fs/binfmt_misc/qemu-aarch64 || ! -f /proc/sys/fs/binfmt_mi
     exit 1
 fi
 
-podman manifest create "$(<tools/toolchain/image)"
+buildah manifest create "$(<tools/toolchain/image)"
 
 
 for arch in "${archs[@]}"; do
     image_id_file="$(mktemp)"
     buildah bud --arch="$arch" --no-cache --pull -f tools/toolchain/Dockerfile --iidfile "$image_id_file"
-    podman manifest add --all "$(<tools/toolchain/image)" "containers-storage:$(<$image_id_file)"
+    buildah manifest add --all "$(<tools/toolchain/image)" "$(<$image_id_file)"
     rm "$image_id_file"
 done
 


### PR DESCRIPTION
The manifest manipulation commands stopped working with podman 3;
the containers-storage: prefix now throws errors.

Switch to `buildah manifest`; since we're building with buildah,
we might as well maintain the manifest with buildah as well.