### PR TITLE
test/lib/failure_injecting_allocation_strategy: remove UB by setting

### DIFF
--- a/test/lib/failure_injecting_allocation_strategy.hh
+++ b/test/lib/failure_injecting_allocation_strategy.hh
@@ -25,7 +25,7 @@
 
 class failure_injecting_allocation_strategy : public allocation_strategy {
     allocation_strategy& _delegate;
-    uint64_t _alloc_count;
+    uint64_t _alloc_count = 0;
     uint64_t _fail_at = std::numeric_limits<uint64_t>::max();
 public:
     failure_injecting_allocation_strategy(allocation_strategy& delegate) : _delegate(delegate) {}


### PR DESCRIPTION
_alloc_count initially to 0.

The _alloc_count hasn't been explicitely specified. As the allocator has
been usually an automatic variable, _alloc_count had initially some
unspecified contents. This probably means that cases where the first few
allocations passed and the later one failed, might haven't ever been
tested. Good thing is that most of the users have been transferred to
the Seastar failure injector, which (by accident) has been correct.

Fixes #9419