### PR TITLE
sstables: mx: partition_reversing_data_source: close internal data consumers

### DIFF
--- a/sstables/mx/partition_reversing_data_source.hh
+++ b/sstables/mx/partition_reversing_data_source.hh
@@ -55,6 +55,8 @@ struct partition_reversing_data_source {
 // We ignore the value of `ir.data_file_positions().start`.
 //
 // We assume that `ir.current_clustered_cursor()`, if engaged, is of type `sstables::mc::bsearch_clustered_cursor*`.
+//
+// The source must be closed before destruction unless `get()` was never called.
 partition_reversing_data_source make_partition_reversing_data_source(
     const schema& s, shared_sstable sst, index_reader& ir, uint64_t pos, size_t len,
     reader_permit permit, const io_priority_class& io_priority, tracing::trace_state_ptr trace_state);


### PR DESCRIPTION
`partition_reversing_data_source` uses `continuous_data_consumer`s
internally (`partition_header_context`, `row_body_skipping_context`)
which hold `input_stream`s opened to sstable data files. These
`input_stream`s must be closed before destruction. Right now they would
sometimes cause "Assertion `_reads_in_progress == 0' failed" on
destruction.

Close the `continuous_data_consumer`s before they are destroyed so they
can close their `input_stream`s.

Fixes #9444.