### PR TITLE
sstables: define generation_type for sstables

### DIFF
--- a/compaction/compaction.cc
+++ b/compaction/compaction.cc
@@ -391,7 +391,7 @@ struct compaction_read_monitor_generator final : public read_monitor_generator {
     }
 private:
     table_state& _table_s;
-    std::unordered_map<int64_t, compaction_read_monitor> _generated_monitors;
+    std::unordered_map<generation_type, compaction_read_monitor> _generated_monitors;
 };
 
 class formatted_sstables_list {
@@ -431,7 +431,7 @@ protected:
     schema_ptr _schema;
     reader_permit _permit;
     std::vector<shared_sstable> _sstables;
-    std::vector<unsigned long> _input_sstable_generations;
+    std::vector<generation_type> _input_sstable_generations;
     // Unused sstables are tracked because if compaction is interrupted we can only delete them.
     // Deleting used sstables could potentially result in data loss.
     std::unordered_set<shared_sstable> _new_partial_sstables;
@@ -1751,7 +1751,7 @@ get_fully_expired_sstables(const table_state& table_s, const std::vector<sstable
         }
     }
 
-    auto compacted_undeleted_gens = boost::copy_range<std::unordered_set<int64_t>>(table_s.compacted_undeleted_sstables()
+    auto compacted_undeleted_gens = boost::copy_range<std::unordered_set<generation_type>>(table_s.compacted_undeleted_sstables()
         | boost::adaptors::transformed(std::mem_fn(&sstables::sstable::generation)));
     auto has_undeleted_ancestor = [&compacted_undeleted_gens] (auto& candidate) {
         // Get ancestors from sstable which is empty after restart. It works for this purpose because

--- a/compaction/compaction_strategy.cc
+++ b/compaction/compaction_strategy.cc
@@ -131,7 +131,7 @@ void size_tiered_backlog_tracker::refresh_sstables_backlog_contribution() {
     // in efficient jobs acting more aggressive than they really have to.
     // TODO: potentially switch to compaction manager's fan-in threshold, so to account for the dynamic
     //  fan-in threshold behavior.
-    const auto& newest_sst = std::ranges::max(_all, {}, std::mem_fn(&sstable::generation));
+    const auto& newest_sst = std::ranges::max(_all, std::less<generation_type>(), std::mem_fn(&sstable::generation));
     auto threshold = newest_sst->get_schema()->min_compaction_threshold();
 
     for (auto& bucket : size_tiered_compaction_strategy::get_buckets(boost::copy_range<std::vector<shared_sstable>>(_all), _stcs_options)) {

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -65,6 +65,7 @@
 #include "query_class_config.hh"
 #include "absl-flat_hash_map.hh"
 #include "utils/cross-shard-barrier.hh"
+#include "sstables/generation_type.hh"
 
 class cell_locker;
 class cell_locker_stats;
@@ -501,9 +502,9 @@ public:
                                           sstables::offstrategy offstrategy = sstables::offstrategy::no);
     future<> add_sstables_and_update_cache(const std::vector<sstables::shared_sstable>& ssts);
     future<> move_sstables_from_staging(std::vector<sstables::shared_sstable>);
-    sstables::shared_sstable make_sstable(sstring dir, int64_t generation, sstables::sstable_version_types v, sstables::sstable_format_types f,
+    sstables::shared_sstable make_sstable(sstring dir, sstables::generation_type generation, sstables::sstable_version_types v, sstables::sstable_format_types f,
             io_error_handler_gen error_handler_gen);
-    sstables::shared_sstable make_sstable(sstring dir, int64_t generation, sstables::sstable_version_types v, sstables::sstable_format_types f);
+    sstables::shared_sstable make_sstable(sstring dir, sstables::generation_type generation, sstables::sstable_version_types v, sstables::sstable_format_types f);
     sstables::shared_sstable make_sstable(sstring dir);
     sstables::shared_sstable make_sstable();
     void cache_truncation_record(db_clock::time_point truncated_at) {
@@ -570,7 +571,7 @@ private:
         _sstable_generation = std::max<uint64_t>(*_sstable_generation, generation /  smp::count + 1);
     }
 
-    uint64_t calculate_generation_for_new_table() {
+    sstables::generation_type calculate_generation_for_new_table() {
         assert(_sstable_generation);
         // FIXME: better way of ensuring we don't attempt to
         // overwrite an existing table.

--- a/replica/distributed_loader.cc
+++ b/replica/distributed_loader.cc
@@ -273,7 +273,7 @@ distributed_loader::make_sstables_available(sstables::sstable_directory& dir, sh
         return dir.do_for_each_sstable([&table, datadir = std::move(datadir), &new_sstables] (sstables::shared_sstable sst) {
             auto gen = table.calculate_generation_for_new_table();
             dblog.trace("Loading {} into {}, new generation {}", sst->get_filename(), datadir.native(), gen);
-            return sst->move_to_new_dir(datadir.native(), gen,  true).then([&table, &new_sstables, sst] {
+            return sst->move_to_new_dir(datadir.native(), gen, true).then([&table, &new_sstables, sst] {
                 // When loading an imported sst, set level to 0 because it may overlap with existing ssts on higher levels.
                 sst->set_sstable_level(0);
                 new_sstables.push_back(std::move(sst));
@@ -322,7 +322,7 @@ distributed_loader::process_upload_dir(distributed<replica::database>& db, distr
             sstables::sstable_directory::lack_of_toc_fatal::no,
             sstables::sstable_directory::enable_dangerous_direct_import_of_cassandra_counters(db.local().get_config().enable_dangerous_direct_import_of_cassandra_counters()),
             sstables::sstable_directory::allow_loading_materialized_view::no,
-            [&global_table] (fs::path dir, int64_t gen, sstables::sstable_version_types v, sstables::sstable_format_types f) {
+            [&global_table] (fs::path dir, sstables::generation_type gen, sstables::sstable_version_types v, sstables::sstable_format_types f) {
                 return global_table->make_sstable(dir.native(), gen, v, f, &error_handler_gen_for_upload_dir);
 
         }).get();
@@ -388,7 +388,7 @@ distributed_loader::get_sstables_from_upload_dir(distributed<replica::database>&
             sstables::sstable_directory::lack_of_toc_fatal::no,
             sstables::sstable_directory::enable_dangerous_direct_import_of_cassandra_counters(db.local().get_config().enable_dangerous_direct_import_of_cassandra_counters()),
             sstables::sstable_directory::allow_loading_materialized_view::no,
-            [&global_table] (fs::path dir, int64_t gen, sstables::sstable_version_types v, sstables::sstable_format_types f) {
+            [&global_table] (fs::path dir, sstables::generation_type gen, sstables::sstable_version_types v, sstables::sstable_format_types f) {
                 return global_table->make_sstable(dir.native(), gen, v, f, &error_handler_gen_for_upload_dir);
 
         }).get();
@@ -480,7 +480,7 @@ future<> distributed_loader::populate_column_family(distributed<replica::databas
             sstables::sstable_directory::lack_of_toc_fatal::yes,
             sstables::sstable_directory::enable_dangerous_direct_import_of_cassandra_counters(db.local().get_config().enable_dangerous_direct_import_of_cassandra_counters()),
             sstables::sstable_directory::allow_loading_materialized_view::yes,
-            [&global_table] (fs::path dir, int64_t gen, sstables::sstable_version_types v, sstables::sstable_format_types f) {
+            [&global_table] (fs::path dir, sstables::generation_type gen, sstables::sstable_version_types v, sstables::sstable_format_types f) {
                 return global_table->make_sstable(dir.native(), gen, v, f);
         }).get();
 

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -338,12 +338,12 @@ static bool belongs_to_other_shard(const std::vector<shard_id>& shards) {
     return shards.size() != size_t(belongs_to_current_shard(shards));
 }
 
-sstables::shared_sstable table::make_sstable(sstring dir, int64_t generation, sstables::sstable_version_types v, sstables::sstable_format_types f,
+sstables::shared_sstable table::make_sstable(sstring dir, sstables::generation_type generation, sstables::sstable_version_types v, sstables::sstable_format_types f,
         io_error_handler_gen error_handler_gen) {
     return get_sstables_manager().make_sstable(_schema, dir, generation, v, f, gc_clock::now(), error_handler_gen);
 }
 
-sstables::shared_sstable table::make_sstable(sstring dir, int64_t generation,
+sstables::shared_sstable table::make_sstable(sstring dir, sstables::generation_type generation,
         sstables::sstable_version_types v, sstables::sstable_format_types f) {
     return get_sstables_manager().make_sstable(_schema, dir, generation, v, f);
 }

--- a/sstables/generation_type.hh
+++ b/sstables/generation_type.hh
@@ -1,0 +1,13 @@
+/*
+ * Copyright (C) 2022-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#include <cstdint>
+
+namespace sstables {
+using generation_type = int64_t;
+}

--- a/sstables/open_info.hh
+++ b/sstables/open_info.hh
@@ -16,6 +16,7 @@
 #include "sstables/version.hh"
 #include "sstables/component_type.hh"
 #include "sstables/shareable_components.hh"
+#include "sstables/generation_type.hh"
 #include <seastar/core/shared_ptr.hh>
 
 namespace sstables {
@@ -24,7 +25,7 @@ struct entry_descriptor {
     sstring sstdir;
     sstring ks;
     sstring cf;
-    int64_t generation;
+    generation_type generation;
     sstable_version_types version;
     sstable_format_types format;
     component_type component;
@@ -35,7 +36,7 @@ struct entry_descriptor {
     // This allows loading sstables from any path, but the filename still has to be valid.
     static entry_descriptor make_descriptor(sstring sstdir, sstring fname, sstring ks, sstring cf);
 
-    entry_descriptor(sstring sstdir, sstring ks, sstring cf, int64_t generation,
+    entry_descriptor(sstring sstdir, sstring ks, sstring cf, generation_type generation,
                      sstable_version_types version, sstable_format_types format,
                      component_type component)
         : sstdir(sstdir), ks(ks), cf(cf), generation(generation), version(version), format(format), component(component) {}
@@ -48,7 +49,7 @@ struct foreign_sstable_open_info {
     std::vector<shard_id> owners;
     seastar::file_handle data;
     seastar::file_handle index;
-    uint64_t generation;
+    generation_type generation;
     sstable_version_types version;
     sstable_format_types format;
     uint64_t uncompressed_data_size;

--- a/sstables/sstable_directory.cc
+++ b/sstables/sstable_directory.cc
@@ -50,7 +50,6 @@ sstable_directory::sstable_directory(fs::path sstable_dir,
 
 void
 sstable_directory::handle_component(scan_state& state, sstables::entry_descriptor desc, fs::path filename) {
-    // If not owned by us, skip
     if ((desc.generation % smp::count) != this_shard_id()) {
         return;
     }

--- a/sstables/sstable_directory.hh
+++ b/sstables/sstable_directory.hh
@@ -22,6 +22,7 @@
 #include "sstables/open_info.hh"                 // for entry_descriptor and foreign_sstable_open_info, chunked_vector wants to know if they are move constructible
 #include "utils/chunked_vector.hh"
 #include "utils/phased_barrier.hh"
+#include "sstables/generation_type.hh"
 
 class compaction_manager;
 
@@ -40,7 +41,7 @@ public:
 
     using sstable_object_from_existing_fn =
         noncopyable_function<sstables::shared_sstable(std::filesystem::path,
-                                                      int64_t,
+                                                      sstables::generation_type,
                                                       sstables::sstable_version_types,
                                                       sstables::sstable_format_types)>;
 
@@ -48,9 +49,9 @@ public:
     // of elements.
     using sstable_info_vector = utils::chunked_vector<sstables::foreign_sstable_open_info>;
 private:
-    using scan_multimap = std::unordered_multimap<int64_t, std::filesystem::path>;
+    using scan_multimap = std::unordered_multimap<generation_type, std::filesystem::path>;
     using scan_descriptors = utils::chunked_vector<sstables::entry_descriptor>;
-    using scan_descriptors_map = std::unordered_map<int64_t, sstables::entry_descriptor>;
+    using scan_descriptors_map = std::unordered_map<generation_type, sstables::entry_descriptor>;
 
     struct scan_state {
         scan_multimap generations_found;

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -45,6 +45,7 @@
 #include "utils/observable.hh"
 #include "sstables/shareable_components.hh"
 #include "sstables/open_info.hh"
+#include "sstables/generation_type.hh"
 #include "query-request.hh"
 #include "mutation_fragment_stream_validator.hh"
 #include "readers/flat_mutation_reader_fwd.hh"
@@ -132,7 +133,7 @@ public:
 public:
     sstable(schema_ptr schema,
             sstring dir,
-            int64_t generation,
+            generation_type generation,
             version_types v,
             format_types f,
             db::large_data_handler& large_data_handler,
@@ -165,13 +166,13 @@ public:
     static component_type component_from_sstring(version_types version, sstring& s);
     static version_types version_from_sstring(sstring& s);
     static format_types format_from_sstring(sstring& s);
-    static sstring component_basename(const sstring& ks, const sstring& cf, version_types version, int64_t generation,
+    static sstring component_basename(const sstring& ks, const sstring& cf, version_types version, generation_type generation,
                                       format_types format, component_type component);
-    static sstring component_basename(const sstring& ks, const sstring& cf, version_types version, int64_t generation,
+    static sstring component_basename(const sstring& ks, const sstring& cf, version_types version, generation_type generation,
                                       format_types format, sstring component);
-    static sstring filename(const sstring& dir, const sstring& ks, const sstring& cf, version_types version, int64_t generation,
+    static sstring filename(const sstring& dir, const sstring& ks, const sstring& cf, version_types version, generation_type generation,
                             format_types format, component_type component);
-    static sstring filename(const sstring& dir, const sstring& ks, const sstring& cf, version_types version, int64_t generation,
+    static sstring filename(const sstring& dir, const sstring& ks, const sstring& cf, version_types version, generation_type generation,
                             format_types format, sstring component);
 
     // load sstable using components shared by a shard
@@ -187,8 +188,8 @@ public:
     // No other uses of the object can happen at this point.
     future<> destroy();
 
-    future<> set_generation(int64_t generation);
-    future<> move_to_new_dir(sstring new_dir, int64_t generation, bool do_sync_dirs = true);
+    future<> set_generation(generation_type generation);
+    future<> move_to_new_dir(sstring new_dir, generation_type generation, bool do_sync_dirs = true);
 
     // Move the sstable to the quarantine_dir
     //
@@ -200,7 +201,7 @@ public:
     // will move it into a quarantine_dir subdirectory of its current directory.
     future<> move_to_quarantine(bool do_sync_dirs = true);
 
-    int64_t generation() const {
+    generation_type generation() const {
         return _generation;
     }
 
@@ -284,7 +285,7 @@ public:
         return _compaction_ancestors;
     }
 
-    void add_ancestor(int64_t generation) {
+    void add_ancestor(generation_type generation) {
         _compaction_ancestors.insert(generation);
     }
 
@@ -359,11 +360,11 @@ public:
         return filename(component_type::TOC);
     }
 
-    static sstring sst_dir_basename(unsigned long gen) {
-        return fmt::format("{:016d}.sstable", gen);
+    static sstring sst_dir_basename(generation_type gen) {
+        return fmt::format("{}.sstable", gen);
     }
 
-    static sstring temp_sst_dir(const sstring& dir, unsigned long gen) {
+    static sstring temp_sst_dir(const sstring& dir, generation_type gen) {
         return dir + "/" + sst_dir_basename(gen);
     }
 
@@ -397,7 +398,7 @@ public:
 
     std::vector<std::pair<component_type, sstring>> all_components() const;
 
-    future<> create_links(const sstring& dir, int64_t generation) const;
+    future<> create_links(const sstring& dir, generation_type generation) const;
 
     future<> create_links(const sstring& dir) const {
         return create_links(dir, _generation);
@@ -503,7 +504,8 @@ private:
     schema_ptr _schema;
     sstring _dir;
     std::optional<sstring> _temp_dir; // Valid while the sstable is being created, until sealed
-    unsigned long _generation = 0;
+    generation_type _generation = 0;
+
     version_types _version;
     format_types _format;
 
@@ -663,9 +665,9 @@ private:
 
     future<> open_or_create_data(open_flags oflags, file_open_options options = {}) noexcept;
 
-    future<> check_create_links_replay(const sstring& dst_dir, int64_t dst_gen, const std::vector<std::pair<sstables::component_type, sstring>>& comps) const;
-    future<> create_links_common(const sstring& dst_dir, int64_t dst_gen, bool mark_for_removal) const;
-    future<> create_links_and_mark_for_removal(const sstring& dst_dir, int64_t dst_gen) const;
+    future<> check_create_links_replay(const sstring& dst_dir, generation_type dst_gen, const std::vector<std::pair<sstables::component_type, sstring>>& comps) const;
+    future<> create_links_common(const sstring& dst_dir, generation_type dst_gen, bool mark_for_removal) const;
+    future<> create_links_and_mark_for_removal(const sstring& dst_dir, generation_type dst_gen) const;
 public:
     future<> read_toc() noexcept;
 

--- a/sstables/sstables_manager.cc
+++ b/sstables/sstables_manager.cc
@@ -35,7 +35,7 @@ const utils::UUID& sstables_manager::get_local_host_id() const {
 
 shared_sstable sstables_manager::make_sstable(schema_ptr schema,
         sstring dir,
-        int64_t generation,
+        generation_type generation,
         sstable_version_types v,
         sstable_format_types f,
         gc_clock::time_point now,

--- a/sstables/sstables_manager.hh
+++ b/sstables/sstables_manager.hh
@@ -72,7 +72,7 @@ public:
     // Constructs a shared sstable
     shared_sstable make_sstable(schema_ptr schema,
             sstring dir,
-            int64_t generation,
+            generation_type generation,
             sstable_version_types v,
             sstable_format_types f,
             gc_clock::time_point now = gc_clock::now(),


### PR DESCRIPTION
No functional changes intended - this series is quite verbose,
but after it's in, it should be considerably easier to change
the type of SSTable generations to something else - e.g. a string
or timeUUID. Future series which change the generation type
will hopefully be much less bloated after this one is in.

Refs #10459 