### PR TITLE
Extend stop compaction api

### DIFF
--- a/api/api-doc/compaction_manager.json
+++ b/api/api-doc/compaction_manager.json
@@ -113,6 +113,46 @@
          ]
       },
       {
+         "path":"/compaction_manager/stop_keyspace_compaction/{keyspace}",
+         "operations":[
+            {
+               "method":"POST",
+               "summary":"Stop all running compaction-like tasks in the given keyspace and tables having the provided type.",
+               "type":"void",
+               "nickname":"stop_keyspace_compaction",
+               "produces":[
+                  "application/json"
+               ],
+               "parameters":[
+                  {
+                     "name":"keyspace",
+                     "description":"The keyspace to stop compaction in",
+                     "required":true,
+                     "allowMultiple":false,
+                     "type":"string",
+                     "paramType":"path"
+                  },
+                  {
+                     "name":"tables",
+                     "description":"Comma-seperated tables to stop compaction in",
+                     "required":false,
+                     "allowMultiple":false,
+                     "type":"string",
+                     "paramType":"query"
+                  },
+                  {
+                     "name":"type",
+                     "description":"The type of compaction to stop. Can be one of: COMPACTION | CLEANUP | SCRUB | UPGRADE | RESHAPE",
+                     "required":true,
+                     "allowMultiple":false,
+                     "type":"string",
+                     "paramType":"query"
+                  }
+               ]
+            }
+         ]
+      },
+      {
       "path": "/compaction_manager/metrics/pending_tasks",
       "operations": [
         {

--- a/api/api-doc/compaction_manager.json
+++ b/api/api-doc/compaction_manager.json
@@ -102,7 +102,7 @@
                "parameters":[
                   {
                      "name":"type",
-                     "description":"the type of compaction to stop. Can be one of: - COMPACTION - VALIDATION - CLEANUP - SCRUB - INDEX_BUILD",
+                     "description":"The type of compaction to stop. Can be one of: COMPACTION | CLEANUP | SCRUB | UPGRADE | RESHAPE",
                      "required":true,
                      "allowMultiple":false,
                      "type":"string",

--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -70,10 +70,11 @@ namespace ss = httpd::storage_service_json;
 using namespace json;
 
 sstring validate_keyspace(http_context& ctx, const parameters& param) {
-    if (ctx.db.local().has_keyspace(param["keyspace"])) {
-        return param["keyspace"];
+    const auto& ks_name = param["keyspace"];
+    if (ctx.db.local().has_keyspace(ks_name)) {
+        return ks_name;
     }
-    throw bad_param_exception("Keyspace " + param["keyspace"] + " Does not exist");
+    throw bad_param_exception(no_such_keyspace(ks_name).what());
 }
 
 // splits a request parameter assumed to hold a comma-separated list of table names

--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -69,7 +69,7 @@ const locator::token_metadata& http_context::get_token_metadata() {
 namespace ss = httpd::storage_service_json;
 using namespace json;
 
-static sstring validate_keyspace(http_context& ctx, const parameters& param) {
+sstring validate_keyspace(http_context& ctx, const parameters& param) {
     if (ctx.db.local().has_keyspace(param["keyspace"])) {
         return param["keyspace"];
     }
@@ -79,7 +79,7 @@ static sstring validate_keyspace(http_context& ctx, const parameters& param) {
 // splits a request parameter assumed to hold a comma-separated list of table names
 // verify that the tables are found, otherwise a bad_param_exception exception is thrown
 // containing the description of the respective no_such_column_family error.
-static std::vector<sstring> parse_tables(const sstring& ks_name, http_context& ctx, const std::unordered_map<sstring, sstring>& query_params, sstring param_name) {
+std::vector<sstring> parse_tables(const sstring& ks_name, http_context& ctx, const std::unordered_map<sstring, sstring>& query_params, sstring param_name) {
     auto it = query_params.find(param_name);
     if (it == query_params.end()) {
         return {};

--- a/api/storage_service.hh
+++ b/api/storage_service.hh
@@ -46,6 +46,15 @@ class gossiper;
 
 namespace api {
 
+// verify that the keyspace parameter is found, otherwise a bad_param_exception exception is thrown
+// containing the description of the respective keyspace error.
+sstring validate_keyspace(http_context& ctx, const parameters& param);
+
+// splits a request parameter assumed to hold a comma-separated list of table names
+// verify that the tables are found, otherwise a bad_param_exception exception is thrown
+// containing the description of the respective no_such_column_family error.
+std::vector<sstring> parse_tables(const sstring& ks_name, http_context& ctx, const std::unordered_map<sstring, sstring>& query_params, sstring param_name);
+
 void set_storage_service(http_context& ctx, routes& r, sharded<service::storage_service>& ss, gms::gossiper& g, sharded<cdc::generation_service>& cdc_gs);
 void set_sstables_loader(http_context& ctx, routes& r, sharded<sstables_loader>& sst_loader);
 void unset_sstables_loader(http_context& ctx, routes& r);

--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -1076,14 +1076,14 @@ const std::vector<sstables::compaction_info> compaction_manager::get_compactions
             }) | boost::adaptors::transformed(to_info));
 }
 
-future<> compaction_manager::stop_compaction(sstring type) {
+future<> compaction_manager::stop_compaction(sstring type, table* table) {
     sstables::compaction_type target_type;
     try {
         target_type = sstables::to_compaction_type(type);
     } catch (...) {
         throw std::runtime_error(format("Compaction of type {} cannot be stopped by compaction manager: {}", type.c_str(), std::current_exception()));
     }
-    return stop_ongoing_compactions("user request", nullptr, target_type);
+    return stop_ongoing_compactions("user request", table, target_type);
 }
 
 void compaction_manager::propagate_replacement(table* t,

--- a/compaction/compaction_manager.hh
+++ b/compaction/compaction_manager.hh
@@ -305,7 +305,7 @@ public:
     }
 
     // Stops ongoing compaction of a given type.
-    future<> stop_compaction(sstring type);
+    future<> stop_compaction(sstring type, table* table = nullptr);
 
     // Stops ongoing compaction of a given table and/or compaction_type.
     future<> stop_ongoing_compactions(sstring reason, table* t = nullptr, std::optional<sstables::compaction_type> type_opt = {});

--- a/test/rest_api/conftest.py
+++ b/test/rest_api/conftest.py
@@ -119,3 +119,4 @@ def cql(request):
 @pytest.fixture(scope="session")
 def this_dc(cql):
     yield cql.execute("SELECT data_center FROM system.local").one()[0]
+

--- a/test/rest_api/test_compaction_manager.py
+++ b/test/rest_api/test_compaction_manager.py
@@ -1,0 +1,20 @@
+# Copyright 2021-present ScyllaDB
+#
+# This file is part of Scylla.
+#
+# Scylla is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Scylla is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
+
+def test_compaction_manager_stop_compaction(rest_api):
+    resp = rest_api.send("POST", "compaction_manager/stop_compaction", { "type": "COMPACTION" })
+    resp.raise_for_status()

--- a/test/rest_api/test_compaction_manager.py
+++ b/test/rest_api/test_compaction_manager.py
@@ -15,6 +15,69 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
 
+import pytest
+import sys
+import requests
+
+# Use the util.py library from ../cql-pytest:
+sys.path.insert(1, sys.path[0] + '/../cql-pytest')
+from util import new_test_table, unique_name
+
+# "keyspace" function: Creates and returns a temporary keyspace to be
+# used in tests that need a keyspace. The keyspace is created with RF=1,
+def new_keyspace(cql, this_dc):
+    name = unique_name()
+    cql.execute(f"CREATE KEYSPACE {name} WITH REPLICATION = {{ 'class' : 'NetworkTopologyStrategy', '{this_dc}' : 1 }}")
+    return name
+
 def test_compaction_manager_stop_compaction(rest_api):
     resp = rest_api.send("POST", "compaction_manager/stop_compaction", { "type": "COMPACTION" })
+
+def test_compaction_manager_stop_keyspace_compaction(cql, this_dc, rest_api):
+    keyspace = new_keyspace(cql, this_dc)
+    resp = rest_api.send("POST", f"compaction_manager/stop_keyspace_compaction/{keyspace}", { "type": "COMPACTION" })
     resp.raise_for_status()
+
+    # non-existing keyspace
+    resp = rest_api.send("POST", f"compaction_manager/stop_keyspace_compaction/XXX", { "type": "COMPACTION" })
+    try:
+        resp.raise_for_status()
+        pytest.fail("Failed to raise exception")
+    except requests.HTTPError as e:
+        expected_status_code = requests.codes.bad_request
+        assert resp.status_code == expected_status_code, e
+
+    cql.execute(f"DROP KEYSPACE {keyspace}")
+
+def test_compaction_manager_stop_keyspace_compaction_tables(cql, this_dc, rest_api):
+    keyspace = new_keyspace(cql, this_dc)
+    with new_test_table(cql, keyspace, "a int, PRIMARY KEY (a)") as t0:
+        test_tables = [t0 if not '.' in t0 else t0.split('.')[1]]
+        resp = rest_api.send("POST", f"compaction_manager/stop_keyspace_compaction/{keyspace}", { "tables": f"{test_tables[0]}", "type": "COMPACTION" })
+        resp.raise_for_status()
+
+        # non-existing table
+        resp = rest_api.send("POST", f"compaction_manager/stop_keyspace_compaction/{keyspace}", { "tables": "XXX", "type": "COMPACTION" })
+        try:
+            resp.raise_for_status()
+            pytest.fail("Failed to raise exception")
+        except requests.HTTPError as e:
+            expected_status_code = requests.codes.bad_request
+            assert resp.status_code == expected_status_code, e
+
+        # multiple tables
+        with new_test_table(cql, keyspace, "b int, PRIMARY KEY (b)") as t1:
+            test_tables += [t1 if not '.' in t1 else t1.split('.')[1]]
+            resp = rest_api.send("POST", f"compaction_manager/stop_keyspace_compaction/{keyspace}", { "tables": f"{test_tables[0]},{test_tables[1]}", "type": "COMPACTION" })
+            resp.raise_for_status()
+
+            # mixed existing and non-existing tables
+            resp = rest_api.send("POST", f"compaction_manager/stop_keyspace_compaction/{keyspace}", { "tables": f"{test_tables[1]},XXX", "type": "COMPACTION" })
+            try:
+                resp.raise_for_status()
+                pytest.fail("Failed to raise exception")
+            except requests.HTTPError as e:
+                expected_status_code = requests.codes.bad_request
+                assert resp.status_code == expected_status_code, e
+
+    cql.execute(f"DROP KEYSPACE {keyspace}")


### PR DESCRIPTION
Allow stopping compaction by type on a given keyspace and list of tables.

Also add api unit test suite that tests the existing `stop_compaction` api
and the new `stop_keyspace_compaction` api.

Fixes #9700
