### PR TITLE
Service level controller: fix wrong default service level removal log

### DIFF
--- a/service/qos/service_level_controller.cc
+++ b/service/qos/service_level_controller.cc
@@ -174,8 +174,8 @@ future<> service_level_controller::update_service_levels_from_distributed_data()
             }
 
             for (; current_it != _service_levels_db.end(); current_it++) {
-                sl_logger.info("service level \"{}\" was deleted.", current_it->first.c_str());
                 if (!current_it->second.is_static) {
+                    sl_logger.info("service level \"{}\" was deleted.", current_it->first.c_str());
                     service_levels_for_delete.emplace(current_it->first, current_it->second.slo);
                 }
             }


### PR DESCRIPTION
An out of block log print resulted in repeated prints about removal of
the default service level. The period of this print is every time the
configuration is scanned for changes. It happens when the default
service level is one of the last on the map (sorted as in the map).

Fixes #8567