### PR TITLE
Propagate CQL coordinator timeouts and failures for reads

### DIFF
--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -534,7 +534,7 @@ indexed_table_select_statement::prepare_command_for_base_query(query_processor& 
     return cmd;
 }
 
-future<std::tuple<foreign_ptr<lw_shared_ptr<query::result>>, lw_shared_ptr<query::read_command>>>
+future<coordinator_result<std::tuple<foreign_ptr<lw_shared_ptr<query::result>>, lw_shared_ptr<query::read_command>>>>
 indexed_table_select_statement::do_execute_base_query(
         query_processor& qp,
         dht::partition_range_vector&& partition_ranges,
@@ -568,7 +568,7 @@ indexed_table_select_statement::do_execute_base_query(
         auto& ranges_to_vnodes = query_state.ranges_to_vnodes;
         auto& concurrency = query_state.concurrency;
         auto& previous_result_size = query_state.previous_result_size;
-        return repeat([this, is_paged, &previous_result_size, &ranges_to_vnodes, &merger, &qp, &state, &options, &concurrency, cmd, timeout]() {
+        return utils::result_repeat([this, is_paged, &previous_result_size, &ranges_to_vnodes, &merger, &qp, &state, &options, &concurrency, cmd, timeout]() {
             // Starting with 1 range, we check if the result was a short read, and if not,
             // we continue exponentially, asking for 2x more ranges than before
             dht::partition_range_vector prange = ranges_to_vnodes(concurrency);
@@ -605,20 +605,18 @@ indexed_table_select_statement::do_execute_base_query(
             if (previous_result_size < query::result_memory_limiter::maximum_result_size && concurrency < max_base_table_query_concurrency) {
                 concurrency *= 2;
             }
-            return qp.proxy().query(_schema, command, std::move(prange), options.get_consistency(), {timeout, state.get_permit(), state.get_client_state(), state.get_trace_state()})
-            .then([is_paged, &previous_result_size, &ranges_to_vnodes, &merger] (service::storage_proxy::coordinator_query_result qr) {
+            return qp.proxy().query_result(_schema, command, std::move(prange), options.get_consistency(), {timeout, state.get_permit(), state.get_client_state(), state.get_trace_state()})
+            .then(utils::result_wrap([is_paged, &previous_result_size, &ranges_to_vnodes, &merger] (service::storage_proxy::coordinator_query_result qr) -> coordinator_result<stop_iteration> {
                 auto is_short_read = qr.query_result->is_short_read();
                 // Results larger than 1MB should be shipped to the client immediately
                 const bool page_limit_reached = is_paged && qr.query_result->buf().size() >= query::result_memory_limiter::maximum_result_size;
                 previous_result_size = qr.query_result->buf().size();
                 merger(std::move(qr.query_result));
                 return stop_iteration(is_short_read || ranges_to_vnodes.empty() || page_limit_reached);
-            });
-        }).then([&merger]() {
-            return merger.get();
-        });
-    }).then([cmd] (foreign_ptr<lw_shared_ptr<query::result>> result) mutable {
-        return make_ready_future<value_type>(value_type(std::move(result), std::move(cmd)));
+            }));
+        }).then(utils::result_wrap([&merger, cmd]() mutable {
+            return make_ready_future<coordinator_result<value_type>>(value_type(merger.get(), std::move(cmd)));
+        }));
     });
 }
 
@@ -630,13 +628,14 @@ indexed_table_select_statement::execute_base_query(
         const query_options& options,
         gc_clock::time_point now,
         lw_shared_ptr<const service::pager::paging_state> paging_state) const {
-    return do_execute_base_query(qp, std::move(partition_ranges), state, options, now, paging_state).then_unpack(
-            [this, &state, &options, now, paging_state = std::move(paging_state)] (foreign_ptr<lw_shared_ptr<query::result>> result, lw_shared_ptr<query::read_command> cmd) {
+    return do_execute_base_query(qp, std::move(partition_ranges), state, options, now, paging_state).then(wrap_result_to_error_message(
+            [this, &state, &options, now, paging_state = std::move(paging_state)] (std::tuple<foreign_ptr<lw_shared_ptr<query::result>>, lw_shared_ptr<query::read_command>> result_and_cmd) {
+        auto&& [result, cmd] = result_and_cmd;
         return process_base_query_results(std::move(result), std::move(cmd), state, options, now, std::move(paging_state));
-    });
+    }));
 }
 
