### PR TITLE
locator: token_metadata: simplify `tokens_iterator`

### DIFF
--- a/locator/token_metadata.cc
+++ b/locator/token_metadata.cc
@@ -115,8 +115,6 @@ public:
         _topology.update_endpoint(ep);
     }
 
-    tokens_iterator tokens_end() const;
-
     /**
      * Creates an iterable range of the sorted tokens starting at the token next
      * after the given one.
@@ -939,16 +937,10 @@ private:
 };
 
 inline
-token_metadata_impl::tokens_iterator
-token_metadata_impl::tokens_end() const {
-    return tokens_iterator(sorted_tokens().end(), sorted_tokens().size());
-}
-
-inline
 boost::iterator_range<token_metadata_impl::tokens_iterator>
 token_metadata_impl::ring_range(const token& start) const {
     auto begin = tokens_iterator(start, this);
-    auto end = tokens_end();
+    auto end = tokens_iterator(sorted_tokens().end(), sorted_tokens().size());
     return boost::make_iterator_range(begin, end);
 }
 
@@ -1827,11 +1819,6 @@ token_metadata::get_bootstrap_tokens() const {
 void
 token_metadata::update_topology(inet_address ep) {
     _impl->update_topology(ep);
-}
-
-token_metadata::tokens_iterator
-token_metadata::tokens_end() const {
-    return tokens_iterator(_impl->tokens_end());
 }
 
 boost::iterator_range<token_metadata::tokens_iterator>

--- a/locator/token_metadata.cc
+++ b/locator/token_metadata.cc
@@ -125,10 +125,10 @@ public:
      *
      * @return The requested range (see the description above)
      */
