### PR TITLE
Raft: a "distributed" test framework using a simulated network (with a simple test)

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -517,6 +517,7 @@ perf_tests = set([
 
 raft_tests = set([
     'test/raft/replication_test',
+    'test/raft/randomized_nemesis_test',
     'test/raft/fsm_test',
     'test/raft/etcd_test',
 ])
@@ -1210,6 +1211,7 @@ deps['test/boost/duration_test'] += ['test/lib/exception_utils.cc']
 deps['test/boost/alternator_base64_test'] += ['alternator/base64.cc']
 
 deps['test/raft/replication_test'] = ['test/raft/replication_test.cc'] + scylla_raft_dependencies
+deps['test/raft/randomized_nemesis_test'] = ['test/raft/randomized_nemesis_test.cc'] + scylla_raft_dependencies
 deps['test/raft/fsm_test'] =  ['test/raft/fsm_test.cc', 'test/lib/log.cc'] + scylla_raft_dependencies
 deps['test/raft/etcd_test'] =  ['test/raft/etcd_test.cc', 'test/lib/log.cc'] + scylla_raft_dependencies
 

--- a/raft/fsm.cc
+++ b/raft/fsm.cc
@@ -596,15 +596,17 @@ void fsm::append_entries_reply(server_id from, append_reply&& reply) {
             return;
         }
 
+        // is_stray_reject may return a false negative so even if the check above passes,
+        // we may still be dealing with a stray reject. That's fine though; it is always safe
+        // to rollback next_idx on a reject and in fact that's what the Raft spec (TLA+) does.
+        // Detecting stray rejects is an optimization that should rarely even be needed.
+
         // Start re-sending from the non matching index, or from
         // the last index in the follower's log.
         // FIXME: make it more efficient
         progress.next_idx = std::min(rejected.non_matching_idx, index_t(rejected.last_idx + 1));
 
         progress.become_probe();
-
-        // We should not fail to apply an entry following the matched one.
-        assert(progress.next_idx != progress.match_idx);
     }
 
     // We may have just applied a configuration that removes this

--- a/raft/fsm.cc
+++ b/raft/fsm.cc
@@ -280,9 +280,7 @@ fsm_output fsm::get_output() {
 
         for (auto idx = observed_ci + 1; idx <= _commit_idx; ++idx) {
             const auto& entry = _log[idx];
-            if (!std::holds_alternative<configuration>(entry->data)) {
-                output.committed.push_back(entry);
-            }
+            output.committed.push_back(entry);
         }
     }
 

--- a/raft/tracker.hh
+++ b/raft/tracker.hh
@@ -56,8 +56,9 @@ public:
     size_t in_flight = 0;
     static constexpr size_t max_in_flight = 10;
 
-    // check if a reject packet should be ignored because it was delayed
-    // or reordered
+    // Check if a reject packet should be ignored because it was delayed or reordered.
+    // This is not 100% accurate (may return false negatives) and should only be relied on
+    // for liveness optimizations, not for safety.
     bool is_stray_reject(const append_reply::rejected&);
 
     void become_probe();

--- a/test/raft/fsm_test.cc
+++ b/test/raft/fsm_test.cc
@@ -1451,3 +1451,65 @@ BOOST_AUTO_TEST_CASE(test_zero) {
     BOOST_CHECK_THROW(raft::configuration cfg(raft::server_address_set{raft::server_address{id}}), std::invalid_argument);
     BOOST_CHECK_THROW(create_follower(id, raft::log(raft::snapshot{})), std::invalid_argument);
 }
+
+BOOST_AUTO_TEST_CASE(test_reordered_reject) {
+    auto id1 = id();
+    raft::fsm fsm1(id1, term_t{1}, server_id{},
+            raft::log{raft::snapshot{.config = {{raft::server_address{id1.id}}}}},
+            trivial_failure_detector, fsm_cfg);
+
+    while (!fsm1.is_leader()) {
+        fsm1.tick();
+    }
+
+    fsm1.add_entry(log_entry::dummy{});
+    (void)fsm1.get_output();
+
+    auto id2 = id();
+    raft::fsm fsm2(id2, term_t{1}, server_id{},
+            raft::log{raft::snapshot{.config = raft::configuration{}}},
+            trivial_failure_detector, fsm_cfg);
+
+    raft_routing_map routes{{fsm1.id(), &fsm1}, {fsm2.id(), &fsm2}};
+
+    fsm1.add_entry(raft::configuration{{raft::server_address{fsm1.id().id}, raft::server_address{fsm2.id().id}}});
+    fsm1.tick();
+
+    // fsm1 wants to append 2 entries to fsm2
+    auto append_idx2_1 = fsm1.get_output();
+
+    fsm1.tick();
+
+    // fsm1 wants to append 2 entries to fsm2 (again)
+    auto append_idx2_2 = fsm1.get_output();
+
+    raft::logger.trace("delivering first append idx=2");
+    deliver(routes, fsm1.id(), std::move(append_idx2_1.messages));
+
+    // fsm2 rejects the first idx=2 append
+    auto reject_1 = fsm2.get_output();
+
+    raft::logger.trace("delivering second append idx=2");
+    deliver(routes, fsm1.id(), std::move(append_idx2_2.messages));
+
+    // fsm2 rejects the second idx=2 append
+    auto reject_2 = fsm2.get_output();
+
+    raft::logger.trace("delivering first reject");
+    deliver(routes, fsm2.id(), std::move(reject_1.messages));
+
+    // fsm1 wants to append 1 entry to fsm2
+    auto append_idx1 = fsm1.get_output();
+
+    raft::logger.trace("delivering append idx=1");
+    deliver(routes, fsm1.id(), std::move(append_idx1.messages));
+
+    // fsm2 accepts the idx=1 append
+    auto accept = fsm2.get_output();
+
+    raft::logger.trace("delivering accept for append idx=1");
+    deliver(routes, fsm2.id(), std::move(accept.messages));
+
+    raft::logger.trace("delivering second reject");
+    deliver(routes, fsm2.id(), std::move(reject_2.messages));
+}

--- a/test/raft/randomized_nemesis_test.cc
+++ b/test/raft/randomized_nemesis_test.cc
@@ -24,6 +24,7 @@
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/gate.hh>
 #include <seastar/core/queue.hh>
+#include <seastar/core/future-util.hh>
 #include <seastar/util/defer.hh>
 
 #include "raft/server.hh"
@@ -1179,6 +1180,60 @@ public:
         _stopped = true;
     }
 };
