### PR TITLE
scylla_io_setup: use preset parameter only on scylla-machine-image

### DIFF
--- a/dist/common/scripts/scylla_io_setup
+++ b/dist/common/scripts/scylla_io_setup
@@ -180,13 +180,14 @@ if __name__ == "__main__":
         print('Requires root permission.')
         sys.exit(1)
     parser = argparse.ArgumentParser(description='IO Setup script for Scylla.')
+    # Just keep for compatibility
     parser.add_argument('--ami', dest='ami', action='store_true',
                         help='configure AWS AMI')
     args = parser.parse_args()
 
     cpudata = scylla_cpuinfo()
     if not is_developer_mode():
-        if args.ami:
+        if is_machine_image() and is_ec2():
             idata = aws_instance()
 
             if not idata.is_supported_instance_class():
@@ -346,7 +347,7 @@ if __name__ == "__main__":
             else:
                 logging.info('This is a supported AWS instance type but there are no preconfigured IO scheduler parameters for it. Running manual iotune.')
                 run_iotune()
-        elif gcp_instance().is_gce_instance():
+        elif is_machine_image() and is_gce():
             idata = gcp_instance()
 
             if idata.is_recommended_instance():
@@ -398,7 +399,7 @@ if __name__ == "__main__":
                 logging.error(
                     'This is not a recommended Google Cloud instance setup for auto local disk tuning, running manual iotune.')
                 run_iotune()
-        elif azure_instance().is_azure_instance():
+        elif is_machine_image() and is_azure():
             idata = azure_instance()
             if idata.is_recommended_instance():
                 disk_properties = {}

--- a/dist/common/scripts/scylla_util.py
+++ b/dist/common/scripts/scylla_util.py
@@ -58,6 +58,9 @@ def is_nonroot():
 def is_offline():
     return Path(scylladir_p() / 'SCYLLA-OFFLINE-FILE').exists()
 
+def is_machine_image():
+    return Path(scylladir_p() / 'scylla-machine-image').exists()
+
 def bindir_p():
     if is_nonroot():
         return scylladir_p() / 'bin'


### PR DESCRIPTION
Applying preset parameter to user created instance may cause problem,
since user can use non-ephemeral disks for RAID volume, or even they
use root disk for /var/lib/scylla.

To avoid that, use preset parameter only when scylla-machine-image is
installed.

Fixes #9828