### PR TITLE
hints: improve debug/trace level logging

### DIFF
--- a/db/hints/manager.hh
+++ b/db/hints/manager.hh
@@ -273,9 +273,10 @@ public:
 
             /// \brief Restore a mutation object from the hints file entry.
             /// \param ctx_ptr pointer to the send context
+            /// \param rp replay position of the hint
             /// \param buf hints file entry
             /// \return The mutation object representing the original mutation stored in the hints file.
-            frozen_mutation_and_schema get_mutation(lw_shared_ptr<send_one_file_ctx> ctx_ptr, fragmented_temporary_buffer& buf, uint64_t operation_id);
+            frozen_mutation_and_schema get_mutation(lw_shared_ptr<send_one_file_ctx> ctx_ptr, db::replay_position rp, fragmented_temporary_buffer& buf, uint64_t operation_id);
 
             /// \brief Get a reference to the column_mapping object for a given frozen mutation.
             /// \param ctx_ptr pointer to the send context


### PR DESCRIPTION
This PR aims to improve usefulness of logging in hinted handoff on the debug and trace levels. The changes are as follows:

- Debug logs are now meant for non-spammy information (here, meaning "not printed for each hint stored or sent") and non-fatal errors - this includes e.g."starting to send hints from a file" and "failed to send a hint due to timeout",
- Trace is used for non-exceptional spammy information printed for each hint send/store,
- Information about the relevant endpoint is included at the beginning, where applicable,
- Hint store/send operations are now numbered and this information is included in the logs - which allows to correlate log messages for the same operation easily,
- More detailed information about hint mutations is printed (schema ID and version, token, partition key, mutation size).

Here is an example of the new log messages - two hints were stored and then sent:

