### PR TITLE
query::reverse_slice(): toggle reversed bit instead of setting it

### DIFF
--- a/enum_set.hh
+++ b/enum_set.hh
@@ -239,6 +239,15 @@ public:
         _mask |= mask_for(e);
     }
 
+    template<enum_type e>
+    void toggle() {
+        _mask ^= mask_for<e>();
+    }
+
+    void toggle(enum_type e) {
+        _mask ^= mask_for(e);
+    }
+
     void add(const enum_set& other) {
         _mask |= other._mask;
     }

--- a/partition_slice_builder.hh
+++ b/partition_slice_builder.hh
@@ -65,6 +65,11 @@ public:
         _options.set<OPTION>();
         return *this;
     }
+    template <query::partition_slice::option OPTION>
+    partition_slice_builder& with_option_toggled() {
+        _options.toggle<OPTION>();
+        return *this;
+    }
 
     query::partition_slice build();
 };

--- a/query.cc
+++ b/query.cc
@@ -146,7 +146,7 @@ partition_slice reverse_slice(const schema& schema, partition_slice slice) {
             std::reverse(ranges.begin(), ranges.end());
             reverse_clustering_ranges_bounds(ranges);
         })
-        .with_option<partition_slice::option::reversed>()
+        .with_option_toggled<partition_slice::option::reversed>()
         .build();
 }
 

--- a/test/boost/enum_set_test.cc
+++ b/test/boost/enum_set_test.cc
@@ -150,3 +150,60 @@ BOOST_AUTO_TEST_CASE(set_add) {
     fs0.add(fruit_set::of<fruit::apple>());
     BOOST_REQUIRE(!fs0.contains(fruit::pear) && fs0.contains(fruit::apple) && !fs0.contains(fruit::banana));
 }
+
+BOOST_AUTO_TEST_CASE(set_toggle) {
+    auto fs = fruit_set();
+    fs.set<fruit::pear>();
+
+    BOOST_REQUIRE(!fs.contains<fruit::apple>());
+    BOOST_REQUIRE(fs.contains<fruit::pear>());
+    BOOST_REQUIRE(!fs.contains<fruit::banana>());
+
+    fs.toggle<fruit::pear>();
+
+    BOOST_REQUIRE(!fs.contains<fruit::apple>());
+    BOOST_REQUIRE(!fs.contains<fruit::pear>());
+    BOOST_REQUIRE(!fs.contains<fruit::banana>());
+
+    fs.toggle<fruit::pear>();
+
+    BOOST_REQUIRE(!fs.contains<fruit::apple>());
+    BOOST_REQUIRE(fs.contains<fruit::pear>());
+    BOOST_REQUIRE(!fs.contains<fruit::banana>());
+
+    fs.toggle(fruit::pear);
+
+    BOOST_REQUIRE(!fs.contains<fruit::apple>());
+    BOOST_REQUIRE(!fs.contains<fruit::pear>());
+    BOOST_REQUIRE(!fs.contains<fruit::banana>());
+
+    fs.toggle(fruit::pear);
+
+    BOOST_REQUIRE(!fs.contains<fruit::apple>());
+    BOOST_REQUIRE(fs.contains<fruit::pear>());
+    BOOST_REQUIRE(!fs.contains<fruit::banana>());
+
+    fs.toggle<fruit::banana>();
+
+    BOOST_REQUIRE(!fs.contains<fruit::apple>());
+    BOOST_REQUIRE(fs.contains<fruit::pear>());
+    BOOST_REQUIRE(fs.contains<fruit::banana>());
+
+    fs.toggle<fruit::apple>();
+
+    BOOST_REQUIRE(fs.contains<fruit::apple>());
+    BOOST_REQUIRE(fs.contains<fruit::pear>());
+    BOOST_REQUIRE(fs.contains<fruit::banana>());
+
+    fs.toggle(fruit::banana);
+
+    BOOST_REQUIRE(fs.contains<fruit::apple>());
+    BOOST_REQUIRE(fs.contains<fruit::pear>());
+    BOOST_REQUIRE(!fs.contains<fruit::banana>());
+
+    fs.toggle(fruit::apple);
+
+    BOOST_REQUIRE(!fs.contains<fruit::apple>());
+    BOOST_REQUIRE(fs.contains<fruit::pear>());
+    BOOST_REQUIRE(!fs.contains<fruit::banana>());
+}


### PR DESCRIPTION
The above mentioned method is supposed to work both ways: reversed <-> forward, so setting the reversed bit is not correct: it should be toggled, which is what this mini-series does.