### PR TITLE
Use the same page size limit in reversed queries as in forward reads

### DIFF
--- a/flat_mutation_reader.cc
+++ b/flat_mutation_reader.cc
@@ -156,7 +156,7 @@ flat_mutation_reader make_reversing_reader(flat_mutation_reader original, query:
                 } else {
                     _mutation_fragments.emplace(std::move(mf));
                     _stack_size += _mutation_fragments.top().memory_usage();
-                    if (_stack_size > _max_size.hard_limit || (_stack_size > _max_size.soft_limit && _below_soft_limit)) {
+                    if (_stack_size > _max_size.get_unlimited_hard_limit() || (_stack_size > _max_size.get_unlimited_soft_limit() && _below_soft_limit)) {
                         const partition_key* key = nullptr;
                         auto it = buffer().end();
                         --it;
@@ -167,15 +167,15 @@ flat_mutation_reader make_reversing_reader(flat_mutation_reader original, query:
                             key = &it->as_partition_start().key().key();
                         }
 
-                        if (_stack_size > _max_size.hard_limit) {
+                        if (_stack_size > _max_size.get_unlimited_hard_limit()) {
                             return make_exception_future<stop_iteration>(std::runtime_error(fmt::format(
                                     "Memory usage of reversed read exceeds hard limit of {} (configured via max_memory_for_unlimited_query_hard_limit), while reading partition {}",
-                                    _max_size.hard_limit,
+                                    _max_size.get_unlimited_hard_limit(),
                                     key->with_schema(*_schema))));
                         } else {
                             fmr_logger.warn(
                                     "Memory usage of reversed read exceeds soft limit of {} (configured via max_memory_for_unlimited_query_soft_limit), while reading partition {}",
-                                    _max_size.soft_limit,
+                                    _max_size.get_unlimited_soft_limit(),
                                     key->with_schema(*_schema));
                             _below_soft_limit = false;
                         }

--- a/gms/feature.hh
+++ b/gms/feature.hh
@@ -148,6 +148,7 @@ extern const std::string_view ALTERNATOR_TTL;
 extern const std::string_view RANGE_SCAN_DATA_VARIANT;
 extern const std::string_view CDC_GENERATIONS_V2;
 extern const std::string_view UDA;
+extern const std::string_view REDUCED_REVERSED_QUERIES_LIMIT;
 
 }
 

--- a/gms/feature_service.cc
+++ b/gms/feature_service.cc
@@ -73,6 +73,7 @@ constexpr std::string_view features::ALTERNATOR_TTL = "ALTERNATOR_TTL";
 constexpr std::string_view features::RANGE_SCAN_DATA_VARIANT = "RANGE_SCAN_DATA_VARIANT";
 constexpr std::string_view features::CDC_GENERATIONS_V2 = "CDC_GENERATIONS_V2";
 constexpr std::string_view features::UDA = "UDA";
+constexpr std::string_view features::REDUCED_REVERSED_QUERIES_LIMIT = "REDUCED_REVERSED_QUERIES_LIMIT";
 
 static logging::logger logger("features");
 
@@ -98,6 +99,7 @@ feature_service::feature_service(feature_config cfg) : _config(cfg)
         , _range_scan_data_variant(*this, features::RANGE_SCAN_DATA_VARIANT)
         , _cdc_generations_v2(*this, features::CDC_GENERATIONS_V2)
         , _uda(*this, features::UDA)
+        , _reduced_reversed_queries_limit(*this, features::REDUCED_REVERSED_QUERIES_LIMIT)
 {}
 
 feature_config feature_config_from_db_config(db::config& cfg, std::set<sstring> disabled) {
@@ -202,6 +204,7 @@ std::set<std::string_view> feature_service::known_feature_set() {
         gms::features::RANGE_SCAN_DATA_VARIANT,
         gms::features::CDC_GENERATIONS_V2,
         gms::features::UDA,
+        gms::features::REDUCED_REVERSED_QUERIES_LIMIT,
     };
 
     for (const sstring& s : _config._disabled_features) {
@@ -307,6 +310,7 @@ void feature_service::enable(const std::set<std::string_view>& list) {
         std::ref(_range_scan_data_variant),
         std::ref(_cdc_generations_v2),
         std::ref(_uda),
+        std::ref(_reduced_reversed_queries_limit),
     })
     {
         if (list.contains(f.name())) {

--- a/gms/feature_service.hh
+++ b/gms/feature_service.hh
@@ -100,6 +100,7 @@ private:
     gms::feature _range_scan_data_variant;
     gms::feature _cdc_generations_v2;
     gms::feature _uda;
+    gms::feature _reduced_reversed_queries_limit;
 
 public:
 
@@ -176,6 +177,10 @@ public:
 
     bool cluster_supports_user_defined_aggregates() const {
         return bool(_uda);
+    }
+
+    bool cluster_supports_reduced_revenced_queries_limit() const {
+        return bool(_reduced_reversed_queries_limit);
     }
 
     static std::set<sstring> to_feature_set(sstring features_string);

--- a/idl/read_command.idl.hh
+++ b/idl/read_command.idl.hh
@@ -50,6 +50,8 @@ class partition_slice {
 struct max_result_size {
     uint64_t soft_limit;
     uint64_t hard_limit;
+    uint64_t unlimited_soft_limit [[version 4.7]] = 0;
+    uint64_t unlimited_hard_limit [[version 4.7]] = 0;
 }
 
 class read_command {

--- a/query_class_config.hh
+++ b/query_class_config.hh
@@ -28,14 +28,31 @@ namespace query {
 struct max_result_size {
     uint64_t soft_limit;
     uint64_t hard_limit;
+    uint64_t unlimited_soft_limit;
+    uint64_t unlimited_hard_limit;
+
+    uint64_t get_unlimited_soft_limit() const {
+        return unlimited_soft_limit == 0 ? soft_limit : unlimited_soft_limit;
+    }
+
+    uint64_t get_unlimited_hard_limit() const {
+        return unlimited_hard_limit == 0 ? hard_limit : unlimited_hard_limit;
+    }
 
     max_result_size() = delete;
-    explicit max_result_size(uint64_t max_size) : soft_limit(max_size), hard_limit(max_size) { }
-    explicit max_result_size(uint64_t soft_limit, uint64_t hard_limit) : soft_limit(soft_limit), hard_limit(hard_limit) { }
+    explicit max_result_size(uint64_t max_size)
+        : soft_limit(max_size), hard_limit(max_size), unlimited_soft_limit(max_size), unlimited_hard_limit(max_size)
+    { }
+    explicit max_result_size(uint64_t soft_limit, uint64_t hard_limit)
+        : soft_limit(soft_limit), hard_limit(hard_limit), unlimited_soft_limit(soft_limit), unlimited_hard_limit(hard_limit)
+    { }
+    explicit max_result_size(uint64_t soft_limit, uint64_t hard_limit, uint64_t unlimited_soft_limit, uint64_t unlimited_hard_limit)
+        : soft_limit(soft_limit), hard_limit(hard_limit), unlimited_soft_limit(unlimited_soft_limit), unlimited_hard_limit(unlimited_hard_limit)
+    { }
 };
 
 inline bool operator==(const max_result_size& a, const max_result_size& b) {
-    return a.soft_limit == b.soft_limit && a.hard_limit == b.hard_limit;
+    return a.soft_limit == b.soft_limit && a.hard_limit == b.hard_limit && a.unlimited_soft_limit == b.unlimited_soft_limit && a.unlimited_hard_limit == b.unlimited_hard_limit;
 }
 
 }


### PR DESCRIPTION
The default for get_unlimited_query_max_result_size() is 100MB (adjustable through config), whereas query::result_memory_limiter::maximum_result_size is 1MB (hard coded, should be enough for everybody)

This limit is then used by the replica to decide when to break pages and, in case of reversed clustering order reads, when to fail the read when accumulated data crosses the threshold. The latter behavior stems from the fact that reversed reads had to accumulate all the data (read in forward order) before they can reverse it and return the result. Reverse reads thus need a higher limit so that they have a higher chance of succeeding.

Most readers are now supporting reading in reverse natively, and only reversing wrappers (make_reversing_reader()) inserted on top of ka/la sstable readers need to accumulate all the data. In other cases, we could break pages sooner. This should lead to better stability (less memory usage) and performance (lower page build latency, higher read concurrency due to less memory footprint).

Tests: unit(dev)