### PR TITLE
Futurize data_read_resolver::resolve and to_data_query_result

### DIFF
--- a/frozen_mutation.hh
+++ b/frozen_mutation.hh
@@ -174,6 +174,7 @@ public:
     // the mutation which was used to create this instance.
     // throws schema_mismatch_error otherwise.
     mutation unfreeze(schema_ptr s) const;
+    future<mutation> unfreeze_gently(schema_ptr s) const;
 
     // Automatically upgrades the stored mutation to the supplied schema with custom column mapping.
     mutation unfreeze_upgrading(schema_ptr schema, const column_mapping& cm) const;

--- a/mutation_partition.cc
+++ b/mutation_partition.cc
@@ -2080,11 +2080,10 @@ to_data_query_result(const reconcilable_result& r, schema_ptr s, const query::pa
     if (reverse == consume_in_reverse::no) {
         frozen_mutation_consumer_adaptor adaptor(s, consumer);
         for (const partition& p : r.partitions()) {
-            const auto res = p.mut().consume(s, adaptor);
+            const auto res = co_await p.mut().consume_gently(s, adaptor);
             if (res.stop == stop_iteration::yes) {
                 break;
             }
-            co_await coroutine::maybe_yield();
         }
     } else {
         for (const partition& p : r.partitions()) {

--- a/mutation_partition.cc
+++ b/mutation_partition.cc
@@ -2088,7 +2088,7 @@ to_data_query_result(const reconcilable_result& r, schema_ptr s, const query::pa
     } else {
         for (const partition& p : r.partitions()) {
             auto m = co_await p.mut().unfreeze_gently(s);
-            const auto res = std::move(m).consume(consumer, reverse);
+            const auto res = co_await std::move(m).consume_gently(consumer, reverse);
             if (res.stop == stop_iteration::yes) {
                 break;
             }

--- a/mutation_partition_view.hh
+++ b/mutation_partition_view.hh
@@ -58,14 +58,21 @@ private:
     template<typename Visitor>
     requires MutationViewVisitor<Visitor>
     void do_accept(const column_mapping&, Visitor& visitor) const;
+
+    template<typename Visitor>
+    requires MutationViewVisitor<Visitor>
+    future<> do_accept_gently(const column_mapping&, Visitor& visitor) const;
 public:
     static mutation_partition_view from_stream(utils::input_stream v) {
         return { v };
     }
     static mutation_partition_view from_view(ser::mutation_partition_view v);
     void accept(const schema& schema, partition_builder& visitor) const;
+    future<> accept_gently(const schema& schema, partition_builder& visitor) const;
     void accept(const column_mapping&, converting_mutation_partition_applier& visitor) const;
+    future<> accept_gently(const column_mapping&, converting_mutation_partition_applier& visitor) const;
     void accept(const column_mapping&, mutation_partition_view_virtual_visitor& mpvvv) const;
+    future<> accept_gently(const column_mapping&, mutation_partition_view_virtual_visitor& mpvvv) const;
 
     std::optional<clustering_key> first_row_key() const;
     std::optional<clustering_key> last_row_key() const;

--- a/mutation_query.hh
+++ b/mutation_query.hh
@@ -159,7 +159,7 @@ public:
     reconcilable_result consume_end_of_stream();
 };
 
-query::result to_data_query_result(
+future<query::result> to_data_query_result(
         const reconcilable_result&,
         schema_ptr,
         const query::partition_slice&,

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -3433,7 +3433,7 @@ public:
             const mutation& m = z.get<1>().mut;
             for (const version& v : z.get<0>()) {
                 auto diff = v.par
-                          ? m.partition().difference(schema, v.par->mut().unfreeze(schema).partition())
+                          ? m.partition().difference(schema, (co_await v.par->mut().unfreeze_gently(schema)).partition())
                           : mutation_partition(*schema, m.partition());
                 std::optional<mutation> mdiff;
                 if (!diff.empty()) {

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -3702,7 +3702,7 @@ protected:
                                || data_resolver->live_partition_count() >= original_partition_limit())
                         && !data_resolver->any_partition_short_read()) {
                     auto result = ::make_foreign(::make_lw_shared<query::result>(
-                            to_data_query_result(std::move(*rr_opt), _schema, _cmd->slice, _cmd->get_row_limit(), cmd->partition_limit)));
+                            co_await to_data_query_result(std::move(*rr_opt), _schema, _cmd->slice, _cmd->get_row_limit(), cmd->partition_limit)));
                     // wait for write to complete before returning result to prevent multiple concurrent read requests to
                     // trigger repair multiple times and to prevent quorum read to return an old value, even after a quorum
                     // another read had returned a newer value (but the newer value had not yet been sent to the other replicas)
@@ -5373,7 +5373,7 @@ storage_proxy::query_nonsingular_data_locally(schema_ptr s, lw_shared_ptr<query:
         ret = co_await query_data_on_all_shards(_db, std::move(s), *local_cmd, ranges, opts, std::move(trace_state), timeout);
     } else {
         auto res = co_await query_mutations_on_all_shards(_db, s, *local_cmd, ranges, std::move(trace_state), timeout);
-        ret = rpc::tuple(make_foreign(make_lw_shared<query::result>(to_data_query_result(std::move(*std::get<0>(res)), std::move(s), local_cmd->slice,
+        ret = rpc::tuple(make_foreign(make_lw_shared<query::result>(co_await to_data_query_result(std::move(*std::get<0>(res)), std::move(s), local_cmd->slice,
                 local_cmd->get_row_limit(), local_cmd->partition_limit, opts))), std::get<1>(res));
     }
     co_return ret;

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -3334,7 +3334,7 @@ public:
     bool all_reached_end() const {
         return _all_reached_end;
     }
-    std::optional<reconcilable_result> resolve(schema_ptr schema, const query::read_command& cmd, uint64_t original_row_limit, uint64_t original_per_partition_limit,
+    future<std::optional<reconcilable_result>> resolve(schema_ptr schema, const query::read_command& cmd, uint64_t original_row_limit, uint64_t original_per_partition_limit,
             uint32_t original_partition_limit) {
         assert(_data_results.size());
 
@@ -3343,7 +3343,7 @@ public:
             // should happen only for range reads since single key reads will not
             // try to reconcile for CL=ONE
             auto& p = _data_results[0].result;
-            return reconcilable_result(p->row_count(), p->partitions(), p->is_short_read());
+            co_return reconcilable_result(p->row_count(), p->partitions(), p->is_short_read());
         }
 
         const auto& s = *schema;
@@ -3406,28 +3406,24 @@ public:
         reconciled_partitions.reserve(versions.size());
 
         // reconcile all versions
-        boost::range::transform(boost::make_iterator_range(versions.begin(), versions.end()), std::back_inserter(reconciled_partitions),
-                                [this, schema, original_per_partition_limit] (std::vector<version>& v) {
+        for (std::vector<version>& v : versions) {
             auto it = boost::range::find_if(v, [] (auto&& ver) {
                     return bool(ver.par);
             });
-#if __cplusplus <= 201703L
-            using mutation_ref = mutation&;
-#else
-            using mutation_ref = mutation&&;
-#endif
-            auto m = boost::accumulate(v, mutation(schema, it->par->mut().key()), [this, schema] (mutation_ref m, const version& ver) {
+            auto m = mutation(schema, it->par->mut().key());
+            for (const version& ver : v) {
                 if (ver.par) {
                     mutation_application_stats app_stats;
                     m.partition().apply(*schema, ver.par->mut().partition(), *schema, app_stats);
+                    co_await coroutine::maybe_yield();
                 }
-                return std::move(m);
-            });
+            }
             auto live_row_count = m.live_row_count();
             _total_live_count += live_row_count;
             _live_partition_count += !!live_row_count;
-            return mutation_and_live_row_count { std::move(m), live_row_count };
-        });
+            reconciled_partitions.emplace_back(mutation_and_live_row_count{ std::move(m), live_row_count });
+            co_await coroutine::maybe_yield();
+        }
         _partition_count = reconciled_partitions.size();
 
         bool has_diff = false;
@@ -3454,13 +3450,14 @@ public:
                         }
                     }
                 }
+                co_await coroutine::maybe_yield();
             }
         }
 
         if (has_diff) {
             if (got_incomplete_information(*schema, cmd, original_row_limit, original_per_partition_limit,
                                            original_partition_limit, reconciled_partitions, versions)) {
-                return {};
+                co_return std::nullopt;
             }
             // filter out partitions with empty diffs
             for (auto it = _diffs.begin(); it != _diffs.end();) {
@@ -3486,12 +3483,14 @@ public:
         // build reconcilable_result from reconciled data
         // traverse backwards since large keys are at the start
         utils::chunked_vector<partition> vec;
-        auto r = boost::accumulate(reconciled_partitions | boost::adaptors::reversed, std::ref(vec), [] (utils::chunked_vector<partition>& a, const mutation_and_live_row_count& m_a_rc) {
-            a.emplace_back(partition(m_a_rc.live_row_count, freeze(m_a_rc.mut)));
-            return std::ref(a);
-        });
+        vec.reserve(_partition_count);
+        for (auto it = reconciled_partitions.rbegin(); it != reconciled_partitions.rend(); it++) {
+            const mutation_and_live_row_count& m_a_rc = *it;
+            vec.emplace_back(partition(m_a_rc.live_row_count, freeze(m_a_rc.mut)));
+            co_await coroutine::maybe_yield();
+        }
 
-        return reconcilable_result(_total_live_count, std::move(r.get()), _is_short_read);
+        co_return reconcilable_result(_total_live_count, std::move(vec), _is_short_read);
     }
     auto total_live_count() const {
         return _total_live_count;
@@ -3685,15 +3684,15 @@ protected:
         make_mutation_data_requests(cmd, data_resolver, _targets.begin(), _targets.end(), timeout);
 
         // Waited on indirectly.
-        (void)data_resolver->done().then_wrapped([this, exec, data_resolver, cmd = std::move(cmd), cl, timeout] (future<result<>> f) {
+        (void)data_resolver->done().then_wrapped([this, exec, data_resolver, cmd = std::move(cmd), cl, timeout] (future<result<>> f) -> future<> {
             try {
                 result<> res = f.get();
                 if (!res) {
                     _result_promise.set_value(std::move(res).as_failure());
                     on_read_resolved();
-                    return;
+                    co_return;
                 }
-                auto rr_opt = data_resolver->resolve(_schema, *cmd, original_row_limit(), original_per_partition_row_limit(), original_partition_limit()); // reconciliation happens here
+                auto rr_opt = co_await data_resolver->resolve(_schema, *cmd, original_row_limit(), original_per_partition_row_limit(), original_partition_limit()); // reconciliation happens here
 
                 // We generate a retry if at least one node reply with count live columns but after merge we have less
                 // than the total number of column we are interested in (which may be < count on a retry).

--- a/test/boost/mutation_query_test.cc
+++ b/test/boost/mutation_query_test.cc
@@ -74,8 +74,9 @@ static query::result_memory_accounter make_accounter() {
     return query::result_memory_accounter{ query::result_memory_limiter::unlimited_result_size };
 }
 
+// Called from a seastar thread
 query::result_set to_result_set(const reconcilable_result& r, schema_ptr s, const query::partition_slice& slice) {
-    return query::result_set::from_raw_result(s, slice, to_data_query_result(r, s, slice, inf32, inf32));
+    return query::result_set::from_raw_result(s, slice, to_data_query_result(r, s, slice, inf32, inf32).get0());
 }
 
 static reconcilable_result mutation_query(schema_ptr s, reader_permit permit, const mutation_source& source, const dht::partition_range& range,
@@ -460,28 +461,28 @@ SEASTAR_TEST_CASE(test_result_row_count) {
             auto src = make_source({m1});
 
             auto r = to_data_query_result(mutation_query(s, semaphore.make_permit(), make_source({m1}), query::full_partition_range, slice, 10000, query::max_partitions, now),
-                    s, slice, inf32, inf32);
+                    s, slice, inf32, inf32).get0();
             BOOST_REQUIRE_EQUAL(r.row_count().value(), 0);
 
             m1.set_static_cell("s1", data_value(bytes("S_v1")), 1);
             r = to_data_query_result(mutation_query(s, semaphore.make_permit(), make_source({m1}), query::full_partition_range, slice, 10000, query::max_partitions, now),
-                    s, slice, inf32, inf32);
+                    s, slice, inf32, inf32).get0();
             BOOST_REQUIRE_EQUAL(r.row_count().value(), 1);
 
             m1.set_clustered_cell(clustering_key::from_single_value(*s, bytes("A")), "v1", data_value(bytes("A_v1")), 1);
             r = to_data_query_result(mutation_query(s, semaphore.make_permit(), make_source({m1}), query::full_partition_range, slice, 10000, query::max_partitions, now),
-                    s, slice, inf32, inf32);
+                    s, slice, inf32, inf32).get0();
             BOOST_REQUIRE_EQUAL(r.row_count().value(), 1);
 
             m1.set_clustered_cell(clustering_key::from_single_value(*s, bytes("B")), "v1", data_value(bytes("B_v1")), 1);
             r = to_data_query_result(mutation_query(s, semaphore.make_permit(), make_source({m1}), query::full_partition_range, slice, 10000, query::max_partitions, now),
-                    s, slice, inf32, inf32);
+                    s, slice, inf32, inf32).get0();
             BOOST_REQUIRE_EQUAL(r.row_count().value(), 2);
 
             mutation m2(s, partition_key::from_single_value(*s, "key2"));
             m2.set_static_cell("s1", data_value(bytes("S_v1")), 1);
             r = to_data_query_result(mutation_query(s, semaphore.make_permit(), make_source({m1, m2}), query::full_partition_range, slice, 10000, query::max_partitions, now),
-                    s, slice, inf32, inf32);
+                    s, slice, inf32, inf32).get0();
             BOOST_REQUIRE_EQUAL(r.row_count().value(), 3);
     });
 }


### PR DESCRIPTION
This series futurizes two synchronous functions used for data reconciliation:
`data_read_resolver::resolve` and `to_data_query_result` and does so
by introducing lower-level asynchronous infrastructure:
`mutation_partition_view::accept_gently`,
`frozen_mutation::unfreeze_gently` and `frozen_mutation::consume_gently`,
and `mutation::consume_gently`.

This trades some cycles on this cold path to prevent known reactor stalls.

Fixes #2361
Fixes #10038