### PR TITLE
compaction_manager: allow stopping sleeping tasks

### DIFF
--- a/compaction/compaction.hh
+++ b/compaction/compaction.hh
@@ -17,6 +17,7 @@
 #include "utils/UUID.hh"
 #include "table_state.hh"
 #include <seastar/core/thread.hh>
+#include <seastar/core/abort_source.hh>
 
 class flat_mutation_reader;
 using namespace compaction;
@@ -56,6 +57,7 @@ struct compaction_data {
     uint64_t total_partitions = 0;
     uint64_t total_keys_written = 0;
     sstring stop_requested;
+    abort_source abort;
     utils::UUID compaction_uuid;
     unsigned compaction_fan_in = 0;
     struct replacement {
@@ -70,6 +72,7 @@ struct compaction_data {
 
     void stop(sstring reason) {
         stop_requested = std::move(reason);
+        abort.request_abort();
     }
 };
 

--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -391,10 +391,14 @@ void compaction_manager::task::finish_compaction() noexcept {
     output_run_identifier = {};
 }
 
+void compaction_manager::task::stop(sstring reason) noexcept {
+    stopping = true;
+    compaction_data.stop(std::move(reason));
+}
+
 future<> compaction_manager::task_stop(lw_shared_ptr<compaction_manager::task> task, sstring reason) {
     cmlog.debug("Stopping task {} table={}", fmt::ptr(task.get()), fmt::ptr(task->compacting_table));
-    task->stopping = true;
-    task->compaction_data.stop(reason);
+    task->stop(reason);
     auto f = task->compaction_done.get_future();
     return f.then_wrapped([task] (future<> f) {
         task->stopping = false;

--- a/compaction/compaction_manager.hh
+++ b/compaction/compaction_manager.hh
@@ -30,6 +30,7 @@
 #include "strategy_control.hh"
 #include "backlog_controller.hh"
 #include "seastarx.hh"
+#include "sstables/exceptions.hh"
 
 namespace replica {
 class table;
@@ -105,6 +106,8 @@ private:
         }
 
         void stop(sstring reason) noexcept;
+
+        sstables::compaction_stopped_exception make_compaction_stopped_exception() const;
     };
 
     // compaction manager may have N fibers to allow parallel compaction per shard.

--- a/compaction/compaction_manager.hh
+++ b/compaction/compaction_manager.hh
@@ -103,6 +103,8 @@ private:
         const utils::UUID& output_run_id() const noexcept {
             return *output_run_identifier;
         }
+
+        void stop(sstring reason) noexcept;
     };
 
     // compaction manager may have N fibers to allow parallel compaction per shard.


### PR DESCRIPTION
Use exponential_backoff_retry::retry(abort_source&)
when sleeping between retries and request abort
when the task is stopped.
    
Fixes #10112
    
Test: unit(dev)