### PR TITLE
cql3: Allow indexed query to select static columns

### DIFF
--- a/cql3/restrictions/statement_restrictions.cc
+++ b/cql3/restrictions/statement_restrictions.cc
@@ -1562,14 +1562,6 @@ void statement_restrictions::validate_secondary_index_selections(bool selects_on
         throw exceptions::invalid_request_exception(
             "Select on indexed columns and with IN clause for the PRIMARY KEY are not supported");
     }
-    // When the user only select static columns, the intent is that we don't query the whole partition but just
-    // the static parts. But 1) we don't have an easy way to do that with 2i and 2) since we don't support index on
-    // static columns
-    // so far, 2i means that you've restricted a non static column, so the query is somewhat non-sensical.
-    if (selects_only_static_columns) {
-        throw exceptions::invalid_request_exception(
-            "Queries using 2ndary indexes don't support selecting only static columns");
-    }
 }
 
 const single_column_restrictions::restrictions_map& statement_restrictions::get_single_column_partition_key_restrictions() const {

--- a/test/cql-pytest/cassandra_tests/validation/entities/static_columns_test.py
+++ b/test/cql-pytest/cassandra_tests/validation/entities/static_columns_test.py
@@ -90,7 +90,6 @@ def testStaticColumns(cql, test_keyspace):
             assert_rows(execute(cql, table, "SELECT * FROM %s"), [0, 1, None, 1], [0, 2, None, 2])
 
 # Migrated from cql_tests.py:TestCQL.static_columns_with_2i_test()
-@pytest.mark.xfail(reason="issue #8869")
 def testStaticColumnsWithSecondaryIndex(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(k int, p int, s int static, v int, PRIMARY KEY (k, p))") as table:
         execute(cql, table, "CREATE INDEX ON %s (v)")


### PR DESCRIPTION
We previously forbade selecting a static column when an index is
used.  But Cassandra allows it, so we should, too -- see #8869.

After removing the static-column check, the existing code gets the
correct result without any further changes (though it may read
multiple rows from the same partition).

Fixes #8869.

Tests: unit (dev)

Signed-off-by: Dejan Mircevski <dejan@scylladb.com>