### PR TITLE
Add username to alternator tracing

### DIFF
--- a/alternator/server.cc
+++ b/alternator/server.cc
@@ -348,7 +348,7 @@ static std::string_view truncated_content_view(const chunked_content& content, s
     }
 }
 
-static tracing::trace_state_ptr maybe_trace_query(service::client_state& client_state, sstring_view op, const chunked_content& query) {
+static tracing::trace_state_ptr maybe_trace_query(service::client_state& client_state, std::string_view username, sstring_view op, const chunked_content& query) {
     tracing::trace_state_ptr trace_state;
     tracing::tracing& tracing_instance = tracing::tracing::get_local_tracing_instance();
     if (tracing_instance.trace_next_query() || tracing_instance.slow_query_tracing_enabled()) {
@@ -357,6 +357,7 @@ static tracing::trace_state_ptr maybe_trace_query(service::client_state& client_
         tracing::add_session_param(trace_state, "alternator_op", op);
         tracing::add_query(trace_state, truncated_content_view(query, buf));
         tracing::begin(trace_state, format("Alternator {}", op), client_state.get_client_address());
+        tracing::set_username(trace_state, auth::authenticated_user(username));
     }
     return trace_state;
 }
@@ -380,7 +381,7 @@ future<executor::request_return_type> server::handle_api_request(std::unique_ptr
     auto units = co_await std::move(units_fut);
     assert(req->content_stream);
     chunked_content content = co_await httpd::read_entire_stream(*req->content_stream);
-    co_await verify_signature(*req, content);
+    auto username = co_await verify_signature(*req, content);
 
     if (slogger.is_enabled(log_level::trace)) {
         std::string buf;
@@ -400,7 +401,7 @@ future<executor::request_return_type> server::handle_api_request(std::unique_ptr
     //FIXME: Client state can provide more context, e.g. client's endpoint address
     // We use unique_ptr because client_state cannot be moved or copied
     executor::client_state client_state{executor::client_state::internal_tag()};
-    tracing::trace_state_ptr trace_state = maybe_trace_query(client_state, op, content);
+    tracing::trace_state_ptr trace_state = maybe_trace_query(client_state, username, op, content);
     tracing::trace(trace_state, op);
     rjson::value json_request = co_await _json_parser.parse(std::move(content));
     co_return co_await callback_it->second(_executor, client_state, trace_state,

--- a/alternator/server.cc
+++ b/alternator/server.cc
@@ -232,10 +232,10 @@ protected:
     }
 };
 
-future<> server::verify_signature(const request& req, const chunked_content& content) {
+future<std::string> server::verify_signature(const request& req, const chunked_content& content) {
     if (!_enforce_authorization) {
         slogger.debug("Skipping authorization");
-        return make_ready_future<>();
+        return make_ready_future<std::string>("<unauthenticated request>");
     }
     auto host_it = req._headers.find("Host");
     if (host_it == req._headers.end()) {
@@ -316,6 +316,7 @@ future<> server::verify_signature(const request& req, const chunked_content& con
             _key_cache.remove(user);
             throw api_error::unrecognized_client("The security token included in the request is invalid.");
         }
+        return user;
     });
 }
 

--- a/alternator/server.hh
+++ b/alternator/server.hh
@@ -84,7 +84,8 @@ public:
     future<> stop();
 private:
     void set_routes(seastar::httpd::routes& r);
-    future<> verify_signature(const seastar::httpd::request&, const chunked_content&);
+    // If verification succeeds, returns the authenticated user's username
+    future<std::string> verify_signature(const seastar::httpd::request&, const chunked_content&);
     future<executor::request_return_type> handle_api_request(std::unique_ptr<request> req);
 };
 

--- a/test/alternator/test_tracing.py
+++ b/test/alternator/test_tracing.py
@@ -266,8 +266,10 @@ def test_slow_query_log(with_slow_query_logging, test_table_s, dynamodb):
     delay = 0.2
     while delay < 30:
         results = full_scan(slow_query_table, ConsistentRead=False)
-        put_item_found = any("PutItem" in result['parameters'] and p in result['parameters'] for result in results)
-        delete_item_found = any("DeleteItem" in result['parameters'] and p in result['parameters'] for result in results)
+        put_item_found = any("PutItem" in result['parameters'] and p in result['parameters']
+                and result['username'] == "alternator" for result in results)
+        delete_item_found = any("DeleteItem" in result['parameters'] and p in result['parameters']
+                and result['username'] == "alternator" for result in results)
         if put_item_found and delete_item_found:
             return
         else:


### PR DESCRIPTION
This series adds filling the `username` column in alternator tracing info, if the username is available. When alternator is enforcing authorization, each request contains a username in its headers.

The difference is as follows. A tracing entry excerpt before the series:
```
{
	(...)
	'source_ip': '::',
	'table_names': 'alternator_Pets.Pets',
	'username': '<unauthenticated request>'
}
```
and after the series:
```
{
	(...)
	'source_ip': '::',
	'table_names': 'alternator_Pets.Pets',
	'username': 'alternator'
}
```
This series also modifies one of the tests to check the username column.

Fixes #8547