### PR TITLE
More nodetool-replacing virtual tables

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1005,6 +1005,7 @@ scylla_core = (['database.cc',
                 'utils/ascii.cc',
                 'utils/like_matcher.cc',
                 'utils/error_injection.cc',
+                'utils/build_id.cc',
                 'mutation_writer/timestamp_based_splitting_writer.cc',
                 'mutation_writer/shard_based_splitting_writer.cc',
                 'mutation_writer/partition_based_splitting_writer.cc',
@@ -1014,6 +1015,7 @@ scylla_core = (['database.cc',
                 'service/raft/schema_raft_state_machine.cc',
                 'service/raft/raft_sys_table_storage.cc',
                 'serializer.cc',
+                'release.cc',
                 'service/raft/raft_rpc.cc',
                 'service/raft/raft_gossip_failure_detector.cc',
                 'service/raft/raft_group_registry.cc',
@@ -1143,7 +1145,7 @@ scylla_tests_dependencies = scylla_core + idls + scylla_tests_generic_dependenci
 scylla_raft_dependencies = scylla_raft_core + ['utils/uuid.cc']
 
 deps = {
-    'scylla': idls + ['main.cc', 'release.cc', 'utils/build_id.cc'] + scylla_core + api + alternator + redis,
+    'scylla': idls + ['main.cc'] + scylla_core + api + alternator + redis,
     'test/tools/cql_repl': idls + ['test/tools/cql_repl.cc'] + scylla_core + scylla_tests_generic_dependencies,
     #FIXME: we don't need all of scylla_core here, only the types module, need to modularize scylla_core.
     'tools/scylla-types': idls + ['tools/scylla-types.cc'] + scylla_core,
@@ -1250,8 +1252,8 @@ deps['test/boost/allocation_strategy_test'] = ['test/boost/allocation_strategy_t
 deps['test/boost/log_heap_test'] = ['test/boost/log_heap_test.cc']
 deps['test/boost/estimated_histogram_test'] = ['test/boost/estimated_histogram_test.cc']
 deps['test/boost/anchorless_list_test'] = ['test/boost/anchorless_list_test.cc']
-deps['test/perf/perf_fast_forward'] += ['release.cc', 'test/perf/linux-perf-event.cc']
-deps['test/perf/perf_simple_query'] += ['release.cc', 'test/perf/perf.cc', 'test/perf/linux-perf-event.cc', 'test/lib/alternator_test_env.cc'] + alternator
+deps['test/perf/perf_fast_forward'] += ['test/perf/linux-perf-event.cc']
+deps['test/perf/perf_simple_query'] += ['test/perf/perf.cc', 'test/perf/linux-perf-event.cc', 'test/lib/alternator_test_env.cc'] + alternator
 deps['test/perf/perf_row_cache_reads'] += ['test/perf/perf.cc', 'test/perf/linux-perf-event.cc']
 deps['test/perf/perf_row_cache_update'] += ['test/perf/perf.cc', 'test/perf/linux-perf-event.cc']
 deps['test/boost/reusable_buffer_test'] = [

--- a/database.hh
+++ b/database.hh
@@ -120,7 +120,7 @@ class rp_handle;
 class data_listeners;
 class large_data_handler;
 
-future<> system_keyspace_make(database& db, service::storage_service& ss);
+future<> system_keyspace_make(distributed<database>& db, distributed<service::storage_service>& ss);
 
 }
 
@@ -1368,7 +1368,7 @@ public:
 private:
     using system_keyspace = bool_class<struct system_keyspace_tag>;
     future<> create_in_memory_keyspace(const lw_shared_ptr<keyspace_metadata>& ksm, system_keyspace system);
-    friend future<> db::system_keyspace_make(database& db, service::storage_service& ss);
+    friend future<> db::system_keyspace_make(distributed<database>& db, distributed<service::storage_service>& ss);
     void setup_metrics();
     void setup_scylla_memory_diagnostics_producer();
 

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -262,7 +262,7 @@ public:
     static future<std::optional<sstring>> get_scylla_local_param(const sstring& key);
 
     static std::vector<schema_ptr> all_tables(const db::config& cfg);
-    static future<> make(database& db, service::storage_service& ss);
+    static future<> make(distributed<database>& db, distributed<service::storage_service>& ss);
 
     /// overloads
 
@@ -417,7 +417,7 @@ public:
 
 }; // class system_keyspace
 
-future<> system_keyspace_make(database& db, service::storage_service& ss);
+future<> system_keyspace_make(distributed<database>& db, distributed<service::storage_service>& ss);
 extern const char *const system_keyspace_CLIENTS;
 
 } // namespace db

--- a/db/virtual_table.hh
+++ b/db/virtual_table.hh
@@ -31,7 +31,6 @@ namespace db {
 class virtual_table {
 protected:
     schema_ptr _s;
-    database* _db = nullptr; // Always valid when attached to a database.
 
 protected: // opt-ins
     // If set to true, the implementation ensures that produced data
@@ -57,8 +56,6 @@ public:
 
     // Keep this object alive as long as the returned mutation_source is alive.
     virtual mutation_source as_mutation_source() = 0;
-
-    void set_database(database& db) { _db = &db; }
 };
 
 // Produces results by filling a memtable on each read.

--- a/distributed_loader.cc
+++ b/distributed_loader.cc
@@ -567,8 +567,8 @@ future<> distributed_loader::populate_keyspace(distributed<database>& db, sstrin
 
 future<> distributed_loader::init_system_keyspace(distributed<database>& db, distributed<service::storage_service>& ss) {
     return seastar::async([&db, &ss] {
-        db.invoke_on_all([&ss] (database& db) {
-            return db::system_keyspace::make(db, ss.local());
+        db.invoke_on_all([&db, &ss] (database&) {
+            return db::system_keyspace::make(db, ss);
         }).get();
 
         const auto& cfg = db.local().get_config();

--- a/docs/design-notes/system_keyspace.md
+++ b/docs/design-notes/system_keyspace.md
@@ -277,3 +277,21 @@ CREATE TABLE system.token_ring (
 ```
 
 Implemented by `token_ring_table` in `db/system_keyspace.cc`.
+
+## system.versions
+
+All version-related information.
+Equivalent of `nodetool version` command, but contains more versions.
+
+Schema:
+```CQL
+CREATE TABLE system.versions (
+    key text PRIMARY KEY,
+    build_id text,
+    build_mode text,
+    compatible_version text,
+    version text
+)
+```
+
+Implemented by `versions_table` in `db/system_keyspace.cc`.

--- a/docs/design-notes/system_keyspace.md
+++ b/docs/design-notes/system_keyspace.md
@@ -175,6 +175,32 @@ CREATE TABLE system.cluster_status (
 
 Implemented by `cluster_status_table` in `db/system_keyspace.cc`.
 
+## system.protocol_servers
+
+The list of all the client-facing data-plane protocol servers and listen addresses (if running).
+Equivalent of the `nodetool statusbinary` plus the `Thrift active` and `Native Transport active` fields from `nodetool info`.
+
+TODO: include control-plane diagnostics-plane protocols here too.
+
+Schema:
+```CQL
+CREATE TABLE system.protocol_servers (
+    name text PRIMARY KEY,
+    is_running boolean,
+    listen_addresses frozen<list<text>>,
+    protocol text,
+    protocol_version text
+)
+```
+
+Columns:
+* `name` - the name/alias of the server, this is sometimes different than the protocol the server serves, e.g.: the CQL server is often called "native";
+* `listen_addresses` - the addresses this server listens on, empty if the server is not running;
+* `protocol` - the name of the protocol this server serves;
+* `protocol_version` - the version of the protocol this server understands;
+
+Implemented by `protocol_servers_table` in `db/system_keyspace.cc`.
+
 ## system.size_estimates
 
 Size estimates for individual token-ranges of each keyspace/table.

--- a/docs/design-notes/system_keyspace.md
+++ b/docs/design-notes/system_keyspace.md
@@ -239,6 +239,24 @@ CREATE TABLE system.snapshots (
 
 Implemented by `snapshots_table` in `db/system_keyspace.cc`.
 
+## system.runtime_info
+
+Runtime specific information, like memory stats, memtable stats, cache stats and more.
+Data is grouped so that related items stay together and are easily queried.
+Roughly equivalent of the `nodetool info`, `nodetool gettraceprobability` and `nodetool statusgossup` commands.
+
+Schema:
+```CQL
+CREATE TABLE system.runtime_info (
+    group text,
+    item text,
+    value text,
+    PRIMARY KEY (group, item)
+)
+```
+
+Implemented by `runtime_info_table` in `db/system_keyspace.cc`.
+
 ## system.token_ring
 
 The ring description for each keyspace.

--- a/docs/design-notes/system_keyspace.md
+++ b/docs/design-notes/system_keyspace.md
@@ -194,6 +194,25 @@ CREATE TABLE system.size_estimates (
 
 Implemented by `size_estimates_mutation_reader` in `db/size_estimates_virtual_reader.{hh,cc}`.
 
+## system.snapshots
+
+The list of snapshots on the node.
+Equivalent to the `nodetool listsnapshots` command.
+
+Schema:
+```CQL
+CREATE TABLE system.snapshots (
+    keyspace_name text,
+    table_name text,
+    snapshot_name text,
+    live bigint,
+    total bigint,
+    PRIMARY KEY (keyspace_name, table_name, snapshot_name)
+)
+```
+
+Implemented by `snapshots_table` in `db/system_keyspace.cc`.
+
 ## system.token_ring
 
 The ring description for each keyspace.

--- a/docs/guides/virtual-tables.md
+++ b/docs/guides/virtual-tables.md
@@ -1,0 +1,96 @@
+# Virtual Tables
+
+Virtual tables are tables that are not backed by physical storage (sstables), instead they generate their content on-the-fly when queried, by a specific reader instance.
+This reader is created by a `mutation_source` object stored in the `table` instance, set previously by `table::set_virtual_reader()`.
+So on a very low level, a table is virtual, if one calls `table::set_virtual_reader()` in its `table` instance.
+
+Virtual tables allow for exposing information already available in memory to the user in the form of a CQL table.
+They are much more lightweight than their regular counterparts and they completely lack all the burden and overhead of updating a persistent storage and keeping it consistent with the already existing in-memory structures.
+Instead virtual table readers can just translate these in-memory structures into CQL results at the time they are queried.
+These tables completely look and act like regular tables from a user's point of view, which is the entire point: the user can use an interface they are already familiar with to query and manipulate data.
+
+
+## What is a good candidate for a virtual table?
+
+In general a good candidate for a virtual table has to match the following conditions:
+1) It exposes data readily available in in-memory structures of the node. The data doesn't have to be related to the node, it can be about the entire cluster too.
+2) The amount of data is small to moderate (partitions/rows in the order of low thousands).
+3) The data is not available from other tables, like regular system tables.
+
+
+## Information retrieval nodetool commands as virtual tables
+
+Some time ago we started adding virtual tables to replace information retrieval nodetool commands.
+These nodetool commands are currently served by one or more REST API endpoints.
+CQL tables are a natural fit to replace these nodetool commands:
+* One can retrieve the information with just a CQL client, instead of having to have both jmx and nodetool setup;
+* Remote access: REST and therefore nodetool is only accessible on the same machine the node lives on for security considerations (see below);
+* Security: CQL has authentication and authorization already, with fine-grained RBAC support;
+* Filtering and aggregation: CQL allows for filtering and selecting rows/columns as well as aggregating them;
+
+Even though not widely known, CQL also has built-in JSON support (`select json...`) so if somebody prefers JSON (used by REST) they can still use JSON with CQL too.
+
+## How to add a new virtual table?
+
+The process of adding a new virtual table is as follows:
+* Choose the appropriate class to inherit from: `db::memtable_filling_virtual_table` or `db::streaming_virtual_table` (located in `db/virtual_table.hh`);
+* Implement the interface generating the data, mind shard awareness and query restrictions if they apply;
+* Instantiate and register your virtual table in `register_virtual_tables()` in `db/system_keyspace.cc`;
+
+### Choosing the right class for you virtual table
+
+#### memtable_filling_virtual_table
+
+If your table generates a constant (that is known in advance) and small amount of data you should use the `db::memtable_filling_virtual_table`.
+This works by first inserting all data into a memtable, then querying said memtable. The memtable takes care of all aspects of the query: read range restrictions, slicing, etc.
+Your implementation's only job is to generate the data and feed it to the `mutation_sink` parameter of `execute()`.
+Partitions and rows can be generated in any order, the memtable takes care of ordering it.
+Shard awareness still applies, see the [shard awareness](#shard-awareness) section.
+
+#### streaming_virtual_table
+
+If your table generates either a lot of data (say 100+ lines) or the amount of data generated is not fixed but dynamic, you should use `db::streaming_virtual_table`.
+This works by generating one partition at a time, fragment-by-fragment, yielding when the data fills a reader buffer.
+Your implementation has to make sure partitions are generated in the right order (very important)!!! The same goes for rows.
+Although the `streaming_virtual_table` will take care of dropping any partitions/rows that are outside of the read-range, this is wasteful, so you also should avoid emitting any partitions that are not in the read-range -- obtainable from `query_restrictions` parameter of `execute()`.
+Shard awareness also applies, see the [shard awareness](#shard-awareness) section.
+
+A typical algorithm works like this:
+```c++
+
+future<> execute(reader_permit permit, result_collector& result, const query_restrictions& qr) override {
+    // First produce all possible partition keys for the to-be-emitted data
+    std::vector<dht::decorated_key> keys;
+    for (const auto& my_key : generate_all_keys()) {
+        auto dk = make_decorated_key(my_key);
+        // Drop those that either don't belong to this shard (see shard awareness) or are outside the read range (not a must but nice-to-do)
+        if (this_shard_owns(dk) && contains_key(qr.partition_range(), dk)) {
+            keys.push_back(std::move(dk));
+        }
+    }
+
+    // Sort keys in token order
+    boost::sort(keys, dht::ring_position_less_comparator(*_s));
+
+    // Iterate over the keys and generate content for them
+    for (auto& dk : keys) {
+        co_await result.emit_partition_start(dk.key);
+        // generate rows, in clustering order!!!
+        co_await result.emit_partition_end();
+    }
+}
+```
+
+#### Shard awareness
+
+Virtual tables have to take care to not emit partitions that don't belong to the shard the read runs on.
+When querying a virtual table, the normal read algorithms are used.
+These expect that the table exists on all shards and on each shard the table will only emit data, whose token belongs to that shard according to the table's (schema's) sharder.
+For convenience the virtual table infrastructure (`db::virtual_table`) takes care of dropping all partitions from your virtual table output that doesn't belong to the current shard.
+This is inefficient however because the data is produced just to be dropped and filtering is not free either.
+So virtual table implementations can instead do this filtering themselves and promise to the `db::virtual_table` (their ancestor class) that they are shard aware and will take care of this.
+They can do this by setting `_shard_aware = true` in their constructor.
+If your table generates very little data and generating partitions is not much more expensive then generating just the keys, you can opt for `db::virtual_table` to take care of shard awareness for you.
+You can do this by setting `_shard_aware = false` in the constructor of your virtual table.
+
+Whichever you choose to do, just make sure to match your implementation with what you set `_shard_aware` to, doing otherwise can cause all sorts of unpredictable errors when your table is queried.

--- a/main.cc
+++ b/main.cc
@@ -1377,11 +1377,11 @@ int main(int ac, char** av) {
 
             if (cfg->alternator_port() || cfg->alternator_https_port()) {
                 with_scheduling_group(dbcfg.statement_scheduling_group, [&alternator_ctl] () mutable {
-                    return alternator_ctl.start();
+                    return alternator_ctl.start_server();
                 }).get();
 
                 ss.local().register_client_shutdown_hook("alternator", [&alternator_ctl] {
-                    alternator_ctl.stop().get();
+                    alternator_ctl.stop_server().get();
                 });
             }
 

--- a/main.cc
+++ b/main.cc
@@ -1329,7 +1329,7 @@ int main(int ac, char** av) {
             cql_transport::controller cql_server_ctl(auth_service, mm_notifier, gossiper.local(), qp, service_memory_limiter, sl_controller, lifecycle_notifier, *cfg);
 
             ss.local().register_client_shutdown_hook("native transport", [&cql_server_ctl] {
-                cql_server_ctl.stop().get();
+                cql_server_ctl.stop_server().get();
             });
 
             std::any stop_cql;
@@ -1341,7 +1341,7 @@ int main(int ac, char** av) {
 
                 // FIXME -- this should be done via client hooks instead
                 stop_cql = defer_verbose_shutdown("native transport", [&cql_server_ctl] {
-                    cql_server_ctl.stop().get();
+                    cql_server_ctl.stop_server().get();
                 });
             }
 

--- a/main.cc
+++ b/main.cc
@@ -1353,7 +1353,7 @@ int main(int ac, char** av) {
             ::thrift_controller thrift_ctl(db, auth_service, qp, service_memory_limiter, ss);
 
             ss.local().register_client_shutdown_hook("rpc server", [&thrift_ctl] {
-                thrift_ctl.stop().get();
+                thrift_ctl.stop_server().get();
             });
 
             std::any stop_rpc;
@@ -1364,7 +1364,7 @@ int main(int ac, char** av) {
 
                 // FIXME -- this should be done via client hooks instead
                 stop_rpc = defer_verbose_shutdown("rpc server", [&thrift_ctl] {
-                    thrift_ctl.stop().get();
+                    thrift_ctl.stop_server().get();
                 });
             }
 

--- a/protocol_server.hh
+++ b/protocol_server.hh
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2021-present ScyllaDB
+ */
+
+/*
+ * This file is part of Scylla.
+ *
+ * Scylla is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Scylla is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "seastarx.hh"
+#include <seastar/core/future.hh>
+#include <vector>
+
+// Abstraction for a server serving some kind of user-facing protocol.
+class protocol_server {
+public:
+    virtual ~protocol_server() = default;
+    /// Name of the server, can be different or the same as than the protocol it serves.
+    virtual sstring name() const = 0;
+    /// Name of the protocol served.
+    virtual sstring protocol() const = 0;
+    /// Version of the protocol served (if any -- not all protocols are versioned).
+    virtual sstring protocol_version() const = 0;
+    /// Addresses the server is listening on, should be empty when server is not running.
+    virtual std::vector<socket_address> listen_addresses() const = 0;
+    /// Start the server.
+    /// Can be called multiple times, in any state of the server.
+    virtual future<> start_server() = 0;
+    /// Stop the server.
+    /// Can be called multiple times, in any state of the server.
+    /// This variant is used on shutdown and therefore it must succeed.
+    virtual future<> stop_server() = 0;
+    /// Stop the server. Weaker variant of \ref stop_server().
+    /// Can be called multiple times, in any state of the server.
+    /// This variant is used by the REST API so failure is acceptable.
+    virtual future<> request_stop_server() = 0;
+};

--- a/redis/service.cc
+++ b/redis/service.cc
@@ -31,7 +31,13 @@
 
 static logging::logger slogger("redis_service");
 
-redis_service::redis_service()
+redis_service::redis_service(seastar::sharded<service::storage_proxy>& proxy, seastar::sharded<auth::service>& auth_service,
+        seastar::sharded<service::migration_manager>& mm, db::config& cfg, seastar::sharded<gms::gossiper>& gossiper)
+    : _proxy(proxy)
+    , _auth_service(auth_service)
+    , _mm(mm)
+    , _cfg(cfg)
+    , _gossiper(gossiper)
 {
 }
 
@@ -59,16 +65,18 @@ future<> redis_service::listen(seastar::sharded<auth::service>& auth_service, db
     redis_cfg._max_request_size = memory::stats().total_memory() / 10;
     redis_cfg._total_redis_db_count = cfg.redis_database_count();
     return gms::inet_address::lookup(addr, family, preferred).then([this, server, addr, &cfg, keepalive, ceo = std::move(ceo), redis_cfg, &auth_service] (seastar::net::inet_address ip) {
-        return server->start(std::ref(_query_processor), std::ref(auth_service), redis_cfg).then([server, &cfg, addr, ip, ceo, keepalive]() {
+        return server->start(std::ref(_query_processor), std::ref(auth_service), redis_cfg).then([this, server, &cfg, addr, ip, ceo, keepalive]() {
             auto f = make_ready_future();
             struct listen_cfg {
                 socket_address addr;
                 std::shared_ptr<seastar::tls::credentials_builder> cred;
             };
 
+            _listen_addresses.clear();
             std::vector<listen_cfg> configs;
             if (cfg.redis_port()) {
                 configs.emplace_back(listen_cfg { {socket_address{ip, cfg.redis_port()}} });
+                _listen_addresses.push_back(configs.back().addr);
             }
 
             // main should have made sure values are clean and neatish
@@ -80,6 +88,7 @@ future<> redis_service::listen(seastar::sharded<auth::service>& auth_service, db
 
                 if (cfg.redis_ssl_port() && cfg.redis_ssl_port() != cfg.redis_port()) {
                     configs.emplace_back(listen_cfg{{ip, cfg.redis_ssl_port()}, std::move(cred)});
+                    _listen_addresses.push_back(configs.back().addr);
                 } else {
                     configs.back().cred = std::move(cred);
                 }
@@ -100,32 +109,51 @@ future<> redis_service::listen(seastar::sharded<auth::service>& auth_service, db
     });
 }
 
-future<> redis_service::init(seastar::sharded<service::storage_proxy>& proxy, seastar::sharded<database>& db,
-        seastar::sharded<auth::service>& auth_service, seastar::sharded<service::migration_manager>& mm, db::config& cfg,
-        seastar::sharded<gms::gossiper>& gossiper)
+sstring redis_service::name() const {
+    return "redis";
+}
+
+sstring redis_service::protocol() const {
+    return "RESP";
+}
+
+sstring redis_service::protocol_version() const {
+    return ::redis::version;
+}
+
+std::vector<socket_address> redis_service::listen_addresses() const {
+    return _listen_addresses;
+}
+
+future<> redis_service::start_server()
 {
     // 1. Create keyspace/tables used by redis API if not exists.
     // 2. Initialize the redis query processor.
     // 3. Listen on the redis transport port.
-    return redis::maybe_create_keyspace(mm, cfg, gossiper).then([this, &proxy, &db] {
-        return _query_processor.start(std::ref(proxy), std::ref(db));
+    return redis::maybe_create_keyspace(_mm, _cfg, _gossiper).then([this] {
+        return _query_processor.start(std::ref(_proxy), std::ref(_proxy.local().get_db()));
     }).then([this] {
         return _query_processor.invoke_on_all([] (auto& processor) {
             return processor.start();
         });
-    }).then([this, &cfg, &auth_service] {
-        return listen(auth_service, cfg);
+    }).then([this] {
+        return listen(_auth_service, _cfg);
     });
 }
 
-future<> redis_service::stop()
+future<> redis_service::stop_server()
 {
     // If the redis protocol disable, the redis_service::init is not
     // invoked at all. Do nothing if `_server is null.
     if (_server) {
         return _server->stop().then([this] {
+            _listen_addresses.clear();
             return _query_processor.stop();
         });
     }
     return make_ready_future<>();
+}
+
+future<> redis_service::request_stop_server() {
+    return stop_server();
 }

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -339,13 +339,6 @@ public:
     void register_client_shutdown_hook(std::string name, client_shutdown_hook hook) {
         _client_shutdown_hooks.push_back({std::move(name), std::move(hook)});
     }
-    void unregister_client_shutdown_hook(std::string name) {
-        auto it = std::find_if(_client_shutdown_hooks.begin(), _client_shutdown_hooks.end(),
-                [&name] (const std::pair<std::string, client_shutdown_hook>& hook) { return hook.first == name; });
-        if (it != _client_shutdown_hooks.end()) {
-            _client_shutdown_hooks.erase(it);
-        }
-    }
 private:
     future<> do_stop_ms();
     future<> do_stop_stream_manager();

--- a/test/cql-pytest/nodetool.py
+++ b/test/cql-pytest/nodetool.py
@@ -72,6 +72,13 @@ def flush(cql, table):
     else:
         run_nodetool(cql, "flush", ks, cf)
 
+def take_snapshot(cql, table, tag, skip_flush):
+    ks, cf = table.split('.')
+    if has_rest_api(cql):
+        requests.post(f'{rest_api_url(cql)}/storage_service/snapshots/', params={'kn': ks, 'cf' : cf, 'tag': tag, 'sf': skip_flush})
+    else:
+        run_nodetool(cql, "flush", ks, cf)
+
 def refreshsizeestimates(cql):
     if has_rest_api(cql):
         # The "nodetool refreshsizeestimates" is not available, or needed, in Scylla

--- a/test/cql-pytest/virtual_tables.py
+++ b/test/cql-pytest/virtual_tables.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+# Copyright 2021-present ScyllaDB
+#
+# This file is part of Scylla.
+#
+# Scylla is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Scylla is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
+
+import pytest
+import util
+import nodetool
+
+def test_snapshots_table(scylla_only, cql, test_keyspace):
+    with util.new_test_table(cql, test_keyspace, 'pk int PRIMARY KEY, v int') as table:
+        cql.execute(f"INSERT INTO {table} (pk, v) VALUES (0, 0)")
+        nodetool.take_snapshot(cql, table, 'my_tag', False)
+        res = list(cql.execute(f"SELECT keyspace_name, table_name, snapshot_name, live, total FROM system.snapshots"))
+        assert len(res) == 1
+        ks, tbl = table.split('.')
+        assert res[0][0] == ks
+        assert res[0][1] == tbl
+        assert res[0][2] == 'my_tag'
+
+# We only want to check that the table exists with the listed columns, to assert
+# backwards compatibility.
+def _check_exists(cql, table_name, columns):
+    cols = ", ".join(columns)
+    assert list(cql.execute(f"SELECT {cols} FROM system.{table_name}"))
+
+def test_protocol_servers(scylla_only, cql):
+    _check_exists(cql, "protocol_servers", ("name", "listen_addresses", "protocol", "protocol_version"))
+
+def test_runtime_info(scylla_only, cql):
+    _check_exists(cql, "runtime_info", ("group", "item", "value"))
+
+def test_versions(scylla_only, cql):
+    _check_exists(cql, "versions", ("key", "build_id", "build_mode", "version"))


### PR DESCRIPTION
This PR introduces 4 new virtual tables aimed at replacing nodetool commands, working towards the long-term goal of replacing nodetool completely at least for cluster information retrieval purposes.
As you may have noticed, most of these replacement are not exact matches. This is on purpose. I feel that the nodetool commands are somewhat chaotic: they might have had a clear plan on what command prints what but after years of organic development they are a mess of fields that feel like don't belong. In addition to this, they are centered on C* terminology which often sounds strange or doesn't make any sense for scylla (off-heap memory, counter cache, etc.).
So in this PR I tried to do a few things:
* Drop all fields that don't make sense for scylla;
* Rename/reformat/rephrase fields that have a corresponding concept in scylla, so that it uses the scylla terminology;
* Group information in tables based on some common theme;

With these guidelines in mind lets look at the virtual tables introduced in this PR:
* `system.snapshots` - replacement for `nodetool listnapshots`;
* `system.protocol_servers`- replacement for `nodetool statusbinary` as well as `Thrift active` and `Native Transport active` from `nodetool info`;
* `system.runtime_info` - replacement for `nodetool info`, not an exact match: some fields were removed, some were refactored to make sense for scylla;
* `system.versions` - replacement for `nodetool version`, prints all versions, including build-id;