### PR TITLE
cdc: log: avoid linearizations

### DIFF
--- a/atomic_cell.hh
+++ b/atomic_cell.hh
@@ -380,6 +380,13 @@ public:
             return make_live(type, timestamp, value, gc_clock::now() + *ttl, *ttl, cm);
         }
     }
+    static atomic_cell make_live(const abstract_type& type, api::timestamp_type timestamp, const managed_bytes_view& value, ttl_opt ttl, collection_member cm = collection_member::no) {
+        if (!ttl) {
+            return make_live(type, timestamp, value, cm);
+        } else {
+            return make_live(type, timestamp, value, gc_clock::now() + *ttl, *ttl, cm);
+        }
+    }
     static atomic_cell make_live_uninitialized(const abstract_type& type, api::timestamp_type timestamp, size_t size);
     friend class atomic_cell_or_collection;
     friend std::ostream& operator<<(std::ostream& os, const atomic_cell& ac);

--- a/cdc/log.cc
+++ b/cdc/log.cc
@@ -984,8 +984,8 @@ private:
     }
 };
 
-static bytes get_bytes(const atomic_cell_view& acv) {
-    return to_bytes(acv.value());
+static managed_bytes get_managed_bytes(const atomic_cell_view& acv) {
+    return managed_bytes(acv.value());
 }
 
 static bytes_view get_bytes_view(const atomic_cell_view& acv, std::forward_list<bytes>& buf) {
@@ -1064,16 +1064,16 @@ struct process_row_visitor {
 
     void live_atomic_cell(const column_definition& cdef, const atomic_cell_view& cell) {
         _ttl_column = get_ttl(cell);
-        bytes value = get_bytes(cell);
+        managed_bytes value = get_managed_bytes(cell);
 
         // delta
         if (_generate_delta_values) {
-            _builder.set_value(_log_ck, cdef, bytes_view(value));
+            _builder.set_value(_log_ck, cdef, value);
         }
 
         // images
         if (_enable_updating_state) {
-            update_row_state(cdef, managed_bytes(value));
+            update_row_state(cdef, std::move(value));
         }
     }
 

--- a/cdc/log.cc
+++ b/cdc/log.cc
@@ -823,14 +823,13 @@ static managed_bytes_opt get_preimage_col_value(const column_definition& cdef, c
                 auto v = pirow->get_view(cdef.name_as_text());
                 auto f = cql_serialization_format::internal();
                 auto n = read_collection_size(v, f);
-                std::vector<bytes> tmp;
+                std::vector<managed_bytes> tmp;
                 tmp.reserve(n);
                 while (n--) {
-                    tmp.emplace_back(read_collection_value(v, f).linearize()); // key
+                    tmp.emplace_back(read_collection_value(v, f)); // key
                     read_collection_value(v, f); // value. ignore.
                 }
-                // FIXME: get rid of this copy in the next commit.
-                return managed_bytes(set_type_impl::serialize_partially_deserialized_form({tmp.begin(), tmp.end()}, f));
+                return set_type_impl::serialize_partially_deserialized_form_fragmented({tmp.begin(), tmp.end()}, f);
             },
             [&] (const abstract_type& o) -> managed_bytes {
                 return pirow->get_blob_fragmented(cdef.name_as_text());

--- a/cdc/log.cc
+++ b/cdc/log.cc
@@ -1670,7 +1670,7 @@ public:
         // clustering rows
         for (const auto& row : *preimage_set) {
             // Construct the clustering key for this row
-            std::vector<bytes> ck_parts;
+            std::vector<managed_bytes> ck_parts;
             ck_parts.reserve(_schema->clustering_key_size());
             for (auto& c : _schema->clustering_key_columns()) {
                 auto v = row.get_view_opt(c.name_as_text());
@@ -1683,7 +1683,7 @@ public:
                     // as there will be no clustering row data to load into the state.
                     return;
                 }
-                ck_parts.emplace_back(v->linearize());
+                ck_parts.emplace_back(managed_bytes(*v));
             }
             auto ck = clustering_key::from_exploded(std::move(ck_parts));
 

--- a/cql3/untyped_result_set.hh
+++ b/cql3/untyped_result_set.hh
@@ -96,6 +96,9 @@ public:
     bytes get_blob(std::string_view name) const {
         return get_view(name).linearize();
     }
+    managed_bytes get_blob_fragmented(std::string_view name) const {
+        return managed_bytes(get_view(name));
+    }
     template<typename T>
     T get_as(std::string_view name) const {
         return value_cast<T>(data_type_for<T>()->deserialize(get_view(name)));

--- a/keys.hh
+++ b/keys.hh
@@ -252,6 +252,14 @@ public:
         return result;
     }
 
+    std::vector<managed_bytes> explode_fragmented() const {
+        std::vector<managed_bytes> result;
+        for (managed_bytes_view c : components()) {
+            result.emplace_back(managed_bytes(c));
+        }
+        return result;
+    }
+
     struct tri_compare {
         typename TopLevel::compound _t;
         tri_compare(const schema& s) : _t(get_compound_type(s)) {}

--- a/types.cc
+++ b/types.cc
@@ -1191,8 +1191,24 @@ map_type_impl::serialize_partially_deserialized_form(
         write_collection_value(out, sf, e.second);
     }
     return b;
+}
 
+managed_bytes
+map_type_impl::serialize_partially_deserialized_form_fragmented(
+        const std::vector<std::pair<managed_bytes_view, managed_bytes_view>>& v, cql_serialization_format sf) {
+    size_t len = collection_value_len(sf) * v.size() * 2 + collection_size_len(sf);
+    for (auto&& e : v) {
+        len += e.first.size() + e.second.size();
+    }
+    managed_bytes b(managed_bytes::initialized_later(), len);
+    managed_bytes_mutable_view out = b;
 
+    write_collection_size(out, v.size(), sf);
+    for (auto&& e : v) {
+        write_collection_value(out, sf, e.first);
+        write_collection_value(out, sf, e.second);
+    }
+    return b;
 }
 
 static std::optional<data_type> update_user_type_aux(

--- a/types.cc
+++ b/types.cc
@@ -1322,6 +1322,12 @@ set_type_impl::serialize_partially_deserialized_form(
     return pack(v.begin(), v.end(), v.size(), sf);
 }
 
+managed_bytes
+set_type_impl::serialize_partially_deserialized_form_fragmented(
+        const std::vector<managed_bytes_view>& v, cql_serialization_format sf) {
+    return pack_fragmented(v.begin(), v.end(), v.size(), sf);
+}
+
 template <FragmentedView View>
 std::vector<managed_bytes> partially_deserialize_listlike(View in, cql_serialization_format sf) {
     auto nr = read_collection_size(in, sf);

--- a/types/map.hh
+++ b/types/map.hh
@@ -59,6 +59,8 @@ public:
     template <FragmentedView View> data_value deserialize(View v, cql_serialization_format sf) const;
     static bytes serialize_partially_deserialized_form(const std::vector<std::pair<bytes_view, bytes_view>>& v,
             cql_serialization_format sf);
+    static managed_bytes serialize_partially_deserialized_form_fragmented(const std::vector<std::pair<managed_bytes_view, managed_bytes_view>>& v,
+            cql_serialization_format sf);
 };
 
 data_value make_map_value(data_type tuple_type, map_type_impl::native_type value);

--- a/types/set.hh
+++ b/types/set.hh
@@ -51,6 +51,8 @@ public:
     template <FragmentedView View> data_value deserialize(View v, cql_serialization_format sf) const;
     static bytes serialize_partially_deserialized_form(
             const std::vector<bytes_view>& v, cql_serialization_format sf);
+    static managed_bytes serialize_partially_deserialized_form_fragmented(
+            const std::vector<managed_bytes_view>& v, cql_serialization_format sf);
 };
 
 data_value make_set_value(data_type tuple_type, set_type_impl::native_type value);


### PR DESCRIPTION
CDC log uses `bytes` to deal with cells and their values, and linearizes all values indiscriminately.
This series makes a switch from `bytes` to `managed_bytes` to avoid that linearization.

Fixes #7506.