### PR TITLE
utils: utf8: fix validate_partial() on non-SIMD-optimized architectures

### DIFF
--- a/utils/utf8.cc
+++ b/utils/utf8.cc
@@ -538,11 +538,17 @@ internal::validate_partial(const uint8_t *data, size_t len) {
 }
 
 #else
+
+namespace internal {
+
 // No SIMD implementation for this arch, fallback to naive method
 partial_validation_results
 validate_partial(const uint8_t *data, size_t len) {
     return validate_partial_naive(data, len);
 }
+
+}
+
 #endif
 
 bool validate(const uint8_t* data, size_t len) {


### PR DESCRIPTION
validate_partial() is declared in the internal namespace, but defined
outside it. This causes calls to validate_partial() to be ambiguous
on architectures that haven't been SIMD-optimized yet (e.g. s390x).

Fix by defining it in the internal namespace.