### PR TITLE
partition_snapshot_reader: do not accidentally copy schema

### DIFF
--- a/partition_snapshot_reader.hh
+++ b/partition_snapshot_reader.hh
@@ -114,7 +114,7 @@ class partition_snapshot_flat_reader : public flat_mutation_reader::impl, public
         // In reversing mode, upper and lower bounds still need to be executed against
         // snapshot schema and ck_range, however we need them to search from "opposite" direction.
         template<typename T, typename... Args>
-        static rows_iter_type lower_bound(const T& t, Args... args) {
+        static rows_iter_type lower_bound(const T& t, Args&&... args) {
             if constexpr (Reversing) {
                 return make_iterator(t.upper_bound(std::forward<Args>(args)...));
             } else {
@@ -122,7 +122,7 @@ class partition_snapshot_flat_reader : public flat_mutation_reader::impl, public
             }
         }
         template<typename T, typename... Args>
-        static rows_iter_type upper_bound(const T& t, Args... args) {
+        static rows_iter_type upper_bound(const T& t, Args&&... args) {
             if constexpr (Reversing) {
                 return make_iterator(t.lower_bound(std::forward<Args>(args)...));
             } else {


### PR DESCRIPTION
Functions `upper_bound` and `lower_bound` had signatures:
```
template<typename T, typename... Args>
static rows_iter_type lower_bound(const T& t, Args... args);
```
This caused a dacay from `const schema&` to `schema` as one of the args,
which in turn copied the schema in a fair number of the queries. Fix
that by setting the parameter type to `Args&&`, which doesn't discard
the reference.

Fixes #9502