### PR TITLE
Harden table truncate

### DIFF
--- a/dirty_memory_manager.hh
+++ b/dirty_memory_manager.hh
@@ -202,6 +202,12 @@ public:
         });
     }
 
+    future<flush_permit> get_all_flush_permits() {
+        return get_units(_background_work_flush_serializer, _max_background_work).then([this] (auto&& units) {
+            return this->get_flush_permit(std::move(units));
+        });
+    }
+
     bool has_extraneous_flushes_requested() const {
         return _extraneous_flushes > 0;
     }

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -219,17 +219,10 @@ public:
         }
     }
 
-    // Clears the active memtable and adds a new, empty one.
+    // Synchronously swaps the active memtable with a new, empty one,
+    // then, clears the existing memtable(s) asynchronously.
     // Exception safe.
-    void clear_and_add() {
-        auto mt = new_memtable();
-        _memtables.clear();
-        // emplace_back might throw only if _memtables was empty
-        // on entry. Otherwise, we rely on clear() not to release
-        // the vector capacity (See https://en.cppreference.com/w/cpp/container/vector/clear)
-        // and lw_shared_ptr being nothrow move constructible.
-        _memtables.emplace_back(std::move(mt));
-    }
+    future<> clear_and_add();
 
     size_t size() const {
         return _memtables.size();

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -1502,8 +1502,8 @@ future<> table::clear() {
             _commitlog->discard_completed_segments(_schema->id(), t->get_and_discard_rp_set());
         }
     }
-    _memtables->clear_and_add();
-    return _cache.invalidate(row_cache::external_updater([] { /* There is no underlying mutation source */ }));
+    co_await _memtables->clear_and_add();
+    co_await _cache.invalidate(row_cache::external_updater([] { /* There is no underlying mutation source */ }));
 }
 
 // NOTE: does not need to be futurized, but might eventually, depending on

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -1496,6 +1496,7 @@ bool table::can_flush() const {
 }
 
 future<> table::clear() {
+    auto permits = co_await _config.dirty_memory_manager->get_all_flush_permits();
     if (_commitlog) {
         for (auto& t : *_memtables) {
             _commitlog->discard_completed_segments(_schema->id(), t->get_and_discard_rp_set());

--- a/test/boost/database_test.cc
+++ b/test/boost/database_test.cc
@@ -93,6 +93,48 @@ SEASTAR_TEST_CASE(test_safety_after_truncate) {
     }, cfg);
 }
 
+// Reproducer for:
+//   https://github.com/scylladb/scylla/issues/10421
+//   https://github.com/scylladb/scylla/issues/10423
+SEASTAR_TEST_CASE(test_truncate_without_snapshot_during_writes) {
+    auto cfg = make_shared<db::config>();
+    cfg->auto_snapshot.set(false);
+    return do_with_cql_env_thread([] (cql_test_env& e) {
+        e.execute_cql("create table ks.cf (k text, v int, primary key (k));").get();
+        auto& db = e.local_db();
+        auto& ks = db.find_keyspace("ks");
+        auto& cf = db.find_column_family("ks", "cf");
+        auto s = cf.schema();
+        int count = 0;
+
+        auto insert_data = [&] (uint32_t begin, uint32_t end) {
+            return parallel_for_each(boost::irange(begin, end), [&] (auto i) -> future<> {
+                auto pkey = partition_key::from_single_value(*s, to_bytes(fmt::format("key{}", i)));
+                mutation m(s, pkey);
+                m.set_clustered_cell(clustering_key_prefix::make_empty(), "v", int32_t(42), {});
+                return do_with(freeze(m), [&] (const auto& fm) {
+                    return db.apply(s, fm, tracing::trace_state_ptr(), db::commitlog::force_sync::no, db::no_timeout).then([&] {
+                        return cf.flush();
+                    }).handle_exception([] (std::exception_ptr ex) {
+                        BOOST_FAIL(format("db.apply failed: {}", ex));
+                    });
+                }).then([&] {
+                    ++count;
+                });
+            });
+        };
+
+        uint32_t num_keys = 1000;
+
+        auto f0 = insert_data(0, num_keys);
+        auto f1 = do_until([&] { return count >= num_keys; }, [&] {
+            return db.truncate(ks, cf, [] { return make_ready_future<db_clock::time_point>(db_clock::now()); }, false /* with_snapshot */).then([] { return yield(); });
+        });
+        f0.get();
+        f1.get();
+    }, cfg);
+}
+
 SEASTAR_TEST_CASE(test_querying_with_limits) {
     return do_with_cql_env([](cql_test_env& e) {
         return seastar::async([&] {


### PR DESCRIPTION
This series fixes a few issue on the table truncate path:
- "memtable_list: safely futurize clear_and_add"
  - reinstates an async version of table::clear_and_add, just safe against #10421
- a unit test reproducing #10421 was added to make sure the new version is indeed safe.
- "table: clear: serialize with ongoing flush" fixes #10423
- a unit test reproducing #10423 was added

Fixes #10281
Fixes #10423

Test: unit(dev), database_test. test_truncate_without_snapshot_during_{writes,flushes} (debug)