### PR TITLE
commitlog: Fix inner loop condition in allocation pre-fill

### DIFF
--- a/db/commitlog/commitlog.cc
+++ b/db/commitlog/commitlog.cc
@@ -1440,7 +1440,7 @@ future<db::commitlog::segment_manager::sseg_ptr> db::commitlog::segment_manager:
                     std::vector<iovec> v;
                     v.reserve(n);
                     size_t m = 0;
-                    while (m < rem && n < max_write) {
+                    while (m < rem && m < max_write) {
                         auto s = std::min(rem - m, buf_size);
                         v.emplace_back(iovec{ buf.get_write(), s});
                         m += s;


### PR DESCRIPTION
Fixes #8369

This was originally found (and fixed) by @gleb-cloudius, but the patch set with the
fix was reverted at some point, and the fix went away. Now the error remains even
in new, nice coroutine code.

We check the wrong var in the inner loop of the pre-fill path of allocate_segment_ex,
often causing us to generate giant writev:s of more or less the whole file.
Not intended.