### PR TITLE
test: serialized_action_test: prevent false-positive timeout in test_phased_barrier_reassignment

### DIFF
--- a/test/boost/serialized_action_test.cc
+++ b/test/boost/serialized_action_test.cc
@@ -158,7 +158,7 @@ SEASTAR_THREAD_TEST_CASE(test_phased_barrier_reassignment) {
         BOOST_ERROR("phased_barrier::advance_and_await timed out");
         _exit(1);
     });
-    completion_timer.arm(1ms);
+    completion_timer.arm(1s);
     bar1.advance_and_await().get();
     bar2.advance_and_await().get();
     completion_timer.cancel();


### PR DESCRIPTION
test_phased_barrier_reassignment has a timeout to prevent the test from
hanging on failure, but it occastionally triggers in debug mode since
the timeout is quite low (1ms). Increase the timeout to prevent false
positives. Since the timeout only expires if the test fails, it will
have no impact on execution time.

Ref #8613