### PR TITLE
treewide: wrap runtime formats with fmt::runtime for fmt 8

### DIFF
--- a/compaction/compaction.cc
+++ b/compaction/compaction.cc
@@ -76,6 +76,7 @@
 #include "mutation_fragment_stream_validator.hh"
 #include "utils/UUID_gen.hh"
 #include "utils/utf8.hh"
+#include "utils/fmt-compat.hh"
 
 namespace sstables {
 
@@ -771,7 +772,7 @@ protected:
     template <typename... Args>
     void log(log_level level, std::string_view fmt, const Args&... args) const {
         if (clogger.is_enabled(level)) {
-            auto msg = fmt::format(fmt, args...);
+            auto msg = fmt::format(fmt::runtime(fmt), args...);
             clogger.log(level, "[{} {}.{} {}] {}", _type, _schema->ks_name(), _schema->cf_name(), _cdata.compaction_uuid, msg);
         }
     }

--- a/cql3/statements/request_validations.hh
+++ b/cql3/statements/request_validations.hh
@@ -42,6 +42,7 @@
 
 #include "exceptions/exceptions.hh"
 #include <seastar/core/print.hh>
+#include "utils/fmt-compat.hh"
 
 #include <boost/range/algorithm/count_if.hpp>
 
@@ -74,7 +75,7 @@ invalid_request(const char* message_template, const MessageArgs&... message_args
                     const char* message_template,
                     const MessageArgs&... message_args) {
         if (!expression) {
-            throw exceptions::invalid_request_exception(fmt::format(message_template, message_args...));
+            throw exceptions::invalid_request_exception(fmt::format(fmt::runtime(message_template), message_args...));
         }
     }
 
@@ -167,7 +168,7 @@ invalid_request(const char* message_template, const MessageArgs&... message_args
     template <typename... MessageArgs>
     exceptions::invalid_request_exception
     invalid_request(const char* message_template, const MessageArgs&... message_args) {
-        return exceptions::invalid_request_exception(fmt::format(message_template, message_args...));
+        return exceptions::invalid_request_exception(fmt::format(fmt::runtime(message_template), message_args...));
     }
 }
 

--- a/database.cc
+++ b/database.cc
@@ -58,6 +58,7 @@
 #include "utils/human_readable.hh"
 #include "utils/fb_utilities.hh"
 #include "utils/stall_free.hh"
+#include "utils/fmt-compat.hh"
 
 #include "db/timeout_clock.hh"
 #include "db/large_data_handler.hh"
@@ -164,7 +165,7 @@ public:
     }
     void operator() (const char* fmt, const auto& param1, const auto&... params) {
         const auto begin = _line_buf.begin();
-        auto it = fmt::format_to(begin, fmt, param1, params...);
+        auto it = fmt::format_to(begin, fmt::runtime(fmt), param1, params...);
         _wr(std::string_view(begin, it - begin));
     }
 };

--- a/db/legacy_schema_migrator.cc
+++ b/db/legacy_schema_migrator.cc
@@ -63,6 +63,7 @@
 #include "schema_builder.hh"
 #include "service/storage_proxy.hh"
 #include "utils/rjson.hh"
+#include "utils/fmt-compat.hh"
 #include "cql3/query_processor.hh"
 #include "cql3/untyped_result_set.hh"
 #include "cql3/util.hh"
@@ -149,7 +150,7 @@ public:
     };
 
     static sstring fmt_query(const char* fmt, const char* table) {
-        return fmt::format(fmt, db::system_keyspace::NAME, table);
+        return fmt::format(fmt::runtime(fmt), db::system_keyspace::NAME, table);
     }
 
     typedef ::shared_ptr<cql3::untyped_result_set> result_set_type;

--- a/redis/reply.hh
+++ b/redis/reply.hh
@@ -27,6 +27,7 @@
 #include <seastar/core/print.hh>
 #include "seastar/core/scattered_message.hh"
 #include "redis/exceptions.hh"
