### PR TITLE
treewide: drop SEASTAR_CONCEPT

### DIFF
--- a/utils/collection-concepts.hh
+++ b/utils/collection-concepts.hh
@@ -23,31 +23,25 @@
 #include <type_traits>
 #include <seastar/util/concepts.hh>
 
-SEASTAR_CONCEPT(
-    template <typename Func, typename T>
-    concept Disposer = requires (Func f, T* val) { 
-        { f(val) } noexcept -> std::same_as<void>;
-    };
-)
+template <typename Func, typename T>
+concept Disposer = requires (Func f, T* val) { 
+    { f(val) } noexcept -> std::same_as<void>;
+};
 
-SEASTAR_CONCEPT(
-    template <typename Key1, typename Key2, typename Less>
-    concept LessComparable = requires (const Key1& a, const Key2& b, Less less) {
-        { less(a, b) } -> std::same_as<bool>;
-        { less(b, a) } -> std::same_as<bool>;
-    };
+template <typename Key1, typename Key2, typename Less>
+concept LessComparable = requires (const Key1& a, const Key2& b, Less less) {
+    { less(a, b) } -> std::same_as<bool>;
+    { less(b, a) } -> std::same_as<bool>;
+};
 
-    template <typename Key1, typename Key2, typename Less>
-    concept LessNothrowComparable = LessComparable<Key1, Key2, Less> && std::is_nothrow_invocable_v<Less, Key1, Key2>;
-)
+template <typename Key1, typename Key2, typename Less>
+concept LessNothrowComparable = LessComparable<Key1, Key2, Less> && std::is_nothrow_invocable_v<Less, Key1, Key2>;
 
-SEASTAR_CONCEPT(
-    template <typename T1, typename T2, typename Compare>
-    concept Comparable = requires (const T1& a, const T2& b, Compare cmp) {
-        // The Comparable is trichotomic comparator that should return 
-        //   negative value when a < b
-        //   zero when a == b
-        //   positive value when a > b
-        { cmp(a, b) } -> std::same_as<int>;
-    };
-)
+template <typename T1, typename T2, typename Compare>
+concept Comparable = requires (const T1& a, const T2& b, Compare cmp) {
+    // The Comparable is trichotomic comparator that should return 
+    //   negative value when a < b
+    //   zero when a == b
+    //   positive value when a > b
+    { cmp(a, b) } -> std::same_as<int>;
+};

--- a/utils/double-decker.hh
+++ b/utils/double-decker.hh
@@ -38,7 +38,7 @@
 
 template <typename Key, typename T, typename Less, typename Compare, int NodeSize,
             bplus::key_search Search = bplus::key_search::binary, bplus::with_debug Debug = bplus::with_debug::no>
-SEASTAR_CONCEPT( requires Comparable<T, T, Compare> && std::is_nothrow_move_constructible_v<T> )
+requires Comparable<T, T, Compare> && std::is_nothrow_move_constructible_v<T>
 class double_decker {
 public:
     using inner_array = intrusive_array<T>;
@@ -124,7 +124,7 @@ public:
         }
 
         template <typename Func>
-        SEASTAR_CONCEPT(requires Disposer<Func, T>)
+        requires Disposer<Func, T>
         iterator erase_and_dispose(Less less, Func&& disp) noexcept {
             disp(&**this); // * to deref this, * to call operator*, & to get addr from ref
 
@@ -249,7 +249,7 @@ public:
     }
 
     template <typename K = Key>
-    SEASTAR_CONCEPT( requires Comparable<K, T, Compare> )
+    requires Comparable<K, T, Compare>
     const_iterator find(const K& key, Compare cmp) const {
         outer_const_iterator bkt = _tree.find(key);
         int idx = 0;
@@ -267,13 +267,13 @@ public:
     }
 
     template <typename K = Key>
-    SEASTAR_CONCEPT( requires Comparable<K, T, Compare> )
+    requires Comparable<K, T, Compare>
     iterator find(const K& k, Compare cmp) {
         return iterator(const_cast<const double_decker*>(this)->find(k, std::move(cmp)));
     }
 
     template <typename K = Key>
