### PR TITLE
Add option to forbid SimpleStrategy in CREATE/ALTER KEYSPACE

### DIFF
--- a/cql3/statements/alter_keyspace_statement.hh
+++ b/cql3/statements/alter_keyspace_statement.hh
@@ -66,6 +66,7 @@ public:
     void validate(service::storage_proxy& proxy, const service::client_state& state) const override;
     future<shared_ptr<cql_transport::event::schema_change>> announce_migration(query_processor& qp) const override;
     virtual std::unique_ptr<prepared_statement> prepare(database& db, cql_stats& stats) override;
+    virtual future<::shared_ptr<messages::result_message>> execute(query_processor& qp, service::query_state& state, const query_options& options) const override;
 };
 
 }

--- a/cql3/statements/create_keyspace_statement.cc
+++ b/cql3/statements/create_keyspace_statement.cc
@@ -57,7 +57,7 @@ namespace cql3 {
 
 namespace statements {
 
-logging::logger create_keyspace_statement::_logger("create_keyspace");
+static logging::logger mylogger("create_keyspace");
 
 create_keyspace_statement::create_keyspace_statement(const sstring& name, shared_ptr<ks_prop_defs> attrs, bool if_not_exists)
     : _name{name}
@@ -209,7 +209,7 @@ create_keyspace_statement::execute(query_processor& qp, service::query_state& st
     return schema_altering_statement::execute(qp, state, options).then([this, warning = std::move(warning)] (::shared_ptr<messages::result_message> msg) {
         if (warning) {
             msg->add_warning(*warning);
-            _logger.warn("{}", *warning);
+            mylogger.warn("{}", *warning);
         }
         return msg;
     });

--- a/cql3/statements/create_keyspace_statement.cc
+++ b/cql3/statements/create_keyspace_statement.cc
@@ -47,6 +47,7 @@
 #include "service/storage_proxy.hh"
 #include "transport/messages/result_message.hh"
 #include "cql3/query_processor.hh"
+#include "db/config.hh"
 
 #include <regex>
 
@@ -147,20 +148,69 @@ future<> cql3::statements::create_keyspace_statement::grant_permissions_to_creat
     });
 }
 
