### PR TITLE
utils/result: optimize result_parallel_for_each

### DIFF
--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -90,6 +90,8 @@
 #include "idl/frozen_schema.dist.impl.hh"
 #include "idl/storage_proxy.dist.hh"
 #include "utils/result.hh"
+#include "utils/result_combinators.hh"
+#include "utils/result_loop.hh"
 #include "utils/overloaded_functor.hh"
 
 namespace bi = boost::intrusive;

--- a/test/boost/result_utils_test.cc
+++ b/test/boost/result_utils_test.cc
@@ -10,6 +10,8 @@
 #include <stdexcept>
 #include "utils/exception_container.hh"
 #include "utils/result.hh"
+#include "utils/result_combinators.hh"
+#include "utils/result_loop.hh"
 
 #include <seastar/testing/test_case.hh>
 #include <seastar/core/sstring.hh>

--- a/utils/result.hh
+++ b/utils/result.hh
@@ -8,12 +8,11 @@
 
 #pragma once
 
-// A collection of utilities related to boost::outcome::result.
+// Basic utilities which allow to start working with boost::outcome::result
+// in conjunction with our exception_container.
 
-#include <utility>
 #include <boost/outcome/policy/base.hpp>
 #include <boost/outcome/result.hpp>
-#include <seastar/core/future.hh>
 #include "utils/exception_container.hh"
 
 namespace bo = BOOST_OUTCOME_V2_NAMESPACE;
@@ -41,142 +40,5 @@ concept ExceptionContainerResult = bo::is_basic_result<R>::value && ExceptionCon
 
 template<typename F>
 concept ExceptionContainerResultFuture = seastar::is_future<F>::value && ExceptionContainerResult<typename F::value_type>;
-
-// A version of parallel_for_each which understands results.
-// In case of a failure, it returns one of the failed results.
-template<typename R, typename Iterator, typename Func>
-requires
-    ExceptionContainerResult<R>
-    && std::is_void_v<typename R::value_type>
-    && requires (Func f, Iterator i) { { f(*i++) } -> std::same_as<seastar::future<R>>; }
-inline seastar::future<R> result_parallel_for_each(Iterator begin, Iterator end, Func&& func) {
-    struct result_reducer {
-        R res = bo::success();
-        void operator()(R&& r) {
-            if (res && !r) {
-                res = std::move(r);
-            }
-        }
-        R get() {
-            return std::move(res);
-        }
-    };
-
-    return seastar::map_reduce(std::move(begin), std::move(end), std::forward<Func>(func), result_reducer{});
-}
-
-// A version of parallel_for_each which understands results.
-// In case of a failure, it returns one of the failed results.
-template<typename R, typename Range, typename Func>
-requires
-    ExceptionContainerResult<R>
-    && std::is_void_v<typename R::value_type>
-inline seastar::future<R> result_parallel_for_each(Range&& range, Func&& func) {
-    return result_parallel_for_each<R>(std::begin(range), std::end(range), std::forward<Func>(func));
-}
-
-// Converts a result into either a ready or an exceptional future.
-// Supports only results which has an exception_container as their error type.
-template<typename R>
-requires ExceptionContainerResult<R>
-seastar::future<typename R::value_type> result_into_future(R&& res) {
-    if (res) {
-        if constexpr (std::is_void_v<typename R::value_type>) {
-            return seastar::make_ready_future<>();
-        } else {
-            return seastar::make_ready_future<typename R::value_type>(std::move(res).assume_value());
-        }
-    } else {
-        return std::move(res).assume_error().template into_exception_future<typename R::value_type>();
-    }
-}
-
-// Converts a non-result future to return a successful result.
-// It _does not_ convert exceptional futures to failed results.
-template<typename R>
-requires ExceptionContainerResult<R>
-seastar::future<R> then_ok_result(seastar::future<typename R::value_type>&& f) {
-    using T = typename R::value_type;
-    if constexpr (std::is_void_v<T>) {
-        return f.then([] {
-            return seastar::make_ready_future<R>(bo::success());
-        });
-    } else {
-        return f.then([] (T&& t) {
-            return seastar::make_ready_future<R>(bo::success(std::move(t)));
-        });
-    }
-}
-
-namespace internal {
-
-template<typename T, typename... Exs>
-using result_with_exception = bo::result<T, exception_container<Exs...>, exception_container_throw_policy>;
-
-template<typename C, typename Arg>
-struct result_wrapped_call_traits {
-    static_assert(ExceptionContainerResult<Arg>);
-    using return_type = decltype(seastar::futurize_invoke(std::declval<C>(), std::declval<typename Arg::value_type>()));
-
-    static auto invoke_with_value(C& c, Arg&& arg) {
-        // Arg must have a value
-        return seastar::futurize_invoke(c, std::move(arg).value());
-    }
-};
-
-template<typename C, typename... Exs>
-struct result_wrapped_call_traits<C, result_with_exception<void, Exs...>> {
-    using return_type = decltype(seastar::futurize_invoke(std::declval<C>()));
-
-    static auto invoke_with_value(C& c, result_with_exception<void, Exs...>&& arg) {
-        return seastar::futurize_invoke(c);
-    }
-};
-
-template<typename C>
-struct result_wrapper {
-    C c;
-
-    result_wrapper(C&& c) : c(std::move(c)) {}
-
-    template<typename InputResult>
-    requires ExceptionContainerResult<InputResult>
-    auto operator()(InputResult arg) {
-        using traits = internal::result_wrapped_call_traits<C, InputResult>;
-        using return_type = typename traits::return_type;
-        static_assert(ExceptionContainerResultFuture<return_type>,
-                "the return type of the call must be a future<result<T>> for some T");
-
-        using return_result_type = typename return_type::value_type;
-        static_assert(std::is_same_v<typename InputResult::error_type, typename return_result_type::error_type>,
-                "the error type of accepted result and returned result are not the same");
-
-        if (arg) {
-            return traits::invoke_with_value(c, std::move(arg));
-        } else {
-            return seastar::make_ready_future<return_result_type>(bo::failure(std::move(arg).assume_error()));
-        }
-    }
-};
-
-}
-
-// Converts a callable to accept a result<T> instead of T.
-// Given a callable which can be called with following arguments and return type:
-//
-//   (T) -> future<result<U>>
-//
-// ...returns a new callable which can be called with the following signature:
-//
-//   (result<T>) -> future<result<U>>
-//
-// On call, the adapted callable is run only if the result<T> contains a value.
-// Otherwise, the adapted callable is not called and the error is returned immediately.
-// The resulting callable must receive result<> as an argument when being called,
-// it won't be automatically converted to result<>.
-template<typename C>
-auto result_wrap(C&& c) {
-    return internal::result_wrapper<C>(std::move(c));
-}
 
 }

