### PR TITLE
interval: constrain comparator parameters

### DIFF
--- a/db/size_estimates_virtual_reader.cc
+++ b/db/size_estimates_virtual_reader.cc
@@ -140,6 +140,9 @@ static std::vector<sstring> get_keyspaces(const schema& s, const database& db, d
         bool operator()(const dht::ring_position& rp, const sstring& ks) {
             return rp.less_compare(_s, as_ring_position(ks));
         }
+        bool operator()(const dht::ring_position& rp1, const dht::ring_position& rp2) {
+            return rp1.less_compare(_s, rp2);
+        }
     };
     auto keyspaces = db.get_non_system_keyspaces();
     auto cmp = keyspace_less_comparator(s);


### PR DESCRIPTION
The interval template member functions mostly accept
tri-comparators but a few functions accept less-comparators.
To reduce the chance of error, and to provide better error
messages, constrain comparator parameters to the expected
signature.

In one case (db/size_estimates_virtual_reader.cc) the caller
had to be adjusted. The comparator supported comparisons
of the interval value type against other types, but not
against itself. To simplify things, we add that signature too,
even though it will never be called.