### PR TITLE
build, treewide: enable -Wredundant-move

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1289,7 +1289,6 @@ warnings = [
     '-Wno-inconsistent-missing-override',
     '-Wno-defaulted-function-deleted',
     '-Wno-redeclared-class-member',
-    '-Wno-redundant-move',
     '-Wno-unsupported-friend',
     '-Wno-unused-variable',
     '-Wno-delete-non-abstract-non-virtual-dtor',

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -950,7 +950,7 @@ lw_shared_ptr<const service::pager::paging_state> indexed_table_select_statement
 
     auto result_view = query::result_view(*results);
     if (!results->row_count() || *results->row_count() == 0) {
-        return std::move(paging_state);
+        return paging_state;
     }
 
     auto&& last_partition_and_clustering_key = result_view.get_last_partition_and_clustering_key();
@@ -985,7 +985,7 @@ lw_shared_ptr<const service::pager::paging_state> indexed_table_select_statement
     auto index_ck = clustering_key::from_range(std::move(exploded_index_ck));
     if (partition_key::tri_compare(*_view_schema)(paging_state->get_partition_key(), index_pk) == 0
             && (!paging_state->get_clustering_key() || clustering_key::prefix_equal_tri_compare(*_view_schema)(*paging_state->get_clustering_key(), index_ck) == 0)) {
-        return std::move(paging_state);
+        return paging_state;
     }
 
     auto paging_state_copy = make_lw_shared<service::pager::paging_state>(service::pager::paging_state(*paging_state));

--- a/db/consistency_level.cc
+++ b/db/consistency_level.cc
@@ -281,7 +281,7 @@ filter_for_query(consistency_level cl,
     size_t local_count;
 
     if (read_repair == read_repair_decision::GLOBAL) { // take RRD.GLOBAL out of the way
-        return std::move(live_endpoints);
+        return live_endpoints;
     }
 
     if (read_repair == read_repair_decision::DC_LOCAL || is_datacenter_local(cl)) {
@@ -299,7 +299,7 @@ filter_for_query(consistency_level cl,
     }
 
     if (bf >= live_endpoints.size()) { // RRD.DC_LOCAL + CL.LOCAL or CL.ALL
-        return std::move(live_endpoints);
+        return live_endpoints;
     }
 
     inet_address_vector_replica_set selected_endpoints;

--- a/db/data_listeners.cc
+++ b/db/data_listeners.cc
@@ -152,7 +152,7 @@ future<toppartitions_query::results> toppartitions_query::gather(unsigned res_si
     auto reduce = [this] (results res, foreign_ptr<std::unique_ptr<std::tuple<top_t, top_t>>> rd_wr) {
         res.read.append(toppartitions_data_listener::localize(std::get<0>(*rd_wr)));
         res.write.append(toppartitions_data_listener::localize(std::get<1>(*rd_wr)));
-        return std::move(res);
+        return res;
     };
     return _query->map_reduce0(map, results{res_size}, reduce)
         .handle_exception([] (auto ep) {

--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -683,16 +683,16 @@ static
 mutation
 redact_columns_for_missing_features(mutation m, schema_features features) {
     if (features.contains(schema_feature::CDC_OPTIONS) && features.contains(schema_feature::PER_TABLE_PARTITIONERS)) {
-        return std::move(m);
+        return m;
     }
     if (m.schema()->cf_name() != SCYLLA_TABLES) {
-        return std::move(m);
+        return m;
     }
     slogger.debug("adjusting schema_tables mutation due to possible in-progress cluster upgrade");
     // The global schema ptr make sure it will be registered in the schema registry.
     global_schema_ptr redacted_schema{scylla_tables(features)};
     m.upgrade(redacted_schema);
-    return std::move(m);
+    return m;
 }
 
 /**
@@ -782,7 +782,7 @@ adjust_schema_for_schema_features(std::vector<mutation> schema, schema_features 
     for (auto& m : schema) {
         m = redact_columns_for_missing_features(m, features);
     }
-    return std::move(schema);
+    return schema;
 }
 
 future<schema_result>

--- a/locator/token_metadata.cc
+++ b/locator/token_metadata.cc
@@ -442,7 +442,7 @@ public:
         }
         all_left_metadata.sort_tokens();
 
-        return std::move(all_left_metadata);
+        return all_left_metadata;
       });
     }
 

--- a/service/misc_services.cc
+++ b/service/misc_services.cc
@@ -182,7 +182,7 @@ future<lowres_clock::duration> cache_hitrate_calculator::recalculate_hitrates() 
         for (auto& r : b) {
             a[r.first] += r.second;
         }
-        return std::move(a);
+        return a;
     };
 
     return _db.map_reduce0(cf_to_cache_hit_stats, std::unordered_map<utils::UUID, stat>(), sum_stats_per_cf).then([this, non_system_filter] (std::unordered_map<utils::UUID, stat> rates) mutable {

--- a/table.cc
+++ b/table.cc
@@ -594,7 +594,7 @@ table::seal_active_memtable(flush_permit&& permit) {
         _config.cf_stats->pending_memtables_flushes_bytes -= memtable_size;
 
         if (f.failed()) {
-            return std::move(f);
+            return f;
         }
 
         if (_commitlog) {

--- a/test/boost/data_listeners_test.cc
+++ b/test/boost/data_listeners_test.cc
@@ -103,7 +103,7 @@ results test_data_listeners(cql_test_env& e, sstring cf_name) {
         [] (results res, results li_res) {
             res.read += li_res.read;
             res.write += li_res.write;
-            return std::move(res);
+            return res;
         }).get0();
 
     testlog.info("test_data_listeners: rd={} wr={}", res.read, res.write);

--- a/utils/config_file.cc
+++ b/utils/config_file.cc
@@ -262,7 +262,7 @@ bpo::options_description utils::config_file::get_options_description() {
 bpo::options_description utils::config_file::get_options_description(boost::program_options::options_description opts) {
     auto init = opts.add_options();
     add_options(init);
-    return std::move(opts);
+    return opts;
 }
 
 bpo::options_description_easy_init&


### PR DESCRIPTION
Returning a function parameter guarantees copy elision and does not
require a std::move().  Enable -Wredundant-move to warn us that the
move is unneeded, and gain slightly more readable code. A few violations
are trivially adjusted.