### PR TITLE
Fix the retry mechanism in Thrift frontend

### DIFF
--- a/thrift/server.hh
+++ b/thrift/server.hh
@@ -121,7 +121,7 @@ public:
     ~thrift_server();
     future<> listen(socket_address addr, bool keepalive);
     future<> stop();
-    void do_accepts(int which, bool keepalive);
+    void do_accepts(int which, bool keepalive, int num_attempts);
     uint64_t total_connections() const;
     uint64_t current_connections() const;
     uint64_t requests_served() const;

--- a/thrift/server.hh
+++ b/thrift/server.hh
@@ -125,9 +125,6 @@ public:
     uint64_t total_connections() const;
     uint64_t current_connections() const;
     uint64_t requests_served() const;
-
-private:
-    void maybe_retry_accept(int which, bool keepalive, std::exception_ptr ex);
 };
 
 #endif /* APPS_SEASTAR_THRIFT_SERVER_HH_ */


### PR DESCRIPTION
Thrift used to be quite unsafe with regard to its retry mechanism, which caused very rapid use of resources, namely the number of file descriptors. It was also prone to use-after-free due to spawning futures without guarding the captured objects with anything.
The mechanism is now cleaned up, and a simple exponential backoff replaced previous constant backoff policy.

Fixes #8317
Tests: unit(dev), manual(see #8317 for a simple reproducer)