### PR TITLE
storage_service: Close reader in load_and_stream

### DIFF
--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -3299,6 +3299,7 @@ future<> storage_service::load_and_stream(sstring ks_name, sstring cf_name,
             slogger.warn("load_and_stream: ops_uuid={}, ks={}, table={}, send_phase, err={}",
                     ops_uuid, ks_name, cf_name, eptr);
         }
+        co_await reader.close();
         try {
             co_await parallel_for_each(metas.begin(), metas.end(), [failed] (std::pair<const gms::inet_address, send_meta_data>& pair) {
                 auto& meta = pair.second;


### PR DESCRIPTION
We forgot to call the reader.close() for the reader when the close api is
introduced.

Fixes #9146