### PR TITLE
hints: use an abort_source with sleep_abortable in flush+send loop

### DIFF
--- a/db/hints/manager.hh
+++ b/db/hints/manager.hh
@@ -33,6 +33,7 @@
 #include <seastar/core/timer.hh>
 #include <seastar/core/lowres_clock.hh>
 #include <seastar/core/shared_mutex.hh>
+#include <seastar/core/abort_source.hh>
 #include "gms/gossiper.hh"
 #include "locator/snitch_base.hh"
 #include "inet_address_vectors.hh"
@@ -43,10 +44,6 @@
 #include "db/hints/sync_point.hh"
 
 class fragmented_temporary_buffer;
-
-namespace seastar {
-class abort_source;
-}
 
 namespace utils {
 class directories;
@@ -150,6 +147,7 @@ public:
             std::unordered_map<table_schema_version, column_mapping> _last_schema_ver_to_column_mapping;
             state_set _state;
             future<> _stopped;
+            abort_source _stop_as;
             clock::time_point _next_flush_tp;
             clock::time_point _next_send_retry_tp;
             key_type _ep_key;


### PR DESCRIPTION
Each hint sender runs an asynchronous loop with tries to flush and then
send hints. Between each attempt, it sleeps at most 10 seconds using
sleep_abortable. However, an overload of sleep_abortable is used which
does not take an abort_source - it should abort the sleep in case
Seastar handles a SIGINT or SIGTERM signal. However, in order for that
to work, the application must not prevent default handling of those
signals in Seastar - but Scylla explicitly does it by disabling the
`auto_handle_sigint_sigterm` option in reactor config. As a result,
those sleeps are never aborted, and - because we wait for the async
loops to stop - they can delay shutdown by at most 10 seconds.

To fix that, an abort_source is added to the hints sender, and the
abort_source is triggered when the corresponding sender is requested to
stop.

Fixes: #9176