### PR TITLE
build, treewide: enable -Wpessimizing-move warning

### DIFF
--- a/api/column_family.hh
+++ b/api/column_family.hh
@@ -77,7 +77,7 @@ struct map_reduce_column_families_locally {
     future<std::unique_ptr<std::any>> operator()(database& db) const {
         auto res = seastar::make_lw_shared<std::unique_ptr<std::any>>(std::make_unique<std::any>(init));
         return do_for_each(db.get_column_families(), [res, this](const std::pair<utils::UUID, seastar::lw_shared_ptr<table>>& i) {
-            *res = std::move(reducer(std::move(*res), mapper(*i.second.get())));
+            *res = reducer(std::move(*res), mapper(*i.second.get()));
         }).then([res] {
             return std::move(*res);
         });

--- a/configure.py
+++ b/configure.py
@@ -1290,7 +1290,6 @@ warnings = [
     '-Wno-inconsistent-missing-override',
     '-Wno-defaulted-function-deleted',
     '-Wno-redeclared-class-member',
-    '-Wno-pessimizing-move',
     '-Wno-redundant-move',
     '-Wno-unsupported-friend',
     '-Wno-unused-variable',

--- a/cql3/constants.hh
+++ b/cql3/constants.hh
@@ -198,7 +198,7 @@ public:
             if (bytes.is_unset_value()) {
                 return UNSET_VALUE;
             }
-            return ::make_shared<constants::value>(std::move(cql3::raw_value::make_value(bytes)));
+            return ::make_shared<constants::value>(cql3::raw_value::make_value(bytes));
         }
     };
 

--- a/cql3/functions/functions.cc
+++ b/cql3/functions/functions.cc
@@ -452,7 +452,7 @@ function_call::bind_and_get(const query_options& options) {
         if (!val) {
             throw exceptions::invalid_request_exception(format("Invalid null value for argument to {}", *_fun));
         }
-        buffers.push_back(std::move(to_bytes_opt(val)));
+        buffers.push_back(to_bytes_opt(val));
     }
     auto result = execute_internal(options.get_cql_serialization_format(), *_fun, std::move(buffers));
     return cql3::raw_value_view::make_temporary(cql3::raw_value::make_value(result));
@@ -569,7 +569,7 @@ function_call::raw::execute(scalar_function& fun, std::vector<shared_ptr<term>> 
     for (auto&& t : parameters) {
         assert(dynamic_cast<terminal*>(t.get()));
         auto&& param = static_cast<terminal*>(t.get())->get(query_options::DEFAULT);
-        buffers.push_back(std::move(to_bytes_opt(param)));
+        buffers.push_back(to_bytes_opt(param));
     }
 
     return execute_internal(cql_serialization_format::internal(), fun, buffers);

--- a/cql3/query_options.cc
+++ b/cql3/query_options.cc
@@ -133,7 +133,7 @@ query_options::query_options(std::unique_ptr<query_options> qo, lw_shared_ptr<se
         std::move(qo->_values),
         std::move(qo->_value_views),
         qo->_skip_metadata,
-        std::move(query_options::specific_options{qo->_options.page_size, paging_state, qo->_options.serial_consistency, qo->_options.timestamp}),
+        query_options::specific_options{qo->_options.page_size, paging_state, qo->_options.serial_consistency, qo->_options.timestamp},
         qo->_cql_serialization_format) {
 
 }
@@ -145,7 +145,7 @@ query_options::query_options(std::unique_ptr<query_options> qo, lw_shared_ptr<se
         std::move(qo->_values),
         std::move(qo->_value_views),
         qo->_skip_metadata,
-        std::move(query_options::specific_options{page_size, paging_state, qo->_options.serial_consistency, qo->_options.timestamp}),
+        query_options::specific_options{page_size, paging_state, qo->_options.serial_consistency, qo->_options.timestamp},
         qo->_cql_serialization_format) {
 
 }

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -1244,7 +1244,7 @@ indexed_table_select_statement::read_posting_list(service::storage_proxy& proxy,
             query::result_view::consume(*qr.query_result,
                                         std::move(partition_slice),
                                         cql3::selection::result_set_builder::visitor(builder, *_view_schema, *selection));
-            return ::make_shared<cql_transport::messages::result_message::rows>(std::move(result(builder.build())));
+            return ::make_shared<cql_transport::messages::result_message::rows>(result(builder.build()));
         });
     }
 

