### PR TITLE
tracing: test/boost/tracing: fix use after free

### DIFF
--- a/tracing/tracing_backend_registry.cc
+++ b/tracing/tracing_backend_registry.cc
@@ -32,9 +32,6 @@ backend_registry::backend_registry()
         : _impl(std::make_unique<nonstatic_class_registry<i_tracing_backend_helper, tracing&>>()) {
 }
 
-backend_registry::~backend_registry() = default;
-
-
 void
 backend_registry::register_backend_creator(sstring name, std::function<std::unique_ptr<i_tracing_backend_helper> (tracing&)> creator) {
     _impl->register_class(std::move(name), std::move(creator));

--- a/tracing/tracing_backend_registry.hh
+++ b/tracing/tracing_backend_registry.hh
@@ -47,7 +47,6 @@ private:
     void register_backend_creator(sstring name, std::function<std::unique_ptr<i_tracing_backend_helper> (tracing&)> creator);
 public:
     backend_registry();
-    ~backend_registry();
     std::unique_ptr<i_tracing_backend_helper> create_backend(const sstring& name, tracing& t) const; // may throw no_such_tracing_backend
     template <typename Backend>
     void register_backend(sstring name);


### PR DESCRIPTION
fixes AddressSanitizer: stack-buffer-underflow on address 0x7ffd9a375820 at pc 0x555ac9721b4e bp 0x7ffd9a374e70 sp 0x7ffd9a374620

Backend registry holds a unique pointer to the backend implementation
that must outlive the whole tracing lifetime until the shutdown call.

So it must be catched/moved before the program exits its scope by
passing out the lambda chain.

Signed-off-by: Ivan Prisyazhnyy <ivan@scylladb.com>