### PR TITLE
CDC generations: refactors and improvements

### DIFF
--- a/cdc/generation.cc
+++ b/cdc/generation.cc
@@ -359,6 +359,8 @@ future<cdc::generation_id> make_new_cdc_generation(
                 2 * ring_delay + duration_cast<milliseconds>(generation_leeway)))};
     co_await sys_dist_ks.insert_cdc_topology_description(gen_id, std::move(gen), { tmptr->count_normal_token_owners() });
 
+    cdc_log.info("New CDC generation: {}", gen_id);
+
     co_return gen_id;
 }
 

--- a/cdc/generation.cc
+++ b/cdc/generation.cc
@@ -298,17 +298,6 @@ bool should_propose_first_generation(const gms::inet_address& me, const gms::gos
     });
 }
 
-future<db_clock::time_point> get_local_streams_timestamp() {
-    return db::system_keyspace::get_saved_cdc_streams_timestamp().then([] (std::optional<db_clock::time_point> ts) {
-        if (!ts) {
-            auto err = format("get_local_streams_timestamp: tried to retrieve streams timestamp after bootstrapping, but it's not present");
-            cdc_log.error("{}", err);
-            throw std::runtime_error(err);
-        }
-        return *ts;
-    });
-}
-
 // non-static for testing
 size_t limit_of_streams_in_topology_description() {
     // Each stream takes 16B and we don't want to exceed 4MB so we can have

--- a/cdc/generation.hh
+++ b/cdc/generation.hh
@@ -22,8 +22,7 @@
 
 /* This module contains classes and functions used to manage CDC generations:
  * sets of CDC stream identifiers used by the cluster to choose partition keys for CDC log writes.
- * Each CDC generation begins operating at a specific time point, called the generation's timestamp
- * (`cdc_streams_timpestamp` or `streams_timestamp` in the code).
+ * Each CDC generation begins operating at a specific time point, called the generation's timestamp.
  * The generation is used by all nodes in the cluster to pick CDC streams until superseded by a new generation.
  *
  * Functions from this module are used by the node joining procedure to introduce new CDC generations to the cluster

--- a/cdc/generation.hh
+++ b/cdc/generation.hh
@@ -169,27 +169,6 @@ future<db_clock::time_point> make_new_cdc_generation(
         std::chrono::milliseconds ring_delay,
         bool add_delay);
 
-/* Retrieves CDC streams generation timestamp from the given endpoint's application state (broadcasted through gossip).
- * We might be during a rolling upgrade, so the timestamp might not be there (if the other node didn't upgrade yet),
- * but if the cluster already supports CDC, then every newly joining node will propose a new CDC generation,
- * which means it will gossip the generation's timestamp.
- */
-std::optional<db_clock::time_point> get_streams_timestamp_for(const gms::inet_address& endpoint, const gms::gossiper&);
-
-/* Inform CDC users about a generation of streams (identified by the given timestamp)
- * by inserting it into the cdc_streams table.
- *
- * Assumes that the cdc_generation_descriptions table contains this generation.
- *
- * Returning from this function does not mean that the table update was successful: the function
- * might run an asynchronous task in the background.
- */
-future<> update_streams_description(
-        db_clock::time_point,
-        shared_ptr<db::system_distributed_keyspace>,
-        noncopyable_function<unsigned()> get_num_token_owners,
-        abort_source&);
-
 /* Part of the upgrade procedure. Useful in case where the version of Scylla that we're upgrading from
  * used the "cdc_streams_descriptions" table. This procedure ensures that the new "cdc_streams_descriptions_v2"
  * table contains streams of all generations that were present in the old table and may still contain data

--- a/cdc/generation.hh
+++ b/cdc/generation.hh
@@ -41,6 +41,7 @@
 #include "dht/token.hh"
 #include "locator/token_metadata.hh"
 #include "utils/chunked_vector.hh"
+#include "cdc/generation_id.hh"
 
 namespace seastar {
     class abort_source;
@@ -132,7 +133,7 @@ public:
 
 class no_generation_data_exception : public std::runtime_error {
 public:
-    no_generation_data_exception(db_clock::time_point generation_ts)
+    no_generation_data_exception(cdc::generation_id generation_ts)
         : std::runtime_error(format("could not find generation data for timestamp {}", generation_ts))
     {}
 };
@@ -159,7 +160,7 @@ bool should_propose_first_generation(const gms::inet_address& me, const gms::gos
  * (not guaranteed in the current implementation, but expected to be the common case;
  *  we assume that `ring_delay` is enough for other nodes to learn about the new generation).
  */
-future<db_clock::time_point> make_new_cdc_generation(
+future<cdc::generation_id> make_new_cdc_generation(
         const db::config& cfg,
         const std::unordered_set<dht::token>& bootstrap_tokens,
         const locator::token_metadata_ptr tmptr,

--- a/cdc/generation.hh
+++ b/cdc/generation.hh
@@ -148,13 +148,6 @@ public:
  */
 bool should_propose_first_generation(const gms::inet_address& me, const gms::gossiper&);
 
-/*
- * Read this node's streams generation timestamp stored in the LOCAL table.
- * Assumes that the node has successfully bootstrapped, and we're not upgrading from a non-CDC version,
- * so the timestamp is present.
- */
-future<db_clock::time_point> get_local_streams_timestamp();
-
 /* Generate a new set of CDC streams and insert it into the distributed cdc_generation_descriptions table.
  * Returns the timestamp of this new generation
  *

--- a/cdc/generation_id.hh
+++ b/cdc/generation_id.hh
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2021 ScyllaDB
+ */
+
+/*
+ * This file is part of Scylla.
+ *
+ * Scylla is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Scylla is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <variant>
+
+#include "db_clock.hh"
+
+namespace cdc {
+
+struct generation_id {
+    db_clock::time_point ts;
+};
+
+std::ostream& operator<<(std::ostream&, const generation_id&);
+bool operator==(const generation_id&, const generation_id&);
+db_clock::time_point get_ts(const generation_id&);
+
+} // namespace cdc

--- a/cdc/generation_service.hh
+++ b/cdc/generation_service.hh
@@ -56,7 +56,7 @@ class generation_service : public peering_sharded_service<generation_service>
     cdc::metadata _cdc_metadata;
 
     /* The latest known generation timestamp and the timestamp that we're currently gossiping
-     * (as CDC_STREAMS_TIMESTAMP application state).
+     * (as CDC_GENERATION_ID application state).
      *
      * Only shard 0 manages this, hence it will be std::nullopt on all shards other than 0.
      * This timestamp is also persisted in the system.cdc_local table.
@@ -67,7 +67,7 @@ class generation_service : public peering_sharded_service<generation_service>
      * different node. In any case, eventually - after one of the nodes gossips the first timestamp
      * - we'll catch on and this variable will be updated with that generation.
      */
-    std::optional<db_clock::time_point> _gen_ts;
+    std::optional<db_clock::time_point> _gen_id;
 public:
     generation_service(const db::config&, gms::gossiper&,
             sharded<db::system_distributed_keyspace>&, abort_source&, const locator::shared_token_metadata&);
@@ -77,7 +77,7 @@ public:
 
     /* After the node bootstraps and creates a new CDC generation, or restarts and loads the last
      * known generation timestamp from persistent storage, this function should be called with
-     * that generation timestamp moved in as the `startup_gen_ts` parameter.
+     * that generation timestamp moved in as the `startup_gen_id` parameter.
      * This passes the responsibility of managing generations from the node startup code to this service;
      * until then, the service remains dormant.
      * At the time of writing this comment, the startup code is in `storage_service::join_token_ring`, hence
@@ -85,7 +85,7 @@ public:
      * Precondition: the node has completed bootstrapping and system_distributed_keyspace is initialized.
      * Must be called on shard 0 - that's where the generation management happens.
      */
-    future<> after_join(std::optional<db_clock::time_point>&& startup_gen_ts);
+    future<> after_join(std::optional<db_clock::time_point>&& startup_gen_id);
 
     cdc::metadata& get_cdc_metadata() {
         return _cdc_metadata;

--- a/cdc/generation_service.hh
+++ b/cdc/generation_service.hh
@@ -23,6 +23,7 @@
 #pragma once
 
 #include "cdc/metadata.hh"
+#include "cdc/generation_id.hh"
 #include "gms/i_endpoint_state_change_subscriber.hh"
 
 namespace db {
@@ -67,7 +68,7 @@ class generation_service : public peering_sharded_service<generation_service>
      * different node. In any case, eventually - after one of the nodes gossips the first timestamp
      * - we'll catch on and this variable will be updated with that generation.
      */
-    std::optional<db_clock::time_point> _gen_id;
+    std::optional<cdc::generation_id> _gen_id;
 public:
     generation_service(const db::config&, gms::gossiper&,
             sharded<db::system_distributed_keyspace>&, abort_source&, const locator::shared_token_metadata&);
@@ -85,7 +86,7 @@ public:
      * Precondition: the node has completed bootstrapping and system_distributed_keyspace is initialized.
      * Must be called on shard 0 - that's where the generation management happens.
      */
-    future<> after_join(std::optional<db_clock::time_point>&& startup_gen_id);
+    future<> after_join(std::optional<cdc::generation_id>&& startup_gen_id);
 
     cdc::metadata& get_cdc_metadata() {
         return _cdc_metadata;
@@ -106,20 +107,20 @@ private:
     /* Retrieve the CDC generation which starts at the given timestamp (from a distributed table created for this purpose)
      * and start using it for CDC log writes if it's not obsolete.
      */
-    future<> handle_cdc_generation(std::optional<db_clock::time_point>);
+    future<> handle_cdc_generation(std::optional<cdc::generation_id>);
 
     /* If `handle_cdc_generation` fails, it schedules an asynchronous retry in the background
      * using `async_handle_cdc_generation`.
      */
-    void async_handle_cdc_generation(db_clock::time_point);
+    void async_handle_cdc_generation(cdc::generation_id);
 
     /* Wrapper around `do_handle_cdc_generation` which intercepts timeout/unavailability exceptions.
      * Returns: do_handle_cdc_generation(ts). */
-    future<bool> do_handle_cdc_generation_intercept_nonfatal_errors(db_clock::time_point);
+    future<bool> do_handle_cdc_generation_intercept_nonfatal_errors(cdc::generation_id);
 
     /* Returns `true` iff we started using the generation (it was not obsolete or already known),
      * which means that this node might write some CDC log entries using streams from this generation. */
-    future<bool> do_handle_cdc_generation(db_clock::time_point);
+    future<bool> do_handle_cdc_generation(cdc::generation_id);
 
     /* Scan CDC generation timestamps gossiped by other nodes and retrieve the latest one.
      * This function should be called once at the end of the node startup procedure

--- a/db/system_distributed_keyspace.cc
+++ b/db/system_distributed_keyspace.cc
@@ -237,27 +237,15 @@ future<> system_distributed_keyspace::remove_view(sstring ks_name, sstring view_
             false).discard_result();
 }
 
-/* We want to make sure that writes/reads to/from cdc_generations and cdc_streams
+/* We want to make sure that writes/reads to/from CDC management-related distributed tables
  * are consistent: a read following an acknowledged write to the same partition should contact
  * at least one of the replicas that the write contacted.
+ *
  * Normally we would achieve that by always using CL = QUORUM,
  * but there's one special case when that's impossible: a single-node cluster. In that case we'll
  * use CL = ONE for writing the data, which will do the right thing -- saving the data in the only
  * possible replica. Until another node joins, reads will also use CL = ONE, retrieving the data
  * from the only existing replica.
- *
- * There is one case where queries wouldn't see the read: if we extend the single-node cluster
- * with two nodes without bootstrapping (so the data won't be streamed to new replicas),
- * and the admin forgets to run repair. Then QUORUM reads might contact only the two new nodes
- * and miss the written entry.
- *
- * Fortunately (aside from the fact that nodes shouldn't be joined without bootstrapping),
- * after the second node joins, it will propose a new CDC generation, so the old entry
- * that was written with CL=ONE won't be used by the cluster anymore. All nodes other than
- * the first one use QUORUM to make the write.
- *
- * And even if the old entry was still needed for some reason, by the time the third node joins,
- * the second node would have already fixed our issue by running read repair on the old entry.
  */
 static db::consistency_level quorum_if_many(size_t num_token_owners) {
     return num_token_owners > 1 ? db::consistency_level::QUORUM : db::consistency_level::ONE;

--- a/db/system_distributed_keyspace.hh
+++ b/db/system_distributed_keyspace.hh
@@ -25,6 +25,7 @@
 #include "schema_fwd.hh"
 #include "service/migration_manager.hh"
 #include "utils/UUID.hh"
+#include "cdc/generation_id.hh"
 
 #include <seastar/core/future.hh>
 #include <seastar/core/sstring.hh>
@@ -96,8 +97,8 @@ public:
     future<> finish_view_build(sstring ks_name, sstring view_name) const;
     future<> remove_view(sstring ks_name, sstring view_name) const;
 
-    future<> insert_cdc_topology_description(db_clock::time_point, const cdc::topology_description&, context);
-    future<std::optional<cdc::topology_description>> read_cdc_topology_description(db_clock::time_point, context);
+    future<> insert_cdc_topology_description(cdc::generation_id, const cdc::topology_description&, context);
+    future<std::optional<cdc::topology_description>> read_cdc_topology_description(cdc::generation_id, context);
 
     future<> create_cdc_desc(db_clock::time_point, const cdc::topology_description&, context);
     future<bool> cdc_desc_exists(db_clock::time_point, context);

--- a/db/system_distributed_keyspace.hh
+++ b/db/system_distributed_keyspace.hh
@@ -96,11 +96,11 @@ public:
     future<> finish_view_build(sstring ks_name, sstring view_name) const;
     future<> remove_view(sstring ks_name, sstring view_name) const;
 
-    future<> insert_cdc_topology_description(db_clock::time_point streams_ts, const cdc::topology_description&, context);
-    future<std::optional<cdc::topology_description>> read_cdc_topology_description(db_clock::time_point streams_ts, context);
+    future<> insert_cdc_topology_description(db_clock::time_point, const cdc::topology_description&, context);
+    future<std::optional<cdc::topology_description>> read_cdc_topology_description(db_clock::time_point, context);
 
-    future<> create_cdc_desc(db_clock::time_point streams_ts, const cdc::topology_description&, context);
-    future<bool> cdc_desc_exists(db_clock::time_point streams_ts, context);
+    future<> create_cdc_desc(db_clock::time_point, const cdc::topology_description&, context);
+    future<bool> cdc_desc_exists(db_clock::time_point, context);
 
     /* Get all generation timestamps appearing in the "cdc_streams_descriptions" table
      * (the old CDC stream description table). */

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -1614,27 +1614,6 @@ future<> update_tokens(const std::unordered_set<dht::token>& tokens) {
     });
 }
 
-future<> update_cdc_streams_timestamp(db_clock::time_point tp) {
-    return qctx->execute_cql(format("INSERT INTO system.{} (key, streams_timestamp) VALUES (?, ?)",
-                v3::CDC_LOCAL), sstring(v3::CDC_LOCAL), tp)
-            .discard_result().then([] { return force_blocking_flush(v3::CDC_LOCAL); });
-}
-
-static const sstring CDC_REWRITTEN_KEY = "rewritten";
-
-future<> cdc_set_rewritten(std::optional<db_clock::time_point> tp) {
-    if (tp) {
-        return qctx->execute_cql(
-                format("INSERT INTO system.{} (key, streams_timestamp) VALUES (?, ?)", v3::CDC_LOCAL),
-                CDC_REWRITTEN_KEY, *tp).discard_result();
-    } else {
-        // Insert just the row marker.
-        return qctx->execute_cql(
-                format("INSERT INTO system.{} (key) VALUES (?)", v3::CDC_LOCAL),
-                CDC_REWRITTEN_KEY).discard_result();
-    }
-}
-
 future<> force_blocking_flush(sstring cfname) {
     assert(qctx);
     return qctx->_qp.invoke_on_all([cfname = std::move(cfname)] (cql3::query_processor& qp) {
@@ -1696,6 +1675,12 @@ future<std::unordered_set<dht::token>> get_local_tokens() {
     });
 }
 
+future<> update_cdc_streams_timestamp(db_clock::time_point tp) {
+    return qctx->execute_cql(format("INSERT INTO system.{} (key, streams_timestamp) VALUES (?, ?)",
+                v3::CDC_LOCAL), sstring(v3::CDC_LOCAL), tp)
+            .discard_result().then([] { return force_blocking_flush(v3::CDC_LOCAL); });
+}
+
 future<std::optional<db_clock::time_point>> get_saved_cdc_streams_timestamp() {
     return qctx->execute_cql(format("SELECT streams_timestamp FROM system.{} WHERE key = ?", v3::CDC_LOCAL), sstring(v3::CDC_LOCAL))
             .then([] (::shared_ptr<cql3::untyped_result_set> msg)-> std::optional<db_clock::time_point> {
@@ -1705,6 +1690,21 @@ future<std::optional<db_clock::time_point>> get_saved_cdc_streams_timestamp() {
 
         return msg->one().get_as<db_clock::time_point>("streams_timestamp");
     });
+}
+
+static const sstring CDC_REWRITTEN_KEY = "rewritten";
+
+future<> cdc_set_rewritten(std::optional<db_clock::time_point> tp) {
+    if (tp) {
+        return qctx->execute_cql(
+                format("INSERT INTO system.{} (key, streams_timestamp) VALUES (?, ?)", v3::CDC_LOCAL),
+                CDC_REWRITTEN_KEY, *tp).discard_result();
+    } else {
+        // Insert just the row marker.
+        return qctx->execute_cql(
+                format("INSERT INTO system.{} (key) VALUES (?)", v3::CDC_LOCAL),
+                CDC_REWRITTEN_KEY).discard_result();
+    }
 }
 
 future<bool> cdc_is_rewritten() {

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -630,15 +630,15 @@ future<> delete_paxos_decision(const schema& s, const partition_key& key, const 
 // CDC related functions
 
 /*
- * Save the CDC streams generation timestamp announced by this node in persistent storage.
+ * Save the CDC generation ID announced by this node in persistent storage.
  */
-future<> update_cdc_streams_timestamp(db_clock::time_point);
+future<> update_cdc_generation_id(db_clock::time_point);
 
 /*
- * Read the CDC streams generation timestamp announced by this node from persistent storage.
+ * Read the CDC generation ID announced by this node from persistent storage.
  * Used to initialize a restarting node.
  */
-future<std::optional<db_clock::time_point>> get_saved_cdc_streams_timestamp();
+future<std::optional<db_clock::time_point>> get_cdc_generation_id();
 
 future<bool> cdc_is_rewritten();
 future<> cdc_set_rewritten(std::optional<db_clock::time_point>);

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -194,11 +194,6 @@ future<> update_tokens(const std::unordered_set<dht::token>& tokens);
  */
 future<> update_tokens(gms::inet_address ep, const std::unordered_set<dht::token>& tokens);
 
-/*
- * Save the CDC streams generation timestamp announced by this node in persistent storage.
- */
-future<> update_cdc_streams_timestamp(db_clock::time_point);
-
 future<> update_preferred_ip(gms::inet_address ep, gms::inet_address preferred_ip);
 future<std::unordered_map<gms::inet_address, gms::inet_address>> get_preferred_ips();
 
@@ -514,12 +509,6 @@ enum class bootstrap_state {
      */
     future<std::unordered_set<dht::token>> get_local_tokens();
 
-    /*
-     * Read the CDC streams generation timestamp announced by this node from persistent storage.
-     * Used to initialize a restarting node.
-     */
-    future<std::optional<db_clock::time_point>> get_saved_cdc_streams_timestamp();
-
     future<std::unordered_map<gms::inet_address, sstring>> load_peer_features();
 
 future<int> increment_and_get_generation();
@@ -637,6 +626,19 @@ future<> save_paxos_promise(const schema& s, const partition_key& key, const uti
 future<> save_paxos_proposal(const schema& s, const service::paxos::proposal& proposal, db::timeout_clock::time_point timeout);
 future<> save_paxos_decision(const schema& s, const service::paxos::proposal& decision, db::timeout_clock::time_point timeout);
 future<> delete_paxos_decision(const schema& s, const partition_key& key, const utils::UUID& ballot, db::timeout_clock::time_point timeout);
+
+// CDC related functions
+
+/*
+ * Save the CDC streams generation timestamp announced by this node in persistent storage.
+ */
+future<> update_cdc_streams_timestamp(db_clock::time_point);
+
+/*
+ * Read the CDC streams generation timestamp announced by this node from persistent storage.
+ * Used to initialize a restarting node.
+ */
+future<std::optional<db_clock::time_point>> get_saved_cdc_streams_timestamp();
 
 future<bool> cdc_is_rewritten();
 future<> cdc_set_rewritten(std::optional<db_clock::time_point>);

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -55,6 +55,7 @@
 #include <map>
 #include <seastar/core/distributed.hh>
 #include "service/paxos/paxos_state.hh"
+#include "cdc/generation_id.hh"
 
 namespace service {
 
@@ -632,16 +633,16 @@ future<> delete_paxos_decision(const schema& s, const partition_key& key, const 
 /*
  * Save the CDC generation ID announced by this node in persistent storage.
  */
-future<> update_cdc_generation_id(db_clock::time_point);
+future<> update_cdc_generation_id(cdc::generation_id);
 
 /*
  * Read the CDC generation ID announced by this node from persistent storage.
  * Used to initialize a restarting node.
  */
-future<std::optional<db_clock::time_point>> get_cdc_generation_id();
+future<std::optional<cdc::generation_id>> get_cdc_generation_id();
 
 future<bool> cdc_is_rewritten();
-future<> cdc_set_rewritten(std::optional<db_clock::time_point>);
+future<> cdc_set_rewritten(std::optional<cdc::generation_id>);
 
 } // namespace system_keyspace
 } // namespace db

--- a/docs/design-notes/cdc.md
+++ b/docs/design-notes/cdc.md
@@ -141,7 +141,7 @@ Next, the node starts gossiping the timestamp of the new generation together wit
 ```
         _gossiper.add_local_application_state({
             { gms::application_state::TOKENS, versioned_value::tokens(_bootstrap_tokens) },
-            { gms::application_state::CDC_STREAMS_TIMESTAMP, versioned_value::cdc_streams_timestamp(_cdc_streams_ts) },
+            { gms::application_state::CDC_GENERATION_ID, versioned_value::cdc_generation_id(_cdc_gen_id) },
             { gms::application_state::STATUS, versioned_value::bootstrapping(_bootstrap_tokens) },
         }).get();
 ```

--- a/gms/application_state.cc
+++ b/gms/application_state.cc
@@ -67,7 +67,7 @@ static const std::map<application_state, sstring> application_state_names = {
     {application_state::VIEW_BACKLOG,           "VIEW_BACKLOG"},
     {application_state::SHARD_COUNT,            "SHARD_COUNT"},
     {application_state::IGNORE_MSB_BITS,        "IGNOR_MSB_BITS"},
-    {application_state::CDC_STREAMS_TIMESTAMP,  "CDC_STREAMS_TIMESTAMP"},
+    {application_state::CDC_GENERATION_ID,      "CDC_STREAMS_TIMESTAMP"}, /* not named "CDC_GENERATION_ID" for backward compatibility */
     {application_state::SNITCH_NAME,            "SNITCH_NAME"},
 };
 

--- a/gms/application_state.hh
+++ b/gms/application_state.hh
@@ -64,7 +64,7 @@ enum class application_state {
     VIEW_BACKLOG,
     SHARD_COUNT,
     IGNORE_MSB_BITS,
-    CDC_STREAMS_TIMESTAMP,
+    CDC_GENERATION_ID,
     SNITCH_NAME,
     // pad to allow adding new states to existing cluster
     X10,

--- a/gms/versioned_value.cc
+++ b/gms/versioned_value.cc
@@ -74,12 +74,12 @@ sstring versioned_value::make_token_string(const std::unordered_set<dht::token>&
     return tokens.begin()->to_sstring();
 }
 
-sstring versioned_value::make_cdc_generation_id_string(std::optional<db_clock::time_point> t) {
+sstring versioned_value::make_cdc_generation_id_string(std::optional<cdc::generation_id> gen_id) {
     // We assume that the db_clock epoch is the same on all receiving nodes.
-    if (!t) {
+    if (!gen_id) {
         return "";
     }
-    return std::to_string(t->time_since_epoch().count());
+    return std::to_string(gen_id->ts.time_since_epoch().count());
 }
 
 std::unordered_set<dht::token> versioned_value::tokens_from_string(const sstring& s) {
@@ -95,11 +95,11 @@ std::unordered_set<dht::token> versioned_value::tokens_from_string(const sstring
     return ret;
 }
 
-std::optional<db_clock::time_point> versioned_value::cdc_generation_id_from_string(const sstring& s) {
+std::optional<cdc::generation_id> versioned_value::cdc_generation_id_from_string(const sstring& s) {
     if (s.empty()) {
         return {};
     }
-    return db_clock::time_point(db_clock::duration(std::stoll(s)));
+    return cdc::generation_id{db_clock::time_point{db_clock::duration(std::stoll(s))}};
 }
 
 }

--- a/gms/versioned_value.cc
+++ b/gms/versioned_value.cc
@@ -74,7 +74,7 @@ sstring versioned_value::make_token_string(const std::unordered_set<dht::token>&
     return tokens.begin()->to_sstring();
 }
 
-sstring versioned_value::make_cdc_streams_timestamp_string(std::optional<db_clock::time_point> t) {
+sstring versioned_value::make_cdc_generation_id_string(std::optional<db_clock::time_point> t) {
     // We assume that the db_clock epoch is the same on all receiving nodes.
     if (!t) {
         return "";
@@ -95,7 +95,7 @@ std::unordered_set<dht::token> versioned_value::tokens_from_string(const sstring
     return ret;
 }
 
-std::optional<db_clock::time_point> versioned_value::cdc_streams_timestamp_from_string(const sstring& s) {
+std::optional<db_clock::time_point> versioned_value::cdc_generation_id_from_string(const sstring& s) {
     if (s.empty()) {
         return {};
     }

--- a/gms/versioned_value.hh
+++ b/gms/versioned_value.hh
@@ -129,13 +129,13 @@ public:
 
     static sstring make_full_token_string(const std::unordered_set<dht::token>& tokens);
     static sstring make_token_string(const std::unordered_set<dht::token>& tokens);
-    static sstring make_cdc_streams_timestamp_string(std::optional<db_clock::time_point> t);
+    static sstring make_cdc_generation_id_string(std::optional<db_clock::time_point> t);
 
     // Reverse of `make_full_token_string`.
     static std::unordered_set<dht::token> tokens_from_string(const sstring&);
 
-    // Reverse of `make_cdc_streams_timestamp_string`.
-    static std::optional<db_clock::time_point> cdc_streams_timestamp_from_string(const sstring&);
+    // Reverse of `make_cdc_generation_id_string`.
+    static std::optional<db_clock::time_point> cdc_generation_id_from_string(const sstring&);
 
     static versioned_value clone_with_higher_version(const versioned_value& value) noexcept {
         return versioned_value(value.value);
@@ -184,8 +184,8 @@ public:
         return versioned_value(make_full_token_string(tokens));
     }
 
-    static versioned_value cdc_streams_timestamp(std::optional<db_clock::time_point> t) {
-        return versioned_value(make_cdc_streams_timestamp_string(t));
+    static versioned_value cdc_generation_id(std::optional<db_clock::time_point> t) {
+        return versioned_value(make_cdc_generation_id_string(t));
     }
 
     static versioned_value removing_nonlocal(const utils::UUID& host_id) {

--- a/gms/versioned_value.hh
+++ b/gms/versioned_value.hh
@@ -46,6 +46,7 @@
 #include "dht/i_partitioner.hh"
 #include "to_string.hh"
 #include "version.hh"
+#include "cdc/generation_id.hh"
 #include <unordered_set>
 #include <vector>
 #include <boost/range/adaptor/transformed.hpp>
@@ -129,13 +130,13 @@ public:
 
     static sstring make_full_token_string(const std::unordered_set<dht::token>& tokens);
     static sstring make_token_string(const std::unordered_set<dht::token>& tokens);
-    static sstring make_cdc_generation_id_string(std::optional<db_clock::time_point> t);
+    static sstring make_cdc_generation_id_string(std::optional<cdc::generation_id>);
 
     // Reverse of `make_full_token_string`.
     static std::unordered_set<dht::token> tokens_from_string(const sstring&);
 
     // Reverse of `make_cdc_generation_id_string`.
-    static std::optional<db_clock::time_point> cdc_generation_id_from_string(const sstring&);
+    static std::optional<cdc::generation_id> cdc_generation_id_from_string(const sstring&);
 
     static versioned_value clone_with_higher_version(const versioned_value& value) noexcept {
         return versioned_value(value.value);
@@ -184,8 +185,8 @@ public:
         return versioned_value(make_full_token_string(tokens));
     }
 
-    static versioned_value cdc_generation_id(std::optional<db_clock::time_point> t) {
-        return versioned_value(make_cdc_generation_id_string(t));
+    static versioned_value cdc_generation_id(std::optional<cdc::generation_id> gen_id) {
+        return versioned_value(make_cdc_generation_id_string(gen_id));
     }
 
     static versioned_value removing_nonlocal(const utils::UUID& host_id) {

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -316,8 +316,8 @@ void storage_service::prepare_to_join(
         // Therefore we update _token_metadata now, before gossip starts.
         tmptr->update_normal_tokens(my_tokens, get_broadcast_address()).get();
 
-        _cdc_streams_ts = db::system_keyspace::get_saved_cdc_streams_timestamp().get0();
-        if (!_cdc_streams_ts) {
+        _cdc_gen_id = db::system_keyspace::get_cdc_generation_id().get0();
+        if (!_cdc_gen_id) {
             // We could not have completed joining if we didn't generate and persist a CDC streams timestamp,
             // unless we are restarting after upgrading from non-CDC supported version.
             // In that case we won't begin a CDC generation: it should be done by one of the nodes
@@ -368,7 +368,7 @@ void storage_service::prepare_to_join(
         // Order is important: both the CDC streams timestamp and tokens must be known when a node handles our status.
         // Exception: there might be no CDC streams timestamp proposed by us if we're upgrading from a non-CDC version.
         app_states.emplace(gms::application_state::TOKENS, versioned_value::tokens(my_tokens));
-        app_states.emplace(gms::application_state::CDC_STREAMS_TIMESTAMP, versioned_value::cdc_streams_timestamp(_cdc_streams_ts));
+        app_states.emplace(gms::application_state::CDC_GENERATION_ID, versioned_value::cdc_generation_id(_cdc_gen_id));
         app_states.emplace(gms::application_state::STATUS, versioned_value::normal(my_tokens));
     }
     if (replacing_a_node_with_same_ip || replacing_a_node_with_diff_ip) {
@@ -404,18 +404,18 @@ void storage_service::maybe_start_sys_dist_ks() {
 /* Broadcasts the chosen tokens through gossip,
  * together with a CDC generation timestamp and STATUS=NORMAL.
  *
- * Assumes that no other functions modify CDC_STREAMS_TIMESTAMP, TOKENS or STATUS
+ * Assumes that no other functions modify CDC_GENERATION_ID, TOKENS or STATUS
  * in the gossiper's local application state while this function runs.
  */
 // Runs inside seastar::async context
 static void set_gossip_tokens(gms::gossiper& g,
-        const std::unordered_set<dht::token>& tokens, std::optional<db_clock::time_point> cdc_streams_ts) {
+        const std::unordered_set<dht::token>& tokens, std::optional<db_clock::time_point> cdc_gen_id) {
     assert(!tokens.empty());
 
     // Order is important: both the CDC streams timestamp and tokens must be known when a node handles our status.
     g.add_local_application_state({
         { gms::application_state::TOKENS, gms::versioned_value::tokens(tokens) },
-        { gms::application_state::CDC_STREAMS_TIMESTAMP, gms::versioned_value::cdc_streams_timestamp(cdc_streams_ts) },
+        { gms::application_state::CDC_GENERATION_ID, gms::versioned_value::cdc_generation_id(cdc_gen_id) },
         { gms::application_state::STATUS, gms::versioned_value::normal(tokens) }
     }).get();
 }
@@ -577,14 +577,14 @@ void storage_service::join_token_ring(int delay) {
 
     if (!db::system_keyspace::bootstrap_complete()) {
         // If we're not bootstrapping then we shouldn't have chosen a CDC streams timestamp yet.
-        assert(should_bootstrap() || !_cdc_streams_ts);
+        assert(should_bootstrap() || !_cdc_gen_id);
 
         // Don't try rewriting CDC stream description tables.
         // See cdc.md design notes, `Streams description table V1 and rewriting` section, for explanation.
         db::system_keyspace::cdc_set_rewritten(std::nullopt).get();
     }
 
-    if (!_cdc_streams_ts) {
+    if (!_cdc_gen_id) {
         // If we didn't choose a CDC streams timestamp at this point, then either
         // 1. we're replacing a node,
         // 2. we've already bootstrapped, but are upgrading from a non-CDC version,
@@ -605,7 +605,7 @@ void storage_service::join_token_ring(int delay) {
                 && (!db::system_keyspace::bootstrap_complete()
                     || cdc::should_propose_first_generation(get_broadcast_address(), _gossiper))) {
             try {
-                _cdc_streams_ts = cdc::make_new_cdc_generation(db().local().get_config(),
+                _cdc_gen_id = cdc::make_new_cdc_generation(db().local().get_config(),
                         _bootstrap_tokens, get_token_metadata_ptr(), _gossiper,
                         _sys_dist_ks.local(), get_ring_delay(), !_for_testing && !is_first_node()).get0();
             } catch (...) {
@@ -617,17 +617,17 @@ void storage_service::join_token_ring(int delay) {
     }
 
     // Persist the CDC streams timestamp before we persist bootstrap_state = COMPLETED.
-    if (_cdc_streams_ts) {
-        db::system_keyspace::update_cdc_streams_timestamp(*_cdc_streams_ts).get();
+    if (_cdc_gen_id) {
+        db::system_keyspace::update_cdc_generation_id(*_cdc_gen_id).get();
     }
     // If we crash now, we will choose a new CDC streams timestamp anyway (because we will also choose a new set of tokens).
     // But if we crash after setting bootstrap_state = COMPLETED, we will keep using the persisted CDC streams timestamp after restarting.
 
     db::system_keyspace::set_bootstrap_state(db::system_keyspace::bootstrap_state::COMPLETED).get();
-    // At this point our local tokens and CDC streams timestamp are chosen (_bootstrap_tokens, _cdc_streams_ts) and will not be changed.
+    // At this point our local tokens and CDC streams timestamp are chosen (_bootstrap_tokens, _cdc_gen_id) and will not be changed.
 
     // start participating in the ring.
-    set_gossip_tokens(_gossiper, _bootstrap_tokens, _cdc_streams_ts);
+    set_gossip_tokens(_gossiper, _bootstrap_tokens, _cdc_gen_id);
     set_mode(mode::NORMAL, "node is now in normal status", true);
 
     if (get_token_metadata().sorted_tokens().empty()) {
@@ -636,7 +636,7 @@ void storage_service::join_token_ring(int delay) {
         throw std::runtime_error(err);
     }
 
-    _cdc_gen_service.local().after_join(std::move(_cdc_streams_ts)).get();
+    _cdc_gen_service.local().after_join(std::move(_cdc_gen_id)).get();
 
     // Ensure that the new CDC stream description table has all required streams.
     // See the function's comment for details.
@@ -681,16 +681,16 @@ void storage_service::bootstrap() {
 
         // After we pick a generation timestamp, we start gossiping it, and we stick with it.
         // We don't do any other generation switches (unless we crash before complecting bootstrap).
-        assert(!_cdc_streams_ts);
+        assert(!_cdc_gen_id);
 
-        _cdc_streams_ts = cdc::make_new_cdc_generation(db().local().get_config(),
+        _cdc_gen_id = cdc::make_new_cdc_generation(db().local().get_config(),
                 _bootstrap_tokens, get_token_metadata_ptr(), _gossiper,
                 _sys_dist_ks.local(), get_ring_delay(), !_for_testing && !is_first_node()).get0();
 
         _gossiper.add_local_application_state({
             // Order is important: both the CDC streams timestamp and tokens must be known when a node handles our status.
             { gms::application_state::TOKENS, versioned_value::tokens(_bootstrap_tokens) },
-            { gms::application_state::CDC_STREAMS_TIMESTAMP, versioned_value::cdc_streams_timestamp(_cdc_streams_ts) },
+            { gms::application_state::CDC_GENERATION_ID, versioned_value::cdc_generation_id(_cdc_gen_id) },
             { gms::application_state::STATUS, versioned_value::bootstrapping(_bootstrap_tokens) },
         }).get();
 
@@ -705,7 +705,7 @@ void storage_service::bootstrap() {
         set_mode(mode::JOINING, sprint("Announce tokens and status of the replacing node"), true);
         _gossiper.add_local_application_state({
             { gms::application_state::TOKENS, versioned_value::tokens(_bootstrap_tokens) },
-            { gms::application_state::CDC_STREAMS_TIMESTAMP, versioned_value::cdc_streams_timestamp(_cdc_streams_ts) },
+            { gms::application_state::CDC_GENERATION_ID, versioned_value::cdc_generation_id(_cdc_gen_id) },
             { gms::application_state::STATUS, versioned_value::hibernate(true) },
         }).get();
         _gossiper.advertise_myself().get();
@@ -1760,7 +1760,7 @@ future<> storage_service::start_gossiping(bind_messaging_port do_bind) {
         return seastar::async([&ss, do_bind] {
             if (!ss._initialized) {
                 slogger.warn("Starting gossip by operator request");
-                auto cdc_gen_ts = db::system_keyspace::get_saved_cdc_streams_timestamp().get0();
+                auto cdc_gen_ts = db::system_keyspace::get_cdc_generation_id().get0();
                 if (!cdc_gen_ts) {
                     cdc_log.warn("CDC generation timestamp missing when starting gossip");
                 }

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -409,7 +409,7 @@ void storage_service::maybe_start_sys_dist_ks() {
  */
 // Runs inside seastar::async context
 static void set_gossip_tokens(gms::gossiper& g,
-        const std::unordered_set<dht::token>& tokens, std::optional<db_clock::time_point> cdc_gen_id) {
+        const std::unordered_set<dht::token>& tokens, std::optional<cdc::generation_id> cdc_gen_id) {
     assert(!tokens.empty());
 
     // Order is important: both the CDC streams timestamp and tokens must be known when a node handles our status.

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -283,7 +283,7 @@ void storage_service::prepare_to_join(
         if (db::system_keyspace::bootstrap_complete()) {
             throw std::runtime_error("Cannot replace address with a node that is already bootstrapped");
         }
-        std::tie(_bootstrap_tokens, _cdc_streams_ts) = prepare_replacement_info(initial_contact_nodes, loaded_peer_features, do_bind).get0();
+        _bootstrap_tokens = prepare_replacement_info(initial_contact_nodes, loaded_peer_features, do_bind).get0();
         auto replace_address = db().local().get_replace_address();
         replacing_a_node_with_same_ip = replace_address && *replace_address == get_broadcast_address();
         replacing_a_node_with_diff_ip = replace_address && *replace_address != get_broadcast_address();
@@ -557,8 +557,8 @@ void storage_service::join_token_ring(int delay) {
     }).get();
 
     if (!db::system_keyspace::bootstrap_complete()) {
-        // If we're not bootstrapping nor replacing, then we shouldn't have chosen a CDC streams timestamp yet.
-        assert(should_bootstrap() || db().local().is_replacing() || !_cdc_streams_ts);
+        // If we're not bootstrapping then we shouldn't have chosen a CDC streams timestamp yet.
+        assert(should_bootstrap() || !_cdc_streams_ts);
 
         // Don't try rewriting CDC stream description tables.
         // See cdc.md design notes, `Streams description table V1 and rewriting` section, for explanation.
@@ -567,7 +567,7 @@ void storage_service::join_token_ring(int delay) {
 
     if (!_cdc_streams_ts) {
         // If we didn't choose a CDC streams timestamp at this point, then either
-        // 1. we're replacing a node which didn't gossip a CDC streams timestamp for whatever reason,
+        // 1. we're replacing a node,
         // 2. we've already bootstrapped, but are upgrading from a non-CDC version,
         // 3. we're starting for the first time, but we're skipping the streaming phase (seed node/auto_bootstrap=off)
         //    and directly joining the token ring.
@@ -1544,8 +1544,7 @@ storage_service::prepare_replacement_info(std::unordered_set<gms::inet_address> 
             throw std::runtime_error(format("Could not find tokens for {} to replace", replace_address));
         }
 
-        auto cdc_streams_ts = cdc::get_streams_timestamp_for(replace_address, _gossiper);
-        replacement_info ret {tokens, cdc_streams_ts};
+        replacement_info ret {std::move(tokens)};
 
         // use the replacee's host Id as our own so we receive hints, etc
         auto host_id = _gossiper.get_host_id(replace_address);

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -66,6 +66,7 @@
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/core/lowres_clock.hh>
 #include "locator/snitch_base.hh"
+#include "cdc/generation_id.hh"
 
 class node_ops_cmd_request;
 class node_ops_cmd_response;
@@ -336,7 +337,7 @@ private:
      * DO NOT use this variable after `join_token_ring` (i.e. after we call `generation_service::after_join`
      * and pass it the ownership of the timestamp.
      */
-    std::optional<db_clock::time_point> _cdc_gen_id;
+    std::optional<cdc::generation_id> _cdc_gen_id;
 
 public:
     void enable_all_features();

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -375,7 +375,7 @@ private:
     void shutdown_client_servers();
 
     // Tokens and the CDC streams timestamp of the replaced node.
-    using replacement_info = std::pair<std::unordered_set<token>, std::optional<db_clock::time_point>>;
+    using replacement_info = std::unordered_set<token>;
     future<replacement_info> prepare_replacement_info(std::unordered_set<gms::inet_address> initial_contact_nodes,
             const std::unordered_map<gms::inet_address, sstring>& loaded_peer_features, bind_messaging_port do_bind = bind_messaging_port::yes);
 

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -336,7 +336,7 @@ private:
      * DO NOT use this variable after `join_token_ring` (i.e. after we call `generation_service::after_join`
      * and pass it the ownership of the timestamp.
      */
-    std::optional<db_clock::time_point> _cdc_streams_ts;
+    std::optional<db_clock::time_point> _cdc_gen_id;
 
 public:
     void enable_all_features();

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -341,10 +341,6 @@ private:
 public:
     void enable_all_features();
 
-    /* Broadcasts the chosen tokens through gossip,
-     * together with a CDC streams timestamp (if we start a new CDC generation) and STATUS=NORMAL. */
-    void set_gossip_tokens(const std::unordered_set<dht::token>&, std::optional<db_clock::time_point>);
-
     void register_subscriber(endpoint_lifecycle_subscriber* subscriber);
 
     future<> unregister_subscriber(endpoint_lifecycle_subscriber* subscriber) noexcept;


### PR DESCRIPTION
The "most important" major changes are:

1. storage_service: simplify CDC generation management during node replace

Previously, when node A replaced node B, it would obtain B's
generation timestamp from its application state (gossiped by other
nodes) and start gossiping it immediately on bootstrap.

But that's not necessary:
  - if this is the timestamp of the last (current) generation, we would
     obtain it from other nodes anyway (every node gossips the last known
     timestamp),
  - if this is the timestamp of an earlier generation, we would forget
     it immediately and start gossiping the last timestamp (obtained from
     other nodes).

This commit simplifies the bootstrap code (in node-replace case) a bit:
the replacing node no longer attempts to retrieve the CDC generation
timestamp from the node being replaced.

2. tree-wide: introduce cdc::generation_id type

Each CDC generation has a timestamp which denotes a logical point in time
when this generation starts operating. That same timestamp is
used to identify the CDC generation. We use this identification scheme
to exchange CDC generations around the cluster.

However, the fact that a generation's timestamp is used as an ID for
this generation is an implementation detail of the currently used method
of managing CDC generations.

Places in the code that deal with the timestamp, e.g. functions which
take it as an argument (such as handle_cdc_generation) are often
interested in the ID aspect, not the "when does the generation start
operating" aspect. They don't care that the ID is a `db_clock::time_point`.
They may sometimes want to retrieve the time point given the ID (such as
do_handle_cdc_generation when it calls `cdc::metadata::insert`),
but they don't care about the fact that the time point actually IS the ID.

In the future we may actually change the specific type of the ID if we
modify the generation management algorithms.

This commit is an intermediate step that will ease the transition in the
future. It introduces a new type, `cdc::generation_id`. Inside it contains
the timestamp, so:
- if a piece of code doesn't care about the timestamp, it just passes
   the ID around
- if it does care, it can access it using the `get_ts` function.
   The fact that `get_ts` simply accesses the ID's only field is an
   implementation detail.


3. cdc: handle missing generation case in check_and_repair_cdc_streams

check_and_repair_cdc_streams assumed that there is always at least
one generation being gossiped by at least one of the nodes. Otherwise it
would enter undefined behavior.

I'm not aware of any "real" scenario where this assumption wouldn't be
satisfied at the moment where check_and_repair_cdc_streams makes it
except perhaps some theoretical races. But it's best to stay on the safe
side.

---

Additionally the PR does some simplifications, stylistic improvements,
removes some dead code, coroutinizes some functions, uncoroutinizes others
(due to miscompiles), adds additional logging, updates some stale comments.
Read commit messages for more details.
