### PR TITLE
exception_container: do not throw in accept

### DIFF
--- a/test/boost/exception_container_test.cc
+++ b/test/boost/exception_container_test.cc
@@ -47,7 +47,7 @@ SEASTAR_TEST_CASE(test_exception_container) {
     BOOST_REQUIRE(foo);
     BOOST_REQUIRE(bar);
 
-    BOOST_REQUIRE_THROW(foo_bar_what(empty), utils::bad_exception_container_access);
+    BOOST_REQUIRE_EQUAL(foo_bar_what(empty), sstring("bad exception container access"));
     BOOST_REQUIRE_EQUAL(foo_bar_what(foo), sstring("foo"));
     BOOST_REQUIRE_EQUAL(foo_bar_what(bar), sstring("bar"));
 
@@ -72,6 +72,26 @@ SEASTAR_TEST_CASE(test_exception_container) {
     BOOST_REQUIRE_THROW(f_empty.get(), utils::bad_exception_container_access);
     BOOST_REQUIRE_THROW(f_foo.get(), foo_exception);
     BOOST_REQUIRE_THROW(f_bar.get(), bar_exception);
+
+    return make_ready_future<>();
+}
+
+SEASTAR_TEST_CASE(test_exception_container_empty_accept) {
+    auto empty = foo_bar_container();
+
+    struct visitor {
+        sstring operator()(const foo_exception&) {
+            return "had foo exception";
+        }
+        sstring operator()(const bar_exception&) {
+            return "had bar exception";
+        }
+        sstring operator()(const utils::bad_exception_container_access&) {
+            return "was empty";
+        }
+    };
+
+    BOOST_REQUIRE_EQUAL(empty.accept(visitor{}), "was empty");
 
     return make_ready_future<>();
 }

--- a/test/boost/result_utils_test.cc
+++ b/test/boost/result_utils_test.cc
@@ -361,6 +361,23 @@ SEASTAR_THREAD_TEST_CASE(test_result_try_catch_dots) {
     });
 }
 
+SEASTAR_THREAD_TEST_CASE(test_result_try_empty_exception_container) {
+    test_result_try_with_policies([] (auto policy) {
+        auto run = [&] () {
+            return policy.do_try(
+                [&] {
+                    return policy.error(exc_container());
+                },
+                utils::result_catch<utils::bad_exception_container_access>([&] (const auto& ex) {
+                    return policy.value("caught");
+                })
+            );
+        };
+
+        BOOST_CHECK_EQUAL(run().value(), "caught");
+    });
+}
+
 SEASTAR_THREAD_TEST_CASE(test_result_try_catch_forward_to_promise) {
     test_result_try_with_policies([] (auto policy) {
         auto handle = [&] (auto f) -> result<int> {

--- a/utils/exception_container.hh
+++ b/utils/exception_container.hh
@@ -79,9 +79,13 @@ public:
         return !empty();
     }
 
-    // Accepts a visitor
+    // Accepts a visitor.
+    // If the container is empty, the visitor is called with
+    // a bad_exception_container_access.
     auto accept(auto f) const {
-        check_nonempty();
+        if (empty()) {
+            return f(bad_exception_container_access());
+        }
         return std::visit(std::move(f), *_eptr);
     }
 


### PR DESCRIPTION
This commit changes the behavior of `exception_container::accept`. Now,
instead of throwing an `utils::bad_exception_container_access` exception
when the container is empty, the provided visitor is invoked with that
exception instead. There are two reasons for this change:

- The exception_container is supposed to allow handling exceptions
  without using the costly C++'s exception runtime. Although an empty
  container is an edge case, I think it the new behavior is more aligned
  with the class' purpose. The old behavior can be simulated by
  providing a visitor which throws when called with bad access
  exception.

- The new behavior fixes a bug in `result_try`/`result_futurize_try`.
  Before the change, if the `try` block returned a failed result with an
  empty exception container, a bad access exception would either be
  thrown or returned as an exceptional future without being handled by
  the `catch` clauses. Although nobody is supposed to return such
  result<>s on purpose, a moved out result can be returned by accident
  and it's important for the exception handling logic to be correct in
  such a situation.

Tests: unit(dev)