### PR TITLE
storage_service: Reject replacing a node that has left the ring

### DIFF
--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -1539,6 +1539,12 @@ storage_service::prepare_replacement_info(std::unordered_set<gms::inet_address> 
             throw std::runtime_error(format("Cannot replace_address {} because it doesn't exist in gossip", replace_address));
         }
 
+        // Reject to replace a node that has left the ring
+        auto status = _gossiper.get_gossip_status(replace_address);
+        if (status == gms::versioned_value::STATUS_LEFT || status == gms::versioned_value::REMOVED_TOKEN) {
+            throw std::runtime_error(format("Cannot replace_address {} because it has left the ring, status={}", replace_address, status));
+        }
+
         auto tokens = get_tokens_for(replace_address);
         if (tokens.empty()) {
             throw std::runtime_error(format("Could not find tokens for {} to replace", replace_address));


### PR DESCRIPTION
1) start n1, n2, n3

2) decommission n3

3) remove /var/lib/scylla for n3

4) start n4 with the same ip address as n3 to replace n3

5) replace will be successful

If a node has left the ring, we should reject the replace operation.

This patch makes the check during replace operation more strict and
rejects the replace if the node has left the ring.

After the patch, we will see

ERROR 2021-04-07 08:02:14,099 [shard 0] init - Startup failed:
std::runtime_error (Cannot replace_adddress 127.0.0.3 because it has left
the ring, status=LEFT)

Fixes #8419