--- a/utils/result_combinators.hh
+++ b/utils/result_combinators.hh
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2022-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#pragma once
+
+#include <utility>
+#include <seastar/core/future.hh>
+#include "utils/result.hh"
+
+namespace utils {
+
+// Converts a result into either a ready or an exceptional future.
+// Supports only results which has an exception_container as their error type.
+template<typename R>
+requires ExceptionContainerResult<R>
+seastar::future<typename R::value_type> result_into_future(R&& res) {
+    if (res) {
+        if constexpr (std::is_void_v<typename R::value_type>) {
+            return seastar::make_ready_future<>();
+        } else {
+            return seastar::make_ready_future<typename R::value_type>(std::move(res).assume_value());
+        }
+    } else {
+        return std::move(res).assume_error().template into_exception_future<typename R::value_type>();
+    }
+}
+
+// Converts a non-result future to return a successful result.
+// It _does not_ convert exceptional futures to failed results.
+template<typename R>
+requires ExceptionContainerResult<R>
+seastar::future<R> then_ok_result(seastar::future<typename R::value_type>&& f) {
+    using T = typename R::value_type;
+    if constexpr (std::is_void_v<T>) {
+        return f.then([] {
+            return seastar::make_ready_future<R>(bo::success());
+        });
+    } else {
+        return f.then([] (T&& t) {
+            return seastar::make_ready_future<R>(bo::success(std::move(t)));
+        });
+    }
+}
+
+namespace internal {
+
+template<typename T, typename... Exs>
+using result_with_exception = bo::result<T, exception_container<Exs...>, exception_container_throw_policy>;
+
+template<typename C, typename Arg>
+struct result_wrapped_call_traits {
+    static_assert(ExceptionContainerResult<Arg>);
+    using return_type = decltype(seastar::futurize_invoke(std::declval<C>(), std::declval<typename Arg::value_type>()));
+
+    static auto invoke_with_value(C& c, Arg&& arg) {
+        // Arg must have a value
+        return seastar::futurize_invoke(c, std::move(arg).value());
+    }
+};
+
+template<typename C, typename... Exs>
+struct result_wrapped_call_traits<C, result_with_exception<void, Exs...>> {
+    using return_type = decltype(seastar::futurize_invoke(std::declval<C>()));
+
+    static auto invoke_with_value(C& c, result_with_exception<void, Exs...>&& arg) {
+        return seastar::futurize_invoke(c);
+    }
+};
+
+template<typename C>
+struct result_wrapper {
+    C c;
+
+    result_wrapper(C&& c) : c(std::move(c)) {}
+
+    template<typename InputResult>
+    requires ExceptionContainerResult<InputResult>
+    auto operator()(InputResult arg) {
+        using traits = internal::result_wrapped_call_traits<C, InputResult>;
+        using return_type = typename traits::return_type;
+        static_assert(ExceptionContainerResultFuture<return_type>,
+                "the return type of the call must be a future<result<T>> for some T");
+
+        using return_result_type = typename return_type::value_type;
+        static_assert(std::is_same_v<typename InputResult::error_type, typename return_result_type::error_type>,
+                "the error type of accepted result and returned result are not the same");
+
+        if (arg) {
+            return traits::invoke_with_value(c, std::move(arg));
+        } else {
+            return seastar::make_ready_future<return_result_type>(bo::failure(std::move(arg).assume_error()));
+        }
+    }
+};
+
+}
+
+// Converts a callable to accept a result<T> instead of T.
+// Given a callable which can be called with following arguments and return type:
+//
+//   (T) -> future<result<U>>
+//
+// ...returns a new callable which can be called with the following signature:
+//
+//   (result<T>) -> future<result<U>>
+//
+// On call, the adapted callable is run only if the result<T> contains a value.
+// Otherwise, the adapted callable is not called and the error is returned immediately.
+// The resulting callable must receive result<> as an argument when being called,
+// it won't be automatically converted to result<>.
+template<typename C>
+auto result_wrap(C&& c) {
+    return internal::result_wrapper<C>(std::move(c));
+}
+
+}

