### PR TITLE
Scrub compaction serialization

### DIFF
--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -765,7 +765,9 @@ future<> compaction_manager::rewrite_sstables(column_family* cf, sstables::compa
 }
 
 future<> compaction_manager::perform_sstable_scrub_validate_mode(column_family* cf) {
-    return run_custom_job(cf, sstables::compaction_type::Scrub, [this, &cf = *cf, sstables = get_candidates(*cf)] () mutable -> future<> {
+    // All sstables must be included, even the ones being compacted, such that everything in table is validated.
+    auto all_sstables = boost::copy_range<std::vector<sstables::shared_sstable>>(*cf->get_sstables());
+    return run_custom_job(cf, sstables::compaction_type::Scrub, [this, &cf = *cf, sstables = std::move(all_sstables)] () mutable -> future<> {
         class pending_tasks {
             compaction_manager::stats& _stats;
             size_t _n;

--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -899,9 +899,14 @@ future<> compaction_manager::perform_sstable_scrub(column_family* cf, sstables::
     if (scrub_mode == sstables::compaction_options::scrub::mode::validate) {
         return perform_sstable_scrub_validate_mode(cf);
     }
-    return rewrite_sstables(cf, sstables::compaction_options::make_scrub(scrub_mode), [this] (const table& cf) {
-        return get_candidates(cf);
-    }, can_purge_tombstones::no);
+    // since we might potentially have ongoing compactions, and we
+    // must ensure that all sstables created before we run are scrubbed,
+    // we need to barrier out any previously running compaction.
+    return cf->run_with_compaction_disabled([this, cf, scrub_mode] {
+        return rewrite_sstables(cf, sstables::compaction_options::make_scrub(scrub_mode), [this] (const table& cf) {
+            return get_candidates(cf);
+        }, can_purge_tombstones::no);
+    });
 }
 
 future<> compaction_manager::remove(column_family* cf) {


### PR DESCRIPTION
Currently scrub compaction filters-out sstables that are undergoing (regular) compaction.
This is surprising to the user and we would like scrub (in validate mode or otherwise) to examine all sstables in the table.

Scrub in VALIDATE mode is read-only, therefore it can run in parallel to regular compaction. However, this series makes sure it selects all sstables in the table, without filtering sstables undergoing compaction.

For scrub in non-validation mode, we would like to ensure that it examined all sstables that were sealed when it started and it fixed any corruption (based on the scrub mode). Therefore, we stop ongoing compactions when running scrub in non-validation modes. Otherwise compaction might just copy the corrupt data onto new sstables, requiring scrub to run again.

Also, acquire _compaction_locks write lock for the table to serialize with other custom compaction jobs like major compaction, reshape, and reshard.

Fixes #9256

Test: unit(dev)
DTest: nodetool_additional_test.py:TestNodetool.{validate_sstable_with_invalid_fragment_test,validate_ks_sstable_with_invalid_fragment_test,validate_with_one_node_expect_data_loss_test}