### PR TITLE
Fast slow query trace doc

### DIFF
--- a/api/api-doc/storage_service.json
+++ b/api/api-doc/storage_service.json
@@ -1963,7 +1963,7 @@
                   },
                   {
                      "name":"fast",
-                     "description":"Enables lightweight tracing mode: if true, tracing ignores all tracing events",
+                     "description":"Lightweight tracing mode: if true, slow queries tracing records only session headers",
                      "required":false,
                      "allowMultiple":false,
                      "type":"boolean",


### PR DESCRIPTION
addressed https://github.com/scylladb/scylla/pull/8314#issuecomment-803671234 (wrike issue: "Tracing: slow query fast mode documentation request")

adds a fast slow queries tracing mode documentation to the docs/guide/tracing.md

patch to the scylla-doc will be dup-ed after this one merged

cc @nyh 
cc @vladzcloudius 