### PR TITLE
gms: gossiper: coroutinize code (continued)

### DIFF
--- a/gms/gossiper.cc
+++ b/gms/gossiper.cc
@@ -1148,29 +1148,27 @@ future<> gossiper::replicate(inet_address ep, application_state key, const versi
 }
 
 future<> gossiper::advertise_removing(inet_address endpoint, utils::UUID host_id, utils::UUID local_host_id) {
-    return seastar::async([this, g = this->shared_from_this(), endpoint, host_id, local_host_id] {
-        auto& state = get_endpoint_state(endpoint);
-        // remember this node's generation
-        int generation = state.get_heart_beat_state().get_generation();
-        logger.info("Removing host: {}", host_id);
-        auto ring_delay = std::chrono::milliseconds(_cfg.ring_delay_ms());
-        logger.info("Sleeping for {}ms to ensure {} does not change", ring_delay.count(), endpoint);
-        sleep_abortable(ring_delay, _abort_source).get();
-        // make sure it did not change
-        auto& eps = get_endpoint_state(endpoint);
-        if (eps.get_heart_beat_state().get_generation() != generation) {
-            throw std::runtime_error(format("Endpoint {} generation changed while trying to remove it", endpoint));
-        }
+    auto& state = get_endpoint_state(endpoint);
+    // remember this node's generation
+    int generation = state.get_heart_beat_state().get_generation();
+    logger.info("Removing host: {}", host_id);
+    auto ring_delay = std::chrono::milliseconds(_cfg.ring_delay_ms());
+    logger.info("Sleeping for {}ms to ensure {} does not change", ring_delay.count(), endpoint);
+    co_await sleep_abortable(ring_delay, _abort_source);
+    // make sure it did not change
+    auto& eps = get_endpoint_state(endpoint);
+    if (eps.get_heart_beat_state().get_generation() != generation) {
+        throw std::runtime_error(format("Endpoint {} generation changed while trying to remove it", endpoint));
+    }
 
-        // update the other node's generation to mimic it as if it had changed it itself
-        logger.info("Advertising removal for {}", endpoint);
-        eps.update_timestamp(); // make sure we don't evict it too soon
-        eps.get_heart_beat_state().force_newer_generation_unsafe();
-        eps.add_application_state(application_state::STATUS, versioned_value::removing_nonlocal(host_id));
-        eps.add_application_state(application_state::REMOVAL_COORDINATOR, versioned_value::removal_coordinator(local_host_id));
-        endpoint_state_map[endpoint] = eps;
-        replicate(endpoint, eps).get();
-    });
+    // update the other node's generation to mimic it as if it had changed it itself
+    logger.info("Advertising removal for {}", endpoint);
+    eps.update_timestamp(); // make sure we don't evict it too soon
+    eps.get_heart_beat_state().force_newer_generation_unsafe();
+    eps.add_application_state(application_state::STATUS, versioned_value::removing_nonlocal(host_id));
+    eps.add_application_state(application_state::REMOVAL_COORDINATOR, versioned_value::removal_coordinator(local_host_id));
+    endpoint_state_map[endpoint] = eps;
+    co_await replicate(endpoint, eps);
 }
 
 future<> gossiper::advertise_token_removed(inet_address endpoint, utils::UUID host_id) {

--- a/gms/gossiper.cc
+++ b/gms/gossiper.cc
@@ -1470,7 +1470,6 @@ void gossiper::update_timestamp_for_nodes(const std::map<inet_address, endpoint_
     }
 }
 
