### PR TITLE
dist/docker: add systemd mode for podman

### DIFF
--- a/dist/docker/debian/build_docker.sh
+++ b/dist/docker/debian/build_docker.sh
@@ -30,6 +30,7 @@ if [[ "$version" = *rc* ]]; then
 fi
 
 mode="release"
+systemd=false
 
 if uname -m | grep x86_64 ; then
   arch="amd64"
@@ -50,6 +51,10 @@ while [ $# -gt 0 ]; do
         --mode)
             mode="$2"
             shift 2
+            ;;
+        --systemd)
+            systemd=true
+            shift 1
             ;;
         *)
             print_usage
@@ -93,27 +98,41 @@ run apt-get -y update
 run apt-get -y install dialog apt-utils
 run bash -ec "echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections"
 run bash -ec "rm -rf /etc/rsyslog.conf"
-run apt-get -y install hostname supervisor openssh-server openssh-client openjdk-11-jre-headless python python-yaml curl rsyslog locales sudo
+if ! $systemd; then
+    run apt-get -y install supervisor
+else
+    run apt-get -y install systemd systemd-sysv
+    run rm -fv /etc/systemd/system/multi-user.target.wants/systemd-resolved.service
+fi
+run apt-get -y install hostname openssh-server openssh-client openjdk-11-jre-headless python python-yaml curl rsyslog locales sudo
 run locale-gen en_US.UTF-8
 run update-locale LANG=en_US.UTF-8 LANGUAGE=en_US:en LC_ALL=en_US.UTF_8
 run bash -ec "dpkg -i packages/*.deb"
 run apt-get -y clean all
 run bash -ec "cat /scylla_bashrc >> /etc/bash.bashrc"
-run mkdir -p /etc/supervisor.conf.d
+if ! $systemd; then
+    run mkdir -p /etc/supervisor.conf.d
+fi
 run mkdir -p /var/log/scylla
 run chown -R scylla:scylla /var/lib/scylla
 
-run mkdir -p /opt/scylladb/supervisor
-bcp dist/common/supervisor/scylla-server.sh /opt/scylladb/supervisor/scylla-server.sh
-bcp dist/common/supervisor/scylla-jmx.sh /opt/scylladb/supervisor/scylla-jmx.sh
-bcp dist/common/supervisor/scylla-node-exporter.sh /opt/scylladb/supervisor/scylla-node-exporter.sh
-bcp dist/common/supervisor/scylla_util.sh /opt/scylladb/supervisor/scylla_util.sh
+if ! $systemd; then
+    run mkdir -p /opt/scylladb/supervisor
+    bcp dist/common/supervisor/scylla-server.sh /opt/scylladb/supervisor/scylla-server.sh
+    bcp dist/common/supervisor/scylla-jmx.sh /opt/scylladb/supervisor/scylla-jmx.sh
+    bcp dist/common/supervisor/scylla-node-exporter.sh /opt/scylladb/supervisor/scylla-node-exporter.sh
+    bcp dist/common/supervisor/scylla_util.sh /opt/scylladb/supervisor/scylla_util.sh
+fi
 
 bconfig --env PATH=/opt/scylladb/python3/bin:/usr/bin:/usr/sbin
 bconfig --env LANG=en_US.UTF-8
 bconfig --env LANGUAGE=en_US:en
 bconfig --env LC_ALL=en_US.UTF-8
-bconfig --entrypoint  '["/docker-entrypoint.py"]'
+if ! $systemd; then
+    bconfig --entrypoint  '["/docker-entrypoint.py"]'
+else
+    bconfig --entrypoint  '["/usr/sbin/init"]'
+fi
 bconfig --cmd  ''
 bconfig --port 10000 --port 9042 --port 9160 --port 9180 --port 7000 --port 7001 --port 22
 bconfig --volume "/var/lib/scylla"

--- a/dist/docker/docker-entrypoint.py
+++ b/dist/docker/docker-entrypoint.py
@@ -28,7 +28,12 @@ try:
     setup.cqlshrc()
     setup.arguments()
     setup.set_housekeeping()
-    supervisord = subprocess.Popen(["/usr/bin/supervisord", "-c",  "/etc/supervisord.conf"])
-    supervisord.wait()
+    # supervisord mode
+    if os.path.exists("/usr/bin/supervisord"):
+        supervisord = subprocess.Popen(["/usr/bin/supervisord", "-c",  "/etc/supervisord.conf"])
+        supervisord.wait()
+    # systemd mode
+    else:
+        subprocess.run(["/usr/bin/systemctl", "start", "scylla-server.service"])
 except Exception:
     logging.exception('failed!')


### PR DESCRIPTION
This add experimental support building systemd based Scylla image for Podman.
It uses systemd support in Podman without root privilege
(see: https://blog.while-true-do.io/podman-systemd-in-containers/).

In systemd based image, it does not automatically execute
docker-entrypoint.py since there is no way to receive arguments,
we need to run it in "podman exec" instead:
  ex) podman exec -it <CONTAINER> /docker-entrypoint.py --alternator-port=8000 --alternator-write-isolation=always