### PR TITLE
schema: associate a registry entry with all instances

### DIFF
--- a/cdc/log.cc
+++ b/cdc/log.cc
@@ -504,7 +504,7 @@ bytes log_data_column_deleted_elements_name_bytes(const bytes& column_name) {
 }
 
 static schema_ptr create_log_schema(const schema& s, std::optional<utils::UUID> uuid) {
-    schema_builder b(s.ks_name(), log_name(s.cf_name()));
+    schema_builder b(*s.registry(), s.ks_name(), log_name(s.cf_name()));
     b.with_partitioner("com.scylladb.dht.CDCPartitioner");
     b.set_compaction_strategy(sstables::compaction_strategy_type::time_window);
     b.set_comment(fmt::format("CDC log for {}.{}", s.ks_name(), s.cf_name()));

--- a/cdc/log.cc
+++ b/cdc/log.cc
@@ -194,7 +194,7 @@ public:
     void on_before_update_column_family(const schema& new_schema, const schema& old_schema, std::vector<mutation>& mutations, api::timestamp_type timestamp) override {
         bool is_cdc = new_schema.cdc_options().enabled();
         bool was_cdc = old_schema.cdc_options().enabled();
-        auto& registry = *new_schema.registry();
+        auto& registry = new_schema.registry();
 
         // we need to create or modify the log & stream schemas iff either we changed cdc status (was != is)
         // or if cdc is on now unconditionally, since then any actual base schema changes will affect the column 
@@ -505,7 +505,7 @@ bytes log_data_column_deleted_elements_name_bytes(const bytes& column_name) {
 }
 
 static schema_ptr create_log_schema(const schema& s, std::optional<utils::UUID> uuid) {
-    schema_builder b(*s.registry(), s.ks_name(), log_name(s.cf_name()));
+    schema_builder b(s.registry(), s.ks_name(), log_name(s.cf_name()));
     b.with_partitioner("com.scylladb.dht.CDCPartitioner");
     b.set_compaction_strategy(sstables::compaction_strategy_type::time_window);
     b.set_comment(fmt::format("CDC log for {}.{}", s.ks_name(), s.cf_name()));

--- a/cql3/statements/create_table_statement.cc
+++ b/cql3/statements/create_table_statement.cc
@@ -133,7 +133,7 @@ future<shared_ptr<cql_transport::event::schema_change>> create_table_statement::
  * @throws InvalidRequestException on failure to validate parsed parameters
  */
 schema_ptr create_table_statement::get_cf_meta_data(const database& db) const {
-    schema_builder builder{keyspace(), column_family(), _id};
+    schema_builder builder{db.get_schema_registry(), keyspace(), column_family(), _id};
     apply_properties_to(builder, db);
     return builder.build(_use_compact_storage ? schema_builder::compact_storage::yes : schema_builder::compact_storage::no);
 }

--- a/cql3/statements/create_view_statement.cc
+++ b/cql3/statements/create_view_statement.cc
@@ -307,7 +307,7 @@ future<shared_ptr<cql_transport::event::schema_change>> create_view_statement::a
                 column_family(), column_names));
     }
 
