### PR TITLE
compression: define 'class' attribute for compression and deprecate 'sstable_compression'

### DIFF
--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -1109,9 +1109,10 @@ void set_storage_service(http_context& ctx, routes& r) {
                                     e.value = p.second;
                                     nm.attributes.push(std::move(e));
                                 }
-                                if (!cp->options().contains(compression_parameters::SSTABLE_COMPRESSION)) {
+                                if (!cp->options().contains(compression_parameters::CLASS)
+                                        && !cp->options().contains(compression_parameters::SSTABLE_COMPRESSION_DEPRECATED)) {
                                     ss::mapper e;
-                                    e.key = compression_parameters::SSTABLE_COMPRESSION;
+                                    e.key = compression_parameters::CLASS;
                                     e.value = cp->name();
                                     nm.attributes.push(std::move(e));
                                 }

--- a/compress.cc
+++ b/compress.cc
@@ -90,7 +90,8 @@ shared_ptr<compressor> compressor::create(const sstring& name, const opt_getter&
 }
 
 shared_ptr<compressor> compressor::create(const std::map<sstring, sstring>& options) {
-    auto i = options.find(compression_parameters::SSTABLE_COMPRESSION);
+  for (auto&& opt_name : {compression_parameters::CLASS, compression_parameters::SSTABLE_COMPRESSION_DEPRECATED}) {
+    auto i = options.find(opt_name);
     if (i != options.end() && !i->second.empty()) {
         return create(i->second, [&options](const sstring& key) -> opt_string {
             auto i = options.find(key);
@@ -100,6 +101,7 @@ shared_ptr<compressor> compressor::create(const std::map<sstring, sstring>& opti
             return { i->second };
         });
     }
+  }
     return {};
 }
 
@@ -107,7 +109,8 @@ thread_local const shared_ptr<compressor> compressor::lz4 = ::make_shared<lz4_pr
 thread_local const shared_ptr<compressor> compressor::snappy = ::make_shared<snappy_processor>(namespace_prefix + "SnappyCompressor");
 thread_local const shared_ptr<compressor> compressor::deflate = ::make_shared<deflate_processor>(namespace_prefix + "DeflateCompressor");
 
-const sstring compression_parameters::SSTABLE_COMPRESSION = "sstable_compression";
+const sstring compression_parameters::CLASS = "class";
+const sstring compression_parameters::SSTABLE_COMPRESSION_DEPRECATED = "sstable_compression";
 const sstring compression_parameters::CHUNK_LENGTH_KB = "chunk_length_in_kb";
 const sstring compression_parameters::CHUNK_LENGTH_KB_ERR = "chunk_length_kb";
 const sstring compression_parameters::CRC_CHECK_CHANCE = "crc_check_chance";
@@ -125,6 +128,7 @@ compression_parameters::compression_parameters(compressor_ptr c)
 
 compression_parameters::compression_parameters(const std::map<sstring, sstring>& options) {
     _compressor = compressor::create(options);
+    _using_deprecated_sstable_compression_name = options.contains(SSTABLE_COMPRESSION_DEPRECATED) && !options.contains(CLASS);
 
     validate_options(options);
 
@@ -172,7 +176,10 @@ std::map<sstring, sstring> compression_parameters::get_options() const {
     }
     auto opts = _compressor->options();
 
-    opts.emplace(compression_parameters::SSTABLE_COMPRESSION, _compressor->name());
+    auto class_key = _using_deprecated_sstable_compression_name
+            ? compression_parameters::SSTABLE_COMPRESSION_DEPRECATED
+            : compression_parameters::CLASS;
+    opts.emplace(class_key, _compressor->name());
     if (_chunk_length) {
         opts.emplace(sstring(CHUNK_LENGTH_KB), std::to_string(_chunk_length.value() / 1024));
     }
@@ -195,7 +202,8 @@ bool compression_parameters::operator!=(const compression_parameters& other) con
 void compression_parameters::validate_options(const std::map<sstring, sstring>& options) {
     // currently, there are no options specific to a particular compressor
     static std::set<sstring> keywords({
-        sstring(SSTABLE_COMPRESSION),
+        sstring(CLASS),
+        sstring(SSTABLE_COMPRESSION_DEPRECATED),
         sstring(CHUNK_LENGTH_KB),
         sstring(CHUNK_LENGTH_KB_ERR),
         sstring(CRC_CHECK_CHANCE),

--- a/compress.hh
+++ b/compress.hh
@@ -96,12 +96,14 @@ public:
     static constexpr int32_t DEFAULT_CHUNK_LENGTH = 4 * 1024;
     static constexpr double DEFAULT_CRC_CHECK_CHANCE = 1.0;
 
-    static const sstring SSTABLE_COMPRESSION;
+    static const sstring CLASS;
+    static const sstring SSTABLE_COMPRESSION_DEPRECATED;
     static const sstring CHUNK_LENGTH_KB;
     static const sstring CHUNK_LENGTH_KB_ERR;
     static const sstring CRC_CHECK_CHANCE;
 private:
     compressor_ptr _compressor;
+    bool _using_deprecated_sstable_compression_name = false;
     std::optional<int> _chunk_length;
     std::optional<double> _crc_check_chance;
 public:

--- a/cql3/statements/cf_prop_defs.cc
+++ b/cql3/statements/cf_prop_defs.cc
@@ -139,9 +139,10 @@ void cf_prop_defs::validate(const database& db, const schema::extensions_map& sc
 
     auto compression_options = get_compression_options();
     if (compression_options && !compression_options->empty()) {
-        auto sstable_compression_class = compression_options->find(sstring(compression_parameters::SSTABLE_COMPRESSION));
-        if (sstable_compression_class == compression_options->end()) {
-            throw exceptions::configuration_exception(sstring("Missing sub-option '") + compression_parameters::SSTABLE_COMPRESSION + "' for the '" + KW_COMPRESSION + "' option.");
+        auto sstable_compression_class1 = compression_options->find(sstring(compression_parameters::CLASS));
+        auto sstable_compression_class2 = compression_options->find(sstring(compression_parameters::SSTABLE_COMPRESSION_DEPRECATED));
+        if (sstable_compression_class1 == compression_options->end() && sstable_compression_class2 == compression_options->end()) {
+            throw exceptions::configuration_exception(sstring("Missing sub-option '") + compression_parameters::CLASS + "' for the '" + KW_COMPRESSION + "' option.");
         }
         compression_parameters cp(*compression_options);
         cp.validate();

--- a/sstables/compress.cc
+++ b/sstables/compress.cc
@@ -269,7 +269,7 @@ local_compression::local_compression(const compression& c)
             if (key == compression_parameters::CHUNK_LENGTH_KB || key == compression_parameters::CHUNK_LENGTH_KB_ERR) {
                 return to_sstring(c.chunk_len / 1024);
             }
-            if (key == compression_parameters::SSTABLE_COMPRESSION) {
+            if (key == compression_parameters::CLASS || key == compression_parameters::SSTABLE_COMPRESSION_DEPRECATED) {
                 return n;
             }
             for (auto& o : c.options.elements) {
@@ -306,7 +306,7 @@ void compression::set_compressor(compressor_ptr c) {
         const sstring& cn = uqn;
         name.value = bytes(cn.begin(), cn.end());
         for (auto& p : c->options()) {
-            if (p.first != compression_parameters::SSTABLE_COMPRESSION) {
+            if (p.first != compression_parameters::CLASS && p.first != compression_parameters::SSTABLE_COMPRESSION_DEPRECATED) {
                 auto& k = p.first;
                 auto& v = p.second;
                 options.elements.push_back({bytes(k.begin(), k.end()), bytes(v.begin(), v.end())});

--- a/test/boost/cql_query_test.cc
+++ b/test/boost/cql_query_test.cc
@@ -1689,30 +1689,30 @@ SEASTAR_TEST_CASE(test_table_compression) {
         e.require_table_exists("ks", "tb1").get();
         BOOST_REQUIRE(e.local_db().find_schema("ks", "tb1")->get_compressor_params().get_compressor() == nullptr);
 
-        e.execute_cql("create table tb5 (foo text PRIMARY KEY, bar text) with compression = { 'sstable_compression' : '' };").get();
+        e.execute_cql("create table tb5 (foo text PRIMARY KEY, bar text) with compression = { 'class' : '' };").get();
         e.require_table_exists("ks", "tb5").get();
         BOOST_REQUIRE(e.local_db().find_schema("ks", "tb5")->get_compressor_params().get_compressor() == nullptr);
 
         BOOST_REQUIRE_THROW(e.execute_cql(
-                "create table tb2 (foo text PRIMARY KEY, bar text) with compression = { 'sstable_compression' : 'LossyCompressor' };").get(),
+                "create table tb2 (foo text PRIMARY KEY, bar text) with compression = { 'class' : 'LossyCompressor' };").get(),
                 std::exception);
         BOOST_REQUIRE_THROW(e.execute_cql(
-                "create table tb2 (foo text PRIMARY KEY, bar text) with compression = { 'sstable_compression' : 'LZ4Compressor', 'chunk_length_kb' : -1 };").get(),
+                "create table tb2 (foo text PRIMARY KEY, bar text) with compression = { 'class' : 'LZ4Compressor', 'chunk_length_kb' : -1 };").get(),
                 std::exception);
         BOOST_REQUIRE_THROW(e.execute_cql(
-                "create table tb2 (foo text PRIMARY KEY, bar text) with compression = { 'sstable_compression' : 'LZ4Compressor', 'chunk_length_kb' : 3 };").get(),
+                "create table tb2 (foo text PRIMARY KEY, bar text) with compression = { 'class' : 'LZ4Compressor', 'chunk_length_kb' : 3 };").get(),
                 std::exception);
 
-        e.execute_cql("create table tb2 (foo text PRIMARY KEY, bar text) with compression = { 'sstable_compression' : 'LZ4Compressor', 'chunk_length_kb' : 2 };").get();
+        e.execute_cql("create table tb2 (foo text PRIMARY KEY, bar text) with compression = { 'class' : 'LZ4Compressor', 'chunk_length_kb' : 2 };").get();
         e.require_table_exists("ks", "tb2").get();
         BOOST_REQUIRE(e.local_db().find_schema("ks", "tb2")->get_compressor_params().get_compressor() == compressor::lz4);
         BOOST_REQUIRE(e.local_db().find_schema("ks", "tb2")->get_compressor_params().chunk_length() == 2 * 1024);
 
-        e.execute_cql("create table tb3 (foo text PRIMARY KEY, bar text) with compression = { 'sstable_compression' : 'DeflateCompressor' };").get();
+        e.execute_cql("create table tb3 (foo text PRIMARY KEY, bar text) with compression = { 'class' : 'DeflateCompressor' };").get();
         e.require_table_exists("ks", "tb3").get();
         BOOST_REQUIRE(e.local_db().find_schema("ks", "tb3")->get_compressor_params().get_compressor() == compressor::deflate);
 
-        e.execute_cql("create table tb4 (foo text PRIMARY KEY, bar text) with compression = { 'sstable_compression' : 'org.apache.cassandra.io.compress.DeflateCompressor' };").get();
+        e.execute_cql("create table tb4 (foo text PRIMARY KEY, bar text) with compression = { 'class' : 'org.apache.cassandra.io.compress.DeflateCompressor' };").get();
         e.require_table_exists("ks", "tb4").get();
         BOOST_REQUIRE(e.local_db().find_schema("ks", "tb4")->get_compressor_params().get_compressor() == compressor::deflate);
 
@@ -3979,7 +3979,7 @@ SEASTAR_TEST_CASE(test_describe_simple_schema) {
                 "    AND caching = {'keys': 'ALL','rows_per_partition': 'ALL'}\n"
                 "    AND comment = ''\n"
                 "    AND compaction = {'class': 'SizeTieredCompactionStrategy'}\n"
-                "    AND compression = {'sstable_compression': 'org.apache.cassandra.io.compress.LZ4Compressor'}\n"
+                "    AND compression = {'class': 'org.apache.cassandra.io.compress.LZ4Compressor'}\n"
                 "    AND crc_check_chance = 1\n"
                 "    AND dclocal_read_repair_chance = 0.1\n"
                 "    AND default_time_to_live = 0\n"
@@ -4000,7 +4000,7 @@ SEASTAR_TEST_CASE(test_describe_simple_schema) {
                 "    AND caching = {'keys': 'ALL','rows_per_partition': 'ALL'}\n"
                 "    AND comment = ''\n"
                 "    AND compaction = {'class': 'SizeTieredCompactionStrategy'}\n"
-                "    AND compression = {'sstable_compression': 'org.apache.cassandra.io.compress.LZ4Compressor'}\n"
+                "    AND compression = {'class': 'org.apache.cassandra.io.compress.LZ4Compressor'}\n"
                 "    AND crc_check_chance = 1\n"
                 "    AND dclocal_read_repair_chance = 0.1\n"
                 "    AND default_time_to_live = 0\n"
@@ -4022,7 +4022,7 @@ SEASTAR_TEST_CASE(test_describe_simple_schema) {
                 "    AND caching = {'keys': 'ALL','rows_per_partition': 'ALL'}\n"
                 "    AND comment = ''\n"
                 "    AND compaction = {'class': 'SizeTieredCompactionStrategy'}\n"
-                "    AND compression = {'sstable_compression': 'org.apache.cassandra.io.compress.LZ4Compressor'}\n"
+                "    AND compression = {'class': 'org.apache.cassandra.io.compress.LZ4Compressor'}\n"
                 "    AND crc_check_chance = 1\n"
                 "    AND dclocal_read_repair_chance = 0.2\n"
                 "    AND default_time_to_live = 0\n"
@@ -4045,7 +4045,7 @@ SEASTAR_TEST_CASE(test_describe_simple_schema) {
                 "    AND caching = {'keys': 'ALL','rows_per_partition': 'ALL'}\n"
                 "    AND comment = ''\n"
                 "    AND compaction = {'class': 'SizeTieredCompactionStrategy'}\n"
-                "    AND compression = {'sstable_compression': 'org.apache.cassandra.io.compress.LZ4Compressor'}\n"
+                "    AND compression = {'class': 'org.apache.cassandra.io.compress.LZ4Compressor'}\n"
                 "    AND crc_check_chance = 1\n"
                 "    AND dclocal_read_repair_chance = 0.2\n"
                 "    AND default_time_to_live = 0\n"
@@ -4067,7 +4067,7 @@ SEASTAR_TEST_CASE(test_describe_simple_schema) {
                 "    AND caching = {'keys': 'ALL','rows_per_partition': 'ALL'}\n"
                 "    AND comment = ''\n"
                 "    AND compaction = {'class': 'SizeTieredCompactionStrategy'}\n"
-                "    AND compression = {'sstable_compression': 'org.apache.cassandra.io.compress.LZ4Compressor'}\n"
+                "    AND compression = {'class': 'org.apache.cassandra.io.compress.LZ4Compressor'}\n"
                 "    AND crc_check_chance = 1\n"
                 "    AND dclocal_read_repair_chance = 0.2\n"
                 "    AND default_time_to_live = 0\n"
@@ -4110,7 +4110,7 @@ SEASTAR_TEST_CASE(test_describe_view_schema) {
                 "    AND caching = {'keys': 'ALL','rows_per_partition': 'ALL'}\n"
                 "    AND comment = ''\n"
                 "    AND compaction = {'class': 'SizeTieredCompactionStrategy'}\n"
-                "    AND compression = {'sstable_compression': 'org.apache.cassandra.io.compress.LZ4Compressor'}\n"
+                "    AND compression = {'class': 'org.apache.cassandra.io.compress.LZ4Compressor'}\n"
                 "    AND crc_check_chance = 1\n"
                 "    AND dclocal_read_repair_chance = 0.1\n"
                 "    AND default_time_to_live = 0\n"
@@ -4132,7 +4132,7 @@ SEASTAR_TEST_CASE(test_describe_view_schema) {
               "    AND caching = {'keys': 'ALL','rows_per_partition': 'ALL'}\n"
               "    AND comment = ''\n"
               "    AND compaction = {'class': 'SizeTieredCompactionStrategy'}\n"
-              "    AND compression = {'sstable_compression': 'org.apache.cassandra.io.compress.LZ4Compressor'}\n"
+              "    AND compression = {'class': 'org.apache.cassandra.io.compress.LZ4Compressor'}\n"
               "    AND crc_check_chance = 1\n"
               "    AND dclocal_read_repair_chance = 0.1\n"
               "    AND default_time_to_live = 0\n"

--- a/test/boost/sstable_3_x_test.cc
+++ b/test/boost/sstable_3_x_test.cc
@@ -370,7 +370,7 @@ SEASTAR_THREAD_TEST_CASE(test_uncompressed_filtering_and_forwarding_read) {
             rc text,
             PRIMARY KEY (pk, ck)
         )
-        WITH compression = { 'sstable_compression' : '' }
+        WITH compression = { 'class' : '' }
         AND caching = {'keys': 'NONE', 'rows_per_partition': 'NONE'}
         """)
 
@@ -635,7 +635,7 @@ SEASTAR_THREAD_TEST_CASE(test_uncompressed_skip_using_index_rows) {
             rc int,
             PRIMARY KEY (pk, ck1, ck2)
         )
-        WITH compression = { 'sstable_compression' : '' }
+        WITH compression = { 'class' : '' }
         AND caching = {'keys': 'NONE', 'rows_per_partition': 'NONE'}
         """)
 
@@ -971,7 +971,7 @@ SEASTAR_THREAD_TEST_CASE(test_uncompressed_filtering_and_forwarding_range_tombst
             rc int,
             PRIMARY KEY (pk, ck1, ck2)
         )
-        WITH compression = { 'sstable_compression' : '' }
+        WITH compression = { 'class' : '' }
         AND caching = {'keys': 'NONE', 'rows_per_partition': 'NONE'}
         """)
 
@@ -1652,10 +1652,10 @@ SEASTAR_THREAD_TEST_CASE(test_uncompressed_counters_read) {
 //
 //  where <compression> is one of the following:
 //  {'enabled': false} for the uncompressed case,
-//  {'sstable_compression': 'org.apache.cassandra.io.compress.LZ4Compressor'} for the LZ4 case,
-//  {'sstable_compression': 'org.apache.cassandra.io.compress.SnappyCompressor'} for the Snappy case,
-//  {'sstable_compression': 'org.apache.cassandra.io.compress.DeflateCompressor'} for the Deflate case,
-//  {'sstable_compression': 'org.apache.cassandra.io.compress.ZstdCompressor', 'compression_level': 1} for the Zstd case.
+//  {'class': 'org.apache.cassandra.io.compress.LZ4Compressor'} for the LZ4 case,
+//  {'class': 'org.apache.cassandra.io.compress.SnappyCompressor'} for the Snappy case,
+//  {'class': 'org.apache.cassandra.io.compress.DeflateCompressor'} for the Deflate case,
+//  {'class': 'org.apache.cassandra.io.compress.ZstdCompressor', 'compression_level': 1} for the Zstd case.
 //
 // INSERT INTO test_ks.test_table(pk, bool_val, double_val, float_val, int_val, long_val, timestamp_val, timeuuid_val,
 //                                uuid_val, text_val)
@@ -1827,7 +1827,7 @@ SEASTAR_THREAD_TEST_CASE(test_deflate_partition_key_with_values_of_different_typ
 SEASTAR_THREAD_TEST_CASE(test_zstd_partition_key_with_values_of_different_types_read) {
     test_partition_key_with_values_of_different_types_read(
         ZSTD_PARTITION_KEY_WITH_VALUES_OF_DIFFERENT_TYPES_PATH, compressor::create({
-            {"sstable_compression", "org.apache.cassandra.io.compress.ZstdCompressor"},
+            {"class", "org.apache.cassandra.io.compress.ZstdCompressor"},
             {"compression_level", "1"}}));
 }
 
@@ -1838,7 +1838,7 @@ SEASTAR_THREAD_TEST_CASE(test_zstd_partition_key_with_values_of_different_types_
 // CREATE KEYSPACE test_ks WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1};
 //
 // CREATE TABLE test_ks.test_table (val1 INT, val2 INT, PRIMARY KEY (val1, val2))
-//      WITH compression = {'sstable_compression': 'org.apache.cassandra.io.compress.ZstdCompressor',
+//      WITH compression = {'class': 'org.apache.cassandra.io.compress.ZstdCompressor',
 //                          'compression_level': 5,
 //                          'chunk_length_in_kb': 4};
 //
@@ -1853,7 +1853,7 @@ static schema_ptr make_zstd_multiple_chunks_schema() {
         .with_column("val1", int32_type, column_kind::partition_key)
         .with_column("val2", int32_type, column_kind::clustering_key)
         .set_compressor_params(compression_parameters{compressor::create({
-            {"sstable_compression", "org.apache.cassandra.io.compress.ZstdCompressor"},
+            {"class", "org.apache.cassandra.io.compress.ZstdCompressor"},
             {"compression_level", "5"},
             {"chunk_length_in_kb", "4"}})})
         .build();
@@ -3137,7 +3137,7 @@ SEASTAR_THREAD_TEST_CASE(compact_deleted_row) {
   test_env::do_with_async([] (test_env& env) {
     BOOST_REQUIRE(smp::count == 1);
     sstring table_name = "compact_deleted_row";
-    // CREATE TABLE test_deleted_row (pk text, ck text, rc1 text, rc2 text, PRIMARY KEY (pk, ck)) WITH compression = {'sstable_compression': ''};
+    // CREATE TABLE test_deleted_row (pk text, ck text, rc1 text, rc2 text, PRIMARY KEY (pk, ck)) WITH compression = {'class': ''};
     schema_builder builder("sst3", table_name);
     builder.with_column("pk", utf8_type, column_kind::partition_key);
     builder.with_column("ck", utf8_type, column_kind::clustering_key);
@@ -3208,7 +3208,7 @@ SEASTAR_THREAD_TEST_CASE(compact_deleted_cell) {
   test_env::do_with_async([] (test_env& env) {
     BOOST_REQUIRE(smp::count == 1);
     sstring table_name = "compact_deleted_cell";
-    //  CREATE TABLE compact_deleted_cell (pk text, ck text, rc text, PRIMARY KEY (pk, ck)) WITH compression = {'sstable_compression': ''};
+    //  CREATE TABLE compact_deleted_cell (pk text, ck text, rc text, PRIMARY KEY (pk, ck)) WITH compression = {'class': ''};
     schema_builder builder("sst3", table_name);
     builder.with_column("pk", utf8_type, column_kind::partition_key);
     builder.with_column("ck", utf8_type, column_kind::clustering_key);
@@ -3497,7 +3497,7 @@ static void write_mut_and_validate(test_env& env, schema_ptr s, const sstring& t
 SEASTAR_THREAD_TEST_CASE(test_write_static_row) {
   test_env::do_with_async([] (test_env& env) {
     sstring table_name = "static_row";
-    // CREATE TABLE static_row (pk text, ck int, st1 int static, st2 text static, PRIMARY KEY (pk, ck)) WITH compression = {'sstable_compression': ''};
+    // CREATE TABLE static_row (pk text, ck int, st1 int static, st2 text static, PRIMARY KEY (pk, ck)) WITH compression = {'class': ''};
     schema_builder builder("sst3", table_name);
     builder.with_column("pk", utf8_type, column_kind::partition_key);
     builder.with_column("ck", int32_type, column_kind::clustering_key);
@@ -3519,7 +3519,7 @@ SEASTAR_THREAD_TEST_CASE(test_write_static_row) {
 SEASTAR_THREAD_TEST_CASE(test_write_composite_partition_key) {
   test_env::do_with_async([] (test_env& env) {
     sstring table_name = "composite_partition_key";
-    // CREATE TABLE composite_partition_key (a int , b text, c boolean, d int, e text, f int, g text, PRIMARY KEY ((a, b, c), d, e)) WITH compression = {'sstable_compression': ''};
+    // CREATE TABLE composite_partition_key (a int , b text, c boolean, d int, e text, f int, g text, PRIMARY KEY ((a, b, c), d, e)) WITH compression = {'class': ''};
     schema_builder builder("sst3", table_name);
     builder.with_column("a", int32_type, column_kind::partition_key);
     builder.with_column("b", utf8_type, column_kind::partition_key);
@@ -3546,7 +3546,7 @@ SEASTAR_THREAD_TEST_CASE(test_write_composite_partition_key) {
 SEASTAR_THREAD_TEST_CASE(test_write_composite_clustering_key) {
   test_env::do_with_async([] (test_env& env) {
     sstring table_name = "composite_clustering_key";
-    // CREATE TABLE composite_clustering_key (a int , b text, c int, d text, e int, f text, PRIMARY KEY (a, b, c, d)) WITH compression = {'sstable_compression': ''};
+    // CREATE TABLE composite_clustering_key (a int , b text, c int, d text, e int, f text, PRIMARY KEY (a, b, c, d)) WITH compression = {'class': ''};
     schema_builder builder("sst3", table_name);
     builder.with_column("a", int32_type, column_kind::partition_key);
     builder.with_column("b", utf8_type, column_kind::clustering_key);
@@ -3572,7 +3572,7 @@ SEASTAR_THREAD_TEST_CASE(test_write_composite_clustering_key) {
 SEASTAR_THREAD_TEST_CASE(test_write_wide_partitions) {
   test_env::do_with_async([] (test_env& env) {
     sstring table_name = "wide_partitions";
-    // CREATE TABLE wide_partitions (pk text, ck text, st text, rc text, PRIMARY KEY (pk, ck) WITH compression = {'sstable_compression': ''};
+    // CREATE TABLE wide_partitions (pk text, ck text, st text, rc text, PRIMARY KEY (pk, ck) WITH compression = {'class': ''};
     schema_builder builder("sst3", table_name);
     builder.with_column("pk", utf8_type, column_kind::partition_key);
     builder.with_column("ck", utf8_type, column_kind::clustering_key);
@@ -3615,7 +3615,7 @@ SEASTAR_THREAD_TEST_CASE(test_write_wide_partitions) {
 SEASTAR_THREAD_TEST_CASE(test_write_ttled_row) {
   test_env::do_with_async([] (test_env& env) {
     sstring table_name = "ttled_row";
-    // CREATE TABLE ttled_row (pk int, ck int, rc int, PRIMARY KEY (pk, ck)) WITH compression = {'sstable_compression': ''};
+    // CREATE TABLE ttled_row (pk int, ck int, rc int, PRIMARY KEY (pk, ck)) WITH compression = {'class': ''};
     schema_builder builder("sst3", table_name);
     builder.with_column("pk", int32_type, column_kind::partition_key);
     builder.with_column("ck", int32_type, column_kind::clustering_key);
@@ -3646,7 +3646,7 @@ SEASTAR_THREAD_TEST_CASE(test_write_ttled_row) {
 SEASTAR_THREAD_TEST_CASE(test_write_ttled_column) {
   test_env::do_with_async([] (test_env& env) {
     sstring table_name = "ttled_column";
-    // CREATE TABLE ttled_column (pk text, rc int, PRIMARY KEY (pk)) WITH compression = {'sstable_compression': ''};
+    // CREATE TABLE ttled_column (pk text, rc int, PRIMARY KEY (pk)) WITH compression = {'class': ''};
     schema_builder builder("sst3", table_name);
     builder.with_column("pk", utf8_type, column_kind::partition_key);
     builder.with_column("rc", int32_type);
@@ -3674,7 +3674,7 @@ SEASTAR_THREAD_TEST_CASE(test_write_ttled_column) {
 SEASTAR_THREAD_TEST_CASE(test_write_deleted_column) {
   test_env::do_with_async([] (test_env& env) {
     sstring table_name = "deleted_column";
-    // CREATE TABLE deleted_column (pk int, rc int, PRIMARY KEY (pk)) WITH compression = {'sstable_compression': ''};
+    // CREATE TABLE deleted_column (pk int, rc int, PRIMARY KEY (pk)) WITH compression = {'class': ''};
     schema_builder builder("sst3", table_name);
     builder.with_column("pk", int32_type, column_kind::partition_key);
     builder.with_column("rc", int32_type);
@@ -3698,7 +3698,7 @@ SEASTAR_THREAD_TEST_CASE(test_write_deleted_column) {
 SEASTAR_THREAD_TEST_CASE(test_write_deleted_row) {
   test_env::do_with_async([] (test_env& env) {
     sstring table_name = "deleted_row";
-    // CREATE TABLE deleted_row (pk int, ck int, PRIMARY KEY (pk, ck)) WITH compression = {'sstable_compression': ''};
+    // CREATE TABLE deleted_row (pk int, ck int, PRIMARY KEY (pk, ck)) WITH compression = {'class': ''};
     schema_builder builder("sst3", table_name);
     builder.with_column("pk", int32_type, column_kind::partition_key);
     builder.with_column("ck", int32_type, column_kind::clustering_key);
@@ -3720,7 +3720,7 @@ SEASTAR_THREAD_TEST_CASE(test_write_collection_wide_update) {
   test_env::do_with_async([] (test_env& env) {
     sstring table_name = "collection_wide_update";
     auto set_of_ints_type = set_type_impl::get_instance(int32_type, true);
-    // CREATE TABLE collection_wide_update (pk int, col set<int>, PRIMARY KEY (pk)) with compression = {'sstable_compression': ''};
+    // CREATE TABLE collection_wide_update (pk int, col set<int>, PRIMARY KEY (pk)) with compression = {'class': ''};
     schema_builder builder("sst3", table_name);
     builder.with_column("pk", int32_type, column_kind::partition_key);
     builder.with_column("col", set_of_ints_type);
@@ -3748,7 +3748,7 @@ SEASTAR_THREAD_TEST_CASE(test_write_collection_incremental_update) {
   test_env::do_with_async([] (test_env& env) {
     sstring table_name = "collection_incremental_update";
     auto set_of_ints_type = set_type_impl::get_instance(int32_type, true);
-    // CREATE TABLE collection_incremental_update (pk int, col set<int>, PRIMARY KEY (pk)) with compression = {'sstable_compression': ''};
+    // CREATE TABLE collection_incremental_update (pk int, col set<int>, PRIMARY KEY (pk)) with compression = {'class': ''};
     schema_builder builder("sst3", table_name);
     builder.with_column("pk", int32_type, column_kind::partition_key);
     builder.with_column("col", set_of_ints_type);
@@ -3771,7 +3771,7 @@ SEASTAR_THREAD_TEST_CASE(test_write_collection_incremental_update) {
 SEASTAR_THREAD_TEST_CASE(test_write_multiple_partitions) {
   test_env::do_with_async([] (test_env& env) {
     sstring table_name = "multiple_partitions";
-    // CREATE TABLE multiple_partitions (pk int, rc1 int, rc2 int, rc3 int, PRIMARY KEY (pk)) WITH compression = {'sstable_compression': ''};
+    // CREATE TABLE multiple_partitions (pk int, rc1 int, rc2 int, rc3 int, PRIMARY KEY (pk)) WITH compression = {'class': ''};
     schema_builder builder("sst3", table_name);
     builder.with_column("pk", int32_type, column_kind::partition_key);
     builder.with_column("rc1", int32_type);
@@ -3801,7 +3801,7 @@ SEASTAR_THREAD_TEST_CASE(test_write_multiple_partitions) {
 
 static void test_write_many_partitions(sstring table_name, tombstone partition_tomb, compression_parameters cp) {
   test_env::do_with_async([table_name, partition_tomb, cp] (test_env& env) {
-    // CREATE TABLE <table_name> (pk int, PRIMARY KEY (pk)) WITH compression = {'sstable_compression': ''};
+    // CREATE TABLE <table_name> (pk int, PRIMARY KEY (pk)) WITH compression = {'class': ''};
     schema_builder builder("sst3", table_name);
     builder.with_column("pk", int32_type, column_kind::partition_key);
     builder.set_compressor_params(cp);
@@ -3870,14 +3870,14 @@ SEASTAR_THREAD_TEST_CASE(test_write_many_partitions_zstd) {
             "many_partitions_zstd",
             tombstone{},
             compression_parameters{compressor::create({
-                {"sstable_compression", "org.apache.cassandra.io.compress.ZstdCompressor"}
+                {"class", "org.apache.cassandra.io.compress.ZstdCompressor"}
             })});
 }
 
 SEASTAR_THREAD_TEST_CASE(test_write_multiple_rows) {
   test_env::do_with_async([] (test_env& env) {
     sstring table_name = "multiple_rows";
-    // CREATE TABLE multiple_rows (pk int, ck int, rc1 int, rc2 int, rc3 int, PRIMARY KEY (pk, ck)) WITH compression = {'sstable_compression': ''};
+    // CREATE TABLE multiple_rows (pk int, ck int, rc1 int, rc2 int, rc3 int, PRIMARY KEY (pk, ck)) WITH compression = {'class': ''};
     schema_builder builder("sst3", table_name);
     builder.with_column("pk", int32_type, column_kind::partition_key);
     builder.with_column("ck", int32_type, column_kind::clustering_key);
@@ -3910,7 +3910,7 @@ SEASTAR_THREAD_TEST_CASE(test_write_multiple_rows) {
 SEASTAR_THREAD_TEST_CASE(test_write_missing_columns_large_set) {
   test_env::do_with_async([] (test_env& env) {
     sstring table_name = "missing_columns_large_set";
-    // CREATE TABLE missing_columns_large_set (pk int, ck int, rc1 int, ..., rc64 int, PRIMARY KEY (pk, ck)) WITH compression = {'sstable_compression': ''};
+    // CREATE TABLE missing_columns_large_set (pk int, ck int, rc1 int, ..., rc64 int, PRIMARY KEY (pk, ck)) WITH compression = {'class': ''};
     schema_builder builder("sst3", table_name);
     builder.with_column("pk", int32_type, column_kind::partition_key);
     builder.with_column("ck", int32_type, column_kind::clustering_key);
@@ -3951,7 +3951,7 @@ SEASTAR_THREAD_TEST_CASE(test_write_missing_columns_large_set) {
 SEASTAR_THREAD_TEST_CASE(test_write_empty_counter) {
   test_env::do_with_async([] (test_env& env) {
     sstring table_name = "empty_counter";
-    // CREATE TABLE empty_counter (pk text, ck text, val counter, PRIMARY KEY (pk, ck)) WITH compression = {'sstable_compression': ''};
+    // CREATE TABLE empty_counter (pk text, ck text, val counter, PRIMARY KEY (pk, ck)) WITH compression = {'class': ''};
     schema_builder builder("sst3", table_name);
     builder.with_column("pk", utf8_type, column_kind::partition_key);
     builder.with_column("ck", utf8_type, column_kind::clustering_key);
@@ -3975,7 +3975,7 @@ SEASTAR_THREAD_TEST_CASE(test_write_empty_counter) {
 SEASTAR_THREAD_TEST_CASE(test_write_counter_table) {
   test_env::do_with_async([] (test_env& env) {
     sstring table_name = "counter_table";
-    // CREATE TABLE counter_table (pk text, ck text, rc1 counter, rc2 counter, PRIMARY KEY (pk, ck)) WITH compression = {'sstable_compression': ''};
+    // CREATE TABLE counter_table (pk text, ck text, rc1 counter, rc2 counter, PRIMARY KEY (pk, ck)) WITH compression = {'class': ''};
     schema_builder builder("sst3", table_name);
     builder.with_column("pk", utf8_type, column_kind::partition_key);
     builder.with_column("ck", utf8_type, column_kind::clustering_key);
@@ -4026,7 +4026,7 @@ SEASTAR_THREAD_TEST_CASE(test_write_different_types) {
     // doubleval double, floatval float, inetval inet, intval int,
     // smallintval smallint, timeval time, tsval timestamp, timeuuidval timeuuid,
     // tinyintval tinyint,  uuidval uuid, varcharval varchar, varintval varint,
-    // durationval duration, PRIMARY KEY (pk)) WITH compression = {'sstable_compression': ''};
+    // durationval duration, PRIMARY KEY (pk)) WITH compression = {'class': ''};
     schema_builder builder("sst3", table_name);
     builder.with_column("pk", utf8_type, column_kind::partition_key);
     builder.with_column("asciival", ascii_type);
@@ -4090,7 +4090,7 @@ SEASTAR_THREAD_TEST_CASE(test_write_different_types) {
 SEASTAR_THREAD_TEST_CASE(test_write_empty_clustering_values) {
   test_env::do_with_async([] (test_env& env) {
     sstring table_name = "empty_clustering_values";
-    // CREATE TABLE empty_clustering_values (pk int, ck1 text, ck2 int, ck3 text, rc int, PRIMARY KEY (pk, ck1, ck2, ck3)) WITH compression = {'sstable_compression': ''};
+    // CREATE TABLE empty_clustering_values (pk int, ck1 text, ck2 int, ck3 text, rc int, PRIMARY KEY (pk, ck1, ck2, ck3)) WITH compression = {'class': ''};
     schema_builder builder("sst3", table_name);
     builder.with_column("pk", int32_type, column_kind::partition_key);
     builder.with_column("ck1", utf8_type, column_kind::clustering_key);
@@ -4115,7 +4115,7 @@ SEASTAR_THREAD_TEST_CASE(test_write_empty_clustering_values) {
 SEASTAR_THREAD_TEST_CASE(test_write_large_clustering_key) {
   test_env::do_with_async([] (test_env& env) {
     sstring table_name = "large_clustering_key";
-    // CREATE TABLE large_clustering_key (pk int, ck1 text, ck2 text, ..., ck35 text, rc int, PRIMARY KEY (pk, ck1, ck2, ..., ck35)) WITH compression = {'sstable_compression': ''};
+    // CREATE TABLE large_clustering_key (pk int, ck1 text, ck2 text, ..., ck35 text, rc int, PRIMARY KEY (pk, ck1, ck2, ..., ck35)) WITH compression = {'class': ''};
     schema_builder builder("sst3", table_name);
     builder.with_column("pk", int32_type, column_kind::partition_key);
     for (auto idx: boost::irange(1, 36)) {
@@ -4147,7 +4147,7 @@ SEASTAR_THREAD_TEST_CASE(test_write_large_clustering_key) {
 SEASTAR_THREAD_TEST_CASE(test_write_compact_table) {
   test_env::do_with_async([] (test_env& env) {
     sstring table_name = "compact_table";
-    // CREATE TABLE compact_table (pk int, ck1 int, ck2 int, rc int, PRIMARY KEY (pk, ck1, ck2)) WITH compression = {'sstable_compression': ''} AND COMPACT STORAGE;
+    // CREATE TABLE compact_table (pk int, ck1 int, ck2 int, rc int, PRIMARY KEY (pk, ck1, ck2)) WITH compression = {'class': ''} AND COMPACT STORAGE;
     schema_builder builder("sst3", table_name);
     builder.with_column("pk", int32_type, column_kind::partition_key);
     builder.with_column("ck1", int32_type, column_kind::clustering_key);
@@ -4175,7 +4175,7 @@ SEASTAR_THREAD_TEST_CASE(test_write_user_defined_type_table) {
             {int32_type, boolean_type, utf8_type}, false);
 
     sstring table_name = "user_defined_type_table";
-    // CREATE TABLE user_defined_type_table (pk int, rc frozen <ut>, PRIMARY KEY (pk)) WITH compression = {'sstable_compression': ''};
+    // CREATE TABLE user_defined_type_table (pk int, rc frozen <ut>, PRIMARY KEY (pk)) WITH compression = {'class': ''};
     schema_builder builder("sst3", table_name);
     builder.with_column("pk", int32_type, column_kind::partition_key);
     builder.with_column("rc", ut);
@@ -4198,7 +4198,7 @@ SEASTAR_THREAD_TEST_CASE(test_write_user_defined_type_table) {
 SEASTAR_THREAD_TEST_CASE(test_write_simple_range_tombstone) {
   test_env::do_with_async([] (test_env& env) {
     sstring table_name = "simple_range_tombstone";
-    // CREATE TABLE simple_range_tombstone (pk int, ck1 text, ck2 text, rc text, PRIMARY KEY (pk, ck1, ck2)) WITH compression = {'sstable_compression': ''};
+    // CREATE TABLE simple_range_tombstone (pk int, ck1 text, ck2 text, rc text, PRIMARY KEY (pk, ck1, ck2)) WITH compression = {'class': ''};
     schema_builder builder("sst3", table_name);
     builder.with_column("pk", int32_type, column_kind::partition_key);
     builder.with_column("ck1", utf8_type, column_kind::clustering_key);
@@ -4223,7 +4223,7 @@ SEASTAR_THREAD_TEST_CASE(test_write_simple_range_tombstone) {
 SEASTAR_THREAD_TEST_CASE(test_write_adjacent_range_tombstones) {
   test_env::do_with_async([] (test_env& env) {
     sstring table_name = "adjacent_range_tombstones";
-    // CREATE TABLE adjacent_range_tombstones (pk text, ck1 text, ck2 text, ck3 text, PRIMARY KEY (pk, ck1, ck2, ck3)) WITH compression = {'sstable_compression': ''};
+    // CREATE TABLE adjacent_range_tombstones (pk text, ck1 text, ck2 text, ck3 text, PRIMARY KEY (pk, ck1, ck2, ck3)) WITH compression = {'class': ''};
     schema_builder builder("sst3", table_name);
     builder.with_column("pk", utf8_type, column_kind::partition_key);
     builder.with_column("ck1", utf8_type, column_kind::clustering_key);
@@ -4264,7 +4264,7 @@ SEASTAR_THREAD_TEST_CASE(test_write_adjacent_range_tombstones) {
 SEASTAR_THREAD_TEST_CASE(test_write_non_adjacent_range_tombstones) {
   test_env::do_with_async([] (test_env& env) {
     sstring table_name = "non_adjacent_range_tombstones";
-    // CREATE TABLE non_adjacent_range_tombstones (pk text, ck1 text, ck2 text, ck3 text, PRIMARY KEY (pk, ck1, ck2, ck3)) WITH compression = {'sstable_compression': ''};
+    // CREATE TABLE non_adjacent_range_tombstones (pk text, ck1 text, ck2 text, ck3 text, PRIMARY KEY (pk, ck1, ck2, ck3)) WITH compression = {'class': ''};
     schema_builder builder("sst3", table_name);
     builder.with_column("pk", utf8_type, column_kind::partition_key);
     builder.with_column("ck1", utf8_type, column_kind::clustering_key);
@@ -4303,7 +4303,7 @@ SEASTAR_THREAD_TEST_CASE(test_write_non_adjacent_range_tombstones) {
 SEASTAR_THREAD_TEST_CASE(test_write_mixed_rows_and_range_tombstones) {
   test_env::do_with_async([] (test_env& env) {
     sstring table_name = "mixed_rows_and_range_tombstones";
-    // CREATE TABLE mixed_rows_and_range_tombstones (pk text, ck1 text, ck2 text, PRIMARY KEY (pk, ck1, ck2)) WITH compression = {'sstable_compression': ''};
+    // CREATE TABLE mixed_rows_and_range_tombstones (pk text, ck1 text, ck2 text, PRIMARY KEY (pk, ck1, ck2)) WITH compression = {'class': ''};
     schema_builder builder("sst3", table_name);
     builder.with_column("pk", utf8_type, column_kind::partition_key);
     builder.with_column("ck1", utf8_type, column_kind::clustering_key);
@@ -4372,7 +4372,7 @@ SEASTAR_THREAD_TEST_CASE(test_write_mixed_rows_and_range_tombstones) {
 SEASTAR_THREAD_TEST_CASE(test_write_many_range_tombstones) {
   test_env::do_with_async([] (test_env& env) {
     sstring table_name = "many_range_tombstones";
-    // CREATE TABLE many_range_tombstones (pk text, ck1 text, ck2 text, PRIMARY KEY (pk, ck1, ck2) WITH compression = {'sstable_compression': ''};
+    // CREATE TABLE many_range_tombstones (pk text, ck1 text, ck2 text, PRIMARY KEY (pk, ck1, ck2) WITH compression = {'class': ''};
     schema_builder builder("sst3", table_name);
     builder.with_column("pk", utf8_type, column_kind::partition_key);
     builder.with_column("ck1", utf8_type, column_kind::clustering_key);
@@ -4402,7 +4402,7 @@ SEASTAR_THREAD_TEST_CASE(test_write_many_range_tombstones) {
 SEASTAR_THREAD_TEST_CASE(test_write_adjacent_range_tombstones_with_rows) {
   test_env::do_with_async([] (test_env& env) {
     sstring table_name = "adjacent_range_tombstones_with_rows";
-    // CREATE TABLE adjacent_range_tombstones_with_rows (pk text, ck1 text, ck2 text, ck3 text, PRIMARY KEY (pk, ck1, ck2, ck3)) WITH compression = {'sstable_compression': ''};
+    // CREATE TABLE adjacent_range_tombstones_with_rows (pk text, ck1 text, ck2 text, ck3 text, PRIMARY KEY (pk, ck1, ck2, ck3)) WITH compression = {'class': ''};
     schema_builder builder("sst3", table_name);
     builder.with_column("pk", utf8_type, column_kind::partition_key);
     builder.with_column("ck1", utf8_type, column_kind::clustering_key);
@@ -4455,7 +4455,7 @@ SEASTAR_THREAD_TEST_CASE(test_write_adjacent_range_tombstones_with_rows) {
 SEASTAR_THREAD_TEST_CASE(test_write_range_tombstone_same_start_with_row) {
   test_env::do_with_async([] (test_env& env) {
     sstring table_name = "range_tombstone_same_start_with_row";
-    // CREATE TABLE range_tombstone_same_start_with_row (pk int, ck1 text, ck2 text, PRIMARY KEY (pk, ck1, ck2)) WITH compression = {'sstable_compression': ''};
+    // CREATE TABLE range_tombstone_same_start_with_row (pk int, ck1 text, ck2 text, PRIMARY KEY (pk, ck1, ck2)) WITH compression = {'class': ''};
     schema_builder builder("sst3", table_name);
     builder.with_column("pk", int32_type, column_kind::partition_key);
     builder.with_column("ck1", utf8_type, column_kind::clustering_key);
@@ -4490,7 +4490,7 @@ SEASTAR_THREAD_TEST_CASE(test_write_range_tombstone_same_start_with_row) {
 SEASTAR_THREAD_TEST_CASE(test_write_range_tombstone_same_end_with_row) {
   test_env::do_with_async([] (test_env& env) {
     sstring table_name = "range_tombstone_same_end_with_row";
-    // CREATE TABLE range_tombstone_same_end_with_row (pk int, ck1 text, ck2 text, PRIMARY KEY (pk, ck1, ck2)) WITH compression = {'sstable_compression': ''};
+    // CREATE TABLE range_tombstone_same_end_with_row (pk int, ck1 text, ck2 text, PRIMARY KEY (pk, ck1, ck2)) WITH compression = {'class': ''};
     schema_builder builder("sst3", table_name);
     builder.with_column("pk", int32_type, column_kind::partition_key);
     builder.with_column("ck1", utf8_type, column_kind::clustering_key);
@@ -4525,7 +4525,7 @@ SEASTAR_THREAD_TEST_CASE(test_write_range_tombstone_same_end_with_row) {
 SEASTAR_THREAD_TEST_CASE(test_write_overlapped_start_range_tombstones) {
   test_env::do_with_async([] (test_env& env) {
     sstring table_name = "overlapped_start_range_tombstones";
-    // CREATE TABLE overlapped_start_range_tombstones (pk int, ck1 text, ck2 text, PRIMARY KEY (pk, ck1, ck2)) WITH compression = {'sstable_compression': ''};
+    // CREATE TABLE overlapped_start_range_tombstones (pk int, ck1 text, ck2 text, PRIMARY KEY (pk, ck1, ck2)) WITH compression = {'class': ''};
     schema_builder builder("sst3", table_name);
     builder.with_column("pk", int32_type, column_kind::partition_key);
     builder.with_column("ck1", utf8_type, column_kind::clustering_key);
@@ -4574,7 +4574,7 @@ SEASTAR_THREAD_TEST_CASE(test_write_overlapped_start_range_tombstones) {
 SEASTAR_THREAD_TEST_CASE(test_write_two_non_adjacent_range_tombstones) {
   test_env::do_with_async([] (test_env& env) {
     sstring table_name = "two_non_adjacent_range_tombstones";
-    // CREATE TABLE two_non_adjacent_range_tombstones (pk int, ck1 text, ck2 text, PRIMARY KEY (pk, ck1, ck2)) WITH compression = {'sstable_compression': ''};
+    // CREATE TABLE two_non_adjacent_range_tombstones (pk int, ck1 text, ck2 text, PRIMARY KEY (pk, ck1, ck2)) WITH compression = {'class': ''};
     schema_builder builder("sst3", table_name);
     builder.with_column("pk", int32_type, column_kind::partition_key);
     builder.with_column("ck1", utf8_type, column_kind::clustering_key);
@@ -4618,7 +4618,7 @@ SEASTAR_THREAD_TEST_CASE(test_write_two_non_adjacent_range_tombstones) {
 SEASTAR_THREAD_TEST_CASE(test_write_overlapped_range_tombstones) {
   test_env::do_with_async([] (test_env& env) {
     sstring table_name = "overlapped_range_tombstones";
-    // CREATE TABLE overlapped_range_tombstones (pk text, ck1 text, ck2 text, ck3 text, PRIMARY KEY (pk, ck1, ck2, ck3)) WITH compression = {'sstable_compression': ''};
+    // CREATE TABLE overlapped_range_tombstones (pk text, ck1 text, ck2 text, ck3 text, PRIMARY KEY (pk, ck1, ck2, ck3)) WITH compression = {'class': ''};
     schema_builder builder("sst3", table_name);
     builder.with_column("pk", utf8_type, column_kind::partition_key);
     builder.with_column("ck1", utf8_type, column_kind::clustering_key);
@@ -4671,7 +4671,7 @@ shared_sstable make_test_sstable(test_env& env, schema_ptr schema, const sstring
 /*
  * The SSTables read is generated using the following queries:
  *
- *  CREATE TABLE empty_index (pk text, PRIMARY KEY (pk)) WITH compression = {'sstable_compression': ''};
+ *  CREATE TABLE empty_index (pk text, PRIMARY KEY (pk)) WITH compression = {'class': ''};
  *  INSERT INTO empty_index (pk) VALUES ('привет');
 */
 
@@ -4694,7 +4694,7 @@ SEASTAR_THREAD_TEST_CASE(test_read_empty_index) {
 SEASTAR_THREAD_TEST_CASE(test_read_rows_only_index) {
   test_env::do_with_async([] (test_env& env) {
     sstring table_name = "rows_only_index";
-    // CREATE TABLE rows_only_index (pk text, ck text, st text, rc text, PRIMARY KEY (pk, ck) WITH compression = {'sstable_compression': ''};
+    // CREATE TABLE rows_only_index (pk text, ck text, st text, rc text, PRIMARY KEY (pk, ck) WITH compression = {'class': ''};
     schema_builder builder("sst3", table_name);
     builder.with_column("pk", utf8_type, column_kind::partition_key);
     builder.with_column("ck", utf8_type, column_kind::clustering_key);
@@ -4714,7 +4714,7 @@ SEASTAR_THREAD_TEST_CASE(test_read_rows_only_index) {
 SEASTAR_THREAD_TEST_CASE(test_read_range_tombstones_only_index) {
   test_env::do_with_async([] (test_env& env) {
     sstring table_name = "range_tombstones_only_index";
-    // CREATE TABLE range_tombstones_only_index (pk text, ck1 text, ck2 text, PRIMARY KEY (pk, ck1, ck2) WITH compression = {'sstable_compression': ''};
+    // CREATE TABLE range_tombstones_only_index (pk text, ck1 text, ck2 text, PRIMARY KEY (pk, ck1, ck2) WITH compression = {'class': ''};
     schema_builder builder("sst3", table_name);
     builder.with_column("pk", utf8_type, column_kind::partition_key);
     builder.with_column("ck1", utf8_type, column_kind::clustering_key);
@@ -4741,7 +4741,7 @@ SEASTAR_THREAD_TEST_CASE(test_read_range_tombstones_only_index) {
 SEASTAR_THREAD_TEST_CASE(test_read_range_tombstone_boundaries_index) {
   test_env::do_with_async([] (test_env& env) {
     sstring table_name = "range_tombstone_boundaries_index";
-    // CREATE TABLE range_tombstone_boundaries_index (pk text, ck1 text, ck2 text, PRIMARY KEY (pk, ck1, ck2) WITH compression = {'sstable_compression': ''};
+    // CREATE TABLE range_tombstone_boundaries_index (pk text, ck1 text, ck2 text, PRIMARY KEY (pk, ck1, ck2) WITH compression = {'class': ''};
     schema_builder builder("sst3", table_name);
     builder.with_column("pk", utf8_type, column_kind::partition_key);
     builder.with_column("ck1", utf8_type, column_kind::clustering_key);
@@ -4756,7 +4756,7 @@ SEASTAR_THREAD_TEST_CASE(test_read_range_tombstone_boundaries_index) {
 
 SEASTAR_THREAD_TEST_CASE(test_read_table_empty_clustering_key) {
   test_env::do_with_async([] (test_env& env) {
-    // CREATE TABLE empty_clustering_key (pk int, v int, PRIMARY KEY (pk)) with compression = {'sstable_compression': ''};
+    // CREATE TABLE empty_clustering_key (pk int, v int, PRIMARY KEY (pk)) with compression = {'class': ''};
     schema_builder builder("sst3", "empty_clustering_key");
     builder.with_column("pk", int32_type, column_kind::partition_key);
     builder.with_column("v", int32_type);
@@ -4835,7 +4835,7 @@ SEASTAR_THREAD_TEST_CASE(test_uncompressed_read_two_rows_fast_forwarding) {
     // Following tests run on files in test/resource/sstables/3.x/uncompressed/read_two_rows_fast_forwarding
     // They were created using following CQL statements:
     //
-    // CREATE TABLE two_rows_fast_forwarding (pk int, ck int, rc int, PRIMARY KEY (pk, ck)) WITH compression = {'sstable_compression': ''};
+    // CREATE TABLE two_rows_fast_forwarding (pk int, ck int, rc int, PRIMARY KEY (pk, ck)) WITH compression = {'class': ''};
     // INSERT INTO two_rows_fast_forwarding (pk, ck, rc) VALUES (0, 7, 7);
     // INSERT INTO two_rows_fast_forwarding (pk, ck, rc) VALUES (0, 8, 8);
 
@@ -4894,7 +4894,7 @@ SEASTAR_THREAD_TEST_CASE(test_dead_row_marker) {
     api::timestamp_type ts = 1543494402386839;
     gc_clock::time_point tp = gc_clock::time_point{} + gc_clock::duration{1543494402};
     sstring table_name = "dead_row_marker";
-    // CREATE TABLE dead_row_marker (pk int, ck int, st int static, rc int , PRIMARY KEY (pk, ck)) WITH compression = {'sstable_compression': ''};
+    // CREATE TABLE dead_row_marker (pk int, ck int, st int static, rc int , PRIMARY KEY (pk, ck)) WITH compression = {'class': ''};
     schema_builder builder("sst3", table_name);
     builder.with_column("pk", int32_type, column_kind::partition_key);
     builder.with_column("ck", int32_type, column_kind::clustering_key);
@@ -4922,7 +4922,7 @@ SEASTAR_THREAD_TEST_CASE(test_shadowable_deletion) {
     /* The created SSTables content should match that of
      * an MV filled with the following queries:
      *
-     * CREATE TABLE cf (p int PRIMARY KEY, v int) WITH compression = {'sstable_compression': ''};
+     * CREATE TABLE cf (p int PRIMARY KEY, v int) WITH compression = {'class': ''};
      * CREATE MATERIALIZED VIEW mv AS SELECT * FROM cf WHERE p IS NOT NULL AND v IS NOT NULL PRIMARY KEY (v, p);
      * INSERT INTO cf (p, v) VALUES (1, 0);
      * UPDATE cf SET v = 1 WHERE p = 1;
@@ -5006,7 +5006,7 @@ SEASTAR_THREAD_TEST_CASE(test_regular_and_shadowable_deletion) {
 SEASTAR_THREAD_TEST_CASE(test_write_static_row_with_missing_columns) {
   test_env::do_with_async([] (test_env& env) {
     sstring table_name = "static_row_with_missing_columns";
-    // CREATE TABLE static_row (pk int, ck int, st1 int static, st2 int static, rc int, PRIMARY KEY (pk, ck)) WITH compression = {'sstable_compression': ''};
+    // CREATE TABLE static_row (pk int, ck int, st1 int static, st2 int static, rc int, PRIMARY KEY (pk, ck)) WITH compression = {'class': ''};
     schema_builder builder("sst3", table_name);
     builder.with_column("pk", int32_type, column_kind::partition_key);
     builder.with_column("ck", int32_type, column_kind::clustering_key);
@@ -5032,7 +5032,7 @@ SEASTAR_THREAD_TEST_CASE(test_write_interleaved_atomic_and_collection_columns) {
   test_env::do_with_async([] (test_env& env) {
     sstring table_name = "interleaved_atomic_and_collection_columns";
     // CREATE TABLE interleaved_atomic_and_collection_columns ( pk int, ck int, rc1 int, rc2 set<int>, rc3 int, rc4 set<int>,
-    //     rc5 int, rc6 set<int>, PRIMARY KEY (pk, ck)) WITH compression = {'sstable_compression': ''};
+    //     rc5 int, rc6 set<int>, PRIMARY KEY (pk, ck)) WITH compression = {'class': ''};
     auto set_of_ints_type = set_type_impl::get_instance(int32_type, true);
     schema_builder builder("sst3", table_name);
     builder.with_column("pk", int32_type, column_kind::partition_key);
@@ -5071,7 +5071,7 @@ SEASTAR_THREAD_TEST_CASE(test_write_static_interleaved_atomic_and_collection_col
     sstring table_name = "static_interleaved_atomic_and_collection_columns";
     // CREATE TABLE static_interleaved_atomic_and_collection_columns ( pk int, ck int, st1 int static,
     //     st2 set<int> static, st3 int static, st4 set<int> static, st5 int static, st6 set<int> static,
-    //     PRIMARY KEY (pk, ck)) WITH compression = {'sstable_compression': ''};
+    //     PRIMARY KEY (pk, ck)) WITH compression = {'class': ''};
     auto set_of_ints_type = set_type_impl::get_instance(int32_type, true);
     schema_builder builder("sst3", table_name);
     builder.with_column("pk", int32_type, column_kind::partition_key);
@@ -5108,7 +5108,7 @@ SEASTAR_THREAD_TEST_CASE(test_write_static_interleaved_atomic_and_collection_col
 SEASTAR_THREAD_TEST_CASE(test_write_empty_static_row) {
   test_env::do_with_async([] (test_env& env) {
     sstring table_name = "empty_static_row";
-    // CREATE TABLE empty_static_row (pk int, ck int, st int static, rc int, PRIMARY KEY (pk, ck)) WITH compression = {'sstable_compression': ''};
+    // CREATE TABLE empty_static_row (pk int, ck int, st int static, rc int, PRIMARY KEY (pk, ck)) WITH compression = {'class': ''};
     schema_builder builder("sst3", table_name);
     builder.with_column("pk", int32_type, column_kind::partition_key);
     builder.with_column("ck", int32_type, column_kind::clustering_key);

--- a/test/boost/sstable_test.cc
+++ b/test/boost/sstable_test.cc
@@ -1205,7 +1205,7 @@ SEASTAR_TEST_CASE(test_skipping_in_compressed_stream) {
         opts.read_ahead = 0;
 
         compression_parameters cp({
-            { compression_parameters::SSTABLE_COMPRESSION, "LZ4Compressor" },
+            { compression_parameters::CLASS, "LZ4Compressor" },
             { compression_parameters::CHUNK_LENGTH_KB, std::to_string(opts.buffer_size/1024) },
         });
 

--- a/test/cql/sstable_compression_attribute_test.cql
+++ b/test/cql/sstable_compression_attribute_test.cql
@@ -1,0 +1,24 @@
+--
+--
+-- Copyright (C) 2021-present ScyllaDB
+-- 
+-- Modified by ScyllaDB
+-- 
+-- This file is part of Scylla.
+-- 
+-- Scylla is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU Affero General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+-- 
+-- Scylla is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+-- 
+-- You should have received a copy of the GNU General Public License
+-- along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
+
+-- test_sstable_compression_deprecated_attribute
+CREATE TABLE t (id int primary key) WITH compression = {'sstable_compression': 'LZ4Compressor'};
+--

--- a/test/cql/sstable_compression_attribute_test.result
+++ b/test/cql/sstable_compression_attribute_test.result
@@ -1,0 +1,27 @@
+--
+--
+-- Copyright (C) 2021-present ScyllaDB
+-- 
+-- Modified by ScyllaDB
+-- 
+-- This file is part of Scylla.
+-- 
+-- Scylla is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU Affero General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+-- 
+-- Scylla is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+-- 
+-- You should have received a copy of the GNU General Public License
+-- along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
+
+-- test_sstable_compression_deprecated_attribute
+CREATE TABLE t (id int primary key) WITH compression = {'sstable_compression': 'LZ4Compressor'};
+{
+	"status" : "ok"
+}
+--

--- a/test/manual/sstable_scan_footprint_test.cc
+++ b/test/manual/sstable_scan_footprint_test.cc
@@ -217,7 +217,7 @@ void test_main_thread(cql_test_env& env) {
         return;
     }
 
-    env.execute_cql(format("{} WITH compression = {{ 'sstable_compression': '{}' }} "
+    env.execute_cql(format("{} WITH compression = {{ 'class': '{}' }} "
                            "AND compaction = {{'class' : 'NullCompactionStrategy'}};",
         "create table test (pk int, ck int, value blob, primary key (pk,ck))", compressor)).get();
 

--- a/test/perf/perf_fast_forward.cc
+++ b/test/perf/perf_fast_forward.cc
@@ -1674,7 +1674,7 @@ void populate(const std::vector<dataset*>& datasets, cql_test_env& env, const ta
         dataset& ds = *ds_ptr;
         output_mgr->add_dataset_population(ds);
 
-        env.execute_cql(format("{} WITH compression = {{ 'sstable_compression': '{}' }};",
+        env.execute_cql(format("{} WITH compression = {{ 'class': '{}' }};",
             ds.create_table_statement(), cfg.compressor)).get();
 
         column_family& cf = find_table(db, ds);


### PR DESCRIPTION
Cassandra 3.0 deprecated the 'sstable_compression' attribute and added
'class' as a replacement. Follow by supporting both.

The SSTABLE_COMPRESSION variable is renamed to SSTABLE_COMPRESSION_DEPRECATED
to detect all uses and prevent future misuse.

Existing unit tests are modified to use the new name, and a test
is added to ensure the old name is still supported.

Fixes #8948.