### PR TITLE
build: enable -Wc++1z-extensions

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1272,7 +1272,6 @@ warnings = [
     '-Wno-tautological-compare',
     '-Wno-parentheses-equality',
     '-Wno-c++11-narrowing',
-    '-Wno-c++1z-extensions',
     '-Wno-sometimes-uninitialized',
     '-Wno-return-stack-address',
     '-Wno-missing-braces',


### PR DESCRIPTION
It was disabled for the move to clang, but now apparently no longer needed. So
re-enable that warning.