### PR TITLE
cql-pytest: relax error conditions for a failed wasm execution

### DIFF
--- a/test/cql-pytest/test_wasm.py
+++ b/test/cql-pytest/test_wasm.py
@@ -83,7 +83,7 @@ def test_fib(cql, test_keyspace, table1, scylla_with_wasm_only):
 
         cql.execute(f"INSERT INTO {table} (p) VALUES (997)")
         # The call request takes too much time and resources, and should therefore fail
-        with pytest.raises(InvalidRequest, match="fuel consumed"):
+        with pytest.raises(InvalidRequest, match="wasm"):
             cql.execute(f"SELECT {test_keyspace}.{fib_name}(p) AS result FROM {table} WHERE p = 997")
 
 # Test that calling a fibonacci function that claims to accept null input works.


### PR DESCRIPTION
Originally, the expected failure for a recursive invocation
test case was to expect that fuel gets exhausted, but it's also
possible to hit a stack limit first. All errors are equally
expected here as long as the execution is halted, so let's relax
the condition and accept any wasm-related InvalidRequest errors.