### PR TITLE
clustering_order_reader_merger: handle empty readers

### DIFF
--- a/test/boost/sstable_datafile_test.cc
+++ b/test/boost/sstable_datafile_test.cc
@@ -7144,7 +7144,6 @@ SEASTAR_TEST_CASE(test_twcs_single_key_reader_filtering) {
 
         auto sst1 = make_sstable_containing(sst_gen, {make_row(0, 0)});
         auto sst2 = make_sstable_containing(sst_gen, {make_row(0, 1)});
-        auto sst3 = make_sstable_containing(sst_gen, {make_row(0, 2)});
         auto dkey = sst1->get_first_decorated_key();
 
         auto cm = make_lw_shared<compaction_manager>();
@@ -7163,7 +7162,6 @@ SEASTAR_TEST_CASE(test_twcs_single_key_reader_filtering) {
         auto set = cs.make_sstable_set(s);
         set.insert(std::move(sst1));
         set.insert(std::move(sst2));
-        set.insert(std::move(sst3));
 
         reader_permit permit = tests::make_permit();
         utils::estimated_histogram eh;
@@ -7186,10 +7184,11 @@ SEASTAR_TEST_CASE(test_twcs_single_key_reader_filtering) {
         // consume all fragments
         while (reader(db::no_timeout).get());
 
-        // sst1 and sst2 should have been checked by the CK filter before we started reading (when we created the reader).
-        // sst3 should have been checked by the CK filter during fragment consumption and shouldn't have passed.
-        // With the bug in #8432, sst3 wouldn't even be checked by the CK filter since it would pass right after checking the PK filter.
-        BOOST_REQUIRE_EQUAL(cf_stats.sstables_checked_by_clustering_filter - checked_by_ck, 1);
-        BOOST_REQUIRE_EQUAL(cf_stats.surviving_sstables_after_clustering_filter - surviving_after_ck, 0);
+        // At least sst2 should be checked by the CK filter during fragment consumption and should pass.
+        // With the bug in #8432, sst2 wouldn't even be checked by the CK filter since it would pass right after checking the PK filter.
+        BOOST_REQUIRE_GE(cf_stats.sstables_checked_by_clustering_filter - checked_by_ck, 1);
+        BOOST_REQUIRE_EQUAL(
+                cf_stats.surviving_sstables_after_clustering_filter - surviving_after_ck,
+                cf_stats.sstables_checked_by_clustering_filter - checked_by_ck);
     });
 }


### PR DESCRIPTION
The merger could return end-of-stream if some (but not all) of the
underlying readers were empty (i.e. not even returning a
`partition_start`). This could happen in places where it was used
(`time_series_sstable_set::create_single_key_sstable_reader`) if we
opened an sstable which did not have the queried partition but passed
all the filters (specifically, the bloom filter returned a false
positive for this sstable).

The commit also extends the random tests for the merger to include empty
readers and adds an explicit test case that catches this bug (in a
limited scope: when we merge a single empty reader).

It also modifies `test_twcs_single_key_reader_filtering` (regression
test for #8432) because the time where the clustering key filter is
invoked changes (some invocations move from the constructor of the
merger to operator()). I checked manually that it still catches the bug
when I reintroduce it.

Fixes #8445.