### PR TITLE
api: (minor) fix typo bool instead of boolean

### DIFF
--- a/api/api-doc/column_family.json
+++ b/api/api-doc/column_family.json
@@ -89,7 +89,7 @@
                      "description":"true if the output of the major compaction should be split in several sstables",
                      "required":false,
                      "allowMultiple":false,
-                     "type":"bool",
+                     "type":"boolean",
                      "paramType":"query"
                   }
                ]


### PR DESCRIPTION
In definition for /column_family/major_compaction/{name} there is an
incorrect use of "bool" instead of "boolean".
