### PR TITLE
cql3: Allow to skip EQ restricted columns in ORDER BY

### DIFF
--- a/cql3/Cql.g
+++ b/cql3/Cql.g
@@ -486,9 +486,9 @@ whereClause returns [std::vector<cql3::relation_ptr> clause]
 
 orderByClause[raw::select_statement::parameters::orderings_type& orderings]
     @init{
-        bool reversed = false;
+        raw::select_statement::ordering ordering = raw::select_statement::ordering::ascending;
     }
-    : c=cident (K_ASC | K_DESC { reversed = true; })? { orderings.emplace_back(c, reversed); }
+    : c=cident (K_ASC | K_DESC { ordering = raw::select_statement::ordering::descending; })? { orderings.emplace_back(c, ordering); }
     ;
 
 jsonValue returns [expression value]

--- a/cql3/expr/expression.hh
+++ b/cql3/expr/expression.hh
@@ -655,6 +655,20 @@ inline auto find_clustering_order(const expression& e) {
 /// True iff binary_operator involves a collection.
 extern bool is_on_collection(const binary_operator&);
 
+// Checks whether the given column occurs in the expression.
+// Uses column_defintion::operator== for comparison, columns with the same name but different schema will not be equal.
+bool contains_column(const column_definition& column, const expression& e);
+
+// Checks whether this expression contains a nonpure function.
+// The expression must be prepared, so that function names are converted to function pointers.
+bool contains_nonpure_function(const expression&);
+
+// Checks whether the given column has an EQ restriction in the expression.
+// EQ restriction is `col = ...` or `(col, col2) = ...`
+// IN restriction is NOT an EQ restriction, this function will not look for IN restrictions.
+// Uses column_defintion::operator== for comparison, columns with the same name but different schema will not be equal.
+bool has_eq_restriction_on_column(const column_definition& column, const expression& e);
+
 /// Replaces every column_definition in an expression with this one.  Throws if any LHS is not a single
 /// column_value.
 extern expression replace_column_def(const expression&, const column_definition*);

--- a/cql3/restrictions/statement_restrictions.cc
+++ b/cql3/restrictions/statement_restrictions.cc
@@ -598,6 +598,14 @@ std::pair<std::optional<secondary_index::index>, ::shared_ptr<cql3::restrictions
     return {chosen_index, chosen_index_restrictions};
 }
 
