### PR TITLE
repair: Wire off-strategy compaction for decommission

### DIFF
--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -580,6 +580,7 @@ public:
             streaming::stream_reason::bootstrap,
             streaming::stream_reason::replace,
             streaming::stream_reason::removenode,
+            streaming::stream_reason::decommission,
         };
         return sstables::offstrategy(operations_supported.contains(reason));
     }


### PR DESCRIPTION
When decommission is done, all nodes that receive data from the
decommission node will run node_ops_cmd::decommission_done handler.

Trigger off-strategy compaction inside the handler to wire off-strategy
for decommission.

Refs #5226