### PR TITLE
cql3: expr: make column_value (and similar) a first-class expression

### DIFF
--- a/cql3/restrictions/single_column_primary_key_restrictions.hh
+++ b/cql3/restrictions/single_column_primary_key_restrictions.hh
@@ -170,7 +170,7 @@ public:
 
     virtual void merge_with(::shared_ptr<restriction> restriction) override {
         if (find_atom(restriction->expression, [] (const expr::binary_operator& b) {
-                    return std::holds_alternative<expr::column_value_tuple>(b.lhs);
+                    return std::holds_alternative<expr::column_value_tuple>(*b.lhs);
                 })) {
             throw exceptions::invalid_request_exception(
                 "Mixing single column relations and multi column relations on clustering columns is not allowed");


### PR DESCRIPTION
Currently, column names can only appear in a boolean binary expression,
but not on their own. This means that in the statement

   SELECT a FROM tab WHERE a > 3;

We can represent the WHERE clause as an expression, but not the selector.

To pave the way for using expressions in selector contexts, we promote
the elements of binary_operator::lhs (column_value, column_value_tuple,
token) to be expressions in their own right. binary_operator::lhs
becomes an expression (wrapped in unique_ptr, because variants can't
contain themselves).

Note that all three new possibilities make sense in a selector:

  SELECT column FROM tab
  SELECT token(pk) FROM tab
  SELECT function_that_accepts_a_tuple((col1, col2)) FROM tab

There is some fallout from this:

 - because binary_operator contains a unique_ptr, it is no longer
   copyable. We add a copy constructor and assignment operator to
   compensate.
 - often, the new elements don't make sense when evaluating a boolean
   expression, which is the only context we had before. We throw in
   these cases. The parser right now prevents such cases from being
   constructed in the first place (this is equivalent to if (some_struct_value)
   in C).
 - in statement_restrictions.cc, we need to evalute the lhs in the context
   of the full binary operator. I introduced with_current_binary_operator()
   for this; an alternative approach is to create a new sub-visitor.