### PR TITLE
Convert compaction to flat_mutation_reader_v2

### DIFF
--- a/compaction/compaction.cc
+++ b/compaction/compaction.cc
@@ -894,7 +894,7 @@ public:
     }
 
     flat_mutation_reader make_sstable_reader() const override {
-        return _compacting->make_local_shard_sstable_reader(_schema,
+        return downgrade_to_v1(_compacting->make_local_shard_sstable_reader(_schema,
                 _permit,
                 query::full_partition_range,
                 _schema->full_slice(),
@@ -902,7 +902,7 @@ public:
                 tracing::trace_state_ptr(),
                 ::streamed_mutation::forwarding::no,
                 ::mutation_reader::forwarding::no,
-                default_read_monitor_generator());
+                default_read_monitor_generator()));
     }
 
     std::string_view report_start_desc() const override {
@@ -940,7 +940,7 @@ public:
     }
 
     flat_mutation_reader make_sstable_reader() const override {
-        return _compacting->make_local_shard_sstable_reader(_schema,
+        return downgrade_to_v1(_compacting->make_local_shard_sstable_reader(_schema,
                 _permit,
                 query::full_partition_range,
                 _schema->full_slice(),
@@ -948,7 +948,7 @@ public:
                 tracing::trace_state_ptr(),
                 ::streamed_mutation::forwarding::no,
                 ::mutation_reader::forwarding::no,
-                _monitor_generator);
+                _monitor_generator));
     }
 
     std::string_view report_start_desc() const override {

--- a/compaction/compaction.cc
+++ b/compaction/compaction.cc
@@ -1426,7 +1426,7 @@ public:
     }
 
     flat_mutation_reader make_sstable_reader() const override {
-        auto crawling_reader = _compacting->make_crawling_reader(_schema, _permit, _io_priority, nullptr);
+        auto crawling_reader = downgrade_to_v1(_compacting->make_crawling_reader(_schema, _permit, _io_priority, nullptr));
         return make_flat_mutation_reader<reader>(std::move(crawling_reader), _options.operation_mode);
     }
 
