### PR TITLE
sstables: convert parse(high level types) to a coroutine

### DIFF
--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -513,63 +513,53 @@ future<> parse(const schema& schema, sstable_version_types v, random_access_read
                      s.header.memory_size,
                      s.header.sampling_level,
                      s.header.size_at_full_sampling);
-    {
-        auto buf = co_await in.read_exactly(s.header.size * sizeof(pos_type));
-        {
-            auto len = s.header.size * sizeof(pos_type);
-            check_buf_size(buf, len);
+    auto buf = co_await in.read_exactly(s.header.size * sizeof(pos_type));
+    auto len = s.header.size * sizeof(pos_type);
+    check_buf_size(buf, len);
 
-            // Positions are encoded in little-endian.
-            auto b = buf.get();
-            s.positions = utils::chunked_vector<pos_type>();
-            while (s.positions.size() != s.header.size) {
-                s.positions.push_back(seastar::read_le<pos_type>(b));
-                b += sizeof(pos_type);
-                co_await make_ready_future<>(); // yield
-            }
-            {
-                // Since the keys in the index are not sized, we need to calculate
-                // the start position of the index i+1 to determine the boundaries
-                // of index i. The "memory_size" field in the header determines the
-                // total memory used by the map, so if we push it to the vector, we
-                // can guarantee that no conditionals are used, and we can always
-                // query the position of the "next" index.
-                s.positions.push_back(s.header.memory_size);
-            }
-
-            co_await in.seek(sizeof(summary::header) + s.header.memory_size);
-            co_await parse(schema, v, in, s.first_key, s.last_key);
-            co_await in.seek(s.positions[0] + sizeof(summary::header));
-
-            s.entries.reserve(s.header.size);
-
-            int idx = 0;
-            {
-                while (s.entries.size() != s.header.size) {
-                    auto pos = s.positions[idx++];
-                    auto next = s.positions[idx];
-
-                    auto entrysize = next - pos;
-                    auto buf = co_await in.read_exactly(entrysize);
-                    {
-                        check_buf_size(buf, entrysize);
-
-                        auto keysize = entrysize - 8;
-                        auto key_data = s.add_summary_data(bytes_view(reinterpret_cast<const int8_t*>(buf.get()), keysize));
-                        buf.trim_front(keysize);
-
-                        // position is little-endian encoded
-                        auto position = seastar::read_le<uint64_t>(buf.get());
-                        auto token = schema.get_partitioner().get_token(key_view(key_data));
-                        s.add_summary_data(token.data());
-                        s.entries.push_back({ token, key_data, position });
-                    }
-                }
-                // Delete last element which isn't part of the on-disk format.
-                s.positions.pop_back();
-            }
-        }
+    // Positions are encoded in little-endian.
+    auto b = buf.get();
+    s.positions = utils::chunked_vector<pos_type>();
+    while (s.positions.size() != s.header.size) {
+        s.positions.push_back(seastar::read_le<pos_type>(b));
+        b += sizeof(pos_type);
+        co_await make_ready_future<>(); // yield
     }
+    // Since the keys in the index are not sized, we need to calculate
+    // the start position of the index i+1 to determine the boundaries
+    // of index i. The "memory_size" field in the header determines the
+    // total memory used by the map, so if we push it to the vector, we
+    // can guarantee that no conditionals are used, and we can always
+    // query the position of the "next" index.
+    s.positions.push_back(s.header.memory_size);
+
+    co_await in.seek(sizeof(summary::header) + s.header.memory_size);
+    co_await parse(schema, v, in, s.first_key, s.last_key);
+    co_await in.seek(s.positions[0] + sizeof(summary::header));
+
+    s.entries.reserve(s.header.size);
+
+    int idx = 0;
+    while (s.entries.size() != s.header.size) {
+        auto pos = s.positions[idx++];
+        auto next = s.positions[idx];
+
+        auto entrysize = next - pos;
+        auto buf = co_await in.read_exactly(entrysize);
+        check_buf_size(buf, entrysize);
+
+        auto keysize = entrysize - 8;
+        auto key_data = s.add_summary_data(bytes_view(reinterpret_cast<const int8_t*>(buf.get()), keysize));
+        buf.trim_front(keysize);
+
+        // position is little-endian encoded
+        auto position = seastar::read_le<uint64_t>(buf.get());
+        auto token = schema.get_partitioner().get_token(key_view(key_data));
+        s.add_summary_data(token.data());
+        s.entries.push_back({ token, key_data, position });
+    }
+    // Delete last element which isn't part of the on-disk format.
+    s.positions.pop_back();
 }
 
 inline void write(sstable_version_types v, file_writer& out, const summary_entry& entry) {
@@ -621,45 +611,41 @@ inline void write(sstable_version_types v, file_writer& out, const std::unique_p
 }
 
 future<> parse(const schema& schema, sstable_version_types v, random_access_reader& in, statistics& s) {
-  try {
-    co_await parse(schema, v, in, s.offsets);
-    {
+    try {
+        co_await parse(schema, v, in, s.offsets);
         // Old versions of Scylla do not respect the order.
         // See https://github.com/scylladb/scylla/issues/3937
         boost::sort(s.offsets.elements, [] (auto&& e1, auto&& e2) { return e1.first < e2.first; });
         for (auto val : s.offsets.elements) {
             auto type = val.first;
             co_await in.seek(val.second);
-            {
-                switch (type) {
-                case metadata_type::Validation:
-                    co_await parse<validation_metadata>(schema, v, in, s.contents[type]);
-                    break;
-                case metadata_type::Compaction:
-                    co_await parse<compaction_metadata>(schema, v, in, s.contents[type]);
-                    break;
-                case metadata_type::Stats:
-                    co_await parse<stats_metadata>(schema, v, in, s.contents[type]);
-                    break;
-                case metadata_type::Serialization:
-                    if (v < sstable_version_types::mc) {
-                        throw malformed_sstable_exception(
-                            "Statistics is malformed: SSTable is in 2.x format but contains serialization header.");
-                    } else {
-                        co_await parse<serialization_header>(schema, v, in, s.contents[type]);
-                    }
-                    break;
-                default:
-                    throw malformed_sstable_exception(fmt::format("Invalid metadata type at Statistics file: {} ", int(type)));
+            switch (type) {
+            case metadata_type::Validation:
+                co_await parse<validation_metadata>(schema, v, in, s.contents[type]);
+                break;
+            case metadata_type::Compaction:
+                co_await parse<compaction_metadata>(schema, v, in, s.contents[type]);
+                break;
+            case metadata_type::Stats:
+                co_await parse<stats_metadata>(schema, v, in, s.contents[type]);
+                break;
+            case metadata_type::Serialization:
+                if (v < sstable_version_types::mc) {
+                    throw malformed_sstable_exception(
+                        "Statistics is malformed: SSTable is in 2.x format but contains serialization header.");
+                } else {
+                    co_await parse<serialization_header>(schema, v, in, s.contents[type]);
                 }
+                break;
+            default:
+                throw malformed_sstable_exception(fmt::format("Invalid metadata type at Statistics file: {} ", int(type)));
             }
         }
+    } catch (const malformed_sstable_exception&) {
+        throw;
+    } catch (...) {
+        throw malformed_sstable_exception(fmt::format("Statistics file is malformed: {}", std::current_exception()));
     }
-        } catch (const malformed_sstable_exception&) {
-            throw;
-        } catch (...) {
-            throw malformed_sstable_exception(fmt::format("Statistics file is malformed: {}", std::current_exception()));
-        }
 }
 
 inline void write(sstable_version_types v, file_writer& out, const statistics& s) {
@@ -673,38 +659,32 @@ future<> parse(const schema& s, sstable_version_types v, random_access_reader& i
     auto len = std::make_unique<uint32_t>();
 
     co_await parse(s, v, in, *len);
-    {
-        uint32_t length = *len;
+    uint32_t length = *len;
 
-        if (length == 0) {
-            throw malformed_sstable_exception("Estimated histogram with zero size found. Can't continue!");
+    if (length == 0) {
+        throw malformed_sstable_exception("Estimated histogram with zero size found. Can't continue!");
+    }
+
+    // Arrays are potentially pre-initialized by the estimated_histogram constructor.
+    eh.bucket_offsets.clear();
+    eh.buckets.clear();
+
+    eh.bucket_offsets.reserve(length - 1);
+    eh.buckets.reserve(length);
+
+    auto type_size = sizeof(uint64_t) * 2;
+    auto buf = co_await in.read_exactly(length * type_size);
+    check_buf_size(buf, length * type_size);
+
+    size_t j = 0;
+    while (eh.buckets.size() != length) {
+        auto offset = net::ntoh(read_unaligned<uint64_t>(buf.get() + (j++) * sizeof(uint64_t)));
+        auto bucket = net::ntoh(read_unaligned<uint64_t>(buf.get() + (j++) * sizeof(uint64_t)));
+        if (!eh.buckets.empty()) {
+            eh.bucket_offsets.push_back(offset);
         }
-
-        // Arrays are potentially pre-initialized by the estimated_histogram constructor.
-        eh.bucket_offsets.clear();
-        eh.buckets.clear();
-
-        eh.bucket_offsets.reserve(length - 1);
-        eh.buckets.reserve(length);
-
-        auto type_size = sizeof(uint64_t) * 2;
-        auto buf = co_await in.read_exactly(length * type_size);
-        {
-            check_buf_size(buf, length * type_size);
-
-            size_t j = 0;
-            {
-                while (eh.buckets.size() != length) {
-                    auto offset = net::ntoh(read_unaligned<uint64_t>(buf.get() + (j++) * sizeof(uint64_t)));
-                    auto bucket = net::ntoh(read_unaligned<uint64_t>(buf.get() + (j++) * sizeof(uint64_t)));
-                    if (!eh.buckets.empty()) {
-                        eh.bucket_offsets.push_back(offset);
-                    }
-                    eh.buckets.push_back(bucket);
-                    co_await make_ready_future<>(); // yield
-                }
-            }
-        }
+        eh.buckets.push_back(bucket);
+        co_await make_ready_future<>(); // yield
     }
 }
 
@@ -750,29 +730,26 @@ future<> parse(const schema& s, sstable_version_types v, random_access_reader& i
     auto a = disk_array<uint32_t, streaming_histogram_element>();
 
     co_await parse(s, v, in, sh.max_bin_size, a);
-    {
-
-        auto length = a.elements.size();
-        if (length > sh.max_bin_size) {
-            throw malformed_sstable_exception("Streaming histogram with more entries than allowed. Can't continue!");
-        }
-
-        // Find bad histogram which had incorrect elements merged due to use of
-        // unordered map. The keys will be unordered. Histogram which size is
-        // less than max allowed will be correct because no entries needed to be
-        // merged, so we can avoid discarding those.
-        // look for commit with title 'streaming_histogram: fix update' for more details.
-        auto possibly_broken_histogram = length == sh.max_bin_size;
-        auto less_comp = [] (auto& x, auto& y) { return x.key < y.key; };
-        if (possibly_broken_histogram && !boost::is_sorted(a.elements, less_comp)) {
-            co_return;
-        }
-
-        auto transform = [] (auto element) -> std::pair<streaming_histogram_element::key_type, streaming_histogram_element::value_type> {
-            return { element.key, element.value };
-        };
-        boost::copy(a.elements | boost::adaptors::transformed(transform), std::inserter(sh.bin, sh.bin.end()));
+    auto length = a.elements.size();
+    if (length > sh.max_bin_size) {
+        throw malformed_sstable_exception("Streaming histogram with more entries than allowed. Can't continue!");
     }
+
+    // Find bad histogram which had incorrect elements merged due to use of
+    // unordered map. The keys will be unordered. Histogram which size is
+    // less than max allowed will be correct because no entries needed to be
+    // merged, so we can avoid discarding those.
+    // look for commit with title 'streaming_histogram: fix update' for more details.
+    auto possibly_broken_histogram = length == sh.max_bin_size;
+    auto less_comp = [] (auto& x, auto& y) { return x.key < y.key; };
+    if (possibly_broken_histogram && !boost::is_sorted(a.elements, less_comp)) {
+        co_return;
+    }
+
+    auto transform = [] (auto element) -> std::pair<streaming_histogram_element::key_type, streaming_histogram_element::value_type> {
+        return { element.key, element.value };
+    };
+    boost::copy(a.elements | boost::adaptors::transformed(transform), std::inserter(sh.bin, sh.bin.end()));
 }
 
 void write(sstable_version_types v, file_writer& out, const utils::streaming_histogram& sh) {
@@ -788,9 +765,7 @@ void write(sstable_version_types v, file_writer& out, const utils::streaming_his
 
 future<> parse(const schema& s, sstable_version_types v, random_access_reader& in, commitlog_interval& ci) {
     co_await parse(s, v, in, ci.start);
-    {
-        co_await parse(s, v, in, ci.end);
-    }
+    co_await parse(s, v, in, ci.end);
 }
 
 void write(sstable_version_types v, file_writer& out, const commitlog_interval& ci) {
@@ -803,26 +778,20 @@ future<> parse(const schema& s, sstable_version_types v, random_access_reader& i
     uint32_t chunk_len = 0;
 
     co_await parse(s, v, in, c.name, c.options, chunk_len, data_len);
-    {
-        c.set_uncompressed_chunk_length(chunk_len);
-        c.set_uncompressed_file_length(data_len);
+    c.set_uncompressed_chunk_length(chunk_len);
+    c.set_uncompressed_file_length(data_len);
 
-        uint32_t len = 0;
-        compression::segmented_offsets::writer offsets = c.offsets.get_writer();
-        co_await parse(s, v, in, len);
-        {
-            auto eoarr = [&c, &len] { return c.offsets.size() == len; };
+    uint32_t len = 0;
+    compression::segmented_offsets::writer offsets = c.offsets.get_writer();
+    co_await parse(s, v, in, len);
+    auto eoarr = [&c, &len] { return c.offsets.size() == len; };
 
-            while (!eoarr()) {
-                auto now = std::min(len - c.offsets.size(), 100000 / sizeof(uint64_t));
-                auto buf = co_await in.read_exactly(now * sizeof(uint64_t));
-                {
-                    for (size_t i = 0; i < now; ++i) {
-                        uint64_t value = read_unaligned<uint64_t>(buf.get() + i * sizeof(uint64_t));
-                        offsets.push_back(net::ntoh(value));
-                    }
-                }
-            }
+    while (!eoarr()) {
+        auto now = std::min(len - c.offsets.size(), 100000 / sizeof(uint64_t));
+        auto buf = co_await in.read_exactly(now * sizeof(uint64_t));
+        for (size_t i = 0; i < now; ++i) {
+            uint64_t value = read_unaligned<uint64_t>(buf.get() + i * sizeof(uint64_t));
+            offsets.push_back(net::ntoh(value));
         }
     }
 }

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -799,13 +799,13 @@ void write(sstable_version_types v, file_writer& out, const commitlog_interval& 
 }
 
 future<> parse(const schema& s, sstable_version_types v, random_access_reader& in, compression& c) {
-    auto data_len_ptr = make_lw_shared<uint64_t>(0);
-    auto chunk_len_ptr = make_lw_shared<uint32_t>(0);
+    uint64_t data_len = 0;
+    uint32_t chunk_len = 0;
 
-    co_await parse(s, v, in, c.name, c.options, *chunk_len_ptr, *data_len_ptr);
+    co_await parse(s, v, in, c.name, c.options, chunk_len, data_len);
     {
-        c.set_uncompressed_chunk_length(*chunk_len_ptr);
-        c.set_uncompressed_file_length(*data_len_ptr);
+        c.set_uncompressed_chunk_length(chunk_len);
+        c.set_uncompressed_file_length(data_len);
 
         uint32_t len = 0;
         compression::segmented_offsets::writer offsets = c.offsets.get_writer();

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -787,9 +787,10 @@ void write(sstable_version_types v, file_writer& out, const utils::streaming_his
 }
 
 future<> parse(const schema& s, sstable_version_types v, random_access_reader& in, commitlog_interval& ci) {
-    return parse(s, v, in, ci.start).then([&ci, v, &s, &in] {
-        return parse(s, v, in, ci.end);
-    });
+    co_await parse(s, v, in, ci.start);
+    {
+        co_await parse(s, v, in, ci.end);
+    }
 }
 
 void write(sstable_version_types v, file_writer& out, const commitlog_interval& ci) {


### PR DESCRIPTION
The parse() function of high-level sstable metadata types are
trivial straight line code and can be easily simplified by 
conversion to coroutines.

Test: unit (dev)