### PR TITLE
cql-pytest: Test selecting from indexed table using only clustering key

### DIFF
--- a/test/cql-pytest/test_secondary_index.py
+++ b/test/cql-pytest/test_secondary_index.py
@@ -21,6 +21,7 @@ import time
 import pytest
 from cassandra.protocol import SyntaxException, AlreadyExists, InvalidRequest, ConfigurationException, ReadFailure, WriteFailure
 from cassandra.query import SimpleStatement
+from cassandra_tests.porting import assert_rows
 
 from util import new_test_table, unique_name
 
@@ -227,3 +228,17 @@ def test_too_large_indexed_value(cql, test_keyspace):
         big = 'x'*66536
         with pytest.raises(WriteFailure):
             cql.execute(f"INSERT INTO {table}(p,c,v) VALUES (0,1,'{big}')")
+
+# Selecting values using only clustering key should require filtering, but work correctly
+# Reproduces issue #8991
+@pytest.mark.xfail(reason="Select from indexed table using only clustering key breaks. Issue #8991")
+def test_filter_cluster_key(cql, test_keyspace):
+    schema = 'p int, c1 int, c2 int, primary key (p, c1, c2)'
+    with new_test_table(cql, test_keyspace, schema) as table:
+        cql.execute(f"CREATE INDEX ON {table}(c2)")
+        cql.execute(f"INSERT INTO {table} (p, c1, c2) VALUES (0, 1, 1)")
+        cql.execute(f"INSERT INTO {table} (p, c1, c2) VALUES (0, 0, 1)")
+        
+        stmt = SimpleStatement(f"SELECT c1, c2 FROM {table} WHERE c1 = 1 and c2 = 1 ALLOW FILTERING")
+        rows = cql.execute(stmt)
+        assert_rows(rows, [1, 1])

--- a/test/cql-pytest/test_secondary_index.py
+++ b/test/cql-pytest/test_secondary_index.py
@@ -231,7 +231,6 @@ def test_too_large_indexed_value(cql, test_keyspace):
 
 # Selecting values using only clustering key should require filtering, but work correctly
 # Reproduces issue #8991
-@pytest.mark.xfail(reason="Select from indexed table using only clustering key breaks. Issue #8991")
 def test_filter_cluster_key(cql, test_keyspace):
     schema = 'p int, c1 int, c2 int, primary key (p, c1, c2)'
     with new_test_table(cql, test_keyspace, schema) as table:


### PR DESCRIPTION
Add examples from issue #8991 to tests
Both of these tests pass on `cassandra 4.0` but fail on `scylla 4.4.3`

First test tests that selecting values from indexed table using only clustering key returns correct values.
The second test tests that performing this operation requires filtering.

The filtering test looks similar to [the one for #7608](https://github.com/scylladb/scylla/blob/1924e8d2b63e6611b78ac6252b5ddbc4884f9d22/test/cql-pytest/test_allow_filtering.py#L124) but there are some differences - here the table has two clustering columns and an index, so it could test different code paths.

Contains a quick fix for the `needs_filtering()` function to make these tests pass.
It returns `true` for this case and the one described in #7708.

This implementation is a bit conservative - it might sometimes return `true` where filtering isn't actually needed, but at least it prevents scylla from returning incorrect results.

Fixes #8991.
Fixes #7708.