### PR TITLE
test: perf: perf_simple_query: collect allocation and task statistics

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1117,6 +1117,7 @@ perf_tests_seastar_deps = [
 
 for t in perf_tests:
     deps[t] = [t + '.cc'] + scylla_tests_dependencies + perf_tests_seastar_deps
+    deps[t] += ['test/perf/perf.cc']
 
 deps['test/boost/sstable_test'] += ['test/lib/normalizing_reader.cc']
 deps['test/boost/sstable_datafile_test'] += ['test/lib/normalizing_reader.cc']
@@ -1139,7 +1140,9 @@ deps['test/boost/log_heap_test'] = ['test/boost/log_heap_test.cc']
 deps['test/boost/estimated_histogram_test'] = ['test/boost/estimated_histogram_test.cc']
 deps['test/boost/anchorless_list_test'] = ['test/boost/anchorless_list_test.cc']
 deps['test/perf/perf_fast_forward'] += ['release.cc']
-deps['test/perf/perf_simple_query'] += ['release.cc']
+deps['test/perf/perf_simple_query'] += ['release.cc', 'test/perf/perf.cc']
+deps['test/perf/perf_row_cache_reads'] += ['test/perf/perf.cc']
+deps['test/perf/perf_row_cache_update'] += ['test/perf/perf.cc']
 deps['test/boost/reusable_buffer_test'] = [
     "test/boost/reusable_buffer_test.cc",
     "test/lib/log.cc",

--- a/test/perf/perf.cc
+++ b/test/perf/perf.cc
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2021 ScyllaDB
+ */
+
+/*
+ * This file is part of Scylla.
+ *
+ * Scylla is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Scylla is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "perf.hh"
+#include "seastarx.hh"
+
+void scheduling_latency_measurer::schedule_tick() {
+    seastar::schedule(make_task(default_scheduling_group(), [self = weak_from_this()] () mutable {
+        if (self) {
+            self->tick();
+        }
+    }));
+}
+
+std::ostream& operator<<(std::ostream& out, const scheduling_latency_measurer& slm) {
+    auto to_ms = [] (int64_t nanos) {
+        return float(nanos) / 1e6;
+    };
+    return out << sprint("{count: %d, "
+                         //"min: %.6f [ms], "
+                         //"50%%: %.6f [ms], "
+                         //"90%%: %.6f [ms], "
+                         "99%%: %.6f [ms], "
+                         "max: %.6f [ms]}",
+        slm.histogram().count(),
+        //to_ms(slm.min().count()),
+        //to_ms(slm.histogram().percentile(0.5)),
+        //to_ms(slm.histogram().percentile(0.9)),
+        to_ms(slm.histogram().percentile(0.99)),
+        to_ms(slm.max().count()));
+}
+

--- a/test/perf/perf.cc
+++ b/test/perf/perf.cc
@@ -20,6 +20,8 @@
  */
 
 #include "perf.hh"
+#include <seastar/core/reactor.hh>
+#include <seastar/core/memory.hh>
 #include "seastarx.hh"
 
 void scheduling_latency_measurer::schedule_tick() {
@@ -48,3 +50,18 @@ std::ostream& operator<<(std::ostream& out, const scheduling_latency_measurer& s
         to_ms(slm.max().count()));
 }
 
+
+executor_shard_stats
+executor_shard_stats_snapshot() {
+    return executor_shard_stats{
+        .allocations = memory::stats().mallocs(),
+        .tasks_executed = engine().get_sched_stats().tasks_processed,
+    };
+}
+
+std::ostream&
+operator<<(std::ostream& os, const perf_result& result) {
+    fmt::print(os, "{:.2f} tps ({:.0} allocs/op, {:.0} tasks/op)",
+            result.throughput, result.mallocs_per_op, result.tasks_per_op);
+    return os;
+}

--- a/test/perf/perf.hh
+++ b/test/perf/perf.hh
@@ -56,8 +56,35 @@ void time_it(Func func, int iterations = 5, int iterations_between_clock_reading
     }
 }
 
+struct executor_shard_stats {
+    uint64_t invocations = 0;
+    uint64_t allocations = 0;
+    uint64_t tasks_executed = 0;
+};
+
+inline
+executor_shard_stats
+operator+(executor_shard_stats a, executor_shard_stats b) {
+    a.invocations += b.invocations;
+    a.allocations += b.allocations;
+    a.tasks_executed += b.tasks_executed;
+    return a;
+}
+
+inline
+executor_shard_stats
+operator-(executor_shard_stats a, executor_shard_stats b) {
+    a.invocations -= b.invocations;
+    a.allocations -= b.allocations;
+    a.tasks_executed -= b.tasks_executed;
+    return a;
+}
+
+executor_shard_stats executor_shard_stats_snapshot();
+
+
 // Drives concurrent and continuous execution of given asynchronous action
-// until a deadline. Counts invocations.
+// until a deadline. Counts invocations and collects statistics.
 template <typename Func>
 class executor {
     const Func _func;
@@ -67,6 +94,7 @@ class executor {
     uint64_t _count;
 private:
     future<> run_worker() {
+        auto stats_begin = executor_shard_stats_snapshot();
         return do_until([this] {
             return _end_at_count ? _count == _end_at_count : lowres_clock::now() >= _end_at;
         }, [this] () mutable {
@@ -84,12 +112,15 @@ public:
     { }
 
     // Returns the number of invocations of @func
-    future<uint64_t> run() {
+    future<executor_shard_stats> run() {
+        auto stats_start = executor_shard_stats_snapshot();
         auto idx = boost::irange(0, (int)_n_workers);
         return parallel_for_each(idx.begin(), idx.end(), [this] (auto idx) mutable {
             return this->run_worker();
-        }).then([this] {
-            return _count;
+        }).then([this, stats_start] {
+            auto stats_end = executor_shard_stats_snapshot();
+            stats_end.invocations = _count;
+            return stats_end - stats_start;
         });
     }
 
@@ -97,6 +128,14 @@ public:
         return make_ready_future<>();
     }
 };
+
+struct perf_result {
+    double throughput;
+    double mallocs_per_op;
+    double tasks_per_op;
+};
+
+std::ostream& operator<<(std::ostream& os, const perf_result& result);
 
 /**
  * Measures throughput of an asynchronous action. Executes the action on all cores
@@ -108,22 +147,27 @@ public:
  */
 template <typename Func>
 static
-std::vector<double> time_parallel(Func func, unsigned concurrency_per_core, int iterations = 5, unsigned operations_per_shard = 0) {
+std::vector<perf_result> time_parallel(Func func, unsigned concurrency_per_core, int iterations = 5, unsigned operations_per_shard = 0) {
     using clk = std::chrono::steady_clock;
     if (operations_per_shard) {
         iterations = 1;
     }
-    std::vector<double> results;
+    std::vector<perf_result> results;
     for (int i = 0; i < iterations; ++i) {
         auto start = clk::now();
         auto end_at = lowres_clock::now() + std::chrono::seconds(1);
         distributed<executor<Func>> exec;
         exec.start(concurrency_per_core, func, std::move(end_at), operations_per_shard).get();
-        auto total = exec.map_reduce(adder<uint64_t>(), [] (auto& oc) { return oc.run(); }).get0();
+        auto stats = exec.map_reduce0(std::mem_fn(&executor<Func>::run),
+                executor_shard_stats(), std::plus<executor_shard_stats>()).get0();
         auto end = clk::now();
         auto duration = std::chrono::duration<double>(end - start).count();
-        auto result = static_cast<double>(total) / duration;
-        std::cout << format("{:.2f}", result) << " tps\n";
+        auto result = perf_result{
+            .throughput = static_cast<double>(stats.invocations) / duration,
+            .mallocs_per_op = double(stats.allocations) / stats.invocations,
+            .tasks_per_op = double(stats.tasks_executed) / stats.invocations,
+        };
+        std::cout << result << "\n";
         results.emplace_back(result);
         exec.stop().get();
     }

--- a/test/perf/perf.hh
+++ b/test/perf/perf.hh
@@ -172,28 +172,4 @@ public:
     clk::duration max() const { return _minmax.max(); }
 };
 
-void scheduling_latency_measurer::schedule_tick() {
-    seastar::schedule(make_task(default_scheduling_group(), [self = weak_from_this()] () mutable {
-        if (self) {
-            self->tick();
-        }
-    }));
-}
-
-std::ostream& operator<<(std::ostream& out, const scheduling_latency_measurer& slm) {
-    auto to_ms = [] (int64_t nanos) {
-        return float(nanos) / 1e6;
-    };
-    return out << sprint("{count: %d, "
-                         //"min: %.6f [ms], "
-                         //"50%%: %.6f [ms], "
-                         //"90%%: %.6f [ms], "
-                         "99%%: %.6f [ms], "
-                         "max: %.6f [ms]}",
-        slm.histogram().count(),
-        //to_ms(slm.min().count()),
-        //to_ms(slm.histogram().percentile(0.5)),
-        //to_ms(slm.histogram().percentile(0.9)),
-        to_ms(slm.histogram().percentile(0.99)),
-        to_ms(slm.max().count()));
-}
+std::ostream& operator<<(std::ostream& out, const scheduling_latency_measurer& slm);


### PR DESCRIPTION
Calculate and display the number of memory allocations and tasks
executed per operation. Sample results (--smp 1):

180022.46 tps (90 allocs/op, 20 tasks/op)
178963.44 tps (90 allocs/op, 20 tasks/op)
178702.41 tps (90 allocs/op, 20 tasks/op)
177679.74 tps (90 allocs/op, 20 tasks/op)
179539.36 tps (90 allocs/op, 20 tasks/op)

median 178963.44 tps (90 allocs/op, 20 tasks/op)
median absolute deviation: 575.92
maximum: 180022.46
minimum: 177679.74

This allows less noisy tracking of how some changes impact performance.
