### PR TITLE
scylla-gdb.py: Add io-queues command

### DIFF
--- a/scylla-gdb.py
+++ b/scylla-gdb.py
@@ -1295,6 +1295,14 @@ class seastar_shared_ptr():
         return self.ref['_p']
 
 
+class std_shared_ptr():
+    def __init__(self, ref):
+        self.ref = ref
+
+    def get(self):
+        return self.ref['_M_ptr']
+
+
 def has_enable_lw_shared_from_this(type):
     for f in type.fields():
         if f.is_base_class and 'enable_lw_shared_from_this' in f.name:

--- a/scylla-gdb.py
+++ b/scylla-gdb.py
@@ -421,6 +421,10 @@ class std_vector:
         return int(self.ref['_M_impl']['_M_end_of_storage']) - int(self.ref['_M_impl']['_M_start'])
 
 
+def std_priority_queue(ref):
+    return std_vector(ref['c'])
+
+
 class std_deque:
     # should reflect the value of _GLIBCXX_DEQUE_BUF_SIZE
     DEQUE_BUF_SIZE = 512

--- a/scylla-gdb.py
+++ b/scylla-gdb.py
@@ -1303,6 +1303,14 @@ class std_shared_ptr():
         return self.ref['_M_ptr']
 
 
+class std_atomic():
+    def __init__(self, ref):
+        self.ref = ref
+
+    def get(self):
+        return self.ref['_M_i']
+
+
 def has_enable_lw_shared_from_this(type):
     for f in type.fields():
         if f.is_base_class and 'enable_lw_shared_from_this' in f.name:


### PR DESCRIPTION
The command can be used to inspect IO queues of a local reactor.
Example output:
```
    (gdb) scylla io-queues
        Dev 0:
            Class:                  |shares:         |ptr:
            --------------------------------------------------------------------------------
            "default"               |1               |(seastar::priority_class_data *)0x6000002c6500
            "commitlog"             |1000            |(seastar::priority_class_data *)0x6000003ad940
            "memtable_flush"        |1000            |(seastar::priority_class_data *)0x6000005cb300
            "streaming"             |200             |(seastar::priority_class_data *)0x0
            "query"                 |1000            |(seastar::priority_class_data *)0x600000718580
            "compaction"            |1000            |(seastar::priority_class_data *)0x6000030ef0c0
    
            Max request size:    2147483647
            Max capacity:        Ticket(weight: 4194303, size: 4194303)
            Capacity tail:       Ticket(weight: 73168384, size: 100561888)
            Capacity head:       Ticket(weight: 77360511, size: 104242143)
    
            Resources executing: Ticket(weight: 2176, size: 514048)
            Resources queued:    Ticket(weight: 384, size: 98304)
            Handles: (1)
                Class 0x6000005d7278:
                    Ticket(weight: 128, size: 32768)
                    Ticket(weight: 128, size: 32768)
                    Ticket(weight: 128, size: 32768)
            Pending in sink: (0)
```

Created when debugging a core dump. Turned out not to be immediately useful for this use case, but I'm publishing it since it may come in handy in future investigations.