### PR TITLE
Handle errors during snapshot

### DIFF
--- a/api/api-doc/storage_service.json
+++ b/api/api-doc/storage_service.json
@@ -624,7 +624,7 @@
                   },
                   {
                      "name":"kn",
-                     "description":"Comma seperated keyspaces name to snapshot",
+                     "description":"Keyspace(s) to snapshot. Multiple keyspaces can be provided using a comma-separated list. If omitted, snapshot all keyspaces.",
                      "required":false,
                      "allowMultiple":false,
                      "type":"string",
@@ -632,7 +632,7 @@
                   },
                   {
                      "name":"cf",
-                     "description":"the column family to snapshot",
+                     "description":"Table(s) to snapshot. Multiple tables (in a single keyspace) can be provided using a comma-separated list. If omitted, snapshot all tables in the given keyspace(s).",
                      "required":false,
                      "allowMultiple":false,
                      "type":"string",

--- a/db/legacy_schema_migrator.cc
+++ b/db/legacy_schema_migrator.cc
@@ -574,12 +574,8 @@ public:
     }
 
     future<> flush_schemas() {
-        return _qp.proxy().get_db().invoke_on_all([this] (replica::database& db) {
-            return parallel_for_each(db::schema_tables::all_table_names(schema_features::full()), [this, &db](const sstring& cf_name) {
-                auto& cf = db.find_column_family(db::schema_tables::NAME, cf_name);
-                return cf.flush();
-            });
-        });
+        auto& db = _qp.db().real_database();
+        return db.flush_on_all(db::schema_tables::NAME, db::schema_tables::all_table_names(schema_features::full()));
     }
 
     future<> migrate() {

--- a/db/snapshot-ctl.hh
+++ b/db/snapshot-ctl.hh
@@ -99,6 +99,9 @@ private:
 
     template <typename Func>
     std::result_of_t<Func()> run_snapshot_list_operation(Func&&);
+
+    future<> do_take_snapshot(sstring tag, std::vector<sstring> keyspace_names, skip_flush sf = skip_flush::no);
+    future<> do_take_column_family_snapshot(sstring ks_name, std::vector<sstring> tables, sstring tag, skip_flush sf = skip_flush::no);
 };
 
 }

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -2103,7 +2103,7 @@ future<> database::snapshot_on_all(std::string_view ks_name, std::vector<sstring
         }
         co_await container().invoke_on_all([ks_name, &table_name, tag, skip_flush] (replica::database& db) {
             auto& t = db.find_column_family(ks_name, table_name);
-            return t.snapshot(db, tag, true);
+            return t.snapshot(db, tag);
         });
     });
 }
@@ -2116,7 +2116,7 @@ future<> database::snapshot_on_all(std::string_view ks_name, sstring tag, bool s
         }
         co_await container().invoke_on_all([id = pair.second, tag, skip_flush] (replica::database& db) {
             auto& t = db.find_column_family(id);
-            return t.snapshot(db, tag, true);
+            return t.snapshot(db, tag);
         });
     });
 }
