### PR TITLE
treewide: distinguish truncated frame errors

### DIFF
--- a/serialization_visitors.hh
+++ b/serialization_visitors.hh
@@ -89,7 +89,7 @@ template<typename Input>
 size_type read_frame_size(Input& in) {
     auto sz = deserialize(in, boost::type<size_type>());
     if (sz < sizeof(size_type)) {
-        throw std::runtime_error("Truncated frame");
+        throw std::runtime_error(fmt::format("IDL frame truncated: expected to have at least {} bytes, got {}", sizeof(size_type), sz));
     }
     return sz - sizeof(size_type);
 }

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -710,7 +710,7 @@ future<fragmented_temporary_buffer> cql_server::connection::read_and_decompress_
     if (flags & cql_frame_flags::compression) {
         if (_compression == cql_compression::lz4) {
             if (length < 4) {
-                throw std::runtime_error("Truncated frame");
+                throw std::runtime_error(fmt::format("CQL frame truncated: expected to have at least 4 bytes, got {}", length));
             }
             return _buffer_reader.read_exactly(_read_buf, length).then([this] (fragmented_temporary_buffer buf) {
                 auto linearization_buffer = bytes_ostream();


### PR DESCRIPTION
We have two identical "Truncated frame" errors, at:
* read_frame_size() in serialization_visitors.hh;
* cql_server::connection::read_and_decompress_frame() in
  transport/server.cc;

When such an exception is thrown, it is impossible to tell where was it
thrown from and it doesn't have any further information contained in it
(beyond the basic information it being thrown implies).
This patch solves both problems: it makes the exception messages unique
per location and it adds information about why it was thrown (the
expected vs. real size of the frame).

Ref: #9482