### PR TITLE
Allow integers in scientific format in `INSERT JSON` 

### DIFF
--- a/cql3/type_json.cc
+++ b/cql3/type_json.cc
@@ -189,7 +189,7 @@ struct from_json_object_visitor {
             throw marshal_exception("bytes_type must be represented as string");
         }
         std::string_view string_v = rjson::to_string_view(value);
-        if (string_v.size() < 2 && string_v[0] != '0' && string_v[1] != 'x') {
+        if (string_v.size() < 2 || string_v[0] != '0' || string_v[1] != 'x') {
             throw marshal_exception("Blob JSON strings must start with 0x");
         }
         string_v.remove_prefix(2);

--- a/test/boost/json_cql_query_test.cc
+++ b/test/boost/json_cql_query_test.cc
@@ -26,6 +26,7 @@
 #include "types/tuple.hh"
 #include "types/user.hh"
 #include "types/list.hh"
+#include "utils/rjson.hh"
 
 using namespace std::literals::chrono_literals;
 
@@ -448,6 +449,115 @@ SEASTAR_TEST_CASE(test_insert_json_null_frozen_collections) {
                 )
             }
          });
+    });
+}
+
+SEASTAR_TEST_CASE(test_insert_json_integer_in_scientific_notation) {
+    return do_with_cql_env_thread([] (cql_test_env& e) {
+        // Verify that our JSON parsing supports
+        // inserting numbers like 1.23e+7 to an integer
+        // column (int, bigint, etc.). Numbers that contain
+        // a fractional part (12.34) are disallowed. Note
+        // that this behavior differs from Cassandra, which
+        // disallows all those types (1.23e+7, 12.34).
+
+        cquery_nofail(e,          
+            "CREATE TABLE scientific_notation ("
+                "    pk int primary key,"
+                "    v bigint,"
+                ");");
+
+        cquery_nofail(e, R"(
+            INSERT INTO scientific_notation JSON '{
+                "pk": 1, "v": 150.0
+            }'
+        )");
+        cquery_nofail(e, R"(
+            INSERT INTO scientific_notation JSON '{
+                "pk": 2, "v": 234
+            }'
+        )");
+        cquery_nofail(e, R"(
+            INSERT INTO scientific_notation JSON '{
+                "pk": 3, "v": 1E+6
+            }'
+        )");
+
+        // JSON standard specifies that numbers
+        // in range [-2^53+1, 2^53-1] are interoperable
+        // meaning implementations will agree 
+        // exactly on their numeric values. This range
+        // corresponds to a fact that double floating-point
+        // type has a 53-bit significand and converting
+        // from an integer in that range to double is non-lossy.
+        //
+        // This checks that precision is not lost 
+        // for the largest possible value in that range
+        // (2^53-1).
+        cquery_nofail(e, R"(
+            INSERT INTO scientific_notation JSON '{
+                "pk": 4, "v": 9.007199254740991E+15
+            }'
+        )"); 
+
+        cquery_nofail(e, R"(
+            INSERT INTO scientific_notation JSON '{
+                "pk": 5, "v": 0.0e3
+            }'
+        )");
+        cquery_nofail(e, R"(
+            INSERT INTO scientific_notation JSON '{
+                "pk": 6, "v": -0.0e1
+            }'
+        )");
+        cquery_nofail(e, R"(
+            INSERT INTO scientific_notation JSON '{
+                "pk": 7, "v": -1.234E+3
+            }'
+        )");
+
+        require_rows(e, "SELECT pk, v FROM scientific_notation", {
+            {int32_type->decompose(1), long_type->decompose(int64_t(150))},
+            {int32_type->decompose(2), long_type->decompose(int64_t(234))},
+            {int32_type->decompose(3), long_type->decompose(int64_t(1000000))},
+            {int32_type->decompose(4), long_type->decompose(int64_t(9007199254740991))},
+            {int32_type->decompose(5), long_type->decompose(int64_t(0))},
+            {int32_type->decompose(6), long_type->decompose(int64_t(0))},
+            {int32_type->decompose(7), long_type->decompose(int64_t(-1234))},
+        });
+
+        BOOST_REQUIRE_THROW(e.execute_cql(R"(
+            INSERT INTO scientific_notation JSON '{
+                "pk": 8, "v": 12.34
+            }'
+        )").get(), marshal_exception);
+        BOOST_REQUIRE_THROW(e.execute_cql(R"(
+            INSERT INTO scientific_notation JSON '{
+                "pk": 9, "v": 1e-1
+            }'
+        )").get(), marshal_exception);
+
+        // JSON specification disallows Inf, -Inf, NaN:
+        // "Numeric values that cannot be represented in the 
+        // grammar below (such as Infinity and NaN) are not permitted."
+        //
+        // RapidJSON has a parsing flag: kParseNanAndInfFlag
+        // which allows it. Verify it's not used:
+        BOOST_REQUIRE_THROW(e.execute_cql(R"(
+            INSERT INTO scientific_notation JSON '{
+                "pk": 10, "v": +Inf
+            }'
+        )").get(), rjson::error);
+        BOOST_REQUIRE_THROW(e.execute_cql(R"(
+            INSERT INTO scientific_notation JSON '{
+                "pk": 11, "v": -inf
+            }'
+        )").get(), rjson::error);
+        BOOST_REQUIRE_THROW(e.execute_cql(R"(
+            INSERT INTO scientific_notation JSON '{
+                "pk": 12, "v": NaN
+            }'
+        )").get(), rjson::error);
     });
 }
 

