### PR TITLE
Enable -Wunused-private-field warning

### DIFF
--- a/auth/resource.cc
+++ b/auth/resource.cc
@@ -185,8 +185,7 @@ std::ostream& operator<<(std::ostream& os, const resource& r) {
     return os;
 }
 
-service_level_resource_view::service_level_resource_view(const resource &r) :
-    _resource(r) {
+service_level_resource_view::service_level_resource_view(const resource &r) {
     if (r._kind != resource_kind::service_level) {
         throw resource_kind_mismatch(resource_kind::service_level, r._kind);
     }

--- a/auth/resource.hh
+++ b/auth/resource.hh
@@ -203,8 +203,6 @@ std::ostream& operator<<(std::ostream&, const role_resource_view&);
 /// A "service_level" view of \ref resource.
 ///
 class service_level_resource_view final {
-    const resource& _resource;
-
 public:
     ///
     /// \throws \ref resource_kind_mismatch if the argument is not a "service_level" resource.

--- a/configure.py
+++ b/configure.py
@@ -1286,7 +1286,6 @@ warnings = [
     '-Wno-redundant-move',
     '-Wno-gnu-designator',
     '-Wno-instantiation-after-specialization',
-    '-Wno-unused-private-field',
     '-Wno-unsupported-friend',
     '-Wno-unused-variable',
     '-Wno-return-std-move',

--- a/cql3/authorized_prepared_statements_cache.hh
+++ b/cql3/authorized_prepared_statements_cache.hh
@@ -106,7 +106,6 @@ public:
 
 private:
     cache_type _cache;
-    logging::logger& _logger;
 
 public:
     // Choose the memory budget such that would allow us ~4K entries when a shard gets 1GB of RAM
@@ -115,7 +114,6 @@ public:
             _cache.remove(k);
             return make_ready_future<value_type>();
         })
-        , _logger(logger)
     {}
 
     future<> insert(auth::authenticated_user user, cql3::prepared_cache_key_type prep_cache_key, value_type v) noexcept {

--- a/cql3/statements/update_statement.cc
+++ b/cql3/statements/update_statement.cc
@@ -360,6 +360,8 @@ insert_json_statement::insert_json_statement(cf_name name,
 insert_json_statement::prepare_internal(database& db, schema_ptr schema,
     variable_specifications& bound_names, std::unique_ptr<attributes> attrs, cql_stats& stats) const
 {
+    // FIXME: handle _if_not_exists. For now, mark it used to quiet the compiler. #8682
+    (void)_if_not_exists;
     assert(dynamic_pointer_cast<constants::literal>(_json_value) || dynamic_pointer_cast<abstract_marker::raw>(_json_value));
     auto json_column_placeholder = ::make_shared<column_identifier>("", true);
     auto prepared_json_value = _json_value->prepare(db, "", make_lw_shared<column_specification>("", "", json_column_placeholder, utf8_type));

--- a/database.cc
+++ b/database.cc
@@ -354,7 +354,7 @@ database::database(const db::config& cfg, database_config dbcfg, service::migrat
     , _user_sstables_manager(std::make_unique<sstables::sstables_manager>(*_large_data_handler, _cfg, feat))
     , _system_sstables_manager(std::make_unique<sstables::sstables_manager>(*_nop_large_data_handler, _cfg, feat))
     , _result_memory_limiter(dbcfg.available_memory / 10)
-    , _data_listeners(std::make_unique<db::data_listeners>(*this))
+    , _data_listeners(std::make_unique<db::data_listeners>())
     , _mnotifier(mn)
     , _feat(feat)
     , _shared_token_metadata(stm)

--- a/db/data_listeners.hh
+++ b/db/data_listeners.hh
@@ -60,12 +60,9 @@ public:
 };
 
 class data_listeners {
-    database& _db;
     std::set<data_listener*> _listeners;
 
 public:
-    data_listeners(database& db) : _db(db) {}
-
     void install(data_listener* listener);
     void uninstall(data_listener* listener);
 

--- a/mutation_rebuilder.hh
+++ b/mutation_rebuilder.hh
@@ -25,11 +25,10 @@
 
 class mutation_rebuilder {
     mutation _m;
-    size_t _remaining_limit;
 
 public:
     mutation_rebuilder(dht::decorated_key dk, schema_ptr s)
-        : _m(std::move(s), std::move(dk)), _remaining_limit(0) {
+        : _m(std::move(s), std::move(dk)) {
     }
 
     stop_iteration consume(tombstone t) {

--- a/redis/server.cc
+++ b/redis/server.cc
@@ -31,7 +31,6 @@
 #include "exceptions/exceptions.hh"
 #include "service/query_state.hh"
 #include "service/storage_service.hh"
-#include "service/storage_proxy.hh"
 
 #include <seastar/core/future-util.hh>
 #include <seastar/core/seastar.hh>
@@ -46,9 +45,8 @@ namespace redis_transport {
 
 static logging::logger logging("redis_server");
 
-redis_server::redis_server(seastar::sharded<service::storage_proxy>& proxy, seastar::sharded<redis::query_processor>& qp, auth::service& auth_service, redis_server_config config)
+redis_server::redis_server(seastar::sharded<redis::query_processor>& qp, auth::service& auth_service, redis_server_config config)
     : server("Redis", logging)
-    , _proxy(proxy)
     , _query_processor(qp)
     , _config(config)
     , _max_request_size(config._max_request_size)

--- a/redis/server.hh
+++ b/redis/server.hh
@@ -67,18 +67,16 @@ struct redis_server_config {
 };
 
 class redis_server : public generic_server::server {
-    seastar::sharded<service::storage_proxy>& _proxy;
     seastar::sharded<redis::query_processor>& _query_processor;
     redis_server_config _config;
     size_t _max_request_size;
     semaphore _memory_available;
     redis::stats _stats;
-    uint64_t _requests_blocked_memory = 0;
     auth::service& _auth_service;
     size_t _total_redis_db_count;
 
 public:
-    redis_server(seastar::sharded<service::storage_proxy>& proxy, seastar::sharded<redis::query_processor>& qp, auth::service& auth_service, redis_server_config config);
+    redis_server(seastar::sharded<redis::query_processor>& qp, auth::service& auth_service, redis_server_config config);
 
     struct result {
         result(redis::redis_message&& m) : _data(make_foreign(std::make_unique<redis::redis_message>(std::move(m)))) {}

--- a/redis/service.cc
+++ b/redis/service.cc
@@ -59,7 +59,7 @@ future<> redis_service::listen(seastar::sharded<auth::service>& auth_service, db
     redis_cfg._max_request_size = memory::stats().total_memory() / 10;
     redis_cfg._total_redis_db_count = cfg.redis_database_count();
     return gms::inet_address::lookup(addr, family, preferred).then([this, server, addr, &cfg, keepalive, ceo = std::move(ceo), redis_cfg, &auth_service] (seastar::net::inet_address ip) {
-        return server->start(std::ref(service::get_storage_proxy()), std::ref(_query_processor), std::ref(auth_service), redis_cfg).then([server, &cfg, addr, ip, ceo, keepalive]() {
+        return server->start(std::ref(_query_processor), std::ref(auth_service), redis_cfg).then([server, &cfg, addr, ip, ceo, keepalive]() {
             auto f = make_ready_future();
             struct listen_cfg {
                 socket_address addr;

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -529,7 +529,6 @@ class repair_writer : public enable_lw_shared_from_this<repair_writer> {
     schema_ptr _schema;
     reader_permit _permit;
     uint64_t _estimated_partitions;
-    size_t _nr_peer_nodes;
     std::optional<future<>> _writer_done;
     std::optional<queue_reader_handle> _mq;
     // Current partition written to disk
@@ -545,12 +544,10 @@ public:
             schema_ptr schema,
             reader_permit permit,
             uint64_t estimated_partitions,
-            size_t nr_peer_nodes,
             streaming::stream_reason reason)
             : _schema(std::move(schema))
             , _permit(std::move(permit))
             , _estimated_partitions(estimated_partitions)
-            , _nr_peer_nodes(nr_peer_nodes)
             , _reason(reason) {
     }
 
@@ -850,7 +847,7 @@ public:
                     _seed,
                     repair_reader::is_local_reader(_repair_master || _same_sharding_config)
               )
-            , _repair_writer(make_lw_shared<repair_writer>(_schema, _permit, _estimated_partitions, _nr_peer_nodes, _reason))
+            , _repair_writer(make_lw_shared<repair_writer>(_schema, _permit, _estimated_partitions, _reason))
             , _sink_source_for_get_full_row_hashes(_repair_meta_id, _nr_peer_nodes,
                     [&ms] (uint32_t repair_meta_id, netw::messaging_service::msg_addr addr) {
                         return ms.local().make_sink_and_source_for_repair_get_full_row_hashes_with_rpc_stream(repair_meta_id, addr);

--- a/service/raft/raft_services.cc
+++ b/service/raft/raft_services.cc
@@ -38,7 +38,7 @@
 logging::logger rslog("raft_services");
 
 raft_services::raft_services(netw::messaging_service& ms, gms::gossiper& gs, cql3::query_processor& qp)
-    : _ms(ms), _gossiper(gs), _qp(qp), _fd(make_shared<raft_gossip_failure_detector>(gs, *this))
+    : _ms(ms), _qp(qp), _fd(make_shared<raft_gossip_failure_detector>(gs, *this))
 {}
 
 void raft_services::init_rpc_verbs() {

--- a/service/raft/raft_services.hh
+++ b/service/raft/raft_services.hh
@@ -53,7 +53,6 @@ class raft_services : public seastar::peering_sharded_service<raft_services> {
     using create_server_result = std::pair<std::unique_ptr<raft::server>, raft_rpc*>;
 
     netw::messaging_service& _ms;
-    gms::gossiper& _gossiper;
     cql3::query_processor& _qp;
     // Shard-local failure detector instance shared among all raft groups
     shared_ptr<raft_gossip_failure_detector> _fd;

--- a/sstables/compaction.cc
+++ b/sstables/compaction.cc
@@ -1414,8 +1414,6 @@ flat_mutation_reader make_scrubbing_reader(flat_mutation_reader rd, compaction_o
 }
 
 class resharding_compaction final : public compaction {
-    shard_id _shard; // shard of current sstable writer
-
     // Partition count estimation for a shard S:
     //
     // TE, the total estimated partition count for a shard S, is defined as

--- a/sstables/index_reader.hh
+++ b/sstables/index_reader.hh
@@ -38,11 +38,10 @@ extern thread_local cached_file::metrics index_page_cache_metrics;
 extern thread_local mc::cached_promoted_index::metrics promoted_index_cache_metrics;
 
 class index_consumer {
-    uint64_t max_quantity;
 public:
     index_list indexes;
 
-    index_consumer(uint64_t q) : max_quantity(q) {
+    index_consumer(uint64_t q) {
         indexes.reserve(q);
     }
 

--- a/sstables/mx/reader.cc
+++ b/sstables/mx/reader.cc
@@ -233,7 +233,6 @@ private:
     api::timestamp_type _column_timestamp;
     gc_clock::time_point _column_local_deletion_time;
     gc_clock::duration _column_ttl;
-    uint32_t _column_value_length;
     fragmented_temporary_buffer _column_value;
     temporary_buffer<char> _cell_path;
     uint64_t _ck_blocks_header;

--- a/streaming/stream_receive_task.hh
+++ b/streaming/stream_receive_task.hh
@@ -55,8 +55,6 @@ private:
     int total_files;
     // total size of files to receive
     long total_size;
-    // true if task is done (either completed or aborted)
-    bool done = false;
 public:
     stream_receive_task(shared_ptr<stream_session> _session, UUID _cf_id, int _total_files, long _total_size);
     ~stream_receive_task();

--- a/streaming/stream_transfer_task.hh
+++ b/streaming/stream_transfer_task.hh
@@ -54,8 +54,6 @@ class send_info;
  */
 class stream_transfer_task : public stream_task {
 private:
-    int32_t sequence_number = 0;
-    bool aborted = false;
     // A stream_transfer_task always contains the same range to stream
     dht::token_range_vector _ranges;
     std::map<unsigned, dht::partition_range_vector> _shard_ranges;

--- a/table.cc
+++ b/table.cc
@@ -475,17 +475,15 @@ public:
 // Handles all tasks related to sstable writing: permit management, compaction backlog updates, etc
 class database_sstable_write_monitor : public permit_monitor, public backlog_write_progress_manager {
     sstables::shared_sstable _sst;
-    compaction_manager& _compaction_manager;
     sstables::compaction_strategy& _compaction_strategy;
     const sstables::writer_offset_tracker* _tracker = nullptr;
     uint64_t _progress_seen = 0;
     api::timestamp_type _maximum_timestamp;
 public:
     database_sstable_write_monitor(lw_shared_ptr<sstable_write_permit> permit, sstables::shared_sstable sst,
-        compaction_manager& manager, sstables::compaction_strategy& strategy, api::timestamp_type max_timestamp)
+        sstables::compaction_strategy& strategy, api::timestamp_type max_timestamp)
             : permit_monitor(std::move(permit))
             , _sst(std::move(sst))
-            , _compaction_manager(manager)
             , _compaction_strategy(strategy)
             , _maximum_timestamp(max_timestamp)
     {}
@@ -611,7 +609,7 @@ table::try_flush_memtable_to_sstable(lw_shared_ptr<memtable> old, sstable_write_
             newtabs.push_back(newtab);
             tlogger.debug("Flushing to {}", newtab->get_filename());
 
-            auto monitor = database_sstable_write_monitor(permit, newtab, _compaction_manager, _compaction_strategy,
+            auto monitor = database_sstable_write_monitor(permit, newtab, _compaction_strategy,
                 old->get_max_timestamp());
 
             return do_with(std::move(monitor), [newtab, cfg = std::move(cfg), old, reader = std::move(reader), &priority] (auto& monitor) mutable {

--- a/test/boost/logalloc_test.cc
+++ b/test/boost/logalloc_test.cc
@@ -928,11 +928,9 @@ public:
 };
 
 class test_reclaimer: public region_group_reclaimer {
-    size_t _threshold;
     test_reclaimer *_result_accumulator;
     region_group _rg;
     std::vector<size_t> _reclaim_sizes;
-    bool _shutdown = false;
     shared_promise<> _unleash_reclaimer;
     seastar::gate _reclaimers_done;
     promise<> _unleashed;

--- a/test/boost/querier_cache_test.cc
+++ b/test/boost/querier_cache_test.cc
@@ -75,7 +75,6 @@ public:
 
 private:
     // Expected value of the above counters, updated by this.
-    unsigned _expected_factory_invoked{};
     query::querier_cache::stats _expected_stats;
 
     simple_schema _s;

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -140,14 +140,12 @@ public:
     static constexpr std::string_view ks_name = "ks";
     static std::atomic<bool> active;
 private:
-    sharded<gms::feature_service>& _feature_service;
     sharded<database>& _db;
     sharded<cql3::query_processor>& _qp;
     sharded<auth::service>& _auth_service;
     sharded<db::view::view_builder>& _view_builder;
     sharded<db::view::view_update_generator>& _view_update_generator;
     sharded<service::migration_notifier>& _mnotifier;
-    sharded<cdc::generation_service>& _cdc_generation_service;
     sharded<qos::service_level_controller>& _sl_controller;
     sharded<service::migration_manager>& _mm;
 private:
@@ -174,7 +172,6 @@ private:
     }
 public:
     single_node_cql_env(
-            sharded<gms::feature_service>& feature_service,
             sharded<database>& db,
             sharded<cql3::query_processor>& qp,
             sharded<auth::service>& auth_service,
@@ -182,16 +179,13 @@ public:
             sharded<db::view::view_update_generator>& view_update_generator,
             sharded<service::migration_notifier>& mnotifier,
             sharded<service::migration_manager>& mm,
-            sharded<cdc::generation_service>& cdc_generation_service,
             sharded<qos::service_level_controller> &sl_controller)
-            : _feature_service(feature_service)
-            , _db(db)
+            : _db(db)
             , _qp(qp)
             , _auth_service(auth_service)
             , _view_builder(view_builder)
             , _view_update_generator(view_update_generator)
             , _mnotifier(mnotifier)
-            , _cdc_generation_service(cdc_generation_service)
             , _sl_controller(sl_controller)
             , _mm(mm)
     { }
@@ -708,7 +702,7 @@ public:
                 // The default user may already exist if this `cql_test_env` is starting with previously populated data.
             }
 
-            single_node_cql_env env(feature_service, db, qp, auth_service, view_builder, view_update_generator, mm_notif, mm, cdc_generation_service, std::ref(sl_controller));
+            single_node_cql_env env(db, qp, auth_service, view_builder, view_update_generator, mm_notif, mm, std::ref(sl_controller));
             env.start().get();
             auto stop_env = defer([&env] { env.stop().get(); });
 


### PR DESCRIPTION
The -Wunused-private-field was squelched when we switched to
clang to make the change easier. But it is a useful warning, so
re-enable it.

It found a serious bug (#8682) and a few minor instances of waste.
