### PR TITLE
scylla_setup: don't run node-exporter setup when it's not installed

### DIFF
--- a/dist/common/scripts/scylla_setup
+++ b/dist/common/scripts/scylla_setup
@@ -114,7 +114,8 @@ def interactive_choose_swap_size():
 
 pkg_files = {
         'scylla-jmx': scylladir_p() / 'jmx/scylla-jmx',
-        'scylla-tools': scylladir_p() / 'share/cassandra/bin/cqlsh'
+        'scylla-tools': scylladir_p() / 'share/cassandra/bin/cqlsh',
+        'scylla-node-exporter': scylladir_p() / 'node_exporter/node_exporter'
         }
 def do_verify_package(pkg):
     if is_offline():
@@ -127,8 +128,11 @@ def do_verify_package(pkg):
         res = 0 if len(glob.glob('/var/db/pkg/*/{}-*'.format(pkg))) else 1
     else:
         print("OS variant not recognized")
-        res = 1
-    if res != 0:
+        sys.exit(1)
+    return res
+
+def do_verify_package_and_exit(pkg):
+    if do_verify_package(pkg) != 0:
         print('{} package is not installed.'.format(pkg))
         sys.exit(1)
 
@@ -349,8 +353,9 @@ if __name__ == '__main__':
         verify_package = interactive_ask_service('Do you want to verify the ScyllaDB packages are installed?', 'Yes - runs a script to confirm that ScyllaDB is installed. No - skips the installation check.', verify_package)
         args.no_verify_package = not verify_package
         if verify_package:
-            do_verify_package('scylla-jmx')
-            do_verify_package('scylla-tools')
+            do_verify_package_and_exit('scylla-jmx')
+            do_verify_package_and_exit('scylla-tools')
+            do_verify_package_and_exit('scylla-node-exporter')
 
     enable_service = interactive_ask_service('Do you want the Scylla server service to automatically start when the Scylla node boots?', 'Yes - Scylla server service automatically starts on Scylla node boot. No - skips this step. Note you will have to start the Scylla Server service manually.', enable_service)
     args.no_enable_service = not enable_service
@@ -503,7 +508,8 @@ if __name__ == '__main__':
         if io_setup:
             run_setup_script('IO configuration', 'scylla_io_setup')
 
-    node_exporter = interactive_ask_service('Do you want to enable node exporter to export Prometheus data from the node? Note that the Scylla monitoring stack uses this data', 'Yes - enable node exporter. No - skip this  step.', node_exporter)
+    if do_verify_package('scylla-node-exporter'):
+        node_exporter = interactive_ask_service('Do you want to enable node exporter to export Prometheus data from the node? Note that the Scylla monitoring stack uses this data', 'Yes - enable node exporter. No - skip this  step.', node_exporter)
     args.no_node_exporter = not node_exporter
     if node_exporter:
         node_exporter_unit = systemd_unit('scylla-node-exporter')


### PR DESCRIPTION
We need to run package existance check before run setup of
node-exporter.

Fixes #8276