### PR TITLE
scripts: use "out()" function for all capture_output subprocesses

### DIFF
--- a/dist/common/scripts/scylla_raid_setup
+++ b/dist/common/scripts/scylla_raid_setup
@@ -96,7 +96,7 @@ if __name__ == '__main__':
         print('{} is already mounted'.format(mount_at))
         sys.exit(1)
 
-    mntunit_bn = run('systemd-escape -p --suffix=mount {}'.format(mount_at), shell=True, check=True, capture_output=True, encoding='utf-8').stdout.strip()
+    mntunit_bn = out('systemd-escape -p --suffix=mount {}'.format(mount_at))
     mntunit = Path('/etc/systemd/system/{}'.format(mntunit_bn))
     if mntunit.exists():
         print('mount unit {} already exists'.format(mntunit))
@@ -145,14 +145,14 @@ if __name__ == '__main__':
         confpath = '/etc/mdadm.conf'
 
     if raid:
-        res = run('mdadm --detail --scan', shell=True, check=True, capture_output=True, encoding='utf-8').stdout.strip()
+        res = out('mdadm --detail --scan')
         with open(confpath, 'w') as f:
             f.write(res)
             f.write('\nMAILADDR root')
 
     os.makedirs(mount_at, exist_ok=True)
 
-    uuid = run(f'blkid -s UUID -o value {fsdev}', shell=True, check=True, capture_output=True, encoding='utf-8').stdout.strip()
+    uuid = out(f'blkid -s UUID -o value {fsdev}')
     after = 'local-fs.target'
     wants = ''
     if raid and args.raid_level != '0':

--- a/dist/common/scripts/scylla_selinux_setup
+++ b/dist/common/scripts/scylla_selinux_setup
@@ -22,7 +22,7 @@ if __name__ == '__main__':
         print("scylla_selinux_setup only supports Red Hat variants")
         sys.exit(0)
 
-    res = run('sestatus', shell=True, check=True, capture_output=True, encoding='utf-8').stdout.strip()
+    res = out('sestatus')
     if res.split(None)[2] != 'disabled':
         run('setenforce 0', shell=True, check=True)
         cfg = sysconfig_parser('/etc/sysconfig/selinux')

--- a/dist/common/scripts/scylla_setup
+++ b/dist/common/scripts/scylla_setup
@@ -125,9 +125,9 @@ def do_verify_package_and_exit(pkg):
 
 def list_block_devices():
     devices = []
-    s = run('lsblk --help', shell=True, check=True, capture_output=True, encoding='utf-8').stdout.strip()
+    s = out('lsblk --help')
     if re.search(r'\s*-p', s, flags=re.MULTILINE):
-        s = run('lsblk -pnr', shell=True, check=True, capture_output=True, encoding='utf-8').stdout.strip()
+        s = out('lsblk -pnr')
         res = re.findall(r'^(\S+) \S+ \S+ \S+ \S+ (\S+)', s, flags=re.MULTILINE)
         for r in res:
             if r[1] != 'rom' and r[1] != 'loop':
@@ -371,20 +371,20 @@ if __name__ == '__main__':
                 hk_restart.mask()
                 hk_restart.stop()
 
-        cur_version=run('scylla --version', shell=True, capture_output=True, encoding='utf-8').stdout.strip()
+        cur_version=out('scylla --version')
         if len(cur_version) > 0:
             if is_debian_variant():
-                new_version=run('sudo -u scylla {}/scylla-housekeeping --uuid-file /var/lib/scylla-housekeeping/housekeeping.uuid --repo-files \'/etc/apt/sources.list.d/scylla*.list\' version --version {} --mode i'.format(scriptsdir(), cur_version), shell=True, capture_output=True, encoding='utf-8', timeout=HOUSEKEEPING_TIMEOUT).stdout.strip()
+                new_version=out('sudo -u scylla {}/scylla-housekeeping --uuid-file /var/lib/scylla-housekeeping/housekeeping.uuid --repo-files \'/etc/apt/sources.list.d/scylla*.list\' version --version {} --mode i'.format(scriptsdir(), cur_version), timeout=HOUSEKEEPING_TIMEOUT)
             else:
-                new_version=run('sudo -u scylla {}/scylla-housekeeping --uuid-file /var/lib/scylla-housekeeping/housekeeping.uuid --repo-files \'/etc/yum.repos.d/scylla*.repo\' version --version {} --mode i'.format(scriptsdir(), cur_version), shell=True, capture_output=True, encoding='utf-8', timeout=HOUSEKEEPING_TIMEOUT).stdout.strip()
+                new_version=out('sudo -u scylla {}/scylla-housekeeping --uuid-file /var/lib/scylla-housekeeping/housekeeping.uuid --repo-files \'/etc/yum.repos.d/scylla*.repo\' version --version {} --mode i'.format(scriptsdir(), cur_version), timeout=HOUSEKEEPING_TIMEOUT)
             if len(new_version) > 0:
                 print(new_version)
         else:
             if is_debian_variant():
-                new_version=run('sudo -u scylla {}/scylla-housekeeping --uuid-file /var/lib/scylla-housekeeping/housekeeping.uuid --repo-files \'/etc/apt/sources.list.d/scylla*.list\' version --version unknown --mode u'.format(scriptsdir()), shell=True, capture_output=True, encoding='utf-8', timeout=HOUSEKEEPING_TIMEOUT).stdout.strip()
+                new_version=out('sudo -u scylla {}/scylla-housekeeping --uuid-file /var/lib/scylla-housekeeping/housekeeping.uuid --repo-files \'/etc/apt/sources.list.d/scylla*.list\' version --version unknown --mode u'.format(scriptsdir()), timeout=HOUSEKEEPING_TIMEOUT)
             else:
