### PR TITLE
transport: remove unused map of stream_id->query states

### DIFF
--- a/transport/server.hh
+++ b/transport/server.hh
@@ -192,7 +192,6 @@ private:
         cql_compression _compression = cql_compression::none;
         cql_serialization_format _cql_serialization_format = cql_serialization_format::latest();
         service::client_state _client_state;
-        std::unordered_map<uint16_t, cql_query_state> _query_states;
         timer<lowres_clock> _shedding_timer;
         bool _shed_incoming_requests = false;
         unsigned _request_cpu = 0;


### PR DESCRIPTION
The map is never touched, so it only occupies precious space for each connection.