### PR TITLE
tools/scylla-sstable: change output of dump commands to JSON

### DIFF
--- a/test/boost/schema_loader_test.cc
+++ b/test/boost/schema_loader_test.cc
@@ -21,6 +21,7 @@ SEASTAR_THREAD_TEST_CASE(test_keyspace_only) {
 
 SEASTAR_THREAD_TEST_CASE(test_single_table) {
     BOOST_REQUIRE_EQUAL(tools::load_schemas("CREATE TABLE ks.cf (pk int PRIMARY KEY, v int)").get().size(), 1);
+    BOOST_REQUIRE_EQUAL(tools::load_schemas("CREATE TABLE ks.cf (pk int PRIMARY KEY, v map<int, int>)").get().size(), 1);
     BOOST_REQUIRE_EQUAL(tools::load_schemas("CREATE KEYSPACE ks WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}; CREATE TABLE ks.cf (pk int PRIMARY KEY, v int);").get().size(), 1);
 }
 

--- a/test/cql-pytest/conftest.py
+++ b/test/cql-pytest/conftest.py
@@ -28,6 +28,10 @@ def pytest_addoption(parser):
         help='CQL server port to connect to')
     parser.addoption('--ssl', action='store_true',
         help='Connect to CQL via an encrypted TLSv1.2 connection')
+    parser.addoption('--scylla-path', action='store', default='',
+        help='Path to the scylla excutable the tests are running against')
+    parser.addoption('--workdir', action='store', default='',
+        help='Path to the workdir of the scylla instance the tests are running against')
 
 # "cql" fixture: set up client object for communicating with the CQL API.
 # The host/port combination of the server are determined by the --host and

--- a/test/cql-pytest/run
+++ b/test/cql-pytest/run
@@ -28,12 +28,13 @@ if '--raft' in sys.argv:
 
 pid = run.run_with_temporary_dir(cmd)
 ip = run.pid_to_ip(pid)
+wd = run.pid_to_dir(pid)
 
 run.wait_for_services(pid, [
     lambda: run.check_rest_api(ip),
     lambda: check_cql(ip)
 ])
-success = run.run_pytest(sys.path[0], ['--host', ip] + sys.argv[1:])
+success = run.run_pytest(sys.path[0], ['--host', ip, '--workdir', wd, '--scylla-path', run.scylla] + sys.argv[1:])
 
 run.summary = 'Scylla tests pass' if success else 'Scylla tests failure'
 

