### PR TITLE
cql3: expr: possible_lhs_values: Handle subscripted columns

### DIFF
--- a/cql3/expr/expression.cc
+++ b/cql3/expr/expression.cc
@@ -803,26 +803,7 @@ value_set possible_lhs_values(const column_definition* cdef, const expression& e
                             throw std::logic_error(format("possible_lhs_values: unhandled operator {}", oper));
                         },
                         [&] (const subscript& s) -> value_set {
-                            // FIXME: This looks wrong, the restriction is for the subscripted value, not the column.
-                            // Code copied from column_value& handler to preserve behaviour.
-                            // I didn't want to introduce changes in a refactor PR.
-                            // Will be fixed in another patch soon.
-                            const column_value& col = get_subscripted_column(s);
-
-                            if (!cdef || cdef != col.col) {
-                                return unbounded_value_set;
-                            }
-                            if (is_compare(oper.op)) {
-                                managed_bytes_opt val = evaluate(oper.rhs, options).value.to_managed_bytes_opt();
-                                if (!val) {
-                                    return empty_value_set; // All NULL comparisons fail; no column values match.
-                                }
-                                return oper.op == oper_t::EQ ? value_set(value_list{*val})
-                                        : to_range(oper.op, std::move(*val));
-                            } else if (oper.op == oper_t::IN) {
-                                return get_IN_values(oper.rhs, options, type->as_less_comparator(), cdef->name_as_text());
-                            }
-                            throw std::logic_error(format("possible_lhs_values: unhandled operator {}", oper));
+                            on_internal_error(expr_logger, "possible_lhs_values: subscripts are not supported as the LHS of a binary expression");
                         },
                         [&] (const tuple_constructor& tuple) -> value_set {
                             if (!cdef) {


### PR DESCRIPTION
This commit makes subscript an invalid argument to possible_lhs_values.
Previously this function simply ignored subscripts and behaved as if it was called on the subscripted column without a subscript.

This behaviour is unexpected and potentially dangerous so it would be better to forbid passing subscript to possible_lhs_values entirely.

Trying to handle subscript correctly is impossible without refactoring the whole function. The first argument is a column for which we would like to know the possible values. What are possible values of a subscripted column c where c[0] = 1? All lists that have 1 on 0th position?

If we wanted to handle this nicely we would have to change the arguments. Such refectoring is best left until the time when this functionality is actually needed, right now it's hard to predict what interface will be needed then.

Originally mentioned in #10139.