### PR TITLE
multishard_mutation_query: do_query: stop ctx if lookup_readers fails

### DIFF
--- a/multishard_mutation_query.cc
+++ b/multishard_mutation_query.cc
@@ -746,11 +746,11 @@ future<typename ResultBuilder::result_type> do_query(
         ResultBuilder&& result_builder) {
     auto ctx = seastar::make_shared<read_context>(db, s, cmd, ranges, trace_state, timeout);
 
-    co_await ctx->lookup_readers(timeout);
-
     std::exception_ptr ex;
 
     try {
+        co_await ctx->lookup_readers(timeout);
+
         auto [last_ckey, result, unconsumed_buffer, compaction_state] = co_await read_page<ResultBuilder>(ctx, s, cmd, ranges, trace_state,
                 std::move(result_builder));
 


### PR DESCRIPTION
lookup_readers might fail after populating some readers
and those better be closed before returning the exception.

Fixes #10351

Signed-off-by: Benny Halevy <bhalevy@scylladb.com>