### PR TITLE
sstables: keys: convert trichotomic comparisons to std::strong_ordering

### DIFF
--- a/dht/i_partitioner.cc
+++ b/dht/i_partitioner.cc
@@ -322,7 +322,7 @@ std::strong_ordering ring_position_comparator_for_sstables::operator()(ring_posi
     }
     if (lh._key) {
         auto rel = rh.key().tri_compare(s, *lh._key);
-        if (rel) {
+        if (rel != std::strong_ordering::equal) {
             return 0 <=> rel;
         }
     }

--- a/sstables/binary_search.hh
+++ b/sstables/binary_search.hh
@@ -50,7 +50,8 @@ namespace sstables {
  */
 template <typename T>
 int binary_search(const dht::i_partitioner& partitioner, const T& entries, const key& sk, const dht::token& token) {
-    int low = 0, mid = entries.size(), high = mid - 1, result = -1;
+    int low = 0, mid = entries.size(), high = mid - 1;
+    std::strong_ordering result = std::strong_ordering::less;
 
     while (low <= high) {
         // The token comparison should yield the right result most of the time.
@@ -64,7 +65,7 @@ int binary_search(const dht::i_partitioner& partitioner, const T& entries, const
         if (token == mid_token) {
             result = sk.tri_compare(mid_key);
         } else {
-            result = token < mid_token ? -1 : 1;
+            result = token < mid_token ? std::strong_ordering::less : std::strong_ordering::greater;
         }
 
         if (result > 0) {

--- a/sstables/key.hh
+++ b/sstables/key.hh
@@ -57,16 +57,16 @@ public:
 
     bool empty() const { return _bytes.empty(); }
 
-    int tri_compare(key_view other) const {
-        return compare_unsigned(_bytes, other._bytes);
+    std::strong_ordering tri_compare(key_view other) const {
+        return compare_unsigned(_bytes, other._bytes) <=> 0;
     }
 
-    int tri_compare(const schema& s, partition_key_view other) const {
+    std::strong_ordering tri_compare(const schema& s, partition_key_view other) const {
         return with_linearized([&] (bytes_view v) {
             auto lf = other.legacy_form(s);
             return lexicographical_tri_compare(
                     v.begin(), v.end(), lf.begin(), lf.end(),
-                    [](uint8_t b1, uint8_t b2) { return (int) b1 - b2; });
+                    [](uint8_t b1, uint8_t b2) { return (int) b1 - b2; }) <=> 0;
         });
     }
 };
@@ -119,12 +119,12 @@ public:
         return composite_view(_bytes, is_compound(s)).explode();
     }
 
-    int32_t tri_compare(key_view k) const {
+    std::strong_ordering tri_compare(key_view k) const {
         if (_kind == kind::before_all_keys) {
-            return -1;
+            return std::strong_ordering::less;
         }
         if (_kind == kind::after_all_keys) {
-            return 1;
+            return std::strong_ordering::greater;
         }
         return key_view(_bytes).tri_compare(k);
     }


### PR DESCRIPTION
Prevent accidental conversions to bool from yielding the wrong results.
Unprepared users (that converted to bool, or assigned to int) are adjusted.

Ref #1449

Test: unit (dev)