### PR TITLE
RFC: simplify sstable reader

### DIFF
--- a/sstables/kl/reader_impl.hh
+++ b/sstables/kl/reader_impl.hh
@@ -253,7 +253,6 @@ private:
                     break;
                 } else {
                     _state = state::ATOM_MASK;
-                    co_yield row_consumer::proceed::yes;
                 }
                 if (read_8(*_processing_data) != read_status::ready) {
                     _state = state::ATOM_MASK_2;

--- a/sstables/kl/reader_impl.hh
+++ b/sstables/kl/reader_impl.hh
@@ -228,7 +228,6 @@ private:
                     _state = state::DELETION_TIME_3;
                     co_yield row_consumer::proceed::yes;
                 }
-            {
                 deletion_time del;
                 del.local_deletion_time = _u32;
                 del.marked_for_delete_at = _u64;
@@ -241,7 +240,6 @@ private:
                 if (ret == row_consumer::proceed::no) {
                     co_yield row_consumer::proceed::no;
                 }
-            }
             }
             while (true) {
                 if (read_short_length_bytes(*_processing_data, _key) != read_status::ready) {
@@ -261,7 +259,6 @@ private:
                     _state = state::ATOM_MASK_2;
                     co_yield row_consumer::proceed::yes;
                 }
-            {
                 auto const mask = column_mask(_u8);
 
                 if ((mask & (column_mask::range_tombstone | column_mask::shadowable)) != column_mask::none) {
@@ -279,7 +276,6 @@ private:
                         _state = state::RANGE_TOMBSTONE_4;
                         co_yield row_consumer::proceed::yes;
                     }
-                {
                     _sst->get_stats().on_range_tombstone_read();
                     deletion_time del;
                     del.local_deletion_time = _u32;
@@ -292,7 +288,6 @@ private:
                     _state = state::ATOM_START;
                     co_yield ret;
                     continue;
-                }
                 } else if ((mask & column_mask::counter) != column_mask::none) {
                     _deleted = false;
                     _counter = true;
@@ -328,13 +323,10 @@ private:
                     _counter = false;
                     _state = state::CELL;
                 }
-            }
-            {
                 if (read_64(*_processing_data) != read_status::ready) {
                     _state = state::CELL_2;
                     co_yield row_consumer::proceed::yes;
                 }
-            }
                 if (read_32(*_processing_data) != read_status::ready) {
                     _state = state::CELL_VALUE_BYTES;
                     co_yield row_consumer::proceed::yes;
@@ -343,7 +335,6 @@ private:
                     _state = state::CELL_VALUE_BYTES_2;
                     co_yield row_consumer::proceed::yes;
                 }
-            {
                 row_consumer::proceed ret;
                 if (_deleted) {
                     if (_val_fragmented.size_bytes() != 4) {
@@ -370,7 +361,6 @@ private:
                 _val_fragmented.remove_prefix(_val_fragmented.size_bytes());
                 _state = state::ATOM_START;
                 co_yield ret;
-            }
             }
         }
     }

--- a/sstables/kl/reader_impl.hh
+++ b/sstables/kl/reader_impl.hh
@@ -135,15 +135,8 @@ class data_consume_rows_context : public data_consumer::continuous_data_consumer
 private:
     enum class state {
         ROW_START,
-        DELETION_TIME_2,
-        DELETION_TIME_3,
         ATOM_START,
-        ATOM_START_2,
-        ATOM_MASK_2,
-        COUNTER_CELL_2,
-        EXPIRING_CELL_3,
-        CELL_VALUE_BYTES_2,
-        RANGE_TOMBSTONE_4,
+        NOT_CLOSING,
     } _state = state::ROW_START;
 
     row_consumer& _consumer;
@@ -164,14 +157,9 @@ private:
     temporary_buffer<char>* _processing_data;
 public:
     using consumer = row_consumer;
+     // assumes !primitive_consumer::active()
     bool non_consuming() const {
-        return (((_state == state::DELETION_TIME_3)
-                || (_state == state::CELL_VALUE_BYTES_2)
-                || (_state == state::ATOM_START_2)
-                || (_state == state::ATOM_MASK_2)
-                || (_state == state::COUNTER_CELL_2)
-                || (_state == state::RANGE_TOMBSTONE_4)
-                || (_state == state::EXPIRING_CELL_3)));
+        return false;
     }
 
     // process() feeds the given data into the state machine.
