### PR TITLE
cql3: Add expr::constant to replace terminal

### DIFF
--- a/cql3/attributes.cc
+++ b/cql3/attributes.cc
@@ -71,7 +71,7 @@ int64_t attributes::get_timestamp(int64_t now, const query_options& options) {
         return now;
     }
 
-    auto tval = _timestamp->bind_and_get(options);
+    auto tval = expr::evaluate_to_raw_view(_timestamp, options);
     if (tval.is_null()) {
         throw exceptions::invalid_request_exception("Invalid null value of timestamp");
     }
@@ -89,7 +89,7 @@ int32_t attributes::get_time_to_live(const query_options& options) {
     if (!_time_to_live)
         return 0;
 
-    auto tval = _time_to_live->bind_and_get(options);
+    auto tval = expr::evaluate_to_raw_view(_time_to_live, options);
     if (tval.is_null()) {
         throw exceptions::invalid_request_exception("Invalid null value of TTL");
     }
@@ -119,7 +119,7 @@ int32_t attributes::get_time_to_live(const query_options& options) {
 
 
 db::timeout_clock::duration attributes::get_timeout(const query_options& options) const {
-    auto timeout = _timeout->bind_and_get(options);
+    auto timeout = expr::evaluate_to_raw_view(_timeout, options);
     if (timeout.is_null() || timeout.is_unset_value()) {
         throw exceptions::invalid_request_exception("Timeout value cannot be unset/null");
     }

--- a/cql3/column_condition.cc
+++ b/cql3/column_condition.cc
@@ -258,11 +258,11 @@ bool column_condition::applies_to(const data_value* cell_value, const query_opti
     std::vector<bytes_opt> in_values;
 
     if (_value) {
-        auto&& lval = dynamic_pointer_cast<multi_item_terminal>(_value->bind(options));
-        if (!lval) {
+        expr::constant lval = expr::evaluate(_value, options);
+        if (lval.is_null()) {
             throw exceptions::invalid_request_exception("Invalid null value for IN condition");
         }
-        for (const managed_bytes_opt& v : lval->copy_elements()) {
+        for (const managed_bytes_opt& v : expr::get_elements(lval)) {
             if (v) {
                 in_values.push_back(to_bytes(*v));
             } else {

--- a/cql3/column_condition.cc
+++ b/cql3/column_condition.cc
@@ -155,7 +155,7 @@ bool column_condition::applies_to(const data_value* cell_value, const query_opti
         assert(cell_value->type()->is_collection());
         const collection_type_impl& cell_type = static_cast<const collection_type_impl&>(*cell_value->type());
 
-        cql3::raw_value_view key = _collection_element->bind_and_get(options);
+        cql3::raw_value_view key = expr::evaluate_to_raw_view(_collection_element, options);
         if (key.is_unset_value()) {
             throw exceptions::invalid_request_exception(
                     format("Invalid 'unset' value in {} element access", cell_type.cql3_type_name()));
@@ -211,7 +211,7 @@ bool column_condition::applies_to(const data_value* cell_value, const query_opti
 
     if (is_compare(_op)) {
         // <, >, >=, <=, !=
-        cql3::raw_value_view param = _value->bind_and_get(options);
+        cql3::raw_value_view param = expr::evaluate_to_raw_view(_value, options);
 
         if (param.is_unset_value()) {
             throw exceptions::invalid_request_exception("Invalid 'unset' value in condition");
@@ -228,7 +228,7 @@ bool column_condition::applies_to(const data_value* cell_value, const query_opti
             // The condition parameter is not null, so only NEQ can return true
             return _op == expr::oper_t::NEQ;
         }
-        // type::validate() is called by bind_and_get(), so it's safe to pass to_bytes() result
+        // type::validate() is called earlier when creating the value, so it's safe to pass to_bytes() result
         // directly to compare.
         return is_satisfied_by(_op, *cell_value->type(), *column.type, *cell_value, to_bytes(param));
     }
@@ -240,7 +240,7 @@ bool column_condition::applies_to(const data_value* cell_value, const query_opti
         if (_matcher) {
             return (*_matcher)(bytes_view(cell_value->serialize_nonnull()));
         } else {
-            auto param = _value->bind_and_get(options);  // LIKE pattern
+            auto param = expr::evaluate_to_raw_view(_value, options);  // LIKE pattern
             if (param.is_unset_value()) {
                 throw exceptions::invalid_request_exception("Invalid 'unset' value in LIKE pattern");
             }
@@ -271,7 +271,7 @@ bool column_condition::applies_to(const data_value* cell_value, const query_opti
         }
     } else {
         for (auto&& v : _in_values) {
-            in_values.emplace_back(to_bytes_opt(v->bind_and_get(options)));
+            in_values.emplace_back(to_bytes_opt(expr::evaluate_to_raw_view(v, options)));
         }
     }
     // If cell value is NULL, IN list must contain NULL or an empty set/list. Otherwise it must contain cell value.

--- a/cql3/constants.cc
+++ b/cql3/constants.cc
@@ -47,10 +47,6 @@ namespace cql3 {
 thread_local const ::shared_ptr<constants::value> constants::UNSET_VALUE = ::make_shared<constants::value>(cql3::raw_value::make_unset_value(), empty_type);
 thread_local const ::shared_ptr<terminal> constants::NULL_VALUE = ::make_shared<constants::null_value>();
 
-data_type constants::value::get_value_type() const {
-    return _my_type;
-}
-
 void constants::deleter::execute(mutation& m, const clustering_key_prefix& prefix, const update_parameters& params) {
     if (column.type->is_multi_cell()) {
         collection_mutation_description coll_m;

--- a/cql3/constants.cc
+++ b/cql3/constants.cc
@@ -44,11 +44,11 @@
 
 namespace cql3 {
 
-thread_local const ::shared_ptr<constants::value> constants::UNSET_VALUE = ::make_shared<constants::value>(cql3::raw_value::make_unset_value());
+thread_local const ::shared_ptr<constants::value> constants::UNSET_VALUE = ::make_shared<constants::value>(cql3::raw_value::make_unset_value(), empty_type);
 thread_local const ::shared_ptr<terminal> constants::NULL_VALUE = ::make_shared<constants::null_value>();
 
 data_type constants::value::get_value_type() const {
-    throw std::runtime_error(fmt::format("get_value_type not implemented {}:{}", __FILE__, __LINE__));
+    return _my_type;
 }
 
 void constants::deleter::execute(mutation& m, const clustering_key_prefix& prefix, const update_parameters& params) {

--- a/cql3/constants.cc
+++ b/cql3/constants.cc
@@ -47,6 +47,10 @@ namespace cql3 {
 thread_local const ::shared_ptr<constants::value> constants::UNSET_VALUE = ::make_shared<constants::value>(cql3::raw_value::make_unset_value());
 thread_local const ::shared_ptr<terminal> constants::NULL_VALUE = ::make_shared<constants::null_value>();
 
+data_type constants::value::get_value_type() const {
+    throw std::runtime_error(fmt::format("get_value_type not implemented {}:{}", __FILE__, __LINE__));
+}
+
 void constants::deleter::execute(mutation& m, const clustering_key_prefix& prefix, const update_parameters& params) {
     if (column.type->is_multi_cell()) {
         collection_mutation_description coll_m;

--- a/cql3/constants.hh
+++ b/cql3/constants.hh
@@ -66,7 +66,8 @@ public:
     class value : public terminal {
     public:
         cql3::raw_value _bytes;
-        value(cql3::raw_value bytes_) : _bytes(std::move(bytes_)) {}
+        data_type _my_type;
+        value(cql3::raw_value bytes_, data_type my_type) : _bytes(std::move(bytes_)), _my_type(std::move(my_type)) {}
         virtual cql3::raw_value get(const query_options& options) override { return _bytes; }
         virtual cql3::raw_value_view bind_and_get(const query_options& options) override { return _bytes.to_view(); }
         virtual sstring to_string() const override { return _bytes.to_view().with_value([] (const FragmentedView auto& v) { return to_hex(v); }); }
@@ -77,7 +78,7 @@ public:
 
     class null_value final : public value {
     public:
-        null_value() : value(cql3::raw_value::make_null()) {}
+        null_value() : value(cql3::raw_value::make_null(), empty_type) {}
         virtual ::shared_ptr<terminal> bind(const query_options& options) override { return {}; }
         virtual sstring to_string() const override { return "null"; }
     };
@@ -113,7 +114,7 @@ public:
             if (bytes.is_unset_value()) {
                 return UNSET_VALUE;
             }
-            return ::make_shared<constants::value>(cql3::raw_value::make_value(bytes));
+            return ::make_shared<constants::value>(cql3::raw_value::make_value(bytes), _receiver->type);
         }
     };
 

--- a/cql3/constants.hh
+++ b/cql3/constants.hh
@@ -66,12 +66,10 @@ public:
     class value : public terminal {
     public:
         cql3::raw_value _bytes;
-        data_type _my_type;
-        value(cql3::raw_value bytes_, data_type my_type) : _bytes(std::move(bytes_)), _my_type(std::move(my_type)) {}
+        value(cql3::raw_value bytes_, data_type my_type) : terminal(std::move(my_type)), _bytes(std::move(bytes_)) {}
         virtual cql3::raw_value get(const query_options& options) override { return _bytes; }
         virtual cql3::raw_value_view bind_and_get(const query_options& options) override { return _bytes.to_view(); }
         virtual sstring to_string() const override { return _bytes.to_view().with_value([] (const FragmentedView auto& v) { return to_hex(v); }); }
-        data_type get_value_type() const override;
     };
 
     static thread_local const ::shared_ptr<value> UNSET_VALUE;

--- a/cql3/constants.hh
+++ b/cql3/constants.hh
@@ -121,7 +121,7 @@ public:
         using operation::operation;
 
         virtual void execute(mutation& m, const clustering_key_prefix& prefix, const update_parameters& params) override {
-            auto value = _t->bind_and_get(params._options);
+            auto value = expr::evaluate_to_raw_view(_t, params._options);
             execute(m, prefix, params, column, std::move(value));
         }
 
@@ -138,7 +138,7 @@ public:
         using operation::operation;
 
         virtual void execute(mutation& m, const clustering_key_prefix& prefix, const update_parameters& params) override {
-            auto value = _t->bind_and_get(params._options);
+            auto value = expr::evaluate_to_raw_view(_t, params._options);
             if (value.is_null()) {
                 throw exceptions::invalid_request_exception("Invalid null value for counter increment");
             } else if (value.is_unset_value()) {
@@ -153,7 +153,7 @@ public:
         using operation::operation;
 
         virtual void execute(mutation& m, const clustering_key_prefix& prefix, const update_parameters& params) override {
-            auto value = _t->bind_and_get(params._options);
+            auto value = expr::evaluate_to_raw_view(_t, params._options);
             if (value.is_null()) {
                 throw exceptions::invalid_request_exception("Invalid null value for counter increment");
             } else if (value.is_unset_value()) {

--- a/cql3/constants.hh
+++ b/cql3/constants.hh
@@ -70,6 +70,7 @@ public:
         virtual cql3::raw_value get(const query_options& options) override { return _bytes; }
         virtual cql3::raw_value_view bind_and_get(const query_options& options) override { return _bytes.to_view(); }
         virtual sstring to_string() const override { return _bytes.to_view().with_value([] (const FragmentedView auto& v) { return to_hex(v); }); }
+        data_type get_value_type() const override;
     };
 
     static thread_local const ::shared_ptr<value> UNSET_VALUE;

--- a/cql3/expr/expression.cc
+++ b/cql3/expr/expression.cc
@@ -1340,5 +1340,38 @@ std::optional<bool> get_bool_value(const constant& constant_val) {
 
     return constant_val.value.to_view().deserialize<bool>(*boolean_type);
 }
+
+constant evaluate(term* term_ptr, const query_options& options) {
+    if (term_ptr == nullptr) {
+        return constant::make_null();
+    }
+
+    ::shared_ptr<terminal> bound = term_ptr->bind(options);
+    if (bound.get() == nullptr) {
+        return constant::make_null();
+    }
+
+    raw_value raw_val = bound->get(options);
+    data_type val_type = bound->get_value_type();
+    return constant(std::move(raw_val), std::move(val_type));
+}
+
+constant evaluate(const ::shared_ptr<term>& term_ptr, const query_options& options) {
+    return evaluate(term_ptr.get(), options);
+}
+
+constant evaluate(term& term_ref, const query_options& options) {
+    return evaluate(&term_ref, options);
+}
+
+cql3::raw_value_view evaluate_to_raw_view(const ::shared_ptr<term>& term_ptr, const query_options& options) {
+    constant value = evaluate(term_ptr, options);
+    return cql3::raw_value_view::make_temporary(std::move(value.value));
+}
+
+cql3::raw_value_view evaluate_to_raw_view(term& term_ref, const query_options& options) {
+    constant value = evaluate(term_ref, options);
+    return cql3::raw_value_view::make_temporary(std::move(value.value));
+}
 } // namespace expr
 } // namespace cql3

--- a/cql3/expr/expression.hh
+++ b/cql3/expr/expression.hh
@@ -542,7 +542,6 @@ std::optional<bool> get_bool_value(const constant&);
 
 // Takes a prepared expression and calculates its value.
 // Later term will be replaced with expression.
-// For now throws because terminal::get_value() is not implemented
 constant evaluate(const ::shared_ptr<term>&, const query_options&);
 constant evaluate(term*, const query_options&);
 constant evaluate(term&, const query_options&);

--- a/cql3/expr/expression.hh
+++ b/cql3/expr/expression.hh
@@ -546,6 +546,12 @@ constant evaluate(const ::shared_ptr<term>&, const query_options&);
 constant evaluate(term*, const query_options&);
 constant evaluate(term&, const query_options&);
 
+// Similar to evaluate(), but ignores any NULL values in the final list value.
+// In an IN restriction nulls can be ignored, because nothing equals NULL.
+constant evaluate_IN_list(const ::shared_ptr<term>&, const query_options&);
+constant evaluate_IN_list(term*, const query_options&);
+constant evaluate_IN_list(term&, const query_options&);
+
 // Calls evaluate() on the term and then converts the constant to raw_value_view
 cql3::raw_value_view evaluate_to_raw_view(const ::shared_ptr<term>&, const query_options&);
 cql3::raw_value_view evaluate_to_raw_view(term&, const query_options&);

--- a/cql3/expr/expression.hh
+++ b/cql3/expr/expression.hh
@@ -83,14 +83,15 @@ class field_selection;
 struct null;
 struct bind_variable;
 struct untyped_constant;
+struct constant;
 struct tuple_constructor;
 struct collection_constructor;
 struct usertype_constructor;
 
 /// A CQL expression -- union of all possible expression types.  bool means a Boolean constant.
-using expression = std::variant<bool, conjunction, binary_operator, column_value, token,
+using expression = std::variant<conjunction, binary_operator, column_value, token,
                                 unresolved_identifier, column_mutation_attribute, function_call, cast,
-                                field_selection, null, bind_variable, untyped_constant,
+                                field_selection, null, bind_variable, untyped_constant, constant,
                                 tuple_constructor, collection_constructor, usertype_constructor>;
 
 template <typename T>
@@ -106,6 +107,7 @@ concept LeafExpression
         || std::same_as<null, E> 
         || std::same_as<bind_variable, E> 
         || std::same_as<untyped_constant, E> 
+        || std::same_as<constant, E>
         ;
 
 // An expression variant element can't contain an expression by value, since the size of the variant
@@ -215,6 +217,26 @@ struct untyped_constant {
     sstring raw_text;
 };
 
+// Represents a constant value with known value and type
+// For null and unset the type can sometimes be set to empty_type
+struct constant {
+    // A value serialized using the internal (latest) cql_serialization_format
+    cql3::raw_value value;
+
+    // Never nullptr, for NULL and UNSET might be empty_type
+    data_type type;
+
+    constant(cql3::raw_value value, data_type type);
+    static constant make_null(data_type val_type = empty_type);
+    static constant make_unset_value(data_type val_type = empty_type);
+    static constant make_bool(bool bool_val);
+
+    bool is_null() const;
+    bool is_unset_value() const;
+    bool is_null_or_unset() const;
+    bool has_empty_value_bytes() const;
+};
+
 // Denotes construction of a tuple from its elements, e.g.  ('a', ?, some_column) in CQL.
 struct tuple_constructor {
     std::vector<expression> elements;
@@ -292,7 +314,7 @@ requires std::regular_invocable<Fn, const binary_operator&>
 const binary_operator* find_atom(const expression& e, Fn f) {
     return std::visit(overloaded_functor{
             [&] (const binary_operator& op) { return f(op) ? &op : nullptr; },
-            [] (bool) -> const binary_operator* { return nullptr; },
+            [] (const constant&) -> const binary_operator* { return nullptr; },
             [&] (const conjunction& conj) -> const binary_operator* {
                 for (auto& child : conj.children) {
                     if (auto found = find_atom(child, f)) {
@@ -365,7 +387,7 @@ size_t count_if(const expression& e, Fn f) {
                 return std::accumulate(conj.children.cbegin(), conj.children.cend(), size_t{0},
                                        [&] (size_t acc, const expression& c) { return acc + count_if(c, f); });
             },
-            [] (bool) -> size_t { return 0; },
+            [] (const constant&) -> size_t { return 0; },
             [] (const column_value&) -> size_t { return 0; },
             [] (const token&) -> size_t { return 0; },
             [] (const unresolved_identifier&) -> size_t { return 0; },
@@ -516,6 +538,7 @@ nested_expression::nested_expression(ExpressionElement auto e)
 // For example "WHERE c = 1 AND (a, c) = (2, 1) AND token(p) < 2 AND FALSE" will return {"c = 1"}.
 std::vector<expression> extract_single_column_restrictions_for_column(const expression&, const column_definition&);
 
+std::optional<bool> get_bool_value(const constant&);
 } // namespace expr
 
 } // namespace cql3

--- a/cql3/expr/expression.hh
+++ b/cql3/expr/expression.hh
@@ -555,6 +555,19 @@ constant evaluate_IN_list(term&, const query_options&);
 // Calls evaluate() on the term and then converts the constant to raw_value_view
 cql3::raw_value_view evaluate_to_raw_view(const ::shared_ptr<term>&, const query_options&);
 cql3::raw_value_view evaluate_to_raw_view(term&, const query_options&);
+
+utils::chunked_vector<managed_bytes> get_list_elements(const constant&);
+utils::chunked_vector<managed_bytes> get_set_elements(const constant&);
+std::vector<managed_bytes_opt> get_tuple_elements(const constant&);
+std::vector<managed_bytes_opt> get_user_type_elements(const constant&);
+std::vector<std::pair<managed_bytes, managed_bytes>> get_map_elements(const constant&);
+
+// Gets the elements of a constant which can be a list, set, tuple or user type
+std::vector<managed_bytes_opt> get_elements(const constant&);
+
+// Get elements of list<tuple<>> as vector<vector<managed_bytes_opt>
+// It is useful with IN restrictions like (a, b) IN [(1, 2), (3, 4)].
+utils::chunked_vector<std::vector<managed_bytes_opt>> get_list_of_tuples_elements(const constant&);
 } // namespace expr
 
 } // namespace cql3

--- a/cql3/expr/expression.hh
+++ b/cql3/expr/expression.hh
@@ -539,6 +539,17 @@ nested_expression::nested_expression(ExpressionElement auto e)
 std::vector<expression> extract_single_column_restrictions_for_column(const expression&, const column_definition&);
 
 std::optional<bool> get_bool_value(const constant&);
+
+// Takes a prepared expression and calculates its value.
+// Later term will be replaced with expression.
+// For now throws because terminal::get_value() is not implemented
+constant evaluate(const ::shared_ptr<term>&, const query_options&);
+constant evaluate(term*, const query_options&);
+constant evaluate(term&, const query_options&);
+
+// Calls evaluate() on the term and then converts the constant to raw_value_view
+cql3::raw_value_view evaluate_to_raw_view(const ::shared_ptr<term>&, const query_options&);
+cql3::raw_value_view evaluate_to_raw_view(term&, const query_options&);
 } // namespace expr
 
 } // namespace cql3

--- a/cql3/expr/term_expr.cc
+++ b/cql3/expr/term_expr.cc
@@ -619,7 +619,8 @@ untyped_constant_prepare_term(const untyped_constant& uc, database& db, const ss
         throw exceptions::invalid_request_exception(format("Invalid {} constant ({}) for \"{}\" of type {}",
             uc.partial_type, uc.raw_text, *receiver->name, receiver->type->as_cql3_type().to_string()));
     }
-    return ::make_shared<constants::value>(cql3::raw_value::make_value(untyped_constant_parsed_value(uc, receiver->type)));
+    raw_value raw_val = cql3::raw_value::make_value(untyped_constant_parsed_value(uc, receiver->type));
+    return ::make_shared<constants::value>(std::move(raw_val), receiver->type);
 }
 
 static

--- a/cql3/expr/term_expr.cc
+++ b/cql3/expr/term_expr.cc
@@ -787,8 +787,8 @@ cast_prepare_term(const cast& c, database& db, const sstring& keyspace, lw_share
 ::shared_ptr<term>
 prepare_term(const expression& expr, database& db, const sstring& keyspace, lw_shared_ptr<column_specification> receiver) {
     return std::visit(overloaded_functor{
-        [&] (bool bool_constant) -> ::shared_ptr<term> {
-            on_internal_error(expr_logger, "bool constants are not yet reachable via term_raw_expr::prepare()");
+        [] (const constant&) -> ::shared_ptr<term> {
+            on_internal_error(expr_logger, "Can't prepare constant_value, it should not appear in parser output");
         },
         [&] (const binary_operator&) -> ::shared_ptr<term> {
             on_internal_error(expr_logger, "binary_operators are not yet reachable via term_raw_expr::prepare()");
@@ -874,8 +874,9 @@ assignment_testable::test_result
 test_assignment(const expression& expr, database& db, const sstring& keyspace, const column_specification& receiver) {
     using test_result = assignment_testable::test_result;
     return std::visit(overloaded_functor{
-        [&] (bool bool_constant) -> test_result {
-            on_internal_error(expr_logger, "bool constants are not yet reachable via term_raw_expr::test_assignment()");
+        [&] (const constant&) -> test_result {
+            // constants shouldn't appear in parser output, only untyped_constants
+            on_internal_error(expr_logger, "constants are not yet reachable via term_raw_expr::test_assignment()");
         },
         [&] (const binary_operator&) -> test_result {
             on_internal_error(expr_logger, "binary_operators are not yet reachable via term_raw_expr::test_assignment()");

--- a/cql3/expr/term_expr.cc
+++ b/cql3/expr/term_expr.cc
@@ -405,7 +405,7 @@ list_prepare_term(const collection_constructor& c, database& db, const sstring& 
         }
         values.push_back(std::move(t));
     }
-    lists::delayed_value value(values);
+    lists::delayed_value value(values, receiver->type);
     if (all_terminal) {
         return value.bind(query_options::DEFAULT);
     } else {

--- a/cql3/expr/term_expr.cc
+++ b/cql3/expr/term_expr.cc
@@ -325,10 +325,8 @@ set_prepare_term(const collection_constructor& c, database& db, const sstring& k
 
         values.push_back(std::move(t));
     }
-    auto compare = dynamic_cast<const set_type_impl&>(receiver->type->without_reversed())
-            .get_elements_type()->as_less_comparator();
 
-    auto value = ::make_shared<sets::delayed_value>(compare, std::move(values));
+    auto value = ::make_shared<sets::delayed_value>(std::move(values), receiver->type);
     if (all_terminal) {
         return value->bind(query_options::DEFAULT);
     } else {

--- a/cql3/functions/function_call.hh
+++ b/cql3/functions/function_call.hh
@@ -76,9 +76,10 @@ public:
         _id = id;
     }
     virtual shared_ptr<terminal> bind(const query_options& options) override;
-    virtual cql3::raw_value_view bind_and_get(const query_options& options) override;
 public:
     virtual bool contains_bind_marker() const override;
+private:
+    cql3::raw_value_view bind_and_get_internal(const query_options& options);
 };
 
 ::shared_ptr<term> prepare_function_call(const expr::function_call& fc, database& db, const sstring& keyspace, lw_shared_ptr<column_specification> receiver);

--- a/cql3/functions/functions.cc
+++ b/cql3/functions/functions.cc
@@ -550,7 +550,7 @@ make_terminal(shared_ptr<function> fun, cql3::raw_value result, cql_serializatio
         if (type.is_collection()) {
             throw std::runtime_error(format("function_call::make_terminal: unhandled collection type {}", type.name()));
         }
-        return make_shared<constants::value>(std::move(result));
+        return make_shared<constants::value>(std::move(result), fun->return_type());
     }
     ));
 }

--- a/cql3/functions/functions.cc
+++ b/cql3/functions/functions.cc
@@ -473,7 +473,7 @@ function_call::bind_and_get(const query_options& options) {
     for (auto&& t : _terms) {
         // For now, we don't allow nulls as argument as no existing function needs it and it
         // simplify things.
-        auto val = t->bind_and_get(options);
+        auto val = expr::evaluate_to_raw_view(t, options);
         if (!val) {
             throw exceptions::invalid_request_exception(format("Invalid null value for argument to {}", *_fun));
         }

--- a/cql3/functions/functions.cc
+++ b/cql3/functions/functions.cc
@@ -463,11 +463,11 @@ function_call::fill_prepare_context(prepare_context& ctx) const {
 
 shared_ptr<terminal>
 function_call::bind(const query_options& options) {
-    return make_terminal(_fun, cql3::raw_value::make_value(bind_and_get(options)), options.get_cql_serialization_format());
+    return make_terminal(_fun, cql3::raw_value::make_value(bind_and_get_internal(options)), options.get_cql_serialization_format());
 }
 
 cql3::raw_value_view
-function_call::bind_and_get(const query_options& options) {
+function_call::bind_and_get_internal(const query_options& options) {
     std::vector<bytes_opt> buffers;
     buffers.reserve(_terms.size());
     for (auto&& t : _terms) {

--- a/cql3/lists.cc
+++ b/cql3/lists.cc
@@ -63,7 +63,7 @@ lists::value::from_serialized(const raw_value_view& val, const list_type_impl& t
                 elements.push_back(element.is_null() ? managed_bytes_opt() : managed_bytes_opt(type.get_elements_type()->decompose(element)));
             }
         }
-        return value(std::move(elements));
+        return value(std::move(elements), type.shared_from_this());
     } catch (marshal_exception& e) {
         throw exceptions::invalid_request_exception(e.what());
     }
@@ -95,7 +95,7 @@ lists::value::equals(const list_type_impl& lt, const value& v) {
 }
 
 data_type lists::value::get_value_type() const {
-    throw std::runtime_error(fmt::format("get_value_type not implemented {}:{}", __FILE__, __LINE__));
+    return _my_type;
 }
 
 const utils::chunked_vector<managed_bytes_opt>&
@@ -150,7 +150,7 @@ lists::delayed_value::bind(const query_options& options) {
 
         buffers.push_back(bo.with_value([] (const FragmentedView auto& v) { return managed_bytes(v); }));
     }
-    return ::make_shared<value>(buffers);
+    return ::make_shared<value>(buffers, _my_type);
 }
 
 ::shared_ptr<terminal>

--- a/cql3/lists.cc
+++ b/cql3/lists.cc
@@ -71,7 +71,7 @@ lists::value::from_serialized(const raw_value_view& val, const list_type_impl& t
 
 cql3::raw_value
 lists::value::get(const query_options& options) {
-    return cql3::raw_value::make_value(get_with_protocol_version(options.get_cql_serialization_format()));
+    return cql3::raw_value::make_value(get_with_protocol_version(cql_serialization_format::internal()));
 }
 
 managed_bytes

--- a/cql3/lists.cc
+++ b/cql3/lists.cc
@@ -94,10 +94,6 @@ lists::value::equals(const list_type_impl& lt, const value& v) {
             [t = lt.get_elements_type()] (const managed_bytes_opt& e1, const managed_bytes_opt& e2) { return t->equal(*e1, *e2); });
 }
 
-data_type lists::value::get_value_type() const {
-    return _my_type;
-}
-
 const utils::chunked_vector<managed_bytes_opt>&
 lists::value::get_elements() const {
     return _elements;

--- a/cql3/lists.cc
+++ b/cql3/lists.cc
@@ -135,7 +135,7 @@ lists::delayed_value::bind(const query_options& options) {
     utils::chunked_vector<managed_bytes_opt> buffers;
     buffers.reserve(_elements.size());
     for (auto&& t : _elements) {
-        auto bo = t->bind_and_get(options);
+        auto bo = expr::evaluate_to_raw_view(t, options);
 
         if (bo.is_null()) {
             throw exceptions::invalid_request_exception("null is not supported inside collections");
@@ -154,7 +154,7 @@ lists::delayed_value::bind_ignore_null(const query_options& options) {
     utils::chunked_vector<managed_bytes_opt> buffers;
     buffers.reserve(_elements.size());
     for (auto&& t : _elements) {
-        auto bo = t->bind_and_get(options);
+        auto bo = expr::evaluate_to_raw_view(t, options);
 
         if (bo.is_null()) {
             continue;
@@ -224,14 +224,14 @@ lists::setter_by_index::execute(mutation& m, const clustering_key_prefix& prefix
     // we should not get here for frozen lists
     assert(column.type->is_multi_cell()); // "Attempted to set an individual element on a frozen list";
 
-    auto index = _idx->bind_and_get(params._options);
+    auto index = expr::evaluate_to_raw_view(_idx, params._options);
     if (index.is_null()) {
         throw exceptions::invalid_request_exception("Invalid null value for list index");
     }
     if (index.is_unset_value()) {
         throw exceptions::invalid_request_exception("Invalid unset value for list index");
     }
-    auto value = _t->bind_and_get(params._options);
+    auto value = expr::evaluate_to_raw_view(_t, params._options);
     if (value.is_unset_value()) {
         return;
     }
@@ -273,8 +273,8 @@ lists::setter_by_uuid::execute(mutation& m, const clustering_key_prefix& prefix,
     // we should not get here for frozen lists
     assert(column.type->is_multi_cell()); // "Attempted to set an individual element on a frozen list";
 
-    auto index = _idx->bind_and_get(params._options);
-    auto value = _t->bind_and_get(params._options);
+    auto index = expr::evaluate_to_raw_view(_idx, params._options);
+    auto value = expr::evaluate_to_raw_view(_t, params._options);
 
     if (!index) {
         throw exceptions::invalid_request_exception("Invalid null value for list index");

--- a/cql3/lists.cc
+++ b/cql3/lists.cc
@@ -94,6 +94,10 @@ lists::value::equals(const list_type_impl& lt, const value& v) {
             [t = lt.get_elements_type()] (const managed_bytes_opt& e1, const managed_bytes_opt& e2) { return t->equal(*e1, *e2); });
 }
 
+data_type lists::value::get_value_type() const {
+    throw std::runtime_error(fmt::format("get_value_type not implemented {}:{}", __FILE__, __LINE__));
+}
+
 const utils::chunked_vector<managed_bytes_opt>&
 lists::value::get_elements() const {
     return _elements;

--- a/cql3/lists.cc
+++ b/cql3/lists.cc
@@ -189,13 +189,13 @@ lists::marker::bind(const query_options& options) {
 
 void
 lists::setter::execute(mutation& m, const clustering_key_prefix& prefix, const update_parameters& params) {
-    auto value = _t->bind(params._options);
+    auto value = expr::evaluate(_t, params._options);
     execute(m, prefix, params, column, std::move(value));
 }
 
 void
-lists::setter::execute(mutation& m, const clustering_key_prefix& prefix, const update_parameters& params, const column_definition& column, ::shared_ptr<terminal> value) {
-    if (value == constants::UNSET_VALUE) {
+lists::setter::execute(mutation& m, const clustering_key_prefix& prefix, const update_parameters& params, const column_definition& column, const expr::constant& value) {
+    if (value.is_unset_value()) {
         return;
     }
     if (column.type->is_multi_cell()) {
@@ -296,8 +296,8 @@ lists::setter_by_uuid::execute(mutation& m, const clustering_key_prefix& prefix,
 
 void
 lists::appender::execute(mutation& m, const clustering_key_prefix& prefix, const update_parameters& params) {
-    const auto& value = _t->bind(params._options);
-    if (value == constants::UNSET_VALUE) {
+    const expr::constant value = expr::evaluate(_t, params._options);
+    if (value.is_unset_value()) {
         return;
     }
     assert(column.type->is_multi_cell()); // "Attempted to append to a frozen list";
@@ -305,22 +305,21 @@ lists::appender::execute(mutation& m, const clustering_key_prefix& prefix, const
 }
 
 void
-lists::do_append(shared_ptr<term> value,
+lists::do_append(const expr::constant& list_value,
         mutation& m,
         const clustering_key_prefix& prefix,
         const column_definition& column,
         const update_parameters& params) {
-    auto&& list_value = dynamic_pointer_cast<lists::value>(value);
     if (column.type->is_multi_cell()) {
         // If we append null, do nothing. Note that for Setter, we've
         // already removed the previous value so we're good here too
-        if (!value || value == constants::UNSET_VALUE) {
+        if (list_value.is_null_or_unset()) {
             return;
         }
 
         auto ltype = static_cast<const list_type_impl*>(column.type.get());
 
-        auto&& to_add = list_value->_elements;
+        auto&& to_add = expr::get_list_elements(list_value);
         collection_mutation_description appended;
         appended.cells.reserve(to_add.size());
         for (auto&& e : to_add) {
@@ -332,7 +331,7 @@ lists::do_append(shared_ptr<term> value,
                 // FIXME: can e be empty?
                 appended.cells.emplace_back(
                     std::move(uuid),
-                    params.make_cell(*ltype->value_comparator(), *e, atomic_cell::collection_member::yes));
+                    params.make_cell(*ltype->value_comparator(), e, atomic_cell::collection_member::yes));
             } catch (utils::timeuuid_submicro_out_of_range&) {
                 throw exceptions::invalid_request_exception("Too many list values per single CQL statement or batch");
             }
@@ -340,11 +339,10 @@ lists::do_append(shared_ptr<term> value,
         m.set_cell(prefix, column, appended.serialize(*ltype));
     } else {
         // for frozen lists, we're overwriting the whole cell value
-        if (!value) {
+        if (list_value.is_null()) {
             m.set_cell(prefix, column, params.make_dead_cell());
         } else {
-            auto newv = list_value->get_with_protocol_version(cql_serialization_format::internal());
-            m.set_cell(prefix, column, params.make_cell(*column.type, newv));
+            m.set_cell(prefix, column, params.make_cell(*column.type, list_value.value.to_view()));
         }
     }
 }
@@ -352,13 +350,11 @@ lists::do_append(shared_ptr<term> value,
 void
 lists::prepender::execute(mutation& m, const clustering_key_prefix& prefix, const update_parameters& params) {
     assert(column.type->is_multi_cell()); // "Attempted to prepend to a frozen list";
-    auto&& value = _t->bind(params._options);
-    if (!value || value == constants::UNSET_VALUE) {
+    expr::constant lvalue = expr::evaluate(_t, params._options);
+    if (lvalue.is_null_or_unset()) {
         return;
     }
-
-    auto&& lvalue = dynamic_pointer_cast<lists::value>(std::move(value));
-    assert(lvalue);
+    assert(lvalue.type->is_list());
 
     // For prepend we need to be able to generate a unique but decreasing
     // timeuuid. We achieve that by by using a time in the past which
@@ -383,14 +379,15 @@ lists::prepender::execute(mutation& m, const clustering_key_prefix& prefix, cons
     }
 
     collection_mutation_description mut;
-    mut.cells.reserve(lvalue->_elements.size());
+    utils::chunked_vector<managed_bytes> list_elements = expr::get_list_elements(lvalue);
+    mut.cells.reserve(list_elements.size());
 
     auto ltype = static_cast<const list_type_impl*>(column.type.get());
-    int clockseq = params._options.next_list_prepend_seq(lvalue->_elements.size(), utils::UUID_gen::SUBMICRO_LIMIT);
-    for (auto&& v : lvalue->_elements) {
+    int clockseq = params._options.next_list_prepend_seq(list_elements.size(), utils::UUID_gen::SUBMICRO_LIMIT);
+    for (auto&& v : list_elements) {
         try {
             auto uuid = utils::UUID_gen::get_time_UUID_bytes_from_micros_and_submicros(std::chrono::microseconds{micros}, clockseq++);
-            mut.cells.emplace_back(bytes(uuid.data(), uuid.size()), params.make_cell(*ltype->value_comparator(), *v, atomic_cell::collection_member::yes));
+            mut.cells.emplace_back(bytes(uuid.data(), uuid.size()), params.make_cell(*ltype->value_comparator(), v, atomic_cell::collection_member::yes));
         } catch (utils::timeuuid_submicro_out_of_range&) {
             throw exceptions::invalid_request_exception("Too many list values per single CQL statement or batch");
         }
@@ -409,7 +406,7 @@ lists::discarder::execute(mutation& m, const clustering_key_prefix& prefix, cons
 
     auto&& existing_list = params.get_prefetched_list(m.key(), prefix, column);
     // We want to call bind before possibly returning to reject queries where the value provided is not a list.
-    auto&& value = _t->bind(params._options);
+    expr::constant lvalue = expr::evaluate(_t, params._options);
 
     if (!existing_list) {
         return;
@@ -421,12 +418,11 @@ lists::discarder::execute(mutation& m, const clustering_key_prefix& prefix, cons
         return;
     }
 
-    if (!value || value == constants::UNSET_VALUE) {
+    if (lvalue.is_null_or_unset()) {
         return;
     }
 
-    auto lvalue = dynamic_pointer_cast<lists::value>(value);
-    assert(lvalue);
+    assert(lvalue.type->is_list());
 
     auto ltype = static_cast<const list_type_impl*>(column.type.get());
 
@@ -434,12 +430,12 @@ lists::discarder::execute(mutation& m, const clustering_key_prefix& prefix, cons
     // Meaning that if toDiscard is big, converting it to a HashSet might be more efficient. However,
     // the read-before-write this operation requires limits its usefulness on big lists, so in practice
     // toDiscard will be small and keeping a list will be more efficient.
-    auto&& to_discard = lvalue->_elements;
+    auto&& to_discard = expr::get_list_elements(lvalue);
     collection_mutation_description mnew;
     for (auto&& cell : elist) {
         auto has_value = [&] (bytes_view value) {
             return std::find_if(to_discard.begin(), to_discard.end(),
-                                [ltype, value] (auto&& v) { return ltype->get_elements_type()->equal(*v, value); })
+                                [ltype, value] (auto&& v) { return ltype->get_elements_type()->equal(v, value); })
                                          != to_discard.end();
         };
         bytes eidx = cell.first.type()->decompose(cell.first);
@@ -459,19 +455,16 @@ lists::discarder_by_index::requires_read() const {
 void
 lists::discarder_by_index::execute(mutation& m, const clustering_key_prefix& prefix, const update_parameters& params) {
     assert(column.type->is_multi_cell()); // "Attempted to delete an item by index from a frozen list";
-    auto&& index = _t->bind(params._options);
-    if (!index) {
+    expr::constant index = expr::evaluate(_t, params._options);
+    if (index.is_null()) {
         throw exceptions::invalid_request_exception("Invalid null value for list index");
     }
-    if (index == constants::UNSET_VALUE) {
+    if (index.is_unset_value()) {
         return;
     }
 
-    auto cvalue = dynamic_pointer_cast<constants::value>(index);
-    assert(cvalue);
-
     auto&& existing_list_opt = params.get_prefetched_list(m.key(), prefix, column);
-    int32_t idx = cvalue->_bytes.to_view().deserialize<int32_t>(*int32_type);
+    int32_t idx = index.value.to_view().deserialize<int32_t>(*int32_type);
 
     if (!existing_list_opt) {
         throw exceptions::invalid_request_exception("Attempted to delete an element from a list which is null");

--- a/cql3/lists.cc
+++ b/cql3/lists.cc
@@ -94,16 +94,6 @@ lists::value::equals(const list_type_impl& lt, const value& v) {
             [t = lt.get_elements_type()] (const managed_bytes_opt& e1, const managed_bytes_opt& e2) { return t->equal(*e1, *e2); });
 }
 
-const utils::chunked_vector<managed_bytes_opt>&
-lists::value::get_elements() const {
-    return _elements;
-}
-
-std::vector<managed_bytes_opt>
-lists::value::copy_elements() const {
-    return std::vector<managed_bytes_opt>(_elements.begin(), _elements.end());
-}
-
 sstring
 lists::value::to_string() const {
     std::ostringstream os;

--- a/cql3/lists.hh
+++ b/cql3/lists.hh
@@ -73,6 +73,7 @@ public:
         virtual std::vector<managed_bytes_opt> copy_elements() const override;
         virtual sstring to_string() const override;
         friend class lists;
+        data_type get_value_type() const override;
     };
     /**
      * Basically similar to a Value, but with some non-pure function (that need

--- a/cql3/lists.hh
+++ b/cql3/lists.hh
@@ -61,10 +61,9 @@ public:
     class value : public multi_item_terminal, collection_terminal {
     public:
         utils::chunked_vector<managed_bytes_opt> _elements;
-        data_type _my_type;
     public:
         explicit value(utils::chunked_vector<managed_bytes_opt> elements, data_type my_type)
-            : _elements(std::move(elements)), _my_type(std::move(my_type)) {
+            : multi_item_terminal(std::move(my_type)), _elements(std::move(elements)) {
         }
         static value from_serialized(const raw_value_view& v, const list_type_impl& type, cql_serialization_format sf);
         virtual cql3::raw_value get(const query_options& options) override;
@@ -74,7 +73,6 @@ public:
         virtual std::vector<managed_bytes_opt> copy_elements() const override;
         virtual sstring to_string() const override;
         friend class lists;
-        data_type get_value_type() const override;
     };
     /**
      * Basically similar to a Value, but with some non-pure function (that need

--- a/cql3/lists.hh
+++ b/cql3/lists.hh
@@ -58,19 +58,18 @@ public:
     static lw_shared_ptr<column_specification> value_spec_of(const column_specification&);
     static lw_shared_ptr<column_specification> uuid_index_spec_of(const column_specification&);
 
-    class value : public multi_item_terminal, collection_terminal {
+    class value : public terminal, collection_terminal {
     public:
         utils::chunked_vector<managed_bytes_opt> _elements;
     public:
         explicit value(utils::chunked_vector<managed_bytes_opt> elements, data_type my_type)
-            : multi_item_terminal(std::move(my_type)), _elements(std::move(elements)) {
+            : terminal(std::move(my_type)), _elements(std::move(elements)) {
         }
         static value from_serialized(const raw_value_view& v, const list_type_impl& type, cql_serialization_format sf);
         virtual cql3::raw_value get(const query_options& options) override;
         virtual managed_bytes get_with_protocol_version(cql_serialization_format sf) override;
         bool equals(const list_type_impl& lt, const value& v);
         const utils::chunked_vector<managed_bytes_opt>& get_elements() const;
-        virtual std::vector<managed_bytes_opt> copy_elements() const override;
         virtual sstring to_string() const override;
         friend class lists;
     };

--- a/cql3/lists.hh
+++ b/cql3/lists.hh
@@ -93,6 +93,9 @@ public:
         virtual bool contains_bind_marker() const override;
         virtual void fill_prepare_context(prepare_context& ctx) const override;
         virtual shared_ptr<terminal> bind(const query_options& options) override;
+
+        // Binds the value, but skips all nulls inside the list
+        virtual shared_ptr<terminal> bind_ignore_null(const query_options& options);
         const std::vector<shared_ptr<term>>& get_elements() const {
             return _elements;
         }

--- a/cql3/lists.hh
+++ b/cql3/lists.hh
@@ -61,9 +61,10 @@ public:
     class value : public multi_item_terminal, collection_terminal {
     public:
         utils::chunked_vector<managed_bytes_opt> _elements;
+        data_type _my_type;
     public:
-        explicit value(utils::chunked_vector<managed_bytes_opt> elements)
-            : _elements(std::move(elements)) {
+        explicit value(utils::chunked_vector<managed_bytes_opt> elements, data_type my_type)
+            : _elements(std::move(elements)), _my_type(std::move(my_type)) {
         }
         static value from_serialized(const raw_value_view& v, const list_type_impl& type, cql_serialization_format sf);
         virtual cql3::raw_value get(const query_options& options) override;
@@ -86,9 +87,10 @@ public:
      */
     class delayed_value : public non_terminal {
         std::vector<shared_ptr<term>> _elements;
+        data_type _my_type;
     public:
-        explicit delayed_value(std::vector<shared_ptr<term>> elements)
-                : _elements(std::move(elements)) {
+        explicit delayed_value(std::vector<shared_ptr<term>> elements, data_type my_type)
+                : _elements(std::move(elements)), _my_type(std::move(my_type)) {
         }
         virtual bool contains_bind_marker() const override;
         virtual void fill_prepare_context(prepare_context& ctx) const override;

--- a/cql3/lists.hh
+++ b/cql3/lists.hh
@@ -119,7 +119,7 @@ public:
                 : operation(column, std::move(t)) {
         }
         virtual void execute(mutation& m, const clustering_key_prefix& prefix, const update_parameters& params) override;
-        static void execute(mutation& m, const clustering_key_prefix& prefix, const update_parameters& params, const column_definition& column, ::shared_ptr<terminal> value);
+        static void execute(mutation& m, const clustering_key_prefix& prefix, const update_parameters& params, const column_definition& column, const expr::constant& value);
     };
 
     class setter_by_index : public operation {
@@ -149,7 +149,7 @@ public:
         virtual void execute(mutation& m, const clustering_key_prefix& prefix, const update_parameters& params) override;
     };
 
-    static void do_append(shared_ptr<term> value,
+    static void do_append(const expr::constant& list_value,
             mutation& m,
             const clustering_key_prefix& prefix,
             const column_definition& column,

--- a/cql3/maps.cc
+++ b/cql3/maps.cc
@@ -118,6 +118,10 @@ maps::value::to_string() const {
     abort();
 }
 
+data_type maps::value::get_value_type() const {
+    throw std::runtime_error(fmt::format("get_value_type not implemented {}:{}", __FILE__, __LINE__));
+}
+
 bool
 maps::delayed_value::contains_bind_marker() const {
     // False since we don't support them in collection

--- a/cql3/maps.cc
+++ b/cql3/maps.cc
@@ -139,7 +139,7 @@ maps::delayed_value::bind(const query_options& options) {
         auto&& value = entry.second;
 
         // We don't support values > 64K because the serialization format encode the length as an unsigned short.
-        auto key_bytes = key->bind_and_get(options);
+        auto key_bytes = expr::evaluate_to_raw_view(key, options);
         if (key_bytes.is_null()) {
             throw exceptions::invalid_request_exception("null is not supported inside collections");
         }
@@ -151,7 +151,7 @@ maps::delayed_value::bind(const query_options& options) {
                                                    std::numeric_limits<uint16_t>::max(),
                                                    key_bytes.size_bytes()));
         }
-        auto value_bytes = value->bind_and_get(options);
+        auto value_bytes = expr::evaluate_to_raw_view(value, options);
         if (value_bytes.is_null()) {
             throw exceptions::invalid_request_exception("null is not supported inside collections");\
         }
@@ -215,8 +215,8 @@ void
 maps::setter_by_key::execute(mutation& m, const clustering_key_prefix& prefix, const update_parameters& params) {
     using exceptions::invalid_request_exception;
     assert(column.type->is_multi_cell()); // "Attempted to set a value for a single key on a frozen map"m
-    auto key = _k->bind_and_get(params._options);
-    auto value = _t->bind_and_get(params._options);
+    auto key = expr::evaluate_to_raw_view(_k, params._options);
+    auto value = expr::evaluate_to_raw_view(_t, params._options);
     if (value.is_unset_value()) {
         return;
     }

--- a/cql3/maps.cc
+++ b/cql3/maps.cc
@@ -81,7 +81,7 @@ maps::value::from_serialized(const raw_value_view& fragmented_value, const map_t
 
 cql3::raw_value
 maps::value::get(const query_options& options) {
-    return cql3::raw_value::make_value(get_with_protocol_version(options.get_cql_serialization_format()));
+    return cql3::raw_value::make_value(get_with_protocol_version(cql_serialization_format::internal()));
 }
 
 managed_bytes

--- a/cql3/maps.cc
+++ b/cql3/maps.cc
@@ -118,10 +118,6 @@ maps::value::to_string() const {
     abort();
 }
 
-data_type maps::value::get_value_type() const {
-    return _my_type;
-}
-
 bool
 maps::delayed_value::contains_bind_marker() const {
     // False since we don't support them in collection

--- a/cql3/maps.hh
+++ b/cql3/maps.hh
@@ -62,17 +62,15 @@ public:
     class value : public terminal, collection_terminal {
     public:
         std::map<managed_bytes, managed_bytes, serialized_compare> map;
-        data_type _my_type;
 
         value(std::map<managed_bytes, managed_bytes, serialized_compare> map, data_type my_type)
-            : map(std::move(map)), _my_type(std::move(my_type)) {
+            : terminal(std::move(my_type)), map(std::move(map)) {
         }
         static value from_serialized(const raw_value_view& value, const map_type_impl& type, cql_serialization_format sf);
         virtual cql3::raw_value get(const query_options& options) override;
         virtual managed_bytes get_with_protocol_version(cql_serialization_format sf) override;
         bool equals(const map_type_impl& mt, const value& v);
         virtual sstring to_string() const override;
-        data_type get_value_type() const override;
     };
 
     // See Lists.DelayedValue

--- a/cql3/maps.hh
+++ b/cql3/maps.hh
@@ -62,9 +62,10 @@ public:
     class value : public terminal, collection_terminal {
     public:
         std::map<managed_bytes, managed_bytes, serialized_compare> map;
+        data_type _my_type;
 
-        value(std::map<managed_bytes, managed_bytes, serialized_compare> map)
-            : map(std::move(map)) {
+        value(std::map<managed_bytes, managed_bytes, serialized_compare> map, data_type my_type)
+            : map(std::move(map)), _my_type(std::move(my_type)) {
         }
         static value from_serialized(const raw_value_view& value, const map_type_impl& type, cql_serialization_format sf);
         virtual cql3::raw_value get(const query_options& options) override;
@@ -76,12 +77,11 @@ public:
 
     // See Lists.DelayedValue
     class delayed_value : public non_terminal {
-        serialized_compare _comparator;
         std::unordered_map<shared_ptr<term>, shared_ptr<term>> _elements;
+        data_type _my_type;
     public:
-        delayed_value(serialized_compare comparator,
-                      std::unordered_map<shared_ptr<term>, shared_ptr<term>> elements)
-                : _comparator(std::move(comparator)), _elements(std::move(elements)) {
+        delayed_value(std::unordered_map<shared_ptr<term>, shared_ptr<term>> elements, data_type my_type)
+                : _elements(std::move(elements)), _my_type(std::move(my_type)) {
         }
         virtual bool contains_bind_marker() const override;
         virtual void fill_prepare_context(prepare_context& ctx) const override;

--- a/cql3/maps.hh
+++ b/cql3/maps.hh
@@ -101,7 +101,7 @@ public:
         }
 
         virtual void execute(mutation& m, const clustering_key_prefix& row_key, const update_parameters& params) override;
-        static void execute(mutation& m, const clustering_key_prefix& row_key, const update_parameters& params, const column_definition& column, ::shared_ptr<terminal> value);
+        static void execute(mutation& m, const clustering_key_prefix& row_key, const update_parameters& params, const column_definition& column, const expr::constant& value);
     };
 
     class setter_by_key : public operation {
@@ -123,7 +123,7 @@ public:
     };
 
     static void do_put(mutation& m, const clustering_key_prefix& prefix, const update_parameters& params,
-            shared_ptr<term> value, const column_definition& column);
+            const expr::constant& value, const column_definition& column);
 
     class discarder_by_key : public operation {
     public:

--- a/cql3/maps.hh
+++ b/cql3/maps.hh
@@ -71,6 +71,7 @@ public:
         virtual managed_bytes get_with_protocol_version(cql_serialization_format sf) override;
         bool equals(const map_type_impl& mt, const value& v);
         virtual sstring to_string() const override;
+        data_type get_value_type() const override;
     };
 
     // See Lists.DelayedValue

--- a/cql3/restrictions/multi_column_restriction.hh
+++ b/cql3/restrictions/multi_column_restriction.hh
@@ -226,8 +226,8 @@ public:
 #endif
 
     clustering_key_prefix composite_value(const query_options& options) const {
-        auto t = static_pointer_cast<tuples::value>(_value->bind(options));
-        auto values = t->get_elements();
+        expr::constant t = expr::evaluate(_value, options);
+        auto values = expr::get_tuple_elements(t);
         std::vector<managed_bytes> components;
         for (unsigned i = 0; i < values.size(); i++) {
             auto component = statements::request_validations::check_not_null(values[i],

--- a/cql3/restrictions/multi_column_restriction.hh
+++ b/cql3/restrictions/multi_column_restriction.hh
@@ -458,7 +458,8 @@ private:
      */
     ::shared_ptr<restriction> make_single_column_restriction(std::optional<cql3::statements::bound> bound, bool inclusive,
                                                              std::size_t column_pos, const managed_bytes_opt& value) const {
-        ::shared_ptr<cql3::term> term = ::make_shared<cql3::constants::value>(cql3::raw_value::make_value(value));
+        ::shared_ptr<cql3::term> term =
+            ::make_shared<cql3::constants::value>(cql3::raw_value::make_value(value), _column_defs[column_pos]->type);
         using namespace expr;
         if (!bound){
             auto r = ::make_shared<cql3::restrictions::single_column_restriction>(*_column_defs[column_pos]);

--- a/cql3/restrictions/restriction.hh
+++ b/cql3/restrictions/restriction.hh
@@ -54,7 +54,7 @@ namespace restrictions {
 class restriction {
 public:
     // Init to false for now, to easily detect errors.  This whole class is going away.
-    cql3::expr::expression expression = false;
+    cql3::expr::expression expression = expr::constant::make_bool(false);
     virtual ~restriction() {}
 };
 

--- a/cql3/restrictions/statement_restrictions.cc
+++ b/cql3/restrictions/statement_restrictions.cc
@@ -1742,7 +1742,7 @@ sstring statement_restrictions::to_string() const {
 
 static bool has_eq_null(const query_options& options, const expression& expr) {
     return find_atom(expr, [&] (const binary_operator& binop) {
-        return binop.op == oper_t::EQ && !binop.rhs->bind_and_get(options);
+        return binop.op == oper_t::EQ && !evaluate_to_raw_view(binop.rhs, options);
     });
 }
 

--- a/cql3/restrictions/statement_restrictions.cc
+++ b/cql3/restrictions/statement_restrictions.cc
@@ -1625,7 +1625,7 @@ void statement_restrictions::prepare_indexed_global(const schema& idx_tbl_schema
             oper_t::EQ,
             // TODO: This should be a unique marker whose value we set at execution time.  There is currently no
             // handy mechanism for doing that in query_options.
-            ::make_shared<constants::value>(raw_value::make_unset_value()));
+            ::make_shared<constants::value>(raw_value::make_unset_value(), token_column->type));
 }
 
 void statement_restrictions::prepare_indexed_local(const schema& idx_tbl_schema) {
@@ -1698,7 +1698,7 @@ std::vector<query::clustering_range> statement_restrictions::get_global_index_cl
     // WARNING: We must not yield to another fiber from here until the function's end, lest this RHS be
     // overwritten.
     const_cast<::shared_ptr<term>&>(std::get<binary_operator>((*_idx_tbl_ck_prefix)[0]).rhs) =
-            ::make_shared<constants::value>(raw_value::make_value(*token_bytes));
+            ::make_shared<constants::value>(raw_value::make_value(*token_bytes), token_column.type);
 
     // Multi column restrictions are not added to _idx_tbl_ck_prefix, they are handled later by filtering.
     return get_single_column_clustering_bounds(options, idx_tbl_schema, *_idx_tbl_ck_prefix);

--- a/cql3/selection/selectable.cc
+++ b/cql3/selection/selectable.cc
@@ -142,8 +142,8 @@ selectable::with_cast::to_string() const {
 shared_ptr<selectable>
 prepare_selectable(const schema& s, const expr::expression& raw_selectable) {
     return std::visit(overloaded_functor{
-        [&] (bool bool_constant) -> shared_ptr<selectable> {
-            on_internal_error(slogger, "no way to express SELECT TRUE/FALSE in the grammar yet");
+        [&] (const expr::constant&) -> shared_ptr<selectable> {
+            on_internal_error(slogger, "no way to express SELECT constant in the grammar yet");
         },
         [&] (const expr::conjunction& conj) -> shared_ptr<selectable> {
             on_internal_error(slogger, "no way to express 'SELECT a AND b' in the grammar yet");
@@ -229,8 +229,8 @@ prepare_selectable(const schema& s, const expr::expression& raw_selectable) {
 bool
 selectable_processes_selection(const expr::expression& raw_selectable) {
     return std::visit(overloaded_functor{
-        [&] (bool bool_constant) -> bool {
-            on_internal_error(slogger, "no way to express SELECT TRUE/FALSE in the grammar yet");
+        [&] (const expr::constant&) -> bool {
+            on_internal_error(slogger, "no way to express SELECT constant in the grammar yet");
         },
         [&] (const expr::conjunction& conj) -> bool {
             on_internal_error(slogger, "no way to express 'SELECT a AND b' in the grammar yet");

--- a/cql3/sets.cc
+++ b/cql3/sets.cc
@@ -105,7 +105,7 @@ sets::delayed_value::bind(const query_options& options) {
 
     std::set<managed_bytes, serialized_compare> buffers(my_set_type.get_elements_type()->as_less_comparator());
     for (auto&& t : _elements) {
-        auto b = t->bind_and_get(options);
+        auto b = expr::evaluate_to_raw_view(t, options);
 
         if (b.is_null()) {
             throw exceptions::invalid_request_exception("null is not supported inside collections");

--- a/cql3/sets.cc
+++ b/cql3/sets.cc
@@ -89,6 +89,10 @@ sets::value::to_string() const {
     return result;
 }
 
+data_type sets::value::get_value_type() const {
+    throw std::runtime_error(fmt::format("get_value_type not implemented {}:{}", __FILE__, __LINE__));
+}
+
 bool
 sets::delayed_value::contains_bind_marker() const {
     // False since we don't support them in collection

--- a/cql3/sets.cc
+++ b/cql3/sets.cc
@@ -89,10 +89,6 @@ sets::value::to_string() const {
     return result;
 }
 
-data_type sets::value::get_value_type() const {
-    return _my_type;
-}
-
 bool
 sets::delayed_value::contains_bind_marker() const {
     // False since we don't support them in collection

--- a/cql3/sets.cc
+++ b/cql3/sets.cc
@@ -52,7 +52,7 @@ sets::value::from_serialized(const raw_value_view& val, const set_type_impl& typ
 
 cql3::raw_value
 sets::value::get(const query_options& options) {
-    return cql3::raw_value::make_value(get_with_protocol_version(options.get_cql_serialization_format()));
+    return cql3::raw_value::make_value(get_with_protocol_version(cql_serialization_format::internal()));
 }
 
 managed_bytes

--- a/cql3/sets.hh
+++ b/cql3/sets.hh
@@ -97,7 +97,7 @@ public:
                 : operation(column, std::move(t)) {
         }
         virtual void execute(mutation& m, const clustering_key_prefix& row_key, const update_parameters& params) override;
-        static void execute(mutation& m, const clustering_key_prefix& row_key, const update_parameters& params, const column_definition& column, ::shared_ptr<terminal> value);
+        static void execute(mutation& m, const clustering_key_prefix& row_key, const update_parameters& params, const column_definition& column, const expr::constant& value);
     };
 
     class adder : public operation {
@@ -107,7 +107,7 @@ public:
         }
         virtual void execute(mutation& m, const clustering_key_prefix& row_key, const update_parameters& params) override;
         static void do_add(mutation& m, const clustering_key_prefix& row_key, const update_parameters& params,
-                shared_ptr<term> value, const column_definition& column);
+                const expr::constant& value, const column_definition& column);
     };
 
     // Note that this is reused for Map subtraction too (we subtract a set from a map)

--- a/cql3/sets.hh
+++ b/cql3/sets.hh
@@ -61,9 +61,10 @@ public:
     class value : public terminal, collection_terminal {
     public:
         std::set<managed_bytes, serialized_compare> _elements;
+        data_type _my_type;
     public:
-        value(std::set<managed_bytes, serialized_compare> elements)
-                : _elements(std::move(elements)) {
+        value(std::set<managed_bytes, serialized_compare> elements, data_type my_type)
+                : _elements(std::move(elements)), _my_type(std::move(my_type)) {
         }
         static value from_serialized(const raw_value_view& v, const set_type_impl& type, cql_serialization_format sf);
         virtual cql3::raw_value get(const query_options& options) override;
@@ -75,11 +76,11 @@ public:
 
     // See Lists.DelayedValue
     class delayed_value : public non_terminal {
-        serialized_compare _comparator;
         std::vector<shared_ptr<term>> _elements;
+        data_type _my_type;
     public:
-        delayed_value(serialized_compare comparator, std::vector<shared_ptr<term>> elements)
-            : _comparator(std::move(comparator)), _elements(std::move(elements)) {
+        delayed_value(std::vector<shared_ptr<term>> elements, data_type my_type)
+            : _elements(std::move(elements)), _my_type(std::move(my_type)) {
         }
         virtual bool contains_bind_marker() const override;
         virtual void fill_prepare_context(prepare_context& ctx) const override;

--- a/cql3/sets.hh
+++ b/cql3/sets.hh
@@ -70,6 +70,7 @@ public:
         virtual managed_bytes get_with_protocol_version(cql_serialization_format sf) override;
         bool equals(const set_type_impl& st, const value& v);
         virtual sstring to_string() const override;
+        data_type get_value_type() const override;
     };
 
     // See Lists.DelayedValue

--- a/cql3/sets.hh
+++ b/cql3/sets.hh
@@ -61,17 +61,15 @@ public:
     class value : public terminal, collection_terminal {
     public:
         std::set<managed_bytes, serialized_compare> _elements;
-        data_type _my_type;
     public:
         value(std::set<managed_bytes, serialized_compare> elements, data_type my_type)
-                : _elements(std::move(elements)), _my_type(std::move(my_type)) {
+                : terminal(std::move(my_type)), _elements(std::move(elements)) {
         }
         static value from_serialized(const raw_value_view& v, const set_type_impl& type, cql_serialization_format sf);
         virtual cql3::raw_value get(const query_options& options) override;
         virtual managed_bytes get_with_protocol_version(cql_serialization_format sf) override;
         bool equals(const set_type_impl& st, const value& v);
         virtual sstring to_string() const override;
-        data_type get_value_type() const override;
     };
 
     // See Lists.DelayedValue

--- a/cql3/single_column_relation.cc
+++ b/cql3/single_column_relation.cc
@@ -114,7 +114,9 @@ single_column_relation::new_IN_restriction(database& db, schema_ptr schema, prep
     }
     auto r = ::make_shared<single_column_restriction>(column_def);
     r->expression = binary_operator{
-            &column_def, expr::oper_t::IN, ::make_shared<lists::delayed_value>(std::move(terms))};
+            &column_def,
+            expr::oper_t::IN,
+            ::make_shared<lists::delayed_value>(std::move(terms), list_type_impl::get_instance(column_def.type, false))};
     return r;
 }
 

--- a/cql3/statements/create_aggregate_statement.cc
+++ b/cql3/statements/create_aggregate_statement.cc
@@ -58,7 +58,7 @@ void create_aggregate_statement::create(service::storage_proxy& proxy, functions
     auto dummy_ident = ::make_shared<column_identifier>("", true);
     auto column_spec = make_lw_shared<column_specification>("", "", dummy_ident, state_type);
     auto initcond_term = prepare_term(_ival, db, _name.keyspace, {column_spec});
-    bytes_opt initcond = to_bytes(*to_managed_bytes_opt(initcond_term->bind_and_get(cql3::query_options::DEFAULT)));
+    bytes_opt initcond = to_bytes(*to_managed_bytes_opt(expr::evaluate_to_raw_view(initcond_term, cql3::query_options::DEFAULT)));
 
     _aggregate = ::make_shared<functions::user_aggregate>(_name, initcond, std::move(state_func), std::move(final_func));
     return;

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -256,7 +256,7 @@ uint64_t select_statement::do_get_limit(const query_options& options, ::shared_p
         return default_limit;
     }
 
-    auto val = limit->bind_and_get(options);
+    auto val = expr::evaluate_to_raw_view(limit, options);
     if (val.is_null()) {
         throw exceptions::invalid_request_exception("Invalid null value of limit");
     }

--- a/cql3/statements/update_statement.cc
+++ b/cql3/statements/update_statement.cc
@@ -140,7 +140,7 @@ void update_statement::add_update_for_key(mutation& m, const query::clustering_r
         if (rb->name().empty() || rb->type == empty_type) {
             // There is no column outside the PK. So no operation could have passed through validation
             assert(_column_operations.empty());
-            constants::setter(*s->regular_begin(), make_shared<constants::value>(cql3::raw_value::make_value(bytes()))).execute(m, prefix, params);
+            constants::setter(*s->regular_begin(), make_shared<constants::value>(cql3::raw_value::make_value(bytes()), empty_type)).execute(m, prefix, params);
         } else {
             // dense means we don't have a row marker, so don't accept to set only the PK. See CASSANDRA-5648.
             if (_column_operations.empty()) {

--- a/cql3/statements/update_statement.cc
+++ b/cql3/statements/update_statement.cc
@@ -191,16 +191,16 @@ insert_prepared_json_statement::execute_set_value(mutation& m, const clustering_
     if (!value) {
         visit(*column.type, make_visitor(
         [&] (const list_type_impl&) {
-            lists::setter::execute(m, prefix, params, column, {});
+            lists::setter::execute(m, prefix, params, column, expr::constant::make_null());
         },
         [&] (const set_type_impl&) {
-            sets::setter::execute(m, prefix, params, column, {});
+            sets::setter::execute(m, prefix, params, column, expr::constant::make_null());
         },
         [&] (const map_type_impl&) {
-            maps::setter::execute(m, prefix, params, column, {});
+            maps::setter::execute(m, prefix, params, column, expr::constant::make_null());
         },
         [&] (const user_type_impl&) {
-            user_types::setter::execute(m, prefix, params, column, {});
+            user_types::setter::execute(m, prefix, params, column, expr::constant::make_null());
         },
         [&] (const abstract_type& type) {
             if (type.is_collection()) {
@@ -215,20 +215,20 @@ insert_prepared_json_statement::execute_set_value(mutation& m, const clustering_
     cql_serialization_format sf = params._options.get_cql_serialization_format();
     visit(*column.type, make_visitor(
     [&] (const list_type_impl& ltype) {
-        lists::setter::execute(m, prefix, params, column,
-                ::make_shared<lists::value>(lists::value::from_serialized(raw_value_view::make_value(*value), ltype, sf)));
+        auto val = ::make_shared<lists::value>(lists::value::from_serialized(raw_value_view::make_value(*value), ltype, sf));
+        lists::setter::execute(m, prefix, params, column, expr::evaluate(val, query_options::DEFAULT));
     },
     [&] (const set_type_impl& stype) {
-        sets::setter::execute(m, prefix, params, column,
-                ::make_shared<sets::value>(sets::value::from_serialized(raw_value_view::make_value(*value), stype, sf)));
+        auto val = ::make_shared<sets::value>(sets::value::from_serialized(raw_value_view::make_value(*value), stype, sf));
+        sets::setter::execute(m, prefix, params, column, expr::evaluate(val, query_options::DEFAULT));
     },
     [&] (const map_type_impl& mtype) {
-        maps::setter::execute(m, prefix, params, column,
-                ::make_shared<maps::value>(maps::value::from_serialized(raw_value_view::make_value(*value), mtype, sf)));
+        auto val = ::make_shared<maps::value>(maps::value::from_serialized(raw_value_view::make_value(*value), mtype, sf));
+        maps::setter::execute(m, prefix, params, column, expr::evaluate(val, query_options::DEFAULT));
     },
     [&] (const user_type_impl& utype) {
-        user_types::setter::execute(m, prefix, params, column,
-                ::make_shared<user_types::value>(user_types::value::from_serialized(raw_value_view::make_value(*value), utype)));
+        auto val = ::make_shared<user_types::value>(user_types::value::from_serialized(raw_value_view::make_value(*value), utype));
+        user_types::setter::execute(m, prefix, params, column, expr::evaluate(val, query_options::DEFAULT));
     },
     [&] (const abstract_type& type) {
         if (type.is_collection()) {

--- a/cql3/statements/update_statement.cc
+++ b/cql3/statements/update_statement.cc
@@ -180,7 +180,7 @@ void update_statement::add_update_for_key(mutation& m, const query::clustering_r
 }
 
 modification_statement::json_cache_opt insert_prepared_json_statement::maybe_prepare_json_cache(const query_options& options) const {
-    sstring json_string = utf8_type->to_string(to_bytes(_term->bind_and_get(options)));
+    sstring json_string = utf8_type->to_string(to_bytes(expr::evaluate_to_raw_view(_term, options)));
     return json_helpers::parse(std::move(json_string), s->all_columns(), options.get_cql_serialization_format());
 }
 

--- a/cql3/term.hh
+++ b/cql3/term.hh
@@ -148,14 +148,6 @@ public:
     }
 };
 
-class multi_item_terminal : public terminal {
-public:
-    multi_item_terminal(data_type my_type) : terminal(std::move(my_type)) {
-    }
-
-    virtual std::vector<managed_bytes_opt> copy_elements() const = 0;
-};
-
 class collection_terminal {
 public:
     virtual ~collection_terminal() {}

--- a/cql3/term.hh
+++ b/cql3/term.hh
@@ -125,7 +125,12 @@ public:
  * consumer can (and should) assume so.
  */
 class terminal : public term {
+    data_type _my_type;
+
 public:
+    terminal(data_type my_type) : _my_type(std::move(my_type)) {
+    }
+
     virtual void fill_prepare_context(prepare_context& ctx) const override {
     }
 
@@ -150,11 +155,16 @@ public:
 
     virtual sstring to_string() const override = 0;
 
-    virtual data_type get_value_type() const = 0;
+    data_type get_value_type() const {
+        return _my_type;
+    }
 };
 
 class multi_item_terminal : public terminal {
 public:
+    multi_item_terminal(data_type my_type) : terminal(std::move(my_type)) {
+    }
+
     virtual std::vector<managed_bytes_opt> copy_elements() const = 0;
 };
 

--- a/cql3/term.hh
+++ b/cql3/term.hh
@@ -85,14 +85,6 @@ public:
     virtual ::shared_ptr<terminal> bind(const query_options& options) = 0;
 
     /**
-     * A shorter for bind(values).get().
-     * We expose it mainly because for constants it can avoids allocating a temporary
-     * object between the bind and the get (note that we still want to be able
-     * to separate bind and get for collections).
-     */
-    virtual cql3::raw_value_view bind_and_get(const query_options& options) = 0;
-
-    /**
      * Whether or not that term contains at least one bind marker.
      *
      * Note that this is slightly different from being or not a NonTerminal,
@@ -149,10 +141,6 @@ public:
      */
     virtual cql3::raw_value get(const query_options& options) = 0;
 
-    virtual cql3::raw_value_view bind_and_get(const query_options& options) override {
-        return raw_value_view::make_temporary(get(options));
-    }
-
     virtual sstring to_string() const override = 0;
 
     data_type get_value_type() const {
@@ -186,14 +174,6 @@ public:
  *   - a non pure function (even if it doesn't have bind marker - see #5616)
  */
 class non_terminal : public term {
-public:
-    virtual cql3::raw_value_view bind_and_get(const query_options& options) override {
-        auto t = bind(options);
-        if (t) {
-            return cql3::raw_value_view::make_temporary(t->get(options));
-        }
-        return cql3::raw_value_view::make_null();
-    };
 };
 
 }

--- a/cql3/term.hh
+++ b/cql3/term.hh
@@ -149,6 +149,8 @@ public:
     }
 
     virtual sstring to_string() const override = 0;
+
+    virtual data_type get_value_type() const = 0;
 };
 
 class multi_item_terminal : public terminal {

--- a/cql3/tuples.cc
+++ b/cql3/tuples.cc
@@ -27,7 +27,7 @@
 namespace cql3 {
 
 data_type tuples::value::get_value_type() const {
-    throw std::runtime_error(fmt::format("get_value_type not implemented {}:{}", __FILE__, __LINE__));
+    return _my_type;
 }
 
 tuples::in_value
@@ -45,14 +45,14 @@ tuples::in_value::from_serialized(const raw_value_view& value_view, const list_t
             // FIXME: Avoid useless copies.
             elements.emplace_back(ttype->split_fragmented(single_fragmented_view(ttype->decompose(e))));
         }
-        return tuples::in_value(elements);
+        return tuples::in_value(elements, type.shared_from_this());
     } catch (marshal_exception& e) {
         throw exceptions::invalid_request_exception(e.what());
     }
 }
 
 data_type tuples::in_value::get_value_type() const {
-    throw std::runtime_error(fmt::format("get_value_type not implemented {}:{}", __FILE__, __LINE__));
+    return _my_type;
 }
 
 tuples::in_marker::in_marker(int32_t bind_index, lw_shared_ptr<column_specification> receiver)

--- a/cql3/tuples.cc
+++ b/cql3/tuples.cc
@@ -23,6 +23,7 @@
 
 #include "tuples.hh"
 #include "types/list.hh"
+#include "cql3/lists.hh"
 
 namespace cql3 {
 
@@ -45,6 +46,24 @@ tuples::in_value::from_serialized(const raw_value_view& value_view, const list_t
     } catch (marshal_exception& e) {
         throw exceptions::invalid_request_exception(e.what());
     }
+}
+
+cql3::raw_value tuples::in_value::get(const query_options& options) {
+    const list_type_impl& my_list_type = dynamic_cast<const list_type_impl&>(get_value_type()->without_reversed());
+    data_type element_tuple_type = my_list_type.get_elements_type();
+
+    utils::chunked_vector<managed_bytes_opt> list_elements;
+    list_elements.reserve(_elements.size());
+    for (const std::vector<managed_bytes_opt>& tuple_elements : _elements) {
+        ::shared_ptr<tuples::value> tvalue =
+            ::make_shared<tuples::value>(tuples::value(tuple_elements, element_tuple_type));
+
+        expr::constant tuple_val = expr::evaluate(tvalue, options);
+        list_elements.emplace_back(std::move(tuple_val.value).to_managed_bytes());
+    }
+
+    ::shared_ptr<lists::value> list_value = ::make_shared<lists::value>(std::move(list_elements), get_value_type());
+    return list_value->get(options);
 }
 
 tuples::in_marker::in_marker(int32_t bind_index, lw_shared_ptr<column_specification> receiver)

--- a/cql3/tuples.cc
+++ b/cql3/tuples.cc
@@ -26,10 +26,6 @@
 
 namespace cql3 {
 
-data_type tuples::value::get_value_type() const {
-    return _my_type;
-}
-
 tuples::in_value
 tuples::in_value::from_serialized(const raw_value_view& value_view, const list_type_impl& type, const query_options& options) {
     try {
@@ -49,10 +45,6 @@ tuples::in_value::from_serialized(const raw_value_view& value_view, const list_t
     } catch (marshal_exception& e) {
         throw exceptions::invalid_request_exception(e.what());
     }
-}
-
-data_type tuples::in_value::get_value_type() const {
-    return _my_type;
 }
 
 tuples::in_marker::in_marker(int32_t bind_index, lw_shared_ptr<column_specification> receiver)

--- a/cql3/tuples.cc
+++ b/cql3/tuples.cc
@@ -26,6 +26,10 @@
 
 namespace cql3 {
 
+data_type tuples::value::get_value_type() const {
+    throw std::runtime_error(fmt::format("get_value_type not implemented {}:{}", __FILE__, __LINE__));
+}
+
 tuples::in_value
 tuples::in_value::from_serialized(const raw_value_view& value_view, const list_type_impl& type, const query_options& options) {
     try {
@@ -45,6 +49,10 @@ tuples::in_value::from_serialized(const raw_value_view& value_view, const list_t
     } catch (marshal_exception& e) {
         throw exceptions::invalid_request_exception(e.what());
     }
+}
+
+data_type tuples::in_value::get_value_type() const {
+    throw std::runtime_error(fmt::format("get_value_type not implemented {}:{}", __FILE__, __LINE__));
 }
 
 tuples::in_marker::in_marker(int32_t bind_index, lw_shared_ptr<column_specification> receiver)

--- a/cql3/tuples.hh
+++ b/cql3/tuples.hh
@@ -61,10 +61,9 @@ public:
     class value : public multi_item_terminal {
     public:
         std::vector<managed_bytes_opt> _elements;
-        data_type _my_type;
     public:
         value(std::vector<managed_bytes_opt> elements, data_type my_type)
-                : _elements(std::move(elements)), _my_type(my_type) {
+                : multi_item_terminal(std::move(my_type)), _elements(std::move(elements)) {
         }
         static value from_serialized(const raw_value_view& buffer, const tuple_type_impl& type) {
           return buffer.with_value([&] (const FragmentedView auto& view) {
@@ -87,7 +86,6 @@ public:
         virtual sstring to_string() const override {
             return format("({})", join(", ", _elements));
         }
-        data_type get_value_type() const override;
     };
 
     /**
@@ -153,10 +151,9 @@ public:
     class in_value : public terminal {
     private:
         utils::chunked_vector<std::vector<managed_bytes_opt>> _elements;
-        data_type _my_type;
     public:
         in_value(utils::chunked_vector<std::vector<managed_bytes_opt>> items, data_type my_type)
-            : _elements(std::move(items)), _my_type(std::move(my_type)) { }
+            : terminal(std::move(my_type)), _elements(std::move(items)) { }
 
         static in_value from_serialized(const raw_value_view& value_view, const list_type_impl& type, const query_options& options);
 
@@ -173,8 +170,6 @@ public:
             std::transform(_elements.begin(), _elements.end(), tuples.begin(), &tuples::tuple_to_string<managed_bytes_opt>);
             return tuple_to_string(tuples);
         }
-
-        data_type get_value_type() const override;
     };
 
     /**

--- a/cql3/tuples.hh
+++ b/cql3/tuples.hh
@@ -86,6 +86,7 @@ public:
         virtual sstring to_string() const override {
             return format("({})", join(", ", _elements));
         }
+        data_type get_value_type() const override;
     };
 
     /**
@@ -169,6 +170,8 @@ public:
             std::transform(_elements.begin(), _elements.end(), tuples.begin(), &tuples::tuple_to_string<managed_bytes_opt>);
             return tuple_to_string(tuples);
         }
+
+        data_type get_value_type() const override;
     };
 
     /**

--- a/cql3/tuples.hh
+++ b/cql3/tuples.hh
@@ -138,11 +138,6 @@ public:
         virtual shared_ptr<terminal> bind(const query_options& options) override {
             return ::make_shared<value>(bind_internal(options), _type);
         }
-
-        virtual cql3::raw_value_view bind_and_get(const query_options& options) override {
-            // We don't "need" that override but it saves us the allocation of a Value object if used
-            return cql3::raw_value_view::make_temporary(cql3::raw_value::make_value(_type->build_value_fragmented(bind_internal(options))));
-        }
     };
 
     /**

--- a/cql3/tuples.hh
+++ b/cql3/tuples.hh
@@ -157,9 +157,7 @@ public:
 
         static in_value from_serialized(const raw_value_view& value_view, const list_type_impl& type, const query_options& options);
 
-        virtual cql3::raw_value get(const query_options& options) override {
-            throw exceptions::unsupported_operation_exception();
-        }
+        virtual cql3::raw_value get(const query_options& options) override;
 
         utils::chunked_vector<std::vector<managed_bytes_opt>> get_split_values() const {
             return _elements;

--- a/cql3/tuples.hh
+++ b/cql3/tuples.hh
@@ -59,12 +59,12 @@ public:
     /**
      * A tuple of terminal values (e.g (123, 'abc')).
      */
-    class value : public multi_item_terminal {
+    class value : public terminal {
     public:
         std::vector<managed_bytes_opt> _elements;
     public:
         value(std::vector<managed_bytes_opt> elements, data_type my_type)
-                : multi_item_terminal(std::move(my_type)), _elements(std::move(elements)) {
+                : terminal(std::move(my_type)), _elements(std::move(elements)) {
         }
         static value from_serialized(const raw_value_view& buffer, const tuple_type_impl& type) {
           return buffer.with_value([&] (const FragmentedView auto& view) {
@@ -73,13 +73,6 @@ public:
         }
         virtual cql3::raw_value get(const query_options& options) override {
             return cql3::raw_value::make_value(tuple_type_impl::build_value_fragmented(_elements));
-        }
-
-        const std::vector<managed_bytes_opt>& get_elements() const {
-            return _elements;
-        }
-        virtual std::vector<managed_bytes_opt> copy_elements() const override {
-            return _elements;
         }
         size_t size() const {
             return _elements.size();

--- a/cql3/tuples.hh
+++ b/cql3/tuples.hh
@@ -45,6 +45,7 @@
 #include "types/collection.hh"
 #include "utils/chunked_vector.hh"
 #include "cql3/column_identifier.hh"
+#include "cql3/expr/expression.hh"
 
 class list_type_impl;
 
@@ -113,7 +114,7 @@ public:
             std::vector<managed_bytes_opt> buffers;
             buffers.resize(_elements.size());
             for (size_t i = 0; i < _elements.size(); ++i) {
-                const auto& value = _elements[i]->bind_and_get(options);
+                const auto& value = expr::evaluate_to_raw_view(_elements[i], options);
                 if (value.is_unset_value()) {
                     throw exceptions::invalid_request_exception(format("Invalid unset value for tuple field number {:d}", i));
                 }

--- a/cql3/user_types.cc
+++ b/cql3/user_types.cc
@@ -51,7 +51,7 @@
 namespace cql3 {
 
 user_types::value::value(std::vector<managed_bytes_opt> elements, data_type my_type)
-        : _elements(std::move(elements)), _my_type(std::move(my_type)) {
+        : multi_item_terminal(std::move(my_type)), _elements(std::move(elements)) {
 }
 
 user_types::value user_types::value::from_serialized(const raw_value_view& v, const user_type_impl& type) {
@@ -80,10 +80,6 @@ std::vector<managed_bytes_opt> user_types::value::copy_elements() const {
 
 sstring user_types::value::to_string() const {
     return format("({})", join(", ", _elements));
-}
-
-data_type user_types::value::get_value_type() const {
-    return _my_type;
 }
 
 user_types::delayed_value::delayed_value(user_type type, std::vector<shared_ptr<term>> values)

--- a/cql3/user_types.cc
+++ b/cql3/user_types.cc
@@ -82,6 +82,10 @@ sstring user_types::value::to_string() const {
     return format("({})", join(", ", _elements));
 }
 
+data_type user_types::value::get_value_type() const {
+    throw std::runtime_error(fmt::format("get_value_type not implemented {}:{}", __FILE__, __LINE__));
+}
+
 user_types::delayed_value::delayed_value(user_type type, std::vector<shared_ptr<term>> values)
         : _type(std::move(type)), _values(std::move(values)) {
 }

--- a/cql3/user_types.cc
+++ b/cql3/user_types.cc
@@ -126,10 +126,6 @@ shared_ptr<terminal> user_types::delayed_value::bind(const query_options& option
     return ::make_shared<user_types::value>(bind_internal(options), _type);
 }
 
-cql3::raw_value_view user_types::delayed_value::bind_and_get(const query_options& options) {
-    return cql3::raw_value_view::make_temporary(cql3::raw_value::make_value(user_type_impl::build_value_fragmented(bind_internal(options))));
-}
-
 shared_ptr<terminal> user_types::marker::bind(const query_options& options) {
     auto value = options.get_value_at(_bind_index);
     if (value.is_null()) {

--- a/cql3/user_types.cc
+++ b/cql3/user_types.cc
@@ -50,8 +50,8 @@
 
 namespace cql3 {
 
-user_types::value::value(std::vector<managed_bytes_opt> elements)
-        : _elements(std::move(elements)) {
+user_types::value::value(std::vector<managed_bytes_opt> elements, data_type my_type)
+        : _elements(std::move(elements)), _my_type(std::move(my_type)) {
 }
 
 user_types::value user_types::value::from_serialized(const raw_value_view& v, const user_type_impl& type) {
@@ -62,7 +62,7 @@ user_types::value user_types::value::from_serialized(const raw_value_view& v, co
                     format("User Defined Type value contained too many fields (expected {}, got {})", type.size(), elements.size()));
         }
 
-        return value(std::move(elements));
+        return value(std::move(elements), type.shared_from_this());
     });
 }
 
@@ -83,7 +83,7 @@ sstring user_types::value::to_string() const {
 }
 
 data_type user_types::value::get_value_type() const {
-    throw std::runtime_error(fmt::format("get_value_type not implemented {}:{}", __FILE__, __LINE__));
+    return _my_type;
 }
 
 user_types::delayed_value::delayed_value(user_type type, std::vector<shared_ptr<term>> values)
@@ -127,7 +127,7 @@ std::vector<managed_bytes_opt> user_types::delayed_value::bind_internal(const qu
 }
 
 shared_ptr<terminal> user_types::delayed_value::bind(const query_options& options) {
-    return ::make_shared<user_types::value>(bind_internal(options));
+    return ::make_shared<user_types::value>(bind_internal(options), _type);
 }
 
 cql3::raw_value_view user_types::delayed_value::bind_and_get(const query_options& options) {

--- a/cql3/user_types.cc
+++ b/cql3/user_types.cc
@@ -104,7 +104,7 @@ std::vector<managed_bytes_opt> user_types::delayed_value::bind_internal(const qu
 
     std::vector<managed_bytes_opt> buffers;
     for (size_t i = 0; i < _type->size(); ++i) {
-        const auto& value = _values[i]->bind_and_get(options);
+        const auto& value = expr::evaluate_to_raw_view(_values[i], options);
         if (!_type->is_multi_cell() && value.is_unset_value()) {
             throw exceptions::invalid_request_exception(format("Invalid unset value for field '{}' of user defined type {}",
                         _type->field_name_as_string(i), _type->get_name_as_string()));
@@ -202,7 +202,7 @@ void user_types::setter::execute(mutation& m, const clustering_key_prefix& row_k
 void user_types::setter_by_field::execute(mutation& m, const clustering_key_prefix& row_key, const update_parameters& params) {
     assert(column.type->is_user_type() && column.type->is_multi_cell());
 
-    auto value = _t->bind_and_get(params._options);
+    auto value = expr::evaluate_to_raw_view(_t, params._options);
     if (value.is_unset_value()) {
         return;
     }

--- a/cql3/user_types.cc
+++ b/cql3/user_types.cc
@@ -51,7 +51,7 @@
 namespace cql3 {
 
 user_types::value::value(std::vector<managed_bytes_opt> elements, data_type my_type)
-        : multi_item_terminal(std::move(my_type)), _elements(std::move(elements)) {
+        : terminal(std::move(my_type)), _elements(std::move(elements)) {
 }
 
 user_types::value user_types::value::from_serialized(const raw_value_view& v, const user_type_impl& type) {
@@ -68,14 +68,6 @@ user_types::value user_types::value::from_serialized(const raw_value_view& v, co
 
 cql3::raw_value user_types::value::get(const query_options&) {
     return cql3::raw_value::make_value(tuple_type_impl::build_value_fragmented(_elements));
-}
-
-const std::vector<managed_bytes_opt>& user_types::value::get_elements() const {
-    return _elements;
-}
-
-std::vector<managed_bytes_opt> user_types::value::copy_elements() const {
-    return _elements;
 }
 
 sstring user_types::value::to_string() const {

--- a/cql3/user_types.hh
+++ b/cql3/user_types.hh
@@ -59,9 +59,9 @@ public:
 
     class value : public multi_item_terminal {
         std::vector<managed_bytes_opt> _elements;
+        data_type _my_type;
     public:
-        explicit value(std::vector<managed_bytes_opt>);
-        explicit value(std::vector<managed_bytes_view_opt>);
+        explicit value(std::vector<managed_bytes_opt>, data_type my_type);
 
         static value from_serialized(const raw_value_view&, const user_type_impl&);
 

--- a/cql3/user_types.hh
+++ b/cql3/user_types.hh
@@ -100,7 +100,7 @@ public:
         using operation::operation;
 
         virtual void execute(mutation& m, const clustering_key_prefix& row_key, const update_parameters& params) override;
-        static void execute(mutation& m, const clustering_key_prefix& prefix, const update_parameters& params, const column_definition& column, ::shared_ptr<terminal> value);
+        static void execute(mutation& m, const clustering_key_prefix& prefix, const update_parameters& params, const column_definition& column, const expr::constant& value);
     };
 
     class setter_by_field : public operation {

--- a/cql3/user_types.hh
+++ b/cql3/user_types.hh
@@ -59,7 +59,6 @@ public:
 
     class value : public multi_item_terminal {
         std::vector<managed_bytes_opt> _elements;
-        data_type _my_type;
     public:
         explicit value(std::vector<managed_bytes_opt>, data_type my_type);
 
@@ -69,7 +68,6 @@ public:
         const std::vector<managed_bytes_opt>& get_elements() const;
         virtual std::vector<managed_bytes_opt> copy_elements() const override;
         virtual sstring to_string() const override;
-        data_type get_value_type() const override;
     };
 
     // Same purpose than Lists.DelayedValue, except we do handle bind marker in that case

--- a/cql3/user_types.hh
+++ b/cql3/user_types.hh
@@ -82,7 +82,6 @@ public:
         std::vector<managed_bytes_opt> bind_internal(const query_options& options);
     public:
         virtual shared_ptr<terminal> bind(const query_options& options) override;
-        virtual cql3::raw_value_view bind_and_get(const query_options& options) override;
     };
 
     class marker : public abstract_marker {

--- a/cql3/user_types.hh
+++ b/cql3/user_types.hh
@@ -69,6 +69,7 @@ public:
         const std::vector<managed_bytes_opt>& get_elements() const;
         virtual std::vector<managed_bytes_opt> copy_elements() const override;
         virtual sstring to_string() const override;
+        data_type get_value_type() const override;
     };
 
     // Same purpose than Lists.DelayedValue, except we do handle bind marker in that case

--- a/cql3/user_types.hh
+++ b/cql3/user_types.hh
@@ -57,7 +57,7 @@ class user_types {
 public:
     static lw_shared_ptr<column_specification> field_spec_of(const column_specification& column, size_t field);
 
-    class value : public multi_item_terminal {
+    class value : public terminal {
         std::vector<managed_bytes_opt> _elements;
     public:
         explicit value(std::vector<managed_bytes_opt>, data_type my_type);
@@ -65,8 +65,6 @@ public:
         static value from_serialized(const raw_value_view&, const user_type_impl&);
 
         virtual cql3::raw_value get(const query_options&) override;
-        const std::vector<managed_bytes_opt>& get_elements() const;
-        virtual std::vector<managed_bytes_opt> copy_elements() const override;
         virtual sstring to_string() const override;
     };
 

--- a/cql3/values.cc
+++ b/cql3/values.cc
@@ -60,7 +60,9 @@ raw_value_view raw_value_view::make_temporary(raw_value&& value) {
     switch (value._data.index()) {
     case 0:  return raw_value_view(managed_bytes(std::get<bytes>(value._data)));
     case 1:  return raw_value_view(std::move(std::get<managed_bytes>(value._data)));
-    default: return raw_value_view::make_null();
+    case 2:  return raw_value_view::make_null();
+    case 3: return raw_value_view::make_unset_value();
+    default: throw std::runtime_error(fmt::format("raw_value_view::make_temporary bad index: {}", value._data.index()));
     }
 }
 

--- a/cql3/values.hh
+++ b/cql3/values.hh
@@ -31,6 +31,7 @@
 #include <seastar/util/variant_utils.hh>
 
 #include "utils/fragmented_temporary_buffer.hh"
+#include "utils/overloaded_functor.hh"
 
 namespace cql3 {
 
@@ -248,6 +249,18 @@ public:
         case 0:  return std::move(std::get<bytes>(_data));
         default: return ::to_bytes(std::get<managed_bytes>(_data));
         }
+    }
+    managed_bytes to_managed_bytes() && {
+        return std::visit(overloaded_functor{
+            [](bytes&& bytes_val) { return managed_bytes(bytes_val); },
+            [](managed_bytes&& managed_bytes_val) { return std::move(managed_bytes_val); },
+            [](null_value&&) -> managed_bytes {
+                throw std::runtime_error("to_managed_bytes() called on raw value that is null");
+            },
+            [](unset_value&&) -> managed_bytes {
+                throw std::runtime_error("to_managed_bytes() called on raw value that is unset_value");
+            }
+        }, std::move(_data));
     }
     raw_value_view to_view() const;
     friend class raw_value_view;

--- a/test/boost/statement_restrictions_test.cc
+++ b/test/boost/statement_restrictions_test.cc
@@ -420,7 +420,8 @@ BOOST_AUTO_TEST_CASE(expression_extract_column_restrictions) {
     // AND pk1 AND pk2
     // AND (pk1, pk2)
     std::vector<expression> big_where;
-    ::shared_ptr<constants::value> zero_value = ::make_shared<constants::value>(raw_value::make_value(I(0)));
+    ::shared_ptr<constants::value> zero_value =
+        ::make_shared<constants::value>(raw_value::make_value(I(0)), int32_type);
 
     expression pk1_restriction(binary_operator(column_value(&col_pk1), oper_t::EQ, zero_value));
     expression pk2_restriction(binary_operator(column_value(&col_pk2), oper_t::EQ, zero_value));

--- a/test/boost/statement_restrictions_test.cc
+++ b/test/boost/statement_restrictions_test.cc
@@ -452,8 +452,8 @@ BOOST_AUTO_TEST_CASE(expression_extract_column_restrictions) {
     expression token_lt_restriction = binary_operator(token{}, oper_t::LT, zero_value);
     expression token_gt_restriction = binary_operator(token{}, oper_t::GT, zero_value);
 
-    expression true_restriction(true);
-    expression false_restriction(false);
+    expression true_restriction = constant::make_bool(true);
+    expression false_restriction = constant::make_bool(false);
     expression token_expr = token{};
     expression pk1_expr = column_value(&col_pk1);
     expression pk2_expr = column_value(&col_pk1);

--- a/test/boost/statement_restrictions_test.cc
+++ b/test/boost/statement_restrictions_test.cc
@@ -437,7 +437,9 @@ BOOST_AUTO_TEST_CASE(expression_extract_column_restrictions) {
         tuple_constructor column_tuple(cql3::restrictions::column_definitions_as_tuple_constructor(columns));
 
         std::vector<managed_bytes_opt> zeros_tuple_elems(columns.size(), managed_bytes_opt(I(0)));
-        ::shared_ptr<tuples::value> zeros_tuple = ::make_shared<tuples::value>(std::move(zeros_tuple_elems));
+        data_type tup_type = tuple_type_impl::get_instance(std::vector<data_type>(columns.size(), int32_type));
+        ::shared_ptr<tuples::value> zeros_tuple =
+            ::make_shared<tuples::value>(std::move(zeros_tuple_elems), std::move(tup_type));
 
         return binary_operator(column_tuple, oper, zeros_tuple);
     };


### PR DESCRIPTION
Add new struct to the `expression` variant:
```c++
// A value serialized with the internal (latest) cql_serialization_format
struct constant {
    cql3::raw_value value;
    data_type type; // Never nullptr, for NULL and UNSET might be empty_type
};
```
and use it where possible instead of `terminal`.

This struct will eventually replace all classes deriving from `terminal`, but for now `terminal` can't be removed completely.

We can't get rid of terminal yet, because sometimes `terminal` is converted back to `term`, which `constant` can't do. This won't be a problem once we replace term with expression.

`bool` is removed from `expression`, now `constant` is used instead.

This is a redesign of PR #9203, there is some discussion about the chosen representation there.