### PR TITLE
node_exporter_install: fix bad owner of node_exporter

### DIFF
--- a/dist/common/scripts/node_exporter_install
+++ b/dist/common/scripts/node_exporter_install
@@ -24,6 +24,8 @@ import os
 import sys
 import tempfile
 import tarfile
+import shutil
+import glob
 from scylla_util import *
 import argparse
 
@@ -61,6 +63,9 @@ if __name__ == '__main__':
             f.write(data)
         with tarfile.open('/var/tmp/node_exporter-{version}.linux-amd64.tar.gz'.format(version=VERSION)) as tf:
             tf.extractall(INSTALL_DIR)
+        shutil.chown(f'{INSTALL_DIR}/node_exporter-{VERSION}.linux-amd64', 'root', 'root')
+        for f in glob.glob(f'{INSTALL_DIR}/node_exporter-{VERSION}.linux-amd64/*'):
+            shutil.chown(f, 'root', 'root')
         os.remove('/var/tmp/node_exporter-{version}.linux-amd64.tar.gz'.format(version=VERSION))
         if node_exporter_p.exists():
             node_exporter_p.unlink()


### PR DESCRIPTION
This is only for older versions (4.3 and older) not for master / next branch, so I will send the PR with branch-4.3.
I'm sending for branch-4.3 but it also occurs on branch-4.2 and older, so please backport them too if we still maintain them.

----

node_exporter files as installed with weird ownership, 3434:3434.
This is because upstream node_exporter tar.gz contain the owner
information, but we should overwrite it to valid one.

Fixes #6222