### PR TITLE
api: keyspace_scrub: validate params

### DIFF
--- a/api/api.cc
+++ b/api/api.cc
@@ -233,5 +233,32 @@ future<> set_server_done(http_context& ctx) {
     });
 }
 
+void req_params::process(const request& req) {
+    // Process mandatory parameters
+    for (auto& [name, ent] : params) {
+        if (!ent.is_mandatory) {
+            continue;
+        }
+        try {
+            ent.value = req.param[name];
+        } catch (std::out_of_range&) {
+            throw httpd::bad_param_exception(fmt::format("Mandatory parameter '{}' was not provided", name));
+        }
+    }
+
+    // Process optional parameters
+    for (auto& [name, value] : req.query_parameters) {
+        try {
+            auto& ent = params.at(name);
+            if (ent.is_mandatory) {
+                throw httpd::bad_param_exception(fmt::format("Parameter '{}' is expected to be provided as part of the request url", name));
+            }
+            ent.value = value;
+        } catch (std::out_of_range&) {
+            throw httpd::bad_param_exception(fmt::format("Unsupported optional parameter '{}'", name));
+        }
+    }
+}
+
 }
 

--- a/api/api.hh
+++ b/api/api.hh
@@ -237,6 +237,66 @@ public:
     operator T() const { return value; }
 };
 
+using mandatory = bool_class<struct mandatory_tag>;
+
+class req_params {
+public:
+    struct def {
+        std::optional<sstring> value;
+        mandatory is_mandatory = mandatory::no;
+
+        def(std::optional<sstring> value_ = std::nullopt, mandatory is_mandatory_ = mandatory::no)
+            : value(std::move(value_))
+            , is_mandatory(is_mandatory_)
+        { }
+
+        def(mandatory is_mandatory_)
+            : is_mandatory(is_mandatory_)
+        { }
+    };
+
+private:
+    std::unordered_map<sstring, def> params;
+
+public:
+    req_params(std::initializer_list<std::pair<sstring, def>> l) {
+        for (const auto& [name, ent] : l) {
+            add(std::move(name), std::move(ent));
+        }
+    }
+
+    void add(sstring name, def ent) {
+        params.emplace(std::move(name), std::move(ent));
+    }
+
+    void process(const request& req);
+
+    const std::optional<sstring>& get(const char* name) const {
+        return params.at(name).value;
+    }
+
+    template <typename T = sstring>
+    const std::optional<T> get_as(const char* name) const {
+        return get(name);
+    }
+
+    template <>
+    const std::optional<bool> get_as(const char* name) const {
+        auto value = get(name);
+        if (!value) {
+            return std::nullopt;
+        }
+        std::transform(value->begin(), value->end(), value->begin(), ::tolower);
+        if (value == "true" || value == "yes" || value == "1") {
+            return true;
+        }
+        if (value == "false" || value == "no" || value == "0") {
+            return false;
+        }
+        throw boost::bad_lexical_cast{};
+    }
+};
+
 utils_json::estimated_histogram time_to_json_histogram(const utils::time_estimated_histogram& val);
 
 }

--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -56,12 +56,15 @@ const locator::token_metadata& http_context::get_token_metadata() {
 namespace ss = httpd::storage_service_json;
 using namespace json;
 
-sstring validate_keyspace(http_context& ctx, const parameters& param) {
-    const auto& ks_name = param["keyspace"];
+sstring validate_keyspace(http_context& ctx, sstring ks_name) {
     if (ctx.db.local().has_keyspace(ks_name)) {
         return ks_name;
     }
     throw bad_param_exception(replica::no_such_keyspace(ks_name).what());
+}
+
+sstring validate_keyspace(http_context& ctx, const parameters& param) {
+    return validate_keyspace(ctx, param["keyspace"]);
 }
 
 // splits a request parameter assumed to hold a comma-separated list of table names

--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -1346,7 +1346,7 @@ void set_snapshot(http_context& ctx, routes& r, sharded<db::snapshot_ctl>& snap_
             } else if (scrub_mode_str == "VALIDATE") {
                 scrub_mode = sstables::compaction_type_options::scrub::mode::validate;
             } else {
-                throw std::invalid_argument(fmt::format("Unknown argument for 'scrub_mode' parameter: {}", scrub_mode_str));
+                throw httpd::bad_param_exception(fmt::format("Unknown argument for 'scrub_mode' parameter: {}", scrub_mode_str));
             }
         }
 
@@ -1369,7 +1369,7 @@ void set_snapshot(http_context& ctx, routes& r, sharded<db::snapshot_ctl>& snap_
         } else if (quarantine_mode_str == "ONLY") {
             opts.quarantine_operation_mode = sstables::compaction_type_options::scrub::quarantine_mode::only;
         } else {
-            throw std::invalid_argument(fmt::format("Unknown argument for 'quarantine_mode' parameter: {}", quarantine_mode_str));
+            throw httpd::bad_param_exception(fmt::format("Unknown argument for 'quarantine_mode' parameter: {}", quarantine_mode_str));
         }
         return f.then([&ctx, keyspace, column_families, opts] {
             return ctx.db.invoke_on_all([=] (replica::database& db) {


### PR DESCRIPTION
Refs #10087

Add validation of all params for the keyspace_scrub api.
The validation method is generic and should be used by all apis eventually,
but I'm leaving that as follow-up work.

While at it, fixed the exception types thrown on invalid `scrub_mode` or `quarantine_mode` values from `std::runtime_error` to `httpd::bad_param_exception` so to generate the `bad_request` http status.

And added unit tests to verify that, and the handling of an unknown parameter.

Test: unit(dev)
DTest: nodetool_additional_test.py::TestNodetool::{test_scrub_with_one_node_expect_data_loss,test_scrub_with_multi_nodes_expect_data_rebuild,test_scrub_sstable_with_invalid_fragment,test_scrub_ks_sstable_with_invalid_fragment,test_scrub_segregate_sstable_with_invalid_fragment,test_scrub_segregate_ks_sstable_with_invalid_fragment}