### PR TITLE
Allow empty partition keys in views

### DIFF
--- a/compound_compat.hh
+++ b/compound_compat.hh
@@ -81,6 +81,12 @@ public:
             , _i(v._type.end(v._packed))
         { }
 
+        // Default constructor is incorrectly needed for c++20
+        // weakly_incrementable concept requires for ranges.
+        // Will be fixed by https://wg21.link/P2325R3 but still
+        // needed for now.
+        iterator() {}
+
         value_type operator*() const {
             int32_t component_size = _i->size();
             if (_offset == -2) {
@@ -106,6 +112,12 @@ public:
                 _offset = -2;
             }
             return *this;
+        }
+
+        iterator operator++(int) {
+            iterator i(*this);
+            ++(*this);
+            return i;
         }
 
         bool operator==(const iterator& other) const {

--- a/compound_compat.hh
+++ b/compound_compat.hh
@@ -72,11 +72,12 @@ public:
         iterator(const legacy_compound_view& v)
             : _singular(v._type.is_singular())
             , _offset(_singular ? 0 : -2)
-            , _i(v._type.begin(v._packed))
+            , _i(_singular && !v._type.begin(v._packed)->size() ?
+                    v._type.end(v._packed) : v._type.begin(v._packed))
         { }
 
         iterator(const legacy_compound_view& v, end_tag)
-            : _offset(-2)
+            : _offset(v._type.is_singular() && !v._type.begin(v._packed)->size() ? 0 : -2)
             , _i(v._type.end(v._packed))
         { }
 

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -2345,9 +2345,6 @@ void sstable::set_first_and_last_keys() {
         return;
     }
     auto decorate_key = [this] (const char *m, const bytes& value) {
-        if (value.empty()) {
-            throw malformed_sstable_exception(format("{} key of summary of {} is empty", m, get_filename()));
-        }
         auto pk = key::from_bytes(value).to_partition_key(*_schema);
         return dht::decorate_key(*_schema, std::move(pk));
     };

--- a/test/cql-pytest/test_secondary_index.py
+++ b/test/cql-pytest/test_secondary_index.py
@@ -276,7 +276,6 @@ def test_multi_column_with_regular_index(cql, test_keyspace):
 # wrong or unusual about an empty string, and it should be supported just
 # like any other string.
 # Reproduces issue #9364
-@pytest.mark.xfail(reason="issue #9364")
 def test_index_empty_string(cql, test_keyspace):
     schema = 'p int, v text, primary key (p)'
     # Searching for v='' without an index (with ALLOW FILTERING), works


### PR DESCRIPTION
Cassandra generally does not allow empty strings as partition keys (note, by the way, that empty strings are allowed as clustering keys, as well as in individual components of a compound partition key).
However, Cassandra does allow empty strings in _regular_ columns - and those regular columns can be indexed by a secondary index, or become an empty partition-key column in a materialized view. As noted in issues #9375 and #9364 and verified in a few xfailing cql-pytest tests, Scylla didn't allow these cases - and this patch series fixes that.

Before the last patch in this series finally enables empty-string partition keys in materialized views, we first need to solve a couple of bugs in our code related to handling empty partition keys:

The first patch fixes issue #10178 - a bug in `key_view::tri_compare()`  where comparing two empty keys returned a random result instead of "equal".

The second patch fixes issue #9352: our tokenizer has an inconsistency where for an empty string key, two variants of the same function return different results:

1. One variant `murmur3_partitioner::get_token(bytes_view key)` returned `minimum_token()` for the empty string. 
2. Another variant `murmur3_partitioner::get_token(const schema& s, partition_key_view key)` did not have this special case, and called the normal hash-function calculation on the empty string (the resulting token is 0).

Variant 2 was an unintentional bug, because Cassandra always does what variant does 1. So the "obvious" fix here would be to fix variant 2 to do what variant 1 does. Nevertheless, we decided to do the opposite: Change variant 1 to match variant 2. The reasoning is as follows:

The `minimum_token()` is `token{token::kind::before_all_keys, 0 }` - it's not a real token. Since we intend in this patch allow real data to exist with the empty key, we need this real data to have a real token. For example, this token needs to be located on the token ring (so the empty-key partition will have replicas) and also belong to one of the shards, and it's not clear that `minimum_token()` will be handled correctly in this context.

After changing the token of the empty string to 0, we note that some places in the code assume that `dht::decorated_key(dh
t::minimum_token(), partition_key::make_empty())` is a legal decorated key. However, as far as I can tell, none of these places actually assume that the partition-key part (the `make_empty()`) really matches the token - this decorated key is only used to start an iteration (ignoring this key itself) or to indicate a non-existent key (in modern code `std::optional` should be used for that).

While normally changing the token of a key is a big faux-pas, which can result in old data no longer being readable, in this case this change is safe because:

1. Scylla previously disallowed empty partition keys (in both base tables and views), so we cannot have had such a partition key saved in any sstable.
3. Cassandra does allow empty partition keys in _views_ and _secondary indexes_, but we do not support migrating sstables of those into Scylla - users are expected to only migrate the base table and then re-create the view or index. So however Cassandra writes those empty-key partitions, we don't care.

The third patch finally fixes the materialized views implementation to not drop view rows with an empty-string partition key (#9375). This means we basically revert commit ec8960df45fa7e64cb7548ffffb9e99fec06700c - which fixed #3262 by disallowing empty partition keys in views, whereas this patch fixes the same problem by handling the empty partition keys correctly.

The fix for the secondary index bug (#9364) comes "for free" because it is based on materialized views.

We already had xfailing test cases for empty strings in materialized views and indexes, and after this series they begin to pass so the "xfail" mark is removed. The series also adds additional test cases that validate additional corner cases discovered during the debugging.

Fixes #9352
Fixes #9364
Fixes #9375
Fixes #10178