### PR TITLE
hints: fix bugs in HTTP API for waiting for hints found by running dtest in debug mode

### DIFF
--- a/db/commitlog/commitlog.cc
+++ b/db/commitlog/commitlog.cc
@@ -1198,6 +1198,10 @@ db::commitlog::segment_manager::segment_manager(config c)
         }
         cfg.max_active_flushes = std::max(uint64_t(1), cfg.max_active_flushes / smp::count);
 
+        if (!cfg.base_segment_id) {
+            cfg.base_segment_id = std::chrono::duration_cast<std::chrono::milliseconds>(runtime::get_boot_time().time_since_epoch()).count() + 1;
+        }
+
         return cfg;
     }())
     , max_size(std::min<size_t>(std::numeric_limits<position_type>::max() / (1024 * 1024), std::max<size_t>(cfg.commitlog_segment_size_in_mb, 1)) * 1024 * 1024)
@@ -1299,7 +1303,7 @@ future<> db::commitlog::segment_manager::init() {
     auto descs = co_await list_descriptors(cfg.commit_log_location);
 
     assert(_reserve_segments.empty()); // _segments_to_replay must not pick them up
-    segment_id_type id = std::chrono::duration_cast<std::chrono::milliseconds>(runtime::get_boot_time().time_since_epoch()).count() + 1;
+    segment_id_type id = *cfg.base_segment_id;
     for (auto& d : descs) {
         id = std::max(id, replay_position(d.id).base_id());
         _segments_to_replay.push_back(cfg.commit_log_location + "/" + d.filename());

--- a/db/commitlog/commitlog.hh
+++ b/db/commitlog/commitlog.hh
@@ -142,6 +142,16 @@ public:
         bool warn_about_segments_left_on_disk_after_shutdown = true;
         bool allow_going_over_size_limit = true;
 
+        // The base segment ID to use.
+        // The segment IDs of newly allocated segments will be issued sequentially
+        // and will start _right after_ this parameter.
+        // If not set, it will be calculated based on the number of milliseconds
+        // since boot time.
+        // If there are segments to replay which have base IDs greater than
+        // this parameter, new segment IDs will start after the largest one
+        // of them.
+        std::optional<segment_id_type> base_segment_id;
+
         const db::extensions * extensions = nullptr;
     };
 

--- a/db/hints/manager.cc
+++ b/db/hints/manager.cc
@@ -417,6 +417,27 @@ future<db::commitlog> manager::end_point_hints_manager::add_store() noexcept {
             // in resource_manager, so its redundant for the commitlog to apply
             // a hard limit.
             cfg.allow_going_over_size_limit = true;
+            // The API for waiting for hint replay relies on replay positions
+            // monotonically increasing. When there are no segments on disk,
+            // by default the commitlog will calculate the first segment ID
+            // based on the boot time. This may cause the following sequence
+            // of events to occur:
+            //
+            // 1. Node starts with empty hints queue
+            // 2. Some hints are written and some segments are created
+            // 3. All hints are replayed
+            // 4. Hint sync point is created
+            // 5. Commitlog instance gets re-created and resets it segment ID counter
+            // 6. New hint segment has the first ID as the first (deleted by now) segment
+            // 7. Waiting for the sync point commences but resolves immediately
+            //    before new hints are replayed - since point 5., `_last_written_rp`
+            //    and `_sent_upper_bound_rp` are not updated because RPs of new
+            //    hints are much lower than both of those marks.
+            //
+            // In order to prevent this situation, we override the base segment ID
+            // of the newly created commitlog instance - it should start with an ID
+            // which is larger than the segment ID of the RP of the last written hint.
+            cfg.base_segment_id = _last_written_rp.base_id();
 
             return commitlog::create_commitlog(std::move(cfg)).then([this] (commitlog l) {
                 // add_store() is triggered every time hint files are forcefully flushed to I/O (every hints_flush_period).

--- a/db/hints/manager.cc
+++ b/db/hints/manager.cc
@@ -959,8 +959,11 @@ future<> manager::end_point_hints_manager::sender::wait_until_hints_are_replayed
         (**ptr).set_exception(abort_requested_exception());
     });
 
-    return (**ptr).get_future().finally([this, sub = std::move(sub)] {
-        manager_logger.debug("[{}] wait_until_hints_are_replayed_up_to(): returning afther the future was satisfied", end_point_key());
+    // When the future resolves, the endpoint manager is not guaranteed to exist anymore
+    // therefore we cannot capture `this`
+    auto ep = end_point_key();
+    return (**ptr).get_future().finally([sub = std::move(sub), ep] {
+        manager_logger.debug("[{}] wait_until_hints_are_replayed_up_to(): returning afther the future was satisfied", ep);
     });
 }
 

--- a/db/hints/manager.cc
+++ b/db/hints/manager.cc
@@ -190,6 +190,10 @@ future<> manager::wait_for_sync_point(abort_source& as, const sync_point::shard_
         }
     });
 
+    if (as.abort_requested()) {
+        local_as.request_abort();
+    }
+
     bool was_aborted = false;
     co_await parallel_for_each(_ep_managers, [this, &was_aborted, &rps, &local_as] (auto& p) {
         const auto addr = p.first;

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -5379,9 +5379,6 @@ future<> storage_proxy::wait_for_hint_sync_point(const db::hints::sync_point spo
     co_await container().invoke_on_all([this, original_shard, &sources, &spoint, &was_aborted] (storage_proxy& sp) {
         auto wait_for = [&sources, original_shard, &was_aborted] (db::hints::manager& mgr, const std::vector<db::hints::sync_point::shard_rps>& shard_rps) {
             const unsigned shard = this_shard_id();
-            if (shard_rps.size() < shard) {
-                return make_ready_future<>();
-            }
             return mgr.wait_for_sync_point(sources[shard], shard_rps[shard]).handle_exception([original_shard, &sources, &was_aborted] (auto eptr) {
                 // Make sure other blocking operations are cancelled soon
                 // by requesting an abort on all shards


### PR DESCRIPTION
This series of commits fixes a small number of bugs with current implementation of HTTP API which allows to wait until hints are replayed, found by running the `hintedhandoff_sync_point_api_test` dtest in debug mode.

Refs: #9320