### PR TITLE
database: coroutinize schema load functions

### DIFF
--- a/database.cc
+++ b/database.cc
@@ -769,65 +769,67 @@ do_parse_schema_tables(distributed<service::storage_proxy>& proxy, const sstring
 
 future<> database::parse_system_tables(distributed<service::storage_proxy>& proxy, distributed<service::migration_manager>& mm) {
     using namespace db::schema_tables;
-    return do_parse_schema_tables(proxy, db::schema_tables::KEYSPACES, [this] (schema_result_value_type &v) {
+    co_await do_parse_schema_tables(proxy, db::schema_tables::KEYSPACES, [&] (schema_result_value_type &v) -> future<> {
         auto ksm = create_keyspace_from_schema_partition(v);
-        return create_keyspace(ksm, true /* bootstrap. do not mark populated yet */, system_keyspace::no);
-    }).then([&proxy, this] {
-        return do_parse_schema_tables(proxy, db::schema_tables::TYPES, [this] (schema_result_value_type &v) {
+        co_return co_await create_keyspace(ksm, true /* bootstrap. do not mark populated yet */, system_keyspace::no);
+    });
+    {
+        co_await do_parse_schema_tables(proxy, db::schema_tables::TYPES, [&] (schema_result_value_type &v) -> future<> {
             auto& ks = this->find_keyspace(v.first);
             auto&& user_types = create_types_from_schema_partition(*ks.metadata(), v.second);
             for (auto&& type : user_types) {
                 ks.add_user_type(type);
             }
-            return make_ready_future<>();
+            co_return;
         });
-    }).then([&proxy, this] {
-        return do_parse_schema_tables(proxy, db::schema_tables::FUNCTIONS, [this] (schema_result_value_type& v) {
+        co_await do_parse_schema_tables(proxy, db::schema_tables::FUNCTIONS, [&] (schema_result_value_type& v) -> future<> {
             auto&& user_functions = create_functions_from_schema_partition(*this, v.second);
             for (auto&& func : user_functions) {
                 cql3::functions::functions::add_function(func);
             }
-            return make_ready_future<>();
+            co_return;
         });
-    }).then([&proxy, this] {
-        return do_parse_schema_tables(proxy, db::schema_tables::TABLES, [this, &proxy] (schema_result_value_type &v) {
-            return create_tables_from_tables_partition(proxy, v.second).then([this, &proxy] (std::map<sstring, schema_ptr> tables) {
-                return parallel_for_each(tables.begin(), tables.end(), [this, &proxy] (auto& t) {
-                    return this->add_column_family_and_make_directory(t.second).then([&proxy, s = t.second] {
+        co_await do_parse_schema_tables(proxy, db::schema_tables::TABLES, [&] (schema_result_value_type &v) -> future<> {
+            std::map<sstring, schema_ptr> tables = co_await create_tables_from_tables_partition(proxy, v.second);
+            {
+                co_await parallel_for_each(tables.begin(), tables.end(), [&] (auto& t) -> future<> {
+                    co_await this->add_column_family_and_make_directory(t.second);
+                    auto s = t.second;
+                    {
                         // Recreate missing column mapping entries in case
                         // we failed to persist them for some reason after a schema change
-                        return db::schema_tables::column_mapping_exists(s->id(), s->version()).then([&proxy, s] (bool cm_exists) {
+                        bool cm_exists = co_await db::schema_tables::column_mapping_exists(s->id(), s->version());
+                        {
                             if (cm_exists) {
-                                return make_ready_future<>();
+                                co_return;
                             }
-                            return db::schema_tables::store_column_mapping(proxy, s, false);
-                        });
-                    });
+                            co_return co_await db::schema_tables::store_column_mapping(proxy, s, false);
+                        }
+                    }
                 });
+            }
             });
-            });
-    }).then([&proxy, &mm, this] {
-        return do_parse_schema_tables(proxy, db::schema_tables::VIEWS, [this, &proxy, &mm] (schema_result_value_type &v) {
-            return create_views_from_schema_partition(proxy, v.second).then([this, &mm, &proxy] (std::vector<view_ptr> views) {
-                return parallel_for_each(views.begin(), views.end(), [this, &mm, &proxy] (auto&& v) {
+        co_await do_parse_schema_tables(proxy, db::schema_tables::VIEWS, [&] (schema_result_value_type &v) -> future<> {
+            std::vector<view_ptr> views = co_await create_views_from_schema_partition(proxy, v.second);
+            {
+                co_await parallel_for_each(views.begin(), views.end(), [&] (auto&& v) -> future<> {
                     // TODO: Remove once computed columns are guaranteed to be featured in the whole cluster.
                     // we fix here the schema in place in oreder to avoid races (write commands comming from other coordinators).
                     view_ptr fixed_v = maybe_fix_legacy_secondary_index_mv_schema(*this, v, nullptr, preserve_version::yes);
                     view_ptr v_to_add = fixed_v ? fixed_v : v;
-                    future<> f = this->add_column_family_and_make_directory(v_to_add);
+                    co_await this->add_column_family_and_make_directory(v_to_add);
                     if (bool(fixed_v)) {
                         v_to_add = fixed_v;
                         auto&& keyspace = find_keyspace(v->ks_name()).metadata();
                         auto mutations = db::schema_tables::make_update_view_mutations(keyspace, view_ptr(v), fixed_v, api::new_timestamp(), true);
-                        f = f.then([this, &proxy, mutations = std::move(mutations)] {
-                            return db::schema_tables::merge_schema(proxy, _feat, std::move(mutations));
-                        });
+                        {
+                            co_await db::schema_tables::merge_schema(proxy, _feat, std::move(mutations));
+                        }
                     }
-                    return f;
                 });
-            });
+            }
         });
-    });
+    }
 }
 
 future<>


### PR DESCRIPTION
Simple coroutinization of the schema load functions, leaving the code tidier.

Test: unit (dev)