### PR TITLE
logalloc: do not capture backtraces by default in debug mode

### DIFF
--- a/db/config.cc
+++ b/db/config.cc
@@ -825,6 +825,8 @@ db::config::config(std::shared_ptr<db::extensions> exts)
         "\t'datacenter_name':N [,...], (Default: 'dc1:1') IFF the class is NetworkTopologyStrategy, assign replication factors to each data center in a comma separated list.\n"
         "\n"
         "Related information: About replication strategy.")
+    , sanitizer_report_backtrace(this, "sanitizer_report_backtrace", value_status::Used, false,
+            "In debug mode, report log-structured allocator sanitizer violations with a backtrace. Slow.")
     , restrict_replication_simplestrategy(this, "restrict_replication_simplestrategy", liveness::LiveUpdate, value_status::Used, db::tri_mode_restriction_t::mode::FALSE, "Controls whether to disable SimpleStrategy replication. Can be true, false, or warn.")
     , restrict_dtcs(this, "restrict_dtcs", liveness::LiveUpdate, value_status::Used, db::tri_mode_restriction_t::mode::FALSE, "Controls whether to prevent setting DateTieredCompactionStrategy. Can be true, false, or warn.")
     , default_log_level(this, "default_log_level", value_status::Used)

--- a/db/config.hh
+++ b/db/config.hh
@@ -354,6 +354,8 @@ public:
     named_value<uint16_t> redis_database_count;
     named_value<string_map> redis_keyspace_replication_strategy_options;
 
+    named_value<bool> sanitizer_report_backtrace;
+
     // Options to restrict (forbid, warn or somehow limit) certain operations
     // or options which non-expert users are more likely to regret than to
     // enjoy:

--- a/main.cc
+++ b/main.cc
@@ -613,6 +613,7 @@ int main(int ac, char** av) {
                 st_cfg.abort_on_lsa_bad_alloc = cfg->abort_on_lsa_bad_alloc();
                 st_cfg.lsa_reclamation_step = cfg->lsa_reclamation_step();
                 st_cfg.background_reclaim_sched_group = background_reclaim_scheduling_group;
+                st_cfg.sanitizer_report_backtrace = cfg->sanitizer_report_backtrace();
                 logalloc::shard_tracker().configure(st_cfg);
             }).get();
 

--- a/utils/logalloc.hh
+++ b/utils/logalloc.hh
@@ -432,6 +432,7 @@ public:
     struct config {
         bool defragment_on_idle;
         bool abort_on_lsa_bad_alloc;
+        bool sanitizer_report_backtrace = false; // Better reports but slower
         size_t lsa_reclamation_step;
         scheduling_group background_reclaim_sched_group;
     };


### PR DESCRIPTION
logalloc has a nice leak/double-free sanitizer, with the nice
feature of capturing backtraces to make error reports easy to
track down. But capturing backtraces is itself very expensive.

This patch makes backtrace capture optional, reducing database_test
runtime from 30 minutes to 20 minutes on my machine.