### PR TITLE
dist/redhat: add scylla-python3 to scylla metapackage dependency

### DIFF
--- a/dist/redhat/scylla.spec
+++ b/dist/redhat/scylla.spec
@@ -7,7 +7,7 @@ Group:          Applications/Databases
 License:        AGPLv3
 URL:            http://www.scylladb.com/
 Source0:        %{reloc_pkg}
-Requires:       %{product}-server = %{version} %{product}-conf = %{version} %{product}-python3 = %{version} %{product}-kernel-conf = %{version} %{product}-jmx = %{version} %{product}-tools = %{version} %{product}-tools-core = %{version} %{product}-node-exporter = %{version}
+Requires:       %{product}-server = %{version} %{product}-conf = %{version} %{product}-python3 = %{version} %{product}-kernel-conf = %{version} %{product}-jmx = %{version} %{product}-tools = %{version} %{product}-tools-core = %{version} %{product}-node-exporter = %{version} %{product}-python3 = %{version}
 Obsoletes:	scylla-server < 1.1
 
 %global _debugsource_template %{nil}


### PR DESCRIPTION
Currently, scylla-python3 is not listed scylla metapackage dependency,
it listed on scylla-server dependency instead.
User may cause mistake of upgrading, because
yum upgrade scylla
or
yum upgrade scylla-<version>\*
will not upgrade scylla-python3, it only upgrade rest of packages.
To avoid such mistake, add scylla-python3 to scylla metapackage
dependency.

Fixes scylladb/scylla-enterprise#1914