### PR TITLE
toolchain: speed up prepare

### DIFF
--- a/tools/toolchain/Dockerfile
+++ b/tools/toolchain/Dockerfile
@@ -4,10 +4,11 @@ ADD ./seastar/install-dependencies.sh ./seastar/
 ADD ./tools/jmx/install-dependencies.sh ./tools/jmx/
 ADD ./tools/java/install-dependencies.sh ./tools/java/
 ADD ./tools/toolchain/system-auth ./
-RUN dnf -y install 'dnf-command(copr)' \
+RUN dnf -y update \
+    && dnf -y install 'dnf-command(copr)' \
     && dnf -y install ccache \
     && dnf -y install devscripts debhelper fakeroot file rpm-build \
-    && ./install-dependencies.sh && dnf -y update && dnf clean all \
+    && ./install-dependencies.sh && dnf clean all \
     && echo 'ALL ALL=(ALL:ALL) NOPASSWD: ALL' >> /etc/sudoers \
     && cp system-auth /etc/pam.d \
     && echo 'Defaults !requiretty' >> /etc/sudoers

--- a/tools/toolchain/prepare
+++ b/tools/toolchain/prepare
@@ -48,7 +48,7 @@ buildah manifest create "$(<tools/toolchain/image)"
 build_arch() {
     local arch="$1"
     image_id_file="$(mktemp)"
-    buildah bud --arch="$arch" --no-cache --pull -f tools/toolchain/Dockerfile --iidfile "$image_id_file"
+    buildah bud --arch="$arch" --squash --no-cache --pull -f tools/toolchain/Dockerfile --iidfile "$image_id_file"
     buildah manifest add --all "$(<tools/toolchain/image)" "$(<$image_id_file)"
     rm "$image_id_file"
 }

--- a/tools/toolchain/prepare
+++ b/tools/toolchain/prepare
@@ -24,10 +24,23 @@ fi
 
 archs=(amd64 arm64 s390x)
 
-if [[ ! -f  /proc/sys/fs/binfmt_misc/qemu-aarch64 || ! -f /proc/sys/fs/binfmt_misc/qemu-s390x ]]; then
-    echo install qemu-user-static
-    exit 1
-fi
+# docker arch has a diffrent spelling than uname arch
+arch_uname_amd64=x86_64
+arch_uname_arm64=aarch64
+arch_uname_s390x=s390x
+
+for arch in "${archs[@]}"; do
+    # translate from docker arch to uname arch
+    indirect="arch_uname_${arch}"
+    arch_uname="${!indirect}"
+    if [[ "$(uname -m)" == "${arch_uname}" ]]; then
+        continue
+    fi
+    if [[ ! -f  /proc/sys/fs/binfmt_misc/qemu-"${arch_uname}" ]]; then
+        echo install qemu-user-static
+        exit 1
+    fi
+done
 
 buildah manifest create "$(<tools/toolchain/image)"
 

--- a/tools/toolchain/prepare
+++ b/tools/toolchain/prepare
@@ -45,12 +45,30 @@ done
 buildah manifest create "$(<tools/toolchain/image)"
 
 
-for arch in "${archs[@]}"; do
+build_arch() {
+    local arch="$1"
     image_id_file="$(mktemp)"
     buildah bud --arch="$arch" --no-cache --pull -f tools/toolchain/Dockerfile --iidfile "$image_id_file"
     buildah manifest add --all "$(<tools/toolchain/image)" "$(<$image_id_file)"
     rm "$image_id_file"
+}
+
+for arch in "${archs[@]}"; do
+    build_arch "$arch" &
 done
+
+fails=0
+
+for arch in "${archs[@]}"; do
+    if ! wait -n; then
+        (( fails += 1 ))
+    fi
+done
+
+if (( fails > 0 )); then
+    echo "$fails failures building arch-specific images"
+    exit 1
+fi
 
 echo "Done building $(<tools/toolchain/image). You can now test it, and push with"
 echo ""


### PR DESCRIPTION
This series speeds up tools/toolchain/prepare in a few ways:
 - builds images in parallel
 - allows running on any arch as host
 - reduces work in building the image
 - removes unneeded layers
