### PR TITLE
generic_server.hh: add missing include

### DIFF
--- a/generic_server.hh
+++ b/generic_server.hh
@@ -12,6 +12,8 @@
 
 #include "seastarx.hh"
 
+#include <list>
+
 #include <seastar/core/future.hh>
 #include <seastar/core/gate.hh>
 #include <seastar/net/api.hh>


### PR DESCRIPTION
Add missing include of `<list>` which caused compile errors on GCC:

```
In file included from generic_server.cc:9:
generic_server.hh:91:10: error: ‘list’ in namespace ‘std’ does not name a template type
   91 |     std::list<gentle_iterator> _gentle_iterators;
      |          ^~~~
generic_server.hh:19:1: note: ‘std::list’ is defined in header ‘<list>’; did you forget to ‘#include <list>’?
   18 | #include <seastar/net/tls.hh>
  +++ |+#include <list>
   19 |
```

Note that there are some GCC compilation problems still left apart from this one.