### PR TITLE
Memtable reversing reader: fix computing rt slice, if there was previously emitted range tombstone.

### DIFF
--- a/partition_snapshot_reader.hh
+++ b/partition_snapshot_reader.hh
@@ -470,18 +470,17 @@ public:
     }
 
     virtual future<> fill_buffer() override {
-      // FIXME: indentation
-      return do_until([this] { return is_end_of_stream() || is_buffer_full(); }, [this] {
-        _reader.with_reserve([&] {
-            if (!_static_row_done) {
-                push_static_row();
-                on_new_range();
-                _static_row_done = true;
-            }
-            do_fill_buffer();
+        return do_until([this] { return is_end_of_stream() || is_buffer_full(); }, [this] {
+            _reader.with_reserve([&] {
+                if (!_static_row_done) {
+                    push_static_row();
+                    on_new_range();
+                    _static_row_done = true;
+                }
+                do_fill_buffer();
+            });
+            return make_ready_future<>();
         });
-        return make_ready_future<>();
-      });
     }
     virtual future<> next_partition() override {
         clear_buffer_to_next_partition();

--- a/range_tombstone_list.cc
+++ b/range_tombstone_list.cc
@@ -306,59 +306,51 @@ range_tombstone_list::reverter range_tombstone_list::apply_reversibly(const sche
     return rev;
 }
 
+namespace {
+struct bv_order_by_end {
+    bound_view::compare less;
+    bv_order_by_end(const schema& s) : less(s) {}
+    bool operator()(bound_view v, const range_tombstone_entry& rt) const { return less(v, rt.end_bound()); }
+    bool operator()(const range_tombstone_entry& rt, bound_view v) const { return less(rt.end_bound(), v); }
+};
+struct bv_order_by_start {
+    bound_view::compare less;
+    bv_order_by_start(const schema& s) : less(s) {}
+    bool operator()(bound_view v, const range_tombstone_entry& rt) const { return less(v, rt.start_bound()); }
+    bool operator()(const range_tombstone_entry& rt, bound_view v) const { return less(rt.start_bound(), v); }
+};
+
+struct pos_order_by_end {
+    position_in_partition::less_compare less;
+    pos_order_by_end(const schema& s) : less(s) {}
+    bool operator()(position_in_partition_view v, const range_tombstone_entry& rt) const { return less(v, rt.end_position()); }
+    bool operator()(const range_tombstone_entry& rt, position_in_partition_view v) const { return less(rt.end_position(), v); }
+};
+struct pos_order_by_start {
+    position_in_partition::less_compare less;
+    pos_order_by_start(const schema& s) : less(s) {}
+    bool operator()(position_in_partition_view v, const range_tombstone_entry& rt) const { return less(v, rt.position()); }
+    bool operator()(const range_tombstone_entry& rt, position_in_partition_view v) const { return less(rt.position(), v); }
+};
+} // namespace
+
 range_tombstone_list::iterator_range
 range_tombstone_list::slice(const schema& s, const query::clustering_range& r) const {
     auto bv_range = bound_view::from_range(r);
-    struct order_by_end {
-        bound_view::compare less;
-        order_by_end(const schema& s) : less(s) {}
-        bool operator()(bound_view v, const range_tombstone_entry& rt) const { return less(v, rt.end_bound()); }
-        bool operator()(const range_tombstone_entry& rt, bound_view v) const { return less(rt.end_bound(), v); }
-    };
-    struct order_by_start {
-        bound_view::compare less;
-        order_by_start(const schema& s) : less(s) {}
-        bool operator()(bound_view v, const range_tombstone_entry& rt) const { return less(v, rt.start_bound()); }
-        bool operator()(const range_tombstone_entry& rt, bound_view v) const { return less(rt.start_bound(), v); }
-    };
     return boost::make_iterator_range(
-        _tombstones.lower_bound(bv_range.first, order_by_end{s}),
-        _tombstones.upper_bound(bv_range.second, order_by_start{s}));
+        _tombstones.lower_bound(bv_range.first, bv_order_by_end{s}),
+        _tombstones.upper_bound(bv_range.second, bv_order_by_start{s}));
 }
 
 range_tombstone_list::iterator_range
 range_tombstone_list::slice(const schema& s, position_in_partition_view start, position_in_partition_view end) const {
-    struct order_by_end {
-        position_in_partition::less_compare less;
-        order_by_end(const schema& s) : less(s) {}
-        bool operator()(position_in_partition_view v, const range_tombstone_entry& rt) const { return less(v, rt.end_position()); }
-        bool operator()(const range_tombstone_entry& rt, position_in_partition_view v) const { return less(rt.end_position(), v); }
-    };
-    struct order_by_start {
-        position_in_partition::less_compare less;
-        order_by_start(const schema& s) : less(s) {}
-        bool operator()(position_in_partition_view v, const range_tombstone_entry& rt) const { return less(v, rt.position()); }
-        bool operator()(const range_tombstone_entry& rt, position_in_partition_view v) const { return less(rt.position(), v); }
-    };
     return boost::make_iterator_range(
-        _tombstones.upper_bound(start, order_by_end{s}), // end_position() is exclusive, hence upper_bound()
-        _tombstones.lower_bound(end, order_by_start{s}));
+        _tombstones.upper_bound(start, pos_order_by_end{s}), // end_position() is exclusive, hence upper_bound()
+        _tombstones.lower_bound(end, pos_order_by_start{s}));
 }
 
 range_tombstone_list::iterator_range
 range_tombstone_list::lower_slice(const schema& s, bound_view start, position_in_partition_view before) const {
-    struct bv_order_by_end {
-        bound_view::compare less;
-        bv_order_by_end(const schema& s) : less(s) {}
-        bool operator()(bound_view v, const range_tombstone_entry& rt) const { return less(v, rt.end_bound()); }
-        bool operator()(const range_tombstone_entry& rt, bound_view v) const { return less(rt.end_bound(), v); }
-    };
-    struct pos_order_by_end {
-        position_in_partition::less_compare less;
-        pos_order_by_end(const schema& s) : less(s) {}
-        bool operator()(position_in_partition_view v, const range_tombstone_entry& rt) const { return less(v, rt.end_position()); }
-        bool operator()(const range_tombstone_entry& rt, position_in_partition_view v) const { return less(rt.end_position(), v); }
-    };
     return boost::make_iterator_range(
         _tombstones.lower_bound(start, bv_order_by_end{s}),
         _tombstones.lower_bound(before, pos_order_by_end{s}));
@@ -366,18 +358,6 @@ range_tombstone_list::lower_slice(const schema& s, bound_view start, position_in
 
 range_tombstone_list::iterator_range
 range_tombstone_list::upper_slice(const schema& s, position_in_partition_view after, bound_view end) const {
-    struct pos_order_by_start {
-        position_in_partition::less_compare less;
-        pos_order_by_start(const schema& s) : less(s) {}
-        bool operator()(position_in_partition_view v, const range_tombstone_entry& rt) const { return less(v, rt.position()); }
-        bool operator()(const range_tombstone_entry& rt, position_in_partition_view v) const { return less(rt.position(), v); }
-    };
-    struct bv_order_by_start {
-        bound_view::compare less;
-        bv_order_by_start(const schema& s) : less(s) {}
-        bool operator()(bound_view v, const range_tombstone_entry& rt) const { return less(v, rt.start_bound()); }
-        bool operator()(const range_tombstone_entry& rt, bound_view v) const { return less(rt.start_bound(), v); }
-    };
     return boost::make_iterator_range(
         _tombstones.upper_bound(after, pos_order_by_start{s}),
         _tombstones.upper_bound(end, bv_order_by_start{s}));

--- a/range_tombstone_list.hh
+++ b/range_tombstone_list.hh
@@ -230,11 +230,16 @@ public:
     tombstone search_tombstone_covering(const schema& s, const clustering_key_prefix& key) const;
 
     using iterator_range = boost::iterator_range<const_iterator>;
-    // Returns range of tombstones which overlap with given range
+    // Returns range tombstones which overlap with given range
     iterator_range slice(const schema& s, const query::clustering_range&) const;
     // Returns range tombstones which overlap with [start, end)
     iterator_range slice(const schema& s, position_in_partition_view start, position_in_partition_view end) const;
-    iterator_range upper_slice(const schema& s, position_in_partition_view start, bound_view end) const;
+
+    // Returns range tombstones with ends inside [start, before).
+    iterator_range lower_slice(const schema& s, bound_view start, position_in_partition_view before) const;
+    // Returns range tombstones with starts inside (after, end].
+    iterator_range upper_slice(const schema& s, position_in_partition_view after, bound_view end) const;
+
     iterator erase(const_iterator, const_iterator);
 
     // Pops the first element and bans (in theory) further additions

--- a/utils/immutable-collection.hh
+++ b/utils/immutable-collection.hh
@@ -64,6 +64,7 @@ public:
     WRAP_METHOD(lower_bound)
     WRAP_METHOD(upper_bound)
     WRAP_METHOD(slice)
+    WRAP_METHOD(lower_slice)
     WRAP_METHOD(upper_slice)
 
     WRAP_CONST_METHOD(empty)


### PR DESCRIPTION
This PR started by realizing that in the memtable reversing reader, it never happened on tests that `do_refresh_state` was called with `last_row` and `last_rts` which are not `std::nullopt`. 

Changes
- fix memtable test (`tesst_memtable_with_many_versions_conforms_to_mutation_source`), so that there is a background job forcing state refreshes,
- fix the way rt_slice is computed (was `(last_rts, cr_range_snapshot.end]`, now is `[cr_range_snapshot.start, last_rts)`). 

Fixes #9486