### PR TITLE
keys: convert trichotomic comparators to return std::strong_ordering

### DIFF
--- a/cql3/update_parameters.hh
+++ b/cql3/update_parameters.hh
@@ -79,11 +79,11 @@ public:
                 : pk_cmp(s)
                 , ck_cmp(s)
             { }
-            int tri_compare(const partition_key& pk1, const clustering_key& ck1,
+            std::strong_ordering tri_compare(const partition_key& pk1, const clustering_key& ck1,
                     const partition_key& pk2, const clustering_key& ck2) const {
 
-                int rc = pk_cmp(pk1, pk2);
-                return rc ? rc : ck_cmp(ck1, ck2);
+                std::strong_ordering rc = pk_cmp(pk1, pk2);
+                return rc != 0 ? rc : ck_cmp(ck1, ck2) <=> 0;
             }
             // Allow mixing std::pair<partition_key, clustering_key> and
             // std::pair<const partition_key&, const clustering_key&> during lookup

--- a/dht/i_partitioner.cc
+++ b/dht/i_partitioner.cc
@@ -302,8 +302,8 @@ std::strong_ordering ring_position_tri_compare(const schema& s, ring_position_vi
     }
     if (lh._key && rh._key) {
         auto c = lh._key->legacy_tri_compare(s, *rh._key);
-        if (c) {
-            return c <=> 0;
+        if (c != 0) {
+            return c;
         }
         return (lh._weight - rh._weight) <=> 0;
     }

--- a/keys.cc
+++ b/keys.cc
@@ -74,18 +74,18 @@ partition_key_view::legacy_form(const schema& s) const {
     return { *get_compound_type(s), _bytes };
 }
 
-int
+std::strong_ordering
 partition_key_view::legacy_tri_compare(const schema& s, partition_key_view o) const {
     auto cmp = legacy_compound_view<c_type>::tri_comparator(*get_compound_type(s));
-    return cmp(this->representation(), o.representation());
+    return cmp(this->representation(), o.representation()) <=> 0;
 }
 
-int
+std::strong_ordering
 partition_key_view::ring_order_tri_compare(const schema& s, partition_key_view k2) const {
     auto t1 = dht::get_token(s, *this);
     auto t2 = dht::get_token(s, k2);
     if (t1 != t2) {
-        return t1 < t2 ? -1 : 1;
+        return t1 < t2 ? std::strong_ordering::less : std::strong_ordering::greater;
     }
     return legacy_tri_compare(s, k2);
 }

--- a/keys.hh
+++ b/keys.hh
@@ -28,6 +28,7 @@
 #include "hashing.hh"
 #include "database_fwd.hh"
 #include "schema_fwd.hh"
+#include <compare>
 
 //
 // This header defines type system for primary key holders.
@@ -84,8 +85,8 @@ public:
     struct tri_compare {
         typename TopLevelView::compound _t;
         tri_compare(const schema &s) : _t(get_compound_type(s)) {}
-        int operator()(const TopLevelView& k1, const TopLevelView& k2) const {
-            return _t->compare(k1.representation(), k2.representation());
+        std::strong_ordering operator()(const TopLevelView& k1, const TopLevelView& k2) const {
+            return _t->compare(k1.representation(), k2.representation()) <=> 0;
         }
     };
 
@@ -244,14 +245,14 @@ public:
     struct tri_compare {
         typename TopLevel::compound _t;
         tri_compare(const schema& s) : _t(get_compound_type(s)) {}
-        int operator()(const TopLevel& k1, const TopLevel& k2) const {
-            return _t->compare(k1.representation(), k2.representation());
+        std::strong_ordering operator()(const TopLevel& k1, const TopLevel& k2) const {
+            return _t->compare(k1.representation(), k2.representation()) <=> 0;
         }
-        int operator()(const TopLevelView& k1, const TopLevel& k2) const {
-            return _t->compare(k1.representation(), k2.representation());
+        std::strong_ordering operator()(const TopLevelView& k1, const TopLevel& k2) const {
+            return _t->compare(k1.representation(), k2.representation()) <=> 0;
         }
-        int operator()(const TopLevel& k1, const TopLevelView& k2) const {
-            return _t->compare(k1.representation(), k2.representation());
+        std::strong_ordering operator()(const TopLevel& k1, const TopLevelView& k2) const {
+            return _t->compare(k1.representation(), k2.representation()) <=> 0;
         }
     };
 
@@ -609,11 +610,11 @@ public:
             : prefix_type(TopLevel::get_compound_type(s))
         { }
 
-        int operator()(const TopLevel& k1, const TopLevel& k2) const {
+        std::strong_ordering operator()(const TopLevel& k1, const TopLevel& k2) const {
             return prefix_equality_tri_compare(prefix_type->types().begin(),
                 prefix_type->begin(k1.representation()), prefix_type->end(k1.representation()),
                 prefix_type->begin(k2.representation()), prefix_type->end(k2.representation()),
-                tri_compare);
+                tri_compare) <=> 0;
         }
     };
 };
@@ -641,7 +642,7 @@ public:
     const legacy_compound_view<c_type> legacy_form(const schema& s) const;
 
     // A trichotomic comparator for ordering compatible with Origin.
-    int legacy_tri_compare(const schema& s, partition_key_view o) const;
+    std::strong_ordering legacy_tri_compare(const schema& s, partition_key_view o) const;
 
     // Checks if keys are equal in a way which is compatible with Origin.
     bool legacy_equal(const schema& s, partition_key_view o) const {
@@ -653,7 +654,7 @@ public:
     }
 
     // A trichotomic comparator which orders keys according to their ordering on the ring.
-    int ring_order_tri_compare(const schema& s, partition_key_view o) const;
+    std::strong_ordering ring_order_tri_compare(const schema& s, partition_key_view o) const;
 
     friend std::ostream& operator<<(std::ostream& out, const partition_key_view& pk);
 };
@@ -717,7 +718,7 @@ public:
     }
 
     // A trichotomic comparator for ordering compatible with Origin.
-    int legacy_tri_compare(const schema& s, const partition_key& o) const {
+    std::strong_ordering legacy_tri_compare(const schema& s, const partition_key& o) const {
         return view().legacy_tri_compare(s, o);
     }
 

--- a/test/boost/test_table.cc
+++ b/test/boost/test_table.cc
@@ -248,7 +248,7 @@ public:
         if (!a.start() || !b.start()) {
             return !a.start();
         }
-        if (auto res = _tri_cmp(a.start()->value(), b.start()->value())) {
+        if (auto res = _tri_cmp(a.start()->value(), b.start()->value()); res != 0) {
             return res < 0;
         }
         return a.start()->is_inclusive() < b.start()->is_inclusive();


### PR DESCRIPTION
A trichotomic comparator returning an int an easily be mistaken
for a less comparator as the return types are convertible.

Use the new std::strong_ordering instead.

A caller in cql3's update_parameters.hh is also converted, following
the path of least resistance.

Ref #1449.

Test: unit (dev)