### PR TITLE
keys, compound: take the argument to from_single_value() by reference

### DIFF
--- a/compound.hh
+++ b/compound.hh
@@ -106,11 +106,11 @@ private:
         return len;
     }
 public:
-    managed_bytes serialize_single(managed_bytes&& v) const {
-        return serialize_value({std::move(v)});
+    managed_bytes serialize_single(const managed_bytes& v) const {
+        return serialize_value(boost::make_iterator_range(&v, 1+&v));
     }
-    managed_bytes serialize_single(bytes&& v) const {
-        return serialize_value({std::move(v)});
+    managed_bytes serialize_single(const bytes& v) const {
+        return serialize_value(boost::make_iterator_range(&v, 1+&v));
     }
     template<typename RangeOfSerializedComponents>
     static managed_bytes serialize_value(RangeOfSerializedComponents&& values) {

--- a/keys.hh
+++ b/keys.hh
@@ -212,12 +212,12 @@ public:
         return TopLevel::from_bytes(get_compound_type(s)->serialize_value_deep(v));
     }
 
-    static TopLevel from_single_value(const schema& s, bytes v) {
-        return TopLevel::from_bytes(get_compound_type(s)->serialize_single(std::move(v)));
+    static TopLevel from_single_value(const schema& s, const bytes& v) {
+        return TopLevel::from_bytes(get_compound_type(s)->serialize_single(v));
     }
 
-    static TopLevel from_single_value(const schema& s, managed_bytes v) {
-        return TopLevel::from_bytes(get_compound_type(s)->serialize_single(std::move(v)));
+    static TopLevel from_single_value(const schema& s, const managed_bytes& v) {
+        return TopLevel::from_bytes(get_compound_type(s)->serialize_single(v));
     }
 
     template <typename T>


### PR DESCRIPTION
Since serialize_value needs to copy the values to a bigger buffer anyway,
there is no point in copying the argument higher in the call chain.
This patch eliminates some pointless copies, for example in
alternator/executor.cc