### PR TITLE
configure: temporarily disable wasm support for aarch64

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1355,8 +1355,12 @@ for mode in modes:
 has_wasmtime = os.path.isfile('/usr/lib64/libwasmtime.a') and os.path.isdir('/usr/local/include/wasmtime')
 
 if has_wasmtime:
-    for mode in modes:
-        modes[mode]['cxxflags'] += ' -DSCYLLA_ENABLE_WASMTIME'
+    if platform.machine() == 'aarch64':
+        print("wasmtime is temporarily not supported on aarch64. Ref: issue #9387")
+        has_wasmtime = False
+    else:
+        for mode in modes:
+            modes[mode]['cxxflags'] += ' -DSCYLLA_ENABLE_WASMTIME'
 else:
     print("wasmtime not found - WASM support will not be enabled in this build")
 


### PR DESCRIPTION
There seems to be a problem with libwasmtime.a dependency on aarch64,
causing occasional segfaults during tests - specifically, tests
which exercise the path for halting wasm execution due to fuel
exhaustion. As a temporary measure, wasm is disabled on this
architecture to unblock the flow.

Refs #9387