### PR TITLE
conofigure.py: Set seastar scheduling groups count explicitly

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1585,6 +1585,7 @@ def configure_seastar(build_dir, mode, mode_config):
         '-DSeastar_API_LEVEL=6',
         '-DSeastar_UNUSED_RESULT_ERROR=ON',
         '-DCMAKE_EXPORT_COMPILE_COMMANDS=ON',
+        '-DSeastar_SCHEDULING_GROUPS_COUNT=16',
     ] + distro_extra_cmake_args
 
     if args.stack_guards is not None:


### PR DESCRIPTION
In order to have stability and also regression control, we set
the scheduling groups parameter explicitly.
The value is the current seastar default so no behavior change is expected.