### PR TITLE
treewide: move UDF out of experimental

### DIFF
--- a/db/config.cc
+++ b/db/config.cc
@@ -836,7 +836,7 @@ db::config::config(std::shared_ptr<db::extensions> exts)
         "Set to true if the cluster was initially installed from 3.1.0. If it was upgraded from an earlier version,"
         " or installed from a later version, leave this set to false. This adjusts the communication protocol to"
         " work around a bug in Scylla 3.1.0")
-    , enable_user_defined_functions(this, "enable_user_defined_functions", value_status::Used, false,  "Enable user defined functions. You must also set experimental-features=udf")
+    , enable_user_defined_functions(this, "enable_user_defined_functions", value_status::Used, false,  "Enable user defined functions.")
     , user_defined_function_time_limit_ms(this, "user_defined_function_time_limit_ms", value_status::Used, 10, "The time limit for each UDF invocation")
     , user_defined_function_allocation_limit_bytes(this, "user_defined_function_allocation_limit_bytes", value_status::Used, 1024*1024, "How much memory each UDF invocation can allocate")
     , user_defined_function_contiguous_allocation_limit_bytes(this, "user_defined_function_contiguous_allocation_limit_bytes", value_status::Used, 1024*1024, "How much memory each UDF invocation can allocate in one chunk")