```
DEBUG 2021-08-13 17:07:21,796 [shard 0] hints_manager - Creating and validating hint directories: /home/piodul/workdirs/hh-tracing/1//hints
DEBUG 2021-08-13 17:07:21,798 [shard 0] hints_manager - Creating and validating hint directories: /home/piodul/workdirs/hh-tracing/1//view_hints
DEBUG 2021-08-13 17:07:21,955 [shard 0] hints_manager - Rebalancing hints in /home/piodul/workdirs/hh-tracing/1//hints
TRACE 2021-08-13 17:07:21,955 [shard 0] hints_manager - shard_id = 0
TRACE 2021-08-13 17:07:21,955 [shard 0] hints_manager - 	IP: 127.0.0.2
DEBUG 2021-08-13 17:07:21,956 [shard 0] hints_manager - Rebalancing hints in /home/piodul/workdirs/hh-tracing/1//view_hints
TRACE 2021-08-13 17:07:21,956 [shard 0] hints_manager - shard_id = 0
DEBUG 2021-08-13 17:07:21,957 [shard 0] hints_manager - [127.0.0.2] get_ep_manager(): creating an ep_manager
DEBUG 2021-08-13 17:07:21,957 [shard 0] hints_manager - [127.0.0.2] add_store(): going to add a store to /home/piodul/workdirs/hh-tracing/1//hints/0/127.0.0.2
DEBUG 2021-08-13 17:07:21,957 [shard 0] hints_manager - [127.0.0.2] ep_manager::sender: started
DEBUG 2021-08-13 17:07:21,957 [shard 0] hints_manager - [127.0.0.2] send_hints(): going to send hints, we have 0 segments to replay
DEBUG 2021-08-13 17:07:21,957 [shard 0] hints_manager - [127.0.0.2] send_hints(): we handled 0 segments
TRACE 2021-08-13 17:07:21,959 [shard 0] hints_manager - [127.0.0.2] notify_replay_waiters(): replay position upper bound was updated to {0, 0, 1}
TRACE 2021-08-13 17:07:25,195 [shard 0] hints_manager - [127.0.0.2, write=0] store_hint(): want to store a hint to table ks.t, schema id: 579b3300-fb4b-11eb-a63b-ee322a24d469, version: 2b2238e8-5043-311b-8382-3b9a44bf0c7a, decorated key: {key: pk{000400000001}, token:-4069959284402364209}, size: 224
TRACE 2021-08-13 17:07:25,195 [shard 0] hints_manager - [127.0.0.2, write=0] store_hint(): updated last written replay position to {0, 375495143, 28}
TRACE 2021-08-13 17:07:25,195 [shard 0] hints_manager - [127.0.0.2, write=0] store_hint(): hint was stored at RP {0, 375495143, 28}
TRACE 2021-08-13 17:07:25,731 [shard 0] hints_manager - [127.0.0.2, write=1] store_hint(): want to store a hint to table ks.t, schema id: 579b3300-fb4b-11eb-a63b-ee322a24d469, version: 2b2238e8-5043-311b-8382-3b9a44bf0c7a, decorated key: {key: pk{000400000001}, token:-4069959284402364209}, size: 224
TRACE 2021-08-13 17:07:25,731 [shard 0] hints_manager - [127.0.0.2, write=1] store_hint(): updated last written replay position to {0, 375495143, 339}
TRACE 2021-08-13 17:07:25,731 [shard 0] hints_manager - [127.0.0.2, write=1] store_hint(): hint was stored at RP {0, 375495143, 339}
DEBUG 2021-08-13 17:07:31,958 [shard 0] hints_manager - [127.0.0.2] add_store(): going to add a store to /home/piodul/workdirs/hh-tracing/1//hints/0/127.0.0.2
DEBUG 2021-08-13 17:07:31,959 [shard 0] hints_manager - [127.0.0.2] send_hints(): going to send hints, we have 1 segments to replay
DEBUG 2021-08-13 17:07:31,959 [shard 0] hints_manager - [127.0.0.2] send_one_file(): started sending hints from segment /home/piodul/workdirs/hh-tracing/1//hints/0/127.0.0.2/HintsLog-2-375495143.log, resuming from RP {0, 0, 0}
DEBUG 2021-08-13 17:07:31,960 [shard 0] hints_manager - [127.0.0.2, send=0] get_column_mapping(): caching new schema version 2b2238e8-5043-311b-8382-3b9a44bf0c7a
TRACE 2021-08-13 17:07:31,960 [shard 0] hints_manager - [127.0.0.2, send=0] get_mutation(): deserialized mutation at RP {0, 375495143, 28}, for table ks.t, schema id: 579b3300-fb4b-11eb-a63b-ee322a24d469, version: 2b2238e8-5043-311b-8382-3b9a44bf0c7a, decorated key: {key: pk{000400000001}, token:-4069959284402364209}, size: 224
TRACE 2021-08-13 17:07:31,960 [shard 0] hints_manager - [127.0.0.2, send=0] do_send_one_mutation(): sending directly
TRACE 2021-08-13 17:07:31,960 [shard 0] hints_manager - [127.0.0.2, send=1] get_mutation(): deserialized mutation at RP {0, 375495143, 339}, for table ks.t, schema id: 579b3300-fb4b-11eb-a63b-ee322a24d469, version: 2b2238e8-5043-311b-8382-3b9a44bf0c7a, decorated key: {key: pk{000400000001}, token:-4069959284402364209}, size: 224
TRACE 2021-08-13 17:07:31,960 [shard 0] hints_manager - [127.0.0.2, send=1] do_send_one_mutation(): sending directly
TRACE 2021-08-13 17:07:31,960 [shard 0] hints_manager - [127.0.0.2, send=1] send_one_hint(): successfully sent
TRACE 2021-08-13 17:07:31,960 [shard 0] hints_manager - [127.0.0.2] notify_replay_waiters(): replay position upper bound was updated to {0, 375495143, 28}
TRACE 2021-08-13 17:07:31,960 [shard 0] hints_manager - [127.0.0.2, send=0] send_one_hint(): successfully sent
TRACE 2021-08-13 17:07:31,960 [shard 0] hints_manager - [127.0.0.2] notify_replay_waiters(): replay position upper bound was updated to {0, 375495143, 340}
DEBUG 2021-08-13 17:07:31,961 [shard 0] hints_manager - [127.0.0.2] send_one_file(): segment /home/piodul/workdirs/hh-tracing/1//hints/0/127.0.0.2/HintsLog-2-375495143.log was sent in full and deleted
TRACE 2021-08-13 17:07:31,961 [shard 0] hints_manager - [127.0.0.2] notify_replay_waiters(): replay position upper bound was updated to {0, 375495143, 340}
DEBUG 2021-08-13 17:07:31,961 [shard 0] hints_manager - [127.0.0.2] send_hints(): we handled 1 segments
```

Fixes: #9025