### PR TITLE
Distributed aggregate query

### DIFF
--- a/cql3/Cql.g
+++ b/cql3/Cql.g
@@ -681,6 +681,7 @@ createAggregateStatement returns [std::unique_ptr<cql3::statements::create_aggre
         std::vector<shared_ptr<cql3_type::raw>> arg_types;
         std::optional<sstring> ffunc;
         std::optional<expr::expression> ival;
+        std::optional<sstring> rfunc;
     }
     : K_CREATE (K_OR K_REPLACE { or_replace = true; })?
       K_AGGREGATE
@@ -695,12 +696,15 @@ createAggregateStatement returns [std::unique_ptr<cql3::statements::create_aggre
       K_SFUNC sfunc = allowedFunctionName
       K_STYPE stype = comparatorType
       (
+        K_REDUCEFUNC reduce_name = allowedFunctionName { rfunc = reduce_name; }
+      )?
+      (
         K_FINALFUNC final_func = allowedFunctionName { ffunc = final_func; }
       )?
       (
         K_INITCOND init_val = term { ival = init_val; }
       )?
-      { $expr = std::make_unique<cql3::statements::create_aggregate_statement>(std::move(fn), std::move(arg_types), std::move(sfunc), std::move(stype), std::move(ffunc), std::move(ival), or_replace, if_not_exists); }
+      { $expr = std::make_unique<cql3::statements::create_aggregate_statement>(std::move(fn), std::move(arg_types), std::move(sfunc), std::move(stype), std::move(rfunc), std::move(ffunc), std::move(ival), or_replace, if_not_exists); }
     ;
 
 createFunctionStatement returns [std::unique_ptr<cql3::statements::create_function_statement> expr]
@@ -1899,6 +1903,7 @@ basic_unreserved_keyword returns [sstring str]
         | K_AGGREGATE
         | K_SFUNC
         | K_STYPE
+        | K_REDUCEFUNC
         | K_FINALFUNC
         | K_INITCOND
         | K_RETURNS
@@ -2077,6 +2082,7 @@ K_FUNCTION:    F U N C T I O N;
 K_AGGREGATE:   A G G R E G A T E;
 K_SFUNC:       S F U N C;
 K_STYPE:       S T Y P E;
+K_REDUCEFUNC:  R E D U C E F U N C;
 K_FINALFUNC:   F I N A L F U N C;
 K_INITCOND:    I N I T C O N D;
 K_RETURNS:     R E T U R N S;

--- a/cql3/expr/expression.hh
+++ b/cql3/expr/expression.hh
@@ -32,6 +32,12 @@
 
 class row;
 
+namespace db {
+namespace functions {
+    class function;
+}
+}
+
 namespace secondary_index {
 class index;
 class secondary_index_manager;
@@ -50,12 +56,6 @@ class query_options;
 namespace selection {
     class selection;
 } // namespace selection
-
-namespace functions {
-
-class function;
-
-}
 
 namespace restrictions {
     class restriction;
@@ -275,7 +275,7 @@ struct column_mutation_attribute {
 };
 
 struct function_call {
-    std::variant<functions::function_name, shared_ptr<functions::function>> func;
+    std::variant<functions::function_name, shared_ptr<db::functions::function>> func;
     std::vector<expression> args;
 
     // 0-based index of the function call within a CQL statement.

--- a/cql3/functions/aggregate_fcts.cc
+++ b/cql3/functions/aggregate_fcts.cc
@@ -8,13 +8,22 @@
  * SPDX-License-Identifier: (AGPL-3.0-or-later and Apache-2.0)
  */
 
-
+#include "bytes.hh"
+#include "types.hh"
+#include "types/tuple.hh"
+#include "cql3/functions/scalar_function.hh"
+#include "cql_serialization_format.hh"
 #include "utils/big_decimal.hh"
 #include "aggregate_fcts.hh"
 #include "user_aggregate.hh"
 #include "functions.hh"
 #include "native_aggregate_function.hh"
 #include "exceptions/exceptions.hh"
+#include "utils/multiprecision_int.hh"
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <type_traits>
 
 using namespace cql3;
 using namespace functions;
@@ -37,14 +46,36 @@ public:
     virtual void add_input(cql_serialization_format sf, const std::vector<opt_bytes>& values) override {
         ++_count;
     }
+    virtual void set_accumulator(const opt_bytes& acc) override {
+        if (acc) {
+            _count = value_cast<int64_t>(long_type->deserialize(bytes_view(*acc)));
+        } else {
+            reset();
+        }
+    }
+    virtual opt_bytes get_accumulator() const override {
+        return long_type->decompose(_count);
+    }
+    virtual void reduce(cql_serialization_format sf, const opt_bytes& acc) override {
+        if (acc) {
+            auto other = value_cast<int64_t>(long_type->deserialize(bytes_view(*acc)));
+            _count += other;
+        }
+    }
 };
 
 class count_rows_function final : public native_aggregate_function {
 public:
     count_rows_function() : native_aggregate_function(COUNT_ROWS_FUNCTION_NAME, long_type, {}) {}
+    virtual bool is_reducible() const override {
+        return true;
+    }
     virtual std::unique_ptr<aggregate> new_aggregate() override {
         return std::make_unique<impl_count_function>();
     }
+    virtual ::shared_ptr<aggregate_function> reducible_aggregate_function() override {
+        return ::make_shared<count_rows_function>();
+    };
     virtual sstring column_name(const std::vector<sstring>& column_names) const override {
         return "count";
     }
@@ -66,6 +97,40 @@ struct int128_accumulator_for {
         }
         return ret;
     }
+
+    static data_value decompose_to_data_value(const type& acc) {
+        uint64_t upper = acc >> 64;
+        uint64_t lower = acc;
+
+        utils::multiprecision_int value(upper);
+        value = (value << 64) + lower;
+        return value;
+    }
+
+    static bytes_opt decompose(const data_value& value) {
+        return varint_type->decompose(value);
+    }
+
+    static bytes_opt decompose(const type& acc) {
+        return varint_type->decompose(decompose_to_data_value(acc));
+    }
+
+    static type cast_to_accumulator(const data_value& value) {
+        auto mint = value_cast<utils::multiprecision_int>(value);
+        uint64_t upper = (uint64_t)(mint >> 64);
+        uint64_t lower = (uint64_t)mint;
+
+        __int128 result = upper;
+        return (result << 64) | lower;
+    }
+
+    static type deserialize(const bytes_opt& acc) {
+        return cast_to_accumulator(varint_type->deserialize(*acc));
+    }
+
+    static shared_ptr<const abstract_type> data_type() {
+        return varint_type;
+    }
 };
 
 template <typename T>
@@ -74,6 +139,30 @@ struct same_type_accumulator_for {
 
     static T narrow(type acc) {
         return acc;
+    }
+
+    static data_value decompose_to_data_value(const type& acc) {
+        return narrow(acc);
+    }
+
+    static bytes_opt decompose(const data_value& value) {
+        return data_type_for<type>()->decompose(value);
+    }
+
+    static bytes_opt decompose(const type& acc) {
+        return data_type_for<type>()->decompose(decompose_to_data_value(acc));
+    }
+
+    static type cast_to_accumulator(const data_value& value) {
+        return value_cast<type>(value);
+    }
+
+    static type deserialize(const bytes_opt& acc) {
+        return cast_to_accumulator(data_type_for<type>()->deserialize(*acc));
+    }
+
+    static shared_ptr<const abstract_type> data_type() {
+        return data_type_for<T>();
     }
 };
 
@@ -85,12 +174,14 @@ struct accumulator_for : public std::conditional_t<std::is_integral_v<T>,
 
 class impl_user_aggregate : public aggregate_function::aggregate {
     ::shared_ptr<scalar_function> _sfunc;
+    ::shared_ptr<scalar_function> _rfunc;
     ::shared_ptr<scalar_function> _finalfunc;
     const bytes_opt _initcond;
     bytes_opt _acc;
 public:
-    impl_user_aggregate(bytes_opt initcond, ::shared_ptr<scalar_function> sfunc, ::shared_ptr<scalar_function> finalfunc)
+    impl_user_aggregate(bytes_opt initcond, ::shared_ptr<scalar_function> sfunc, ::shared_ptr<scalar_function> rfunc, ::shared_ptr<scalar_function> finalfunc)
             : _sfunc(std::move(sfunc))
+            , _rfunc(std::move(rfunc))
             , _finalfunc(std::move(finalfunc))
             , _initcond(std::move(initcond))
             , _acc(_initcond)
@@ -106,10 +197,21 @@ public:
         args.insert(args.end(), values.begin(), values.end());
         _acc = _sfunc->execute(sf, args);
     }
+    virtual void set_accumulator(const opt_bytes& acc) override {
+        _acc = acc;
+    }
+    virtual opt_bytes get_accumulator() const override {
+        return _acc;
+    }
+    virtual void reduce(cql_serialization_format sf, const opt_bytes& acc) override {
+        std::vector<bytes_opt> args{_acc, acc};
+        _acc = _rfunc->execute(sf, args);
+    }
 };
 
 template <typename Type>
-class impl_sum_function_for final : public aggregate_function::aggregate {
+class impl_sum_function_for : public aggregate_function::aggregate {
+protected:
     using accumulator_type = typename accumulator_for<Type>::type;
     accumulator_type _sum{};
 public:
@@ -125,15 +227,59 @@ public:
         }
         _sum += value_cast<Type>(data_type_for<Type>()->deserialize(*values[0]));
     }
+    virtual void set_accumulator(const opt_bytes& acc) override {
+        if (acc) {
+            _sum = accumulator_for<Type>::deserialize(acc);
+        } else {
+            reset();
+        }
+    }
+    virtual opt_bytes get_accumulator() const override {
+        return accumulator_for<Type>::decompose(_sum);
+    }
+    virtual void reduce(cql_serialization_format sf, const opt_bytes& acc) override {
+        if (acc) {
+            auto other = accumulator_for<Type>::deserialize(acc);
+            _sum += other;
+        }
+    }
 };
 
 template <typename Type>
-class sum_function_for final : public native_aggregate_function {
+class impl_reducible_sum_function final : public impl_sum_function_for<Type> {
+public:
+    virtual bytes_opt compute(cql_serialization_format sf) override {
+        return this->get_accumulator();
+    }
+};
+
+template <typename Type>
+class sum_function_for : public native_aggregate_function {
 public:
     sum_function_for() : native_aggregate_function("sum", data_type_for<Type>(), { data_type_for<Type>() }) {}
+    sum_function_for(data_type return_type, std::vector<data_type> arg_types) 
+      : native_aggregate_function("sum", std::move(return_type), std::move(arg_types)) {}
+
+    virtual bool is_reducible() const override {
+        return true;
+    }
+
     virtual std::unique_ptr<aggregate> new_aggregate() override {
         return std::make_unique<impl_sum_function_for<Type>>();
     }
+
+    virtual ::shared_ptr<aggregate_function> reducible_aggregate_function() override {
+        class reducible_sum_function : public sum_function_for<Type> {
+        public:
+            reducible_sum_function() : sum_function_for(accumulator_for<Type>::data_type(), { data_type_for<Type>() }) {}
+
+            virtual std::unique_ptr<aggregate> new_aggregate() override {
+                return std::make_unique<impl_reducible_sum_function<Type>>();
+            }
+        };
+
+        return ::make_shared<reducible_sum_function>();
+    };
 };
 
 
@@ -161,7 +307,8 @@ public:
 };
 
 template <typename Type>
-class impl_avg_function_for final : public aggregate_function::aggregate {
+class impl_avg_function_for : public aggregate_function::aggregate {
+protected:
    typename accumulator_for<Type>::type _sum{};
    int64_t _count = 0;
 public:
@@ -183,14 +330,72 @@ public:
         ++_count;
         _sum += value_cast<Type>(data_type_for<Type>()->deserialize(*values[0]));
     }
+    virtual void set_accumulator(const opt_bytes& acc) override {
+        if (acc) {
+            data_type tuple_type = tuple_type_impl::get_instance({accumulator_for<Type>::data_type(), long_type});
+            auto tuple = value_cast<tuple_type_impl::native_type>(tuple_type->deserialize(bytes_view(*acc)));
+
+            _sum = accumulator_for<Type>::cast_to_accumulator(tuple[0]);
+            _count = value_cast<int64_t>(tuple[1]);
+        } else {
+            reset();
+        }
+    }
+    virtual opt_bytes get_accumulator() const override {
+        data_value tuple_val = make_tuple_value(
+            tuple_type_impl::get_instance({accumulator_for<Type>::data_type(), long_type}),
+            {accumulator_for<Type>::decompose_to_data_value(_sum), data_value(_count)}
+        );
+        return tuple_val.serialize();
+    }
+    virtual void reduce(cql_serialization_format sf, const opt_bytes& acc) override {
+        if (acc) {
+            data_type tuple_type = tuple_type_impl::get_instance({accumulator_for<Type>::data_type(), long_type});
+            auto tuple = value_cast<tuple_type_impl::native_type>(tuple_type->deserialize(bytes_view(*acc)));
+
+            _sum += accumulator_for<Type>::cast_to_accumulator(tuple[0]);
+            _count += value_cast<int64_t>(tuple[1]);
+        }
+    }
 };
 
 template <typename Type>