@@ -205,15 +193,14 @@ private:
     processing_result_generator do_process_state() {
         while (true) {
             if (_state == state::ROW_START) {
+                _state = state::NOT_CLOSING;
                 if (read_short_length_bytes(*_processing_data, _key) != read_status::ready) {
                     co_yield row_consumer::proceed::yes;
                 }
                 if (read_32(*_processing_data) != read_status::ready) {
-                    _state = state::DELETION_TIME_2;
                     co_yield row_consumer::proceed::yes;
                 }
                 if (read_64(*_processing_data) != read_status::ready) {
-                    _state = state::DELETION_TIME_3;
                     co_yield row_consumer::proceed::yes;
                 }
                 deletion_time del;
@@ -231,7 +218,6 @@ private:
             }
             while (true) {
                 if (read_short_length_bytes(*_processing_data, _key) != read_status::ready) {
-                    _state = state::ATOM_START_2;
                     co_yield row_consumer::proceed::yes;
                 }
                 if (_u16 == 0) {
@@ -240,8 +226,8 @@ private:
                     co_yield _consumer.consume_row_end();
                     break;
                 }
+                _state = state::NOT_CLOSING;
                 if (read_8(*_processing_data) != read_status::ready) {
-                    _state = state::ATOM_MASK_2;
                     co_yield row_consumer::proceed::yes;
                 }
                 auto const mask = column_mask(_u8);
@@ -255,7 +241,6 @@ private:
                         co_yield row_consumer::proceed::yes;
                     }
                     if (read_64(*_processing_data) != read_status::ready) {
-                        _state = state::RANGE_TOMBSTONE_4;
                         co_yield row_consumer::proceed::yes;
                     }
                     _sst->get_stats().on_range_tombstone_read();
@@ -274,7 +259,6 @@ private:
                     _deleted = false;
                     _counter = true;
                     if (read_64(*_processing_data) != read_status::ready) {
-                        _state = state::COUNTER_CELL_2;
                         co_yield row_consumer::proceed::yes;
                     }
                     // _timestamp_of_last_deletion = _u64;
@@ -286,7 +270,6 @@ private:
                     }
                     _ttl = _u32;
                     if (read_32(*_processing_data) != read_status::ready) {
-                        _state = state::EXPIRING_CELL_3;
                         co_yield row_consumer::proceed::yes;
                     }
                     _expiration = _u32;
@@ -306,7 +289,6 @@ private:
                     co_yield row_consumer::proceed::yes;
                 }
                 if (read_bytes(*_processing_data, _u32, _val_fragmented) != read_status::ready) {
-                    _state = state::CELL_VALUE_BYTES_2;
                     co_yield row_consumer::proceed::yes;
                 }
                 row_consumer::proceed ret;
