### PR TITLE
cql3: restrictions: statement_restrictions: pass arguments to std::bi…

### DIFF
--- a/cql3/restrictions/statement_restrictions.cc
+++ b/cql3/restrictions/statement_restrictions.cc
@@ -1767,8 +1767,8 @@ static bool has_eq_null(const query_options& options, const expression& expr) {
 }
 
 bool statement_restrictions::range_or_slice_eq_null(const query_options& options) const {
-    return boost::algorithm::any_of(_partition_range_restrictions, std::bind_front(has_eq_null, options))
-            || boost::algorithm::any_of(_clustering_prefix_restrictions, std::bind_front(has_eq_null, options));
+    return boost::algorithm::any_of(_partition_range_restrictions, std::bind_front(has_eq_null, std::cref(options)))
+            || boost::algorithm::any_of(_clustering_prefix_restrictions, std::bind_front(has_eq_null, std::cref(options)));
 }
 } // namespace restrictions
 } // namespace cql3


### PR DESCRIPTION
…nd_front by reference

Fix an accidental copy of query_options in range_or_slice_eq_null.