### PR TITLE
install.sh: add supervisor support

### DIFF
--- a/dist/common/supervisor/scylla-jmx.sh
+++ b/dist/common/supervisor/scylla-jmx.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+. $(dirname "$0")/scylla_util.sh
+
+. "$sysconfdir"/scylla-jmx
+
+exec "$scylladir"/jmx/scylla-jmx $SCYLLA_JMX_PORT $SCYLLA_API_PORT $SCYLLA_API_ADDR $SCYLLA_JMX_ADDR $SCYLLA_JMX_FILE $SCYLLA_JMX_LOCAL $SCYLLA_JMX_REMOTE $SCYLLA_JMX_DEBUG

--- a/dist/common/supervisor/scylla-node-exporter.sh
+++ b/dist/common/supervisor/scylla-node-exporter.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+. $(dirname "$0")/scylla_util.sh
+
+. "$sysconfdir"/scylla-node-exporter
+
+exec "$scylladir"/node_exporter/node_exporter $SCYLLA_NODE_EXPORTER_ARGS

--- a/dist/common/supervisor/scylla-server.sh
+++ b/dist/common/supervisor/scylla-server.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+. $(dirname "$0")/scylla_util.sh
+
+. "$sysconfdir"/scylla-server
+
+for f in "$etcdir"/scylla.d/*.conf; do
+    . "$f"
+done
+
+if is_privileged; then
+    "$scriptsdir"/scylla_prepare
+fi
+execsudo /usr/bin/env SCYLLA_HOME=$SCYLLA_HOME SCYLLA_CONF=$SCYLLA_CONF "$bindir"/scylla $SCYLLA_ARGS $SEASTAR_IO $DEV_MODE $CPUSET $SCYLLA_DOCKER_ARGS

--- a/dist/common/supervisor/scylla_util.sh
+++ b/dist/common/supervisor/scylla_util.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+scylladir="$(readlink -f $(dirname "$0")/..)"
+
+is_nonroot() {
+    [ -f "$scylladir"/SCYLLA-NONROOT-FILE ]
+}
+
+is_privileged() {
+    [ ${EUID:-${UID}} = 0 ]
+}
+
+execsudo() {
+    if is_nonroot; then
+        exec "$@"
+    else
+        exec sudo -u scylla -g scylla "$@"
+    fi
+}
+scriptsdir="$scylladir/scripts"
+# scylla_sysconfdir.py is compatible both on python and bash
+. "$scriptsdir"/scylla_sysconfdir.py
+if is_nonroot; then
+    etcdir="$scylladir/etc"
+    bindir="$scylladir/bin"
+    sysconfdir="$scylladir/$SYSCONFDIR"
+else
+    etcdir="/etc"
+    bindir="/usr/bin"
+    sysconfdir="$SYSCONFDIR"
+fi
+

--- a/unified/uninstall.sh
+++ b/unified/uninstall.sh
@@ -73,6 +73,7 @@ rm -fv "$rsystemd"/{scylla-*.service,scylla-*.timer,scylla-*.slice}
 if ! $nonroot; then
     rm -rfv "$retc"/systemd/system/scylla-*.service.d
     rm -fv "$retc"/bash_completion.d/nodetool-completion
+    rm -fv "$retc"/supervisord.d/scylla-*.ini
     rm -fv "$rusr"/lib/sysctl.d/99-scylla-*.conf
     rm -fv "$rusr"/bin/{scylla,iotune,scyllatop}
     rm -fv "$rusr"/sbin/{scylla_*setup,node_exporter_install,node_health_check,scylla_ec2_check,scylla_kernel_check}


### PR DESCRIPTION
Bring supervisor support from dist/docker to install.sh, make it
installable from relocatable package.
This enables to use supervisor with nonroot / offline environment,
and also make relocatable package able to run in Docker environment.

Related #8849