### PR TITLE
sstables: Fix deletion of partial SSTables

### DIFF
--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -2679,7 +2679,6 @@ fsync_directory(const io_error_handler& error_handler, sstring dirname) {
 
 static future<>
 remove_by_toc_name(sstring sstable_toc_name) {
-    auto dir = parent_path(sstable_toc_name);
     sstring prefix = sstable_toc_name.substr(0, sstable_toc_name.size() - sstable_version_constants::TOC_SUFFIX.size());
     sstring new_toc_name = prefix + sstable_version_constants::TEMPORARY_TOC_SUFFIX;
 
@@ -2687,7 +2686,7 @@ remove_by_toc_name(sstring sstable_toc_name) {
     if (co_await sstable_io_check(sstable_write_error_handler, file_exists, sstable_toc_name)) {
         // If new_toc_name exists it will be atomically replaced.  See rename(2)
         co_await sstable_io_check(sstable_write_error_handler, rename_file, sstable_toc_name, new_toc_name);
-        co_await fsync_directory(sstable_write_error_handler, dir);
+        co_await fsync_directory(sstable_write_error_handler, parent_path(new_toc_name));
     } else {
         if (!co_await sstable_io_check(sstable_write_error_handler, file_exists, new_toc_name)) {
             sstlog.warn("Unable to delete {} because it doesn't exist.", sstable_toc_name);
@@ -2729,7 +2728,7 @@ remove_by_toc_name(sstring sstable_toc_name) {
             sstlog.debug("Forgiving ENOENT when deleting file {}", fname);
         }
     });
-    co_await fsync_directory(sstable_write_error_handler, dir);
+    co_await fsync_directory(sstable_write_error_handler, parent_path(new_toc_name));
     co_await sstable_io_check(sstable_write_error_handler, remove_file, new_toc_name);
 }
 

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -2663,10 +2663,11 @@ static inline sstring parent_path(const sstring& fname) {
     return fs::canonical(fs::path(fname)).parent_path().string();
 }
 
+// Must be called on a directory.
 future<>
-fsync_directory(const io_error_handler& error_handler, sstring fname) {
+fsync_directory(const io_error_handler& error_handler, sstring dirname) {
     return ::sstable_io_check(error_handler, [&] {
-        return open_checked_directory(error_handler, parent_path(fname)).then([] (file f) {
+        return open_checked_directory(error_handler, dirname).then([] (file f) {
             return do_with(std::move(f), [] (file& f) {
                 return f.flush().then([&f] {
                     return f.close();


### PR DESCRIPTION
If SSTable write fails, it will leave a partial sst which contains
a temporary TOC in addition to other components partially written.
temporary TOC content is written upfront, to allow us from deleting
all partial components using the former content if write fails.

After commit e5fc4b6, partial sst cannot be deleted because it is
incorrectly assuming all files being deleted unconditionally has
TOC, but that's not true for partial files that need to be removed.
The consequence of this is that space of partial files cannot be
reclaimed, making it worse for Scylla to recover from ENOSPC,
which could happen by selecting a set of files for compaction with
higher chance of suceeeding given the free space.
Let's fix this by taking into account temp TOC for partial files.

Fixes #10410.

Signed-off-by: Raphael S. Carvalho <raphaelsc@scylladb.com>