### PR TITLE
Alternator TTL improvements

### DIFF
--- a/alternator/ttl.cc
+++ b/alternator/ttl.cc
@@ -507,6 +507,8 @@ struct scan_ranges_context {
         selection = cql3::selection::selection::wildcard(s);
         query::partition_slice::option_set opts = selection->get_query_options();
         opts.set<query::partition_slice::option::allow_short_read>();
+        // It is important that the scan bypass cache to avoid polluting it:
+        opts.set<query::partition_slice::option::bypass_cache>();
         std::vector<query::clustering_range> ck_bounds{query::clustering_range::make_open_ended_both_sides()};
         auto partition_slice = query::partition_slice(std::move(ck_bounds), {}, std::move(regular_columns), opts);
         command = ::make_lw_shared<query::read_command>(s->id(), s->version(), partition_slice, proxy.get_max_result_size(partition_slice));

--- a/alternator/ttl.cc
+++ b/alternator/ttl.cc
@@ -13,6 +13,7 @@
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/sleep.hh>
 #include <seastar/core/future.hh>
+#include <seastar/core/lowres_clock.hh>
 #include <seastar/coroutine/maybe_yield.hh>
 #include <boost/multiprecision/cpp_int.hpp>
 
@@ -44,6 +45,7 @@
 #include "alternator/controller.hh"
 #include "alternator/serialization.hh"
 #include "dht/sharder.hh"
+#include "db/config.hh"
 
 #include "ttl.hh"
 
@@ -609,7 +611,7 @@ static future<> scan_table_ranges(
     }
 }
 
-// scan_table() scans data in one table "owned" by this shard, looking for
+// scan_table() scans, in one table, data "owned" by this shard, looking for
 // expired items and deleting them.
 // We consider each node to "own" its primary token ranges, i.e., the tokens
 // that this node is their first replica in the ring. Inside the node, each
