### PR TITLE
build: enable -Wunused-function

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1290,7 +1290,6 @@ warnings = [
     '-Wno-delete-non-abstract-non-virtual-dtor',
     '-Wno-unknown-attributes',
     '-Wno-braced-scalar-init',
-    '-Wno-unused-function',
     '-Wno-implicit-int-float-conversion',
     '-Wno-delete-abstract-non-virtual-dtor',
     '-Wno-uninitialized-const-reference',

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -677,12 +677,6 @@ future<> cql_server::connection::process_request() {
     });
 }
 
-static inline bytes_view to_bytes_view(temporary_buffer<char>& b)
-{
-    using byte = bytes_view::value_type;
-    return bytes_view(reinterpret_cast<const byte*>(b.get()), b.size());
-}
-
 namespace compression_buffers {
 
 // Reusable buffers for compression and decompression. Cleared every


### PR DESCRIPTION
Also drop a single violation in transport/server.cc. This helps
prevent dead code from piling up.

Three functions in row_cache_test that are not used in debug mode
are moved near their user, and under the same ifdef, to avoid triggering
the error.
