### PR TITLE
db: virtual_table: convert chained_delegating_reader to v2

### DIFF
--- a/db/chained_delegating_reader.hh
+++ b/db/chained_delegating_reader.hh
@@ -23,17 +23,17 @@
 
 #include <seastar/core/shared_future.hh>
 
-#include "flat_mutation_reader.hh"
+#include "flat_mutation_reader_v2.hh"
 
 // A reader which allows to insert a deferring operation before reading.
 // All calls will first wait for a future to resolve, then forward to a given underlying reader.
-class chained_delegating_reader : public flat_mutation_reader::impl {
-    std::unique_ptr<flat_mutation_reader> _underlying;
-    std::function<future<flat_mutation_reader>()> _populate_reader;
+class chained_delegating_reader : public flat_mutation_reader_v2::impl {
+    std::unique_ptr<flat_mutation_reader_v2> _underlying;
+    std::function<future<flat_mutation_reader_v2>()> _populate_reader;
     std::function<void()> _on_destroyed;
     
 public:
-    chained_delegating_reader(schema_ptr s, std::function<future<flat_mutation_reader>()>&& populate, reader_permit permit, std::function<void()> on_destroyed = []{})
+    chained_delegating_reader(schema_ptr s, std::function<future<flat_mutation_reader_v2>()>&& populate, reader_permit permit, std::function<void()> on_destroyed = []{})
         : impl(s, std::move(permit))
         , _populate_reader(std::move(populate))
         , _on_destroyed(std::move(on_destroyed))
@@ -47,8 +47,8 @@ public:
 
     virtual future<> fill_buffer() override {
         if (!_underlying) {
-            return _populate_reader().then([this] (flat_mutation_reader&& rd) {
-                _underlying = std::make_unique<flat_mutation_reader>(std::move(rd));
+            return _populate_reader().then([this] (flat_mutation_reader_v2&& rd) {
+                _underlying = std::make_unique<flat_mutation_reader_v2>(std::move(rd));
                 return fill_buffer();
             });
         }
@@ -65,8 +65,8 @@ public:
 
     virtual future<> fast_forward_to(position_range pr) override {
         if (!_underlying) {
-            return _populate_reader().then([this, pr = std::move(pr)] (flat_mutation_reader&& rd) mutable {
-                _underlying = std::make_unique<flat_mutation_reader>(std::move(rd));
+            return _populate_reader().then([this, pr = std::move(pr)] (flat_mutation_reader_v2&& rd) mutable {
+                _underlying = std::make_unique<flat_mutation_reader_v2>(std::move(rd));
                 return fast_forward_to(pr);
             });
         }
@@ -93,8 +93,8 @@ public:
 
     virtual future<> fast_forward_to(const dht::partition_range& pr) override {
         if (!_underlying) {
-            return _populate_reader().then([this, &pr] (flat_mutation_reader&& rd) mutable {
-                _underlying = std::make_unique<flat_mutation_reader>(std::move(rd));
+            return _populate_reader().then([this, &pr] (flat_mutation_reader_v2&& rd) mutable {
+                _underlying = std::make_unique<flat_mutation_reader_v2>(std::move(rd));
                 return fast_forward_to(pr);
             });
         }


### PR DESCRIPTION
As part of changing the codebase to flat_mutation_reader_v2,
change chained_delegating_reader and its user virtual_table.

Since the reader does not process fragments (only forwarding
things around), only glue code is affected. It is also not
performance sensitive, so the extra conversions are unimportant.

Test: unit (dev)