### PR TITLE
SCYLLA-VERSION-GEN:set release-version value length

### DIFF
--- a/SCYLLA-VERSION-GEN
+++ b/SCYLLA-VERSION-GEN
@@ -68,7 +68,7 @@ then
 	SCYLLA_RELEASE=$(cat version | awk -F'-' '{print $2}')
 else
 	DATE=$(date --utc +%Y%m%d)
-	GIT_COMMIT=$(git -C "$SCRIPT_DIR" log --pretty=format:'%h' -n 1)
+	GIT_COMMIT=$(git -C "$SCRIPT_DIR" log --pretty=format:'%h' -n 1 --abbrev=12)
 	SCYLLA_VERSION=$VERSION
 	# For custom package builds, replace "0" with "counter.your_name",
 	# where counter starts at 1 and increments for successive versions.


### PR DESCRIPTION
Noticed this issue during my debug sessions while building Scylla on x86 and Arm (https://jenkins.scylladb.com/job/scylla-master/job/releng-testing/job/build/670/artifact/)

from x86 log (https://jenkins.scylladb.com/job/scylla-master/job/releng-testing/job/build/670/artifact/output-build-x86_64.txt)
```
[883/2823] cd tools/python3 && ./reloc/build_reloc.sh --version $(<../../build/SCYLLA-PRODUCT-FILE)-$(<../../build/SCYLLA-VERSION-FILE)-$(<../../build/SCYLLA-RELEASE-FILE) --nodeps --packages "python3-pyyaml python3-urwid python3-pyparsing python3-requests python3-pyudev python3-setuptools python3-psutil python3-distro python3-click python3-six" --pip-packages "scylla-driver geomet"
5.1.dev-0.20220209.23da2b58796
```
from arm log (https://jenkins.scylladb.com/job/scylla-master/job/releng-testing/job/build/670/artifact/output-build-aarch64.txt)
```
[244/2823] cd tools/python3 && ./reloc/build_reloc.sh --version $(<../../build/SCYLLA-PRODUCT-FILE)-$(<../../build/SCYLLA-VERSION-FILE)-$(<../../build/SCYLLA-RELEASE-FILE) --nodeps --packages "python3-pyyaml python3-urwid python3-pyparsing python3-requests python3-pyudev python3-setuptools python3-psutil python3-distro python3-click python3-six" --pip-packages "scylla-driver geomet"
5.1.dev-0.20220209.23da2b587
```

Related to git config parameter core.abbrev which is not defined so default is set for auto (based: https://git-scm.com/docs/git-config#Documentation/git-config.txt-coreabbrev)

Fixes: https://github.com/scylladb/scylla/issues/10108