### PR TITLE
gms: feature_service: reduce boilerplate to add a cluster feature

### DIFF
--- a/alternator/streams.cc
+++ b/alternator/streams.cc
@@ -1045,10 +1045,10 @@ void executor::add_stream_options(const rjson::value& stream_specification, sche
     if (stream_enabled->GetBool()) {
         auto db = sp.data_dictionary();
 
-        if (!db.features().cluster_supports_cdc()) {
+        if (!db.features().cdc) {
             throw api_error::validation("StreamSpecification: streams (CDC) feature not enabled in cluster.");
         }
-        if (!db.features().cluster_supports_alternator_streams()) {
+        if (!db.features().alternator_streams) {
             throw api_error::validation("StreamSpecification: alternator streams feature not enabled in cluster.");
         }
 

--- a/alternator/ttl.cc
+++ b/alternator/ttl.cc
@@ -64,7 +64,7 @@ static const sstring TTL_TAG_KEY("system:ttl_attribute");
 
 future<executor::request_return_type> executor::update_time_to_live(client_state& client_state, service_permit permit, rjson::value request) {
     _stats.api_operations.update_time_to_live++;
-    if (!_proxy.data_dictionary().features().cluster_supports_alternator_ttl()) {
+    if (!_proxy.data_dictionary().features().alternator_ttl) {
         co_return api_error::unknown_operation("UpdateTimeToLive not yet supported. Experimental support is available if the 'alternator-ttl' experimental feature is enabled on all nodes.");
     }
 
@@ -118,7 +118,7 @@ future<executor::request_return_type> executor::update_time_to_live(client_state
 
 future<executor::request_return_type> executor::describe_time_to_live(client_state& client_state, service_permit permit, rjson::value request) {
     _stats.api_operations.describe_time_to_live++;
-    if (!_proxy.data_dictionary().features().cluster_supports_alternator_ttl()) {
+    if (!_proxy.data_dictionary().features().alternator_ttl) {
         co_return api_error::unknown_operation("DescribeTimeToLive not yet supported. Experimental support is available if the 'alternator_ttl' experimental feature is enabled on all nodes.");
     }
     schema_ptr schema = get_table(_proxy, request);
@@ -782,7 +782,7 @@ future<> expiration_service::run() {
 future<> expiration_service::start() {
     // Called by main() on each shard to start the expiration-service
     // thread. Just runs run() in the background and allows stop().
-    if (_db.features().cluster_supports_alternator_ttl()) {
+    if (_db.features().alternator_ttl) {
         if (!shutting_down()) {
             _end = run().handle_exception([] (std::exception_ptr ep) {
                 tlogger.error("expiration_service failed: {}", ep);

--- a/cdc/generation.cc
+++ b/cdc/generation.cc
@@ -340,7 +340,7 @@ future<cdc::generation_id> generation_service::make_new_generation(const std::un
     auto normal_token_owners = tmptr->count_normal_token_owners();
     assert(normal_token_owners);
 
-    if (_feature_service.cluster_supports_cdc_generations_v2()) {
+    if (_feature_service.cdc_generations_v2) {
         auto uuid = utils::make_random_uuid();
         cdc_log.info("Inserting new generation data at UUID {}", uuid);
         // This may take a while.
@@ -778,7 +778,7 @@ future<> generation_service::check_and_repair_cdc_streams() {
         cdc_log.warn("check_and_repair_cdc_streams: no generation observed in gossip");
         should_regenerate = true;
     } else if (std::holds_alternative<cdc::generation_id_v1>(*latest)
-            && _feature_service.cluster_supports_cdc_generations_v2()) {
+            && _feature_service.cdc_generations_v2) {
         cdc_log.info(
             "Cluster still using CDC generation storage format V1 (id: {}), even though it already understands the V2 format."
             " Creating a new generation using V2.", *latest);

--- a/cql3/statements/alter_keyspace_statement.cc
+++ b/cql3/statements/alter_keyspace_statement.cc
@@ -61,7 +61,7 @@ void cql3::statements::alter_keyspace_statement::validate(query_processor& qp, c
         } catch (const std::runtime_error& e) {
             throw exceptions::invalid_request_exception(e.what());
         }
-        if (!qp.proxy().features().cluster_supports_keyspace_storage_options()
+        if (!qp.proxy().features().keyspace_storage_options
             && _attrs->get_storage_options().type_string() != "LOCAL") {
         throw exceptions::invalid_request_exception("Keyspace storage options not supported in the cluster");
     }

--- a/cql3/statements/cf_prop_defs.cc
+++ b/cql3/statements/cf_prop_defs.cc
@@ -121,12 +121,12 @@ void cf_prop_defs::validate(const data_dictionary::database db, sstring ks_name,
         cp.validate();
     }
 
-    if (auto caching_options = get_caching_options(); caching_options && !caching_options->enabled() && !db.features().cluster_supports_per_table_caching()) {
+    if (auto caching_options = get_caching_options(); caching_options && !caching_options->enabled() && !db.features().per_table_caching) {
         throw exceptions::configuration_exception(KW_CACHING + " can't contain \"'enabled':false\" unless whole cluster supports it");
     }
 
     auto cdc_options = get_cdc_options(schema_extensions);
-    if (cdc_options && cdc_options->enabled() && !db.features().cluster_supports_cdc()) {
+    if (cdc_options && cdc_options->enabled() && !db.features().cdc) {
         throw exceptions::configuration_exception("CDC not supported by the cluster");
     }
 

--- a/cql3/statements/create_aggregate_statement.cc
+++ b/cql3/statements/create_aggregate_statement.cc
@@ -23,7 +23,7 @@ namespace cql3 {
 namespace statements {
 
 shared_ptr<functions::function> create_aggregate_statement::create(query_processor& qp, functions::function* old) const {
-    if (!qp.proxy().features().cluster_supports_user_defined_aggregates()) {
+    if (!qp.proxy().features().user_defined_aggregates) {
         throw exceptions::invalid_request_exception("Cluster does not support user-defined aggregates, upgrade the whole cluster in order to use UDA");
     }
     if (old && !dynamic_cast<functions::user_aggregate*>(old)) {

--- a/cql3/statements/create_keyspace_statement.cc
+++ b/cql3/statements/create_keyspace_statement.cc
@@ -79,7 +79,7 @@ void create_keyspace_statement::validate(query_processor& qp, const service::cli
     } catch (const std::runtime_error& e) {
         throw exceptions::invalid_request_exception(e.what());
     }
-    if (!qp.proxy().features().cluster_supports_keyspace_storage_options()
+    if (!qp.proxy().features().keyspace_storage_options
             && _attrs->get_storage_options().type_string() != "LOCAL") {
         throw exceptions::invalid_request_exception("Keyspace storage options not supported in the cluster");
     }

--- a/cql3/statements/create_table_statement.cc
+++ b/cql3/statements/create_table_statement.cc
@@ -209,7 +209,7 @@ std::unique_ptr<prepared_statement> create_table_statement::raw_statement::prepa
                     }
                 }
 
-                if (!db.features().cluster_supports_nonfrozen_udts()) {
+                if (!db.features().nonfrozen_udts) {
                     throw exceptions::invalid_request_exception("Non-frozen UDT support is not enabled");
                 }
             }

--- a/cql3/statements/function_statement.cc
+++ b/cql3/statements/function_statement.cc
@@ -57,7 +57,7 @@ data_type function_statement::prepare_type(query_processor& qp, cql3_type::raw& 
 }
 
 void function_statement::create_arg_types(query_processor& qp) const {
-    if (!qp.proxy().features().cluster_supports_user_defined_functions()) {
+    if (!qp.proxy().features().user_defined_functions) {
         throw exceptions::invalid_request_exception("User defined functions are disabled. Set enable_user_defined_functions and experimental_features:udf to enable them");
     }
 

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -1633,7 +1633,7 @@ std::unique_ptr<prepared_statement> select_statement::prepare(data_dictionary::d
             && !restrictions->need_filtering()  // No filtering
             && group_by_cell_indices->empty()   // No GROUP BY
             // All potential intermediate coordinators must support forwarding
-            && db.features().cluster_supports_parallelized_aggregation()
+            && db.features().parallelized_aggregation
             && db.get_config().enable_parallelized_aggregation();
     };
 

--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -2257,7 +2257,7 @@ static void make_update_indices_mutations(
     mutation indices_mutation(indexes(), partition_key::from_singular(*indexes(), old_table->ks_name()));
 
     auto diff = difference(old_table->all_indices(), new_table->all_indices());
-    bool new_token_column_computation = db.features().cluster_supports_correct_idx_token_in_secondary_index();
+    bool new_token_column_computation = db.features().correct_idx_token_in_secondary_index;
 
     // indices that are no longer needed
     for (auto&& name : diff.entries_only_on_left) {

--- a/db/sstables-format-selector.cc
+++ b/db/sstables-format-selector.cc
@@ -62,8 +62,8 @@ future<> sstables_format_selector::do_maybe_select_format(sstables::sstable_vers
 future<> sstables_format_selector::start() {
     assert(this_shard_id() == 0);
     return read_sstables_format().then([this] {
-        _features.local().cluster_supports_me_sstable().when_enabled(_me_feature_listener);
-        _features.local().cluster_supports_md_sstable().when_enabled(_md_feature_listener);
+        _features.local().me_sstable.when_enabled(_me_feature_listener);
+        _features.local().md_sstable.when_enabled(_md_feature_listener);
         return make_ready_future<>();
     });
 }

--- a/gms/feature.hh
+++ b/gms/feature.hh
@@ -70,7 +70,7 @@ public:
     const sstring& name() const {
         return _name;
     }
-    explicit operator bool() const {
+    operator bool() const {
         return _enabled;
     }
     friend inline std::ostream& operator<<(std::ostream& os, const feature& f) {

--- a/gms/feature.hh
+++ b/gms/feature.hh
@@ -96,34 +96,4 @@ public:
     }
 };
 
-namespace features {
-
-extern const std::string_view UDF;
-extern const std::string_view MD_SSTABLE;
-extern const std::string_view ME_SSTABLE;
-extern const std::string_view VIEW_VIRTUAL_COLUMNS;
-extern const std::string_view DIGEST_INSENSITIVE_TO_EXPIRY;
-extern const std::string_view COMPUTED_COLUMNS;
-extern const std::string_view CDC;
-extern const std::string_view NONFROZEN_UDTS;
-extern const std::string_view HINTED_HANDOFF_SEPARATE_CONNECTION;
-extern const std::string_view LWT;
-extern const std::string_view PER_TABLE_PARTITIONERS;
-extern const std::string_view PER_TABLE_CACHING;
-extern const std::string_view DIGEST_FOR_NULL_VALUES;
-extern const std::string_view CORRECT_IDX_TOKEN_IN_SECONDARY_INDEX;
-extern const std::string_view ALTERNATOR_STREAMS;
-extern const std::string_view ALTERNATOR_TTL;
-extern const std::string_view RANGE_SCAN_DATA_VARIANT;
-extern const std::string_view CDC_GENERATIONS_V2;
-extern const std::string_view UDA;
-extern const std::string_view SEPARATE_PAGE_SIZE_AND_SAFETY_LIMIT;
-extern const std::string_view SUPPORTS_RAFT_CLUSTER_MANAGEMENT;
-extern const std::string_view USES_RAFT_CLUSTER_MANAGEMENT;
-extern const std::string_view TOMBSTONE_GC_OPTIONS;
-extern const std::string_view PARALLELIZED_AGGREGATION;
-extern const std::string_view KEYSPACE_STORAGE_OPTIONS;
-
-}
-
 } // namespace gms

--- a/gms/feature.hh
+++ b/gms/feature.hh
@@ -98,28 +98,9 @@ public:
 
 namespace features {
 
-extern const std::string_view RANGE_TOMBSTONES;
-extern const std::string_view LARGE_PARTITIONS;
-extern const std::string_view MATERIALIZED_VIEWS;
-extern const std::string_view COUNTERS;
-extern const std::string_view INDEXES;
-extern const std::string_view DIGEST_MULTIPARTITION_READ;
-extern const std::string_view CORRECT_COUNTER_ORDER;
-extern const std::string_view SCHEMA_TABLES_V3;
-extern const std::string_view CORRECT_NON_COMPOUND_RANGE_TOMBSTONES;
-extern const std::string_view WRITE_FAILURE_REPLY;
-extern const std::string_view XXHASH;
 extern const std::string_view UDF;
-extern const std::string_view ROLES;
-extern const std::string_view LA_SSTABLE;
-extern const std::string_view STREAM_WITH_RPC_STREAM;
-extern const std::string_view MC_SSTABLE;
 extern const std::string_view MD_SSTABLE;
 extern const std::string_view ME_SSTABLE;
-extern const std::string_view ROW_LEVEL_REPAIR;
-extern const std::string_view TRUNCATION_TABLE;
-extern const std::string_view CORRECT_STATIC_COMPACT_IN_MC;
-extern const std::string_view UNBOUNDED_RANGE_TOMBSTONES;
 extern const std::string_view VIEW_VIRTUAL_COLUMNS;
 extern const std::string_view DIGEST_INSENSITIVE_TO_EXPIRY;
 extern const std::string_view COMPUTED_COLUMNS;

--- a/gms/feature_service.cc
+++ b/gms/feature_service.cc
@@ -18,28 +18,9 @@
 #include <boost/algorithm/string/classification.hpp>
 #include <boost/algorithm/string/split.hpp>
 
-namespace gms {
+using namespace std::literals;
 
-// Deprecated features - sent to other nodes via gossip, but assumed true in the code
-constexpr std::string_view features::RANGE_TOMBSTONES = "RANGE_TOMBSTONES";
-constexpr std::string_view features::LARGE_PARTITIONS = "LARGE_PARTITIONS";
-constexpr std::string_view features::MATERIALIZED_VIEWS = "MATERIALIZED_VIEWS";
-constexpr std::string_view features::COUNTERS = "COUNTERS";
-constexpr std::string_view features::INDEXES = "INDEXES";
-constexpr std::string_view features::DIGEST_MULTIPARTITION_READ = "DIGEST_MULTIPARTITION_READ";
-constexpr std::string_view features::CORRECT_COUNTER_ORDER = "CORRECT_COUNTER_ORDER";
-constexpr std::string_view features::SCHEMA_TABLES_V3 = "SCHEMA_TABLES_V3";
-constexpr std::string_view features::CORRECT_NON_COMPOUND_RANGE_TOMBSTONES = "CORRECT_NON_COMPOUND_RANGE_TOMBSTONES";
-constexpr std::string_view features::WRITE_FAILURE_REPLY = "WRITE_FAILURE_REPLY";
-constexpr std::string_view features::XXHASH = "XXHASH";
-constexpr std::string_view features::ROLES = "ROLES";
-constexpr std::string_view features::LA_SSTABLE = "LA_SSTABLE_FORMAT";
-constexpr std::string_view features::STREAM_WITH_RPC_STREAM = "STREAM_WITH_RPC_STREAM";
-constexpr std::string_view features::ROW_LEVEL_REPAIR = "ROW_LEVEL_REPAIR";
-constexpr std::string_view features::TRUNCATION_TABLE = "TRUNCATION_TABLE";
-constexpr std::string_view features::CORRECT_STATIC_COMPACT_IN_MC = "CORRECT_STATIC_COMPACT_IN_MC";
-constexpr std::string_view features::UNBOUNDED_RANGE_TOMBSTONES = "UNBOUNDED_RANGE_TOMBSTONES";
-constexpr std::string_view features::MC_SSTABLE = "MC_SSTABLE_FORMAT";
+namespace gms {
 
 // Up-to-date features
 constexpr std::string_view features::UDF = "UDF";
@@ -192,25 +173,25 @@ std::set<std::string_view> feature_service::known_feature_set() {
     // return sstring("FEATURE1,FEATURE2")
     std::set<std::string_view> features = {
         // Deprecated features - sent to other nodes via gossip, but assumed true in the code
-        gms::features::RANGE_TOMBSTONES,
-        gms::features::LARGE_PARTITIONS,
-        gms::features::COUNTERS,
-        gms::features::DIGEST_MULTIPARTITION_READ,
-        gms::features::CORRECT_COUNTER_ORDER,
-        gms::features::SCHEMA_TABLES_V3,
-        gms::features::CORRECT_NON_COMPOUND_RANGE_TOMBSTONES,
-        gms::features::WRITE_FAILURE_REPLY,
-        gms::features::XXHASH,
-        gms::features::ROLES,
-        gms::features::LA_SSTABLE,
-        gms::features::STREAM_WITH_RPC_STREAM,
-        gms::features::MATERIALIZED_VIEWS,
-        gms::features::INDEXES,
-        gms::features::ROW_LEVEL_REPAIR,
-        gms::features::TRUNCATION_TABLE,
-        gms::features::CORRECT_STATIC_COMPACT_IN_MC,
-        gms::features::UNBOUNDED_RANGE_TOMBSTONES,
-        gms::features::MC_SSTABLE,
+        "RANGE_TOMBSTONES"sv,
+        "LARGE_PARTITIONS"sv,
+        "COUNTERS"sv,
+        "DIGEST_MULTIPARTITION_READ"sv,
+        "CORRECT_COUNTER_ORDER"sv,
+        "SCHEMA_TABLES_V3"sv,
+        "CORRECT_NON_COMPOUND_RANGE_TOMBSTONES"sv,
+        "WRITE_FAILURE_REPLY"sv,
+        "XXHASH"sv,
+        "ROLES"sv,
+        "LA_SSTABLE_FORMAT"sv,
+        "STREAM_WITH_RPC_STREAM"sv,
+        "MATERIALIZED_VIEWS"sv,
+        "INDEXES"sv,
+        "ROW_LEVEL_REPAIR"sv,
+        "TRUNCATION_TABLE"sv,
+        "CORRECT_STATIC_COMPACT_IN_MC"sv,
+        "UNBOUNDED_RANGE_TOMBSTONES"sv,
+        "MC_SSTABLE_FORMAT"sv,
     };
 
     for (auto& [name, f_ref] : _registered_features) {

--- a/gms/feature_service.cc
+++ b/gms/feature_service.cc
@@ -211,34 +211,11 @@ std::set<std::string_view> feature_service::known_feature_set() {
         gms::features::CORRECT_STATIC_COMPACT_IN_MC,
         gms::features::UNBOUNDED_RANGE_TOMBSTONES,
         gms::features::MC_SSTABLE,
-
-        // Up-to-date features
-        gms::features::VIEW_VIRTUAL_COLUMNS,
-        gms::features::DIGEST_INSENSITIVE_TO_EXPIRY,
-        gms::features::COMPUTED_COLUMNS,
-        gms::features::NONFROZEN_UDTS,
-        gms::features::HINTED_HANDOFF_SEPARATE_CONNECTION,
-        gms::features::PER_TABLE_PARTITIONERS,
-        gms::features::PER_TABLE_CACHING,
-        gms::features::LWT,
-        gms::features::MD_SSTABLE,
-        gms::features::ME_SSTABLE,
-        gms::features::UDF,
-        gms::features::CDC,
-        gms::features::DIGEST_FOR_NULL_VALUES,
-        gms::features::CORRECT_IDX_TOKEN_IN_SECONDARY_INDEX,
-        gms::features::ALTERNATOR_STREAMS,
-        gms::features::ALTERNATOR_TTL,
-        gms::features::RANGE_SCAN_DATA_VARIANT,
-        gms::features::CDC_GENERATIONS_V2,
-        gms::features::UDA,
-        gms::features::SEPARATE_PAGE_SIZE_AND_SAFETY_LIMIT,
-        gms::features::SUPPORTS_RAFT_CLUSTER_MANAGEMENT,
-        gms::features::USES_RAFT_CLUSTER_MANAGEMENT,
-        gms::features::TOMBSTONE_GC_OPTIONS,
-        gms::features::PARALLELIZED_AGGREGATION,
-        gms::features::KEYSPACE_STORAGE_OPTIONS,
     };
+
+    for (auto& [name, f_ref] : _registered_features) {
+        features.insert(name);
+    }
 
     for (const sstring& s : _config._disabled_features) {
         features.erase(s);

--- a/gms/feature_service.cc
+++ b/gms/feature_service.cc
@@ -17,6 +17,7 @@
 #include "to_string.hh"
 #include <boost/algorithm/string/classification.hpp>
 #include <boost/algorithm/string/split.hpp>
+#include <boost/range/adaptor/map.hpp>
 
 namespace gms {
 
@@ -229,34 +230,7 @@ void feature_service::persist_enabled_feature_info(const gms::feature& f) const 
 }
 
 void feature_service::enable(const std::set<std::string_view>& list) {
-    for (gms::feature& f : {
-        std::ref(_udf_feature),
-        std::ref(_md_sstable_feature),
-        std::ref(_me_sstable_feature),
-        std::ref(_view_virtual_columns),
-        std::ref(_digest_insensitive_to_expiry),
-        std::ref(_computed_columns),
-        std::ref(_cdc_feature),
-        std::ref(_nonfrozen_udts),
-        std::ref(_hinted_handoff_separate_connection),
-        std::ref(_lwt_feature),
-        std::ref(_per_table_partitioners_feature),
-        std::ref(_per_table_caching_feature),
-        std::ref(_digest_for_null_values_feature),
-        std::ref(_correct_idx_token_in_secondary_index_feature),
-        std::ref(_alternator_streams_feature),
-        std::ref(_alternator_ttl_feature),
-        std::ref(_range_scan_data_variant),
-        std::ref(_cdc_generations_v2),
-        std::ref(_uda),
-        std::ref(_separate_page_size_and_safety_limit),
-        std::ref(_supports_raft_cluster_mgmt),
-        std::ref(_uses_raft_cluster_mgmt),
-        std::ref(_tombstone_gc_options),
-        std::ref(_parallelized_aggregation),
-        std::ref(_keyspace_storage_options),
-    })
-    {
+    for (gms::feature& f : _registered_features | boost::adaptors::map_values) {
         if (list.contains(f.name())) {
             if (db::qctx && !f) {
                 persist_enabled_feature_info(f);

--- a/gms/feature_service.cc
+++ b/gms/feature_service.cc
@@ -18,8 +18,6 @@
 #include <boost/algorithm/string/classification.hpp>
 #include <boost/algorithm/string/split.hpp>
 
-using namespace std::literals;
-
 namespace gms {
 
 static logging::logger logger("features");
@@ -28,31 +26,6 @@ feature_config::feature_config() {
 }
 
 feature_service::feature_service(feature_config cfg) : _config(cfg)
-        , _udf_feature(*this, "UDF"sv)
-        , _md_sstable_feature(*this, "MD_SSTABLE_FORMAT"sv)
-        , _me_sstable_feature(*this, "ME_SSTABLE_FORMAT"sv)
-        , _view_virtual_columns(*this, "VIEW_VIRTUAL_COLUMNS"sv)
-        , _digest_insensitive_to_expiry(*this, "DIGEST_INSENSITIVE_TO_EXPIRY"sv)
-        , _computed_columns(*this, "COMPUTED_COLUMNS"sv)
-        , _cdc_feature(*this, "CDC"sv)
-        , _nonfrozen_udts(*this, "NONFROZEN_UDTS"sv)
-        , _hinted_handoff_separate_connection(*this, "HINTED_HANDOFF_SEPARATE_CONNECTION"sv)
-        , _lwt_feature(*this, "LWT"sv)
-        , _per_table_partitioners_feature(*this, "PER_TABLE_PARTITIONERS"sv)
-        , _per_table_caching_feature(*this, "PER_TABLE_CACHING"sv)
-        , _digest_for_null_values_feature(*this, "DIGEST_FOR_NULL_VALUES"sv)
-        , _correct_idx_token_in_secondary_index_feature(*this, "CORRECT_IDX_TOKEN_IN_SECONDARY_INDEX"sv)
-        , _alternator_streams_feature(*this, "ALTERNATOR_STREAMS"sv)
-        , _alternator_ttl_feature(*this, "ALTERNATOR_TTL"sv)
-        , _range_scan_data_variant(*this, "RANGE_SCAN_DATA_VARIANT"sv)
-        , _cdc_generations_v2(*this, "CDC_GENERATIONS_V2"sv)
-        , _uda(*this, "UDA"sv)
-        , _separate_page_size_and_safety_limit(*this, "SEPARATE_PAGE_SIZE_AND_SAFETY_LIMIT"sv)
-        , _supports_raft_cluster_mgmt(*this, "SUPPORTS_RAFT_CLUSTER_MANAGEMENT"sv)
-        , _uses_raft_cluster_mgmt(*this, "USES_RAFT_CLUSTER_MANAGEMENT"sv)
-        , _tombstone_gc_options(*this, "TOMBSTONE_GC_OPTIONS"sv)
-        , _parallelized_aggregation(*this, "PARALLELIZED_AGGREGATION"sv)
-        , _keyspace_storage_options(*this, "KEYSPACE_STORAGE_OPTIONS"sv)
 {}
 
 feature_config feature_config_from_db_config(db::config& cfg, std::set<sstring> disabled) {

--- a/gms/feature_service.cc
+++ b/gms/feature_service.cc
@@ -199,12 +199,12 @@ void feature::enable() {
 
 db::schema_features feature_service::cluster_schema_features() const {
     db::schema_features f;
-    f.set_if<db::schema_feature::VIEW_VIRTUAL_COLUMNS>(bool(_view_virtual_columns));
-    f.set_if<db::schema_feature::DIGEST_INSENSITIVE_TO_EXPIRY>(bool(_digest_insensitive_to_expiry));
-    f.set_if<db::schema_feature::COMPUTED_COLUMNS>(bool(_computed_columns));
-    f.set_if<db::schema_feature::CDC_OPTIONS>(bool(_cdc_feature));
-    f.set_if<db::schema_feature::PER_TABLE_PARTITIONERS>(bool(_per_table_partitioners_feature));
-    f.set_if<db::schema_feature::SCYLLA_KEYSPACES>(bool(_keyspace_storage_options));
+    f.set_if<db::schema_feature::VIEW_VIRTUAL_COLUMNS>(view_virtual_columns);
+    f.set_if<db::schema_feature::DIGEST_INSENSITIVE_TO_EXPIRY>(digest_insensitive_to_expiry);
+    f.set_if<db::schema_feature::COMPUTED_COLUMNS>(computed_columns);
+    f.set_if<db::schema_feature::CDC_OPTIONS>(cdc);
+    f.set_if<db::schema_feature::PER_TABLE_PARTITIONERS>(per_table_partitioners);
+    f.set_if<db::schema_feature::SCYLLA_KEYSPACES>(keyspace_storage_options);
     return f;
 }
 

--- a/gms/feature_service.cc
+++ b/gms/feature_service.cc
@@ -22,64 +22,37 @@ using namespace std::literals;
 
 namespace gms {
 
-// Up-to-date features
-constexpr std::string_view features::UDF = "UDF";
-constexpr std::string_view features::MD_SSTABLE = "MD_SSTABLE_FORMAT";
-constexpr std::string_view features::ME_SSTABLE = "ME_SSTABLE_FORMAT";
-constexpr std::string_view features::VIEW_VIRTUAL_COLUMNS = "VIEW_VIRTUAL_COLUMNS";
-constexpr std::string_view features::DIGEST_INSENSITIVE_TO_EXPIRY = "DIGEST_INSENSITIVE_TO_EXPIRY";
-constexpr std::string_view features::COMPUTED_COLUMNS = "COMPUTED_COLUMNS";
-constexpr std::string_view features::CDC = "CDC";
-constexpr std::string_view features::NONFROZEN_UDTS = "NONFROZEN_UDTS";
-constexpr std::string_view features::HINTED_HANDOFF_SEPARATE_CONNECTION = "HINTED_HANDOFF_SEPARATE_CONNECTION";
-constexpr std::string_view features::LWT = "LWT";
-constexpr std::string_view features::PER_TABLE_PARTITIONERS = "PER_TABLE_PARTITIONERS";
-constexpr std::string_view features::PER_TABLE_CACHING = "PER_TABLE_CACHING";
-constexpr std::string_view features::DIGEST_FOR_NULL_VALUES = "DIGEST_FOR_NULL_VALUES";
-constexpr std::string_view features::CORRECT_IDX_TOKEN_IN_SECONDARY_INDEX = "CORRECT_IDX_TOKEN_IN_SECONDARY_INDEX";
-constexpr std::string_view features::ALTERNATOR_STREAMS = "ALTERNATOR_STREAMS";
-constexpr std::string_view features::ALTERNATOR_TTL = "ALTERNATOR_TTL";
-constexpr std::string_view features::RANGE_SCAN_DATA_VARIANT = "RANGE_SCAN_DATA_VARIANT";
-constexpr std::string_view features::CDC_GENERATIONS_V2 = "CDC_GENERATIONS_V2";
-constexpr std::string_view features::UDA = "UDA";
-constexpr std::string_view features::SEPARATE_PAGE_SIZE_AND_SAFETY_LIMIT = "SEPARATE_PAGE_SIZE_AND_SAFETY_LIMIT";
-constexpr std::string_view features::SUPPORTS_RAFT_CLUSTER_MANAGEMENT = "SUPPORTS_RAFT_CLUSTER_MANAGEMENT";
-constexpr std::string_view features::USES_RAFT_CLUSTER_MANAGEMENT = "USES_RAFT_CLUSTER_MANAGEMENT";
-constexpr std::string_view features::TOMBSTONE_GC_OPTIONS = "TOMBSTONE_GC_OPTIONS";
-constexpr std::string_view features::PARALLELIZED_AGGREGATION = "PARALLELIZED_AGGREGATION";
-constexpr std::string_view features::KEYSPACE_STORAGE_OPTIONS = "KEYSPACE_STORAGE_OPTIONS";
-
 static logging::logger logger("features");
 
 feature_config::feature_config() {
 }
 
 feature_service::feature_service(feature_config cfg) : _config(cfg)
-        , _udf_feature(*this, features::UDF)
-        , _md_sstable_feature(*this, features::MD_SSTABLE)
-        , _me_sstable_feature(*this, features::ME_SSTABLE)
-        , _view_virtual_columns(*this, features::VIEW_VIRTUAL_COLUMNS)
-        , _digest_insensitive_to_expiry(*this, features::DIGEST_INSENSITIVE_TO_EXPIRY)
-        , _computed_columns(*this, features::COMPUTED_COLUMNS)
-        , _cdc_feature(*this, features::CDC)
-        , _nonfrozen_udts(*this, features::NONFROZEN_UDTS)
-        , _hinted_handoff_separate_connection(*this, features::HINTED_HANDOFF_SEPARATE_CONNECTION)
-        , _lwt_feature(*this, features::LWT)
-        , _per_table_partitioners_feature(*this, features::PER_TABLE_PARTITIONERS)
-        , _per_table_caching_feature(*this, features::PER_TABLE_CACHING)
-        , _digest_for_null_values_feature(*this, features::DIGEST_FOR_NULL_VALUES)
-        , _correct_idx_token_in_secondary_index_feature(*this, features::CORRECT_IDX_TOKEN_IN_SECONDARY_INDEX)
-        , _alternator_streams_feature(*this, features::ALTERNATOR_STREAMS)
-        , _alternator_ttl_feature(*this, features::ALTERNATOR_TTL)
-        , _range_scan_data_variant(*this, features::RANGE_SCAN_DATA_VARIANT)
-        , _cdc_generations_v2(*this, features::CDC_GENERATIONS_V2)
-        , _uda(*this, features::UDA)
-        , _separate_page_size_and_safety_limit(*this, features::SEPARATE_PAGE_SIZE_AND_SAFETY_LIMIT)
-        , _supports_raft_cluster_mgmt(*this, features::SUPPORTS_RAFT_CLUSTER_MANAGEMENT)
-        , _uses_raft_cluster_mgmt(*this, features::USES_RAFT_CLUSTER_MANAGEMENT)
-        , _tombstone_gc_options(*this, features::TOMBSTONE_GC_OPTIONS)
-        , _parallelized_aggregation(*this, features::PARALLELIZED_AGGREGATION)
-        , _keyspace_storage_options(*this, features::KEYSPACE_STORAGE_OPTIONS)
+        , _udf_feature(*this, "UDF"sv)
+        , _md_sstable_feature(*this, "MD_SSTABLE_FORMAT"sv)
+        , _me_sstable_feature(*this, "ME_SSTABLE_FORMAT"sv)
+        , _view_virtual_columns(*this, "VIEW_VIRTUAL_COLUMNS"sv)
+        , _digest_insensitive_to_expiry(*this, "DIGEST_INSENSITIVE_TO_EXPIRY"sv)
+        , _computed_columns(*this, "COMPUTED_COLUMNS"sv)
+        , _cdc_feature(*this, "CDC"sv)
+        , _nonfrozen_udts(*this, "NONFROZEN_UDTS"sv)
+        , _hinted_handoff_separate_connection(*this, "HINTED_HANDOFF_SEPARATE_CONNECTION"sv)
+        , _lwt_feature(*this, "LWT"sv)
+        , _per_table_partitioners_feature(*this, "PER_TABLE_PARTITIONERS"sv)
+        , _per_table_caching_feature(*this, "PER_TABLE_CACHING"sv)
+        , _digest_for_null_values_feature(*this, "DIGEST_FOR_NULL_VALUES"sv)
+        , _correct_idx_token_in_secondary_index_feature(*this, "CORRECT_IDX_TOKEN_IN_SECONDARY_INDEX"sv)
+        , _alternator_streams_feature(*this, "ALTERNATOR_STREAMS"sv)
+        , _alternator_ttl_feature(*this, "ALTERNATOR_TTL"sv)
+        , _range_scan_data_variant(*this, "RANGE_SCAN_DATA_VARIANT"sv)
+        , _cdc_generations_v2(*this, "CDC_GENERATIONS_V2"sv)
+        , _uda(*this, "UDA"sv)
+        , _separate_page_size_and_safety_limit(*this, "SEPARATE_PAGE_SIZE_AND_SAFETY_LIMIT"sv)
+        , _supports_raft_cluster_mgmt(*this, "SUPPORTS_RAFT_CLUSTER_MANAGEMENT"sv)
+        , _uses_raft_cluster_mgmt(*this, "USES_RAFT_CLUSTER_MANAGEMENT"sv)
+        , _tombstone_gc_options(*this, "TOMBSTONE_GC_OPTIONS"sv)
+        , _parallelized_aggregation(*this, "PARALLELIZED_AGGREGATION"sv)
+        , _keyspace_storage_options(*this, "KEYSPACE_STORAGE_OPTIONS"sv)
 {}
 
 feature_config feature_config_from_db_config(db::config& cfg, std::set<sstring> disabled) {
@@ -91,17 +64,17 @@ feature_config feature_config_from_db_config(db::config& cfg, std::set<sstring> 
     case sstables::sstable_version_types::ka:
     case sstables::sstable_version_types::la:
     case sstables::sstable_version_types::mc:
-        fcfg._disabled_features.insert(sstring(gms::features::MD_SSTABLE));
+        fcfg._disabled_features.insert("MD_SSTABLE_FORMAT"s);
         [[fallthrough]];
     case sstables::sstable_version_types::md:
-        fcfg._disabled_features.insert(sstring(gms::features::ME_SSTABLE));
+        fcfg._disabled_features.insert("ME_SSTABLE_FORMAT"s);
         [[fallthrough]];
     case sstables::sstable_version_types::me:
         break;
     }
 
     if (!cfg.enable_user_defined_functions()) {
-        fcfg._disabled_features.insert(sstring(gms::features::UDF));
+        fcfg._disabled_features.insert("UDF");
     } else {
         if (!cfg.check_experimental(db::experimental_features_t::UDF)) {
             throw std::runtime_error(
@@ -111,23 +84,23 @@ feature_config feature_config_from_db_config(db::config& cfg, std::set<sstring> 
     }
 
     if (!cfg.check_experimental(db::experimental_features_t::ALTERNATOR_STREAMS)) {
-        fcfg._disabled_features.insert(sstring(gms::features::ALTERNATOR_STREAMS));
+        fcfg._disabled_features.insert("ALTERNATOR_STREAMS"s);
     }
     if (!cfg.check_experimental(db::experimental_features_t::ALTERNATOR_TTL)) {
-        fcfg._disabled_features.insert(sstring(gms::features::ALTERNATOR_TTL));
+        fcfg._disabled_features.insert("ALTERNATOR_TTL"s);
     }
     if (!cfg.check_experimental(db::experimental_features_t::RAFT)) {
-        fcfg._disabled_features.insert(sstring(gms::features::SUPPORTS_RAFT_CLUSTER_MANAGEMENT));
-        fcfg._disabled_features.insert(sstring(gms::features::USES_RAFT_CLUSTER_MANAGEMENT));
+        fcfg._disabled_features.insert("SUPPORTS_RAFT_CLUSTER_MANAGEMENT"s);
+        fcfg._disabled_features.insert("USES_RAFT_CLUSTER_MANAGEMENT"s);
     } else {
         // Disable support for using raft cluster management so that it cannot
         // be enabled by accident.
         // This prevents the `USES_RAFT_CLUSTER_MANAGEMENT` feature from being
         // advertised via gossip ahead of time.
-        fcfg._masked_features.insert(sstring(gms::features::USES_RAFT_CLUSTER_MANAGEMENT));
+        fcfg._masked_features.insert("USES_RAFT_CLUSTER_MANAGEMENT"s);
     }
     if (!cfg.check_experimental(db::experimental_features_t::KEYSPACE_STORAGE_OPTIONS)) {
-        fcfg._disabled_features.insert(sstring(gms::features::KEYSPACE_STORAGE_OPTIONS));
+        fcfg._disabled_features.insert("KEYSPACE_STORAGE_OPTIONS"s);
     }
 
     return fcfg;

--- a/gms/feature_service.hh
+++ b/gms/feature_service.hh
@@ -38,6 +38,8 @@ private:
 
 feature_config feature_config_from_db_config(db::config& cfg, std::set<sstring> disabled = {});
 
+using namespace std::literals;
+
 /**
  * A gossip feature tracks whether all the nodes the current one is
  * aware of support the specified feature.
@@ -69,31 +71,31 @@ public:
     static constexpr const char* ENABLED_FEATURES_KEY = "enabled_features";
 
 private:
-    gms::feature _udf_feature;
-    gms::feature _md_sstable_feature;
-    gms::feature _me_sstable_feature;
-    gms::feature _view_virtual_columns;
-    gms::feature _digest_insensitive_to_expiry;
-    gms::feature _computed_columns;
-    gms::feature _cdc_feature;
-    gms::feature _nonfrozen_udts;
-    gms::feature _hinted_handoff_separate_connection;
-    gms::feature _lwt_feature;
-    gms::feature _per_table_partitioners_feature;
-    gms::feature _per_table_caching_feature;
-    gms::feature _digest_for_null_values_feature;
-    gms::feature _correct_idx_token_in_secondary_index_feature;
-    gms::feature _alternator_streams_feature;
-    gms::feature _alternator_ttl_feature;
-    gms::feature _range_scan_data_variant;
-    gms::feature _cdc_generations_v2;
-    gms::feature _uda;
-    gms::feature _separate_page_size_and_safety_limit;
-    gms::feature _supports_raft_cluster_mgmt;
-    gms::feature _uses_raft_cluster_mgmt;
-    gms::feature _tombstone_gc_options;
-    gms::feature _parallelized_aggregation;
-    gms::feature _keyspace_storage_options;
+    gms::feature _udf_feature { *this, "UDF"sv };
+    gms::feature _md_sstable_feature { *this, "MD_SSTABLE_FORMAT"sv };
+    gms::feature _me_sstable_feature { *this, "ME_SSTABLE_FORMAT"sv };
+    gms::feature _view_virtual_columns { *this, "VIEW_VIRTUAL_COLUMNS"sv };
+    gms::feature _digest_insensitive_to_expiry { *this, "DIGEST_INSENSITIVE_TO_EXPIRY"sv };
+    gms::feature _computed_columns { *this, "COMPUTED_COLUMNS"sv };
+    gms::feature _cdc_feature { *this, "CDC"sv };
+    gms::feature _nonfrozen_udts { *this, "NONFROZEN_UDTS"sv };
+    gms::feature _hinted_handoff_separate_connection { *this, "HINTED_HANDOFF_SEPARATE_CONNECTION"sv };
+    gms::feature _lwt_feature { *this, "LWT"sv };
+    gms::feature _per_table_partitioners_feature { *this, "PER_TABLE_PARTITIONERS"sv };
+    gms::feature _per_table_caching_feature { *this, "PER_TABLE_CACHING"sv };
+    gms::feature _digest_for_null_values_feature { *this, "DIGEST_FOR_NULL_VALUES"sv };
+    gms::feature _correct_idx_token_in_secondary_index_feature { *this, "CORRECT_IDX_TOKEN_IN_SECONDARY_INDEX"sv };
+    gms::feature _alternator_streams_feature { *this, "ALTERNATOR_STREAMS"sv };
+    gms::feature _alternator_ttl_feature { *this, "ALTERNATOR_TTL"sv };
+    gms::feature _range_scan_data_variant { *this, "RANGE_SCAN_DATA_VARIANT"sv };
+    gms::feature _cdc_generations_v2 { *this, "CDC_GENERATIONS_V2"sv };
+    gms::feature _uda { *this, "UDA"sv };
+    gms::feature _separate_page_size_and_safety_limit { *this, "SEPARATE_PAGE_SIZE_AND_SAFETY_LIMIT"sv };
+    gms::feature _supports_raft_cluster_mgmt { *this, "SUPPORTS_RAFT_CLUSTER_MANAGEMENT"sv };
+    gms::feature _uses_raft_cluster_mgmt { *this, "USES_RAFT_CLUSTER_MANAGEMENT"sv };
+    gms::feature _tombstone_gc_options { *this, "TOMBSTONE_GC_OPTIONS"sv };
+    gms::feature _parallelized_aggregation { *this, "PARALLELIZED_AGGREGATION"sv };
+    gms::feature _keyspace_storage_options { *this, "KEYSPACE_STORAGE_OPTIONS"sv };
 
 public:
 

--- a/gms/feature_service.hh
+++ b/gms/feature_service.hh
@@ -70,114 +70,26 @@ public:
     // persist enabled features
     static constexpr const char* ENABLED_FEATURES_KEY = "enabled_features";
 
-private:
-    gms::feature _udf_feature { *this, "UDF"sv };
-    gms::feature _md_sstable_feature { *this, "MD_SSTABLE_FORMAT"sv };
-    gms::feature _me_sstable_feature { *this, "ME_SSTABLE_FORMAT"sv };
-    gms::feature _view_virtual_columns { *this, "VIEW_VIRTUAL_COLUMNS"sv };
-    gms::feature _digest_insensitive_to_expiry { *this, "DIGEST_INSENSITIVE_TO_EXPIRY"sv };
-    gms::feature _computed_columns { *this, "COMPUTED_COLUMNS"sv };
-    gms::feature _cdc_feature { *this, "CDC"sv };
-    gms::feature _nonfrozen_udts { *this, "NONFROZEN_UDTS"sv };
-    gms::feature _hinted_handoff_separate_connection { *this, "HINTED_HANDOFF_SEPARATE_CONNECTION"sv };
-    gms::feature _lwt_feature { *this, "LWT"sv };
-    gms::feature _per_table_partitioners_feature { *this, "PER_TABLE_PARTITIONERS"sv };
-    gms::feature _per_table_caching_feature { *this, "PER_TABLE_CACHING"sv };
-    gms::feature _digest_for_null_values_feature { *this, "DIGEST_FOR_NULL_VALUES"sv };
-    gms::feature _correct_idx_token_in_secondary_index_feature { *this, "CORRECT_IDX_TOKEN_IN_SECONDARY_INDEX"sv };
-    gms::feature _alternator_streams_feature { *this, "ALTERNATOR_STREAMS"sv };
-    gms::feature _alternator_ttl_feature { *this, "ALTERNATOR_TTL"sv };
-    gms::feature _range_scan_data_variant { *this, "RANGE_SCAN_DATA_VARIANT"sv };
-    gms::feature _cdc_generations_v2 { *this, "CDC_GENERATIONS_V2"sv };
-    gms::feature _uda { *this, "UDA"sv };
-    gms::feature _separate_page_size_and_safety_limit { *this, "SEPARATE_PAGE_SIZE_AND_SAFETY_LIMIT"sv };
-    gms::feature _supports_raft_cluster_mgmt { *this, "SUPPORTS_RAFT_CLUSTER_MANAGEMENT"sv };
-    gms::feature _uses_raft_cluster_mgmt { *this, "USES_RAFT_CLUSTER_MANAGEMENT"sv };
-    gms::feature _tombstone_gc_options { *this, "TOMBSTONE_GC_OPTIONS"sv };
-    gms::feature _parallelized_aggregation { *this, "PARALLELIZED_AGGREGATION"sv };
-    gms::feature _keyspace_storage_options { *this, "KEYSPACE_STORAGE_OPTIONS"sv };
-
 public:
-
-    const std::unordered_map<sstring, std::reference_wrapper<feature>>& registered_features() const;
-
-    bool cluster_supports_user_defined_functions() const {
-        return bool(_udf_feature);
-    }
-
-    const feature& cluster_supports_md_sstable() const {
-        return _md_sstable_feature;
-    }
-
-    const feature& cluster_supports_me_sstable() const {
-        return _me_sstable_feature;
-    }
-
-    const feature& cluster_supports_cdc() const {
-        return _cdc_feature;
-    }
-
-    const feature& cluster_supports_per_table_partitioners() const {
-        return _per_table_partitioners_feature;
-    }
-
-    const feature& cluster_supports_per_table_caching() const {
-        return _per_table_caching_feature;
-    }
-
-    const feature& cluster_supports_digest_for_null_values() const {
-        return _digest_for_null_values_feature;
-    }
-
-    const feature& cluster_supports_view_virtual_columns() const {
-        return _view_virtual_columns;
-    }
-    const feature& cluster_supports_digest_insensitive_to_expiry() const {
-        return _digest_insensitive_to_expiry;
-    }
-
-    const feature& cluster_supports_computed_columns() const {
-        return _computed_columns;
-    }
-
-    bool cluster_supports_nonfrozen_udts() const {
-        return bool(_nonfrozen_udts);
-    }
-
-    bool cluster_supports_hinted_handoff_separate_connection() {
-        return bool(_hinted_handoff_separate_connection);
-    }
-
-    bool cluster_supports_lwt() const {
-        return bool(_lwt_feature);
-    }
-
-    bool cluster_supports_correct_idx_token_in_secondary_index() const {
-        return bool(_correct_idx_token_in_secondary_index_feature);
-    }
-
-    bool cluster_supports_alternator_streams() const {
-        return bool(_alternator_streams_feature);
-    }
-
-    bool cluster_supports_alternator_ttl() const {
-        return bool(_alternator_ttl_feature);
-    }
-
-    // Range scans have a data variant, which produces query::result directly,
-    // instead of through the intermediate reconcilable_result format.
-    bool cluster_supports_range_scan_data_variant() const {
-        return bool(_range_scan_data_variant);
-    }
-
-    bool cluster_supports_cdc_generations_v2() const {
-        return bool(_cdc_generations_v2);
-    }
-
-    bool cluster_supports_user_defined_aggregates() const {
-        return bool(_uda);
-    }
-
+    gms::feature user_defined_functions { *this, "UDF"sv };
+    gms::feature md_sstable { *this, "MD_SSTABLE_FORMAT"sv };
+    gms::feature me_sstable { *this, "ME_SSTABLE_FORMAT"sv };
+    gms::feature view_virtual_columns { *this, "VIEW_VIRTUAL_COLUMNS"sv };
+    gms::feature digest_insensitive_to_expiry { *this, "DIGEST_INSENSITIVE_TO_EXPIRY"sv };
+    gms::feature computed_columns { *this, "COMPUTED_COLUMNS"sv };
+    gms::feature cdc { *this, "CDC"sv };
+    gms::feature nonfrozen_udts { *this, "NONFROZEN_UDTS"sv };
+    gms::feature hinted_handoff_separate_connection { *this, "HINTED_HANDOFF_SEPARATE_CONNECTION"sv };
+    gms::feature lwt { *this, "LWT"sv };
+    gms::feature per_table_partitioners { *this, "PER_TABLE_PARTITIONERS"sv };
+    gms::feature per_table_caching { *this, "PER_TABLE_CACHING"sv };
+    gms::feature digest_for_null_values { *this, "DIGEST_FOR_NULL_VALUES"sv };
+    gms::feature correct_idx_token_in_secondary_index { *this, "CORRECT_IDX_TOKEN_IN_SECONDARY_INDEX"sv };
+    gms::feature alternator_streams { *this, "ALTERNATOR_STREAMS"sv };
+    gms::feature alternator_ttl { *this, "ALTERNATOR_TTL"sv };
+    gms::feature range_scan_data_variant { *this, "RANGE_SCAN_DATA_VARIANT"sv };
+    gms::feature cdc_generations_v2 { *this, "CDC_GENERATIONS_V2"sv };
+    gms::feature user_defined_aggregates { *this, "UDA"sv };
     // Historically max_result_size contained only two fields: soft_limit and
     // hard_limit. It was somehow obscure because for normal paged queries both
     // fields were equal and meant page size. For unpaged queries and reversed
@@ -190,29 +102,16 @@ public:
     // a backwards compatible change so this new cluster feature is used to make
     // sure the whole cluster supports the new page_size field and we can safely
     // send it to replicas.
-    bool cluster_supports_separate_page_size_and_safety_limit() const {
-        return bool(_separate_page_size_and_safety_limit);
-    }
+    gms::feature separate_page_size_and_safety_limit { *this, "SEPARATE_PAGE_SIZE_AND_SAFETY_LIMIT"sv };
+    gms::feature supports_raft_cluster_mgmt { *this, "SUPPORTS_RAFT_CLUSTER_MANAGEMENT"sv };
+    gms::feature uses_raft_cluster_mgmt { *this, "USES_RAFT_CLUSTER_MANAGEMENT"sv };
+    gms::feature tombstone_gc_options { *this, "TOMBSTONE_GC_OPTIONS"sv };
+    gms::feature parallelized_aggregation { *this, "PARALLELIZED_AGGREGATION"sv };
+    gms::feature keyspace_storage_options { *this, "KEYSPACE_STORAGE_OPTIONS"sv };
 
-    bool cluster_supports_tombstone_gc_options() const {
-        return bool(_tombstone_gc_options);
-    }
+public:
 
-    bool cluster_supports_parallelized_aggregation() const {
-        return bool(_parallelized_aggregation);
-    }
-
-    const feature& cluster_supports_raft_cluster_mgmt() const {
-        return _supports_raft_cluster_mgmt;
-    }
-
-    bool cluster_uses_raft_cluster_mgmt() const {
-        return static_cast<bool>(_uses_raft_cluster_mgmt);
-    }
-
-    bool cluster_supports_keyspace_storage_options() const {
-        return bool(_keyspace_storage_options);
-    }
+    const std::unordered_map<sstring, std::reference_wrapper<feature>>& registered_features() const;
 
     static std::set<sstring> to_feature_set(sstring features_string);
     // Persist enabled feature in the `system.scylla_local` table under the "enabled_features" key.

--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -1062,7 +1062,7 @@ int repair_service::do_repair_start(sstring keyspace, std::unordered_map<sstring
         auto uuid = id.uuid;
 
         bool needs_flush_before_repair = false;
-        if (db.local().features().cluster_supports_tombstone_gc_options()) {
+        if (db.local().features().tombstone_gc_options) {
             for (auto& table: cfs) {
                 auto s = db.local().find_column_family(keyspace, table).schema();
                 const auto& options = s->tombstone_gc_options();

--- a/service/migration_manager.cc
+++ b/service/migration_manager.cc
@@ -104,11 +104,11 @@ void migration_manager::init_messaging_service()
     };
 
     if (this_shard_id() == 0) {
-        _feature_listeners.push_back(_feat.cluster_supports_view_virtual_columns().when_enabled(update_schema));
-        _feature_listeners.push_back(_feat.cluster_supports_digest_insensitive_to_expiry().when_enabled(update_schema));
-        _feature_listeners.push_back(_feat.cluster_supports_cdc().when_enabled(update_schema));
-        _feature_listeners.push_back(_feat.cluster_supports_per_table_partitioners().when_enabled(update_schema));
-        _feature_listeners.push_back(_feat.cluster_supports_computed_columns().when_enabled(update_schema));
+        _feature_listeners.push_back(_feat.view_virtual_columns.when_enabled(update_schema));
+        _feature_listeners.push_back(_feat.digest_insensitive_to_expiry.when_enabled(update_schema));
+        _feature_listeners.push_back(_feat.cdc.when_enabled(update_schema));
+        _feature_listeners.push_back(_feat.per_table_partitioners.when_enabled(update_schema));
+        _feature_listeners.push_back(_feat.computed_columns.when_enabled(update_schema));
     }
 
     _messaging.register_definitions_update([this] (const rpc::client_info& cinfo, std::vector<frozen_mutation> fm, rpc::optional<std::vector<canonical_mutation>> cm) {

--- a/service/raft/raft_group_registry.cc
+++ b/service/raft/raft_group_registry.cc
@@ -24,7 +24,7 @@ raft_group_registry::raft_group_registry(bool is_enabled, netw::messaging_servic
     : _is_enabled(is_enabled)
     , _ms(ms)
     , _fd(make_shared<raft_gossip_failure_detector>(gossiper, _srv_address_mappings))
-    , _raft_support_listener(feat.cluster_supports_raft_cluster_mgmt().when_enabled([] {
+    , _raft_support_listener(feat.uses_raft_cluster_mgmt.when_enabled([] {
         // TODO: join group 0 on upgrade
     }))
 {

--- a/tombstone_gc.cc
+++ b/tombstone_gc.cc
@@ -175,7 +175,7 @@ void validate_tombstone_gc_options(const tombstone_gc_options* options, data_dic
     if (!options) {
         return;
     }
-    if (!db.features().cluster_supports_tombstone_gc_options()) {
+    if (!db.features().tombstone_gc_options) {
         throw exceptions::configuration_exception("tombstone_gc option not supported by the cluster");
     }
 


### PR DESCRIPTION
Currently, adding a cluster feature requires editing several files and
repeating the new feature name several times. This series reduces
the boilerplate to a single line (for non-experimental features), and
perhaps three for experimental features.