### PR TITLE
build, utils/bptree.hh: drop -Wno-gnu-designator warning

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1284,7 +1284,6 @@ warnings = [
     '-Wno-redeclared-class-member',
     '-Wno-pessimizing-move',
     '-Wno-redundant-move',
-    '-Wno-gnu-designator',
     '-Wno-unsupported-friend',
     '-Wno-unused-variable',
     '-Wno-delete-non-abstract-non-virtual-dtor',

--- a/utils/bptree.hh
+++ b/utils/bptree.hh
@@ -1605,7 +1605,7 @@ class node final {
 
     void insert_into_parent(node& nn, Key sep, Less less, prealloc& nodes) noexcept {
         nn._parent = _parent;
-        _parent->insert_key(std::move(sep), node_or_data{n: &nn}, less, nodes);
+        _parent->insert_key(std::move(sep), node_or_data{.n = &nn}, less, nodes);
     }
 
     void insert_into_root(node& nn, Key sep, prealloc& nodes) noexcept {
@@ -1656,7 +1656,7 @@ class node final {
             cur = cur->_parent;
         }
 
-        insert(i, std::move(k), node_or_data{d: d}, less, nodes);
+        insert(i, std::move(k), node_or_data{.d = d}, less, nodes);
         assert(nodes.empty());
     }
 


### PR DESCRIPTION
Drop the warning about old-stye GNU designated initializers and
convert two violations in bptree.hh to the standard C++20 syntax.