### PR TITLE
scylla_ntp_setup: support systemd-timesyncd

### DIFF
--- a/dist/common/scripts/scylla_ntp_setup
+++ b/dist/common/scripts/scylla_ntp_setup
@@ -40,24 +40,29 @@ if __name__ == '__main__':
                         help='specify subdomain of pool.ntp.org (ex: centos, fedora or amazon)')
     args = parser.parse_args()
 
-    if shutil.which('ntpd'):
-        pkg_uninstall('ntp')
-    if not shutil.which('chronyd'):
-        pkg_install('chrony')
-    if is_debian_variant():
-        confpath = '/etc/chrony/chrony.conf'
-        chronyd = 'chrony.service'
+    # use systemd-timesyncd
+    if systemd_unit.available('systemd-timesyncd'):
+        run('timedatectl set-ntp true', shell=True, check=True)
+    # use chrony
     else:
-        confpath = '/etc/chrony.conf'
-        chronyd = 'chronyd.service'
-    with open(confpath) as f:
-        conf = f.read()
-    if args.subdomain:
-        conf2 = re.sub(r'pool\s+([0-9]+)\.(\S+)\.pool\.ntp\.org', 'pool \\1.{}.pool.ntp.org'.format(args.subdomain), conf, flags=re.MULTILINE)
-        with open(confpath, 'w') as f:
-            f.write(conf2)
-        conf = conf2
-    chronyd = systemd_unit(chronyd)
-    chronyd.enable()
-    chronyd.restart()
-    run('chronyc -a makestep', shell=True, check=True)
+        if shutil.which('ntpd'):
+            pkg_uninstall('ntp')
+        if not shutil.which('chronyd'):
+            pkg_install('chrony')
+        if is_debian_variant():
+            confpath = '/etc/chrony/chrony.conf'
+            chronyd = 'chrony.service'
+        else:
+            confpath = '/etc/chrony.conf'
+            chronyd = 'chronyd.service'
+        with open(confpath) as f:
+            conf = f.read()
+        if args.subdomain:
+            conf2 = re.sub(r'pool\s+([0-9]+)\.(\S+)\.pool\.ntp\.org', 'pool \\1.{}.pool.ntp.org'.format(args.subdomain), conf, flags=re.MULTILINE)
+            with open(confpath, 'w') as f:
+                f.write(conf2)
+            conf = conf2
+        chronyd = systemd_unit(chronyd)
+        chronyd.enable()
+        chronyd.restart()
+        run('chronyc -a makestep', shell=True, check=True)

--- a/dist/common/scripts/scylla_util.py
+++ b/dist/common/scripts/scylla_util.py
@@ -811,6 +811,12 @@ class systemd_unit:
     def reload(cls):
         run('systemctl daemon-reload', shell=True, check=True)
 
+    @classmethod
+    def available(cls, unit):
+        res = run('systemctl cat {}'.format(unit), shell=True, check=True, stdout=DEVNULL, stderr=DEVNULL)
+        return True if res.returncode == 0 else False
+
+
 class sysconfig_parser:
     def __load(self):
         f = io.StringIO('[global]\n{}'.format(self._data))


### PR DESCRIPTION
On Ubuntu/Debian systemd-timesyncd is default NTP client, and installed
by default.
So use it instead of installing chrony.

Fixes #8339