### PR TITLE
storage_proxy: do not send timed out requests to replicas

### DIFF
--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -3646,6 +3646,11 @@ public:
     virtual future<foreign_ptr<lw_shared_ptr<query::result>>> execute(storage_proxy::clock_type::time_point timeout) {
         digest_resolver_ptr digest_resolver = ::make_shared<digest_read_resolver>(_schema, _cl, _block_for,
                 db::is_datacenter_local(_cl) ? db::count_local_endpoints(_targets): _targets.size(), timeout);
+        if (timeout <= storage_proxy::clock_type::now()) {
+            return make_exception_future<foreign_ptr<lw_shared_ptr<query::result>>>(
+                exceptions::overloaded_exception(format("Request timed out before being sent to replicas"))
+            );
+        }
         auto exec = shared_from_this();
 
         // Waited on indirectly.


### PR DESCRIPTION
Currently the coordinator node will happily send read requests
to replicas, even if they are already past their timeout.
Instead, the coordinator should let the client know that it's
overloaded - judged by the fact that the request was stuck
on the coordinator side so long.

Fixes #8395

Tests: manual:
        by issuing requests with `USING TIMEOUT 0s` and observing driver outputs + wireshark