### PR TITLE
auth: remove the fixed 15s delay during auth setup

### DIFF
--- a/auth/common.hh
+++ b/auth/common.hh
@@ -70,10 +70,6 @@ future<> once_among_shards(Task&& f) {
     return make_ready_future<>();
 }
 
-inline future<> delay_until_system_ready(seastar::abort_source& as) {
-    return sleep_abortable(15s, as);
-}
-
 // Func must support being invoked more than once.
 future<> do_after_system_ready(seastar::abort_source& as, seastar::noncopyable_function<future<>()> func);
 


### PR DESCRIPTION
The auth intialization path contains a fixed 15s delay,
which used to work around a couple of issues (#3320, #3850),
but is right now quite useless, because a retry mechanism
is already in place anyway.
This patch speeds up the boot process if authentication is enabled.
In particular, for a single-node clusters, common for test setups,
auth initialization now takes a couple of milliseconds instead
of the whole 15 seconds.

Fixes #8648
Tests: unit(release), https://github.com/scylladb/scylla/pull/8645 on top of this patch executes 15s faster than without it (no coincidence here).