### PR TITLE
Add service level config change subscription API

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -509,6 +509,7 @@ scylla_tests = set([
     'test/boost/stall_free_test',
     'test/boost/sstable_set_test',
     'test/boost/reader_concurrency_semaphore_test',
+    'test/boost/service_level_controller_test',
     'test/manual/ec2_snitch_test',
     'test/manual/enormous_table_scan_test',
     'test/manual/gce_snitch_test',

--- a/service/qos/qos_configuration_change_subscriber.hh
+++ b/service/qos/qos_configuration_change_subscriber.hh
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2021-present ScyllaDB
+ */
+
+/*
+ * This file is part of Scylla.
+ *
+ * Scylla is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Scylla is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "qos_common.hh"
+
+namespace qos {
+    class qos_configuration_change_subscriber {
+    public:
+        /** This callback is going to be called just before the service level is available **/
+        virtual future<> on_before_service_level_add(sstring name, service_level_options slo) = 0;
+        /** This callback is going to be called just after the service level is removed **/
+        virtual future<> on_after_service_level_remove(sstring name) = 0;
+        /** This callback is going to be called just before the service level is changed **/
+        virtual future<> on_before_service_level_change(sstring name, service_level_options slo_before, service_level_options slo_after) = 0;
+
+        virtual ~qos_configuration_change_subscriber() {};
+    };
+}

--- a/service/qos/service_level_controller.cc
+++ b/service/qos/service_level_controller.cc
@@ -231,15 +231,34 @@ future<std::optional<service_level_options>> service_level_controller::find_serv
 }
 
 future<>  service_level_controller::notify_service_level_added(sstring name, service_level sl_data) {
-    _service_levels_db.emplace(name, sl_data);
-    return make_ready_future();
+    return seastar::async( [this, name, sl_data] {
+        _subscribers.for_each([name, sl_data] (qos_configuration_change_subscriber* subscriber) {
+            try {
+                subscriber->on_before_service_level_add(name, sl_data.slo).get();
+            } catch (...) {
+                sl_logger.error("notify_service_level_added: exception occurred in one of the observers callbacks {}", std::current_exception());
+            }
+        });
+        _service_levels_db.emplace(name, sl_data);
+    });
+
 }
 
 future<> service_level_controller::notify_service_level_updated(sstring name, service_level_options slo) {
     auto sl_it = _service_levels_db.find(name);
     future<> f = make_ready_future();
     if (sl_it != _service_levels_db.end()) {
-        sl_it->second.slo = slo;
+        service_level_options slo_before = sl_it->second.slo;
+        return seastar::async( [this,sl_it, name, slo_before, slo] {
+            _subscribers.for_each([name, slo_before, slo] (qos_configuration_change_subscriber* subscriber) {
+                try {
+                    subscriber->on_before_service_level_change(name, slo_before, slo).get();
+                } catch (...) {
+                    sl_logger.error("notify_service_level_updated: exception occurred in one of the observers callbacks {}", std::current_exception());
+                }
+            });
+            sl_it->second.slo = slo;
+        });
     }
     return f;
 }
