### PR TITLE
build: enable -Winconsistent-missing-override warning

### DIFF
--- a/auth/transitional.cc
+++ b/auth/transitional.cc
@@ -157,7 +157,7 @@ public:
                 return _complete || _sasl->is_complete();
             }
 
-            virtual future<authenticated_user> get_authenticated_user() const {
+            virtual future<authenticated_user> get_authenticated_user() const override {
                 return futurize_invoke([this] {
                     return _sasl->get_authenticated_user().handle_exception([](auto ep) {
                         try {

--- a/cache_flat_mutation_reader.hh
+++ b/cache_flat_mutation_reader.hh
@@ -203,7 +203,7 @@ public:
     virtual future<> fast_forward_to(position_range pr) override {
         return make_exception_future<>(make_backtraced_exception_ptr<std::bad_function_call>());
     }
-    virtual future<> close() noexcept {
+    virtual future<> close() noexcept override {
         auto close_read_context = _read_context_holder ?  _read_context_holder->close() : make_ready_future<>();
         auto close_underlying = _underlying_holder ? _underlying_holder->close() : make_ready_future<>();
         return when_all_succeed(std::move(close_read_context), std::move(close_underlying)).discard_result();

--- a/compaction/compaction.cc
+++ b/compaction/compaction.cc
@@ -258,7 +258,7 @@ public:
         }
     }
 
-    virtual uint64_t written() const {
+    virtual uint64_t written() const override {
         if (_tracker) {
             return _tracker->offset;
         }

--- a/compaction/compaction_strategy.cc
+++ b/compaction/compaction_strategy.cc
@@ -375,7 +375,7 @@ public:
         return 0;
     }
 
-    virtual compaction_strategy_type type() const {
+    virtual compaction_strategy_type type() const override {
         return compaction_strategy_type::null;
     }
 

--- a/compaction/date_tiered_compaction_strategy.hh
+++ b/compaction/date_tiered_compaction_strategy.hh
@@ -299,7 +299,7 @@ public:
         return _manifest.get_estimated_tasks(cf);
     }
 
-    virtual compaction_strategy_type type() const {
+    virtual compaction_strategy_type type() const override {
         return compaction_strategy_type::date_tiered;
     }
 

--- a/compaction/leveled_compaction_strategy.hh
+++ b/compaction/leveled_compaction_strategy.hh
@@ -69,7 +69,7 @@ public:
         return false;
     }
 
-    virtual compaction_strategy_type type() const {
+    virtual compaction_strategy_type type() const override {
         return compaction_strategy_type::leveled;
     }
     virtual std::unique_ptr<sstable_set_impl> make_sstable_set(schema_ptr schema) const override;

--- a/compaction/size_tiered_compaction_strategy.hh
+++ b/compaction/size_tiered_compaction_strategy.hh
@@ -141,7 +141,7 @@ public:
         int min_threshold, int max_threshold, size_tiered_compaction_strategy_options options);
     virtual int64_t estimated_pending_compactions(column_family& cf) const override;
 
-    virtual compaction_strategy_type type() const {
+    virtual compaction_strategy_type type() const override {
         return compaction_strategy_type::size_tiered;
     }
 

--- a/compaction/time_window_compaction_strategy.hh
+++ b/compaction/time_window_compaction_strategy.hh
@@ -179,7 +179,7 @@ public:
         return _estimated_remaining_tasks;
     }
 
-    virtual compaction_strategy_type type() const {
+    virtual compaction_strategy_type type() const override {
         return compaction_strategy_type::time_window;
     }
 

--- a/configure.py
+++ b/configure.py
@@ -1299,7 +1299,6 @@ warnings = [
     '-Wno-overloaded-virtual',
     '-Wno-stringop-overflow',
     '-Wno-unused-command-line-argument',
-    '-Wno-inconsistent-missing-override',
     '-Wno-defaulted-function-deleted',
     '-Wno-redeclared-class-member',
     '-Wno-unsupported-friend',

--- a/cql3/column_identifier.hh
+++ b/cql3/column_identifier.hh
@@ -80,7 +80,7 @@ public:
 
     const bytes& name() const;
 
-    sstring to_string() const;
+    virtual sstring to_string() const override;
 
     sstring to_cql_string() const;
 

--- a/cql3/cql3_type.cc
+++ b/cql3/cql3_type.cc
@@ -98,18 +98,18 @@ public:
         : _type{type}
     { }
 public:
-    virtual cql3_type prepare(database& db, const sstring& keyspace) {
+    virtual cql3_type prepare(database& db, const sstring& keyspace) override {
         return _type;
     }
     cql3_type prepare_internal(const sstring&, const user_types_metadata&) override {
         return _type;
     }
 
-    virtual bool supports_freezing() const {
+    virtual bool supports_freezing() const override {
         return false;
     }
 
-    virtual bool is_counter() const {
+    virtual bool is_counter() const override {
         return _type.is_counter();
     }
 

--- a/cql3/functions/abstract_function.hh
+++ b/cql3/functions/abstract_function.hh
@@ -73,7 +73,7 @@ protected:
 
 public:
 
-    virtual bool requires_thread() const;
+    virtual bool requires_thread() const override;
 
     virtual const function_name& name() const override {
         return _name;
@@ -83,7 +83,7 @@ public:
         return _arg_types;
     }
 
-    virtual const data_type& return_type() const {
+    virtual const data_type& return_type() const override {
         return _return_type;
     }
 

--- a/cql3/functions/as_json_function.hh
+++ b/cql3/functions/as_json_function.hh
@@ -76,7 +76,7 @@ public:
         : _selector_names(std::move(selector_names)), _selector_types(std::move(selector_types)) {
     }
 
-    virtual bool requires_thread() const;
+    virtual bool requires_thread() const override;
 
     virtual bytes_opt execute(cql_serialization_format sf, const std::vector<bytes_opt>& parameters) override {
         bytes_ostream encoded_row;

--- a/cql3/lists.hh
+++ b/cql3/lists.hh
@@ -69,7 +69,7 @@ public:
         virtual cql3::raw_value get(const query_options& options) override;
         virtual managed_bytes get_with_protocol_version(cql_serialization_format sf) override;
         bool equals(const list_type_impl& lt, const value& v);
-        virtual sstring to_string() const;
+        virtual sstring to_string() const override;
         friend class lists;
     };
     /**
@@ -128,7 +128,7 @@ public:
             : operation(column, std::move(t)), _idx(std::move(idx)) {
         }
         virtual bool requires_read() const override;
-        virtual void fill_prepare_context(prepare_context& ctx) const;
+        virtual void fill_prepare_context(prepare_context& ctx) const override;
         virtual void execute(mutation& m, const clustering_key_prefix& prefix, const update_parameters& params) override;
     };
 
@@ -174,7 +174,7 @@ public:
                 : operation(column, std::move(idx)) {
         }
         virtual bool requires_read() const override;
-        virtual void execute(mutation& m, const clustering_key_prefix& prefix, const update_parameters& params);
+        virtual void execute(mutation& m, const clustering_key_prefix& prefix, const update_parameters& params) override;
     };
 };
 

--- a/cql3/maps.hh
+++ b/cql3/maps.hh
@@ -68,9 +68,9 @@ public:
         }
         static value from_serialized(const raw_value_view& value, const map_type_impl& type, cql_serialization_format sf);
         virtual cql3::raw_value get(const query_options& options) override;
-        virtual managed_bytes get_with_protocol_version(cql_serialization_format sf);
+        virtual managed_bytes get_with_protocol_version(cql_serialization_format sf) override;
         bool equals(const map_type_impl& mt, const value& v);
-        virtual sstring to_string() const;
+        virtual sstring to_string() const override;
     };
 
     // See Lists.DelayedValue
@@ -83,7 +83,7 @@ public:
         }
         virtual bool contains_bind_marker() const override;
         virtual void fill_prepare_context(prepare_context& ctx) const override;
-        shared_ptr<terminal> bind(const query_options& options);
+        virtual shared_ptr<terminal> bind(const query_options& options) override;
     };
 
     class marker : public abstract_marker {

--- a/cql3/operation_impl.hh
+++ b/cql3/operation_impl.hh
@@ -86,7 +86,7 @@ public:
         return *_id;
     }
 
-    ::shared_ptr<operation> prepare(database& db, const sstring& keyspace, const column_definition& receiver) const {
+    virtual ::shared_ptr<operation> prepare(database& db, const sstring& keyspace, const column_definition& receiver) const override {
         // No validation, deleting a column is always "well typed"
         return ::make_shared<constants::deleter>(receiver);
     }

--- a/cql3/selection/field_selector.hh
+++ b/cql3/selection/field_selector.hh
@@ -105,7 +105,7 @@ public:
         return _type->field_type(_field);
     }
 
-    virtual void reset() {
+    virtual void reset() override {
         _selected->reset();
     }
 

--- a/cql3/selection/selection.cc
+++ b/cql3/selection/selection.cc
@@ -141,7 +141,7 @@ protected:
             }
         }
 
-        virtual bool is_aggregate() const {
+        virtual bool is_aggregate() const override {
             return false;
         }
     };
@@ -208,7 +208,7 @@ protected:
             return output_row;
         }
 
-        virtual void add_input_row(cql_serialization_format sf, result_set_builder& rs) {
+        virtual void add_input_row(cql_serialization_format sf, result_set_builder& rs) override {
             for (auto&& s : _selectors) {
                 s->add_input(sf, rs);
             }

--- a/cql3/sets.hh
+++ b/cql3/sets.hh
@@ -82,7 +82,7 @@ public:
         }
         virtual bool contains_bind_marker() const override;
         virtual void fill_prepare_context(prepare_context& ctx) const override;
-        virtual shared_ptr<terminal> bind(const query_options& options);
+        virtual shared_ptr<terminal> bind(const query_options& options) override;
     };
 
     class marker : public abstract_marker {

--- a/cql3/single_column_relation.hh
+++ b/cql3/single_column_relation.hh
@@ -146,7 +146,7 @@ protected:
 
 protected:
     virtual ::shared_ptr<restrictions::restriction> new_EQ_restriction(database& db, schema_ptr schema,
-                                           prepare_context& ctx);
+                                           prepare_context& ctx) override;
 
     virtual ::shared_ptr<restrictions::restriction> new_IN_restriction(database& db, schema_ptr schema,
                                            prepare_context& ctx) override;

--- a/cql3/statements/select_statement.hh
+++ b/cql3/statements/select_statement.hh
@@ -127,8 +127,8 @@ public:
     virtual uint32_t get_bound_terms() const override;
     virtual future<> check_access(service::storage_proxy& proxy, const service::client_state& state) const override;
     virtual void validate(service::storage_proxy&, const service::client_state& state) const override;
-    virtual bool depends_on_keyspace(const sstring& ks_name) const;
-    virtual bool depends_on_column_family(const sstring& cf_name) const;
+    virtual bool depends_on_keyspace(const sstring& ks_name) const override;
+    virtual bool depends_on_column_family(const sstring& cf_name) const override;
 
     virtual future<::shared_ptr<cql_transport::messages::result_message>> execute(query_processor& qp,
         service::query_state& state, const query_options& options) const override;

--- a/cql3/term.hh
+++ b/cql3/term.hh
@@ -123,7 +123,7 @@ public:
     terminal(data_type my_type) : _my_type(std::move(my_type)) {
     }
 
-    virtual void fill_prepare_context(prepare_context& ctx) const {
+    virtual void fill_prepare_context(prepare_context& ctx) const override {
     }
 
     virtual ::shared_ptr<terminal> bind(const query_options& options) override {
@@ -141,7 +141,7 @@ public:
      */
     virtual cql3::raw_value get(const query_options& options) = 0;
 
-    virtual sstring to_string() const = 0;
+    virtual sstring to_string() const override = 0;
 
     data_type get_value_type() const {
         return _my_type;

--- a/cql3/user_types.hh
+++ b/cql3/user_types.hh
@@ -75,7 +75,7 @@ public:
     public:
         delayed_value(user_type type, std::vector<shared_ptr<term>> values);
         virtual bool contains_bind_marker() const override;
-        virtual void fill_prepare_context(prepare_context& ctx) const;
+        virtual void fill_prepare_context(prepare_context& ctx) const override;
     private:
         std::vector<managed_bytes_opt> bind_internal(const query_options& options);
     public:

--- a/db/commitlog/commitlog.cc
+++ b/db/commitlog/commitlog.cc
@@ -2061,7 +2061,7 @@ future<db::rp_handle> db::commitlog::add(const cf_id_type& id,
         serializer_func_entry_writer(const cf_id_type& id, size_t sz, serializer_func func, db::commitlog::force_sync sync)
             : entry_writer(sync), _id(id), _func(std::move(func)), _size(sz)
         {}
-        const cf_id_type& id(size_t) const { return _id; }
+        const cf_id_type& id(size_t) const override { return _id; }
         size_t size(segment&, size_t) override { return _size; }
         size_t size(segment&) override { return _size; }
         size_t size() const override { return _size; }

--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -2487,7 +2487,7 @@ static void prepare_builder_from_table_row(const schema_ctxt& ctxt, schema_build
                 bytes serialize() const override {
                     return _bytes;
                 }
-                bool is_placeholder() const {
+                virtual bool is_placeholder() const override {
                     return true;
                 }
             };

--- a/dht/murmur3_partitioner.hh
+++ b/dht/murmur3_partitioner.hh
@@ -30,7 +30,7 @@ namespace dht {
 class murmur3_partitioner final : public i_partitioner {
 public:
     murmur3_partitioner() = default;
-    virtual const sstring name() const { return "org.apache.cassandra.dht.Murmur3Partitioner"; }
+    virtual const sstring name() const override { return "org.apache.cassandra.dht.Murmur3Partitioner"; }
     virtual token get_token(const schema& s, partition_key_view key) const override;
     virtual token get_token(const sstables::key_view& key) const override;
 private:

--- a/hashing_partition_visitor.hh
+++ b/hashing_partition_visitor.hh
@@ -42,25 +42,25 @@ public:
         , _s(s)
     { }
 
-    virtual void accept_partition_tombstone(tombstone t) {
+    virtual void accept_partition_tombstone(tombstone t) override {
         feed_hash(_h, t);
     }
 
-    virtual void accept_static_cell(column_id id, atomic_cell_view cell) {
+    virtual void accept_static_cell(column_id id, atomic_cell_view cell) override {
         auto&& col = _s.static_column_at(id);
         feed_hash(_h, col.name());
         feed_hash(_h, col.type->name());
         feed_hash(_h, cell, col);
     }
 
-    virtual void accept_static_cell(column_id id, collection_mutation_view cell) {
+    virtual void accept_static_cell(column_id id, collection_mutation_view cell) override {
         auto&& col = _s.static_column_at(id);
         feed_hash(_h, col.name());
         feed_hash(_h, col.type->name());
         feed_hash(_h, cell, col);
     }
 
-    virtual void accept_row_tombstone(const range_tombstone& rt) {
+    virtual void accept_row_tombstone(const range_tombstone& rt) override {
         feed_hash(_h, rt, _s);
     }
 
@@ -73,14 +73,14 @@ public:
         feed_hash(_h, rm);
     }
 
-    virtual void accept_row_cell(column_id id, atomic_cell_view cell) {
+    virtual void accept_row_cell(column_id id, atomic_cell_view cell) override {
         auto&& col = _s.regular_column_at(id);
         feed_hash(_h, col.name());
         feed_hash(_h, col.type->name());
         feed_hash(_h, cell, col);
     }
 
-    virtual void accept_row_cell(column_id id, collection_mutation_view cell) {
+    virtual void accept_row_cell(column_id id, collection_mutation_view cell) override {
         auto&& col = _s.regular_column_at(id);
         feed_hash(_h, col.name());
         feed_hash(_h, col.type->name());

--- a/locator/local_strategy.hh
+++ b/locator/local_strategy.hh
@@ -40,7 +40,7 @@ protected:
 public:
     local_strategy(const shared_token_metadata& token_metadata, snitch_ptr& snitch, const std::map<sstring, sstring>& config_options);
     virtual ~local_strategy() {};
-    virtual size_t get_replication_factor() const;
+    virtual size_t get_replication_factor() const override;
     /**
      * We need to override this even if we override calculateNaturalEndpoints,
      * because the default implementation depends on token calculations but

--- a/locator/production_snitch_base.hh
+++ b/locator/production_snitch_base.hh
@@ -70,8 +70,8 @@ public:
 
     production_snitch_base(const sstring& prop_file_name = "");
 
-    virtual sstring get_rack(inet_address endpoint);
-    virtual sstring get_datacenter(inet_address endpoint);
+    virtual sstring get_rack(inet_address endpoint) override;
+    virtual sstring get_datacenter(inet_address endpoint) override;
     virtual void set_my_distributed(distributed<snitch_ptr>* d) override;
 
     void reset_io_state();

--- a/mutation_reader.hh
+++ b/mutation_reader.hh
@@ -121,7 +121,7 @@ public:
         _end_of_stream = false;
         return _rd.fast_forward_to(std::move(pr));
     }
-    virtual future<> close() noexcept {
+    virtual future<> close() noexcept override {
         return _rd.close();
     }
 };

--- a/raft/server.cc
+++ b/raft/server.cc
@@ -73,7 +73,7 @@ public:
 
 
     // server interface
-    future<> add_entry(command command, wait_type type);
+    future<> add_entry(command command, wait_type type) override;
     future<snapshot_reply> apply_snapshot(server_id from, install_snapshot snp) override;
     future<> set_configuration(server_address_set c_new) override;
     raft::configuration get_configuration() const override;
@@ -84,7 +84,7 @@ public:
     void wait_until_candidate() override;
     future<> wait_election_done() override;
     future<> wait_log_idx_term(std::pair<index_t, term_t> idx_log) override;
-    std::pair<index_t, term_t> log_last_idx_term();
+    std::pair<index_t, term_t> log_last_idx_term() override;
     void elapse_election() override;
     bool is_leader() override;
     void tick() override;

--- a/redis/server.hh
+++ b/redis/server.hh
@@ -115,7 +115,7 @@ private:
         future<result> process_request_internal();
     };
 
-    shared_ptr<generic_server::connection> make_connection(socket_address server_addr, connected_socket&& fd, socket_address addr);
+    virtual shared_ptr<generic_server::connection> make_connection(socket_address server_addr, connected_socket&& fd, socket_address addr) override;
     future<> unadvertise_connection(shared_ptr<generic_server::connection> conn) override;
 
     const ::timeout_config& timeout_config() { return _config._timeout_config; }

--- a/service/load_broadcaster.hh
+++ b/service/load_broadcaster.hh
@@ -66,20 +66,20 @@ public:
         assert(_stopped);
     }
 
-    void on_change(gms::inet_address endpoint, gms::application_state state, const gms::versioned_value& value) {
+    virtual void on_change(gms::inet_address endpoint, gms::application_state state, const gms::versioned_value& value) override {
         if (state == gms::application_state::LOAD) {
             _load_info[endpoint] = std::stod(value.value);
         }
     }
 
-    void on_join(gms::inet_address endpoint, gms::endpoint_state ep_state) override {
+    virtual void on_join(gms::inet_address endpoint, gms::endpoint_state ep_state) override {
         auto* local_value = ep_state.get_application_state_ptr(gms::application_state::LOAD);
         if (local_value) {
             on_change(endpoint, gms::application_state::LOAD, *local_value);
         }
     }
     
-    void before_change(gms::inet_address endpoint, gms::endpoint_state current_state, gms::application_state new_state_key, const gms::versioned_value& newValue) {}
+    virtual void before_change(gms::inet_address endpoint, gms::endpoint_state current_state, gms::application_state new_state_key, const gms::versioned_value& newValue) override {}
 
     void on_alive(gms::inet_address endpoint, gms::endpoint_state) override {}
 
@@ -87,7 +87,7 @@ public:
 
     void on_restart(gms::inet_address endpoint, gms::endpoint_state) override {}
 
-    void on_remove(gms::inet_address endpoint) {
+    virtual void on_remove(gms::inet_address endpoint) override {
         _load_info.erase(endpoint);
     }
 

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -3803,7 +3803,7 @@ class speculating_read_executor : public abstract_read_executor {
     timer<storage_proxy::clock_type> _speculate_timer;
 public:
     using abstract_read_executor::abstract_read_executor;
-    virtual void make_requests(digest_resolver_ptr resolver, storage_proxy::clock_type::time_point timeout) {
+    virtual void make_requests(digest_resolver_ptr resolver, storage_proxy::clock_type::time_point timeout) override {
         _speculate_timer.set_callback([this, resolver, timeout] {
             if (!resolver->is_completed()) { // at the time the callback runs request may be completed already
                 resolver->add_wait_targets(1); // we send one more request so wait for it too

--- a/service/view_update_backlog_broker.hh
+++ b/service/view_update_backlog_broker.hh
@@ -54,7 +54,7 @@ public:
     virtual void on_remove(gms::inet_address) override;
 
     virtual void on_join(gms::inet_address, gms::endpoint_state) override { }
-    virtual void before_change(gms::inet_address, gms::endpoint_state, gms::application_state, const gms::versioned_value&) { }
+    virtual void before_change(gms::inet_address, gms::endpoint_state, gms::application_state, const gms::versioned_value&) override { }
     virtual void on_alive(gms::inet_address, gms::endpoint_state) override { }
     virtual void on_dead(gms::inet_address, gms::endpoint_state) override { }
     virtual void on_restart(gms::inet_address, gms::endpoint_state) override { }

--- a/sstables/compress.cc
+++ b/sstables/compress.cc
@@ -502,7 +502,7 @@ public:
             , _full_checksum(ChecksumType::init_checksum())
     {}
 
-    future<> put(net::packet data) { abort(); }
+    virtual future<> put(net::packet data) override { abort(); }
     virtual future<> put(temporary_buffer<char> buf) override {
         auto output_len = _compression.compress_max_size(buf.size());
 

--- a/sstables/mx/writer.cc
+++ b/sstables/mx/writer.cc
@@ -818,7 +818,7 @@ public:
     stop_iteration consume(static_row&& sr) override;
     stop_iteration consume(clustering_row&& cr) override;
     stop_iteration consume(range_tombstone&& rt) override;
-    stop_iteration consume_end_of_partition();
+    stop_iteration consume_end_of_partition() override;
     void consume_end_of_stream() override;
 };
 

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -114,7 +114,7 @@ static thread_local sstable_tracker tracker;
 // Because this is a noop and won't hold any state, it is better to use a global than a
 // thread_local. It will be faster, specially on non-x86.
 struct noop_write_monitor final : public write_monitor {
-    virtual void on_write_started(const writer_offset_tracker&) { };
+    virtual void on_write_started(const writer_offset_tracker&) override { };
     virtual void on_data_write_completed() override { }
 };
 static noop_write_monitor default_noop_write_monitor;
@@ -430,7 +430,7 @@ template <typename DiskSetOfTaggedUnion, typename Member>
 struct single_tagged_union_member_serdes_for final : single_tagged_union_member_serdes<DiskSetOfTaggedUnion> {
     using base = single_tagged_union_member_serdes<DiskSetOfTaggedUnion>;
     using value_type = typename base::value_type;
-    virtual future<> do_parse(const schema& s, sstable_version_types version, random_access_reader& in, value_type& v) const {
+    virtual future<> do_parse(const schema& s, sstable_version_types version, random_access_reader& in, value_type& v) const override {
         v = Member();
         return parse(s, version, in, boost::get<Member>(v).value);
     }

--- a/sstables/writer.hh
+++ b/sstables/writer.hh
@@ -108,7 +108,7 @@ public:
     explicit sizing_data_sink(uint64_t& dest) : _size(dest) {
         _size = 0;
     }
-    virtual temporary_buffer<char> allocate_buffer(size_t size) {
+    virtual temporary_buffer<char> allocate_buffer(size_t size) override {
         return temporary_buffer<char>(size);
     }
     virtual future<> put(net::packet data) override {
@@ -165,7 +165,7 @@ public:
     virtual temporary_buffer<char> allocate_buffer(size_t size) override {
         return _out.allocate_buffer(size); // preserve alignment requirements
     }
-    future<> put(net::packet data) { abort(); }
+    virtual future<> put(net::packet data) override { abort(); }
     virtual future<> put(temporary_buffer<char> buf) override {
         // bufs will usually be a multiple of chunk size, but this won't be the case for
         // the last buffer being flushed.
@@ -181,7 +181,7 @@ public:
         return _out.put(std::move(buf));
     }
 
-    virtual future<> close() {
+    virtual future<> close() override {
         // Nothing to do, because close at the file_stream level will call flush on us.
         return _out.close();
     }

--- a/test/boost/data_listeners_test.cc
+++ b/test/boost/data_listeners_test.cc
@@ -39,7 +39,7 @@ public:
     table_listener(sstring cf_name) : _cf_name(cf_name) {}
 
     virtual flat_mutation_reader on_read(const schema_ptr& s, const dht::partition_range& range,
-            const query::partition_slice& slice, flat_mutation_reader&& rd) {
+            const query::partition_slice& slice, flat_mutation_reader&& rd) override {
         if (s->cf_name() == _cf_name) {
             return make_filtering_reader(std::move(rd), [this, &range, &slice, s = std::move(s)] (const dht::decorated_key& dk) {
                 testlog.info("listener {}: read {}", fmt::ptr(this), dk);

--- a/test/boost/flat_mutation_reader_test.cc
+++ b/test/boost/flat_mutation_reader_test.cc
@@ -297,7 +297,7 @@ SEASTAR_THREAD_TEST_CASE(test_flat_mutation_reader_move_buffer_content_to) {
     struct dummy_reader_impl : public flat_mutation_reader::impl {
         using flat_mutation_reader::impl::impl;
         virtual future<> fill_buffer() override { return make_ready_future<>(); }
-        virtual future<> next_partition() { return make_ready_future<>(); }
+        virtual future<> next_partition() override { return make_ready_future<>(); }
         virtual future<> fast_forward_to(const dht::partition_range&) override { return make_ready_future<>(); }
         virtual future<> fast_forward_to(position_range) override { return make_ready_future<>(); }
         virtual future<> close() noexcept override { return make_ready_future<>(); };

--- a/test/boost/network_topology_strategy_test.cc
+++ b/test/boost/network_topology_strategy_test.cc
@@ -569,7 +569,7 @@ std::unique_ptr<i_endpoint_snitch> generate_snitch(const std::unordered_map<sstr
         sstring get_datacenter(inet_address endpoint) override {
             return _node_to_dc.at(endpoint);
         }
-        sstring get_name() const {
+        sstring get_name() const override {
             return "muminpappa";
         }
     private:

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -418,7 +418,7 @@ public:
         return _core_local.start(std::ref(_auth_service), std::ref(_sl_controller));
     }
 
-    future<> stop() {
+    future<> stop() override {
         return _core_local.stop();
     }
 

--- a/test/lib/sstable_run_based_compaction_strategy_for_tests.hh
+++ b/test/lib/sstable_run_based_compaction_strategy_for_tests.hh
@@ -39,7 +39,7 @@ public:
 
     virtual int64_t estimated_pending_compactions(column_family& cf) const override;
 
-    virtual compaction_strategy_type type() const;
+    virtual compaction_strategy_type type() const override;
 
     virtual compaction_backlog_tracker& get_backlog_tracker() override;
 };

--- a/test/perf/perf_collection.cc
+++ b/test/perf/perf_collection.cc
@@ -134,7 +134,7 @@ public:
         assert(i.second);
         i.first.erase(key_compare{});
     }
-    virtual void show_stats() {
+    virtual void show_stats() override {
         struct bplus::stats st = _t.get_stats();
         fmt::print("nodes:     {}\n", st.nodes);
         for (int i = 0; i < (int)st.nodes_filled.size(); i++) {
@@ -191,12 +191,12 @@ public:
                 st.indirect_tiny, st.indirect_small, st.indirect_medium, st.indirect_large,
                 st.direct_static, st.direct_dynamic);
     }
-    virtual void show_stats() {
+    virtual void show_stats() override {
         test_tree::stats st = _t.get_stats();
         show_node_stats("inner", st.inners);
         show_node_stats(" leaf", st.leaves);
     }
-    virtual ~radix_tester() { clear(); }
+    virtual ~radix_tester() override { clear(); }
 };
 
 #include "intrusive_set_external_comparator.hh"
@@ -265,7 +265,7 @@ public:
         auto i = _t.insert_before(_t.end(), n);
         _t.erase(i);
     }
-    virtual void show_stats() { }
+    virtual void show_stats() override { }
     virtual ~isec_tester() { clear(); }
 };
 
@@ -302,7 +302,7 @@ public:
         auto i = _t.insert_before(_t.end(), key);
         _t.erase(i);
     }
-    virtual void show_stats() {
+    virtual void show_stats() override {
         struct intrusive_b::stats st = _t.get_stats();
         fmt::print("nodes:     {}\n", st.nodes);
         for (int i = 0; i < (int)st.nodes_filled.size(); i++) {
@@ -347,7 +347,7 @@ public:
         assert(i.second);
         _s.erase(i.first);
     }
-    virtual void show_stats() { }
+    virtual void show_stats() override { }
     virtual ~set_tester() = default;
 };
 
@@ -380,7 +380,7 @@ public:
         assert(i.second);
         _m.erase(i.first);
     }
-    virtual void show_stats() { }
+    virtual void show_stats() override { }
     virtual ~map_tester() = default;
 };
 

--- a/test/raft/replication.hh
+++ b/test/raft/replication.hh
@@ -429,12 +429,12 @@ public:
             _conf(std::move(conf)), _snapshots(snapshots),
             _persisted_snapshots(persisted_snapshots) {}
     persistence() {}
-    virtual future<> store_term_and_vote(raft::term_t term, raft::server_id vote) { return seastar::sleep(1us); }
-    virtual future<std::pair<raft::term_t, raft::server_id>> load_term_and_vote() {
+    virtual future<> store_term_and_vote(raft::term_t term, raft::server_id vote) override { return seastar::sleep(1us); }
+    virtual future<std::pair<raft::term_t, raft::server_id>> load_term_and_vote() override {
         auto term_and_vote = std::make_pair(_conf.term, _conf.vote);
         return make_ready_future<std::pair<raft::term_t, raft::server_id>>(term_and_vote);
     }
-    virtual future<> store_snapshot_descriptor(const raft::snapshot_descriptor& snap, size_t preserve_log_entries) {
+    virtual future<> store_snapshot_descriptor(const raft::snapshot_descriptor& snap, size_t preserve_log_entries) override {
         (*_persisted_snapshots)[_id] = std::make_pair(snap, (*_snapshots)[_id][snap.id]);
         tlogger.debug("sm[{}] persists snapshot {}", _id, (*_snapshots)[_id][snap.id].hasher.finalize_uint64());
         return make_ready_future<>();
@@ -442,16 +442,16 @@ public:
     future<raft::snapshot_descriptor> load_snapshot_descriptor() override {
         return make_ready_future<raft::snapshot_descriptor>(_conf.snapshot);
     }
-    virtual future<> store_log_entries(const std::vector<raft::log_entry_ptr>& entries) { return seastar::sleep(1us); };
-    virtual future<raft::log_entries> load_log() {
+    virtual future<> store_log_entries(const std::vector<raft::log_entry_ptr>& entries) override { return seastar::sleep(1us); };
+    virtual future<raft::log_entries> load_log() override {
         raft::log_entries log;
         for (auto&& e : _conf.log) {
             log.emplace_back(make_lw_shared(std::move(e)));
         }
         return make_ready_future<raft::log_entries>(std::move(log));
     }
-    virtual future<> truncate_log(raft::index_t idx) { return make_ready_future<>(); }
-    virtual future<> abort() { return make_ready_future<>(); }
+    virtual future<> truncate_log(raft::index_t idx) override { return make_ready_future<>(); }
+    virtual future<> abort() override { return make_ready_future<>(); }
 };
 
 template <typename Clock>

--- a/transport/messages/result_message.hh
+++ b/transport/messages/result_message.hh
@@ -116,7 +116,7 @@ public:
     virtual void accept(result_message::visitor& v) const override {
         v.visit(*this);
     }
-    virtual std::optional<unsigned> move_to_shard() const {
+    virtual std::optional<unsigned> move_to_shard() const override {
         return _shard;
     }
 

--- a/transport/server.hh
+++ b/transport/server.hh
@@ -278,7 +278,7 @@ private:
     friend class type_codec;
 
 private:
-    shared_ptr<generic_server::connection> make_connection(socket_address server_addr, connected_socket&& fd, socket_address addr);
+    virtual shared_ptr<generic_server::connection> make_connection(socket_address server_addr, connected_socket&& fd, socket_address addr) override;
     future<> advertise_new_connection(shared_ptr<generic_server::connection> conn) override;
     future<> unadvertise_connection(shared_ptr<generic_server::connection> conn) override;
 

--- a/utils/allocation_strategy.hh
+++ b/utils/allocation_strategy.hh
@@ -228,7 +228,7 @@ public:
         ::free(obj);
     }
 
-    virtual size_t object_memory_size_in_allocator(const void* obj) const noexcept {
+    virtual size_t object_memory_size_in_allocator(const void* obj) const noexcept override {
         return ::malloc_usable_size(const_cast<void *>(obj));
     }
 };


### PR DESCRIPTION
This warning can catch a virtual function that thinks it
overrides another, but doesn't, because the two functions
have different signatures. This isn't very likely since most
of our virtual functions override pure virtuals, but it's
still worth having.

Enable the warning and fix numerous violations.