### PR TITLE
types/map.hh: add missing const qualifiers

### DIFF
--- a/types/map.hh
+++ b/types/map.hh
@@ -69,7 +69,7 @@ requires std::convertible_to<std::ranges::range_value_t<Range>, std::pair<const 
 bytes map_type_impl::serialize_to_bytes(const Range& map_range) {
     size_t serialized_len = 4;
     size_t map_size = 0;
-    for (const std::pair<bytes, bytes>& elem : map_range) {
+    for (const std::pair<const bytes, bytes>& elem : map_range) {
         serialized_len += 4 + elem.first.size() + 4 + elem.second.size();
         map_size += 1;
     }
@@ -83,7 +83,7 @@ bytes map_type_impl::serialize_to_bytes(const Range& map_range) {
     bytes::iterator out = result.begin();
 
     write_collection_size(out, map_size, cql_serialization_format::internal());
-    for (const std::pair<bytes, bytes>& elem : map_range) {
+    for (const std::pair<const bytes, bytes>& elem : map_range) {
         if (elem.first.size() > std::numeric_limits<int32_t>::max()) {
             throw exceptions::invalid_request_exception(
                 fmt::format("Map key size too large: {} bytes > {}", map_size, std::numeric_limits<int32_t>::max()));
@@ -106,7 +106,7 @@ requires std::convertible_to<std::ranges::range_value_t<Range>, std::pair<const 
 managed_bytes map_type_impl::serialize_to_managed_bytes(const Range& map_range) {
     size_t serialized_len = 4;
     size_t map_size = 0;
-    for (const std::pair<managed_bytes, managed_bytes>& elem : map_range) {
+    for (const std::pair<const managed_bytes, managed_bytes>& elem : map_range) {
         serialized_len += 4 + elem.first.size() + 4 + elem.second.size();
         map_size += 1;
     }
@@ -120,7 +120,7 @@ managed_bytes map_type_impl::serialize_to_managed_bytes(const Range& map_range) 
     managed_bytes_mutable_view out(result);
 
     write_collection_size(out, map_size, cql_serialization_format::internal());
-    for (const std::pair<managed_bytes, managed_bytes>& elem : map_range) {
+    for (const std::pair<const managed_bytes, managed_bytes>& elem : map_range) {
         if (elem.first.size() > std::numeric_limits<int32_t>::max()) {
             throw exceptions::invalid_request_exception(
                 fmt::format("Map key size too large: {} bytes > {}", map_size, std::numeric_limits<int32_t>::max()));


### PR DESCRIPTION
Add missing `const` qualifiers in `serialize_to_bytes` and `serialize_to_managed_bytes`. Lack of those qualifiers caused GCC
compilation error:
```
./types/map.hh: In instantiation of ‘static bytes map_type_impl::serialize_to_bytes(const Range&) [with Range = std::map<seastar::basic_sstring<signed char, unsigned int, 31, false>, seastar::basic_sstring<signed char, unsigned int, 31, false>, serialized_compare>; bytes = seastar::basic_sstring<signed char, unsigned int, 31, false>]’:
cql3/type_json.cc:138:45:   required from here
./types/map.hh:72:41: error: loop variable ‘elem’ of type ‘const std::pair<seastar::basic_sstring<signed char, unsigned int, 31, false>, seastar::basic_sstring<signed char, unsigned int, 31, false> >&’ binds to a temporary constructed from type ‘const std::pair<const seastar::basic_sstring<signed char, unsigned int, 31, false>, seastar::basic_sstring<signed char, unsigned int, 31, false> >’ [-Werror=range-loop-construct]
   72 |     for (const std::pair<bytes, bytes>& elem : map_range) {
      |                                         ^~~~
./types/map.hh:72:41: note: use non-reference type ‘const std::pair<seastar::basic_sstring<signed char, unsigned int, 31, false>, seastar::basic_sstring<signed char, unsigned int, 31, false> >’ to make the copy explicit or ‘const std::pair<const seastar::basic_sstring<signed char, unsigned int, 31, false>, seastar::basic_sstring<signed char, unsigned int, 31, false> >&’ to prevent copying
```

Adding those `const` qualifiers there is correct, as the definition of those functions specifies that the range is of `std::pair<const bytes, bytes>` elements, not `std::pair<bytes, bytes>` (before the change):
```
requires std::convertible_to<std::ranges::range_value_t<Range>, 
                             std::pair<const bytes, bytes>>
```

Note that there are some GCC compilation problems still left apart from this one.