### PR TITLE
gms/gossiper.cc: Add gauge for live and unrechable nodes

### DIFF
--- a/gms/gossiper.cc
+++ b/gms/gossiper.cc
@@ -151,7 +151,16 @@ gossiper::gossiper(abort_source& as, feature_service& features, const locator::s
                     return 0;
                 }
             }, sm::description("Heartbeat of the current Node.")),
+        sm::make_gauge("live",
+            [this] {
+                return _live_endpoints.size();
+            }, sm::description("How many live nodes the current node sees")),
+        sm::make_gauge("unreachable",
+            [this] {
+                return _unreachable_endpoints.size();
+            }, sm::description("How many unreachable nodes the current node sees")),
     });
+
 }
 
 /*


### PR DESCRIPTION
this patch adds two gauges:
scylla_gossip_live - how many live nodes the gossiper sees
scylla_gossip_unreachable - how many nodes the gossiper tries to connect
to but cannot.

Both metrics are reported once per node (i.e., per node, not per shard) it
gives visibility to how a specific node sees the cluster.

For example, a split-brain 6 nodes cluster (3 and 3). Each node would
report that it sees 2 nodes, but the monitoring system would see that
there are, in fact, 6 nodes.

Example of two nodes cluster, both running:
```
scylla_gossip_live{shard="0"} 1.000000
scylla_gossip_unreachable{shard="0"} 0.000000
```

Example of two nodes cluster, one is down:
```
scylla_gossip_live{shard="0"} 0.000000
scylla_gossip_unreachable{shard="0"} 1.000000
```

Fixes #10102

Signed-off-by: Amnon Heiman <amnon@scylladb.com>