### PR TITLE
nonroot: generate scylla_sysconfdir.py correctly

### DIFF
--- a/dist/common/scripts/scylla_sysconfdir.py
+++ b/dist/common/scripts/scylla_sysconfdir.py
@@ -1,1 +1,0 @@
-SYSCONFDIR="/etc/sysconfig"

--- a/install.sh
+++ b/install.sh
@@ -376,6 +376,10 @@ EOS
 else
     install -m755 -d "$rdata"/saved_caches
     install -d -m755 "$rsystemd"/scylla-server.service.d
+
+    cat << EOS > "$rprefix"/scripts/scylla_sysconfdir.py
+SYSCONFDIR="$prefix/$sysconfdir"
+EOS
     if [ -d /var/log/journal ]; then
         cat << EOS > "$rsystemd"/scylla-server.service.d/nonroot.conf
 [Service]
@@ -404,9 +408,6 @@ StandardOutput=
 StandardOutput=file:$rprefix/scylla-server.log
 StandardError=
 StandardError=inherit
-EOS
-        cat << EOS > "$rprefix"/scripts/scylla_sysconfdir.py
-SYSCONFDIR="$sysconfdir"
 EOS
     fi
 


### PR DESCRIPTION
We have scripting bug, when /var/log/journal exists, install.sh does not generate scylla_sysconfdir.py.
Stop generating scylla_sysconfdir.py in if else condition, do that
unconditionally in install.sh, also drop pre-generated
scylla_sysconfdir.py from dist/common/scripts.

Also, $rsysconfdir is correct path to point both nonroot mode and root
mode sysconfdir, instead of $sysconfdir.

Fixes #8385