### PR TITLE
Alternator: add slow query logging

### DIFF
--- a/test/alternator/test_tracing.py
+++ b/test/alternator/test_tracing.py
@@ -31,6 +31,7 @@ import pytest
 import requests
 import re
 import time
+import json
 from botocore.exceptions import ClientError
 from util import random_string, full_scan, full_query, create_test_table
 
@@ -69,6 +70,46 @@ def with_tracing(dynamodb):
     response = requests.get(url+'/storage_service/trace_probability')
     if response.status_code != 200 or response.content.decode('utf-8') != '0':
         pytest.skip('Failed to verify tracing disabled')
+
+# Similarly to the fixture above, slow query logging is enabled only for the run of the
+# test function. Slow logging is set up with threshold equal to 0 microseconds,
+# which effectively means that each query will be qualified as slow and logged.
+@pytest.fixture(scope="function")
+def with_slow_query_logging(dynamodb):
+    print("with_slow_query_logging enabling slow query logging")
+    if dynamodb.meta.client._endpoint.host.endswith('.amazonaws.com'):
+        pytest.skip('Scylla-only feature not supported by AWS')
+    url = dynamodb.meta.client._endpoint.host
+    # The REST API is on port 10000, and always http, not https.
+    url = re.sub(r':[0-9]+(/|$)', ':10000', url)
+    url = re.sub(r'^https:', 'http:', url)
+    slow_query_info = requests.get(url+'/storage_service/slow_query')
+    if slow_query_info.status_code != 200:
+        pytest.skip('Failed to fetch slow query logging info')
+    slow_query_json = json.loads(slow_query_info.text)
+    print(slow_query_json)
+    response = requests.post(url+'/storage_service/slow_query?enable=true')
+    if response.status_code != 200:
+        pytest.skip('Failed to enable slow query logging')
+    response = requests.post(url+'/storage_service/slow_query?threshold=0')
+    if response.status_code != 200:
+        pytest.skip('Failed to enable slow query logging threshold')
+    # verify that logging is really enabled
+    response = requests.get(url+'/storage_service/slow_query')
+    if response.status_code != 200:
+        pytest.skip('Failed to verify slow query logging')
+    response_json = json.loads(response.text)
+    if response_json['enable'] != True or response_json['threshold'] != 0:
+        pytest.skip('Failed to verify slow query logging values')
+    print(response_json)
+    yield
+    print("with_slow_query_logging restoring slow query logging")
+    response = requests.post(url+'/storage_service/slow_query?enable='+str(slow_query_json['enable']))
+    if response.status_code != 200:
+        pytest.fail('Failed to restore slow query logging')
+    response = requests.post(url+'/storage_service/slow_query?threshold='+str(slow_query_json['threshold']))
+    if response.status_code != 200:
+        pytest.fail('Failed to restore slow query logging threshold')
 
 # Unfortunately, we currently have no way of directly finding the tracing
 # session of a specific Alternator request. We could have returned the
@@ -212,3 +253,24 @@ def test_tracing_all(with_tracing, test_table_s_isolation_always, dynamodb):
 # We could use traces to show that the right things actually happen during a
 # request. In issue #6747 we suspected that maybe GetItem doesn't read just
 # the requested item, and a tracing test can prove or disprove that hunch.
+
+def test_slow_query_log(with_slow_query_logging, test_table_s, dynamodb):
+    table = test_table_s
+    p = random_string(20)
+    print(f"Traced key: {p}")
+    table.put_item(Item={'p': p})
+    table.delete_item(Key={'p': p})
+    # Verify that the operations got logged. Each operation taking more than 0 microseconds is logged,
+    # which effectively logs all requests as slow.
+    slow_query_table = dynamodb.Table('.scylla.alternator.system_traces.node_slow_log')
+    delay = 0.2
+    while delay < 30:
+        results = full_scan(slow_query_table, ConsistentRead=False)
+        put_item_found = any("PutItem" in result['parameters'] and p in result['parameters'] for result in results)
+        delete_item_found = any("DeleteItem" in result['parameters'] and p in result['parameters'] for result in results)
+        if put_item_found and delete_item_found:
+            return
+        else:
+            time.sleep(delay)
+            delay += 1
+    pytest.fail("Slow query entries not found")

