### PR TITLE
repair: Allow abort repair jobs in early stage

### DIFF
--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -319,10 +319,13 @@ tracker::tracker(size_t max_repair_memory)
 }
 
 void tracker::start(repair_uniq_id id) {
+    _pending_repairs.insert(id.uuid);
     _status[id.id] = repair_status::RUNNING;
 }
 
 void tracker::done(repair_uniq_id id, bool succeeded) {
+    _pending_repairs.erase(id.uuid);
+    _aborted_pending_repairs.erase(id.uuid);
     if (succeeded) {
         _status.erase(id.id);
     } else {
@@ -419,13 +422,17 @@ size_t tracker::nr_running_repair_jobs() {
     return count;
 }
 
+bool tracker::is_aborted(const utils::UUID& uuid) {
+    return _aborted_pending_repairs.contains(uuid);
+}
+
 void tracker::abort_all_repairs() {
-    size_t count = nr_running_repair_jobs();
+    _aborted_pending_repairs = _pending_repairs;
     for (auto& x : _repairs) {
         auto& ri = x.second;
         ri->abort();
     }
-    rlogger.info0("Aborted {} repair job(s)", count);
+    rlogger.info0("Aborted {} repair job(s), aborted={}", _aborted_pending_repairs.size(), _aborted_pending_repairs);
 }
 
 void tracker::abort_repair_node_ops(utils::UUID ops_uuid) {
@@ -1146,6 +1153,10 @@ int repair_service::do_repair_start(sstring keyspace, std::unordered_map<sstring
             }
         });
 
+        if (repair_tracker().is_aborted(id.uuid)) {
+            throw std::runtime_error("aborted by user request");
+        }
+
         for (auto shard : boost::irange(unsigned(0), smp::count)) {
             auto f = container().invoke_on(shard, [keyspace, table_ids, id, ranges, hints_batchlog_flushed,
                     data_centers = options.data_centers, hosts = options.hosts, ignore_nodes] (repair_service& local_repair) mutable {
@@ -1247,6 +1258,9 @@ future<> repair_service::do_sync_data_using_repair(
         auto table_ids = get_table_ids(db.local(), keyspace, cfs);
         std::vector<future<>> repair_results;
         repair_results.reserve(smp::count);
+        if (repair_tracker().is_aborted(id.uuid)) {
+            throw std::runtime_error("aborted by user request");
+        }
         for (auto shard : boost::irange(unsigned(0), smp::count)) {
             auto f = container().invoke_on(shard, [keyspace, table_ids, id, ranges, neighbors, reason, ops_uuid] (repair_service& local_repair) mutable {
                 auto data_centers = std::vector<sstring>();

--- a/repair/repair.hh
+++ b/repair/repair.hh
@@ -226,6 +226,8 @@ private:
     std::atomic_bool _shutdown alignas(seastar::cache_line_size);
     // Map repair id into repair_info.
     std::unordered_map<int, lw_shared_ptr<repair_info>> _repairs;
+    std::unordered_set<utils::UUID> _pending_repairs;
+    std::unordered_set<utils::UUID> _aborted_pending_repairs;
     // The semaphore used to control the maximum
     // ranges that can be repaired in parallel.
     named_semaphore _range_parallelism_semaphore;
@@ -251,6 +253,7 @@ public:
     future<repair_status> repair_await_completion(int id, std::chrono::steady_clock::time_point timeout);
     float report_progress(streaming::stream_reason reason);
     void abort_repair_node_ops(utils::UUID ops_uuid);
+    bool is_aborted(const utils::UUID& uuid);
 };
 
 future<uint64_t> estimate_partitions(seastar::sharded<replica::database>& db, const sstring& keyspace,


### PR DESCRIPTION
Consider this:

- User starts a repair job with http api
- User aborts all repair
- The repair_info object for the repair job is created
- The repair job is not aborted

In this patch, the repair uuid is recorded before repair_info object is
created, so that repair can now abort repair jobs in the early stage.

Fixes #10384