### PR TITLE
types: convert has_empty predicate to a concept

### DIFF
--- a/types.hh
+++ b/types.hh
@@ -305,22 +305,13 @@ operator<(const emptyable<T>& me1, const emptyable<T>& me2) {
 
 // Checks whether T::empty() const exists and returns bool
 template <typename T>
-class has_empty {
-    template <typename X>
-    constexpr static auto check(const X* x) -> std::enable_if_t<std::is_same<bool, decltype(x->empty())>::value, bool> {
-        return true;
-    }
-    template <typename X>
-    constexpr static auto check(...) -> bool {
-        return false;
-    }
-public:
-    constexpr static bool value = check<T>(nullptr);
+concept has_empty = requires (T obj) {
+    { obj.empty() } -> std::same_as<bool>;
 };
 
 template <typename T>
 using maybe_empty =
-        std::conditional_t<has_empty<T>::value, T, emptyable<T>>;
+        std::conditional_t<has_empty<T>, T, emptyable<T>>;
 
 class abstract_type;
 class data_value;


### PR DESCRIPTION
has_empty is a textbook example of a concept: it checks whether a type
has an empty() method that returns bool. It is now implemented with
enable_if, simplify it to a concept.

I verified that the debug build doesn't contain any incorrect
emtpyable<T> (e.g. for strings).