@@ -352,10 +334,10 @@ public:
 
     void verify_end_state() {
         // If reading a partial row (i.e., when we have a clustering row
-        // filter and using a promoted index), we may be in ATOM_START or ATOM_START_2
+        // filter and using a promoted index), we may be in ATOM_START
         // state instead of ROW_START. In that case we did not read the
         // end-of-row marker and consume_row_end() was never called.
-        if (_state == state::ATOM_START || _state == state::ATOM_START_2) {
+        if (_state == state::ATOM_START) {
             _consumer.consume_row_end();
             return;
         }

--- a/sstables/kl/reader_impl.hh
+++ b/sstables/kl/reader_impl.hh
@@ -193,11 +193,6 @@ public:
     // leave only the unprocessed part. The caller must handle calling
     // process() again, and/or refilling the buffer, as needed.
     data_consumer::processing_result process_state(temporary_buffer<char>& data) {
-        _processing_data = &data;
-        return _gen.generate();
-    }
-private:
-    processing_result_generator do_process_state() {
 #if 0
         // Testing hack: call process() for tiny chunks separately, to verify
         // that primitive types crossing input buffer are handled correctly.
@@ -215,7 +210,12 @@ private:
             return row_consumer::proceed::yes;
         }
 #endif
-        sstlog.trace("data_consume_row_context {}: state={}, size={}", fmt::ptr(this), static_cast<int>(_state), _processing_data->size());
+        sstlog.trace("data_consume_row_context {}: state={}, size={}", fmt::ptr(this), static_cast<int>(_state), data.size());
+        _processing_data = &data;
+        return _gen.generate();
+    }
+private:
+    processing_result_generator do_process_state() {
         while (true) {
         switch (_state) {
         case state::ROW_START:

--- a/sstables/kl/reader_impl.hh
+++ b/sstables/kl/reader_impl.hh
@@ -310,7 +310,6 @@ private:
                 }
                 // _timestamp_of_last_deletion = _u64;
                 _state = state::CELL;
-                goto state_CELL;
             } else if ((mask & column_mask::expiration) != column_mask::none) {
                 _deleted = false;
                 _counter = false;
@@ -326,7 +325,6 @@ private:
                 }
                 _expiration = _u32;
                 _state = state::CELL;
-                break;
             } else {
                 // FIXME: see ColumnSerializer.java:deserializeColumnBody
                 if ((mask & column_mask::counter_update) != column_mask::none) {
@@ -336,11 +334,9 @@ private:
                 _deleted = (mask & column_mask::deletion) != column_mask::none;
                 _counter = false;
                 _state = state::CELL;
-                break;
             }
         }
-        state_CELL:
-        case state::CELL: {
+        {
             if (read_64(*_processing_data) != read_status::ready) {
                 _state = state::CELL_2;
                 co_yield row_consumer::proceed::yes;

--- a/sstables/kl/reader_impl.hh
+++ b/sstables/kl/reader_impl.hh
@@ -216,162 +216,162 @@ private:
     processing_result_generator do_process_state() {
         while (true) {
             if (_state == state::ROW_START) {
-            if (read_short_length_bytes(*_processing_data, _key) != read_status::ready) {
-                _state = state::DELETION_TIME;
-                co_yield row_consumer::proceed::yes;
-            }
-            if (read_32(*_processing_data) != read_status::ready) {
-                _state = state::DELETION_TIME_2;
-                co_yield row_consumer::proceed::yes;
-            }
-            if (read_64(*_processing_data) != read_status::ready) {
-                _state = state::DELETION_TIME_3;
-                co_yield row_consumer::proceed::yes;
-            }
-        {
-            deletion_time del;
-            del.local_deletion_time = _u32;
-            del.marked_for_delete_at = _u64;
-            _sst->get_stats().on_row_read();
-            auto ret = _consumer.consume_row_start(key_view(to_bytes_view(_key)), del);
-            // after calling the consume function, we can release the
-            // buffers we held for it.
-            _key.release();
-            _state = state::ATOM_START;
-            if (ret == row_consumer::proceed::no) {
-                co_yield row_consumer::proceed::no;
-            }
-        }
-        }
-        while (true) {
-            if (read_short_length_bytes(*_processing_data, _key) != read_status::ready) {
-                _state = state::ATOM_START_2;
-                co_yield row_consumer::proceed::yes;
-            }
-            if (_u16 == 0) {
-                // end of row marker
-                _state = state::ROW_START;
-                co_yield _consumer.consume_row_end();
-                break;
-            } else {
-                _state = state::ATOM_MASK;
-                co_yield row_consumer::proceed::yes;
-            }
-            if (read_8(*_processing_data) != read_status::ready) {
-                _state = state::ATOM_MASK_2;
-                co_yield row_consumer::proceed::yes;
-            }
-        {
-            auto const mask = column_mask(_u8);
-
-            if ((mask & (column_mask::range_tombstone | column_mask::shadowable)) != column_mask::none) {
-                _state = state::RANGE_TOMBSTONE;
-                _shadowable = (mask & column_mask::shadowable) != column_mask::none;
-                if (read_short_length_bytes(*_processing_data, _val) != read_status::ready) {
-                    _state = state::RANGE_TOMBSTONE_2;
+                if (read_short_length_bytes(*_processing_data, _key) != read_status::ready) {
+                    _state = state::DELETION_TIME;
                     co_yield row_consumer::proceed::yes;
                 }
                 if (read_32(*_processing_data) != read_status::ready) {
-                    _state = state::RANGE_TOMBSTONE_3;
+                    _state = state::DELETION_TIME_2;
                     co_yield row_consumer::proceed::yes;
                 }
                 if (read_64(*_processing_data) != read_status::ready) {
-                    _state = state::RANGE_TOMBSTONE_4;
+                    _state = state::DELETION_TIME_3;
                     co_yield row_consumer::proceed::yes;
                 }
             {
-                _sst->get_stats().on_range_tombstone_read();
                 deletion_time del;
                 del.local_deletion_time = _u32;
                 del.marked_for_delete_at = _u64;
-                auto ret = _shadowable
-                        ? _consumer.consume_shadowable_row_tombstone(to_bytes_view(_key), del)
-                        : _consumer.consume_range_tombstone(to_bytes_view(_key), to_bytes_view(_val), del);
+                _sst->get_stats().on_row_read();
+                auto ret = _consumer.consume_row_start(key_view(to_bytes_view(_key)), del);
+                // after calling the consume function, we can release the
+                // buffers we held for it.
                 _key.release();
-                _val.release();
+                _state = state::ATOM_START;
+                if (ret == row_consumer::proceed::no) {
+                    co_yield row_consumer::proceed::no;
+                }
+            }
+            }
+            while (true) {
+                if (read_short_length_bytes(*_processing_data, _key) != read_status::ready) {
+                    _state = state::ATOM_START_2;
+                    co_yield row_consumer::proceed::yes;
+                }
+                if (_u16 == 0) {
+                    // end of row marker
+                    _state = state::ROW_START;
+                    co_yield _consumer.consume_row_end();
+                    break;
+                } else {
+                    _state = state::ATOM_MASK;
+                    co_yield row_consumer::proceed::yes;
+                }
+                if (read_8(*_processing_data) != read_status::ready) {
+                    _state = state::ATOM_MASK_2;
+                    co_yield row_consumer::proceed::yes;
+                }
+            {
+                auto const mask = column_mask(_u8);
+
+                if ((mask & (column_mask::range_tombstone | column_mask::shadowable)) != column_mask::none) {
+                    _state = state::RANGE_TOMBSTONE;
+                    _shadowable = (mask & column_mask::shadowable) != column_mask::none;
+                    if (read_short_length_bytes(*_processing_data, _val) != read_status::ready) {
+                        _state = state::RANGE_TOMBSTONE_2;
+                        co_yield row_consumer::proceed::yes;
+                    }
+                    if (read_32(*_processing_data) != read_status::ready) {
+                        _state = state::RANGE_TOMBSTONE_3;
+                        co_yield row_consumer::proceed::yes;
+                    }
+                    if (read_64(*_processing_data) != read_status::ready) {
+                        _state = state::RANGE_TOMBSTONE_4;
+                        co_yield row_consumer::proceed::yes;
+                    }
+                {
+                    _sst->get_stats().on_range_tombstone_read();
+                    deletion_time del;
+                    del.local_deletion_time = _u32;
+                    del.marked_for_delete_at = _u64;
+                    auto ret = _shadowable
+                            ? _consumer.consume_shadowable_row_tombstone(to_bytes_view(_key), del)
+                            : _consumer.consume_range_tombstone(to_bytes_view(_key), to_bytes_view(_val), del);
+                    _key.release();
+                    _val.release();
+                    _state = state::ATOM_START;
+                    co_yield ret;
+                    continue;
+                }
+                } else if ((mask & column_mask::counter) != column_mask::none) {
+                    _deleted = false;
+                    _counter = true;
+                    _state = state::COUNTER_CELL;
+                    if (read_64(*_processing_data) != read_status::ready) {
+                        _state = state::COUNTER_CELL_2;
+                        co_yield row_consumer::proceed::yes;
+                    }
+                    // _timestamp_of_last_deletion = _u64;
+                    _state = state::CELL;
+                } else if ((mask & column_mask::expiration) != column_mask::none) {
+                    _deleted = false;
+                    _counter = false;
+                    _state = state::EXPIRING_CELL;
+                    if (read_32(*_processing_data) != read_status::ready) {
+                        _state = state::EXPIRING_CELL_2;
+                        co_yield row_consumer::proceed::yes;
+                    }
+                    _ttl = _u32;
+                    if (read_32(*_processing_data) != read_status::ready) {
+                        _state = state::EXPIRING_CELL_3;
+                        co_yield row_consumer::proceed::yes;
+                    }
+                    _expiration = _u32;
+                    _state = state::CELL;
+                } else {
+                    // FIXME: see ColumnSerializer.java:deserializeColumnBody
+                    if ((mask & column_mask::counter_update) != column_mask::none) {
+                        throw malformed_sstable_exception("FIXME COUNTER_UPDATE_MASK");
+                    }
+                    _ttl = _expiration = 0;
+                    _deleted = (mask & column_mask::deletion) != column_mask::none;
+                    _counter = false;
+                    _state = state::CELL;
+                }
+            }
+            {
+                if (read_64(*_processing_data) != read_status::ready) {
+                    _state = state::CELL_2;
+                    co_yield row_consumer::proceed::yes;
+                }
+            }
+                if (read_32(*_processing_data) != read_status::ready) {
+                    _state = state::CELL_VALUE_BYTES;
+                    co_yield row_consumer::proceed::yes;
+                }
+                if (read_bytes(*_processing_data, _u32, _val_fragmented) != read_status::ready) {
+                    _state = state::CELL_VALUE_BYTES_2;
+                    co_yield row_consumer::proceed::yes;
+                }
+            {
+                row_consumer::proceed ret;
+                if (_deleted) {
+                    if (_val_fragmented.size_bytes() != 4) {
+                        throw malformed_sstable_exception("deleted cell expects local_deletion_time value");
+                    }
+                    _val = temporary_buffer<char>(4);
+                    auto v = fragmented_temporary_buffer::view(_val_fragmented);
+                    read_fragmented(v, 4, reinterpret_cast<bytes::value_type*>(_val.get_write()));
+                    deletion_time del;
+                    del.local_deletion_time = consume_be<uint32_t>(_val);
+                    del.marked_for_delete_at = _u64;
+                    ret = _consumer.consume_deleted_cell(to_bytes_view(_key), del);
+                    _val.release();
+                } else if (_counter) {
+                    ret = _consumer.consume_counter_cell(to_bytes_view(_key),
+                            fragmented_temporary_buffer::view(_val_fragmented), _u64);
+                } else {
+                    ret = _consumer.consume_cell(to_bytes_view(_key),
+                            fragmented_temporary_buffer::view(_val_fragmented), _u64, _ttl, _expiration);
+                }
+                // after calling the consume function, we can release the
+                // buffers we held for it.
+                _key.release();
+                _val_fragmented.remove_prefix(_val_fragmented.size_bytes());
                 _state = state::ATOM_START;
                 co_yield ret;
-                continue;
             }
-            } else if ((mask & column_mask::counter) != column_mask::none) {
-                _deleted = false;
-                _counter = true;
-                _state = state::COUNTER_CELL;
-                if (read_64(*_processing_data) != read_status::ready) {
-                    _state = state::COUNTER_CELL_2;
-                    co_yield row_consumer::proceed::yes;
-                }
-                // _timestamp_of_last_deletion = _u64;
-                _state = state::CELL;
-            } else if ((mask & column_mask::expiration) != column_mask::none) {
-                _deleted = false;
-                _counter = false;
-                _state = state::EXPIRING_CELL;
-                if (read_32(*_processing_data) != read_status::ready) {
-                    _state = state::EXPIRING_CELL_2;
-                    co_yield row_consumer::proceed::yes;
-                }
-                _ttl = _u32;
-                if (read_32(*_processing_data) != read_status::ready) {
-                    _state = state::EXPIRING_CELL_3;
-                    co_yield row_consumer::proceed::yes;
-                }
-                _expiration = _u32;
-                _state = state::CELL;
-            } else {
-                // FIXME: see ColumnSerializer.java:deserializeColumnBody
-                if ((mask & column_mask::counter_update) != column_mask::none) {
-                    throw malformed_sstable_exception("FIXME COUNTER_UPDATE_MASK");
-                }
-                _ttl = _expiration = 0;
-                _deleted = (mask & column_mask::deletion) != column_mask::none;
-                _counter = false;
-                _state = state::CELL;
             }
-        }
-        {
-            if (read_64(*_processing_data) != read_status::ready) {
-                _state = state::CELL_2;
-                co_yield row_consumer::proceed::yes;
-            }
-        }
-            if (read_32(*_processing_data) != read_status::ready) {
-                _state = state::CELL_VALUE_BYTES;
-                co_yield row_consumer::proceed::yes;
-            }
-            if (read_bytes(*_processing_data, _u32, _val_fragmented) != read_status::ready) {
-                _state = state::CELL_VALUE_BYTES_2;
-                co_yield row_consumer::proceed::yes;
-            }
-        {
-            row_consumer::proceed ret;
-            if (_deleted) {
-                if (_val_fragmented.size_bytes() != 4) {
-                    throw malformed_sstable_exception("deleted cell expects local_deletion_time value");
-                }
-                _val = temporary_buffer<char>(4);
-                auto v = fragmented_temporary_buffer::view(_val_fragmented);
-                read_fragmented(v, 4, reinterpret_cast<bytes::value_type*>(_val.get_write()));
-                deletion_time del;
-                del.local_deletion_time = consume_be<uint32_t>(_val);
-                del.marked_for_delete_at = _u64;
-                ret = _consumer.consume_deleted_cell(to_bytes_view(_key), del);
-                _val.release();
-            } else if (_counter) {
-                ret = _consumer.consume_counter_cell(to_bytes_view(_key),
-                        fragmented_temporary_buffer::view(_val_fragmented), _u64);
-            } else {
-                ret = _consumer.consume_cell(to_bytes_view(_key),
-                        fragmented_temporary_buffer::view(_val_fragmented), _u64, _ttl, _expiration);
-            }
-            // after calling the consume function, we can release the
-            // buffers we held for it.
-            _key.release();
-            _val_fragmented.remove_prefix(_val_fragmented.size_bytes());
-            _state = state::ATOM_START;
-            co_yield ret;
-        }
-        }
         }
     }
 public:

--- a/sstables/kl/reader_impl.hh
+++ b/sstables/kl/reader_impl.hh
@@ -155,7 +155,6 @@ private:
         RANGE_TOMBSTONE_2,
         RANGE_TOMBSTONE_3,
         RANGE_TOMBSTONE_4,
-        STOP_THEN_ATOM_START,
     } _state = state::ROW_START;
 
     row_consumer& _consumer;
@@ -181,7 +180,6 @@ public:
                 || (_state == state::CELL_VALUE_BYTES_2)
                 || (_state == state::ATOM_START_2)
                 || (_state == state::ATOM_MASK_2)
-                || (_state == state::STOP_THEN_ATOM_START)
                 || (_state == state::COUNTER_CELL_2)
                 || (_state == state::RANGE_TOMBSTONE_4)
                 || (_state == state::EXPIRING_CELL_3)));
@@ -409,10 +407,6 @@ private:
             }
             break;
         }
