### PR TITLE
snapshots: Fix snapshot-ctl to include snapshots of dropped tables

### DIFF
--- a/database.hh
+++ b/database.hh
@@ -49,6 +49,7 @@
 #include <limits>
 #include "schema_fwd.hh"
 #include "db/view/view.hh"
+#include "db/snapshot-ctl.hh"
 #include "gms/feature.hh"
 #include "memtable.hh"
 #include "mutation_reader.hh"
@@ -1570,7 +1571,15 @@ public:
      *                  will be deleted.
      * table_name - A name of a specific table inside the keyspace, if empty all tables will be deleted.
      */
-    future<> clear_snapshot(sstring tag, std::vector<sstring> keyspace_names, const sstring& table_name);
+    future<> clear_snapshot(sstring tag, std::vector<sstring> keyspace_names, const sstring& table_name); 
+
+    struct snapshot_details_result {
+        sstring snapshot_name;
+        db::snapshot_ctl::snapshot_details details;
+        bool operator==(const snapshot_details_result&) const = default;
+    };
+
+    future<std::vector<snapshot_details_result>> get_snapshot_details();
 
     friend std::ostream& operator<<(std::ostream& out, const database& db);
     const flat_hash_map<sstring, keyspace>& get_keyspaces() const {

--- a/db/snapshot-ctl.hh
+++ b/db/snapshot-ctl.hh
@@ -61,6 +61,8 @@ public:
         int64_t total;
         sstring cf;
         sstring ks;
+
+        bool operator==(const snapshot_details&) const = default;
     };
     explicit snapshot_ctl(sharded<database>& db) : _db(db) {}
 


### PR DESCRIPTION
Snapshot-ctl methods fetch information about snapshots from column family objects. The problem with this is that we get rid
of these objects once the table gets dropped, while the snapshots might still be present (the auto_snapshot option is specifically made to create this kind of situation). This commit switches from relying on column family interface to scanning every datadir that the database knows of in search for "snapshots" folders.

This PR is rebased onto bhalevy@2804fc4 in order to use `sstables::snapshots_dir` introduced by @bhalevy 

Fixes #3463
Closes #7122