### PR TITLE
types: fix is_string for reversed types

### DIFF
--- a/types.cc
+++ b/types.cc
@@ -777,6 +777,7 @@ bool abstract_type::is_native() const { return !is_collection() && !is_tuple(); 
 bool abstract_type::is_string() const {
     struct visitor {
         bool operator()(const abstract_type&) { return false; }
+        bool operator()(const reversed_type_impl& t) { return t.underlying_type()->is_string(); }
         bool operator()(const string_type_impl&) { return true; }
     };
     return visit(*this, visitor{});


### PR DESCRIPTION
Checking if the type is string is subtly broken for reversed types,
and these types will not be recognized as strings, even though they are.
As a result, if somebody creates a column with DESC order and then
tries to use operator LIKE on it, it will fail because the type
would not be recognized as a string.

Fixes #10183