### PR TITLE
cql3: Reject updates with NULL key values

### DIFF
--- a/test/cql-pytest/cassandra_tests/validation/entities/frozen_collections_test.py
+++ b/test/cql-pytest/cassandra_tests/validation/entities/frozen_collections_test.py
@@ -86,15 +86,12 @@ def do_test_partition_key_usage(cql, test_keyspace, typ, v1, v2, v3, v4):
                    [v2, 0],
                    [v4, 0])
 
-@pytest.mark.xfail(reason="fails just because of null key, issue #7852")
 def test_partition_key_usage_set(cql, test_keyspace):
     do_test_partition_key_usage(cql, test_keyspace, "set<int>", set(), {1, 2, 3}, {4, 5, 6}, {7, 8, 9})
 
-@pytest.mark.xfail(reason="fails just because of null key, issue #7852")
 def test_partition_key_usage_list(cql, test_keyspace):
     do_test_partition_key_usage(cql, test_keyspace, "list<int>", [], [1, 2, 3], [4, 5, 6], [7, 8, 9])
 
-@pytest.mark.xfail(reason="fails just because of null key, issue #7852")
 def test_partition_key_usage_map(cql, test_keyspace):
     do_test_partition_key_usage(cql, test_keyspace, "map<int, int>", {}, {1: 10, 2: 20, 3: 30}, {4: 40, 5: 50, 6: 60}, {7: 70, 8: 80, 9: 90})
 


### PR DESCRIPTION
We were silently ignoring INSERTs with NULL values for primary-key
columns, which Cassandra rejects.  Fix it by rejecting any
modification_statement that would operate on empty partition or
clustering range.

This is the most direct fix, because range and slice are calculated in
one place for all modification statements.  It covers not only NULL
cases, but also impossible restrictions like c>0 AND c<0.
Unfortunately, Cassandra doesn't treat all modification statements
consistently, so this fix cannot fully match its behavior.  We err on
the side of tolerance, accepting some DELETE statements that Cassandra
rejects.  We add a TODO for rejecting such DELETEs later.

Fixes #7852.

Tests: unit (dev), cql-pytest against Cassandra 4.0

Signed-off-by: Dejan Mircevski <dejan@scylladb.com>