### PR TITLE
keys, compound: eliminate some careless copies of shared pointers

### DIFF
--- a/compound.hh
+++ b/compound.hh
@@ -47,7 +47,7 @@ public:
 
     compound_type(std::vector<data_type> types)
         : _types(std::move(types))
-        , _byte_order_equal(std::all_of(_types.begin(), _types.end(), [] (auto t) {
+        , _byte_order_equal(std::all_of(_types.begin(), _types.end(), [] (const auto& t) {
                 return t->is_byte_order_equal();
             }))
         , _byte_order_comparable(false)

--- a/keys.hh
+++ b/keys.hh
@@ -491,8 +491,8 @@ public:
     using prefix_view_type = prefix_view_on_full_compound<TopLevel, PrefixTopLevel>;
 
     bool is_prefixed_by(const schema& s, const PrefixTopLevel& prefix) const {
-        auto t = base::get_compound_type(s);
-        auto prefix_type = PrefixTopLevel::get_compound_type(s);
+        const auto& t = base::get_compound_type(s);
+        const auto& prefix_type = PrefixTopLevel::get_compound_type(s);
         return ::is_prefixed_by(t->types().begin(),
             t->begin(*this), t->end(*this),
             prefix_type->begin(prefix), prefix_type->end(prefix),
@@ -594,7 +594,7 @@ public:
     }
 
     bool is_prefixed_by(const schema& s, const TopLevel& prefix) const {
-        auto t = base::get_compound_type(s);
+        const auto& t = base::get_compound_type(s);
         return ::is_prefixed_by(t->types().begin(),
             t->begin(*this), t->end(*this),
             t->begin(prefix), t->end(prefix),


### PR DESCRIPTION
Using `auto` copies the shared pointers. We don't want that, so let's use
`const auto&`.