### PR TITLE
treewide: reduce header interdependencies

### DIFF
--- a/atomic_cell.hh
+++ b/atomic_cell.hh
@@ -26,7 +26,6 @@
 #include "tombstone.hh"
 #include "gc_clock.hh"
 #include "utils/managed_bytes.hh"
-#include "utils/fragment_range.hh"
 #include <seastar/net//byteorder.hh>
 #include <seastar/util/bool_class.hh>
 #include <cstdint>

--- a/cache_flat_mutation_reader.hh
+++ b/cache_flat_mutation_reader.hh
@@ -25,12 +25,11 @@
 #include "row_cache.hh"
 #include "mutation_reader.hh"
 #include "mutation_fragment.hh"
-#include "partition_version.hh"
-#include "utils/logalloc.hh"
 #include "query-request.hh"
 #include "partition_snapshot_row_cursor.hh"
 #include "read_context.hh"
 #include "flat_mutation_reader.hh"
+#include "clustering_key_filter.hh"
 
 namespace cache {
 

--- a/canonical_mutation.cc
+++ b/canonical_mutation.cc
@@ -21,6 +21,8 @@
 
 #include "canonical_mutation.hh"
 #include "mutation.hh"
+#include "mutation_partition_view.hh"
+#include "mutation_partition_visitor.hh"
 #include "mutation_partition_serializer.hh"
 #include "counters.hh"
 #include "converting_mutation_partition_applier.hh"

--- a/canonical_mutation.hh
+++ b/canonical_mutation.hh
@@ -24,9 +24,12 @@
 #include "bytes.hh"
 #include "schema_fwd.hh"
 #include "database_fwd.hh"
-#include "mutation_partition_visitor.hh"
-#include "mutation_partition_serializer.hh"
+#include "bytes_ostream.hh"
 #include <iosfwd>
+
+namespace utils {
+    class UUID;
+} // namespace utils
 
 // Immutable mutation form which can be read using any schema version of the same table.
 // Safe to access from other shards via const&.

--- a/cdc/generation.cc
+++ b/cdc/generation.cc
@@ -38,6 +38,7 @@
 #include "gms/inet_address.hh"
 #include "gms/gossiper.hh"
 #include "gms/feature_service.hh"
+#include "utils/UUID_gen.hh"
 
 #include "cdc/generation.hh"
 #include "cdc/cdc_options.hh"

--- a/cell_locking.hh
+++ b/cell_locking.hh
@@ -24,7 +24,6 @@
 #include <boost/intrusive/unordered_set.hpp>
 
 #include "utils/small_vector.hh"
-#include "mutation_fragment.hh"
 #include "mutation_partition.hh"
 #include "xx_hasher.hh"
 

--- a/compaction_garbage_collector.hh
+++ b/compaction_garbage_collector.hh
@@ -21,10 +21,11 @@
 
 #pragma once
 
-#include "collection_mutation.hh"
+#include "schema_fwd.hh"
 
 class atomic_cell;
 class row_marker;
+struct collection_mutation_description;
 
 class compaction_garbage_collector {
 public:

--- a/compaction_strategy.hh
+++ b/compaction_strategy.hh
@@ -28,7 +28,6 @@
 #include "schema_fwd.hh"
 #include "sstables/shared_sstable.hh"
 #include "exceptions/exceptions.hh"
-#include "sstables/compaction_backlog_manager.hh"
 #include "compaction_strategy_type.hh"
 
 class table;
@@ -36,6 +35,7 @@ using column_family = table;
 
 class flat_mutation_reader;
 struct mutation_source_metadata;
+class compaction_backlog_tracker;
 
 namespace sstables {
 

--- a/compatible_ring_position.hh
+++ b/compatible_ring_position.hh
@@ -22,7 +22,7 @@
 
 #pragma once
 
-#include "query-request.hh"
+#include "dht/i_partitioner.hh"
 #include <optional>
 #include <variant>
 

--- a/converting_mutation_partition_applier.hh
+++ b/converting_mutation_partition_applier.hh
@@ -22,12 +22,17 @@
 #pragma once
 
 #include "mutation_partition_visitor.hh"
+#include "atomic_cell.hh"
+#include "schema.hh" // temporary: bring in definition of `column_kind`
 
 class schema;
 class row;
 class mutation_partition;
 class column_mapping;
 class deletable_row;
+class column_definition;
+class abstract_type;
+class atomic_cell_or_collection;
 
 // Mutation partition visitor which applies visited data into
 // existing mutation_partition. The visited data may be of a different schema.

--- a/cql3/attributes.cc
+++ b/cql3/attributes.cc
@@ -40,6 +40,7 @@
  */
 
 #include "cql3/attributes.hh"
+#include "cql3/column_identifier.hh"
 
 namespace cql3 {
 

--- a/cql3/authorized_prepared_statements_cache.hh
+++ b/cql3/authorized_prepared_statements_cache.hh
@@ -22,6 +22,7 @@
 #pragma once
 
 #include "cql3/prepared_statements_cache.hh"
+#include "auth/authenticated_user.hh"
 
 namespace cql3 {
 

--- a/cql3/expr/expression.cc
+++ b/cql3/expr/expression.cc
@@ -34,11 +34,13 @@
 #include "cql3/lists.hh"
 #include "cql3/statements/request_validations.hh"
 #include "cql3/tuples.hh"
+#include "cql3/selection/selection.hh"
 #include "index/secondary_index_manager.hh"
 #include "types/list.hh"
 #include "types/map.hh"
 #include "types/set.hh"
 #include "utils/like_matcher.hh"
+#include "query-result-reader.hh"
 
 namespace cql3 {
 namespace expr {

--- a/cql3/expr/expression.hh
+++ b/cql3/expr/expression.hh
@@ -28,24 +28,32 @@
 #include <concepts>
 
 #include "bytes.hh"
-#include "cql3/query_options.hh"
-#include "cql3/selection/selection.hh"
 #include "cql3/statements/bound.hh"
 #include "cql3/term.hh"
 #include "database_fwd.hh"
 #include "gc_clock.hh"
-#include "mutation_partition.hh"
-#include "query-result-reader.hh"
 #include "range.hh"
 #include "seastarx.hh"
 #include "utils/overloaded_functor.hh"
+
+class row;
 
 namespace secondary_index {
 class index;
 class secondary_index_manager;
 } // namespace secondary_index
 
+namespace query {
+    class result_row_view;
+} // namespace query
+
 namespace cql3 {
+
+class query_options;
+
+namespace selection {
+    class selection;
+} // namespace selection
 
 namespace expr {
 

--- a/cql3/functions/abstract_function.hh
+++ b/cql3/functions/abstract_function.hh
@@ -48,6 +48,8 @@
 #include <iosfwd>
 #include <boost/functional/hash.hpp>
 
+#include "cql3/functions/function_name.hh"
+
 namespace std {
     std::ostream& operator<<(std::ostream& os, const std::vector<data_type>& arg_types);
 }

--- a/cql3/functions/as_json_function.hh
+++ b/cql3/functions/as_json_function.hh
@@ -43,6 +43,7 @@
 
 #include "cql3/functions/function.hh"
 #include "cql3/functions/scalar_function.hh"
+#include "cql3/functions/function_name.hh"
 #include "cql3/cql3_type.hh"
 #include "cql3/type_json.hh"
 

--- a/cql3/functions/function.hh
+++ b/cql3/functions/function.hh
@@ -41,13 +41,14 @@
 
 #pragma once
 
-#include "function_name.hh"
 #include "types.hh"
 #include <vector>
 #include <optional>
 
 namespace cql3 {
 namespace functions {
+
+class function_name;
 
 class function {
 public:

--- a/cql3/functions/function_call.hh
+++ b/cql3/functions/function_call.hh
@@ -45,6 +45,7 @@
 #include "scalar_function.hh"
 #include "cql3/term.hh"
 #include "exceptions/exceptions.hh"
+#include "cql3/functions/function_name.hh"
 
 namespace cql3 {
 namespace functions {

--- a/cql3/functions/token_fct.hh
+++ b/cql3/functions/token_fct.hh
@@ -45,6 +45,7 @@
 #include "native_scalar_function.hh"
 #include "dht/i_partitioner.hh"
 #include "utils/UUID.hh"
+#include "unimplemented.hh"
 
 namespace cql3 {
 namespace functions {

--- a/cql3/operation.hh
+++ b/cql3/operation.hh
@@ -46,6 +46,7 @@
 #include "database_fwd.hh"
 #include "term.hh"
 #include "update_parameters.hh"
+#include "cql3/column_identifier.hh"
 
 #include <optional>
 

--- a/cql3/prepared_statements_cache.hh
+++ b/cql3/prepared_statements_cache.hh
@@ -24,7 +24,9 @@
 #pragma once
 
 #include "utils/loading_cache.hh"
+#include "utils/hash.hh"
 #include "cql3/statements/prepared_statement.hh"
+#include "cql3/column_specification.hh"
 
 namespace cql3 {
 

--- a/cql3/query_options.cc
+++ b/cql3/query_options.cc
@@ -43,6 +43,7 @@
 #include "query_options.hh"
 #include "version.hh"
 #include "db/consistency_level_type.hh"
+#include "cql3/column_identifier.hh"
 
 namespace cql3 {
 

--- a/cql3/query_options.hh
+++ b/cql3/query_options.hh
@@ -47,8 +47,6 @@
 #include "db/consistency_level_type.hh"
 #include "service/query_state.hh"
 #include "service/pager/paging_state.hh"
-#include "cql3/column_specification.hh"
-#include "cql3/column_identifier.hh"
 #include "cql3/values.hh"
 #include "cql_serialization_format.hh"
 
@@ -56,6 +54,8 @@ namespace cql3 {
 
 class cql_config;
 extern const cql_config default_cql_config;
+
+class column_specification;
 
 /**
  * Options for a query.

--- a/cql3/query_processor.cc
+++ b/cql3/query_processor.cc
@@ -46,6 +46,7 @@
 #include "cql3/CqlParser.hpp"
 #include "cql3/error_collector.hh"
 #include "cql3/statements/batch_statement.hh"
+#include "cql3/statements/modification_statement.hh"
 #include "cql3/util.hh"
 #include "cql3/untyped_result_set.hh"
 #include "db/config.hh"

--- a/cql3/query_processor.hh
+++ b/cql3/query_processor.hh
@@ -50,16 +50,16 @@
 
 #include "cql3/prepared_statements_cache.hh"
 #include "cql3/authorized_prepared_statements_cache.hh"
-#include "cql3/query_options.hh"
 #include "cql3/statements/prepared_statement.hh"
 #include "exceptions/exceptions.hh"
-#include "log.hh"
 #include "service/migration_listener.hh"
-#include "service/query_state.hh"
 #include "transport/messages/result_message.hh"
+#include "service/qos/service_level_controller.hh"
+#include "service/client_state.hh"
 
 namespace service {
 class migration_manager;
+class query_state;
 }
 
 namespace cql3 {
@@ -105,6 +105,8 @@ public:
 };
 
 class cql_config;
+class query_options;
+class cql_statement;
 
 class query_processor {
 public:

--- a/cql3/selection/abstract_function_selector.cc
+++ b/cql3/selection/abstract_function_selector.cc
@@ -41,6 +41,7 @@
 #include "aggregate_function_selector.hh"
 #include "scalar_function_selector.hh"
 #include "to_string.hh"
+#include "cql3/selection/selector_factories.hh"
 
 namespace cql3 {
 

--- a/cql3/selection/abstract_function_selector.hh
+++ b/cql3/selection/abstract_function_selector.hh
@@ -40,12 +40,14 @@
 #pragma once
 
 #include "selector.hh"
-#include "selector_factories.hh"
 #include "cql3/functions/function.hh"
+#include "cql3/functions/function_name.hh"
 #include <boost/algorithm/cxx11/any_of.hpp>
 
 namespace cql3 {
 namespace selection {
+
+class selector_factories;
 
 class abstract_function_selector : public selector {
 protected:

--- a/cql3/selection/aggregate_function_selector.hh
+++ b/cql3/selection/aggregate_function_selector.hh
@@ -39,6 +39,7 @@
 
 #include "abstract_function_selector.hh"
 #include "cql3/functions/aggregate_function.hh"
+#include "cql_serialization_format.hh"
 
 #pragma once
 

--- a/cql3/selection/selector_factories.hh
+++ b/cql3/selection/selector_factories.hh
@@ -43,12 +43,13 @@
 
 #include <vector>
 #include "cql3/selection/selector.hh"
-#include "cql3/selection/selectable.hh"
 #include "schema.hh"
 
 namespace cql3 {
 
 namespace selection {
+
+class selectable;
 
 /**
  * A set of <code>selector</code> factories.

--- a/cql3/statements/alter_keyspace_statement.cc
+++ b/cql3/statements/alter_keyspace_statement.cc
@@ -46,6 +46,7 @@
 #include "db/system_keyspace.hh"
 #include "database.hh"
 #include "cql3/query_processor.hh"
+#include "cql3/statements/ks_prop_defs.hh"
 
 bool is_system_keyspace(std::string_view keyspace);
 

--- a/cql3/statements/alter_keyspace_statement.hh
+++ b/cql3/statements/alter_keyspace_statement.hh
@@ -44,13 +44,14 @@
 #include <memory>
 
 #include "cql3/statements/schema_altering_statement.hh"
-#include "cql3/statements/ks_prop_defs.hh"
 
 namespace cql3 {
 
 class query_processor;
 
 namespace statements {
+
+class ks_prop_defs;
 
 class alter_keyspace_statement : public schema_altering_statement {
     sstring _name;

--- a/cql3/statements/alter_service_level_statement.cc
+++ b/cql3/statements/alter_service_level_statement.cc
@@ -23,6 +23,8 @@
 #include "cql3/statements/alter_service_level_statement.hh"
 #include "service/qos/service_level_controller.hh"
 #include "transport/messages/result_message.hh"
+#include "service/client_state.hh"
+#include "service/query_state.hh"
 
 namespace cql3 {
 

--- a/cql3/statements/alter_table_statement.hh
+++ b/cql3/statements/alter_table_statement.hh
@@ -44,6 +44,7 @@
 #include "cql3/statements/schema_altering_statement.hh"
 #include "cql3/statements/cf_prop_defs.hh"
 #include "cql3/cql3_type.hh"
+#include "cql3/column_identifier.hh"
 #include "database_fwd.hh"
 
 namespace cql3 {

--- a/cql3/statements/alter_type_statement.hh
+++ b/cql3/statements/alter_type_statement.hh
@@ -44,6 +44,7 @@
 #include "cql3/statements/schema_altering_statement.hh"
 #include "cql3/cql3_type.hh"
 #include "cql3/ut_name.hh"
+#include "database_fwd.hh"
 
 namespace service {
 class migration_manager;

--- a/cql3/statements/alter_view_statement.hh
+++ b/cql3/statements/alter_view_statement.hh
@@ -46,11 +46,11 @@
 #include "database_fwd.hh"
 #include "cql3/statements/cf_prop_defs.hh"
 #include "cql3/statements/schema_altering_statement.hh"
-#include "cql3/cf_name.hh"
 
 namespace cql3 {
 
 class query_processor;
+class cf_name;
 
 namespace statements {
 

--- a/cql3/statements/attach_service_level_statement.cc
+++ b/cql3/statements/attach_service_level_statement.cc
@@ -24,6 +24,8 @@
 #include "service/qos/service_level_controller.hh"
 #include "exceptions/exceptions.hh"
 #include "transport/messages/result_message.hh"
+#include "service/client_state.hh"
+#include "service/query_state.hh"
 
 namespace cql3 {
 

--- a/cql3/statements/authentication_statement.hh
+++ b/cql3/statements/authentication_statement.hh
@@ -42,7 +42,6 @@
 #pragma once
 
 #include "cql3/cql_statement.hh"
-#include "prepared_statement.hh"
 #include "raw/parsed_statement.hh"
 #include "transport/messages_fwd.hh"
 

--- a/cql3/statements/authorization_statement.cc
+++ b/cql3/statements/authorization_statement.cc
@@ -41,6 +41,8 @@
 
 #include "authorization_statement.hh"
 #include "transport/messages/result_message.hh"
+#include "service/client_state.hh"
+#include "auth/resource.hh"
 
 uint32_t cql3::statements::authorization_statement::get_bound_terms() const {
     return 0;

--- a/cql3/statements/authorization_statement.hh
+++ b/cql3/statements/authorization_statement.hh
@@ -42,7 +42,6 @@
 #pragma once
 
 #include "cql3/cql_statement.hh"
-#include "prepared_statement.hh"
 #include "raw/parsed_statement.hh"
 #include "transport/messages_fwd.hh"
 

--- a/cql3/statements/batch_statement.hh
+++ b/cql3/statements/batch_statement.hh
@@ -36,23 +36,24 @@
  * You should have received a copy of the GNU General Public License
  * along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
  */
+#pragma once
 
 #include "cql3/cql_statement.hh"
-#include "modification_statement.hh"
-#include "raw/modification_statement.hh"
 #include "raw/batch_statement.hh"
-#include "transport/messages/result_message.hh"
 #include "timestamp.hh"
 #include "log.hh"
-#include "to_string.hh"
 
-#pragma once
+namespace cql_transport::messages {
+    class result_message;
+}
 
 namespace cql3 {
 
 class query_processor;
 
 namespace statements {
+
+class modification_statement;
 
 /**
  * A <code>BATCH</code> statement parsed from a CQL query.

--- a/cql3/statements/cf_statement.cc
+++ b/cql3/statements/cf_statement.cc
@@ -41,6 +41,7 @@
 
 #include "raw/cf_statement.hh"
 #include "service/client_state.hh"
+#include "cql3/column_specification.hh"
 
 namespace cql3 {
 

--- a/cql3/statements/create_function_statement.cc
+++ b/cql3/statements/create_function_statement.cc
@@ -21,6 +21,7 @@
 
 #include "cql3/statements/create_function_statement.hh"
 #include "cql3/functions/functions.hh"
+#include "cql3/functions/user_function.hh"
 #include "prepared_statement.hh"
 #include "service/migration_manager.hh"
 #include "service/storage_proxy.hh"

--- a/cql3/statements/create_function_statement.hh
+++ b/cql3/statements/create_function_statement.hh
@@ -22,11 +22,18 @@
 #pragma once
 
 #include "cql3/statements/function_statement.hh"
-#include "cql3/functions/user_function.hh"
+#include "cql3/cql3_type.hh"
 
 namespace cql3 {
+
 class query_processor;
+
+namespace functions {
+    class user_function;
+}
+
 namespace statements {
+
 class create_function_statement final : public create_function_statement_base {
     virtual std::unique_ptr<prepared_statement> prepare(database& db, cql_stats& stats) override;
     virtual future<shared_ptr<cql_transport::event::schema_change>> announce_migration(

--- a/cql3/statements/create_index_statement.cc
+++ b/cql3/statements/create_index_statement.cc
@@ -51,6 +51,8 @@
 #include "index/target_parser.hh"
 #include "gms/feature_service.hh"
 #include "cql3/query_processor.hh"
+#include "cql3/index_name.hh"
+#include "cql3/statements/index_prop_defs.hh"
 
 #include <boost/range/adaptor/transformed.hpp>
 #include <boost/algorithm/string/join.hpp>

--- a/cql3/statements/create_index_statement.hh
+++ b/cql3/statements/create_index_statement.hh
@@ -42,15 +42,9 @@
 #pragma once
 
 #include "schema_altering_statement.hh"
-#include "index_prop_defs.hh"
 #include "index_target.hh"
-#include "raw/cf_statement.hh"
 
-#include "cql3/index_name.hh"
-#include "cql3/cql3_type.hh"
-
-#include "service/migration_manager.hh"
-#include "schema.hh"
+#include "schema_fwd.hh"
 
 #include <seastar/core/shared_ptr.hh>
 
@@ -63,8 +57,11 @@
 namespace cql3 {
 
 class query_processor;
+class index_name;
 
 namespace statements {
+
+class index_prop_defs;
 
 /** A <code>CREATE INDEX</code> statement parsed from a CQL query. */
 class create_index_statement : public schema_altering_statement {

--- a/cql3/statements/create_keyspace_statement.cc
+++ b/cql3/statements/create_keyspace_statement.cc
@@ -40,6 +40,7 @@
  */
 
 #include "cql3/statements/create_keyspace_statement.hh"
+#include "cql3/statements/ks_prop_defs.hh"
 #include "prepared_statement.hh"
 #include "database.hh"
 #include "service/migration_manager.hh"

--- a/cql3/statements/create_keyspace_statement.hh
+++ b/cql3/statements/create_keyspace_statement.hh
@@ -42,7 +42,6 @@
 #pragma once
 
 #include "cql3/statements/schema_altering_statement.hh"
-#include "cql3/statements/ks_prop_defs.hh"
 #include "transport/event.hh"
 #include "log.hh"
 
@@ -53,6 +52,8 @@ namespace cql3 {
 class query_processor;
 
 namespace statements {
+
+class ks_prop_defs;
 
 /** A <code>CREATE KEYSPACE</code> statement parsed from a CQL query. */
 class create_keyspace_statement : public schema_altering_statement {

--- a/cql3/statements/create_service_level_statement.cc
+++ b/cql3/statements/create_service_level_statement.cc
@@ -23,6 +23,8 @@
 #include "cql3/statements/create_service_level_statement.hh"
 #include "service/qos/service_level_controller.hh"
 #include "transport/messages/result_message.hh"
+#include "service/client_state.hh"
+#include "service/query_state.hh"
 
 namespace cql3 {
 

--- a/cql3/statements/create_table_statement.cc
+++ b/cql3/statements/create_table_statement.cc
@@ -57,6 +57,7 @@
 #include "database.hh"
 #include "types/user.hh"
 #include "gms/feature_service.hh"
+#include "service/migration_manager.hh"
 
 namespace cql3 {
 

--- a/cql3/statements/create_table_statement.hh
+++ b/cql3/statements/create_table_statement.hh
@@ -42,12 +42,10 @@
 #pragma once
 
 #include "cql3/statements/schema_altering_statement.hh"
-#include "cql3/statements/cf_prop_defs.hh"
 #include "cql3/statements/cf_properties.hh"
 #include "cql3/statements/raw/cf_statement.hh"
 #include "cql3/cql3_type.hh"
 
-#include "service/migration_manager.hh"
 #include "schema_fwd.hh"
 
 #include <seastar/core/shared_ptr.hh>
@@ -62,6 +60,7 @@
 namespace cql3 {
 
 class query_processor;
+class cf_prop_defs;
 
 namespace statements {
 

--- a/cql3/statements/create_type_statement.hh
+++ b/cql3/statements/create_type_statement.hh
@@ -42,6 +42,7 @@
 #include "cql3/statements/schema_altering_statement.hh"
 #include "cql3/cql3_type.hh"
 #include "cql3/ut_name.hh"
+#include "database_fwd.hh"
 
 namespace cql3 {
 

--- a/cql3/statements/create_view_statement.cc
+++ b/cql3/statements/create_view_statement.cc
@@ -66,6 +66,7 @@
 #include "database.hh"
 #include "gms/feature_service.hh"
 #include "db/view/view.hh"
+#include "service/migration_manager.hh"
 
 namespace cql3 {
 

--- a/cql3/statements/create_view_statement.hh
+++ b/cql3/statements/create_view_statement.hh
@@ -20,15 +20,8 @@
 #pragma once
 
 #include "cql3/statements/schema_altering_statement.hh"
-#include "cql3/statements/cf_prop_defs.hh"
 #include "cql3/statements/cf_properties.hh"
-#include "cql3/cql3_type.hh"
-#include "cql3/selection/raw_selector.hh"
-#include "cql3/relation.hh"
 #include "cql3/cf_name.hh"
-
-#include "service/migration_manager.hh"
-#include "schema.hh"
 
 #include <seastar/core/shared_ptr.hh>
 
@@ -39,6 +32,11 @@
 namespace cql3 {
 
 class query_processor;
+class relation;
+
+namespace selection {
+    class raw_selector;
+} // namespace selection
 
 namespace statements {
 

--- a/cql3/statements/delete_statement.hh
+++ b/cql3/statements/delete_statement.hh
@@ -42,12 +42,11 @@
 #pragma once
 
 #include "cql3/statements/modification_statement.hh"
-#include "cql3/statements/raw/modification_statement.hh"
-#include "cql3/attributes.hh"
-#include "cql3/operation.hh"
 #include "database_fwd.hh"
 
 namespace cql3 {
+
+class attributes;
 
 namespace statements {
 

--- a/cql3/statements/detach_service_level_statement.cc
+++ b/cql3/statements/detach_service_level_statement.cc
@@ -23,6 +23,8 @@
 #include "cql3/statements/detach_service_level_statement.hh"
 #include "service/qos/service_level_controller.hh"
 #include "transport/messages/result_message.hh"
+#include "service/client_state.hh"
+#include "service/query_state.hh"
 
 namespace cql3 {
 

--- a/cql3/statements/drop_function_statement.cc
+++ b/cql3/statements/drop_function_statement.cc
@@ -21,6 +21,7 @@
 
 #include "cql3/statements/drop_function_statement.hh"
 #include "cql3/functions/functions.hh"
+#include "cql3/functions/user_function.hh"
 #include "prepared_statement.hh"
 #include "service/migration_manager.hh"
 #include "cql3/query_processor.hh"

--- a/cql3/statements/drop_index_statement.cc
+++ b/cql3/statements/drop_index_statement.cc
@@ -47,6 +47,7 @@
 #include "database.hh"
 #include "gms/feature_service.hh"
 #include "cql3/query_processor.hh"
+#include "cql3/index_name.hh"
 
 namespace cql3 {
 

--- a/cql3/statements/drop_index_statement.hh
+++ b/cql3/statements/drop_index_statement.hh
@@ -42,16 +42,17 @@
 #pragma once
 
 #include "cql3/statements/schema_altering_statement.hh"
-#include "cql3/index_name.hh"
 
-#include <seastar/core/distributed.hh>
 #include <seastar/core/shared_ptr.hh>
 #include <optional>
 #include <memory>
 
+#include "schema_fwd.hh"
+
 namespace cql3 {
 
 class query_processor;
+class index_name;
 
 namespace statements {
 

--- a/cql3/statements/drop_service_level_statement.cc
+++ b/cql3/statements/drop_service_level_statement.cc
@@ -23,6 +23,8 @@
 #include "cql3/statements/drop_service_level_statement.hh"
 #include "service/qos/service_level_controller.hh"
 #include "transport/messages/result_message.hh"
+#include "service/client_state.hh"
+#include "service/query_state.hh"
 
 namespace cql3 {
 

--- a/cql3/statements/drop_table_statement.hh
+++ b/cql3/statements/drop_table_statement.hh
@@ -43,11 +43,10 @@
 
 #include "cql3/statements/schema_altering_statement.hh"
 
-#include "cql3/cf_name.hh"
-
 namespace cql3 {
 
 class query_processor;
+class cf_name;
 
 namespace statements {
 

--- a/cql3/statements/drop_type_statement.hh
+++ b/cql3/statements/drop_type_statement.hh
@@ -40,7 +40,6 @@
 #pragma once
 
 #include "cql3/statements/schema_altering_statement.hh"
-#include "cql3/cql3_type.hh"
 #include "cql3/ut_name.hh"
 
 namespace cql3 {

--- a/cql3/statements/drop_view_statement.hh
+++ b/cql3/statements/drop_view_statement.hh
@@ -44,13 +44,13 @@
 #include <seastar/core/shared_ptr.hh>
 
 #include "cql3/statements/schema_altering_statement.hh"
-#include "cql3/cf_name.hh"
 
 #include "database_fwd.hh"
 
 namespace cql3 {
 
 class query_processor;
+class cf_name;
 
 namespace statements {
 

--- a/cql3/statements/function_statement.cc
+++ b/cql3/statements/function_statement.cc
@@ -21,6 +21,7 @@
 
 #include "cql3/statements/function_statement.hh"
 #include "cql3/functions/functions.hh"
+#include "cql3/functions/user_function.hh"
 #include "db/config.hh"
 #include "database.hh"
 #include "gms/feature_service.hh"

--- a/cql3/statements/function_statement.hh
+++ b/cql3/statements/function_statement.hh
@@ -22,9 +22,15 @@
 #pragma once
 
 #include "cql3/statements/schema_altering_statement.hh"
-#include "cql3/functions/user_function.hh"
+#include "cql3/functions/function_name.hh"
+#include "cql3/cql3_type.hh"
 
 namespace cql3 {
+
+namespace functions {
+    class function;
+} // namespace functions
+
 namespace statements {
 
 class function_statement : public schema_altering_statement {

--- a/cql3/statements/grant_statement.cc
+++ b/cql3/statements/grant_statement.cc
@@ -41,6 +41,8 @@
 
 #include "grant_statement.hh"
 #include "auth/authorizer.hh"
+#include "cql3/statements/prepared_statement.hh"
+#include "service/query_state.hh"
 
 std::unique_ptr<cql3::statements::prepared_statement> cql3::statements::grant_statement::prepare(
                 database& db, cql_stats& stats) {

--- a/cql3/statements/ks_prop_defs.cc
+++ b/cql3/statements/ks_prop_defs.cc
@@ -41,6 +41,7 @@
 
 #include "cql3/statements/ks_prop_defs.hh"
 #include "database.hh"
+#include "locator/token_metadata.hh"
 
 namespace cql3 {
 

--- a/cql3/statements/ks_prop_defs.hh
+++ b/cql3/statements/ks_prop_defs.hh
@@ -42,13 +42,16 @@
 #pragma once
 
 #include "cql3/statements/property_definitions.hh"
-#include "locator/token_metadata.hh"
 
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/core/sstring.hh>
 #include <optional>
 
 class keyspace_metadata;
+
+namespace locator {
+    class token_metadata;
+} // namespace locator
 
 namespace cql3 {
 

--- a/cql3/statements/list_service_level_attachments_statement.cc
+++ b/cql3/statements/list_service_level_attachments_statement.cc
@@ -23,6 +23,8 @@
 #include "cql3/statements/list_service_level_attachments_statement.hh"
 #include "service/qos/service_level_controller.hh"
 #include "transport/messages/result_message.hh"
+#include "service/client_state.hh"
+#include "service/query_state.hh"
 
 namespace cql3 {
 

--- a/cql3/statements/list_service_level_statement.cc
+++ b/cql3/statements/list_service_level_statement.cc
@@ -24,6 +24,8 @@
 #include "service/qos/service_level_controller.hh"
 #include "transport/messages/result_message.hh"
 #include "utils/overloaded_functor.hh"
+#include "service/client_state.hh"
+#include "service/query_state.hh"
 
 namespace cql3 {
 

--- a/cql3/statements/modification_statement.hh
+++ b/cql3/statements/modification_statement.hh
@@ -41,25 +41,16 @@
 
 #pragma once
 
-#include "cql3/restrictions/restriction.hh"
-#include "cql3/statements/raw/cf_statement.hh"
-#include "cql3/statements/bound.hh"
+#include "cql3/stats.hh"
 #include "cql3/column_identifier.hh"
 #include "cql3/update_parameters.hh"
 #include "cql3/column_condition.hh"
 #include "cql3/cql_statement.hh"
-#include "cql3/attributes.hh"
-#include "cql3/operation.hh"
 #include "cql3/relation.hh"
 #include "cql3/restrictions/statement_restrictions.hh"
-#include "cql3/single_column_relation.hh"
 #include "cql3/statements/statement_type.hh"
 
 #include <seastar/core/shared_ptr.hh>
-#include <seastar/core/future-util.hh>
-
-#include "unimplemented.hh"
-#include "validation.hh"
 
 #include <memory>
 #include <optional>
@@ -67,6 +58,8 @@
 namespace cql3 {
 
 class query_processor;
+class attributes;
+class operation;
 
 namespace statements {
 

--- a/cql3/statements/prepared_statement.hh
+++ b/cql3/statements/prepared_statement.hh
@@ -41,19 +41,19 @@
 
 #pragma once
 
-#include "cql3/variable_specifications.hh"
-#include "cql3/column_specification.hh"
-#include "cql3/column_identifier.hh"
-#include "cql3/cql_statement.hh"
-
 #include <seastar/core/shared_ptr.hh>
-
 #include <seastar/core/weak_ptr.hh>
 #include <seastar/core/checked_ptr.hh>
 #include <optional>
 #include <vector>
 
+#include "exceptions/exceptions.hh"
+
 namespace cql3 {
+
+class variable_specifications;
+class column_specification;
+class cql_statement;
 
 namespace statements {
 
@@ -63,22 +63,22 @@ struct invalidated_prepared_usage_attempt {
     }
 };
 
-class prepared_statement : public weakly_referencable<prepared_statement> {
+class prepared_statement : public seastar::weakly_referencable<prepared_statement> {
 public:
-    typedef seastar::checked_ptr<weak_ptr<prepared_statement>> checked_weak_ptr;
+    typedef seastar::checked_ptr<seastar::weak_ptr<prepared_statement>> checked_weak_ptr;
 
 public:
-    const ::shared_ptr<cql_statement> statement;
-    const std::vector<lw_shared_ptr<column_specification>> bound_names;
+    const seastar::shared_ptr<cql_statement> statement;
+    const std::vector<seastar::lw_shared_ptr<column_specification>> bound_names;
     std::vector<uint16_t> partition_key_bind_indices;
 
-    prepared_statement(::shared_ptr<cql_statement> statement_, std::vector<lw_shared_ptr<column_specification>> bound_names_, std::vector<uint16_t> partition_key_bind_indices);
+    prepared_statement(seastar::shared_ptr<cql_statement> statement_, std::vector<seastar::lw_shared_ptr<column_specification>> bound_names_, std::vector<uint16_t> partition_key_bind_indices);
 
-    prepared_statement(::shared_ptr<cql_statement> statement_, const variable_specifications& names, const std::vector<uint16_t>& partition_key_bind_indices);
+    prepared_statement(seastar::shared_ptr<cql_statement> statement_, const variable_specifications& names, const std::vector<uint16_t>& partition_key_bind_indices);
 
-    prepared_statement(::shared_ptr<cql_statement> statement_, variable_specifications&& names, std::vector<uint16_t>&& partition_key_bind_indices);
+    prepared_statement(seastar::shared_ptr<cql_statement> statement_, variable_specifications&& names, std::vector<uint16_t>&& partition_key_bind_indices);
 
-    prepared_statement(::shared_ptr<cql_statement>&& statement_);
+    prepared_statement(seastar::shared_ptr<cql_statement>&& statement_);
 
     checked_weak_ptr checked_weak_from_this() {
         return checked_weak_ptr(this->weak_from_this());

--- a/cql3/statements/raw/batch_statement.hh
+++ b/cql3/statements/raw/batch_statement.hh
@@ -36,21 +36,19 @@
  * You should have received a copy of the GNU General Public License
  * along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
  */
-
-#include "cql3/cql_statement.hh"
-#include "modification_statement.hh"
-#include "transport/messages/result_message.hh"
-#include "timestamp.hh"
-#include "log.hh"
-#include "to_string.hh"
-
 #pragma once
+
+#include "cql3/statements/raw/cf_statement.hh"
+#include "cql3/statements/raw/modification_statement.hh"
+#include "service/client_state.hh"
 
 namespace cql3 {
 
 namespace statements {
 
 namespace raw {
+
+class modification_statement;
 
 class batch_statement : public raw::cf_statement {
 public:

--- a/cql3/statements/raw/delete_statement.hh
+++ b/cql3/statements/raw/delete_statement.hh
@@ -41,7 +41,6 @@
 
 #pragma once
 
-#include "cql3/statements/modification_statement.hh"
 #include "cql3/statements/raw/modification_statement.hh"
 #include "cql3/attributes.hh"
 #include "cql3/operation.hh"
@@ -49,7 +48,11 @@
 
 namespace cql3 {
 
+class relation;
+
 namespace statements {
+
+class modification_statement;
 
 namespace raw {
 

--- a/cql3/statements/raw/insert_statement.hh
+++ b/cql3/statements/raw/insert_statement.hh
@@ -41,7 +41,6 @@
 
 #pragma once
 
-#include "cql3/statements/modification_statement.hh"
 #include "cql3/statements/raw/modification_statement.hh"
 #include "cql3/column_identifier.hh"
 #include "cql3/term.hh"
@@ -49,11 +48,12 @@
 #include "database_fwd.hh"
 
 #include <vector>
-#include "unimplemented.hh"
 
 namespace cql3 {
 
 namespace statements {
+
+class modification_statement;
 
 namespace raw {
 

--- a/cql3/statements/raw/modification_statement.hh
+++ b/cql3/statements/raw/modification_statement.hh
@@ -41,21 +41,13 @@
 
 #pragma once
 
-#include "cql3/restrictions/restriction.hh"
 #include "cql3/statements/raw/cf_statement.hh"
 #include "cql3/column_identifier.hh"
-#include "cql3/update_parameters.hh"
 #include "cql3/column_condition.hh"
-#include "cql3/cql_statement.hh"
 #include "cql3/attributes.hh"
-#include "cql3/operation.hh"
-#include "cql3/relation.hh"
 
 #include <seastar/core/shared_ptr.hh>
-#include <seastar/core/future-util.hh>
 
-#include "unimplemented.hh"
-#include "validation.hh"
 
 #include <memory>
 

--- a/cql3/statements/raw/parsed_statement.cc
+++ b/cql3/statements/raw/parsed_statement.cc
@@ -42,6 +42,7 @@
 #include "parsed_statement.hh"
 
 #include "cql3/statements/prepared_statement.hh"
+#include "cql3/column_specification.hh"
 
 namespace cql3 {
 

--- a/cql3/statements/raw/parsed_statement.hh
+++ b/cql3/statements/raw/parsed_statement.hh
@@ -42,15 +42,19 @@
 #pragma once
 
 #include "cql3/variable_specifications.hh"
-#include "cql3/column_identifier.hh"
-#include "cql3/stats.hh"
+#include "cql3/column_specification.hh"
 
 #include <seastar/core/shared_ptr.hh>
 
 #include <optional>
 #include <vector>
 
+class database;
+
 namespace cql3 {
+
+class column_identifier;
+class cql_stats;
 
 namespace statements {
 

--- a/cql3/statements/raw/select_statement.hh
+++ b/cql3/statements/raw/select_statement.hh
@@ -43,19 +43,20 @@
 
 #include "cql3/statements/raw/cf_statement.hh"
 #include "cql3/statements/prepared_statement.hh"
-#include "cql3/cql_statement.hh"
-#include "cql3/selection/selection.hh"
-#include "cql3/selection/raw_selector.hh"
-#include "cql3/restrictions/statement_restrictions.hh"
-#include "cql3/result_set.hh"
+#include "cql3/relation.hh"
 #include "cql3/attributes.hh"
-#include "exceptions/unrecognized_entity_exception.hh"
-#include "service/client_state.hh"
 #include <seastar/core/shared_ptr.hh>
-#include <seastar/core/distributed.hh>
-#include "validation.hh"
 
 namespace cql3 {
+
+namespace selection {
+    class selection;
+    class raw_selector;
+} // namespace selection
+
+namespace restrictions {
+    class statement_restrictions;
+} // namespace restrictions
 
 namespace statements {
 

--- a/cql3/statements/raw/update_statement.hh
+++ b/cql3/statements/raw/update_statement.hh
@@ -41,21 +41,21 @@
 
 #pragma once
 
-#include "cql3/statements/modification_statement.hh"
 #include "cql3/statements/raw/modification_statement.hh"
 #include "cql3/column_identifier.hh"
-#include "cql3/term.hh"
+#include "cql3/operation.hh"
+#include "cql3/relation.hh"
 
 #include "database_fwd.hh"
 
 #include <vector>
-#include "unimplemented.hh"
 
 namespace cql3 {
 
 namespace statements {
 
 class update_statement;
+class modification_statement;
 
 namespace raw {
 

--- a/cql3/statements/raw/use_statement.hh
+++ b/cql3/statements/raw/use_statement.hh
@@ -43,6 +43,8 @@
 
 #include "cql3/statements/raw/parsed_statement.hh"
 
+#include <seastar/core/sstring.hh>
+
 namespace cql3 {
 
 namespace statements {

--- a/cql3/statements/revoke_statement.cc
+++ b/cql3/statements/revoke_statement.cc
@@ -41,6 +41,8 @@
 
 #include "revoke_statement.hh"
 #include "auth/authorizer.hh"
+#include "cql3/statements/prepared_statement.hh"
+#include "service/query_state.hh"
 
 std::unique_ptr<cql3::statements::prepared_statement> cql3::statements::revoke_statement::prepare(
                 database& db, cql_stats& stats) {

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -47,7 +47,10 @@
 #include "cql3/selection/selection.hh"
 #include "cql3/util.hh"
 #include "cql3/restrictions/single_column_primary_key_restrictions.hh"
+#include "cql3/restrictions/statement_restrictions.hh"
 #include "cql3/selection/selector_factories.hh"
+#include "validation.hh"
+#include "exceptions/unrecognized_entity_exception.hh"
 #include <seastar/core/shared_ptr.hh>
 #include "query-result-reader.hh"
 #include "query_result_merger.hh"

--- a/cql3/statements/select_statement.hh
+++ b/cql3/statements/select_statement.hh
@@ -41,23 +41,29 @@
 
 #pragma once
 
-#include "cql3/statements/raw/cf_statement.hh"
 #include "cql3/statements/raw/select_statement.hh"
 #include "cql3/cql_statement.hh"
-#include "cql3/selection/selection.hh"
-#include "cql3/selection/raw_selector.hh"
-#include "cql3/restrictions/statement_restrictions.hh"
-#include "cql3/result_set.hh"
-#include "exceptions/unrecognized_entity_exception.hh"
-#include "service/client_state.hh"
+#include "cql3/stats.hh"
 #include <seastar/core/shared_ptr.hh>
-#include <seastar/core/distributed.hh>
-#include "validation.hh"
 #include "transport/messages/result_message.hh"
+#include "index/secondary_index_manager.hh"
+
+namespace service {
+    class client_state;
+} // namespace service
 
 namespace cql3 {
 
 class query_processor;
+
+namespace selection {
+    class selection;
+} // namespace selection
+
+namespace restrictions {
+    class restrictions;
+    class statement_restrictions;
+} // namespace restrictions
 
 namespace statements {
 

--- a/cql3/statements/update_statement.cc
+++ b/cql3/statements/update_statement.cc
@@ -47,6 +47,7 @@
 
 #include "cql3/operation_impl.hh"
 #include "cql3/type_json.hh"
+#include "cql3/single_column_relation.hh"
 #include "types/map.hh"
 #include "types/set.hh"
 #include "types/list.hh"

--- a/cql3/statements/update_statement.hh
+++ b/cql3/statements/update_statement.hh
@@ -42,11 +42,13 @@
 #pragma once
 
 #include "cql3/statements/modification_statement.hh"
-#include "cql3/term.hh"
+#include "cql3/attributes.hh"
 
 #include "database_fwd.hh"
 
 namespace cql3 {
+
+class term;
 
 namespace statements {
 

--- a/cql3/statements/use_statement.cc
+++ b/cql3/statements/use_statement.cc
@@ -43,6 +43,7 @@
 #include "cql3/statements/raw/use_statement.hh"
 #include "cql3/query_processor.hh"
 #include "transport/messages/result_message.hh"
+#include "service/query_state.hh"
 
 namespace cql3 {
 

--- a/cql3/statements/use_statement.hh
+++ b/cql3/statements/use_statement.hh
@@ -52,22 +52,22 @@ namespace statements {
 
 class use_statement : public cql_statement_no_metadata {
 private:
-    const sstring _keyspace;
+    const seastar::sstring _keyspace;
 
 public:
-    use_statement(sstring keyspace);
+    use_statement(seastar::sstring keyspace);
 
     virtual uint32_t get_bound_terms() const override;
 
-    virtual bool depends_on_keyspace(const sstring& ks_name) const override;
+    virtual bool depends_on_keyspace(const seastar::sstring& ks_name) const override;
 
-    virtual bool depends_on_column_family(const sstring& cf_name) const override;
+    virtual bool depends_on_column_family(const seastar::sstring& cf_name) const override;
 
-    virtual future<> check_access(service::storage_proxy& proxy, const service::client_state& state) const override;
+    virtual seastar::future<> check_access(service::storage_proxy& proxy, const service::client_state& state) const override;
 
     virtual void validate(service::storage_proxy&, const service::client_state& state) const override;
 
-    virtual future<::shared_ptr<cql_transport::messages::result_message>>
+    virtual seastar::future<seastar::shared_ptr<cql_transport::messages::result_message>>
     execute(query_processor& qp, service::query_state& state, const query_options& options) const override;
 };
 

--- a/cql3/term.hh
+++ b/cql3/term.hh
@@ -41,16 +41,14 @@
 
 #pragma once
 
-#include <optional>
-#include "variable_specifications.hh"
 #include "cql3/assignment_testable.hh"
 #include "cql3/query_options.hh"
 #include "cql3/values.hh"
-#include "types.hh"
 
 namespace cql3 {
 
 class terminal;
+class variable_specifications;
 
 /**
  * A CQL3 term, i.e. a column value with or without bind variables.

--- a/cql3/tuples.hh
+++ b/cql3/tuples.hh
@@ -44,6 +44,7 @@
 #include "types/tuple.hh"
 #include "types/collection.hh"
 #include "utils/chunked_vector.hh"
+#include "cql3/column_identifier.hh"
 
 class list_type_impl;
 

--- a/cql3/type_cast.hh
+++ b/cql3/type_cast.hh
@@ -41,6 +41,7 @@
 
 #include "term.hh"
 #include "cql3_type.hh"
+#include "cql3/column_identifier.hh"
 
 namespace cql3 {
 

--- a/db/commitlog/commitlog_extensions.hh
+++ b/db/commitlog/commitlog_extensions.hh
@@ -25,14 +25,13 @@
 #include <optional>
 #include <seastar/core/seastar.hh>
 
-#include "commitlog.hh"
-
 namespace db {
     class commitlog_file_extension {
     public:
         virtual ~commitlog_file_extension() {}
-        virtual future<file> wrap_file(const sstring& filename, file, open_flags flags) = 0;
-        virtual future<> before_delete(const sstring& filename) = 0;
+        virtual seastar::future<seastar::file> wrap_file(const seastar::sstring& filename,
+            seastar::file, seastar::open_flags flags) = 0;
+        virtual seastar::future<> before_delete(const seastar::sstring& filename) = 0;
     };
 }
 

--- a/db/commitlog/commitlog_replayer.cc
+++ b/db/commitlog/commitlog_replayer.cc
@@ -61,6 +61,7 @@
 #include "db/extensions.hh"
 #include "utils/fragmented_temporary_buffer.hh"
 #include "validation.hh"
+#include "mutation_partition_view.hh"
 
 static logging::logger rlogger("commitlog_replayer");
 

--- a/db/consistency_level.hh
+++ b/db/consistency_level.hh
@@ -44,7 +44,6 @@
 #include "db/consistency_level_type.hh"
 #include "db/read_repair_decision.hh"
 #include "exceptions/exceptions.hh"
-#include "utils/fb_utilities.hh"
 #include "gms/inet_address.hh"
 #include "inet_address_vectors.hh"
 #include "log.hh"

--- a/db/data_listeners.hh
+++ b/db/data_listeners.hh
@@ -30,12 +30,13 @@
 #include "schema_fwd.hh"
 #include "flat_mutation_reader.hh"
 #include "mutation_reader.hh"
-#include "frozen_mutation.hh"
 #include "utils/top_k.hh"
 #include "schema_registry.hh"
 
 #include <vector>
 #include <set>
+
+class frozen_mutation;
 
 namespace db {
 

--- a/db/hints/host_filter.hh
+++ b/db/hints/host_filter.hh
@@ -21,16 +21,18 @@
 
 #pragma once
 
-#include <functional>
 #include <unordered_set>
-#include <exception>
-#include <iostream>
+#include <stdexcept>
+#include <iosfwd>
 #include <string_view>
 
 #include <seastar/core/sstring.hh>
-#include "gms/inet_address.hh"
 #include "locator/snitch_base.hh"
 #include "seastarx.hh"
+
+namespace gms {
+    class inet_address;
+} // namespace gms
 
 namespace db {
 namespace hints {

--- a/db/hints/manager.cc
+++ b/db/hints/manager.cc
@@ -42,6 +42,7 @@
 #include "utils/directories.hh"
 #include "utils/UUID_gen.hh"
 #include "locator/abstract_replication_strategy.hh"
+#include "mutation_partition_view.hh"
 
 using namespace std::literals::chrono_literals;
 

--- a/db/hints/manager.hh
+++ b/db/hints/manager.hh
@@ -33,16 +33,16 @@
 #include <seastar/core/lowres_clock.hh>
 #include <seastar/core/shared_mutex.hh>
 #include <seastar/core/expiring_fifo.hh>
-#include "lister.hh"
 #include "gms/gossiper.hh"
 #include "locator/snitch_base.hh"
 #include "inet_address_vectors.hh"
 #include "service/endpoint_lifecycle_subscriber.hh"
 #include "db/commitlog/commitlog.hh"
 #include "utils/loading_shared_values.hh"
-#include "utils/fragmented_temporary_buffer.hh"
 #include "db/hints/resource_manager.hh"
 #include "db/hints/host_filter.hh"
+
+class fragmented_temporary_buffer;
 
 namespace service {
 class storage_service;

--- a/db/hints/resource_manager.hh
+++ b/db/hints/resource_manager.hh
@@ -29,7 +29,6 @@
 #include <seastar/core/future.hh>
 #include "seastarx.hh"
 #include <unordered_set>
-#include "gms/gossiper.hh"
 #include "utils/small_vector.hh"
 #include "lister.hh"
 #include "enum_set.hh"
@@ -38,6 +37,11 @@ namespace service {
 class storage_proxy;
 class storage_service;
 }
+
+namespace gms {
+    class gossiper;
+    class inet_address;
+} // namespace gms
 
 namespace db {
 namespace hints {

--- a/db/system_distributed_keyspace.cc
+++ b/db/system_distributed_keyspace.cc
@@ -33,6 +33,7 @@
 #include "cdc/generation.hh"
 #include "cql3/query_processor.hh"
 #include "service/storage_proxy.hh"
+#include "service/migration_manager.hh"
 
 #include <seastar/core/seastar.hh>
 #include <seastar/core/shared_ptr.hh>

--- a/db/system_distributed_keyspace.hh
+++ b/db/system_distributed_keyspace.hh
@@ -23,7 +23,6 @@
 
 #include "bytes.hh"
 #include "schema_fwd.hh"
-#include "service/migration_manager.hh"
 #include "service/qos/qos_common.hh"
 #include "utils/UUID.hh"
 #include "cdc/generation_id.hh"
@@ -45,6 +44,7 @@ namespace cdc {
 
 namespace service {
     class storage_proxy;
+    class migration_manager;
 }
 
 namespace db {

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -84,6 +84,7 @@
 #include "db/virtual_table.hh"
 #include "service/storage_service.hh"
 #include "gms/gossiper.hh"
+#include "service/paxos/paxos_state.hh"
 
 #include "idl/frozen_mutation.dist.hh"
 #include "serializer_impl.hh"

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -48,19 +48,22 @@
 #include "utils/UUID.hh"
 #include "gms/inet_address.hh"
 #include "query-result-set.hh"
-#include "locator/token_metadata.hh"
 #include "db_clock.hh"
 #include "db/commitlog/replay_position.hh"
 #include "mutation_query.hh"
 #include <map>
 #include <seastar/core/distributed.hh>
-#include "service/paxos/paxos_state.hh"
 #include "cdc/generation_id.hh"
 
 namespace service {
 
 class storage_proxy;
 class storage_service;
+
+namespace paxos {
+    class paxos_state;
+    class proposal;
+} // namespace service::paxos
 
 }
 
@@ -76,6 +79,10 @@ namespace gms {
     class feature;
     class feature_service;
 }
+
+namespace locator {
+    class endpoint_dc_rack;
+} // namespace locator
 
 bool is_system_keyspace(std::string_view ks_name);
 

--- a/db/view/row_locking.cc
+++ b/db/view/row_locking.cc
@@ -21,6 +21,7 @@
 
 #include "row_locking.hh"
 #include "log.hh"
+#include "utils/latency.hh"
 
 #include <seastar/core/when_all.hh>
 

--- a/db/view/row_locking.hh
+++ b/db/view/row_locking.hh
@@ -43,8 +43,6 @@
 #include "dht/i_partitioner.hh"
 #include "query-request.hh"
 #include "utils/estimated_histogram.hh"
-#include "utils/histogram.hh"
-#include "utils/latency.hh"
 
 class row_locker {
 public:

--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -59,6 +59,7 @@
 #include "clustering_bounds_comparator.hh"
 #include "cql3/statements/select_statement.hh"
 #include "cql3/util.hh"
+#include "cql3/restrictions/statement_restrictions.hh"
 #include "db/view/view.hh"
 #include "db/view/view_builder.hh"
 #include "db/view/view_updating_consumer.hh"
@@ -80,6 +81,7 @@
 #include "types/list.hh"
 #include "types/map.hh"
 #include "utils/error_injection.hh"
+#include "utils/exponential_backoff_retry.hh"
 
 using namespace std::chrono_literals;
 

--- a/db/view/view.hh
+++ b/db/view/view.hh
@@ -21,15 +21,11 @@
 
 #pragma once
 
-#include "view_stats.hh"
 #include "dht/i_partitioner.hh"
 #include "gc_clock.hh"
 #include "query-request.hh"
 #include "schema_fwd.hh"
-#include "mutation_fragment.hh"
 #include "flat_mutation_reader.hh"
-
-#include <seastar/core/semaphore.hh>
 
 class frozen_mutation_and_schema;
 struct cf_stats;
@@ -42,6 +38,8 @@ using allow_hints = bool_class<allow_hints_tag>;
 namespace db {
 
 namespace view {
+
+class stats;
 
 // Part of the view description which depends on the base schema version.
 //

--- a/db/view/view_builder.hh
+++ b/db/view/view_builder.hh
@@ -22,11 +22,8 @@
 #pragma once
 
 #include "dht/i_partitioner.hh"
-#include "keys.hh"
 #include "query-request.hh"
 #include "service/migration_listener.hh"
-#include "service/migration_manager.hh"
-#include "utils/exponential_backoff_retry.hh"
 #include "utils/serialized_action.hh"
 #include "utils/UUID.hh"
 #include "database.hh"
@@ -56,7 +53,12 @@ class view_build_progress;
 
 }
 
+namespace service {
+    class migration_manager;
+} // namespace service
+
 class database;
+class exponential_backoff_retry;
 
 namespace db::view {
 

--- a/db/view/view_update_generator.cc
+++ b/db/view/view_update_generator.cc
@@ -23,6 +23,7 @@
 #include "view_update_generator.hh"
 #include "service/priority_manager.hh"
 #include "utils/error_injection.hh"
+#include "db/view/view_updating_consumer.hh"
 
 static logging::logger vug_logger("view_update_generator");
 

--- a/db/view/view_update_generator.hh
+++ b/db/view/view_update_generator.hh
@@ -22,8 +22,7 @@
 #pragma once
 
 #include "database.hh"
-#include "sstables/sstables.hh"
-#include "db/view/view_updating_consumer.hh"
+#include "sstables/shared_sstable.hh"
 
 #include <seastar/core/abort_source.hh>
 #include <seastar/core/condition-variable.hh>

--- a/flat_mutation_reader.cc
+++ b/flat_mutation_reader.cc
@@ -33,6 +33,8 @@
 #include "utils/exceptions.hh"
 #include <seastar/core/on_internal_error.hh>
 
+#include "clustering_key_filter.hh"
+
 logging::logger fmr_logger("flat_mutation_reader");
 
 flat_mutation_reader& flat_mutation_reader::operator=(flat_mutation_reader&& o) noexcept {

--- a/flat_mutation_reader.hh
+++ b/flat_mutation_reader.hh
@@ -25,11 +25,9 @@
 #include <seastar/core/future.hh>
 
 #include "dht/i_partitioner.hh"
-#include "position_in_partition.hh"
 #include "mutation_fragment.hh"
 #include "tracing/trace_state.hh"
 #include "mutation.hh"
-#include "query_class_config.hh"
 #include "mutation_consumer_concepts.hh"
 
 #include <seastar/core/thread.hh>
@@ -42,6 +40,7 @@
 using seastar::future;
 
 class mutation_source;
+class position_in_partition;
 
 /*
  * Allows iteration on mutations using mutation_fragments.

--- a/frozen_mutation.cc
+++ b/frozen_mutation.cc
@@ -42,6 +42,7 @@
 #include "idl/mutation.dist.impl.hh"
 #include "flat_mutation_reader.hh"
 #include "converting_mutation_partition_applier.hh"
+#include "mutation_partition_view.hh"
 
 //
 // Representation layout:

--- a/hashing_partition_visitor.hh
+++ b/hashing_partition_visitor.hh
@@ -27,6 +27,7 @@
 #include "atomic_cell_hash.hh"
 #include "keys.hh"
 #include "counters.hh"
+#include "position_in_partition.hh"
 
 // Calculates a hash of a mutation_partition which is consistent with
 // mutation equality. For any equal mutations, no matter which schema

--- a/memtable-sstable.hh
+++ b/memtable-sstable.hh
@@ -25,34 +25,34 @@
 
 #pragma once
 
-#include "memtable.hh"
 #include "sstables/shared_sstable.hh"
-#include "sstables/progress_monitor.hh"
 #include <seastar/core/future.hh>
-#include <seastar/core/file.hh>
-#include <seastar/core/thread.hh>
-#include <seastar/core/shared_ptr.hh>
+#include <seastar/core/io_priority_class.hh>
+
+class memtable;
+class flat_mutation_reader;
 
 namespace sstables {
 class sstables_manager;
 class sstable_writer_config;
+class write_monitor;
 }
 
-future<>
+seastar::future<>
 write_memtable_to_sstable(flat_mutation_reader reader,
         memtable& mt, sstables::shared_sstable sst,
         sstables::write_monitor& monitor,
         sstables::sstable_writer_config& cfg,
-        const io_priority_class& pc);
+        const seastar::io_priority_class& pc);
 
-future<>
+seastar::future<>
 write_memtable_to_sstable(memtable& mt,
         sstables::shared_sstable sst,
         sstables::write_monitor& mon,
         sstables::sstable_writer_config& cfg,
-        const io_priority_class& pc = default_priority_class());
+        const seastar::io_priority_class& pc = seastar::default_priority_class());
 
-future<>
+seastar::future<>
 write_memtable_to_sstable(memtable& mt,
         sstables::shared_sstable sst,
         sstables::sstable_writer_config cfg);

--- a/memtable.cc
+++ b/memtable.cc
@@ -26,6 +26,7 @@
 #include "frozen_mutation.hh"
 #include "partition_snapshot_reader.hh"
 #include "partition_builder.hh"
+#include "mutation_partition_view.hh"
 
 namespace {
 

--- a/multishard_mutation_query.hh
+++ b/multishard_mutation_query.hh
@@ -23,10 +23,27 @@
 
 #include "database_fwd.hh"
 #include "schema_fwd.hh"
-#include "mutation_query.hh"
 #include "cache_temperature.hh"
+#include "db/timeout_clock.hh"
+#include "dht/i_partitioner.hh"
 
 #include <seastar/core/distributed.hh>
+
+#include "seastarx.hh"
+
+class reconcilable_result;
+
+namespace query {
+
+class read_command;
+class result;
+class result_options;
+
+} // namespace query
+
+namespace tracing {
+    class trace_state_ptr;
+} // namespace tracing
 
 /// Run the mutation query on all shards.
 ///

--- a/mutation_partition.cc
+++ b/mutation_partition.cc
@@ -40,6 +40,8 @@
 #include "types/map.hh"
 #include "compaction_garbage_collector.hh"
 #include "utils/exceptions.hh"
+#include "clustering_key_filter.hh"
+#include "mutation_partition_view.hh"
 
 logging::logger mplog("mutation_partition");
 

--- a/mutation_partition.hh
+++ b/mutation_partition.hh
@@ -37,18 +37,20 @@
 #include "position_in_partition.hh"
 #include "atomic_cell_or_collection.hh"
 #include "query-result.hh"
-#include "mutation_partition_view.hh"
-#include "mutation_partition_visitor.hh"
-#include "utils/managed_vector.hh"
 #include "hashing_partition_visitor.hh"
 #include "range_tombstone_list.hh"
-#include "clustering_key_filter.hh"
 #include "utils/intrusive_btree.hh"
 #include "utils/preempt.hh"
 #include "utils/managed_ref.hh"
 #include "utils/compact-radix-tree.hh"
 
 class mutation_fragment;
+class mutation_partition_view;
+class mutation_partition_visitor;
+
+namespace query {
+    class clustering_key_filter_ranges;
+} // namespace query
 
 struct cell_hash {
     using size_type = uint64_t;

--- a/mutation_partition_serializer.hh
+++ b/mutation_partition_serializer.hh
@@ -21,9 +21,7 @@
 
 #pragma once
 
-#include "utils/data_input.hh"
 #include "database_fwd.hh"
-#include "mutation_partition_view.hh"
 #include "bytes_ostream.hh"
 #include "mutation_fragment.hh"
 

--- a/mutation_partition_view.hh
+++ b/mutation_partition_view.hh
@@ -24,6 +24,7 @@
 #include "database_fwd.hh"
 #include "mutation_partition_visitor.hh"
 #include "utils/input_stream.hh"
+#include "atomic_cell.hh"
 
 namespace ser {
 class mutation_partition_view;

--- a/mutation_partition_visitor.hh
+++ b/mutation_partition_visitor.hh
@@ -21,27 +21,30 @@
 
 #pragma once
 
-#include "atomic_cell.hh"
-#include "collection_mutation.hh"
-#include "tombstone.hh"
-#include "range_tombstone.hh"
-#include "keys.hh"
+#include <seastar/util/bool_class.hh>
 
+#include "schema_fwd.hh"
+
+class atomic_cell_view;
+class collection_mutation_view;
 class row_marker;
 class row_tombstone;
+class range_tombstone;
+class tombstone;
+class position_in_partition_view;
 
 // When used on an entry, marks the range between this entry and the previous
 // one as continuous or discontinuous, excluding the keys of both entries.
 // This information doesn't apply to continuity of the entries themselves,
 // that is specified by is_dummy flag.
 // See class doc of mutation_partition.
-using is_continuous = bool_class<class continuous_tag>;
+using is_continuous = seastar::bool_class<class continuous_tag>;
 
 // Dummy entry is an entry which is incomplete.
 // Typically used for marking bounds of continuity range.
 // See class doc of mutation_partition.
 class dummy_tag {};
-using is_dummy = bool_class<dummy_tag>;
+using is_dummy = seastar::bool_class<dummy_tag>;
 
 // Guarantees:
 //

--- a/mutation_query.hh
+++ b/mutation_query.hh
@@ -23,16 +23,14 @@
 
 #include "query-request.hh"
 #include "query-result.hh"
-#include "mutation_reader.hh"
 #include "frozen_mutation.hh"
 #include "db/timeout_clock.hh"
-#include "querier.hh"
+#include "mutation.hh"
 #include "utils/chunked_vector.hh"
-#include "query_class_config.hh"
-#include <seastar/core/execution_stage.hh>
 
 class reconcilable_result;
 class frozen_reconcilable_result;
+class mutation_source;
 
 // Can be read by other cores after publishing.
 struct partition {

--- a/mutation_reader.hh
+++ b/mutation_reader.hh
@@ -23,7 +23,6 @@
 
 #include <vector>
 
-#include "clustering_key_filter.hh"
 #include <seastar/core/future.hh>
 #include <seastar/core/future-util.hh>
 #include <seastar/core/do_with.hh>

--- a/partition_builder.hh
+++ b/partition_builder.hh
@@ -21,8 +21,13 @@
 
 #pragma once
 
+#include "schema.hh"
 #include "mutation_partition.hh"
-#include "mutation_partition_view.hh"
+#include "mutation_partition_visitor.hh"
+#include "tombstone.hh"
+#include "atomic_cell.hh"
+#include "range_tombstone.hh"
+#include "collection_mutation.hh"
 
 // Partition visitor which builds mutation_partition corresponding to the data its fed with.
 class partition_builder final : public mutation_partition_visitor {

--- a/partition_snapshot_reader.hh
+++ b/partition_snapshot_reader.hh
@@ -23,6 +23,7 @@
 
 #include "partition_version.hh"
 #include "flat_mutation_reader.hh"
+#include "clustering_key_filter.hh"
 #include <boost/range/algorithm/heap_algorithm.hpp>
 
 struct partition_snapshot_reader_dummy_accounter {

--- a/partition_version.hh
+++ b/partition_version.hh
@@ -22,7 +22,6 @@
 #pragma once
 
 #include "mutation_partition.hh"
-#include "mutation_fragment.hh"
 #include "utils/anchorless_list.hh"
 #include "utils/logalloc.hh"
 #include "utils/coroutine.hh"
@@ -30,6 +29,8 @@
 
 #include <boost/intrusive/parent_from_member.hpp>
 #include <boost/intrusive/slist.hpp>
+
+class static_row;
 
 // This is MVCC implementation for mutation_partitions.
 //

--- a/query-result-reader.hh
+++ b/query-result-reader.hh
@@ -24,9 +24,7 @@
 #include <boost/range/adaptor/transformed.hpp>
 #include <boost/range/numeric.hpp>
 
-#include "query-request.hh"
 #include "query-result.hh"
-#include "utils/data_input.hh"
 #include "digest_algorithm.hh"
 
 #include "idl/uuid.dist.hh"

--- a/query-result-set.hh
+++ b/query-result-set.hh
@@ -23,9 +23,8 @@
 
 
 #include <seastar/core/shared_ptr.hh>
-#include "query-request.hh"
-#include "query-result.hh"
-#include "schema_fwd.hh"
+#include "types.hh"
+#include "schema.hh"
 
 #include <optional>
 #include <stdexcept>
@@ -33,6 +32,8 @@
 class mutation;
 
 namespace query {
+
+class result;
 
 class no_value : public std::runtime_error {
 public:

--- a/range_tombstone_list.hh
+++ b/range_tombstone_list.hh
@@ -24,10 +24,11 @@
 #include <seastar/util/defer.hh>
 #include "range_tombstone.hh"
 #include "query-request.hh"
-#include "position_in_partition.hh"
 #include "utils/preempt.hh"
 #include <iosfwd>
 #include <variant>
+
+class position_in_partition_view;
 
 class range_tombstone_list final {
     using range_tombstones_type = range_tombstone::container_type;

--- a/reader_permit.hh
+++ b/reader_permit.hh
@@ -21,12 +21,14 @@
 
 #pragma once
 
-#include <seastar/core/shared_ptr.hh>
-#include <seastar/core/file.hh>
 #include "seastarx.hh"
 
 #include "db/timeout_clock.hh"
 #include "schema_fwd.hh"
+
+namespace seastar {
+    class file;
+} // namespace seastar
 
 struct reader_resources {
     int count = 0;

--- a/release.cc
+++ b/release.cc
@@ -29,12 +29,12 @@ static const char scylla_build_mode_str[] = SCYLLA_BUILD_MODE;
 
 std::string scylla_version()
 {
-    return format("{}-{}", scylla_version_str, scylla_release_str);
+    return seastar::format("{}-{}", scylla_version_str, scylla_release_str);
 }
 
 std::string scylla_build_mode()
 {
-    return format("{}", scylla_build_mode_str);
+    return seastar::format("{}", scylla_build_mode_str);
 }
 
 // get the version number into writeable memory, so we can grep for it if we get a core dump

--- a/row_cache.hh
+++ b/row_cache.hh
@@ -26,7 +26,6 @@
 #include <boost/intrusive/parent_from_member.hpp>
 
 #include <seastar/core/memory.hh>
-#include <seastar/core/thread.hh>
 #include <seastar/util/noncopyable_function.hh>
 
 #include "mutation_reader.hh"
@@ -34,7 +33,6 @@
 #include "utils/phased_barrier.hh"
 #include "utils/histogram.hh"
 #include "partition_version.hh"
-#include "utils/estimated_histogram.hh"
 #include "tracing/trace_state.hh"
 #include <seastar/core/metrics_registration.hh>
 #include "mutation_cleaner.hh"

--- a/schema.hh
+++ b/schema.hh
@@ -35,7 +35,6 @@
 #include "types.hh"
 #include "compound.hh"
 #include "gc_clock.hh"
-#include "unimplemented.hh"
 #include "utils/UUID.hh"
 #include "compress.hh"
 #include "compaction_strategy_type.hh"

--- a/service/raft/raft_sys_table_storage.cc
+++ b/service/raft/raft_sys_table_storage.cc
@@ -30,6 +30,7 @@
 #include "idl/raft.dist.impl.hh"
 
 #include "cql3/statements/batch_statement.hh"
+#include "cql3/statements/modification_statement.hh"
 #include "cql3/query_processor.hh"
 
 #include <seastar/core/loop.hh>

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -104,6 +104,8 @@
 #include "seastar/core/with_timeout.hh"
 #include "locator/abstract_replication_strategy.hh"
 #include "service/paxos/cas_request.hh"
+#include "mutation_partition_view.hh"
+#include "service/paxos/paxos_state.hh"
 
 namespace bi = boost::intrusive;
 

--- a/sstables/compaction.cc
+++ b/sstables/compaction.cc
@@ -71,6 +71,7 @@
 #include "mutation_writer/partition_based_splitting_writer.hh"
 #include "mutation_source_metadata.hh"
 #include "mutation_fragment_stream_validator.hh"
+#include "utils/UUID_gen.hh"
 
 namespace sstables {
 

--- a/sstables/mutation_fragment_filter.hh
+++ b/sstables/mutation_fragment_filter.hh
@@ -23,6 +23,7 @@
 
 #include "mutation_fragment.hh"
 #include "clustering_ranges_walker.hh"
+#include "clustering_key_filter.hh"
 
 namespace sstables {
 

--- a/table_helper.cc
+++ b/table_helper.cc
@@ -25,6 +25,7 @@
 #include "cql3/statements/create_table_statement.hh"
 #include "cql3/statements/modification_statement.hh"
 #include "database.hh"
+#include "service/migration_manager.hh"
 
 future<> table_helper::setup_table(cql3::query_processor& qp) const {
     auto& db = qp.db();

--- a/table_helper.hh
+++ b/table_helper.hh
@@ -23,8 +23,7 @@
 #pragma once
 
 #include "cql3/statements/prepared_statement.hh"
-#include "service/migration_manager.hh"
-
+#include "service/query_state.hh"
 
 namespace cql3 {
 class query_processor;

--- a/test/boost/cdc_test.cc
+++ b/test/boost/cdc_test.cc
@@ -40,6 +40,8 @@
 #include "types/set.hh"
 #include "types/user.hh"
 
+#include "utils/UUID_gen.hh"
+
 using namespace std::string_literals;
 
 namespace cdc {

--- a/test/boost/counter_test.cc
+++ b/test/boost/counter_test.cc
@@ -34,6 +34,7 @@
 #include "keys.hh"
 #include "mutation.hh"
 #include "frozen_mutation.hh"
+#include "mutation_partition_view.hh"
 
 void verify_shard_order(counter_cell_view ccv) {
     if (ccv.shards().begin() == ccv.shards().end()) {

--- a/test/boost/cql_query_test.cc
+++ b/test/boost/cql_query_test.cc
@@ -55,6 +55,7 @@
 #include "gms/feature.hh"
 #include "db/query_context.hh"
 #include "service/qos/qos_common.hh"
+#include "utils/UUID_gen.hh"
 
 using namespace std::literals::chrono_literals;
 

--- a/test/boost/flat_mutation_reader_test.cc
+++ b/test/boost/flat_mutation_reader_test.cc
@@ -35,6 +35,7 @@
 #include "row_cache.hh"
 #include "test/lib/tmpdir.hh"
 #include "repair/repair.hh"
+#include "mutation_partition_view.hh"
 
 #include "test/lib/simple_schema.hh"
 #include "test/lib/flat_mutation_reader_assertions.hh"

--- a/test/boost/frozen_mutation_test.cc
+++ b/test/boost/frozen_mutation_test.cc
@@ -28,6 +28,7 @@
 
 #include "frozen_mutation.hh"
 #include "schema_builder.hh"
+#include "mutation_partition_view.hh"
 #include "test/lib/mutation_assertions.hh"
 #include "test/lib/mutation_source_test.hh"
 

--- a/test/boost/logalloc_test.cc
+++ b/test/boost/logalloc_test.cc
@@ -26,11 +26,14 @@
 #include <chrono>
 #include <random>
 
+#include <seastar/core/circular_buffer.hh>
 #include <seastar/core/print.hh>
 #include <seastar/core/thread.hh>
 #include <seastar/core/timer.hh>
 #include <seastar/core/sleep.hh>
 #include <seastar/core/thread_cputime_clock.hh>
+#include <seastar/core/when_all.hh>
+#include <seastar/core/with_timeout.hh>
 #include <seastar/testing/test_case.hh>
 #include <seastar/testing/thread_test_case.hh>
 #include <seastar/util/defer.hh>

--- a/test/boost/view_build_test.cc
+++ b/test/boost/view_build_test.cc
@@ -23,6 +23,7 @@
 
 #include "database.hh"
 #include "db/view/view_builder.hh"
+#include "db/view/view_updating_consumer.hh"
 #include "db/system_keyspace.hh"
 #include "db/system_keyspace_view_types.hh"
 #include "db/config.hh"

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -31,6 +31,7 @@
 #include "cql3/query_processor.hh"
 #include "cql3/query_options.hh"
 #include "cql3/statements/batch_statement.hh"
+#include "cql3/statements/modification_statement.hh"
 #include "cql3/cql_config.hh"
 #include <seastar/core/distributed.hh>
 #include <seastar/core/abort_source.hh>

--- a/test/lib/mutation_source_test.cc
+++ b/test/lib/mutation_source_test.cc
@@ -42,6 +42,7 @@
 #include "types/list.hh"
 #include "types/set.hh"
 #include <seastar/util/closeable.hh>
+#include "utils/UUID_gen.hh"
 
 // partitions must be sorted by decorated key
 static void require_no_token_duplicates(const std::vector<mutation>& partitions) {

--- a/test/manual/sstable_scan_footprint_test.cc
+++ b/test/manual/sstable_scan_footprint_test.cc
@@ -35,6 +35,7 @@
 #include <seastar/core/units.hh>
 #include <seastar/core/future-util.hh>
 #include <seastar/core/timer.hh>
+#include <seastar/core/fstream.hh>
 #include <seastar/util/log.hh>
 
 app_template app;

--- a/test/perf/perf_fast_forward.cc
+++ b/test/perf/perf_fast_forward.cc
@@ -53,6 +53,10 @@ using namespace seastar;
 namespace fs = std::filesystem;
 using int_range = nonwrapping_range<int>;
 
+namespace sstables {
+    extern bool use_binary_search_in_promoted_index;
+} // namespace sstables
+
 reactor::io_stats s;
 
 static bool errors_found = false;

--- a/test/perf/perf_idl.cc
+++ b/test/perf/perf_idl.cc
@@ -25,6 +25,7 @@
 #include "test/lib/simple_schema.hh"
 
 #include "frozen_mutation.hh"
+#include "mutation_partition_view.hh"
 
 namespace tests {
 

--- a/thrift/handler.hh
+++ b/thrift/handler.hh
@@ -30,6 +30,7 @@
 #include <memory>
 
 struct timeout_config;
+class service_permit;
 
 std::unique_ptr<::cassandra::CassandraCobSvIfFactory> create_handler_factory(distributed<database>& db, distributed<cql3::query_processor>& qp, auth::service&, timeout_config, service_permit& current_permit);
 

--- a/thrift/server.hh
+++ b/thrift/server.hh
@@ -33,6 +33,7 @@
 #include <boost/intrusive/list.hpp>
 #include "database_fwd.hh"
 #include "utils/updateable_value.hh"
+#include "service_permit.hh"
 
 class thrift_server;
 class thrift_stats;

--- a/tracing/trace_keyspace_helper.hh
+++ b/tracing/trace_keyspace_helper.hh
@@ -45,6 +45,7 @@
 #include <seastar/core/metrics_registration.hh>
 #include "tracing/tracing.hh"
 #include "table_helper.hh"
+#include "cql3/values.hh"
 
 namespace tracing {
 

--- a/transport/messages/result_message.hh
+++ b/transport/messages/result_message.hh
@@ -24,6 +24,7 @@
 
 #include "cql3/result_set.hh"
 #include "cql3/statements/prepared_statement.hh"
+#include "cql3/cql_statement.hh"
 
 #include "transport/messages/result_message_base.hh"
 #include "transport/event.hh"

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -28,6 +28,7 @@
 #include <boost/range/adaptor/sliced.hpp>
 
 #include "cql3/statements/batch_statement.hh"
+#include "cql3/statements/modification_statement.hh"
 #include "types/collection.hh"
 #include "types/list.hh"
 #include "types/set.hh"

--- a/transport/server.hh
+++ b/transport/server.hh
@@ -41,6 +41,8 @@
 #include <seastar/core/execution_stage.hh>
 #include "utils/updateable_value.hh"
 #include "generic_server.hh"
+#include "service/query_state.hh"
+#include "cql3/query_options.hh"
 
 namespace scollectd {
 

--- a/utils/large_bitset.hh
+++ b/utils/large_bitset.hh
@@ -24,12 +24,7 @@
 
 #pragma once
 
-#include <memory>
-#include <vector>
 #include <limits>
-#include <iterator>
-#include <algorithm>
-#include <seastar/core/thread.hh>
 #include <seastar/core/preempt.hh>
 #include "utils/chunked_vector.hh"
 

--- a/utils/logalloc.cc
+++ b/utils/logalloc.cc
@@ -35,8 +35,10 @@
 #include <seastar/core/metrics.hh>
 #include <seastar/core/reactor.hh>
 #include <seastar/core/coroutine.hh>
+#include <seastar/core/with_scheduling_group.hh>
 #include <seastar/util/alloc_failure_injector.hh>
 #include <seastar/util/backtrace.hh>
+#include <seastar/util/later.hh>
 
 #include "utils/logalloc.hh"
 #include "log.hh"

--- a/utils/logalloc.hh
+++ b/utils/logalloc.hh
@@ -23,14 +23,10 @@
 
 #include <memory>
 #include <seastar/core/memory.hh>
-#include <seastar/core/idle_cpu_handler.hh>
 #include <seastar/core/condition-variable.hh>
 #include <seastar/core/smp.hh>
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/core/shared_future.hh>
-#include <seastar/core/gate.hh>
-#include <seastar/core/future-util.hh>
-#include <seastar/core/circular_buffer.hh>
 #include <seastar/core/expiring_fifo.hh>
 #include "allocation_strategy.hh"
 #include <boost/heap/binomial_heap.hpp>

--- a/utils/phased_barrier.hh
+++ b/utils/phased_barrier.hh
@@ -22,7 +22,6 @@
 #pragma once
 
 #include <seastar/core/future.hh>
-#include <seastar/core/future-util.hh>
 #include <seastar/core/gate.hh>
 #include <seastar/core/shared_ptr.hh>
 #include "seastarx.hh"

--- a/version.hh
+++ b/version.hh
@@ -26,16 +26,14 @@
 #include <seastar/core/print.hh>
 #include <tuple>
 
-#include "seastarx.hh"
-
 namespace version {
 class version {
     std::tuple<uint16_t, uint16_t, uint16_t> _version;
 public:
     version(uint16_t x, uint16_t y = 0, uint16_t z = 0): _version(std::make_tuple(x, y, z)) {}
 
-    sstring to_sstring() {
-        return format("{:d}.{:d}.{:d}", std::get<0>(_version), std::get<1>(_version), std::get<2>(_version));
+    seastar::sstring to_sstring() {
+        return seastar::format("{:d}.{:d}.{:d}", std::get<0>(_version), std::get<1>(_version), std::get<2>(_version));
     }
 
     static version current() {
@@ -65,7 +63,7 @@ public:
     }
 };
 
-inline const sstring& release() {
+inline const seastar::sstring& release() {
     static thread_local auto str_ver = version::current().to_sstring();
     return str_ver;
 }


### PR DESCRIPTION
Use forward declarations wherever possible.

Signed-off-by: Pavel Solodovnikov <pa.solodovnikov@scylladb.com>