### PR TITLE
cql3: replace cql3::selection::selectable::raw hierarchy with expressions

### DIFF
--- a/cql3/Cql.g
+++ b/cql3/Cql.g
@@ -456,7 +456,8 @@ unaliasedSelector returns [shared_ptr<selectable::raw> s]
                                                                                               cql3::expr::unresolved_identifier{std::move(c)}}); }
        | f=functionName args=selectionFunctionArgs { tmp = ::make_shared<selectable::with_expression::raw>(
                                                         cql3::expr::function_call{std::move(f), std::move(args)}); }
-       | K_CAST      '(' arg=unaliasedSelector K_AS t=native_type ')'  { tmp = ::make_shared<selectable::with_cast::raw>(std::move(arg), std::move(t)); }
+       | K_CAST      '(' arg=unaliasedSelector K_AS t=native_type ')'  { tmp = ::make_shared<selectable::with_expression::raw>(
+                                                        cql3::expr::cast{std::move(arg), std::move(t)}); }
        )
        ( '.' fi=cident { tmp = make_shared<selectable::with_field_selection::raw>(std::move(tmp), std::move(fi)); } )*
     { $s = tmp; }

--- a/cql3/Cql.g
+++ b/cql3/Cql.g
@@ -448,8 +448,12 @@ unaliasedSelector returns [shared_ptr<selectable::raw> s]
     @init { shared_ptr<selectable::raw> tmp; }
     :  ( c=cident                                  { tmp = make_shared<selectable::with_expression::raw>(cql3::expr::unresolved_identifier{std::move(c)}); }
        | K_COUNT '(' countArgument ')'             { tmp = selectable::with_function::raw::make_count_rows_function(); }
-       | K_WRITETIME '(' c=cident ')'              { tmp = make_shared<selectable::writetime_or_ttl::raw>(c, true); }
-       | K_TTL       '(' c=cident ')'              { tmp = make_shared<selectable::writetime_or_ttl::raw>(c, false); }
+       | K_WRITETIME '(' c=cident ')'              { tmp = make_shared<selectable::with_expression::raw>(
+                                                        cql3::expr::column_mutation_attribute{cql3::expr::column_mutation_attribute::attribute_kind::writetime,
+                                                                                              cql3::expr::unresolved_identifier{std::move(c)}}); }
+       | K_TTL       '(' c=cident ')'              { tmp = make_shared<selectable::with_expression::raw>(
+                                                        cql3::expr::column_mutation_attribute{cql3::expr::column_mutation_attribute::attribute_kind::ttl,
+                                                                                              cql3::expr::unresolved_identifier{std::move(c)}}); }
        | f=functionName args=selectionFunctionArgs { tmp = ::make_shared<selectable::with_function::raw>(std::move(f), std::move(args)); }
        | K_CAST      '(' arg=unaliasedSelector K_AS t=native_type ')'  { tmp = ::make_shared<selectable::with_cast::raw>(std::move(arg), std::move(t)); }
        )

--- a/cql3/Cql.g
+++ b/cql3/Cql.g
@@ -446,7 +446,7 @@ selector returns [shared_ptr<raw_selector> s]
 
 unaliasedSelector returns [shared_ptr<selectable::raw> s]
     @init { shared_ptr<selectable::raw> tmp; }
