### PR TITLE
repair: Shortcut when no followers to repair with

### DIFF
--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -1177,6 +1177,12 @@ static future<> repair_range(repair_info& ri, const dht::token_range& range) {
             }
             neighbors.swap(live_neighbors);
       }
+      if (neighbors.empty()) {
+            auto status = "skipped_no_followers";
+            rlogger.warn("Repair {} out of {} ranges, id={}, shard={}, keyspace={}, table={}, range={}, peers={}, live_peers={}, status={}",
+            ri.ranges_index, ri.ranges.size(), ri.id, ri.shard, ri.keyspace, ri.table_names(), range, neighbors, live_neighbors, status);
+            return make_ready_future<>();
+      }
       return ::service::get_local_migration_manager().sync_schema(ri.db.local(), neighbors).then([&neighbors, &ri, range, id] {
         return do_for_each(ri.table_ids.begin(), ri.table_ids.end(), [&ri, &neighbors, range] (utils::UUID table_id) {
             sstring cf;


### PR DESCRIPTION
- 3 nodes in the cluster with rf = 3
- run repair on node1 with ignore_nodes to ignore node2 and node3
- node1 has no followers to repair with

However, currently node1 will walk through the repair procedure to read
data from disk and calculate hashes which are unnecessary.

This patch fixes this issue, so that in case there are no followers, we
skip the range and avoid the unnecessary work.

Before:
   $ curl -X POST http://127.0.0.1:10000/storage_service/repair_async/myks3?ignore_nodes="127.0.0.2,127.0.0.3"

   repair - repair id [id=1, uuid=ff39151b-2ce9-4885-b7e9-89158b14b5c2] on shard 0 stats:
   repair_reason=repair, keyspace=myks3, tables={standard1},
   ranges_nr=769, sub_ranges_nr=769, round_nr=1456,
   round_nr_fast_path_already_synced=1456,
   round_nr_fast_path_same_combined_hashes=0,
   round_nr_slow_path=0, rpc_call_nr=0, tx_hashes_nr=0, rx_hashes_nr=0, duration=0.19 seconds,
   tx_row_nr=0, rx_row_nr=0, tx_row_bytes=0, rx_row_bytes=0,
   row_from_disk_bytes={{127.0.0.1, 2822972}},
   row_from_disk_nr={{127.0.0.1, 6218}},
   row_from_disk_bytes_per_sec={{127.0.0.1, 14.1695}} MiB/s,
   row_from_disk_rows_per_sec={{127.0.0.1, 32726.3}} Rows/s,
   tx_row_nr_peer={}, rx_row_nr_peer={}

Data was read from disk.

After:
   $ curl -X POST http://127.0.0.1:10000/storage_service/repair_async/myks3?ignore_nodes="127.0.0.2,127.0.0.3"

   repair - repair id [id=1, uuid=c6df8b23-bd3b-4ebc-8d4c-a11d1ebcca39] on shard 0 stats:
   repair_reason=repair, keyspace=myks3, tables={standard1}, ranges_nr=769,
   sub_ranges_nr=0, round_nr=0, round_nr_fast_path_already_synced=0,
   round_nr_fast_path_same_combined_hashes=0, round_nr_slow_path=0,
   rpc_call_nr=0, tx_hashes_nr=0, rx_hashes_nr=0, duration=0.0 seconds,
   tx_row_nr=0, rx_row_nr=0, tx_row_bytes=0, rx_row_bytes=0,
   row_from_disk_bytes={},
   row_from_disk_nr={},
   row_from_disk_bytes_per_sec={} MiB/s,
   row_from_disk_rows_per_sec={} Rows/s,
   tx_row_nr_peer={}, rx_row_nr_peer={}

No data was read from disk.

Fixes #8256