+using strategy_class_registry = class_registry<
+    locator::abstract_replication_strategy,
+    const sstring&,
+    const locator::shared_token_metadata&,
+    locator::snitch_ptr&,
+    const std::map<sstring, sstring>&>;
+
+// Check for replication strategy choices which are restricted by the
+// configuration. This check can throw a configuration_exception immediately
+// if the strategy is forbidden by the configuration, or return a warning
+// string if the restriction was set to "warn".
+// This function is only supposed to check for replication strategies
+// restricted by the configuration. Checks for other types of strategy
+// errors (such as unknown replication strategy name or unknown options
+// to a known replication strategy) are done elsewhere.
+std::optional<sstring> check_restricted_replication_strategy(
+    service::storage_proxy& proxy,
+    const sstring& keyspace,
+    const ks_prop_defs& attrs)
+{
+    if (!attrs.get_replication_strategy_class()) {
+        return std::nullopt;
+    }
+    sstring replication_strategy = strategy_class_registry::to_qualified_class_name(
+        *attrs.get_replication_strategy_class());
+    // SimpleStrategy is not recommended in any setup which already has - or
+    // may have in the future - multiple racks or DCs. So depending on how
+    // protective we are configured, let's prevent it or allow with a warning:
+    if (replication_strategy == "org.apache.cassandra.locator.SimpleStrategy") {
+        switch(proxy.local_db().get_config().restrict_replication_simplestrategy()) {
+        case db::tri_mode_restriction_t::mode::TRUE:
+            throw exceptions::configuration_exception(
+                "SimpleStrategy replication class is not recommended, and "
+                "forbidden by the current configuration. Please use "
+                "NetworkToplogyStrategy instead. You may also override this "
+                "restriction with the restrict_replication_simplestrategy=false "
+                "configuration option.");
+        case db::tri_mode_restriction_t::mode::WARN:
+            return format("SimpleStrategy replication class is not "
+                "recommended, but was used for keyspace {}. The "
+                "restrict_replication_simplestrategy configuration option "
+                "can be changed to silence this warning or make it into an error.",
+                keyspace);
+        case db::tri_mode_restriction_t::mode::FALSE:
+            // Scylla was configured to allow SimpleStrategy, but let's warn
+            // if it's used on a cluster which *already* has multiple DCs:
+            if (proxy.get_token_metadata_ptr()->get_topology().get_datacenter_endpoints().size() > 1) {
+                return "Using SimpleStrategy in a multi-datacenter environment is not recommended.";
+            }
+            break;
+        }
+    }
+    return std::nullopt;
+}
+
 future<::shared_ptr<messages::result_message>>
 create_keyspace_statement::execute(query_processor& qp, service::query_state& state, const query_options& options) const {
-    service::storage_proxy& proxy = qp.proxy();
-    return schema_altering_statement::execute(qp, state, options).then([this, p = proxy.shared_from_this()] (::shared_ptr<messages::result_message> msg) {
-        bool multidc = p->get_token_metadata_ptr()->get_topology().get_datacenter_endpoints().size() > 1;
-        bool simple = _attrs->get_replication_strategy_class() == "SimpleStrategy";
-
-        if (multidc && simple) {
-            static const auto warning = "Using SimpleStrategy in a multi-datacenter environment is not recommended.";
-
-            msg->add_warning(warning);
-            _logger.warn(warning);
+    std::optional<sstring> warning = check_restricted_replication_strategy(qp.proxy(), keyspace(), *_attrs);
+    return schema_altering_statement::execute(qp, state, options).then([this, warning = std::move(warning)] (::shared_ptr<messages::result_message> msg) {
+        if (warning) {
+            msg->add_warning(*warning);
+            _logger.warn("{}", *warning);
         }
-
         return msg;
     });
 }

--- a/cql3/statements/create_keyspace_statement.hh
+++ b/cql3/statements/create_keyspace_statement.hh
@@ -43,7 +43,6 @@
 
 #include "cql3/statements/schema_altering_statement.hh"
 #include "transport/event.hh"
-#include "log.hh"
 
 #include <seastar/core/shared_ptr.hh>
 
@@ -58,8 +57,6 @@ class ks_prop_defs;
 /** A <code>CREATE KEYSPACE</code> statement parsed from a CQL query. */
 class create_keyspace_statement : public schema_altering_statement {
 private:
-    static logging::logger _logger;
-
     sstring _name;
     shared_ptr<ks_prop_defs> _attrs;
     bool _if_not_exists;

--- a/cql3/statements/create_keyspace_statement.hh
+++ b/cql3/statements/create_keyspace_statement.hh
@@ -97,6 +97,11 @@ public:
     execute(query_processor& qp, service::query_state& state, const query_options& options) const override;
 };
 
+std::optional<sstring> check_restricted_replication_strategy(
+    service::storage_proxy& proxy,
+    const sstring& keyspace,
+    const ks_prop_defs& attrs);
+
 }
 
 }

--- a/db/config.cc
+++ b/db/config.cc
@@ -823,7 +823,7 @@ db::config::config(std::shared_ptr<db::extensions> exts)
         "\t'datacenter_name':N [,...], (Default: 'dc1:1') IFF the class is NetworkTopologyStrategy, assign replication factors to each data center in a comma separated list.\n"
         "\n"
         "Related information: About replication strategy.")
-
+    , restrict_replication_simplestrategy(this, "restrict_replication_simplestrategy", liveness::LiveUpdate, value_status::Used, db::tri_mode_restriction_t::mode::FALSE, "Controls whether to disable SimpleStrategy replication. Can be true, false, or warn.")
     , default_log_level(this, "default_log_level", value_status::Used)
     , logger_log_level(this, "logger_log_level", value_status::Used)
     , log_to_stdout(this, "log_to_stdout", value_status::Used)

--- a/db/config.cc
+++ b/db/config.cc
@@ -121,6 +121,10 @@ const config_type config_type_for<std::vector<enum_option<db::experimental_featu
         "experimental features", value_to_json<std::vector<sstring>>);
 
 template <>
+const config_type config_type_for<enum_option<db::tri_mode_restriction_t>> = config_type(
+        "restriction mode", value_to_json<sstring>);
+
+template <>
 const config_type config_type_for<db::config::hinted_handoff_enabled_type> = config_type("hinted handoff enabled", hinted_handoff_enabled_to_json);
 
 }