--- a/cql3/values.hh
+++ b/cql3/values.hh
@@ -201,10 +201,10 @@ class raw_value {
     {}
 public:
     static raw_value make_null() {
-        return raw_value{std::move(null_value{})};
+        return raw_value{null_value{}};
     }
     static raw_value make_unset_value() {
-        return raw_value{std::move(unset_value{})};
+        return raw_value{unset_value{}};
     }
     static raw_value make_value(const raw_value_view& view);
     static raw_value make_value(managed_bytes&& mb) {

--- a/db/view/build_progress_virtual_reader.hh
+++ b/db/view/build_progress_virtual_reader.hh
@@ -143,7 +143,7 @@ class build_progress_virtual_reader {
                         _previous_clustering_key = ck;
                         mf = mutation_fragment(*_schema, _permit, clustering_row(
                                 std::move(ck),
-                                std::move(scylla_in_progress_row.tomb()),
+                                scylla_in_progress_row.tomb(),
                                 std::move(scylla_in_progress_row.marker()),
                                 std::move(legacy_in_progress_row)));
                     } else if (mf.is_range_tombstone()) {

--- a/db/virtual_table.cc
+++ b/db/virtual_table.cc
@@ -97,7 +97,7 @@ mutation_source memtable_filling_virtual_table::as_mutation_source() {
                     });
                 }
 
-                return std::move(rd);
+                return rd;
             });
         };
 

