### PR TITLE
cql3: deinline non-trivial methods in selection.hh

### DIFF
--- a/alternator/streams.cc
+++ b/alternator/streams.cc
@@ -40,6 +40,7 @@
 #include "cql3/selection/selection.hh"
 #include "cql3/result_set.hh"
 #include "cql3/type_json.hh"
+#include "cql3/column_identifier.hh"
 #include "schema_builder.hh"
 #include "service/storage_proxy.hh"
 #include "gms/feature.hh"

--- a/cql3/selection/selectable.cc
+++ b/cql3/selection/selectable.cc
@@ -28,6 +28,7 @@
 #include "cql3/functions/functions.hh"
 #include "cql3/functions/castas_fcts.hh"
 #include "cql3/functions/aggregate_fcts.hh"
+#include "cql3/expr/expression.hh"
 #include "abstract_function_selector.hh"
 #include "writetime_or_ttl_selector.hh"
 

--- a/cql3/statements/alter_type_statement.cc
+++ b/cql3/statements/alter_type_statement.cc
@@ -40,6 +40,7 @@
 #include "cql3/statements/alter_type_statement.hh"
 #include "cql3/statements/create_type_statement.hh"
 #include "cql3/query_processor.hh"
+#include "cql3/column_identifier.hh"
 #include "prepared_statement.hh"
 #include "schema_builder.hh"
 #include "service/migration_manager.hh"

--- a/cql3/statements/create_type_statement.cc
+++ b/cql3/statements/create_type_statement.cc
@@ -44,6 +44,7 @@
 #include "service/storage_proxy.hh"
 #include "user_types_metadata.hh"
 #include "cql3/query_processor.hh"
+#include "cql3/column_identifier.hh"
 
 namespace cql3 {
 

--- a/cql3/statements/list_permissions_statement.cc
+++ b/cql3/statements/list_permissions_statement.cc
@@ -46,6 +46,7 @@
 #include "auth/authorizer.hh"
 #include "auth/common.hh"
 #include "cql3/result_set.hh"
+#include "cql3/column_identifier.hh"
 #include "transport/messages/result_message.hh"
 
 cql3::statements::list_permissions_statement::list_permissions_statement(

--- a/cql3/statements/list_service_level_attachments_statement.cc
+++ b/cql3/statements/list_service_level_attachments_statement.cc
@@ -21,6 +21,7 @@
 
 #include "seastarx.hh"
 #include "cql3/statements/list_service_level_attachments_statement.hh"
+#include "cql3/column_identifier.hh"
 #include "service/qos/service_level_controller.hh"
 #include "transport/messages/result_message.hh"
 #include "service/client_state.hh"

--- a/cql3/statements/list_service_level_statement.cc
+++ b/cql3/statements/list_service_level_statement.cc
@@ -21,6 +21,7 @@
 
 #include "seastarx.hh"
 #include "cql3/statements/list_service_level_statement.hh"
+#include "cql3/column_identifier.hh"
 #include "service/qos/service_level_controller.hh"
 #include "transport/messages/result_message.hh"
 #include "utils/overloaded_functor.hh"

--- a/cql3/statements/list_users_statement.cc
+++ b/cql3/statements/list_users_statement.cc
@@ -42,6 +42,7 @@
 #include "list_users_statement.hh"
 #include "cql3/query_processor.hh"
 #include "cql3/query_options.hh"
+#include "cql3/column_identifier.hh"
 #include "auth/common.hh"
 #include "transport/messages/result_message.hh"
 

--- a/cql3/statements/role-management-statements.cc
+++ b/cql3/statements/role-management-statements.cc
@@ -46,6 +46,7 @@
 #include "auth/common.hh"
 #include "auth/role_manager.hh"
 #include "cql3/column_specification.hh"
+#include "cql3/column_identifier.hh"
 #include "cql3/query_processor.hh"
 #include "cql3/statements/alter_role_statement.hh"
 #include "cql3/statements/create_role_statement.hh"

--- a/cql3/untyped_result_set.cc
+++ b/cql3/untyped_result_set.cc
@@ -45,6 +45,7 @@
 #include <stdexcept>
 #include "untyped_result_set.hh"
 #include "result_set.hh"
+#include "cql3/column_identifier.hh"
 #include "transport/messages/result_message.hh"
 
 cql3::untyped_result_set_row::untyped_result_set_row(const index_map& index, const cql3::metadata& metadata, data_views data)

--- a/test/boost/cdc_test.cc
+++ b/test/boost/cdc_test.cc
@@ -41,6 +41,8 @@
 #include "types/set.hh"
 #include "types/user.hh"
 
+#include "cql3/column_identifier.hh"
+
 #include "utils/UUID_gen.hh"
 
 using namespace std::string_literals;

--- a/test/tools/cql_repl.cc
+++ b/test/tools/cql_repl.cc
@@ -40,6 +40,7 @@
 #include "db/paxos_grace_seconds_extension.hh"
 #include "cql3/cql_config.hh"
 #include "cql3/type_json.hh"
+#include "cql3/column_identifier.hh"
 #include "test/lib/exception_utils.hh"
 #include "alternator/tags_extension.hh"
 #include "cdc/cdc_extension.hh"

--- a/thrift/handler.cc
+++ b/thrift/handler.cc
@@ -45,6 +45,7 @@
 #include "service/storage_service.hh"
 #include "service/query_state.hh"
 #include "cql3/query_processor.hh"
+#include "cql3/column_identifier.hh"
 #include "timeout_config.hh"
 #include <boost/range/adaptor/transformed.hpp>
 #include <boost/range/adaptor/filtered.hpp>


### PR DESCRIPTION
This allows us to forward-declare raw_selector, which in turn reduces
indirect inclusions of expression.hh from 147 to 58, reducing rebuilds
when anything in that area changes.

Includes that were lost due to the change are restored in individual
translation units.