### PR TITLE
test: sstable_test: don't read compressed file size from closed file

### DIFF
--- a/test/boost/sstable_test.cc
+++ b/test/boost/sstable_test.cc
@@ -795,7 +795,7 @@ SEASTAR_TEST_CASE(test_skipping_in_compressed_stream) {
         uncompressed_size += buf2.size();
         out.close().get();
 
-        auto compressed_size = f.size().get0();
+        auto compressed_size = seastar::file_size(file_path).get0();
         c.update(compressed_size);
 
         auto make_is = [&] {


### PR DESCRIPTION
We read the compressed file size from a file that was already closed,
resulting in EBADF on my machine. Not sure why it works for everyone
else.

Fix by reading the size using the path.