### PR TITLE
treewide: remove inclusions of storage_proxy.hh from headers

### DIFF
--- a/alternator/executor.hh
+++ b/alternator/executor.hh
@@ -27,9 +27,9 @@
 #include <seastar/json/json_elements.hh>
 #include <seastar/core/sharded.hh>
 
-#include "service/storage_proxy.hh"
 #include "service/migration_manager.hh"
 #include "service/client_state.hh"
+#include "service_permit.hh"
 #include "db/timeout_clock.hh"
 
 #include "alternator/error.hh"
@@ -51,6 +51,7 @@ namespace cql3::selection {
 
 namespace service {
     class storage_service;
+    class storage_proxy;
 }
 
 namespace cdc {

--- a/alternator/server.hh
+++ b/alternator/server.hh
@@ -23,6 +23,7 @@
 
 #include "alternator/executor.hh"
 #include <seastar/core/future.hh>
+#include <seastar/core/condition-variable.hh>
 #include <seastar/http/httpd.hh>
 #include <seastar/net/tls.hh>
 #include <optional>

--- a/cdc/generation_service.hh
+++ b/cdc/generation_service.hh
@@ -22,16 +22,26 @@
 
 #pragma once
 
+#include <seastar/core/sharded.hh>
 #include "cdc/metadata.hh"
 #include "cdc/generation_id.hh"
 #include "gms/i_endpoint_state_change_subscriber.hh"
 
 namespace db {
 class system_distributed_keyspace;
+class config;
 }
 
 namespace gms {
 class gossiper;
+}
+
+namespace seastar {
+class abort_source;
+}
+
+namespace locator {
+class shared_token_metadata;
 }
 
 namespace cdc {

--- a/cdc/log.cc
+++ b/cdc/log.cc
@@ -42,6 +42,7 @@
 #include "schema_builder.hh"
 #include "service/migration_listener.hh"
 #include "service/storage_service.hh"
+#include "service/storage_proxy.hh"
 #include "types/tuple.hh"
 #include "cql3/statements/select_statement.hh"
 #include "cql3/multi_column_relation.hh"

--- a/cdc/split.hh
+++ b/cdc/split.hh
@@ -24,6 +24,7 @@
 #include <vector>
 #include <boost/dynamic_bitset.hpp>
 #include "schema_fwd.hh"
+#include "database_fwd.hh"
 #include "timestamp.hh"
 #include "bytes.hh"
 #include <seastar/util/noncopyable_function.hh>

--- a/connection_notifier.cc
+++ b/connection_notifier.cc
@@ -22,6 +22,7 @@
 #include "connection_notifier.hh"
 #include "cql3/constants.hh"
 #include "database.hh"
+#include "service/storage_proxy.hh"
 
 #include <stdexcept>
 

--- a/cql3/cql_statement.hh
+++ b/cql3/cql_statement.hh
@@ -43,9 +43,14 @@
 
 #include "service/client_state.hh"
 #include "service/query_state.hh"
-#include "service/storage_proxy.hh"
 #include "cql3/query_options.hh"
 #include "timeout_config.hh"
+
+namespace service {
+
+class storage_proxy;
+
+}
 
 namespace cql_transport {
 

--- a/cql3/statements/alter_keyspace_statement.cc
+++ b/cql3/statements/alter_keyspace_statement.cc
@@ -42,6 +42,7 @@
 #include "alter_keyspace_statement.hh"
 #include "prepared_statement.hh"
 #include "service/migration_manager.hh"
+#include "service/storage_proxy.hh"
 #include "db/system_keyspace.hh"
 #include "database.hh"
 #include "cql3/query_processor.hh"

--- a/cql3/statements/alter_table_statement.cc
+++ b/cql3/statements/alter_table_statement.cc
@@ -43,6 +43,7 @@
 #include "index/secondary_index_manager.hh"
 #include "prepared_statement.hh"
 #include "service/migration_manager.hh"
+#include "service/storage_proxy.hh"
 #include "validation.hh"
 #include "db/extensions.hh"
 #include <boost/range/adaptor/filtered.hpp>

--- a/cql3/statements/alter_view_statement.cc
+++ b/cql3/statements/alter_view_statement.cc
@@ -42,6 +42,7 @@
 #include "cql3/statements/alter_view_statement.hh"
 #include "cql3/statements/prepared_statement.hh"
 #include "service/migration_manager.hh"
+#include "service/storage_proxy.hh"
 #include "validation.hh"
 #include "view_info.hh"
 #include "db/extensions.hh"

--- a/cql3/statements/batch_statement.hh
+++ b/cql3/statements/batch_statement.hh
@@ -41,7 +41,6 @@
 #include "modification_statement.hh"
 #include "raw/modification_statement.hh"
 #include "raw/batch_statement.hh"
-#include "service/storage_proxy.hh"
 #include "transport/messages/result_message.hh"
 #include "timestamp.hh"
 #include "log.hh"

--- a/cql3/statements/create_function_statement.cc
+++ b/cql3/statements/create_function_statement.cc
@@ -23,6 +23,7 @@
 #include "cql3/functions/functions.hh"
 #include "prepared_statement.hh"
 #include "service/migration_manager.hh"
+#include "service/storage_proxy.hh"
 #include "lua.hh"
 #include "database.hh"
 #include "cql3/query_processor.hh"

--- a/cql3/statements/create_keyspace_statement.cc
+++ b/cql3/statements/create_keyspace_statement.cc
@@ -43,6 +43,7 @@
 #include "prepared_statement.hh"
 #include "database.hh"
 #include "service/migration_manager.hh"
+#include "service/storage_proxy.hh"
 #include "transport/messages/result_message.hh"
 #include "cql3/query_processor.hh"
 

--- a/cql3/statements/create_type_statement.cc
+++ b/cql3/statements/create_type_statement.cc
@@ -41,6 +41,7 @@
 #include "prepared_statement.hh"
 #include "database.hh"
 #include "service/migration_manager.hh"
+#include "service/storage_proxy.hh"
 #include "user_types_metadata.hh"
 #include "cql3/query_processor.hh"
 

--- a/cql3/statements/drop_index_statement.cc
+++ b/cql3/statements/drop_index_statement.cc
@@ -42,6 +42,7 @@
 #include "cql3/statements/drop_index_statement.hh"
 #include "cql3/statements/prepared_statement.hh"
 #include "service/migration_manager.hh"
+#include "service/storage_proxy.hh"
 #include "schema_builder.hh"
 #include "database.hh"
 #include "gms/feature_service.hh"

--- a/cql3/statements/drop_table_statement.cc
+++ b/cql3/statements/drop_table_statement.cc
@@ -43,6 +43,7 @@
 #include "cql3/statements/prepared_statement.hh"
 #include "cql3/query_processor.hh"
 #include "service/migration_manager.hh"
+#include "service/storage_proxy.hh"
 
 namespace cql3 {
 

--- a/cql3/statements/drop_type_statement.cc
+++ b/cql3/statements/drop_type_statement.cc
@@ -44,6 +44,7 @@
 #include "boost/range/adaptor/map.hpp"
 
 #include "service/migration_manager.hh"
+#include "service/storage_proxy.hh"
 #include "database.hh"
 #include "user_types_metadata.hh"
 

--- a/cql3/statements/drop_view_statement.cc
+++ b/cql3/statements/drop_view_statement.cc
@@ -43,6 +43,7 @@
 #include "cql3/statements/prepared_statement.hh"
 #include "cql3/query_processor.hh"
 #include "service/migration_manager.hh"
+#include "service/storage_proxy.hh"
 #include "view_info.hh"
 #include "database.hh"
 

--- a/cql3/statements/function_statement.cc
+++ b/cql3/statements/function_statement.cc
@@ -24,6 +24,7 @@
 #include "db/config.hh"
 #include "database.hh"
 #include "gms/feature_service.hh"
+#include "service/storage_proxy.hh"
 
 namespace cql3 {
 namespace statements {

--- a/cql3/statements/modification_statement.hh
+++ b/cql3/statements/modification_statement.hh
@@ -60,7 +60,6 @@
 
 #include "unimplemented.hh"
 #include "validation.hh"
-#include "service/storage_proxy.hh"
 
 #include <memory>
 #include <optional>

--- a/cql3/statements/raw/batch_statement.hh
+++ b/cql3/statements/raw/batch_statement.hh
@@ -39,7 +39,6 @@
 
 #include "cql3/cql_statement.hh"
 #include "modification_statement.hh"
-#include "service/storage_proxy.hh"
 #include "transport/messages/result_message.hh"
 #include "timestamp.hh"
 #include "log.hh"

--- a/cql3/statements/raw/modification_statement.hh
+++ b/cql3/statements/raw/modification_statement.hh
@@ -56,7 +56,6 @@
 
 #include "unimplemented.hh"
 #include "validation.hh"
-#include "service/storage_proxy.hh"
 
 #include <memory>
 

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -52,6 +52,7 @@
 #include "query-result-reader.hh"
 #include "query_result_merger.hh"
 #include "service/pager/query_pagers.hh"
+#include "service/storage_proxy.hh"
 #include <seastar/core/execution_stage.hh>
 #include "view_info.hh"
 #include "partition_slice_builder.hh"

--- a/cql3/statements/truncate_statement.cc
+++ b/cql3/statements/truncate_statement.cc
@@ -44,6 +44,7 @@
 #include "cql3/cql_statement.hh"
 #include "database.hh"
 #include "cql3/query_processor.hh"
+#include "service/storage_proxy.hh"
 #include <optional>
 
 namespace cql3 {

--- a/database.cc
+++ b/database.cc
@@ -35,6 +35,7 @@
 #include <seastar/core/metrics.hh>
 #include <seastar/util/defer.hh>
 #include <boost/algorithm/string/split.hpp>
+#include <boost/algorithm/string/erase.hpp>
 #include "sstables/sstables.hh"
 #include "sstables/sstables_manager.hh"
 #include "sstables/compaction.hh"
@@ -54,6 +55,7 @@
 #include "gms/feature_service.hh"
 
 #include "utils/human_readable.hh"
+#include "utils/fb_utilities.hh"
 
 #include "db/timeout_clock.hh"
 #include "db/large_data_handler.hh"

--- a/db/legacy_schema_migrator.cc
+++ b/db/legacy_schema_migrator.cc
@@ -61,6 +61,7 @@
 #include "system_keyspace.hh"
 #include "schema_tables.hh"
 #include "schema_builder.hh"
+#include "service/storage_proxy.hh"
 #include "utils/rjson.hh"
 #include "cql3/query_processor.hh"
 #include "cql3/untyped_result_set.hh"

--- a/db/query_context.hh
+++ b/db/query_context.hh
@@ -22,6 +22,7 @@
 
 #include <memory>
 #include <seastar/core/sharded.hh>
+#include <seastar/core/distributed.hh>
 #include <seastar/core/future.hh>
 #include "cql3/query_processor.hh"
 #include "cql3/query_options.hh"

--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -41,6 +41,7 @@
 #include "db/schema_tables.hh"
 
 #include "service/migration_manager.hh"
+#include "service/storage_proxy.hh"
 #include "gms/feature_service.hh"
 #include "partition_slice_builder.hh"
 #include "dht/i_partitioner.hh"

--- a/db/schema_tables.hh
+++ b/db/schema_tables.hh
@@ -40,7 +40,6 @@
 
 #pragma once
 
-#include "service/storage_proxy.hh"
 #include "mutation.hh"
 #include "cql3/functions/user_function.hh"
 #include "schema_fwd.hh"
@@ -48,6 +47,7 @@
 #include "hashing.hh"
 #include "schema_mutations.hh"
 #include "types/map.hh"
+#include "query-result-set.hh"
 
 #include <vector>
 #include <map>
@@ -61,6 +61,13 @@ class result_set;
 namespace service {
 
 class storage_service;
+class storage_proxy;
+
+}
+
+namespace gms {
+
+class feature_service;
 
 }
 

--- a/db/system_distributed_keyspace.cc
+++ b/db/system_distributed_keyspace.cc
@@ -32,6 +32,7 @@
 #include "types/set.hh"
 #include "cdc/generation.hh"
 #include "cql3/query_processor.hh"
+#include "service/storage_proxy.hh"
 
 #include <seastar/core/seastar.hh>
 #include <seastar/core/shared_ptr.hh>

--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -70,6 +70,7 @@
 #include "mutation_partition.hh"
 #include "service/migration_manager.hh"
 #include "service/storage_service.hh"
+#include "service/storage_proxy.hh"
 #include "view_info.hh"
 #include "view_update_checks.hh"
 #include "types/user.hh"

--- a/db/view/view_update_checks.hh
+++ b/db/view/view_update_checks.hh
@@ -21,9 +21,13 @@
 
 #pragma once
 
+#include <seastar/core/future.hh>
 #include "streaming/stream_reason.hh"
 #include <boost/range/adaptor/map.hpp>
 #include <boost/algorithm/cxx11/any_of.hpp>
+#include "seastarx.hh"
+
+class table;
 
 namespace db {
 

--- a/raft/logical_clock.hh
+++ b/raft/logical_clock.hh
@@ -21,6 +21,7 @@
 #pragma once
 
 #include <chrono>
+#include <ostream>
 
 namespace raft {
 

--- a/redis/keyspace_utils.cc
+++ b/redis/keyspace_utils.cc
@@ -30,6 +30,7 @@
 #include "db/query_context.hh"
 #include "auth/service.hh"
 #include "service/migration_manager.hh"
+#include "service/storage_proxy.hh"
 #include "service/client_state.hh"
 #include "transport/server.hh"
 #include "db/system_keyspace.hh"

--- a/redis/server.cc
+++ b/redis/server.cc
@@ -31,6 +31,7 @@
 #include "exceptions/exceptions.hh"
 #include "service/query_state.hh"
 #include "service/storage_service.hh"
+#include "service/storage_proxy.hh"
 
 #include <seastar/core/future-util.hh>
 #include <seastar/core/seastar.hh>

--- a/redis/server.hh
+++ b/redis/server.hh
@@ -32,7 +32,6 @@
 #include "auth/service.hh"
 #include "cql3/values.hh"
 #include "service/client_state.hh"
-#include "service/storage_proxy.hh"
 #include "service_permit.hh"
 #include "timeout_config.hh"
 #include "utils/estimated_histogram.hh"
@@ -42,6 +41,7 @@
 #include <seastar/core/seastar.hh>
 #include <seastar/core/semaphore.hh>
 #include <seastar/core/sharded.hh>
+#include <seastar/core/execution_stage.hh>
 #include <seastar/net/tls.hh>
 
 #include <memory>
@@ -49,6 +49,12 @@
 db::consistency_level make_consistency_level(const sstring&);
 
 class redis_exception;
+
+namespace service {
+
+class storage_proxy;
+
+}
 
 namespace redis_transport {
 

--- a/redis/service.cc
+++ b/redis/service.cc
@@ -23,6 +23,7 @@
 #include "redis/service.hh"
 #include "redis/keyspace_utils.hh"
 #include "redis/server.hh"
+#include "service/storage_proxy.hh"
 #include "db/config.hh"
 #include "log.hh"
 #include "auth/common.hh"

--- a/service/migration_manager.cc
+++ b/service/migration_manager.cc
@@ -42,6 +42,7 @@
 #include <seastar/core/sleep.hh>
 #include "schema_registry.hh"
 #include "service/migration_manager.hh"
+#include "service/storage_proxy.hh"
 
 #include "service/migration_listener.hh"
 #include "message/messaging_service.hh"

--- a/service/migration_task.cc
+++ b/service/migration_task.cc
@@ -43,6 +43,7 @@
 
 #include "message/messaging_service.hh"
 #include "gms/failure_detector.hh"
+#include "gms/gossiper.hh"
 #include "db/schema_tables.hh"
 #include "frozen_mutation.hh"
 #include "migration_manager.hh"

--- a/service/pager/query_pager.hh
+++ b/service/pager/query_pager.hh
@@ -44,10 +44,11 @@
 #include "paging_state.hh"
 #include "cql3/result_set.hh"
 #include "cql3/selection/selection.hh"
-#include "service/storage_proxy.hh"
 #include "service/query_state.hh"
 
 namespace service {
+
+class storage_proxy_coordinator_query_result;
 
 namespace pager {
 

--- a/service/pager/query_pager.hh
+++ b/service/pager/query_pager.hh
@@ -157,7 +157,7 @@ protected:
     template<typename Base>
     class query_result_visitor;
     
-    future<service::storage_proxy::coordinator_query_result>
+    future<service::storage_proxy_coordinator_query_result>
     do_fetch_page(uint32_t page_size, gc_clock::time_point now, db::timeout_clock::time_point timeout);
 
     template<typename Visitor>

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -47,6 +47,7 @@
 #include "gms/inet_address.hh"
 #include "log.hh"
 #include "service/migration_manager.hh"
+#include "service/storage_proxy.hh"
 #include "to_string.hh"
 #include "gms/gossiper.hh"
 #include "gms/failure_detector.hh"

--- a/sstables/kl/writer.hh
+++ b/sstables/kl/writer.hh
@@ -20,6 +20,7 @@
  */
 
 #include "sstables/writer_impl.hh"
+#include "sstables/writer.hh"
 
 namespace sstables {
 

--- a/sstables/scanning_clustered_index_cursor.hh
+++ b/sstables/scanning_clustered_index_cursor.hh
@@ -24,8 +24,11 @@
 #include "sstables/index_entry.hh"
 #include "sstables/promoted_index_blocks_reader.hh"
 #include "schema.hh"
+#include "log.hh"
 
 namespace sstables {
+
+extern logging::logger sstlog;
 
 // Cursor implementation which incrementally consumes promoted index entries
 // from an input stream.

--- a/table.cc
+++ b/table.cc
@@ -42,7 +42,9 @@
 #include <boost/range/adaptor/map.hpp>
 #include "utils/error_injection.hh"
 #include "utils/histogram_metrics_helper.hh"
+#include "utils/fb_utilities.hh"
 #include "mutation_source_metadata.hh"
+#include "gms/gossiper.hh"
 
 static logging::logger tlogger("table");
 static seastar::metrics::label column_family_label("cf");

--- a/test/boost/batchlog_manager_test.cc
+++ b/test/boost/batchlog_manager_test.cc
@@ -36,6 +36,7 @@
 #include "cql3/query_processor.hh"
 #include "cql3/untyped_result_set.hh"
 #include "db/batchlog_manager.hh"
+#include "service/storage_proxy.hh"
 
 #include "message/messaging_service.hh"
 

--- a/test/boost/database_test.cc
+++ b/test/boost/database_test.cc
@@ -31,6 +31,7 @@
 #include "test/lib/log.hh"
 
 #include "database.hh"
+#include "lister.hh"
 #include "partition_slice_builder.hh"
 #include "frozen_mutation.hh"
 #include "test/lib/mutation_source_test.hh"

--- a/test/boost/schema_change_test.cc
+++ b/test/boost/schema_change_test.cc
@@ -30,6 +30,7 @@
 #include "test/lib/mutation_source_test.hh"
 #include "test/lib/result_set_assertions.hh"
 #include "service/migration_manager.hh"
+#include "service/storage_proxy.hh"
 #include "schema_builder.hh"
 #include "schema_registry.hh"
 #include "db/schema_tables.hh"

--- a/test/boost/user_types_test.cc
+++ b/test/boost/user_types_test.cc
@@ -28,6 +28,8 @@
 #include "types/list.hh"
 #include "test/lib/exception_utils.hh"
 
+#include <boost/algorithm/string/join.hpp>
+
 // Specifies that the given 'cql' query fails with the 'msg' message.
 // Requires a cql_test_env. The caller must be inside thread.
 #define REQUIRE_INVALID(e, cql, msg) \

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -42,6 +42,7 @@
 #include "sstables/compaction_manager.hh"
 #include "message/messaging_service.hh"
 #include "service/storage_service.hh"
+#include "service/storage_proxy.hh"
 #include "auth/service.hh"
 #include "auth/common.hh"
 #include "db/config.hh"

--- a/test/lib/index_reader_assertions.hh
+++ b/test/lib/index_reader_assertions.hh
@@ -26,6 +26,7 @@
 #include "dht/i_partitioner.hh"
 #include "schema.hh"
 #include "sstables/index_reader.hh"
+#include "reader_permit.hh"
 
 class index_reader_assertions {
     std::unique_ptr<sstables::index_reader> _r;

--- a/test/lib/reader_lifecycle_policy.hh
+++ b/test/lib/reader_lifecycle_policy.hh
@@ -22,6 +22,7 @@
 #pragma once
 
 #include "mutation_reader.hh"
+#include <seastar/core/gate.hh>
 
 class test_reader_lifecycle_policy
         : public reader_lifecycle_policy

--- a/test/lib/select_statement_utils.hh
+++ b/test/lib/select_statement_utils.hh
@@ -22,6 +22,7 @@
 #pragma once
 
 #include <seastar/core/future.hh>
+#include "seastarx.hh"
 
 namespace cql3 {
 

--- a/test/perf/perf_fast_forward.cc
+++ b/test/perf/perf_fast_forward.cc
@@ -20,6 +20,8 @@
  */
 
 #include <boost/algorithm/string/replace.hpp>
+#include <boost/algorithm/string/split.hpp>
+#include <boost/algorithm/string/join.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
 #include <boost/range/irange.hpp>
 #include <boost/range/algorithm_ext.hpp>
@@ -45,6 +47,7 @@
 
 using namespace std::chrono_literals;
 using namespace seastar;
+namespace fs = std::filesystem;
 using int_range = nonwrapping_range<int>;
 
 reactor::io_stats s;

--- a/test/perf/perf_simple_query.cc
+++ b/test/perf/perf_simple_query.cc
@@ -20,6 +20,7 @@
  */
 
 #include <boost/algorithm/string/split.hpp>
+#include <boost/algorithm/string/classification.hpp>
 #include <json/json.h>
 
 #include <boost/range/irange.hpp>

--- a/test/unit/bptree_validation.hh
+++ b/test/unit/bptree_validation.hh
@@ -21,6 +21,9 @@
 
 #pragma once
 
+#include <stddef.h>
+#include "utils/bptree.hh"
+
 namespace bplus {
 
 template <typename K, typename T, typename Less, size_t NodeSize>

--- a/test/unit/btree_validation.hh
+++ b/test/unit/btree_validation.hh
@@ -21,6 +21,9 @@
 
 #pragma once
 
+#include <stddef.h>
+#include "utils/intrusive_btree.hh"
+
 namespace intrusive_b {
 
 class member_hook;

--- a/test/unit/collection_stress.hh
+++ b/test/unit/collection_stress.hh
@@ -24,6 +24,7 @@
 #include <vector>
 #include <random>
 #include <string>
+#include <seastar/core/thread.hh>
 #include "utils/logalloc.hh"
 
 struct stress_config {

--- a/test/unit/radix_tree_printer.hh
+++ b/test/unit/radix_tree_printer.hh
@@ -22,6 +22,7 @@
 #pragma once
 
 #include <fmt/core.h>
+#include "utils/compact-radix-tree.hh"
 
 namespace compact_radix_tree {
 

--- a/test/unit/tree_test_key.hh
+++ b/test/unit/tree_test_key.hh
@@ -21,6 +21,10 @@
 
 #pragma once
 
+#include <fmt/core.h>
+#include <cassert>
+#include "utils/bptree.hh"
+
 /*
  * Helper class that helps to check that tree
  * - works with keys without default contstuctor

--- a/thrift/handler.cc
+++ b/thrift/handler.cc
@@ -35,6 +35,7 @@
 #include <boost/move/iterator.hpp>
 #include "db/marshal/type_parser.hh"
 #include "service/migration_manager.hh"
+#include "service/storage_proxy.hh"
 #include "utils/class_registrator.hh"
 #include "noexcept_traits.hh"
 #include "schema_registry.hh"

--- a/thrift/server.cc
+++ b/thrift/server.cc
@@ -21,6 +21,7 @@
 
 #include "server.hh"
 #include "handler.hh"
+#include "db/config.hh"
 #include <seastar/core/future-util.hh>
 #include <seastar/core/circular_buffer.hh>
 #include <seastar/core/metrics.hh>

--- a/tracing/trace_keyspace_helper.cc
+++ b/tracing/trace_keyspace_helper.cc
@@ -49,6 +49,7 @@
 #include "types/set.hh"
 #include "types/map.hh"
 #include "utils/UUID_gen.hh"
+#include "utils/fb_utilities.hh"
 
 namespace tracing {
 

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -35,6 +35,7 @@
 #include "dht/token-sharding.hh"
 #include "service/migration_manager.hh"
 #include "service/memory_limiter.hh"
+#include "service/storage_proxy.hh"
 #include "db/consistency_level_type.hh"
 #include "database.hh"
 #include "db/write_type.hh"

--- a/transport/server.hh
+++ b/transport/server.hh
@@ -25,7 +25,6 @@
 #include <seastar/core/seastar.hh>
 #include "service/endpoint_lifecycle_subscriber.hh"
 #include "service/migration_listener.hh"
-#include "service/storage_proxy.hh"
 #include "cql3/query_processor.hh"
 #include "cql3/values.hh"
 #include "auth/authenticator.hh"
@@ -39,6 +38,7 @@
 #include "utils/fragmented_temporary_buffer.hh"
 #include "service_permit.hh"
 #include <seastar/core/sharded.hh>
+#include <seastar/core/execution_stage.hh>
 #include "utils/updateable_value.hh"
 #include "service/qos/service_level_controller.hh"
 #include "generic_server.hh"

--- a/types/listlike_partial_deserializing_iterator.hh
+++ b/types/listlike_partial_deserializing_iterator.hh
@@ -25,6 +25,7 @@
 #include "cql_serialization_format.hh"
 #include "utils/fragment_range.hh"
 #include "utils/managed_bytes.hh"
+#include "types.hh"
 
 int read_collection_size(bytes_view& in, cql_serialization_format sf);
 bytes_view read_collection_value(bytes_view& in, cql_serialization_format sf);

--- a/utils/compact-radix-tree.hh
+++ b/utils/compact-radix-tree.hh
@@ -27,6 +27,7 @@
 #include <fmt/core.h>
 #include "utils/allocation_strategy.hh"
 #include "utils/array-search.hh"
+#include <boost/intrusive/parent_from_member.hpp>
 
 class size_calculator;
 

--- a/utils/fragment_range.hh
+++ b/utils/fragment_range.hh
@@ -26,6 +26,7 @@
 #include <boost/range/algorithm/for_each.hpp>
 #include <seastar/net/byteorder.hh>
 #include <seastar/core/print.hh>
+#include <seastar/util/backtrace.hh>
 
 #include "marshal_exception.hh"
 #include "bytes.hh"

--- a/utils/histogram_metrics_helper.hh
+++ b/utils/histogram_metrics_helper.hh
@@ -23,6 +23,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <seastar/core/metrics_types.hh>
 #include "seastarx.hh"
 #include "estimated_histogram.hh"

--- a/utils/intrusive_btree.hh
+++ b/utils/intrusive_btree.hh
@@ -19,6 +19,8 @@
  * along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#pragma once
+
 #include <boost/intrusive/parent_from_member.hpp>
 #include <seastar/util/defer.hh>
 #include <seastar/util/alloc_failure_injector.hh>


### PR DESCRIPTION
Reduce rebuilds and build time by removing unnecessary includes. Along the way,
improve header sanity.

Ref #1.

Test: dev-headers, unit(dev).