### PR TITLE
schema_tables: make the_merge_lock thread_local

### DIFF
--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -855,7 +855,7 @@ read_keyspace_mutation(distributed<service::storage_proxy>& proxy, const sstring
     return query_partition_mutation(proxy.local(), std::move(s), std::move(cmd), std::move(key));
 }
 
-static semaphore the_merge_lock {1};
+static thread_local semaphore the_merge_lock {1};
 
 future<> merge_lock() {
     return smp::submit_to(0, [] { return the_merge_lock.wait(); });


### PR DESCRIPTION
the_merge_lock is global, which is fine now because it is only used
in shard 0. However, if we run multiple nodes in a single process,
there will be multiple shard 0:s, and the_merge_lock will be accessed
from multiple threads. This won't work.

To fix, make it thread_local. It would be better to make it a member
of some controlling object, but there isn't one.