### PR TITLE
mutation_source_test: test reverse reads

### DIFF
--- a/db/virtual_table.cc
+++ b/db/virtual_table.cc
@@ -149,8 +149,8 @@ mutation_source streaming_virtual_table::as_mutation_source() {
             }
         };
 
-        auto reader_and_handle = make_queue_reader(_s, permit);
-        auto consumer = std::make_unique<my_result_collector>(_s, permit, &pr, std::move(reader_and_handle.second));
+        auto reader_and_handle = make_queue_reader(s, permit);
+        auto consumer = std::make_unique<my_result_collector>(s, permit, &pr, std::move(reader_and_handle.second));
         auto f = execute(permit, *consumer, *consumer);
 
         // It is safe to discard this future because:

--- a/flat_mutation_reader.hh
+++ b/flat_mutation_reader.hh
@@ -810,16 +810,23 @@ flat_mutation_reader make_nonforwardable(flat_mutation_reader, bool);
 
 flat_mutation_reader make_empty_flat_reader(schema_ptr s, reader_permit permit);
 
+// Mutation vector cannot be empty, all mutations should have the same schema.
 flat_mutation_reader flat_mutation_reader_from_mutations(reader_permit permit, std::vector<mutation>,
         const dht::partition_range& pr = query::full_partition_range, streamed_mutation::forwarding fwd = streamed_mutation::forwarding::no);
+
+// Mutation vector cannot be empty, all mutations should have the same schema.
 inline flat_mutation_reader flat_mutation_reader_from_mutations(reader_permit permit, std::vector<mutation> ms, streamed_mutation::forwarding fwd) {
     return flat_mutation_reader_from_mutations(std::move(permit), std::move(ms), query::full_partition_range, fwd);
 }
+
+// Mutation vector cannot be empty, all mutations should have the same schema.
 flat_mutation_reader
 flat_mutation_reader_from_mutations(reader_permit permit,
                                     std::vector<mutation> ms,
                                     const query::partition_slice& slice,
                                     streamed_mutation::forwarding fwd = streamed_mutation::forwarding::no);
