### PR TITLE
mutation_reader: update make_filtering_reader() to flat_mutation_reader_v2

### DIFF
--- a/compaction/compaction.cc
+++ b/compaction/compaction.cc
@@ -1125,7 +1125,7 @@ public:
         : cleanup_compaction(table_s, std::move(descriptor), cdata, opts.owned_ranges) {}
 
     flat_mutation_reader make_sstable_reader() const override {
-        return make_filtering_reader(regular_compaction::make_sstable_reader(), make_partition_filter());
+        return downgrade_to_v1(make_filtering_reader(upgrade_to_v2(regular_compaction::make_sstable_reader()), make_partition_filter()));
     }
 
     std::string_view report_start_desc() const override {

--- a/mutation_reader.hh
+++ b/mutation_reader.hh
@@ -74,12 +74,12 @@ template <typename MutationFilter>
 requires requires(MutationFilter mf, const dht::decorated_key& dk) {
     { mf(dk) } -> std::same_as<bool>;
 }
-class filtering_reader : public flat_mutation_reader::impl {
-    flat_mutation_reader _rd;
+class filtering_reader : public flat_mutation_reader_v2::impl {
+    flat_mutation_reader_v2 _rd;
     MutationFilter _filter;
     static_assert(std::is_same<bool, std::result_of_t<MutationFilter(const dht::decorated_key&)>>::value, "bad MutationFilter signature");
 public:
-    filtering_reader(flat_mutation_reader rd, MutationFilter&& filter)
+    filtering_reader(flat_mutation_reader_v2 rd, MutationFilter&& filter)
         : impl(rd.schema(), rd.permit())
         , _rd(std::move(rd))
         , _filter(std::forward<MutationFilter>(filter)) {
@@ -132,8 +132,8 @@ public:
 // accepts mutation const& and returns a bool. The mutation stays in the
 // stream if and only if the filter returns true.
 template <typename MutationFilter>
-flat_mutation_reader make_filtering_reader(flat_mutation_reader rd, MutationFilter&& filter) {
-    return make_flat_mutation_reader<filtering_reader<MutationFilter>>(std::move(rd), std::forward<MutationFilter>(filter));
+flat_mutation_reader_v2 make_filtering_reader(flat_mutation_reader_v2 rd, MutationFilter&& filter) {
+    return make_flat_mutation_reader_v2<filtering_reader<MutationFilter>>(std::move(rd), std::forward<MutationFilter>(filter));
 }
 
 /// Create a wrapper that filters fragments according to partition range and slice.

--- a/test/boost/data_listeners_test.cc
+++ b/test/boost/data_listeners_test.cc
@@ -41,11 +41,11 @@ public:
     virtual flat_mutation_reader on_read(const schema_ptr& s, const dht::partition_range& range,
             const query::partition_slice& slice, flat_mutation_reader&& rd) override {
         if (s->cf_name() == _cf_name) {
-            return make_filtering_reader(std::move(rd), [this, &range, &slice, s = std::move(s)] (const dht::decorated_key& dk) {
+            return downgrade_to_v1(make_filtering_reader(upgrade_to_v2(std::move(rd)), [this, &range, &slice, s = std::move(s)] (const dht::decorated_key& dk) {
                 testlog.info("listener {}: read {}", fmt::ptr(this), dk);
                 ++read;
                 return true;
-            });
+            }));
         }
         return std::move(rd);
     }


### PR DESCRIPTION
As part of the drive to move over to flat_mutation_reader_v2, update
make_filtering_reader(). Since it doesn't examine range tombstones
(only the partition_start, to filter the key) the entire patch
is just glue code upgrading and downgrading users in the pipeline
(or removing a conversion, in one case).

Test: unit (dev)