### PR TITLE
 sstables: consumer: reuse the fragmented_temporary_buffer in read_bytes()

### DIFF
--- a/sstables/consumer.hh
+++ b/sstables/consumer.hh
@@ -220,8 +220,9 @@ public:
     }
     inline read_status read_bytes(temporary_buffer<char>& data, uint32_t len, fragmented_temporary_buffer& where) {
         if (data.size() >= len) {
-            std::vector<temporary_buffer<char>> fragments;
-            fragments.push_back(data.share(0,len));
+            auto fragments = std::move(where).release();
+            fragments.clear();
+            fragments.push_back(data.share(0, len));
             where = fragmented_temporary_buffer(std::move(fragments), len);
             data.trim_front(len);
             return read_status::ready;

--- a/utils/fragmented_temporary_buffer.hh
+++ b/utils/fragmented_temporary_buffer.hh
@@ -99,6 +99,10 @@ public:
         }
         return fragmented_temporary_buffer(std::move(fragments), data_size);
     }
+
+    vector_type release() && noexcept {
+        return std::move(_fragments);
+    }
 };
 
 class fragmented_temporary_buffer::view {


### PR DESCRIPTION
primitive_consumer::read_bytes() destroys and creates a vector for every value it reads.
This happens for every cell.
We can save a bit of work by reusing the vector.