+
+// Mutation vector cannot be empty, all mutations should have the same schema.
 flat_mutation_reader
 flat_mutation_reader_from_mutations(reader_permit permit,
                                     std::vector<mutation> ms,

--- a/flat_mutation_reader.hh
+++ b/flat_mutation_reader.hh
@@ -917,10 +917,14 @@ make_generating_reader(schema_ptr s, reader_permit permit, std::function<future<
 ///     to enforce a limit on memory consumption. When reaching the soft limit
 ///     a warning will be logged. When reaching the hard limit the read will be
 ///     aborted.
+/// \param slice serves as a convenience slice storage for reads that have to
+///     store an edited slice somewhere. This is common for reads that work
+///     with a native-reversed slice and so have to convert the one used in the
+///     query -- which is in half-reversed format.
 ///
 /// FIXME: reversing should be done in the sstable layer, see #1413.
 flat_mutation_reader
-make_reversing_reader(flat_mutation_reader original, query::max_result_size max_size);
+make_reversing_reader(flat_mutation_reader original, query::max_result_size max_size, std::unique_ptr<query::partition_slice> slice = {});
 
 /// A cosumer function that is passed a flat_mutation_reader to be consumed from
 /// and returns a future<> resolved when the reader is fully consumed, and closed.

--- a/memtable.cc
+++ b/memtable.cc
@@ -671,7 +671,7 @@ partition_snapshot_ptr memtable_entry::snapshot(memtable& mtbl) {
 }
 
 flat_mutation_reader
-memtable::make_flat_reader(schema_ptr s,
+memtable::do_make_flat_reader(schema_ptr s,
                       reader_permit permit,
                       const dht::partition_range& range,
                       const query::partition_slice& slice,
@@ -702,13 +702,39 @@ memtable::make_flat_reader(schema_ptr s,
         rd.upgrade_schema(s);
         return rd;
     } else {
-        auto res = make_flat_mutation_reader<scanning_reader>(std::move(s), shared_from_this(), std::move(permit), range, slice, pc, fwd_mr);
-        if (fwd == streamed_mutation::forwarding::yes) {
-            return make_forwardable(std::move(res));
-        } else {
-            return res;
-        }
+        return make_flat_mutation_reader<scanning_reader>(std::move(s), shared_from_this(), std::move(permit), range, slice, pc, fwd_mr);
     }
+}
+
+flat_mutation_reader
+memtable::make_flat_reader(schema_ptr s, reader_permit permit, const dht::partition_range& range, const query::partition_slice& query_slice,
+        const io_priority_class& pc, tracing::trace_state_ptr trace_state_ptr, streamed_mutation::forwarding fwd, mutation_reader::forwarding fwd_mr) {
+    // When the memtable is flushed while a scanning read is ongoing, an sstable
+    // reader is created to replace the memtable reader mid-air. This sstable
+    // reader will get the memtable's slice. We don't want this sstable reader
+    // to read in reverse as we are reversing the stream on top of the memtable
+    // reader. Unreverse the slice here so when it is passed to the sstable
+    // reader it doesn't try to read in reverse. This is not required technically
+    // for single partition reads, but we do it anyway to keep things simple.
+    std::unique_ptr<query::partition_slice> unreversed_slice;
+    const auto reversed = query_slice.options.contains(query::partition_slice::option::reversed);
+    auto fwd_sm = fwd;
+    if (reversed) {
+        fwd_sm = streamed_mutation::forwarding::no;
+        s = s->make_reversed();
+        unreversed_slice = std::make_unique<query::partition_slice>(query::half_reverse_slice(*s, query_slice));
+    }
+    const auto& slice = reversed ? *unreversed_slice : query_slice;
+
+    auto rd = do_make_flat_reader(std::move(s), permit, range, slice, pc, std::move(trace_state_ptr), fwd_sm, fwd_mr);
+
+    if (reversed) {
+        rd = make_reversing_reader(std::move(rd), permit.max_result_size(), std::move(unreversed_slice));
+    }
+    if (fwd && (reversed || !query::is_single_partition(range) || fwd_mr)) {
+        rd = make_forwardable(std::move(rd));
+    }
+    return rd;
 }
 
 flat_mutation_reader

--- a/memtable.hh
+++ b/memtable.hh
@@ -177,6 +177,8 @@ private:
     void remove_flushed_memory(uint64_t);
     void clear() noexcept;
     uint64_t dirty_size() const;
+    flat_mutation_reader do_make_flat_reader(schema_ptr, reader_permit permit, const dht::partition_range& range, const query::partition_slice& slice,
+            const io_priority_class& pc, tracing::trace_state_ptr trace_state_ptr, streamed_mutation::forwarding fwd, mutation_reader::forwarding fwd_mr);
 public:
     explicit memtable(schema_ptr schema, dirty_memory_manager&, table_stats& table_stats, memtable_list *memtable_list = nullptr,
             seastar::scheduling_group compaction_scheduling_group = seastar::current_scheduling_group());

--- a/multishard_mutation_query.cc
+++ b/multishard_mutation_query.cc
@@ -661,7 +661,7 @@ future<page_consume_result<ResultBuilder>> read_page(
     std::exception_ptr ex;
     try {
         auto [ckey, result] = co_await query::consume_page(reader, compaction_state, cmd.slice, std::move(result_builder), cmd.get_row_limit(),
-                cmd.partition_limit, cmd.timestamp, *cmd.max_result_size);
+                cmd.partition_limit, cmd.timestamp);
         const auto& cstats = compaction_state->stats();
         tracing::trace(trace_state, "Page stats: {} partition(s), {} static row(s) ({} live, {} dead), {} clustering row(s) ({} live, {} dead) and {} range tombstone(s)",
                 cstats.partitions,

--- a/mutation_query.hh
+++ b/mutation_query.hh
@@ -150,6 +150,7 @@ class reconcilable_result_builder {
     // make this the last member so it is destroyed first. #7240
     utils::chunked_vector<partition> _result;
 public:
+    // Expects table schema (non-reversed) and half-reversed (legacy) slice when building results for reverse query.
     reconcilable_result_builder(const schema& s, const query::partition_slice& slice,
                                 query::result_memory_accounter&& accounter) noexcept
         : _schema(s), _slice(slice), _reversed(_slice.options.contains(query::partition_slice::option::reversed))

--- a/mutation_reader.hh
+++ b/mutation_reader.hh
@@ -157,6 +157,9 @@ partition_presence_checker make_default_partition_presence_checker() {
 // independent mutation_reader.
 // The reader returns mutations having all the same schema, the one passed
 // when invoking the source.
+// When reading in reverse, a reverse schema has to be passed (compared to the
+// table's schema), and a half-reverse (legacy) slice.
+// See docs/design-notes/reverse-reads.md for more details.
 class mutation_source {
     using partition_range = const dht::partition_range&;
     using io_priority = const io_priority_class&;

--- a/querier.hh
+++ b/querier.hh
@@ -95,17 +95,7 @@ auto consume_page(flat_mutation_reader& reader,
                 compaction_state,
                 clustering_position_tracker(std::move(consumer), last_ckey));
 
-        auto consume = [&reader, &slice, reader_consumer = std::move(reader_consumer), max_size] () mutable {
-            if (slice.options.contains(query::partition_slice::option::reversed)) {
-                return with_closeable(make_reversing_reader(make_flat_mutation_reader<delegating_reader>(reader), max_size),
-                        [reader_consumer = std::move(reader_consumer)] (flat_mutation_reader& reversing_reader) mutable {
-                    return reversing_reader.consume(std::move(reader_consumer));
-                });
-            }
-            return reader.consume(std::move(reader_consumer));
-        };
-
-        return consume().then([last_ckey] (auto&&... results) mutable {
+        return reader.consume(std::move(reader_consumer)).then([last_ckey] (auto&&... results) mutable {
             static_assert(sizeof...(results) <= 1);
             return make_ready_future<std::tuple<std::optional<clustering_key_prefix>, std::decay_t<decltype(results)>...>>(std::tuple(std::move(*last_ckey), std::move(results)...));
         });
@@ -128,14 +118,6 @@ protected:
     std::variant<flat_mutation_reader, reader_concurrency_semaphore::inactive_read_handle> _reader;
     dht::partition_ranges_view _query_ranges;
 
-protected:
-    schema_ptr underlying_schema() const {
-        if (is_reversed()) {
-            return _schema->make_reversed();
-        }
-        return _schema;
-    }
-
 public:
     querier_base(reader_permit permit, std::unique_ptr<const dht::partition_range> range,
             std::unique_ptr<const query::partition_slice> slice, flat_mutation_reader reader, dht::partition_ranges_view query_ranges)
@@ -153,7 +135,7 @@ public:
         , _permit(std::move(permit))
         , _range(std::make_unique<const dht::partition_range>(std::move(range)))
         , _slice(std::make_unique<const query::partition_slice>(std::move(slice)))
-        , _reader(ms.make_reader(underlying_schema(), _permit, *_range, *_slice, pc, std::move(trace_ptr), streamed_mutation::forwarding::no, mutation_reader::forwarding::no))
+        , _reader(ms.make_reader(_schema, _permit, *_range, *_slice, pc, std::move(trace_ptr), streamed_mutation::forwarding::no, mutation_reader::forwarding::no))
         , _query_ranges(*_range)
     { }
 

--- a/querier.hh
+++ b/querier.hh
@@ -83,8 +83,7 @@ auto consume_page(flat_mutation_reader& reader,
         Consumer&& consumer,
         uint64_t row_limit,
         uint32_t partition_limit,
-        gc_clock::time_point query_time,
-        query::max_result_size max_size) {
+        gc_clock::time_point query_time) {
     return reader.peek().then([=, &reader, consumer = std::move(consumer), &slice] (
                 mutation_fragment* next_fragment) mutable {
         const auto next_fragment_kind = next_fragment ? next_fragment->mutation_fragment_kind() : mutation_fragment::kind::partition_end;
@@ -217,10 +216,9 @@ public:
             uint64_t row_limit,
             uint32_t partition_limit,
             gc_clock::time_point query_time,
-            query::max_result_size max_size,
             tracing::trace_state_ptr trace_ptr = {}) {
         return ::query::consume_page(std::get<flat_mutation_reader>(_reader), _compaction_state, *_slice, std::move(consumer), row_limit,
-                partition_limit, query_time, max_size).then([this, trace_ptr = std::move(trace_ptr)] (auto&& results) {
+                partition_limit, query_time).then([this, trace_ptr = std::move(trace_ptr)] (auto&& results) {
             _last_ckey = std::get<std::optional<clustering_key>>(std::move(results));
             const auto& cstats = _compaction_state->stats();
             tracing::trace(trace_ptr, "Page stats: {} partition(s), {} static row(s) ({} live, {} dead), {} clustering row(s) ({} live, {} dead) and {} range tombstone(s)",

--- a/query-request.hh
+++ b/query-request.hh
@@ -239,11 +239,15 @@ public:
 };
 
 // See docs/design-notes/reverse-reads.md
+// In the following functions, `schema` may be reversed or not (both work).
 partition_slice legacy_reverse_slice_to_native_reverse_slice(const schema& schema, partition_slice slice);
 partition_slice native_reverse_slice_to_legacy_reverse_slice(const schema& schema, partition_slice slice);
-// Fully reverse slice (forward to native reverse)
-// Also set the reversed bit in `partition_slice::options`.
+// Fully reverse slice (forward to native reverse or native reverse to forward).
+// Also toggles the reversed bit in `partition_slice::options`.
 partition_slice reverse_slice(const schema& schema, partition_slice slice);
+// Half reverse slice (forwad to legacy reverse or legacy reverse to forward).
+// Also toggles the reversed bit in `partition_slice::options`.
+partition_slice half_reverse_slice(const schema&, partition_slice);
 
 constexpr auto max_partitions = std::numeric_limits<uint32_t>::max();
 

--- a/query.cc
+++ b/query.cc
@@ -150,6 +150,19 @@ partition_slice reverse_slice(const schema& schema, partition_slice slice) {
         .build();
 }
 
+partition_slice half_reverse_slice(const schema& schema, partition_slice slice) {
+    return partition_slice_builder(schema, std::move(slice))
+        .mutate_ranges([] (clustering_row_ranges& ranges) {
+            std::reverse(ranges.begin(), ranges.end());
+        })
+        .mutate_specific_ranges([] (specific_ranges& sranges) {
+            auto& ranges = sranges.ranges();
+            std::reverse(ranges.begin(), ranges.end());
+        })
+        .with_option_toggled<partition_slice::option::reversed>()
+        .build();
+}
+
 partition_slice::partition_slice(clustering_row_ranges row_ranges,
     query::column_id_vector static_columns,
     query::column_id_vector regular_columns,

--- a/row_cache.hh
+++ b/row_cache.hh
@@ -359,6 +359,9 @@ private:
     //
     // internal_updater is only kept alive until its invocation returns.
     future<> do_update(external_updater eu, internal_updater iu) noexcept;
+
+    flat_mutation_reader do_make_reader(schema_ptr, reader_permit permit, const dht::partition_range&, const query::partition_slice&,
+            const io_priority_class&, tracing::trace_state_ptr, streamed_mutation::forwarding, mutation_reader::forwarding);
 public:
     ~row_cache();
     row_cache(schema_ptr, snapshot_source, cache_tracker&, is_continuous = is_continuous::no);

--- a/sstables/sstable_set.cc
+++ b/sstables/sstable_set.cc
@@ -875,12 +875,13 @@ time_series_sstable_set::create_single_key_sstable_reader(
             return false;
     };
 
+    auto reversed = slice.options.contains(query::partition_slice::option::reversed);
     // Note that `sstable_position_reader_queue` always includes a reader which emits a `partition_start` fragment,
     // guaranteeing that the reader we return emits it as well; this helps us avoid the problem from #3552.
     return make_clustering_combined_reader(
             schema, permit, fwd_sm,
             make_position_reader_queue(
-                std::move(create_reader), std::move(filter), *pos.key(), schema, permit, fwd_sm, false));
+                std::move(create_reader), std::move(filter), *pos.key(), schema, permit, fwd_sm, reversed));
 }
 
 compound_sstable_set::compound_sstable_set(schema_ptr schema, std::vector<lw_shared_ptr<sstable_set>> sets)

--- a/table.cc
+++ b/table.cc
@@ -2002,7 +2002,7 @@ table::query(schema_ptr s,
 
         std::exception_ptr ex;
       try {
-        co_await q.consume_page(query_result_builder(*s, qs.builder), qs.remaining_rows(), qs.remaining_partitions(), qs.cmd.timestamp, permit.max_result_size(), trace_state);
+        co_await q.consume_page(query_result_builder(*s, qs.builder), qs.remaining_rows(), qs.remaining_partitions(), qs.cmd.timestamp, trace_state);
       } catch (...) {
         ex = std::current_exception();
       }
@@ -2055,7 +2055,7 @@ table::mutation_query(schema_ptr s,
     // legacy format.
     auto result_schema = cmd.slice.options.contains(query::partition_slice::option::reversed) ? s->make_reversed() : s;
     auto rrb = reconcilable_result_builder(*result_schema, cmd.slice, std::move(accounter));
-    auto r = co_await q.consume_page(std::move(rrb), cmd.get_row_limit(), cmd.partition_limit, cmd.timestamp, permit.max_result_size(), trace_state);
+    auto r = co_await q.consume_page(std::move(rrb), cmd.get_row_limit(), cmd.partition_limit, cmd.timestamp, trace_state);
 
     if (!saved_querier || (!q.are_limits_reached() && !r.is_short_read())) {
         co_await q.close();

--- a/test/boost/mutation_query_test.cc
+++ b/test/boost/mutation_query_test.cc
@@ -96,8 +96,7 @@ static reconcilable_result mutation_query(schema_ptr s, reader_permit permit, co
     auto close_querier = deferred_close(querier);
     auto table_schema = slice.options.contains(query::partition_slice::option::reversed) ? s->make_reversed() : s;
     auto rrb = reconcilable_result_builder(*table_schema, slice, make_accounter());
-    return querier.consume_page(std::move(rrb), row_limit, partition_limit, query_time,
-            query::max_result_size(std::numeric_limits<uint64_t>::max())).get();
+    return querier.consume_page(std::move(rrb), row_limit, partition_limit, query_time).get();
 }
 
 SEASTAR_TEST_CASE(test_reading_from_single_partition) {
@@ -547,8 +546,7 @@ static void data_query(schema_ptr s, reader_permit permit, const mutation_source
     auto querier = query::data_querier(source, s, std::move(permit), range, slice, service::get_local_sstable_query_read_priority(), {});
     auto close_querier = deferred_close(querier);
     auto qrb = query_result_builder(*s, builder);
-    querier.consume_page(std::move(qrb), std::numeric_limits<uint32_t>::max(), std::numeric_limits<uint32_t>::max(), gc_clock::now(),
-            query::max_result_size(std::numeric_limits<uint64_t>::max())).get();
+    querier.consume_page(std::move(qrb), std::numeric_limits<uint32_t>::max(), std::numeric_limits<uint32_t>::max(), gc_clock::now()).get();
 }
 
 SEASTAR_THREAD_TEST_CASE(test_result_size_calculation) {

--- a/test/boost/mutation_reader_test.cc
+++ b/test/boost/mutation_reader_test.cc
@@ -2731,14 +2731,15 @@ SEASTAR_THREAD_TEST_CASE(test_manual_paused_evictable_reader_is_mutation_source)
     public:
         maybe_pausing_reader(
                 memtable& mt,
+                schema_ptr query_schema,
                 reader_permit permit,
                 const dht::partition_range& pr,
                 const query::partition_slice& ps,
                 const io_priority_class& pc,
                 tracing::trace_state_ptr trace_state,
                 mutation_reader::forwarding fwd_mr)
-            : impl(mt.schema(), std::move(permit)), _reader(nullptr) {
-            std::tie(_reader, _handle) = make_manually_paused_evictable_reader(mt.as_data_source(), mt.schema(), _permit, pr, ps, pc,
+            : impl(std::move(query_schema), std::move(permit)), _reader(nullptr) {
+            std::tie(_reader, _handle) = make_manually_paused_evictable_reader(mt.as_data_source(), _schema, _permit, pr, ps, pc,
                     std::move(trace_state), fwd_mr);
         }
         virtual future<> fill_buffer() override {
@@ -2786,7 +2787,7 @@ SEASTAR_THREAD_TEST_CASE(test_manual_paused_evictable_reader_is_mutation_source)
                 tracing::trace_state_ptr trace_state,
                 streamed_mutation::forwarding fwd_sm,
                 mutation_reader::forwarding fwd_mr) mutable {
-            auto mr = make_flat_mutation_reader<maybe_pausing_reader>(*mt, std::move(permit), range, slice, pc, std::move(trace_state), fwd_mr);
+            auto mr = make_flat_mutation_reader<maybe_pausing_reader>(*mt, s, std::move(permit), range, slice, pc, std::move(trace_state), fwd_mr);
             if (fwd_sm == streamed_mutation::forwarding::yes) {
                 return make_forwardable(std::move(mr));
             }

--- a/test/boost/mutation_reader_test.cc
+++ b/test/boost/mutation_reader_test.cc
@@ -3811,13 +3811,13 @@ SEASTAR_TEST_CASE(test_clustering_order_merger_sstable_set) {
             (const time_series_sstable_set& sst_set,
                 const std::unordered_set<int64_t>& included_gens, streamed_mutation::forwarding fwd) {
         auto permit = env.make_reader_permit();
-        auto q = sst_set.make_min_position_reader_queue(
+        auto q = sst_set.make_position_reader_queue(
             [s, &pr, fwd, permit] (sstable& sst) {
                 return sst.make_reader_v1(s, permit, pr,
                                           s->full_slice(), seastar::default_priority_class(), nullptr, fwd);
             },
             [included_gens] (const sstable& sst) { return included_gens.contains(sst.generation()); },
-            pk, s, permit, fwd);
+            pk, s, permit, fwd, false);
         return make_clustering_combined_reader(s, permit, fwd, std::move(q));
     };
 

--- a/test/boost/querier_cache_test.cc
+++ b/test/boost/querier_cache_test.cc
@@ -221,8 +221,7 @@ public:
         const auto cache_key = make_cache_key(key);
 
         auto querier = make_querier<Querier>(range);
-        auto dk_ck = querier.consume_page(dummy_result_builder{}, row_limit, std::numeric_limits<uint32_t>::max(),
-                gc_clock::now(), query::max_result_size(std::numeric_limits<uint64_t>::max())).get0();
+        auto dk_ck = querier.consume_page(dummy_result_builder{}, row_limit, std::numeric_limits<uint32_t>::max(), gc_clock::now()).get0();
         auto&& dk = dk_ck.first;
         auto&& ck = dk_ck.second;
         auto permit = querier.permit();

--- a/test/lib/flat_mutation_reader_assertions.hh
+++ b/test/lib/flat_mutation_reader_assertions.hh
@@ -304,6 +304,7 @@ public:
     }
 
     flat_reader_assertions& produces(const schema& s, const mutation_fragment& mf) {
+        testlog.trace("Expect {}", mutation_fragment::printer(s, mf));
         auto mfopt = read_next();
         if (!mfopt) {
             BOOST_FAIL(format("Expected {}, but got end of stream", mutation_fragment::printer(*_reader.schema(), mf)));

--- a/test/lib/mutation_source_test.cc
+++ b/test/lib/mutation_source_test.cc
@@ -1773,6 +1773,34 @@ void run_mutation_source_tests(populate_fn_ex populate, bool with_partition_rang
                     ms.make_reader(s, std::move(permit), pr, slice, pc, std::move(tr), fwd, mr_fwd));
         });
     }, with_partition_range_forwarding);
+
+    // read in reverse
+    run_mutation_reader_tests([populate] (schema_ptr s, const std::vector<mutation>& m, gc_clock::time_point t) -> mutation_source {
+        auto table_schema = s->make_reversed();
+
+        std::vector<mutation> reversed_mutations;
+        reversed_mutations.reserve(m.size());
+        for (const auto& mut : m) {
+            reversed_mutations.emplace_back(reverse(mut));
+        }
+        auto ms = populate(table_schema, reversed_mutations, t);
+
+        return mutation_source([table_schema, ms = std::move(ms), reversed_slices = std::list<query::partition_slice>()] (
+                    schema_ptr query_schema,
+                    reader_permit permit,
+                    const dht::partition_range& pr,
+                    const query::partition_slice& slice,
+                    const io_priority_class& pc,
+                    tracing::trace_state_ptr tr,
+                    streamed_mutation::forwarding fwd,
+                    mutation_reader::forwarding mr_fwd) mutable {
+            reversed_slices.emplace_back(partition_slice_builder(*table_schema, query::native_reverse_slice_to_legacy_reverse_slice(*table_schema, slice))
+                        .with_option<query::partition_slice::option::reversed>()
+                        .build());
+
+            return ms.make_reader(query_schema, std::move(permit), pr, reversed_slices.back(), pc, tr, fwd, mr_fwd);
+        });
+    }, false); // FIXME: pass with_partition_range_forwarding after all natively reversing sources have fast-forwarding support
 }
 
 struct mutation_sets {

--- a/test/perf/perf_row_cache_reads.cc
+++ b/test/perf/perf_row_cache_reads.cc
@@ -210,8 +210,7 @@ void test_scan_with_range_delete_over_rows() {
             q.consume_page(noop_compacted_fragments_consumer(),
                            std::numeric_limits<uint32_t>::max(),
                            std::numeric_limits<uint32_t>::max(),
-                           gc_clock::now(),
-                           query::max_result_size(query::result_memory_limiter::unlimited_result_size)).get();
+                           gc_clock::now()).get();
         });
 
         slm.stop();


### PR DESCRIPTION
Currently no mutation-source supports reading in reverse natively but we are working on changing that, adding native reverse read support to memtable, cache and sstable readers. To ensure that all mutation sources work in a correct and uniform manner when reading in reverse, we add a reverse test to the mutation source test suite. This test reverses the data that it passes to `populate()`, then reads in forward order (in reverse compared to the data order). For this we use the currently established reverse read API: reverse schema (schema order == query order) and half-reversed (legacy) slice.
All mutation sources are prepared to work with reversed reads, using the `make_reversing_reader()` adapter. As we progress with our native reverse support, we will replace these adapters with native reversing support. As part of this, we push down the reversing reader adapter currently existing on the `query::consume_page()` level, to the individual mutation sources.
