### PR TITLE
test: cql-pytest: skip tests depending on timeuuid monotonicity

### DIFF
--- a/test/cql-pytest/cassandra_tests/validation/entities/type_test.py
+++ b/test/cql-pytest/cassandra_tests/validation/entities/type_test.py
@@ -32,6 +32,7 @@ def testNonExistingOnes(cql, test_keyspace):
     # reported instead of just doing nothing:
     execute(cql, test_keyspace, "DROP TYPE IF EXISTS keyspace_does_not_exist.type_does_not_exist")
 
+@pytest.mark.skip(reason="Issue #9300")
 def testNowToUUIDCompatibility(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a int, b uuid, PRIMARY KEY (a, b))") as table:
         execute(cql, table, "INSERT INTO %s (a, b) VALUES (0, now())")
@@ -44,6 +45,7 @@ def testDateCompatibility(cql, test_keyspace):
         execute(cql, table, "INSERT INTO %s (a, b, c, d) VALUES (1, unixTimestampOf(now()), dateOf(now()), dateOf(now()))")
         assert len(list(execute(cql, table, "SELECT * FROM %s WHERE a=1 AND b <= toUnixTimestamp(now())"))) == 1
 
+@pytest.mark.skip(reason="Issue #9300")
 def testReversedTypeCompatibility(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a int, b timeuuid, PRIMARY KEY (a, b)) WITH CLUSTERING ORDER BY (b DESC)") as table:
         execute(cql, table, "INSERT INTO %s (a, b) VALUES (0, now())")


### PR DESCRIPTION
timeuuid is not monotonic when now() is called on different connections,
so when running tests that depend on that property, we get failures if
using the Scylla driver (which became standard in 729d0fe).

Skip the tests for now, until we figure out what to do. We probably
can't make now() globally monotonic, and there isn't much to gain
by making it monotonic only per connection, since clients are allowed
to switch connections (and even nodes) at will.

Ref #9300