### PR TITLE
messaging_service: do not listen on port 0

### DIFF
--- a/docs/design-notes/protocols.md
+++ b/docs/design-notes/protocols.md
@@ -78,6 +78,9 @@ used _only_ for "storage" messages (read and write), and other messages such
 as gossip were sent to a different port. So today we are still stuck with
 this outdated name of this configuration option.
 
+Configuring `storage_port` or `ssl_storage_port` to 0 disables listening
+on the respective unecrypted/encrypted inter-node communication port.
+
 There is also a `listen_address` configuration option to set the IP address
 (and therefore network interface) on which Scylla should listen for the
 internal protocol. This address defaults to `localhost`, but in any

--- a/message/messaging_service.cc
+++ b/message/messaging_service.cc
@@ -420,7 +420,15 @@ void messaging_service::do_start_listen() {
         if (_server_tls[0]) {
             mlogger.info("Starting Encrypted Messaging Service on SSL port {}", _cfg.ssl_port);
         }
-        mlogger.info("Starting Messaging Service on port {}", _cfg.port);
+        if (_server_tls[1]) {
+            mlogger.info("Starting Encrypted Messaging Service on SSL broadcast address {} port {}", utils::fb_utilities::get_broadcast_address(), _cfg.ssl_port);
+        }
+        if (_server[0]) {
+            mlogger.info("Starting Messaging Service on port {}", _cfg.port);
+        }
+        if (_server[1]) {
+            mlogger.info("Starting Messaging Service on broadcast address {} port {}", utils::fb_utilities::get_broadcast_address(), _cfg.port);
+        }
     }
 }
 

--- a/message/messaging_service.cc
+++ b/message/messaging_service.cc
@@ -357,7 +357,7 @@ void messaging_service::do_start_listen() {
         cfg.sched_group = scheduling_group_for_isolation_cookie(isolation_cookie);
         return cfg;
     };
-    if (!_server[0] && _cfg.encrypt != encrypt_what::all) {
+    if (!_server[0] && _cfg.encrypt != encrypt_what::all && _cfg.port) {
         auto listen = [&] (const gms::inet_address& a, rpc::streaming_domain_type sdomain) {
             so.streaming_domain = sdomain;
             so.filter_connection = {};
@@ -390,7 +390,7 @@ void messaging_service::do_start_listen() {
         }
     }
     
-    if (!_server_tls[0]) {
+    if (!_server_tls[0] && _cfg.ssl_port) {
         auto listen = [&] (const gms::inet_address& a, rpc::streaming_domain_type sdomain) {
             so.filter_connection = {};
             so.streaming_domain = sdomain;


### PR DESCRIPTION
We never want to listen on port 0, even if configured so.
When the listen port is set to 0, the OS will choose the
port randomly, which makes it useless for communicating
with other nodes in the cluster, since we don't support that.
    
Also, it causes the listen_ports_conf_test internode_ssl_test
to fail since it expects to disable listening on storage_port
or ssl_storage_port when set to 0, as seen in
https://github.com/scylladb/scylla-dtest/issues/2174.

Fixes #8957

Test: unit(dev)
DTest: listen_ports_conf_test (modified)