### PR TITLE
removed master from version drop-down

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -115,7 +115,7 @@ html_theme_options = {
     ('Scylla University', 'https://university.scylladb.com/'),
     ('ScyllaDB Home', 'https://www.scylladb.com/')],
     'github_issues_repository': 'scylladb/scylla',
-    'hide_version_dropdown': ['master']
+    'hide_version_dropdown': ['master'],
     'default_branch': 'stable',
     'show_sidebar_index': True,
 }


### PR DESCRIPTION
This PR removes "master" from the documentation version dropdown list. Master is still there but not accessible from the drop-down. This way only released branches are visible to readers
the PR allows you to see 
4.4 as the released branch
and 4.5 as a preview. 
A warning is included with the preview version. The language is not the best, but will be fixed in another PR.

