### PR TITLE
.gitignore: add compile_commands.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ test/*/*.reject
 .vscode
 docs/_build
 docs/poetry.lock
+compile_commands.json


### PR DESCRIPTION
compile_commands.json is a format of compilation database info for use
with several editors, such as VSCode (with official C++ extension) and
Vim (with youcompleteme). It can be generated with ninja:
```
ninja -t compdb > compile_commands.json
```

I propose this addition, so that this file won't be commited by
accident.