### PR TITLE
Prepare for ungloballing schema registry

### DIFF
--- a/database.cc
+++ b/database.cc
@@ -380,10 +380,11 @@ database::database(const db::config& cfg, database_config dbcfg, service::migrat
     , _sst_dir_semaphore(sst_dir_sem)
     , _wasm_engine(std::make_unique<wasm::engine>())
     , _stop_barrier(std::move(barrier))
+    , _schema_registry(local_schema_registry())
 {
     assert(dbcfg.available_memory != 0); // Detect misconfigured unit tests, see #7544
 
-    local_schema_registry().init(*this); // TODO: we're never unbound.
+    _schema_registry.init(*this); // TODO: we're never unbound.
     setup_metrics();
 
     _row_cache_tracker.set_compaction_scheduling_group(dbcfg.memory_compaction_scheduling_group);
@@ -881,7 +882,7 @@ void database::drop_keyspace(const sstring& name) {
 }
 
 void database::add_column_family(keyspace& ks, schema_ptr schema, column_family::config cfg) {
-    schema = local_schema_registry().learn(schema);
+    schema = _schema_registry.learn(schema);
     schema->registry_entry()->mark_synced();
 
     lw_shared_ptr<column_family> cf;
@@ -919,7 +920,7 @@ future<> database::add_column_family_and_make_directory(schema_ptr schema) {
 bool database::update_column_family(schema_ptr new_schema) {
     column_family& cfm = find_column_family(new_schema->id());
     bool columns_changed = !cfm.schema()->equal_columns(*new_schema);
-    auto s = local_schema_registry().learn(new_schema);
+    auto s = _schema_registry.learn(new_schema);
     s->registry_entry()->mark_synced();
     cfm.set_schema(s);
     find_keyspace(s->ks_name()).metadata()->add_or_update_column_family(s);
@@ -1613,6 +1614,10 @@ future<reader_permit> database::obtain_reader_permit(table& tbl, const char* con
 
 future<reader_permit> database::obtain_reader_permit(schema_ptr schema, const char* const op_name, db::timeout_clock::time_point timeout) {
     return obtain_reader_permit(find_column_family(std::move(schema)), op_name, timeout);
+}
+
+schema_registry& database::get_schema_registry() const {
+    return _schema_registry;
 }
 
 std::ostream& operator<<(std::ostream& out, const column_family& cf) {

--- a/database.hh
+++ b/database.hh
@@ -81,7 +81,7 @@ class cell_locker;
 class cell_locker_stats;
 class locked_cell;
 class mutation;
-
+class schema_registry;
 class frozen_mutation;
 class reconcilable_result;
 
@@ -1398,6 +1398,8 @@ private:
     std::unique_ptr<wasm::engine> _wasm_engine;
     utils::cross_shard_barrier _stop_barrier;
 
+    schema_registry& _schema_registry;
+
 public:
     future<> init_commitlog();
     const gms::feature_service& features() const { return _feat; }
@@ -1683,6 +1685,8 @@ public:
     sharded<semaphore>& get_sharded_sst_dir_semaphore() {
         return _sst_dir_semaphore;
     }
+
+    schema_registry& get_schema_registry() const;
 };
 
 future<> start_large_data_handler(sharded<database>& db);

--- a/frozen_schema.hh
+++ b/frozen_schema.hh
@@ -35,7 +35,7 @@ class frozen_schema {
     bytes _data;
 public:
     explicit frozen_schema(bytes);
-    frozen_schema(const schema_ptr&);
+    explicit frozen_schema(const schema_ptr&);
     frozen_schema(frozen_schema&&) = default;
     frozen_schema(const frozen_schema&) = default;
     frozen_schema& operator=(const frozen_schema&) = default;

--- a/schema.cc
+++ b/schema.cc
@@ -483,6 +483,13 @@ schema::registry_entry() const noexcept {
     return _registry_entry;
 }
 
+schema_registry* schema::registry() const noexcept {
+    if (!_registry_entry) {
+        return nullptr;
+    }
+    return &_registry_entry->registry();
+}
+
 sstring schema::thrift_key_validator() const {
     if (partition_key_size() == 1) {
         return partition_key_columns().begin()->type->name();

--- a/schema.cc
+++ b/schema.cc
@@ -950,25 +950,39 @@ schema_builder& schema_builder::with_null_sharder() {
     return *this;
 }
 
-schema_builder::schema_builder(std::string_view ks_name, std::string_view cf_name,
+schema_builder::schema_builder(schema_registry* registry, std::string_view ks_name, std::string_view cf_name,
         std::optional<utils::UUID> id, data_type rct)
-        : _raw(id ? *id : utils::UUID_gen::get_time_UUID())
+        : _registry(registry)
+        , _raw(id ? *id : utils::UUID_gen::get_time_UUID())
 {
     _raw._ks_name = sstring(ks_name);
     _raw._cf_name = sstring(cf_name);
     _raw._regular_column_name_type = rct;
 }
 
+schema_builder::schema_builder(schema_registry& registry, std::string_view ks_name, std::string_view cf_name,
+        std::optional<utils::UUID> id, data_type rct)
+        : schema_builder(&registry, ks_name, cf_name, id, std::move(rct))
+{
+}
+
+schema_builder::schema_builder(std::string_view ks_name, std::string_view cf_name,
+        std::optional<utils::UUID> id, data_type rct)
+    : schema_builder(nullptr, ks_name, cf_name, id, rct)
+{
+}
+
 schema_builder::schema_builder(const schema_ptr s)
-    : schema_builder(s->_raw)
+    : schema_builder(s->registry(), s->_raw)
 {
     if (s->is_view()) {
         _view_info = s->view_info()->raw();
     }
 }
 
-schema_builder::schema_builder(const schema::raw_schema& raw)
-    : _raw(raw)
+schema_builder::schema_builder(schema_registry* registry, const schema::raw_schema& raw)
+    : _registry(registry)
+    , _raw(raw)
 {
     static_assert(schema::row_column_ids_are_ordered_by_name::value, "row columns don't need to be ordered by name");
     // Schema builder may add or remove columns and their ids need to be
@@ -980,6 +994,7 @@ schema_builder::schema_builder(const schema::raw_schema& raw)
 }
 
 schema_builder::schema_builder(
+        schema_registry* registry,
         std::optional<utils::UUID> id,
         std::string_view ks_name,
         std::string_view cf_name,
@@ -989,7 +1004,7 @@ schema_builder::schema_builder(
         std::vector<schema::column> static_columns,
         data_type regular_column_name_type,
         sstring comment)
-    : schema_builder(ks_name, cf_name, std::move(id), std::move(regular_column_name_type)) {
+    : schema_builder(registry, ks_name, cf_name, std::move(id), std::move(regular_column_name_type)) {
     for (auto&& column : partition_key) {
         with_column(std::move(column.name), std::move(column.type), column_kind::partition_key);
     }
@@ -1003,6 +1018,35 @@ schema_builder::schema_builder(
         with_column(std::move(column.name), std::move(column.type), column_kind::static_column);
     }
     set_comment(comment);
+}
+
+schema_builder::schema_builder(
+        schema_registry& registry,
+        std::optional<utils::UUID> id,
+        std::string_view ks_name,
+        std::string_view cf_name,
+        std::vector<schema::column> partition_key,
+        std::vector<schema::column> clustering_key,
+        std::vector<schema::column> regular_columns,
+        std::vector<schema::column> static_columns,
+        data_type regular_column_name_type,
+        sstring comment)
+    : schema_builder(&registry, id, ks_name, cf_name, std::move(partition_key), std::move(clustering_key), std::move(regular_columns),
+            std::move(static_columns), std::move(regular_column_name_type), std::move(comment)) {
+}
+
+schema_builder::schema_builder(
+        std::optional<utils::UUID> id,
+        std::string_view ks_name,
+        std::string_view cf_name,
+        std::vector<schema::column> partition_key,
+        std::vector<schema::column> clustering_key,
+        std::vector<schema::column> regular_columns,
+        std::vector<schema::column> static_columns,
+        data_type regular_column_name_type,
+        sstring comment)
+    : schema_builder(nullptr, id, ks_name, cf_name, std::move(partition_key), std::move(clustering_key), std::move(regular_columns),
+            std::move(static_columns), std::move(regular_column_name_type), std::move(comment)) {
 }
 
 column_definition& schema_builder::find_column(const cql3::column_identifier& c) {
@@ -1261,6 +1305,7 @@ schema_ptr schema_builder::build() {
             dynamic_pointer_cast<db::paxos_grace_seconds_extension>(it->second)->get_paxos_grace_seconds();
     }
 
+    (void)_registry;
     return make_lw_shared<schema>(schema::private_tag{}, new_raw, _view_info);
 }
 

--- a/schema.cc
+++ b/schema.cc
@@ -1627,12 +1627,6 @@ schema_ptr schema::make_reversed() const {
     return make_lw_shared<schema>(schema::reversed_tag{}, *this);
 }
 
-schema_ptr schema::get_reversed() const {
-    return local_schema_registry().get_or_load(utils::UUID_gen::negate(_raw._version), [this] (table_schema_version) {
-        return frozen_schema(make_reversed());
-    });
-}
-
 raw_view_info::raw_view_info(utils::UUID base_id, sstring base_name, bool include_all_columns, sstring where_clause)
         : _base_id(std::move(base_id))
         , _base_name(std::move(base_name))

--- a/schema.cc
+++ b/schema.cc
@@ -451,11 +451,11 @@ schema::schema(reversed_tag, const schema& o)
 {
 }
 
-lw_shared_ptr<const schema> make_shared_schema(std::optional<utils::UUID> id, std::string_view ks_name,
+static lw_shared_ptr<const schema> make_shared_schema(schema_registry* registry, std::optional<utils::UUID> id, std::string_view ks_name,
     std::string_view cf_name, std::vector<schema::column> partition_key, std::vector<schema::column> clustering_key,
     std::vector<schema::column> regular_columns, std::vector<schema::column> static_columns,
     data_type regular_column_name_type, sstring comment) {
-    schema_builder builder(std::move(ks_name), std::move(cf_name), std::move(id), std::move(regular_column_name_type));
+    schema_builder builder(registry, std::move(ks_name), std::move(cf_name), std::move(id), std::move(regular_column_name_type));
     for (auto&& column : partition_key) {
         builder.with_column(std::move(column.name), std::move(column.type), column_kind::partition_key);
     }
@@ -470,6 +470,22 @@ lw_shared_ptr<const schema> make_shared_schema(std::optional<utils::UUID> id, st
     }
     builder.set_comment(comment);
     return builder.build();
+}
+
+lw_shared_ptr<const schema> make_shared_schema(schema_registry& registry, std::optional<utils::UUID> id, std::string_view ks_name,
+    std::string_view cf_name, std::vector<schema::column> partition_key, std::vector<schema::column> clustering_key,
+    std::vector<schema::column> regular_columns, std::vector<schema::column> static_columns,
+    data_type regular_column_name_type, sstring comment) {
+    return make_shared_schema(&registry, id, ks_name, cf_name, std::move(partition_key), std::move(clustering_key),
+            std::move(regular_columns), std::move(static_columns), std::move(regular_column_name_type), std::move(comment));
+}
+
+lw_shared_ptr<const schema> make_shared_schema(std::optional<utils::UUID> id, std::string_view ks_name,
+    std::string_view cf_name, std::vector<schema::column> partition_key, std::vector<schema::column> clustering_key,
+    std::vector<schema::column> regular_columns, std::vector<schema::column> static_columns,
+    data_type regular_column_name_type, sstring comment) {
+    return make_shared_schema(nullptr, id, ks_name, cf_name, std::move(partition_key), std::move(clustering_key),
+            std::move(regular_columns), std::move(static_columns), std::move(regular_column_name_type), std::move(comment));
 }
 
 schema::~schema() {

--- a/schema.cc
+++ b/schema.cc
@@ -490,7 +490,7 @@ lw_shared_ptr<const schema> make_shared_schema(std::optional<utils::UUID> id, st
 
 schema::~schema() {
     if (_registry_entry) {
-        _registry_entry->detach_schema();
+        _registry_entry->detach_schema(*this);
     }
 }
 

--- a/schema.cc
+++ b/schema.cc
@@ -326,7 +326,7 @@ schema::raw_schema::raw_schema(utils::UUID id)
     , _sharder(::get_sharder(smp::count, default_partitioner_ignore_msb))
 { }
 
-schema::schema(private_tag, const raw_schema& raw, std::optional<raw_view_info> raw_view_info)
+schema::schema(private_tag, schema_registry* registry, const raw_schema& raw, std::optional<raw_view_info> raw_view_info)
     : _raw(raw)
     , _offsets([this] {
         if (_raw._columns.size() > std::numeric_limits<column_count_type>::max()) {
@@ -413,6 +413,10 @@ schema::schema(private_tag, const raw_schema& raw, std::optional<raw_view_info> 
     if (raw_view_info) {
         _view_info = std::make_unique<::view_info>(*this, *raw_view_info);
     }
+
+    if (registry) {
+        registry->pair_with_entry(*this);
+    }
 }
 
 schema::schema(const schema& o, const std::function<void(schema&)>& transform)
@@ -431,6 +435,10 @@ schema::schema(const schema& o, const std::function<void(schema&)>& transform)
         if (o.view_info()->base_info()) {
             _view_info->set_base_info(o.view_info()->base_info());
         }
+    }
+
+    if (o.registry()) {
+        o.registry()->pair_with_entry(*this);
     }
 }
 
@@ -1321,8 +1329,7 @@ schema_ptr schema_builder::build() {
             dynamic_pointer_cast<db::paxos_grace_seconds_extension>(it->second)->get_paxos_grace_seconds();
     }
 
-    (void)_registry;
-    return make_lw_shared<schema>(schema::private_tag{}, new_raw, _view_info);
+    return make_lw_shared<schema>(schema::private_tag{}, _registry, new_raw, _view_info);
 }
 
 const cdc::options& schema::cdc_options() const {

--- a/schema.hh
+++ b/schema.hh
@@ -132,6 +132,7 @@ private:
 using table_schema_version = utils::UUID;
 
 class schema;
+class schema_registry;
 class schema_registry_entry;
 class schema_builder;
 
@@ -963,6 +964,8 @@ public:
     friend class schema_registry_entry;
     // May be called from different shard
     schema_registry_entry* registry_entry() const noexcept;
+    // Null when registry_entry() is null
+    schema_registry* registry() const noexcept;
     // Returns true iff this schema version was synced with on current node.
     // Schema version is said to be synced with when its mutations were merged
     // into current node's schema, so that current node's schema is at least as

--- a/schema.hh
+++ b/schema.hh
@@ -987,19 +987,6 @@ public:
     // different C++ objects).
     // The schema's version is also reversed using UUID_gen::negate().
     schema_ptr make_reversed() const;
-
-    // Get the reversed counterpart of this schema from the schema registry.
-    //
-    // If not present in the registry, create one (via \ref make_reversed()) and
-    // load it. Unlike \ref make_reversed(), this method guarantees that double
-    // reversing will return the very same C++ object:
-    //
-    //      auto schema = make_schema();
-    //      auto reverse_schema = schema->get_reversed();
-    //      assert(reverse_schema->get_reversed().get() == schema.get());
-    //      assert(schema->get_reversed().get() == reverse_schema.get());
-    //
-    schema_ptr get_reversed() const;
 };
 
 lw_shared_ptr<const schema> make_shared_schema(std::optional<utils::UUID> id, std::string_view ks_name, std::string_view cf_name,

--- a/schema.hh
+++ b/schema.hh
@@ -992,6 +992,10 @@ public:
     schema_ptr make_reversed() const;
 };
 
+lw_shared_ptr<const schema> make_shared_schema(schema_registry& registry, std::optional<utils::UUID> id, std::string_view ks_name, std::string_view cf_name,
+    std::vector<schema::column> partition_key, std::vector<schema::column> clustering_key, std::vector<schema::column> regular_columns,
+    std::vector<schema::column> static_columns, data_type regular_column_name_type, sstring comment = "");
+
 lw_shared_ptr<const schema> make_shared_schema(std::optional<utils::UUID> id, std::string_view ks_name, std::string_view cf_name,
     std::vector<schema::column> partition_key, std::vector<schema::column> clustering_key, std::vector<schema::column> regular_columns,
     std::vector<schema::column> static_columns, data_type regular_column_name_type, sstring comment = "");

--- a/schema.hh
+++ b/schema.hh
@@ -706,7 +706,7 @@ private:
     schema(const schema&, const std::function<void(schema&)>&);
     class private_tag{};
 public:
-    schema(private_tag, const raw_schema&, std::optional<raw_view_info>);
+    schema(private_tag, schema_registry* registry, const raw_schema&, std::optional<raw_view_info>);
     schema(const schema&);
     // See \ref make_reversed().
     schema(reversed_tag, const schema&);

--- a/schema_builder.hh
+++ b/schema_builder.hh
@@ -26,19 +26,50 @@
 #include "cdc/log.hh"
 #include "dht/i_partitioner.hh"
 
+class schema_registry;
+
 struct schema_builder {
 public:
     enum class compact_storage { no, yes };
 private:
+    schema_registry* _registry = nullptr;
     schema::raw_schema _raw;
     std::optional<compact_storage> _compact_storage;
     std::optional<table_schema_version> _version;
     std::optional<raw_view_info> _view_info;
-    schema_builder(const schema::raw_schema&);
+    schema_builder(schema_registry*, const schema::raw_schema&);
 public:
+    schema_builder(schema_registry* registry, std::string_view ks_name, std::string_view cf_name,
+            std::optional<utils::UUID> = { },
+            data_type regular_column_name_type = utf8_type);
+    schema_builder(schema_registry& registry, std::string_view ks_name, std::string_view cf_name,
+            std::optional<utils::UUID> = { },
+            data_type regular_column_name_type = utf8_type);
     schema_builder(std::string_view ks_name, std::string_view cf_name,
             std::optional<utils::UUID> = { },
             data_type regular_column_name_type = utf8_type);
+    schema_builder(
+            schema_registry* registry,
+            std::optional<utils::UUID> id,
+            std::string_view ks_name,
+            std::string_view cf_name,
+            std::vector<schema::column> partition_key,
+            std::vector<schema::column> clustering_key,
+            std::vector<schema::column> regular_columns,
+            std::vector<schema::column> static_columns,
+            data_type regular_column_name_type,
+            sstring comment = "");
+    schema_builder(
+            schema_registry& registry,
+            std::optional<utils::UUID> id,
+            std::string_view ks_name,
+            std::string_view cf_name,
+            std::vector<schema::column> partition_key,
+            std::vector<schema::column> clustering_key,
+            std::vector<schema::column> regular_columns,
+            std::vector<schema::column> static_columns,
+            data_type regular_column_name_type,
+            sstring comment = "");
     schema_builder(
             std::optional<utils::UUID> id,
             std::string_view ks_name,

--- a/schema_registry.cc
+++ b/schema_registry.cc
@@ -102,10 +102,6 @@ schema_ptr schema_registry::get(table_schema_version v) const {
     return get_entry(v).get_schema();
 }
 
-frozen_schema schema_registry::get_frozen(table_schema_version v) const {
-    return get_entry(v).frozen();
-}
-
 future<schema_ptr> schema_registry::get_or_load(table_schema_version v, const async_schema_loader& loader) {
     auto i = _entries.find(v);
     if (i == _entries.end()) {

--- a/schema_registry.cc
+++ b/schema_registry.cc
@@ -20,6 +20,7 @@
  */
 
 #include <seastar/core/sharded.hh>
+#include <seastar/core/reactor.hh>
 
 #include "schema_registry.hh"
 #include "log.hh"
@@ -253,7 +254,10 @@ void schema_registry_entry::detach_schema(const schema& s) noexcept {
         return;
     }
     slogger.trace("Deactivating {}", _version);
-    _erase_timer.arm(_registry.grace_period());
+    // Some tests that use schemas don't start a reactor
+    if (engine_is_ready()) [[likely]] {
+        _erase_timer.arm(_registry.grace_period());
+    }
 }
 
 void schema_registry_entry::ensure_frozen() {

--- a/schema_registry.cc
+++ b/schema_registry.cc
@@ -171,6 +171,7 @@ schema_ptr schema_registry::get_or_load(table_schema_version v, std::function<sc
     if (e._state == schema_registry_entry::state::LOADING) {
         return load(e);
     }
+    assert(e._factory);
     return e.get_schema();
 }
 
@@ -256,6 +257,11 @@ void schema_registry_entry::detach_schema(const schema& s) noexcept {
         return;
     }
     slogger.trace("Deactivating {}", _version);
+    if (!_factory) {
+        //assert(_state == state::INITIAL);
+        erase();
+        return;
+    }
     // Some tests that use schemas don't start a reactor
     if (engine_is_ready()) [[likely]] {
         _erase_timer.arm(_registry.grace_period());

--- a/schema_registry.hh
+++ b/schema_registry.hh
@@ -75,7 +75,7 @@ class schema_registry_entry : public enable_lw_shared_from_this<schema_registry_
     std::optional<frozen_schema> _frozen_schema; // engaged when state == LOADED
     // valid when state == LOADED
     // This is != nullptr when there is an alive schema_ptr associated with this entry.
-    const ::schema* _schema = nullptr;
+    std::vector<const ::schema*> _schemas;
 
     enum class sync_state { NOT_SYNCED, SYNCING, SYNCED };
     sync_state _sync_state;
@@ -104,7 +104,7 @@ public:
     table_schema_version version() const { return _version; }
 public:
     // Called by class schema
-    void detach_schema() noexcept;
+    void detach_schema(const schema& s) noexcept;
 };
 
 //

--- a/schema_registry.hh
+++ b/schema_registry.hh
@@ -89,6 +89,7 @@ public:
     schema_registry_entry(const schema_registry_entry&) = delete;
     ~schema_registry_entry();
     schema_ptr load(frozen_schema);
+    schema_registry& registry() const { return _registry; }
     future<schema_ptr> start_loading(async_schema_loader);
     schema_ptr get_schema(); // call only when state >= LOADED
     // Can be called from other shards

--- a/schema_registry.hh
+++ b/schema_registry.hh
@@ -86,6 +86,7 @@ class schema_registry_entry : public enable_lw_shared_from_this<schema_registry_
 
     friend class schema_registry;
 private:
+    void pair_with(const schema& s);
     schema_ptr do_load(schema_factory factory);
 public:
     schema_registry_entry(table_schema_version v, schema_registry& r);
@@ -125,7 +126,9 @@ class schema_registry {
     std::unique_ptr<db::schema_ctxt> _ctxt;
 
     friend class schema_registry_entry;
+    friend class schema;
     schema_registry_entry& get_entry(table_schema_version) const;
+    void pair_with_entry(const schema& s);
     // Duration for which unused entries are kept alive to avoid
     // too frequent re-requests and syncs. Default is 1 second.
     schema_registry_entry::erase_clock::duration grace_period() const;

--- a/schema_registry.hh
+++ b/schema_registry.hh
@@ -145,10 +145,6 @@ public:
     // or loading is in progress.
     schema_ptr get(table_schema_version) const;
 
-    // Looks up schema version. Throws schema_version_not_found when not found
-    // or loading is in progress.
-    frozen_schema get_frozen(table_schema_version) const;
-
     // Attempts to add given schema to the registry. If the registry already
     // knows about the schema, returns existing entry, otherwise returns back
     // the schema which was passed as argument. Users should prefer to use the

--- a/schema_registry.hh
+++ b/schema_registry.hh
@@ -87,6 +87,7 @@ class schema_registry_entry : public enable_lw_shared_from_this<schema_registry_
 
     friend class schema_registry;
 private:
+    void erase();
     void pair_with(const schema& s);
     schema_ptr do_load(schema_factory factory);
 public:

--- a/service/migration_manager.cc
+++ b/service/migration_manager.cc
@@ -168,9 +168,9 @@ void migration_manager::init_messaging_service()
         auto& proxy = get_local_storage_proxy();
         proxy.get_stats().replica_cross_shard_ops += shard != this_shard_id();
         // FIXME: should this get an smp_service_group? Probably one separate from reads and writes.
-        return container().invoke_on(shard, [v, &proxy] (auto&& sp) {
+        return container().invoke_on(shard, [v, &db = proxy.get_db()] (auto&& sp) {
             mlogger.debug("Schema version request for {}", v);
-            return proxy.local_db().get_schema_registry().get_frozen(v);
+            return frozen_schema(db.local().get_schema_registry().get(v));
         });
     });
 }

--- a/service/migration_manager.cc
+++ b/service/migration_manager.cc
@@ -165,11 +165,12 @@ void migration_manager::init_messaging_service()
         return make_ready_future<utils::UUID>(service::get_local_storage_proxy().get_db().local().get_version());
     });
     _messaging.register_get_schema_version([this] (unsigned shard, table_schema_version v) {
-        get_local_storage_proxy().get_stats().replica_cross_shard_ops += shard != this_shard_id();
+        auto& proxy = get_local_storage_proxy();
+        proxy.get_stats().replica_cross_shard_ops += shard != this_shard_id();
         // FIXME: should this get an smp_service_group? Probably one separate from reads and writes.
-        return container().invoke_on(shard, [v] (auto&& sp) {
+        return container().invoke_on(shard, [v, &proxy] (auto&& sp) {
             mlogger.debug("Schema version request for {}", v);
-            return local_schema_registry().get_frozen(v);
+            return proxy.local_db().get_schema_registry().get_frozen(v);
         });
     });
 }
@@ -1165,7 +1166,8 @@ future<> migration_manager::sync_schema(const database& db, const std::vector<gm
 }
 
 future<column_mapping> get_column_mapping(utils::UUID table_id, table_schema_version v) {
-    schema_ptr s = local_schema_registry().get_or_null(v);
+    auto& db = get_local_storage_proxy().local_db();
+    schema_ptr s = db.get_schema_registry().get_or_null(v);
     if (s) {
         return make_ready_future<column_mapping>(s->get_column_mapping());
     }

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -4061,7 +4061,7 @@ storage_proxy::query_singular(lw_shared_ptr<query::read_command> cmd,
     utils::small_vector<std::pair<::shared_ptr<abstract_read_executor>, dht::token_range>, 1> exec;
     exec.reserve(partition_ranges.size());
 
-    schema_ptr schema = local_schema_registry().get(cmd->schema_version);
+    schema_ptr schema = _db.local().get_schema_registry().get(cmd->schema_version);
 
     db::read_repair_decision repair_decision = query_options.read_repair_decision
         ? *query_options.read_repair_decision : new_read_repair_decision(*schema);
@@ -4143,7 +4143,7 @@ storage_proxy::query_partition_key_range_concurrent(storage_proxy::clock_type::t
         uint32_t remaining_partition_count,
         replicas_per_token_range preferred_replicas,
         service_permit permit) {
-    schema_ptr schema = local_schema_registry().get(cmd->schema_version);
+    schema_ptr schema = _db.local().get_schema_registry().get(cmd->schema_version);
     keyspace& ks = _db.local().find_keyspace(schema->ks_name());
     std::vector<::shared_ptr<abstract_read_executor>> exec;
     auto p = shared_from_this();
@@ -4336,7 +4336,7 @@ storage_proxy::query_partition_key_range(lw_shared_ptr<query::read_command> cmd,
         dht::partition_range_vector partition_ranges,
         db::consistency_level cl,
         storage_proxy::coordinator_query_options query_options) {
-    schema_ptr schema = local_schema_registry().get(cmd->schema_version);
+    schema_ptr schema = _db.local().get_schema_registry().get(cmd->schema_version);
     keyspace& ks = _db.local().find_keyspace(schema->ks_name());
 
     // when dealing with LocalStrategy keyspaces, we can skip the range splitting and merging (which can be

--- a/test/boost/schema_change_test.cc
+++ b/test/boost/schema_change_test.cc
@@ -835,23 +835,3 @@ SEASTAR_TEST_CASE(test_schema_make_reversed) {
 
     return make_ready_future<>();
 }
-
-SEASTAR_TEST_CASE(test_schema_get_reversed) {
-    return do_with_cql_env([this] (cql_test_env& e) {
-        auto schema = schema_builder("tests", get_name())
-                .with_column("pk", bytes_type, column_kind::partition_key)
-                .with_column("ck", bytes_type, column_kind::clustering_key)
-                .with_column("v1", bytes_type)
-                .build();
-        schema = local_schema_registry().learn(schema);
-        auto reversed_schema = schema->get_reversed();
-
-        testlog.info("        &schema: {}", fmt::ptr(schema.get()));
-        testlog.info("&reverse_schema: {}", fmt::ptr(reversed_schema.get()));
-
-        BOOST_REQUIRE_EQUAL(reversed_schema->get_reversed().get(), schema.get());
-        BOOST_REQUIRE_EQUAL(schema->get_reversed().get(), reversed_schema.get());
-
-        return make_ready_future<>();
-    });
-}


### PR DESCRIPTION
To be able to un-global the schema registry we need the following:
* An alternative way to the schema-registry so code can migrate away from `local_schema_registry()`;
* All schemas having an associated registry entry, so `global_schema_ptr` can keep working;
* Schemas have to be (able to be) registered at creation time;
* Schema registry has to be able to deal with multiple schemas per entry;
* Schema registry has to offer an appropriate `get_or_load()` method for all use-cases;

This patchset addresses all the above points, preparing the ground for a gradual migration to a world without a global schema registry. `database` gains a `_schema_registry` member and an appropriate getter, which for now returns the global schema registry, but allows for code to migrate to use the database as a registry provider.
Then the entire schema creation pipeline is prepared so callers can propagate a schema registry instance down to the schema should they choose to. If they do, the schema will now register itself at creation time.
The registry is also prepared for this: it now supports multiple schema entries per registry entry (which is the reality once all schema objects are registered) and it abstracts away the loading mechanism and introduces a new `get_or_load()` catering for schema factory methods.

Once this is merged another series will follow churning through the entire codebase, making sure all schema instances have a registry propagated to them, then makes the registry a mandatory argument of the schema constructor.
This series was split off from https://github.com/scylladb/scylla/pull/9620. The latter was a huge series, so it was split in multiple parts to facilitate review and merge.

Tests: unit(dev)