### PR TITLE
schema: add get_reversed()

### DIFF
--- a/schema.cc
+++ b/schema.cc
@@ -1595,6 +1595,12 @@ schema_ptr schema::make_reversed() const {
     return make_lw_shared<schema>(schema::reversed_tag{}, *this);
 }
 
+schema_ptr schema::get_reversed() const {
+    return local_schema_registry().get_or_load(utils::UUID_gen::negate(_raw._version), [this] (table_schema_version) {
+        return frozen_schema(make_reversed());
+    });
+}
+
 raw_view_info::raw_view_info(utils::UUID base_id, sstring base_name, bool include_all_columns, sstring where_clause)
         : _base_id(std::move(base_id))
         , _base_name(std::move(base_name))

--- a/schema.hh
+++ b/schema.hh
@@ -986,6 +986,19 @@ public:
     // different C++ objects).
     // The schema's version is also reversed using UUID_gen::negate().
     schema_ptr make_reversed() const;
+
+    // Get the reversed counterpart of this schema from the schema registry.
+    //
+    // If not present in the registry, create one (via \ref make_reversed()) and
+    // load it. Unlike \ref make_reversed(), this method guarantees that double
+    // reversing will return the very same C++ object:
+    //
+    //      auto schema = make_schema();
+    //      auto reverse_schema = schema->get_reversed();
+    //      assert(reverse_schema->get_reversed().get() == schema.get());
+    //      assert(schema->get_reversed().get() == reverse_schema.get());
+    //
+    schema_ptr get_reversed() const;
 };
 
 lw_shared_ptr<const schema> make_shared_schema(std::optional<utils::UUID> id, std::string_view ks_name, std::string_view cf_name,

--- a/test/boost/schema_change_test.cc
+++ b/test/boost/schema_change_test.cc
@@ -835,3 +835,23 @@ SEASTAR_TEST_CASE(test_schema_make_reversed) {
 
     return make_ready_future<>();
 }
+
+SEASTAR_TEST_CASE(test_schema_get_reversed) {
+    return do_with_cql_env([this] (cql_test_env& e) {
+        auto schema = schema_builder("tests", get_name())
+                .with_column("pk", bytes_type, column_kind::partition_key)
+                .with_column("ck", bytes_type, column_kind::clustering_key)
+                .with_column("v1", bytes_type)
+                .build();
+        schema = local_schema_registry().learn(schema);
+        auto reversed_schema = schema->get_reversed();
+
+        testlog.info("        &schema: {}", fmt::ptr(schema.get()));
+        testlog.info("&reverse_schema: {}", fmt::ptr(reversed_schema.get()));
+
+        BOOST_REQUIRE_EQUAL(reversed_schema->get_reversed().get(), schema.get());
+        BOOST_REQUIRE_EQUAL(schema->get_reversed().get(), reversed_schema.get());
+
+        return make_ready_future<>();
+    });
+}


### PR DESCRIPTION
A variant of make_reversed() which goes through the schema registry,
teaching the schema to the registry if necessary. This effectively
caches the result of the reversing and as an added bonus double
reversing yields the very same schema C++ object that was the starting
point.