--- a/flat_mutation_reader.hh
+++ b/flat_mutation_reader.hh
@@ -557,7 +557,7 @@ public:
             // most close implementations are expexcted to return a ready future
             // so expedite prcessing it.
             if (f.available() && !f.failed()) {
-                return std::move(f);
+                return f;
             }
             // close must not fail
             return f.handle_exception([i = std::move(i)] (std::exception_ptr ep) mutable {

--- a/flat_mutation_reader_v2.hh
+++ b/flat_mutation_reader_v2.hh
@@ -592,7 +592,7 @@ public:
             // most close implementations are expexcted to return a ready future
             // so expedite prcessing it.
             if (f.available() && !f.failed()) {
-                return std::move(f);
+                return f;
             }
             // close must not fail
             return f.handle_exception([i = std::move(i)] (std::exception_ptr ep) mutable {

--- a/hashers.cc
+++ b/hashers.cc
@@ -90,7 +90,7 @@ template <typename T, size_t size> bytes cryptopp_hasher<T, size>::calculate(con
     typename cryptopp_hasher<T, size>::impl::impl_type hash;
     unsigned char digest[size];
     hash.CalculateDigest(digest, reinterpret_cast<const unsigned char*>(s.data()), s.size());
-    return std::move(bytes{reinterpret_cast<const int8_t*>(digest), size});
+    return bytes{reinterpret_cast<const int8_t*>(digest), size};
 }
 
 template class cryptopp_hasher<md5_hasher, 16>;

--- a/locator/ec2_snitch.cc
+++ b/locator/ec2_snitch.cc
@@ -70,8 +70,8 @@ future<sstring> ec2_snitch::aws_api_call(sstring addr, uint16_t port, sstring cm
     return connect(socket_address(inet_address{addr}, port))
     .then([this, addr, cmd] (connected_socket fd) {
         _sd = std::move(fd);
-        _in = std::move(_sd.input());
-        _out = std::move(_sd.output());
+        _in = _sd.input();
+        _out = _sd.output();
         _zone_req = sstring("GET ") + cmd +
                     sstring(" HTTP/1.1\r\nHost: ") +addr +
                     sstring("\r\n\r\n");

--- a/locator/production_snitch_base.cc
+++ b/locator/production_snitch_base.cc
@@ -144,7 +144,7 @@ future<> production_snitch_base::load_property_file() {
                 return f.dma_read_exactly<char>(0, s);
             });
         }).then([this] (temporary_buffer<char> tb) {
-            _prop_file_contents = std::move(std::string(tb.get(), _prop_file_size));
+            _prop_file_contents = std::string(tb.get(), _prop_file_size);
             parse_property_file();
 
             return make_ready_future<>();

--- a/message/messaging_service.cc
+++ b/message/messaging_service.cc
@@ -879,7 +879,7 @@ messaging_service::make_sink_and_source_for_stream_mutation_fragments(utils::UUI
         auto rpc_handler = rpc()->make_client<rpc::source<int32_t> (utils::UUID, utils::UUID, utils::UUID, uint64_t, streaming::stream_reason, rpc::sink<frozen_mutation_fragment, streaming::stream_mutation_fragments_cmd>)>(messaging_verb::STREAM_MUTATION_FRAGMENTS);
         return rpc_handler(*rpc_client , plan_id, schema_id, cf_id, estimated_partitions, reason, sink).then_wrapped([sink, rpc_client] (future<rpc::source<int32_t>> source) mutable {
             return (source.failed() ? sink.close() : make_ready_future<>()).then([sink = std::move(sink), source = std::move(source)] () mutable {
-                return make_ready_future<value_type>(value_type(std::move(sink), std::move(source.get0())));
+                return make_ready_future<value_type>(value_type(std::move(sink), source.get0()));
             });
         });
     });

--- a/querier.cc
+++ b/querier.cc
@@ -208,7 +208,7 @@ static std::unique_ptr<querier_base> find_querier(querier_cache::index& index, u
     tracing::trace(trace_state, "Found cached querier for key {} and range(s) {}", key, ranges);
     auto ptr = std::move(it->second);
     index.erase(it);
-    return std::move(ptr);
+    return ptr;
 }
 
 querier_cache::querier_cache(std::chrono::seconds entry_ttl)

--- a/reader_concurrency_semaphore.cc
+++ b/reader_concurrency_semaphore.cc
@@ -535,7 +535,7 @@ flat_mutation_reader reader_concurrency_semaphore::detach_inactive_reader(inacti
             break;
     }
     --_stats.inactive_reads;
-    return std::move(reader);
+    return reader;
 }
 
 void reader_concurrency_semaphore::evict(inactive_read& ir, evict_reason reason) noexcept {

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -892,7 +892,7 @@ public:
                 _stop_promise->set_value();
             }
         });
-        return std::move(ret);
+        return ret;
     }
 
     static std::unordered_map<node_repair_meta_id, lw_shared_ptr<repair_meta>>& repair_meta_map();

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -2628,7 +2628,7 @@ future<> storage_proxy::send_hint_to_all_replicas(frozen_mutation_and_schema fm_
         return mutate_internal(std::move(ms), db::consistency_level::ALL, false, nullptr, empty_service_permit());
     }
 
-    std::array<hint_wrapper, 1> ms{hint_wrapper { std::move(fm_a_s.fm.unfreeze(fm_a_s.s)) }};
+    std::array<hint_wrapper, 1> ms{hint_wrapper { fm_a_s.fm.unfreeze(fm_a_s.s) }};
     return mutate_internal(std::move(ms), db::consistency_level::ALL, false, nullptr, empty_service_permit());
 }
 

