### PR TITLE
utils/rjson.cc: ignore buggy GCC warning

### DIFF
--- a/utils/rjson.cc
+++ b/utils/rjson.cc
@@ -234,7 +234,10 @@ future<> print(const rjson::value& value, seastar::output_stream<char>& os, size
         size_t _pos = 0;
         future<> _f = make_ready_future<>();
 
+        #pragma GCC diagnostic push
+        #pragma GCC diagnostic ignored "-Wunused-local-typedefs"
         using Ch = char;
+        #pragma GCC diagnostic pop
 
         void send(bool try_reuse = true) {
             if (_f.failed()) {


### PR DESCRIPTION
When compiling `utils/rjson.cc` on GCC, the compilation triggers the following warning (which becomes a compilation error):

```
utils/rjson.cc: In function ‘seastar::future<> rjson::print(const value&, seastar::output_stream<char>&, size_t)’:
utils/rjson.cc:239:15: error: typedef ‘using Ch = char’ locally defined but not used [-Werror=unused-local-typedefs]
  239 |         using Ch = char;
      |               ^~
```

This warning is a false positive. `using Ch` is actually used internally
by `rapidjson::Writer`. This is a known GCC bug (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=61596), which has not been fixed since 2014.

I disabled this warning only locally as all other code is not affected by this warning and no other code already disables this warning.

Note that there are some GCC compilation problems still left apart from this one.