### PR TITLE
commitlog: reduce inclusions of commitlog.hh due to db::commitlog::force_sync

### DIFF
--- a/database.hh
+++ b/database.hh
@@ -46,6 +46,7 @@
 #include <seastar/core/future.hh>
 #include <seastar/core/gate.hh>
 #include "db/commitlog/replay_position.hh"
+#include "db/commitlog/commitlog_types.hh"
 #include <limits>
 #include "schema_fwd.hh"
 #include "db/view/view.hh"
@@ -1303,7 +1304,7 @@ private:
             const frozen_mutation&,
             tracing::trace_state_ptr,
             db::timeout_clock::time_point,
-            db::commitlog::force_sync> _apply_stage;
+            db::commitlog_force_sync> _apply_stage;
 
     flat_hash_map<sstring, keyspace> _keyspaces;
     std::unordered_map<utils::UUID, lw_shared_ptr<column_family>> _column_families;
@@ -1364,8 +1365,8 @@ private:
     void setup_scylla_memory_diagnostics_producer();
 
     friend class db_apply_executor;
-    future<> do_apply(schema_ptr, const frozen_mutation&, tracing::trace_state_ptr tr_state, db::timeout_clock::time_point timeout, db::commitlog::force_sync sync);
-    future<> apply_with_commitlog(schema_ptr, column_family&, utils::UUID, const frozen_mutation&, db::timeout_clock::time_point timeout, db::commitlog::force_sync sync);
+    future<> do_apply(schema_ptr, const frozen_mutation&, tracing::trace_state_ptr tr_state, db::timeout_clock::time_point timeout, db::commitlog_force_sync sync);
+    future<> apply_with_commitlog(schema_ptr, column_family&, utils::UUID, const frozen_mutation&, db::timeout_clock::time_point timeout, db::commitlog_force_sync sync);
     future<> apply_with_commitlog(column_family& cf, const mutation& m, db::timeout_clock::time_point timeout);
 
     future<mutation> do_apply_counter_update(column_family& cf, const frozen_mutation& fm, schema_ptr m_schema, db::timeout_clock::time_point timeout,
@@ -1473,7 +1474,7 @@ public:
                                                 tracing::trace_state_ptr trace_state, db::timeout_clock::time_point timeout);
     // Apply the mutation atomically.
     // Throws timed_out_error when timeout is reached.
-    future<> apply(schema_ptr, const frozen_mutation&, tracing::trace_state_ptr tr_state, db::commitlog::force_sync sync, db::timeout_clock::time_point timeout);
+    future<> apply(schema_ptr, const frozen_mutation&, tracing::trace_state_ptr tr_state, db::commitlog_force_sync sync, db::timeout_clock::time_point timeout);
     future<> apply_hint(schema_ptr, const frozen_mutation&, tracing::trace_state_ptr tr_state, db::timeout_clock::time_point timeout);
     future<mutation> apply_counter_update(schema_ptr, const frozen_mutation& m, db::timeout_clock::time_point timeout, tracing::trace_state_ptr trace_state);
     keyspace::config make_keyspace_config(const keyspace_metadata& ksm);

--- a/db/commitlog/commitlog_entry.hh
+++ b/db/commitlog/commitlog_entry.hh
@@ -23,6 +23,7 @@
 
 #include <optional>
 
+#include "commitlog_types.hh"
 #include "frozen_mutation.hh"
 #include "schema_fwd.hh"
 
@@ -39,7 +40,7 @@ public:
 
 class commitlog_entry_writer {
 public:
-    using force_sync = bool_class<class force_sync_tag>;
+    using force_sync = db::commitlog_force_sync;
 private:
     schema_ptr _schema;
     const frozen_mutation& _mutation;

--- a/db/commitlog/commitlog_types.hh
+++ b/db/commitlog/commitlog_types.hh
@@ -1,0 +1,32 @@
+
+/*
+ * Copyright 2021-present ScyllaDB
+ */
+
+/*
+ * This file is part of Scylla.
+ *
+ * Scylla is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Scylla is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <seastar/util/bool_class.hh>
+#include "seastarx.hh"
+
+namespace db {
+
+using commitlog_force_sync = bool_class<class force_sync_tag>;
+
+}

--- a/db/commitlog/rp_set.hh
+++ b/db/commitlog/rp_set.hh
@@ -43,7 +43,6 @@
 #include <unordered_map>
 
 #include "replay_position.hh"
-#include "commitlog.hh"
 
 namespace db {
 

--- a/table.cc
+++ b/table.cc
@@ -48,6 +48,7 @@
 #include "mutation_source_metadata.hh"
 #include "gms/gossiper.hh"
 #include "db/config.hh"
+#include "db/commitlog/commitlog.hh"
 
 #include <boost/range/algorithm/remove_if.hpp>
 

--- a/test/boost/database_test.cc
+++ b/test/boost/database_test.cc
@@ -39,6 +39,7 @@
 #include "sstables/sstables.hh"
 #include "db/config.hh"
 #include "db/commitlog/commitlog_replayer.hh"
+#include "db/commitlog/commitlog.hh"
 #include "test/lib/tmpdir.hh"
 #include "db/data_listeners.hh"
 #include "multishard_mutation_query.hh"

--- a/test/manual/sstable_scan_footprint_test.cc
+++ b/test/manual/sstable_scan_footprint_test.cc
@@ -28,6 +28,7 @@
 #include "row_cache.hh"
 #include "database.hh"
 #include "db/config.hh"
+#include "db/commitlog/commitlog.hh"
 
 #include <boost/range/irange.hpp>
 #include <seastar/core/app-template.hh>

--- a/test/perf/perf_cache_eviction.cc
+++ b/test/perf/perf_cache_eviction.cc
@@ -27,6 +27,7 @@
 #include <seastar/core/app-template.hh>
 #include "database.hh"
 #include "db/config.hh"
+#include "db/commitlog/commitlog.hh"
 #include "partition_slice_builder.hh"
 #include "utils/int_range.hh"
 #include "utils/div_ceil.hh"


### PR DESCRIPTION
There are now 231 translation units that indirectly include commitlog.hh
due to the need to have access to db::commitlog::force_sync.

Move that type to a new file commitlog_types.hh and make it available
without access to the commitlog class.

This reduces the number of translation units that depend on commitlog.hh
to 84, improving compile time.