### PR TITLE
api: Escape PK in the result of `toppartitions` call

### DIFF
--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -11,6 +11,7 @@
 #include "db/config.hh"
 #include "db/schema_tables.hh"
 #include "utils/hash.hh"
+#include "utils/utf8.hh"
 #include <sstream>
 #include <time.h>
 #include <algorithm>
@@ -127,14 +128,14 @@ seastar::future<json::json_return_type> run_toppartitions_query(db::toppartition
 
                 for (auto& d: topk_results.read.top(q.list_size())) {
                     cf::toppartitions_record r;
-                    r.partition = (legacy_request ? "" : "(" + d.item.schema->ks_name() + ":" + d.item.schema->cf_name() + ") ") + sstring(d.item);
+                    r.partition = (legacy_request ? "" : "(" + d.item.schema->ks_name() + ":" + d.item.schema->cf_name() + ") ") + utils::utf8::escape_json(sstring(d.item));
                     r.count = d.count;
                     r.error = d.error;
                     results.read.push(r);
                 }
                 for (auto& d: topk_results.write.top(q.list_size())) {
                     cf::toppartitions_record r;
-                    r.partition = (legacy_request ? "" : "(" + d.item.schema->ks_name() + ":" + d.item.schema->cf_name() + ") ") + sstring(d.item);
+                    r.partition = (legacy_request ? "" : "(" + d.item.schema->ks_name() + ":" + d.item.schema->cf_name() + ") ") + utils::utf8::escape_json(sstring(d.item));
                     r.count = d.count;
                     r.error = d.error;
                     results.write.push(r);

--- a/utils/utf8.cc
+++ b/utils/utf8.cc
@@ -38,6 +38,8 @@
  */
 
 #include "utf8.hh"
+#include <sstream>
+#include <iomanip>
 
 namespace utils {
 
@@ -582,6 +584,30 @@ std::optional<size_t> validate_with_error_position(const uint8_t *data, size_t l
     }
     // Second pass - data is invalid. Find the error position using naive method
     return validate_naive(data, len);
+}
+
+// From https://stackoverflow.com/a/33799784/12786387
+sstring escape_json(const sstring &s) {
+    std::ostringstream o;
+    for (auto c = s.cbegin(); c != s.cend(); c++) {
+        switch (*c) {
+        case '"': o << "\\\""; break;
+        case '\\': o << "\\\\"; break;
+        case '\b': o << "\\b"; break;
+        case '\f': o << "\\f"; break;
+        case '\n': o << "\\n"; break;
+        case '\r': o << "\\r"; break;
+        case '\t': o << "\\t"; break;
+        default:
+            if ('\x00' <= *c && *c <= '\x1f') {
+                o << "\\u"
+                  << std::hex << std::setw(4) << std::setfill('0') << (int)*c;
+            } else {
+                o << *c;
+            }
+        }
+    }
+    return o.str();
 }
 
 } // namespace utf8

--- a/utils/utf8.hh
+++ b/utils/utf8.hh
@@ -12,6 +12,7 @@
 #pragma once
 
 #include <cstdint>
+#include <seastar/core/sstring.hh>
 #include "bytes.hh"
 #include "fragment_range.hh"
 
@@ -103,6 +104,8 @@ std::optional<size_t> validate_with_error_position_fragmented(FragmentedView aut
     }
     return std::nullopt;
 }
+
+sstring escape_json(const sstring &s);
 
 } // namespace utf8
 


### PR DESCRIPTION
This PR adds JSON-compliant escaping to the PKs displayed in the results of `toppartitions` call.

Stringified PK is included in the JSON returned by API endpoint `/storage_service/toppartitions`:

```
{"read_cardinality": 101, "read":
  [
     {"partition": "(ks:table) PK1", "count": 1, "error": 0},
     {"partition":...
```

But PKs can contain all sorts of characters, e.g. `"}]}`, `\r` that mess the JSON syntax and make it unreadable to nodetool/JMX. Especially when cassandra-stress writes them.

Fixes #9061