### PR TITLE
install.sh:set aio conf during installation

### DIFF
--- a/dist/common/scripts/scylla_io_setup
+++ b/dist/common/scripts/scylla_io_setup
@@ -122,7 +122,6 @@ class scylla_cpuinfo:
             return len(self._cpu_data["system"])
 
 def run_iotune():
-            configure_aio_slots()
             if "SCYLLA_CONF" in os.environ:
                 conf_dir = os.environ["SCYLLA_CONF"]
             else:

--- a/dist/common/scripts/scylla_prepare
+++ b/dist/common/scripts/scylla_prepare
@@ -116,8 +116,6 @@ if __name__ == '__main__':
         os.remove('/etc/scylla/ami_disabled')
         sys.exit(1)
 
-    configure_aio_slots()
-
     if mode == 'virtio':
         tap = cfg.get('TAP')
         user = cfg.get('USER')
@@ -147,4 +145,3 @@ if __name__ == '__main__':
             print(f'Exception occurred while creating perftune.yaml: {e}')
             print('To fix the error, please re-run scylla_setup.')
             sys.exit(1)
-

--- a/dist/common/scripts/scylla_util.py
+++ b/dist/common/scripts/scylla_util.py
@@ -102,27 +102,6 @@ def scyllabindir():
 def sysconfdir():
     return str(sysconfdir_p())
 
-def get_required_aio_slots():
-    return cpu_count() * 11026 + 65536
-
-def configure_aio_slots():
-    aio_conf_file = "/etc/sysctl.d/aio-max-nr.conf"
-    aio_max_nr_value = "fs.aio-max-nr = " + str(get_required_aio_slots())
-    mode = 'w+'
-    if os.path.exists(aio_conf_file):
-        with open(aio_conf_file, 'r') as file:
-            for line in file:
-                aio_conf_value = re.findall(r"[=]?\d*\.\d+|\d+", line)
-                aio_value = int((', '.join(map(str, aio_conf_value))))
-                if aio_value > get_required_aio_slots():
-                    with open('/proc/sys/fs/aio-max-nr', mode) as f:
-                        f.write(str(aio_value))
-    else:
-        with open(aio_conf_file, mode) as f:
-            f.write(aio_max_nr_value + '\n')
-        with open('/proc/sys/fs/aio-max-nr', mode) as f:
-            f.write(str(get_required_aio_slots()))
-
 # @param headers dict of k:v
 def curl(url, headers=None, byte=False, timeout=3, max_retries=5, retry_interval=5):
     retries = 0

--- a/dist/common/sysctl.d/99-scylla-aio.conf
+++ b/dist/common/sysctl.d/99-scylla-aio.conf
@@ -1,0 +1,2 @@
+# Raise max AIO events
+fs.aio-max-nr = 5578536

--- a/dist/debian/debian/scylla-kernel-conf.postinst
+++ b/dist/debian/debian/scylla-kernel-conf.postinst
@@ -11,6 +11,7 @@ else
     sysctl -p/usr/lib/sysctl.d/99-scylla-sched.conf || :
     sysctl -p/usr/lib/sysctl.d/99-scylla-vm.conf || :
     sysctl -p/usr/lib/sysctl.d/99-scylla-inotify.conf || :
+    sysctl -p/usr/lib/sysctl.d/99-scylla-aio.conf || :
 fi
 
 #DEBHELPER#

--- a/dist/redhat/scylla.spec
+++ b/dist/redhat/scylla.spec
@@ -211,6 +211,7 @@ if Scylla is the main application on your server and you wish to optimize its la
 /usr/lib/systemd/systemd-sysctl 99-scylla-sched.conf >/dev/null 2>&1 || :
 /usr/lib/systemd/systemd-sysctl 99-scylla-vm.conf >/dev/null 2>&1 || :
 /usr/lib/systemd/systemd-sysctl 99-scylla-inotify.conf >/dev/null 2>&1 || :
+/usr/lib/systemd/systemd-sysctl 99-scylla-aio.conf >/dev/null 2>&1 || :
 
 %files kernel-conf
 %defattr(-,root,root)


### PR DESCRIPTION
This is a follow up change to https://github.com/scylladb/scylla/pull/8512

Let's add aio conf file during scylla installation process and make sure
we also remove this file when uninstall Scyll