### PR TITLE
tls: Add certficate_revocation_list option for client/server encryption options

### DIFF
--- a/conf/scylla.yaml
+++ b/conf/scylla.yaml
@@ -435,6 +435,7 @@ commitlog_total_space_in_mb: -1
 #    certificate: conf/scylla.crt
 #    keyfile: conf/scylla.key
 #    truststore: <none, use system trust>
+#    certficate_revocation_list: <none>
 #    require_client_auth: False
 #    priority_string: <none, use default>
 
@@ -444,6 +445,7 @@ commitlog_total_space_in_mb: -1
 #    certificate: conf/scylla.crt
 #    keyfile: conf/scylla.key
 #    truststore: <none, use system trust>
+#    certficate_revocation_list: <none>
 #    require_client_auth: False
 #    priority_string: <none, use default>
 

--- a/db/config.cc
+++ b/db/config.cc
@@ -724,6 +724,7 @@ db::config::config(std::shared_ptr<db::extensions> exts)
         "certificate : (Default: conf/scylla.crt) The location of a PEM-encoded x509 certificate used to identify and encrypt the internode communication.\n"
         "keyfile : (Default: conf/scylla.key) PEM Key file associated with certificate.\n"
         "truststore : (Default: <system truststore> ) Location of the truststore containing the trusted certificate for authenticating remote servers.\n"
+        "certficate_revocation_list : (Default: <none> ) PEM encoded certificate revocation list.\n"
         "\n"
         "The advanced settings are:\n"
         "\n"
@@ -737,6 +738,7 @@ db::config::config(std::shared_ptr<db::extensions> exts)
         "\tcertificate: (Default: conf/scylla.crt) The location of a PEM-encoded x509 certificate used to identify and encrypt the client/server communication.\n"
         "\tkeyfile: (Default: conf/scylla.key) PEM Key file associated with certificate.\n"
         "truststore : (Default: <system truststore> ) Location of the truststore containing the trusted certificate for authenticating remote servers.\n"
+        "certficate_revocation_list : (Default: <none> ) PEM encoded certificate revocation list.\n"
         "\n"
         "The advanced settings are:\n"
         "\n"
@@ -1092,6 +1094,9 @@ future<> configure_tls_creds_builder(seastar::tls::credentials_builder& creds, d
 
     if (options.contains("truststore")) {
         co_await creds.set_x509_trust_file(options.at("truststore"), seastar::tls::x509_crt_format::PEM);
+    }
+    if (options.contains("certficate_revocation_list")) {
+        co_await creds.set_x509_crl_file(options.at("certficate_revocation_list"), seastar::tls::x509_crt_format::PEM);
     }
 }
 


### PR DESCRIPTION
Fixes #9630

Adds support for importing a CRL certificate reovcation list. This will be
monitored and reloaded like certs/keys. Allows blacklisting individual certs.