### PR TITLE
time_window_compaction_strategy: put expired sstables in a separate c…

### DIFF
--- a/compaction/time_window_compaction_strategy.cc
+++ b/compaction/time_window_compaction_strategy.cc
@@ -220,14 +220,11 @@ time_window_compaction_strategy::get_sstables_for_compaction(column_family& cf, 
     }
 
     if (!expired.empty()) {
-        auto is_expired = [&] (const shared_sstable& s) { return expired.contains(s); };
-        candidates.erase(boost::remove_if(candidates, is_expired), candidates.end());
+        clogger.debug("Going to compact {} expired sstables", expired.size());
+        return compaction_descriptor(has_only_fully_expired::yes, std::vector<shared_sstable>(expired.begin(), expired.end()), cf.get_sstable_set(), service::get_local_compaction_priority());
     }
 
     auto compaction_candidates = get_next_non_expired_sstables(cf, std::move(candidates), gc_before);
-    if (!expired.empty()) {
-        compaction_candidates.insert(compaction_candidates.end(), expired.begin(), expired.end());
-    }
     return compaction_descriptor(std::move(compaction_candidates), cf.get_sstable_set(), service::get_local_compaction_priority());
 }
 


### PR DESCRIPTION
compaction task

It's much more efficient to have a separate compaction task that consists
completely from expired sstables and make sure it gets a unique "weight" than
mixing expired sstables with non-expired sstables adding an unpredictable
latency to an eviction event of an expired sstable.

This change also improves the visibility of eviction events because now
they are always going to appear in the log as compactions that compact into
an empty set:

```
INFO  2021-10-27 22:34:31,602 [shard 0] compaction - [Compact keyspace1.standard1 94b238a0-3797-11ec-9096-d42e99f5c250] Compacted 10 sstables to []. 2GB to 0 bytes (~0% of original) in 1ms = 0 bytes/s. ~8409216 total partitions merged to 0.
```

Fixes #9533