--- a/test/cql-pytest/test_tools.py
+++ b/test/cql-pytest/test_tools.py
@@ -1,0 +1,158 @@
+# Copyright 2022-present ScyllaDB
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+#############################################################################
+# Tests for the tools hosted by scylla
+#############################################################################
+
+import glob
+import json
+import nodetool
+import os
+import pytest
+import subprocess
+import util
+
+
+def simple_no_clustering_table(cql, keyspace):
+    table = util.unique_name()
+    schema = f"CREATE TABLE {keyspace}.{table} (pk int PRIMARY KEY , v int)"
+
+    cql.execute(schema)
+
+    for pk in range(0, 10):
+        cql.execute(f"INSERT INTO {keyspace}.{table} (pk, v) VALUES ({pk}, 0)")
+
+    nodetool.flush(cql, f"{keyspace}.{table}")
+
+    return table, schema
+
+
+def simple_clustering_table(cql, keyspace):
+    table = util.unique_name()
+    schema = f"CREATE TABLE {keyspace}.{table} (pk int, ck int, v int, PRIMARY KEY (pk, ck))"
+
+    cql.execute(schema)
+
+    for pk in range(0, 10):
+        for ck in range(0, 10):
+            cql.execute(f"INSERT INTO {keyspace}.{table} (pk, ck, v) VALUES ({pk}, {ck}, 0)")
+
+    nodetool.flush(cql, f"{keyspace}.{table}")
+
+    return table, schema
+
+
+def clustering_table_with_collection(cql, keyspace):
+    table = util.unique_name()
+    schema = f"CREATE TABLE {keyspace}.{table} (pk int, ck int, v map<int, text>, PRIMARY KEY (pk, ck))"
+
+    cql.execute(schema)
+
+    for pk in range(0, 10):
+        for ck in range(0, 10):
+            map_vals = {f"{p}: '{c}'" for p in range(0, pk) for c in range(0, ck)}
+            map_str = ", ".join(map_vals)
+            cql.execute(f"INSERT INTO {keyspace}.{table} (pk, ck, v) VALUES ({pk}, {ck}, {{{map_str}}})")
+
+    nodetool.flush(cql, f"{keyspace}.{table}")
+
+    return table, schema
+
+
+def clustering_table_with_udt(cql, keyspace):
+    table = util.unique_name()
+    create_type_schema = f"CREATE TYPE {keyspace}.type1 (f1 int, f2 text)"
+    create_table_schema = f" CREATE TABLE {keyspace}.{table} (pk int, ck int, v type1, PRIMARY KEY (pk, ck))"
+
+    cql.execute(create_type_schema)
+    cql.execute(create_table_schema)
+
+    for pk in range(0, 10):
+        for ck in range(0, 10):
+            cql.execute(f"INSERT INTO {keyspace}.{table} (pk, ck, v) VALUES ({pk}, {ck}, {{f1: 100, f2: 'asd'}})")
+
+    nodetool.flush(cql, f"{keyspace}.{table}")
+
+    return table, "; ".join((create_type_schema, create_table_schema))
+
+
+def table_with_counters(cql, keyspace):
+    table = util.unique_name()
+    schema = f"CREATE TABLE {keyspace}.{table} (pk int PRIMARY KEY, v counter)"
+
+    cql.execute(schema)
+
+    for pk in range(0, 10):
+        for c in range(0, 4):
+            cql.execute(f"UPDATE {keyspace}.{table} SET v = v + 1 WHERE pk = {pk};")
+
+    nodetool.flush(cql, f"{keyspace}.{table}")
+
+    return table, schema
+
+
+@pytest.fixture(scope="module", params=[
+        simple_no_clustering_table,
+        simple_clustering_table,
+        clustering_table_with_collection,
+        clustering_table_with_udt,
+        table_with_counters,
+])
+def scylla_sstable(request, tmp_path_factory, cql, test_keyspace, scylla_only):
+    workdir = request.config.getoption('workdir')
+    scylla_path = request.config.getoption('scylla_path')
+    if not workdir or not scylla_path:
+        pytest.skip('Cannot run tool tests: workdir and/or scylla_path not provided')
+
+    table, schema = request.param(cql, test_keyspace)
+
+    schema_file = os.path.join(tmp_path_factory.getbasetemp(), "schema.cql")
+    with open(schema_file, "w") as f:
+        f.write(schema)
+
+    sstables = glob.glob(os.path.join(workdir, 'data', test_keyspace, table + '-*', '*-Data.db'))
+
+    try:
+        yield (scylla_path, schema_file, sstables)
+    finally:
+        cql.execute(f"DROP TABLE {test_keyspace}.{table}")
+
+
+def one_sstable(sstables):
+    return [sstables[0]]
+
+
+def all_sstables(sstables):
+    return sstables
+
+
+@pytest.mark.parametrize("what", ["index", "compression-info", "summary", "statistics", "scylla-metadata"])
+@pytest.mark.parametrize("which_sstables", [one_sstable, all_sstables])
+def test_scylla_sstable_dump(scylla_sstable, what, which_sstables):
+    (scylla_path, schema_file, sstables) = scylla_sstable
+
+    out = subprocess.check_output([scylla_path, "sstable", f"dump-{what}", "--schema-file", schema_file] + which_sstables(sstables))
+
+    print(out)
+
+    assert out
+    assert json.loads(out)
+
+
+@pytest.mark.parametrize("merge", [True, False])
+@pytest.mark.parametrize("output_format", ["text", "json"])
+def test_scylla_sstable_dump_merge(scylla_sstable, merge, output_format):
+    (scylla_path, schema_file, sstables) = scylla_sstable
+
+    args = [scylla_path, "sstable", "dump-data", "--schema-file", schema_file, "--output-format", output_format]
+    if merge:
+        args.append("--merge")
+    out = subprocess.check_output(args + sstables)
+
+    print(out)
+
+    assert out
+    if output_format == "json":
+        assert json.loads(out)

