### PR TITLE
compaction: scrub/segregate: adjust partition-estimate as buckets accumulate

### DIFF
--- a/compaction/compaction.cc
+++ b/compaction/compaction.cc
@@ -561,7 +561,7 @@ protected:
         });
     }
 
-    uint64_t partitions_per_sstable() const {
+    virtual uint64_t partitions_per_sstable() const {
         // some tests use _max_sstable_size == 0 for force many one partition per sstable
         auto max_sstable_size = std::max<uint64_t>(_max_sstable_size, 1);
         uint64_t estimated_sstables = std::max(1UL, uint64_t(ceil(double(_start_size) / max_sstable_size)));
@@ -1397,6 +1397,7 @@ private:
     compaction_type_options::scrub _options;
     std::string _scrub_start_description;
     std::string _scrub_finish_description;
+    uint64_t _bucket_count = 0;
 
 public:
     scrub_compaction(column_family& cf, compaction_descriptor descriptor, compaction_data& info, compaction_type_options::scrub options)
@@ -1419,9 +1420,22 @@ public:
         return make_flat_mutation_reader<reader>(std::move(crawling_reader), _options.operation_mode);
     }
 
+    uint64_t partitions_per_sstable() const override {
+        const auto original_estimate = compaction::partitions_per_sstable();
+        if (_bucket_count <= 1) {
+            return original_estimate;
+        } else {
+            const auto shift = std::min(uint64_t(63), _bucket_count - 1);
+            return std::max(uint64_t(1), original_estimate >> shift);
+        }
+    }
+
     reader_consumer make_interposer_consumer(reader_consumer end_consumer) override {
         return [this, end_consumer = std::move(end_consumer)] (flat_mutation_reader reader) mutable -> future<> {
-            return mutation_writer::segregate_by_partition(std::move(reader), 100, std::move(end_consumer));
+            return mutation_writer::segregate_by_partition(std::move(reader), 100, [consumer = std::move(end_consumer), this] (flat_mutation_reader rd) {
+                ++_bucket_count;
+                return consumer(std::move(rd));
+            });
         };
     }
 


### PR DESCRIPTION
Scrub compaction simply uses the default compaction mechanism for estimating the number of partition going into each output sstable. This is fine for the majority of the cases where the input sstable is not split at all or is split into a few output sstables. It becomes a problem when an input sstable has to be split into hundreds or thousands (both have been seen in the wild) of output sstable. Most of these output sstables will have 1-2 partitions with a few rows. At this number of sstables, unnecessarily bloated bloom-filters (allocated based on the original estimate) becomes a serious problem, to the point of potentially causing OOM.
This is fixed by exponentially reducing the partition estimate once more then a few buckets are created.

Fixes https://github.com/scylladb/scylla/issues/9463