### PR TITLE
Reduce compaction serialization

### DIFF
--- a/compaction/compaction.cc
+++ b/compaction/compaction.cc
@@ -731,6 +731,7 @@ private:
         compaction_result ret {
             .new_sstables = std::move(_all_new_sstables),
             .ended_at = ended_at,
+            .start_size = _start_size,
             .end_size = _end_size,
         };
 

--- a/compaction/compaction.hh
+++ b/compaction/compaction.hh
@@ -88,6 +88,7 @@ struct compaction_data {
 struct compaction_result {
     std::vector<sstables::shared_sstable> new_sstables;
     std::chrono::time_point<db_clock> ended_at;
+    uint64_t start_size = 0;
     uint64_t end_size = 0;
 };
 

--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -309,7 +309,6 @@ future<> compaction_manager::task::compact_sstables(sstables::compaction_descrip
         }
     };
     auto compaction_type = descriptor.options.type();
-    auto start_size = boost::accumulate(descriptor.sstables | boost::adaptors::transformed(std::mem_fn(&sstables::sstable::data_size)), uint64_t(0));
 
     sstables::compaction_result res = co_await sstables::compact_sstables(std::move(descriptor), cdata, t.as_table_state());
     if (compaction_type != sstables::compaction_type::Compaction) {
@@ -318,7 +317,7 @@ future<> compaction_manager::task::compact_sstables(sstables::compaction_descrip
     auto ended_at = std::chrono::duration_cast<std::chrono::milliseconds>(res.ended_at.time_since_epoch());
 
     co_return co_await t.as_table_state().update_compaction_history(cdata.compaction_uuid, t.schema()->ks_name(), t.schema()->cf_name(), ended_at,
-                                                                    start_size, res.end_size);
+                                                                    res.start_size, res.end_size);
 }
 
 class compaction_manager::major_compaction_task : public compaction_manager::task {

--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -308,10 +308,10 @@ future<> compaction_manager::task::compact_sstables(sstables::compaction_descrip
             release_exhausted(desc.old_sstables);
         }
     };
-    auto compaction_type = descriptor.options.type();
 
+    bool should_update_history = this->should_update_history(descriptor.options.type());
     sstables::compaction_result res = co_await sstables::compact_sstables(std::move(descriptor), cdata, t.as_table_state());
