### PR TITLE
docker: fix housekeeping --repo-files to apt repository

### DIFF
--- a/dist/docker/scylla-housekeeping-service.sh
+++ b/dist/docker/scylla-housekeeping-service.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 sleep 5
-/opt/scylladb/scripts/scylla-housekeeping --uuid-file /var/lib/scylla-housekeeping/housekeeping.uuid --repo-files '/etc/yum.repos.d/scylla*.repo'  -q version --mode cr || true
+/opt/scylladb/scripts/scylla-housekeeping --uuid-file /var/lib/scylla-housekeeping/housekeeping.uuid --repo-files '/etc/apt/sources.list.d/scylla*.list'  -q version --mode cr || true
 while true; do
     sleep 1d
-    /opt/scylladb/scripts/scylla-housekeeping --uuid-file /var/lib/scylla-housekeeping/housekeeping.uuid --repo-files '/etc/yum.repos.d/scylla*.repo' -q version --mode cd || true
+    /opt/scylladb/scripts/scylla-housekeeping --uuid-file /var/lib/scylla-housekeeping/housekeeping.uuid --repo-files '/etc/apt/sources.list.d/scylla*.list' -q version --mode cd || true
 done
 


### PR DESCRIPTION
Even we switched to Ubuntu based container image, housekeeping still
using yum repository.
It should be switched to apt repository.

Fixes #9144