### PR TITLE
alternator: migrate expression parsers to string_view

### DIFF
--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -1565,7 +1565,7 @@ static parsed::condition_expression get_parsed_condition_expression(rjson::value
         throw api_error::validation("ConditionExpression must not be empty");
     }
     try {
-        return parse_condition_expression(condition_expression->GetString());
+        return parse_condition_expression(rjson::to_string_view(*condition_expression));
     } catch(expressions_syntax_error& e) {
         throw api_error::validation(e.what());
     }
@@ -2179,7 +2179,7 @@ static attrs_to_get calculate_attrs_to_get(const rjson::value& req, std::unorder
         const rjson::value* expression_attribute_names = rjson::find(req, "ExpressionAttributeNames");
         std::vector<parsed::path> paths_to_get;
         try {
-            paths_to_get = parse_projection_expression(projection_expression.GetString());
+            paths_to_get = parse_projection_expression(rjson::to_string_view(projection_expression));
         } catch(expressions_syntax_error& e) {
             throw api_error::validation(e.what());
         }
@@ -2360,7 +2360,7 @@ update_item_operation::update_item_operation(service::storage_proxy& proxy, rjso
             throw api_error::validation("UpdateExpression must be a string");
         }
         try {
-            parsed::update_expression expr = parse_update_expression(update_expression->GetString());
+            parsed::update_expression expr = parse_update_expression(rjson::to_string_view(*update_expression));
             resolve_update_expression(expr,
                     expression_attribute_names, expression_attribute_values,
                     used_attribute_names, used_attribute_values);
@@ -3265,9 +3265,7 @@ filter::filter(const rjson::value& request, request_type rt,
             throw api_error::validation("Cannot use both old-style and new-style parameters in same request: FilterExpression and AttributesToGet");
         }
         try {
-            // FIXME: make parse_condition_expression take string_view, get
-            // rid of the silly conversion to std::string.
-            auto parsed = parse_condition_expression(std::string(rjson::to_string_view(*expression)));
+            auto parsed = parse_condition_expression(rjson::to_string_view(*expression));
             const rjson::value* expression_attribute_names = rjson::find(request, "ExpressionAttributeNames");
             const rjson::value* expression_attribute_values = rjson::find(request, "ExpressionAttributeValues");
             resolve_condition_expression(parsed,
@@ -3871,7 +3869,7 @@ calculate_bounds_condition_expression(schema_ptr schema,
     // sort-key range.
     parsed::condition_expression p;
     try {
-        p = parse_condition_expression(std::string(rjson::to_string_view(expression)));
+        p = parse_condition_expression(rjson::to_string_view(expression));
     } catch(expressions_syntax_error& e) {
         throw api_error::validation(e.what());
     }

--- a/alternator/expressions.cc
+++ b/alternator/expressions.cc
@@ -29,7 +29,7 @@
 namespace alternator {
 
 template <typename Func, typename Result = std::result_of_t<Func(expressionsParser&)>>
-Result do_with_parser(std::string input, Func&& f) {
+Result do_with_parser(std::string_view input, Func&& f) {
     expressionsLexer::InputStreamType input_stream{
         reinterpret_cast<const ANTLR_UINT8*>(input.data()),
         ANTLR_ENC_UTF8,
@@ -44,7 +44,7 @@ Result do_with_parser(std::string input, Func&& f) {
 }
 
 parsed::update_expression
-parse_update_expression(std::string query) {
+parse_update_expression(std::string_view query) {
     try {
         return do_with_parser(query,  std::mem_fn(&expressionsParser::update_expression));
     } catch (...) {
@@ -53,7 +53,7 @@ parse_update_expression(std::string query) {
 }
 
 std::vector<parsed::path>
-parse_projection_expression(std::string query) {
+parse_projection_expression(std::string_view query) {
     try {
         return do_with_parser(query,  std::mem_fn(&expressionsParser::projection_expression));
     } catch (...) {
@@ -62,7 +62,7 @@ parse_projection_expression(std::string query) {
 }
 
 parsed::condition_expression
-parse_condition_expression(std::string query) {
+parse_condition_expression(std::string_view query) {
     try {
         return do_with_parser(query,  std::mem_fn(&expressionsParser::condition_expression));
     } catch (...) {

--- a/alternator/expressions.hh
+++ b/alternator/expressions.hh
@@ -26,9 +26,9 @@ public:
     using runtime_error::runtime_error;
 };
 
-parsed::update_expression parse_update_expression(std::string query);
-std::vector<parsed::path> parse_projection_expression(std::string query);
-parsed::condition_expression parse_condition_expression(std::string query);
+parsed::update_expression parse_update_expression(std::string_view query);
+std::vector<parsed::path> parse_projection_expression(std::string_view query);
+parsed::condition_expression parse_condition_expression(std::string_view query);
 
 void resolve_update_expression(parsed::update_expression& ue,
         const rjson::value* expression_attribute_names,


### PR DESCRIPTION
Following the advice in the FIXME note, helper functions for parsing
expressions are now based on string views to avoid a few unnecessary
conversions to std::string.

Tests: unit(dev)