### PR TITLE
Convert (almost) all uses of flat_mutation_reader_assertions to v2

### DIFF
--- a/test/boost/memtable_test.cc
+++ b/test/boost/memtable_test.cc
@@ -688,7 +688,7 @@ SEASTAR_TEST_CASE(memtable_flush_compresses_mutations) {
 
         // Treat the table as mutation_source and assert we get the expected mutation and end of stream
         mutation_source ms = t.as_mutation_source();
-        assert_that(ms.make_reader(s, semaphore.make_permit()))
+        assert_that(ms.make_reader_v2(s, semaphore.make_permit()))
             .produces(m2)
             .produces_end_of_stream();
     }, db_config);

--- a/test/boost/mutation_reader_test.cc
+++ b/test/boost/mutation_reader_test.cc
@@ -3809,8 +3809,8 @@ SEASTAR_THREAD_TEST_CASE(test_clustering_order_merger_in_memory) {
 
     // Test case with 0 readers
     for (auto fwd: {streamed_mutation::forwarding::no, streamed_mutation::forwarding::yes}) {
-        auto r = downgrade_to_v1(make_clustering_combined_reader(g._s, semaphore.make_permit(), fwd,
-                std::make_unique<simple_position_reader_queue>(*g._s, std::vector<reader_bounds>{})));
+        auto r = make_clustering_combined_reader(g._s, semaphore.make_permit(), fwd,
+                std::make_unique<simple_position_reader_queue>(*g._s, std::vector<reader_bounds>{}));
         assert_that(std::move(r)).produces_end_of_stream();
     }
 }

