### PR TITLE
Revert adding DefaultDependencies=no, move local-fs.target to Before=

### DIFF
--- a/dist/common/scripts/scylla_coredump_setup
+++ b/dist/common/scripts/scylla_coredump_setup
@@ -67,7 +67,6 @@ Description=Save coredump to scylla data directory
 Conflicts=umount.target
 Before=scylla-server.service
 After=local-fs.target
-DefaultDependencies=no
 
 [Mount]
 What=/var/lib/scylla/coredump

--- a/dist/common/scripts/scylla_coredump_setup
+++ b/dist/common/scripts/scylla_coredump_setup
@@ -65,8 +65,7 @@ ExternalSizeMax=1024G
 [Unit]
 Description=Save coredump to scylla data directory
 Conflicts=umount.target
-Before=scylla-server.service
-After=local-fs.target
+Before=local-fs.target scylla-server.service
 
 [Mount]
 What=/var/lib/scylla/coredump

--- a/dist/common/scripts/scylla_raid_setup
+++ b/dist/common/scripts/scylla_raid_setup
@@ -161,15 +161,15 @@ if __name__ == '__main__':
     os.makedirs(mount_at, exist_ok=True)
 
     uuid = run(f'blkid -s UUID -o value {fsdev}', shell=True, check=True, capture_output=True, encoding='utf-8').stdout.strip()
-    after = 'local-fs.target'
+    after = ''
     if raid:
-        after += f' {md_service}'
+        after += f'After={md_service}'
     unit_data = f'''
 [Unit]
 Description=Scylla data directory
-Before=scylla-server.service
-After={after}
 Wants={md_service}
+Before=local-fs.target scylla-server.service
+{after}
 
 [Mount]
 What=/dev/disk/by-uuid/{uuid}

--- a/dist/common/scripts/scylla_raid_setup
+++ b/dist/common/scripts/scylla_raid_setup
@@ -170,7 +170,6 @@ Description=Scylla data directory
 Before=scylla-server.service
 After={after}
 Wants={md_service}
-DefaultDependencies=no
 
 [Mount]
 What=/dev/disk/by-uuid/{uuid}


### PR DESCRIPTION
All mount units generated by systemd-fstab-generator have
"Before=local-fs.target", it is opposite of our mount units.
Seems like it is the reason we got "ordering cycle" error on #8482,
we need to move local-fs.target to Before= to fix the error.

Fixes #8761
