### PR TITLE
cdc: Handle compact storage tables correctly

### DIFF
--- a/test/cql/cdc_compact_storage_test.cql
+++ b/test/cql/cdc_compact_storage_test.cql
@@ -1,0 +1,4 @@
+create table tb2 (pk int, ck int, PRIMARY KEY (pk, ck)) with compact storage and cdc = {'enabled': true, 'preimage': true, 'postimage': true};
+-- Should add 3 rows (preimage + postimage + delta). Delta has only key columns and "pk" + "ck"
+insert into tb2 (pk, ck) VALUES (2, 22) USING TTL 2222;
+select "cdc$batch_seq_no", "cdc$operation", "cdc$ttl", pk, ck from tb2_scylla_cdc_log;

--- a/test/cql/cdc_compact_storage_test.result
+++ b/test/cql/cdc_compact_storage_test.result
@@ -1,0 +1,28 @@
+create table tb2 (pk int, ck int, PRIMARY KEY (pk, ck)) with compact storage and cdc = {'enabled': true, 'preimage': true, 'postimage': true};
+{
+	"status" : "ok"
+}
+-- Should add 3 rows (preimage + postimage + delta). Delta has only key columns and "pk" + "ck"
+insert into tb2 (pk, ck) VALUES (2, 22) USING TTL 2222;
+{
+	"status" : "ok"
+}
+select "cdc$batch_seq_no", "cdc$operation", "cdc$ttl", pk, ck from tb2_scylla_cdc_log;
+{
+	"rows" : 
+	[
+		{
+			"cdc$batch_seq_no" : "0",
+			"cdc$operation" : "1",
+			"cdc$ttl" : "2222",
+			"ck" : "22",
+			"pk" : "2"
+		},
+		{
+			"cdc$batch_seq_no" : "1",
+			"cdc$operation" : "9",
+			"ck" : "22",
+			"pk" : "2"
+		}
+	]
+}


### PR DESCRIPTION
When a table with compact storage has no regular column (only primary
key columns), an artificial column of type empty is added. Such column
type can't be returned via CQL so CDC Log shouldn't contain a column
that reflects this artificial column.

This patch does two things:
1. Make sure that CDC Log schema does not contain columns that reflect
   the artificial column from a base table.
2. When composing mutation to CDC Log, ommit the artificial column.

Fixes #8410

Signed-off-by: Piotr Jastrzebski <piotr@scylladb.com>