### PR TITLE
db: range_tombstone_list: Deoverlap empty range tombstones

### DIFF
--- a/range_tombstone_list.cc
+++ b/range_tombstone_list.cc
@@ -48,11 +48,15 @@ void range_tombstone_list::apply_reversibly(const schema& s,
         tombstone tomb,
         reverter& rev)
 {
+    position_in_partition::less_compare less(s);
     position_in_partition start(position_in_partition::range_tag_t(), bound_view(std::move(start_key), start_kind));
     position_in_partition end(position_in_partition::range_tag_t(), bound_view(std::move(end_key), end_kind));
 
+    if (!less(start, end)) {
+        return;
+    }
+
     if (!_tombstones.empty()) {
-        position_in_partition::less_compare less(s);
         auto last = --_tombstones.end();
         range_tombstones_type::iterator it;
         if (less(start, last->end_position())) {

--- a/range_tombstone_list.hh
+++ b/range_tombstone_list.hh
@@ -297,7 +297,13 @@ public:
 private:
     void apply_reversibly(const schema& s, clustering_key_prefix start, bound_kind start_kind,
                           clustering_key_prefix end, bound_kind end_kind, tombstone tomb, reverter& rev);
-    void insert_from(const schema& s, range_tombstones_type::iterator it, clustering_key_prefix start,
-                     bound_kind start_kind, clustering_key_prefix end, bound_kind end_kind, tombstone tomb, reverter& rev);
+
+    void insert_from(const schema& s,
+                     range_tombstones_type::iterator it,
+                     position_in_partition start,
+                     position_in_partition end,
+                     tombstone tomb,
+                     reverter& rev);
+
     range_tombstones_type::iterator find(const schema& s, const range_tombstone_entry& rt);
 };


### PR DESCRIPTION
Appending an empty range adjacent to an existing range tombstone would
not deoverlap (by dropping the empty range tombstone) resulting in
different (non canoncial) result depending on the order of appending.

Suppose that range tombstone [a, b] covers range tombstone [x, x), and [a, x) and [x, b) are range tombstones which correspond to [a, b] split around position x.

Appending [a, x) then [x, b) then [x, x) would give [a, b)
Appending [a, x) then [x, x) then [x, b) would give [a, x), [x, x), [x, b)

The fix is to drop empty range tombstones in range_tombstone_list so that the result is canonical.

Fixes #9661