+
+// Calls the given function (``tick''s) as fast as the Seastar reactor allows and yields between each call.
+// May be provided a limit for the number of calls; crashes if the limit is reached before the ticker
+// is `abort()`ed.
+// Call `start()` to start the ticking.
+class ticker {
+    bool _stop = false;
+    std::optional<future<>> _ticker;
+
+public:
+    ticker() = default;
+    ticker(const ticker&) = delete;
+    ticker(ticker&&) = delete;
+
+    ~ticker() {
+        assert(!_ticker);
+    }
+
+    void start(noncopyable_function<void()> on_tick, uint64_t limit = std::numeric_limits<uint64_t>::max()) {
+        _ticker = tick(std::move(on_tick), limit);
+    }
+
+    future<> abort() && {
+        if (_ticker) {
+            _stop = true;
+            co_await *std::exchange(_ticker, std::nullopt);
+        }
+    }
+
+private:
+    future<> tick(noncopyable_function<void()> on_tick, uint64_t limit) {
+        for (uint64_t i = 0; i < limit; ++i) {
+            if (_stop) {
+                tlogger.debug("ticker: finishing after {} ticks", i);
+                co_return;
+            }
+            on_tick();
+            co_await seastar::later();
+        }
+
+        tlogger.error("ticker: limit reached");
+        assert(false);
+    }
+};
+
+template <PureStateMachine M>
+future<> with_env_and_ticker(noncopyable_function<future<>(environment<M>&, ticker&)> f) {
+    environment<M> env;
+    ticker t;
+    co_await f(env, t).finally([&] () -> future<> {
+        co_await std::move(t).abort();
+        co_await std::move(env).abort();
+    });
+}
 
 SEASTAR_TEST_CASE(dummy_test) {
     return seastar::make_ready_future<>();

--- a/test/raft/randomized_nemesis_test.cc
+++ b/test/raft/randomized_nemesis_test.cc
@@ -21,8 +21,16 @@
 
 #include <seastar/testing/test_case.hh>
 #include <seastar/core/timed_out_error.hh>
+#include <seastar/core/coroutine.hh>
+#include <seastar/core/gate.hh>
+#include <seastar/util/defer.hh>
 
+#include "raft/server.hh"
 #include "raft/logical_clock.hh"
+#include "serializer.hh"
+#include "serializer_impl.hh"
+#include "idl/uuid.dist.hh"
+#include "idl/uuid.dist.impl.hh"
 
 using namespace seastar;
 
@@ -189,6 +197,167 @@ public:
         return f;
     }
 };
+
+// Used to uniquely identify commands passed into `apply` in order to return
+// the outputs of these commands. See `impure_state_machine` and `call`.
+using cmd_id_t = utils::UUID;
+
+// A set of in-memory snapshots maintained by a single Raft server.
+// The different parts of the server (the state machine, persistence,
+// rpc) will share a single `snapshots_t`.
+template <typename State>
+using snapshots_t = std::unordered_map<raft::snapshot_id, State>;
+
+// To replicate a state machine, our Raft implementation requires it to
+// be represented with the `raft::state_machine` interface.
+//
+// `impure_state_machine` is an implementation of `raft::state_machine`
+// that wraps a `PureStateMachine`. It keeps a variable of type `state_t`
+// representing the current state. In `apply` it deserializes the given
+// command into `input_t`, uses the transition (`delta`) function to
+// produce the next state and output, replaces its current state with the
+// obtained state and returns the output (more on that below); it does so
+// sequentially for every given command. We can think of `PureStateMachine`
+// as the actual state machine - the business logic, and `impure_state_machine`
+// as the ``boilerplate'' that allows the pure machine to be replicated
+// by Raft and communicate with the external world.
+//
+// The interface also requires maintainance of snapshots. We use the
+// `snapshots_t` introduced above; `impure_state_machine` keeps a reference to `snapshots_t`
+// because it will share it with an implementation of `raft::persistence`.
+template <PureStateMachine M>
+class impure_state_machine : public raft::state_machine {
+    typename M::state_t _val;
+    snapshots_t<typename M::state_t>& _snapshots;
+
+    // Used to ensure that when `abort()` returns there are
+    // no more in-progress methods running on this object.
+    seastar::gate _gate;
+
+    // To obtain output from an applied command, the client (see `call`)
+    // first allocates a channel in this data structure by calling `with_output_channel`
+    // and makes the returned command ID a part of the command passed to Raft.
+    // When (if) we eventually apply the command, we use the ID to find the output channel
+    // here and push the output to the client waiting on the other end.
+    // The channel is allocated only on the local server where `with_output_channel`
+    // was called; other replicas of the state machine will therefore not find the ID
+    // in their instances of `_output_channels` so they just drop the output.
+    std::unordered_map<cmd_id_t, promise<typename M::output_t>> _output_channels;
+
+public:
+    impure_state_machine(snapshots_t<typename M::state_t>& snapshots)
+        : _val(M::init), _snapshots(snapshots) {}
+
+    future<> apply(std::vector<raft::command_cref> cmds) override {
+        return with_gate(_gate, [this, cmds = std::move(cmds)] () -> future<> {
+            for (auto& cref : cmds) {
+                _gate.check();
+
+                auto is = ser::as_input_stream(cref);
+                auto cmd_id = ser::deserialize(is, boost::type<cmd_id_t>{});
+                auto input = ser::deserialize(is, boost::type<typename M::input_t>{});
+                auto [new_state, output] = M::delta(std::move(_val), std::move(input));
+                _val = std::move(new_state);
+
+                auto it = _output_channels.find(cmd_id);
+                if (it != _output_channels.end()) {
+                    // We are on the leader server where the client submitted the command
+                    // and waits for the output. Send it to them.
+                    it->second.set_value(std::move(output));
+                } else {
+                    // This is not the leader on which the command was submitted,
+                    // or it is but the client already gave up on us and deallocated the channel.
+                    // In any case we simply drop the output.
+                }
+
+                co_await make_ready_future<>(); // maybe yield
+            }
+        });
+    }
+
+    future<raft::snapshot_id> take_snapshot() override {
+        auto id = raft::snapshot_id{utils::make_random_uuid()};
+        _snapshots[id] = _val;
+        co_return id;
+    }
+
+    void drop_snapshot(raft::snapshot_id id) override {
+        _snapshots.erase(id);
+    }
+
+    future<> load_snapshot(raft::snapshot_id id) override {
+        auto it = _snapshots.find(id);
+        assert(it != _snapshots.end()); // dunno if the snapshot can actually be missing
+        _val = it->second;
+        co_return;
+    }
+
+    future<> abort() override {
+        return _gate.close();
+    }
+
+    // Before sending a command to Raft, the client must obtain a command ID
+    // and an output channel using this function.
+    template <typename F>
+    future<typename M::output_t> with_output_channel(F&& f) {
+        return with_gate(_gate, [this, f = std::move(f)] () mutable -> future<typename M::output_t> {
+            promise<typename M::output_t> p;
+            auto fut = p.get_future();
+            auto cmd_id = utils::make_random_uuid();
+            assert(_output_channels.emplace(cmd_id, std::move(p)).second);
+
+            auto _ = defer([this, cmd_id] { _output_channels.erase(cmd_id); });
+            co_return co_await std::forward<F>(f)(cmd_id, std::move(fut));
+        });
+    }
+};
+
+// TODO: serializable concept?
+template <typename Input>
+raft::command make_command(const cmd_id_t& cmd_id, const Input& input) {
+    raft::command cmd;
+    ser::serialize(cmd, cmd_id);
+    ser::serialize(cmd, input);
+    return cmd;
+}
+
+// TODO: handle other errors?
+template <PureStateMachine M>
+using call_result_t = std::variant<typename M::output_t, timed_out_error, raft::not_a_leader>;
+
+// Sends a given `input` as a command to `server`, waits until the command gets replicated
+// and applied on that server and returns the produced output.
+//
+// The wait time is limited using `timeout` which is a logical time point referring to the
+// logical clock used by `timer`. Standard way to use is to pass `timer.now() + X_t`
+// as the time point, where `X` is the maximum number of ticks that we wait for.
+//
+// `sm` must be a reference to the state machine owned by `server`.
+//
+// The `server` may currently be a follower, in which case it will return a `not_a_leader` error.
+template <PureStateMachine M>
+future<call_result_t<M>> call(
+        typename M::input_t input,
+        raft::logical_clock::time_point timeout,
+        logical_timer& timer,
+        raft::server& server,
+        impure_state_machine<M>& sm) {
+    try {
+        co_return co_await sm.with_output_channel([&] (cmd_id_t cmd_id, future<typename M::output_t> f) {
+            return timer.with_timeout(timeout, [&] (future<typename M::output_t> f) -> future<typename M::output_t> {
+                co_await server.add_entry(
+                        make_command(std::move(cmd_id), std::move(input)),
+                        raft::wait_type::applied);
+
+                co_return co_await std::move(f);
+            }(std::move(f)));
+        });
+    } catch (raft::not_a_leader e) {
+        co_return e;
+    } catch (timed_out_error e) {
+        co_return e;
+    }
+}
 
 SEASTAR_TEST_CASE(dummy_test) {
     return seastar::make_ready_future<>();

--- a/test/raft/randomized_nemesis_test.cc
+++ b/test/raft/randomized_nemesis_test.cc
@@ -20,6 +20,11 @@
  */
 
 #include <seastar/testing/test_case.hh>
+#include <seastar/core/timed_out_error.hh>
+
+#include "raft/logical_clock.hh"
+
+using namespace seastar;
 
 // A direct translaction of a mathematical definition of a state machine
 // (see e.g. Wikipedia) as a C++ concept. Implementations of this concept
@@ -44,6 +49,145 @@ requires (typename M::state_t s, typename M::input_t i) {
     // The initial state, of type `state_t`.
     M::init;
     requires std::is_same_v<const typename M::state_t, decltype(M::init)>;
+};
+
+constexpr raft::logical_clock::duration operator "" _t(unsigned long long ticks) {
+    return raft::logical_clock::duration{ticks};
+}
+
+// A wrapper around `raft::logical_clock` that allows scheduling events to happen after a certain number of ticks.
+class logical_timer {
+    struct scheduled_impl {
+    private:
+        bool _resolved = false;
+
+        virtual void do_resolve() = 0;
+
+    public:
+        virtual ~scheduled_impl() { }
+
+        void resolve() {
+            if (!_resolved) {
+                do_resolve();
+                _resolved = true;
+            }
+        }
+
+        void mark_resolved() { _resolved = true; }
+        bool resolved() { return _resolved; }
+    };
+
+    struct scheduled {
+        raft::logical_clock::time_point _at;
+        seastar::shared_ptr<scheduled_impl> _impl;
+
+        void resolve() { _impl->resolve(); }
+        bool resolved() { return _impl->resolved(); }
+    };
+
+    raft::logical_clock _clock;
+
+    // A min-heap of `scheduled` events sorted by `_at`.
+    std::vector<scheduled> _scheduled;
+
+    // Comparator for the `_scheduled` min-heap.
+    static bool cmp(const scheduled& a, const scheduled& b) {
+        return a._at > b._at;
+    }
+
+public:
+    logical_timer() = default;
+
+    logical_timer(const logical_timer&) = delete;
+    logical_timer(logical_timer&&) = default;
+
+    // Returns the current logical time (number of `tick()`s since initialization).
+    raft::logical_clock::time_point now() {
+        return _clock.now();
+    }
+
+    // Tick the internal clock.
+    // Resolve all events whose scheduled times arrive after that tick.
+    void tick() {
+        _clock.advance();
+        while (!_scheduled.empty() && _scheduled.front()._at <= _clock.now()) {
+            _scheduled.front().resolve();
+            std::pop_heap(_scheduled.begin(), _scheduled.end(), cmp);
+            _scheduled.pop_back();
+        }
+    }
+
+    // Given a future `f` and a logical time point `tp`, returns a future that resolves
+    // when either `f` resolves or the time point `tp` arrives (according to the number of `tick()` calls),
+    // whichever comes first.
+    //
+    // Note: if `tp` comes first, that doesn't cancel any in-progress computations behind `f`.
+    // `f` effectively becomes a discarded future.
+    // Note: there is a possibility that the internal heap will grow unbounded if we call `with_timeout`
+    // more often than we `tick`, so don't do that. It is recommended to call at least one
+    // `tick` per one `with_timeout` call (on average in the long run).
+    template <typename... T>
+    future<T...> with_timeout(raft::logical_clock::time_point tp, future<T...> f) {
+        if (f.available()) {
+            return f;
+        }
+
+        struct sched : public scheduled_impl {
+            promise<T...> _p;
+
+            virtual ~sched() override { }
+            virtual void do_resolve() override {
+                _p.set_exception(std::make_exception_ptr(timed_out_error()));
+            }
+        };
+
+        auto s = make_shared<sched>();
+        auto res = s->_p.get_future();
+
+        _scheduled.push_back(scheduled{
+            ._at = tp,
+            ._impl = s
+        });
+        std::push_heap(_scheduled.begin(), _scheduled.end(), cmp);
+
+        (void)f.then_wrapped([s = std::move(s)] (auto&& f) mutable {
+            if (s->resolved()) {
+                f.ignore_ready_future();
+            } else {
+                f.forward_to(std::move(s->_p));
+                s->mark_resolved();
+                // tick() will (eventually) clear the `_scheduled` entry.
+            }
+        });
+
+        return res;
+    }
+
+    // Returns a future that resolves after a number of `tick()`s represented by `d`.
+    // Example usage: `sleep(20_t)` resolves after 20 `tick()`s.
+    // Note: analogous remark applies as for `with_timeout`, i.e. make sure to call at least one `tick`
+    // per one `sleep` call on average.
+    future<> sleep(raft::logical_clock::duration d) {
+        if (d == raft::logical_clock::duration{0}) {
+            return make_ready_future<>();
+        }
+
+        struct sched : public scheduled_impl {
+            promise<> _p;
+            virtual ~sched() override {}
+            virtual void do_resolve() override { _p.set_value(); }
+        };
+
+        auto s = make_shared<sched>();
+        auto f = s->_p.get_future();
+        _scheduled.push_back(scheduled{
+            ._at = now() + d,
+            ._impl = std::move(s)
+        });
+        std::push_heap(_scheduled.begin(), _scheduled.end(), cmp);
+
+        return f;
+    }
 };
 
 SEASTAR_TEST_CASE(dummy_test) {

--- a/test/raft/randomized_nemesis_test.cc
+++ b/test/raft/randomized_nemesis_test.cc
@@ -537,6 +537,117 @@ public:
     }
 };
 
