### PR TITLE
scylla_raid_setup: enabling mdmonitor.service on Debian variants

### DIFF
--- a/dist/common/scripts/scylla_raid_setup
+++ b/dist/common/scripts/scylla_raid_setup
@@ -161,6 +161,7 @@ if __name__ == '__main__':
 Description=Scylla data directory
 Before=scylla-server.service
 After={after}
+Wants={md_service}
 DefaultDependencies=no
 
 [Mount]
@@ -184,7 +185,6 @@ WantedBy=multi-user.target
             f.write(f'RequiresMountsFor={mount_at}\n')
 
     systemd_unit.reload()
-    md_service.enable()
     md_service.start()
     mount = systemd_unit(mntunit_bn)
     mount.start()


### PR DESCRIPTION
On Debian variants, mdmonitor.service cannnot enable because it missing
[Install] section, so 'systemctl enable mdmonitor.service' will fail,
not able to run mdmonitor after the system restarted.

To force running the service, add Wants=mdmonitor.service on
var-lib-scylla.mount.

Fixes #8494
