### PR TITLE
replica: Optimize empty_flat_reader out of the hot path

### DIFF
--- a/replica/memtable.cc
+++ b/replica/memtable.cc
@@ -693,8 +693,8 @@ partition_snapshot_ptr memtable_entry::snapshot(memtable& mtbl) {
     return _pe.read(mtbl.region(), mtbl.cleaner(), _schema, no_cache_tracker);
 }
 
-flat_mutation_reader_v2
-memtable::make_flat_reader(schema_ptr s,
+flat_mutation_reader_v2_opt
+memtable::make_flat_reader_opt(schema_ptr s,
                       reader_permit permit,
                       const dht::partition_range& range,
                       const query::partition_slice& slice,
@@ -715,7 +715,7 @@ memtable::make_flat_reader(schema_ptr s,
             }
         });
         if (!snp) {
-            return make_empty_flat_reader_v2(std::move(s), std::move(permit));
+            return {};
         }
         auto dk = pos.as_decorated_key();
 

--- a/replica/memtable.hh
+++ b/replica/memtable.hh
@@ -238,14 +238,29 @@ public:
     // The 'range' parameter must be live as long as the reader is being used
     //
     // Mutations returned by the reader will all have given schema.
-    flat_mutation_reader_v2 make_flat_reader(schema_ptr,
+    flat_mutation_reader_v2 make_flat_reader(schema_ptr s,
                                              reader_permit permit,
                                              const dht::partition_range& range,
                                              const query::partition_slice& slice,
                                              const io_priority_class& pc = default_priority_class(),
                                              tracing::trace_state_ptr trace_state_ptr = nullptr,
                                              streamed_mutation::forwarding fwd = streamed_mutation::forwarding::no,
-                                             mutation_reader::forwarding fwd_mr = mutation_reader::forwarding::yes);
+                                             mutation_reader::forwarding fwd_mr = mutation_reader::forwarding::yes) {
+        if (auto reader_opt = make_flat_reader_opt(s, permit, range, slice, pc, std::move(trace_state_ptr), fwd, fwd_mr)) {
+            return std::move(*reader_opt);
+        }
+        [[unlikely]] return make_empty_flat_reader_v2(std::move(s), std::move(permit));
+    }
+    // Same as make_flat_reader, but returns an empty optional instead of a no-op reader when there is nothing to
+    // read. This is an optimization.
+    flat_mutation_reader_v2_opt make_flat_reader_opt(schema_ptr,
+                                          reader_permit permit,
+                                          const dht::partition_range& range,
+                                          const query::partition_slice& slice,
+                                          const io_priority_class& pc = default_priority_class(),
+                                          tracing::trace_state_ptr trace_state_ptr = nullptr,
+                                          streamed_mutation::forwarding fwd = streamed_mutation::forwarding::no,
+                                          mutation_reader::forwarding fwd_mr = mutation_reader::forwarding::yes);
 
     flat_mutation_reader_v2 make_flat_reader(schema_ptr s,
                                              reader_permit permit,

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -185,7 +185,9 @@ table::make_reader_v2(schema_ptr s,
 
     const auto bypass_cache = slice.options.contains(query::partition_slice::option::bypass_cache);
     if (cache_enabled() && !bypass_cache && !(reversed && _config.reversed_reads_auto_bypass_cache())) {
-        readers.emplace_back(upgrade_to_v2(_cache.make_reader(s, permit, range, slice, pc, std::move(trace_state), fwd, fwd_mr)));
+        if (auto reader_opt = _cache.make_reader_opt(s, permit, range, slice, pc, std::move(trace_state), fwd, fwd_mr)) {
+            readers.emplace_back(upgrade_to_v2(std::move(*reader_opt)));
+        }
     } else {
         readers.emplace_back(make_sstable_reader(s, permit, _sstables, range, slice, pc, std::move(trace_state), fwd, fwd_mr));
     }

--- a/row_cache.hh
+++ b/row_cache.hh
@@ -361,7 +361,22 @@ public:
     // User needs to ensure that the row_cache object stays alive
     // as long as the reader is used.
     // The range must not wrap around.
-    flat_mutation_reader make_reader(schema_ptr,
+    flat_mutation_reader make_reader(schema_ptr s,
+                                     reader_permit permit,
+                                     const dht::partition_range& range,
+                                     const query::partition_slice& slice,
+                                     const io_priority_class& pc = default_priority_class(),
+                                     tracing::trace_state_ptr trace_state = nullptr,
+                                     streamed_mutation::forwarding fwd = streamed_mutation::forwarding::no,
+                                     mutation_reader::forwarding fwd_mr = mutation_reader::forwarding::no) {
+        if (auto reader_opt = make_reader_opt(s, permit, range, slice, pc, std::move(trace_state), fwd, fwd_mr)) {
+            return std::move(*reader_opt);
+        }
+        [[unlikely]] return make_empty_flat_reader(std::move(s), std::move(permit));
+    }
+    // Same as make_reader, but returns an empty optional instead of a no-op reader when there is nothing to
+    // read. This is an optimization.
+    flat_mutation_reader_opt make_reader_opt(schema_ptr,
                                      reader_permit permit,
                                      const dht::partition_range&,
                                      const query::partition_slice&,


### PR DESCRIPTION
When row_cache::make_reader() and memtable::make_flat_reader() see that the query result is empty, they return empty_flat_reader, which is a trivial implementation of flat_mutation_reader.
Even though empty_flat_reader doesn't do anything meaningful, it still needs to be created, handled in merging_reader and destroyed. Turns out this is costly.

This patch series replaces hot path uses of empty_flat_reader with an empty optional.

Performance effects:

`perf_simple_query --smp 1`
TPS: 138k -> 168k
allocs/op: 80.2 -> 71.1
insns/op: 49.9k -> 45.1k

`perf_simple_query --smp 1 --enable-cache=1 --flush`
TPS: 125k -> 150k
allocs/op: 79.2 -> 71.1
insns/op: 51.7k -> 47.2k

For a cassandra-stress benchmark (localhost, 100% cache reads) this translates to a TPS increase from ~42k to ~48k per hyperthread.

Note that this optimization is effective for single-partition reads where the queried partition is only in cache/sstables or only in memtables. Other queries (e.g. where the partition is in both cache in memtables and needs to be merged) are unaffected.