### PR TITLE
raft: test `modify_config` API in `randomized_nemesis_test`

### DIFF
--- a/raft/raft.hh
+++ b/raft/raft.hh
@@ -550,7 +550,8 @@ public:
     // unfinished send operation may return an error after this
     // function is called.
     //
-    // The implementation must ensure that `_client->apply_snapshot(...)` is not called
+    // The implementation must ensure that `_client->apply_snapshot`, `_client->execute_add_entry`,
+    // `_client->execute_modify_config` and `_client->execute_read_barrier` are not called
     // after `abort()` is called (even before `abort()` future resolves).
     virtual future<> abort() = 0;
 private:

--- a/test/raft/randomized_nemesis_test.cc
+++ b/test/raft/randomized_nemesis_test.cc
@@ -2291,8 +2291,7 @@ struct bouncing {
                 --bounces;
 
                 if (n_a_l->leader) {
-                    assert(n_a_l->leader != srv_id);
-                    if (!tried.contains(n_a_l->leader)) {
+                    if (n_a_l->leader == srv_id || !tried.contains(n_a_l->leader)) {
                         co_await timer.sleep(known_leader_delay);
                         srv_id = n_a_l->leader;
                         tlogger.trace("bouncing call: got `not_a_leader`, rerouted to {}", srv_id);

--- a/test/raft/randomized_nemesis_test.cc
+++ b/test/raft/randomized_nemesis_test.cc
@@ -1275,6 +1275,8 @@ future<reconfigure_result_t> modify_config(
         co_return e;
     } catch (raft::request_aborted&) {
         co_return timed_out_error{};
+    } catch (seastar::timed_out_error e) {
+        co_return e;
     } catch (...) {
         tlogger.error("unexpected exception from modify_config: {}", std::current_exception());
         assert(false);


### PR DESCRIPTION
Extend the reconfiguration nemesis to send `modify_config` requests as
well as `reconfigure` requests. It chooses one or the other with
probability 1/2.

Fix a bunch of problems that surfaced during testing.
