### PR TITLE
Propagate coordinator timeouts for regular writes and batches without throwing

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -501,6 +501,7 @@ scylla_tests = set([
     'test/boost/schema_loader_test',
     'test/boost/lister_test',
     'test/boost/group0_test',
+    'test/boost/exception_container_test',
     'test/manual/ec2_snitch_test',
     'test/manual/enormous_table_scan_test',
     'test/manual/gce_snitch_test',

--- a/configure.py
+++ b/configure.py
@@ -502,6 +502,7 @@ scylla_tests = set([
     'test/boost/lister_test',
     'test/boost/group0_test',
     'test/boost/exception_container_test',
+    'test/boost/result_utils_test',
     'test/manual/ec2_snitch_test',
     'test/manual/enormous_table_scan_test',
     'test/manual/gce_snitch_test',

--- a/cql3/cql_statement.hh
+++ b/cql3/cql_statement.hh
@@ -75,11 +75,28 @@ public:
     /**
      * Execute the statement and return the resulting result or null if there is no result.
      *
+     * In case of a failure, it must return an exceptional future. It must not use
+     * the result_message::exception to indicate failure.
+     *
      * @param state the current query state
      * @param options options for this query (consistency, variables, pageSize, ...)
      */
     virtual seastar::future<seastar::shared_ptr<cql_transport::messages::result_message>>
         execute(query_processor& qp, service::query_state& state, const query_options& options) const = 0;
+
+    /**
+     * Execute the statement and return the resulting result or null if there is no result.
+     *
+     * Unlike execute(), it is allowed to return a result_message::exception which contains
+     * an exception that needs to be explicitly handled.
+     *
+     * @param state the current query state
+     * @param options options for this query (consistency, variables, pageSize, ...)
+     */
+    virtual seastar::future<seastar::shared_ptr<cql_transport::messages::result_message>>
+            execute_without_checking_exception_message(query_processor& qp, service::query_state& state, const query_options& options) const {
+        return execute(qp, state, options);
+    }
 
     virtual bool depends_on_keyspace(const seastar::sstring& ks_name) const = 0;
 

--- a/cql3/query_processor.cc
+++ b/cql3/query_processor.cc
@@ -462,7 +462,7 @@ future<> query_processor::stop() {
 }
 
 future<::shared_ptr<result_message>>
-query_processor::execute_direct(const sstring_view& query_string, service::query_state& query_state, query_options& options) {
+query_processor::execute_direct_without_checking_exception_message(const sstring_view& query_string, service::query_state& query_state, query_options& options) {
     log.trace("execute_direct: \"{}\"", query_string);
     tracing::trace(query_state.get_trace_state(), "Parsing a statement");
     auto p = get_statement(query_string, query_state.get_client_state());
@@ -495,7 +495,7 @@ query_processor::execute_direct(const sstring_view& query_string, service::query
 }
 
 future<::shared_ptr<result_message>>
-query_processor::execute_prepared(
+query_processor::execute_prepared_without_checking_exception_message(
         statements::prepared_statement::checked_weak_ptr prepared,
         cql3::prepared_cache_key_type cache_key,
         service::query_state& query_state,
@@ -526,7 +526,7 @@ query_processor::process_authorized_statement(const ::shared_ptr<cql_statement> 
 
     statement->validate(*this, client_state);
 
-    auto fut = statement->execute(*this, query_state, options);
+    auto fut = statement->execute_without_checking_exception_message(*this, query_state, options);
 
     return fut.then([statement] (auto msg) {
         if (msg) {
@@ -849,7 +849,7 @@ query_processor::execute_with_params(
 }
 
 future<::shared_ptr<cql_transport::messages::result_message>>
-query_processor::execute_batch(
+query_processor::execute_batch_without_checking_exception_message(
         ::shared_ptr<statements::batch_statement> batch,
         service::query_state& query_state,
         query_options& options,

--- a/cql3/statements/batch_statement.cc
+++ b/cql3/statements/batch_statement.cc
@@ -24,6 +24,9 @@
 #include <boost/algorithm/cxx11/all_of.hpp>
 #include <boost/range/adaptor/uniqued.hpp>
 
+template<typename T = void>
+using coordinator_result = exceptions::coordinator_result<T>;
+
 namespace cql3 {
 
 namespace statements {
@@ -242,6 +245,12 @@ static thread_local inheriting_concrete_execution_stage<
 
 future<shared_ptr<cql_transport::messages::result_message>> batch_statement::execute(
         query_processor& qp, service::query_state& state, const query_options& options) const {
+    return execute_without_checking_exception_message(qp, state, options)
+            .then(cql_transport::messages::propagate_exception_as_future<shared_ptr<cql_transport::messages::result_message>>);
+}
+
+future<shared_ptr<cql_transport::messages::result_message>> batch_statement::execute_without_checking_exception_message(
+        query_processor& qp, service::query_state& state, const query_options& options) const {
     cql3::util::validate_timestamp(options, _attrs);
     return batch_stage(this, seastar::ref(qp), seastar::ref(state),
                        seastar::cref(options), false, options.get_timestamp(state));
@@ -272,13 +281,17 @@ future<shared_ptr<cql_transport::messages::result_message>> batch_statement::do_
     return get_mutations(qp, options, timeout, local, now, query_state).then([this, &qp, &options, timeout, tr_state = query_state.get_trace_state(),
                                                                                                                                permit = query_state.get_permit()] (std::vector<mutation> ms) mutable {
         return execute_without_conditions(qp, std::move(ms), options.get_consistency(), timeout, std::move(tr_state), std::move(permit));
-    }).then([] {
+    }).then([] (coordinator_result<> res) {
+        if (!res) {
+            return make_ready_future<shared_ptr<cql_transport::messages::result_message>>(
+                    seastar::make_shared<cql_transport::messages::result_message::exception>(std::move(res).assume_error()));
+        }
         return make_ready_future<shared_ptr<cql_transport::messages::result_message>>(
                 make_shared<cql_transport::messages::result_message::void_message>());
     });
 }
 
-future<> batch_statement::execute_without_conditions(
+future<coordinator_result<>> batch_statement::execute_without_conditions(
         query_processor& qp,
         std::vector<mutation> mutations,
         db::consistency_level cl,
@@ -311,8 +324,7 @@ future<> batch_statement::execute_without_conditions(
             mutate_atomic = false;
         }
     }
-    return qp.proxy().mutate_with_triggers(std::move(mutations), cl, timeout, mutate_atomic, std::move(tr_state), std::move(permit))
-            .then(utils::result_into_future<exceptions::coordinator_result<>>);
+    return qp.proxy().mutate_with_triggers(std::move(mutations), cl, timeout, mutate_atomic, std::move(tr_state), std::move(permit));
 }
 
 future<shared_ptr<cql_transport::messages::result_message>> batch_statement::execute_with_conditions(

--- a/cql3/statements/batch_statement.cc
+++ b/cql3/statements/batch_statement.cc
@@ -311,7 +311,8 @@ future<> batch_statement::execute_without_conditions(
             mutate_atomic = false;
         }
     }
-    return qp.proxy().mutate_with_triggers(std::move(mutations), cl, timeout, mutate_atomic, std::move(tr_state), std::move(permit));
+    return qp.proxy().mutate_with_triggers(std::move(mutations), cl, timeout, mutate_atomic, std::move(tr_state), std::move(permit))
+            .then(utils::result_into_future<exceptions::coordinator_result<>>);
 }
 
 future<shared_ptr<cql_transport::messages::result_message>> batch_statement::execute_with_conditions(

--- a/cql3/statements/batch_statement.hh
+++ b/cql3/statements/batch_statement.hh
@@ -15,6 +15,7 @@
 #include "timestamp.hh"
 #include "log.hh"
 #include "service_permit.hh"
+#include "exceptions/exceptions.hh"
 
 namespace cql_transport::messages {
     class result_message;
@@ -121,6 +122,9 @@ public:
 
     virtual future<shared_ptr<cql_transport::messages::result_message>> execute(
             query_processor& qp, service::query_state& state, const query_options& options) const override;
+
+    virtual future<shared_ptr<cql_transport::messages::result_message>> execute_without_checking_exception_message(
+            query_processor& qp, service::query_state& state, const query_options& options) const override;
 private:
     friend class batch_statement_executor;
     future<shared_ptr<cql_transport::messages::result_message>> do_execute(
@@ -128,7 +132,7 @@ private:
             service::query_state& query_state, const query_options& options,
             bool local, api::timestamp_type now) const;
 
-    future<> execute_without_conditions(
+    future<exceptions::coordinator_result<>> execute_without_conditions(
             query_processor& qp,
             std::vector<mutation> mutations,
             db::consistency_level cl,

--- a/cql3/statements/modification_statement.cc
+++ b/cql3/statements/modification_statement.cc
@@ -274,7 +274,8 @@ modification_statement::execute_without_condition(query_processor& qp, service::
             return now();
         }
         
-        return qp.proxy().mutate_with_triggers(std::move(mutations), cl, timeout, false, qs.get_trace_state(), qs.get_permit(), this->is_raw_counter_shard_write());
+        return qp.proxy().mutate_with_triggers(std::move(mutations), cl, timeout, false, qs.get_trace_state(), qs.get_permit(), this->is_raw_counter_shard_write())
+                .then(utils::result_into_future<exceptions::coordinator_result<>>);;
     });
 }
 

--- a/cql3/statements/modification_statement.cc
+++ b/cql3/statements/modification_statement.cc
@@ -33,6 +33,9 @@
 #include "cql3/query_processor.hh"
 #include "service/storage_proxy.hh"
 
+template<typename T = void>
+using coordinator_result = exceptions::coordinator_result<T>;
+
 bool is_internal_keyspace(std::string_view name);
 
 namespace cql3 {
@@ -241,6 +244,12 @@ static thread_local inheriting_concrete_execution_stage<
 
 future<::shared_ptr<cql_transport::messages::result_message>>
 modification_statement::execute(query_processor& qp, service::query_state& qs, const query_options& options) const {
+    return execute_without_checking_exception_message(qp, qs, options)
+            .then(cql_transport::messages::propagate_exception_as_future<shared_ptr<cql_transport::messages::result_message>>);
+}
+
+future<::shared_ptr<cql_transport::messages::result_message>>
+modification_statement::execute_without_checking_exception_message(query_processor& qp, service::query_state& qs, const query_options& options) const {
     cql3::util::validate_timestamp(options, attrs);
     return modify_stage(this, seastar::ref(qp), seastar::ref(qs), seastar::cref(options));
 }
@@ -259,23 +268,26 @@ modification_statement::do_execute(query_processor& qp, service::query_state& qs
         return execute_with_condition(qp, qs, options);
     }
 
-    return execute_without_condition(qp, qs, options).then([] {
+    return execute_without_condition(qp, qs, options).then([] (coordinator_result<> res) {
+        if (!res) {
+            return make_ready_future<::shared_ptr<cql_transport::messages::result_message>>(
+                    seastar::make_shared<cql_transport::messages::result_message::exception>(std::move(res).assume_error()));
+        }
         return make_ready_future<::shared_ptr<cql_transport::messages::result_message>>(
                 ::shared_ptr<cql_transport::messages::result_message>{});
     });
 }
 
-future<>
+future<coordinator_result<>>
 modification_statement::execute_without_condition(query_processor& qp, service::query_state& qs, const query_options& options) const {
     auto cl = options.get_consistency();
     auto timeout = db::timeout_clock::now() + get_timeout(qs.get_client_state(), options);
     return get_mutations(qp, options, timeout, false, options.get_timestamp(qs), qs).then([this, cl, timeout, &qp, &qs] (auto mutations) {
         if (mutations.empty()) {
-            return now();
+            return make_ready_future<coordinator_result<>>(bo::success());
         }
         
-        return qp.proxy().mutate_with_triggers(std::move(mutations), cl, timeout, false, qs.get_trace_state(), qs.get_permit(), this->is_raw_counter_shard_write())
-                .then(utils::result_into_future<exceptions::coordinator_result<>>);;
+        return qp.proxy().mutate_with_triggers(std::move(mutations), cl, timeout, false, qs.get_trace_state(), qs.get_permit(), this->is_raw_counter_shard_write());
     });
 }
 

--- a/cql3/statements/modification_statement.hh
+++ b/cql3/statements/modification_statement.hh
@@ -21,6 +21,7 @@
 #include "cql3/relation.hh"
 #include "cql3/restrictions/statement_restrictions.hh"
 #include "cql3/statements/statement_type.hh"
+#include "exceptions/exceptions.hh"
 
 #include <seastar/core/shared_ptr.hh>
 
@@ -236,8 +237,11 @@ public:
     virtual future<::shared_ptr<cql_transport::messages::result_message>>
     execute(query_processor& qp, service::query_state& qs, const query_options& options) const override;
 
+    virtual future<::shared_ptr<cql_transport::messages::result_message>>
+    execute_without_checking_exception_message(query_processor& qp, service::query_state& qs, const query_options& options) const override;
+
 private:
-    future<>
+    future<exceptions::coordinator_result<>>
     execute_without_condition(query_processor& qp, service::query_state& qs, const query_options& options) const;
 
     future<::shared_ptr<cql_transport::messages::result_message>>

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -53,6 +53,7 @@
 #include <boost/range/algorithm/transform.hpp>
 #include <boost/range/algorithm/partition.hpp>
 #include <boost/intrusive/list.hpp>
+#include <boost/outcome/result.hpp>
 #include "utils/latency.hh"
 #include "schema.hh"
 #include "schema_registry.hh"
@@ -88,8 +89,12 @@
 #include "idl/frozen_schema.dist.hh"
 #include "idl/frozen_schema.dist.impl.hh"
 #include "idl/storage_proxy.dist.hh"
+#include "utils/result.hh"
 
 namespace bi = boost::intrusive;
+
+template<typename T = void>
+using result = service::storage_proxy::result<T>;
 
 namespace service {
 

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -2409,16 +2409,16 @@ storage_proxy::mutate_internal(Range mutations, db::consistency_level cl, bool c
     });
 }
 
-future<>
+future<result<>>
 storage_proxy::mutate_with_triggers(std::vector<mutation> mutations, db::consistency_level cl,
     clock_type::time_point timeout,
     bool should_mutate_atomically, tracing::trace_state_ptr tr_state, service_permit permit, bool raw_counters) {
     warn(unimplemented::cause::TRIGGERS);
     if (should_mutate_atomically) {
         assert(!raw_counters);
-        return mutate_atomically(std::move(mutations), cl, timeout, std::move(tr_state), std::move(permit));
+        return mutate_atomically_result(std::move(mutations), cl, timeout, std::move(tr_state), std::move(permit));
     }
-    return mutate(std::move(mutations), cl, timeout, std::move(tr_state), std::move(permit), raw_counters);
+    return mutate_result(std::move(mutations), cl, timeout, std::move(tr_state), std::move(permit), raw_counters);
 }
 
 /**

--- a/service/storage_proxy.hh
+++ b/service/storage_proxy.hh
@@ -44,6 +44,7 @@
 #include "service/endpoint_lifecycle_subscriber.hh"
 #include <seastar/core/circular_buffer.hh>
 #include "query_ranges_to_vnodes.hh"
+#include "exceptions/exceptions.hh"
 
 class reconcilable_result;
 class frozen_mutation_and_schema;
@@ -123,6 +124,8 @@ public:
         TIMEOUT,
         FAILURE,
     };
+    template<typename T = void>
+    using result = exceptions::coordinator_result<T>;
     using clock_type = lowres_clock;
     struct config {
         db::hints::host_filter hinted_handoff_enabled = {};

--- a/service/storage_proxy.hh
+++ b/service/storage_proxy.hh
@@ -254,7 +254,7 @@ private:
     seastar::metrics::metric_groups _metrics;
     uint64_t _background_write_throttle_threahsold;
     inheriting_concrete_execution_stage<
-            future<>,
+            future<result<>>,
             storage_proxy*,
             std::vector<mutation>,
             db::consistency_level,
@@ -396,7 +396,7 @@ private:
 
     gms::inet_address find_leader_for_counter_update(const mutation& m, db::consistency_level cl);
 
-    future<> do_mutate(std::vector<mutation> mutations, db::consistency_level cl, clock_type::time_point timeout, tracing::trace_state_ptr tr_state, service_permit permit, bool, lw_shared_ptr<cdc::operation_result_tracker> cdc_tracker);
+    future<result<>> do_mutate(std::vector<mutation> mutations, db::consistency_level cl, clock_type::time_point timeout, tracing::trace_state_ptr tr_state, service_permit permit, bool, lw_shared_ptr<cdc::operation_result_tracker> cdc_tracker);
 
     future<> send_to_endpoint(
             std::unique_ptr<mutation_holder> m,
@@ -503,6 +503,13 @@ public:
     * @param tr_state trace state handle
     */
     future<> mutate(std::vector<mutation> mutations, db::consistency_level cl, clock_type::time_point timeout, tracing::trace_state_ptr tr_state, service_permit permit, bool raw_counters = false);
+
+    /**
+    * See mutate. Does the same, but returns some exceptions
+    * through the result<>, which allows for efficient inspection
+    * of the exception on the exception handling path.
+    */
+    future<result<>> mutate_result(std::vector<mutation> mutations, db::consistency_level cl, clock_type::time_point timeout, tracing::trace_state_ptr tr_state, service_permit permit, bool raw_counters = false);
 
     paxos_participants
     get_paxos_participants(const sstring& ks_name, const dht::token& token, db::consistency_level consistency_for_paxos);

--- a/service/storage_proxy.hh
+++ b/service/storage_proxy.hh
@@ -299,7 +299,7 @@ private:
     void remove_response_handler_entry(response_handlers_map::iterator entry);
     void got_response(response_id_type id, gms::inet_address from, std::optional<db::view::update_backlog> backlog);
     void got_failure_response(response_id_type id, gms::inet_address from, size_t count, std::optional<db::view::update_backlog> backlog, error err, std::optional<sstring> msg);
-    future<> response_wait(response_id_type id, clock_type::time_point timeout);
+    future<result<>> response_wait(response_id_type id, clock_type::time_point timeout);
     ::shared_ptr<abstract_write_response_handler>& get_write_response_handler(storage_proxy::response_id_type id);
     response_id_type create_write_response_handler_helper(schema_ptr s, const dht::token& token,
             std::unique_ptr<mutation_holder> mh, db::consistency_level cl, db::write_type type, tracing::trace_state_ptr tr_state,
@@ -374,7 +374,7 @@ private:
     future<unique_response_handler_vector> mutate_prepare(Range&& mutations, db::consistency_level cl, db::write_type type, service_permit permit, CreateWriteHandler handler);
     template<typename Range>
     future<unique_response_handler_vector> mutate_prepare(Range&& mutations, db::consistency_level cl, db::write_type type, tracing::trace_state_ptr tr_state, service_permit permit);
-    future<> mutate_begin(unique_response_handler_vector ids, db::consistency_level cl, tracing::trace_state_ptr trace_state, std::optional<clock_type::time_point> timeout_opt = { });
+    future<result<>> mutate_begin(unique_response_handler_vector ids, db::consistency_level cl, tracing::trace_state_ptr trace_state, std::optional<clock_type::time_point> timeout_opt = { });
     future<> mutate_end(future<> mutate_result, utils::latency_counter, write_stats& stats, tracing::trace_state_ptr trace_state);
     future<> schedule_repair(std::unordered_map<dht::token, std::unordered_map<gms::inet_address, std::optional<mutation>>> diffs, db::consistency_level cl, tracing::trace_state_ptr trace_state, service_permit permit);
     bool need_throttle_writes() const;

--- a/service/storage_proxy.hh
+++ b/service/storage_proxy.hh
@@ -381,7 +381,7 @@ private:
     void unthrottle();
     void handle_read_error(std::exception_ptr eptr, bool range);
     template<typename Range>
-    future<> mutate_internal(Range mutations, db::consistency_level cl, bool counter_write, tracing::trace_state_ptr tr_state, service_permit permit, std::optional<clock_type::time_point> timeout_opt = { }, lw_shared_ptr<cdc::operation_result_tracker> cdc_tracker = { });
+    future<result<>> mutate_internal(Range mutations, db::consistency_level cl, bool counter_write, tracing::trace_state_ptr tr_state, service_permit permit, std::optional<clock_type::time_point> timeout_opt = { }, lw_shared_ptr<cdc::operation_result_tracker> cdc_tracker = { });
     future<rpc::tuple<foreign_ptr<lw_shared_ptr<reconcilable_result>>, cache_temperature>> query_nonsingular_mutations_locally(
             schema_ptr s, lw_shared_ptr<query::read_command> cmd, const dht::partition_range_vector&& pr, tracing::trace_state_ptr trace_state,
             clock_type::time_point timeout);

--- a/service/storage_proxy.hh
+++ b/service/storage_proxy.hh
@@ -532,6 +532,13 @@ public:
     */
     future<> mutate_atomically(std::vector<mutation> mutations, db::consistency_level cl, clock_type::time_point timeout, tracing::trace_state_ptr tr_state, service_permit permit);
 
+    /**
+    * See mutate_atomically. Does the same, but returns some exceptions
+    * through the result<>, which allows for efficient inspection
+    * of the exception on the exception handling path.
+    */
+    future<result<>> mutate_atomically_result(std::vector<mutation> mutations, db::consistency_level cl, clock_type::time_point timeout, tracing::trace_state_ptr tr_state, service_permit permit);
+
     future<> send_hint_to_all_replicas(frozen_mutation_and_schema fm_a_s);
 
     // Send a mutation to one specific remote target.

--- a/service/storage_proxy.hh
+++ b/service/storage_proxy.hh
@@ -517,8 +517,8 @@ public:
     future<> replicate_counter_from_leader(mutation m, db::consistency_level cl, tracing::trace_state_ptr tr_state,
                                            clock_type::time_point timeout, service_permit permit);
 
-    future<> mutate_with_triggers(std::vector<mutation> mutations, db::consistency_level cl, clock_type::time_point timeout,
-                                  bool should_mutate_atomically, tracing::trace_state_ptr tr_state, service_permit permit, bool raw_counters = false);
+    future<result<>> mutate_with_triggers(std::vector<mutation> mutations, db::consistency_level cl, clock_type::time_point timeout,
+                                          bool should_mutate_atomically, tracing::trace_state_ptr tr_state, service_permit permit, bool raw_counters = false);
 
     /**
     * See mutate. Adds additional steps before and after writing a batch.

--- a/service/storage_proxy.hh
+++ b/service/storage_proxy.hh
@@ -375,7 +375,7 @@ private:
     template<typename Range>
     future<unique_response_handler_vector> mutate_prepare(Range&& mutations, db::consistency_level cl, db::write_type type, tracing::trace_state_ptr tr_state, service_permit permit);
     future<result<>> mutate_begin(unique_response_handler_vector ids, db::consistency_level cl, tracing::trace_state_ptr trace_state, std::optional<clock_type::time_point> timeout_opt = { });
-    future<> mutate_end(future<> mutate_result, utils::latency_counter, write_stats& stats, tracing::trace_state_ptr trace_state);
+    future<> mutate_end(future<result<>> mutate_result, utils::latency_counter, write_stats& stats, tracing::trace_state_ptr trace_state);
     future<> schedule_repair(std::unordered_map<dht::token, std::unordered_map<gms::inet_address, std::optional<mutation>>> diffs, db::consistency_level cl, tracing::trace_state_ptr trace_state, service_permit permit);
     bool need_throttle_writes() const;
     void unthrottle();

--- a/service/storage_proxy.hh
+++ b/service/storage_proxy.hh
@@ -375,7 +375,7 @@ private:
     template<typename Range>
     future<unique_response_handler_vector> mutate_prepare(Range&& mutations, db::consistency_level cl, db::write_type type, tracing::trace_state_ptr tr_state, service_permit permit);
     future<result<>> mutate_begin(unique_response_handler_vector ids, db::consistency_level cl, tracing::trace_state_ptr trace_state, std::optional<clock_type::time_point> timeout_opt = { });
-    future<> mutate_end(future<result<>> mutate_result, utils::latency_counter, write_stats& stats, tracing::trace_state_ptr trace_state);
+    future<result<>> mutate_end(future<result<>> mutate_result, utils::latency_counter, write_stats& stats, tracing::trace_state_ptr trace_state);
     future<> schedule_repair(std::unordered_map<dht::token, std::unordered_map<gms::inet_address, std::optional<mutation>>> diffs, db::consistency_level cl, tracing::trace_state_ptr trace_state, service_permit permit);
     bool need_throttle_writes() const;
     void unthrottle();

--- a/test/boost/cql_functions_test.cc
+++ b/test/boost/cql_functions_test.cc
@@ -66,6 +66,7 @@ SEASTAR_TEST_CASE(test_functions) {
                     }
                 }
                 virtual void visit(const result_message::bounce_to_shard& rows) override { throw "bad"; }
+                virtual void visit(const result_message::exception&) override { throw "bad"; }
             };
             validator v;
             msg->accept(v);

--- a/test/boost/exception_container_test.cc
+++ b/test/boost/exception_container_test.cc
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2022-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#include <stdexcept>
+#include "utils/exception_container.hh"
+
+#include <seastar/testing/test_case.hh>
+#include <seastar/core/sstring.hh>
+
+using namespace seastar;
+
+class foo_exception : public std::exception {
+public:
+    const char* what() const noexcept override {
+        return "foo";
+    }
+};
+
+class bar_exception : public std::exception {
+public:
+    const char* what() const noexcept override {
+        return "bar";
+    }
+};
+
+using foo_bar_container = utils::exception_container<foo_exception, bar_exception>;
+
+static sstring foo_bar_what(const foo_bar_container& fbc) {
+    return fbc.accept([] (const auto& ex) { return ex.what(); });
+}
+
+SEASTAR_TEST_CASE(test_exception_container) {
+    auto empty = foo_bar_container();
+    auto foo = foo_bar_container(foo_exception());
+    auto bar = foo_bar_container(bar_exception());
+
+    BOOST_REQUIRE(empty.empty());
+    BOOST_REQUIRE(!foo.empty());
+    BOOST_REQUIRE(!bar.empty());
+
+    BOOST_REQUIRE(!empty);
+    BOOST_REQUIRE(foo);
+    BOOST_REQUIRE(bar);
+
+    BOOST_REQUIRE_THROW(foo_bar_what(empty), utils::bad_exception_container_access);
+    BOOST_REQUIRE_EQUAL(foo_bar_what(foo), sstring("foo"));
+    BOOST_REQUIRE_EQUAL(foo_bar_what(bar), sstring("bar"));
+
+    BOOST_REQUIRE_THROW(empty.throw_me(), utils::bad_exception_container_access);
+    BOOST_REQUIRE_THROW(foo.throw_me(), foo_exception);
+    BOOST_REQUIRE_THROW(bar.throw_me(), bar_exception);
+
+    // Construct the futures outside BOOST_REQUIRE_THROW
+    // otherwise the checks would pass if as_exception_future throwed
+    // and we don't want that
+    auto f_empty = empty.as_exception_future();
+    auto f_foo = foo.as_exception_future();
+    auto f_bar = bar.as_exception_future();
+    BOOST_REQUIRE_THROW(f_empty.get(), utils::bad_exception_container_access);
+    BOOST_REQUIRE_THROW(f_foo.get(), foo_exception);
+    BOOST_REQUIRE_THROW(f_bar.get(), bar_exception);
+
+    // Same reasoning as with as_exception_future
+    f_empty = std::move(empty).into_exception_future();
+    f_foo = std::move(foo).into_exception_future();
+    f_bar = std::move(bar).into_exception_future();
+    BOOST_REQUIRE_THROW(f_empty.get(), utils::bad_exception_container_access);
+    BOOST_REQUIRE_THROW(f_foo.get(), foo_exception);
+    BOOST_REQUIRE_THROW(f_bar.get(), bar_exception);
+
+    return make_ready_future<>();
+}

--- a/test/boost/result_utils_test.cc
+++ b/test/boost/result_utils_test.cc
@@ -1,0 +1,127 @@
+/*
+ * Copyright (C) 2022-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#include <vector>
+#include <stdexcept>
+#include "utils/exception_container.hh"
+#include "utils/result.hh"
+
+#include <seastar/testing/test_case.hh>
+#include <seastar/core/sstring.hh>
+#include <seastar/core/map_reduce.hh>
+#include <seastar/testing/thread_test_case.hh>
+
+using namespace seastar;
+
+class foo_exception : public std::exception {
+public:
+    const char* what() const noexcept override {
+        return "foo";
+    }
+};
+
+class bar_exception : public std::exception {
+public:
+    const char* what() const noexcept override {
+        return "bar";
+    }
+};
+
+using exc_container = utils::exception_container<foo_exception, bar_exception>;
+
+template<typename T = void>
+using result = bo::result<T, exc_container,utils::exception_container_throw_policy>;
+
+SEASTAR_TEST_CASE(test_exception_container_throw_policy) {
+    result<> r_ok = bo::success();
+    BOOST_REQUIRE_NO_THROW(r_ok.value());
+    BOOST_REQUIRE_THROW(r_ok.error(), bo::bad_result_access);
+
+    result<> r_err_foo = bo::failure(foo_exception());
+    BOOST_REQUIRE_NO_THROW(r_err_foo.error());
+    BOOST_REQUIRE_THROW(r_err_foo.value(), foo_exception);
+
+    return make_ready_future<>();
+}
+
+SEASTAR_THREAD_TEST_CASE(test_result_into_future) {
+    // T == void
+
+    result<> r_ok = bo::success();
+    auto f_ok = utils::result_into_future(std::move(r_ok));
+    BOOST_REQUIRE_NO_THROW(f_ok.get());
+
+    result<> r_err_foo = bo::failure(foo_exception());
+    auto f_err_foo = utils::result_into_future(std::move(r_err_foo));
+    BOOST_REQUIRE_THROW(f_err_foo.get(), foo_exception);
+
+    // T != void
+
+    result<int> r_ok_int = bo::success();
+    auto f_ok_int = utils::result_into_future(std::move(r_ok_int));
+    BOOST_REQUIRE_NO_THROW(f_ok_int.get());
+
+    result<int> r_err_foo_int = bo::failure(foo_exception());
+    auto f_err_foo_int = utils::result_into_future(std::move(r_err_foo_int));
+    BOOST_REQUIRE_THROW(f_err_foo_int.get(), foo_exception);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_then_ok_result) {
+    auto f_void = utils::then_ok_result<result<>>(make_ready_future<>());
+    BOOST_REQUIRE_NO_THROW(f_void.get().value());
+
+    auto f_int = utils::then_ok_result<result<int>>(make_ready_future<int>(123));
+    BOOST_REQUIRE_EQUAL(f_int.get().value(), 123);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_result_wrap) {
+    int run_count = 0;
+
+    // T == void
+    auto fun_void = utils::result_wrap([&run_count] {
+        ++run_count;
+        return result<>(bo::success());
+    });
+
+    BOOST_REQUIRE_NO_THROW(fun_void(result<>(bo::success())).get().value());
+    BOOST_REQUIRE_EQUAL(run_count, 1);
+
+    BOOST_REQUIRE_THROW(fun_void(result<>(bo::failure(foo_exception()))).get().value(), foo_exception);
+    BOOST_REQUIRE_EQUAL(run_count, 1);
+
+    // T != void
+    auto fun_int = utils::result_wrap([&run_count] (int i) {
+        ++run_count;
+        return result<int>(bo::success(i));
+    });
+
+    BOOST_REQUIRE_EQUAL(fun_int(result<int>(bo::success(123))).get().value(), 123);
+    BOOST_REQUIRE_EQUAL(run_count, 2);
+
+    BOOST_REQUIRE_THROW(fun_int(result<int>(bo::failure(foo_exception()))).get().value(), foo_exception);
+    BOOST_REQUIRE_EQUAL(run_count, 2);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_result_parallel_for_each) {
+    auto reduce = [] (auto... params) {
+        std::vector<result<>> v;
+        (v.push_back(std::move(params)), ...);
+        utils::result_parallel_for_each<result<>>(std::move(v), [] (result<>& r) {
+            return make_ready_future<result<>>(std::move(r));
+        }).get().value(); // <- trying to access the value throws in case of error
+    };
+
+    auto foo_exc = [] () { return result<>(bo::failure(foo_exception())); };
+    auto bar_exc = [] () { return result<>(bo::failure(bar_exception())); };
+
+    BOOST_REQUIRE_NO_THROW(reduce(bo::success(), bo::success()));
+    BOOST_REQUIRE_THROW(reduce(foo_exc(), bo::success()), foo_exception);
+    BOOST_REQUIRE_THROW(reduce(bo::success(), foo_exc()), foo_exception);
+    BOOST_REQUIRE_THROW(reduce(foo_exc(), bar_exc()), foo_exception);
+    BOOST_REQUIRE_THROW(reduce(bar_exc(), foo_exc()), bar_exception);
+}

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -196,7 +196,9 @@ public:
         testlog.trace("{}(\"{}\")", __FUNCTION__, text);
         auto qs = make_query_state();
         auto qo = make_shared<cql3::query_options>(cql3::query_options::DEFAULT);
-        return local_qp().execute_direct(text, *qs, *qo).finally([qs, qo] {});
+        return local_qp().execute_direct_without_checking_exception_message(text, *qs, *qo).then([qs, qo] (auto msg) {
+            return cql_transport::messages::propagate_exception_as_future(std::move(msg));
+        });
     }
 
     virtual future<::shared_ptr<cql_transport::messages::result_message>> execute_cql(
@@ -206,7 +208,9 @@ public:
         testlog.trace("{}(\"{}\")", __FUNCTION__, text);
         auto qs = make_query_state();
         auto& lqo = *qo;
-        return local_qp().execute_direct(text, *qs, lqo).finally([qs, qo = std::move(qo)] {});
+        return local_qp().execute_direct_without_checking_exception_message(text, *qs, lqo).then([qs, qo = std::move(qo)] (auto msg) {
+            return cql_transport::messages::propagate_exception_as_future(std::move(msg));
+        });
     }
 
     virtual future<cql3::prepared_cache_key_type> prepare(sstring query) override {
@@ -249,8 +253,10 @@ public:
 
         auto qs = make_query_state();
         auto& lqo = *qo;
-        return local_qp().execute_prepared(std::move(prepared), std::move(id), *qs, lqo, true)
-            .finally([qs, qo = std::move(qo)] {});
+        return local_qp().execute_prepared_without_checking_exception_message(std::move(prepared), std::move(id), *qs, lqo, true)
+            .then([qs, qo = std::move(qo)] (auto msg) {
+                return cql_transport::messages::propagate_exception_as_future(std::move(msg));
+            });
     }
 
     virtual future<std::vector<mutation>> get_modification_mutations(const sstring& text) override {
@@ -822,7 +828,9 @@ public:
             local_qp().get_cql_stats());
         auto qs = make_query_state();
         auto& lqo = *qo;
-        return local_qp().execute_batch(batch, *qs, lqo, {}).finally([qs, batch, qo = std::move(qo)] {});
+        return local_qp().execute_batch_without_checking_exception_message(batch, *qs, lqo, {}).then([qs, batch, qo = std::move(qo)] (auto msg) {
+            return cql_transport::messages::propagate_exception_as_future(std::move(msg));
+        });
     }
 };
 

--- a/test/tools/cql_repl.cc
+++ b/test/tools/cql_repl.cc
@@ -70,6 +70,10 @@ public:
         assert(false);
     }
 
+    virtual void visit(const cql_transport::messages::result_message::exception& m) override {
+        m.throw_me();
+    }
+
     virtual void visit(const cql_transport::messages::result_message::rows& m) override {
         Json::Value& output_rows = _root["rows"];
         const auto input_rows = m.rs().result_set().rows();

--- a/thrift/handler.cc
+++ b/thrift/handler.cc
@@ -1038,6 +1038,9 @@ public:
         virtual void visit(const cql_transport::messages::result_message::bounce_to_shard& m) override {
             throw TProtocolException(TProtocolException::TProtocolExceptionType::NOT_IMPLEMENTED, "Thrift does not support executing LWT statements");
         }
+        virtual void visit(const cql_transport::messages::result_message::exception& m) override {
+            m.throw_me();
+        }
     };
 
     void execute_cql3_query(thrift_fn::function<void(CqlResult const& _return)> cob, thrift_fn::function<void(::apache::thrift::TDelayedException* _throw)> exn_cob, const std::string& query, const Compression::type compression, const ConsistencyLevel::type consistency) {

--- a/transport/messages/result_message.cc
+++ b/transport/messages/result_message.cc
@@ -22,6 +22,11 @@ std::ostream& operator<<(std::ostream& os, const result_message::bounce_to_shard
     return os;
 }
 
+std::ostream& operator<<(std::ostream& os, const result_message::exception& msg) {
+    fmt::print(os, "{{result_message::exception {}}}", msg.get_exception());
+    return os;
+}
+
 std::ostream& operator<<(std::ostream& os, const result_message::set_keyspace& msg) {
     fmt::print(os, "{{result_message::set_keyspace {}}}", msg.get_keyspace());
     return os;
@@ -78,10 +83,15 @@ std::ostream& operator<<(std::ostream& os, const result_message& msg) {
         void visit(const result_message::schema_change& m) override { _os << m; };
         void visit(const result_message::rows& m) override { _os << m; };
         void visit(const result_message::bounce_to_shard& m) override { _os << m; };
+        void visit(const result_message::exception& m) override { _os << m; };
     };
     visitor print_visitor{os};
     msg.accept(print_visitor);
     return os;
+}
+
+void result_message::visitor_base::visit(const result_message::exception& ex) {
+    ex.throw_me();
 }
 
 }

--- a/transport/messages/result_message_base.hh
+++ b/transport/messages/result_message_base.hh
@@ -38,6 +38,12 @@ public:
     virtual std::optional<unsigned> move_to_shard() const {
         return std::nullopt;
     }
+
+    virtual bool is_exception() const {
+        return false;
+    }
+
+    virtual void throw_if_exception() const {}
     //
     // Message types:
     //
@@ -47,6 +53,7 @@ public:
     class schema_change;
     class rows;
     class bounce_to_shard;
+    class exception;
 };
 
 std::ostream& operator<<(std::ostream& os, const result_message& msg);

--- a/transport/server.hh
+++ b/transport/server.hh
@@ -169,6 +169,7 @@ public:
             gms::gossiper& g);
 public:
     using response = cql_transport::response;
+    using result_with_foreign_response_ptr = exceptions::coordinator_result<foreign_ptr<std::unique_ptr<cql_server::response>>>;
     service::endpoint_lifecycle_subscriber* get_lifecycle_listener() const noexcept;
     service::migration_listener* get_migration_listener() const noexcept;
 private:
@@ -226,10 +227,10 @@ private:
         future<std::unique_ptr<cql_server::response>> process_startup(uint16_t stream, request_reader in, service::client_state& client_state, tracing::trace_state_ptr trace_state);
         future<std::unique_ptr<cql_server::response>> process_auth_response(uint16_t stream, request_reader in, service::client_state& client_state, tracing::trace_state_ptr trace_state);
         future<std::unique_ptr<cql_server::response>> process_options(uint16_t stream, request_reader in, service::client_state& client_state, tracing::trace_state_ptr trace_state);
-        future<foreign_ptr<std::unique_ptr<cql_server::response>>> process_query(uint16_t stream, request_reader in, service::client_state& client_state, service_permit permit, tracing::trace_state_ptr trace_state);
+        future<result_with_foreign_response_ptr> process_query(uint16_t stream, request_reader in, service::client_state& client_state, service_permit permit, tracing::trace_state_ptr trace_state);
         future<std::unique_ptr<cql_server::response>> process_prepare(uint16_t stream, request_reader in, service::client_state& client_state, tracing::trace_state_ptr trace_state);
-        future<foreign_ptr<std::unique_ptr<cql_server::response>>> process_execute(uint16_t stream, request_reader in, service::client_state& client_state, service_permit permit, tracing::trace_state_ptr trace_state);
-        future<foreign_ptr<std::unique_ptr<cql_server::response>>> process_batch(uint16_t stream, request_reader in, service::client_state& client_state, service_permit permit, tracing::trace_state_ptr trace_state);
+        future<result_with_foreign_response_ptr> process_execute(uint16_t stream, request_reader in, service::client_state& client_state, service_permit permit, tracing::trace_state_ptr trace_state);
+        future<result_with_foreign_response_ptr> process_batch(uint16_t stream, request_reader in, service::client_state& client_state, service_permit permit, tracing::trace_state_ptr trace_state);
         future<std::unique_ptr<cql_server::response>> process_register(uint16_t stream, request_reader in, service::client_state& client_state, tracing::trace_state_ptr trace_state);
 
         std::unique_ptr<cql_server::response> make_unavailable_error(int16_t stream, exceptions::exception_code err, sstring msg, db::consistency_level cl, int32_t required, int32_t alive, const tracing::trace_state_ptr& tr_state) const;
@@ -252,11 +253,11 @@ private:
 
         // Helper functions to encapsulate bounce_to_shard processing for query, execute and batch verbs
         template<typename Process>
-        future<foreign_ptr<std::unique_ptr<cql_server::response>>>
+        future<result_with_foreign_response_ptr>
         process(uint16_t stream, request_reader in, service::client_state& client_state, service_permit permit, tracing::trace_state_ptr trace_state,
                 Process process_fn);
         template<typename Process>
-        future<foreign_ptr<std::unique_ptr<cql_server::response>>>
+        future<result_with_foreign_response_ptr>
         process_on_shard(::shared_ptr<messages::result_message::bounce_to_shard> bounce_msg, uint16_t stream, fragmented_temporary_buffer::istream is, service::client_state& cs,
                 service_permit permit, tracing::trace_state_ptr trace_state, Process process_fn);
 

--- a/utils/exception_container.hh
+++ b/utils/exception_container.hh
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2022-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#pragma once
+
+#include <exception>
+#include <typeinfo>
+#include <type_traits>
+#include <memory>
+#include <ostream>
+#include <variant>
+#include <seastar/core/future.hh>
+#include <seastar/core/distributed.hh>
+#include <seastar/util/log.hh>
+#include "utils/variant_element.hh"
+
+namespace utils {
+
+class bad_exception_container_access : public std::exception {
+public:
+    const char* what() const noexcept override {
+        return "bad exception container access";
+    }
+};
+
+// A variant-like type capable of holding one of the allowed exception types.
+// This allows inspecting the exception in the error handling code without
+// having to resort to costly rethrowing of std::exception_ptr, as is
+// in the case of the usual exception handling.
+//
+// It's not as ergonomic as using exceptions with seastar, but allows for
+// fast inspection and manipulation.
+//
+// Exceptions are held in a std::variant. The variant is kept behind
+// a std::unique_ptr to ensure that moves are cheap. This means that
+// a moved-out exception container becomes "empty" and does not contain
+// a valid exception.
+//
+// Copying is not supported.
+template<typename... Exs>
+struct exception_container {
+private:
+    using exception_variant = std::variant<Exs...>;
+
+    // TODO: Idea for a possible improvement: get rid of the variant
+    // and just store a pointer to an error allocated on the heap.
+    // Keep an integer which identifies the variant.
+    // Bonus points: if each error type has a unique, globally-assigned
+    // identified integer, then conversion of the exception_container
+    // to a container supporting a superset of errors becomes very cheap.
+    seastar::foreign_ptr<std::unique_ptr<std::variant<Exs...>>> _eptr;
+
+    void check_nonempty() const {
+        if (empty()) {
+            throw bad_exception_container_access();
+        }
+    }
+
+public:
+    // Constructs an exception_container which does not contain any exception.
+    exception_container() = default;
+
+    template<typename Ex>
+    requires VariantElement<Ex, exception_variant>
+    exception_container(Ex&& ex)
+            : _eptr(seastar::make_foreign(std::make_unique<exception_variant>(std::move(ex))))
+    { }
+
+    inline bool empty() const {
+        return __builtin_expect(!_eptr, false);
+    }
+
+    inline operator bool() const {
+        return !empty();
+    }
+
+    // Accepts a visitor
+    auto accept(auto f) const {
+        check_nonempty();
+        return std::visit(std::move(f), *_eptr);
+    }
+
+    // Throws currently held exception as a C++ exception.
+    // If the container is empty, it throws bad_exception_container_access.
+    [[noreturn]] void throw_me() const {
+        check_nonempty();
+        std::visit([] (const auto& ex) { throw ex; }, *_eptr);
+        std::terminate(); // Should be unreachable
+    }
+
+    // Creates an exceptional future from this error.
+    // The exception is copied into the new exceptional future.
+    // If the container is empty, returns an exceptional future
+    // with the bad_exception_container_access exception.
+    template<typename T = void>
+    seastar::future<T> as_exception_future() const & {
+        if (!_eptr) {
+            return seastar::make_exception_future<T>(bad_exception_container_access());
+        }
+        return std::visit([] (const auto& ex) {
+            return seastar::make_exception_future<T>(ex);
+        }, *_eptr);
+    }
+
+    // Transforms this exception future into an exceptional future.
+    // The exception is moved out and the container becomes empty.
+    // If the container was empty, returns an exceptional future
+    // with the bad_exception_container_access exception.
+    template<typename T = void>
+    seastar::future<T> into_exception_future() && {
+        if (!_eptr) {
+            return seastar::make_exception_future<T>(bad_exception_container_access());
+        }
+        auto f = std::visit([] (auto&& ex) {
+            return seastar::make_exception_future<T>(std::move(ex));
+        }, *_eptr);
+        _eptr.reset();
+        return f;
+    }
+};
+
+template<typename... Exs>
+inline std::ostream& operator<<(std::ostream& os, const exception_container<Exs...>& ec) {
+    ec.accept([&os] (const auto& ex) { os << ex; });
+    return os;
+}
+
+template<typename T>
+struct is_exception_container : std::false_type {};
+
+template<typename... Exs>
+struct is_exception_container<exception_container<Exs...>> : std::true_type {};
+
+template<typename T>
+concept ExceptionContainer = is_exception_container<T>::value;
+
+}

--- a/utils/result.hh
+++ b/utils/result.hh
@@ -1,0 +1,182 @@
+/*
+ * Copyright 2022-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#pragma once
+
+// A collection of utilities related to boost::outcome::result.
+
+#include <utility>
+#include <boost/outcome/policy/base.hpp>
+#include <boost/outcome/result.hpp>
+#include <seastar/core/future.hh>
+#include "utils/exception_container.hh"
+
+namespace bo = BOOST_OUTCOME_V2_NAMESPACE;
+
+namespace utils {
+
+// A policy which throws the container_error associated with the result
+// if there was an attempt to access value while it was not present.
+struct exception_container_throw_policy : bo::policy::base {
+    template<class Impl> static constexpr void wide_value_check(Impl&& self) {
+        if (!base::_has_value(self)) {
+            base::_error(self).throw_me();
+        }
+    }
+
+    template<class Impl> static constexpr void wide_error_check(Impl&& self) {
+        if (!base::_has_error(self)) {
+            throw bo::bad_result_access("no error");
+        }
+    }
+};
+
+template<typename R>
+concept ExceptionContainerResult = bo::is_basic_result<R>::value && ExceptionContainer<typename R::error_type>;
+
+template<typename F>
+concept ExceptionContainerResultFuture = seastar::is_future<F>::value && ExceptionContainerResult<typename F::value_type>;
+
+// A version of parallel_for_each which understands results.
+// In case of a failure, it returns one of the failed results.
+template<typename R, typename Iterator, typename Func>
+requires
+    ExceptionContainerResult<R>
+    && std::is_void_v<typename R::value_type>
+    && requires (Func f, Iterator i) { { f(*i++) } -> std::same_as<seastar::future<R>>; }
+inline seastar::future<R> result_parallel_for_each(Iterator begin, Iterator end, Func&& func) {
+    struct result_reducer {
+        R res = bo::success();
+        void operator()(R&& r) {
+            if (res && !r) {
+                res = std::move(r);
+            }
+        }
+        R get() {
+            return std::move(res);
+        }
+    };
+
+    return seastar::map_reduce(std::move(begin), std::move(end), std::forward<Func>(func), result_reducer{});
+}
+
+// A version of parallel_for_each which understands results.
+// In case of a failure, it returns one of the failed results.
+template<typename R, typename Range, typename Func>
+requires
+    ExceptionContainerResult<R>
+    && std::is_void_v<typename R::value_type>
+inline seastar::future<R> result_parallel_for_each(Range&& range, Func&& func) {
+    return result_parallel_for_each<R>(std::begin(range), std::end(range), std::forward<Func>(func));
+}
+
+// Converts a result into either a ready or an exceptional future.
+// Supports only results which has an exception_container as their error type.
+template<typename R>
+requires ExceptionContainerResult<R>
+seastar::future<typename R::value_type> result_into_future(R&& res) {
+    if (res) {
+        if constexpr (std::is_void_v<typename R::value_type>) {
+            return seastar::make_ready_future<>();
+        } else {
+            return seastar::make_ready_future<typename R::value_type>(std::move(res).assume_value());
+        }
+    } else {
+        return std::move(res).assume_error().template into_exception_future<typename R::value_type>();
+    }
+}
+
+// Converts a non-result future to return a successful result.
+// It _does not_ convert exceptional futures to failed results.
+template<typename R>
+requires ExceptionContainerResult<R>
+seastar::future<R> then_ok_result(seastar::future<typename R::value_type>&& f) {
+    using T = typename R::value_type;
+    if constexpr (std::is_void_v<T>) {
+        return f.then([] {
+            return seastar::make_ready_future<R>(bo::success());
+        });
+    } else {
+        return f.then([] (T&& t) {
+            return seastar::make_ready_future<R>(bo::success(std::move(t)));
+        });
+    }
+}
+
+namespace internal {
+
+template<typename T, typename... Exs>
+using result_with_exception = bo::result<T, exception_container<Exs...>, exception_container_throw_policy>;
+
+template<typename C, typename Arg>
+struct result_wrapped_call_traits {
+    static_assert(ExceptionContainerResult<Arg>);
+    using return_type = decltype(seastar::futurize_invoke(std::declval<C>(), std::declval<typename Arg::value_type>()));
+
+    static auto invoke_with_value(C& c, Arg&& arg) {
+        // Arg must have a value
+        return seastar::futurize_invoke(c, std::move(arg).value());
+    }
+};
+
+template<typename C, typename... Exs>
+struct result_wrapped_call_traits<C, result_with_exception<void, Exs...>> {
+    using return_type = decltype(seastar::futurize_invoke(std::declval<C>()));
+
+    static auto invoke_with_value(C& c, result_with_exception<void, Exs...>&& arg) {
+        return seastar::futurize_invoke(c);
+    }
+};
+
+template<typename C>
+struct result_wrapper {
+    C c;
+
+    result_wrapper(C&& c) : c(std::move(c)) {}
+
+    template<typename InputResult>
+    requires ExceptionContainerResult<InputResult>
+    auto operator()(InputResult arg) {
+        using traits = internal::result_wrapped_call_traits<C, InputResult>;
+        using return_type = typename traits::return_type;
+        static_assert(ExceptionContainerResultFuture<return_type>,
+                "the return type of the call must be a future<result<T>> for some T");
+
+        using return_result_type = typename return_type::value_type;
+        static_assert(std::is_same_v<typename InputResult::error_type, typename return_result_type::error_type>,
+                "the error type of accepted result and returned result are not the same");
+
+        if (arg) {
+            return traits::invoke_with_value(c, std::move(arg));
+        } else {
+            return seastar::make_ready_future<return_result_type>(bo::failure(std::move(arg).assume_error()));
+        }
+    }
+};
+
+}
+
+// Converts a callable to accept a result<T> instead of T.
+// Given a callable which can be called with following arguments and return type:
+//
+//   (T) -> future<result<U>>
+//
+// ...returns a new callable which can be called with the following signature:
+//
+//   (result<T>) -> future<result<U>>
+//
+// On call, the adapted callable is run only if the result<T> contains a value.
+// Otherwise, the adapted callable is not called and the error is returned immediately.
+// The resulting callable must receive result<> as an argument when being called,
+// it won't be automatically converted to result<>.
+template<typename C>
+auto result_wrap(C&& c) {
+    return internal::result_wrapper<C>(std::move(c));
+}
+
+}


### PR DESCRIPTION
Currently, most of the failures that occur during CQL reads or writes are reported using C++ exceptions. Although the seastar framework avoids most of the cost of unwinding by keeping exceptions in futures as `std::exception_ptr`s, the exceptions need to be inspected at various points for the purposes of accounting metrics or converting them to a CQL error response. Analyzing the value and type of an exception held by `std::exception_ptr`'s cannot be done without rethrowing the exception, and that can be very costly even if the exception is immediately caught. Because of that, exceptions are not a good fit for reporting failures which happen frequently during overload, especially if the CPU is the bottleneck.

This PR introduces facilities for reporting exceptions as values using the boost::outcome library. As a first step, the need to use exceptions for reporting timeouts was eliminated for regular and batch writes, and no exceptions are thrown between creation of a `mutation_write_timeout_exception` and its serialization as a CQL response in the `cql_server`.

The types and helpers introduced here can be reused in order to migrate more exceptions and exception paths in a similar fashion.

Results of `perf_simple_query --smp 1 --operations-per-shard 1000000`:

    Master (00a9326ae79a8317055d7e5ad10b1ddff3613cc8)
    128789.53 tps ( 82.2 allocs/op,  12.2 tasks/op,   49245 insns/op)

    This PR
    127072.93 tps ( 82.2 allocs/op,  12.2 tasks/op,   49356 insns/op)

The new version seems to be slower by about 100 insns/op, fortunately not by much (about 0.2%).

Tests: unit(dev), unit(result_utils_test, debug)