-    :  ( c=cident                                  { tmp = c; }
+    :  ( c=cident                                  { tmp = make_shared<selectable::with_expression::raw>(cql3::expr::unresolved_identifier{std::move(c)}); }
        | K_COUNT '(' countArgument ')'             { tmp = selectable::with_function::raw::make_count_rows_function(); }
        | K_WRITETIME '(' c=cident ')'              { tmp = make_shared<selectable::writetime_or_ttl::raw>(c, true); }
        | K_TTL       '(' c=cident ')'              { tmp = make_shared<selectable::writetime_or_ttl::raw>(c, false); }

--- a/cql3/Cql.g
+++ b/cql3/Cql.g
@@ -447,14 +447,15 @@ selector returns [shared_ptr<raw_selector> s]
 unaliasedSelector returns [shared_ptr<selectable::raw> s]
     @init { shared_ptr<selectable::raw> tmp; }
     :  ( c=cident                                  { tmp = make_shared<selectable::with_expression::raw>(cql3::expr::unresolved_identifier{std::move(c)}); }
-       | K_COUNT '(' countArgument ')'             { tmp = selectable::with_function::raw::make_count_rows_function(); }
+       | K_COUNT '(' countArgument ')'             { tmp = ::make_shared<selectable::with_expression::raw>(make_count_rows_function_expression()); }
        | K_WRITETIME '(' c=cident ')'              { tmp = make_shared<selectable::with_expression::raw>(
                                                         cql3::expr::column_mutation_attribute{cql3::expr::column_mutation_attribute::attribute_kind::writetime,
                                                                                               cql3::expr::unresolved_identifier{std::move(c)}}); }
        | K_TTL       '(' c=cident ')'              { tmp = make_shared<selectable::with_expression::raw>(
                                                         cql3::expr::column_mutation_attribute{cql3::expr::column_mutation_attribute::attribute_kind::ttl,
                                                                                               cql3::expr::unresolved_identifier{std::move(c)}}); }
-       | f=functionName args=selectionFunctionArgs { tmp = ::make_shared<selectable::with_function::raw>(std::move(f), std::move(args)); }
+       | f=functionName args=selectionFunctionArgs { tmp = ::make_shared<selectable::with_expression::raw>(
+                                                        cql3::expr::function_call{std::move(f), std::move(args)}); }
        | K_CAST      '(' arg=unaliasedSelector K_AS t=native_type ')'  { tmp = ::make_shared<selectable::with_cast::raw>(std::move(arg), std::move(t)); }
        )
        ( '.' fi=cident { tmp = make_shared<selectable::with_field_selection::raw>(std::move(tmp), std::move(fi)); } )*

--- a/cql3/Cql.g
+++ b/cql3/Cql.g
@@ -459,7 +459,8 @@ unaliasedSelector returns [shared_ptr<selectable::raw> s]
        | K_CAST      '(' arg=unaliasedSelector K_AS t=native_type ')'  { tmp = ::make_shared<selectable::with_expression::raw>(
                                                         cql3::expr::cast{std::move(arg), std::move(t)}); }
        )
-       ( '.' fi=cident { tmp = make_shared<selectable::with_field_selection::raw>(std::move(tmp), std::move(fi)); } )*
+       ( '.' fi=cident { tmp = make_shared<selectable::with_expression::raw>(
+                                cql3::expr::field_selection{std::move(tmp), std::move(fi)}); } )*
     { $s = tmp; }
     ;
 

--- a/cql3/column_identifier.cc
+++ b/cql3/column_identifier.cc
@@ -67,11 +67,11 @@ sstring column_identifier::to_cql_string() const {
     return util::maybe_quote(_text);
 }
 
-sstring column_identifier::raw::to_cql_string() const {
+sstring column_identifier_raw::to_cql_string() const {
     return util::maybe_quote(_text);
 }
 
-column_identifier::raw::raw(sstring raw_text, bool keep_case)
+column_identifier_raw::column_identifier_raw(sstring raw_text, bool keep_case)
     : _raw_text{raw_text}
     , _text{raw_text}
 {
@@ -80,12 +80,12 @@ column_identifier::raw::raw(sstring raw_text, bool keep_case)
     }
 }
 
-::shared_ptr<selection::selectable> column_identifier::raw::prepare(const schema& s) const {
+::shared_ptr<selection::selectable> column_identifier_raw::prepare(const schema& s) const {
     return prepare_column_identifier(s);
 }
 
 ::shared_ptr<column_identifier>
-column_identifier::raw::prepare_column_identifier(const schema& schema) const {
+column_identifier_raw::prepare_column_identifier(const schema& schema) const {
     if (schema.regular_column_name_type() == utf8_type) {
         return ::make_shared<column_identifier>(_text, true);
     }
@@ -102,23 +102,23 @@ column_identifier::raw::prepare_column_identifier(const schema& schema) const {
     return ::make_shared<column_identifier>(schema.regular_column_name_type()->from_string(_raw_text), _text);
 }
 
-bool column_identifier::raw::processes_selection() const {
+bool column_identifier_raw::processes_selection() const {
     return false;
 }
 
-bool column_identifier::raw::operator==(const raw& other) const {
+bool column_identifier_raw::operator==(const column_identifier_raw& other) const {
     return _text == other._text;
 }
 
-bool column_identifier::raw::operator!=(const raw& other) const {
+bool column_identifier_raw::operator!=(const column_identifier_raw& other) const {
     return !operator==(other);
 }
 
-sstring column_identifier::raw::to_string() const {
+sstring column_identifier_raw::to_string() const {
     return _text;
 }
 
-std::ostream& operator<<(std::ostream& out, const column_identifier::raw& id) {
+std::ostream& operator<<(std::ostream& out, const column_identifier_raw& id) {
     return out << id._text;
 }
 

--- a/cql3/column_identifier.hh
+++ b/cql3/column_identifier.hh
@@ -51,6 +51,8 @@
 
 namespace cql3 {
 
+class column_identifier_raw;
+
 /**
  * Represents an identifer for a CQL column definition.
  * TODO : should support light-weight mode without text representation for when not interned
@@ -96,7 +98,7 @@ public:
     virtual ::shared_ptr<selection::selector::factory> new_selector_factory(database& db, schema_ptr schema,
         std::vector<const column_definition*>& defs) override;
 
-    class raw;
+    using raw = column_identifier_raw;
 };
 
 /**
@@ -105,28 +107,28 @@ public:
  * once the comparator is known with prepare(). This should only be used with identifiers that are actual
  * column names. See CASSANDRA-8178 for more background.
  */
-class column_identifier::raw final : public selectable::raw {
+class column_identifier_raw final : public selection::selectable::raw {
 private:
     const sstring _raw_text;
     sstring _text;
 public:
-    raw(sstring raw_text, bool keep_case);
+    column_identifier_raw(sstring raw_text, bool keep_case);
 
-    virtual ::shared_ptr<selectable> prepare(const schema& s) const override;
+    virtual ::shared_ptr<selection::selectable> prepare(const schema& s) const override;
 
     ::shared_ptr<column_identifier> prepare_column_identifier(const schema& s) const;
 
     virtual bool processes_selection() const override;
 
-    bool operator==(const raw& other) const;
+    bool operator==(const column_identifier_raw& other) const;
 
-    bool operator!=(const raw& other) const;
+    bool operator!=(const column_identifier_raw& other) const;
 
     virtual sstring to_string() const;
     sstring to_cql_string() const;
 
-    friend std::hash<column_identifier::raw>;
-    friend std::ostream& operator<<(std::ostream& out, const column_identifier::raw& id);
+    friend std::hash<column_identifier_raw>;
+    friend std::ostream& operator<<(std::ostream& out, const column_identifier_raw& id);
 };
 
 static inline
@@ -151,7 +153,7 @@ struct hash<cql3::column_identifier> {
 };
 
 template<>
-struct hash<cql3::column_identifier::raw> {
+struct hash<cql3::column_identifier_raw> {
     size_t operator()(const cql3::column_identifier::raw& r) const {
         return std::hash<sstring>()(r._text);
     }

--- a/cql3/column_identifier.hh
+++ b/cql3/column_identifier.hh
@@ -107,18 +107,20 @@ public:
  * once the comparator is known with prepare(). This should only be used with identifiers that are actual
  * column names. See CASSANDRA-8178 for more background.
  */
-class column_identifier_raw final : public selection::selectable::raw {
+class column_identifier_raw final {
 private:
     const sstring _raw_text;
     sstring _text;
 public:
     column_identifier_raw(sstring raw_text, bool keep_case);
 
-    virtual ::shared_ptr<selection::selectable> prepare(const schema& s) const override;
+    // for selectable::with_expression::raw:
+    ::shared_ptr<selection::selectable> prepare(const schema& s) const;
 
     ::shared_ptr<column_identifier> prepare_column_identifier(const schema& s) const;
 
-    virtual bool processes_selection() const override;
+    // for selectable::with_expression::raw:
+    bool processes_selection() const;
 
     bool operator==(const column_identifier_raw& other) const;
 

--- a/cql3/expr/expression.cc
+++ b/cql3/expr/expression.cc
@@ -957,18 +957,18 @@ std::ostream& operator<<(std::ostream& os, const expression& expr) {
             [&] (const function_call& fc)  {
                 std::visit(overloaded_functor{
                     [&] (const functions::function_name& named) {
-                        fmt::print(os, "{}(args)", named);
+                        fmt::print(os, "{}({})", named, fmt::join(fc.args, ", "));
                     },
                     [&] (const shared_ptr<functions::function>& anon) {
-                        fmt::print(os, "<anonymous function>(args)");
+                        fmt::print(os, "<anonymous function>({})", fmt::join(fc.args, ", "));
                     },
                 }, fc.func);
             },
             [&] (const cast& c)  {
-                fmt::print(os, "(<selectable> AS {})", c.type);
+                fmt::print(os, "({} AS {})", *c.arg, c.type);
             },
             [&] (const field_selection& fs)  {
-                fmt::print(os, "(<selectable>.{})", fs.field);
+                fmt::print(os, "({}.{})", *fs.structure, fs.field);
             },
         }, expr);
     return os;

--- a/cql3/expr/expression.cc
+++ b/cql3/expr/expression.cc
@@ -70,22 +70,10 @@ nested_expression::operator=(const nested_expression& o) {
 }
 
 binary_operator::binary_operator(expression lhs, oper_t op, ::shared_ptr<term> rhs, comparison_order order)
-            : lhs(std::make_unique<expression>(std::move(lhs)))
+            : lhs(std::move(lhs))
             , op(op)
             , rhs(std::move(rhs))
             , order(order) {
-}
-
-binary_operator::binary_operator(const binary_operator& x) : binary_operator(*x.lhs, x.op, x.rhs, x.order) {
-}
-
-binary_operator&
-binary_operator::operator=(const binary_operator& x) {
-    *lhs = *x.lhs;
-    op = x.op;
-    rhs = x.rhs;
-    order = x.order;
-    return *this;
 }
 
 // Since column_identifier_raw is forward-declared in expression.hh, delay destructor instantiation here
@@ -913,7 +901,7 @@ bool is_on_collection(const binary_operator& b) {
     if (b.op == oper_t::CONTAINS || b.op == oper_t::CONTAINS_KEY) {
         return true;
     }
-    if (auto tuple = std::get_if<column_value_tuple>(b.lhs.get())) {
+    if (auto tuple = std::get_if<column_value_tuple>(&*b.lhs)) {
         return boost::algorithm::any_of(tuple->elements, [] (const column_value& v) { return v.sub; });
     }
     return false;

--- a/cql3/expr/expression.cc
+++ b/cql3/expr/expression.cc
@@ -53,6 +53,22 @@ using boost::adaptors::filtered;
 using boost::adaptors::transformed;
 
 
+nested_expression::nested_expression(expression e)
+        : _e(std::make_unique<expression>(std::move(e))) {
+}
+
+nested_expression::nested_expression(const nested_expression& o)
+        : nested_expression(*o._e) {
+}
+
+nested_expression&
+nested_expression::operator=(const nested_expression& o) {
+    if (this != &o) {
+        _e = std::make_unique<expression>(*o._e);
+    }
+    return *this;
+}
+
 binary_operator::binary_operator(expression lhs, oper_t op, ::shared_ptr<term> rhs, comparison_order order)
             : lhs(std::make_unique<expression>(std::move(lhs)))
             , op(op)

--- a/cql3/expr/expression.cc
+++ b/cql3/expr/expression.cc
@@ -925,7 +925,14 @@ std::ostream& operator<<(std::ostream& os, const expression& expr) {
                         *cma.column);
             },
             [&] (const function_call& fc)  {
-                fmt::print(os, "{}(args)", fc.func);
+                std::visit(overloaded_functor{
+                    [&] (const functions::function_name& named) {
+                        fmt::print(os, "{}(args)", named);
+                    },
+                    [&] (const shared_ptr<functions::function>& anon) {
+                        fmt::print(os, "<anonymous function>(args)");
+                    },
+                }, fc.func);
             },
         }, expr);
     return os;

--- a/cql3/expr/expression.hh
+++ b/cql3/expr/expression.hh
@@ -72,6 +72,24 @@ class unresolved_identifier;
 using expression = std::variant<bool, conjunction, binary_operator, column_value, column_value_tuple, token,
                                 unresolved_identifier>;
 
+// An expression variant element can't contain an expression by value, since the size of the variant
+// will be infinite. `nested_expression` contains an expression indirectly, but has value semantics and
+// is copyable.
+class nested_expression {
+    std::unique_ptr<expression> _e;
+public:
+    // not explicit, an expression _is_ a nested expression
+    nested_expression(expression e);
+    nested_expression(const nested_expression&);
+    nested_expression(nested_expression&&) = default;
+    nested_expression& operator=(const nested_expression&);
+    nested_expression& operator=(nested_expression&&) = default;
+    const expression* operator->() const { return _e.get(); }
+    expression* operator->() { return _e.get(); }
+    const expression& operator*() const { return *_e.get(); }
+    expression& operator*() { return *_e.get(); }
+};
+
 /// A column, optionally subscripted by a term (eg, c1 or c2['abc']).
 struct column_value {
     const column_definition* col;

--- a/cql3/expr/expression.hh
+++ b/cql3/expr/expression.hh
@@ -59,6 +59,12 @@ namespace selection {
     class selectable_raw;
 } // namespace selection
 
+namespace functions {
+
+class function;
+
+}
+
 namespace expr {
 
 struct allow_local_index_tag {};
@@ -168,7 +174,7 @@ struct column_mutation_attribute {
 };
 
 struct function_call {
-    functions::function_name func;
+    std::variant<functions::function_name, shared_ptr<functions::function>> func;
     std::vector<shared_ptr<selection::selectable_raw>> args;
 };
 

--- a/cql3/expr/expression.hh
+++ b/cql3/expr/expression.hh
@@ -127,17 +127,12 @@ enum class comparison_order : char {
 
 /// Operator restriction: LHS op RHS.
 struct binary_operator {
-    std::unique_ptr<expression> lhs;
+    nested_expression lhs;
     oper_t op;
     ::shared_ptr<term> rhs;
     comparison_order order;
 
     binary_operator(expression lhs, oper_t op, ::shared_ptr<term> rhs, comparison_order order = comparison_order::cql);
-
-    binary_operator(const binary_operator& x);
-    binary_operator& operator=(const binary_operator&);
-    binary_operator(binary_operator&& x) = default;
-    binary_operator& operator=(binary_operator&& x) = default;
 };
 
 /// A conjunction of restrictions.

--- a/cql3/expr/expression.hh
+++ b/cql3/expr/expression.hh
@@ -57,7 +57,6 @@ class query_options;
 
 namespace selection {
     class selection;
-    class selectable_raw;
 } // namespace selection
 
 namespace functions {
@@ -179,16 +178,16 @@ struct column_mutation_attribute {
 
 struct function_call {
     std::variant<functions::function_name, shared_ptr<functions::function>> func;
-    std::vector<shared_ptr<selection::selectable_raw>> args;
+    std::vector<expression> args;
 };
 
 struct cast {
-    shared_ptr<selection::selectable_raw> arg;
+    nested_expression arg;
     cql3_type type;
 };
 
 struct field_selection {
-    shared_ptr<selection::selectable_raw> structure;
+    nested_expression structure;
     shared_ptr<column_identifier_raw> field;
 };
 

--- a/cql3/expr/expression.hh
+++ b/cql3/expr/expression.hh
@@ -35,6 +35,7 @@
 #include "range.hh"
 #include "seastarx.hh"
 #include "utils/overloaded_functor.hh"
+#include "utils/variant_element.hh"
 
 class row;
 
@@ -72,6 +73,9 @@ class unresolved_identifier;
 using expression = std::variant<bool, conjunction, binary_operator, column_value, column_value_tuple, token,
                                 unresolved_identifier>;
 
+template <typename T>
+concept ExpressionElement = utils::VariantElement<T, expression>;
+
 // An expression variant element can't contain an expression by value, since the size of the variant
 // will be infinite. `nested_expression` contains an expression indirectly, but has value semantics and
 // is copyable.
@@ -80,6 +84,8 @@ class nested_expression {
 public:
     // not explicit, an expression _is_ a nested expression
     nested_expression(expression e);
+    // not explicit, an ExpressionElement _is_ an expression
+    nested_expression(ExpressionElement auto e);
     nested_expression(const nested_expression&);
     nested_expression(nested_expression&&) = default;
     nested_expression& operator=(const nested_expression&);
@@ -331,6 +337,9 @@ column_value_tuple::column_value_tuple(Range r)
         : column_value_tuple(std::vector<column_value>(r.begin(), r.end())) {
 }
 
+nested_expression::nested_expression(ExpressionElement auto e)
+        : nested_expression(expression(std::move(e))) {
+}
 
 } // namespace expr
 

--- a/cql3/restrictions/statement_restrictions.cc
+++ b/cql3/restrictions/statement_restrictions.cc
@@ -226,6 +226,10 @@ static std::vector<expr::expression> extract_partition_range(
         void operator()(const cast&) {
             on_internal_error(rlogger, "extract_partition_range(cast)");
         }
+
+        void operator()(const field_selection&) {
+            on_internal_error(rlogger, "extract_partition_range(field_selection)");
+        }
     } v;
     std::visit(v, where_clause);
     if (v.tokens) {
@@ -306,6 +310,10 @@ static std::vector<expr::expression> extract_clustering_prefix_restrictions(
 
         void operator()(const cast&) {
             on_internal_error(rlogger, "extract_clustering_prefix_restrictions(cast)");
+        }
+
+        void operator()(const field_selection&) {
+            on_internal_error(rlogger, "extract_clustering_prefix_restrictions(field_selection)");
         }
     } v;
     std::visit(v, where_clause);
@@ -994,6 +1002,10 @@ struct multi_column_range_accumulator {
 
     void operator()(const cast&) {
         on_internal_error(rlogger, "typecast encountered outside binary operator");
+    }
+
+    void operator()(const field_selection&) {
+        on_internal_error(rlogger, "field selection encountered outside binary operator");
     }
 
     /// Intersects each range with v.  If any intersection is empty, clears ranges.

--- a/cql3/restrictions/statement_restrictions.cc
+++ b/cql3/restrictions/statement_restrictions.cc
@@ -218,6 +218,10 @@ static std::vector<expr::expression> extract_partition_range(
         void operator()(const column_mutation_attribute&) {
             on_internal_error(rlogger, "extract_partition_range(column_mutation_attribute)");
         }
+
+        void operator()(const function_call&) {
+            on_internal_error(rlogger, "extract_partition_range(function_call)");
+        }
     } v;
     std::visit(v, where_clause);
     if (v.tokens) {
@@ -290,6 +294,10 @@ static std::vector<expr::expression> extract_clustering_prefix_restrictions(
 
         void operator()(const column_mutation_attribute&) {
             on_internal_error(rlogger, "extract_clustering_prefix_restrictions(column_mutation_attribute)");
+        }
+
+        void operator()(const function_call&) {
+            on_internal_error(rlogger, "extract_clustering_prefix_restrictions(function_call)");
         }
     } v;
     std::visit(v, where_clause);
@@ -970,6 +978,10 @@ struct multi_column_range_accumulator {
 
     void operator()(const column_mutation_attribute&) {
         on_internal_error(rlogger, "writetime/ttl encountered outside binary operator");
+    }
+
+    void operator()(const function_call&) {
+        on_internal_error(rlogger, "function call encountered outside binary operator");
     }
 
     /// Intersects each range with v.  If any intersection is empty, clears ranges.

--- a/cql3/restrictions/statement_restrictions.cc
+++ b/cql3/restrictions/statement_restrictions.cc
@@ -690,7 +690,7 @@ dht::partition_range_vector partition_ranges_from_singles(
     size_t product_size = 1;
     for (const auto& e : expressions) {
         if (const auto arbitrary_binop = find_atom(e, [] (const binary_operator&) { return true; })) {
-            if (auto cv = std::get_if<expr::column_value>(arbitrary_binop->lhs.get())) {
+            if (auto cv = std::get_if<expr::column_value>(&*arbitrary_binop->lhs)) {
                 const value_set vals = possible_lhs_values(cv->col, e, options);
                 if (auto lst = std::get_if<value_list>(&vals)) {
                     if (lst->empty()) {

--- a/cql3/restrictions/statement_restrictions.cc
+++ b/cql3/restrictions/statement_restrictions.cc
@@ -222,6 +222,10 @@ static std::vector<expr::expression> extract_partition_range(
         void operator()(const function_call&) {
             on_internal_error(rlogger, "extract_partition_range(function_call)");
         }
+
+        void operator()(const cast&) {
+            on_internal_error(rlogger, "extract_partition_range(cast)");
+        }
     } v;
     std::visit(v, where_clause);
     if (v.tokens) {
@@ -298,6 +302,10 @@ static std::vector<expr::expression> extract_clustering_prefix_restrictions(
 
         void operator()(const function_call&) {
             on_internal_error(rlogger, "extract_clustering_prefix_restrictions(function_call)");
+        }
+
+        void operator()(const cast&) {
+            on_internal_error(rlogger, "extract_clustering_prefix_restrictions(cast)");
         }
     } v;
     std::visit(v, where_clause);
@@ -982,6 +990,10 @@ struct multi_column_range_accumulator {
 
     void operator()(const function_call&) {
         on_internal_error(rlogger, "function call encountered outside binary operator");
+    }
+
+    void operator()(const cast&) {
+        on_internal_error(rlogger, "typecast encountered outside binary operator");
     }
 
     /// Intersects each range with v.  If any intersection is empty, clears ranges.

--- a/cql3/restrictions/statement_restrictions.cc
+++ b/cql3/restrictions/statement_restrictions.cc
@@ -210,6 +210,10 @@ static std::vector<expr::expression> extract_partition_range(
         }
 
         void operator()(bool) {}
+
+        void operator()(const unresolved_identifier&) {
+            on_internal_error(rlogger, "extract_partition_range(unresolved_identifier)");
+        }
     } v;
     std::visit(v, where_clause);
     if (v.tokens) {
@@ -275,6 +279,10 @@ static std::vector<expr::expression> extract_clustering_prefix_restrictions(
         }
 
         void operator()(bool) {}
+
+        void operator()(const unresolved_identifier&) {
+            on_internal_error(rlogger, "extract_clustering_prefix_restrictions(unresolved_identifier)");
+        }
     } v;
     std::visit(v, where_clause);
 
@@ -946,6 +954,10 @@ struct multi_column_range_accumulator {
 
     void operator()(const token&) {
         on_internal_error(rlogger, "Token encountered outside binary operator");
+    }
+
+    void operator()(const unresolved_identifier&) {
+        on_internal_error(rlogger, "Unresolved identifier encountered outside binary operator");
     }
 
     /// Intersects each range with v.  If any intersection is empty, clears ranges.

--- a/cql3/restrictions/statement_restrictions.cc
+++ b/cql3/restrictions/statement_restrictions.cc
@@ -214,6 +214,10 @@ static std::vector<expr::expression> extract_partition_range(
         void operator()(const unresolved_identifier&) {
             on_internal_error(rlogger, "extract_partition_range(unresolved_identifier)");
         }
+
+        void operator()(const column_mutation_attribute&) {
+            on_internal_error(rlogger, "extract_partition_range(column_mutation_attribute)");
+        }
     } v;
     std::visit(v, where_clause);
     if (v.tokens) {
@@ -282,6 +286,10 @@ static std::vector<expr::expression> extract_clustering_prefix_restrictions(
 
         void operator()(const unresolved_identifier&) {
             on_internal_error(rlogger, "extract_clustering_prefix_restrictions(unresolved_identifier)");
+        }
+
+        void operator()(const column_mutation_attribute&) {
+            on_internal_error(rlogger, "extract_clustering_prefix_restrictions(column_mutation_attribute)");
         }
     } v;
     std::visit(v, where_clause);
@@ -958,6 +966,10 @@ struct multi_column_range_accumulator {
 
     void operator()(const unresolved_identifier&) {
         on_internal_error(rlogger, "Unresolved identifier encountered outside binary operator");
+    }
+
+    void operator()(const column_mutation_attribute&) {
+        on_internal_error(rlogger, "writetime/ttl encountered outside binary operator");
     }
 
     /// Intersects each range with v.  If any intersection is empty, clears ranges.

--- a/cql3/selection/raw_selector.hh
+++ b/cql3/selection/raw_selector.hh
@@ -43,6 +43,7 @@
 #pragma once
 
 #include "cql3/selection/selectable.hh"
+#include "cql3/expr/expression.hh"
 #include "cql3/column_identifier.hh"
 
 namespace cql3 {
@@ -51,11 +52,11 @@ namespace selection {
 
 class raw_selector {
 public:
-    const ::shared_ptr<selectable::raw> selectable_;
+    const expr::expression selectable_;
     const ::shared_ptr<column_identifier> alias;
 
-    raw_selector(shared_ptr<selectable::raw> selectable__, shared_ptr<column_identifier> alias_)
-        : selectable_{selectable__}
+    raw_selector(expr::expression selectable__, shared_ptr<column_identifier> alias_)
+        : selectable_{std::move(selectable__)}
         , alias{alias_}
     { }
 
@@ -70,13 +71,13 @@ public:
         std::vector<::shared_ptr<selectable>> r;
         r.reserve(raws.size());
         for (auto&& raw : raws) {
-            r.emplace_back(raw->selectable_->prepare(schema));
+            r.emplace_back(prepare_selectable(schema, raw->selectable_));
         }
         return r;
     }
 
     bool processes_selection() const {
-        return selectable_->processes_selection();
+        return selectable_processes_selection(selectable_);
     }
 };
 

--- a/cql3/selection/selectable.cc
+++ b/cql3/selection/selectable.cc
@@ -153,16 +153,6 @@ selectable::with_cast::to_string() const {
 }
 
 shared_ptr<selectable>
-selectable::with_cast::raw::prepare(const schema& s) const {
-    return ::make_shared<selectable::with_cast>(_arg->prepare(s), _type);
-}
-
-bool
-selectable::with_cast::raw::processes_selection() const {
-    return true;
-}
-
-shared_ptr<selectable>
 selectable::with_expression::raw::prepare(const schema& s) const {
     return std::visit(overloaded_functor{
         [&] (bool bool_constant) -> shared_ptr<selectable> {
@@ -217,6 +207,9 @@ selectable::with_expression::raw::prepare(const schema& s) const {
                 },
             }, fc.func);
         },
+        [&] (const expr::cast& c) -> shared_ptr<selectable> {
+            return ::make_shared<selectable::with_cast>(c.arg->prepare(s), c.type);
+        },
     }, _expr);
 }
 
@@ -252,6 +245,9 @@ selectable::with_expression::raw::processes_selection() const {
             return true;
         },
         [&] (const expr::function_call& fc) -> bool {
+            return true;
+        },
+        [&] (const expr::cast& c) -> bool {
             return true;
         },
     }, _expr);

--- a/cql3/selection/selectable.cc
+++ b/cql3/selection/selectable.cc
@@ -234,6 +234,9 @@ selectable::with_expression::raw::prepare(const schema& s) const {
                 }));
             return ::make_shared<selectable::with_function>(std::move(name), std::move(args));
         },
+        [&] (const expr::unresolved_identifier& ui) -> shared_ptr<selectable> {
+            return ui.ident->prepare(s);
+        },
     }, _expr);
 }
 
@@ -261,6 +264,9 @@ selectable::with_expression::raw::processes_selection() const {
             // Arguably, should return false, because it only processes the partition key.
             // But selectable::with_function considers it true now, so return that.
             return true;
+        },
+        [&] (const expr::unresolved_identifier& ui) -> bool {
+            return ui.ident->processes_selection();
         },
     }, _expr);
 };

--- a/cql3/selection/selectable.hh
+++ b/cql3/selection/selectable.hh
@@ -54,6 +54,20 @@ namespace cql3 {
 
 namespace selection {
 
+class selectable;
+
+class selectable_raw {
+public:
+    virtual ~selectable_raw() {}
+
+    virtual ::shared_ptr<selectable> prepare(const schema& s) const = 0;
+
+    /**
+     * Returns true if any processing is performed on the selected column.
+     **/
+    virtual bool processes_selection() const = 0;
+};
+
 class selectable {
 public:
     virtual ~selectable() {}
@@ -69,17 +83,7 @@ protected:
         return defs.size() - 1;
     }
 public:
-    class raw {
-    public:
-        virtual ~raw() {}
-
-        virtual ::shared_ptr<selectable> prepare(const schema& s) const = 0;
-
-        /**
-         * Returns true if any processing is performed on the selected column.
-         **/
-        virtual bool processes_selection() const = 0;
-    };
+    using raw = selectable_raw;
 
     class writetime_or_ttl;
 

--- a/cql3/selection/selectable.hh
+++ b/cql3/selection/selectable.hh
@@ -124,16 +124,6 @@ public:
     virtual sstring to_string() const override;
 
     virtual shared_ptr<selector::factory> new_selector_factory(database& db, schema_ptr s, std::vector<const column_definition*>& defs) override;
-    class raw : public selectable::raw {
-        shared_ptr<functions::function> _function;
-        std::vector<shared_ptr<selectable::raw>> _args;
-    public:
-        raw(shared_ptr<functions::function> f, std::vector<shared_ptr<selectable::raw>> args)
-                : _function(f), _args(std::move(args)) {
-        }
-        virtual shared_ptr<selectable> prepare(const schema& s) const override;
-        virtual bool processes_selection() const override;
-    };
 };
 
 class selectable::with_cast : public selectable {

--- a/cql3/selection/selectable.hh
+++ b/cql3/selection/selectable.hh
@@ -137,16 +137,6 @@ public:
     virtual sstring to_string() const override;
 
     virtual shared_ptr<selector::factory> new_selector_factory(database& db, schema_ptr s, std::vector<const column_definition*>& defs) override;
-    class raw : public selectable::raw {
-        ::shared_ptr<selectable::raw> _arg;
-        cql3_type _type;
-    public:
-        raw(shared_ptr<selectable::raw> arg, cql3_type type)
-                : _arg(std::move(arg)), _type(std::move(type)) {
-        }
-        virtual shared_ptr<selectable> prepare(const schema& s) const override;
-        virtual bool processes_selection() const override;
-    };
 };
 
 class selectable::with_expression {

--- a/cql3/selection/selectable.hh
+++ b/cql3/selection/selectable.hh
@@ -109,18 +109,9 @@ public:
     virtual sstring to_string() const override;
 
     virtual shared_ptr<selector::factory> new_selector_factory(database& db, schema_ptr s, std::vector<const column_definition*>& defs) override;
-    class raw : public selectable::raw {
-        functions::function_name _function_name;
-        std::vector<shared_ptr<selectable::raw>> _args;
-    public:
-        raw(functions::function_name function_name, std::vector<shared_ptr<selectable::raw>> args)
-                : _function_name(std::move(function_name)), _args(std::move(args)) {
-        }
-        virtual shared_ptr<selectable> prepare(const schema& s) const override;
-        virtual bool processes_selection() const override;
-        static ::shared_ptr<selectable::with_function::raw> make_count_rows_function();
-    };
 };
+
+expr::expression make_count_rows_function_expression();
 
 class selectable::with_anonymous_function : public selectable {
     shared_ptr<functions::function> _function;

--- a/cql3/selection/selectable.hh
+++ b/cql3/selection/selectable.hh
@@ -48,6 +48,7 @@
 #include "cql3/cql3_type.hh"
 #include "cql3/functions/function.hh"
 #include "cql3/functions/function_name.hh"
+#include "cql3/expr/expression.hh"
 
 namespace cql3 {
 
@@ -88,6 +89,7 @@ public:
     class with_field_selection;
 
     class with_cast;
+    class with_expression;
 };
 
 std::ostream & operator<<(std::ostream &os, const selectable& s);
@@ -159,6 +161,18 @@ public:
         }
         virtual shared_ptr<selectable> prepare(const schema& s) const override;
         virtual bool processes_selection() const override;
+    };
+};
+
+class selectable::with_expression {
+public:
+    class raw : public selectable::raw {
+        cql3::expr::expression _expr;
+    public:
+        explicit raw(cql3::expr::expression expr) : _expr(std::move(expr)) {}
+        virtual shared_ptr<selectable> prepare(const schema& s) const override;
+        virtual bool processes_selection() const override;
+        const cql3::expr::expression& expression() const { return _expr; }
     };
 };
 

--- a/cql3/selection/selectable.hh
+++ b/cql3/selection/selectable.hh
@@ -56,18 +56,6 @@ namespace selection {
 
 class selectable;
 
-class selectable_raw {
-public:
-    virtual ~selectable_raw() {}
-
-    virtual ::shared_ptr<selectable> prepare(const schema& s) const = 0;
-
-    /**
-     * Returns true if any processing is performed on the selected column.
-     **/
-    virtual bool processes_selection() const = 0;
-};
-
 class selectable {
 public:
     virtual ~selectable() {}
@@ -83,8 +71,6 @@ protected:
         return defs.size() - 1;
     }
 public:
-    using raw = selectable_raw;
-
     class writetime_or_ttl;
 
     class with_function;
@@ -93,7 +79,6 @@ public:
     class with_field_selection;
 
     class with_cast;
-    class with_expression;
 };
 
 std::ostream & operator<<(std::ostream &os, const selectable& s);
@@ -139,17 +124,8 @@ public:
     virtual shared_ptr<selector::factory> new_selector_factory(database& db, schema_ptr s, std::vector<const column_definition*>& defs) override;
 };
 
-class selectable::with_expression {
-public:
-    class raw : public selectable::raw {
-        cql3::expr::expression _expr;
-    public:
-        explicit raw(cql3::expr::expression expr) : _expr(std::move(expr)) {}
-        virtual shared_ptr<selectable> prepare(const schema& s) const override;
-        virtual bool processes_selection() const override;
-        const cql3::expr::expression& expression() const { return _expr; }
-    };
-};
+shared_ptr<selectable> prepare_selectable(const schema& s, const expr::expression& raw_selectable);
+bool selectable_processes_selection(const expr::expression& raw_selectable);
 
 }
 

--- a/cql3/selection/selectable_with_field_selection.hh
+++ b/cql3/selection/selectable_with_field_selection.hh
@@ -62,17 +62,6 @@ public:
     virtual sstring to_string() const override;
 
     virtual shared_ptr<selector::factory> new_selector_factory(database& db, schema_ptr s, std::vector<const column_definition*>& defs) override;
-
-    class raw : public selectable::raw {
-        shared_ptr<selectable::raw> _selected;
-        shared_ptr<column_identifier::raw> _field;
-    public:
-        raw(shared_ptr<selectable::raw> selected, shared_ptr<column_identifier::raw> field)
-                : _selected(std::move(selected)), _field(std::move(field)) {
-        }
-        virtual shared_ptr<selectable> prepare(const schema& s) const override;
-        virtual bool processes_selection() const override;
-    };
 };
 
 }

--- a/cql3/selection/writetime_or_ttl.hh
+++ b/cql3/selection/writetime_or_ttl.hh
@@ -61,17 +61,6 @@ public:
     virtual sstring to_string() const override;
 
     virtual shared_ptr<selector::factory> new_selector_factory(database& db, schema_ptr s, std::vector<const column_definition*>& defs) override;
-
-    class raw : public selectable::raw {
-        shared_ptr<column_identifier::raw> _id;
-        bool _is_writetime;
-    public:
-        raw(shared_ptr<column_identifier::raw> id, bool is_writetime)
-            : _id(std::move(id)), _is_writetime(is_writetime) {
-        }
-        virtual shared_ptr<selectable> prepare(const schema& s) const override;
-        virtual bool processes_selection() const override;
-    };
 };
 
 }

--- a/cql3/statements/create_view_statement.cc
+++ b/cql3/statements/create_view_statement.cc
@@ -203,9 +203,6 @@ future<shared_ptr<cql_transport::event::schema_change>> create_view_statement::a
         }
 
         auto selectable = selector->selectable_;
-        if (dynamic_pointer_cast<selection::selectable::with_field_selection::raw>(selectable)) {
-            throw exceptions::invalid_request_exception(format("Cannot select out a part of type when defining a materialized view"));
-        }
         shared_ptr<column_identifier::raw> identifier;
         if (auto e = dynamic_pointer_cast<selection::selectable::with_expression::raw>(selectable)) {
             std::visit(overloaded_functor{

--- a/cql3/statements/create_view_statement.cc
+++ b/cql3/statements/create_view_statement.cc
@@ -212,6 +212,12 @@ future<shared_ptr<cql_transport::event::schema_change>> create_view_statement::a
         if (dynamic_pointer_cast<selection::selectable::writetime_or_ttl::raw>(selectable)) {
             throw exceptions::invalid_request_exception(format("Cannot use function when defining a materialized view"));
         }
+        if (auto e = dynamic_pointer_cast<selection::selectable::with_expression::raw>(selectable)) {
+            std::visit(overloaded_functor{
+                [] (const auto& default_case) -> void { throw exceptions::invalid_request_exception(format("Cannot use general expressions when defining a materialized view")); },
+            },
+            e->expression());
+        }
 
         assert(dynamic_pointer_cast<column_identifier::raw>(selectable));
         auto identifier = static_pointer_cast<column_identifier::raw>(selectable);

--- a/cql3/statements/create_view_statement.cc
+++ b/cql3/statements/create_view_statement.cc
@@ -206,9 +206,6 @@ future<shared_ptr<cql_transport::event::schema_change>> create_view_statement::a
         if (dynamic_pointer_cast<selection::selectable::with_field_selection::raw>(selectable)) {
             throw exceptions::invalid_request_exception(format("Cannot select out a part of type when defining a materialized view"));
         }
-        if (dynamic_pointer_cast<selection::selectable::with_function::raw>(selectable)) {
-            throw exceptions::invalid_request_exception(format("Cannot use function when defining a materialized view"));
-        }
         shared_ptr<column_identifier::raw> identifier;
         if (auto e = dynamic_pointer_cast<selection::selectable::with_expression::raw>(selectable)) {
             std::visit(overloaded_functor{

--- a/cql3/statements/create_view_statement.cc
+++ b/cql3/statements/create_view_statement.cc
@@ -209,9 +209,6 @@ future<shared_ptr<cql_transport::event::schema_change>> create_view_statement::a
         if (dynamic_pointer_cast<selection::selectable::with_function::raw>(selectable)) {
             throw exceptions::invalid_request_exception(format("Cannot use function when defining a materialized view"));
         }
-        if (dynamic_pointer_cast<selection::selectable::writetime_or_ttl::raw>(selectable)) {
-            throw exceptions::invalid_request_exception(format("Cannot use function when defining a materialized view"));
-        }
         shared_ptr<column_identifier::raw> identifier;
         if (auto e = dynamic_pointer_cast<selection::selectable::with_expression::raw>(selectable)) {
             std::visit(overloaded_functor{

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -1400,7 +1400,7 @@ void select_statement::maybe_jsonize_select_clause(database& db, schema_ptr sche
         }
         auto as_json = ::make_shared<functions::as_json_function>(std::move(selector_names), std::move(selector_types));
         auto as_json_selector = ::make_shared<selection::raw_selector>(
-                ::make_shared<selection::selectable::with_anonymous_function::raw>(as_json, std::move(raw_selectables)), nullptr);
+                ::make_shared<selection::selectable::with_expression::raw>(expr::function_call{as_json, std::move(raw_selectables)}), nullptr);
         _select_clause.clear();
         _select_clause.push_back(as_json_selector);
     }

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -1373,7 +1373,9 @@ void select_statement::maybe_jsonize_select_clause(database& db, schema_ptr sche
             _select_clause.reserve(schema->all_columns().size());
             for (const column_definition& column_def : schema->all_columns_in_select_order()) {
                 _select_clause.push_back(make_shared<selection::raw_selector>(
-                        ::make_shared<column_identifier::raw>(column_def.name_as_text(), true), nullptr));
+                    make_shared<selection::selectable::with_expression::raw>(
+                        expr::unresolved_identifier{::make_shared<column_identifier::raw>(column_def.name_as_text(), true)}),
+                    nullptr));
             }
         }
 

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -1373,8 +1373,7 @@ void select_statement::maybe_jsonize_select_clause(database& db, schema_ptr sche
             _select_clause.reserve(schema->all_columns().size());
             for (const column_definition& column_def : schema->all_columns_in_select_order()) {
                 _select_clause.push_back(make_shared<selection::raw_selector>(
-                    make_shared<selection::selectable::with_expression::raw>(
-                        expr::unresolved_identifier{::make_shared<column_identifier::raw>(column_def.name_as_text(), true)}),
+                    expr::unresolved_identifier{::make_shared<column_identifier::raw>(column_def.name_as_text(), true)},
                     nullptr));
             }
         }
@@ -1393,14 +1392,14 @@ void select_statement::maybe_jsonize_select_clause(database& db, schema_ptr sche
         }
 
         // Prepare args for as_json_function
-        std::vector<::shared_ptr<selection::selectable::raw>> raw_selectables;
+        std::vector<expr::expression> raw_selectables;
         raw_selectables.reserve(_select_clause.size());
         for (const auto& raw_selector : _select_clause) {
             raw_selectables.push_back(raw_selector->selectable_);
         }
         auto as_json = ::make_shared<functions::as_json_function>(std::move(selector_names), std::move(selector_types));
         auto as_json_selector = ::make_shared<selection::raw_selector>(
-                ::make_shared<selection::selectable::with_expression::raw>(expr::function_call{as_json, std::move(raw_selectables)}), nullptr);
+                expr::function_call{as_json, std::move(raw_selectables)}, nullptr);
         _select_clause.clear();
         _select_clause.push_back(as_json_selector);
     }

--- a/utils/variant_element.hh
+++ b/utils/variant_element.hh
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2021-present ScyllaDB
+ */
+
+/*
+ * This file is part of Scylla.
+ *
+ * Scylla is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Scylla is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <variant>
+#include <type_traits>
+
+namespace utils {
+
+// Given type T and an std::variant Variant, return std::true_type if T is a variant element
+// This is also the recursion base case (empty variant), so return false.
+template <typename T, typename Variant>
+struct is_variant_element : std::false_type {
+};
+
+// Match - return true
+template <typename T, typename... Elements>
+struct is_variant_element<T, std::variant<T, Elements...>> : std::true_type {
+};
+
+// No match - recurse
+template <typename T, typename U, typename... Elements>
+struct is_variant_element<T, std::variant<U, Elements...>> : is_variant_element<T, std::variant<Elements...>> {
+};
+
+// Givent type T and std::variant, true if T is one of the variant elements.
+template <typename T, typename Variant>
+concept VariantElement = is_variant_element<T, Variant>::value;
+
+}


### PR DESCRIPTION
Currently, the grammar has two parallel hierarchies. One hierarchy is
used in the WHERE clause, and is based on a combination of `term`
and expressions. The other is used in the SELECT clause, and is
using the cql3::selection::selectable hierarchy. There is some overlap
between the hierarchies: both can name columns. Logically, however,
they overlap completely - in SQL anything you can select you can
filter on, and vice versa. So merging the two hierarchies is important if
we want to enrich CQL. This series does that, partially (see below),
converting the SELECT clause to expressions.

There is another hierarchy split: between the "raw", pre-prepare object
hierarchy, and post-prepare non-raw. This series limits itself to converting
the raw hierarchy and leaves the non-raw hierarchy alone.

An important design choice is not to have this raw/non-raw split in expressions.
Note that most of the hierarchy is completely parallel: addition is addition
both before prepare and after prepare (but see [1]). The main difference
is around identifiers - before preparation they are unresolved, and after
preparation they become `column_definition` objects. We resolve that by
having two separate types: `unresolved_identifier` for the pre-prepare phase,
and the existing `column_value` for post-prepare phase.

Alternative choices would be to keep a separate expression::raw variant, or
to template the expression variant on whether it is raw or not. I think it would
cause undue bloat and confusion.

Note the series introduces many on_internal_error() calls. This is because
there is not a lot of overlap in the hierarchies today; you can't have a cast in
the WHERE clause, for example. These on_internal_error() calls cannot be
triggered since the grammar does not yet allow such expressions to be
expressed. As we expand the grammar, they will have to be replaced with
working implementations.

Lastly, field selection is expressible in both hierarchies. This series does not yet
merge the two representations (`column_value.sub` vs `field_selection`), but it
should be easy to do so later.

[1] the `+` operator can also be translated to list concatenation, which we may
  choose to represent by yet another type.

Test: unit(dev)