### PR TITLE
Add new Python test dependencies to dbuild

### DIFF
--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -31,8 +31,10 @@ debian_base_packages=(
     clang
     gdb
     liblua5.3-dev
+    python3-aiohttp
     python3-pyparsing
     python3-colorama
+    python3-tabulate
     libsnappy-dev
     libjsoncpp-dev
     rapidjson-dev
@@ -67,9 +69,11 @@ fedora_packages=(
     maven
     patchelf
     python3
+    python3-aiohttp
     python3-pip
     python3-magic
     python3-colorama
+    python3-tabulate
     python3-boto3
     python3-pytest
     python3-redis


### PR DESCRIPTION
In order to see that the new tests pass dbuild at all, one must first dbuild dependencies which appear in test.py.v3 branch.