### PR TITLE
readers: Make result_collector use queue reader handle v2.

### DIFF
--- a/db/virtual_table.hh
+++ b/db/virtual_table.hh
@@ -72,7 +72,7 @@ public:
 
     // Subsequent calls should pass fragments which form a valid mutation fragment stream (see mutation_fragment.hh).
     // Concurrent calls not allowed.
-    virtual future<> take(mutation_fragment) = 0;
+    virtual future<> take(mutation_fragment_v2) = 0;
 
 public: // helpers
     future<> emit_partition_start(dht::decorated_key dk);

--- a/test/boost/virtual_table_mutation_source_test.cc
+++ b/test/boost/virtual_table_mutation_source_test.cc
@@ -41,9 +41,9 @@ public:
             do_for_each(_mutations, [mt] (const mutation& m) {
                 mt->apply(m);
             }).get();
-            auto rdr = downgrade_to_v1(mt->make_flat_reader(_s, permit));
+            auto rdr = mt->make_flat_reader(_s, permit);
             auto close_rdr = deferred_close(rdr);
-            rdr.consume_pausable([&rc] (mutation_fragment mf) {
+            rdr.consume_pausable([&rc] (mutation_fragment_v2 mf) {
                 return rc.take(std::move(mf)).then([] { return stop_iteration::no; });
             }).get();
         });


### PR DESCRIPTION
Transitively modifies streaming_virtual_table::as_mutation_source,
along with the tests.