### PR TITLE
Add partial admission control to Thrift frontend

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -1304,7 +1304,7 @@ int main(int ac, char** av) {
                 api::unset_transport_controller(ctx).get();
             });
 
-            ::thrift_controller thrift_ctl(db, auth_service, qp);
+            ::thrift_controller thrift_ctl(db, auth_service, qp, service_memory_limiter);
 
             ss.register_client_shutdown_hook("rpc server", [&thrift_ctl] {
                 thrift_ctl.stop().get();

--- a/service/memory_limiter.hh
+++ b/service/memory_limiter.hh
@@ -21,6 +21,7 @@
 
 #pragma once
 
+#include "seastarx.hh"
 #include <seastar/core/semaphore.hh>
 
 namespace service {

--- a/service_permit.hh
+++ b/service_permit.hh
@@ -29,6 +29,8 @@ class service_permit {
     service_permit(seastar::semaphore_units<>&& u) : _permit(seastar::make_lw_shared<seastar::semaphore_units<>>(std::move(u))) {}
     friend service_permit make_service_permit(seastar::semaphore_units<>&& permit);
     friend service_permit empty_service_permit();
+public:
+    size_t count() const { return _permit ? _permit->count() : 0; };
 };
 
 inline service_permit make_service_permit(seastar::semaphore_units<>&& permit) {

--- a/thrift/controller.hh
+++ b/thrift/controller.hh
@@ -24,6 +24,7 @@
 #include <seastar/core/semaphore.hh>
 #include <seastar/core/distributed.hh>
 #include <seastar/core/future.hh>
+#include "service/memory_limiter.hh"
 
 using namespace seastar;
 
@@ -40,12 +41,13 @@ class thrift_controller {
     distributed<database>& _db;
     sharded<auth::service>& _auth_service;
     sharded<cql3::query_processor>& _qp;
+    sharded<service::memory_limiter>& _mem_limiter;
 
     future<> do_start_server();
     future<> do_stop_server();
 
 public:
-    thrift_controller(distributed<database>&, sharded<auth::service>&, sharded<cql3::query_processor>&);
+    thrift_controller(distributed<database>&, sharded<auth::service>&, sharded<cql3::query_processor>&, sharded<service::memory_limiter>&);
     future<> start_server();
     future<> stop_server();
     future<> stop();

--- a/thrift/handler.hh
+++ b/thrift/handler.hh
@@ -31,6 +31,6 @@
 
 struct timeout_config;
 
-std::unique_ptr<::cassandra::CassandraCobSvIfFactory> create_handler_factory(distributed<database>& db, distributed<cql3::query_processor>& qp, auth::service&, timeout_config);
+std::unique_ptr<::cassandra::CassandraCobSvIfFactory> create_handler_factory(distributed<database>& db, distributed<cql3::query_processor>& qp, auth::service&, timeout_config, service_permit& current_permit);
 
 #endif /* APPS_SEASTAR_THRIFT_HANDLER_HH_ */

--- a/thrift/server.hh
+++ b/thrift/server.hh
@@ -31,6 +31,7 @@
 #include <memory>
 #include <cstdint>
 #include <boost/intrusive/list.hpp>
+#include "database.hh"
 
 class thrift_server;
 class thrift_stats;
@@ -119,6 +120,8 @@ private:
     uint64_t _requests_serving = 0;
     uint64_t _requests_blocked_memory = 0;
     semaphore& _memory_available;
+    utils::updateable_value<uint32_t> _max_concurrent_requests;
+    size_t _requests_shed;
     thrift_server_config _config;
     boost::intrusive::list<connection> _connections_list;
     seastar::gate _stop_gate;
@@ -135,6 +138,7 @@ public:
     size_t max_request_size() const;
     const semaphore& memory_available() const;
     uint64_t requests_blocked_memory() const;
+    uint64_t requests_shed() const;
 
 private:
     void maybe_retry_accept(int which, bool keepalive, std::exception_ptr ex);

--- a/thrift/server.hh
+++ b/thrift/server.hh
@@ -116,6 +116,7 @@ private:
     uint64_t _total_connections = 0;
     uint64_t _current_connections = 0;
     uint64_t _requests_served = 0;
+    uint64_t _requests_blocked_memory = 0;
     semaphore& _memory_available;
     thrift_server_config _config;
     boost::intrusive::list<connection> _connections_list;
@@ -131,6 +132,7 @@ public:
     uint64_t requests_served() const;
     size_t max_request_size() const;
     const semaphore& memory_available() const;
+    uint64_t requests_blocked_memory() const;
 
 private:
     void maybe_retry_accept(int which, bool keepalive, std::exception_ptr ex);

--- a/thrift/server.hh
+++ b/thrift/server.hh
@@ -116,6 +116,7 @@ private:
     uint64_t _total_connections = 0;
     uint64_t _current_connections = 0;
     uint64_t _requests_served = 0;
+    uint64_t _requests_serving = 0;
     uint64_t _requests_blocked_memory = 0;
     semaphore& _memory_available;
     thrift_server_config _config;
@@ -130,6 +131,7 @@ public:
     uint64_t total_connections() const;
     uint64_t current_connections() const;
     uint64_t requests_served() const;
+    uint64_t requests_serving() const;
     size_t max_request_size() const;
     const semaphore& memory_available() const;
     uint64_t requests_blocked_memory() const;


### PR DESCRIPTION
This pull request adds partial admission control to Thrift frontend. The solution is partial mostly because the Thrift layer, aside from allowing Thrift messages, may also be used as a base protocol for CQL messages. Coupling admission control to this one is a little bit more complicated due to how the layer currently works - a Thrift handler, created once per connection, keeps a local `query_state` instance for the occasion of handling CQL requests. However, `query_state` should be kept per query, not per connection, so adding admission control to this aspect of the frontend is left for later.

Finally, the way service permits are passed from the server, via the handler factory, handler and then to queries is hacky. I haven't figured out how to force Thrift to pass custom context per query, so the way it works now is by relying on the fact that the server does not yield (in Seastar sense) between having read the request and launching the proper handler. Due to that, it's possible to just store the service permit in the server itself, pass the reference (address) to it down to the handler, and then read it back from the handling code and claim ownership of it. It works, but if anyone has a better idea, please share.

Refs #4826