### PR TITLE
Repair: add a stringify function for node_ops_cmd

### DIFF
--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -1799,3 +1799,52 @@ future<> repair_service::init_metrics() {
     _node_ops_metrics.init();
     return make_ready_future<>();
 }
+
+std::ostream& operator<<(std::ostream& out, node_ops_cmd cmd) {
+    switch (cmd) {
+        case node_ops_cmd::removenode_prepare:
+            return out << "removenode_prepare";
+        case node_ops_cmd::removenode_heartbeat:
+            return out << "removenode_heartbeat";
+        case node_ops_cmd::removenode_sync_data:
+            return out << "removenode_sync_data";
+        case node_ops_cmd::removenode_abort:
+            return out << "removenode_abort";
+        case node_ops_cmd::removenode_done:
+            return out << "removenode_done";
+        case node_ops_cmd::replace_prepare:
+            return out << "replace_prepare";
+        case node_ops_cmd::replace_prepare_mark_alive:
+            return out << "replace_prepare_mark_alive";
+        case node_ops_cmd::replace_prepare_pending_ranges:
+            return out << "replace_prepare_pending_ranges";
+        case node_ops_cmd::replace_heartbeat:
+            return out << "replace_heartbeat";
+        case node_ops_cmd::replace_abort:
+            return out << "replace_abort";
+        case node_ops_cmd::replace_done:
+            return out << "replace_done";
+        case node_ops_cmd::decommission_prepare:
+            return out << "decommission_prepare";
+        case node_ops_cmd::decommission_heartbeat:
+            return out << "decommission_heartbeat";
+        case node_ops_cmd::decommission_abort:
+            return out << "decommission_abort";
+        case node_ops_cmd::decommission_done:
+            return out << "decommission_done";
+        case node_ops_cmd::bootstrap_prepare:
+            return out << "bootstrap_prepare";
+        case node_ops_cmd::bootstrap_heartbeat:
+            return out << "bootstrap_heartbeat";
+        case node_ops_cmd::bootstrap_abort:
+            return out << "bootstrap_abort";
+        case node_ops_cmd::bootstrap_done:
+            return out << "bootstrap_done";
+        case node_ops_cmd::query_pending_ops:
+            return out << "query_pending_ops";
+        case node_ops_cmd::repair_updater:
+            return out << "repair_updater";
+        default:
+            return out << "unknown cmd (" << cmd << ")";
+    }
+}

--- a/repair/repair.hh
+++ b/repair/repair.hh
@@ -444,6 +444,8 @@ enum class node_ops_cmd : uint32_t {
      repair_updater,
 };
 
+std::ostream& operator<<(std::ostream& out, node_ops_cmd cmd);
+
 // The cmd and ops_uuid are mandatory for each request.
 // The ignore_nodes and leaving_node are optional.
 struct node_ops_cmd_request {

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -2344,7 +2344,7 @@ void storage_service::node_ops_cmd_check(gms::inet_address coordinator, const no
         // Peer node wants to start a new node operation. Make sure no pending node operation is in progress.
         if (!_node_ops.empty()) {
             msg = format("node_ops_cmd_check: Node {} rejected node_ops_cmd={} from node={} with ops_uuid={}, pending_node_ops={}, pending node ops is in progress",
-                    get_broadcast_address(), uint32_t(req.cmd), coordinator, req.ops_uuid, ops_uuids);
+                    get_broadcast_address(), req.cmd, coordinator, req.ops_uuid, ops_uuids);
         }
     } else {
         if (ops_uuids.size() == 1 && ops_uuids.front() == req.ops_uuid) {
@@ -2352,11 +2352,11 @@ void storage_service::node_ops_cmd_check(gms::inet_address coordinator, const no
         } else if (ops_uuids.size() == 0) {
             // The ops_uuid received is unknown. Fail the request.
             msg = format("node_ops_cmd_check: Node {} rejected node_ops_cmd={} from node={} with ops_uuid={}, pending_node_ops={}, the node ops is unknown",
-                    get_broadcast_address(), uint32_t(req.cmd), coordinator, req.ops_uuid, ops_uuids);
+                    get_broadcast_address(), req.cmd, coordinator, req.ops_uuid, ops_uuids);
         } else {
             // Other node ops is in progress. Fail the request.
             msg = format("node_ops_cmd_check: Node {} rejected node_ops_cmd={} from node={} with ops_uuid={}, pending_node_ops={}, pending node ops is in progress",
-                    get_broadcast_address(), uint32_t(req.cmd), coordinator, req.ops_uuid, ops_uuids);
+                    get_broadcast_address(), req.cmd, coordinator, req.ops_uuid, ops_uuids);
         }
     }
     if (!msg.empty()) {
@@ -2368,7 +2368,7 @@ void storage_service::node_ops_cmd_check(gms::inet_address coordinator, const no
 future<node_ops_cmd_response> storage_service::node_ops_cmd_handler(gms::inet_address coordinator, node_ops_cmd_request req) {
     return seastar::async([this, coordinator, req = std::move(req)] () mutable {
         auto ops_uuid = req.ops_uuid;
-        slogger.debug("node_ops_cmd_handler cmd={}, ops_uuid={}", uint32_t(req.cmd), ops_uuid);
+        slogger.debug("node_ops_cmd_handler cmd={}, ops_uuid={}", req.cmd, ops_uuid);
 
         if (req.cmd == node_ops_cmd::query_pending_ops) {
             bool ok = true;
@@ -2573,7 +2573,7 @@ future<node_ops_cmd_response> storage_service::node_ops_cmd_handler(gms::inet_ad
         } else if (req.cmd == node_ops_cmd::bootstrap_abort) {
             node_ops_abort(ops_uuid);
         } else {
-            auto msg = format("node_ops_cmd_handler: ops_uuid={}, unknown cmd={}", req.ops_uuid, uint32_t(req.cmd));
+            auto msg = format("node_ops_cmd_handler: ops_uuid={}, unknown cmd={}", req.ops_uuid, req.cmd);
             slogger.warn("{}", msg);
             throw std::runtime_error(msg);
         }


### PR DESCRIPTION
Adding a strigify function for the node_ops_cmd enum,
will make the log output more readable and will make it
possible (hopefully) to do initial analysis without consulting
the source code.

Refs #9629

Signed-off-by: Eliran Sinvani <eliransin@scylladb.com>