### PR TITLE
build: enable -Wrange-loop-construct warning

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1292,7 +1292,6 @@ warnings = [
     '-Wno-delete-non-abstract-non-virtual-dtor',
     '-Wno-unknown-attributes',
     '-Wno-braced-scalar-init',
-    '-Wno-range-loop-construct',
     '-Wno-unused-function',
     '-Wno-implicit-int-float-conversion',
     '-Wno-delete-abstract-non-virtual-dtor',

--- a/test/boost/castas_fcts_test.cc
+++ b/test/boost/castas_fcts_test.cc
@@ -621,7 +621,7 @@ SEASTAR_TEST_CASE(test_identity_casts) {
                 {duration_type, "5h23m10s"},
         };
 
-        for (const auto [type, value] : type_value_pairs) {
+        for (const auto& [type, value] : type_value_pairs) {
             const auto type_name = type->cql3_type_name();
             cquery_nofail(e, format("create table t_{} (pk int primary key, v {})", type_name, type_name));
             cquery_nofail(e, format("insert into t_{} (pk, v) values (0, {})", type_name, value));

--- a/test/boost/mutation_test.cc
+++ b/test/boost/mutation_test.cc
@@ -2826,7 +2826,7 @@ void check_row_summaries(const schema& schema, column_kind kind, const row_summa
     auto column_tri_cmp = [] (const std::pair<const column_id, value_summary>& a, const std::pair<const column_id, value_summary>& b) {
         return a.first - b.first;
     };
-    for (const auto [actual_column, expected_column] : iterate_over_in_ordered_lockstep(actual, expected, column_tri_cmp)) {
+    for (const auto& [actual_column, expected_column] : iterate_over_in_ordered_lockstep(actual, expected, column_tri_cmp)) {
         BOOST_REQUIRE(expected_column);
         const auto [expected_column_id, expected_cell_or_collection] = *expected_column;
         if (!actual_column) {

--- a/test/lib/random_schema.cc
+++ b/test/lib/random_schema.cc
@@ -798,7 +798,7 @@ std::unordered_set<const user_type_impl*> dump_udts(data_type type) {
 
 std::unordered_set<const user_type_impl*> dump_udts(const std::vector<data_type>& types) {
     std::unordered_set<const user_type_impl*> udts;
-    for (const auto dt : types) {
+    for (const auto& dt : types) {
         const auto* const type = dt.get();
         if (auto maybe_user_type = dynamic_cast<const user_type_impl*>(type)) {
             udts.insert(maybe_user_type);


### PR DESCRIPTION
This warning triggers when a range for ("for (auto x : range)") causes
non-trivial copies, prompting the developer to replace with a capture
by reference. A few minor violations in the test suite are corrected.