### PR TITLE
db: schema_tables: coroutinize

### DIFF
--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -803,7 +803,7 @@ read_schema_for_keyspaces(distributed<service::storage_proxy>& proxy, const sstr
         }
         return std::move(result);
     };
-    return map_reduce(keyspace_names.begin(), keyspace_names.end(), map, schema_result{}, insert);
+    co_return co_await map_reduce(keyspace_names.begin(), keyspace_names.end(), map, schema_result{}, insert);
 }
 
 static

--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -3251,10 +3251,10 @@ future<> drop_column_mapping(utils::UUID table_id, table_schema_version version)
     const static sstring DEL_COLUMN_MAPPING_QUERY =
         format("DELETE FROM system.{} WHERE cf_id = ? and schema_version = ?",
             db::schema_tables::SCYLLA_TABLE_SCHEMA_HISTORY);
-    return qctx->qp().execute_internal(
+    co_await qctx->qp().execute_internal(
         DEL_COLUMN_MAPPING_QUERY,
         db::consistency_level::LOCAL_ONE,
-        {table_id, version}).discard_result();
+        {table_id, version});
 }
 
 } // namespace schema_tables

--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -2347,15 +2347,15 @@ future<schema_ptr> create_table_from_name(distributed<service::storage_proxy>& p
  */
 future<std::map<sstring, schema_ptr>> create_tables_from_tables_partition(distributed<service::storage_proxy>& proxy, const schema_result::mapped_type& result)
 {
-    auto tables = make_lw_shared<std::map<sstring, schema_ptr>>();
+    auto tables = std::map<sstring, schema_ptr>();
     co_await parallel_for_each(result->rows().begin(), result->rows().end(), [&] (const query::result_set_row& row) -> future<> {
         schema_ptr cfm = co_await create_table_from_table_row(proxy, row);
         {
-            tables->emplace(cfm->cf_name(), std::move(cfm));
+            tables.emplace(cfm->cf_name(), std::move(cfm));
         }
     });
     {
-        co_return std::move(*tables);
+        co_return std::move(tables);
     }
 }
 

--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -1035,7 +1035,7 @@ static void fill_column_info(const schema& table,
 future<> store_column_mapping(distributed<service::storage_proxy>& proxy, schema_ptr s, bool with_ttl) {
     // Skip "system*" tables -- only user-related tables are relevant
     if (static_cast<std::string_view>(s->ks_name()).starts_with(db::system_keyspace::NAME)) {
-        return make_ready_future<>();
+        co_return;
     }
     schema_ptr history_tbl = scylla_table_schema_history();
 
@@ -1056,7 +1056,7 @@ future<> store_column_mapping(distributed<service::storage_proxy>& proxy, schema
         fill_column_info(*s, ckey, cdef, ts, ttl, m);
         muts.emplace_back(std::move(m));
     }
-    return proxy.local().mutate_locally(std::move(muts), tracing::trace_state_ptr());
+    co_await proxy.local().mutate_locally(std::move(muts), tracing::trace_state_ptr());
 }
 
 static future<> do_merge_schema(distributed<service::storage_proxy>& proxy, std::vector<mutation> mutations, bool do_flush)

--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -855,7 +855,7 @@ read_schema_partition_for_table(distributed<service::storage_proxy>& proxy, sche
             .build();
     auto cmd = make_lw_shared<query::read_command>(schema->id(), schema->version(), std::move(slice), proxy.local().get_max_result_size(slice),
             query::row_limit(query::max_rows));
-    return query_partition_mutation(proxy.local(), std::move(schema), std::move(cmd), std::move(keyspace_key));
+    co_return co_await query_partition_mutation(proxy.local(), std::move(schema), std::move(cmd), std::move(keyspace_key));
 }
 
 future<mutation>

--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -52,8 +52,6 @@
 #include "schema_builder.hh"
 #include "map_difference.hh"
 #include "utils/UUID_gen.hh"
-#include <seastar/core/do_with.hh>
-#include <seastar/core/thread.hh>
 #include <seastar/coroutine/all.hh>
 #include "log.hh"
 #include "frozen_schema.hh"

--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -927,8 +927,8 @@ future<> merge_schema(distributed<service::storage_proxy>& proxy, gms::feature_s
 }
 
 future<> recalculate_schema_version(distributed<service::storage_proxy>& proxy, gms::feature_service& feat) {
-    return with_merge_lock([&proxy, &feat] {
-        return update_schema_version_and_announce(proxy, feat.cluster_schema_features());
+    co_await with_merge_lock([&] () -> future<> {
+        co_await update_schema_version_and_announce(proxy, feat.cluster_schema_features());
     });
 }
 

--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -864,7 +864,7 @@ read_keyspace_mutation(distributed<service::storage_proxy>& proxy, const sstring
     auto key = partition_key::from_singular(*s, keyspace_name);
     auto slice = s->full_slice();
     auto cmd = make_lw_shared<query::read_command>(s->id(), s->version(), std::move(slice), proxy.local().get_max_result_size(slice));
-    return query_partition_mutation(proxy.local(), std::move(s), std::move(cmd), std::move(key));
+    co_return co_await query_partition_mutation(proxy.local(), std::move(s), std::move(cmd), std::move(key));
 }
 
 static thread_local semaphore the_merge_lock {1};

--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -3237,13 +3237,14 @@ future<column_mapping> get_column_mapping(utils::UUID table_id, table_schema_ver
 }
 
 future<bool> column_mapping_exists(utils::UUID table_id, table_schema_version version) {
-    return qctx->qp().execute_internal(
+    shared_ptr<cql3::untyped_result_set> results = co_await qctx->qp().execute_internal(
         GET_COLUMN_MAPPING_QUERY,
         db::consistency_level::LOCAL_ONE,
         {table_id, version}
-    ).then([] (shared_ptr<cql3::untyped_result_set> results) {
-        return !results->empty();
-    });
+    );
+    {
+        co_return !results->empty();
+    }
 }
 
 future<> drop_column_mapping(utils::UUID table_id, table_schema_version version) {


### PR DESCRIPTION
schema_tables is quite hairy, but can be easily simplified with coroutines.

In addition to switching future-returning functions to coroutines, we also
switch Seastar threads to coroutines. This is less of a clear-cut win; the
motivation is to reduce the chances of someone calling a function that
expects to run in a thread from a non-thread context. This sometimes works
by accident, but when it doesn't, it's pretty bad. So a uniform calling convention
has some benefit.

I left the extra indents in, since the indent-fixing patch is hard to rebase in case
a rebase is needed. I will follow up with an indent fix post merge.

Test: unit (dev, debug, release)