### PR TITLE
Switch to use NODE_OPS_CMD for decommission and bootstrap operation

### DIFF
--- a/idl/partition_checksum.idl.hh
+++ b/idl/partition_checksum.idl.hh
@@ -116,6 +116,10 @@ enum class node_ops_cmd : uint32_t {
      replace_heartbeat,
      replace_abort,
      replace_done,
+     decommission_prepare,
+     decommission_heartbeat,
+     decommission_abort,
+     decommission_done,
 };
 
 struct node_ops_cmd_request {

--- a/idl/partition_checksum.idl.hh
+++ b/idl/partition_checksum.idl.hh
@@ -120,17 +120,31 @@ enum class node_ops_cmd : uint32_t {
      decommission_heartbeat,
      decommission_abort,
      decommission_done,
+     bootstrap_prepare,
+     bootstrap_heartbeat,
+     bootstrap_abort,
+     bootstrap_done,
+     query_pending_ops,
 };
 
 struct node_ops_cmd_request {
+    // Mandatory field, set by all cmds
     node_ops_cmd cmd;
+    // Mandatory field, set by all cmds
     utils::UUID ops_uuid;
+    // Optional field, list nodes to ignore, set by all cmds
     std::list<gms::inet_address> ignore_nodes;
+    // Optional field, list leaving nodes, set by decommission and removenode cmd
     std::list<gms::inet_address> leaving_nodes;
-    // Map existing nodes to replacing nodes
+    // Optional field, map existing nodes to replacing nodes, set by replace cmd
     std::unordered_map<gms::inet_address, gms::inet_address> replace_nodes;
+    // Optional field, map bootstrapping nodes to bootstrap tokens, set by bootstrap cmd
+    std::unordered_map<gms::inet_address, std::list<dht::token>> bootstrap_nodes;
 };
 
 struct node_ops_cmd_response {
+    // Mandatory field, set by all cmds
     bool ok;
+    // Optional field, set by query_pending_ops cmd
+    std::list<utils::UUID> pending_ops;
 };

--- a/repair/repair.hh
+++ b/repair/repair.hh
@@ -500,21 +500,52 @@ enum class node_ops_cmd : uint32_t {
      decommission_heartbeat,
      decommission_abort,
      decommission_done,
+     bootstrap_prepare,
+     bootstrap_heartbeat,
+     bootstrap_abort,
+     bootstrap_done,
+     query_pending_ops,
 };
 
 // The cmd and ops_uuid are mandatory for each request.
 // The ignore_nodes and leaving_node are optional.
 struct node_ops_cmd_request {
+    // Mandatory field, set by all cmds
     node_ops_cmd cmd;
+    // Mandatory field, set by all cmds
     utils::UUID ops_uuid;
+    // Optional field, list nodes to ignore, set by all cmds
     std::list<gms::inet_address> ignore_nodes;
+    // Optional field, list leaving nodes, set by decommission and removenode cmd
     std::list<gms::inet_address> leaving_nodes;
-    // Map existing nodes to replacing nodes
+    // Optional field, map existing nodes to replacing nodes, set by replace cmd
     std::unordered_map<gms::inet_address, gms::inet_address> replace_nodes;
+    // Optional field, map bootstrapping nodes to bootstrap tokens, set by bootstrap cmd
+    std::unordered_map<gms::inet_address, std::list<dht::token>> bootstrap_nodes;
+    node_ops_cmd_request(node_ops_cmd command,
+            utils::UUID uuid,
+            std::list<gms::inet_address> ignore = {},
+            std::list<gms::inet_address> leaving = {},
+            std::unordered_map<gms::inet_address, gms::inet_address> replace = {},
+            std::unordered_map<gms::inet_address, std::list<dht::token>> bootstrap = {})
+        : cmd(command)
+        , ops_uuid(std::move(uuid))
+        , ignore_nodes(std::move(ignore))
+        , leaving_nodes(std::move(leaving))
+        , replace_nodes(std::move(replace))
+        , bootstrap_nodes(std::move(bootstrap)) {
+    }
 };
 
 struct node_ops_cmd_response {
+    // Mandatory field, set by all cmds
     bool ok;
+    // Optional field, set by query_pending_ops cmd
+    std::list<utils::UUID> pending_ops;
+    node_ops_cmd_response(bool o, std::list<utils::UUID> pending = {})
+        : ok(o)
+        , pending_ops(std::move(pending)) {
+    }
 };
 
 namespace std {

--- a/repair/repair.hh
+++ b/repair/repair.hh
@@ -496,6 +496,10 @@ enum class node_ops_cmd : uint32_t {
      replace_heartbeat,
      replace_abort,
      replace_done,
+     decommission_prepare,
+     decommission_heartbeat,
+     decommission_abort,
+     decommission_done,
 };
 
 // The cmd and ops_uuid are mandatory for each request.

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -380,6 +380,7 @@ private:
             const std::unordered_map<gms::inet_address, sstring>& loaded_peer_features, bind_messaging_port do_bind = bind_messaging_port::yes);
 
     void run_replace_ops();
+    void run_bootstrap_ops();
 
 public:
     future<bool> is_initialized();


### PR DESCRIPTION
In commit 323f72e48a7d89d9edc40257a1f45c202accc146 (repair: Switch to
use NODE_OPS_CMD for replace operation), we switched replace operation
to use the new NODE_OPS_CMD infrastructure.

In this patch set, we continue the work to switch decommission and bootstrap 
operation to use NODE_OPS_CMD.

Fixes #8472
Fixes #8471