### PR TITLE
sstables: mx: writer: make large partition stats accounting branch-free

### DIFF
--- a/sstables/mx/writer.cc
+++ b/sstables/mx/writer.cc
@@ -1046,12 +1046,8 @@ void writer::maybe_record_large_partitions(const sstables::sstable& sst, const s
     size_entry.max_value = std::max(size_entry.max_value, partition_size);
     row_count_entry.max_value = std::max(row_count_entry.max_value, rows);
     auto ret = _sst.get_large_data_handler().maybe_record_large_partitions(sst, partition_key, partition_size, rows).get0();
-    if (ret.size) [[unlikely]] {
-        size_entry.above_threshold++;
-    }
-    if (ret.rows) [[unlikely]] {
-        row_count_entry.above_threshold++;
-    }
+    size_entry.above_threshold += unsigned(bool(ret.size));
+    row_count_entry.above_threshold += unsigned(bool(ret.rows));
 }
 
 void writer::maybe_record_large_rows(const sstables::sstable& sst, const sstables::key& partition_key,


### PR DESCRIPTION
It is bad form to introduce branches just for statistics, since branches
can be expensive (even when perfectly predictable, they consume branch
history resources). Switch to simple addition instead; this should be
not cause any cache misses since we already touch other statistics
earlier.

The inputs are already boolean, but cast them to boolean just so it
is clear we're adding 0/1, not a count.