### PR TITLE
Service Level Controller: Stop polling distributed data when decommissioned (reworked)

### DIFF
--- a/service/qos/service_level_controller.cc
+++ b/service/qos/service_level_controller.cc
@@ -410,4 +410,16 @@ future<> service_level_controller::do_remove_service_level(sstring name, bool re
     return make_ready_future();
 }
 
+void service_level_controller::on_join_cluster(const gms::inet_address& endpoint) { }
+
+void service_level_controller::on_leave_cluster(const gms::inet_address& endpoint) {
+    if (this_shard_id() == global_controller && endpoint == utils::fb_utilities::get_broadcast_address()) {
+        _global_controller_db->dist_data_update_aborter.request_abort();
+    }
+}
+
+void service_level_controller::on_up(const gms::inet_address& endpoint) { }
+
+void service_level_controller::on_down(const gms::inet_address& endpoint) { }
+
 }

--- a/service/qos/service_level_controller.hh
+++ b/service/qos/service_level_controller.hh
@@ -32,6 +32,7 @@
 #include <map>
 #include <unordered_set>
 #include "qos_common.hh"
+#include "service/endpoint_lifecycle_subscriber.hh"
 
 namespace db {
     class system_distributed_keyspace;
@@ -56,7 +57,7 @@ struct service_level {
  *      2. Local controllers that act upon the data and facilitates execution in
  *      the service level context
  */
-class service_level_controller : public peering_sharded_service<service_level_controller> {
+class service_level_controller : public peering_sharded_service<service_level_controller>, public service::endpoint_lifecycle_subscriber {
 public:
     class service_level_distributed_data_accessor {
     public:
@@ -222,5 +223,11 @@ private:
 
 public:
     static sstring default_service_level_name;
+
+public:
+    virtual void on_join_cluster(const gms::inet_address& endpoint) override;
+    virtual void on_leave_cluster(const gms::inet_address& endpoint) override;
+    virtual void on_up(const gms::inet_address& endpoint) override;
+    virtual void on_down(const gms::inet_address& endpoint) override;
 };
 }


### PR DESCRIPTION
This is a rework of #8916 
The polling loop of the service level controller queries a distributed table in order to detect
configuration changes. If a node gets decommissioned, this loop continues to run until shutdown, if a node
stays in the decommissioned mode without being shut down, the loop will fail to query the table and this will
result in warnings and eventually errors in the log. This is not really harmful but it adds unnecessary noise
to the log.
The series below lays the infrastructure for observing storage service state changes, which eventually being
used to break the loop upon preparation for decommissioning.
Tests:
Unit test (dev)
Failing tests in jenkins.

Fixes #8836

The previous merge (possibly due to conflict resolution) contained a misplaced get that caused an abort on shutdown.