### PR TITLE
alternator: fill UnprocessedKeys for failed batch reads

### DIFF
--- a/test/alternator/test_batch.py
+++ b/test/alternator/test_batch.py
@@ -402,3 +402,21 @@ def test_batch_get_item_partial(scylla_only, dynamodb, test_table_sn):
         assert multiset(responses) == multiset(
             [{'p': p, 'c': i, 'content': content} for i in range(count)])
         assert some_keys_were_unprocessed
+
+# Test that if the batch read failure is total, i.e. all read requests
+# failed, it's reported as an error and not as a regular response with
+# UnprocessedKeys set to all given keys.
+def test_batch_get_item_full_failure(scylla_only, dynamodb, test_table_sn):
+    p = random_string()
+    content = random_string()
+    count = 10
+    with test_table_sn.batch_writer() as batch:
+        for i in range(count):
+            batch.put_item(Item={
+                'p': p, 'c': i, 'content': content})
+    responses = []
+    to_read = { test_table_sn.name: {'Keys': [{'p': p, 'c': c} for c in range(count)], 'ConsistentRead': True } }
+    # The error injection is permanent, so it will fire for each batch read.
+    with scylla_inject_error(dynamodb, "alternator_batch_get_item", one_shot=False):
+        with pytest.raises(ClientError, match="InternalServerError"):
+            reply = test_table_sn.meta.client.batch_get_item(RequestItems = to_read)

--- a/test/alternator/test_batch.py
+++ b/test/alternator/test_batch.py
@@ -9,7 +9,7 @@
 import pytest
 import random
 from botocore.exceptions import ClientError
-from util import random_string, full_scan, full_query, multiset
+from util import random_string, full_scan, full_query, multiset, scylla_inject_error
 
 # Test ensuring that items inserted by a batched statement can be properly extracted
 # via GetItem. Schema has both hash and sort keys.
@@ -373,3 +373,32 @@ def test_batch_get_item_large(test_table_sn):
         responses.extend(reply['Responses'][test_table_sn.name])
     assert multiset(responses) == multiset(
         [{'p': p, 'c': i, 'content': long_content} for i in range(count)])
+
+# Test for checking that returning partial results as UnprocessedKeys
+# is properly handled. This test relies on error injection available
+# only in Scylla compiled with appropriate flags (present in dev/debug/sanitize
+# modes) and is skipped otherwise.
+def test_batch_get_item_partial(scylla_only, dynamodb, test_table_sn):
+    p = random_string()
+    content = random_string()
+    count = 10
+    with test_table_sn.batch_writer() as batch:
+        for i in range(count):
+            batch.put_item(Item={
+                'p': p, 'c': i, 'content': content})
+    responses = []
+    to_read = { test_table_sn.name: {'Keys': [{'p': p, 'c': c} for c in range(count)], 'ConsistentRead': True } }
+    with scylla_inject_error(dynamodb, "alternator_batch_get_item", one_shot=True):
+        some_keys_were_unprocessed = False
+        while to_read:
+            reply = test_table_sn.meta.client.batch_get_item(RequestItems = to_read)
+            assert 'UnprocessedKeys' in reply
+            to_read = reply['UnprocessedKeys']
+            some_keys_were_unprocessed = some_keys_were_unprocessed or len(to_read) > 0
+            print("Left to read:", to_read)
+            assert 'Responses' in reply
+            assert test_table_sn.name in reply['Responses']
+            responses.extend(reply['Responses'][test_table_sn.name])
+        assert multiset(responses) == multiset(
+            [{'p': p, 'c': i, 'content': content} for i in range(count)])
+        assert some_keys_were_unprocessed

--- a/test/alternator/util.py
+++ b/test/alternator/util.py
@@ -8,6 +8,9 @@ import string
 import random
 import collections
 import time
+import re
+import requests
+import pytest
 from contextlib import contextmanager
 from botocore.hooks import HierarchicalEmitter
 
@@ -206,3 +209,25 @@ def client_no_transform(client):
 
 def is_aws(dynamodb):
     return dynamodb.meta.client._endpoint.host.endswith('.amazonaws.com')
+
+# Tries to inject an error via Scylla REST API. It only works on Scylla,
+# and only in specific build modes (dev, debug, sanitize), so this function
+# will trigger a test to be skipped if it cannot be executed.
+@contextmanager
+def scylla_inject_error(dynamodb, err, one_shot=False):
+    if dynamodb.meta.client._endpoint.host.endswith('.amazonaws.com'):
+        pytest.skip("Error injection not enabled on AWS")
+    url = dynamodb.meta.client._endpoint.host
+    # The REST API is on port 10000, and always http, not https.
+    url = re.sub(r':[0-9]+(/|$)', ':10000', url)
+    url = re.sub(r'^https:', 'http:', url)
+    response = requests.post(f'{url}/v2/error_injection/injection/{err}?one_shot={one_shot}')
+    response = requests.get(f'{url}/v2/error_injection/injection')
+    print("Enabled error injections:", response.content.decode('utf-8'))
+    if response.content.decode('utf-8') == "[]":
+        pytest.skip("Error injection not enabled in Scylla - try compiling in dev/debug/sanitize mode")
+    try:
+        yield
+    finally:
+        print("Disabling error injection", err)
+        response = requests.delete(f'{url}/v2/error_injection/injection/{err}')


### PR DESCRIPTION
DynamoDB protocol specifies that when getting items in a batch
failed only partially, unprocessed keys can be returned so that
the user can perform a retry.
Alternator used to fail the whole request if any of the reads failed,
but right now it instead produces the list of unprocessed keys
and returns them to the user, as long as at least 1 read was
successful.

This series comes with a test based on Scylla's error injection mechanism, and thus is only useful in modes which come with error injection compiled in. In release mode, expect to see the following message:
SKIPPED (Error injection not enabled in Scylla - try compiling in dev/debug/sanitize mode)

Fixes #9984