### PR TITLE
migration_manager: retire global storage proxy refs

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -930,7 +930,7 @@ int main(int ac, char** av) {
             // engine().at_exit([&proxy] { return proxy.stop(); });
             supervisor::notify("starting migration manager");
             debug::the_migration_manager = &mm;
-            mm.start(std::ref(mm_notifier), std::ref(feature_service), std::ref(messaging), std::ref(gossiper), std::ref(raft_gr)).get();
+            mm.start(std::ref(mm_notifier), std::ref(feature_service), std::ref(messaging), std::ref(proxy), std::ref(gossiper), std::ref(raft_gr)).get();
             auto stop_migration_manager = defer_verbose_shutdown("migration manager", [&mm] {
                 mm.stop().get();
             });

--- a/service/migration_manager.cc
+++ b/service/migration_manager.cc
@@ -166,8 +166,6 @@ void migration_manager::init_messaging_service()
                 return cm.to_mutation(db.find_column_family(cm.column_family_id()).schema());
             }));
             return make_ready_future<rpc::tuple<frozen_mutations, canonical_mutations>>(rpc::tuple(std::move(fm), std::move(cm)));
-        }).finally([p = get_local_shared_storage_proxy()] {
-            // keep local proxy alive
         });
     });
     _messaging.register_schema_check([] {

--- a/service/migration_manager.cc
+++ b/service/migration_manager.cc
@@ -174,7 +174,6 @@ void migration_manager::init_messaging_service()
         return make_ready_future<utils::UUID>(service::get_local_storage_proxy().get_db().local().get_version());
     });
     _messaging.register_get_schema_version([this] (unsigned shard, table_schema_version v) {
-        get_local_storage_proxy().get_stats().replica_cross_shard_ops += shard != this_shard_id();
         // FIXME: should this get an smp_service_group? Probably one separate from reads and writes.
         return container().invoke_on(shard, [v] (auto&& sp) {
             mlogger.debug("Schema version request for {}", v);

--- a/service/migration_manager.cc
+++ b/service/migration_manager.cc
@@ -132,11 +132,11 @@ void migration_manager::init_messaging_service()
         auto src = netw::messaging_service::get_source(cinfo);
         auto f = make_ready_future<>();
         if (cm) {
-            f = do_with(std::move(*cm), get_local_shared_storage_proxy(), [this, src] (const std::vector<canonical_mutation>& mutations, shared_ptr<storage_proxy>& p) {
+            f = do_with(std::move(*cm), [this, src] (const std::vector<canonical_mutation>& mutations) {
                 return merge_schema_in_background(src, mutations);
             });
         } else {
-            f = do_with(std::move(fm), get_local_shared_storage_proxy(), [this, src] (const std::vector<frozen_mutation>& mutations, shared_ptr<storage_proxy>& p) {
+            f = do_with(std::move(fm), [this, src] (const std::vector<frozen_mutation>& mutations) {
                 return merge_schema_in_background(src, mutations);
             });
         }

--- a/service/migration_manager.hh
+++ b/service/migration_manager.hh
@@ -72,6 +72,8 @@ class versioned_value;
 
 namespace service {
 
+class storage_proxy;
+
 template<typename M>
 concept MergeableMutation = std::is_same<M, canonical_mutation>::value || std::is_same<M, frozen_mutation>::value;
 
@@ -87,13 +89,14 @@ private:
     static const std::chrono::milliseconds migration_delay;
     gms::feature_service& _feat;
     netw::messaging_service& _messaging;
+    service::storage_proxy& _storage_proxy;
     gms::gossiper& _gossiper;
     seastar::abort_source _as;
     service::raft_group_registry& _raft_gr;
     serialized_action _schema_push;
     utils::UUID _schema_version_to_publish;
 public:
-    migration_manager(migration_notifier&, gms::feature_service&, netw::messaging_service& ms, gms::gossiper& gossiper, service::raft_group_registry& raft_gr);
+    migration_manager(migration_notifier&, gms::feature_service&, netw::messaging_service& ms, service::storage_proxy&, gms::gossiper& gossiper, service::raft_group_registry& raft_gr);
 
     migration_notifier& get_notifier() { return _notifier; }
     const migration_notifier& get_notifier() const { return _notifier; }

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -634,7 +634,7 @@ public:
             proxy.start(std::ref(db), std::ref(gossiper), spcfg, std::ref(b), scheduling_group_key_create(sg_conf).get0(), std::ref(feature_service), std::ref(token_metadata), std::ref(erm_factory), std::ref(ms)).get();
             auto stop_proxy = defer([&proxy] { proxy.stop().get(); });
 
-            mm.start(std::ref(mm_notif), std::ref(feature_service), std::ref(ms), std::ref(gossiper), std::ref(raft_gr)).get();
+            mm.start(std::ref(mm_notif), std::ref(feature_service), std::ref(ms), std::ref(proxy), std::ref(gossiper), std::ref(raft_gr)).get();
             auto stop_mm = defer([&mm] { mm.stop().get(); });
 
             cql3::query_processor::memory_config qp_mcfg = {memory::stats().total_memory() / 256, memory::stats().total_memory() / 2560};


### PR DESCRIPTION
Replace get_local_storage_proxy() and get_local_storage_proxy() with
constructor-provided references. Some unneeded cases were removed.

Test: unit (dev)