### PR TITLE
frozen_schema: avoid allocating contiguous memory

### DIFF
--- a/frozen_schema.cc
+++ b/frozen_schema.cc
@@ -29,7 +29,7 @@ frozen_schema::frozen_schema(const schema_ptr& s)
         std::move(wr).write_version(s->version())
                      .write_mutations(sm)
                      .end_schema();
-        return to_bytes(out.linearize());
+        return out;
     }())
 { }
 
@@ -41,11 +41,11 @@ schema_ptr frozen_schema::unfreeze(const db::schema_ctxt& ctxt) const {
          : db::schema_tables::create_table_from_mutations(ctxt, sv.mutations(), sv.version());
 }
 
-frozen_schema::frozen_schema(bytes b)
+frozen_schema::frozen_schema(bytes_ostream b)
     : _data(std::move(b))
 { }
 
-bytes_view frozen_schema::representation() const
+const bytes_ostream& frozen_schema::representation() const
 {
     return _data;
 }

--- a/frozen_schema.hh
+++ b/frozen_schema.hh
@@ -10,7 +10,7 @@
 
 #include "schema_fwd.hh"
 #include "frozen_mutation.hh"
-#include "bytes.hh"
+#include "bytes_ostream.hh"
 
 namespace db {
 class schema_ctxt;
@@ -19,14 +19,14 @@ class schema_ctxt;
 // Transport for schema_ptr across shards/nodes.
 // It's safe to access from another shard by const&.
 class frozen_schema {
-    bytes _data;
+    bytes_ostream _data;
 public:
-    explicit frozen_schema(bytes);
+    explicit frozen_schema(bytes_ostream);
     frozen_schema(const schema_ptr&);
     frozen_schema(frozen_schema&&) = default;
     frozen_schema(const frozen_schema&) = default;
     frozen_schema& operator=(const frozen_schema&) = default;
     frozen_schema& operator=(frozen_schema&&) = default;
     schema_ptr unfreeze(const db::schema_ctxt&) const;
-    bytes_view representation() const;
+    const bytes_ostream& representation() const;
 };


### PR DESCRIPTION
A frozen schema can be quite large (in #10071 we measured 500 bytes per
column, and there can be thousands of columns in extreme tables). This
can cause large contiguous allocations and therefor memory stalls or
even failures to allocate.

Switch to bytes_ostream as the internal representation. Fortunately
frozen_schema is internally implemented as bytes_ostream, so the
change is minimal.

Ref #10071.

Test: unit (dev)