### PR TITLE
docker: install pidof command to the Docker image

### DIFF
--- a/dist/docker/debian/build_docker.sh
+++ b/dist/docker/debian/build_docker.sh
@@ -80,7 +80,7 @@ run apt-get -y update
 run apt-get -y install dialog apt-utils
 run bash -ec "echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections"
 run bash -ec "rm -rf /etc/rsyslog.conf"
-run apt-get -y install hostname supervisor openssh-server openssh-client openjdk-11-jre-headless python python-yaml curl rsyslog locales sudo
+run apt-get -y install hostname supervisor openssh-server openssh-client openjdk-11-jre-headless python python-yaml curl rsyslog locales sudo sysvinit-utils
 run locale-gen en_US.UTF-8
 run update-locale LANG=en_US.UTF-8 LANGUAGE=en_US:en LC_ALL=en_US.UTF_8
 run bash -ec "dpkg -i packages/*.deb"


### PR DESCRIPTION
Since seastar-cpu-map.sh requires pidof, we need to install it.

Fixes #10238