### PR TITLE
schema_tables: drop leftover change to system_schema.keyspaces

### DIFF
--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -238,7 +238,6 @@ schema_ptr keyspaces() {
         {
             {"durable_writes", boolean_type},
             {"replication", map_type_impl::get_instance(utf8_type, utf8_type, false)},
-            {"storage", map_type_impl::get_instance(utf8_type, utf8_type, false)},
         },
         // static columns
         {},


### PR DESCRIPTION
Series 59d56a3fd7ab22a3184de2ebfb3df67580316ff9 introduced
an accidental backward incompatible regression by adding
a column to system_schema.keyspaces and then not even using
it for anything. It's a leftover from the original hackathon
implementation and should never reach master in the first place.
Fortunately, the series isn't part of any stable release yet.

Fixes #10376
Tests: manual, verifying that the system_schema.keyspaces table
no longer contains the extraneous column.