### PR TITLE
Allow empty partition keys in views

### DIFF
--- a/dht/murmur3_partitioner.cc
+++ b/dht/murmur3_partitioner.cc
@@ -41,7 +41,11 @@ token
 murmur3_partitioner::get_token(const schema& s, partition_key_view key) const {
     std::array<uint64_t, 2> hash;
     auto&& legacy = key.legacy_form(s);
-    utils::murmur_hash::hash3_x64_128(legacy.begin(), legacy.size(), 0, hash);
+    auto size = legacy.size();
+    if (size == 0) {
+        return minimum_token();
+    }
+    utils::murmur_hash::hash3_x64_128(legacy.begin(), size, 0, hash);
     return get_token(hash[0]);
 }
 

--- a/mutation_fragment_stream_validator.hh
+++ b/mutation_fragment_stream_validator.hh
@@ -27,7 +27,7 @@ class mutation_fragment_stream_validator {
     const ::schema& _schema;
     mutation_fragment_v2::kind _prev_kind;
     position_in_partition _prev_pos;
-    dht::decorated_key _prev_partition_key;
+    std::optional<dht::decorated_key> _prev_partition_key;
 public:
     explicit mutation_fragment_stream_validator(const schema& s);
 
@@ -127,13 +127,13 @@ public:
     /// Only valid if `operator()(const dht::decorated_key&)` or
     /// `operator()(dht::token)` was used.
     dht::token previous_token() const {
-        return _prev_partition_key.token();
+        return _prev_partition_key->token();
     }
     /// The previous valid partition key.
     ///
     /// Only valid if `operator()(const dht::decorated_key&)` was used.
     const dht::decorated_key& previous_partition_key() const {
-        return _prev_partition_key;
+        return *_prev_partition_key;
     }
 };
 

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -2341,9 +2341,6 @@ void sstable::set_first_and_last_keys() {
         return;
     }
     auto decorate_key = [this] (const char *m, const bytes& value) {
-        if (value.empty()) {
-            throw malformed_sstable_exception(format("{} key of summary of {} is empty", m, get_filename()));
-        }
         auto pk = key::from_bytes(value).to_partition_key(*_schema);
         return dht::decorate_key(*_schema, std::move(pk));
     };

--- a/test/boost/view_schema_pkey_test.cc
+++ b/test/boost/view_schema_pkey_test.cc
@@ -715,6 +715,12 @@ SEASTAR_TEST_CASE(test_base_non_pk_columns_in_view_partition_key_are_non_emtpy) 
                     });
         }
 
+        // The following if'ed-out tests verified behavior that we
+        // no longer believe to be correct, and also turns out not to be
+        // compatible with Cassandra (see issue #9375): these tests checked
+        // that if a view row should get an empty string as a partition key,
+        // this row should not be generated. But this is not the case.
+#if 0
         auto views_not_matching = {
                 "create materialized view {} as select * from cf "
                 "where p1 is not null and p2 is not null and c is not null and v is not null "
@@ -764,5 +770,6 @@ SEASTAR_TEST_CASE(test_base_non_pk_columns_in_view_partition_key_are_non_emtpy) 
             auto msg = e.execute_cql(format("select p1, p2, c, v from {}", name)).get0();
             assert_that(msg).is_rows().is_empty();
         });
+#endif
     });
 }

--- a/test/cql-pytest/test_secondary_index.py
+++ b/test/cql-pytest/test_secondary_index.py
@@ -276,7 +276,6 @@ def test_multi_column_with_regular_index(cql, test_keyspace):
 # wrong or unusual about an empty string, and it should be supported just
 # like any other string.
 # Reproduces issue #9364
-@pytest.mark.xfail(reason="issue #9364")
 def test_index_empty_string(cql, test_keyspace):
     schema = 'p int, v text, primary key (p)'
     # Searching for v='' without an index (with ALLOW FILTERING), works


### PR DESCRIPTION
Although Cassandra generally does not allow empty strings as partition
keys (they are allowed as clustering keys!), it *does* allow empty strings
in regular columns to be indexed by a secondary index, or to become an
empty partition-key column in a materialized view. As noted in issues #9375
and #9364 and verified in a few xfailing cql-pytest tests, Scylla didn't
allow these cases - and this two-patch series fixes that.

The first patch fixes #9352 - an inconsistency in our tokenizer which
resulted in Scylla not being able to look up an empty key in the
sstable's index. Then, the second patch fixes the materialized views
implementation to not drop view rows with an empty-string partition key.
The fix for secondary index bug comes "for free" because it is based
on materialized views.

We already had xfailing test cases for empty strings in materialized
views and indexes, and after this series they begin to pass so the
"xfail" mark is removed. The series also adds additional test cases
that validate additional corner cases discovered during the debugging.

Fixes #9352
Fixes #9364
Fixes #9375