### PR TITLE
Make internal statements caching more coherent

### DIFF
--- a/auth/default_authorizer.cc
+++ b/auth/default_authorizer.cc
@@ -77,7 +77,7 @@ future<bool> default_authorizer::any_granted() const {
             query,
             db::consistency_level::LOCAL_ONE,
             {},
-            true).then([this](::shared_ptr<cql3::untyped_result_set> results) {
+            cql3::query_processor::cache_internal::yes).then([this](::shared_ptr<cql3::untyped_result_set> results) {
         return !results->empty();
     });
 }
@@ -223,7 +223,7 @@ future<std::vector<permission_details>> default_authorizer::list_all() const {
             db::consistency_level::ONE,
             internal_distributed_query_state(),
             {},
-            true).then([](::shared_ptr<cql3::untyped_result_set> results) {
+            cql3::query_processor::cache_internal::yes).then([](::shared_ptr<cql3::untyped_result_set> results) {
         std::vector<permission_details> all_details;
 
         for (const auto& row : *results) {

--- a/auth/default_authorizer.cc
+++ b/auth/default_authorizer.cc
@@ -170,7 +170,7 @@ default_authorizer::authorize(const role_or_anonymous& maybe_role, const resourc
             query,
             db::consistency_level::LOCAL_ONE,
             {*maybe_role.name, r.name()},
-            cql3::query_processor::cache_internal::no).then([](::shared_ptr<cql3::untyped_result_set> results) {
+            cql3::query_processor::cache_internal::yes).then([](::shared_ptr<cql3::untyped_result_set> results) {
         if (results->empty()) {
             return permissions::NONE;
         }

--- a/auth/default_authorizer.cc
+++ b/auth/default_authorizer.cc
@@ -88,7 +88,8 @@ future<> default_authorizer::migrate_legacy_metadata() const {
 
     return _qp.execute_internal(
             query,
-            db::consistency_level::LOCAL_ONE).then([this](::shared_ptr<cql3::untyped_result_set> results) {
+            db::consistency_level::LOCAL_ONE,
+            cql3::query_processor::cache_internal::no).then([this](::shared_ptr<cql3::untyped_result_set> results) {
         return do_for_each(*results, [this](const cql3::untyped_result_set_row& row) {
             return do_with(
                     row.get_as<sstring>("username"),
@@ -168,7 +169,8 @@ default_authorizer::authorize(const role_or_anonymous& maybe_role, const resourc
     return _qp.execute_internal(
             query,
             db::consistency_level::LOCAL_ONE,
-            {*maybe_role.name, r.name()}).then([](::shared_ptr<cql3::untyped_result_set> results) {
+            {*maybe_role.name, r.name()},
+            cql3::query_processor::cache_internal::no).then([](::shared_ptr<cql3::untyped_result_set> results) {
         if (results->empty()) {
             return permissions::NONE;
         }
@@ -197,7 +199,8 @@ default_authorizer::modify(
                 query,
                 db::consistency_level::ONE,
                 internal_distributed_query_state(),
-                {permissions::to_strings(set), sstring(role_name), resource.name()}).discard_result();
+                {permissions::to_strings(set), sstring(role_name), resource.name()},
+                cql3::query_processor::cache_internal::no).discard_result();
     });
 }
 
@@ -249,7 +252,8 @@ future<> default_authorizer::revoke_all(std::string_view role_name) const {
             query,
             db::consistency_level::ONE,
             internal_distributed_query_state(),
-            {sstring(role_name)}).discard_result().handle_exception([role_name](auto ep) {
+            {sstring(role_name)},
+            cql3::query_processor::cache_internal::no).discard_result().handle_exception([role_name](auto ep) {
         try {
             std::rethrow_exception(ep);
         } catch (exceptions::request_execution_exception& e) {
@@ -268,7 +272,8 @@ future<> default_authorizer::revoke_all(const resource& resource) const {
     return _qp.execute_internal(
             query,
             db::consistency_level::LOCAL_ONE,
-            {resource.name()}).then_wrapped([this, resource](future<::shared_ptr<cql3::untyped_result_set>> f) {
+            {resource.name()},
+            cql3::query_processor::cache_internal::no).then_wrapped([this, resource](future<::shared_ptr<cql3::untyped_result_set>> f) {
         try {
             auto res = f.get0();
             return parallel_for_each(
@@ -284,7 +289,8 @@ future<> default_authorizer::revoke_all(const resource& resource) const {
                 return _qp.execute_internal(
                         query,
                         db::consistency_level::LOCAL_ONE,
-                        {r.get_as<sstring>(ROLE_NAME), resource.name()}).discard_result().handle_exception(
+                        {r.get_as<sstring>(ROLE_NAME), resource.name()},
+                        cql3::query_processor::cache_internal::no).discard_result().handle_exception(
                                 [resource](auto ep) {
                     try {
                         std::rethrow_exception(ep);

--- a/auth/password_authenticator.cc
+++ b/auth/password_authenticator.cc
@@ -211,7 +211,7 @@ future<authenticated_user> password_authenticator::authenticate(
                 consistency_for_user(username),
                 internal_distributed_query_state(),
                 {username},
-                true);
+                cql3::query_processor::cache_internal::yes);
     }).then_wrapped([=](future<::shared_ptr<cql3::untyped_result_set>> f) {
         try {
             auto res = f.get0();

--- a/auth/password_authenticator.cc
+++ b/auth/password_authenticator.cc
@@ -87,7 +87,8 @@ future<> password_authenticator::migrate_legacy_metadata() const {
     return _qp.execute_internal(
             query,
             db::consistency_level::QUORUM,
-            internal_distributed_query_state()).then([this](::shared_ptr<cql3::untyped_result_set> results) {
+            internal_distributed_query_state(),
+            cql3::query_processor::cache_internal::no).then([this](::shared_ptr<cql3::untyped_result_set> results) {
         return do_for_each(*results, [this](const cql3::untyped_result_set_row& row) {
             auto username = row.get_as<sstring>("username");
             auto salted_hash = row.get_as<sstring>(SALTED_HASH);
@@ -96,7 +97,8 @@ future<> password_authenticator::migrate_legacy_metadata() const {
                     update_row_query(),
                     consistency_for_user(username),
                     internal_distributed_query_state(),
-                    {std::move(salted_hash), username}).discard_result();
+                    {std::move(salted_hash), username},
+                    cql3::query_processor::cache_internal::no).discard_result();
         }).finally([results] {});
     }).then([] {
        plogger.info("Finished migrating legacy authentication metadata.");
@@ -113,7 +115,8 @@ future<> password_authenticator::create_default_if_missing() const {
                     update_row_query(),
                     db::consistency_level::QUORUM,
                     internal_distributed_query_state(),
-                    {passwords::hash(DEFAULT_USER_PASSWORD, rng_for_salt), DEFAULT_USER_NAME}).then([](auto&&) {
+                    {passwords::hash(DEFAULT_USER_PASSWORD, rng_for_salt), DEFAULT_USER_NAME},
+                    cql3::query_processor::cache_internal::no).then([](auto&&) {
                 plogger.info("Created default superuser authentication record.");
             });
         }
@@ -244,7 +247,8 @@ future<> password_authenticator::create(std::string_view role_name, const authen
             update_row_query(),
             consistency_for_user(role_name),
             internal_distributed_query_state(),
-            {passwords::hash(*options.password, rng_for_salt), sstring(role_name)}).discard_result();
+            {passwords::hash(*options.password, rng_for_salt), sstring(role_name)},
+            cql3::query_processor::cache_internal::no).discard_result();
 }
 
 future<> password_authenticator::alter(std::string_view role_name, const authentication_options& options) const {
@@ -261,7 +265,8 @@ future<> password_authenticator::alter(std::string_view role_name, const authent
             query,
             consistency_for_user(role_name),
             internal_distributed_query_state(),
-            {passwords::hash(*options.password, rng_for_salt), sstring(role_name)}).discard_result();
+            {passwords::hash(*options.password, rng_for_salt), sstring(role_name)},
+            cql3::query_processor::cache_internal::no).discard_result();
 }
 
 future<> password_authenticator::drop(std::string_view name) const {
@@ -273,7 +278,8 @@ future<> password_authenticator::drop(std::string_view name) const {
     return _qp.execute_internal(
             query, consistency_for_user(name),
             internal_distributed_query_state(),
-            {sstring(name)}).discard_result();
+            {sstring(name)},
+            cql3::query_processor::cache_internal::no).discard_result();
 }
 
 future<custom_options> password_authenticator::query_custom_options(std::string_view role_name) const {

--- a/auth/roles-metadata.cc
+++ b/auth/roles-metadata.cc
@@ -56,14 +56,14 @@ future<bool> default_role_row_satisfies(
                 query,
                 db::consistency_level::ONE,
                 {meta::DEFAULT_SUPERUSER_NAME},
-                true).then([&qp, &p](::shared_ptr<cql3::untyped_result_set> results) {
+                cql3::query_processor::cache_internal::yes).then([&qp, &p](::shared_ptr<cql3::untyped_result_set> results) {
             if (results->empty()) {
                 return qp.execute_internal(
                         query,
                         db::consistency_level::QUORUM,
                         internal_distributed_query_state(),
                         {meta::DEFAULT_SUPERUSER_NAME},
-                        true).then([&p](::shared_ptr<cql3::untyped_result_set> results) {
+                        cql3::query_processor::cache_internal::yes).then([&p](::shared_ptr<cql3::untyped_result_set> results) {
                     if (results->empty()) {
                         return make_ready_future<bool>(false);
                     }

--- a/auth/roles-metadata.cc
+++ b/auth/roles-metadata.cc
@@ -86,7 +86,8 @@ future<bool> any_nondefault_role_row_satisfies(
         return qp.execute_internal(
                 query,
                 db::consistency_level::QUORUM,
-                internal_distributed_query_state()).then([&p](::shared_ptr<cql3::untyped_result_set> results) {
+                internal_distributed_query_state(),
+                cql3::query_processor::cache_internal::no).then([&p](::shared_ptr<cql3::untyped_result_set> results) {
             if (results->empty()) {
                 return false;
             }

--- a/auth/service.cc
+++ b/auth/service.cc
@@ -219,7 +219,8 @@ future<bool> service::has_existing_legacy_users() const {
 
             return _qp.execute_internal(
                     all_users_query,
-                    db::consistency_level::QUORUM).then([](auto results) {
+                    db::consistency_level::QUORUM,
+                    cql3::query_processor::cache_internal::no).then([](auto results) {
                 return make_ready_future<bool>(!results->empty());
             });
         });

--- a/auth/service.cc
+++ b/auth/service.cc
@@ -203,7 +203,7 @@ future<bool> service::has_existing_legacy_users() const {
             default_user_query,
             db::consistency_level::ONE,
             {meta::DEFAULT_SUPERUSER_NAME},
-            true).then([this](auto results) {
+            cql3::query_processor::cache_internal::yes).then([this](auto results) {
         if (!results->empty()) {
             return make_ready_future<bool>(true);
         }
@@ -212,7 +212,7 @@ future<bool> service::has_existing_legacy_users() const {
                 default_user_query,
                 db::consistency_level::QUORUM,
                 {meta::DEFAULT_SUPERUSER_NAME},
-                true).then([this](auto results) {
+                cql3::query_processor::cache_internal::yes).then([this](auto results) {
             if (!results->empty()) {
                 return make_ready_future<bool>(true);
             }

--- a/auth/standard_role_manager.cc
+++ b/auth/standard_role_manager.cc
@@ -178,7 +178,8 @@ future<> standard_role_manager::create_default_role_if_missing() const {
                     query,
                     db::consistency_level::QUORUM,
                     internal_distributed_query_state(),
-                    {meta::DEFAULT_SUPERUSER_NAME}).then([](auto&&) {
+                    {meta::DEFAULT_SUPERUSER_NAME},
+                    cql3::query_processor::cache_internal::no).then([](auto&&) {
                 log.info("Created default superuser role '{}'.", meta::DEFAULT_SUPERUSER_NAME);
                 return make_ready_future<>();
             });
@@ -204,7 +205,8 @@ future<> standard_role_manager::migrate_legacy_metadata() const {
     return _qp.execute_internal(
             query,
             db::consistency_level::QUORUM,
-            internal_distributed_query_state()).then([this](::shared_ptr<cql3::untyped_result_set> results) {
+            internal_distributed_query_state(),
+            cql3::query_processor::cache_internal::no).then([this](::shared_ptr<cql3::untyped_result_set> results) {
         return do_for_each(*results, [this](const cql3::untyped_result_set_row& row) {
             role_config config;
             config.is_superuser = row.get_or<bool>("super", false);
@@ -309,7 +311,8 @@ standard_role_manager::alter(std::string_view role_name, const role_config_updat
                         meta::roles_table::role_col_name),
                 consistency_for_role(role_name),
                 internal_distributed_query_state(),
-                {sstring(role_name)}).discard_result();
+                {sstring(role_name)},
+                cql3::query_processor::cache_internal::no).discard_result();
     });
 }
 
@@ -328,7 +331,8 @@ future<> standard_role_manager::drop(std::string_view role_name) {
                     query,
                     consistency_for_role(role_name),
                     internal_distributed_query_state(),
-                    {sstring(role_name)}).then([this, role_name](::shared_ptr<cql3::untyped_result_set> members) {
+                    {sstring(role_name)},
+                    cql3::query_processor::cache_internal::no).then([this, role_name](::shared_ptr<cql3::untyped_result_set> members) {
                 return parallel_for_each(
                         members->begin(),
                         members->end(),
@@ -360,7 +364,7 @@ future<> standard_role_manager::drop(std::string_view role_name) {
         // Delete all attributes for that role
         const auto remove_attributes_of = [this, role_name] {
             static const sstring query = format("DELETE FROM {} WHERE role = ?", meta::role_attributes_table::qualified_name());
-            return _qp.execute_internal(query, {sstring(role_name)}).discard_result();
+            return _qp.execute_internal(query, {sstring(role_name)}, cql3::query_processor::cache_internal::yes).discard_result();
         };
 
         // Finally, delete the role itself.
@@ -373,7 +377,8 @@ future<> standard_role_manager::drop(std::string_view role_name) {
                     query,
                     consistency_for_role(role_name),
                     internal_distributed_query_state(),
-                    {sstring(role_name)}).discard_result();
+                    {sstring(role_name)},
+                    cql3::query_processor::cache_internal::no).discard_result();
         };
 
         return when_all_succeed(revoke_from_members(), revoke_members_of(),
@@ -401,7 +406,8 @@ standard_role_manager::modify_membership(
                 query,
                 consistency_for_role(grantee_name),
                 internal_distributed_query_state(),
-                {role_set{sstring(role_name)}, sstring(grantee_name)}).discard_result();
+                {role_set{sstring(role_name)}, sstring(grantee_name)},
+                cql3::query_processor::cache_internal::no).discard_result();
     };
 
     const auto modify_role_members = [this, role_name, grantee_name, ch] {
@@ -412,7 +418,8 @@ standard_role_manager::modify_membership(
                                 meta::role_members_table::qualified_name),
                         consistency_for_role(role_name),
                         internal_distributed_query_state(),
-                        {sstring(role_name), sstring(grantee_name)}).discard_result();
+                        {sstring(role_name), sstring(grantee_name)},
+                        cql3::query_processor::cache_internal::no).discard_result();
 
             case membership_change::remove:
                 return _qp.execute_internal(
@@ -420,7 +427,8 @@ standard_role_manager::modify_membership(
                                 meta::role_members_table::qualified_name),
                         consistency_for_role(role_name),
                         internal_distributed_query_state(),
-                        {sstring(role_name), sstring(grantee_name)}).discard_result();
+                        {sstring(role_name), sstring(grantee_name)},
+                        cql3::query_processor::cache_internal::no).discard_result();
         }
 
         return make_ready_future<>();
@@ -522,7 +530,8 @@ future<role_set> standard_role_manager::query_all() {
     return _qp.execute_internal(
             query,
             db::consistency_level::QUORUM,
-            internal_distributed_query_state()).then([](::shared_ptr<cql3::untyped_result_set> results) {
+            internal_distributed_query_state(),
+            cql3::query_processor::cache_internal::no).then([](::shared_ptr<cql3::untyped_result_set> results) {
         role_set roles;
 
         std::transform(
@@ -557,7 +566,7 @@ future<bool> standard_role_manager::can_login(std::string_view role_name) {
 
 future<std::optional<sstring>> standard_role_manager::get_attribute(std::string_view role_name, std::string_view attribute_name) {
     static const sstring query = format("SELECT name, value FROM {} WHERE role = ? AND name = ?", meta::role_attributes_table::qualified_name());
-    return _qp.execute_internal(query, {sstring(role_name), sstring(attribute_name)}).then([] (shared_ptr<cql3::untyped_result_set> result_set) {
+    return _qp.execute_internal(query, {sstring(role_name), sstring(attribute_name)}, cql3::query_processor::cache_internal::yes).then([] (shared_ptr<cql3::untyped_result_set> result_set) {
         if (!result_set->empty()) {
             const cql3::untyped_result_set_row &row = result_set->one();
             return std::optional<sstring>(row.get_as<sstring>("value"));
@@ -590,7 +599,7 @@ future<> standard_role_manager::set_attribute(std::string_view role_name, std::s
             if (!role_exists) {
                 throw auth::nonexistant_role(role_name);
             }
-            return _qp.execute_internal(query, {sstring(role_name), sstring(attribute_name), sstring(attribute_value)}).discard_result();
+            return _qp.execute_internal(query, {sstring(role_name), sstring(attribute_name), sstring(attribute_value)}, cql3::query_processor::cache_internal::yes).discard_result();
         });
     });
 
@@ -603,7 +612,7 @@ future<> standard_role_manager::remove_attribute(std::string_view role_name, std
             if (!role_exists) {
                 throw auth::nonexistant_role(role_name);
             }
-            return _qp.execute_internal(query, {sstring(role_name), sstring(attribute_name)}).discard_result();
+            return _qp.execute_internal(query, {sstring(role_name), sstring(attribute_name)}, cql3::query_processor::cache_internal::yes).discard_result();
         });
     });
 }

--- a/auth/standard_role_manager.cc
+++ b/auth/standard_role_manager.cc
@@ -531,7 +531,7 @@ future<role_set> standard_role_manager::query_all() {
             query,
             db::consistency_level::QUORUM,
             internal_distributed_query_state(),
-            cql3::query_processor::cache_internal::no).then([](::shared_ptr<cql3::untyped_result_set> results) {
+            cql3::query_processor::cache_internal::yes).then([](::shared_ptr<cql3::untyped_result_set> results) {
         role_set roles;
 
         std::transform(

--- a/auth/standard_role_manager.cc
+++ b/auth/standard_role_manager.cc
@@ -95,7 +95,7 @@ static future<std::optional<record>> find_record(cql3::query_processor& qp, std:
             consistency_for_role(role_name),
             internal_distributed_query_state(),
             {sstring(role_name)},
-            true).then([](::shared_ptr<cql3::untyped_result_set> results) {
+            cql3::query_processor::cache_internal::yes).then([](::shared_ptr<cql3::untyped_result_set> results) {
         if (results->empty()) {
             return std::optional<record>();
         }
@@ -267,7 +267,7 @@ future<> standard_role_manager::create_or_replace(std::string_view role_name, co
             consistency_for_role(role_name),
             internal_distributed_query_state(),
             {sstring(role_name), c.is_superuser, c.can_login},
-            true).discard_result();
+            cql3::query_processor::cache_internal::yes).discard_result();
 }
 
 future<>

--- a/cql3/query_processor.cc
+++ b/cql3/query_processor.cc
@@ -808,7 +808,7 @@ query_processor::execute_internal(
         const sstring& query_string,
         db::consistency_level cl,
         const std::initializer_list<data_value>& values,
-        bool cache) {
+        cache_internal cache) {
     return execute_internal(query_string, cl, *_internal_state, values, cache);
 }
 
@@ -818,7 +818,7 @@ query_processor::execute_internal(
         db::consistency_level cl,
         service::query_state& query_state,
         const std::initializer_list<data_value>& values,
-        bool cache) {
+        cache_internal cache) {
 
     if (log.is_enabled(logging::log_level::trace)) {
         log.trace("execute_internal: {}\"{}\" ({})", cache ? "(cached) " : "", query_string, ::join(", ", values));

--- a/cql3/query_processor.hh
+++ b/cql3/query_processor.hh
@@ -244,7 +244,7 @@ public:
     // creating namespaces, etc) is explicitly forbidden via this interface.
     future<::shared_ptr<untyped_result_set>>
     execute_internal(const sstring& query_string, const std::initializer_list<data_value>& values = { }) {
-        return execute_internal(query_string, db::consistency_level::ONE, values, true);
+        return execute_internal(query_string, db::consistency_level::ONE, values, cache_internal::yes);
     }
 
     statements::prepared_statement::checked_weak_ptr prepare_internal(const sstring& query);
@@ -298,6 +298,8 @@ public:
             const sstring& query_string,
             noncopyable_function<future<stop_iteration>(const cql3::untyped_result_set_row&)>&& f);
 
+    class cache_internal_tag;
+    using cache_internal = bool_class<cache_internal_tag>;
     // NOTICE: Internal queries should be used with care, as they are expected
     // to be used for local tables (e.g. from the `system` keyspace).
     // Data modifications will usually be performed with consistency level ONE
@@ -308,13 +310,13 @@ public:
             const sstring& query_string,
             db::consistency_level,
             const std::initializer_list<data_value>& = { },
-            bool cache = false);
+            cache_internal cache = cache_internal::no);
     future<::shared_ptr<untyped_result_set>> execute_internal(
             const sstring& query_string,
             db::consistency_level,
             service::query_state& query_state,
             const std::initializer_list<data_value>& = { },
-            bool cache = false);
+            cache_internal cache = cache_internal::no);
 
     future<::shared_ptr<untyped_result_set>> execute_with_params(
             statements::prepared_statement::checked_weak_ptr p,

--- a/cql3/query_processor.hh
+++ b/cql3/query_processor.hh
@@ -236,17 +236,6 @@ public:
             service::query_state& query_state,
             query_options& options);
 
-    // NOTICE: Internal queries should be used with care, as they are expected
-    // to be used for local tables (e.g. from the `system` keyspace).
-    // Data modifications will usually be performed with consistency level ONE
-    // and schema changes will not be announced to other nodes.
-    // Because of that, changing global schema state (e.g. modifying non-local tables,
-    // creating namespaces, etc) is explicitly forbidden via this interface.
-    future<::shared_ptr<untyped_result_set>>
-    execute_internal(const sstring& query_string, const std::initializer_list<data_value>& values = { }) {
-        return execute_internal(query_string, db::consistency_level::ONE, values, cache_internal::yes);
-    }
-
     statements::prepared_statement::checked_weak_ptr prepare_internal(const sstring& query);
 
     /*!
@@ -300,6 +289,7 @@ public:
 
     class cache_internal_tag;
     using cache_internal = bool_class<cache_internal_tag>;
+    
     // NOTICE: Internal queries should be used with care, as they are expected
     // to be used for local tables (e.g. from the `system` keyspace).
     // Data modifications will usually be performed with consistency level ONE
@@ -309,15 +299,35 @@ public:
     future<::shared_ptr<untyped_result_set>> execute_internal(
             const sstring& query_string,
             db::consistency_level,
-            const std::initializer_list<data_value>& = { },
-            cache_internal cache = cache_internal::no);
+            const std::initializer_list<data_value>&,
+            cache_internal cache);
     future<::shared_ptr<untyped_result_set>> execute_internal(
             const sstring& query_string,
             db::consistency_level,
             service::query_state& query_state,
-            const std::initializer_list<data_value>& = { },
-            cache_internal cache = cache_internal::no);
-
+            const std::initializer_list<data_value>&,
+            cache_internal cache);
+    future<::shared_ptr<untyped_result_set>> execute_internal(
+            const sstring& query_string,
+            db::consistency_level cl,
+            cache_internal cache) {
+        return execute_internal(query_string, cl, {}, cache);
+    }
+    future<::shared_ptr<untyped_result_set>> execute_internal(
+            const sstring& query_string,
+            db::consistency_level cl,
+            service::query_state& query_state,
+            cache_internal cache) {
+        return execute_internal(query_string, cl, query_state, {}, cache);
+    }
+    future<::shared_ptr<untyped_result_set>>
+    execute_internal(const sstring& query_string, const std::initializer_list<data_value>& values, cache_internal cache) {
+        return execute_internal(query_string, db::consistency_level::ONE, values, cache);
+    }
+    future<::shared_ptr<untyped_result_set>>
+    execute_internal(const sstring& query_string, cache_internal cache) {
+        return execute_internal(query_string, db::consistency_level::ONE, {}, cache);
+    }
     future<::shared_ptr<untyped_result_set>> execute_with_params(
             statements::prepared_statement::checked_weak_ptr p,
             db::consistency_level,

--- a/db/query_context.hh
+++ b/db/query_context.hh
@@ -56,7 +56,7 @@ struct query_context {
                 cql3::query_options::DEFAULT.get_consistency(),
                 tctx.query_state,
                 { data_value(std::forward<Args>(args))... },
-                true);
+                cql3::query_processor::cache_internal::yes);
         });
     }
 

--- a/db/query_context.hh
+++ b/db/query_context.hh
@@ -29,7 +29,7 @@ struct query_context {
 
     template <typename... Args>
     future<::shared_ptr<cql3::untyped_result_set>> execute_cql(sstring req, Args&&... args) {
-        return _qp.local().execute_internal(req, { data_value(std::forward<Args>(args))... });
+        return _qp.local().execute_internal(req, { data_value(std::forward<Args>(args))... }, cql3::query_processor::cache_internal::yes);
     }
 
     template <typename... Args>

--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -3343,7 +3343,7 @@ future<bool> column_mapping_exists(utils::UUID table_id, table_schema_version ve
         GET_COLUMN_MAPPING_QUERY,
         db::consistency_level::LOCAL_ONE,
         {table_id, version},
-        cql3::query_processor::cache_internal::no
+        cql3::query_processor::cache_internal::yes
     );
     co_return !results->empty();
 }

--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -3301,7 +3301,8 @@ future<column_mapping> get_column_mapping(utils::UUID table_id, table_schema_ver
     shared_ptr<cql3::untyped_result_set> results = co_await qctx->qp().execute_internal(
         GET_COLUMN_MAPPING_QUERY,
         db::consistency_level::LOCAL_ONE,
-        {table_id, version}
+        {table_id, version},
+        cql3::query_processor::cache_internal::no
     );
     if (results->empty()) {
         // If we don't have a stored column_mapping for an obsolete schema version
@@ -3341,7 +3342,8 @@ future<bool> column_mapping_exists(utils::UUID table_id, table_schema_version ve
     shared_ptr<cql3::untyped_result_set> results = co_await qctx->qp().execute_internal(
         GET_COLUMN_MAPPING_QUERY,
         db::consistency_level::LOCAL_ONE,
-        {table_id, version}
+        {table_id, version},
+        cql3::query_processor::cache_internal::no
     );
     co_return !results->empty();
 }
@@ -3353,7 +3355,8 @@ future<> drop_column_mapping(utils::UUID table_id, table_schema_version version)
     co_await qctx->qp().execute_internal(
         DEL_COLUMN_MAPPING_QUERY,
         db::consistency_level::LOCAL_ONE,
-        {table_id, version});
+        {table_id, version},
+        cql3::query_processor::cache_internal::no);
 }
 
 } // namespace schema_tables

--- a/db/system_distributed_keyspace.cc
+++ b/db/system_distributed_keyspace.cc
@@ -803,7 +803,7 @@ static qos::service_level_options::timeout_type get_duration(const cql3::untyped
 future<qos::service_levels_info> system_distributed_keyspace::get_service_levels() const {
     static sstring prepared_query = format("SELECT * FROM {}.{};", NAME, SERVICE_LEVELS);
 
-    return _qp.execute_internal(prepared_query, db::consistency_level::ONE, internal_distributed_query_state(), {}).then([] (shared_ptr<cql3::untyped_result_set> result_set) {
+    return _qp.execute_internal(prepared_query, db::consistency_level::ONE, internal_distributed_query_state(), cql3::query_processor::cache_internal::yes).then([] (shared_ptr<cql3::untyped_result_set> result_set) {
         qos::service_levels_info service_levels;
         for (auto &&row : *result_set) {
             try {
@@ -824,7 +824,7 @@ future<qos::service_levels_info> system_distributed_keyspace::get_service_levels
 
 future<qos::service_levels_info> system_distributed_keyspace::get_service_level(sstring service_level_name) const {
     static sstring prepared_query = format("SELECT * FROM {}.{} WHERE service_level = ?;", NAME, SERVICE_LEVELS);
-    return _qp.execute_internal(prepared_query, db::consistency_level::ONE, internal_distributed_query_state(), {service_level_name}, cql3::query_processor::cache_internal::no).then(
+    return _qp.execute_internal(prepared_query, db::consistency_level::ONE, internal_distributed_query_state(), {service_level_name}, cql3::query_processor::cache_internal::yes).then(
                 [service_level_name = std::move(service_level_name)] (shared_ptr<cql3::untyped_result_set> result_set) {
         qos::service_levels_info service_levels;
         if (!result_set->empty()) {

--- a/service/raft/raft_group0.cc
+++ b/service/raft/raft_group0.cc
@@ -354,7 +354,7 @@ static future<discovery::peer_set> load_discovered_peers(cql3::query_processor& 
     static const auto load_cql = format(
             "SELECT server_info, raft_id FROM system.{} WHERE key = '{}'",
             db::system_keyspace::DISCOVERY, DISCOVERY_KEY);
-    auto rs = co_await qp.execute_internal(load_cql);
+    auto rs = co_await qp.execute_internal(load_cql, cql3::query_processor::cache_internal::yes);
     assert(rs);
 
     discovery::peer_set peers;

--- a/service/raft/raft_sys_table_storage.cc
+++ b/service/raft/raft_sys_table_storage.cc
@@ -48,13 +48,13 @@ future<> raft_sys_table_storage::store_term_and_vote(raft::term_t term, raft::se
             db::system_keyspace::RAFT);
         return _qp.execute_internal(
             store_cql,
-            {_group_id.id, int64_t(term), vote.id}).discard_result();
+            {_group_id.id, int64_t(term), vote.id}, cql3::query_processor::cache_internal::yes).discard_result();
     });
 }
 
 future<std::pair<raft::term_t, raft::server_id>> raft_sys_table_storage::load_term_and_vote() {
     static const auto load_cql = format("SELECT vote_term, vote FROM system.{} WHERE group_id = ? LIMIT 1", db::system_keyspace::RAFT);
-    ::shared_ptr<cql3::untyped_result_set> rs = co_await _qp.execute_internal(load_cql, {_group_id.id});
+    ::shared_ptr<cql3::untyped_result_set> rs = co_await _qp.execute_internal(load_cql, {_group_id.id}, cql3::query_processor::cache_internal::yes);
     if (rs->empty()) {
         co_return std::pair(raft::term_t(), raft::server_id());
     }
@@ -70,13 +70,14 @@ future<> raft_sys_table_storage::store_commit_idx(raft::index_t idx) {
             db::system_keyspace::RAFT);
         return _qp.execute_internal(
             store_cql,
-            {_group_id.id, int64_t(idx)}).discard_result();
+            {_group_id.id, int64_t(idx)},
+            cql3::query_processor::cache_internal::yes).discard_result();
     });
 }
 
 future<raft::index_t> raft_sys_table_storage::load_commit_idx() {
     static const auto load_cql = format("SELECT commit_idx FROM system.{} WHERE group_id = ? LIMIT 1", db::system_keyspace::RAFT);
-    ::shared_ptr<cql3::untyped_result_set> rs = co_await _qp.execute_internal(load_cql, {_group_id.id});
+    ::shared_ptr<cql3::untyped_result_set> rs = co_await _qp.execute_internal(load_cql, {_group_id.id}, cql3::query_processor::cache_internal::yes);
     if (rs->empty()) {
         co_return raft::index_t(0);
     }
@@ -87,7 +88,7 @@ future<raft::index_t> raft_sys_table_storage::load_commit_idx() {
 
 future<raft::log_entries> raft_sys_table_storage::load_log() {
     static const auto load_cql = format("SELECT term, \"index\", data FROM system.{} WHERE group_id = ?", db::system_keyspace::RAFT);
-    ::shared_ptr<cql3::untyped_result_set> rs = co_await _qp.execute_internal(load_cql, {_group_id.id});
+    ::shared_ptr<cql3::untyped_result_set> rs = co_await _qp.execute_internal(load_cql, {_group_id.id}, cql3::query_processor::cache_internal::yes);
 
     raft::log_entries log;
     for (const cql3::untyped_result_set_row& row : *rs) {
@@ -113,7 +114,7 @@ future<raft::log_entries> raft_sys_table_storage::load_log() {
 
 future<raft::snapshot_descriptor> raft_sys_table_storage::load_snapshot_descriptor() {
     static const auto load_id_cql = format("SELECT snapshot_id FROM system.{} WHERE group_id = ? LIMIT 1", db::system_keyspace::RAFT);
-    ::shared_ptr<cql3::untyped_result_set> id_rs = co_await _qp.execute_internal(load_id_cql, {_group_id.id});
+    ::shared_ptr<cql3::untyped_result_set> id_rs = co_await _qp.execute_internal(load_id_cql, {_group_id.id}, cql3::query_processor::cache_internal::yes);
     if (id_rs->empty() || !id_rs->one().has("snapshot_id")) {
         co_return raft::snapshot_descriptor();
     }
@@ -123,13 +124,13 @@ future<raft::snapshot_descriptor> raft_sys_table_storage::load_snapshot_descript
     // Fetch raft log index and term for the latest snapshot descriptor
     static const auto load_snp_info_cql = format("SELECT idx, term FROM system.{} WHERE group_id = ? AND server_id = ?",
         db::system_keyspace::RAFT_SNAPSHOTS);
-    ::shared_ptr<cql3::untyped_result_set> snp_rs = co_await _qp.execute_internal(load_snp_info_cql, {_group_id.id, _server_id.id});
+    ::shared_ptr<cql3::untyped_result_set> snp_rs = co_await _qp.execute_internal(load_snp_info_cql, {_group_id.id, _server_id.id}, cql3::query_processor::cache_internal::yes);
     // Should be only one matching row, since each individual server can only
     // have a single snapshot installed at a time
     const auto& snp_row = snp_rs->one();
     // Fetch current and previous raft configurations for the snapshot
     static const auto  load_cfg_cql = format("SELECT server_id, disposition, can_vote, ip_addr FROM system.{} WHERE group_id = ? AND my_server_id = ?", db::system_keyspace::RAFT_CONFIG);
-    ::shared_ptr<cql3::untyped_result_set> cfg_rs = co_await _qp.execute_internal(load_cfg_cql, {_group_id.id, _server_id.id});
+    ::shared_ptr<cql3::untyped_result_set> cfg_rs = co_await _qp.execute_internal(load_cfg_cql, {_group_id.id, _server_id.id}, cql3::query_processor::cache_internal::yes);
 
     raft::configuration cfg;
 
@@ -157,30 +158,34 @@ future<> raft_sys_table_storage::store_snapshot_descriptor(const raft::snapshot_
             db::system_keyspace::RAFT_SNAPSHOTS);
         co_await _qp.execute_internal(
             store_snp_cql,
-            {_group_id.id, _server_id.id, snap.id.id, int64_t(snap.idx), int64_t(snap.term)}
+            {_group_id.id, _server_id.id, snap.id.id, int64_t(snap.idx), int64_t(snap.term)},
+            cql3::query_processor::cache_internal::yes
         );
         // remove old configs
         static const auto delete_raft_cfg_cql = format("DELETE FROM system.{} WHERE group_id = ? AND my_server_id = ?", db::system_keyspace::RAFT_CONFIG);
-        co_await _qp.execute_internal(delete_raft_cfg_cql, {_group_id.id, _server_id.id});
+        co_await _qp.execute_internal(delete_raft_cfg_cql, {_group_id.id, _server_id.id}, cql3::query_processor::cache_internal::yes);
         // store current and previous raft configurations
         static const auto store_raft_cfg_cql = format("INSERT INTO system.{} (group_id, my_server_id, server_id, disposition, can_vote, ip_addr) VALUES (?, ?, ?, ?, ?, ?)",
             db::system_keyspace::RAFT_CONFIG);
         for (const raft::server_address& srv_addr : snap.config.current) {
             co_await _qp.execute_internal(store_raft_cfg_cql,
                 {_group_id.id, _server_id.id, srv_addr.id.id, "CURRENT", srv_addr.can_vote,
-                    ser::deserialize_from_buffer(srv_addr.info, boost::type<gms::inet_address>()).addr()});
+                    ser::deserialize_from_buffer(srv_addr.info, boost::type<gms::inet_address>()).addr()},
+                    cql3::query_processor::cache_internal::yes);
         }
         for (const raft::server_address& srv_addr : snap.config.previous) {
             co_await _qp.execute_internal(store_raft_cfg_cql,
                 {_group_id.id, _server_id.id, srv_addr.id.id, "PREVIOUS", srv_addr.can_vote,
-                    ser::deserialize_from_buffer(srv_addr.info, boost::type<gms::inet_address>()).addr()});
+                    ser::deserialize_from_buffer(srv_addr.info, boost::type<gms::inet_address>()).addr()},
+                    cql3::query_processor::cache_internal::yes);
         }
         // Also update the latest snapshot id in `system.raft` table
         static const auto store_latest_id_cql = format("INSERT INTO system.{} (group_id, snapshot_id) VALUES (?, ?)",
             db::system_keyspace::RAFT);
         co_await _qp.execute_internal(
             store_latest_id_cql,
-            {_group_id.id, snap.id.id}
+            {_group_id.id, snap.id.id},
+            cql3::query_processor::cache_internal::yes
         );
         if (preserve_log_entries > snap.idx) {
             co_return;
@@ -269,7 +274,7 @@ future<> raft_sys_table_storage::truncate_log(raft::index_t idx) {
     return execute_with_linearization_point([this, idx] {
         static const auto truncate_cql = format("DELETE FROM system.{} WHERE group_id = ? AND \"index\" >= ?",
             db::system_keyspace::RAFT); 
-        return _qp.execute_internal(truncate_cql, {_group_id.id, int64_t(idx)}).discard_result();
+        return _qp.execute_internal(truncate_cql, {_group_id.id, int64_t(idx)}, cql3::query_processor::cache_internal::yes).discard_result();
     });
 }
 
@@ -281,7 +286,7 @@ future<> raft_sys_table_storage::abort() {
 
 future<> raft_sys_table_storage::truncate_log_tail(raft::index_t idx) {
     static const auto truncate_cql = format("DELETE FROM system.{} WHERE group_id = ? AND \"index\" <= ?", db::system_keyspace::RAFT);
-    return _qp.execute_internal(truncate_cql, {_group_id.id, int64_t(idx)}).discard_result();
+    return _qp.execute_internal(truncate_cql, {_group_id.id, int64_t(idx)}, cql3::query_processor::cache_internal::yes).discard_result();
 }
 
 future<> raft_sys_table_storage::execute_with_linearization_point(std::function<future<>()> f) {

--- a/test/boost/batchlog_manager_test.cc
+++ b/test/boost/batchlog_manager_test.cc
@@ -60,7 +60,7 @@ SEASTAR_TEST_CASE(test_execute_batch) {
                 });
             });
         }).then([&qp] {
-            return qp.execute_internal("select * from ks.cf where p1 = ? and c1 = ?;", { sstring("key1"), 1 }).then([](auto rs) {
+            return qp.execute_internal("select * from ks.cf where p1 = ? and c1 = ?;", { sstring("key1"), 1 }, cql3::query_processor::cache_internal::yes).then([](auto rs) {
                 BOOST_REQUIRE(!rs->empty());
                 auto i = rs->one().template get_as<int32_t>("r1");
                 BOOST_CHECK_EQUAL(i, int32_t(100));

--- a/test/boost/cql_query_test.cc
+++ b/test/boost/cql_query_test.cc
@@ -4549,11 +4549,11 @@ SEASTAR_TEST_CASE(test_internal_schema_changes_on_a_distributed_table) {
         return seastar::async([&e] {
             cquery_nofail(e, "create table t (p int primary key, v int)");
             const auto local_err = exception_predicate::message_contains("internal query");
-            BOOST_REQUIRE_EXCEPTION(e.local_qp().execute_internal("alter table ks.t add col abcd").get(), std::logic_error, local_err);
-            BOOST_REQUIRE_EXCEPTION(e.local_qp().execute_internal("create table ks.t2 (id int primary key)").get(), std::logic_error, local_err);
-            BOOST_REQUIRE_EXCEPTION(e.local_qp().execute_internal("create index on ks.t(v)").get(), std::logic_error, local_err);
-            BOOST_REQUIRE_EXCEPTION(e.local_qp().execute_internal("drop table ks.t").get(), std::logic_error, local_err);
-            BOOST_REQUIRE_EXCEPTION(e.local_qp().execute_internal("drop keyspace ks").get(), std::logic_error, local_err);
+            BOOST_REQUIRE_EXCEPTION(e.local_qp().execute_internal("alter table ks.t add col abcd", cql3::query_processor::cache_internal::yes).get(), std::logic_error, local_err);
+            BOOST_REQUIRE_EXCEPTION(e.local_qp().execute_internal("create table ks.t2 (id int primary key)", cql3::query_processor::cache_internal::yes).get(), std::logic_error, local_err);
+            BOOST_REQUIRE_EXCEPTION(e.local_qp().execute_internal("create index on ks.t(v)", cql3::query_processor::cache_internal::yes).get(), std::logic_error, local_err);
+            BOOST_REQUIRE_EXCEPTION(e.local_qp().execute_internal("drop table ks.t", cql3::query_processor::cache_internal::yes).get(), std::logic_error, local_err);
+            BOOST_REQUIRE_EXCEPTION(e.local_qp().execute_internal("drop keyspace ks", cql3::query_processor::cache_internal::yes).get(), std::logic_error, local_err);
         });
     });
 }


### PR DESCRIPTION
There was some doubts about which internal prepared statements are cached and which aren't.
In addition some queries that should have been cached (IMO), weren't. This PR adds some verbosity
to the caching enabling parameter as well as adding caching to some queries.
As a followup I would suggest to have internal queries as a compile time strings that have a compile time hash, this
will make the cache lookup not be dependent on the query textual length as it is today, this makes sense given that the
queries are static even today.