### PR TITLE
main: fix max-io-requests spelling in warning text

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -315,7 +315,7 @@ verify_seastar_io_scheduler(const boost::program_options::variables_map& opts, b
         note_bad_conf("none of --max-io-requests, --io-properties and --io-properties-file are set.");
     }
     if (opts.contains("max-io-requests") && opts["max-io-requests"].as<unsigned>() < 4) {
-        auto cause = format("I/O Queue capacity for this shard is too low ({:d}, minimum 4 expected).", opts["max_io_requests"].as<unsigned>());
+        auto cause = format("I/O Queue capacity for this shard is too low ({:d}, minimum 4 expected).", opts["max-io-requests"].as<unsigned>());
         note_bad_conf(cause);
     }
 }


### PR DESCRIPTION
An incorrect spelling of max-io-requests was used in creating the warning message text. Due to conversion to unsigned, the code would crash due to bad_lexical_cast exception. The spelling of this configuration name was fixed in the past (44f3ad836bf), but only in the `if` condition.

Fix by using the correct spelling.