### PR TITLE
scylla_sysconfig_setup: handle >=32CPUs correctly

### DIFF
--- a/dist/common/scripts/scylla_sysconfig_setup
+++ b/dist/common/scripts/scylla_sysconfig_setup
@@ -72,7 +72,7 @@ if __name__ == '__main__':
     if args.setup_nic_and_disks:
         res = out('{} --tune net --nic {} --get-cpu-mask'.format(perftune_base_command(), ifname))
         # we need to extract CPU mask from output, since perftune.py may also print warning messages (#10082)
-        match = re.match('(.*)(0x[0-9a-f]+)', res, re.DOTALL)
+        match = re.match('(.*\n)?(0x[0-9a-f]+(?:,0x[0-9a-f]+)*)', res, re.DOTALL)
         try:
             warning = match.group(1)
             rps_cpus = match.group(2)


### PR DESCRIPTION
Seems like 59adf05 has a bug, the regex pattern only handles first
32CPUs cpuset pattern, and ignores rest.
We should extend regex pattern to handle all CPUs.

Fixes #10523