### PR TITLE
thrift: switch to replica::database uses to data_dictionary

### DIFF
--- a/data_dictionary/data_dictionary.cc
+++ b/data_dictionary/data_dictionary.cc
@@ -80,6 +80,11 @@ database::find_keyspace(std::string_view name) const {
     return *ks;
 }
 
+std::vector<keyspace>
+database::get_keyspaces() const {
+    return _ops->get_keyspaces(*this);
+}
+
 std::optional<table>
 database::try_find_table(std::string_view ks, std::string_view table) const {
     return _ops->try_find_table(*this, ks, table);

--- a/data_dictionary/data_dictionary.hh
+++ b/data_dictionary/data_dictionary.hh
@@ -24,6 +24,7 @@
 #include <optional>
 #include <set>
 #include <string_view>
+#include <vector>
 #include <seastar/core/shared_ptr.hh>
 #include "seastarx.hh"
 #include "utils/UUID.hh"
@@ -113,6 +114,7 @@ public:
     keyspace find_keyspace(std::string_view name) const;
     std::optional<keyspace> try_find_keyspace(std::string_view name) const;
     bool has_keyspace(std::string_view name) const;  // throws no_keyspace
+    std::vector<keyspace> get_keyspaces() const;
     table find_table(std::string_view ks, std::string_view table) const;  // throws no_such_column_family
     table find_column_family(utils::UUID uuid) const;  // throws no_such_column_family
     schema_ptr find_schema(std::string_view ks, std::string_view table) const;  // throws no_such_column_family

--- a/data_dictionary/impl.hh
+++ b/data_dictionary/impl.hh
@@ -31,6 +31,7 @@ class impl {
 public:
     virtual ~impl();
     virtual std::optional<keyspace> try_find_keyspace(database db, std::string_view name) const = 0;
+    virtual std::vector<keyspace> get_keyspaces(database db) const = 0;
     virtual std::optional<table> try_find_table(database db, std::string_view ks, std::string_view tab) const = 0;
     virtual std::optional<table> try_find_table(database db, utils::UUID id) const = 0;
     virtual const secondary_index::secondary_index_manager& get_index_manager(table t) const = 0;

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -2276,6 +2276,15 @@ public:
             return std::nullopt;
         }
     }
