### PR TITLE
Disable thrift by default

### DIFF
--- a/db/config.cc
+++ b/db/config.cc
@@ -564,7 +564,7 @@ db::config::config(std::shared_ptr<db::extensions> exts)
         "RPC address to broadcast to drivers and other Scylla nodes. This cannot be set to 0.0.0.0. If blank, it is set to the value of the rpc_address or rpc_interface. If rpc_address or rpc_interfaceis set to 0.0.0.0, this property must be set.\n")
     , rpc_port(this, "rpc_port", "thrift_port", value_status::Used, 9160,
         "Thrift port for client connections.")
-    , start_rpc(this, "start_rpc", value_status::Used, true,
+    , start_rpc(this, "start_rpc", value_status::Used, false,
         "Starts the Thrift RPC server")
     , rpc_keepalive(this, "rpc_keepalive", value_status::Used, true,
         "Enable or disable keepalive on client connections (RPC or native).")

--- a/docs/design-notes/protocols.md
+++ b/docs/design-notes/protocols.md
@@ -166,9 +166,13 @@ but was recently dropped in Cassandra (version 4.0) and is likely to be
 dropped by Scylla in the future as well, so it is not recommended for new
 applications.
 
-By default scylla listens to the Thrift protocol on port 9160, which can be
-configured via the `rpc_port` configuration option. Again, this confusing name
-was used for backward-compatibility with Cassandra's configuration files.
+By default, Scylla does not enable the Thrift server. In order to use it,
+it must be explicitly enabled by setting the `start_rpc` configuration option
+to true.
+
+When Thrift is enabled, by default scylla listens to the Thrift protocol on port 9160,
+which can be configured via the `rpc_port` configuration option. Again, this confusing
+name was used for backward-compatibility with Cassandra's configuration files.
 Cassandra used the term "rpc" because Apache Thrift is a remote procedure
 call (RPC) framework. In Scylla, this name is especially confusing, because
 as mentioned above, Scylla's internal communication protocol is based on


### PR DESCRIPTION
The Thrift layer is functional, but it's not usually the first-choice protocol for Scylla users, so it's hereby disabled by default.

Fixes #8336