### PR TITLE
abstract_read_resolver: bring back cancelling timeout timer on read f…

### DIFF
--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -2858,6 +2858,7 @@ protected:
         // The exception container was created on the same shard,
         // so it should be cheap to clone and not throw
         _done_promise.set_value(ex.clone());
+        _timeout.cancel();
         on_failure(std::move(ex));
     }
 public:


### PR DESCRIPTION
…ailure

Recent PR #10092 (propagating read timeouts on coordinator without
throwing) accidentally removed a line which cancelled
`abstract_read_resolver`'s `_timeout` timer after a read failure.
Because of that, it might happen that after a read failure the timer is
triggered and the `_done_promise` is set twice which triggers an assert
in seastar.

This commit brings back the line which cancels the timeout timer.

Fixes: #10193