### PR TITLE
Micro Benchmark: Fix division by zero in 'perf_fast_forward'

### DIFF
--- a/test/perf/perf_fast_forward.cc
+++ b/test/perf/perf_fast_forward.cc
@@ -724,7 +724,7 @@ public:
             cache_insertions(),
             allocations(),
             tasks(),
-            instructions() / fragments_read,
+            fragments_read ? instructions() / fragments_read : 0,
             cpu_utilization() * 100
         };
     }


### PR DESCRIPTION
Commit 8d6e575 introduced a new stat, instructions per fragment.
Computing this new stat can end with a division by zero when
the number of fragmens read is 0. Here we fix it by reporting
0 ins/f when no fragments were read.

Fixes #9231