### PR TITLE
repair: trigger repair abort_source only from shard 0

### DIFF
--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -477,8 +477,10 @@ void tracker::abort_all_repairs() {
         auto& ri = x.second;
         ri->abort();
     }
-    _abort_all_as.request_abort();
-    _abort_all_as = seastar::abort_source();
+    if (this_shard_id() == 0) {
+        _abort_all_as.request_abort();
+        _abort_all_as = seastar::abort_source();
+    }
     rlogger.info0("Aborted {} repair job(s)", count);
 }
 


### PR DESCRIPTION
When user requests repair to be forcefully aborted, the `_abort_all_as`
abort source could be modified from multiple shards in parallel by the
`tracker::abort_all_repairs()` function, which can lead to undefined
behavior and to a crash. This commit makes sure that `_abort_all_as` is
used only from shard 0 when repair is aborted.

Fixes #8693