### PR TITLE
cql3: expr: allow bind markers in collection literals

### DIFF
--- a/cql3/expr/expression.cc
+++ b/cql3/expr/expression.cc
@@ -1820,16 +1820,16 @@ static constant evaluate_list(const collection_constructor& collection,
     for (const expression& element : collection.elements) {
         constant evaluated_element = evaluate(element, options);
 
+        if (evaluated_element.is_unset_value()) {
+            throw exceptions::invalid_request_exception("unset value is not supported inside collections");
+        }
+
         if (evaluated_element.is_null()) {
             if (skip_null) {
                 continue;
             }
 
             throw exceptions::invalid_request_exception("null is not supported inside collections");
-        }
-
-        if (evaluated_element.is_unset_value()) {
-            return constant::make_unset_value(collection.type);
         }
 
         evaluated_elements.emplace_back(std::move(evaluated_element).value.to_managed_bytes());
@@ -1851,7 +1851,7 @@ static constant evaluate_set(const collection_constructor& collection, const que
         }
 
         if (evaluated_element.is_unset_value()) {
-            return constant::make_unset_value(collection.type);
+            throw exceptions::invalid_request_exception("unset value is not supported inside collections");
         }
 
         if (evaluated_element.view().size_bytes() > std::numeric_limits<uint16_t>::max()) {
@@ -1884,12 +1884,8 @@ static constant evaluate_map(const collection_constructor& collection, const que
                 throw exceptions::invalid_request_exception("null is not supported inside collections");
             }
 
-            if (key.is_unset_value()) {
+            if (key.is_unset_value() || value.is_unset_value()) {
                 throw exceptions::invalid_request_exception("unset value is not supported inside collections");
-            }
-
-            if (value.is_unset_value()) {
-                return constant::make_unset_value(collection.type);
             }
 
             if (key.view().size_bytes() > std::numeric_limits<uint16_t>::max()) {

--- a/cql3/expr/prepare_expr.cc
+++ b/cql3/expr/prepare_expr.cc
@@ -204,11 +204,7 @@ map_prepare_expression(const collection_constructor& c, data_dictionary::databas
         expression k = prepare_expression(entry_tuple.elements[0], db, keyspace, key_spec);
         expression v = prepare_expression(entry_tuple.elements[1], db, keyspace, value_spec);
 
-        if (contains_bind_marker(k) || contains_bind_marker(k)) {
-            throw exceptions::invalid_request_exception(format("Invalid map literal for {}: bind variables are not supported inside collection literals", *receiver->name));
-        }
-
-        // Even when there are no bind markers, the value can still contain a nonpure function
+        // Check if one of values contains a nonpure function
         if (!is<constant>(k) || !is<constant>(v)) {
             all_terminal = false;
         }
@@ -316,10 +312,6 @@ set_prepare_expression(const collection_constructor& c, data_dictionary::databas
     {
         expression elem = prepare_expression(e, db, keyspace, value_spec);
 
-        if (contains_bind_marker(elem)) {
-            throw exceptions::invalid_request_exception(format("Invalid set literal for {}: bind variables are not supported inside collection literals", *receiver->name));
-        }
-
         if (!is<constant>(elem)) {
             all_terminal = false;
         }
@@ -401,9 +393,6 @@ list_prepare_expression(const collection_constructor& c, data_dictionary::databa
     for (auto& e : c.elements) {
         expression elem = prepare_expression(e, db, keyspace, value_spec);
 
-        if (contains_bind_marker(elem)) {
-            throw exceptions::invalid_request_exception(format("Invalid list literal for {}: bind variables are not supported inside collection literals", *receiver->name));
-        }
         if (!is<constant>(elem)) {
             all_terminal = false;
         }

--- a/test/boost/cql_query_test.cc
+++ b/test/boost/cql_query_test.cc
@@ -357,7 +357,7 @@ SEASTAR_TEST_CASE(test_tuple_elements_validation) {
 SEASTAR_TEST_CASE(test_list_of_tuples_with_bound_var) {
     return do_with_cql_env_thread([](cql_test_env& e) {
         e.execute_cql("create table cf (pk int PRIMARY KEY, c1 list<frozen<tuple<int,int>>>);").get();
-        BOOST_REQUIRE_THROW(e.prepare("update cf SET c1 = c1 + [(?,9999)] where pk = 999;").get0(), exceptions::invalid_request_exception);
+        e.prepare("update cf SET c1 = c1 + [(?,9999)] where pk = 999;").get0();
     });
 }
 


### PR DESCRIPTION
Allowing bind markers in collection literals is a change which causes minor differences in behavior between Scylla and Cassandra. Despite such an undesirable effect, I think allowing them is a good idea because it makes [refactoring work made by cvybhu](https://github.com/scylladb/scylla/pull/10409) easier - https://github.com/cvybhu/scylla/commit/469d03f8c2efda3ca9736f5a9e0169f02767bba4.

Also, making Scylla accept a superset of valid Cassandra cql expressions does not make us less compatible (maybe apart from test suit compatibility).