### PR TITLE
scylla_prepare: print Traceback with current user-friendly messages

### DIFF
--- a/dist/common/scripts/scylla_prepare
+++ b/dist/common/scripts/scylla_prepare
@@ -12,6 +12,7 @@ import sys
 import glob
 import platform
 import distro
+import traceback
 
 from scylla_util import *
 from subprocess import run
@@ -129,6 +130,7 @@ if __name__ == '__main__':
             if create_perftune_conf(cfg):
                 run("{} --options-file /etc/scylla.d/perftune.yaml".format(perftune_base_command()), shell=True, check=True)
         except Exception as e:
-            print(f'Exception occurred while creating perftune.yaml: {e}')
-            print('To fix the error, please re-run scylla_setup.')
+            print(f'Exception occurred while creating perftune.yaml:\n')
+            traceback.print_exc()
+            print('\nTo fix the error, please re-run scylla_setup.')
             sys.exit(1)


### PR DESCRIPTION
On e1b15ba, we introduce user-friendly error message when Exception
occured while generating perftune.yaml.
However, it becomes difficult to investigate bugs since we dropped
traceback.
To resolve this problem, let's print both traceback and user-friendly
messages.

Related #10050