+    virtual std::vector<data_dictionary::keyspace> get_keyspaces(data_dictionary::database db) const override {
+        std::vector<data_dictionary::keyspace> ret;
+        const auto& keyspaces = unwrap(db).get_keyspaces();
+        ret.reserve(keyspaces.size());
+        for (auto& ks : keyspaces) {
+            ret.push_back(wrap(ks.second));
+        }
+        return ret;
+    }
     virtual std::optional<data_dictionary::table> try_find_table(data_dictionary::database db, std::string_view ks, std::string_view table) const override {
         try {
             return wrap(unwrap(db).find_column_family(ks, table));

--- a/thrift/controller.cc
+++ b/thrift/controller.cc
@@ -85,7 +85,7 @@ future<> thrift_controller::do_start_server() {
     tsc.max_request_size = cfg.thrift_max_message_length_in_mb() * (uint64_t(1) << 20);
     return utils::resolve(cfg.rpc_address, family, preferred).then([this, tserver, port = cfg.rpc_port(), keepalive, tsc] (gms::inet_address ip) {
         _addr.emplace(ip, port);
-        return tserver->start(std::ref(_db), std::ref(_qp), std::ref(_ss), std::ref(_proxy), std::ref(_auth_service), std::ref(_mem_limiter), tsc).then([tserver, port, ip, keepalive] {
+        return tserver->start(sharded_parameter([this] { return _db.local().as_data_dictionary(); }), std::ref(_qp), std::ref(_ss), std::ref(_proxy), std::ref(_auth_service), std::ref(_mem_limiter), tsc).then([tserver, port, ip, keepalive] {
             // #293 - do not stop anything
             //engine().at_exit([tserver] {
             //    return tserver->stop();

--- a/thrift/handler.hh
+++ b/thrift/handler.hh
@@ -24,8 +24,6 @@
 
 #include "Cassandra.h"
 #include "auth/service.hh"
-#include "replica/database_fwd.hh"
-#include <seastar/core/distributed.hh>
 #include "cql3/query_processor.hh"
 #include <memory>
 
@@ -33,6 +31,10 @@ struct timeout_config;
 class service_permit;
 namespace service { class storage_service; }
 
-std::unique_ptr<::cassandra::CassandraCobSvIfFactory> create_handler_factory(distributed<replica::database>& db, distributed<cql3::query_processor>& qp, sharded<service::storage_service>& ss, sharded<service::storage_proxy>& proxy, auth::service&, timeout_config, service_permit& current_permit);
+namespace data_dictionary {
+class database;
+}
+
+std::unique_ptr<::cassandra::CassandraCobSvIfFactory> create_handler_factory(data_dictionary::database db, distributed<cql3::query_processor>& qp, sharded<service::storage_service>& ss, sharded<service::storage_proxy>& proxy, auth::service&, timeout_config, service_permit& current_permit);
 
 #endif /* APPS_SEASTAR_THRIFT_HANDLER_HH_ */

--- a/thrift/server.cc
+++ b/thrift/server.cc
@@ -22,7 +22,6 @@
 #include "server.hh"
 #include "handler.hh"
 #include "db/config.hh"
-#include "replica/database.hh"
 #include <seastar/core/future-util.hh>
 #include <seastar/core/circular_buffer.hh>
 #include <seastar/core/metrics.hh>
@@ -66,7 +65,7 @@ public:
     thrift_stats(thrift_server& server);
 };
 
-thrift_server::thrift_server(distributed<replica::database>& db,
+thrift_server::thrift_server(data_dictionary::database db,
                              distributed<cql3::query_processor>& qp,
                              sharded<service::storage_service>& ss,
                              sharded<service::storage_proxy>& proxy,
@@ -78,7 +77,7 @@ thrift_server::thrift_server(distributed<replica::database>& db,
         , _protocol_factory(new TBinaryProtocolFactoryT<TMemoryBuffer>())
         , _processor_factory(new CassandraAsyncProcessorFactory(_handler_factory))
         , _memory_available(ml.get_semaphore())
-        , _max_concurrent_requests(db.local().get_config().max_concurrent_requests_per_shard)
+        , _max_concurrent_requests(db.get_config().max_concurrent_requests_per_shard)
         , _config(config) {
 }
 

--- a/thrift/server.hh
+++ b/thrift/server.hh
@@ -31,7 +31,6 @@
 #include <memory>
 #include <cstdint>
 #include <boost/intrusive/list.hpp>
-#include "replica/database_fwd.hh"
 #include "utils/updateable_value.hh"
 #include "service_permit.hh"
 
@@ -77,6 +76,10 @@ class service;
 }
 
 namespace service { class storage_service; }
+
+namespace data_dictionary {
+class database;
+}
 
 struct thrift_server_config {
     ::timeout_config timeout_config;
@@ -129,7 +132,7 @@ private:
     boost::intrusive::list<connection> _connections_list;
     seastar::gate _stop_gate;
 public:
-    thrift_server(distributed<replica::database>& db, distributed<cql3::query_processor>& qp, sharded<service::storage_service>& ss, sharded<service::storage_proxy>& proxy, auth::service&, service::memory_limiter& ml, thrift_server_config config);
+    thrift_server(data_dictionary::database db, distributed<cql3::query_processor>& qp, sharded<service::storage_service>& ss, sharded<service::storage_proxy>& proxy, auth::service&, service::memory_limiter& ml, thrift_server_config config);
     ~thrift_server();
     future<> listen(socket_address addr, bool keepalive);
     future<> stop();


### PR DESCRIPTION
replica::database is (as its name indicates) a replica-side service, while thrift
is coordinator-side. Convert thrift's use of replica::database for data dictionary
lookups to the data_dictionary module. Since data_dictionary was missing a
get_keyspaces() operation, add that.

Thrift still uses replica::database to get the schema version. That should be
provided by migration_manager, but changing that is left for later.