### PR TITLE
test/alternator: rewrite run script to share code with cql-pytest's run script

### DIFF
--- a/test/alternator/run
+++ b/test/alternator/run
@@ -1,181 +1,83 @@
-#!/bin/bash
+#!/usr/bin/env python3
+# Use the run.py library from ../cql-pytest:
+import sys
+sys.path.insert(1, sys.path[0] + '/../cql-pytest')
+import run
 
-# Exit if any one of the commands below fails
-set -e
+import os
+import requests
+import time
+import cassandra.cluster
+import cassandra.auth
 
-script_path=$(dirname $(readlink -e $0))
-source_path=$script_path/../..
+# check_alternator() below uses verify=False to accept self-signed SSL
+# certificates but then we get scary warnings. This trick disables them:
+import urllib3
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
-# By default, we take the latest build/*/scylla as the executable:
-SCYLLA=${SCYLLA-$(ls -t "$source_path/build/"*"/scylla" | head -1)}
-SCYLLA=$(readlink -f "$SCYLLA")
+print('Scylla is: ' + run.scylla + '.')
 
-# Below, we need to use python3 and the Cassandra drive to set up the
-# authentication credentials expected by some of the tests that check
-# authentication. If they are not installed there isn't much point of
-# even starting Scylla
-if ! python3 -c 'from cassandra.cluster import Cluster' >/dev/null 2>&1
-then
-    echo "Error: python3 and python3-cassandra-driver must be installed to configure Alternator authentication." >&2
-    exit 1
-fi
+# run_alternator_cmd runs the same as run_scylla_cmd with *additional*
+# parameters, so in particular both CQL and Alternator will be enabled.
+# This is useful for us because we need CQL to setup authentication.
+def run_alternator_cmd(pid, dir):
+    (cmd, env) = run.run_scylla_cmd(pid, dir)
+    ip = run.pid_to_ip(pid)
+    cmd += [
+        '--alternator-address', ip,
+        '--alternator-enforce-authorization', '1',
+        '--alternator-write-isolation', 'always_use_lwt',
+        '--alternator-streams-time-window-s', '0',
+        '--alternator-timeout-in-ms', '30000',
+    ]
+    if '--https' in sys.argv:
+        run.setup_ssl_certificate(dir)
+        cmd += ['--alternator-https-port', '8043',
+            '--alternator-encryption-options', f'keyfile={dir}/scylla.key',
+            '--alternator-encryption-options', f'certificate={dir}/scylla.crt',
+        ]
+    else:
+        cmd += ['--alternator-port', '8000']
 
-# Pick a loopback IP address for Scylla to run, in an attempt not to collide
-# other concurrent runs of Scylla. CCM uses 127.0.0.<nodenum>, so if we use
-# 127.1.*.* which cannot collide with it. Moreover, we'll take the last two
-# bytes of the address from the current process - so as to allow multiple
-# concurrent runs of this code to use a different address.
-SCYLLA_IP=127.1.$(($$ >> 8 & 255)).$(($$ & 255))
-echo "Running Scylla on $SCYLLA_IP"
+    return (cmd, env)
 
-tmp_dir="$(readlink -e ${TMPDIR-/tmp})"/alternator-test-$$
-mkdir "$tmp_dir"
+pid = run.run_with_temporary_dir(run_alternator_cmd)
+ip = run.pid_to_ip(pid)
 
-# We run the cleanup() function on exit for any reason - successful finish
-# of the script, an error (since we have "set -e"), or a signal.
-# It ensures that Scylla is killed and its temporary storage directory is
-# deleted. It also shows Scylla's output log.
-code=17
-summary=
-cleanup() {
-    kill -9 $SCYLLA_PROCESS 2>/dev/null || :
-    echo
-    echo "Scylla log:"
-    echo
-    # we want to cat "$tmp_dir/log", but this can take a long time,
-    # especially if stdout is piped, and be interrupted. We don't want
-    # the "rm" below to not happen, so we need to open the file later,
-    # and cat it later:
-    exec 3<"$tmp_dir/log"
-    rm -rf --preserve-root "$tmp_dir"
-    cat <&3
-    echo $summary
-    exit $code
-}
-trap 'cleanup' EXIT
+if '--https' in sys.argv:
+    alternator_url=f"https://{ip}:8043"
+else:
+    alternator_url=f"http://{ip}:8000"
 
