### PR TITLE
scylla_raid_setup: revert workaround patch and stop using mdmonitor for branch-4.5

### DIFF
--- a/dist/common/scripts/scylla_raid_setup
+++ b/dist/common/scripts/scylla_raid_setup
@@ -115,11 +115,6 @@ if __name__ == '__main__':
         pkg_install('xfsprogs')
     if not shutil.which('mdadm'):
         pkg_install('mdadm')
-    if args.raid_level != '0':
-        try:
-            md_service = systemd_unit('mdmonitor.service')
-        except SystemdException:
-            md_service = systemd_unit('mdadm.service')
 
     print('Creating {type} for scylla using {nr_disk} disk(s): {disks}'.format(type='RAID0' if raid else 'XFS volume', nr_disk=len(disks), disks=args.disks))
     procs=[]
@@ -154,16 +149,11 @@ if __name__ == '__main__':
     os.makedirs(mount_at, exist_ok=True)
 
     uuid = run(f'blkid -s UUID -o value {fsdev}', shell=True, check=True, capture_output=True, encoding='utf-8').stdout.strip()
-    after = 'local-fs.target'
-    wants = ''
-    if raid and args.raid_level != '0':
-        after += f' {md_service}'
-        wants = f'\nWants={md_service}'
     unit_data = f'''
 [Unit]
 Description=Scylla data directory
 Before=scylla-server.service
-After={after}{wants}
+After=local-fs.target
 DefaultDependencies=no
 
 [Mount]
@@ -187,8 +177,6 @@ WantedBy=multi-user.target
             f.write(f'RequiresMountsFor={mount_at}\n')
 
     systemd_unit.reload()
-    if args.raid_level != '0':
-        md_service.start()
     mount = systemd_unit(mntunit_bn)
     mount.start()
     if args.enable_on_nextboot:


### PR DESCRIPTION
We found that monitor mode of mdadm does not work on RAID0, and it is
not a bug, expected behavior according to RHEL developer.
Therefore, we should revert workaround patch which downgrades mdadm,
and stop enabling mdmonitor since we always use RAID0.

See #9540

----

This is branch-4.5 version of https://github.com/scylladb/scylla/pull/9970, since branch-4.5 does not have RAID5, so the implementation should be different.
Instead of original patch, this PR unconditionally drop mdmonitor since we only use RAID0 on this branch.

The implementation is copied from https://github.com/scylladb/scylla-enterprise/pull/2107