### PR TITLE
Add keyspace_offstrategy_compaction api

### DIFF
--- a/api/api-doc/storage_service.json
+++ b/api/api-doc/storage_service.json
@@ -766,6 +766,38 @@
          ]
       },
       {
+         "path":"/storage_service/keyspace_offstrategy_compaction/{keyspace}",
+         "operations":[
+            {
+               "method":"POST",
+               "summary":"Perform offstrategy compaction, if needed, in a single keyspace",
+               "type":"long",
+               "nickname":"perform_keyspace_offstrategy_compaction",
+               "produces":[
+                  "application/json"
+               ],
+               "parameters":[
+                  {
+                     "name":"keyspace",
+                     "description":"The keyspace to operate on",
+                     "required":true,
+                     "allowMultiple":false,
+                     "type":"string",
+                     "paramType":"path"
+                  },
+                  {
+                     "name":"cf",
+                     "description":"Comma-seperated table names",
+                     "required":false,
+                     "allowMultiple":false,
+                     "type":"string",
+                     "paramType":"query"
+                  }
+               ]
+            }
+         ]
+      },
+      {
          "path":"/storage_service/keyspace_scrub/{keyspace}",
          "operations":[
             {

--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -772,13 +772,6 @@ future<> compaction_manager::perform_offstrategy(replica::table* t) {
     return task->compaction_done.get_future().finally([task] {});
 }
 
-void compaction_manager::submit_offstrategy(replica::table* t) {
-    // Run in background.
-    // This is safe since the compaction task is tracked
-    // by the compaction_manager until stop()
-    (void)perform_offstrategy(t);
-}
-
 future<> compaction_manager::rewrite_sstables(replica::table* t, sstables::compaction_type_options options, get_candidates_func get_func, can_purge_tombstones can_purge) {
     auto task = make_lw_shared<compaction_manager::task>(t, options.type(), get_compaction_state(t));
     _tasks.push_back(task);

--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -742,21 +742,21 @@ future<> compaction_manager::perform_offstrategy(replica::table* t) {
                 _stats.active_tasks++;
                 task->setup_new_compaction();
 
-                return t->run_offstrategy_compaction(task->compaction_data).then_wrapped([this, task] (future<> f) mutable {
+                return t->run_offstrategy_compaction(task->compaction_data).then_wrapped([this, task, schema = t->schema()] (future<> f) mutable {
                     _stats.active_tasks--;
                     task->finish_compaction();
                     try {
                         f.get();
                         _stats.completed_tasks++;
                     } catch (sstables::compaction_stopped_exception& e) {
-                        cmlog.info("off-strategy compaction: {}", e.what());
+                        cmlog.info("off-strategy compaction of {}.{} was stopped: {}", schema->ks_name(), schema->cf_name(), e.what());
                     } catch (sstables::compaction_aborted_exception& e) {
                         _stats.errors++;
-                        cmlog.error("off-strategy compaction: {}", e.what());
+                        cmlog.info("off-strategy compaction of {}.{} was aborted: {}", schema->ks_name(), schema->cf_name(), e.what());
                     } catch (...) {
                         _stats.errors++;
                         _stats.pending_tasks++;
-                        cmlog.error("off-strategy compaction failed due to {}, retrying...", std::current_exception());
+                        cmlog.error("off-strategy compaction of {}.{} failed due to {}, retrying...", schema->ks_name(), schema->cf_name(), std::current_exception());
                         return put_task_to_sleep(task).then([] {
                             return make_ready_future<stop_iteration>(stop_iteration::no);
                         });

--- a/compaction/compaction_manager.hh
+++ b/compaction/compaction_manager.hh
@@ -239,7 +239,6 @@ public:
     void submit(replica::table* t);
 
     // Submit a table to be off-strategy compacted.
-    void submit_offstrategy(replica::table* t);
     future<> perform_offstrategy(replica::table* t);
 
     // Submit a table to be cleaned up and wait for its termination.

--- a/compaction/compaction_manager.hh
+++ b/compaction/compaction_manager.hh
@@ -240,6 +240,7 @@ public:
 
     // Submit a table to be off-strategy compacted.
     void submit_offstrategy(replica::table* t);
+    future<> perform_offstrategy(replica::table* t);
 
     // Submit a table to be cleaned up and wait for its termination.
     //

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -889,7 +889,12 @@ public:
     void start_compaction();
     void trigger_compaction();
     void try_trigger_compaction() noexcept;
+    // Triggers offstrategy compaction, if needed, in the background.
     void trigger_offstrategy_compaction();
+    // Performs offstrategy compaction, if needed, returning
+    // a future<bool> that is resolved when offstrategy_compaction completes.
+    // The future value is true iff offstrategy compaction was required.
+    future<bool> perform_offstrategy_compaction();
     future<> run_offstrategy_compaction(sstables::compaction_data& info);
     void set_compaction_strategy(sstables::compaction_strategy_type strategy);
     const sstables::compaction_strategy& get_compaction_strategy() const {


### PR DESCRIPTION
This series adds methods to perform offstrategy compaction, if needed, returning a future<bool>
so the caller can wait on it until compaction completes.
The returned value is true iff offstrategy compaction was needed.

The added keyspace_offstrategy_compaction calls perform_offstrategy_compaction on the specified keyspace and tables, return the number of tables that required offstrategy compaction.

A respective unit test was added to the rest_api pytest.

This PR replaces https://github.com/scylladb/scylla/pull/9095 that suggested adding an option to `keyspace_compaction`
since offstrategy compaction triggering logic is different enough from major compaction meriting a new api.

Test: unit (dev)