### PR TITLE
treewide: get rid of incorrect reinterpret casts

### DIFF
--- a/bytes_ostream.hh
+++ b/bytes_ostream.hh
@@ -24,7 +24,6 @@
 #include <boost/range/iterator_range.hpp>
 
 #include "bytes.hh"
-#include <seastar/core/unaligned.hh>
 #include "hashing.hh"
 #include <seastar/core/simple-stream.hh>
 /**

--- a/service/pager/paging_state.cc
+++ b/service/pager/paging_state.cc
@@ -55,6 +55,7 @@
 #include "idl/token.dist.impl.hh"
 #include "idl/range.dist.impl.hh"
 #include "message/messaging_service.hh"
+#include "utils/bit_cast.hh"
 
 service::pager::paging_state::paging_state(partition_key pk,
         std::optional<clustering_key> ck,
@@ -94,7 +95,7 @@ lw_shared_ptr<service::pager::paging_state> service::pager::paging_state::deseri
         return nullptr;
     }
 
-    if (data.value().size() < sizeof(uint32_t) || le_to_cpu(*unaligned_cast<int32_t*>(data.value().begin())) != netw::messaging_service::current_version) {
+    if (data.value().size() < sizeof(uint32_t) || le_to_cpu(read_unaligned<int32_t>(data.value().begin())) != netw::messaging_service::current_version) {
         throw exceptions::protocol_exception("Invalid value for the paging state");
     }
 
@@ -114,6 +115,6 @@ lw_shared_ptr<service::pager::paging_state> service::pager::paging_state::deseri
 bytes_opt service::pager::paging_state::serialize() const {
     bytes b = ser::serialize_to_buffer<bytes>(*this, sizeof(uint32_t));
     // put serialization format id
-    *unaligned_cast<int32_t*>(b.begin()) = cpu_to_le(netw::messaging_service::current_version);
+    write_unaligned<int32_t>(b.begin(), cpu_to_le(netw::messaging_service::current_version));
     return {std::move(b)};
 }

--- a/sstables/writer.hh
+++ b/sstables/writer.hh
@@ -31,6 +31,7 @@
 #include "version.hh"
 #include "counters.hh"
 #include "service/storage_service.hh"
+#include "utils/bit_cast.hh"
 
 namespace sstables {
 
@@ -262,10 +263,8 @@ template <typename T, typename W>
 requires Writer<W>
 inline typename std::enable_if_t<std::is_integral<T>::value, void>
 write(sstable_version_types v, W& out, T i) {
-    auto *nr = reinterpret_cast<const net::packed<T> *>(&i);
-    i = net::hton(*nr);
-    auto p = reinterpret_cast<const char*>(&i);
-    out.write(p, sizeof(T));
+    i = net::hton(i);
+    out.write(reinterpret_cast<const char*>(&i), sizeof(T));
 }
 
 template <typename T, typename W>
@@ -283,10 +282,8 @@ inline void write(sstable_version_types v, W& out, bool i) {
 }
 
 inline void write(sstable_version_types v, file_writer& out, double d) {
-    auto *nr = reinterpret_cast<const net::packed<unsigned long> *>(&d);
-    auto tmp = net::hton(*nr);
-    auto p = reinterpret_cast<const char*>(&tmp);
-    out.write(p, sizeof(unsigned long));
+    unsigned long tmp = net::hton(bit_cast<unsigned long>(d));
+    out.write(reinterpret_cast<const char*>(&tmp), sizeof(unsigned long));
 }
 
 

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -67,6 +67,7 @@
 #include "types/user.hh"
 
 #include "transport/cql_protocol_extension.hh"
+#include "utils/bit_cast.hh"
 
 namespace cql_transport {
 
@@ -379,8 +380,8 @@ cql_server::connection::parse_frame(temporary_buffer<char> buf) const {
     switch (_version) {
     case 1:
     case 2: {
-        auto raw = reinterpret_cast<const cql_binary_frame_v1*>(buf.get());
-        auto cooked = net::ntoh(*raw);
+        cql_binary_frame_v1 raw = read_unaligned<cql_binary_frame_v1>(buf.get());
+        auto cooked = net::ntoh(raw);
         v3.version = cooked.version;
         v3.flags = cooked.flags;
         v3.opcode = cooked.opcode;
@@ -390,7 +391,8 @@ cql_server::connection::parse_frame(temporary_buffer<char> buf) const {
     }
     case 3:
     case 4: {
-        v3 = net::ntoh(*reinterpret_cast<const cql_binary_frame_v3*>(buf.get()));
+        cql_binary_frame_v3 raw = read_unaligned<cql_binary_frame_v3>(buf.get());
+        v3 = net::ntoh(raw);
         break;
     }
     default:

--- a/types.cc
+++ b/types.cc
@@ -175,7 +175,7 @@ integer_type_impl<T>::integer_type_impl(
 
 template <typename T> static bytes decompose_value(T v) {
     bytes b(bytes::initialized_later(), sizeof(v));
-    *reinterpret_cast<T*>(b.begin()) = (T)net::hton(v);
+    write_unaligned<T>(b.begin(), net::hton(v));
     return b;
 }
 

--- a/types.hh
+++ b/types.hh
@@ -50,6 +50,7 @@
 #include "utils/fragmented_temporary_buffer.hh"
 #include "utils/exceptions.hh"
 #include "utils/managed_bytes.hh"
+#include "utils/bit_cast.hh"
 
 class tuple_type_impl;
 class big_decimal;
@@ -1165,7 +1166,7 @@ T read_simple(bytes_view& v) {
     }
     auto p = v.begin();
     v.remove_prefix(sizeof(T));
-    return net::ntoh(*reinterpret_cast<const net::packed<T>*>(p));
+    return net::ntoh(read_unaligned<T>(p));
 }
 
 template<typename T>
@@ -1174,7 +1175,7 @@ T read_simple_exactly(bytes_view v) {
         throw_with_backtrace<marshal_exception>(format("read_simple_exactly - size mismatch (expected {:d}, got {:d})", sizeof(T), v.size()));
     }
     auto p = v.begin();
-    return net::ntoh(*reinterpret_cast<const net::packed<T>*>(p));
+    return net::ntoh(read_unaligned<T>(p));
 }
 
 inline

--- a/utils/bit_cast.hh
+++ b/utils/bit_cast.hh
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2021 ScyllaDB
+ */
+
+/*
+ * This file is part of Scylla.
+ *
+ * Scylla is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Scylla is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <cstring>
+#include <cstddef>
+#include <type_traits>
+
+template <class T> concept Trivial = std::is_trivial_v<T>;
+template <class T> concept TriviallyCopyable = std::is_trivially_copyable_v<T>;
+
+// C++20 has std::bit_cast, which does the same thing,
+// (but better, because it supports constexpr through compiler magic)
+// but it hasn't made its way to our libstdc++ yet.
+template <Trivial To, TriviallyCopyable From>
+requires (sizeof(To) == sizeof(From))
+To bit_cast(const From& src) noexcept {
+    To dst;
+    std::memcpy(&dst, &src, sizeof(To));
+    return dst;
+}
+
+template <Trivial To>
+To read_unaligned(const void* src) {
+    To dst;
+    std::memcpy(&dst, src, sizeof(To));
+    return dst;
+}
+
+template <TriviallyCopyable From>
+void write_unaligned(void* dst, const From& src) {
+    std::memcpy(dst, &src, sizeof(From));
+}

--- a/utils/crc.hh
+++ b/utils/crc.hh
@@ -105,12 +105,12 @@ public:
             --size;
         }
         if ((reinterpret_cast<uintptr_t>(in) & 3) && size >= 2) {
-            process_le(*reinterpret_cast<const uint16_t*>(in));
+            process_le(seastar::read_le<uint16_t>(reinterpret_cast<const char*>(in)));
             in += 2;
             size -= 2;
         }
         if ((reinterpret_cast<uintptr_t>(in) & 7) && size >= 4) {
-            process_le(*reinterpret_cast<const uint32_t*>(in));
+            process_le(seastar::read_le<uint32_t>(reinterpret_cast<const char*>(in)));
             in += 4;
             size -= 4;
         }
@@ -146,17 +146,17 @@ public:
         }
 
         while (size >= 8) {
-            process_le(*reinterpret_cast<const uint64_t*>(in));
+            process_le(seastar::read_le<uint64_t>(reinterpret_cast<const char*>(in)));
             in += 8;
             size -= 8;
         }
         if (size >= 4) {
-            process_le(*reinterpret_cast<const uint32_t*>(in));
+            process_le(seastar::read_le<uint32_t>(reinterpret_cast<const char*>(in)));
             in += 4;
             size -= 4;
         }
         if (size >= 2) {
-            process_le(*reinterpret_cast<const uint16_t*>(in));
+            process_le(seastar::read_le<uint16_t>(reinterpret_cast<const char*>(in)));
             in += 2;
             size -= 2;
         }

--- a/utils/linearizing_input_stream.hh
+++ b/utils/linearizing_input_stream.hh
@@ -27,6 +27,7 @@
 #include <seastar/util/backtrace.hh>
 
 #include "utils/fragment_range.hh"
+#include "utils/bit_cast.hh"
 
 namespace utils {
 
@@ -112,7 +113,7 @@ public:
     requires std::is_trivial_v<Type>
     Type read_trivial() {
         auto [bv, linearized] = do_read(sizeof(Type));
-        auto ret = net::ntoh(*reinterpret_cast<const net::packed<Type>*>(bv.begin()));
+        auto ret = net::ntoh(::read_unaligned<net::packed<Type>>(bv.begin()));
         if (linearized) {
             _linearized_values.pop_back();
         }

--- a/utils/managed_bytes.hh
+++ b/utils/managed_bytes.hh
@@ -27,7 +27,6 @@
 #include "bytes.hh"
 #include "utils/allocation_strategy.hh"
 #include "utils/fragment_range.hh"
-#include <seastar/core/unaligned.hh>
 #include <seastar/util/alloc_failure_injector.hh>
 #include <unordered_map>
 #include <type_traits>


### PR DESCRIPTION
In some places we use the `*reinterpret_cast<const net::packed<T>*>(&x)`
pattern to reinterpret memory. This is a violation of C++'s aliasing rules,
which invokes undefined behaviour.

The blessed way to correctly reinterpret memory is to copy it into a new
object. Let's do that.

Note: the reinterpret_cast way has no performance advantage. Compilers
recognize the memory copy pattern and optimize it away.