### PR TITLE
aws: initialize self._disks['ebs'] when no EBS disks

### DIFF
--- a/dist/common/scripts/scylla_util.py
+++ b/dist/common/scripts/scylla_util.py
@@ -403,6 +403,8 @@ class aws_instance:
             if not self.__device_exists(self.__xenify(dev)):
                 continue
             self._disks[t] += [self.__xenify(dev)]
+        if not 'ebs' in self._disks:
+            self._disks['ebs'] = []
 
     def __mac_address(self, nic='eth0'):
         with open('/sys/class/net/{}/address'.format(nic)) as f:


### PR DESCRIPTION
Seems like aws_instance.ebs_disks() causes traceback when no EBS disks
available, need to initialize with empty list.

Fixes #8365