### PR TITLE
Fix propagating view update generation failures

### DIFF
--- a/table.cc
+++ b/table.cc
@@ -1676,14 +1676,21 @@ future<> table::generate_and_propagate_view_updates(const schema_ptr& base,
             std::move(existings),
             now);
 
+    std::exception_ptr err = nullptr;
     while (true) {
+        utils::chunked_vector<frozen_mutation_and_schema> updates;
         try {
-            auto updates = co_await builder.build_some();
-            if (updates.empty()) {
-                break;
-            }
-            tracing::trace(tr_state, "Generated {} view update mutations", updates.size());
-            auto units = seastar::consume_units(*_config.view_update_concurrency_semaphore, memory_usage_of(updates));
+            updates = co_await builder.build_some();
+        } catch (...) {
+            err = std::current_exception();
+            break;
+        }
+        if (updates.empty()) {
+            break;
+        }
+        tracing::trace(tr_state, "Generated {} view update mutations", updates.size());
+        auto units = seastar::consume_units(*_config.view_update_concurrency_semaphore, memory_usage_of(updates));
+        try {
             co_await db::view::mutate_MV(base_token, std::move(updates), _view_stats, *_config.cf_stats, tr_state,
                 std::move(units), service::allow_hints::yes, db::view::wait_for_all_updates::no).handle_exception([] (auto ignored) { });
         } catch (...) {
@@ -1694,6 +1701,9 @@ future<> table::generate_and_propagate_view_updates(const schema_ptr& base,
         }
     }
     co_await builder.close();
+    if (err) {
+        std::rethrow_exception(err);
+    }
 }
 
 /**


### PR DESCRIPTION
When the generate-and-propagate-view-updates routine was rewritten
to allow partial results, one important validation got lost:
previously, an error which occured during update *generation*
was propagated to the user - as an example, the indexed column
value must be smaller than 64kB, otherwise it cannot act as primary
key part in the underlying view. Errors on view update *propagation*
are however ignored in this layer, because it becomes a background
process.
During the rewrite these two got mixed up and so it was possible
to ignore an error that should have been propagated.
This behavior is now fixed.

Fixes #9013