### PR TITLE
view: convert build_progress_virtual_reader to flat_mutation_reader_v2

### DIFF
--- a/mutation_fragment_v2.hh
+++ b/mutation_fragment_v2.hh
@@ -53,8 +53,11 @@ public:
         : _pos(pos)
         , _tomb(tomb)
     { }
-    const position_in_partition& position() const {
+    const position_in_partition& position() const & {
         return _pos;
+    }
+    position_in_partition position() && {
+        return std::move(_pos);
     }
     void set_position(position_in_partition pos) {
         _pos = std::move(pos);


### PR DESCRIPTION
build_progress_virtual_reader is a virtual reader that trims off
the last clustering key column from an underlying base table. It
is here converted to flat_mutation_reader_v2.

Because range_tombstone_change uses position_in_partition, not
clustering_key_prefix, we need a new adjust_ckey() overload.

Note the transformation is likely incorrect. When trimming the
last clustering key column, an inclusive bound changes should
change to exclusive. However, the original code did not do this,
so we don't fix it here. It's immaterial anyway since the base
table doesn't include range tombstones.

Test: unit (dev)   (which has a test for this reader)