### PR TITLE
sstables: remove unused uppermost_bound from clustering_ranges_walker…

### DIFF
--- a/clustering_ranges_walker.hh
+++ b/clustering_ranges_walker.hh
@@ -311,11 +311,6 @@ public:
         return _current_start;
     }
 
-    // Returns the upper bound of the last range in provided ranges set
-    position_in_partition_view uppermost_bound() const {
-        return position_in_partition_view::for_range_end(_ranges.back());
-    }
-
     // When lower_bound() changes, this also does
     // Always > 0.
     size_t lower_bound_change_counter() const {

--- a/sstables/mutation_fragment_filter.hh
+++ b/sstables/mutation_fragment_filter.hh
@@ -171,16 +171,6 @@ public:
     position_in_partition_view lower_bound() const {
         return _walker.lower_bound();
     }
-
-    /// Returns the uppermost bound of the active clustering ranges
-    ///
-    /// If the filter is in streamed_mutation::forwarding::yes mode then there
-    /// is a single active range which is the one to which the reader was fast-forwarded to.
-    /// Otherwise, there may be multiple clustering ranges (as provided during the reader
-    /// creation) and this function would return the upper bound of the last one.
-    position_in_partition_view uppermost_bound() const {
-        return _fwd ? _fwd_end : _walker.uppermost_bound();
-    }
 };
 
 };   // namespace sstables


### PR DESCRIPTION
… and mutation_fragment_filter

Those methods are never used so it's better not to keep a dead code
around.

Tests: unit(dev)

Signed-off-by: Piotr Jastrzebski <piotr@scylladb.com>