### PR TITLE
Propagate exceptions without throwing

### DIFF
--- a/database.cc
+++ b/database.cc
@@ -1441,8 +1441,8 @@ database::query(schema_ptr s, const query::read_command& cmd, query::result_opti
     if (querier_opt) {
         co_await querier_opt->close();
     }
-    if(ex) {
-        std::rethrow_exception(std::move(ex));
+    if (ex) {
+        co_return coroutine::exception(std::move(ex));
     }
 
     auto hit_rate = cf.get_global_cache_hit_rate();
@@ -1497,8 +1497,8 @@ database::query_mutations(schema_ptr s, const query::read_command& cmd, const dh
     if (querier_opt) {
         co_await querier_opt->close();
     }
-    if(ex) {
-        std::rethrow_exception(std::move(ex));
+    if (ex) {
+        co_return coroutine::exception(std::move(ex));
     }
 
     auto hit_rate = cf.get_global_cache_hit_rate();
@@ -1868,8 +1868,8 @@ future<> database::do_apply(schema_ptr s, const frozen_mutation& m, tracing::tra
     auto uuid = m.column_family_id();
     auto& cf = find_column_family(uuid);
     if (!s->is_synced()) {
-        throw std::runtime_error(format("attempted to mutate using not synced schema of {}.{}, version={}",
-                                 s->ks_name(), s->cf_name(), s->version()));
+        return make_exception_future<>(std::runtime_error(format("attempted to mutate using not synced schema of {}.{}, version={}",
+                s->ks_name(), s->cf_name(), s->version())));
     }
 
     sync = sync || db::commitlog::force_sync(s->wait_for_sync_to_commitlog());

--- a/db/commitlog/commitlog.cc
+++ b/db/commitlog/commitlog.cc
@@ -670,7 +670,7 @@ public:
         _closed_file = true;
 
         if (p) {
-            std::rethrow_exception(p);
+            co_return coroutine::exception(std::move(p));
         }
 
         co_return me;
@@ -1530,7 +1530,7 @@ future<db::commitlog::segment_manager::sseg_ptr> db::commitlog::segment_manager:
         co_await f.close();
     }
     if (ep) {
-        std::rethrow_exception(ep);
+        co_return coroutine::exception(std::move(ep));
     }
 
     co_return make_shared<segment>(shared_from_this(), std::move(d), std::move(f), max_size, align);
@@ -1589,7 +1589,7 @@ future<db::commitlog::segment_manager::sseg_ptr> db::commitlog::segment_manager:
 
 future<db::commitlog::segment_manager::sseg_ptr> db::commitlog::segment_manager::new_segment() {
     if (_shutdown) {
-        throw std::runtime_error("Commitlog has been shut down. Cannot add data");
+        co_return coroutine::make_exception(std::runtime_error("Commitlog has been shut down. Cannot add data"));
     }
 
     ++_new_counter;

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -1614,7 +1614,7 @@ future<> remove_endpoint(gms::inet_address ep) {
 
 future<> update_tokens(const std::unordered_set<dht::token>& tokens) {
     if (tokens.empty()) {
-        throw std::invalid_argument("remove_endpoint should be used instead");
+        return make_exception_future<>(std::invalid_argument("remove_endpoint should be used instead"));
     }
 
     sstring req = format("INSERT INTO system.{} (key, tokens) VALUES (?, ?)", LOCAL);

--- a/flat_mutation_reader.cc
+++ b/flat_mutation_reader.cc
@@ -164,10 +164,10 @@ flat_mutation_reader make_reversing_reader(flat_mutation_reader& original, query
                         }
 
                         if (_stack_size > _max_size.hard_limit) {
-                            throw std::runtime_error(fmt::format(
+                            return make_exception_future<stop_iteration>(std::runtime_error(fmt::format(
                                     "Memory usage of reversed read exceeds hard limit of {} (configured via max_memory_for_unlimited_query_hard_limit), while reading partition {}",
                                     _max_size.hard_limit,
-                                    key->with_schema(*_schema)));
+                                    key->with_schema(*_schema))));
                         } else {
                             fmr_logger.warn(
                                     "Memory usage of reversed read exceeds soft limit of {} (configured via max_memory_for_unlimited_query_soft_limit), while reading partition {}",
@@ -628,7 +628,7 @@ flat_mutation_reader_from_mutations(reader_permit permit, std::vector<mutation> 
             return make_ready_future<>();
         };
         virtual future<> fast_forward_to(position_range cr, db::timeout_clock::time_point timeout) override {
-            throw std::runtime_error("This reader can't be fast forwarded to another position.");
+            return make_exception_future<>(std::runtime_error("This reader can't be fast forwarded to another position."));
         };
         virtual future<> close() noexcept override {
             return make_ready_future<>();

--- a/multishard_mutation_query.cc
+++ b/multishard_mutation_query.cc
@@ -658,7 +658,7 @@ future<page_consume_result<ResultBuilder>> read_page(
         ex = std::current_exception();
     }
     co_await reader.close();
-    std::rethrow_exception(std::move(ex));
+    co_return coroutine::exception(std::move(ex));
 }
 
 template <typename ResultBuilder>
@@ -691,8 +691,7 @@ future<typename ResultBuilder::result_type> do_query(
     }
 
     co_await ctx->stop();
-
-    std::rethrow_exception(std::move(ex));
+    co_return coroutine::exception(std::move(ex));
 }
 
 template <typename ResultBuilder>

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -2708,7 +2708,7 @@ future<bool> sstable::has_partition_key(const utils::hashed_key& hk, const dht::
     }
     co_await sem.stop();
     if (ex) {
-        std::rethrow_exception(std::move(ex));
+        co_return coroutine::exception(std::move(ex));
     }
     co_return present;
 }

--- a/table.cc
+++ b/table.cc
@@ -2010,7 +2010,7 @@ table::query(schema_ptr s,
             querier_opt = {};
         }
         if (ex) {
-            std::rethrow_exception(std::move(ex));
+            co_return coroutine::exception(std::move(ex));
         }
     }
 
@@ -2067,7 +2067,7 @@ table::mutation_query(schema_ptr s,
     ex = std::current_exception();
   }
     co_await q.close();
-    std::rethrow_exception(std::move(ex));
+    co_return coroutine::exception(std::move(ex));
 }
 
 mutation_source


### PR DESCRIPTION
NOTE: this series depends on a Seastar submodule update, currently queued in next: 0ed35c6af052ab291a69af98b5c13e023470cba3

In order to avoid needless throwing, exceptions are passed
directly wherever possible. Two mechanisms which help with that are:
 1. `make_exception_future<>` for futures
 2. `co_return coroutine::exception(...)` for coroutines
    which return `future<T>` (the mechanism does not work for `future<>`
    without parameters, unfortunately)

Tests: unit(release)
