### PR TITLE
gossip: Promote gossip quarantine over log to info level

### DIFF
--- a/gms/gossiper.cc
+++ b/gms/gossiper.cc
@@ -749,7 +749,7 @@ void gossiper::do_status_check() {
     for (auto it = _just_removed_endpoints.begin(); it != _just_removed_endpoints.end();) {
         auto& t= it->second;
         if ((now - t) > quarantine_delay()) {
-            logger.debug("{} ms elapsed, {} gossip quarantine over", quarantine_delay().count(), it->first);
+            logger.info("{} ms elapsed, {} gossip quarantine over", quarantine_delay().count(), it->first);
             it = _just_removed_endpoints.erase(it);
         } else {
             it++;


### PR DESCRIPTION
1) Start node n1, n2, n3

2) Bootstrap n4 and kill n4 in the middle of bootstrap

3) Wipe data on n4 and start n4 again

After step 2, n1, n2 and n3 will remove n4 from gossip after
fat_client_timeout and put n4 in quarantine for quarantine_delay().

If n4 bootstraps again in step 3 before the quarantine finishes, n1, n2
and n3 will ignore gossip updates from n4, and n4 will not learn gossip
updates from the cluster.

After PR #8896, the bootstrap will be rejected.

This patch promotes the gossip quarantine over log to info level, so
that dtest can wait for the log to bootstrap the node again.

Refs #8889
Refs #8890