### PR TITLE
dist: raise fs.file-max and fs.nr_open to enough size for scylla

### DIFF
--- a/dist/common/sysctl.d/99-scylla-filemax.conf
+++ b/dist/common/sysctl.d/99-scylla-filemax.conf
@@ -1,0 +1,5 @@
+# Raise maximum number of file-handles that the kernel will allocate
+fs.file-max = 9223372036854775807
+
+# Raise maximum number of file-handles a process can allocate
+fs.nr_open = 1073741816

--- a/dist/debian/debian/scylla-kernel-conf.postinst
+++ b/dist/debian/debian/scylla-kernel-conf.postinst
@@ -12,6 +12,7 @@ else
     sysctl -p/usr/lib/sysctl.d/99-scylla-vm.conf || :
     sysctl -p/usr/lib/sysctl.d/99-scylla-inotify.conf || :
     sysctl -p/usr/lib/sysctl.d/99-scylla-aio.conf || :
+    sysctl -p/usr/lib/sysctl.d/99-scylla-filemax.conf || :
 fi
 
 #DEBHELPER#

--- a/dist/redhat/scylla.spec
+++ b/dist/redhat/scylla.spec
@@ -212,6 +212,7 @@ if Scylla is the main application on your server and you wish to optimize its la
 /usr/lib/systemd/systemd-sysctl 99-scylla-vm.conf >/dev/null 2>&1 || :
 /usr/lib/systemd/systemd-sysctl 99-scylla-inotify.conf >/dev/null 2>&1 || :
 /usr/lib/systemd/systemd-sysctl 99-scylla-aio.conf >/dev/null 2>&1 || :
+/usr/lib/systemd/systemd-sysctl 99-scylla-filemax.conf >/dev/null 2>&1 || :
 
 %files kernel-conf
 %defattr(-,root,root)


### PR DESCRIPTION
Currently, we configure LimitNOFILE on scylla-server.service, but we
don't configure fs.nr_open and fs.file-max.
When fs.nr_open or fs.file-max are smaller than LimitNOFILE, we may fail
to allocate FDs.
To fix this issue, we need to raise these parameter when it's smaller
than LimitNOFILE.

Fixes #9456