### PR TITLE
flat_mutation_reader: downgrade_to_v1 - reset state of rt_assembler

### DIFF
--- a/flat_mutation_reader.hh
+++ b/flat_mutation_reader.hh
@@ -144,7 +144,7 @@ public:
         tracked_buffer _buffer;
         size_t _buffer_size = 0;
     protected:
-        size_t max_buffer_size_in_bytes = 8 * 1024;
+        size_t max_buffer_size_in_bytes = default_max_buffer_size_in_bytes();
         bool _end_of_stream = false;
         schema_ptr _schema;
         reader_permit _permit;
@@ -182,6 +182,7 @@ public:
         bool is_end_of_stream() const { return _end_of_stream; }
         bool is_buffer_empty() const { return _buffer.empty(); }
         bool is_buffer_full() const { return _buffer_size >= max_buffer_size_in_bytes; }
+        static constexpr size_t default_max_buffer_size_in_bytes() { return 8 * 1024; }
 
         mutation_fragment pop_mutation_fragment() {
             auto mf = std::move(_buffer.front());
@@ -569,6 +570,9 @@ public:
     bool is_end_of_stream() const { return _impl->is_end_of_stream(); }
     bool is_buffer_empty() const { return _impl->is_buffer_empty(); }
     bool is_buffer_full() const { return _impl->is_buffer_full(); }
+    static constexpr size_t default_max_buffer_size_in_bytes() {
+        return impl::default_max_buffer_size_in_bytes();
+    }
     mutation_fragment pop_mutation_fragment() { return _impl->pop_mutation_fragment(); }
     void unpop_mutation_fragment(mutation_fragment mf) { _impl->unpop_mutation_fragment(std::move(mf)); }
     const schema_ptr& schema() const { return _impl->_schema; }

--- a/flat_mutation_reader_v2.hh
+++ b/flat_mutation_reader_v2.hh
@@ -179,7 +179,7 @@ public:
         tracked_buffer _buffer;
         size_t _buffer_size = 0;
     protected:
-        size_t max_buffer_size_in_bytes = 8 * 1024;
+        size_t max_buffer_size_in_bytes = default_max_buffer_size_in_bytes();
 
         // The stream producer should set this to indicate that there are no
         // more fragments to produce.
@@ -223,6 +223,7 @@ public:
         bool is_end_of_stream() const { return _end_of_stream; }
         bool is_buffer_empty() const { return _buffer.empty(); }
         bool is_buffer_full() const { return _buffer_size >= max_buffer_size_in_bytes; }
+        static constexpr size_t default_max_buffer_size_in_bytes() { return 8 * 1024; }
 
         mutation_fragment_v2 pop_mutation_fragment() {
             auto mf = std::move(_buffer.front());
@@ -613,6 +614,9 @@ public:
     bool is_end_of_stream() const { return _impl->is_end_of_stream() && is_buffer_empty(); }
     bool is_buffer_empty() const { return _impl->is_buffer_empty(); }
     bool is_buffer_full() const { return _impl->is_buffer_full(); }
+    static constexpr size_t default_max_buffer_size_in_bytes() {
+        return impl::default_max_buffer_size_in_bytes();
+    }
     mutation_fragment_v2 pop_mutation_fragment() { return _impl->pop_mutation_fragment(); }
     void unpop_mutation_fragment(mutation_fragment_v2 mf) { _impl->unpop_mutation_fragment(std::move(mf)); }
     const schema_ptr& schema() const { return _impl->_schema; }


### PR DESCRIPTION
The downgrade_to_v1 didn't reset the state of range tombstone assembler
in case of the calls to next_partition or fast_forward_to, which caused
a situation where the closing range tombstone change is cleared from the
buffer before being emitted, without notifying the assembler. This patch
fixes the behaviour in fast_forward_to as well.

Fixes #9022