### PR TITLE
scylla_cpuset_setup: stop deleting perftune.yaml and skip update cpuset.conf when same parameter specified

### DIFF
--- a/dist/common/scripts/scylla_cpuset_setup
+++ b/dist/common/scripts/scylla_cpuset_setup
@@ -26,12 +26,18 @@ if __name__ == '__main__':
         parser.print_help()
         sys.exit(1)
 
-    cfg = sysconfig_parser('/etc/scylla.d/cpuset.conf')
-    cfg.set('CPUSET', '{cpuset}{smp}'.format( \
-            cpuset='--cpuset {} '.format(args.cpuset) if args.cpuset else '', \
-            smp='--smp {} '.format(args.smp) if args.smp else '' \
-            ))
-    cfg.commit()
-
-    if os.path.exists('/etc/scylla.d/perftune.yaml'):
-        os.remove('/etc/scylla.d/perftune.yaml')
+    cpuset = smp = None
+    try:
+        cfg = sysconfig_parser('/etc/scylla.d/cpuset.conf')
+        line = cfg.get('CPUSET')
+        cpuset_args = parser.parse_args(line.split())
+        cpuset = cpuset_args.cpuset
+        smp = cpuset_args.smp
+    except:
+        pass
+    if cpuset != args.cpuset or smp != args.smp:
+        cfg.set('CPUSET', '{cpuset}{smp}'.format( \
+                cpuset='--cpuset {} '.format(args.cpuset) if args.cpuset else '', \
+                smp='--smp {} '.format(args.smp) if args.smp else '' \
+                ))
+        cfg.commit()

--- a/dist/common/scripts/scylla_prepare
+++ b/dist/common/scripts/scylla_prepare
@@ -43,6 +43,16 @@ def get_tune_mode(nic):
     else:
         raise Exception('tune mode not found')
 
+def config_updated():
+    perftune_mtime = os.path.getmtime('/etc/scylla.d/perftune.yaml')
+    cpuset_mtime = os.path.getmtime('/etc/scylla.d/cpuset.conf')
+    sysconfig_mtime = os.path.getmtime(sysconfdir_p() / 'scylla-server')
+    print("perftune_mtime < cpuset_mtime:{}".format(perftune_mtime < cpuset_mtime))
+    print("perftune_mtime < sysconfig_mtime:{}".format(perftune_mtime < sysconfig_mtime))
+    if perftune_mtime < cpuset_mtime or perftune_mtime < sysconfig_mtime:
+        return True
+    return False
+
 def create_perftune_conf(cfg):
     """
     This function checks if a perftune configuration file should be created and
@@ -65,7 +75,7 @@ def create_perftune_conf(cfg):
         params += ' --write-back-cache=false'
 
     if len(params) > 0:
-        if os.path.exists('/etc/scylla.d/perftune.yaml'):
+        if os.path.exists('/etc/scylla.d/perftune.yaml') and not config_updated():
             return True
 
         mode = get_tune_mode(nic)


### PR DESCRIPTION
To make scylla setup scripts easier to handle in Ansible, stop deleting
perftune.yaml and detect cpuset.conf changes by mtime of the file.
Also, skip update cpuset.conf when same parameter specified.

Fixes #10121