-future<std::tuple<foreign_ptr<lw_shared_ptr<query::result>>, lw_shared_ptr<query::read_command>>>
+future<coordinator_result<std::tuple<foreign_ptr<lw_shared_ptr<query::result>>, lw_shared_ptr<query::read_command>>>>
 indexed_table_select_statement::do_execute_base_query(
         query_processor& qp,
         std::vector<primary_key>&& primary_keys,
@@ -671,7 +670,7 @@ indexed_table_select_statement::do_execute_base_query(
         auto &key_it = query_state.current_primary_key;
         auto &previous_result_size = query_state.previous_result_size;
         auto &next_iteration_size = query_state.next_iteration_size;
-        return repeat([this, is_paged, &previous_result_size, &next_iteration_size, &keys, &key_it, &merger, &qp, &state, &options, cmd, timeout]() {
+        return utils::result_repeat([this, is_paged, &previous_result_size, &next_iteration_size, &keys, &key_it, &merger, &qp, &state, &options, cmd, timeout]() {
             // Starting with 1 key, we check if the result was a short read, and if not,
             // we continue exponentially, asking for 2x more key than before
             auto already_done = std::distance(keys.begin(), key_it);
@@ -685,7 +684,7 @@ indexed_table_select_statement::do_execute_base_query(
             auto command = ::make_lw_shared<query::read_command>(*cmd);
 
             query::result_merger oneshot_merger(cmd->get_row_limit(), query::max_partitions);
-            return map_reduce(key_it, key_it_end, [this, &qp, &state, &options, cmd, timeout] (auto& key) {
+            return utils::result_map_reduce(key_it, key_it_end, [this, &qp, &state, &options, cmd, timeout] (auto& key) {
                 auto command = ::make_lw_shared<query::read_command>(*cmd);
                 // for each partition, read just one clustering row (TODO: can
                 // get all needed rows of one partition at once.)
@@ -693,11 +692,11 @@ indexed_table_select_statement::do_execute_base_query(
                 if (key.clustering) {
                     command->slice._row_ranges.push_back(query::clustering_range::make_singular(key.clustering));
                 }
-                return qp.proxy().query(_schema, command, {dht::partition_range::make_singular(key.partition)}, options.get_consistency(), {timeout, state.get_permit(), state.get_client_state(), state.get_trace_state()})
-                .then([] (service::storage_proxy::coordinator_query_result qr) {
+                return qp.proxy().query_result(_schema, command, {dht::partition_range::make_singular(key.partition)}, options.get_consistency(), {timeout, state.get_permit(), state.get_client_state(), state.get_trace_state()})
+                .then(utils::result_wrap([] (service::storage_proxy::coordinator_query_result qr) -> coordinator_result<foreign_ptr<lw_shared_ptr<query::result>>> {
                     return std::move(qr.query_result);
-                });
-            }, std::move(oneshot_merger)).then([is_paged, &previous_result_size, &key_it, key_it_end = std::move(key_it_end), &keys, &merger] (foreign_ptr<lw_shared_ptr<query::result>> result) {
+                }));
+            }, std::move(oneshot_merger)).then(utils::result_wrap([is_paged, &previous_result_size, &key_it, key_it_end = std::move(key_it_end), &keys, &merger] (foreign_ptr<lw_shared_ptr<query::result>> result) -> coordinator_result<stop_iteration> {
                 auto is_short_read = result->is_short_read();
                 // Results larger than 1MB should be shipped to the client immediately
                 const bool page_limit_reached = is_paged && result->buf().size() >= query::result_memory_limiter::maximum_result_size;
@@ -705,12 +704,10 @@ indexed_table_select_statement::do_execute_base_query(
                 merger(std::move(result));
                 key_it = key_it_end;
                 return stop_iteration(is_short_read || key_it == keys.end() || page_limit_reached);
-            });
-        }).then([&merger] () {
-            return merger.get();
-        }).then([cmd] (foreign_ptr<lw_shared_ptr<query::result>> result) mutable {
-            return make_ready_future<value_type>(value_type(std::move(result), std::move(cmd)));
-        });
+            }));
+        }).then(utils::result_wrap([&merger, cmd] () mutable {
+            return make_ready_future<coordinator_result<value_type>>(value_type(merger.get(), std::move(cmd)));
+        }));
     });
 }
 
@@ -722,10 +719,11 @@ indexed_table_select_statement::execute_base_query(
         const query_options& options,
         gc_clock::time_point now,
         lw_shared_ptr<const service::pager::paging_state> paging_state) const {
-    return do_execute_base_query(qp, std::move(primary_keys), state, options, now, paging_state).then_unpack(
-            [this, &state, &options, now, paging_state = std::move(paging_state)] (foreign_ptr<lw_shared_ptr<query::result>> result, lw_shared_ptr<query::read_command> cmd) {
+    return do_execute_base_query(qp, std::move(primary_keys), state, options, now, paging_state).then(wrap_result_to_error_message(
+            [this, &state, &options, now, paging_state = std::move(paging_state)] (std::tuple<foreign_ptr<lw_shared_ptr<query::result>>, lw_shared_ptr<query::read_command>> result_and_cmd){
+        auto&& [result, cmd] = result_and_cmd;
         return process_base_query_results(std::move(result), std::move(cmd), state, options, now, std::move(paging_state));
-    });
+    }));
 }
 
 future<shared_ptr<cql_transport::messages::result_message>>
@@ -1102,8 +1100,8 @@ indexed_table_select_statement::do_execute(query_processor& qp,
                 [this, &options, &qp, &state, now, whole_partitions, partition_slices] (cql3::selection::result_set_builder& builder, std::unique_ptr<cql3::query_options>& internal_options) {
             // page size is set to the internal count page size, regardless of the user-provided value
             internal_options.reset(new cql3::query_options(std::move(internal_options), options.get_paging_state(), internal_paging_size));
-            return repeat([this, &builder, &options, &internal_options, &qp, &state, now, whole_partitions, partition_slices] () {
-                auto consume_results = [this, &builder, &options, &internal_options, &state] (foreign_ptr<lw_shared_ptr<query::result>> results, lw_shared_ptr<query::read_command> cmd, lw_shared_ptr<const service::pager::paging_state> paging_state) {
+            return utils::result_repeat([this, &builder, &options, &internal_options, &qp, &state, now, whole_partitions, partition_slices] () {
+                auto consume_results = [this, &builder, &options, &internal_options, &state] (foreign_ptr<lw_shared_ptr<query::result>> results, lw_shared_ptr<query::read_command> cmd, lw_shared_ptr<const service::pager::paging_state> paging_state) -> coordinator_result<stop_iteration> {
                     if (paging_state) {
                         paging_state = generate_view_paging_state_from_base_query_results(paging_state, results, state, options);
                     }
@@ -1120,29 +1118,29 @@ indexed_table_select_statement::do_execute(query_processor& qp,
                 };
 
                 if (whole_partitions || partition_slices) {
-                    return find_index_partition_ranges(qp, state, *internal_options).then_unpack(
+                    return find_index_partition_ranges(qp, state, *internal_options).then(utils::result_wrap_unpack(
                             [this, now, &state, &internal_options, &qp, consume_results = std::move(consume_results)] (dht::partition_range_vector partition_ranges, lw_shared_ptr<const service::pager::paging_state> paging_state) {
                         return do_execute_base_query(qp, std::move(partition_ranges), state, *internal_options, now, paging_state)
-                        .then_unpack([paging_state, consume_results = std::move(consume_results)](foreign_ptr<lw_shared_ptr<query::result>> results, lw_shared_ptr<query::read_command> cmd) {
+                        .then(utils::result_wrap_unpack([paging_state, consume_results = std::move(consume_results)](foreign_ptr<lw_shared_ptr<query::result>> results, lw_shared_ptr<query::read_command> cmd) {
                             return consume_results(std::move(results), std::move(cmd), std::move(paging_state));
-                        });
-                    });
+                        }));
+                    }));
                 } else {
-                    return find_index_clustering_rows(qp, state, *internal_options).then_unpack(
+                    return find_index_clustering_rows(qp, state, *internal_options).then(utils::result_wrap_unpack(
                             [this, now, &state, &internal_options, &qp, consume_results = std::move(consume_results)] (std::vector<primary_key> primary_keys, lw_shared_ptr<const service::pager::paging_state> paging_state) {
                         return this->do_execute_base_query(qp, std::move(primary_keys), state, *internal_options, now, paging_state)
-                        .then_unpack([paging_state, consume_results = std::move(consume_results)](foreign_ptr<lw_shared_ptr<query::result>> results, lw_shared_ptr<query::read_command> cmd) {
+                        .then(utils::result_wrap_unpack([paging_state, consume_results = std::move(consume_results)](foreign_ptr<lw_shared_ptr<query::result>> results, lw_shared_ptr<query::read_command> cmd) {
                             return consume_results(std::move(results), std::move(cmd), std::move(paging_state));
-                        });
-                    });
+                        }));
+                    }));
                 }
-            }).then([this, &builder] () {
+            }).then(wrap_result_to_error_message([this, &builder] () {
                 auto rs = builder.build();
                 update_stats_rows_read(rs->size());
                 _stats.filtered_rows_matched_total += _restrictions_need_filtering ? rs->size() : 0;
                 auto msg = ::make_shared<cql_transport::messages::result_message::rows>(result(std::move(rs)));
                 return make_ready_future<shared_ptr<cql_transport::messages::result_message>>(std::move(msg));
-            });
+            }));
         });
     }
 
@@ -1150,16 +1148,18 @@ indexed_table_select_statement::do_execute(query_processor& qp,
         tracing::trace(state.get_trace_state(), "Consulting index {} for a single slice of keys", _index.metadata().name());
         // In this case, can use our normal query machinery, which retrieves
         // entire partitions or the same slice for many partitions.
-        return find_index_partition_ranges(qp, state, options).then_unpack([now, &state, &options, &qp, this] (dht::partition_range_vector partition_ranges, lw_shared_ptr<const service::pager::paging_state> paging_state) {
+        return find_index_partition_ranges(qp, state, options).then(wrap_result_to_error_message([now, &state, &options, &qp, this] (std::tuple<dht::partition_range_vector, lw_shared_ptr<const service::pager::paging_state>> result) {
+            auto&& [partition_ranges, paging_state] = result;
             return this->execute_base_query(qp, std::move(partition_ranges), state, options, now, std::move(paging_state));
-        });
+        }));
     } else {
         tracing::trace(state.get_trace_state(), "Consulting index {} for a list of rows containing keys", _index.metadata().name());
         // In this case, we need to retrieve a list of rows (not entire
         // partitions) and then retrieve those specific rows.
-        return find_index_clustering_rows(qp, state, options).then_unpack([now, &state, &options, &qp, this] (std::vector<primary_key> primary_keys, lw_shared_ptr<const service::pager::paging_state> paging_state) {
+        return find_index_clustering_rows(qp, state, options).then(wrap_result_to_error_message([now, &state, &options, &qp, this] (std::tuple<std::vector<primary_key>, lw_shared_ptr<const service::pager::paging_state>> result) {
+            auto&& [primary_keys, paging_state] = result;
             return this->execute_base_query(qp, std::move(primary_keys), state, options, now, std::move(paging_state));
-        });
+        }));
     }
 }
 
