### PR TITLE
install-dependencies.sh: add gdb

### DIFF
--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -29,6 +29,7 @@ fi
 
 debian_base_packages=(
     clang
+    gdb
     liblua5.3-dev
     python3-pyparsing
     python3-colorama
@@ -46,6 +47,7 @@ debian_base_packages=(
 
 fedora_packages=(
     clang
+    gdb
     lua-devel
     yaml-cpp-devel
     thrift-devel
@@ -111,6 +113,7 @@ fedora_python3_packages=(
 )
 
 centos_packages=(
+    gdb
     yaml-cpp-devel
     thrift-devel
     scylla-antlr35-tool
@@ -133,6 +136,7 @@ centos_packages=(
 #
 # aur: antlr3, antlr3-cpp-headers-git
 arch_packages=(
+    gdb
     base-devel
     filesystem
     git

--- a/tools/toolchain/Dockerfile
+++ b/tools/toolchain/Dockerfile
@@ -6,7 +6,6 @@ ADD ./tools/java/install-dependencies.sh ./tools/java/
 ADD ./tools/toolchain/system-auth ./
 RUN dnf -y install 'dnf-command(copr)' \
     && dnf -y install ccache \
-    && dnf -y install gdb \
     && dnf -y install devscripts debhelper fakeroot file rpm-build \
     && ./install-dependencies.sh && dnf -y update && dnf clean all \
     && echo 'ALL ALL=(ALL:ALL) NOPASSWD: ALL' >> /etc/sudoers \


### PR DESCRIPTION
gdb is used for testing scylla-gdb.py (since 3c2e852dd), so it needs
to be listed as a dependency. Add it there. It was listed as a
courtesy dependency in the frozen toolchain (which is why it still
worked), so it's removed from there.