### PR TITLE
config: correct description of listen_address

### DIFF
--- a/conf/scylla.yaml
+++ b/conf/scylla.yaml
@@ -81,10 +81,12 @@ seed_provider:
           # Ex: "<ip1>,<ip2>,<ip3>"
           - seeds: "127.0.0.1"
 
-# Address or interface to bind to and tell other Scylla nodes to connect to.
+# Address to bind to and tell other Scylla nodes to connect to.
 # You _must_ change this if you want multiple nodes to be able to communicate!
 #
-# Setting listen_address to 0.0.0.0 is always wrong.
+# If you leave broadcast_address (below) empty, then setting listen_address
+# to 0.0.0.0 is wrong as other nodes will not know how to reach this node.
+# If you set broadcast_address, then you can set listen_address to 0.0.0.0.
 listen_address: localhost
 
 # Address to broadcast to other Scylla nodes

--- a/db/config.cc
+++ b/db/config.cc
@@ -226,12 +226,7 @@ db::config::config(std::shared_ptr<db::extensions> exts)
     , cluster_name(this, "cluster_name", value_status::Used, "",
         "The name of the cluster; used to prevent machines in one logical cluster from joining another. All nodes participating in a cluster must have the same value.")
     , listen_address(this, "listen_address", value_status::Used, "localhost",
-        "The IP address or hostname that Scylla binds to for connecting to other Scylla nodes. Set this parameter or listen_interface, not both. You must change the default setting for multiple nodes to communicate:\n"
-        "\n"
-        "Generally set to empty. If the node is properly configured (host name, name resolution, and so on), Scylla uses InetAddress.getLocalHost() to get the local address from the system.\n"
-        "For a single node cluster, you can use the default setting (localhost).\n"
-        "If Scylla can't find the correct address, you must specify the IP address or host name.\n"
-        "Never specify 0.0.0.0; it is always wrong.")
+        "The IP address or hostname that Scylla binds to for connecting to other Scylla nodes. You must change the default setting for multiple nodes to communicate. Do not set to 0.0.0.0, unless you have set broadcast_address to an address that other nodes can use to reach this node.")
     , listen_interface(this, "listen_interface", value_status::Unused, "eth0",
         "The interface that Scylla binds to for connecting to other Scylla nodes. Interfaces must correspond to a single address, IP aliasing is not supported. See listen_address.")
     , listen_interface_prefer_ipv6(this, "listen_interface_prefer_ipv6", value_status::Used, false,


### PR DESCRIPTION
 - it does not support using interface names
 - listen_interface is not supported
 - 0.0.0.0 will work (and is reasonable) if you set broadcast_address
 - empty setting is not supported

Fixes #8381.