### PR TITLE
Overhaul compaction_manager::task

### DIFF
--- a/compaction/compaction.cc
+++ b/compaction/compaction.cc
@@ -86,7 +86,7 @@ compaction_type to_compaction_type(sstring type_name) {
     throw std::runtime_error("Invalid Compaction Type Name");
 }
 
-static std::string_view to_string(compaction_type type) {
+std::string_view to_string(compaction_type type) {
     switch (type) {
     case compaction_type::Compaction: return "Compact";
     case compaction_type::Cleanup: return "Cleanup";

--- a/compaction/compaction.hh
+++ b/compaction/compaction.hh
@@ -43,6 +43,7 @@ public:
 
 sstring compaction_name(compaction_type type);
 compaction_type to_compaction_type(sstring type_name);
+std::string_view to_string(compaction_type type);
 
 struct compaction_info {
     utils::UUID compaction_uuid;

--- a/compaction/compaction.hh
+++ b/compaction/compaction.hh
@@ -41,8 +41,17 @@ public:
     friend std::ostream& operator<<(std::ostream&, pretty_printed_throughput);
 };
 
+// Return the name of the compaction type
+// as used over the REST api, e.g. "COMPACTION" or "CLEANUP".
 sstring compaction_name(compaction_type type);
+
+// Reverse map the name of the compaction type
+// as used over the REST api, e.g. "COMPACTION" or "CLEANUP",
+// to the compaction_type enum code.
 compaction_type to_compaction_type(sstring type_name);
+
+// Return a string respresenting the compaction type
+// as a verb for logging purposes, e.g. "Compact" or "Cleanup".
 std::string_view to_string(compaction_type type);
 
 struct compaction_info {

--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -476,6 +476,8 @@ void compaction_manager::register_metrics() {
                        sm::description("Holds the number of completed compaction tasks.")),
         sm::make_derive("failed_compactions", [this] { return _stats.errors; },
                        sm::description("Holds the number of failed compaction tasks.")),
+        sm::make_gauge("postponed_compactions", [this] { return _postponed.size(); },
+                       sm::description("Holds the number of tables with postponed compaction.")),
         sm::make_gauge("backlog", [this] { return _last_backlog; },
                        sm::description("Holds the sum of compaction backlog for all tables in the system.")),
         sm::make_gauge("normalized_backlog", [this] { return _last_backlog / _available_memory; },

--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -474,6 +474,8 @@ void compaction_manager::register_metrics() {
                        sm::description("Holds the number of compaction tasks waiting for an opportunity to run.")),
         sm::make_derive("completed_compactions", [this] { return _stats.completed_tasks; },
                        sm::description("Holds the number of completed compaction tasks.")),
+        sm::make_derive("failed_compactions", [this] { return _stats.errors; },
+                       sm::description("Holds the number of failed compaction tasks.")),
         sm::make_gauge("backlog", [this] { return _last_backlog; },
                        sm::description("Holds the sum of compaction backlog for all tables in the system.")),
         sm::make_gauge("normalized_backlog", [this] { return _last_backlog / _available_memory; },

--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -259,7 +259,7 @@ future<> compaction_manager::perform_major_compaction(replica::table* t) {
         return make_ready_future<>();
     }
 
-    auto task = make_shared<compaction_manager::task>(t, sstables::compaction_type::Compaction, get_compaction_state(t));
+    auto task = make_shared<compaction_manager::task>(*this, t, sstables::compaction_type::Compaction);
     _tasks.push_back(task);
     cmlog.debug("Major compaction task {} table={}: started", fmt::ptr(task.get()), fmt::ptr(t));
 
@@ -314,7 +314,7 @@ future<> compaction_manager::run_custom_job(replica::table* t, sstables::compact
         return make_ready_future<>();
     }
 
-    auto task = make_shared<compaction_manager::task>(t, type, get_compaction_state(t));
+    auto task = make_shared<compaction_manager::task>(*this, t, type);
     _tasks.push_back(task);
     cmlog.debug("{} task {} table={}: started", type, fmt::ptr(task.get()), fmt::ptr(task->compacting_table));
 
@@ -642,7 +642,7 @@ void compaction_manager::submit(replica::table* t) {
         return;
     }
 
-    auto task = make_shared<compaction_manager::task>(t, sstables::compaction_type::Compaction, get_compaction_state(t));
+    auto task = make_shared<compaction_manager::task>(*this, t, sstables::compaction_type::Compaction);
     _tasks.push_back(task);
     _stats.pending_tasks++;
     cmlog.debug("Compaction task {} table={}: started", fmt::ptr(task.get()), fmt::ptr(task->compacting_table));
@@ -711,7 +711,7 @@ void compaction_manager::submit(replica::table* t) {
 }
 
 future<> compaction_manager::perform_offstrategy(replica::table* t) {
-    auto task = make_shared<compaction_manager::task>(t, sstables::compaction_type::Reshape, get_compaction_state(t));
+    auto task = make_shared<compaction_manager::task>(*this, t, sstables::compaction_type::Reshape);
     _tasks.push_back(task);
     _stats.pending_tasks++;
     cmlog.debug("Offstrategy compaction task {} table={}: started", fmt::ptr(task.get()), fmt::ptr(task->compacting_table));
@@ -779,7 +779,7 @@ future<> compaction_manager::rewrite_sstables(replica::table* t, sstables::compa
         return a->data_size() > b->data_size();
     });
 
-    auto task = make_shared<compaction_manager::task>(t, options.type(), get_compaction_state(t));
+    auto task = make_shared<compaction_manager::task>(*this, t, options.type());
     _tasks.push_back(task);
     cmlog.debug("{} task {} table={}: started", options.type(), fmt::ptr(task.get()), fmt::ptr(task->compacting_table));
 

--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -495,14 +495,12 @@ sstables::shared_sstable compaction_manager::sstables_task::consume_sstable() {
 
 void compaction_manager::task::setup_new_compaction(utils::UUID output_run_id) {
     _compaction_data = create_compaction_data();
-    _compaction_running = true;
     _output_run_identifier = output_run_id;
     switch_state(state::active);
 }
 
 void compaction_manager::task::finish_compaction(state finish_state) noexcept {
     switch_state(finish_state);
-    _compaction_running = false;
     _output_run_identifier = utils::null_uuid();
     if (finish_state != state::failed) {
         _compaction_retry.reset();

--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -536,7 +536,7 @@ void compaction_manager::postponed_compactions_reevaluation() {
     });
 }
 
-void compaction_manager::reevaluate_postponed_compactions() {
+void compaction_manager::reevaluate_postponed_compactions() noexcept {
     _postponed_reevaluation.signal();
 }
 

--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -472,6 +472,8 @@ void compaction_manager::register_metrics() {
                        sm::description("Holds the number of currently active compactions.")),
         sm::make_gauge("pending_compactions", [this] { return _stats.pending_tasks; },
                        sm::description("Holds the number of compaction tasks waiting for an opportunity to run.")),
+        sm::make_derive("completed_compactions", [this] { return _stats.completed_tasks; },
+                       sm::description("Holds the number of completed compaction tasks.")),
         sm::make_gauge("backlog", [this] { return _last_backlog; },
                        sm::description("Holds the sum of compaction backlog for all tables in the system.")),
         sm::make_gauge("normalized_backlog", [this] { return _last_backlog / _available_memory; },

--- a/compaction/compaction_manager.hh
+++ b/compaction/compaction_manager.hh
@@ -96,6 +96,9 @@ private:
         task(task&&) = delete;
         task(const task&) = delete;
 
+        // Return true if the task isn't stopped
+        // and the compaction manager allows proceeding.
+        inline bool can_proceed() const;
         void setup_new_compaction(utils::UUID output_run_id = utils::null_uuid());
         void finish_compaction() noexcept;
 
@@ -200,8 +203,9 @@ private:
     // throws std::out_of_range exception if not found.
     compaction_state& get_compaction_state(replica::table* t);
 
-    // Return true if compaction manager and task weren't asked to stop.
-    inline bool can_proceed(const shared_ptr<task>& task);
+    // Return true if compaction manager is enabled and
+    // table still exists and compaction is not disabled for the table.
+    inline bool can_proceed(replica::table* t) const;
 
     inline future<> put_task_to_sleep(shared_ptr<task>& task);
 

--- a/compaction/compaction_manager.hh
+++ b/compaction/compaction_manager.hh
@@ -102,7 +102,6 @@ public:
         shared_future<> _compaction_done = make_ready_future<>();
         exponential_backoff_retry _compaction_retry = exponential_backoff_retry(std::chrono::seconds(5), std::chrono::seconds(300));
         sstables::compaction_type _type;
-        bool _compaction_running = false;
         utils::UUID _output_run_identifier;
         gate::holder _gate_holder;
         sstring _description;
@@ -153,7 +152,7 @@ public:
         }
 
         bool compaction_running() const noexcept {
-            return _compaction_running;
+            return _state == state::active;
         }
 
         const sstables::compaction_data& compaction_data() const noexcept {
@@ -165,7 +164,7 @@ public:
         }
 
         bool generating_output_run() const noexcept {
-            return _compaction_running && _output_run_identifier;
+            return compaction_running() && _output_run_identifier;
         }
         const utils::UUID& output_run_id() const noexcept {
             return _output_run_identifier;

--- a/compaction/compaction_manager.hh
+++ b/compaction/compaction_manager.hh
@@ -114,7 +114,7 @@ private:
     };
 
     // compaction manager may have N fibers to allow parallel compaction per shard.
-    std::list<lw_shared_ptr<task>> _tasks;
+    std::list<shared_ptr<task>> _tasks;
 
     // Possible states in which the compaction manager can be found.
     //
@@ -170,7 +170,7 @@ private:
     class strategy_control;
     std::unique_ptr<strategy_control> _strategy_control;
 private:
-    future<> stop_tasks(std::vector<lw_shared_ptr<task>> tasks, sstring reason);
+    future<> stop_tasks(std::vector<shared_ptr<task>> tasks, sstring reason);
 
     // Return the largest fan-in of currently running compactions
     unsigned current_compaction_fan_in_threshold() const;
@@ -199,9 +199,9 @@ private:
     compaction_state& get_compaction_state(replica::table* t);
 
     // Return true if compaction manager and task weren't asked to stop.
-    inline bool can_proceed(const lw_shared_ptr<task>& task);
+    inline bool can_proceed(const shared_ptr<task>& task);
 
-    inline future<> put_task_to_sleep(lw_shared_ptr<task>& task);
+    inline future<> put_task_to_sleep(shared_ptr<task>& task);
 
     // Compaction manager stop itself if it finds an storage I/O error which results in
     // stop of transportation services. It cannot make progress anyway.
@@ -299,7 +299,7 @@ public:
 
     // Returns true if table has an ongoing compaction, running on its behalf
     bool has_table_ongoing_compaction(const replica::table* t) const {
-        return std::any_of(_tasks.begin(), _tasks.end(), [t] (const lw_shared_ptr<task>& task) {
+        return std::any_of(_tasks.begin(), _tasks.end(), [t] (const shared_ptr<task>& task) {
             return task->compacting_table == t && task->compaction_running;
         });
     };

--- a/compaction/compaction_manager.hh
+++ b/compaction/compaction_manager.hh
@@ -72,7 +72,8 @@ private:
             return compaction_disabled_counter > 0;
         }
     };
-
+public:
+    // TODO: turn task into a class
     struct task {
         compaction_manager& cm;
         replica::table* compacting_table = nullptr;
@@ -116,8 +117,11 @@ private:
         void stop(sstring reason) noexcept;
 
         sstables::compaction_stopped_exception make_compaction_stopped_exception() const;
+
+        std::string describe() const;
     };
 
+private:
     // compaction manager may have N fibers to allow parallel compaction per shard.
     std::list<shared_ptr<task>> _tasks;
 
@@ -342,3 +346,4 @@ public:
 
 bool needs_cleanup(const sstables::shared_sstable& sst, const dht::token_range_vector& owned_ranges, schema_ptr s);
 
+std::ostream& operator<<(std::ostream& os, const compaction_manager::task& task);

--- a/compaction/compaction_manager.hh
+++ b/compaction/compaction_manager.hh
@@ -272,7 +272,7 @@ private:
     inline bool maybe_stop_on_error(std::exception_ptr err, bool can_retry);
 
     void postponed_compactions_reevaluation();
-    void reevaluate_postponed_compactions();
+    void reevaluate_postponed_compactions() noexcept;
     // Postpone compaction for a table that couldn't be executed due to ongoing
     // similar-sized compaction.
     void postpone_compaction_for_table(replica::table* t);

--- a/compaction/compaction_manager.hh
+++ b/compaction/compaction_manager.hh
@@ -74,6 +74,7 @@ private:
     };
 
     struct task {
+        compaction_manager& cm;
         replica::table* compacting_table = nullptr;
         shared_future<> compaction_done = make_ready_future<>();
         exponential_backoff_retry compaction_retry = exponential_backoff_retry(std::chrono::seconds(5), std::chrono::seconds(300));
@@ -84,10 +85,11 @@ private:
         compaction_state& compaction_state;
         gate::holder gate_holder;
 
-        explicit task(replica::table* t, sstables::compaction_type type, struct compaction_state& cs)
-            : compacting_table(t)
+        explicit task(compaction_manager& mgr, replica::table* t, sstables::compaction_type type)
+            : cm(mgr)
+            , compacting_table(t)
             , type(type)
-            , compaction_state(cs)
+            , compaction_state(cm.get_compaction_state(t))
             , gate_holder(compaction_state.gate.hold())
         {}
 

--- a/sstables/sstable_directory.cc
+++ b/sstables/sstable_directory.cc
@@ -352,7 +352,7 @@ future<uint64_t> sstable_directory::reshape(compaction_manager& cm, replica::tab
 
             desc.creator = creator;
 
-            return cm.run_custom_job(&table, compaction_type::Reshape, [this, &table, sstlist = std::move(sstlist), desc = std::move(desc)] (sstables::compaction_data& info) mutable {
+            return cm.run_custom_job(&table, compaction_type::Reshape, "Reshape compaction", [this, &table, sstlist = std::move(sstlist), desc = std::move(desc)] (sstables::compaction_data& info) mutable {
                 return sstables::compact_sstables(std::move(desc), info, table.as_table_state()).then([this, sstlist = std::move(sstlist)] (sstables::compaction_result result) mutable {
                     return remove_input_sstables_from_reshaping(std::move(sstlist)).then([this, new_sstables = std::move(result.new_sstables)] () mutable {
                         return collect_output_sstables_from_reshaping(std::move(new_sstables));
@@ -407,7 +407,7 @@ sstable_directory::reshard(sstable_info_vector shared_info, compaction_manager& 
             // parallel_for_each so the statistics about pending jobs are updated to reflect all
             // jobs. But only one will run in parallel at a time
             return parallel_for_each(buckets, [this, iop, &cm, &table, creator = std::move(creator)] (std::vector<sstables::shared_sstable>& sstlist) mutable {
-                return cm.run_custom_job(&table, compaction_type::Reshard, [this, iop, &cm, &table, creator, &sstlist] (sstables::compaction_data& info) {
+                return cm.run_custom_job(&table, compaction_type::Reshard, "Reshard compaction", [this, iop, &cm, &table, creator, &sstlist] (sstables::compaction_data& info) {
                     sstables::compaction_descriptor desc(sstlist, {}, iop);
                     desc.options = sstables::compaction_type_options::make_reshard();
                     desc.creator = std::move(creator);

--- a/test/lib/sstable_utils.cc
+++ b/test/lib/sstable_utils.cc
@@ -189,7 +189,7 @@ future<shared_sstable> test_env::reusable_sst(schema_ptr schema, sstring dir, un
 }
 
 sstables::compaction_data& compaction_manager_test::register_compaction(utils::UUID output_run_id, replica::column_family* cf) {
-    auto task = make_shared<compaction_manager::task>(cf, sstables::compaction_type::Compaction, _cm._compaction_state[cf]);
+    auto task = make_shared<compaction_manager::task>(_cm, cf, sstables::compaction_type::Compaction);
     testlog.debug("compaction_manager_test: register_compaction: task {} cf={}", fmt::ptr(task.get()), fmt::ptr(cf));
     task->compaction_running = true;
     task->compaction_data = compaction_manager::create_compaction_data();

--- a/test/lib/sstable_utils.cc
+++ b/test/lib/sstable_utils.cc
@@ -190,7 +190,7 @@ future<shared_sstable> test_env::reusable_sst(schema_ptr schema, sstring dir, un
 
 sstables::compaction_data& compaction_manager_test::register_compaction(utils::UUID output_run_id, replica::column_family* cf) {
     auto task = make_shared<compaction_manager::task>(_cm, cf, sstables::compaction_type::Compaction);
-    testlog.debug("compaction_manager_test: register_compaction: task {} cf={}", fmt::ptr(task.get()), fmt::ptr(cf));
+    testlog.debug("compaction_manager_test: register_compaction: {}", *task);
     task->compaction_running = true;
     task->compaction_data = compaction_manager::create_compaction_data();
     task->output_run_identifier = std::move(output_run_id);
@@ -202,7 +202,7 @@ void compaction_manager_test::deregister_compaction(const sstables::compaction_d
     auto it = boost::find_if(_cm._tasks, [&c] (auto& task) { return task->compaction_data.compaction_uuid == c.compaction_uuid; });
     if (it != _cm._tasks.end()) {
         auto task = *it;
-        testlog.debug("compaction_manager_test: deregister_compaction uuid={}: task {} table={}", c.compaction_uuid, fmt::ptr(task.get()), fmt::ptr(task->compacting_table));
+        testlog.debug("compaction_manager_test: deregister_compaction uuid={}: {}", c.compaction_uuid, *task);
         _cm._tasks.erase(it);
     } else {
         testlog.debug("compaction_manager_test: deregister_compaction uuid={}: task not found", c.compaction_uuid);

--- a/test/lib/sstable_utils.cc
+++ b/test/lib/sstable_utils.cc
@@ -189,7 +189,7 @@ future<shared_sstable> test_env::reusable_sst(schema_ptr schema, sstring dir, un
 }
 
 sstables::compaction_data& compaction_manager_test::register_compaction(utils::UUID output_run_id, replica::column_family* cf) {
-    auto task = make_lw_shared<compaction_manager::task>(cf, sstables::compaction_type::Compaction, _cm._compaction_state[cf]);
+    auto task = make_shared<compaction_manager::task>(cf, sstables::compaction_type::Compaction, _cm._compaction_state[cf]);
     testlog.debug("compaction_manager_test: register_compaction: task {} cf={}", fmt::ptr(task.get()), fmt::ptr(cf));
     task->compaction_running = true;
     task->compaction_data = compaction_manager::create_compaction_data();

--- a/test/lib/sstable_utils.hh
+++ b/test/lib/sstable_utils.hh
@@ -345,7 +345,9 @@ class compaction_manager_test {
 public:
     explicit compaction_manager_test(compaction_manager& cm) noexcept : _cm(cm) {}
 
-    sstables::compaction_data& register_compaction(utils::UUID output_run_id, replica::column_family* cf);
+    future<> run(utils::UUID output_run_id, replica::column_family* cf, noncopyable_function<future<> (sstables::compaction_data&)> job);
+private:
+    sstables::compaction_data& register_compaction(shared_ptr<compaction_manager::task> task);
 
     void deregister_compaction(const sstables::compaction_data& c);
 };


### PR DESCRIPTION
The series overhauls the compaction_manager::task design and implementation
by properly layering the functionality between the compaction_manager
that deals with generic task execution, and the per-task business logic that is defined
in a set of classes derived from the generic task class.

While at it, the series introduces `task::state` and a set of helper functions to manage it
to prevent leaks in the statistics, fixing #9974.

Two more stats counter were exposed: `completed_tasks` and a new `postponed_tasks`.

Test: sstable_compaction_test
Dtest: compaction_test.py compaction_additional_test.py

Fixes #9974