### PR TITLE
alternator: doc, test: fix mentions of reverse queries

### DIFF
--- a/docs/alternator/compatibility.md
+++ b/docs/alternator/compatibility.md
@@ -121,11 +121,6 @@ they should be easy to detect. Here is a list of these unimplemented features:
   read parts of items or to just count them, is not yet supported.
   https://github.com/scylladb/scylla/issues/5058
 
-* The ScanIndexForward=false of the Query operation - to read a partition
-  in reverse order - is currently implemented inefficiently, and limited
-  by default to partitions of size 100 MB.
-  https://github.com/scylladb/scylla/issues/7586
-
 * Alternator does not yet support the DynamoDB API calls that control which
   table is available in which data center (DC): CreateGlobalTable,
   UpdateGlobalTable, DescribeGlobalTable, ListGlobalTables,

--- a/test/alternator/test_query.py
+++ b/test/alternator/test_query.py
@@ -437,7 +437,6 @@ def test_query_reverse_paging(test_table_sn):
 # several seconds), so we mark it with "veryslow" - so it's not run unless
 # the "--runveryslow" option is passed to pytest.
 @pytest.mark.veryslow
-@pytest.mark.xfail(reason="issue #7586")
 def test_query_reverse_long(test_table_sn):
     # Insert many big strings into one partition sized over 100MB:
     p = random_string()


### PR DESCRIPTION
Now that issues #7586 and #9487 were fixed, reverse queries - even in
long partitions - work well, we can drop the claim in
alternator/docs/compatibility.md that reverse queries are buggy for
large partitions.

We can also remove the "xfail" mark from the test that checks this
feature, as it now passes.

Refs #7586
Refs #9487

Signed-off-by: Nadav Har'El <nyh@scylladb.com>