--- a/test/boost/double_decker_test.cc
+++ b/test/boost/double_decker_test.cc
@@ -187,11 +187,11 @@ SEASTAR_THREAD_TEST_CASE(test_self_iterator) {
     collection c(compound_key::less_compare{});
     test_data::compare cmp;
 
-    c.insert(1, std::move(test_data(1, "a")), cmp);
-    c.insert(1, std::move(test_data(1, "b")), cmp);
-    c.insert(2, std::move(test_data(2, "c")), cmp);
-    c.insert(3, std::move(test_data(3, "d")), cmp);
-    c.insert(3, std::move(test_data(3, "e")), cmp);
+    c.insert(1, test_data(1, "a"), cmp);
+    c.insert(1, test_data(1, "b"), cmp);
+    c.insert(2, test_data(2, "c"), cmp);
+    c.insert(3, test_data(3, "d"), cmp);
+    c.insert(3, test_data(3, "e"), cmp);
 
     auto erase_by_ptr = [&] (int key, std::string sub) {
         test_data* d = &*c.find(compound_key(key, sub), cmp);
@@ -215,7 +215,7 @@ SEASTAR_THREAD_TEST_CASE(test_end_iterator) {
     collection c(compound_key::less_compare{});
     test_data::compare cmp;
 
-    c.insert(1, std::move(test_data(1, "a")), cmp);
+    c.insert(1, test_data(1, "a"), cmp);
     auto i = std::prev(c.end());
     BOOST_REQUIRE(*i == compound_key(1, "a"));
 
@@ -291,7 +291,7 @@ SEASTAR_THREAD_TEST_CASE(test_insert_and_erase) {
         compound_key k(tests::random::get_int<int>(100), tests::random::get_sstring(3));
 
         if (c.find(k, cmp) == c.end()) {
-            auto it = c.insert(k.key, std::move(test_data(k.key, k.sub_key)), cmp);
+            auto it = c.insert(k.key, test_data(k.key, k.sub_key), cmp);
             BOOST_REQUIRE(*it == k);
             nr++;
         }
@@ -331,7 +331,7 @@ SEASTAR_THREAD_TEST_CASE(test_compaction) {
                 compound_key k(tests::random::get_int<int>(400), tests::random::get_sstring(3));
 
                 if (c.find(k, cmp) == c.end()) {
-                    auto it = c.insert(k.key, std::move(test_data(k.key, k.sub_key)), cmp);
+                    auto it = c.insert(k.key, test_data(k.key, k.sub_key), cmp);
                     BOOST_REQUIRE(*it == k);
                     s.insert(std::move(k));
                     nr++;
@@ -368,7 +368,7 @@ SEASTAR_THREAD_TEST_CASE(test_range_erase) {
             collection c(compound_key::less_compare{});
 
             for (auto&& k : keys) {
-                c.insert(k.key, std::move(test_data(k.key, k.sub_key)), cmp);
+                c.insert(k.key, test_data(k.key, k.sub_key), cmp);
             }
 
             auto iter_at = [&c] (size_t at) -> collection::iterator {

--- a/test/boost/flat_mutation_reader_test.cc
+++ b/test/boost/flat_mutation_reader_test.cc
@@ -754,7 +754,7 @@ SEASTAR_THREAD_TEST_CASE(test_mutation_reader_from_fragments_as_mutation_source)
                     fragments.emplace_back(std::move(mf));
                     return stop_iteration::no;
                 }, db::no_timeout).get();
-                return std::move(fragments);
+                return fragments;
             };
 
             auto rd = make_flat_mutation_reader_from_fragments(schema, tests::make_permit(), get_fragments(), range, slice);

--- a/test/boost/mutation_reader_test.cc
+++ b/test/boost/mutation_reader_test.cc
@@ -3097,7 +3097,7 @@ flat_mutation_reader create_evictable_reader_and_evict_after_first_buffer(
 
     while(permit.semaphore().try_evict_one_inactive_read());
 
-    return std::move(rd);
+    return rd;
 }
 
 flat_mutation_reader create_evictable_reader_and_evict_after_first_buffer(

--- a/test/boost/sstable_datafile_test.cc
+++ b/test/boost/sstable_datafile_test.cc
@@ -4987,7 +4987,7 @@ SEASTAR_THREAD_TEST_CASE(test_scrub_segregate_stack) {
         size_t i = 0;
         for (const auto& segregated_fragment_stream : segregated_fragment_streams) {
             testlog.debug("Checking position monotonicity of segregated stream #{}", i++);
-            assert_that(make_flat_mutation_reader_from_fragments(schema, permit, std::move(copy_fragments(segregated_fragment_stream))))
+            assert_that(make_flat_mutation_reader_from_fragments(schema, permit, copy_fragments(segregated_fragment_stream)))
                     .has_monotonic_positions();
         }
     }
@@ -4998,7 +4998,7 @@ SEASTAR_THREAD_TEST_CASE(test_scrub_segregate_stack) {
         readers.reserve(segregated_fragment_streams.size());
 
         for (const auto& segregated_fragment_stream : segregated_fragment_streams) {
-            readers.emplace_back(make_flat_mutation_reader_from_fragments(schema, permit, std::move(copy_fragments(segregated_fragment_stream))));
+            readers.emplace_back(make_flat_mutation_reader_from_fragments(schema, permit, copy_fragments(segregated_fragment_stream)));
         }
 
         assert_that(make_combined_reader(schema, permit, std::move(readers))).has_monotonic_positions();
@@ -5010,7 +5010,7 @@ SEASTAR_THREAD_TEST_CASE(test_scrub_segregate_stack) {
         readers.reserve(segregated_fragment_streams.size());
 
         for (const auto& segregated_fragment_stream : segregated_fragment_streams) {
-            readers.emplace_back(make_flat_mutation_reader_from_fragments(schema, permit, std::move(copy_fragments(segregated_fragment_stream))));
+            readers.emplace_back(make_flat_mutation_reader_from_fragments(schema, permit, copy_fragments(segregated_fragment_stream)));
         }
 
         auto rd = assert_that(make_combined_reader(schema, permit, std::move(readers)));

--- a/test/raft/helpers.hh
+++ b/test/raft/helpers.hh
@@ -92,7 +92,7 @@ raft::command create_command(T val) {
     raft::command command;
     ser::serialize(command, val);
 
-    return std::move(command);
+    return command;
 }
 
 raft::fsm_config fsm_cfg{.append_request_threshold = 1, .enable_prevoting = false};

--- a/test/unit/bptree_compaction_test.cc
+++ b/test/unit/bptree_compaction_test.cc
@@ -75,7 +75,7 @@ int main(int argc, char **argv) {
             stress_compact_collection(cfg,
                 /* insert */ [&] (int key) {
                     test_key k(key);
-                    auto ti = t->emplace(std::move(copy_key(k)), k);
+                    auto ti = t->emplace(copy_key(k), k);
                     assert(ti.second);
                 },
                 /* erase */ [&] (int key) {

--- a/test/unit/bptree_stress_test.cc
+++ b/test/unit/bptree_stress_test.cc
@@ -91,11 +91,11 @@ int main(int argc, char **argv) {
                     test_key k(key);
 
                     if (rep % 2 != 1) {
-                        auto ir = t->emplace(std::move(copy_key(k)), k);
+                        auto ir = t->emplace(copy_key(k), k);
                         assert(ir.second);
                     } else {
                         auto ir = t->lower_bound(k);
-                        ir.emplace_before(std::move(copy_key(k)), test_key_compare{}, k);
+                        ir.emplace_before(copy_key(k), test_key_compare{}, k);
                     }
                     oracle[key] = key + 10;
 

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -664,7 +664,7 @@ future<> cql_server::connection::process_request() {
             (void)_process_request_stage(this, istream, op, stream, seastar::ref(_client_state), tracing_requested, mem_permit)
                     .then_wrapped([this, buf = std::move(buf), mem_permit, leave = std::move(leave)] (future<foreign_ptr<std::unique_ptr<cql_server::response>>> response_f) mutable {
                 try {
-                    write_response(std::move(response_f.get0()), std::move(mem_permit), _compression);
+                    write_response(response_f.get0(), std::move(mem_permit), _compression);
                     _ready_to_respond = _ready_to_respond.finally([leave = std::move(leave)] {});
                 } catch (...) {
                     clogger.error("request processing failed: {}", std::current_exception());

--- a/types.cc
+++ b/types.cc
@@ -2697,7 +2697,7 @@ struct from_string_visitor {
                 field_len[i] = fields[i].size();
             }
         }
-        return std::move(concat_fields(fields, field_len));
+        return concat_fields(fields, field_len);
     }
     bytes operator()(const collection_type_impl&) {
         // FIXME:


### PR DESCRIPTION
This warning prevents using std::move() where it can hurt
- on an unnamed temporary or a named automatic variable being
returned from a function. In both cases the value could be
constructed directly in its final destination, but std::move()
prevents it.

Fix the handful of cases (all trivial), and enable the warning.