### PR TITLE
tests: use kernel page cache

### DIFF
--- a/test.py
+++ b/test.py
@@ -255,7 +255,7 @@ class Test:
 
 
 class UnitTest(Test):
-    standard_args = shlex.split("--overprovisioned --unsafe-bypass-fsync 1 --blocked-reactor-notify-ms 2000000 --collectd 0")
+    standard_args = shlex.split("--overprovisioned --unsafe-bypass-fsync 1 --kernel-page-cache 1 --blocked-reactor-notify-ms 2000000 --collectd 0")
 
     def __init__(self, test_no, shortname, args, suite, mode, options):
         super().__init__(test_no, shortname, suite, mode, options)

--- a/test/alternator/run
+++ b/test/alternator/run
@@ -90,7 +90,7 @@ ln -s "$SCYLLA" "$SCYLLA_LINK"
         --experimental-features=alternator-streams \
         --ring-delay-ms 0 --collectd 0 \
         --smp 2 -m 1G \
-        --overprovisioned --unsafe-bypass-fsync 1 \
+        --overprovisioned --unsafe-bypass-fsync 1 --kernel-page-cache 1 \
         --api-address $SCYLLA_IP \
         --rpc-address $SCYLLA_IP \
         --listen-address $SCYLLA_IP \

--- a/test/cql-pytest/run.py
+++ b/test/cql-pytest/run.py
@@ -172,6 +172,7 @@ def run_scylla_cmd(pid, dir):
         '-m', '1G',
         '--overprovisioned',
         '--unsafe-bypass-fsync', '1',
+        '--kernel-page-cache', '1',
         '--api-address', ip,
         '--rpc-address', ip,
         '--listen-address', ip,

--- a/test/redis/run
+++ b/test/redis/run
@@ -69,7 +69,7 @@ ln -s "$SCYLLA" "$SCYLLA_LINK"
         --experimental-features=cdc \
         --ring-delay-ms 0 --collectd 0 \
         --smp 2 -m 1G \
-        --overprovisioned --unsafe-bypass-fsync 1 \
+        --overprovisioned --unsafe-bypass-fsync 1 --kernel-page-cache 1 \
         --api-address $SCYLLA_IP \
         --rpc-address $SCYLLA_IP \
         --listen-address $SCYLLA_IP \


### PR DESCRIPTION
Tests are short-lived and use a small amount of data. They
are also often run repeatly, and the data is deleted immediately
after the test. This is a good scenario for using the kernel page
cache, as it can cache read-only data from test to test, and avoid
spilling write data to disk if it is deleted quickly.

Acknowledge this by using the new --kernel-page-cache option for
tests.

This is expected to help on large machines, where the disk can be
overloaded. Smaller machines with NVMe disks probably will not see
a difference.