### PR TITLE
cql-pytest: relax another condition for a failed wasm execution

### DIFF
--- a/test/cql-pytest/test_wasm.py
+++ b/test/cql-pytest/test_wasm.py
@@ -316,7 +316,7 @@ def test_fib_called_on_null(cql, test_keyspace, table1, scylla_with_wasm_only):
 
         cql.execute(f"INSERT INTO {table} (p) VALUES (997)")
         # The call request takes too much time and resources, and should therefore fail
-        with pytest.raises(InvalidRequest, match="fuel consumed"):
+        with pytest.raises(InvalidRequest, match="wasm"):
           cql.execute(f"SELECT {test_keyspace}.{fib_name}(p) AS result FROM {table} WHERE p = 997")
 
 # Test that an infinite loop gets broken out of eventually


### PR DESCRIPTION
The previous commit already relaxed the condition for test_fib,
but the same should be done for test_fib_called_on_null
for an identical reason - more than 1 error can be expected
in the case of calling heavily recursive function, and either
fuel exhaustion, or hitting the stack limit, or any other
InvalidRequest exception should be accepted.

Note that `test_infinite_loop` is not amended the same way - that's because the only expected error in there is actual fuel consumption - neither stack nor allocations, nor anything else should be problematic.