### PR TITLE
cql3: term: make term::raw, term::multi_column_raw forward declarable

### DIFF
--- a/cql3/tuples.hh
+++ b/cql3/tuples.hh
@@ -64,7 +64,7 @@ public:
     class literal : public term::multi_column_raw {
         std::vector<shared_ptr<term::raw>> _elements;
     public:
-        literal(std::vector<shared_ptr<raw>> elements)
+        literal(std::vector<shared_ptr<term::raw>> elements)
                 : _elements(std::move(elements)) {
         }
         virtual shared_ptr<term> prepare(database& db, const sstring& keyspace, lw_shared_ptr<column_specification> receiver) const override;


### PR DESCRIPTION
As preparation for converting term::raw an expression, make it
forward declarable so that we can have a term::raw that is an
expression, and an expression that is a term::raw, without driving
the compiler insane.