### PR TITLE
Remove the mutation-based restriction checks

### DIFF
--- a/cql3/expr/expression.cc
+++ b/cql3/expr/expression.cc
@@ -101,9 +101,10 @@ struct column_value_eval_bag {
 };
 
 /// Returns col's value from queried data.
-managed_bytes_opt get_value_from_partition_slice(
-        const column_value& col, row_data_from_partition_slice data, const query_options& options) {
+managed_bytes_opt get_value(const column_value& col, const column_value_eval_bag& bag) {
     auto cdef = col.col;
+    const row_data_from_partition_slice& data = bag.row_data;
+    const query_options& options = bag.options;
     if (col.sub) {
         auto col_type = static_pointer_cast<const collection_type_impl>(cdef->type);
         if (!col_type->is_map()) {
@@ -133,11 +134,6 @@ managed_bytes_opt get_value_from_partition_slice(
             throw exceptions::unsupported_operation_exception("Unknown column kind");
         }
     }
-}
-
-/// Returns col's value from the fetched data.
-managed_bytes_opt get_value(const column_value& col, const column_value_eval_bag& bag) {
-    return get_value_from_partition_slice(col, bag.row_data, bag.options);
 }
 
 /// Type for comparing results of get_value().

--- a/cql3/expr/expression.hh
+++ b/cql3/expr/expression.hh
@@ -137,12 +137,6 @@ extern bool is_satisfied_by(
         const query::result_row_view& static_row, const query::result_row_view* row,
         const selection::selection&, const query_options&);
 
-/// True iff restr is satisfied with respect to the row provided from a mutation.
-extern bool is_satisfied_by(
-        const expression& restr,
-        const schema& schema, const partition_key& key, const clustering_key_prefix& ckey, const row& cells,
-        const query_options& options, gc_clock::time_point now);
-
 /// Finds the first binary_operator in restr that represents a bound and returns its RHS as a tuple.  If no
 /// such binary_operator exists, returns an empty vector.  The search is depth first.
 extern std::vector<managed_bytes_opt> first_multicolumn_bound(const expression&, const query_options&, statements::bound);

--- a/database.hh
+++ b/database.hh
@@ -1001,7 +1001,7 @@ public:
 private:
     future<row_locker::lock_holder> do_push_view_replica_updates(schema_ptr s, mutation m, db::timeout_clock::time_point timeout, mutation_source source,
             tracing::trace_state_ptr tr_state, reader_concurrency_semaphore& sem, const io_priority_class& io_priority, query::partition_slice::option_set custom_opts) const;
-    std::vector<view_ptr> affected_views(const schema_ptr& base, const mutation& update, gc_clock::time_point now) const;
+    std::vector<view_ptr> affected_views(const schema_ptr& base, const mutation& update) const;
     future<> generate_and_propagate_view_updates(const schema_ptr& base,
             reader_permit permit,
             std::vector<db::view::view_and_base>&& views,

--- a/db/view/view.hh
+++ b/db/view/view.hh
@@ -92,11 +92,10 @@ struct view_and_base {
  * @param base the base table schema.
  * @param view_info the view info.
  * @param key the partition key that is updated.
- * @param time_point time of the operation (for handling liveness: TTL, tombstones, etc).
  * @return false if we can guarantee that inserting an update for specified key
  * won't affect the view in any way, true otherwise.
  */
-bool partition_key_matches(const schema& base, const view_info& view, const dht::decorated_key& key, gc_clock::time_point now);
+bool partition_key_matches(const schema& base, const view_info& view, const dht::decorated_key& key);
 
 /**
  * Whether the view might be affected by the provided update.
@@ -108,11 +107,10 @@ bool partition_key_matches(const schema& base, const view_info& view, const dht:
  * @param view_info the view info.
  * @param key the partition key that is updated.
  * @param update the base table update being applied.
- * @param time_point time of the operation (for handling liveness: TTL, tombstones, etc).
  * @return false if we can guarantee that inserting update for key
  * won't affect the view in any way, true otherwise.
  */
-bool may_be_affected_by(const schema& base, const view_info& view, const dht::decorated_key& key, const rows_entry& update, gc_clock::time_point now);
+bool may_be_affected_by(const schema& base, const view_info& view, const dht::decorated_key& key, const rows_entry& update);
 
 /**
  * Whether a given base row matches the view filter (and thus if the view should have a corresponding entry).
@@ -133,7 +131,7 @@ bool may_be_affected_by(const schema& base, const view_info& view, const dht::de
  */
 bool matches_view_filter(const schema& base, const view_info& view, const partition_key& key, const clustering_row& update, gc_clock::time_point now);
 
-bool clustering_prefix_matches(const schema& base, const partition_key& key, const clustering_key_prefix& ck, gc_clock::time_point now);
+bool clustering_prefix_matches(const schema& base, const partition_key& key, const clustering_key_prefix& ck);
 
 class view_updates final {
     view_ptr _view;
@@ -226,8 +224,7 @@ future<query::clustering_row_ranges> calculate_affected_clustering_ranges(
         const schema& base,
         const dht::decorated_key& key,
         const mutation_partition& mp,
-        const std::vector<view_and_base>& views,
-        gc_clock::time_point now);
+        const std::vector<view_and_base>& views);
 
 struct wait_for_all_updates_tag {};
 using wait_for_all_updates = bool_class<wait_for_all_updates_tag>;


### PR DESCRIPTION
This series unifies the interface for checking if CQL restrictions are satisfied. Previously, an additional mutation-based approach was added in the materialized views layer, but the decision was reached that it's better to have a single API based on partition slices. With that, the regular selection path gets simplified at the cost of more complicated view generation path, which is a good tradeoff.
Note that in order to unify the interface, the view layer performs ugly transformations in order to adjust the input for `is_satisfied_by`. Reviewers, please take a close look at this code (`matches_view_filter`, `clustering_prefix_matches`, `partition_key_matches`), because it looks error-prone and relies on dirty internals of our serialization layer. If somebody has a better suggestion on how to do the transformation, I'm all ears.

Tests: unit(release), manual(playing with materialized views with custom filters)
Fixes #7215 