### PR TITLE
auth: Remove `const` from role_manager methods

### DIFF
--- a/auth/role_manager.hh
+++ b/auth/role_manager.hh
@@ -120,17 +120,17 @@ public:
     ///
     /// \returns an exceptional future with \ref role_already_exists for a role that has previously been created.
     ///
-    virtual future<> create(std::string_view role_name, const role_config&) const = 0;
+    virtual future<> create(std::string_view role_name, const role_config&) = 0;
 
     ///
     /// \returns an exceptional future with \ref nonexistant_role if the role does not exist.
     ///
-    virtual future<> drop(std::string_view role_name) const = 0;
+    virtual future<> drop(std::string_view role_name) = 0;
 
     ///
     /// \returns an exceptional future with \ref nonexistant_role if the role does not exist.
     ///
-    virtual future<> alter(std::string_view role_name, const role_config_update&) const = 0;
+    virtual future<> alter(std::string_view role_name, const role_config_update&) = 0;
 
     ///
     /// Grant `role_name` to `grantee_name`.
@@ -140,7 +140,7 @@ public:
     /// \returns an exceptional future with \ref role_already_included if granting the role would be redundant, or
     /// create a cycle.
     ///
-    virtual future<> grant(std::string_view grantee_name, std::string_view role_name) const = 0;
+    virtual future<> grant(std::string_view grantee_name, std::string_view role_name) = 0;
 
     ///
     /// Revoke `role_name` from `revokee_name`.
@@ -149,46 +149,46 @@ public:
     ///
     /// \returns an exceptional future with \ref revoke_ungranted_role if the role was not granted.
     ///
-    virtual future<> revoke(std::string_view revokee_name, std::string_view role_name) const = 0;
+    virtual future<> revoke(std::string_view revokee_name, std::string_view role_name) = 0;
 
     ///
     /// \returns an exceptional future with \ref nonexistant_role if the role does not exist.
     ///
-    virtual future<role_set> query_granted(std::string_view grantee, recursive_role_query) const = 0;
+    virtual future<role_set> query_granted(std::string_view grantee, recursive_role_query) = 0;
 
-    virtual future<role_set> query_all() const = 0;
+    virtual future<role_set> query_all() = 0;
 
-    virtual future<bool> exists(std::string_view role_name) const = 0;
-
-    ///
-    /// \returns an exceptional future with \ref nonexistant_role if the role does not exist.
-    ///
-    virtual future<bool> is_superuser(std::string_view role_name) const = 0;
+    virtual future<bool> exists(std::string_view role_name) = 0;
 
     ///
     /// \returns an exceptional future with \ref nonexistant_role if the role does not exist.
     ///
-    virtual future<bool> can_login(std::string_view role_name) const = 0;
+    virtual future<bool> is_superuser(std::string_view role_name) = 0;
+
+    ///
+    /// \returns an exceptional future with \ref nonexistant_role if the role does not exist.
+    ///
+    virtual future<bool> can_login(std::string_view role_name) = 0;
 
     ///
     /// \returns the value of the named attribute, if one is set.
     ///
-    virtual future<std::optional<sstring>> get_attribute(std::string_view role_name, std::string_view attribute_name) const = 0;
+    virtual future<std::optional<sstring>> get_attribute(std::string_view role_name, std::string_view attribute_name) = 0;
 
     ///
     /// \returns a mapping of each role's value for the named attribute, if one is set for the role.
     ///
-    virtual future<attribute_vals> query_attribute_for_all(std::string_view attribute_name) const = 0;
+    virtual future<attribute_vals> query_attribute_for_all(std::string_view attribute_name) = 0;
 
     /// Sets `attribute_name` with `attribute_value` for `role_name`.
     /// \returns an exceptional future with nonexistant_role if the role does not exist.
     ///
-    virtual future<> set_attribute(std::string_view role_name, std::string_view attribute_name, std::string_view attribute_value) const = 0;
+    virtual future<> set_attribute(std::string_view role_name, std::string_view attribute_name, std::string_view attribute_value) = 0;
 
     /// Removes `attribute_name` for `role_name`.
     /// \returns an exceptional future with nonexistant_role if the role does not exist.
     /// \note: This is a no-op if the role does not have the named attribute set.
     ///
