### PR TITLE
utils: compact-radix-tree: fix accidental cache line bouncing

### DIFF
--- a/utils/compact-radix-tree.hh
+++ b/utils/compact-radix-tree.hh
@@ -564,7 +564,11 @@ private:
 
         node_head_ptr& operator=(node_head* v) noexcept {
             _v = v;
-            if (_v != nullptr) {
+            // Checking (_v != &nil_root) is not needed for correctness, since
+            // nil_root's _backref is never read anyway. But we do this check for
+            // performance reasons: since nil_root is shared between shards,
+            // writing to it would cause serious cache contention.
+            if (_v != nullptr && _v != &nil_root) {
                 _v->_backref = this;
             }
             return *this;


### PR DESCRIPTION
Whenever a node_head_ptr is assigned to nil_root, the _backref inside it is
overwritten. But since nil_root is shared between shards, this causes severe
cache line bouncing. (It was observed to reduce the total write throughput
of Scylla by 90% on a large NUMA machine).

This backreference is never read anyway, so fix this bug by not writing it.

Fixes #9252