### PR TITLE
Use the same page size limit in reverse queries as in forward reads

### DIFF
--- a/gms/feature.hh
+++ b/gms/feature.hh
@@ -148,6 +148,7 @@ extern const std::string_view ALTERNATOR_TTL;
 extern const std::string_view RANGE_SCAN_DATA_VARIANT;
 extern const std::string_view CDC_GENERATIONS_V2;
 extern const std::string_view UDA;
+extern const std::string_view SEPARATE_PAGE_SIZE_AND_SAFETY_LIMIT;
 
 }
 

--- a/gms/feature_service.cc
+++ b/gms/feature_service.cc
@@ -73,6 +73,7 @@ constexpr std::string_view features::ALTERNATOR_TTL = "ALTERNATOR_TTL";
 constexpr std::string_view features::RANGE_SCAN_DATA_VARIANT = "RANGE_SCAN_DATA_VARIANT";
 constexpr std::string_view features::CDC_GENERATIONS_V2 = "CDC_GENERATIONS_V2";
 constexpr std::string_view features::UDA = "UDA";
+constexpr std::string_view features::SEPARATE_PAGE_SIZE_AND_SAFETY_LIMIT = "SEPARATE_PAGE_SIZE_AND_SAFETY_LIMIT";
 
 static logging::logger logger("features");
 
@@ -98,6 +99,7 @@ feature_service::feature_service(feature_config cfg) : _config(cfg)
         , _range_scan_data_variant(*this, features::RANGE_SCAN_DATA_VARIANT)
         , _cdc_generations_v2(*this, features::CDC_GENERATIONS_V2)
         , _uda(*this, features::UDA)