@@ -1032,7 +1032,7 @@ std::unordered_map<sstring, db::experimental_features_t::feature> db::experiment
     // removed altogether.
     return {
         {"lwt", UNUSED},
-        {"udf", UDF},
+        {"udf", UNUSED},
         {"cdc", UNUSED},
         {"alternator-streams", ALTERNATOR_STREAMS},
         {"alternator-ttl", ALTERNATOR_TTL},

--- a/gms/feature_service.cc
+++ b/gms/feature_service.cc
@@ -119,12 +119,6 @@ feature_config feature_config_from_db_config(db::config& cfg, std::set<sstring> 
 
     if (!cfg.enable_user_defined_functions()) {
         fcfg._disabled_features.insert(sstring(gms::features::UDF));
-    } else {
-        if (!cfg.check_experimental(db::experimental_features_t::UDF)) {
-            throw std::runtime_error(
-                    "You must use both enable_user_defined_functions and experimental_features:udf "
-                    "to enable user-defined functions");
-        }
     }
 
     if (!cfg.check_experimental(db::experimental_features_t::ALTERNATOR_STREAMS)) {

--- a/test/boost/config_test.cc
+++ b/test/boost/config_test.cc
@@ -920,7 +920,6 @@ SEASTAR_TEST_CASE(test_parse_experimental_features_cdc) {
     cfg.read_from_yaml("experimental_features:\n    - cdc\n", throw_on_error);
     BOOST_CHECK_EQUAL(cfg.experimental_features(), features{ef::UNUSED});
     BOOST_CHECK(cfg.check_experimental(ef::UNUSED));
-    BOOST_CHECK(!cfg.check_experimental(ef::UDF));
     BOOST_CHECK(!cfg.check_experimental(ef::ALTERNATOR_STREAMS));
     BOOST_CHECK(!cfg.check_experimental(ef::RAFT));
     return make_ready_future();
@@ -932,19 +931,6 @@ SEASTAR_TEST_CASE(test_parse_experimental_features_unused) {
     cfg.read_from_yaml("experimental_features:\n    - lwt\n", throw_on_error);
     BOOST_CHECK_EQUAL(cfg.experimental_features(), features{ef::UNUSED});
     BOOST_CHECK(cfg.check_experimental(ef::UNUSED));
-    BOOST_CHECK(!cfg.check_experimental(ef::UDF));
-    BOOST_CHECK(!cfg.check_experimental(ef::ALTERNATOR_STREAMS));
-    BOOST_CHECK(!cfg.check_experimental(ef::RAFT));
-    return make_ready_future();
-}
-
-SEASTAR_TEST_CASE(test_parse_experimental_features_udf) {
-    auto cfg_ptr = std::make_unique<config>();
-    config& cfg = *cfg_ptr;
-    cfg.read_from_yaml("experimental_features:\n    - udf\n", throw_on_error);
-    BOOST_CHECK_EQUAL(cfg.experimental_features(), features{ef::UDF});
-    BOOST_CHECK(!cfg.check_experimental(ef::UNUSED));
-    BOOST_CHECK(cfg.check_experimental(ef::UDF));
     BOOST_CHECK(!cfg.check_experimental(ef::ALTERNATOR_STREAMS));
     BOOST_CHECK(!cfg.check_experimental(ef::RAFT));
     return make_ready_future();
@@ -956,7 +942,6 @@ SEASTAR_TEST_CASE(test_parse_experimental_features_alternator_streams) {
     cfg.read_from_yaml("experimental_features:\n    - alternator-streams\n", throw_on_error);
     BOOST_CHECK_EQUAL(cfg.experimental_features(), features{ef::ALTERNATOR_STREAMS});
     BOOST_CHECK(!cfg.check_experimental(ef::UNUSED));
-    BOOST_CHECK(!cfg.check_experimental(ef::UDF));
     BOOST_CHECK(cfg.check_experimental(ef::ALTERNATOR_STREAMS));
     BOOST_CHECK(!cfg.check_experimental(ef::RAFT));
     return make_ready_future();
@@ -968,7 +953,6 @@ SEASTAR_TEST_CASE(test_parse_experimental_features_raft) {
     cfg.read_from_yaml("experimental_features:\n    - raft\n", throw_on_error);
     BOOST_CHECK_EQUAL(cfg.experimental_features(), features{ef::RAFT});
     BOOST_CHECK(!cfg.check_experimental(ef::UNUSED));
-    BOOST_CHECK(!cfg.check_experimental(ef::UDF));
     BOOST_CHECK(!cfg.check_experimental(ef::ALTERNATOR_STREAMS));
     BOOST_CHECK(cfg.check_experimental(ef::RAFT));
     return make_ready_future();
@@ -980,7 +964,6 @@ SEASTAR_TEST_CASE(test_parse_experimental_features_multiple) {
     cfg.read_from_yaml("experimental_features:\n    - cdc\n    - lwt\n    - cdc\n", throw_on_error);
     BOOST_CHECK_EQUAL(cfg.experimental_features(), (features{ef::UNUSED, ef::UNUSED, ef::UNUSED}));
     BOOST_CHECK(cfg.check_experimental(ef::UNUSED));
-    BOOST_CHECK(!cfg.check_experimental(ef::UDF));
     BOOST_CHECK(!cfg.check_experimental(ef::ALTERNATOR_STREAMS));
     return make_ready_future();
 }
@@ -994,7 +977,6 @@ SEASTAR_TEST_CASE(test_parse_experimental_features_invalid) {
                            BOOST_REQUIRE_EQUAL(opt, "experimental_features");
                            BOOST_REQUIRE_NE(msg.find("line 2, column 7"), msg.npos);
                            BOOST_CHECK(!cfg.check_experimental(ef::UNUSED));
-                           BOOST_CHECK(!cfg.check_experimental(ef::UDF));
                            BOOST_CHECK(!cfg.check_experimental(ef::ALTERNATOR_STREAMS));
                        });
     return make_ready_future();
@@ -1005,7 +987,6 @@ SEASTAR_TEST_CASE(test_parse_experimental_true) {
     config& cfg = *cfg_ptr;
     cfg.read_from_yaml("experimental: true", throw_on_error);
     BOOST_CHECK(!cfg.check_experimental(ef::UNUSED));
-    BOOST_CHECK(cfg.check_experimental(ef::UDF));
     BOOST_CHECK(cfg.check_experimental(ef::ALTERNATOR_STREAMS));
     BOOST_CHECK(!cfg.check_experimental(ef::RAFT));
     return make_ready_future();
@@ -1016,7 +997,6 @@ SEASTAR_TEST_CASE(test_parse_experimental_false) {
     config& cfg = *cfg_ptr;
     cfg.read_from_yaml("experimental: false", throw_on_error);
     BOOST_CHECK(!cfg.check_experimental(ef::UNUSED));
-    BOOST_CHECK(!cfg.check_experimental(ef::UDF));
     BOOST_CHECK(!cfg.check_experimental(ef::ALTERNATOR_STREAMS));
     BOOST_CHECK(!cfg.check_experimental(ef::RAFT));
     return make_ready_future();

--- a/test/boost/schema_change_test.cc
+++ b/test/boost/schema_change_test.cc
@@ -640,7 +640,6 @@ future<> test_schema_digest_does_not_change_with_disabled_features(sstring data_
     auto db_cfg_ptr = ::make_shared<db::config>(std::move(extensions));
     auto& db_cfg = *db_cfg_ptr;
     db_cfg.enable_user_defined_functions({true}, db::config::config_source::CommandLine);
-    db_cfg.experimental_features({experimental_features_t::UDF}, db::config::config_source::CommandLine);
     if (regenerate) {
         db_cfg.data_file_directories({data_dir}, db::config::config_source::CommandLine);
     } else {

--- a/test/boost/user_function_test.cc
+++ b/test/boost/user_function_test.cc
@@ -55,7 +55,6 @@ static future<> with_udf_enabled(Func&& func) {
     // Raise timeout to survive debug mode and contention, but keep in
     // mind that some tests expect timeout.
     db_cfg.user_defined_function_time_limit_ms(1000);
-    db_cfg.experimental_features({db::experimental_features_t::UDF}, db::config::config_source::CommandLine);
     return do_with_cql_env_thread(std::forward<Func>(func), db_cfg_ptr);
 }
 
@@ -985,7 +984,6 @@ SEASTAR_THREAD_TEST_CASE(test_user_function_db_init) {
 
     db_cfg.data_file_directories({data_dir.path().string()}, db::config::config_source::CommandLine);
     db_cfg.enable_user_defined_functions({true}, db::config::config_source::CommandLine);
-    db_cfg.experimental_features({db::experimental_features_t::UDF}, db::config::config_source::CommandLine);
 
     do_with_cql_env_thread([] (cql_test_env& e) {
         e.execute_cql("CREATE FUNCTION my_func(a int, b float) CALLED ON NULL INPUT RETURNS int LANGUAGE Lua AS 'return 2';").get();


### PR DESCRIPTION
This commit drops the experimental flag guarding UDF.
After this commit is merged, UDF/UDA support is not considered
experimental anymore.

Draft, because I'm still verifying dtests (which mostly work already!)