### PR TITLE
cql3: include system distributed tables in system stats

### DIFF
--- a/cql3/statements/modification_statement.cc
+++ b/cql3/statements/modification_statement.cc
@@ -61,7 +61,7 @@
 #include "cql3/query_processor.hh"
 #include "service/storage_proxy.hh"
 
-bool is_system_keyspace(std::string_view name);
+bool is_internal_keyspace(std::string_view name);
 
 namespace cql3 {
 
@@ -90,7 +90,7 @@ modification_statement::modification_statement(statement_type type_, uint32_t bo
     , attrs{std::move(attrs_)}
     , _column_operations{}
     , _stats(stats_)
-    , _ks_sel(::is_system_keyspace(schema_->ks_name()) ? ks_selector::SYSTEM : ks_selector::NONSYSTEM)
+    , _ks_sel(::is_internal_keyspace(schema_->ks_name()) ? ks_selector::SYSTEM : ks_selector::NONSYSTEM)
 { }
 
 uint32_t modification_statement::get_bound_terms() const {

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -66,7 +66,7 @@
 #include "test/lib/select_statement_utils.hh"
 #include <boost/algorithm/cxx11/any_of.hpp>
 
-bool is_system_keyspace(std::string_view name);
+bool is_internal_keyspace(std::string_view name);
 
 namespace cql3 {
 
@@ -156,7 +156,7 @@ select_statement::select_statement(schema_ptr schema,
     , _per_partition_limit(std::move(per_partition_limit))
     , _ordering_comparator(std::move(ordering_comparator))
     , _stats(stats)
-    , _ks_sel(::is_system_keyspace(schema->ks_name()) ? ks_selector::SYSTEM : ks_selector::NONSYSTEM)
+    , _ks_sel(::is_internal_keyspace(schema->ks_name()) ? ks_selector::SYSTEM : ks_selector::NONSYSTEM)
     , _attrs(std::move(attrs))
 {
     _opts = _selection->get_query_options();


### PR DESCRIPTION
Some time ago we started gathering stats for system tables in a separate
class in order to be able to distinguish which queries come from the
user - e.g. if the unpaged queries are internal or not.
Originally, only local system tables were moved into this class,
i.e. system and system_schema. It would make sense, however, to also
include other internal keyspaces in this separate class - which includes
system_distributed, system_traces, etc.

Fixes #9380