### PR TITLE
secondary_index: Fix TOKEN() restrictions in indexed SELECTs

### DIFF
--- a/cql3/expr/expression.cc
+++ b/cql3/expr/expression.cc
@@ -903,6 +903,27 @@ expression replace_column_def(const expression& expr, const column_definition* n
         }, expr);
 }
 
+expression replace_token(const expression& expr, const column_definition* new_cdef) {
+    return std::visit(overloaded_functor{
+            [] (bool b) { return expression(b); },
+            [&] (const conjunction& conj) {
+                const auto applied = conj.children | transformed(
+                        std::bind(replace_token, std::placeholders::_1, new_cdef));
+                return expression(conjunction{std::vector(applied.begin(), applied.end())});
+            },
+            [&] (const binary_operator& oper) {
+                return expression(binary_operator(replace_token(*oper.lhs, new_cdef), oper.op, oper.rhs));
+            },
+            [&] (const column_value&) {
+                return expr;
+            },
+            [&] (const column_value_tuple&) -> expression {
+                throw std::logic_error(format("replace_token invalid with column tuple: {}", to_string(expr)));
+            },
+            [&] (const token&) -> expression { return column_value{new_cdef}; }
+        }, expr);
+}
+
 std::ostream& operator<<(std::ostream& s, oper_t op) {
     switch (op) {
     case oper_t::EQ:

--- a/cql3/expr/expression.hh
+++ b/cql3/expr/expression.hh
@@ -281,6 +281,10 @@ extern bool is_on_collection(const binary_operator&);
 /// column_value.
 extern expression replace_column_def(const expression&, const column_definition*);
 
+// Replaces all occurences of token(p1, p2) on the left hand side with the given colum.
+// For example this changes token(p1, p2) < token(1, 2) to my_column_name < token(1, 2).
+extern expression replace_token(const expression&, const column_definition*);
+
 inline oper_t pick_operator(statements::bound b, bool inclusive) {
     return is_start(b) ?
             (inclusive ? oper_t::GTE : oper_t::GT) :

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -1158,6 +1158,10 @@ query::partition_slice indexed_table_select_statement::get_partition_slice_for_g
         if (single_pk_restrictions && single_pk_restrictions->is_all_eq()) {
             partition_slice_builder.with_ranges(
                     _restrictions->get_global_index_clustering_ranges(options, *_view_schema));
+        } else if (_restrictions->has_token_restrictions()) {
+            // Restrictions like token(p1, p2) < 0 have all partition key components restricted, but require special handling.
+            partition_slice_builder.with_ranges(
+                    _restrictions->get_global_index_token_clustering_ranges(options, *_view_schema));
         }
     }
 

--- a/test/boost/secondary_index_test.cc
+++ b/test/boost/secondary_index_test.cc
@@ -1533,6 +1533,27 @@ SEASTAR_TEST_CASE(test_computed_columns) {
     });
 }
 
+// Sorted by token value. See testset_tokens for token values.
+static const std::vector<std::vector<bytes_opt>> testset_pks = {
+    { int32_type->decompose(5) },
+    { int32_type->decompose(1) },
+    { int32_type->decompose(0) },
+    { int32_type->decompose(2) },
+    { int32_type->decompose(4) },
+    { int32_type->decompose(6) },
+    { int32_type->decompose(3) },
+};
+
+static const std::vector<int64_t> testset_tokens = {
+    { -7509452495886106294 },
+    { -4069959284402364209 },
+    { -3485513579396041028 },
+    { -3248873570005575792 },
+    { -2729420104000364805 },
+    { +2705480034054113608 },
+    { +9010454139840013625 },
+};
+
 // Ref: #3423 - rows should be returned in token order,
 // using signed comparison (ref: #7443)
 SEASTAR_TEST_CASE(test_token_order) {
@@ -1544,22 +1565,12 @@ SEASTAR_TEST_CASE(test_token_order) {
             cquery_nofail(e, format("INSERT INTO t (pk, v) VALUES ({}, 1)", i).c_str());
         }
 
-        std::vector<std::vector<bytes_opt>> expected_rows = {
-            { int32_type->decompose(5) }, // token(pk) = -7509452495886106294
-            { int32_type->decompose(1) }, // token(pk) = -4069959284402364209
-            { int32_type->decompose(0) }, // token(pk) = -3485513579396041028
-            { int32_type->decompose(2) }, // token(pk) = -3248873570005575792
-            { int32_type->decompose(4) }, // token(pk) = -2729420104000364805
-            { int32_type->decompose(6) }, // token(pk) = +2705480034054113608
-            { int32_type->decompose(3) }, // token(pk) = +9010454139840013625
-        };
-
         eventually([&] {
             auto nonindex_order = cquery_nofail(e, "SELECT pk FROM t");
             auto index_order = cquery_nofail(e, "SELECT pk FROM t WHERE v = 1");
 
-            assert_that(nonindex_order).is_rows().with_rows(expected_rows);
-            assert_that(index_order).is_rows().with_rows(expected_rows);
+            assert_that(nonindex_order).is_rows().with_rows(testset_pks);
+            assert_that(index_order).is_rows().with_rows(testset_pks);
         });
     });
 }

