### PR TITLE
hinted handoff: error injection for slowing down hint replay

### DIFF
--- a/db/hints/manager.cc
+++ b/db/hints/manager.cc
@@ -41,6 +41,7 @@
 #include "service_permit.hh"
 #include "utils/directories.hh"
 #include "utils/UUID_gen.hh"
+#include "utils/error_injection.hh"
 
 using namespace std::literals::chrono_literals;
 
@@ -849,6 +850,8 @@ future<> manager::end_point_hints_manager::sender::send_one_hint(lw_shared_ptr<s
             }
             return make_ready_future<>();
         }).finally([units = std::move(units), ctx_ptr] {});
+
+        return utils::get_local_injector().inject("hinted_handoff_slow_hint_replay", std::chrono::seconds(1));
     }).handle_exception([this, ctx_ptr, rp] (auto eptr) {
         manager_logger.trace("send_one_file(): Hmmm. Something bad had happend: {}", eptr);
         ctx_ptr->on_hint_send_failure(rp);


### PR DESCRIPTION
Adds a `hinted_handoff_slow_hint_replay` error injection point. When
enabled, it limits hints sent from one hint queue to at most 1 per
second (each hint send is delayed by 1 second with respect to the moment
when the previous one was issued).

This injection point will be useful in dtests - slowing down hint replay
to a crawl will make it possible to test how some operations behave
while hints are being replayed.

Refs: #6649