### PR TITLE
cql3/expr: Improve column printing

### DIFF
--- a/cql3/expr/expression.cc
+++ b/cql3/expr/expression.cc
@@ -808,7 +808,7 @@ bool has_supporting_index(
 }
 
 std::ostream& operator<<(std::ostream& os, const column_value& cv) {
-    os << *cv.col;
+    os << cv.col->name_as_text();
     if (cv.sub) {
         os << '[' << *cv.sub << ']';
     }
@@ -823,10 +823,10 @@ std::ostream& operator<<(std::ostream& os, const expression& expr) {
                 std::visit(overloaded_functor{
                         [&] (const token& t) { os << "TOKEN"; },
                         [&] (const column_value& col) {
-                            fmt::print(os, "({})", col);
+                            fmt::print(os, "{}", col);
                         },
                         [&] (const std::vector<column_value>& cvs) {
-                            fmt::print(os, "(({}))", fmt::join(cvs, ","));
+                            fmt::print(os, "({})", fmt::join(cvs, ","));
                         },
                     }, opr.lhs);
                 os << ' ' << opr.op << ' ' << *opr.rhs;


### PR DESCRIPTION
Before this change, we would print an expression like this:

((ColumnDefinition{name=c, type=org.apache.cassandra.db.marshal.Int32Type, kind=CLUSTERING_COLUMN, componentIndex=0, droppedAt=-9223372036854775808}) = 0000007b)

Now, we print the same expression like this:

(c = 0000007b)

Tests: unit (dev)

Signed-off-by: Dejan Mircevski <dejan@scylladb.com>