### PR TITLE
Add failure detection with higher granularity for read replicas

### DIFF
--- a/db/consistency_level.cc
+++ b/db/consistency_level.cc
@@ -394,7 +394,13 @@ bool
 is_sufficient_live_nodes(consistency_level cl,
                          keyspace& ks,
                          const inet_address_vector_replica_set& live_endpoints) {
+    return is_sufficient_live_nodes(cl, ks, live_endpoints.begin(), live_endpoints.end());
+}
+
+bool is_sufficient_live_nodes(consistency_level cl, keyspace& ks, const inet_address_vector_replica_set::const_iterator& begin_it,
+        const inet_address_vector_replica_set::const_iterator& end_it) {
     using namespace locator;
+    auto live_endpoints = boost::make_iterator_range(begin_it, end_it);
 
     switch (cl) {
     case consistency_level::ANY:

--- a/db/consistency_level.hh
+++ b/db/consistency_level.hh
@@ -100,6 +100,8 @@ bool
 is_sufficient_live_nodes(consistency_level cl,
                          keyspace& ks,
                          const inet_address_vector_replica_set& live_endpoints);
+bool is_sufficient_live_nodes(consistency_level cl, keyspace& ks, const inet_address_vector_replica_set::const_iterator& begin_it,
+        const inet_address_vector_replica_set::const_iterator& end_it);
 
 template<typename Range, typename PendingRange = std::array<gms::inet_address, 0>>
 void assure_sufficient_live_nodes(

--- a/docs/design-notes/qualifying-replicas-for-reads.md
+++ b/docs/design-notes/qualifying-replicas-for-reads.md
@@ -1,0 +1,90 @@
+# Qualifying replicas for read operations
+
+## Failure detection based on last seen information
+
+### Intro
+
+When a read request arrives at the coordinator node, it is later
+forwarded to one or more replicas in order to read the actual data
+and return it back to the client. Each request has an associated
+timeout, which indicates how long the client is willing to wait
+for the query results.
+This timeout information can be leveraged to lift some pressure off
+the coordinator if some of the target replicas are in fact dead,
+having network problems, etc.
+
+### Gathering last seen information
+
+The coordinator should be able to predict whether a replica is likely
+to respond to a request in time or not. This prediction should be as
+precise as possible, but at the same time have minimal overhead, because
+performing read requests is on the hot path. A simple failure detection
+mechanism with high granularity is implemented as follows:
+ * each time a request is sent to a replica, this attempt's timestamp
+   is recorded
+ * first timestamp of a streak of unresponded requests is recorded separately
+   in order to see how long ago the coordinator started to try to communicate
+   with a replica; example:
+    1. sent request A
+    2. received a response for A
+    3. sent request B <-- this is the interesting timestamp, since the node
+         hasn't responded at all after this request was sent
+    4. sent request C
+    5. sent request D
+ * each time a response is received from a replica, the node is marked as responsive
+
+The "last time a request was sent without response" metrics is a cheap, rough
+implementation of a failure detector - if the node hasn't responded for more than
+X milliseconds since the previous request and the current request is going
+to time out in X milliseconds, the target node gets more and more likely to be
+qualified as dead.
+
+Finally, when a replica was not contacted in a long while (e.g. the full timeout period),
+a communication attempt will be performed anyway, just in case the replica came back
+to full responsiveness.
+
+### Omitting replicas not likely to respond in time
+
+Based on the last seen information, the coordinator is now allowed
+to make an educated guess whether a replica is alive and ready to respond.
+A simple, probabilistic approach is implemented as follows.
+At first, we compute how much time left (`TL`) the request still has until
+it reaches its deadline and times out. From the last seen information
+we fetch the last time without any response: `TWR`.
+If `TL` is larger than `TWR`, then the node is likely alive, so the request
+is let through. If, however, `TL < TWR`, it suggests that the replica might
+not be alive, so it may be probabilistically omitted as a potential target.
+The chance of omitting a replica is `(TWR-TL)/TL`, which means that the chance
+increases linearly along with the time in which the node is not responsive,
+i.e. the more likely it is that the replica is dead, the higher its chances
+for being qualified as unreliable.
+Once the time without response reaches `2*TL`, the chance reaches almost 100%,
+but there always exist a small chance (`>=0.01%`) for letting a request through
+in case the replica started responding.
+
+### Letting reads through if the consistency level might not be fulfilled
+
+One fail-safe mechanism is in place to prevent failing requests if they still
+have a chance of success. Namely, if we're about to disqualify a replica
+based on this failure detector, **but** this disqualification will also
+cause the request to immediately fail due to not being able to fulfill
+its consistency level, the request is let through anyway.
+A trivial example when this mechanism can be observed is consistency level ALL:
+all replicas are required to be alive for this level to be fulfilled, so the failure
+detector will not try to disqualify any replicas prematurely.
+
+### So, it's a dynamic snitch?
+
+Kind of, but currently it's only expected to work once the replica is
+likely dead and thus not able to respond. Ideally, it would have no influence
+over how the requests are distributed as long as replicas regularly respond
+to their requests in time. A scenario in which this mechanism is expected to be
+particularly effective is when a replica dies suddenly without broadcasting
+that it's going to die. In this case, the stock failure detector can take tens
+of seconds to figure out that this replica is dead, which also means that
+coordinators would try to send data to it, which results in a sharp increase
+of background reads, which in turn lack a proper backpressure mechanism
+(at least at the time of writing this doc). With the qualification mechanism
+in place, the node is qualified as not likely to respond potentially much
+quicker, especially if its requests have short timeout values (e.g. 500ms).
+ 

--- a/message/last_seen_info.hh
+++ b/message/last_seen_info.hh
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2021-present ScyllaDB
+ */
+
+/*
+ * This file is part of Scylla.
+ *
+ * Scylla is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Scylla is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <seastar/core/lowres_clock.hh>
+
+namespace netw {
+
+struct last_seen_info {
+    using clock_type = seastar::lowres_clock;
+    static constexpr clock_type::time_point unknown = clock_type::time_point::min();
+    clock_type::time_point last_sent_without_response = unknown;
+    clock_type::time_point last_attempt = unknown;
+
+    void mark_sent(clock_type::time_point tp);
+    void mark_got_response();
+};
+
+}

--- a/message/messaging_service.cc
+++ b/message/messaging_service.cc
@@ -250,6 +250,17 @@ rpc::stats messaging_service::shard_info::get_stats() const {
     return rpc_client->get_stats();
 }
 
+void last_seen_info::mark_sent(clock_type::time_point req_time) {
+    last_attempt = req_time;
+    if (last_sent_without_response == last_seen_info::unknown) {
+        last_sent_without_response = req_time;
+    }
+}
+
+void last_seen_info::mark_got_response() {
+    last_sent_without_response = last_seen_info::unknown;
+}
+
 void messaging_service::foreach_client(std::function<void(const msg_addr& id, const shard_info& info)> f) const {
     for (unsigned idx = 0; idx < _clients.size(); idx ++) {
         for (auto i = _clients[idx].cbegin(); i != _clients[idx].cend(); i++) {

--- a/message/messaging_service.hh
+++ b/message/messaging_service.hh
@@ -42,6 +42,7 @@
 #include "service/paxos/prepare_response.hh"
 #include "raft/raft.hh"
 #include "db/hints/messages.hh"
+#include "message/last_seen_info.hh"
 
 #include <list>
 #include <vector>

--- a/message/messaging_service.hh
+++ b/message/messaging_service.hh
@@ -43,6 +43,7 @@
 #include "raft/raft.hh"
 #include "db/hints/messages.hh"
 #include "message/last_seen_info.hh"
+#include "absl-flat_hash_map.hh"
 
 #include <list>
 #include <vector>
@@ -283,6 +284,7 @@ private:
     std::unique_ptr<seastar::tls::credentials_builder> _credentials_builder;
     std::array<std::unique_ptr<rpc_protocol_server_wrapper>, 2> _server_tls;
     std::vector<clients_map> _clients;
+    absl::flat_hash_map<gms::inet_address, last_seen_info> _last_seen;
     uint64_t _dropped_messages[static_cast<int32_t>(messaging_verb::LAST)] = {};
     bool _shutting_down = false;
     std::list<std::function<void(gms::inet_address ep)>> _connection_drop_notifiers;
@@ -601,6 +603,9 @@ private:
 public:
     // Return rpc::protocol::client for a shard which is a ip + cpuid pair.
     shared_ptr<rpc_protocol_client_wrapper> get_rpc_client(messaging_verb verb, msg_addr id);
+    last_seen_info get_last_seen_info_for(gms::inet_address ep);
+    void mark_sent(gms::inet_address ep, clock_type::time_point);
+    void mark_got_response(gms::inet_address ep);
     void remove_error_rpc_client(messaging_verb verb, msg_addr id);
     void remove_rpc_client(msg_addr id);
     using drop_notifier_handler = decltype(_connection_drop_notifiers)::iterator;

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -1535,7 +1535,8 @@ storage_proxy_stats::stats::stats()
         , digest_read_errors(COORDINATOR_STATS_CATEGORY, "read_errors", "number of digest read requests that failed", "digest")
         , mutation_data_read_attempts(COORDINATOR_STATS_CATEGORY, "reads", "number of mutation data read requests", "mutation_data")
         , mutation_data_read_completed(COORDINATOR_STATS_CATEGORY, "completed_reads", "number of mutation data read requests that completed", "mutation_data")
-        , mutation_data_read_errors(COORDINATOR_STATS_CATEGORY, "read_errors", "number of mutation data read requests that failed", "mutation_data") { }
+        , mutation_data_read_errors(COORDINATOR_STATS_CATEGORY, "read_errors", "number of mutation data read requests that failed", "mutation_data")
+        , read_requests_speculatively_refused(COORDINATOR_STATS_CATEGORY, "read_requests_speculatively_refused", "number of requests which were destined for this endpoint, but speculatively refused", "data") { }
 
 void storage_proxy_stats::stats::register_split_metrics_local() {
     write_stats::register_split_metrics_local();
@@ -4670,6 +4671,7 @@ bool storage_proxy::is_likely_alive(const gms::inet_address& ep, clock_type::tim
         int fail_chance = std::min<long>((time_without_response.count() - time_left.count()) * granularity / time_left.count(), granularity - 1);
         int roll = dice(_urandom);
         if (roll < fail_chance) {
+            ++get_stats().read_requests_speculatively_refused.get_ep_stat(ep);
             slogger.debug("Overload protection: speculatively disqualifying {} as a candidate for a read request with {}ms left until timeout, "
                     "since it hasn't responded for at least {}ms", ep, time_left.count(), time_without_response.count());
             return false;

--- a/service/storage_proxy.hh
+++ b/service/storage_proxy.hh
@@ -481,6 +481,11 @@ public:
         }
         return next;
     }
+
+    std::default_random_engine& get_urandom() {
+        return _urandom;
+    }
+
     void init_messaging_service(shared_ptr<migration_manager>);
     future<> uninit_messaging_service();
 

--- a/service/storage_proxy.hh
+++ b/service/storage_proxy.hh
@@ -68,6 +68,7 @@
 #include "db/hints/host_filter.hh"
 #include "utils/small_vector.hh"
 #include "service/endpoint_lifecycle_subscriber.hh"
+#include "message/last_seen_info.hh"
 
 class reconcilable_result;
 class frozen_mutation_and_schema;
@@ -348,9 +349,11 @@ private:
     bool cannot_hint(const Range& targets, db::write_type type) const;
     bool hints_enabled(db::write_type type) const noexcept;
     db::hints::manager& hints_manager_for(db::write_type type);
+    bool is_likely_alive(const gms::inet_address& ep, clock_type::time_point timeout);
     inet_address_vector_replica_set get_live_endpoints(keyspace& ks, const dht::token& token) const;
+    inet_address_vector_replica_set get_live_endpoints_for_read(keyspace& ks, const dht::token& token, db::consistency_level cl, clock_type::time_point timeout);
     static void sort_endpoints_by_proximity(inet_address_vector_replica_set& eps);
-    inet_address_vector_replica_set get_live_sorted_endpoints(keyspace& ks, const dht::token& token) const;
+    inet_address_vector_replica_set get_live_sorted_endpoints_for_read(keyspace& ks, const dht::token& token, db::consistency_level cl, clock_type::time_point timeout);
     db::read_repair_decision new_read_repair_decision(const schema& s);
     ::shared_ptr<abstract_read_executor> get_read_executor(lw_shared_ptr<query::read_command> cmd,
             schema_ptr schema,
@@ -360,7 +363,8 @@ private:
             tracing::trace_state_ptr trace_state,
             const inet_address_vector_replica_set& preferred_endpoints,
             bool& is_bounced_read,
-            service_permit permit);
+            service_permit permit,
+            clock_type::time_point timeout);
     future<rpc::tuple<foreign_ptr<lw_shared_ptr<query::result>>, cache_temperature>> query_result_local(schema_ptr, lw_shared_ptr<query::read_command> cmd, const dht::partition_range& pr,
                                                                            query::result_options opts,
                                                                            tracing::trace_state_ptr trace_state,
@@ -446,6 +450,7 @@ private:
 
     future<> create_hint_queue_sync_point(utils::UUID sync_point_id, std::vector<gms::inet_address> endpoints, clock_type::time_point deadline);
     future<bool> check_hint_queue_sync_point(utils::UUID sync_point);
+
 public:
     storage_proxy(distributed<database>& db, config cfg, db::view::node_update_backlog& max_view_update_backlog,
             scheduling_group_key stats_key, gms::feature_service& feat, const locator::shared_token_metadata& stm, netw::messaging_service& ms);

--- a/service/storage_proxy_stats.hh
+++ b/service/storage_proxy_stats.hh
@@ -202,6 +202,11 @@ struct stats : public write_stats {
     split_stats mutation_data_read_completed;
     split_stats mutation_data_read_errors;
 
+    // number of requests which were destined for this endpoint, but speculatively
+    // directed to other replicas or dropped, because this endpoint was not likely
+    // to respond within deadline
+    split_stats read_requests_speculatively_refused;
+
 public:
     stats();
     void register_stats();


### PR DESCRIPTION
This series presents a mechanism of disqualifying a node from read operations if it looks down. It's based on estimating how long ago the target node was still responsive - an as that time gets longer than request's timeout, the chance for dropping the request increases.

Spin-off from #8098, which also claimed to be able to estimate reliably if a replica is overloaded, which is considerably harder to do properly.