-class avg_function_for final : public native_aggregate_function {
+class impl_reducible_avg_function : public impl_avg_function_for<Type> {
+public:
+    virtual bytes_opt compute(cql_serialization_format sf) override {
+        return this->get_accumulator();
+    }
+};
+
+template <typename Type>
+class avg_function_for : public native_aggregate_function {
 public:
     avg_function_for() : native_aggregate_function("avg", data_type_for<Type>(), { data_type_for<Type>() }) {}
+    avg_function_for(data_type return_type, std::vector<data_type> arg_types) 
+      : native_aggregate_function("avg", std::move(return_type), std::move(arg_types)) {}
+
+    virtual bool is_reducible() const override {
+        return true;
+    }
+
     virtual std::unique_ptr<aggregate> new_aggregate() override {
         return std::make_unique<impl_avg_function_for<Type>>();
+    }
+
+    virtual ::shared_ptr<aggregate_function> reducible_aggregate_function() override {
+        class reducible_avg_function : public avg_function_for<Type> {
+        public:
+            reducible_avg_function() : avg_function_for(
+                tuple_type_impl::get_instance({accumulator_for<Type>::data_type(), long_type}), 
+                { data_type_for<Type>() }
+            ) {}
+
+            virtual std::unique_ptr<aggregate> new_aggregate() override {
+                return std::make_unique<impl_reducible_avg_function<Type>>();
+            }
+        };
+
+        return ::make_shared<reducible_avg_function>();
     }
 };
 
@@ -269,6 +474,22 @@ public:
             _max = max_wrapper(*_max, val);
         }
     }
+    virtual void set_accumulator(const opt_bytes& acc) override {
+        if (acc) {
+            _max = value_cast<typename aggregate_type_for<Type>::type>(data_type_for<Type>()->deserialize(*acc));
+        } else {
+            reset();
+        }
+    }
+    virtual opt_bytes get_accumulator() const override {
+        if (_max) {
+            return data_type_for<Type>()->decompose(data_value(Type{*_max}));
+        }
+        return {};
+    }
+    virtual void reduce(cql_serialization_format sf, const opt_bytes& acc) override {
+        return add_input(sf, {acc});
+    }
 };
 
 /// The same as `impl_max_function_for' but without compile-time dependency on `Type'.
@@ -288,9 +509,21 @@ public:
         if (values.empty() || !values[0]) {
             return;
         }
-        if (!_max || _io_type->less(*_max, *values[0])) {
+        if (!_max || !_max->length() || _io_type->less(*_max, *values[0])) {
             _max = values[0];
         }
+    }
+    virtual void set_accumulator(const opt_bytes& acc) override {
+        _max = acc;
+    }
+    virtual opt_bytes get_accumulator() const override {
+        return _max;
+    }
+    virtual void reduce(cql_serialization_format sf, const opt_bytes& acc) override {
+        if (acc && !acc->length()) {
+            return;
+        }
+        return add_input(sf, {acc});
     }
 };
 
@@ -298,9 +531,15 @@ template <typename Type>
 class max_function_for final : public native_aggregate_function {
 public:
     max_function_for() : native_aggregate_function("max", data_type_for<Type>(), { data_type_for<Type>() }) {}
+    virtual bool is_reducible() const override {
+        return true;
+    }
     virtual std::unique_ptr<aggregate> new_aggregate() override {
         return std::make_unique<impl_max_function_for<Type>>();
     }
+    virtual ::shared_ptr<aggregate_function> reducible_aggregate_function() override {
+        return ::make_shared<max_function_for<Type>>();
+    };
 };
 
 class max_dynamic_function final : public native_aggregate_function {
@@ -309,9 +548,15 @@ public:
     max_dynamic_function(data_type io_type)
             : native_aggregate_function("max", io_type, { io_type })
             , _io_type(std::move(io_type)) {}
+    virtual bool is_reducible() const override {
+        return true;
+    }            
     virtual std::unique_ptr<aggregate> new_aggregate() override {
         return std::make_unique<impl_max_dynamic_function>(_io_type);
     }
+    virtual ::shared_ptr<aggregate_function> reducible_aggregate_function() override {
+        return ::make_shared<max_dynamic_function>(_io_type);
+    };
 };
 
 /**
@@ -370,6 +615,22 @@ public:
             _min = min_wrapper(*_min, val);
         }
     }
+    virtual void set_accumulator(const opt_bytes& acc) override {
+        if (acc) {
+            _min = value_cast<typename aggregate_type_for<Type>::type>(data_type_for<Type>()->deserialize(*acc));
+        } else {
+            reset();
+        }
+    }
+    virtual opt_bytes get_accumulator() const override {
+        if (_min) {
+            return data_type_for<Type>()->decompose(data_value(Type{*_min}));
+        }
+        return {};
+    }
+    virtual void reduce(cql_serialization_format sf, const opt_bytes& acc) override {
+        return add_input(sf, {acc});
+    }
 };
 
 /// The same as `impl_min_function_for' but without compile-time dependency on `Type'.
@@ -389,9 +650,21 @@ public:
         if (values.empty() || !values[0]) {
             return;
         }
-        if (!_min || _io_type->less(*values[0], *_min)) {
+        if (!_min || !_min->length() || _io_type->less(*values[0], *_min)) {
             _min = values[0];
         }
+    }
+    virtual void set_accumulator(const opt_bytes& acc) override {
+        _min = acc;
+    }
+    virtual opt_bytes get_accumulator() const override {
+        return _min;
+    }
+    virtual void reduce(cql_serialization_format sf, const opt_bytes& acc) override {
+        if (acc && !acc->length()) {
+            return;
+        }
+        return add_input(sf, {acc});
     }
 };
 
@@ -399,9 +672,15 @@ template <typename Type>
 class min_function_for final : public native_aggregate_function {
 public:
     min_function_for() : native_aggregate_function("min", data_type_for<Type>(), { data_type_for<Type>() }) {}
+    virtual bool is_reducible() const override {
+        return true;
+    }
     virtual std::unique_ptr<aggregate> new_aggregate() override {
         return std::make_unique<impl_min_function_for<Type>>();
     }
+    virtual ::shared_ptr<aggregate_function> reducible_aggregate_function() override {
+        return ::make_shared<min_function_for<Type>>();
+    };
 };
 
 class min_dynamic_function final : public native_aggregate_function {
@@ -410,9 +689,15 @@ public:
     min_dynamic_function(data_type io_type)
             : native_aggregate_function("min", io_type, { io_type })
             , _io_type(std::move(io_type)) {}
+    virtual bool is_reducible() const override {
+        return true;
+    }
     virtual std::unique_ptr<aggregate> new_aggregate() override {
         return std::make_unique<impl_min_dynamic_function>(_io_type);
     }
+    virtual ::shared_ptr<aggregate_function> reducible_aggregate_function() override {
+        return ::make_shared<min_dynamic_function>(_io_type);
+    };
 };
 
 /**
@@ -444,15 +729,37 @@ public:
         }
         ++_count;
     }
+    virtual void set_accumulator(const opt_bytes& acc) override {
+        if (acc) {
+            _count = value_cast<int64_t>(long_type->deserialize(bytes_view(*acc)));
+        } else {
+            reset();
+        }
+    }
+    virtual opt_bytes get_accumulator() const override {
+        return long_type->decompose(_count);
+    }
+    virtual void reduce(cql_serialization_format sf, const opt_bytes& acc) override {
+        if (acc) {
+            auto other = value_cast<int64_t>(long_type->deserialize(bytes_view(*acc)));
+            _count += other;
+        }
+    }
 };
 
 template <typename Type>
 class count_function_for final : public native_aggregate_function {
 public:
     count_function_for() : native_aggregate_function("count", long_type, { data_type_for<Type>() }) {}
+    virtual bool is_reducible() const override {
+        return true;
+    }
     virtual std::unique_ptr<aggregate> new_aggregate() override {
         return std::make_unique<impl_count_function_for<Type>>();
     }
+    virtual ::shared_ptr<aggregate_function> reducible_aggregate_function() override {
+        return ::make_shared<count_function_for<Type>>();
+    };
 };
 
 /**
@@ -491,7 +798,13 @@ user_aggregate::user_aggregate(function_name fname, bytes_opt initcond, ::shared
 {}
 
 std::unique_ptr<aggregate_function::aggregate> user_aggregate::new_aggregate() {
-    return std::make_unique<impl_user_aggregate>(_initcond, _sfunc, _finalfunc);
+    return std::make_unique<impl_user_aggregate>(_initcond, _sfunc, _reducefunc, _finalfunc);
+}
+
+::shared_ptr<aggregate_function> user_aggregate::reducible_aggregate_function() {
+    auto name = _name;
+    name.name += "_reducible";
+    return ::make_shared<user_aggregate>(name, _initcond, _sfunc, _reducefunc, nullptr);
 }
 
 bool user_aggregate::is_pure() const { return _sfunc->is_pure() && (!_finalfunc || _finalfunc->is_pure()); }

--- a/cql3/functions/aggregate_fcts.cc
+++ b/cql3/functions/aggregate_fcts.cc
@@ -482,10 +482,11 @@ static data_type uda_return_type(const ::shared_ptr<scalar_function>& ffunc, con
     return ffunc ? ffunc->return_type() : sfunc->return_type();
 }
 
-user_aggregate::user_aggregate(function_name fname, bytes_opt initcond, ::shared_ptr<scalar_function> sfunc, ::shared_ptr<scalar_function> finalfunc)
+user_aggregate::user_aggregate(function_name fname, bytes_opt initcond, ::shared_ptr<scalar_function> sfunc, ::shared_ptr<scalar_function> reducefunc, ::shared_ptr<scalar_function> finalfunc)
         : abstract_function(std::move(fname), state_arg_types_to_uda_arg_types(sfunc->arg_types()), uda_return_type(finalfunc, sfunc))
         , _initcond(std::move(initcond))
         , _sfunc(std::move(sfunc))
+        , _reducefunc(std::move(reducefunc))
         , _finalfunc(std::move(finalfunc))
 {}
 

--- a/cql3/functions/aggregate_fcts.cc
+++ b/cql3/functions/aggregate_fcts.cc
@@ -497,6 +497,7 @@ std::unique_ptr<aggregate_function::aggregate> user_aggregate::new_aggregate() {
 bool user_aggregate::is_pure() const { return _sfunc->is_pure() && (!_finalfunc || _finalfunc->is_pure()); }
 bool user_aggregate::is_native() const { return false; }
 bool user_aggregate::is_aggregate() const { return true; }
+bool user_aggregate::is_reducible() const { return _reducefunc != nullptr; }
 bool user_aggregate::requires_thread() const { return _sfunc->requires_thread() || (_finalfunc && _finalfunc->requires_thread()); }
 bool user_aggregate::has_finalfunc() const { return _finalfunc != nullptr; }
 

--- a/cql3/functions/aggregate_function.hh
+++ b/cql3/functions/aggregate_function.hh
@@ -10,84 +10,12 @@
 
 #pragma once
 
-#include "function.hh"
-#include <optional>
+#include "db/functions/aggregate_function.hh"
 
 namespace cql3 {
 namespace functions {
 
-
-/**
- * Performs a calculation on a set of values and return a single value.
- */
-class aggregate_function : public virtual function {
-public:
-    class aggregate;
-
-    /**
-     * Creates a new <code>Aggregate</code> instance.
-     *
-     * @return a new <code>Aggregate</code> instance.
-     */
-    virtual std::unique_ptr<aggregate> new_aggregate() = 0;
-
-    /**
-     * Checks wheather the function can be distributed and is able to reduce states.
-     *
-     * @return <code>true</code> if the function is reducible, <code>false</code> otherwise.
-     */
-    virtual bool is_reducible() const = 0;
-
-    /**
-     * Creates a <code>Aggregate Function</code> that can be reduced.
-     * Such <code>Aggregate Function</code> returns <code>Aggregate</code>,
-     * which returns not finalized output, but its accumulator that can be 
-     * later reduced with other one.
-     *
-     * Reducible aggregate function can be obtained only if <code>is_reducible()</code>
-     * return true. Otherwise, it should return <code>nullptr</code>.
-     *
-     * @return a reducible <code>Aggregate Function</code>.
-     */
-    virtual ::shared_ptr<aggregate_function> reducible_aggregate_function() = 0;
-
-    /**
-     * An aggregation operation.
-     */
-    class aggregate {
-    public:
-        using opt_bytes = aggregate_function::opt_bytes;
-
-        virtual ~aggregate() {}
-
-        /**
-         * Adds the specified input to this aggregate.
-         *
-         * @param protocol_version native protocol version
-         * @param values the values to add to the aggregate.
-         */
-        virtual void add_input(cql_serialization_format sf, const std::vector<opt_bytes>& values) = 0;
-
-        /**
-         * Computes and returns the aggregate current value.
-         *
-         * @param protocol_version native protocol version
-         * @return the aggregate current value.
-         */
-        virtual opt_bytes compute(cql_serialization_format sf) = 0;
-
-        virtual void set_accumulator(const opt_bytes& acc) = 0;
-
-        virtual opt_bytes get_accumulator() const = 0;
-
-        virtual void reduce(cql_serialization_format sf, const opt_bytes& acc) = 0;
-
-        /**
-         * Reset this aggregate.
-         */
-        virtual void reset() = 0;
-    };
-};
+using aggregate_function = db::functions::aggregate_function;
 
 }
 }

