### PR TITLE
hints: make hints concurrency configurable and reduce the default

### DIFF
--- a/db/config.cc
+++ b/db/config.cc
@@ -591,6 +591,8 @@ db::config::config(std::shared_ptr<db::extensions> exts)
     , hinted_handoff_enabled(this, "hinted_handoff_enabled", value_status::Used, db::config::hinted_handoff_enabled_type(db::config::hinted_handoff_enabled_type::enabled_for_all_tag()),
         "Enable or disable hinted handoff. To enable per data center, add data center list. For example: hinted_handoff_enabled: DC1,DC2. A hint indicates that the write needs to be replayed to an unavailable node. "
         "Related information: About hinted handoff writes")
+    , max_hinted_handoff_concurrency(this, "max_hinted_handoff_concurrency", liveness::LiveUpdate, value_status::Used, 0,
+        "Maximum concurrency allowed for sending hints. The concurrency is divided across shards and rounded up if not divisible by the number of shards. By default (or when set to 0), concurrency of 8*shard_count will be used.")
     , hinted_handoff_throttle_in_kb(this, "hinted_handoff_throttle_in_kb", value_status::Unused, 1024,
         "Maximum throttle per delivery thread in kilobytes per second. This rate reduces proportionally to the number of nodes in the cluster. For example, if there are two nodes in the cluster, each delivery thread will use the maximum rate. If there are three, each node will throttle to half of the maximum, since the two nodes are expected to deliver hints simultaneously.")
     , max_hint_window_in_ms(this, "max_hint_window_in_ms", value_status::Used, 10800000,

--- a/db/config.hh
+++ b/db/config.hh
@@ -241,6 +241,7 @@ public:
     named_value<uint32_t> dynamic_snitch_reset_interval_in_ms;
     named_value<uint32_t> dynamic_snitch_update_interval_in_ms;
     named_value<hinted_handoff_enabled_type> hinted_handoff_enabled;
+    named_value<uint32_t> max_hinted_handoff_concurrency;
     named_value<uint32_t> hinted_handoff_throttle_in_kb;
     named_value<uint32_t> max_hint_window_in_ms;
     named_value<uint32_t> max_hints_delivery_threads;

--- a/db/hints/resource_manager.hh
+++ b/db/hints/resource_manager.hh
@@ -31,6 +31,7 @@
 #include <unordered_set>
 #include "gms/gossiper.hh"
 #include "utils/small_vector.hh"
+#include "utils/updateable_value.hh"
 #include "lister.hh"
 #include "enum_set.hh"
 
@@ -122,7 +123,7 @@ private:
 
 class resource_manager {
     const size_t _max_send_in_flight_memory;
-    const size_t _min_send_hint_budget;
+    utils::updateable_value<uint32_t> _max_hints_send_queue_length;
     seastar::named_semaphore _send_limiter;
 
     seastar::named_semaphore _operation_lock;
@@ -169,12 +170,12 @@ class resource_manager {
 public:
     static constexpr size_t hint_segment_size_in_mb = 32;
     static constexpr size_t max_hints_per_ep_size_mb = 128; // 4 files 32MB each
-    static constexpr size_t max_hints_send_queue_length = 128;
+    static constexpr size_t default_per_shard_concurrency_limit = 8;
 
 public:
-    resource_manager(size_t max_send_in_flight_memory)
-        : _max_send_in_flight_memory(std::max(max_send_in_flight_memory, max_hints_send_queue_length))
-        , _min_send_hint_budget(_max_send_in_flight_memory / max_hints_send_queue_length)
+    resource_manager(size_t max_send_in_flight_memory, utils::updateable_value<uint32_t> max_hint_sending_concurrency)
+        : _max_send_in_flight_memory(max_send_in_flight_memory)
+        , _max_hints_send_queue_length(std::move(max_hint_sending_concurrency))
         , _send_limiter(_max_send_in_flight_memory, named_semaphore_exception_factory{"send limiter"})
         , _operation_lock(1, named_semaphore_exception_factory{"operation lock"})
         , _space_watchdog(_shard_managers, _per_device_limits_map)

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -1788,7 +1788,7 @@ storage_proxy::storage_proxy(distributed<database>& db, storage_proxy::config cf
     , _hints_write_smp_service_group(cfg.hints_write_smp_service_group)
     , _write_ack_smp_service_group(cfg.write_ack_smp_service_group)
     , _next_response_id(std::chrono::system_clock::now().time_since_epoch()/1ms)
-    , _hints_resource_manager(cfg.available_memory / 10)
+    , _hints_resource_manager(cfg.available_memory / 10, _db.local().get_config().max_hinted_handoff_concurrency)
     , _hints_manager(_db.local().get_config().hints_directory(), cfg.hinted_handoff_enabled, _db.local().get_config().max_hint_window_in_ms(), _hints_resource_manager, _db)
     , _hints_directory_initializer(std::move(cfg.hints_directory_initializer))
     , _hints_for_views_manager(_db.local().get_config().view_hints_directory(), {}, _db.local().get_config().max_hint_window_in_ms(), _hints_resource_manager, _db)


### PR DESCRIPTION
Previously, hinted handoff had a hardcoded concurrency limit - at most
128 hints could be sent from a single shard at once. This commit makes
this limit configurable by adding a new configuration option:
`max_hinted_handoff_concurrency_per_shard`. This option can be updated
in runtime. Additionally, the default concurrency per shard is made
lower and is now 8.

The motivation for reducing the concurrency was to mitigate the negative
impact hints may have on performance of the receiving node due to them
not being properly isolated with respect to I/O.

Tests:
- unit(dev)
- dtests(hintedhandoff_additional_test.py)

Refs: #8624