### PR TITLE
flat_mutation_reader: downgrade_to_v1 - reset state of rt_assembler

### DIFF
--- a/cql3/expr/expression.cc
+++ b/cql3/expr/expression.cc
@@ -101,9 +101,10 @@ struct column_value_eval_bag {
 };
 
 /// Returns col's value from queried data.
-managed_bytes_opt get_value_from_partition_slice(
-        const column_value& col, row_data_from_partition_slice data, const query_options& options) {
+managed_bytes_opt get_value(const column_value& col, const column_value_eval_bag& bag) {
     auto cdef = col.col;
+    const row_data_from_partition_slice& data = bag.row_data;
+    const query_options& options = bag.options;
     if (col.sub) {
         auto col_type = static_pointer_cast<const collection_type_impl>(cdef->type);
         if (!col_type->is_map()) {
@@ -133,11 +134,6 @@ managed_bytes_opt get_value_from_partition_slice(
             throw exceptions::unsupported_operation_exception("Unknown column kind");
         }
     }
-}
-
-/// Returns col's value from the fetched data.
-managed_bytes_opt get_value(const column_value& col, const column_value_eval_bag& bag) {
-    return get_value_from_partition_slice(col, bag.row_data, bag.options);
 }
 
 /// Type for comparing results of get_value().

--- a/cql3/expr/expression.hh
+++ b/cql3/expr/expression.hh
@@ -137,12 +137,6 @@ extern bool is_satisfied_by(
         const query::result_row_view& static_row, const query::result_row_view* row,
         const selection::selection&, const query_options&);
 
-/// True iff restr is satisfied with respect to the row provided from a mutation.
-extern bool is_satisfied_by(
-        const expression& restr,
-        const schema& schema, const partition_key& key, const clustering_key_prefix& ckey, const row& cells,
-        const query_options& options, gc_clock::time_point now);
-
 /// Finds the first binary_operator in restr that represents a bound and returns its RHS as a tuple.  If no
 /// such binary_operator exists, returns an empty vector.  The search is depth first.
 extern std::vector<managed_bytes_opt> first_multicolumn_bound(const expression&, const query_options&, statements::bound);

--- a/database.hh
+++ b/database.hh
@@ -1001,7 +1001,7 @@ public:
 private:
     future<row_locker::lock_holder> do_push_view_replica_updates(schema_ptr s, mutation m, db::timeout_clock::time_point timeout, mutation_source source,
             tracing::trace_state_ptr tr_state, reader_concurrency_semaphore& sem, const io_priority_class& io_priority, query::partition_slice::option_set custom_opts) const;
-    std::vector<view_ptr> affected_views(const schema_ptr& base, const mutation& update, gc_clock::time_point now) const;
+    std::vector<view_ptr> affected_views(const schema_ptr& base, const mutation& update) const;
     future<> generate_and_propagate_view_updates(const schema_ptr& base,
             reader_permit permit,
             std::vector<db::view::view_and_base>&& views,

--- a/db/view/view.hh
+++ b/db/view/view.hh
@@ -92,11 +92,10 @@ struct view_and_base {
  * @param base the base table schema.
  * @param view_info the view info.
  * @param key the partition key that is updated.
- * @param time_point time of the operation (for handling liveness: TTL, tombstones, etc).
  * @return false if we can guarantee that inserting an update for specified key
  * won't affect the view in any way, true otherwise.
  */
-bool partition_key_matches(const schema& base, const view_info& view, const dht::decorated_key& key, gc_clock::time_point now);
+bool partition_key_matches(const schema& base, const view_info& view, const dht::decorated_key& key);
 
 /**
  * Whether the view might be affected by the provided update.
@@ -108,11 +107,10 @@ bool partition_key_matches(const schema& base, const view_info& view, const dht:
  * @param view_info the view info.
  * @param key the partition key that is updated.
  * @param update the base table update being applied.
- * @param time_point time of the operation (for handling liveness: TTL, tombstones, etc).
  * @return false if we can guarantee that inserting update for key
  * won't affect the view in any way, true otherwise.
  */
-bool may_be_affected_by(const schema& base, const view_info& view, const dht::decorated_key& key, const rows_entry& update, gc_clock::time_point now);
+bool may_be_affected_by(const schema& base, const view_info& view, const dht::decorated_key& key, const rows_entry& update);
 
 /**
  * Whether a given base row matches the view filter (and thus if the view should have a corresponding entry).
@@ -133,7 +131,7 @@ bool may_be_affected_by(const schema& base, const view_info& view, const dht::de
  */
 bool matches_view_filter(const schema& base, const view_info& view, const partition_key& key, const clustering_row& update, gc_clock::time_point now);
 
-bool clustering_prefix_matches(const schema& base, const partition_key& key, const clustering_key_prefix& ck, gc_clock::time_point now);
+bool clustering_prefix_matches(const schema& base, const partition_key& key, const clustering_key_prefix& ck);
 
 class view_updates final {
     view_ptr _view;
@@ -226,8 +224,7 @@ future<query::clustering_row_ranges> calculate_affected_clustering_ranges(
         const schema& base,
         const dht::decorated_key& key,
         const mutation_partition& mp,
-        const std::vector<view_and_base>& views,
-        gc_clock::time_point now);
+        const std::vector<view_and_base>& views);
 
 struct wait_for_all_updates_tag {};
 using wait_for_all_updates = bool_class<wait_for_all_updates_tag>;

--- a/test/lib/mutation_source_test.cc
+++ b/test/lib/mutation_source_test.cc
@@ -1419,6 +1419,28 @@ void test_slicing_with_overlapping_range_tombstones(tests::reader_concurrency_se
     }
 }
 
+void test_downgrade_to_v1_clear_buffer(tests::reader_concurrency_semaphore_wrapper& semaphore, populate_fn_ex populate) {
+    simple_schema s;
+    auto pkey = s.make_pkey();
+    const size_t row_count = 100; // Enough to trigger is_buffer_full.
+
+    std::vector<mutation> mutations {{s.schema(), pkey}};
+    mutation &m = mutations.front();
+
+    s.delete_range(m, s.make_ckey_range(0, 100));
+    for (size_t i = 0; i < 100; ++i) {
+        s.add_row(m, s.make_ckey(i), "v");
+    }
+
+    auto ms = populate(s.schema(), mutations, gc_clock::now());
+    auto pr = dht::partition_range::make_singular(pkey);
+
+    assert_that(downgrade_to_v1(ms.make_reader_v2(s.schema(), semaphore.make_permit())))
+            .produces_partition_start(pkey) // Read something.
+            .next_partition()               // Next partition clears buffer.
+            .produces_end_of_stream();      // Expect no active range tombstone change at this point.
+}
+
 void test_range_tombstones_v2(tests::reader_concurrency_semaphore_wrapper& semaphore, populate_fn_ex populate) {
     simple_schema s;
     auto pkey = s.make_pkey();
@@ -1640,6 +1662,7 @@ void run_mutation_reader_tests(populate_fn_ex populate) {
     tests::reader_concurrency_semaphore_wrapper semaphore;
 
     test_range_tombstones_v2(semaphore, populate);
+    test_downgrade_to_v1_clear_buffer(semaphore, populate);
     test_reader_conversions(semaphore, populate);
     test_slicing_and_fast_forwarding(semaphore, populate);
     test_date_tiered_clustering_slicing(semaphore, populate);


### PR DESCRIPTION
The downgrade_to_v1 didn't reset the state of range tombstone assembler in case of the calls to next_partition or fast_forward_to, which caused a situation where the closing range tombstone change is cleared from the buffer before being emitted, without notifying the assembler. This patch fixes the behaviour in fast_forward_to as well.
