### PR TITLE
cql3: expression: don't copy expression in has_supporting_index()

### DIFF
--- a/cql3/expr/expression.cc
+++ b/cql3/expr/expression.cc
@@ -818,7 +818,7 @@ bool has_supporting_index(
         const secondary_index::secondary_index_manager& index_manager,
         allow_local_index allow_local) {
     const auto indexes = index_manager.list_indexes();
-    const auto support = std::bind(is_supported_by, expr, std::placeholders::_1);
+    const auto support = std::bind(is_supported_by, std::ref(expr), std::placeholders::_1);
     return allow_local ? boost::algorithm::any_of(indexes, support)
             : boost::algorithm::any_of(
                     indexes | filtered([] (const secondary_index::index& i) { return !i.metadata().local(); }),


### PR DESCRIPTION
std::bind() copies the bound parameters for safekeeping. Here this
includes expr, which can be quite heavyweight. Use std::ref() to
prevent copying. This is safe since the bound expression is executed
and discarded before has_supporting_index() returns.