### PR TITLE
cql3: Add evaluate(expression) and use instead of term::bind()

### DIFF
--- a/cql3/constants.cc
+++ b/cql3/constants.cc
@@ -58,4 +58,8 @@ void constants::deleter::execute(mutation& m, const clustering_key_prefix& prefi
     }
 }
 
+expr::expression constants::marker::to_expression() {
+    throw std::runtime_error(fmt::format("to_expression not implemented! {}:{}", __FILE__, __LINE__));
+}
+
 }

--- a/cql3/constants.cc
+++ b/cql3/constants.cc
@@ -59,7 +59,11 @@ void constants::deleter::execute(mutation& m, const clustering_key_prefix& prefi
 }
 
 expr::expression constants::marker::to_expression() {
-    throw std::runtime_error(fmt::format("to_expression not implemented! {}:{}", __FILE__, __LINE__));
+    return expr::bind_variable {
+        .shape = expr::bind_variable::shape_type::scalar,
+        .bind_index = _bind_index,
+        .value_type = _receiver->type
+    };
 }
 
 }

--- a/cql3/constants.hh
+++ b/cql3/constants.hh
@@ -101,6 +101,7 @@ public:
             return ::make_shared<constants::value>(cql3::raw_value::make_value(bytes), _receiver->type);
         }
 
+        virtual expr::expression to_expression() override;
     private:
         cql3::raw_value_view bind_and_get_internal(const query_options& options) {
             try {

--- a/cql3/expr/expression.cc
+++ b/cql3/expr/expression.cc
@@ -1468,5 +1468,13 @@ utils::chunked_vector<std::vector<managed_bytes_opt>> get_list_of_tuples_element
 
     return tuples_list;
 }
+
+expression to_expression(const ::shared_ptr<term>& term_ptr) {
+    if (term_ptr.get() == nullptr) {
+        return constant::make_null();
+    }
+
+    return term_ptr->to_expression();
+}
 } // namespace expr
 } // namespace cql3

