### PR TITLE
cql3: use existing constant for max result in indexed statements

### DIFF
--- a/cql3/statements/select_statement.hh
+++ b/cql3/statements/select_statement.hh
@@ -194,7 +194,6 @@ class indexed_table_select_statement : public select_statement {
     noncopyable_function<dht::partition_range_vector(const query_options&)> _get_partition_ranges_for_posting_list;
     noncopyable_function<query::partition_slice(const query_options&)> _get_partition_slice_for_posting_list;
 public:
-    static constexpr size_t max_base_table_query_result_bytes = 1024*1024;
     static constexpr size_t max_base_table_query_concurrency = 4096;
 
     static ::shared_ptr<cql3::statements::select_statement> prepare(database& db,


### PR DESCRIPTION
Original code which introduced enforcing page limits for indexed
statements created a new constant for max result size in bytes.
Botond reported that we already have such a constant, so it's now
used instead of reinventing it from scratch.

Refs #8814
Tests: unit(release)