### PR TITLE
storage_proxy: specialize query_singular() for non-IN queries

### DIFF
--- a/service/storage_proxy.hh
+++ b/service/storage_proxy.hh
@@ -320,6 +320,20 @@ private:
             dht::partition_range_vector&& partition_ranges,
             db::consistency_level cl,
             coordinator_query_options optional_params);
+    future<coordinator_query_result> query_singular_nonvector(lw_shared_ptr<query::read_command> cmd,
+            dht::partition_range&& pr,
+            db::consistency_level cl,
+            coordinator_query_options optional_params,
+            schema_ptr&& schema,
+            clock_type::time_point timeout,
+            db::read_repair_decision repair_decision);
+    future<coordinator_query_result> query_singular_vector(lw_shared_ptr<query::read_command> cmd,
+            dht::partition_range_vector&& pr,
+            db::consistency_level cl,
+            coordinator_query_options optional_params,
+            schema_ptr&& schema,
+            clock_type::time_point timeout,
+            db::read_repair_decision repair_decision);
     response_id_type register_response_handler(shared_ptr<abstract_write_response_handler>&& h);
     void remove_response_handler(response_id_type id);
     void remove_response_handler_entry(response_handlers_map::iterator entry);


### PR DESCRIPTION
query_singular() accepts a partition_range_vector, corresponding to an IN
query. But such queries are rare compared to single-partition queries,
and the generarlization is expensive: we need to map_reduce the partitions,
and collect results in a merger and trim them.

Specialize for the common case by having a fast path for non-IN queries.
The code was derived from the general case with everything related
to multiple partitions removed, and two continuations (once separated
by map_reduce) merged.

Some fat still remains, the code contains a few std::vector and
std::unordered_map manipulations, but they are left for later.

perf_simple_query --smp 1 --operations-per-shard 1000000 --task-quota-ms 10:

before: median 208080.16 tps ( 81.1 allocs/op,  15.1 tasks/op,   48871 insns/op)

after:  median 221415.47 tps ( 74.1 allocs/op,  12.1 tasks/op,   46667 insns/op)

So, a ~6% improvement in tps and 5% improvement in instructions per op.
Also large reduction in tasks and allocations.

The change of course increases the maintenance burden, but I believe
it is worth the speedup.