### PR TITLE
Fix some errors and issues found by gcc 12

### DIFF
--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -3087,7 +3087,7 @@ static void check_big_array(const rjson::value& val, int& size_left);
 
 static bool is_big(const rjson::value& val, int big_size = 100'000) {
     if (val.IsString()) {
-        return val.GetStringLength() > big_size;
+        return ssize_t(val.GetStringLength()) > big_size;
     } else if (val.IsObject()) {
         check_big_object(val, big_size);
         return big_size < 0;

--- a/api/api.hh
+++ b/api/api.hh
@@ -280,7 +280,8 @@ public:
         return get(name);
     }
 
-    template <>
+    template <typename T = sstring>
+    requires std::same_as<T, bool>
     const std::optional<bool> get_as(const char* name) const {
         auto value = get(name);
         if (!value) {

--- a/compaction/compaction_manager.hh
+++ b/compaction/compaction_manager.hh
@@ -396,7 +396,7 @@ public:
     class compaction_reenabler {
         compaction_manager& _cm;
         replica::table* _table;
-        compaction_state& _compaction_state;
+        compaction_manager::compaction_state& _compaction_state;
         gate::holder _holder;
 
     public:
@@ -409,7 +409,7 @@ public:
             return _table;
         }
 
-        const compaction_state& compaction_state() const noexcept {
+        const compaction_manager::compaction_state& compaction_state() const noexcept {
             return _compaction_state;
         }
     };

--- a/compaction/leveled_compaction_strategy.cc
+++ b/compaction/leveled_compaction_strategy.cc
@@ -223,7 +223,7 @@ leveled_compaction_strategy::get_cleanup_compaction_jobs(table_state& table_s, s
     auto levels = leveled_manifest::get_levels(candidates);
 
     ret = size_tiered_compaction_strategy(_stcs_options).get_cleanup_compaction_jobs(table_s, std::move(levels[0]));
-    for (auto level = 1; level < levels.size(); level++) {
+    for (size_t level = 1; level < levels.size(); level++) {
         if (levels[level].empty()) {
             continue;
         }

--- a/configure.py
+++ b/configure.py
@@ -1328,6 +1328,11 @@ warnings = [
     '-Wno-array-bounds',
     '-Wno-nonnull',
     '-Wno-catch-value',
+    '-Wno-stringop-overread', # false positives with gcc 12
+    '-Wno-uninitialized',  # false positives with gcc 12,
+    '-Wno-missing-attributes', # something in seastar's memory.cc, TBD,
+    '-Wno-use-after-free', # false positives with gcc 12
+    '-Wno-dangling-pointer', # false positives with gcc 12
 ]
 
 warnings = [w

--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -908,7 +908,7 @@ future<stop_iteration> view_update_builder::stop() const {
 }
 
 future<utils::chunked_vector<frozen_mutation_and_schema>> view_update_builder::build_some() {
-    auto _ = co_await advance_all();
+    (void)co_await advance_all();
     bool do_advance_updates = false;
     bool do_advance_existings = false;
     if (_update && _update->is_partition_start()) {

--- a/locator/abstract_replication_strategy.cc
+++ b/locator/abstract_replication_strategy.cc
@@ -468,6 +468,7 @@ std::ostream& operator<<(std::ostream& os, locator::replication_strategy_type t)
     case locator::replication_strategy_type::everywhere_topology:
         return os << "everywhere_topology";
     };
+    std::abort();
 }
 
 std::ostream& operator<<(std::ostream& os, const locator::effective_replication_map::factory_key& key) {

--- a/readers/mutation_reader.cc
+++ b/readers/mutation_reader.cc
@@ -111,6 +111,7 @@ static mutation_fragment_v2::kind to_mutation_fragment_kind_v2(mutation_fragment
         case mutation_fragment::kind::partition_end:
             return mutation_fragment_v2::kind::partition_end;
     }
+    std::abort();
 }
 
 mutation_fragment_stream_validator::mutation_fragment_stream_validator(const ::schema& s)

--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -1090,6 +1090,7 @@ int repair_service::do_repair_start(sstring keyspace, std::unordered_map<sstring
                     try {
                         auto& ms = get_messaging();
                         auto resp = co_await ser::partition_checksum_rpc_verbs::send_repair_flush_hints_batchlog(&ms, netw::msg_addr(node), req);
+                        (void)resp; // nothing to do with response yet
                     } catch (...) {
                         rlogger.warn("repair[{}]: Sending repair_flush_hints_batchlog to node={}, participants={}, failed: {}",
                                 uuid, node, participants, std::current_exception());

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -2703,6 +2703,7 @@ private:
             try {
                 auto& ms = _ri.messaging.local();
                 repair_update_system_table_response resp = co_await ser::partition_checksum_rpc_verbs::send_repair_update_system_table(&ms, netw::messaging_service::msg_addr(node), req);
+                (void)resp;  // nothing to do with the response yet
                 rlogger.debug("repair[{}]: Finished to update system.repair_history table of node {}", _ri.id.uuid, node);
             } catch (...) {
                 rlogger.warn("repair[{}]: Failed to update system.repair_history table of node {}: {}", _ri.id.uuid, node, std::current_exception());

--- a/service/forward_service.cc
+++ b/service/forward_service.cc
@@ -57,7 +57,7 @@ static inet_address_vector_replica_set get_live_endpoints(replica::keyspace& ks,
     auto eps = erm->get_natural_endpoints_without_node_being_replaced(token);
     auto itend = boost::range::remove_if(
         eps,
-        std::not1(std::bind1st(std::mem_fn(&gms::gossiper::is_alive), &gms::get_local_gossiper()))
+        std::not_fn(std::bind_front(std::mem_fn(&gms::gossiper::is_alive), &gms::get_local_gossiper()))
     );
     eps.erase(itend, eps.end());
     return eps;

--- a/tombstone_gc.cc
+++ b/tombstone_gc.cc
@@ -115,6 +115,7 @@ get_gc_before_for_range_result get_gc_before_for_range(schema_ptr s, const dht::
         return {min_gc_before, max_gc_before, knows_entire_range};
     }
     }
+    std::abort();
 }
 
 gc_clock::time_point get_gc_before_for_key(schema_ptr s, const dht::decorated_key& dk, const gc_clock::time_point& query_time) {
@@ -151,6 +152,7 @@ gc_clock::time_point get_gc_before_for_key(schema_ptr s, const dht::decorated_ke
                 s->ks_name(), s->cf_name(), dk, repair_timestamp, propagation_delay.count(), gc_before);
         return gc_before;
     }
+    std::abort();
 }
 
 void update_repair_time(schema_ptr s, const dht::token_range& range, gc_clock::time_point repair_time) {

--- a/utils/result_loop.hh
+++ b/utils/result_loop.hh
@@ -229,7 +229,6 @@ public:
 
 template<typename Iterator, typename Mapper, typename Initial, typename Reducer>
 requires requires (Iterator i, Mapper mapper, Initial initial, Reducer reduce) {
-    ExceptionContainerResult<Initial>;
     *i++;
     { i != i } -> std::convertible_to<bool>;
     { mapper(*i) } -> ExceptionContainerResultFuture<>;


### PR DESCRIPTION
gcc 12 checks some things that clang doesn't, resulting in compile errors.
This series fixes some of theses issues, but still builds (and tests) with clang.

Unfortunately, we still don't have a clean gcc build due to an outstanding bug [1].

[1] https://gcc.gnu.org/bugzilla/show_bug.cgi?id=98056