### PR TITLE
dist/common/scripts: generate debug log when exception occurred

### DIFF
--- a/dist/common/scripts/scylla_prepare
+++ b/dist/common/scripts/scylla_prepare
@@ -12,7 +12,6 @@ import sys
 import glob
 import platform
 import distro
-import traceback
 
 from scylla_util import *
 from subprocess import run
@@ -131,6 +130,6 @@ if __name__ == '__main__':
                 run("{} --options-file /etc/scylla.d/perftune.yaml".format(perftune_base_command()), shell=True, check=True)
         except Exception as e:
             print(f'Exception occurred while creating perftune.yaml:\n')
-            traceback.print_exc()
+            scylla_excepthook(*sys.exc_info())
             print('\nTo fix the error, please re-run scylla_setup.')
             sys.exit(1)

--- a/dist/common/scripts/scylla_util.py
+++ b/dist/common/scripts/scylla_util.py
@@ -21,6 +21,23 @@ from scylla_product import PRODUCT
 
 from multiprocessing import cpu_count
 
+import traceback
+import traceback_with_variables
+import logging
+
+
+def scylla_excepthook(etype, value, tb):
+    traceback.print_exception(etype, value, tb)
+    exc_logger = logging.getLogger(__name__)
+    exc_logger.setLevel(logging.DEBUG)
+    exc_logger_file = f'/var/tmp/{os.path.basename(sys.argv[0])}-{os.getpid()}-debug.log'
+    exc_logger.addHandler(logging.FileHandler(exc_logger_file))
+    traceback_with_variables.print_exc(e=value, file_=traceback_with_variables.LoggerAsFile(exc_logger))
+    print(f'Debug log created: {exc_logger_file}')
+
+sys.excepthook = scylla_excepthook
+
+
 def out(cmd, shell=True, timeout=None, encoding='utf-8'):
     res = subprocess.run(cmd, capture_output=True, shell=shell, timeout=timeout, check=False, encoding=encoding)
     if res.returncode != 0:

--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -123,6 +123,7 @@ fedora_python3_packages=(
 pip_packages=(
     scylla-driver
     geomet
+    traceback-with-variables
 )
 
 centos_packages=(
@@ -293,6 +294,7 @@ elif [ "$ID" = "fedora" ]; then
     pip3 install "geomet<0.3,>=0.1"
     # Disable C extensions
     pip3 install scylla-driver --install-option="--no-murmur3" --install-option="--no-libev" --install-option="--no-cython"
+    pip3 install traceback-with-variables
 
     cargo install cxxbridge-cmd --root /usr/local
     if [ -f "$(node_exporter_fullpath)" ] && node_exporter_checksum; then


### PR DESCRIPTION
Using traceback_with_variables module, generate more detail traceback
with variables into debug log.
This will help fixing bugs which is hard to reproduce.