### PR TITLE
repair: Log improvement and cleanup

### DIFF
--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -612,11 +612,11 @@ repair_info::repair_info(repair_service& repair,
 }
 
 void repair_info::check_failed_ranges() {
-    rlogger.info("repair id {} on shard {} stats: repair_reason={}, keyspace={}, tables={}, ranges_nr={}, sub_ranges_nr={}, {}",
-        id, shard, reason, keyspace, table_names(), ranges.size(), _sub_ranges_nr, _stats.get_stats());
+    rlogger.info("repair id {} on shard {} stats: repair_reason={}, keyspace={}, tables={}, ranges_nr={}, {}",
+        id, shard, reason, keyspace, table_names(), ranges.size(), _stats.get_stats());
     if (nr_failed_ranges) {
-        rlogger.warn("repair id {} on shard {} failed - {} ranges failed", id, shard, nr_failed_ranges);
-        throw std::runtime_error(format("repair id {} on shard {} failed to repair {} sub ranges", id, shard, nr_failed_ranges));
+        rlogger.warn("repair id {} on shard {} failed - {} out of {} ranges failed", id, shard, nr_failed_ranges, ranges.size());
+        throw std::runtime_error(format("repair id {} on shard {} failed to repair {} out of {} ranges", id, shard, nr_failed_ranges, ranges.size()));
     } else {
         if (dropped_tables.size()) {
             rlogger.warn("repair id {} on shard {} completed successfully, keyspace={}, ignoring dropped tables={}", id, shard, keyspace, dropped_tables);
@@ -686,7 +686,6 @@ future<> repair_info::repair_range(const dht::token_range& range) {
             } catch (no_such_column_family&) {
                 return make_ready_future<>();
             }
-            _sub_ranges_nr++;
             // Row level repair
             if (dropped_tables.contains(cf)) {
                 return make_ready_future<>();

--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -525,7 +525,6 @@ future<> tracker::run(repair_uniq_id id, std::function<void ()> func) {
             rlogger.info("repair id {} completed successfully", id);
             done(id, true);
         }).handle_exception([this, id] (std::exception_ptr ep) {
-            rlogger.warn("repair id {} failed: {}", id, ep);
             done(id, false);
             return make_exception_future(std::move(ep));
         });

--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -645,9 +645,8 @@ repair_neighbors repair_info::get_repair_neighbors(const dht::token_range& range
 // Repair a single local range, multiple column families.
 // Comparable to RepairSession in Origin
 future<> repair_info::repair_range(const dht::token_range& range) {
-    auto id = utils::UUID_gen::get_time_UUID();
     repair_neighbors neighbors = get_repair_neighbors(range);
-    return do_with(std::move(neighbors.all), std::move(neighbors.mandatory), [this, range, id] (auto& neighbors, auto& mandatory_neighbors) {
+    return do_with(std::move(neighbors.all), std::move(neighbors.mandatory), [this, range] (auto& neighbors, auto& mandatory_neighbors) {
       auto live_neighbors = boost::copy_range<std::vector<gms::inet_address>>(neighbors |
                     boost::adaptors::filtered([] (const gms::inet_address& node) { return gms::get_local_gossiper().is_alive(node); }));
       for (auto& node : mandatory_neighbors) {
@@ -678,7 +677,7 @@ future<> repair_info::repair_range(const dht::token_range& range) {
             ranges_index, ranges.size(), id, shard, keyspace, table_names(), range, neighbors, live_neighbors, status);
             return make_ready_future<>();
       }
-      return mm.sync_schema(db.local(), neighbors).then([this, &neighbors, range, id] {
+      return mm.sync_schema(db.local(), neighbors).then([this, &neighbors, range] {
         return do_for_each(table_ids.begin(), table_ids.end(), [this, &neighbors, range] (utils::UUID table_id) {
             sstring cf;
             try {

--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -1011,7 +1011,6 @@ static future<> repair_ranges(lw_shared_ptr<repair_info> ri) {
         repair_tracker().remove_repair_info(ri->id.id);
         return make_ready_future<>();
     }).handle_exception([ri] (std::exception_ptr eptr) {
-        rlogger.warn("repair id {} on shard {} failed: {}", ri->id, this_shard_id(), eptr);
         repair_tracker().remove_repair_info(ri->id.id);
         return make_exception_future<>(std::move(eptr));
     });

--- a/repair/repair.hh
+++ b/repair/repair.hh
@@ -197,7 +197,6 @@ public:
     bool aborted = false;
     int ranges_index = 0;
     repair_stats _stats;
-    uint64_t _sub_ranges_nr = 0;
     std::unordered_set<sstring> dropped_tables;
     std::optional<utils::UUID> _ops_uuid;
 public:


### PR DESCRIPTION
This series improves the repair logging by removing the unused sub_ranges_nr counter, adding peer node ip in the log, removing redundant logs in case of error.  