### PR TITLE
compaction_manager api: stop ongoing compactions

### DIFF
--- a/api/column_family.cc
+++ b/api/column_family.cc
@@ -876,7 +876,7 @@ void set_column_family(http_context& ctx, routes& r) {
         return ctx.db.invoke_on(0, [&ctx, req = std::move(req)] (database& db) {
             auto g = database::autocompaction_toggle_guard(db);
             return foreach_column_family(ctx, req->param["name"], [](column_family &cf) {
-                cf.disable_auto_compaction();
+                return cf.disable_auto_compaction();
             }).then([g = std::move(g)] {
                 return make_ready_future<json::json_return_type>(json_void());
             });

--- a/api/compaction_manager.cc
+++ b/api/compaction_manager.cc
@@ -111,7 +111,7 @@ void set_compaction_manager(http_context& ctx, routes& r) {
         auto type = req->get_query_param("type");
         return ctx.db.invoke_on_all([type] (database& db) {
             auto& cm = db.get_compaction_manager();
-            cm.stop_compaction(type);
+            return cm.stop_compaction(type);
         }).then([] {
             return make_ready_future<json::json_return_type>(json_void());
         });

--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -153,7 +153,7 @@ future<json::json_return_type> set_tables_autocompaction(http_context& ctx, serv
                     if (enabled) {
                         cf.enable_auto_compaction();
                     } else {
-                        cf.disable_auto_compaction();
+                        return cf.disable_auto_compaction();
                     }
                     return make_ready_future<>();
                 });

--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -561,7 +561,8 @@ future<> compaction_manager::stop_ongoing_compactions(sstring reason, column_fam
     auto tasks = boost::copy_range<std::vector<lw_shared_ptr<task>>>(_tasks | boost::adaptors::filtered([cf, type_opt] (auto& task) {
         return (!cf || task->compacting_cf == cf) && (!type_opt || task->type == *type_opt);
     }));
-    if (cmlog.is_enabled(logging::log_level::info)) {
+    logging::log_level level = tasks.empty() ? log_level::debug : log_level::info;
+    if (cmlog.is_enabled(level)) {
         std::string scope = "";
         if (cf) {
             scope = fmt::format(" for table {}.{}", cf->schema()->ks_name(), cf->schema()->cf_name());
@@ -569,7 +570,7 @@ future<> compaction_manager::stop_ongoing_compactions(sstring reason, column_fam
         if (type_opt) {
             scope += fmt::format(" {} type={}", scope.size() ? "and" : "for", *type_opt);
         }
-        cmlog.info("Stopping {} tasks for {} ongoing compactions{} due to {}", tasks.size(), ongoing_compactions, scope, reason);
+        cmlog.log(level, "Stopping {} tasks for {} ongoing compactions{} due to {}", tasks.size(), ongoing_compactions, scope, reason);
     }
     return stop_tasks(std::move(tasks), std::move(reason));
 }

--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -556,16 +556,6 @@ future<> compaction_manager::stop_tasks(std::vector<lw_shared_ptr<task>> tasks, 
     });
 }
 
-future<> compaction_manager::stop_ongoing_compactions(sstring reason) {
-    auto ongoing_compactions = get_compactions().size();
-
-    // Wait for each task handler to stop. Copy list because task remove itself
-    // from the list when done.
-    auto tasks = boost::copy_range<std::vector<lw_shared_ptr<task>>>(_tasks);
-    cmlog.info("Stopping {} tasks for {} ongoing compactions due to {}", tasks.size(), ongoing_compactions, reason);
-    return stop_tasks(std::move(tasks), std::move(reason));
-}
-
 future<> compaction_manager::stop_ongoing_compactions(sstring reason, column_family* cf, std::optional<sstables::compaction_type> type_opt) {
     auto ongoing_compactions = get_compactions(cf).size();
     auto tasks = boost::copy_range<std::vector<lw_shared_ptr<task>>>(_tasks | boost::adaptors::filtered([cf, type_opt] (auto& task) {

--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -1072,19 +1072,14 @@ const std::vector<sstables::compaction_info> compaction_manager::get_compactions
             }) | boost::adaptors::transformed(to_info));
 }
 
-void compaction_manager::stop_compaction(sstring type) {
+future<> compaction_manager::stop_compaction(sstring type) {
     sstables::compaction_type target_type;
     try {
         target_type = sstables::to_compaction_type(type);
     } catch (...) {
         throw std::runtime_error(format("Compaction of type {} cannot be stopped by compaction manager: {}", type.c_str(), std::current_exception()));
     }
-    // FIXME: switch to task_stop(), and wait for their termination, so API user can know when compactions actually stopped.
-    for (auto& task : _tasks) {
-        if (task->compaction_running && target_type == task->type) {
-            task->compaction_data.stop("user request");
-        }
-    }
+    return stop_ongoing_compactions("user request", nullptr, target_type);
 }
 
 void compaction_manager::propagate_replacement(column_family* cf,

--- a/compaction/compaction_manager.hh
+++ b/compaction/compaction_manager.hh
@@ -212,7 +212,6 @@ private:
     future<> rewrite_sstables(column_family* cf, sstables::compaction_type_options options, get_candidates_func, can_purge_tombstones can_purge = can_purge_tombstones::yes);
 
     future<> stop_ongoing_compactions(sstring reason);
-    future<> stop_ongoing_compactions(sstring reason, column_family* cf);
     optimized_optional<abort_source::subscription> _early_abort_subscription;
 public:
     compaction_manager(compaction_scheduling_group csg, maintenance_scheduling_group msg, size_t available_memory, abort_source& as);
@@ -308,6 +307,9 @@ public:
 
     // Stops ongoing compaction of a given type.
     void stop_compaction(sstring type);
+
+    // Stops ongoing compaction of a given table.
+    future<> stop_ongoing_compactions(sstring reason, column_family* cf);
 
     double backlog() {
         return _backlog_manager.backlog();

--- a/compaction/compaction_manager.hh
+++ b/compaction/compaction_manager.hh
@@ -305,7 +305,7 @@ public:
     }
 
     // Stops ongoing compaction of a given type.
-    void stop_compaction(sstring type);
+    future<> stop_compaction(sstring type);
 
     // Stops ongoing compaction of a given table and/or compaction_type.
     future<> stop_ongoing_compactions(sstring reason, column_family* cf = nullptr, std::optional<sstables::compaction_type> type_opt = {});

--- a/compaction/compaction_manager.hh
+++ b/compaction/compaction_manager.hh
@@ -308,8 +308,8 @@ public:
     // Stops ongoing compaction of a given type.
     void stop_compaction(sstring type);
 
-    // Stops ongoing compaction of a given table.
-    future<> stop_ongoing_compactions(sstring reason, column_family* cf);
+    // Stops ongoing compaction of a given table and/or compaction_type.
+    future<> stop_ongoing_compactions(sstring reason, column_family* cf, std::optional<sstables::compaction_type> type_opt = {});
 
     double backlog() {
         return _backlog_manager.backlog();

--- a/compaction/compaction_manager.hh
+++ b/compaction/compaction_manager.hh
@@ -211,7 +211,6 @@ private:
 
     future<> rewrite_sstables(column_family* cf, sstables::compaction_type_options options, get_candidates_func, can_purge_tombstones can_purge = can_purge_tombstones::yes);
 
-    future<> stop_ongoing_compactions(sstring reason);
     optimized_optional<abort_source::subscription> _early_abort_subscription;
 public:
     compaction_manager(compaction_scheduling_group csg, maintenance_scheduling_group msg, size_t available_memory, abort_source& as);
@@ -309,7 +308,7 @@ public:
     void stop_compaction(sstring type);
 
     // Stops ongoing compaction of a given table and/or compaction_type.
-    future<> stop_ongoing_compactions(sstring reason, column_family* cf, std::optional<sstables::compaction_type> type_opt = {});
+    future<> stop_ongoing_compactions(sstring reason, column_family* cf = nullptr, std::optional<sstables::compaction_type> type_opt = {});
 
     double backlog() {
         return _backlog_manager.backlog();

--- a/compaction/compaction_manager.hh
+++ b/compaction/compaction_manager.hh
@@ -292,7 +292,7 @@ public:
     // throws std::out_of_range exception if not found.
     compaction_state& get_compaction_state(table* t);
 
-    const std::vector<sstables::compaction_info> get_compactions() const;
+    const std::vector<sstables::compaction_info> get_compactions(table* cf = nullptr) const;
 
     // Returns true if table has an ongoing compaction, running on its behalf
     bool has_table_ongoing_compaction(const column_family* cf) const {

--- a/database.hh
+++ b/database.hh
@@ -947,7 +947,7 @@ public:
     void drop_hit_rate(gms::inet_address addr);
 
     void enable_auto_compaction();
-    void disable_auto_compaction();
+    future<> disable_auto_compaction();
     bool is_auto_compaction_disabled_by_user() const {
       return _compaction_disabled_by_user;
     }

--- a/distributed_loader.cc
+++ b/distributed_loader.cc
@@ -503,8 +503,7 @@ future<> distributed_loader::populate_column_family(distributed<database>& db, s
 
         db.invoke_on_all([&global_table, generation] (database& db) {
             global_table->update_sstables_known_generation(generation);
-            global_table->disable_auto_compaction();
-            return make_ready_future<>();
+            return global_table->disable_auto_compaction();
         }).get();
 
         reshard(directory, db, ks, cf, [&global_table, sstdir, sst_version] (shard_id shard) mutable {

--- a/table.cc
+++ b/table.cc
@@ -2160,14 +2160,14 @@ std::chrono::milliseconds table::get_coordinator_read_latency_percentile(double 
 
 void
 table::enable_auto_compaction() {
-    // XXX: unmute backlog. turn table backlog back on.
+    // FIXME: unmute backlog. turn table backlog back on.
     //      see table::disable_auto_compaction() notes.
     _compaction_disabled_by_user = false;
 }
 
 future<>
 table::disable_auto_compaction() {
-    // XXX: mute backlog. When we disable background compactions
+    // FIXME: mute backlog. When we disable background compactions
     // for the table, we must also disable current backlog of the
     // table compaction strategy that contributes to the scheduling
     // group resources prioritization.
@@ -2194,8 +2194,9 @@ table::disable_auto_compaction() {
     // - it will break computation of major compaction descriptor
     //   for new submissions
     _compaction_disabled_by_user = true;
-    // FIXME: stop ongoing compactions
-    return make_ready_future<>();
+    return with_gate(_async_gate, [this] {
+        return compaction_manager().stop_ongoing_compactions("disable auto-compaction", this);
+    });
 }
 
 flat_mutation_reader

--- a/table.cc
+++ b/table.cc
@@ -2165,7 +2165,7 @@ table::enable_auto_compaction() {
     _compaction_disabled_by_user = false;
 }
 
-void
+future<>
 table::disable_auto_compaction() {
     // XXX: mute backlog. When we disable background compactions
     // for the table, we must also disable current backlog of the
@@ -2194,6 +2194,8 @@ table::disable_auto_compaction() {
     // - it will break computation of major compaction descriptor
     //   for new submissions
     _compaction_disabled_by_user = true;
+    // FIXME: stop ongoing compactions
+    return make_ready_future<>();
 }
 
 flat_mutation_reader

--- a/test/boost/cql_query_test.cc
+++ b/test/boost/cql_query_test.cc
@@ -4763,7 +4763,7 @@ static future<> test_clustering_filtering_3_with_compaction_strategy(const std::
         cquery_nofail(e, format("CREATE TABLE cf(pk text, ck int, v text, PRIMARY KEY(pk, ck)) WITH COMPACTION = {{'class': '{}'}}", cs));
         e.db().invoke_on_all([] (database& db) {
             auto& table = db.find_column_family("ks", "cf");
-            table.disable_auto_compaction();
+            return table.disable_auto_compaction();
         }).get();
         cquery_nofail(e, "INSERT INTO  cf(pk, ck, v) VALUES ('a', 1, 'a1')");
         e.db().invoke_on_all([] (database& db) { return db.flush_all_memtables(); }).get();

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -3522,7 +3522,7 @@ SEASTAR_TEST_CASE(autocompaction_control_test) {
         // auto compaction is enabled by default
         BOOST_REQUIRE(!cf->is_auto_compaction_disabled_by_user());
         // disable auto compaction by user
-        cf->disable_auto_compaction();
+        cf->disable_auto_compaction().get();
         // check it is disabled
         BOOST_REQUIRE(cf->is_auto_compaction_disabled_by_user());
 

--- a/test/boost/sstable_directory_test.cc
+++ b/test/boost/sstable_directory_test.cc
@@ -490,7 +490,7 @@ SEASTAR_TEST_CASE(sstable_directory_shared_sstables_reshard_correctly) {
 
         e.db().invoke_on_all([] (database& db) {
             auto& cf = db.find_column_family("ks", "cf");
-            cf.disable_auto_compaction();
+            return cf.disable_auto_compaction();
         }).get();
 
         unsigned num_sstables = 10 * smp::count;
@@ -539,7 +539,7 @@ SEASTAR_TEST_CASE(sstable_directory_shared_sstables_reshard_distributes_well_eve
 
         e.db().invoke_on_all([] (database& db) {
             auto& cf = db.find_column_family("ks", "cf");
-            cf.disable_auto_compaction();
+            return cf.disable_auto_compaction();
         }).get();
 
         unsigned num_sstables = 10 * smp::count;
@@ -588,7 +588,7 @@ SEASTAR_TEST_CASE(sstable_directory_shared_sstables_reshard_respect_max_threshol
 
         e.db().invoke_on_all([] (database& db) {
             auto& cf = db.find_column_family("ks", "cf");
-            cf.disable_auto_compaction();
+            return cf.disable_auto_compaction();
         }).get();
 
         unsigned num_sstables = (cf.schema()->max_compaction_threshold() + 1) * smp::count;


### PR DESCRIPTION
This series extends `compaction_manager::stop_ongoing_compaction` so it can be used from the api layer for:
- table::disable_auto_compaction
- compaction_manager::stop_compaction

Fixes #9313
Fixes #9695

Test: unit(dev)