### PR TITLE
main: use correct max-io-requests option spelling

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -314,7 +314,7 @@ verify_seastar_io_scheduler(const boost::program_options::variables_map& opts, b
     if (!opts.contains("max-io-requests") && !(opts.contains("io-properties") || opts.contains("io-properties-file"))) {
         note_bad_conf("none of --max-io-requests, --io-properties and --io-properties-file are set.");
     }
-    if (opts.contains("max-io-requests") && opts["max_io_requests"].as<unsigned>() < 4) {
+    if (opts.contains("max-io-requests") && opts["max-io-requests"].as<unsigned>() < 4) {
         auto cause = format("I/O Queue capacity for this shard is too low ({:d}, minimum 4 expected).", opts["max_io_requests"].as<unsigned>());
         note_bad_conf(cause);
     }


### PR DESCRIPTION
We check for the existence of the option using one spelling,
then read it using another, so we crash with bad_lexical_cast
if it's present when casting the empty string to unsigned.

Fix by using the correct spelling.