### PR TITLE
test/perf: close test_env to pass an assert in sstables_manager destructor

### DIFF
--- a/test/perf/perf_sstable.hh
+++ b/test/perf/perf_sstable.hh
@@ -110,7 +110,10 @@ public:
            , _mt(make_lw_shared<memtable>(s))
     {}
 
-    future<> stop() { return make_ready_future<>(); }
+    future<> stop() {
+        _sst.clear();
+        return _env.stop();
+    }
 
     future<> fill_memtable() {
         auto idx = boost::irange(0, int(_cfg.partitions / _cfg.sstables));


### PR DESCRIPTION
When destroying an perf_sstable_test_env, an assert in sstables_manager
destructor fails, because it hasn't been closed.
Fix by removing all references to sstables from perf_sstable_test_env,
and then closing the test_env(as well as the sstables_manager)

Fixes #8736 