### PR TITLE
gossiper: Update timestamp for nodes in ack and ack2 msg handler

### DIFF
--- a/gms/gossiper.hh
+++ b/gms/gossiper.hh
@@ -423,6 +423,8 @@ public:
      */
     int compare_endpoint_startup(inet_address addr1, inet_address addr2);
 private:
+    void update_timestamp_for_nodes(const std::map<inet_address, endpoint_state>& map);
+
     void mark_alive(inet_address addr, endpoint_state& local_state);
 
     void real_mark_alive(inet_address addr, endpoint_state& local_state);


### PR DESCRIPTION
In commit 425e3b11827ab5db6d68024134233e85064c7f74 (gossip: Introduce
direct failure detector), the call to notify_failure_detector inside ack
and ack2 msg handler was removed since there is no need to update the
old failure detector anymore. However, the timestamp for endpoit_state
is also updated inside notify_failure_detector. With the new failure
detector we still need the timestamp for endpoit_state. Otherwise, nodes
might be removed from gossip wrongly.

For example, as we saw in issue #8702:

INFO  2021-05-24 22:45:24,713 [shard 0] gossip - FatClient 127.0.60.2
has been silent for 5000ms, removing from gossip

To fix, update the timestamp as we do before in ack and ack2 msg
handler.

Fixes #8702