### PR TITLE
lister: add directory_lister

### DIFF
--- a/lister.hh
+++ b/lister.hh
@@ -13,6 +13,8 @@
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/core/file.hh>
 #include <seastar/core/enum.hh>
+#include <seastar/core/queue.hh>
+#include <seastar/core/pipe.hh>
 #include <seastar/util/bool_class.hh>
 
 #include "seastarx.hh"
@@ -151,6 +153,53 @@ private:
      * exceptional future with std::system_error exception if type of the file represented by @param de may not be retrieved.
      */
     future<directory_entry> guarantee_type(directory_entry de);
+};
+
+class directory_lister {
+    fs::path _dir;
+    lister::dir_entry_types _type;
+    lister::filter_type _filter;
+    lister::show_hidden _do_show_hidden;
+    seastar::queue<std::optional<directory_entry>> _queue;
+    std::unique_ptr<lister> _lister;
+    std::optional<future<>> _opt_done_fut;
+public:
+    directory_lister(fs::path dir,
+            lister::dir_entry_types type = {directory_entry_type::regular, directory_entry_type::directory},
+            lister::filter_type filter = [] (const fs::path& parent_dir, const directory_entry& entry) { return true; },
+            lister::show_hidden do_show_hidden = lister::show_hidden::yes) noexcept
+        : _dir(std::move(dir))
+        , _type(type)
+        , _filter(std::move(filter))
+        , _do_show_hidden(do_show_hidden)
+        , _queue(512 / sizeof(std::optional<directory_entry>))
+    { }
+
+    ~directory_lister();
+
+    // Get the next directory_entry from the lister,
+    // if available.  When the directory listing is done,
+    // a disengaged optional is returned.
+    //
+    // Caller should either drain all entries using get()
+    // until it gets a disengaged result or an error, or
+    // close() can be called to terminate the listing prematurely,
+    // and wait on any background work to complete.
+    //
+    // Calling get() after the listing is done and a disengaged
+    // result has been returned results in a broken_pipe_exception.
+    future<std::optional<directory_entry>> get();
+
+    // Abort the directory_lister with a given exception
+    // Further calls to get() will fail with this exception.
+    void abort(std::exception_ptr ex = std::make_exception_ptr(broken_pipe_exception()));
+
+    // Close the directory_lister, ignoring any errors.
+    // Must be called after abort() or if get() did not drain the queue.
+    //
+    // Close aborts the lister, waking up get() if any is waiting,
+    // and waits for all background work to complete.
+    future<> close() noexcept;
 };
 
 static inline fs::path operator/(const fs::path& lhs, const char* rhs) {

--- a/sstables/sstable_directory.cc
+++ b/sstables/sstable_directory.cc
@@ -169,54 +169,54 @@ sstable_directory::process_sstable_dir(const ::io_priority_class& iop, bool sort
     scan_state state;
 
     co_await lister::scan_dir(_sstable_dir, { directory_entry_type::regular },
-                [this, sort_sstables_according_to_owner, &state] (fs::path parent_dir, directory_entry de) {
-            auto comps = sstables::entry_descriptor::make_descriptor(_sstable_dir.native(), de.name);
-            handle_component(state, std::move(comps), parent_dir / fs::path(de.name));
-            return make_ready_future<>();
-        }, &manifest_json_filter);
+            [this, sort_sstables_according_to_owner, &state] (fs::path parent_dir, directory_entry de) {
+        auto comps = sstables::entry_descriptor::make_descriptor(_sstable_dir.native(), de.name);
+        handle_component(state, std::move(comps), parent_dir / fs::path(de.name));
+        return make_ready_future<>();
+    }, &manifest_json_filter);
 
-            // Always okay to delete files with a temporary TOC. We want to do it before we process
-            // the generations seen: it's okay to reuse those generations since the files will have
-            // been deleted anyway.
-            for (auto& desc: state.temp_toc_found) {
-                auto range = state.generations_found.equal_range(desc.generation);
-                for (auto it = range.first; it != range.second; ++it) {
-                    auto& path = it->second;
-                    dirlog.trace("Scheduling to remove file {}, from an SSTable with a Temporary TOC", path.native());
-                    _files_for_removal.insert(path.native());
-                }
-                state.generations_found.erase(range.first, range.second);
-                state.descriptors.erase(desc.generation);
-            }
+    // Always okay to delete files with a temporary TOC. We want to do it before we process
+    // the generations seen: it's okay to reuse those generations since the files will have
+    // been deleted anyway.
+    for (auto& desc: state.temp_toc_found) {
+        auto range = state.generations_found.equal_range(desc.generation);
+        for (auto it = range.first; it != range.second; ++it) {
+            auto& path = it->second;
+            dirlog.trace("Scheduling to remove file {}, from an SSTable with a Temporary TOC", path.native());
+            _files_for_removal.insert(path.native());
+        }
+        state.generations_found.erase(range.first, range.second);
+        state.descriptors.erase(desc.generation);
+    }
 
-            _max_generation_seen =  boost::accumulate(state.generations_found | boost::adaptors::map_keys, int64_t(0), [] (int64_t a, int64_t b) {
-                return std::max<int64_t>(a, b);
-            });
+    _max_generation_seen =  boost::accumulate(state.generations_found | boost::adaptors::map_keys, int64_t(0), [] (int64_t a, int64_t b) {
+        return std::max<int64_t>(a, b);
+    });
 
-            dirlog.debug("After {} scanned, seen generation {}. {} descriptors found, {} different files found ",
-                    _sstable_dir, _max_generation_seen, state.descriptors.size(), state.generations_found.size());
+    dirlog.debug("After {} scanned, seen generation {}. {} descriptors found, {} different files found ",
+            _sstable_dir, _max_generation_seen, state.descriptors.size(), state.generations_found.size());
 
-            // _descriptors is everything with a TOC. So after we remove this, what's left is
-            // SSTables for which a TOC was not found.
+    // _descriptors is everything with a TOC. So after we remove this, what's left is
+    // SSTables for which a TOC was not found.
     co_await parallel_for_each_restricted(state.descriptors, [this, sort_sstables_according_to_owner, &state, &iop] (std::tuple<int64_t, sstables::entry_descriptor>&& t) {
-                auto& desc = std::get<1>(t);
-                state.generations_found.erase(desc.generation);
-                // This will try to pre-load this file and throw an exception if it is invalid
-                return process_descriptor(std::move(desc), iop, sort_sstables_according_to_owner);
-            });
+        auto& desc = std::get<1>(t);
+        state.generations_found.erase(desc.generation);
+        // This will try to pre-load this file and throw an exception if it is invalid
+        return process_descriptor(std::move(desc), iop, sort_sstables_according_to_owner);
+    });
 
