### PR TITLE
scylla_util.py: introduce common APIs for cloud instance

### DIFF
--- a/dist/common/scripts/scylla_io_setup
+++ b/dist/common/scripts/scylla_io_setup
@@ -194,7 +194,7 @@ if __name__ == "__main__":
                 sys.exit(1)
             disk_properties = {}
             disk_properties["mountpoint"] = datadir()
-            nr_disks = len(idata.ephemeral_disks())
+            nr_disks = len(idata.get_local_disks())
             ## both i3 and i2 can run with 1 I/O Queue per shard
             if idata.instance() == "i3.large":
                 disk_properties["read_iops"] = 111000


### PR DESCRIPTION
Currently, cloud instances classes APIs are not unified, some method
name different between clouds.
For example, getting ephemeral disks is 'ephemeral_disks()' on AWS,
but 'getEphemeralOsDisks()' on gce and azure.
To fix this, add abstract class 'cloud_instance' and make sure
common APIs and change method names to unified one.

Fixes #9742