### PR TITLE
Allow gossip info lookup in production_snitch_base (and children) via "private" ip as well as public

### DIFF
--- a/locator/production_snitch_base.cc
+++ b/locator/production_snitch_base.cc
@@ -119,6 +119,11 @@ sstring production_snitch_base::get_endpoint_info(inet_address endpoint, gms::ap
         }
     }
 
+    auto resolved = gms::get_local_gossiper().get_local_messaging().get_public_endpoint_for(endpoint);
+    if (resolved != endpoint) {
+        return get_endpoint_info(resolved, key, default_val);
+    }
+
     // ...if still not found - return a default value
     return default_val;
 }

--- a/message/messaging_service.hh
+++ b/message/messaging_service.hh
@@ -274,7 +274,7 @@ private:
 private:
     config _cfg;
     // map: Node broadcast address -> Node internal IP for communication within the same data center
-    std::unordered_map<gms::inet_address, gms::inet_address> _preferred_ip_cache;
+    std::unordered_map<gms::inet_address, gms::inet_address> _preferred_ip_cache, _preferred_to_endpoint;
     std::unique_ptr<rpc_protocol_wrapper> _rpc;
     std::array<std::unique_ptr<rpc_protocol_server_wrapper>, 2> _server;
     ::shared_ptr<seastar::tls::server_credentials> _credentials;
@@ -309,6 +309,7 @@ public:
     gms::inet_address get_preferred_ip(gms::inet_address ep);
     void init_local_preferred_ip_cache(const std::unordered_map<gms::inet_address, gms::inet_address>& ips_cache);
     void cache_preferred_ip(gms::inet_address ep, gms::inet_address ip);
+    gms::inet_address get_public_endpoint_for(const gms::inet_address&) const;
 
     future<> unregister_handler(messaging_verb verb);
 


### PR DESCRIPTION
Refs #9653

When authenticating TLS downgrade for rpc connections using "private" addresses, we still need to get actual gossip endpoint info for the node(s). This set adds a reverse mapping for quick lookup and augments snitches to fall back to get state info for resolved IP if asked with other than public endpoint address.