### PR TITLE
types: remove linearization from abstract_type::compare

### DIFF
--- a/cql3/selection/field_selector.hh
+++ b/cql3/selection/field_selector.hh
@@ -97,7 +97,7 @@ public:
         if (!value) {
             return std::nullopt;
         }
-        auto&& buffers = _type->split(*value);
+        auto&& buffers = _type->split(single_fragmented_view(*value));
         bytes_opt ret;
         if (_field < buffers.size() && buffers[_field]) {
             ret = to_bytes(*buffers[_field]);

--- a/cql3/tuples.cc
+++ b/cql3/tuples.cc
@@ -92,7 +92,7 @@ tuples::in_value::from_serialized(const fragmented_temporary_buffer::view& value
         std::vector<std::vector<bytes_opt>> elements;
         elements.reserve(l.size());
         for (auto&& e : l) {
-            elements.emplace_back(to_bytes_opt_vec(ttype->split(ttype->decompose(e))));
+            elements.emplace_back(ttype->split(single_fragmented_view(ttype->decompose(e))));
         }
         return tuples::in_value(elements);
     } catch (marshal_exception& e) {

--- a/cql3/tuples.hh
+++ b/cql3/tuples.hh
@@ -117,9 +117,7 @@ public:
             : value(to_bytes_opt_vec(std::move(elements))) {
         }
         static value from_serialized(const fragmented_temporary_buffer::view& buffer, const tuple_type_impl& type) {
-          return with_linearized(buffer, [&] (bytes_view view) {
-              return value(type.split(view));
-          });
+            return value(type.split(buffer));
         }
         virtual cql3::raw_value get(const query_options& options) override {
             return cql3::raw_value::make_value(tuple_type_impl::build_value(_elements));

--- a/cql3/type_json.cc
+++ b/cql3/type_json.cc
@@ -334,7 +334,8 @@ static sstring to_json_string_aux(const set_type_impl& t, bytes_view bv) {
     bool first = true;
     auto sf = cql_serialization_format::internal();
     out << '[';
-    std::for_each(llpdi::begin(bv, sf), llpdi::end(bv, sf), [&first, &out, &t] (bytes_view e) {
+    managed_bytes_view mbv(bv);
+    std::for_each(llpdi::begin(mbv, sf), llpdi::end(mbv, sf), [&first, &out, &t] (const managed_bytes_view& e) {
         if (first) {
             first = false;
         } else {
@@ -352,7 +353,8 @@ static sstring to_json_string_aux(const list_type_impl& t, bytes_view bv) {
     bool first = true;
     auto sf = cql_serialization_format::internal();
     out << '[';
-    std::for_each(llpdi::begin(bv, sf), llpdi::end(bv, sf), [&first, &out, &t] (bytes_view e) {
+    managed_bytes_view mbv(bv);
+    std::for_each(llpdi::begin(mbv, sf), llpdi::end(mbv, sf), [&first, &out, &t] (const managed_bytes_view& e) {
         if (first) {
             first = false;
         } else {

--- a/cql3/type_json.cc
+++ b/cql3/type_json.cc
@@ -29,6 +29,7 @@
 #include "types/tuple.hh"
 #include "types/user.hh"
 #include "types/listlike_partial_deserializing_iterator.hh"
+#include "utils/managed_bytes.hh"
 
 static inline bool is_control_char(char c) {
     return c >= 0 && c <= 0x1F;
@@ -475,4 +476,8 @@ struct to_json_string_visitor {
 
 sstring to_json_string(const abstract_type& t, bytes_view bv) {
     return visit(t, to_json_string_visitor{bv});
+}
+
+sstring to_json_string(const abstract_type& t, const managed_bytes_view& mbv) {
+    return visit(t, to_json_string_visitor{linearized(mbv)});
 }

--- a/cql3/type_json.hh
+++ b/cql3/type_json.hh
@@ -26,6 +26,8 @@
 
 bytes from_json_object(const abstract_type &t, const rjson::value& value, cql_serialization_format sf);
 sstring to_json_string(const abstract_type &t, bytes_view bv);
+sstring to_json_string(const abstract_type &t, const managed_bytes_view& bv);
+
 inline sstring to_json_string(const abstract_type &t, const bytes& b) {
     return to_json_string(t, bytes_view(b));
 }

--- a/cql3/user_types.cc
+++ b/cql3/user_types.cc
@@ -155,15 +155,12 @@ user_types::value::value(std::vector<bytes_view_opt> elements)
 }
 
 user_types::value user_types::value::from_serialized(const fragmented_temporary_buffer::view& v, const user_type_impl& type) {
-    return with_linearized(v, [&] (bytes_view val) {
-        auto elements = type.split(val);
-        if (elements.size() > type.size()) {
-            throw exceptions::invalid_request_exception(
-                    format("User Defined Type value contained too many fields (expected {}, got {})", type.size(), elements.size()));
-        }
-
-        return value(elements);
-    });
+    auto elements = type.split(v);
+    if (elements.size() > type.size()) {
+        throw exceptions::invalid_request_exception(
+                format("User Defined Type value contained too many fields (expected {}, got {})", type.size(), elements.size()));
+    }
+    return value(elements);
 }
 
 cql3::raw_value user_types::value::get(const query_options&) {

--- a/types.cc
+++ b/types.cc
@@ -53,6 +53,8 @@
 #include "utils/date.h"
 #include "utils/utf8.hh"
 #include "utils/ascii.hh"
+#include "utils/fragment_range.hh"
+#include "utils/managed_bytes.hh"
 #include "mutation_partition.hh"
 
 #include "types/user.hh"
@@ -3148,6 +3150,11 @@ bytes serialize_field_index(size_t idx) {
 size_t deserialize_field_index(const bytes_view& b) {
     assert(b.size() == sizeof(int16_t));
     return read_be<int16_t>(reinterpret_cast<const char*>(b.data()));
+}
+
+size_t deserialize_field_index(managed_bytes_view b) {
+    assert(b.size_bytes() == sizeof(int16_t));
+    return be_to_cpu(read_simple_native<int16_t>(b));
 }
 
 thread_local const shared_ptr<const abstract_type> byte_type(make_shared<byte_type_impl>());

--- a/types.cc
+++ b/types.cc
@@ -632,15 +632,6 @@ size_t collection_value_len(cql_serialization_format sf) {
 }
 
 
-template <FragmentedView View>
-int read_collection_size(View& in, cql_serialization_format sf) {
-    if (sf.using_32_bits_for_collections()) {
-        return read_simple<int32_t>(in);
-    } else {
-        return read_simple<uint16_t>(in);
-    }
-}
-
 int read_collection_size(bytes_view& in, cql_serialization_format sf) {
     if (sf.using_32_bits_for_collections()) {
         return read_simple<int32_t>(in);
@@ -655,12 +646,6 @@ void write_collection_size(bytes::iterator& out, int size, cql_serialization_for
     } else {
         serialize_int16(out, uint16_t(size));
     }
-}
-
-template <FragmentedView View>
-View read_collection_value(View& in, cql_serialization_format sf) {
-    auto size = sf.using_32_bits_for_collections() ? read_simple<int32_t>(in) : read_simple<uint16_t>(in);
-    return read_simple_bytes(in, size);
 }
 
 bytes_view read_collection_value(bytes_view& in, cql_serialization_format sf) {

--- a/types.cc
+++ b/types.cc
@@ -2250,11 +2250,6 @@ bool abstract_type::equal(managed_bytes_view v1, managed_bytes_view v2) const {
     });
 }
 
-std::vector<bytes_view_opt>
-tuple_type_impl::split(bytes_view v) const {
-    return { tuple_deserializing_iterator::start(v), tuple_deserializing_iterator::finish(v) };
-}
-
 // Count number of ':' which are not preceded by '\'.
 static std::size_t count_segments(sstring_view v) {
     std::size_t segment_count = 1;

--- a/types.hh
+++ b/types.hh
@@ -714,6 +714,7 @@ inline bool operator!=(const data_value& x, const data_value& y)
 }
 
 using bytes_view_opt = std::optional<bytes_view>;
+using managed_bytes_view_opt = std::optional<managed_bytes_view>;
 
 static inline
 bool optional_less_compare(data_type t, bytes_view_opt e1, bytes_view_opt e2) {
@@ -749,7 +750,7 @@ int tri_compare(data_type t, managed_bytes_view e1, managed_bytes_view e2) {
 
 inline
 int
-tri_compare_opt(data_type t, bytes_view_opt v1, bytes_view_opt v2) {
+tri_compare_opt(data_type t, managed_bytes_view_opt v1, managed_bytes_view_opt v2) {
     if (!v1 || !v2) {
         return int(bool(v1)) - int(bool(v2));
     } else {

--- a/types/listlike_partial_deserializing_iterator.hh
+++ b/types/listlike_partial_deserializing_iterator.hh
@@ -29,10 +29,19 @@ int read_collection_size(bytes_view& in, cql_serialization_format sf);
 bytes_view read_collection_value(bytes_view& in, cql_serialization_format sf);
 
 template <FragmentedView View>
-int read_collection_size(View& in, cql_serialization_format);
+int read_collection_size(View& in, cql_serialization_format sf) {
+    if (sf.using_32_bits_for_collections()) {
+        return read_simple<int32_t>(in);
+    } else {
+        return read_simple<uint16_t>(in);
+    }
+}
 
 template <FragmentedView View>
-View read_collection_value(View& in, cql_serialization_format);
+View read_collection_value(View& in, cql_serialization_format sf) {
+    auto size = sf.using_32_bits_for_collections() ? read_simple<int32_t>(in) : read_simple<uint16_t>(in);
+    return read_simple_bytes(in, size);
+}
 
 // iterator that takes a set or list in serialized form, and emits
 // each element, still in serialized form

--- a/types/listlike_partial_deserializing_iterator.hh
+++ b/types/listlike_partial_deserializing_iterator.hh
@@ -22,8 +22,9 @@
 #pragma once
 
 #include <iterator>
-#include "bytes.hh"
 #include "cql_serialization_format.hh"
+#include "utils/fragment_range.hh"
+#include "utils/managed_bytes.hh"
 
 int read_collection_size(bytes_view& in, cql_serialization_format sf);
 bytes_view read_collection_value(bytes_view& in, cql_serialization_format sf);
@@ -48,18 +49,18 @@ View read_collection_value(View& in, cql_serialization_format sf) {
 class listlike_partial_deserializing_iterator {
 public:
     using iterator_category = std::input_iterator_tag;
-    using value_type = bytes_view;
+    using value_type = managed_bytes_view;
     using difference_type = std::ptrdiff_t;
-    using pointer = bytes_view*;
-    using reference = bytes_view&;
+    using pointer = managed_bytes_view*;
+    using reference = managed_bytes_view&;
 private:
-    bytes_view* _in;
+    managed_bytes_view* _in;
     int _remain;
-    bytes_view _cur;
+    managed_bytes_view _cur;
     cql_serialization_format _sf;
 private:
     struct end_tag {};
-    listlike_partial_deserializing_iterator(bytes_view& in, cql_serialization_format sf)
+    listlike_partial_deserializing_iterator(managed_bytes_view& in, cql_serialization_format sf)
             : _in(&in), _sf(sf) {
         _remain = read_collection_size(*_in, _sf);
         parse();
@@ -68,7 +69,7 @@ private:
             : _remain(0), _sf(cql_serialization_format::internal()) {  // _sf is bogus, but doesn't matter
     }
 public:
-    bytes_view operator*() const { return _cur; }
+    managed_bytes_view operator*() const { return _cur; }
     listlike_partial_deserializing_iterator& operator++() {
         --_remain;
         parse();
@@ -84,10 +85,10 @@ public:
     bool operator!=(const listlike_partial_deserializing_iterator& x) const {
         return _remain != x._remain;
     }
-    static listlike_partial_deserializing_iterator begin(bytes_view& in, cql_serialization_format sf) {
+    static listlike_partial_deserializing_iterator begin(managed_bytes_view& in, cql_serialization_format sf) {
         return { in, sf };
     }
-    static listlike_partial_deserializing_iterator end(bytes_view in, cql_serialization_format sf) {
+    static listlike_partial_deserializing_iterator end(managed_bytes_view in, cql_serialization_format sf) {
         return { end_tag() };
     }
 private:

--- a/types/map.hh
+++ b/types/map.hh
@@ -53,7 +53,7 @@ public:
     virtual bool is_compatible_with_frozen(const collection_type_impl& previous) const override;
     virtual bool is_value_compatible_with_frozen(const collection_type_impl& previous) const override;
     static int32_t compare_maps(data_type keys_comparator, data_type values_comparator,
-                        bytes_view o1, bytes_view o2);
+                        managed_bytes_view o1, managed_bytes_view o2);
     using abstract_type::deserialize;
     using collection_type_impl::deserialize;
     template <FragmentedView View> data_value deserialize(View v, cql_serialization_format sf) const;

--- a/types/tuple.hh
+++ b/types/tuple.hh
@@ -123,7 +123,18 @@ public:
     const std::vector<data_type>& all_types() const {
         return _types;
     }
-    std::vector<bytes_view_opt> split(bytes_view v) const;
+    std::vector<bytes_opt> split(FragmentedView auto v) const {
+        std::vector<bytes_opt> elements;
+        while (!v.empty()) {
+            auto fragmented_element_optional = read_tuple_element(v);
+            if (fragmented_element_optional) {
+                elements.push_back(linearized(*fragmented_element_optional));
+            } else {
+                elements.push_back(std::nullopt);
+            }
+        }
+        return elements;
+    }
     template <typename RangeOf_bytes_opt>  // also accepts bytes_view_opt
     static bytes build_value(RangeOf_bytes_opt&& range) {
         auto item_size = [] (auto&& v) { return 4 + (v ? v->size() : 0); };

--- a/types/user.hh
+++ b/types/user.hh
@@ -75,3 +75,4 @@ constexpr size_t max_udt_fields = std::numeric_limits<int16_t>::max();
 // Refer to collection_mutation.hh for a detailed description on how the serialized indices are used inside mutations.
 bytes serialize_field_index(size_t);
 size_t deserialize_field_index(const bytes_view&);
+size_t deserialize_field_index(managed_bytes_view);


### PR DESCRIPTION
This patch is another series on removing big allocations from scylla. 
The buffers in `compare_visitor` were replaced with `managed_bytes_view`, similiar change was also needed in tuple_deserializing_iterator and listlike_partial_deserializing_iterator, and was applied as well.

Tests:unit(dev)