### PR TITLE
db/virtual_table: Streaming tables for large data + describe_ring example table

### DIFF
--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -80,7 +80,7 @@ static ss::token_range token_range_endpoints_to_json(const dht::token_range_endp
     r.rpc_endpoints = d._rpc_endpoints;
     for (auto det : d._endpoint_details) {
         ss::endpoint_detail ed;
-        ed.host = det._host;
+        ed.host = boost::lexical_cast<std::string>(det._host);
         ed.datacenter = det._datacenter;
         if (det._rack != "") {
             ed.rack = det._rack;

--- a/database.hh
+++ b/database.hh
@@ -86,6 +86,7 @@ class reconcilable_result;
 
 namespace service {
 class storage_proxy;
+class storage_service;
 class migration_notifier;
 class migration_manager;
 }
@@ -123,7 +124,7 @@ class data_listeners;
 class large_data_handler;
 
 namespace system_keyspace {
-future<> make(database& db);
+future<> make(database& db, service::storage_service& ss);
 }
 }
 
@@ -1356,7 +1357,7 @@ public:
 private:
     using system_keyspace = bool_class<struct system_keyspace_tag>;
     void create_in_memory_keyspace(const lw_shared_ptr<keyspace_metadata>& ksm, system_keyspace system);
-    friend future<> db::system_keyspace::make(database& db);
+    friend future<> db::system_keyspace::make(database& db, service::storage_service& ss);
     void setup_metrics();
     void setup_scylla_memory_diagnostics_producer();
 

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -38,6 +38,7 @@
  * along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <boost/range/algorithm.hpp>
 #include <boost/range/algorithm_ext/push_back.hpp>
 #include <boost/range/adaptor/transformed.hpp>
 #include <boost/range/adaptor/filtered.hpp>
@@ -1844,6 +1845,95 @@ public:
     }
 };
 
+class describe_ring_table : public streaming_virtual_table {
+private:
+    service::storage_service& _ss;
+public:
+    describe_ring_table(service::storage_service& ss)
+            : streaming_virtual_table(build_schema())
+            , _ss(ss)
+    {
+        _shard_aware = true;
+    }
+
+    static schema_ptr build_schema() {
+        auto id = generate_legacy_id(NAME, "describe_ring");
+        return schema_builder(NAME, "describe_ring", std::make_optional(id))
+            .with_column("keyspace_name", utf8_type, column_kind::partition_key)
+            .with_column("start_token", utf8_type, column_kind::clustering_key)
+            .with_column("endpoint", inet_addr_type, column_kind::clustering_key)
+            .with_column("end_token", utf8_type)
+            .with_column("dc", utf8_type)
+            .with_column("rack", utf8_type)
+            .with_version(generate_schema_version(id))
+            .build();
+    }
+
+    dht::decorated_key make_partition_key(const sstring& name) {
+        return dht::decorate_key(*_s, partition_key::from_single_value(*_s, data_value(name).serialize_nonnull()));
+    }
+
+    clustering_key make_clustering_key(sstring start_token, gms::inet_address host) {
+        return clustering_key::from_exploded(*_s, {
+            data_value(start_token).serialize_nonnull(),
+            data_value(host).serialize_nonnull()
+        });
+    }
+
+    struct endpoint_details_cmp {
+        bool operator()(const dht::endpoint_details& l, const dht::endpoint_details& r) const {
+            return inet_addr_type->less(
+                data_value(l._host).serialize_nonnull(),
+                data_value(r._host).serialize_nonnull());
+        }
+    };
+
+    future<> execute(reader_permit permit, result_collector& result, const query_restrictions& qr) override {
+        struct decorated_keyspace_name {
+            sstring name;
+            dht::decorated_key key;
+        };
+
+        auto keyspace_names = boost::copy_range<std::vector<decorated_keyspace_name>>(
+                _db->get_keyspaces() | boost::adaptors::transformed([this] (auto&& e) {
+                    return decorated_keyspace_name{e.first, make_partition_key(e.first)};
+        }));
+
+        boost::sort(keyspace_names, [less = dht::ring_position_less_comparator(*_s)]
+                (const decorated_keyspace_name& l, const decorated_keyspace_name& r) {
+            return less(l.key, r.key);
+        });
+
+        for (const decorated_keyspace_name& e : keyspace_names) {
+            auto&& dk = e.key;
+            if (!this_shard_owns(dk) || !contains_key(qr.partition_range(), dk) || !_db->has_keyspace(e.name)) {
+                continue;
+            }
+
+            std::vector<dht::token_range_endpoints> ranges = _ss.describe_ring(e.name);
+
+            co_await result.emit_partition_start(dk);
+            boost::sort(ranges, [] (const dht::token_range_endpoints& l, const dht::token_range_endpoints& r) {
+                return l._start_token < r._start_token;
+            });
+
+            for (dht::token_range_endpoints& range : ranges) {
+                boost::sort(range._endpoint_details, endpoint_details_cmp());
+
+                for (const dht::endpoint_details& detail : range._endpoint_details) {
+                    clustering_row cr(make_clustering_key(range._start_token, detail._host));
+                    set_cell(cr.cells(), "end_token", sstring(range._end_token));
+                    set_cell(cr.cells(), "dc", sstring(detail._datacenter));
+                    set_cell(cr.cells(), "rack", sstring(detail._rack));
+                    co_await result.emit_row(std::move(cr));
+                }
+            }
+
+            co_await result.emit_partition_end();
+        }
+    }
+};
+
 // Map from table's schema ID to table itself. Helps avoiding accidental duplication.
 static thread_local std::map<utils::UUID, std::unique_ptr<virtual_table>> virtual_tables;
 
