### PR TITLE
Use expressions to calculate the global-index partition slice

### DIFF
--- a/cql3/restrictions/statement_restrictions.cc
+++ b/cql3/restrictions/statement_restrictions.cc
@@ -221,20 +221,9 @@ static std::vector<expr::expression> extract_partition_range(
     return {};
 }
 
-/// Extracts where_clause atoms with clustering-column LHS and copies them to a vector such that:
-/// 1. all elements must be simultaneously satisfied (as restrictions) for where_clause to be satisfied
-/// 2. each element is an atom or a conjunction of atoms
-/// 3. either all atoms (across all elements) are multi-column or they are all single-column
-/// 4. if single-column, then:
-///   4.1 all atoms from an element have the same LHS, which we call the element's LHS
-///   4.2 each element's LHS is different from any other element's LHS
-///   4.3 the list of each element's LHS, in order, forms a clustering-key prefix
-///   4.4 elements other than the last have only EQ or IN atoms
-///   4.5 the last element has only EQ, IN, or is_slice() atoms
-///
-/// These elements define the boundaries of any clustering slice that can possibly meet where_clause.
-///
-/// This vector can be calculated before binding expression markers, since LHS and operator are always known.
+/// Extracts where_clause atoms with clustering-column LHS and copies them to a vector.  These elements define the
+/// boundaries of any clustering slice that can possibly meet where_clause.  This vector can be calculated before
+/// binding expression markers, since LHS and operator are always known.
 static std::vector<expr::expression> extract_clustering_prefix_restrictions(
         const expr::expression& where_clause, schema_ptr schema) {
     using namespace expr;

--- a/cql3/restrictions/statement_restrictions.cc
+++ b/cql3/restrictions/statement_restrictions.cc
@@ -1215,7 +1215,7 @@ std::vector<query::clustering_range> statement_restrictions::get_clustering_boun
     if (_clustering_prefix_restrictions.empty()) {
         return {query::clustering_range::make_open_ended_both_sides()};
     }
-    if (count_if(_clustering_prefix_restrictions[0], expr::is_multi_column)) {
+    if (find_atom(_clustering_prefix_restrictions[0], expr::is_multi_column)) {
         bool all_natural = true, all_reverse = true; ///< Whether column types are reversed or natural.
         for (auto& r : _clustering_prefix_restrictions) { // TODO: move to constructor, do only once.
             using namespace expr;

--- a/cql3/restrictions/statement_restrictions.cc
+++ b/cql3/restrictions/statement_restrictions.cc
@@ -363,6 +363,7 @@ statement_restrictions::statement_restrictions(database& db,
                                     "(unless you use the token() function or allow filtering)");
                         }
                         _partition_key_restrictions = _partition_key_restrictions->merge_to(_schema, restriction);
+                        _partition_range_is_simple &= !find(restriction->expression, expr::oper_t::IN);
                     } else if (def.is_clustering_key()) {
                         _clustering_columns_restrictions = _clustering_columns_restrictions->merge_to(_schema, restriction);
                     } else {
@@ -370,7 +371,6 @@ statement_restrictions::statement_restrictions(database& db,
                     }
                 }
                 _where = _where.has_value() ? make_conjunction(std::move(*_where), restriction->expression) : restriction->expression;
-                _partition_range_is_simple &= !find(restriction->expression, expr::oper_t::IN);
             }
         }
     }

--- a/cql3/restrictions/statement_restrictions.hh
+++ b/cql3/restrictions/statement_restrictions.hh
@@ -121,6 +121,13 @@ private:
     /// 5. if multi-column, then each element is a binary_operator
     std::vector<expr::expression> _clustering_prefix_restrictions;
 
+    /// Like _clustering_prefix_restrictions, but for the indexing table (if this is an index-reading statement).
+    /// Recall that the index-table CK is (token, PK, CK) of the base table for a global index and (indexed column,
+    /// CK) for a local index.
+    ///
+    /// Elements are single-column binary operators.  The first element's RHS is a dummy value.
+    std::optional<std::vector<expr::expression>> _idx_tbl_ck_prefix;
+
     /// Parts of _where defining the partition range.
     ///
     /// If the partition range is dictated by token restrictions, this is a single element that holds all the
