### PR TITLE
cql3: disentangle column_identifier from selectable

### DIFF
--- a/cql3/column_identifier.cc
+++ b/cql3/column_identifier.cc
@@ -80,7 +80,7 @@ column_identifier_raw::column_identifier_raw(sstring raw_text, bool keep_case)
     }
 }
 
-::shared_ptr<selection::selectable> column_identifier_raw::prepare(const schema& s) const {
+::shared_ptr<column_identifier> column_identifier_raw::prepare(const schema& s) const {
     return prepare_column_identifier(s);
 }
 
@@ -123,15 +123,15 @@ std::ostream& operator<<(std::ostream& out, const column_identifier_raw& id) {
 }
 
 ::shared_ptr<selection::selector::factory>
-column_identifier::new_selector_factory(database& db, schema_ptr schema, std::vector<const column_definition*>& defs) {
-    auto def = get_column_definition(*schema, *this);
+selectable_column::new_selector_factory(database& db, schema_ptr schema, std::vector<const column_definition*>& defs) {
+    auto def = get_column_definition(*schema, _ci);
     if (!def) {
-        throw exceptions::invalid_request_exception(format("Undefined name {} in selection clause", _text));
+        throw exceptions::invalid_request_exception(format("Undefined name {} in selection clause", _ci.text()));
     }
     // Do not allow explicitly selecting hidden columns. We also skip them on
     // "SELECT *" (see selection::wildcard()).
     if (def->is_hidden_from_cql()) {
-        throw exceptions::invalid_request_exception(format("Undefined name {} in selection clause", _text));
+        throw exceptions::invalid_request_exception(format("Undefined name {} in selection clause", _ci.text()));
     }
     return selection::simple_selector::new_factory(def->name_as_text(), add_and_get_index(*def, defs), def->type);
 }

--- a/cql3/column_identifier.cc
+++ b/cql3/column_identifier.cc
@@ -21,7 +21,6 @@
 
 #include "cql3/column_identifier.hh"
 #include "exceptions/exceptions.hh"
-#include "cql3/selection/simple_selector.hh"
 #include "cql3/util.hh"
 #include "cql3/query_options.hh"
 
@@ -120,20 +119,6 @@ sstring column_identifier_raw::to_string() const {
 
 std::ostream& operator<<(std::ostream& out, const column_identifier_raw& id) {
     return out << id._text;
-}
-
-::shared_ptr<selection::selector::factory>
-selectable_column::new_selector_factory(database& db, schema_ptr schema, std::vector<const column_definition*>& defs) {
-    auto def = get_column_definition(*schema, _ci);
-    if (!def) {
-        throw exceptions::invalid_request_exception(format("Undefined name {} in selection clause", _ci.text()));
-    }
-    // Do not allow explicitly selecting hidden columns. We also skip them on
-    // "SELECT *" (see selection::wildcard()).
-    if (def->is_hidden_from_cql()) {
-        throw exceptions::invalid_request_exception(format("Undefined name {} in selection clause", _ci.text()));
-    }
-    return selection::simple_selector::new_factory(def->name_as_text(), add_and_get_index(*def, defs), def->type);
 }
 
 }

--- a/cql3/column_identifier.hh
+++ b/cql3/column_identifier.hh
@@ -57,7 +57,7 @@ class column_identifier_raw;
  * Represents an identifer for a CQL column definition.
  * TODO : should support light-weight mode without text representation for when not interned
  */
-class column_identifier final : public selection::selectable {
+class column_identifier final {
 public:
     bytes bytes_;
 private:
@@ -80,7 +80,7 @@ public:
 
     const bytes& name() const;
 
-    virtual sstring to_string() const override;
+    sstring to_string() const;
 
     sstring to_cql_string() const;
 
@@ -95,10 +95,18 @@ public:
     }
 #endif
 
+    using raw = column_identifier_raw;
+};
+
+class selectable_column : public selection::selectable {
+    column_identifier _ci;
+public:
+    explicit selectable_column(column_identifier ci) : _ci(std::move(ci)) {}
     virtual ::shared_ptr<selection::selector::factory> new_selector_factory(database& db, schema_ptr schema,
         std::vector<const column_definition*>& defs) override;
-
-    using raw = column_identifier_raw;
+    virtual sstring to_string() const override {
+        return _ci.to_string();
+    }
 };
 
 /**
@@ -115,7 +123,7 @@ public:
     column_identifier_raw(sstring raw_text, bool keep_case);
 
     // for selectable::with_expression::raw:
-    ::shared_ptr<selection::selectable> prepare(const schema& s) const;
+    ::shared_ptr<column_identifier> prepare(const schema& s) const;
 
     ::shared_ptr<column_identifier> prepare_column_identifier(const schema& s) const;
 

--- a/cql3/column_identifier.hh
+++ b/cql3/column_identifier.hh
@@ -41,8 +41,6 @@
 
 #pragma once
 
-#include "cql3/selection/selectable.hh"
-
 #include "schema.hh"
 
 #include <algorithm>
@@ -96,17 +94,6 @@ public:
 #endif
 
     using raw = column_identifier_raw;
-};
-
-class selectable_column : public selection::selectable {
-    column_identifier _ci;
-public:
-    explicit selectable_column(column_identifier ci) : _ci(std::move(ci)) {}
-    virtual ::shared_ptr<selection::selector::factory> new_selector_factory(database& db, schema_ptr schema,
-        std::vector<const column_definition*>& defs) override;
-    virtual sstring to_string() const override {
-        return _ci.to_string();
-    }
 };
 
 /**

--- a/cql3/expr/expression.hh
+++ b/cql3/expr/expression.hh
@@ -26,10 +26,12 @@
 #include <seastar/core/shared_ptr.hh>
 #include <variant>
 #include <concepts>
+#include <numeric>
 
 #include "bytes.hh"
 #include "cql3/statements/bound.hh"
 #include "cql3/column_identifier.hh"
+#include "cql3/assignment_testable.hh"
 #include "cql3/cql3_type.hh"
 #include "cql3/functions/function_name.hh"
 #include "database_fwd.hh"


### PR DESCRIPTION
column_identifier serves two purposes: a value type used to denote an
identifier (which may or may not map to a table column), and `selectable`
implementation used for selecting table columns. This stands in the way
of further refactoring - the unification of the WHERE clause prepare path
(prepare_expression()) and the SELECT clause prepare path
(prepare_selectable()).

Reduce the entanglement by moving the selectable-specific parts to a new
type, selectable_column, and leaving column_identifier as a pure value type.