### PR TITLE
memtable_list: clear_and_add: let caller clear the old memtables

### DIFF
--- a/replica/database.hh
+++ b/replica/database.hh
@@ -220,9 +220,9 @@ public:
     }
 
     // Synchronously swaps the active memtable with a new, empty one,
-    // then, clears the existing memtable(s) asynchronously.
+    // returning the old memtables list.
     // Exception safe.
-    future<> clear_and_add();
+    std::vector<replica::shared_memtable> clear_and_add();
 
     size_t size() const {
         return _memtables.size();

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -1513,7 +1513,10 @@ future<> table::clear() {
             _commitlog->discard_completed_segments(_schema->id(), t->get_and_discard_rp_set());
         }
     }
-    co_await _memtables->clear_and_add();
+    auto old_memtables = _memtables->clear_and_add();
+    for (auto& smt : old_memtables) {
+        co_await smt->clear_gently();
+    }
     co_await _cache.invalidate(row_cache::external_updater([] { /* There is no underlying mutation source */ }));
 }
 


### PR DESCRIPTION
As a follow up on b8263e550aca7e1a2cd905a2dca5b8012e915d30,
make clear_and_add synchronous yet again, and just return
the swapped list of memtables so that the caller (table::clear)
can clear them gently.

Refs https://github.com/scylladb/scylla/pull/10424#discussion_r867455056

Signed-off-by: Benny Halevy <bhalevy@scylladb.com>