-                new_version=run('sudo -u scylla {}/scylla-housekeeping --uuid-file /var/lib/scylla-housekeeping/housekeeping.uuid --repo-files \'/etc/yum.repos.d/scylla*.repo\' version --version unknown --mode u'.format(scriptsdir()), shell=True, capture_output=True, encoding='utf-8', timeout=HOUSEKEEPING_TIMEOUT)
-            print('A Scylla executable was not found, please check your installation {}'.format(new_version))
+                new_version=out('sudo -u scylla {}/scylla-housekeeping --uuid-file /var/lib/scylla-housekeeping/housekeeping.uuid --repo-files \'/etc/yum.repos.d/scylla*.repo\' version --version unknown --mode u'.format(scriptsdir()))
+            print('A Scylla executable was not found, please check your installation {}'.format(new_version), timeout=HOUSEKEEPING_TIMEOUT)
 
         if is_redhat_variant():
             selinux_setup = interactive_ask_service('Do you want to disable SELinux?', 'Yes - disables SELinux. Choosing Yes greatly improves performance. No - keeps SELinux activated.', selinux_setup)
@@ -482,7 +482,7 @@ if __name__ == '__main__':
             run_setup_script('Performance Tuning', 'scylla_sysconfig_setup --nic {nic} {setup_args}'.format(nic=args.nic, setup_args=setup_args))
 
     if is_nonroot():
-        params = run('systemctl --no-pager show user@1000.service', shell=True, check=True, capture_output=True, encoding='utf-8').stdout.strip()
+        params = out('systemctl --no-pager show user@1000.service')
         res = re.findall(r'^LimitNOFILE=(.*)$', params, flags=re.MULTILINE)
         if res and int(res[0]) < 10000:
             colorprint('{red}NOFILE hard limit is too low, enabling developer mode{nocolor}')

--- a/dist/common/scripts/scylla_swap_setup
+++ b/dist/common/scripts/scylla_swap_setup
@@ -78,7 +78,7 @@ if __name__ == '__main__':
     run('dd if=/dev/zero of={} bs=1M count={}'.format(swapfile, swapsize_mb), shell=True, check=True)
     swapfile.chmod(0o600)
     run('mkswap -f {}'.format(swapfile), shell=True, check=True)
-    swapunit_bn = run('systemd-escape -p --suffix=swap {}'.format(swapfile), shell=True, check=True, capture_output=True, encoding='utf-8').stdout.strip()
+    swapunit_bn = out('systemd-escape -p --suffix=swap {}'.format(swapfile))
     swapunit = Path('/etc/systemd/system/{}'.format(swapunit_bn))
     if swapunit.exists():
         print('swap unit {} already exists'.format(swapunit))

--- a/dist/common/scripts/scylla_sysconfig_setup
+++ b/dist/common/scripts/scylla_sysconfig_setup
@@ -88,7 +88,7 @@ if __name__ == '__main__':
     ethdrv = ''
     ethpciid = ''
     if network_mode == 'dpdk':
-        dpdk_status = run('/opt/scylladb/scripts/dpdk-devbind.py --status', shell=True, check=True, capture_output=True, encoding='utf-8').stdout.strip()
+        dpdk_status = out('/opt/scylladb/scripts/dpdk-devbind.py --status')
         match = re.search('if={} drv=(\S+)'.format(ifname), dpdk_status, flags=re.MULTILINE)
         ethdrv = match.group(1)
         match = re.search('^(\\S+:\\S+:\\S+\.\\S+) [^\n]+ if={} '.format(ifname), dpdk_status, flags=re.MULTILINE)

--- a/dist/common/scripts/scylla_util.py
+++ b/dist/common/scripts/scylla_util.py
@@ -172,7 +172,7 @@ SYSTEM_PARTITION_UUIDS = [
 ]
 
 def get_partition_uuid(dev):
-    return run(f'lsblk -n -oPARTTYPE {dev}', shell=True, check=True, capture_output=True, encoding='utf-8').stdout.strip()
+    return out(f'lsblk -n -oPARTTYPE {dev}')
 
 def is_system_partition(dev):
     uuid = get_partition_uuid(dev)
@@ -268,7 +268,7 @@ def get_set_nic_and_disks_config_value(cfg):
 
 
 def swap_exists():
-    swaps = run('swapon --noheadings --raw', shell=True, check=True, capture_output=True, encoding='utf-8').stdout.strip()
+    swaps = out('swapon --noheadings --raw')
     return True if swaps != '' else False
 
 def pkg_error_exit(pkg):
@@ -378,7 +378,7 @@ class systemd_unit:
         return run('systemctl {} disable {}'.format(self.ctlparam, self._unit), shell=True, check=True)
 
     def is_active(self):
-        return run('systemctl {} is-active {}'.format(self.ctlparam, self._unit), shell=True, capture_output=True, encoding='utf-8').stdout.strip()
+        return out('systemctl {} is-active {}'.format(self.ctlparam, self._unit))
 
     def mask(self):
         return run('systemctl {} mask {}'.format(self.ctlparam, self._unit), shell=True, check=True)


### PR DESCRIPTION
On acaf0bb we applied out() just for perftune.py because we had issue #10390
with this script.
But the issue can happen with other commands too, let's apply it to all
commands which uses capture_output.

related #10390