### PR TITLE
expressions: avoid invalid behavior when evaluating map subscripts

### DIFF
--- a/test/cql-pytest/test_filtering.py
+++ b/test/cql-pytest/test_filtering.py
@@ -14,6 +14,7 @@ import pytest
 from util import new_test_table
 from cassandra.protocol import InvalidRequest
 from cassandra.connection import DRIVER_NAME, DRIVER_VERSION
+from cassandra.query import UNSET_VALUE
 
 # When filtering for "x > 0" or "x < 0", rows with an unset value for x
 # should not match the filter.
@@ -167,3 +168,51 @@ def test_filtering_with_in_relation(cql, test_keyspace, cassandra_bug):
         assert set(res) == set([(1,2,3,4), (3,4,5,6)])
         res = cql.execute(f"select * from {table} where v in (5,7) ALLOW FILTERING")
         assert set(res) == set([(2,3,4,5), (4,5,6,7)])
+
+# Test that subscripts in expressions work as expected. They should only work
+# on map columns, and must have the correct type.
+# This test is a superset of test test_null.py::test_map_subscript_null which
+# tests only the special case of a null subscript.
+# Reproduces #10361
+@pytest.mark.xfail(reason="Issue #10361")
+def test_filtering_with_subscript(cql, test_keyspace):
+    with new_test_table(cql, test_keyspace,
+            "p int, m1 map<int, int>, m2 map<text, text>, s set<int>, PRIMARY KEY (p)") as table:
+        # Check for *errors* in subscript expressions - such as wrong type or
+        # null - with an empty table. This will force the implementation to
+        # check for these errors before actually evaluating the filter
+        # expression - because there will be no rows to filter.
+
+        # A subscript is not allowed on a non-map column (in this case, a set)
+        with pytest.raises(InvalidRequest, match='cannot be used as a map'):
+            cql.execute(f"SELECT p FROM {table} WHERE s[2] = 3 ALLOW FILTERING")
+        # A wrong type is passed for the subscript is not allowed
+        with pytest.raises(InvalidRequest, match='key\(m1\)'):
+            cql.execute(f"select p from {table} where m1['black'] = 2 ALLOW FILTERING")
+        with pytest.raises(InvalidRequest, match='key\(m2\)'):
+            cql.execute(f"select p from {table} where m2[1] = 2 ALLOW FILTERING")
+        # A "null" is not allowed as a key (reproduces #10361)
+        with pytest.raises(InvalidRequest, match='Unsupported null map key for column m1'):
+            cql.execute(f"select p from {table} where m1[null] = 2 ALLOW FILTERING")
+        with pytest.raises(InvalidRequest, match='Unsupported null map key for column m2'):
+            cql.execute(f"select p from {table} where m2[null] = 'hi' ALLOW FILTERING")
+        # Similar to above checks, but using a prepared statement. We can't
+        # cause the driver to send the wrong type to a bound variable, so we
+        # can't check that case unfortunately, but we have a new UNSET_VALUE
+        # case.
+        stmt = cql.prepare(f"select p from {table} where m1[?] = 2 ALLOW FILTERING")
+        with pytest.raises(InvalidRequest, match='Unsupported null map key for column m1'):
+            cql.execute(stmt, [None])
+        with pytest.raises(InvalidRequest, match='Unsupported unset map key for column m1'):
+            cql.execute(stmt, [UNSET_VALUE])
+
+        # Finally, check for sucessful filtering with subscripts. For that we
+        # need to add some data:
+        cql.execute("INSERT INTO "+table+" (p, m1, m2) VALUES (1, {1:2, 3:4}, {'dog':'cat', 'hi':'hello'})")
+        cql.execute("INSERT INTO "+table+" (p, m1, m2) VALUES (2, {2:3, 4:5}, {'man':'woman', 'black':'white'})")
+        res = cql.execute(f"select p from {table} where m1[1] = 2 ALLOW FILTERING")
+        assert list(res) == [(1,)]
+        res = cql.execute(f"select p from {table} where m2['black'] = 'white' ALLOW FILTERING")
+        assert list(res) == [(2,)]
+        res = cql.execute(stmt, [1])
+        assert list(res) == [(1,)]

--- a/test/cql-pytest/test_null.py
+++ b/test/cql-pytest/test_null.py
@@ -160,7 +160,15 @@ def test_filtering_null_comparison_no_filtering(cql, table1):
         cql.execute(f"SELECT c FROM {table1} WHERE p='x' AND m CONTAINS KEY NULL")
 
 # Test that null subscript m[null] is caught as the appropriate invalid-
-# request error, and not some internal server error as we had in #10361.
+# request error, and not some internal server error as we had in #10361
+# or crash as in #10399.
+# This test is a subset of test_filtering.py::test_filtering_with_subscript
+# which tests additional cases of subscripts, not just with nulls.
+# However, another difference between this test and the other one is that
+# this test uses a shared table (table1), so when this entire test file is
+# run, the following test sees a non-empty table so it needs to invoke the
+# filtering function. This makes this test able to reproduce #10399 while
+# the other test can't
 @pytest.mark.xfail(reason="Issue #10361")
 def test_map_subscript_null(cql, table1):
     with pytest.raises(InvalidRequest, match='null'):


### PR DESCRIPTION
When we have an expression with a null or unset subscript, i.e.,
m[?] with ? bound to a null or UNSET_VALUE, the current code which
evaluates this expression implicitly assumes that the subscript is
a valid value of the right type and deserializes it. This assumption
can cause crashes (see #10399) or bizarre errors (see #10361).

In this patch, when we see an invalid subscript, we return a nullopt
signifying that the expression could not be calculated. When this
expression is used as a filter, the considered row will silently not
match.

This patch fixes #10399 because requests with null or unset values
will no longer cause dereferencing invalid data. However,
issue #10361 remains open because when a null or unset_value *constant*
is used in a filtering expression, we expect to see an error - not
silently matching nothing.

The rationale of the fix here is that we'll need to add, in a later patch,
an expression-resolution stage which checks whether an expression after
binding - but before evaluation - has a null or unset constant subscript
(we need to verify this even if there is no data in the table). But even
if we do that, and the if() introduced in this patch into evaluation
becomess less criticial, it will still be important in the future if we
add support for non-constant subscripts (e.g., m[a] where a is another
column) - we'll still need the check introduced in this patch to just
skip rows with missing "a" instead of crashing on them.

In this patch we also introduce another test which demonstrates the
fact that we don't generate errors on null or UNSET_VALUE subscripts.
After this patch, the new test will no longer crash or cause weird
errors, but it won't cause any errors at all (just empty results),
so it is another, better, reproducer for #10361. The new test also
starts with an empty table, so it verifies that the validation we're
missing must be done before evaluating the expression - not during
the evaluation itself (which won't happen when the the table is empty).

Fixes #10399.

Signed-off-by: Nadav Har'El <nyh@scylladb.com>