### PR TITLE
test: perf: don't truncate allocation/req and tasks/req report

### DIFF
--- a/test/perf/perf.cc
+++ b/test/perf/perf.cc
@@ -61,7 +61,7 @@ executor_shard_stats_snapshot() {
 
 std::ostream&
 operator<<(std::ostream& os, const perf_result& result) {
-    fmt::print(os, "{:.2f} tps ({:.0} allocs/op, {:.0} tasks/op)",
+    fmt::print(os, "{:.2f} tps ({:5.1f} allocs/op, {:5.1f} tasks/op)",
             result.throughput, result.mallocs_per_op, result.tasks_per_op);
     return os;
 }


### PR DESCRIPTION
I used {:.0} to truncate to integer, but apparently that resulted
in only one significant digit in the report, so 93.1 was reported as
90. Use the {:5.1f} to avoid truncation, and even get an extra
digit (we can have fractional tasks/op due to batching).

Current result is 93.1 allocs/op, 20.1 tasks/op (which suggests
batch size of around 10).