### PR TITLE
Improve flat_mutation_reader::consume_pausable

### DIFF
--- a/flat_mutation_reader.hh
+++ b/flat_mutation_reader.hh
@@ -132,11 +132,10 @@ public:
         // Next call will start from the next mutation_fragment in the stream.
         future<> consume_pausable(Consumer consumer, db::timeout_clock::time_point timeout) {
             return repeat([this, consumer = std::move(consumer), timeout] () mutable {
-                if (is_end_of_stream() && is_buffer_empty()) {
-                    return make_ready_future<stop_iteration>(stop_iteration::yes);
-                }
-
                 if (is_buffer_empty()) {
+                    if (is_end_of_stream()) {
+                        return make_ready_future<stop_iteration>(stop_iteration::yes);
+                    }
                     return fill_buffer(timeout).then([] {
                         return make_ready_future<stop_iteration>(stop_iteration::no);
                     });

--- a/flat_mutation_reader.hh
+++ b/flat_mutation_reader.hh
@@ -141,6 +141,10 @@ public:
                     });
                 }
 
+                if constexpr (std::is_same_v<future<stop_iteration>, decltype(consumer(pop_mutation_fragment()))>) {
+                    return consumer(pop_mutation_fragment());
+                }
+
                 return futurize_invoke([&consumer, mf = pop_mutation_fragment()] () mutable {
                     return consumer(std::move(mf));
                 });

--- a/flat_mutation_reader.hh
+++ b/flat_mutation_reader.hh
@@ -143,11 +143,11 @@ public:
 
                 if constexpr (std::is_same_v<future<stop_iteration>, decltype(consumer(pop_mutation_fragment()))>) {
                     return consumer(pop_mutation_fragment());
+                } else {
+                    auto result = stop_iteration::no;
+                    while ((result = consumer(pop_mutation_fragment())) != stop_iteration::yes && !is_buffer_empty() && !need_preempt()) {}
+                    return make_ready_future<stop_iteration>(result);
                 }
-
-                return futurize_invoke([&consumer, mf = pop_mutation_fragment()] () mutable {
-                    return consumer(std::move(mf));
-                });
             });
         }
 

--- a/flat_mutation_reader.hh
+++ b/flat_mutation_reader.hh
@@ -131,8 +131,7 @@ public:
         // Stops when consumer returns stop_iteration::yes or end of stream is reached.
         // Next call will start from the next mutation_fragment in the stream.
         future<> consume_pausable(Consumer consumer, db::timeout_clock::time_point timeout) {
-            return do_with(std::move(consumer), [this, timeout] (Consumer& consumer) {
-                return repeat([this, &consumer, timeout] {
+                return repeat([this, consumer = std::move(consumer), timeout] () mutable {
                     if (is_end_of_stream() && is_buffer_empty()) {
                         return make_ready_future<stop_iteration>(stop_iteration::yes);
                     }
@@ -147,7 +146,6 @@ public:
                         return consumer(std::move(mf));
                     });
                 });
-            });
         }
 
         template<typename Consumer, typename Filter>


### PR DESCRIPTION
`flat_mutation_reader::consume_pausable` is widely used in Scylla. Some places worth mentioning are memtables and combined readers but there are others as well.

This patchset improves `consume_pausable` in three ways:
1. it removes unnecessary allocation
2. it rearranges ifs to not check the same thing twice
3. for a consumer that returns plain stop_iteration not a future<stop_iteration> it reduces the amount of future usage

Test: unit(dev, release, debug)

Combined reader microbenchmark has shown from 2% to 22% improvement in median execution time while memtable microbenchmark has shown from 3.6% to 7.8% improvement in median execution time.

Before the change:
```
./build/release/test/perf/perf_mutation_readers --random-seed 3549335083
single run iterations:    0
single run duration:      1.000s
number of runs:           5
number of cores:          16
random seed:              3549335083

test                                      iterations      median         mad         min         max
combined.one_row                             1316234   140.120ns     0.020ns   140.074ns   140.141ns
combined.single_active                          7332    91.484us    31.890ns    91.453us    91.778us
combined.many_overlapping                        945   870.973us   429.720ns   868.625us   871.403us
combined.disjoint_interleaved                   7102    85.989us     7.847ns    85.973us    85.997us
combined.disjoint_ranges                        7129    85.570us     7.840ns    85.562us    85.596us
combined.overlapping_partitions_disjoint_rows        5458   124.787us    56.738ns   124.731us   125.370us
clustering_combined.ranges_generic           1920688   217.940ns     0.184ns   217.742ns   218.275ns
clustering_combined.ranges_specialized       1935318   194.610ns     0.199ns   194.210ns   195.228ns
memtable.one_partition_one_row                624001     1.600us     1.405ns     1.599us     1.605us
memtable.one_partition_many_rows               79551    12.555us     1.829ns    12.549us    12.558us
memtable.many_partitions_one_row               40557    24.748us    77.083ns    24.644us    25.135us
memtable.many_partitions_many_rows              3220   310.429us    57.628ns   310.295us   311.189us
```

After the change:
```
./build/release/test/perf/perf_mutation_readers --random-seed 3549335083
single run iterations:    0
single run duration:      1.000s
number of runs:           5
number of cores:          16
random seed:              3549335083

test                                      iterations      median         mad         min         max
combined.one_row                             1358839   109.222ns     0.122ns   109.089ns   109.348ns
combined.single_active                          7525    87.305us    25.540ns    87.273us    87.362us
combined.many_overlapping                        962   853.195us     1.904us   851.244us   855.142us
combined.disjoint_interleaved                   7310    81.988us    28.877ns    81.949us    82.032us
combined.disjoint_ranges                        7315    81.699us    37.144ns    81.662us    81.874us
combined.overlapping_partitions_disjoint_rows        5591   120.964us    15.294ns   120.949us   121.120us
clustering_combined.ranges_generic           1954722   211.993ns     0.052ns   211.883ns   212.084ns
clustering_combined.ranges_specialized       2042194   187.807ns     0.066ns   187.732ns   188.289ns
memtable.one_partition_one_row                648701     1.542us     0.339ns     1.542us     1.543us
memtable.one_partition_many_rows               85007    11.759us     1.168ns    11.752us    11.782us
memtable.many_partitions_one_row               43893    22.805us    17.147ns    22.782us    22.843us
memtable.many_partitions_many_rows              3441   290.220us    41.720ns   290.172us   290.306us
```
