### PR TITLE
gms: gossiper: coroutinize `apply_state` functions

### DIFF
--- a/gms/gossiper.cc
+++ b/gms/gossiper.cc
@@ -596,12 +596,11 @@ future<> gossiper::do_apply_state_locally(gms::inet_address node, const endpoint
     }
 }
 
-// Runs inside seastar::async context
-void gossiper::apply_state_locally_without_listener_notification(std::unordered_map<inet_address, endpoint_state> map) {
+future<> gossiper::apply_state_locally_without_listener_notification(std::unordered_map<inet_address, endpoint_state> map) {
     for (auto& x : map) {
         const inet_address& node = x.first;
         const endpoint_state& remote_state = x.second;
-        do_apply_state_locally(node, remote_state, false).get();
+        co_await do_apply_state_locally(node, remote_state, false);
     }
 }
 
@@ -1893,7 +1892,7 @@ future<> gossiper::do_shadow_round(std::unordered_set<gms::inet_address> nodes) 
                 });
             }).get();
             for (auto& response : responses) {
-                apply_state_locally_without_listener_notification(response.endpoint_state_map);
+                apply_state_locally_without_listener_notification(response.endpoint_state_map).get();
             }
             if (!nodes_talked.empty()) {
                 break;

--- a/gms/gossiper.hh
+++ b/gms/gossiper.hh
@@ -441,7 +441,7 @@ private:
     void do_apply_state_locally(gms::inet_address node, const endpoint_state& remote_state, bool listener_notification);
     void apply_state_locally_without_listener_notification(std::unordered_map<inet_address, endpoint_state> map);
 
-    void apply_new_states(inet_address addr, endpoint_state& local_state, const endpoint_state& remote_state);
+    future<> apply_new_states(inet_address addr, endpoint_state& local_state, const endpoint_state& remote_state);
 
     // notify that a local application state is going to change (doesn't get triggered for remote changes)
     future<> do_before_change_notifications(inet_address addr, const endpoint_state& ep_state, const application_state& ap_state, const versioned_value& new_value);

--- a/gms/gossiper.hh
+++ b/gms/gossiper.hh
@@ -439,7 +439,7 @@ public:
     inet_address_vector_replica_set endpoint_filter(const sstring& local_rack, const std::unordered_map<sstring, std::unordered_set<gms::inet_address>>& endpoints);
 private:
     future<> do_apply_state_locally(gms::inet_address node, const endpoint_state& remote_state, bool listener_notification);
-    void apply_state_locally_without_listener_notification(std::unordered_map<inet_address, endpoint_state> map);
+    future<> apply_state_locally_without_listener_notification(std::unordered_map<inet_address, endpoint_state> map);
 
     future<> apply_new_states(inet_address addr, endpoint_state& local_state, const endpoint_state& remote_state);
 

--- a/gms/gossiper.hh
+++ b/gms/gossiper.hh
@@ -438,7 +438,7 @@ public:
     // filter `endpoints` by `local_rack`
     inet_address_vector_replica_set endpoint_filter(const sstring& local_rack, const std::unordered_map<sstring, std::unordered_set<gms::inet_address>>& endpoints);
 private:
-    void do_apply_state_locally(gms::inet_address node, const endpoint_state& remote_state, bool listener_notification);
+    future<> do_apply_state_locally(gms::inet_address node, const endpoint_state& remote_state, bool listener_notification);
     void apply_state_locally_without_listener_notification(std::unordered_map<inet_address, endpoint_state> map);
 
     future<> apply_new_states(inet_address addr, endpoint_state& local_state, const endpoint_state& remote_state);


### PR DESCRIPTION
Mostly trivial conversions to coroutines in the gossiper to facilitate code readability.