### PR TITLE
tools: toolchain: dbuild: improve cgroupv2 detection code

### DIFF
--- a/tools/toolchain/dbuild
+++ b/tools/toolchain/dbuild
@@ -156,7 +156,7 @@ else
     # --pids-limit is not supported on podman with cgroupsv1
     # detection code from
     #   https://unix.stackexchange.com/questions/617764/how-do-i-check-if-system-is-using-cgroupv1
-    if grep -q 'cgroup2.*/sys/fs/cgroup' /proc/mounts; then
+    if grep -q 'cgroup2.*/sys/fs/cgroup ' /proc/mounts; then
         docker_common_args+=(
             --pids-limit -1
             --annotation run.oci.keep_original_groups=1


### PR DESCRIPTION
dbuild detects if the kernel is using cgroupv2 by checking if the
cgroup2 filesystem is mounted on /sys/fs/cgroup. However, on Ubuntu
20.10, the cgroup filesystem is mounted on /sys/fs/cgroup and the
cgroup2 filesystem is mounted on /sys/fs/cgroup/unified. This second
mount matches the search expression and gives a false positive.

Fix by adding a space at the end; this will fail to match
/sys/fs/cgroup/unified.