@@ -1217,7 +1217,7 @@ query::partition_slice indexed_table_select_statement::get_partition_slice_for_l
 // Utility function for reading from the index view (get_index_view()))
 // the posting-list for a particular value of the indexed column.
 // Remember a secondary index can only be created on a single column.
-future<::shared_ptr<cql_transport::messages::result_message::rows>>
+future<coordinator_result<::shared_ptr<cql_transport::messages::result_message::rows>>>
 indexed_table_select_statement::read_posting_list(query_processor& qp,
                   const query_options& options,
                   uint64_t limit,
@@ -1255,27 +1255,29 @@ indexed_table_select_statement::read_posting_list(query_processor& qp,
 
     int32_t page_size = options.get_page_size();
     if (page_size <= 0 || !service::pager::query_pagers::may_need_paging(*_view_schema, page_size, *cmd, partition_ranges)) {
-        return qp.proxy().query(_view_schema, cmd, std::move(partition_ranges), options.get_consistency(), {timeout, state.get_permit(), state.get_client_state(), state.get_trace_state()})
-        .then([this, now, &options, selection = std::move(selection), partition_slice = std::move(partition_slice)] (service::storage_proxy::coordinator_query_result qr) {
+        return qp.proxy().query_result(_view_schema, cmd, std::move(partition_ranges), options.get_consistency(), {timeout, state.get_permit(), state.get_client_state(), state.get_trace_state()})
+        .then(utils::result_wrap([this, now, &options, selection = std::move(selection), partition_slice = std::move(partition_slice)] (service::storage_proxy::coordinator_query_result qr)
+                -> coordinator_result<::shared_ptr<cql_transport::messages::result_message::rows>> {
             cql3::selection::result_set_builder builder(*selection, now, options.get_cql_serialization_format());
             query::result_view::consume(*qr.query_result,
                                         std::move(partition_slice),
                                         cql3::selection::result_set_builder::visitor(builder, *_view_schema, *selection));
             return ::make_shared<cql_transport::messages::result_message::rows>(result(builder.build()));
-        });
+        }));
     }
 
     auto p = service::pager::query_pagers::pager(qp.proxy(), _view_schema, selection,
             state, options, cmd, std::move(partition_ranges), nullptr);
-    return p->fetch_page(options.get_page_size(), now, timeout).then([p = std::move(p), &options, limit, now] (std::unique_ptr<cql3::result_set> rs) {
+    return p->fetch_page_result(options.get_page_size(), now, timeout).then(utils::result_wrap([p = std::move(p), &options, limit, now] (std::unique_ptr<cql3::result_set> rs)
+            -> coordinator_result<::shared_ptr<cql_transport::messages::result_message::rows>> {
         rs->get_metadata().set_paging_state(p->state());
         return ::make_shared<cql_transport::messages::result_message::rows>(result(std::move(rs)));
-    });
+    }));
 }
 
 // Note: the partitions keys returned by this function are sorted
 // in token order. See issue #3423.
-future<std::tuple<dht::partition_range_vector, lw_shared_ptr<const service::pager::paging_state>>>
+future<coordinator_result<std::tuple<dht::partition_range_vector, lw_shared_ptr<const service::pager::paging_state>>>>
 indexed_table_select_statement::find_index_partition_ranges(query_processor& qp,
                                              service::query_state& state,
                                              const query_options& options) const
@@ -1283,7 +1285,7 @@ indexed_table_select_statement::find_index_partition_ranges(query_processor& qp,
     using value_type = std::tuple<dht::partition_range_vector, lw_shared_ptr<const service::pager::paging_state>>;
     auto now = gc_clock::now();
     auto timeout = db::timeout_clock::now() + get_timeout(state.get_client_state(), options);
-    return read_posting_list(qp, options, get_limit(options), state, now, timeout, false).then(
+    return read_posting_list(qp, options, get_limit(options), state, now, timeout, false).then(utils::result_wrap(
             [this, now, &options] (::shared_ptr<cql_transport::messages::result_message::rows> rows) {
         auto rs = cql3::untyped_result_set(rows);
         dht::partition_range_vector partition_ranges;
@@ -1312,19 +1314,19 @@ indexed_table_select_statement::find_index_partition_ranges(query_processor& qp,
             partition_ranges.emplace_back(range);
         }
         auto paging_state = rows->rs().get_metadata().paging_state();
-        return make_ready_future<value_type>(value_type(std::move(partition_ranges), std::move(paging_state)));
-    });
+        return make_ready_future<coordinator_result<value_type>>(value_type(std::move(partition_ranges), std::move(paging_state)));
+    }));
 }
 
 // Note: the partitions keys returned by this function are sorted
 // in token order. See issue #3423.
