### PR TITLE
cql3: expr: is_supported_by: Return false for subscripted values

### DIFF
--- a/cql3/expr/expression.cc
+++ b/cql3/expr/expression.cc
@@ -1001,12 +1001,8 @@ bool is_supported_by(const expression& expr, const secondary_index::index& idx) 
                         },
                         [&] (const token&) { return false; },
                         [&] (const subscript& s) -> bool {
-                            // FIXME: This seems wrong, should probably just return false.
                             // We don't support indexes on map entries yet.
-                            // For now behaviour copied from column_value& handler to preserve behaviour.
-                            // Fill be fixed soon in a separate patch.
-                            const column_value& col = get_subscripted_column(s);
-                            return idx.supports_expression(*col.col, oper.op);
+                            return false;
                         },
                         [&] (const binary_operator&) -> bool {
                             on_internal_error(expr_logger, "is_supported_by: nested binary operators are not supported");


### PR DESCRIPTION
is_supported_by checks whether a given restriction
can be supported by some index.

Currently when a subscripted value, e.g `m[1]` is encountered,
we ignore the fact that there is a subscript and ask
whether an index can support the `m` itself.

This looks like unintentional behaviour leftover
from the times when column_value had a sub field,
which could be easily forgotten about.

Scylla doesn't support indexes on collection elements at all,
so simply returning false there seems like a good idea.

This has been originally noticed in #10139, but I didn't change the behaviour to keep the PR focused.

I think this change shouldn't break anything, this branch shouldn't be ever reached because a message about not supporting is thrown before anything happens at all.