### PR TITLE
alternator: add support for AttributeUpdates Add operation

### DIFF
--- a/alternator/serialization.cc
+++ b/alternator/serialization.cc
@@ -373,4 +373,23 @@ std::optional<rjson::value> set_diff(const rjson::value& v1, const rjson::value&
     return ret;
 }
 
+// Take two JSON-encoded list values (remember that a list value is
+// {"L": [...the actual list]}) and return the concatenation, again as
+// a list value.
+// Returns a null value if one of the arguments is not actually a list.
+rjson::value list_concatenate(const rjson::value& v1, const rjson::value& v2) {
+    const rjson::value* list1 = unwrap_list(v1);
+    const rjson::value* list2 = unwrap_list(v2);
+    if (!list1 || !list2) {
+        return rjson::null_value();
+    }
+    rjson::value cat = rjson::copy(*list1);
+    for (const auto& a : list2->GetArray()) {
+        rjson::push_back(cat, rjson::copy(a));
+    }
+    rjson::value ret = rjson::empty_object();
+    rjson::set(ret, "L", std::move(cat));
+    return ret;
+}
+
 }

--- a/alternator/serialization.hh
+++ b/alternator/serialization.hh
@@ -85,5 +85,11 @@ rjson::value set_sum(const rjson::value& v1, const rjson::value& v2);
 // DynamoDB does not allow empty sets, so if resulting set is empty, return
 // an unset optional instead.
 std::optional<rjson::value> set_diff(const rjson::value& v1, const rjson::value& v2);
+// Take two JSON-encoded list values (remember that a list value is
+// {"L": [...the actual list]}) and return the concatenation, again as
+// a list value.
+// Returns a null value if one of the arguments is not actually a list.
+rjson::value list_concatenate(const rjson::value& v1, const rjson::value& v2);
+
 
 }

--- a/test/alternator/test_item.py
+++ b/test/alternator/test_item.py
@@ -514,8 +514,8 @@ def test_update_item_delete(test_table_s):
     assert not 'Item' in test_table_s.get_item(Key={'p': p}, ConsistentRead=True)
 
 # Test for UpdateItem's AttributeUpdate's ADD operation, which has different
-# meanings for numbers and sets - but not for other types.
-@pytest.mark.xfail(reason="UpdateItem AttributeUpdates ADD not implemented")
+# meanings for numbers and sets (and as it turns out, also for lists) - but
+# not for other types.
 def test_update_item_add(test_table_s):
     p = random_string()
 


### PR DESCRIPTION
In UpdateItem's AttributeUpdates (old-style parameter) we were missing
support for the ADD operation - which can increment a number, or add
items to sets (or to lists, even though this fact isn't documented).

This two-patch series add this missing feature. The first patch just moves
an existing function to where we can reuse it, and the second patch is
the actual implementation of the feature (and enabling its test).
    
Fixes #5893