### PR TITLE
workload prioritization: Reduce the logging sensitivity to "glitches" in

### DIFF
--- a/service/qos/service_level_controller.cc
+++ b/service/qos/service_level_controller.cc
@@ -35,7 +35,10 @@ sstring service_level_controller::default_service_level_name = "default";
 
 service_level_controller::service_level_controller(sharded<auth::service>& auth_service, service_level_options default_service_level_config):
         _sl_data_accessor(nullptr),
-        _auth_service(auth_service)
+        _auth_service(auth_service),
+        _last_successful_config_update(seastar::lowres_clock::now()),
+        _logged_intervals(0)
+
 {
     if (this_shard_id() == global_controller) {
         _global_controller_db = std::make_unique<global_controller_data>();
@@ -124,13 +127,12 @@ future<> service_level_controller::update_service_levels_from_distributed_data()
     return with_semaphore(_global_controller_db->notifications_serializer, 1, [this] () {
         return async([this] () {
             service_levels_info service_levels;
-            try {
-                service_levels = _sl_data_accessor->get_service_levels().get0();
-            } catch (...) {
-                sl_logger.warn("update_service_levels_from_distributed_data: an error occurred"
-                        " while retrieving configuration ({})", std::current_exception());
-                return;
-            }
+            // The next statement can throw, but that's fine since we would like the caller
+            // to be able to agreggate those failures and only report when it is critical or noteworthy.
+            // one common reason for failure is because one of the nodes comes down and before this node
+            // detects it the scan query done inside this call is failing.
+            service_levels = _sl_data_accessor->get_service_levels().get0();
+
             service_levels_info service_levels_for_add_or_update;
             service_levels_info service_levels_for_delete;
 
@@ -260,17 +262,28 @@ void service_level_controller::update_from_distributed_data(std::chrono::duratio
     }
     if (_global_controller_db->distributed_data_update.available()) {
         sl_logger.info("update_from_distributed_data: starting configuration polling loop");
+        _logged_intervals = 0;
         _global_controller_db->distributed_data_update = repeat([this, interval] {
             return sleep_abortable<steady_clock_type>(std::chrono::duration_cast<steady_clock_type::duration>(interval),
                     _global_controller_db->dist_data_update_aborter).then_wrapped([this] (future<>&& f) {
                 try {
                     f.get();
-                    return update_service_levels_from_distributed_data().then_wrapped([] (future<>&& f){
+                    return update_service_levels_from_distributed_data().then_wrapped([this] (future<>&& f){
                         try {
                             f.get();
+                            _last_successful_config_update = seastar::lowres_clock::now();
+                            _logged_intervals = 0;
                         } catch (...) {
-                            sl_logger.warn("update_from_distributed_data: exception occurred in distributed"
-                                    " data check loop: {}", std::current_exception());
+                            using namespace std::literals::chrono_literals;
+                            constexpr auto age_resolution = 90s;
+                            constexpr unsigned error_threshold = 10; // Change the logging level to error after 10 age_resolution intervals.
+                            unsigned configuration_age = (seastar::lowres_clock::now() - _last_successful_config_update) / age_resolution;
+                            if (configuration_age > _logged_intervals) {
+                                log_level ll = configuration_age >= error_threshold ? log_level::error : log_level::warn;
+                                sl_logger.log(ll, "update_from_distributed_data: failed to update configuration for more than  {} seconds : {}",
+                                        (age_resolution*configuration_age).count(), std::current_exception());
+                                _logged_intervals++;
+                            }
                         }
                         return stop_iteration::no;
                     });

--- a/service/qos/service_level_controller.hh
+++ b/service/qos/service_level_controller.hh
@@ -90,6 +90,9 @@ private:
     service_level _default_service_level;
     service_level_distributed_data_accessor_ptr _sl_data_accessor;
     sharded<auth::service>& _auth_service;
+    std::chrono::time_point<seastar::lowres_clock> _last_successful_config_update;
+    unsigned _logged_intervals;
+
 public:
     service_level_controller(sharded<auth::service>& auth_service, service_level_options default_service_level_config);
 


### PR DESCRIPTION
availability

Before this patch every failure to pull the configuration have been
reported as a warning. However this is confusing for users for two
reasons:
1. It pollutes the logs if the configuration is polled which is Scylla's
   mode of operation. Such a line is logged every failed iteration.
2. It confuses users because even though this level is warning, it logs
   out an exception and the log message contains the word failed.

We see it a lot during QA runs and customer questions from the field.

Point 2 is only solvable by reducing the verbosity of the logged
information, which will make debugging harder.
Point 1 is addressed here in the following manner, first the
one shot configuration pull function is not handling the exception
itself, this is OK because it is harmless to fail once or twice in a
row in configuration pulling like in every other query, the caller is
the one that will be responsible to handle the exception and log the
information. Second, the polling loop capture the exceptions being
thrown from the configuration pulling function and only report an error
with the latest exception if the polling has failed in consecutive
iterations over the last 90 seconds. This value was chosen because this
is about the empirical worst case time that it takes to a node to notice
one of the other nodes in the cluster is down (hence not querying it).

It is not important for the user or to us to be notified on temporary
glitches in availability (through this error at least) and since we are
eventually consistent is ok that some nodes will catch up with the
configuration later than others.

We also set a threshold in which if the configuration still couldn't be
retrieved then the logging level is bumped to ERROR.