### PR TITLE
utils: untie rjson.hh from base64.hh

### DIFF
--- a/alternator/conditions.cc
+++ b/alternator/conditions.cc
@@ -29,6 +29,7 @@
 #include "utils/rjson.hh"
 #include "serialization.hh"
 #include "utils/base64.hh"
+#include "utils/rjson.hh"
 #include <stdexcept>
 #include <boost/algorithm/cxx11/all_of.hpp>
 #include <boost/algorithm/cxx11/any_of.hpp>
@@ -262,7 +263,7 @@ bool check_CONTAINS(const rjson::value* v1, const rjson::value& v2) {
     if (kv1.name == "S" && kv2.name == "S") {
         return rjson::to_string_view(kv1.value).find(rjson::to_string_view(kv2.value)) != std::string_view::npos;
     } else if (kv1.name == "B" && kv2.name == "B") {
-        return base64_decode(kv1.value).find(base64_decode(kv2.value)) != bytes::npos;
+        return rjson::base64_decode(kv1.value).find(rjson::base64_decode(kv2.value)) != bytes::npos;
     } else if (is_set_of(kv1.name, kv2.name)) {
         for (auto i = kv1.value.Begin(); i != kv1.value.End(); ++i) {
             if (*i == kv2.value) {
@@ -386,7 +387,7 @@ bool check_compare(const rjson::value* v1, const rjson::value& v2, const Compara
                    std::string_view(kv2.value.GetString(), kv2.value.GetStringLength()));
     }
     if (kv1.name == "B") {
-        return cmp(base64_decode(kv1.value), base64_decode(kv2.value));
+        return cmp(rjson::base64_decode(kv1.value), rjson::base64_decode(kv2.value));
     }
     // cannot reach here, as check_comparable_type() verifies the type is one
     // of the above options.
@@ -476,7 +477,7 @@ static bool check_BETWEEN(const rjson::value* v, const rjson::value& lb, const r
                              bounds_from_query);
     }
     if (kv_v.name == "B") {
-        return check_BETWEEN(base64_decode(kv_v.value), base64_decode(kv_lb.value), base64_decode(kv_ub.value), bounds_from_query);
+        return check_BETWEEN(rjson::base64_decode(kv_v.value), rjson::base64_decode(kv_lb.value), rjson::base64_decode(kv_ub.value), bounds_from_query);
     }
     if (v_from_query) {
         throw api_error::validation(

--- a/alternator/serialization.cc
+++ b/alternator/serialization.cc
@@ -20,6 +20,7 @@
  */
 
 #include "utils/base64.hh"
+#include "utils/rjson.hh"
 #include "log.hh"
 #include "serialization.hh"
 #include "error.hh"
@@ -68,7 +69,7 @@ struct from_json_visitor {
         bo.write(t.from_string(rjson::to_string_view(v)));
     }
     void operator()(const bytes_type_impl& t) const {
-        bo.write(base64_decode(v));
+        bo.write(rjson::base64_decode(v));
     }
     void operator()(const boolean_type_impl& t) const {
         bo.write(boolean_type->decompose(v.GetBool()));
@@ -196,7 +197,7 @@ bytes get_key_from_typed_value(const rjson::value& key_typed_value, const column
                 format("The AttributeValue for a key attribute cannot contain an empty string value. Key: {}", column.name_as_text()));
     }
     if (column.type == bytes_type) {
-        return base64_decode(it->value);
+        return rjson::base64_decode(it->value);
     } else {
         return column.type->from_string(rjson::to_string_view(it->value));
     }

--- a/test/boost/alternator_unit_test.cc
+++ b/test/boost/alternator_unit_test.cc
@@ -25,6 +25,7 @@
 #include <seastar/util/defer.hh>
 #include <seastar/core/memory.hh>
 #include "utils/base64.hh"
+#include "utils/rjson.hh"
 
 static bytes_view to_bytes_view(const std::string& s) {
     return bytes_view(reinterpret_cast<const signed char*>(s.c_str()), s.size());

--- a/utils/base64.hh
+++ b/utils/base64.hh
@@ -23,15 +23,10 @@
 
 #include <string_view>
 #include "bytes.hh"
-#include "utils/rjson.hh"
 
 std::string base64_encode(bytes_view);
 
 bytes base64_decode(std::string_view);
-
-inline bytes base64_decode(const rjson::value& v) {
-  return base64_decode(std::string_view(v.GetString(), v.GetStringLength()));
-}
 
 size_t base64_decoded_len(std::string_view str);
 

--- a/utils/rjson.hh
+++ b/utils/rjson.hh
@@ -41,6 +41,7 @@
 
 #include <string>
 #include <stdexcept>
+#include "utils/base64.hh"
 
 namespace rjson {
 class error : public std::exception {
@@ -302,6 +303,10 @@ rjson::value from_string_map(const std::map<sstring, sstring>& map);
 
 // The function operates on sstrings for historical reasons.
 sstring quote_json_string(const sstring& value);
+
+inline bytes base64_decode(const value& v) {
+  return ::base64_decode(std::string_view(v.GetString(), v.GetStringLength()));
+}
 
 } // end namespace rjson
 


### PR DESCRIPTION
base64.hh pulls in the huge rjson.hh, so if someone just wants
a base64 codec they have to pull in the entire rapidjson library.

Move the json related parts of base64.hh to rjson.hh and adjust
includes and namespaces.

In practice it doesn't make much difference, as all users of base64
appear to want json too. But it's cleaner not to mix the two.