### PR TITLE
snapshot_ctl: true_snapshots_size: fix space accounting

### DIFF
--- a/db/snapshot-ctl.cc
+++ b/db/snapshot-ctl.cc
@@ -206,19 +206,18 @@ snapshot_ctl::get_snapshot_details() {
 }
 
 future<int64_t> snapshot_ctl::true_snapshots_size() {
-    return run_snapshot_list_operation([this] {
-            return do_with(int64_t(0), [this] (auto& local_total) {
-                return parallel_for_each(_db.local().get_column_families(), [&local_total] (auto& cf_pair) {
-                    return cf_pair.second->get_snapshot_details().then([&local_total] (auto map) {
-                        for (auto&& snap_map: map) {
-                            local_total += snap_map.second.live;
-                        }
-                        return make_ready_future<>();
-                     });
-                }).then([&local_total] {
-                    return make_ready_future<int64_t>(local_total);
+    return run_snapshot_list_operation([this] () mutable {
+        return do_with(int64_t(0), [this] (auto& total) {
+            return parallel_for_each(_db.local().get_column_families(), [&total] (auto& cf_pair) {
+                return cf_pair.second->get_snapshot_details().then([&total] (auto map) {
+                    for (auto&& snap_map: map) {
+                        total += snap_map.second.live;
+                    }
                 });
+            }).then([&total] {
+                return total;
             });
+        });
     });
 }
 

--- a/db/snapshot-ctl.cc
+++ b/db/snapshot-ctl.cc
@@ -207,9 +207,8 @@ snapshot_ctl::get_snapshot_details() {
 
 future<int64_t> snapshot_ctl::true_snapshots_size() {
     return run_snapshot_list_operation([this] {
-        return _db.map_reduce(adder<int64_t>(), [] (replica::database& db) {
-            return do_with(int64_t(0), [&db] (auto& local_total) {
-                return parallel_for_each(db.get_column_families(), [&local_total] (auto& cf_pair) {
+            return do_with(int64_t(0), [this] (auto& local_total) {
+                return parallel_for_each(_db.local().get_column_families(), [&local_total] (auto& cf_pair) {
                     return cf_pair.second->get_snapshot_details().then([&local_total] (auto map) {
                         for (auto&& snap_map: map) {
                             local_total += snap_map.second.live;
@@ -220,7 +219,6 @@ future<int64_t> snapshot_ctl::true_snapshots_size() {
                     return make_ready_future<int64_t>(local_total);
                 });
             });
-        });
     });
 }
 

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -1519,7 +1519,9 @@ future<std::unordered_map<sstring, table::snapshot_details>> table::get_snapshot
                 auto snapshot_name = de.name;
                 all_snapshots.emplace(snapshot_name, snapshot_details());
                 return lister::scan_dir(snapshots_dir / fs::path(snapshot_name),  { directory_entry_type::regular }, [this, datadir, &all_snapshots, snapshot_name] (fs::path snapshot_dir, directory_entry de) {
-                    return io_check(file_size, (snapshot_dir / de.name).native()).then([this, datadir, &all_snapshots, snapshot_name, snapshot_dir, name = de.name] (auto size) {
+                    return io_check(file_stat, (snapshot_dir / de.name).native(), follow_symlink::no).then([this, datadir, &all_snapshots, snapshot_name, snapshot_dir, name = de.name] (stat_data sd) {
+                        auto size = sd.allocated_size;
+
                         // The manifest is the only file expected to be in this directory not belonging to the SSTable.
                         // For it, we account the total size, but zero it for the true size calculation.
                         //

--- a/test/boost/database_test.cc
+++ b/test/boost/database_test.cc
@@ -47,6 +47,7 @@
 #include "db/data_listeners.hh"
 #include "multishard_mutation_query.hh"
 #include "transport/messages/result_message.hh"
+#include "db/snapshot-ctl.hh"
 
 using namespace std::chrono_literals;
 
@@ -529,6 +530,91 @@ SEASTAR_TEST_CASE(clear_nonexistent_snapshot) {
     });
 }
 
+SEASTAR_TEST_CASE(test_snapshot_ctl_details) {
+    return do_with_some_data([] (cql_test_env& e) {
+        sharded<db::snapshot_ctl> sc;
+        sc.start(std::ref(e.db())).get();
+        auto stop_sc = deferred_stop(sc);
+
+        auto& cf = e.local_db().find_column_family("ks", "cf");
+        take_snapshot(e).get();
+
+        auto details = cf.get_snapshot_details().get0();
+        BOOST_REQUIRE_EQUAL(details.size(), 1);
+
+        auto sd = details["test"];
+        BOOST_REQUIRE_EQUAL(sd.live, 0);
+        BOOST_REQUIRE_GT(sd.total, 0);
+
+        auto sc_details = sc.local().get_snapshot_details().get0();
+        BOOST_REQUIRE_EQUAL(sc_details.size(), 1);
+
+        auto sc_sd_vec = sc_details["test"];
+        BOOST_REQUIRE_EQUAL(sc_sd_vec.size(), 1);
+        const auto &sc_sd = sc_sd_vec[0];
+        BOOST_REQUIRE_EQUAL(sc_sd.ks, "ks");
+        BOOST_REQUIRE_EQUAL(sc_sd.cf, "cf");
+        BOOST_REQUIRE_EQUAL(sc_sd.live, sd.live);
+        BOOST_REQUIRE_EQUAL(sc_sd.total, sd.total);
+
+        lister::scan_dir(fs::path(cf.dir()), { directory_entry_type::regular }, [] (fs::path parent_dir, directory_entry de) {
+            fs::remove(parent_dir / de.name);
+            return make_ready_future<>();
+        }).get();
+
+        auto sd_post_deletion = cf.get_snapshot_details().get0().at("test");
+
+        BOOST_REQUIRE_EQUAL(sd_post_deletion.total, sd_post_deletion.live);
+        BOOST_REQUIRE_EQUAL(sd.total, sd_post_deletion.live);
+
+        sc_details = sc.local().get_snapshot_details().get0();
+        auto sc_sd_post_deletion_vec = sc_details["test"];
+        BOOST_REQUIRE_EQUAL(sc_sd_post_deletion_vec.size(), 1);
+        const auto &sc_sd_post_deletion = sc_sd_post_deletion_vec[0];
+        BOOST_REQUIRE_EQUAL(sc_sd_post_deletion.ks, "ks");
+        BOOST_REQUIRE_EQUAL(sc_sd_post_deletion.cf, "cf");
+        BOOST_REQUIRE_EQUAL(sc_sd_post_deletion.live, sd_post_deletion.live);
+        BOOST_REQUIRE_EQUAL(sc_sd_post_deletion.total, sd_post_deletion.total);
+
+        return make_ready_future<>();
+    });
+}
+
+SEASTAR_TEST_CASE(test_snapshot_ctl_true_snapshots_size) {
+    return do_with_some_data([] (cql_test_env& e) {
+        sharded<db::snapshot_ctl> sc;
+        sc.start(std::ref(e.db())).get();
+        auto stop_sc = deferred_stop(sc);
+
+        auto& cf = e.local_db().find_column_family("ks", "cf");
+        take_snapshot(e).get();
+
+        auto details = cf.get_snapshot_details().get0();
+        BOOST_REQUIRE_EQUAL(details.size(), 1);
+
+        auto sd = details["test"];
+        BOOST_REQUIRE_EQUAL(sd.live, 0);
+        BOOST_REQUIRE_GT(sd.total, 0);
+
+        auto sc_live_size = sc.local().true_snapshots_size().get0();
+        BOOST_REQUIRE_EQUAL(sc_live_size, sd.live);
+
+        lister::scan_dir(fs::path(cf.dir()), { directory_entry_type::regular }, [] (fs::path parent_dir, directory_entry de) {
+            fs::remove(parent_dir / de.name);
+            return make_ready_future<>();
+        }).get();
+
+        auto sd_post_deletion = cf.get_snapshot_details().get0().at("test");
+
+        BOOST_REQUIRE_EQUAL(sd_post_deletion.total, sd_post_deletion.live);
+        BOOST_REQUIRE_EQUAL(sd.total, sd_post_deletion.live);
+
+        sc_live_size = sc.local().true_snapshots_size().get0();
+        BOOST_REQUIRE_EQUAL(sc_live_size, sd_post_deletion.live);
+
+        return make_ready_future<>();
+    });
+}
 
 // toppartitions_query caused a lw_shared_ptr to cross shards when moving results, #5104
 SEASTAR_TEST_CASE(toppartitions_cross_shard_schema_ptr) {


### PR DESCRIPTION
This pull request fixes two preexisting issues related to snapshot_ctl::true_snapshots_size

https://github.com/scylladb/scylla/issues/9897
https://github.com/scylladb/scylla/issues/9898

And adds a couple unit tests to tests the snapshot_ctl functionality.

Test: unit(dev), database_test.{test_snapshot_ctl_details,test_snapshot_ctl_true_snapshots_size}(debug)