### PR TITLE
table: Always use explicit commitlog discard + clear out rp_set

### DIFF
--- a/memtable.hh
+++ b/memtable.hh
@@ -272,8 +272,14 @@ public:
     const db::replay_position& replay_position() const {
         return _replay_position;
     }
-    const db::rp_set& rp_set() const {
-        return _rp_set;
+    /**
+     * Returns the current rp_set, and resets the
+     * stored one to empty. Only used for flushing
+     * purposes, to one-shot report discarded rp:s
+     * to commitlog
+     */
+    db::rp_set get_and_discard_rp_set() {
+        return std::exchange(_rp_set, {});
     }
     friend class iterator_reader;
 

--- a/table.cc
+++ b/table.cc
@@ -598,7 +598,7 @@ table::seal_active_memtable(flush_permit&& permit) {
         }
 
         if (_commitlog) {
-            _commitlog->discard_completed_segments(_schema->id(), old->rp_set());
+            _commitlog->discard_completed_segments(_schema->id(), old->get_and_discard_rp_set());
         }
         return previous_flush.finally([op = std::move(op)] { });
     });
@@ -1504,7 +1504,9 @@ bool table::can_flush() const {
 future<> table::clear() {
     _memtables->clear_and_add();
     if (_commitlog) {
-        _commitlog->discard_completed_segments(_schema->id());
+        for (auto& t : *_memtables) {
+            _commitlog->discard_completed_segments(_schema->id(), t->get_and_discard_rp_set());
+        }
     }
     return _cache.invalidate(row_cache::external_updater([] { /* There is no underlying mutation source */ }));
 }


### PR DESCRIPTION
Fixes #8733

If a memtable flush is still pending when we call table::clear(),
we can end up doing a "discard-all" call to commitlog, followed
by a per-segment-count (using rp_set) _later_. This will foobar
our internal usage counts and quite probably cause assertion
failures.
Fixed by always doing per-memtable explicit discard call. But to
ensure this works, since a memtable being flushed remains on
memtable list for a while (why?), we must also ensure we clear
out the rp_set on discard.