### PR TITLE
Generate view updates in smaller parts

### DIFF
--- a/table.cc
+++ b/table.cc
@@ -1666,20 +1666,28 @@ future<> table::generate_and_propagate_view_updates(const schema_ptr& base,
         tracing::trace_state_ptr tr_state,
         gc_clock::time_point now) const {
     auto base_token = m.token();
-    auto updates = co_await db::view::generate_view_updates(
+    db::view::view_update_builder builder = co_await db::view::make_view_update_builder(
             base,
             std::move(views),
             flat_mutation_reader_from_mutations(std::move(permit), {std::move(m)}),
             std::move(existings),
             now);
-    tracing::trace(tr_state, "Generated {} view update mutations", updates.size());
-    auto units = seastar::consume_units(*_config.view_update_concurrency_semaphore, memory_usage_of(updates));
-    try {
-        co_await db::view::mutate_MV(std::move(base_token), std::move(updates), _view_stats, *_config.cf_stats, std::move(tr_state),
-            std::move(units), service::allow_hints::yes, db::view::wait_for_all_updates::no);
-    } catch (...) {
-        // ignore
+
+    while (true) {
+        try {
+            auto updates = co_await builder.build_some();
+            if (updates.empty()) {
+                break;
+            }
+            tracing::trace(tr_state, "Generated {} view update mutations", updates.size());
+            auto units = seastar::consume_units(*_config.view_update_concurrency_semaphore, memory_usage_of(updates));
+            co_await db::view::mutate_MV(base_token, std::move(updates), _view_stats, *_config.cf_stats, tr_state,
+                std::move(units), service::allow_hints::yes, db::view::wait_for_all_updates::no).handle_exception([] (auto ignored) { });
+        } catch (...) {
+            // ignore
+        }
     }
+    co_await builder.close();
 }
 
 /**
@@ -1779,20 +1787,37 @@ future<> table::populate_views(
         dht::token base_token,
         flat_mutation_reader&& reader,
         gc_clock::time_point now) {
-    auto& schema = reader.schema();
-    auto updates = co_await db::view::generate_view_updates(
+    auto schema = reader.schema();
+    db::view::view_update_builder builder = co_await db::view::make_view_update_builder(
             schema,
             std::move(views),
             std::move(reader),
             { },
             now);
-    size_t update_size = memory_usage_of(updates);
-    size_t units_to_wait_for = std::min(_config.view_update_concurrency_semaphore_limit, update_size);
-    auto units = co_await seastar::get_units(*_config.view_update_concurrency_semaphore, units_to_wait_for);
-    auto units_to_consume = update_size - units_to_wait_for;
-    units.adopt(seastar::consume_units(*_config.view_update_concurrency_semaphore, units_to_consume));
-    co_await db::view::mutate_MV(std::move(base_token), std::move(updates), _view_stats, *_config.cf_stats,
-            tracing::trace_state_ptr(), std::move(units), service::allow_hints::no, db::view::wait_for_all_updates::yes);
+
+    std::exception_ptr err;
+    while (true) {
+        try {
+            auto updates = co_await builder.build_some();
+            if (updates.empty()) {
+                break;
+            }
+            size_t update_size = memory_usage_of(updates);
+            size_t units_to_wait_for = std::min(_config.view_update_concurrency_semaphore_limit, update_size);
+            auto units = co_await seastar::get_units(*_config.view_update_concurrency_semaphore, units_to_wait_for);
+            units.adopt(seastar::consume_units(*_config.view_update_concurrency_semaphore, update_size - units_to_wait_for));
+            co_await db::view::mutate_MV(base_token, std::move(updates), _view_stats, *_config.cf_stats,
+                    tracing::trace_state_ptr(), std::move(units), service::allow_hints::no, db::view::wait_for_all_updates::yes);
+        } catch (...) {
+            if (!err) {
+                err = std::current_exception();
+            }
+        }
+    }
+    co_await builder.close();
+    if (err) {
+        std::rethrow_exception(err);
+    }
 }
 
 void table::set_hit_rate(gms::inet_address addr, cache_temperature rate) {

--- a/table.cc
+++ b/table.cc
@@ -1684,7 +1684,10 @@ future<> table::generate_and_propagate_view_updates(const schema_ptr& base,
             co_await db::view::mutate_MV(base_token, std::move(updates), _view_stats, *_config.cf_stats, tr_state,
                 std::move(units), service::allow_hints::yes, db::view::wait_for_all_updates::no).handle_exception([] (auto ignored) { });
         } catch (...) {
-            // ignore
+            // Ignore exceptions: any individual failure to propagate a view update will be reported
+            // by a separate mechanism in mutate_MV() function. Moreover, we should continue trying
+            // to generate updates even if some of them fail, in order to minimize the potential
+            // inconsistencies caused by not being able to propagate an update
         }
     }
     co_await builder.close();

--- a/test/cql-pytest/test_secondary_index.py
+++ b/test/cql-pytest/test_secondary_index.py
@@ -201,3 +201,19 @@ def test_partition_deletion(cql, test_keyspace, scylla_only):
         cql.execute(f"DELETE FROM {table} WHERE p = 1")
         res = [row for row in cql.execute(f"SELECT * FROM {table}_c1_idx_index")]
         assert len(res) == 0
+
+# Test that deleting a clustering range works fine, even if it produces a large batch
+# of individual view updates. Refs #8852 - view updates used to be applied with
+# per-partition granularity, but after fixing the issue it's no longer the case,
+# so a regression test is necessary. Scylla-only - relies on the underlying
+# representation of the index table.
+def test_range_deletion(cql, test_keyspace, scylla_only):
+    schema = 'p int, c1 int, c2 int, v int, primary key (p,c1,c2)'
+    with new_test_table(cql, test_keyspace, schema) as table:
+        cql.execute(f"CREATE INDEX ON {table}(c1)")
+        prep = cql.prepare(f"INSERT INTO {table}(p,c1,c2) VALUES (1, ?, 1)")
+        for i in range(1342):
+            cql.execute(prep, [i])
+        cql.execute(f"DELETE FROM {table} WHERE p = 1 AND c1 > 5 and c1 < 846")
+        res = [row.c1 for row in cql.execute(f"SELECT * FROM {table}_c1_idx_index")]
+        assert sorted(res) == [x for x in range(1342) if x <= 5 or x >= 846]


### PR DESCRIPTION
In order to avoid large allocations and too large mutations
generated from large view updates, granularity of the process
is broken down from per-partition to smaller chunks.
The view update builder now produces partial updates, no more
than 100 view rows at a time.

The series was tested manually with a particular scenario in mind -
deleting a large base partition, which results in creating
a view update per each deleted row - which, with sufficiently
large partitions, can reach millions. Before the series, Scylla
experienced an out-of-memory condition after the view update
generation mechanism tried to load too much data into a contiguous
buffer. Multiple large allocation warnings and reactor stalls were
observed as well. After the series, the operation is still rather slow,
but does not induce reactor stalls nor allocator problems.
A reduced version of the above test is added as a unit test -
it does not check for huge partitions, but instead uses a number
just large enough to cause the update generation process to be split
into multiple chunks.

Fixes #8852