@@ -1854,6 +1944,7 @@ void register_virtual_tables(service::storage_service& ss) {
 
     // Add built-in virtual tables here.
     add_table(std::make_unique<nodetool_status_table>(ss));
+    add_table(std::make_unique<describe_ring_table>(ss));
 }
 
 std::vector<schema_ptr> all_tables() {

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -214,7 +214,7 @@ future<> set_scylla_local_param(const sstring& key, const sstring& value);
 future<std::optional<sstring>> get_scylla_local_param(const sstring& key);
 
 std::vector<schema_ptr> all_tables();
-future<> make(database& db);
+future<> make(database& db, service::storage_service& ss);
 
 /// overloads
 

--- a/db/virtual_table.cc
+++ b/db/virtual_table.cc
@@ -106,4 +106,90 @@ mutation_source memtable_filling_virtual_table::as_mutation_source() {
     });
 }
 
+mutation_source streaming_virtual_table::as_mutation_source() {
+    return mutation_source([this] (schema_ptr s,
+        reader_permit permit,
+        const dht::partition_range& pr,
+        const query::partition_slice& slice,
+        const io_priority_class& pc,
+        tracing::trace_state_ptr trace_state,
+        streamed_mutation::forwarding fwd,
+        mutation_reader::forwarding fwd_mr) {
+
+        // We cannot pass the partition_range directly to execute()
+        // because it is not guaranteed to be alive until execute() resolves.
+        // It is only guaranteed to be alive as long as the returned reader is alive.
+        // We achieve safety by mediating access through query_restrictions. When the reader
+        // dies, pr is cleared and execute() will get an exception.
+        struct my_result_collector : public result_collector, public query_restrictions {
+            queue_reader_handle handle;
+
+            // Valid until handle.is_terminated(), which is set to true when the
+            // queue_reader dies.
+            const dht::partition_range* pr;
+            mutation_reader::forwarding fwd_mr;
+
+            my_result_collector(schema_ptr s, reader_permit p, const dht::partition_range* pr, queue_reader_handle&& handle)
+                : result_collector(s, p)
+                , handle(std::move(handle))
+                , pr(pr)
+            { }
+
+            // result_collector
+            future<> take(mutation_fragment fragment) override {
+                return handle.push(std::move(fragment));
+            }
+
+            // query_restrictions
+            const dht::partition_range& partition_range() const override {
+                if (handle.is_terminated()) {
+                    throw std::runtime_error("read abandoned");
+                }
+                return *pr;
+            }
+        };
+
+        auto reader_and_handle = make_queue_reader(_s, permit);
+        auto consumer = std::make_unique<my_result_collector>(_s, permit, &pr, std::move(reader_and_handle.second));
+        auto f = execute(permit, *consumer, *consumer);
+
+        // It is safe to discard this future because:
+        // - after calling `handle.push_end_of_stream()` the reader can be discarded;
+        // - if the reader dies first, `execute()` will get an exception on attempt to push fragments.
+        (void)f.then_wrapped([c = std::move(consumer)] (auto&& f) {
+            if (f.failed()) {
+                c->handle.abort(f.get_exception());
+            } else if (!c->handle.is_terminated()) {
+                c->handle.push_end_of_stream();
+            }
+        });
+
+        auto rd = make_slicing_filtering_reader(std::move(reader_and_handle.first), pr, slice);
+
+        if (!_shard_aware) {
+            rd = make_filtering_reader(std::move(rd), [this] (const dht::decorated_key& dk) -> bool {
+                return this_shard_owns(dk);
+            });
+        }
+
+        if (fwd == streamed_mutation::forwarding::yes) {
+            rd = make_forwardable(std::move(rd));
+        }
+
+        return rd;
+    });
+}
+
+future<> result_collector::emit_partition_start(dht::decorated_key dk) {
+        return take(mutation_fragment(*_schema, _permit, partition_start(std::move(dk), {})));
+}
+
+future<> result_collector::emit_partition_end() {
+    return take(mutation_fragment(*_schema, _permit, partition_end()));
+}
+
+future<> result_collector::emit_row(clustering_row&& cr) {
+    return take(mutation_fragment(*_schema, _permit, std::move(cr)));
+}
+
 }

