### PR TITLE
Fix map subscript crashes when map or subscript is null

### DIFF
--- a/cql3/expr/expression.cc
+++ b/cql3/expr/expression.cc
@@ -177,6 +177,35 @@ static managed_bytes_opt get_value(const column_maybe_subscripted& col, const co
             const auto& data_map = value_cast<map_type_impl::native_type>(deserialized);
             const auto key = evaluate(s->sub, options);
             auto&& key_type = col_type->name_comparator();
+            if (key.is_null()) {
+                // For m[null] return null.
+                // This is different from Cassandra - which treats m[null]
+                // as an invalid request error. But m[null] -> null is more
+                // consistent with our usual null treatement (e.g., both
+                // null[2] and null < 2 return null). It will also allow us
+                // to support non-constant subscripts (e.g., m[a]) where "a"
+                // may be null in some rows and non-null in others, and it's
+                // not an error.
+                return std::nullopt;
+            }
+            if (key.is_unset_value()) {
+                // An m[?] with ? bound to UNSET_VALUE is a invalid query.
+                // We could have detected it earlier while binding, but since
+                // we currently don't, we must protect the following code
+                // which can't work with an UNSET_VALUE. Note that the
+                // placement of this check here means that in an empty table,
+                // where we never need to evaluate the filter expression, this
+                // error will not be detected.
+                throw exceptions::invalid_request_exception(
+                    format("Unsupported unset map key for column {}",
+                        cdef->name_as_text()));
+            }
+            if (key.type != key_type) {
+                // This can't happen, we always verify the index type earlier.
+                throw std::logic_error(
+                    format("Tried to evaluate expression with wrong type for subscript of {}",
+                        cdef->name_as_text()));
+            }
             const auto found = key.view().with_linearized([&] (bytes_view key_bv) {
                 using entry = std::pair<data_value, data_value>;
                 return std::find_if(data_map.cbegin(), data_map.cend(), [&] (const entry& element) {

--- a/cql3/expr/expression.cc
+++ b/cql3/expr/expression.cc
@@ -168,7 +168,12 @@ static managed_bytes_opt get_value(const column_maybe_subscripted& col, const co
                         format("Column definition {} does not match any column in the query selection",
                         cdef->name_as_text()));
             }
-            const auto deserialized = cdef->type->deserialize(managed_bytes_view(*data.other_columns[index]));
+            const managed_bytes_opt& serialized = data.other_columns[index];
+            if (!serialized) {
+                // For null[i] we return null.
+                return std::nullopt;
+            }
+            const auto deserialized = cdef->type->deserialize(managed_bytes_view(*serialized));
             const auto& data_map = value_cast<map_type_impl::native_type>(deserialized);
             const auto key = evaluate(s->sub, options);
             auto&& key_type = col_type->name_comparator();

--- a/test/cql-pytest/test_filtering.py
+++ b/test/cql-pytest/test_filtering.py
@@ -14,6 +14,7 @@ import pytest
 from util import new_test_table
 from cassandra.protocol import InvalidRequest
 from cassandra.connection import DRIVER_NAME, DRIVER_VERSION
+from cassandra.query import UNSET_VALUE
 
 # When filtering for "x > 0" or "x < 0", rows with an unset value for x
 # should not match the filter.
@@ -167,3 +168,71 @@ def test_filtering_with_in_relation(cql, test_keyspace, cassandra_bug):
         assert set(res) == set([(1,2,3,4), (3,4,5,6)])
         res = cql.execute(f"select * from {table} where v in (5,7) ALLOW FILTERING")
         assert set(res) == set([(2,3,4,5), (4,5,6,7)])
+
+# Test that subscripts in expressions work as expected. They should only work
+# on map columns, and must have the correct type.
+# This test is a superset of test test_null.py::test_map_subscript_null which
+# tests only the special case of a null subscript.
+# Reproduces #10361
+@pytest.mark.xfail(reason="Issue #10361")
+def test_filtering_with_subscript(cql, test_keyspace):
+    with new_test_table(cql, test_keyspace,
+            "p int, m1 map<int, int>, m2 map<text, text>, s set<int>, PRIMARY KEY (p)") as table:
+        # Check for *errors* in subscript expressions - such as wrong type or
+        # null - with an empty table. This will force the implementation to
+        # check for these errors before actually evaluating the filter
+        # expression - because there will be no rows to filter.
+
+        # A subscript is not allowed on a non-map column (in this case, a set)
+        with pytest.raises(InvalidRequest, match='cannot be used as a map'):
+            cql.execute(f"SELECT p FROM {table} WHERE s[2] = 3 ALLOW FILTERING")
+        # A wrong type is passed for the subscript is not allowed
+        with pytest.raises(InvalidRequest, match='key\(m1\)'):
+            cql.execute(f"select p from {table} where m1['black'] = 2 ALLOW FILTERING")
+        with pytest.raises(InvalidRequest, match='key\(m2\)'):
+            cql.execute(f"select p from {table} where m2[1] = 2 ALLOW FILTERING")
+        # A "null" is not allowed as a key (reproduces #10361)
+        with pytest.raises(InvalidRequest, match='Unsupported null map key for column m1'):
+            cql.execute(f"select p from {table} where m1[null] = 2 ALLOW FILTERING")
+        with pytest.raises(InvalidRequest, match='Unsupported null map key for column m2'):
+            cql.execute(f"select p from {table} where m2[null] = 'hi' ALLOW FILTERING")
+        # Similar to above checks, but using a prepared statement. We can't
+        # cause the driver to send the wrong type to a bound variable, so we
+        # can't check that case unfortunately, but we have a new UNSET_VALUE
+        # case.
+        stmt = cql.prepare(f"select p from {table} where m1[?] = 2 ALLOW FILTERING")
+        with pytest.raises(InvalidRequest, match='Unsupported null map key for column m1'):
+            cql.execute(stmt, [None])
+        with pytest.raises(InvalidRequest, match='Unsupported unset map key for column m1'):
+            cql.execute(stmt, [UNSET_VALUE])
+
+        # Finally, check for sucessful filtering with subscripts. For that we
+        # need to add some data:
+        cql.execute("INSERT INTO "+table+" (p, m1, m2) VALUES (1, {1:2, 3:4}, {'dog':'cat', 'hi':'hello'})")
+        cql.execute("INSERT INTO "+table+" (p, m1, m2) VALUES (2, {2:3, 4:5}, {'man':'woman', 'black':'white'})")
+        res = cql.execute(f"select p from {table} where m1[1] = 2 ALLOW FILTERING")
+        assert list(res) == [(1,)]
+        res = cql.execute(f"select p from {table} where m2['black'] = 'white' ALLOW FILTERING")
+        assert list(res) == [(2,)]
+        res = cql.execute(stmt, [1])
+        assert list(res) == [(1,)]
+
+        # Try again the null-key request (reproduces #10361) that we did
+        # earlier when there was no data in the table. Now there is, and
+        # the scan brings up several rows, it may exercise different code
+        # paths.
+        with pytest.raises(InvalidRequest, match='Unsupported null map key for column m1'):
+            cql.execute(f"select p from {table} where m1[null] = 2 ALLOW FILTERING")
+
+# Beyond the tests of map subscript expressions above, also test what happens
+# when the expression is fine (e.g., m[2] = 3) but the *data* itself is null.
+# We used to have a bug there where we attempted to incorrectly deserialize
+# this null and get marshaling errors or even crashes - see issue #10417.
+# This test reproduces #10417, but not always - run with "--count" to
+# reproduce failures.
+@pytest.mark.xfail(reason="Issue #10417")
+def test_filtering_null_map_with_subscript(cql, test_keyspace):
+    schema = 'p text primary key, m map<int, int>'
+    with new_test_table(cql, test_keyspace, schema) as table:
+        cql.execute(f"INSERT INTO {table} (p) VALUES ('dog')")
+        assert list(cql.execute(f"SELECT p FROM {table} WHERE m[2] = 3 ALLOW FILTERING")) == []

--- a/test/cql-pytest/test_filtering.py
+++ b/test/cql-pytest/test_filtering.py
@@ -230,7 +230,6 @@ def test_filtering_with_subscript(cql, test_keyspace):
 # this null and get marshaling errors or even crashes - see issue #10417.
 # This test reproduces #10417, but not always - run with "--count" to
 # reproduce failures.
-@pytest.mark.xfail(reason="Issue #10417")
 def test_filtering_null_map_with_subscript(cql, test_keyspace):
     schema = 'p text primary key, m map<int, int>'
     with new_test_table(cql, test_keyspace, schema) as table:

--- a/test/cql-pytest/test_null.py
+++ b/test/cql-pytest/test_null.py
@@ -159,9 +159,16 @@ def test_filtering_null_comparison_no_filtering(cql, table1):
     with pytest.raises(InvalidRequest, match='ALLOW FILTERING'):
         cql.execute(f"SELECT c FROM {table1} WHERE p='x' AND m CONTAINS KEY NULL")
 
-# Test that null subscript m[null] is caught as the appropriate invalid-
-# request error, and not some internal server error or crash as we had in
-# #10361, #10399 and #10417.
+# Cassandra considers the null subscript 'm[null]' to be an invalid request.
+# In Scylla we decided to it differently (we think better): m[null] is simply
+# a null, so the filter 'WHERE m[null] = 3' is not an error - it just doesn't
+# match anything. This is more consistent with our usual null handling (null[2]
+# and null < 2 are both defined as returning null), and will also allow us
+# in the future to support non-constant subscript - for example m[a] where
+# the column a can be null for some rows and non-null for other rows.
+# Before we implemented the above decision, we had multiple bugs in this case,
+# resulting in bizarre errors and even crashes (see #10361, #10399 and #10417).
+#
 # Because this test uses a shared table (table1), then depending on how it's
 # run, it sometimes sees an empty table and sometimes a table with data
 # (and null values for the map m...), so this test mixes several different
@@ -169,9 +176,6 @@ def test_filtering_null_comparison_no_filtering(cql, table1):
 # by test_filtering.py::test_filtering_with_subscript and
 # test_filtering.py::test_filtering_null_map_with_subscript so this test
 # should eventually be deleted.
-@pytest.mark.xfail(reason="Issue #10361, #10399")
-def test_map_subscript_null(cql, table1):
-    with pytest.raises(InvalidRequest, match='null'):
-        cql.execute(f"SELECT p FROM {table1} WHERE m[null] = 3 ALLOW FILTERING")
-    with pytest.raises(InvalidRequest, match='null'):
-        cql.execute(cql.prepare(f"SELECT p FROM {table1} WHERE m[?] = 3 ALLOW FILTERING"), [None])
+def test_map_subscript_null(cql, table1, cassandra_bug):
+    assert list(cql.execute(f"SELECT p FROM {table1} WHERE m[null] = 3 ALLOW FILTERING")) == []
+    assert list(cql.execute(cql.prepare(f"SELECT p FROM {table1} WHERE m[?] = 3 ALLOW FILTERING"), [None])) == []

--- a/test/cql-pytest/test_null.py
+++ b/test/cql-pytest/test_null.py
@@ -169,7 +169,7 @@ def test_filtering_null_comparison_no_filtering(cql, table1):
 # by test_filtering.py::test_filtering_with_subscript and
 # test_filtering.py::test_filtering_null_map_with_subscript so this test
 # should eventually be deleted.
-@pytest.mark.xfail(reason="Issue #10361, #10399, 10417")
+@pytest.mark.xfail(reason="Issue #10361, #10399")
 def test_map_subscript_null(cql, table1):
     with pytest.raises(InvalidRequest, match='null'):
         cql.execute(f"SELECT p FROM {table1} WHERE m[null] = 3 ALLOW FILTERING")

--- a/test/cql-pytest/test_null.py
+++ b/test/cql-pytest/test_null.py
@@ -160,8 +160,16 @@ def test_filtering_null_comparison_no_filtering(cql, table1):
         cql.execute(f"SELECT c FROM {table1} WHERE p='x' AND m CONTAINS KEY NULL")
 
 # Test that null subscript m[null] is caught as the appropriate invalid-
-# request error, and not some internal server error as we had in #10361.
-@pytest.mark.xfail(reason="Issue #10361")
+# request error, and not some internal server error or crash as we had in
+# #10361, #10399 and #10417.
+# Because this test uses a shared table (table1), then depending on how it's
+# run, it sometimes sees an empty table and sometimes a table with data
+# (and null values for the map m...), so this test mixes several different
+# concerns and problems. The same problems are better covered separately
+# by test_filtering.py::test_filtering_with_subscript and
+# test_filtering.py::test_filtering_null_map_with_subscript so this test
+# should eventually be deleted.
+@pytest.mark.xfail(reason="Issue #10361, #10399, 10417")
 def test_map_subscript_null(cql, table1):
     with pytest.raises(InvalidRequest, match='null'):
         cql.execute(f"SELECT p FROM {table1} WHERE m[null] = 3 ALLOW FILTERING")


### PR DESCRIPTION
In the filtering expression "WHERE m[?] = 2", our implementation was buggy when either the map, or the subscript, was NULL (and also when the latter was an UNSET_VALUE). Our code ended up dereferencing null objects, yielding bizarre errors when we were lucky, or crashes when we were less lucky - see examples of both in issues #10361, #10399, #10401. The existing test `test_null.py::test_map_subscript_null` reproduced all these bugs sporadically.

In this series we improve the test to reproduce the separate bugs separately, and also reproduce additional problems (like the UNSET_VALUE). We then **define** both `m[NULL]` and `NULL[2]` to result in NULL instead of the existing undefined (and buggy, and crashing) behavior. This new definition is consistent with our usual SQL-inspired tradition that NULL "wins" in expressions - e.g., `NULL < 2` is also defined as resulting in NULL.

However, this decision differs from Cassandra, where `m[NULL]` is considered an error but `NULL[2]` is allowed. We believe that making `m[NULL]` be a NULL instead of an error is more consistent, and moreover - necessary if we ever want to support more complicate expressions like `m[a]`, where the column `a` can be NULL for some rows and non-NULL for others, and it doesn't make sense to return an "invalid query" error in the middle of the scan.

Fixes #10361
Fixes #10399 
Fixes #10401