### PR TITLE
gms, service: futurize and coroutinize gossiper-related code

### DIFF
--- a/cdc/generation_service.hh
+++ b/cdc/generation_service.hh
@@ -113,14 +113,14 @@ public:
         return _cdc_metadata;
     }
 
-    virtual void before_change(gms::inet_address, gms::endpoint_state, gms::application_state, const gms::versioned_value&) override {}
-    virtual void on_alive(gms::inet_address, gms::endpoint_state) override {}
-    virtual void on_dead(gms::inet_address, gms::endpoint_state) override {}
-    virtual void on_remove(gms::inet_address) override {}
-    virtual void on_restart(gms::inet_address, gms::endpoint_state) override {}
+    virtual future<> before_change(gms::inet_address, gms::endpoint_state, gms::application_state, const gms::versioned_value&) override { return make_ready_future(); }
+    virtual future<> on_alive(gms::inet_address, gms::endpoint_state) override { return make_ready_future(); }
+    virtual future<> on_dead(gms::inet_address, gms::endpoint_state) override { return make_ready_future(); }
+    virtual future<> on_remove(gms::inet_address) override { return make_ready_future(); }
+    virtual future<> on_restart(gms::inet_address, gms::endpoint_state) override { return make_ready_future(); }
 
-    virtual void on_join(gms::inet_address, gms::endpoint_state) override;
-    virtual void on_change(gms::inet_address, gms::application_state, const gms::versioned_value&) override;
+    virtual future<> on_join(gms::inet_address, gms::endpoint_state) override;
+    virtual future<> on_change(gms::inet_address, gms::application_state, const gms::versioned_value&) override;
 
     future<> check_and_repair_cdc_streams();
 

--- a/gms/gossiper.hh
+++ b/gms/gossiper.hh
@@ -310,7 +310,7 @@ public:
     /**
      * Removes the endpoint from Gossip but retains endpoint state
      */
-    void remove_endpoint(inet_address endpoint);
+    future<> remove_endpoint(inet_address endpoint);
     future<> force_remove_endpoint(inet_address endpoint);
 private:
     /**

--- a/gms/gossiper.hh
+++ b/gms/gossiper.hh
@@ -393,7 +393,7 @@ private:
     /* Sends a Gossip message to an unreachable member */
     future<> do_gossip_to_unreachable_member(gossip_digest_syn message);
 
-    void do_status_check();
+    future<> do_status_check();
 
 public:
     clk::time_point get_expire_time_for_endpoint(inet_address endpoint) const noexcept;

--- a/gms/i_endpoint_state_change_subscriber.hh
+++ b/gms/i_endpoint_state_change_subscriber.hh
@@ -63,17 +63,17 @@ public:
      * @param endpoint endpoint for which the state change occurred.
      * @param epState  state that actually changed for the above endpoint.
      */
-    virtual void on_join(inet_address endpoint, endpoint_state ep_state) = 0;
+    virtual future<> on_join(inet_address endpoint, endpoint_state ep_state) = 0;
 
-    virtual void before_change(inet_address endpoint, endpoint_state current_state, application_state new_statekey, const versioned_value& newvalue) = 0;
+    virtual future<> before_change(inet_address endpoint, endpoint_state current_state, application_state new_statekey, const versioned_value& newvalue) = 0;
 
-    virtual void on_change(inet_address endpoint, application_state state, const versioned_value& value) = 0;
+    virtual future<> on_change(inet_address endpoint, application_state state, const versioned_value& value) = 0;
 
-    virtual void on_alive(inet_address endpoint, endpoint_state state) = 0;
+    virtual future<> on_alive(inet_address endpoint, endpoint_state state) = 0;
 
-    virtual void on_dead(inet_address endpoint, endpoint_state state) = 0;
+    virtual future<> on_dead(inet_address endpoint, endpoint_state state) = 0;
 
-    virtual void on_remove(inet_address endpoint) = 0;
+    virtual future<> on_remove(inet_address endpoint) = 0;
 
     /**
      * Called whenever a node is restarted.
@@ -81,7 +81,7 @@ public:
      * previously marked down. It will have only if {@code state.isAlive() == false}
      * as {@code state} is from before the restarted node is marked up.
      */
-    virtual void on_restart(inet_address endpoint, endpoint_state state) = 0;
+    virtual future<> on_restart(inet_address endpoint, endpoint_state state) = 0;
 };
 
 } // namespace gms

