### PR TITLE
Make calculating affected ranges yieldable

### DIFF
--- a/database.hh
+++ b/database.hh
@@ -1002,7 +1002,7 @@ public:
     }
 
 private:
-    future<row_locker::lock_holder> do_push_view_replica_updates(const schema_ptr& s, mutation&& m, db::timeout_clock::time_point timeout, mutation_source&& source,
+    future<row_locker::lock_holder> do_push_view_replica_updates(schema_ptr s, mutation m, db::timeout_clock::time_point timeout, mutation_source source,
             tracing::trace_state_ptr tr_state, reader_concurrency_semaphore& sem, const io_priority_class& io_priority, query::partition_slice::option_set custom_opts) const;
     std::vector<view_ptr> affected_views(const schema_ptr& base, const mutation& update, gc_clock::time_point now) const;
     future<> generate_and_propagate_view_updates(const schema_ptr& base,

--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -54,6 +54,7 @@
 #include <boost/algorithm/cxx11/all_of.hpp>
 
 #include <seastar/core/future-util.hh>
+#include <seastar/core/coroutine.hh>
 
 #include "database.hh"
 #include "clustering_bounds_comparator.hh"
@@ -1053,7 +1054,7 @@ future<std::vector<frozen_mutation_and_schema>> generate_view_updates(
     });
 }
 
-query::clustering_row_ranges calculate_affected_clustering_ranges(const schema& base,
+future<query::clustering_row_ranges> calculate_affected_clustering_ranges(const schema& base,
         const dht::decorated_key& key,
         const mutation_partition& mp,
         const std::vector<view_and_base>& views,
@@ -1070,6 +1071,7 @@ query::clustering_row_ranges calculate_affected_clustering_ranges(const schema& 
             }
             for (auto&& r : v.view->view_info()->partition_slice().default_row_ranges()) {
                 view_row_ranges.push_back(r.transform(std::mem_fn(&clustering_key_prefix::view)));
+                co_await make_ready_future<>(); // yield if needed
             }
         }
     }
@@ -1086,6 +1088,7 @@ query::clustering_row_ranges calculate_affected_clustering_ranges(const schema& 
                 if (overlap) {
                     row_ranges.push_back(std::move(overlap).value());
                 }
+                co_await make_ready_future<>(); // yield if needed
             }
         }
     }
@@ -1094,6 +1097,7 @@ query::clustering_row_ranges calculate_affected_clustering_ranges(const schema& 
         if (update_requires_read_before_write(base, views, key, row, now)) {
             row_ranges.emplace_back(row.key());
         }
+        co_await make_ready_future<>(); // yield if needed
     }
 
     // Note that the views could have restrictions on regular columns,
@@ -1104,7 +1108,7 @@ query::clustering_row_ranges calculate_affected_clustering_ranges(const schema& 
     // this mutation.
 
     //FIXME: Unfortunate copy.
-    return boost::copy_range<query::clustering_row_ranges>(
+    co_return boost::copy_range<query::clustering_row_ranges>(
             nonwrapping_range<clustering_key_prefix_view>::deoverlap(std::move(row_ranges), cmp)
             | boost::adaptors::transformed([] (auto&& v) {
                 return std::move(v).transform([] (auto&& ckv) { return clustering_key_prefix(ckv); });

--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -1058,8 +1058,8 @@ query::clustering_row_ranges calculate_affected_clustering_ranges(const schema& 
         const mutation_partition& mp,
         const std::vector<view_and_base>& views,
         gc_clock::time_point now) {
-    std::vector<nonwrapping_range<clustering_key_prefix_view>> row_ranges;
-    std::vector<nonwrapping_range<clustering_key_prefix_view>> view_row_ranges;
+    utils::chunked_vector<nonwrapping_range<clustering_key_prefix_view>> row_ranges;
+    utils::chunked_vector<nonwrapping_range<clustering_key_prefix_view>> view_row_ranges;
     clustering_key_prefix_view::tri_compare cmp(base);
     if (mp.partition_tombstone() || !mp.row_tombstones().empty()) {
         for (auto&& v : views) {

--- a/db/view/view.hh
+++ b/db/view/view.hh
@@ -141,7 +141,7 @@ future<std::vector<frozen_mutation_and_schema>> generate_view_updates(
         flat_mutation_reader_opt&& existings,
         gc_clock::time_point now);
 
-query::clustering_row_ranges calculate_affected_clustering_ranges(
+future<query::clustering_row_ranges> calculate_affected_clustering_ranges(
         const schema& base,
         const dht::decorated_key& key,
         const mutation_partition& mp,

--- a/interval.hh
+++ b/interval.hh
@@ -615,8 +615,14 @@ public:
     }
     // Takes a vector of possibly overlapping intervals and returns a vector containing
     // a set of non-overlapping intervals covering the same values.
-    template<typename Comparator>
-    static std::vector<nonwrapping_interval> deoverlap(std::vector<nonwrapping_interval> intervals, Comparator&& cmp) {
+    template<typename Comparator, typename IntervalVec>
+    requires requires (IntervalVec vec) {
+        { vec.begin() } -> std::random_access_iterator;
+        { vec.end() } -> std::random_access_iterator;
+        { vec.reserve(1) };
+        { vec.front() } -> std::same_as<nonwrapping_interval&>;
+    }
+    static IntervalVec deoverlap(IntervalVec intervals, Comparator&& cmp) {
         auto size = intervals.size();
         if (size <= 1) {
             return intervals;
@@ -626,7 +632,7 @@ public:
             return wrapping_interval<T>::less_than(r1._interval.start_bound(), r2._interval.start_bound(), cmp);
         });
 
-        std::vector<nonwrapping_interval> deoverlapped_intervals;
+        IntervalVec deoverlapped_intervals;
         deoverlapped_intervals.reserve(size);
 
         auto&& current = intervals[0];

--- a/table.cc
+++ b/table.cc
@@ -2208,7 +2208,7 @@ future<row_locker::lock_holder> table::do_push_view_replica_updates(schema_ptr s
     if (views.empty()) {
         co_return row_locker::lock_holder();
     }
-    auto cr_ranges = db::view::calculate_affected_clustering_ranges(*base, m.decorated_key(), m.partition(), views, now);
+    auto cr_ranges = co_await db::view::calculate_affected_clustering_ranges(*base, m.decorated_key(), m.partition(), views, now);
     if (cr_ranges.empty()) {
         tracing::trace(tr_state, "View updates do not require read-before-write");
         co_await generate_and_propagate_view_updates(base, sem.make_permit(s.get(), "push-view-updates-1"), std::move(views), std::move(m), { }, std::move(tr_state), now);


### PR DESCRIPTION
This series partially addresses #8852 and its problems caused by deleting large partitions from tables with materialized views. The issue in question is not fixed by this series, because a full fix requires a more complex rewrite of the view update mechanism.
This series makes calculating affected clustering ranges for materialized view updates more resilient to large allocations and stalls. It does so by futurizing the function which can potentially involve large computations and makes it use non-contiguous storage instead of std::vector to avoid large allocations.

Tests: unit(release)