### PR TITLE
Loading cache improve eviction use policy

### DIFF
--- a/alternator/auth.hh
+++ b/alternator/auth.hh
@@ -35,7 +35,7 @@ namespace alternator {
 
 using hmac_sha256_digest = std::array<char, 32>;
 
-using key_cache = utils::loading_cache<std::string, std::string>;
+using key_cache = utils::loading_cache<std::string, std::string, 1>;
 
 std::string get_signature(std::string_view access_key_id, std::string_view secret_access_key, std::string_view host, std::string_view method,
         std::string_view orig_datestamp, std::string_view signed_headers_str, const std::map<std::string_view, std::string_view>& signed_headers_map,

--- a/auth/permissions_cache.hh
+++ b/auth/permissions_cache.hh
@@ -67,6 +67,7 @@ class permissions_cache final {
     using cache_type = utils::loading_cache<
             std::pair<role_or_anonymous, resource>,
             permission_set,
+            1,
             utils::loading_cache_reload_enabled::yes,
             utils::simple_entry_size<permission_set>,
             utils::tuple_hash>;

--- a/cql3/authorized_prepared_statements_cache.hh
+++ b/cql3/authorized_prepared_statements_cache.hh
@@ -115,6 +115,7 @@ private:
     using checked_weak_ptr = typename statements::prepared_statement::checked_weak_ptr;
     using cache_type = utils::loading_cache<cache_key_type,
                                             checked_weak_ptr,
+                                            1,
                                             utils::loading_cache_reload_enabled::yes,
                                             authorized_prepared_statements_cache_size,
                                             std::hash<cache_key_type>,

--- a/cql3/authorized_prepared_statements_cache.hh
+++ b/cql3/authorized_prepared_statements_cache.hh
@@ -94,6 +94,7 @@ class authorized_prepared_statements_cache {
 public:
     struct stats {
         uint64_t authorized_prepared_statements_cache_evictions = 0;
+        uint64_t authorized_prepared_statements_new_gen_on_cache_size_evictions = 0;
     };
 
     static stats& shard_stats() {
@@ -108,6 +109,10 @@ public:
         static void inc_evictions() noexcept {
             ++shard_stats().authorized_prepared_statements_cache_evictions;
         }
+
+        static void inc_new_gen_on_cache_size_eviction() noexcept {
+            ++shard_stats().authorized_prepared_statements_new_gen_on_cache_size_evictions;
+        }
     };
 
 private:
@@ -120,6 +125,7 @@ private:
                                             authorized_prepared_statements_cache_size,
                                             std::hash<cache_key_type>,
                                             std::equal_to<cache_key_type>,
+                                            authorized_prepared_statements_cache_stats_updater,
                                             authorized_prepared_statements_cache_stats_updater>;
 
 public:

--- a/cql3/prepared_statements_cache.hh
+++ b/cql3/prepared_statements_cache.hh
@@ -84,6 +84,7 @@ class prepared_statements_cache {
 public:
     struct stats {
         uint64_t prepared_cache_evictions = 0;
+        uint64_t new_gen_on_cache_size_evictions = 0;
     };
 
     static stats& shard_stats() {
@@ -98,6 +99,9 @@ public:
         static void inc_evictions() noexcept {
             ++shard_stats().prepared_cache_evictions;
         }
+        static void inc_new_gen_on_cache_size_eviction() noexcept {
+            ++shard_stats().new_gen_on_cache_size_evictions;
+        }
     };
 
 private:
@@ -109,7 +113,7 @@ private:
     //
     // Therefore a typical "pollution" (when a cache entry is used only once) would involve
     // 2 cache hits.
-    using cache_type = utils::loading_cache<cache_key_type, prepared_cache_entry, 2, utils::loading_cache_reload_enabled::no, prepared_cache_entry_size, utils::tuple_hash, std::equal_to<cache_key_type>, prepared_cache_stats_updater>;
+    using cache_type = utils::loading_cache<cache_key_type, prepared_cache_entry, 2, utils::loading_cache_reload_enabled::no, prepared_cache_entry_size, utils::tuple_hash, std::equal_to<cache_key_type>, prepared_cache_stats_updater, prepared_cache_stats_updater>;
     using cache_value_ptr = typename cache_type::value_ptr;
     using checked_weak_ptr = typename statements::prepared_statement::checked_weak_ptr;
 

--- a/cql3/query_processor.cc
+++ b/cql3/query_processor.cc
@@ -348,6 +348,11 @@ query_processor::query_processor(service::storage_proxy& proxy, database& db, se
                             [] { return prepared_statements_cache::shard_stats().prepared_cache_evictions; },
                             sm::description("Counts the number of prepared statements cache entries evictions.")),
 
+                    sm::make_derive(
+                            "new_gen_on_cache_size_evictions",
+                            [] { return prepared_statements_cache::shard_stats().new_gen_on_cache_size_evictions; },
+                            sm::description("Counts the number of prepared statements cache entries evictions from the new generation partition due to a cache size restrictions. This is usually a sign of a cache pollution.")),
+
                     sm::make_gauge(
                             "prepared_cache_size",
                             [this] { return _prepared_cache.size(); },
@@ -428,6 +433,11 @@ query_processor::query_processor(service::storage_proxy& proxy, database& db, se
                             "authorized_prepared_statements_cache_evictions",
                             [] { return authorized_prepared_statements_cache::shard_stats().authorized_prepared_statements_cache_evictions; },
                             sm::description("Counts the number of authenticated prepared statements cache entries evictions.")),
+
+                    sm::make_derive(
+                            "authorized_prepared_statements_new_gen_on_cache_size_evictions",
+                            [] { return authorized_prepared_statements_cache::shard_stats().authorized_prepared_statements_new_gen_on_cache_size_evictions; },
+                            sm::description("Counts the number of authenticated prepared statements cache entries evictions from the new generation partition due to a cache size restrictions. This is usually a sign of a cache pollution.")),
 
                     sm::make_gauge(
                             "authorized_prepared_statements_cache_size",

--- a/utils/loading_cache.hh
+++ b/utils/loading_cache.hh
@@ -45,10 +45,66 @@ namespace bi = boost::intrusive;
 
 namespace utils {
 
+enum class loading_cache_reload_enabled { no, yes };
+
+template <typename Tp>
+struct simple_entry_size {
+    size_t operator()(const Tp& val) {
+        return 1;
+    }
+};
+
+/// \brief Loading cache is a cache that loads the value into the cache using the given asynchronous callback.
+///
+/// Each cached value if reloading is enabled (\tparam ReloadEnabled == loading_cache_reload_enabled::yes) is reloaded after
+/// the "refresh" time period since it was loaded for the last time.
+///
+/// The values are going to be evicted from the cache if they are not accessed during the "expiration" period or haven't
+/// been reloaded even once during the same period.
+///
+/// If "expiration" is set to zero - the caching is going to be disabled and get_XXX(...) is going to call the "loader" callback
+/// every time in order to get the requested value.
+///
+/// \note In order to avoid the eviction of cached entries due to "aging" of the contained value the user has to choose
+/// the "expiration" to be at least ("refresh" + "max load latency"). This way the value is going to stay in the cache and is going to be
+/// read in a non-blocking way as long as it's frequently accessed. Note however that since reloading is an asynchronous
+/// procedure it may get delayed by other running task. Therefore choosing the "expiration" too close to the ("refresh" + "max load latency")
+/// value one risks to have his/her cache values evicted when the system is heavily loaded.
+///
+/// The cache is also limited in size and if adding the next value is going
+/// to exceed the cache size limit the least recently used value(s) is(are) going to be evicted until the size of the cache
+/// becomes such that adding the new value is not going to break the size limit. If the new entry's size is greater than
+/// the cache size then the get_XXX(...) method is going to return a future with the loading_cache::entry_is_too_big exception.
+///
+/// The size of the cache is defined as a sum of sizes of all cached entries.
+/// The size of each entry is defined by the value returned by the \tparam EntrySize predicate applied on it.
+///
+/// The get(key) or get_ptr(key) methods ensures that the "loader" callback is called only once for each cached entry regardless of how many
+/// callers are calling for the get_XXX(key) for the same "key" at the same time. Only after the value is evicted from the cache
+/// it's going to be "loaded" in the context of get_XXX(key). As long as the value is cached get_XXX(key) is going to return the
+/// cached value immediately and reload it in the background every "refresh" time period as described above.
+///
+/// \tparam Key type of the cache key
+/// \tparam Tp type of the cached value
+/// \tparam ReloadEnabled if loading_cache_reload_enabled::yes allow reloading the values otherwise don't reload
+/// \tparam EntrySize predicate to calculate the entry size
+/// \tparam Hash hash function
+/// \tparam EqualPred equality predicate
+/// \tparam LoadingSharedValuesStats statistics incrementing class (see utils::loading_shared_values)
+/// \tparam Alloc elements allocator
+template<typename Key,
+         typename Tp,
+         loading_cache_reload_enabled ReloadEnabled = loading_cache_reload_enabled::no,
+         typename EntrySize = simple_entry_size<Tp>,
+         typename Hash = std::hash<Key>,
+         typename EqualPred = std::equal_to<Key>,
+         typename LoadingSharedValuesStats = utils::do_nothing_loading_shared_values_stats,
+         typename Alloc = std::pmr::polymorphic_allocator<>>
+class loading_cache {
+
 using loading_cache_clock_type = seastar::lowres_clock;
 using safe_link_list_hook = bi::list_base_hook<bi::link_mode<bi::safe_link>>;
 
-template<typename Tp, typename Key, typename EntrySize , typename Hash, typename EqualPred, typename LoadingSharedValuesStats>
 class timestamped_val {
 public:
     using value_type = Tp;
@@ -122,161 +178,17 @@ private:
     }
 };
 
-template <typename Tp>
-struct simple_entry_size {
-    size_t operator()(const Tp& val) {
-        return 1;
-    }
-};
-
-template<typename Tp, typename Key, typename EntrySize , typename Hash, typename EqualPred, typename LoadingSharedValuesStats>
-class timestamped_val<Tp, Key, EntrySize, Hash, EqualPred, LoadingSharedValuesStats>::value_ptr {
 private:
-    using ts_value_type = timestamped_val<Tp, Key, EntrySize, Hash, EqualPred, LoadingSharedValuesStats>;
-    using loading_values_type = typename ts_value_type::loading_values_type;
-
-public:
+    using loading_values_type = typename timestamped_val::loading_values_type;
     using timestamped_val_ptr = typename loading_values_type::entry_ptr;
-    using value_type = Tp;
-
-private:
-    timestamped_val_ptr _ts_val_ptr;
-
-public:
-    value_ptr(timestamped_val_ptr ts_val_ptr) : _ts_val_ptr(std::move(ts_val_ptr)) {
-        if (_ts_val_ptr) {
-            _ts_val_ptr->touch();
-        }
-    }
-    value_ptr(std::nullptr_t) noexcept : _ts_val_ptr() {}
-    bool operator==(const value_ptr& x) const { return _ts_val_ptr == x._ts_val_ptr; }
-    bool operator!=(const value_ptr& x) const { return !operator==(x); }
-    explicit operator bool() const noexcept { return bool(_ts_val_ptr); }
-    value_type& operator*() const noexcept { return _ts_val_ptr->value(); }
-    value_type* operator->() const noexcept { return &_ts_val_ptr->value(); }
-
-    friend std::ostream& operator<<(std::ostream& os, const value_ptr& vp) {
-        return os << vp._ts_val_ptr;
-    }
-};
-
-/// \brief This is and LRU list entry which is also an anchor for a loading_cache value.
-template<typename Tp, typename Key, typename EntrySize , typename Hash, typename EqualPred, typename LoadingSharedValuesStats>
-class timestamped_val<Tp, Key, EntrySize, Hash, EqualPred, LoadingSharedValuesStats>::lru_entry : public safe_link_list_hook {
-private:
-    using ts_value_type = timestamped_val<Tp, Key, EntrySize, Hash, EqualPred, LoadingSharedValuesStats>;
-    using loading_values_type = typename ts_value_type::loading_values_type;
-
-public:
-    using lru_list_type = bi::list<lru_entry>;
-    using timestamped_val_ptr = typename loading_values_type::entry_ptr;
-
-private:
-    timestamped_val_ptr _ts_val_ptr;
-    lru_list_type& _lru_list;
-    size_t& _cache_size;
-
-public:
-    lru_entry(timestamped_val_ptr ts_val, lru_list_type& lru_list, size_t& cache_size)
-        : _ts_val_ptr(std::move(ts_val))
-        , _lru_list(lru_list)
-        , _cache_size(cache_size)
-    {
-        _ts_val_ptr->set_anchor_back_reference(this);
-        _cache_size += _ts_val_ptr->size();
-    }
-
-    ~lru_entry() {
-        if (safe_link_list_hook::is_linked()) {
-            _lru_list.erase(_lru_list.iterator_to(*this));
-        }
-        _cache_size -= _ts_val_ptr->size();
-        _ts_val_ptr->set_anchor_back_reference(nullptr);
-    }
-
-    size_t& cache_size() noexcept {
-        return _cache_size;
-    }
-
-    /// Set this item as the most recently used item.
-    /// The MRU item is going to be at the front of the _lru_list, the LRU item - at the back.
-    void touch() noexcept {
-        if (safe_link_list_hook::is_linked()) {
-            _lru_list.erase(_lru_list.iterator_to(*this));
-        }
-        _lru_list.push_front(*this);
-    }
-
-    const Key& key() const noexcept {
-        return loading_values_type::to_key(_ts_val_ptr);
-    }
-
-    timestamped_val& timestamped_value() noexcept { return *_ts_val_ptr; }
-    const timestamped_val& timestamped_value() const noexcept { return *_ts_val_ptr; }
-    timestamped_val_ptr timestamped_value_ptr() noexcept { return _ts_val_ptr; }
-};
-
-enum class loading_cache_reload_enabled { no, yes };
-
-/// \brief Loading cache is a cache that loads the value into the cache using the given asynchronous callback.
-///
-/// Each cached value if reloading is enabled (\tparam ReloadEnabled == loading_cache_reload_enabled::yes) is reloaded after
-/// the "refresh" time period since it was loaded for the last time.
-///
-/// The values are going to be evicted from the cache if they are not accessed during the "expiration" period or haven't
-/// been reloaded even once during the same period.
-///
-/// If "expiration" is set to zero - the caching is going to be disabled and get_XXX(...) is going to call the "loader" callback
-/// every time in order to get the requested value.
-///
-/// \note In order to avoid the eviction of cached entries due to "aging" of the contained value the user has to choose
-/// the "expiration" to be at least ("refresh" + "max load latency"). This way the value is going to stay in the cache and is going to be
-/// read in a non-blocking way as long as it's frequently accessed. Note however that since reloading is an asynchronous
-/// procedure it may get delayed by other running task. Therefore choosing the "expiration" too close to the ("refresh" + "max load latency")
-/// value one risks to have his/her cache values evicted when the system is heavily loaded.
-///
-/// The cache is also limited in size and if adding the next value is going
-/// to exceed the cache size limit the least recently used value(s) is(are) going to be evicted until the size of the cache
-/// becomes such that adding the new value is not going to break the size limit. If the new entry's size is greater than
-/// the cache size then the get_XXX(...) method is going to return a future with the loading_cache::entry_is_too_big exception.
-///
-/// The size of the cache is defined as a sum of sizes of all cached entries.
-/// The size of each entry is defined by the value returned by the \tparam EntrySize predicate applied on it.
-///
-/// The get(key) or get_ptr(key) methods ensures that the "loader" callback is called only once for each cached entry regardless of how many
-/// callers are calling for the get_XXX(key) for the same "key" at the same time. Only after the value is evicted from the cache
-/// it's going to be "loaded" in the context of get_XXX(key). As long as the value is cached get_XXX(key) is going to return the
-/// cached value immediately and reload it in the background every "refresh" time period as described above.
-///
-/// \tparam Key type of the cache key
-/// \tparam Tp type of the cached value
-/// \tparam ReloadEnabled if loading_cache_reload_enabled::yes allow reloading the values otherwise don't reload
-/// \tparam EntrySize predicate to calculate the entry size
-/// \tparam Hash hash function
-/// \tparam EqualPred equality predicate
-/// \tparam LoadingSharedValuesStats statistics incrementing class (see utils::loading_shared_values)
-/// \tparam Alloc elements allocator
-template<typename Key,
-         typename Tp,
-         loading_cache_reload_enabled ReloadEnabled = loading_cache_reload_enabled::no,
-         typename EntrySize = simple_entry_size<Tp>,
-         typename Hash = std::hash<Key>,
-         typename EqualPred = std::equal_to<Key>,
-         typename LoadingSharedValuesStats = utils::do_nothing_loading_shared_values_stats,
-         typename Alloc = std::pmr::polymorphic_allocator<>>
-class loading_cache {
-private:
-    using ts_value_type = timestamped_val<Tp, Key, EntrySize, Hash, EqualPred, LoadingSharedValuesStats>;
-    using loading_values_type = typename ts_value_type::loading_values_type;
-    using timestamped_val_ptr = typename loading_values_type::entry_ptr;
-    using ts_value_lru_entry = typename ts_value_type::lru_entry;
+    using ts_value_lru_entry = typename timestamped_val::lru_entry;
     using lru_list_type = typename ts_value_lru_entry::lru_list_type;
     using list_iterator = typename lru_list_type::iterator;
 
 public:
     using value_type = Tp;
     using key_type = Key;
-    using value_ptr = typename ts_value_type::value_ptr;
+    using value_ptr = typename timestamped_val::value_ptr;
 
     class entry_is_too_big : public std::exception {};
 
@@ -339,7 +251,7 @@ public:
 
         return _loading_values.get_or_load(k, [this, load = std::forward<LoadFunc>(load)] (const Key& k) mutable {
             return load(k).then([this] (value_type val) {
-                return ts_value_type(std::move(val));
+                return timestamped_val(std::move(val));
             });
         }).then([this, k] (timestamped_val_ptr ts_val_ptr) {
             // check again since it could have already been inserted and initialized
@@ -511,7 +423,7 @@ private:
         _lru_list.remove_and_dispose_if([now, this] (const ts_value_lru_entry& lru_entry) {
             using namespace std::chrono;
             // An entry should be discarded if it hasn't been reloaded for too long or nobody cares about it anymore
-            const ts_value_type& v = lru_entry.timestamped_value();
+            const timestamped_val& v = lru_entry.timestamped_value();
             auto since_last_read = now - v.last_read();
             auto since_loaded = now - v.loaded();
             if (_expiry < since_last_read || (ReloadEnabled == loading_cache_reload_enabled::yes && _expiry < since_loaded)) {
@@ -591,6 +503,91 @@ private:
     std::function<future<Tp>(const Key&)> _load;
     timer<loading_cache_clock_type> _timer;
     seastar::gate _timer_reads_gate;
+};
+
+template<typename Key, typename Tp, loading_cache_reload_enabled ReloadEnabled, typename EntrySize, typename Hash, typename EqualPred, typename LoadingSharedValuesStats, typename Alloc>
+class loading_cache<Key, Tp, ReloadEnabled, EntrySize, Hash, EqualPred, LoadingSharedValuesStats, Alloc>::timestamped_val::value_ptr {
+private:
+    using loading_values_type = typename timestamped_val::loading_values_type;
+
+public:
+    using timestamped_val_ptr = typename loading_values_type::entry_ptr;
+    using value_type = Tp;
+
+private:
+    timestamped_val_ptr _ts_val_ptr;
+
+public:
+    value_ptr(timestamped_val_ptr ts_val_ptr) : _ts_val_ptr(std::move(ts_val_ptr)) {
+        if (_ts_val_ptr) {
+            _ts_val_ptr->touch();
+        }
+    }
+    value_ptr(std::nullptr_t) noexcept : _ts_val_ptr() {}
+    bool operator==(const value_ptr& x) const { return _ts_val_ptr == x._ts_val_ptr; }
+    bool operator!=(const value_ptr& x) const { return !operator==(x); }
+    explicit operator bool() const noexcept { return bool(_ts_val_ptr); }
+    value_type& operator*() const noexcept { return _ts_val_ptr->value(); }
+    value_type* operator->() const noexcept { return &_ts_val_ptr->value(); }
+
+    friend std::ostream& operator<<(std::ostream& os, const value_ptr& vp) {
+        return os << vp._ts_val_ptr;
+    }
+};
+
+/// \brief This is and LRU list entry which is also an anchor for a loading_cache value.
+template<typename Key, typename Tp, loading_cache_reload_enabled ReloadEnabled, typename EntrySize, typename Hash, typename EqualPred, typename LoadingSharedValuesStats, typename Alloc>
+class loading_cache<Key, Tp, ReloadEnabled, EntrySize, Hash, EqualPred, LoadingSharedValuesStats, Alloc>::timestamped_val::lru_entry : public safe_link_list_hook {
+private:
+    using loading_values_type = typename timestamped_val::loading_values_type;
+
+public:
+    using lru_list_type = bi::list<lru_entry>;
+    using timestamped_val_ptr = typename loading_values_type::entry_ptr;
+
+private:
+    timestamped_val_ptr _ts_val_ptr;
+    lru_list_type& _lru_list;
+    size_t& _cache_size;
+
+public:
+    lru_entry(timestamped_val_ptr ts_val, lru_list_type& lru_list, size_t& cache_size)
+        : _ts_val_ptr(std::move(ts_val))
+        , _lru_list(lru_list)
+        , _cache_size(cache_size)
+    {
+        _ts_val_ptr->set_anchor_back_reference(this);
+        _cache_size += _ts_val_ptr->size();
+    }
+
+    ~lru_entry() {
+        if (safe_link_list_hook::is_linked()) {
+            _lru_list.erase(_lru_list.iterator_to(*this));
+        }
+        _cache_size -= _ts_val_ptr->size();
+        _ts_val_ptr->set_anchor_back_reference(nullptr);
+    }
+
+    size_t& cache_size() noexcept {
+        return _cache_size;
+    }
+
+    /// Set this item as the most recently used item.
+    /// The MRU item is going to be at the front of the _lru_list, the LRU item - at the back.
+    void touch() noexcept {
+        if (safe_link_list_hook::is_linked()) {
+            _lru_list.erase(_lru_list.iterator_to(*this));
+        }
+        _lru_list.push_front(*this);
+    }
+
+    const Key& key() const noexcept {
+        return loading_values_type::to_key(_ts_val_ptr);
+    }
+
+    timestamped_val& timestamped_value() noexcept { return *_ts_val_ptr; }
+    const timestamped_val& timestamped_value() const noexcept { return *_ts_val_ptr; }
+    timestamped_val_ptr timestamped_value_ptr() noexcept { return _ts_val_ptr; }
 };
 
 }

--- a/utils/loading_cache.hh
+++ b/utils/loading_cache.hh
@@ -55,6 +55,10 @@ struct simple_entry_size {
     }
 };
 
+struct do_nothing_loading_cache_stats {
+    static void inc_new_gen_on_cache_size_eviction() noexcept {};
+};
+
 /// \brief Loading cache is a cache that loads the value into the cache using the given asynchronous callback.
 ///
 /// Each cached value if reloading is enabled (\tparam ReloadEnabled == loading_cache_reload_enabled::yes) is reloaded after
@@ -101,6 +105,7 @@ template<typename Key,
          typename Hash = std::hash<Key>,
          typename EqualPred = std::equal_to<Key>,
          typename LoadingSharedValuesStats = utils::do_nothing_loading_shared_values_stats,
+         typename LoadingCacheStats = utils::do_nothing_loading_cache_stats,
          typename Alloc = std::pmr::polymorphic_allocator<>>
 class loading_cache {
 
@@ -202,6 +207,8 @@ private:
         , _logger(logger)
         , _timer([this] { on_timer(); })
     {
+        static_assert(noexcept(LoadingCacheStats::inc_new_gen_on_cache_size_eviction()), "LoadingCacheStats::inc_new_gen_on_cache_size_eviction must be non-throwing");
+
         // Sanity check: if expiration period is given then non-zero refresh period and maximal size are required
         if (caching_enabled() && (_refresh == std::chrono::milliseconds(0) || _max_size == 0)) {
             throw exceptions::configuration_exception("loading_cache: caching is enabled but refresh period and/or max_size are zero");
@@ -488,6 +495,7 @@ private:
             ts_value_lru_entry& lru_entry = *_new_gen_list.rbegin();
             _logger.trace("shrink(): {}: dropping the new generation entry: ms since last_read {}", lru_entry.key(), duration_cast<milliseconds>(loading_cache_clock_type::now() - lru_entry.timestamped_value().last_read()).count());
             loading_cache::destroy_ts_value(&lru_entry);
+            LoadingCacheStats::inc_new_gen_on_cache_size_eviction();
         }
 
         while (_current_size > _max_size) {
@@ -557,8 +565,8 @@ private:
     seastar::gate _timer_reads_gate;
 };
 
-template<typename Key, typename Tp, int PartitionHitThreshold, loading_cache_reload_enabled ReloadEnabled, typename EntrySize, typename Hash, typename EqualPred, typename LoadingSharedValuesStats, typename Alloc>
-class loading_cache<Key, Tp, PartitionHitThreshold, ReloadEnabled, EntrySize, Hash, EqualPred, LoadingSharedValuesStats, Alloc>::timestamped_val::value_ptr {
+template<typename Key, typename Tp, int PartitionHitThreshold, loading_cache_reload_enabled ReloadEnabled, typename EntrySize, typename Hash, typename EqualPred, typename LoadingSharedValuesStats, typename LoadingCacheStats, typename Alloc>
+class loading_cache<Key, Tp, PartitionHitThreshold, ReloadEnabled, EntrySize, Hash, EqualPred, LoadingSharedValuesStats, LoadingCacheStats, Alloc>::timestamped_val::value_ptr {
 private:
     using loading_values_type = typename timestamped_val::loading_values_type;
 
@@ -588,8 +596,8 @@ public:
 };
 
 /// \brief This is and LRU list entry which is also an anchor for a loading_cache value.
-template<typename Key, typename Tp, int PartitionHitThreshold, loading_cache_reload_enabled ReloadEnabled, typename EntrySize, typename Hash, typename EqualPred, typename LoadingSharedValuesStats, typename Alloc>
-class loading_cache<Key, Tp, PartitionHitThreshold, ReloadEnabled, EntrySize, Hash, EqualPred, LoadingSharedValuesStats, Alloc>::timestamped_val::lru_entry : public safe_link_list_hook {
+template<typename Key, typename Tp, int PartitionHitThreshold, loading_cache_reload_enabled ReloadEnabled, typename EntrySize, typename Hash, typename EqualPred, typename LoadingSharedValuesStats, typename  LoadingCacheStats, typename Alloc>
+class loading_cache<Key, Tp, PartitionHitThreshold, ReloadEnabled, EntrySize, Hash, EqualPred, LoadingSharedValuesStats, LoadingCacheStats, Alloc>::timestamped_val::lru_entry : public safe_link_list_hook {
 private:
     using loading_values_type = typename timestamped_val::loading_values_type;
 


### PR DESCRIPTION
Introduce a 2 partition cache eviction policy.
This is meant to improve a resilience against a polluting user(s) that keeps on pushing new keys into the cache and never uses them which shares a cache with a good user(s) that reuse cached entries.  