### PR TITLE
cql3/expr: Handle `IN ?` bound to null

### DIFF
--- a/test/cql-pytest/test_null.py
+++ b/test/cql-pytest/test_null.py
@@ -63,3 +63,20 @@ def test_insert_null_key(cql, table1):
         cql.execute(stmt, [s, None])
     with pytest.raises(InvalidRequest, match='null value'):
         cql.execute(stmt, [None, s])
+
+def test_primary_key_in_null(cql, table1):
+    '''Tests handling of "key_column in ?" where ? is bound to null.'''
+    with pytest.raises(InvalidRequest, match='null value'):
+        cql.execute(cql.prepare(f"SELECT p FROM {table1} WHERE p IN ?"), [None])
+    with pytest.raises(InvalidRequest, match='null value'):
+        cql.execute(cql.prepare(f"SELECT p FROM {table1} WHERE p='' AND c IN ?"), [None])
+    with pytest.raises(InvalidRequest, match='Invalid null value for IN restriction'):
+        cql.execute(cql.prepare(f"SELECT p FROM {table1} WHERE p='' AND (c) IN ?"), [None])
+
+# Cassandra says "IN predicates on non-primary-key columns (v) is not yet supported".
+def test_regular_column_in_null(scylla_only, cql, table1):
+    '''Tests handling of "regular_column in ?" where ? is bound to null.'''
+    # Without any rows in the table, SELECT will shortcircuit before evaluating the WHERE clause.
+    cql.execute(f"INSERT INTO {table1} (p,c) VALUES ('p', 'c')")
+    with pytest.raises(InvalidRequest, match='null value'):
+        cql.execute(cql.prepare(f"SELECT v FROM {table1} WHERE v IN ? ALLOW FILTERING"), [None])


### PR DESCRIPTION
Previously, we crashed when the IN marker is bound to null.  Throw
invalid_request_exception instead.

This is a 4.4 backport of the #8265 fix.

Tests: unit (dev)

(cherry picked from commit 8db24fc03b76915dd8ec9c5e3ccd77c05b7f384c)

Signed-off-by: Dejan Mircevski <dejan@scylladb.com>