### PR TITLE
commitlog: Don't allow error_handler to swallow exception

### DIFF
--- a/db/commitlog/commitlog.cc
+++ b/db/commitlog/commitlog.cc
@@ -1540,8 +1540,13 @@ future<db::commitlog::segment_manager::sseg_ptr> db::commitlog::segment_manager:
 
         f = make_checked_file(commit_error_handler, std::move(f));
     } catch (...) {
+        ep = std::current_exception();
+    }
+    if (ep) {
+        // do this early, so iff we are to fast-fail server,
+        // we do it before anything else can go wrong.
         try {
-            commit_error_handler(std::current_exception());
+            commit_error_handler(ep);
         } catch (...) {
             ep = std::current_exception();
         }


### PR DESCRIPTION
Fixes #9798

If an exception in allocate_segment_ex is (sub)type of std::system_error,
commit_error_handler might _not_ cause throw (doh), in which case the error
handling code would forget the current exception and return an unusable
segment.

Now only used as an exception pointer replacer.