### PR TITLE
Commitlog: refactor file handling - simplify file management + make bookkeep safer

### DIFF
--- a/db/commitlog/commitlog.cc
+++ b/db/commitlog/commitlog.cc
@@ -110,6 +110,10 @@ db::commitlog::config db::commitlog::config::from_db_config(const db::config& cf
     c.use_o_dsync = cfg.commitlog_use_o_dsync();
     c.allow_going_over_size_limit = !cfg.commitlog_use_hard_size_limit();
 
+    if (cfg.commitlog_flush_threshold_in_mb() >= 0) {
+        c.commitlog_flush_threshold_in_mb = cfg.commitlog_flush_threshold_in_mb();
+    }
+
     return c;
 }
 

--- a/db/commitlog/commitlog.hh
+++ b/db/commitlog/commitlog.hh
@@ -109,7 +109,6 @@ public:
         sync_mode mode = sync_mode::PERIODIC;
         std::string fname_prefix = descriptor::FILENAME_PREFIX;
 
-        bool reuse_segments = true;
         bool use_o_dsync = false;
         bool warn_about_segments_left_on_disk_after_shutdown = true;
         bool allow_going_over_size_limit = true;

--- a/db/config.cc
+++ b/db/config.cc
@@ -427,6 +427,8 @@ db::config::config(std::shared_ptr<db::extensions> exts)
     /* Note: Unused. Retained for upgrade compat. Deprecate and remove in a cycle or two. */
     , commitlog_reuse_segments(this, "commitlog_reuse_segments", value_status::Unused, true,
         "Whether or not to re-use commitlog segments when finished instead of deleting them. Can improve commitlog latency on some file systems.\n")        
