### PR TITLE
db/config: configure logging based on app_template::seastar_options

### DIFF
--- a/db/config.hh
+++ b/db/config.hh
@@ -41,6 +41,9 @@ struct logging_settings;
 namespace tls {
 class credentials_builder;
 }
+namespace log_cli {
+class options;
+}
 }
 
 namespace db {
@@ -373,7 +376,7 @@ public:
     named_value<tri_mode_restriction> restrict_replication_simplestrategy;
     named_value<tri_mode_restriction> restrict_dtcs;
 
-    seastar::logging_settings logging_settings(const boost::program_options::variables_map&) const;
+    seastar::logging_settings logging_settings(const log_cli::options&) const;
 
     const db::extensions& extensions() const;
 

--- a/main.cc
+++ b/main.cc
@@ -516,7 +516,7 @@ int main(int ac, char** av) {
 
         tcp_syncookies_sanity();
 
-        return seastar::async([cfg, ext, &db, &qp, &bm, &proxy, &mm, &mm_notifier, &ctx, &opts, &dirs,
+        return seastar::async([&app, cfg, ext, &db, &qp, &bm, &proxy, &mm, &mm_notifier, &ctx, &opts, &dirs,
                 &prometheus_server, &cf_cache_hitrate_calculator, &load_meter, &feature_service,
                 &token_metadata, &erm_factory, &snapshot_ctl, &messaging, &sst_dir_semaphore, &raft_gr, &service_memory_limiter,
                 &repair, &sst_loader, &ss, &lifecycle_notifier, &stream_manager] {
@@ -545,7 +545,7 @@ int main(int ac, char** av) {
             });
 
             logalloc::prime_segment_pool(memory::stats().total_memory(), memory::min_free_memory()).get();
-            logging::apply_settings(cfg->logging_settings(opts));
+            logging::apply_settings(cfg->logging_settings(app.options().log_opts));
 
             startlog.info(startup_msg, scylla_version(), get_build_id());
 


### PR DESCRIPTION
Scylla has its own config file which supports configuring aspects of
logging, in addition to the built-in CLI logging options. When applying
this configuration, the CLI provided option values have priority over
the ones coming from the option file. To implement this scylla currently
reads CLI options belonging to seastar from the boost program options
variable map. The internal representation of CLI options however do not
constitute an API of seastar and are thus subject to change (even if
unlikely). This patch moves away from this practice and uses the new
shiny C++ api: `app_template::seastar_options` to obtain the current
logging options.

This PR depends on seastar patch: "[PATCH v2 00/13] Allow programatically configuring seastar" and it has to be commited at the same time the seastar submodule is updated with the above series.