### PR TITLE
logalloc: reduce minimum lsa reserve in allocating_section to 1

### DIFF
--- a/utils/logalloc.hh
+++ b/utils/logalloc.hh
@@ -688,7 +688,7 @@ struct reclaim_lock {
 // should reserve up front in order to not cause allocation failures.
 class allocating_section {
     // Do not decay below these minimal values
-    static constexpr size_t s_min_lsa_reserve = 10;
+    static constexpr size_t s_min_lsa_reserve = 1;
     static constexpr size_t s_min_std_reserve = 1024;
     static constexpr uint64_t s_bytes_per_decay = 10'000'000'000;
     static constexpr unsigned s_segments_per_decay = 100'000;


### PR DESCRIPTION
Many workloads have fairly constant and small request sizes, so we
don't need large reserves for them. These workloads suffer needlessly
from the current large reserve of 10 segments (1.2MB) when they really
need a few hundred bytes. Reduce the reserve to a minimum of 1 segment.

Note that due to #8542 this can make a large difference. Consider a
workload that has a 1000-byte footprint in cache. If we've just
consumed some free memory and reduced the reserve to zero, then
we'll evict about 50,000 objects before proceeding to compact. With
the reserved reduced to 1, we'll evict 128 objects.  All this
for 1000 bytes of memory.

Of course, #8542 should be fixed, but reducing the reserve provides
some quick relief and makes sense even with the larger fix. The
reserve will quickly grow for workloads that handle bigger requests,
so they won't see an impact from the reduction.