### PR TITLE
tools: utils: add configure_tool_mode()

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1143,8 +1143,8 @@ deps = {
     'scylla': idls + ['main.cc', 'release.cc', 'utils/build_id.cc'] + scylla_core + api + alternator + redis,
     'test/tools/cql_repl': idls + ['test/tools/cql_repl.cc'] + scylla_core + scylla_tests_generic_dependencies,
     #FIXME: we don't need all of scylla_core here, only the types module, need to modularize scylla_core.
-    'tools/scylla-types': idls + ['tools/scylla-types.cc'] + scylla_core,
-    'tools/scylla-sstable': idls + ['tools/scylla-sstable.cc', 'tools/schema_loader.cc'] + scylla_core,
+    'tools/scylla-types': idls + ['tools/scylla-types.cc', 'tools/utils.cc'] + scylla_core,
+    'tools/scylla-sstable': idls + ['tools/scylla-sstable.cc', 'tools/schema_loader.cc', 'tools/utils.cc'] + scylla_core,
 }
 
 pure_boost_tests = set([

--- a/tools/scylla-sstable.cc
+++ b/tools/scylla-sstable.cc
@@ -669,7 +669,7 @@ const std::vector<operation> operations{
 } // anonymous namespace
 
 int main(int argc, char** argv) {
-    app_template::config app_cfg;
+    app_template::seastar_options app_cfg;
     app_cfg.name = app_name;
 
     const auto description_template =
@@ -725,6 +725,8 @@ $ scylla-sstable --validate /path/to/md-123456-big-Data.db /path/to/md-123457-bi
                     [] (const auto& op) { return sstring(op.name()); } ), ", ");
 
     const auto op_help = fmt::format("operation to run, one of ({})", op_list);
+
+    tools::utils::configure_tool_mode(app_cfg, sst_log.name());
 
     app_template app(std::move(app_cfg));
 

--- a/tools/scylla-types.cc
+++ b/tools/scylla-types.cc
@@ -170,7 +170,7 @@ const std::vector<action_handler> action_handlers = {
 int main(int argc, char** argv) {
     namespace bpo = boost::program_options;
 
-    app_template::config app_cfg;
+    app_template::seastar_options app_cfg;
     app_cfg.name = "scylla-types";
 
     auto description_template =
@@ -202,6 +202,8 @@ $ scylla-types --print --prefix-compound -t TimeUUIDType -t Int32Type 0010d00819
 )";
     app_cfg.description = format(description_template, boost::algorithm::join(action_handlers | boost::adaptors::transformed(
                     [] (const action_handler& ah) { return format("* --{} - {}", ah.name(), ah.description()); } ), "\n"));
+
+    tools::utils::configure_tool_mode(app_cfg);
 
     app_template app(std::move(app_cfg));
 

--- a/tools/utils.cc
+++ b/tools/utils.cc
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2021-present ScyllaDB
+ */
+
+/*
+ * This file is part of Scylla.
+ *
+ * Scylla is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Scylla is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "tools/utils.hh"
+
+namespace tools::utils {
+
+void configure_tool_mode(app_template::seastar_options& opts, const sstring& logger_name) {
+    opts.reactor_opts.blocked_reactor_notify_ms.set_value(60000);
+    opts.reactor_opts.overprovisioned.set_value();
+    opts.reactor_opts.idle_poll_time_us.set_value(0);
+    opts.reactor_opts.poll_aio.set_value(false);
+    opts.reactor_opts.relaxed_dma.set_value();
+    opts.reactor_opts.unsafe_bypass_fsync.set_value(true);
+    opts.reactor_opts.kernel_page_cache.set_value(true);
+    opts.smp_opts.thread_affinity.set_value(false);
+    opts.smp_opts.mbind.set_value(false);
+    opts.smp_opts.smp.set_value(1);
+    opts.smp_opts.lock_memory.set_value(false);
+    opts.log_opts.default_log_level.set_value(log_level::warn);
+    if (!logger_name.empty()) {
+        opts.log_opts.logger_log_level.set_value({});
+        opts.log_opts.logger_log_level.get_value()[logger_name] = log_level::info;
+    }
+}
+
+} // namespace tools::utils

--- a/tools/utils.hh
+++ b/tools/utils.hh
@@ -22,9 +22,11 @@
 #include <boost/algorithm/string/join.hpp>
 #include <boost/range/adaptor/transformed.hpp>
 #include <boost/program_options.hpp>
+#include <seastar/core/app-template.hh>
 #include <string>
 #include <vector>
 #include <fmt/format.h>
+#include "seastarx.hh"
 
 namespace tools::utils {
 
@@ -53,5 +55,11 @@ const Op& get_selected_operation(boost::program_options::variables_map& app_conf
     }
     throw std::invalid_argument(fmt::format("error: need exactly one {}, cannot specify more then one of {}", alias, all_operation_names));
 }
+
+// Configure seastar with defaults more appropriate for a tool.
+// Make seastar not act as if it owns the place, taking over all system resources.
+// Set WARN as the default log level, except for the logger \p logger_name, which
+// is configured with INFO level.
+void configure_tool_mode(app_template::seastar_options& opts, const sstring& logger_name = {});
 
 } // namespace tools::utils


### PR DESCRIPTION
Which configures seastar to act more appropriate to a tool app. I.e.
don't act as if it owns the place, taking over all system resources.
These tools are often run on a developer machine, or even next to a
running scylla instance, we want them to be the least intrusive
possible.
Also use the new tool mode in the existing tools.

This PR depends on seastar patch: "[PATCH v2 00/13] Allow programatically configuring seastar".

Future plans:
* Expose std allocator in seastar via a config option and use it for tools;