### PR TITLE
tools/toolchain: stop ignoring error on install-dependencies.sh, run jmx/java script correctly

### DIFF
--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -211,9 +211,9 @@ if $PRINT_NODE_EXPORTER; then
     exit 0
 fi
 
-bash seastar/install-dependencies.sh
-bash tools/jmx/install-dependencies.sh
-bash tools/java/install-dependencies.sh
+./seastar/install-dependencies.sh
+./tools/jmx/install-dependencies.sh
+./tools/java/install-dependencies.sh
 
 if [ "$ID" = "ubuntu" ] || [ "$ID" = "debian" ]; then
     apt-get -y install "${debian_base_packages[@]}"

--- a/tools/toolchain/Dockerfile
+++ b/tools/toolchain/Dockerfile
@@ -1,12 +1,14 @@
 FROM docker.io/fedora:33
 ADD ./install-dependencies.sh ./
 ADD ./seastar/install-dependencies.sh ./seastar/
+ADD ./tools/jmx/install-dependencies.sh ./tools/jmx/
+ADD ./tools/java/install-dependencies.sh ./tools/java/
 ADD ./tools/toolchain/system-auth ./
 RUN dnf -y install 'dnf-command(copr)' \
     && dnf -y install ccache \
     && dnf -y install gdb \
     && dnf -y install devscripts debhelper fakeroot file rpm-build \
-    && /bin/bash -x ./install-dependencies.sh && dnf -y update && dnf clean all \
+    && ./install-dependencies.sh && dnf -y update && dnf clean all \
     && echo 'ALL ALL=(ALL:ALL) NOPASSWD: ALL' >> /etc/sudoers \
     && cp system-auth /etc/pam.d \
     && echo 'Defaults !requiretty' >> /etc/sudoers


### PR DESCRIPTION
We should run install-dependencies.sh with -e option to prevent ignoring
error in the script.
Also, need to add tools/jmx/install-dependencies.sh and
tools/java/install-dependencies.sh, to fix 'No such file or directory'
error on them.

Fixes #8293