-    virtual future<> remove_attribute(std::string_view role_name, std::string_view attribute_name) const = 0;
+    virtual future<> remove_attribute(std::string_view role_name, std::string_view attribute_name) = 0;
 };
 }

--- a/auth/service.hh
+++ b/auth/service.hh
@@ -157,7 +157,7 @@ public:
         return *_authorizer;
     }
 
-    const role_manager& underlying_role_manager() const {
+    role_manager& underlying_role_manager() const {
         return *_role_manager;
     }
 

--- a/auth/standard_role_manager.cc
+++ b/auth/standard_role_manager.cc
@@ -206,7 +206,7 @@ future<> standard_role_manager::create_default_role_if_missing() const {
 
 static const sstring legacy_table_name{"users"};
 
-bool standard_role_manager::legacy_metadata_exists() const {
+bool standard_role_manager::legacy_metadata_exists() {
     return _qp.db().has_schema(meta::AUTH_KS, legacy_table_name);
 }
 
@@ -284,7 +284,7 @@ future<> standard_role_manager::create_or_replace(std::string_view role_name, co
 }
 
 future<>
-standard_role_manager::create(std::string_view role_name, const role_config& c) const {
+standard_role_manager::create(std::string_view role_name, const role_config& c) {
     return this->exists(role_name).then([this, role_name, &c](bool role_exists) {
         if (role_exists) {
             throw role_already_exists(role_name);
@@ -295,7 +295,7 @@ standard_role_manager::create(std::string_view role_name, const role_config& c) 
 }
 
 future<>
-standard_role_manager::alter(std::string_view role_name, const role_config_update& u) const {
+standard_role_manager::alter(std::string_view role_name, const role_config_update& u) {
     static const auto build_column_assignments = [](const role_config_update& u) -> sstring {
         std::vector<sstring> assignments;
 
@@ -326,7 +326,7 @@ standard_role_manager::alter(std::string_view role_name, const role_config_updat
     });
 }
 
-future<> standard_role_manager::drop(std::string_view role_name) const {
+future<> standard_role_manager::drop(std::string_view role_name) {
     return this->exists(role_name).then([this, role_name](bool role_exists) {
         if (!role_exists) {
             throw nonexistant_role(role_name);
@@ -443,7 +443,7 @@ standard_role_manager::modify_membership(
 }
 
 future<>
-standard_role_manager::grant(std::string_view grantee_name, std::string_view role_name) const {
+standard_role_manager::grant(std::string_view grantee_name, std::string_view role_name) {
     const auto check_redundant = [this, role_name, grantee_name] {
         return this->query_granted(
                 grantee_name,
@@ -474,7 +474,7 @@ standard_role_manager::grant(std::string_view grantee_name, std::string_view rol
 }
 
 future<>
-standard_role_manager::revoke(std::string_view revokee_name, std::string_view role_name) const {
+standard_role_manager::revoke(std::string_view revokee_name, std::string_view role_name) {
     return this->exists(role_name).then([this, revokee_name, role_name](bool role_exists) {
         if (!role_exists) {
             throw nonexistant_role(sstring(role_name));
@@ -514,7 +514,7 @@ static future<> collect_roles(
     });
 }
 
-future<role_set> standard_role_manager::query_granted(std::string_view grantee_name, recursive_role_query m) const {
+future<role_set> standard_role_manager::query_granted(std::string_view grantee_name, recursive_role_query m) {
     const bool recurse = (m == recursive_role_query::yes);
 
     return do_with(
@@ -524,7 +524,7 @@ future<role_set> standard_role_manager::query_granted(std::string_view grantee_n
     });
 }
 
-future<role_set> standard_role_manager::query_all() const {
+future<role_set> standard_role_manager::query_all() {
     static const sstring query = format("SELECT {} FROM {}",
             meta::roles_table::role_col_name,
             meta::roles_table::qualified_name);
@@ -550,25 +550,25 @@ future<role_set> standard_role_manager::query_all() const {
     });
 }
 
-future<bool> standard_role_manager::exists(std::string_view role_name) const  {
+future<bool> standard_role_manager::exists(std::string_view role_name) {
     return find_record(_qp, role_name).then([](std::optional<record> mr) {
         return static_cast<bool>(mr);
     });
 }
 
-future<bool> standard_role_manager::is_superuser(std::string_view role_name) const {
+future<bool> standard_role_manager::is_superuser(std::string_view role_name) {
     return require_record(_qp, role_name).then([](record r) {
         return r.is_superuser;
     });
 }
 
-future<bool> standard_role_manager::can_login(std::string_view role_name) const {
+future<bool> standard_role_manager::can_login(std::string_view role_name) {
     return require_record(_qp, role_name).then([](record r) {
         return r.can_login;
     });
 }
 
-future<std::optional<sstring>> standard_role_manager::get_attribute(std::string_view role_name, std::string_view attribute_name) const {
+future<std::optional<sstring>> standard_role_manager::get_attribute(std::string_view role_name, std::string_view attribute_name) {
     static const sstring query = format("SELECT name, value FROM {} WHERE role = ? AND name = ?", meta::role_attributes_table::qualified_name());
     return _qp.execute_internal(query, {sstring(role_name), sstring(attribute_name)}).then([] (shared_ptr<cql3::untyped_result_set> result_set) {
         if (!result_set->empty()) {
@@ -579,7 +579,7 @@ future<std::optional<sstring>> standard_role_manager::get_attribute(std::string_
     });
 }
 
-future<role_manager::attribute_vals> standard_role_manager::query_attribute_for_all (std::string_view attribute_name) const {
+future<role_manager::attribute_vals> standard_role_manager::query_attribute_for_all (std::string_view attribute_name) {
     return query_all().then([this, attribute_name] (role_set roles) {
         return do_with(attribute_vals{}, [this, attribute_name, roles = std::move(roles)] (attribute_vals &role_to_att_val) {
             return parallel_for_each(roles.begin(), roles.end(), [this, &role_to_att_val, attribute_name] (sstring role) {
@@ -595,7 +595,7 @@ future<role_manager::attribute_vals> standard_role_manager::query_attribute_for_
     });
 }
 
-future<> standard_role_manager::set_attribute(std::string_view role_name, std::string_view attribute_name, std::string_view attribute_value) const {
+future<> standard_role_manager::set_attribute(std::string_view role_name, std::string_view attribute_name, std::string_view attribute_value) {
     static const sstring query = format("INSERT INTO {} (role, name, value)  VALUES (?, ?, ?)", meta::role_attributes_table::qualified_name());
     return do_with(sstring(role_name), sstring(attribute_name), sstring(attribute_value), [this] (sstring& role_name, sstring &attribute_name,
             sstring &attribute_value) {
@@ -609,7 +609,7 @@ future<> standard_role_manager::set_attribute(std::string_view role_name, std::s
 
 }
 
-future<> standard_role_manager::remove_attribute(std::string_view role_name, std::string_view attribute_name) const {
+future<> standard_role_manager::remove_attribute(std::string_view role_name, std::string_view attribute_name) {
     static const sstring query = format("DELETE FROM {} WHERE role = ? AND name = ?", meta::role_attributes_table::qualified_name());
     return do_with(sstring(role_name), sstring(attribute_name), [this] (sstring& role_name, sstring &attribute_name) {
         return exists(role_name).then([&role_name, &attribute_name, this] (bool role_exists) {

--- a/auth/standard_role_manager.hh
+++ b/auth/standard_role_manager.hh
@@ -63,40 +63,40 @@ public:
 
     virtual future<> stop() override;
 
-    virtual future<> create(std::string_view role_name, const role_config&) const override;
+    virtual future<> create(std::string_view role_name, const role_config&) override;
 
-    virtual future<> drop(std::string_view role_name) const override;
+    virtual future<> drop(std::string_view role_name) override;
 
-    virtual future<> alter(std::string_view role_name, const role_config_update&) const override;
+    virtual future<> alter(std::string_view role_name, const role_config_update&) override;
 
-    virtual future<> grant(std::string_view grantee_name, std::string_view role_name) const override;
+    virtual future<> grant(std::string_view grantee_name, std::string_view role_name) override;
 
-    virtual future<> revoke(std::string_view revokee_name, std::string_view role_name) const override;
+    virtual future<> revoke(std::string_view revokee_name, std::string_view role_name) override;
 
-    virtual future<role_set> query_granted(std::string_view grantee_name, recursive_role_query) const override;
+    virtual future<role_set> query_granted(std::string_view grantee_name, recursive_role_query) override;
 
-    virtual future<role_set> query_all() const override;
+    virtual future<role_set> query_all() override;
 
-    virtual future<bool> exists(std::string_view role_name) const override;
+    virtual future<bool> exists(std::string_view role_name) override;
 
-    virtual future<bool> is_superuser(std::string_view role_name) const override;
+    virtual future<bool> is_superuser(std::string_view role_name) override;
 
-    virtual future<bool> can_login(std::string_view role_name) const override;
+    virtual future<bool> can_login(std::string_view role_name) override;
 
-    virtual future<std::optional<sstring>> get_attribute(std::string_view role_name, std::string_view attribute_name) const override;
+    virtual future<std::optional<sstring>> get_attribute(std::string_view role_name, std::string_view attribute_name) override;
 
-    virtual future<role_manager::attribute_vals> query_attribute_for_all(std::string_view attribute_name) const override;
+    virtual future<role_manager::attribute_vals> query_attribute_for_all(std::string_view attribute_name) override;
 
-    virtual future<> set_attribute(std::string_view role_name, std::string_view attribute_name, std::string_view attribute_value) const override;
+    virtual future<> set_attribute(std::string_view role_name, std::string_view attribute_name, std::string_view attribute_value) override;
 
-    virtual future<> remove_attribute(std::string_view role_name, std::string_view attribute_name) const override;
+    virtual future<> remove_attribute(std::string_view role_name, std::string_view attribute_name) override;
 
 private:
     enum class membership_change { add, remove };
 
     future<> create_metadata_tables_if_missing() const;
 
-    bool legacy_metadata_exists() const;
+    bool legacy_metadata_exists();
 
     future<> migrate_legacy_metadata() const;
 

--- a/cql3/statements/role-management-statements.cc
+++ b/cql3/statements/role-management-statements.cc
@@ -350,7 +350,7 @@ list_roles_statement::execute(query_processor&, service::query_state& state, con
                     make_column_spec("options", custom_options_type)});
 
     static const auto make_results = [](
-            const auth::role_manager& rm,
+            auth::role_manager& rm,
             const auth::authenticator& a,
             auth::role_set&& roles) -> future<result_message_ptr> {
         auto results = std::make_unique<result_set>(metadata);
@@ -397,7 +397,7 @@ list_roles_statement::execute(query_processor&, service::query_state& state, con
     const auto& as = *cs.get_auth_service();
 
     return auth::has_superuser(as, *cs.user()).then([this, &state, &cs, &as](bool super) {
-        const auto& rm = as.underlying_role_manager();
+        auto& rm = as.underlying_role_manager();
         const auto& a = as.underlying_authenticator();
         const auto query_mode = _recursive ? auth::recursive_role_query::yes : auth::recursive_role_query::no;
 

--- a/service/client_state.cc
+++ b/service/client_state.cc
@@ -65,7 +65,7 @@ future<> service::client_state::check_user_can_login() {
         return make_ready_future();
     }
 
-    const auto& role_manager = _auth_service->underlying_role_manager();
+    auto& role_manager = _auth_service->underlying_role_manager();
 
     return role_manager.exists(*_user->name).then([this](bool exists) mutable {
         if (!exists) {
@@ -274,7 +274,7 @@ future<> service::client_state::ensure_exists(const auth::resource& r) const {
 
 future<> service::client_state::maybe_update_per_service_level_params() {
     if (_sl_controller && _user && _user->name) {
-        const auto& role_manager = _auth_service->underlying_role_manager();
+        auto& role_manager = _auth_service->underlying_role_manager();
         auto role_set = co_await role_manager.query_granted(_user->name.value(), auth::recursive_role_query::yes);
         auto slo_opt = co_await _sl_controller->find_service_level(role_set);
         if (!slo_opt) {


### PR DESCRIPTION
Some subclasses want to maintain state, which constness needlessly precludes.

Tests: unit (dev)

Signed-off-by: Dejan Mircevski <dejan@scylladb.com>