### PR TITLE
cql-pytest: Drop needless INSERT in test_null

### DIFF
--- a/test/cql-pytest/test_null.py
+++ b/test/cql-pytest/test_null.py
@@ -66,19 +66,17 @@ def test_insert_null_key(cql, table1):
 
 def test_primary_key_in_null(cql, table1):
     '''Tests handling of "key_column in ?" where ? is bound to null.'''
-    s = random_string()
-    cql.execute(f"INSERT INTO {table1} (p,c) VALUES ('{s}', '{s}')")
     with pytest.raises(InvalidRequest, match='null value'):
         cql.execute(cql.prepare(f"SELECT p FROM {table1} WHERE p IN ?"), [None])
     with pytest.raises(InvalidRequest, match='null value'):
-        cql.execute(cql.prepare(f"SELECT p FROM {table1} WHERE p='{s}' AND c IN ?"), [None])
+        cql.execute(cql.prepare(f"SELECT p FROM {table1} WHERE p='' AND c IN ?"), [None])
     with pytest.raises(InvalidRequest, match='Invalid null value for IN restriction'):
-        cql.execute(cql.prepare(f"SELECT p FROM {table1} WHERE p='{s}' AND (c) IN ?"), [None])
+        cql.execute(cql.prepare(f"SELECT p FROM {table1} WHERE p='' AND (c) IN ?"), [None])
 
 # Cassandra says "IN predicates on non-primary-key columns (v) is not yet supported".
 def test_regular_column_in_null(scylla_only, cql, table1):
     '''Tests handling of "regular_column in ?" where ? is bound to null.'''
-    s = random_string()
-    cql.execute(f"INSERT INTO {table1} (p,c) VALUES ('{s}', '{s}')")
+    # Without any rows in the table, SELECT will shortcircuit before evaluating the WHERE clause.
+    cql.execute(f"INSERT INTO {table1} (p,c) VALUES ('p', 'c')")
     with pytest.raises(InvalidRequest, match='null value'):
         cql.execute(cql.prepare(f"SELECT v FROM {table1} WHERE v IN ? ALLOW FILTERING"), [None])


### PR DESCRIPTION
One INSERT statement was unnecessary for the test, so delete it.
Another was necessary, so explain it.

Tests: cql-pytest/test_null on both Scylla and Cassandra

Signed-off-by: Dejan Mircevski <dejan@scylladb.com>