### PR TITLE
compaction: get rid of reader v1

### DIFF
--- a/compaction/compaction.cc
+++ b/compaction/compaction.cc
@@ -1470,7 +1470,6 @@ public:
     }
 
     friend flat_mutation_reader_v2 make_scrubbing_reader(flat_mutation_reader_v2 rd, compaction_type_options::scrub::mode scrub_mode);
-    friend flat_mutation_reader make_scrubbing_reader(flat_mutation_reader rd, compaction_type_options::scrub::mode scrub_mode);
 };
 
 flat_mutation_reader_v2 make_scrubbing_reader(flat_mutation_reader_v2 rd, compaction_type_options::scrub::mode scrub_mode) {

--- a/compaction/compaction.cc
+++ b/compaction/compaction.cc
@@ -1150,7 +1150,7 @@ public:
         return "Cleaned";
     }
 
-    flat_mutation_reader::filter make_partition_filter() const {
+    flat_mutation_reader_v2::filter make_partition_filter() const {
         return [this] (const dht::decorated_key& dk) {
 #ifdef SEASTAR_DEBUG
             // sstables should never be shared with other shards at this point.

--- a/compaction/compaction.hh
+++ b/compaction/compaction.hh
@@ -19,7 +19,6 @@
 #include <seastar/core/thread.hh>
 #include <seastar/core/abort_source.hh>
 
-class flat_mutation_reader;
 using namespace compaction;
 
 namespace sstables {

--- a/compaction/compaction_strategy.hh
+++ b/compaction/compaction_strategy.hh
@@ -16,7 +16,6 @@
 #include "sstables/shared_sstable.hh"
 #include "exceptions/exceptions.hh"
 #include "compaction_strategy_type.hh"
-#include "readers/flat_mutation_reader.hh"
 #include "table_state.hh"
 #include "strategy_control.hh"
 

--- a/readers/flat_mutation_reader.hh
+++ b/readers/flat_mutation_reader.hh
@@ -423,39 +423,6 @@ public:
         return _impl->consume(std::move(consumer));
     }
 
-    class filter {
-    private:
-        std::function<bool (const dht::decorated_key&)> _partition_filter = [] (const dht::decorated_key&) { return true; };
-        std::function<bool (const mutation_fragment&)> _mutation_fragment_filter = [] (const mutation_fragment&) { return true; };
-    public:
-        filter() = default;
-
-        filter(std::function<bool (const dht::decorated_key&)>&& pf)
-            : _partition_filter(std::move(pf))
-        { }
-
-        filter(std::function<bool (const dht::decorated_key&)>&& pf,
-               std::function<bool (const mutation_fragment&)>&& mf)
-            : _partition_filter(std::move(pf))
-            , _mutation_fragment_filter(std::move(mf))
-        { }
-
-        template <typename Functor>
-        filter(Functor&& f)
-            : _partition_filter(std::forward<Functor>(f))
-        { }
-
-        bool operator()(const dht::decorated_key& dk) const {
-            return _partition_filter(dk);
-        }
-
-        bool operator()(const mutation_fragment& mf) const {
-            return _mutation_fragment_filter(mf);
-        }
-
-        void on_end_of_stream() const { }
-    };
-
     struct no_filter {
         bool operator()(const dht::decorated_key& dk) const {
             return true;


### PR DESCRIPTION
This series gets rid of the remaining usage of flat_mutation_reader v1 in compaction

Test: sstable_compaction_test