--- a/cql3/functions/aggregate_function.hh
+++ b/cql3/functions/aggregate_function.hh
@@ -32,6 +32,26 @@ public:
     virtual std::unique_ptr<aggregate> new_aggregate() = 0;
 
     /**
+     * Checks wheather the function can be distributed and is able to reduce states.
+     *
+     * @return <code>true</code> if the function is reducible, <code>false</code> otherwise.
+     */
+    virtual bool is_reducible() const = 0;
+
+    /**
+     * Creates a <code>Aggregate Function</code> that can be reduced.
+     * Such <code>Aggregate Function</code> returns <code>Aggregate</code>,
+     * which returns not finalized output, but its accumulator that can be 
+     * later reduced with other one.
+     *
+     * Reducible aggregate function can be obtained only if <code>is_reducible()</code>
+     * return true. Otherwise, it should return <code>nullptr</code>.
+     *
+     * @return a reducible <code>Aggregate Function</code>.
+     */
+    virtual ::shared_ptr<aggregate_function> reducible_aggregate_function() = 0;
+
+    /**
      * An aggregation operation.
      */
     class aggregate {
@@ -55,6 +75,12 @@ public:
          * @return the aggregate current value.
          */
         virtual opt_bytes compute(cql_serialization_format sf) = 0;
+
+        virtual void set_accumulator(const opt_bytes& acc) = 0;
+
+        virtual opt_bytes get_accumulator() const = 0;
+
+        virtual void reduce(cql_serialization_format sf, const opt_bytes& acc) = 0;
 
         /**
          * Reset this aggregate.

--- a/cql3/functions/function.hh
+++ b/cql3/functions/function.hh
@@ -10,66 +10,12 @@
 
 #pragma once
 
-#include "types.hh"
-#include <vector>
-#include <optional>
+#include "db/functions/function.hh"
 
 namespace cql3 {
 namespace functions {
 
-class function_name;
-
-class function {
-public:
-    using opt_bytes = std::optional<bytes>;
-    virtual ~function() {}
-    virtual const function_name& name() const = 0;
-    virtual const std::vector<data_type>& arg_types() const = 0;
-    virtual const data_type& return_type() const = 0;
-
-    /**
-     * Checks whether the function is a pure function (as in doesn't depend on, nor produce side effects) or not.
-     *
-     * @return <code>true</code> if the function is a pure function, <code>false</code> otherwise.
-     */
-    virtual bool is_pure() const = 0;
-
-    /**
-     * Checks whether the function is a native/hard coded one or not.
-     *
-     * @return <code>true</code> if the function is a native/hard coded one, <code>false</code> otherwise.
-     */
-    virtual bool is_native() const = 0;
-
-    virtual bool requires_thread() const = 0;
-
-    /**
-     * Checks whether the function is an aggregate function or not.
-     *
-     * @return <code>true</code> if the function is an aggregate function, <code>false</code> otherwise.
-     */
-    virtual bool is_aggregate() const = 0;
-
-    virtual void print(std::ostream& os) const = 0;
-
-    /**
-     * Returns the name of the function to use within a ResultSet.
-     *
-     * @param column_names the names of the columns used to call the function
-     * @return the name of the function to use within a ResultSet
-     */
-    virtual sstring column_name(const std::vector<sstring>& column_names) const = 0;
-
-    friend class function_call;
-    friend std::ostream& operator<<(std::ostream& os, const function& f);
-};
-
-inline
-std::ostream&
-operator<<(std::ostream& os, const function& f) {
-    f.print(os);
-    return os;
-}
+using function = db::functions::function;
 
 }
 }

--- a/cql3/functions/function_name.hh
+++ b/cql3/functions/function_name.hh
@@ -10,66 +10,12 @@
 
 #pragma once
 
-#include <seastar/core/sstring.hh>
-#include "seastarx.hh"
-#include <iosfwd>
-#include <functional>
-
-namespace db {
-
-sstring system_keyspace_name();
-
-}
+#include "db/functions/function_name.hh"
 
 namespace cql3 {
-
 namespace functions {
 
-class function_name final {
-public:
-    sstring keyspace;
-    sstring name;
-
-    static function_name native_function(sstring name) {
-        return function_name(db::system_keyspace_name(), name);
-    }
-
-    function_name() = default; // for ANTLR
-    function_name(sstring keyspace, sstring name)
-            : keyspace(std::move(keyspace)), name(std::move(name)) {
-    }
-
-    function_name as_native_function() const {
-        return native_function(name);
-    }
-
-    bool has_keyspace() const {
-        return !keyspace.empty();
-    }
-
-    bool operator==(const function_name& x) const {
-        return keyspace == x.keyspace && name == x.name;
-    }
-};
-
-inline
-std::ostream& operator<<(std::ostream& os, const function_name& fn) {
-    if (!fn.keyspace.empty()) {
-        os << fn.keyspace << ".";
-    }
-    return os << fn.name;
-}
+using function_name = db::functions::function_name;
 
 }
-}
-
-namespace std {
-
-template <>
-struct hash<cql3::functions::function_name> {
-    size_t operator()(const cql3::functions::function_name& x) const {
-        return std::hash<sstring>()(x.keyspace) ^ std::hash<sstring>()(x.name);
-    }
-};
-
 }

--- a/cql3/functions/functions.hh
+++ b/cql3/functions/functions.hh
@@ -60,6 +60,7 @@ public:
     static boost::iterator_range<declared_t::iterator> find(const function_name& name);
     static declared_t::iterator find_iter(const function_name& name, const std::vector<data_type>& arg_types);
     static shared_ptr<function> find(const function_name& name, const std::vector<data_type>& arg_types);
+    static shared_ptr<function> mock_get(const function_name& name, const std::vector<data_type>& arg_types);
     static void clear_functions() noexcept;
     static void add_function(shared_ptr<function>);
     static void replace_function(shared_ptr<function>);

