### PR TITLE
storage_service: Generate view update for load and stream

### DIFF
--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -3224,7 +3224,7 @@ future<> storage_service::load_and_stream(sstring ks_name, sstring cf_name,
     auto& table = _db.local().find_column_family(table_id);
     auto s = table.schema();
     const auto cf_id = s->id();
-    const auto reason = streaming::stream_reason::rebuild;
+    const auto reason = streaming::stream_reason::repair;
     auto& rs = _db.local().find_keyspace(ks_name).get_replication_strategy();
 
     size_t nr_sst_total = sstables.size();


### PR DESCRIPTION
Currently, view will be not updated because the streaming reason is set
to streaming::stream_reason::rebuild. On the receiver side, only
streaming with the reason streaming::stream_reason::repair will trigger
view update.

Change the stream reason to repair to trigger view update for load and
stream. This makes load_and_stream behaves the same as nodetool refresh.

Note: However, this is not very efficient though.

Consider RF = 3, sst1, sst2, sst3 from the older cluster. When sst1 is
loaded, it streams to 3 replica nodes, if we generate view updates, we
will have 3 view updates for this replica (each of the peer nodes finds
its peer and writes the view update to peer). After loading sst2 and
sst3, we will have 9 view updates in total for a single partition.
If we create the view after the load and stream process, we will only
have 3 view updates for a single partition.

If we create the view after the load and stream process, we will only
have 3 view updates for a single partition.

Fixes #9205