-    SEASTAR_CONCEPT( requires Comparable<K, T, Compare> )
+    requires Comparable<K, T, Compare>
     const_iterator lower_bound(const K& key, Compare cmp, bound_hint& hint) const {
         outer_const_iterator bkt = _tree.lower_bound(key, hint.key_match);
 
@@ -300,26 +300,26 @@ public:
     }
 
     template <typename K = Key>
-    SEASTAR_CONCEPT( requires Comparable<K, T, Compare> )
+    requires Comparable<K, T, Compare>
     iterator lower_bound(const K& key, Compare cmp, bound_hint& hint) {
         return iterator(const_cast<const double_decker*>(this)->lower_bound(key, std::move(cmp), hint));
     }
 
     template <typename K = Key>
-    SEASTAR_CONCEPT( requires Comparable<K, T, Compare> )
+    requires Comparable<K, T, Compare>
     const_iterator lower_bound(const K& key, Compare cmp) const {
         bound_hint hint;
         return lower_bound(key, cmp, hint);
     }
 
     template <typename K = Key>
-    SEASTAR_CONCEPT( requires Comparable<K, T, Compare> )
+    requires Comparable<K, T, Compare>
     iterator lower_bound(const K& key, Compare cmp) {
         return iterator(const_cast<const double_decker*>(this)->lower_bound(key, std::move(cmp)));
     }
 
     template <typename K = Key>
-    SEASTAR_CONCEPT( requires Comparable<K, T, Compare> )
+    requires Comparable<K, T, Compare>
     const_iterator upper_bound(const K& key, Compare cmp) const {
         bool key_match;
         outer_const_iterator bkt = _tree.lower_bound(key, key_match);
@@ -340,13 +340,13 @@ public:
     }
 
     template <typename K = Key>
-    SEASTAR_CONCEPT( requires Comparable<K, T, Compare> )
+    requires Comparable<K, T, Compare>
     iterator upper_bound(const K& key, Compare cmp) {
         return iterator(const_cast<const double_decker*>(this)->upper_bound(key, std::move(cmp)));
     }
 
     template <typename Func>
