### PR TITLE
Add compaction stats to tracing data

### DIFF
--- a/table.cc
+++ b/table.cc
@@ -2001,7 +2001,7 @@ table::query(schema_ptr s,
 
         std::exception_ptr ex;
       try {
-        co_await q.consume_page(query_result_builder(*s, qs.builder), qs.remaining_rows(), qs.remaining_partitions(), qs.cmd.timestamp, permit.max_result_size());
+        co_await q.consume_page(query_result_builder(*s, qs.builder), qs.remaining_rows(), qs.remaining_partitions(), qs.cmd.timestamp, permit.max_result_size(), trace_state);
       } catch (...) {
         ex = std::current_exception();
       }
@@ -2054,7 +2054,7 @@ table::mutation_query(schema_ptr s,
     // legacy format.
     auto result_schema = cmd.slice.options.contains(query::partition_slice::option::reversed) ? s->make_reversed() : s;
     auto rrb = reconcilable_result_builder(*result_schema, cmd.slice, std::move(accounter));
-    auto r = co_await q.consume_page(std::move(rrb), cmd.get_row_limit(), cmd.partition_limit, cmd.timestamp, permit.max_result_size());
+    auto r = co_await q.consume_page(std::move(rrb), cmd.get_row_limit(), cmd.partition_limit, cmd.timestamp, permit.max_result_size(), trace_state);
 
     if (!saved_querier || (!q.are_limits_reached() && !r.is_short_read())) {
         co_await q.close();


### PR DESCRIPTION
Too many tombstones (row or range) are a common source of query performance problems, yet currently we have no visibility into the amount of tombstones a query has to process while constructing the results. This series addresses this by collecting stats about the compacted data in `compact_mutation_state`. This contains the number of partitions, static rows (live and dead), clustering rows (live and dead) and range tombstones. This data is then added to tracing on each query path.
Example trace:
```
 activity                                                                                                                              | timestamp                  | source    | source_elapsed | client
---------------------------------------------------------------------------------------------------------------------------------------+----------------------------+-----------+----------------+-----------
                                                                                                                    Execute CQL3 query | 2021-09-22 12:06:24.089000 | 127.0.0.1 |              0 | 127.0.0.1
                                                                                                         Parsing a statement [shard 0] | 2021-09-22 12:06:24.089552 | 127.0.0.1 |              1 | 127.0.0.1
                                                                                                      Processing a statement [shard 0] | 2021-09-22 12:06:24.089674 | 127.0.0.1 |            122 | 127.0.0.1
      Creating read executor for token -4069959284402364209 with all: {127.0.0.1} targets: {127.0.0.1} repair decision: NONE [shard 0] | 2021-09-22 12:06:24.089724 | 127.0.0.1 |            173 | 127.0.0.1
                                                                                                 read_data: querying locally [shard 0] | 2021-09-22 12:06:24.089727 | 127.0.0.1 |            175 | 127.0.0.1
                                                    Start querying singular range {{-4069959284402364209, pk{000400000001}}} [shard 0] | 2021-09-22 12:06:24.089732 | 127.0.0.1 |            181 | 127.0.0.1
                                Querying cache for range {{-4069959284402364209, pk{000400000001}}} and slice {(-inf, +inf)} [shard 0] | 2021-09-22 12:06:24.089751 | 127.0.0.1 |            199 | 127.0.0.1
 Page stats: 1 partition(s), 0 static row(s) (0 live, 0 dead), 4 clustering row(s) (3 live, 1 dead) and 1 range tombstone(s) [shard 0] | 2021-09-22 12:06:24.089838 | 127.0.0.1 |            286 | 127.0.0.1
                                                                                                            Querying is done [shard 0] | 2021-09-22 12:06:24.089847 | 127.0.0.1 |            295 | 127.0.0.1
                                                                                        Done processing - preparing a result [shard 0] | 2021-09-22 12:06:24.089862 | 127.0.0.1 |            311 | 127.0.0.1
                                                                                                                      Request complete | 2021-09-22 12:06:24.089326 | 127.0.0.1 |            326 | 127.0.0.1

```

Tests: unit(dev)

Fixes: https://github.com/scylladb/scylla/issues/5471