### PR TITLE
treewide: correct mislicensed source files

### DIFF
--- a/alternator/expressions.g
+++ b/alternator/expressions.g
@@ -1,8 +1,5 @@
 /*
  * Copyright 2019 ScyllaDB
- *
- * This file is part of Scylla. See the LICENSE.PROPRIETARY file in the
- * top-level directory for licensing information.
  */
 
 /*

--- a/gms/inet_address_serializer.hh
+++ b/gms/inet_address_serializer.hh
@@ -5,7 +5,18 @@
 /*
  * This file is part of Scylla.
  *
- * See the LICENSE.PROPRIETARY file in the top-level directory for licensing information.
+ * Scylla is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Scylla is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 #pragma once


### PR DESCRIPTION
alternator/expressions.g had both AGPL and proprietary licensing. The
proprietary one is removed.

gms/inet_address_serializer.hh had only a proprietary license; it is
replaced by the AGPL.

Fixes #8465.