### PR TITLE
docs/conf.py:update scylla-4.6 to latest

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -65,10 +65,10 @@ redirects_file = "_utils/redirections.yaml"
 TAGS = []
 smv_tag_whitelist = multiversion_regex_builder(TAGS)
 # Whitelist pattern for branches (set to None to ignore all branches)
-BRANCHES = ['branch-4.4', 'branch-4.5', 'master']
+BRANCHES = ['branch-4.5', 'branch-4.6', 'master']
 smv_branch_whitelist = multiversion_regex_builder(BRANCHES)
 # Defines which version is considered to be the latest stable version.
-smv_latest_version = 'branch-4.5'
+smv_latest_version = 'branch-4.6'
 smv_rename_latest_version = 'stable'
 # Must be listed in smv_tag_whitelist or smv_branch_whitelist.
 # Whitelist pattern for remotes (set to None to use local branches only)


### PR DESCRIPTION
Now that Scylla 4.6 is out, it;s the latest release available

Closes: https://github.com/scylladb/scylla/issues/10266