### PR TITLE
database: Detemplate run_async

### DIFF
--- a/database.hh
+++ b/database.hh
@@ -616,14 +616,7 @@ public:
         return _config.dirty_memory_manager->region_group();
     }
 
-    // Used for asynchronous operations that may defer and need to guarantee that the column
-    // family will be alive until their termination
-    template<typename Func, typename Futurator = futurize<std::result_of_t<Func()>>, typename... Args>
-    typename Futurator::type run_async(Func&& func, Args&&... args) {
-        return with_gate(_async_gate, [func = std::forward<Func>(func), args = std::make_tuple(std::forward<Args>(args)...)] () mutable {
-            return Futurator::apply(func, std::move(args));
-        });
-    }
+    seastar::gate& async_gate() { return _async_gate; }
 
     uint64_t failed_counter_applies_to_memtable() const {
         return _failed_counter_applies_to_memtable;


### PR DESCRIPTION
Use noncopyable_function to avoid unnecessary template usage.