### PR TITLE
cql3: disambiguate an error message for indexes and IN clause

### DIFF
--- a/cql3/restrictions/statement_restrictions.cc
+++ b/cql3/restrictions/statement_restrictions.cc
@@ -1580,7 +1580,7 @@ bool statement_restrictions::need_filtering() const {
 void statement_restrictions::validate_secondary_index_selections(bool selects_only_static_columns) {
     if (key_is_in_relation()) {
         throw exceptions::invalid_request_exception(
-            "Select on indexed columns and with IN clause for the PRIMARY KEY are not supported");
+            "Index cannot be used if the partition key is restricted with IN clause. This query would require filtering instead.");
     }
 }
 


### PR DESCRIPTION
A user pointed out a misleading error message produced when
an indexed column is queried along with an IN relation
on the partition key. The message suggests that such queries are
not supported, but they are supported - just without indexing.
In particular, with ALLOW FILTERING, such queries are perfectly
fine.