-    boost::iterator_range<tokens_iterator> ring_range(const token& start, bool include_min = false) const;
+    boost::iterator_range<tokens_iterator> ring_range(const token& start) const;
 
     boost::iterator_range<tokens_iterator> ring_range(
-        const std::optional<dht::partition_range::bound>& start, bool include_min = false) const;
+        const std::optional<dht::partition_range::bound>& start) const;
 
     topology& get_topology() {
         return _topology;
@@ -962,8 +962,8 @@ token_metadata_impl::tokens_end() const {
 
 inline
 boost::iterator_range<token_metadata_impl::tokens_iterator>
-token_metadata_impl::ring_range(const token& start, bool include_min) const {
-    auto begin = tokens_iterator(start, this, include_min);
+token_metadata_impl::ring_range(const token& start) const {
+    auto begin = tokens_iterator(start, this);
     auto end = tokens_end();
     return boost::make_iterator_range(begin, end);
 }
@@ -1318,11 +1318,8 @@ void token_metadata_impl::add_bootstrap_token(token t, inet_address endpoint) {
 }
 
 boost::iterator_range<token_metadata_impl::tokens_iterator>
-token_metadata_impl::ring_range(
-    const std::optional<dht::partition_range::bound>& start,
-    bool include_min) const
-{
-    auto r = ring_range(start ? start->value().token() : dht::minimum_token(), include_min);
+token_metadata_impl::ring_range(const std::optional<dht::partition_range::bound>& start) const {
+    auto r = ring_range(start ? start->value().token() : dht::minimum_token());
 
     if (!r.empty()) {
         // We should skip the first token if it's excluded by the range.
@@ -1854,17 +1851,16 @@ token_metadata::tokens_end() const {
 }
 
 boost::iterator_range<token_metadata::tokens_iterator>
-token_metadata::ring_range(const token& start, bool include_min) const {
-    auto impl_range = _impl->ring_range(start, include_min);
+token_metadata::ring_range(const token& start) const {
+    auto impl_range = _impl->ring_range(start);
     return boost::make_iterator_range(
             tokens_iterator(std::move(impl_range.begin())),
             tokens_iterator(std::move(impl_range.end())));
 }
 
 boost::iterator_range<token_metadata::tokens_iterator>
-token_metadata::ring_range(
-        const std::optional<dht::partition_range::bound>& start, bool include_min) const {
-    auto impl_range = _impl->ring_range(start, include_min);
+token_metadata::ring_range(const std::optional<dht::partition_range::bound>& start) const {
+    auto impl_range = _impl->ring_range(start);
     return boost::make_iterator_range(
             tokens_iterator(std::move(impl_range.begin())),
             tokens_iterator(std::move(impl_range.end())));

--- a/locator/token_metadata.hh
+++ b/locator/token_metadata.hh
@@ -203,9 +203,9 @@ public:
      *
      * @return The requested range (see the description above)
      */
-    boost::iterator_range<tokens_iterator> ring_range(const token& start, bool include_min = false) const;
+    boost::iterator_range<tokens_iterator> ring_range(const token& start) const;
     boost::iterator_range<tokens_iterator> ring_range(
-        const std::optional<dht::partition_range::bound>& start, bool include_min = false) const;
+        const std::optional<dht::partition_range::bound>& start) const;
 
     topology& get_topology();
     const topology& get_topology() const;

--- a/locator/token_metadata.hh
+++ b/locator/token_metadata.hh
@@ -141,7 +141,6 @@ private:
 };
 
 class token_metadata_impl;
-class tokens_iterator_impl;
 
 class token_metadata final {
     std::unique_ptr<token_metadata_impl> _impl;
@@ -156,20 +155,18 @@ private:
         using difference_type = std::ptrdiff_t;
         using pointer = token*;
         using reference = token&;
-    private:
-        using impl_type = tokens_iterator_impl;
-        std::unique_ptr<impl_type> _impl;
     public:
-        explicit tokens_iterator(tokens_iterator_impl);
-        tokens_iterator(const tokens_iterator&);
-        tokens_iterator(tokens_iterator&&) = default;
-        tokens_iterator& operator=(const tokens_iterator&);
-        tokens_iterator& operator=(tokens_iterator&&) = default;
-        ~tokens_iterator();
+        tokens_iterator() = default;
+        tokens_iterator(const token& start, const token_metadata_impl* token_metadata);
         bool operator==(const tokens_iterator& it) const;
-        bool operator!=(const tokens_iterator& it) const;
-        const token& operator*();
+        const token& operator*() const;
         tokens_iterator& operator++();
+    private:
+        std::vector<token>::const_iterator _cur_it;
+        size_t _remaining = 0;
+        const token_metadata_impl* _token_metadata = nullptr;
+
+        friend class token_metadata_impl;
     };
     token_metadata(std::unordered_map<token, inet_address> token_to_endpoint_map, std::unordered_map<inet_address, utils::UUID> endpoints_map, topology topology);
 public:

--- a/locator/token_metadata.hh
+++ b/locator/token_metadata.hh
@@ -194,7 +194,6 @@ public:
     const std::unordered_set<inet_address>& get_leaving_endpoints() const;
     const std::unordered_map<token, inet_address>& get_bootstrap_tokens() const;
     void update_topology(inet_address ep);
-    tokens_iterator tokens_end() const;
     /**
      * Creates an iterable range of the sorted tokens starting at the token next
      * after the given one.

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -4681,7 +4681,7 @@ void query_ranges_to_vnodes_generator::process_one_range(size_t n, dht::partitio
     }
 
     // divide the queryRange into pieces delimited by the ring
-    auto ring_iter = _tmptr->ring_range(cr.start(), false);
+    auto ring_iter = _tmptr->ring_range(cr.start());
     for (const dht::token& upper_bound_token : ring_iter) {
         /*
          * remainder can be a range/bounds of token _or_ keys and we want to split it with a token:


### PR DESCRIPTION
`ring_range()`/`tokens_iterator` are more complicated than they need to be. The `include_min` parameter is not used anywhere, and `tokens_iterator` is pimplified without a good reason. Simplify that.