@@ -184,6 +188,23 @@ template <>
 class convert<enum_option<db::experimental_features_t>> {
 public:
     static bool decode(const Node& node, enum_option<db::experimental_features_t>& rhs) {
+        std::string name;
+        if (!convert<std::string>::decode(node, name)) {
+            return false;
+        }
+        try {
+            std::istringstream(name) >> rhs;
+        } catch (boost::program_options::invalid_option_value&) {
+            return false;
+        }
+        return true;
+    }
+};
+
+template <>
+class convert<enum_option<db::tri_mode_restriction_t>> {
+public:
+    static bool decode(const Node& node, enum_option<db::tri_mode_restriction_t>& rhs) {
         std::string name;
         if (!convert<std::string>::decode(node, name)) {
             return false;
@@ -964,6 +985,14 @@ std::unordered_map<sstring, db::experimental_features_t::feature> db::experiment
 
 std::vector<enum_option<db::experimental_features_t>> db::experimental_features_t::all() {
     return {UDF, ALTERNATOR_STREAMS};
+}
+
+std::unordered_map<sstring, db::tri_mode_restriction_t::mode> db::tri_mode_restriction_t::map() {
+    return {{"true", db::tri_mode_restriction_t::mode::TRUE},
+            {"1", db::tri_mode_restriction_t::mode::TRUE},
+            {"false", db::tri_mode_restriction_t::mode::FALSE},
+            {"0", db::tri_mode_restriction_t::mode::FALSE},
+            {"warn", db::tri_mode_restriction_t::mode::WARN}};
 }
 
 template struct utils::config_file::named_value<seastar::log_level>;

--- a/db/config.hh
+++ b/db/config.hh
@@ -353,6 +353,11 @@ public:
     named_value<uint16_t> redis_database_count;
     named_value<string_map> redis_keyspace_replication_strategy_options;
 
+    // Options to restrict (forbid, warn or somehow limit) certain operations
+    // or options which non-expert users are more likely to regret than to
+    // enjoy:
+    named_value<tri_mode_restriction> restrict_replication_simplestrategy;
+
     seastar::logging_settings logging_settings(const boost::program_options::variables_map&) const;
 
     const db::extensions& extensions() const;

--- a/db/config.hh
+++ b/db/config.hh
@@ -87,6 +87,16 @@ struct experimental_features_t {
     static std::vector<enum_option<experimental_features_t>> all();
 };
 
+/// A restriction that can be in three modes: true (the operation is disabled),
+/// false (the operation is allowed), or warn (the operation is allowed but
+/// produces a warning in the log).
+struct tri_mode_restriction_t {
+    enum class mode { FALSE, TRUE, WARN };
+    static std::unordered_map<sstring, mode> map(); // for enum_option<>
+};
+using tri_mode_restriction = enum_option<tri_mode_restriction_t>;
+
+
 class config : public utils::config_file {
 public:
     config();

--- a/utils/enum_option.hh
+++ b/utils/enum_option.hh
@@ -87,8 +87,12 @@ class enum_option {
         return _value == that._value;
     }
 
+    // For comparison with enum values using if or switch:
     bool operator==(typename map_t::mapped_type value) const {
         return _value == value;
+    }
+    operator typename map_t::mapped_type() const {
+        return _value;
     }
 
     // For program_options parser:


### PR DESCRIPTION
This series adds a new configuration option -
restrict_replication_simplestrategy - which can be used to restrict the
ability to use SimpleStrategy in a CREATE KEYSPACE or ALTER KEYSPACE
statement. This is part of a new effort (dubbed "safe mode") to allow an
installation to restrict operations which are un-recommended or dangerous
(see issue #8586 for why SimpleStrategy is bad).

The new restrict_replication_simplestrategy option has three values:
"true", "false", and "warn":

For the time being, the default is still "false", which means SimpleStrategy is not
restricted, and can still be used freely.

Setting a value of "true" means that SimpleStrategy *is* restricted -
trying to create a a table with it will fail:

    cqlsh> CREATE KEYSPACE try1 WITH REPLICATION = { 'class' :
           'SimpleStrategy', 'replication_factor': 1 };

    ConfigurationException: SimpleStrategy replication class is not
    recommended, and forbidden by the current configuration. Please use
    NetworkToplogyStrategy instead. You may also override this restriction
    with the restrict_replication_simplestrategy=false configuration
    option.

Trying to ALTER an existing keyspace to use SimpleStrategy will
similarly fail.

The value "warn" allows - like "false" - SimpleStrategy to be used, but
produces a warning when used to create a keyspace. This warning appears
in the CREATE/ALTER KEYSPACE statement's response (an interactive cqlsh
user will see this warning), and also in Scylla's logs. For example:

    cqlsh> CREATE KEYSPACE try1 WITH REPLICATION = { 'class' :
           'SimpleStrategy', 'replication_factor': 1 };

    Warnings :
    SimpleStrategy replication class is not recommended, but was used for
    keyspace try1. The restrict_replication_simplestrategy configuration
    option can be changed to silence this warning or make it into an error.

Fixes #8586

