### PR TITLE
treewide: replace seastar::fmt_print() with fmt::print()

### DIFF
--- a/atomic_cell.cc
+++ b/atomic_cell.cc
@@ -137,7 +137,7 @@ size_t atomic_cell_or_collection::external_memory_usage(const abstract_type& t) 
 std::ostream&
 operator<<(std::ostream& os, const atomic_cell_view& acv) {
     if (acv.is_live()) {
-        return fmt_print(os, "atomic_cell{{{},ts={:d},expiry={:d},ttl={:d}}}",
+        fmt::print(os, "atomic_cell{{{},ts={:d},expiry={:d},ttl={:d}}}",
             acv.is_counter_update()
                     ? "counter_update_value=" + to_sstring(acv.counter_update_value())
                     : to_hex(to_bytes(acv.value())),
@@ -145,9 +145,10 @@ operator<<(std::ostream& os, const atomic_cell_view& acv) {
             acv.is_live_and_has_ttl() ? acv.expiry().time_since_epoch().count() : -1,
             acv.is_live_and_has_ttl() ? acv.ttl().count() : 0);
     } else {
-        return fmt_print(os, "atomic_cell{{DEAD,ts={:d},deletion_time={:d}}}",
+        fmt::print(os, "atomic_cell{{DEAD,ts={:d},deletion_time={:d}}}",
             acv.timestamp(), acv.deletion_time().time_since_epoch().count());
     }
+    return os;
 }
 
 std::ostream&
@@ -172,15 +173,16 @@ operator<<(std::ostream& os, const atomic_cell_view::printer& acvp) {
         } else {
             cell_value_string_builder << type.to_string(to_bytes(acv.value()));
         }
-        return fmt_print(os, "atomic_cell{{{},ts={:d},expiry={:d},ttl={:d}}}",
+        fmt::print(os, "atomic_cell{{{},ts={:d},expiry={:d},ttl={:d}}}",
             cell_value_string_builder.str(),
             acv.timestamp(),
             acv.is_live_and_has_ttl() ? acv.expiry().time_since_epoch().count() : -1,
             acv.is_live_and_has_ttl() ? acv.ttl().count() : 0);
     } else {
-        return fmt_print(os, "atomic_cell{{DEAD,ts={:d},deletion_time={:d}}}",
+        fmt::print(os, "atomic_cell{{DEAD,ts={:d},deletion_time={:d}}}",
             acv.timestamp(), acv.deletion_time().time_since_epoch().count());
     }
+    return os;
 }
 
 std::ostream&

--- a/database.cc
+++ b/database.cc
@@ -1607,7 +1607,8 @@ future<reader_permit> database::obtain_reader_permit(schema_ptr schema, const ch
 }
 
 std::ostream& operator<<(std::ostream& out, const column_family& cf) {
-    return fmt_print(out, "{{column_family: {}/{}}}", cf._schema->ks_name(), cf._schema->cf_name());
+    fmt::print(out, "{{column_family: {}/{}}}", cf._schema->ks_name(), cf._schema->cf_name());
+    return out;
 }
 
 std::ostream& operator<<(std::ostream& out, const database& db) {
@@ -2006,7 +2007,8 @@ std::ostream&
 operator<<(std::ostream& os, const exploded_clustering_prefix& ecp) {
     // Can't pass to_hex() to transformed(), since it is overloaded, so wrap:
     auto enhex = [] (auto&& x) { return to_hex(x); };
-    return fmt_print(os, "prefix{{{}}}", ::join(":", ecp._v | boost::adaptors::transformed(enhex)));
+    fmt::print(os, "prefix{{{}}}", ::join(":", ecp._v | boost::adaptors::transformed(enhex)));
+    return os;
 }
 
 sstring database::get_available_index_name(const sstring &ks_name, const sstring &cf_name,

--- a/mutation.cc
+++ b/mutation.cc
@@ -209,7 +209,7 @@ std::ostream& operator<<(std::ostream& os, const mutation& m) {
     const ::schema& s = *m.schema();
     const auto& dk = m.decorated_key();
 
-    fmt_print(os, "{{table: '{}.{}', key: {{", s.ks_name(), s.cf_name());
+    fmt::print(os, "{{table: '{}.{}', key: {{", s.ks_name(), s.cf_name());
 
     auto type_iterator = dk._key.get_compound_type(s)->types().begin();
     auto column_iterator = s.partition_key_columns().begin();
@@ -220,7 +220,7 @@ std::ostream& operator<<(std::ostream& os, const mutation& m) {
         ++column_iterator;
     }
 
-    fmt_print(os, "token: {}}}, ", dk._token);
+    fmt::print(os, "token: {}}}, ", dk._token);
     os << mutation_partition::printer(s, m.partition()) << "\n}";
     return os;
 }

--- a/mutation_partition.cc
+++ b/mutation_partition.cc
@@ -905,7 +905,8 @@ bool has_any_live_data(const schema& s, column_kind kind, const row& cells, tomb
 
 std::ostream&
 operator<<(std::ostream& os, const std::pair<column_id, const atomic_cell_or_collection::printer&>& c) {
-    return fmt_print(os, "{{column: {} {}}}", c.first, c.second);
+    fmt::print(os, "{{column: {} {}}}", c.first, c.second);
+    return os;
 }
 
 // Transforms given range of printable into a range of strings where each element
@@ -931,13 +932,14 @@ operator<<(std::ostream& os, const row::printer& p) {
 std::ostream&
 operator<<(std::ostream& os, const row_marker& rm) {
     if (rm.is_missing()) {
-        return fmt_print(os, "{{row_marker: }}");
+        fmt::print(os, "{{row_marker: }}");
     } else if (rm._ttl == row_marker::dead) {
-        return fmt_print(os, "{{row_marker: dead {} {}}}", rm._timestamp, rm._expiry.time_since_epoch().count());
+        fmt::print(os, "{{row_marker: dead {} {}}}", rm._timestamp, rm._expiry.time_since_epoch().count());
     } else {
-        return fmt_print(os, "{{row_marker: {} {} {}}}", rm._timestamp, rm._ttl.count(),
+        fmt::print(os, "{{row_marker: {} {} {}}}", rm._timestamp, rm._ttl.count(),
             rm._ttl != row_marker::no_ttl ? rm._expiry.time_since_epoch().count() : 0);
     }
+    return os;
 }
 
 std::ostream&
@@ -956,9 +958,10 @@ operator<<(std::ostream& os, const deletable_row::printer& p) {
 std::ostream&
 operator<<(std::ostream& os, const rows_entry::printer& p) {
     auto& re = p._rows_entry;
-    return fmt_print(os, "{{rows_entry: cont={} dummy={} {} {}}}", re.continuous(), re.dummy(),
+    fmt::print(os, "{{rows_entry: cont={} dummy={} {} {}}}", re.continuous(), re.dummy(),
                   position_in_partition_view::printer(p._schema, re.position()),
                   deletable_row::printer(p._schema, re._row));
+    return os;
 }
 
 std::ostream&

--- a/transport/messages/result_message.cc
+++ b/transport/messages/result_message.cc
@@ -26,28 +26,34 @@
 namespace cql_transport::messages {
 
 std::ostream& operator<<(std::ostream& os, const result_message::void_message& msg) {
-    return fmt_print(os, "{{result_message::void}}");
+    fmt::print(os, "{{result_message::void}}");
+    return os;
 }
 
 std::ostream& operator<<(std::ostream& os, const result_message::bounce_to_shard& msg) {
-    return fmt_print(os, "{{result_message::bounce_to_shard {}}}", msg.move_to_shard());
+    fmt::print(os, "{{result_message::bounce_to_shard {}}}", msg.move_to_shard());
+    return os;
 }
 
 std::ostream& operator<<(std::ostream& os, const result_message::set_keyspace& msg) {
-    return fmt_print(os, "{{result_message::set_keyspace {}}}", msg.get_keyspace());
+    fmt::print(os, "{{result_message::set_keyspace {}}}", msg.get_keyspace());
+    return os;
 }
 
 std::ostream& operator<<(std::ostream& os, const result_message::prepared::thrift& msg) {
-    return fmt_print(os, "{{result_message::prepared::thrift {:d}}}", msg.get_id());
+    fmt::print(os, "{{result_message::prepared::thrift {:d}}}", msg.get_id());
+    return os;
 }
 
 std::ostream& operator<<(std::ostream& os, const result_message::prepared::cql& msg) {
-    return fmt_print(os, "{{result_message::prepared::cql {}}}", to_hex(msg.get_id()));
+    fmt::print(os, "{{result_message::prepared::cql {}}}", to_hex(msg.get_id()));
+    return os;
 }
 
 std::ostream& operator<<(std::ostream& os, const result_message::schema_change& msg) {
     // FIXME: format contents
-    return fmt_print(os, "{{result_message::prepared::schema_change {:p}}}", (void*)msg.get_change().get());
+    fmt::print(os, "{{result_message::prepared::schema_change {:p}}}", (void*)msg.get_change().get());
+    return os;
 }
 
 std::ostream& operator<<(std::ostream& os, const result_message::rows& msg) {


### PR DESCRIPTION
We shouldn't be using Seastar as a text formatting library; that's
not its focus. Use fmt directly instead. fmt::print() doesn't return
the output stream which is a minor inconvenience, but that's life.