--- a/test/boost/row_cache_test.cc
+++ b/test/boost/row_cache_test.cc
@@ -402,7 +402,7 @@ SEASTAR_TEST_CASE(test_cache_delegates_to_underlying_only_once_multiple_mutation
 
         auto do_test = [&s, &semaphore, &partitions] (const mutation_source& ds, const dht::partition_range& range,
                                           int& secondary_calls_count, int expected_calls) {
-            assert_that(ds.make_reader(s, semaphore.make_permit(), range))
+            assert_that(ds.make_reader_v2(s, semaphore.make_permit(), range))
                 .produces(slice(partitions, range))
                 .produces_end_of_stream();
             BOOST_CHECK_EQUAL(expected_calls, secondary_calls_count);
@@ -489,25 +489,25 @@ SEASTAR_TEST_CASE(test_cache_delegates_to_underlying_only_once_multiple_mutation
             auto range = dht::partition_range::make(
                 {partitions[0].decorated_key(), true},
                 {partitions[1].decorated_key(), true});
-            assert_that(ds.make_reader(s, semaphore.make_permit(), range))
+            assert_that(ds.make_reader_v2(s, semaphore.make_permit(), range))
                 .produces(slice(partitions, range))
                 .produces_end_of_stream();
             BOOST_CHECK_EQUAL(3, secondary_calls_count);
-            assert_that(ds.make_reader(s, semaphore.make_permit(), range))
+            assert_that(ds.make_reader_v2(s, semaphore.make_permit(), range))
                 .produces(slice(partitions, range))
                 .produces_end_of_stream();
             BOOST_CHECK_EQUAL(3, secondary_calls_count);
             auto range2 = dht::partition_range::make(
                 {partitions[0].decorated_key(), true},
                 {partitions[1].decorated_key(), false});
-            assert_that(ds.make_reader(s, semaphore.make_permit(), range2))
+            assert_that(ds.make_reader_v2(s, semaphore.make_permit(), range2))
                 .produces(slice(partitions, range2))
                 .produces_end_of_stream();
             BOOST_CHECK_EQUAL(3, secondary_calls_count);
             auto range3 = dht::partition_range::make(
                 {dht::ring_position::starting_at(key_before_all.token())},
                 {partitions[2].decorated_key(), false});
-            assert_that(ds.make_reader(s, semaphore.make_permit(), range3))
+            assert_that(ds.make_reader_v2(s, semaphore.make_permit(), range3))
                 .produces(slice(partitions, range3))
                 .produces_end_of_stream();
             BOOST_CHECK_EQUAL(5, secondary_calls_count);
@@ -529,7 +529,7 @@ SEASTAR_TEST_CASE(test_cache_delegates_to_underlying_only_once_multiple_mutation
 
             cache->invalidate(row_cache::external_updater([] {}), key_after_all).get();
 
-            assert_that(ds.make_reader(s, semaphore.make_permit(), query::full_partition_range))
+            assert_that(ds.make_reader_v2(s, semaphore.make_permit(), query::full_partition_range))
                 .produces(slice(partitions, query::full_partition_range))
                 .produces_end_of_stream();
             BOOST_CHECK_EQUAL(partitions.size() + 2, secondary_calls_count);

--- a/test/boost/schema_changes_test.cc
+++ b/test/boost/schema_changes_test.cc
@@ -57,14 +57,14 @@ SEASTAR_TEST_CASE(test_schema_changes) {
             const auto pr = dht::partition_range::make_open_ended_both_sides();
 
             auto mr = assert_that(created_with_base_schema->as_mutation_source()
-                        .make_reader(changed, env.make_reader_permit(), pr, changed->full_slice()));
+                        .make_reader_v2(changed, env.make_reader_permit(), pr, changed->full_slice()));
             for (auto& m : changed_mutations) {
                 mr.produces(m);
             }
             mr.produces_end_of_stream();
 
             mr = assert_that(created_with_changed_schema->as_mutation_source()
-                    .make_reader(changed, env.make_reader_permit(), pr, changed->full_slice()));
+                    .make_reader_v2(changed, env.make_reader_permit(), pr, changed->full_slice()));
             for (auto& m : changed_mutations) {
                 mr.produces(m);
             }

--- a/test/boost/sstable_3_x_test.cc
+++ b/test/boost/sstable_3_x_test.cc
@@ -1533,7 +1533,7 @@ SEASTAR_TEST_CASE(test_uncompressed_counters_read) {
     BOOST_REQUIRE(cdef);
 
     auto generate = [&] (api::timestamp_type timestamp, int64_t value, int64_t clock) {
-        std::vector<flat_reader_assertions::assert_function> assertions;
+        std::vector<flat_reader_assertions_v2::assert_function> assertions;
 
         assertions.push_back([&, timestamp, value, clock] (const column_definition& def,
                                                            const atomic_cell_or_collection* cell) {
@@ -2447,7 +2447,7 @@ SEASTAR_TEST_CASE(test_uncompressed_deleted_cells_read) {
     BOOST_REQUIRE(int_cdef);
 
     auto generate = [&] (uint64_t timestamp, uint64_t deletion_time) {
-        std::vector<flat_reader_assertions::assert_function> assertions;
+        std::vector<flat_reader_assertions_v2::assert_function> assertions;
 
         assertions.push_back([timestamp, deletion_time] (const column_definition& def,
                                  const atomic_cell_or_collection* cell) {
@@ -2916,7 +2916,7 @@ SEASTAR_TEST_CASE(test_uncompressed_collections_read) {
     BOOST_REQUIRE(map_cdef);
 
     auto generate = [&] (std::vector<int> set_val, std::vector<sstring> list_val, std::vector<std::pair<int, sstring>> map_val) {
-        std::vector<flat_reader_assertions::assert_function> assertions;
+        std::vector<flat_reader_assertions_v2::assert_function> assertions;
 
         assertions.push_back([val = std::move(set_val)] (const column_definition& def,
                                                          const atomic_cell_or_collection* cell) {

--- a/test/boost/sstable_conforms_to_mutation_source_test.cc
+++ b/test/boost/sstable_conforms_to_mutation_source_test.cc
@@ -259,12 +259,12 @@ SEASTAR_THREAD_TEST_CASE(test_sstable_reversing_reader_random_schema) {
                 auto prange = dht::partition_range::make_singular(m.decorated_key());
 
                 {
-                    auto r1 = source.make_reader(query_schema, semaphore.make_permit(), prange,
+                    auto r1 = source.make_reader_v2(query_schema, semaphore.make_permit(), prange,
                             slice, default_priority_class(), nullptr,
                             streamed_mutation::forwarding::no, mutation_reader::forwarding::no);
                     auto close_r1 = deferred_action([&r1] { r1.close().get(); });
 
-                    auto r2 = rev_source.make_reader(query_schema, semaphore.make_permit(), prange,
+                    auto r2 = rev_source.make_reader_v2(query_schema, semaphore.make_permit(), prange,
                             rev_slice, default_priority_class(), nullptr,
                             streamed_mutation::forwarding::no, mutation_reader::forwarding::no);
                     close_r1.cancel();
@@ -272,12 +272,12 @@ SEASTAR_THREAD_TEST_CASE(test_sstable_reversing_reader_random_schema) {
                     compare_readers(*query_schema, std::move(r1), std::move(r2));
                 }
 
-                auto r1 = source.make_reader(query_schema, semaphore.make_permit(), prange,
+                auto r1 = source.make_reader_v2(query_schema, semaphore.make_permit(), prange,
                         query_schema->full_slice(), default_priority_class(), nullptr,
                         streamed_mutation::forwarding::yes, mutation_reader::forwarding::no);
                 auto close_r1 = deferred_action([&r1] { r1.close().get(); });
 
-                auto r2 = rev_source.make_reader(query_schema, semaphore.make_permit(), prange,
+                auto r2 = rev_source.make_reader_v2(query_schema, semaphore.make_permit(), prange,
                         rev_full_slice, default_priority_class(), nullptr,
                         streamed_mutation::forwarding::yes, mutation_reader::forwarding::no);
                 close_r1.cancel();

--- a/test/boost/sstable_datafile_test.cc
+++ b/test/boost/sstable_datafile_test.cc
@@ -337,12 +337,6 @@ SEASTAR_TEST_CASE(datafile_generation_16) {
 }
 
 // mutation_reader for sstable keeping all the required objects alive.
-static flat_mutation_reader sstable_reader(shared_sstable sst, schema_ptr s, reader_permit permit) {
-    return sst->as_mutation_source().make_reader(s, std::move(permit), query::full_partition_range, s->full_slice());
-
-}
-
-// mutation_reader for sstable keeping all the required objects alive.
 static flat_mutation_reader_v2 sstable_reader_v2(shared_sstable sst, schema_ptr s, reader_permit permit) {
     return sst->as_mutation_source().make_reader_v2(s, std::move(permit), query::full_partition_range, s->full_slice());
 

--- a/test/boost/sstable_datafile_test.cc
+++ b/test/boost/sstable_datafile_test.cc
@@ -342,8 +342,14 @@ static flat_mutation_reader sstable_reader(shared_sstable sst, schema_ptr s, rea
 
 }
 
-static flat_mutation_reader sstable_reader(shared_sstable sst, schema_ptr s, reader_permit permit, const dht::partition_range& pr) {
-    return sst->as_mutation_source().make_reader(s, std::move(permit), pr, s->full_slice());
+// mutation_reader for sstable keeping all the required objects alive.
+static flat_mutation_reader_v2 sstable_reader_v2(shared_sstable sst, schema_ptr s, reader_permit permit) {
+    return sst->as_mutation_source().make_reader_v2(s, std::move(permit), query::full_partition_range, s->full_slice());
+
+}
+
+static flat_mutation_reader_v2 sstable_reader_v2(shared_sstable sst, schema_ptr s, reader_permit permit, const dht::partition_range& pr) {
+    return sst->as_mutation_source().make_reader_v2(s, std::move(permit), pr, s->full_slice());
 }
 
 SEASTAR_TEST_CASE(datafile_generation_37) {
@@ -509,9 +515,9 @@ SEASTAR_TEST_CASE(datafile_generation_47) {
         auto sst = env.make_sstable(s, tmpdir_path, 47, sstables::get_highest_sstable_version(), big);
         return write_memtable_to_sstable_for_test(*mt, sst).then([&env, s, tmpdir_path] {
             return env.reusable_sst(s, tmpdir_path, 47).then([&env, s] (auto sstp) mutable {
-                auto reader = make_lw_shared<flat_mutation_reader>(sstable_reader(sstp, s, env.make_reader_permit()));
+                auto reader = make_lw_shared<flat_mutation_reader_v2>(sstable_reader_v2(sstp, s, env.make_reader_permit()));
                 return repeat([reader] {
-                    return (*reader)().then([] (mutation_fragment_opt m) {
+                    return (*reader)().then([] (mutation_fragment_v2_opt m) {
                         if (!m) {
                             return make_ready_future<stop_iteration>(stop_iteration::yes);
                         }
@@ -569,7 +575,7 @@ SEASTAR_TEST_CASE(test_counter_write) {
             write_memtable_to_sstable_for_test(*mt, sst).get();
 
             auto sstp = env.reusable_sst(s, tmpdir_path, 900).get0();
-            assert_that(sstable_reader(sstp, s, env.make_reader_permit()))
+            assert_that(sstable_reader_v2(sstp, s, env.make_reader_permit()))
                 .produces(m)
                 .produces_end_of_stream();
         });
@@ -633,7 +639,7 @@ SEASTAR_TEST_CASE(check_multi_schema) {
             auto sst = env.make_sstable(s, get_test_dir("multi_schema_test", s), 1, version, big);
             auto f = sst->load();
             return f.then([&env, sst, s] {
-                auto reader = make_lw_shared<flat_mutation_reader>(sstable_reader(sst, s, env.make_reader_permit()));
+                auto reader = make_lw_shared<flat_mutation_reader_v2>(sstable_reader_v2(sst, s, env.make_reader_permit()));
                 return read_mutation_from_flat_mutation_reader(*reader).then([reader, s] (mutation_opt m) {
                     BOOST_REQUIRE(m);
                     BOOST_REQUIRE(m->key().equal(*s, partition_key::from_singular(*s, 0)));
@@ -646,7 +652,7 @@ SEASTAR_TEST_CASE(check_multi_schema) {
                     auto& cdef = *s->get_column_definition("e");
                     BOOST_REQUIRE_EQUAL(cells.cell_at(cdef.id).as_atomic_cell(cdef).value(), managed_bytes(int32_type->decompose(5)));
                     return (*reader)();
-                }).then([reader, s] (mutation_fragment_opt m) {
+                }).then([reader, s] (mutation_fragment_v2_opt m) {
                     BOOST_REQUIRE(!m);
                 }).finally([reader] {
                     return reader->close();
@@ -890,7 +896,7 @@ SEASTAR_TEST_CASE(test_counter_read) {
 
             auto sst = env.make_sstable(s, get_test_dir("counter_test", s), 5, version, big);
             sst->load().get();
-            auto reader = sstable_reader(sst, s, env.make_reader_permit());
+            auto reader = sstable_reader_v2(sst, s, env.make_reader_permit());
             auto close_reader = deferred_close(reader);
 
             auto mfopt = reader().get0();
@@ -1850,10 +1856,10 @@ SEASTAR_TEST_CASE(test_partition_skipping) {
         dht::decorated_key::less_comparator cmp(s);
         std::sort(keys.begin(), keys.end(), cmp);
 
-        assert_that(sstable_reader(sst, s, env.make_reader_permit())).produces(keys);
+        assert_that(sstable_reader_v2(sst, s, env.make_reader_permit())).produces(keys);
 
         auto pr = dht::partition_range::make(dht::ring_position(keys[0]), dht::ring_position(keys[1]));
-        assert_that(sstable_reader(sst, s, env.make_reader_permit(), pr))
+        assert_that(sstable_reader_v2(sst, s, env.make_reader_permit(), pr))
             .produces(keys[0])
             .produces(keys[1])
             .produces_end_of_stream()
@@ -1863,7 +1869,7 @@ SEASTAR_TEST_CASE(test_partition_skipping) {
             .produces_end_of_stream();
 
         pr = dht::partition_range::make(dht::ring_position(keys[1]), dht::ring_position(keys[1]));
-        assert_that(sstable_reader(sst, s, env.make_reader_permit(), pr))
+        assert_that(sstable_reader_v2(sst, s, env.make_reader_permit(), pr))
             .produces(keys[1])
             .produces_end_of_stream()
             .fast_forward_to(dht::partition_range::make(dht::ring_position(keys[3]), dht::ring_position(keys[4])))
@@ -1883,7 +1889,7 @@ SEASTAR_TEST_CASE(test_partition_skipping) {
             .produces_end_of_stream();
 
         pr = dht::partition_range::make({ dht::ring_position(keys[0]), false }, { dht::ring_position(keys[1]), false});
-        assert_that(sstable_reader(sst, s, env.make_reader_permit(), pr))
+        assert_that(sstable_reader_v2(sst, s, env.make_reader_permit(), pr))
             .produces_end_of_stream()
             .fast_forward_to(dht::partition_range::make(dht::ring_position(keys[6]), dht::ring_position(keys[6])))
             .produces(keys[6])
@@ -1947,7 +1953,7 @@ SEASTAR_TEST_CASE(test_repeated_tombstone_skipping) {
                 .with_range(query::clustering_range::make_singular(ck2))
                 .with_range(query::clustering_range::make_singular(ck3))
                 .build();
-            flat_mutation_reader rd = ms.make_reader(table.schema(), env.make_reader_permit(), query::full_partition_range, slice);
+            auto rd = ms.make_reader_v2(table.schema(), env.make_reader_permit(), query::full_partition_range, slice);
             assert_that(std::move(rd)).has_monotonic_positions();
         }
       }
@@ -1986,7 +1992,7 @@ SEASTAR_TEST_CASE(test_skipping_using_index) {
         auto sst = make_sstable_easy(env, dir.path(), make_flat_mutation_reader_from_mutations_v2(table.schema(), env.make_reader_permit(), partitions), cfg, 1, version);
 
         auto ms = as_mutation_source(sst);
-        auto rd = ms.make_reader(table.schema(),
+        auto rd = ms.make_reader_v2(table.schema(),
             env.make_reader_permit(),
             query::full_partition_range,
             table.schema()->full_slice(),
@@ -2384,7 +2390,7 @@ SEASTAR_TEST_CASE(test_summary_entry_spanning_more_keys_than_min_interval) {
 
         std::set<mutation, mutation_decorated_key_less_comparator> merged;
         merged.insert(mutations.begin(), mutations.end());
-        auto rd = assert_that(sst->as_mutation_source().make_reader(s, env.make_reader_permit(), query::full_partition_range));
+        auto rd = assert_that(sst->as_mutation_source().make_reader_v2(s, env.make_reader_permit(), query::full_partition_range));
         auto keys_read = 0;
         for (auto&& m : merged) {
             keys_read++;
@@ -2394,7 +2400,7 @@ SEASTAR_TEST_CASE(test_summary_entry_spanning_more_keys_than_min_interval) {
         BOOST_REQUIRE(keys_read == keys_written);
 
         auto r = dht::partition_range::make({mutations.back().decorated_key(), true}, {mutations.back().decorated_key(), true});
-        assert_that(sst->as_mutation_source().make_reader(s, env.make_reader_permit(), r))
+        assert_that(sst->as_mutation_source().make_reader_v2(s, env.make_reader_permit(), r))
             .produces(slice(mutations, r))
             .produces_end_of_stream();
     });
@@ -2430,10 +2436,10 @@ SEASTAR_TEST_CASE(test_wrong_counter_shard_order) {
 
             auto sst = env.make_sstable(s, get_test_dir("wrong_counter_shard_order", s), 2, version, big);
             sst->load().get0();
-            auto reader = sstable_reader(sst, s, env.make_reader_permit());
+            auto reader = sstable_reader_v2(sst, s, env.make_reader_permit());
             auto close_reader = deferred_close(reader);
 
-            auto verify_row = [&s] (mutation_fragment_opt mfopt, int64_t expected_value) {
+            auto verify_row = [&s] (mutation_fragment_v2_opt mfopt, int64_t expected_value) {
                 BOOST_REQUIRE(bool(mfopt));
                 auto& mf = *mfopt;
                 BOOST_REQUIRE(mf.is_clustering_row());
@@ -2543,7 +2549,7 @@ SEASTAR_TEST_CASE(test_old_format_non_compound_range_tombstone_is_read) {
 
                 {
                     auto slice = partition_slice_builder(*s).with_range(query::clustering_range::make_singular({ck})).build();
-                    assert_that(sst->as_mutation_source().make_reader(s, env.make_reader_permit(), dht::partition_range::make_singular(dk), slice))
+                    assert_that(sst->as_mutation_source().make_reader_v2(s, env.make_reader_permit(), dht::partition_range::make_singular(dk), slice))
                             .produces(m)
                             .produces_end_of_stream();
                 }
@@ -2727,7 +2733,7 @@ SEASTAR_TEST_CASE(test_reads_cassandra_static_compact) {
         m.set_clustered_cell(clustering_key::make_empty(), *s->get_column_definition("c2"),
                     atomic_cell::make_live(*utf8_type, 1551785032379079, utf8_type->decompose("cde"), {}));
 
-        assert_that(sst->as_mutation_source().make_reader(s, env.make_reader_permit()))
+        assert_that(sst->as_mutation_source().make_reader_v2(s, env.make_reader_permit()))
             .produces(m)
             .produces_end_of_stream();
     });

--- a/test/boost/sstable_mutation_test.cc
+++ b/test/boost/sstable_mutation_test.cc
@@ -1010,7 +1010,7 @@ SEASTAR_TEST_CASE(test_promoted_index_blocks_are_monotonic_compound_dense) {
 
         {
             auto slice = partition_slice_builder(*s).with_range(query::clustering_range::make_starting_with({ck1})).build();
-            assert_that(sst->as_mutation_source().make_reader(s, env.make_reader_permit(), dht::partition_range::make_singular(dk), slice))
+            assert_that(sst->as_mutation_source().make_reader_v2(s, env.make_reader_permit(), dht::partition_range::make_singular(dk), slice))
                     .produces(m, slice.get_all_ranges())
                     .produces_end_of_stream();
         }
@@ -1061,7 +1061,7 @@ SEASTAR_TEST_CASE(test_promoted_index_blocks_are_monotonic_non_compound_dense) {
 
         {
             auto slice = partition_slice_builder(*s).with_range(query::clustering_range::make_starting_with({ck1})).build();
-            assert_that(sst->as_mutation_source().make_reader(s, env.make_reader_permit(), dht::partition_range::make_singular(dk), slice))
+            assert_that(sst->as_mutation_source().make_reader_v2(s, env.make_reader_permit(), dht::partition_range::make_singular(dk), slice))
                     .produces(m)
                     .produces_end_of_stream();
         }
@@ -1105,7 +1105,7 @@ SEASTAR_TEST_CASE(test_promoted_index_repeats_open_tombstones) {
 
             {
                 auto slice = partition_slice_builder(*s).with_range(query::clustering_range::make_starting_with({ck})).build();
-                assert_that(sst->as_mutation_source().make_reader(s, env.make_reader_permit(), dht::partition_range::make_singular(dk), slice))
+                assert_that(sst->as_mutation_source().make_reader_v2(s, env.make_reader_permit(), dht::partition_range::make_singular(dk), slice))
                         .produces(m, slice.get_all_ranges())
                         .produces_end_of_stream();
             }
@@ -1142,7 +1142,7 @@ SEASTAR_TEST_CASE(test_range_tombstones_are_correctly_seralized_for_non_compound
 
         {
             auto slice = partition_slice_builder(*s).build();
-            assert_that(sst->as_mutation_source().make_reader(s, env.make_reader_permit(), dht::partition_range::make_singular(dk), slice))
+            assert_that(sst->as_mutation_source().make_reader_v2(s, env.make_reader_permit(), dht::partition_range::make_singular(dk), slice))
                     .produces(m)
                     .produces_end_of_stream();
         }
@@ -1211,7 +1211,7 @@ SEASTAR_TEST_CASE(test_writing_combined_stream_with_tombstones_at_the_same_posit
             mt1->make_flat_reader(s, combined_permit), mt2->make_flat_reader(s, combined_permit));
         auto sst = make_sstable_easy(env, dir.path(), std::move(mr), env.manager().configure_writer(), 1, version);
 
-        assert_that(sst->as_mutation_source().make_reader(s, env.make_reader_permit()))
+        assert_that(sst->as_mutation_source().make_reader_v2(s, env.make_reader_permit()))
             .produces(m1 + m2)
             .produces_end_of_stream();
       }
@@ -1249,7 +1249,7 @@ SEASTAR_TEST_CASE(test_no_index_reads_when_rows_fall_into_range_boundaries) {
             auto before = index_accesses();
 
             {
-                assert_that(ms.make_reader(s, env.make_reader_permit()))
+                assert_that(ms.make_reader_v2(s, env.make_reader_permit()))
                     .produces(m1)
                     .produces(m2)
                     .produces_end_of_stream();
@@ -1540,7 +1540,7 @@ SEASTAR_TEST_CASE(test_counter_header_size) {
 
     for (const auto version : writable_sstable_versions) {
         auto sst = make_sstable_easy(env, dir.path(), mt, env.manager().configure_writer(), 1, version);
-        assert_that(sst->as_mutation_source().make_reader(s, env.make_reader_permit()))
+        assert_that(sst->as_mutation_source().make_reader_v2(s, env.make_reader_permit()))
             .produces(m)
             .produces_end_of_stream();
     }
@@ -1577,7 +1577,7 @@ SEASTAR_TEST_CASE(test_static_compact_tables_are_read) {
             sstable_writer_config cfg = env.manager().configure_writer();
             auto ms = make_sstable_mutation_source(env, s, dir.path().string(), muts, cfg, version);
 
-            assert_that(ms.make_reader(s, env.make_reader_permit()))
+            assert_that(ms.make_reader_v2(s, env.make_reader_permit()))
                 .produces(muts[0])
                 .produces(muts[1])
                 .produces_end_of_stream();

--- a/test/boost/sstable_resharding_test.cc
+++ b/test/boost/sstable_resharding_test.cc
@@ -115,7 +115,7 @@ void run_sstable_resharding_test() {
         auto shard = shards.front();
         BOOST_REQUIRE(column_family_test::calculate_shard_from_sstable_generation(new_sst->generation()) == shard);
 
-        auto rd = assert_that(new_sst->as_mutation_source().make_reader(s, env.make_reader_permit()));
+        auto rd = assert_that(new_sst->as_mutation_source().make_reader_v2(s, env.make_reader_permit()));
         BOOST_REQUIRE(muts[shard].size() == keys_per_shard);
         for (auto k : boost::irange(0u, keys_per_shard)) {
             rd.produces(muts[shard][k]);

--- a/test/lib/mutation_source_test.cc
+++ b/test/lib/mutation_source_test.cc
@@ -16,6 +16,7 @@
 #include "mutation_rebuilder.hh"
 #include "test/lib/simple_schema.hh"
 #include "readers/flat_mutation_reader.hh"
+#include "readers/flat_mutation_reader_v2.hh"
 #include "test/lib/flat_mutation_reader_assertions.hh"
 #include "mutation_query.hh"
 #include "mutation_rebuilder.hh"
@@ -62,6 +63,16 @@ public:
     explicit partition_range_walker(std::vector<dht::partition_range> ranges) : _ranges(ranges) { }
     const dht::partition_range& initial_range() const { return _ranges[0]; }
     void fast_forward_if_needed(flat_reader_assertions& mr, const mutation& expected, bool verify_eos = true) {
+        while (!current_range().contains(expected.decorated_key(), dht::ring_position_comparator(*expected.schema()))) {
+            _current_position++;
+            assert(_current_position < _ranges.size());
+            if (verify_eos) {
+                mr.produces_end_of_stream();
+            }
+            mr.fast_forward_to(current_range());
+        }
+    }
+    void fast_forward_if_needed(flat_reader_assertions_v2& mr, const mutation& expected, bool verify_eos = true) {
         while (!current_range().contains(expected.decorated_key(), dht::ring_position_comparator(*expected.schema()))) {
             _current_position++;
             assert(_current_position < _ranges.size());
@@ -168,8 +179,8 @@ static void test_slicing_and_fast_forwarding(tests::reader_concurrency_semaphore
                 auto test_common = [&] (const query::partition_slice& slice) {
                     testlog.info("Read whole partitions at once");
                     auto pranges_walker = partition_range_walker(pranges);
-                    auto mr = ms.make_reader(s.schema(), semaphore.make_permit(), pranges_walker.initial_range(), slice,
-                                             default_priority_class(), nullptr, streamed_mutation::forwarding::no, fwd_mr);
+                    auto mr = ms.make_reader_v2(s.schema(), semaphore.make_permit(), pranges_walker.initial_range(), slice,
+                                                default_priority_class(), nullptr, streamed_mutation::forwarding::no, fwd_mr);
                     auto actual = assert_that(std::move(mr));
                     for (auto& expected : mutations) {
                         pranges_walker.fast_forward_if_needed(actual, expected);
@@ -183,7 +194,8 @@ static void test_slicing_and_fast_forwarding(tests::reader_concurrency_semaphore
                             if (expected.partition().find_row(*s.schema(), ck)) {
                                 auto end_position = position_in_partition(position_in_partition::after_clustering_row_tag_t(), ck);
                                 actual.may_produce_tombstones(position_range(start_position, end_position));
-                                actual.produces_row_with_key(ck, expected.partition().tombstone_for_row(*s.schema(), ck).regular().timestamp);
+                                actual.produces_row_with_key(ck, expected.partition().range_tombstone_for_row(*s.schema(), ck));
+                                actual.may_produce_tombstones(position_range(start_position, end_position));
                                 start_position = std::move(end_position);
                             }
                         }
@@ -194,8 +206,8 @@ static void test_slicing_and_fast_forwarding(tests::reader_concurrency_semaphore
 
                     testlog.info("Read partitions with fast-forwarding to each individual row");
                     pranges_walker = partition_range_walker(pranges);
-                    mr = ms.make_reader(s.schema(), semaphore.make_permit(), pranges_walker.initial_range(), slice,
-                                        default_priority_class(), nullptr, streamed_mutation::forwarding::yes, fwd_mr);
+                    mr = ms.make_reader_v2(s.schema(), semaphore.make_permit(), pranges_walker.initial_range(), slice,
+                                           default_priority_class(), nullptr, streamed_mutation::forwarding::yes, fwd_mr);
                     actual = assert_that(std::move(mr));
                     for (auto& expected : mutations) {
                         pranges_walker.fast_forward_if_needed(actual, expected);
@@ -212,7 +224,7 @@ static void test_slicing_and_fast_forwarding(tests::reader_concurrency_semaphore
                             actual.fast_forward_to(pos_range);
                             actual.may_produce_tombstones(pos_range);
                             if (expected.partition().find_row(*s.schema(), ck)) {
-                                actual.produces_row_with_key(ck, expected.partition().tombstone_for_row(*s.schema(), ck).regular().timestamp);
+                                actual.produces_row_with_key(ck, expected.partition().range_tombstone_for_row(*s.schema(), ck));
                                 actual.may_produce_tombstones(pos_range);
                             }
                             actual.produces_end_of_stream();
@@ -230,15 +242,15 @@ static void test_slicing_and_fast_forwarding(tests::reader_concurrency_semaphore
                 test_common(slice);
 
                 testlog.info("Test monotonic positions");
-                auto mr = ms.make_reader(s.schema(), semaphore.make_permit(), query::full_partition_range, slice,
+                auto mr = ms.make_reader_v2(s.schema(), semaphore.make_permit(), query::full_partition_range, slice,
                                             default_priority_class(), nullptr, streamed_mutation::forwarding::no, fwd_mr);
                 assert_that(std::move(mr)).has_monotonic_positions();
 
                 if (range_size != 1) {
                     testlog.info("Read partitions fast-forwarded to the range of interest");
                     auto pranges_walker = partition_range_walker(pranges);
-                    mr = ms.make_reader(s.schema(), semaphore.make_permit(), pranges_walker.initial_range(), slice,
-                                        default_priority_class(), nullptr, streamed_mutation::forwarding::yes, fwd_mr);
+                    mr = ms.make_reader_v2(s.schema(), semaphore.make_permit(), pranges_walker.initial_range(), slice,
+                                           default_priority_class(), nullptr, streamed_mutation::forwarding::yes, fwd_mr);
                     auto actual = assert_that(std::move(mr));
                     for (auto& expected : mutations) {
                         pranges_walker.fast_forward_if_needed(actual, expected);
@@ -253,13 +265,13 @@ static void test_slicing_and_fast_forwarding(tests::reader_concurrency_semaphore
                         actual.fast_forward_to(position_range(
                             position_in_partition(position_in_partition::clustering_row_tag_t(), start_ck),
                             position_in_partition(position_in_partition::clustering_row_tag_t(), end_ck)));
-                        auto current_position = position_in_partition(position_in_partition::clustering_row_tag_t(), start_ck);
+                        auto current_position = position_in_partition(position_in_partition::after_static_row_tag_t());
                         for (auto current = start; current < start + range_size; current++) {
                             auto ck = s.make_ckey(current);
                             if (expected.partition().find_row(*s.schema(), ck)) {
                                 auto end_position = position_in_partition(position_in_partition::after_clustering_row_tag_t(), ck);
                                 actual.may_produce_tombstones(position_range(current_position, end_position));
-                                actual.produces_row_with_key(ck, expected.partition().tombstone_for_row(*s.schema(), ck).regular().timestamp);
+                                actual.produces_row_with_key(ck, expected.partition().range_tombstone_for_row(*s.schema(), ck));
                                 current_position = std::move(end_position);
                             }
                         }
@@ -277,8 +289,8 @@ static void test_slicing_and_fast_forwarding(tests::reader_concurrency_semaphore
 
                 testlog.info("Read partitions with just static rows");
                 auto pranges_walker = partition_range_walker(pranges);
-                mr = ms.make_reader(s.schema(), semaphore.make_permit(), pranges_walker.initial_range(), slice,
-                                    default_priority_class(), nullptr, streamed_mutation::forwarding::no, fwd_mr);
+                mr = ms.make_reader_v2(s.schema(), semaphore.make_permit(), pranges_walker.initial_range(), slice,
+                                       default_priority_class(), nullptr, streamed_mutation::forwarding::no, fwd_mr);
                 auto actual = assert_that(std::move(mr));
                 for (auto& expected : mutations) {
                     pranges_walker.fast_forward_if_needed(actual, expected);
@@ -304,7 +316,7 @@ static void test_slicing_and_fast_forwarding(tests::reader_concurrency_semaphore
                     test_common(slice);
 
                     testlog.info("Test monotonic positions");
-                    auto mr = ms.make_reader(s.schema(), semaphore.make_permit(), query::full_partition_range, slice,
+                    auto mr = ms.make_reader_v2(s.schema(), semaphore.make_permit(), query::full_partition_range, slice,
                                                 default_priority_class(), nullptr, streamed_mutation::forwarding::no, fwd_mr);
                     assert_that(std::move(mr)).has_monotonic_positions();
                 }
@@ -376,12 +388,11 @@ static void test_streamed_mutation_forwarding_is_consistent_with_slicing(tests::
 
         mutation_source ms = populate(m.schema(), {m}, gc_clock::now());
 
-        flat_mutation_reader sliced_reader =
-            ms.make_reader(m.schema(), semaphore.make_permit(), prange, slice_with_ranges);
+        auto sliced_reader = ms.make_reader_v2(m.schema(), semaphore.make_permit(), prange, slice_with_ranges);
         auto close_sliced_reader = deferred_close(sliced_reader);
 
-        flat_mutation_reader fwd_reader =
-            ms.make_reader(m.schema(), semaphore.make_permit(), prange, full_slice, default_priority_class(), nullptr, streamed_mutation::forwarding::yes);
+        auto fwd_reader =
+            ms.make_reader_v2(m.schema(), semaphore.make_permit(), prange, full_slice, default_priority_class(), nullptr, streamed_mutation::forwarding::yes);
         std::vector<position_range> position_ranges;
         for (auto& r: ranges) {
             position_ranges.emplace_back(r);
@@ -421,9 +432,9 @@ static void test_streamed_mutation_forwarding_guarantees(tests::reader_concurren
 
     mutation_source ms = populate(s, std::vector<mutation>({m}), gc_clock::now());
 
-    auto new_stream = [&ms, s, &semaphore, &m] () -> flat_reader_assertions {
+    auto new_stream = [&ms, s, &semaphore, &m] () -> flat_reader_assertions_v2 {
         testlog.info("Creating new streamed_mutation");
-        auto res = assert_that(ms.make_reader(s,
+        auto res = assert_that(ms.make_reader_v2(s,
             semaphore.make_permit(),
             query::full_partition_range,
             s->full_slice(),
@@ -434,7 +445,7 @@ static void test_streamed_mutation_forwarding_guarantees(tests::reader_concurren
         return res;
     };
 
-    auto verify_range = [&] (flat_reader_assertions& sm, int start, int end) {
+    auto verify_range = [&] (flat_reader_assertions_v2& sm, int start, int end) {
         sm.fast_forward_to(keys[start], keys[end]);
 
         for (; start < end; ++start) {
@@ -559,7 +570,7 @@ static void test_fast_forwarding_across_partitions_to_empty_range(tests::reader_
     mutation_source ms = populate(s, partitions, gc_clock::now());
 
     auto pr = dht::partition_range::make({keys[0]}, {keys[1]});
-    auto rd = assert_that(ms.make_reader(s,
+    auto rd = assert_that(ms.make_reader_v2(s,
         semaphore.make_permit(),
         pr,
         s->full_slice(),
@@ -830,7 +841,7 @@ static void test_range_queries(tests::reader_concurrency_semaphore_wrapper& sema
 
     auto test_slice = [&] (dht::partition_range r) {
         testlog.info("Testing range {}", r);
-        assert_that(ds.make_reader(s, semaphore.make_permit(), r))
+        assert_that(ds.make_reader_v2(s, semaphore.make_permit(), r))
             .produces(slice(partitions, r))
             .produces_end_of_stream();
     };
@@ -934,7 +945,7 @@ void test_all_data_is_read_back(tests::reader_concurrency_semaphore_wrapper& sem
         auto ms = populate(m.schema(), {m}, query_time);
         mutation copy(m);
         copy.partition().compact_for_compaction(*copy.schema(), always_gc, copy.decorated_key(), query_time);
-        assert_that(ms.make_reader(m.schema(), semaphore.make_permit())).produces_compacted(copy, query_time);
+        assert_that(ms.make_reader_v2(m.schema(), semaphore.make_permit())).produces_compacted(copy, query_time);
     });
 }
 
@@ -976,7 +987,7 @@ static void test_date_tiered_clustering_slicing(tests::reader_concurrency_semaph
             .with_range(ss.make_ckey_range(1, 2))
             .build();
         auto prange = dht::partition_range::make_singular(pkey);
-        assert_that(ms.make_reader(s, semaphore.make_permit(), prange, slice))
+        assert_that(ms.make_reader_v2(s, semaphore.make_permit(), prange, slice))
             .produces(m1, slice.row_ranges(*s, pkey.key()))
             .produces_end_of_stream();
     }
@@ -986,7 +997,7 @@ static void test_date_tiered_clustering_slicing(tests::reader_concurrency_semaph
             .with_range(query::clustering_range::make_singular(ss.make_ckey(0)))
             .build();
         auto prange = dht::partition_range::make_singular(pkey);
-        assert_that(ms.make_reader(s, semaphore.make_permit(), prange, slice))
+        assert_that(ms.make_reader_v2(s, semaphore.make_permit(), prange, slice))
             .produces(m1)
             .produces_end_of_stream();
     }
@@ -1073,14 +1084,14 @@ static void test_clustering_slices(tests::reader_concurrency_semaphore_wrapper& 
         auto slice = partition_slice_builder(*s)
             .with_range(query::clustering_range::make_singular(make_ck(0)))
             .build();
-        assert_that(ds.make_reader(s, semaphore.make_permit(), pr, slice))
+        assert_that(ds.make_reader_v2(s, semaphore.make_permit(), pr, slice))
             .produces_eos_or_empty_mutation();
     }
 
     {
         auto slice = partition_slice_builder(*s)
             .build();
-        auto rd = assert_that(ds.make_reader(s, semaphore.make_permit(), pr, slice, default_priority_class(), nullptr, streamed_mutation::forwarding::yes));
+        auto rd = assert_that(ds.make_reader_v2(s, semaphore.make_permit(), pr, slice, default_priority_class(), nullptr, streamed_mutation::forwarding::yes));
         rd.produces_partition_start(pk)
           .fast_forward_to(position_range(position_in_partition::for_key(ck1), position_in_partition::after_key(ck2)))
           .produces_row_with_key(ck1)
@@ -1091,7 +1102,7 @@ static void test_clustering_slices(tests::reader_concurrency_semaphore_wrapper& 
     {
         auto slice = partition_slice_builder(*s)
             .build();
-        auto rd = assert_that(ds.make_reader(s, semaphore.make_permit(), pr, slice, default_priority_class(), nullptr, streamed_mutation::forwarding::yes));
+        auto rd = assert_that(ds.make_reader_v2(s, semaphore.make_permit(), pr, slice, default_priority_class(), nullptr, streamed_mutation::forwarding::yes));
         rd.produces_partition_start(pk)
           .produces_end_of_stream()
           .fast_forward_to(position_range(position_in_partition::for_key(ck1), position_in_partition::after_key(ck2)))
@@ -1103,7 +1114,7 @@ static void test_clustering_slices(tests::reader_concurrency_semaphore_wrapper& 
         auto slice = partition_slice_builder(*s)
             .with_range(query::clustering_range::make_singular(make_ck(1)))
             .build();
-        assert_that(ds.make_reader(s, semaphore.make_permit(), pr, slice))
+        assert_that(ds.make_reader_v2(s, semaphore.make_permit(), pr, slice))
             .produces(row1 + row2 + row3 + row4 + row5 + del_1, slice.row_ranges(*s, pk.key()))
             .produces_end_of_stream();
     }
@@ -1111,7 +1122,7 @@ static void test_clustering_slices(tests::reader_concurrency_semaphore_wrapper& 
         auto slice = partition_slice_builder(*s)
             .with_range(query::clustering_range::make_singular(make_ck(2)))
             .build();
-        assert_that(ds.make_reader(s, semaphore.make_permit(), pr, slice))
+        assert_that(ds.make_reader_v2(s, semaphore.make_permit(), pr, slice))
             .produces(row6 + row7 + del_1 + del_2, slice.row_ranges(*s, pk.key()))
             .produces_end_of_stream();
     }
@@ -1120,7 +1131,7 @@ static void test_clustering_slices(tests::reader_concurrency_semaphore_wrapper& 
         auto slice = partition_slice_builder(*s)
             .with_range(query::clustering_range::make_singular(make_ck(1, 2)))
             .build();
-        assert_that(ds.make_reader(s, semaphore.make_permit(), pr, slice))
+        assert_that(ds.make_reader_v2(s, semaphore.make_permit(), pr, slice))
             .produces(row3 + row4 + del_1, slice.row_ranges(*s, pk.key()))
             .produces_end_of_stream();
     }
@@ -1129,7 +1140,7 @@ static void test_clustering_slices(tests::reader_concurrency_semaphore_wrapper& 
         auto slice = partition_slice_builder(*s)
             .with_range(query::clustering_range::make_singular(make_ck(3)))
             .build();
-        assert_that(ds.make_reader(s, semaphore.make_permit(), pr, slice))
+        assert_that(ds.make_reader_v2(s, semaphore.make_permit(), pr, slice))
             .produces(row8 + del_3, slice.row_ranges(*s, pk.key()))
             .produces_end_of_stream();
     }
@@ -1137,12 +1148,12 @@ static void test_clustering_slices(tests::reader_concurrency_semaphore_wrapper& 
     // Test out-of-range partition keys
     {
         auto pr = dht::partition_range::make_singular(keys[0]);
-        assert_that(ds.make_reader(s, semaphore.make_permit(), pr, s->full_slice()))
+        assert_that(ds.make_reader_v2(s, semaphore.make_permit(), pr, s->full_slice()))
             .produces_eos_or_empty_mutation();
     }
     {
         auto pr = dht::partition_range::make_singular(keys[2]);
-        assert_that(ds.make_reader(s, semaphore.make_permit(), pr, s->full_slice()))
+        assert_that(ds.make_reader_v2(s, semaphore.make_permit(), pr, s->full_slice()))
             .produces_eos_or_empty_mutation();
     }
 }
@@ -1165,7 +1176,7 @@ static void test_query_only_static_row(tests::reader_concurrency_semaphore_wrapp
     // fully populate cache
     {
         auto prange = dht::partition_range::make_ending_with(dht::ring_position(m1.decorated_key()));
-        assert_that(ms.make_reader(s.schema(), semaphore.make_permit(), prange, s.schema()->full_slice()))
+        assert_that(ms.make_reader_v2(s.schema(), semaphore.make_permit(), prange, s.schema()->full_slice()))
             .produces(m1)
             .produces_end_of_stream();
     }
@@ -1176,7 +1187,7 @@ static void test_query_only_static_row(tests::reader_concurrency_semaphore_wrapp
             .with_ranges({})
             .build();
         auto prange = dht::partition_range::make_ending_with(dht::ring_position(m1.decorated_key()));
-        assert_that(ms.make_reader(s.schema(), semaphore.make_permit(), prange, slice))
+        assert_that(ms.make_reader_v2(s.schema(), semaphore.make_permit(), prange, slice))
             .produces(m1, slice.row_ranges(*s.schema(), m1.key()))
             .produces_end_of_stream();
     }
@@ -1187,7 +1198,7 @@ static void test_query_only_static_row(tests::reader_concurrency_semaphore_wrapp
             .with_ranges({})
             .build();
         auto prange = dht::partition_range::make_singular(m1.decorated_key());
-        assert_that(ms.make_reader(s.schema(), semaphore.make_permit(), prange, slice))
+        assert_that(ms.make_reader_v2(s.schema(), semaphore.make_permit(), prange, slice))
             .produces(m1, slice.row_ranges(*s.schema(), m1.key()))
             .produces_end_of_stream();
     }
@@ -1209,7 +1220,7 @@ static void test_query_no_clustering_ranges_no_static_columns(tests::reader_conc
 
     {
         auto prange = dht::partition_range::make_ending_with(dht::ring_position(m1.decorated_key()));
-        assert_that(ms.make_reader(s.schema(), semaphore.make_permit(), prange, s.schema()->full_slice()))
+        assert_that(ms.make_reader_v2(s.schema(), semaphore.make_permit(), prange, s.schema()->full_slice()))
             .produces(m1)
             .produces_end_of_stream();
     }
@@ -1220,7 +1231,7 @@ static void test_query_no_clustering_ranges_no_static_columns(tests::reader_conc
             .with_ranges({})
             .build();
         auto prange = dht::partition_range::make_ending_with(dht::ring_position(m1.decorated_key()));
-        assert_that(ms.make_reader(s.schema(), semaphore.make_permit(), prange, slice))
+        assert_that(ms.make_reader_v2(s.schema(), semaphore.make_permit(), prange, slice))
             .produces(m1, slice.row_ranges(*s.schema(), m1.key()))
             .produces_end_of_stream();
     }
@@ -1231,7 +1242,7 @@ static void test_query_no_clustering_ranges_no_static_columns(tests::reader_conc
             .with_ranges({})
             .build();
         auto prange = dht::partition_range::make_singular(m1.decorated_key());
-        assert_that(ms.make_reader(s.schema(), semaphore.make_permit(), prange, slice))
+        assert_that(ms.make_reader_v2(s.schema(), semaphore.make_permit(), prange, slice))
             .produces(m1, slice.row_ranges(*s.schema(), m1.key()))
             .produces_end_of_stream();
     }
@@ -1248,7 +1259,7 @@ void test_streamed_mutation_forwarding_succeeds_with_no_data(tests::reader_concu
     s.add_row(m, cks[0], "data");
 
     auto source = populate(s.schema(), {m}, gc_clock::now());
-    assert_that(source.make_reader(s.schema(),
+    assert_that(source.make_reader_v2(s.schema(),
                 semaphore.make_permit(),
                 query::full_partition_range,
                 s.schema()->full_slice(),
@@ -1667,7 +1678,7 @@ void test_next_partition(tests::reader_concurrency_semaphore_wrapper& semaphore,
         mutations.push_back(std::move(m));
     }
     auto source = populate(s.schema(), mutations, gc_clock::now());
-    assert_that(source.make_reader(s.schema(), semaphore.make_permit()))
+    assert_that(source.make_reader_v2(s.schema(), semaphore.make_permit()))
         .next_partition() // Does nothing before first partition
         .produces_partition_start(pkeys[0])
         .produces_static_row()
@@ -2797,6 +2808,65 @@ mutation forwardable_reader_to_mutation(flat_mutation_reader r, const std::vecto
     };
 
     std::optional<mutation_rebuilder> builder{};
+    r.consume(consumer(r.schema(), builder)).get();
+    BOOST_REQUIRE(builder);
+    for (auto& range : fwd_ranges) {
+        testlog.trace("forwardable_reader_to_mutation: forwarding to {}", range);
+        r.fast_forward_to(range).get();
+        r.consume(consumer(r.schema(), builder)).get();
+    }
+
+    auto m = builder->consume_end_of_stream();
+    BOOST_REQUIRE(m);
+
+    return std::move(*m);
+}
+
+mutation forwardable_reader_to_mutation(flat_mutation_reader_v2 r, const std::vector<position_range>& fwd_ranges) {
+    auto close_reader = deferred_close(r);
+
+    struct consumer {
+        schema_ptr _s;
+        std::optional<mutation_rebuilder_v2>& _builder;
+        consumer(schema_ptr s, std::optional<mutation_rebuilder_v2>& builder)
+            : _s(std::move(s))
+            , _builder(builder) { }
+
+        void consume_new_partition(const dht::decorated_key& dk) {
+            assert(!_builder);
+            _builder = mutation_rebuilder_v2(std::move(_s));
+            _builder->consume_new_partition(dk);
+        }
+
+        stop_iteration consume(tombstone t) {
+            assert(_builder);
+            return _builder->consume(t);
+        }
+
+        stop_iteration consume(range_tombstone_change&& rt) {
+            assert(_builder);
+            return _builder->consume(std::move(rt));
+        }
+
+        stop_iteration consume(static_row&& sr) {
+            assert(_builder);
+            return _builder->consume(std::move(sr));
+        }
+
+        stop_iteration consume(clustering_row&& cr) {
+            assert(_builder);
+            return _builder->consume(std::move(cr));
+        }
+
+        stop_iteration consume_end_of_partition() {
+            assert(_builder);
+            return stop_iteration::yes;
+        }
+
+        void consume_end_of_stream() { }
+    };
+
+    std::optional<mutation_rebuilder_v2> builder{};
     r.consume(consumer(r.schema(), builder)).get();
     BOOST_REQUIRE(builder);
     for (auto& range : fwd_ranges) {

--- a/test/lib/mutation_source_test.hh
+++ b/test/lib/mutation_source_test.hh
@@ -72,8 +72,6 @@ bytes make_blob(size_t blob_size);
 void for_each_schema_change(std::function<void(schema_ptr, const std::vector<mutation>&,
                                                schema_ptr, const std::vector<mutation>&)>);
 
-void compare_readers(const schema&, flat_mutation_reader authority, flat_mutation_reader tested);
-void compare_readers(const schema&, flat_mutation_reader authority, flat_mutation_reader tested, const std::vector<position_range>& fwd_ranges);
 void compare_readers(const schema&, flat_mutation_reader_v2 authority, flat_mutation_reader_v2 tested);
 void compare_readers(const schema&, flat_mutation_reader_v2 authority, flat_mutation_reader_v2 tested, const std::vector<position_range>& fwd_ranges);
 
@@ -82,5 +80,4 @@ void compare_readers(const schema&, flat_mutation_reader_v2 authority, flat_muta
 //
 // Assumes that for each subsequent `r1`, `r2` in `fwd_ranges`, `r1.end() <= r2.start()`.
 // Must be run in a seastar::thread.
-mutation forwardable_reader_to_mutation(flat_mutation_reader r, const std::vector<position_range>& fwd_ranges);
 mutation forwardable_reader_to_mutation(flat_mutation_reader_v2 r, const std::vector<position_range>& fwd_ranges);

--- a/test/lib/mutation_source_test.hh
+++ b/test/lib/mutation_source_test.hh
@@ -83,3 +83,4 @@ void compare_readers(const schema&, flat_mutation_reader_v2 authority, flat_muta
 // Assumes that for each subsequent `r1`, `r2` in `fwd_ranges`, `r1.end() <= r2.start()`.
 // Must be run in a seastar::thread.
 mutation forwardable_reader_to_mutation(flat_mutation_reader r, const std::vector<position_range>& fwd_ranges);
+mutation forwardable_reader_to_mutation(flat_mutation_reader_v2 r, const std::vector<position_range>& fwd_ranges);

--- a/test/lib/sstable_utils.cc
+++ b/test/lib/sstable_utils.cc
@@ -87,7 +87,7 @@ sstables::shared_sstable make_sstable_containing(std::function<sstables::shared_
     }
 
     // validate the sstable
-    auto rd = assert_that(sst->as_mutation_source().make_reader(s, semaphore.make_permit()));
+    auto rd = assert_that(sst->as_mutation_source().make_reader_v2(s, semaphore.make_permit()));
     for (auto&& m : merged) {
         rd.produces(m);
     }


### PR DESCRIPTION
"Almost" because 2 uses of the v1 asserter remain (as they are deliberate).