--- a/dht/token_range_endpoints.hh
+++ b/dht/token_range_endpoints.hh
@@ -24,10 +24,11 @@
 #include <seastar/core/sstring.hh>
 
 #include "seastarx.hh"
+#include "gms/inet_address.hh"
 
 namespace dht {
 struct endpoint_details {
-    sstring _host;
+    gms::inet_address _host;
     sstring _datacenter;
     sstring _rack;
 };

--- a/distributed_loader.cc
+++ b/distributed_loader.cc
@@ -623,8 +623,8 @@ future<> distributed_loader::populate_keyspace(distributed<database>& db, sstrin
     }
 }
 
-future<> distributed_loader::init_system_keyspace(distributed<database>& db) {
-    return seastar::async([&db] {
+future<> distributed_loader::init_system_keyspace(distributed<database>& db, distributed<service::storage_service>& ss) {
+    return seastar::async([&db, &ss] {
         // We need to init commitlog on shard0 before it is inited on other shards
         // because it obtains the list of pre-existing segments for replay, which must
         // not include reserve segments created by active commitlogs.
@@ -638,8 +638,8 @@ future<> distributed_loader::init_system_keyspace(distributed<database>& db) {
             return db.init_commitlog();
         }).get();
 
-        db.invoke_on_all([] (database& db) {
-            return db::system_keyspace::make(db);
+        db.invoke_on_all([&ss] (database& db) {
+            return db::system_keyspace::make(db, ss.local());
         }).get();
 
         const auto& cfg = db.local().get_config();

--- a/distributed_loader.hh
+++ b/distributed_loader.hh
@@ -53,6 +53,7 @@ class sstable_directory;
 namespace service {
 
 class storage_proxy;
+class storage_service;
 class migration_manager;
 
 }
@@ -80,7 +81,7 @@ public:
             get_sstables_from_upload_dir(distributed<database>& db, sstring ks, sstring cf);
     static future<> populate_column_family(distributed<database>& db, sstring sstdir, sstring ks, sstring cf);
     static future<> populate_keyspace(distributed<database>& db, sstring datadir, sstring ks_name);
-    static future<> init_system_keyspace(distributed<database>& db);
+    static future<> init_system_keyspace(distributed<database>& db, distributed<service::storage_service>& ss);
     static future<> ensure_system_table_directories(distributed<database>& db);
     static future<> init_non_system_keyspaces(distributed<database>& db, distributed<service::storage_proxy>& proxy, distributed<service::migration_manager>& mm);
 private:

--- a/main.cc
+++ b/main.cc
@@ -938,7 +938,7 @@ int main(int ac, char** av) {
             // Iteration through column family directory for sstable loading is
             // done only by shard 0, so we'll no longer face race conditions as
             // described here: https://github.com/scylladb/scylla/issues/1014
-            distributed_loader::init_system_keyspace(db).get();
+            distributed_loader::init_system_keyspace(db, ss).get();
 
             supervisor::notify("starting gossip");
             // Moved local parameters here, esp since with the

--- a/mutation_reader.cc
+++ b/mutation_reader.cc
@@ -1956,7 +1956,13 @@ public:
         return _full->get_future();
     }
     virtual future<> next_partition() override {
-        return make_exception_future<>(make_backtraced_exception_ptr<std::bad_function_call>());
+        clear_buffer_to_next_partition();
+        if (is_buffer_empty() && !is_end_of_stream()) {
+            return fill_buffer(db::no_timeout).then([this] {
+                return next_partition();
+            });
+        }
+        return make_ready_future<>();
     }
     virtual future<> fast_forward_to(const dht::partition_range&, db::timeout_clock::time_point) override {
         return make_exception_future<>(make_backtraced_exception_ptr<std::bad_function_call>());

--- a/mutation_reader.hh
+++ b/mutation_reader.hh
@@ -136,6 +136,9 @@ flat_mutation_reader make_filtering_reader(flat_mutation_reader rd, MutationFilt
     return make_flat_mutation_reader<filtering_reader<MutationFilter>>(std::move(rd), std::forward<MutationFilter>(filter));
 }
 
+/// Create a wrapper that filters fragments according to partition range and slice.
+flat_mutation_reader make_slicing_filtering_reader(flat_mutation_reader, const dht::partition_range&, const query::partition_slice&);
+
 /// A partition_presence_checker quickly returns whether a key is known not to exist
 /// in a data source (it may return false positives, but not false negatives).
 enum class partition_presence_checker_result {

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -3480,11 +3480,11 @@ storage_service::describe_ring(const sstring& keyspace, bool include_only_local_
         }
         for (auto endpoint : addresses) {
             endpoint_details details;
-            details._host = boost::lexical_cast<std::string>(endpoint);
+            details._host = endpoint;
             details._datacenter = locator::i_endpoint_snitch::get_local_snitch_ptr()->get_datacenter(endpoint);
             details._rack = locator::i_endpoint_snitch::get_local_snitch_ptr()->get_rack(endpoint);
             tr._rpc_endpoints.push_back(get_rpc_address(endpoint));
-            tr._endpoints.push_back(details._host);
+            tr._endpoints.push_back(boost::lexical_cast<std::string>(details._host));
             tr._endpoint_details.push_back(details);
         }
         ranges.push_back(tr);

--- a/test/boost/virtual_table_mutation_source_test.cc
+++ b/test/boost/virtual_table_mutation_source_test.cc
@@ -39,6 +39,30 @@ public:
     }
 };
 
+class streaming_test_vt : public db::streaming_virtual_table {
+    schema_ptr _s;
+    std::vector<mutation> _mutations;
+public:
+    streaming_test_vt(schema_ptr s, std::vector<mutation> mutations)
+            : streaming_virtual_table(s)
+            , _s(s)
+            , _mutations(std::move(mutations)) {}
+
+    virtual future<> execute(reader_permit permit, db::result_collector& rc) override {
+        return async([this, permit, &rc] {
+            auto mt = make_lw_shared<memtable>(_s);
+            do_for_each(_mutations, [mt] (const mutation& m) {
+                mt->apply(m);
+            }).get();
+            auto rdr = mt->make_flat_reader(_s, permit);
+            auto close_rdr = deferred_close(rdr);
+            rdr.consume_pausable([&rc] (mutation_fragment mf) {
+                return rc.take(std::move(mf)).then([] { return stop_iteration::no; });
+            }, db::no_timeout).get();
+        });
+    }
+};
+
 SEASTAR_THREAD_TEST_CASE(test_memtable_filling_vt_as_mutation_source) {
     std::unique_ptr<memtable_filling_test_vt> table; // Used to prolong table's life
 
@@ -46,4 +70,22 @@ SEASTAR_THREAD_TEST_CASE(test_memtable_filling_vt_as_mutation_source) {
         table = std::make_unique<memtable_filling_test_vt>(s, mutations);
         return table->as_mutation_source();
     });
+}
+
+SEASTAR_THREAD_TEST_CASE(test_streaming_vt_as_mutation_source) {
+    std::unique_ptr<streaming_test_vt> table; // Used to prolong table's life
+
+    run_mutation_source_tests([&table] (schema_ptr s, const std::vector<mutation>& mutations, gc_clock::time_point) -> mutation_source {
+        table = std::make_unique<streaming_test_vt>(s, mutations);
+        return mutation_source([ms = table->as_mutation_source()] (schema_ptr s,
+                reader_permit permit,
+                const dht::partition_range& pr,
+                const query::partition_slice& slice,
+                const io_priority_class& pc,
+                tracing::trace_state_ptr trace_state,
+                streamed_mutation::forwarding stream_fwd,
+                mutation_reader::forwarding) {
+            return ms.make_reader(s, permit, pr, slice, pc, trace_state, stream_fwd, mutation_reader::forwarding::no);
+        });
+    }, false /* with_partition_range_forwarding */);
 }

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -629,7 +629,7 @@ public:
                 view_update_generator.stop().get();
             });
 
-            distributed_loader::init_system_keyspace(db).get();
+            distributed_loader::init_system_keyspace(db, ss).get();
 
             auto& ks = db.local().find_keyspace(db::system_keyspace::NAME);
             parallel_for_each(ks.metadata()->cf_meta_data(), [&ks] (auto& pair) {

--- a/test/lib/mutation_source_test.cc
+++ b/test/lib/mutation_source_test.cc
@@ -1660,15 +1660,13 @@ void test_reader_conversions(tests::reader_concurrency_semaphore_wrapper& semaph
 
 void test_next_partition(tests::reader_concurrency_semaphore_wrapper&, populate_fn_ex);
 
-void run_mutation_reader_tests(populate_fn_ex populate) {
+void run_mutation_reader_tests(populate_fn_ex populate, bool with_partition_range_forwarding) {
     tests::reader_concurrency_semaphore_wrapper semaphore;
 
     test_range_tombstones_v2(semaphore, populate);
     test_downgrade_to_v1_clear_buffer(semaphore, populate);
     test_reader_conversions(semaphore, populate);
-    test_slicing_and_fast_forwarding(semaphore, populate);
     test_date_tiered_clustering_slicing(semaphore, populate);
-    test_fast_forwarding_across_partitions_to_empty_range(semaphore, populate);
     test_clustering_slices(semaphore, populate);
     test_mutation_reader_fragments_have_monotonic_positions(semaphore, populate);
     test_streamed_mutation_forwarding_across_range_tombstones(semaphore, populate);
@@ -1682,6 +1680,11 @@ void run_mutation_reader_tests(populate_fn_ex populate) {
     test_next_partition(semaphore, populate);
     test_streamed_mutation_forwarding_succeeds_with_no_data(semaphore, populate);
     test_slicing_with_overlapping_range_tombstones(semaphore, populate);
+    
+    if (with_partition_range_forwarding) {
+        test_fast_forwarding_across_partitions_to_empty_range(semaphore, populate);
+        test_slicing_and_fast_forwarding(semaphore, populate);
+    }
 }
 
 void test_next_partition(tests::reader_concurrency_semaphore_wrapper& semaphore, populate_fn_ex populate) {
@@ -1717,15 +1720,15 @@ void test_next_partition(tests::reader_concurrency_semaphore_wrapper& semaphore,
         .produces_end_of_stream();
 }
 
-void run_mutation_source_tests(populate_fn populate) {
+void run_mutation_source_tests(populate_fn populate, bool with_partition_range_forwarding) {
     auto populate_ex = [populate = std::move(populate)] (schema_ptr s, const std::vector<mutation>& muts, gc_clock::time_point) {
         return populate(std::move(s), muts);
     };
-    run_mutation_source_tests(std::move(populate_ex));
+    run_mutation_source_tests(std::move(populate_ex), with_partition_range_forwarding);
 }
 
-void run_mutation_source_tests(populate_fn_ex populate) {
-    run_mutation_reader_tests(populate);
+void run_mutation_source_tests(populate_fn_ex populate, bool with_partition_range_forwarding) {
+    run_mutation_reader_tests(populate, with_partition_range_forwarding);
 
     // ? -> v2 -> v1 -> *
     run_mutation_reader_tests([populate] (schema_ptr s, const std::vector<mutation>& m, gc_clock::time_point t) -> mutation_source {
@@ -1740,7 +1743,7 @@ void run_mutation_source_tests(populate_fn_ex populate) {
             return downgrade_to_v1(
                     ms.make_reader_v2(s, std::move(permit), pr, slice, pc, std::move(tr), fwd, mr_fwd));
         });
-    });
+    }, with_partition_range_forwarding);
 
     // ? -> v1 -> v2 -> *
     run_mutation_reader_tests([populate] (schema_ptr s, const std::vector<mutation>& m, gc_clock::time_point t) -> mutation_source {
@@ -1755,7 +1758,7 @@ void run_mutation_source_tests(populate_fn_ex populate) {
             return upgrade_to_v2(
                     ms.make_reader(s, std::move(permit), pr, slice, pc, std::move(tr), fwd, mr_fwd));
         });
-    });
+    }, with_partition_range_forwarding);
 }
 
 struct mutation_sets {

--- a/test/lib/mutation_source_test.hh
+++ b/test/lib/mutation_source_test.hh
@@ -28,8 +28,8 @@ using populate_fn = std::function<mutation_source(schema_ptr s, const std::vecto
 using populate_fn_ex = std::function<mutation_source(schema_ptr s, const std::vector<mutation>&, gc_clock::time_point)>;
 
 // Must be run in a seastar thread
-void run_mutation_source_tests(populate_fn populate);
-void run_mutation_source_tests(populate_fn_ex populate);
+void run_mutation_source_tests(populate_fn populate, bool with_partition_range_forwarding = true);
+void run_mutation_source_tests(populate_fn_ex populate, bool with_partition_range_forwarding = true);
 
 enum are_equal { no, yes };
 

--- a/thrift/handler.cc
+++ b/thrift/handler.cc
@@ -769,7 +769,7 @@ public:
                 std::vector<EndpointDetails> eds;
                 std::transform(tr._endpoint_details.begin(), tr._endpoint_details.end(), std::back_inserter(eds), [](auto&& ed) {
                     EndpointDetails detail;
-                    detail.__set_host(ed._host);
+                    detail.__set_host(boost::lexical_cast<std::string>(ed._host));
                     detail.__set_datacenter(ed._datacenter);
                     detail.__set_rack(ed._rack);
                     return detail;


### PR DESCRIPTION
This is the 2nd PR in series with the goal to finish the hackathon project authored by @tgrabiec, @kostja, @amnonh and @mmatczuk (improved virtual tables + function call syntax in CQL). This one introduces a new implementation of the virtual tables, the streaming tables, which are suitable for large amounts of data.

This PR was created by @jul-stas and @StarostaGit