### PR TITLE
compaction_manager: only start concurrent compactions when fan-in increases

### DIFF
--- a/sstables/compaction.cc
+++ b/sstables/compaction.cc
@@ -515,6 +515,7 @@ protected:
         _info->run_identifier = _run_identifier;
         _info->cf = &cf;
         _info->compaction_uuid = utils::UUID_gen::get_time_UUID();
+        _info->fan_in = descriptor.fan_in();
         for (auto& sst : _sstables) {
             _stats_collector.update(sst->get_encoding_stats_for_compaction());
         }
@@ -1650,6 +1651,11 @@ get_fully_expired_sstables(column_family& cf, const std::vector<sstables::shared
         }
     }
     return candidates;
+}
+
+unsigned
+compaction_descriptor::fan_in() const {
+    return sstables.size();
 }
 
 }

--- a/sstables/compaction.hh
+++ b/sstables/compaction.hh
@@ -74,6 +74,7 @@ namespace sstables {
             const std::vector<shared_sstable> added;
         };
         std::vector<replacement> pending_replacements;
+        unsigned fan_in = 0;
 
         bool is_stop_requested() const {
             return stop_requested.size() > 0;

--- a/sstables/compaction_descriptor.hh
+++ b/sstables/compaction_descriptor.hh
@@ -155,6 +155,8 @@ struct compaction_descriptor {
 
     ::io_priority_class io_priority = default_priority_class();
 
+    unsigned fan_in() const;
+
     compaction_descriptor() = default;
 
     static constexpr int default_level = 0;

--- a/sstables/compaction_manager.hh
+++ b/sstables/compaction_manager.hh
@@ -123,7 +123,7 @@ private:
     future<> task_stop(lw_shared_ptr<task> task);
 
     // Return true if weight is not registered.
-    bool can_register_weight(column_family* cf, int weight) const;
+    bool can_register_weight(column_family* cf, int weight, unsigned fan_in) const;
     // Register weight for a column family. Do that only if can_register_weight()
     // returned true.
     void register_weight(int weight);
@@ -246,6 +246,8 @@ public:
     const std::list<lw_shared_ptr<sstables::compaction_info>>& get_compactions() const {
         return _compactions;
     }
+
+    unsigned current_fan_in_threshold() const;
 
     // Returns true if table has an ongoing compaction, running on its behalf
     bool has_table_ongoing_compaction(column_family* cf) const {


### PR DESCRIPTION
Under default configuration, as soon as we have two similar-sized
sstables we can start compacting them. This is great for reducing
read amplification in a system under light write load, but it also
increases write amplification under heavy write load.

To reduce this write amplification, only admit new compactions if
they have higher fan-in than all current compactions. If the system
is incurring backlog, then the fan-in will increase until compactions
with retire with fan in at exactly the rate that compactions with the
same fan-in arrive. When write load reduces, the fan-in threshold
will reduce too.

This effectively trades write amplification against efficiency,
trying to self-tune by looking at the current fan-in as a measure
of backlog.