### PR TITLE
compaction/scrub: segregate input only in segregate mode

### DIFF
--- a/compaction/compaction.cc
+++ b/compaction/compaction.cc
@@ -1431,6 +1431,9 @@ public:
     }
 
     reader_consumer make_interposer_consumer(reader_consumer end_consumer) override {
+        if (!use_interposer_consumer()) {
+            return end_consumer;
+        }
         return [this, end_consumer = std::move(end_consumer)] (flat_mutation_reader reader) mutable -> future<> {
             return mutation_writer::segregate_by_partition(std::move(reader), 100, [consumer = std::move(end_consumer), this] (flat_mutation_reader rd) {
                 ++_bucket_count;


### PR DESCRIPTION
scrub_compaction assumes that `make_interposer_consumer()` is called
only when `use_interposer_consumer()` returns true. This is false, so in
effect scrub always ends up using the segregating interposer. Fix this
by short-circuiting the former method when the latter returns true,
returning the passed-in consumer unchanged.

Tests: unit(dev)

Fix: #9541