### PR TITLE
db: schema_tables: clean up read_schema_partition_for_keyspace() coroutine captures

### DIFF
--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -818,10 +818,8 @@ future<mutation> query_partition_mutation(service::storage_proxy& proxy,
 }
 
 future<schema_result_value_type>
-read_schema_partition_for_keyspace(distributed<service::storage_proxy>& proxy, const sstring& schema_table_name_, const sstring& keyspace_name_)
+read_schema_partition_for_keyspace(distributed<service::storage_proxy>& proxy, sstring schema_table_name, sstring keyspace_name)
 {
-    auto schema_table_name = schema_table_name_; // capture for co_await
-    auto keyspace_name = keyspace_name_; // capture for co_await
     auto schema = proxy.local().get_db().local().find_schema(NAME, schema_table_name);
     auto keyspace_key = dht::decorate_key(*schema,
         partition_key::from_singular(*schema, keyspace_name));

--- a/db/schema_tables.hh
+++ b/db/schema_tables.hh
@@ -184,7 +184,7 @@ future<std::vector<canonical_mutation>> convert_schema_to_mutations(distributed<
 std::vector<mutation> adjust_schema_for_schema_features(std::vector<mutation> schema, schema_features features);
 
 future<schema_result_value_type>
-read_schema_partition_for_keyspace(distributed<service::storage_proxy>& proxy, const sstring& schema_table_name, const sstring& keyspace_name);
+read_schema_partition_for_keyspace(distributed<service::storage_proxy>& proxy, sstring schema_table_name, sstring keyspace_name);
 future<mutation> read_keyspace_mutation(distributed<service::storage_proxy>&, const sstring& keyspace_name);
 
 future<> merge_schema(distributed<service::storage_proxy>& proxy, gms::feature_service& feat, std::vector<mutation> mutations);


### PR DESCRIPTION
read_schema_partition_for_keyspace() copies some parameters to capture them
in a coroutine, but the same can be achieved more cleanly by changing the
reference parameters to value parameters, so do that.

Test: unit (dev)