### PR TITLE
Partition based splitting writer exception safety

### DIFF
--- a/mutation_reader.cc
+++ b/mutation_reader.cc
@@ -2010,7 +2010,7 @@ public:
             _full.reset();
         }
     }
-    void abort(std::exception_ptr ep) {
+    void abort(std::exception_ptr ep) noexcept {
         _ex = std::move(ep);
         if (_full) {
             _full->set_exception(_ex);
@@ -2022,8 +2022,14 @@ public:
     }
 };
 
-void queue_reader_handle::abandon() {
-    abort(std::make_exception_ptr<std::runtime_error>(std::runtime_error("Abandoned queue_reader_handle")));
+void queue_reader_handle::abandon() noexcept {
+    std::exception_ptr ex;
+    try {
+        ex = std::make_exception_ptr<std::runtime_error>(std::runtime_error("Abandoned queue_reader_handle"));
+    } catch (...) {
+        ex = std::current_exception();
+    }
+    abort(std::move(ex));
 }
 
 queue_reader_handle::queue_reader_handle(queue_reader& reader) noexcept : _reader(&reader) {

--- a/mutation_reader.hh
+++ b/mutation_reader.hh
@@ -579,7 +579,7 @@ private:
 private:
     explicit queue_reader_handle(queue_reader& reader) noexcept;
 
-    void abandon();
+    void abandon() noexcept;
 
 public:
     queue_reader_handle(queue_reader_handle&& o) noexcept;

--- a/mutation_writer/partition_based_splitting_writer.cc
+++ b/mutation_writer/partition_based_splitting_writer.cc
@@ -54,7 +54,12 @@ private:
         });
         it->writer.consume_end_of_stream();
         co_await it->writer.close();
-        *it = bucket{bucket_writer(_schema, _permit, _consumer), key};
+        try {
+            *it = bucket{bucket_writer(_schema, _permit, _consumer), key};
+        } catch (...) {
+            _buckets.erase(it);
+            throw;
+        }
         co_return &*it;
     }
 public:

--- a/mutation_writer/partition_based_splitting_writer.cc
+++ b/mutation_writer/partition_based_splitting_writer.cc
@@ -128,8 +128,14 @@ public:
 future<> segregate_by_partition(flat_mutation_reader producer, unsigned max_buckets, reader_consumer consumer) {
     auto schema = producer.schema();
     auto permit = producer.permit();
+  try {
     return feed_writer(std::move(producer),
             partition_based_splitting_mutation_writer(std::move(schema), std::move(permit), std::move(consumer), max_buckets));
+  } catch (...) {
+    return producer.close().then([ex = std::current_exception()] () mutable {
+        return make_exception_future<>(std::move(ex));
+     });
+  }
 }
 
 } // namespace mutation_writer


### PR DESCRIPTION
The partition based splitting writer (used by scrub) was found to be exception-unsafe, converting an `std::bad_alloc` to an assert failure. This series fixes the problem and adds a unit test checking the exception safety against `std::bad_alloc`:s fixing any other related problems found.

Fixes: https://github.com/scylladb/scylla/issues/9452