-        case state::STOP_THEN_ATOM_START:
-            _state = state::ATOM_START;
-            co_yield row_consumer::proceed::no;
-            continue;
         }
 
         co_yield row_consumer::proceed::yes;

--- a/sstables/mx/reader.cc
+++ b/sstables/mx/reader.cc
@@ -513,7 +513,7 @@ private:
                 co_yield skip(*_processing_data, _next_row_offset - current_pos);
                 goto flags_label;
             }
-
+          }
             if (_extended_flags.is_static()) {
                 if (_flags.has_timestamp() || _flags.has_ttl() || _flags.has_deletion()) {
                     throw malformed_sstable_exception(format("Static row has unexpected flags: timestamp={}, ttl={}, deletion={}",
@@ -523,29 +523,28 @@ private:
             }
             if (!_flags.has_timestamp()) {
                 _state = state::ROW_BODY_DELETION;
-                goto row_body_deletion_label;
+            } else {
+                if (read_unsigned_vint(*_processing_data) != read_status::ready) {
+                    _state = state::ROW_BODY_TIMESTAMP;
+                    co_yield consumer_m::proceed::yes;
+                }
+
+                _liveness.set_timestamp(parse_timestamp(_header, _u64));
+                if (!_flags.has_ttl()) {
+                    _state = state::ROW_BODY_DELETION;
+                } else {
+                    if (read_unsigned_vint(*_processing_data) != read_status::ready) {
+                        _state = state::ROW_BODY_TIMESTAMP_TTL;
+                        co_yield consumer_m::proceed::yes;
+                    }
+                    _liveness.set_ttl(parse_ttl(_header, _u64));
+                    if (read_unsigned_vint(*_processing_data) != read_status::ready) {
+                        _state = state::ROW_BODY_TIMESTAMP_DELTIME;
+                        co_yield consumer_m::proceed::yes;
+                    }
+                    _liveness.set_local_deletion_time(parse_expiry(_header, _u64));
+                }
             }
-            if (read_unsigned_vint(*_processing_data) != read_status::ready) {
-                _state = state::ROW_BODY_TIMESTAMP;
-                co_yield consumer_m::proceed::yes;
-            }
-          }
-            _liveness.set_timestamp(parse_timestamp(_header, _u64));
-            if (!_flags.has_ttl()) {
-                _state = state::ROW_BODY_DELETION;
-                goto row_body_deletion_label;
-            }
-            if (read_unsigned_vint(*_processing_data) != read_status::ready) {
-                _state = state::ROW_BODY_TIMESTAMP_TTL;
-                co_yield consumer_m::proceed::yes;
-            }
-            _liveness.set_ttl(parse_ttl(_header, _u64));
-            if (read_unsigned_vint(*_processing_data) != read_status::ready) {
-                _state = state::ROW_BODY_TIMESTAMP_DELTIME;
-                co_yield consumer_m::proceed::yes;
-            }
-            _liveness.set_local_deletion_time(parse_expiry(_header, _u64));
-        row_body_deletion_label:
             if (!_flags.has_deletion()) {
                 _state = state::ROW_BODY_SHADOWABLE_DELETION;
             } else {

--- a/sstables/mx/reader.cc
+++ b/sstables/mx/reader.cc
@@ -452,14 +452,14 @@ private:
             }
             if (!should_read_block_header()) {
                 _state = state::CK_BLOCK2;
-                goto ck_block2_label;
+            } else {
+                if (read_unsigned_vint(*_processing_data) != read_status::ready) {
+                    _state = state::CK_BLOCK_HEADER;
+                    co_yield consumer_m::proceed::yes;
+                }
+                _ck_blocks_header = _u64;
             }
-            if (read_unsigned_vint(*_processing_data) != read_status::ready) {
-                _state = state::CK_BLOCK_HEADER;
-                co_yield consumer_m::proceed::yes;
-            }
-            _ck_blocks_header = _u64;
-        ck_block2_label: {
+        {
             if (is_block_null()) {
                 _null_component_occured = true;
                 move_to_next_ck_block();

--- a/sstables/mx/reader.cc
+++ b/sstables/mx/reader.cc
@@ -674,14 +674,13 @@ private:
             if (_column_flags.use_row_timestamp()) {
                 _column_timestamp = _liveness.timestamp();
                 _state = state::COLUMN_DELETION_TIME;
-                goto column_deletion_time_label;
+            } else {
+                if (read_unsigned_vint(*_processing_data) != read_status::ready) {
+                    _state = state::COLUMN_TIMESTAMP;
+                    co_yield consumer_m::proceed::yes;
+                }
+                _column_timestamp = parse_timestamp(_header, _u64);
             }
-            if (read_unsigned_vint(*_processing_data) != read_status::ready) {
-                _state = state::COLUMN_TIMESTAMP;
-                co_yield consumer_m::proceed::yes;
-            }
-            _column_timestamp = parse_timestamp(_header, _u64);
-        column_deletion_time_label:
             if (_column_flags.use_row_ttl()) {
                 _column_local_deletion_time = _liveness.local_deletion_time();
                 _state = state::COLUMN_TTL;

--- a/sstables/mx/reader.cc
+++ b/sstables/mx/reader.cc
@@ -505,7 +505,7 @@ private:
                     if (_subcolumns_to_read == 0) {
                         const sstables::column_translation::column_info& column_info = get_column_info();
                         move_to_next_column();
-                        if (_consumer.consume_complex_column_end(column_info) != consumer_m::proceed::yes) {
+                        if (_consumer.consume_complex_column_end(column_info) == consumer_m::proceed::no) {
                             _consuming = false;
                             co_yield consumer_m::proceed::no;
                             _consuming = true;
@@ -579,7 +579,7 @@ private:
                 if (_subcolumns_to_read == 0) {
                     const sstables::column_translation::column_info& column_info = get_column_info();
                     move_to_next_column();
-                    if (_consumer.consume_complex_column_end(column_info) != consumer_m::proceed::yes) {
+                    if (_consumer.consume_complex_column_end(column_info) == consumer_m::proceed::no) {
                         co_yield consumer_m::proceed::no;
                     }
                 }

--- a/sstables/mx/reader.cc
+++ b/sstables/mx/reader.cc
@@ -607,18 +607,15 @@ private:
                     _row->_columns_selector.set();
                 }
             }
-            row_body_missing_columns_read_columns_label:
-                if (_missing_columns_to_read == 0) {
-                    skip_absent_columns();
-                    goto column_label;
+                while (_missing_columns_to_read > 0) {
+                    --_missing_columns_to_read;
+                    if (read_unsigned_vint(*_processing_data) != read_status::ready) {
+                        _state = state::ROW_BODY_MISSING_COLUMNS_READ_COLUMNS_2;
+                        co_yield consumer_m::proceed::yes;
+                    }
+                    _row->_columns_selector.flip(_u64);
                 }
-                --_missing_columns_to_read;
-                if (read_unsigned_vint(*_processing_data) != read_status::ready) {
-                    _state = state::ROW_BODY_MISSING_COLUMNS_READ_COLUMNS_2;
-                    co_yield consumer_m::proceed::yes;
-                }
-                _row->_columns_selector.flip(_u64);
-                goto row_body_missing_columns_read_columns_label;
+                skip_absent_columns();
             } else {
                 _row->_columns_selector.set();
             }

--- a/sstables/mx/reader.cc
+++ b/sstables/mx/reader.cc
@@ -133,7 +133,6 @@ private:
         PARTITION_START,
         DELETION_TIME,
         FLAGS,
-        FLAGS_2,
         OTHER,
     } _state = state::PARTITION_START;
 
@@ -314,7 +313,6 @@ private:
             _row_tombstone = {};
             _row_shadowable_tombstone = {};
             if (read_8(*_processing_data) != read_status::ready) {
-                _state = state::FLAGS_2;
                 co_yield consumer_m::proceed::yes;
             }
             _flags = unfiltered_flags_m(_u8);
@@ -668,11 +666,11 @@ private:
                         format("Corrupted range tombstone: invalid boundary type {}", _range_tombstone_kind));
                 }
                 _sst->get_stats().on_range_tombstone_read();
+                _state = state::FLAGS;
                 if (_consumer.consume_range_tombstone(_row_key,
                                                       to_bound_kind(_range_tombstone_kind),
                                                       _left_range_tombstone) == consumer_m::proceed::no) {
                     _row_key.clear();
-                    _state = state::FLAGS;
                     co_yield consumer_m::proceed::no;
                 }
                 _row_key.clear();
@@ -687,12 +685,12 @@ private:
             }
             _sst->get_stats().on_range_tombstone_read();
             _right_range_tombstone.deletion_time = parse_expiry(_header, _u64);
+            _state = state::FLAGS;
             if (_consumer.consume_range_tombstone(_row_key,
                                                   _range_tombstone_kind,
                                                   _left_range_tombstone,
                                                   _right_range_tombstone) == consumer_m::proceed::no) {
                 _row_key.clear();
-                _state = state::FLAGS;
                 co_yield consumer_m::proceed::no;
             }
             _row_key.clear();
@@ -720,9 +718,9 @@ public:
 
     void verify_end_state() {
         // If reading a partial row (i.e., when we have a clustering row
-        // filter and using a promoted index), we may be in FLAGS or FLAGS_2
+        // filter and using a promoted index), we may be in FLAGS
         // state instead of PARTITION_START.
-        if (_state == state::FLAGS || _state == state::FLAGS_2) {
+        if (_state == state::FLAGS) {
             _consumer.on_end_of_stream();
             return;
         }

--- a/sstables/mx/reader.cc
+++ b/sstables/mx/reader.cc
@@ -429,7 +429,10 @@ private:
             if (ret == consumer_m::row_processing_result::skip_row) {
                 _state = state::FLAGS;
                 auto current_pos = position() - _processing_data->size();
-                co_yield skip(*_processing_data, _next_row_offset - current_pos);
+                auto maybe_skip_bytes = skip(*_processing_data, _next_row_offset - current_pos);
+                if (std::holds_alternative<skip_bytes>(maybe_skip_bytes)) {
+                    co_yield maybe_skip_bytes;
+                }
                 goto flags_label;
             }
           }

--- a/sstables/mx/reader.cc
+++ b/sstables/mx/reader.cc
@@ -282,14 +282,13 @@ private:
         if (_state != state::PARTITION_START) {
             goto flags_label;
         }
-        partition_start_label:
+        partition_start_label: {
             _is_first_unfiltered = true;
             _state = state::DELETION_TIME;
             co_yield read_short_length_bytes(*_processing_data, _pk);
             _state = state::OTHER;
             co_yield read_32(*_processing_data);
             co_yield read_64(*_processing_data);
-        {
             deletion_time del;
             del.local_deletion_time = _u32;
             del.marked_for_delete_at = _u64;
@@ -359,7 +358,6 @@ private:
                     co_yield read_unsigned_vint(*_processing_data);
                     _ck_blocks_header = _u64;
                 }
-            {
                 if (is_block_null()) {
                     _null_component_occured = true;
                     move_to_next_ck_block();
@@ -380,7 +378,6 @@ private:
                     status = read_unsigned_vint_length_bytes(*_processing_data, _column_value);
                 }
                 co_yield status;
-            }
                 _row_key.push_back(std::move(_column_value));
                 move_to_next_ck_block();
             }
@@ -388,11 +385,10 @@ private:
                 _reading_range_tombstone_ck = false;
                 goto range_tombstone_body_label;
             }
-        row_body_label:
+        row_body_label: {
             co_yield read_unsigned_vint(*_processing_data);
             _next_row_offset = position() - _processing_data->size() + _u64;
             co_yield read_unsigned_vint(*_processing_data);
-          {
             // Ignore the result
             consumer_m::row_processing_result ret = _extended_flags.is_static()
                 ? _consumer.consume_static_row_start()
@@ -413,7 +409,6 @@ private:
                 }
                 goto flags_label;
             }
-          }
             if (_extended_flags.is_static()) {
                 if (_flags.has_timestamp() || _flags.has_ttl() || _flags.has_deletion()) {
                     throw malformed_sstable_exception(format("Static row has unexpected flags: timestamp={}, ttl={}, deletion={}",
@@ -451,7 +446,6 @@ private:
             }
             if (!_flags.has_all_columns()) {
                 co_yield read_unsigned_vint(*_processing_data);
-            {
                 uint64_t missing_column_bitmap_or_count = _u64;
                 if (_row->_columns.size() < 64) {
                     _row->_columns_selector.clear();
@@ -469,7 +463,6 @@ private:
                     _missing_columns_to_read = missing_column_bitmap_or_count;
                     _row->_columns_selector.set();
                 }
-            }
                 while (_missing_columns_to_read > 0) {
                     --_missing_columns_to_read;
                     co_yield read_unsigned_vint(*_processing_data);
@@ -479,6 +472,7 @@ private:
             } else {
                 _row->_columns_selector.set();
             }
+        }
         column_label:
             if (_subcolumns_to_read == 0) {
                 if (no_more_columns()) {

--- a/sstables/mx/reader.cc
+++ b/sstables/mx/reader.cc
@@ -575,11 +575,8 @@ private:
                 } else {
                     _state = state::ROW_BODY_MARKER;
                 }
-                if (_consumer.consume_row_marker_and_tombstone(
-                        _liveness, std::move(_row_tombstone), std::move(_row_shadowable_tombstone)) == consumer_m::proceed::no) {
-                    _state = state::ROW_BODY_MISSING_COLUMNS;
-                    co_yield consumer_m::proceed::yes;
-                }
+                _consumer.consume_row_marker_and_tombstone(
+                        _liveness, std::move(_row_tombstone), std::move(_row_shadowable_tombstone));
             }
             if (!_flags.has_all_columns()) {
                 if (read_unsigned_vint(*_processing_data) != read_status::ready) {

--- a/sstables/processing_result_generator.hh
+++ b/sstables/processing_result_generator.hh
@@ -1,0 +1,113 @@
+/*
+ * Copyright (C) 2021 ScyllaDB
+ */
+
+/*
+ * This file is part of Scylla.
+ *
+ * Scylla is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Scylla is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <seastar/core/coroutine.hh>
+#include "sstables/consumer.hh"
+
+/* To construct an processing_result_generator object, you need a function that is a coroutine (uses co_yield)
+ * and has return type of this class. The execution of the coroutine can be then controlled using this class.
+ * To execute a fragment of the coroutine that ends at an co_yield, and get the yielded value use generate().
+ * Each subsequent generate() call starts after the last co_yield and continues until another one is encountered.
+ *
+ * Explanation of C++ coroutines below:
+ * A "co_yield val" call is equivalent to "co_await yield_value(val)". In yield_value we save the value in
+ * "current_value", and it returns a suspend_always object, causing the coroutine to return to the caller after
+ * each co_yield.
+ * The await_transform() method is deleted, so we don't use co_await directly without yielding any value.
+ * The unhandled_exception() method is called when an unhandled exception is detected in the coroutine. We
+ * save it to a local variable, and check it in our generate() calls.
+ */
+class processing_result_generator {
+public:
+    struct promise_type {
+        using handle_type = std::experimental::coroutine_handle<promise_type>;
+        processing_result_generator get_return_object() {
+            return processing_result_generator{handle_type::from_promise(*this)};
+        }
+        // the coroutine doesn't start running until the first handle::resume() call
+        static std::experimental::suspend_always initial_suspend() noexcept {
+            return {};
+        }
+        static std::experimental::suspend_always final_suspend() noexcept {
+            return {};
+        }
+        std::experimental::suspend_always yield_value(data_consumer::processing_result value) noexcept {
+            current_value = std::move(value);
+            return {};
+        }
+        // Disallow co_await in generator coroutines.
+        void await_transform() = delete;
+
+        void unhandled_exception() {
+            caught_exception = std::current_exception();
+        }
+        void return_void() noexcept {}
+
+        data_consumer::processing_result current_value;
+        std::exception_ptr caught_exception;
+    };
+private:
+    std::experimental::coroutine_handle<promise_type> m_coroutine;
+public:
+    explicit processing_result_generator(const std::experimental::coroutine_handle<promise_type> coroutine) :
+        m_coroutine{coroutine}
+    {}
+
+    processing_result_generator() = default;
+    ~processing_result_generator() {
+        if (m_coroutine) {
+            m_coroutine.destroy();
+        }
+    }
+
+    processing_result_generator(const processing_result_generator&) = delete;
+    processing_result_generator& operator=(const processing_result_generator&) = delete;
+
+    processing_result_generator(processing_result_generator&& other) noexcept :
+        m_coroutine{other.m_coroutine}
+    {
+        other.m_coroutine = {};
+    }
+    processing_result_generator& operator=(processing_result_generator&& other) noexcept {
+        if (this != &other) {
+            if (m_coroutine) {
+                m_coroutine.destroy();
+            }
+            m_coroutine = other.m_coroutine;
+            other.m_coroutine = {};
+        }
+        return *this;
+    }
+    data_consumer::processing_result generate() {
+        m_coroutine();
+        if (m_coroutine.promise().caught_exception) {
+            std::rethrow_exception(m_coroutine.promise().caught_exception);
+        }
+        return m_coroutine.promise().current_value;
+    }
+};
+
+template<typename... Args>
+struct std::experimental::coroutine_traits<processing_result_generator, Args...> {
+    using promise_type = processing_result_generator::promise_type;
+};


### PR DESCRIPTION
This patch simplifies the sstable reader by getting rid of the state that we needed to remember in the sstable reader and running in a coroutine instead(as suggested in #7952).
I'm posting the RFC mainly to get an opinion on the synchronization approach that was used, I still need to fix the style of the patch, and add the same change for mx sstables reader.
We've decided with @haaawk that instead of filling a queue, and waiting for `fill_buffer()` to move `mutation_fragments` from the queue to the buffer, we can limit the `mutation_fragments` generation to the `fill_buffer()` duration, when we can skip the queue altogether and fill the buffer directly.
We're reading and consuming the sstable in a coroutine `producer_main()`, in which we wait on a semaphore for a `fill_buffer()` call. In the producer coroutine we wait for buffers from the sstable input_stream, and after consuming enough, we wait on the semaphore again, resuming caller of fill_buffer. The errors thrown in the coroutine are returned through the semaphore using broken().
This change does not improve the efficiency of sstable reading, but after some more style improvements, it should make following the production easier