### PR TITLE
cql3: Check if partition-key restrictions are all EQ at preparation time

### DIFF
--- a/cql3/restrictions/statement_restrictions.cc
+++ b/cql3/restrictions/statement_restrictions.cc
@@ -636,19 +636,6 @@ void error_if_exceeds(size_t size, size_t limit) {
 /// Computes partition-key ranges from expressions, which contains EQ/IN for every partition column.
 dht::partition_range_vector partition_ranges_from_singles(
         const std::vector<expr::expression>& expressions, const query_options& options, const schema& schema) {
-    if (std::ranges::all_of(expressions, [] (const expression& e) { return find(e, oper_t::EQ); })) {
-        // Special case to avoid a vector of vectors, which makes for a couple of extra allocations per request.
-        std::vector<managed_bytes> pk_value(schema.partition_key_size());
-        for (const auto& e : expressions) {
-            const auto col = std::get<column_value>(find(e, oper_t::EQ)->lhs).col;
-            const auto vals = std::get<value_list>(possible_lhs_values(col, e, options));
-            if (vals.empty()) { // Case of C=1 AND C=2.
-                return {};
-            }
-            pk_value[schema.position(*col)] = std::move(vals[0]);
-        }
-        return {range_from_bytes(schema, pk_value)};
-    }
     const size_t size_limit =
             options.get_cql_config().restrictions.partition_key_restrictions_max_cartesian_product_size;
     // Each element is a vector of that column's possible values:
@@ -679,6 +666,22 @@ dht::partition_range_vector partition_ranges_from_singles(
     return ranges;
 }
 
+/// Computes partition-key ranges from EQ restrictions on each partition column.  Returns a single singleton range if
+/// the EQ restrictions are not mutually conflicting.  Otherwise, returns an empty vector.
+dht::partition_range_vector partition_ranges_from_EQs(
+        const std::vector<expr::expression>& eq_expressions, const query_options& options, const schema& schema) {
+    std::vector<managed_bytes> pk_value(schema.partition_key_size());
+    for (const auto& e : eq_expressions) {
+        const auto col = std::get<column_value>(find(e, oper_t::EQ)->lhs).col;
+        const auto vals = std::get<value_list>(possible_lhs_values(col, e, options));
+        if (vals.empty()) { // Case of C=1 AND C=2.
+            return {};
+        }
+        pk_value[schema.position(*col)] = std::move(vals[0]);
+    }
+    return {range_from_bytes(schema, pk_value)};
+}
+
 } // anonymous namespace
 
 dht::partition_range_vector statement_restrictions::get_partition_key_ranges(const query_options& options) const {
@@ -692,6 +695,9 @@ dht::partition_range_vector statement_restrictions::get_partition_key_ranges(con
                     format("Unexpected size of token restrictions: {}", _partition_range_restrictions.size()));
         }
         return partition_ranges_from_token(_partition_range_restrictions[0], options);
+    } else if (_partition_range_is_simple) {
+        // Special case to avoid extra allocations required for a Cartesian product.
+        return partition_ranges_from_EQs(_partition_range_restrictions, options, *_schema);
     }
     return partition_ranges_from_singles(_partition_range_restrictions, options, *_schema);
 }

--- a/cql3/restrictions/statement_restrictions.hh
+++ b/cql3/restrictions/statement_restrictions.hh
@@ -107,6 +107,7 @@ private:
     std::optional<expr::expression> _where; ///< The entire WHERE clause.
     std::vector<expr::expression> _clustering_prefix_restrictions; ///< Parts of _where defining the clustering slice.
     std::vector<expr::expression> _partition_range_restrictions; ///< Parts of _where defining the partition range.
+    bool _partition_range_is_simple; ///< False iff _partition_range_restrictions imply a Cartesian product.
 
 public:
     /**

--- a/cql3/restrictions/statement_restrictions.hh
+++ b/cql3/restrictions/statement_restrictions.hh
@@ -126,8 +126,6 @@ public:
         bool for_view = false,
         bool allow_filtering = false);
 
-    void add_single_column_restriction(::shared_ptr<single_column_restriction> restriction, bool for_view, bool allow_filtering);
-public:
     const std::vector<::shared_ptr<restrictions>>& index_restrictions() const;
 
     /**

--- a/cql3/restrictions/statement_restrictions.hh
+++ b/cql3/restrictions/statement_restrictions.hh
@@ -126,7 +126,6 @@ public:
         bool for_view = false,
         bool allow_filtering = false);
 
-    void add_restriction(::shared_ptr<restriction> restriction, bool for_view, bool allow_filtering);
     void add_single_column_restriction(::shared_ptr<single_column_restriction> restriction, bool for_view, bool allow_filtering);
 public:
     const std::vector<::shared_ptr<restrictions>>& index_restrictions() const;


### PR DESCRIPTION
Previously, we checked if all partition-key restrictions were EQ at runtime.  This is, however, known already at prep time; no need to redo it on every query execution.  Move the check to prep time.

Tests: unit (dev, debug), perf_simple_query