### PR TITLE
Improve validation of "enable", "postimage" and "ttl" CDC options

### DIFF
--- a/cdc/log.cc
+++ b/cdc/log.cc
@@ -377,7 +377,13 @@ cdc::options::options(const std::map<sstring, sstring>& map) {
                 throw exceptions::configuration_exception("Invalid value for CDC option \"delta\": " + p.second);
             }
         } else if (key == "ttl") {
-            _ttl = std::stoi(p.second);
+            try {
+                _ttl = std::stoi(p.second);
+            } catch (std::invalid_argument& e) {
+                throw exceptions::configuration_exception("Invalid value for CDC option \"ttl\": " + p.second);
+            } catch (std::out_of_range& e) {
+                throw exceptions::configuration_exception("Invalid CDC option: ttl too large");
+            }
             if (_ttl < 0) {
                 throw exceptions::configuration_exception("Invalid CDC option: ttl must be >= 0");
             }

--- a/cdc/log.cc
+++ b/cdc/log.cc
@@ -349,7 +349,11 @@ cdc::options::options(const std::map<sstring, sstring>& map) {
         auto is_false = val == "false" || val == "0";
 
         if (key == "enabled") {
-            _enabled = is_true;
+            if (is_true || is_false) {
+                _enabled = is_true;    
+            } else {
+                throw exceptions::configuration_exception("Invalid value for CDC option \"enabled\": " + p.second);
+            }
         } else if (key == "preimage") {
             if (is_true || val == image_mode_string_on) {
                 _preimage = image_mode::on;
@@ -361,7 +365,11 @@ cdc::options::options(const std::map<sstring, sstring>& map) {
                 throw exceptions::configuration_exception("Invalid value for CDC option \"preimage\": " + p.second);
             }
         } else if (key == "postimage") {
-            _postimage = is_true;
+            if (is_true || is_false) {
+                _postimage = is_true;    
+            } else {
+                throw exceptions::configuration_exception("Invalid value for CDC option \"postimage\": " + p.second);
+            }
         } else if (key == "delta") {
             if (val == delta_mode_string_keys) {
                 _delta_mode = delta_mode::keys;


### PR DESCRIPTION
### First commit
In the first commit, add validation of `enable` and `postimage` CDC options. Both options are boolean options, but previously they were not validated, meaning you could issue a query:

```
CREATE TABLE ks.t(pk int, PRIMARY KEY(pk)) WITH cdc = {'enabled': 'dsfdsd'};
```

and it would be executed without any errors, silently interpreting `dsfdsd` as false.

The first commit narrows possible values of those boolean CDC options to `false`, `true`, `0`, `1`. After applying this change, issuing the query above would result in this error message:

```
ConfigurationException: Invalid value for CDC option "enabled": dsfdsd
```

I actually encountered this lacking validation myself, as I mistakenly issued a query:
```
CREATE TABLE ks.t(pk int, PRIMARY KEY(pk)) WITH cdc = {'enabled': true, 'preimage': true, 'postimage': 'full'};
```
incorrectly assigning `full` to `postimage`, instead of `preimage`. However, before this commit, this query ran correctly and it interpreted `full` as `false` and disabled postimages altogether. 

### Second commit
The second commit improves the error message of invalid `ttl` CDC option:

Before:
```
CREATE TABLE ks.t(pk int, PRIMARY KEY(pk)) WITH cdc = {'enabled': true, 'ttl': 'invalid'};
ServerError: stoi
```

After:
```
CREATE TABLE ks.t(pk int, PRIMARY KEY(pk)) WITH cdc = {'enabled': true, 'ttl': 'kgjhfkjd'};
ConfigurationException: Invalid value for CDC option "ttl": kgjhfkjd
```

```
CREATE TABLE ks.t(pk int, PRIMARY KEY(pk)) WITH cdc = {'enabled': true, 'ttl': '75747885787487'};
ConfigurationException: Invalid CDC option: ttl too large
```