### PR TITLE
db: config: add a flag to disable new reversed reads algorithm

### DIFF
--- a/conf/scylla.yaml
+++ b/conf/scylla.yaml
@@ -534,3 +534,7 @@ murmur3_partitioner_ignore_msb_bits: 12
 # queries correctly.
 # The option can be updated without restarting Scylla.
 # reversed_reads_auto_bypass_cache: true
+
+# Use a new optimized algorithm for performing reversed reads.
+# Set to `false` to fall-back to the old algorithm.
+# enable_optimized_reversed_reads: true

--- a/db/config.cc
+++ b/db/config.cc
@@ -842,6 +842,8 @@ db::config::config(std::shared_ptr<db::extensions> exts)
     , strict_allow_filtering(this, "strict_allow_filtering", liveness::LiveUpdate, value_status::Used, strict_allow_filtering_default(), "Match Cassandra in requiring ALLOW FILTERING on slow queries. Can be true, false, or warn. When false, Scylla accepts some slow queries even without ALLOW FILTERING that Cassandra rejects. Warn is same as false, but with warning.")
     , reversed_reads_auto_bypass_cache(this, "reversed_reads_auto_bypass_cache", liveness::LiveUpdate, value_status::Used, false,
             "Bypass in-memory data cache (the row cache) when performing reversed queries.")
+    , enable_optimized_reversed_reads(this, "enable_optimized_reversed_reads", liveness::LiveUpdate, value_status::Used, true,
+            "Use a new optimized algorithm for performing reversed reads.")
     , alternator_port(this, "alternator_port", value_status::Used, 0, "Alternator API port")
     , alternator_https_port(this, "alternator_https_port", value_status::Used, 0, "Alternator API HTTPS port")
     , alternator_address(this, "alternator_address", value_status::Used, "0.0.0.0", "Alternator API listening address")

--- a/db/config.hh
+++ b/db/config.hh
@@ -350,6 +350,7 @@ public:
     named_value<bool> cdc_dont_rewrite_streams;
     named_value<tri_mode_restriction> strict_allow_filtering;
     named_value<bool> reversed_reads_auto_bypass_cache;
+    named_value<bool> enable_optimized_reversed_reads;
 
     named_value<uint16_t> alternator_port;
     named_value<uint16_t> alternator_https_port;

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -1136,6 +1136,7 @@ keyspace::make_column_family_config(const schema& s, const database& db) const {
     cfg.statement_scheduling_group = _config.statement_scheduling_group;
     cfg.enable_metrics_reporting = db_config.enable_keyspace_column_family_metrics();
     cfg.reversed_reads_auto_bypass_cache = db_config.reversed_reads_auto_bypass_cache;
+    cfg.enable_optimized_reversed_reads = db_config.enable_optimized_reversed_reads;
 
     // avoid self-reporting
     if (is_system_table(s)) {

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -396,7 +396,8 @@ public:
         db::data_listeners* data_listeners = nullptr;
         // Not really table-specific (it's a global configuration parameter), but stored here
         // for easy access from `table` member functions:
-        utils::updateable_value<bool> reversed_reads_auto_bypass_cache{true};
+        utils::updateable_value<bool> reversed_reads_auto_bypass_cache{false};
+        utils::updateable_value<bool> enable_optimized_reversed_reads{true};
     };
     struct no_commitlog {};
 


### PR DESCRIPTION
Just in case the new algorithm turns out to be buggy, or give a
performance regression, add a flag to fall-back to the old algorithm for
use in the field.