### PR TITLE
gossiper: Send generation number with shutdown message

### DIFF
--- a/gms/gossiper.hh
+++ b/gms/gossiper.hh
@@ -128,7 +128,7 @@ private:
     future<> handle_ack_msg(msg_addr from, gossip_digest_ack ack_msg);
     future<> handle_ack2_msg(msg_addr from, gossip_digest_ack2 msg);
     future<> handle_echo_msg(inet_address from, std::optional<int64_t> generation_number_opt);
-    future<> handle_shutdown_msg(inet_address from);
+    future<> handle_shutdown_msg(inet_address from, std::optional<int64_t> generation_number_opt);
     future<> do_send_ack_msg(msg_addr from, gossip_digest_syn syn_msg);
     future<> do_send_ack2_msg(msg_addr from, utils::chunked_vector<gossip_digest> ack_msg_digest);
     future<gossip_get_endpoint_states_response> handle_get_endpoint_states_msg(gossip_get_endpoint_states_request request);

--- a/message/messaging_service.cc
+++ b/message/messaging_service.cc
@@ -1111,14 +1111,14 @@ future<> messaging_service::send_gossip_echo(msg_addr id, int64_t generation_num
     return send_message_timeout<void>(this, messaging_verb::GOSSIP_ECHO, std::move(id), timeout, generation_number);
 }
 
-void messaging_service::register_gossip_shutdown(std::function<rpc::no_wait_type (inet_address from)>&& func) {
+void messaging_service::register_gossip_shutdown(std::function<rpc::no_wait_type (inet_address from, rpc::optional<int64_t> generation_number)>&& func) {
     register_handler(this, messaging_verb::GOSSIP_SHUTDOWN, std::move(func));
 }
 future<> messaging_service::unregister_gossip_shutdown() {
     return unregister_handler(netw::messaging_verb::GOSSIP_SHUTDOWN);
 }
-future<> messaging_service::send_gossip_shutdown(msg_addr id, inet_address from) {
-    return send_message_oneway(this, messaging_verb::GOSSIP_SHUTDOWN, std::move(id), std::move(from));
+future<> messaging_service::send_gossip_shutdown(msg_addr id, inet_address from, int64_t generation_number) {
+    return send_message_oneway(this, messaging_verb::GOSSIP_SHUTDOWN, std::move(id), std::move(from), generation_number);
 }
 
 // gossip syn

--- a/message/messaging_service.hh
+++ b/message/messaging_service.hh
@@ -413,9 +413,9 @@ public:
     future<> send_gossip_echo(msg_addr id, int64_t generation_number, std::chrono::milliseconds timeout);
 
     // Wrapper for GOSSIP_SHUTDOWN
-    void register_gossip_shutdown(std::function<rpc::no_wait_type (inet_address from)>&& func);
+    void register_gossip_shutdown(std::function<rpc::no_wait_type (inet_address from, rpc::optional<int64_t> generation_number)>&& func);
     future<> unregister_gossip_shutdown();
-    future<> send_gossip_shutdown(msg_addr id, inet_address from);
+    future<> send_gossip_shutdown(msg_addr id, inet_address from, int64_t generation_number);
 
     // Wrapper for GOSSIP_DIGEST_SYN
     void register_gossip_digest_syn(std::function<rpc::no_wait_type (const rpc::client_info& cinfo, gms::gossip_digest_syn)>&& func);

--- a/test/manual/message.cc
+++ b/test/manual/message.cc
@@ -108,7 +108,7 @@ public:
             return messaging_service::no_wait();
         });
 
-        ms.register_gossip_shutdown([] (inet_address from) {
+        ms.register_gossip_shutdown([] (inet_address from, rpc::optional<int64_t> generation_number_opt) {
             fmt::print("Server got shutdown msg = {}\n", from);
             return messaging_service::no_wait();
         });
@@ -142,7 +142,8 @@ public:
         fmt::print("=== {} ===\n", __func__);
         auto id = get_msg_addr();
         inet_address from("127.0.0.1");
-        return ms.send_gossip_shutdown(id, from).then([] () {
+        int64_t gen = 0x1;
+        return ms.send_gossip_shutdown(id, from, gen).then([] () {
             fmt::print("Client sent gossip_shutdown got reply = void\n");
             return make_ready_future<>();
         });


### PR DESCRIPTION
Consider:
- n1, n2 in the cluster
- n2 shutdown
- n2 sends gossip shutdown message to n1
- n1 delays processing of the handler of shutdown message
- n2 restarts
- n1 learns new gossip state of n2
- n1 resumes to handle the shutdown message
- n1 will mark n2 as shutdown status incorrectly until n2 restarts again

To prevent this, we can send the gossip generation number along with the
shutdown message. If the generation number does not match the local
generation number for the remote node, the shutdown message will be
ignored.

Since we use the rpc::optional to send the generation number, it works
with mixed cluster.

Fixes #8597