### PR TITLE
Docs: Update doc project name to scylla dev

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -46,7 +46,7 @@ autosectionlabel_prefix_document = True
 master_doc = 'contents'
 
 # General information about the project.
-project = 'Scylla Documentation'
+project = 'Scylla Dev'
 copyright = str(date.today().year) + ', ScyllaDB. All rights reserved.'
 author = u'Scylla Project Contributors'
 


### PR DESCRIPTION
initially reported https://github.com/scylladb/scylla-docs/issues/3768#issuecomment-1091368109
by @annastuchlik 

"project" is a config parameter used to generated the developer documentation site https://scylla.docs.scylladb.com
For example, in the breadcrumb 
![image](https://user-images.githubusercontent.com/170200/162193161-b7d1670a-9a09-454a-a716-dba50ef6d317.png)
and in the non latest version warning
![image](https://user-images.githubusercontent.com/170200/162193284-43a0242c-cac5-4031-b464-9cc8217b3edd.png)

Having "Documentation" in the project name is redundant, see the second example above.
Naming the project "Scylla" make sense, but we are already using that project name for user facing https://docs.scylladb.com

"Scylla Dev" fix the problem
![image](https://user-images.githubusercontent.com/170200/162193834-635b315c-173a-4895-abb6-b699513e4e4e.png)