-# Set up SSL certificates needed for "--alternator-https-port=8043"
-# to work. We only need to do this if the "--https" option was explicitly
-# passed - otherwise the test would not use HTTPS anyway.
-alternator_port_option="--alternator-port=8000"
-alternator_url="http://$SCYLLA_IP:8000"
-for i
-do
-    if [ "$i" = --https ]
-    then
-        openssl genrsa 2048 > "$tmp_dir/scylla.key"
-        openssl req -new -x509 -nodes -sha256 -days 365 -subj "/C=IL/ST=None/L=None/O=None/OU=None/CN=example.com" -key "$tmp_dir/scylla.key" -out "$tmp_dir/scylla.crt"
-        alternator_port_option="--alternator-https-port=8043"
-        alternator_url="https://$SCYLLA_IP:8043"
-    fi
-done
+# Wait for both CQL and Alternator APIs to become responsive. We obviously
+# need the Alternator API to test Alternator, but currently we also need
+# CQL for setting up authentication.
+def check_alternator(url):
+    try:
+        requests.get(url, verify=False)
+    except requests.ConnectionError:
+        raise run.NotYetUp
+    # Any other exception may indicate a problem, and is passed to the caller.
 
-# To make things easier for users of "killall", "top", and similar, we want
-# the Scylla executable which we run during the test to have a different name
-# from manul runs of Scylla. Unfortunately, using "exec -a" to change just
-# argv[0] isn't good enough - because killall inspects the actual executable
-# filename in /proc/<pid>/stat. So we need to name the executable differently.
-# Luckily, using a symbolic link is good enough.
-SCYLLA_LINK="$tmp_dir"/test_scylla
-ln -s "$SCYLLA" "$SCYLLA_LINK"
-
-"$SCYLLA_LINK" --options-file "$source_path/conf/scylla.yaml" \
-        --alternator-address $SCYLLA_IP \
-        $alternator_port_option \
-        --alternator-enforce-authorization=1 \
-        --alternator-write-isolation=always_use_lwt \
-        --alternator-streams-time-window-s=0 \
-        --alternator-timeout-in-ms 30000 \
-        --developer-mode=1 \
-        --experimental-features=alternator-streams \
-        --ring-delay-ms 0 --collectd 0 \
-        --smp 2 -m 1G \
-        --overprovisioned --unsafe-bypass-fsync 1 --kernel-page-cache 1 \
-        --api-address $SCYLLA_IP \
-        --rpc-address $SCYLLA_IP \
-        --listen-address $SCYLLA_IP \
-        --prometheus-address $SCYLLA_IP \
-        --seed-provider-parameters seeds=$SCYLLA_IP \
-        --workdir "$tmp_dir" \
-        --alternator-encryption-options keyfile="$tmp_dir/scylla.key" \
-        --alternator-encryption-options certificate="$tmp_dir/scylla.crt" \
-        --auto-snapshot 0 \
-        --skip-wait-for-gossip-to-settle 0 \
-        --logger-log-level compaction=warn \
-        --logger-log-level migration_manager=warn \
-        --num-tokens 16 \
-        >"$tmp_dir/log" 2>&1 &
-SCYLLA_PROCESS=$!
+run.wait_for_services(pid, [
+    lambda: run.check_cql(ip),
+    lambda: check_alternator(alternator_url),
+])
 
 # Set up the the proper authentication credentials needed by the Alternator
