### PR TITLE
 utils/small_vector: remove noexcept from the copy constructor, which  potentially throws

### DIFF
--- a/utils/small_vector.hh
+++ b/utils/small_vector.hh
@@ -192,7 +192,7 @@ public:
         }
     }
 
-    small_vector(const small_vector& other) noexcept : small_vector() {
+    small_vector(const small_vector& other) : small_vector() {
         reserve(other.size());
         _end = std::uninitialized_copy(other.begin(), other.end(), _end);
     }


### PR DESCRIPTION
The copy constructor of small vector has a noexcept specifier, however
it calls `reserve(size_t)`, which can throw `std::bad_alloc`. This
causes issues when using it inside tests that use
alloc_failure_injector, but potentially could also float up in the
production.

Fixes #9337.