--- a/locator/production_snitch_base.cc
+++ b/locator/production_snitch_base.cc
@@ -261,37 +261,43 @@ void reconnectable_snitch_helper::reconnect(gms::inet_address public_address, gm
 reconnectable_snitch_helper::reconnectable_snitch_helper(sstring local_dc)
         : _local_dc(local_dc) {}
 
-void reconnectable_snitch_helper::before_change(gms::inet_address endpoint, gms::endpoint_state cs, gms::application_state new_state_key, const gms::versioned_value& new_value) {
+future<> reconnectable_snitch_helper::before_change(gms::inet_address endpoint, gms::endpoint_state cs, gms::application_state new_state_key, const gms::versioned_value& new_value) {
     // do nothing.
+    return make_ready_future();
 }
 
-void reconnectable_snitch_helper::on_join(gms::inet_address endpoint, gms::endpoint_state ep_state) {
+future<> reconnectable_snitch_helper::on_join(gms::inet_address endpoint, gms::endpoint_state ep_state) {
     auto* internal_ip_state = ep_state.get_application_state_ptr(gms::application_state::INTERNAL_IP);
     if (internal_ip_state) {
         reconnect(endpoint, *internal_ip_state);
     }
+    return make_ready_future();
 }
 
-void reconnectable_snitch_helper::on_change(gms::inet_address endpoint, gms::application_state state, const gms::versioned_value& value) {
+future<> reconnectable_snitch_helper::on_change(gms::inet_address endpoint, gms::application_state state, const gms::versioned_value& value) {
     if (state == gms::application_state::INTERNAL_IP) {
         reconnect(endpoint, value);
     }
+    return make_ready_future();
 }
 
-void reconnectable_snitch_helper::on_alive(gms::inet_address endpoint, gms::endpoint_state ep_state) {
-    on_join(std::move(endpoint), std::move(ep_state));
+future<> reconnectable_snitch_helper::on_alive(gms::inet_address endpoint, gms::endpoint_state ep_state) {
+    return on_join(std::move(endpoint), std::move(ep_state));
 }
 
-void reconnectable_snitch_helper::on_dead(gms::inet_address endpoint, gms::endpoint_state ep_state) {
+future<> reconnectable_snitch_helper::on_dead(gms::inet_address endpoint, gms::endpoint_state ep_state) {
     // do nothing.
+    return make_ready_future();
 }
 
-void reconnectable_snitch_helper::on_remove(gms::inet_address endpoint) {
+future<> reconnectable_snitch_helper::on_remove(gms::inet_address endpoint) {
     // do nothing.
+    return make_ready_future();
 }
 
-void reconnectable_snitch_helper::on_restart(gms::inet_address endpoint, gms::endpoint_state state) {
+future<> reconnectable_snitch_helper::on_restart(gms::inet_address endpoint, gms::endpoint_state state) {
     // do nothing.
+    return make_ready_future();
 }
 
 } // namespace locator

--- a/locator/reconnectable_snitch_helper.hh
+++ b/locator/reconnectable_snitch_helper.hh
@@ -52,12 +52,12 @@ private:
     void reconnect(gms::inet_address public_address, gms::inet_address local_address);
 public:
     reconnectable_snitch_helper(sstring local_dc);
-    void before_change(gms::inet_address endpoint, gms::endpoint_state cs, gms::application_state new_state_key, const gms::versioned_value& new_value) override;
-    void on_join(gms::inet_address endpoint, gms::endpoint_state ep_state) override;
-    void on_change(gms::inet_address endpoint, gms::application_state state, const gms::versioned_value& value) override;
-    void on_alive(gms::inet_address endpoint, gms::endpoint_state ep_state) override;
-    void on_dead(gms::inet_address endpoint, gms::endpoint_state ep_state) override;
-    void on_remove(gms::inet_address endpoint) override;
-    void on_restart(gms::inet_address endpoint, gms::endpoint_state state) override;
+    future<> before_change(gms::inet_address endpoint, gms::endpoint_state cs, gms::application_state new_state_key, const gms::versioned_value& new_value) override;
+    future<> on_join(gms::inet_address endpoint, gms::endpoint_state ep_state) override;
+    future<> on_change(gms::inet_address endpoint, gms::application_state state, const gms::versioned_value& value) override;
+    future<> on_alive(gms::inet_address endpoint, gms::endpoint_state ep_state) override;
+    future<> on_dead(gms::inet_address endpoint, gms::endpoint_state ep_state) override;
+    future<> on_remove(gms::inet_address endpoint) override;
+    future<> on_restart(gms::inet_address endpoint, gms::endpoint_state state) override;
 };
 } // namespace locator

--- a/locator/reconnectable_snitch_helper.hh
+++ b/locator/reconnectable_snitch_helper.hh
@@ -48,8 +48,8 @@ private:
     static logging::logger& logger();
     sstring _local_dc;
 private:
-    void reconnect(gms::inet_address public_address, const gms::versioned_value& local_address_value);
-    void reconnect(gms::inet_address public_address, gms::inet_address local_address);
+    future<> reconnect(gms::inet_address public_address, const gms::versioned_value& local_address_value);
+    future<> reconnect(gms::inet_address public_address, gms::inet_address local_address);
 public:
     reconnectable_snitch_helper(sstring local_dc);
     future<> before_change(gms::inet_address endpoint, gms::endpoint_state cs, gms::application_state new_state_key, const gms::versioned_value& new_value) override;

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -3059,38 +3059,45 @@ class row_level_repair_gossip_helper : public gms::i_endpoint_state_change_subsc
             rlogger.warn("Failed to remove row level repair for node {}: {}", node, ep);
         }).get();
     }
-    virtual void on_join(
+    virtual future<> on_join(
             gms::inet_address endpoint,
             gms::endpoint_state ep_state) override {
+        return make_ready_future();
     }
-    virtual void before_change(
+    virtual future<> before_change(
             gms::inet_address endpoint,
             gms::endpoint_state current_state,
             gms::application_state new_state_key,
             const gms::versioned_value& new_value) override {
+        return make_ready_future();
     }
-    virtual void on_change(
+    virtual future<> on_change(
             gms::inet_address endpoint,
             gms::application_state state,
             const gms::versioned_value& value) override {
+        return make_ready_future();
     }
-    virtual void on_alive(
+    virtual future<> on_alive(
             gms::inet_address endpoint,
             gms::endpoint_state state) override {
+        return make_ready_future();
     }
-    virtual void on_dead(
+    virtual future<> on_dead(
             gms::inet_address endpoint,
             gms::endpoint_state state) override {
         remove_row_level_repair(endpoint);
+        return make_ready_future();
     }
-    virtual void on_remove(
+    virtual future<> on_remove(
             gms::inet_address endpoint) override {
         remove_row_level_repair(endpoint);
+        return make_ready_future();
     }
-    virtual void on_restart(
+    virtual future<> on_restart(
             gms::inet_address endpoint,
             gms::endpoint_state ep_state) override {
         remove_row_level_repair(endpoint);
+        return make_ready_future();
     }
 };
 

--- a/service/load_broadcaster.hh
+++ b/service/load_broadcaster.hh
@@ -66,29 +66,32 @@ public:
         assert(_stopped);
     }
 
-    virtual void on_change(gms::inet_address endpoint, gms::application_state state, const gms::versioned_value& value) override {
+    virtual future<> on_change(gms::inet_address endpoint, gms::application_state state, const gms::versioned_value& value) override {
         if (state == gms::application_state::LOAD) {
             _load_info[endpoint] = std::stod(value.value);
         }
+        return make_ready_future();
     }
 
-    virtual void on_join(gms::inet_address endpoint, gms::endpoint_state ep_state) override {
+    virtual future<> on_join(gms::inet_address endpoint, gms::endpoint_state ep_state) override {
         auto* local_value = ep_state.get_application_state_ptr(gms::application_state::LOAD);
         if (local_value) {
-            on_change(endpoint, gms::application_state::LOAD, *local_value);
+            return on_change(endpoint, gms::application_state::LOAD, *local_value);
         }
+        return make_ready_future();
     }
     
-    virtual void before_change(gms::inet_address endpoint, gms::endpoint_state current_state, gms::application_state new_state_key, const gms::versioned_value& newValue) override {}
+    virtual future<> before_change(gms::inet_address endpoint, gms::endpoint_state current_state, gms::application_state new_state_key, const gms::versioned_value& newValue) override { return make_ready_future(); }
 
-    void on_alive(gms::inet_address endpoint, gms::endpoint_state) override {}
+    future<> on_alive(gms::inet_address endpoint, gms::endpoint_state) override { return make_ready_future(); }
 
-    void on_dead(gms::inet_address endpoint, gms::endpoint_state) override {}
+    future<> on_dead(gms::inet_address endpoint, gms::endpoint_state) override { return make_ready_future(); }
 
-    void on_restart(gms::inet_address endpoint, gms::endpoint_state) override {}
+    future<> on_restart(gms::inet_address endpoint, gms::endpoint_state) override { return make_ready_future(); }
 
-    virtual void on_remove(gms::inet_address endpoint) override {
+    virtual future<> on_remove(gms::inet_address endpoint) override {
         _load_info.erase(endpoint);
+        return make_ready_future();
     }
 
     const std::unordered_map<gms::inet_address, double> get_load_info() const {

--- a/service/migration_manager.cc
+++ b/service/migration_manager.cc
@@ -1232,25 +1232,28 @@ future<column_mapping> get_column_mapping(utils::UUID table_id, table_schema_ver
     return db::schema_tables::get_column_mapping(table_id, v);
 }
 
-void migration_manager::on_join(gms::inet_address endpoint, gms::endpoint_state ep_state) {
+future<> migration_manager::on_join(gms::inet_address endpoint, gms::endpoint_state ep_state) {
     schedule_schema_pull(endpoint, ep_state);
+    return make_ready_future();
 }
 
-void migration_manager::on_change(gms::inet_address endpoint, gms::application_state state, const gms::versioned_value& value) {
+future<> migration_manager::on_change(gms::inet_address endpoint, gms::application_state state, const gms::versioned_value& value) {
     if (state == gms::application_state::SCHEMA) {
         auto* ep_state = _gossiper.get_endpoint_state_for_endpoint_ptr(endpoint);
         if (!ep_state || _gossiper.is_dead_state(*ep_state)) {
             mlogger.debug("Ignoring state change for dead or unknown endpoint: {}", endpoint);
-            return;
+            return make_ready_future();
         }
         if (_storage_proxy.get_token_metadata_ptr()->is_member(endpoint)) {
             schedule_schema_pull(endpoint, *ep_state);
         }
     }
+    return make_ready_future();
 }
 
-void migration_manager::on_alive(gms::inet_address endpoint, gms::endpoint_state state) {
+future<> migration_manager::on_alive(gms::inet_address endpoint, gms::endpoint_state state) {
     schedule_schema_pull(endpoint, state);
+    return make_ready_future();
 }
 
 }

--- a/service/migration_manager.cc
+++ b/service/migration_manager.cc
@@ -392,7 +392,7 @@ bool migration_manager::should_pull_schema_from(const gms::inet_address& endpoin
 future<> migration_notifier::create_keyspace(const lw_shared_ptr<keyspace_metadata>& ksm) {
     return seastar::async([this, ksm] {
         const auto& name = ksm->name();
-        _listeners.for_each([&name] (migration_listener* listener) {
+        _listeners.thread_for_each([&name] (migration_listener* listener) {
             try {
                 listener->on_create_keyspace(name);
             } catch (...) {
@@ -406,7 +406,7 @@ future<> migration_notifier::create_column_family(const schema_ptr& cfm) {
     return seastar::async([this, cfm] {
         const auto& ks_name = cfm->ks_name();
         const auto& cf_name = cfm->cf_name();
-        _listeners.for_each([&ks_name, &cf_name] (migration_listener* listener) {
+        _listeners.thread_for_each([&ks_name, &cf_name] (migration_listener* listener) {
             try {
                 listener->on_create_column_family(ks_name, cf_name);
             } catch (...) {
@@ -420,7 +420,7 @@ future<> migration_notifier::create_user_type(const user_type& type) {
     return seastar::async([this, type] {
         const auto& ks_name = type->_keyspace;
         const auto& type_name = type->get_name_as_string();
-        _listeners.for_each([&ks_name, &type_name] (migration_listener* listener) {
+        _listeners.thread_for_each([&ks_name, &type_name] (migration_listener* listener) {
             try {
                 listener->on_create_user_type(ks_name, type_name);
             } catch (...) {
@@ -434,7 +434,7 @@ future<> migration_notifier::create_view(const view_ptr& view) {
     return seastar::async([this, view] {
         const auto& ks_name = view->ks_name();
         const auto& view_name = view->cf_name();
-        _listeners.for_each([&ks_name, &view_name] (migration_listener* listener) {
+        _listeners.thread_for_each([&ks_name, &view_name] (migration_listener* listener) {
             try {
                 listener->on_create_view(ks_name, view_name);
             } catch (...) {
@@ -461,7 +461,7 @@ public void notifyCreateAggregate(UDAggregate udf)
 future<> migration_notifier::update_keyspace(const lw_shared_ptr<keyspace_metadata>& ksm) {
     return seastar::async([this, ksm] {
         const auto& name = ksm->name();
-        _listeners.for_each([&name] (migration_listener* listener) {
+        _listeners.thread_for_each([&name] (migration_listener* listener) {
             try {
                 listener->on_update_keyspace(name);
             } catch (...) {
@@ -475,7 +475,7 @@ future<> migration_notifier::update_column_family(const schema_ptr& cfm, bool co
     return seastar::async([this, cfm, columns_changed] {
         const auto& ks_name = cfm->ks_name();
         const auto& cf_name = cfm->cf_name();
-        _listeners.for_each([&ks_name, &cf_name, columns_changed] (migration_listener* listener) {
+        _listeners.thread_for_each([&ks_name, &cf_name, columns_changed] (migration_listener* listener) {
             try {
                 listener->on_update_column_family(ks_name, cf_name, columns_changed);
             } catch (...) {
@@ -489,7 +489,7 @@ future<> migration_notifier::update_user_type(const user_type& type) {
     return seastar::async([this, type] {
         const auto& ks_name = type->_keyspace;
         const auto& type_name = type->get_name_as_string();
-        _listeners.for_each([&ks_name, &type_name] (migration_listener* listener) {
+        _listeners.thread_for_each([&ks_name, &type_name] (migration_listener* listener) {
             try {
                 listener->on_update_user_type(ks_name, type_name);
             } catch (...) {
@@ -503,7 +503,7 @@ future<> migration_notifier::update_view(const view_ptr& view, bool columns_chan
     return seastar::async([this, view, columns_changed] {
         const auto& ks_name = view->ks_name();
         const auto& view_name = view->cf_name();
-        _listeners.for_each([&ks_name, &view_name, columns_changed] (migration_listener* listener) {
+        _listeners.thread_for_each([&ks_name, &view_name, columns_changed] (migration_listener* listener) {
             try {
                 listener->on_update_view(ks_name, view_name, columns_changed);
             } catch (...) {
@@ -529,7 +529,7 @@ public void notifyUpdateAggregate(UDAggregate udf)
 
 future<> migration_notifier::drop_keyspace(const sstring& ks_name) {
     return seastar::async([this, ks_name] {
-        _listeners.for_each([&ks_name] (migration_listener* listener) {
+        _listeners.thread_for_each([&ks_name] (migration_listener* listener) {
             try {
                 listener->on_drop_keyspace(ks_name);
             } catch (...) {
@@ -543,7 +543,7 @@ future<> migration_notifier::drop_column_family(const schema_ptr& cfm) {
     return seastar::async([this, cfm] {
         const auto& cf_name = cfm->cf_name();
         const auto& ks_name = cfm->ks_name();
-        _listeners.for_each([&ks_name, &cf_name] (migration_listener* listener) {
+        _listeners.thread_for_each([&ks_name, &cf_name] (migration_listener* listener) {
             try {
                 listener->on_drop_column_family(ks_name, cf_name);
             } catch (...) {
@@ -557,7 +557,7 @@ future<> migration_notifier::drop_user_type(const user_type& type) {
     return seastar::async([this, type] {
         auto&& ks_name = type->_keyspace;
         auto&& type_name = type->get_name_as_string();
-        _listeners.for_each([&ks_name, &type_name] (migration_listener* listener) {
+        _listeners.thread_for_each([&ks_name, &type_name] (migration_listener* listener) {
             try {
                 listener->on_drop_user_type(ks_name, type_name);
             } catch (...) {
@@ -571,7 +571,7 @@ future<> migration_notifier::drop_view(const view_ptr& view) {
     return seastar::async([this, view] {
         auto&& ks_name = view->ks_name();
         auto&& view_name = view->cf_name();
-        _listeners.for_each([&ks_name, &view_name] (migration_listener* listener) {
+        _listeners.thread_for_each([&ks_name, &view_name] (migration_listener* listener) {
             try {
                 listener->on_drop_view(ks_name, view_name);
             } catch (...) {
@@ -583,7 +583,7 @@ future<> migration_notifier::drop_view(const view_ptr& view) {
 
 void migration_notifier::before_create_column_family(const schema& schema,
         std::vector<mutation>& mutations, api::timestamp_type timestamp) {
-    _listeners.for_each([&mutations, &schema, timestamp] (migration_listener* listener) {
+    _listeners.thread_for_each([&mutations, &schema, timestamp] (migration_listener* listener) {
         // allow exceptions. so a listener can effectively kill a create-table
         listener->on_before_create_column_family(schema, mutations, timestamp);
     });
@@ -591,7 +591,7 @@ void migration_notifier::before_create_column_family(const schema& schema,
 
 void migration_notifier::before_update_column_family(const schema& new_schema,
         const schema& old_schema, std::vector<mutation>& mutations, api::timestamp_type ts) {
-    _listeners.for_each([&mutations, &new_schema, &old_schema, ts] (migration_listener* listener) {
+    _listeners.thread_for_each([&mutations, &new_schema, &old_schema, ts] (migration_listener* listener) {
         // allow exceptions. so a listener can effectively kill an update-column
         listener->on_before_update_column_family(new_schema, old_schema, mutations, ts);
     });
@@ -599,7 +599,7 @@ void migration_notifier::before_update_column_family(const schema& new_schema,
 
 void migration_notifier::before_drop_column_family(const schema& schema,
         std::vector<mutation>& mutations, api::timestamp_type ts) {
-    _listeners.for_each([&mutations, &schema, ts] (migration_listener* listener) {
+    _listeners.thread_for_each([&mutations, &schema, ts] (migration_listener* listener) {
         // allow exceptions. so a listener can effectively kill a drop-column
         listener->on_before_drop_column_family(schema, mutations, ts);
     });

--- a/service/migration_manager.hh
+++ b/service/migration_manager.hh
@@ -235,13 +235,13 @@ public:
     future<schema_ptr> get_schema_for_write(table_schema_version, netw::msg_addr from, netw::messaging_service& ms);
 
 private:
-    virtual void on_join(gms::inet_address endpoint, gms::endpoint_state ep_state) override;
-    virtual void on_change(gms::inet_address endpoint, gms::application_state state, const gms::versioned_value& value) override;
-    virtual void on_alive(gms::inet_address endpoint, gms::endpoint_state state) override;
-    virtual void on_dead(gms::inet_address endpoint, gms::endpoint_state state) override {}
-    virtual void on_remove(gms::inet_address endpoint) override {}
-    virtual void on_restart(gms::inet_address endpoint, gms::endpoint_state state) override {}
-    virtual void before_change(gms::inet_address endpoint, gms::endpoint_state current_state, gms::application_state new_statekey, const gms::versioned_value& newvalue) override {}
+    virtual future<> on_join(gms::inet_address endpoint, gms::endpoint_state ep_state) override;
+    virtual future<> on_change(gms::inet_address endpoint, gms::application_state state, const gms::versioned_value& value) override;
+    virtual future<> on_alive(gms::inet_address endpoint, gms::endpoint_state state) override;
+    virtual future<> on_dead(gms::inet_address endpoint, gms::endpoint_state state) override { return make_ready_future(); }
+    virtual future<> on_remove(gms::inet_address endpoint) override { return make_ready_future(); }
+    virtual future<> on_restart(gms::inet_address endpoint, gms::endpoint_state state) override { return make_ready_future(); }
+    virtual future<> before_change(gms::inet_address endpoint, gms::endpoint_state current_state, gms::application_state new_statekey, const gms::versioned_value& newvalue) override { return make_ready_future(); }
 };
 
 future<column_mapping> get_column_mapping(utils::UUID table_id, table_schema_version v);

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -1541,7 +1541,7 @@ future<> storage_service::check_for_endpoint_collision(std::unordered_set<gms::i
 
 // Runs inside seastar::async context
 void storage_service::remove_endpoint(inet_address endpoint) {
-    _gossiper.remove_endpoint(endpoint);
+    _gossiper.remove_endpoint(endpoint).get();
     db::system_keyspace::remove_endpoint(endpoint).then_wrapped([endpoint] (auto&& f) {
         try {
             f.get();

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -798,11 +798,11 @@ future<> storage_service::handle_state_replacing_update_pending_ranges(mutable_t
     co_await update_pending_ranges(tmptr, format("handle_state_replacing {}", replacing_node));
 }
 
-void storage_service::handle_state_replacing(inet_address replacing_node) {
+future<> storage_service::handle_state_replacing(inet_address replacing_node) {
     slogger.debug("endpoint={} handle_state_replacing", replacing_node);
     auto host_id = _gossiper.get_host_id(replacing_node);
-    auto tmlock = get_token_metadata_lock().get0();
-    auto tmptr = get_mutable_token_metadata_ptr().get0();
+    auto tmlock = co_await get_token_metadata_lock();
+    auto tmptr = co_await get_mutable_token_metadata_ptr();
     auto existing_node_opt = tmptr->get_endpoint_for_host_id(host_id);
     auto replace_addr = _db.local().get_replace_address();
     if (replacing_node == get_broadcast_address() && replace_addr && *replace_addr == get_broadcast_address()) {
@@ -810,7 +810,7 @@ void storage_service::handle_state_replacing(inet_address replacing_node) {
     }
     if (!existing_node_opt) {
         slogger.warn("Can not find the existing node for the replacing node {}", replacing_node);
-        return;
+        co_return;
     }
     auto existing_node = *existing_node_opt;
     auto existing_tokens = get_tokens_for(existing_node);
@@ -820,12 +820,12 @@ void storage_service::handle_state_replacing(inet_address replacing_node) {
     tmptr->add_replacing_endpoint(existing_node, replacing_node);
     if (_gossiper.is_alive(replacing_node)) {
         slogger.info("handle_state_replacing: Replacing node {} is already alive, update pending ranges", replacing_node);
-        handle_state_replacing_update_pending_ranges(tmptr, replacing_node).get();
+        co_await handle_state_replacing_update_pending_ranges(tmptr, replacing_node);
     } else {
         slogger.info("handle_state_replacing: Replacing node {} is not alive yet, delay update pending ranges", replacing_node);
         _replacing_nodes_pending_ranges_updater.insert(replacing_node);
     }
-    replicate_to_all_cores(std::move(tmptr)).get();
+    co_await replicate_to_all_cores(std::move(tmptr));
 }
 
 future<> storage_service::handle_state_bootstrap(inet_address endpoint) {
@@ -1162,7 +1162,7 @@ future<> storage_service::on_change(inet_address endpoint, application_state sta
         } else if (move_name == sstring(versioned_value::STATUS_MOVING)) {
             handle_state_moving(endpoint, pieces);
         } else if (move_name == sstring(versioned_value::HIBERNATE)) {
-            handle_state_replacing(endpoint);
+            co_await handle_state_replacing(endpoint);
         } else {
             co_return; // did nothing.
         }

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -3475,7 +3475,7 @@ storage_service::get_natural_endpoints(const sstring& keyspace, const token& pos
 
 future<> endpoint_lifecycle_notifier::notify_down(gms::inet_address endpoint) {
     return seastar::async([this, endpoint] {
-        _subscribers.for_each([endpoint] (endpoint_lifecycle_subscriber* subscriber) {
+        _subscribers.thread_for_each([endpoint] (endpoint_lifecycle_subscriber* subscriber) {
             try {
                 subscriber->on_down(endpoint);
             } catch (...) {
@@ -3495,7 +3495,7 @@ void storage_service::notify_down(inet_address endpoint) {
 
 future<> endpoint_lifecycle_notifier::notify_left(gms::inet_address endpoint) {
     return seastar::async([this, endpoint] {
-        _subscribers.for_each([endpoint] (endpoint_lifecycle_subscriber* subscriber) {
+        _subscribers.thread_for_each([endpoint] (endpoint_lifecycle_subscriber* subscriber) {
             try {
                 subscriber->on_leave_cluster(endpoint);
             } catch (...) {
@@ -3514,7 +3514,7 @@ void storage_service::notify_left(inet_address endpoint) {
 
 future<> endpoint_lifecycle_notifier::notify_up(gms::inet_address endpoint) {
     return seastar::async([this, endpoint] {
-        _subscribers.for_each([endpoint] (endpoint_lifecycle_subscriber* subscriber) {
+        _subscribers.thread_for_each([endpoint] (endpoint_lifecycle_subscriber* subscriber) {
             try {
                 subscriber->on_up(endpoint);
             } catch (...) {
@@ -3537,7 +3537,7 @@ void storage_service::notify_up(inet_address endpoint)
 
 future<> endpoint_lifecycle_notifier::notify_joined(gms::inet_address endpoint) {
     return seastar::async([this, endpoint] {
-        _subscribers.for_each([endpoint] (endpoint_lifecycle_subscriber* subscriber) {
+        _subscribers.thread_for_each([endpoint] (endpoint_lifecycle_subscriber* subscriber) {
             try {
                 subscriber->on_join_cluster(endpoint);
             } catch (...) {

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -499,8 +499,8 @@ public:
             const sstring& keyspace,
             const dht::token_range_vector& ranges) const;
 public:
-    virtual void on_join(gms::inet_address endpoint, gms::endpoint_state ep_state) override;
-    virtual void before_change(gms::inet_address endpoint, gms::endpoint_state current_state, gms::application_state new_state_key, const gms::versioned_value& new_value) override;
+    virtual future<> on_join(gms::inet_address endpoint, gms::endpoint_state ep_state) override;
+    virtual future<> before_change(gms::inet_address endpoint, gms::endpoint_state current_state, gms::application_state new_state_key, const gms::versioned_value& new_value) override;
     /*
      * Handle the reception of a new particular ApplicationState for a particular endpoint. Note that the value of the
      * ApplicationState has not necessarily "changed" since the last known value, if we already received the same update
@@ -533,11 +533,11 @@ public:
      * Note: Any time a node state changes from STATUS_NORMAL, it will not be visible to new nodes. So it follows that
      * you should never bootstrap a new node during a removenode, decommission or move.
      */
-    virtual void on_change(inet_address endpoint, application_state state, const versioned_value& value) override;
-    virtual void on_alive(gms::inet_address endpoint, gms::endpoint_state state) override;
-    virtual void on_dead(gms::inet_address endpoint, gms::endpoint_state state) override;
-    virtual void on_remove(gms::inet_address endpoint) override;
-    virtual void on_restart(gms::inet_address endpoint, gms::endpoint_state state) override;
+    virtual future<> on_change(inet_address endpoint, application_state state, const versioned_value& value) override;
+    virtual future<> on_alive(gms::inet_address endpoint, gms::endpoint_state state) override;
+    virtual future<> on_dead(gms::inet_address endpoint, gms::endpoint_state state) override;
+    virtual future<> on_remove(gms::inet_address endpoint) override;
+    virtual future<> on_restart(gms::inet_address endpoint, gms::endpoint_state state) override;
 
 public:
     // For migration_listener

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -578,7 +578,7 @@ private:
      *
      * @param endpoint bootstrapping node
      */
-    void handle_state_bootstrap(inet_address endpoint);
+    future<> handle_state_bootstrap(inet_address endpoint);
 
     /**
      * Handle node move to normal state. That is, node is entering token ring and participating

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -563,7 +563,7 @@ public:
     virtual void on_drop_view(const sstring& ks_name, const sstring& view_name) override {}
 private:
     void update_peer_info(inet_address endpoint);
-    void do_update_system_peers_table(gms::inet_address endpoint, const application_state& state, const versioned_value& value);
+    future<> do_update_system_peers_table(gms::inet_address endpoint, const application_state& state, const versioned_value& value);
 
     std::unordered_set<token> get_tokens_for(inet_address endpoint);
 private:

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -592,7 +592,7 @@ private:
      *
      * @param endpoint node
      */
-    void handle_state_leaving(inet_address endpoint);
+    future<> handle_state_leaving(inet_address endpoint);
 
     /**
      * Handle node leaving the ring. This will happen when a node is decommissioned

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -357,8 +357,7 @@ public:
     }
 private:
     future<> do_stop_ms();
-    // Runs in thread context
-    void shutdown_protocol_servers();
+    future<> shutdown_protocol_servers();
 
     // Tokens and the CDC streams timestamp of the replaced node.
     using replacement_info = std::unordered_set<token>;

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -634,7 +634,7 @@ private:
     void excise(std::unordered_set<token> tokens, inet_address endpoint, long expire_time);
 
     /** unlike excise we just need this endpoint gone without going through any notifications **/
-    void remove_endpoint(inet_address endpoint);
+    future<> remove_endpoint(inet_address endpoint);
 
     void add_expire_time_if_found(inet_address endpoint, int64_t expire_time);
 

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -600,7 +600,7 @@ private:
      * @param endpoint If reason for leaving is decommission, endpoint is the leaving node.
      * @param pieces STATE_LEFT,token
      */
-    void handle_state_left(inet_address endpoint, std::vector<sstring> pieces);
+    future<> handle_state_left(inet_address endpoint, std::vector<sstring> pieces);
 
     /**
      * Handle node moving inside the ring.

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -586,7 +586,7 @@ private:
      *
      * @param endpoint node
      */
-    void handle_state_normal(inet_address endpoint);
+    future<> handle_state_normal(inet_address endpoint);
 
     /**
      * Handle node preparing to leave the ring

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -843,11 +843,11 @@ private:
     void do_isolate_on_error(disk_error type);
     future<> isolate();
 
-    void notify_down(inet_address endpoint);
-    void notify_left(inet_address endpoint);
-    void notify_up(inet_address endpoint);
-    void notify_joined(inet_address endpoint);
-    void notify_cql_change(inet_address endpoint, bool ready);
+    future<> notify_down(inet_address endpoint);
+    future<> notify_left(inet_address endpoint);
+    future<> notify_up(inet_address endpoint);
+    future<> notify_joined(inet_address endpoint);
+    future<> notify_cql_change(inet_address endpoint, bool ready);
 public:
     future<bool> is_cleanup_allowed(sstring keyspace);
     bool is_repair_based_node_ops_enabled(streaming::stream_reason reason);

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -616,7 +616,7 @@ private:
      * @param endpoint node
      * @param pieces either REMOVED_TOKEN (node is gone) or REMOVING_TOKEN (replicas need to be restored)
      */
-    void handle_state_removing(inet_address endpoint, std::vector<sstring> pieces);
+    future<> handle_state_removing(inet_address endpoint, std::vector<sstring> pieces);
 
     /**
      * Handle notification that a node is replacing another node.

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -626,7 +626,8 @@ private:
      */
     void handle_state_replacing(inet_address endpoint);
 
-    void handle_state_replacing_update_pending_ranges(mutable_token_metadata_ptr tmptr, inet_address replacing_node);
+    future<>
+    handle_state_replacing_update_pending_ranges(mutable_token_metadata_ptr tmptr, inet_address replacing_node);
 
 private:
     void excise(std::unordered_set<token> tokens, inet_address endpoint);

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -630,8 +630,8 @@ private:
     handle_state_replacing_update_pending_ranges(mutable_token_metadata_ptr tmptr, inet_address replacing_node);
 
 private:
-    void excise(std::unordered_set<token> tokens, inet_address endpoint);
-    void excise(std::unordered_set<token> tokens, inet_address endpoint, long expire_time);
+    future<> excise(std::unordered_set<token> tokens, inet_address endpoint);
+    future<> excise(std::unordered_set<token> tokens, inet_address endpoint, long expire_time);
 
     /** unlike excise we just need this endpoint gone without going through any notifications **/
     future<> remove_endpoint(inet_address endpoint);

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -562,7 +562,7 @@ public:
     virtual void on_drop_aggregate(const sstring& ks_name, const sstring& aggregate_name) override {}
     virtual void on_drop_view(const sstring& ks_name, const sstring& view_name) override {}
 private:
-    void update_peer_info(inet_address endpoint);
+    future<> update_peer_info(inet_address endpoint);
     future<> do_update_system_peers_table(gms::inet_address endpoint, const application_state& state, const versioned_value& value);
 
     std::unordered_set<token> get_tokens_for(inet_address endpoint);

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -740,7 +740,7 @@ private:
      * Broadcast leaving status and update local _token_metadata accordingly
      */
     future<> start_leaving();
-    void leave_ring();
+    future<> leave_ring();
     void unbootstrap();
 
 public:

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -624,7 +624,7 @@ private:
      *
      * @param endpoint node
      */
-    void handle_state_replacing(inet_address endpoint);
+    future<> handle_state_replacing(inet_address endpoint);
 
     future<>
     handle_state_replacing_update_pending_ranges(mutable_token_metadata_ptr tmptr, inet_address replacing_node);

--- a/service/view_update_backlog_broker.hh
+++ b/service/view_update_backlog_broker.hh
@@ -52,15 +52,15 @@ public:
 
     seastar::future<> stop();
 
-    virtual void on_change(gms::inet_address, gms::application_state, const gms::versioned_value&) override;
+    virtual future<> on_change(gms::inet_address, gms::application_state, const gms::versioned_value&) override;
 
-    virtual void on_remove(gms::inet_address) override;
+    virtual future<> on_remove(gms::inet_address) override;
 
-    virtual void on_join(gms::inet_address, gms::endpoint_state) override { }
-    virtual void before_change(gms::inet_address, gms::endpoint_state, gms::application_state, const gms::versioned_value&) override { }
-    virtual void on_alive(gms::inet_address, gms::endpoint_state) override { }
-    virtual void on_dead(gms::inet_address, gms::endpoint_state) override { }
-    virtual void on_restart(gms::inet_address, gms::endpoint_state) override { }
+    virtual future<> on_join(gms::inet_address, gms::endpoint_state) override { return make_ready_future(); }
+    virtual future<> before_change(gms::inet_address, gms::endpoint_state, gms::application_state, const gms::versioned_value&) override { return make_ready_future(); }
+    virtual future<> on_alive(gms::inet_address, gms::endpoint_state) override { return make_ready_future(); }
+    virtual future<> on_dead(gms::inet_address, gms::endpoint_state) override { return make_ready_future(); }
+    virtual future<> on_restart(gms::inet_address, gms::endpoint_state) override { return make_ready_future(); }
 };
 
 }

--- a/streaming/stream_manager.cc
+++ b/streaming/stream_manager.cc
@@ -307,7 +307,7 @@ void stream_manager::fail_all_sessions() {
     }
 }
 
-void stream_manager::on_remove(inet_address endpoint) {
+future<> stream_manager::on_remove(inet_address endpoint) {
     if (has_peer(endpoint)) {
         sslog.info("stream_manager: Close all stream_session with peer = {} in on_remove", endpoint);
         //FIXME: discarded future.
@@ -317,9 +317,10 @@ void stream_manager::on_remove(inet_address endpoint) {
             sslog.warn("stream_manager: Fail to close sessions peer = {} in on_remove", endpoint);
         });
     }
+    return make_ready_future();
 }
 
-void stream_manager::on_restart(inet_address endpoint, endpoint_state ep_state) {
+future<> stream_manager::on_restart(inet_address endpoint, endpoint_state ep_state) {
     if (has_peer(endpoint)) {
         sslog.info("stream_manager: Close all stream_session with peer = {} in on_restart", endpoint);
         //FIXME: discarded future.
@@ -329,9 +330,10 @@ void stream_manager::on_restart(inet_address endpoint, endpoint_state ep_state) 
             sslog.warn("stream_manager: Fail to close sessions peer = {} in on_restart", endpoint);
         });
     }
+    return make_ready_future();
 }
 
-void stream_manager::on_dead(inet_address endpoint, endpoint_state ep_state) {
+future<> stream_manager::on_dead(inet_address endpoint, endpoint_state ep_state) {
     if (has_peer(endpoint)) {
         sslog.info("stream_manager: Close all stream_session with peer = {} in on_dead", endpoint);
         //FIXME: discarded future.
@@ -341,6 +343,7 @@ void stream_manager::on_dead(inet_address endpoint, endpoint_state ep_state) {
             sslog.warn("stream_manager: Fail to close sessions peer = {} in on_dead", endpoint);
         });
     }
+    return make_ready_future();
 }
 
 shared_ptr<stream_session> stream_manager::get_session(utils::UUID plan_id, gms::inet_address from, const char* verb, std::optional<utils::UUID> cf_id) {

--- a/streaming/stream_manager.hh
+++ b/streaming/stream_manager.hh
@@ -193,13 +193,13 @@ public:
     shared_ptr<stream_session> get_session(utils::UUID plan_id, gms::inet_address from, const char* verb, std::optional<utils::UUID> cf_id = {});
 
 public:
-    virtual void on_join(inet_address endpoint, endpoint_state ep_state) override {}
-    virtual void before_change(inet_address endpoint, endpoint_state current_state, application_state new_state_key, const versioned_value& new_value) override {}
-    virtual void on_change(inet_address endpoint, application_state state, const versioned_value& value) override {}
-    virtual void on_alive(inet_address endpoint, endpoint_state state) override {}
-    virtual void on_dead(inet_address endpoint, endpoint_state state) override;
-    virtual void on_remove(inet_address endpoint) override;
-    virtual void on_restart(inet_address endpoint, endpoint_state ep_state) override;
+    virtual future<> on_join(inet_address endpoint, endpoint_state ep_state) override { return make_ready_future(); }
+    virtual future<> before_change(inet_address endpoint, endpoint_state current_state, application_state new_state_key, const versioned_value& new_value) override { return make_ready_future(); }
+    virtual future<> on_change(inet_address endpoint, application_state state, const versioned_value& value) override { return make_ready_future(); }
+    virtual future<> on_alive(inet_address endpoint, endpoint_state state) override { return make_ready_future(); }
+    virtual future<> on_dead(inet_address endpoint, endpoint_state state) override;
+    virtual future<> on_remove(inet_address endpoint) override;
+    virtual future<> on_restart(inet_address endpoint, endpoint_state ep_state) override;
 
 private:
     void fail_all_sessions();

--- a/utils/atomic_vector.hh
+++ b/utils/atomic_vector.hh
@@ -24,6 +24,7 @@
 #include <seastar/core/rwlock.hh>
 #include <seastar/util/defer.hh>
 #include <seastar/util/noncopyable_function.hh>
+#include <seastar/core/coroutine.hh>
 
 #include <vector>
 
@@ -60,6 +61,21 @@ public:
         // reallocated.
         for (size_t i = 0, n = _vec.size(); i < n; ++i) {
             func(_vec[i]);
+        }
+    }
+
+    // The callback function must not call remove.
+    //
+    // We would take callbacks that take a T&, but we had bugs in the
+    // past with some of those callbacks holding that reference past a
+    // preemption.
+    seastar::future<> for_each(seastar::noncopyable_function<seastar::future<>(T)> func) {
+        auto holder = co_await _vec_lock.hold_read_lock();
+        // We grab a lock in remove(), but not in add(), so we
+        // iterate using indexes to guard against the vector being
+        // reallocated.
+        for (size_t i = 0, n = _vec.size(); i < n; ++i) {
+            co_await func(_vec[i]);
         }
     }
 };

--- a/utils/atomic_vector.hh
+++ b/utils/atomic_vector.hh
@@ -50,7 +50,7 @@ public:
     // We would take callbacks that take a T&, but we had bugs in the
     // past with some of those callbacks holding that reference past a
     // preemption.
-    void for_each(seastar::noncopyable_function<void(T)> func) {
+    void thread_for_each(seastar::noncopyable_function<void(T)> func) {
         _vec_lock.for_read().lock().get();
         auto unlock = seastar::defer([this] {
             _vec_lock.for_read().unlock();


### PR DESCRIPTION
This series greatly reduces gossipers' dependence on `seastar::async` (yet, not completely).

`i_endpoint_state_change_subscriber` callbacks are converted to return futures (again, to get rid of `seastar::async` dependency), all users are adjusted appropriately (e.g. `storage_service`, `cdc::generation_service`, `streaming::stream_manager`, `view_update_backlog_broker` and `migration_manager`).
This includes futurizing and coroutinizing the whole function call chain up to the `i_endpoint_state_change_subscriber` callback functions.

To aid the conversion process, a non-`seastar::async` dependent variant of `utils::atomic_vector::for_each` is introduced (`for_each_futurized`). A different name is used to clearly distinguish converted and non-converted code, so that the last step (remove `seastar::async()` wrappers around callback-calling code in gossiper) is easier. This is left for a follow-up series, though.

Tests: unit(dev)