### PR TITLE
cql3: Don't allow unset values inside UDT

### DIFF
--- a/cql3/expr/expression.cc
+++ b/cql3/expr/expression.cc
@@ -1679,8 +1679,8 @@ constant evaluate(const usertype_constructor& user_val, const query_options& opt
 
         constant field_val = evaluate(cur_field->second, options);
         if (field_val.is_unset_value()) {
-            // TODO: Behaviour copied from user_types::delayed_value::bind(), but this seems incorrect
-            field_val.value = raw_value::make_null();
+            throw exceptions::invalid_request_exception(format(
+                "Invalid unset value for field '{}' of user defined type ", utype.field_name_as_string(i)));
         }
 
         field_values.emplace_back(std::move(field_val.value).to_managed_bytes_opt());

--- a/test/cql-pytest/cassandra_tests/validation/entities/user_types_test.py
+++ b/test/cql-pytest/cassandra_tests/validation/entities/user_types_test.py
@@ -169,7 +169,6 @@ def testAlterNonFrozenUDT(cql, test_keyspace):
                 assert_rows(execute(cql, table, "SELECT v FROM %s"), [user_type("a", 3, "foo", "abc", "c", 0)])
                 assert_rows(execute(cql, table, "SELECT v.c FROM %s"), [0])
 
-@pytest.mark.xfail(reason="#9671")
 def testUDTWithUnsetValues(cql, test_keyspace):
     with create_type(cql, test_keyspace, "(x int, y int)") as myType:
         with create_type(cql, test_keyspace, f"(a frozen<{myType}>)") as myOtherType:


### PR DESCRIPTION
Scylla doesn't support unset values inside UDT.
The old code used to convert `unset` to `null`, which seems incorrect.

There is an extra space in the error message to retain compatability with Cassandra.

Fixes: #9671