### PR TITLE
table: Get rid of table::run_compaction helper

### DIFF
--- a/database.hh
+++ b/database.hh
@@ -881,7 +881,6 @@ public:
     void start_compaction();
     void trigger_compaction();
     void try_trigger_compaction() noexcept;
-    future<> run_compaction(sstables::compaction_descriptor descriptor);
     void trigger_offstrategy_compaction();
     future<> run_offstrategy_compaction();
     void set_compaction_strategy(sstables::compaction_strategy_type strategy);

--- a/table.cc
+++ b/table.cc
@@ -951,10 +951,6 @@ void table::do_trigger_compaction() {
     }
 }
 
-future<> table::run_compaction(sstables::compaction_descriptor descriptor) {
-    return compact_sstables(std::move(descriptor));
-}
-
 void table::trigger_offstrategy_compaction() {
     // If the user calls trigger_offstrategy_compaction() to trigger
     // off-strategy explicitly, cancel the timeout based automatic trigger.


### PR DESCRIPTION
The table::run_compaction is a trivial wrapper for
table::compact_sstables.

We have lots of similar {start, trigger, run}_compaction functions.
Dropping the run_compaction wrapper to reduce confusion.