### PR TITLE
RFC: Alternator: stream results + chunk results to remove large allocations

### DIFF
--- a/alternator/executor.hh
+++ b/alternator/executor.hh
@@ -73,6 +73,16 @@ public:
     explicit make_jsonable(rjson::value&& value);
     std::string to_json() const override;
 };
+
+/**
+ * Make return type for serializing the object "streamed",
+ * i.e. direct to HTTP output stream. Note: only useful for
+ * (very) large objects as there are overhead issues with this
+ * as well, but for massive lists of return objects this can
+ * help avoid large allocations/many re-allocs
+ */ 
+json::json_return_type make_streamed(rjson::value&&);
+
 struct json_string : public json::jsonable {
     std::string _value;
 public:

--- a/alternator/streams.cc
+++ b/alternator/streams.cc
@@ -1023,8 +1023,8 @@ future<executor::request_return_type> executor::get_records(client_state& client
 
         // ugh. figure out if we are and end-of-shard
         auto normal_token_owners = _proxy.get_token_metadata_ptr()->count_normal_token_owners();
-        
-        return _sdks.cdc_current_generation_timestamp({ normal_token_owners }).then([this, iter, high_ts, start_time, ret = std::move(ret)](db_clock::time_point ts) mutable {
+
+        return _sdks.cdc_current_generation_timestamp({ normal_token_owners }).then([this, iter, high_ts, start_time, ret = std::move(ret), nrecords](db_clock::time_point ts) mutable {
             auto& shard = iter.shard;            
 
             if (shard.time < ts && ts < high_ts) {
@@ -1041,6 +1041,10 @@ future<executor::request_return_type> executor::get_records(client_state& client
                 rjson::add(ret, "NextShardIterator", iter);
             }
             _stats.api_operations.get_records_latency.add(std::chrono::steady_clock::now() - start_time);
+            // TODO: determine a better threshold...
+            if (nrecords > 10) {
+                return make_ready_future<executor::request_return_type>(make_streamed(std::move(ret)));
+            }
             return make_ready_future<executor::request_return_type>(make_jsonable(std::move(ret)));
         });
     });

--- a/idl/query.idl.hh
+++ b/idl/query.idl.hh
@@ -22,11 +22,11 @@ class qr_clustered_row stub [[writable]] {
 class qr_partition stub [[writable]] {
     std::optional<partition_key> key; // present when send_partition_key option set in partition_slice
     qr_row static_row;
-    std::vector<qr_clustered_row> rows; // ordered by key
+    utils::chunked_vector<qr_clustered_row> rows; // ordered by key
 };
 
 class query_result stub [[writable]] {
-    std::vector<qr_partition> partitions; // in ring order
+    utils::chunked_vector<qr_partition> partitions; // in ring order
 };
 
 enum class digest_algorithm : uint8_t {


### PR DESCRIPTION
Refs: #9555 

When running the "Kraken" dynamodb streams test to provoke the issued observed by QA, I noticed on my setup mainly two things: Large allocation stalls (+ warnings) and timeouts on read semaphores in DB. 

This tries to address the first issue, partly by making query_result_view serialization using chunked vector instead of linear one, and by introducing a streaming option for json return objects, avoiding linearizing to string before wire.
Note that the latter has some overhead issues of its own, mainly data copying, since we essentially will be triple buffering (local, wrapped http stream, and final output stream). Still, normal string output will typically do a lot of realloc which is potential extra copies as well, so...

This is not really performance tested, but with these tweaks I no longer get large alloc stalls at least, so that is a plus. :-)