### PR TITLE
scylla-fstrim.timer: fix wrong description from 'daily' to 'weekly'

### DIFF
--- a/dist/common/systemd/scylla-fstrim.timer
+++ b/dist/common/systemd/scylla-fstrim.timer
@@ -1,5 +1,5 @@
 [Unit]
-Description=Run Scylla fstrim daily
+Description=Run Scylla fstrim weekly
 After=scylla-server.service
 BindsTo=scylla-server.service
 


### PR DESCRIPTION
It scheduled weekly, not daily.

Fixes #8633