### PR TITLE
cql3: expr: Fix expr::visit so that it works with references

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -503,6 +503,7 @@ scylla_tests = set([
     'test/boost/group0_test',
     'test/boost/exception_container_test',
     'test/boost/result_utils_test',
+    'test/boost/expr_test',
     'test/manual/ec2_snitch_test',
     'test/manual/enormous_table_scan_test',
     'test/manual/gce_snitch_test',
@@ -1268,6 +1269,7 @@ deps['test/boost/linearizing_input_stream_test'] = [
     "test/boost/linearizing_input_stream_test.cc",
     "test/lib/log.cc",
 ]
+deps['test/boost/expr_test'] = ['test/boost/expr_test.cc'] + scylla_core
 
 deps['test/boost/duration_test'] += ['test/lib/exception_utils.cc']
 deps['test/boost/schema_loader_test'] += ['tools/schema_loader.cc']

--- a/cql3/expr/expression.hh
+++ b/cql3/expr/expression.hh
@@ -155,8 +155,11 @@ public:
     expression& operator=(const expression&);
     expression& operator=(expression&&) noexcept = default;
 
-    friend decltype(auto) visit(invocable_on_expression auto&& visitor, const expression& e);
-    friend decltype(auto) visit(invocable_on_expression_ref auto&& visitor, expression& e);
+    template <invocable_on_expression Visitor>
+    friend decltype(auto) visit(Visitor&& visitor, const expression& e);
+
+    template <invocable_on_expression_ref Visitor>
+    friend decltype(auto) visit(Visitor&& visitor, expression& e);
 
     template <ExpressionElement E>
     friend bool is(const expression& e);
@@ -371,12 +374,14 @@ inline expression::expression()
         : expression(conjunction{}) {
 }
 
-decltype(auto) visit(invocable_on_expression auto&& visitor, const expression& e) {
-    return std::visit(visitor, e._v->v);
+template <invocable_on_expression Visitor>
+decltype(auto) visit(Visitor&& visitor, const expression& e) {
+    return std::visit(std::forward<Visitor>(visitor), e._v->v);
 }
 
-decltype(auto) visit(invocable_on_expression_ref auto&& visitor, expression& e) {
-    return std::visit(visitor, e._v->v);
+template <invocable_on_expression_ref Visitor>
+decltype(auto) visit(Visitor&& visitor, expression& e) {
+    return std::visit(std::forward<Visitor>(visitor), e._v->v);
 }
 
 template <ExpressionElement E>

--- a/cql3/expr/expression.hh
+++ b/cql3/expr/expression.hh
@@ -155,8 +155,8 @@ public:
     expression& operator=(const expression&);
     expression& operator=(expression&&) noexcept = default;
 
-    friend auto visit(invocable_on_expression auto&& visitor, const expression& e);
-    friend auto visit(invocable_on_expression_ref auto&& visitor, expression& e);
+    friend decltype(auto) visit(invocable_on_expression auto&& visitor, const expression& e);
+    friend decltype(auto) visit(invocable_on_expression_ref auto&& visitor, expression& e);
 
     template <ExpressionElement E>
     friend bool is(const expression& e);
@@ -371,11 +371,11 @@ inline expression::expression()
         : expression(conjunction{}) {
 }
 
-auto visit(invocable_on_expression auto&& visitor, const expression& e) {
+decltype(auto) visit(invocable_on_expression auto&& visitor, const expression& e) {
     return std::visit(visitor, e._v->v);
 }
 
-auto visit(invocable_on_expression_ref auto&& visitor, expression& e) {
+decltype(auto) visit(invocable_on_expression_ref auto&& visitor, expression& e) {
     return std::visit(visitor, e._v->v);
 }
 

--- a/test/boost/expr_test.cc
+++ b/test/boost/expr_test.cc
@@ -1,0 +1,68 @@
+#define BOOST_TEST_MODULE core
+
+#include <boost/test/unit_test.hpp>
+#include <utility>
+#include "cql3/expr/expression.hh"
+#include "utils/overloaded_functor.hh"
+#include <cassert>
+
+using namespace cql3::expr;
+
+bind_variable new_bind_variable(int bind_index) {
+    return bind_variable {
+        .shape = bind_variable::shape_type::scalar,
+        .bind_index = bind_index,
+        .receiver = nullptr
+    };
+}
+
+BOOST_AUTO_TEST_CASE(expr_visit_get_int) {
+    expression e = new_bind_variable(1245);
+
+    int read_value = visit(overloaded_functor {
+        [](const bind_variable& bv) -> int { return bv.bind_index; },
+        [](const auto&) -> int { throw std::runtime_error("Unreachable"); }
+    }, e);
+
+    BOOST_REQUIRE_EQUAL(read_value, 1245);
+}
+
+BOOST_AUTO_TEST_CASE(expr_visit_void_return) {
+    expression e = new_bind_variable(1245);
+
+    visit(overloaded_functor {
+        [](const bind_variable& bv) { BOOST_REQUIRE_EQUAL(bv.bind_index, 1245); },
+        [](const auto&) { throw std::runtime_error("Unreachable"); }
+    }, e);
+}
+
+BOOST_AUTO_TEST_CASE(expr_visit_const_ref) {
+    const expression e = new_bind_variable(123);
+
+    const bind_variable& ref = visit(overloaded_functor {
+        [](const bind_variable& bv) -> const bind_variable& { return bv; },
+        [](const auto&) -> const bind_variable& { throw std::runtime_error("Unreachable"); }
+    }, e);
+
+    BOOST_REQUIRE_EQUAL(ref.bind_index, 123);
+}
+
+BOOST_AUTO_TEST_CASE(expr_visit_ref) {
+    expression e = new_bind_variable(456);
+
+    bind_variable& ref = visit(overloaded_functor {
+        [](bind_variable& bv) -> bind_variable& { return bv; },
+        [](auto&) -> bind_variable& { throw std::runtime_error("Unreachable"); }
+    }, e);
+
+    BOOST_REQUIRE_EQUAL(ref.bind_index, 456);
+
+    ref.bind_index = 135;
+
+    bind_variable& ref2 = visit(overloaded_functor {
+        [](bind_variable& bv) -> bind_variable& { return bv; },
+        [](auto&) -> bind_variable& { throw std::runtime_error("Unreachable"); }
+    }, e);
+
+    BOOST_REQUIRE_EQUAL(ref2.bind_index, 135);
+}

--- a/test/boost/expr_test.cc
+++ b/test/boost/expr_test.cc
@@ -66,3 +66,22 @@ BOOST_AUTO_TEST_CASE(expr_visit_ref) {
 
     BOOST_REQUIRE_EQUAL(ref2.bind_index, 135);
 }
+
+
+struct rvalue_visitor {
+    rvalue_visitor(){};
+    rvalue_visitor(const rvalue_visitor&) = delete;
+
+    bind_variable& operator()(bind_variable& bv) && { return bv; }
+    bind_variable& operator()(auto&) && { throw std::runtime_error("Unreachable"); }
+} v;
+
+BOOST_AUTO_TEST_CASE(expr_visit_visitor_rvalue) {
+    expression e = new_bind_variable(456);
+
+    rvalue_visitor visitor;
+
+    bind_variable& ref2 = visit(std::move(visitor), e);
+
+    BOOST_REQUIRE_EQUAL(ref2.bind_index, 456);
+}


### PR DESCRIPTION
There is a bug in `expr::visit`. When trying to return a reference from a visitor it actually returns a reference to some temporary location.
So trying to do something like:
```c++
const expression e = new_bind_variable(123);

const bind_variable& ref = visit(overloaded_functor {
    [](const bind_variable& bv) -> const bind_variable& { return bv; },
    [](const auto&) -> const bind_variable& { throw std::runtime_error("Unreachable"); }
}, e);

std::cout << ref << std::endl;
 ```
 Would actually print a random stack location instead of the value inside of `e`.
 Additionally trying to return a non-const reference doesn't compile.
 
 Current implementation of `expr::visit` is:
 ```c++
 auto visit(invocable_on_expression auto&& visitor, const expression& e) {
    return std::visit(visitor, e._v->v);
}
 ```
  
For reference, `std::visit` looks like this:
 ```c++
template<typename _Res, typename _Visitor, typename... _Variants>
constexpr _Res
visit(_Visitor&& __visitor, _Variants&&... __variants)
{
  return std::__do_visit<_Res>(std::forward<_Visitor>(__visitor),
                               std::forward<_Variants>(__variants)...);
}
 ```
 
 The problem is that `auto` can evaluate to `int` or `float`, but not to `int&`.
 It has now been changed to `decltype(auto)`, which is able to express references.
 I also added a missing `std::forward` on the visitor argument.

The new version looks like this:
 ```c++
template <invocable_on_expression Visitor>
decltype(auto) visit(Visitor&& visitor, const expression& e) {
    return std::visit(std::forward<Visitor>(visitor), e._v->v);
}
```

I added some tests of `expr::visit` in `boost/expr_test`, but sadly they are not as throughout as they could be, Ideally I could return a refernce from `std::visit` and `expr::visit` and then check that they both point to the same address in memory.
I can't do this because it would require to access a private field of `expression`.
Some test pass before the fix, even though they shouldn't, but I'm not sure how to make them better without making field of expression public.

 I played around with some code, it can be found here: https://github.com/cvybhu/attached-files/blob/main/visit/visit_playground.cpp