### PR TITLE
treewide: don't include "db/system_distributed_keyspace.hh" from headers

### DIFF
--- a/database.cc
+++ b/database.cc
@@ -26,6 +26,7 @@
 #include <seastar/core/future-util.hh>
 #include "db/commitlog/commitlog_entry.hh"
 #include "db/system_keyspace.hh"
+#include "db/system_distributed_keyspace.hh"
 #include "db/commitlog/commitlog.hh"
 #include "db/config.hh"
 #include "to_string.hh"

--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -61,6 +61,7 @@
 #include "db/view/view_updating_consumer.hh"
 #include "db/system_keyspace_view_types.hh"
 #include "db/system_keyspace.hh"
+#include "db/system_distributed_keyspace.hh"
 #include "frozen_mutation.hh"
 #include "gms/inet_address.hh"
 #include "keys.hh"

--- a/db/view/view_builder.hh
+++ b/db/view/view_builder.hh
@@ -22,7 +22,6 @@
 #pragma once
 
 #include "database.hh"
-#include "db/system_distributed_keyspace.hh"
 #include "dht/i_partitioner.hh"
 #include "keys.hh"
 #include "query-request.hh"
@@ -43,6 +42,12 @@
 #include <optional>
 #include <unordered_map>
 #include <vector>
+
+namespace db {
+
+class system_distributed_keyspace;
+
+}
 
 namespace db::system_keyspace {
 

--- a/db/view/view_update_checks.hh
+++ b/db/view/view_update_checks.hh
@@ -21,10 +21,15 @@
 
 #pragma once
 
-#include "db/system_distributed_keyspace.hh"
 #include "streaming/stream_reason.hh"
 #include <boost/range/adaptor/map.hpp>
 #include <boost/algorithm/cxx11/any_of.hpp>
+
+namespace db {
+
+class system_distributed_keyspace;
+
+}
 
 namespace db::view {
 

--- a/message/messaging_service.hh
+++ b/message/messaging_service.hh
@@ -74,6 +74,7 @@ class update_backlog;
 class frozen_mutation;
 class frozen_schema;
 class partition_checksum;
+class canonical_mutation;
 
 namespace dht {
     class token;

--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -37,6 +37,7 @@
 #include "hashers.hh"
 #include "locator/network_topology_strategy.hh"
 #include "utils/bit_cast.hh"
+#include "service/migration_manager.hh"
 
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/algorithm/string/split.hpp>

--- a/repair/repair.hh
+++ b/repair/repair.hh
@@ -30,6 +30,7 @@
 #include <seastar/core/sharded.hh>
 #include <seastar/core/future.hh>
 #include <seastar/core/condition-variable.hh>
+#include <seastar/core/gate.hh>
 
 #include "database_fwd.hh"
 #include "frozen_mutation.hh"

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -51,6 +51,7 @@
 #include "repair/row_level.hh"
 #include "mutation_source_metadata.hh"
 #include "utils/stall_free.hh"
+#include "service/migration_manager.hh"
 
 extern logging::logger rlogger;
 

--- a/repair/row_level.hh
+++ b/repair/row_level.hh
@@ -23,11 +23,16 @@
 
 #include <vector>
 #include "gms/inet_address.hh"
-#include "db/system_distributed_keyspace.hh"
 #include "repair/repair.hh"
 #include <seastar/core/distributed.hh>
 
 class row_level_repair_gossip_helper;
+
+namespace db {
+
+class system_distributed_keyspace;
+
+}
 
 namespace gms {
     class gossiper;

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -93,6 +93,7 @@
 #include "cdc/cdc_options.hh"
 #include "utils/histogram_metrics_helper.hh"
 #include "service/paxos/prepare_summary.hh"
+#include "service/migration_manager.hh"
 #include "service/paxos/proposal.hh"
 #include "locator/token_metadata.hh"
 #include "seastar/core/coroutine.hh"

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -42,6 +42,7 @@
 #include <seastar/core/distributed.hh>
 #include "locator/snitch_base.hh"
 #include "db/system_keyspace.hh"
+#include "db/system_distributed_keyspace.hh"
 #include "utils/UUID.hh"
 #include "gms/inet_address.hh"
 #include "log.hh"

--- a/streaming/stream_session.cc
+++ b/streaming/stream_session.cc
@@ -55,6 +55,7 @@
 #include "streaming/stream_exception.hh"
 #include "service/storage_proxy.hh"
 #include "service/priority_manager.hh"
+#include "service/migration_manager.hh"
 #include "query-request.hh"
 #include "schema_registry.hh"
 #include "mutation_writer/multishard_writer.hh"

--- a/streaming/stream_session.hh
+++ b/streaming/stream_session.hh
@@ -53,10 +53,15 @@
 #include "streaming/session_info.hh"
 #include "query-request.hh"
 #include "dht/i_partitioner.hh"
-#include "db/system_distributed_keyspace.hh"
 #include <map>
 #include <vector>
 #include <memory>
+
+namespace db {
+
+class system_distributed_keyspace;
+
+}
 
 namespace db::view {
 


### PR DESCRIPTION
This just causes unneeded and slower recompliations. Instead replace
with forward declarations, or includes of smaller headers that were
incidentally brought in by the one removed. The .cc files that really
need it gain the include, but they are few.

Ref #1.