### PR TITLE
Prepare for inheriting from reader_concurrency_semaphore

### DIFF
--- a/reader_concurrency_semaphore.cc
+++ b/reader_concurrency_semaphore.cc
@@ -751,6 +751,7 @@ std::runtime_error reader_concurrency_semaphore::stopped_exception() {
 future<> reader_concurrency_semaphore::stop() noexcept {
     assert(!_stopped);
     _stopped = true;
+    co_await stop_ext_pre();
     clear_inactive_reads();
     co_await _close_readers_gate.close();
     co_await _permit_gate.close();
@@ -761,6 +762,7 @@ future<> reader_concurrency_semaphore::stop() noexcept {
         co_await std::move(*_execution_loop_future);
     }
     broken(std::make_exception_ptr(stopped_exception()));
+    co_await stop_ext_post();
     co_return;
 }
 

--- a/reader_concurrency_semaphore.hh
+++ b/reader_concurrency_semaphore.hh
@@ -258,7 +258,7 @@ public:
         : reader_concurrency_semaphore(count, memory, std::move(name), max_queue_length)
     {}
 
-    ~reader_concurrency_semaphore();
+    virtual ~reader_concurrency_semaphore();
 
     reader_concurrency_semaphore(const reader_concurrency_semaphore&) = delete;
     reader_concurrency_semaphore& operator=(const reader_concurrency_semaphore&) = delete;
@@ -313,7 +313,17 @@ public:
 
     /// Clear all inactive reads.
     void clear_inactive_reads();
-
+private:
+    // The following two functions are extension points for
+    // future inheriting classes that needs to run some stop
+    // logic just before or just after the current stop logic.
+    virtual future<> stop_ext_pre() {
+        return make_ready_future<>();
+    }
+    virtual future<> stop_ext_post() {
+        return make_ready_future<>();
+    }
+public:
     /// Stop the reader_concurrency_semaphore and clear all inactive reads.
     ///
     /// Wait on all async background work to complete.


### PR DESCRIPTION
Some future and enterprise features requires us to inherit from
reader_concurrency_semaphore, this might require additional
"wrap up" operations to be done on stop which serves as a barrier
for the semaphore. Here we simply make stop virtual so it is
inherited and can be augmented.
This change have no significant impact neither  in performance and
nor potential coding mistakes since stop can be called once in a
lifetime of a semaphore (performance hit is negligible) and if a
programmer forgets to call the base classes stop, the base class
destructor will fail to assert that stop have been called so we
will find out early in the testing phase.

Signed-off-by: Eliran Sinvani <eliransin@scylladb.com>