### PR TITLE
system keyspace: introduce "large_row_counts"

### DIFF
--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -564,7 +564,10 @@ schema_ptr system_keyspace::size_estimates() {
             {"partition_key", utf8_type}
         }, // CLUSTERING ORDER BY (partition_size DESC)
         // regular columns
-        {{"compaction_time", timestamp_type}},
+        {
+            {"rows", long_type},
+            {"compaction_time", timestamp_type}
+        },
         // static columns
         {},
         // regular column name type

--- a/docs/design-notes/system_keyspace.md
+++ b/docs/design-notes/system_keyspace.md
@@ -6,11 +6,12 @@ This section describes layouts and usage of system.* tables.
 
 Scylla performs better if partitions, rows, or cells are not too
 large. To help diagnose cases where these grow too large, scylla keeps
-3 tables that record large partitions, rows, and cells, respectively.
+3 tables that record large partitions (including those with too many
+rows), rows, and cells, respectively.
 
 The meaning of an entry in each of these tables is similar. It means
-that there is a particular sstable with a large partition, row, or
-cell. In particular, this implies that:
+that there is a particular sstable with a large partition, row, cell,
+or a partition with too many rows. In particular, this implies that:
 
 * There is no entry until compaction aggregates enough data in a
   single sstable.
@@ -20,7 +21,8 @@ In addition, the entries also have a TTL of 30 days.
 
 ## system.large\_partitions
 
-Large partition table can be used to trace largest partitions in a cluster.
+Large partition table can be used to trace largest partitions in a
+cluster.  Partitions with too many rows are also recorded there.
 
 Schema:
 ~~~
@@ -30,6 +32,7 @@ CREATE TABLE system.large_partitions (
     sstable_name text,
     partition_size bigint,
     partition_key text,
+    rows bigint,
     compaction_time timestamp,
     PRIMARY KEY ((keyspace_name, table_name), sstable_name, partition_size, partition_key)
 ) WITH CLUSTERING ORDER BY (sstable_name ASC, partition_size DESC, partition_key ASC);

--- a/test/boost/cql_query_large_test.cc
+++ b/test/boost/cql_query_large_test.cc
@@ -52,6 +52,12 @@ SEASTAR_TEST_CASE(test_large_partitions) {
     return do_with_cql_env([](cql_test_env& e) { return make_ready_future<>(); }, cfg);
 }
 
+SEASTAR_TEST_CASE(test_large_row_count) {
+    auto cfg = make_shared<db::config>();
+    cfg->compaction_rows_count_warning_threshold(0);
+    return do_with_cql_env([](cql_test_env& e) { return make_ready_future<>(); }, cfg);
+}
+
 static void flush(cql_test_env& e) {
     e.db().invoke_on_all([](database& dbi) {
         return dbi.flush_all_memtables();

--- a/test/boost/sstable_3_x_test.cc
+++ b/test/boost/sstable_3_x_test.cc
@@ -5151,13 +5151,6 @@ struct large_row_handler : public db::large_data_handler {
         start();
     }
 
-    virtual void log_too_many_rows(const sstables::sstable& sst, const sstables::key& partition_key,
-            uint64_t rows_count) const override {
-        const schema_ptr s = sst.get_schema();
-        callback(*s, partition_key, nullptr, rows_count);
-        return;
-    }
-
     virtual future<> record_large_rows(const sstables::sstable& sst, const sstables::key& partition_key,
             const clustering_key_prefix* clustering_key, uint64_t row_size) const override {
         const schema_ptr s = sst.get_schema();
@@ -5171,7 +5164,9 @@ struct large_row_handler : public db::large_data_handler {
     }
 
     virtual future<> record_large_partitions(const sstables::sstable& sst,
-            const sstables::key& partition_key, uint64_t partition_size) const override {
+        const sstables::key& partition_key, uint64_t partition_size, uint64_t rows_count) const override {
+        const schema_ptr s = sst.get_schema();
+        callback(*s, partition_key, nullptr, rows_count);
         return make_ready_future<>();
     }
 


### PR DESCRIPTION
This table records partitions with over-threshold number of rows.

Fixes #9506

Signed-off-by: Michael Livshin <michael.livshin@scylladb.com>