### PR TITLE
cql3: Filter regular-index results on multi-column

### DIFF
--- a/cql3/restrictions/statement_restrictions.hh
+++ b/cql3/restrictions/statement_restrictions.hh
@@ -103,6 +103,7 @@ private:
     bool _is_key_range = false;
 
     bool _has_queriable_regular_index = false, _has_queriable_pk_index = false, _has_queriable_ck_index = false;
+    bool _has_multi_column; ///< True iff _clustering_columns_restrictions has a multi-column restriction.
 
     std::optional<expr::expression> _where; ///< The entire WHERE clause.
 


### PR DESCRIPTION
When a WHERE clause contains a multi-column restriction and an indexed
regular column, we must filter the results.  It is generally not
possible to craft the index-table query so it fetches only the
matching rows, because that table's clustering key doesn't match up
with the column tuple.

Fixes #9085.

Tests: unit (dev, debug)

Signed-off-by: Dejan Mircevski <dejan@scylladb.com>