### PR TITLE
Service Level Controller: Add an extention point to the API

### DIFF
--- a/service/qos/qos_configuration_change_subscriber.hh
+++ b/service/qos/qos_configuration_change_subscriber.hh
@@ -23,15 +23,20 @@
 
 #include "qos_common.hh"
 
+
 namespace qos {
+
+    struct service_level_info {
+        sstring name;
+    };
     class qos_configuration_change_subscriber {
     public:
         /** This callback is going to be called just before the service level is available **/
-        virtual future<> on_before_service_level_add(sstring name, service_level_options slo) = 0;
+        virtual future<> on_before_service_level_add(service_level_options slo, service_level_info sl_info) = 0;
         /** This callback is going to be called just after the service level is removed **/
-        virtual future<> on_after_service_level_remove(sstring name) = 0;
+        virtual future<> on_after_service_level_remove(service_level_info sl_info) = 0;
         /** This callback is going to be called just before the service level is changed **/
-        virtual future<> on_before_service_level_change(sstring name, service_level_options slo_before, service_level_options slo_after) = 0;
+        virtual future<> on_before_service_level_change(service_level_options slo_before, service_level_options slo_after, service_level_info sl_info) = 0;
 
         virtual ~qos_configuration_change_subscriber() {};
     };

--- a/service/qos/service_level_controller.cc
+++ b/service/qos/service_level_controller.cc
@@ -234,7 +234,7 @@ future<>  service_level_controller::notify_service_level_added(sstring name, ser
     return seastar::async( [this, name, sl_data] {
         _subscribers.for_each([name, sl_data] (qos_configuration_change_subscriber* subscriber) {
             try {
-                subscriber->on_before_service_level_add(name, sl_data.slo).get();
+                subscriber->on_before_service_level_add(sl_data.slo, {name}).get();
             } catch (...) {
                 sl_logger.error("notify_service_level_added: exception occurred in one of the observers callbacks {}", std::current_exception());
             }
@@ -252,7 +252,7 @@ future<> service_level_controller::notify_service_level_updated(sstring name, se
         return seastar::async( [this,sl_it, name, slo_before, slo] {
             _subscribers.for_each([name, slo_before, slo] (qos_configuration_change_subscriber* subscriber) {
                 try {
-                    subscriber->on_before_service_level_change(name, slo_before, slo).get();
+                    subscriber->on_before_service_level_change(slo_before, slo, {name}).get();
                 } catch (...) {
                     sl_logger.error("notify_service_level_updated: exception occurred in one of the observers callbacks {}", std::current_exception());
                 }
@@ -270,7 +270,7 @@ future<> service_level_controller::notify_service_level_removed(sstring name) {
         return seastar::async( [this, name] {
             _subscribers.for_each([name] (qos_configuration_change_subscriber* subscriber) {
                 try {
-                    subscriber->on_after_service_level_remove(name).get();
+                    subscriber->on_after_service_level_remove({name}).get();
                 } catch (...) {
                     sl_logger.error("notify_service_level_removed: exception occurred in one of the observers callbacks {}", std::current_exception());
                 }

--- a/test/boost/service_level_controller_test.cc
+++ b/test/boost/service_level_controller_test.cc
@@ -63,18 +63,18 @@ struct qos_configuration_change_suscriber_simple : public qos_configuration_chan
 
     std::vector<service_level_op> ops;
 
-    virtual future<> on_before_service_level_add(sstring name, service_level_options slo) override {
-        ops.push_back(add_op{name, slo});
+    virtual future<> on_before_service_level_add(service_level_options slo, service_level_info sl_info) override {
+        ops.push_back(add_op{sl_info.name, slo});
         return make_ready_future<>();
     }
 
-    virtual future<> on_after_service_level_remove(sstring name) override {
-        ops.push_back(remove_op{name});
+    virtual future<> on_after_service_level_remove(service_level_info sl_info) override {
+        ops.push_back(remove_op{sl_info.name});
         return make_ready_future<>();
     }
 
-    virtual future<> on_before_service_level_change(sstring name, service_level_options slo_before, service_level_options slo_after) override {
-        ops.push_back(change_op{name, slo_before, slo_after});
+    virtual future<> on_before_service_level_change(service_level_options slo_before, service_level_options slo_after, service_level_info sl_info) override {
+        ops.push_back(change_op{sl_info.name, slo_before, slo_after});
         return make_ready_future<>();
     }
 };


### PR DESCRIPTION
In order to ease future extensions to the information being sent
by the service level configuration change API, we pack the additional
parameters (other the the service level options) to the interface in a
structure. This will allow an easy expansion in the future if more
parameters needs to be sent to the observer.

Signed-off-by: Eliran Sinvani <eliransin@scylladb.com>