### PR TITLE
qos: make sure to wait for service level updates on shutdown

### DIFF
--- a/db/system_distributed_keyspace.cc
+++ b/db/system_distributed_keyspace.cc
@@ -541,7 +541,7 @@ system_distributed_keyspace::get_cdc_desc_v1_timestamps(context ctx) {
 future<qos::service_levels_info> system_distributed_keyspace::get_service_levels() const {
     static sstring prepared_query = format("SELECT * FROM {}.{};", NAME, SERVICE_LEVELS);
 
-    return _qp.execute_internal(prepared_query, {}).then([] (shared_ptr<cql3::untyped_result_set> result_set) {
+    return _qp.execute_internal(prepared_query, db::consistency_level::ONE, internal_distributed_query_state(), {}).then([] (shared_ptr<cql3::untyped_result_set> result_set) {
         qos::service_levels_info service_levels;
         for (auto &&row : *result_set) {
             auto service_level_name = row.get_as<sstring>("service_level");
@@ -554,7 +554,7 @@ future<qos::service_levels_info> system_distributed_keyspace::get_service_levels
 
 future<qos::service_levels_info> system_distributed_keyspace::get_service_level(sstring service_level_name) const {
     static sstring prepared_query = format("SELECT * FROM {}.{} WHERE service_level = ?;", NAME, SERVICE_LEVELS);
-    return _qp.execute_internal(prepared_query, {service_level_name}).then([] (shared_ptr<cql3::untyped_result_set> result_set) {
+    return _qp.execute_internal(prepared_query, db::consistency_level::ONE, internal_distributed_query_state(), {service_level_name}).then([] (shared_ptr<cql3::untyped_result_set> result_set) {
         qos::service_levels_info service_levels;
         if (!result_set->empty()) {
             auto &&row = result_set->one();
@@ -568,12 +568,12 @@ future<qos::service_levels_info> system_distributed_keyspace::get_service_level(
 
 future<> system_distributed_keyspace::set_service_level(sstring service_level_name, qos::service_level_options slo) const {
     static sstring prepared_puery = format("INSERT INTO {}.{} (service_level) VALUES (?);", NAME, SERVICE_LEVELS);
-    return _qp.execute_internal(prepared_puery, {service_level_name}).discard_result();
+    return _qp.execute_internal(prepared_puery, db::consistency_level::ONE, internal_distributed_query_state(), {service_level_name}).discard_result();
 }
 
 future<> system_distributed_keyspace::drop_service_level(sstring service_level_name) const {
     static sstring prepared_query = format("DELETE FROM {}.{} WHERE service_level= ?;", NAME, SERVICE_LEVELS);
-    return _qp.execute_internal(prepared_query, {service_level_name}).discard_result();
+    return _qp.execute_internal(prepared_query, db::consistency_level::ONE, internal_distributed_query_state(), {service_level_name}).discard_result();
 }
 
 }

--- a/service/qos/service_level_controller.cc
+++ b/service/qos/service_level_controller.cc
@@ -86,15 +86,28 @@ void service_level_controller::set_distributed_data_accessor(service_level_distr
     }
 }
 
-future<> service_level_controller::stop() {
-    // unregister from the service level distributed data accessor.
-    _sl_data_accessor = nullptr;
-    if (this_shard_id() == global_controller) {
-        // abort the loop of the distributed data checking if it is running
-        _global_controller_db->dist_data_update_aborter.request_abort();
-        _global_controller_db->notifications_serializer.broken();
+future<> service_level_controller::drain() {
+    if (this_shard_id() != global_controller) {
+        return make_ready_future();
     }
-    return std::exchange(_distributed_data_updater, make_ready_future<>());
+    // abort the loop of the distributed data checking if it is running
+    if (!_global_controller_db->dist_data_update_aborter.abort_requested()) {
+        _global_controller_db->dist_data_update_aborter.request_abort();
+    }
+    _global_controller_db->notifications_serializer.broken();
+    return std::exchange(_global_controller_db->distributed_data_update, make_ready_future<>()).then_wrapped([] (future<> f) {
+        try {
+            f.get();
+        } catch (const broken_semaphore& ignored) {
+        } catch (const sleep_aborted& ignored) {
+        } catch (const exceptions::unavailable_exception& ignored) {
+        } catch (const exceptions::read_timeout_exception& ignored) {
+        }
+    });
+}
+
+future<> service_level_controller::stop() {
+    return drain();
 }
 
 future<> service_level_controller::update_service_levels_from_distributed_data() {
@@ -103,63 +116,65 @@ future<> service_level_controller::update_service_levels_from_distributed_data()
         return make_ready_future();
     }
 
-    return container().invoke_on(global_controller, [] (service_level_controller& sl_controller) {
-        return with_semaphore(sl_controller._global_controller_db->notifications_serializer, 1, [&sl_controller] () {
-            return async([&sl_controller] () {
-                service_levels_info service_levels = sl_controller._sl_data_accessor->get_service_levels().get0();
-                service_levels_info service_levels_for_add_or_update;
-                service_levels_info service_levels_for_delete;
+    if (this_shard_id() != global_controller) {
+        return make_ready_future();
+    }
 
-                auto current_it = sl_controller._service_levels_db.begin();
-                auto new_state_it = service_levels.begin();
+    return with_semaphore(_global_controller_db->notifications_serializer, 1, [this] () {
+        return async([this] () {
+            service_levels_info service_levels = _sl_data_accessor->get_service_levels().get0();
+            service_levels_info service_levels_for_add_or_update;
+            service_levels_info service_levels_for_delete;
 
-                // we want to detect 3 kinds of objects in one pass -
-                // 1. new service levels that have been added to the distributed keyspace
-                // 2. existing service levels that have changed
-                // 3. removed service levels
-                // this loop is batching together add/update operation and remove operation
-                // then they are all executed together.The reason for this is to allow for
-                // firstly delete all that there is to be deleted and only then adding new
-                // service levels.
-                while (current_it != sl_controller._service_levels_db.end() && new_state_it != service_levels.end()) {
-                    if (current_it->first == new_state_it->first) {
-                        //the service level exists on both the cureent and new state.
-                       if (current_it->second.slo != new_state_it->second) {
-                           // The service level configuration is different
-                           // in the new state and the old state, meaning it needs to be updated.
-                           service_levels_for_add_or_update.insert(*new_state_it);
-                       }
-                       current_it++;
-                       new_state_it++;
-                   } else if (current_it->first < new_state_it->first) {
-                       //The service level does not exists in the new state so it needs to be
-                       //removed, but only if it is not static since static configurations dont
-                       //come from the distributed keyspace but from code.
-                       if (!current_it->second.is_static) {
-                           service_levels_for_delete.emplace(current_it->first, current_it->second.slo);
-                       }
-                       current_it++;
-                   } else { /*new_it->first < current_it->first */
-                       // The service level exits in the new state but not in the old state
-                       // so it needs to be added.
-                       service_levels_for_add_or_update.insert(*new_state_it);
-                       new_state_it++;
-                   }
-                }
+            auto current_it = _service_levels_db.begin();
+            auto new_state_it = service_levels.begin();
 
-                for (; current_it != sl_controller._service_levels_db.end(); current_it++) {
-                    service_levels_for_delete.emplace(current_it->first, current_it->second.slo);
+            // we want to detect 3 kinds of objects in one pass -
+            // 1. new service levels that have been added to the distributed keyspace
+            // 2. existing service levels that have changed
+            // 3. removed service levels
+            // this loop is batching together add/update operation and remove operation
+            // then they are all executed together.The reason for this is to allow for
+            // firstly delete all that there is to be deleted and only then adding new
+            // service levels.
+            while (current_it != _service_levels_db.end() && new_state_it != service_levels.end()) {
+                if (current_it->first == new_state_it->first) {
+                    //the service level exists on both the cureent and new state.
+                    if (current_it->second.slo != new_state_it->second) {
+                        // The service level configuration is different
+                        // in the new state and the old state, meaning it needs to be updated.
+                        service_levels_for_add_or_update.insert(*new_state_it);
+                    }
+                    current_it++;
+                    new_state_it++;
+                } else if (current_it->first < new_state_it->first) {
+                    //The service level does not exists in the new state so it needs to be
+                    //removed, but only if it is not static since static configurations dont
+                    //come from the distributed keyspace but from code.
+                    if (!current_it->second.is_static) {
+                        service_levels_for_delete.emplace(current_it->first, current_it->second.slo);
+                    }
+                    current_it++;
+                } else { /*new_it->first < current_it->first */
+                    // The service level exits in the new state but not in the old state
+                    // so it needs to be added.
+                    service_levels_for_add_or_update.insert(*new_state_it);
+                    new_state_it++;
                 }
-                std::copy(new_state_it, service_levels.end(), std::inserter(service_levels_for_add_or_update,
-                        service_levels_for_add_or_update.end()));
+            }
 
-                for (auto&& sl : service_levels_for_delete) {
-                    sl_controller.do_remove_service_level(sl.first, false).get();
-                }
-                for (auto&& sl : service_levels_for_add_or_update) {
-                    sl_controller.do_add_service_level(sl.first, sl.second).get();
-                }
-            });
+            for (; current_it != _service_levels_db.end(); current_it++) {
+                service_levels_for_delete.emplace(current_it->first, current_it->second.slo);
+            }
+            std::copy(new_state_it, service_levels.end(), std::inserter(service_levels_for_add_or_update,
+                    service_levels_for_add_or_update.end()));
+
+            for (auto&& sl : service_levels_for_delete) {
+                do_remove_service_level(sl.first, false).get();
+            }
+            for (auto&& sl : service_levels_for_add_or_update) {
+                do_add_service_level(sl.first, sl.second).get();
+            }
         });
     });
 }
@@ -225,24 +240,25 @@ future<> service_level_controller::notify_service_level_removed(sstring name) {
 }
 
 void service_level_controller::update_from_distributed_data(std::chrono::duration<float> interval) {
-    _distributed_data_updater = container().invoke_on(global_controller, [interval] (service_level_controller& global_sl) {
-        if (global_sl._global_controller_db->distributed_data_update.available()) {
-            global_sl._global_controller_db->distributed_data_update = repeat([interval, &global_sl] {
-                return sleep_abortable<steady_clock_type>(std::chrono::duration_cast<steady_clock_type::duration>(interval),
-                        global_sl._global_controller_db->dist_data_update_aborter).then_wrapped([&global_sl] (future<>&& f) {
-                        try {
-                            f.get();
-                            return global_sl.update_service_levels_from_distributed_data().then([] {
-                                    return stop_iteration::no;
-                            });
-                        }
-                        catch (const sleep_aborted& e) {
-                            return make_ready_future<seastar::bool_class<seastar::stop_iteration_tag>>(stop_iteration::yes);
-                        }
-                    });
-            });
-        }
-    });
+    if (this_shard_id() != global_controller) {
+        throw std::runtime_error(format("Service level updates from distributed data can only be activated on shard {}", global_controller));
+    }
+    if (_global_controller_db->distributed_data_update.available()) {
+        _global_controller_db->distributed_data_update = repeat([this, interval] {
+            return sleep_abortable<steady_clock_type>(std::chrono::duration_cast<steady_clock_type::duration>(interval),
+                    _global_controller_db->dist_data_update_aborter).then_wrapped([this] (future<>&& f) {
+                    try {
+                        f.get();
+                        return update_service_levels_from_distributed_data().then([this] {
+                                return stop_iteration::no;
+                        });
+                    }
+                    catch (const sleep_aborted& e) {
+                        return make_ready_future<seastar::bool_class<seastar::stop_iteration_tag>>(stop_iteration::yes);
+                    }
+                });
+        });
+    }
 }
 
 future<> service_level_controller::add_distributed_service_level(sstring name, service_level_options slo, bool if_not_exists) {

--- a/service/qos/service_level_controller.hh
+++ b/service/qos/service_level_controller.hh
@@ -90,7 +90,6 @@ private:
     service_level _default_service_level;
     service_level_distributed_data_accessor_ptr _sl_data_accessor;
     sharded<auth::service>& _auth_service;
-    future<> _distributed_data_updater = make_ready_future<>();
 public:
     service_level_controller(sharded<auth::service>& auth_service, service_level_options default_service_level_config);
 
@@ -121,6 +120,12 @@ public:
      * or not.
      */
     future<> remove_service_level(sstring name, bool remove_static);
+
+    /**
+     * stops the distributed updater
+     * @return a future that is resolved when the updates stopped
+     */
+    future<> drain();
 
     /**
      * stops all ongoing operations if exists


### PR DESCRIPTION
The service level controller spawns an updating thread,
which wasn't properly waited for during shutdown.
This behavior is now fixed.

Tests: manual

Fixes #8468