### PR TITLE
dist/debian: rename .default file correctly

### DIFF
--- a/dist/debian/debian_files_gen.py
+++ b/dist/debian/debian_files_gen.py
@@ -55,12 +55,15 @@ if product != 'scylla':
     for p in Path('build/debian/debian').glob('scylla-*'):
         # pat1: scylla-server.service
         #    -> scylla-enterprise-server.scylla-server.service
+        #       or
+        #       scylla-server.default
+        #    -> scylla-enterprise-server.scylla-server.default
         # pat2: scylla-server.scylla-fstrim.service
         #    -> scylla-enterprise-server.scylla-fstrim.service
         # pat3: scylla-conf.install
         #    -> scylla-enterprise-conf.install
 
-        if m := re.match(r'^scylla(-[^.]+)\.service$', p.name):
+        if m := re.match(r'^scylla(-[^.]+)\.(service|default)$', p.name):
             p.rename(p.parent / f'{product}{m.group(1)}.{p.name}')
         elif m := re.match(r'^scylla(-[^.]+\.scylla-[^.]+\.[^.]+)$', p.name):
             p.rename(p.parent / f'{product}{m.group(1)}')


### PR DESCRIPTION
On 'product != scylla' environment, we have a bug with .default file
(sysconfig file) handling.
Since .default file should be install original name, package name can be
doesn't match with .default filename.
(ex: default file is /etc/default/scylla-node-exporter, but
     package name is scylla-enterprise-node-exporter)
When filename doesn't match with package name, it should be renamed with
as follows:
`<package name>.<filename>.default`
We already do this on .service file, but mistakenly haven't handled
.default file, so let's add it too.

Related scylladb/scylla-enterprise#1718
Fixes #8527