### PR TITLE
Split view builder shutdown procedure to drain + stop

### DIFF
--- a/db/view/view_builder.hh
+++ b/db/view/view_builder.hh
@@ -206,6 +206,11 @@ public:
     future<> start(service::migration_manager&);
 
     /**
+     * Drains view building in order to prepare it for shutdown.
+     */
+    future<> drain();
+
+    /**
      * Stops the view building process.
      */
     future<> stop();


### PR DESCRIPTION
In order to be able to avoid a deadlock when CQL server cannot be started,
the view builder shutdown procedure is now split to two parts -
- drain and stop. Drain is performed before storage proxy shutdown,
but stop() will be called even before drain is scheduled.
The deadlock is as follows:
 - view builder creates a reader permit in order to be able
   to read from system tables
 - CQL server fails to start, shutdown procedure begins
 - view builder stop() is not called (because it was not scheduled
   yet), so it holds onto its reader permit
 - database shutdown procedure waits for all permits to be destroyed,
   and it hangs indefinitely because view builder keeps holding
   its permit.

Fixes #9306