### PR TITLE
scylla_util: return boolean calling systemd_unit.available

### DIFF
--- a/dist/common/scripts/scylla_util.py
+++ b/dist/common/scripts/scylla_util.py
@@ -1055,8 +1055,8 @@ class systemd_unit:
 
     @classmethod
     def available(cls, unit):
-        res = run('systemctl cat {}'.format(unit), shell=True, check=True, stdout=DEVNULL, stderr=DEVNULL)
-        return True if res.returncode == 0 else False
+        res = run('systemctl cat {}'.format(unit), shell=True, check=False, stdout=DEVNULL, stderr=DEVNULL)
+        return res.returncode == 0
 
 
 class sysconfig_parser:


### PR DESCRIPTION
As of now, 'systemd_unit.available' works ok only when provided unit is present.
It raises Exception instead of returning boolean when provided systemd unit is absent.

So, make it return boolean in both cases.
For now, it will fix "scylla_setup" script workability on the Centos7

Fixes https://github.com/scylladb/scylla/issues/9848