### PR TITLE
logalloc: improve background reclaim shares management

### DIFF
--- a/test/boost/logalloc_test.cc
+++ b/test/boost/logalloc_test.cc
@@ -30,6 +30,7 @@
 #include <seastar/core/thread.hh>
 #include <seastar/core/timer.hh>
 #include <seastar/core/sleep.hh>
+#include <seastar/core/thread_cputime_clock.hh>
 #include <seastar/testing/test_case.hh>
 #include <seastar/testing/thread_test_case.hh>
 #include <seastar/util/defer.hh>
@@ -1532,8 +1533,11 @@ SEASTAR_THREAD_TEST_CASE(background_reclaim) {
     
         // Pretend to do some work. Sleeping would be too easy, as the background reclaim group would use
         // all that time.
-        auto deadline = std::chrono::steady_clock::now() + 100ms;
-        while (std::chrono::steady_clock::now() < deadline) {
+        //
+        // Use thread_cputime_clock to prevent overcommitted test machines from stealing CPU time
+        // and causing test failures.
+        auto deadline = thread_cputime_clock::now() + 100ms;
+        while (thread_cputime_clock::now() < deadline) {
             thread::maybe_yield();
         }
     }

--- a/utils/logalloc.cc
+++ b/utils/logalloc.cc
@@ -409,9 +409,11 @@ private:
         llogger.debug("background_reclaimer::main_loop: exit");
     }
     void adjust_shares() {
-        if (_main_loop_wait && have_work()) {
+        if (have_work()) {
             _sg.set_shares(1 + (1000 * (free_memory_threshold - memory::stats().free_memory())) / free_memory_threshold);
-            main_loop_wake();
+            if (_main_loop_wait) {
+                main_loop_wake();
+            }
         }
     }
 public:

--- a/utils/logalloc.cc
+++ b/utils/logalloc.cc
@@ -410,7 +410,9 @@ private:
     }
     void adjust_shares() {
         if (have_work()) {
-            _sg.set_shares(1 + (1000 * (free_memory_threshold - memory::stats().free_memory())) / free_memory_threshold);
+            auto shares = 1 + (1000 * (free_memory_threshold - memory::stats().free_memory())) / free_memory_threshold;
+            _sg.set_shares(shares);
+            llogger.trace("background_reclaimer::adjust_shares: {}", shares);
             if (_main_loop_wait) {
                 main_loop_wake();
             }

--- a/utils/logalloc.cc
+++ b/utils/logalloc.cc
@@ -422,7 +422,7 @@ public:
     explicit background_reclaimer(scheduling_group sg, noncopyable_function<void (size_t target)> reclaim)
             : _sg(sg)
             , _reclaim(std::move(reclaim))
-            , _adjust_shares_timer(_sg, [this] { adjust_shares(); })
+            , _adjust_shares_timer(default_scheduling_group(), [this] { adjust_shares(); })
             , _done(with_scheduling_group(_sg, [this] { return main_loop(); })) {
         if (sg != default_scheduling_group()) {
             _adjust_shares_timer.arm_periodic(50ms);


### PR DESCRIPTION
The log structured allocator's background reclaimer tries to
allocate CPU power proportional to memory demand, but a
bug made that not happen. Fix the bug, add some logging,
and future-proof the timer. Also, harden the test agains\
overcommitted test machines.

Fixes #8234.

Test: logalloc_test(dev), 20 concurrent runs on 2 cores (1 hyperthread each)