-    if (compaction_type != sstables::compaction_type::Compaction) {
+    if (!should_update_history) {
         co_return;
     }
     auto ended_at = std::chrono::duration_cast<std::chrono::milliseconds>(res.ended_at.time_since_epoch());

--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -885,10 +885,24 @@ protected:
             try {
                 bool should_update_history = this->should_update_history(descriptor.options.type());
                 sstables::compaction_result res = co_await compact_sstables(std::move(descriptor), _compaction_data, std::move(release_exhausted));
+                finish_compaction();
+                // update_history can take a long time compared to
+                // compaction, as a call issued on shard S1 can be
+                // handled on shard S2. If the other shard is under
+                // heavy load, we may unnecessarily block kicking off a
+                // new compaction. Normally it isn't a problem, as
+                // compactions aren't super frequent, but there were
+                // edge cases where the described behaviour caused
+                // compaction to fail to keep up with excessive
+                // flushing, leading to too many sstables on disk and
+                // OOM during a read. There is no need to wait with
+                // next compaction until history is updated, so release
+                // the weight earlier to remove unnecessary
+                // serialization.
+                weight_r.deregister();
                 if (should_update_history) {
                     co_await update_history(*_compacting_table, res, _compaction_data);
                 }
-                finish_compaction();
                 _cm.reevaluate_postponed_compactions();
                 continue;
             } catch (...) {

--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -883,7 +883,11 @@ protected:
             std::exception_ptr ex;
 
             try {
-                co_await compact_sstables_and_update_history(std::move(descriptor), _compaction_data, std::move(release_exhausted));
+                bool should_update_history = this->should_update_history(descriptor.options.type());
+                sstables::compaction_result res = co_await compact_sstables(std::move(descriptor), _compaction_data, std::move(release_exhausted));
+                if (should_update_history) {
+                    co_await update_history(*_compacting_table, res, _compaction_data);
+                }
                 finish_compaction();
                 _cm.reevaluate_postponed_compactions();
                 continue;

--- a/compaction/compaction_manager.hh
+++ b/compaction/compaction_manager.hh
@@ -147,6 +147,7 @@ public:
         using release_exhausted_func_t = std::function<void(const std::vector<sstables::shared_sstable>& exhausted_sstables)>;
         future<> compact_sstables(sstables::compaction_descriptor descriptor, sstables::compaction_data& cdata, release_exhausted_func_t release_exhausted,
                                   can_purge_tombstones can_purge = can_purge_tombstones::yes);
+        future<> update_history(replica::table& t, const sstables::compaction_result& res, const sstables::compaction_data& cdata);
         bool should_update_history(sstables::compaction_type ct) {
             return ct == sstables::compaction_type::Compaction;
         }

--- a/compaction/compaction_manager.hh
+++ b/compaction/compaction_manager.hh
@@ -147,6 +147,9 @@ public:
         using release_exhausted_func_t = std::function<void(const std::vector<sstables::shared_sstable>& exhausted_sstables)>;
         future<> compact_sstables(sstables::compaction_descriptor descriptor, sstables::compaction_data& cdata, release_exhausted_func_t release_exhausted,
                                   can_purge_tombstones can_purge = can_purge_tombstones::yes);
+        bool should_update_history(sstables::compaction_type ct) {
+            return ct == sstables::compaction_type::Compaction;
+        }
     public:
         future<> run() noexcept;
 

--- a/compaction/compaction_manager.hh
+++ b/compaction/compaction_manager.hh
@@ -145,7 +145,7 @@ public:
 
         // Compacts set of SSTables according to the descriptor.
         using release_exhausted_func_t = std::function<void(const std::vector<sstables::shared_sstable>& exhausted_sstables)>;
-        future<> compact_sstables(sstables::compaction_descriptor descriptor, sstables::compaction_data& cdata, release_exhausted_func_t release_exhausted,
+        future<> compact_sstables_and_update_history(sstables::compaction_descriptor descriptor, sstables::compaction_data& cdata, release_exhausted_func_t release_exhausted,
                                   can_purge_tombstones can_purge = can_purge_tombstones::yes);
         future<> update_history(replica::table& t, const sstables::compaction_result& res, const sstables::compaction_data& cdata);
         bool should_update_history(sstables::compaction_type ct) {

--- a/compaction/compaction_manager.hh
+++ b/compaction/compaction_manager.hh
@@ -147,6 +147,8 @@ public:
         using release_exhausted_func_t = std::function<void(const std::vector<sstables::shared_sstable>& exhausted_sstables)>;
         future<> compact_sstables_and_update_history(sstables::compaction_descriptor descriptor, sstables::compaction_data& cdata, release_exhausted_func_t release_exhausted,
                                   can_purge_tombstones can_purge = can_purge_tombstones::yes);
+        future<sstables::compaction_result> compact_sstables(sstables::compaction_descriptor descriptor, sstables::compaction_data& cdata, release_exhausted_func_t release_exhausted,
+                                  can_purge_tombstones can_purge = can_purge_tombstones::yes);
         future<> update_history(replica::table& t, const sstables::compaction_result& res, const sstables::compaction_data& cdata);
         bool should_update_history(sstables::compaction_type ct) {
             return ct == sstables::compaction_type::Compaction;


### PR DESCRIPTION
update_history can take a long time compared to compaction, as a call
issued on shard S1 can be handled on shard S2. If the other shard is
under heavy load, we may unnecessarily block kicking off a new
compaction. Normally it isn't a problem, as compactions aren't super
frequent, but there were edge cases where the described behaviour caused
compaction to fail to keep up with excessive flushing, leading to too
many sstables on disk and OOM during a read.

There is no need to wait with next compaction until history is updated,
so release the weight earlier to remove unnecessary serialization.

Changelog:
v3:
- explicitly call deregister instead of moving the weight RAII object to release weight
- mark compaction as finished when sstables are compacted, without waiting for history to update

v2:
- Split the patches differently for easier review
- Rebased agains newer master, which contains fixes that failed the debug version of the test
- Removed the test, as it will be provided by [PR#10717](https://github.com/scylladb/scylla/pull/10717)