### PR TITLE
main: add a debug symbol for service level controller

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -404,6 +404,7 @@ static auto defer_verbose_shutdown(const char* what, Func&& func) {
 namespace debug {
 sharded<netw::messaging_service>* the_messaging_service;
 sharded<cql3::query_processor>* the_query_processor;
+sharded<qos::service_level_controller>* the_sl_controller;
 }
 
 int main(int ac, char** av) {
@@ -815,6 +816,7 @@ int main(int ac, char** av) {
 
             static sharded<auth::service> auth_service;
             static sharded<qos::service_level_controller> sl_controller;
+            debug::the_sl_controller = &sl_controller;
 
             //starting service level controller
             qos::service_level_options default_service_level_configuration;


### PR DESCRIPTION
It's notoriously hard to find the service level controller symbol
(possible by guessing the offset based on system_distributed_keyspace
address, but it's very cumbersome). To make the debugging process
easier, the symbol is exported via the `debug` namespace.