### PR TITLE
storage_proxy: use freeze_gently

### DIFF
--- a/frozen_mutation.hh
+++ b/frozen_mutation.hh
@@ -84,6 +84,8 @@ public:
 
 frozen_mutation freeze(const mutation& m);
 
+future<frozen_mutation> freeze_gently(const mutation& m);
+
 struct frozen_mutation_and_schema {
     frozen_mutation fm;
     schema_ptr s;

--- a/mutation_partition_serializer.cc
+++ b/mutation_partition_serializer.cc
@@ -20,6 +20,9 @@
  * along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <seastar/core/coroutine.hh>
+#include <seastar/coroutine/maybe_yield.hh>
+
 #include "mutation_partition_serializer.hh"
 #include "mutation_partition.hh"
 
@@ -203,6 +206,21 @@ void mutation_partition_serializer::write_serialized(Writer&& writer, const sche
     std::move(clustering_rows).end_rows().end_mutation_partition();
 }
 
+template<typename Writer>
+future<> mutation_partition_serializer::write_serialized_gently(Writer&& writer, const schema& s, const mutation_partition& mp)
+{
+    auto srow_writer = std::move(writer).write_tomb(mp.partition_tombstone()).start_static_row();
+    auto row_tombstones = write_row_cells(std::move(srow_writer), mp.static_row().get(), s, column_kind::static_column).end_static_row().start_range_tombstones();
+    co_await coroutine::maybe_yield();
+    write_tombstones(s, row_tombstones, mp.row_tombstones());
+    auto clustering_rows = std::move(row_tombstones).end_range_tombstones().start_rows();
+    for (auto&& cr : mp.non_dummy_rows()) {
+        co_await coroutine::maybe_yield();
+        write_row(clustering_rows.add(), s, cr.key(), cr.row().cells(), cr.row().marker(), cr.row().deleted_at()).end_deletable_row();
+    }
+    std::move(clustering_rows).end_rows().end_mutation_partition();
+}
+
 mutation_partition_serializer::mutation_partition_serializer(const schema& schema, const mutation_partition& p)
     : _schema(schema), _p(p)
 { }
@@ -215,6 +233,11 @@ mutation_partition_serializer::write(bytes_ostream& out) const {
 void mutation_partition_serializer::write(ser::writer_of_mutation_partition<bytes_ostream>&& wr) const
 {
     write_serialized(std::move(wr), _schema, _p);
+}
+
+future<> mutation_partition_serializer::write_gently(ser::writer_of_mutation_partition<bytes_ostream>&& wr) const
+{
+    return write_serialized_gently(std::move(wr), _schema, _p);
 }
 
 void serialize_mutation_fragments(const schema& s, tombstone partition_tombstone,

--- a/mutation_partition_serializer.hh
+++ b/mutation_partition_serializer.hh
@@ -40,12 +40,16 @@ private:
 private:
     template<typename Writer>
     static void write_serialized(Writer&& out, const schema&, const mutation_partition&);
+
+    template<typename Writer>
+    static future<> write_serialized_gently(Writer&& out, const schema&, const mutation_partition&);
 public:
     using count_type = uint32_t;
     mutation_partition_serializer(const schema&, const mutation_partition&);
 public:
     void write(bytes_ostream&) const;
     void write(ser::writer_of_mutation_partition<bytes_ostream>&&) const;
+    future<> write_gently(ser::writer_of_mutation_partition<bytes_ostream>&&) const;
 };
 
 void serialize_mutation_fragments(const schema& s, tombstone partition_tombstone,

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -4685,7 +4685,7 @@ future<bool> storage_proxy::cas(schema_ptr schema, shared_ptr<cas_request> reque
                 tracing::trace(handler->tr_state, "CAS precondition is met; proposing client-requested updates for {}", ballot);
             }
 
-            auto proposal = make_lw_shared<paxos::proposal>(ballot, freeze(*mutation));
+            auto proposal = make_lw_shared<paxos::proposal>(ballot, co_await freeze_gently(*mutation));
 
             bool is_accepted = co_await handler->accept_proposal(proposal);
             if (is_accepted) {

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -3318,7 +3318,7 @@ public:
     bool all_reached_end() const {
         return _all_reached_end;
     }
-    std::optional<reconcilable_result> resolve(schema_ptr schema, const query::read_command& cmd, uint64_t original_row_limit, uint64_t original_per_partition_limit,
+    future<std::optional<reconcilable_result>> resolve(schema_ptr schema, const query::read_command& cmd, uint64_t original_row_limit, uint64_t original_per_partition_limit,
             uint32_t original_partition_limit) {
         assert(_data_results.size());
 
@@ -3327,7 +3327,7 @@ public:
             // should happen only for range reads since single key reads will not
             // try to reconcile for CL=ONE
             auto& p = _data_results[0].result;
-            return reconcilable_result(p->row_count(), p->partitions(), p->is_short_read());
+            co_return reconcilable_result(p->row_count(), p->partitions(), p->is_short_read());
         }
 
         const auto& s = *schema;
@@ -3444,7 +3444,7 @@ public:
         if (has_diff) {
             if (got_incomplete_information(*schema, cmd, original_row_limit, original_per_partition_limit,
                                            original_partition_limit, reconciled_partitions, versions)) {
-                return {};
+                co_return std::nullopt;
             }
             // filter out partitions with empty diffs
             for (auto it = _diffs.begin(); it != _diffs.end();) {
@@ -3470,12 +3470,12 @@ public:
         // build reconcilable_result from reconciled data
         // traverse backwards since large keys are at the start
         utils::chunked_vector<partition> vec;
-        auto r = boost::accumulate(reconciled_partitions | boost::adaptors::reversed, std::ref(vec), [] (utils::chunked_vector<partition>& a, const mutation_and_live_row_count& m_a_rc) {
-            a.emplace_back(partition(m_a_rc.live_row_count, freeze(m_a_rc.mut)));
-            return std::ref(a);
-        });
+        for (auto it = reconciled_partitions.rbegin(); it != reconciled_partitions.rend(); it++) {
+            const mutation_and_live_row_count& m_a_rc = *it;
+            vec.emplace_back(partition(m_a_rc.live_row_count, co_await freeze_gently(m_a_rc.mut)));
+        }
 
-        return reconcilable_result(_total_live_count, std::move(r.get()), _is_short_read);
+        co_return reconcilable_result(_total_live_count, std::move(vec), _is_short_read);
     }
     auto total_live_count() const {
         return _total_live_count;
@@ -3669,10 +3669,10 @@ protected:
         make_mutation_data_requests(cmd, data_resolver, _targets.begin(), _targets.end(), timeout);
 
         // Waited on indirectly.
-        (void)data_resolver->done().then_wrapped([this, exec, data_resolver, cmd = std::move(cmd), cl, timeout] (future<> f) {
+        (void)data_resolver->done().then_wrapped([this, exec, data_resolver, cmd = std::move(cmd), cl, timeout] (future<> f) -> future<> {
             try {
                 f.get();
-                auto rr_opt = data_resolver->resolve(_schema, *cmd, original_row_limit(), original_per_partition_row_limit(), original_partition_limit()); // reconciliation happens here
+                auto rr_opt = co_await data_resolver->resolve(_schema, *cmd, original_row_limit(), original_per_partition_row_limit(), original_partition_limit()); // reconciliation happens here
 
                 // We generate a retry if at least one node reply with count live columns but after merge we have less
                 // than the total number of column we are interested in (which may be < count on a retry).


### PR DESCRIPTION
Introduce `freeze_gently(const mutation&)` function to freeze a mutation using continuations,
allowing yielding in between rows.

Use it in storage_proxy::resolve to deal with #9866
(don't mark it as fixed yet until verified, as it might need also yielding between cells, not only between rows)

In addition, use freeze_gently for `apply_locally()` and `cas()`.

Other synchronous call sites of freeze(mutation) like `create_write_response_handler` (when creating a `shared_mutation`) or creating `per_destination_mutation` may follow up later. They require more work and may present a bigger risk.

Test: unit(dev)
DTest: cdc_test.py::TestCdc::test_cluster_expansion_with_cdc