### PR TITLE
[PR v10] Introduce native reversed format

### DIFF
--- a/clustering_bounds_comparator.hh
+++ b/clustering_bounds_comparator.hh
@@ -40,7 +40,10 @@ enum class bound_kind : uint8_t {
 
 std::ostream& operator<<(std::ostream& out, const bound_kind k);
 
+// Swaps start <-> end && incl <-> excl
 bound_kind invert_kind(bound_kind k);
+// Swaps start <-> end
+bound_kind reverse_kind(bound_kind k);
 int32_t weight(bound_kind k);
 
 class bound_view {

--- a/db/view/view.hh
+++ b/db/view/view.hh
@@ -192,8 +192,8 @@ public:
             , _view_updates(std::move(views_to_update))
             , _updates(std::move(updates))
             , _existings(std::move(existings))
-            , _update_tombstone_tracker(*_schema, false)
-            , _existing_tombstone_tracker(*_schema, false)
+            , _update_tombstone_tracker(*_schema)
+            , _existing_tombstone_tracker(*_schema)
             , _now(now) {
     }
     view_update_builder(view_update_builder&& other) noexcept = default;

--- a/docs/design-notes/reverse-reads.md
+++ b/docs/design-notes/reverse-reads.md
@@ -1,0 +1,123 @@
+# Reverse reads
+
+A read is called reverse when it reads with reverse clustering order
+(compared to that of the schema). Example:
+
+    CREATE TABLE mytable (
+        pk int,
+        ck int,
+        s int STATIC,
+        v int,
+        PRIMARY KEY (pk, ck)
+    ) WITH
+        CLUSTERING ORDER BY (ck ASC);
+
+    # Forward read (using table's native order)
+    SELECT * FROM mytable WHERE pk = 1;
+    # Explicit forward order
+    SELECT * FROM mytable WHERE pk = 1 ORDER BY ck ASC;
+
+    # Reverse read
+    SELECT * FROM mytable WHERE pk = 1 ORDER BY ck DESC;
+
+If the table's native clustering order is DESC, then a read with ASC
+order is considered reverse.
+
+## Legacy format
+
+The legacy format is how scylla handled reverse queries internally. We
+are in the process of migrating to the native reverse format, but for
+now coordinator-side code still uses the legacy format.
+
+### Request
+
+The `query::partition_slice::options::reversed` flag is set.
+Clustering ranges in both `query::partition_slice::_row_ranges` and
+`query::specific_ranges::_ranges`
+(`query::partition_slice::_specific_ranges`) are half-reversed: they
+are ordered in reverse, but when they are compared to other
+mutation-fragments, their end bound is used as position, instead of the
+start bound as usual. When compared to other clustering ranges the end
+bound is used as the start bound and vice-versa.
+Example:
+
+For the clustering keys (ASC order): `ck1`, `ck2`, `ck3`, `ck4`, `ck5`,
+`ck6`.
+A `_row_ranges` field of a slice might contain this:
+
+    [ck1, ck2], [ck4, ck5]
+
+The legacy reversed version would look like this:
+
+    [ck4, ck5], [ck1, ck2]
+
+Note how the ranges themselves are the same (bounds not reversed), it is
+just the range vector itself that is reversed.
+
+### Result
+
+Results are ordered with the reversed clustering order with the caveat
+that range-tombstones are ordered by their end bound, using the native
+schema's comparators. For example given the following partition:
+
+    ps{pk1}, sr{}, cr{ck1}, rt{[ck2, ck4)}, cr{ck2}, cr{ck3}, cr{ck4}, ck{ck5}, pe{}
+
+The legacy reverse format equivalent of this looks like the following:
+
+    ps{pk1}, sr{}, cr{ck5}, rt{[ck2, ck4)}, cr{ck4}, cr{ck3}, cr{ck2}, ck{ck1}, pe{}
+
+Note:
+* Only clustering elements change;
+* Range tombstone's bounds are not reversed;
+* Range tombstones can be ordered off-by-one due to native schema
+  comparators used: `rt{[ck2, ck4)}` should be ordered *after*
+  `cr{ck4}`.
+
+Legend:
+* ps = partitions-tart
+* sr = static-row
+* cr = clustering-row
+* rt = range-tombstone
+* pe = partition-end
+
+## Native format
+
+The native format uses ordering equivalent to that of a table with
+reverse clustering format. Using `mytable` as an example, the native
+reverse format would be an identical table `my_reverse_table`, which
+uses `CLUSTERING ORDER BY (ck DESC);`. This allows middle layers in a
+read pipeline to just use a schema with reversed clustering order and
+process the reverse stream as normal.
+
+### Request
+
+The `query::partition_slice::options::reversed` flag is set as in the
+legacy format. Clustering ranges in both
+`query::partition_slice::_row_ranges` and
+`query::specific_ranges::_ranges`
+(`query::partition_slice::_specific_ranges`) are fully-reversed: they
+are ordered in reverse, their bound being swapped as well.
+Example:
+
+For the clustering keys (ASC order): `ck1`, `ck2`, `ck3`, `ck4`, `ck5`,
+`ck6`.
+A `_row_ranges` field of a slice might contain this:
+
+    [ck1, ck2], [ck4, ck5]
+
+The native reversed version would look like this:
+
+    [ck5, ck4], [ck2, ck1]
+
+In addition to this, the schema is reversed on the replica, at the start
+of the read, so all the reverse-capable and intermediate readers in the
+stack get a reversed schema to work with.
+
+### Result
+
+Results are ordered with the reversed clustering order with
+the bounds of range-tombstones swapped. For example, given the same
+partition that was used in the legacy format example, the native reverse
+version would look like this:
+
+    ps{pk1}, sr{}, cr{ck5}, cr{ck4}, rt{(ck4, ck2]}, cr{ck3}, cr{ck2}, ck{ck1}, pe{}

--- a/flat_mutation_reader.cc
+++ b/flat_mutation_reader.cc
@@ -219,8 +219,15 @@ flat_mutation_reader make_reversing_reader(flat_mutation_reader original, query:
             return make_ready_future<>();
         }
 
-        virtual future<> fast_forward_to(const dht::partition_range&) override {
-            return make_exception_future<>(make_backtraced_exception_ptr<std::bad_function_call>());
+        virtual future<> fast_forward_to(const dht::partition_range& pr) override {
+            clear_buffer();
+            while (!_mutation_fragments.empty()) {
+                _mutation_fragments.pop();
+            }
+            _stack_size = 0;
+            _partition_end = std::nullopt;
+            _end_of_stream = false;
+            return _source.fast_forward_to(pr);
         }
 
         virtual future<> fast_forward_to(position_range) override {

--- a/flat_mutation_reader.hh
+++ b/flat_mutation_reader.hh
@@ -890,14 +890,17 @@ future<> consume_partitions(flat_mutation_reader& reader, Consumer consumer) {
 flat_mutation_reader
 make_generating_reader(schema_ptr s, reader_permit permit, std::function<future<mutation_fragment_opt> ()> get_next_fragment);
 
-/// A reader that emits partitions in reverse.
+/// A reader that emits partitions in native reverse order.
 ///
-/// 1. Static row is still emitted first.
-/// 2. Range tombstones are ordered by their end position.
-/// 3. Clustered rows and range tombstones are emitted in descending order.
-/// Because of 2 and 3 the guarantee that a range tombstone is emitted before
+/// 1. The reader's schema() method will return a reversed schema (see
+///    \ref schema::make_reversed()).
+/// 2. Static row is still emitted first.
+/// 3. Range tombstones' bounds are reversed (see \ref range_tombstone::reverse()).
+/// 4. Clustered rows and range tombstones are emitted in descending order.
+/// Because of 3 and 4 the guarantee that a range tombstone is emitted before
 /// any mutation fragment affected by it still holds.
 /// Ordering of partitions themselves remains unchanged.
+/// For more details see docs/design-notes/reverse-reads.md.
 ///
 /// \param original the reader to be reversed, has to be kept alive while the
 ///     reversing reader is in use.

--- a/flat_mutation_reader.hh
+++ b/flat_mutation_reader.hh
@@ -902,8 +902,7 @@ make_generating_reader(schema_ptr s, reader_permit permit, std::function<future<
 /// Ordering of partitions themselves remains unchanged.
 /// For more details see docs/design-notes/reverse-reads.md.
 ///
-/// \param original the reader to be reversed, has to be kept alive while the
-///     reversing reader is in use.
+/// \param original the reader to be reversed
 /// \param max_size the maximum amount of memory the reader is allowed to use
 ///     for reversing and conversely the maximum size of the results. The
 ///     reverse reader reads entire partitions into memory, before reversing
@@ -914,7 +913,7 @@ make_generating_reader(schema_ptr s, reader_permit permit, std::function<future<
 ///
 /// FIXME: reversing should be done in the sstable layer, see #1413.
 flat_mutation_reader
-make_reversing_reader(flat_mutation_reader& original, query::max_result_size max_size);
+make_reversing_reader(flat_mutation_reader original, query::max_result_size max_size);
 
 /// A cosumer function that is passed a flat_mutation_reader to be consumed from
 /// and returns a future<> resolved when the reader is fully consumed, and closed.

--- a/idl/read_command.idl.hh
+++ b/idl/read_command.idl.hh
@@ -30,6 +30,12 @@ class specific_ranges {
     std::vector<nonwrapping_range<clustering_key_prefix>> ranges();
 };
 
+// COMPATIBILITY NOTE: the partition-slice for reverse queries has two different
+// format:
+// * legacy format
+// * native format
+// The wire format uses the legacy format. See docs/design-notes/reverse-reads.md
+// for more details on the formats.
 class partition_slice {
     std::vector<nonwrapping_range<clustering_key_prefix>> default_row_ranges();
     utils::small_vector<uint32_t, 8> static_columns;

--- a/keys.cc
+++ b/keys.cc
@@ -27,6 +27,8 @@
 #include <boost/algorithm/string.hpp>
 #include <boost/any.hpp>
 
+logging::logger klog("keys");
+
 std::ostream& operator<<(std::ostream& out, const partition_key& pk) {
     return out << "pk{" << to_hex(managed_bytes_view(pk.representation())) << "}";
 }
@@ -124,6 +126,16 @@ bound_kind invert_kind(bound_kind k) {
     case bound_kind::incl_end:   return bound_kind::excl_start;
     }
     abort();
+}
+
+bound_kind reverse_kind(bound_kind k) {
+    switch (k) {
+    case bound_kind::excl_start: return bound_kind::excl_end;
+    case bound_kind::incl_start: return bound_kind::incl_end;
+    case bound_kind::excl_end:   return bound_kind::excl_start;
+    case bound_kind::incl_end:   return bound_kind::incl_start;
+    }
+    on_internal_error(klog, format("reverse_kind(): invalid value for `bound_kind`: {}", static_cast<std::underlying_type_t<bound_kind>>(k)));
 }
 
 int32_t weight(bound_kind k) {

--- a/mutation.cc
+++ b/mutation.cc
@@ -199,6 +199,12 @@ future<mutation_opt> read_mutation_from_flat_mutation_reader(flat_mutation_reade
     return r.consume(mutation_rebuilder(r.schema()));
 }
 
+mutation reverse(mutation mut) {
+    auto reverse_schema = mut.schema()->make_reversed();
+    mutation_rebuilder reverse_rebuilder(reverse_schema);
+    return *std::move(mut).consume(reverse_rebuilder, consume_in_reverse::yes).result;
+}
+
 std::ostream& operator<<(std::ostream& os, const mutation& m) {
     const ::schema& s = *m.schema();
     const auto& dk = m.decorated_key();

--- a/mutation.hh
+++ b/mutation.hh
@@ -82,8 +82,11 @@ public:
         : _ptr(std::make_unique<data>(std::move(schema), std::move(key), std::move(mp)))
     { }
     mutation(const mutation& m)
-        : _ptr(std::make_unique<data>(schema_ptr(m.schema()), dht::decorated_key(m.decorated_key()), m.partition()))
-    { }
+    {
+        if (m._ptr) {
+            _ptr = std::make_unique<data>(schema_ptr(m.schema()), dht::decorated_key(m.decorated_key()), m.partition());
+        }
+    }
     mutation(mutation&&) = default;
     mutation& operator=(mutation&& x) = default;
     mutation& operator=(const mutation& m);

--- a/mutation.hh
+++ b/mutation.hh
@@ -330,3 +330,7 @@ class flat_mutation_reader;
 
 // Reads a single partition from a reader. Returns empty optional if there are no more partitions to be read.
 future<mutation_opt> read_mutation_from_flat_mutation_reader(flat_mutation_reader& reader);
+
+// Reverses the mutation as if it was created with a schema with reverse
+// clustering order. The resulting mutation will contain a reverse schema too.
+mutation reverse(mutation mut);

--- a/mutation.hh
+++ b/mutation.hh
@@ -191,7 +191,11 @@ stop_iteration consume_clustering_fragments(const schema& s, mutation_partition&
             stop = consumer.consume(std::move(rts_it->tombstone()));
             ++rts_it;
         } else {
-            stop = consumer.consume(clustering_row(std::move(*crs_it)));
+            // Dummy rows are part of the in-memory representation but should be
+            // invisible to reads.
+            if (!crs_it->dummy()) {
+                stop = consumer.consume(clustering_row(std::move(*crs_it)));
+            }
             ++crs_it;
         }
     }

--- a/mutation_compactor.hh
+++ b/mutation_compactor.hh
@@ -224,7 +224,7 @@ public:
         , _row_limit(limit)
         , _partition_limit(partition_limit)
         , _partition_row_limit(_slice.options.contains(query::partition_slice::option::distinct) ? 1 : slice.partition_row_limit())
-        , _range_tombstones(s, _slice.options.contains(query::partition_slice::option::reversed))
+        , _range_tombstones(s, false)
         , _last_dk({dht::token(), partition_key::make_empty()})
     {
         static_assert(!sstable_compaction(), "This constructor cannot be used for sstable compaction.");

--- a/mutation_compactor.hh
+++ b/mutation_compactor.hh
@@ -224,7 +224,7 @@ public:
         , _row_limit(limit)
         , _partition_limit(partition_limit)
         , _partition_row_limit(_slice.options.contains(query::partition_slice::option::distinct) ? 1 : slice.partition_row_limit())
-        , _range_tombstones(s, false)
+        , _range_tombstones(s)
         , _last_dk({dht::token(), partition_key::make_empty()})
     {
         static_assert(!sstable_compaction(), "This constructor cannot be used for sstable compaction.");
@@ -238,7 +238,7 @@ public:
         , _get_max_purgeable(std::move(get_max_purgeable))
         , _can_gc([this] (tombstone t) { return can_gc(t); })
         , _slice(s.full_slice())
-        , _range_tombstones(s, false)
+        , _range_tombstones(s)
         , _last_dk({dht::token(), partition_key::make_empty()})
         , _collector(std::make_unique<mutation_compactor_garbage_collector>(_schema))
     {

--- a/mutation_partition.cc
+++ b/mutation_partition.cc
@@ -2040,7 +2040,7 @@ to_data_query_result(const reconcilable_result& r, schema_ptr s, const query::pa
     query::result::builder builder(slice, opts, query::result_memory_accounter{ query::result_memory_limiter::unlimited_result_size });
     auto consumer = compact_for_query<emit_only_live_rows::yes, query_result_builder>(*s, gc_clock::time_point::min(), slice, max_rows,
             max_partitions, query_result_builder(*s, builder));
-    const auto reverse = slice.options.contains(query::partition_slice::option::reversed) ? consume_in_reverse::yes : consume_in_reverse::no;
+    const auto reverse = slice.options.contains(query::partition_slice::option::reversed) ? consume_in_reverse::legacy_half_reverse : consume_in_reverse::no;
 
     for (const partition& p : r.partitions()) {
         const auto res = p.mut().unfreeze(s).consume(consumer, reverse);
@@ -2059,7 +2059,7 @@ query_mutation(mutation&& m, const query::partition_slice& slice, uint64_t row_l
     query::result::builder builder(slice, opts, query::result_memory_accounter{ query::result_memory_limiter::unlimited_result_size });
     auto consumer = compact_for_query<emit_only_live_rows::yes, query_result_builder>(*m.schema(), now, slice, row_limit,
             query::max_partitions, query_result_builder(*m.schema(), builder));
-    const auto reverse = slice.options.contains(query::partition_slice::option::reversed) ? consume_in_reverse::yes : consume_in_reverse::no;
+    const auto reverse = slice.options.contains(query::partition_slice::option::reversed) ? consume_in_reverse::legacy_half_reverse : consume_in_reverse::no;
     std::move(m).consume(consumer, reverse);
     return builder.build();
 }

--- a/mutation_query.hh
+++ b/mutation_query.hh
@@ -137,6 +137,7 @@ public:
 class reconcilable_result_builder {
     const schema& _schema;
     const query::partition_slice& _slice;
+    bool _reversed;
 
     bool _return_static_content_on_partition_with_no_rows{};
     bool _static_row_is_alive{};
@@ -151,7 +152,7 @@ class reconcilable_result_builder {
 public:
     reconcilable_result_builder(const schema& s, const query::partition_slice& slice,
                                 query::result_memory_accounter&& accounter) noexcept
-        : _schema(s), _slice(slice)
+        : _schema(s), _slice(slice), _reversed(_slice.options.contains(query::partition_slice::option::reversed))
         , _memory_accounter(std::move(accounter))
     { }
 

--- a/partition_slice_builder.cc
+++ b/partition_slice_builder.cc
@@ -25,6 +25,15 @@
 
 #include "partition_slice_builder.hh"
 
+partition_slice_builder::partition_slice_builder(const schema& schema, query::partition_slice slice)
+    : _regular_columns(std::move(slice.regular_columns))
+    , _static_columns(std::move(slice.static_columns))
+    , _row_ranges(std::move(slice._row_ranges))
+    , _schema(schema)
+    , _options(std::move(slice.options))
+{
+}
+
 partition_slice_builder::partition_slice_builder(const schema& schema)
     : _schema(schema)
 {

--- a/partition_slice_builder.cc
+++ b/partition_slice_builder.cc
@@ -29,6 +29,7 @@ partition_slice_builder::partition_slice_builder(const schema& schema, query::pa
     : _regular_columns(std::move(slice.regular_columns))
     , _static_columns(std::move(slice.static_columns))
     , _row_ranges(std::move(slice._row_ranges))
+    , _specific_ranges(std::move(slice._specific_ranges))
     , _schema(schema)
     , _options(std::move(slice.options))
 {
@@ -72,7 +73,8 @@ partition_slice_builder::build() {
         std::move(ranges),
         std::move(static_columns),
         std::move(regular_columns),
-        std::move(_options)
+        std::move(_options),
+        std::move(_specific_ranges)
     };
 }
 
@@ -93,6 +95,22 @@ partition_slice_builder::with_ranges(std::vector<query::clustering_range> ranges
         for (auto&& r : ranges) {
             with_range(std::move(r));
         }
+    }
+    return *this;
+}
+
+partition_slice_builder&
+partition_slice_builder::mutate_ranges(std::function<void(std::vector<query::clustering_range>&)> func) {
+    if (_row_ranges) {
+        func(*_row_ranges);
+    }
+    return *this;
+}
+
+partition_slice_builder&
+partition_slice_builder::mutate_specific_ranges(std::function<void(query::specific_ranges&)> func) {
+    if (_specific_ranges) {
+        func(*_specific_ranges);
     }
     return *this;
 }

--- a/partition_slice_builder.hh
+++ b/partition_slice_builder.hh
@@ -44,6 +44,7 @@ class partition_slice_builder {
     query::partition_slice::option_set _options;
 public:
     partition_slice_builder(const schema& schema);
+    partition_slice_builder(const schema& schema, query::partition_slice slice);
 
     partition_slice_builder& with_static_column(bytes name);
     partition_slice_builder& with_no_static_columns();

--- a/partition_slice_builder.hh
+++ b/partition_slice_builder.hh
@@ -40,6 +40,7 @@ class partition_slice_builder {
     std::optional<query::column_id_vector> _regular_columns;
     std::optional<query::column_id_vector> _static_columns;
     std::optional<std::vector<query::clustering_range>> _row_ranges;
+    std::unique_ptr<query::specific_ranges> _specific_ranges;
     const schema& _schema;
     query::partition_slice::option_set _options;
 public:
@@ -52,6 +53,10 @@ public:
     partition_slice_builder& with_no_regular_columns();
     partition_slice_builder& with_range(query::clustering_range range);
     partition_slice_builder& with_ranges(std::vector<query::clustering_range>);
+    // noop if no ranges have been set yet
+    partition_slice_builder& mutate_ranges(std::function<void(std::vector<query::clustering_range>&)>);
+    // noop if no specific ranges have been set yet
+    partition_slice_builder& mutate_specific_ranges(std::function<void(query::specific_ranges&)>);
     partition_slice_builder& without_partition_key_columns();
     partition_slice_builder& without_clustering_key_columns();
     partition_slice_builder& reversed();

--- a/querier.hh
+++ b/querier.hh
@@ -97,7 +97,7 @@ auto consume_page(flat_mutation_reader& reader,
 
         auto consume = [&reader, &slice, reader_consumer = std::move(reader_consumer), max_size] () mutable {
             if (slice.options.contains(query::partition_slice::option::reversed)) {
-                return with_closeable(make_reversing_reader(reader, max_size),
+                return with_closeable(make_reversing_reader(make_flat_mutation_reader<delegating_reader>(reader), max_size),
                         [reader_consumer = std::move(reader_consumer)] (flat_mutation_reader& reversing_reader) mutable {
                     return reversing_reader.consume(std::move(reader_consumer));
                 });

--- a/querier.hh
+++ b/querier.hh
@@ -128,6 +128,14 @@ protected:
     std::variant<flat_mutation_reader, reader_concurrency_semaphore::inactive_read_handle> _reader;
     dht::partition_ranges_view _query_ranges;
 
+protected:
+    schema_ptr underlying_schema() const {
+        if (is_reversed()) {
+            return _schema->make_reversed();
+        }
+        return _schema;
+    }
+
 public:
     querier_base(reader_permit permit, std::unique_ptr<const dht::partition_range> range,
             std::unique_ptr<const query::partition_slice> slice, flat_mutation_reader reader, dht::partition_ranges_view query_ranges)
@@ -145,7 +153,7 @@ public:
         , _permit(std::move(permit))
         , _range(std::make_unique<const dht::partition_range>(std::move(range)))
         , _slice(std::make_unique<const query::partition_slice>(std::move(slice)))
-        , _reader(ms.make_reader(_schema, _permit, *_range, *_slice, pc, std::move(trace_ptr), streamed_mutation::forwarding::no, mutation_reader::forwarding::no))
+        , _reader(ms.make_reader(underlying_schema(), _permit, *_range, *_slice, pc, std::move(trace_ptr), streamed_mutation::forwarding::no, mutation_reader::forwarding::no))
         , _query_ranges(*_range)
     { }
 

--- a/query-request.hh
+++ b/query-request.hh
@@ -110,6 +110,9 @@ public:
     const clustering_row_ranges& ranges() const {
         return _ranges;
     }
+    clustering_row_ranges& ranges() {
+        return _ranges;
+    }
 private:
     friend std::ostream& operator<<(std::ostream& out, const specific_ranges& r);
 

--- a/query-request.hh
+++ b/query-request.hh
@@ -33,6 +33,7 @@
 #include "query_class_config.hh"
 
 class position_in_partition_view;
+class partition_slice_builder;
 
 namespace query {
 
@@ -128,6 +129,7 @@ constexpr auto max_rows_if_set = std::numeric_limits<uint32_t>::max();
 // Can be accessed across cores.
 // Schema-dependent.
 class partition_slice {
+    friend class ::partition_slice_builder;
 public:
     enum class option {
         send_clustering_key,

--- a/query-request.hh
+++ b/query-request.hh
@@ -128,6 +128,13 @@ constexpr auto max_rows_if_set = std::numeric_limits<uint32_t>::max();
 // Specifies subset of rows, columns and cell attributes to be returned in a query.
 // Can be accessed across cores.
 // Schema-dependent.
+//
+// COMPATIBILITY NOTE: the partition-slice for reverse queries has two different
+// format:
+// * legacy format
+// * native format
+// The wire format uses the legacy format. See docs/design-notes/reverse-reads.md
+// for more details on the formats.
 class partition_slice {
     friend class ::partition_slice_builder;
 public:

--- a/query-request.hh
+++ b/query-request.hh
@@ -231,6 +231,13 @@ public:
     friend std::ostream& operator<<(std::ostream& out, const specific_ranges& ps);
 };
 
+// See docs/design-notes/reverse-reads.md
+partition_slice legacy_reverse_slice_to_native_reverse_slice(const schema& schema, partition_slice slice);
+partition_slice native_reverse_slice_to_legacy_reverse_slice(const schema& schema, partition_slice slice);
+// Fully reverse slice (forward to native reverse)
+// Also set the reversed bit in `partition_slice::options`.
+partition_slice reverse_slice(const schema& schema, partition_slice slice);
+
 constexpr auto max_partitions = std::numeric_limits<uint32_t>::max();
 
 // Tagged integers to disambiguate constructor arguments.

--- a/range_tombstone.hh
+++ b/range_tombstone.hh
@@ -261,13 +261,12 @@ class range_tombstone_accumulator {
     tombstone _partition_tombstone;
     std::deque<range_tombstone> _range_tombstones;
     tombstone _current_tombstone;
-    bool _reversed;
 private:
     void update_current_tombstone();
     void drop_unneeded_tombstones(const clustering_key_prefix& ck, int w = 0);
 public:
-    range_tombstone_accumulator(const schema& s, bool reversed)
-        : _cmp(s), _reversed(reversed) { }
+    explicit range_tombstone_accumulator(const schema& s)
+        : _cmp(s) { }
 
     void set_partition_tombstone(tombstone t) {
         _partition_tombstone = t;

--- a/range_tombstone.hh
+++ b/range_tombstone.hh
@@ -192,6 +192,15 @@ public:
         end_kind = new_end.kind();
     }
 
+    // Swap bounds to reverse range-tombstone -- as if it came from a table with
+    // reverse native order. See docs/design-notes/reverse-reads.md.
+    void reverse() {
+        std::swap(start, end);
+        std::swap(start_kind, end_kind);
+        start_kind = reverse_kind(start_kind);
+        end_kind = reverse_kind(end_kind);
+    }
+
     size_t external_memory_usage(const schema&) const noexcept {
         return start.external_memory_usage() + end.external_memory_usage();
     }

--- a/schema.hh
+++ b/schema.hh
@@ -698,6 +698,7 @@ private:
     lw_shared_ptr<cql3::column_specification> make_column_specification(const column_definition& def);
     void rebuild();
     schema(const raw_schema&, std::optional<raw_view_info>);
+    schema(const schema&, const std::function<void(schema&)>&);
 public:
     schema(const schema&);
     ~schema();

--- a/table.cc
+++ b/table.cc
@@ -2052,7 +2052,10 @@ table::mutation_query(schema_ptr s,
 
     std::exception_ptr ex;
   try {
-    auto rrb = reconcilable_result_builder(*s, cmd.slice, std::move(accounter));
+    // Un-reverse the schema sent to the coordinator, it expects the
+    // legacy format.
+    auto result_schema = cmd.slice.options.contains(query::partition_slice::option::reversed) ? s->make_reversed() : s;
+    auto rrb = reconcilable_result_builder(*result_schema, cmd.slice, std::move(accounter));
     auto r = co_await q.consume_page(std::move(rrb), cmd.get_row_limit(), cmd.partition_limit, cmd.timestamp, class_config.max_memory_for_unlimited_query);
 
     if (!saved_querier || (!q.are_limits_reached() && !r.is_short_read())) {

--- a/test/boost/UUID_test.cc
+++ b/test/boost/UUID_test.cc
@@ -230,3 +230,20 @@ BOOST_AUTO_TEST_CASE(test_max_time_uuid) {
     auto unix_timestamp = utils::UUID_gen::unix_timestamp(uuid);
     BOOST_CHECK(unix_timestamp == millis);
 }
+
+BOOST_AUTO_TEST_CASE(test_negate) {
+    using namespace utils;
+
+    auto original_uuid = UUID_gen::get_time_UUID();
+    BOOST_TEST_MESSAGE(fmt::format("original_uuid:   {}", original_uuid));
+
+    auto negated_uuid = UUID_gen::negate(original_uuid);
+    BOOST_TEST_MESSAGE(fmt::format("negated_uuid:    {}", negated_uuid));
+
+    BOOST_REQUIRE(original_uuid != negated_uuid);
+
+    auto re_negated_uuid = UUID_gen::negate(negated_uuid);
+    BOOST_TEST_MESSAGE(fmt::format("re_negated_uuid: {}", re_negated_uuid));
+
+    BOOST_REQUIRE(original_uuid == re_negated_uuid);
+}

--- a/test/boost/mutation_query_test.cc
+++ b/test/boost/mutation_query_test.cc
@@ -65,7 +65,11 @@ mutation_source make_source(std::vector<mutation> mutations) {
             const io_priority_class& pc, tracing::trace_state_ptr, streamed_mutation::forwarding fwd, mutation_reader::forwarding fwd_mr) {
         assert(range.is_full()); // slicing not implemented yet
         for (auto&& m : mutations) {
-            assert(m.schema() == s);
+            if (slice.options.contains(query::partition_slice::option::reversed)) {
+                assert(m.schema()->make_reversed()->version() == s->version());
+            } else {
+                assert(m.schema() == s);
+            }
         }
         return flat_mutation_reader_from_mutations(std::move(permit), mutations, slice, fwd);
     });

--- a/test/boost/mutation_test.cc
+++ b/test/boost/mutation_test.cc
@@ -2889,7 +2889,7 @@ void check_clustering_row_summaries(const schema& schema, const clustering_row_s
 }
 
 void check_clustering_summaries(const schema& schema, const partition_summary& actual, const partition_summary& expected) {
-    range_tombstone_accumulator range_tombstones(schema, false);
+    range_tombstone_accumulator range_tombstones(schema);
     range_tombstones.set_partition_tombstone(expected.tomb);
 
     for (auto [actual_frag, expected_frag] : iterate_over_in_ordered_lockstep(actual.clustering_fragments, expected.clustering_fragments,

--- a/test/boost/range_tombstone_list_test.cc
+++ b/test/boost/range_tombstone_list_test.cc
@@ -884,8 +884,7 @@ BOOST_AUTO_TEST_CASE(test_accumulator) {
     auto ts1 = 1;
     auto ts2 = 2;
 
-    testlog.info("Forward");
-    auto acc = range_tombstone_accumulator(*s, false);
+    auto acc = range_tombstone_accumulator(*s);
     acc.apply(rtie(0, 4, ts1));
     BOOST_REQUIRE_EQUAL(acc.tombstone_for_row(key({ 0 })), tombstone(ts1, gc_now));
     acc.apply(rtie(1, 2, ts2));
@@ -904,26 +903,4 @@ BOOST_AUTO_TEST_CASE(test_accumulator) {
     BOOST_REQUIRE_EQUAL(acc.tombstone_for_row(key({ 13 })), tombstone(ts2, gc_now));
     BOOST_REQUIRE_EQUAL(acc.tombstone_for_row(key({ 14 })), tombstone());
     BOOST_REQUIRE_EQUAL(acc.tombstone_for_row(key({ 15 })), tombstone());
-
-    testlog.info("Reversed");
-    acc = range_tombstone_accumulator(*s, true);
-
-    BOOST_REQUIRE_EQUAL(acc.tombstone_for_row(key({ 15 })), tombstone());
-    BOOST_REQUIRE_EQUAL(acc.tombstone_for_row(key({ 14 })), tombstone());
-    acc.apply(rtie(11, 14, ts2));
-    BOOST_REQUIRE_EQUAL(acc.tombstone_for_row(key({ 13 })), tombstone(ts2, gc_now));
-    BOOST_REQUIRE_EQUAL(acc.tombstone_for_row(key({ 12 })), tombstone(ts2, gc_now));
-    acc.apply(rtie(10, 12, ts1));
-    BOOST_REQUIRE_EQUAL(acc.tombstone_for_row(key({ 11 })), tombstone(ts2, gc_now));
-    BOOST_REQUIRE_EQUAL(acc.tombstone_for_row(key({ 10 })), tombstone(ts1, gc_now));
-    BOOST_REQUIRE_EQUAL(acc.tombstone_for_row(key({ 9 })), tombstone());
-    acc.apply(rtie(6, 8, ts2));
-    BOOST_REQUIRE_EQUAL(acc.tombstone_for_row(key({ 5 })), tombstone());
-    BOOST_REQUIRE_EQUAL(acc.tombstone_for_row(key({ 4 })), tombstone());
-    acc.apply(rtie(0, 4, ts1));
-    BOOST_REQUIRE_EQUAL(acc.tombstone_for_row(key({ 3 })), tombstone(ts1, gc_now));
-    BOOST_REQUIRE_EQUAL(acc.tombstone_for_row(key({ 2 })), tombstone(ts1, gc_now));
-    acc.apply(rtie(1, 2, ts2));
-    BOOST_REQUIRE_EQUAL(acc.tombstone_for_row(key({ 1 })), tombstone(ts2, gc_now));
-    BOOST_REQUIRE_EQUAL(acc.tombstone_for_row(key({ 0 })), tombstone(ts1, gc_now));
 }

--- a/test/boost/schema_change_test.cc
+++ b/test/boost/schema_change_test.cc
@@ -42,6 +42,7 @@
 #include "test/lib/log.hh"
 #include "serializer_impl.hh"
 #include "cdc/cdc_extension.hh"
+#include "utils/UUID_gen.hh"
 
 SEASTAR_TEST_CASE(test_new_schema_with_no_structural_change_is_propagated) {
     return do_with_cql_env([](cql_test_env& e) {
@@ -806,4 +807,27 @@ SEASTAR_TEST_CASE(test_schema_tables_use_null_sharder) {
             }
         }).get();
     }, raft_cql_test_config());
+}
+
+SEASTAR_TEST_CASE(test_schema_make_reversed) {
+    auto schema = schema_builder("tests", get_name())
+            .with_column("pk", bytes_type, column_kind::partition_key)
+            .with_column("ck", bytes_type, column_kind::clustering_key)
+            .with_column("v1", bytes_type)
+            .build();
+    testlog.info("            schema->version(): {}", schema->version());
+
+    auto reversed_schema = schema->make_reversed();
+    testlog.info("   reversed_schema->version(): {}", reversed_schema->version());
+
+    BOOST_REQUIRE(schema->version() != reversed_schema->version());
+    BOOST_REQUIRE(utils::UUID_gen::negate(schema->version()) == reversed_schema->version());
+
+    auto re_reversed_schema = reversed_schema->make_reversed();
+    testlog.info("re_reversed_schema->version(): {}", re_reversed_schema->version());
+
+    BOOST_REQUIRE(schema->version() == re_reversed_schema->version());
+    BOOST_REQUIRE(reversed_schema->version() != re_reversed_schema->version());
+
+    return make_ready_future<>();
 }

--- a/test/lib/mutation_source_test.cc
+++ b/test/lib/mutation_source_test.cc
@@ -406,7 +406,8 @@ static void test_streamed_mutation_forwarding_is_consistent_with_slicing(tests::
 
             void consume_new_partition(const dht::decorated_key& dk) {
                 assert(!_builder);
-                _builder = mutation_rebuilder(dk, std::move(_s));
+                _builder = mutation_rebuilder(std::move(_s));
+                _builder->consume_new_partition(dk);
             }
 
             stop_iteration consume(tombstone t) {

--- a/test/lib/mutation_source_test.cc
+++ b/test/lib/mutation_source_test.cc
@@ -843,7 +843,7 @@ static void test_streamed_mutation_forwarding_across_range_tombstones(tests::rea
 }
 
 static void test_range_queries(tests::reader_concurrency_semaphore_wrapper& semaphore, populate_fn_ex populate) {
-    testlog.info("Testing range queries");
+    testlog.info(__PRETTY_FUNCTION__);
 
     auto s = schema_builder("ks", "cf")
         .with_column("key", bytes_type, column_kind::partition_key)
@@ -1197,7 +1197,7 @@ static void test_clustering_slices(tests::reader_concurrency_semaphore_wrapper& 
 }
 
 static void test_query_only_static_row(tests::reader_concurrency_semaphore_wrapper& semaphore, populate_fn_ex populate) {
-    BOOST_TEST_MESSAGE(__PRETTY_FUNCTION__);
+    testlog.info(__PRETTY_FUNCTION__);
 
     simple_schema s;
 
@@ -1243,7 +1243,7 @@ static void test_query_only_static_row(tests::reader_concurrency_semaphore_wrapp
 }
 
 static void test_query_no_clustering_ranges_no_static_columns(tests::reader_concurrency_semaphore_wrapper& semaphore, populate_fn_ex populate) {
-    BOOST_TEST_MESSAGE(__PRETTY_FUNCTION__);
+    testlog.info(__PRETTY_FUNCTION__);
 
     simple_schema s(simple_schema::with_static::no);
 
@@ -1287,6 +1287,8 @@ static void test_query_no_clustering_ranges_no_static_columns(tests::reader_conc
 }
 
 void test_streamed_mutation_forwarding_succeeds_with_no_data(tests::reader_concurrency_semaphore_wrapper& semaphore, populate_fn_ex populate) {
+    testlog.info(__PRETTY_FUNCTION__);
+
     simple_schema s;
     auto cks = s.make_ckeys(6);
 
@@ -1324,6 +1326,8 @@ void test_streamed_mutation_forwarding_succeeds_with_no_data(tests::reader_concu
 
 static
 void test_slicing_with_overlapping_range_tombstones(tests::reader_concurrency_semaphore_wrapper& semaphore, populate_fn_ex populate) {
+    testlog.info(__PRETTY_FUNCTION__);
+
     simple_schema ss;
     auto s = ss.schema();
 
@@ -1421,6 +1425,8 @@ void test_slicing_with_overlapping_range_tombstones(tests::reader_concurrency_se
 }
 
 void test_downgrade_to_v1_clear_buffer(tests::reader_concurrency_semaphore_wrapper& semaphore, populate_fn_ex populate) {
+    testlog.info(__PRETTY_FUNCTION__);
+
     simple_schema s;
     auto pkey = s.make_pkey();
     sstring value(256, 'v');
@@ -1445,6 +1451,8 @@ void test_downgrade_to_v1_clear_buffer(tests::reader_concurrency_semaphore_wrapp
 }
 
 void test_range_tombstones_v2(tests::reader_concurrency_semaphore_wrapper& semaphore, populate_fn_ex populate) {
+    testlog.info(__PRETTY_FUNCTION__);
+
     simple_schema s;
     auto pkey = s.make_pkey();
 
@@ -1635,7 +1643,8 @@ void test_range_tombstones_v2(tests::reader_concurrency_semaphore_wrapper& semap
 }
 
 void test_reader_conversions(tests::reader_concurrency_semaphore_wrapper& semaphore, populate_fn_ex populate) {
-    BOOST_TEST_MESSAGE(__PRETTY_FUNCTION__);
+    testlog.info(__PRETTY_FUNCTION__);
+
     for_each_mutation([&] (const mutation& m) mutable {
         const auto query_time = gc_clock::now();
 
@@ -1662,6 +1671,8 @@ void test_reader_conversions(tests::reader_concurrency_semaphore_wrapper& semaph
 void test_next_partition(tests::reader_concurrency_semaphore_wrapper&, populate_fn_ex);
 
 void run_mutation_reader_tests(populate_fn_ex populate, bool with_partition_range_forwarding) {
+    testlog.info(__PRETTY_FUNCTION__);
+
     tests::reader_concurrency_semaphore_wrapper semaphore;
 
     test_range_tombstones_v2(semaphore, populate);
@@ -1689,6 +1700,8 @@ void run_mutation_reader_tests(populate_fn_ex populate, bool with_partition_rang
 }
 
 void test_next_partition(tests::reader_concurrency_semaphore_wrapper& semaphore, populate_fn_ex populate) {
+    testlog.info(__PRETTY_FUNCTION__);
+
     simple_schema s;
     auto pkeys = s.make_pkeys(4);
 

--- a/types.cc
+++ b/types.cc
@@ -3436,3 +3436,11 @@ std::ostream& operator<<(std::ostream& out, const data_value& v) {
 shared_ptr<const reversed_type_impl> reversed_type_impl::get_instance(data_type type) {
     return intern::get_instance(std::move(type));
 }
+
+data_type reversed(data_type type) {
+    if (type->is_reversed()) {
+        return type->underlying_type();
+    } else {
+        return reversed_type_impl::get_instance(type);
+    }
+}

--- a/types.hh
+++ b/types.hh
@@ -829,6 +829,10 @@ public:
 };
 using reversed_type = shared_ptr<const reversed_type_impl>;
 
+// Reverse the sort order of the type by wrapping in or stripping reversed_type,
+// as needed.
+data_type reversed(data_type);
+
 class map_type_impl;
 using map_type = shared_ptr<const map_type_impl>;
 

--- a/utils/UUID_gen.hh
+++ b/utils/UUID_gen.hh
@@ -397,6 +397,16 @@ public:
                (0x0fff000000000000UL & msb) >> 48 |
                 0x0000000000001000L); // sets the version to 1.
     }
+
+    // Produce an UUID which is derived from this UUID in a reversible manner
+    //
+    // Such that:
+    //
+    //      auto original_uuid = UUID_gen::get_time_UUID();
+    //      auto negated_uuid = UUID_gen::negate(original_uuid);
+    //      assert(original_uuid != negated_uuid);
+    //      assert(original_uuid == UUID_gen::negate(negated_uuid));
+    static UUID negate(UUID);
 };
 
 // for the curious, here is how I generated START_EPOCH


### PR DESCRIPTION
We define the native reverse format as a reversed mutation fragment
stream that is identical to one that would be emitted by a table with
the same schema but with reversed clustering order. The main difference
to the current format is how range tombstones are handled: instead of
looking at their start or end bound depending on the order, we always
use them as-usual and the reversing reader swaps their bounds to
facilitate this. This allows us to treat reversed streams completely
transparently: just pass along them a reversed schema and all the
reader, compacting and result building code is happily ignorant about
the fact that it is a reversed stream.

This series is the first step towards implementing efficient reverse
reads. It allows us to remove all the special casing we have in various
places for reverse reads and thus treating reverse streams transparently
in all the middle layers. The only layers that have to know about the
actual reversing are mutation sources proper. The plan is that when
reading in reverse we create a reversed schema in the top layer then
pass this down as the schema for the read. There are two layers that
will need to act on this reversed schema:
* The layer sitting on top of the first layer which still can't handle
  reversed streams, this layer will create a reversed reader to handle
  the transition.
* The mutation source proper: which will obtain the underlying schema
  and will emit the data in reverse order.

Once all the mutation sources are able to handle reverse reads, we can
get rid of the reverse reader entirely.

Refs: #1413

Tests: unit(dev)

TODO:
* v2
* more testing

Also on: https://github.com/denesb/scylla.git reverse-reads/v3

Changelog

v3:
* Drop the entire schema transformation mechanism;
* Drop reversing from `schema_builder()`;
* Don't keep any information about whether the schema is reversed or not
  in the schema itself, instead make reversing deterministic w.r.t.
  schema version, such that:
  `s.version() == s.make_reversed().make_reversed().version()`;
* Re-reverse range tombstones in `streaming_mutation_freezer`, so
  `reconcilable_results` sent to the coordinator during read repair
  still use the old reverse format;

v2:
* Add `data_type reversed(data_type)`;
* Add `bound_kind reverse_kind(bound_kind)`;
* Make new API safer to use:
    - `schema::underlying_type()`: return this when unengaged;
    - `schema::make_transformed()`: noop when applying the same
      transformation again;
* Generalize reversed into transformation. Add support to transferring
  to remote nodes and shards by way of making `schema_tables` aware of
  the transformation;
* Use reverse schema everywhere in reverse reader;