### PR TITLE
table: Always use explicit commitlog discard + clear out rp_set (v3)

### DIFF
--- a/memtable.hh
+++ b/memtable.hh
@@ -271,7 +271,13 @@ public:
     const db::replay_position& replay_position() const {
         return _replay_position;
     }
-    db::rp_set rp_set() {
+    /**
+     * Returns the current rp_set, and resets the
+     * stored one to empty. Only used for flushing
+     * purposes, to one-shot report discarded rp:s
+     * to commitlog
+     */
+    db::rp_set get_and_discard_rp_set() {
         return std::exchange(_rp_set, {});
     }
     friend class iterator_reader;


### PR DESCRIPTION
Fixes #8733

If a memtable flush is still pending when we call table::clear(),
we can end up doing a "discard-all" call to commitlog, followed
by a per-segment-count (using rp_set) _later_. This will foobar
our internal usage counts and quite probably cause assertion
failures.
Fixed by always doing per-memtable explicit discard call. But to
ensure this works, since a memtable being flushed remains on
memtable list for a while (why?), we must also ensure we clear
out the rp_set on discard.

v2:
* Rename rp_set getter to more omnious name, since we actually
  clear rp_set.
v3:
* Fix table::clear to discard rp_sets before memtables