### PR TITLE
scylla_io_setup: check root privilege on root mode

### DIFF
--- a/dist/common/scripts/scylla_io_setup
+++ b/dist/common/scripts/scylla_io_setup
@@ -176,6 +176,9 @@ def run_iotune():
                 sys.exit(1)
 
 if __name__ == "__main__":
+    if not is_nonroot() and os.getuid() > 0:
+        print('Requires root permission.')
+        sys.exit(1)
     parser = argparse.ArgumentParser(description='IO Setup script for Scylla.')
     parser.add_argument('--ami', dest='ami', action='store_true',
                         help='configure AWS AMI')


### PR DESCRIPTION
This is side effect of allowing to run scylla_io_setup in nonroot mode, the script able to run in non-root user even the installation is not nonroot mode.
Result of that, the script finally failed to write io_properties.yaml and causes permission denied.
Since the evaluation takes long time, we should run permission check before starting it.

We need to add root privilege check again, but skip it on nonroot mode.

Fixes #8915