### PR TITLE
secondary_index_manager: stop including expression.hh

### DIFF
--- a/api/column_family.cc
+++ b/api/column_family.cc
@@ -30,6 +30,7 @@
 #include "db/system_keyspace_view_types.hh"
 #include "db/data_listeners.hh"
 #include "storage_service.hh"
+#include "unimplemented.hh"
 
 extern logging::logger apilog;
 

--- a/api/compaction_manager.cc
+++ b/api/compaction_manager.cc
@@ -24,6 +24,7 @@
 #include "api/api-doc/compaction_manager.json.hh"
 #include "db/system_keyspace.hh"
 #include "column_family.hh"
+#include "unimplemented.hh"
 #include <utility>
 
 namespace api {

--- a/index/secondary_index_manager.cc
+++ b/index/secondary_index_manager.cc
@@ -43,6 +43,7 @@
 
 #include "cql3/statements/index_target.hh"
 #include "cql3/util.hh"
+#include "cql3/expr/expression.hh"
 #include "index/target_parser.hh"
 #include "db/query_context.hh"
 #include "schema_builder.hh"

--- a/index/secondary_index_manager.hh
+++ b/index/secondary_index_manager.hh
@@ -43,11 +43,16 @@
 
 #include "schema.hh"
 
-#include "cql3/expr/expression.hh"
 #include "database_fwd.hh"
 
 #include <vector>
 #include <set>
+
+namespace cql3::expr {
+
+enum class oper_t;
+
+}
 
 namespace secondary_index {
 

--- a/service/client_state.cc
+++ b/service/client_state.cc
@@ -52,6 +52,7 @@
 #include "db/system_distributed_keyspace.hh"
 #include "database.hh"
 #include "cdc/log.hh"
+#include "utils/overloaded_functor.hh"
 #include <seastar/core/coroutine.hh>
 
 thread_local api::timestamp_type service::client_state::_last_timestamp_micros = 0;

--- a/test/boost/cql_query_like_test.cc
+++ b/test/boost/cql_query_like_test.cc
@@ -39,6 +39,7 @@
 #include "types/set.hh"
 #include "test/lib/exception_utils.hh"
 #include "schema_builder.hh"
+#include "cql3/query_options.hh"
 
 using namespace std::literals::chrono_literals;
 

--- a/test/boost/error_injection_test.cc
+++ b/test/boost/error_injection_test.cc
@@ -27,6 +27,7 @@
 #include "test/lib/cql_assertions.hh"
 #include "types/list.hh"
 #include "log.hh"
+#include "cql3/query_options.hh"
 #include <chrono>
 
 using namespace std::literals::chrono_literals;

--- a/test/boost/restrictions_test.cc
+++ b/test/boost/restrictions_test.cc
@@ -26,6 +26,7 @@
 
 #include "cql3/cql_config.hh"
 #include "cql3/values.hh"
+#include "cql3/query_options.hh"
 #include "test/lib/cql_assertions.hh"
 #include "test/lib/cql_test_env.hh"
 #include "test/lib/exception_utils.hh"

--- a/test/boost/view_build_test.cc
+++ b/test/boost/view_build_test.cc
@@ -27,6 +27,7 @@
 #include "db/system_keyspace.hh"
 #include "db/system_keyspace_view_types.hh"
 #include "db/config.hh"
+#include "cql3/query_options.hh"
 
 #include <seastar/testing/test_case.hh>
 #include <seastar/testing/thread_test_case.hh>

--- a/test/lib/cql_test_env.hh
+++ b/test/lib/cql_test_env.hh
@@ -52,6 +52,12 @@ namespace cql3 {
     class query_processor;
 }
 
+namespace service {
+
+class client_state;
+
+}
+
 class not_prepared_exception : public std::runtime_error {
 public:
     not_prepared_exception(const cql3::prepared_cache_key_type& id) : std::runtime_error(format("Not prepared: {}", id)) {}


### PR DESCRIPTION
Use a forward declaration of cql3::expr::oper_t to reduce the
number of translation units depending on expression.hh.

Before:

    $ find build/dev -name '*.d' | xargs cat | grep -c expression.hh
    272

After:

    $ find build/dev -name '*.d' | xargs cat | grep -c expression.hh
    154

Some translation units adjust their includes to restore access
to required headers.