### PR TITLE
cdc: Throw when ALTERing cdc options is missing "enabled":"..."

### DIFF
--- a/cdc/cdc_options.hh
+++ b/cdc/cdc_options.hh
@@ -22,6 +22,7 @@
 #pragma once
 
 #include <map>
+#include <optional>
 #include <seastar/core/sstring.hh>
 #include "seastarx.hh"
 
@@ -49,7 +50,7 @@ std::ostream& operator<<(std::ostream& os, delta_mode);
 std::ostream& operator<<(std::ostream& os, image_mode);
 
 class options final {
-    bool _enabled = false;
+    std::optional<bool> _enabled;
     image_mode _preimage = image_mode::off;
     bool _postimage = false;
     delta_mode _delta_mode = delta_mode::full;
@@ -61,7 +62,8 @@ public:
     std::map<sstring, sstring> to_map() const;
     sstring to_sstring() const;
 
-    bool enabled() const { return _enabled; }
+    bool enabled() const { return _enabled.value_or(false); }
+    bool is_enabled_set() const { return _enabled.has_value(); }
     bool preimage() const { return _preimage != image_mode::off; }
     bool full_preimage() const { return _preimage == image_mode::full; }
     bool postimage() const { return _postimage; }

--- a/cdc/log.cc
+++ b/cdc/log.cc
@@ -331,10 +331,6 @@ std::ostream& cdc::operator<<(std::ostream& os, image_mode m) {
 }
 
 cdc::options::options(const std::map<sstring, sstring>& map) {
-    if (!map.contains("enabled")) {
-        return;
-    }
-
     for (auto& p : map) {
         auto key = p.first;
         auto val = p.second;
@@ -347,7 +343,7 @@ cdc::options::options(const std::map<sstring, sstring>& map) {
 
         if (key == "enabled") {
             if (is_true || is_false) {
-                _enabled = is_true;    
+                enabled(is_true);
             } else {
                 throw exceptions::configuration_exception("Invalid value for CDC option \"enabled\": " + p.second);
             }
@@ -391,11 +387,12 @@ cdc::options::options(const std::map<sstring, sstring>& map) {
 }
 
 std::map<sstring, sstring> cdc::options::to_map() const {
-    if (!_enabled) {
+    if (!is_enabled_set()) {
         return {};
     }
+
     return {
-        { "enabled", _enabled ? "true" : "false" },
+        { "enabled", enabled() ? "true" : "false" },
         { "preimage", to_string(_preimage) },
         { "postimage", _postimage ? "true" : "false" },
         { "delta", to_string(_delta_mode) },
@@ -408,7 +405,7 @@ sstring cdc::options::to_sstring() const {
 }
 
 bool cdc::options::operator==(const options& o) const {
-    return _enabled == o._enabled && _preimage == o._preimage && _postimage == o._postimage && _ttl == o._ttl
+    return enabled() == o.enabled() && _preimage == o._preimage && _postimage == o._postimage && _ttl == o._ttl
             && _delta_mode == o._delta_mode;
 }
 bool cdc::options::operator!=(const options& o) const {


### PR DESCRIPTION
The problem was that such a command:
```
alter table ks.cf with cdc={'ttl': 120};
```
would assume that "enabled" parameter is the default ("false") and, in effect, disable CDC on that table. This commit forces the user to add "enabled" key to ALTER command.

Fixes #6475