### PR TITLE
utils: config_file: delete unneeded template instantation of operator<<()

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1285,7 +1285,6 @@ warnings = [
     '-Wno-pessimizing-move',
     '-Wno-redundant-move',
     '-Wno-gnu-designator',
-    '-Wno-instantiation-after-specialization',
     '-Wno-unsupported-friend',
     '-Wno-unused-variable',
     '-Wno-return-std-move',

--- a/utils/config_file.cc
+++ b/utils/config_file.cc
@@ -201,7 +201,6 @@ std::istream& std::operator>>(std::istream& is, std::vector<seastar::sstring>& r
 
    return is;
 }
-template std::istream& std::operator>>(std::istream&, std::unordered_map<seastar::sstring, seastar::sstring>&);
 
 thread_local unsigned utils::config_file::s_shard_id = 0;
 

--- a/utils/config_file_impl.hh
+++ b/utils/config_file_impl.hh
@@ -79,9 +79,6 @@ std::istream& operator>>(std::istream&, std::unordered_map<K, V, Args...>&);
 template<>
 std::istream& operator>>(std::istream&, std::unordered_map<seastar::sstring, seastar::sstring>&);
 
-extern template
-std::istream& operator>>(std::istream&, std::unordered_map<seastar::sstring, seastar::sstring>&);
-
 template<typename V, typename... Args>
 std::istream& operator>>(std::istream&, std::vector<V, Args...>&);
 


### PR DESCRIPTION
config_file.cc instantiates std::istream& std::operator>>(std::istream&,
std::unordered_map<seastar::sstring, seastar::sstring>&), but that
instantiation is ignored since config_file_impl.hh specializes
that signature. -Winstantiation-after-specialization warns about it,
so re-enable it now that the code base is clean.

Also remove the matching "extern template" declaration, which has no
definition any more.