### PR TITLE
Build performance: do not include the entire <seastar/net/ip.hh>

### DIFF
--- a/db/batchlog_manager.hh
+++ b/db/batchlog_manager.hh
@@ -49,8 +49,6 @@
 #include <seastar/core/metrics_registration.hh>
 #include <seastar/core/abort_source.hh>
 
-#include "gms/inet_address.hh"
-#include "inet_address_vectors.hh"
 #include "db_clock.hh"
 #include "mutation.hh"
 #include "utils/UUID.hh"

--- a/db/hints/sync_point.cc
+++ b/db/hints/sync_point.cc
@@ -23,6 +23,7 @@
 #include <unordered_set>
 
 #include <seastar/core/simple-stream.hh>
+#include <seastar/core/smp.hh>
 
 #include "db/hints/sync_point.hh"
 #include "gms/inet_address_serializer.hh"

--- a/dht/token-sharding.hh
+++ b/dht/token-sharding.hh
@@ -22,6 +22,7 @@
 #pragma once
 
 #include "dht/token.hh"
+#include <seastar/core/smp.hh>
 
 namespace dht {
 

--- a/flat_mutation_reader.hh
+++ b/flat_mutation_reader.hh
@@ -23,6 +23,7 @@
 
 #include <seastar/util/bool_class.hh>
 #include <seastar/core/future.hh>
+#include <seastar/core/circular_buffer.hh>
 
 #include "dht/i_partitioner.hh"
 #include "mutation_fragment.hh"

--- a/gms/inet_address.cc
+++ b/gms/inet_address.cc
@@ -90,3 +90,7 @@ std::ostream& gms::operator<<(std::ostream& os, const inet_address& x) {
     }
     return os;
 }
+
+sstring gms::inet_address::to_sstring() const {
+    return format("{}", *this);
+}

--- a/gms/inet_address.hh
+++ b/gms/inet_address.hh
@@ -21,15 +21,15 @@
 
 #pragma once
 
-#include <utility>
-
-#include <seastar/core/print.hh>
-#include <seastar/net/ip.hh>
+#include <seastar/net/ipv4_address.hh>
 #include <seastar/net/inet_address.hh>
 #include <seastar/net/socket_defs.hh>
-#include "utils/serialization.hh"
-#include <sstream>
+#include <iosfwd>
 #include <optional>
+#include <functional>
+
+#include "bytes.hh"
+#include "seastarx.hh"
 
 namespace gms {
 
@@ -74,9 +74,7 @@ public:
     uint32_t raw_addr() const {
         return addr().as_ipv4_address().ip;
     }
-    sstring to_sstring() const {
-        return format("{}", *this);
-    }
+    sstring to_sstring() const;
     friend inline bool operator==(const inet_address& x, const inet_address& y) noexcept {
         return x._addr == y._addr;
     }

--- a/gms/inet_address_serializer.hh
+++ b/gms/inet_address_serializer.hh
@@ -21,6 +21,8 @@
 
 #pragma once
 
+#include <seastar/net/ipv4_address.hh>
+#include <seastar/net/ipv6_address.hh>
 #include "inet_address.hh"
 #include "serializer.hh"
 

--- a/locator/azure_snitch.cc
+++ b/locator/azure_snitch.cc
@@ -43,6 +43,7 @@
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/seastar.hh>
 #include <seastar/http/response_parser.hh>
+#include <seastar/net/api.hh>
 #include <seastar/net/dns.hh>
 
 #include <boost/algorithm/string/classification.hpp>

--- a/locator/ec2_snitch.hh
+++ b/locator/ec2_snitch.hh
@@ -22,6 +22,7 @@
 
 #include "locator/production_snitch_base.hh"
 #include <seastar/http/response_parser.hh>
+#include <seastar/net/api.hh>
 
 namespace locator {
 class ec2_snitch : public production_snitch_base {

--- a/locator/gce_snitch.cc
+++ b/locator/gce_snitch.cc
@@ -38,6 +38,7 @@
  * Copyright (C) 2018-present ScyllaDB
  */
 
+#include <seastar/net/api.hh>
 #include <seastar/net/dns.hh>
 #include <seastar/core/seastar.hh>
 #include "locator/gce_snitch.hh"

--- a/reader_concurrency_semaphore.hh
+++ b/reader_concurrency_semaphore.hh
@@ -24,6 +24,7 @@
 #include <boost/intrusive/list.hpp>
 #include <seastar/core/future.hh>
 #include <seastar/core/gate.hh>
+#include <seastar/core/queue.hh>
 #include "reader_permit.hh"
 #include "flat_mutation_reader_v2.hh"
 

--- a/service/storage_proxy.hh
+++ b/service/storage_proxy.hh
@@ -70,6 +70,7 @@
 #include "db/hints/host_filter.hh"
 #include "utils/small_vector.hh"
 #include "service/endpoint_lifecycle_subscriber.hh"
+#include <seastar/core/circular_buffer.hh>
 
 class reconcilable_result;
 class frozen_mutation_and_schema;

--- a/test/boost/hint_test.cc
+++ b/test/boost/hint_test.cc
@@ -21,6 +21,7 @@
 
 #include <boost/test/unit_test.hpp>
 #include <seastar/testing/test_case.hh>
+#include <seastar/core/smp.hh>
 
 #include "db/hints/sync_point.hh"
 

--- a/types.cc
+++ b/types.cc
@@ -29,7 +29,6 @@
 #include "cql3/util.hh"
 #include "concrete_types.hh"
 #include <seastar/core/print.hh>
-#include <seastar/net/ip.hh>
 #include "utils/exceptions.hh"
 #include "utils/serialization.hh"
 #include "vint-serialization.hh"

--- a/types.hh
+++ b/types.hh
@@ -36,7 +36,8 @@
 #include "to_string.hh"
 #include "duration.hh"
 #include "marshal_exception.hh"
-#include <seastar/net/ip.hh>
+#include <seastar/net/ipv4_address.hh>
+#include <seastar/net/ipv6_address.hh>
 #include <seastar/net/inet_address.hh>
 #include <seastar/util/backtrace.hh>
 #include "hashing.hh"

--- a/utils/bloom_filter.cc
+++ b/utils/bloom_filter.cc
@@ -45,6 +45,7 @@
 #include "utils/murmur_hash.hh"
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/core/align.hh>
+#include <seastar/core/loop.hh>
 #include "utils/large_bitset.hh"
 #include <array>
 #include <cstdlib>


### PR DESCRIPTION
The header file <seastar/net/ip.hh> is a large collection of unrelated stuff, and according to ClangBuildAnalyzer, takes 2 seconds to compile for every source file that included it - and unfortunately virtually all Scylla source files included it - through either "types.hh" or "gms/inet_address.hh". That's 2*300 CPU seconds wasted.

In this two-patch series we completely eliminate the inclusion of <seastar/net/ip.hh> from Scylla. We still need the ipv4_address, ipv6_address types (e.g., gms/inet_address.hh uses it to hold a node's IP address) so those were split (in a Seastar patch that is already in) from ip.hh into separate small header files that we can include.

This patch reduces the entire build time (of build/dev/scylla) by 4% - reducing almost 10 sCPU minutes (!) from the build.