### PR TITLE
rename `coarse_clock` to `coarse_steady_clock`

### DIFF
--- a/utils/coarse_steady_clock.hh
+++ b/utils/coarse_steady_clock.hh
@@ -21,16 +21,22 @@
 
 #pragma once
 
+// A coarser and faster version of std::steady_clock, using
+// CLOCK_MONOTONIC_COARSE instead of CLOCK_MONOTONIC.
+//
+// Intended for measuring time taken by synchronous code paths (where
+// seastar::lowres_clock is not suitable).
+
 #include <chrono>
 #include <ctime>
 
 namespace utils {
 
-struct coarse_clock {
+struct coarse_steady_clock {
     using duration   = std::chrono::nanoseconds;
     using rep        = duration::rep;
     using period     = duration::period;
-    using time_point = std::chrono::time_point<coarse_clock, duration>;
+    using time_point = std::chrono::time_point<coarse_steady_clock, duration>;
 
     static constexpr bool is_steady = true;
 

--- a/utils/logalloc.cc
+++ b/utils/logalloc.cc
@@ -46,7 +46,7 @@
 #include "utils/log_heap.hh"
 #include "utils/preempt.hh"
 #include "utils/vle.hh"
-#include "utils/coarse_clock.hh"
+#include "utils/coarse_steady_clock.hh"
 
 #include <random>
 #include <chrono>
@@ -2118,7 +2118,7 @@ static void reclaim_from_evictable(region::impl& r, size_t target_mem_in_use, is
 }
 
 class reclaim_timer {
-    using clock = utils::coarse_clock;
+    using clock = utils::coarse_steady_clock;
 
     const is_preemptible _preemptible;
     const size_t _memory_to_release;


### PR DESCRIPTION
Also add a comment to explain why it exists.

Signed-off-by: Michael Livshin <michael.livshin@scylladb.com>