### PR TITLE
dist/redhat: prevent removing .mount files during upgrade

### DIFF
--- a/dist/debian/debian/scylla-server.postrm
+++ b/dist/debian/debian/scylla-server.postrm
@@ -12,8 +12,6 @@ case "$1" in
         if [ "$1" = "purge" ]; then
             rm -rf /etc/systemd/system/scylla-server.service.d/
         fi
-        rm -f /etc/systemd/system/var-lib-systemd-coredump.mount
-        rm -f /etc/systemd/system/var-lib-scylla.mount
         ;;
 esac
 

--- a/dist/redhat/scylla.spec
+++ b/dist/redhat/scylla.spec
@@ -141,9 +141,9 @@ rm -rf $RPM_BUILD_ROOT
 %ghost /etc/systemd/system/scylla-server.service.d/capabilities.conf
 %ghost /etc/systemd/system/scylla-server.service.d/mounts.conf
 /etc/systemd/system/scylla-server.service.d/dependencies.conf
-%ghost /etc/systemd/system/var-lib-systemd-coredump.mount
+%ghost %config /etc/systemd/system/var-lib-systemd-coredump.mount
 %ghost /etc/systemd/system/scylla-cpupower.service
-%ghost /etc/systemd/system/var-lib-scylla.mount
+%ghost %config /etc/systemd/system/var-lib-scylla.mount
 
 %package conf
 Group:          Applications/Databases


### PR DESCRIPTION
We removed %ghost for .mount files at a677c46, it was for prevent
removing .mount files during package remove.
However, after a677c46 rpm removes .mount files during package upgrade,
because rpm things removed %ghost files are now dropped from package.
To fix both problem, specify .mount files as "%ghost %config".
It will keep files both package upgrade and package remove.

Fixes #8924