### PR TITLE
storage_proxy: use small_vector for vectors of inet_address

### DIFF
--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -415,7 +415,7 @@ void set_storage_service(http_context& ctx, routes& r) {
         auto keyspace = validate_keyspace(ctx, req->param);
         std::vector<ss::maplist_mapper> res;
         return make_ready_future<json::json_return_type>(stream_range_as_array(service::get_local_storage_service().get_range_to_address_map(keyspace),
-                [](const std::pair<dht::token_range, std::vector<gms::inet_address>>& entry){
+                [](const std::pair<dht::token_range, inet_address_vector_replica_set>& entry){
             ss::maplist_mapper m;
             if (entry.first.start()) {
                 m.key.push(entry.first.start().value().value().to_sstring());

--- a/db/consistency_level.cc
+++ b/db/consistency_level.cc
@@ -155,11 +155,11 @@ bool is_local(gms::inet_address endpoint) {
            snitch_ptr->get_datacenter(endpoint);
 }
 
-std::vector<gms::inet_address>
+inet_address_vector_replica_set
 filter_for_query(consistency_level cl,
                  keyspace& ks,
-                 std::vector<gms::inet_address> live_endpoints,
-                 const std::vector<gms::inet_address>& preferred_endpoints,
+                 inet_address_vector_replica_set live_endpoints,
+                 const inet_address_vector_replica_set& preferred_endpoints,
                  read_repair_decision read_repair,
                  gms::inet_address* extra,
                  column_family* cf) {
@@ -187,7 +187,7 @@ filter_for_query(consistency_level cl,
         return std::move(live_endpoints);
     }
 
-    std::vector<gms::inet_address> selected_endpoints;
+    inet_address_vector_replica_set selected_endpoints;
 
     // Pre-select endpoints based on client preference. If the endpoints
     // selected this way aren't enough to satisfy CL requirements select the
@@ -201,7 +201,7 @@ filter_for_query(consistency_level cl,
              if (extra) {
                  *extra = selected == bf ? live_endpoints.front() : *(it + bf);
              }
-             return std::vector<gms::inet_address>(it, it + bf);
+             return inet_address_vector_replica_set(it, it + bf);
         } else if (selected) {
              selected_endpoints.reserve(bf);
              std::move(it, live_endpoints.end(), std::back_inserter(selected_endpoints));
@@ -255,10 +255,10 @@ filter_for_query(consistency_level cl,
     return selected_endpoints;
 }
 
-std::vector<gms::inet_address> filter_for_query(consistency_level cl,
+inet_address_vector_replica_set filter_for_query(consistency_level cl,
         keyspace& ks,
-        std::vector<gms::inet_address>& live_endpoints,
-        const std::vector<gms::inet_address>& preferred_endpoints,
+        inet_address_vector_replica_set& live_endpoints,
+        const inet_address_vector_replica_set& preferred_endpoints,
         column_family* cf) {
     return filter_for_query(cl, ks, live_endpoints, preferred_endpoints, read_repair_decision::NONE, nullptr, cf);
 }
@@ -266,7 +266,7 @@ std::vector<gms::inet_address> filter_for_query(consistency_level cl,
 bool
 is_sufficient_live_nodes(consistency_level cl,
                          keyspace& ks,
-                         const std::vector<gms::inet_address>& live_endpoints) {
+                         const inet_address_vector_replica_set& live_endpoints) {
     using namespace locator;
 
     switch (cl) {

--- a/db/consistency_level.cc
+++ b/db/consistency_level.cc
@@ -242,7 +242,7 @@ filter_for_query(consistency_level cl,
         if (!old_node && ht_max - ht_min > 0.01) { // if there is old node or hit rates are close skip calculations
             // local node is always first if present (see storage_proxy::get_live_sorted_endpoints)
             unsigned local_idx = epi[0].first == utils::fb_utilities::get_broadcast_address() ? 0 : epi.size() + 1;
-            live_endpoints = miss_equalizing_combination(epi, local_idx, remaining_bf, bool(extra));
+            live_endpoints = boost::copy_range<inet_address_vector_replica_set>(miss_equalizing_combination(epi, local_idx, remaining_bf, bool(extra)));
         }
     }
 

--- a/db/consistency_level.hh
+++ b/db/consistency_level.hh
@@ -47,6 +47,7 @@
 #include "exceptions/exceptions.hh"
 #include "utils/fb_utilities.hh"
 #include "gms/inet_address.hh"
+#include "inet_address_vectors.hh"
 #include "database.hh"
 
 #include <iosfwd>
@@ -75,19 +76,19 @@ inline size_t count_local_endpoints(const Range& live_endpoints) {
     return std::count_if(live_endpoints.begin(), live_endpoints.end(), is_local);
 }
 
-std::vector<gms::inet_address>
+inet_address_vector_replica_set
 filter_for_query(consistency_level cl,
                  keyspace& ks,
-                 std::vector<gms::inet_address> live_endpoints,
-                 const std::vector<gms::inet_address>& preferred_endpoints,
+                 inet_address_vector_replica_set live_endpoints,
+                 const inet_address_vector_replica_set& preferred_endpoints,
                  read_repair_decision read_repair,
                  gms::inet_address* extra,
                  column_family* cf);
 
-std::vector<gms::inet_address> filter_for_query(consistency_level cl,
+inet_address_vector_replica_set filter_for_query(consistency_level cl,
         keyspace& ks,
-        std::vector<gms::inet_address>& live_endpoints,
-        const std::vector<gms::inet_address>& preferred_endpoints,
+        inet_address_vector_replica_set& live_endpoints,
+        const inet_address_vector_replica_set& preferred_endpoints,
         column_family* cf);
 
 struct dc_node_count {
@@ -132,7 +133,7 @@ inline std::unordered_map<sstring, dc_node_count> count_per_dc_endpoints(
 bool
 is_sufficient_live_nodes(consistency_level cl,
                          keyspace& ks,
-                         const std::vector<gms::inet_address>& live_endpoints);
+                         const inet_address_vector_replica_set& live_endpoints);
 
 template<typename Range, typename PendingRange>
 inline bool assure_sufficient_live_nodes_each_quorum(

--- a/db/hints/manager.cc
+++ b/db/hints/manager.cc
@@ -418,7 +418,7 @@ future<timespec> manager::end_point_hints_manager::sender::get_last_file_modific
     });
 }
 
-future<> manager::end_point_hints_manager::sender::do_send_one_mutation(frozen_mutation_and_schema m, const std::vector<gms::inet_address>& natural_endpoints) noexcept {
+future<> manager::end_point_hints_manager::sender::do_send_one_mutation(frozen_mutation_and_schema m, const inet_address_vector_replica_set& natural_endpoints) noexcept {
     return futurize_invoke([this, m = std::move(m), &natural_endpoints] () mutable -> future<> {
         // The fact that we send with CL::ALL in both cases below ensures that new hints are not going
         // to be generated as a result of hints sending.
@@ -804,7 +804,7 @@ future<> manager::end_point_hints_manager::sender::send_one_mutation(frozen_muta
     keyspace& ks = _db.find_keyspace(m.s->ks_name());
     auto& rs = ks.get_replication_strategy();
     auto token = dht::get_token(*m.s, m.fm.key());
-    std::vector<gms::inet_address> natural_endpoints = rs.get_natural_endpoints(std::move(token));
+    inet_address_vector_replica_set natural_endpoints = rs.get_natural_endpoints(std::move(token));
 
     return do_send_one_mutation(std::move(m), natural_endpoints);
 }

--- a/db/hints/manager.hh
+++ b/db/hints/manager.hh
@@ -36,6 +36,7 @@
 #include "lister.hh"
 #include "gms/gossiper.hh"
 #include "locator/snitch_base.hh"
+#include "inet_address_vectors.hh"
 #include "service/endpoint_lifecycle_subscriber.hh"
 #include "db/commitlog/commitlog.hh"
 #include "utils/loading_shared_values.hh"
@@ -292,7 +293,7 @@ public:
             /// \param m mutation to send
             /// \param natural_endpoints current replicas for the given mutation
             /// \return future that resolves when the operation is complete
-            future<> do_send_one_mutation(frozen_mutation_and_schema m, const std::vector<gms::inet_address>& natural_endpoints) noexcept;
+            future<> do_send_one_mutation(frozen_mutation_and_schema m, const inet_address_vector_replica_set& natural_endpoints) noexcept;
 
             /// \brief Send one mutation out.
             ///

--- a/db/hints/messages.hh
+++ b/db/hints/messages.hh
@@ -23,6 +23,7 @@
 
 #include <vector>
 #include <seastar/core/lowres_clock.hh>
+#include "gms/inet_address.hh"
 
 #include "utils/UUID.hh"
 

--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -1169,7 +1169,7 @@ get_view_natural_endpoint(const sstring& keyspace_name,
     return view_endpoints[base_it - base_endpoints.begin()];
 }
 
-static future<> apply_to_remote_endpoints(gms::inet_address target, std::vector<gms::inet_address>&& pending_endpoints,
+static future<> apply_to_remote_endpoints(gms::inet_address target, inet_address_vector_topology_change&& pending_endpoints,
         frozen_mutation_and_schema& mut, const dht::token& base_token, const dht::token& view_token,
         service::allow_hints allow_hints, tracing::trace_state_ptr tr_state) {
 

--- a/dht/range_streamer.cc
+++ b/dht/range_streamer.cc
@@ -131,7 +131,7 @@ range_streamer::get_all_ranges_with_sources_for(const sstring& keyspace_name, dh
             }
             const range<token>& src_range = x.first;
             if (src_range.contains(desired_range, dht::tri_compare)) {
-                std::vector<inet_address>& addresses = x.second;
+                inet_address_vector_replica_set& addresses = x.second;
                 auto preferred = snitch->get_sorted_list_by_proximity(_address, addresses);
                 for (inet_address& p : preferred) {
                     range_sources[desired_range].push_back(p);

--- a/inet_address_vectors.hh
+++ b/inet_address_vectors.hh
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2021 ScyllaDB
+ */
+
+/*
+ * This file is part of Scylla.
+ *
+ * Scylla is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Scylla is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "gms/inet_address.hh"
+#include <vector>
+
+using inet_address_vector_replica_set = std::vector<gms::inet_address>;
+
+using inet_address_vector_topology_change = std::vector<gms::inet_address>;

--- a/inet_address_vectors.hh
+++ b/inet_address_vectors.hh
@@ -22,8 +22,8 @@
 #pragma once
 
 #include "gms/inet_address.hh"
-#include <vector>
+#include "utils/small_vector.hh"
 
-using inet_address_vector_replica_set = std::vector<gms::inet_address>;
+using inet_address_vector_replica_set = utils::small_vector<gms::inet_address, 3>;
 
-using inet_address_vector_topology_change = std::vector<gms::inet_address>;
+using inet_address_vector_topology_change = utils::small_vector<gms::inet_address, 1>;

--- a/locator/abstract_replication_strategy.cc
+++ b/locator/abstract_replication_strategy.cc
@@ -74,11 +74,11 @@ void abstract_replication_strategy::validate_replication_strategy(const sstring&
     }
 }
 
-std::vector<inet_address> abstract_replication_strategy::get_natural_endpoints(const token& search_token, can_yield can_yield) {
+inet_address_vector_replica_set abstract_replication_strategy::get_natural_endpoints(const token& search_token, can_yield can_yield) {
     return do_get_natural_endpoints(search_token, *_shared_token_metadata.get(), can_yield);
 }
 
-std::vector<inet_address> abstract_replication_strategy::do_get_natural_endpoints(const token& search_token, const token_metadata& tm, can_yield can_yield) {
+inet_address_vector_replica_set abstract_replication_strategy::do_get_natural_endpoints(const token& search_token, const token_metadata& tm, can_yield can_yield) {
     const token& key_token = tm.first_token(search_token);
     auto& cached_endpoints = get_cached_endpoints(tm);
     auto res = cached_endpoints.find(key_token);
@@ -94,9 +94,9 @@ std::vector<inet_address> abstract_replication_strategy::do_get_natural_endpoint
     return res->second;
 }
 
-std::vector<inet_address> abstract_replication_strategy::get_natural_endpoints_without_node_being_replaced(const token& search_token, can_yield can_yield) {
+inet_address_vector_replica_set abstract_replication_strategy::get_natural_endpoints_without_node_being_replaced(const token& search_token, can_yield can_yield) {
     token_metadata_ptr tmptr = _shared_token_metadata.get();
-    std::vector<gms::inet_address> natural_endpoints = do_get_natural_endpoints(search_token, *tmptr, can_yield);
+    inet_address_vector_replica_set natural_endpoints = do_get_natural_endpoints(search_token, *tmptr, can_yield);
     if (tmptr->is_any_node_being_replaced() &&
         allow_remove_node_being_replaced_from_natural_endpoints()) {
         // When a new node is started to replace an existing dead node, we want
@@ -132,7 +132,7 @@ void abstract_replication_strategy::validate_replication_factor(sstring rf) cons
     }
 }
 
-inline std::unordered_map<token, std::vector<inet_address>>&
+inline std::unordered_map<token, inet_address_vector_replica_set>&
 abstract_replication_strategy::get_cached_endpoints(const token_metadata& tm) {
     auto ring_version = tm.get_ring_version();
     if (_last_invalidated_ring_version != ring_version) {
@@ -272,9 +272,9 @@ abstract_replication_strategy::get_address_ranges(const token_metadata& tm, inet
     return ret;
 }
 
-std::unordered_map<dht::token_range, std::vector<inet_address>>
+std::unordered_map<dht::token_range, inet_address_vector_replica_set>
 abstract_replication_strategy::get_range_addresses(const token_metadata& tm, can_yield can_yield) const {
-    std::unordered_map<dht::token_range, std::vector<inet_address>> ret;
+    std::unordered_map<dht::token_range, inet_address_vector_replica_set> ret;
     for (auto& t : tm.sorted_tokens()) {
         dht::token_range_vector ranges = tm.get_primary_ranges_for(t);
         auto eps = calculate_natural_endpoints(t, tm, can_yield);

--- a/locator/everywhere_replication_strategy.cc
+++ b/locator/everywhere_replication_strategy.cc
@@ -47,13 +47,13 @@ namespace locator {
 everywhere_replication_strategy::everywhere_replication_strategy(const sstring& keyspace_name, const shared_token_metadata& token_metadata, snitch_ptr& snitch, const std::map<sstring, sstring>& config_options) :
         abstract_replication_strategy(keyspace_name, token_metadata, snitch, config_options, replication_strategy_type::everywhere_topology) {}
 
-std::vector<inet_address> everywhere_replication_strategy::calculate_natural_endpoints(const token& search_token, const token_metadata& tm, can_yield) const {
-    return tm.get_all_endpoints();
+inet_address_vector_replica_set everywhere_replication_strategy::calculate_natural_endpoints(const token& search_token, const token_metadata& tm, can_yield) const {
+    return boost::copy_range<inet_address_vector_replica_set>(tm.get_all_endpoints());
 }
 
-std::vector<inet_address> everywhere_replication_strategy::do_get_natural_endpoints(const token& search_token, const token_metadata& tm, can_yield can_yield) {
+inet_address_vector_replica_set everywhere_replication_strategy::do_get_natural_endpoints(const token& search_token, const token_metadata& tm, can_yield can_yield) {
     if (tm.sorted_tokens().empty()) {
-        return std::vector<inet_address>({utils::fb_utilities::get_broadcast_address()});
+        return inet_address_vector_replica_set({utils::fb_utilities::get_broadcast_address()});
     }
     return calculate_natural_endpoints(search_token, tm, can_yield);
 }

--- a/locator/everywhere_replication_strategy.hh
+++ b/locator/everywhere_replication_strategy.hh
@@ -46,8 +46,8 @@ class everywhere_replication_strategy : public abstract_replication_strategy {
 public:
     everywhere_replication_strategy(const sstring& keyspace_name, const shared_token_metadata& token_metadata, snitch_ptr& snitch, const std::map<sstring,sstring>& config_options);
 
-    virtual std::vector<inet_address> calculate_natural_endpoints(const token& search_token, const token_metadata& tm, can_yield) const override;
-    std::vector<inet_address> do_get_natural_endpoints(const token& search_token, const token_metadata& tm, can_yield) override;
+    virtual inet_address_vector_replica_set calculate_natural_endpoints(const token& search_token, const token_metadata& tm, can_yield) const override;
+    inet_address_vector_replica_set do_get_natural_endpoints(const token& search_token, const token_metadata& tm, can_yield) override;
 
     virtual void validate_options() const override { /* noop */ }
 

--- a/locator/local_strategy.cc
+++ b/locator/local_strategy.cc
@@ -30,12 +30,12 @@ namespace locator {
 local_strategy::local_strategy(const sstring& keyspace_name, const shared_token_metadata& token_metadata, snitch_ptr& snitch, const std::map<sstring, sstring>& config_options) :
         abstract_replication_strategy(keyspace_name, token_metadata, snitch, config_options, replication_strategy_type::local) {}
 
-std::vector<inet_address> local_strategy::do_get_natural_endpoints(const token& t, const token_metadata& tm, can_yield can_yield) {
+inet_address_vector_replica_set local_strategy::do_get_natural_endpoints(const token& t, const token_metadata& tm, can_yield can_yield) {
     return calculate_natural_endpoints(t, tm, can_yield);
 }
 
-std::vector<inet_address> local_strategy::calculate_natural_endpoints(const token& t, const token_metadata& tm, can_yield) const {
-    return std::vector<inet_address>({utils::fb_utilities::get_broadcast_address()});
+inet_address_vector_replica_set local_strategy::calculate_natural_endpoints(const token& t, const token_metadata& tm, can_yield) const {
+    return inet_address_vector_replica_set({utils::fb_utilities::get_broadcast_address()});
 }
 
 void local_strategy::validate_options() const {

--- a/locator/local_strategy.hh
+++ b/locator/local_strategy.hh
@@ -36,7 +36,7 @@ using token = dht::token;
 
 class local_strategy : public abstract_replication_strategy {
 protected:
-    virtual std::vector<inet_address> calculate_natural_endpoints(const token& search_token, const token_metadata& tm, can_yield) const override;
+    virtual inet_address_vector_replica_set calculate_natural_endpoints(const token& search_token, const token_metadata& tm, can_yield) const override;
 public:
     local_strategy(const sstring& keyspace_name, const shared_token_metadata& token_metadata, snitch_ptr& snitch, const std::map<sstring, sstring>& config_options);
     virtual ~local_strategy() {};
@@ -46,7 +46,7 @@ public:
      * because the default implementation depends on token calculations but
      * LocalStrategy may be used before tokens are set up.
      */
-    std::vector<inet_address> do_get_natural_endpoints(const token& search_token, const token_metadata& tm, can_yield) override;
+    inet_address_vector_replica_set do_get_natural_endpoints(const token& search_token, const token_metadata& tm, can_yield) override;
 
     virtual void validate_options() const override;
 

--- a/locator/network_topology_strategy.cc
+++ b/locator/network_topology_strategy.cc
@@ -102,7 +102,7 @@ network_topology_strategy::network_topology_strategy(
     }
 }
 
-std::vector<inet_address>
+inet_address_vector_replica_set
 network_topology_strategy::calculate_natural_endpoints(
     const token& search_token, const token_metadata& tm, can_yield can_yield) const {
 

--- a/locator/network_topology_strategy.cc
+++ b/locator/network_topology_strategy.cc
@@ -258,7 +258,7 @@ network_topology_strategy::calculate_natural_endpoints(
         }
     }
 
-    return std::move(replicas.get_vector());
+    return boost::copy_range<inet_address_vector_replica_set>(replicas.get_vector());
 }
 
 void network_topology_strategy::validate_options() const {

--- a/locator/network_topology_strategy.hh
+++ b/locator/network_topology_strategy.hh
@@ -75,7 +75,7 @@ protected:
      * calculate endpoints in one pass through the tokens by tracking our
      * progress in each DC, rack etc.
      */
-    virtual std::vector<inet_address> calculate_natural_endpoints(
+    virtual inet_address_vector_replica_set calculate_natural_endpoints(
         const token& search_token, const token_metadata& tm, can_yield) const override;
 
     virtual void validate_options() const override;

--- a/locator/simple_snitch.hh
+++ b/locator/simple_snitch.hh
@@ -66,7 +66,7 @@ struct simple_snitch : public snitch_base {
     }
 
     virtual void sort_by_proximity(
-        inet_address address, std::vector<inet_address>& addresses) override {
+        inet_address address, inet_address_vector_replica_set& addresses) override {
         // Optimization to avoid walking the list
     }
 

--- a/locator/simple_strategy.cc
+++ b/locator/simple_strategy.cc
@@ -42,11 +42,11 @@ simple_strategy::simple_strategy(const sstring& keyspace_name, const shared_toke
     }
 }
 
-std::vector<inet_address> simple_strategy::calculate_natural_endpoints(const token& t, const token_metadata& tm, can_yield can_yield) const {
+inet_address_vector_replica_set simple_strategy::calculate_natural_endpoints(const token& t, const token_metadata& tm, can_yield can_yield) const {
     const std::vector<token>& tokens = tm.sorted_tokens();
 
     if (tokens.empty()) {
-        return std::vector<inet_address>();
+        return inet_address_vector_replica_set();
     }
 
     size_t replicas = get_replication_factor();

--- a/locator/simple_strategy.cc
+++ b/locator/simple_strategy.cc
@@ -66,7 +66,7 @@ inet_address_vector_replica_set simple_strategy::calculate_natural_endpoints(con
         endpoints.push_back(*ep);
     }
 
-    return std::move(endpoints.get_vector());
+    return boost::copy_range<inet_address_vector_replica_set>(endpoints.get_vector());
 }
 
 size_t simple_strategy::get_replication_factor() const {

--- a/locator/simple_strategy.hh
+++ b/locator/simple_strategy.hh
@@ -30,7 +30,7 @@ namespace locator {
 
 class simple_strategy : public abstract_replication_strategy {
 protected:
-    virtual std::vector<inet_address> calculate_natural_endpoints(const token& search_token, const token_metadata& tm, can_yield) const override;
+    virtual inet_address_vector_replica_set calculate_natural_endpoints(const token& search_token, const token_metadata& tm, can_yield) const override;
 public:
     simple_strategy(const sstring& keyspace_name, const shared_token_metadata& token_metadata, snitch_ptr& snitch, const std::map<sstring, sstring>& config_options);
     virtual ~simple_strategy() {};

--- a/locator/snitch_base.cc
+++ b/locator/snitch_base.cc
@@ -49,11 +49,11 @@ snitch_base::get_endpoint_info(inet_address endpoint,
     return ep_state ? std::optional(ep_state->value) : std::nullopt;
 }
 
-std::vector<inet_address> snitch_base::get_sorted_list_by_proximity(
+inet_address_vector_replica_set snitch_base::get_sorted_list_by_proximity(
     inet_address address,
-    std::vector<inet_address>& unsorted_address) {
+    inet_address_vector_replica_set& unsorted_address) {
 
-    std::vector<inet_address>
+    inet_address_vector_replica_set
         preferred(unsorted_address.begin(), unsorted_address.end());
 
     sort_by_proximity(address, preferred);
@@ -61,7 +61,7 @@ std::vector<inet_address> snitch_base::get_sorted_list_by_proximity(
 }
 
 void snitch_base::sort_by_proximity(
-    inet_address address, std::vector<inet_address>& addresses) {
+    inet_address address, inet_address_vector_replica_set& addresses) {
 
     std::sort(addresses.begin(), addresses.end(),
               [this, &address](inet_address& a1, inet_address& a2)
@@ -122,9 +122,9 @@ int snitch_base::compare_endpoints(
 }
 
 bool snitch_base::is_worth_merging_for_range_query(
-    std::vector<inet_address>& merged,
-    std::vector<inet_address>& l1,
-    std::vector<inet_address>& l2) {
+    inet_address_vector_replica_set& merged,
+    inet_address_vector_replica_set& l1,
+    inet_address_vector_replica_set& l2) {
     //
     // Querying remote DC is likely to be an order of magnitude slower than
     // querying locally, so 2 queries to local nodes is likely to still be
@@ -136,7 +136,7 @@ bool snitch_base::is_worth_merging_for_range_query(
         : true;
 }
 
-bool snitch_base::has_remote_node(std::vector<inet_address>& l) {
+bool snitch_base::has_remote_node(inet_address_vector_replica_set& l) {
     for (auto&& ep : l) {
         if (_my_dc != get_datacenter(ep)) {
             return true;

--- a/locator/snitch_base.hh
+++ b/locator/snitch_base.hh
@@ -44,6 +44,7 @@
 #include <boost/signals2/dummy_mutex.hpp>
 
 #include "gms/inet_address.hh"
+#include "inet_address_vectors.hh"
 #include "gms/versioned_value.hh"
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/core/thread.hh>
@@ -94,16 +95,16 @@ public:
     /**
      * returns a new <tt>List</tt> sorted by proximity to the given endpoint
      */
-    virtual std::vector<inet_address> get_sorted_list_by_proximity(
+    virtual inet_address_vector_replica_set get_sorted_list_by_proximity(
         inet_address address,
-        std::vector<inet_address>& unsorted_address) = 0;
+        inet_address_vector_replica_set& unsorted_address) = 0;
 
     /**
      * This method will sort the <tt>List</tt> by proximity to the given
      * address.
      */
     virtual void sort_by_proximity(
-        inet_address address, std::vector<inet_address>& addresses) = 0;
+        inet_address address, inet_address_vector_replica_set& addresses) = 0;
 
     /**
      * compares two endpoints in relation to the target endpoint, returning as
@@ -127,9 +128,9 @@ public:
      * against l2.
      */
     virtual bool is_worth_merging_for_range_query(
-        std::vector<inet_address>& merged,
-        std::vector<inet_address>& l1,
-        std::vector<inet_address>& l2) = 0;
+        inet_address_vector_replica_set& merged,
+        inet_address_vector_replica_set& l1,
+        inet_address_vector_replica_set& l2) = 0;
 
     virtual ~i_endpoint_snitch() { assert(_state == snitch_state::stopped); };
 
@@ -426,25 +427,25 @@ public:
     // virtual sstring get_datacenter(inet_address endpoint)  = 0;
     //
 
-    virtual std::vector<inet_address> get_sorted_list_by_proximity(
+    virtual inet_address_vector_replica_set get_sorted_list_by_proximity(
         inet_address address,
-        std::vector<inet_address>& unsorted_address) override;
+        inet_address_vector_replica_set& unsorted_address) override;
 
     virtual void sort_by_proximity(
-        inet_address address, std::vector<inet_address>& addresses) override;
+        inet_address address, inet_address_vector_replica_set& addresses) override;
 
     virtual int compare_endpoints(
         inet_address& address, inet_address& a1, inet_address& a2) override;
 
     virtual bool is_worth_merging_for_range_query(
-        std::vector<inet_address>& merged,
-        std::vector<inet_address>& l1,
-        std::vector<inet_address>& l2) override;
+        inet_address_vector_replica_set& merged,
+        inet_address_vector_replica_set& l1,
+        inet_address_vector_replica_set& l2) override;
 
     virtual future<> gossip_snitch_info(std::list<std::pair<gms::application_state, gms::versioned_value>> info) override;
 
 private:
-    bool has_remote_node(std::vector<inet_address>& l);
+    bool has_remote_node(inet_address_vector_replica_set& l);
 
 protected:
     static std::optional<sstring> get_endpoint_info(inet_address endpoint,

--- a/locator/token_metadata.cc
+++ b/locator/token_metadata.cc
@@ -735,7 +735,7 @@ public:
 #endif
 public:
     // returns empty vector if keyspace_name not found.
-    std::vector<gms::inet_address> pending_endpoints_for(const token& token, const sstring& keyspace_name) const;
+    inet_address_vector_topology_change pending_endpoints_for(const token& token, const sstring& keyspace_name) const;
 #if 0
     /**
      * @deprecated retained for benefit of old tests
@@ -1676,7 +1676,7 @@ void token_metadata_impl::del_replacing_endpoint(inet_address existing_node) {
     _replacing_endpoints.erase(existing_node);
 }
 
-std::vector<gms::inet_address> token_metadata_impl::pending_endpoints_for(const token& token, const sstring& keyspace_name) const {
+inet_address_vector_topology_change token_metadata_impl::pending_endpoints_for(const token& token, const sstring& keyspace_name) const {
     // Fast path 0: pending ranges not found for this keyspace_name
     const auto pr_it = _pending_ranges_interval_map.find(keyspace_name);
     if (pr_it == _pending_ranges_interval_map.end()) {
@@ -1690,12 +1690,12 @@ std::vector<gms::inet_address> token_metadata_impl::pending_endpoints_for(const 
     }
 
     // Slow path: lookup pending ranges
-    std::vector<gms::inet_address> endpoints;
+    inet_address_vector_topology_change endpoints;
     auto interval = range_to_interval(range<dht::token>(token));
     const auto it = ks_map.find(interval);
     if (it != ks_map.end()) {
         // interval_map does not work with std::vector, convert to std::vector of ips
-        endpoints = std::vector<gms::inet_address>(it->second.begin(), it->second.end());
+        endpoints = inet_address_vector_topology_change(it->second.begin(), it->second.end());
     }
     return endpoints;
 }
@@ -2050,7 +2050,7 @@ token_metadata::count_normal_token_owners() const {
     return _impl->count_normal_token_owners();
 }
 
-std::vector<gms::inet_address>
+inet_address_vector_topology_change
 token_metadata::pending_endpoints_for(const token& token, const sstring& keyspace_name) const {
     return _impl->pending_endpoints_for(token, keyspace_name);
 }

--- a/locator/token_metadata.hh
+++ b/locator/token_metadata.hh
@@ -43,6 +43,7 @@
 #include <unordered_map>
 #include "gms/inet_address.hh"
 #include "dht/i_partitioner.hh"
+#include "inet_address_vectors.hh"
 #include "utils/UUID.hh"
 #include <optional>
 #include <memory>
@@ -334,7 +335,7 @@ public:
     size_t count_normal_token_owners() const;
 
     // returns empty vector if keyspace_name not found.
-    std::vector<gms::inet_address> pending_endpoints_for(const token& token, const sstring& keyspace_name) const;
+    inet_address_vector_topology_change pending_endpoints_for(const token& token, const sstring& keyspace_name) const;
 
     /** @return an endpoint to token multimap representation of tokenToEndpointMap (a copy) */
     std::multimap<inet_address, token> get_endpoint_to_token_map_for_reading() const;

--- a/message/messaging_service.cc
+++ b/message/messaging_service.cc
@@ -1189,7 +1189,7 @@ void messaging_service::register_mutation(std::function<future<rpc::no_wait_type
 future<> messaging_service::unregister_mutation() {
     return unregister_handler(netw::messaging_verb::MUTATION);
 }
-future<> messaging_service::send_mutation(msg_addr id, clock_type::time_point timeout, const frozen_mutation& fm, std::vector<inet_address> forward,
+future<> messaging_service::send_mutation(msg_addr id, clock_type::time_point timeout, const frozen_mutation& fm, inet_address_vector_replica_set forward,
     inet_address reply_to, unsigned shard, response_id_type response_id, std::optional<tracing::trace_info> trace_info) {
     return send_message_oneway_timeout(this, timeout, messaging_verb::MUTATION, std::move(id), fm, std::move(forward),
         std::move(reply_to), shard, std::move(response_id), std::move(trace_info));
@@ -1462,7 +1462,7 @@ future<> messaging_service::unregister_paxos_learn() {
     return unregister_handler(netw::messaging_verb::PAXOS_LEARN);
 }
 future<> messaging_service::send_paxos_learn(msg_addr id, clock_type::time_point timeout, const service::paxos::proposal& decision,
-    std::vector<inet_address> forward, inet_address reply_to, unsigned shard, response_id_type response_id,
+    inet_address_vector_replica_set forward, inet_address reply_to, unsigned shard, response_id_type response_id,
     std::optional<tracing::trace_info> trace_info) {
     return send_message_oneway_timeout(this, timeout, messaging_verb::PAXOS_LEARN, std::move(id), decision, std::move(forward),
         std::move(reply_to), shard, std::move(response_id), std::move(trace_info));
@@ -1488,7 +1488,7 @@ void messaging_service::register_hint_mutation(std::function<future<rpc::no_wait
 future<> messaging_service::unregister_hint_mutation() {
     return unregister_handler(netw::messaging_verb::HINT_MUTATION);
 }
-future<> messaging_service::send_hint_mutation(msg_addr id, clock_type::time_point timeout, const frozen_mutation& fm, std::vector<inet_address> forward,
+future<> messaging_service::send_hint_mutation(msg_addr id, clock_type::time_point timeout, const frozen_mutation& fm, inet_address_vector_replica_set forward,
         inet_address reply_to, unsigned shard, response_id_type response_id, std::optional<tracing::trace_info> trace_info) {
     return send_message_oneway_timeout(this, timeout, messaging_verb::HINT_MUTATION, std::move(id), fm, std::move(forward),
         std::move(reply_to), shard, std::move(response_id), std::move(trace_info));

--- a/message/messaging_service.hh
+++ b/message/messaging_service.hh
@@ -27,6 +27,7 @@
 #include <seastar/core/distributed.hh>
 #include <seastar/core/sstring.hh>
 #include "gms/inet_address.hh"
+#include "inet_address_vectors.hh"
 #include <seastar/rpc/rpc_types.hh>
 #include <unordered_map>
 #include "query-request.hh"
@@ -462,7 +463,7 @@ public:
     void register_mutation(std::function<future<rpc::no_wait_type> (const rpc::client_info&, rpc::opt_time_point, frozen_mutation fm, std::vector<inet_address> forward,
         inet_address reply_to, unsigned shard, response_id_type response_id, rpc::optional<std::optional<tracing::trace_info>> trace_info)>&& func);
     future<> unregister_mutation();
-    future<> send_mutation(msg_addr id, clock_type::time_point timeout, const frozen_mutation& fm, std::vector<inet_address> forward,
+    future<> send_mutation(msg_addr id, clock_type::time_point timeout, const frozen_mutation& fm, inet_address_vector_replica_set forward,
         inet_address reply_to, unsigned shard, response_id_type response_id, std::optional<tracing::trace_info> trace_info = std::nullopt);
 
     // Wrapper for COUNTER_MUTATION
@@ -543,7 +544,7 @@ public:
     future<> unregister_paxos_learn();
 
     future<> send_paxos_learn(msg_addr id, clock_type::time_point timeout, const service::paxos::proposal& decision,
-            std::vector<inet_address> forward, inet_address reply_to, unsigned shard, response_id_type response_id,
+            inet_address_vector_replica_set forward, inet_address reply_to, unsigned shard, response_id_type response_id,
             std::optional<tracing::trace_info> trace_info = std::nullopt);
 
     void register_paxos_prune(std::function<future<rpc::no_wait_type>(const rpc::client_info&, rpc::opt_time_point, UUID schema_id, partition_key key,
@@ -557,7 +558,7 @@ public:
     void register_hint_mutation(std::function<future<rpc::no_wait_type> (const rpc::client_info&, rpc::opt_time_point, frozen_mutation fm, std::vector<inet_address> forward,
         inet_address reply_to, unsigned shard, response_id_type response_id, rpc::optional<std::optional<tracing::trace_info>> trace_info)>&& func);
     future<> unregister_hint_mutation();
-    future<> send_hint_mutation(msg_addr id, clock_type::time_point timeout, const frozen_mutation& fm, std::vector<inet_address> forward,
+    future<> send_hint_mutation(msg_addr id, clock_type::time_point timeout, const frozen_mutation& fm, inet_address_vector_replica_set forward,
         inet_address reply_to, unsigned shard, response_id_type response_id, std::optional<tracing::trace_info> trace_info = std::nullopt);
 
     void register_hint_sync_point_create(std::function<future<db::hints::sync_point_create_response> (db::hints::sync_point_create_request request)>&& func);

--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -284,7 +284,7 @@ static std::vector<gms::inet_address> get_neighbors(database& db,
         ret.erase(it, ret.end());
     }
 
-    return ret;
+    return boost::copy_range<std::vector<gms::inet_address>>(std::move(ret));
 
 #if 0
     // Origin's ActiveRepairService.getNeighbors() also verifies that the
@@ -1686,7 +1686,7 @@ static future<> do_decommission_removenode_with_repair(seastar::sharded<database
                         // Choose the decommission node n3 to run repair to
                         // sync with one of the replica nodes, e.g., n1, in the
                         // local DC.
-                        neighbors_set = get_neighbors_set(new_eps);
+                        neighbors_set = get_neighbors_set(boost::copy_range<std::vector<inet_address>>(new_eps));
                     }
                 } else {
                     throw std::runtime_error(format("{}: keyspace={}, range={}, current_replica_endpoints={}, new_replica_endpoints={}, wrong nubmer of new owner node={}",

--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -1591,7 +1591,7 @@ static future<> do_decommission_removenode_with_repair(seastar::sharded<database
             rlogger.info("{}: started with keyspace={}, leaving_node={}, nr_ranges={}", op, keyspace_name, leaving_node, ranges.size());
             size_t nr_ranges_total = ranges.size();
             size_t nr_ranges_skipped = 0;
-            std::unordered_map<dht::token_range, std::vector<inet_address>> current_replica_endpoints;
+            std::unordered_map<dht::token_range, inet_address_vector_replica_set> current_replica_endpoints;
             // Find (for each range) all nodes that store replicas for these ranges as well
             for (auto& r : ranges) {
                 auto end_token = r.end() ? r.end()->value() : dht::maximum_token();
@@ -1614,8 +1614,8 @@ static future<> do_decommission_removenode_with_repair(seastar::sharded<database
                     ops->check_abort();
                 }
                 auto end_token = r.end() ? r.end()->value() : dht::maximum_token();
-                const std::vector<inet_address> new_eps = ks.get_replication_strategy().calculate_natural_endpoints(end_token, temp, utils::can_yield::yes);
-                const std::vector<inet_address>& current_eps = current_replica_endpoints[r];
+                const inet_address_vector_replica_set new_eps = ks.get_replication_strategy().calculate_natural_endpoints(end_token, temp, utils::can_yield::yes);
+                const inet_address_vector_replica_set& current_eps = current_replica_endpoints[r];
                 std::unordered_set<inet_address> neighbors_set(new_eps.begin(), new_eps.end());
                 bool skip_this_range = false;
                 auto new_owner = neighbors_set;

--- a/service/storage_proxy.hh
+++ b/service/storage_proxy.hh
@@ -45,6 +45,7 @@
 #include "query-request.hh"
 #include "query-result.hh"
 #include "query-result-set.hh"
+#include "inet_address_vectors.hh"
 #include <seastar/core/distributed.hh>
 #include <seastar/core/execution_stage.hh>
 #include <seastar/core/scheduling_specific.hh>
@@ -243,7 +244,7 @@ public:
     // Holds  a list of endpoints participating in CAS request, for a given
     // consistency level, token, and state of joining/leaving nodes.
     struct paxos_participants {
-        std::vector<gms::inet_address> endpoints;
+        inet_address_vector_replica_set endpoints;
         // How many participants are required for a quorum (i.e. is it SERIAL or LOCAL_SERIAL).
         size_t required_participants;
         bool has_dead_endpoints;
@@ -338,7 +339,7 @@ private:
             std::unique_ptr<mutation_holder> mh, db::consistency_level cl, db::write_type type, tracing::trace_state_ptr tr_state,
             service_permit permit);
     response_id_type create_write_response_handler(keyspace& ks, db::consistency_level cl, db::write_type type, std::unique_ptr<mutation_holder> m, std::unordered_set<gms::inet_address> targets,
-            const std::vector<gms::inet_address>& pending_endpoints, std::vector<gms::inet_address>, tracing::trace_state_ptr tr_state, storage_proxy::write_stats& stats, service_permit permit);
+            const inet_address_vector_topology_change& pending_endpoints, inet_address_vector_topology_change, tracing::trace_state_ptr tr_state, storage_proxy::write_stats& stats, service_permit permit);
     response_id_type create_write_response_handler(const mutation&, db::consistency_level cl, db::write_type type, tracing::trace_state_ptr tr_state, service_permit permit);
     response_id_type create_write_response_handler(const hint_wrapper&, db::consistency_level cl, db::write_type type, tracing::trace_state_ptr tr_state, service_permit permit);
     response_id_type create_write_response_handler(const std::unordered_map<gms::inet_address, std::optional<mutation>>&, db::consistency_level cl, db::write_type type, tracing::trace_state_ptr tr_state, service_permit permit);
@@ -355,9 +356,9 @@ private:
     bool cannot_hint(const Range& targets, db::write_type type) const;
     bool hints_enabled(db::write_type type) const noexcept;
     db::hints::manager& hints_manager_for(db::write_type type);
-    std::vector<gms::inet_address> get_live_endpoints(keyspace& ks, const dht::token& token) const;
-    static void sort_endpoints_by_proximity(std::vector<gms::inet_address>& eps);
-    std::vector<gms::inet_address> get_live_sorted_endpoints(keyspace& ks, const dht::token& token) const;
+    inet_address_vector_replica_set get_live_endpoints(keyspace& ks, const dht::token& token) const;
+    static void sort_endpoints_by_proximity(inet_address_vector_replica_set& eps);
+    inet_address_vector_replica_set get_live_sorted_endpoints(keyspace& ks, const dht::token& token) const;
     db::read_repair_decision new_read_repair_decision(const schema& s);
     ::shared_ptr<abstract_read_executor> get_read_executor(lw_shared_ptr<query::read_command> cmd,
             schema_ptr schema,
@@ -365,7 +366,7 @@ private:
             db::consistency_level cl,
             db::read_repair_decision repair_decision,
             tracing::trace_state_ptr trace_state,
-            const std::vector<gms::inet_address>& preferred_endpoints,
+            const inet_address_vector_replica_set& preferred_endpoints,
             bool& is_bounced_read,
             service_permit permit);
     future<rpc::tuple<foreign_ptr<lw_shared_ptr<query::result>>, cache_temperature>> query_result_local(schema_ptr, lw_shared_ptr<query::read_command> cmd, const dht::partition_range& pr,
@@ -380,7 +381,7 @@ private:
             dht::partition_range_vector partition_ranges,
             db::consistency_level cl,
             coordinator_query_options optional_params);
-    static std::vector<gms::inet_address> intersection(const std::vector<gms::inet_address>& l1, const std::vector<gms::inet_address>& l2);
+    static inet_address_vector_replica_set intersection(const inet_address_vector_replica_set& l1, const inet_address_vector_replica_set& l2);
     future<query_partition_key_range_concurrent_result> query_partition_key_range_concurrent(clock_type::time_point timeout,
             std::vector<foreign_ptr<lw_shared_ptr<query::result>>>&& results,
             lw_shared_ptr<query::read_command> cmd,
@@ -434,7 +435,7 @@ private:
     future<> send_to_endpoint(
             std::unique_ptr<mutation_holder> m,
             gms::inet_address target,
-            std::vector<gms::inet_address> pending_endpoints,
+            inet_address_vector_topology_change pending_endpoints,
             db::write_type type,
             tracing::trace_state_ptr tr_state,
             write_stats& stats,
@@ -562,9 +563,9 @@ public:
     // Inspired by Cassandra's StorageProxy.sendToHintedEndpoints but without
     // hinted handoff support, and just one target. See also
     // send_to_live_endpoints() - another take on the same original function.
-    future<> send_to_endpoint(frozen_mutation_and_schema fm_a_s, gms::inet_address target, std::vector<gms::inet_address> pending_endpoints, db::write_type type,
+    future<> send_to_endpoint(frozen_mutation_and_schema fm_a_s, gms::inet_address target, inet_address_vector_topology_change pending_endpoints, db::write_type type,
             tracing::trace_state_ptr tr_state, write_stats& stats, allow_hints allow_hints = allow_hints::yes);
-    future<> send_to_endpoint(frozen_mutation_and_schema fm_a_s, gms::inet_address target, std::vector<gms::inet_address> pending_endpoints, db::write_type type,
+    future<> send_to_endpoint(frozen_mutation_and_schema fm_a_s, gms::inet_address target, inet_address_vector_topology_change pending_endpoints, db::write_type type,
             tracing::trace_state_ptr tr_state, allow_hints allow_hints = allow_hints::yes);
 
     // Send a mutation to a specific remote target as a hint.
@@ -693,7 +694,7 @@ private:
     // Is either set explicitly or derived from the consistency level set in keyspace options.
     db::consistency_level _cl_for_learn;
     // Live endpoints, as per get_paxos_participants()
-    std::vector<gms::inet_address> _live_endpoints;
+    inet_address_vector_replica_set _live_endpoints;
     // How many endpoints need to respond favourably for the protocol to progress to the next step.
     size_t _required_participants;
     // A deadline when the entire CAS operation timeout expires, derived from write_request_timeout_in_ms

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -43,6 +43,7 @@
 #include "service/endpoint_lifecycle_subscriber.hh"
 #include "locator/token_metadata.hh"
 #include "gms/gossiper.hh"
+#include "inet_address_vectors.hh"
 #include <seastar/core/distributed.hh>
 #include "dht/i_partitioner.hh"
 #include "dht/token_range_endpoints.hh"
@@ -468,16 +469,16 @@ public:
      */
     sstring get_rpc_address(const inet_address& endpoint) const;
 
-    std::unordered_map<dht::token_range, std::vector<inet_address>> get_range_to_address_map(const sstring& keyspace) const;
+    std::unordered_map<dht::token_range, inet_address_vector_replica_set> get_range_to_address_map(const sstring& keyspace) const;
 
-    std::unordered_map<dht::token_range, std::vector<inet_address>> get_range_to_address_map_in_local_dc(
+    std::unordered_map<dht::token_range, inet_address_vector_replica_set> get_range_to_address_map_in_local_dc(
             const sstring& keyspace) const;
 
     std::vector<token> get_tokens_in_local_dc() const;
 
     bool is_local_dc(const inet_address& targetHost) const;
 
-    std::unordered_map<dht::token_range, std::vector<inet_address>> get_range_to_address_map(const sstring& keyspace,
+    std::unordered_map<dht::token_range, inet_address_vector_replica_set> get_range_to_address_map(const sstring& keyspace,
             const std::vector<token>& sorted_tokens) const;
 
     /**
@@ -510,7 +511,7 @@ public:
      * @param ranges
      * @return mapping of ranges to the replicas responsible for them.
     */
-    std::unordered_map<dht::token_range, std::vector<inet_address>> construct_range_to_endpoint_map(
+    std::unordered_map<dht::token_range, inet_address_vector_replica_set> construct_range_to_endpoint_map(
             const sstring& keyspace,
             const dht::token_range_vector& ranges) const;
 public:
@@ -727,7 +728,7 @@ public:
      * @param key key for which we need to find the endpoint
      * @return the endpoint responsible for this key
      */
-    std::vector<gms::inet_address> get_natural_endpoints(const sstring& keyspace,
+    inet_address_vector_replica_set get_natural_endpoints(const sstring& keyspace,
             const sstring& cf, const sstring& key) const;
 
     /**
@@ -738,7 +739,7 @@ public:
      * @param pos position for which we need to find the endpoint
      * @return the endpoint responsible for this token
      */
-    std::vector<gms::inet_address>  get_natural_endpoints(const sstring& keyspace, const token& pos) const;
+    inet_address_vector_replica_set  get_natural_endpoints(const sstring& keyspace, const token& pos) const;
 
     /**
      * @return Vector of Token ranges (_not_ keys!) together with estimated key count,

--- a/test/boost/network_topology_strategy_test.cc
+++ b/test/boost/network_topology_strategy_test.cc
@@ -48,7 +48,7 @@ struct ring_point {
     inet_address host;
 };
 
-void print_natural_endpoints(double point, const std::vector<inet_address> v) {
+void print_natural_endpoints(double point, const inet_address_vector_replica_set v) {
     testlog.debug("Natural endpoints for a token {}:", point);
     std::string str;
     std::ostringstream strm(str);
@@ -105,7 +105,7 @@ void strategy_sanity_check(
 
 void endpoints_check(
     abstract_replication_strategy* ars_ptr,
-    std::vector<inet_address>& endpoints) {
+    inet_address_vector_replica_set& endpoints) {
 
     // Check the total RF
     BOOST_CHECK(endpoints.size() == ars_ptr->get_replication_factor());

--- a/utils/small_vector.hh
+++ b/utils/small_vector.hh
@@ -468,4 +468,19 @@ public:
     }
 };
 
+template <typename T, size_t N>
+std::ostream& operator<<(std::ostream& os, const utils::small_vector<T, N>& v) {
+    os << "{";
+    bool first = true;
+    for (auto&& e : v) {
+        if (!first) {
+            os << ", ";
+        }
+        first = false;
+        os << e;
+    }
+    os << "}";
+    return os;
+}
+
 }


### PR DESCRIPTION
storage_proxy uses std::vector<inet_address> for small lists of nodes - for replication (often 2-3 replicas per operation) and for pending operations (usually 0-1). These vectors require an allocation, sometimes more than one if reserve() is not used correctly.

This series switches storage_proxy to use utils::small_vector instead, removing the allocations in the common case.

Test results (perf_simple_query --smp 1 --task-quota-ms 10):

```
before: median 184810.98 tps ( 91.1 allocs/op,  20.1 tasks/op,   54564 insns/op)
after:  median 192125.99 tps ( 87.1 allocs/op,  20.1 tasks/op,   53673 insns/op)
```

4 allocations and ~900 instructions are removed (the tps figure is also improved, but it is less reliable due to cpu frequency changes).

The type change is unfortunately not contained in storage_proxy - the abstraction leaks to providers of replica sets and topology change vectors. This is sad but IMO the benefits make it worthwhile.

I expect more such changes can be applied in storage_proxy, specifically std::unordered_set<gms::inet_address> and vectors of response handles.