### PR TITLE
repair: Improve memory usage tracking and oom protection

### DIFF
--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -593,6 +593,7 @@ repair_info::repair_info(repair_service& repair,
     streaming::stream_reason reason_,
     std::optional<utils::UUID> ops_uuid)
     : db(repair.get_db())
+    , rs(repair)
     , messaging(repair.get_messaging().container())
     , sys_dist_ks(repair.get_sys_dist_ks())
     , view_update_generator(repair.get_view_update_generator())

--- a/repair/repair.hh
+++ b/repair/repair.hh
@@ -169,6 +169,7 @@ public:
 class repair_info {
 public:
     seastar::sharded<database>& db;
+    repair_service& rs;
     seastar::sharded<netw::messaging_service>& messaging;
     sharded<db::system_distributed_keyspace>& sys_dist_ks;
     sharded<db::view::view_update_generator>& view_update_generator;

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -2788,6 +2788,16 @@ public:
             auto schema_version = s->version();
             bool table_dropped = false;
 
+            auto& mem_sem = _ri.rs.memory_sem();
+            auto max = _ri.rs.max_repair_memory();
+            auto wanted = (_all_live_peer_nodes.size() + 1) * tracker::max_repair_memory_per_range();
+            wanted = std::min(max, wanted);
+            rlogger.trace("repair[{}]: Started to get memory budget, wanted={}, available={}, max_repair_memory={}",
+                    _ri.id.uuid, wanted, mem_sem.current(), max);
+            auto mem_permit = seastar::get_units(mem_sem, wanted).get0();
+            rlogger.trace("repair[{}]: Finished to get memory budget, wanted={}, available={}, max_repair_memory={}",
+                    _ri.id.uuid, wanted, mem_sem.current(), max);
+
             auto permit = _ri.db.local().obtain_reader_permit(_cf, "repair-meta", db::no_timeout).get0();
 
             repair_meta master(_ri.db,
@@ -2967,6 +2977,8 @@ repair_service::repair_service(distributed<gms::gossiper>& gossiper,
     , _sys_dist_ks(sys_dist_ks)
     , _view_update_generator(vug)
     , _mm(mm)
+    , _max_repair_memory(max_repair_memory)
+    , _memory_sem(max_repair_memory)
 {
     if (this_shard_id() == 0) {
         _gossip_helper = make_shared<row_level_repair_gossip_helper>();

--- a/repair/row_level.hh
+++ b/repair/row_level.hh
@@ -54,6 +54,9 @@ class repair_service : public seastar::peering_sharded_service<repair_service> {
     std::unique_ptr<tracker> _tracker;
     bool _stopped = false;
 
+    size_t _max_repair_memory;
+    seastar::semaphore _memory_sem;
+
     future<> init_ms_handlers();
     future<> uninit_ms_handlers();
 
@@ -108,6 +111,8 @@ public:
     sharded<db::system_distributed_keyspace>& get_sys_dist_ks() noexcept { return _sys_dist_ks; }
     sharded<db::view::view_update_generator>& get_view_update_generator() noexcept { return _view_update_generator; }
     gms::gossiper& get_gossiper() noexcept { return _gossiper.local(); }
+    size_t max_repair_memory() const { return _max_repair_memory; }
+    seastar::semaphore& memory_sem() { return _memory_sem; }
 };
 
 class repair_info;


### PR DESCRIPTION
Currently, the repair parallelism is calculated by the number of memory
allocated to repair and memory usage per repair instance. However, the
memory usage per repair instance does not take the max possible memory
usage caused by repair followers.

As a result, when repairing a table with more replication factors, e.g.,
3 DCs, each has 3 replicas, the repair master node would use 9X repair
buffer size in worse cases. This would cause OOM when the system is
under pressure.

This patch introduces a semaphore to cap the max memory usage.

Each repair instance takes the max possible memory usage budget before
it starts. This ensures repair would never use more than the memory
allocated to repair.

Fixes #9817