### PR TITLE
Clean up > 2-year-old features

### DIFF
--- a/gms/feature_service.cc
+++ b/gms/feature_service.cc
@@ -45,12 +45,12 @@ constexpr std::string_view features::LA_SSTABLE = "LA_SSTABLE_FORMAT";
 constexpr std::string_view features::STREAM_WITH_RPC_STREAM = "STREAM_WITH_RPC_STREAM";
 constexpr std::string_view features::ROW_LEVEL_REPAIR = "ROW_LEVEL_REPAIR";
 constexpr std::string_view features::TRUNCATION_TABLE = "TRUNCATION_TABLE";
+constexpr std::string_view features::CORRECT_STATIC_COMPACT_IN_MC = "CORRECT_STATIC_COMPACT_IN_MC";
 
 // Up-to-date features
 constexpr std::string_view features::UDF = "UDF";
 constexpr std::string_view features::MC_SSTABLE = "MC_SSTABLE_FORMAT";
 constexpr std::string_view features::MD_SSTABLE = "MD_SSTABLE_FORMAT";
-constexpr std::string_view features::CORRECT_STATIC_COMPACT_IN_MC = "CORRECT_STATIC_COMPACT_IN_MC";
 constexpr std::string_view features::UNBOUNDED_RANGE_TOMBSTONES = "UNBOUNDED_RANGE_TOMBSTONES";
 constexpr std::string_view features::VIEW_VIRTUAL_COLUMNS = "VIEW_VIRTUAL_COLUMNS";
 constexpr std::string_view features::DIGEST_INSENSITIVE_TO_EXPIRY = "DIGEST_INSENSITIVE_TO_EXPIRY";
@@ -75,7 +75,6 @@ feature_service::feature_service(feature_config cfg) : _config(cfg)
         , _udf_feature(*this, features::UDF)
         , _mc_sstable_feature(*this, features::MC_SSTABLE)
         , _md_sstable_feature(*this, features::MD_SSTABLE)
-        , _correct_static_compact_in_mc(*this, features::CORRECT_STATIC_COMPACT_IN_MC)
         , _unbounded_range_tombstones_feature(*this, features::UNBOUNDED_RANGE_TOMBSTONES)
         , _view_virtual_columns(*this, features::VIEW_VIRTUAL_COLUMNS)
         , _digest_insensitive_to_expiry(*this, features::DIGEST_INSENSITIVE_TO_EXPIRY)