--- a/cql3/functions/user_aggregate.hh
+++ b/cql3/functions/user_aggregate.hh
@@ -18,9 +18,10 @@ namespace functions {
 class user_aggregate : public abstract_function, public aggregate_function{
     bytes_opt _initcond;
     ::shared_ptr<scalar_function> _sfunc;
+    ::shared_ptr<scalar_function> _reducefunc;
     ::shared_ptr<scalar_function> _finalfunc;
 public:
-    user_aggregate(function_name fname, bytes_opt initcond, ::shared_ptr<scalar_function> sfunc, ::shared_ptr<scalar_function> finalfunc);
+    user_aggregate(function_name fname, bytes_opt initcond, ::shared_ptr<scalar_function> sfunc, ::shared_ptr<scalar_function> reducefunc, ::shared_ptr<scalar_function> finalfunc);
     virtual std::unique_ptr<aggregate_function::aggregate> new_aggregate() override;
     virtual bool is_pure() const override;
     virtual bool is_native() const override;

--- a/cql3/functions/user_aggregate.hh
+++ b/cql3/functions/user_aggregate.hh
@@ -23,10 +23,11 @@ class user_aggregate : public abstract_function, public aggregate_function{
 public:
     user_aggregate(function_name fname, bytes_opt initcond, ::shared_ptr<scalar_function> sfunc, ::shared_ptr<scalar_function> reducefunc, ::shared_ptr<scalar_function> finalfunc);
     virtual std::unique_ptr<aggregate_function::aggregate> new_aggregate() override;
+    virtual ::shared_ptr<aggregate_function> reducible_aggregate_function() override;
     virtual bool is_pure() const override;
     virtual bool is_native() const override;
     virtual bool is_aggregate() const override;
-    bool is_reducible() const override;
+    virtual bool is_reducible() const override;
     virtual bool requires_thread() const override;
     bool has_finalfunc() const;
 

--- a/cql3/functions/user_aggregate.hh
+++ b/cql3/functions/user_aggregate.hh
@@ -26,11 +26,15 @@ public:
     virtual bool is_pure() const override;
     virtual bool is_native() const override;
     virtual bool is_aggregate() const override;
+    bool is_reducible() const override;
     virtual bool requires_thread() const override;
     bool has_finalfunc() const;
 
     const scalar_function& sfunc() const {
         return *_sfunc;
+    }
+    const scalar_function& reducefunc() const {
+        return *_reducefunc;
     }
     const scalar_function& finalfunc() const {
         return *_finalfunc;

--- a/cql3/selection/abstract_function_selector.cc
+++ b/cql3/selection/abstract_function_selector.cc
@@ -81,6 +81,31 @@ abstract_function_selector::new_factory(shared_ptr<functions::function> fun, sha
             }
             return p->name().name == "countRows";
         }
+
+        virtual bool is_reducible_selector_factory() const override {
+            auto p = dynamic_cast<functions::aggregate_function*>(_fun.get());
+            if (!p) {
+                return false;
+            }
+            return p->is_reducible();
+        }
+
+        virtual std::optional<std::pair<query::forward_request::reduction_type, query::forward_request::aggregation_info>> 
+        get_reduction() const override {
+            auto p = dynamic_cast<functions::aggregate_function*>(_fun.get());
+            if (!p) {
+                return std::nullopt;
+            }
+
+            auto type = (p->name().name == "countRows") ? query::forward_request::reduction_type::count : query::forward_request::reduction_type::aggregate;
+            auto info = query::forward_request::aggregation_info {
+                .name = p->name(),
+                .column_names = _factories->get_column_names()
+            };
+
+            return {{type, info}};
+        }
+
     };
 
     return make_shared<fun_selector_factory>(std::move(fun), std::move(factories));

--- a/cql3/selection/abstract_function_selector.cc
+++ b/cql3/selection/abstract_function_selector.cc
@@ -70,6 +70,10 @@ abstract_function_selector::new_factory(shared_ptr<functions::function> fun, sha
             return _fun->is_aggregate() || _factories->contains_only_aggregate_functions();
         }
 
+        virtual bool contains_only_simple_arguments() const override {
+            return _factories->contains_only_simple_selection();
+        }
+
         virtual bool is_count_selector_factory() const override {
             auto p = dynamic_cast<functions::abstract_function*>(_fun.get());
             if (!p) {

--- a/cql3/selection/selection.cc
+++ b/cql3/selection/selection.cc
@@ -182,6 +182,14 @@ public:
         return _factories->does_count();
     }
 
+    virtual bool is_reducible() const override {
+        return _factories->does_reduction();
+    }
+
+    virtual query::forward_request::reductions_info get_reductions() const override {
+        return _factories->get_reductions();
+    }
+
 protected:
     class selectors_with_processing : public selectors {
     private:

--- a/cql3/selection/selection.hh
+++ b/cql3/selection/selection.hh
@@ -144,6 +144,10 @@ public:
 
     virtual bool is_count() const {return false;}
 
+    virtual bool is_reducible() const {return false;}
+
+    virtual query::forward_request::reductions_info get_reductions() const {return {{}, {}};}
+
     /**
      * Checks that selectors are either all aggregates or that none of them is.
      *

--- a/cql3/selection/selector.hh
+++ b/cql3/selection/selector.hh
@@ -12,6 +12,7 @@
 
 #include <vector>
 #include "cql3/assignment_testable.hh"
+#include "query-request.hh"
 #include "types.hh"
 #include "schema_fwd.hh"
 #include "counters.hh"
@@ -149,6 +150,13 @@ public:
     virtual bool is_count_selector_factory() const {
         return false;
     }
+
+    virtual bool is_reducible_selector_factory() const {
+        return false;
+    }
+
+    virtual std::optional<std::pair<query::forward_request::reduction_type, query::forward_request::aggregation_info>> 
+    get_reduction() const {return std::nullopt;}
 
     /**
      * Checks if this factory creates <code>writetime</code> selectors instances.

--- a/cql3/selection/selector.hh
+++ b/cql3/selection/selector.hh
@@ -117,6 +117,26 @@ public:
     virtual ::shared_ptr<selector> new_instance() const = 0;
 
     /**
+     * Checks if this factory creates simple selectors instances.
+     *
+     * @return <code>true</code> if this factory creates simple selectors instances,
+     * <code>false</code> otherwise
+     */
+    virtual bool is_simple_selector_factory() const {
+        return false;
+    }
+
+    /**
+     * Checks if arguments for this factory contains only simple slectors.
+     *
+     * @return <code>true</code> if this factory contains 
+     * <code>false</code> otherwise, or if it isn't function selector factory
+     */
+    virtual bool contains_only_simple_arguments() const {
+        return false;
+    }
+
+    /**
      * Checks if this factory creates selectors instances that creates aggregates.
      *
      * @return <code>true</code> if this factory creates selectors instances that creates aggregates,

--- a/cql3/selection/selector_factories.cc
+++ b/cql3/selection/selector_factories.cc
@@ -22,6 +22,7 @@ selector_factories::selector_factories(std::vector<::shared_ptr<selectable>> sel
         std::vector<const column_definition*>& defs)
     : _contains_write_time_factory(false)
     , _contains_ttl_factory(false)
+    , _number_of_simple_factories(0)
     , _number_of_aggregate_factories(0)
     , _number_of_factories_for_post_processing(0)
 {
@@ -33,6 +34,8 @@ selector_factories::selector_factories(std::vector<::shared_ptr<selectable>> sel
         _contains_ttl_factory |= factory->is_ttl_selector_factory();
         if (factory->is_aggregate_selector_factory()) {
             ++_number_of_aggregate_factories;
+        } else if (factory->is_simple_selector_factory()) {
+            ++_number_of_simple_factories;
         }
         _factories.emplace_back(std::move(factory));
     }

--- a/cql3/selection/selector_factories.hh
+++ b/cql3/selection/selector_factories.hh
@@ -41,6 +41,11 @@ private:
     bool _contains_ttl_factory;
 
     /**
+     * The number of factories creating simple selectors.
+     */
+    uint32_t _number_of_simple_factories;
+
+    /**
      * The number of factories creating aggregates.
      */
     uint32_t _number_of_aggregate_factories;
@@ -77,6 +82,17 @@ public:
      * @param index the index of the column definition in the Selection's list of columns
      */
     void add_selector_for_post_processing(const column_definition& def, uint32_t index);
+
+    /**
+     * Checks if this <code>SelectorFactories</code> contains only factories for simple selectors.
+     *
+     * @return <code>true</code> if this <code>SelectorFactories</code> contains only factories for simple selectors,
+     * <code>false</code> otherwise.
+     */
+    bool contains_only_simple_selection() const {
+        auto size = _factories.size();
+        return _number_of_simple_factories == (size - _number_of_factories_for_post_processing);
+    }
 
     /**
      * Checks if this <code>SelectorFactories</code> contains only factories for aggregates.

--- a/cql3/selection/selector_factories.hh
+++ b/cql3/selection/selector_factories.hh
@@ -10,6 +10,7 @@
 
 #pragma once
 
+#include <algorithm>
 #include <stdexcept>
 #include <vector>
 #include "cql3/selection/selector.hh"
@@ -124,19 +125,12 @@ public:
     }
 
     bool does_reduction() const {
-        if (_factories.size() != 1) {
-            return false;
-        }
-
-        return _factories[0]->is_reducible_selector_factory() && _factories[0]->contains_only_simple_arguments();
+        return std::all_of(_factories.cbegin(), _factories.cend(), [](const ::shared_ptr<selector::factory>& factory) {
+            return factory->is_reducible_selector_factory() && factory->contains_only_simple_arguments();
+        });
     }
 
     query::forward_request::reductions_info get_reductions() const {
-        // For now we only supports reduction of single selection
-        if (_factories.size() != 1) {
-            return {};
-        }
-
         std::vector<query::forward_request::reduction_type> types;
         std::vector<query::forward_request::aggregation_info> infos;
         for (const auto& factory: _factories) {

--- a/cql3/selection/simple_selector.hh
+++ b/cql3/selection/simple_selector.hh
@@ -29,6 +29,10 @@ public:
         , _type(type)
     { }
 
+    virtual bool is_simple_selector_factory() const override {
+        return true;
+    }
+
     virtual sstring column_name() const override {
         return _column_name;
     }

--- a/cql3/statements/create_aggregate_statement.cc
+++ b/cql3/statements/create_aggregate_statement.cc
@@ -22,7 +22,7 @@ namespace cql3 {
 
 namespace statements {
 
-shared_ptr<functions::function> create_aggregate_statement::create(query_processor& qp, functions::function* old) const {
+shared_ptr<db::functions::function> create_aggregate_statement::create(query_processor& qp, db::functions::function* old) const {
     if (!qp.proxy().features().user_defined_aggregates) {
         throw exceptions::invalid_request_exception("Cluster does not support user-defined aggregates, upgrade the whole cluster in order to use UDA");
     }

--- a/cql3/statements/create_aggregate_statement.cc
+++ b/cql3/statements/create_aggregate_statement.cc
@@ -42,6 +42,17 @@ shared_ptr<functions::function> create_aggregate_statement::create(query_process
         throw exceptions::invalid_request_exception(format("State function '{}' doesn't return state", _sfunc));
     }
 
+    ::shared_ptr<cql3::functions::scalar_function> reduce_func = nullptr;
+    if (_rfunc) {
+        if (!qp.proxy().features().uda_native_parallelized_aggregation) {
+            throw exceptions::invalid_request_exception("Cluster does not support reduction function for user-defined aggregates, upgrade the whole cluster in order to define REDUCEFUNC for UDA");
+        }
+
+        reduce_func = dynamic_pointer_cast<functions::scalar_function>(functions::functions::find(functions::function_name{_name.keyspace, _rfunc.value()}, {state_type, state_type}));
+        if (!reduce_func) {
+            throw exceptions::invalid_request_exception(format("Scalar reduce function {} for state type {} not found.", _rfunc.value(), state_type->name()));
+        }
+    }
     ::shared_ptr<cql3::functions::scalar_function> final_func = nullptr;
     if (_ffunc) {
         final_func = dynamic_pointer_cast<functions::scalar_function>(functions::functions::find(functions::function_name{_name.keyspace, _ffunc.value()}, {state_type}));
@@ -58,7 +69,7 @@ shared_ptr<functions::function> create_aggregate_statement::create(query_process
         initcond = std::move(initcond_term).to_bytes();
     }
 
-    return ::make_shared<functions::user_aggregate>(_name, initcond, std::move(state_func), std::move(final_func));
+    return ::make_shared<functions::user_aggregate>(_name, initcond, std::move(state_func), std::move(reduce_func), std::move(final_func));
 }
 
 std::unique_ptr<prepared_statement> create_aggregate_statement::prepare(data_dictionary::database db, cql_stats& stats) {
@@ -80,10 +91,11 @@ create_aggregate_statement::prepare_schema_mutations(query_processor& qp, api::t
 }
 
 create_aggregate_statement::create_aggregate_statement(functions::function_name name, std::vector<shared_ptr<cql3_type::raw>> arg_types,
-            sstring sfunc, shared_ptr<cql3_type::raw> stype, std::optional<sstring> ffunc, std::optional<expr::expression> ival, bool or_replace, bool if_not_exists)
+            sstring sfunc, shared_ptr<cql3_type::raw> stype, std::optional<sstring> rfunc, std::optional<sstring> ffunc, std::optional<expr::expression> ival, bool or_replace, bool if_not_exists)
         : create_function_statement_base(std::move(name), std::move(arg_types), or_replace, if_not_exists)
         , _sfunc(std::move(sfunc))
         , _stype(std::move(stype))
+        , _rfunc(std::move(rfunc))
         , _ffunc(std::move(ffunc))
         , _ival(std::move(ival))
     {}

--- a/cql3/statements/create_aggregate_statement.hh
+++ b/cql3/statements/create_aggregate_statement.hh
@@ -31,12 +31,13 @@ class create_aggregate_statement final : public create_function_statement_base {
 
     sstring _sfunc;
     shared_ptr<cql3_type::raw> _stype;
+    std::optional<sstring> _rfunc;
     std::optional<sstring> _ffunc;
     std::optional<expr::expression> _ival;
 
 public:
     create_aggregate_statement(functions::function_name name, std::vector<shared_ptr<cql3_type::raw>> arg_types,
-            sstring sfunc, shared_ptr<cql3_type::raw> stype, std::optional<sstring> ffunc, std::optional<expr::expression> ival, bool or_replace, bool if_not_exists);
+            sstring sfunc, shared_ptr<cql3_type::raw> stype, std::optional<sstring> rfunc, std::optional<sstring> ffunc, std::optional<expr::expression> ival, bool or_replace, bool if_not_exists);
 };
 }
 }

--- a/cql3/statements/create_aggregate_statement.hh
+++ b/cql3/statements/create_aggregate_statement.hh
@@ -27,7 +27,7 @@ class create_aggregate_statement final : public create_function_statement_base {
     virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats) override;
     future<std::pair<::shared_ptr<cql_transport::event::schema_change>, std::vector<mutation>>> prepare_schema_mutations(query_processor& qp, api::timestamp_type) const override;
 
-    virtual shared_ptr<functions::function> create(query_processor& qp, functions::function* old) const override;
+    virtual shared_ptr<db::functions::function> create(query_processor& qp, db::functions::function* old) const override;
 
     sstring _sfunc;
     shared_ptr<cql3_type::raw> _stype;

--- a/cql3/statements/create_function_statement.hh
+++ b/cql3/statements/create_function_statement.hh
@@ -25,7 +25,7 @@ class create_function_statement final : public create_function_statement_base {
     virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats) override;
     future<std::pair<::shared_ptr<cql_transport::event::schema_change>, std::vector<mutation>>> prepare_schema_mutations(query_processor& qp, api::timestamp_type) const override;
 
-    virtual shared_ptr<functions::function> create(query_processor& qp, functions::function* old) const override;
+    virtual shared_ptr<db::functions::function> create(query_processor& qp, db::functions::function* old) const override;
     sstring _language;
     sstring _body;
     std::vector<shared_ptr<column_identifier>> _arg_names;

--- a/cql3/statements/function_statement.hh
+++ b/cql3/statements/function_statement.hh
@@ -12,11 +12,13 @@
 #include "cql3/functions/function_name.hh"
 #include "cql3/cql3_type.hh"
 
-namespace cql3 {
-
+namespace db {
 namespace functions {
     class function;
-} // namespace functions
+}
+}
+
+namespace cql3 {
 
 namespace statements {
 
@@ -24,23 +26,23 @@ class function_statement : public schema_altering_statement {
 protected:
     virtual future<> check_access(query_processor& qp, const service::client_state& state) const override;
     virtual void prepare_keyspace(const service::client_state& state) override;
-    functions::function_name _name;
+    db::functions::function_name _name;
     std::vector<shared_ptr<cql3_type::raw>> _raw_arg_types;
     mutable std::vector<data_type> _arg_types;
     static shared_ptr<cql_transport::event::schema_change> create_schema_change(
-            const functions::function& func, bool created);
+            const db::functions::function& func, bool created);
     function_statement(functions::function_name name, std::vector<shared_ptr<cql3_type::raw>> raw_arg_types);
     void create_arg_types(query_processor& qp) const;
     data_type prepare_type(query_processor& qp, cql3_type::raw &t) const;
-    virtual shared_ptr<functions::function> validate_while_executing(query_processor&) const = 0;
+    virtual shared_ptr<db::functions::function> validate_while_executing(query_processor&) const = 0;
 };
 
 // common logic for creating UDF and UDA
 class create_function_statement_base : public function_statement {
 protected:
     virtual void validate(query_processor& qp, const service::client_state& state) const override;
-    virtual shared_ptr<functions::function> create(query_processor& qp, functions::function* old) const = 0;
-    virtual shared_ptr<functions::function> validate_while_executing(query_processor&) const override;
+    virtual shared_ptr<db::functions::function> create(query_processor& qp, db::functions::function* old) const = 0;
+    virtual shared_ptr<db::functions::function> validate_while_executing(query_processor&) const override;
 
     bool _or_replace;
     bool _if_not_exists;
@@ -53,7 +55,7 @@ protected:
 class drop_function_statement_base : public function_statement {
 protected:
     virtual void validate(query_processor&, const service::client_state& state) const override;
-    virtual shared_ptr<functions::function> validate_while_executing(query_processor&) const override;
+    virtual shared_ptr<db::functions::function> validate_while_executing(query_processor&) const override;
 
     bool _args_present;
     bool _if_exists;

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -1516,7 +1516,7 @@ parallelized_select_statement::do_execute(
     return qp.forwarder().dispatch(req, state.get_trace_state()).then([this] (query::forward_result res) {
         auto meta = make_shared<metadata>(*_selection->get_result_metadata());
         auto rs = std::make_unique<result_set>(std::move(meta));
-        rs->add_column_value(*res.query_results[0]);
+        rs->add_row(res.query_results);
         update_stats_rows_read(rs->size());
         return shared_ptr<cql_transport::messages::result_message>(
             make_shared<cql_transport::messages::result_message::rows>(result(std::move(rs)))

--- a/db/functions/aggregate_function.hh
+++ b/db/functions/aggregate_function.hh
@@ -1,0 +1,93 @@
+/*
+ * Modified by ScyllaDB
+ *
+ * Copyright (C) 2022-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: (AGPL-3.0-or-later and Apache-2.0)
+ */
+
+#pragma once
+
+#include "function.hh"
+#include <optional>
+
+namespace db {
+namespace functions {
+
+
+/**
+ * Performs a calculation on a set of values and return a single value.
+ */
+class aggregate_function : public virtual function {
+public:
+    class aggregate;
+
+    /**
+     * Creates a new <code>Aggregate</code> instance.
+     *
+     * @return a new <code>Aggregate</code> instance.
+     */
+    virtual std::unique_ptr<aggregate> new_aggregate() = 0;
+
+    /**
+     * Checks wheather the function can be distributed and is able to reduce states.
+     *
+     * @return <code>true</code> if the function is reducible, <code>false</code> otherwise.
+     */
+    virtual bool is_reducible() const = 0;
+
+    /**
+     * Creates a <code>Aggregate Function</code> that can be reduced.
+     * Such <code>Aggregate Function</code> returns <code>Aggregate</code>,
+     * which returns not finalized output, but its accumulator that can be 
+     * later reduced with other one.
+     *
+     * Reducible aggregate function can be obtained only if <code>is_reducible()</code>
+     * return true. Otherwise, it should return <code>nullptr</code>.
+     *
+     * @return a reducible <code>Aggregate Function</code>.
+     */
+    virtual ::shared_ptr<aggregate_function> reducible_aggregate_function() = 0;
+
+    /**
+     * An aggregation operation.
+     */
+    class aggregate {
+    public:
+        using opt_bytes = aggregate_function::opt_bytes;
+
+        virtual ~aggregate() {}
+
+        /**
+         * Adds the specified input to this aggregate.
+         *
+         * @param protocol_version native protocol version
+         * @param values the values to add to the aggregate.
+         */
+        virtual void add_input(cql_serialization_format sf, const std::vector<opt_bytes>& values) = 0;
+
+        /**
+         * Computes and returns the aggregate current value.
+         *
+         * @param protocol_version native protocol version
+         * @return the aggregate current value.
+         */
+        virtual opt_bytes compute(cql_serialization_format sf) = 0;
+
+        virtual void set_accumulator(const opt_bytes& acc) = 0;
+
+        virtual opt_bytes get_accumulator() const = 0;
+
+        virtual void reduce(cql_serialization_format sf, const opt_bytes& acc) = 0;
+
+        /**
+         * Reset this aggregate.
+         */
+        virtual void reset() = 0;
+    };
+};
+
+}
+}

--- a/db/functions/function.hh
+++ b/db/functions/function.hh
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2022-present ScyllaDB
+ *
+ * Modified by ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: (AGPL-3.0-or-later and Apache-2.0)
+ */
+
+#pragma once
+
+#include "types.hh"
+#include <vector>
+#include <optional>
+
+namespace db {
+namespace functions {
+
+class function_name;
+
+class function {
+public:
+    using opt_bytes = std::optional<bytes>;
+    virtual ~function() {}
+    virtual const function_name& name() const = 0;
+    virtual const std::vector<data_type>& arg_types() const = 0;
+    virtual const data_type& return_type() const = 0;
+
+    /**
+     * Checks whether the function is a pure function (as in doesn't depend on, nor produce side effects) or not.
+     *
+     * @return <code>true</code> if the function is a pure function, <code>false</code> otherwise.
+     */
+    virtual bool is_pure() const = 0;
+
+    /**
+     * Checks whether the function is a native/hard coded one or not.
+     *
+     * @return <code>true</code> if the function is a native/hard coded one, <code>false</code> otherwise.
+     */
+    virtual bool is_native() const = 0;
+
+    virtual bool requires_thread() const = 0;
+
+    /**
+     * Checks whether the function is an aggregate function or not.
+     *
+     * @return <code>true</code> if the function is an aggregate function, <code>false</code> otherwise.
+     */
+    virtual bool is_aggregate() const = 0;
+
+    virtual void print(std::ostream& os) const = 0;
+
+    /**
+     * Returns the name of the function to use within a ResultSet.
+     *
+     * @param column_names the names of the columns used to call the function
+     * @return the name of the function to use within a ResultSet
+     */
+    virtual sstring column_name(const std::vector<sstring>& column_names) const = 0;
+
+    friend class function_call;
+    friend std::ostream& operator<<(std::ostream& os, const function& f);
+};
+
+inline
+std::ostream&
+operator<<(std::ostream& os, const function& f) {
+    f.print(os);
+    return os;
+}
+
+}
+}

--- a/db/functions/function_name.hh
+++ b/db/functions/function_name.hh
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2022-present ScyllaDB
+ *
+ * Modified by ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: (AGPL-3.0-or-later and Apache-2.0)
+ */
+
+#pragma once
+
+#include <seastar/core/sstring.hh>
+#include "seastarx.hh"
+#include <iosfwd>
+#include <functional>
+
+namespace db {
+
+sstring system_keyspace_name();
+
+namespace functions {
+
+class function_name final {
+public:
+    sstring keyspace;
+    sstring name;
+
+    static function_name native_function(sstring name) {
+        return function_name(db::system_keyspace_name(), name);
+    }
+
+    function_name() = default; // for ANTLR
+    function_name(sstring keyspace, sstring name)
+            : keyspace(std::move(keyspace)), name(std::move(name)) {
+    }
+
+    function_name as_native_function() const {
+        return native_function(name);
+    }
+
+    bool has_keyspace() const {
+        return !keyspace.empty();
+    }
+
+    bool operator==(const function_name& x) const {
+        return keyspace == x.keyspace && name == x.name;
+    }
+};
+
+inline
+std::ostream& operator<<(std::ostream& os, const function_name& fn) {
+    if (!fn.keyspace.empty()) {
+        os << fn.keyspace << ".";
+    }
+    return os << fn.name;
+}
+
+}
+}
+
+
+
+
+namespace std {
+
+template <>
+struct hash<db::functions::function_name> {
+    size_t operator()(const db::functions::function_name& x) const {
+        return std::hash<sstring>()(x.keyspace) ^ std::hash<sstring>()(x.name);
+    }
+};
+
+}

--- a/db/schema_features.hh
+++ b/db/schema_features.hh
@@ -23,6 +23,7 @@ enum class schema_feature {
     CDC_OPTIONS,
     PER_TABLE_PARTITIONERS,
     SCYLLA_KEYSPACES,
+    SCYLLA_AGGREGATES,
 };
 
 using schema_features = enum_set<super_enum<schema_feature,
@@ -31,7 +32,8 @@ using schema_features = enum_set<super_enum<schema_feature,
     schema_feature::COMPUTED_COLUMNS,
     schema_feature::CDC_OPTIONS,
     schema_feature::PER_TABLE_PARTITIONERS,
-    schema_feature::SCYLLA_KEYSPACES
+    schema_feature::SCYLLA_KEYSPACES,
+    schema_feature::SCYLLA_AGGREGATES
     >>;
 
 }

--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -155,7 +155,7 @@ static future<user_types_to_drop> merge_types(distributed<service::storage_proxy
     schema_result after);
 
 static future<> merge_functions(distributed<service::storage_proxy>& proxy, schema_result before, schema_result after);
-static future<> merge_aggregates(distributed<service::storage_proxy>& proxy, schema_result before, schema_result after);
+static future<> merge_aggregates(distributed<service::storage_proxy>& proxy, schema_result before, schema_result after, schema_result scylla_before, schema_result scylla_after);
 
 static future<> do_merge_schema(distributed<service::storage_proxy>&, std::vector<mutation>, bool do_flush);
 
@@ -647,6 +647,37 @@ schema_ptr aggregates() {
     return schema;
 }
 
+schema_ptr scylla_aggregates() {
+    static thread_local auto schema = [] {
+        schema_builder builder(generate_legacy_id(NAME, SCYLLA_AGGREGATES), NAME, SCYLLA_AGGREGATES,
+        // partition key
+        {{"keyspace_name", utf8_type}},
+        // clustering key
+        {
+            {"aggregate_name", utf8_type}, 
+            {"argument_types", list_type_impl::get_instance(utf8_type, false)}
+        },
+        //regular columns
+        {
+            {"reduce_func", utf8_type},
+            {"state_type", utf8_type},
+        },
+        //static columns,
+        {},
+        // regular column name type
+        utf8_type,
+        // comment
+        "scylla-specific information for user defined aggregates"
+        );
+        
+        builder.set_gc_grace_seconds(schema_gc_grace);
+        builder.with_version(system_keyspace::generate_schema_version(builder.uuid()));
+        builder.with_null_sharder();
+        return builder.build();
+    }();
+    return schema;
+}
+
 schema_ptr scylla_table_schema_history() {
     static thread_local auto s = [] {
         schema_builder builder(db::system_keyspace::NAME, SCYLLA_TABLE_SCHEMA_HISTORY, generate_legacy_id(db::system_keyspace::NAME, SCYLLA_TABLE_SCHEMA_HISTORY));
@@ -1075,6 +1106,7 @@ static future<> do_merge_schema(distributed<service::storage_proxy>& proxy, std:
     auto&& old_views = co_await read_tables_for_keyspaces(proxy, keyspaces, views());
     auto old_functions = co_await read_schema_for_keyspaces(proxy, FUNCTIONS, keyspaces);
     auto old_aggregates = co_await read_schema_for_keyspaces(proxy, AGGREGATES, keyspaces);
+    auto old_scylla_aggregates = co_await read_schema_for_keyspaces(proxy, SCYLLA_AGGREGATES, keyspaces);
 
     if (proxy.local().get_db().local().uses_schema_commitlog()) {
         co_await proxy.local().get_db().local().apply(freeze(mutations), db::no_timeout);
@@ -1096,6 +1128,7 @@ static future<> do_merge_schema(distributed<service::storage_proxy>& proxy, std:
     auto&& new_views = co_await read_tables_for_keyspaces(proxy, keyspaces, views());
     auto new_functions = co_await read_schema_for_keyspaces(proxy, FUNCTIONS, keyspaces);
     auto new_aggregates = co_await read_schema_for_keyspaces(proxy, AGGREGATES, keyspaces);
+    auto new_scylla_aggregates = co_await read_schema_for_keyspaces(proxy, SCYLLA_AGGREGATES, keyspaces);
 
     std::set<sstring> keyspaces_to_drop = co_await merge_keyspaces(proxy, std::move(old_keyspaces), std::move(new_keyspaces));
     auto types_to_drop = co_await merge_types(proxy, std::move(old_types), std::move(new_types));
@@ -1103,7 +1136,7 @@ static future<> do_merge_schema(distributed<service::storage_proxy>& proxy, std:
         std::move(old_column_families), std::move(new_column_families),
         std::move(old_views), std::move(new_views));
     co_await merge_functions(proxy, std::move(old_functions), std::move(new_functions));
-    co_await merge_aggregates(proxy, std::move(old_aggregates), std::move(new_aggregates));
+    co_await merge_aggregates(proxy, std::move(old_aggregates), std::move(new_aggregates), std::move(old_scylla_aggregates), std::move(new_scylla_aggregates));
     co_await types_to_drop.drop();
 
     co_await proxy.local().get_db().invoke_on_all([&] (replica::database& db) -> future<> {
@@ -1371,10 +1404,7 @@ static std::vector<const query::result_set_row*> collect_rows(const std::set<sst
     return ret;
 }
 
-// Build a map from primary keys to rows.
-static std::map<std::vector<bytes>, const query::result_set_row*> build_row_map(const query::result_set& result) {
-    const std::vector<query::result_set_row>& rows = result.rows();
-    const schema_ptr& schema = result.schema();
+static std::vector<column_definition> get_primary_key_definition(const schema_ptr& schema) {
     std::vector<column_definition> primary_key;
     for (const auto& column : schema->partition_key_columns()) {
         primary_key.push_back(column);
@@ -1382,13 +1412,26 @@ static std::map<std::vector<bytes>, const query::result_set_row*> build_row_map(
     for (const auto& column : schema->clustering_key_columns()) {
         primary_key.push_back(column);
     }
+    
+    return primary_key;
+}
+
+static std::vector<bytes> get_primary_key(const std::vector<column_definition>& primary_key, const query::result_set_row* row) {
+    std::vector<bytes> key;
+    for (const auto& column : primary_key) {
+        const data_value *val = row->get_data_value(column.name_as_text());
+        key.push_back(val->serialize_nonnull());
+    }
+    return key;
+}
+
+// Build a map from primary keys to rows.
+static std::map<std::vector<bytes>, const query::result_set_row*> build_row_map(const query::result_set& result) {
+    const std::vector<query::result_set_row>& rows = result.rows();
+    auto primary_key = get_primary_key_definition(result.schema());
     std::map<std::vector<bytes>, const query::result_set_row*> ret;
     for (const auto& row: rows) {
-        std::vector<bytes> key;
-        for (const auto& column : primary_key) {
-            const data_value *val = row.get_data_value(column.name_as_text());
-            key.push_back(val->serialize_nonnull());
-        }
+        auto key = get_primary_key(primary_key, &row);
         ret.insert(std::pair(std::move(key), &row));
     }
     return ret;
@@ -1428,6 +1471,76 @@ static row_diff diff_rows(const schema_result& before, const schema_result& afte
         }
     }
     return {std::move(altered), std::move(created), std::move(dropped)};
+}
+
+// User-defined aggregate stores its information in two tables: aggregates and scylla_aggregates
+// The difference has to be joined to properly create an UDA.
+//
+// FIXME: Since UDA cannot be altered now, set of differing rows should be empty and those rows are
+// ignored in calculating the diff.
+struct aggregate_diff {
+    std::vector<std::pair<const query::result_set_row*, const query::result_set_row*>> created;
+    std::vector<std::pair<const query::result_set_row*, const query::result_set_row*>> dropped;
+};
+
+static aggregate_diff diff_aggregates_rows(const schema_result& aggr_before, const schema_result& aggr_after, 
+        const schema_result& scylla_aggr_before, const schema_result& scylla_aggr_after) {
+    using map = std::map<std::vector<bytes>, const query::result_set_row*>;
+    auto aggr_diff = difference(aggr_before, aggr_after, indirect_equal_to<lw_shared_ptr<query::result_set>>());
+
+    std::vector<std::pair<const query::result_set_row*, const query::result_set_row*>> created;
+    std::vector<std::pair<const query::result_set_row*, const query::result_set_row*>> dropped;
+
+    // Primary key for `aggregates` and `scylla_aggregates` tables
+    auto primary_key = get_primary_key_definition(aggregates());
+
+    // DROPPED
+    for (const auto& key : aggr_diff.entries_only_on_left) {
+        auto scylla_entry = scylla_aggr_before.find(key);
+        auto scylla_aggr_rows = (scylla_entry != scylla_aggr_before.end()) ? build_row_map(*scylla_entry->second) : map();
+
+        for (const auto& row : aggr_before.find(key)->second->rows()) {
+            auto pk = get_primary_key(primary_key, &row);
+            auto entry = scylla_aggr_rows.find(pk);
+            dropped.push_back({&row, (entry != scylla_aggr_rows.end()) ? entry->second : nullptr});
+        }
+    }
+    // CREATED
+    for (const auto& key : aggr_diff.entries_only_on_right) {
+        auto scylla_entry = scylla_aggr_after.find(key);
+        auto scylla_aggr_rows = (scylla_entry != scylla_aggr_after.end()) ? build_row_map(*scylla_entry->second) : map();
+
+        for (const auto& row : aggr_after.find(key)->second->rows()) {
+            auto pk = get_primary_key(primary_key, &row);
+            auto entry = scylla_aggr_rows.find(pk);
+            created.push_back({&row, (entry != scylla_aggr_rows.end()) ? entry->second : nullptr});
+        }
+    }
+    for (const auto& key : aggr_diff.entries_differing) {
+        auto aggr_before_rows = build_row_map(*aggr_before.find(key)->second);
+        auto aggr_after_rows = build_row_map(*aggr_after.find(key)->second);
+        auto diff = difference(aggr_before_rows, aggr_after_rows, indirect_equal_to<const query::result_set_row*>());
+        
+        auto scylla_entry_before = scylla_aggr_before.find(key);
+        auto scylla_aggr_rows_before = (scylla_entry_before != scylla_aggr_before.end()) ? build_row_map(*scylla_entry_before->second) : map();
+        auto scylla_entry_after = scylla_aggr_after.find(key);
+        auto scylla_aggr_rows_after = (scylla_entry_after != scylla_aggr_after.end()) ? build_row_map(*scylla_entry_after->second) : map();
+
+        for (const auto& k : diff.entries_only_on_left) {
+            auto entry = scylla_aggr_rows_before.find(k);
+            dropped.push_back({
+                aggr_before_rows.find(k)->second, (entry != scylla_aggr_rows_before.end()) ? entry->second : nullptr
+            });
+        }
+        for (const auto& k : diff.entries_only_on_right) {
+            auto entry = scylla_aggr_rows_after.find(k);
+            created.push_back({
+                aggr_after_rows.find(k)->second, (entry != scylla_aggr_rows_after.end()) ? entry->second : nullptr
+            });
+        }
+    }
+
+    return {std::move(created), std::move(dropped)};
 }
 
 template<typename V>
@@ -1523,6 +1636,11 @@ static std::vector<data_type> read_arg_types(replica::database& db, const query:
     return arg_types;
 }
 
+static std::vector<data_value> read_arg_values(const query::result_set_row& row) {
+    auto args = get_list<sstring>(row, "argument_types");
+    return std::vector<data_value>(args.begin(), args.end());
+}
+
 #if 0
     // see the comments for mergeKeyspaces()
     private static void mergeAggregates(Map<DecoratedKey, ColumnFamily> before, Map<DecoratedKey, ColumnFamily> after)
@@ -1616,7 +1734,7 @@ static shared_ptr<cql3::functions::user_function> create_func(replica::database&
     }
 }
 
-static shared_ptr<cql3::functions::user_aggregate> create_aggregate(replica::database& db, const query::result_set_row& row) {
+static shared_ptr<cql3::functions::user_aggregate> create_aggregate(replica::database& db, const query::result_set_row& row, const query::result_set_row* scylla_row) {
     cql3::functions::function_name name{
             row.get_nonnull<sstring>("keyspace_name"), row.get_nonnull<sstring>("aggregate_name")};
     auto arg_types = read_arg_types(db, row, name.keyspace);
@@ -1635,6 +1753,19 @@ static shared_ptr<cql3::functions::user_aggregate> create_aggregate(replica::dat
     if (state_func->return_type() != state_type) {
         throw std::runtime_error(format("State function {} needed by aggregate {} doesn't return state", sfunc, name.name));
     }
+
+    ::shared_ptr<cql3::functions::scalar_function> reduce_func = nullptr;
+    if (scylla_row) {
+        auto rfunc_name = scylla_row->get<sstring>("reduce_func");
+        auto rfunc = cql3::functions::functions::find(cql3::functions::function_name{name.keyspace, rfunc_name.value()}, {state_type, state_type});
+        if (!rfunc) {
+            throw std::runtime_error(format("Reduce function {} needed by aggregate {} not found", rfunc_name.value(), name.name));
+        }
+        reduce_func = dynamic_pointer_cast<cql3::functions::scalar_function>(rfunc);
+        if (!reduce_func) {
+            throw std::runtime_error(format("Reduce function {} needed by aggregate {} is not a scalar function", rfunc_name.value(), name.name));
+        }
+    }
     
     ::shared_ptr<cql3::functions::scalar_function> final_func = nullptr;
     if (ffunc) {
@@ -1649,9 +1780,7 @@ static shared_ptr<cql3::functions::user_aggregate> create_aggregate(replica::dat
     if (initcond_str) {
         initcond = state_type->from_string(initcond_str.value());
     }
-
-    return ::make_shared<cql3::functions::user_aggregate>(name, initcond, std::move(state_func), nullptr, std::move(final_func));
-
+    return ::make_shared<cql3::functions::user_aggregate>(name, initcond, std::move(state_func), std::move(reduce_func), std::move(final_func));
 }
 
 static future<> merge_functions(distributed<service::storage_proxy>& proxy, schema_result before, schema_result after,
@@ -1676,8 +1805,19 @@ static future<> merge_functions(distributed<service::storage_proxy>& proxy, sche
     co_await merge_functions(proxy, before, after, create_func);
 }
 
-static future<> merge_aggregates(distributed<service::storage_proxy>& proxy, schema_result before, schema_result after) {
-    co_await merge_functions(proxy, before, after, create_aggregate);
+static future<> merge_aggregates(distributed<service::storage_proxy>& proxy, schema_result before, schema_result after, 
+        schema_result scylla_before, schema_result scylla_after) {
+    auto diff = diff_aggregates_rows(before, after, scylla_before, scylla_after);
+
+    co_await proxy.local().get_db().invoke_on_all([&] (replica::database& db) {
+        for (const auto& val : diff.created) {
+            cql3::functions::functions::add_function(create_aggregate(db, *val.first, val.second));
+        }
+        for (const auto& val : diff.dropped) {
+            auto func = create_aggregate(db, *val.first, val.second);
+            cql3::functions::functions::remove_function(func->name(), func->arg_types());
+        }
+    });
 }
 
 template<typename... Args>
@@ -2019,7 +2159,7 @@ static std::pair<mutation, clustering_key> get_mutation(schema_ptr s, const cql3
     return {std::move(m), std::move(ckey)};
 }
 
-std::vector<mutation> make_create_aggregate_mutations(shared_ptr<cql3::functions::user_aggregate> aggregate, api::timestamp_type timestamp) {
+std::vector<mutation> make_create_aggregate_mutations(schema_features features, shared_ptr<cql3::functions::user_aggregate> aggregate, api::timestamp_type timestamp) {
     schema_ptr s = aggregates();
     auto p = get_mutation(s, *aggregate);
     mutation& m = p.first;
@@ -2035,11 +2175,30 @@ std::vector<mutation> make_create_aggregate_mutations(shared_ptr<cql3::functions
     m.set_clustered_cell(ckey, "return_type", aggregate->return_type()->as_cql3_type().to_string(), timestamp);
     m.set_clustered_cell(ckey, "state_func", aggregate->sfunc().name().name, timestamp);
     m.set_clustered_cell(ckey, "state_type", state_type->as_cql3_type().to_string(), timestamp);
-    return {m};
+    std::vector<mutation> muts = {m};
+
+    if (features.contains<schema_feature::SCYLLA_AGGREGATES>() && aggregate->is_reducible()) {
+        schema_ptr sa_schema = scylla_aggregates();
+        auto sa_p = get_mutation(sa_schema, *aggregate);
+        mutation& sa_mut = sa_p.first;
+        clustering_key& sa_ckey = sa_p.second;
+        sa_mut.set_clustered_cell(sa_ckey, "reduce_func", aggregate->reducefunc().name().name, timestamp);
+        sa_mut.set_clustered_cell(sa_ckey, "state_type", state_type->as_cql3_type().to_string(), timestamp);
+
+        muts.emplace_back(sa_mut);
+    }
+
+    return muts;
 }
 
-std::vector<mutation> make_drop_aggregate_mutations(shared_ptr<cql3::functions::user_aggregate> aggregate, api::timestamp_type timestamp) {
-    return make_drop_function_mutations(aggregates(), *aggregate, timestamp);
+std::vector<mutation> make_drop_aggregate_mutations(schema_features features, shared_ptr<cql3::functions::user_aggregate> aggregate, api::timestamp_type timestamp) {
+    auto muts = make_drop_function_mutations(aggregates(), *aggregate, timestamp);
+    if (features.contains<schema_feature::SCYLLA_AGGREGATES>() && aggregate->is_reducible()) {
+        auto scylla_muts = make_drop_function_mutations(scylla_aggregates(), *aggregate, timestamp);
+        muts.insert(muts.end(), scylla_muts.begin(), scylla_muts.end());
+    }
+
+    return muts;
 }
 
 /*
@@ -3238,6 +3397,9 @@ std::vector<schema_ptr> all_tables(schema_features features) {
     }
     if (features.contains<schema_feature::SCYLLA_KEYSPACES>()) {
         result.emplace_back(scylla_keyspaces());
+    }
+    if (features.contains<schema_feature::SCYLLA_AGGREGATES>()) {
+        result.emplace_back(scylla_aggregates());
     }
     return result;
 }

--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -1650,7 +1650,7 @@ static shared_ptr<cql3::functions::user_aggregate> create_aggregate(replica::dat
         initcond = state_type->from_string(initcond_str.value());
     }
 
-    return ::make_shared<cql3::functions::user_aggregate>(name, initcond, std::move(state_func), std::move(final_func));
+    return ::make_shared<cql3::functions::user_aggregate>(name, initcond, std::move(state_func), nullptr, std::move(final_func));
 
 }
 

--- a/db/schema_tables.hh
+++ b/db/schema_tables.hh
@@ -115,6 +115,7 @@ static constexpr auto VIEWS = "views";
 static constexpr auto TYPES = "types";
 static constexpr auto FUNCTIONS = "functions";
 static constexpr auto AGGREGATES = "aggregates";
+static constexpr auto SCYLLA_AGGREGATES = "scylla_aggregates";
 static constexpr auto INDEXES = "indexes";
 static constexpr auto VIEW_VIRTUAL_COLUMNS = "view_virtual_columns"; // Scylla specific
 static constexpr auto COMPUTED_COLUMNS = "computed_columns"; // Scylla specific
@@ -212,9 +213,9 @@ std::vector<mutation> make_create_function_mutations(shared_ptr<cql3::functions:
 
 std::vector<mutation> make_drop_function_mutations(shared_ptr<cql3::functions::user_function> func, api::timestamp_type timestamp);
 
-std::vector<mutation> make_create_aggregate_mutations(shared_ptr<cql3::functions::user_aggregate> func, api::timestamp_type timestamp);
+std::vector<mutation> make_create_aggregate_mutations(schema_features features, shared_ptr<cql3::functions::user_aggregate> func, api::timestamp_type timestamp);
 
-std::vector<mutation> make_drop_aggregate_mutations(shared_ptr<cql3::functions::user_aggregate> aggregate, api::timestamp_type timestamp);
+std::vector<mutation> make_drop_aggregate_mutations(schema_features features, shared_ptr<cql3::functions::user_aggregate> aggregate, api::timestamp_type timestamp);
 
 std::vector<mutation> make_drop_type_mutations(lw_shared_ptr<keyspace_metadata> keyspace, user_type type, api::timestamp_type timestamp);
 

--- a/gms/feature_service.cc
+++ b/gms/feature_service.cc
@@ -205,6 +205,7 @@ db::schema_features feature_service::cluster_schema_features() const {
     f.set_if<db::schema_feature::CDC_OPTIONS>(cdc);
     f.set_if<db::schema_feature::PER_TABLE_PARTITIONERS>(per_table_partitioners);
     f.set_if<db::schema_feature::SCYLLA_KEYSPACES>(keyspace_storage_options);
+    f.set_if<db::schema_feature::SCYLLA_AGGREGATES>(aggregate_storage_options);
     return f;
 }
 

--- a/gms/feature_service.hh
+++ b/gms/feature_service.hh
@@ -110,6 +110,7 @@ public:
     gms::feature keyspace_storage_options { *this, "KEYSPACE_STORAGE_OPTIONS"sv };
     gms::feature typed_errors_in_read_rpc { *this, "TYPED_ERRORS_IN_READ_RPC"sv };
     gms::feature schema_commitlog { *this, "SCHEMA_COMMITLOG"sv };
+    gms::feature uda_native_parallelized_aggregation { *this, "UDA_NATIVE_PARALLELIZED_AGGREGATION"sv };
 
 public:
 

--- a/gms/feature_service.hh
+++ b/gms/feature_service.hh
@@ -111,6 +111,7 @@ public:
     gms::feature typed_errors_in_read_rpc { *this, "TYPED_ERRORS_IN_READ_RPC"sv };
     gms::feature schema_commitlog { *this, "SCHEMA_COMMITLOG"sv };
     gms::feature uda_native_parallelized_aggregation { *this, "UDA_NATIVE_PARALLELIZED_AGGREGATION"sv };
+    gms::feature aggregate_storage_options { *this, "AGGREGATE_STORAGE_OPTIONS"sv };
 
 public:
 

--- a/idl/forward_request.idl.hh
+++ b/idl/forward_request.idl.hh
@@ -1,8 +1,22 @@
+namespace db {
+namespace functions {
+class function_name {
+    sstring keyspace;
+    sstring name;
+};
+}
+}
 namespace query {
 struct forward_request {
+    struct aggregation_info {
+        db::functions::function_name name;
+        std::vector<sstring> column_names;
+    };
     enum class reduction_type : uint8_t {
         count,
+        aggregate
     };
+
     std::vector<query::forward_request::reduction_type> reduction_types;
 
     query::read_command cmd;
@@ -10,6 +24,8 @@ struct forward_request {
 
     db::consistency_level cl;
     lowres_clock::time_point timeout;
+
+    std::optional<std::vector<query::forward_request::aggregation_info>> aggregation_infos [[version 5.1]];
 };
 
 struct forward_result {

--- a/query-request.hh
+++ b/query-request.hh
@@ -9,9 +9,12 @@
 
 #pragma once
 
+#include <memory>
 #include <optional>
 
 #include "db/functions/function_name.hh"
+#include "db/functions/function.hh"
+#include "db/functions/aggregate_function.hh"
 #include "keys.hh"
 #include "dht/i_partitioner.hh"
 #include "enum_set.hh"
@@ -382,8 +385,8 @@ struct forward_request {
         std::vector<aggregation_info> infos;
     };
 
-    // multiple reduction types are needed to support queries like:
     // `SELECT min(x), max(x), avg(x) FROM tab`
+    // multiple reduction types are needed to support queries like:
     std::vector<reduction_type> reduction_types;
 
     query::read_command cmd;
@@ -391,19 +394,19 @@ struct forward_request {
 
     db::consistency_level cl;
     lowres_clock::time_point timeout;
+    std::optional<std::vector<aggregation_info>> aggregation_infos;
 };
 
 std::ostream& operator<<(std::ostream& out, const forward_request& r);
 std::ostream& operator<<(std::ostream& out, const forward_request::reduction_type& r);
+std::ostream& operator<<(std::ostream& out, const forward_request::aggregation_info& a);
 
 struct forward_result {
     // vector storing query result for each selected column
     std::vector<bytes_opt> query_results;
 
-    void merge(const forward_result& other, const std::vector<forward_request::reduction_type>& types);
-
     struct printer {
-        const std::vector<forward_request::reduction_type>& types;
+        const std::vector<::shared_ptr<db::functions::aggregate_function>>& functions;
         const query::forward_result& res;
     };
 };

--- a/query-request.hh
+++ b/query-request.hh
@@ -11,6 +11,7 @@
 
 #include <optional>
 
+#include "db/functions/function_name.hh"
 #include "keys.hh"
 #include "dht/i_partitioner.hh"
 #include "enum_set.hh"
@@ -369,6 +370,16 @@ public:
 struct forward_request {
     enum class reduction_type {
         count,
+        aggregate
+    };
+    struct aggregation_info {
+        db::functions::function_name name;
+        std::vector<sstring> column_names;
+    };
+    struct reductions_info { 
+        // Used by selector_factries to prepare reductions information
+        std::vector<reduction_type> types;
+        std::vector<aggregation_info> infos;
     };
 
     // multiple reduction types are needed to support queries like:

--- a/query-request.hh
+++ b/query-request.hh
@@ -385,8 +385,6 @@ struct forward_request {
         std::vector<aggregation_info> infos;
     };
 
-    // `SELECT min(x), max(x), avg(x) FROM tab`
-    // multiple reduction types are needed to support queries like:
     std::vector<reduction_type> reduction_types;
 
     query::read_command cmd;

--- a/query.cc
+++ b/query.cc
@@ -7,16 +7,22 @@
  */
 
 #include <limits>
+#include <memory>
+#include <stdexcept>
 #include "query-request.hh"
 #include "query-result.hh"
 #include "query-result-writer.hh"
 #include "query-result-set.hh"
+#include "seastar/core/shared_ptr.hh"
+#include "seastar/core/thread.hh"
 #include "to_string.hh"
 #include "bytes.hh"
 #include "mutation_partition_serializer.hh"
 #include "query-result-reader.hh"
 #include "query_result_merger.hh"
 #include "partition_slice_builder.hh"
+#include "schema_registry.hh"
+#include "utils/overloaded_functor.hh"
 
 namespace query {
 
@@ -68,16 +74,29 @@ std::ostream& operator<<(std::ostream& out, const forward_request::reduction_typ
         case forward_request::reduction_type::count:
             out << "count";
             break;
+        case forward_request::reduction_type::aggregate:
+            out << "aggregate";
+            break;
     }
     return out << "}";
+}
+
+std::ostream& operator<<(std::ostream& out, const forward_request::aggregation_info& a) {
+    return out << "aggregation_info{"
+        << ", name=" << a.name
+        << ", column_names=[" << join(",", a.column_names) << "]"
+        << "}";
 }
 
 std::ostream& operator<<(std::ostream& out, const forward_request& r) {
     auto ms = std::chrono::time_point_cast<std::chrono::milliseconds>(r.timeout).time_since_epoch().count();
 
-    return out << "forward_request{"
-        << "reduction_types=[" << join(",", r.reduction_types) << "]"
-        << ", cmd=" << r.cmd
+    out << "forward_request{"
+        << "reductions=[" << join(",", r.reduction_types) << "]";
+    if(r.aggregation_infos) {
+        out << ", aggregation_infos=[" << join(",", r.aggregation_infos.value()) << "]";
+    }
+    return out << ", cmd=" << r.cmd
         << ", pr=" << r.pr
         << ", cl=" << r.cl
         << ", timeout(ms)=" << ms << "}";
@@ -401,54 +420,18 @@ foreign_ptr<lw_shared_ptr<query::result>> result_merger::get() {
     return make_foreign(make_lw_shared<query::result>(std::move(w), is_short_read, row_count, partition_count));
 }
 
-static bytes_opt merge_singular_results(bytes_opt r1, bytes_opt r2, forward_request::reduction_type reduction) {
-    switch (reduction) {
-        case forward_request::reduction_type::count: {
-            auto count1 = value_cast<int64_t>(long_type->deserialize(bytes_view(*r1)));
-            auto count2 = value_cast<int64_t>(long_type->deserialize(bytes_view(*r2)));
-            return data_value(count1 + count2).serialize();
-        }
-    }
-    throw std::runtime_error("unknown reduction type");
-}
-
-void forward_result::merge(const forward_result& other, const std::vector<forward_request::reduction_type>& reduction_types) {
-    if (query_results.empty()) {
-        query_results.resize(other.query_results.size());
-    }
-
-    if (query_results.size() != other.query_results.size() || query_results.size() != reduction_types.size()) {
-        on_internal_error(
-            qlogger,
-            format("forward_result::merge(): operation cannot be completed due to invalid argument sizes. "
-                    "this.query_results.size(): {} "
-                    "other.query_results.size(): {} "
-                    "reduction_types.size(): {}",
-                    query_results.size(), other.query_results.size(), reduction_types.size())
-        );
-    }
-
-    for (size_t i = 0; i < query_results.size(); i++) {
-        query_results[i] = merge_singular_results(query_results[i], other.query_results[i], reduction_types[i]);
-    }
-}
-
 std::ostream& operator<<(std::ostream& out, const query::forward_result::printer& p) {
-    if (p.types.size() != p.res.query_results.size()) {
+    if (p.functions.size() != p.res.query_results.size()) {
         return out << "[malformed forward_result (" << p.res.query_results.size()
-            << " results, " << p.types.size() << " reduction types)]";
+            << " results, " << p.functions.size() << " aggregates)]";
     }
 
     out << "[";
-    for (size_t i = 0; i < p.types.size(); i++) {
-        switch (p.types[i]) {
-            case forward_request::reduction_type::count: {
-                auto count = value_cast<int64_t>(long_type->deserialize(bytes_view(*p.res.query_results[i])));
-                out << count;
-            }
-        }
+    for (size_t i = 0; i < p.functions.size(); i++) {
+        auto& return_type = p.functions[i]->return_type();
+        out << return_type->to_string(bytes_view(*p.res.query_results[i]));
 
-        if (i + 1 < p.types.size()) {
+        if (i + 1 < p.functions.size()) {
             out << ", ";
         }
     }

--- a/service/forward_service.cc
+++ b/service/forward_service.cc
@@ -12,6 +12,7 @@
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/future-util.hh>
 #include <seastar/core/smp.hh>
+#include <stdexcept>
 
 #include "cql_serialization_format.hh"
 #include "db/consistency_level.hh"
@@ -27,13 +28,17 @@
 #include "replica/database.hh"
 #include "schema.hh"
 #include "schema_registry.hh"
-#include <seastar/core/do_with.hh>
+#include "seastar/core/do_with.hh"
+#include "seastar/core/future.hh"
+#include "seastar/core/on_internal_error.hh"
+#include "seastar/core/when_all.hh"
 #include "service/pager/query_pagers.hh"
 #include "tracing/trace_state.hh"
 #include "tracing/tracing.hh"
 #include "utils/fb_utilities.hh"
 #include "service/storage_proxy.hh"
 
+#include "cql3/functions/aggregate_function.hh"
 #include "cql3/column_identifier.hh"
 #include "cql3/cql_config.hh"
 #include "cql3/query_options.hh"
@@ -42,11 +47,131 @@
 #include "cql3/selection/selectable-expr.hh"
 #include "cql3/selection/selectable.hh"
 #include "cql3/selection/selection.hh"
-
+#include "cql3/functions/functions.hh"
+#include "cql3/functions/user_aggregate.hh"
 namespace service {
 
 static constexpr int DEFAULT_INTERNAL_PAGING_SIZE = 10000;
 static logging::logger flogger("forward_service");
+
+static std::vector<::shared_ptr<db::functions::aggregate_function>> get_functions(const query::forward_request& request);
+
+class forward_aggregates {
+private:
+    std::vector<::shared_ptr<db::functions::aggregate_function>> _funcs;
+    std::vector<std::unique_ptr<db::functions::aggregate_function::aggregate>> _aggrs;
+
+public:
+    forward_aggregates(const query::forward_request& request);
+    void merge(query::forward_result& result, const query::forward_result& other);
+    void finalize(query::forward_result& result);
+
+    template<typename Func>
+    auto with_thread_if_needed(Func&& func) const {
+        bool required = std::any_of(_funcs.cbegin(), _funcs.cend(), [](const ::shared_ptr<db::functions::aggregate_function>& f) { 
+            return f->requires_thread(); 
+        });
+
+        if (required) {
+            return async(std::move(func));
+        } else {
+            return futurize_invoke(std::move(func));
+        }
+    }
+};
+
+forward_aggregates::forward_aggregates(const query::forward_request& request) {
+    _funcs = get_functions(request);
+    std::vector<std::unique_ptr<db::functions::aggregate_function::aggregate>> aggrs;
+
+    for (auto& func: _funcs) {
+        aggrs.push_back(func->new_aggregate());
+    }
+    _aggrs = std::move(aggrs);
+}
+
+void forward_aggregates::merge(query::forward_result &result, const query::forward_result &other) {
+    if (result.query_results.empty()) {
+        result.query_results.resize(other.query_results.size());
+    }
+
+    if (result.query_results.size() != other.query_results.size() || result.query_results.size() != _aggrs.size()) {
+        on_internal_error(
+            flogger,
+            format("forward_aggregates::merge(): operation cannot be completed due to invalid argument sizes. "
+                    "this.aggrs.size(): {} "
+                    "result.query_result.size(): {} "
+                    "other.query_results.size(): {} ",
+                    _aggrs.size(), result.query_results.size(), other.query_results.size())
+        );
+    }
+
+    for (size_t i = 0; i < _aggrs.size(); i++) {
+        _aggrs[i]->set_accumulator(result.query_results[i]);
+        _aggrs[i]->reduce(cql_serialization_format::internal(), other.query_results[i]);
+        result.query_results[i] = _aggrs[i]->get_accumulator();
+    }
+}
+
+void forward_aggregates::finalize(query::forward_result &result) {
+    if (result.query_results.size() != _aggrs.size()) {
+        on_internal_error(
+            flogger,
+            format("forward_aggregates::finalize(): operation cannot be completed due to invalid argument sizes. "
+                    "this.aggrs.size(): {} "
+                    "result.query_result.size(): {} ",
+                    _aggrs.size(), result.query_results.size())
+        );
+    }
+
+    for (size_t i = 0; i < _aggrs.size(); i++) {
+        _aggrs[i]->set_accumulator(result.query_results[i]);
+        result.query_results[i] = _aggrs[i]->compute(cql_serialization_format::internal());
+    }
+}
+
+static std::vector<::shared_ptr<db::functions::aggregate_function>> get_functions(const query::forward_request& request) {
+    
+    schema_ptr schema = local_schema_registry().get(request.cmd.schema_version);
+    std::vector<::shared_ptr<db::functions::aggregate_function>> aggrs;
+
+    auto name_as_type = [&] (const sstring& name) -> data_type {
+        return schema->get_column_definition(to_bytes(name))->type->underlying_type();
+    };
+
+    for (size_t i = 0; i < request.reduction_types.size(); i++) {
+        ::shared_ptr<db::functions::aggregate_function> aggr;
+
+        if (!request.aggregation_infos) {
+            if (request.reduction_types[i] == query::forward_request::reduction_type::aggregate) {
+                throw std::runtime_error("No aggregation info for reduction type aggregation.");
+            }
+
+            auto name = db::functions::function_name::native_function("countRows");
+            auto func = cql3::functions::functions::find(name, {});
+            aggr = dynamic_pointer_cast<db::functions::aggregate_function>(func);
+            if (!aggr) {
+                throw std::runtime_error("Count function not found.");
+            }
+        } else {
+            auto& info = request.aggregation_infos.value()[i];
+            auto types = boost::copy_range<std::vector<data_type>>(info.column_names | boost::adaptors::transformed(name_as_type));
+            
+            auto func = cql3::functions::functions::mock_get(info.name, types);
+            if (!func) {
+                throw std::runtime_error(format("Cannot mock aggregate function {}", info.name));    
+            }
+
+            aggr = dynamic_pointer_cast<db::functions::aggregate_function>(func);
+            if (!aggr) {
+                throw std::runtime_error(format("Aggregate function {} not found.", info.name));
+            }
+        }
+        aggrs.emplace_back(aggr);
+    }
+    
+    return aggrs;
+}
 
 static const dht::token& end_token(const dht::partition_range& r) {
     static const dht::token max_token = dht::maximum_token();
@@ -172,24 +297,45 @@ future<> forward_service::stop() {
 // stored in `forward_request`. It has to mocked on the receiving node,
 // based on requested reduction types.
 static shared_ptr<cql3::selection::selection> mock_selection(
-    const std::vector<query::forward_request::reduction_type>& reduction_types,
+    query::forward_request& request,
     schema_ptr schema,
     replica::database& db
 ) {
     std::vector<shared_ptr<cql3::selection::raw_selector>> raw_selectors;
 
-    auto mock_singular_selection = [&] (const query::forward_request::reduction_type& type) {
-        switch (type) {
-            case query::forward_request::reduction_type::count: {
-                auto selectable = cql3::selection::make_count_rows_function_expression();
-                auto column_identifier = make_shared<cql3::column_identifier>("count", false);
-                return make_shared<cql3::selection::raw_selector>(selectable, column_identifier);
-            }
+    auto functions = get_functions(request);
+
+    auto mock_singular_selection = [&] (
+        const ::shared_ptr<db::functions::aggregate_function>& aggr_function,
+        const query::forward_request::reduction_type& reduction, 
+        const std::optional<query::forward_request::aggregation_info>& info
+    ) {
+        auto name_as_expression = [] (const sstring& name) -> cql3::expr::expression {
+            return cql3::expr::unresolved_identifier {
+                make_shared<cql3::column_identifier_raw>(name, false)
+            };
+        };
+
+        if (reduction == query::forward_request::reduction_type::count) {
+            auto selectable = cql3::selection::make_count_rows_function_expression();
+            auto column_identifier = make_shared<cql3::column_identifier>("count", false);
+            return make_shared<cql3::selection::raw_selector>(selectable, column_identifier);
         }
+
+        if (!info) {
+            on_internal_error(flogger, "No aggregation info for reduction type aggregation.");
+        }
+
+        auto reducible_aggr = aggr_function->reducible_aggregate_function();
+        auto arg_exprs =boost::copy_range<std::vector<cql3::expr::expression>>(info->column_names | boost::adaptors::transformed(name_as_expression));
+        auto fc_expr = cql3::expr::function_call{reducible_aggr, arg_exprs};
+        auto column_identifier = make_shared<cql3::column_identifier>(info->name.name, false);
+        return make_shared<cql3::selection::raw_selector>(fc_expr, column_identifier);
     };
 
-    for (auto const& type : reduction_types) {
-        raw_selectors.emplace_back(mock_singular_selection(type));
+    for (size_t i = 0; i < request.reduction_types.size(); i++) {
+        auto info = (request.aggregation_infos) ? std::optional(request.aggregation_infos->at(i)) : std::nullopt;
+        raw_selectors.emplace_back(mock_singular_selection(functions[i], request.reduction_types[i], info));
     }
 
     return cql3::selection::selection::from_selectors(db.as_data_dictionary(), schema, std::move(raw_selectors));
@@ -200,21 +346,28 @@ future<query::forward_result> forward_service::dispatch_to_shards(
     std::optional<tracing::trace_info> tr_info
 ) {
     _stats.requests_dispatched_to_own_shards += 1;
+    std::optional<query::forward_result> result;
+    std::vector<future<query::forward_result>> futures;
 
-    auto result = co_await container().map_reduce0(
-        [req, tr_info] (auto& fs) {
+    for (const auto& s : smp::all_cpus()) {
+        futures.push_back(container().invoke_on(s, [req, tr_info] (auto& fs) {
             return fs.execute_on_this_shard(req, tr_info);
-        },
-        std::optional<query::forward_result>(),
-        [&req] (std::optional<query::forward_result> partial, query::forward_result mapped) -> std::optional<query::forward_result>{
-            if (partial) {
-                mapped.merge(*partial, req.reduction_types);
-            }
-            return {mapped};
-        }
-    );
+        }));
+    }
+    auto results = co_await when_all_succeed(futures.begin(), futures.end());
 
-    co_return *result;
+    forward_aggregates aggrs(req);
+    co_return co_await aggrs.with_thread_if_needed([&aggrs, results = std::move(results), result = std::move(result)] () mutable {
+        for (auto& r : results) {
+            if (result) {
+                aggrs.merge(*result, r);
+            }
+            else {
+                result = r;
+            }
+        }
+        return *result;
+    });
 }
 
 // This function executes forward_request on a shard.
@@ -238,7 +391,7 @@ future<query::forward_result> forward_service::execute_on_this_shard(
     auto timeout = req.timeout;
     auto now = gc_clock::now();
 
-    auto selection = mock_selection(req.reduction_types, schema, _db.local());
+    auto selection = mock_selection(req, schema, _db.local());
     auto query_state = make_lw_shared<service::query_state>(
         client_state::for_internal_calls(),
         tr_state,
@@ -275,21 +428,21 @@ future<query::forward_result> forward_service::execute_on_this_shard(
         co_await pager->fetch_page(rs_builder, DEFAULT_INTERNAL_PAGING_SIZE, now, timeout);
     }
 
-    co_return co_await rs_builder.with_thread_if_needed([&rs_builder, reduction_types = std::move(req.reduction_types), tr_state = std::move(tr_state)] {
+    co_return co_await rs_builder.with_thread_if_needed([&req, &rs_builder, reductions = req.reduction_types, tr_state = std::move(tr_state)] {
         auto rs = rs_builder.build();
         auto& rows = rs->rows();
         if (rows.size() != 1) {
             flogger.error("aggregation result row count != 1");
             throw std::runtime_error("aggregation result row count != 1");
         }
-        if (rows[0].size() != reduction_types.size()) {
+        if (rows[0].size() != reductions.size()) {
             flogger.error("aggregation result column count does not match requested column count");
             throw std::runtime_error("aggregation result column count does not match requested column count");
         }
         query::forward_result res = { .query_results = rows[0] };
 
         query::forward_result::printer res_printer{
-            .types = reduction_types,
+            .functions = get_functions(req),
             .res = res
         };
         tracing::trace(tr_state, "On shard execution result is {}", res_printer);
@@ -346,9 +499,9 @@ future<query::forward_result> forward_service::dispatch(query::forward_request r
 
     retrying_dispatcher dispatcher(*this, tr_state);
     std::optional<query::forward_result> result;
-
+    
     return do_with(std::move(dispatcher), std::move(result), std::move(vnodes_per_addr), std::move(req), std::move(tr_state),
-        [this] (
+        [] (
             retrying_dispatcher& dispatcher,
             std::optional<query::forward_result>& result,
             std::map<netw::messaging_service::msg_addr, dht::partition_range_vector>& vnodes_per_addr,
@@ -356,9 +509,9 @@ future<query::forward_result> forward_service::dispatch(query::forward_request r
             tracing::trace_state_ptr& tr_state
         )-> future<query::forward_result> {
             return parallel_for_each(vnodes_per_addr.begin(), vnodes_per_addr.end(),
-                [this, &req, &result, &tr_state, &dispatcher] (
+                [&req, &result, &tr_state, &dispatcher] (
                     std::pair<netw::messaging_service::msg_addr, dht::partition_range_vector> vnodes_with_addr
-                ) -> future<> {
+                ) {
                     netw::messaging_service::msg_addr addr = vnodes_with_addr.first;
                     std::optional<query::forward_result>& result_ = result;
                     tracing::trace_state_ptr& tr_state_ = tr_state;
@@ -370,34 +523,43 @@ future<query::forward_result> forward_service::dispatch(query::forward_request r
                     tracing::trace(tr_state_, "Sending forward_request to {}", addr);
                     flogger.debug("dispatching forward_request={} to address={}", req_with_modified_pr, addr);
 
-                    query::forward_result partial_result = co_await dispatcher_.dispatch_to_node(
-                        addr,
-                        req_with_modified_pr
-                    );
-
-                    query::forward_result::printer partial_result_printer{
-                        .types = req_with_modified_pr.reduction_types,
-                        .res = partial_result
-                    };
-                    tracing::trace(tr_state_, "Received forward_result={} from {}", partial_result_printer, addr);
-                    flogger.debug("received forward_result={} from {}", partial_result_printer, addr);
-
-                    if (result_) {
-                        result_->merge(partial_result, req_with_modified_pr.reduction_types);
-                    } else {
-                        result_ = partial_result;
-                    }
+                    return dispatcher_.dispatch_to_node(addr, req_with_modified_pr).then(
+                        [&req, addr = std::move(addr), &result_, tr_state_ = std::move(tr_state_)] (
+                            query::forward_result partial_result
+                        ) mutable {
+                            forward_aggregates aggrs(req);
+                            query::forward_result::printer partial_result_printer{
+                                .functions = get_functions(req),
+                                .res = partial_result
+                            };
+                            tracing::trace(tr_state_, "Received forward_result={} from {}", partial_result_printer, addr);
+                            flogger.debug("received forward_result={} from {}", partial_result_printer, addr);
+                            
+                            return aggrs.with_thread_if_needed([&result_, &aggrs, partial_result = std::move(partial_result)] () mutable {
+                                if (result_) {
+                                    aggrs.merge(*result_, partial_result);
+                                } else {
+                                    result_ = partial_result;
+                                }
+                            });
+                    });       
                 }
             ).then(
-                [&result, &req, &tr_state] () -> query::forward_result {
-                    query::forward_result::printer result_printer{
-                        .types = req.reduction_types,
-                        .res = *result
-                    };
-                    tracing::trace(tr_state, "Merged result is {}", result_printer);
-                    flogger.debug("merged result is {}", result_printer);
+                [&result, &req, &tr_state] () -> future<query::forward_result> {
+                    forward_aggregates aggrs(req);
+                    return do_with(std::move(aggrs), [&result, &req, &tr_state] (forward_aggregates& aggrs) {
+                        return aggrs.with_thread_if_needed([&result, &req, &tr_state, &aggrs] () mutable {
+                            query::forward_result::printer result_printer{
+                                .functions = get_functions(req),
+                                .res = *result
+                            };
+                            tracing::trace(tr_state, "Merged result is {}", result_printer);
+                            flogger.debug("merged result is {}", result_printer);
 
-                    return *result;
+                            aggrs.finalize(*result);
+                            return *result;
+                        });
+                    });
                 }
             );
         }

--- a/service/migration_manager.cc
+++ b/service/migration_manager.cc
@@ -735,14 +735,14 @@ future<std::vector<mutation>> migration_manager::prepare_function_drop_announcem
 future<std::vector<mutation>> migration_manager::prepare_new_aggregate_announcement(shared_ptr<cql3::functions::user_aggregate> aggregate, api::timestamp_type ts) {
     auto& db = _storage_proxy.get_db().local();
     auto&& keyspace = db.find_keyspace(aggregate->name().keyspace);
-    auto mutations = db::schema_tables::make_create_aggregate_mutations(aggregate, ts);
+    auto mutations = db::schema_tables::make_create_aggregate_mutations(db.features().cluster_schema_features(), aggregate, ts);
     return include_keyspace(*keyspace.metadata(), std::move(mutations));
 }
 
 future<std::vector<mutation>> migration_manager::prepare_aggregate_drop_announcement(shared_ptr<cql3::functions::user_aggregate> aggregate, api::timestamp_type ts) {
     auto& db = _storage_proxy.get_db().local();
     auto&& keyspace = db.find_keyspace(aggregate->name().keyspace);
-    auto mutations = db::schema_tables::make_drop_aggregate_mutations(aggregate, ts);
+    auto mutations = db::schema_tables::make_drop_aggregate_mutations(db.features().cluster_schema_features(), aggregate, ts);
     return include_keyspace(*keyspace.metadata(), std::move(mutations));
 }
 


### PR DESCRIPTION
This PR extends #9209. It consists of 2 main points:

## UDA reduction and distribution
To enable parallelization of user-defined aggregates, reduction function was added to UDA definition. Reduction function is optional and it has to be scalar function that takes 2 arguments with type of UDA's state and returns UDA's state

## Distribution of native aggregates
All currently implemented native aggregates got their reducible counterpart, which return their state as final result, so it can be reduced with other result. Hence all native aggregates can now be distributed.

# Mixed-cluster testing

## Setup
Local 3-node cluster made with current master. `node1` updated to this branch. Accessing node with `ccm <node-name> cqlsh`

## Test
I've tested belowed things from both old and new node:
- creating UDA with reduce function - not allowed
- selecting count(*) - distributed
- selecting other aggregate function - not distributed

# Issues
Fixes: #10224 