### PR TITLE
Fix artificial view update size limit

### DIFF
--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -409,7 +409,7 @@ private:
 
 public:
     data_query_result_builder(const schema& s, const query::partition_slice& slice)
-        : _res_builder(slice, query::result_options::only_result(), query::result_memory_accounter{10*1024*1024})
+        : _res_builder(slice, query::result_options::only_result(), query::result_memory_accounter{query::result_memory_limiter::unlimited_result_size})
         , _builder(s, _res_builder) { }
 
     void consume_new_partition(const dht::decorated_key& dk) { _builder.consume_new_partition(dk); }

--- a/test/cql-pytest/test_materialized_view.py
+++ b/test/cql-pytest/test_materialized_view.py
@@ -1,0 +1,60 @@
+# Copyright 2021-present ScyllaDB
+#
+# This file is part of Scylla.
+#
+# Scylla is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Scylla is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
+
+# Tests for materialized views
+
+import time
+import pytest
+
+from util import new_test_table, unique_name
+
+# Test that building a view with a large value succeeds. Regression test
+# for a bug where values larger than 10MB were rejected during building (#9047)
+def test_build_view_with_large_row(cql, test_keyspace):
+    schema = 'p int, c int, v text, primary key (p,c)'
+    mv = unique_name()
+    with new_test_table(cql, test_keyspace, schema) as table:
+        big = 'x'*11*1024*1024
+        cql.execute(f"INSERT INTO {table}(p,c,v) VALUES (1,1,'{big}')")
+        cql.execute(f"CREATE MATERIALIZED VIEW {test_keyspace}.{mv} AS SELECT * FROM {table} WHERE p IS NOT NULL AND c IS NOT NULL PRIMARY KEY (c,p)")
+        try:
+            retrieved_row = False
+            for _ in range(50):
+                res = [row for row in cql.execute(f"SELECT * FROM {test_keyspace}.{mv}")]
+                if len(res) == 1 and res[0].v == big:
+                    retrieved_row = True
+                    break
+                else:
+                    time.sleep(0.1)
+            assert retrieved_row
+        finally:
+            cql.execute(f"DROP MATERIALIZED VIEW {test_keyspace}.{mv}")
+
+# Test that updating a view with a large value succeeds. Regression test
+# for a bug where values larger than 10MB were rejected during building (#9047)
+def test_update_view_with_large_row(cql, test_keyspace):
+    schema = 'p int, c int, v text, primary key (p,c)'
+    mv = unique_name()
+    with new_test_table(cql, test_keyspace, schema) as table:
+        cql.execute(f"CREATE MATERIALIZED VIEW {test_keyspace}.{mv} AS SELECT * FROM {table} WHERE p IS NOT NULL AND c IS NOT NULL PRIMARY KEY (c,p)")
+        try:
+            big = 'x'*11*1024*1024
+            cql.execute(f"INSERT INTO {table}(p,c,v) VALUES (1,1,'{big}')")
+            res = [row for row in cql.execute(f"SELECT * FROM {test_keyspace}.{mv}")]
+            assert len(res) == 1 and res[0].v == big
+        finally:
+            cql.execute(f"DROP MATERIALIZED VIEW {test_keyspace}.{mv}")


### PR DESCRIPTION
The series which split the view update process into smaller parts
accidentally put an artificial 10MB limit on the generated mutation
size, which is wrong - this limit is configurable for users,
and, what's more important, this data was already validated when
it was inserted into the base table. Thus, the limit is lifted.
  
The series comes with a cql-pytest which failed before the fix and succeeds now. This bug is also  covered by `wide_rows_test.py:TestWideRows_with_LeveledCompactionStrategy.test_large_cell_in_materialized_view` dtest, but it needs over a minute to run, as opposed to cql-pytest's <1 second. 

Fixes #9047

Tests: unit(release), dtest(wide_rows_test.py:TestWideRows_with_LeveledCompactionStrategy.test_large_cell_in_materialized_view)