### PR TITLE
mutation_writer: partition_based_splitting_writer: limit number of max buckets

### DIFF
--- a/compaction/compaction.cc
+++ b/compaction/compaction.cc
@@ -1473,7 +1473,7 @@ public:
 
     reader_consumer make_interposer_consumer(reader_consumer end_consumer) override {
         return [this, end_consumer = std::move(end_consumer)] (flat_mutation_reader reader) mutable -> future<> {
-            return mutation_writer::segregate_by_partition(std::move(reader), std::move(end_consumer));
+            return mutation_writer::segregate_by_partition(std::move(reader), 100, std::move(end_consumer));
         };
     }
 

--- a/mutation_writer/partition_based_splitting_writer.hh
+++ b/mutation_writer/partition_based_splitting_writer.hh
@@ -34,6 +34,10 @@ namespace mutation_writer {
 // streams that honor it.
 // This is useful for scrub compaction to split sstables containing out-of-order
 // and/or duplicate partitions into sstables that honor the partition ordering.
-future<> segregate_by_partition(flat_mutation_reader producer, reader_consumer consumer);
+//
+// The parameter max_buckets limits the number of live buckets. When reaching the
+// limit, an existing (the largest) bucket will be closed before a new one is
+// created.
+future<> segregate_by_partition(flat_mutation_reader producer, unsigned max_buckets, reader_consumer consumer);
 
 } // namespace mutation_writer

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -2620,7 +2620,7 @@ SEASTAR_THREAD_TEST_CASE(test_scrub_segregate_stack) {
     std::list<std::deque<mutation_fragment>> segregated_fragment_streams;
 
     mutation_writer::segregate_by_partition(make_scrubbing_reader(make_flat_mutation_reader_from_fragments(schema, permit, std::move(all_fragments)),
-                sstables::compaction_type_options::scrub::mode::segregate), [&schema, &segregated_fragment_streams] (flat_mutation_reader rd) {
+                sstables::compaction_type_options::scrub::mode::segregate), 100, [&schema, &segregated_fragment_streams] (flat_mutation_reader rd) {
         return async([&schema, &segregated_fragment_streams, rd = std::move(rd)] () mutable {
             auto close = deferred_close(rd);
             auto& fragments = segregated_fragment_streams.emplace_back();


### PR DESCRIPTION
Recently we observed an OOM caused by the partition based splitting writer going crazy, creating 1.7K buckets while scrubbing an especially broken sstable. To avoid situations like that in the future, this patch provides a max limit for the number of live buckets. When the number of buckets reach this number, the largest bucket is closed and replaced by a bucket. This will end up  reating more output sstables during scrub overall, but now they won't all be written at the same time causing insane memory pressure and possibly OOM.
Scrub compaction sets this limit to 100, the same limit the TWCS's timestamp based splitting writer uses (implemented through the classifier - `time_window_compaction_strategy::max_data_segregation_window_count`).

Fixes: #9400 

Tests: unit(dev)