--- a/utils/result_loop.hh
+++ b/utils/result_loop.hh
@@ -8,9 +8,28 @@
 
 #pragma once
 
+#include <iterator>
+#include <seastar/core/coroutine.hh>
+#include <seastar/coroutine/exception.hh>
 #include "utils/result.hh"
 
 namespace utils {
+
+namespace internal {
+
+template<typename Iterator, typename IteratorCategory>
+inline size_t iterator_range_estimate_vector_capacity(Iterator begin, Iterator end, IteratorCategory category) {
+    // Return 0 in general case
+    return 0;
+}
+
+template<typename Iterator, typename IteratorCategory>
+inline size_t iterator_range_estimate_vector_capacity(Iterator begin, Iterator end, std::forward_iterator_tag category) {
+    // May require linear scan, but it's better than reallocation
+    return std::distance(begin, end);
+}
+
+}
 
 // A version of parallel_for_each which understands results.
 // In case of a failure, it returns one of the failed results.
@@ -19,20 +38,56 @@ requires
     ExceptionContainerResult<R>
     && std::is_void_v<typename R::value_type>
     && requires (Func f, Iterator i) { { f(*i++) } -> std::same_as<seastar::future<R>>; }
-inline seastar::future<R> result_parallel_for_each(Iterator begin, Iterator end, Func&& func) {
-    struct result_reducer {
-        R res = bo::success();
-        void operator()(R&& r) {
-            if (res && !r) {
-                res = std::move(r);
+inline seastar::future<R> result_parallel_for_each(Iterator begin, Iterator end, Func&& func) noexcept {
+    std::vector<seastar::future<R>> futs;
+    while (begin != end) {
+        auto f = seastar::futurize_invoke(std::forward<Func>(func), *begin++);
+        seastar::memory::scoped_critical_alloc_section _;
+        if (f.available() && !f.failed()) {
+            auto res = f.get();
+            if (res) {
+                continue;
             }
+            f = seastar::make_ready_future<R>(std::move(res));
         }
-        R get() {
-            return std::move(res);
+        if (futs.empty()) {
+            using itraits = std::iterator_traits<Iterator>;
+            auto n = (internal::iterator_range_estimate_vector_capacity(begin, end, typename itraits::iterator_category()) + 1);
+            futs.reserve(n);
         }
-    };
+        futs.push_back(std::move(f));
+    }
 
-    return seastar::map_reduce(std::move(begin), std::move(end), std::forward<Func>(func), result_reducer{});
+    if (futs.empty()) {
+        return seastar::make_ready_future<R>(bo::success());
+    }
+
+    // Use a coroutine so that the waiting task is allocated only once
+    return ([] (std::vector<seastar::future<R>> futs) noexcept -> seastar::future<R> {
+        using error_type = typename R::error_type;
+        std::variant<std::monostate, error_type, std::exception_ptr> result_state;
+        while (!futs.empty()) {
+            // TODO: Avoid try..catching here if seastar coroutines allow that
+            // Or not? Explicit checks might be slower on the happy path
+            try {
+                auto res = co_await std::move(futs.back());
+                if (!res) {
+                    result_state = std::move(res).assume_error();
+                }
+            } catch (...) {
+                result_state = std::current_exception();
+            }
+            futs.pop_back();
+        }
+        if (std::holds_alternative<std::monostate>(result_state)) {
+            co_return bo::success();
+        } else if (auto* error = std::get_if<error_type>(&result_state)) {
+            co_return std::move(*error);
+        } else {
+            co_return seastar::coroutine::exception(
+                    std::get<std::exception_ptr>(std::move(result_state)));
+        }
+    })(std::move(futs));
 }
 
 // A version of parallel_for_each which understands results.

--- a/utils/result_loop.hh
+++ b/utils/result_loop.hh
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2022-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#pragma once
+
+#include "utils/result.hh"
+
+namespace utils {
+
+// A version of parallel_for_each which understands results.
+// In case of a failure, it returns one of the failed results.
+template<typename R, typename Iterator, typename Func>
+requires
+    ExceptionContainerResult<R>
+    && std::is_void_v<typename R::value_type>
+    && requires (Func f, Iterator i) { { f(*i++) } -> std::same_as<seastar::future<R>>; }
+inline seastar::future<R> result_parallel_for_each(Iterator begin, Iterator end, Func&& func) {
+    struct result_reducer {
+        R res = bo::success();
+        void operator()(R&& r) {
+            if (res && !r) {
+                res = std::move(r);
+            }
+        }
+        R get() {
+            return std::move(res);
+        }
+    };
+
+    return seastar::map_reduce(std::move(begin), std::move(end), std::forward<Func>(func), result_reducer{});
+}
+
+// A version of parallel_for_each which understands results.
+// In case of a failure, it returns one of the failed results.
+template<typename R, typename Range, typename Func>
+requires
+    ExceptionContainerResult<R>
+    && std::is_void_v<typename R::value_type>
+inline seastar::future<R> result_parallel_for_each(Range&& range, Func&& func) {
+    return result_parallel_for_each<R>(std::begin(range), std::end(range), std::forward<Func>(func));
+}
+
+}


### PR DESCRIPTION
This PR rewrites the `utils::result_parallel_for_each`'s implementation to resemble the original `seastar::parallel_for_each` more closely instead of using the less efficient `seastar::map_reduce`. It uses less tasks and allocations now, as demonstrated in the results from the `perf_result_query` benchmark, attached at the end of the cover letter.

The main drawback of the new implementation is that it needs to rethrow exceptions propagated as exceptional futures from the parallel sub-invocations. Contrary to the original `seastar::parallel_for_each` which uses a custom task to collect results, the new `utils::result_parallel_for_each` uses a coroutine and there doesn't currently seem to be a way to co_await for a future and inspect its state without either rethrowing or handling it in then_wrapped (which allocates a continuation). Fortunately, rethrowing is not needed for exceptions returned in failed result<>, which are already intended to be a more performant alternative to regular exceptions.

As a bonus, definitions from `utils/result.hh` are now split across three different headers in order to improve (re)compilation times.

Results from `perf_simple_query --smp 1 --operations-per-shard 1000000 --write` (before vs. after):

```
126872.54 tps ( 67.2 allocs/op,  14.2 tasks/op,   52404 insns/op)
126532.13 tps ( 67.2 allocs/op,  14.2 tasks/op,   52408 insns/op)
126864.99 tps ( 67.2 allocs/op,  14.2 tasks/op,   52428 insns/op)
127073.10 tps ( 67.2 allocs/op,  14.2 tasks/op,   52404 insns/op)
126895.85 tps ( 67.2 allocs/op,  14.2 tasks/op,   52411 insns/op)

127894.02 tps ( 66.2 allocs/op,  13.2 tasks/op,   52036 insns/op)
127671.51 tps ( 66.2 allocs/op,  13.2 tasks/op,   52042 insns/op)
127541.42 tps ( 66.2 allocs/op,  13.2 tasks/op,   52044 insns/op)
127409.10 tps ( 66.2 allocs/op,  13.2 tasks/op,   52052 insns/op)
127831.30 tps ( 66.2 allocs/op,  13.2 tasks/op,   52043 insns/op)
```

Test: unit(dev), unit(result_utils_test, debug)