### PR TITLE
Service Level Controller: Stop polling distributed data when decommissioned

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -491,6 +491,7 @@ int main(int ac, char** av) {
     service::load_meter load_meter;
     debug::db = &db;
     auto& proxy = service::get_storage_proxy();
+    auto& ss = service::get_storage_service();
     sharded<service::migration_manager> mm;
     api::http_context ctx(db, proxy, load_meter, token_metadata);
     httpd::http_server_control prometheus_server;
@@ -532,7 +533,7 @@ int main(int ac, char** av) {
         return seastar::async([cfg, ext, &db, &qp, &proxy, &mm, &mm_notifier, &ctx, &opts, &dirs,
                 &prometheus_server, &cf_cache_hitrate_calculator, &load_meter, &feature_service,
                 &token_metadata, &snapshot_ctl, &messaging, &sst_dir_semaphore, &raft_gr, &service_memory_limiter,
-                &repair] {
+                &repair, &ss] {
           try {
             // disable reactor stall detection during startup
             auto blocked_reactor_notify_ms = engine().get_blocked_reactor_notify_ms();
@@ -1116,16 +1117,14 @@ int main(int ac, char** av) {
             }
             view_hints_dir_initializer.ensure_rebalanced().get();
 
-            proxy.invoke_on_all([] (service::storage_proxy& local_proxy) {
-                auto& ss = service::get_local_storage_service();
-                ss.register_subscriber(&local_proxy);
+            proxy.invoke_on_all([&ss] (service::storage_proxy& local_proxy) {
+                ss.local().register_subscriber(&local_proxy);
                 return local_proxy.start_hints_manager(gms::get_local_gossiper().shared_from_this());
             }).get();
 
-            auto drain_proxy = defer_verbose_shutdown("drain storage proxy", [&proxy] {
-                proxy.invoke_on_all([] (service::storage_proxy& local_proxy) mutable {
-                    auto& ss = service::get_local_storage_service();
-                    return ss.unregister_subscriber(&local_proxy).finally([&local_proxy] {
+            auto drain_proxy = defer_verbose_shutdown("drain storage proxy", [&proxy, &ss] {
+                proxy.invoke_on_all([&ss] (service::storage_proxy& local_proxy) mutable {                    
+                    return ss.local().unregister_subscriber(&local_proxy).finally([&local_proxy] {
                         return local_proxy.drain_on_shutdown();
                     });
                 }).get();
@@ -1169,11 +1168,10 @@ int main(int ac, char** av) {
                 cdc.stop().get();
             });
 
-            supervisor::notify("starting storage service", true);
-            auto& ss = service::get_local_storage_service();
-            ss.init_messaging_service_part().get();
+            supervisor::notify("starting storage service", true);            
+            ss.local().init_messaging_service_part().get();
             auto stop_ss_msg = defer_verbose_shutdown("storage service messaging", [&ss] {
-                ss.uninit_messaging_service_part().get();
+                ss.local().uninit_messaging_service_part().get();
             });
             api::set_server_messaging_service(ctx, messaging).get();
             auto stop_messaging_api = defer_verbose_shutdown("messaging service API", [&ctx] {
@@ -1185,9 +1183,9 @@ int main(int ac, char** av) {
                 api::unset_server_repair(ctx).get();
             });
 
-            gossiper.local().register_(ss.shared_from_this());
+            gossiper.local().register_(ss.local().shared_from_this());
             auto stop_listening = defer_verbose_shutdown("storage service notifications", [&gossiper, &ss] {
-                gossiper.local().unregister_(ss.shared_from_this()).get();
+                gossiper.local().unregister_(ss.local().shared_from_this()).get();
             });
 
             /*
@@ -1206,19 +1204,19 @@ int main(int ac, char** av) {
 
             // Register storage_service to migration_notifier so we can update
             // pending ranges when keyspace is chagned
-            mm_notifier.local().register_listener(&ss);
+            mm_notifier.local().register_listener(&ss.local());
             auto stop_mm_listener = defer_verbose_shutdown("storage service notifications", [&mm_notifier, &ss] {
-                mm_notifier.local().unregister_listener(&ss).get();
+                mm_notifier.local().unregister_listener(&ss.local()).get();
             });
 
             with_scheduling_group(maintenance_scheduling_group, [&] {
-                return ss.init_server();
+                return ss.local().init_server();
             }).get();
 
             sst_format_selector.sync();
 
             with_scheduling_group(maintenance_scheduling_group, [&] {
-                return ss.join_cluster();
+                return ss.local().join_cluster();
             }).get();
 
             sl_controller.invoke_on_all([] (qos::service_level_controller& controller) {
@@ -1334,7 +1332,7 @@ int main(int ac, char** av) {
 
             cql_transport::controller cql_server_ctl(auth_service, mm_notifier, gossiper.local(), qp, service_memory_limiter, sl_controller, *cfg);
 
-            ss.register_client_shutdown_hook("native transport", [&cql_server_ctl] {
+            ss.local().register_client_shutdown_hook("native transport", [&cql_server_ctl] {
                 cql_server_ctl.stop().get();
             });
 
@@ -1358,7 +1356,7 @@ int main(int ac, char** av) {
 
             ::thrift_controller thrift_ctl(db, auth_service, qp, service_memory_limiter);
 
-            ss.register_client_shutdown_hook("rpc server", [&thrift_ctl] {
+            ss.local().register_client_shutdown_hook("rpc server", [&thrift_ctl] {
                 thrift_ctl.stop().get();
             });
 
@@ -1386,7 +1384,7 @@ int main(int ac, char** av) {
                     return alternator_ctl.start();
                 }).get();
 
-                ss.register_client_shutdown_hook("alternator", [&alternator_ctl] {
+                ss.local().register_client_shutdown_hook("alternator", [&alternator_ctl] {
                     alternator_ctl.stop().get();
                 });
             }

--- a/service/qos/service_level_controller.cc
+++ b/service/qos/service_level_controller.cc
@@ -410,4 +410,16 @@ future<> service_level_controller::do_remove_service_level(sstring name, bool re
     return make_ready_future();
 }
 
+void service_level_controller::on_join_cluster(const gms::inet_address& endpoint) { }
+
+void service_level_controller::on_leave_cluster(const gms::inet_address& endpoint) {
+    if (this_shard_id() == global_controller && endpoint == utils::fb_utilities::get_broadcast_address()) {
+        _global_controller_db->dist_data_update_aborter.request_abort();
+    }
+}
+
+void service_level_controller::on_up(const gms::inet_address& endpoint) { }
+
+void service_level_controller::on_down(const gms::inet_address& endpoint) { }
+
 }

--- a/service/qos/service_level_controller.hh
+++ b/service/qos/service_level_controller.hh
@@ -32,6 +32,7 @@
 #include <map>
 #include <unordered_set>
 #include "qos_common.hh"
+#include "service/endpoint_lifecycle_subscriber.hh"
 
 namespace db {
     class system_distributed_keyspace;
@@ -56,7 +57,7 @@ struct service_level {
  *      2. Local controllers that act upon the data and facilitates execution in
  *      the service level context
  */
-class service_level_controller : public peering_sharded_service<service_level_controller> {
+class service_level_controller : public peering_sharded_service<service_level_controller>, public service::endpoint_lifecycle_subscriber {
 public:
     class service_level_distributed_data_accessor {
     public:
@@ -222,5 +223,11 @@ private:
 
 public:
     static sstring default_service_level_name;
+
+public:
+    virtual void on_join_cluster(const gms::inet_address& endpoint) override;
+    virtual void on_leave_cluster(const gms::inet_address& endpoint) override;
+    virtual void on_up(const gms::inet_address& endpoint) override;
+    virtual void on_down(const gms::inet_address& endpoint) override;
 };
 }


### PR DESCRIPTION
The polling loop of the service level controller queries a distributed table in order to detect
configuration changes. If a node gets decommissioned, this loop continues to run until shutdown, if a node
stays in the decommissioned mode without being shut down, the loop will fail to query the table and this will
result in warnings and eventually errors in the log. This is not really harmful but it adds unnecessary noise
to the log.
The series below lays the infrastructure for observing storage service state changes, which eventually being
used to break the loop upon preparation for decommissioning.
Tests:
Unit test (dev)
Next Gating Dtests

Fixes #8836