+bool statement_restrictions::has_eq_restriction_on_column(const column_definition& column) const {
+    if (!_where.has_value()) {
+        return false;
+    }
+
+    return expr::has_eq_restriction_on_column(column, *_where);
+}
+
 std::vector<const column_definition*> statement_restrictions::get_column_defs_for_filtering(database& db) const {
     std::vector<const column_definition*> column_defs_for_filtering;
     if (need_filtering()) {

--- a/cql3/restrictions/statement_restrictions.hh
+++ b/cql3/restrictions/statement_restrictions.hh
@@ -215,6 +215,12 @@ public:
         return has_token(_partition_key_restrictions->expression);
     }
 
+    // Checks whether the given column has an EQ restriction.
+    // EQ restriction is `col = ...` or `(col, col2) = ...`
+    // IN restriction is NOT an EQ restriction, this function will not look for IN restrictions.
+    // Uses column_defintion::operator== for comparison, columns with the same name but different schema will not be equal.
+    bool has_eq_restriction_on_column(const column_definition&) const;
+
     /**
      * Builds a possibly empty collection of column definitions that will be used for filtering
      * @param db - the database context

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -1412,8 +1412,11 @@ std::unique_ptr<prepared_statement> select_statement::prepare(database& db, cql_
     if (!_parameters->orderings().empty()) {
         assert(!for_view);
         verify_ordering_is_allowed(*restrictions);
-        ordering_comparator = get_ordering_comparator(*schema, *selection, *restrictions);
-        is_reversed_ = is_reversed(*schema);
+        prepared_orderings_type prepared_orderings = prepare_orderings(*schema);
+        verify_ordering_is_valid(prepared_orderings, *schema, *restrictions);
+
+        ordering_comparator = get_ordering_comparator(prepared_orderings, *selection, *restrictions);
+        is_reversed_ = is_ordering_reversed(prepared_orderings);
     }
 
     std::vector<sstring> warnings;
@@ -1502,6 +1505,159 @@ void select_statement::verify_ordering_is_allowed(const restrictions::statement_
     }
 }
 
+void select_statement::handle_unrecognized_ordering_column(const column_identifier& column) const
+{
+    if (contains_alias(column)) {
+        throw exceptions::invalid_request_exception(format("Aliases are not allowed in order by clause ('{}')", column));
+    }
+    throw exceptions::invalid_request_exception(format("Order by on unknown column {}", column));
+}
+
+select_statement::prepared_orderings_type select_statement::prepare_orderings(const schema& schema) const {
+    prepared_orderings_type prepared_orderings;
+    prepared_orderings.reserve(_parameters->orderings().size());
+
+    for (auto&& [column_id, column_ordering] : _parameters->orderings()) {
+        ::shared_ptr<column_identifier> column = column_id->prepare_column_identifier(schema);
+
+        const column_definition* def = schema.get_column_definition(column->name());
+        if (def == nullptr) {
+            handle_unrecognized_ordering_column(*column);
+        }
+
+        if (!def->is_clustering_key()) {
+            throw exceptions::invalid_request_exception(format("Order by is currently only supported on the clustered columns of the PRIMARY KEY, got {}", *column));
+        }
+
+        prepared_orderings.emplace_back(def, column_ordering);
+    }
+
+    // Uncomment this to allow specifing ORDER BY columns in any order.
+    // Right now specifying ORDER BY (c2 asc, c1 asc) is illegal, it can only be ORDER BY (c1 asc, c2 asc).
+    //
+    // std::sort(prepared_orderings.begin(), prepared_orderings.end(),
+    //     [](const std::pair<const column_definition*, ordering>& a, const std::pair<const column_definition*, ordering>& b) {
+    //         return a.first->component_index() < b.first->component_index();
+    //     }
+    // );
+
+    return prepared_orderings;
+}
+
+// Checks whether this ordering causes select results on this column to be reversed.
+// A clustering column can be ordered in the descending order in the table.
+// Then specifying ascending order would cause the results of this column to be reverse in comparison to a standard select.
+static bool are_column_select_results_reversed(const column_definition& column, select_statement::ordering column_ordering) {
+    if (column_ordering == select_statement::ordering::ascending) {
+        if (column.type->is_reversed()) {
+            return true;
+        } else {
+            return false;
+        }
+    } else { // descending ordering
+        if (column.type->is_reversed()) {
+            return false;
+        } else {
+            return true;
+        }
+    }
+}
+
+bool select_statement::is_ordering_reversed(const prepared_orderings_type& orderings) const {
+    if (orderings.empty()) {
+        return false;
+    }
+
+    return are_column_select_results_reversed(*orderings[0].first, orderings[0].second);
+}
+
+void select_statement::verify_ordering_is_valid(const prepared_orderings_type& orderings,
+                                                const schema& schema,
+                                                const restrictions::statement_restrictions& restrictions) const {
+    if (orderings.empty()) {
+        return;
+    }
+
+    // Verify that columns are in the same order as in schema definition
+    for (size_t i = 0; i + 1 < orderings.size(); i++) {
+        if (orderings[i].first->component_index() >= orderings[i + 1].first->component_index()) {
+            throw exceptions::invalid_request_exception("Order by currently only supports the ordering of columns following their declared order in the PRIMARY KEY");
+        }
+    }
+
+    // We only allow leaving select results unchanged or reversing them. Find out if they should be reversed.
+    bool is_reversed = is_ordering_reversed(orderings);
+
+    // Now verify that
+    // 1. Each column in the specified clustering prefix either has an ordering, or an EQ restriction.
+    //    When there is an EQ restriction ordering is not needed because only a single value is possible.
+    // 2. The ordering leaves the selected rows unchanged or reverses the normal result.
+    //    For that to happen the ordering must reverse all columns or none at all.
+    uint32_t max_ck_index = orderings.back().first->component_index();
+    auto orderings_iterator = orderings.begin();
+    for (uint32_t ck_column_index = 0; ck_column_index <= max_ck_index; ck_column_index++) {
+        if (orderings_iterator->first->component_index() != ck_column_index) {
+            // We don't have ordering for this column. Fail with an error.
+            const column_definition& cur_ck_column = schema.clustering_column_at(ck_column_index);
+            throw exceptions::invalid_request_exception(format(
+                    "Unsupported order by relation - column {} doesn't have an ordering.",
+                    cur_ck_column.name_as_text()));
+        }
+
+        // We have ordering for this column, let's see if its reversing is right.
+        const column_definition* cur_ck_column = orderings_iterator->first;
+        bool is_cur_column_reversed = are_column_select_results_reversed(*cur_ck_column, orderings_iterator->second);
+        if (is_cur_column_reversed != is_reversed) {
+            throw exceptions::invalid_request_exception(
+                    format("Unsupported order by relation - only reversing all columns is supported, "
+                           "but column {} has opposite ordering", cur_ck_column->name_as_text()));
+        }
+        orderings_iterator++;
+    }
+}
+
+select_statement::ordering_comparator_type select_statement::get_ordering_comparator(const prepared_orderings_type& orderings,
+    selection::selection& selection,
+    const restrictions::statement_restrictions& restrictions) {
+    if (!restrictions.key_is_in_relation()) {
+        return {};
+    }
+
+    std::vector<std::pair<uint32_t, data_type>> sorters;
+    sorters.reserve(orderings.size());
+
+    // If we order post-query (see orderResults), the sorted column needs to be in the ResultSet for sorting,
+    // even if we don't
+    // ultimately ship them to the client (CASSANDRA-4911).
+    for (auto&& [column_def, is_descending] : orderings) {
+        auto index = selection.index_of(*column_def);
+        if (index < 0) {
+            index = selection.add_column_for_post_processing(*column_def);
+        }
+
+        sorters.emplace_back(index, column_def->type);
+    }
+
+    return [sorters = std::move(sorters)] (const result_row_type& r1, const result_row_type& r2) mutable {
+        for (auto&& e : sorters) {
+            auto& c1 = r1[e.first];
+            auto& c2 = r2[e.first];
+            auto type = e.second;
+
+            if (bool(c1) != bool(c2)) {
+                return bool(c2);
+            }
+            if (c1) {
+                auto result = type->compare(*c1, *c2);
+                if (result != 0) {
+                    return result < 0;
+                }
+            }
+        }
+        return false;
+    };
+}
+
 void select_statement::validate_distinct_selection(const schema& schema,
                                                    const selection::selection& selection,
                                                    const restrictions::statement_restrictions& restrictions)
@@ -1528,107 +1684,6 @@ void select_statement::validate_distinct_selection(const schema& schema,
             throw exceptions::invalid_request_exception(format("SELECT DISTINCT queries must request all the partition key columns (missing {})", def.name_as_text()));
         }
     }
-}
-
-void select_statement::handle_unrecognized_ordering_column(const column_identifier& column) const
-{
-    if (contains_alias(column)) {
-        throw exceptions::invalid_request_exception(format("Aliases are not allowed in order by clause ('{}')", column));
-    }
-    throw exceptions::invalid_request_exception(format("Order by on unknown column {}", column));
-}
-
-select_statement::ordering_comparator_type
-select_statement::get_ordering_comparator(const schema& schema,
-                                          selection::selection& selection,
-                                          const restrictions::statement_restrictions& restrictions)
-{
-    if (!restrictions.key_is_in_relation()) {
-        return {};
-    }
-
-    std::vector<std::pair<uint32_t, data_type>> sorters;
-    sorters.reserve(_parameters->orderings().size());
-
-    // If we order post-query (see orderResults), the sorted column needs to be in the ResultSet for sorting,
-    // even if we don't
-    // ultimately ship them to the client (CASSANDRA-4911).
-    for (auto&& e : _parameters->orderings()) {
-        auto&& raw = e.first;
-        ::shared_ptr<column_identifier> column = raw->prepare_column_identifier(schema);
-        const column_definition* def = schema.get_column_definition(column->name());
-        if (!def) {
-            handle_unrecognized_ordering_column(*column);
-        }
-        auto index = selection.index_of(*def);
-        if (index < 0) {
-            index = selection.add_column_for_post_processing(*def);
-        }
-
-        sorters.emplace_back(index, def->type);
-    }
-
-    return [sorters = std::move(sorters)] (const result_row_type& r1, const result_row_type& r2) mutable {
-        for (auto&& e : sorters) {
-            auto& c1 = r1[e.first];
-            auto& c2 = r2[e.first];
-            auto type = e.second;
-
-            if (bool(c1) != bool(c2)) {
-                return bool(c2);
-            }
-            if (c1) {
-                auto result = type->compare(*c1, *c2);
-                if (result != 0) {
-                    return result < 0;
-                }
-            }
-        }
-        return false;
-    };
-}
-
-bool select_statement::is_reversed(const schema& schema) const {
-    assert(_parameters->orderings().size() > 0);
-    parameters::orderings_type::size_type i = 0;
-    bool is_reversed_ = false;
-    bool relation_order_unsupported = false;
-
-    for (auto&& e : _parameters->orderings()) {
-        ::shared_ptr<column_identifier> column = e.first->prepare_column_identifier(schema);
-        bool reversed = e.second;
-
-        auto def = schema.get_column_definition(column->name());
-        if (!def) {
-            handle_unrecognized_ordering_column(*column);
-        }
-
-        if (!def->is_clustering_key()) {
-            throw exceptions::invalid_request_exception(format("Order by is currently only supported on the clustered columns of the PRIMARY KEY, got {}", *column));
-        }
-
-        if (i != def->component_index()) {
-            throw exceptions::invalid_request_exception(
-                "Order by currently only support the ordering of columns following their declared order in the PRIMARY KEY");
-        }
-
-        bool current_reverse_status = (reversed != def->type->is_reversed());
-
-        if (i == 0) {
-            is_reversed_ = current_reverse_status;
-        }
-
-        if (is_reversed_ != current_reverse_status) {
-            relation_order_unsupported = true;
-        }
-        ++i;
-    }
-
-    if (relation_order_unsupported) {
-        throw exceptions::invalid_request_exception("Unsupported order by relation");
-    }
-
-    return is_reversed_;
 }
 
 /// True iff restrictions require ALLOW FILTERING despite there being no coordinator-side filtering.

--- a/test/cql-pytest/cassandra_tests/validation/operations/select_order_by_test.py
+++ b/test/cql-pytest/cassandra_tests/validation/operations/select_order_by_test.py
@@ -562,7 +562,6 @@ def testInOrderByWithTwoPartitionKeyColumns(cql, test_keyspace):
 
 # Test that ORDER BY columns allow skipping equality-restricted clustering columns, see CASSANDRA-10271.
 # Reproduces Scylla issue #2247.
-@pytest.mark.xfail(reason="Issue #2247")
 def testAllowSkippingEqualityAndSingleValueInRestrictedClusteringColumns(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a int, b int, c int, d int, PRIMARY KEY (a, b, c))") as table:
         execute(cql, table, "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)", 0, 0, 0, 0)
@@ -609,7 +608,10 @@ def testAllowSkippingEqualityAndSingleValueInRestrictedClusteringColumns(cql, te
                    [0, 0, 2, 2],
                    [0, 0, 1, 1])
 
-        errorMsg = "Order by currently only supports the ordering of columns following their declared order in the PRIMARY KEY"
+        # Minimal error message part that works both with Scylla and Cassandra
+        # Cassandra says: Order by currently only supports the ordering of columns following their declared order in the PRIMARY KEY
+        # Scylla says: Unsupported order by relation - column {} doesn't have an ordering or EQ relation.
+        errorMsg = "rder by"
 
         assert_invalid_message(cql, table, errorMsg, "SELECT * FROM %s WHERE a=? AND b<? ORDER BY c DESC", 0, 1)
 


### PR DESCRIPTION
In queries like:
```cql
SELECT * FROM t WHERE p = 0 AND c1 = 0 ORDER BY (c1 ASC, c2 ASC)
```
we can skip the requirement to specify ordering for `c1` column.

The `c1` column is restricted by an `EQ` restriction, so it can have
at most one value anyway, there is no need to sort.

This commit makes it possible to write just:
```cql
SELECT * FROM t WHERE p = 0 AND c1 = 0 ORDER BY (c2 ASC)
```

I reorganized the ordering code, I feel that it's now clearer and easier to understand.
It's possible to only introduce a small change to the existing code, but I feel like it becomes a bit too messy.
I tried it out on the [`orderby_disorder_small`](https://github.com/cvybhu/scylla/commits/orderby_disorder_small) branch.

The diff is a bit messy because I moved all ordering functions to one place,
it's better to read [select_statement.cc](https://github.com/cvybhu/scylla/blob/orderby_disorder/cql3/statements/select_statement.cc#L1495-L1658) lines 1495-1658 directly.

In the new code it would also be trivial to allow specifying columns in any order, we would just have to sort them.
For now I commented out the code needed to do that, because the point of this PR was to fix #2247.
Allowing this would require some more work changing the existing tests.

Fixes: #2247
