### PR TITLE
iotune - Fix i3en.xlarge check

### DIFF
--- a/dist/common/scripts/scylla_io_setup
+++ b/dist/common/scripts/scylla_io_setup
@@ -217,7 +217,7 @@ if __name__ == "__main__":
                     disk_properties["read_bandwidth"] = 330301440
                     disk_properties["write_iops"] = 33177
                     disk_properties["write_bandwidth"] = 165675008
-                elif idata.instance() in ("i3.xlarge", "i3en.2xlarge"):
+                elif idata.instance() in ("i3en.xlarge", "i3en.2xlarge"):
                     disk_properties["read_iops"] = 84480 * nr_disks
                     disk_properties["read_bandwidth"] = 666894336 * nr_disks
                     disk_properties["write_iops"] = 66969 * nr_disks


### PR DESCRIPTION
i3en.xlarge is currently not getting tuned properly. A quick test using Scylla AMI ( ami-07a31481e4394d346 ) reveals that the storage capabilities under this instance are greatly reduced:

$ grep iops /etc/scylla.d/io_properties.yaml
  read_iops: 257024
  write_iops: 174080

This patch corrects this typo, in such a way that iotune now properly tunes this instance type.