### PR TITLE
sys_dist_ks: new keyspace for system tables with Everywhere strategy

### DIFF
--- a/database.cc
+++ b/database.cc
@@ -1135,7 +1135,8 @@ void keyspace::mark_as_populated() {
 
 
 static bool is_system_table(const schema& s) {
-    return s.ks_name() == db::system_keyspace::NAME || s.ks_name() == db::system_distributed_keyspace::NAME;
+    return s.ks_name() == db::system_keyspace::NAME || s.ks_name() == db::system_distributed_keyspace::NAME
+        || s.ks_name() == db::system_distributed_keyspace::NAME_EVERYWHERE;
 }
 
 column_family::config

--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -107,7 +107,8 @@ static logging::logger diff_logger("schema_diff");
 
 static bool is_extra_durable(const sstring& ks_name, const sstring& cf_name) {
     return (is_system_keyspace(ks_name) && db::system_keyspace::is_extra_durable(cf_name))
-        || (ks_name == db::system_distributed_keyspace::NAME && db::system_distributed_keyspace::is_extra_durable(cf_name));
+        || ((ks_name == db::system_distributed_keyspace::NAME || ks_name == db::system_distributed_keyspace::NAME_EVERYWHERE)
+                && db::system_distributed_keyspace::is_extra_durable(cf_name));
 }
 
 

--- a/db/system_distributed_keyspace.cc
+++ b/db/system_distributed_keyspace.cc
@@ -168,6 +168,15 @@ future<> system_distributed_keyspace::start() {
         return _mm.announce_new_keyspace(ksm, api::min_timestamp);
     });
 
+    co_await ignore_existing([this] {
+        auto ksm = keyspace_metadata::new_keyspace(
+                NAME_EVERYWHERE,
+                "org.apache.cassandra.locator.EverywhereStrategy",
+                {},
+                true /* durable_writes */);
+        return _mm.announce_new_keyspace(ksm, api::min_timestamp);
+    });
+
     for (auto&& table : all_tables()) {
         co_await ignore_existing([this, table = std::move(table)] {
             return _mm.announce_new_column_family(std::move(table), api::min_timestamp);

--- a/db/system_distributed_keyspace.hh
+++ b/db/system_distributed_keyspace.hh
@@ -51,6 +51,8 @@ namespace db {
 class system_distributed_keyspace {
 public:
     static constexpr auto NAME = "system_distributed";
+    static constexpr auto NAME_EVERYWHERE = "system_distributed_everywhere";
+
     static constexpr auto VIEW_BUILD_STATUS = "view_build_status";
 
     /* Nodes use this table to communicate new CDC stream generations to other nodes. */

--- a/distributed_loader.cc
+++ b/distributed_loader.cc
@@ -60,6 +60,7 @@ bool is_system_keyspace(std::string_view name) {
 
 static const std::unordered_set<std::string_view> internal_keyspaces = {
         db::system_distributed_keyspace::NAME,
+        db::system_distributed_keyspace::NAME_EVERYWHERE,
         db::system_keyspace::NAME,
         db::schema_tables::NAME,
         auth::meta::AUTH_KS,

--- a/service/client_state.cc
+++ b/service/client_state.cc
@@ -207,7 +207,7 @@ future<> service::client_state::has_access(const sstring& ks, auth::command_desc
                     auth::permission::ALTER, auth::permission::DROP>();
 
             if (cdc_topology_description_forbidden_permissions.contains(cmd.permission)) {
-                if (ks == db::system_distributed_keyspace::NAME
+                if ((ks == db::system_distributed_keyspace::NAME || ks == db::system_distributed_keyspace::NAME_EVERYWHERE)
                         && (resource_view.table() == db::system_distributed_keyspace::CDC_DESC_V2
                         || resource_view.table() == db::system_distributed_keyspace::CDC_TOPOLOGY_DESCRIPTION
                         || resource_view.table() == db::system_distributed_keyspace::CDC_TIMESTAMPS)) {


### PR DESCRIPTION
`system_distributed_everywhere` is a new keyspace that uses Everywhere
replication strategy. This is useful, for example, when we want to store
internal data that should be accessible by every node; the data can be
written using CL=ALL (e.g. during node operations such as node
bootstrap, which require all nodes to be alive - at least currently) and
then read by each node locally using CL=ONE (e.g. during node restarts).

Split from PR #8286 per @avikivity's request.