--- a/tracing/trace_state.cc
+++ b/tracing/trace_state.cc
@@ -135,6 +135,10 @@ void trace_state::add_query(sstring_view val) {
     _params_ptr->queries.emplace_back(std::move(val));
 }
 
+void trace_state::add_session_param(sstring_view key, sstring_view val) {
+    _records->session_rec.parameters.emplace(std::move(key), std::move(val));
+}
+
 void trace_state::set_user_timestamp(api::timestamp_type val) {
     _params_ptr->user_timestamp.emplace(val);
 }

--- a/tracing/trace_state.hh
+++ b/tracing/trace_state.hh
@@ -358,6 +358,16 @@ private:
     void add_query(sstring_view val);
 
     /**
+     * Store a custom session parameter.
+     * 
+     * Thus value will be stored in the params<string, string> map of a tracing session
+     * 
+     * @param key the parameter key
+     * @param val the parameter value
+     */
+    void add_session_param(sstring_view key, sstring_view val);
+
+    /**
      * Store a user provided timestamp.
      *
      * This value will eventually be stored in a params<string, string> map of a tracing session
@@ -475,6 +485,7 @@ private:
     friend void set_consistency_level(const trace_state_ptr& p, db::consistency_level val);
     friend void set_optional_serial_consistency_level(const trace_state_ptr& p, const std::optional<db::consistency_level>&val);
     friend void add_query(const trace_state_ptr& p, sstring_view val);
+    friend void add_session_param(const trace_state_ptr& p, sstring_view key, sstring_view val);
     friend void set_user_timestamp(const trace_state_ptr& p, api::timestamp_type val);
     friend void add_prepared_statement(const trace_state_ptr& p, prepared_checked_weak_ptr& prepared);
     friend void set_username(const trace_state_ptr& p, const std::optional<auth::authenticated_user>& user);
@@ -613,6 +624,12 @@ inline void set_optional_serial_consistency_level(const trace_state_ptr& p, cons
 inline void add_query(const trace_state_ptr& p, sstring_view val) {
     if (p) {
         p->add_query(std::move(val));
+    }
+}
+
+inline void add_session_param(const trace_state_ptr& p, sstring_view key, sstring_view val) {
+    if (p) {
+        p->add_session_param(std::move(key), std::move(val));
     }
 }
 


### PR DESCRIPTION
This series adds slow query logging capability to alternator. Queries which last longer than the specified threshold are logged in `system_traces.node_slow_log` and traced.

In order to be better prepared for https://github.com/scylladb/scylla/issues/2572, this series also expands the tracing API to allow custom key-value params and adds a custom `alternator_op` parameter to the slow node log. This information can also be deduced from the tracing session id by consulting the system_traces.events table, but https://github.com/scylladb/scylla/issues/2572 's assumption is that this tracing might not always be available in the future.

This series comes with a simple test case which checks if operation logs indeed end up in `system_traces.node_slow_log`.

Tests:
unit(dev, alternator pytest)
manual: verified that no operations are logged if slow query logging is disabled; verified that operations that take less time than the threshold are not logged; verified with test_batch.py::test_batch_write_item_large that a large-enough operation is indeed logged and traced.

Fixes #8292

Example trace:

```cql
cqlsh> select parameters, duration from system_traces.node_slow_log where start_time=b7a44589-8711-11eb-8053-14c6c5faf955;

 parameters                                                                                  | duration
---------------------------------------------------------------------------------------------+----------
 {'alternator_op': 'DeleteTable', 'query': '{"TableName": "alternator_Test_1615979572905"}'} |    75732
```