### PR TITLE
utils: data_input: replace enable_if with tightened concept

### DIFF
--- a/utils/data_input.hh
+++ b/utils/data_input.hh
@@ -24,6 +24,7 @@
 
 #include "bytes.hh"
 #include <seastar/net/byteorder.hh>
+#include <concepts>
 
 class data_input {
 public:
@@ -90,8 +91,8 @@ public:
     }
 private:
     template<typename T> size_t ssize(const T &) const;
-    template<typename T>
-    inline std::enable_if_t<std::is_fundamental<T>::value, T> peek_primitive() const {
+    template<std::integral T>
+    inline T peek_primitive() const {
         ensure(sizeof(T));
         T t;
         std::copy_n(_view.begin(), sizeof(T), reinterpret_cast<char *>(&t));


### PR DESCRIPTION
std::is_fundamental isn't a good constraint since it include nullptr_t
and void. Replace with std::integral which is sufficient. Use a concept
instead of enable_if to simplify the code.