### PR TITLE
repair: Init repair metrics during startup

### DIFF
--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -114,6 +114,11 @@ private:
         return removenode_total_ranges == 0 ? 1 : float(removenode_finished_ranges) / float(removenode_total_ranges);
     }
     float repair_finished_percentage();
+public:
+    void init() {
+        // Dummy function to call during startup to initialize the thread local
+        // variable node_ops_metrics _node_ops_metrics below.
+    }
 };
 
 static thread_local node_ops_metrics _node_ops_metrics;
@@ -1908,8 +1913,14 @@ future<> repair_service::replace_with_repair(locator::token_metadata_ptr tmptr, 
     co_return co_await do_rebuild_replace_with_repair(std::move(cloned_tmptr), std::move(op), std::move(source_dc), reason);
 }
 
+future<> repair_service::init_metrics() {
+    _node_ops_metrics.init();
+    return make_ready_future<>();
+}
+
 future<> repair_service::init_ms_handlers() {
     auto& ms = this->_messaging;
+
 
     ms.register_node_ops_cmd([] (const rpc::client_info& cinfo, node_ops_cmd_request req) {
         auto src_cpu_id = cinfo.retrieve_auxiliary<uint32_t>("src_cpu_id");

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -3012,6 +3012,7 @@ repair_service::repair_service(distributed<gms::gossiper>& gossiper,
 
 future<> repair_service::start() {
     return when_all_succeed(
+            init_metrics(),
             init_ms_handlers(),
             init_row_level_ms_handlers()
     ).discard_result();

--- a/repair/row_level.hh
+++ b/repair/row_level.hh
@@ -59,6 +59,8 @@ class repair_service : public seastar::peering_sharded_service<repair_service> {
     future<> init_row_level_ms_handlers();
     future<> uninit_row_level_ms_handlers();
 
+    future<> init_metrics();
+
 public:
     repair_service(distributed<gms::gossiper>& gossiper,
             netw::messaging_service& ms,


### PR DESCRIPTION
The _node_ops_metrics is thread local, it is constructed when it
is first accessed.

If there are no node operations, the metrics will not be shown. To make the
metrics more consistent, init during startup.

Refs #8311