### PR TITLE
compaction_manager: rewrite_sstables: do not acquire table write lock

### DIFF
--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -812,8 +812,9 @@ future<> compaction_manager::rewrite_sstables(replica::table* t, sstables::compa
             };
 
             auto maintenance_permit = co_await seastar::get_units(_maintenance_ops_sem, 1);
-            // Take write lock for table to serialize cleanup/upgrade sstables/scrub with major compaction/reshape/reshard.
-            auto write_lock_holder = co_await _compaction_state[&t].lock.hold_write_lock();
+            // FIXME: acquiring the read lock is not needed after acquiring the _maintenance_ops_sem
+            // only major compaction needs to acquire the write lock to synchronize with regular compaction.
+            auto lock_holder = co_await _compaction_state[&t].lock.hold_read_lock();
 
             _stats.pending_tasks--;
             _stats.active_tasks++;


### PR DESCRIPTION
This change effectively reverts 40a6049ac285f1a317c6c804c09ae7363cd73ffb
that is no longer required after 6737c880458c216c9ab933b0348b9f78fe79c648
where the _maintenance_ops_sem is used to serialize
tasks using rewrite_sstables like cleanup, upgrade, reshape,
or scrub, with major compaction.
    
Since regular compaction may run in parallel no lock
is required per-table.
    
This solves the slowness in cleanup compaction (and
likely in upgrade sstables seen in #10060, and possibly #10166.

With that, rewrite_sstable can run compaction in the maintenance
scheduling group again, reinstating 4c05e5f966d691594a604cf076113efc7f42b1af and reverting a9427f150abd20227f8f967ae7b768480097b608.
    
Fixes #10175
Refs #10060

Test: unit(dev)
DTest: compaction_test.py compaction_additional_test.py

All passed except for currently failing dtests: test_double_compaction_by_cleanup_and_major_compactions (scylladb/scylla-dtest#2394) and test_twcs_multiple_sstables_during_decommission (scylladb/scylla-dtest#2616)