### PR TITLE
storage_proxy: digest_read_resolver: use small_vector for holding digests

### DIFF
--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -2838,7 +2838,7 @@ class digest_read_resolver : public abstract_read_resolver {
     promise<digest_read_result> _cl_promise; // cl is reached
     bool _cl_reported = false;
     foreign_ptr<lw_shared_ptr<query::result>> _data_result;
-    std::vector<query::result_digest> _digest_results;
+    utils::small_vector<query::result_digest, 3> _digest_results;
     api::timestamp_type _last_modified = api::missing_timestamp;
     size_t _target_count_for_cl; // _target_count_for_cl < _targets_count if CL=LOCAL and RRD.GLOBAL
 


### PR DESCRIPTION
There is typically just 1-2 digests per query, so we can allocate
space for them in digest_read_resolver using small_vector, saving
an allocation.

Results: (perf_simple_query --smp 1 --operations-per-shard 1000000 --task-quota-ms 10)
    before: median 215301.75 tps ( 75.1 allocs/op,  12.1 tasks/op,   45238 insns/op)
    after:  median 221121.37 tps ( 74.1 allocs/op,  12.1 tasks/op,   45186 insns/op)

While the throughput numbers are not reliable due to frequency throttling,
it's clear there are fewer allocations and instuctions executed.