-# test. This requires connecting to Scylla with CQL - we'll wait up for
-# one minute for this to work:
-setup_authentication() {
-    python3 -c 'from cassandra.cluster import Cluster; Cluster(["'$SCYLLA_IP'"]).connect().execute("INSERT INTO system_auth.roles (role, salted_hash) VALUES ('\''alternator'\'', '\''secret_pass'\'')")'
-}
-# Test that Alternator is serving. Alternator starts after CQL, so we use
-# check_alternator() to verify that both are up.
-check_alternator() {
-    python3 -c 'import requests; requests.get("'$alternator_url'/")'
-}
-echo "Scylla is: $SCYLLA."
-echo -n "Booting Scylla..."
-ok=
-SECONDS=0
-while ((SECONDS < 200))
-do
-    sleep 1
-    echo -n .
-    if ! kill -0 $SCYLLA_PROCESS 2>/dev/null
-    then
-        summary="Error: Scylla failed to boot after $SECONDS seconds."
-        break
-    fi
-    case "`check_alternator 2>&1`" in
-    *"Connection refused"*)
-        # This may indicate that Scylla is still booting, or that it failed
-        # to boot and exited. Try again (and check again if Scylla exited).
-        continue;;
-    esac
-    err=`setup_authentication 2>&1` && ok=yes && break
-    case "$err" in
-    *NoHostAvailable:*)
-        # This is what we expect while Scylla is still booting.
-        ;;
-    *ImportError:*|*"command not found"*)
-        summary="Error: need python3 and python3-cassandra-driver to configure Alternator authentication."
-        echo
-        echo $summary
-        break;;
-    *)
-        summary="Unknown error trying to set authentication credentials: '$err'"
-        echo
-        echo $summary
-        break;;
-    esac
-done
-if test -n "$ok" && kill -0 $SCYLLA_PROCESS 2>/dev/null
-then
-    echo "Done ($SECONDS seconds)"
-else
-    echo
-    if test -z "$summary"
-    then
-        summary="Error: Scylla failed to boot after $SECONDS seconds."
-        echo $summary
-    fi
-    exit 1
-fi
+# test. Currently this can only be done through CQL, which is why above we
+# needed to make sure CQL is available.
+cluster = run.get_cql_cluster(ip)
+cluster.connect().execute("INSERT INTO system_auth.roles (role, salted_hash) VALUES ('alternator', 'secret_pass')")
+cluster.shutdown()
 
-cd "$script_path"
-set +e
-pytest --url $alternator_url -o junit_family=xunit2 "$@"
-code=$?
-case $code in
-0) summary="Alternator tests pass";;
-*) summary="Alternator tests failure";;
-esac
+# Finally run pytest:
+success = run.run_pytest(sys.path[0], ['--url', alternator_url] + sys.argv[1:])
 
-# Note that the cleanup() function runs now, just like on any exit from
-# any reason in this script. It will delete the temporary files and
-# announce the failure or success of the test.
+run.summary = 'Alternator tests pass' if success else 'Alternator tests failure'
+
+exit(0 if success else 1)
+
+# Note that the run.cleanup_all() function runs now, just like on any exit
+# for any reason in this script. It will delete the temporary files and
+# announce the failure or success of the test (printing run.summary).

--- a/test/cql-pytest/run
+++ b/test/cql-pytest/run
@@ -10,7 +10,7 @@ pid = run.run_with_temporary_dir(run.run_scylla_cmd)
 ip = run.pid_to_ip(pid)
 
 run.wait_for_cql(pid, ip)
-success = run.run_cql_pytest(ip, sys.argv[1:])
+success = run.run_pytest(sys.path[0], ['--host', ip] + sys.argv[1:])
 
 run.summary = 'Scylla tests pass' if success else 'Scylla tests failure'
 

--- a/test/cql-pytest/run-cassandra
+++ b/test/cql-pytest/run-cassandra
@@ -88,7 +88,7 @@ pid = run.run_with_temporary_dir(run_cassandra_cmd)
 ip = run.pid_to_ip(pid)
 
 run.wait_for_cql(pid, ip)
-success = run.run_cql_pytest(ip, sys.argv[1:])
+success = run.run_pytest(sys.path[0], ['--host', ip] + sys.argv[1:])
 
 run.summary = 'Cassandra tests pass' if success else 'Cassandra tests failure'
 

--- a/test/cql-pytest/run.py
+++ b/test/cql-pytest/run.py
@@ -25,6 +25,7 @@ def pid_to_dir(pid):
 
 def run_with_temporary_dir(run_cmd_generator):
     global run_with_temporary_dir_pids
+    global run_pytest_pids
     # Below, there is a small time window, after we fork and the child
     # started running but before we save this child's process id in
     # run_with_temporary_dir_pids. In that small time window, a signal may
