### PR TITLE
test/cql-pytest: switch some fixture scopes from "session" to "module"

### DIFF
--- a/test/cql-pytest/test_allow_filtering.py
+++ b/test/cql-pytest/test_allow_filtering.py
@@ -87,7 +87,7 @@ def check_af_mandatory(cql, table_and_everything, where, filt):
         expected_results = list(filter(filt, everything))
         assert results == expected_results
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def table1(cql, test_keyspace):
     table = test_keyspace + "." + unique_name()
     cql.execute("CREATE TABLE " + table +
@@ -180,7 +180,7 @@ def wait_for_index(cql, table, column, everything):
         time.sleep(0.1)
     pytest.fail('Timeout waiting for index to become up to date.')
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def table2(cql, test_keyspace):
     table = test_keyspace + "." + unique_name()
     cql.execute("CREATE TABLE " + table +
@@ -218,7 +218,7 @@ def test_allow_filtering_indexed_a_and_k(cql, table2):
 # table3 is an even more elaborate table with several partition key columns,
 # clustering key columns, and indexed columns of different types, to allow
 # us to check even more esoteric cases.
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def table3(cql, test_keyspace):
     table = test_keyspace + "." + unique_name()
     cql.execute("CREATE TABLE " + table +

--- a/test/cql-pytest/test_frozen_collection.py
+++ b/test/cql-pytest/test_frozen_collection.py
@@ -30,7 +30,7 @@ from util import unique_name, new_test_table
 
 
 # A test table with a (frozen) nested collection as its primary key.
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def table1(cql, test_keyspace):
     table = test_keyspace + "." + unique_name()
     cql.execute(f"CREATE TABLE {table} (k frozen<map<set<int>, int>> PRIMARY KEY)")
@@ -114,7 +114,7 @@ def test_wrong_set_order_in_nested_2(cql, table1):
 # setup described there, it does not happen with just a frozen<set>.
 # With just a frozen<set>, we can insert it or look it up in a wrong
 # order, and everything is fine.
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def table_fsi(cql, test_keyspace):
     table = test_keyspace + "." + unique_name()
     cql.execute(f"CREATE TABLE {table} (k frozen<set<int>> PRIMARY KEY)")

--- a/test/cql-pytest/test_json.py
+++ b/test/cql-pytest/test_json.py
@@ -33,14 +33,14 @@ import random
 import json
 from decimal import Decimal
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def type1(cql, test_keyspace):
     type_name = test_keyspace + "." + unique_name()
     cql.execute("CREATE TYPE " + type_name + " (t text, b boolean)")
     yield type_name
     cql.execute("DROP TYPE " + type_name)
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def table1(cql, test_keyspace, type1):
     table = test_keyspace + "." + unique_name()
     cql.execute(f"CREATE TABLE {table} (p int PRIMARY KEY, v int, a ascii, b boolean, vi varint, mai map<ascii, int>, tup frozen<tuple<text, int>>, l list<text>, d double, t time, dec decimal, tupmap map<frozen<tuple<text, int>>, int>, t1 frozen<{type1}>)")

--- a/test/cql-pytest/test_shedding.py
+++ b/test/cql-pytest/test_shedding.py
@@ -25,7 +25,7 @@ from cassandra.protocol import InvalidRequest
 from util import unique_name, random_string
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def table1(cql, test_keyspace):
     table = test_keyspace + "." + unique_name()
     cql.execute(f"CREATE TABLE {table} (p int primary key, t1 text, t2 text, t3 text, t4 text, t5 text, t6 text)")

--- a/test/cql-pytest/test_type_duration.py
+++ b/test/cql-pytest/test_type_duration.py
@@ -27,7 +27,7 @@ import random
 
 from cassandra.util import Duration
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def table1(cql, test_keyspace):
     table = test_keyspace + "." + unique_name()
     cql.execute(f"CREATE TABLE {table} (p int PRIMARY KEY, d duration)")

--- a/test/cql-pytest/test_type_time.py
+++ b/test/cql-pytest/test_type_time.py
@@ -26,7 +26,7 @@ import random
 
 from cassandra.util import Time
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def table1(cql, test_keyspace):
     table = test_keyspace + "." + unique_name()
     cql.execute(f"CREATE TABLE {table} (p int PRIMARY KEY, t time)")

--- a/test/cql-pytest/test_using_timeout.py
+++ b/test/cql-pytest/test_using_timeout.py
@@ -26,7 +26,7 @@ from cassandra.util import Duration
 def r(regex):
     return re.compile(regex, re.IGNORECASE)
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def table1(cql, test_keyspace):
     table = test_keyspace + "." + unique_name()
     cql.execute("CREATE TABLE " + table +

--- a/test/cql-pytest/test_utf8.py
+++ b/test/cql-pytest/test_utf8.py
@@ -29,7 +29,7 @@ from cassandra.protocol import SyntaxException, AlreadyExists, InvalidRequest, C
 from util import unique_name, random_string
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def table1(cql, test_keyspace):
     table = test_keyspace + "." + unique_name()
     cql.execute(f"CREATE TABLE {table} (k text, c text, primary key (k, c))")

--- a/test/cql-pytest/test_validation.py
+++ b/test/cql-pytest/test_validation.py
@@ -28,7 +28,7 @@ import random
 from cassandra.protocol import SyntaxException, AlreadyExists, InvalidRequest, ConfigurationException, ReadFailure
 from util import unique_name
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def table1(cql, test_keyspace):
     table = test_keyspace + "." + unique_name()
     cql.execute(f"CREATE TABLE {table} (k int primary key, a ascii, t text)")


### PR DESCRIPTION
Fixtures in conftest.py (e.g., the test_keyspace fixture) can be shared by
all tests in all source files, so they are marked with the "session"
scope: All the tests in the testing session may share the same instance.
This is fine.

Some of test files have additional fixtures for creating special tables
needed only in those files. Those were also, unnecessarily, marked
"session" scope as well. This means that these temporary tables are
only deleted at the very end of test suite, event though they can be
deleted at the end of the test file which needed them - other test
source files don't have access to it anyway. This is exactly what the
"module" fixture scope is, so this patch changes all the fixtures that
are private to one test file to use the "module" scope.

After this patch, the teardown of the last test in the suite goes down
from 0.26 seconds to just 0.06 seconds.

Another benefit is that the peak disk usage of the test suite is
lower, because some of the temporary tables are deleted sooner.

This patch does not change any test functionality, and also does not
make any test faster - it just changes the order of the fixture
teardowns.

Signed-off-by: Nadav Har'El <nyh@scylladb.com>