### PR TITLE
dist: Add support for disabling writeback cache

### DIFF
--- a/dist/common/scripts/scylla_prepare
+++ b/dist/common/scripts/scylla_prepare
@@ -74,6 +74,9 @@ def create_perftune_conf(cfg):
     if cfg.has_option('SET_CLOCKSOURCE') and cfg.get('SET_CLOCKSOURCE') == 'yes':
         params += ' --tune system --tune-clock'
 
+    if cfg.has_option('DISABLE_WRITEBACK_CACHE') and cfg.get('DISABLE_WRITEBACK_CACHE') == 'yes':
+        params += ' --write-back-cache=false'
+
     if len(params) > 0:
         if os.path.exists('/etc/scylla.d/perftune.yaml'):
             return True

--- a/dist/common/scripts/scylla_sysconfig_setup
+++ b/dist/common/scripts/scylla_sysconfig_setup
@@ -44,6 +44,10 @@ if __name__ == '__main__':
         set_clocksource = str2bool(cfg.get('SET_CLOCKSOURCE'))
     else:
         set_clocksource = 'no'
+    if cfg.has_option('DISABLE_WRITEBACK_CACHE'):
+        disable_writeback_cache = str2bool(cfg.get('DISABLE_WRITEBACK_CACHE'))
+    else:
+        disable_writeback_cache = 'no'
     ami = str2bool(cfg.get('AMI'))
     
     parser = argparse.ArgumentParser(description='Setting parameters on Scylla sysconfig file.')
@@ -65,6 +69,8 @@ if __name__ == '__main__':
                         help='setup NIC\'s and disks\' interrupts, RPS, XPS, nomerges and I/O scheduler')
     parser.add_argument('--set-clocksource', action='store_true', default=set_clocksource,
                         help='Set enforcing fastest available Linux clocksource')
+    parser.add_argument('--disable-writeback-cache', action='store_true', default=disable_writeback_cache,
+                        help='Disable disk writeback cache')
     parser.add_argument('--ami', action='store_true', default=ami,
                         help='AMI instance mode')
     args = parser.parse_args()
@@ -118,6 +124,9 @@ if __name__ == '__main__':
 
     if cfg.has_option('SET_CLOCKSOURCE') and str2bool(cfg.get('SET_CLOCKSOURCE')) != args.set_clocksource:
         cfg.set('SET_CLOCKSOURCE', bool2str(args.set_clocksource))
+
+    if cfg.has_option('DISABLE_WRITEBACK_CACHE') and str2bool(cfg.get('DISABLE_WRITEBACK_CACHE')) != args.disable_writeback_cache:
+        cfg.set('DISABLE_WRITEBACK_CACHE', bool2str(args.disable_writeback_cache))
         
     if str2bool(cfg.get('AMI')) != args.ami:
         cfg.set('AMI', bool2str(args.ami))

--- a/dist/common/sysconfig/scylla-server
+++ b/dist/common/sysconfig/scylla-server
@@ -45,3 +45,6 @@ SCYLLA_ARGS="--log-to-syslog 1 --log-to-stdout 0 --default-log-level info --netw
 
 # setup as AMI instance
 AMI=no
+
+# Disable disk writeback cache
+DISABLE_WRITEBACK_CACHE=no


### PR DESCRIPTION
This adds support for disabling writeback cache by adding a new
DISABLE_WRITEBACK_CACHE option to "scylla-server" sysconfig file, which
makes the "scylla_prepare" script (that is run before Scylla starts up)
call perftune.py with appropriate parameters. Also add a
"--disable-writeback-cache" option to "scylla_sysconfig_setup", which
can be called by scylla-machine image scripts, for example.

Refs: #7341
Tests: dtest (next-gating)