### PR TITLE
system_table: Advertise scylla version

### DIFF
--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -1213,7 +1213,7 @@ static future<> setup_version(distributed<gms::feature_service>& feat, sharded<n
         auto& snitch = locator::i_endpoint_snitch::get_local_snitch_ptr();
 
         return qctx->execute_cql(req, sstring(db::system_keyspace::LOCAL),
-                             version::release(),
+                             scylla_version(),
                              cql3::query_processor::CQL_VERSION,
                              ::cassandra::thrift_version,
                              to_sstring(cql_serialization_format::latest_version),

--- a/gms/versioned_value.cc
+++ b/gms/versioned_value.cc
@@ -37,6 +37,7 @@
  */
 #include "gms/versioned_value.hh"
 #include "message/messaging_service.hh"
+#include "release.hh"
 
 #include <boost/algorithm/string/split.hpp>
 #include <boost/algorithm/string/classification.hpp>
@@ -103,6 +104,10 @@ std::optional<cdc::generation_id> versioned_value::cdc_generation_id_from_string
         return {};
     }
     return cdc::generation_id{db_clock::time_point{db_clock::duration(std::stoll(s))}};
+}
+
+versioned_value versioned_value::release_version() {
+    return versioned_value(scylla_version());
 }
 
 }

--- a/gms/versioned_value.hh
+++ b/gms/versioned_value.hh
@@ -234,9 +234,7 @@ public:
         return versioned_value(format("{}", endpoint));
     }
 
-    static versioned_value release_version() {
-        return versioned_value(version::release());
-    }
+    static versioned_value release_version();
 
     static versioned_value network_version();
 


### PR DESCRIPTION
A hard-coded number is used currently. Advertise the real scylla
version.

Before:
```
   cqlsh> SELECT release_version from system.peers ;

    release_version
   -----------------
              3.0.8
              3.0.8

   (2 rows)
   cqlsh> SELECT release_version from system.local  ;

    release_version
   -----------------
              3.0.8

   (1 rows)
```
After:
```
   cqlsh> SELECT release_version from system.peers ;

    release_version
   -----------------
              4.6.dev-0.20210528.33d88f992
              4.6.dev-0.20210528.33d88f992

   (2 rows)
   cqlsh> SELECT release_version from system.local  ;

    release_version
   -----------------
              4.6.dev-0.20210528.33d88f992

   (1 rows)
```
Fixes #8740