@@ -38,6 +39,7 @@ def run_with_temporary_dir(run_cmd_generator):
     if pid == 0:
         # Child
         run_with_temporary_dir_pids = set() # no children to clean up on child
+        run_pytest_pids = set()
         pid = os.getpid()
         dir = pid_to_dir(pid)
         os.mkdir(dir)
@@ -56,7 +58,7 @@ def run_with_temporary_dir(run_cmd_generator):
         # will eventually deliver a SIGKILL as part of cleanup_all().
         os.setsid()
         os.execve(cmd[0], cmd, dict(os.environ, **env))
-        # execvp will not return. If it cannot run the program, it will raise
+        # execve will not return. If it cannot run the program, it will raise
         # an exception.
     # Parent
     run_with_temporary_dir_pids.add(pid)
@@ -96,10 +98,21 @@ def abort_run_with_temporary_dir(pid):
     return f
 
 summary=''
+run_pytest_pids = set()
 
 def cleanup_all():
     global summary
     global run_with_temporary_dir_pids
+    global run_pytest_pids
+    # Kill pytest first, before killing the tested server, so we don't
+    # continue to get a barrage of errors when the test runs with the
+    # server killed.
+    for pid in run_pytest_pids:
+        try:
+            os.kill(pid, 9)
+            os.waitpid(pid, 0) # don't leave an annoying zombie
+        except ProcessLookupError:
+            pass
     for pid in run_with_temporary_dir_pids:
         f = abort_run_with_temporary_dir(pid)
         print('\nSubprocess output:\n')
@@ -203,53 +216,100 @@ def run_scylla_cmd(pid, dir):
         '--authenticator', 'PasswordAuthenticator',
         ], {})
 
-## Test that CQL is serving.
-def check_cql(ip):
+# Get a Cluster object to connect to CQL at the given IP address (and with
+# the appropriate username and password). It's important to shutdown() this
+# Cluster object when done with it, otherwise we can get errors at the end
+# of the run when background tasks continue to spawn futures after exit.
+def get_cql_cluster(ip):
     auth_provider = cassandra.auth.PlainTextAuthProvider(username='cassandra', password='cassandra')
-    cassandra.cluster.Cluster([ip], auth_provider=auth_provider).connect()
+    return cassandra.cluster.Cluster([ip], auth_provider=auth_provider)
 
-# Wait for scylla to finish booting successfully. Raises an exception if
-# we know it did not.
-def wait_for_cql(pid, ip):
+## Test that CQL is serving, for wait_for_services() below.
+def check_cql(ip):
+    try:
+        cluster = get_cql_cluster(ip)
+        cluster.connect()
+        cluster.shutdown()
+    except cassandra.cluster.NoHostAvailable:
+        raise NotYetUp
+    # Any other exception may indicate a problem, and is passed to the caller.
+
+# wait_for_services() waits for scylla to finish booting successfully and
+# listen to services checked by the given "checkers". Raises an exception
+# if we know Scylla did not boot properly (as soon as we know - not waiting
+# for a timeout).
+#
+# Each checker is a function which returns successfully if the service it
+# checks is up, or throws an exception if it is not. If the service is not
+# *yet* up, it should throw the NotYetUp exception, indicating that
+# wait_for_services() should continue to retry. Any other exceptions means
+# an unrecoverable error was detected, and retry would be hopeless.
+#
+# wait_for_services has a hard-coded timeout of 200 seconds.
+class NotYetUp(Exception):
+    pass
+def wait_for_services(pid, checkers):
     start_time = time.time()
-    cql_ready = False
+    ready = False
     while time.time() < start_time + 200:
         time.sleep(0.1)
         # To check if Scylla died already (i.e., failed to boot), we need
         # to first get rid of the zombie (if it exists) with waitpid, and
         # then check if the process still exists, with kill.
-        os.waitpid(pid, os.P_NOWAIT)
-        os.kill(pid, 0)
         try:
-            check_cql(ip)
-            # if check_cql did not raise an exception, we're done:
-            cql_ready = True
+            os.waitpid(pid, os.P_NOWAIT)
+            os.kill(pid, 0)
+        except (ProcessLookupError, ChildProcessError):
+            # Scylla is dead, we cannot recover
             break
