### PR TITLE
scylla_raid_setup: use mdmonitor only when RAID level > 0

### DIFF
--- a/dist/common/scripts/scylla_raid_setup
+++ b/dist/common/scripts/scylla_raid_setup
@@ -17,8 +17,6 @@ import distro
 from pathlib import Path
 from scylla_util import *
 from subprocess import run
-import distro
-from pkg_resources import parse_version
 
 if __name__ == '__main__':
     if os.getuid() > 0:
@@ -108,25 +106,6 @@ if __name__ == '__main__':
         pkg_install('xfsprogs')
     if not shutil.which('mdadm'):
         pkg_install('mdadm')
-    # XXX: Workaround for mdmonitor.service issue on CentOS8
-    if is_redhat_variant() and distro.version() == '8':
-        mdadm_rpm = run('rpm -q mdadm', shell=True, check=True, capture_output=True, encoding='utf-8').stdout.strip()
-        match = re.match(r'^mdadm-([0-9]+\.[0-9]+-[a-zA-Z0-9]+)\.', mdadm_rpm)
-        mdadm_version = match.group(1)
-        if parse_version('4.1-14') < parse_version(mdadm_version):
-            repo_data = '''
-[BaseOS_8_3_2011]
-name=CentOS8.3.2011 - Base
-baseurl=http://vault.centos.org/8.3.2011/BaseOS/$basearch/os/
-gpgcheck=1
-enabled=0
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial
-'''[1:-1]
-            with open('/etc/yum.repos.d/CentOS-Vault-8.3.repo', 'w') as f:
-                f.write(repo_data)
-            run('dnf downgrade --enablerepo=BaseOS_8_3_2011 -y mdadm', shell=True, check=True)
-            run('dnf install -y python3-dnf-plugin-versionlock', shell=True, check=True)
-            run('dnf versionlock add mdadm', shell=True, check=True)
     try:
         md_service = systemd_unit('mdmonitor.service')
     except SystemdException:

--- a/dist/common/scripts/scylla_raid_setup
+++ b/dist/common/scripts/scylla_raid_setup
@@ -106,10 +106,11 @@ if __name__ == '__main__':
         pkg_install('xfsprogs')
     if not shutil.which('mdadm'):
         pkg_install('mdadm')
-    try:
-        md_service = systemd_unit('mdmonitor.service')
-    except SystemdException:
-        md_service = systemd_unit('mdadm.service')
+    if args.raid_level != '0':
+        try:
+            md_service = systemd_unit('mdmonitor.service')
+        except SystemdException:
+            md_service = systemd_unit('mdadm.service')
 
     print('Creating {type} for scylla using {nr_disk} disk(s): {disks}'.format(type=f'RAID{args.raid_level}' if raid else 'XFS volume', nr_disk=len(disks), disks=args.disks))
     procs=[]
@@ -153,8 +154,10 @@ if __name__ == '__main__':
 
     uuid = run(f'blkid -s UUID -o value {fsdev}', shell=True, check=True, capture_output=True, encoding='utf-8').stdout.strip()
     after = 'local-fs.target'
-    if raid:
+    wants = ''
+    if raid and args.raid_level != '0':
         after += f' {md_service}'
+        wants = f'\nWants={md_service}'
     opt_discard = ''
     if args.online_discard:
         opt_discard = ',discard'
@@ -162,8 +165,7 @@ if __name__ == '__main__':
 [Unit]
 Description=Scylla data directory
 Before=scylla-server.service
-After={after}
-Wants={md_service}
+After={after}{wants}
 DefaultDependencies=no
 
 [Mount]
@@ -187,7 +189,8 @@ WantedBy=multi-user.target
             f.write(f'RequiresMountsFor={mount_at}\n')
 
     systemd_unit.reload()
-    md_service.start()
+    if args.raid_level != '0':
+        md_service.start()
     mount = systemd_unit(mntunit_bn)
     mount.start()
     if args.enable_on_nextboot:


### PR DESCRIPTION
We found that monitor mode of mdadm does not work on RAID0, and it is
not a bug, expected behavior according to RHEL developer.
Therefore, we should stop enabling mdmonitor when RAID0 is specified.

Fixes #9540

----

This reverts 0d8f932 and introduce correct fix.