### PR TITLE
alternator: decouple auth from CQL query processor

### DIFF
--- a/alternator/auth.hh
+++ b/alternator/auth.hh
@@ -27,8 +27,8 @@
 #include "gc_clock.hh"
 #include "utils/loading_cache.hh"
 
-namespace cql3 {
-class query_processor;
+namespace service {
+class storage_proxy;
 }
 
 namespace alternator {
@@ -41,6 +41,6 @@ std::string get_signature(std::string_view access_key_id, std::string_view secre
         std::string_view orig_datestamp, std::string_view signed_headers_str, const std::map<std::string_view, std::string_view>& signed_headers_map,
         const std::vector<temporary_buffer<char>>& body_content, std::string_view region, std::string_view service, std::string_view query_string);
 
-future<std::string> get_key_from_roles(cql3::query_processor& qp, std::string username);
+future<std::string> get_key_from_roles(service::storage_proxy& proxy, std::string username);
 
 }

--- a/alternator/controller.cc
+++ b/alternator/controller.cc
@@ -40,7 +40,6 @@ controller::controller(
         sharded<service::migration_manager>& mm,
         sharded<db::system_distributed_keyspace>& sys_dist_ks,
         sharded<cdc::generation_service>& cdc_gen_svc,
-        sharded<cql3::query_processor>& qp,
         sharded<service::memory_limiter>& memory_limiter,
         const db::config& config)
     : _gossiper(gossiper)
@@ -48,7 +47,6 @@ controller::controller(
     , _mm(mm)
     , _sys_dist_ks(sys_dist_ks)
     , _cdc_gen_svc(cdc_gen_svc)
-    , _qp(qp)
     , _memory_limiter(memory_limiter)
     , _config(config)
 {
@@ -79,7 +77,7 @@ future<> controller::start() {
         auto get_cdc_metadata = [] (cdc::generation_service& svc) { return std::ref(svc.get_cdc_metadata()); };
 
         _executor.start(std::ref(_gossiper), std::ref(_proxy), std::ref(_mm), std::ref(_sys_dist_ks), sharded_parameter(get_cdc_metadata, std::ref(_cdc_gen_svc)), _ssg.value()).get();
-        _server.start(std::ref(_executor), std::ref(_qp), std::ref(_proxy), std::ref(_gossiper)).get();
+        _server.start(std::ref(_executor), std::ref(_proxy), std::ref(_gossiper)).get();
         std::optional<uint16_t> alternator_port;
         if (_config.alternator_port()) {
             alternator_port = _config.alternator_port();

--- a/alternator/controller.hh
+++ b/alternator/controller.hh
@@ -39,10 +39,6 @@ namespace cdc {
 class generation_service;
 }
 
-namespace cql3 {
-class query_processor;
-}
-
 namespace gms {
 
 class gossiper;
@@ -62,7 +58,6 @@ class controller {
     sharded<service::migration_manager>& _mm;
     sharded<db::system_distributed_keyspace>& _sys_dist_ks;
     sharded<cdc::generation_service>& _cdc_gen_svc;
-    sharded<cql3::query_processor>& _qp;
     sharded<service::memory_limiter>& _memory_limiter;
     const db::config& _config;
 
@@ -77,7 +72,6 @@ public:
         sharded<service::migration_manager>& mm,
         sharded<db::system_distributed_keyspace>& sys_dist_ks,
         sharded<cdc::generation_service>& cdc_gen_svc,
-        sharded<cql3::query_processor>& qp,
         sharded<service::memory_limiter>& memory_limiter,
         const db::config& config);
 

--- a/alternator/server.hh
+++ b/alternator/server.hh
@@ -45,7 +45,6 @@ class server {
     http_server _http_server;
     http_server _https_server;
     executor& _executor;
-    cql3::query_processor& _qp;
     service::storage_proxy& _proxy;
     gms::gossiper& _gossiper;
 
@@ -79,7 +78,7 @@ class server {
     json_parser _json_parser;
 
 public:
-    server(executor& executor, cql3::query_processor& qp, service::storage_proxy& proxy, gms::gossiper& gossiper);
+    server(executor& executor, service::storage_proxy& proxy, gms::gossiper& gossiper);
 
     future<> init(net::inet_address addr, std::optional<uint16_t> port, std::optional<uint16_t> https_port, std::optional<tls::credentials_builder> creds,
             bool enforce_authorization, semaphore* memory_limiter, utils::updateable_value<uint32_t> max_concurrent_requests);

--- a/main.cc
+++ b/main.cc
@@ -1368,7 +1368,7 @@ int main(int ac, char** av) {
                 api::unset_rpc_controller(ctx).get();
             });
 
-            alternator::controller alternator_ctl(gossiper, proxy, mm, sys_dist_ks, cdc_generation_service, qp, service_memory_limiter, *cfg);
+            alternator::controller alternator_ctl(gossiper, proxy, mm, sys_dist_ks, cdc_generation_service, service_memory_limiter, *cfg);
 
             if (cfg->alternator_port() || cfg->alternator_https_port()) {
                 with_scheduling_group(dbcfg.statement_scheduling_group, [&alternator_ctl] () mutable {


### PR DESCRIPTION
Alternator auth module used to piggy-back on top of CQL query processor
to retrieve authentication data, but it's no longer the case.
Instead, storage proxy is used directly.

Tests: unit(release)