-                // For files missing TOC, it depends on where this is coming from.
-                // If scylla was supposed to have generated this SSTable, this is not okay and
-                // we refuse to proceed. If this coming from, say, an import, then we just delete,
-                // log and proceed.
-                for (auto& path : state.generations_found | boost::adaptors::map_values) {
-                    if (_throw_on_missing_toc) {
-                        throw sstables::malformed_sstable_exception(format("At directory: {}: no TOC found for SSTable {}!. Refusing to boot", _sstable_dir.native(), path.native()));
-                    } else {
-                        dirlog.info("Found incomplete SSTable {} at directory {}. Removing", path.native(), _sstable_dir.native());
-                        _files_for_removal.insert(path.native());
-                    }
-                }
+    // For files missing TOC, it depends on where this is coming from.
+    // If scylla was supposed to have generated this SSTable, this is not okay and
+    // we refuse to proceed. If this coming from, say, an import, then we just delete,
+    // log and proceed.
+    for (auto& path : state.generations_found | boost::adaptors::map_values) {
+        if (_throw_on_missing_toc) {
+            throw sstables::malformed_sstable_exception(format("At directory: {}: no TOC found for SSTable {}!. Refusing to boot", _sstable_dir.native(), path.native()));
+        } else {
+            dirlog.info("Found incomplete SSTable {} at directory {}. Removing", path.native(), _sstable_dir.native());
+            _files_for_removal.insert(path.native());
+        }
+    }
 }
 
 future<>


### PR DESCRIPTION
directory_lister provides a simpler interface compared to lister.

After creating the directory_lister,
its async get() method should be called repeatedly,
returning a std::optional<directory_entry> each call,
until it returns a disengaged entry or an error.
    
This is especially suitable for coroutines
as demonstrated in the unit tests that were added.
    
For example:
```c++
        auto dl = directory_lister(path);
        while (auto de = co_await dl.get()) {
            co_await process(*de);
        }
```

Signed-off-by: Benny Halevy <bhalevy@scylladb.com>