--- a/test/boost/json_cql_query_test.cc
+++ b/test/boost/json_cql_query_test.cc
@@ -295,6 +295,17 @@ SEASTAR_TEST_CASE(test_insert_json_types) {
             }
         });
 
+        BOOST_REQUIRE_THROW(e.execute_cql(R"(
+            INSERT INTO all_types JSON '{
+                "a": "abc", "c": "6"
+            }'
+        )").get(), marshal_exception);
+        BOOST_REQUIRE_THROW(e.execute_cql(R"(
+            INSERT INTO all_types JSON '{
+                "a": "abc", "c": "0392fa"
+            }'
+        )").get(), marshal_exception);
+
         e.execute_cql("CREATE TABLE multi_column_pk_table (p1 int, p2 int, p3 int, c1 int, c2 int, v int, PRIMARY KEY((p1, p2, p3), c1, c2));").get();
         e.require_table_exists("ks", "multi_column_pk_table").get();
 

--- a/test/boost/json_cql_query_test.cc
+++ b/test/boost/json_cql_query_test.cc
@@ -306,6 +306,34 @@ SEASTAR_TEST_CASE(test_insert_json_types) {
             }'
         )").get(), marshal_exception);
 
+        BOOST_REQUIRE_THROW(e.execute_cql(R"(
+            INSERT INTO all_types JSON '{
+                "a": "abc", "\"G\"": 87654321
+            }'
+        )").get(), marshal_exception);
+
+        BOOST_REQUIRE_THROW(e.execute_cql(R"(
+            INSERT INTO all_types JSON '{
+                "a": "abc", "k": 123456
+            }'
+        )").get(), marshal_exception);
+        BOOST_REQUIRE_THROW(e.execute_cql(R"(
+            INSERT INTO all_types JSON '{
+                "a": "abc", "k": "3157"
+            }'
+        )").get(), marshal_exception);
+
+        BOOST_REQUIRE_THROW(e.execute_cql(R"(
+            INSERT INTO all_types JSON '{
+                "a": "abc", "r": 12.34
+            }'
+        )").get(), marshal_exception);
+        BOOST_REQUIRE_THROW(e.execute_cql(R"(
+            INSERT INTO all_types JSON '{
+                "a": "abc", "s": 1234
+            }'
+        )").get(), marshal_exception);
+
         e.execute_cql("CREATE TABLE multi_column_pk_table (p1 int, p2 int, p3 int, c1 int, c2 int, v int, PRIMARY KEY((p1, p2, p3), c1, c2));").get();
         e.require_table_exists("ks", "multi_column_pk_table").get();
 


### PR DESCRIPTION
Add support for specifing integers in scientific format (for example 1.234e8) in INSERT JSON statement:

```
INSERT INTO table JSON '{"int_column": 1e7}';
```

Before the JSON parsing library was switched to RapidJSON from JsonCpp, this statement used to work correctly, because JsonCpp transparently casts double to integer value.

Inserting a floating-point number ending with .0 is allowed, as the fractional part is zero. Non-zero fractional part (for example 12.34) is disallowed. A new test is added to test all those behaviors.

This behavior differs from Cassandra, which disallows those types of numbers (1e7, 123.0 and 12.34), however some users rely on that behavior and JSON specification itself does not distinct between floating-point numbers and integer numbers (only a single "number" type is defined).

This PR also fixes two minor issues I noticed while looking at the code: wrong blob validation and missing `IsString()` checks that could result in assertion error.

Fixes #10100
Fixes #10114
Fixes #10115