-    SEASTAR_CONCEPT(requires Disposer<Func, T>)
+    requires Disposer<Func, T>
     void clear_and_dispose(Func&& disp) noexcept {
         _tree.clear_and_dispose([&disp] (inner_array* arr) noexcept {
             arr->for_each(disp);
@@ -356,7 +356,7 @@ public:
     void clear() noexcept { clear_and_dispose(bplus::default_dispose<T>); }
 
     template <typename Func>
-    SEASTAR_CONCEPT(requires Disposer<Func, T>)
+    requires Disposer<Func, T>
     iterator erase_and_dispose(iterator begin, iterator end, Func&& disp) noexcept {
         bool same_bucket = begin._bucket == end._bucket;
 

--- a/utils/intrusive-array.hh
+++ b/utils/intrusive-array.hh
@@ -28,17 +28,15 @@
 #include "utils/allocation_strategy.hh"
 #include "utils/collection-concepts.hh"
 
-SEASTAR_CONCEPT(
-    template <typename T>
-    concept BoundsKeeper = requires (T val, bool bit) {
-        { val.is_head() } noexcept -> std::same_as<bool>;
-        { val.set_head(bit) } noexcept -> std::same_as<void>;
-        { val.is_tail() } noexcept -> std::same_as<bool>;
-        { val.set_tail(bit) } noexcept -> std::same_as<void>;
-        { val.with_train() } noexcept -> std::same_as<bool>;
-        { val.set_train(bit) } noexcept -> std::same_as<void>;
-    };
-)
+template <typename T>
+concept BoundsKeeper = requires (T val, bool bit) {
+    { val.is_head() } noexcept -> std::same_as<bool>;
+    { val.set_head(bit) } noexcept -> std::same_as<void>;
+    { val.is_tail() } noexcept -> std::same_as<bool>;
+    { val.set_tail(bit) } noexcept -> std::same_as<void>;
+    { val.with_train() } noexcept -> std::same_as<bool>;
+    { val.set_train(bit) } noexcept -> std::same_as<void>;
+};
 
 /*
  * A plain array of T-s that grows and shrinks by constructing a new
@@ -52,7 +50,7 @@ SEASTAR_CONCEPT(
  * element. Respectively, the T must keep head/tail flags on itself.
  */
 template <typename T>
-SEASTAR_CONCEPT( requires BoundsKeeper<T> && std::is_nothrow_move_constructible_v<T> )
+requires BoundsKeeper<T> && std::is_nothrow_move_constructible_v<T>
 class intrusive_array {
     // Sanity constant to avoid infinite loops searching for tail
     static constexpr int max_len = std::numeric_limits<short int>::max();
@@ -268,7 +266,7 @@ public:
 
     // A helper for keeping the array sorted
     template <typename K, typename Compare>
-    SEASTAR_CONCEPT( requires Comparable<K, T, Compare> )
+    requires Comparable<K, T, Compare>
     const_iterator lower_bound(const K& val, Compare cmp, bool& match) const {
         int i = 0;
 
@@ -284,27 +282,27 @@ public:
     }
 
     template <typename K, typename Compare>
-    SEASTAR_CONCEPT( requires Comparable<K, T, Compare> )
+    requires Comparable<K, T, Compare>
     iterator lower_bound(const K& val, Compare cmp, bool& match) {
         return const_cast<iterator>(const_cast<const intrusive_array*>(this)->lower_bound(val, std::move(cmp), match));
     }
 
     template <typename K, typename Compare>
-    SEASTAR_CONCEPT( requires Comparable<K, T, Compare> )
+    requires Comparable<K, T, Compare>
     const_iterator lower_bound(const K& val, Compare cmp) const {
         bool match = false;
         return lower_bound(val, cmp, match);
     }
 
     template <typename K, typename Compare>
-    SEASTAR_CONCEPT( requires Comparable<K, T, Compare> )
+    requires Comparable<K, T, Compare>
     iterator lower_bound(const K& val, Compare cmp) {
         return const_cast<iterator>(const_cast<const intrusive_array*>(this)->lower_bound(val, std::move(cmp)));
     }
 
     // And its peer ... just to be used
     template <typename K, typename Compare>
-    SEASTAR_CONCEPT( requires Comparable<K, T, Compare> )
+    requires Comparable<K, T, Compare>
     const_iterator upper_bound(const K& val, Compare cmp) const {
         int i = 0;
 
@@ -318,13 +316,13 @@ public:
     }
 
     template <typename K, typename Compare>
-    SEASTAR_CONCEPT( requires Comparable<K, T, Compare> )
+    requires Comparable<K, T, Compare>
     iterator upper_bound(const K& val, Compare cmp) {
         return const_cast<iterator>(const_cast<const intrusive_array*>(this)->upper_bound(val, std::move(cmp)));
     }
 
     template <typename Func>
-    SEASTAR_CONCEPT(requires Disposer<Func, T>)
+    requires Disposer<Func, T>
     void for_each(Func&& fn) noexcept {
         bool tail = false;
 

--- a/utils/stall_free.hh
+++ b/utils/stall_free.hh
@@ -34,7 +34,7 @@ namespace utils {
 // Similar to std::merge but it does not stall. Must run inside a seastar
 // thread. It merges items from list2 into list1. Items from list2 can only be copied.
 template<class T, class Compare>
-SEASTAR_CONCEPT(requires LessComparable<T, T, Compare>)
+requires LessComparable<T, T, Compare>
 void merge_to_gently(std::list<T>& list1, const std::list<T>& list2, Compare comp) {
     auto first1 = list1.begin();
     auto first2 = list2.begin();


### PR DESCRIPTION
Since Scylla requires C++20, there is no need to protect
concept definitions or usages with SEASTAR_CONCEPT; it just
clutters the code. This patch therefore removes all uses.