### PR TITLE
abstract_replication_strategy: avoid reactor stalls in `get_address_ranges` and friends

### DIFF
--- a/locator/abstract_replication_strategy.cc
+++ b/locator/abstract_replication_strategy.cc
@@ -243,6 +243,10 @@ abstract_replication_strategy::get_address_ranges(const token_metadata& tm, can_
                 ret.emplace(ep, rng);
             }
         }
+
+        if (can_yield) {
+            seastar::thread::maybe_yield();
+        }
     }
     return ret;
 }
@@ -268,6 +272,10 @@ abstract_replication_strategy::get_address_ranges(const token_metadata& tm, inet
         if (!found) {
             logger.debug("token={} natural_endpoints={}: endpoint={} not found", t, eps, endpoint);
         }
+
+        if (can_yield) {
+            seastar::thread::maybe_yield();
+        }
     }
     return ret;
 }
@@ -280,6 +288,10 @@ abstract_replication_strategy::get_range_addresses(const token_metadata& tm, can
         auto eps = calculate_natural_endpoints(t, tm, can_yield);
         for (auto& r : ranges) {
             ret.emplace(r, eps);
+        }
+
+        if (can_yield) {
+            seastar::thread::maybe_yield();
         }
     }
     return ret;

--- a/locator/abstract_replication_strategy.hh
+++ b/locator/abstract_replication_strategy.hh
@@ -92,7 +92,14 @@ public:
         snitch_ptr& snitch,
         const std::map<sstring, sstring>& config_options,
         replication_strategy_type my_type);
+
+    // The returned vector has size O(number of normal token owners), which is O(number of nodes in the cluster).
+    // Note: it is not guaranteed that the function will actually yield. If the complexity of a particular implementation
+    // is small, that implementation may not yield since by itself it won't cause a reactor stall (assuming practical
+    // cluster sizes and number of tokens per node). The caller is responsible for yielding if they call this function
+    // in a loop.
     virtual inet_address_vector_replica_set calculate_natural_endpoints(const token& search_token, const token_metadata& tm, can_yield = can_yield::no) const = 0;
+
     virtual ~abstract_replication_strategy() {}
     static std::unique_ptr<abstract_replication_strategy> create_replication_strategy(const sstring& ks_name, const sstring& strategy_name, const shared_token_metadata& stm, const std::map<sstring, sstring>& config_options);
     static void validate_replication_strategy(const sstring& ks_name,

--- a/locator/token_metadata.hh
+++ b/locator/token_metadata.hh
@@ -293,8 +293,14 @@ public:
      */
     future<> clear_gently() noexcept;
 
+    /*
+     * Number of returned ranges = O(tokens.size())
+     */
     dht::token_range_vector get_primary_ranges_for(std::unordered_set<token> tokens) const;
 
+    /*
+     * Number of returned ranges = O(1)
+     */
     dht::token_range_vector get_primary_ranges_for(token right) const;
     static boost::icl::interval<token>::interval_type range_to_interval(range<dht::token> r);
     static range<dht::token> interval_to_range(boost::icl::interval<token>::interval_type i);


### PR DESCRIPTION
The algorithm used in `get_address_ranges` and `get_range_addresses`
calls `calculate_natural_endpoints` in a loop; the loop iterates over
all tokens in the token ring. If the complexity of a particular
implementation of `calculate_natural_endpoints` is large - say `θ(n)`,
where `n` is the number of tokens - this results in an `θ(n^2)`
algorithm (or worse). This case happens for `Everywhere` replication strategy.

For small clusters this doesn't matter that much, but if `n` is, say, `20*255`,
this may result in huge reactor stalls, as observed in practice.

We avoid these stalls by inserting tactical yields. We hope that
some day someone actually implements a subquadratic algortihm here.

The commit also adds a comment on
`abstract_replication_strategy::calculate_natural_endpoints` explaining
that the interface does not give a complexity guarantee (at this point);
the different implementations have different complexities.

For example, `Everywhere` implementation always iterates over all tokens
in the token ring, so it has `θ(n)` worst and best case complexity.
On the other hand, `NetworkTopologyStrategy` implementation usually
finishes after visiting a small part of the token ring (specifically,
as soon as it finds a token for each node in the ring) and performs
a constant number of operations for each visited token on average,
but theoretically its worst case complexity is actually `O(n + k^2)`,
where `n` is the number of all tokens and `k` is the number of endpoints
(the `k^2` appears since for each endpoint we must perform finds and
inserts on `unordered_set` of size `O(k)`; `unordered_set` operations
have `O(1)` average complexity but `O(size of the set)` worst case
complexity).

Therefore it's not easy to put any complexity guarantee in the interface
at this point. Instead, we say that:
- some implementations may yield - if their complexities force us to do so
- but in general, there is no guarantee that the implementation may
  yield - e.g. the `Everywhere` implementation does not yield.

Fixes #8555.