### PR TITLE
Harden compaction manager remove

### DIFF
--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -1009,11 +1009,11 @@ future<> compaction_manager::remove(column_family* cf) {
     // The requirement above is provided by stop_ongoing_compactions().
     _postponed.erase(cf);
 
-    // Wait for all functions running under gate to terminate.
-    auto close_gate = _compaction_state[cf].gate.close();
-
     // Wait for the termination of an ongoing compaction on cf, if any.
-    co_await when_all_succeed(stop_ongoing_compactions("column family removal", cf), std::move(close_gate));
+    co_await stop_ongoing_compactions("column family removal", cf);
+
+    // Wait for all functions running under gate to terminate.
+    co_await _compaction_state[cf].gate.close();
 #ifdef DEBUG
     auto found = false;
     sstring msg;

--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -1006,20 +1006,20 @@ future<> compaction_manager::perform_sstable_scrub(column_family* cf, sstables::
 future<> compaction_manager::remove(column_family* cf) {
     auto handle = _compaction_state.extract(cf);
 
-  if (!handle.empty()) {
-    auto& c_state = handle.mapped();
+    if (!handle.empty()) {
+        auto& c_state = handle.mapped();
 
-    // We need to guarantee that a task being stopped will not retry to compact
-    // a column family being removed.
-    // The requirement above is provided by stop_ongoing_compactions().
-    _postponed.erase(cf);
+        // We need to guarantee that a task being stopped will not retry to compact
+        // a column family being removed.
+        // The requirement above is provided by stop_ongoing_compactions().
+        _postponed.erase(cf);
 
-    // Wait for the termination of an ongoing compaction on cf, if any.
-    co_await stop_ongoing_compactions("column family removal", cf);
+        // Wait for the termination of an ongoing compaction on cf, if any.
+        co_await stop_ongoing_compactions("column family removal", cf);
 
-    // Wait for all functions running under gate to terminate.
-    co_await c_state.gate.close();
-  }
+        // Wait for all functions running under gate to terminate.
+        co_await c_state.gate.close();
+    }
 #ifdef DEBUG
     auto found = false;
     sstring msg;

--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -539,19 +539,21 @@ future<> compaction_manager::stop_tasks(std::vector<lw_shared_ptr<task>> tasks, 
 }
 
 future<> compaction_manager::stop_ongoing_compactions(sstring reason) {
-    cmlog.info("Stopping {} ongoing compactions due to {}", get_compactions().size(), reason);
+    auto ongoing_compactions = get_compactions().size();
 
     // Wait for each task handler to stop. Copy list because task remove itself
     // from the list when done.
     auto tasks = boost::copy_range<std::vector<lw_shared_ptr<task>>>(_tasks);
+    cmlog.info("Stopping {} tasks for {} ongoing compactions due to {}", tasks.size(), ongoing_compactions, reason);
     return stop_tasks(std::move(tasks), std::move(reason));
 }
 
 future<> compaction_manager::stop_ongoing_compactions(sstring reason, column_family* cf) {
+    auto ongoing_compactions = get_compactions().size();
     auto tasks = boost::copy_range<std::vector<lw_shared_ptr<task>>>(_tasks | boost::adaptors::filtered([cf] (auto& task) {
         return task->compacting_cf == cf;
     }));
-    cmlog.info("Stopping {} ongoing compactions for table {}.{} due to {}", tasks.size(), cf->schema()->ks_name(), cf->schema()->cf_name(), reason);
+    cmlog.info("Stopping {} tasks for {} ongoing compactions for table {}.{} due to {}", tasks.size(), ongoing_compactions, cf->schema()->ks_name(), cf->schema()->cf_name(), reason);
     return stop_tasks(std::move(tasks), std::move(reason));
 }
 

--- a/compaction/compaction_manager.hh
+++ b/compaction/compaction_manager.hh
@@ -66,6 +66,22 @@ public:
         const ::io_priority_class& io;
     };
 private:
+    struct compaction_state {
+        // Used both by compaction tasks that refer to the compaction_state
+        // and by any function running under run_with_compaction_disabled().
+        seastar::gate gate;
+
+        // Prevents table from running major and minor compaction at the same time.
+        rwlock lock;
+
+        // Raised by any function running under run_with_compaction_disabled();
+        long compaction_disabled_counter = 0;
+
+        bool compaction_disabled() const noexcept {
+            return compaction_disabled_counter > 0;
+        }
+    };
+
     struct task {
         column_family* compacting_cf = nullptr;
         shared_future<> compaction_done = make_ready_future<>();
@@ -75,8 +91,15 @@ private:
         bool compaction_running = false;
         utils::UUID output_run_identifier;
         sstables::compaction_data compaction_data;
+        compaction_state& compaction_state;
+        gate::holder gate_holder;
 
-        explicit task(column_family* cf, sstables::compaction_type type) : compacting_cf(cf), type(type) {}
+        explicit task(column_family* cf, sstables::compaction_type type, struct compaction_state& cs)
+            : compacting_cf(cf)
+            , type(type)
+            , compaction_state(cs)
+            , gate_holder(compaction_state.gate.hold())
+        {}
 
         task(task&&) = delete;
         task(const task&) = delete;
@@ -125,21 +148,6 @@ private:
     // reduce disk space requirement.
     semaphore _major_compaction_sem{1};
 
-    struct compaction_state {
-        // Used both by compaction tasks that refer to the compaction_state
-        // and by any function running under run_with_compaction_disabled().
-        seastar::gate gate;
-
-        // Prevents table from running major and minor compaction at the same time.
-        rwlock lock;
-
-        // Raised by any function running under run_with_compaction_disabled();
-        long compaction_disabled_counter = 0;
-
-        bool compaction_disabled() const noexcept {
-            return compaction_disabled_counter > 0;
-        }
-    };
     std::unordered_map<table*, compaction_state> _compaction_state;
 
     semaphore _custom_job_sem{1};

--- a/compaction/compaction_manager.hh
+++ b/compaction/compaction_manager.hh
@@ -78,6 +78,9 @@ private:
 
         explicit task(column_family* cf, sstables::compaction_type type) : compacting_cf(cf), type(type) {}
 
+        task(task&&) = delete;
+        task(const task&) = delete;
+
         void setup_new_compaction();
         void finish_compaction();
     };

--- a/compaction/compaction_manager.hh
+++ b/compaction/compaction_manager.hh
@@ -276,6 +276,11 @@ public:
     // Run a function with compaction temporarily disabled for a table T.
     future<> run_with_compaction_disabled(table* t, std::function<future<> ()> func);
 
+    // Adds a column family to the compaction manager.
+    // Creates a compaction_state structure that can be used for submitting
+    // compaction jobs of all types.
+    void add(column_family* cf);
+
     // Remove a column family from the compaction manager.
     // Cancel requests on cf and wait for a possible ongoing compaction on cf.
     future<> remove(column_family* cf);
@@ -283,6 +288,10 @@ public:
     const stats& get_stats() const {
         return _stats;
     }
+
+    // gets the table's compaction state
+    // throws std::out_of_range exception if not found.
+    compaction_state& get_compaction_state(table* t);
 
     const std::vector<sstables::compaction_info> get_compactions() const;
 

--- a/table.cc
+++ b/table.cc
@@ -1207,6 +1207,7 @@ table::table(schema_ptr schema, config config, db::commitlog* cl, compaction_man
         tlogger.warn("Writes disabled, column family no durable.");
     }
     set_metrics();
+    _compaction_manager.add(this);
 }
 
 partition_presence_checker

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -3365,6 +3365,7 @@ SEASTAR_TEST_CASE(incremental_compaction_data_resurrection_test) {
         cfg.enable_incremental_backups = false;
         auto tracker = make_lw_shared<cache_tracker>();
         auto cf = make_lw_shared<column_family>(s, cfg, column_family::no_commitlog(), *cm, cl_stats, *tracker);
+        auto stop_cf = deferred_stop(*cf);
         cf->mark_ready_for_writes();
         cf->start();
         cf->set_compaction_strategy(sstables::compaction_strategy_type::null);

--- a/test/lib/sstable_utils.cc
+++ b/test/lib/sstable_utils.cc
@@ -211,5 +211,7 @@ sstables::compaction_data& compaction_manager_test::register_compaction(utils::U
 
 void compaction_manager_test::deregister_compaction(const sstables::compaction_data& c) {
     auto it = boost::find_if(_cm._tasks, [&c] (auto& task) { return task->compaction_data.compaction_uuid == c.compaction_uuid; });
-    _cm._tasks.remove(*it);
+    if (it != _cm._tasks.end()) {
+        _cm._tasks.erase(it);
+    }
 }

--- a/test/lib/sstable_utils.cc
+++ b/test/lib/sstable_utils.cc
@@ -202,7 +202,7 @@ future<shared_sstable> test_env::reusable_sst(schema_ptr schema, sstring dir, un
 }
 
 sstables::compaction_data& compaction_manager_test::register_compaction(utils::UUID output_run_id, column_family* cf) {
-    auto task = make_lw_shared<compaction_manager::task>(cf, sstables::compaction_type::Compaction);
+    auto task = make_lw_shared<compaction_manager::task>(cf, sstables::compaction_type::Compaction, _cm._compaction_state[cf]);
     testlog.debug("compaction_manager_test: register_compaction: task {} cf={}", fmt::ptr(task.get()), fmt::ptr(cf));
     task->compaction_running = true;
     task->compaction_data = compaction_manager::create_compaction_data();

--- a/test/lib/sstable_utils.cc
+++ b/test/lib/sstable_utils.cc
@@ -177,8 +177,9 @@ future<compaction_result> compact_sstables(sstables::compaction_descriptor descr
     auto& cm = cf.get_compaction_manager();
     auto& cdata = compaction_manager_test(cm).register_compaction(descriptor.run_identifier, &cf);
     return sstables::compact_sstables(std::move(descriptor), cdata, cf.as_table_state()).then([&cdata, &cm] (sstables::compaction_result res) {
-        compaction_manager_test(cm).deregister_compaction(cdata);
         return res;
+    }).finally([&cm, &cdata] {
+        compaction_manager_test(cm).deregister_compaction(cdata);
     });
 }
 

--- a/test/lib/sstable_utils.cc
+++ b/test/lib/sstable_utils.cc
@@ -202,6 +202,7 @@ future<shared_sstable> test_env::reusable_sst(schema_ptr schema, sstring dir, un
 
 sstables::compaction_data& compaction_manager_test::register_compaction(utils::UUID output_run_id, column_family* cf) {
     auto task = make_lw_shared<compaction_manager::task>(cf, sstables::compaction_type::Compaction);
+    testlog.debug("compaction_manager_test: register_compaction: task {} cf={}", fmt::ptr(task.get()), fmt::ptr(cf));
     task->compaction_running = true;
     task->compaction_data = compaction_manager::create_compaction_data();
     task->output_run_identifier = std::move(output_run_id);
@@ -212,6 +213,10 @@ sstables::compaction_data& compaction_manager_test::register_compaction(utils::U
 void compaction_manager_test::deregister_compaction(const sstables::compaction_data& c) {
     auto it = boost::find_if(_cm._tasks, [&c] (auto& task) { return task->compaction_data.compaction_uuid == c.compaction_uuid; });
     if (it != _cm._tasks.end()) {
+        auto task = *it;
+        testlog.debug("compaction_manager_test: deregister_compaction uuid={}: task {} cf={}", c.compaction_uuid, fmt::ptr(task.get()), fmt::ptr(task->compacting_cf));
         _cm._tasks.erase(it);
+    } else {
+        testlog.debug("compaction_manager_test: deregister_compaction uuid={}: task not found", c.compaction_uuid);
     }
 }

--- a/test/lib/sstable_utils.hh
+++ b/test/lib/sstable_utils.hh
@@ -346,21 +346,11 @@ public:
 class compaction_manager_test {
     compaction_manager& _cm;
 public:
-    explicit compaction_manager_test(compaction_manager& cm) : _cm(cm) {}
+    explicit compaction_manager_test(compaction_manager& cm) noexcept : _cm(cm) {}
 
-    sstables::compaction_data& register_compaction(utils::UUID output_run_id = {}, column_family* cf = nullptr) {
-        auto task = make_lw_shared<compaction_manager::task>(cf, sstables::compaction_type::Compaction);
-        task->compaction_running = true;
-        task->compaction_data = compaction_manager::create_compaction_data();
-        task->output_run_identifier = std::move(output_run_id);
-        _cm._tasks.push_back(task);
-        return task->compaction_data;
-    }
+    sstables::compaction_data& register_compaction(utils::UUID output_run_id = {}, column_family* cf = nullptr);
 
-    void deregister_compaction(const sstables::compaction_data& c) {
-        auto it = boost::find_if(_cm._tasks, [&c] (auto& task) { return task->compaction_data.compaction_uuid == c.compaction_uuid; });
-        _cm._tasks.remove(*it);
-    }
+    void deregister_compaction(const sstables::compaction_data& c);
 };
 
 future<compaction_result> compact_sstables(sstables::compaction_descriptor descriptor, column_family& cf,


### PR DESCRIPTION
This series hardens compaction_manager::remove by:
- add debug logging around task execution and stopping.
- access compaction_state as lw_shared_ptr rather than via a raw pointer.
  - with that, detach it from `_compaction_state` in `compaction_manager::remove` right away, to prevent further use of it while compactions are stopped.
 - added write_lock in `remove` to make sure the lock is not held by any stray task.

Test: unit(dev), sstable_compaction_test(debug)
Dtest: alternator_tests.py:AlternatorTest.test_slow_query_logging (debug)