-        except cassandra.cluster.NoHostAvailable:
+        try:
+            for checker in checkers:
+                checker()
+            # If all checkers passed, we're finally done
+            ready = True
+            break
+        except NotYetUp:
             pass
     duration = str(round(time.time() - start_time, 1)) + ' seconds'
-    if not cql_ready:
-        print(f'Boot did not complete in {duration}.')
-        check_cql(ip) # this will fail, and show why
-    os.waitpid(pid, os.P_NOWAIT)
-    os.kill(pid, 0)
+    if not ready:
+        print(f'Boot failed after {duration}.')
+        # Run the checkers again, not catching NotYetUp, to show exception
+        # traces of which of the checks failed and how.
+        os.waitpid(pid, os.P_NOWAIT)
+        os.kill(pid, 0)
+        for checker in checkers:
+            checker()
     print(f'Boot successful ({duration}).')
     sys.stdout.flush()
 
+def wait_for_cql(pid, ip):
+    wait_for_services(pid, [lambda: check_cql(ip)])
+
 def run_pytest(pytest_dir, additional_parameters):
+    global run_with_temporary_dir_pids
+    global run_pytest_pids
     sys.stdout.flush()
     sys.stderr.flush()
     pid = os.fork()
     if pid == 0:
         # child:
-        global run_with_temporary_dir_pids
         run_with_temporary_dir_pids = set() # no children to clean up on child
+        run_pytest_pids = set()
         os.chdir(pytest_dir)
         os.execvp('pytest', ['pytest',
             '-o', 'junit_family=xunit2'] + additional_parameters)
         exit(1)
     # parent:
+    run_pytest_pids.add(pid)
     if os.waitpid(pid, 0)[1]:
         return False
     else:
         return True
+
+# Set up self-signed SSL certificate in dir/scylla.key, dir/scylla.crt.
+# These can be used for setting up an HTTPS server for Alternator, or for
+# any other part of Scylla which needs SSL.
+def setup_ssl_certificate(dir):
+    # FIXME: error checking (if "openssl" isn't found, for example)
+    os.system(f'openssl genrsa 2048 > "{dir}/scylla.key"')
+    os.system(f'openssl req -new -x509 -nodes -sha256 -days 365 -subj "/C=IL/ST=None/L=None/O=None/OU=None/CN=example.com" -key "{dir}/scylla.key" -out "{dir}/scylla.crt"')

--- a/test/cql-pytest/run.py
+++ b/test/cql-pytest/run.py
@@ -236,8 +236,7 @@ def wait_for_cql(pid, ip):
     print(f'Boot successful ({duration}).')
     sys.stdout.flush()
 
-def run_cql_pytest(ip, additional_parameters):
-    cql_pytest_dir = os.path.join(source_path, 'test/cql-pytest')
+def run_pytest(pytest_dir, additional_parameters):
     sys.stdout.flush()
     sys.stderr.flush()
     pid = os.fork()
@@ -245,9 +244,9 @@ def run_cql_pytest(ip, additional_parameters):
         # child:
         global run_with_temporary_dir_pids
         run_with_temporary_dir_pids = set() # no children to clean up on child
-        os.chdir(cql_pytest_dir)
+        os.chdir(pytest_dir)
         os.execvp('pytest', ['pytest',
-            '--host', ip, '-o', 'junit_family=xunit2'] + additional_parameters)
+            '-o', 'junit_family=xunit2'] + additional_parameters)
         exit(1)
     # parent:
     if os.waitpid(pid, 0)[1]:


### PR DESCRIPTION
In this small series, I rewrite test/alternator/run to Python using the utility functions developed for test/cql-pytest. In the future, we should do the same to test/redis/run and test/scylla-gdb/run.

The benefit of this rewrite is less code duplication (all run scripts start with the same duplicate code to deal with temporary directories, to run Scylla IP addresses, etc.), but most importantly - in the future fixes we do to cql-pytest (e.g., parameters needed to start Scylla efficiently, how to shut down Scylla, etc.) will appear automatically in alternator test without needing to remember to change both.

Another benefit is that test/alternator/run will now be Python, not a shell script. This should make it easier to integrate it into test.py (refs #6212) in the future - if we want to.