-    schema_builder builder{keyspace(), column_family()};
+    schema_builder builder{db.get_schema_registry(), keyspace(), column_family()};
     auto add_columns = [this, &builder] (std::vector<const column_definition*>& defs, column_kind kind) mutable {
         for (auto* def : defs) {
             auto&& type = _properties.get_reversable_type(*def->column_specification->name, def->type);

--- a/database.cc
+++ b/database.cc
@@ -318,7 +318,7 @@ void database::setup_scylla_memory_diagnostics_producer() {
 }
 
 database::database(const db::config& cfg, database_config dbcfg, service::migration_notifier& mn, gms::feature_service& feat, const locator::shared_token_metadata& stm,
-        abort_source& as, sharded<semaphore>& sst_dir_sem, utils::cross_shard_barrier barrier)
+        schema_registry& sr, abort_source& as, sharded<semaphore>& sst_dir_sem, utils::cross_shard_barrier barrier)
     : _stats(make_lw_shared<db_stats>())
     , _cl_stats(std::make_unique<cell_locker_stats>())
     , _cfg(cfg)
@@ -372,7 +372,7 @@ database::database(const db::config& cfg, database_config dbcfg, service::migrat
     , _sst_dir_semaphore(sst_dir_sem)
     , _wasm_engine(std::make_unique<wasm::engine>())
     , _stop_barrier(std::move(barrier))
-    , _schema_registry(local_schema_registry())
+    , _schema_registry(sr)
 {
     assert(dbcfg.available_memory != 0); // Detect misconfigured unit tests, see #7544
 

--- a/database.cc
+++ b/database.cc
@@ -376,7 +376,6 @@ database::database(const db::config& cfg, database_config dbcfg, service::migrat
 {
     assert(dbcfg.available_memory != 0); // Detect misconfigured unit tests, see #7544
 
-    _schema_registry.init(*this); // TODO: we're never unbound.
     setup_metrics();
 
     _row_cache_tracker.set_compaction_scheduling_group(dbcfg.memory_compaction_scheduling_group);

--- a/database.cc
+++ b/database.cc
@@ -873,7 +873,6 @@ void database::drop_keyspace(const sstring& name) {
 }
 
 void database::add_column_family(keyspace& ks, schema_ptr schema, column_family::config cfg) {
-    schema = _schema_registry.learn(schema);
     schema->registry_entry()->mark_synced();
 
     lw_shared_ptr<column_family> cf;
@@ -908,10 +907,9 @@ future<> database::add_column_family_and_make_directory(schema_ptr schema) {
     return ks.make_directory_for_column_family(schema->cf_name(), schema->id());
 }
 
-bool database::update_column_family(schema_ptr new_schema) {
-    column_family& cfm = find_column_family(new_schema->id());
-    bool columns_changed = !cfm.schema()->equal_columns(*new_schema);
-    auto s = _schema_registry.learn(new_schema);
+bool database::update_column_family(schema_ptr s) {
+    column_family& cfm = find_column_family(s->id());
+    bool columns_changed = !cfm.schema()->equal_columns(*s);
     s->registry_entry()->mark_synced();
     cfm.set_schema(s);
     find_keyspace(s->ks_name()).metadata()->add_or_update_column_family(s);

--- a/database.cc
+++ b/database.cc
@@ -873,7 +873,7 @@ void database::drop_keyspace(const sstring& name) {
 }
 
 void database::add_column_family(keyspace& ks, schema_ptr schema, column_family::config cfg) {
-    schema->registry_entry()->mark_synced();
+    schema->registry_entry().mark_synced();
 
     lw_shared_ptr<column_family> cf;
     if (cfg.enable_commitlog && _commitlog) {
@@ -910,7 +910,7 @@ future<> database::add_column_family_and_make_directory(schema_ptr schema) {
 bool database::update_column_family(schema_ptr s) {
     column_family& cfm = find_column_family(s->id());
     bool columns_changed = !cfm.schema()->equal_columns(*s);
-    s->registry_entry()->mark_synced();
+    s->registry_entry().mark_synced();
     cfm.set_schema(s);
     find_keyspace(s->ks_name()).metadata()->add_or_update_column_family(s);
     if (s->is_view()) {

--- a/database.hh
+++ b/database.hh
@@ -81,7 +81,7 @@ class cell_locker;
 class cell_locker_stats;
 class locked_cell;
 class mutation;
-
+class schema_registry;
 class frozen_mutation;
 class reconcilable_result;
 
@@ -1361,6 +1361,8 @@ private:
     std::unique_ptr<wasm::engine> _wasm_engine;
     utils::cross_shard_barrier _stop_barrier;
 
+    schema_registry& _schema_registry;
+
 public:
     future<> init_commitlog();
     const gms::feature_service& features() const { return _feat; }
@@ -1641,6 +1643,8 @@ public:
     sharded<semaphore>& get_sharded_sst_dir_semaphore() {
         return _sst_dir_semaphore;
     }
+
+    schema_registry& get_schema_registry() const;
 };
 
 future<> start_large_data_handler(sharded<database>& db);

--- a/database.hh
+++ b/database.hh
@@ -1422,7 +1422,7 @@ public:
 
     future<> parse_system_tables(distributed<service::storage_proxy>&);
     database(const db::config&, database_config dbcfg, service::migration_notifier& mn, gms::feature_service& feat, const locator::shared_token_metadata& stm,
-            abort_source& as, sharded<semaphore>& sst_dir_sem, utils::cross_shard_barrier barrier = utils::cross_shard_barrier(utils::cross_shard_barrier::solo{}) /* for single-shard usage */);
+            schema_registry& sr, abort_source& as, sharded<semaphore>& sst_dir_sem, utils::cross_shard_barrier barrier = utils::cross_shard_barrier(utils::cross_shard_barrier::solo{}) /* for single-shard usage */);
     database(database&&) = delete;
     ~database();
 

--- a/db/batchlog_manager.cc
+++ b/db/batchlog_manager.cc
@@ -61,6 +61,7 @@
 #include "gms/failure_detector.hh"
 #include "gms/gossiper.hh"
 #include "schema_registry.hh"
+#include "schema_mutations.hh"
 #include "idl/uuid.dist.hh"
 #include "idl/frozen_schema.dist.hh"
 #include "serializer_impl.hh"

--- a/db/legacy_schema_migrator.cc
+++ b/db/legacy_schema_migrator.cc
@@ -180,7 +180,7 @@ public:
             auto cf_name = td.get_as<sstring>("columnfamily_name");
             auto id = td.get_or("cf_id", generate_legacy_id(ks_name, cf_name));
 
-            schema_builder builder(dst.name, cf_name, id);
+            schema_builder builder(_qp.db().get_schema_registry(), dst.name, cf_name, id);
 
             builder.with_version(sm.digest());
 

--- a/db/legacy_schema_migrator.cc
+++ b/db/legacy_schema_migrator.cc
@@ -163,10 +163,12 @@ public:
 
         typedef std::tuple<future<result_set_type>, future<result_set_type>, future<result_set_type>, future<db::schema_tables::legacy::schema_mutations>> result_tuple;
 
+        auto& registry = _qp.db().get_schema_registry();
+
         return when_all(_qp.execute_internal(tq, { dst.name, cf_name }),
                         _qp.execute_internal(cq, { dst.name, cf_name }),
                         _qp.execute_internal(zq, { dst.name, cf_name }),
-                        db::schema_tables::legacy::read_table_mutations(_sp, dst.name, cf_name, db::system_keyspace::legacy::column_families()))
+                        db::schema_tables::legacy::read_table_mutations(_sp, dst.name, cf_name, db::system_keyspace::legacy::column_families(registry)))
                     .then([this, &dst, cf_name, timestamp](result_tuple&& t) {
 
             result_set_type tables = std::get<0>(t).get0();

--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -2089,7 +2089,7 @@ static data_type expand_user_type(data_type original) {
 }
 
 static void add_dropped_column_to_schema_mutation(schema_ptr table, const sstring& name, const schema::dropped_column& column, api::timestamp_type timestamp, mutation& m) {
-    auto ckey = clustering_key::from_exploded(*dropped_columns(*table->registry()), {utf8_type->decompose(table->cf_name()), utf8_type->decompose(name)});
+    auto ckey = clustering_key::from_exploded(*dropped_columns(table->registry()), {utf8_type->decompose(table->cf_name()), utf8_type->decompose(name)});
     db_clock::time_point tp(db_clock::duration(column.timestamp));
     m.set_clustered_cell(ckey, "dropped_time", tp, timestamp);
 
@@ -2103,7 +2103,7 @@ static void add_dropped_column_to_schema_mutation(schema_ptr table, const sstrin
 }
 
 mutation make_scylla_tables_mutation(schema_ptr table, api::timestamp_type timestamp) {
-    auto& registry = *table->registry();
+    auto& registry = table->registry();
     schema_ptr s = tables(registry);
     auto pkey = partition_key::from_singular(*s, table->ks_name());
     auto ckey = clustering_key::from_singular(*s, table->cf_name());
@@ -2136,7 +2136,7 @@ static schema_mutations make_table_mutations(schema_ptr table, api::timestamp_ty
 
     // For property that can be null (and can be changed), we insert tombstones, to make sure
     // we don't keep a property the user has removed
-    auto& registry = *table->registry();
+    auto& registry = table->registry();
     schema_ptr s = tables(registry);
     auto pkey = partition_key::from_singular(*s, table->ks_name());
     mutation m{s, pkey};
@@ -2237,7 +2237,7 @@ static void make_update_indices_mutations(
 }
 
 static void add_drop_column_to_mutations(schema_ptr table, const sstring& name, const schema::dropped_column& dc, api::timestamp_type timestamp, std::vector<mutation>& mutations) {
-    auto& registry = *table->registry();
+    auto& registry = table->registry();
     schema_ptr s = dropped_columns(registry);
     auto pkey = partition_key::from_singular(*s, table->ks_name());
     auto ckey = clustering_key::from_exploded(*s, {utf8_type->decompose(table->cf_name()), utf8_type->decompose(name)});
@@ -2251,7 +2251,7 @@ static void make_update_columns_mutations(schema_ptr old_table,
         api::timestamp_type timestamp,
         bool from_thrift,
         std::vector<mutation>& mutations) {
-    auto& registry = *old_table->registry();
+    auto& registry = old_table->registry();
     mutation columns_mutation(columns(registry), partition_key::from_singular(*columns(registry), old_table->ks_name()));
     mutation view_virtual_columns_mutation(view_virtual_columns(registry), partition_key::from_singular(*columns(registry), old_table->ks_name()));
     mutation computed_columns_mutation(computed_columns(registry), partition_key::from_singular(*columns(registry), old_table->ks_name()));
@@ -2335,7 +2335,7 @@ static void make_drop_table_or_view_mutations(schema_ptr schema_table,
             schema_ptr table_or_view,
             api::timestamp_type timestamp,
             std::vector<mutation>& mutations) {
-    auto& registry = *schema_table->registry();
+    auto& registry = schema_table->registry();
     auto pkey = partition_key::from_singular(*schema_table, table_or_view->ks_name());
     mutation m{schema_table, pkey};
     auto ckey = clustering_key::from_singular(*schema_table, table_or_view->cf_name());
@@ -2768,7 +2768,7 @@ static void add_index_to_schema_mutation(schema_ptr table,
 
 static void drop_index_from_schema_mutation(schema_ptr table, const index_metadata& index, long timestamp, std::vector<mutation>& mutations)
 {
-    auto& registry = *table->registry();
+    auto& registry = table->registry();
     schema_ptr s = indexes(registry);
     auto pkey = partition_key::from_singular(*s, table->ks_name());
     auto ckey = clustering_key::from_exploded(*s, {utf8_type->decompose(table->cf_name()), utf8_type->decompose(index.name())});
@@ -2937,7 +2937,7 @@ static schema_mutations make_view_mutations(view_ptr view, api::timestamp_type t
 
     // For properties that can be null (and can be changed), we insert tombstones, to make sure
     // we don't keep a property the user has removed
-    auto& registry = *view->registry();
+    auto& registry = view->registry();
     schema_ptr s = views(registry);
     auto pkey = partition_key::from_singular(*s, view->ks_name());
     mutation m{s, pkey};

--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -135,6 +135,12 @@ schema_ctxt::schema_ctxt(distributed<service::storage_proxy>& proxy)
     : schema_ctxt(proxy.local().get_db())
 {}
 
+schema_ctxt::schema_ctxt(for_tests, db::extensions& ext)
+    : _extensions(ext)
+    , _murmur3_partitioner_ignore_msb_bits(12)
+    , _schema_registry_grace_period(1)
+{}
+
 namespace schema_tables {
 
 logging::logger slogger("schema_tables");

--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -487,9 +487,13 @@ schema_ptr triggers() {
     return schema;
 }
 
+utils::UUID views_id() {
+    return generate_legacy_id(NAME, VIEWS);
+}
+
 schema_ptr views() {
     static thread_local auto schema = [] {
-        schema_builder builder(generate_legacy_id(NAME, VIEWS), NAME, VIEWS,
+        schema_builder builder(views_id(), NAME, VIEWS,
         // partition key
         {{"keyspace_name", utf8_type}},
         // clustering key

--- a/db/schema_tables.hh
+++ b/db/schema_tables.hh
@@ -139,6 +139,8 @@ schema_ptr computed_columns();
 // Belongs to the "system" keyspace
 schema_ptr scylla_table_schema_history();
 
+utils::UUID views_id();
+
 }
 
 namespace legacy {

--- a/db/schema_tables.hh
+++ b/db/schema_tables.hh
@@ -210,7 +210,7 @@ future<std::set<sstring>> merge_keyspaces(distributed<service::storage_proxy>& p
 
 std::vector<mutation> make_create_keyspace_mutations(lw_shared_ptr<keyspace_metadata> keyspace, api::timestamp_type timestamp, bool with_tables_and_types_and_functions = true);
 
-std::vector<mutation> make_drop_keyspace_mutations(lw_shared_ptr<keyspace_metadata> keyspace, api::timestamp_type timestamp);
+std::vector<mutation> make_drop_keyspace_mutations(schema_registry& registry, lw_shared_ptr<keyspace_metadata> keyspace, api::timestamp_type timestamp);
 
 lw_shared_ptr<keyspace_metadata> create_keyspace_from_schema_partition(const schema_result_value_type& partition);
 

--- a/db/schema_tables.hh
+++ b/db/schema_tables.hh
@@ -87,6 +87,10 @@ public:
     schema_ctxt(distributed<database>&);
     schema_ctxt(distributed<service::storage_proxy>&);
 
+    // For tests *only*.
+    class for_tests {};
+    schema_ctxt(for_tests, db::extensions&);
+
     const db::extensions& extensions() const {
         return _extensions;
     }

--- a/db/size_estimates_virtual_reader.cc
+++ b/db/size_estimates_virtual_reader.cc
@@ -256,7 +256,7 @@ future<> size_estimates_mutation_reader::get_next_partition() {
         return get_local_ranges(_db);
     }).then([this] (auto&& ranges) {
         auto estimates = this->estimates_for_current_keyspace(std::move(ranges));
-        auto mutations = db::system_keyspace::make_size_estimates_mutation(*_current_partition, std::move(estimates));
+        auto mutations = db::system_keyspace::make_size_estimates_mutation(_db.get_schema_registry(), *_current_partition, std::move(estimates));
         ++_current_partition;
         std::vector<mutation> ms;
         ms.emplace_back(std::move(mutations));

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -2374,13 +2374,13 @@ void register_virtual_tables(distributed<database>& dist_db, distributed<service
 
 std::vector<schema_ptr> system_keyspace::all_tables(schema_registry& registry, const db::config& cfg) {
     std::vector<schema_ptr> r;
-    auto schema_tables = db::schema_tables::all_tables(schema_features::full());
+    auto schema_tables = db::schema_tables::all_tables(registry, schema_features::full());
     std::copy(schema_tables.begin(), schema_tables.end(), std::back_inserter(r));
     r.insert(r.end(), { built_indexes(registry), hints(registry), batchlog(registry), paxos(registry), local(registry),
                     peers(registry), peer_events(registry), range_xfers(registry),
                     compactions_in_progress(registry), compaction_history(registry),
                     sstable_activity(registry), clients(registry), size_estimates(registry), large_partitions(registry), large_rows(registry), large_cells(registry),
-                    scylla_local(registry), db::schema_tables::scylla_table_schema_history(),
+                    scylla_local(registry), db::schema_tables::scylla_table_schema_history(registry),
                     v3::views_builds_in_progress(registry), v3::built_views(registry),
                     v3::scylla_views_builds_in_progress(registry),
                     v3::truncated(registry),

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -122,6 +122,10 @@ table_schema_version system_keyspace::generate_schema_version(utils::UUID table_
     return utils::UUID_gen::get_name_UUID(h.finalize());
 }
 
+table_schema_version system_keyspace::generate_schema_version(const char* keyspace_name, const char* table_name, uint16_t offset) {
+    return generate_schema_version(generate_legacy_id(keyspace_name, table_name), offset);
+}
+
 // Currently, the type variables (uuid_type, etc.) are thread-local reference-
 // counted shared pointers. This forces us to also make the built in schemas
 // below thread-local as well.

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -228,6 +228,7 @@ public:
     static schema_ptr raft_snapshots();
 
     static table_schema_version generate_schema_version(utils::UUID table_id, uint16_t offset = 0);
+    static table_schema_version generate_schema_version(const char* keyspace_name, const char* table_name, uint16_t offset = 0);
 
     // Only for testing.
     static void minimal_setup(distributed<cql3::query_processor>& qp);

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -100,19 +100,19 @@ struct truncation_record;
 typedef std::vector<db::replay_position> replay_positions;
 
 class system_keyspace {
-    static schema_ptr raft_config();
-    static schema_ptr local();
-    static schema_ptr peers();
-    static schema_ptr peer_events();
-    static schema_ptr range_xfers();
-    static schema_ptr compactions_in_progress();
-    static schema_ptr compaction_history();
-    static schema_ptr sstable_activity();
-    static schema_ptr large_partitions();
-    static schema_ptr large_rows();
-    static schema_ptr large_cells();
-    static schema_ptr scylla_local();
-    static schema_ptr clients();
+    static schema_ptr raft_config(schema_registry& registry);
+    static schema_ptr local(schema_registry& registry);
+    static schema_ptr peers(schema_registry& registry);
+    static schema_ptr peer_events(schema_registry& registry);
+    static schema_ptr range_xfers(schema_registry& registry);
+    static schema_ptr compactions_in_progress(schema_registry& registry);
+    static schema_ptr compaction_history(schema_registry& registry);
+    static schema_ptr sstable_activity(schema_registry& registry);
+    static schema_ptr large_partitions(schema_registry& registry);
+    static schema_ptr large_rows(schema_registry& registry);
+    static schema_ptr large_cells(schema_registry& registry);
+    static schema_ptr scylla_local(schema_registry& registry);
+    static schema_ptr clients(schema_registry& registry);
     static future<> setup_version(distributed<gms::feature_service>& feat, sharded<netw::messaging_service>& ms, const db::config& cfg);
     static future<> check_health(const sstring& cluster_name);
     static future<> force_blocking_flush(sstring cfname);
@@ -122,7 +122,7 @@ class system_keyspace {
     template <typename Value>
     static future<> update_cached_values(gms::inet_address ep, sstring column_name, Value value);
 public:
-    static schema_ptr size_estimates();
+    static schema_ptr size_estimates(schema_registry& registry);
 public:
     static constexpr auto NAME = "system";
     static constexpr auto HINTS = "hints";
@@ -163,23 +163,23 @@ public:
         static constexpr auto BUILT_VIEWS = "built_views";
         static constexpr auto SCYLLA_VIEWS_BUILDS_IN_PROGRESS = "scylla_views_builds_in_progress";
         static constexpr auto CDC_LOCAL = "cdc_local";
-        static schema_ptr batches();
-        static schema_ptr built_indexes();
-        static schema_ptr local();
-        static schema_ptr truncated();
-        static schema_ptr peers();
-        static schema_ptr peer_events();
-        static schema_ptr range_xfers();
-        static schema_ptr compaction_history();
-        static schema_ptr sstable_activity();
-        static schema_ptr size_estimates();
-        static schema_ptr large_partitions();
-        static schema_ptr scylla_local();
-        static schema_ptr available_ranges();
-        static schema_ptr views_builds_in_progress();
-        static schema_ptr built_views();
-        static schema_ptr scylla_views_builds_in_progress();
-        static schema_ptr cdc_local();
+        static schema_ptr batches(schema_registry& registry);
+        static schema_ptr built_indexes(schema_registry& registry);
+        static schema_ptr local(schema_registry& registry);
+        static schema_ptr truncated(schema_registry& registry);
+        static schema_ptr peers(schema_registry& registry);
+        static schema_ptr peer_events(schema_registry& registry);
+        static schema_ptr range_xfers(schema_registry& registry);
+        static schema_ptr compaction_history(schema_registry& registry);
+        static schema_ptr sstable_activity(schema_registry& registry);
+        static schema_ptr size_estimates(schema_registry& registry);
+        static schema_ptr large_partitions(schema_registry& registry);
+        static schema_ptr scylla_local(schema_registry& registry);
+        static schema_ptr available_ranges(schema_registry& registry);
+        static schema_ptr views_builds_in_progress(schema_registry& registry);
+        static schema_ptr built_views(schema_registry& registry);
+        static schema_ptr scylla_views_builds_in_progress(schema_registry& registry);
+        static schema_ptr cdc_local(schema_registry& registry);
     };
 
     struct legacy {
@@ -193,15 +193,15 @@ public:
         static constexpr auto FUNCTIONS = "schema_functions";
         static constexpr auto AGGREGATES = "schema_aggregates";
 
-        static schema_ptr keyspaces();
-        static schema_ptr column_families();
-        static schema_ptr columns();
-        static schema_ptr triggers();
-        static schema_ptr usertypes();
-        static schema_ptr functions();
-        static schema_ptr aggregates();
-        static schema_ptr hints();
-        static schema_ptr batchlog();
+        static schema_ptr keyspaces(schema_registry& registry);
+        static schema_ptr column_families(schema_registry& registry);
+        static schema_ptr columns(schema_registry& registry);
+        static schema_ptr triggers(schema_registry& registry);
+        static schema_ptr usertypes(schema_registry& registry);
+        static schema_ptr functions(schema_registry& registry);
+        static schema_ptr aggregates(schema_registry& registry);
+        static schema_ptr hints(schema_registry& registry);
+        static schema_ptr batchlog(schema_registry& registry);
     };
 
     static constexpr const char* extra_durable_tables[] = { PAXOS };
@@ -220,12 +220,12 @@ public:
     using view_name = system_keyspace_view_name;
     using view_build_progress = system_keyspace_view_build_progress;
 
-    static schema_ptr hints();
-    static schema_ptr batchlog();
-    static schema_ptr paxos();
-    static schema_ptr built_indexes(); // TODO (from Cassandra): make private
-    static schema_ptr raft();
-    static schema_ptr raft_snapshots();
+    static schema_ptr hints(schema_registry& registry);
+    static schema_ptr batchlog(schema_registry& registry);
+    static schema_ptr paxos(schema_registry& registry);
+    static schema_ptr built_indexes(schema_registry& registry); // TODO (from Cassandra): make private
+    static schema_ptr raft(schema_registry& registry);
+    static schema_ptr raft_snapshots(schema_registry& registry);
 
     static table_schema_version generate_schema_version(utils::UUID table_id, uint16_t offset = 0);
     static table_schema_version generate_schema_version(const char* keyspace_name, const char* table_name, uint16_t offset = 0);
@@ -262,7 +262,7 @@ public:
     static future<> set_scylla_local_param(const sstring& key, const sstring& value);
     static future<std::optional<sstring>> get_scylla_local_param(const sstring& key);
 
-    static std::vector<schema_ptr> all_tables(const db::config& cfg);
+    static std::vector<schema_ptr> all_tables(schema_registry& registry, const db::config& cfg);
     static future<> make(distributed<database>& db, distributed<service::storage_service>& ss);
 
     /// overloads
@@ -381,7 +381,7 @@ public:
     /**
      * Builds a mutation for SIZE_ESTIMATES_CF containing the specified estimates.
      */
-    static mutation make_size_estimates_mutation(const sstring& ks, std::vector<range_estimates> estimates);
+    static mutation make_size_estimates_mutation(schema_registry& registry, const sstring& ks, std::vector<range_estimates> estimates);
 
     static future<> register_view_for_building(sstring ks_name, sstring view_name, const dht::token& token);
     static future<> update_view_build_progress(sstring ks_name, sstring view_name, const dht::token& token);

--- a/frozen_schema.cc
+++ b/frozen_schema.cc
@@ -46,12 +46,12 @@ frozen_schema::frozen_schema(const schema_ptr& s)
     }())
 { }
 
-schema_ptr frozen_schema::unfreeze(const db::schema_ctxt& ctxt) const {
+schema_ptr frozen_schema::unfreeze(schema_registry& registry) const {
     auto in = ser::as_input_stream(_data);
     auto sv = ser::deserialize(in, boost::type<ser::schema_view>());
     return sv.mutations().is_view
-         ? db::schema_tables::create_view_from_mutations(ctxt, schema_mutations(sv.mutations()), sv.version())
-         : db::schema_tables::create_table_from_mutations(ctxt, schema_mutations(sv.mutations()), sv.version());
+         ? db::schema_tables::create_view_from_mutations(registry, schema_mutations(registry, sv.mutations()), sv.version())
+         : db::schema_tables::create_table_from_mutations(registry, schema_mutations(registry, sv.mutations()), sv.version());
 }
 
 frozen_schema::frozen_schema(bytes b)

--- a/frozen_schema.cc
+++ b/frozen_schema.cc
@@ -40,7 +40,7 @@ frozen_schema::frozen_schema(const schema_ptr& s)
         bytes_ostream out;
         ser::writer_of_schema<bytes_ostream> wr(out);
         std::move(wr).write_version(s->version())
-                     .write_mutations(sm)
+                     .write_mutations(frozen_schema_mutations(sm))
                      .end_schema();
         return to_bytes(out.linearize());
     }())
@@ -49,9 +49,9 @@ frozen_schema::frozen_schema(const schema_ptr& s)
 schema_ptr frozen_schema::unfreeze(const db::schema_ctxt& ctxt) const {
     auto in = ser::as_input_stream(_data);
     auto sv = ser::deserialize(in, boost::type<ser::schema_view>());
-    return sv.mutations().is_view()
-         ? db::schema_tables::create_view_from_mutations(ctxt, sv.mutations(), sv.version())
-         : db::schema_tables::create_table_from_mutations(ctxt, sv.mutations(), sv.version());
+    return sv.mutations().is_view
+         ? db::schema_tables::create_view_from_mutations(ctxt, schema_mutations(sv.mutations()), sv.version())
+         : db::schema_tables::create_table_from_mutations(ctxt, schema_mutations(sv.mutations()), sv.version());
 }
 
 frozen_schema::frozen_schema(bytes b)

--- a/frozen_schema.hh
+++ b/frozen_schema.hh
@@ -25,9 +25,7 @@
 #include "frozen_mutation.hh"
 #include "bytes.hh"
 
-namespace db {
-class schema_ctxt;
-}
+class schema_registry;
 
 // Transport for schema_ptr across shards/nodes.
 // It's safe to access from another shard by const&.
@@ -40,6 +38,6 @@ public:
     frozen_schema(const frozen_schema&) = default;
     frozen_schema& operator=(const frozen_schema&) = default;
     frozen_schema& operator=(frozen_schema&&) = default;
-    schema_ptr unfreeze(const db::schema_ctxt&) const;
+    schema_ptr unfreeze(schema_registry&) const;
     bytes_view representation() const;
 };

--- a/frozen_schema.hh
+++ b/frozen_schema.hh
@@ -35,7 +35,7 @@ class frozen_schema {
     bytes _data;
 public:
     explicit frozen_schema(bytes);
-    frozen_schema(const schema_ptr&);
+    explicit frozen_schema(const schema_ptr&);
     frozen_schema(frozen_schema&&) = default;
     frozen_schema(const frozen_schema&) = default;
     frozen_schema& operator=(const frozen_schema&) = default;

--- a/idl/frozen_schema.idl.hh
+++ b/idl/frozen_schema.idl.hh
@@ -23,20 +23,20 @@ class canonical_mutation final {
     bytes representation();
 };
 
-class schema_mutations {
-    canonical_mutation columnfamilies_canonical_mutation();
-    canonical_mutation columns_canonical_mutation();
-    bool is_view()[[version 1.6]];
-    std::optional<canonical_mutation> indices_canonical_mutation()[[version 2.0]];
-    std::optional<canonical_mutation> dropped_columns_canonical_mutation()[[version 2.0]];
-    std::optional<canonical_mutation> scylla_tables_canonical_mutation()[[version 2.0]];
-    std::optional<canonical_mutation> view_virtual_columns_canonical_mutation()[[version 2.4]];
-    std::optional<canonical_mutation> computed_columns_canonical_mutation()[[version 3.2]];
+class frozen_schema_mutations {
+    canonical_mutation columnfamilies;
+    canonical_mutation columns;
+    bool is_view[[version 1.6]];
+    std::optional<canonical_mutation> indices[[version 2.0]];
+    std::optional<canonical_mutation> dropped_columns[[version 2.0]];
+    std::optional<canonical_mutation> scylla_tables[[version 2.0]];
+    std::optional<canonical_mutation> view_virtual_columns[[version 2.4]];
+    std::optional<canonical_mutation> computed_columns[[version 3.2]];
 };
 
 class schema stub [[writable]] {
     utils::UUID version;
-    schema_mutations mutations;
+    frozen_schema_mutations mutations;
 };
 
 class frozen_schema final {

--- a/index/secondary_index_manager.cc
+++ b/index/secondary_index_manager.cc
@@ -123,7 +123,7 @@ static bytes get_available_token_column_name(const schema& schema) {
 view_ptr secondary_index_manager::create_view_for_index(const index_metadata& im, bool new_token_column_computation) const {
     auto schema = _cf.schema();
     sstring index_target_name = im.options().at(cql3::statements::index_target::target_option_name);
-    schema_builder builder{*schema->registry(), schema->ks_name(), index_table_name(im.name())};
+    schema_builder builder{schema->registry(), schema->ks_name(), index_table_name(im.name())};
     auto target_info = target_parser::parse(schema, im);
     const auto* index_target = im.local() ? target_info.ck_columns.front() : target_info.pk_columns.front();
     auto target_type = target_info.type;

--- a/index/secondary_index_manager.cc
+++ b/index/secondary_index_manager.cc
@@ -123,7 +123,7 @@ static bytes get_available_token_column_name(const schema& schema) {
 view_ptr secondary_index_manager::create_view_for_index(const index_metadata& im, bool new_token_column_computation) const {
     auto schema = _cf.schema();
     sstring index_target_name = im.options().at(cql3::statements::index_target::target_option_name);
-    schema_builder builder{schema->ks_name(), index_table_name(im.name())};
+    schema_builder builder{*schema->registry(), schema->ks_name(), index_table_name(im.name())};
     auto target_info = target_parser::parse(schema, im);
     const auto* index_target = im.local() ? target_info.ck_columns.front() : target_info.pk_columns.front();
     auto target_type = target_info.type;

--- a/main.cc
+++ b/main.cc
@@ -857,9 +857,6 @@ int main(int ac, char** av) {
             view_hints_dir_initializer.ensure_created_and_verified().get();
 
             schema_registry.start().get();
-            schema_registry.invoke_on_all([] (::schema_registry& sr) {
-                ::set_local_schema_registry(sr);
-            }).get();
             auto stop_schema_registry = defer([&schema_registry] {
                 schema_registry.stop().get();
             });

--- a/main.cc
+++ b/main.cc
@@ -856,7 +856,7 @@ int main(int ac, char** av) {
             }
             view_hints_dir_initializer.ensure_created_and_verified().get();
 
-            schema_registry.start().get();
+            schema_registry.start(std::cref(*cfg)).get();
             auto stop_schema_registry = defer([&schema_registry] {
                 schema_registry.stop().get();
             });

--- a/schema.cc
+++ b/schema.cc
@@ -459,7 +459,7 @@ schema::schema(reversed_tag, const schema& o)
 {
 }
 
-static lw_shared_ptr<const schema> make_shared_schema(schema_registry* registry, std::optional<utils::UUID> id, std::string_view ks_name,
+lw_shared_ptr<const schema> make_shared_schema(schema_registry& registry, std::optional<utils::UUID> id, std::string_view ks_name,
     std::string_view cf_name, std::vector<schema::column> partition_key, std::vector<schema::column> clustering_key,
     std::vector<schema::column> regular_columns, std::vector<schema::column> static_columns,
     data_type regular_column_name_type, sstring comment) {
@@ -478,22 +478,6 @@ static lw_shared_ptr<const schema> make_shared_schema(schema_registry* registry,
     }
     builder.set_comment(comment);
     return builder.build();
-}
-
-lw_shared_ptr<const schema> make_shared_schema(schema_registry& registry, std::optional<utils::UUID> id, std::string_view ks_name,
-    std::string_view cf_name, std::vector<schema::column> partition_key, std::vector<schema::column> clustering_key,
-    std::vector<schema::column> regular_columns, std::vector<schema::column> static_columns,
-    data_type regular_column_name_type, sstring comment) {
-    return make_shared_schema(&registry, id, ks_name, cf_name, std::move(partition_key), std::move(clustering_key),
-            std::move(regular_columns), std::move(static_columns), std::move(regular_column_name_type), std::move(comment));
-}
-
-lw_shared_ptr<const schema> make_shared_schema(std::optional<utils::UUID> id, std::string_view ks_name,
-    std::string_view cf_name, std::vector<schema::column> partition_key, std::vector<schema::column> clustering_key,
-    std::vector<schema::column> regular_columns, std::vector<schema::column> static_columns,
-    data_type regular_column_name_type, sstring comment) {
-    return make_shared_schema(nullptr, id, ks_name, cf_name, std::move(partition_key), std::move(clustering_key),
-            std::move(regular_columns), std::move(static_columns), std::move(regular_column_name_type), std::move(comment));
 }
 
 schema::~schema() {

--- a/schema.cc
+++ b/schema.cc
@@ -483,6 +483,13 @@ schema::registry_entry() const noexcept {
     return _registry_entry;
 }
 
+schema_registry* schema::registry() const noexcept {
+    if (!_registry_entry) {
+        return nullptr;
+    }
+    return &_registry_entry->registry();
+}
+
 sstring schema::thrift_key_validator() const {
     if (partition_key_size() == 1) {
         return partition_key_columns().begin()->type->name();

--- a/schema.cc
+++ b/schema.cc
@@ -459,11 +459,11 @@ schema::schema(reversed_tag, const schema& o)
 {
 }
 
-lw_shared_ptr<const schema> make_shared_schema(std::optional<utils::UUID> id, std::string_view ks_name,
+static lw_shared_ptr<const schema> make_shared_schema(schema_registry* registry, std::optional<utils::UUID> id, std::string_view ks_name,
     std::string_view cf_name, std::vector<schema::column> partition_key, std::vector<schema::column> clustering_key,
     std::vector<schema::column> regular_columns, std::vector<schema::column> static_columns,
     data_type regular_column_name_type, sstring comment) {
-    schema_builder builder(std::move(ks_name), std::move(cf_name), std::move(id), std::move(regular_column_name_type));
+    schema_builder builder(registry, std::move(ks_name), std::move(cf_name), std::move(id), std::move(regular_column_name_type));
     for (auto&& column : partition_key) {
         builder.with_column(std::move(column.name), std::move(column.type), column_kind::partition_key);
     }
@@ -478,6 +478,22 @@ lw_shared_ptr<const schema> make_shared_schema(std::optional<utils::UUID> id, st
     }
     builder.set_comment(comment);
     return builder.build();
+}
+
+lw_shared_ptr<const schema> make_shared_schema(schema_registry& registry, std::optional<utils::UUID> id, std::string_view ks_name,
+    std::string_view cf_name, std::vector<schema::column> partition_key, std::vector<schema::column> clustering_key,
+    std::vector<schema::column> regular_columns, std::vector<schema::column> static_columns,
+    data_type regular_column_name_type, sstring comment) {
+    return make_shared_schema(&registry, id, ks_name, cf_name, std::move(partition_key), std::move(clustering_key),
+            std::move(regular_columns), std::move(static_columns), std::move(regular_column_name_type), std::move(comment));
+}
+
+lw_shared_ptr<const schema> make_shared_schema(std::optional<utils::UUID> id, std::string_view ks_name,
+    std::string_view cf_name, std::vector<schema::column> partition_key, std::vector<schema::column> clustering_key,
+    std::vector<schema::column> regular_columns, std::vector<schema::column> static_columns,
+    data_type regular_column_name_type, sstring comment) {
+    return make_shared_schema(nullptr, id, ks_name, cf_name, std::move(partition_key), std::move(clustering_key),
+            std::move(regular_columns), std::move(static_columns), std::move(regular_column_name_type), std::move(comment));
 }
 
 schema::~schema() {

--- a/schema.cc
+++ b/schema.cc
@@ -326,7 +326,7 @@ schema::raw_schema::raw_schema(utils::UUID id)
     , _sharder(::get_sharder(smp::count, default_partitioner_ignore_msb))
 { }
 
-schema::schema(private_tag, schema_registry* registry, const raw_schema& raw, std::optional<raw_view_info> raw_view_info)
+schema::schema(private_tag, schema_registry& registry, const raw_schema& raw, std::optional<raw_view_info> raw_view_info)
     : _raw(raw)
     , _offsets([this] {
         if (_raw._columns.size() > std::numeric_limits<column_count_type>::max()) {
@@ -414,9 +414,7 @@ schema::schema(private_tag, schema_registry* registry, const raw_schema& raw, st
         _view_info = std::make_unique<::view_info>(*this, *raw_view_info);
     }
 
-    if (registry) {
-        registry->pair_with_entry(*this);
-    }
+    registry.pair_with_entry(*this);
 }
 
 schema::schema(const schema& o, const std::function<void(schema&)>& transform)
@@ -437,9 +435,7 @@ schema::schema(const schema& o, const std::function<void(schema&)>& transform)
         }
     }
 
-    if (o.registry()) {
-        o.registry()->pair_with_entry(*this);
-    }
+    o.registry()->pair_with_entry(*this);
 }
 
 schema::schema(const schema& o)
@@ -1272,7 +1268,7 @@ schema_ptr schema_builder::build() {
             dynamic_pointer_cast<db::paxos_grace_seconds_extension>(it->second)->get_paxos_grace_seconds();
     }
 
-    return make_lw_shared<schema>(schema::private_tag{}, &_registry, new_raw, _view_info);
+    return make_lw_shared<schema>(schema::private_tag{}, _registry, new_raw, _view_info);
 }
 
 const cdc::options& schema::cdc_options() const {

--- a/schema.cc
+++ b/schema.cc
@@ -950,25 +950,39 @@ schema_builder& schema_builder::with_null_sharder() {
     return *this;
 }
 
-schema_builder::schema_builder(std::string_view ks_name, std::string_view cf_name,
+schema_builder::schema_builder(schema_registry* registry, std::string_view ks_name, std::string_view cf_name,
         std::optional<utils::UUID> id, data_type rct)
-        : _raw(id ? *id : utils::UUID_gen::get_time_UUID())
+        : _registry(registry)
+        , _raw(id ? *id : utils::UUID_gen::get_time_UUID())
 {
     _raw._ks_name = sstring(ks_name);
     _raw._cf_name = sstring(cf_name);
     _raw._regular_column_name_type = rct;
 }
 
+schema_builder::schema_builder(schema_registry& registry, std::string_view ks_name, std::string_view cf_name,
+        std::optional<utils::UUID> id, data_type rct)
+        : schema_builder(&registry, ks_name, cf_name, id, std::move(rct))
+{
+}
+
+schema_builder::schema_builder(std::string_view ks_name, std::string_view cf_name,
+        std::optional<utils::UUID> id, data_type rct)
+    : schema_builder(nullptr, ks_name, cf_name, id, rct)
+{
+}
+
 schema_builder::schema_builder(const schema_ptr s)
-    : schema_builder(s->_raw)
+    : schema_builder(s->registry(), s->_raw)
 {
     if (s->is_view()) {
         _view_info = s->view_info()->raw();
     }
 }
 
-schema_builder::schema_builder(const schema::raw_schema& raw)
-    : _raw(raw)
+schema_builder::schema_builder(schema_registry* registry, const schema::raw_schema& raw)
+    : _registry(registry)
+    , _raw(raw)
 {
     static_assert(schema::row_column_ids_are_ordered_by_name::value, "row columns don't need to be ordered by name");
     // Schema builder may add or remove columns and their ids need to be
@@ -980,6 +994,7 @@ schema_builder::schema_builder(const schema::raw_schema& raw)
 }
 
 schema_builder::schema_builder(
+        schema_registry* registry,
         std::optional<utils::UUID> id,
         std::string_view ks_name,
         std::string_view cf_name,
@@ -989,7 +1004,7 @@ schema_builder::schema_builder(
         std::vector<schema::column> static_columns,
         data_type regular_column_name_type,
         sstring comment)
-    : schema_builder(ks_name, cf_name, std::move(id), std::move(regular_column_name_type)) {
+    : schema_builder(registry, ks_name, cf_name, std::move(id), std::move(regular_column_name_type)) {
     for (auto&& column : partition_key) {
         with_column(std::move(column.name), std::move(column.type), column_kind::partition_key);
     }
@@ -1003,6 +1018,35 @@ schema_builder::schema_builder(
         with_column(std::move(column.name), std::move(column.type), column_kind::static_column);
     }
     set_comment(comment);
+}
+
+schema_builder::schema_builder(
+        schema_registry& registry,
+        std::optional<utils::UUID> id,
+        std::string_view ks_name,
+        std::string_view cf_name,
+        std::vector<schema::column> partition_key,
+        std::vector<schema::column> clustering_key,
+        std::vector<schema::column> regular_columns,
+        std::vector<schema::column> static_columns,
+        data_type regular_column_name_type,
+        sstring comment)
+    : schema_builder(&registry, id, ks_name, cf_name, std::move(partition_key), std::move(clustering_key), std::move(regular_columns),
+            std::move(static_columns), std::move(regular_column_name_type), std::move(comment)) {
+}
+
+schema_builder::schema_builder(
+        std::optional<utils::UUID> id,
+        std::string_view ks_name,
+        std::string_view cf_name,
+        std::vector<schema::column> partition_key,
+        std::vector<schema::column> clustering_key,
+        std::vector<schema::column> regular_columns,
+        std::vector<schema::column> static_columns,
+        data_type regular_column_name_type,
+        sstring comment)
+    : schema_builder(nullptr, id, ks_name, cf_name, std::move(partition_key), std::move(clustering_key), std::move(regular_columns),
+            std::move(static_columns), std::move(regular_column_name_type), std::move(comment)) {
 }
 
 column_definition& schema_builder::find_column(const cql3::column_identifier& c) {
@@ -1261,6 +1305,7 @@ schema_ptr schema_builder::build() {
             dynamic_pointer_cast<db::paxos_grace_seconds_extension>(it->second)->get_paxos_grace_seconds();
     }
 
+    (void)_registry;
     return make_lw_shared<schema>(schema::private_tag{}, new_raw, _view_info);
 }
 

--- a/schema.cc
+++ b/schema.cc
@@ -1635,7 +1635,9 @@ bool schema::equal_columns(const schema& other) const {
 }
 
 schema_ptr schema::make_reversed() const {
-    return make_lw_shared<schema>(schema::reversed_tag{}, *this);
+    return registry().get_or_load(utils::UUID_gen::negate(version()), [this] (table_schema_version) {
+        return make_lw_shared<schema>(schema::reversed_tag{}, *this);
+    });
 }
 
 raw_view_info::raw_view_info(utils::UUID base_id, sstring base_name, bool include_all_columns, sstring where_clause)

--- a/schema.cc
+++ b/schema.cc
@@ -1627,12 +1627,6 @@ schema_ptr schema::make_reversed() const {
     return make_lw_shared<schema>(schema::reversed_tag{}, *this);
 }
 
-schema_ptr schema::get_reversed() const {
-    return local_schema_registry().get_or_load(utils::UUID_gen::negate(_raw._version), [this] (table_schema_version) {
-        return frozen_schema(make_reversed());
-    });
-}
-
 raw_view_info::raw_view_info(utils::UUID base_id, sstring base_name, bool include_all_columns, sstring where_clause)
         : _base_id(std::move(base_id))
         , _base_name(std::move(base_name))

--- a/schema.cc
+++ b/schema.cc
@@ -474,7 +474,7 @@ lw_shared_ptr<const schema> make_shared_schema(std::optional<utils::UUID> id, st
 
 schema::~schema() {
     if (_registry_entry) {
-        _registry_entry->detach_schema();
+        _registry_entry->detach_schema(*this);
     }
 }
 

--- a/schema.cc
+++ b/schema.cc
@@ -435,7 +435,7 @@ schema::schema(const schema& o, const std::function<void(schema&)>& transform)
         }
     }
 
-    o.registry()->pair_with_entry(*this);
+    o.registry().pair_with_entry(*this);
 }
 
 schema::schema(const schema& o)
@@ -482,16 +482,13 @@ schema::~schema() {
     }
 }
 
-schema_registry_entry*
+schema_registry_entry&
 schema::registry_entry() const noexcept {
-    return _registry_entry;
+    return *_registry_entry;
 }
 
-schema_registry* schema::registry() const noexcept {
-    if (!_registry_entry) {
-        return nullptr;
-    }
-    return &_registry_entry->registry();
+schema_registry& schema::registry() const noexcept {
+    return _registry_entry->registry();
 }
 
 sstring schema::thrift_key_validator() const {
@@ -965,7 +962,7 @@ schema_builder::schema_builder(schema_registry& registry, std::string_view ks_na
 }
 
 schema_builder::schema_builder(const schema_ptr s)
-    : schema_builder(*s->registry(), s->_raw)
+    : schema_builder(s->registry(), s->_raw)
 {
     if (s->is_view()) {
         _view_info = s->view_info()->raw();

--- a/schema.hh
+++ b/schema.hh
@@ -706,7 +706,7 @@ private:
     schema(const schema&, const std::function<void(schema&)>&);
     class private_tag{};
 public:
-    schema(private_tag, schema_registry* registry, const raw_schema&, std::optional<raw_view_info>);
+    schema(private_tag, schema_registry& registry, const raw_schema&, std::optional<raw_view_info>);
     schema(const schema&);
     // See \ref make_reversed().
     schema(reversed_tag, const schema&);

--- a/schema.hh
+++ b/schema.hh
@@ -132,6 +132,7 @@ private:
 using table_schema_version = utils::UUID;
 
 class schema;
+class schema_registry;
 class schema_registry_entry;
 class schema_builder;
 
@@ -963,6 +964,8 @@ public:
     friend class schema_registry_entry;
     // May be called from different shard
     schema_registry_entry* registry_entry() const noexcept;
+    // Null when registry_entry() is null
+    schema_registry* registry() const noexcept;
     // Returns true iff this schema version was synced with on current node.
     // Schema version is said to be synced with when its mutations were merged
     // into current node's schema, so that current node's schema is at least as

--- a/schema.hh
+++ b/schema.hh
@@ -987,19 +987,6 @@ public:
     // different C++ objects).
     // The schema's version is also reversed using UUID_gen::negate().
     schema_ptr make_reversed() const;
-
-    // Get the reversed counterpart of this schema from the schema registry.
-    //
-    // If not present in the registry, create one (via \ref make_reversed()) and
-    // load it. Unlike \ref make_reversed(), this method guarantees that double
-    // reversing will return the very same C++ object:
-    //
-    //      auto schema = make_schema();
-    //      auto reverse_schema = schema->get_reversed();
-    //      assert(reverse_schema->get_reversed().get() == schema.get());
-    //      assert(schema->get_reversed().get() == reverse_schema.get());
-    //
-    schema_ptr get_reversed() const;
 };
 
 lw_shared_ptr<const schema> make_shared_schema(std::optional<utils::UUID> id, std::string_view ks_name, std::string_view cf_name,

--- a/schema.hh
+++ b/schema.hh
@@ -963,9 +963,8 @@ public:
     const column_mapping& get_column_mapping() const;
     friend class schema_registry_entry;
     // May be called from different shard
-    schema_registry_entry* registry_entry() const noexcept;
-    // Null when registry_entry() is null
-    schema_registry* registry() const noexcept;
+    schema_registry_entry& registry_entry() const noexcept;
+    schema_registry& registry() const noexcept;
     // Returns true iff this schema version was synced with on current node.
     // Schema version is said to be synced with when its mutations were merged
     // into current node's schema, so that current node's schema is at least as

--- a/schema.hh
+++ b/schema.hh
@@ -992,6 +992,10 @@ public:
     schema_ptr make_reversed() const;
 };
 
+lw_shared_ptr<const schema> make_shared_schema(schema_registry& registry, std::optional<utils::UUID> id, std::string_view ks_name, std::string_view cf_name,
+    std::vector<schema::column> partition_key, std::vector<schema::column> clustering_key, std::vector<schema::column> regular_columns,
+    std::vector<schema::column> static_columns, data_type regular_column_name_type, sstring comment = "");
+
 lw_shared_ptr<const schema> make_shared_schema(std::optional<utils::UUID> id, std::string_view ks_name, std::string_view cf_name,
     std::vector<schema::column> partition_key, std::vector<schema::column> clustering_key, std::vector<schema::column> regular_columns,
     std::vector<schema::column> static_columns, data_type regular_column_name_type, sstring comment = "");

--- a/schema.hh
+++ b/schema.hh
@@ -706,7 +706,7 @@ private:
     schema(const schema&, const std::function<void(schema&)>&);
     class private_tag{};
 public:
-    schema(private_tag, const raw_schema&, std::optional<raw_view_info>);
+    schema(private_tag, schema_registry* registry, const raw_schema&, std::optional<raw_view_info>);
     schema(const schema&);
     // See \ref make_reversed().
     schema(reversed_tag, const schema&);

--- a/schema.hh
+++ b/schema.hh
@@ -996,10 +996,6 @@ lw_shared_ptr<const schema> make_shared_schema(schema_registry& registry, std::o
     std::vector<schema::column> partition_key, std::vector<schema::column> clustering_key, std::vector<schema::column> regular_columns,
     std::vector<schema::column> static_columns, data_type regular_column_name_type, sstring comment = "");
 
-lw_shared_ptr<const schema> make_shared_schema(std::optional<utils::UUID> id, std::string_view ks_name, std::string_view cf_name,
-    std::vector<schema::column> partition_key, std::vector<schema::column> clustering_key, std::vector<schema::column> regular_columns,
-    std::vector<schema::column> static_columns, data_type regular_column_name_type, sstring comment = "");
-
 bool operator==(const schema&, const schema&);
 
 /**

--- a/schema_builder.hh
+++ b/schema_builder.hh
@@ -26,19 +26,50 @@
 #include "cdc/log.hh"
 #include "dht/i_partitioner.hh"
 
+class schema_registry;
+
 struct schema_builder {
 public:
     enum class compact_storage { no, yes };
 private:
+    schema_registry* _registry = nullptr;
     schema::raw_schema _raw;
     std::optional<compact_storage> _compact_storage;
     std::optional<table_schema_version> _version;
     std::optional<raw_view_info> _view_info;
-    schema_builder(const schema::raw_schema&);
+    schema_builder(schema_registry*, const schema::raw_schema&);
 public:
+    schema_builder(schema_registry* registry, std::string_view ks_name, std::string_view cf_name,
+            std::optional<utils::UUID> = { },
+            data_type regular_column_name_type = utf8_type);
+    schema_builder(schema_registry& registry, std::string_view ks_name, std::string_view cf_name,
+            std::optional<utils::UUID> = { },
+            data_type regular_column_name_type = utf8_type);
     schema_builder(std::string_view ks_name, std::string_view cf_name,
             std::optional<utils::UUID> = { },
             data_type regular_column_name_type = utf8_type);
+    schema_builder(
+            schema_registry* registry,
+            std::optional<utils::UUID> id,
+            std::string_view ks_name,
+            std::string_view cf_name,
+            std::vector<schema::column> partition_key,
+            std::vector<schema::column> clustering_key,
+            std::vector<schema::column> regular_columns,
+            std::vector<schema::column> static_columns,
+            data_type regular_column_name_type,
+            sstring comment = "");
+    schema_builder(
+            schema_registry& registry,
+            std::optional<utils::UUID> id,
+            std::string_view ks_name,
+            std::string_view cf_name,
+            std::vector<schema::column> partition_key,
+            std::vector<schema::column> clustering_key,
+            std::vector<schema::column> regular_columns,
+            std::vector<schema::column> static_columns,
+            data_type regular_column_name_type,
+            sstring comment = "");
     schema_builder(
             std::optional<utils::UUID> id,
             std::string_view ks_name,

--- a/schema_builder.hh
+++ b/schema_builder.hh
@@ -32,45 +32,18 @@ struct schema_builder {
 public:
     enum class compact_storage { no, yes };
 private:
-    schema_registry* _registry = nullptr;
+    schema_registry& _registry;
     schema::raw_schema _raw;
     std::optional<compact_storage> _compact_storage;
     std::optional<table_schema_version> _version;
     std::optional<raw_view_info> _view_info;
-    schema_builder(schema_registry*, const schema::raw_schema&);
+    schema_builder(schema_registry&, const schema::raw_schema&);
 public:
-    schema_builder(schema_registry* registry, std::string_view ks_name, std::string_view cf_name,
-            std::optional<utils::UUID> = { },
-            data_type regular_column_name_type = utf8_type);
     schema_builder(schema_registry& registry, std::string_view ks_name, std::string_view cf_name,
             std::optional<utils::UUID> = { },
             data_type regular_column_name_type = utf8_type);
-    schema_builder(std::string_view ks_name, std::string_view cf_name,
-            std::optional<utils::UUID> = { },
-            data_type regular_column_name_type = utf8_type);
-    schema_builder(
-            schema_registry* registry,
-            std::optional<utils::UUID> id,
-            std::string_view ks_name,
-            std::string_view cf_name,
-            std::vector<schema::column> partition_key,
-            std::vector<schema::column> clustering_key,
-            std::vector<schema::column> regular_columns,
-            std::vector<schema::column> static_columns,
-            data_type regular_column_name_type,
-            sstring comment = "");
     schema_builder(
             schema_registry& registry,
-            std::optional<utils::UUID> id,
-            std::string_view ks_name,
-            std::string_view cf_name,
-            std::vector<schema::column> partition_key,
-            std::vector<schema::column> clustering_key,
-            std::vector<schema::column> regular_columns,
-            std::vector<schema::column> static_columns,
-            data_type regular_column_name_type,
-            sstring comment = "");
-    schema_builder(
             std::optional<utils::UUID> id,
             std::string_view ks_name,
             std::string_view cf_name,

--- a/schema_mutations.cc
+++ b/schema_mutations.cc
@@ -25,21 +25,34 @@
 #include "hashers.hh"
 #include "utils/UUID_gen.hh"
 
-schema_mutations::schema_mutations(canonical_mutation columnfamilies,
-                                   canonical_mutation columns,
-                                   bool is_view,
-                                   std::optional<canonical_mutation> indices,
-                                   std::optional<canonical_mutation> dropped_columns,
-                                   std::optional<canonical_mutation> scylla_tables,
-                                   std::optional<canonical_mutation> view_virtual_columns,
-                                   std::optional<canonical_mutation> computed_columns)
-    : _columnfamilies(columnfamilies.to_mutation(is_view ? db::schema_tables::views() : db::schema_tables::tables()))
-    , _columns(columns.to_mutation(db::schema_tables::columns()))
-    , _view_virtual_columns(view_virtual_columns ? mutation_opt{view_virtual_columns.value().to_mutation(db::schema_tables::view_virtual_columns())} : std::nullopt)
-    , _computed_columns(computed_columns ? mutation_opt{computed_columns.value().to_mutation(db::schema_tables::computed_columns())} : std::nullopt)
-    , _indices(indices ? mutation_opt{indices.value().to_mutation(db::schema_tables::indexes())} : std::nullopt)
-    , _dropped_columns(dropped_columns ? mutation_opt{dropped_columns.value().to_mutation(db::schema_tables::dropped_columns())} : std::nullopt)
-    , _scylla_tables(scylla_tables ? mutation_opt{scylla_tables.value().to_mutation(db::schema_tables::scylla_tables())} : std::nullopt)
+
+frozen_schema_mutations::frozen_schema_mutations(const schema_mutations& sm) : columnfamilies(sm.columnfamilies_mutation()) , columns(sm.columns_mutation()), is_view(sm.is_view())
+{
+    if (sm.view_virtual_columns_mutation()) {
+        view_virtual_columns.emplace(*sm.view_virtual_columns_mutation());
+    }
+    if (sm.computed_columns_mutation()) {
+        computed_columns.emplace(*sm.computed_columns_mutation());
+    }
+    if (sm.indices_mutation()) {
+        indices.emplace(*sm.indices_mutation());
+    }
+    if (sm.dropped_columns_mutation()) {
+        dropped_columns.emplace(*sm.dropped_columns_mutation());
+    }
+    if (sm.scylla_tables()) {
+        scylla_tables.emplace(*sm.scylla_tables());
+    }
+}
+
+schema_mutations::schema_mutations(frozen_schema_mutations fsm)
+    : _columnfamilies(fsm.columnfamilies.to_mutation(fsm.is_view ? db::schema_tables::views() : db::schema_tables::tables()))
+    , _columns(fsm.columns.to_mutation(db::schema_tables::columns()))
+    , _view_virtual_columns(fsm.view_virtual_columns ? mutation_opt{fsm.view_virtual_columns.value().to_mutation(db::schema_tables::view_virtual_columns())} : std::nullopt)
+    , _computed_columns(fsm.computed_columns ? mutation_opt{fsm.computed_columns.value().to_mutation(db::schema_tables::computed_columns())} : std::nullopt)
+    , _indices(fsm.indices ? mutation_opt{fsm.indices.value().to_mutation(db::schema_tables::indexes())} : std::nullopt)
+    , _dropped_columns(fsm.dropped_columns ? mutation_opt{fsm.dropped_columns.value().to_mutation(db::schema_tables::dropped_columns())} : std::nullopt)
+    , _scylla_tables(fsm.scylla_tables ? mutation_opt{fsm.scylla_tables.value().to_mutation(db::schema_tables::scylla_tables())} : std::nullopt)
 {}
 
 void schema_mutations::copy_to(std::vector<mutation>& dst) const {

--- a/schema_mutations.cc
+++ b/schema_mutations.cc
@@ -45,14 +45,14 @@ frozen_schema_mutations::frozen_schema_mutations(const schema_mutations& sm) : c
     }
 }
 
-schema_mutations::schema_mutations(frozen_schema_mutations fsm)
-    : _columnfamilies(fsm.columnfamilies.to_mutation(fsm.is_view ? db::schema_tables::views() : db::schema_tables::tables()))
-    , _columns(fsm.columns.to_mutation(db::schema_tables::columns()))
-    , _view_virtual_columns(fsm.view_virtual_columns ? mutation_opt{fsm.view_virtual_columns.value().to_mutation(db::schema_tables::view_virtual_columns())} : std::nullopt)
-    , _computed_columns(fsm.computed_columns ? mutation_opt{fsm.computed_columns.value().to_mutation(db::schema_tables::computed_columns())} : std::nullopt)
-    , _indices(fsm.indices ? mutation_opt{fsm.indices.value().to_mutation(db::schema_tables::indexes())} : std::nullopt)
-    , _dropped_columns(fsm.dropped_columns ? mutation_opt{fsm.dropped_columns.value().to_mutation(db::schema_tables::dropped_columns())} : std::nullopt)
-    , _scylla_tables(fsm.scylla_tables ? mutation_opt{fsm.scylla_tables.value().to_mutation(db::schema_tables::scylla_tables())} : std::nullopt)
+schema_mutations::schema_mutations(schema_registry& registry, frozen_schema_mutations fsm)
+    : _columnfamilies(fsm.columnfamilies.to_mutation(fsm.is_view ? db::schema_tables::views(registry) : db::schema_tables::tables(registry)))
+    , _columns(fsm.columns.to_mutation(db::schema_tables::columns(registry)))
+    , _view_virtual_columns(fsm.view_virtual_columns ? mutation_opt{fsm.view_virtual_columns.value().to_mutation(db::schema_tables::view_virtual_columns(registry))} : std::nullopt)
+    , _computed_columns(fsm.computed_columns ? mutation_opt{fsm.computed_columns.value().to_mutation(db::schema_tables::computed_columns(registry))} : std::nullopt)
+    , _indices(fsm.indices ? mutation_opt{fsm.indices.value().to_mutation(db::schema_tables::indexes(registry))} : std::nullopt)
+    , _dropped_columns(fsm.dropped_columns ? mutation_opt{fsm.dropped_columns.value().to_mutation(db::schema_tables::dropped_columns(registry))} : std::nullopt)
+    , _scylla_tables(fsm.scylla_tables ? mutation_opt{fsm.scylla_tables.value().to_mutation(db::schema_tables::scylla_tables(registry))} : std::nullopt)
 {}
 
 void schema_mutations::copy_to(std::vector<mutation>& dst) const {

--- a/schema_mutations.cc
+++ b/schema_mutations.cc
@@ -162,7 +162,7 @@ bool schema_mutations::live() const {
 }
 
 bool schema_mutations::is_view() const {
-    return _columnfamilies.schema() == db::schema_tables::views();
+    return _columnfamilies.schema()->id() == db::schema_tables::views_id();
 }
 
 std::ostream& operator<<(std::ostream& out, const schema_mutations& sm) {

--- a/schema_mutations.hh
+++ b/schema_mutations.hh
@@ -26,6 +26,39 @@
 #include "schema_fwd.hh"
 #include "canonical_mutation.hh"
 
+class schema_mutations;
+
+struct frozen_schema_mutations {
+    canonical_mutation columnfamilies;
+    canonical_mutation columns;
+    bool is_view;
+    std::optional<canonical_mutation> view_virtual_columns;
+    std::optional<canonical_mutation> computed_columns;
+    std::optional<canonical_mutation> indices;
+    std::optional<canonical_mutation> dropped_columns;
+    std::optional<canonical_mutation> scylla_tables;
+
+    frozen_schema_mutations(
+            canonical_mutation columnfamilies,
+            canonical_mutation columns,
+            bool is_view,
+            std::optional<canonical_mutation> indices,
+            std::optional<canonical_mutation> dropped_columns,
+            std::optional<canonical_mutation> scylla_tables,
+            std::optional<canonical_mutation> view_virtual_columns,
+            std::optional<canonical_mutation> computed_columns)
+        : columnfamilies(std::move(columnfamilies))
+        , columns(std::move(columns))
+        , is_view(is_view)
+        , view_virtual_columns(std::move(view_virtual_columns))
+        , computed_columns(std::move(computed_columns))
+        , indices(std::move(indices))
+        , dropped_columns(std::move(dropped_columns))
+        , scylla_tables(std::move(scylla_tables))
+    { }
+    frozen_schema_mutations(const schema_mutations& sm);
+};
+
 // Commutative representation of table schema
 // Equality ignores tombstones.
 class schema_mutations {
@@ -47,14 +80,7 @@ public:
             , _dropped_columns(std::move(dropped_columns))
             , _scylla_tables(std::move(scylla_tables))
     { }
-    schema_mutations(canonical_mutation columnfamilies,
-                     canonical_mutation columns,
-                     bool is_view,
-                     std::optional<canonical_mutation> indices,
-                     std::optional<canonical_mutation> dropped_columns,
-                     std::optional<canonical_mutation> scylla_tables,
-                     std::optional<canonical_mutation> view_virtual_columns,
-                     std::optional<canonical_mutation> computed_columns);
+    explicit schema_mutations(frozen_schema_mutations);
 
     schema_mutations(schema_mutations&&) = default;
     schema_mutations& operator=(schema_mutations&&) = default;

--- a/schema_mutations.hh
+++ b/schema_mutations.hh
@@ -80,7 +80,7 @@ public:
             , _dropped_columns(std::move(dropped_columns))
             , _scylla_tables(std::move(scylla_tables))
     { }
-    explicit schema_mutations(frozen_schema_mutations);
+    schema_mutations(schema_registry& registry, frozen_schema_mutations);
 
     schema_mutations(schema_mutations&&) = default;
     schema_mutations& operator=(schema_mutations&&) = default;

--- a/schema_registry.cc
+++ b/schema_registry.cc
@@ -29,8 +29,6 @@
 
 static logging::logger slogger("schema_registry");
 
-static thread_local schema_registry* registry = nullptr;
-
 schema_version_not_found::schema_version_not_found(table_schema_version v)
         : std::runtime_error{format("Schema version {} not found", v)}
 { }
@@ -314,15 +312,6 @@ void schema_registry_entry::mark_synced() {
     }
     _sync_state = sync_state::SYNCED;
     slogger.debug("Marked {} as synced", _version);
-}
-
-
-void set_local_schema_registry(schema_registry& sr) {
-    registry = &sr;
-}
-
-schema_registry& local_schema_registry() {
-    return *registry;
 }
 
 global_schema_ptr::global_schema_ptr(const global_schema_ptr& o)

--- a/schema_registry.cc
+++ b/schema_registry.cc
@@ -102,10 +102,6 @@ schema_ptr schema_registry::get(table_schema_version v) const {
     return get_entry(v).get_schema();
 }
 
-frozen_schema schema_registry::get_frozen(table_schema_version v) const {
-    return get_entry(v).frozen();
-}
-
 future<schema_ptr> schema_registry::get_or_load(table_schema_version v, const async_schema_loader& loader) {
     auto i = _entries.find(v);
     if (i == _entries.end()) {

--- a/schema_registry.cc
+++ b/schema_registry.cc
@@ -330,20 +330,20 @@ schema_ptr global_schema_ptr::get() const {
         // object originated so as long as this object lives the registry entries lives too
         // and it is safe to reference them on foreign shards.
         if (_base_schema) {
-            registered_bs = registered_schema(*_base_schema->registry_entry());
-            if (_base_schema->registry_entry()->is_synced()) {
-                registered_bs->registry_entry()->mark_synced();
+            registered_bs = registered_schema(_base_schema->registry_entry());
+            if (_base_schema->registry_entry().is_synced()) {
+                registered_bs->registry_entry().mark_synced();
             }
         }
-        schema_ptr s = registered_schema(*_ptr->registry_entry());
+        schema_ptr s = registered_schema(_ptr->registry_entry());
         if (s->is_view()) {
             if (!s->view_info()->base_info()) {
                 // we know that registered_bs is valid here because we make sure of it in the constructors.
                 s->view_info()->set_base_info(s->view_info()->make_base_dependent_view_info(*registered_bs));
             }
         }
-        if (_ptr->registry_entry()->is_synced()) {
-            s->registry_entry()->mark_synced();
+        if (_ptr->registry_entry().is_synced()) {
+            s->registry_entry().mark_synced();
         }
         return s;
     }
@@ -352,11 +352,11 @@ schema_ptr global_schema_ptr::get() const {
 global_schema_ptr::global_schema_ptr(const schema_ptr& ptr)
         : _ptr(ptr)
         , _cpu_of_origin(this_shard_id()) {
-    _ptr->registry_entry()->ensure_frozen();
+    _ptr->registry_entry().ensure_frozen();
     if (_ptr->is_view()) {
         if (_ptr->view_info()->base_info()) {
             _base_schema = _ptr->view_info()->base_info()->base_schema();
-            _base_schema->registry_entry()->ensure_frozen();
+            _base_schema->registry_entry().ensure_frozen();
         } else {
             on_internal_error(slogger, format("Tried to build a global schema for view {}.{} with an uninitialized base info", _ptr->ks_name(), _ptr->cf_name()));
         }

--- a/schema_registry.cc
+++ b/schema_registry.cc
@@ -379,36 +379,15 @@ schema_ptr global_schema_ptr::get() const {
 }
 
 global_schema_ptr::global_schema_ptr(const schema_ptr& ptr)
-        : _cpu_of_origin(this_shard_id()) {
-    // _ptr must always have an associated registry entry,
-    // if ptr doesn't, we need to load it into the registry.
-    auto ensure_registry_entry = [] (const schema_ptr& s) {
-        schema_registry_entry* e = s->registry_entry();
-        if (e) {
-            e->ensure_frozen();
-            return s;
+        : _ptr(ptr)
+        , _cpu_of_origin(this_shard_id()) {
+    _ptr->registry_entry()->ensure_frozen();
+    if (_ptr->is_view()) {
+        if (_ptr->view_info()->base_info()) {
+            _base_schema = _ptr->view_info()->base_info()->base_schema();
+            _base_schema->registry_entry()->ensure_frozen();
         } else {
-            auto loaded_s = local_schema_registry().get_or_load(s->version(), [&s] (table_schema_version) {
-                return frozen_schema(s);
-            });
-            loaded_s->registry_entry()->ensure_frozen();
-            return loaded_s;
-        }
-    };
-
-    schema_ptr s = ensure_registry_entry(ptr);
-    if (s->is_view()) {
-        if (s->view_info()->base_info()) {
-            _base_schema = ensure_registry_entry(s->view_info()->base_info()->base_schema());
-        } else if (ptr->view_info()->base_info()) {
-            _base_schema = ensure_registry_entry(ptr->view_info()->base_info()->base_schema());
-        } else {
-            on_internal_error(slogger, format("Tried to build a global schema for view {}.{} with an uninitialized base info", s->ks_name(), s->cf_name()));
-        }
-
-        if (!s->view_info()->base_info() || !s->view_info()->base_info()->base_schema()->registry_entry()) {
-            s->view_info()->set_base_info(s->view_info()->make_base_dependent_view_info(*_base_schema));
+            on_internal_error(slogger, format("Tried to build a global schema for view {}.{} with an uninitialized base info", _ptr->ks_name(), _ptr->cf_name()));
         }
     }
-    _ptr = s;
 }

--- a/schema_registry.cc
+++ b/schema_registry.cc
@@ -29,7 +29,7 @@
 
 static logging::logger slogger("schema_registry");
 
-static thread_local schema_registry registry;
+static thread_local schema_registry* registry = nullptr;
 
 schema_version_not_found::schema_version_not_found(table_schema_version v)
         : std::runtime_error{format("Schema version {} not found", v)}
@@ -316,8 +316,13 @@ void schema_registry_entry::mark_synced() {
     slogger.debug("Marked {} as synced", _version);
 }
 
+
+void set_local_schema_registry(schema_registry& sr) {
+    registry = &sr;
+}
+
 schema_registry& local_schema_registry() {
-    return registry;
+    return *registry;
 }
 
 global_schema_ptr::global_schema_ptr(const global_schema_ptr& o)

--- a/schema_registry.cc
+++ b/schema_registry.cc
@@ -75,12 +75,9 @@ schema_registry_entry::schema_registry_entry(table_schema_version v, schema_regi
     });
 }
 
-schema_registry::schema_registry() = default;
+schema_registry::schema_registry(const db::schema_ctxt& ctxt) : _ctxt(std::make_unique<db::schema_ctxt>(ctxt)) { }
+schema_registry::schema_registry(const db::config& cfg) : schema_registry(db::schema_ctxt(cfg)) { }
 schema_registry::~schema_registry() = default;
-
-void schema_registry::init(const db::schema_ctxt& ctxt) {
-    _ctxt = std::make_unique<db::schema_ctxt>(ctxt);
-}
 
 schema_ptr schema_registry::learn(const schema_ptr& s) {
     if (s->registry_entry()) {

--- a/schema_registry.cc
+++ b/schema_registry.cc
@@ -193,9 +193,7 @@ schema_ptr schema_registry_entry::do_load(schema_factory factory) {
 
 schema_ptr schema_registry_entry::load(frozen_schema fs) {
     return do_load([this, fs = std::move(fs)] {
-        auto s = fs.unfreeze(*_registry._ctxt);
-        pair_with(*s);
-        return s;
+        return fs.unfreeze(_registry);
     });
 }
 

--- a/schema_registry.cc
+++ b/schema_registry.cc
@@ -79,21 +79,6 @@ schema_registry::schema_registry(const db::schema_ctxt& ctxt) : _ctxt(std::make_
 schema_registry::schema_registry(const db::config& cfg) : schema_registry(db::schema_ctxt(cfg)) { }
 schema_registry::~schema_registry() = default;
 
-schema_ptr schema_registry::learn(const schema_ptr& s) {
-    if (s->registry_entry()) {
-        return std::move(s);
-    }
-    auto i = _entries.find(s->version());
-    if (i != _entries.end()) {
-        return i->second->get_schema();
-    }
-    slogger.debug("Learning about version {} of {}.{}", s->version(), s->ks_name(), s->cf_name());
-    auto e_ptr = make_lw_shared<schema_registry_entry>(s->version(), *this);
-    auto loaded_s = e_ptr->load(frozen_schema(s));
-    _entries.emplace(s->version(), e_ptr);
-    return loaded_s;
-}
-
 schema_registry_entry& schema_registry::get_entry(table_schema_version v) const {
     auto i = _entries.find(v);
     if (i == _entries.end()) {

--- a/schema_registry.cc
+++ b/schema_registry.cc
@@ -77,6 +77,7 @@ schema_registry_entry::schema_registry_entry(table_schema_version v, schema_regi
     });
 }
 
+schema_registry::schema_registry() = default;
 schema_registry::~schema_registry() = default;
 
 void schema_registry::init(const db::schema_ctxt& ctxt) {

--- a/schema_registry.cc
+++ b/schema_registry.cc
@@ -20,6 +20,7 @@
  */
 
 #include <seastar/core/sharded.hh>
+#include <seastar/core/reactor.hh>
 
 #include "schema_registry.hh"
 #include "log.hh"
@@ -253,7 +254,10 @@ void schema_registry_entry::detach_schema(const schema& s) noexcept {
         return;
     }
     slogger.trace("Deactivating {}", _version);
-    _erase_timer.arm(_registry.grace_period());
+    // Some tests that use schemas don't start a reactor
+    if (engine_is_ready()) [[likely]] {
+        _erase_timer.arm(_registry.grace_period());
+    }
 }
 
 void schema_registry_entry::ensure_frozen() {

--- a/schema_registry.cc
+++ b/schema_registry.cc
@@ -342,9 +342,10 @@ schema_ptr global_schema_ptr::get() const {
         return _ptr;
     } else {
         auto registered_schema = [](const schema_registry_entry& e) {
-            schema_ptr ret = local_schema_registry().get_or_null(e.version());
+            auto& local_registry = e.registry().container().local();
+            schema_ptr ret = local_registry.get_or_null(e.version());
             if (!ret) {
-                ret = local_schema_registry().get_or_load(e.version(), [&e](table_schema_version) {
+                ret = local_registry.get_or_load(e.version(), [&e](table_schema_version) {
                     return e.frozen();
                 });
             }

--- a/schema_registry.hh
+++ b/schema_registry.hh
@@ -75,7 +75,7 @@ class schema_registry_entry : public enable_lw_shared_from_this<schema_registry_
     std::optional<frozen_schema> _frozen_schema; // engaged when state == LOADED
     // valid when state == LOADED
     // This is != nullptr when there is an alive schema_ptr associated with this entry.
-    const ::schema* _schema = nullptr;
+    std::vector<const ::schema*> _schemas;
 
     enum class sync_state { NOT_SYNCED, SYNCING, SYNCED };
     sync_state _sync_state;
@@ -104,7 +104,7 @@ public:
     table_schema_version version() const { return _version; }
 public:
     // Called by class schema
-    void detach_schema() noexcept;
+    void detach_schema(const schema& s) noexcept;
 };
 
 //

--- a/schema_registry.hh
+++ b/schema_registry.hh
@@ -89,6 +89,7 @@ public:
     schema_registry_entry(const schema_registry_entry&) = delete;
     ~schema_registry_entry();
     schema_ptr load(frozen_schema);
+    schema_registry& registry() const { return _registry; }
     future<schema_ptr> start_loading(async_schema_loader);
     schema_ptr get_schema(); // call only when state >= LOADED
     // Can be called from other shards

--- a/schema_registry.hh
+++ b/schema_registry.hh
@@ -173,9 +173,6 @@ public:
     schema_ptr learn(const schema_ptr&);
 };
 
-void set_local_schema_registry(schema_registry&);
-schema_registry& local_schema_registry();
-
 // Schema pointer which can be safely accessed/passed across shards via
 // const&. Useful for ensuring that schema version obtained on one shard is
 // automatically propagated to other shards, no matter how long the processing

--- a/schema_registry.hh
+++ b/schema_registry.hh
@@ -163,14 +163,6 @@ public:
     // Looks up schema version. Throws schema_version_not_found when not found
     // or loading is in progress.
     schema_ptr get(table_schema_version) const;
-
-    // Attempts to add given schema to the registry. If the registry already
-    // knows about the schema, returns existing entry, otherwise returns back
-    // the schema which was passed as argument. Users should prefer to use the
-    // schema_ptr returned by this method instead of the one passed to it,
-    // because doing so ensures that the entry will be kept in the registry as
-    // long as the schema is actively used.
-    schema_ptr learn(const schema_ptr&);
 };
 
 // Schema pointer which can be safely accessed/passed across shards via

--- a/schema_registry.hh
+++ b/schema_registry.hh
@@ -123,7 +123,7 @@ public:
 // alive the registry will keep its entry. To ensure remote nodes can query current node
 // for schema version, make sure that schema_ptr for the request is alive around the call.
 //
-class schema_registry {
+class schema_registry : public peering_sharded_service<schema_registry> {
     std::unordered_map<table_schema_version, lw_shared_ptr<schema_registry_entry>> _entries;
     std::unique_ptr<db::schema_ctxt> _ctxt;
 
@@ -173,6 +173,7 @@ public:
     schema_ptr learn(const schema_ptr&);
 };
 
+void set_local_schema_registry(schema_registry&);
 schema_registry& local_schema_registry();
 
 // Schema pointer which can be safely accessed/passed across shards via

--- a/schema_registry.hh
+++ b/schema_registry.hh
@@ -86,6 +86,7 @@ class schema_registry_entry : public enable_lw_shared_from_this<schema_registry_
 
     friend class schema_registry;
 private:
+    void pair_with(const schema& s);
     schema_ptr do_load(schema_factory factory);
 public:
     schema_registry_entry(table_schema_version v, schema_registry& r);
@@ -125,7 +126,9 @@ class schema_registry {
     std::unique_ptr<db::schema_ctxt> _ctxt;
 
     friend class schema_registry_entry;
+    friend class schema;
     schema_registry_entry& get_entry(table_schema_version) const;
+    void pair_with_entry(const schema& s);
     // Duration for which unused entries are kept alive to avoid
     // too frequent re-requests and syncs. Default is 1 second.
     schema_registry_entry::erase_clock::duration grace_period() const;

--- a/schema_registry.hh
+++ b/schema_registry.hh
@@ -29,6 +29,7 @@
 #include "frozen_schema.hh"
 
 namespace db {
+class config;
 class schema_ctxt;
 }
 
@@ -138,10 +139,9 @@ class schema_registry : public peering_sharded_service<schema_registry> {
     schema_ptr get_or_load(table_schema_version, std::function<schema_ptr(schema_registry_entry&)> loader);
 
 public:
-    schema_registry();
+    explicit schema_registry(const db::schema_ctxt&);
+    explicit schema_registry(const db::config&);
     ~schema_registry();
-    // workaround to this object being magically appearing from nowhere.
-    void init(const db::schema_ctxt&);
 
     db::schema_ctxt& get_context() { return *_ctxt; }
 

--- a/schema_registry.hh
+++ b/schema_registry.hh
@@ -138,6 +138,7 @@ class schema_registry {
     schema_ptr get_or_load(table_schema_version, std::function<schema_ptr(schema_registry_entry&)> loader);
 
 public:
+    schema_registry();
     ~schema_registry();
     // workaround to this object being magically appearing from nowhere.
     void init(const db::schema_ctxt&);

--- a/schema_registry.hh
+++ b/schema_registry.hh
@@ -142,6 +142,8 @@ public:
     // workaround to this object being magically appearing from nowhere.
     void init(const db::schema_ctxt&);
 
+    db::schema_ctxt& get_context() { return *_ctxt; }
+
     // Looks up schema by version or loads it using supplied loader.
     schema_ptr get_or_load(table_schema_version, const frozen_schema_loader&);
 

--- a/schema_registry.hh
+++ b/schema_registry.hh
@@ -145,10 +145,6 @@ public:
     // or loading is in progress.
     schema_ptr get(table_schema_version) const;
 
-    // Looks up schema version. Throws schema_version_not_found when not found
-    // or loading is in progress.
-    frozen_schema get_frozen(table_schema_version) const;
-
     // Attempts to add given schema to the registry. If the registry already
     // knows about the schema, returns existing entry, otherwise returns back
     // the schema which was passed as argument. Users should prefer to use the

--- a/service/migration_manager.cc
+++ b/service/migration_manager.cc
@@ -159,7 +159,7 @@ void migration_manager::init_messaging_service()
         // FIXME: should this get an smp_service_group? Probably one separate from reads and writes.
         return container().invoke_on(shard, [v, &proxy] (auto&& sp) {
             mlogger.debug("Schema version request for {}", v);
-            return proxy.local_db().get_schema_registry().get_frozen(v);
+            return frozen_schema(proxy.local_db().get_schema_registry().get(v));
         });
     });
 }

--- a/service/migration_manager.cc
+++ b/service/migration_manager.cc
@@ -805,7 +805,7 @@ future<> migration_manager::announce_keyspace_drop(const sstring& ks_name)
     }
     auto& keyspace = db.find_keyspace(ks_name);
     mlogger.info("Drop Keyspace '{}'", ks_name);
-    auto&& mutations = db::schema_tables::make_drop_keyspace_mutations(keyspace.metadata(), api::new_timestamp());
+    auto&& mutations = db::schema_tables::make_drop_keyspace_mutations(db.get_schema_registry(), keyspace.metadata(), api::new_timestamp());
     return announce(std::move(mutations));
 }
 

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -4015,7 +4015,7 @@ storage_proxy::query_singular(lw_shared_ptr<query::read_command> cmd,
     utils::small_vector<std::pair<::shared_ptr<abstract_read_executor>, dht::token_range>, 1> exec;
     exec.reserve(partition_ranges.size());
 
-    schema_ptr schema = local_schema_registry().get(cmd->schema_version);
+    schema_ptr schema = _db.local().get_schema_registry().get(cmd->schema_version);
 
     db::read_repair_decision repair_decision = query_options.read_repair_decision
         ? *query_options.read_repair_decision : new_read_repair_decision(*schema);
@@ -4097,7 +4097,7 @@ storage_proxy::query_partition_key_range_concurrent(storage_proxy::clock_type::t
         uint32_t remaining_partition_count,
         replicas_per_token_range preferred_replicas,
         service_permit permit) {
-    schema_ptr schema = local_schema_registry().get(cmd->schema_version);
+    schema_ptr schema = _db.local().get_schema_registry().get(cmd->schema_version);
     keyspace& ks = _db.local().find_keyspace(schema->ks_name());
     std::vector<::shared_ptr<abstract_read_executor>> exec;
     auto p = shared_from_this();
@@ -4266,7 +4266,7 @@ storage_proxy::query_partition_key_range(lw_shared_ptr<query::read_command> cmd,
         dht::partition_range_vector partition_ranges,
         db::consistency_level cl,
         storage_proxy::coordinator_query_options query_options) {
-    schema_ptr schema = local_schema_registry().get(cmd->schema_version);
+    schema_ptr schema = _db.local().get_schema_registry().get(cmd->schema_version);
     keyspace& ks = _db.local().find_keyspace(schema->ks_name());
 
     // when dealing with LocalStrategy keyspaces, we can skip the range splitting and merging (which can be

--- a/test/boost/cache_flat_mutation_reader_test.cc
+++ b/test/boost/cache_flat_mutation_reader_test.cc
@@ -37,6 +37,7 @@
 #include "test/lib/mutation_assertions.hh"
 #include "test/lib/flat_mutation_reader_assertions.hh"
 #include "test/lib/reader_concurrency_semaphore.hh"
+#include "test/lib/schema_registry.hh"
 
 #include <variant>
 
@@ -46,8 +47,10 @@
  * ===================
  */
 
+static thread_local tests::schema_registry_wrapper registry;
+
 static schema_ptr make_schema() {
-    return schema_builder("ks", "cf")
+    return schema_builder(registry, "ks", "cf")
         .with_column("pk", int32_type, column_kind::partition_key)
         .with_column("ck", int32_type, column_kind::clustering_key)
         .with_column("v", int32_type)

--- a/test/boost/canonical_mutation_test.cc
+++ b/test/boost/canonical_mutation_test.cc
@@ -25,6 +25,7 @@
 #include "canonical_mutation.hh"
 #include "test/lib/mutation_source_test.hh"
 #include "test/lib/mutation_assertions.hh"
+#include "test/lib/schema_registry.hh"
 
 #include <seastar/testing/test_case.hh>
 
@@ -32,7 +33,8 @@
 
 SEASTAR_TEST_CASE(test_conversion_back_and_forth) {
     return seastar::async([] {
-        for_each_mutation([] (const mutation& m) {
+        tests::schema_registry_wrapper registry;
+        for_each_mutation(registry, [] (const mutation& m) {
             canonical_mutation cm(m);
             assert_that(cm.to_mutation(m.schema())).is_equal_to(m);
         });
@@ -41,7 +43,8 @@ SEASTAR_TEST_CASE(test_conversion_back_and_forth) {
 
 SEASTAR_TEST_CASE(test_reading_with_different_schemas) {
     return seastar::async([] {
-        for_each_mutation_pair([] (const mutation& m1, const mutation& m2, are_equal eq) {
+        tests::schema_registry_wrapper registry;
+        for_each_mutation_pair(registry, [] (const mutation& m1, const mutation& m2, are_equal eq) {
             if (m1.schema() == m2.schema()) {
                 return;
             }

--- a/test/boost/cdc_test.cc
+++ b/test/boost/cdc_test.cc
@@ -58,7 +58,7 @@ SEASTAR_THREAD_TEST_CASE(test_find_mutation_timestamp) {
         cquery_nofail(e, "CREATE TABLE ks.t (pk int, ck int, vstatic int static, vint int, "
                 "vmap map<int, int>, vfmap frozen<map<int, int>>, vut ut, vfut frozen<ut>, primary key (pk, ck))");
 
-        auto schema = schema_builder("ks", "t")
+        auto schema = schema_builder(e.local_db().get_schema_registry(), "ks", "t")
             .with_column("pk", int32_type, column_kind::partition_key)
             .with_column("vstatic", int32_type, column_kind::static_column)
             .with_column("ck", int32_type, column_kind::clustering_key)

--- a/test/boost/commitlog_test.cc
+++ b/test/boost/commitlog_test.cc
@@ -52,6 +52,7 @@
 #include "test/lib/data_model.hh"
 #include "test/lib/sstable_utils.hh"
 #include "test/lib/mutation_source_test.hh"
+#include "test/lib/schema_registry.hh"
 
 using namespace db;
 
@@ -664,6 +665,7 @@ using namespace std::chrono_literals;
 SEASTAR_TEST_CASE(test_commitlog_add_entries) {
     return cl_test([](commitlog& log) {
         return seastar::async([&] {
+            tests::schema_registry_wrapper registry;
             using force_sync = commitlog_entry_writer::force_sync;
 
             constexpr auto n = 10;
@@ -676,7 +678,7 @@ SEASTAR_TEST_CASE(test_commitlog_add_entries) {
                 mutations.reserve(n);
                 
                 for (auto i = 0; i < n; ++i) {
-                    random_mutation_generator gen(random_mutation_generator::generate_counters(false));
+                    random_mutation_generator gen(registry, random_mutation_generator::generate_counters(false));
                     mutations.emplace_back(gen(1).front());
                     writers.emplace_back(gen.schema(), mutations.back(), fs);
                 }

--- a/test/boost/compound_test.cc
+++ b/test/boost/compound_test.cc
@@ -28,6 +28,7 @@
 #include "test/boost/range_assert.hh"
 #include "schema_builder.hh"
 #include "dht/murmur3_partitioner.hh"
+#include "test/lib/schema_registry.hh"
 
 static std::vector<managed_bytes> to_bytes_vec(std::vector<sstring> values) {
     std::vector<managed_bytes> result;
@@ -195,11 +196,12 @@ SEASTAR_THREAD_TEST_CASE(test_conversion_to_legacy_form) {
 }
 
 SEASTAR_THREAD_TEST_CASE(test_conversion_to_legacy_form_same_token_singular) {
-    auto s = schema_builder("ks", "cf")
+    tests::schema_registry_wrapper registry;
+    auto s = schema_builder(registry, "ks", "cf")
                 .with_column("c", int32_type, column_kind::partition_key)
                 .with_column("v", int32_type)
                 .build();
-    auto s1 = schema_builder("ks", "cf")
+    auto s1 = schema_builder(registry, "ks", "cf")
                   .with_column("c", byte_type, column_kind::partition_key)
                   .with_column("v", int32_type)
                   .build();
@@ -216,12 +218,13 @@ SEASTAR_THREAD_TEST_CASE(test_conversion_to_legacy_form_same_token_singular) {
 }
 
 SEASTAR_THREAD_TEST_CASE(test_conversion_to_legacy_form_same_token_two_components) {
-    auto s = schema_builder("ks", "cf")
+    tests::schema_registry_wrapper registry;
+    auto s = schema_builder(registry, "ks", "cf")
                 .with_column("c1", int32_type, column_kind::partition_key)
                 .with_column("c2", int32_type, column_kind::partition_key)
                 .with_column("v", int32_type)
                 .build();
-    auto s1 = schema_builder("ks", "cf")
+    auto s1 = schema_builder(registry, "ks", "cf")
                   .with_column("c", byte_type, column_kind::partition_key)
                   .with_column("v", int32_type)
                   .build();
@@ -310,7 +313,8 @@ SEASTAR_THREAD_TEST_CASE(test_enconding_of_singular_composite) {
 SEASTAR_THREAD_TEST_CASE(test_enconding_of_static_composite) {
     using components = std::vector<composite::component>;
 
-    auto s = schema_builder("ks", "cf")
+    tests::schema_registry_wrapper registry;
+    auto s = schema_builder(registry, "ks", "cf")
         .with_column("pk", bytes_type, column_kind::partition_key)
         .with_column("ck", bytes_type, column_kind::clustering_key)
         .with_column("v", bytes_type, column_kind::regular_column)

--- a/test/boost/counter_test.cc
+++ b/test/boost/counter_test.cc
@@ -30,6 +30,7 @@
 
 #include <seastar/testing/test_case.hh>
 #include "test/lib/random_utils.hh"
+#include "test/lib/schema_registry.hh"
 #include "schema_builder.hh"
 #include "keys.hh"
 #include "mutation.hh"
@@ -160,8 +161,8 @@ SEASTAR_TEST_CASE(test_apply) {
     });
 }
 
-schema_ptr get_schema() {
-    return schema_builder("ks", "cf")
+schema_ptr get_schema(schema_registry& registry) {
+    return schema_builder(registry, "ks", "cf")
             .with_column("pk", int32_type, column_kind::partition_key)
             .with_column("ck", int32_type, column_kind::clustering_key)
             .with_column("s1", counter_type, column_kind::static_column)
@@ -196,7 +197,8 @@ atomic_cell_view get_static_counter_cell(mutation& m) {
 
 SEASTAR_TEST_CASE(test_counter_mutations) {
     return seastar::async([] {
-        auto s = get_schema();
+        tests::schema_registry_wrapper registry;
+        auto s = get_schema(registry);
 
         auto id = generate_ids(4);
 
@@ -357,7 +359,8 @@ SEASTAR_TEST_CASE(test_counter_mutations) {
 
 SEASTAR_TEST_CASE(test_counter_update_mutations) {
     return seastar::async([] {
-        auto s = get_schema();
+        tests::schema_registry_wrapper registry;
+        auto s = get_schema(registry);
 
         auto pk = partition_key::from_single_value(*s, int32_type->decompose(0));
         auto ck = clustering_key::from_single_value(*s, int32_type->decompose(0));
@@ -405,7 +408,8 @@ SEASTAR_TEST_CASE(test_counter_update_mutations) {
 
 SEASTAR_TEST_CASE(test_transfer_updates_to_shards) {
     return seastar::async([] {
-        auto s = get_schema();
+        tests::schema_registry_wrapper registry;
+        auto s = get_schema(registry);
 
         auto pk = partition_key::from_single_value(*s, int32_type->decompose(0));
         auto ck = clustering_key::from_single_value(*s, int32_type->decompose(0));

--- a/test/boost/cql_functions_test.cc
+++ b/test/boost/cql_functions_test.cc
@@ -46,9 +46,9 @@ using namespace std::literals::chrono_literals;
 
 SEASTAR_TEST_CASE(test_functions) {
     return do_with_cql_env([] (cql_test_env& e) {
-        return e.create_table([](std::string_view ks_name) {
+        return e.create_table([&e](std::string_view ks_name) {
             // CQL: create table cf (p1 varchar primary key, u uuid, tu timeuuid);
-            return *schema_builder(ks_name, "cf")
+            return *schema_builder(e.local_db().get_schema_registry(), ks_name, "cf")
                     .with_column("p1", utf8_type, column_kind::partition_key)
                     .with_column("c1", int32_type, column_kind::clustering_key)
                     .with_column("tu", timeuuid_type)
@@ -154,8 +154,8 @@ public:
         : _e(e), _column_type(column_type), _sorted_values{data_value(sorted_values)...}
     {
         const auto cf_name = table_name();
-        _e.create_table([column_type, cf_name] (std::string_view ks_name) {
-            return *schema_builder(ks_name, cf_name)
+        _e.create_table([this, column_type, cf_name] (std::string_view ks_name) {
+            return *schema_builder(_e.local_db().get_schema_registry(), ks_name, cf_name)
                     .with_column("pk", utf8_type, column_kind::partition_key)
                     .with_column("ck", int32_type, column_kind::clustering_key)
                     .with_column("value", column_type)

--- a/test/boost/cql_query_large_test.cc
+++ b/test/boost/cql_query_large_test.cc
@@ -145,9 +145,9 @@ SEASTAR_TEST_CASE(test_insert_large_collection_values) {
             auto map_type = map_type_impl::get_instance(utf8_type, utf8_type, true);
             auto set_type = set_type_impl::get_instance(utf8_type, true);
             auto list_type = list_type_impl::get_instance(utf8_type, true);
-            e.create_table([map_type, set_type, list_type] (std::string_view ks_name) {
+            e.create_table([&e, map_type, set_type, list_type] (std::string_view ks_name) {
                 // CQL: CREATE TABLE tbl (pk text PRIMARY KEY, m map<text, text>, s set<text>, l list<text>);
-                return *schema_builder(ks_name, "tbl")
+                return *schema_builder(e.local_db().get_schema_registry(), ks_name, "tbl")
                         .with_column("pk", utf8_type, column_kind::partition_key)
                         .with_column("m", map_type)
                         .with_column("s", set_type)

--- a/test/boost/gossip_test.cc
+++ b/test/boost/gossip_test.cc
@@ -119,9 +119,6 @@ SEASTAR_TEST_CASE(test_boot_shutdown){
 
         sharded<schema_registry> schema_registry;
         schema_registry.start().get();
-        schema_registry.invoke_on_all([] (::schema_registry& sr) {
-            ::set_local_schema_registry(sr);
-        }).get();
         auto stop_schema_registry = defer([&schema_registry] {
             schema_registry.stop().get();
         });

--- a/test/boost/gossip_test.cc
+++ b/test/boost/gossip_test.cc
@@ -118,7 +118,7 @@ SEASTAR_TEST_CASE(test_boot_shutdown){
         });
 
         sharded<schema_registry> schema_registry;
-        schema_registry.start().get();
+        schema_registry.start(std::cref(*cfg)).get();
         auto stop_schema_registry = defer([&schema_registry] {
             schema_registry.stop().get();
         });

--- a/test/boost/keys_test.cc
+++ b/test/boost/keys_test.cc
@@ -31,9 +31,11 @@
 #include "idl/keys.dist.hh"
 #include "serializer_impl.hh"
 #include "idl/keys.dist.impl.hh"
+#include "test/lib/schema_registry.hh"
 
 BOOST_AUTO_TEST_CASE(test_key_is_prefixed_by) {
-    auto s_ptr = schema_builder("", "")
+    tests::schema_registry_wrapper registry;
+    auto s_ptr = schema_builder(registry, "", "")
             .with_column("c1", bytes_type, column_kind::partition_key)
             .with_column("c2", bytes_type, column_kind::clustering_key)
             .with_column("c3", bytes_type, column_kind::clustering_key)
@@ -55,7 +57,8 @@ BOOST_AUTO_TEST_CASE(test_key_is_prefixed_by) {
 }
 
 BOOST_AUTO_TEST_CASE(test_key_component_iterator) {
-    auto s_ptr = schema_builder("", "")
+    tests::schema_registry_wrapper registry;
+    auto s_ptr = schema_builder(registry, "", "")
             .with_column("c1", bytes_type, column_kind::partition_key)
             .with_column("c2", bytes_type, column_kind::clustering_key)
             .with_column("c3", bytes_type, column_kind::clustering_key)
@@ -84,7 +87,8 @@ BOOST_AUTO_TEST_CASE(test_key_component_iterator) {
 }
 
 BOOST_AUTO_TEST_CASE(test_legacy_ordering_for_non_composite_key) {
-    auto s_ptr = schema_builder("", "")
+    tests::schema_registry_wrapper registry;
+    auto s_ptr = schema_builder(registry, "", "")
             .with_column("c1", bytes_type, column_kind::partition_key)
             .build();
     const schema& s = *s_ptr;
@@ -105,7 +109,8 @@ BOOST_AUTO_TEST_CASE(test_legacy_ordering_for_non_composite_key) {
 }
 
 BOOST_AUTO_TEST_CASE(test_legacy_ordering_for_composite_keys) {
-    auto s_ptr = schema_builder("", "")
+    tests::schema_registry_wrapper registry;
+    auto s_ptr = schema_builder(registry, "", "")
             .with_column("c1", bytes_type, column_kind::partition_key)
             .with_column("c2", bytes_type, column_kind::partition_key)
             .build();
@@ -133,7 +138,8 @@ BOOST_AUTO_TEST_CASE(test_legacy_ordering_for_composite_keys) {
 }
 
 BOOST_AUTO_TEST_CASE(test_conversions_between_view_and_wrapper) {
-    auto s_ptr = schema_builder("", "")
+    tests::schema_registry_wrapper registry;
+    auto s_ptr = schema_builder(registry, "", "")
             .with_column("c1", bytes_type, column_kind::partition_key)
             .build();
     const schema& s = *s_ptr;
@@ -161,7 +167,8 @@ T reserialize(const T& v) {
 }
 
 BOOST_AUTO_TEST_CASE(test_serialization) {
-    auto s = schema_builder("ks", "cf")
+    tests::schema_registry_wrapper registry;
+    auto s = schema_builder(registry, "ks", "cf")
             .with_column("pk", bytes_type, column_kind::partition_key)
             .with_column("v", bytes_type)
             .build();
@@ -174,7 +181,8 @@ BOOST_AUTO_TEST_CASE(test_serialization) {
 
 
 BOOST_AUTO_TEST_CASE(test_from_nodetool_style_string) {
-    auto s1 = schema_builder("", "")
+    tests::schema_registry_wrapper registry;
+    auto s1 = schema_builder(registry, "", "")
             .with_column("c1", utf8_type, column_kind::partition_key)
             .with_column("c2", bytes_type, column_kind::clustering_key)
             .with_column("c3", bytes_type, column_kind::clustering_key)
@@ -187,7 +195,7 @@ BOOST_AUTO_TEST_CASE(test_from_nodetool_style_string) {
     auto key2 = partition_key::from_nodetool_style_string(s1, "value");
     BOOST_REQUIRE(key1.equal(*s1, key2));
 
-    auto s2 = schema_builder("", "")
+    auto s2 = schema_builder(registry, "", "")
             .with_column("c1", utf8_type, column_kind::partition_key)
             .with_column("c2", utf8_type, column_kind::partition_key)
             .with_column("c3", bytes_type, column_kind::clustering_key)

--- a/test/boost/multishard_combining_reader_as_mutation_source_test.cc
+++ b/test/boost/multishard_combining_reader_as_mutation_source_test.cc
@@ -118,7 +118,7 @@ SEASTAR_THREAD_TEST_CASE(test_multishard_combining_reader) {
     }
 
     do_with_cql_env_thread([&] (cql_test_env& env) -> future<> {
-        run_mutation_source_tests(make_populate(false, false));
+        run_mutation_source_tests(make_populate(false, false), &env);
         return make_ready_future<>();
     }).get();
 }
@@ -130,7 +130,7 @@ SEASTAR_THREAD_TEST_CASE(test_multishard_combining_reader_evict_paused) {
     }
 
     do_with_cql_env_thread([&] (cql_test_env& env) -> future<> {
-        run_mutation_source_tests(make_populate(true, false));
+        run_mutation_source_tests(make_populate(true, false), &env);
         return make_ready_future<>();
     }).get();
 }
@@ -145,7 +145,7 @@ SEASTAR_THREAD_TEST_CASE(test_multishard_combining_reader_with_tiny_buffer) {
     }
 
     do_with_cql_env_thread([&] (cql_test_env& env) -> future<> {
-        run_mutation_source_tests_plain(make_populate(true, true), true);
+        run_mutation_source_tests_plain(make_populate(true, true), &env, true);
         return make_ready_future<>();
     }).get();
 }
@@ -157,7 +157,7 @@ SEASTAR_THREAD_TEST_CASE(test_multishard_combining_reader_with_tiny_buffer_dowgr
     }
 
     do_with_cql_env_thread([&] (cql_test_env& env) -> future<> {
-        run_mutation_source_tests_downgrade(make_populate(true, true), true);
+        run_mutation_source_tests_downgrade(make_populate(true, true), &env, true);
         return make_ready_future<>();
     }).get();
 }
@@ -169,7 +169,7 @@ SEASTAR_THREAD_TEST_CASE(test_multishard_combining_reader_with_tiny_buffer_upgra
     }
 
     do_with_cql_env_thread([&] (cql_test_env& env) -> future<> {
-        run_mutation_source_tests_upgrade(make_populate(true, true), true);
+        run_mutation_source_tests_upgrade(make_populate(true, true), &env, true);
         return make_ready_future<>();
     }).get();
 }
@@ -181,7 +181,7 @@ SEASTAR_THREAD_TEST_CASE(test_multishard_combining_reader_with_tiny_buffer_rever
     }
 
     do_with_cql_env_thread([&] (cql_test_env& env) -> future<> {
-        run_mutation_source_tests_reverse(make_populate(true, true), true);
+        run_mutation_source_tests_reverse(make_populate(true, true), &env, true);
         return make_ready_future<>();
     }).get();
 }

--- a/test/boost/mutation_fragment_test.cc
+++ b/test/boost/mutation_fragment_test.cc
@@ -145,7 +145,8 @@ SEASTAR_TEST_CASE(test_mutation_merger_conforms_to_mutation_source) {
 
 SEASTAR_TEST_CASE(test_range_tombstones_stream) {
     return seastar::async([] {
-        auto s = schema_builder("ks", "cf")
+        tests::schema_registry_wrapper registry;
+        auto s = schema_builder(registry, "ks", "cf")
                 .with_column("pk", int32_type, column_kind::partition_key)
                 .with_column("ck1", int32_type, column_kind::clustering_key)
                 .with_column("ck2", int32_type, column_kind::clustering_key)
@@ -267,7 +268,8 @@ position_in_partition position_after_prefixed(const clustering_key& ck) {
 
 SEASTAR_TEST_CASE(test_ordering_of_position_in_partition_and_composite_view) {
     return seastar::async([] {
-        auto s = schema_builder("ks", "cf")
+        tests::schema_registry_wrapper registry;
+        auto s = schema_builder(registry, "ks", "cf")
             .with_column("pk", int32_type, column_kind::partition_key)
             .with_column("ck1", int32_type, column_kind::clustering_key)
             .with_column("ck2", int32_type, column_kind::clustering_key)
@@ -329,7 +331,8 @@ SEASTAR_TEST_CASE(test_ordering_of_position_in_partition_and_composite_view) {
 
 SEASTAR_TEST_CASE(test_ordering_of_position_in_partition_and_composite_view_in_a_dense_table) {
     return seastar::async([] {
-        auto s = schema_builder("ks", "cf")
+        tests::schema_registry_wrapper registry;
+        auto s = schema_builder(registry, "ks", "cf")
             .with_column("pk", int32_type, column_kind::partition_key)
             .with_column("ck1", int32_type, column_kind::clustering_key)
             .with_column("ck2", int32_type, column_kind::clustering_key)
@@ -403,7 +406,8 @@ SEASTAR_TEST_CASE(test_ordering_of_position_in_partition_and_composite_view_in_a
 SEASTAR_TEST_CASE(test_schema_upgrader_is_equivalent_with_mutation_upgrade) {
     return seastar::async([] {
         tests::reader_concurrency_semaphore_wrapper semaphore;
-        for_each_mutation_pair([&](const mutation& m1, const mutation& m2, are_equal eq) {
+        tests::schema_registry_wrapper registry;
+        for_each_mutation_pair(registry, [&](const mutation& m1, const mutation& m2, are_equal eq) {
             if (m1.schema()->version() != m2.schema()->version()) {
                 // upgrade m1 to m2's schema
 

--- a/test/boost/mutation_writer_test.cc
+++ b/test/boost/mutation_writer_test.cc
@@ -104,23 +104,25 @@ SEASTAR_TEST_CASE(test_multishard_writer) {
             }
         };
 
-        test_random_streams(random_mutation_generator(random_mutation_generator::generate_counters::no, local_shard_only::no), 0);
-        test_random_streams(random_mutation_generator(random_mutation_generator::generate_counters::yes, local_shard_only::no), 0);
+        auto& registry = e.local_db().get_schema_registry();
 
-        test_random_streams(random_mutation_generator(random_mutation_generator::generate_counters::no, local_shard_only::no), 1);
-        test_random_streams(random_mutation_generator(random_mutation_generator::generate_counters::yes, local_shard_only::no), 1);
+        test_random_streams(random_mutation_generator(registry, random_mutation_generator::generate_counters::no, local_shard_only::no), 0);
+        test_random_streams(random_mutation_generator(registry, random_mutation_generator::generate_counters::yes, local_shard_only::no), 0);
 
-        test_random_streams(random_mutation_generator(random_mutation_generator::generate_counters::no, local_shard_only::no), many_partitions());
-        test_random_streams(random_mutation_generator(random_mutation_generator::generate_counters::yes, local_shard_only::no), many_partitions());
+        test_random_streams(random_mutation_generator(registry, random_mutation_generator::generate_counters::no, local_shard_only::no), 1);
+        test_random_streams(random_mutation_generator(registry, random_mutation_generator::generate_counters::yes, local_shard_only::no), 1);
+
+        test_random_streams(random_mutation_generator(registry, random_mutation_generator::generate_counters::no, local_shard_only::no), many_partitions());
+        test_random_streams(random_mutation_generator(registry, random_mutation_generator::generate_counters::yes, local_shard_only::no), many_partitions());
 
         try {
-            test_random_streams(random_mutation_generator(random_mutation_generator::generate_counters::no, local_shard_only::no), many_partitions(), generate_error::yes);
+            test_random_streams(random_mutation_generator(registry, random_mutation_generator::generate_counters::no, local_shard_only::no), many_partitions(), generate_error::yes);
             BOOST_ASSERT(false);
         } catch (...) {
         }
 
         try {
-            test_random_streams(random_mutation_generator(random_mutation_generator::generate_counters::yes, local_shard_only::no), many_partitions(), generate_error::yes);
+            test_random_streams(random_mutation_generator(registry, random_mutation_generator::generate_counters::yes, local_shard_only::no), many_partitions(), generate_error::yes);
             BOOST_ASSERT(false);
         } catch (...) {
         }
@@ -174,8 +176,10 @@ SEASTAR_TEST_CASE(test_multishard_writer_producer_aborts) {
             }
         };
 
-        test_random_streams(random_mutation_generator(random_mutation_generator::generate_counters::no, local_shard_only::yes), 1000, generate_error::no);
-        test_random_streams(random_mutation_generator(random_mutation_generator::generate_counters::no, local_shard_only::yes), 1000, generate_error::yes);
+        auto& registry = e.local_db().get_schema_registry();
+
+        test_random_streams(random_mutation_generator(registry, random_mutation_generator::generate_counters::no, local_shard_only::yes), 1000, generate_error::no);
+        test_random_streams(random_mutation_generator(registry, random_mutation_generator::generate_counters::no, local_shard_only::yes), 1000, generate_error::yes);
     });
 }
 

--- a/test/boost/nonwrapping_range_test.cc
+++ b/test/boost/nonwrapping_range_test.cc
@@ -30,6 +30,8 @@
 
 #include "locator/token_metadata.hh"
 
+#include "test/lib/schema_registry.hh"
+
 using ring_position = dht::ring_position;
 
 static
@@ -42,7 +44,8 @@ bool includes_token(const schema& s, const dht::partition_range& r, const dht::t
 
 BOOST_AUTO_TEST_CASE(test_range_with_positions_within_the_same_token) {
     using bound = dht::partition_range::bound;
-    auto s = schema_builder("ks", "cf")
+    tests::schema_registry_wrapper registry;
+    auto s = schema_builder(registry, "ks", "cf")
         .with_column("key", bytes_type, column_kind::partition_key)
         .with_column("v", bytes_type)
         .build();

--- a/test/boost/partitioner_test.cc
+++ b/test/boost/partitioner_test.cc
@@ -34,6 +34,7 @@
 #include "test/lib/simple_schema.hh"
 #include "test/lib/log.hh"
 #include "test/boost/total_order_check.hh"
+#include "test/lib/schema_registry.hh"
 
 template <typename... Args>
 static
@@ -53,7 +54,8 @@ static int64_t long_from_token(dht::token token) {
 }
 
 SEASTAR_THREAD_TEST_CASE(test_decorated_key_is_compatible_with_origin) {
-    auto s = schema_builder("ks", "cf")
+    tests::schema_registry_wrapper registry;
+    auto s = schema_builder(registry, "ks", "cf")
         .with_column("c1", int32_type, column_kind::partition_key)
         .with_column("c2", int32_type, column_kind::partition_key)
         .with_column("v", int32_type)
@@ -92,7 +94,8 @@ SEASTAR_THREAD_TEST_CASE(test_token_wraparound_2) {
 }
 
 SEASTAR_THREAD_TEST_CASE(test_ring_position_is_comparable_with_decorated_key) {
-    auto s = schema_builder("ks", "cf")
+    tests::schema_registry_wrapper registry;
+    auto s = schema_builder(registry, "ks", "cf")
         .with_column("pk", bytes_type, column_kind::partition_key)
         .with_column("v", int32_type)
         .build();
@@ -231,7 +234,8 @@ void test_sharding(const dht::sharder& sharder, unsigned shards, std::vector<dht
     auto prev_token = [] (dht::token token) {
         return token_from_long(long_from_token(token) - 1);
     };
-    auto s = schema_builder("ks", "cf")
+    tests::schema_registry_wrapper registry;
+    auto s = schema_builder(registry, "ks", "cf")
         .with_column("c1", int32_type, column_kind::partition_key)
         .with_column("c2", int32_type, column_kind::partition_key)
         .with_column("v", int32_type)
@@ -323,7 +327,8 @@ normalize(dht::partition_range pr) {
 static
 void
 test_something_with_some_interesting_ranges_and_sharder(std::function<void (const schema&, const dht::partition_range&)> func_to_test) {
-    auto s = schema_builder("ks", "cf")
+    tests::schema_registry_wrapper registry;
+    auto s = schema_builder(registry, "ks", "cf")
         .with_column("c1", int32_type, column_kind::partition_key)
         .with_column("c2", int32_type, column_kind::partition_key)
         .with_column("v", int32_type)
@@ -395,7 +400,8 @@ SEASTAR_THREAD_TEST_CASE(test_split_range_single_shard) {
 static
 void
 test_something_with_some_interesting_ranges_and_sharder_with_token_range(std::function<void (const dht::sharder&, const schema&, const dht::token_range&)> func_to_test) {
-    auto s = schema_builder("ks", "cf")
+    tests::schema_registry_wrapper registry;
+    auto s = schema_builder(registry, "ks", "cf")
         .with_column("c1", int32_type, column_kind::partition_key)
         .with_column("c2", int32_type, column_kind::partition_key)
         .with_column("v", int32_type)

--- a/test/boost/querier_cache_test.cc
+++ b/test/boost/querier_cache_test.cc
@@ -783,7 +783,9 @@ SEASTAR_THREAD_TEST_CASE(test_unique_inactive_read_handle) {
     reader_concurrency_semaphore sem2(reader_concurrency_semaphore::no_limits{}, ""); // to see the message for an unnamed semaphore
     auto stop_sem2 = deferred_stop(sem2);
 
-    auto schema = schema_builder("ks", "cf")
+    tests::schema_registry_wrapper registry;
+
+    auto schema = schema_builder(registry, "ks", "cf")
         .with_column("pk", int32_type, column_kind::partition_key)
         .with_column("v", int32_type)
         .build();

--- a/test/boost/range_test.cc
+++ b/test/boost/range_test.cc
@@ -30,6 +30,7 @@
 #include "schema_builder.hh"
 
 #include "locator/token_metadata.hh"
+#include "test/lib/schema_registry.hh"
 
 // yuck, but what can one do?  needed for BOOST_REQUIRE_EQUAL
 namespace std {
@@ -50,7 +51,8 @@ bool includes_token(const schema& s, const dht::partition_range& r, const dht::t
 }
 
 BOOST_AUTO_TEST_CASE(test_range_with_positions_within_the_same_token) {
-    auto s = schema_builder("ks", "cf")
+    tests::schema_registry_wrapper registry;
+    auto s = schema_builder(registry, "ks", "cf")
         .with_column("key", bytes_type, column_kind::partition_key)
         .with_column("v", bytes_type)
         .build();

--- a/test/boost/range_tombstone_list_test.cc
+++ b/test/boost/range_tombstone_list_test.cc
@@ -29,10 +29,13 @@
 #include "range_tombstone_list.hh"
 #include "test/boost/range_tombstone_list_assertions.hh"
 #include "test/lib/log.hh"
+#include "test/lib/schema_registry.hh"
 
 #include <seastar/util/defer.hh>
 
-static thread_local schema_ptr s = schema_builder("ks", "cf")
+static thread_local tests::schema_registry_wrapper registry;
+
+static thread_local schema_ptr s = schema_builder(registry, "ks", "cf")
         .with_column("pk", int32_type, column_kind::partition_key)
         .with_column("ck1", int32_type, column_kind::clustering_key)
         .with_column("ck2", int32_type, column_kind::clustering_key)

--- a/test/boost/reader_concurrency_semaphore_test.cc
+++ b/test/boost/reader_concurrency_semaphore_test.cc
@@ -527,13 +527,14 @@ SEASTAR_TEST_CASE(reader_concurrency_semaphore_max_queue_length) {
 }
 
 SEASTAR_THREAD_TEST_CASE(reader_concurrency_semaphore_dump_reader_diganostics) {
+    tests::schema_registry_wrapper registry;
     reader_concurrency_semaphore semaphore(reader_concurrency_semaphore::no_limits{}, get_name());
     auto stop_sem = deferred_stop(semaphore);
 
     const auto nr_tables = tests::random::get_int<unsigned>(2, 4);
     std::vector<schema_ptr> schemas;
     for (unsigned i = 0; i < nr_tables; ++i) {
-        schemas.emplace_back(schema_builder("ks", fmt::format("tbl{}", i))
+        schemas.emplace_back(schema_builder(registry, "ks", fmt::format("tbl{}", i))
                 .with_column("pk", int32_type, column_kind::partition_key)
                 .with_column("v", int32_type, column_kind::regular_column).build());
     }

--- a/test/boost/schema_change_test.cc
+++ b/test/boost/schema_change_test.cc
@@ -835,23 +835,3 @@ SEASTAR_TEST_CASE(test_schema_make_reversed) {
 
     return make_ready_future<>();
 }
-
-SEASTAR_TEST_CASE(test_schema_get_reversed) {
-    return do_with_cql_env([this] (cql_test_env& e) {
-        auto schema = schema_builder("tests", get_name())
-                .with_column("pk", bytes_type, column_kind::partition_key)
-                .with_column("ck", bytes_type, column_kind::clustering_key)
-                .with_column("v1", bytes_type)
-                .build();
-        schema = local_schema_registry().learn(schema);
-        auto reversed_schema = schema->get_reversed();
-
-        testlog.info("        &schema: {}", fmt::ptr(schema.get()));
-        testlog.info("&reverse_schema: {}", fmt::ptr(reversed_schema.get()));
-
-        BOOST_REQUIRE_EQUAL(reversed_schema->get_reversed().get(), schema.get());
-        BOOST_REQUIRE_EQUAL(schema->get_reversed().get(), reversed_schema.get());
-
-        return make_ready_future<>();
-    });
-}

--- a/test/boost/schema_change_test.cc
+++ b/test/boost/schema_change_test.cc
@@ -835,5 +835,8 @@ SEASTAR_TEST_CASE(test_schema_make_reversed) {
     BOOST_REQUIRE(schema->version() == re_reversed_schema->version());
     BOOST_REQUIRE(reversed_schema->version() != re_reversed_schema->version());
 
+    BOOST_REQUIRE(re_reversed_schema.get() == schema.get());
+    BOOST_REQUIRE(schema->make_reversed().get() == reversed_schema.get());
+
     return make_ready_future<>();
 }

--- a/test/boost/schema_registry_test.cc
+++ b/test/boost/schema_registry_test.cc
@@ -95,7 +95,7 @@ SEASTAR_TEST_CASE(test_schema_is_synced_when_syncer_doesnt_defer) {
         tests::schema_registry_wrapper registry;
         auto s = registry->get_or_load(random_schema_version(), [&registry] (table_schema_version v) { return random_schema(registry, v); });
         BOOST_REQUIRE(!s->is_synced());
-        s->registry_entry()->maybe_sync([] { return make_ready_future<>(); }).get();
+        s->registry_entry().maybe_sync([] { return make_ready_future<>(); }).get();
         BOOST_REQUIRE(s->is_synced());
     });
 }
@@ -105,7 +105,7 @@ SEASTAR_TEST_CASE(test_schema_is_synced_when_syncer_defers) {
         tests::schema_registry_wrapper registry;
         auto s = registry->get_or_load(random_schema_version(), [&registry] (table_schema_version v) { return random_schema(registry, v); });
         BOOST_REQUIRE(!s->is_synced());
-        s->registry_entry()->maybe_sync([] { return later(); }).get();
+        s->registry_entry().maybe_sync([] { return later(); }).get();
         BOOST_REQUIRE(s->is_synced());
     });
 }
@@ -118,14 +118,14 @@ SEASTAR_TEST_CASE(test_failed_sync_can_be_retried) {
 
         promise<> fail_sync;
 
-        auto f1 = s->registry_entry()->maybe_sync([&fail_sync] () mutable {
+        auto f1 = s->registry_entry().maybe_sync([&fail_sync] () mutable {
             return fail_sync.get_future().then([] {
                 throw std::runtime_error("sync failed");
             });
         });
 
         // concurrent maybe_sync should attach the the current one
-        auto f2 = s->registry_entry()->maybe_sync([] { return make_ready_future<>(); });
+        auto f2 = s->registry_entry().maybe_sync([] { return make_ready_future<>(); });
 
         fail_sync.set_value();
 
@@ -145,7 +145,7 @@ SEASTAR_TEST_CASE(test_failed_sync_can_be_retried) {
 
         BOOST_REQUIRE(!s->is_synced());
 
-        s->registry_entry()->maybe_sync([] { return make_ready_future<>(); }).get();
+        s->registry_entry().maybe_sync([] { return make_ready_future<>(); }).get();
         BOOST_REQUIRE(s->is_synced());
     });
 }

--- a/test/boost/sstable_3_x_test.cc
+++ b/test/boost/sstable_3_x_test.cc
@@ -53,6 +53,7 @@
 #include "sstables/mx/writer.hh"
 #include "test/lib/simple_schema.hh"
 #include "test/lib/exception_utils.hh"
+#include "test/lib/schema_registry.hh"
 
 #include <boost/range/algorithm/sort.hpp>
 
@@ -177,8 +178,10 @@ public:
 static thread_local const sstring UNCOMPRESSED_FILTERING_AND_FORWARDING_PATH =
     "test/resource/sstables/3.x/uncompressed/filtering_and_forwarding";
 
+static thread_local tests::schema_registry_wrapper _registry;
+
 static schema_ptr make_uncompressed_filtering_and_forwarding_schema() {
-    return schema_builder("test_ks", "test_table")
+    return schema_builder(_registry, "test_ks", "test_table")
         .with_column("pk", int32_type, column_kind::partition_key)
         .with_column("ck", int32_type, column_kind::clustering_key)
         .with_column("s", int32_type, column_kind::static_column)
@@ -431,7 +434,7 @@ static thread_local const sstring UNCOMPRESSED_SKIP_USING_INDEX_ROWS_PATH =
     "test/resource/sstables/3.x/uncompressed/skip_using_index_rows";
 
 static schema_ptr make_uncompressed_skip_using_index_rows_schema() {
-    return schema_builder("test_ks", "test_table")
+    return schema_builder(_registry, "test_ks", "test_table")
         .with_column("pk", int32_type, column_kind::partition_key)
         .with_column("ck", int32_type, column_kind::clustering_key)
         .with_column("st", int32_type, column_kind::static_column)
@@ -679,7 +682,7 @@ static thread_local const sstring UNCOMPRESSED_FILTERING_AND_FORWARDING_RANGE_TO
     "test/resource/sstables/3.x/uncompressed/filtering_and_forwarding_range_tombstones";
 
 static schema_ptr make_uncompressed_filtering_and_forwarding_range_tombstones_schema() {
-    return schema_builder("test_ks", "test_table")
+    return schema_builder(_registry, "test_ks", "test_table")
         .with_column("pk", int32_type, column_kind::partition_key)
         .with_column("ck1", int32_type, column_kind::clustering_key)
         .with_column("ck2", int32_type, column_kind::clustering_key)
@@ -978,7 +981,7 @@ static thread_local const sstring UNCOMPRESSED_SLICING_INTERLEAVED_ROWS_AND_RTS_
     "test/resource/sstables/3.x/uncompressed/slicing_interleaved_rows_and_rts";
 
 static schema_ptr make_uncompressed_slicing_interleaved_rows_and_rts_schema() {
-    return schema_builder("test_ks", "test_table")
+    return schema_builder(_registry, "test_ks", "test_table")
         .with_column("pk", int32_type, column_kind::partition_key)
         .with_column("ck1", int32_type, column_kind::clustering_key)
         .with_column("ck2", int32_type, column_kind::clustering_key)
@@ -1164,7 +1167,7 @@ static thread_local const sstring UNCOMPRESSED_STATIC_ROW_PATH =
     "test/resource/sstables/3.x/uncompressed/static_row";
 
 static schema_ptr make_uncompressed_static_row_schema() {
-    return schema_builder("test_ks", "test_table")
+    return schema_builder(_registry, "test_ks", "test_table")
         .with_column("pk", int32_type, column_kind::partition_key)
         .with_column("ck", int32_type, column_kind::clustering_key)
         .with_column("s", int32_type, column_kind::static_column)
@@ -1248,7 +1251,7 @@ SEASTAR_TEST_CASE(test_uncompressed_random_partitioner) {
     const sstring uncompressed_random_partitioner_path =
             "test/resource/sstables/3.x/uncompressed/random_partitioner";
     const schema_ptr uncompressed_random_partitioner_schema =
-            schema_builder("test_ks", "test_table")
+            schema_builder(env.registry(), "test_ks", "test_table")
                 .with_column("pk", int32_type, column_kind::partition_key)
                 .with_column("ck", int32_type, column_kind::clustering_key)
                 .with_column("v", int32_type)
@@ -1293,7 +1296,7 @@ static thread_local const sstring UNCOMPRESSED_COMPOUND_STATIC_ROW_PATH =
     "test/resource/sstables/3.x/uncompressed/compound_static_row";
 
 static schema_ptr make_uncompressed_compound_static_row_schema() {
-    return schema_builder("test_ks", "test_table")
+    return schema_builder(_registry, "test_ks", "test_table")
         .with_column("pk", int32_type, column_kind::partition_key)
         .with_column("ck", int32_type, column_kind::clustering_key)
         .with_column("s_int", int32_type, column_kind::static_column)
@@ -1390,7 +1393,7 @@ static thread_local const sstring UNCOMPRESSED_PARTITION_KEY_ONLY_PATH =
     "test/resource/sstables/3.x/uncompressed/partition_key_only";
 
 static schema_ptr make_uncompressed_partition_key_only_schema() {
-    return schema_builder("test_ks", "test_table")
+    return schema_builder(_registry, "test_ks", "test_table")
         .with_column("pk", int32_type, column_kind::partition_key)
         .set_compressor_params(compression_parameters::no_compression())
         .build();
@@ -1453,7 +1456,7 @@ static thread_local const sstring UNCOMPRESSED_PARTITION_KEY_WITH_VALUE_PATH =
     "test/resource/sstables/3.x/uncompressed/partition_key_with_value";
 
 static schema_ptr make_uncompressed_partition_key_with_value_schema() {
-    return schema_builder("test_ks", "test_table")
+    return schema_builder(_registry, "test_ks", "test_table")
         .with_column("pk", int32_type, column_kind::partition_key)
         .with_column("val", int32_type)
         .set_compressor_params(compression_parameters::no_compression())
@@ -1521,7 +1524,7 @@ static thread_local const sstring UNCOMPRESSED_COUNTERS_PATH =
     "test/resource/sstables/3.x/uncompressed/counters";
 
 static thread_local const schema_ptr UNCOMPRESSED_COUNTERS_SCHEMA =
-    schema_builder("test_ks", "test_table")
+    schema_builder(_registry, "test_ks", "test_table")
         .with_column("pk", int32_type, column_kind::partition_key)
         .with_column("val", counter_type)
         .set_compressor_params(compression_parameters::no_compression())
@@ -1640,7 +1643,7 @@ static const sstring ZSTD_PARTITION_KEY_WITH_VALUES_OF_DIFFERENT_TYPES_PATH =
     "test/resource/sstables/3.x/zstd/partition_key_with_values_of_different_types";
 
 static schema_builder make_partition_key_with_values_of_different_types_schema_builder() {
-    return schema_builder("test_ks", "test_table")
+    return schema_builder(_registry, "test_ks", "test_table")
         .with_column("pk", int32_type, column_kind::partition_key)
         .with_column("bool_val", boolean_type)
         .with_column("double_val", double_type)
@@ -1794,7 +1797,7 @@ static thread_local const sstring ZSTD_MULTIPLE_CHUNKS_PATH =
     "test/resource/sstables/3.x/zstd/multiple_chunks";
 
 static schema_ptr make_zstd_multiple_chunks_schema() {
-    return schema_builder("test_ks", "test_table")
+    return schema_builder(_registry, "test_ks", "test_table")
         .with_column("val1", int32_type, column_kind::partition_key)
         .with_column("val2", int32_type, column_kind::clustering_key)
         .set_compressor_params(compression_parameters{compressor::create({
@@ -1866,7 +1869,7 @@ static thread_local const sstring UNCOMPRESSED_SUBSET_OF_COLUMNS_PATH =
     "test/resource/sstables/3.x/uncompressed/subset_of_columns";
 
 static schema_ptr make_uncompressed_subset_of_columns_schema() {
-    return schema_builder("test_ks", "test_table")
+    return schema_builder(_registry, "test_ks", "test_table")
         .with_column("pk", int32_type, column_kind::partition_key)
         .with_column("bool_val", boolean_type)
         .with_column("double_val", double_type)
@@ -2043,7 +2046,7 @@ static thread_local const sstring UNCOMPRESSED_LARGE_SUBSET_OF_COLUMNS_SPARSE_PA
     "test/resource/sstables/3.x/uncompressed/large_subset_of_columns_sparse";
 
 static schema_ptr make_uncompressed_large_subset_of_columns_sparse_schema() {
-  return schema_builder("test_ks", "test_table")
+  return schema_builder(_registry, "test_ks", "test_table")
         .with_column("pk", int32_type, column_kind::partition_key)
         .with_column("val1", int32_type)
         .with_column("val2", int32_type)
@@ -2261,7 +2264,7 @@ static thread_local const sstring UNCOMPRESSED_LARGE_SUBSET_OF_COLUMNS_DENSE_PAT
     "test/resource/sstables/3.x/uncompressed/large_subset_of_columns_dense";
 
 static schema_ptr make_uncompressed_large_subset_of_columns_dense_schema() {
-    return schema_builder("test_ks", "test_table")
+    return schema_builder(_registry, "test_ks", "test_table")
         .with_column("pk", int32_type, column_kind::partition_key)
         .with_column("val1", int32_type)
         .with_column("val2", int32_type)
@@ -2432,7 +2435,7 @@ SEASTAR_TEST_CASE(test_uncompressed_large_subset_of_columns_dense_read) {
 static thread_local const sstring UNCOMPRESSED_DELETED_CELLS_PATH = "test/resource/sstables/3.x/uncompressed/deleted_cells";
 
 static schema_ptr make_uncompressed_deleted_cells_schema() {
-    return schema_builder("test_ks", "test_table")
+    return schema_builder(_registry, "test_ks", "test_table")
         .with_column("pk", int32_type, column_kind::partition_key)
         .with_column("ck", int32_type, column_kind::clustering_key)
         .with_column("val", int32_type)
@@ -2520,7 +2523,7 @@ SEASTAR_TEST_CASE(test_uncompressed_deleted_cells_read) {
 static thread_local const sstring UNCOMPRESSED_RANGE_TOMBSTONES_SIMPLE_PATH = "test/resource/sstables/3.x/uncompressed/range_tombstones_simple";
 
 static schema_ptr make_uncompressed_range_tombstones_simple_schema() {
-    return schema_builder("test_ks", "test_table")
+    return schema_builder(_registry, "test_ks", "test_table")
         .with_column("pk", int32_type, column_kind::partition_key)
         .with_column("ck", int32_type, column_kind::clustering_key)
         .with_column("val", int32_type)
@@ -2589,7 +2592,7 @@ SEASTAR_TEST_CASE(test_uncompressed_range_tombstones_simple_read) {
 static thread_local const sstring UNCOMPRESSED_RANGE_TOMBSTONES_PARTIAL_PATH = "test/resource/sstables/3.x/uncompressed/range_tombstones_partial";
 
 static  schema_ptr make_uncompressed_range_tombstones_partial_schema() {
-    return schema_builder("test_ks", "test_table")
+    return schema_builder(_registry, "test_ks", "test_table")
         .with_column("pk", int32_type, column_kind::partition_key)
         .with_column("ck1", int32_type, column_kind::clustering_key)
         .with_column("ck2", int32_type, column_kind::clustering_key)
@@ -2652,7 +2655,7 @@ SEASTAR_TEST_CASE(test_uncompressed_range_tombstones_partial_read) {
 static thread_local const sstring UNCOMPRESSED_SIMPLE_PATH = "test/resource/sstables/3.x/uncompressed/simple";
 
 static schema_ptr make_uncompressed_simple_schema() {
-    return schema_builder("test_ks", "test_table")
+    return schema_builder(_registry, "test_ks", "test_table")
         .with_column("pk", int32_type, column_kind::partition_key)
         .with_column("ck", int32_type, column_kind::clustering_key)
         .with_column("val", int32_type)
@@ -2792,7 +2795,7 @@ SEASTAR_TEST_CASE(test_uncompressed_simple_read) {
 static thread_local const sstring UNCOMPRESSED_COMPOUND_CK_PATH = "test/resource/sstables/3.x/uncompressed/compound_ck";
 
 static schema_ptr make_uncompressed_compound_ck_schema() {
-    return schema_builder("test_ks", "test_table")
+    return schema_builder(_registry, "test_ks", "test_table")
         .with_column("pk", int32_type, column_kind::partition_key)
         .with_column("ck_int", int32_type, column_kind::clustering_key)
         .with_column("ck_text", utf8_type, column_kind::clustering_key)
@@ -2895,7 +2898,7 @@ static thread_local const sstring UNCOMPRESSED_COLLECTIONS_PATH =
     "test/resource/sstables/3.x/uncompressed/collections";
 
 static schema_ptr make_uncompressed_collections_schema() {
-    return schema_builder("test_ks", "test_table")
+    return schema_builder(_registry, "test_ks", "test_table")
         .with_column("pk", int32_type, column_kind::partition_key)
         .with_column("set_val", set_type_impl::get_instance(int32_type, true))
         .with_column("list_val", list_type_impl::get_instance(utf8_type, true))
@@ -3060,7 +3063,7 @@ SEASTAR_TEST_CASE(compact_deleted_row) {
     BOOST_REQUIRE(smp::count == 1);
     sstring table_name = "compact_deleted_row";
     // CREATE TABLE test_deleted_row (pk text, ck text, rc1 text, rc2 text, PRIMARY KEY (pk, ck)) WITH compression = {'sstable_compression': ''};
-    schema_builder builder("sst3", table_name);
+    schema_builder builder(env.registry(), "sst3", table_name);
     builder.with_column("pk", utf8_type, column_kind::partition_key);
     builder.with_column("ck", utf8_type, column_kind::clustering_key);
     builder.with_column("rc1", utf8_type);
@@ -3131,7 +3134,7 @@ SEASTAR_TEST_CASE(compact_deleted_cell) {
     BOOST_REQUIRE(smp::count == 1);
     sstring table_name = "compact_deleted_cell";
     //  CREATE TABLE compact_deleted_cell (pk text, ck text, rc text, PRIMARY KEY (pk, ck)) WITH compression = {'sstable_compression': ''};
-    schema_builder builder("sst3", table_name);
+    schema_builder builder(env.registry(), "sst3", table_name);
     builder.with_column("pk", utf8_type, column_kind::partition_key);
     builder.with_column("ck", utf8_type, column_kind::clustering_key);
     builder.with_column("rc", utf8_type);
@@ -3420,7 +3423,7 @@ SEASTAR_TEST_CASE(test_write_static_row) {
   return test_env::do_with_async([] (test_env& env) {
     sstring table_name = "static_row";
     // CREATE TABLE static_row (pk text, ck int, st1 int static, st2 text static, PRIMARY KEY (pk, ck)) WITH compression = {'sstable_compression': ''};
-    schema_builder builder("sst3", table_name);
+    schema_builder builder(env.registry(), "sst3", table_name);
     builder.with_column("pk", utf8_type, column_kind::partition_key);
     builder.with_column("ck", int32_type, column_kind::clustering_key);
     builder.with_column("st1", int32_type, column_kind::static_column);
@@ -3442,7 +3445,7 @@ SEASTAR_TEST_CASE(test_write_composite_partition_key) {
   return test_env::do_with_async([] (test_env& env) {
     sstring table_name = "composite_partition_key";
     // CREATE TABLE composite_partition_key (a int , b text, c boolean, d int, e text, f int, g text, PRIMARY KEY ((a, b, c), d, e)) WITH compression = {'sstable_compression': ''};
-    schema_builder builder("sst3", table_name);
+    schema_builder builder(env.registry(), "sst3", table_name);
     builder.with_column("a", int32_type, column_kind::partition_key);
     builder.with_column("b", utf8_type, column_kind::partition_key);
     builder.with_column("c", boolean_type, column_kind::partition_key);
@@ -3469,7 +3472,7 @@ SEASTAR_TEST_CASE(test_write_composite_clustering_key) {
   return test_env::do_with_async([] (test_env& env) {
     sstring table_name = "composite_clustering_key";
     // CREATE TABLE composite_clustering_key (a int , b text, c int, d text, e int, f text, PRIMARY KEY (a, b, c, d)) WITH compression = {'sstable_compression': ''};
-    schema_builder builder("sst3", table_name);
+    schema_builder builder(env.registry(), "sst3", table_name);
     builder.with_column("a", int32_type, column_kind::partition_key);
     builder.with_column("b", utf8_type, column_kind::clustering_key);
     builder.with_column("c", int32_type, column_kind::clustering_key);
@@ -3495,7 +3498,7 @@ SEASTAR_TEST_CASE(test_write_wide_partitions) {
   return test_env::do_with_async([] (test_env& env) {
     sstring table_name = "wide_partitions";
     // CREATE TABLE wide_partitions (pk text, ck text, st text, rc text, PRIMARY KEY (pk, ck) WITH compression = {'sstable_compression': ''};
-    schema_builder builder("sst3", table_name);
+    schema_builder builder(env.registry(), "sst3", table_name);
     builder.with_column("pk", utf8_type, column_kind::partition_key);
     builder.with_column("ck", utf8_type, column_kind::clustering_key);
     builder.with_column("st", utf8_type, column_kind::static_column);
@@ -3538,7 +3541,7 @@ SEASTAR_TEST_CASE(test_write_ttled_row) {
   return test_env::do_with_async([] (test_env& env) {
     sstring table_name = "ttled_row";
     // CREATE TABLE ttled_row (pk int, ck int, rc int, PRIMARY KEY (pk, ck)) WITH compression = {'sstable_compression': ''};
-    schema_builder builder("sst3", table_name);
+    schema_builder builder(env.registry(), "sst3", table_name);
     builder.with_column("pk", int32_type, column_kind::partition_key);
     builder.with_column("ck", int32_type, column_kind::clustering_key);
     builder.with_column("rc", int32_type);
@@ -3569,7 +3572,7 @@ SEASTAR_TEST_CASE(test_write_ttled_column) {
   return test_env::do_with_async([] (test_env& env) {
     sstring table_name = "ttled_column";
     // CREATE TABLE ttled_column (pk text, rc int, PRIMARY KEY (pk)) WITH compression = {'sstable_compression': ''};
-    schema_builder builder("sst3", table_name);
+    schema_builder builder(env.registry(), "sst3", table_name);
     builder.with_column("pk", utf8_type, column_kind::partition_key);
     builder.with_column("rc", int32_type);
     builder.set_compressor_params(compression_parameters::no_compression());
@@ -3597,7 +3600,7 @@ SEASTAR_TEST_CASE(test_write_deleted_column) {
   return test_env::do_with_async([] (test_env& env) {
     sstring table_name = "deleted_column";
     // CREATE TABLE deleted_column (pk int, rc int, PRIMARY KEY (pk)) WITH compression = {'sstable_compression': ''};
-    schema_builder builder("sst3", table_name);
+    schema_builder builder(env.registry(), "sst3", table_name);
     builder.with_column("pk", int32_type, column_kind::partition_key);
     builder.with_column("rc", int32_type);
     builder.set_compressor_params(compression_parameters::no_compression());
@@ -3621,7 +3624,7 @@ SEASTAR_TEST_CASE(test_write_deleted_row) {
   return test_env::do_with_async([] (test_env& env) {
     sstring table_name = "deleted_row";
     // CREATE TABLE deleted_row (pk int, ck int, PRIMARY KEY (pk, ck)) WITH compression = {'sstable_compression': ''};
-    schema_builder builder("sst3", table_name);
+    schema_builder builder(env.registry(), "sst3", table_name);
     builder.with_column("pk", int32_type, column_kind::partition_key);
     builder.with_column("ck", int32_type, column_kind::clustering_key);
     builder.set_compressor_params(compression_parameters::no_compression());
@@ -3643,7 +3646,7 @@ SEASTAR_TEST_CASE(test_write_collection_wide_update) {
     sstring table_name = "collection_wide_update";
     auto set_of_ints_type = set_type_impl::get_instance(int32_type, true);
     // CREATE TABLE collection_wide_update (pk int, col set<int>, PRIMARY KEY (pk)) with compression = {'sstable_compression': ''};
-    schema_builder builder("sst3", table_name);
+    schema_builder builder(env.registry(), "sst3", table_name);
     builder.with_column("pk", int32_type, column_kind::partition_key);
     builder.with_column("col", set_of_ints_type);
     builder.set_compressor_params(compression_parameters::no_compression());
@@ -3671,7 +3674,7 @@ SEASTAR_TEST_CASE(test_write_collection_incremental_update) {
     sstring table_name = "collection_incremental_update";
     auto set_of_ints_type = set_type_impl::get_instance(int32_type, true);
     // CREATE TABLE collection_incremental_update (pk int, col set<int>, PRIMARY KEY (pk)) with compression = {'sstable_compression': ''};
-    schema_builder builder("sst3", table_name);
+    schema_builder builder(env.registry(), "sst3", table_name);
     builder.with_column("pk", int32_type, column_kind::partition_key);
     builder.with_column("col", set_of_ints_type);
     builder.set_compressor_params(compression_parameters::no_compression());
@@ -3694,7 +3697,7 @@ SEASTAR_TEST_CASE(test_write_multiple_partitions) {
   return test_env::do_with_async([] (test_env& env) {
     sstring table_name = "multiple_partitions";
     // CREATE TABLE multiple_partitions (pk int, rc1 int, rc2 int, rc3 int, PRIMARY KEY (pk)) WITH compression = {'sstable_compression': ''};
-    schema_builder builder("sst3", table_name);
+    schema_builder builder(env.registry(), "sst3", table_name);
     builder.with_column("pk", int32_type, column_kind::partition_key);
     builder.with_column("rc1", int32_type);
     builder.with_column("rc2", int32_type);
@@ -3724,7 +3727,7 @@ SEASTAR_TEST_CASE(test_write_multiple_partitions) {
 static future<> test_write_many_partitions(sstring table_name, tombstone partition_tomb, compression_parameters cp) {
   return test_env::do_with_async([table_name, partition_tomb, cp] (test_env& env) {
     // CREATE TABLE <table_name> (pk int, PRIMARY KEY (pk)) WITH compression = {'sstable_compression': ''};
-    schema_builder builder("sst3", table_name);
+    schema_builder builder(env.registry(), "sst3", table_name);
     builder.with_column("pk", int32_type, column_kind::partition_key);
     builder.set_compressor_params(cp);
     schema_ptr s = builder.build(schema_builder::compact_storage::no);
@@ -3800,7 +3803,7 @@ SEASTAR_TEST_CASE(test_write_multiple_rows) {
   return test_env::do_with_async([] (test_env& env) {
     sstring table_name = "multiple_rows";
     // CREATE TABLE multiple_rows (pk int, ck int, rc1 int, rc2 int, rc3 int, PRIMARY KEY (pk, ck)) WITH compression = {'sstable_compression': ''};
-    schema_builder builder("sst3", table_name);
+    schema_builder builder(env.registry(), "sst3", table_name);
     builder.with_column("pk", int32_type, column_kind::partition_key);
     builder.with_column("ck", int32_type, column_kind::clustering_key);
     builder.with_column("rc1", int32_type);
@@ -3833,7 +3836,7 @@ SEASTAR_TEST_CASE(test_write_missing_columns_large_set) {
   return test_env::do_with_async([] (test_env& env) {
     sstring table_name = "missing_columns_large_set";
     // CREATE TABLE missing_columns_large_set (pk int, ck int, rc1 int, ..., rc64 int, PRIMARY KEY (pk, ck)) WITH compression = {'sstable_compression': ''};
-    schema_builder builder("sst3", table_name);
+    schema_builder builder(env.registry(), "sst3", table_name);
     builder.with_column("pk", int32_type, column_kind::partition_key);
     builder.with_column("ck", int32_type, column_kind::clustering_key);
     for (auto idx: boost::irange(1, 65)) {
@@ -3874,7 +3877,7 @@ SEASTAR_TEST_CASE(test_write_empty_counter) {
   return test_env::do_with_async([] (test_env& env) {
     sstring table_name = "empty_counter";
     // CREATE TABLE empty_counter (pk text, ck text, val counter, PRIMARY KEY (pk, ck)) WITH compression = {'sstable_compression': ''};
-    schema_builder builder("sst3", table_name);
+    schema_builder builder(env.registry(), "sst3", table_name);
     builder.with_column("pk", utf8_type, column_kind::partition_key);
     builder.with_column("ck", utf8_type, column_kind::clustering_key);
     builder.with_column("val", counter_type);
@@ -3898,7 +3901,7 @@ SEASTAR_TEST_CASE(test_write_counter_table) {
   return test_env::do_with_async([] (test_env& env) {
     sstring table_name = "counter_table";
     // CREATE TABLE counter_table (pk text, ck text, rc1 counter, rc2 counter, PRIMARY KEY (pk, ck)) WITH compression = {'sstable_compression': ''};
-    schema_builder builder("sst3", table_name);
+    schema_builder builder(env.registry(), "sst3", table_name);
     builder.with_column("pk", utf8_type, column_kind::partition_key);
     builder.with_column("ck", utf8_type, column_kind::clustering_key);
     builder.with_column("rc1", counter_type);
@@ -3949,7 +3952,7 @@ SEASTAR_TEST_CASE(test_write_different_types) {
     // smallintval smallint, timeval time, tsval timestamp, timeuuidval timeuuid,
     // tinyintval tinyint,  uuidval uuid, varcharval varchar, varintval varint,
     // durationval duration, PRIMARY KEY (pk)) WITH compression = {'sstable_compression': ''};
-    schema_builder builder("sst3", table_name);
+    schema_builder builder(env.registry(), "sst3", table_name);
     builder.with_column("pk", utf8_type, column_kind::partition_key);
     builder.with_column("asciival", ascii_type);
     builder.with_column("bigintval", long_type);
@@ -4013,7 +4016,7 @@ SEASTAR_TEST_CASE(test_write_empty_clustering_values) {
   return test_env::do_with_async([] (test_env& env) {
     sstring table_name = "empty_clustering_values";
     // CREATE TABLE empty_clustering_values (pk int, ck1 text, ck2 int, ck3 text, rc int, PRIMARY KEY (pk, ck1, ck2, ck3)) WITH compression = {'sstable_compression': ''};
-    schema_builder builder("sst3", table_name);
+    schema_builder builder(env.registry(), "sst3", table_name);
     builder.with_column("pk", int32_type, column_kind::partition_key);
     builder.with_column("ck1", utf8_type, column_kind::clustering_key);
     builder.with_column("ck2", int32_type, column_kind::clustering_key);
@@ -4038,7 +4041,7 @@ SEASTAR_TEST_CASE(test_write_large_clustering_key) {
   return test_env::do_with_async([] (test_env& env) {
     sstring table_name = "large_clustering_key";
     // CREATE TABLE large_clustering_key (pk int, ck1 text, ck2 text, ..., ck35 text, rc int, PRIMARY KEY (pk, ck1, ck2, ..., ck35)) WITH compression = {'sstable_compression': ''};
-    schema_builder builder("sst3", table_name);
+    schema_builder builder(env.registry(), "sst3", table_name);
     builder.with_column("pk", int32_type, column_kind::partition_key);
     for (auto idx: boost::irange(1, 36)) {
         builder.with_column(to_bytes(format("ck{}", idx)), utf8_type, column_kind::clustering_key);
@@ -4070,7 +4073,7 @@ SEASTAR_TEST_CASE(test_write_compact_table) {
   return test_env::do_with_async([] (test_env& env) {
     sstring table_name = "compact_table";
     // CREATE TABLE compact_table (pk int, ck1 int, ck2 int, rc int, PRIMARY KEY (pk, ck1, ck2)) WITH compression = {'sstable_compression': ''} AND COMPACT STORAGE;
-    schema_builder builder("sst3", table_name);
+    schema_builder builder(env.registry(), "sst3", table_name);
     builder.with_column("pk", int32_type, column_kind::partition_key);
     builder.with_column("ck1", int32_type, column_kind::clustering_key);
     builder.with_column("ck2", int32_type, column_kind::clustering_key);
@@ -4098,7 +4101,7 @@ SEASTAR_TEST_CASE(test_write_user_defined_type_table) {
 
     sstring table_name = "user_defined_type_table";
     // CREATE TABLE user_defined_type_table (pk int, rc frozen <ut>, PRIMARY KEY (pk)) WITH compression = {'sstable_compression': ''};
-    schema_builder builder("sst3", table_name);
+    schema_builder builder(env.registry(), "sst3", table_name);
     builder.with_column("pk", int32_type, column_kind::partition_key);
     builder.with_column("rc", ut);
     builder.set_compressor_params(compression_parameters::no_compression());
@@ -4121,7 +4124,7 @@ SEASTAR_TEST_CASE(test_write_simple_range_tombstone) {
   return test_env::do_with_async([] (test_env& env) {
     sstring table_name = "simple_range_tombstone";
     // CREATE TABLE simple_range_tombstone (pk int, ck1 text, ck2 text, rc text, PRIMARY KEY (pk, ck1, ck2)) WITH compression = {'sstable_compression': ''};
-    schema_builder builder("sst3", table_name);
+    schema_builder builder(env.registry(), "sst3", table_name);
     builder.with_column("pk", int32_type, column_kind::partition_key);
     builder.with_column("ck1", utf8_type, column_kind::clustering_key);
     builder.with_column("ck2", utf8_type, column_kind::clustering_key);
@@ -4146,7 +4149,7 @@ SEASTAR_TEST_CASE(test_write_adjacent_range_tombstones) {
   return test_env::do_with_async([] (test_env& env) {
     sstring table_name = "adjacent_range_tombstones";
     // CREATE TABLE adjacent_range_tombstones (pk text, ck1 text, ck2 text, ck3 text, PRIMARY KEY (pk, ck1, ck2, ck3)) WITH compression = {'sstable_compression': ''};
-    schema_builder builder("sst3", table_name);
+    schema_builder builder(env.registry(), "sst3", table_name);
     builder.with_column("pk", utf8_type, column_kind::partition_key);
     builder.with_column("ck1", utf8_type, column_kind::clustering_key);
     builder.with_column("ck2", utf8_type, column_kind::clustering_key);
@@ -4187,7 +4190,7 @@ SEASTAR_TEST_CASE(test_write_non_adjacent_range_tombstones) {
   return test_env::do_with_async([] (test_env& env) {
     sstring table_name = "non_adjacent_range_tombstones";
     // CREATE TABLE non_adjacent_range_tombstones (pk text, ck1 text, ck2 text, ck3 text, PRIMARY KEY (pk, ck1, ck2, ck3)) WITH compression = {'sstable_compression': ''};
-    schema_builder builder("sst3", table_name);
+    schema_builder builder(env.registry(), "sst3", table_name);
     builder.with_column("pk", utf8_type, column_kind::partition_key);
     builder.with_column("ck1", utf8_type, column_kind::clustering_key);
     builder.with_column("ck2", utf8_type, column_kind::clustering_key);
@@ -4226,7 +4229,7 @@ SEASTAR_TEST_CASE(test_write_mixed_rows_and_range_tombstones) {
   return test_env::do_with_async([] (test_env& env) {
     sstring table_name = "mixed_rows_and_range_tombstones";
     // CREATE TABLE mixed_rows_and_range_tombstones (pk text, ck1 text, ck2 text, PRIMARY KEY (pk, ck1, ck2)) WITH compression = {'sstable_compression': ''};
-    schema_builder builder("sst3", table_name);
+    schema_builder builder(env.registry(), "sst3", table_name);
     builder.with_column("pk", utf8_type, column_kind::partition_key);
     builder.with_column("ck1", utf8_type, column_kind::clustering_key);
     builder.with_column("ck2", utf8_type, column_kind::clustering_key);
@@ -4295,7 +4298,7 @@ SEASTAR_TEST_CASE(test_write_many_range_tombstones) {
   return test_env::do_with_async([] (test_env& env) {
     sstring table_name = "many_range_tombstones";
     // CREATE TABLE many_range_tombstones (pk text, ck1 text, ck2 text, PRIMARY KEY (pk, ck1, ck2) WITH compression = {'sstable_compression': ''};
-    schema_builder builder("sst3", table_name);
+    schema_builder builder(env.registry(), "sst3", table_name);
     builder.with_column("pk", utf8_type, column_kind::partition_key);
     builder.with_column("ck1", utf8_type, column_kind::clustering_key);
     builder.with_column("ck2", utf8_type, column_kind::clustering_key);
@@ -4325,7 +4328,7 @@ SEASTAR_TEST_CASE(test_write_adjacent_range_tombstones_with_rows) {
   return test_env::do_with_async([] (test_env& env) {
     sstring table_name = "adjacent_range_tombstones_with_rows";
     // CREATE TABLE adjacent_range_tombstones_with_rows (pk text, ck1 text, ck2 text, ck3 text, PRIMARY KEY (pk, ck1, ck2, ck3)) WITH compression = {'sstable_compression': ''};
-    schema_builder builder("sst3", table_name);
+    schema_builder builder(env.registry(), "sst3", table_name);
     builder.with_column("pk", utf8_type, column_kind::partition_key);
     builder.with_column("ck1", utf8_type, column_kind::clustering_key);
     builder.with_column("ck2", utf8_type, column_kind::clustering_key);
@@ -4378,7 +4381,7 @@ SEASTAR_TEST_CASE(test_write_range_tombstone_same_start_with_row) {
   return test_env::do_with_async([] (test_env& env) {
     sstring table_name = "range_tombstone_same_start_with_row";
     // CREATE TABLE range_tombstone_same_start_with_row (pk int, ck1 text, ck2 text, PRIMARY KEY (pk, ck1, ck2)) WITH compression = {'sstable_compression': ''};
-    schema_builder builder("sst3", table_name);
+    schema_builder builder(env.registry(), "sst3", table_name);
     builder.with_column("pk", int32_type, column_kind::partition_key);
     builder.with_column("ck1", utf8_type, column_kind::clustering_key);
     builder.with_column("ck2", utf8_type, column_kind::clustering_key);
@@ -4413,7 +4416,7 @@ SEASTAR_TEST_CASE(test_write_range_tombstone_same_end_with_row) {
   return test_env::do_with_async([] (test_env& env) {
     sstring table_name = "range_tombstone_same_end_with_row";
     // CREATE TABLE range_tombstone_same_end_with_row (pk int, ck1 text, ck2 text, PRIMARY KEY (pk, ck1, ck2)) WITH compression = {'sstable_compression': ''};
-    schema_builder builder("sst3", table_name);
+    schema_builder builder(env.registry(), "sst3", table_name);
     builder.with_column("pk", int32_type, column_kind::partition_key);
     builder.with_column("ck1", utf8_type, column_kind::clustering_key);
     builder.with_column("ck2", utf8_type, column_kind::clustering_key);
@@ -4448,7 +4451,7 @@ SEASTAR_TEST_CASE(test_write_overlapped_start_range_tombstones) {
   return test_env::do_with_async([] (test_env& env) {
     sstring table_name = "overlapped_start_range_tombstones";
     // CREATE TABLE overlapped_start_range_tombstones (pk int, ck1 text, ck2 text, PRIMARY KEY (pk, ck1, ck2)) WITH compression = {'sstable_compression': ''};
-    schema_builder builder("sst3", table_name);
+    schema_builder builder(env.registry(), "sst3", table_name);
     builder.with_column("pk", int32_type, column_kind::partition_key);
     builder.with_column("ck1", utf8_type, column_kind::clustering_key);
     builder.with_column("ck2", utf8_type, column_kind::clustering_key);
@@ -4497,7 +4500,7 @@ SEASTAR_TEST_CASE(test_write_two_non_adjacent_range_tombstones) {
   return test_env::do_with_async([] (test_env& env) {
     sstring table_name = "two_non_adjacent_range_tombstones";
     // CREATE TABLE two_non_adjacent_range_tombstones (pk int, ck1 text, ck2 text, PRIMARY KEY (pk, ck1, ck2)) WITH compression = {'sstable_compression': ''};
-    schema_builder builder("sst3", table_name);
+    schema_builder builder(env.registry(), "sst3", table_name);
     builder.with_column("pk", int32_type, column_kind::partition_key);
     builder.with_column("ck1", utf8_type, column_kind::clustering_key);
     builder.with_column("ck2", utf8_type, column_kind::clustering_key);
@@ -4541,7 +4544,7 @@ SEASTAR_TEST_CASE(test_write_overlapped_range_tombstones) {
   return test_env::do_with_async([] (test_env& env) {
     sstring table_name = "overlapped_range_tombstones";
     // CREATE TABLE overlapped_range_tombstones (pk text, ck1 text, ck2 text, ck3 text, PRIMARY KEY (pk, ck1, ck2, ck3)) WITH compression = {'sstable_compression': ''};
-    schema_builder builder("sst3", table_name);
+    schema_builder builder(env.registry(), "sst3", table_name);
     builder.with_column("pk", utf8_type, column_kind::partition_key);
     builder.with_column("ck1", utf8_type, column_kind::clustering_key);
     builder.with_column("ck2", utf8_type, column_kind::clustering_key);
@@ -4601,7 +4604,7 @@ shared_sstable make_test_sstable(test_env& env, schema_ptr schema, const sstring
 SEASTAR_TEST_CASE(test_read_empty_index) {
   return test_env::do_with_async([] (test_env& env) {
     sstring table_name = "empty_index";
-    schema_builder builder("sst3", table_name);
+    schema_builder builder(env.registry(), "sst3", table_name);
     builder.with_column("pk", utf8_type, column_kind::partition_key);
     builder.set_compressor_params(compression_parameters::no_compression());
     schema_ptr s = builder.build(schema_builder::compact_storage::no);
@@ -4618,7 +4621,7 @@ SEASTAR_TEST_CASE(test_read_rows_only_index) {
   return test_env::do_with_async([] (test_env& env) {
     sstring table_name = "rows_only_index";
     // CREATE TABLE rows_only_index (pk text, ck text, st text, rc text, PRIMARY KEY (pk, ck) WITH compression = {'sstable_compression': ''};
-    schema_builder builder("sst3", table_name);
+    schema_builder builder(env.registry(), "sst3", table_name);
     builder.with_column("pk", utf8_type, column_kind::partition_key);
     builder.with_column("ck", utf8_type, column_kind::clustering_key);
     builder.with_column("st", utf8_type, column_kind::static_column);
@@ -4638,7 +4641,7 @@ SEASTAR_TEST_CASE(test_read_range_tombstones_only_index) {
   return test_env::do_with_async([] (test_env& env) {
     sstring table_name = "range_tombstones_only_index";
     // CREATE TABLE range_tombstones_only_index (pk text, ck1 text, ck2 text, PRIMARY KEY (pk, ck1, ck2) WITH compression = {'sstable_compression': ''};
-    schema_builder builder("sst3", table_name);
+    schema_builder builder(env.registry(), "sst3", table_name);
     builder.with_column("pk", utf8_type, column_kind::partition_key);
     builder.with_column("ck1", utf8_type, column_kind::clustering_key);
     builder.with_column("ck2", utf8_type, column_kind::clustering_key);
@@ -4665,7 +4668,7 @@ SEASTAR_TEST_CASE(test_read_range_tombstone_boundaries_index) {
   return test_env::do_with_async([] (test_env& env) {
     sstring table_name = "range_tombstone_boundaries_index";
     // CREATE TABLE range_tombstone_boundaries_index (pk text, ck1 text, ck2 text, PRIMARY KEY (pk, ck1, ck2) WITH compression = {'sstable_compression': ''};
-    schema_builder builder("sst3", table_name);
+    schema_builder builder(env.registry(), "sst3", table_name);
     builder.with_column("pk", utf8_type, column_kind::partition_key);
     builder.with_column("ck1", utf8_type, column_kind::clustering_key);
     builder.with_column("ck2", utf8_type, column_kind::clustering_key);
@@ -4680,7 +4683,7 @@ SEASTAR_TEST_CASE(test_read_range_tombstone_boundaries_index) {
 SEASTAR_TEST_CASE(test_read_table_empty_clustering_key) {
   return test_env::do_with_async([] (test_env& env) {
     // CREATE TABLE empty_clustering_key (pk int, v int, PRIMARY KEY (pk)) with compression = {'sstable_compression': ''};
-    schema_builder builder("sst3", "empty_clustering_key");
+    schema_builder builder(env.registry(), "sst3", "empty_clustering_key");
     builder.with_column("pk", int32_type, column_kind::partition_key);
     builder.with_column("v", int32_type);
     builder.set_compressor_params(compression_parameters::no_compression());
@@ -4711,7 +4714,7 @@ SEASTAR_TEST_CASE(test_complex_column_zero_subcolumns_read) {
     const sstring path =
         "test/resource/sstables/3.x/uncompressed/complex_column_zero_subcolumns";
 
-    schema_ptr s = schema_builder("test_ks", "test_table")
+    schema_ptr s = schema_builder(env.registry(), "test_ks", "test_table")
         .with_column("id", uuid_type, column_kind::partition_key)
         .with_column("bytes_in", long_type)
         .with_column("bytes_out", long_type)
@@ -4764,7 +4767,7 @@ SEASTAR_TEST_CASE(test_uncompressed_read_two_rows_fast_forwarding) {
 
     static const sstring path = "test/resource/sstables/3.x/uncompressed/read_two_rows_fast_forwarding";
     static thread_local const schema_ptr s =
-        schema_builder("test_ks", "two_rows_fast_forwarding")
+        schema_builder(_registry, "test_ks", "two_rows_fast_forwarding")
             .with_column("pk", int32_type, column_kind::partition_key)
             .with_column("ck", int32_type, column_kind::clustering_key)
             .with_column("rc", int32_type)
@@ -4818,7 +4821,7 @@ SEASTAR_TEST_CASE(test_dead_row_marker) {
     gc_clock::time_point tp = gc_clock::time_point{} + gc_clock::duration{1543494402};
     sstring table_name = "dead_row_marker";
     // CREATE TABLE dead_row_marker (pk int, ck int, st int static, rc int , PRIMARY KEY (pk, ck)) WITH compression = {'sstable_compression': ''};
-    schema_builder builder("sst3", table_name);
+    schema_builder builder(env.registry(), "sst3", table_name);
     builder.with_column("pk", int32_type, column_kind::partition_key);
     builder.with_column("ck", int32_type, column_kind::clustering_key);
     builder.with_column("st", int32_type, column_kind::static_column);
@@ -4851,7 +4854,7 @@ SEASTAR_TEST_CASE(test_shadowable_deletion) {
      * UPDATE cf SET v = 1 WHERE p = 1;
      */
     sstring table_name = "shadowable_deletion";
-    schema_builder builder("sst3", table_name);
+    schema_builder builder(env.registry(), "sst3", table_name);
     builder.with_column("pk", int32_type, column_kind::partition_key);
     builder.with_column("ck", int32_type, column_kind::clustering_key);
     builder.set_compressor_params(compression_parameters::no_compression());
@@ -4890,7 +4893,7 @@ SEASTAR_TEST_CASE(test_regular_and_shadowable_deletion) {
      * UPDATE cf USING TIMESTAMP 1540230874370003 SET v = 1 WHERE p = 1 AND c = 1;
      */
     sstring table_name = "regular_and_shadowable_deletion";
-    schema_builder builder("sst3", table_name);
+    schema_builder builder(env.registry(), "sst3", table_name);
     builder.with_column("v", int32_type, column_kind::partition_key);
     builder.with_column("p", int32_type, column_kind::clustering_key);
     builder.with_column("c", int32_type, column_kind::clustering_key);
@@ -4930,7 +4933,7 @@ SEASTAR_TEST_CASE(test_write_static_row_with_missing_columns) {
   return test_env::do_with_async([] (test_env& env) {
     sstring table_name = "static_row_with_missing_columns";
     // CREATE TABLE static_row (pk int, ck int, st1 int static, st2 int static, rc int, PRIMARY KEY (pk, ck)) WITH compression = {'sstable_compression': ''};
-    schema_builder builder("sst3", table_name);
+    schema_builder builder(env.registry(), "sst3", table_name);
     builder.with_column("pk", int32_type, column_kind::partition_key);
     builder.with_column("ck", int32_type, column_kind::clustering_key);
     builder.with_column("st1", int32_type, column_kind::static_column);
@@ -4957,7 +4960,7 @@ SEASTAR_TEST_CASE(test_write_interleaved_atomic_and_collection_columns) {
     // CREATE TABLE interleaved_atomic_and_collection_columns ( pk int, ck int, rc1 int, rc2 set<int>, rc3 int, rc4 set<int>,
     //     rc5 int, rc6 set<int>, PRIMARY KEY (pk, ck)) WITH compression = {'sstable_compression': ''};
     auto set_of_ints_type = set_type_impl::get_instance(int32_type, true);
-    schema_builder builder("sst3", table_name);
+    schema_builder builder(env.registry(), "sst3", table_name);
     builder.with_column("pk", int32_type, column_kind::partition_key);
     builder.with_column("ck", int32_type, column_kind::clustering_key);
     builder.with_column("rc1", int32_type);
@@ -4996,7 +4999,7 @@ SEASTAR_TEST_CASE(test_write_static_interleaved_atomic_and_collection_columns) {
     //     st2 set<int> static, st3 int static, st4 set<int> static, st5 int static, st6 set<int> static,
     //     PRIMARY KEY (pk, ck)) WITH compression = {'sstable_compression': ''};
     auto set_of_ints_type = set_type_impl::get_instance(int32_type, true);
-    schema_builder builder("sst3", table_name);
+    schema_builder builder(env.registry(), "sst3", table_name);
     builder.with_column("pk", int32_type, column_kind::partition_key);
     builder.with_column("ck", int32_type, column_kind::clustering_key);
     builder.with_column("st1", int32_type, column_kind::static_column);
@@ -5032,7 +5035,7 @@ SEASTAR_TEST_CASE(test_write_empty_static_row) {
   return test_env::do_with_async([] (test_env& env) {
     sstring table_name = "empty_static_row";
     // CREATE TABLE empty_static_row (pk int, ck int, st int static, rc int, PRIMARY KEY (pk, ck)) WITH compression = {'sstable_compression': ''};
-    schema_builder builder("sst3", table_name);
+    schema_builder builder(env.registry(), "sst3", table_name);
     builder.with_column("pk", int32_type, column_kind::partition_key);
     builder.with_column("ck", int32_type, column_kind::clustering_key);
     builder.with_column("st", int32_type, column_kind::static_column);
@@ -5073,7 +5076,7 @@ SEASTAR_TEST_CASE(test_read_missing_summary) {
   return test_env::do_with_async([] (test_env& env) {
     const sstring path = "test/resource/sstables/3.x/uncompressed/read_missing_summary";
     const schema_ptr s =
-        schema_builder("test_ks", "test_table")
+        schema_builder(env.registry(), "test_ks", "test_table")
             .with_column("pk", utf8_type, column_kind::partition_key)
             .with_column("ck", utf8_type, column_kind::clustering_key)
             .with_column("rc", utf8_type)
@@ -5089,7 +5092,7 @@ SEASTAR_TEST_CASE(test_sstable_reader_on_unknown_column) {
  return test_env::do_with_async([] (test_env& env) {
     api::timestamp_type write_timestamp = 1525385507816568;
     auto get_builder = [&] (bool has_missing_column) {
-        auto builder = schema_builder("ks", "cf")
+        auto builder = schema_builder(env.registry(), "ks", "cf")
             .with_column("pk", int32_type, column_kind::partition_key)
             .with_column("ck", int32_type, column_kind::clustering_key);
         if (!has_missing_column) {
@@ -5330,7 +5333,7 @@ SEASTAR_TEST_CASE(test_legacy_udt_in_collection_table) {
     auto l_type = list_type_impl::get_instance(ut, true);
     auto fl_type = list_type_impl::get_instance(ut, false);
 
-    auto s = schema_builder("ks", "t")
+    auto s = schema_builder(env.registry(), "ks", "t")
         .with_column("pk", int32_type, column_kind::partition_key)
         .with_column("m", m_type)
         .with_column("fm", fm_type)

--- a/test/boost/sstable_test.cc
+++ b/test/boost/sstable_test.cc
@@ -768,7 +768,7 @@ SEASTAR_TEST_CASE(sub_partitions_read) {
   schema_ptr s = large_partition_schema(*registry);
   return for_each_sstable_version([s, registry = std::move(registry)] (const sstables::sstable::version_types version) {
    return test_env::do_with_async([s, version] (test_env& env) {
-        auto sstp = load_large_partition_sst(*s->registry(), env, version).get();
+        auto sstp = load_large_partition_sst(s->registry(), env, version).get();
         auto nrows = count_rows(env, sstp, s, "18wX", "18xB").get();
         BOOST_REQUIRE(nrows == 5);
    });

--- a/test/boost/sstable_test.hh
+++ b/test/boost/sstable_test.hh
@@ -34,6 +34,7 @@
 #include "test/lib/sstable_test_env.hh"
 #include "test/lib/sstable_utils.hh"
 #include "test/lib/tmpdir.hh"
+#include "test/lib/schema_registry.hh"
 #include <boost/test/unit_test.hpp>
 #include <array>
 
@@ -88,9 +89,15 @@ inline sstring get_test_dir(const sstring& name, const schema_ptr s)
     return seastar::format("test/resource/sstables/{}/{}/{}-1c6ace40fad111e7b9cf000000000002", name, s->ks_name(), s->cf_name());
 }
 
+namespace {
+
+static thread_local tests::schema_registry_wrapper _schema_registry;
+
+}
+
 inline schema_ptr composite_schema() {
     static thread_local auto s = [] {
-        schema_builder builder(make_shared_schema({}, "tests", "composite",
+        schema_builder builder(make_shared_schema(_schema_registry, {}, "tests", "composite",
         // partition key
         {{"name", bytes_type}, {"col1", bytes_type}},
         // clustering key
@@ -112,7 +119,7 @@ inline schema_ptr composite_schema() {
 inline schema_ptr set_schema() {
     static thread_local auto s = [] {
         auto my_set_type = set_type_impl::get_instance(bytes_type, false);
-        schema_builder builder(make_shared_schema({}, "tests", "set_pk",
+        schema_builder builder(make_shared_schema(_schema_registry, {}, "tests", "set_pk",
         // partition key
         {{"ss", my_set_type}},
         // clustering key
@@ -136,7 +143,7 @@ inline schema_ptr set_schema() {
 inline schema_ptr map_schema() {
     static thread_local auto s = [] {
         auto my_map_type = map_type_impl::get_instance(bytes_type, bytes_type, false);
-        schema_builder builder(make_shared_schema({}, "tests", "map_pk",
+        schema_builder builder(make_shared_schema(_schema_registry, {}, "tests", "map_pk",
         // partition key
         {{"ss", my_map_type}},
         // clustering key
@@ -160,7 +167,7 @@ inline schema_ptr map_schema() {
 inline schema_ptr list_schema() {
     static thread_local auto s = [] {
         auto my_list_type = list_type_impl::get_instance(bytes_type, false);
-        schema_builder builder(make_shared_schema({}, "tests", "list_pk",
+        schema_builder builder(make_shared_schema(_schema_registry, {}, "tests", "list_pk",
         // partition key
         {{"ss", my_list_type}},
         // clustering key
@@ -183,7 +190,7 @@ inline schema_ptr list_schema() {
 
 inline schema_ptr uncompressed_schema(int32_t min_index_interval = 0) {
     auto uncompressed = [=] {
-        schema_builder builder(make_shared_schema(generate_legacy_id("ks", "uncompressed"), "ks", "uncompressed",
+        schema_builder builder(make_shared_schema(_schema_registry, generate_legacy_id("ks", "uncompressed"), "ks", "uncompressed",
         // partition key
         {{"name", utf8_type}},
         // clustering key
@@ -218,7 +225,7 @@ inline schema_ptr complex_schema() {
         auto my_fset_type = set_type_impl::get_instance(bytes_type, false);
         auto my_set_static_type = set_type_impl::get_instance(bytes_type, true);
 
-        schema_builder builder(make_shared_schema({}, "tests", "complex_schema",
+        schema_builder builder(make_shared_schema(_schema_registry, {}, "tests", "complex_schema",
         // partition key
         {{"key", bytes_type}},
         // clustering key
@@ -245,7 +252,7 @@ inline schema_ptr complex_schema() {
 
 inline schema_ptr columns_schema() {
     static thread_local auto columns = [] {
-        schema_builder builder(make_shared_schema(generate_legacy_id("name", "columns"), "name", "columns",
+        schema_builder builder(make_shared_schema(_schema_registry, generate_legacy_id("name", "columns"), "name", "columns",
         // partition key
         {{"keyspace_name", utf8_type}},
         // clustering key
@@ -273,7 +280,7 @@ inline schema_ptr columns_schema() {
 
 inline schema_ptr compact_simple_dense_schema() {
     static thread_local auto s = [] {
-        schema_builder builder(make_shared_schema({}, "tests", "compact_simple_dense",
+        schema_builder builder(make_shared_schema(_schema_registry, {}, "tests", "compact_simple_dense",
         // partition key
         {{"ks", bytes_type}},
         // clustering key
@@ -294,7 +301,7 @@ inline schema_ptr compact_simple_dense_schema() {
 
 inline schema_ptr compact_dense_schema() {
     static thread_local auto s = [] {
-        schema_builder builder(make_shared_schema({}, "tests", "compact_simple_dense",
+        schema_builder builder(make_shared_schema(_schema_registry, {}, "tests", "compact_simple_dense",
         // partition key
         {{"ks", bytes_type}},
         // clustering key
@@ -315,7 +322,7 @@ inline schema_ptr compact_dense_schema() {
 
 inline schema_ptr compact_sparse_schema() {
     static thread_local auto s = [] {
-        schema_builder builder(make_shared_schema({}, "tests", "compact_sparse",
+        schema_builder builder(make_shared_schema(_schema_registry, {}, "tests", "compact_sparse",
         // partition key
         {{"ks", bytes_type}},
         // clustering key
@@ -343,7 +350,7 @@ inline schema_ptr compact_sparse_schema() {
 //    sure we are testing the exact some one we have in our test dir.
 inline schema_ptr peers_schema() {
     static thread_local auto peers = [] {
-        schema_builder builder(make_shared_schema(generate_legacy_id("system", "peers"), "system", "peers",
+        schema_builder builder(make_shared_schema(_schema_registry, generate_legacy_id("system", "peers"), "system", "peers",
         // partition key
         {{"peer", inet_addr_type}},
         // clustering key

--- a/test/boost/storage_proxy_test.cc
+++ b/test/boost/storage_proxy_test.cc
@@ -45,8 +45,8 @@ static std::vector<dht::ring_position> make_ring(schema_ptr s, int n_keys) {
 
 SEASTAR_TEST_CASE(test_get_restricted_ranges) {
     return do_with_cql_env([](cql_test_env& e) {
-        return seastar::async([] {
-            auto s = schema_builder("ks", "cf")
+        return seastar::async([&e] {
+            auto s = schema_builder(e.local_db().get_schema_registry(), "ks", "cf")
                     .with_column("pk", bytes_type, column_kind::partition_key)
                     .with_column("v", bytes_type, column_kind::regular_column)
                     .build();

--- a/test/boost/virtual_table_mutation_source_test.cc
+++ b/test/boost/virtual_table_mutation_source_test.cc
@@ -87,5 +87,5 @@ SEASTAR_THREAD_TEST_CASE(test_streaming_vt_as_mutation_source) {
                 mutation_reader::forwarding) {
             return ms.make_reader(s, permit, pr, slice, pc, trace_state, stream_fwd, mutation_reader::forwarding::no);
         });
-    }, false /* with_partition_range_forwarding */);
+    }, nullptr, false /* with_partition_range_forwarding */);
 }

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -578,7 +578,7 @@ public:
             auto stop_storage_service = defer([&ss] { ss.stop().get(); });
 
             sharded<schema_registry> schema_registry;
-            schema_registry.start().get();
+            schema_registry.start(std::cref(*cfg)).get();
             auto stop_schema_registry = defer([&schema_registry] {
                 schema_registry.stop().get();
             });

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -579,9 +579,6 @@ public:
 
             sharded<schema_registry> schema_registry;
             schema_registry.start().get();
-            schema_registry.invoke_on_all([] (::schema_registry& sr) {
-                ::set_local_schema_registry(sr);
-            }).get();
             auto stop_schema_registry = defer([&schema_registry] {
                 schema_registry.stop().get();
             });

--- a/test/lib/data_model.cc
+++ b/test/lib/data_model.cc
@@ -263,8 +263,8 @@ void table_description::alter_column_type(std::vector<column>& columns, const ss
     std::get<data_type>(*it) = new_type;
 }
 
-schema_ptr table_description::build_schema() const {
-    auto sb = schema_builder("ks", "cf");
+schema_ptr table_description::build_schema(schema_registry& registry) const {
+    auto sb = schema_builder(registry, "ks", "cf");
     for (auto&& [ name, type ] : _partition_key) {
         sb.with_column(utf8_type->decompose(name), type, column_kind::partition_key);
     }
@@ -367,8 +367,8 @@ void table_description::rename_clustering_column(const sstring& from, const sstr
     std::get<sstring>(*it) = to;
 }
 
-table_description::table table_description::build() const {
-    auto s = build_schema();
+table_description::table table_description::build(schema_registry& registry) const {
+    auto s = build_schema(registry);
     return { boost::algorithm::join(_change_log, "\n"), s, build_mutations(s) };
 }
 

--- a/test/lib/data_model.hh
+++ b/test/lib/data_model.hh
@@ -24,6 +24,7 @@
 #include "mutation.hh"
 #include "cql3/cql3_type.hh"
 #include "schema.hh"
+#include "schema_registry.hh"
 
 namespace tests::data_model {
 
@@ -142,7 +143,7 @@ private:
     void remove_column(std::vector<column>& columns, const sstring& name);
     static void alter_column_type(std::vector<column>& columns, const sstring& name, data_type new_type);
 
-    schema_ptr build_schema() const;
+    schema_ptr build_schema(::schema_registry& registry) const;
 
     std::vector<mutation> build_mutations(schema_ptr s) const;
 public:
@@ -174,7 +175,7 @@ public:
         schema_ptr schema;
         std::vector<mutation> mutations;
     };
-    table build() const;
+    table build(::schema_registry& registry) const;
 };
 
 }

--- a/test/lib/mutation_source_test.cc
+++ b/test/lib/mutation_source_test.cc
@@ -1729,10 +1729,7 @@ void run_mutation_reader_tests(populate_fn_ex populate, cql_test_env* test_env, 
         extensions.emplace();
         extensions->start().get();
         schema_registry.emplace();
-        schema_registry->start().get();
-        schema_registry->invoke_on_all([&] (::schema_registry& r) {
-            r.init(db::schema_ctxt(db::schema_ctxt::for_tests{}, extensions->local()));
-        }).get();
+        schema_registry->start(sharded_parameter([] (db::extensions& e) { return db::schema_ctxt(db::schema_ctxt::for_tests{}, e); }, std::ref(*extensions))).get();
     }
     auto& local_registry = test_env ? test_env->local_db().get_schema_registry() : schema_registry->local();
 

--- a/test/lib/mutation_source_test.cc
+++ b/test/lib/mutation_source_test.cc
@@ -1709,6 +1709,8 @@ void run_mutation_reader_tests(populate_fn_ex populate, tests::reader_concurrenc
 }
 
 void run_mutation_reader_tests(populate_fn_ex populate, cql_test_env* test_env, bool with_partition_range_forwarding) {
+    testlog.info("{}: {}", __PRETTY_FUNCTION__, fmt::ptr(test_env));
+
     auto semaphore = test_env ? tests::reader_concurrency_semaphore_wrapper(test_env->local_db().get_reader_concurrency_semaphore()) : tests::reader_concurrency_semaphore_wrapper();
 
     run_mutation_reader_tests(std::move(populate), semaphore, with_partition_range_forwarding);
@@ -1766,10 +1768,12 @@ void run_mutation_source_tests(populate_fn_ex populate, cql_test_env* test_env, 
 }
 
 void run_mutation_source_tests_plain(populate_fn_ex populate, cql_test_env* test_env, bool with_partition_range_forwarding) {
+    testlog.info(__PRETTY_FUNCTION__);
     run_mutation_reader_tests(populate, test_env, with_partition_range_forwarding);
 }
 
 void run_mutation_source_tests_downgrade(populate_fn_ex populate, cql_test_env* test_env, bool with_partition_range_forwarding) {
+    testlog.info(__PRETTY_FUNCTION__);
     // ? -> v2 -> v1 -> *
     run_mutation_reader_tests([populate] (schema_ptr s, const std::vector<mutation>& m, gc_clock::time_point t) -> mutation_source {
         return mutation_source([ms = populate(s, m, t)] (schema_ptr s,
@@ -1787,6 +1791,7 @@ void run_mutation_source_tests_downgrade(populate_fn_ex populate, cql_test_env* 
 }
 
 void run_mutation_source_tests_upgrade(populate_fn_ex populate, cql_test_env* test_env, bool with_partition_range_forwarding) {
+    testlog.info(__PRETTY_FUNCTION__);
     // ? -> v1 -> v2 -> *
     run_mutation_reader_tests([populate] (schema_ptr s, const std::vector<mutation>& m, gc_clock::time_point t) -> mutation_source {
         return mutation_source([ms = populate(s, m, t)] (schema_ptr s,
@@ -1804,6 +1809,7 @@ void run_mutation_source_tests_upgrade(populate_fn_ex populate, cql_test_env* te
 }
 
 void run_mutation_source_tests_reverse(populate_fn_ex populate, cql_test_env* test_env, bool with_partition_range_forwarding) {
+    testlog.info(__PRETTY_FUNCTION__);
     // read in reverse
     run_mutation_reader_tests([populate] (schema_ptr s, const std::vector<mutation>& m, gc_clock::time_point t) -> mutation_source {
         auto table_schema = s->make_reversed();

--- a/test/lib/mutation_source_test.hh
+++ b/test/lib/mutation_source_test.hh
@@ -41,10 +41,10 @@ enum are_equal { no, yes };
 
 // Calls the provided function on mutation pairs, equal and not equal. Is supposed
 // to exercise all potential ways two mutations may differ.
-void for_each_mutation_pair(std::function<void(const mutation&, const mutation&, are_equal)>);
+void for_each_mutation_pair(schema_registry& registry, std::function<void(const mutation&, const mutation&, are_equal)>);
 
 // Calls the provided function on mutations. Is supposed to exercise as many differences as possible.
-void for_each_mutation(std::function<void(const mutation&)>);
+void for_each_mutation(schema_registry& registry, std::function<void(const mutation&)>);
 
 // Returns true if mutations in schema s1 can be upgraded to s2.
 inline bool can_upgrade_schema(schema_ptr from, schema_ptr to) {
@@ -63,7 +63,7 @@ public:
     // is no higher level tombstone will cover lower level tombstones and no
     // tombstone will cover data, i.e. compacting the mutation will not result
     // in any changes.
-    explicit random_mutation_generator(generate_counters, local_shard_only lso = local_shard_only::yes,
+    explicit random_mutation_generator(schema_registry& registry, generate_counters, local_shard_only lso = local_shard_only::yes,
             generate_uncompactable uc = generate_uncompactable::no);
     ~random_mutation_generator();
     mutation operator()();

--- a/test/lib/mutation_source_test.hh
+++ b/test/lib/mutation_source_test.hh
@@ -24,16 +24,18 @@
 #include "mutation_reader.hh"
 #include "test/lib/sstable_utils.hh"
 
+class cql_test_env;
+
 using populate_fn = std::function<mutation_source(schema_ptr s, const std::vector<mutation>&)>;
 using populate_fn_ex = std::function<mutation_source(schema_ptr s, const std::vector<mutation>&, gc_clock::time_point)>;
 
 // Must be run in a seastar thread
-void run_mutation_source_tests(populate_fn populate, bool with_partition_range_forwarding = true);
-void run_mutation_source_tests(populate_fn_ex populate, bool with_partition_range_forwarding = true);
-void run_mutation_source_tests_plain(populate_fn_ex populate, bool with_partition_range_forwarding = true);
-void run_mutation_source_tests_downgrade(populate_fn_ex populate, bool with_partition_range_forwarding = true);
-void run_mutation_source_tests_upgrade(populate_fn_ex populate, bool with_partition_range_forwarding = true);
-void run_mutation_source_tests_reverse(populate_fn_ex populate, bool with_partition_range_forwarding = true);
+void run_mutation_source_tests(populate_fn populate, cql_test_env* test_env = nullptr, bool with_partition_range_forwarding = true);
+void run_mutation_source_tests(populate_fn_ex populate, cql_test_env* test_env = nullptr, bool with_partition_range_forwarding = true);
+void run_mutation_source_tests_plain(populate_fn_ex populate, cql_test_env* test_env = nullptr, bool with_partition_range_forwarding = true);
+void run_mutation_source_tests_downgrade(populate_fn_ex populate, cql_test_env* test_env = nullptr, bool with_partition_range_forwarding = true);
+void run_mutation_source_tests_upgrade(populate_fn_ex populate, cql_test_env* test_env = nullptr, bool with_partition_range_forwarding = true);
+void run_mutation_source_tests_reverse(populate_fn_ex populate, cql_test_env* test_env = nullptr, bool with_partition_range_forwarding = true);
 
 enum are_equal { no, yes };
 

--- a/test/lib/random_schema.cc
+++ b/test/lib/random_schema.cc
@@ -747,9 +747,9 @@ expiry_generator no_expiry_expiry_generator() {
 
 namespace {
 
-schema_ptr build_random_schema(uint32_t seed, random_schema_specification& spec) {
+schema_ptr build_random_schema(schema_registry& registry, uint32_t seed, random_schema_specification& spec) {
     auto engine = std::mt19937{seed};
-    auto builder = schema_builder(spec.keyspace_name(), spec.table_name(engine));
+    auto builder = schema_builder(registry, spec.keyspace_name(), spec.table_name(engine));
 
     auto pk_columns = spec.partition_key_columns(engine);
     assert(!pk_columns.empty()); // Let's not pull in boost::test here
@@ -925,7 +925,7 @@ data_model::mutation_description::key random_schema::make_clustering_key(uint32_
 }
 
 random_schema::random_schema(uint32_t seed, random_schema_specification& spec)
-    : _schema(build_random_schema(seed, spec)) {
+    : _schema(build_random_schema(_registry, seed, spec)) {
 }
 
 sstring random_schema::cql() const {

--- a/test/lib/random_schema.hh
+++ b/test/lib/random_schema.hh
@@ -24,6 +24,7 @@
 #include "schema.hh"
 #include "dht/i_partitioner.hh"
 #include "test/lib/data_model.hh"
+#include "test/lib/schema_registry.hh"
 
 ///
 /// Random schema and random data generation related utilities.
@@ -161,6 +162,7 @@ expiry_generator no_expiry_expiry_generator();
 /// The schema is generated when the class is constructed.
 /// The generation is deterministic, the same seed will generate the same schema.
 class random_schema {
+    tests::schema_registry_wrapper _registry;
     schema_ptr _schema;
 
 private:

--- a/test/lib/reader_concurrency_semaphore.hh
+++ b/test/lib/reader_concurrency_semaphore.hh
@@ -28,18 +28,25 @@ namespace tests {
 
 // Must be used in a seastar thread.
 class reader_concurrency_semaphore_wrapper {
-    std::unique_ptr<::reader_concurrency_semaphore> _semaphore;
+    std::unique_ptr<::reader_concurrency_semaphore> _stored_semaphore;
+    ::reader_concurrency_semaphore& _semaphore;
 
 public:
-    reader_concurrency_semaphore_wrapper(const char* name = nullptr)
-        : _semaphore(std::make_unique<::reader_concurrency_semaphore>(::reader_concurrency_semaphore::no_limits{}, name ? name : "test")) {
-    }
+    explicit reader_concurrency_semaphore_wrapper(reader_concurrency_semaphore& semaphore)
+        : _semaphore(semaphore)
+    { }
+    explicit reader_concurrency_semaphore_wrapper(const char* name = nullptr)
+        : _stored_semaphore(std::make_unique<::reader_concurrency_semaphore>(::reader_concurrency_semaphore::no_limits{}, name ? name : "test"))
+        , _semaphore(*_stored_semaphore)
+    { }
     ~reader_concurrency_semaphore_wrapper() {
-        _semaphore->stop().get();
+        if (_stored_semaphore) {
+            _stored_semaphore->stop().get();
+        }
     }
 
-    reader_concurrency_semaphore& semaphore() { return *_semaphore; };
-    reader_permit make_permit() { return _semaphore->make_tracking_only_permit(nullptr, "test", db::no_timeout); }
+    reader_concurrency_semaphore& semaphore() { return _semaphore; };
+    reader_permit make_permit() { return _semaphore.make_tracking_only_permit(nullptr, "test", db::no_timeout); }
 };
 
 } // namespace tests

--- a/test/lib/schema_registry.hh
+++ b/test/lib/schema_registry.hh
@@ -37,9 +37,8 @@ public:
         : _registry(registry) {
     }
     schema_registry_wrapper()
-        : _stored_registry(std::in_place_t{})
+        : _stored_registry(std::in_place_t{}, db::schema_ctxt(db::schema_ctxt::for_tests{}, _extensions))
         , _registry(*_stored_registry) {
-        _registry.init(db::schema_ctxt(db::schema_ctxt::for_tests{}, _extensions));
     }
     schema_registry_wrapper(const schema_registry_wrapper&) = delete;
     schema_registry_wrapper(schema_registry_wrapper&&) = delete;

--- a/test/lib/schema_registry.hh
+++ b/test/lib/schema_registry.hh
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2021-present ScyllaDB
+ */
+
+/*
+ * This file is part of Scylla.
+ *
+ * Scylla is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Scylla is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "../../schema_registry.hh"
+#include "db/schema_tables.hh"
+#include "db/extensions.hh"
+
+namespace tests {
+
+class schema_registry_wrapper {
+    db::extensions _extensions;
+    std::optional<schema_registry> _stored_registry;
+    schema_registry& _registry;
+
+public:
+    explicit schema_registry_wrapper(schema_registry& registry)
+        : _registry(registry) {
+    }
+    schema_registry_wrapper()
+        : _stored_registry(std::in_place_t{})
+        , _registry(*_stored_registry) {
+        _registry.init(db::schema_ctxt(db::schema_ctxt::for_tests{}, _extensions));
+    }
+    schema_registry_wrapper(const schema_registry_wrapper&) = delete;
+    schema_registry_wrapper(schema_registry_wrapper&&) = delete;
+    schema_registry_wrapper& operator=(const schema_registry_wrapper&) = delete;
+    schema_registry_wrapper& operator=(schema_registry_wrapper&&) = delete;
+
+    schema_registry& registry() { return _registry; }
+
+    operator schema_registry&() { return _registry; }
+
+    schema_registry& operator*() { return _registry; }
+    schema_registry* operator->() { return &_registry; }
+};
+
+} // namespace tests

--- a/test/lib/simple_schema.hh
+++ b/test/lib/simple_schema.hh
@@ -47,7 +47,7 @@ class simple_schema {
     table_schema_version _v_def_version;
 
     simple_schema(schema_ptr s, api::timestamp_type timestamp)
-        : _registry(make_lw_shared<tests::schema_registry_wrapper>(*s->registry()))
+        : _registry(make_lw_shared<tests::schema_registry_wrapper>(s->registry()))
         , _s(s)
         , _timestamp(timestamp)
     {}

--- a/test/lib/test_services.cc
+++ b/test/lib/test_services.cc
@@ -59,13 +59,13 @@ column_family_for_tests::data::data()
     : semaphore(reader_concurrency_semaphore::no_limits{}, "column_family_for_tests")
 { }
 
-column_family_for_tests::column_family_for_tests(sstables::sstables_manager& sstables_manager)
+
+column_family_for_tests::column_family_for_tests(sstables::sstables_manager& sstables_manager, schema_registry& registry)
     : column_family_for_tests(
-        sstables_manager,
-        schema_builder(some_keyspace, some_column_family)
-            .with_column(utf8_type->decompose("p1"), utf8_type, column_kind::partition_key)
-            .build()
-    )
+            sstables_manager,
+            schema_builder(registry, some_keyspace, some_column_family)
+                .with_column(utf8_type->decompose("p1"), utf8_type, column_kind::partition_key)
+                .build())
 { }
 
 column_family_for_tests::column_family_for_tests(sstables::sstables_manager& sstables_manager, schema_ptr s)

--- a/test/lib/test_services.hh
+++ b/test/lib/test_services.hh
@@ -54,7 +54,7 @@ struct column_family_for_tests {
     };
     lw_shared_ptr<data> _data;
 
-    explicit column_family_for_tests(sstables::sstables_manager& sstables_manager);
+    explicit column_family_for_tests(sstables::sstables_manager& sstables_manager, schema_registry& registry);
 
     explicit column_family_for_tests(sstables::sstables_manager& sstables_manager, schema_ptr s);
 

--- a/test/manual/enormous_table_scan_test.cc
+++ b/test/manual/enormous_table_scan_test.cc
@@ -217,8 +217,8 @@ static bool has_more_pages(::shared_ptr<cql_transport::messages::result_message>
 
 SEASTAR_TEST_CASE(scan_enormous_table_test) {
     return do_with_cql_env_thread([] (cql_test_env& e) {
-        e.create_table([](std::string_view ks_name) {
-            return *schema_builder(ks_name, "enormous_table")
+        e.create_table([&e](std::string_view ks_name) {
+            return *schema_builder(e.local_db().get_schema_registry(), ks_name, "enormous_table")
                     .with_column("pk", long_type, column_kind::partition_key)
                     .with_column("ck", long_type, column_kind::clustering_key)
                     .set_comment("a very big table (4.5 billion entries, one partition)")
@@ -249,8 +249,8 @@ SEASTAR_TEST_CASE(scan_enormous_table_test) {
 
 SEASTAR_TEST_CASE(count_enormous_table_test) {
     return do_with_cql_env_thread([] (cql_test_env& e) {
-        e.create_table([](std::string_view ks_name) {
-            return *schema_builder(ks_name, "enormous_table")
+        e.create_table([&e](std::string_view ks_name) {
+            return *schema_builder(e.local_db().get_schema_registry(), ks_name, "enormous_table")
                     .with_column("pk", long_type, column_kind::partition_key)
                     .with_column("ck", long_type, column_kind::clustering_key)
                     .set_comment("a very big table (4.5 billion entries, one partition)")

--- a/test/perf/perf_mutation.cc
+++ b/test/perf/perf_mutation.cc
@@ -23,6 +23,7 @@
 #include "database.hh"
 #include "schema_builder.hh"
 #include "test/perf/perf.hh"
+#include "test/lib/schema_registry.hh"
 #include <seastar/core/app-template.hh>
 #include <seastar/core/reactor.hh>
 
@@ -37,7 +38,8 @@ int main(int argc, char* argv[]) {
         ("column-count", bpo::value<size_t>()->default_value(1), "column count");
     return app.run_deprecated(argc, argv, [&] {
         size_t column_count = app.configuration()["column-count"].as<size_t>();
-        auto builder = schema_builder("ks", "cf")
+        tests::schema_registry_wrapper registry;
+        auto builder = schema_builder(registry, "ks", "cf")
             .with_column("p1", utf8_type, column_kind::partition_key)
             .with_column("c1", int32_type, column_kind::clustering_key);
 

--- a/test/perf/perf_row_cache_reads.cc
+++ b/test/perf/perf_row_cache_reads.cc
@@ -67,7 +67,9 @@ static const auto MB = 1024 * 1024;
 void test_scans_with_dummy_entries() {
     std::cout << __FUNCTION__<< std::endl;
 
-    auto s = schema_builder("ks", "cf")
+    tests::schema_registry_wrapper registry;
+
+    auto s = schema_builder(registry, "ks", "cf")
             .with_column("pk", uuid_type, column_kind::partition_key)
             .with_column("st", bytes_type, column_kind::static_column)
             .with_column("ck", reversed_type_impl::get_instance(uuid_type), column_kind::clustering_key)

--- a/test/perf/perf_row_cache_update.cc
+++ b/test/perf/perf_row_cache_update.cc
@@ -34,6 +34,7 @@
 #include "memtable.hh"
 #include "test/perf/perf.hh"
 #include "test/lib/reader_concurrency_semaphore.hh"
+#include "test/lib/schema_registry.hh"
 
 static const int update_iterations = 16;
 static const int cell_size = 128;
@@ -134,7 +135,8 @@ void run_test(const sstring& name, schema_ptr s, MutationGenerator&& gen) {
 }
 
 void test_small_partitions() {
-    auto s = schema_builder("ks", "cf")
+    tests::schema_registry_wrapper registry;
+    auto s = schema_builder(registry, "ks", "cf")
         .with_column("pk", uuid_type, column_kind::partition_key)
         .with_column("v1", bytes_type, column_kind::regular_column)
         .with_column("v2", bytes_type, column_kind::regular_column)
@@ -154,7 +156,8 @@ void test_small_partitions() {
 }
 
 void test_partition_with_lots_of_small_rows() {
-    auto s = schema_builder("ks", "cf")
+    tests::schema_registry_wrapper registry;
+    auto s = schema_builder(registry, "ks", "cf")
         .with_column("pk", uuid_type, column_kind::partition_key)
         .with_column("ck", reversed_type_impl::get_instance(int32_type), column_kind::clustering_key)
         .with_column("v1", bytes_type, column_kind::regular_column)
@@ -178,7 +181,8 @@ void test_partition_with_lots_of_small_rows() {
 }
 
 void test_partition_with_few_small_rows() {
-    auto s = schema_builder("ks", "cf")
+    tests::schema_registry_wrapper registry;
+    auto s = schema_builder(registry, "ks", "cf")
         .with_column("pk", uuid_type, column_kind::partition_key)
         .with_column("ck", reversed_type_impl::get_instance(int32_type), column_kind::clustering_key)
         .with_column("v1", bytes_type, column_kind::regular_column)
@@ -204,7 +208,8 @@ void test_partition_with_few_small_rows() {
 }
 
 void test_partition_with_lots_of_range_tombstones() {
-    auto s = schema_builder("ks", "cf")
+    tests::schema_registry_wrapper registry;
+    auto s = schema_builder(registry, "ks", "cf")
         .with_column("pk", uuid_type, column_kind::partition_key)
         .with_column("ck", reversed_type_impl::get_instance(int32_type), column_kind::clustering_key)
         .with_column("v1", bytes_type, column_kind::regular_column)

--- a/test/perf/perf_sstable.hh
+++ b/test/perf/perf_sstable.hh
@@ -31,6 +31,7 @@
 #include "test/lib/sstable_utils.hh"
 #include "test/lib/test_services.hh"
 #include "test/lib/random_utils.hh"
+#include "test/lib/schema_registry.hh"
 #include <boost/accumulators/framework/accumulator_set.hpp>
 #include <boost/accumulators/framework/features.hpp>
 #include <boost/accumulators/statistics/mean.hpp>
@@ -40,6 +41,7 @@
 using namespace sstables;
 
 class perf_sstable_test_env {
+    tests::schema_registry_wrapper _registry;
     test_env _env;
 
 public:
@@ -90,7 +92,7 @@ private:
             columns.push_back(schema::column{ to_bytes(format("column{:04d}", i)), utf8_type });
         }
 
-        schema_builder builder(make_shared_schema(generate_legacy_id("ks", "perf-test"), "ks", "perf-test",
+        schema_builder builder(make_shared_schema(_registry, generate_legacy_id("ks", "perf-test"), "ks", "perf-test",
             // partition key
             {{"name", utf8_type}},
             // clustering key

--- a/test/unit/row_cache_alloc_stress_test.cc
+++ b/test/unit/row_cache_alloc_stress_test.cc
@@ -32,6 +32,7 @@
 #include "schema_builder.hh"
 #include "memtable.hh"
 #include "test/lib/reader_concurrency_semaphore.hh"
+#include "test/lib/schema_registry.hh"
 
 static
 partition_key new_key(schema_ptr s) {
@@ -63,7 +64,8 @@ int main(int argc, char** argv) {
         // able to populate cache with large mutations This test works only
         // with seastar's allocator.
         return seastar::async([] {
-            auto s = schema_builder("ks", "cf")
+            tests::schema_registry_wrapper registry;
+            auto s = schema_builder(registry, "ks", "cf")
                 .with_column("pk", bytes_type, column_kind::partition_key)
                 .with_column("ck", bytes_type, column_kind::clustering_key)
                 .with_column("v", bytes_type, column_kind::regular_column)

--- a/tools/schema_loader.cc
+++ b/tools/schema_loader.cc
@@ -74,7 +74,6 @@ std::vector<schema_ptr> do_load_schemas(std::string_view schema_str) {
     }
 
     schema_registry registry;
-    ::set_local_schema_registry(registry);
 
     database db(cfg, dbcfg, migration_notifier, feature_service, token_metadata, registry, as, sst_dir_sem);
     auto stop_db = deferred_stop(db);

--- a/tools/schema_loader.cc
+++ b/tools/schema_loader.cc
@@ -82,7 +82,7 @@ std::vector<schema_ptr> do_load_schemas(std::string_view schema_str) {
                 "org.apache.cassandra.locator.LocalStrategy",
                 std::map<sstring, sstring>{},
                 false)).get();
-    db.add_column_family(db.find_keyspace(db::schema_tables::NAME), db::schema_tables::dropped_columns(), {});
+    db.add_column_family(db.find_keyspace(db::schema_tables::NAME), db::schema_tables::dropped_columns(db.get_schema_registry()), {});
 
     std::vector<schema_ptr> schemas;
 
@@ -125,7 +125,7 @@ std::vector<schema_ptr> do_load_schemas(std::string_view schema_str) {
                 throw std::runtime_error(fmt::format("tools::do_load_schemas(): expected modification statement to be against {}.{}, but it is against {}.{}",
                             db::schema_tables::NAME, db::schema_tables::DROPPED_COLUMNS, p->keyspace(), p->column_family()));
             }
-            auto schema = db::schema_tables::dropped_columns();
+            auto schema = db::schema_tables::dropped_columns(db.get_schema_registry());
             cql3::statements::modification_statement::json_cache_opt json_cache{};
             cql3::update_parameters params(schema, cql3::query_options::DEFAULT, api::new_timestamp(), schema->default_time_to_live(), cql3::update_parameters::prefetch_data(schema));
             auto pkeys = p->build_partition_keys(cql3::query_options::DEFAULT, json_cache);

--- a/tools/schema_loader.cc
+++ b/tools/schema_loader.cc
@@ -73,7 +73,7 @@ std::vector<schema_ptr> do_load_schemas(std::string_view schema_str) {
         locator::i_endpoint_snitch::create_snitch(cfg.endpoint_snitch()).get();
     }
 
-    schema_registry registry;
+    schema_registry registry(cfg);
 
     database db(cfg, dbcfg, migration_notifier, feature_service, token_metadata, registry, as, sst_dir_sem);
     auto stop_db = deferred_stop(db);

--- a/tools/schema_loader.cc
+++ b/tools/schema_loader.cc
@@ -39,6 +39,7 @@
 #include "locator/snitch_base.hh"
 #include "tools/schema_loader.hh"
 #include "utils/fb_utilities.hh"
+#include "schema_registry.hh"
 
 namespace {
 
@@ -72,7 +73,10 @@ std::vector<schema_ptr> do_load_schemas(std::string_view schema_str) {
         locator::i_endpoint_snitch::create_snitch(cfg.endpoint_snitch()).get();
     }
 
-    database db(cfg, dbcfg, migration_notifier, feature_service, token_metadata, as, sst_dir_sem);
+    schema_registry registry;
+    ::set_local_schema_registry(registry);
+
+    database db(cfg, dbcfg, migration_notifier, feature_service, token_metadata, registry, as, sst_dir_sem);
     auto stop_db = deferred_stop(db);
 
     // Mock system_schema keyspace to be able to parse modification statements


### PR DESCRIPTION
Currently only those schemas are guaranteed to have a corresponding registry entry, that are associated with a table, and said table is registered with the database with `database::add_column_family()` or `database::update_column_family()`. These methods call `schema_registry::learn()` adding acorresponding registry entry to the registry. This patchset changes this such that all schema instances are now registered in a registry at the moment of their creation. Furthermore, the registry is now not a shard-global object, but a sharded service that lives in main. This still happens to contain all schemas on the local shard, but as the registry is now propagated down to use-sites via parameters, it is possible to segregate schemas into multiple registries.

This patchset can be viewed as yet another battle in the long crusade against globals and one assuming this wouldn't be too far from the truth. However the original motivation for starting this effort was the fact that despite adding `schema::get_reversed()` we couldn't use it. This function returns a reversed version of the schema, by first looking in the registry to see if it has it to save the effort of creating this reversed version if it already exists. However after adding this method we soon found that we just can't use it. The global schema registry requires a special initialize call which just doesn't exists in tests. I could have solved this problem by adding yet another global registry wrapper to tests, but every time I added a global to solve test problems
I later had to undo it and deeply regretted it. So this time I set out to do the right thing (tm) from the get-go: un-global the schema registry and create local instances in tests requiring it. But this series goes even further than that: I wanted to remove the ambiguity around some schemas being in the registry and other not. On the surface we have a clear rule on what schemas are and aren't in the registry:  those that are associated with a table that is currently registered in the database are in the registry, and others aren't. But there is more to this:
* Older versions of such table schemas can still be present in the
  registry;
* Schemas of recently dropped tables can still be present in the
  registry;
* Any schema which happened to be used with `global_schema_ptr` will be
  in the registry (for some time);

This series gets completely rid of this ambiguity: all schemas are in the registry, at the very moment they are constructed. If a schema exists, it is in the registry.

To be completely honest at many points I started to doubt myself about this patchset especially as it started to grow. Strictly speaking if making schema registry usable in tests was my only goal, I could have gotten away with much less code. But I think that getting rid of a hidden global and making the code more consistent and more future proof (multi-tenancy?) is overall worth it.

Tests: unit(dev, release, debug)