--- a/cql3/expr/expression.cc
+++ b/cql3/expr/expression.cc
@@ -1120,7 +1120,8 @@ expression search_and_replace(const expression& e,
                     return tuple_constructor{
                         boost::copy_range<std::vector<expression>>(
                             tc.elements | boost::adaptors::transformed(recurse)
-                        )
+                        ),
+                        tc.type
                     };
                 },
                 [&] (const collection_constructor& c) -> expression {
@@ -1128,7 +1129,8 @@ expression search_and_replace(const expression& e,
                         c.style,
                         boost::copy_range<std::vector<expression>>(
                             c.elements | boost::adaptors::transformed(recurse)
-                        )
+                        ),
+                        c.type
                     };
                 },
                 [&] (const usertype_constructor& uc) -> expression {
@@ -1136,7 +1138,7 @@ expression search_and_replace(const expression& e,
                     for (auto& [k, v] : uc.elements) {
                         m.emplace(k, recurse(*v));
                     }
-                    return usertype_constructor{std::move(m)};
+                    return usertype_constructor{std::move(m), uc.type};
                 },
                 [&] (const function_call& fc) -> expression {
                     return function_call{

--- a/cql3/expr/expression.cc
+++ b/cql3/expr/expression.cc
@@ -1310,29 +1310,7 @@ constant evaluate(term* term_ptr, const query_options& options) {
         return constant::make_null();
     }
 
-    if (dynamic_cast<abstract_marker*>(term_ptr) != nullptr
-     || dynamic_cast<tuples::value*>(term_ptr) != nullptr
-     || dynamic_cast<tuples::delayed_value*>(term_ptr) != nullptr
-     || dynamic_cast<lists::value*>(term_ptr) != nullptr
-     || dynamic_cast<lists::delayed_value*>(term_ptr) != nullptr 
-     || dynamic_cast<sets::value*>(term_ptr) != nullptr
-     || dynamic_cast<sets::delayed_value*>(term_ptr) != nullptr
-     || dynamic_cast<maps::value*>(term_ptr) != nullptr
-     || dynamic_cast<maps::delayed_value*>(term_ptr) != nullptr
-     || dynamic_cast<user_types::value*>(term_ptr) != nullptr
-     || dynamic_cast<user_types::delayed_value*>(term_ptr) != nullptr
-     || dynamic_cast<functions::function_call*>(term_ptr) != nullptr) {
-        return evaluate(term_ptr->to_expression(), options);
-    }
-
-    ::shared_ptr<terminal> bound = term_ptr->bind(options);
-    if (bound.get() == nullptr) {
-        return constant::make_null();
-    }
-
-    raw_value raw_val = bound->get(options);
-    data_type val_type = bound->get_value_type();
-    return constant(std::move(raw_val), std::move(val_type));
+    return evaluate(term_ptr->to_expression(), options);
 }
 
 constant evaluate(const ::shared_ptr<term>& term_ptr, const query_options& options) {

--- a/cql3/expr/expression.cc
+++ b/cql3/expr/expression.cc
@@ -1369,6 +1369,68 @@ cql3::raw_value_view evaluate_to_raw_view(term& term_ref, const query_options& o
     return cql3::raw_value_view::make_temporary(std::move(value.value));
 }
 
+constant evaluate(const expression& e, const query_options& options) {
+    return std::visit(overloaded_functor {
+        [](const binary_operator&) -> constant {
+            on_internal_error(expr_logger, "Can't evaluate a binary_operator");
+        },
+        [](const conjunction&) -> constant {
+            on_internal_error(expr_logger, "Can't evaluate a conjunction");
+        },
+        [](const token&) -> constant {
+            on_internal_error(expr_logger, "Can't evaluate token");
+        },
+        [](const unresolved_identifier&) -> constant {
+            on_internal_error(expr_logger, "Can't evaluate unresolved_identifier");
+        },
+        [](const column_mutation_attribute&) -> constant {
+            on_internal_error(expr_logger, "Can't evaluate a column_mutation_attribute");
+        },
+        [](const cast&) -> constant {
+            on_internal_error(expr_logger, "Can't evaluate a cast");
+        },
+        [](const field_selection&) -> constant {
+            on_internal_error(expr_logger, "Can't evaluate a field_selection");
+        },
+
+        // TODO Should these be evaluable?
+        [](const column_value&) -> constant {
+            on_internal_error(expr_logger, "Can't evaluate a column_value");
+        },
+        [](const untyped_constant&) -> constant {
+            on_internal_error(expr_logger, "Can't evaluate a untyped_constant ");
+        },
+
+        [](const null&) { return constant::make_null(); },
+        [](const constant& c) { return c; },
+        [&](const bind_variable& bind_var) { return evaluate(bind_var, options); },
+        [&](const tuple_constructor& tup) { return evaluate(tup, options); },
+        [&](const collection_constructor& col) { return evaluate(col, options); },
+        [&](const usertype_constructor& user_val) { return evaluate(user_val, options); },
+        [&](const function_call& fun_call) { return evaluate(fun_call, options); }
+    }, e);
+}
+
+constant evaluate(const bind_variable& bind_var, const query_options& options) {
+    throw std::runtime_error(fmt::format("evaluate not implemented {}:{}", __FILE__, __LINE__));
+}
+
+constant evaluate(const tuple_constructor& tuple, const query_options& options) {
+    throw std::runtime_error(fmt::format("evaluate not implemented {}:{}", __FILE__, __LINE__));
+}
+
+constant evaluate(const collection_constructor& collection, const query_options& options) {
+    throw std::runtime_error(fmt::format("evaluate not implemented {}:{}", __FILE__, __LINE__));
+}
+
+constant evaluate(const usertype_constructor& user_val, const query_options& options) {
+    throw std::runtime_error(fmt::format("evaluate not implemented {}:{}", __FILE__, __LINE__));
+}
+
+constant evaluate(const function_call& fun_call, const query_options& options) {
+    throw std::runtime_error(fmt::format("evaluate not implemented {}:{}", __FILE__, __LINE__));
+}
+
 static void ensure_can_get_value_elements(const constant& val,
                                           abstract_type::kind expected_type_kind,
                                           const char* caller_name) {

--- a/cql3/expr/expression.hh
+++ b/cql3/expr/expression.hh
@@ -208,6 +208,11 @@ struct bind_variable {
     // FIXME: infer shape from expression rather than from grammar
     shape_type shape;
     int32_t bind_index;
+
+    // Type of the bound value.
+    // Before preparing can be nullptr.
+    // After preparing always holds a valid type.
+    data_type value_type;
 };
 
 // A constant which does not yet have a date type. It is partially typed

--- a/cql3/expr/expression.hh
+++ b/cql3/expr/expression.hh
@@ -241,6 +241,10 @@ struct constant {
 // Denotes construction of a tuple from its elements, e.g.  ('a', ?, some_column) in CQL.
 struct tuple_constructor {
     std::vector<expression> elements;
+
+    // Might be nullptr before prepare.
+    // After prepare always holds a valid type, although it might be reversed_type(tuple_type).
+    data_type type;
 };
 
 // Constructs a collection of same-typed elements
@@ -248,12 +252,20 @@ struct collection_constructor {
     enum class style_type { list, set, map };
     style_type style;
     std::vector<expression> elements;
+
+    // Might be nullptr before prepare.
+    // After prepare always holds a valid type, although it might be reversed_type(collection_type).
+    data_type type;
 };
 
 // Constructs an object of a user-defined type
 struct usertype_constructor {
     using elements_map_type = std::unordered_map<column_identifier, nested_expression>;
     elements_map_type elements;
+
+    // Might be nullptr before prepare.
+    // After prepare always holds a valid type, although it might be reversed_type(user_type).
+    data_type type;
 };
 
 /// Creates a conjunction of a and b.  If either a or b is itself a conjunction, its children are inserted

--- a/cql3/expr/expression.hh
+++ b/cql3/expr/expression.hh
@@ -574,6 +574,15 @@ constant evaluate_IN_list(term&, const query_options&);
 cql3::raw_value_view evaluate_to_raw_view(const ::shared_ptr<term>&, const query_options&);
 cql3::raw_value_view evaluate_to_raw_view(term&, const query_options&);
 
+// Takes a prepared expression and calculates its value.
+// Evaluates bound values, calls functions and returns just the bytes and type.
+constant evaluate(const expression& e, const query_options&);
+constant evaluate(const bind_variable&, const query_options&);
+constant evaluate(const tuple_constructor&, const query_options&);
+constant evaluate(const collection_constructor&, const query_options&);
+constant evaluate(const usertype_constructor&, const query_options&);
+constant evaluate(const function_call&, const query_options&);
+
 utils::chunked_vector<managed_bytes> get_list_elements(const constant&);
 utils::chunked_vector<managed_bytes> get_set_elements(const constant&);
 std::vector<managed_bytes_opt> get_tuple_elements(const constant&);

--- a/cql3/expr/expression.hh
+++ b/cql3/expr/expression.hh
@@ -29,7 +29,6 @@
 
 #include "bytes.hh"
 #include "cql3/statements/bound.hh"
-#include "cql3/term.hh"
 #include "cql3/column_identifier.hh"
 #include "cql3/cql3_type.hh"
 #include "cql3/functions/function_name.hh"
@@ -39,6 +38,7 @@
 #include "seastarx.hh"
 #include "utils/overloaded_functor.hh"
 #include "utils/variant_element.hh"
+#include "cql3/values.hh"
 
 class row;
 
@@ -52,6 +52,7 @@ namespace query {
 } // namespace query
 
 namespace cql3 {
+struct term;
 
 class column_identifier_raw;
 class query_options;

--- a/cql3/expr/expression.hh
+++ b/cql3/expr/expression.hh
@@ -569,6 +569,8 @@ std::vector<managed_bytes_opt> get_elements(const constant&);
 // Get elements of list<tuple<>> as vector<vector<managed_bytes_opt>
 // It is useful with IN restrictions like (a, b) IN [(1, 2), (3, 4)].
 utils::chunked_vector<std::vector<managed_bytes_opt>> get_list_of_tuples_elements(const constant&);
+
+expression to_expression(const ::shared_ptr<term>&);
 } // namespace expr
 
 } // namespace cql3

--- a/cql3/functions/function_call.hh
+++ b/cql3/functions/function_call.hh
@@ -76,6 +76,8 @@ public:
         _id = id;
     }
     virtual shared_ptr<terminal> bind(const query_options& options) override;
+
+    virtual expr::expression to_expression() override;
 public:
     virtual bool contains_bind_marker() const override;
 private:

--- a/cql3/functions/functions.cc
+++ b/cql3/functions/functions.cc
@@ -512,6 +512,7 @@ expr::expression function_call::to_expression() {
     return expr::function_call {
         .func = _fun,
         .args = std::move(args),
+        .lwt_cache_id = _id,
     };
 }
 

--- a/cql3/functions/functions.cc
+++ b/cql3/functions/functions.cc
@@ -502,7 +502,17 @@ function_call::bind_and_get_internal(const query_options& options) {
 }
 
 expr::expression function_call::to_expression() {
-    throw std::runtime_error(fmt::format("to_expression not implemented! {}:{}", __FILE__, __LINE__));
+    std::vector<expr::expression> args;
+    args.reserve(_terms.size());
+
+    for (const ::shared_ptr<term>& t : _terms) {
+        args.emplace_back(expr::to_expression(t));
+    }
+
+    return expr::function_call {
+        .func = _fun,
+        .args = std::move(args),
+    };
 }
 
 static

--- a/cql3/functions/functions.cc
+++ b/cql3/functions/functions.cc
@@ -501,6 +501,10 @@ function_call::bind_and_get_internal(const query_options& options) {
     return cql3::raw_value_view::make_temporary(cql3::raw_value::make_value(result));
 }
 
+expr::expression function_call::to_expression() {
+    throw std::runtime_error(fmt::format("to_expression not implemented! {}:{}", __FILE__, __LINE__));
+}
+
 static
 bytes_opt
 execute_internal(cql_serialization_format sf, scalar_function& fun, std::vector<bytes_opt> params) {

--- a/cql3/lists.cc
+++ b/cql3/lists.cc
@@ -158,6 +158,10 @@ lists::delayed_value::bind_ignore_null(const query_options& options) {
     return ::make_shared<value>(buffers, _my_type);
 }
 
+expr::expression lists::delayed_value::to_expression() {
+    throw std::runtime_error(fmt::format("to_expression not implemented! {}:{}", __FILE__, __LINE__));
+}
+
 ::shared_ptr<terminal>
 lists::marker::bind(const query_options& options) {
     const auto& value = options.get_value_at(_bind_index);
@@ -175,6 +179,10 @@ lists::marker::bind(const query_options& options) {
                     format("Exception while binding column {:s}: {:s}", _receiver->name->to_cql_string(), e.what()));
         }
     }
+}
+
+expr::expression lists::marker::to_expression() {
+    throw std::runtime_error(fmt::format("to_expression not implemented! {}:{}", __FILE__, __LINE__));
 }
 
 void

--- a/cql3/lists.cc
+++ b/cql3/lists.cc
@@ -182,7 +182,11 @@ lists::marker::bind(const query_options& options) {
 }
 
 expr::expression lists::marker::to_expression() {
-    throw std::runtime_error(fmt::format("to_expression not implemented! {}:{}", __FILE__, __LINE__));
+    return expr::bind_variable {
+        .shape = expr::bind_variable::shape_type::scalar,
+        .bind_index = _bind_index,
+        .value_type = _receiver->type
+    };
 }
 
 void

--- a/cql3/lists.cc
+++ b/cql3/lists.cc
@@ -159,7 +159,18 @@ lists::delayed_value::bind_ignore_null(const query_options& options) {
 }
 
 expr::expression lists::delayed_value::to_expression() {
-    throw std::runtime_error(fmt::format("to_expression not implemented! {}:{}", __FILE__, __LINE__));
+    std::vector<expr::expression> new_elements;
+    new_elements.reserve(_elements.size());
+
+    for (shared_ptr<term>& e : _elements) {
+        new_elements.emplace_back(expr::to_expression(e));
+    }
+
+    return expr::collection_constructor {
+        .style = expr::collection_constructor::style_type::list,
+        .elements = std::move(new_elements),
+        .type = _my_type
+    };
 }
 
 ::shared_ptr<terminal>

--- a/cql3/lists.hh
+++ b/cql3/lists.hh
@@ -98,6 +98,8 @@ public:
         const std::vector<shared_ptr<term>>& get_elements() const {
             return _elements;
         }
+
+        virtual expr::expression to_expression() override;
     };
 
     /**
@@ -109,6 +111,8 @@ public:
             : abstract_marker{bind_index, std::move(receiver)}
         { }
         virtual ::shared_ptr<terminal> bind(const query_options& options) override;
+
+        virtual expr::expression to_expression() override;
     };
 
 public:

--- a/cql3/maps.cc
+++ b/cql3/maps.cc
@@ -190,7 +190,11 @@ maps::marker::bind(const query_options& options) {
 }
 
 expr::expression maps::marker::to_expression() {
-    throw std::runtime_error(fmt::format("to_expression not implemented! {}:{}", __FILE__, __LINE__));
+    return expr::bind_variable {
+        .shape = expr::bind_variable::shape_type::scalar,
+        .bind_index = _bind_index,
+        .value_type = _receiver->type
+    };
 }
 
 void

--- a/cql3/maps.cc
+++ b/cql3/maps.cc
@@ -163,6 +163,10 @@ maps::delayed_value::bind(const query_options& options) {
     return ::make_shared<value>(std::move(buffers), _my_type);
 }
 
+expr::expression maps::delayed_value::to_expression() {
+    throw std::runtime_error(fmt::format("to_expression not implemented! {}:{}", __FILE__, __LINE__));
+}
+
 ::shared_ptr<terminal>
 maps::marker::bind(const query_options& options) {
     auto val = options.get_value_at(_bind_index);
@@ -183,6 +187,10 @@ maps::marker::bind(const query_options& options) {
                     val,
                     dynamic_cast<const map_type_impl&>(_receiver->type->without_reversed()),
                     options.get_cql_serialization_format()));
+}
+
+expr::expression maps::marker::to_expression() {
+    throw std::runtime_error(fmt::format("to_expression not implemented! {}:{}", __FILE__, __LINE__));
 }
 
 void

--- a/cql3/maps.hh
+++ b/cql3/maps.hh
@@ -84,6 +84,8 @@ public:
         virtual bool contains_bind_marker() const override;
         virtual void fill_prepare_context(prepare_context& ctx) const override;
         virtual shared_ptr<terminal> bind(const query_options& options) override;
+
+        virtual expr::expression to_expression() override;
     };
 
     class marker : public abstract_marker {
@@ -92,6 +94,7 @@ public:
             : abstract_marker{bind_index, std::move(receiver)}
         { }
         virtual ::shared_ptr<terminal> bind(const query_options& options) override;
+        virtual expr::expression to_expression() override;
     };
 
     class setter : public operation {

--- a/cql3/restrictions/multi_column_restriction.hh
+++ b/cql3/restrictions/multi_column_restriction.hh
@@ -59,11 +59,14 @@ inline
 expr::tuple_constructor
 column_definitions_as_tuple_constructor(const std::vector<const column_definition*>& defs) {
     std::vector<expr::expression> columns;
+    std::vector<data_type> column_types;
     columns.reserve(defs.size());
     for (auto& def : defs) {
         columns.push_back(expr::column_value{def});
+        column_types.push_back(def->type);
     }
-    return expr::tuple_constructor{std::move(columns)};
+    data_type ttype = tuple_type_impl::get_instance(std::move(column_types));
+    return expr::tuple_constructor{std::move(columns), std::move(ttype)};
 }
 
 class multi_column_restriction : public clustering_key_restrictions {

--- a/cql3/sets.cc
+++ b/cql3/sets.cc
@@ -156,7 +156,11 @@ sets::marker::bind(const query_options& options) {
 }
 
 expr::expression sets::marker::to_expression() {
-    throw std::runtime_error(fmt::format("to_expression not implemented! {}:{}", __FILE__, __LINE__));
+    return expr::bind_variable {
+        .shape = expr::bind_variable::shape_type::scalar,
+        .bind_index = _bind_index,
+        .value_type = _receiver->type
+    };
 }
 
 void

--- a/cql3/sets.cc
+++ b/cql3/sets.cc
@@ -125,7 +125,18 @@ sets::delayed_value::bind(const query_options& options) {
 }
 
 expr::expression sets::delayed_value::to_expression() {
-    throw std::runtime_error(fmt::format("to_expression not implemented! {}:{}", __FILE__, __LINE__));
+    std::vector<expr::expression> new_elements;
+    new_elements.reserve(_elements.size());
+
+    for (shared_ptr<term>& e : _elements) {
+        new_elements.emplace_back(expr::to_expression(e));
+    }
+
+    return expr::collection_constructor {
+        .style = expr::collection_constructor::style_type::set,
+        .elements = std::move(new_elements),
+        .type = _my_type,
+    };
 }
 
 sets::marker::marker(int32_t bind_index, lw_shared_ptr<column_specification> receiver)

--- a/cql3/sets.cc
+++ b/cql3/sets.cc
@@ -124,6 +124,9 @@ sets::delayed_value::bind(const query_options& options) {
     return ::make_shared<value>(std::move(buffers), _my_type);
 }
 
+expr::expression sets::delayed_value::to_expression() {
+    throw std::runtime_error(fmt::format("to_expression not implemented! {}:{}", __FILE__, __LINE__));
+}
 
 sets::marker::marker(int32_t bind_index, lw_shared_ptr<column_specification> receiver)
     : abstract_marker{bind_index, std::move(receiver)} {
@@ -150,6 +153,10 @@ sets::marker::bind(const query_options& options) {
         }
         return make_shared<cql3::sets::value>(value::from_serialized(value, type, options.get_cql_serialization_format()));
     }
+}
+
+expr::expression sets::marker::to_expression() {
+    throw std::runtime_error(fmt::format("to_expression not implemented! {}:{}", __FILE__, __LINE__));
 }
 
 void

--- a/cql3/sets.hh
+++ b/cql3/sets.hh
@@ -83,12 +83,15 @@ public:
         virtual bool contains_bind_marker() const override;
         virtual void fill_prepare_context(prepare_context& ctx) const override;
         virtual shared_ptr<terminal> bind(const query_options& options) override;
+
+        virtual expr::expression to_expression() override;
     };
 
     class marker : public abstract_marker {
     public:
         marker(int32_t bind_index, lw_shared_ptr<column_specification> receiver);
         virtual ::shared_ptr<terminal> bind(const query_options& options) override;
+        virtual expr::expression to_expression() override;
     };
 
     class setter : public operation {

--- a/cql3/term.hh
+++ b/cql3/term.hh
@@ -44,6 +44,7 @@
 #include "cql3/assignment_testable.hh"
 #include "cql3/query_options.hh"
 #include "cql3/values.hh"
+#include "cql3/expr/expression.hh"
 
 #include <variant>
 #include <vector>
@@ -99,6 +100,10 @@ public:
 
     friend std::ostream& operator<<(std::ostream& out, const term& t) {
         return out << t.to_string();
+    }
+
+    expr::expression to_expression() {
+        throw std::runtime_error("unimplemented");
     }
 };
 

--- a/cql3/term.hh
+++ b/cql3/term.hh
@@ -102,9 +102,7 @@ public:
         return out << t.to_string();
     }
 
-    expr::expression to_expression() {
-        throw std::runtime_error("unimplemented");
-    }
+    virtual expr::expression to_expression() = 0;
 };
 
 /**
@@ -150,6 +148,11 @@ public:
 
     data_type get_value_type() const {
         return _my_type;
+    }
+
+    virtual expr::expression to_expression() override {
+        cql3::raw_value raw_val = get(query_options::DEFAULT);
+        return expr::constant(std::move(raw_val), get_value_type());
     }
 };
 

--- a/cql3/tuples.cc
+++ b/cql3/tuples.cc
@@ -28,7 +28,17 @@
 namespace cql3 {
 
 expr::expression tuples::delayed_value::to_expression() {
-    throw std::runtime_error(fmt::format("to_expression not implemented! {}:{}", __FILE__, __LINE__));
+    std::vector<expr::expression> new_elements;
+    new_elements.reserve(_elements.size());
+
+    for (shared_ptr<term>& e : _elements) {
+        new_elements.emplace_back(expr::to_expression(e));
+    }
+
+    return expr::tuple_constructor {
+        .elements = std::move(new_elements),
+        .type = _type,
+    };
 }
 
 tuples::in_value

--- a/cql3/tuples.cc
+++ b/cql3/tuples.cc
@@ -27,6 +27,10 @@
 
 namespace cql3 {
 
+expr::expression tuples::delayed_value::to_expression() {
+    throw std::runtime_error(fmt::format("to_expression not implemented! {}:{}", __FILE__, __LINE__));
+}
+
 tuples::in_value
 tuples::in_value::from_serialized(const raw_value_view& value_view, const list_type_impl& type, const query_options& options) {
     try {
@@ -64,6 +68,14 @@ cql3::raw_value tuples::in_value::get(const query_options& options) {
 
     ::shared_ptr<lists::value> list_value = ::make_shared<lists::value>(std::move(list_elements), get_value_type());
     return list_value->get(options);
+}
+
+expr::expression tuples::marker::to_expression() {
+    throw std::runtime_error(fmt::format("to_expression not implemented! {}:{}", __FILE__, __LINE__));
+}
+
+expr::expression tuples::in_marker::to_expression() {
+    throw std::runtime_error(fmt::format("to_expression not implemented! {}:{}", __FILE__, __LINE__));
 }
 
 tuples::in_marker::in_marker(int32_t bind_index, lw_shared_ptr<column_specification> receiver)

--- a/cql3/tuples.cc
+++ b/cql3/tuples.cc
@@ -71,11 +71,19 @@ cql3::raw_value tuples::in_value::get(const query_options& options) {
 }
 
 expr::expression tuples::marker::to_expression() {
-    throw std::runtime_error(fmt::format("to_expression not implemented! {}:{}", __FILE__, __LINE__));
+    return expr::bind_variable {
+        .shape = expr::bind_variable::shape_type::tuple,
+        .bind_index = _bind_index,
+        .value_type = _receiver->type
+    };
 }
 
 expr::expression tuples::in_marker::to_expression() {
-    throw std::runtime_error(fmt::format("to_expression not implemented! {}:{}", __FILE__, __LINE__));
+    return expr::bind_variable {
+        .shape = expr::bind_variable::shape_type::tuple_in,
+        .bind_index = _bind_index,
+        .value_type = _receiver->type
+    };
 }
 
 tuples::in_marker::in_marker(int32_t bind_index, lw_shared_ptr<column_specification> receiver)

--- a/cql3/tuples.hh
+++ b/cql3/tuples.hh
@@ -131,6 +131,8 @@ public:
         virtual shared_ptr<terminal> bind(const query_options& options) override {
             return ::make_shared<value>(bind_internal(options), _type);
         }
+
+        virtual expr::expression to_expression() override;
     };
 
     /**
@@ -185,6 +187,8 @@ public:
                 return make_shared<tuples::value>(value::from_serialized(value, type));
             }
         }
+
+        virtual expr::expression to_expression() override;
     };
 
     /**
@@ -195,6 +199,7 @@ public:
         in_marker(int32_t bind_index, lw_shared_ptr<column_specification> receiver);
 
         virtual shared_ptr<terminal> bind(const query_options& options) override;
+        virtual expr::expression to_expression() override;
     };
 
     template <typename T>

--- a/cql3/user_types.cc
+++ b/cql3/user_types.cc
@@ -119,7 +119,17 @@ shared_ptr<terminal> user_types::delayed_value::bind(const query_options& option
 }
 
 expr::expression user_types::delayed_value::to_expression() {
-    throw std::runtime_error(fmt::format("to_expression not implemented! {}:{}", __FILE__, __LINE__));
+    expr::usertype_constructor::elements_map_type new_elements;
+    for (size_t i = 0; i < _values.size(); i++) {
+        column_identifier field_name(_type->field_names().at(i), _type->string_field_names().at(i));
+        expr::nested_expression field_value(expr::to_expression(_values[i]));
+        new_elements.emplace(std::move(field_name), std::move(field_value));
+    }
+
+    return expr::usertype_constructor {
+        .elements = std::move(new_elements),
+        .type = _type
+    };
 }
 
 shared_ptr<terminal> user_types::marker::bind(const query_options& options) {

--- a/cql3/user_types.cc
+++ b/cql3/user_types.cc
@@ -118,6 +118,10 @@ shared_ptr<terminal> user_types::delayed_value::bind(const query_options& option
     return ::make_shared<user_types::value>(bind_internal(options), _type);
 }
 
+expr::expression user_types::delayed_value::to_expression() {
+    throw std::runtime_error(fmt::format("to_expression not implemented! {}:{}", __FILE__, __LINE__));
+}
+
 shared_ptr<terminal> user_types::marker::bind(const query_options& options) {
     auto value = options.get_value_at(_bind_index);
     if (value.is_null()) {
@@ -127,6 +131,10 @@ shared_ptr<terminal> user_types::marker::bind(const query_options& options) {
         return constants::UNSET_VALUE;
     }
     return make_shared<user_types::value>(value::from_serialized(value, static_cast<const user_type_impl&>(*_receiver->type)));
+}
+
+expr::expression user_types::marker::to_expression() {
+    throw std::runtime_error(fmt::format("to_expression not implemented! {}:{}", __FILE__, __LINE__));
 }
 
 void user_types::setter::execute(mutation& m, const clustering_key_prefix& row_key, const update_parameters& params) {

--- a/cql3/user_types.cc
+++ b/cql3/user_types.cc
@@ -134,7 +134,11 @@ shared_ptr<terminal> user_types::marker::bind(const query_options& options) {
 }
 
 expr::expression user_types::marker::to_expression() {
-    throw std::runtime_error(fmt::format("to_expression not implemented! {}:{}", __FILE__, __LINE__));
+    return expr::bind_variable {
+        .shape = expr::bind_variable::shape_type::scalar,
+        .bind_index = _bind_index,
+        .value_type = _receiver->type
+    };
 }
 
 void user_types::setter::execute(mutation& m, const clustering_key_prefix& row_key, const update_parameters& params) {

--- a/cql3/user_types.hh
+++ b/cql3/user_types.hh
@@ -80,6 +80,8 @@ public:
         std::vector<managed_bytes_opt> bind_internal(const query_options& options);
     public:
         virtual shared_ptr<terminal> bind(const query_options& options) override;
+
+        virtual expr::expression to_expression() override;
     };
 
     class marker : public abstract_marker {
@@ -91,6 +93,7 @@ public:
         }
 
         virtual shared_ptr<terminal> bind(const query_options& options) override;
+        virtual expr::expression to_expression() override;
     };
 
     class setter : public operation {

--- a/cql3/values.hh
+++ b/cql3/values.hh
@@ -262,6 +262,18 @@ public:
             }
         }, std::move(_data));
     }
+    managed_bytes_opt to_managed_bytes_opt() && {
+        return std::visit(overloaded_functor{
+            [](bytes&& bytes_val) { return managed_bytes_opt(bytes_val); },
+            [](managed_bytes&& managed_bytes_val) { return managed_bytes_opt(std::move(managed_bytes_val)); },
+            [](null_value&&) -> managed_bytes_opt {
+                return std::nullopt;
+            },
+            [](unset_value&&) -> managed_bytes_opt {
+                return std::nullopt;
+            }
+        }, std::move(_data));
+    }
     raw_value_view to_view() const;
     friend class raw_value_view;
 };

--- a/database.cc
+++ b/database.cc
@@ -53,6 +53,7 @@
 #include "db/schema_tables.hh"
 #include "compaction/compaction_manager.hh"
 #include "gms/feature_service.hh"
+#include "timeout_config.hh"
 
 #include "utils/human_readable.hh"
 #include "utils/fb_utilities.hh"

--- a/test/boost/statement_restrictions_test.cc
+++ b/test/boost/statement_restrictions_test.cc
@@ -460,7 +460,10 @@ BOOST_AUTO_TEST_CASE(expression_extract_column_restrictions) {
     expression token_expr = token{};
     expression pk1_expr = column_value(&col_pk1);
     expression pk2_expr = column_value(&col_pk1);
-    expression pk1_pk2_expr = tuple_constructor{{expression{column_value{&col_pk1}}, expression{column_value{&col_pk2}}}};
+    data_type ttype = tuple_type_impl::get_instance({int32_type, int32_type});
+    expression pk1_pk2_expr = tuple_constructor{{expression{column_value{&col_pk1}},
+                                                 expression{column_value{&col_pk2}}},
+                                                std::move(ttype)};
 
     big_where.push_back(pk1_restriction);
     big_where.push_back(pk2_restriction);

--- a/test/boost/user_types_test.cc
+++ b/test/boost/user_types_test.cc
@@ -580,7 +580,7 @@ SEASTAR_TEST_CASE(test_nonfrozen_user_types_prepared) {
         BOOST_REQUIRE_EXCEPTION(
             execute_prepared("insert into cf (a, b) values (?, ?)", {mk_int(4), mk_longer_tuple({4, "text4", int64_t(4), 5})}),
             exceptions::invalid_request_exception,
-            exception_predicate::message_equals("User Defined Type value contained too many fields (expected 3, got 4)"));
+            exception_predicate::message_contains("contained too many fields (expected 3, got 4)"));
     });
 }
 

--- a/types.hh
+++ b/types.hh
@@ -614,6 +614,9 @@ public:
 private:
     mutable sstring _cql3_type_name;
 protected:
+    bool _contains_set_or_map = false;
+    bool _contains_collection = false;
+
     // native_value_* methods are virualized versions of native_type's
     // sizeof/alignof/copy-ctor/move-ctor etc.
     void* native_value_clone(const void* from) const;
@@ -829,7 +832,10 @@ class reversed_type_impl : public abstract_type {
         : abstract_type(kind::reversed, "org.apache.cassandra.db.marshal.ReversedType(" + t->name() + ")",
                         t->value_length_if_fixed())
         , _underlying_type(t)
-    {}
+    {
+        _contains_set_or_map = _underlying_type->contains_set_or_map();
+        _contains_collection = _underlying_type->contains_collection();
+    }
 public:
     const data_type& underlying_type() const {
         return _underlying_type;

--- a/types.hh
+++ b/types.hh
@@ -600,6 +600,12 @@ public:
         return is_reversed() ? *underlying_type() : *this;
     }
 
+    // Checks whether there can be a set or map somewhere inside a value of this type.
+    bool contains_set_or_map() const;
+
+    // Checks whether there can be a collection somewhere inside a value of this type.
+    bool contains_collection() const;
+
     friend class list_type_impl;
 private:
     mutable sstring _cql3_type_name;

--- a/types.hh
+++ b/types.hh
@@ -606,6 +606,10 @@ public:
     // Checks whether there can be a collection somewhere inside a value of this type.
     bool contains_collection() const;
 
+    // Checks whether a bound value of this type has to be reserialized.
+    // This can be for example because there is a set inside that needs to be sorted.
+    bool bound_value_needs_to_be_reserialized(const cql_serialization_format& sf) const;
+
     friend class list_type_impl;
 private:
     mutable sstring _cql3_type_name;

--- a/types/collection.hh
+++ b/types/collection.hh
@@ -46,7 +46,9 @@ public:
 protected:
     bool _is_multi_cell;
     explicit collection_type_impl(kind k, sstring name, bool is_multi_cell)
-            : abstract_type(k, std::move(name), {}), _is_multi_cell(is_multi_cell) {}
+            : abstract_type(k, std::move(name), {}), _is_multi_cell(is_multi_cell) {
+                _contains_collection = true;
+            }
 public:
     bool is_multi_cell() const { return _is_multi_cell; }
     virtual data_type name_comparator() const = 0;

--- a/types/tuple.hh
+++ b/types/tuple.hh
@@ -214,6 +214,7 @@ public:
         return ret;
     }
 private:
+    void set_contains_collections();
     static sstring make_name(const std::vector<data_type>& types);
     friend abstract_type;
 };


### PR DESCRIPTION
This PR adds the function:
```c++
constant evaluate(const expression&, const query_options&);
```
which evaluates the given expression to a constant value.
It binds all the bound values, calls functions, and reduces the whole expression to just raw bytes and `data_type`, just like `bind()` and `get()` did for `term`.

The code is often similar to the original `bind()` implementation in `lists.cc`, `sets.cc`, etc.

## Notes:
* For some reason in the original code, when a collection contains `unset_value`, then the whole collection is evaluated to `unset_value`. I'm not sure why this is the case, considering it's impossible to have `unset_value` inside a collection, because we forbid bind markers inside collections. For example here: https://github.com/scylladb/scylla/blob/cc8fc737614b537042bc6e6d5048628a8538677a/cql3/lists.cc#L134
This seems to have been introduced by Pekka Enberg in 50ec81ee671351254e60c9fa83d858bbedd0b9f0, but he has left the company.
I didn't change the behaviour, maybe there is a reason behind it, although maybe it would be better to just throw `invalid_request_exception`.
* There was a strange limitation on map key size, it seems incorrect: https://github.com/scylladb/scylla/blob/cc8fc737614b537042bc6e6d5048628a8538677a/cql3/maps.cc#L150, but I left it in.
* When evaluating a `user_type` value, the old code tolerated `unset_value` in a field, but it was later converted to NULL. This means that `unset_value` doesn't work inside a `user_type`, I didn't change it, will do in another PR.
* We can't fully get rid of `bind()` yet, because it's used in `prepare_term` to return a `terminal`. It will be removed in the next PR, where we finally get rid of `term`.