### PR TITLE
schema_tables: forward-declare user_function and user_aggerates

### DIFF
--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -33,6 +33,8 @@
 #include "system_distributed_keyspace.hh"
 #include "cql3/cql3_type.hh"
 #include "cql3/functions/functions.hh"
+#include "cql3/functions/user_function.hh"
+#include "cql3/functions/user_aggregate.hh"
 #include "cql3/util.hh"
 #include "types/list.hh"
 #include "types/set.hh"

--- a/db/schema_tables.hh
+++ b/db/schema_tables.hh
@@ -13,8 +13,6 @@
 #pragma once
 
 #include "mutation.hh"
-#include "cql3/functions/user_function.hh"
-#include "cql3/functions/user_aggregate.hh"
 #include "schema_fwd.hh"
 #include "schema_features.hh"
 #include "hashing.hh"
@@ -51,6 +49,13 @@ class storage_proxy;
 namespace gms {
 
 class feature_service;
+
+}
+
+namespace cql3::functions {
+
+class user_function;
+class user_aggregate;
 
 }
 

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -16,6 +16,7 @@
 #include "db/config.hh"
 #include "to_string.hh"
 #include "cql3/functions/functions.hh"
+#include "cql3/functions/user_function.hh"
 #include <seastar/core/seastar.hh>
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/reactor.hh>
@@ -61,6 +62,8 @@
 #include "replica/data_dictionary_impl.hh"
 #include "readers/multi_range.hh"
 #include "readers/multishard.hh"
+
+#include "lang/wasm.hh"
 
 using namespace std::chrono_literals;
 using namespace db;

--- a/service/migration_manager.cc
+++ b/service/migration_manager.cc
@@ -31,6 +31,7 @@
 #include "types/user.hh"
 #include "db/system_keyspace.hh"
 #include "cql3/functions/user_aggregate.hh"
+#include "cql3/functions/user_function.hh"
 
 #include "serialization_visitors.hh"
 #include "serializer.hh"


### PR DESCRIPTION
These bring in wasm.hh (though they really shouldn't) and make
everyone suffer. Forward declare instead and add missing includes
where needed.