### PR TITLE
repair: Handle everywhere_topology in bootstrap_with_repair  

### DIFF
--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -1579,6 +1579,7 @@ future<> bootstrap_with_repair(seastar::sharded<database>& db, seastar::sharded<
             auto& strat = ks.get_replication_strategy();
             dht::token_range_vector desired_ranges = strat.get_pending_address_ranges(tmptr, tokens, myip, utils::can_yield::yes);
             bool find_node_in_local_dc_only = strat.get_type() == locator::replication_strategy_type::network_topology;
+            bool everywhere_topology = strat.get_type() == locator::replication_strategy_type::everywhere_topology;
 
             //Active ranges
             auto metadata_clone = tmptr->clone_only_token_map().get0();
@@ -1656,7 +1657,9 @@ future<> bootstrap_with_repair(seastar::sharded<database>& db, seastar::sharded<
                         };
                         auto old_endpoints_in_local_dc = get_old_endpoints_in_local_dc();
                         auto rf_in_local_dc = get_rf_in_local_dc();
-                        if (old_endpoints.size() == strat.get_replication_factor()) {
+                        if (everywhere_topology) {
+                            neighbors = old_endpoints_in_local_dc;
+                        } else if (old_endpoints.size() == strat.get_replication_factor()) {
                             // For example, with RF = 3 and 3 nodes n1, n2, n3
                             // in the cluster, n4 is bootstrapped, old_replicas
                             // = {n1, n2, n3}, new_replicas = {n1, n2, n4}, n3

--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -1631,8 +1631,8 @@ future<> bootstrap_with_repair(seastar::sharded<database>& db, seastar::sharded<
                             auto nodes = boost::copy_range<std::vector<gms::inet_address>>(old_nodes |
                                     boost::adaptors::filtered([&] (const gms::inet_address& node) { return !new_nodes.contains(node); }));
                             if (nodes.size() != 1) {
-                                throw std::runtime_error(format("bootstrap_with_repair: keyspace={}, range={}, expected 1 node losing range but found more nodes={}",
-                                        keyspace_name, desired_range, nodes));
+                                throw std::runtime_error(format("bootstrap_with_repair: keyspace={}, range={}, expected 1 node losing range but found {} nodes={}",
+                                        keyspace_name, desired_range, nodes.size(), nodes));
                             }
                             return nodes;
                         };


### PR DESCRIPTION
 repair: Handle everywhere_topology in bootstrap_with_repair
 
 The everywhere_topology returns the number of nodes in the cluster as
 RF. This makes only streaming from the node losing the range impossible
 since no node is losing the range after bootstrap.
 
 Shortcut to stream from all nodes in local dc in case the keyspace is
 everywhere_topology.
 
 Fixes #8503