+    , commitlog_flush_threshold_in_mb(this, "commitlog_flush_threshold_in_mb", value_status::Used, -1,
+        "Threshold for commitlog disk usage. When used disk space goes above this value, Scylla initiates flushes of memtables to disk for the oldest commitlog segments, removing those log segments. Adjusting this affects disk usage vs. write latency. Default is (approximately) commitlog_total_space_in_mb - <num shards>*commitlog_segment_size_in_mb.")
     , commitlog_use_o_dsync(this, "commitlog_use_o_dsync", value_status::Used, true,
         "Whether or not to use O_DSYNC mode for commitlog segments IO. Can improve commitlog latency on some file systems.\n")
     , commitlog_use_hard_size_limit(this, "commitlog_use_hard_size_limit", value_status::Used, false,

--- a/db/config.cc
+++ b/db/config.cc
@@ -424,8 +424,9 @@ db::config::config(std::shared_ptr<db::extensions> exts)
     , commitlog_total_space_in_mb(this, "commitlog_total_space_in_mb", value_status::Used, -1,
         "Total space used for commitlogs. If the used space goes above this value, Scylla rounds up to the next nearest segment multiple and flushes memtables to disk for the oldest commitlog segments, removing those log segments. This reduces the amount of data to replay on startup, and prevents infrequently-updated tables from indefinitely keeping commitlog segments. A small total commitlog space tends to cause more flush activity on less-active tables.\n"
         "Related information: Configuring memtable throughput")
-    , commitlog_reuse_segments(this, "commitlog_reuse_segments", value_status::Used, true,
-        "Whether or not to re-use commitlog segments when finished instead of deleting them. Can improve commitlog latency on some file systems.\n")
+    /* Note: Unused. Retained for upgrade compat. Deprecate and remove in a cycle or two. */
+    , commitlog_reuse_segments(this, "commitlog_reuse_segments", value_status::Unused, true,
+        "Whether or not to re-use commitlog segments when finished instead of deleting them. Can improve commitlog latency on some file systems.\n")        
     , commitlog_use_o_dsync(this, "commitlog_use_o_dsync", value_status::Used, true,
         "Whether or not to use O_DSYNC mode for commitlog segments IO. Can improve commitlog latency on some file systems.\n")
     , commitlog_use_hard_size_limit(this, "commitlog_use_hard_size_limit", value_status::Used, false,

--- a/db/config.hh
+++ b/db/config.hh
@@ -173,6 +173,7 @@ public:
     named_value<uint32_t> commitlog_sync_batch_window_in_ms;
     named_value<int64_t> commitlog_total_space_in_mb;
     named_value<bool> commitlog_reuse_segments; // unused. retained for upgrade compat
+    named_value<int64_t> commitlog_flush_threshold_in_mb;
     named_value<bool> commitlog_use_o_dsync;
     named_value<bool> commitlog_use_hard_size_limit;
     named_value<bool> compaction_preheat_key_cache;

--- a/db/config.hh
+++ b/db/config.hh
@@ -172,7 +172,7 @@ public:
     named_value<uint32_t> commitlog_sync_period_in_ms;
     named_value<uint32_t> commitlog_sync_batch_window_in_ms;
     named_value<int64_t> commitlog_total_space_in_mb;
-    named_value<bool> commitlog_reuse_segments;
+    named_value<bool> commitlog_reuse_segments; // unused. retained for upgrade compat
     named_value<bool> commitlog_use_o_dsync;
     named_value<bool> commitlog_use_hard_size_limit;
     named_value<bool> compaction_preheat_key_cache;

--- a/db/hints/manager.cc
+++ b/db/hints/manager.cc
@@ -392,9 +392,6 @@ future<db::commitlog> manager::end_point_hints_manager::add_store() noexcept {
             cfg.fname_prefix = manager::FILENAME_PREFIX;
             cfg.extensions = &_shard_manager.local_db().extensions();
 
-            // HH doesn't utilize the flow that benefits from reusing segments.
-            // Therefore let's simply disable it to avoid any possible confusion.
-            cfg.reuse_segments = false;
             // HH leaves segments on disk after commitlog shutdown, and later reads
             // them when commitlog is re-created. This is expected to happen regularly
             // during standard HH workload, so no need to print a warning about it.

--- a/test/boost/commitlog_test.cc
+++ b/test/boost/commitlog_test.cc
@@ -752,7 +752,6 @@ SEASTAR_TEST_CASE(test_commitlog_deadlock_in_recycle) {
     // ensure total size per shard is not multiple of segment size.
     cfg.commitlog_total_space_in_mb = 5 * smp::count;
     cfg.commitlog_sync_period_in_ms = 10;
-    cfg.reuse_segments = true;
     cfg.allow_going_over_size_limit = false;
     cfg.use_o_dsync = true; // make sure we pre-allocate.
 
@@ -823,7 +822,6 @@ SEASTAR_TEST_CASE(test_commitlog_shutdown_during_wait) {
     // ensure total size per shard is not multiple of segment size.
     cfg.commitlog_total_space_in_mb = 5 * smp::count;
     cfg.commitlog_sync_period_in_ms = 10;
-    cfg.reuse_segments = true;
     cfg.allow_going_over_size_limit = false;
     cfg.use_o_dsync = true; // make sure we pre-allocate.
 
@@ -891,7 +889,6 @@ SEASTAR_TEST_CASE(test_commitlog_deadlock_with_flush_threshold) {
     cfg.commitlog_segment_size_in_mb = max_size_mb;
     cfg.commitlog_total_space_in_mb = 2 * max_size_mb * smp::count;
     cfg.commitlog_sync_period_in_ms = 10;
-    cfg.reuse_segments = true;
     cfg.allow_going_over_size_limit = false;
     cfg.use_o_dsync = true; // make sure we pre-allocate.
 
@@ -937,7 +934,7 @@ SEASTAR_TEST_CASE(test_commitlog_deadlock_with_flush_threshold) {
     }
 }
 
-static future<> do_test_exception_in_allocate_ex(bool do_file_delete, bool reuse = true) {
+static future<> do_test_exception_in_allocate_ex(bool do_file_delete) {
     commitlog::config cfg;
 
     constexpr auto max_size_mb = 1;
@@ -945,7 +942,6 @@ static future<> do_test_exception_in_allocate_ex(bool do_file_delete, bool reuse
     cfg.commitlog_segment_size_in_mb = max_size_mb;
     cfg.commitlog_total_space_in_mb = 2 * max_size_mb * smp::count;
     cfg.commitlog_sync_period_in_ms = 10;
-    cfg.reuse_segments = reuse;
     cfg.allow_going_over_size_limit = false; // #9348 - now can enforce size limit always
     cfg.use_o_dsync = true; // make sure we pre-allocate.
 
@@ -1030,18 +1026,11 @@ SEASTAR_TEST_CASE(test_commitlog_exceptions_in_allocate_ex) {
     co_await do_test_exception_in_allocate_ex(false);
 }
 
-SEASTAR_TEST_CASE(test_commitlog_exceptions_in_allocate_ex_no_recycle) {
-    co_await do_test_exception_in_allocate_ex(false, false);
-}
-
 /**
  * Test generating an exception in segment file allocation, but also 
  * delete the file, which in turn should cause follow-up exceptions
  * in cleanup delete. Which CL should handle
  */
-SEASTAR_TEST_CASE(test_commitlog_exceptions_in_allocate_ex_deleted_file) {
-    co_await do_test_exception_in_allocate_ex(true, false);
-}
 
 SEASTAR_TEST_CASE(test_commitlog_exceptions_in_allocate_ex_deleted_file_no_recycle) {
     co_await do_test_exception_in_allocate_ex(true);


### PR DESCRIPTION
Adds a "named_file" wrapper type in commitlog, encapsulating file and disk size, the latter being updated automatically on write/truncate/allocate/delete operations. Use this instead of loose vars in segments, and also in recycle/delete lists.

Having the data propagate with the objects means we can dispose of re-reading sizes from disk, which in turn means we know what "our" view of the file sizes is when we try to delete/recycle them -> we can bookkeep accurately (from our view point) without having to resort to the rather horrible recalculation of disk footprint. 

This series also drops non-recycled segment handling, since it is not used anywhere, and just makes things harder. 
It also adds a parameter to set flush threshold. 
These two first patches could be broken out into separate PR:s if need be.