### PR TITLE
redis: switch from replica/database to data_dictionary

### DIFF
--- a/redis/controller.hh
+++ b/redis/controller.hh
@@ -26,6 +26,7 @@
 #include "seastar/core/sharded.hh"
 
 #include "protocol_server.hh"
+#include "data_dictionary/data_dictionary.hh"
 
 namespace db {
 class config;
@@ -52,10 +53,6 @@ namespace gms {
 class gossiper;
 }
 
-namespace replica {
-class database;
-}
-
 namespace redis {
 
 // As defined in: https://redis.io/topics/protocol
@@ -70,6 +67,7 @@ class controller : public protocol_server {
     seastar::sharded<redis::query_processor> _query_processor;
     seastar::shared_ptr<seastar::sharded<redis_transport::redis_server>> _server;
     seastar::sharded<service::storage_proxy>& _proxy;
+    data_dictionary::database _db;
     seastar::sharded<auth::service>& _auth_service;
     seastar::sharded<service::migration_manager>& _mm;
     db::config& _cfg;

--- a/redis/keyspace_utils.cc
+++ b/redis/keyspace_utils.cc
@@ -36,10 +36,10 @@
 #include "transport/server.hh"
 #include "db/system_keyspace.hh"
 #include "schema.hh"
-#include "replica/database.hh"
 #include "gms/gossiper.hh"
 #include <seastar/core/print.hh>
 #include "db/config.hh"
+#include "data_dictionary/keyspace_metadata.hh"
 
 using namespace seastar;
 
@@ -151,17 +151,17 @@ schema_ptr zsets_schema(sstring ks_name) {
     return builder.build(schema_builder::compact_storage::yes);
 }
 
-future<> create_keyspace_if_not_exists_impl(seastar::sharded<service::storage_proxy>& proxy, seastar::sharded<service::migration_manager>& mm, db::config& config, int default_replication_factor) {
+future<> create_keyspace_if_not_exists_impl(seastar::sharded<service::storage_proxy>& proxy, data_dictionary::database db, seastar::sharded<service::migration_manager>& mm, db::config& config, int default_replication_factor) {
     assert(this_shard_id() == 0);
     auto keyspace_replication_strategy_options = config.redis_keyspace_replication_strategy_options();
     if (!keyspace_replication_strategy_options.contains("class")) {
         keyspace_replication_strategy_options["class"] = "SimpleStrategy";
         keyspace_replication_strategy_options["replication_factor"] = fmt::format("{}", default_replication_factor);
     }
-    auto keyspace_gen = [&proxy, &mm, &config, keyspace_replication_strategy_options = std::move(keyspace_replication_strategy_options)]  (sstring name) -> future<> {
+    auto keyspace_gen = [&proxy, db, &mm, &config, keyspace_replication_strategy_options = std::move(keyspace_replication_strategy_options)]  (sstring name) -> future<> {
         auto& mml = mm.local();
         auto& proxyl = proxy.local();
-        if (proxyl.get_db().local().has_keyspace(name)) {
+        if (db.has_keyspace(name)) {
             co_return;
         }
         auto attrs = make_shared<cql3::statements::ks_prop_defs>();
@@ -175,10 +175,10 @@ future<> create_keyspace_if_not_exists_impl(seastar::sharded<service::storage_pr
         const auto& tm = *proxyl.get_token_metadata_ptr();
         co_return co_await mml.announce(mml.prepare_new_keyspace_announcement(attrs->as_ks_metadata(name, tm)));
     };
-    auto table_gen = [&proxy, &mm] (sstring ks_name, sstring cf_name, schema_ptr schema) -> future<> {
+    auto table_gen = [&proxy, db, &mm] (sstring ks_name, sstring cf_name, schema_ptr schema) -> future<> {
         auto& mml= mm.local();
         auto& proxyl = proxy.local();
-        if (proxyl.get_db().local().has_schema(ks_name, cf_name)) {
+        if (db.has_schema(ks_name, cf_name)) {
             co_return;
         }
         logger.info("Create keyspace: {}, table: {} for redis.", ks_name, cf_name);
@@ -202,14 +202,14 @@ future<> create_keyspace_if_not_exists_impl(seastar::sharded<service::storage_pr
     });
 }
 
-future<> maybe_create_keyspace(seastar::sharded<service::storage_proxy>& proxy, seastar::sharded<service::migration_manager>& mm, db::config& config, sharded<gms::gossiper>& gossiper) {
-    return gms::get_up_endpoint_count(gossiper.local()).then([&proxy, &mm, &config] (auto live_endpoint_count) {
+future<> maybe_create_keyspace(seastar::sharded<service::storage_proxy>& proxy, data_dictionary::database db, seastar::sharded<service::migration_manager>& mm, db::config& config, sharded<gms::gossiper>& gossiper) {
+    return gms::get_up_endpoint_count(gossiper.local()).then([&proxy, db, &mm, &config] (auto live_endpoint_count) {
         int replication_factor = 3;
         if (live_endpoint_count < replication_factor) {
             replication_factor = 1;
             logger.warn("Creating keyspace for redis with unsafe, live endpoint nodes count: {}.", live_endpoint_count);
         }
-        return create_keyspace_if_not_exists_impl(proxy, mm, config, replication_factor);
+        return create_keyspace_if_not_exists_impl(proxy, db, mm, config, replication_factor);
     });
 }
 

--- a/redis/keyspace_utils.hh
+++ b/redis/keyspace_utils.hh
@@ -36,6 +36,10 @@ namespace gms {
 class gossiper;
 }
 
+namespace data_dictionary {
+class database;
+}
+
 namespace redis {
 
 static constexpr auto DATA_COLUMN_NAME = "data";
@@ -45,6 +49,6 @@ static constexpr auto HASHes          = "HASHes";
 static constexpr auto SETs            = "SETs";
 static constexpr auto ZSETs           = "ZSETs";
 
-seastar::future<> maybe_create_keyspace(seastar::sharded<service::storage_proxy>& proxy, seastar::sharded<service::migration_manager>& mm, db::config& cfg, seastar::sharded<gms::gossiper>& g);
+seastar::future<> maybe_create_keyspace(seastar::sharded<service::storage_proxy>& proxy, data_dictionary::database db, seastar::sharded<service::migration_manager>& mm, db::config& cfg, seastar::sharded<gms::gossiper>& g);
 
 }

--- a/redis/options.cc
+++ b/redis/options.cc
@@ -23,7 +23,6 @@
 #include "types.hh"
 #include "service/storage_proxy.hh"
 #include "schema.hh"
-#include "replica/database.hh"
 #include <seastar/core/print.hh>
 #include "redis/keyspace_utils.hh"
 
@@ -32,7 +31,7 @@ using namespace seastar;
 namespace redis {
 
 schema_ptr get_schema(service::storage_proxy& proxy, const sstring& ks_name, const sstring& cf_name) {
-    auto& db = proxy.get_db().local();
+    auto db = proxy.data_dictionary();
     auto schema = db.find_schema(ks_name, cf_name);
     return schema;
 }

--- a/redis/query_processor.cc
+++ b/redis/query_processor.cc
@@ -31,7 +31,7 @@ namespace redis {
 
 distributed<query_processor> _the_query_processor;
 
-query_processor::query_processor(service::storage_proxy& proxy, distributed<replica::database>& db)
+query_processor::query_processor(service::storage_proxy& proxy, data_dictionary::database db)
         : _proxy(proxy)
         , _db(db)
 {

--- a/redis/query_processor.hh
+++ b/redis/query_processor.hh
@@ -26,9 +26,7 @@
 #include <seastar/core/gate.hh>
 #include <seastar/core/metrics_registration.hh>
 
-namespace replica {
-class database;
-}
+#include "data_dictionary/data_dictionary.hh"
 
 class service_permit;
 
@@ -45,15 +43,15 @@ class redis_message;
 
 class query_processor {
     service::storage_proxy& _proxy;
-    seastar::sharded<replica::database>& _db;
+    data_dictionary::database _db;
     seastar::metrics::metric_groups _metrics;
     seastar::gate _pending_command_gate;
 public:
-    query_processor(service::storage_proxy& proxy, seastar::sharded<replica::database>& db);
+    query_processor(service::storage_proxy& proxy, data_dictionary::database db);
 
     ~query_processor();
 
-    seastar::sharded<replica::database>& db() {
+    data_dictionary::database db() {
         return _db;
     }
 


### PR DESCRIPTION
redis uses replica/database only for data dictionary purposes;
switch it to the much lighter weight data_dictionary module.