### PR TITLE
alternator: executor: eliminate some pointless reserializations

### DIFF
--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -3344,7 +3344,7 @@ static dht::partition_range calculate_pk_bound(schema_ptr schema, const column_d
         throw api_error::validation(format("A single attribute is required for a hash key EQ restriction: {}", attrs));
     }
     bytes raw_value = get_key_from_typed_value(attrs[0], pk_cdef);
-    partition_key pk = partition_key::from_singular(*schema, pk_cdef.type->deserialize(raw_value));
+    partition_key pk = partition_key::from_singular_bytes(*schema, std::move(raw_value));
     auto decorated_key = dht::decorate_key(*schema, pk);
     return dht::partition_range(decorated_key);
 }
@@ -3648,7 +3648,7 @@ calculate_bounds_condition_expression(schema_ptr schema,
                             "KeyConditionExpression allows only one condition for each key");
                 }
                 bytes raw_value = get_constant_value(cond._values[!toplevel_ind], pk_cdef);
-                partition_key pk = partition_key::from_singular(*schema, pk_cdef.type->deserialize(raw_value));
+                partition_key pk = partition_key::from_singular_bytes(*schema, std::move(raw_value));
                 auto decorated_key = dht::decorate_key(*schema, pk);
                 partition_ranges.push_back(dht::partition_range(decorated_key));
             } else if (ck_cdef && sstring(key) == ck_cdef->name_as_text()) {

--- a/keys.hh
+++ b/keys.hh
@@ -166,6 +166,14 @@ protected:
     static inline const auto& get_compound_type(const schema& s) {
         return TopLevel::get_compound_type(s);
     }
+private:
+    static const data_type& get_singular_type(const schema& s) {
+        const auto& ct = get_compound_type(s);
+        if (!ct->is_singular()) {
+            throw std::invalid_argument("compound is not singular");
+        }
+        return ct->types()[0];
+    }
 public:
     struct with_schema_wrapper {
         with_schema_wrapper(const schema& s, const TopLevel& key) : s(s), key(key) {}
@@ -223,12 +231,13 @@ public:
     template <typename T>
     static
     TopLevel from_singular(const schema& s, const T& v) {
-        auto ct = get_compound_type(s);
-        if (!ct->is_singular()) {
-            throw std::invalid_argument("compound is not singular");
-        }
-        auto type = ct->types()[0];
+        const auto& type = get_singular_type(s);
         return from_single_value(s, type->decompose(v));
+    }
+
+    static TopLevel from_singular_bytes(const schema& s, const bytes& b) {
+        get_singular_type(s); // validation
+        return from_single_value(s, b);
     }
 
     TopLevelView view() const {


### PR DESCRIPTION
There are places where abstract_type::deserialize is called just to pass the
result to compound_wrapper::from_singular, which immediately serializes it
again.

Get rid of this ritual by adding a version of from_singular which takes
a serialized argument.

As a bonus, along the way we eliminate some pointless copies of lw_shared_ptr
and std::shared_ptr caused by two careless uses of `auto`.