@@ -2170,7 +2170,7 @@ future<> database::truncate(const keyspace& ks, column_family& cf, timestamp_fun
 
     if (auto_snapshot) {
         auto name = format("{:d}-{}", truncated_at.time_since_epoch().count(), cf.schema()->cf_name());
-        co_await cf.snapshot(*this, name, true);
+        co_await cf.snapshot(*this, name);
     }
 
     db::replay_position rp = co_await cf.discard_sstables(truncated_at);

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -2170,7 +2170,7 @@ future<> database::truncate(const keyspace& ks, column_family& cf, timestamp_fun
 
     if (auto_snapshot) {
         auto name = format("{:d}-{}", truncated_at.time_since_epoch().count(), cf.schema()->cf_name());
-        co_await cf.snapshot(*this, name);
+        co_await cf.snapshot(*this, name, true);
     }
 
     db::replay_position rp = co_await cf.discard_sstables(truncated_at);

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1565,6 +1565,9 @@ public:
     // flush all tables in a keyspace on all shards.
     future<> flush_on_all(std::string_view ks_name);
 
+    future<> snapshot_on_all(std::string_view ks_name, std::vector<sstring> table_names, sstring tag, bool skip_flush);
+    future<> snapshot_on_all(std::string_view ks_name, sstring tag, bool skip_flush);
+
     // See #937. Truncation now requires a callback to get a time stamp
     // that must be guaranteed to be the same for all shards.
     typedef std::function<future<db_clock::time_point>()> timestamp_func;

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -831,7 +831,7 @@ public:
     db::replay_position set_low_replay_position_mark();
 
 private:
-    future<> snapshot(database& db, sstring name, bool skip_flush = false);
+    future<> snapshot(database& db, sstring name);
 
     friend class database;
 public:

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -830,7 +830,11 @@ public:
 
     db::replay_position set_low_replay_position_mark();
 
+private:
     future<> snapshot(database& db, sstring name, bool skip_flush = false);
+
+    friend class database;
+public:
     future<std::unordered_map<sstring, snapshot_details>> get_snapshot_details();
 
     /*!

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1206,7 +1206,7 @@ class db_user_types_storage;
 //   local metadata reads
 //   use shard_of() for data
 
-class database {
+class database : public peering_sharded_service<database> {
     friend class ::database_test;
 public:
     enum class table_kind {
@@ -1556,6 +1556,14 @@ public:
 
     future<> flush_all_memtables();
     future<> flush(const sstring& ks, const sstring& cf);
+    // flush a table identified by the given id on all shards.
+    future<> flush_on_all(utils::UUID id);
+    // flush a single table in a keyspace on all shards.
+    future<> flush_on_all(std::string_view ks_name, std::string_view table_name);
+    // flush a list of tables in a keyspace on all shards.
+    future<> flush_on_all(std::string_view ks_name, std::vector<sstring> table_names);
+    // flush all tables in a keyspace on all shards.
+    future<> flush_on_all(std::string_view ks_name);
 
     // See #937. Truncation now requires a callback to get a time stamp
     // that must be guaranteed to be the same for all shards.

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -1345,11 +1345,11 @@ future<> table::write_schema_as_cql(database& db, sstring dir) const {
 
 }
 
-future<> table::snapshot(database& db, sstring name, bool skip_flush) {
+future<> table::snapshot(database& db, sstring name) {
     auto jsondir = _config.datadir + "/snapshots/" + name;
-    tlogger.debug("snapshot {}: skip_flush={}", jsondir, skip_flush);
-    auto f = skip_flush ? make_ready_future<>() : flush();
-    return f.then([this, &db, jsondir = std::move(jsondir)]() {
+    tlogger.debug("snapshot {}", jsondir);
+
+    // FIXME: indentation
        return with_semaphore(_sstable_deletion_sem, 1, [this, &db, jsondir = std::move(jsondir)]() {
         auto tables = boost::copy_range<std::vector<sstables::shared_sstable>>(*_sstables->all());
         return do_with(std::move(tables), std::move(jsondir), [this, &db] (std::vector<sstables::shared_sstable>& tables, const sstring& jsondir) {
@@ -1415,7 +1415,6 @@ future<> table::snapshot(database& db, sstring name, bool skip_flush) {
             });
         });
        });
-    });
 }
 
 future<bool> table::snapshot_exists(sstring tag) {

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -9,6 +9,7 @@
 #include <seastar/core/seastar.hh>
 #include <seastar/core/coroutine.hh>
 #include <seastar/coroutine/maybe_yield.hh>
+#include <seastar/coroutine/exception.hh>
 #include <seastar/util/closeable.hh>
 
 #include "replica/database.hh"
@@ -1349,72 +1350,83 @@ future<> table::snapshot(database& db, sstring name) {
     auto jsondir = _config.datadir + "/snapshots/" + name;
     tlogger.debug("snapshot {}", jsondir);
 
-    // FIXME: indentation
-       return with_semaphore(_sstable_deletion_sem, 1, [this, &db, jsondir = std::move(jsondir)]() {
-        auto tables = boost::copy_range<std::vector<sstables::shared_sstable>>(*_sstables->all());
-        return do_with(std::move(tables), std::move(jsondir), [this, &db] (std::vector<sstables::shared_sstable>& tables, const sstring& jsondir) {
-            return io_check([&jsondir] { return recursive_touch_directory(jsondir); }).then([this, &db, &jsondir, &tables] {
-                return max_concurrent_for_each(tables, db.get_config().initial_sstable_loading_concurrency(), [&db, &jsondir] (sstables::shared_sstable sstable) {
-                  return with_semaphore(db.get_sharded_sst_dir_semaphore().local(), 1, [&jsondir, sstable] {
-                    return io_check([sstable, &dir = jsondir] {
-                        return sstable->create_links(dir);
-                    });
-                  });
-                });
-            }).then([&jsondir, &tables] {
-                return io_check(sync_directory, jsondir);
-            }).finally([this, &tables, &db, &jsondir] {
-                auto shard = std::hash<sstring>()(jsondir) % smp::count;
-                std::unordered_set<sstring> table_names;
-                for (auto& sst : tables) {
-                    auto f = sst->get_filename();
-                    auto rf = f.substr(sst->get_dir().size() + 1);
-                    table_names.insert(std::move(rf));
-                }
-                return smp::submit_to(shard, [requester = this_shard_id(), &jsondir, this, &db,
-                                              tables = std::move(table_names), datadir = _config.datadir] {
+    auto sstable_deletion_guard = co_await get_units(_sstable_deletion_sem, 1);
+    std::exception_ptr ex;
 
-                    if (!pending_snapshots.contains(jsondir)) {
-                        pending_snapshots.emplace(jsondir, make_lw_shared<snapshot_manager>());
-                    }
-                    auto snapshot = pending_snapshots.at(jsondir);
-                    for (auto&& sst: tables) {
-                        snapshot->files.insert(std::move(sst));
-                    }
-
-                    tlogger.debug("snapshot {}: signal requests", jsondir);
-                    snapshot->requests.signal(1);
-                    auto my_work = make_ready_future<>();
-                    if (requester == this_shard_id()) {
-                        tlogger.debug("snapshot {}: waiting for all shards", jsondir);
-                        my_work = snapshot->requests.wait(smp::count).then([&jsondir,
-                                                                            &db, snapshot, this] {
-                            // this_shard_id() here == requester == this_shard_id() before submit_to() above,
-                            // so the db reference is still local
-                            tlogger.debug("snapshot {}: writing schema.cql", jsondir);
-                            return write_schema_as_cql(db, jsondir).handle_exception([&jsondir](std::exception_ptr ptr) {
-                                tlogger.error("Failed writing schema file in snapshot in {} with exception {}", jsondir, ptr);
-                                return make_ready_future<>();
-                            }).finally([&jsondir, snapshot] () mutable {
-                                tlogger.debug("snapshot {}: seal_snapshot", jsondir);
-                                return seal_snapshot(jsondir).handle_exception([&jsondir] (std::exception_ptr ex) {
-                                    tlogger.error("Failed to seal snapshot in {}: {}. Ignored.", jsondir, ex);
-                                }).then([snapshot, &jsondir] {
-                                    tlogger.debug("snapshot {}: done", jsondir);
-                                    snapshot->manifest_write.signal(smp::count);
-                                    return make_ready_future<>();
-                                });
-                            });
-                        });
-                    }
-                    return my_work.finally([snapshot, &jsondir, requester] {
-                        tlogger.debug("snapshot {}: waiting for manifest on behalf of shard {}", jsondir, requester);
-                        return snapshot->manifest_write.wait(1);
-                    }).then([snapshot] {});
+    std::vector<sstables::shared_sstable> tables;
+    try {
+        tables = boost::copy_range<std::vector<sstables::shared_sstable>>(*_sstables->all());
+        co_await io_check([&jsondir] { return recursive_touch_directory(jsondir); });
+        co_await max_concurrent_for_each(tables, db.get_config().initial_sstable_loading_concurrency(), [&db, &jsondir] (sstables::shared_sstable sstable) {
+            return with_semaphore(db.get_sharded_sst_dir_semaphore().local(), 1, [&jsondir, sstable] {
+                return io_check([sstable, &dir = jsondir] {
+                    return sstable->create_links(dir);
                 });
             });
         });
-       });
+        co_await io_check(sync_directory, jsondir);
+    } catch (...) {
+        ex = std::current_exception();
+    }
+
+    auto shard = std::hash<sstring>()(jsondir) % smp::count;
+    std::unordered_set<sstring> table_names;
+    try {
+        for (auto& sst : tables) {
+            auto f = sst->get_filename();
+            auto rf = f.substr(sst->get_dir().size() + 1);
+            table_names.insert(std::move(rf));
+        }
+    } catch (...) {
+        ex = std::current_exception();
+    }
+    co_await smp::submit_to(shard, [requester = this_shard_id(), &jsondir, this, &db,
+            tables = std::move(table_names), datadir = _config.datadir, ex = std::move(ex)] () mutable -> future<> {
+        if (!pending_snapshots.contains(jsondir)) {
+            try {
+                pending_snapshots.emplace(jsondir, make_lw_shared<snapshot_manager>());
+            } catch (...) {
+                // abort since the process will hang if we can't coordinate
+                // snapshot across shards, similar to failing to allocation a continuation.
+                tlogger.error("Failed allocating snapshot_manager: {}. Aborting.", std::current_exception());
+                abort();
+            }
+        }
+        auto snapshot = pending_snapshots.at(jsondir);
+        try {
+            for (auto&& sst: tables) {
+                snapshot->files.insert(std::move(sst));
+            }
+        } catch (...) {
+            ex = std::current_exception();
+        }
+
+        tlogger.debug("snapshot {}: signal requests", jsondir);
+        snapshot->requests.signal(1);
+        if (requester == this_shard_id()) {
+            tlogger.debug("snapshot {}: waiting for all shards", jsondir);
+            co_await snapshot->requests.wait(smp::count);
+            // this_shard_id() here == requester == this_shard_id() before submit_to() above,
+            // so the db reference is still local
+            tlogger.debug("snapshot {}: writing schema.cql", jsondir);
+            co_await write_schema_as_cql(db, jsondir).handle_exception([&] (std::exception_ptr ptr) {
+                tlogger.error("Failed writing schema file in snapshot in {} with exception {}", jsondir, ptr);
+                ex = std::move(ptr);
+            });
+            tlogger.debug("snapshot {}: seal_snapshot", jsondir);
+            co_await seal_snapshot(jsondir).handle_exception([&] (std::exception_ptr ptr) {
+                tlogger.error("Failed to seal snapshot in {}: {}.", jsondir, ptr);
+                ex = std::move(ptr);
+            });
+            snapshot->manifest_write.signal(smp::count);
+        }
+        tlogger.debug("snapshot {}: waiting for manifest on behalf of shard {}", jsondir, requester);
+        co_await snapshot->manifest_write.wait(1);
+        tlogger.debug("snapshot {}: done: error={}", jsondir, ex);
+        if (ex) {
+            co_await coroutine::return_exception(std::move(ex));
+        }
+    });
 }
 
 future<bool> table::snapshot_exists(sstring tag) {

--- a/test/boost/database_test.cc
+++ b/test/boost/database_test.cc
@@ -432,10 +432,7 @@ future<> do_with_some_data(std::vector<sstring> cf_names, std::function<future<>
 
 future<> take_snapshot(sharded<replica::database>& db, bool skip_flush = false, sstring ks_name = "ks", sstring cf_name = "cf", sstring snapshot_name = "test") {
     try {
-        co_await db.invoke_on_all([&ks_name, &cf_name, &snapshot_name, skip_flush] (replica::database& db) {
-            auto& cf = db.find_column_family(ks_name, cf_name);
-            return cf.snapshot(db, snapshot_name, skip_flush);
-        });
+        co_await db.local().snapshot_on_all(ks_name, {cf_name}, snapshot_name, skip_flush);
     } catch (...) {
         testlog.error("Could not take snapshot for {}.{} snapshot_name={} skip_flush={}: {}",
                 ks_name, cf_name, snapshot_name, skip_flush, std::current_exception());

--- a/test/boost/extensions_test.cc
+++ b/test/boost/extensions_test.cc
@@ -89,10 +89,7 @@ SEASTAR_TEST_CASE(simple_sstable_extension) {
             // minimal data
             return e.execute_cql("insert into ks.cf (id, value) values (1, 100);").discard_result().then([&e] {
                 // flush all shards
-                return e.db().invoke_on_all([](replica::database& db) {
-                    auto& cf = db.find_column_family("ks", "cf");
-                    return cf.flush();
-                }).then([] {
+                return e.db().local().flush_on_all("ks", "cf").then([] {
                     BOOST_REQUIRE(counter > 1);
                 });
             });

--- a/test/cql-pytest/util.py
+++ b/test/cql-pytest/util.py
@@ -107,6 +107,19 @@ def new_materialized_view(cql, table, select, pk, where):
     finally:
         cql.execute(f"DROP MATERIALIZED VIEW {mv}")
 
+# A utility function for creating a new temporary secondary index of
+# an existing table.
+@contextmanager
+def new_secondary_index(cql, table, column, name='', extra=''):
+    keyspace = table.split('.')[0]
+    if not name:
+        name = unique_name()
+    cql.execute(f"CREATE INDEX {name} ON {table} ({column}) {extra}")
+    try:
+        yield f"{keyspace}.{name}"
+    finally:
+        cql.execute(f"DROP INDEX {keyspace}.{name}")
+
 def project(column_name_string, rows):
     """Returns a list of column values from each of the rows."""
     return [getattr(r, column_name_string) for r in rows]

--- a/test/rest_api/rest_util.py
+++ b/test/rest_api/rest_util.py
@@ -1,0 +1,32 @@
+import time
+
+from contextlib import contextmanager
+
+# A utility function for creating a new temporary snapshot.
+# If no keyspaces are given, a snapshot is taken over all keyspaces and tables.
+# If no tables are given, a snapshot is taken over all tables in the keyspace.
+# If no tag is given, a unique tag will be computed using the current time, in milliseconds.
+# It can be used in a "with", as:
+#   with new_test_snapshot(cql, tag, keyspace, [table(s)]) as snapshot:
+# This is not a fixture - see those in conftest.py.
+@contextmanager
+def new_test_snapshot(rest_api, keyspaces=[], tables=[], tag=""):
+    if not tag:
+        tag = f"test_snapshot_{int(time.time() * 1000)}"
+    params = { "tag": tag }
+    if type(keyspaces) is str:
+        params["kn"] = keyspaces
+    else:
+        params["kn"] = ",".join(keyspaces)
+    if tables:
+        if type(tables) is str:
+            params["cf"] = tables
+        else:
+            params["cf"] = ",".join(tables)
+    resp = rest_api.send("POST", "storage_service/snapshots", params)
+    resp.raise_for_status()
+    try:
+        yield tag
+    finally:
+        resp = rest_api.send("DELETE", "storage_service/snapshots", params)
+        resp.raise_for_status()

--- a/test/rest_api/test_storage_service.py
+++ b/test/rest_api/test_storage_service.py
@@ -281,6 +281,12 @@ def test_storage_service_snapshot(cql, this_dc, rest_api):
                     'value': [{'ks': ks0, 'cf': cf00, 'total': 1, 'live': 0}]
                 })
 
+                cql.execute(f"TRUNCATE {table00}")
+                verify_snapshot_details({
+                    'key': snapshot0,
+                    'value': [{'ks': ks0, 'cf': cf00, 'total': 1, 'live': 1}]
+                })
+
             with new_test_table(cql, keyspace0, "p text PRIMARY KEY") as table01:
                 _, cf01 = table01.split('.')
                 stmt = cql.prepare(f"INSERT INTO {table01} (p) VALUES (?)")
@@ -291,7 +297,7 @@ def test_storage_service_snapshot(cql, this_dc, rest_api):
                     verify_snapshot_details({
                         'key': snapshot1,
                         'value': [
-                            {'ks': ks0, 'cf': cf00, 'total': 1, 'live': 0},
+                            {'ks': ks0, 'cf': cf00, 'total': 0, 'live': 0},
                             {'ks': ks0, 'cf': cf01, 'total': 1, 'live': 0}
                         ]
                     })
@@ -305,7 +311,7 @@ def test_storage_service_snapshot(cql, this_dc, rest_api):
                             verify_snapshot_details({
                                 'key': snapshot2,
                                 'value': [
-                                    {'ks': ks0, 'cf': cf00, 'total': 1, 'live': 0},
+                                    {'ks': ks0, 'cf': cf00, 'total': 0, 'live': 0},
                                     {'ks': ks0, 'cf': cf01, 'total': 1, 'live': 0},
                                     {'ks': ks1, 'cf': cf10, 'total': 0, 'live': 0}
                                 ]
@@ -316,7 +322,7 @@ def test_storage_service_snapshot(cql, this_dc, rest_api):
                             verify_snapshot_details({
                                 'key': snapshot3,
                                 'value': [
-                                    {'ks': ks0, 'cf': cf00, 'total': 1, 'live': 0},
+                                    {'ks': ks0, 'cf': cf00, 'total': 0, 'live': 0},
                                     {'ks': ks0, 'cf': cf01, 'total': 1, 'live': 0},
                                     {'ks': ks1, 'cf': cf10, 'total': 0, 'live': 0}
                                 ]

--- a/test/rest_api/test_storage_service.py
+++ b/test/rest_api/test_storage_service.py
@@ -11,6 +11,7 @@ import time
 # Use the util.py library from ../cql-pytest:
 sys.path.insert(1, sys.path[0] + '/../cql-pytest')
 from util import unique_name, new_test_table, new_test_keyspace
+from rest_util import new_test_snapshot
 
 # "keyspace" function: Creates and returns a temporary keyspace to be
 # used in tests that need a keyspace. The keyspace is created with RF=1,
@@ -241,3 +242,82 @@ def test_storage_service_flush(cql, this_dc, rest_api):
 
                 resp = rest_api.send("POST", f"storage_service/keyspace_flush/{ks}", { "cf": f"{t0},no_such_table,{t1}"} )
                 assert resp.status_code == requests.codes.bad_request
+
+def test_storage_service_snapshot(cql, this_dc, rest_api):
+    resp = rest_api.send("GET", "storage_service/snapshots")
+    resp.raise_for_status()
+
+    def verify_snapshot_details(expected):
+        resp = rest_api.send("GET", "storage_service/snapshots")
+        found = False
+        for data in resp.json():
+            if data['key'] == expected['key']:
+                assert not found
+                found = True
+                sort_key = lambda v: f"{v['ks']}-{v['cf']}"
+                value = sorted([v for v in data['value'] if not v['ks'].startswith('system')], key=sort_key)
+                expected_value = sorted(expected['value'], key=sort_key)
+                assert len(value) == len(expected_value), f"length mismatch: expected {expected_value} but got {value}"
+                for i in range(len(value)):
+                    v = value[i]
+                    # normalize `total` and `live`
+                    # since we care only if they are zero or not
+                    v['total'] = 1 if v['total'] else 0
+                    v['live'] = 1 if v['live'] else 0
+                    ev = expected_value[i]
+                    assert v == ev
+        assert found, f"key='{expected['key']}' not found in {resp.json()}"
+
+    with new_test_keyspace(cql, f"WITH REPLICATION = {{ 'class' : 'NetworkTopologyStrategy', '{this_dc}' : 1 }}") as keyspace0:
+        with new_test_table(cql, keyspace0, "p text PRIMARY KEY") as table00:
+            ks0, cf00 = table00.split('.')
+            stmt = cql.prepare(f"INSERT INTO {table00} (p) VALUES (?)")
+            cql.execute(stmt, ["pk0"])
+
+            # single keyspace / table
+            with new_test_snapshot(rest_api, ks0, cf00) as snapshot0:
+                verify_snapshot_details({
+                    'key': snapshot0,
+                    'value': [{'ks': ks0, 'cf': cf00, 'total': 1, 'live': 0}]
+                })
+
+            with new_test_table(cql, keyspace0, "p text PRIMARY KEY") as table01:
+                _, cf01 = table01.split('.')
+                stmt = cql.prepare(f"INSERT INTO {table01} (p) VALUES (?)")
+                cql.execute(stmt, ["pk1"])
+
+                # single keyspace / multiple tables
+                with new_test_snapshot(rest_api, ks0, [cf00, cf01]) as snapshot1:
+                    verify_snapshot_details({
+                        'key': snapshot1,
+                        'value': [
+                            {'ks': ks0, 'cf': cf00, 'total': 1, 'live': 0},
+                            {'ks': ks0, 'cf': cf01, 'total': 1, 'live': 0}
+                        ]
+                    })
+
+                with new_test_keyspace(cql, f"WITH REPLICATION = {{ 'class' : 'NetworkTopologyStrategy', '{this_dc}' : 1 }}") as keyspace1:
+                    with new_test_table(cql, keyspace1, "p text PRIMARY KEY") as table10:
+                        ks1, cf10 = table10.split('.')
+
+                        # multiple keyspaces
+                        with new_test_snapshot(rest_api, [ks0, ks1]) as snapshot2:
+                            verify_snapshot_details({
+                                'key': snapshot2,
+                                'value': [
+                                    {'ks': ks0, 'cf': cf00, 'total': 1, 'live': 0},
+                                    {'ks': ks0, 'cf': cf01, 'total': 1, 'live': 0},
+                                    {'ks': ks1, 'cf': cf10, 'total': 0, 'live': 0}
+                                ]
+                            })
+
+                        # all keyspaces
+                        with new_test_snapshot(rest_api, ) as snapshot3:
+                            verify_snapshot_details({
+                                'key': snapshot3,
+                                'value': [
+                                    {'ks': ks0, 'cf': cf00, 'total': 1, 'live': 0},
+                                    {'ks': ks0, 'cf': cf01, 'total': 1, 'live': 0},
+                                    {'ks': ks1, 'cf': cf10, 'total': 0, 'live': 0}
+                                ]
+                            })


### PR DESCRIPTION
This series refactors `table::snapshot` and moves the responsibility
to flush the table before taking the snapshot to the caller.

`flush_on_all` and `snapshot_on_all` helpers are added to replica::database
(by making it a peering_sharded_service) and upper layers,
including api and snapshot-ctl now call it instead of calling cf.snapshot directly.

With that, error are handed in table::snapshot and propagated
back to the callers.

Failure to allocate the `snapshot_manager` object is fatal,
similar to failure to allocate a continuation, since we can't
coordinate across the shards without it.

Test: unit(dev), rest_api(debug)

Fixes #10500