### PR TITLE
storage_service: check for existing normal token owners before bootstrapping

### DIFF
--- a/db/system_distributed_keyspace.cc
+++ b/db/system_distributed_keyspace.cc
@@ -435,6 +435,7 @@ static future<utils::chunked_vector<mutation>> get_cdc_generation_mutations(
         size_t num_replicas,
         size_t concurrency,
         const cdc::topology_description& desc) {
+    assert(num_replicas);
     auto s = db.find_schema(system_distributed_keyspace::NAME_EVERYWHERE, system_distributed_keyspace::CDC_GENERATIONS_V2);
 
     // To insert the data quickly and efficiently we send it in batches of multiple rows

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -676,6 +676,18 @@ void storage_service::bootstrap() {
         // Wait until we know tokens of existing node before announcing join status.
         _gossiper.wait_for_range_setup().get();
 
+        if (get_token_metadata_ptr()->count_normal_token_owners() == 0) {
+            // We're joining an existing cluster, so there are normal nodes in the cluster.
+            // We've waited for tokens to arrive.
+            // But we didn't see any normal token owners. Something's wrong, we cannot proceed.
+            throw std::runtime_error{
+                    "Failed to learn about other nodes' tokens during bootstrap. Make sure that:\n"
+                    " - the node can contact other nodes in the cluster,\n"
+                    " - the `ring_delay` parameter is large enough (the 30s default should be enough for small-to-middle-sized clusters),\n"
+                    " - a node with this IP didn't recently leave the cluster. If it did, wait for some time first (the IP is quarantined),\n"
+                    "and retry the bootstrap."};
+        }
+
         // Even if we reached this point before but crashed, we will make a new CDC generation.
         // It doesn't hurt: other nodes will (potentially) just do more generation switches.
         // We do this because with this new attempt at bootstrapping we picked a different set of tokens.


### PR DESCRIPTION
The bootstrap procedure starts by "waiting for range setup", which means
waiting for a time interval specified by the `ring_delay` parameter (30s
by default) so the node can receive the tokens of other nodes before
introducing its own tokens.

However it may sometimes happen that the node doesn't receive the
tokens. There are no explicit checks for this. But the code may crash in
weird ways if the tokens-received assuption is false, and we are lucky
if it does crash (instead of, for example, allowing the node to
incorrectly bootstrap, causing data loss in the process).

Introduce an explicit check-and-throw-if-false: a bootstrapping node now
checks that there's at least one NORMAL token in the token ring, which
means that it had to have contacted at least one existing node
in the cluster, which means that it received the gossip application
states of all nodes from that node; in particular the tokens of all
nodes.

Also add an assert in CDC code which relies on that assumption
(and would cause weird division-by-zero errors if the assumption
was false; better to crash on assert than this).

Ref #8889.