### PR TITLE
cql-pytest: add nodetool flush feature and use it in a test

### DIFF
--- a/test/cql-pytest/nodetool.py
+++ b/test/cql-pytest/nodetool.py
@@ -1,0 +1,73 @@
+# Copyright 2021 ScyllaDB
+#
+# This file is part of Scylla.
+#
+# Scylla is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Scylla is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
+##################################################################
+
+# This file provides a few nodetool-compatible commands that may be useful
+# for tests. The intent is *not* to test nodetool itself, but just to
+# use nodetool functionality - e.g., "nodetool flush" when testing CQL.
+#
+# When testing against a locally-running Scylla these functions do not
+# actually use nodetool but rather Scylla's REST API. This simplifies
+# running the test because an external Java process implementing JMX is
+# not needed. However, when the REST API port is not available (i.e, when
+# testing against Cassandra or some remote installation of Scylla) the
+# external "nodetool" command is used, and must be available in the path or
+# chosen with the NODETOOL environment variable.
+
+import requests
+import os
+import subprocess
+
+# For a "cql" object connected to one node, find the REST API URL
+# with the same node and port 10000.
+# TODO: We may need to change this function or its callers to add proper
+# support for testing on multi-node clusters.
+def rest_api_url(cql):
+    return f'http://{cql.cluster.contact_points[0]}:10000'
+
+# Check whether the REST API at port 10000 is available - if not we will
+# fall back to using an external "nodetool" program.
+# We only check this once per REST API URL, and cache the decision.
+checked_rest_api = {}
+def has_rest_api(cql):
+    url = rest_api_url(cql)
+    if not url in checked_rest_api:
+        # Scylla's REST API does not have an official "ping" command,
+        # so we just list the keyspaces as a (usually) short operation
+        try:
+            ok = requests.get(f'{url}/column_family/name/keyspace').ok
+        except:
+            ok = False
+        checked_rest_api[url] = ok
+    return checked_rest_api[url]
+
+
+# Run the external "nodetool" executable (can be overridden by the NODETOOL
+# environment variable). Only call this if the REST API doesn't work.
+nodetool_cmd = os.getenv('NODETOOL') or 'nodetool'
+def run_nodetool(cql, *args):
+    # TODO: We may need to change this function or its callers to add proper
+    # support for testing on multi-node clusters.
+    host = cql.cluster.contact_points[0]
+    subprocess.run([nodetool_cmd, '-h', host, *args])
+
+def flush(cql, table):
+    ks, cf = table.split('.')
+    if has_rest_api(cql):
+        requests.post(f'{rest_api_url(cql)}/storage_service/keyspace_flush/{ks}', params={'cf' : cf})
+    else:
+        run_nodetool(cql, "flush", ks, cf)

--- a/test/cql-pytest/run-cassandra
+++ b/test/cql-pytest/run-cassandra
@@ -48,7 +48,14 @@ def run_cassandra_cmd(pid, dir):
     os.mkdir(os.path.join(dir, 'hints'))
     env = { 'CASSANDRA_CONF': confdir,
             'CASSANDRA_LOG_DIR': logsdir,
-            'CASSANDRA_INCLUDE': '' }
+            'CASSANDRA_INCLUDE': '',
+            # Unfortunately, Cassandra's JMX cannot listen only on a specific
+            # interface. To allow tests to use JMX (nodetool), we need to
+            # have it listen on 0.0.0.0 :-( This is insecure, but arguably
+            # can be forgiven for test enviroments. The following JVM_OPTS
+            # configures that:
+            'JVM_OPTS': '-Dcassandra.jmx.remote.port=7199',
+          }
     # On JVM 11, Cassandra requires a bunch of configuration options in
     # conf/jvm11-server.options, or it fails loading classes because of JPMS.
     # The following options were copied from Cassandra's jvm11-server.options.

--- a/test/cql-pytest/test_sstable.py
+++ b/test/cql-pytest/test_sstable.py
@@ -1,0 +1,51 @@
+# Copyright 2021 ScyllaDB
+#
+# This file is part of Scylla.
+#
+# Scylla is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Scylla is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
+
+#############################################################################
+# The cql-pytest framework is about testing CQL functionality, so
+# implementation details like sstables cannot be tested directly. However,
+# we are still able to reproduce some bugs by tricks such as writing some
+# data to the table and then force it to be written to the disk (nodetool
+# flush) and then trying to read the data again, knowing it must come from
+# the disk.
+#############################################################################
+
+import pytest
+from util import unique_name, new_test_table
+import nodetool
+
+# Reproduces issue #8138, where the sstable reader in a TWCS sstable set
+# had a bug and resulted in no results for queries.
+# This is a Scylla-only test because it uses BYPASS CACHE which does
+# not exist on Cassandra.
+def test_twcs_optimal_query_path(cql, test_keyspace, scylla_only):
+    with new_test_table(cql, test_keyspace,
+        "pk int, ck int, v int, PRIMARY KEY (pk, ck)",
+        " WITH COMPACTION = {" +
+        " 'compaction_window_size': '1'," +
+        " 'compaction_window_unit': 'MINUTES'," +
+        " 'class': 'org.apache.cassandra.db.compaction.TimeWindowCompactionStrategy' }") as table:
+        cql.execute(f"INSERT INTO {table} (pk, ck, v) VALUES (0, 0, 0)")
+        # Obviously, scanning the table should now return exactly one row:
+        assert 1 == len(list(cql.execute(f"SELECT * FROM {table} WHERE pk = 0")))
+        # We will now flush the memtable to disk, and execute the same
+        # query again with BYPASS CACHE, to be sure to exercise the code that
+        # reads from sstables. We will obviously expect to see the same one
+        # result. Issue #8138 caused here zero results, as well as a crash
+        # in the debug build.
+        nodetool.flush(cql, table)
+        assert 1 == len(list(cql.execute(f"SELECT * FROM {table} WHERE pk = 0 BYPASS CACHE")))


### PR DESCRIPTION
The first patch adds a nodetool-like capability to the cql-pytest framework.
It is *not* meant to be used to test nodetool itself, but rather to give CQL
tests the ability to use nodetool operations - currently only one operation -
"nodetool flush". 

We try to use Scylla's REST API, if possible, and only fall back to using an
external "nodetool" command when the REST API is not available - i.e., when
testing Cassandra. The benefit of using the REST API is that we don't need
to run the jmx server to test Scylla.

The second patch is an example of using the new nodetool flush feature
in a test that needs to flush data to reproduce a bug (which has already
been fixed).


