### PR TITLE
cql3: represent lists as chunked_vector instead of std::vector

### DIFF
--- a/cql3/column_condition.cc
+++ b/cql3/column_condition.cc
@@ -262,7 +262,7 @@ bool column_condition::applies_to(const data_value* cell_value, const query_opti
         if (!lval) {
             throw exceptions::invalid_request_exception("Invalid null value for IN condition");
         }
-        for (const managed_bytes_opt& v : lval->get_elements()) {
+        for (const managed_bytes_opt& v : lval->copy_elements()) {
             if (v) {
                 in_values.push_back(to_bytes(*v));
             } else {

--- a/cql3/lists.cc
+++ b/cql3/lists.cc
@@ -179,6 +179,11 @@ lists::value::get_elements() const {
     return _elements;
 }
 
+std::vector<managed_bytes_opt>
+lists::value::copy_elements() const {
+    return _elements;
+}
+
 sstring
 lists::value::to_string() const {
     std::ostringstream os;

--- a/cql3/lists.hh
+++ b/cql3/lists.hh
@@ -44,6 +44,7 @@
 #include "cql3/abstract_marker.hh"
 #include "to_string.hh"
 #include "operation.hh"
+#include "utils/chunked_vector.hh"
 
 namespace cql3 {
 
@@ -73,16 +74,16 @@ public:
 
     class value : public multi_item_terminal, collection_terminal {
     public:
-        std::vector<managed_bytes_opt> _elements;
+        utils::chunked_vector<managed_bytes_opt> _elements;
     public:
-        explicit value(std::vector<managed_bytes_opt> elements)
+        explicit value(utils::chunked_vector<managed_bytes_opt> elements)
             : _elements(std::move(elements)) {
         }
         static value from_serialized(const raw_value_view& v, const list_type_impl& type, cql_serialization_format sf);
         virtual cql3::raw_value get(const query_options& options) override;
         virtual managed_bytes get_with_protocol_version(cql_serialization_format sf) override;
         bool equals(const list_type_impl& lt, const value& v);
-        const std::vector<managed_bytes_opt>& get_elements() const;
+        const utils::chunked_vector<managed_bytes_opt>& get_elements() const;
         virtual std::vector<managed_bytes_opt> copy_elements() const override;
         virtual sstring to_string() const;
         friend class lists;

--- a/cql3/lists.hh
+++ b/cql3/lists.hh
@@ -82,7 +82,8 @@ public:
         virtual cql3::raw_value get(const query_options& options) override;
         virtual managed_bytes get_with_protocol_version(cql_serialization_format sf) override;
         bool equals(const list_type_impl& lt, const value& v);
-        virtual const std::vector<managed_bytes_opt>& get_elements() const override;
+        const std::vector<managed_bytes_opt>& get_elements() const;
+        virtual std::vector<managed_bytes_opt> copy_elements() const override;
         virtual sstring to_string() const;
         friend class lists;
     };

--- a/cql3/restrictions/multi_column_restriction.hh
+++ b/cql3/restrictions/multi_column_restriction.hh
@@ -315,7 +315,7 @@ public:
     }
 #endif
 protected:
-    virtual std::vector<std::vector<managed_bytes_opt>> split_values(const query_options& options) const = 0;
+    virtual utils::chunked_vector<std::vector<managed_bytes_opt>> split_values(const query_options& options) const = 0;
 };
 
 /**
@@ -338,8 +338,8 @@ public:
     }
 
 protected:
-    virtual std::vector<std::vector<managed_bytes_opt>> split_values(const query_options& options) const override {
-        std::vector<std::vector<managed_bytes_opt>> buffers(_values.size());
+    virtual utils::chunked_vector<std::vector<managed_bytes_opt>> split_values(const query_options& options) const override {
+        utils::chunked_vector<std::vector<managed_bytes_opt>> buffers(_values.size());
         std::transform(_values.begin(), _values.end(), buffers.begin(), [&] (const ::shared_ptr<term>& value) {
             auto term = static_pointer_cast<multi_item_terminal>(value->bind(options));
             return term->copy_elements();
@@ -367,7 +367,7 @@ public:
     }
 
 protected:
-    virtual std::vector<std::vector<managed_bytes_opt>> split_values(const query_options& options) const override {
+    virtual utils::chunked_vector<std::vector<managed_bytes_opt>> split_values(const query_options& options) const override {
         auto in_marker = static_pointer_cast<tuples::in_marker>(_marker);
         auto in_value = static_pointer_cast<tuples::in_value>(in_marker->bind(options));
         statements::request_validations::check_not_null(in_value, "Invalid null value for IN restriction");

--- a/cql3/restrictions/multi_column_restriction.hh
+++ b/cql3/restrictions/multi_column_restriction.hh
@@ -342,7 +342,7 @@ protected:
         std::vector<std::vector<managed_bytes_opt>> buffers(_values.size());
         std::transform(_values.begin(), _values.end(), buffers.begin(), [&] (const ::shared_ptr<term>& value) {
             auto term = static_pointer_cast<multi_item_terminal>(value->bind(options));
-            return term->get_elements();
+            return term->copy_elements();
         });
         return buffers;
     }

--- a/cql3/sets.cc
+++ b/cql3/sets.cc
@@ -137,7 +137,7 @@ sets::value::from_serialized(const raw_value_view& val, const set_type_impl& typ
     try {
         std::set<managed_bytes, serialized_compare> elements(type.get_elements_type()->as_less_comparator());
         if (sf.collection_format_unchanged()) {
-            std::vector<managed_bytes> tmp = val.with_value([sf] (const FragmentedView auto& v) {
+            utils::chunked_vector<managed_bytes> tmp = val.with_value([sf] (const FragmentedView auto& v) {
                 return partially_deserialize_listlike(v, sf);
             });
             for (auto&& element : tmp) {

--- a/cql3/term.hh
+++ b/cql3/term.hh
@@ -192,7 +192,7 @@ public:
 
 class multi_item_terminal : public terminal {
 public:
-    virtual const std::vector<managed_bytes_opt>& get_elements() const = 0;
+    virtual std::vector<managed_bytes_opt> copy_elements() const = 0;
 };
 
 class collection_terminal {

--- a/cql3/tuples.cc
+++ b/cql3/tuples.cc
@@ -89,7 +89,7 @@ tuples::in_value::from_serialized(const raw_value_view& value_view, const list_t
         auto ttype = dynamic_pointer_cast<const tuple_type_impl>(type.get_elements_type());
         assert(ttype);
 
-        std::vector<std::vector<managed_bytes_opt>> elements;
+        utils::chunked_vector<std::vector<managed_bytes_opt>> elements;
         elements.reserve(l.size());
         for (auto&& e : l) {
             // FIXME: Avoid useless copies.

--- a/cql3/tuples.hh
+++ b/cql3/tuples.hh
@@ -43,6 +43,7 @@
 #include "abstract_marker.hh"
 #include "types/tuple.hh"
 #include "types/collection.hh"
+#include "utils/chunked_vector.hh"
 
 class list_type_impl;
 
@@ -198,9 +199,9 @@ public:
      */
     class in_value : public terminal {
     private:
-        std::vector<std::vector<managed_bytes_opt>> _elements;
+        utils::chunked_vector<std::vector<managed_bytes_opt>> _elements;
     public:
-        in_value(std::vector<std::vector<managed_bytes_opt>> items) : _elements(std::move(items)) { }
+        in_value(utils::chunked_vector<std::vector<managed_bytes_opt>> items) : _elements(std::move(items)) { }
 
         static in_value from_serialized(const raw_value_view& value_view, const list_type_impl& type, const query_options& options);
 
@@ -208,7 +209,7 @@ public:
             throw exceptions::unsupported_operation_exception();
         }
 
-        std::vector<std::vector<managed_bytes_opt>> get_split_values() const {
+        utils::chunked_vector<std::vector<managed_bytes_opt>> get_split_values() const {
             return _elements;
         }
 

--- a/cql3/tuples.hh
+++ b/cql3/tuples.hh
@@ -122,7 +122,10 @@ public:
             return cql3::raw_value::make_value(tuple_type_impl::build_value_fragmented(_elements));
         }
 
-        virtual const std::vector<managed_bytes_opt>& get_elements() const override {
+        const std::vector<managed_bytes_opt>& get_elements() const {
+            return _elements;
+        }
+        virtual std::vector<managed_bytes_opt> copy_elements() const override {
             return _elements;
         }
         size_t size() const {

--- a/cql3/user_types.cc
+++ b/cql3/user_types.cc
@@ -170,6 +170,10 @@ const std::vector<managed_bytes_opt>& user_types::value::get_elements() const {
     return _elements;
 }
 
+std::vector<managed_bytes_opt> user_types::value::copy_elements() const {
+    return _elements;
+}
+
 sstring user_types::value::to_string() const {
     return format("({})", join(", ", _elements));
 }
@@ -263,7 +267,7 @@ void user_types::setter::execute(mutation& m, const clustering_key_prefix& row_k
         mut.tomb = params.make_tombstone_just_before();
 
         if (value) {
-            auto ut_value = static_pointer_cast<multi_item_terminal>(value);
+            auto ut_value = static_pointer_cast<user_types::value>(value);
 
             const auto& elems = ut_value->get_elements();
             // There might be fewer elements given than fields in the type

--- a/cql3/user_types.hh
+++ b/cql3/user_types.hh
@@ -81,7 +81,8 @@ public:
         static value from_serialized(const raw_value_view&, const user_type_impl&);
 
         virtual cql3::raw_value get(const query_options&) override;
-        virtual const std::vector<managed_bytes_opt>& get_elements() const override;
+        const std::vector<managed_bytes_opt>& get_elements() const;
+        virtual std::vector<managed_bytes_opt> copy_elements() const override;
         virtual sstring to_string() const override;
     };
 

--- a/types.cc
+++ b/types.cc
@@ -1345,17 +1345,17 @@ set_type_impl::serialize_partially_deserialized_form_fragmented(
 }
 
 template <FragmentedView View>
-std::vector<managed_bytes> partially_deserialize_listlike(View in, cql_serialization_format sf) {
+utils::chunked_vector<managed_bytes> partially_deserialize_listlike(View in, cql_serialization_format sf) {
     auto nr = read_collection_size(in, sf);
-    std::vector<managed_bytes> elements;
+    utils::chunked_vector<managed_bytes> elements;
     elements.reserve(nr);
     for (int i = 0; i != nr; ++i) {
         elements.emplace_back(read_collection_value(in, sf));
     }
     return elements;
 }
-template std::vector<managed_bytes> partially_deserialize_listlike(managed_bytes_view in, cql_serialization_format sf);
-template std::vector<managed_bytes> partially_deserialize_listlike(fragmented_temporary_buffer::view in, cql_serialization_format sf);
+template utils::chunked_vector<managed_bytes> partially_deserialize_listlike(managed_bytes_view in, cql_serialization_format sf);
+template utils::chunked_vector<managed_bytes> partially_deserialize_listlike(fragmented_temporary_buffer::view in, cql_serialization_format sf);
 
 template <FragmentedView View>
 std::vector<std::pair<managed_bytes, managed_bytes>> partially_deserialize_map(View in, cql_serialization_format sf) {

--- a/types.hh
+++ b/types.hh
@@ -51,6 +51,7 @@
 #include "utils/exceptions.hh"
 #include "utils/managed_bytes.hh"
 #include "utils/bit_cast.hh"
+#include "utils/chunked_vector.hh"
 
 class tuple_type_impl;
 class big_decimal;
@@ -1223,7 +1224,7 @@ void write_collection_value(managed_bytes_mutable_view&, cql_serialization_forma
 // Splits a serialized collection into a vector of elements, but does not recursively deserialize the elements.
 // Does not perform validation.
 template <FragmentedView View>
-std::vector<managed_bytes> partially_deserialize_listlike(View in, cql_serialization_format sf);
+utils::chunked_vector<managed_bytes> partially_deserialize_listlike(View in, cql_serialization_format sf);
 template <FragmentedView View>
 std::vector<std::pair<managed_bytes, managed_bytes>> partially_deserialize_map(View in, cql_serialization_format sf);
 


### PR DESCRIPTION
The cql3 layer manipulates lists as `std::vector`s (of `managed_bytes_opt`). Since lists can be arbitrarily large, let's use chunked vectors there to prevent potentially large contiguous allocations.