### PR TITLE
repair: Do not wait for hint replay

### DIFF
--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -1233,14 +1233,6 @@ int repair_service::do_repair_start(sstring keyspace, std::unordered_map<sstring
             cfs = std::move(cfs), ranges = std::move(ranges), options = std::move(options), ignore_nodes = std::move(ignore_nodes)] () mutable {
         auto participants = get_hosts_participating_in_repair(db.local(), keyspace, ranges, options.data_centers, options.hosts, ignore_nodes).get();
 
-        if (db.local().get_config().wait_for_hint_replay_before_repair()) {
-            auto waiting_nodes = db.local().get_token_metadata().get_all_endpoints();
-            std::erase_if(waiting_nodes, [&] (const auto& addr) {
-                return ignore_nodes.contains(addr);
-            });
-            try_wait_for_hints_to_be_replayed(id, std::move(waiting_nodes), participants).get();
-        }
-
         std::vector<future<>> repair_results;
         repair_results.reserve(smp::count);
         auto table_ids = get_table_ids(db.local(), keyspace, cfs);


### PR DESCRIPTION
Since we are moving to use rest api to control hint replay, do not
wait for hint replay unconditionally in repair for now.

This patch fixes regressions introduced by 49f4a2f968 (repair: plug in
waiting for hints to be sent before repair).

Fixes #8612
Fixes #8831