### PR TITLE
tools: toolchain: dbuild: define die() earlier

### DIFF
--- a/tools/toolchain/dbuild
+++ b/tools/toolchain/dbuild
@@ -4,6 +4,18 @@ if [[ -f ~/.config/scylladb/dbuild ]]; then
     . ~/.config/scylladb/dbuild
 fi
 
+function die () {
+    msg="$1"
+    if [[ -n "$msg" ]]; then
+        echo "$(basename $0): $msg." 1>&2
+    fi
+    cat <<EOF 1>&2
+
+Run \`$0 --help' to print the full help message.
+EOF
+    exit 1
+}
+
 if which docker >/dev/null 2>&1 ; then
   tool=${DBUILD_TOOL-docker}
 elif which podman >/dev/null 2>&1 ; then
@@ -67,18 +79,6 @@ ENVIRONMENT
     be used to set up the SCYLLADB_DBUILD environment variable.
 EOF
     exit 0
-}
-
-function die () {
-    msg="$1"
-    if [[ -n "$msg" ]]; then
-        echo "$(basename $0): $msg." 1>&2
-    fi
-    cat <<EOF 1>&2
-
-Run \`$0 --help' to print the full help message.
-EOF
-    exit 1
 }
 
 if [[ $# -eq 0 ]]; then


### PR DESCRIPTION
die() is called before it is defined, so it doesn't work. Move it eariler.

Ref #8520.