### PR TITLE
cql3: add USING TIMEOUT support for deletes

### DIFF
--- a/cql3/Cql.g
+++ b/cql3/Cql.g
@@ -588,7 +588,7 @@ deleteStatement returns [std::unique_ptr<raw::delete_statement> expr]
     }
     : K_DELETE ( dels=deleteSelection { column_deletions = std::move(dels); } )?
       K_FROM cf=columnFamilyName
-      ( usingClauseDelete[attrs] )?
+      ( usingClause[attrs] )?
       K_WHERE wclause=whereClause
       ( K_IF ( K_EXISTS { if_exists = true; } | conditions=updateConditions ))?
       {
@@ -610,10 +610,6 @@ deleteOp returns [std::unique_ptr<cql3::operation::raw_deletion> op]
     : c=cident                { $op = std::make_unique<cql3::operation::column_deletion>(std::move(c)); }
     | c=cident '[' t=term ']' { $op = std::make_unique<cql3::operation::element_deletion>(std::move(c), std::move(t)); }
     | c=cident '.' field=ident { $op = std::make_unique<cql3::operation::field_deletion>(std::move(c), std::move(field)); }
-    ;
-
-usingClauseDelete[std::unique_ptr<cql3::attributes::raw>& attrs]
-    : K_USING K_TIMESTAMP ts=intValue { attrs->timestamp = ts; }
     ;
 
 /**

--- a/cql3/statements/delete_statement.cc
+++ b/cql3/statements/delete_statement.cc
@@ -213,7 +213,11 @@ delete_statement::delete_statement(cf_name name,
     : raw::modification_statement(std::move(name), std::move(attrs), std::move(conditions), false, if_exists)
     , _deletions(std::move(deletions))
     , _where_clause(std::move(where_clause))
-{ }
+{
+    if (_attrs->time_to_live) {
+        throw exceptions::invalid_request_exception("TTL attribute is not allowed for deletes");
+    }
+}
 
 }
 

--- a/test/cql-pytest/test_using_timeout.py
+++ b/test/cql-pytest/test_using_timeout.py
@@ -44,6 +44,10 @@ def test_per_query_timeout_effective(scylla_only, cql, table1):
         cql.execute(f"INSERT INTO {table} (p,c,v) VALUES ({key},1,1) USING TIMEOUT 0ms")
     with pytest.raises(WriteTimeout):
         cql.execute(f"UPDATE {table} USING TIMEOUT 0ms SET v = 5 WHERE p = {key} AND c = 1")
+    with pytest.raises(WriteTimeout):
+        cql.execute(f"DELETE FROM {table} USING TIMEOUT 0ms WHERE p = {key}")
+    with pytest.raises(WriteTimeout):
+        cql.execute(f"DELETE FROM {table} USING TIMEOUT 0ms AND timestamp 42 WHERE p = {key}")
 
 # Performing operations with large enough timeout should succeed
 def test_per_query_timeout_large_enough(scylla_only, cql, table1):
@@ -159,3 +163,4 @@ def test_invalid_timeout(scylla_only, cql, table1):
     invalid(f"SELECT * FROM {table} USING TIMEOUT 60s AND TIMESTAMP 42")
     invalid(f"SELECT * FROM {table} USING TIMEOUT 60s AND TTL 10000")
     invalid(f"SELECT * FROM {table} USING TIMEOUT 60s AND TTL 123 AND TIMESTAMP 911")
+    invalid (f"DELETE FROM {table} USING TIMEOUT 60s AND TTL 42 WHERE p = 42")


### PR DESCRIPTION
Turns out the DELETE statement already supports attributes
like timestamp, so it's ridiculously easy to add USING TIMEOUT
support - it's just the matter of accepting it in the grammar.

Fixes #8855