### PR TITLE
wasm: add null handling for wasm udf

### DIFF
--- a/cql3/functions/user_function.cc
+++ b/cql3/functions/user_function.cc
@@ -40,6 +40,11 @@ bytes_opt user_function::execute(cql_serialization_format sf, const std::vector<
     if (!seastar::thread::running_in_thread()) {
         on_internal_error(log, "User function cannot be executed in this context");
     }
+    for (auto& param : parameters) {
+        if (!param && !_called_on_null_input) {
+            return std::nullopt;
+        }
+    }
     return seastar::visit(_ctx,
         [&] (lua_context& ctx) -> bytes_opt {
             std::vector<data_value> values;
@@ -47,9 +52,6 @@ bytes_opt user_function::execute(cql_serialization_format sf, const std::vector<
             for (int i = 0, n = types.size(); i != n; ++i) {
                 const data_type& type = types[i];
                 const bytes_opt& bytes = parameters[i];
-                if (!bytes && !_called_on_null_input) {
-                    return std::nullopt;
-                }
                 values.push_back(bytes ? type->deserialize(*bytes) : data_value::make_null(type));
             }
             return lua::run_script(lua::bitcode_view{ctx.bitcode}, values, return_type(), ctx.cfg).get0();

--- a/test/cql-pytest/test_wasm.py
+++ b/test/cql-pytest/test_wasm.py
@@ -64,9 +64,9 @@ def test_fib(cql, test_keyspace, table1, scylla_with_wasm_only):
         res = [row for row in cql.execute(f"SELECT {test_keyspace}.{fib_name}(p) AS result FROM {table} WHERE p = 14")]
         assert len(res) == 1 and res[0].result == 377
 
-        # This function cannot be called on null values
-        with pytest.raises(InvalidRequest, match="null value"):
-            cql.execute(f"SELECT {test_keyspace}.{fib_name}(p2) AS result FROM {table} WHERE p = 14")
+        # This function returns null on null values
+        res = [row for row in cql.execute(f"SELECT {test_keyspace}.{fib_name}(p2) AS result FROM {table} WHERE p = 14")]
+        assert len(res) == 1 and res[0].result is None
 
         cql.execute(f"INSERT INTO {table} (p) VALUES (997)")
         # The call request takes too much time and resources, and should therefore fail


### PR DESCRIPTION
As the name suggests, for UDFs defined as RETURNS NULL ON NULL
INPUT, we sometimes want to return nulls. However, currently
we do not return nulls. Instead, we fail on the null check in
init_arg_visitor. Fix by adding null handling before passing
arguments, same as in lua.

Signed-off-by: Wojciech Mitros <wojciech.mitros@scylladb.com>