### PR TITLE
utils: build_id: correct fmt include

### DIFF
--- a/utils/build_id.cc
+++ b/utils/build_id.cc
@@ -3,7 +3,7 @@
  */
 
 #include "build_id.hh"
-#include <fmt/printf.h>
+#include <fmt/ostream.h>
 #include <link.h>
 #include <seastar/core/align.hh>
 #include <sstream>


### PR DESCRIPTION
fmt::print(std::ostream&) is in <fmt/ostream.h>