### PR TITLE
storage_service: Fix argument in send_meta_data::do_receive

### DIFF
--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -3147,7 +3147,7 @@ private:
         int32_t status = 0;
         while (auto status_opt = co_await _source()) {
             status = std::get<0>(*status_opt);
-            slogger.debug("send_meta_data: got error code={}, from node={}, status={}", status, _node);
+            slogger.debug("send_meta_data: got error code={}, from node={}", status, _node);
             if (status == -1) {
                 _error_from_peer = true;
             }


### PR DESCRIPTION
The extra status print is not needed in the log.

Fixes the following error:

ERROR 2021-08-10 10:54:21,088 [shard 0] storage_service -
service/storage_service.cc:3150 @do_receive: failed to log message:
fmt='send_meta_data: got error code={}, from node={}, status={}':
fmt::v7::format_error (argument not found)

Fixes #9183