--- a/tools/scylla-sstable.cc
+++ b/tools/scylla-sstable.cc
@@ -24,6 +24,10 @@
 #include "types/map.hh"
 #include "tools/schema_loader.hh"
 #include "tools/utils.hh"
+#include "utils/rjson.hh"
+
+// has to be below the utils/rjson.hh include
+#include <rapidjson/ostreamwrapper.h>
 
 using namespace seastar;
 
@@ -185,6 +189,71 @@ public:
             return make_ready_future<stop_iteration>(stop_iteration::yes);
         }
         return std::move(mf).consume(_consumer);
+    }
+};
+
+class json_writer {
+    using stream = rapidjson::BasicOStreamWrapper<std::ostream>;
+    using writer = rapidjson::Writer<stream, rjson::encoding, rjson::encoding, rjson::allocator>;
+
+    stream _stream;
+    writer _writer;
+
+public:
+    json_writer() : _stream(std::cout), _writer(_stream)
+    { }
+
+    // following the rapidjson method names here
+    bool Null() { return _writer.Null(); }
+    bool Bool(bool b) { return _writer.Bool(b); }
+    bool Int(int i) { return _writer.Int(i); }
+    bool Uint(unsigned i) { return _writer.Uint(i); }
+    bool Int64(int64_t i) { return _writer.Int64(i); }
+    bool Uint64(uint64_t i) { return _writer.Uint64(i); }
+    bool Double(double d) { return _writer.Double(d); }
+    bool RawNumber(std::string_view str) { return _writer.RawNumber(str.data(), str.size(), false); }
+    bool String(std::string_view str) { return _writer.String(str.data(), str.size(), false); }
+    bool StartObject() { return _writer.StartObject(); }
+    bool Key(std::string_view str) { return _writer.Key(str.data(), str.size(), false); }
+    bool EndObject(rapidjson::SizeType memberCount = 0) { return _writer.EndObject(memberCount); }
+    bool StartArray() { return _writer.StartArray(); }
+    bool EndArray(rapidjson::SizeType elementCount = 0) { return _writer.EndArray(elementCount); }
+
+    // scylla-specific extensions (still following rapidjson naming scheme for consistency)
+    template <typename T>
+    void AsString(const T& obj) {
+        String(fmt::format("{}", obj));
+    }
+    void PartitionKey(const schema& schema, const partition_key& pkey, std::optional<dht::token> token = {}) {
+        StartObject();
+        if (token) {
+            Key("token");
+            AsString(*token);
+        }
+        Key("raw");
+        String(to_hex(pkey.representation()));
+        Key("value");
+        AsString(pkey.with_schema(schema));
+        EndObject();
+    }
+    void StartStream() {
+        StartObject();
+        Key("sstables");
+        StartObject();
+    }
+    void EndStream() {
+        EndObject();
+        EndObject();
+    }
+    void SstableKey(const sstables::sstable& sst) {
+        Key(sst.get_filename());
+    }
+    void SstableKey(const sstables::sstable* const sst) {
+        if (sst) {
+            SstableKey(*sst);
+        } else {
+            Key("anonymous");
+        }
     }
 };
 

