### PR TITLE
continuous_data_consumer: properly skip bytes at the end of a range

### DIFF
--- a/sstables/consumer.hh
+++ b/sstables/consumer.hh
@@ -607,10 +607,11 @@ public:
                 assert(data.size() == 0);
                 _remain -= orig_data_size;
                 if (skip.get_value() >= _remain) {
+                    skip_bytes skip_remaining(_remain);
                     _stream_position.position += _remain;
                     _remain = 0;
                     verify_end_state();
-                    return make_ready_future<consumption_result_type>(stop_consuming<char>{std::move(data)});
+                    return make_ready_future<consumption_result_type>(std::move(skip_remaining));
                 }
                 _stream_position.position += skip.get_value();
                 _remain -= skip.get_value();


### PR DESCRIPTION
When skipping bytes at the end of a continuous_data_consumer range,
the position of the consumer is moved after the skipped bytes, but
the position of the underlying input_stream is not.

This patch adds skipping of the underlying input_stream, to make
its position consistent with the position of the consumer.

Fixes #9024

Signed-off-by: Wojciech Mitros <wojciech.mitros@scylladb.com>