### PR TITLE
table: Make compacting reader v2.

### DIFF
--- a/mutation_reader.cc
+++ b/mutation_reader.cc
@@ -17,6 +17,7 @@
 
 #include "mutation_reader.hh"
 #include "flat_mutation_reader.hh"
+#include "flat_mutation_reader_v2.hh"
 #include "schema_registry.hh"
 #include "mutation_compactor.hh"
 #include "dht/sharder.hh"
@@ -2463,6 +2464,11 @@ public:
 flat_mutation_reader make_compacting_reader(flat_mutation_reader_v2 source, gc_clock::time_point compaction_time,
         std::function<api::timestamp_type(const dht::decorated_key&)> get_max_purgeable, streamed_mutation::forwarding fwd) {
     return make_flat_mutation_reader<compacting_reader>(std::move(source), compaction_time, get_max_purgeable, fwd);
+}
+
+flat_mutation_reader_v2 make_compacting_reader_v2(flat_mutation_reader_v2 source, gc_clock::time_point compaction_time,
+        std::function<api::timestamp_type(const dht::decorated_key&)> get_max_purgeable, streamed_mutation::forwarding fwd) {
+    return upgrade_to_v2(make_flat_mutation_reader<compacting_reader>(std::move(source), compaction_time, get_max_purgeable, fwd));
 }
 
 position_reader_queue::~position_reader_queue() {}

--- a/mutation_reader.hh
+++ b/mutation_reader.hh
@@ -698,6 +698,10 @@ flat_mutation_reader make_compacting_reader(flat_mutation_reader_v2 source, gc_c
         std::function<api::timestamp_type(const dht::decorated_key&)> get_max_purgeable,
         streamed_mutation::forwarding fwd = streamed_mutation::forwarding::no);
 
+flat_mutation_reader_v2 make_compacting_reader_v2(flat_mutation_reader_v2 source, gc_clock::time_point compaction_time,
+        std::function<api::timestamp_type(const dht::decorated_key&)> get_max_purgeable,
+        streamed_mutation::forwarding fwd = streamed_mutation::forwarding::no);
+
 // A mutation reader together with an upper bound on the set of positions of fragments
 // that the reader will return. The upper bound does not need to be exact.
 struct reader_and_upper_bound {


### PR DESCRIPTION
This is a facade change only to add a factory function that does
upgrade_to_v2 internally. It exists side by side with the v1 version.