-future<std::tuple<std::vector<indexed_table_select_statement::primary_key>, lw_shared_ptr<const service::pager::paging_state>>>
+future<coordinator_result<std::tuple<std::vector<indexed_table_select_statement::primary_key>, lw_shared_ptr<const service::pager::paging_state>>>>
 indexed_table_select_statement::find_index_clustering_rows(query_processor& qp, service::query_state& state, const query_options& options) const
 {
     using value_type = std::tuple<std::vector<indexed_table_select_statement::primary_key>, lw_shared_ptr<const service::pager::paging_state>>;
     auto now = gc_clock::now();
     auto timeout = db::timeout_clock::now() + get_timeout(state.get_client_state(), options);
-    return read_posting_list(qp, options, get_limit(options), state, now, timeout, true).then(
+    return read_posting_list(qp, options, get_limit(options), state, now, timeout, true).then(utils::result_wrap(
             [this, now, &options] (::shared_ptr<cql_transport::messages::result_message::rows> rows) {
 
         auto rs = cql3::untyped_result_set(rows);
@@ -1344,8 +1346,8 @@ indexed_table_select_statement::find_index_clustering_rows(query_processor& qp, 
             primary_keys.emplace_back(primary_key{std::move(dk), std::move(ck)});
         }
         auto paging_state = rows->rs().get_metadata().paging_state();
-        return make_ready_future<value_type>(value_type(std::move(primary_keys), std::move(paging_state)));
-    });
+        return make_ready_future<coordinator_result<value_type>>(value_type(std::move(primary_keys), std::move(paging_state)));
+    }));
 }
 
 

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -310,6 +310,15 @@ select_statement::execute(query_processor& qp,
                              service::query_state& state,
                              const query_options& options) const
 {
+    return execute_without_checking_exception_message(qp, state, options)
+            .then(cql_transport::messages::propagate_exception_as_future<shared_ptr<cql_transport::messages::result_message>>);
+}
+
+future<shared_ptr<cql_transport::messages::result_message>>
+select_statement::execute_without_checking_exception_message(query_processor& qp,
+                             service::query_state& state,
+                             const query_options& options) const
+{
     return select_stage(this, seastar::ref(qp), seastar::ref(state), seastar::cref(options));
 }
 
