### PR TITLE
Handle excess logging of non existing local endpoint

### DIFF
--- a/gms/gossiper.cc
+++ b/gms/gossiper.cc
@@ -2013,7 +2013,6 @@ future<> gossiper::add_local_application_state(std::list<std::pair<application_s
             if (!es) {
                 auto err = format("endpoint_state_map does not contain endpoint = {}, application_states = {}",
                                   ep_addr, states);
-                logger.error("{}", err);
                 throw std::runtime_error(err);
             }
 


### PR DESCRIPTION
This PR removes excess logging of non existing endpoint which is being demoted and reprinted as a warning few lines down the same function.

Fixes #8616