+template <typename State, State init_state>
+class persistence : public raft::persistence {
+    snapshots_t<State>& _snapshots;
+
+    std::pair<raft::snapshot, State> _stored_snapshot;
+    std::pair<raft::term_t, raft::server_id> _stored_term_and_vote;
+
+    // Invariants:
+    // 1. for each entry except the first, the raft index is equal to the raft index of the previous entry plus one.
+    // 2. the index of the first entry is <= _stored_snapshot.first.idx + 1.
+    // 3. the index of the last entry is >= _stored_snapshot.first.idx.
+    // Informally, the last two invariants say that the stored log intersects or ``touches'' the snapshot ``on the right side''.
+    raft::log_entries _stored_entries;
+
+    // Returns an iterator to the entry in `_stored_entries` whose raft index is `idx` if the entry exists.
+    // If all entries in `_stored_entries` have greater indexes, returns the first one.
+    // If all entries have smaller indexes, returns end().
+    raft::log_entries::iterator find(raft::index_t idx) {
+        // The correctness of this depends on the `_stored_entries` invariant.
+        auto b = _stored_entries.begin();
+        if (b == _stored_entries.end() || (*b)->idx >= idx) {
+            return b;
+        }
+        return b + std::min((idx - (*b)->idx).get_value(), _stored_entries.size());
+    }
+
+public:
+    // If this is the first server of a cluster, it must be initialized with a singleton configuration
+    // containing opnly this server's ID which must be also provided here as `init_config_id`.
+    // Otherwise it must be initialized with an empty configuration (it will be added to the cluster
+    // through a configuration change) and `init_config_id` must be `nullopt`.
+    persistence(snapshots_t<State>& snaps, std::optional<raft::server_id> init_config_id)
+        : _snapshots(snaps)
+        , _stored_snapshot(
+                raft::snapshot{
+                    .config = init_config_id ? raft::configuration{*init_config_id} : raft::configuration{}
+                },
+                init_state)
+        , _stored_term_and_vote(raft::term_t{1}, raft::server_id{})
+    {}
+
+    virtual future<> store_term_and_vote(raft::term_t term, raft::server_id vote) override {
+        _stored_term_and_vote = std::pair{term, vote};
+        co_return;
+    }
+
+    virtual future<std::pair<raft::term_t, raft::server_id>> load_term_and_vote() override {
+        co_return _stored_term_and_vote;
+    }
+
+    virtual future<> store_snapshot(const raft::snapshot& snap, size_t preserve_log_entries) override {
+        // The snapshot's index cannot be smaller than the index of the first stored entry minus one;
+        // that would create a ``gap'' in the log.
+        assert(_stored_entries.empty() || snap.idx + 1 >= _stored_entries.front()->idx);
+
+        auto it = _snapshots.find(snap.id);
+        assert(it != _snapshots.end());
+        _stored_snapshot = {snap, it->second};
+
+        auto first_to_remain = snap.idx + 1 >= preserve_log_entries ? raft::index_t{snap.idx + 1 - preserve_log_entries} : raft::index_t{0};
+        _stored_entries.erase(_stored_entries.begin(), find(first_to_remain));
+
+        co_return;
+    }
+
+    virtual future<raft::snapshot> load_snapshot() override {
+        auto [snap, state] = _stored_snapshot;
+        _snapshots[snap.id] = std::move(state);
+        co_return snap;
+    }
+
+    virtual future<> store_log_entries(const std::vector<raft::log_entry_ptr>& entries) override {
+        if (entries.empty()) {
+            co_return;
+        }
+
+        // The raft server is supposed to provide entries in strictly increasing order,
+        // hence the following assertions.
+        if (_stored_entries.empty()) {
+            assert(entries.front()->idx == _stored_snapshot.first.idx + 1);
+        } else {
+            assert(entries.front()->idx == _stored_entries.back()->idx + 1);
+        }
+
+        _stored_entries.push_back(entries[0]);
+        for (size_t i = 1; i < entries.size(); ++i) {
+            assert(entries[i]->idx == entries[i-1]->idx + 1);
+            _stored_entries.push_back(entries[i]);
+        }
+
+        co_return;
+    }
+
+    virtual future<raft::log_entries> load_log() override {
+        co_return _stored_entries;
+    }
+
+    virtual future<> truncate_log(raft::index_t idx) override {
+        _stored_entries.erase(find(idx), _stored_entries.end());
+        co_return;
+    }
+
+    virtual future<> abort() override {
+        // There are no yields anywhere in our methods so no need to wait for anything.
+        // We assume that our methods won't be called after `abort()`.
+        // TODO: is this assumption correct? This could be expressed in the type system by making `abort()`
+        // a &&-qualified method (meaning that it consumes the object which then cannot be used).
+        co_return;
+    }
+};
+
 SEASTAR_TEST_CASE(dummy_test) {
     return seastar::make_ready_future<>();
 }

