### PR TITLE
sstables/index_reader: short-circuit fast-forward-to when at EOF

### DIFF
--- a/sstables/index_reader.hh
+++ b/sstables/index_reader.hh
@@ -774,6 +774,9 @@ public:
 
     // Advance index_reader bounds to the bounds of the supplied range
     future<> advance_to(const dht::partition_range& range) {
+        if (eof()) {
+            return make_ready_future<>();
+        }
         return seastar::when_all_succeed(
             advance_lower_to_start(range),
             advance_upper_to_end(range)).discard_result();
@@ -911,6 +914,9 @@ public:
     // If upper_bound is provided, the upper bound within position is looked up
     future<bool> advance_lower_and_check_if_present(
             dht::ring_position_view key, std::optional<position_in_partition_view> pos = {}) {
+        if (eof()) {
+            return make_ready_future<bool>(false);
+        }
         return advance_to(_lower_bound, key).then([this, key, pos] {
             if (eof()) {
                 return make_ready_future<bool>(false);
@@ -1037,6 +1043,9 @@ public:
     // Positions the cursor on the first partition which is not smaller than pos (like std::lower_bound).
     // Must be called for non-decreasing positions.
     future<> advance_to(dht::ring_position_view pos) {
+        if (eof()) {
+            return make_ready_future<>();
+        }
         return advance_to(_lower_bound, pos);
     }
 

--- a/test/lib/random_schema.cc
+++ b/test/lib/random_schema.cc
@@ -1103,4 +1103,12 @@ future<std::vector<mutation>> generate_random_mutations(
     });
 }
 
+future<std::vector<mutation>> generate_random_mutations(tests::random_schema& random_schema, size_t partition_count) {
+    return generate_random_mutations(
+            random_schema,
+            default_timestamp_generator(),
+            no_expiry_expiry_generator(),
+            std::uniform_int_distribution<size_t>(partition_count, partition_count));
+}
+
 } // namespace tests

--- a/test/lib/random_schema.hh
+++ b/test/lib/random_schema.hh
@@ -242,4 +242,7 @@ future<std::vector<mutation>> generate_random_mutations(
         std::uniform_int_distribution<size_t> clustering_row_count_dist = std::uniform_int_distribution<size_t>(16, 128),
         std::uniform_int_distribution<size_t> range_tombstone_count_dist = std::uniform_int_distribution<size_t>(4, 16));
 
+/// Generate exactly partition_count partitions. See the more general overload above.
+future<std::vector<mutation>> generate_random_mutations(tests::random_schema& random_schema, size_t partition_count);
+
 } // namespace tests


### PR DESCRIPTION
Attempting to call advance_to() on the index, after it is positioned at EOF, can result in an assert failure, because the operation results in an attempt to move backwards in the index-file (to read the last index page, which was already read). This only happens if the index cache entry belonging to the last index page is evicted, otherwise the advance operation just looks-up said entry and returns it. To prevent this, we add an early return conditioned on eof() to all the partition-level advance-to methods.
A regression unit test reproducing the above described crash is also added.

Fixes: #10403