@@ -637,6 +639,7 @@ static future<bool> scan_table(
 {
     // Check if an expiration-time attribute is enabled for this table.
     // If not, just return false immediately.
+    // FIXME: the setting of the TTL may change in the middle of a long scan!
     std::optional<std::string> attribute_name = find_tag(*s, TTL_TAG_KEY);
     if (!attribute_name) {
         co_return false;
@@ -719,6 +722,7 @@ future<> expiration_service::run() {
     // also need to notice when a new table is added, a table is
     // deleted or when ttl is enabled or disabled for a table!
     for (;;) {
+        auto start = lowres_clock::now();
         // _db.tables() may change under our feet during a
         // long-living loop, so we must keep our own copy of the list of
         // schemas.
@@ -751,10 +755,20 @@ future<> expiration_service::run() {
                 }
             }
         }
-        // FIXME: replace this silly 1-second sleep by something smarter.
-        try {
-            co_await seastar::sleep_abortable(std::chrono::seconds(1), _abort_source);
-        } catch(seastar::sleep_aborted&) {}
+        // The TTL scanner runs above once over all tables, at full steam.
+        // After completing such a scan, we sleep until it's time start
+        // another scan. TODO: If the scan went too fast, we can slow it down
+        // in the next iteration by reducing the scanner's scheduling-group
+        // share (if using a separate scheduling group), or introduce
+        // finer-grain sleeps into the scanning code.
+        std::chrono::seconds scan_duration(std::chrono::duration_cast<std::chrono::seconds>(lowres_clock::now() - start));
+        std::chrono::seconds period(_db.get_config().alternator_ttl_period_in_seconds());
+        if (scan_duration < period) {
+            try {
+                tlogger.info("sleeping {} seconds until next period", (period - scan_duration).count());
+                co_await seastar::sleep_abortable(period - scan_duration, _abort_source);
+            } catch(seastar::sleep_aborted&) {}
+        }
     }
 }
 

--- a/db/config.cc
+++ b/db/config.cc
@@ -863,6 +863,9 @@ db::config::config(std::shared_ptr<db::extensions> exts)
     , alternator_streams_time_window_s(this, "alternator_streams_time_window_s", value_status::Used, 10, "CDC query confidence window for alternator streams")
     , alternator_timeout_in_ms(this, "alternator_timeout_in_ms", value_status::Used, 10000,
         "The server-side timeout for completing Alternator API requests.")
+    , alternator_ttl_period_in_seconds(this, "alternator_ttl_period_in_seconds", value_status::Used,
+        60*60*24,
+        "The default period for Alternator's expiration scan. Alternator attempts to scan every table within that period.")
     , abort_on_ebadf(this, "abort_on_ebadf", value_status::Used, true, "Abort the server on incorrect file descriptor access. Throws exception when disabled.")
     , redis_port(this, "redis_port", value_status::Used, 0, "Port on which the REDIS transport listens for clients.")
     , redis_ssl_port(this, "redis_ssl_port", value_status::Used, 0, "Port on which the REDIS TLS native transport listens for clients.")

--- a/db/config.hh
+++ b/db/config.hh
@@ -349,6 +349,7 @@ public:
     named_value<sstring> alternator_write_isolation;
     named_value<uint32_t> alternator_streams_time_window_s;
     named_value<uint32_t> alternator_timeout_in_ms;
+    named_value<uint32_t> alternator_ttl_period_in_seconds;
 
     named_value<bool> abort_on_ebadf;
 

--- a/docs/alternator/compatibility.md
+++ b/docs/alternator/compatibility.md
@@ -108,8 +108,21 @@ they should be easy to detect. Here is a list of these unimplemented features:
   are projected. This wastes some disk space when it is not needed.
   https://github.com/scylladb/scylla/issues/5036
 
-* DynamoDB's TTL (per-item expiration) feature is not supported. Note that
-  this is a different feature from Scylla's feature with the same name.
+* DynamoDB's TTL (item expiration) feature is supported, but in this release
+  still considered experimental and needs to be enabled explicitly with the
+  `--experimental-features=alternator-ttl` configuration option.
+  The experimental implementation is mostly complete, but not throughly
+  tested or optimized.
+  Like in DynamoDB, Alternator items which are set to expire at a certain
+  time will not disappear exactly at that time, but only after some delay.
+  DynamoDB guarantees that the expiration delay will be less than 48 hours
+  (though for small tables the delay is often much shorter). In Alternator,
+  the expiration delay is configurable - it defaults to 24 hours but can
+  be set with the `--alternator-ttl-period-in-seconds` configuration option.
+
+  One thing that this implementation is still missing is that expiration
+  events appear in the Streams API as normal deletions - without the
+  distinctive marker on deletions which are really expirations.
   https://github.com/scylladb/scylla/issues/5060
 
 * DynamoDB's new multi-item transaction feature (TransactWriteItems,

--- a/test/alternator/run
+++ b/test/alternator/run
@@ -43,6 +43,7 @@ def run_alternator_cmd(pid, dir):
         '--alternator-write-isolation', 'always_use_lwt',
         '--alternator-streams-time-window-s', '0',
         '--alternator-timeout-in-ms', '30000',
+        '--alternator-ttl-period-in-seconds', '1',
         # Allow testing experimental features. Following issue #9467, we need
         # to add here specific experimental features as they are introduced.
         # We only list here Alternator-specific experimental features - CQL


### PR DESCRIPTION
This small series continues to improve the Alternator TTL implementation:

1. Instead of repeating the full scan one second after the previous finished, we now add an option `--alternator-ttl-period-in-seconds` that controls how frequently the scan is started - e.g., maybe just once per 24 hours (this is the new default). Note that the expiration scan still runs at a fixed pace in the "management" scheduling group and may finish in less than 24 hours, in which case we just sleep until the next scan. We could later run the expiration scanner in a separate scheduling group and play with its shares - or find a different way to slow the scan - but this isn't done yet in this patch.

2. Bypass the cache when scanning the tables for expired items - to not stuff the cache with data the user doesn't access.

3. Update compatibility.md, which claims we have no TTL support at all, with a more optimistic representation of what we actually have now.