### PR TITLE
sstables: convert enable_if to equivalent concepts

### DIFF
--- a/sstables/m_format_read_helpers.hh
+++ b/sstables/m_format_read_helpers.hh
@@ -23,6 +23,7 @@
 
 #include <limits>
 #include <type_traits>
+#include <concepts>
 #include <seastar/core/future.hh>
 #include "gc_clock.hh"
 #include "timestamp.hh"
@@ -40,13 +41,8 @@ class random_access_reader;
 future<uint64_t> read_unsigned_vint(random_access_reader& in);
 future<int64_t> read_signed_vint(random_access_reader& in);
 
-template <typename T>
-typename std::enable_if_t<!std::is_integral_v<T>>
-read_vint(random_access_reader& in, T& t) = delete;
-
-template <typename T>
+template <std::integral T>
 inline future<> read_vint(random_access_reader& in, T& value) {
-    static_assert(std::is_integral_v<T>, "Non-integral values can't be read using read_vint");
     if constexpr(std::is_unsigned_v<T>) {
         return read_unsigned_vint(in).then([&value] (uint64_t res) {
             value = res;

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -332,7 +332,7 @@ future<> parse(const schema& s, sstable_version_types v, random_access_reader& i
 // to do is to convert each member because they are all stored big endian.
 // We'll offer a specialization for that case below.
 template <typename Size, typename Members>
-typename std::enable_if_t<!std::is_integral<Members>::value, future<>>
+future<>
 parse(const schema& s, sstable_version_types v, random_access_reader& in, Size& len, utils::chunked_vector<Members>& arr) {
 
     auto count = make_lw_shared<size_t>(0);
@@ -345,8 +345,8 @@ parse(const schema& s, sstable_version_types v, random_access_reader& in, Size& 
     });
 }
 
-template <typename Size, typename Members>
-typename std::enable_if_t<std::is_integral<Members>::value, future<>>
+template <typename Size, std::integral Members>
+future<>
 parse(const schema&, sstable_version_types, random_access_reader& in, Size& len, utils::chunked_vector<Members>& arr) {
     auto done = make_lw_shared<size_t>(0);
     return repeat([&in, &len, &arr, done]  {

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -267,8 +267,8 @@ future<> parse(const schema& s, sstable_version_types v, random_access_reader& i
 }
 
 // Intended to be used for a type that describes itself through describe_type().
-template <class T>
-typename std::enable_if_t<!std::is_integral<T>::value && !std::is_enum<T>::value, future<>>
+template <self_describing T>
+future<>
 parse(const schema& s, sstable_version_types v, random_access_reader& in, T& t) {
     return t.describe_type(v, [v, &s, &in] (auto&&... what) -> future<> {
         return parse(s, v, in, what...);

--- a/sstables/types.hh
+++ b/sstables/types.hh
@@ -256,9 +256,8 @@ struct metadata {
 template <typename T>
 uint64_t serialized_size(sstable_version_types v, const T& object);
 
-template <class T, typename W>
-requires Writer<W>
-typename std::enable_if_t<!std::is_integral<T>::value && !std::is_enum<T>::value, void>
+template <self_describing T, Writer W>
+void
 write(sstable_version_types v, W& out, const T& t);
 
 // serialized_size() implementation for metadata class

--- a/sstables/writer.hh
+++ b/sstables/writer.hh
@@ -246,15 +246,8 @@ void write_signed_vint(W& out, int64_t value) {
     return write_vint_impl(out, value);
 }
 
-template <typename T, typename W>
-requires Writer<W>
-typename std::enable_if_t<!std::is_integral_v<T>>
-write_vint(W& out, T t) = delete;
-
-template <typename T, typename W>
-requires Writer<W>
+template <std::integral T, Writer W>
 inline void write_vint(W& out, T value) {
-    static_assert(std::is_integral_v<T>, "Non-integral values can't be written using write_vint");
     return std::is_unsigned_v<T> ? write_unsigned_vint(out, value) : write_signed_vint(out, value);
 }
 

--- a/sstables/writer.hh
+++ b/sstables/writer.hh
@@ -369,15 +369,15 @@ inline void write(sstable_version_types ver, file_writer& out, const disk_data_v
 }
 
 template <typename Members>
-inline typename std::enable_if_t<!std::is_integral<Members>::value, void>
+inline void
 write(sstable_version_types v, file_writer& out, const utils::chunked_vector<Members>& arr) {
     for (auto& a : arr) {
         write(v, out, a);
     }
 }
 
-template <typename Members>
-inline typename std::enable_if_t<std::is_integral<Members>::value, void>
+template <std::integral Members>
+inline void
 write(sstable_version_types v, file_writer& out, const utils::chunked_vector<Members>& arr) {
     std::vector<Members> tmp;
     size_t per_loop = 100000 / sizeof(Members);

--- a/sstables/writer.hh
+++ b/sstables/writer.hh
@@ -328,9 +328,8 @@ write(sstable_version_types v, W& out, const T& t) {
     });
 }
 
-template <typename T, typename U>
+template <std::integral T, std::integral U>
 void check_truncate_and_assign(T& to, const U from) {
-    static_assert(std::is_integral<T>::value && std::is_integral<U>::value, "T and U must be integral");
     to = from;
     if (to != from) {
         throw std::overflow_error("assigning U to T caused an overflow");


### PR DESCRIPTION
enable_if is hard to understand, especially its error messages. Convert
enable_if in sstable code to concepts.

A new concept is introduced, self_describing, for the case of a type
that follows the obj.describe_type() protocol. Otherwise this is quite
straightforward.
