### PR TITLE
wip: UUID-based sstable generations

### DIFF
--- a/replica/database.hh
+++ b/replica/database.hh
@@ -508,9 +508,9 @@ public:
                                           sstables::offstrategy offstrategy = sstables::offstrategy::no);
     future<> add_sstables_and_update_cache(const std::vector<sstables::shared_sstable>& ssts);
     future<> move_sstables_from_staging(std::vector<sstables::shared_sstable>);
-    sstables::shared_sstable make_sstable(sstring dir, int64_t generation, sstables::sstable_version_types v, sstables::sstable_format_types f,
+    sstables::shared_sstable make_sstable(sstring dir, int64_t generation, utils::UUID uuid_generation, sstables::sstable_version_types v, sstables::sstable_format_types f,
             io_error_handler_gen error_handler_gen);
-    sstables::shared_sstable make_sstable(sstring dir, int64_t generation, sstables::sstable_version_types v, sstables::sstable_format_types f);
+    sstables::shared_sstable make_sstable(sstring dir, int64_t generation, utils::UUID uuid_generation, sstables::sstable_version_types v, sstables::sstable_format_types f);
     sstables::shared_sstable make_sstable(sstring dir);
     sstables::shared_sstable make_sstable();
     void cache_truncation_record(db_clock::time_point truncated_at) {
@@ -583,6 +583,8 @@ private:
         // overwrite an existing table.
         return (*_sstable_generation)++ * smp::count + this_shard_id();
     }
+
+    utils::UUID calculate_uuid_generation_for_new_table();
 
     // inverse of calculate_generation_for_new_table(), used to determine which
     // shard a sstable should be opened at.

--- a/scylla-gdb.py
+++ b/scylla-gdb.py
@@ -1852,7 +1852,6 @@ class scylla_memory(gdb.Command):
                           sys_virt_dirty=dirty_mem_mgr(db['_system_dirty_memory_manager']).virt_dirty()))
 
         scylla_memory.print_coordinator_stats()
-        scylla_memory.print_replica_stats()
 
         gdb.write('Small pools:\n')
         small_pools = cpu_mem['small_pools']
@@ -4480,7 +4479,7 @@ class scylla_read_stats(gdb.Command):
             semaphores = [gdb.parse_and_eval(arg) for arg in args.split(' ')]
         else:
             db = find_db()
-            semaphores = [db["_read_concurrency_sem"], db["_streaming_concurrency_sem"], db["_system_read_concurrency_sem"]]
+            semaphores = [db["_streaming_concurrency_sem"], db["_system_read_concurrency_sem"]]
             try:
                 semaphores.append(db["_compaction_concurrency_sem"])
             except gdb.error:

--- a/sstables/open_info.hh
+++ b/sstables/open_info.hh
@@ -25,6 +25,7 @@ struct entry_descriptor {
     sstring ks;
     sstring cf;
     int64_t generation;
+    utils::UUID uuid_generation;
     sstable_version_types version;
     sstable_format_types format;
     component_type component;
@@ -35,10 +36,10 @@ struct entry_descriptor {
     // This allows loading sstables from any path, but the filename still has to be valid.
     static entry_descriptor make_descriptor(sstring sstdir, sstring fname, sstring ks, sstring cf);
 
-    entry_descriptor(sstring sstdir, sstring ks, sstring cf, int64_t generation,
+    entry_descriptor(sstring sstdir, sstring ks, sstring cf, int64_t generation, utils::UUID uuid_generation,
                      sstable_version_types version, sstable_format_types format,
                      component_type component)
-        : sstdir(sstdir), ks(ks), cf(cf), generation(generation), version(version), format(format), component(component) {}
+        : sstdir(sstdir), ks(ks), cf(cf), generation(generation), uuid_generation(uuid_generation), version(version), format(format), component(component) {}
 };
 
 // contains data for loading a sstable using components shared by a single shard;
@@ -49,6 +50,7 @@ struct foreign_sstable_open_info {
     seastar::file_handle data;
     seastar::file_handle index;
     uint64_t generation;
+    utils::UUID uuid_generation;
     sstable_version_types version;
     sstable_format_types format;
     uint64_t uncompressed_data_size;

--- a/sstables/sstable_directory.hh
+++ b/sstables/sstable_directory.hh
@@ -41,6 +41,7 @@ public:
     using sstable_object_from_existing_fn =
         noncopyable_function<sstables::shared_sstable(std::filesystem::path,
                                                       int64_t,
+                                                      utils::UUID,
                                                       sstables::sstable_version_types,
                                                       sstables::sstable_format_types)>;
 

--- a/sstables/sstables_manager.cc
+++ b/sstables/sstables_manager.cc
@@ -36,12 +36,13 @@ const utils::UUID& sstables_manager::get_local_host_id() const {
 shared_sstable sstables_manager::make_sstable(schema_ptr schema,
         sstring dir,
         int64_t generation,
+        utils::UUID uuid_generation,
         sstable_version_types v,
         sstable_format_types f,
         gc_clock::time_point now,
         io_error_handler_gen error_handler_gen,
         size_t buffer_size) {
-    return make_lw_shared<sstable>(std::move(schema), std::move(dir), generation, v, f, get_large_data_handler(), *this, now, std::move(error_handler_gen), buffer_size);
+    return make_lw_shared<sstable>(std::move(schema), std::move(dir), generation, uuid_generation, v, f, get_large_data_handler(), *this, now, std::move(error_handler_gen), buffer_size);
 }
 
 sstable_writer_config sstables_manager::configure_writer(sstring origin) const {

--- a/sstables/sstables_manager.hh
+++ b/sstables/sstables_manager.hh
@@ -73,6 +73,7 @@ public:
     shared_sstable make_sstable(schema_ptr schema,
             sstring dir,
             int64_t generation,
+            utils::UUID uuid_generation,
             sstable_version_types v,
             sstable_format_types f,
             gc_clock::time_point now = gc_clock::now(),

--- a/tools/scylla-sstable.cc
+++ b/tools/scylla-sstable.cc
@@ -142,7 +142,7 @@ const std::vector<sstables::shared_sstable> load_sstables(schema_ptr schema, sst
         const auto sst_filename = sst_path.filename();
 
         auto ed = sstables::entry_descriptor::make_descriptor(dir_path.c_str(), sst_filename.c_str(), schema->ks_name(), schema->cf_name());
-        auto sst = sst_man.make_sstable(schema, dir_path.c_str(), ed.generation, ed.version, ed.format);
+        auto sst = sst_man.make_sstable(schema, dir_path.c_str(), ed.generation, ed.uuid_generation, ed.version, ed.format);
 
         co_await sst->load();
 


### PR DESCRIPTION
**RFC DRAFT**
This pull request is in no way production-ready, it's just work in progress that I decided to publish as a draft for transparency.
This commit makes it work unconditionally, which is not the way we want it implemented. Nonetheless, it identifies all the places that needed to change in order to introduce such a feature. Right now most of the interfaces simply accept both `int64_t generation` and `utils::UUID uuid_generation` parameters and simply prefer the second one if it's not equal to `utils::UUID`. It's not perfect, but also less intrusive than the alternatives (custom struct/variant/optionals).

TODO:
 - add a cluster feature guarding this mechanism
 - add a configuration variable guarding this mechanism
 - add tests

**RFC DRAFT**

This commit enables timeUUID-based generations for SSTables.