### PR TITLE
Fix bad lowres_clock::duration assumptions

### DIFF
--- a/gms/gossiper.cc
+++ b/gms/gossiper.cc
@@ -763,7 +763,7 @@ future<> gossiper::update_live_endpoints_version() {
 
 future<> gossiper::failure_detector_loop_for_node(gms::inet_address node, int64_t gossip_generation, uint64_t live_endpoints_version) {
     auto last = gossiper::clk::now();
-    auto diff = std::chrono::milliseconds(0);
+    auto diff = gossiper::clk::duration(0);
     auto echo_interval = std::chrono::milliseconds(2000);
     auto max_duration = echo_interval + std::chrono::milliseconds(_cfg.failure_detector_timeout_in_ms());
     while (is_enabled()) {

--- a/service/misc_services.cc
+++ b/service/misc_services.cc
@@ -214,12 +214,13 @@ future<lowres_clock::duration> cache_hitrate_calculator::recalculate_hitrates() 
         });
     }).then([this] {
         _slen = _gstate.size();
+        using namespace std::chrono_literals;
         return _gossiper.add_local_application_state(gms::application_state::CACHE_HITRATES, gms::versioned_value::cache_hitrates(_gstate)).then([this] {
             // if max difference during this round is big schedule next recalculate earlier
             if (_diff < 0.01) {
-                return std::chrono::milliseconds(2000);
+                return lowres_clock::duration(2000ms);
             } else {
-                return std::chrono::milliseconds(500);
+                return lowres_clock::duration(500ms);
             }
         });
     }).finally([this] {

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -589,7 +589,7 @@ public:
             return ret;
         } else {
             // budget is small (< ret) so can be converted to microseconds
-            return budget;
+            return std::chrono::duration_cast<std::chrono::microseconds>(budget);
         }
     }
     // Calculates how much to delay completing the request. The delay adds to the request's inherent latency.


### PR DESCRIPTION
Some code assumes that lowres_clock::duration is milliseconds, but public
documentation never claimed that. Harden the code for a change in the
definition by removing the assumptions.