### PR TITLE
forward_service: retry failed forwarder call

### DIFF
--- a/service/forward_service.hh
+++ b/service/forward_service.hh
@@ -155,6 +155,8 @@ private:
     void register_metrics();
     void init_messaging_service();
     future<> uninit_messaging_service();
+
+    friend class retrying_dispatcher;
 };
 
 } // namespace service


### PR DESCRIPTION
This pull request adds support for retrying failed forwarder calls (currently used to parallelize `select count(*) from ...` queries).  Failed-to-forward sub-queries will be executed locally (on a super-coordinator). This local execution is meant as a fallback for a forward_requests that could not be sent to its destined coordinator (e.g. due gossiper not reacting fast enough). Local execution was chosen as the safest one - it does not require sending data to another coordinator.

Due to problems with misscompilations, some parts of the `forward_service` were uncoroutinized.

Fixes: #10131