### PR TITLE
Harden batchlog_manager stop and call from main in deferred action

### DIFF
--- a/db/batchlog_manager.cc
+++ b/db/batchlog_manager.cc
@@ -152,6 +152,10 @@ future<> db::batchlog_manager::stop() {
     if (!_stop.abort_requested()) {
         _stop.request_abort();
     }
+    if (this_shard_id() == 0) {
+        // Abort do_batch_log_replay if waiting on the semaphore.
+        _sem.broken();
+    }
     return std::exchange(_started, make_ready_future<>()).finally([this] {
         return _gate.close();
     });

--- a/db/batchlog_manager.hh
+++ b/db/batchlog_manager.hh
@@ -107,6 +107,8 @@ public:
     batchlog_manager(cql3::query_processor&, batchlog_manager_config config);
 
     future<> start();
+    // abort the replay loop and return its future.
+    future<> drain();
     future<> stop();
 
     future<> do_batch_log_replay();

--- a/db/batchlog_manager.hh
+++ b/db/batchlog_manager.hh
@@ -47,6 +47,7 @@
 #include <seastar/core/timer.hh>
 #include <seastar/core/gate.hh>
 #include <seastar/core/metrics_registration.hh>
+#include <seastar/core/abort_source.hh>
 
 #include "gms/inet_address.hh"
 #include "inet_address_vectors.hh"
@@ -89,12 +90,12 @@ private:
     cql3::query_processor& _qp;
     db_clock::duration _write_request_timeout;
     uint64_t _replay_rate;
-    timer<clock_type> _timer;
+    future<> _started;
     std::chrono::milliseconds _delay;
     semaphore _sem{1};
     seastar::gate _gate;
     unsigned _cpu = 0;
-    bool _stop = false;
+    seastar::abort_source _stop;
 
     std::default_random_engine _e1{std::random_device{}()};
 
@@ -119,6 +120,8 @@ public:
     db_clock::duration get_batch_log_timeout() const;
 
     inet_address_vector_replica_set endpoint_filter(const sstring&, const std::unordered_map<sstring, std::unordered_set<gms::inet_address>>&);
+private:
+    future<> batchlog_replay_loop();
 };
 
 extern distributed<batchlog_manager> _the_batchlog_manager;

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -2026,7 +2026,7 @@ future<> storage_service::decommission() {
             slogger.info("DECOMMISSIONING: stopped transport");
 
             db::get_batchlog_manager().invoke_on_all([] (auto& bm) {
-                return bm.stop();
+                return bm.drain();
             }).get();
             slogger.info("DECOMMISSIONING: stop batchlog_manager done");
 
@@ -2719,7 +2719,7 @@ future<> storage_service::do_drain(bool on_shutdown) {
         flush_column_families();
 
         db::get_batchlog_manager().invoke_on_all([] (auto& bm) {
-            return bm.stop();
+            return bm.drain();
         }).get();
 
         set_mode(mode::DRAINING, "shutting down migration manager", false);


### PR DESCRIPTION
This PR contains the parts relevant to batchlog_manager stop in #8998 without adding a gate to the storage_proxy for synchronization with on-going queries in storage_proxy::drain_on_shutdown.

As explained in #9009, we see that the batchlog_manager isn't stopped if scylla shuts down during startup, e.g. when waiting for gossip to settle, since currently the batchlog_manager is stopped only from `storage_service::do_drain`, while `storage_service::drain_on_shutdown` deferred shutdown is installed only later on:
https://github.com/scylladb/scylla/blob/222ef17305b07e8faabd5d921e2bad0d7f78e106/main.cc#L1419-L1421

Fixes #9009

Test: unit(dev)
DTest: compact_storage_tests.py:TestCompactStorage.wide_row_test paging_test:TestPagingDatasetChanges.test_cell_TTL_expiry_during_paging update_cluster_layout_tests:TestUpdateClusterLayout.simple_add_new_node_while_adding_info_{1,2}_test (dev)