### PR TITLE
utils: crc: fix build with big-endian architectures and 1-byte objects

### DIFF
--- a/utils/crc.hh
+++ b/utils/crc.hh
@@ -172,6 +172,7 @@ public:
         static_assert(std::is_integral<T>::value, "T must be integral type.");
 #if defined(__BYTE_ORDER__) && defined(__ORDER_BIG_ENDIAN__) && __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
         switch (sizeof(T)) {
+        case 1: break;
         case 2: in = __builtin_bswap16(in); break;
         case 4: in = __builtin_bswap32(in); break;
         case 8: in = __builtin_bswap64(in); break;
@@ -196,6 +197,7 @@ public:
         static_assert(std::is_integral<T>::value, "T must be integral type.");
 #if defined(__BYTE_ORDER__) && defined(__ORDER_BIG_ENDIAN__) && __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
         switch (sizeof(T)) {
+        case 1: break;
         case 2: in = __builtin_bswap16(in); break;
         case 4: in = __builtin_bswap32(in); break;
         case 8: in = __builtin_bswap64(in); break;


### PR DESCRIPTION
crc has some code to reverse endianness on big-endian machines, but does
not handle the case of a 1-byte object (which doesn't need any adjustement).
This causes clang to complain that the switch statement doesn't handle that
case.

Fix by adding a no-op case.