+        , _separate_page_size_and_safety_limit(*this, features::SEPARATE_PAGE_SIZE_AND_SAFETY_LIMIT)
 {}
 
 feature_config feature_config_from_db_config(db::config& cfg, std::set<sstring> disabled) {
@@ -202,6 +204,7 @@ std::set<std::string_view> feature_service::known_feature_set() {
         gms::features::RANGE_SCAN_DATA_VARIANT,
         gms::features::CDC_GENERATIONS_V2,
         gms::features::UDA,
+        gms::features::SEPARATE_PAGE_SIZE_AND_SAFETY_LIMIT,
     };
 
     for (const sstring& s : _config._disabled_features) {
@@ -307,6 +310,7 @@ void feature_service::enable(const std::set<std::string_view>& list) {
         std::ref(_range_scan_data_variant),
         std::ref(_cdc_generations_v2),
         std::ref(_uda),
+        std::ref(_separate_page_size_and_safety_limit),
     })
     {
         if (list.contains(f.name())) {

--- a/gms/feature_service.hh
+++ b/gms/feature_service.hh
@@ -100,6 +100,7 @@ private:
     gms::feature _range_scan_data_variant;
     gms::feature _cdc_generations_v2;
     gms::feature _uda;
+    gms::feature _separate_page_size_and_safety_limit;
 
 public:
 
@@ -176,6 +177,22 @@ public:
 
     bool cluster_supports_user_defined_aggregates() const {
         return bool(_uda);
+    }
+
+    // Historically max_result_size contained only two fields: soft_limit and
+    // hard_limit. It was somehow obscure because for normal paged queries both
+    // fields were equal and meant page size. For unpaged queries and reversed
+    // queries soft_limit was used to warn when the size of the result exceeded
+    // the soft_limit and hard_limit was used to throw when the result was
+    // bigger than this hard_limit. To clean things up, we introduced the third
+    // field into max_result_size. It's name is page_size. Now page_size always
+    // means the size of the page while soft and hard limits are just what their
+    // names suggest. They are no longer interepreted as page size. This is not
+    // a backwards compatible change so this new cluster feature is used to make
+    // sure the whole cluster supports the new page_size field and we can safely
+    // send it to replicas.
+    bool cluster_supports_separate_page_size_and_safety_limit() const {
+        return bool(_separate_page_size_and_safety_limit);
     }
 
     static std::set<sstring> to_feature_set(sstring features_string);

--- a/idl/read_command.idl.hh
+++ b/idl/read_command.idl.hh
@@ -50,6 +50,7 @@ class partition_slice {
 struct max_result_size {
     uint64_t soft_limit;
     uint64_t hard_limit;
+    uint64_t page_size [[version 4.7]] = 0;
 }
 
 class read_command {

--- a/query_class_config.hh
+++ b/query_class_config.hh
@@ -23,19 +23,91 @@
 
 #include <cinttypes>
 
+namespace ser {
+
+template <typename T>
+class serializer;
+
+};
+
+
 namespace query {
 
+/*
+ * This struct is used in two incompatible ways.
+ *
+ * SEPARATE_PAGE_SIZE_AND_SAFETY_LIMIT cluster feature determines which way is
+ * used.
+ *
+ * 1. If SEPARATE_PAGE_SIZE_AND_SAFETY_LIMIT is not enabled on the cluster then
+ *    `page_size` field is ignored. Depending on the query type the meaning of
+ *    the remaining two fields is:
+ *
+ *    a. For unpaged queries or for reverse queries:
+ *
+ *          * `soft_limit` is used to warn about queries that result exceeds
+ *            this limit. If the limit is exceeded, a warning will be written to
+ *            the log.
+ *
+ *          * `hard_limit` is used to terminate a query which result exceeds
+ *            this limit. If the limit is exceeded, the operation will end with
+ *            an exception.
+ *
+ *    b. For all other queries, `soft_limit` == `hard_limit` and their value is
+ *       really a page_size in bytes. If the page is not previously cut by the
+ *       page row limit then reaching the size of `soft_limit`/`hard_limit`
+ *       bytes will cause a page to be finished.
+ *
+ * 2. If SEPARATE_PAGE_SIZE_AND_SAFETY_LIMIT is enabled on the cluster then all
+ *    three fields are always set. They are used in different places:
+ *
+ *    a. `soft_limit` and `hard_limit` are used for unpaged queries and in a
+ *       reversing reader used for reading KA/LA sstables. Their meaning is the
+ *       same as in (1.a) above.
+ *
+ *    b. all other queries use `page_size` field only and the meaning of the
+ *       field is the same ase in (1.b) above.
+ *
+ * Two interpretations of the `max_result_size` struct are not compatible so we
+ * need to take care of handling a mixed clusters.
+ *
+ * As long as SEPARATE_PAGE_SIZE_AND_SAFETY_LIMIT cluster feature is not
+ * supported by all nodes in the clustser, new nodes will always use the
+ * interpretation described in the point (1). `soft_limit` and `hard_limit`
+ * fields will be set appropriately to the query type and `page_size` field
+ * will be set to 0. Old nodes will ignare `page_size` anyways and new nodes
+ * will know to ignore it as well when it's set to 0. Old nodes will never set
+ * `page_size` and that means new nodes will give it a default value of 0 and
+ * ignore it for messages that miss this field.
+ *
+ * Once SEPARATE_PAGE_SIZE_AND_SAFETY_LIMIT cluster feature becomes supported by
+ * the whole cluster, new nodes will start to set `page_size` to the right value
+ * according to the interpretation described in the point (2).
+ */
 struct max_result_size {
     uint64_t soft_limit;
     uint64_t hard_limit;
+private:
+    uint64_t page_size = 0;
+public:
 
     max_result_size() = delete;
     explicit max_result_size(uint64_t max_size) : soft_limit(max_size), hard_limit(max_size) { }
     explicit max_result_size(uint64_t soft_limit, uint64_t hard_limit) : soft_limit(soft_limit), hard_limit(hard_limit) { }
+    max_result_size(uint64_t soft_limit, uint64_t hard_limit, uint64_t page_size)
+            : soft_limit(soft_limit)
+            , hard_limit(hard_limit)
+            , page_size(page_size)
+    { }
+    uint64_t get_page_size() const {
+        return page_size == 0 ? hard_limit : page_size;
+    }
+    friend bool operator==(const max_result_size&, const max_result_size&);
+    friend class ser::serializer<query::max_result_size>;
 };
 
 inline bool operator==(const max_result_size& a, const max_result_size& b) {
-    return a.soft_limit == b.soft_limit && a.hard_limit == b.hard_limit;
+    return a.soft_limit == b.soft_limit && a.hard_limit == b.hard_limit && a.page_size == b.page_size;
 }
 
 }


### PR DESCRIPTION
The default for get_unlimited_query_max_result_size() is 100MB (adjustable through config), whereas query::result_memory_limiter::maximum_result_size is 1MB (hard coded, should be enough for everybody)

This limit is then used by the replica to decide when to break pages and, in case of reversed clustering order reads, when to fail the read when accumulated data crosses the threshold. The latter behavior stems from the fact that reversed reads had to accumulate all the data (read in forward order) before they can reverse it and return the result. Reverse reads thus need a higher limit so that they have a higher chance of succeeding.

Most readers are now supporting reading in reverse natively, and only reversing wrappers (make_reversing_reader()) inserted on top of ka/la sstable readers need to accumulate all the data. In other cases, we could break pages sooner. This should lead to better stability (less memory usage) and performance (lower page build latency, higher read concurrency due to less memory footprint).

Tests: unit(dev)