### PR TITLE
replica/database: truncate: temporarily disable compaction on table and views before flush

### DIFF
--- a/replica/database.cc
+++ b/replica/database.cc
@@ -2089,14 +2089,16 @@ future<> database::truncate(const keyspace& ks, column_family& cf, timestamp_fun
                             // creating the sstables that would create them.
                             assert(!did_flush || low_mark <= rp || rp == db::replay_position());
                             rp = std::max(low_mark, rp);
-                    co_await parallel_for_each(cf.views(), [this, truncated_at, should_flush] (view_ptr v) {
+                    co_await parallel_for_each(cf.views(), [this, truncated_at, should_flush] (view_ptr v) -> future<> {
                         auto& vcf = find_column_family(v);
-                        return _compaction_manager->run_with_compaction_disabled(&vcf, [&vcf, truncated_at, should_flush] {
-                            return (should_flush ? vcf.flush() : vcf.clear()).then([&vcf, truncated_at, should_flush] {
-                                return vcf.discard_sstables(truncated_at).then([&vcf, truncated_at, should_flush](db::replay_position rp) {
-                                    return db::system_keyspace::save_truncation_record(vcf, truncated_at, rp);
-                                });
-                            });
+                        co_await _compaction_manager->run_with_compaction_disabled(&vcf, [&vcf, truncated_at, should_flush] () -> future<> {
+                            if (should_flush) {
+                                co_await vcf.flush();
+                            } else {
+                                co_await vcf.clear();
+                            }
+                            db::replay_position rp = co_await vcf.discard_sstables(truncated_at);
+                            co_await db::system_keyspace::save_truncation_record(vcf, truncated_at, rp);
                         });
                     });
                                 // save_truncation_record() may actually fail after we cached the truncation time

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1580,7 +1580,6 @@ public:
     /** Truncates the given column family */
     future<> truncate(sstring ksname, sstring cfname, timestamp_func);
     future<> truncate(const keyspace& ks, column_family& cf, timestamp_func, bool with_snapshot = true);
-    future<> truncate_views(const column_family& base, db_clock::time_point truncated_at, bool should_flush);
 
     bool update_column_family(schema_ptr s);
     future<> drop_column_family(const sstring& ks_name, const sstring& cf_name, timestamp_func, bool with_snapshot = true);


### PR DESCRIPTION
Flushing the base table triggers view building
and corresponding compactions on the view tables.
    
Temporarily disable compaction on both the base
table and all its view before flush and snapshot
since those flushed sstables are about to be truncated
anyway right after the snapshot is taken.
    
This should make truncate go faster.

In the process, this series also embeds `database::truncate_views`
into `truncate` and coroutinizes both
    
Refs #6309
    
Test: unit(dev)
