### PR TITLE
repair: Add ignore_nodes option

### DIFF
--- a/api/api-doc/storage_service.json
+++ b/api/api-doc/storage_service.json
@@ -971,6 +971,14 @@
                      "paramType":"query"
                   },
                   {
+                     "name":"ignore_nodes",
+                     "description":"Which hosts are to ignore in this repair. Multiple hosts can be listed separated by commas.",
+                     "required":false,
+                     "allowMultiple":false,
+                     "type":"string",
+                     "paramType":"query"
+                  },
+                  {
                      "name":"trace",
                      "description":"If the value is the string 'true' with any capitalization, enable tracing of the repair.",
                      "required":false,

--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -160,7 +160,7 @@ void unset_rpc_controller(http_context& ctx, routes& r) {
 void set_repair(http_context& ctx, routes& r, sharded<netw::messaging_service>& ms) {
     ss::repair_async.set(r, [&ctx, &ms](std::unique_ptr<request> req) {
         static std::vector<sstring> options = {"primaryRange", "parallelism", "incremental",
-                "jobThreads", "ranges", "columnFamilies", "dataCenters", "hosts", "trace",
+                "jobThreads", "ranges", "columnFamilies", "dataCenters", "hosts", "ignore_nodes", "trace",
                 "startToken", "endToken" };
         std::unordered_map<sstring, sstring> options_map;
         for (auto o : options) {

--- a/repair/repair.hh
+++ b/repair/repair.hh
@@ -21,6 +21,7 @@
 
 #pragma once
 
+#include <unordered_set>
 #include <unordered_map>
 #include <exception>
 #include <absl/container/btree_set.h>
@@ -227,6 +228,7 @@ public:
     shard_id shard;
     std::vector<sstring> data_centers;
     std::vector<sstring> hosts;
+    std::unordered_set<gms::inet_address> ignore_nodes;
     streaming::stream_reason reason;
     std::unordered_map<dht::token_range, repair_neighbors> neighbors;
     uint64_t nr_ranges_finished = 0;
@@ -264,6 +266,7 @@ public:
             repair_uniq_id id_,
             const std::vector<sstring>& data_centers_,
             const std::vector<sstring>& hosts_,
+            const std::unordered_set<gms::inet_address>& ingore_nodes_,
             streaming::stream_reason reason_,
             std::optional<utils::UUID> ops_uuid);
     future<> do_streaming();


### PR DESCRIPTION
In some cases, user may want to repair the cluster, ignoring the node
that is down. For example, run repair before run removenode operation to
remove a dead node.

Currently, repair will ignore the dead node and keep running repair
without the dead node but report the repair is partial and report the
repair is failed. It is hard to tell if the repair is failed only due to
the dead node is not present or some other errors.

In order to exclude the dead node, one can use the hosts option. But it
is hard to understand and use, because one needs to list all the "good"
hosts including the node itself. It will be much simpler, if one can
just specify the node to exclude explicitly.

In addition, we support ignore nodes option in other node operations
like removenode. This change makes the interface to ignore a node
explicitly more consistent.

Refs: #7806