### PR TITLE
RFC: Commitlog: Do proper bookkeep of which segments have been flush requested

### DIFF
--- a/db/commitlog/commitlog.cc
+++ b/db/commitlog/commitlog.cc
@@ -1590,7 +1590,7 @@ future<db::commitlog::segment_manager::sseg_ptr> db::commitlog::segment_manager:
             auto f = cfg.reuse_segments ? _recycled_segments.not_empty() :  _disk_deletions.get_shared_future();
             if (!f.available()) {
                 _new_counter = 0; // zero this so timer task does not duplicate the below flush
-                flush_segments(0); // force memtable flush already
+                flush_segments(max_size); // force memtable flush already
             }
             try {
                 co_await std::move(f);


### PR DESCRIPTION
Keeps track of low RP for flush requested segments (those we've requested memtable flush for), so that if we do a size-based flush (get X bytes), we do so with "new" (not already requested) segment areas. 

As an addition to this, we can then lower the flush size from "everything" to "one segment please" when blocking on no available recycled segment (if using hard limit).

Cherry-picked/separated from #9580. 