@@ -249,7 +268,15 @@ future<> service_level_controller::notify_service_level_removed(sstring name) {
     if (sl_it != _service_levels_db.end()) {
         _service_levels_db.erase(sl_it);
     }
-    return make_ready_future();
+    return seastar::async( [this, name] {
+        _subscribers.for_each([name] (qos_configuration_change_subscriber* subscriber) {
+            try {
+                subscriber->on_after_service_level_remove(name).get();
+            } catch (...) {
+                sl_logger.error("notify_service_level_removed: exception occurred in one of the observers callbacks {}", std::current_exception());
+            }
+        });
+    });
 }
 
 void service_level_controller::update_from_distributed_data(std::chrono::duration<float> interval) {
@@ -422,5 +449,13 @@ void service_level_controller::on_leave_cluster(const gms::inet_address& endpoin
 void service_level_controller::on_up(const gms::inet_address& endpoint) { }
 
 void service_level_controller::on_down(const gms::inet_address& endpoint) { }
+
+void service_level_controller::register_subscriber(qos_configuration_change_subscriber* subscriber) {
+    _subscribers.add(subscriber);
+}
+
+future<> service_level_controller::unregister_subscriber(qos_configuration_change_subscriber* subscriber) {
+    return _subscribers.remove(subscriber);
+}
 
 }

--- a/test/boost/service_level_controller_test.cc
+++ b/test/boost/service_level_controller_test.cc
@@ -1,0 +1,126 @@
+/*
+ * Copyright (C) 2021-present ScyllaDB
+ */
+
+/*
+ * This file is part of Scylla.
+ *
+ * Scylla is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Scylla is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#include <boost/test/unit_test.hpp>
+#include <stdlib.h>
+#include <iostream>
+
+#include "seastarx.hh"
+#include <seastar/testing/test_case.hh>
+#include <seastar/testing/thread_test_case.hh>
+#include <seastar/core/future-util.hh>
+#include <algorithm>
+#include "service/qos/service_level_controller.hh"
+#include "service/qos/qos_configuration_change_subscriber.hh"
+#include "auth/service.hh"
+#include "utils/overloaded_functor.hh"
+
+using namespace qos;
+struct add_op {
+    sstring name;
+    service_level_options slo;
+    bool operator==(const add_op& other) const = default;
+    bool operator!=(const add_op& other) const = default;
+};
+
+struct remove_op {
+    sstring name;
+    bool operator==(const remove_op& other) const = default;
+    bool operator!=(const remove_op& other) const = default;
+};
+
+struct change_op {
+    sstring name;
+    service_level_options slo_before;
+    service_level_options slo_after;
+    bool operator==(const change_op& other) const = default;
+    bool operator!=(const change_op& other) const = default;
+};
+
+using service_level_op =  std::variant<add_op, remove_op, change_op>;
+
+struct qos_configuration_change_suscriber_simple : public qos_configuration_change_subscriber {
+
+
+    std::vector<service_level_op> ops;
+
+    virtual future<> on_before_service_level_add(sstring name, service_level_options slo) override {
+        ops.push_back(add_op{name, slo});
+        return make_ready_future<>();
+    }
+
+    virtual future<> on_after_service_level_remove(sstring name) override {
+        ops.push_back(remove_op{name});
+        return make_ready_future<>();
+    }
+
+    virtual future<> on_before_service_level_change(sstring name, service_level_options slo_before, service_level_options slo_after) override {
+        ops.push_back(change_op{name, slo_before, slo_after});
+        return make_ready_future<>();
+    }
+};
+
+std::ostream& operator<<(std::ostream& os, const add_op& op) {
+    return os << "Service Level: added '" << op.name << "' with " << op.slo.workload;
+}
+
+std::ostream& operator<<(std::ostream& os, const change_op& op) {
+    return os << "Service Level: changed '" << op.name << "' from " << op.slo_before.workload << " to " << op.slo_after.workload;
+}
+
+std::ostream& operator<<(std::ostream& os, const remove_op& op) {
+    return os << "Service Level: removed '" << op.name << "'";
+}
+
+std::ostream& operator<<(std::ostream& os, const service_level_op& op) {
+     std::visit(overloaded_functor {
+            [&os] (const add_op& op) { os << op; },
+            [&os] (const remove_op& op) { os << op; },
+            [&os] (const change_op& op) { os << op; },
+     }, op);
+     return os;
+}
+
+SEASTAR_THREAD_TEST_CASE(subscriber_simple) {
+    sharded<service_level_controller> sl_controller;
+    sharded<auth::service> auth_service;
+    sl_controller.start(std::ref(auth_service), service_level_options{}).get();
+    qos_configuration_change_suscriber_simple ccss;
+    sl_controller.local().register_subscriber(&ccss);
+    sl_controller.local().add_service_level("sl1", service_level_options{}).get();
+    sl_controller.local().add_service_level("sl2", service_level_options{}).get();
+    service_level_options slo;
+    slo.workload = service_level_options::workload_type::interactive;
+    sl_controller.local().add_service_level("sl1", slo).get();
+    sl_controller.local().remove_service_level("sl2", false).get();
+
+    std::vector<service_level_op> expected_result = {
+        add_op{"sl1", service_level_options{}},
+        add_op{"sl2", service_level_options{}},
+        change_op{"sl1", service_level_options{}, slo},
+        remove_op{"sl2"},
+    };
+
+    sl_controller.local().unregister_subscriber(&ccss).get();
+    BOOST_REQUIRE_EQUAL(ccss.ops, expected_result);
+    sl_controller.stop().get();
+}


### PR DESCRIPTION
In order to decouple the service level controller from the systems logic, we introduce an API for subscribing to configuration changes. The timing of the call was determined with resource creation and destruction in mind. An API subscriber can create
resources that will be available from the very start of the service level existence it can also destroy them since the service level
is guarantied not to exist anymore at the time of the call to the deletion notification callback.

Testing:
unit tests - all + a newly added one.
dtests - next-gating (dev mode)