### PR TITLE
Docs: improve debugging.md

### DIFF
--- a/docs/guides/debugging.md
+++ b/docs/guides/debugging.md
@@ -149,6 +149,9 @@ places. You can always load it by hand if GDB refuses or fails to load it:
 
     (gdb) source /path/to/your/.gdbinit
 
+Scylla provides the following [gdbinit](../../gdbinit) file helpful for debugging scylla
+at the root of the source tree.
+
 #### TUI
 
 GDB has a terminal based GUI called

--- a/docs/guides/debugging.md
+++ b/docs/guides/debugging.md
@@ -327,12 +327,16 @@ Or from the executable like this:
     $ eu-unstrip -n --exec $executable
 
 With the build-id you can find the relocatable using the
-[scylla-pkg.git/scripts/scylla-s3-reloc (private repo)](https://github.com/scylladb/scylla-pkg/#looking-for-a-build)
-script.
+http://backtrace.scylladb.com/index.html search form.
+The form can also be used to decode backtraces generated
+by the corresponding scylla binary.
 
 **NOTE**: Use the normal relocatable package, usually called
 `scylla-package.tar.gz`, not not the debuginfo one usually called
 `scylla-debug-package.tar.gz`.
+
+Build-id:s for all official releases are listed on
+http://backtrace.scylladb.com/releases.html.
 
 ##### Loading the core
 

--- a/gdbinit
+++ b/gdbinit
@@ -1,0 +1,19 @@
+# Recommended .gdbinit for debugging scylla
+# See docs/guides/debugging.md for more information
+handle SIG34 pass noprint
+handle SIGUSR1 pass noprint
+set print pretty
+set python print-stack full
+set auto-load safe-path /opt/scylladb/libreloc
+add-auto-load-safe-path /lib64
+add-auto-load-safe-path /usr/lib64
+set debug libthread-db 1
+
+# Register pretty-printer helpers for printing common
+# std-c++ stl containers.
+python
+import glob
+sys.path.insert(0, glob.glob('/usr/share/gcc-*/python')[0])
+from libstdcxx.v6.printers import register_libstdcxx_printers
+register_libstdcxx_printers (None)
+end


### PR DESCRIPTION
This series update debugging.md with:
- add an example .gdbinit file
- update recommendation for finding the relocatable packages using a build-id on http://backtrace.scylladb.com/