### PR TITLE
test: make rjson allocator test working in debug mode

### DIFF
--- a/test/boost/alternator_unit_test.cc
+++ b/test/boost/alternator_unit_test.cc
@@ -23,6 +23,7 @@
 #include <boost/test/included/unit_test.hpp>
 
 #include <seastar/util/defer.hh>
+#include <seastar/core/memory.hh>
 #include "alternator/base64.hh"
 
 static bytes_view to_bytes_view(const std::string& s) {
@@ -81,10 +82,10 @@ BOOST_AUTO_TEST_CASE(test_base64_begins_with) {
 }
 
 BOOST_AUTO_TEST_CASE(test_allocator_fail_gracefully) {
-// Unfortunately the address sanitizer fails if the allocator is not able
-// to allocate the requested memory. The test is therefore skipped for debug  mode
-#ifndef DEBUG
-    static constexpr size_t too_large_alloc_size = 0xffffffffff;
+    // Allocation size is set to a ridiculously high value to ensure
+    // that it will immediately fail - trying to lazily allocate just
+    // a little more than total memory may still succeed.
+    static size_t too_large_alloc_size = memory::stats().total_memory() * 1024 * 1024;
     rjson::allocator allocator;
     // Impossible allocation should throw
     BOOST_REQUIRE_THROW(allocator.Malloc(too_large_alloc_size), rjson::error);
@@ -96,5 +97,4 @@ BOOST_AUTO_TEST_CASE(test_allocator_fail_gracefully) {
     // and also be destroyed gracefully later
     rapidjson::internal::Stack stack(&allocator, 0);
     BOOST_REQUIRE_THROW(stack.Push<char>(too_large_alloc_size), rjson::error);
-#endif
 }


### PR DESCRIPTION
Following Nadav's advice (https://github.com/scylladb/scylla/pull/8529#issuecomment-824888874),
instead of ignoring the test in debug mode, the allocator simply
has a special path of failing sufficiently large allocation requests.
With that, a problem with the address sanitizer is bypassed
and other debug mode sanitizers can inspect and check
if there are no more problems related to wrapping the original
rapidjson allocator.

As a result, the test succeeds - with a single warning from UB sanitizer (that doesn't fail the test):
```
/usr/include/rapidjson/internal/stack.h:117:43: runtime error: applying non-zero offset 281473634533375 to null pointer
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /usr/include/rapidjson/internal/stack.h:117:43 in
```
The warning results from the fact that rapidjson's stack initializes its stack start pointer and end pointer with `nullptr` and then uses pointer arithmetics to compare `start + X` with `end`, and adding offsets to `nullptr` is not considered as defined behavior. 

Also, it's actually already fixed in rapidjson's master branch (16872af88915176f49e389defb167f899e2c230a):
```git
Avoid pointer arithmetic on null pointer to remove undefined behavior

The existing checks triggered undefined behavior when the stack was empty (null pointer). This change avoid this:
* If `stackTop_` and `stackEnd_` are null, it results in a `ptrdiff_t` of `0`
* If `stackTop_` and `stackEnd_` are valid pointers, they produce a `ptrdiff_t` with the remaining size on the stack
```

Tests: unit(release, debug)

Refs #8529