-// Runs inside seastar::async context
 void gossiper::mark_alive(inet_address addr, endpoint_state& local_state) {
     // if (MessagingService.instance().getVersion(addr) < MessagingService.VERSION_20) {
     //     real_mark_alive(addr, local_state);

--- a/gms/gossiper.hh
+++ b/gms/gossiper.hh
@@ -401,7 +401,7 @@ private:
 
     void mark_alive(inet_address addr, endpoint_state& local_state);
 
-    void real_mark_alive(inet_address addr, endpoint_state& local_state);
+    future<> real_mark_alive(inet_address addr, endpoint_state& local_state);
 
     future<> mark_dead(inet_address addr, endpoint_state& local_state);
 

--- a/gms/gossiper.hh
+++ b/gms/gossiper.hh
@@ -430,7 +430,7 @@ private:
     void apply_new_states(inet_address addr, endpoint_state& local_state, const endpoint_state& remote_state);
 
     // notify that a local application state is going to change (doesn't get triggered for remote changes)
-    void do_before_change_notifications(inet_address addr, const endpoint_state& ep_state, const application_state& ap_state, const versioned_value& new_value);
+    future<> do_before_change_notifications(inet_address addr, const endpoint_state& ep_state, const application_state& ap_state, const versioned_value& new_value);
 
     // notify that an application state has changed
     void do_on_change_notifications(inet_address addr, const application_state& state, const versioned_value& value);

--- a/gms/gossiper.hh
+++ b/gms/gossiper.hh
@@ -433,7 +433,7 @@ private:
     future<> do_before_change_notifications(inet_address addr, const endpoint_state& ep_state, const application_state& ap_state, const versioned_value& new_value);
 
     // notify that an application state has changed
-    void do_on_change_notifications(inet_address addr, const application_state& state, const versioned_value& value);
+    future<> do_on_change_notifications(inet_address addr, const application_state& state, const versioned_value& value);
     /* Request all the state for the endpoint in the g_digest */
 
     void request_all(gossip_digest& g_digest, utils::chunked_vector<gossip_digest>& delta_gossip_digest_list, int remote_generation);

--- a/gms/gossiper.hh
+++ b/gms/gossiper.hh
@@ -260,7 +260,7 @@ public:
     /**
      * @param endpoint end point that is convicted.
      */
-    void convict(inet_address endpoint);
+    future<> convict(inet_address endpoint);
 
     /**
      * Return either: the greatest heartbeat or application state
@@ -554,7 +554,7 @@ public:
     bool is_normal_ring_member(const inet_address& endpoint) const;
     bool is_cql_ready(const inet_address& endpoint) const;
     bool is_silent_shutdown_state(const endpoint_state& ep_state) const;
-    void mark_as_shutdown(const inet_address& endpoint);
+    future<> mark_as_shutdown(const inet_address& endpoint);
     void force_newer_generation();
 public:
     std::string_view get_gossip_status(const endpoint_state& ep_state) const noexcept;

--- a/gms/gossiper.hh
+++ b/gms/gossiper.hh
@@ -403,7 +403,7 @@ private:
 
     void real_mark_alive(inet_address addr, endpoint_state& local_state);
 
-    void mark_dead(inet_address addr, endpoint_state& local_state);
+    future<> mark_dead(inet_address addr, endpoint_state& local_state);
 
     /**
      * This method is called whenever there is a "big" change in ep state (a generation change for a known node).

--- a/gms/gossiper.hh
+++ b/gms/gossiper.hh
@@ -411,7 +411,7 @@ private:
      * @param ep      endpoint
      * @param ep_state EndpointState for the endpoint
      */
-    void handle_major_state_change(inet_address ep, const endpoint_state& eps);
+    future<> handle_major_state_change(inet_address ep, const endpoint_state& eps);
 
 public:
     bool is_alive(inet_address ep) const;


### PR DESCRIPTION
This series continues the effort of https://github.com/scylladb/scylla/pull/9844 to reduce `seastar::async` usage and coroutinize in the gossiper code.

There are mostly trivial conversions from using `.get()` to `co_await`, where appropriate, as well, as elimination of `seastar::async()` wrappers.

A few more functions are not yet converted, though (e.g. `apply_new_states`, `do_apply_state_locally`, `apply_state_locally`, `apply_state_locally_without_listener_notification`, maybe a few others, as well).

The motivation is to be able to call every public API function of `gossiper` class without requiring `seastar::async` context.

Tests: unit(debug, dev), dtest (topology-related tests)