### PR TITLE
Coroutinize view_update_builder::build_some

### DIFF
--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -929,6 +929,7 @@ future<utils::chunked_vector<frozen_mutation_and_schema>> view_update_builder::b
     utils::chunked_vector<frozen_mutation_and_schema> mutations;
     for (auto& update : _view_updates) {
         update.move_to(mutations);
+        co_await coroutine::maybe_yield();
     }
     co_return mutations;
 }

--- a/db/view/view.hh
+++ b/db/view/view.hh
@@ -139,7 +139,7 @@ public:
             , _updates(8, partition_key::hashing(*_view), partition_key::equality(*_view)) {
     }
 
-    void move_to(utils::chunked_vector<frozen_mutation_and_schema>& mutations);
+    future<> move_to(utils::chunked_vector<frozen_mutation_and_schema>& mutations);
 
     void generate_update(const partition_key& base_key, const clustering_row& update, const std::optional<clustering_row>& existing, gc_clock::time_point now);
 


### PR DESCRIPTION
Simplify view_update_builder::build_some by turning it into a coroutine,
and make view_updates::move_to async (also using a coroutine) so it may yield in-between building the updates, since freezing each mutation can be cpu intensive and preparing many updates synchronously may cause reactor stalls.

Test: unit(dev)
DTest: materialized_views_test.py(dev)

