### PR TITLE
add multi-version control to docs 

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -157,7 +157,7 @@ redirects_file = "_utils/redirections.yaml"
 TAGS = []
 smv_tag_whitelist = multiversion_regex_builder(TAGS)
 # Whitelist pattern for branches (set to None to ignore all branches)
-BRANCHES = ['master']
+BRANCHES = ['branch-4.3', 'branch-4.4', 'branch-4.5']
 smv_branch_whitelist = multiversion_regex_builder(BRANCHES)
 # Whitelist pattern for remotes (set to None to use local branches only)
 smv_remote_whitelist = r"^origin$"
@@ -165,6 +165,8 @@ smv_remote_whitelist = r"^origin$"
 smv_released_pattern = r'^tags/.*$'
 # Format for versioned output directories inside the build directory
 smv_outputdir_format = '{ref.name}'
+smv_latest_version = 'branch-4.4'
+smv_rename_latest_version = 'stable' # Use the commit hash
 
 # -- Options for LaTeX page output ---------------------------------------
 


### PR DESCRIPTION
This PR adds the ability to branch docs on a version by version basis. 

@dgarcia360  please review

To Test 

Run multiversionpreview 

Before - only Master was a selection (which we didn't want )
![Screenshot from 2021-07-29 12-00-54](https://user-images.githubusercontent.com/36125151/127463821-3272c742-b0bf-4ca4-912a-a5a73d313315.png)


After - there is a dropdown and 4.4 is the default page
![Screenshot from 2021-07-29 12-00-11](https://user-images.githubusercontent.com/36125151/127463877-747327a2-b71b-47f2-b0bc-ee4b7acd32ed.png)
