### PR TITLE
dependencies: add rust

### DIFF
--- a/docs/design-notes/rust.md
+++ b/docs/design-notes/rust.md
@@ -1,0 +1,38 @@
+# Rust and C++
+
+Rust introduces many useful features that are missing in C++. This document
+shows how to use them in Scylla.
+
+## Using Rust in Scylla
+
+To create a Rust package `new_pkg` and use it in a C++ source file:
+1. Create a new package in the `rust` directory using `cargo new new_pkg --lib`
+2. Modify crate type to a static library by adding
+```
+[lib]
+crate-type = ["staticlib"]
+```
+to `new_pkg/Cargo.toml`
+3. Add `"new_pkg",` to the workspace members list in `Cargo.toml`
+4. Write your Rust code in `new_pkg/src/lib.rs`
+5. To export a function `fn foo(x: i32) -> i32`, add its declaration as follows to the same file
+```
+#[cxx::bridge(namespace = "rust")]
+mod ffi {
+    extern "Rust" {
+        fn inc(x: i32) -> i32;
+    }
+}
+```
+6. Add `"rust/new_pkg/src/lib.rs"` to the `rusts` list in `configure.py`
+7. Include the `rust/new_pkg.hh` header and use `rust::foo()` in the selected c++ file.
+
+## Rust interoperability implementation
+
+Using Rust alongside C++ in scylla is made possible by the Rust crate CXX. The `cxx::bridge` macro,
+together with `mod ffi` and `extern "Rust"` mark items to be exported to C++. During compilation,
+a compatible version is generated with temporary names. It can be later linked with a header file, generated from the source code using `cxxbridge` command. The header exposed all items with original names and can be included like any other c++ header.
+
+Compilation is managed by `cargo`. Like in any Rust project, modules added to Scylla can be fully
+customized using corresponding `Cargo.toml` files. Currently, all modules are compiled to static
+libraries (TODO: dynamic or flexible)

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,0 +1,4 @@
+[workspace]
+members = [
+    "inc",
+]

--- a/rust/inc/Cargo.toml
+++ b/rust/inc/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "inc"
+version = "0.1.0"
+edition = "2021"
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+cxx = "1.0"
+
+[lib]
+crate-type = ["staticlib"]

--- a/rust/inc/src/lib.rs
+++ b/rust/inc/src/lib.rs
@@ -1,0 +1,17 @@
+/*
+ * Copyright (C) 2022-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: (AGPL-3.0-or-later and Apache-2.0)
+ */
+
+#[cxx::bridge(namespace = "rust")]
+mod ffi {
+    extern "Rust" {
+        fn inc(x: i32) -> i32;
+    }
+}
+fn inc(x: i32) -> i32 {
+    x + 1
+}

--- a/test/boost/rust_test.cc
+++ b/test/boost/rust_test.cc
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) 2022-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#define BOOST_TEST_MODULE core
+
+#include <boost/test/unit_test.hpp>
+
+#include "rust/inc.hh"
+
+BOOST_AUTO_TEST_CASE(test_inc) {
+    int k = 1;
+    BOOST_REQUIRE(rust::inc(k) == 2);
+}


### PR DESCRIPTION
The main reason for adding rust dependency to scylla is the
wasmtime library, which is written in rust. Although there
exist c++ bindings, they don't expose all of its features,
so we want to do that ourselves using rust's cxx.

The patch also includes an example rust source to be used in
c++, and its example use in tests/boost/rust_test.

The usage of wasmtime has been slightly modified to avoid
duplicate symbol errors, but as a result of adding a Rust 
dependency, it is going to be removed from `configure.py`
completely anyway

Signed-off-by: Wojciech Mitros <wojciech.mitros@scylladb.com>