--- a/test/boost/secondary_index_test.cc
+++ b/test/boost/secondary_index_test.cc
@@ -1575,6 +1575,228 @@ SEASTAR_TEST_CASE(test_token_order) {
     });
 }
 
+SEASTAR_TEST_CASE(test_select_with_token_range_cases) {
+    return do_with_cql_env_thread([] (auto& e) {
+        cquery_nofail(e, "CREATE TABLE t (pk int, v int, PRIMARY KEY(pk))");
+
+        for (int i = 0; i < 7; i++) {
+            // v=1 in each row, so WHERE v = 1 will select them all
+            cquery_nofail(e, format("INSERT INTO t (pk, v) VALUES ({}, 1)", i).c_str());
+        }
+
+        auto get_result_rows = [&](int start, int end) {
+            std::vector<std::vector<bytes_opt>> result;
+            for (int i = start; i <= end; i++) {
+                result.push_back({ testset_pks[i][0], int32_type->decompose(1) });
+            }
+            return result;
+        };
+
+        auto get_query = [&](sstring token_restriction) {
+            return format("SELECT * FROM t WHERE v = 1 AND {} ALLOW FILTERING", token_restriction);
+        };
+
+        auto q = [&](sstring token_restriction) {
+            return cquery_nofail(e, get_query(token_restriction).c_str());
+        };
+
+        auto inclusive_inclusive_range = [](int64_t start, int64_t end) { return format("token(pk) >= {} AND token(pk) <= {}", start, end); };
+        auto exclusive_inclusive_range = [](int64_t start, int64_t end) { return format("token(pk) > {} AND token(pk) <= {}", start, end); };
+        auto inclusive_exclusive_range = [](int64_t start, int64_t end) { return format("token(pk) >= {} AND token(pk) < {}", start, end); };
+        auto exclusive_exclusive_range = [](int64_t start, int64_t end) { return format("token(pk) > {} AND token(pk) < {}", start, end); };
+
+        auto inclusive_infinity_range = [](int64_t start) { return format("token(pk) >= {}", start); };
+        auto exclusive_infinity_range = [](int64_t start) { return format("token(pk) > {}", start); };
+
+        auto infinity_inclusive_range = [](int64_t end) { return format("token(pk) <= {}", end); };
+        auto infinity_exclusive_range = [](int64_t end) { return format("token(pk) < {}", end); };
+
+        auto equal_range = [](int64_t value) { return format("token(pk) = {}", value); };
+
+        auto do_tests = [&] {
+            assert_that(q(inclusive_inclusive_range(testset_tokens[1], testset_tokens[5]))).is_rows().with_rows(get_result_rows(1, 5));
+            assert_that(q(inclusive_inclusive_range(testset_tokens[1], testset_tokens[5] - 1))).is_rows().with_rows(get_result_rows(1, 4));
+            assert_that(q(inclusive_inclusive_range(testset_tokens[1], testset_tokens[5] + 1))).is_rows().with_rows(get_result_rows(1, 5));
+            assert_that(q(inclusive_inclusive_range(testset_tokens[1] + 1, testset_tokens[5]))).is_rows().with_rows(get_result_rows(2, 5));
+
+            assert_that(q(exclusive_inclusive_range(testset_tokens[1], testset_tokens[4]))).is_rows().with_rows(get_result_rows(2, 4));
+
+            assert_that(q(inclusive_exclusive_range(testset_tokens[1], testset_tokens[4]))).is_rows().with_rows(get_result_rows(1, 3));
+
+            assert_that(q(exclusive_exclusive_range(testset_tokens[1], testset_tokens[4]))).is_rows().with_rows(get_result_rows(2, 3));
+
+            assert_that(q(inclusive_infinity_range(testset_tokens[3]))).is_rows().with_rows(get_result_rows(3, testset_pks.size() - 1));
+
+            assert_that(q(exclusive_infinity_range(testset_tokens[3]))).is_rows().with_rows(get_result_rows(4, testset_pks.size() - 1));
+
+            assert_that(q(infinity_inclusive_range(testset_tokens[3]))).is_rows().with_rows(get_result_rows(0, 3));
+
+            assert_that(q(infinity_exclusive_range(testset_tokens[3]))).is_rows().with_rows(get_result_rows(0, 2));
+            
+            assert_that(q("token(pk) < 0")).is_rows().with_rows(get_result_rows(0, 4));
+
+            assert_that(q("token(pk) > 0")).is_rows().with_rows(get_result_rows(5, testset_pks.size() - 1));
+
+            assert_that(q(equal_range(testset_tokens[3]))).is_rows().with_rows(get_result_rows(3, 3));
+
+            // empty range
+            assert_that(q("token(pk) < 5 AND token(pk) > 100")).is_rows().with_size(0);
+
+            // prepared statement
+            auto prepared_id = e.prepare(get_query("token(pk) >= ? AND token(pk) <= ?")).get0();
+            auto msg = e.execute_prepared(prepared_id, {
+                cql3::raw_value::make_value(long_type->decompose(testset_tokens[1])), cql3::raw_value::make_value(long_type->decompose(testset_tokens[5]))
+            }).get0();
+            assert_that(msg).is_rows().with_rows(get_result_rows(1, 5));
+
+            msg = e.execute_prepared(prepared_id, {
+                cql3::raw_value::make_value(long_type->decompose(testset_tokens[2])), cql3::raw_value::make_value(long_type->decompose(testset_tokens[6]))
+            }).get0();
+            assert_that(msg).is_rows().with_rows(get_result_rows(2, 6));
+        };
+
+        do_tests();
+
+        cquery_nofail(e, "CREATE INDEX t_global ON t(v)");
+
+        eventually(do_tests);
+
+        cquery_nofail(e, "DROP INDEX t_global");
+        cquery_nofail(e, "CREATE INDEX t_local ON t((pk), v)");
+
+        eventually(do_tests);
+    });
+}
+
+struct testset_row {
+    int pk1, pk2;
+    int64_t token;
+    int ck1, ck2;
+    int v, v2;
+};
+
+SEASTAR_TEST_CASE(test_select_with_token_range_filtering) {
+    return do_with_cql_env_thread([] (auto& e) {
+        // Do tests for each column (excluding partition key columns - cannot mix partition column 
+        // restrictions and TOKEN restrictions). First run the query without index, then with global index,
+        // and finally with local index.
+
+        cquery_nofail(e, "CREATE TABLE t (pk1 int, pk2 int, ck1 int, ck2 int, v int, v2 int, PRIMARY KEY((pk1, pk2), ck1, ck2))");
+
+        std::map<std::pair<int, int>, int64_t> pk_to_token = {
+            {{3, 3}, -5763496297744201138},
+            {{2, 2}, -3974863545882308264},
+            {{1, 3},   793791837967961899},
+            {{2, 1},  1222388547083740924},
+            {{2, 3},  3312996362008120679},
+            {{1, 2},  4881097376275569167},
+            {{1, 1},  5765203080415074583},
+            {{3, 2},  6375086356864122089},
+            {{3, 1},  8740098777817515610}
+        };
+
+        std::vector<testset_row> rows;
+        auto insert_row = [&](testset_row row) {
+            cquery_nofail(e, format("INSERT INTO t(pk1, pk2, ck1, ck2, v, v2) VALUES ({}, {}, {}, {}, {}, {})", row.pk1, row.pk2, row.ck1, row.ck2, row.v, row.v2).c_str());
+            rows.push_back(row);
+        };
+
+        for (int pk1 = 1; pk1 <= 3; pk1++) {
+            for (int pk2 = 1; pk2 <= 3; pk2++) {
+                insert_row(testset_row{pk1, pk2, pk_to_token[{pk1, pk2}], 1, 1, 1, 1});
+                insert_row(testset_row{pk1, pk2, pk_to_token[{pk1, pk2}], 1, 3, 2, 1});
+                insert_row(testset_row{pk1, pk2, pk_to_token[{pk1, pk2}], 2, 1, 3, 1});
+            }
+        }
+
+        auto do_test = [&](sstring token_restriction, sstring column_restrictions, std::function<bool(const testset_row&)> matches_row) {
+            auto expected_rows = boost::copy_range<std::vector<std::vector<bytes_opt>>>(rows |
+                boost::adaptors::filtered(std::move(matches_row)) | boost::adaptors::transformed([] (const testset_row& row) {
+                return std::vector<bytes_opt> { 
+                    int32_type->decompose(row.pk1), int32_type->decompose(row.pk2), 
+                    int32_type->decompose(row.ck1), int32_type->decompose(row.ck2), 
+                    int32_type->decompose(row.v), int32_type->decompose(row.v2) 
+                };
+            }));
+            auto msg = cquery_nofail(e, format("SELECT pk1, pk2, ck1, ck2, v, v2 FROM t WHERE {} AND {} ALLOW FILTERING", token_restriction, column_restrictions).c_str());
+            assert_that(msg).is_rows().with_rows_ignore_order(expected_rows);
+        };
+
+        auto do_tests_ck1 = [&] {
+            do_test("token(pk1, pk2) >= token(1, 2)", "ck1 = 1", [&](const testset_row& row) { return row.ck1 == 1 && row.token >= pk_to_token[{1, 2}]; });
+            do_test("token(pk1, pk2) >= token(1, 2)", "ck1 = 1 AND v2 = 1", [&](const testset_row& row) { return row.ck1 == 1 && row.v2 == 1 && row.token >= pk_to_token[{1, 2}]; });
+            do_test("token(pk1, pk2) >= token(1, 2)", "ck1 = 1 AND ck2 = 3", [&](const testset_row& row) { return row.ck1 == 1 && row.ck2 == 3 && row.token >= pk_to_token[{1, 2}]; });
+            do_test("token(pk1, pk2) >= token(1, 2)", "ck1 = 1 AND ck2 = 3 AND v = 2", [&](const testset_row& row) { return row.ck1 == 1 && row.ck2 == 3 && row.v == 2 && row.token >= pk_to_token[{1, 2}]; });
+            do_test("token(pk1, pk2) >= token(1, 2)", "ck1 = 1 AND v = 3", [&](const testset_row& row) { return row.ck1 == 1 && row.v == 3 && row.token >= pk_to_token[{1, 2}]; });
+        };
+
+        auto do_tests_ck2 = [&] {
+            do_test("token(pk1, pk2) <= token(1, 3)", "ck2 = 1", [&](const testset_row& row) { return row.ck2 == 1 && row.token <= pk_to_token[{1, 3}]; });
+            do_test("token(pk1, pk2) <= token(1, 3)", "ck2 = 1 AND ck1 = 1", [&](const testset_row& row) { return row.ck2 == 1 && row.ck1 == 1 && row.token <= pk_to_token[{1, 3}]; });
+            do_test("token(pk1, pk2) <= token(1, 3)", "ck2 = 1 AND v2 = 1", [&](const testset_row& row) { return row.ck2 == 1 && row.v2 == 1 && row.token <= pk_to_token[{1, 3}]; });
+        };
+
+        auto do_tests_v = [&] {
+            do_test("token(pk1, pk2) <= token(3, 2)", "v = 2", [&](const testset_row& row) { return row.v == 2 && row.token <= pk_to_token[{3, 2}]; });
+            do_test("token(pk1, pk2) <= token(3, 2)", "v = 2 AND ck1 = 1", [&](const testset_row& row) { return row.v == 2 && row.ck1 == 1 && row.token <= pk_to_token[{3, 2}]; });
+            do_test("token(pk1, pk2) <= token(3, 2)", "v = 2 AND ck1 = 1 AND ck2 = 3", [&](const testset_row& row) { return row.v == 2 && row.ck1 == 1 && row.ck2 == 3 && row.token <= pk_to_token[{3, 2}]; });
+        };
+
+        auto do_tests_v2 = [&] {
+            do_test("token(pk1, pk2) <= token(3, 2)", "v2 = 1", [&](const testset_row& row) { return row.v2 == 1 && row.token <= pk_to_token[{3, 2}]; });
+            do_test("token(pk1, pk2) <= token(3, 2)", "v2 = 1 AND ck1 = 1", [&](const testset_row& row) { return row.v2 == 1 && row.ck1 == 1 && row.token <= pk_to_token[{3, 2}]; });
+            do_test("token(pk1, pk2) <= token(3, 2)", "v2 = 1 AND ck1 = 1 AND ck2 = 1", [&](const testset_row& row) { return row.v2 == 1 && row.ck1 == 1 && row.ck2 == 1 && row.token <= pk_to_token[{3, 2}]; });
+            do_test("token(pk1, pk2) <= token(3, 2)", "v2 = 1 AND ck2 = 1", [&](const testset_row& row) { return row.v2 == 1 && row.ck2 == 1 && row.token <= pk_to_token[{3, 2}]; });
+        };
+
+        do_tests_ck1();
+        cquery_nofail(e, "CREATE INDEX t_global ON t(ck1)");
+        eventually(do_tests_ck1);
+        cquery_nofail(e, "DROP INDEX t_global");
+        cquery_nofail(e, "CREATE INDEX t_local ON t((pk1, pk2), ck1)");
+        eventually(do_tests_ck1);
+        cquery_nofail(e, "DROP INDEX t_local");
+
+        do_tests_ck2();
+        cquery_nofail(e, "CREATE INDEX t_global ON t(ck2)");
+        eventually(do_tests_ck2);
+        cquery_nofail(e, "DROP INDEX t_global");
+        cquery_nofail(e, "CREATE INDEX t_local ON t((pk1, pk2), ck2)");
+        eventually(do_tests_ck2);
+        cquery_nofail(e, "DROP INDEX t_local");
+
+        do_tests_v();
+        cquery_nofail(e, "CREATE INDEX t_global ON t(v)");
+        eventually(do_tests_v);
+        cquery_nofail(e, "DROP INDEX t_global");
+        cquery_nofail(e, "CREATE INDEX t_local ON t((pk1, pk2), v)");
+        eventually(do_tests_v);
+        cquery_nofail(e, "DROP INDEX t_local");
+
+        do_tests_v2();
+        cquery_nofail(e, "CREATE INDEX t_global ON t(v2)");
+        eventually(do_tests_v2);
+        cquery_nofail(e, "DROP INDEX t_global");
+        cquery_nofail(e, "CREATE INDEX t_local ON t((pk1, pk2), v2)");
+        eventually(do_tests_v2);
+        cquery_nofail(e, "DROP INDEX t_local");
+
+        // Two indexes
+        cquery_nofail(e, "CREATE INDEX t_global ON t(v2)");
+        cquery_nofail(e, "CREATE INDEX t_global2 ON t(ck2)");
+        eventually(do_tests_v2);
+        eventually(do_tests_ck2);
+        cquery_nofail(e, "DROP INDEX t_global");
+        cquery_nofail(e, "DROP INDEX t_global2");
+        cquery_nofail(e, "CREATE INDEX t_local ON t((pk1, pk2), v2)");
+        cquery_nofail(e, "CREATE INDEX t_local2 ON t((pk1, pk2), ck2)");
+        eventually(do_tests_v2);
+        eventually(do_tests_ck2);
+        cquery_nofail(e, "DROP INDEX t_local");
+        cquery_nofail(e, "DROP INDEX t_local2");
+    });
+}
+
 // Ref: #5708 - filtering should be applied on an indexed column
 // if the restriction is not eligible for indexing (it's not EQ)
 SEASTAR_TEST_CASE(test_filtering_indexed_column) {


### PR DESCRIPTION
This is a rewrite of an old PR: #7582

`TOKEN()` restrictions don't work properly when a query uses an index.
For example this returns both rows:
```cql
CREATE TABLE t(pk int, ck int, v int, PRIMARY KEY(pk, ck));
CREATE INDEX ON t(v);
INSERT INTO t (pk, ck, v) VALUES (0, 0, 0);
INSERT INTO t (pk, ck, v) VALUES (1, 0, 0);
SELECT token(pk), pk, ck, v FROM t WHERE v = 0 AND token(pk) = token(0) ALLOW FILTERING;
```

This functionality is supported on both old and new indexes.
In old indexes the type of the token column was `blob`.
This causes problems, because `blob` representation of tokens is ordered differently. Tokens represented as blobs are ordered like this:
```
0, 1, 2, 3, 4, 5, ..., bigint_max, bigint_min, ...., -5, -4, -3, -2, -1
```
Because of that clustering range for `token()` restrictions needs to be translated to two clustering ranges on the `blob` column.

To create old indexes disable the feature called: `CORRECT_IDX_TOKEN_IN_SECONDARY_INDEX`
or run scylla version from branch [`cvybhu/si-token2-old-index`](https://github.com/cvybhu/scylla/commits/si-token2-old-index)

I'm not sure if it's possible to create automatic tests with old indexes. I ran `dev-test` manually on the `si-token2-old-index` branch, and the only tests that failed were the ones testing row ordering. Rows should be ordered by `token`, but because in old indexes the token is represented as a `blob` this ordering breaks. This is a known issue (#7443), that has been fixed by introducing new indexes.

To sum up:
* `token()` restrictions are fixed on both new and old indexes.
* When using old indexes, the rows are not properly ordered by token.
* With new indexes the rows are properly ordered by token.

Fixes #7043