### PR TITLE
validation: complete transition to data_dictionary module

### DIFF
--- a/validation.cc
+++ b/validation.cc
@@ -12,7 +12,9 @@
  */
 
 #include "validation.hh"
-#include "replica/database.hh"
+#include "schema.hh"
+#include "keys.hh"
+#include "data_dictionary/data_dictionary.hh"
 #include "exceptions/exceptions.hh"
 
 namespace validation {

--- a/validation.hh
+++ b/validation.hh
@@ -14,10 +14,11 @@
 #pragma once
 
 #include <seastar/core/sstring.hh>
-#include "replica/database_fwd.hh"
 #include "schema_fwd.hh"
 
 using namespace seastar;
+
+class partition_key_view;
 
 namespace data_dictionary {
 class database;


### PR DESCRIPTION
The API was converted in 00de5f4876050fb9748e2763dbac7e83cce79306,
but some #includes remain. Remove them.