### PR TITLE
Fix i3en.xlarge problem in scylla_io_setup.

### DIFF
--- a/dist/common/scripts/scylla_io_setup
+++ b/dist/common/scripts/scylla_io_setup
@@ -217,7 +217,7 @@ if __name__ == "__main__":
                     disk_properties["read_bandwidth"] = 330301440
                     disk_properties["write_iops"] = 33177
                     disk_properties["write_bandwidth"] = 165675008
-                elif idata.instance() in ("i3.xlarge", "i3en.2xlarge"):
+                elif idata.instance() in ("i3en.xlarge", "i3en.2xlarge"):
                     disk_properties["read_iops"] = 84480 * nr_disks
                     disk_properties["read_bandwidth"] = 666894336 * nr_disks
                     disk_properties["write_iops"] = 66969 * nr_disks


### PR DESCRIPTION
The io numbers of i3en.xlarge that are predicted  when calling `scylla_io_setup --ami` do not match with what is measured when calling `scylla_io_setup`.

Predicted:

    read_bandwidth: 2043674624
    read_iops: 257024
    write_bandwidth: 1024458752
    write_iops: 174080

Measured

    read_iops: 92776
    read_bandwidth: 748515456
    write_iops: 72220
    write_bandwidth: 330152736

The cause is the `i3en.xlarge` is not correctly written in the
i3en branch. It is written as `i3.xlarge`.

After fixing we get the following prediction:

    read_bandwidth: 666894336
    read_iops: 84480
    write_bandwidth: 333447168
    write_iops: 66969

Which is much more in line with what is being measured.