### PR TITLE
hints: use token_metadata to tell if node has left the ring

### DIFF
--- a/db/hints/manager.cc
+++ b/db/hints/manager.cc
@@ -441,7 +441,10 @@ bool manager::end_point_hints_manager::sender::can_send() noexcept {
 
     try {
         auto ep_state_ptr = _gossiper. get_endpoint_state_for_endpoint_ptr(end_point_key());
-        if (!ep_state_ptr || !ep_state_ptr->is_alive()) {
+        if (ep_state_ptr && ep_state_ptr->is_alive()) {
+            _state.remove(state::ep_state_left_the_ring);
+            return true;
+        } else {
             if (!_state.contains(state::ep_state_left_the_ring)) {
                 auto ep_gossip_state_val = _gossiper.get_gossip_status(end_point_key());
                 // If node has been removed from the ring it's going to be removed from the gossiper::endpoint_state
@@ -462,9 +465,6 @@ bool manager::end_point_hints_manager::sender::can_send() noexcept {
             }
             // send the hints out if the destination Node is part of the ring - we will send to all new replicas in this case
             return _state.contains(state::ep_state_left_the_ring);
-        } else {
-            _state.remove(state::ep_state_left_the_ring);
-            return true;
         }
     } catch (...) {
         return false;

--- a/db/hints/manager.hh
+++ b/db/hints/manager.hh
@@ -235,7 +235,7 @@ public:
             bool send_one_file(const sstring& fname);
 
             /// \brief Checks if we can still send hints.
-            /// \return TRUE if the destination Node is either ALIVE or has left the NORMAL state (e.g. has been decommissioned).
+            /// \return TRUE if the destination Node is either ALIVE or has left the ring (e.g. after decommission or removenode).
             bool can_send() noexcept;
 
             /// \brief Restore a mutation object from the hints file entry.

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -2343,10 +2343,10 @@ void storage_service::excise(std::unordered_set<token> tokens, inet_address endp
     tmptr->remove_endpoint(endpoint);
     tmptr->remove_bootstrap_tokens(tokens);
 
-    notify_left(endpoint);
-
     update_pending_ranges(tmptr, format("excise {}", endpoint)).get();
     replicate_to_all_cores(std::move(tmptr)).get();
+
+    notify_left(endpoint);
 }
 
 void storage_service::excise(std::unordered_set<token> tokens, inet_address endpoint, int64_t expire_time) {

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -2338,13 +2338,14 @@ void storage_service::excise(std::unordered_set<token> tokens, inet_address endp
     slogger.info("Removing tokens {} for {}", tokens, endpoint);
     // FIXME: HintedHandOffManager.instance.deleteHintsForEndpoint(endpoint);
     remove_endpoint(endpoint);
-    auto tmlock = get_token_metadata_lock().get0();
+    auto tmlock = std::make_optional(get_token_metadata_lock().get0());
     auto tmptr = get_mutable_token_metadata_ptr().get0();
     tmptr->remove_endpoint(endpoint);
     tmptr->remove_bootstrap_tokens(tokens);
 
     update_pending_ranges(tmptr, format("excise {}", endpoint)).get();
     replicate_to_all_cores(std::move(tmptr)).get();
+    tmlock.reset();
 
     notify_left(endpoint);
 }


### PR DESCRIPTION
This PR changes the `can_send` function so that it looks at the `token_metadata` in order to tell if the destination node is in the ring. Previously, gossiper state was used for that purpose and required a relatively complicated condition to check. The new logic just uses `token_metadata::is_member` which reduces complexity of the `can_send` function.

Additionally, `storage_service` is slightly modified so that during a removenode operation the `token_metadata` is first updated and only then endpoint lifecycle subscribers are notified. This was done in order to prevent a race just like the one which happened in #5087 - hints manager is a lifecycle subscriber and starts a draining operation when a node is removed, and in order for draining to work correctly, `can_send` should keep returning true for that node.

Tests:

- unit(dev)
- dtest(hintedhandoff_additional_test.py)
- dtest(topology_test.py)