### PR TITLE
scylla_setup: add RAID5 support

### DIFF
--- a/dist/common/scripts/scylla_raid_setup
+++ b/dist/common/scripts/scylla_raid_setup
@@ -48,6 +48,8 @@ if __name__ == '__main__':
                         help='specify how will this device be used (data, commitlog, or all)')
     parser.add_argument('--force-raid', action='store_true', default=False,
                         help='force constructing RAID when only one disk is specified')
+    parser.add_argument('--raid-level', default='0',
+                        help='specify RAID level')
 
     args = parser.parse_args()
 
@@ -120,7 +122,7 @@ if __name__ == '__main__':
     except SystemdException:
         md_service = systemd_unit('mdadm.service')
 
-    print('Creating {type} for scylla using {nr_disk} disk(s): {disks}'.format(type='RAID0' if raid else 'XFS volume', nr_disk=len(disks), disks=args.disks))
+    print('Creating {type} for scylla using {nr_disk} disk(s): {disks}'.format(type='fRAID{args.raid_level}' if raid else 'XFS volume', nr_disk=len(disks), disks=args.disks))
     procs=[]
     for disk in disks:
         d = disk.replace('/dev/', '')
@@ -135,7 +137,7 @@ if __name__ == '__main__':
         proc.wait()
     if raid:
         run('udevadm settle', shell=True, check=True)
-        run('mdadm --create --verbose --force --run {raid} --level=0 -c1024 --raid-devices={nr_disk} {disks}'.format(raid=fsdev, nr_disk=len(disks), disks=args.disks.replace(',', ' ')), shell=True, check=True)
+        run('mdadm --create --verbose --force --run {raid} --level={level} -c1024 --raid-devices={nr_disk} {disks}'.format(raid=fsdev, level=args.raid_level, nr_disk=len(disks), disks=args.disks.replace(',', ' ')), shell=True, check=True)
         run('udevadm settle', shell=True, check=True)
 
     major_minor = os.stat(fsdev).st_rdev

--- a/dist/common/scripts/scylla_setup
+++ b/dist/common/scripts/scylla_setup
@@ -225,6 +225,8 @@ if __name__ == '__main__':
     group.add_argument('--no-raid-setup', action='store_true',
                         default=default_no_raid_setup,
                         help='skip raid setup')
+    parser.add_argument('--raid-level-5', action='store_true', default=False,
+                        help='use RAID5 for RAID volume')
     parser.add_argument('--nic',
                         help='specify NIC')
     parser.add_argument('--ntp-domain',
@@ -316,6 +318,7 @@ if __name__ == '__main__':
     bootparam_setup = not args.no_bootparam_setup
     ntp_setup = not args.no_ntp_setup
     raid_setup = not args.no_raid_setup
+    raid_level_5 = args.raid_level_5
     coredump_setup = not args.no_coredump_setup
     sysconfig_setup = not args.no_sysconfig_setup
     io_setup = args.io_setup
@@ -420,11 +423,13 @@ if __name__ == '__main__':
             else:
                 run_setup_script('NTP', 'scylla_ntp_setup')
 
-        res = interactive_ask_service('Do you want to setup RAID0 and XFS?', 'It is recommended to use RAID0 and XFS for Scylla data. If you select yes, you will be prompted to choose the unmounted disks to use for Scylla data. Selected disks are formatted as part of the process.\nYes - choose a disk/disks to format and setup for RAID0 and XFS. No - skip this step.', raid_setup)
+        res = interactive_ask_service('Do you want to setup RAID and XFS?', 'It is recommended to use RAID and XFS for Scylla data. If you select yes, you will be prompted to choose the unmounted disks to use for Scylla data. Selected disks are formatted as part of the process.\nYes - choose a disk/disks to format and setup for RAID and XFS. No - skip this step.', raid_setup)
         if res:
-            raid_setup = interactive_ask_service('Are you sure you want to setup RAID0 and XFS?', 'If you choose Yes, the selected drive will be reformated, erasing all existing data in the process.', raid_setup)
+            raid_setup = interactive_ask_service('Are you sure you want to setup RAID and XFS?', 'If you choose Yes, the selected drive will be reformated, erasing all existing data in the process.', raid_setup)
         else:
             raid_setup = False
+        if res and raid_setup:
+            raid_level_5 = interactive_ask_service('Do you want to change RAID level to RAID5?', 'If you choose Yes, change RAID level to RAID5. Otherwise we will use RAID0.', raid_level_5)
         if res and raid_setup and os.path.exists('/etc/systemd/system/var-lib-scylla.mount'):
             colorprint('{red}/etc/systemd/system/var-lib-scylla.mount already exists, skipping RAID setup.{nocolor}')
             raid_setup = False
@@ -472,7 +477,8 @@ if __name__ == '__main__':
 
         args.no_raid_setup = not raid_setup
         if raid_setup:
-            run_setup_script('RAID', f'scylla_raid_setup --disks {disks} --enable-on-nextboot')
+            level = '5' if raid_level_5 else '0'
+            run_setup_script('RAID', f'scylla_raid_setup --disks {disks} --enable-on-nextboot --raid-level={level}')
 
         coredump_setup = interactive_ask_service('Do you want to enable coredumps?', 'Yes - sets up coredump to allow a post-mortem analysis of the Scylla state just prior to a crash. No - skips this step.', coredump_setup)
         args.no_coredump_setup = not coredump_setup


### PR DESCRIPTION
This supports optional RAID5 support on scylla_setup.

Fixes #9076