@@ -469,6 +476,14 @@ public:
      * @return clustering key restrictions split into single column restrictions (e.g. for filtering support).
      */
     const single_column_restrictions::restrictions_map& get_single_column_clustering_key_restrictions() const;
+
+    /// Prepares internal data for evaluating index-table queries.  Must be called before
+    /// get_global_index_clustering_ranges().
+    void prepare_indexed(const schema& idx_tbl_schema, bool is_local);
+
+    /// Calculates clustering ranges for querying a global-index table.
+    std::vector<query::clustering_range> get_global_index_clustering_ranges(
+            const query_options& options, const schema& idx_tbl_schema) const;
 };
 
 }

--- a/cql3/restrictions/statement_restrictions.hh
+++ b/cql3/restrictions/statement_restrictions.hh
@@ -105,8 +105,30 @@ private:
     bool _has_queriable_regular_index = false, _has_queriable_pk_index = false, _has_queriable_ck_index = false;
 
     std::optional<expr::expression> _where; ///< The entire WHERE clause.
-    std::vector<expr::expression> _clustering_prefix_restrictions; ///< Parts of _where defining the clustering slice.
-    std::vector<expr::expression> _partition_range_restrictions; ///< Parts of _where defining the partition range.
+
+    /// Parts of _where defining the clustering slice.
+    ///
+    /// Meets all of the following conditions:
+    /// 1. all elements must be simultaneously satisfied (as restrictions) for _where to be satisfied
+    /// 2. each element is an atom or a conjunction of atoms
+    /// 3. either all atoms (across all elements) are multi-column or they are all single-column
+    /// 4. if single-column, then:
+    ///   4.1 all atoms from an element have the same LHS, which we call the element's LHS
+    ///   4.2 each element's LHS is different from any other element's LHS
+    ///   4.3 the list of each element's LHS, in order, forms a clustering-key prefix
+    ///   4.4 elements other than the last have only EQ or IN atoms
+    ///   4.5 the last element has only EQ, IN, or is_slice() atoms
+    /// 5. if multi-column, then each element is a binary_operator
+    std::vector<expr::expression> _clustering_prefix_restrictions;
+
+    /// Parts of _where defining the partition range.
+    ///
+    /// If the partition range is dictated by token restrictions, this is a single element that holds all the
+    /// binary_operators on token.  If single-column restrictions define the partition range, each element holds
+    /// restrictions for one partition column.  Each partition column has a corresponding element, but the elements
+    /// are in arbitrary order.
+    std::vector<expr::expression> _partition_range_restrictions;
+
     bool _partition_range_is_simple; ///< False iff _partition_range_restrictions imply a Cartesian product.
 
 public:

--- a/test/cql-pytest/cassandra_tests/validation/entities/secondary_index_test.py
+++ b/test/cql-pytest/cassandra_tests/validation/entities/secondary_index_test.py
@@ -666,6 +666,8 @@ def testIndexesOnClustering(cql, test_keyspace):
 
         assert_rows(execute(cql, table, "SELECT v1 FROM %s WHERE id1 = 0 AND id2 = 0 AND author = 'bob' AND time = 0"),
                    ["A"])
+        assert_rows(execute(cql, table, "SELECT v1 FROM %s WHERE id1 = 0 AND id2 = 0 AND author = 'bob'"),
+                    ["A"], ["B"])
 
         # Test for CASSANDRA-8206
         execute(cql, table, "UPDATE %s SET v2 = null WHERE id1 = 0 AND id2 = 0 AND author = 'bob' AND time = 1")
@@ -801,6 +803,9 @@ def testPartitionKeyWithIndex(cql, test_keyspace):
                        [1, 2, 3])
             assert_rows(execute(cql, table, "SELECT * FROM %s WHERE b = 3"),
                        [2, 3, 4])
+            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a=5 AND b=6"),
+                       [5, 6, 7])
+            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a=5 AND b=5"))
 
 def testAllowFilteringOnPartitionKeyWithSecondaryIndex(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(pk1 int, pk2 int, c1 int, c2 int, v int, PRIMARY KEY ((pk1, pk2), c1, c2))") as table:


### PR DESCRIPTION
Another step towards dropping the `restrictions` class.  When calculating the partition slice of a global-index table, use `expression` objects instead of a `restrictions` subclass.

Refs #7217.

Tests: unit (all dev, some debug)