### PR TITLE
dist/debian: keep sysconfdir.conf for scylla-housekeeping on 'remove'

### DIFF
--- a/dist/debian/debian/scylla-server.postrm
+++ b/dist/debian/debian/scylla-server.postrm
@@ -4,13 +4,13 @@ set -e
 
 case "$1" in
     purge|remove)
-        rm -rf /etc/systemd/system/scylla-housekeeping-daily.service.d/
-        rm -rf /etc/systemd/system/scylla-housekeeping-restart.service.d/
         rm -rf /etc/systemd/system/scylla-helper.slice.d/
         # We need to keep dependencies.conf and sysconfdir.conf on 'remove',
         # otherwise it will be missing after rollback.
         if [ "$1" = "purge" ]; then
             rm -rf /etc/systemd/system/scylla-server.service.d/
+            rm -rf /etc/systemd/system/scylla-housekeeping-daily.service.d/
+            rm -rf /etc/systemd/system/scylla-housekeeping-restart.service.d/
         fi
         ;;
 esac


### PR DESCRIPTION
Same as 4309785, dpkg does not re-install confffiles when it removed by
user, we are missing sysconfdir.conf for scylla-housekeeping on rollback.
To prevent this, we need to stop removing drop-in file directory on
'remove'.

Fixes #9109