### PR TITLE
cql3: expr: Replace column_value::sub with subscript struct in expression

### DIFF
--- a/cql3/expr/expression.cc
+++ b/cql3/expr/expression.cc
@@ -195,6 +195,20 @@ const abstract_type* get_value_comparator(const column_value& cv) {
             : get_value_comparator(cv.col);
 }
 
+/// Type for comparing results of get_value().
+__attribute__((unused)) // For now mark as unused so that the code compiles, will be used soon
+const abstract_type* get_value_comparator(const column_maybe_subscripted& col) {
+    return std::visit(overloaded_functor {
+        [](const column_value* cv) {
+            return get_value_comparator(*cv);
+        },
+        [](const subscript* s) {
+            const column_value& cv = get_subscripted_column(*s);
+            return static_pointer_cast<const collection_type_impl>(cv.col->type)->value_comparator().get();
+        }
+    }, col);
+}
+
 /// True iff lhs's value equals rhs.
 bool equal(const managed_bytes_opt& rhs, const column_value& lhs, const column_value_eval_bag& bag) {
     if (!rhs) {

--- a/cql3/expr/expression.cc
+++ b/cql3/expr/expression.cc
@@ -148,10 +148,9 @@ using column_maybe_subscripted = std::variant<const column_value*, const subscri
 
 /// Converts an expression to column_maybe subscripted
 column_maybe_subscripted as_column_maybe_subscripted(const expression& e) {
-    // TODO(subscript): Uncomment once subscript is added to expression
-    // if (auto cval = as_if<subscript>(&e)) {
-    //     return cval;
-    // }
+    if (auto cval = as_if<subscript>(&e)) {
+        return cval;
+    }
 
     if (!is<column_value>(e)) {
         on_internal_error(expr_logger, format("as_column_maybe_subscripted: bad expression: {}", e));
@@ -1474,11 +1473,10 @@ expression search_and_replace(const expression& e,
                     return cv;
                 },
                 [&] (const subscript& s) -> expression {
-                    // TODO(subscript): Uncomment once subscript is added to expression
-                    // return subscript {
-                    //     .val = recurse(s.val),
-                    //     .sub = recurse(s.sub)
-                    // };
+                    return subscript {
+                        .val = recurse(s.val),
+                        .sub = recurse(s.sub)
+                    };
                     throw std::runtime_error("expr: search_and_replace - subscript not added to expression yet");
                 },
                 [&] (LeafExpression auto const& e) -> expression {

--- a/cql3/expr/expression.cc
+++ b/cql3/expr/expression.cc
@@ -147,7 +147,6 @@ managed_bytes_opt get_value(const column_value& col, const column_value_eval_bag
 using column_maybe_subscripted = std::variant<const column_value*, const subscript*>;
 
 /// Converts an expression to column_maybe subscripted
-__attribute__((unused))
 column_maybe_subscripted as_column_maybe_subscripted(const expression& e) {
     // TODO(subscript): Uncomment once subscript is added to expression
     // if (auto cval = as_if<subscript>(&e)) {
@@ -162,7 +161,6 @@ column_maybe_subscripted as_column_maybe_subscripted(const expression& e) {
 
 /// Gets the subscripted column_value out of the column_maybe_subscript.
 /// Only columns can be subscripted in CQL, so we can expect that the subscripted expression is a column_value.
-__attribute__((unused)) // For now mark as unused so that the code compiles, will be used soon
 const column_value& get_subscripted_column(const column_maybe_subscripted& cms) {
     return std::visit(overloaded_functor{
         [&](const column_value* cv) -> const column_value& {
@@ -175,7 +173,6 @@ const column_value& get_subscripted_column(const column_maybe_subscripted& cms) 
 }
 
 /// Returns col's value from queried data.
-__attribute__((unused)) // For now mark as unused so that the code compiles, will be used soon
 static managed_bytes_opt get_value(const column_maybe_subscripted& col, const column_value_eval_bag& bag) {
     const row_data_from_partition_slice& data = bag.row_data;
     const query_options& options = bag.options;
@@ -224,7 +221,6 @@ const abstract_type* get_value_comparator(const column_value& cv) {
 }
 
 /// Type for comparing results of get_value().
-__attribute__((unused)) // For now mark as unused so that the code compiles, will be used soon
 const abstract_type* get_value_comparator(const column_maybe_subscripted& col) {
     return std::visit(overloaded_functor {
         [](const column_value* cv) {

--- a/cql3/expr/expression.cc
+++ b/cql3/expr/expression.cc
@@ -143,6 +143,9 @@ managed_bytes_opt get_value(const column_value& col, const column_value_eval_bag
     }
 }
 
+/// column that might be subscripted - e.g col1, col2, col3[sub1]
+using column_maybe_subscripted = std::variant<const column_value*, const subscript*>;
+
 /// Type for comparing results of get_value().
 const abstract_type* get_value_comparator(const column_definition* cdef) {
     return &cdef->type->without_reversed();

--- a/cql3/expr/expression.cc
+++ b/cql3/expr/expression.cc
@@ -1122,6 +1122,9 @@ std::ostream& operator<<(std::ostream& os, const expression& expr) {
             [&] (const column_value& col) {
                 fmt::print(os, "{}", col);
             },
+            [&] (const subscript& sub) {
+                fmt::print(os, "{}[{}]", sub.val, sub.sub);
+            },
             [&] (const unresolved_identifier& ui) {
                 fmt::print(os, "unresolved({})", *ui.ident);
             },

--- a/cql3/expr/expression.cc
+++ b/cql3/expr/expression.cc
@@ -1548,6 +1548,13 @@ std::vector<expression> extract_single_column_restrictions_for_column(const expr
             }
         }
 
+        void operator()(const subscript& s) {
+            const column_value& cv = get_subscripted_column(s);
+            if (*cv.col == column && current_binary_operator != nullptr) {
+                restrictions.emplace_back(*current_binary_operator);
+            }
+        }
+
         void operator()(const token&) {}
         void operator()(const unresolved_identifier&) {}
         void operator()(const column_mutation_attribute&) {}

--- a/cql3/expr/expression.cc
+++ b/cql3/expr/expression.cc
@@ -840,6 +840,28 @@ value_set possible_lhs_values(const column_definition* cdef, const expression& e
                             }
                             throw std::logic_error(format("possible_lhs_values: unhandled operator {}", oper));
                         },
+                        [&] (const subscript& s) -> value_set {
+                            // FIXME: This looks wrong, the restriction is for the subscripted value, not the column.
+                            // Code copied from column_value& handler to preserve behaviour.
+                            // I didn't want to introduce changes in a refactor PR.
+                            // Will be fixed in another patch soon.
+                            const column_value& col = get_subscripted_column(s);
+
+                            if (!cdef || cdef != col.col) {
+                                return unbounded_value_set;
+                            }
+                            if (is_compare(oper.op)) {
+                                managed_bytes_opt val = evaluate(oper.rhs, options).value.to_managed_bytes_opt();
+                                if (!val) {
+                                    return empty_value_set; // All NULL comparisons fail; no column values match.
+                                }
+                                return oper.op == oper_t::EQ ? value_set(value_list{*val})
+                                        : to_range(oper.op, std::move(*val));
+                            } else if (oper.op == oper_t::IN) {
+                                return get_IN_values(oper.rhs, options, type->as_less_comparator(), cdef->name_as_text());
+                            }
+                            throw std::logic_error(format("possible_lhs_values: unhandled operator {}", oper));
+                        },
                         [&] (const tuple_constructor& tuple) -> value_set {
                             if (!cdef) {
                                 return unbounded_value_set;
@@ -940,6 +962,9 @@ value_set possible_lhs_values(const column_definition* cdef, const expression& e
             },
             [] (const column_value&) -> value_set {
                 on_internal_error(expr_logger, "possible_lhs_values: a column cannot serve as a restriction by itself");
+            },
+            [] (const subscript&) -> value_set {
+                on_internal_error(expr_logger, "possible_lhs_values: a subscript cannot serve as a restriction by itself");
             },
             [] (const token&) -> value_set {
                 on_internal_error(expr_logger, "possible_lhs_values: the token function cannot serve as a restriction by itself");

--- a/cql3/expr/expression.cc
+++ b/cql3/expr/expression.cc
@@ -1225,7 +1225,7 @@ bool is_on_collection(const binary_operator& b) {
         return true;
     }
     if (auto tuple = expr::as_if<tuple_constructor>(&b.lhs)) {
-        return boost::algorithm::any_of(tuple->elements, [] (const expression& v) { return expr::as<column_value>(v).sub; });
+        return boost::algorithm::any_of(tuple->elements, [] (const expression& v) { return expr::is<subscript>(v); });
     }
     return false;
 }

--- a/cql3/expr/expression.cc
+++ b/cql3/expr/expression.cc
@@ -2242,6 +2242,10 @@ void fill_prepare_context(expression& e, prepare_context& ctx) {
                 fill_prepare_context(*cv.sub, ctx);
             }
         },
+        [&](subscript& s) {
+            fill_prepare_context(s.val, ctx);
+            fill_prepare_context(s.sub, ctx);
+        },
         [](untyped_constant&) {},
         [](null&) {},
         [](constant&) {},

--- a/cql3/expr/expression.cc
+++ b/cql3/expr/expression.cc
@@ -146,6 +146,20 @@ managed_bytes_opt get_value(const column_value& col, const column_value_eval_bag
 /// column that might be subscripted - e.g col1, col2, col3[sub1]
 using column_maybe_subscripted = std::variant<const column_value*, const subscript*>;
 
+/// Converts an expression to column_maybe subscripted
+__attribute__((unused))
+column_maybe_subscripted as_column_maybe_subscripted(const expression& e) {
+    // TODO(subscript): Uncomment once subscript is added to expression
+    // if (auto cval = as_if<subscript>(&e)) {
+    //     return cval;
+    // }
+
+    if (!is<column_value>(e)) {
+        on_internal_error(expr_logger, format("as_column_maybe_subscripted: bad expression: {}", e));
+    }
+    return &as<column_value>(e);
+}
+
 /// Returns col's value from queried data.
 __attribute__((unused)) // For now mark as unused so that the code compiles, will be used soon
 static managed_bytes_opt get_value(const column_maybe_subscripted& col, const column_value_eval_bag& bag) {

--- a/cql3/expr/expression.cc
+++ b/cql3/expr/expression.cc
@@ -1473,6 +1473,14 @@ expression search_and_replace(const expression& e,
                     }
                     return cv;
                 },
+                [&] (const subscript& s) -> expression {
+                    // TODO(subscript): Uncomment once subscript is added to expression
+                    // return subscript {
+                    //     .val = recurse(s.val),
+                    //     .sub = recurse(s.sub)
+                    // };
+                    throw std::runtime_error("expr: search_and_replace - subscript not added to expression yet");
+                },
                 [&] (LeafExpression auto const& e) -> expression {
                     return e;
                 },

--- a/cql3/expr/expression.cc
+++ b/cql3/expr/expression.cc
@@ -160,6 +160,20 @@ column_maybe_subscripted as_column_maybe_subscripted(const expression& e) {
     return &as<column_value>(e);
 }
 
+/// Gets the subscripted column_value out of the column_maybe_subscript.
+/// Only columns can be subscripted in CQL, so we can expect that the subscripted expression is a column_value.
+__attribute__((unused)) // For now mark as unused so that the code compiles, will be used soon
+const column_value& get_subscripted_column(const column_maybe_subscripted& cms) {
+    return std::visit(overloaded_functor{
+        [&](const column_value* cv) -> const column_value& {
+            return *cv;
+        },
+        [&](const subscript* sub) -> const column_value& {
+            return get_subscripted_column(*sub);
+        }
+    }, cms);
+}
+
 /// Returns col's value from queried data.
 __attribute__((unused)) // For now mark as unused so that the code compiles, will be used soon
 static managed_bytes_opt get_value(const column_maybe_subscripted& col, const column_value_eval_bag& bag) {

--- a/cql3/expr/expression.cc
+++ b/cql3/expr/expression.cc
@@ -1013,6 +1013,14 @@ bool is_supported_by(const expression& expr, const secondary_index::index& idx) 
                             return false;
                         },
                         [&] (const token&) { return false; },
+                        [&] (const subscript& s) -> bool {
+                            // FIXME: This seems wrong, should probably just return false.
+                            // We don't support indexes on map entries yet.
+                            // For now behaviour copied from column_value& handler to preserve behaviour.
+                            // Fill be fixed soon in a separate patch.
+                            const column_value& col = get_subscripted_column(s);
+                            return idx.supports_expression(*col.col, oper.op);
+                        },
                         [&] (const binary_operator&) -> bool {
                             on_internal_error(expr_logger, "is_supported_by: nested binary operators are not supported");
                         },

--- a/cql3/expr/expression.cc
+++ b/cql3/expr/expression.cc
@@ -1665,6 +1665,9 @@ constant evaluate(const expression& e, const query_options& options) {
         [](const column_value&) -> constant {
             on_internal_error(expr_logger, "Can't evaluate a column_value");
         },
+        [](const subscript&) -> constant {
+            on_internal_error(expr_logger, "Can't evaluate a subscript");
+        },
         [](const untyped_constant&) -> constant {
             on_internal_error(expr_logger, "Can't evaluate a untyped_constant ");
         },

--- a/cql3/expr/expression.cc
+++ b/cql3/expr/expression.cc
@@ -1352,6 +1352,12 @@ bool recurse_until(const expression& e, const noncopyable_function<bool (const e
                 }
                 return false;
             },
+            [&] (const subscript& sub) {
+                if (recurse_until(sub.val, predicate_fun)) {
+                    return true;
+                }
+                return recurse_until(sub.sub, predicate_fun);
+            },
             [&] (const column_mutation_attribute& a) {
                 return recurse_until(a.column, predicate_fun);
             },

--- a/cql3/expr/expression.hh
+++ b/cql3/expr/expression.hh
@@ -193,6 +193,12 @@ struct column_value {
     column_value(const column_definition* col, expr::expression sub) : col(col), sub(std::move(sub)) {}
 };
 
+/// A subscripted value, eg list_colum[2], val[sub]
+struct subscript {
+    expression val;
+    expression sub;
+};
+
 /// Represents token function on LHS of an operator relation.  No need to list column definitions
 /// here -- token takes exactly the partition key as its argument.
 struct token {};

--- a/cql3/expr/expression.hh
+++ b/cql3/expr/expression.hh
@@ -185,16 +185,16 @@ concept LeafExpression
         || std::same_as<bind_variable, E> 
         || std::same_as<untyped_constant, E> 
         || std::same_as<constant, E>
+        || std::same_as<column_value, E>
         ;
 
-/// A column, optionally subscripted by a value (eg, c1 or c2['abc']).
+/// A column, usually encountered on the left side of a restriction.
+/// An expression like `mycol < 5` would be expressed as a binary_operator
+/// with column_value on the left hand side.
 struct column_value {
     const column_definition* col;
-    std::optional<expression> sub; ///< If present, this LHS is col[sub], otherwise just col.
-    /// For easy creation of vector<column_value> from vector<column_definition*>.
+
     column_value(const column_definition* col) : col(col) {}
-    /// The compiler doesn't auto-generate this due to the other constructor's existence.
-    column_value(const column_definition* col, expr::expression sub) : col(col), sub(std::move(sub)) {}
 };
 
 /// A subscripted value, eg list_colum[2], val[sub]

--- a/cql3/expr/expression.hh
+++ b/cql3/expr/expression.hh
@@ -199,6 +199,15 @@ struct subscript {
     expression sub;
 };
 
+/// Gets the subscripted column_value out of the subscript.
+/// Only columns can be subscripted in CQL, so we can expect that the subscripted expression is a column_value.
+const column_value& get_subscripted_column(const subscript&);
+
+/// Gets the column_definition* out of expression that can be a column_value or subscript
+/// Only columns can be subscripted in CQL, so we can expect that the subscripted expression is a column_value.
+const column_value& get_subscripted_column(const expression&);
+
+
 /// Represents token function on LHS of an operator relation.  No need to list column definitions
 /// here -- token takes exactly the partition key as its argument.
 struct token {};

--- a/cql3/expr/expression.hh
+++ b/cql3/expr/expression.hh
@@ -65,6 +65,7 @@ using allow_local_index = bool_class<allow_local_index_tag>;
 struct binary_operator;
 struct conjunction;
 struct column_value;
+struct subscript;
 struct token;
 struct unresolved_identifier;
 struct column_mutation_attribute;
@@ -84,6 +85,7 @@ concept ExpressionElement
         = std::same_as<T, conjunction>
         || std::same_as<T, binary_operator>
         || std::same_as<T, column_value>
+        || std::same_as<T, subscript>
         || std::same_as<T, token>
         || std::same_as<T, unresolved_identifier>
         || std::same_as<T, column_mutation_attribute>
@@ -104,6 +106,7 @@ concept invocable_on_expression
         = std::invocable<Func, conjunction>
         && std::invocable<Func, binary_operator>
         && std::invocable<Func, column_value>
+        && std::invocable<Func, subscript>
         && std::invocable<Func, token>
         && std::invocable<Func, unresolved_identifier>
         && std::invocable<Func, column_mutation_attribute>
@@ -124,6 +127,7 @@ concept invocable_on_expression_ref
         = std::invocable<Func, conjunction&>
         && std::invocable<Func, binary_operator&>
         && std::invocable<Func, column_value&>
+        && std::invocable<Func, subscript&>
         && std::invocable<Func, token&>
         && std::invocable<Func, unresolved_identifier&>
         && std::invocable<Func, column_mutation_attribute&>
@@ -376,7 +380,7 @@ struct expression::impl final {
             conjunction, binary_operator, column_value, token, unresolved_identifier,
             column_mutation_attribute, function_call, cast, field_selection, null,
             bind_variable, untyped_constant, constant, tuple_constructor, collection_constructor,
-            usertype_constructor>;
+            usertype_constructor, subscript>;
     variant_type v;
     impl(variant_type v) : v(std::move(v)) {}
 };

--- a/cql3/expr/prepare_expr.cc
+++ b/cql3/expr/prepare_expr.cc
@@ -995,6 +995,9 @@ test_assignment(const expression& expr, data_dictionary::database db, const sstr
         [&] (const column_value&) -> test_result {
             on_internal_error(expr_logger, "column_values are not yet reachable via test_assignment()");
         },
+        [&] (const subscript&) -> test_result {
+            on_internal_error(expr_logger, "subscripts are not yet reachable via test_assignment()");
+        },
         [&] (const token&) -> test_result {
             on_internal_error(expr_logger, "tokens are not yet reachable via test_assignment()");
         },

--- a/cql3/expr/prepare_expr.cc
+++ b/cql3/expr/prepare_expr.cc
@@ -904,6 +904,9 @@ prepare_expression(const expression& expr, data_dictionary::database db, const s
         [&] (const column_value&) -> expression {
             on_internal_error(expr_logger, "column_values are not yet reachable via prepare_expression()");
         },
+        [&] (const subscript&) -> expression {
+            on_internal_error(expr_logger, "subscripts are not yet reachable via prepare_expression()");
+        },
         [&] (const token&) -> expression {
             on_internal_error(expr_logger, "tokens are not yet reachable via prepare_expression()");
         },

--- a/cql3/restrictions/statement_restrictions.cc
+++ b/cql3/restrictions/statement_restrictions.cc
@@ -311,6 +311,21 @@ static std::vector<expr::expression> extract_clustering_prefix_restrictions(
             });
         }
 
+        void operator()(const subscript& sub) {
+            const column_value& cval = get_subscripted_column(sub.val);
+
+            with_current_binary_operator(*this, [&] (const binary_operator& b) {
+                if (cval.col->is_clustering_key()) {
+                    const auto found = single.find(cval.col);
+                    if (found == single.end()) {
+                        single[cval.col] = b;
+                    } else {
+                        found->second = make_conjunction(std::move(found->second), b);
+                    }
+                }
+            });
+        }
+
         void operator()(const token&) {
             // A token cannot be a clustering prefix restriction
         }

--- a/cql3/restrictions/statement_restrictions.cc
+++ b/cql3/restrictions/statement_restrictions.cc
@@ -818,7 +818,7 @@ dht::partition_range_vector partition_ranges_from_EQs(
         const std::vector<expr::expression>& eq_expressions, const query_options& options, const schema& schema) {
     std::vector<managed_bytes> pk_value(schema.partition_key_size());
     for (const auto& e : eq_expressions) {
-        const auto col = expr::as<column_value>(find(e, oper_t::EQ)->lhs).col;
+        const auto col = expr::get_subscripted_column(find(e, oper_t::EQ)->lhs).col;
         const auto vals = std::get<value_list>(possible_lhs_values(col, e, options));
         if (vals.empty()) { // Case of C=1 AND C=2.
             return {};

--- a/cql3/restrictions/statement_restrictions.cc
+++ b/cql3/restrictions/statement_restrictions.cc
@@ -1041,6 +1041,10 @@ struct multi_column_range_accumulator {
         on_internal_error(rlogger, "Column encountered outside binary operator");
     }
 
+    void operator()(const subscript&) {
+        on_internal_error(rlogger, "Subscript encountered outside binary operator");
+    }
+
     void operator()(const token&) {
         on_internal_error(rlogger, "Token encountered outside binary operator");
     }

--- a/cql3/selection/selectable.cc
+++ b/cql3/selection/selectable.cc
@@ -170,6 +170,9 @@ prepare_selectable(const schema& s, const expr::expression& raw_selectable) {
             // so bridge them.
             return ::make_shared<selectable_column>(column_identifier(column.col->name(), column.col->name_as_text()));
         },
+        [&] (const expr::subscript& sub) -> shared_ptr<selectable> {
+            on_internal_error(slogger, "no way to express 'SELECT a[b]' in the grammar yet");
+        },
         [&] (const expr::token& tok) -> shared_ptr<selectable> {
             // expr::token implicitly the partition key as arguments, but
             // the selectable equivalent (with_function) needs explicit arguments,

--- a/cql3/selection/selectable.cc
+++ b/cql3/selection/selectable.cc
@@ -255,6 +255,9 @@ selectable_processes_selection(const expr::expression& raw_selectable) {
         [&] (const expr::binary_operator& conj) -> bool {
             on_internal_error(slogger, "no way to express 'SELECT a binop b' in the grammar yet");
         },
+        [] (const expr::subscript&) -> bool {
+            on_internal_error(slogger, "no way to express 'SELECT a[b]' in the grammar yet");
+        },
         [&] (const expr::column_value& column) -> bool {
             // There is no path that reaches here, but expr::column_value and column_identifier are logically the same,
             // so bridge them.

--- a/cql3/single_column_relation.cc
+++ b/cql3/single_column_relation.cc
@@ -57,7 +57,7 @@ single_column_relation::new_EQ_restriction(data_dictionary::database db, schema_
     auto&& entry_value = to_expression({receivers[1]}, *_value, db, schema->ks_name(), ctx);
     auto r = make_shared<restrictions::single_column_restriction>(column_def);
     r->expression = binary_operator{
-        column_value(&column_def, std::move(entry_key)), oper_t::EQ, std::move(entry_value)};
+        subscript{.val = column_value(&column_def), .sub = std::move(entry_key)}, oper_t::EQ, std::move(entry_value)};
     return r;
 }
 


### PR DESCRIPTION
Currently a subscripted column is expressed using the struct `column_value`:
```c++
/// A column, optionally subscripted by a value (eg, c1 or c2['abc']).
struct column_value {
    const column_definition* col;
    std::optional<expression> sub; ///< If present, this LHS is col[sub], otherwise just col.
}
 ```
 
 It would be better to have a generic AST node for expressing arbitrary subscripted values:
 ```c++
 /// A subscripted value, eg list_colum[2], val[sub]
struct subscript {
    expression val;
    expression sub;
};
```

The `subscript` struct would allow us to express more, for example:
* subscripted `column_identifier`, not only `column_definition` (needed to get rid of `relation` class)
* nested subscripts: `col[1][2]`


Adding `subscript` to `expression` variant immediately would require to implement all `expr::visit` handlers immediately in the same commit, so I took a different approach. At first the struct is just there and visit handlers are implemented one by one in advance, then at the end `subscript` is added to the `expression`. This way all the new code can be neatly divided into commits and everything is still bisectable.

There were a few cases where the existing behaviour seemed to make little sense, but I didn't change it to keep the PR focused on refactoring. I left a `FIXME` comments there and I will submit separate patches to fix them.