### PR TITLE
schema_tables: don't flush in tests

### DIFF
--- a/db/config.cc
+++ b/db/config.cc
@@ -836,6 +836,8 @@ db::config::config(std::shared_ptr<db::extensions> exts)
         "Related information: About replication strategy.")
     , sanitizer_report_backtrace(this, "sanitizer_report_backtrace", value_status::Used, false,
             "In debug mode, report log-structured allocator sanitizer violations with a backtrace. Slow.")
+    , flush_schema_tables_after_modification(this, "flush_schema_tables_after_modification", liveness::LiveUpdate, value_status::Used, true,
+        "Flush tables in the system_schema keyspace after schema modification. This is required for crash recovery, but slows down tests and can be disabled for them")
     , restrict_replication_simplestrategy(this, "restrict_replication_simplestrategy", liveness::LiveUpdate, value_status::Used, db::tri_mode_restriction_t::mode::FALSE, "Controls whether to disable SimpleStrategy replication. Can be true, false, or warn.")
     , restrict_dtcs(this, "restrict_dtcs", liveness::LiveUpdate, value_status::Used, db::tri_mode_restriction_t::mode::FALSE, "Controls whether to prevent setting DateTieredCompactionStrategy. Can be true, false, or warn.")
     , default_log_level(this, "default_log_level", value_status::Used)

--- a/db/config.hh
+++ b/db/config.hh
@@ -365,6 +365,7 @@ public:
     named_value<string_map> redis_keyspace_replication_strategy_options;
 
     named_value<bool> sanitizer_report_backtrace;
+    named_value<bool> flush_schema_tables_after_modification;
 
     // Options to restrict (forbid, warn or somehow limit) certain operations
     // or options which non-expert users are more likely to regret than to

--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -898,7 +898,8 @@ future<> update_schema_version_and_announce(distributed<service::storage_proxy>&
 future<> merge_schema(distributed<service::storage_proxy>& proxy, gms::feature_service& feat, std::vector<mutation> mutations)
 {
     co_await with_merge_lock([&] () mutable -> future<> {
-        co_await do_merge_schema(proxy, std::move(mutations), true);
+        bool flush_schema = proxy.local().get_db().local().get_config().flush_schema_tables_after_modification();
+        co_await do_merge_schema(proxy, std::move(mutations), flush_schema);
         co_await update_schema_version_and_announce(proxy, feat.cluster_schema_features());
     });
 }

--- a/test/cql-pytest/run.py
+++ b/test/cql-pytest/run.py
@@ -188,6 +188,7 @@ def run_scylla_cmd(pid, dir):
         '--max-networking-io-control-blocks', '100',
         '--unsafe-bypass-fsync', '1',
         '--kernel-page-cache', '1',
+        '--flush-schema-tables-after-modification', 'false',
         '--api-address', ip,
         '--rpc-address', ip,
         '--listen-address', ip,

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -107,6 +107,8 @@ cql_test_config::cql_test_config(shared_ptr<db::config> cfg)
     db_config->commitlog_use_o_dsync.set(false);
 
     db_config->add_cdc_extension();
+
+    db_config->flush_schema_tables_after_modification.set(false);
 }
 
 cql_test_config::cql_test_config(const cql_test_config&) = default;

--- a/test/redis/run
+++ b/test/redis/run
@@ -71,6 +71,7 @@ ln -s "$SCYLLA" "$SCYLLA_LINK"
         --smp 2 -m 1G \
         --overprovisioned --unsafe-bypass-fsync 1 --kernel-page-cache 1 \
         --max-networking-io-control-blocks 100 \
+        --flush-schema-tables-after-modification false \
         --api-address $SCYLLA_IP \
         --rpc-address $SCYLLA_IP \
         --listen-address $SCYLLA_IP \


### PR DESCRIPTION
Flushing schema tables is important for crash recovery (without a flush,
we might have sstables using a new schema before the commitlog entry
noting the schema change has been replayed), but not important for tests
that do not test crash recovery. Avoiding those flushes reduces system,
user, and real time on tests running on a consumer-level SSD.

before:
real	8m51.347s
user	7m5.743s
sys	5m11.185s

after:
real	7m4.249s
user	5m14.085s
sys	2m11.197s

Note real time is higher that user+sys time divided by the number
of hardware threads, indicating that there is still idle time due
to the disk flushing, so more work is needed.