### PR TITLE
table: ensure memtable is actually in memtable list before erasing

### DIFF
--- a/database.hh
+++ b/database.hh
@@ -210,9 +210,13 @@ public:
         return _memtables.back();
     }
 
-    // The caller has to make sure the element exist before calling this.
+    // # 8904 - this method is akin to std::set::erase(key_type), not
+    // erase(iterator). Should be tolerant against non-existing.
     void erase(const shared_memtable& element) {
-        _memtables.erase(boost::range::find(_memtables, element));
+        auto i = boost::range::find(_memtables, element);
+        if (i != _memtables.end()) {
+            _memtables.erase(i);
+        }
     }
 
     // Clears the active memtable and adds a new, empty one.


### PR DESCRIPTION
Fixes #8749

if a table::clear() was issued while we were flushing a memtable,
the memtable is already gone from list. We need to check this before
erase. Otherwise we get random memory corruption via
std::vector::erase

Verrifying this 100% deals with parent issue is nor easy, but repeated runs of the failing test
case are so far positive whereas previously occasional crashes occurred.
Regardless, the change is needed, since memtable_list::erase is unguarded.