+#include "utils/fmt-compat.hh"
 
 namespace redis {
 
@@ -106,7 +107,7 @@ private:
     template<typename... Args>
     static inline sstring make_message(const char* fmt, Args&&... args) noexcept {
         try {
-            return fmt::format(fmt, std::forward<Args>(args)...);
+            return fmt::format(fmt::runtime(fmt), std::forward<Args>(args)...);
         } catch (...) {
             return sstring();
         }   

--- a/test/boost/auth_test.cc
+++ b/test/boost/auth_test.cc
@@ -45,6 +45,8 @@
 #include "db/config.hh"
 #include "cql3/query_processor.hh"
 
+#include "utils/fmt-compat.hh"
+
 SEASTAR_TEST_CASE(test_default_authenticator) {
     return do_with_cql_env([](cql_test_env& env) {
         auto& a = env.local_auth_service().underlying_authenticator();
@@ -174,7 +176,7 @@ namespace {
 void require_table_protected(cql_test_env& env, const char* table) {
     using exception_predicate::message_contains;
     using unauth = exceptions::unauthorized_exception;
-    const auto q = [&] (const char* stmt) { return env.execute_cql(fmt::format(stmt, table)).get(); };
+    const auto q = [&] (const char* stmt) { return env.execute_cql(fmt::format(fmt::runtime(stmt), table)).get(); };
     BOOST_TEST_INFO(table);
     BOOST_REQUIRE_EXCEPTION(q("ALTER TABLE {} ALTER role TYPE blob"), unauth, message_contains("is protected"));
     BOOST_REQUIRE_EXCEPTION(q("ALTER TABLE {} RENAME role TO user"), unauth, message_contains("is protected"));

--- a/test/boost/cql_query_test.cc
+++ b/test/boost/cql_query_test.cc
@@ -49,6 +49,7 @@
 #include "compaction/compaction_manager.hh"
 #include "test/lib/exception_utils.hh"
 #include "utils/rjson.hh"
+#include "utils/fmt-compat.hh"
 #include "schema_builder.hh"
 #include "service/migration_manager.hh"
 #include <regex>
@@ -3491,7 +3492,7 @@ SEASTAR_TEST_CASE(test_select_with_mixed_order_table) {
         generate_with_inclusiveness_permutations({0,1,2,3},{0,1,2,3});
 
         for (auto&& test_case  : test_cases) {
-            auto msg = e.execute_cql(fmt::format(select_query_template,test_case.generate_cql_slice_expresion(column_names))).get0();
+            auto msg = e.execute_cql(fmt::format(fmt::runtime(select_query_template) ,test_case.generate_cql_slice_expresion(column_names))).get0();
             assert_that(msg).is_rows().with_rows(test_case.genrate_results_for_validation(ordering));
         }
     });

--- a/test/boost/view_schema_pkey_test.cc
+++ b/test/boost/view_schema_pkey_test.cc
@@ -33,6 +33,7 @@
 #include "test/lib/cql_assertions.hh"
 #include "types/set.hh"
 #include "types/list.hh"
+#include "utils/fmt-compat.hh"
 
 using namespace std::literals::chrono_literals;
 
@@ -714,7 +715,7 @@ SEASTAR_TEST_CASE(test_base_non_pk_columns_in_view_partition_key_are_non_emtpy) 
         for (auto&& view : views_matching) {
             auto name = make_view_name();
             auto f = e.local_view_builder().wait_until_built("ks", name);
-            e.execute_cql(fmt::format(view, name)).get();
+            e.execute_cql(fmt::format(fmt::runtime(view), name)).get();
             f.get();
             auto msg = e.execute_cql(format("select p1, p2, c, v from {}", name)).get0();
             assert_that(msg).is_rows()
@@ -739,7 +740,7 @@ SEASTAR_TEST_CASE(test_base_non_pk_columns_in_view_partition_key_are_non_emtpy) 
         for (auto&& view : views_not_matching) {
             auto name = make_view_name();
             auto f = e.local_view_builder().wait_until_built("ks", name);
-            e.execute_cql(fmt::format(view, name)).get();
+            e.execute_cql(fmt::format(fmt::runtime(view), name)).get();
             f.get();
             auto msg = e.execute_cql(format("select p1, p2, c, v from {}", name)).get0();
             assert_that(msg).is_rows().is_empty();

--- a/utils/directories.cc
+++ b/utils/directories.cc
@@ -24,6 +24,7 @@
 #include "supervisor.hh"
 #include "directories.hh"
 #include "utils/disk-error-handler.hh"
+#include "utils/fmt-compat.hh"
 #include "db/config.hh"
 #include "lister.hh"
 
@@ -109,7 +110,7 @@ future<> directories::create_and_verify(directories::set dir_set) {
 template <typename... Args>
 static inline
 future<> verification_error(fs::path path, const char* fstr, Args&&... args) {
-    auto emsg = fmt::format(fstr, std::forward<Args>(args)...);
+    auto emsg = fmt::format(fmt::runtime(fstr), std::forward<Args>(args)...);
     startlog.error("{}: {}", path.string(), emsg);
     return make_exception_future<>(std::runtime_error(emsg));
 }

--- a/utils/fmt-compat.hh
+++ b/utils/fmt-compat.hh
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-present ScyllaDB
+ * Copyright (C) 2021-present ScyllaDB
  */
 
 /*
@@ -21,17 +21,21 @@
 
 #pragma once
 
-#include <utility>
-#include "utils/fmt-compat.hh"
+#include <fmt/core.h>
 
-namespace thrift {
+// compatibility between fmt < 8 (that doesn't have fmt::runtime())
+// and fmt 8 (that requires it)
 
-template <typename Ex, typename... Args>
-Ex
-make_exception(const char* fmt, Args&&... args) {
-    Ex ex;
-    ex.why = fmt::format(fmt::runtime(fmt), std::forward<Args>(args)...);
-    return ex;
+#if FMT_VERSION < 8'00'00
+
+namespace fmt {
+
+// fmt 8 requires that non-constant format strings be wrapped with
+// fmt::runtime(), supply a nop-op version for older fmt
+auto runtime(auto fmt_string) {
+    return fmt_string;
 }
 
 }
+
+#endif


### PR DESCRIPTION
fmt 8 checks format strings at compile time, and requires that
non-compile-time format strings be wrapped with fmt::runtime().

Do that, and to allow coexistence with fmt 7, supply our own
do-nothing version of fmt::runtime() if needed. Strictly speaking
we shouldn't be introducing names into the fmt namespace, but this
is transitional only.