### PR TITLE
alternator: coroutinize handle_api_request

### DIFF
--- a/alternator/server.cc
+++ b/alternator/server.cc
@@ -319,13 +319,6 @@ future<> server::verify_signature(const request& req, const chunked_content& con
     });
 }
 
-future<chunked_content> server::read_content_and_verify_signature(request& req) {
-    assert(req.content_stream);
-    chunked_content content = co_await httpd::read_entire_stream(*req.content_stream);
-    co_await verify_signature(req, content);
-    co_return std::move(content);
-}
-
 static tracing::trace_state_ptr create_tracing_session() {
     tracing::trace_state_props_set props;
     props.set<tracing::trace_state_props::full_tracing>();

--- a/alternator/server.hh
+++ b/alternator/server.hh
@@ -85,7 +85,7 @@ private:
     void set_routes(seastar::httpd::routes& r);
     future<> verify_signature(const seastar::httpd::request&, const chunked_content&);
     future<chunked_content> read_content_and_verify_signature(seastar::httpd::request&);
-    future<executor::request_return_type> handle_api_request(std::unique_ptr<request>&& req);
+    future<executor::request_return_type> handle_api_request(std::unique_ptr<request> req);
 };
 
 }

--- a/alternator/server.hh
+++ b/alternator/server.hh
@@ -84,7 +84,6 @@ public:
 private:
     void set_routes(seastar::httpd::routes& r);
     future<> verify_signature(const seastar::httpd::request&, const chunked_content&);
-    future<chunked_content> read_content_and_verify_signature(seastar::httpd::request&);
     future<executor::request_return_type> handle_api_request(std::unique_ptr<request> req);
 };
 


### PR DESCRIPTION
The indentation level is significantly reduced, and so is the number
of allocations. The function signature is changed from taking an rvalue
ref to taking the unique_ptr by value, because otherwise the coroutine
captures the request as a reference, which results in use-after-free.

Tests: unit(dev)