### PR TITLE
gdb: Fix heapprof() dereferencing of backtrace

### DIFF
--- a/scylla-gdb.py
+++ b/scylla-gdb.py
@@ -1902,7 +1902,7 @@ class scylla_heapprof(gdb.Command):
                 n = root
                 n.size += size
                 n.count += count
-                bt = site['backtrace']
+                bt = site['backtrace']['_main']
                 addresses = list(int(f['addr']) for f in static_vector(bt['_frames']))
                 addresses.pop(0)  # drop memory::get_backtrace()
                 if args.inverted:


### PR DESCRIPTION
Seastar seems to have added another layer of indirection to
alloc_site_list_head/backtrace, so scylla_heapprof() can't find the
members it's looking for, resulting in errors.  Fix it by
dereferencing the added layer.

Signed-off-by: Dejan Mircevski <dejan@scylladb.com>