### PR TITLE
alternator: add stub implementation of TTL's API operations

### DIFF
--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -200,7 +200,7 @@ schema_ptr executor::find_table(service::storage_proxy& proxy, const rjson::valu
     }
 }
 
-static schema_ptr get_table(service::storage_proxy& proxy, const rjson::value& request) {
+schema_ptr get_table(service::storage_proxy& proxy, const rjson::value& request) {
     auto schema = executor::find_table(proxy, request);
     if (!schema) {
         // if we get here then the name was missing, since syntax or missing actual CF 
@@ -704,7 +704,7 @@ static void update_tags_map(const rjson::value& tags, std::map<sstring, sstring>
 // FIXME: Updating tags currently relies on updating schema, which may be subject
 // to races during concurrent updates of the same table. Once Scylla schema updates
 // are fixed, this issue will automatically get fixed as well.
-static future<> update_tags(service::migration_manager& mm, schema_ptr schema, std::map<sstring, sstring>&& tags_map) {
+future<> update_tags(service::migration_manager& mm, schema_ptr schema, std::map<sstring, sstring>&& tags_map) {
     schema_builder builder(schema);
     builder.add_extension(tags_extension::NAME, ::make_shared<tags_extension>(std::move(tags_map)));
     return mm.announce_column_family_update(builder.build(), false, std::vector<view_ptr>(), std::nullopt);

--- a/alternator/executor.hh
+++ b/alternator/executor.hh
@@ -84,6 +84,10 @@ namespace parsed {
 class path;
 };
 
+const std::map<sstring, sstring>& get_tags_of_table(schema_ptr schema);
+future<> update_tags(service::migration_manager& mm, schema_ptr schema, std::map<sstring, sstring>&& tags_map);
+schema_ptr get_table(service::storage_proxy& proxy, const rjson::value& request);
+
 // An attribute_path_map object is used to hold data for various attributes
 // paths (parsed::path) in a hierarchy of attribute paths. Each attribute path
 // has a root attribute, and then modified by member and index operators -

--- a/alternator/executor.hh
+++ b/alternator/executor.hh
@@ -187,6 +187,8 @@ public:
     future<request_return_type> tag_resource(client_state& client_state, service_permit permit, rjson::value request);
     future<request_return_type> untag_resource(client_state& client_state, service_permit permit, rjson::value request);
     future<request_return_type> list_tags_of_resource(client_state& client_state, service_permit permit, rjson::value request);
+    future<request_return_type> update_time_to_live(client_state& client_state, service_permit permit, rjson::value request);
+    future<request_return_type> describe_time_to_live(client_state& client_state, service_permit permit, rjson::value request);
     future<request_return_type> list_streams(client_state& client_state, service_permit permit, rjson::value request);
     future<request_return_type> describe_stream(client_state& client_state, service_permit permit, rjson::value request);
     future<request_return_type> get_shard_iterator(client_state& client_state, service_permit permit, rjson::value request);

--- a/alternator/server.cc
+++ b/alternator/server.cc
@@ -504,6 +504,12 @@ server::server(executor& exec, cql3::query_processor& qp, service::storage_proxy
         {"ListTagsOfResource", [] (executor& e, executor::client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value json_request, std::unique_ptr<request> req) {
             return e.list_tags_of_resource(client_state, std::move(permit), std::move(json_request));
         }},
+        {"UpdateTimeToLive", [] (executor& e, executor::client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value json_request, std::unique_ptr<request> req) {
+            return e.update_time_to_live(client_state, std::move(permit), std::move(json_request));
+        }},
+        {"DescribeTimeToLive", [] (executor& e, executor::client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value json_request, std::unique_ptr<request> req) {
+            return e.describe_time_to_live(client_state, std::move(permit), std::move(json_request));
+        }},
         {"ListStreams", [] (executor& e, executor::client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value json_request, std::unique_ptr<request> req) {
             return e.list_streams(client_state, std::move(permit), std::move(json_request));
         }},

--- a/alternator/ttl.cc
+++ b/alternator/ttl.cc
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2021-present ScyllaDB
+ */
+
+/*
+ * This file is part of Scylla.
+ *
+ * Scylla is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Scylla is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <seastar/core/sstring.hh>
+#include <seastar/core/coroutine.hh>
+
+#include "executor.hh"
+#include "service/storage_proxy.hh"
+#include "gms/feature_service.hh"
+#include "database.hh"
+#include "utils/rjson.hh"
+
+namespace alternator {
+
+// We write the expiration-time attribute enabled on a table using a
+// tag TTL_TAG_KEY.
+// Currently, the *value* of this tag is simply the name of the attribute,
+// and the expiration scanner interprets it as an Alternator attribute name -
+// It can refer to a real column or if that doesn't exist, to a member of
+// the ":attrs" map column. Although this is designed for Alternator, it may
+// be good enough for CQL as well (there, the ":attrs" column won't exist).
+static const sstring TTL_TAG_KEY("system:ttl_attribute");
+
+future<executor::request_return_type> executor::update_time_to_live(client_state& client_state, service_permit permit, rjson::value request) {
+    _stats.api_operations.update_time_to_live++;
+    if (!_proxy.get_db().local().features().cluster_supports_alternator_ttl()) {
+        co_return api_error::unknown_operation("UpdateTimeToLive not yet supported. Experimental support is available if the 'alternator_ttl' experimental feature is enabled on all nodes.");
+    }
+
+    schema_ptr schema = get_table(_proxy, request);
+    rjson::value* spec = rjson::find(request, "TimeToLiveSpecification");
+    if (!spec || !spec->IsObject()) {
+        co_return api_error::validation("UpdateTimeToLive missing mandatory TimeToLiveSpecification");
+    }
+    const rjson::value* v = rjson::find(*spec, "Enabled");
+    if (!v || !v->IsBool()) {
+        co_return api_error::validation("UpdateTimeToLive requires boolean Enabled");
+    }
+    bool enabled = v->GetBool();
+    v = rjson::find(*spec, "AttributeName");
+    if (!v || !v->IsString()) {
+        co_return api_error::validation("UpdateTimeToLive requires string AttributeName");
+    }
+    // Although the DynamoDB documentation specifies that attribute names
+    // should be between 1 and 64K bytes, in practice, it only allows
+    // between 1 and 255 bytes. There are no other limitations on which
+    // characters are allowed in the name.
+    if (v->GetStringLength() < 1 || v->GetStringLength() > 255) {
+        co_return api_error::validation("The length of AttributeName must be between 1 and 255");
+    }
+    sstring attribute_name(v->GetString(), v->GetStringLength());
+
+    std::map<sstring, sstring> tags_map = get_tags_of_table(schema);
+    if (enabled) {
+        if (tags_map.contains(TTL_TAG_KEY)) {
+            co_return api_error::validation("TTL is already enabled");
+        }
+        tags_map[TTL_TAG_KEY] = attribute_name;
+    } else {
+        auto i = tags_map.find(TTL_TAG_KEY);
+        if (i == tags_map.end()) {
+            co_return api_error::validation("TTL is already disabled");
+        } else if (i->second != attribute_name) {
+            co_return api_error::validation(format(
+                "Requested to disable TTL on attribute {}, but a different attribute {} is enabled.",
+                attribute_name, i->second));
+        }
+        tags_map.erase(TTL_TAG_KEY);
+    }
+    co_await update_tags(_mm, schema, std::move(tags_map));
+    // Prepare the response, which contains a TimeToLiveSpecification
+    // basically identical to the request's
+    rjson::value response = rjson::empty_object();
+    rjson::set(response, "TimeToLiveSpecification", std::move(*spec));
+    co_return make_jsonable(std::move(response));
+}
+
+future<executor::request_return_type> executor::describe_time_to_live(client_state& client_state, service_permit permit, rjson::value request) {
+    _stats.api_operations.update_time_to_live++;
+    if (!_proxy.get_db().local().features().cluster_supports_alternator_ttl()) {
+        co_return api_error::unknown_operation("DescribeTimeToLive not yet supported. Experimental support is available if the 'alternator_ttl' experimental feature is enabled on all nodes.");
+    }
+    schema_ptr schema = get_table(_proxy, request);
+    std::map<sstring, sstring> tags_map = get_tags_of_table(schema);
+    rjson::value desc = rjson::empty_object();
+    auto i = tags_map.find(TTL_TAG_KEY);
+    if (i == tags_map.end()) {
+        rjson::set(desc, "TimeToLiveStatus", "DISABLED");
+    } else {
+        rjson::set(desc, "TimeToLiveStatus", "ENABLED");
+        rjson::set(desc, "AttributeName", rjson::from_string(i->second));
+    }
+    rjson::value response = rjson::empty_object();
+    rjson::set(response, "TimeToLiveDescription", std::move(desc));
+    co_return make_jsonable(std::move(response));
+}
+
+} // namespace alternator

--- a/configure.py
+++ b/configure.py
@@ -1068,6 +1068,7 @@ alternator = [
        'alternator/conditions.cc',
        'alternator/auth.cc',
        'alternator/streams.cc',
+       'alternator/ttl.cc',
 ]
 
 redis = [

--- a/db/config.hh
+++ b/db/config.hh
@@ -90,7 +90,7 @@ namespace db {
 struct experimental_features_t {
     // NOTE: RAFT feature is not enabled via `experimental` umbrella flag.
     // This option should be enabled explicitly.
-    enum feature { UNUSED, UDF, UNUSED_CDC, ALTERNATOR_STREAMS, RAFT };
+    enum feature { UNUSED, UDF, UNUSED_CDC, ALTERNATOR_STREAMS, ALTERNATOR_TTL, RAFT };
     static std::unordered_map<sstring, feature> map(); // See enum_option.
     static std::vector<enum_option<experimental_features_t>> all();
 };

--- a/gms/feature.hh
+++ b/gms/feature.hh
@@ -144,6 +144,7 @@ extern const std::string_view PER_TABLE_CACHING;
 extern const std::string_view DIGEST_FOR_NULL_VALUES;
 extern const std::string_view CORRECT_IDX_TOKEN_IN_SECONDARY_INDEX;
 extern const std::string_view ALTERNATOR_STREAMS;
+extern const std::string_view ALTERNATOR_TTL;
 extern const std::string_view RANGE_SCAN_DATA_VARIANT;
 extern const std::string_view CDC_GENERATIONS_V2;
 extern const std::string_view UDA;

--- a/gms/feature_service.cc
+++ b/gms/feature_service.cc
@@ -64,6 +64,7 @@ constexpr std::string_view features::PER_TABLE_CACHING = "PER_TABLE_CACHING";
 constexpr std::string_view features::DIGEST_FOR_NULL_VALUES = "DIGEST_FOR_NULL_VALUES";
 constexpr std::string_view features::CORRECT_IDX_TOKEN_IN_SECONDARY_INDEX = "CORRECT_IDX_TOKEN_IN_SECONDARY_INDEX";
 constexpr std::string_view features::ALTERNATOR_STREAMS = "ALTERNATOR_STREAMS";
+constexpr std::string_view features::ALTERNATOR_TTL = "ALTERNATOR_TTL";
 constexpr std::string_view features::RANGE_SCAN_DATA_VARIANT = "RANGE_SCAN_DATA_VARIANT";
 constexpr std::string_view features::CDC_GENERATIONS_V2 = "CDC_GENERATIONS_V2";
 constexpr std::string_view features::UDA = "UDA";
@@ -88,6 +89,7 @@ feature_service::feature_service(feature_config cfg) : _config(cfg)
         , _digest_for_null_values_feature(*this, features::DIGEST_FOR_NULL_VALUES)
         , _correct_idx_token_in_secondary_index_feature(*this, features::CORRECT_IDX_TOKEN_IN_SECONDARY_INDEX)
         , _alternator_streams_feature(*this, features::ALTERNATOR_STREAMS)
+        , _alternator_ttl_feature(*this, features::ALTERNATOR_TTL)
         , _range_scan_data_variant(*this, features::RANGE_SCAN_DATA_VARIANT)
         , _cdc_generations_v2(*this, features::CDC_GENERATIONS_V2)
         , _uda(*this, features::UDA)
@@ -113,6 +115,9 @@ feature_config feature_config_from_db_config(db::config& cfg, std::set<sstring> 
 
     if (!cfg.check_experimental(db::experimental_features_t::ALTERNATOR_STREAMS)) {
         fcfg._disabled_features.insert(sstring(gms::features::ALTERNATOR_STREAMS));
+    }
+    if (!cfg.check_experimental(db::experimental_features_t::ALTERNATOR_TTL)) {
+        fcfg._disabled_features.insert(sstring(gms::features::ALTERNATOR_TTL));
     }
 
     return fcfg;
@@ -184,6 +189,7 @@ std::set<std::string_view> feature_service::known_feature_set() {
         gms::features::DIGEST_FOR_NULL_VALUES,
         gms::features::CORRECT_IDX_TOKEN_IN_SECONDARY_INDEX,
         gms::features::ALTERNATOR_STREAMS,
+        gms::features::ALTERNATOR_TTL,
         gms::features::RANGE_SCAN_DATA_VARIANT,
         gms::features::CDC_GENERATIONS_V2,
         gms::features::UDA,
@@ -263,6 +269,7 @@ void feature_service::enable(const std::set<std::string_view>& list) {
         std::ref(_digest_for_null_values_feature),
         std::ref(_correct_idx_token_in_secondary_index_feature),
         std::ref(_alternator_streams_feature),
+        std::ref(_alternator_ttl_feature),
         std::ref(_range_scan_data_variant),
         std::ref(_cdc_generations_v2),
         std::ref(_uda),

--- a/gms/feature_service.hh
+++ b/gms/feature_service.hh
@@ -89,6 +89,7 @@ private:
     gms::feature _digest_for_null_values_feature;
     gms::feature _correct_idx_token_in_secondary_index_feature;
     gms::feature _alternator_streams_feature;
+    gms::feature _alternator_ttl_feature;
     gms::feature _range_scan_data_variant;
     gms::feature _cdc_generations_v2;
     gms::feature _uda;
@@ -147,6 +148,10 @@ public:
 
     bool cluster_supports_alternator_streams() const {
         return bool(_alternator_streams_feature);
+    }
+
+    bool cluster_supports_alternator_ttl() const {
+        return bool(_alternator_ttl_feature);
     }
 
     // Range scans have a data variant, which produces query::result directly,

--- a/test/alternator/test_streams.py
+++ b/test/alternator/test_streams.py
@@ -23,7 +23,7 @@ import time
 import urllib.request
 
 from botocore.exceptions import ClientError
-from util import list_tables, test_table_name, create_test_table, random_string, freeze
+from util import list_tables, unique_table_name, create_test_table, random_string, freeze
 from contextlib import contextmanager
 from urllib.error import URLError
 from boto3.dynamodb.types import TypeDeserializer
@@ -1241,7 +1241,7 @@ def test_streams_1_new_and_old_images(test_table_ss_new_and_old_images, dynamodb
 # just do multiple tests on its setup.
 @pytest.fixture(scope="module")
 def test_table_stream_with_result(dynamodb, dynamodbstreams):
-    tablename = test_table_name()
+    tablename = unique_table_name()
     result = dynamodb.meta.client.create_table(TableName=tablename,
         BillingMode='PAY_PER_REQUEST',
         StreamSpecification={'StreamEnabled': True, 'StreamViewType': 'KEYS_ONLY'},

--- a/test/alternator/test_table.py
+++ b/test/alternator/test_table.py
@@ -19,7 +19,7 @@
 
 import pytest
 from botocore.exceptions import ClientError
-from util import list_tables, test_table_name, create_test_table, random_string
+from util import list_tables, unique_table_name, create_test_table, random_string
 
 # Utility function for create a table with a given name and some valid
 # schema.. This function initiates the table's creation, but doesn't
@@ -210,13 +210,13 @@ def test_create_table_already_exists(dynamodb, test_table):
 # DynamoDB did) to PROVISIONED so ProvisionedThroughput is allowed.
 def test_create_table_billing_mode_errors(dynamodb, test_table):
     with pytest.raises(ClientError, match='ValidationException'):
-        create_table(dynamodb, test_table_name(), BillingMode='unknown')
+        create_table(dynamodb, unique_table_name(), BillingMode='unknown')
     # billing mode is case-sensitive
     with pytest.raises(ClientError, match='ValidationException'):
-        create_table(dynamodb, test_table_name(), BillingMode='pay_per_request')
+        create_table(dynamodb, unique_table_name(), BillingMode='pay_per_request')
     # PAY_PER_REQUEST cannot come with a ProvisionedThroughput:
     with pytest.raises(ClientError, match='ValidationException'):
-        create_table(dynamodb, test_table_name(),
+        create_table(dynamodb, unique_table_name(),
             BillingMode='PAY_PER_REQUEST', ProvisionedThroughput={'ReadCapacityUnits': 10, 'WriteCapacityUnits': 10})
     # On the other hand, PROVISIONED requires ProvisionedThroughput:
     # By the way, ProvisionedThroughput not only needs to appear, it must
@@ -224,11 +224,11 @@ def test_create_table_billing_mode_errors(dynamodb, test_table):
     # this with boto3, because boto3 has its own verification that if
     # ProvisionedThroughput is given, it must have the correct form.
     with pytest.raises(ClientError, match='ValidationException'):
-        create_table(dynamodb, test_table_name(), BillingMode='PROVISIONED')
+        create_table(dynamodb, unique_table_name(), BillingMode='PROVISIONED')
     # If BillingMode is completely missing, it defaults to PROVISIONED, so
     # ProvisionedThroughput is required
     with pytest.raises(ClientError, match='ValidationException'):
-        dynamodb.create_table(TableName=test_table_name(),
+        dynamodb.create_table(TableName=unique_table_name(),
             KeySchema=[{ 'AttributeName': 'p', 'KeyType': 'HASH' }],
             AttributeDefinitions=[{ 'AttributeName': 'p', 'AttributeType': 'S' }])
 

--- a/test/alternator/test_tag.py
+++ b/test/alternator/test_tag.py
@@ -25,7 +25,7 @@ import pytest
 from botocore.exceptions import ClientError
 import re
 import time
-from util import multiset, create_test_table, test_table_name
+from util import multiset, create_test_table, unique_table_name
 
 def delete_tags(table, arn):
     got = table.meta.client.list_tags_of_resource(ResourceArn=arn)
@@ -167,7 +167,7 @@ def test_too_long_tags_from_creation(dynamodb):
     from distutils.version import LooseVersion
     if (LooseVersion(botocore.__version__) < LooseVersion('1.12.136')):
         pytest.skip("Botocore version 1.12.136 or above required to run this test")
-    name = test_table_name()
+    name = unique_table_name()
     # Setting 100 tags is not allowed, the following table creation should fail:
     with pytest.raises(ClientError, match='ValidationException'):
         dynamodb.create_table(TableName=name,
@@ -193,7 +193,7 @@ def test_forbidden_tags_from_creation(scylla_only, dynamodb):
     from distutils.version import LooseVersion
     if (LooseVersion(botocore.__version__) < LooseVersion('1.12.136')):
         pytest.skip("Botocore version 1.12.136 or above required to run this test")
-    name = test_table_name()
+    name = unique_table_name()
     # It is not allowed to set the system:write_isolation to "dog", so the
     # following table creation should fail:
     with pytest.raises(ClientError, match='ValidationException'):

--- a/test/alternator/test_ttl.py
+++ b/test/alternator/test_ttl.py
@@ -19,12 +19,36 @@
 
 import pytest
 import time
+import re
 from botocore.exceptions import ClientError
-from util import new_test_table, random_string, full_query
+from util import new_test_table, random_string, full_query, test_table_name
+from contextlib import contextmanager
+
+# passes_or_raises() is similar to pytest.raises(), except that while raises()
+# expects a certain exception must happen, the new passes_or_raises()
+# expects the code to either pass (not raise), or if it throws, it must
+# throw the specific specified exception.
+@contextmanager
+def passes_or_raises(expected_exception, match=None):
+    # Sadly __tracebackhide__=True only drops some of the unhelpful backtrace
+    # lines. See https://github.com/pytest-dev/pytest/issues/2057
+    __tracebackhide__ = True
+    try:
+        yield
+        # The user's "with" code is running during the yield. If it didn't
+        # throw we return from the function - the raises_or_not() passed as
+        # the "or not" case.
+        return
+    except expected_exception as err:
+        if match == None or re.search(match, str(err)):
+            # The raises_or_not() passed on as the "raises" case
+            return
+        pytest.fail(f"exception message '{err}' did not match '{match}'")
+    except Exception as err:
+        pytest.fail(f"Got unexpected exception type {type(err).__name__} instead of {expected_exception.__name__}: {err}")
 
 # Test the DescribeTimeToLive operation on a table where the time-to-live
 # feature was *not* enabled.
-@pytest.mark.xfail(reason="TTL not implemented yet #5060")
 def test_describe_ttl_without_ttl(test_table):
     response = test_table.meta.client.describe_time_to_live(TableName=test_table.name)
     assert 'TimeToLiveDescription' in response
@@ -34,7 +58,6 @@ def test_describe_ttl_without_ttl(test_table):
 
 # Test that UpdateTimeToLive can be used to pick an expiration-time attribute
 # and this information becomes available via DescribeTimeToLive
-@pytest.mark.xfail(reason="TTL not implemented yet #5060")
 def test_ttl_enable(dynamodb):
     with new_test_table(dynamodb,
         KeySchema=[ { 'AttributeName': 'p', 'KeyType': 'HASH' }, ],
@@ -70,7 +93,6 @@ def test_ttl_enable(dynamodb):
 # disable TTL if it was enabled in the last hour (according to DynamoDB's
 # documentation). We have below a much longer test for the successful TTL
 # disable case.
-@pytest.mark.xfail(reason="TTL not implemented yet #5060")
 def test_ttl_disable_errors(dynamodb):
     with new_test_table(dynamodb,
         KeySchema=[ { 'AttributeName': 'p', 'KeyType': 'HASH' }, ],
@@ -92,10 +114,10 @@ def test_ttl_disable_errors(dynamodb):
         with pytest.raises(ClientError, match='ValidationException.*different'):
             client.update_time_to_live(TableName=table.name,
                 TimeToLiveSpecification={'AttributeName': 'dog', 'Enabled': False})
-        # Finally disable TTL the right way :-) But on DynamoDB this fails
+        # Finally disable TTL the right way :-) On DynamoDB this fails
         # because you are not allowed to modify the TTL setting twice in
-        # one hour!
-        with pytest.raises(ClientError, match='ValidationException.*multiple times'):
+        # one hour, but in our implementation it can also pass quickly.
+        with passes_or_raises(ClientError, match='ValidationException.*multiple times'):
             client.update_time_to_live(TableName=table.name,
                 TimeToLiveSpecification={'AttributeName': 'expiration', 'Enabled': False})
 
@@ -104,7 +126,6 @@ def test_ttl_disable_errors(dynamodb):
 # (the documentation suggests a full hour, but in practice it seems 30
 # minutes).
 @pytest.mark.veryslow
-@pytest.mark.xfail(reason="TTL not implemented yet #5060")
 def test_ttl_disable(dynamodb):
     with new_test_table(dynamodb,
         KeySchema=[ { 'AttributeName': 'p', 'KeyType': 'HASH' }, ],
@@ -130,6 +151,30 @@ def test_ttl_disable(dynamodb):
                 continue
         assert client.describe_time_to_live(TableName=table.name)['TimeToLiveDescription'] == {
             'TimeToLiveStatus': 'DISABLED'}
+
+# Test various errors in the UpdateTimeToLive request.
+# Unfortunately, the boto3 library catches most incorrect inputs on the
+# client side, so we can't check the following errors here :-(
+# 1. Missing UpdateTimeToLive parameters AttributeName or Enabled
+# 2. Wrong types for them (e.g., string for Enabled)
+# 3. Empty string for AttributeName
+# There are only a few things that boto3 doesn't guard, so we can check them:
+def test_update_ttl_errors(dynamodb):
+    client = dynamodb.meta.client
+    # Can't set TTL on a non-existent table
+    nonexistent_table = test_table_name()
+    with pytest.raises(ClientError, match='ResourceNotFoundException'):
+        client.update_time_to_live(TableName=nonexistent_table,
+            TimeToLiveSpecification={'AttributeName': 'expiration', 'Enabled': True})
+    with new_test_table(dynamodb,
+            KeySchema=[ { 'AttributeName': 'p', 'KeyType': 'HASH' }, ],
+            AttributeDefinitions=[ { 'AttributeName': 'p', 'AttributeType': 'S' } ]) as table:
+        # AttributeName must be between 1 and 255 characters long. We
+        # can't check 0 (boto3 guards against this in the client), but
+        # can check >255.
+        with pytest.raises(ClientError, match='ValidationException.*length'):
+            client.update_time_to_live(TableName=table.name,
+                TimeToLiveSpecification={'AttributeName': 'x'*256, 'Enabled': True})
 
 # Basic test that expiration indeed expires items that should be expired,
 # and doesn't expire items which shouldn't be expired.

--- a/test/alternator/test_ttl.py
+++ b/test/alternator/test_ttl.py
@@ -21,7 +21,7 @@ import pytest
 import time
 import re
 from botocore.exceptions import ClientError
-from util import new_test_table, random_string, full_query, test_table_name
+from util import new_test_table, random_string, full_query, unique_table_name
 from contextlib import contextmanager
 
 # passes_or_raises() is similar to pytest.raises(), except that while raises()
@@ -162,7 +162,7 @@ def test_ttl_disable(dynamodb):
 def test_update_ttl_errors(dynamodb):
     client = dynamodb.meta.client
     # Can't set TTL on a non-existent table
-    nonexistent_table = test_table_name()
+    nonexistent_table = unique_table_name()
     with pytest.raises(ClientError, match='ResourceNotFoundException'):
         client.update_time_to_live(TableName=nonexistent_table,
             TimeToLiveSpecification={'AttributeName': 'expiration', 'Enabled': True})

--- a/test/alternator/util.py
+++ b/test/alternator/util.py
@@ -124,17 +124,17 @@ def multiset(items):
 # NOTE: alternator_Test prefix contains a capital letter on purpose,
 #in order to validate case sensitivity in alternator
 test_table_prefix = 'alternator_Test_'
-def test_table_name():
+def unique_table_name():
     current_ms = int(round(time.time() * 1000))
-    # In the off chance that test_table_name() is called twice in the same millisecond...
-    if test_table_name.last_ms >= current_ms:
-        current_ms = test_table_name.last_ms + 1
-    test_table_name.last_ms = current_ms
+    # If unique_table_name() is called twice in the same millisecond...
+    if unique_table_name.last_ms >= current_ms:
+        current_ms = unique_table_name.last_ms + 1
+    unique_table_name.last_ms = current_ms
     return test_table_prefix + str(current_ms)
-test_table_name.last_ms = 0
+unique_table_name.last_ms = 0
 
 def create_test_table(dynamodb, **kwargs):
-    name = test_table_name()
+    name = unique_table_name()
     print("fixture creating new table {}".format(name))
     table = dynamodb.create_table(TableName=name,
         BillingMode='PAY_PER_REQUEST', **kwargs)


### PR DESCRIPTION
This small series adds a stub implementation of Alternator's UpdateTimeToLive and DescribeTimeToLive operations. These operations can enable, disable, or inquire about, the chosen expiration-time attribute.    Currently, the information about the chosen attribute is only saved, with no actual expiration of any items taking place.

Because this is an incomplete implementation of this feature, it is not enabled unless an experimental flag is enabled on all nodes in the cluster. 

See the individual patches for more information on what this series does.

Refs #5060.