### PR TITLE
Fix service level negative timeouts

### DIFF
--- a/cql3/statements/sl_prop_defs.cc
+++ b/cql3/statements/sl_prop_defs.cc
@@ -48,6 +48,9 @@ void sl_prop_defs::validate() {
         if (duration.nanoseconds % 1'000'000 != 0) {
             throw exceptions::invalid_request_exception("Timeout values must be expressed in millisecond granularity");
         }
+        if (duration.nanoseconds < 0) {
+            throw exceptions::invalid_request_exception("Timeout values must be nonnegative");
+        }
         return std::chrono::duration_cast<lowres_clock::duration>(std::chrono::nanoseconds(duration.nanoseconds));
     };
 

--- a/test/cql-pytest/conftest.py
+++ b/test/cql-pytest/conftest.py
@@ -24,6 +24,7 @@
 
 import pytest
 
+from cassandra.auth import PlainTextAuthProvider
 from cassandra.cluster import Cluster, ConsistencyLevel, ExecutionProfile, EXEC_PROFILE_DEFAULT
 from cassandra.policies import RoundRobinPolicy
 
@@ -60,7 +61,9 @@ def cql(request):
         # TODO: make the protocol version an option, to allow testing with
         # different versions. If we drop this setting completely, it will
         # mean pick the latest version supported by the client and the server.
-        protocol_version=4
+        protocol_version=4,
+        # Use the default superuser credentials, which work for both Scylla and Cassandra
+        auth_provider=PlainTextAuthProvider(username='cassandra', password='cassandra'),
     )
     return cluster.connect()
 

--- a/test/cql-pytest/run-cassandra
+++ b/test/cql-pytest/run-cassandra
@@ -40,6 +40,7 @@ def run_cassandra_cmd(pid, dir):
               'listen_address: ' + ip + '\n' +
               'auto_snapshot: false\n' +
               'enable_user_defined_functions: true\n' +
+              'authenticator: PasswordAuthenticator\n' +
               'enable_materialized_views: true\n', file=f)
     print('Booting Cassandra on ' + ip + ' in ' + dir + '...')
     logsdir = os.path.join(dir, 'logs')

--- a/test/cql-pytest/run.py
+++ b/test/cql-pytest/run.py
@@ -186,11 +186,15 @@ def run_scylla_cmd(pid, dir):
         '--num-tokens', '16',
         # Allow testing experimental features
         '--experimental', '1', '--enable-user-defined-functions', '1',
+        # Set up authentication in order to allow testing this module
+        # and other modules dependent on it: e.g. service levels
+        '--authenticator', 'PasswordAuthenticator',
         ], {})
 
 ## Test that CQL is serving.
 def check_cql(ip):
-    cassandra.cluster.Cluster([ip]).connect()
+    auth_provider = cassandra.auth.PlainTextAuthProvider(username='cassandra', password='cassandra')
+    cassandra.cluster.Cluster([ip], auth_provider=auth_provider).connect()
 
 # Wait for scylla to finish booting successfully. Raises an exception if
 # we know it did not.

--- a/test/cql-pytest/test_service_levels.py
+++ b/test/cql-pytest/test_service_levels.py
@@ -1,0 +1,70 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 ScyllaDB
+#
+# This file is part of Scylla.
+#
+# Scylla is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Scylla is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
+
+#############################################################################
+# Tests for the service levels infrastructure. Service levels can be attached
+# to roles in order to apply various role-specific parameters, like timeouts.
+#############################################################################
+
+from contextlib import contextmanager
+from util import unique_name, new_test_table
+
+from cassandra.protocol import InvalidRequest, ReadTimeout
+from cassandra.util import Duration
+
+import pytest
+
+@contextmanager
+def new_service_level(cql):
+    try:
+        sl = f"sl_{unique_name()}"
+        cql.execute(f"CREATE SERVICE LEVEL {sl}")
+        cql.execute(f"ATTACH SERVICE LEVEL {sl} TO {cql.cluster.auth_provider.username}")
+        yield sl
+    finally:
+        cql.execute(f"DETACH SERVICE LEVEL FROM {cql.cluster.auth_provider.username}")
+        cql.execute(f"DROP SERVICE LEVEL IF EXISTS {sl}")
+
+# Test that setting service level timeouts correctly sets the timeout parameter
+def test_set_service_level_timeouts(scylla_only, cql):
+    with new_service_level(cql) as sl:
+        cql.execute(f"ALTER SERVICE LEVEL {sl} WITH timeout = 575ms")
+        res = cql.execute(f"LIST SERVICE LEVEL {sl}")
+        assert res.one().timeout == Duration(0, 0, 575000000)
+        cql.execute(f"ALTER SERVICE LEVEL {sl} WITH timeout = 2h")
+        res = cql.execute(f"LIST SERVICE LEVEL {sl}")
+        assert res.one().timeout == Duration(0, 0, 2*60*60*10**9)
+        cql.execute(f"ALTER SERVICE LEVEL {sl} WITH timeout = null")
+        res = cql.execute(f"LIST SERVICE LEVEL {sl}")
+        assert not res.one().timeout
+
+# Test that incorrect service level timeout values result in an error
+def test_validate_service_level_timeouts(scylla_only, cql):
+    with new_service_level(cql) as sl:
+        for incorrect in ['1ns', '-5s','writetime', '1second', '10d', '5y', '7', '0']:
+            print(f"Checking {incorrect}")
+            with pytest.raises(Exception):
+                cql.execute(f"ALTER SERVICE LEVEL {sl} WITH timeout = {incorrect}")
+
+# Test that the service level is correctly attached to the user's role
+def test_attached_service_level(scylla_only, cql):
+    with new_service_level(cql) as sl:
+        res_one = cql.execute(f"LIST ATTACHED SERVICE LEVEL OF {cql.cluster.auth_provider.username}").one()
+        assert res_one.role == cql.cluster.auth_provider.username and res_one.service_level == sl
+        res_one = cql.execute(f"LIST ALL ATTACHED SERVICE LEVELS").one()
+        assert res_one.role == cql.cluster.auth_provider.username and res_one.service_level == sl


### PR DESCRIPTION
This series fixes a minor validation issue with service level timeouts - negative values were not checked. This bug is benign because negative timeouts act just like a 0s timeout, but the original series claimed to validate against negative values, so it's hereby fixed.
More importantly however, this series follows by enabling cql-pytest to run service level tests and provides a first batch of them, including a missing test case for negative timeouts.
The idea is similar to what we already have in alternator test suite - authentication is unconditionally enabled, which doesn't affect any existing tests, but at the same time allows writing test cases which rely on authentication - e.g. service levels.

One very sad side effect of this change is +15 seconds of boot time, which is a result of a hardcoded delay in Scylla authentication module:
https://github.com/scylladb/scylla/blob/c0dafa75d9f334c1ac932aa7de5618ac5c80f188/auth/common.hh#L73-L75
While this delay is more or less negligible for production clusters, it's extremely annoing for cql-pytest, since 15 seconds is a heavy chunk of its total execution time. Perhaps it's time to try and reevaluate the hardcoded 15 seconds and try to fix the issue more properly? In particular, a local single node cluster should be able to set up its authentication tables almost immediately, and definitely doesn't need to unconditionally wait for 15 seconds before trying to do so.