### PR TITLE
types: Unreverse tuple subtype for serialization

### DIFF
--- a/test/cql-pytest/cassandra_tests/validation/entities/frozen_collections_test.py
+++ b/test/cql-pytest/cassandra_tests/validation/entities/frozen_collections_test.py
@@ -440,7 +440,6 @@ def testNestedClusteringKeyUsage(cql, test_keyspace):
         )
 
 # Reproduces issue #7868 and #7902
-@pytest.mark.xfail(reason="fails because of issue #7902")
 def testNestedClusteringKeyUsageWithReverseOrder(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a int, b frozen<map<set<int>, list<int>>>, c frozen<set<int>>, d int, PRIMARY KEY (a, b, c)) WITH CLUSTERING ORDER BY (b DESC)") as table:
         execute(cql, table, "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)", 0, {}, set(), 0)

--- a/types.cc
+++ b/types.cc
@@ -1620,10 +1620,10 @@ static void serialize_aux(const tuple_type_impl& type, const tuple_type_impl::na
     assert(elems.size() <= type.size());
 
     for (size_t i = 0; i < elems.size(); ++i) {
-        const data_type& t = type.type(i);
+        const abstract_type& t = type.type(i)->without_reversed();
         const data_value& v = elems[i];
-        if (!v.is_null() && t != v.type()) {
-            throw std::runtime_error(format("tuple element type mismatch: expected {}, got {}", t->name(), v.type()->name()));
+        if (!v.is_null() && t != *v.type()) {
+            throw std::runtime_error(format("tuple element type mismatch: expected {}, got {}", t.name(), v.type()->name()));
         }
 
         if (v.is_null()) {


### PR DESCRIPTION
When a tuple value is serialized, we go through every element type and
use it to serialize element values.  But an element type can be
reversed, which is artificially different from the type of the value
being read.  This results in a server error due to the type mismatch.
Fix it by unreversing the element type prior to comparing it to the
value type.

Fixes #7902

Tests: unit (dev)

Signed-off-by: Dejan Mircevski <dejan@scylladb.com>