### PR TITLE
Support installing our rpm to SLES

### DIFF
--- a/dist/common/scripts/scylla_coredump_setup
+++ b/dist/common/scripts/scylla_coredump_setup
@@ -26,6 +26,7 @@ import argparse
 import subprocess
 import time
 import tempfile
+import shutil
 from scylla_util import *
 from subprocess import run
 
@@ -45,8 +46,11 @@ if __name__ == '__main__':
         run('sysctl -p /etc/sysctl.d/99-scylla-coredump.conf', shell=True, check=True)
 # Other distributions can use systemd-coredump, so setup it
     else:
-        if is_debian_variant() and not shutil.which('coredumpctl'):
-            apt_install('systemd-coredump')
+        if is_debian_variant() or is_suse_variant():
+            if not shutil.which('coredumpctl'):
+                pkg_install('systemd-coredump')
+                if is_suse_variant():
+                    systemd_unit('systemd-coredump.socket').restart()
         conf_data = '''
 [Coredump]
 Storage=external

--- a/dist/common/scripts/scylla_setup
+++ b/dist/common/scripts/scylla_setup
@@ -121,7 +121,7 @@ def do_verify_package(pkg):
         res = 0 if pkg_files[pkg].exists() else 1
     elif is_debian_variant():
         res = run('dpkg -s {}'.format(pkg), shell=True, stdout=DEVNULL, stderr=DEVNULL).returncode
-    elif is_redhat_variant():
+    elif is_redhat_variant() or is_suse_variant():
         res = run('rpm -q {}'.format(pkg), shell=True, stdout=DEVNULL, stderr=DEVNULL).returncode
     elif is_gentoo():
         res = 0 if len(glob.glob('/var/db/pkg/*/{}-*'.format(pkg))) else 1

--- a/dist/common/scripts/scylla_util.py
+++ b/dist/common/scripts/scylla_util.py
@@ -713,6 +713,11 @@ def emerge_install(pkg):
         pkg_error_exit(pkg)
     return run(f'emerge -uq {pkg}', shell=True, check=True)
 
+def zypper_install(pkg):
+    if is_offline():
+        pkg_error_exit(pkg)
+    return run(f'zypper install -y {pkg}', shell=True, check=True)
+
 def pkg_distro():
     if is_debian_variant():
         return 'debian'
@@ -733,6 +738,8 @@ def pkg_install(pkg):
         return apt_install(pkg)
     elif is_gentoo():
         return emerge_install(pkg)
+    elif is_suse_variant():
+        return zypper_install(pkg)
     else:
         pkg_error_exit(pkg)
 


### PR DESCRIPTION
Basically SLES support is already done in f20736d93d4d8e4f9c5539f2daa23351724b05a0, but it was for offline installer.
This fixes few more problems to install our rpm to SLES.
After this change, we can just install our rpm for both CentOS/RHEL and SLES in single image, like unified deb.
SLES uses original package manager called 'zypper', but it does support yum repository so no need to change required for repo.