### PR TITLE
build: enable -Wreturn-std-move

### DIFF
--- a/api/api.hh
+++ b/api/api.hh
@@ -71,7 +71,7 @@ T map_sum(T&& dest, const S& src) {
     for (auto i : src) {
         dest[i.first] += i.second;
     }
-    return dest;
+    return std::move(dest);
 }
 
 template <typename MAP>

--- a/configure.py
+++ b/configure.py
@@ -1287,7 +1287,6 @@ warnings = [
     '-Wno-gnu-designator',
     '-Wno-unsupported-friend',
     '-Wno-unused-variable',
-    '-Wno-return-std-move',
     '-Wno-delete-non-abstract-non-virtual-dtor',
     '-Wno-unknown-attributes',
     '-Wno-braced-scalar-init',

--- a/cql3/statements/alter_type_statement.cc
+++ b/cql3/statements/alter_type_statement.cc
@@ -219,7 +219,7 @@ user_type alter_type_statement::renames::make_updated_type(database& db, user_ty
         }
         new_names[*idx] = rename.second->name();
     }
-    auto&& updated = user_type_impl::get_instance(to_update->_keyspace, to_update->_name, std::move(new_names), to_update->field_types(), to_update->is_multi_cell());
+    auto updated = user_type_impl::get_instance(to_update->_keyspace, to_update->_name, std::move(new_names), to_update->field_types(), to_update->is_multi_cell());
     create_type_statement::check_for_duplicate_names(updated);
     return updated;
 }

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -1665,7 +1665,7 @@ future<std::unordered_set<dht::token>> get_local_tokens() {
             slogger.error("{}", err);
             throw std::runtime_error(err);
         }
-        return tokens;
+        return std::move(tokens);
     });
 }
 

--- a/sstables/leveled_manifest.hh
+++ b/sstables/leveled_manifest.hh
@@ -338,10 +338,10 @@ private:
                     break;
                 }
             }
-            return candidates;
+            return std::move(candidates);
         }
 
-        return candidates;
+        return std::move(candidates);
     }
 public:
     size_t get_level_size(uint32_t level) {


### PR DESCRIPTION
Clang warns when "return std::move(x)" is needed to elide a copy,
but the call to std::move() is missing. We disabled the warning during
the migration to clang. This patch re-enables the warning and fixes
the places it points out, usually by adding std::move() and in one
place by converting the returned variable from a reference to a local,
so normal copy elision can take place.