### PR TITLE
transport: close connections when too large requests arrive

### DIFF
--- a/transport/server.cc
+++ b/transport/server.cc
@@ -601,11 +601,11 @@ future<> cql_server::connection::process_request() {
         auto stream = f.stream;
         auto mem_estimate = f.length * 2 + 8000; // Allow for extra copies and bookkeeping
         if (mem_estimate > _server._max_request_size) {
-            return _read_buf.skip(f.length).then([length = f.length, stream = f.stream, mem_estimate, this] () {
-                write_response(make_error(stream, exceptions::exception_code::INVALID,
-                        format("request size too large (frame size {:d}; estimate {:d}; allowed {:d}", length, mem_estimate, _server._max_request_size),
-                        tracing::trace_state_ptr()));
-                return make_ready_future<>();
+            write_response(make_error(stream, exceptions::exception_code::INVALID,
+                    format("request size too large (frame size {:d}; estimate {:d}; allowed {:d}", f.length, mem_estimate, _server._max_request_size),
+                    tracing::trace_state_ptr()));
+            return std::exchange(_ready_to_respond, make_ready_future<>()).then([this] {
+                return _read_buf.close();
             });
         }
 


### PR DESCRIPTION
Too large requests are currently handled by the CQL server by
skipping them and sending back an error response.
That's however wasteful and dangerous: bogus request sizes
will force Scylla to potentially skip gigabytes of data
- and skipping is done by simply reading from the socket,
so it may results in gigabytes of bandwidth wasted.
Even if the request size is not bogus, closing the connection
forces users to adjust their request sizes, which should be done
anyway.

Originally, there was a bug in handling too large requests which
only read their headers and then left the connection in a broken,
undefined state, trying to interpret the rest of the large request
as a next CQL header. It was later fixed to skip the request, but
closing the connection is a safer thing to do.

Fixes #8798

Tests: unit(release), manual(sending a request with bogus huge size, as described in #8798)