### PR TITLE
repair: row_level: clear_gently on close

### DIFF
--- a/frozen_mutation.hh
+++ b/frozen_mutation.hh
@@ -128,6 +128,10 @@ public:
     const bytes_ostream& representation() const { return _bytes; }
 
     mutation_fragment unfreeze(const schema& s, reader_permit permit);
+
+    future<> clear_gently() noexcept {
+        return _bytes.clear_gently();
+    }
 };
 
 frozen_mutation_fragment freeze(const schema& s, const mutation_fragment& mf);

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -731,6 +731,7 @@ private:
     row_level_repair* _row_level_repair_ptr;
     std::vector<repair_node_state> _all_node_states;
     is_dirty_on_master _dirty_on_master = is_dirty_on_master::no;
+    std::optional<shared_promise<>> _stop_promise;
 public:
     std::vector<repair_node_state>& all_nodes() {
         return _all_node_states;
@@ -846,16 +847,33 @@ public:
 
 public:
     future<> stop() {
+        // Handle deferred stop
+        if (_stop_promise) {
+            if (!_stop_promise->available()) {
+                rlogger.debug("repair_meta::stop: wait on previous stop");
+            }
+            return _stop_promise->get_shared_future();
+        }
+        _stop_promise.emplace();
+        auto ret = _stop_promise->get_shared_future();
         auto gate_future = _gate.close();
         auto f1 = _sink_source_for_get_full_row_hashes.close();
         auto f2 = _sink_source_for_get_row_diff.close();
         auto f3 = _sink_source_for_put_row_diff.close();
         rlogger.debug("repair_meta::stop");
-        return when_all_succeed(std::move(gate_future), std::move(f1), std::move(f2), std::move(f3)).discard_result().finally([this] {
+        // move to background.  waited on via _stop_promise->get_future.
+        (void)when_all_succeed(std::move(gate_future), std::move(f1), std::move(f2), std::move(f3)).discard_result().finally([this] {
             return _repair_writer->wait_for_writer_done().finally([this] {
                 return close();
             });
+        }).then_wrapped([this] (future<> f) {
+            if (f.failed()) {
+                _stop_promise->set_exception(f.get_exception());
+            } else {
+                _stop_promise->set_value();
+            }
         });
+        return std::move(ret);
     }
 
     static std::unordered_map<node_repair_meta_id, lw_shared_ptr<repair_meta>>& repair_meta_map();
@@ -2807,9 +2825,9 @@ public:
                     _all_live_peer_nodes,
                     _all_live_peer_nodes.size(),
                     this);
-            auto auto_close_master = defer([&master] {
-                master.close().handle_exception([] (std::exception_ptr ep) {
-                    rlogger.warn("Failed auto-closing Row Level Repair (Master): {}. Ignored.", ep);
+            auto auto_stop_master = defer([&master] {
+                master.stop().handle_exception([] (std::exception_ptr ep) {
+                    rlogger.warn("Failed auto-stopping Row Level Repair (Master): {}. Ignored.", ep);
                 }).get();
             });
 

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -846,6 +846,15 @@ public:
     }
 
 public:
+    future<> clear_gently() noexcept {
+        // FIXME: coroutinize
+        return utils::clear_gently(_peer_row_hash_sets).then([this] {
+            return utils::clear_gently(_working_row_buf);
+        }).then([this] {
+            return utils::clear_gently(_row_buf);
+        });
+    }
+
     future<> stop() {
         // Handle deferred stop
         if (_stop_promise) {
@@ -864,7 +873,9 @@ public:
         // move to background.  waited on via _stop_promise->get_future.
         (void)when_all_succeed(std::move(gate_future), std::move(f1), std::move(f2), std::move(f3)).discard_result().finally([this] {
             return _repair_writer->wait_for_writer_done().finally([this] {
-                return close();
+                return close().then([this] {
+                    return clear_gently();
+                });
             });
         }).then_wrapped([this] (future<> f) {
             if (f.failed()) {

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -400,6 +400,16 @@ public:
     is_dirty_on_master dirty_on_master() const {
         return _dirty_on_master;
     }
+    future<> clear_gently() noexcept {
+        auto f = _fm ? _fm->clear_gently() : make_ready_future<>();
+        return f.finally([this] {
+            _fm.reset();
+            _dk_with_hash = {};
+            _boundary.reset();
+            _hash.reset();
+            _mf = {};
+        });
+    }
 };
 
 class repair_reader {

--- a/test/boost/stall_free_test.cc
+++ b/test/boost/stall_free_test.cc
@@ -21,6 +21,8 @@
 
 #include <seastar/testing/thread_test_case.hh>
 #include "utils/stall_free.hh"
+#include "utils/small_vector.hh"
+#include "utils/chunked_vector.hh"
 
 SEASTAR_THREAD_TEST_CASE(test_merge1) {
     std::list<int> l1{1, 2, 5, 8};
@@ -52,4 +54,396 @@ SEASTAR_THREAD_TEST_CASE(test_merge4) {
     std::list<int> expected{1};
     utils::merge_to_gently(l1, l2, std::less<int>());
     BOOST_CHECK(l1 == expected);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_clear_gently_string) {
+    sstring s0 = "hello";
+    utils::clear_gently(s0).get();
+    BOOST_CHECK(s0.empty());
+
+    std::string s1 = "hello";
+    utils::clear_gently(s1).get();
+    BOOST_CHECK(s1.empty());
+}
+
+SEASTAR_THREAD_TEST_CASE(test_clear_gently_trivial_unique_ptr) {
+    std::unique_ptr<int> p = std::make_unique<int>(0);
+
+    utils::clear_gently(p).get();
+    BOOST_CHECK(p);
+}
+
+template <typename T>
+struct clear_gently_tracker {
+    std::unique_ptr<T> v;
+    std::function<void (T)> on_clear;
+    clear_gently_tracker(T i, std::function<void (T)> f) : v(std::make_unique<T>(std::move(i))), on_clear(std::move(f)) {}
+    clear_gently_tracker(clear_gently_tracker&& x) noexcept : v(std::move(x.v)), on_clear(std::move(x.on_clear)) {}
+    clear_gently_tracker& operator=(clear_gently_tracker&& x) noexcept {
+        if (&x != this) {
+            std::swap(v, x.v);
+            std::swap(on_clear, x.on_clear);
+        }
+        return *this;
+    }
+    future<> clear_gently() noexcept {
+        on_clear(*v);
+        v.reset();
+        return make_ready_future<>();
+    }
+};
+
+SEASTAR_THREAD_TEST_CASE(test_clear_gently_non_trivial_unique_ptr) {
+    int cleared_gently = 0;
+    std::unique_ptr<clear_gently_tracker<int>> p = std::make_unique<clear_gently_tracker<int>>(0, [&cleared_gently] (int) {
+        cleared_gently++;
+    });
+
+    utils::clear_gently(p).get();
+    BOOST_CHECK(p);
+    BOOST_REQUIRE_EQUAL(cleared_gently, 1);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_clear_gently_shared_ptr) {
+    int cleared_gently = 0;
+    lw_shared_ptr<clear_gently_tracker<int>> p0 = make_lw_shared<clear_gently_tracker<int>>(0, [&cleared_gently] (int) {
+        cleared_gently++;
+    });
+
+    utils::clear_gently(p0).get();
+    BOOST_CHECK(p0);
+    BOOST_REQUIRE_EQUAL(cleared_gently, 1);
+
+    lw_shared_ptr<clear_gently_tracker<int>> p1 = p0;
+
+    utils::clear_gently(p0).get();
+    BOOST_CHECK(p0);
+    BOOST_REQUIRE_EQUAL(cleared_gently, 1);
+    utils::clear_gently(p1).get();
+    BOOST_CHECK(p1);
+    BOOST_REQUIRE_EQUAL(cleared_gently, 1);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_clear_gently_trivial_array) {
+    std::array<int, 3> a = {0, 1, 2};
+    std::array<int, 3> ref = a;
+
+    utils::clear_gently(a).get();
+    // a is expected to remain unchanged
+    BOOST_REQUIRE(a == ref);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_clear_gently_non_trivial_array) {
+    constexpr int count = 3;
+    std::array<std::unique_ptr<clear_gently_tracker<int>>, count> a;
+    int cleared_gently = 0;
+
+    for (int i = 0; i < count; i++) {
+        a[i] = std::make_unique<clear_gently_tracker<int>>(i, [&cleared_gently] (int) {
+            cleared_gently++;
+        });
+    }
+
+    utils::clear_gently(a).get();
+    BOOST_REQUIRE_EQUAL(cleared_gently, count);
+    for (int i = 0; i < count; i++) {
+        BOOST_REQUIRE(a[i]);
+    }
+}
+
+SEASTAR_THREAD_TEST_CASE(test_clear_gently_trivial_vector) {
+    constexpr int count = 100;
+    std::vector<int> v;
+
+    v.reserve(count);
+    for (int i = 0; i < count; i++) {
+        v.emplace_back(i);
+    }
+
+    utils::clear_gently(v).get();
+    BOOST_CHECK(v.empty());
+}
+
+SEASTAR_THREAD_TEST_CASE(test_clear_gently_trivial_small_vector) {
+    utils::small_vector<int, 1> v;
+    constexpr int count = 10;
+
+    v.reserve(count);
+    for (int i = 0; i < count; i++) {
+        v.emplace_back(i);
+    }
+
+    utils::clear_gently(v).get();
+    BOOST_CHECK(v.empty());
+}
+
+SEASTAR_THREAD_TEST_CASE(test_clear_gently_vector) {
+    std::vector<int> res;
+    struct X {
+        int v;
+        std::vector<int>& r;
+        X(int i, std::vector<int>& res) : v(i), r(res) {}
+        X(X&& x) noexcept : v(x.v), r(x.r) {}
+        future<> clear_gently() noexcept {
+            r.push_back(v);
+            return make_ready_future<>();
+        }
+    };
+    // Make sure std::vector<X> is not considered as TriviallyClearableSequence
+    // although struct X is trivially destructible - since it also
+    // has a clear_gently method, that must be called.
+    static_assert(std::is_trivially_destructible_v<X>);
+    std::vector<X> v;
+    constexpr int count = 100;
+
+    res.reserve(count);
+    v.reserve(count);
+    for (int i = 0; i < count; i++) {
+        v.emplace_back(X(i, res));
+    }
+
+    utils::clear_gently(v).get();
+    BOOST_CHECK(v.empty());
+
+    // verify that the items were cleared in reverse order
+    for (int i = 0; i < count; i++) {
+        BOOST_REQUIRE_EQUAL(res[i], 99 - i);
+    }
+}
+
+SEASTAR_THREAD_TEST_CASE(test_clear_gently_small_vector) {
+    std::vector<int> res;
+    utils::small_vector<clear_gently_tracker<int>, 1> v;
+    constexpr int count = 100;
+
+    res.reserve(count);
+    v.reserve(count);
+    for (int i = 0; i < count; i++) {
+        v.emplace_back(clear_gently_tracker<int>(i, [&res] (int i) {
+            res.emplace_back(i);
+        }));
+    }
+
+    utils::clear_gently(v).get();
+    BOOST_CHECK(v.empty());
+
+    // verify that the items were cleared in reverse order
+    for (int i = 0; i < count; i++) {
+        BOOST_REQUIRE_EQUAL(res[i], 99 - i);
+    }
+}
+
+SEASTAR_THREAD_TEST_CASE(test_clear_gently_chunked_vector) {
+    std::vector<int> res;
+    utils::chunked_vector<clear_gently_tracker<int>> v;
+    constexpr int count = 100;
+
+    res.reserve(count);
+    v.reserve(count);
+    for (int i = 0; i < count; i++) {
+        v.emplace_back(clear_gently_tracker<int>(i, [&res] (int i) {
+            res.emplace_back(i);
+        }));
+    }
+
+    utils::clear_gently(v).get();
+    BOOST_CHECK(v.empty());
+
+    // verify that the items were cleared in reverse order
+    for (int i = 0; i < count; i++) {
+        BOOST_REQUIRE_EQUAL(res[i], 99 - i);
+    }
+}
+
+SEASTAR_THREAD_TEST_CASE(test_clear_gently_list) {
+    constexpr int count = 100;
+    std::list<clear_gently_tracker<int>> v;
+    int cleared_gently = 0;
+
+    for (int i = 0; i < count; i++) {
+        v.emplace_back(clear_gently_tracker<int>(i, [&cleared_gently] (int) {
+            cleared_gently++;
+        }));
+    }
+
+    utils::clear_gently(v).get();
+    BOOST_CHECK(v.empty());
+    BOOST_REQUIRE_EQUAL(cleared_gently, count);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_clear_gently_deque) {
+    constexpr int count = 100;
+    std::deque<clear_gently_tracker<int>> v;
+    int cleared_gently = 0;
+
+    for (int i = 0; i < count; i++) {
+        v.emplace_back(clear_gently_tracker<int>(i, [&cleared_gently] (int) {
+            cleared_gently++;
+        }));
+    }
+
+    utils::clear_gently(v).get();
+    BOOST_CHECK(v.empty());
+    BOOST_REQUIRE_EQUAL(cleared_gently, count);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_clear_gently_unordered_map) {
+    std::unordered_map<int, sstring> c;
+    constexpr int count = 100;
+
+    for (int i = 0; i < count; i++) {
+        c.insert(std::pair<int, sstring>(i, format("{}", i)));
+    }
+
+    utils::clear_gently(c).get();
+    BOOST_CHECK(c.empty());
+}
+
+SEASTAR_THREAD_TEST_CASE(test_clear_gently_nested_vector) {
+    constexpr int top_count = 10;
+    constexpr int count = 10;
+    std::vector<std::vector<clear_gently_tracker<std::pair<int, int>>>> c;
+    int cleared_gently = 0;
+
+    c.reserve(top_count);
+    for (int i = 0; i < top_count; i++) {
+        std::vector<clear_gently_tracker<std::pair<int, int>>> v;
+        v.reserve(count);
+        for (int j = 0; j < count; j++) {
+            v.emplace_back(clear_gently_tracker<std::pair<int, int>>({i, j}, [&cleared_gently] (std::pair<int, int>) {
+                cleared_gently++;
+            }));
+        }
+        c.emplace_back(std::move(v));
+    }
+
+    utils::clear_gently(c).get();
+    BOOST_CHECK(c.empty());
+    BOOST_REQUIRE_EQUAL(cleared_gently, top_count * count);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_clear_gently_nested_object) {
+    constexpr int count = 100;
+    std::vector<clear_gently_tracker<int>> v;
+    int cleared_gently = 0;
+
+    v.reserve(count);
+    for (int i = 0; i < count; i++) {
+        v.emplace_back(clear_gently_tracker<int>(i, [&cleared_gently] (int) {
+            cleared_gently++;
+        }));
+    }
+
+    utils::clear_gently(v).get();
+    BOOST_CHECK(v.empty());
+    BOOST_REQUIRE_EQUAL(cleared_gently, count);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_clear_gently_map_object) {
+    constexpr int count = 100;
+    std::map<int, clear_gently_tracker<int>> v;
+    int cleared_gently = 0;
+
+    for (int i = 0; i < count; i++) {
+        v.insert(std::pair<int, clear_gently_tracker<int>>(i, clear_gently_tracker<int>(i, [&cleared_gently] (int) {
+            cleared_gently++;
+        })));
+    }
+
+    utils::clear_gently(v).get();
+    BOOST_CHECK(v.empty());
+    BOOST_REQUIRE_EQUAL(cleared_gently, count);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_clear_gently_unordered_map_object) {
+    constexpr int count = 100;
+    std::unordered_map<int, clear_gently_tracker<int>> v;
+    int cleared_gently = 0;
+
+    for (int i = 0; i < count; i++) {
+        v.insert(std::pair<int, clear_gently_tracker<int>>(i, clear_gently_tracker<int>(i, [&cleared_gently] (int) {
+            cleared_gently++;
+        })));
+    }
+
+    utils::clear_gently(v).get();
+    BOOST_CHECK(v.empty());
+    BOOST_REQUIRE_EQUAL(cleared_gently, count);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_clear_gently_nested_unordered_map) {
+    constexpr int top_count = 10;
+    constexpr int count = 10;
+    std::unordered_map<int, std::vector<clear_gently_tracker<std::pair<int, int>>>> c;
+    int cleared_gently = 0;
+
+    for (int i = 0; i < top_count; i++) {
+        std::vector<clear_gently_tracker<std::pair<int, int>>> v;
+        v.reserve(count);
+        for (int j = 0; j < count; j++) {
+            v.emplace_back(clear_gently_tracker<std::pair<int, int>>({i, j}, [&cleared_gently] (std::pair<int, int>) {
+                cleared_gently++;
+            }));
+        }
+        c.insert(std::pair<int, std::vector<clear_gently_tracker<std::pair<int, int>>>>(i, std::move(v)));
+    }
+
+    utils::clear_gently(c).get();
+    BOOST_CHECK(c.empty());
+    BOOST_REQUIRE_EQUAL(cleared_gently, top_count * count);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_clear_gently_nested_container) {
+    constexpr int top_count = 10;
+    constexpr int count = 10;
+    std::list<std::unordered_map<int, clear_gently_tracker<std::pair<int, int>>>> c;
+    int cleared_gently = 0;
+
+    for (int i = 0; i < top_count; i++) {
+        std::unordered_map<int, clear_gently_tracker<std::pair<int, int>>> m;
+        for (int j = 0; j < count; j++) {
+            m.insert(std::pair<int, clear_gently_tracker<std::pair<int, int>>>(j, clear_gently_tracker<std::pair<int, int>>({i, j}, [&cleared_gently] (std::pair<int, int>) {
+                cleared_gently++;
+            })));
+        }
+        c.push_back(std::move(m));
+    }
+
+    utils::clear_gently(c).get();
+    BOOST_CHECK(c.empty());
+    BOOST_REQUIRE_EQUAL(cleared_gently, top_count * count);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_clear_gently_multi_nesting) {
+    struct V {
+        std::vector<clear_gently_tracker<std::tuple<int, int, int>>> v;
+        V(int i, int j, int count, std::function<void (std::tuple<int, int, int>)> f) {
+            v.reserve(count);
+            for (int k = 0; k < count; k++) {
+                v.emplace_back(clear_gently_tracker<std::tuple<int, int, int>>({i, j, k}, f));
+            }
+        }
+        future<> clear_gently() {
+            return utils::clear_gently(v);
+        }
+    };
+    constexpr int top_count = 10;
+    constexpr int mid_count = 10;
+    constexpr int count = 10;
+    std::vector<std::map<int, V>> c;
+    int cleared_gently = 0;
+
+    for (int i = 0; i < top_count; i++) {
+        std::map<int, V> m;
+        for (int j = 0; j < mid_count; j++) {
+            m.insert(std::pair<int, V>(j, V(i, j, count, [&cleared_gently] (std::tuple<int, int, int>) {
+                cleared_gently++;
+            })));
+        }
+        c.push_back(std::move(m));
+    }
+
+    utils::clear_gently(c).get();
+    BOOST_CHECK(c.empty());
+    BOOST_REQUIRE_EQUAL(cleared_gently, top_count * mid_count * count);
 }

--- a/utils/stall_free.hh
+++ b/utils/stall_free.hh
@@ -28,6 +28,8 @@
 #include <seastar/core/future-util.hh>
 #include "utils/collection-concepts.hh"
 
+using namespace seastar;
+
 namespace utils {
 
 
@@ -57,14 +59,178 @@ void merge_to_gently(std::list<T>& list1, const std::list<T>& list2, Compare com
     }
 }
 
-template<class T>
-seastar::future<> clear_gently(std::list<T>& list) {
-    return repeat([&list] () mutable {
-        if (list.empty()) {
-            return seastar::stop_iteration::yes;
-        }
-        list.pop_back();
-        return seastar::stop_iteration::no;
+// The clear_gently functions are meant for
+// gently destroying the contents of containers.
+// The containers can be re-used after clear_gently
+// or may be destroyed.  But unlike e.g. std::vector::clear(),
+// clear_gently will not necessarily keep the object allocation.
+
+template <typename T>
+concept HasClearGentlyMethod = requires (T x) {
+    { x.clear_gently() } -> std::same_as<future<>>;
+};
+
+template <typename T>
+concept SmartPointer = requires (T x) {
+    { *x } -> std::same_as<typename T::element_type&>;
+};
+
+template <typename T>
+concept SharedPointer = SmartPointer<T> && requires (T x) {
+    { x.use_count() } -> std::convertible_to<long>;
+};
+
+template <typename T>
+concept StringLike = requires (T x) {
+    std::is_same_v<typename T::traits_type, std::char_traits<typename T::value_type>>;
+};
+
+template <typename T>
+concept Iterable = requires (T x) {
+    { x.empty() } -> std::same_as<bool>;
+    { x.begin() } -> std::same_as<typename T::iterator>;
+    { x.end() } -> std::same_as<typename T::iterator>;
+};
+
+template <typename T>
+concept Sequence = Iterable<T> && requires (T x, size_t n) {
+    { x.back() } -> std::same_as<typename T::value_type&>;
+    { x.pop_back() } -> std::same_as<void>;
+};
+
+template <typename T>
+concept TriviallyClearableSequence =
+    Sequence<T> && std::is_trivially_destructible_v<typename T::value_type> && !HasClearGentlyMethod<typename T::value_type> && requires (T s) {
+        { s.clear() } -> std::same_as<void>;
+    };
+
+template <typename T>
+concept Container = Iterable<T> && requires (T x, typename T::iterator it) {
+    { x.erase(it) } -> std::same_as<typename T::iterator>;
+};
+
+template <typename T>
+concept MapLike = Container<T> && requires (T x) {
+    std::is_same_v<typename T::value_type, std::pair<const typename T::key_type, typename T::mapped_type>>;
+};
+
+template <HasClearGentlyMethod T>
+future<> clear_gently(T& o) noexcept;
+
+template <SharedPointer T>
+future<> clear_gently(T& o) noexcept;
+
+template <SmartPointer T>
+future<> clear_gently(T& o) noexcept;
+
+template <typename T, std::size_t N>
+future<> clear_gently(std::array<T, N>&a) noexcept;
+
+template <typename T>
+requires (StringLike<T> || TriviallyClearableSequence<T>)
+future<> clear_gently(T& s) noexcept;
+
+template <Sequence T>
+requires (!StringLike<T> && !TriviallyClearableSequence<T>)
+future<> clear_gently(T& v) noexcept;
+
+template <MapLike T>
+future<> clear_gently(T& c) noexcept;
+
+template <Container T>
+requires (!StringLike<T> && !Sequence<T> && !MapLike<T>)
+future<> clear_gently(T& c) noexcept;
+
+namespace internal {
+
+template <typename T>
+concept HasClearGentlyImpl = requires (T x) {
+    { clear_gently(x) } -> std::same_as<future<>>;
+};
+
+template <typename T>
+requires HasClearGentlyImpl<T>
+future<> clear_gently(T& x) noexcept {
+    return utils::clear_gently(x);
+}
+
+// This default implementation of clear_gently
+// is required to "terminate" recursive clear_gently calls
+// at trivial objects
+template <typename T>
+future<> clear_gently(T&) noexcept {
+    return make_ready_future<>();
+}
+
+} // namespace internal
+
+template <HasClearGentlyMethod T>
+future<> clear_gently(T& o) noexcept {
+    return futurize_invoke(std::bind(&T::clear_gently, &o));
+}
+
+template <SharedPointer T>
+future<> clear_gently(T& o) noexcept {
+    if (o.use_count() == 1) {
+        return internal::clear_gently(*o);
+    }
+    return make_ready_future<>();
+}
+
+template <SmartPointer T>
+future<> clear_gently(T& o) noexcept {
+    return internal::clear_gently(*o);
+}
+
+template <typename T, std::size_t N>
+future<> clear_gently(std::array<T, N>& a) noexcept {
+    return do_for_each(a, [] (T& o) {
+        return internal::clear_gently(o);
+    });
+}
+
+// Trivially destructible elements can be safely cleared in bulk
+template <typename T>
+requires (StringLike<T> || TriviallyClearableSequence<T>)
+future<> clear_gently(T& s) noexcept {
+    // Note: clear() is pointless in this case since it keeps the allocation
+    // and since the values are trivially destructible it achieves nothing.
+    // `s = {}` will free the vector/string allocation.
+    s = {};
+    return make_ready_future<>();
+}
+
+// Clear the elements gently and destroy them one-by-one
+// in reverse order, to avoid copying.
+template <Sequence T>
+requires (!StringLike<T> && !TriviallyClearableSequence<T>)
+future<> clear_gently(T& v) noexcept {
+    return do_until([&v] { return v.empty(); }, [&v] {
+        return internal::clear_gently(v.back()).then([&v] {
+            v.pop_back();
+        });
+    });
+    return make_ready_future<>();
+}
+
+template <MapLike T>
+future<> clear_gently(T& c) noexcept {
+    return do_until([&c] { return c.empty(); }, [&c] {
+        auto it = c.begin();
+        return internal::clear_gently(it->second).then([&c, it = std::move(it)] () mutable {
+            c.erase(it);
+        });
+    });
+}
+
+template <Container T>
+requires (!StringLike<T> && !Sequence<T> && !MapLike<T>)
+future<> clear_gently(T& c) noexcept {
+    return do_until([&c] { return c.empty(); }, [&c] {
+        auto it = c.begin();
+        return internal::clear_gently(*it).then([&c, it = std::move(it)] () mutable {
+            c.erase(it);
+        });
     });
 }
 


### PR DESCRIPTION
To prevent a reactor stall as seen in #8926

Fixes #8926

Test: unit(dev)
DTest: repair_additional_test.py:RepairAdditionalTest.repair_same_row_diff_value_3nodes_diff_shard_count_test

Signed-off-by: Benny Halevy <bhalevy@scylladb.com>