### PR TITLE
Block creation of MV on CDC Log

### DIFF
--- a/cql3/statements/create_view_statement.cc
+++ b/cql3/statements/create_view_statement.cc
@@ -187,6 +187,10 @@ future<shared_ptr<cql_transport::event::schema_change>> create_view_statement::a
         throw exceptions::invalid_request_exception(format("Materialized views cannot be created against other materialized views"));
     }
 
+    if (cdc::get_base_table(db, *schema)) {
+        throw exceptions::invalid_request_exception(format("Materialized views cannot be created on CDC Log tables"));
+    }
+
     if (schema->gc_grace_seconds().count() == 0) {
         throw exceptions::invalid_request_exception(fmt::format(
                 "Cannot create materialized view '{}' for base table "

--- a/test/cql/cdc_disallow_materialized_view_for_cdc_log_test.cql
+++ b/test/cql/cdc_disallow_materialized_view_for_cdc_log_test.cql
@@ -1,0 +1,3 @@
+create table tb1 (pk int primary key, v int) with cdc = {'enabled': true};
+
+create materialized view tb1_mv as select * from tb1_scylla_cdc_log where v is not null primary key (v);

--- a/test/cql/cdc_disallow_materialized_view_for_cdc_log_test.result
+++ b/test/cql/cdc_disallow_materialized_view_for_cdc_log_test.result
@@ -1,0 +1,10 @@
+create table tb1 (pk int primary key, v int) with cdc = {'enabled': true};
+{
+	"status" : "ok"
+}
+
+create materialized view tb1_mv as select * from tb1_scylla_cdc_log where v is not null primary key (v);
+{
+	"message" : "exceptions::invalid_request_exception (Materialized views cannot be created on CDC Log tables)",
+	"status" : "error"
+}


### PR DESCRIPTION
Add a restriction in create_view_statement to disallow creation of MV for CDC Log table.

Also add a CQL test that checks the new restriction works.

Test: unit(dev)

Fixes #9233