@@ -1691,7 +1691,7 @@ static future<compaction_result> scrub_sstables_validate_mode(sstables::compacti
     clogger.info("Scrubbing in validate mode {}", sstables_list_msg);
 
     auto permit = table_s.make_compaction_reader_permit();
-    auto reader = sstables->make_crawling_reader(schema, permit, descriptor.io_priority, nullptr);
+    auto reader = downgrade_to_v1(sstables->make_crawling_reader(schema, permit, descriptor.io_priority, nullptr));
 
     const auto valid = co_await scrub_validate_mode_validate_reader(std::move(reader), cdata);
 

--- a/compaction/compaction.cc
+++ b/compaction/compaction.cc
@@ -1512,14 +1512,14 @@ public:
 
     // Use reader that makes sure no non-local mutation will not be filtered out.
     flat_mutation_reader make_sstable_reader() const override {
-        return _compacting->make_range_sstable_reader(_schema,
+        return downgrade_to_v1(_compacting->make_range_sstable_reader(_schema,
                 _permit,
                 query::full_partition_range,
                 _schema->full_slice(),
                 _io_priority,
                 nullptr,
                 ::streamed_mutation::forwarding::no,
-                ::mutation_reader::forwarding::no);
+                ::mutation_reader::forwarding::no));
 
     }
 

--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -1521,7 +1521,7 @@ future<> view_builder::initialize_reader_at_current_token(build_step& step) {
   return step.reader.close().then([this, &step] {
     step.pslice = make_partition_slice(*step.base->schema());
     step.prange = dht::partition_range(dht::ring_position::starting_at(step.current_token()), dht::ring_position::max());
-    step.reader = step.base->get_sstable_set().make_local_shard_sstable_reader(
+    step.reader = downgrade_to_v1(step.base->get_sstable_set().make_local_shard_sstable_reader(
             step.base->schema(),
             _permit,
             step.prange,
@@ -1529,7 +1529,7 @@ future<> view_builder::initialize_reader_at_current_token(build_step& step) {
             default_priority_class(),
             nullptr,
             streamed_mutation::forwarding::no,
-            mutation_reader::forwarding::no);
+            mutation_reader::forwarding::no));
   });
 }
 

--- a/db/view/view_update_generator.cc
+++ b/db/view/view_update_generator.cc
@@ -85,7 +85,7 @@ future<> view_update_generator::start() {
                                 tracing::trace_state_ptr ts,
                                 streamed_mutation::forwarding fwd_ms,
                                 mutation_reader::forwarding fwd_mr) {
-                        return ssts->make_range_sstable_reader(s, std::move(permit), pr, ps, pc, std::move(ts), fwd_ms, fwd_mr);
+                        return downgrade_to_v1(ssts->make_range_sstable_reader(s, std::move(permit), pr, ps, pc, std::move(ts), fwd_ms, fwd_mr));
                     });
                     auto [staging_sstable_reader, staging_sstable_reader_handle] = make_manually_paused_evictable_reader(
                             std::move(ms),

--- a/sstables/sstable_set.cc
+++ b/sstables/sstable_set.cc
@@ -1084,7 +1084,7 @@ sstable_set::create_single_key_sstable_reader(
             std::move(permit), sstable_histogram, pr, slice, pc, std::move(trace_state), fwd, fwd_mr);
 }
 
-flat_mutation_reader
+flat_mutation_reader_v2
 sstable_set::make_range_sstable_reader(
         schema_ptr s,
         reader_permit permit,
@@ -1100,13 +1100,13 @@ sstable_set::make_range_sstable_reader(
             (shared_sstable& sst, const dht::partition_range& pr) mutable {
         return sst->make_reader(s, permit, pr, slice, pc, trace_state, fwd, fwd_mr, monitor_generator(sst));
     };
-    return make_combined_reader(s, std::move(permit), std::make_unique<incremental_reader_selector>(s,
+    return upgrade_to_v2(make_combined_reader(s, std::move(permit), std::make_unique<incremental_reader_selector>(s,
                     shared_from_this(),
                     pr,
                     std::move(trace_state),
                     std::move(reader_factory_fn)),
             fwd,
-            fwd_mr);
+            fwd_mr));
 }
 
 flat_mutation_reader_v2

--- a/sstables/sstable_set.hh
+++ b/sstables/sstable_set.hh
@@ -22,6 +22,7 @@
 #pragma once
 
 #include "flat_mutation_reader.hh"
+#include "flat_mutation_reader_v2.hh"
 #include "sstables/progress_monitor.hh"
 #include "shared_sstable.hh"
 #include "dht/i_partitioner.hh"
@@ -134,7 +135,7 @@ public:
         read_monitor_generator& rmg = default_read_monitor_generator()) const;
 
     // Filters out mutations that don't belong to the current shard.
-    flat_mutation_reader make_local_shard_sstable_reader(
+    flat_mutation_reader_v2 make_local_shard_sstable_reader(
         schema_ptr,
         reader_permit,
         const dht::partition_range&,

--- a/sstables/sstable_set.hh
+++ b/sstables/sstable_set.hh
@@ -157,7 +157,7 @@ public:
             mutation_reader::forwarding,
             read_monitor_generator& rmg = default_read_monitor_generator()) const;
 
-    flat_mutation_reader make_crawling_reader(
+    flat_mutation_reader_v2 make_crawling_reader(
             schema_ptr,
             reader_permit,
             const io_priority_class&,

--- a/sstables/sstable_set.hh
+++ b/sstables/sstable_set.hh
@@ -123,7 +123,7 @@ public:
     ///
     /// The reader is unrestricted, but will account its resource usage on the
     /// semaphore belonging to the passed-in permit.
-    flat_mutation_reader make_range_sstable_reader(
+    flat_mutation_reader_v2 make_range_sstable_reader(
         schema_ptr,
         reader_permit,
         const dht::partition_range&,

--- a/table.cc
+++ b/table.cc
@@ -266,8 +266,8 @@ flat_mutation_reader table::make_streaming_reader(schema_ptr schema, reader_perm
     auto trace_state = tracing::trace_state_ptr();
     const auto fwd = streamed_mutation::forwarding::no;
     const auto fwd_mr = mutation_reader::forwarding::no;
-    return sstables->make_range_sstable_reader(std::move(schema), std::move(permit), range, slice, pc,
-            std::move(trace_state), fwd, fwd_mr);
+    return downgrade_to_v1(sstables->make_range_sstable_reader(std::move(schema), std::move(permit), range, slice, pc,
+            std::move(trace_state), fwd, fwd_mr));
 }
 
 future<std::vector<locked_cell>> table::lock_counter_cells(const mutation& m, db::timeout_clock::time_point timeout) {

--- a/table.cc
+++ b/table.cc
@@ -84,8 +84,8 @@ table::make_sstable_reader(schema_ptr s,
         return sstables->create_single_key_sstable_reader(const_cast<column_family*>(this), std::move(s), std::move(permit),
                 _stats.estimated_sstable_per_read, pr, slice, pc, std::move(trace_state), fwd, fwd_mr);
     } else {
-        return sstables->make_local_shard_sstable_reader(std::move(s), std::move(permit), pr, slice, pc,
-                std::move(trace_state), fwd, fwd_mr);
+        return downgrade_to_v1(sstables->make_local_shard_sstable_reader(std::move(s), std::move(permit), pr, slice, pc,
+                std::move(trace_state), fwd, fwd_mr));
     }
 }
 

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -3342,14 +3342,14 @@ SEASTAR_TEST_CASE(purged_tombstone_consumer_sstable_test) {
             for (auto&& sst : all) {
                 compacting->insert(std::move(sst));
             }
-            auto reader = compacting->make_range_sstable_reader(s,
+            auto reader = downgrade_to_v1(compacting->make_range_sstable_reader(s,
                 env.make_reader_permit(),
                 query::full_partition_range,
                 s->full_slice(),
                 service::get_local_compaction_priority(),
                 nullptr,
                 ::streamed_mutation::forwarding::no,
-                ::mutation_reader::forwarding::no);
+                ::mutation_reader::forwarding::no));
 
             auto r = std::move(reader);
             auto close_r = deferred_close(r);


### PR DESCRIPTION
Since sstable reader was already converted to flat_mutation_reader_v2, compaction layer can naturally be converted too.

There are many dependencies that use v1. Those strictly needed like readers in sstable set, which links compaction to sstable reader, were converted to v2 in this series. For those that aren't essential we're relying on V1<-->V2 adaptors, and conversion work on them will be postponed. Those being postponed are: scrub specialized reader (needs a validator for mutation_fragment_v2), interposer consumer, combined reader which is used by incremental selector. incremental selector itself was converted to v2.

tests: unit(debug).