### PR TITLE
TWCS: improve estimated remaining tasks

### DIFF
--- a/compaction/time_window_compaction_strategy.cc
+++ b/compaction/time_window_compaction_strategy.cc
@@ -217,6 +217,7 @@ time_window_compaction_strategy::get_sstables_for_compaction(table_state& table_
     auto compaction_time = gc_clock::now();
 
     if (candidates.empty()) {
+        _estimated_remaining_tasks = 0;
         return compaction_descriptor();
     }
 


### PR DESCRIPTION
This series contains 2 changes around `time_window_compaction_strategy::update_estimated_compaction_by_tasks`:
- reset `_estimated_remaining_tasks` to zero when running out of candidates (that fixes #10418 in 4.6)
- improve estimate for `bucket_compaction_mode::major`

Test: unit(dev)
DTest: `resharding_test.py::TestReshardingTombstonesSingleNode::test_disable_tombstone_removal_during_reshard[1-TimeWindowCompactionStrategy-15]`