### PR TITLE
utils::is_timeout_exception: Ensure we handle nested exception types

### DIFF
--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -4999,14 +4999,10 @@ void storage_proxy::init_messaging_service(shared_ptr<migration_manager> mm) {
                     });
                 }).handle_exception([reply_to, shard, &p, &errors] (std::exception_ptr eptr) {
                     seastar::log_level l = seastar::log_level::warn;
-                    try {
-                        std::rethrow_exception(eptr);
-                    } catch (timed_out_error&) {
+                    if (is_timeout_exception(eptr)) {
                         // ignore timeouts so that logs are not flooded.
                         // database total_writes_timedout counter was incremented.
                         l = seastar::log_level::debug;
-                    } catch (...) {
-                        // ignore
                     }
                     slogger.log(l, "Failed to apply mutation from {}#{}: {}", reply_to, shard, eptr);
                     errors++;

--- a/utils/exceptions.cc
+++ b/utils/exceptions.cc
@@ -80,6 +80,8 @@ bool is_timeout_exception(std::exception_ptr e) {
         return true;
     } catch (seastar::timed_out_error& unused) {
         return true;
+    } catch (const std::nested_exception& e) {
+        return is_timeout_exception(e.nested_ptr());
     } catch (...) {
     }
     return false;


### PR DESCRIPTION
Fixes #9922

storage proxy uses is_timeout_exception to traverse different code paths.
a6202ae079b44da44f402f50001bd2df1cb49673 broke this (because bit rot and
intermixing), by wrapping exception for information purposes.

This adds check of nested types in exception handling, as well as a test
for the routine itself.