### PR TITLE
row_cache: Make row_cache reader from sstables compacting.

### DIFF
--- a/replica/table.cc
+++ b/replica/table.cc
@@ -1333,7 +1333,12 @@ table::sstables_as_snapshot_source() {
                 tracing::trace_state_ptr trace_state,
                 streamed_mutation::forwarding fwd,
                 mutation_reader::forwarding fwd_mr) {
-            return make_sstable_reader(std::move(s), std::move(permit), sst_set, r, slice, pc, std::move(trace_state), fwd, fwd_mr);
+            auto reader = make_sstable_reader(std::move(s), std::move(permit), sst_set, r, slice, pc, std::move(trace_state), fwd, fwd_mr);
+            return make_compacting_reader(
+                std::move(reader),
+                gc_clock::now(),
+                [](const dht::decorated_key&) { return api::min_timestamp; },
+                fwd);
         }, [this, sst_set] {
             return make_partition_presence_checker(sst_set);
         });


### PR DESCRIPTION
Reading data from sstables without compacting first puts unnecessary pressure on the cache. The mutation streams need to be resolved anyway before passing to subsequent consumers, so it's better to do it as close to the source as possible.