### PR TITLE
unified: abort install when non-bash shell detected

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -22,6 +22,11 @@
 
 set -e
 
+if [ -z "$BASH_VERSION" ]; then
+    echo "Unsupported shell, please run this script on bash."
+    exit 1
+fi
+
 print_usage() {
     cat <<EOF
 Usage: install.sh [options]

--- a/unified/install.sh
+++ b/unified/install.sh
@@ -22,6 +22,11 @@
 
 set -e
 
+if [ -z "$BASH_VERSION" ]; then
+    echo "Unsupported shell, please run this script on bash."
+    exit 1
+fi
+
 print_usage() {
     cat <<EOF
 Usage: install.sh [options]

--- a/unified/uninstall.sh
+++ b/unified/uninstall.sh
@@ -22,6 +22,11 @@
 
 set -e
 
+if [ -z "$BASH_VERSION" ]; then
+    echo "Unsupported shell, please run this script on bash."
+    exit 1
+fi
+
 # change directory to the package's root directory
 cd "$(dirname "$0")"
 


### PR DESCRIPTION
On Debian variants, sh -x ./install.sh will fail since our script in
written in bash, and /bin/sh in Debian variants is dash, not bash.

So detect non-bash shell and print error message, let users to run in
bash.

Fixes #8479