### PR TITLE
Don't throw exceptions on the replica side when handling single partition reads and writes

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -508,6 +508,8 @@ scylla_tests = set([
     'test/boost/rate_limiter_test',
     'test/boost/per_partition_rate_limit_test',
     'test/boost/expr_test',
+    'test/boost/exceptions_optimized_test',
+    'test/boost/exceptions_fallback_test',
     'test/manual/ec2_snitch_test',
     'test/manual/enormous_table_scan_test',
     'test/manual/gce_snitch_test',
@@ -1290,6 +1292,8 @@ deps['test/boost/linearizing_input_stream_test'] = [
 ]
 deps['test/boost/expr_test'] = ['test/boost/expr_test.cc'] + scylla_core
 deps['test/boost/rate_limiter_test'] = ['test/boost/rate_limiter_test.cc', 'db/rate_limiter.cc']
+deps['test/boost/exceptions_optimized_test'] = ['test/boost/exceptions_optimized_test.cc', 'utils/exceptions.cc']
+deps['test/boost/exceptions_fallback_test'] = ['test/boost/exceptions_fallback_test.cc', 'utils/exceptions.cc']
 
 deps['test/boost/duration_test'] += ['test/lib/exception_utils.cc']
 deps['test/boost/schema_loader_test'] += ['tools/schema_loader.cc']

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -1911,12 +1911,8 @@ Future database::update_write_metrics(Future&& f) {
             auto ep = f.get_exception();
             if (is_timeout_exception(ep)) {
                 ++s->total_writes_timedout;
-            }
-            try {
-                std::rethrow_exception(ep);
-            } catch (replica::rate_limit_exception&) {
+            } else if (try_catch<replica::rate_limit_exception>(ep)) {
                 ++s->total_writes_rate_limited;
-            } catch (...) {
             }
             return futurize<Future>::make_exception_future(std::move(ep));
         }

--- a/test/boost/exceptions_fallback_test.cc
+++ b/test/boost/exceptions_fallback_test.cc
@@ -1,0 +1,11 @@
+/*
+ * Copyright (C) 2022-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#define NO_OPTIMIZED_EXCEPTION_HANDLING
+
+#include "exceptions_test.inc.cc"

--- a/test/boost/exceptions_optimized_test.cc
+++ b/test/boost/exceptions_optimized_test.cc
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2022-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#if defined(NO_OPTIMIZED_EXCEPTION_HANDLING)
+#undef NO_OPTIMIZED_EXCEPTION_HANDLING
+#endif
+
+#include "utils/exceptions.hh"
+
+#if defined(OPTIMIZED_EXCEPTION_HANDLING_AVAILABLE)
+
+#include "exceptions_test.inc.cc"
+
+#else
+
+#include <boost/test/unit_test_log.hpp>
+#include <seastar/testing/test_case.hh>
+
+SEASTAR_TEST_CASE(test_noop) {
+    BOOST_TEST_MESSAGE("Optimized implementation of handling exceptions "
+            "without throwing is not available. Skipping tests in this file.");
+    return seastar::make_ready_future<>();
+}
+
+#endif

--- a/test/boost/exceptions_test.inc.cc
+++ b/test/boost/exceptions_test.inc.cc
@@ -1,0 +1,137 @@
+/*
+ * Copyright (C) 2022-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+// Common definitions of test cases used in
+//   handle_exception_optimized_test.cc
+//   handle_exception_fallback_test.cc
+
+#include <exception>
+#include <stdexcept>
+#include <type_traits>
+#include <cxxabi.h>
+#include <boost/test/unit_test_log.hpp>
+#include <boost/test/tools/old/interface.hpp>
+#include <boost/test/unit_test.hpp>
+
+#include "seastarx.hh"
+#include <seastar/core/future.hh>
+#include <seastar/testing/test_case.hh>
+#include <seastar/util/log.hh>
+
+#include "utils/exceptions.hh"
+
+class base_exception : public std::exception {};
+class derived_exception : public base_exception {};
+
+static void dummy_fn(void*) {
+    //
+}
+
+template<typename T>
+static std::exception_ptr maybe_wrap_eptr(T&& t) {
+    if constexpr (std::is_same_v<T, std::exception_ptr>) {
+        return std::move(t);
+    } else {
+        return std::make_exception_ptr(std::move(t));
+    }
+}
+
+static const std::type_info& eptr_typeid(std::exception_ptr eptr) {
+    try {
+        std::rethrow_exception(eptr);
+    } catch (...) {
+        return *abi::__cxa_current_exception_type();
+    }
+}
+
+template<typename Capture, typename Throw>
+static void check_catch(Throw&& ex) {
+    auto eptr = maybe_wrap_eptr(std::move(ex));
+    BOOST_TEST_MESSAGE("Checking if " << seastar::pretty_type_name(eptr_typeid(eptr))
+            << " is caught as " << seastar::pretty_type_name(typeid(Capture)));
+
+    auto typed_eptr = try_catch<Capture>(eptr);
+    BOOST_CHECK_NE(typed_eptr, nullptr);
+
+    // Verify that it's the same as what the usual throwing gives
+    // TODO: Does this check make sense? Does the standard guarantee
+    // that this will give the same pointer?
+    try {
+        std::rethrow_exception(eptr);
+    } catch (Capture& t) {
+        BOOST_CHECK_EQUAL(typed_eptr, &t);
+    } catch (...) {
+        // Can happen if the first check fails, just skip
+        assert(typed_eptr == nullptr);
+    }
+}
+
+template<typename Capture, typename Throw>
+static void check_no_catch(Throw&& ex) {
+    auto eptr = maybe_wrap_eptr(std::move(ex));
+    BOOST_TEST_MESSAGE("Checking if " << seastar::pretty_type_name(eptr_typeid(eptr))
+            << " is NOT caught as " << seastar::pretty_type_name(typeid(Capture)));
+
+    auto typed_eptr = try_catch<Capture>(eptr);
+    BOOST_CHECK_EQUAL(typed_eptr, nullptr);
+}
+
+template<typename A, typename B>
+static std::exception_ptr make_nested_eptr(A&& a, B&& b) {
+    try {
+        throw std::move(b);
+    } catch (...) {
+        try {
+            std::throw_with_nested(std::move(a));
+        } catch (...) {
+            return std::current_exception();
+        }
+    }
+}
+
+SEASTAR_TEST_CASE(test_try_catch) {
+    // Some standard examples, throwing exceptions derived from std::exception
+    // and catching them through their base types
+
+    check_catch<derived_exception>(derived_exception());
+    check_catch<base_exception>(derived_exception());
+    check_catch<std::exception>(derived_exception());
+    check_no_catch<std::runtime_error>(derived_exception());
+
+    check_no_catch<derived_exception>(base_exception());
+    check_catch<base_exception>(base_exception());
+    check_catch<std::exception>(base_exception());
+    check_no_catch<std::runtime_error>(base_exception());
+
+    // Catching nested exceptions
+    check_catch<base_exception>(make_nested_eptr(base_exception(), derived_exception()));
+    check_catch<std::nested_exception>(make_nested_eptr(base_exception(), derived_exception()));
+    check_no_catch<derived_exception>(make_nested_eptr(base_exception(), derived_exception()));
+
+    // Check that everything works if we throw some crazy stuff
+    check_catch<int>(int(1));
+    check_no_catch<std::exception>(int(1));
+
+    check_no_catch<int>(nullptr);
+    check_no_catch<std::exception>(nullptr);
+
+    // Catching pointers is not supported, but nothing should break if they are
+    // being thrown
+    derived_exception exc;
+    check_no_catch<int>(&exc);
+    check_no_catch<std::exception>(&exc);
+
+    check_no_catch<int>(&dummy_fn);
+    check_no_catch<std::exception>(&dummy_fn);
+
+    check_no_catch<int>(&std::exception::what);
+    check_no_catch<std::exception>(&std::exception::what);
+
+    return make_ready_future<>();
+}
+

--- a/utils/abi/eh_ia64.hh
+++ b/utils/abi/eh_ia64.hh
@@ -1,0 +1,52 @@
+
+/*
+ * Copyright (C) 2022-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#pragma once
+
+#include <unwind.h>
+#include <typeinfo>
+#include <exception>
+
+// This file defines structures/functions derived from the Itanium C++ ABI.
+// Source: https://itanium-cxx-abi.github.io/cxx-abi/abi-eh.html
+
+namespace utils {
+namespace abi {
+
+// __cxa_exception (exception object header), as defined in section 2.2.1
+struct cxa_exception { 
+    std::type_info* exceptionType;
+    void (*exceptionDestructor)(void*); 
+    std::unexpected_handler unexpectedHandler;
+    std::terminate_handler terminateHandler;
+    cxa_exception* nextException;
+
+    int handlerCount;
+    int	handlerSwitchValue;
+    const char* actionRecord;
+    const char* languageSpecificData;
+    void* catchTemp;
+    void* adjustedPtr;
+
+    _Unwind_Exception unwindHeader;
+};
+
+// Given a pointer to the exception data, returns the pointer
+// to the __cxa_exception header.
+inline cxa_exception* get_cxa_exception(void* eptr) {
+    // From section 2.2.1:
+    // "By convention, a __cxa_exception pointer points at the C++ object
+    // representing the exception being thrown, immediately following
+    // the header. The header structure is accessed at a negative offset
+    // from the __cxa_exception pointer."
+    return reinterpret_cast<cxa_exception*>(eptr) - 1;
+}
+
+} // abi
+} // utils

--- a/utils/exceptions.cc
+++ b/utils/exceptions.cc
@@ -15,6 +15,7 @@
 #include <system_error>
 #include <atomic>
 #include "exceptions.hh"
+#include "utils/abi/eh_ia64.hh"
 
 #include <iostream>
 
@@ -73,3 +74,25 @@ bool is_timeout_exception(std::exception_ptr e) {
     }
     return false;
 }
+
+#if defined(OPTIMIZED_EXCEPTION_HANDLING_AVAILABLE)
+
+#include <typeinfo>
+#include "utils/abi/eh_ia64.hh"
+
+void* utils::internal::try_catch_dynamic(std::exception_ptr& eptr, const std::type_info* catch_type) noexcept {
+    // In both libstdc++ and libc++, exception_ptr has just one field
+    // which is a pointer to the exception data
+    void* raw_ptr = reinterpret_cast<void*&>(eptr);
+    const std::type_info* ex_type = utils::abi::get_cxa_exception(raw_ptr)->exceptionType;
+
+    // __do_catch can return true and set raw_ptr to nullptr, but only in the case
+    // when catch_type is a pointer and a nullptr is thrown. try_catch_dynamic
+    // doesn't work with catching pointers.
+    if (catch_type->__do_catch(ex_type, &raw_ptr, 1)) {
+        return raw_ptr;
+    }
+    return nullptr;
+}
+
+#endif // __GLIBCXX__

--- a/utils/exceptions.hh
+++ b/utils/exceptions.hh
@@ -8,11 +8,26 @@
 
 #pragma once
 
+#include <cstddef>
+
+#if defined(__GLIBCXX__) && (defined(__x86_64__) || defined(__aarch64__))
+  #define OPTIMIZED_EXCEPTION_HANDLING_AVAILABLE
+#endif
+
+#if !defined(NO_OPTIMIZED_EXCEPTION_HANDLING)
+  #if defined(OPTIMIZED_EXCEPTION_HANDLING_AVAILABLE)
+    #define USE_OPTIMIZED_EXCEPTION_HANDLING
+  #else
+    #warn "Fast implementation of some of the exception handling routines is not available for this platform. Expect poor exception handling performance."
+  #endif
+#endif
+
 #include <seastar/core/sstring.hh>
 #include <seastar/core/on_internal_error.hh>
 
 #include <functional>
 #include <system_error>
+#include <type_traits>
 
 namespace seastar { class logger; }
 
@@ -59,4 +74,37 @@ inline void maybe_rethrow_exception(std::exception_ptr ex) {
     if (ex) {
         std::rethrow_exception(std::move(ex));
     }
+}
+
+namespace utils::internal {
+
+#if defined(OPTIMIZED_EXCEPTION_HANDLING_AVAILABLE)
+void* try_catch_dynamic(std::exception_ptr& eptr, const std::type_info* catch_type) noexcept;
+#endif
+
+} // utils::internal
+
+/// If the exception_ptr holds an exception which would match on a `catch (T&)`
+/// clause, returns a pointer to it. Otherwise, returns `nullptr`.
+///
+/// The exception behind the pointer is valid as long as the exception
+/// behind the exception_ptr is valid.
+template<typename T>
+inline T* try_catch(std::exception_ptr& eptr) noexcept {
+    static_assert(!std::is_pointer_v<T>, "catching pointers is not supported");
+    static_assert(!std::is_lvalue_reference_v<T> && !std::is_rvalue_reference_v<T>,
+            "T must not be a reference");
+
+#if defined(USE_OPTIMIZED_EXCEPTION_HANDLING)
+    void* opt_ptr = utils::internal::try_catch_dynamic(eptr, &typeid(std::remove_const_t<T>));
+    return reinterpret_cast<T*>(opt_ptr);
+#else
+    try {
+        std::rethrow_exception(eptr);
+    } catch (T& t) {
+        return &t;
+    } catch (...) {
+    }
+    return nullptr;
+#endif
 }


### PR DESCRIPTION
This PR gets rid of exception throws/rethrows on the replica side for writes and single-partition reads. This goal is achieved without using `boost::outcome` but rather by replacing the parts of the code which throw with appropriate seastar idioms and by introducing two helper functions:

1.`try_catch` allows to inspect the type and value behind an `std::exception_ptr`. When libstdc++ is used, this function does not need to throw the exception and avoids the very costly unwind process. This based on the "How to catch an exception_ptr without even try-ing" proposal mentioned in https://github.com/scylladb/scylla/issues/10260.

This function allows to replace the current `try..catch` chains which inspect the exception type and account it in the metrics.

Example:

```c++
// Before
try {
    std::rethrow_exception(eptr);
} catch (std::runtime_exception& ex) {
    // 1
} catch (...) {
    // 2
}

// After
if (auto* ex = try_catch<std::runtime_exception>(eptr)) {
    // 1
} else {
    // 2
}
```

2. `make_nested_exception_ptr` which is meant to be a replacement for `std::throw_with_nested`. Unlike the original function, it does not require an exception being currently thrown and does not throw itself - instead, it takes the nested exception as an `std::exception_ptr` and produces another `std::exception_ptr` itself.

Apart from the above, seastar idioms such as `make_exception_future`, `co_await as_future`, `co_return coroutine::exception()` are used to propagate exceptions without throwing. This brings the number of exception throws to zero for single partition reads and writes (tested with scylla-bench, --mode=read and --mode=write).

Results from `perf_simple_query`:

```
Before (719724e4df6b12524a6428f0a9ab20027bbed254):
  Writes:
    Normal:
      127841.40 tps ( 56.2 allocs/op,  13.2 tasks/op,   50042 insns/op,        0 errors)
    Timeouts:
      94770.81 tps ( 53.1 allocs/op,   5.1 tasks/op,   78678 insns/op,  1000000 errors)
  Reads:
    Normal:
      138902.31 tps ( 65.1 allocs/op,  12.1 tasks/op,   43106 insns/op,        0 errors)
    Timeouts:
      62447.01 tps ( 49.7 allocs/op,  12.1 tasks/op,  135984 insns/op,   936846 errors)

After (d8ac4c02bfb7786dc9ed30d2db3b99df09bf448f):
  Writes:
    Normal:
      127359.12 tps ( 56.2 allocs/op,  13.2 tasks/op,   49782 insns/op,        0 errors)
    Timeouts:
      163068.38 tps ( 52.1 allocs/op,   5.1 tasks/op,   40615 insns/op,  1000000 errors)
  Reads:
    Normal:
      151221.15 tps ( 65.1 allocs/op,  12.1 tasks/op,   43028 insns/op,        0 errors)
    Timeouts:
      192094.11 tps ( 41.2 allocs/op,  12.1 tasks/op,   33403 insns/op,   960604 errors)
```