### PR TITLE
replica: database: move shard_of implementation to mutation layer

### DIFF
--- a/db/commitlog/commitlog_replayer.cc
+++ b/db/commitlog/commitlog_replayer.cc
@@ -246,7 +246,8 @@ future<> db::commitlog_replayer::impl::process(stats* s, commitlog::buffer_and_r
             return make_ready_future<>();
         }
 
-        auto shard = _db.local().shard_of(fm);
+        const auto& schema = *_db.local().find_column_family(uuid).schema();
+        auto shard = fm.shard_of(schema);
         return _db.invoke_on(shard, [this, cer = std::move(cer), &src_cm, rp, shard, s] (replica::database& db) mutable -> future<> {
             auto& fm = cer.mutation();
             // TODO: might need better verification that the deserialized mutation

--- a/frozen_mutation.hh
+++ b/frozen_mutation.hh
@@ -193,6 +193,10 @@ public:
     template<FlattenedConsumerV2 Consumer>
     auto consume(schema_ptr s, frozen_mutation_consumer_adaptor<Consumer>& adaptor) const -> frozen_mutation_consume_result<decltype(adaptor.consumer().consume_end_of_stream())>;
 
+    unsigned shard_of(const schema& s) const {
+        return dht::shard_of(s, dht::get_token(s, key()));
+    }
+
     struct printer {
         const frozen_mutation& self;
         schema_ptr schema;

--- a/mutation.hh
+++ b/mutation.hh
@@ -182,6 +182,10 @@ public:
     // Returns a subset of this mutation holding only information relevant for given clustering ranges.
     // Range tombstones will be trimmed to the boundaries of the clustering ranges.
     mutation sliced(const query::clustering_row_ranges&) const;
+
+    unsigned shard_of() const {
+        return dht::shard_of(*schema(), token());
+    }
 private:
     friend std::ostream& operator<<(std::ostream& os, const mutation& m);
 };

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -820,20 +820,6 @@ database::init_commitlog() {
     });
 }
 
-unsigned
-database::shard_of(const mutation& m) {
-    return dht::shard_of(*m.schema(), m.token());
-}
-
-unsigned
-database::shard_of(const frozen_mutation& m) {
-    // FIXME: This lookup wouldn't be necessary if we
-    // sent the partition key in legacy form or together
-    // with token.
-    schema_ptr schema = find_schema(m.column_family_id());
-    return dht::shard_of(*schema, dht::get_token(*schema, m.key()));
-}
-
 future<> database::update_keyspace(sharded<service::storage_proxy>& proxy, const sstring& name) {
     auto v = co_await db::schema_tables::read_schema_partition_for_keyspace(proxy, db::schema_tables::KEYSPACES, name);
     auto& ks = find_keyspace(name);

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1475,8 +1475,6 @@ public:
     future<> stop();
     future<> close_tables(table_kind kind_to_close);
 
-    unsigned shard_of(const mutation& m);
-    unsigned shard_of(const frozen_mutation& m);
     future<std::tuple<lw_shared_ptr<query::result>, cache_temperature>> query(schema_ptr, const query::read_command& cmd, query::result_options opts,
                                                                   const dht::partition_range_vector& ranges, tracing::trace_state_ptr trace_state,
                                                                   db::timeout_clock::time_point timeout);

--- a/test/boost/commitlog_test.cc
+++ b/test/boost/commitlog_test.cc
@@ -618,7 +618,7 @@ SEASTAR_TEST_CASE(test_commitlog_replay_invalid_key){
             auto fm = freeze(m);
             commitlog_entry_writer cew(s, fm, db::commitlog::force_sync::yes);
             cl.add_entry(m.column_family_id(), cew, db::no_timeout).get();
-            return db.shard_of(m);
+            return m.shard_of();
         };
 
         const auto shard = add_entry(bytes{});


### PR DESCRIPTION
We don't need the database to determine the shard of the mutation,
only its schema. So move the implementation to the respecive
definitions of mutation and frozen_mutation.

Signed-off-by: Benny Halevy <bhalevy@scylladb.com>