### PR TITLE
collection_mutation: don't linearize collection values

### DIFF
--- a/utils/managed_bytes.hh
+++ b/utils/managed_bytes.hh
@@ -450,6 +450,9 @@ public:
     bytes linearize() const {
         return linearized(*this);
     }
+    bool is_linearized() {
+        return _current_fragment.size() == _size;
+    }
 
     // Allow casting mutable views to immutable views.
     friend class managed_bytes_basic_view<mutable_view::no>;


### PR DESCRIPTION
Yet another patch preventing potentially large allocations.
Currently, collection_mutation{_view,}_description linearize each collection
value during deserialization. It's not unthinkable that a user adds a
large element to a list or a map, so let's avoid that.

This patch removes the dependency on linearizing_input_stream, which does not
provide a way to read fragmented subbuffers, and replaces it with a new
helper, which does. (Extending linearizing_input_stream is not viable without
rewriting it completely).

Only linearization of collection values is corrected in this patch.
Collection keys are still linearized. Storing them in managed_bytes is likely
to be more harmful than helpful, because large map keys are extremely unlikely,
and UUIDs, which are used as keys in lists, do not fit into manages_bytes's
small value optimization, so this would incure an extra allocation for every
list element.

Note: this patch leaves utils/linearizing_input_stream.hh unused.

Refs: #8120