@@ -385,7 +394,7 @@ select_statement::do_execute(query_processor& qp,
     if (!aggregate && !_restrictions_need_filtering && (page_size <= 0
             || !service::pager::query_pagers::may_need_paging(*_schema, page_size,
                     *command, key_ranges))) {
-        return execute(qp, command, std::move(key_ranges), state, options, now);
+        return execute_without_checking_exception_message(qp, command, std::move(key_ranges), state, options, now);
     }
 
     command->slice.options.set<query::partition_slice::option::allow_short_read>();
@@ -722,6 +731,18 @@ indexed_table_select_statement::execute_base_query(
 
 future<shared_ptr<cql_transport::messages::result_message>>
 select_statement::execute(query_processor& qp,
+                          lw_shared_ptr<query::read_command> cmd,
+                          dht::partition_range_vector&& partition_ranges,
+                          service::query_state& state,
+                          const query_options& options,
+                          gc_clock::time_point now) const
+{
+    return execute_without_checking_exception_message(qp, std::move(cmd), std::move(partition_ranges), state, options, now)
+            .then(cql_transport::messages::propagate_exception_as_future<shared_ptr<cql_transport::messages::result_message>>);
+}
+
+future<shared_ptr<cql_transport::messages::result_message>>
+select_statement::execute_without_checking_exception_message(query_processor& qp,
                           lw_shared_ptr<query::read_command> cmd,
                           dht::partition_range_vector&& partition_ranges,
                           service::query_state& state,

--- a/cql3/statements/select_statement.hh
+++ b/cql3/statements/select_statement.hh
@@ -19,6 +19,7 @@
 #include <seastar/core/shared_ptr.hh>
 #include "transport/messages/result_message.hh"
 #include "index/secondary_index_manager.hh"
+#include "exceptions/exceptions.hh"
 
 namespace service {
     class client_state;
@@ -46,6 +47,8 @@ namespace statements {
  */
 class select_statement : public cql_statement {
 public:
+    template<typename T>
+    using coordinator_result = exceptions::coordinator_result<T>;
     using parameters = raw::select_statement::parameters;
     using ordering_comparator_type = raw::select_statement::ordering_comparator_type;
     static constexpr int DEFAULT_COUNT_PAGE_SIZE = 10000;

--- a/cql3/statements/select_statement.hh
+++ b/cql3/statements/select_statement.hh
@@ -109,7 +109,14 @@ public:
     virtual future<::shared_ptr<cql_transport::messages::result_message>> execute(query_processor& qp,
         service::query_state& state, const query_options& options) const override;
 
+    virtual future<::shared_ptr<cql_transport::messages::result_message>>
+        execute_without_checking_exception_message(query_processor& qp, service::query_state& qs, const query_options& options) const override;
+
     future<::shared_ptr<cql_transport::messages::result_message>> execute(query_processor& qp,
+        lw_shared_ptr<query::read_command> cmd, dht::partition_range_vector&& partition_ranges, service::query_state& state,
+         const query_options& options, gc_clock::time_point now) const;
+
+    future<::shared_ptr<cql_transport::messages::result_message>> execute_without_checking_exception_message(query_processor& qp,
         lw_shared_ptr<query::read_command> cmd, dht::partition_range_vector&& partition_ranges, service::query_state& state,
          const query_options& options, gc_clock::time_point now) const;
 

--- a/cql3/statements/select_statement.hh
+++ b/cql3/statements/select_statement.hh
@@ -216,11 +216,11 @@ private:
     lw_shared_ptr<const service::pager::paging_state> generate_view_paging_state_from_base_query_results(lw_shared_ptr<const service::pager::paging_state> paging_state,
             const foreign_ptr<lw_shared_ptr<query::result>>& results, service::query_state& state, const query_options& options) const;
 
-    future<std::tuple<dht::partition_range_vector, lw_shared_ptr<const service::pager::paging_state>>> find_index_partition_ranges(query_processor& qp,
+    future<coordinator_result<std::tuple<dht::partition_range_vector, lw_shared_ptr<const service::pager::paging_state>>>> find_index_partition_ranges(query_processor& qp,
                                                                     service::query_state& state,
                                                                     const query_options& options) const;
 
-    future<std::tuple<std::vector<primary_key>, lw_shared_ptr<const service::pager::paging_state>>> find_index_clustering_rows(query_processor& qp,
+    future<coordinator_result<std::tuple<std::vector<primary_key>, lw_shared_ptr<const service::pager::paging_state>>>> find_index_clustering_rows(query_processor& qp,
                                                                 service::query_state& state,
                                                                 const query_options& options) const;
 
@@ -237,7 +237,7 @@ private:
     prepare_command_for_base_query(query_processor& qp, const query_options& options, service::query_state& state, gc_clock::time_point now,
             bool use_paging) const;
 
-    future<std::tuple<foreign_ptr<lw_shared_ptr<query::result>>, lw_shared_ptr<query::read_command>>>
+    future<coordinator_result<std::tuple<foreign_ptr<lw_shared_ptr<query::result>>, lw_shared_ptr<query::read_command>>>>
     do_execute_base_query(
             query_processor& qp,
             dht::partition_range_vector&& partition_ranges,
@@ -263,7 +263,7 @@ private:
     // but to implement the general case (multiple rows from multiple partitions)
     // efficiently, we will need more support from other layers.
     // Keys are ordered in token order (see #3423)
-    future<std::tuple<foreign_ptr<lw_shared_ptr<query::result>>, lw_shared_ptr<query::read_command>>>
+    future<coordinator_result<std::tuple<foreign_ptr<lw_shared_ptr<query::result>>, lw_shared_ptr<query::read_command>>>>
     do_execute_base_query(
             query_processor& qp,
             std::vector<primary_key>&& primary_keys,
@@ -285,7 +285,7 @@ private:
         _stats.secondary_index_rows_read += rows_read;
     }
 
-    future<::shared_ptr<cql_transport::messages::result_message::rows>>read_posting_list(
+    future<coordinator_result<::shared_ptr<cql_transport::messages::result_message::rows>>> read_posting_list(
             query_processor& qp,
             const query_options& options,
             uint64_t limit,

--- a/exceptions/exceptions.hh
+++ b/exceptions/exceptions.hh
@@ -348,7 +348,9 @@ public:
 // It is advised to use this mechanism mainly for exceptions which can
 // happen frequently, e.g. signalling timeouts, overloads or rate limits.
 using coordinator_exception_container = utils::exception_container<
-    mutation_write_timeout_exception
+    mutation_write_timeout_exception,
+    read_timeout_exception,
+    read_failure_exception
 >;
 
 template<typename T = void>

--- a/service/storage_proxy.hh
+++ b/service/storage_proxy.hh
@@ -13,6 +13,7 @@
 
 #pragma once
 
+#include <variant>
 #include "replica/database_fwd.hh"
 #include "data_dictionary/data_dictionary.hh"
 #include "message/messaging_service_fwd.hh"
@@ -379,7 +380,7 @@ private:
     future<result<>> schedule_repair(std::unordered_map<dht::token, std::unordered_map<gms::inet_address, std::optional<mutation>>> diffs, db::consistency_level cl, tracing::trace_state_ptr trace_state, service_permit permit);
     bool need_throttle_writes() const;
     void unthrottle();
-    void handle_read_error(std::exception_ptr eptr, bool range);
+    void handle_read_error(std::variant<exceptions::coordinator_exception_container, std::exception_ptr> failure, bool range);
     template<typename Range>
     future<result<>> mutate_internal(Range mutations, db::consistency_level cl, bool counter_write, tracing::trace_state_ptr tr_state, service_permit permit, std::optional<clock_type::time_point> timeout_opt = { }, lw_shared_ptr<cdc::operation_result_tracker> cdc_tracker = { });
     future<rpc::tuple<foreign_ptr<lw_shared_ptr<reconcilable_result>>, cache_temperature>> query_nonsingular_mutations_locally(

--- a/service/storage_proxy.hh
+++ b/service/storage_proxy.hh
@@ -291,7 +291,7 @@ private:
 
     cdc_stats _cdc_stats;
 private:
-    future<coordinator_query_result> query_singular(lw_shared_ptr<query::read_command> cmd,
+    future<result<coordinator_query_result>> query_singular(lw_shared_ptr<query::read_command> cmd,
             dht::partition_range_vector&& partition_ranges,
             db::consistency_level cl,
             coordinator_query_options optional_params);

--- a/service/storage_proxy.hh
+++ b/service/storage_proxy.hh
@@ -376,7 +376,7 @@ private:
     future<unique_response_handler_vector> mutate_prepare(Range&& mutations, db::consistency_level cl, db::write_type type, tracing::trace_state_ptr tr_state, service_permit permit);
     future<result<>> mutate_begin(unique_response_handler_vector ids, db::consistency_level cl, tracing::trace_state_ptr trace_state, std::optional<clock_type::time_point> timeout_opt = { });
     future<result<>> mutate_end(future<result<>> mutate_result, utils::latency_counter, write_stats& stats, tracing::trace_state_ptr trace_state);
-    future<> schedule_repair(std::unordered_map<dht::token, std::unordered_map<gms::inet_address, std::optional<mutation>>> diffs, db::consistency_level cl, tracing::trace_state_ptr trace_state, service_permit permit);
+    future<result<>> schedule_repair(std::unordered_map<dht::token, std::unordered_map<gms::inet_address, std::optional<mutation>>> diffs, db::consistency_level cl, tracing::trace_state_ptr trace_state, service_permit permit);
     bool need_throttle_writes() const;
     void unthrottle();
     void handle_read_error(std::exception_ptr eptr, bool range);

--- a/service/storage_proxy.hh
+++ b/service/storage_proxy.hh
@@ -361,7 +361,7 @@ private:
             replicas_per_token_range preferred_replicas,
             service_permit permit);
 
-    future<coordinator_query_result> do_query(schema_ptr,
+    future<result<coordinator_query_result>> do_query(schema_ptr,
         lw_shared_ptr<query::read_command> cmd,
         dht::partition_range_vector&& partition_ranges,
         db::consistency_level cl,
@@ -579,6 +579,16 @@ public:
      * parameter can be changed after being passed to this method.
      */
     future<coordinator_query_result> query(schema_ptr,
+        lw_shared_ptr<query::read_command> cmd,
+        dht::partition_range_vector&& partition_ranges,
+        db::consistency_level cl,
+        coordinator_query_options optional_params);
+
+    /*
+     * Like query(), but is allowed to return some exceptions as a result.
+     * The caller must remember to handle them properly.
+     */
+    future<result<coordinator_query_result>> query_result(schema_ptr,
         lw_shared_ptr<query::read_command> cmd,
         dht::partition_range_vector&& partition_ranges,
         db::consistency_level cl,

--- a/service/storage_proxy.hh
+++ b/service/storage_proxy.hh
@@ -349,7 +349,7 @@ private:
             db::consistency_level cl,
             coordinator_query_options optional_params);
     static inet_address_vector_replica_set intersection(const inet_address_vector_replica_set& l1, const inet_address_vector_replica_set& l2);
-    future<query_partition_key_range_concurrent_result> query_partition_key_range_concurrent(clock_type::time_point timeout,
+    future<result<query_partition_key_range_concurrent_result>> query_partition_key_range_concurrent(clock_type::time_point timeout,
             std::vector<foreign_ptr<lw_shared_ptr<query::result>>>&& results,
             lw_shared_ptr<query::read_command> cmd,
             db::consistency_level cl,

--- a/service/storage_proxy.hh
+++ b/service/storage_proxy.hh
@@ -344,7 +344,7 @@ private:
                                                                                                    tracing::trace_state_ptr trace_state,
                                                                                                    clock_type::time_point timeout,
                                                                                                    query::digest_algorithm da);
-    future<coordinator_query_result> query_partition_key_range(lw_shared_ptr<query::read_command> cmd,
+    future<result<coordinator_query_result>> query_partition_key_range(lw_shared_ptr<query::read_command> cmd,
             dht::partition_range_vector partition_ranges,
             db::consistency_level cl,
             coordinator_query_options optional_params);

--- a/test/boost/result_utils_test.cc
+++ b/test/boost/result_utils_test.cc
@@ -110,6 +110,18 @@ SEASTAR_THREAD_TEST_CASE(test_result_wrap) {
 
     BOOST_REQUIRE_THROW(fun_int(result<int>(bo::failure(foo_exception()))).get().value(), foo_exception);
     BOOST_REQUIRE_EQUAL(run_count, 2);
+
+    // T is a tuple, result_wrap_unpack
+    auto fun_tuple = utils::result_wrap_unpack([&run_count] (int x, int y) -> result<int> {
+        ++run_count;
+        return bo::success(x + y);
+    });
+
+    BOOST_REQUIRE_EQUAL(fun_tuple(result<std::tuple<int, int>>(bo::success(std::make_tuple(123, 321)))).get().value(), 444);
+    BOOST_REQUIRE_EQUAL(run_count, 3);
+
+    BOOST_REQUIRE_THROW(fun_tuple(result<std::tuple<int, int>>(bo::failure(foo_exception()))).get().value(), foo_exception);
+    BOOST_REQUIRE_EQUAL(run_count, 3);
 }
 
 // If T is a future, attaches a continuation and converts it to future<U>

--- a/utils/result.hh
+++ b/utils/result.hh
@@ -44,4 +44,16 @@ concept ExceptionContainerResult = bo::is_basic_result<R>::value && ExceptionCon
 template<typename F>
 concept ExceptionContainerResultFuture = seastar::is_future<F>::value && ExceptionContainerResult<typename F::value_type>;
 
+template<typename L, typename R>
+concept ResultRebindableTo =
+    bo::is_basic_result<L>::value &&
+    bo::is_basic_result<R>::value &&
+    std::same_as<typename L::error_type, typename R::error_type> &&
+    std::same_as<typename L::no_value_policy_type, typename R::no_value_policy_type>;
+
+// Creates a result type which has the same error type as R, but has a different value type.
+// The name was inspired by std::allocator::rebind.
+template<typename T, ExceptionContainerResult R>
+using rebind_result = bo::result<T, typename R::error_type, exception_container_throw_policy>;
+
 }

--- a/utils/result_combinators.hh
+++ b/utils/result_combinators.hh
@@ -47,6 +47,16 @@ seastar::future<R> then_ok_result(seastar::future<typename R::value_type>&& f) {
     }
 }
 
+// Takes a result<T>, discards the inner value and returns result<>.
+template<ExceptionContainerResult R>
+rebind_result<void, R> result_discard_value(R&& res) {
+    if (res) {
+        return bo::success();
+    } else {
+        return std::move(res).as_failure();
+    }
+}
+
 namespace internal {
 
 template<typename C, typename Arg>

--- a/utils/result_try.hh
+++ b/utils/result_try.hh
@@ -103,6 +103,18 @@ public:
     void forward_to_promise(seastar::promise<S>& p) {
         p.set_value(std::move(_failed_result).as_failure());
     }
+
+    const typename R::error_type& as_inner() const & {
+        return _failed_result.assume_error();
+    }
+
+    typename R::error_type&& as_inner() && {
+        return std::move(_failed_result).assume_error();
+    }
+
+    typename R::error_type clone_inner() {
+        return _failed_result.assume_error().clone();
+    }
 };
 
 static_assert(ExceptionHandle<failed_result_handle<dummy_result<>>>);
@@ -128,6 +140,18 @@ public:
     requires std::same_as<typename R::error_type, typename S::error_type>
     void forward_to_promise(seastar::promise<S>& p) {
         p.set_exception(std::move(_eptr));
+    }
+
+    const std::exception_ptr& as_inner() const & {
+        return _eptr;
+    }
+
+    std::exception_ptr&& as_inner() && {
+        return std::move(_eptr);
+    }
+
+    std::exception_ptr clone_inner() {
+        return _eptr;
     }
 };
 

--- a/utils/result_try.hh
+++ b/utils/result_try.hh
@@ -59,7 +59,7 @@ struct futurizing_converter {
 };
 
 template<typename From, typename Converter, typename To>
-concept ConvertsWithTo = std::convertible_to<From, typename Converter::template wrapped_type<To>>;
+concept ConvertsWithTo = std::convertible_to<typename Converter::template wrapped_type<From>, typename Converter::template wrapped_type<To>>;
 
 // We require forall<ExceptionContainerResult R> ExceptionHandle<H, R>.
 // However, C++ does not support quantification like that in the constraints.


### PR DESCRIPTION
This PR propagates the read coordinator logic so that read timeout and read failure exceptions are propagated without throwing on the coordinator side.

This PR is only concerned with exceptions which were originally thrown by the coordinator (in read resolvers). Exceptions propagated through RPC and RPC timeouts will still throw, although those exceptions will be caught and converted into exceptions-as-values by read resolvers.

This is a continuation of work started in #10014.

Results of `perf_simple_query --smp 1 --operations-per-shard 1000000` (read workload), compared with merge base (10880fb0a720e3dcddcb301f8f1c624923e89a03):

```
BEFORE:
125085.13 tps ( 80.2 allocs/op,  12.2 tasks/op,   49010 insns/op)
125645.88 tps ( 80.2 allocs/op,  12.2 tasks/op,   49008 insns/op)
126148.85 tps ( 80.2 allocs/op,  12.2 tasks/op,   49005 insns/op)
126044.40 tps ( 80.2 allocs/op,  12.2 tasks/op,   49005 insns/op)
125799.75 tps ( 80.2 allocs/op,  12.2 tasks/op,   49003 insns/op)

AFTER:
127557.21 tps ( 80.2 allocs/op,  12.2 tasks/op,   49197 insns/op)
127835.98 tps ( 80.2 allocs/op,  12.2 tasks/op,   49198 insns/op)
127749.81 tps ( 80.2 allocs/op,  12.2 tasks/op,   49202 insns/op)
128941.17 tps ( 80.2 allocs/op,  12.2 tasks/op,   49192 insns/op)
129276.15 tps ( 80.2 allocs/op,  12.2 tasks/op,   49182 insns/op)
```

The PR does not introduce additional allocations on the read happy-path. The number of instructions used grows by about 200 insns/op. The increase in TPS is probably just a measurement error.