### PR TITLE
alternator: ttl: don't initialize vector from initializer_list in coroutine

### DIFF
--- a/alternator/ttl.cc
+++ b/alternator/ttl.cc
@@ -579,7 +579,8 @@ static future<bool> scan_table(
         // Note that because of issue #9167 we need to run a separate
         // query on each partition range, and can't pass several of
         // them into one partition_range_vector.
-        dht::partition_range_vector partition_ranges = {*range};
+        dht::partition_range_vector partition_ranges;
+        partition_ranges.push_back(std::move(*range));
         // FIXME: if scanning a single range fails, including network errors,
         // we fail the entire scan (and rescan from the beginning). Need to
         // reconsider this. Saving the scan position might be a good enough


### PR DESCRIPTION
Initializing a vector from an initializer_list defeats move construction
(since initializer_list is const). Moreover it is suspected to cause a
crash due to a miscompile. In any case, this patch fixes the crash.

Fixes #9735.