--- a/test/raft/randomized_nemesis_test.cc
+++ b/test/raft/randomized_nemesis_test.cc
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2021 ScyllaDB
+ */
+
+/*
+ * This file is part of Scylla.
+ *
+ * Scylla is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Scylla is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <seastar/testing/test_case.hh>
+
+// A direct translaction of a mathematical definition of a state machine
+// (see e.g. Wikipedia) as a C++ concept. Implementations of this concept
+// do not store the state, they only define the types, the transition function
+// (which is a pure function), and the initial state (which is a constant).
+template <typename M> concept PureStateMachine =
+requires (typename M::state_t s, typename M::input_t i) {
+    // The type of all possible states.
+    typename M::state_t;
+
+    // The type of all possible inputs (commands).
+    typename M::input_t;
+
+    // The type of all possible outputs.
+    typename M::output_t;
+
+    // The transition function (a pure function - no side effects). It takes a state
+    // and an input, and returns the next state and the output produced
+    // by applying the input to the given state.
+    { M::delta(s, i) } -> std::same_as<std::pair<typename M::state_t, typename M::output_t>>;
+
+    // The initial state, of type `state_t`.
+    M::init;
+    requires std::is_same_v<const typename M::state_t, decltype(M::init)>;
+};
+
+SEASTAR_TEST_CASE(dummy_test) {
+    return seastar::make_ready_future<>();
+}

--- a/test/raft/randomized_nemesis_test.cc
+++ b/test/raft/randomized_nemesis_test.cc
@@ -33,6 +33,7 @@
 #include "idl/uuid.dist.impl.hh"
 
 using namespace seastar;
+using namespace std::chrono_literals;
 
 // A direct translaction of a mathematical definition of a state machine
 // (see e.g. Wikipedia) as a C++ concept. Implementations of this concept
@@ -645,6 +646,80 @@ public:
         // TODO: is this assumption correct? This could be expressed in the type system by making `abort()`
         // a &&-qualified method (meaning that it consumes the object which then cannot be used).
         co_return;
+    }
+};
+
+// A failure detector using heartbeats for deciding whether to convict a server
+// as failed. We convict a server if we don't receive a heartbeat for a long enough time.
+// `failure_detector` assumes a message-passing method given by a `send_heartbeat_t` function
+// through the constructor for sending heartbeats and assumes that `receive_heartbeat` is called
+// whenever another server sends a message to us.
+// To decide who to send heartbeats to we use the ``current knowledge'' of servers in the network
+// which is updated through `add_server` and `remove_server` functions.
+class failure_detector : public raft::failure_detector {
+public:
+    using send_heartbeat_t = std::function<void(raft::server_id dst)>;
+
+private:
+    raft::logical_clock _clock;
+
+    // The set of known servers, used to broadcast heartbeats.
+    std::unordered_set<raft::server_id> _known;
+
+    // The last time we received a heartbeat from a server.
+    std::unordered_map<raft::server_id, raft::logical_clock::time_point> _last_heard;
+
+    // The last time we sent a heartbeat.
+    raft::logical_clock::time_point _last_beat;
+
+    send_heartbeat_t _send_heartbeat;
+
+public:
+    failure_detector(send_heartbeat_t f)
+        : _send_heartbeat(std::move(f))
+    {
+        send_heartbeats();
+        assert(_last_beat == _clock.now());
+    }
+
+    void receive_heartbeat(raft::server_id src) {
+        assert(_known.contains(src));
+        _last_heard[src] = std::max(_clock.now(), _last_heard[src]);
+    }
+
+    void tick() {
+        _clock.advance();
+
+        // TODO: make it adjustable
+        static const raft::logical_clock::duration _heartbeat_period = 10_t;
+
+        if (_last_beat + _heartbeat_period <= _clock.now()) {
+            send_heartbeats();
+        }
+    }
+
+    void send_heartbeats() {
+        for (auto& dst : _known) {
+            _send_heartbeat(dst);
+        }
+        _last_beat = _clock.now();
+    }
+
+    // We expect a server to be added through this function before we receive a heartbeat from it.
+    void add_server(raft::server_id id) {
+        _known.insert(id);
+    }
+
+    void remove_server(raft::server_id id) {
+        _known.erase(id);
+        _last_heard.erase(id);
+    }
+
+    bool is_alive(raft::server_id id) override {
+        // TODO: make it adjustable
+        static const raft::logical_clock::duration _convict_threshold = 50_t;
+
+        return _clock.now() < _last_heard[id] + _convict_threshold;
     }
 };
 

--- a/test/raft/randomized_nemesis_test.cc
+++ b/test/raft/randomized_nemesis_test.cc
@@ -35,6 +35,8 @@
 using namespace seastar;
 using namespace std::chrono_literals;
 
+seastar::logger tlogger("randomized_nemesis_test");
+
 // A direct translaction of a mathematical definition of a state machine
 // (see e.g. Wikipedia) as a C++ concept. Implementations of this concept
 // do not store the state, they only define the types, the transition function
@@ -720,6 +722,125 @@ public:
         static const raft::logical_clock::duration _convict_threshold = 50_t;
 
         return _clock.now() < _last_heard[id] + _convict_threshold;
+    }
+};
+
+// `network` is a simple priority queue of `event`s, where an `event` is a message associated
+// with its planned delivery time. The queue uses a logical clock to decide when to deliver messages.
+// It delives all messages whose associated times are smaller than the ``current time'', the latter
+// determined by the number of `tick()` calls.
+//
+// Note: the actual delivery happens through a function that is passed in the `network` constructor.
+// The function may return `false` (for whatever reason) denoting that it failed to deliver the message.
+// In this case network will backup this message and retry the delivery on every later `tick` until
+// it succeeds.
+template <typename Payload>
+class network {
+public:
+    // When the time comes to deliver a message we use this function.
+    // However, based on the implementation, delivery may not be possible at the moment we try
+    // it (for example when delivery is implemented as pushing onto another queue which is currently
+    // full); this is represented by the returned boolean: delivery was successful if and only if
+    // the function returns true; if it wasn't successful, we are supposed to retry later.
+    using deliver_t = std::function<bool(raft::server_id src, raft::server_id dst, const Payload&)>;
+
+private:
+    struct message {
+        raft::server_id src;
+        raft::server_id dst;
+
+        // shared ptr to implement duplication of messages
+        lw_shared_ptr<Payload> payload;
+    };
+
+    struct event {
+        raft::logical_clock::time_point time;
+        message msg;
+    };
+
+    deliver_t _deliver;
+
+    // A min-heap of event occurences compared by their time points.
+    std::vector<event> _events;
+
+    // Comparator for the `_events` min-heap.
+    static bool cmp(const event& o1, const event& o2) {
+        return o1.time > o2.time;
+    }
+
+    // A FIFO queue of backed up messages, i.e. messages that couldn't have been delivered
+    // at their scheduled times according to the delivery function. We retry those messages
+    // on each tick.
+    // We use a list to be able to remove messages from the middle in O(1) (when we retry
+    // only some messages in `_delayed` may successfully be delivered, possibly from the middle
+    // of the queue).
+    // Note: using this list should rarely be necessary; delivery failure usually means that something's
+    // wrong with the testing infrastructure (e.g. it can't keep up with processing incoming
+    // messages). When we e.g. simulate node crashes, messages to these nodes should be dropped,
+    // which should be represented by the delivery function returning `true` (but silently
+    // dropping the ``delivered'' message).
+    std::list<message> _delayed;
+
+    // A pair (dst, [src1, src2, ...]) in this set denotes that `dst`
+    // does not receive messages from src1, src2, ...
+    std::unordered_map<raft::server_id, std::unordered_set<raft::server_id>> _grudges;
+
+    raft::logical_clock _clock;
+
+public:
+    network(deliver_t f)
+        : _deliver(std::move(f)) {}
+
+    void send(raft::server_id src, raft::server_id dst, Payload payload) {
+        // Predict the delivery time in advance.
+        // Our prediction may be wrong if a grudge exists at this expected moment of delivery.
+        // Messages may also be reordered.
+        // TODO: scale with number of msgs already in transit and payload size?
+        // TODO: randomize the delivery time
+        auto delivery_time = _clock.now() + 5_t;
+
+        _events.push_back(event{delivery_time, message{src, dst, make_lw_shared<Payload>(std::move(payload))}});
+        std::push_heap(_events.begin(), _events.end(), cmp);
+    }
+
+    void tick() {
+        _clock.advance();
+        deliver();
+    }
+
+private:
+    void deliver() {
+        // Retry all delayed messages first.
+        for (auto it = _delayed.begin(); it != _delayed.end();) {
+            if (_deliver(it->src, it->dst, *it->payload)) {
+                it = _delayed.erase(it);
+            } else {
+                // Delayed again.
+                ++it;
+            }
+        }
+
+        // Deliver every message whose time has come.
+        while (!_events.empty() && _events.front().time <= _clock.now()) {
+            auto& [_, m] = _events.front();
+            if (!_grudges[m.dst].contains(m.src)) {
+                if (!_deliver(m.src, m.dst, *m.payload)) {
+                    // Cannot deliver at this moment. Backup the message to be retried on the next `deliver()` call.
+                    _delayed.push_back(std::move(m));
+
+                    // _delayed should rarely be needed, if _delayed is growing then the test infrastructure
+                    // must have some kind of a liveness problem (which may eventually cause OOM). Let's warn the user.
+                    if (_delayed.size() > 100) {
+                        tlogger.warn("network: large number of delayed messages ({})", _delayed.size());
+                    }
+                }
+            } else {
+                // A grudge means that we drop the message.
+            }
+
+            std::pop_heap(_events.begin(), _events.end(), cmp);
+            _events.pop_back();
+        }
     }
 };
 

--- a/test/raft/randomized_nemesis_test.cc
+++ b/test/raft/randomized_nemesis_test.cc
@@ -909,6 +909,149 @@ private:
     }
 };
 
+// Contains a `raft::server` and other facilities needed for it and the underlying
+// modules (persistence, rpc, etc.) to run, and to communicate with the external environment.
+template <PureStateMachine M>
+class raft_server {
+    raft::server_id _id;
+
+    std::unique_ptr<snapshots_t<typename M::state_t>> _snapshots;
+    std::unique_ptr<delivery_queue<typename M::state_t>> _queue;
+    std::unique_ptr<raft::server> _server;
+
+    // The following objects are owned by _server:
+    impure_state_machine<M>& _sm;
+    rpc<typename M::state_t>& _rpc;
+
+    bool _started = false;
+    bool _stopped = false;
+
+public:
+    // Create a `raft::server` with the given `id` and all other facilities required
+    // by the server (the state machine, RPC instance and so on). The server will use
+    // `send_rpc` to send RPC messages to other servers and `fd` for failure detection.
+    //
+    // If this is the first server in the cluster, pass `first_server = true`; this will
+    // cause the server to be created with a non-empty singleton configuration containing itself.
+    // Otherwise, pass `first_server = false`; that server, in order to function, must be then added
+    // by the existing cluster through a configuration change.
+    //
+    // The created server is not started yet; use `start` for that.
+    static std::unique_ptr<raft_server> create(
+            raft::server_id id,
+            shared_ptr<failure_detector> fd,
+            bool first_server,
+            typename rpc<typename M::state_t>::send_message_t send_rpc) {
+        using state_t = typename M::state_t;
+
+        auto snapshots = std::make_unique<snapshots_t<state_t>>();
+        auto sm = std::make_unique<impure_state_machine<M>>(*snapshots);
+        auto rpc_ = std::make_unique<rpc<state_t>>(*snapshots, std::move(send_rpc));
+        auto persistence_ = std::make_unique<persistence<state_t, M::init>>(*snapshots, first_server ? std::optional{id} : std::nullopt);
+        auto queue = std::make_unique<delivery_queue<state_t>>(*rpc_);
+
+        auto& sm_ref = *sm;
+        auto& rpc_ref = *rpc_;
+
+        auto server = raft::create_server(
+                id, std::move(rpc_), std::move(sm), std::move(persistence_), std::move(fd),
+                raft::server::configuration{});
+
+        return std::make_unique<raft_server>(initializer{
+            ._id = id,
+            ._snapshots = std::move(snapshots),
+            ._queue = std::move(queue),
+            ._server = std::move(server),
+            ._sm = sm_ref,
+            ._rpc = rpc_ref
+        });
+    }
+
+    ~raft_server() {
+        assert(!_started || _stopped);
+    }
+
+    raft_server(const raft_server&&) = delete;
+    raft_server(raft_server&&) = delete;
+
+    // Start the server. Can be called at most once.
+    //
+    // TODO: implement server ``crashes'' and ``restarts''.
+    // A crashed server needs a new delivery queue to be created in order to restart but must
+    // reuse the previous `persistence`. Perhaps the delivery queue should be created in `start`?
+    future<> start() {
+        assert(!_started);
+        _started = true;
+
+        co_await _server->start();
+        _queue->start();
+    }
+
+    // Stop the given server. Must be called before the server is destroyed
+    // (unless it was never started in the first place).
+    future<> abort() && {
+        assert(_started);
+        co_await std::move(*_queue).abort();
+        co_await _server->abort();
+        _stopped = true;
+    }
+
+    void tick() {
+        assert(_started);
+        _rpc.tick();
+        _server->tick();
+    }
+
+    future<call_result_t<M>> call(
+            typename M::input_t input,
+            raft::logical_clock::time_point timeout,
+            logical_timer& timer) {
+        assert(_started);
+        return ::call(std::move(input), timeout, timer, *_server, _sm);
+    }
+
+    future<> set_configuration(raft::server_address_set c) {
+        assert(_started);
+        return _server->set_configuration(std::move(c));
+    }
+
+    bool is_leader() const {
+        return _server->is_leader();
+    }
+
+    raft::server_id id() const {
+        return _id;
+    }
+
+    bool deliver(raft::server_id src, const typename rpc<typename M::state_t>::message_t& m) {
+        assert(_started);
+        return _queue->push(src, m);
+    }
+
+private:
+    struct initializer {
+        raft::server_id _id;
+
+        std::unique_ptr<snapshots_t<typename M::state_t>> _snapshots;
+        std::unique_ptr<delivery_queue<typename M::state_t>> _queue;
+        std::unique_ptr<raft::server> _server;
+
+        impure_state_machine<M>& _sm;
+        rpc<typename M::state_t>& _rpc;
+    };
+
+    raft_server(initializer i)
+        : _id(i._id)
+        , _snapshots(std::move(i._snapshots))
+        , _queue(std::move(i._queue))
+        , _server(std::move(i._server))
+        , _sm(i._sm)
+        , _rpc(i._rpc) {
+    }
+
+    friend std::unique_ptr<raft_server> std::make_unique<raft_server, raft_server::initializer>(initializer&&);
+};
+
 SEASTAR_TEST_CASE(dummy_test) {
     return seastar::make_ready_future<>();
 }

--- a/test/raft/randomized_nemesis_test.cc
+++ b/test/raft/randomized_nemesis_test.cc
@@ -1052,6 +1052,134 @@ private:
     friend std::unique_ptr<raft_server> std::make_unique<raft_server, raft_server::initializer>(initializer&&);
 };
 
+// Raft uses UUID 0 as special case.
+// Convert local 0-based integer id to raft +1 UUID
+static utils::UUID to_raft_uuid(size_t local_id) {
+    return utils::UUID{0, local_id + 1};
+}
+
+static raft::server_id to_raft_id(size_t local_id) {
+    return raft::server_id{to_raft_uuid(local_id)};
+}
+
+// A set of `raft_server`s connected by a `network`.
+//
+// The `network` is initialized with a message delivery function
+// which notifies the destination's failure detector on each message
+// and if the message contains an RPC payload, pushes it into the destination's
+// `delivery_queue`.
+//
+// Needs to be periodically `tick()`ed which ticks the network
+// and underlying servers.
+template <PureStateMachine M>
+class environment {
+    using input_t = typename M::output_t;
+    using state_t = typename M::state_t;
+    using output_t = typename M::output_t;
+
+    struct route {
+        std::unique_ptr<raft_server<M>> _server;
+        shared_ptr<failure_detector> _fd;
+    };
+
+    // Used to deliver messages coming from the network to appropriate servers and their failure detectors.
+    // Also keeps the servers and the failure detectors alive (owns them).
+    // Before we show a Raft server to others we must add it to this map.
+    std::unordered_map<raft::server_id, route> _routes;
+
+    // Used to create a new ID in `new_server`.
+    size_t _next_id = 0;
+
+    // Engaged optional: RPC message, nullopt: heartbeat
+    using message_t = std::optional<typename rpc<state_t>::message_t>;
+    network<message_t> _network;
+
+    bool _stopped = false;
+
+public:
+    environment()
+            : _network(
+        [this] (raft::server_id src, raft::server_id dst, const message_t& m) -> bool {
+            auto& [s, fd] = _routes.at(dst);
+            fd->receive_heartbeat(src);
+            if (m) {
+                return s->deliver(src, *m);
+            }
+            return true;
+        }) {
+    }
+
+    ~environment() {
+        assert(_routes.empty() || _stopped);
+    }
+
+    environment(const environment&) = delete;
+    environment(environment&&) = delete;
+
+    // TODO: adjustable/randomizable ticking ratios
+    void tick() {
+        _network.tick();
+        for (auto& [_, r] : _routes) {
+            r._server->tick();
+            r._fd->tick();
+        }
+    }
+
+    // Creates and starts a server with a local (uniquely owned) failure detector,
+    // connects it to the network and returns its ID.
+    //
+    // If `first == true` the server is created with a singleton configuration containing itself.
+    // Otherwise it is created with an empty configuration. The user must explicitly ask for a configuration change
+    // if they want to make a cluster (group) out of this server and other existing servers.
+    // The user should be able to create multiple clusters by calling `new_server` multiple times with `first = true`.
+    // (`first` means ``first in group'').
+    future<raft::server_id> new_server(bool first) {
+        auto id = to_raft_id(_next_id++);
+
+        // TODO: in the future we want to simulate multiple raft servers running on a single ``node'',
+        // sharing a single failure detector. We will then likely split `new_server` into two steps: `new_node` and `new_server`,
+        // the first creating the failure detector for a node and wiring it up, the second creating a server on a given node.
+        // We will also possibly need to introduce some kind of ``node IDs'' which `failure_detector` (and `network`)
+        // will operate on (currently they operate on `raft::server_id`s, assuming a 1-1 mapping of server-to-node).
+        auto fd = seastar::make_shared<failure_detector>([id, this] (raft::server_id dst) {
+            _network.send(id, dst, std::nullopt);
+        });
+
+        auto srv = raft_server<M>::create(id, fd, first,
+                [id, this] (raft::server_id dst, typename rpc<state_t>::message_t m) {
+            _network.send(id, dst, {std::move(m)});
+        });
+
+        co_await srv->start();
+
+        // Add us to other servers' failure detectors.
+        for (auto& [_, r] : _routes) {
+            r._fd->add_server(id);
+        }
+
+        // Add other servers to our failure detector.
+        for (auto& [id, _] : _routes) {
+            fd->add_server(id);
+        }
+
+        _routes.emplace(id, route{std::move(srv), std::move(fd)});
+
+        co_return id;
+    }
+
+    raft_server<M>& get_server(raft::server_id id) {
+        return *_routes.at(id)._server;
+    }
+
+    // Must be called before we are destroyed unless `new_server` was never called.
+    future<> abort() && {
+        for (auto& [_, r] : _routes) {
+            co_await std::move(*r._server).abort();
+        }
+        _stopped = true;
+    }
+};
+
 SEASTAR_TEST_CASE(dummy_test) {
     return seastar::make_ready_future<>();
 }

--- a/test/raft/randomized_nemesis_test.cc
+++ b/test/raft/randomized_nemesis_test.cc
@@ -1235,6 +1235,130 @@ future<> with_env_and_ticker(noncopyable_function<future<>(environment<M>&, tick
     });
 }
 
-SEASTAR_TEST_CASE(dummy_test) {
-    return seastar::make_ready_future<>();
+struct ExReg {
+    // Replaces the state with `x` and returns the previous state.
+    struct exchange { int32_t x; };
+
+    // Returns the state.
+    struct read {};
+
+    // Return value for `exchange` or `read`.
+    struct ret { int32_t x; };
+
+    using state_t = int32_t;
+    using input_t = std::variant<read, exchange>;
+    using output_t = ret;
+
+    static std::pair<state_t, output_t> delta(state_t curr, input_t input) {
+        using res_t = std::pair<state_t, output_t>;
+
+        return std::visit(make_visitor(
+        [&curr] (const exchange& w) -> res_t {
+            return {w.x, ret{curr}};
+        },
+        [&curr] (const read&) -> res_t {
+            return {curr, ret{curr}};
+        }
+        ), input);
+    }
+
+    static const state_t init = 0;
+};
+
+namespace ser {
+    template <>
+    struct serializer<ExReg::exchange> {
+        template <typename Output>
+        static void write(Output& buf, const ExReg::exchange& op) { serializer<int32_t>::write(buf, op.x); };
+
+        template <typename Input>
+        static ExReg::exchange read(Input& buf) { return { serializer<int32_t>::read(buf) }; }
+
+        template <typename Input>
+        static void skip(Input& buf) { serializer<int32_t>::skip(buf); }
+    };
+
+    template <>
+    struct serializer<ExReg::read> {
+        template <typename Output>
+        static void write(Output& buf, const ExReg::read&) {};
+
+        template <typename Input>
+        static ExReg::read read(Input& buf) { return {}; }
+
+        template <typename Input>
+        static void skip(Input& buf) {}
+    };
+}
+
+bool operator==(ExReg::ret a, ExReg::ret b) { return a.x == b.x; }
+
+SEASTAR_TEST_CASE(basic_test) {
+    return with_env_and_ticker<ExReg>([] (environment<ExReg>& env, ticker& t) -> future<> {
+        using output_t = typename ExReg::output_t;
+
+        logical_timer timer;
+        t.start([&] {
+            env.tick();
+            timer.tick();
+        }, 10000);
+
+        auto leader_id = co_await env.new_server(true);
+
+        // Wait at most 100 ticks for the server to elect itself as a leader.
+        co_await timer.with_timeout(timer.now() + 100_t, ([&] () -> future<> {
+            while (true) {
+                if (env.get_server(leader_id).is_leader()) {
+                    co_return;
+                }
+                co_await seastar::later();
+            }
+        })());
+
+        assert(env.get_server(leader_id).is_leader());
+
+        auto call = [&] (ExReg::input_t input, raft::logical_clock::duration timeout) {
+            return env.get_server(leader_id).call(std::move(input),  timer.now() + timeout, timer);
+        };
+
+        auto eq = [] (const call_result_t<ExReg>& r, const output_t& expected) {
+            return std::holds_alternative<output_t>(r) && std::get<output_t>(r) == expected;
+        };
+
+        for (int i = 1; i <= 100; ++i) {
+            assert(eq(co_await call(ExReg::exchange{i}, 100_t), ExReg::ret{i - 1}));
+        }
+
+        tlogger.debug("100 exchanges - single server - passed");
+
+        auto id2 = co_await env.new_server(false);
+        auto id3 = co_await env.new_server(false);
+
+        tlogger.debug("Started 2 more servers, changing configuration");
+
+        co_await env.get_server(leader_id).set_configuration({{.id = leader_id}, {.id = id2}, {.id = id3}});
+
+        tlogger.debug("Configuration changed");
+
+        co_await call(ExReg::exchange{0}, 100_t);
+        for (int i = 1; i <= 100; ++i) {
+            assert(eq(co_await call(ExReg::exchange{i}, 100_t), ExReg::ret{i - 1}));
+        }
+
+        tlogger.debug("100 exchanges - three servers - passed");
+
+        // concurrent calls
+        std::vector<future<call_result_t<ExReg>>> futs;
+        for (int i = 0; i < 100; ++i) {
+            futs.push_back(call(ExReg::read{}, 100_t));
+            co_await timer.sleep(2_t);
+        }
+        for (int i = 0; i < 100; ++i) {
+            assert(eq(co_await std::move(futs[i]), ExReg::ret{100}));
+        }
+
+        tlogger.debug("100 concurrent reads - three servers - passed");
+    });
+
+    tlogger.debug("Finished");
 }


### PR DESCRIPTION
The PR starts by introducing `PureStateMachine`,
which is the most direct translation of the mathematical
definition of a state machine that I could come up with. Represented by
a C++ concept, it consists of: a set of inputs (represented by the
`input_t` type), outputs (`output_t` type), states (`state_t`), an
initial state (`init`) and a transition function (called `delta`) which
given a state and an input returns a new state and an output.

The rest of the distributed testing infrastructure is going to be
generic w.r.t. `PureStateMachine`. This will allow easily implementing
tests using both simple and complex state machines by substituting the
proper definition for this concept.

One possibility of modifying this definition would be to have `delta`
return `future<pair<state_t, output_t>>` instead of
`pair<state_t, output_t>`. This would lose some "purity" but allow
long computations without reactor stalls in the tests. Such modification,
if we decide to do it, is trivial.


To replicate a state machine, our Raft implementation requires it to
be represented with the `raft::state_machine` interface.

`impure_state_machine` is an implementation of `raft::state_machine`
that wraps a `PureStateMachine`. It keeps a variable of type `state_t`
representing the current state. In `apply` it deserializes the given
command into `input_t`, uses the transition (`delta`) function to
produce the next state and output, replaces its current state with the
obtained state and returns the output (more on that below); it does so
sequentially for every given command. We can think of `PureStateMachine`
as the actual state machine - the business logic, and `impure_state_machine`
as the "boilerplate" that allows the pure machine to be replicated by
Raft and communicate with the external world.

The interface also requires maintainance of snapshots. We introduce the
`snapshots_t` type representing a set of snapshots known by a state
machine. `impure_state_machine` keeps a reference to `snapshots_t`
because it will share it with an implementation of `raft::persistence`
coming with a later commit.

Returning outputs is a bit tricky because `apply` is "write-only" - it
returns `future<>`. We use the following technique:
1. Before sending a command to a Raft leader through `server::add_entry`,
one must first directly contact the instance of `impure_state_machine`
replicated by the leader, asking it to allocate an "output channel".
2. On such a request, `impure_state_machine` creates a channel
(represented by a promise-future pair) and a unique ID; it stores the
input side of the channel (the promise) with this ID internally and returns
the ID and the output side of the channel (the future) to the requester.
3. After obtaining the ID, one serializes the ID together with the input
and sends it as a command to Raft. Thus commands are (ID, machine input)
pairs.
4. When `impure_state_machine` applies a command, it looks for a promise
with the given ID. If it finds one, it sends the output through this
channel.
5. The command sender waits for the output on the obtained future.

The allocation and deallocation of channels is done using the
`impure_state_machine::with_output_channel` function. The `call`
function is an implementation of the above technique.

Note that only the leader will attempt to send the output - other
replicas won't find the ID in their internal data structure. The set of
IDs and channels is no a part of the replicated state.

A failure may cause the output to never arrive (or even the command to
never be applied) so `call` waits for a limited time. It may also
mistakenly call a server which is not currently the leader, but it
is prepared to handle this error.


We implement the `raft::rpc` interface, allowing Raft servers to
communicate with other Raft servers.

The implementation is mostly boilerplate. It assumes that there exists a
method of message passing, given by a `send_message_t` function passed
in the constructor. It also handles the receival of messages in the
`receive` function. It defines the message type (`message_t`) that will
 be used by the message-passing method.

The actual message passing is implemented with `network` and `delivery_queue`
which we describe later.

The only slightly complex thing in `rpc` is the implementation of `send_snapshot`
which is the only function in the `raft::rpc` interface that actually
expects a response. To implement this, before sending the snapshot
message we allocate a promise-future pair and assign to it a unique ID;
we store the promise and the ID in a data structure. We then send the
snapshot together with the ID and wait on the future. The message
receival function on the other side, when it receives the snapshot message,
applies the snapshot and sends back a snapshot reply message that contains
the same ID. When we receive a snapshot reply message we look up the ID in the
data structure and if we find a promise, we push the reply through that
promise.

`rpc` also keeps a reference to `snapshots_t` - it will refer to the
same set of snapshots as the `impure_state_machine` on the same server.
It accesses the set when it receives or sends a snapshot message.

We define the `server_set` interface with two functions:
`add_server` and `remove_server`. `rpc` keeps a reference to a
`server_set` and adds/removes servers to/from this set when its
`add_server`/`remove_server` functions (from the `raft::rpc` interface)
get called. We do this because `rpc` does not actually care about the
current set of servers, but our future implementation of
`raft::failure_detector` will; thus it will also implement the
`server_set` interface and let `rpc` update it.


Probably the most complex implementation of this series, `persistence`
represents the data that does not get lost between server crashes and
restarts.

We store a log of commands in `_stored_entries`. It is invariably
"contiguous", meaning that the index of each entry except the first
is equal to the index of the previous entry at all times (i.e. after each
yield). Maintaining that invariant is actually pretty hard due to the
requirements of the interface. Namely, `store_log_entries` may be
called concurrently with different index sets. Consider the following
example. There are 3 concurrent calls of `store_log_entries`:
1. with indexes {1, 2, 3},
2. with indexes {4, 5, 6},
3. with indexes {7, 8, 9}.

Suppose that the log is initially empty.

Now suppose that call 3. is faster than everyone else. It easily stores
the entries without breaking the invariant; now the log contains
{7,8,9}. Now suppose that call 1. is the next fastest one. It now has
a problem because storing {1,2,3} would create a hole in the log, which
we do not allow. Thus it must wait for the gap {4,5,6} to be filled.

To implement the waiting we use an interval map of promises. When a call
wants to store a set of entries with indexes {n, n+1, ..., m}, it
creates a promise and inserts it into the map under the (closed) interval
[n-1, m+1] (keys in the interval map are intervals), then waits on the
corresponding future. Now, whenever someone manages to store entries
{n', n'+1 ..., m'}, it queries all intervals in the map that intersect
the interval [n', m'] and resolves the promises. Indeed, it is now safe
to store any contiguous set of entries which intersects or "touches"
the interval [n', m'] without creating a hole in the log (assuming
that in between no truncations happen, but for now we assert - probably
wrongly - that they don't; see the code). Fortunately, `boost::icl`
gives an easy-to-use interval map implementation.

`persistence` can also be asked to store or load a snapshot. For this it
shares the snapshots set with `impure_state_machine` and `rpc` through a
`snapshots_t&` variable.


In order to simulate a production environment as closely as possible, we
implement a failure detector which uses heartbeats for deciding whether
to convict a server as failed. We convict a server if we don't receive a
heartbeat for a long enough time.

Similarly to `rpc`, `failure_detector` assumes a message passing method
given by a `send_heartbeat_t` function through the constructor.

`failure_detector` also implements the `server_set` interface introduced
previously. It uses the knowledge about existing servers to decide who
to send heartbeats to (it broadcasts them to all known servers). When
we initialize `rpc`, we will pass it a reference to the `failure_detector`
where it expect a `server_set&`.


`network` is a simple priority queue of "events", where an event is a
message associated with delivery time. Each message contains a source,
a destination, and payload. The queue uses a logical clock to decide
when to deliver messages; it delivers are messages whose associated
times are smaller than the current time.

The exact delivery method is unknown to `network` but passed as a
`deliver_t` function in the constructor. The type of payload is generic.


The fact that `network` has delivered a message does not mean the
message was processed by the receiver. In fact, `network` assumes that
delivery is instantaneous, while processing a message may be a long,
complex computation, or even require IO. Thus, after a message is
delivered, something else must ensure that it is processed by the
destination server.

That something in our framework is `delivery_queue`. It will be the
bridge between `network` and `rpc`. While `network` is shared by all
servers - it represents the "environment" in which the servers live -
each server has its own private `delivery_queue`. When `network`
delivers an RPC message it will end up inside `delivery_queue`. A
separate fiber, `delivery_queue::receive_fiber()`, will process those
messages by calling `rpc::receive` (which is a potentially long
operation, thus returns a `future<>`) on the `rpc` of the destination
server.


`raft_server` is a package that contains the `raft::server` and other
facilities needed for the server to communicate with its environment:
the delivery queue, the set of snapshots (shared by
`impure_state_machine`, `rpc` and `persistence`), references to
`impure_state_machine` and `failure_detector`, the `future` returned by
`delivery_queue::receive_fiber` (if the server was started), and a
ticker which advances the clocks of `raft::server` and
`failure_detector`.

We also implement a `create_server` function that initializes the entire
package, a `start_server` function that starts the `raft::server`, the receive
fiber and the ticker, and a `stop_server` which does the opposite.

The `create_server` function requires a `network` whose payload type is
`optional<rpc<M::state_t>::message_t`, where `M` is the replicated
`PureStateMachine`. The optional distinguishes RPC messages from simple
heartbeats. We will see in the last commit (which wires everything up)
that when the `network` delivers a message we will notify the failure
detector and if the optional is engaged, push the contents onto the
delivery queue.


Finally, the PR introduces a simple test as an example of using the framework
introduced in previous commits. We introduce `RWRegister`, an implementation of
`PureStateMachine` that handles "write" and "read" inputs; a write
replaces the state and returns an acknowledgement, a read does not
modify the state and returns the current state. In order to pass the
inputs to Raft we must serialize them into commands so we implement
instances of `ser::serializer` for `RWRegister`'s input types.

The test creates a `network`, passing it a delivery message function
which notifies the destination's failure detector on each message and if
the message contains an RPC payload, pushes it into the destination's
`delivery_queue`. It also creates a ticker that advances the `network`'s
clock. Then it creates and starts a server and runs a simple mostly
sequential workload of writes, reads, and configuration changes
(although it seems that not everything is yet possible).


The pull request also fixes a bug that caused configuration change waiters
to never be notified; see the last commit.

----

cc @kostja @gleb-cloudius @ManManson @alecco

read commits in topological order for best review experience