### PR TITLE
utils: logalloc: correct and adjust timing unit in stall report

### DIFF
--- a/utils/logalloc.cc
+++ b/utils/logalloc.cc
@@ -2190,8 +2190,8 @@ private:
         auto info_level = _stall_detected ? log_level::info : log_level::debug;
         auto MiB = 1024*1024;
 
-        timing_logger.log(time_level, "Reclamation cycle took {} ms, trying to release {:.3f} MiB {}preemptibly",
-                          _duration.count(), (float)_memory_to_release / MiB, _preemptible ? "" : "non-");
+        timing_logger.log(time_level, "Reclamation cycle took {} us, trying to release {:.3f} MiB {}preemptibly",
+                          _duration / 1us, (float)_memory_to_release / MiB, _preemptible ? "" : "non-");
         log_if_any(info_level, "reserved segments", _reserve_segments);
         if (_memory_released > 0) {
             auto bytes_per_second =


### PR DESCRIPTION
The stall report uses the millisecond unit, but actually reports
nanoseconds.

Switch to microseconds (milliseconds are a bit too coarse) and
use the safer "duration / 1us" style rather than "duration::count()"
that leads to unit confusion.

Fixes #9733.