### PR TITLE
Calculate partition ranges from expr::expression

### DIFF
--- a/cql3/restrictions/statement_restrictions.hh
+++ b/cql3/restrictions/statement_restrictions.hh
@@ -106,6 +106,7 @@ private:
 
     std::optional<expr::expression> _where; ///< The entire WHERE clause.
     std::vector<expr::expression> _clustering_prefix_restrictions; ///< Parts of _where defining the clustering slice.
+    std::vector<expr::expression> _partition_range_restrictions; ///< Parts of _where defining the partition range.
 
 public:
     /**

--- a/cql3/statements/modification_statement.cc
+++ b/cql3/statements/modification_statement.cc
@@ -246,7 +246,7 @@ modification_statement::create_clustering_ranges(const query_options& options, c
 
 dht::partition_range_vector
 modification_statement::build_partition_keys(const query_options& options, const json_cache_opt& json_cache) const {
-    auto keys = _restrictions->get_partition_key_restrictions()->bounds_ranges(options);
+    auto keys = _restrictions->get_partition_key_ranges(options);
     for (auto const& k : keys) {
         validation::validate_cql_key(*s, *k.start()->value().key());
     }

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -1103,7 +1103,7 @@ indexed_table_select_statement::do_execute(service::storage_proxy& proxy,
 }
 
 dht::partition_range_vector indexed_table_select_statement::get_partition_ranges_for_local_index_posting_list(const query_options& options) const {
-    return _restrictions->get_partition_key_restrictions()->bounds_ranges(options);
+    return _restrictions->get_partition_key_ranges(options);
 }
 
 dht::partition_range_vector indexed_table_select_statement::get_partition_ranges_for_global_index_posting_list(const query_options& options) const {


### PR DESCRIPTION
In an ongoing effort to drop the `restrictions` class hierarchy, rewrite the partition-range calculation code to use the new `expression` objects.

Refs: #7217 #3815

Tests: unit (dev, debug)