### PR TITLE
test: increase timeout to account for flat_mutation_reader_v2 tests

### DIFF
--- a/test.py
+++ b/test.py
@@ -576,7 +576,7 @@ def parse_cmd_line():
                         help="Run only tests for given build mode(s)")
     parser.add_argument('--repeat', action="store", default="1", type=int,
                         help="number of times to repeat test execution")
-    parser.add_argument('--timeout', action="store", default="12000", type=int,
+    parser.add_argument('--timeout', action="store", default="24000", type=int,
                         help="timeout value for test execution")
     parser.add_argument('--verbose', '-v', action='store_true', default=False,
                         help='Verbose reporting')


### PR DESCRIPTION
Since fce124bd9029a ("Merge "Introduce flat_mutation_reader_v2" from
Tomasz") tests involving mutation_reader are a lot slower due to
the new API testing. On slower machines it's enough to time out.

Work underway to improve the situation, and it will also revert back
to the original timing once the flat_mutation_reader_v2 work is done,
but meanwhile, increase the timeout.