### PR TITLE
cql3: expr: replace column_value_tuple by a composition of tuple_constructor and column_value

### DIFF
--- a/cql3/expr/term_expr.cc
+++ b/cql3/expr/term_expr.cc
@@ -799,9 +799,6 @@ prepare_term(const expression& expr, database& db, const sstring& keyspace, lw_s
         [&] (const column_value&) -> ::shared_ptr<term> {
             on_internal_error(expr_logger, "column_values are not yet reachable via term_raw_expr::prepare()");
         },
-        [&] (const column_value_tuple&) -> ::shared_ptr<term> {
-            on_internal_error(expr_logger, "column_value_tuples are not yet reachable via term_raw_expr::prepare()");
-        },
         [&] (const token&) -> ::shared_ptr<term> {
             on_internal_error(expr_logger, "tokens are not yet reachable via term_raw_expr::prepare()");
         },
@@ -888,9 +885,6 @@ test_assignment(const expression& expr, database& db, const sstring& keyspace, c
         },
         [&] (const column_value&) -> test_result {
             on_internal_error(expr_logger, "column_values are not yet reachable via term_raw_expr::test_assignment()");
-        },
-        [&] (const column_value_tuple&) -> test_result {
-            on_internal_error(expr_logger, "column_value_tuples are not yet reachable via term_raw_expr::test_assignment()");
         },
         [&] (const token&) -> test_result {
             on_internal_error(expr_logger, "tokens are not yet reachable via term_raw_expr::test_assignment()");

--- a/cql3/restrictions/multi_column_restriction.hh
+++ b/cql3/restrictions/multi_column_restriction.hh
@@ -54,6 +54,17 @@ namespace cql3 {
 
 namespace restrictions {
 
+inline
+expr::tuple_constructor
+column_definitions_as_tuple_constructor(const std::vector<const column_definition*>& defs) {
+    std::vector<expr::expression> columns;
+    columns.reserve(defs.size());
+    for (auto& def : defs) {
+        columns.push_back(expr::column_value{def});
+    }
+    return expr::tuple_constructor{std::move(columns)};
+}
+
 class multi_column_restriction : public clustering_key_restrictions {
 private:
     bool _has_only_asc_columns;
@@ -189,7 +200,7 @@ public:
     {
         using namespace expr;
         expression = binary_operator{
-            column_value_tuple(_column_defs), oper_t::EQ, _value};
+            column_definitions_as_tuple_constructor(_column_defs), oper_t::EQ, _value};
     }
 
     virtual bool is_supported_by(const secondary_index::index& index) const override {
@@ -302,7 +313,7 @@ public:
     {
         using namespace expr;
         expression = binary_operator{
-            column_value_tuple(_column_defs),
+            column_definitions_as_tuple_constructor(_column_defs),
             oper_t::IN,
             ::make_shared<lists::delayed_value>(_values)};
     }
@@ -321,7 +332,7 @@ public:
         : IN(schema, std::move(defs)), _marker(marker) {
         using namespace expr;
         expression = binary_operator{
-            column_value_tuple(_column_defs),
+            column_definitions_as_tuple_constructor(_column_defs),
             oper_t::IN,
             std::move(marker)};
     }
@@ -343,7 +354,7 @@ public:
         : slice(schema, defs, term_slice::new_instance(bound, inclusive, term), m)
     {
         expression = expr::binary_operator{
-            expr::column_value_tuple(defs),
+            column_definitions_as_tuple_constructor(defs),
             expr::pick_operator(bound, inclusive),
             std::move(term),
             m};

--- a/cql3/restrictions/single_column_primary_key_restrictions.hh
+++ b/cql3/restrictions/single_column_primary_key_restrictions.hh
@@ -150,7 +150,7 @@ public:
 
     virtual void merge_with(::shared_ptr<restriction> restriction) override {
         if (find_atom(restriction->expression, [] (const expr::binary_operator& b) {
-                    return std::holds_alternative<expr::column_value_tuple>(*b.lhs);
+                    return std::holds_alternative<expr::tuple_constructor>(*b.lhs);
                 })) {
             throw exceptions::invalid_request_exception(
                 "Mixing single column relations and multi column relations on clustering columns is not allowed");

--- a/cql3/selection/selectable.cc
+++ b/cql3/selection/selectable.cc
@@ -156,9 +156,6 @@ prepare_selectable(const schema& s, const expr::expression& raw_selectable) {
             // so bridge them.
             return ::make_shared<column_identifier>(column.col->name(), column.col->name_as_text());
         },
-        [&] (const expr::column_value_tuple& conj) -> shared_ptr<selectable> {
-            on_internal_error(slogger, "no way to express 'SELECT (a, b, c)' in the grammar yet");
-        },
         [&] (const expr::token& tok) -> shared_ptr<selectable> {
             // expr::token implicitly the partition key as arguments, but
             // the selectable equivalent (with_function) needs explicit arguments,
@@ -245,9 +242,6 @@ selectable_processes_selection(const expr::expression& raw_selectable) {
             // There is no path that reaches here, but expr::column_value and column_identifier are logically the same,
             // so bridge them.
             return false;
-        },
-        [&] (const expr::column_value_tuple& conj) -> bool {
-            on_internal_error(slogger, "no way to express 'SELECT (a, b, c)' in the grammar yet");
         },
         [&] (const expr::token&) -> bool {
             // Arguably, should return false, because it only processes the partition key.

--- a/test/boost/statement_restrictions_test.cc
+++ b/test/boost/statement_restrictions_test.cc
@@ -433,7 +433,7 @@ BOOST_AUTO_TEST_CASE(expression_extract_column_restrictions) {
     expression r2_restriction(binary_operator(column_value(&col_r2), oper_t::EQ, zero_value));
 
     auto make_multi_column_restriction = [](std::vector<const column_definition*> columns, oper_t oper) -> expression {
-        column_value_tuple column_tuple(columns);
+        tuple_constructor column_tuple(cql3::restrictions::column_definitions_as_tuple_constructor(columns));
 
         std::vector<managed_bytes_opt> zeros_tuple_elems(columns.size(), managed_bytes_opt(I(0)));
         ::shared_ptr<tuples::value> zeros_tuple = ::make_shared<tuples::value>(std::move(zeros_tuple_elems));
@@ -457,7 +457,7 @@ BOOST_AUTO_TEST_CASE(expression_extract_column_restrictions) {
     expression token_expr = token{};
     expression pk1_expr = column_value(&col_pk1);
     expression pk2_expr = column_value(&col_pk1);
-    expression pk1_pk2_expr = column_value_tuple({&col_pk1, &col_pk2});
+    expression pk1_pk2_expr = tuple_constructor{{expression{column_value{&col_pk1}}, expression{column_value{&col_pk2}}}};
 
     big_where.push_back(pk1_restriction);
     big_where.push_back(pk2_restriction);


### PR DESCRIPTION
column_value_tuple overlaps both column_value and tuple_constructor
(in different respects) and can be replaced by a combination: a
tuple_constructor of column_value. The replacement is more expressive
(we can have a tuple of column_value and other expression types), though
the code (especially grammar) do not allow it yet.

So remove column_value_tuple and replace it everywhere with
tuple_constructor. Visitors get the merged behavior of the existing
tuple_constructor and column_value_tuple, which is usually trivial
since tuple_constructor and column_value_tuple came from different
hierarchies (term::raw and relation), so usually one of the types
just calls on_internal_error().

The change results in awkwards casts in two areas: WHERE clause
filtering (equal() and related), and clustering key range evaluations
(limits() and related). When equal() is replaced by recursive
evaluate(), the casts will go way (to be replaced by the evaluate())
visitor. Clustering key range extraction will remain limited
to tuples of column_value, so the prepare phase will have to vet
the expressions to ensure the casts don't fail (and use the
filtering path if they will).

Tests: unit (dev)