### PR TITLE
cql3/modification_statement: Replace empty-range check with null check

### DIFF
--- a/cql3/restrictions/statement_restrictions.hh
+++ b/cql3/restrictions/statement_restrictions.hh
@@ -522,6 +522,9 @@ public:
             const query_options& options, const schema& idx_tbl_schema) const;
 
     sstring to_string() const;
+
+    /// True iff the partition range or slice is empty specifically due to a =NULL restriction.
+    bool range_or_slice_eq_null(const query_options& options) const;
 };
 
 }

--- a/cql3/statements/modification_statement.cc
+++ b/cql3/statements/modification_statement.cc
@@ -138,16 +138,13 @@ future<> modification_statement::check_access(service::storage_proxy& proxy, con
 
 future<std::vector<mutation>>
 modification_statement::get_mutations(service::storage_proxy& proxy, const query_options& options, db::timeout_clock::time_point timeout, bool local, int64_t now, service::query_state& qs) const {
+    if (_restrictions->range_or_slice_eq_null(options)) { // See #7852 and #9290.
+        throw exceptions::invalid_request_exception("Invalid null value in condition for a key column");
+    }
     auto cl = options.get_consistency();
     auto json_cache = maybe_prepare_json_cache(options);
     auto keys = build_partition_keys(options, json_cache);
-    if (keys.empty()) {
-        throw exceptions::invalid_request_exception("Invalid partition key in a modification statement");
-    }
     auto ranges = create_clustering_ranges(options, json_cache);
-    if (ranges.empty() && !type.is_delete() /* DELETE is allowed on empty ranges (TODO: but not on WHERE ck=NULL).*/) {
-        throw exceptions::invalid_request_exception("Invalid clustering key in a modification statement");
-    }
     auto f = make_ready_future<update_parameters::prefetch_data>(s);
 
     if (is_counter()) {

--- a/test/cql-pytest/test_null.py
+++ b/test/cql-pytest/test_null.py
@@ -50,17 +50,17 @@ def test_insert_missing_key(cql, table1):
 # This reproduces issue #7852.
 def test_insert_null_key(cql, table1):
     s = random_string()
-    with pytest.raises(InvalidRequest, match=re.compile('Invalid (null|clustering)')):
+    with pytest.raises(InvalidRequest, match='null value'):
         cql.execute(f"INSERT INTO {table1} (p,c) VALUES ('{s}', null)")
-    with pytest.raises(InvalidRequest, match=re.compile('Invalid (null|partition)')):
+    with pytest.raises(InvalidRequest, match='null value'):
         cql.execute(f"INSERT INTO {table1} (p,c) VALUES (null, '{s}')")
     # Try the same thing with prepared statement, where a "None" stands for
     # a null. Note that this is completely different from UNSET_VALUE - only
     # with the latter should the insertion be ignored.
     stmt = cql.prepare(f"INSERT INTO {table1} (p,c) VALUES (?, ?)")
-    with pytest.raises(InvalidRequest, match=re.compile('Invalid (null|clustering)')):
+    with pytest.raises(InvalidRequest, match='null value'):
         cql.execute(stmt, [s, None])
-    with pytest.raises(InvalidRequest, match=re.compile('Invalid (null|partition)')):
+    with pytest.raises(InvalidRequest, match='null value'):
         cql.execute(stmt, [None, s])
 
 def test_primary_key_in_null(cql, table1):
@@ -84,15 +84,14 @@ def test_regular_column_in_null(scylla_only, cql, table1):
 def test_delete_impossible_clustering_range(cql, table1):
     cql.execute(f"DELETE FROM {table1} WHERE p='p' and c<'a' and c>'a'")
 
-@pytest.mark.xfail(reason="Unimplemented for clustering key")
 def test_delete_null_key(cql, table1):
-    with pytest.raises(InvalidRequest, match=re.compile('Invalid (null|partition)')):
+    with pytest.raises(InvalidRequest, match='null value'):
         cql.execute(f"DELETE FROM {table1} WHERE p=null")
-    with pytest.raises(InvalidRequest, match=re.compile('Invalid (null|partition)')):
+    with pytest.raises(InvalidRequest, match='null value'):
         cql.execute(cql.prepare(f"DELETE FROM {table1} WHERE p=?"), [None])
-    with pytest.raises(InvalidRequest, match=re.compile('Invalid (null|clustering)')):
+    with pytest.raises(InvalidRequest, match='null value'):
         cql.execute(f"DELETE FROM {table1} WHERE p='p' AND c=null")
-    with pytest.raises(InvalidRequest, match=re.compile('Invalid (null|clustering)')):
+    with pytest.raises(InvalidRequest, match='null value'):
         cql.execute(cql.prepare(f"DELETE FROM {table1} WHERE p='p' AND c=?"), [None])
 
 # Test what SELECT does with the restriction "WHERE v=NULL".

--- a/test/cql-pytest/test_range_and_slice.py
+++ b/test/cql-pytest/test_range_and_slice.py
@@ -1,0 +1,27 @@
+# Copyright 2021-present ScyllaDB
+#
+# This file is part of Scylla.
+#
+# Scylla is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Scylla is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
+
+#############################################################################
+# Tests the calculation of partition range and slice.
+
+import pytest
+from util import new_test_table
+
+def test_delete_where_empty_IN(cql, test_keyspace):
+    """Tests that DELETE FROM t WHERE p IN () is allowed.  See #9311."""
+    with new_test_table(cql, test_keyspace, "p int, PRIMARY KEY (p)") as table:
+        cql.execute(f"DELETE FROM {table} WHERE p IN ()")


### PR DESCRIPTION
The empty-range check causes more bugs than it fixes.  Replace it with
an explicit check for =NULL (see #7852).

Fixes #9311.
Fixes #9290.

Tests: unit (dev), cql-pytest on Cassandra 4.0

Signed-off-by: Dejan Mircevski <dejan@scylladb.com>