### PR TITLE
cql3: Ignore regular index in multi-column WHERE

### DIFF
--- a/cql3/restrictions/statement_restrictions.hh
+++ b/cql3/restrictions/statement_restrictions.hh
@@ -103,6 +103,7 @@ private:
     bool _is_key_range = false;
 
     bool _has_queriable_regular_index = false, _has_queriable_pk_index = false, _has_queriable_ck_index = false;
+    bool _has_multi_column; ///< True iff _clustering_columns_restrictions has a multi-column restriction.
 
     std::optional<expr::expression> _where; ///< The entire WHERE clause.
 

--- a/test/cql-pytest/test_secondary_index.py
+++ b/test/cql-pytest/test_secondary_index.py
@@ -241,3 +241,23 @@ def test_filter_cluster_key(cql, test_keyspace):
         stmt = SimpleStatement(f"SELECT c1, c2 FROM {table} WHERE c1 = 1 and c2 = 1 ALLOW FILTERING")
         rows = cql.execute(stmt)
         assert_rows(rows, [1, 1])
+
+# Reproduces #9085.  Scylla-only because Cassandra uses indices differently.
+def test_multi_column_skips_regular_index(cql, test_keyspace, scylla_only):
+    with new_test_table(cql, test_keyspace, 'p int, c1 int, c2 int, r int, primary key(p,c1,c2)') as tbl:
+        cql.execute(f'CREATE INDEX ON {tbl}(r)')
+        cql.execute(f'INSERT INTO {tbl}(p, c1, c2, r) VALUES (1, 1, 1, 0)')
+        cql.execute(f'INSERT INTO {tbl}(p, c1, c2, r) VALUES (1, 1, 2, 1)')
+        cql.execute(f'INSERT INTO {tbl}(p, c1, c2, r) VALUES (1, 2, 1, 0)')
+        with pytest.raises(InvalidRequest, match="use ALLOW FILTERING"):
+            cql.execute(f'SELECT c1 FROM {tbl} WHERE p=1 AND (c1,c2)<(2,0) AND r=0')
+
+@pytest.mark.xfail(reason="Other restrictions are ignored when clustering key is constrained.  Issue #6200")
+def test_multi_column_with_regular_index_gives_correct_results(cql, test_keyspace):
+    with new_test_table(cql, test_keyspace, 'p int, c1 int, c2 int, r int, primary key(p,c1,c2)') as tbl:
+        cql.execute(f'CREATE INDEX ON {tbl}(r)')
+        cql.execute(f'INSERT INTO {tbl}(p, c1, c2, r) VALUES (1, 1, 1, 0)')
+        cql.execute(f'INSERT INTO {tbl}(p, c1, c2, r) VALUES (1, 1, 2, 1)')
+        cql.execute(f'INSERT INTO {tbl}(p, c1, c2, r) VALUES (1, 2, 1, 0)')
+        assert_rows(cql.execute(f'SELECT c1 FROM {tbl} WHERE (c1,c2)<(2,0) AND r=0 ALLOW FILTERING'), [1])
+        assert_rows(cql.execute(f'SELECT c1 FROM {tbl} WHERE p=1 AND (c1,c2)<(2,0) AND r=0 ALLOW FILTERING'), [1])


### PR DESCRIPTION
When the WHERE clause contains a multi-column restriction as well as
an equality on an indexed regular column, we will not use the index.
The index cannot eliminate post-fetch filtering here, but it does add
an extra table query to the execution.

This is similar to db63b4034, which dealt with a clustering-column
index.  Here we deal with a non-key column being indexed.

Fixes #9085.

Tests: unit (dev, debug)

Signed-off-by: Dejan Mircevski <dejan@scylladb.com>