--- a/tools/scylla-sstable.cc
+++ b/tools/scylla-sstable.cc
@@ -194,43 +194,39 @@ class dumping_consumer : public sstable_consumer {
     public:
         explicit text_dumper(const schema& s) : _schema(s) { }
         virtual future<> on_start_of_stream() override {
-            std::cout << "{stream_start}" << std::endl;
+            fmt::print("{{stream_start}}\n");
             return make_ready_future<>();
         }
         virtual future<stop_iteration> on_new_sstable(const sstables::sstable* const sst) override {
-            std::cout << "{sstable_start";
-            if (sst) {
-                std::cout << ": filename " << sst->get_filename();
-            }
-            std::cout << "}" << std::endl;
+            fmt::print("{{sstable_start{}}}\n", sst ? fmt::format(": filename {}", sst->get_filename()) : "");
             return make_ready_future<stop_iteration>(stop_iteration::no);
         }
         virtual future<stop_iteration> consume(partition_start&& ps) override {
-            std::cout << ps << std::endl;
+            fmt::print("{}\n", ps);
             return make_ready_future<stop_iteration>(stop_iteration::no);
         }
         virtual future<stop_iteration> consume(static_row&& sr) override {
-            std::cout << static_row::printer(_schema, sr) << std::endl;
+            fmt::print("{}\n", static_row::printer(_schema, sr));
             return make_ready_future<stop_iteration>(stop_iteration::no);
         }
         virtual future<stop_iteration> consume(clustering_row&& cr) override {
-            std::cout << clustering_row::printer(_schema, cr) << std::endl;
+            fmt::print("{}\n", clustering_row::printer(_schema, cr));
             return make_ready_future<stop_iteration>(stop_iteration::no);
         }
         virtual future<stop_iteration> consume(range_tombstone_change&& rtc) override {
-            std::cout << rtc << std::endl;
+            fmt::print("{}\n", rtc);
             return make_ready_future<stop_iteration>(stop_iteration::no);
         }
         virtual future<stop_iteration> consume(partition_end&& pe) override {
-            std::cout << "{partition_end}" << std::endl;
+            fmt::print("{{partition_end}}\n");
             return make_ready_future<stop_iteration>(stop_iteration::no);
         }
         virtual future<stop_iteration> on_end_of_sstable() override {
-            std::cout << "{sstable_end}" << std::endl;
+            fmt::print("{{sstable_end}}\n");
             return make_ready_future<stop_iteration>(stop_iteration::no);
         }
         virtual future<> on_end_of_stream() override {
-            std::cout << "{stream_end}" << std::endl;
+            fmt::print("{{stream_end}}\n");
             return make_ready_future<>();
         }
     };


### PR DESCRIPTION
Replacing the previous text output with the exception of the dump-data
command. The text output was supposed to be human-friendly but it is not
really human friendlier than a well formatted JSON, the latter having
the additional advantage of being machine friendly too. Although the
text output already exists, having just one output format makes the code
much simpler and easier to maintain so we chose not to pay the higher
maintenance price for a format that is not expected to see much (if any)
use.
Although the JSON written by the tool is not formatted, it can easily be
formatted by e.g. piping it through `jq`. The latter also allows lookup
of specific field(s).
The JSON schema of each command is documented in the --help output of
the respective command (e.g. scylla sstable data-dump --help) .

We keep the text output of the dump-data command as this is using
scylla's built-in printer that we also use in logging and tests. Some
people might be used to this format, so leave it in: the code already
exists for it and lives in scylla core, so we don't need to maintain it
separately. The default output-format of dump-data is now JSON.

A smoke test suite is added for the dump commands too. The tests only
check that some output is present and that it is valid JSON.

Refs: #9882

Tests: unit(dev)

Also on: https://github.com/denesb/scylla.git scylla-sstable-json/v2

Changelog

v3:
* Rebase on recent master (which has the required seastar fixes for
  debug tests)

v2:
* Document the JSON schema of each command.
* Use the SAX-style API of rapidjson to generate streaming JSON, instead
  of hand-generating it.