### PR TITLE
db/virtual_table: Streaming tables for large data + describe_ring example table

### DIFF
--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -80,7 +80,7 @@ static ss::token_range token_range_endpoints_to_json(const dht::token_range_endp
     r.rpc_endpoints = d._rpc_endpoints;
     for (auto det : d._endpoint_details) {
         ss::endpoint_detail ed;
-        ed.host = det._host;
+        ed.host = boost::lexical_cast<std::string>(det._host);
         ed.datacenter = det._datacenter;
         if (det._rack != "") {
             ed.rack = det._rack;

--- a/database.hh
+++ b/database.hh
@@ -86,6 +86,7 @@ class reconcilable_result;
 
 namespace service {
 class storage_proxy;
+class storage_service;
 class migration_notifier;
 class migration_manager;
 }
@@ -123,7 +124,7 @@ class data_listeners;
 class large_data_handler;
 
 namespace system_keyspace {
-future<> make(database& db);
+future<> make(database& db, service::storage_service& ss);
 }
 }
 
@@ -1366,7 +1367,7 @@ public:
 private:
     using system_keyspace = bool_class<struct system_keyspace_tag>;
     void create_in_memory_keyspace(const lw_shared_ptr<keyspace_metadata>& ksm, system_keyspace system);
-    friend future<> db::system_keyspace::make(database& db);
+    friend future<> db::system_keyspace::make(database& db, service::storage_service& ss);
     void setup_metrics();
     void setup_scylla_memory_diagnostics_producer();
 

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -1779,8 +1779,12 @@ future<> set_bootstrap_state(bootstrap_state state) {
 }
 
 class nodetool_status_table : public memtable_filling_virtual_table {
+private:
+    service::storage_service& _ss;
 public:
-    nodetool_status_table() : memtable_filling_virtual_table(build_schema()) {}
+    nodetool_status_table(service::storage_service& ss)
+            : memtable_filling_virtual_table(build_schema())
+            , _ss(ss) {}
 
     static schema_ptr build_schema() {
         auto id = generate_legacy_id(NAME, "status");
@@ -1798,9 +1802,8 @@ public:
     }
 
     future<> execute(std::function<void(mutation)> mutation_sink, db::timeout_clock::time_point timeout) override {
-        auto& ss = service::get_local_storage_service();
-        return ss.get_ownership().then([&, mutation_sink] (std::map<gms::inet_address, float> ownership) {
-            const locator::token_metadata& tm = ss.get_token_metadata();
+        return _ss.get_ownership().then([&, mutation_sink] (std::map<gms::inet_address, float> ownership) {
+            const locator::token_metadata& tm = _ss.get_token_metadata();
             gms::gossiper& gs = gms::get_local_gossiper();
 
             for (auto&& e : gs.endpoint_state_map) {
@@ -1838,13 +1841,13 @@ public:
 // Map from table's schema ID to table itself. Helps avoiding accidental duplication.
 static thread_local std::map<utils::UUID, std::unique_ptr<virtual_table>> virtual_tables;
 
-void register_virtual_tables() {
+void register_virtual_tables(service::storage_service& ss) {
     auto add_table = [] (std::unique_ptr<virtual_table>&& tbl) {
         virtual_tables[tbl->schema()->id()] = std::move(tbl);
     };
 
     // Add built-in virtual tables here.
-    add_table(std::make_unique<nodetool_status_table>());
+    add_table(std::make_unique<nodetool_status_table>(ss));
 }
 
 std::vector<schema_ptr> all_tables() {
@@ -1894,8 +1897,8 @@ static bool maybe_write_in_user_memory(schema_ptr s, database& db) {
             || s == v3::scylla_views_builds_in_progress();
 }
 
-future<> make(database& db) {
-    register_virtual_tables();
+future<> make(database& db, service::storage_service& ss) {
+    register_virtual_tables(ss);
 
     auto enable_cache = db.get_config().enable_cache();
     bool durable = db.get_config().data_file_directories().size() > 0;

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -214,7 +214,7 @@ future<> set_scylla_local_param(const sstring& key, const sstring& value);
 future<std::optional<sstring>> get_scylla_local_param(const sstring& key);
 
 std::vector<schema_ptr> all_tables();
-future<> make(database& db);
+future<> make(database& db, service::storage_service& ss);
 
 /// overloads
 

--- a/db/virtual_table.cc
+++ b/db/virtual_table.cc
@@ -106,4 +106,94 @@ mutation_source memtable_filling_virtual_table::as_mutation_source() {
     });
 }
 
+mutation_source streaming_virtual_table::as_mutation_source() {
+    return mutation_source([this] (schema_ptr s,
+        reader_permit permit,
+        const dht::partition_range& pr,
+        const query::partition_slice& slice,
+        const io_priority_class& pc,
+        tracing::trace_state_ptr trace_state,
+        streamed_mutation::forwarding fwd,
+        mutation_reader::forwarding fwd_mr) {
+
+        if (fwd == streamed_mutation::forwarding::yes) {
+            throw std::runtime_error("streamed_mutation::forwarding::yes unsupported in virtual tables");
+        }
+
+        if (fwd_mr == mutation_reader::forwarding::yes) {
+            throw std::runtime_error("mutation_reader::forwarding::yes unsupported in virtual tables");
+        }
+
+        // We cannot pass the partition_range directly to execute()
+        // because it is not guaranteed to be alive until execute() resolves.
+        // It is only guaranteed to be alive as long as the returned reader is alive.
+        // We achieve safety by mediating access through query_restrictions. When the reader
+        // dies, pr is cleared and execute() will get an exception.
+        struct my_result_collector : public result_collector, public query_restrictions {
+            queue_reader_handle handle;
+
+            // Valid until handle.is_terminated(), which is set to true when the
+            // queue_reader dies.
+            const dht::partition_range* pr;
+            mutation_reader::forwarding fwd_mr;
+
+            my_result_collector(schema_ptr s, reader_permit p, const dht::partition_range* pr, queue_reader_handle&& handle)
+                : result_collector(s, p)
+                , handle(std::move(handle))
+                , pr(pr)
+            { }
+
+            // result_collector
+            future<> take(mutation_fragment fragment) override {
+                return handle.push(std::move(fragment));
+            }
+
+            // query_restrictions
+            const dht::partition_range& partition_range() const override {
+                if (handle.is_terminated()) {
+                    throw std::runtime_error("read abandoned");
+                }
+                return *pr;
+            }
+        };
+
+        auto reader_and_handle = make_queue_reader(_s, permit);
+        auto consumer = std::make_unique<my_result_collector>(_s, permit, &pr, std::move(reader_and_handle.second));
+        auto f = execute(permit, *consumer, *consumer);
+
+        // It is safe to discard this future because:
+        // - after calling `handle.push_end_of_stream()` the reader can be discarded;
+        // - if the reader dies first, `execute()` will get an exception on attempt to push fragments.
+        (void)f.then_wrapped([c = std::move(consumer)] (auto&& f) {
+            if (f.failed()) {
+                c->handle.abort(f.get_exception());
+            } else if (!c->handle.is_terminated()) {
+                c->handle.push_end_of_stream();
+            }
+        });
+
+        auto rd = make_slicing_filtering_reader(std::move(reader_and_handle.first), pr, slice);
+
+        if (!_shard_aware) {
+            rd = make_filtering_reader(std::move(rd), [this] (const dht::decorated_key& dk) -> bool {
+                return this_shard_owns(dk);
+            });
+        }
+
+        return rd;
+    });
+}
+
+future<> result_collector::emit_partition_start(dht::decorated_key dk) {
+        return take(mutation_fragment(*_schema, _permit, partition_start(std::move(dk), {})));
+}
+
+future<> result_collector::emit_partition_end() {
+    return take(mutation_fragment(*_schema, _permit, partition_end()));
+}
+
+future<> result_collector::emit_row(clustering_row&& cr) {
+    return take(mutation_fragment(*_schema, _permit, std::move(cr)));
+}
+
 }

--- a/dht/token_range_endpoints.hh
+++ b/dht/token_range_endpoints.hh
@@ -24,10 +24,11 @@
 #include <seastar/core/sstring.hh>
 
 #include "seastarx.hh"
+#include "gms/inet_address.hh"
 
 namespace dht {
 struct endpoint_details {
-    sstring _host;
+    gms::inet_address _host;
     sstring _datacenter;
     sstring _rack;
 };

--- a/distributed_loader.cc
+++ b/distributed_loader.cc
@@ -623,8 +623,8 @@ future<> distributed_loader::populate_keyspace(distributed<database>& db, sstrin
     }
 }
 
-future<> distributed_loader::init_system_keyspace(distributed<database>& db) {
-    return seastar::async([&db] {
+future<> distributed_loader::init_system_keyspace(distributed<database>& db, distributed<service::storage_service>& ss) {
+    return seastar::async([&db, &ss] {
         // We need to init commitlog on shard0 before it is inited on other shards
         // because it obtains the list of pre-existing segments for replay, which must
         // not include reserve segments created by active commitlogs.
@@ -638,8 +638,8 @@ future<> distributed_loader::init_system_keyspace(distributed<database>& db) {
             return db.init_commitlog();
         }).get();
 
-        db.invoke_on_all([] (database& db) {
-            return db::system_keyspace::make(db);
+        db.invoke_on_all([&ss] (database& db) {
+            return db::system_keyspace::make(db, ss.local());
         }).get();
 
         const auto& cfg = db.local().get_config();

--- a/distributed_loader.hh
+++ b/distributed_loader.hh
@@ -53,6 +53,7 @@ class sstable_directory;
 namespace service {
 
 class storage_proxy;
+class storage_service;
 class migration_manager;
 
 }
@@ -80,7 +81,7 @@ public:
             get_sstables_from_upload_dir(distributed<database>& db, sstring ks, sstring cf);
     static future<> populate_column_family(distributed<database>& db, sstring sstdir, sstring ks, sstring cf);
     static future<> populate_keyspace(distributed<database>& db, sstring datadir, sstring ks_name);
-    static future<> init_system_keyspace(distributed<database>& db);
+    static future<> init_system_keyspace(distributed<database>& db, distributed<service::storage_service>& ss);
     static future<> ensure_system_table_directories(distributed<database>& db);
     static future<> init_non_system_keyspaces(distributed<database>& db, distributed<service::storage_proxy>& proxy, distributed<service::migration_manager>& mm);
 private:

--- a/mutation_reader.cc
+++ b/mutation_reader.cc
@@ -2032,7 +2032,13 @@ public:
         return _full->get_future();
     }
     virtual future<> next_partition() override {
-        return make_exception_future<>(make_backtraced_exception_ptr<std::bad_function_call>());
+        clear_buffer_to_next_partition();
+        if (is_buffer_empty() && !is_end_of_stream()) {
+            return fill_buffer(db::no_timeout).then([this] {
+                return next_partition();
+            });
+        }
+        return make_ready_future<>();
     }
     virtual future<> fast_forward_to(const dht::partition_range&, db::timeout_clock::time_point) override {
         return make_exception_future<>(make_backtraced_exception_ptr<std::bad_function_call>());

--- a/mutation_reader.hh
+++ b/mutation_reader.hh
@@ -136,6 +136,8 @@ flat_mutation_reader make_filtering_reader(flat_mutation_reader rd, MutationFilt
     return make_flat_mutation_reader<filtering_reader<MutationFilter>>(std::move(rd), std::forward<MutationFilter>(filter));
 }
 
+flat_mutation_reader make_slicing_filtering_reader(flat_mutation_reader, const dht::partition_range&, const query::partition_slice&);
+
 /// A partition_presence_checker quickly returns whether a key is known not to exist
 /// in a data source (it may return false positives, but not false negatives).
 enum class partition_presence_checker_result {

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -3458,11 +3458,11 @@ storage_service::describe_ring(const sstring& keyspace, bool include_only_local_
         }
         for (auto endpoint : addresses) {
             endpoint_details details;
-            details._host = boost::lexical_cast<std::string>(endpoint);
+            details._host = endpoint;
             details._datacenter = locator::i_endpoint_snitch::get_local_snitch_ptr()->get_datacenter(endpoint);
             details._rack = locator::i_endpoint_snitch::get_local_snitch_ptr()->get_rack(endpoint);
             tr._rpc_endpoints.push_back(get_rpc_address(endpoint));
-            tr._endpoints.push_back(details._host);
+            tr._endpoints.push_back(boost::lexical_cast<std::string>(details._host));
             tr._endpoint_details.push_back(details);
         }
         ranges.push_back(tr);

--- a/test/boost/virtual_table_mutation_source_test.cc
+++ b/test/boost/virtual_table_mutation_source_test.cc
@@ -39,6 +39,30 @@ public:
     }
 };
 
+class streaming_test_vt : public db::streaming_virtual_table {
+    schema_ptr _s;
+    std::vector<mutation> _mutations;
+public:
+    streaming_test_vt(schema_ptr s, std::vector<mutation> mutations)
+            : streaming_virtual_table(s)
+            , _s(s)
+            , _mutations(std::move(mutations)) {}
+
+    virtual future<> execute(reader_permit permit, db::result_collector& rc) override {
+        return async([this, permit, &rc] {
+            auto mt = make_lw_shared<memtable>(_s);
+            do_for_each(_mutations, [mt] (const mutation& m) {
+                mt->apply(m);
+            }).get();
+            auto rdr = mt->make_flat_reader(_s, tests::make_permit());
+            auto close_rdr = deferred_close(rdr);
+            rdr.consume_pausable([&rc] (mutation_fragment mf) {
+                return rc.take(std::move(mf)).then([] { return stop_iteration::no; });
+            }, db::no_timeout).get();
+        });
+    }
+};
+
 SEASTAR_THREAD_TEST_CASE(test_memtable_filling_vt_as_mutation_source) {
     std::unique_ptr<memtable_filling_test_vt> table; // Used to prolong table's life
 
@@ -46,4 +70,28 @@ SEASTAR_THREAD_TEST_CASE(test_memtable_filling_vt_as_mutation_source) {
         table = std::make_unique<memtable_filling_test_vt>(s, mutations);
         return table->as_mutation_source();
     });
+}
+
+SEASTAR_THREAD_TEST_CASE(test_streaming_vt_as_mutation_source) {
+    std::unique_ptr<streaming_test_vt> table; // Used to prolong table's life
+
+    run_mutation_source_tests([&table] (schema_ptr s, const std::vector<mutation>& mutations, gc_clock::time_point) -> mutation_source {
+        table = std::make_unique<streaming_test_vt>(s, mutations);
+
+        auto factory_fn = [ms = table->as_mutation_source()] (schema_ptr s,
+                reader_permit permit,
+                const dht::partition_range& pr,
+                const query::partition_slice& slice,
+                const io_priority_class& pc,
+                tracing::trace_state_ptr trace_state,
+                streamed_mutation::forwarding stream_fwd,
+                mutation_reader::forwarding) {
+            auto rdr = ms.make_reader(s, permit, pr, slice, pc, trace_state, streamed_mutation::forwarding::no, mutation_reader::forwarding::no);
+            if (stream_fwd == streamed_mutation::forwarding::yes) {
+                return make_forwardable(std::move(rdr));
+            }
+            return rdr;
+        };
+        return mutation_source(std::move(factory_fn));
+    }, false /* with_partition_range_forwarding */);
 }

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -628,7 +628,7 @@ public:
                 view_update_generator.stop().get();
             });
 
-            distributed_loader::init_system_keyspace(db).get();
+            distributed_loader::init_system_keyspace(db, ss).get();
 
             auto& ks = db.local().find_keyspace(db::system_keyspace::NAME);
             parallel_for_each(ks.metadata()->cf_meta_data(), [&ks] (auto& pair) {

--- a/test/lib/mutation_source_test.hh
+++ b/test/lib/mutation_source_test.hh
@@ -28,8 +28,8 @@ using populate_fn = std::function<mutation_source(schema_ptr s, const std::vecto
 using populate_fn_ex = std::function<mutation_source(schema_ptr s, const std::vector<mutation>&, gc_clock::time_point)>;
 
 // Must be run in a seastar thread
-void run_mutation_source_tests(populate_fn populate);
-void run_mutation_source_tests(populate_fn_ex populate);
+void run_mutation_source_tests(populate_fn populate, bool with_partition_range_forwarding = true);
+void run_mutation_source_tests(populate_fn_ex populate, bool with_partition_range_forwarding = true);
 
 enum are_equal { no, yes };
 

--- a/thrift/handler.cc
+++ b/thrift/handler.cc
@@ -769,7 +769,7 @@ public:
                 std::vector<EndpointDetails> eds;
                 std::transform(tr._endpoint_details.begin(), tr._endpoint_details.end(), std::back_inserter(eds), [](auto&& ed) {
                     EndpointDetails detail;
-                    detail.__set_host(ed._host);
+                    detail.__set_host(boost::lexical_cast<std::string>(ed._host));
                     detail.__set_datacenter(ed._datacenter);
                     detail.__set_rack(ed._rack);
                     return detail;


### PR DESCRIPTION
This is the 2nd PR in series with the goal to finish the hackathon project authored by @tgrabiec, @kostja, @amnonh and @mmatczuk (improved virtual tables + function call syntax in CQL). This one introduces a new implementation of the virtual tables, the streaming tables, which are suitable for large amounts of data.

This PR was created by @jul-stas and @StarostaGit