### PR TITLE
Prevent reactor stall in utils::merge_to_gently

### DIFF
--- a/utils/stall_free.hh
+++ b/utils/stall_free.hh
@@ -44,8 +44,9 @@ void merge_to_gently(std::list<T>& list1, const std::list<T>& list2, Compare com
         seastar::thread::maybe_yield();
         if (first1 == last1) {
             // Copy remaining items of list2 into list1
-            std::copy_if(first2, last2, std::back_inserter(list1), [] (const auto&) { return true; });
-            return;
+            list1.insert(last1, *first2);
+            ++first2;
+            continue;
         }
         if (comp(*first2, *first1)) {
             first1 = list1.insert(first1, *first2);

--- a/utils/stall_free.hh
+++ b/utils/stall_free.hh
@@ -49,7 +49,7 @@ void merge_to_gently(std::list<T>& list1, const std::list<T>& list2, Compare com
             continue;
         }
         if (comp(*first2, *first1)) {
-            first1 = list1.insert(first1, *first2);
+            list1.insert(first1, *first2);
             ++first2;
         } else {
             ++first1;


### PR DESCRIPTION
std::copy_if runs without yielding.
    
See https://github.com/scylladb/scylla/issues/8897#issuecomment-867522480
    
Also, eliminate extraneous loop on merge

first1 will point to the inserted value which is a copy of *first2.
Since list2 is sorted in ascending order, the next item from list2
will never be less than the one we've just inserted,
so we waste an iteration to merely increment first1 again.

Fixes #8897

Test: unit(dev), stall_free_test(debug)
DTest: repair_additional_test.py:RepairAdditionalTest.{repair_same_row_diff_value_3nodes_diff_shard_count_test,repair_disjoint_row_3nodes_diff_shard_count_test} (dev)
