### PR TITLE
cql3: improve expression ergonomics

### DIFF
--- a/cql3/Cql.g
+++ b/cql3/Cql.g
@@ -230,26 +230,26 @@ struct uninitialized {
         }
         std::map<sstring, sstring> res;
         for (auto&& entry : map.elements) {
-            auto entry_tuple = std::get_if<tuple_constructor>(&entry);
+            auto entry_tuple = expr::as_if<tuple_constructor>(&entry);
             // Because the parser tries to be smart and recover on error (to
             // allow displaying more than one error I suppose), we have default-constructed
             // entries in map.elements. Just skip those, a proper error will be thrown in the end.
             if (!entry_tuple || entry_tuple->elements.size() != 2) {
                 break;
             }
-            auto left = std::get_if<untyped_constant>(&entry_tuple->elements[0]);
+            auto left = expr::as_if<untyped_constant>(&entry_tuple->elements[0]);
             if (!left) {
                 sstring msg = fmt::format("Invalid property name: {}", entry_tuple->elements[0]);
-                if (std::holds_alternative<bind_variable>(entry_tuple->elements[0])) {
+                if (expr::is<bind_variable>(entry_tuple->elements[0])) {
                     msg += " (bind variables are not supported in DDL queries)";
                 }
                 add_recognition_error(msg);
                 break;
             }
-            auto right = std::get_if<untyped_constant>(&entry_tuple->elements[1]);
+            auto right = expr::as_if<untyped_constant>(&entry_tuple->elements[1]);
             if (!right) {
                 sstring msg = fmt::format("Invalid property value: {} for property: {}", entry_tuple->elements[0], entry_tuple->elements[1]);
-                if (std::holds_alternative<bind_variable>(entry_tuple->elements[1])) {
+                if (expr::is<bind_variable>(entry_tuple->elements[1])) {
                     msg += " (bind variables are not supported in DDL queries)";
                 }
                 add_recognition_error(msg);

--- a/cql3/column_condition.cc
+++ b/cql3/column_condition.cc
@@ -325,7 +325,7 @@ column_condition::raw::prepare(database& db, const sstring& keyspace, const colu
     }
 
     if (_op == expr::oper_t::LIKE) {
-        auto literal_term = std::get_if<expr::untyped_constant>(&*_value);
+        auto literal_term = expr::as_if<expr::untyped_constant>(&*_value);
         if (literal_term) {
             // Pass matcher object
             const sstring& pattern = literal_term->raw_text;

--- a/cql3/expr/expression.cc
+++ b/cql3/expr/expression.cc
@@ -59,6 +59,15 @@ logging::logger expr_logger("cql_expression");
 using boost::adaptors::filtered;
 using boost::adaptors::transformed;
 
+expression::expression(const expression& o)
+        : _v(std::make_unique<impl>(*o._v)) {
+}
+
+expression&
+expression::operator=(const expression& o) {
+    *this = expression(o);
+    return *this;
+}
 
 nested_expression::nested_expression(expression e)
         : _e(std::make_unique<expression>(std::move(e))) {

--- a/cql3/expr/expression.hh
+++ b/cql3/expr/expression.hh
@@ -122,6 +122,23 @@ auto visit(invocable_on_expression auto&& visitor, const expression& expr) {
     return std::visit(visitor, expr);
 }
 
+template <ExpressionElement E>
+bool is(const expression& e) {
+    return expr::is<E>(e);
+}
+
+template <ExpressionElement E>
+const E&
+as(const expression& e) {
+    return expr::as<E>(e);
+}
+
+template <ExpressionElement E>
+const E*
+as_if(const expression* e) {
+    return std::get_if<E>(e);
+}
+
 // An expression that doesn't contain subexpressions
 template <typename E>
 concept LeafExpression
@@ -518,11 +535,11 @@ inline bool is_compare(oper_t op) {
 }
 
 inline bool is_multi_column(const binary_operator& op) {
-    return holds_alternative<tuple_constructor>(*op.lhs);
+    return expr::is<tuple_constructor>(*op.lhs);
 }
 
 inline bool has_token(const expression& e) {
-    return find_atom(e, [] (const binary_operator& o) { return std::holds_alternative<token>(*o.lhs); });
+    return find_atom(e, [] (const binary_operator& o) { return expr::is<token>(*o.lhs); });
 }
 
 inline bool has_slice_or_needs_filtering(const expression& e) {

--- a/cql3/expr/term_expr.cc
+++ b/cql3/expr/term_expr.cc
@@ -63,7 +63,7 @@ usertype_constructor_validate_assignable_to(const usertype_constructor& u, datab
         if (!u.elements.contains(field)) {
             continue;
         }
-        const expression& value = *u.elements.at(field);
+        const expression& value = u.elements.at(field);
         auto&& field_spec = usertype_field_spec_of(receiver, i);
         if (!assignment_testable::is_assignable(test_assignment(value, db, keyspace, *field_spec))) {
             throw exceptions::invalid_request_exception(format("Invalid user type literal for {}: field {} is not of type {}", receiver.name, field, field_spec->type->as_cql3_type()));
@@ -98,7 +98,7 @@ usertype_constructor_prepare_term(const usertype_constructor& u, database& db, c
         if (iraw == u.elements.end()) {
             raw = expr::null();
         } else {
-            raw = *iraw->second;
+            raw = iraw->second;
             ++found_values;
         }
         auto&& value = prepare_term(raw, db, keyspace, usertype_field_spec_of(*receiver, i));
@@ -740,7 +740,7 @@ null_prepare_term(database& db, const sstring& keyspace, lw_shared_ptr<column_sp
 static
 sstring
 cast_display_name(const cast& c) {
-    return format("({}){}", std::get<shared_ptr<cql3_type::raw>>(c.type), *c.arg);
+    return format("({}){}", std::get<shared_ptr<cql3_type::raw>>(c.type), c.arg);
 }
 
 static
@@ -773,13 +773,13 @@ static
 shared_ptr<term>
 cast_prepare_term(const cast& c, database& db, const sstring& keyspace, lw_shared_ptr<column_specification> receiver) {
     auto type = std::get<shared_ptr<cql3_type::raw>>(c.type);
-    if (!is_assignable(test_assignment(*c.arg, db, keyspace, *casted_spec_of(c, db, keyspace, *receiver)))) {
-        throw exceptions::invalid_request_exception(format("Cannot cast value {} to type {}", *c.arg, type));
+    if (!is_assignable(test_assignment(c.arg, db, keyspace, *casted_spec_of(c, db, keyspace, *receiver)))) {
+        throw exceptions::invalid_request_exception(format("Cannot cast value {} to type {}", c.arg, type));
     }
     if (!is_assignable(cast_test_assignment(c, db, keyspace, *receiver))) {
         throw exceptions::invalid_request_exception(format("Cannot assign value {} to {} of type {}", c, receiver->name, receiver->type->as_cql3_type()));
     }
-    return prepare_term(*c.arg, db, keyspace, receiver);
+    return prepare_term(c.arg, db, keyspace, receiver);
 }
 
 ::shared_ptr<term>

--- a/cql3/expr/term_expr.cc
+++ b/cql3/expr/term_expr.cc
@@ -154,7 +154,7 @@ map_validate_assignable_to(const collection_constructor& c, database& db, const 
     auto&& key_spec = map_key_spec_of(receiver);
     auto&& value_spec = map_value_spec_of(receiver);
     for (auto&& entry : c.elements) {
-        auto& entry_tuple = std::get<tuple_constructor>(entry);
+        auto& entry_tuple = expr::as<tuple_constructor>(entry);
         if (entry_tuple.elements.size() != 2) {
             on_internal_error(expr_logger, "map element is not a tuple of arity 2");
         }
@@ -182,7 +182,7 @@ map_test_assignment(const collection_constructor& c, database& db, const sstring
     // It's an exact match if all are exact match, but is not assignable as soon as any is non assignable.
     auto res = assignment_testable::test_result::EXACT_MATCH;
     for (auto entry : c.elements) {
-        auto& entry_tuple = std::get<tuple_constructor>(entry);
+        auto& entry_tuple = expr::as<tuple_constructor>(entry);
         if (entry_tuple.elements.size() != 2) {
             on_internal_error(expr_logger, "map element is not a tuple of arity 2");
         }
@@ -207,7 +207,7 @@ map_prepare_term(const collection_constructor& c, database& db, const sstring& k
     values.reserve(c.elements.size());
     bool all_terminal = true;
     for (auto&& entry : c.elements) {
-        auto& entry_tuple = std::get<tuple_constructor>(entry);
+        auto& entry_tuple = expr::as<tuple_constructor>(entry);
         if (entry_tuple.elements.size() != 2) {
             on_internal_error(expr_logger, "map element is not a tuple of arity 2");
         }

--- a/cql3/expr/term_expr.cc
+++ b/cql3/expr/term_expr.cc
@@ -784,7 +784,7 @@ cast_prepare_term(const cast& c, database& db, const sstring& keyspace, lw_share
 
 ::shared_ptr<term>
 prepare_term(const expression& expr, database& db, const sstring& keyspace, lw_shared_ptr<column_specification> receiver) {
-    return std::visit(overloaded_functor{
+    return expr::visit(overloaded_functor{
         [] (const constant&) -> ::shared_ptr<term> {
             on_internal_error(expr_logger, "Can't prepare constant_value, it should not appear in parser output");
         },
@@ -849,7 +849,7 @@ prepare_term(const expression& expr, database& db, const sstring& keyspace, lw_s
 
 ::shared_ptr<term>
 prepare_term_multi_column(const expression& expr, database& db, const sstring& keyspace, const std::vector<lw_shared_ptr<column_specification>>& receivers) {
-    return std::visit(overloaded_functor{
+    return expr::visit(overloaded_functor{
         [&] (const bind_variable& bv) -> ::shared_ptr<term> {
             switch (bv.shape) {
             case expr::bind_variable::shape_type::scalar: on_internal_error(expr_logger, "prepare_term_multi_column(bind_variable(scalar))");
@@ -871,7 +871,7 @@ prepare_term_multi_column(const expression& expr, database& db, const sstring& k
 assignment_testable::test_result
 test_assignment(const expression& expr, database& db, const sstring& keyspace, const column_specification& receiver) {
     using test_result = assignment_testable::test_result;
-    return std::visit(overloaded_functor{
+    return expr::visit(overloaded_functor{
         [&] (const constant&) -> test_result {
             // constants shouldn't appear in parser output, only untyped_constants
             on_internal_error(expr_logger, "constants are not yet reachable via term_raw_expr::test_assignment()");

--- a/cql3/restrictions/multi_column_restriction.hh
+++ b/cql3/restrictions/multi_column_restriction.hh
@@ -477,7 +477,7 @@ private:
         using namespace expr;
         if (!bound){
             auto r = ::make_shared<cql3::restrictions::single_column_restriction>(*_column_defs[column_pos]);
-            r->expression = binary_operator{_column_defs[column_pos], expr::oper_t::EQ, std::move(term)};
+            r->expression = binary_operator{column_value{_column_defs[column_pos]}, expr::oper_t::EQ, std::move(term)};
             return r;
         } else {
             auto r = ::make_shared<cql3::restrictions::single_column_restriction>(*_column_defs[column_pos]);

--- a/cql3/restrictions/single_column_primary_key_restrictions.hh
+++ b/cql3/restrictions/single_column_primary_key_restrictions.hh
@@ -150,7 +150,7 @@ public:
 
     virtual void merge_with(::shared_ptr<restriction> restriction) override {
         if (find_atom(restriction->expression, [] (const expr::binary_operator& b) {
-                    return expr::is<expr::tuple_constructor>(*b.lhs);
+                    return expr::is<expr::tuple_constructor>(b.lhs);
                 })) {
             throw exceptions::invalid_request_exception(
                 "Mixing single column relations and multi column relations on clustering columns is not allowed");

--- a/cql3/restrictions/single_column_primary_key_restrictions.hh
+++ b/cql3/restrictions/single_column_primary_key_restrictions.hh
@@ -150,7 +150,7 @@ public:
 
     virtual void merge_with(::shared_ptr<restriction> restriction) override {
         if (find_atom(restriction->expression, [] (const expr::binary_operator& b) {
-                    return std::holds_alternative<expr::tuple_constructor>(*b.lhs);
+                    return expr::is<expr::tuple_constructor>(*b.lhs);
                 })) {
             throw exceptions::invalid_request_exception(
                 "Mixing single column relations and multi column relations on clustering columns is not allowed");
@@ -169,7 +169,7 @@ public:
         for (auto&& e : restrictions()) {
             auto&& r = e.second;
             assert(!has_slice(r->expression));
-            auto values = std::get<expr::value_list>(possible_lhs_values(e.first, r->expression, options));
+            auto values = expr::as<expr::value_list>(possible_lhs_values(e.first, r->expression, options));
             if (values.empty()) {
                 return {};
             }

--- a/cql3/restrictions/statement_restrictions.cc
+++ b/cql3/restrictions/statement_restrictions.cc
@@ -164,7 +164,7 @@ static std::vector<expr::expression> extract_partition_range(
         const binary_operator* current_binary_operator = nullptr;
 
         void operator()(const conjunction& c) {
-            std::ranges::for_each(c.children, [this] (const expression& child) { std::visit(*this, child); });
+            std::ranges::for_each(c.children, [this] (const expression& child) { expr::visit(*this, child); });
         }
 
         void operator()(const binary_operator& b) {
@@ -172,7 +172,7 @@ static std::vector<expr::expression> extract_partition_range(
                 throw std::logic_error("Nested binary operators are not supported");
             }
             current_binary_operator = &b;
-            std::visit(*this, *b.lhs);
+            expr::visit(*this, *b.lhs);
             current_binary_operator = nullptr;
         }
 
@@ -246,7 +246,7 @@ static std::vector<expr::expression> extract_partition_range(
             on_internal_error(rlogger, "extract_partition_range(usertype_constructor)");
         }
     } v;
-    std::visit(v, where_clause);
+    expr::visit(v, where_clause);
     if (v.tokens) {
         return {std::move(*v.tokens)};
     }
@@ -273,7 +273,7 @@ static std::vector<expr::expression> extract_clustering_prefix_restrictions(
         const binary_operator* current_binary_operator = nullptr;
 
         void operator()(const conjunction& c) {
-            std::ranges::for_each(c.children, [this] (const expression& child) { std::visit(*this, child); });
+            std::ranges::for_each(c.children, [this] (const expression& child) { expr::visit(*this, child); });
         }
 
         void operator()(const binary_operator& b) {
@@ -281,7 +281,7 @@ static std::vector<expr::expression> extract_clustering_prefix_restrictions(
                 throw std::logic_error("Nested binary operators are not supported");
             }
             current_binary_operator = &b;
-            std::visit(*this, *b.lhs);
+            expr::visit(*this, *b.lhs);
             current_binary_operator = nullptr;
         }
 
@@ -356,7 +356,7 @@ static std::vector<expr::expression> extract_clustering_prefix_restrictions(
             on_internal_error(rlogger, "extract_clustering_prefix_restrictions(usertype_constructor)");
         }
     } v;
-    std::visit(v, where_clause);
+    expr::visit(v, where_clause);
 
     if (!v.multi.empty()) {
         return move(v.multi);
@@ -996,7 +996,7 @@ struct multi_column_range_accumulator {
     }
 
     void operator()(const conjunction& c) {
-        std::ranges::for_each(c.children, [this] (const expression& child) { std::visit(*this, child); });
+        std::ranges::for_each(c.children, [this] (const expression& child) { expr::visit(*this, child); });
     }
 
     void operator()(const constant& v) {
@@ -1103,7 +1103,7 @@ std::vector<query::clustering_range> get_multi_column_clustering_bounds(
         const std::vector<expression>& multi_column_restrictions) {
     multi_column_range_accumulator acc{options, schema};
     for (const auto& restr : multi_column_restrictions) {
-        std::visit(acc, restr);
+        expr::visit(acc, restr);
     }
     return acc.ranges;
 }

--- a/cql3/restrictions/statement_restrictions.cc
+++ b/cql3/restrictions/statement_restrictions.cc
@@ -287,7 +287,7 @@ static std::vector<expr::expression> extract_clustering_prefix_restrictions(
 
         void operator()(const tuple_constructor& tc) {
             for (auto& e : tc.elements) {
-                if (!std::holds_alternative<column_value>(e)) {
+                if (!expr::is<column_value>(e)) {
                     on_internal_error(rlogger, fmt::format("extract_clustering_prefix_restrictions: tuple of non-column_value: {}", tc));
                 }
             }
@@ -403,7 +403,7 @@ statement_restrictions::statement_restrictions(database& db,
                 }
                 // currently, the grammar only allows the NULL argument to be
                 // "IS NOT", so this assertion should not be able to fail
-                assert(std::holds_alternative<expr::null>(*r->get_value()));
+                assert(expr::is<expr::null>(*r->get_value()));
 
                 auto col_id = r->get_entity()->prepare_column_identifier(*schema);
                 const auto *cd = get_column_definition(*schema, *col_id);
@@ -762,7 +762,7 @@ dht::partition_range_vector partition_ranges_from_singles(
     size_t product_size = 1;
     for (const auto& e : expressions) {
         if (const auto arbitrary_binop = find_atom(e, [] (const binary_operator&) { return true; })) {
-            if (auto cv = std::get_if<expr::column_value>(&*arbitrary_binop->lhs)) {
+            if (auto cv = expr::as_if<expr::column_value>(&*arbitrary_binop->lhs)) {
                 const value_set vals = possible_lhs_values(cv->col, e, options);
                 if (auto lst = std::get_if<value_list>(&vals)) {
                     if (lst->empty()) {
@@ -791,7 +791,7 @@ dht::partition_range_vector partition_ranges_from_EQs(
         const std::vector<expr::expression>& eq_expressions, const query_options& options, const schema& schema) {
     std::vector<managed_bytes> pk_value(schema.partition_key_size());
     for (const auto& e : eq_expressions) {
-        const auto col = std::get<column_value>(*find(e, oper_t::EQ)->lhs).col;
+        const auto col = expr::as<column_value>(*find(e, oper_t::EQ)->lhs).col;
         const auto vals = std::get<value_list>(possible_lhs_values(col, e, options));
         if (vals.empty()) { // Case of C=1 AND C=2.
             return {};
@@ -977,10 +977,10 @@ struct multi_column_range_accumulator {
     void operator()(const binary_operator& binop) {
         if (is_compare(binop.op)) {
             auto opt_values = expr::get_tuple_elements(expr::evaluate(binop.rhs, options));
-            auto& lhs = std::get<tuple_constructor>(*binop.lhs);
+            auto& lhs = expr::as<tuple_constructor>(*binop.lhs);
             std::vector<managed_bytes> values(lhs.elements.size());
             for (size_t i = 0; i < lhs.elements.size(); ++i) {
-                auto& col = std::get<column_value>(lhs.elements.at(i));
+                auto& col = expr::as<column_value>(lhs.elements.at(i));
                 values[i] = *statements::request_validations::check_not_null(
                         opt_values[i],
                         "Invalid null value in condition for column %s", col.col->name_as_text());
@@ -1429,12 +1429,12 @@ std::vector<query::clustering_range> statement_restrictions::get_clustering_boun
         bool all_natural = true, all_reverse = true; ///< Whether column types are reversed or natural.
         for (auto& r : _clustering_prefix_restrictions) { // TODO: move to constructor, do only once.
             using namespace expr;
-            const auto& binop = std::get<binary_operator>(r);
+            const auto& binop = expr::as<binary_operator>(r);
             if (is_clustering_order(binop)) {
                 return {range_from_raw_bounds(_clustering_prefix_restrictions, options, *_schema)};
             }
-            for (auto& element : std::get<tuple_constructor>(*binop.lhs).elements) {
-                auto& cv = std::get<column_value>(element);
+            for (auto& element : expr::as<tuple_constructor>(*binop.lhs).elements) {
+                auto& cv = expr::as<column_value>(element);
                 if (cv.col->type->is_reversed()) {
                     all_natural = false;
                 } else {
@@ -1602,7 +1602,7 @@ void statement_restrictions::prepare_indexed_global(const schema& idx_tbl_schema
     _idx_tbl_ck_prefix = std::vector<expr::expression>(1 + _schema->partition_key_size());
     _idx_tbl_ck_prefix->reserve(_idx_tbl_ck_prefix->size() + idx_tbl_schema.clustering_key_size());
     for (const auto& e : _partition_range_restrictions) {
-        const auto col = std::get<column_value>(*find(e, oper_t::EQ)->lhs).col;
+        const auto col = expr::as<column_value>(*find(e, oper_t::EQ)->lhs).col;
         const auto pos = _schema->position(*col) + 1;
         (*_idx_tbl_ck_prefix)[pos] = replace_column_def(e, &idx_tbl_schema.clustering_column_at(pos));
     }
@@ -1652,7 +1652,7 @@ void statement_restrictions::add_clustering_restrictions_to_idx_ck_prefix(const 
         if (!any_binop) {
             break;
         }
-        const auto col = std::get<column_value>(*any_binop->lhs).col;
+        const auto col = expr::as<column_value>(*any_binop->lhs).col;
         _idx_tbl_ck_prefix->push_back(replace_column_def(e, idx_tbl_schema.get_column_definition(col->name())));
     }
 }
@@ -1666,7 +1666,7 @@ std::vector<query::clustering_range> statement_restrictions::get_global_index_cl
     }
     std::vector<managed_bytes> pk_value(_schema->partition_key_size());
     for (const auto& e : _partition_range_restrictions) {
-        const auto col = std::get<column_value>(*find(e, oper_t::EQ)->lhs).col;
+        const auto col = expr::as<column_value>(*find(e, oper_t::EQ)->lhs).col;
         const auto vals = std::get<value_list>(possible_lhs_values(col, e, options));
         if (vals.empty()) { // Case of C=1 AND C=2.
             return {};
@@ -1686,7 +1686,7 @@ std::vector<query::clustering_range> statement_restrictions::get_global_index_cl
     }
     // WARNING: We must not yield to another fiber from here until the function's end, lest this RHS be
     // overwritten.
-    const_cast<::shared_ptr<term>&>(std::get<binary_operator>((*_idx_tbl_ck_prefix)[0]).rhs) =
+    const_cast<::shared_ptr<term>&>(expr::as<binary_operator>((*_idx_tbl_ck_prefix)[0]).rhs) =
             ::make_shared<constants::value>(raw_value::make_value(*token_bytes), token_column.type);
 
     // Multi column restrictions are not added to _idx_tbl_ck_prefix, they are handled later by filtering.

--- a/cql3/selection/selectable.cc
+++ b/cql3/selection/selectable.cc
@@ -172,7 +172,7 @@ prepare_selectable(const schema& s, const expr::expression& raw_selectable) {
             return ui.ident->prepare(s);
         },
         [&] (const expr::column_mutation_attribute& cma) -> shared_ptr<selectable> {
-            auto unresolved_id = expr::as<expr::unresolved_identifier>(*cma.column);
+            auto unresolved_id = expr::as<expr::unresolved_identifier>(cma.column);
             bool is_writetime = cma.kind == expr::column_mutation_attribute::attribute_kind::writetime;
             return make_shared<selectable::writetime_or_ttl>(unresolved_id.ident->prepare_column_identifier(s), is_writetime);
         },
@@ -197,12 +197,12 @@ prepare_selectable(const schema& s, const expr::expression& raw_selectable) {
                 // FIXME: adjust prepare_seletable() signature so we can prepare the type too
                 on_internal_error(slogger, "unprepared type in selector type cast");
             }
-            return ::make_shared<selectable::with_cast>(prepare_selectable(s, *c.arg), *t);
+            return ::make_shared<selectable::with_cast>(prepare_selectable(s, c.arg), *t);
         },
         [&] (const expr::field_selection& fs) -> shared_ptr<selectable> {
             // static_pointer_cast<> needed due to lack of covariant return type
             // support with smart pointers
-            return make_shared<selectable::with_field_selection>(prepare_selectable(s, *fs.structure),
+            return make_shared<selectable::with_field_selection>(prepare_selectable(s, fs.structure),
                     static_pointer_cast<column_identifier>(fs.field->prepare(s)));
         },
         [&] (const expr::null&) -> shared_ptr<selectable> {

--- a/cql3/selection/selectable.cc
+++ b/cql3/selection/selectable.cc
@@ -141,7 +141,7 @@ selectable::with_cast::to_string() const {
 
 shared_ptr<selectable>
 prepare_selectable(const schema& s, const expr::expression& raw_selectable) {
-    return std::visit(overloaded_functor{
+    return expr::visit(overloaded_functor{
         [&] (const expr::constant&) -> shared_ptr<selectable> {
             on_internal_error(slogger, "no way to express SELECT constant in the grammar yet");
         },
@@ -228,7 +228,7 @@ prepare_selectable(const schema& s, const expr::expression& raw_selectable) {
 
 bool
 selectable_processes_selection(const expr::expression& raw_selectable) {
-    return std::visit(overloaded_functor{
+    return expr::visit(overloaded_functor{
         [&] (const expr::constant&) -> bool {
             on_internal_error(slogger, "no way to express SELECT constant in the grammar yet");
         },

--- a/cql3/selection/selectable.cc
+++ b/cql3/selection/selectable.cc
@@ -172,7 +172,7 @@ prepare_selectable(const schema& s, const expr::expression& raw_selectable) {
             return ui.ident->prepare(s);
         },
         [&] (const expr::column_mutation_attribute& cma) -> shared_ptr<selectable> {
-            auto unresolved_id = std::get<expr::unresolved_identifier>(*cma.column);
+            auto unresolved_id = expr::as<expr::unresolved_identifier>(*cma.column);
             bool is_writetime = cma.kind == expr::column_mutation_attribute::attribute_kind::writetime;
             return make_shared<selectable::writetime_or_ttl>(unresolved_id.ident->prepare_column_identifier(s), is_writetime);
         },

--- a/cql3/single_column_relation.cc
+++ b/cql3/single_column_relation.cc
@@ -77,7 +77,7 @@ single_column_relation::new_EQ_restriction(database& db, schema_ptr schema, prep
     if (!_map_key) {
         auto r = ::make_shared<restrictions::single_column_restriction>(column_def);
         auto term = to_term(to_receivers(*schema, column_def), *_value, db, schema->ks_name(), ctx);
-        r->expression = binary_operator{&column_def, expr::oper_t::EQ, std::move(term)};
+        r->expression = binary_operator{column_value{&column_def}, expr::oper_t::EQ, std::move(term)};
         return r;
     }
     auto&& receivers = to_receivers(*schema, column_def);
@@ -102,19 +102,19 @@ single_column_relation::new_IN_restriction(database& db, schema_ptr schema, prep
     if (_value) {
         auto term = to_term(receivers, *_value, db, schema->ks_name(), ctx);
         auto r = ::make_shared<single_column_restriction>(column_def);
-        r->expression = binary_operator{&column_def, expr::oper_t::IN, std::move(term)};
+        r->expression = binary_operator{column_value{&column_def}, expr::oper_t::IN, std::move(term)};
         return r;
     }
     auto terms = to_terms(receivers, _in_values, db, schema->ks_name(), ctx);
     // Convert a single-item IN restriction to an EQ restriction
     if (terms.size() == 1) {
         auto r = ::make_shared<single_column_restriction>(column_def);
-        r->expression = binary_operator{&column_def, expr::oper_t::EQ, std::move(terms[0])};
+        r->expression = binary_operator{column_value{&column_def}, expr::oper_t::EQ, std::move(terms[0])};
         return r;
     }
     auto r = ::make_shared<single_column_restriction>(column_def);
     r->expression = binary_operator{
-            &column_def,
+            column_value{&column_def},
             expr::oper_t::IN,
             ::make_shared<lists::delayed_value>(std::move(terms), list_type_impl::get_instance(column_def.type, false))};
     return r;
@@ -130,7 +130,7 @@ single_column_relation::new_LIKE_restriction(
     }
     auto term = to_term(to_receivers(*schema, column_def), *_value, db, schema->ks_name(), ctx);
     auto r = ::make_shared<restrictions::single_column_restriction>(column_def);
-    r->expression = binary_operator{&column_def, expr::oper_t::LIKE, std::move(term)};
+    r->expression = binary_operator{column_value{&column_def}, expr::oper_t::LIKE, std::move(term)};
     return r;
 }
 

--- a/cql3/single_column_relation.hh
+++ b/cql3/single_column_relation.hh
@@ -171,7 +171,7 @@ protected:
 
         auto term = to_term(to_receivers(*schema, column_def), *_value, db, schema->ks_name(), ctx);
         auto r = ::make_shared<restrictions::single_column_restriction>(column_def);
-        r->expression = expr::binary_operator{&column_def, _relation_type, std::move(term)};
+        r->expression = expr::binary_operator{expr::column_value{&column_def}, _relation_type, std::move(term)};
         return r;
     }
 
@@ -182,7 +182,7 @@ protected:
         auto term = to_term(to_receivers(*schema, column_def), *_value, db, schema->ks_name(), ctx);
         auto r = ::make_shared<restrictions::single_column_restriction>(column_def);
         r->expression = expr::binary_operator{
-                &column_def, is_key ? expr::oper_t::CONTAINS_KEY : expr::oper_t::CONTAINS, std::move(term)};
+                expr::column_value{&column_def}, is_key ? expr::oper_t::CONTAINS_KEY : expr::oper_t::CONTAINS, std::move(term)};
         return r;
     }
 

--- a/cql3/statements/create_view_statement.cc
+++ b/cql3/statements/create_view_statement.cc
@@ -204,7 +204,7 @@ future<shared_ptr<cql_transport::event::schema_change>> create_view_statement::a
 
         auto& selectable = selector->selectable_;
         shared_ptr<column_identifier::raw> identifier;
-        std::visit(overloaded_functor{
+        expr::visit(overloaded_functor{
             [&] (const expr::unresolved_identifier& ui) { identifier = ui.ident; },
             [] (const auto& default_case) -> void { throw exceptions::invalid_request_exception(format("Cannot use general expressions when defining a materialized view")); },
         }, selectable);

--- a/cql3/statements/update_statement.cc
+++ b/cql3/statements/update_statement.cc
@@ -363,7 +363,7 @@ insert_json_statement::prepare_internal(database& db, schema_ptr schema,
 {
     // FIXME: handle _if_not_exists. For now, mark it used to quiet the compiler. #8682
     (void)_if_not_exists;
-    assert(std::holds_alternative<cql3::expr::untyped_constant>(_json_value) || std::holds_alternative<cql3::expr::bind_variable>(_json_value));
+    assert(expr::is<cql3::expr::untyped_constant>(_json_value) || expr::is<cql3::expr::bind_variable>(_json_value));
     auto json_column_placeholder = ::make_shared<column_identifier>("", true);
     auto prepared_json_value = prepare_term(_json_value, db, "", make_lw_shared<column_specification>("", "", json_column_placeholder, utf8_type));
     prepared_json_value->fill_prepare_context(ctx);

--- a/cql3/user_types.cc
+++ b/cql3/user_types.cc
@@ -122,7 +122,7 @@ expr::expression user_types::delayed_value::to_expression() {
     expr::usertype_constructor::elements_map_type new_elements;
     for (size_t i = 0; i < _values.size(); i++) {
         column_identifier field_name(_type->field_names().at(i), _type->string_field_names().at(i));
-        expr::nested_expression field_value(expr::to_expression(_values[i]));
+        expr::expression field_value(expr::to_expression(_values[i]));
         new_elements.emplace(std::move(field_name), std::move(field_value));
     }
 


### PR DESCRIPTION
The `expression` type (an std::variant) suffers from bad ergonomics:
 - std::variant has poor/no constraints, so compiler error messages are long and uninformative
 - it cannot be forward-declared (since std::variant does not support incomplete types)
 - the type name is long, polluting compiler error messages and debug symbols
 - it requires an artificial `nested_expression` when one expression is nested inside another
 
This series fixes those drawbacks by wrapping the variant in a class, adding constraints, and adding an extra indirection.

Test: unit (dev)