### PR TITLE
dist: scylla_raid_setup: reduce xfs block size to 1k

### DIFF
--- a/dist/common/scripts/scylla_raid_setup
+++ b/dist/common/scripts/scylla_raid_setup
@@ -137,7 +137,15 @@ if __name__ == '__main__':
         run('udevadm settle', shell=True, check=True)
         run('mdadm --create --verbose --force --run {raid} --level=0 -c1024 --raid-devices={nr_disk} {disks}'.format(raid=fsdev, nr_disk=len(disks), disks=args.disks.replace(',', ' ')), shell=True, check=True)
         run('udevadm settle', shell=True, check=True)
-    run('mkfs.xfs {} -f -K'.format(fsdev), shell=True, check=True)
+
+    major_minor = os.stat(fsdev).st_rdev
+    major, minor = major_minor // 256, major_minor % 256
+    sector_size = int(open(f'/sys/dev/block/{major}:{minor}/queue/logical_block_size').read())
+    # We want smaller block sizes to allow smaller commitlog writes without
+    # stalling. The minimum block size for crc enabled filesystems is 1024,
+    # and it also cannot be smaller than the sector size.
+    block_size = max(1024, sector_size)
+    run(f'mkfs.xfs -b size={block_size} {fsdev} -f -K', shell=True, check=True)
 
     if is_debian_variant():
         confpath = '/etc/mdadm/mdadm.conf'


### PR DESCRIPTION
Since Linux 5.12 [1], XFS is able to to asynchronously overwrite
sub-block ranges without stalling. However, we want good performance
on older Linux versions, so this patch reduces the block size to the
minimum possible.

That turns out to be 1024 for crc-protected filesystems (which we want)
and it can also not be smaller than the sector size. So we fetch the
sector size and set the block size to that if it is larger than 512.
Most SSDs have a sector size of 512, so this isn't a problem.

Tested on AWS i3.large.

Fixes #8156.

[1] https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=ed1128c2d0c87e5ff49c40f5529f06bc35f4251b