@@ -174,9 +173,9 @@ std::set<std::string_view> feature_service::known_feature_set() {
         gms::features::INDEXES,
         gms::features::ROW_LEVEL_REPAIR,
         gms::features::TRUNCATION_TABLE,
+        gms::features::CORRECT_STATIC_COMPACT_IN_MC,
 
         // Up-to-date features
-        gms::features::CORRECT_STATIC_COMPACT_IN_MC,
         gms::features::VIEW_VIRTUAL_COLUMNS,
         gms::features::DIGEST_INSENSITIVE_TO_EXPIRY,
         gms::features::COMPUTED_COLUMNS,
@@ -259,7 +258,6 @@ void feature_service::enable(const std::set<std::string_view>& list) {
         std::ref(_udf_feature),
         std::ref(_mc_sstable_feature),
         std::ref(_md_sstable_feature),
-        std::ref(_correct_static_compact_in_mc),
         std::ref(_unbounded_range_tombstones_feature),
         std::ref(_view_virtual_columns),
         std::ref(_digest_insensitive_to_expiry),

--- a/gms/feature_service.cc
+++ b/gms/feature_service.cc
@@ -44,12 +44,12 @@ constexpr std::string_view features::ROLES = "ROLES";
 constexpr std::string_view features::LA_SSTABLE = "LA_SSTABLE_FORMAT";
 constexpr std::string_view features::STREAM_WITH_RPC_STREAM = "STREAM_WITH_RPC_STREAM";
 constexpr std::string_view features::ROW_LEVEL_REPAIR = "ROW_LEVEL_REPAIR";
+constexpr std::string_view features::TRUNCATION_TABLE = "TRUNCATION_TABLE";
 
 // Up-to-date features
 constexpr std::string_view features::UDF = "UDF";
 constexpr std::string_view features::MC_SSTABLE = "MC_SSTABLE_FORMAT";
 constexpr std::string_view features::MD_SSTABLE = "MD_SSTABLE_FORMAT";
-constexpr std::string_view features::TRUNCATION_TABLE = "TRUNCATION_TABLE";
 constexpr std::string_view features::CORRECT_STATIC_COMPACT_IN_MC = "CORRECT_STATIC_COMPACT_IN_MC";
 constexpr std::string_view features::UNBOUNDED_RANGE_TOMBSTONES = "UNBOUNDED_RANGE_TOMBSTONES";
 constexpr std::string_view features::VIEW_VIRTUAL_COLUMNS = "VIEW_VIRTUAL_COLUMNS";
@@ -75,7 +75,6 @@ feature_service::feature_service(feature_config cfg) : _config(cfg)
         , _udf_feature(*this, features::UDF)
         , _mc_sstable_feature(*this, features::MC_SSTABLE)
         , _md_sstable_feature(*this, features::MD_SSTABLE)
-        , _truncation_table(*this, features::TRUNCATION_TABLE)
         , _correct_static_compact_in_mc(*this, features::CORRECT_STATIC_COMPACT_IN_MC)
         , _unbounded_range_tombstones_feature(*this, features::UNBOUNDED_RANGE_TOMBSTONES)
         , _view_virtual_columns(*this, features::VIEW_VIRTUAL_COLUMNS)
@@ -174,9 +173,9 @@ std::set<std::string_view> feature_service::known_feature_set() {
         gms::features::MATERIALIZED_VIEWS,
         gms::features::INDEXES,
         gms::features::ROW_LEVEL_REPAIR,
+        gms::features::TRUNCATION_TABLE,
 
         // Up-to-date features
-        gms::features::TRUNCATION_TABLE,
         gms::features::CORRECT_STATIC_COMPACT_IN_MC,
         gms::features::VIEW_VIRTUAL_COLUMNS,
         gms::features::DIGEST_INSENSITIVE_TO_EXPIRY,
@@ -260,7 +259,6 @@ void feature_service::enable(const std::set<std::string_view>& list) {
         std::ref(_udf_feature),
         std::ref(_mc_sstable_feature),
         std::ref(_md_sstable_feature),
-        std::ref(_truncation_table),
         std::ref(_correct_static_compact_in_mc),
         std::ref(_unbounded_range_tombstones_feature),
         std::ref(_view_virtual_columns),

--- a/gms/feature_service.cc
+++ b/gms/feature_service.cc
@@ -43,12 +43,12 @@ constexpr std::string_view features::XXHASH = "XXHASH";
 constexpr std::string_view features::ROLES = "ROLES";
 constexpr std::string_view features::LA_SSTABLE = "LA_SSTABLE_FORMAT";
 constexpr std::string_view features::STREAM_WITH_RPC_STREAM = "STREAM_WITH_RPC_STREAM";
+constexpr std::string_view features::ROW_LEVEL_REPAIR = "ROW_LEVEL_REPAIR";
 
 // Up-to-date features
 constexpr std::string_view features::UDF = "UDF";
 constexpr std::string_view features::MC_SSTABLE = "MC_SSTABLE_FORMAT";
 constexpr std::string_view features::MD_SSTABLE = "MD_SSTABLE_FORMAT";
-constexpr std::string_view features::ROW_LEVEL_REPAIR = "ROW_LEVEL_REPAIR";
 constexpr std::string_view features::TRUNCATION_TABLE = "TRUNCATION_TABLE";
 constexpr std::string_view features::CORRECT_STATIC_COMPACT_IN_MC = "CORRECT_STATIC_COMPACT_IN_MC";
 constexpr std::string_view features::UNBOUNDED_RANGE_TOMBSTONES = "UNBOUNDED_RANGE_TOMBSTONES";
@@ -75,7 +75,6 @@ feature_service::feature_service(feature_config cfg) : _config(cfg)
         , _udf_feature(*this, features::UDF)
         , _mc_sstable_feature(*this, features::MC_SSTABLE)
         , _md_sstable_feature(*this, features::MD_SSTABLE)
-        , _row_level_repair_feature(*this, features::ROW_LEVEL_REPAIR)
         , _truncation_table(*this, features::TRUNCATION_TABLE)
         , _correct_static_compact_in_mc(*this, features::CORRECT_STATIC_COMPACT_IN_MC)
         , _unbounded_range_tombstones_feature(*this, features::UNBOUNDED_RANGE_TOMBSTONES)
@@ -174,9 +173,9 @@ std::set<std::string_view> feature_service::known_feature_set() {
         gms::features::STREAM_WITH_RPC_STREAM,
         gms::features::MATERIALIZED_VIEWS,
         gms::features::INDEXES,
+        gms::features::ROW_LEVEL_REPAIR,
 
         // Up-to-date features
-        gms::features::ROW_LEVEL_REPAIR,
         gms::features::TRUNCATION_TABLE,
         gms::features::CORRECT_STATIC_COMPACT_IN_MC,
         gms::features::VIEW_VIRTUAL_COLUMNS,
@@ -261,7 +260,6 @@ void feature_service::enable(const std::set<std::string_view>& list) {
         std::ref(_udf_feature),
         std::ref(_mc_sstable_feature),
         std::ref(_md_sstable_feature),
-        std::ref(_row_level_repair_feature),
         std::ref(_truncation_table),
         std::ref(_correct_static_compact_in_mc),
         std::ref(_unbounded_range_tombstones_feature),

--- a/gms/feature_service.hh
+++ b/gms/feature_service.hh
@@ -78,7 +78,6 @@ private:
     gms::feature _udf_feature;
     gms::feature _mc_sstable_feature;
     gms::feature _md_sstable_feature;
-    gms::feature _correct_static_compact_in_mc;
     gms::feature _unbounded_range_tombstones_feature;
     gms::feature _view_virtual_columns;
     gms::feature _digest_insensitive_to_expiry;
@@ -123,9 +122,6 @@ public:
         return _digest_for_null_values_feature;
     }
 
-    const feature& cluster_supports_correct_static_compact_in_mc() const {
-        return _correct_static_compact_in_mc;
-    }
     const feature& cluster_supports_unbounded_range_tombstones() const {
         return _unbounded_range_tombstones_feature;
     }

--- a/gms/feature_service.hh
+++ b/gms/feature_service.hh
@@ -78,7 +78,6 @@ private:
     gms::feature _udf_feature;
     gms::feature _mc_sstable_feature;
     gms::feature _md_sstable_feature;
-    gms::feature _truncation_table;
     gms::feature _correct_static_compact_in_mc;
     gms::feature _unbounded_range_tombstones_feature;
     gms::feature _view_virtual_columns;
@@ -124,12 +123,6 @@ public:
         return _digest_for_null_values_feature;
     }
 
-    feature& cluster_supports_truncation_table() {
-        return _truncation_table;
-    }
-    const feature& cluster_supports_truncation_table() const {
-        return _truncation_table;
-    }
     const feature& cluster_supports_correct_static_compact_in_mc() const {
         return _correct_static_compact_in_mc;
     }

--- a/gms/feature_service.hh
+++ b/gms/feature_service.hh
@@ -78,7 +78,6 @@ private:
     gms::feature _udf_feature;
     gms::feature _mc_sstable_feature;
     gms::feature _md_sstable_feature;
-    gms::feature _row_level_repair_feature;
     gms::feature _truncation_table;
     gms::feature _correct_static_compact_in_mc;
     gms::feature _unbounded_range_tombstones_feature;
@@ -125,9 +124,6 @@ public:
         return _digest_for_null_values_feature;
     }
 
-    bool cluster_supports_row_level_repair() const {
-        return bool(_row_level_repair_feature);
-    }
     feature& cluster_supports_truncation_table() {
         return _truncation_table;
     }

--- a/repair/repair.hh
+++ b/repair/repair.hh
@@ -253,7 +253,6 @@ public:
     lw_shared_ptr<streaming::stream_plan> _sp_in;
     lw_shared_ptr<streaming::stream_plan> _sp_out;
     repair_stats _stats;
-    bool _row_level_repair;
     uint64_t _sub_ranges_nr = 0;
     std::unordered_set<sstring> dropped_tables;
     std::optional<utils::UUID> _ops_uuid;
@@ -280,9 +279,6 @@ public:
     repair_neighbors get_repair_neighbors(const dht::token_range& range);
     void update_statistics(const repair_stats& stats) {
         _stats.add(stats);
-    }
-    bool row_level_repair() {
-        return _row_level_repair;
     }
     const std::vector<sstring>& table_names() {
         return cfs;

--- a/sstables/kl/writer.hh
+++ b/sstables/kl/writer.hh
@@ -30,7 +30,6 @@ class sstable_writer_k_l : public sstable_writer::writer_impl {
     std::unique_ptr<file_writer> _writer;
     shard_id _shard; // Specifies which shard new sstable will belong to.
     write_monitor* _monitor;
-    bool _correctly_serialize_non_compound_range_tombstones;
     utils::UUID _run_identifier;
 
     std::unique_ptr<file_writer> _index;
@@ -109,7 +108,6 @@ public:
     sstable_writer_k_l(sstable_writer_k_l&& o) : writer_impl(o._sst, o._schema, o._pc, o._cfg), _backup(o._backup),
         _leave_unsealed(o._leave_unsealed), _compression_enabled(o._compression_enabled), _writer(std::move(o._writer)),
         _shard(o._shard), _monitor(o._monitor),
-        _correctly_serialize_non_compound_range_tombstones(o._correctly_serialize_non_compound_range_tombstones),
         _run_identifier(o._run_identifier),
         _index(std::move(o._index)),
         _max_sstable_size(o._max_sstable_size), _tombstone_written(o._tombstone_written),

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -117,8 +117,6 @@ struct sstable_writer_config {
     std::optional<db::replay_position> replay_position;
     std::optional<int> sstable_level;
     write_monitor* monitor = &default_write_monitor();
-    bool correctly_serialize_non_compound_range_tombstones;
-    bool correctly_serialize_static_compact_in_mc;
     utils::UUID run_identifier = utils::make_random_uuid();
     size_t summary_byte_cost;
     sstring origin;

--- a/sstables/sstables_manager.cc
+++ b/sstables/sstables_manager.cc
@@ -61,8 +61,6 @@ sstable_writer_config sstables_manager::configure_writer(sstring origin) const {
             : mutation_fragment_stream_validation_level::token;
     cfg.summary_byte_cost = summary_byte_cost(_db_config.sstable_summary_ratio());
 
-    cfg.correctly_serialize_non_compound_range_tombstones = true;
-    cfg.correctly_serialize_static_compact_in_mc = true;
     cfg.origin = std::move(origin);
 
     return cfg;

--- a/sstables/sstables_manager.cc
+++ b/sstables/sstables_manager.cc
@@ -62,8 +62,7 @@ sstable_writer_config sstables_manager::configure_writer(sstring origin) const {
     cfg.summary_byte_cost = summary_byte_cost(_db_config.sstable_summary_ratio());
 
     cfg.correctly_serialize_non_compound_range_tombstones = true;
-    cfg.correctly_serialize_static_compact_in_mc =
-            bool(_features.cluster_supports_correct_static_compact_in_mc());
+    cfg.correctly_serialize_static_compact_in_mc = true;
     cfg.origin = std::move(origin);
 
     return cfg;


### PR DESCRIPTION
Following the work started in 253a7640e, a new batch of old features is assumed to be always available. They are all still announced via gossip, but the code assumes that the feature is always true, because we only support upgrades from a previous release, and the release window is considerably smaller than 2 years.

Features picked this time via `git blame`, along with the date of their introduction:

* fe4afb1aa3 (Asias He                  2018-09-05 14:52:10 +0800  109) static const sstring ROW_LEVEL_REPAIR = "ROW_LEVEL_REPAIR";
* ff5e541335 (Calle Wilund              2019-02-05 13:06:07 +0000  110) static const sstring TRUNCATION_TABLE = "TRUNCATION_TABLE";
* fefef7b9eb (Tomasz Grabiec            2019-03-05 19:08:07 +0100  111) static const sstring CORRECT_STATIC_COMPACT_IN_MC = "CORRECT_STATIC_COMPACT_IN_MC";

Tests: unit(dev)