### PR TITLE
dist: allow running scylla-housekeeping with strict umask setting

### DIFF
--- a/dist/common/scripts/scylla-housekeeping
+++ b/dist/common/scripts/scylla-housekeeping
@@ -100,7 +100,7 @@ def version_compare(a, b):
 def create_uuid_file(fl):
     with open(args.uuid_file, 'w') as myfile:
         myfile.write(str(uuid.uuid1()) + "\n")
-        os.fchmod(myfile, 0o644)
+    os.chmod(args.uuid_file, 0o644)
 
 
 def sanitize_version(version):


### PR DESCRIPTION
This fixes script bug of #9739 (Replaces os.fchmod to os.chmod).

see: https://github.com/scylladb/scylla/pull/9739#discussion_r769547592