### PR TITLE
cdc: Handle compact storage correctly in preimage

### DIFF
--- a/cdc/log.cc
+++ b/cdc/log.cc
@@ -1505,6 +1505,11 @@ public:
         }
 
         auto process_cell = [&, this] (const column_definition& cdef) {
+            // If table uses compact storage it may contain a column of type empty
+            // and we need to ignore such a field because it is not present in CDC log.
+            if (cdef.type->get_kind() == abstract_type::kind::empty) {
+                return;
+            }
             if (auto current = get_col_from_row_state(row_state, cdef)) {
                 _builder->set_value(image_ck, cdef, *current);
             } else if (op == operation::pre_image) {

--- a/test/cql/cdc_compact_storage_test.cql
+++ b/test/cql/cdc_compact_storage_test.cql
@@ -1,4 +1,14 @@
-create table tb2 (pk int, ck int, PRIMARY KEY (pk, ck)) with compact storage and cdc = {'enabled': true, 'preimage': true, 'postimage': true};
--- Should add 3 rows (preimage + postimage + delta). Delta has only key columns and "pk" + "ck"
-insert into tb2 (pk, ck) VALUES (2, 22) USING TTL 2222;
-select "cdc$batch_seq_no", "cdc$operation", "cdc$ttl", pk, ck from tb2_scylla_cdc_log;
+create table tb2 (pk int, ck int, v int, PRIMARY KEY (pk, ck)) with compact storage and cdc = {'enabled': true, 'preimage': true, 'postimage': true};
+-- Should add 2 rows (postimage + delta).
+insert into tb2 (pk, ck, v) VALUES (2, 22, 111) USING TTL 2222;
+select "cdc$batch_seq_no", "cdc$operation", "cdc$ttl", pk, ck, v from tb2_scylla_cdc_log;
+-- Should add 3 rows (preimage + postimage + delta).
+insert into tb2 (pk, ck, v) VALUES (2, 22, 1111) USING TTL 2223;
+select "cdc$batch_seq_no", "cdc$operation", "cdc$ttl", pk, ck, v from tb2_scylla_cdc_log;
+create table tb3 (pk int, ck int, PRIMARY KEY (pk, ck)) with compact storage and cdc = {'enabled': true, 'preimage': true, 'postimage': true};
+-- Should add 2 rows (postimage + delta).
+insert into tb3 (pk, ck) VALUES (2, 22) USING TTL 2222;
+select "cdc$batch_seq_no", "cdc$operation", "cdc$ttl", pk, ck from tb3_scylla_cdc_log;
+-- Should add 3 rows (preimage + postimage + delta).
+insert into tb3 (pk, ck) VALUES (2, 22) USING TTL 2223;
+select "cdc$batch_seq_no", "cdc$operation", "cdc$ttl", pk, ck from tb3_scylla_cdc_log;

--- a/test/cql/cdc_compact_storage_test.result
+++ b/test/cql/cdc_compact_storage_test.result
@@ -1,13 +1,91 @@
-create table tb2 (pk int, ck int, PRIMARY KEY (pk, ck)) with compact storage and cdc = {'enabled': true, 'preimage': true, 'postimage': true};
+create table tb2 (pk int, ck int, v int, PRIMARY KEY (pk, ck)) with compact storage and cdc = {'enabled': true, 'preimage': true, 'postimage': true};
 {
 	"status" : "ok"
 }
--- Should add 3 rows (preimage + postimage + delta). Delta has only key columns and "pk" + "ck"
-insert into tb2 (pk, ck) VALUES (2, 22) USING TTL 2222;
+-- Should add 2 rows (postimage + delta).
+insert into tb2 (pk, ck, v) VALUES (2, 22, 111) USING TTL 2222;
 {
 	"status" : "ok"
 }
-select "cdc$batch_seq_no", "cdc$operation", "cdc$ttl", pk, ck from tb2_scylla_cdc_log;
+select "cdc$batch_seq_no", "cdc$operation", "cdc$ttl", pk, ck, v from tb2_scylla_cdc_log;
+{
+	"rows" : 
+	[
+		{
+			"cdc$batch_seq_no" : "0",
+			"cdc$operation" : "1",
+			"cdc$ttl" : "2222",
+			"ck" : "22",
+			"pk" : "2",
+			"v" : "111"
+		},
+		{
+			"cdc$batch_seq_no" : "1",
+			"cdc$operation" : "9",
+			"ck" : "22",
+			"pk" : "2",
+			"v" : "111"
+		}
+	]
+}
+-- Should add 3 rows (preimage + postimage + delta).
+insert into tb2 (pk, ck, v) VALUES (2, 22, 1111) USING TTL 2223;
+{
+	"status" : "ok"
+}
+select "cdc$batch_seq_no", "cdc$operation", "cdc$ttl", pk, ck, v from tb2_scylla_cdc_log;
+{
+	"rows" : 
+	[
+		{
+			"cdc$batch_seq_no" : "0",
+			"cdc$operation" : "1",
+			"cdc$ttl" : "2222",
+			"ck" : "22",
+			"pk" : "2",
+			"v" : "111"
+		},
+		{
+			"cdc$batch_seq_no" : "1",
+			"cdc$operation" : "9",
+			"ck" : "22",
+			"pk" : "2",
+			"v" : "111"
+		},
+		{
+			"cdc$batch_seq_no" : "0",
+			"cdc$operation" : "0",
+			"ck" : "22",
+			"pk" : "2",
+			"v" : "111"
+		},
+		{
+			"cdc$batch_seq_no" : "1",
+			"cdc$operation" : "1",
+			"cdc$ttl" : "2223",
+			"ck" : "22",
+			"pk" : "2",
+			"v" : "1111"
+		},
+		{
+			"cdc$batch_seq_no" : "2",
+			"cdc$operation" : "9",
+			"ck" : "22",
+			"pk" : "2",
+			"v" : "1111"
+		}
+	]
+}
+create table tb3 (pk int, ck int, PRIMARY KEY (pk, ck)) with compact storage and cdc = {'enabled': true, 'preimage': true, 'postimage': true};
+{
+	"status" : "ok"
+}
+-- Should add 2 rows (postimage + delta).
+insert into tb3 (pk, ck) VALUES (2, 22) USING TTL 2222;
+{
+	"status" : "ok"
+}
+select "cdc$batch_seq_no", "cdc$operation", "cdc$ttl", pk, ck from tb3_scylla_cdc_log;
 {
 	"rows" : 
 	[
@@ -20,6 +98,49 @@ select "cdc$batch_seq_no", "cdc$operation", "cdc$ttl", pk, ck from tb2_scylla_cd
 		},
 		{
 			"cdc$batch_seq_no" : "1",
+			"cdc$operation" : "9",
+			"ck" : "22",
+			"pk" : "2"
+		}
+	]
+}
+-- Should add 3 rows (preimage + postimage + delta).
+insert into tb3 (pk, ck) VALUES (2, 22) USING TTL 2223;
+{
+	"status" : "ok"
+}
+select "cdc$batch_seq_no", "cdc$operation", "cdc$ttl", pk, ck from tb3_scylla_cdc_log;
+{
+	"rows" : 
+	[
+		{
+			"cdc$batch_seq_no" : "0",
+			"cdc$operation" : "1",
+			"cdc$ttl" : "2222",
+			"ck" : "22",
+			"pk" : "2"
+		},
+		{
+			"cdc$batch_seq_no" : "1",
+			"cdc$operation" : "9",
+			"ck" : "22",
+			"pk" : "2"
+		},
+		{
+			"cdc$batch_seq_no" : "0",
+			"cdc$operation" : "0",
+			"ck" : "22",
+			"pk" : "2"
+		},
+		{
+			"cdc$batch_seq_no" : "1",
+			"cdc$operation" : "1",
+			"cdc$ttl" : "2223",
+			"ck" : "22",
+			"pk" : "2"
+		},
+		{
+			"cdc$batch_seq_no" : "2",
 			"cdc$operation" : "9",
 			"ck" : "22",
 			"pk" : "2"


### PR DESCRIPTION
Base tables that use compact storage may have a special artificial
column that has an empty type.

c010cefc4d1b10d1413f1c6862b7afa08a1245f7 fixed the main CDC path to
handle such columns correctly and to not include them in the CDC Log
schema.

This patch makes sure that generation of preimage ignores such empty
column as well.

Fixes #9876

Signed-off-by: Piotr Jastrzebski <piotr@scylladb.com>