### PR TITLE
build: reinstate -Wunknown-attributes

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1308,7 +1308,6 @@ warnings = [
     '-Wno-unsupported-friend',
     '-Wno-unused-variable',
     '-Wno-delete-non-abstract-non-virtual-dtor',
-    '-Wno-unknown-attributes',
     '-Wno-braced-scalar-init',
     '-Wno-implicit-int-float-conversion',
     '-Wno-delete-abstract-non-virtual-dtor',


### PR DESCRIPTION
The warning was disabled during the migration to clang, but now it
appears unnecessary (perhaps clang added support for the attributes
it did not have then). It is valuable for detecting misspelled
attributes, so enable it again.