### PR TITLE
cf_prop_defs: Fix extensions merge to handle removal

### DIFF
--- a/cql3/statements/cf_prop_defs.cc
+++ b/cql3/statements/cf_prop_defs.cc
@@ -322,7 +322,11 @@ void cf_prop_defs::apply_to_builder(schema_builder& builder, schema::extensions_
 
     // for extensions that are not altered, keep the old ones
     auto& old_exts = builder.get_extensions();
-    schema_extensions.insert(old_exts.begin(), old_exts.end());
+    for (auto& [key, ext] : old_exts) {
+        if (!_properties.count(key)) {
+            schema_extensions.emplace(key, ext);
+        }
+    }
 
     builder.set_extensions(std::move(schema_extensions));
 }


### PR DESCRIPTION
Fixes #8773

When refactored for cdc, properties -> extensions merge
was modified so it did not handle _removal_ (i.e. an
extension function returning null -> no entry in new map).

This causes certain enterprise extensions to not be able
to disable themselves.

Fixed by filtering existing extensions by property keywords.
Unit test added.

Requires backport to 2020.1 and all other affected releases.