### PR TITLE
range_tombstone_change_generator: flush: emit closing range_tombstone_change

### DIFF
--- a/range_tombstone_change_generator.hh
+++ b/range_tombstone_change_generator.hh
@@ -71,6 +71,10 @@ public:
     // FIXME: respect preemption
     template<RangeTombstoneChangeConsumer C>
     void flush(position_in_partition_view upper_bound, C consumer) {
+        if (_range_tombstones.empty()) {
+            return;
+        }
+
         position_in_partition::less_compare less(_schema);
         std::optional<range_tombstone> prev;
 

--- a/range_tombstone_change_generator.hh
+++ b/range_tombstone_change_generator.hh
@@ -68,17 +68,23 @@ public:
     // for accumulated range tombstones.
     // After this, only range_tombstones with positions >= upper_bound may be added,
     // which guarantees that they won't affect the output of this flush.
+    //
+    // If upper_bound == position_in_partition::after_all_clustered_rows(),
+    // emits all remaining range_tombstone_changes.
+    // No range_tombstones may be added after this.
+    //
     // FIXME: respect preemption
     template<RangeTombstoneChangeConsumer C>
-    void flush(position_in_partition_view upper_bound, C consumer) {
+    void flush(const position_in_partition_view upper_bound, C consumer) {
         if (_range_tombstones.empty()) {
             return;
         }
 
         position_in_partition::tri_compare cmp(_schema);
         std::optional<range_tombstone> prev;
+        bool flush_all = cmp(upper_bound, position_in_partition::after_all_clustered_rows()) == 0;
 
-        while (!_range_tombstones.empty() && (cmp(_range_tombstones.begin()->end_position(), upper_bound) < 0)) {
+        while (!_range_tombstones.empty() && (flush_all || (cmp(_range_tombstones.begin()->end_position(), upper_bound) < 0))) {
             auto rt = _range_tombstones.pop(_range_tombstones.begin());
 
             if (prev && (cmp(prev->end_position(), rt.position()) < 0)) { // [1]

--- a/range_tombstone_change_generator.hh
+++ b/range_tombstone_change_generator.hh
@@ -75,19 +75,19 @@ public:
             return;
         }
 
-        position_in_partition::less_compare less(_schema);
+        position_in_partition::tri_compare cmp(_schema);
         std::optional<range_tombstone> prev;
 
-        while (!_range_tombstones.empty() && less(_range_tombstones.begin()->end_position(), upper_bound)) {
+        while (!_range_tombstones.empty() && (cmp(_range_tombstones.begin()->end_position(), upper_bound) < 0)) {
             auto rt = _range_tombstones.pop(_range_tombstones.begin());
 
-            if (prev && less(prev->end_position(), rt.position())) { // [1]
+            if (prev && (cmp(prev->end_position(), rt.position()) < 0)) { // [1]
                 // previous range tombstone not adjacent, emit gap.
                 consumer(range_tombstone_change(prev->end_position(), tombstone()));
             }
 
             // Check if start of rt was already emitted, emit if not.
-            if (!less(rt.position(), _lower_bound)) {
+            if (cmp(rt.position(), _lower_bound) >= 0) {
                 consumer(range_tombstone_change(rt.position(), rt.tomb));
             }
 
@@ -99,15 +99,15 @@ public:
         // It cannot get adjacent later because prev->end_position() < upper_bound,
         // so nothing == prev->end_position() can be added after this invocation.
         if (prev && (_range_tombstones.empty()
-                     || less(prev->end_position(), _range_tombstones.begin()->position()))) {
+                     || (cmp(prev->end_position(), _range_tombstones.begin()->position()) < 0))) {
             consumer(range_tombstone_change(prev->end_position(), tombstone())); // [2]
         }
 
         // Emit the fragment for start bound of a range_tombstone which is overlapping with upper_bound,
         // unless no such fragment or already emitted.
         if (!_range_tombstones.empty()
-            && less(_range_tombstones.begin()->position(), upper_bound)
-            && (!less(_range_tombstones.begin()->position(), _lower_bound))) {
+            && (cmp(_range_tombstones.begin()->position(), upper_bound) < 0)
+            && (cmp(_range_tombstones.begin()->position(), _lower_bound) >= 0)) {
             consumer(range_tombstone_change(
                     _range_tombstones.begin()->position(), _range_tombstones.begin()->tombstone().tomb));
         }


### PR DESCRIPTION
When the highest tombstone is open ended, we must
emit a closing range_tombstone_change at
position_in_partition::after_all_clustered_rows().
    
Since all consumers need to do it, implement the logic
in the range_tombstone_change_generator itself.

It turned out that mutation::consume doesn't do that,
hence this series, and 5a09e5234ef4e1ee673bc7fca481defbbb2c0384 in particular,
fix the issue.

Change 028b2a8cdfdc12721b2be23d175cbc756d2507de exposes the issue
by generating a richer set of random range_tombstone that include open-ended
range tombstones.

Fixes #10316

Test: unit(dev)

Signed-off-by: Benny Halevy <bhalevy@scylladb.com>
