### PR TITLE
build: re-enable -Wmisleading-indentation

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1277,7 +1277,6 @@ warnings = [
     '-Wno-return-stack-address',
     '-Wno-missing-braces',
     '-Wno-unused-lambda-capture',
-    '-Wno-misleading-indentation',
     '-Wno-overflow',
     '-Wno-noexcept-type',
     '-Wno-nonnull-compare',


### PR DESCRIPTION
This can catch mismatches between visual indication about
control flow and what the compiler actually does. Looks like
boost cleaned up its indentation since it was disabled in
7f38634080a ("dist/debian: Switch to g++-7/boost-1.63 on
Ubuntu 14.04/16.04"). It's unlikely to pop back since modern
compilers enable it by default.