### PR TITLE
scylla-gdb.py: add commands to dump sstables summary and index-cache

### DIFF
--- a/scylla-gdb.py
+++ b/scylla-gdb.py
@@ -768,6 +768,37 @@ class chunked_managed_vector:
                 yield e
 
 
+class sstring:
+    def __init__(self, ref):
+        self.ref = ref
+
+    @staticmethod
+    def to_hex(data, size):
+        inf = gdb.selected_inferior()
+        return bytes(inf.read_memory(data, size)).hex()
+
+    def as_hex(self):
+        return self.to_hex(self.data(), len(self))
+
+    def is_internal(self):
+        return self.ref['u']['internal']['size'] >= 0
+
+    def __len__(self):
+        if self.is_internal():
+            return self.ref['u']['internal']['size']
+        else:
+            return self.ref['u']['external']['size']
+
+    def data(self):
+        if self.is_internal():
+            return self.ref['u']['internal']['str']
+        else:
+            return self.ref['u']['external']['str']
+
+    def __str__(self):
+        return self.as_hex()
+
+
 def uint64_t(val):
     val = int(val)
     if val < 0:

--- a/scylla-gdb.py
+++ b/scylla-gdb.py
@@ -341,10 +341,10 @@ class std_variant:
     def index(self):
         return int(self.ref['_M_index'])
 
-    def get(self):
+    # workaround for when template arguments refuses to work
+    def get_with_type(self, current_type):
         index = self.index()
         variadic_union = self.ref['_M_u']
-        current_type = self.member_types[index].strip_typedefs()
         for i in range(index):
             variadic_union = variadic_union['_M_rest']
 
@@ -355,6 +355,11 @@ class std_variant:
 
         # non-literal types are stored via a __gnu_cxx::__aligned_membuf
         return wrapper['_M_storage'].reinterpret_cast(current_type.pointer()).dereference()
+
+    def get(self):
+        index = self.index()
+        current_type = self.member_types[index].strip_typedefs()
+        return self.get_with_type(index, current_type)
 
 
 class std_map:

--- a/scylla-gdb.py
+++ b/scylla-gdb.py
@@ -731,6 +731,24 @@ class std_list:
         return deref(it['_M_node'])
 
 
+class managed_vector:
+    def __init__(self, ref):
+        self._ref = ref
+
+    def __len__(self):
+        return int(self._ref['_size'])
+
+    def __nonzero__(self):
+        return self.__len__() > 0
+
+    def __bool__(self):
+        return self.__len__() > 0
+
+    def __iter__(self):
+        for i in range(len(self)):
+            yield self._ref['_data'][i]
+
+
 def uint64_t(val):
     val = int(val)
     if val < 0:

--- a/scylla-gdb.py
+++ b/scylla-gdb.py
@@ -3005,6 +3005,15 @@ class small_vector(object):
     def __init__(self, ref):
         self.ref = ref
 
+    def __len__(self):
+        return self.ref['_begin'] - self.ref['_end']
+
+    def __iter__(self):
+        e = self.ref['_begin']
+        while e != self.ref['_end']:
+            yield e.dereference()
+            e += 1
+
     def external_memory_footprint(self):
         if self.ref['_begin'] == self.ref['_internal']['storage'].address:
             return 0

--- a/scylla-gdb.py
+++ b/scylla-gdb.py
@@ -749,6 +749,25 @@ class managed_vector:
             yield self._ref['_data'][i]
 
 
+class chunked_managed_vector:
+    def __init__(self, ref):
+        self._ref = ref
+
+    def __len__(self):
+        return int(self._ref['_size'])
+
+    def __nonzero__(self):
+        return self.__len__() > 0
+
+    def __bool__(self):
+        return self.__len__() > 0
+
+    def __iter__(self):
+        for chunk in managed_vector(self._ref['_chunks']):
+            for e in managed_vector(chunk):
+                yield e
+
+
 def uint64_t(val):
     val = int(val)
     if val < 0:

--- a/test/scylla-gdb/test_misc.py
+++ b/test/scylla-gdb/test_misc.py
@@ -144,4 +144,7 @@ def task(gdb, scylla_gdb):
 def test_fiber(gdb, task):
     scylla(gdb, f'fiber {task}')
 
+def test_sstable_summary(gdb, sstable):
+    scylla(gdb, f'sstable-summary {sstable}')
+
 # FIXME: need a simple test for lsa-segment

--- a/test/scylla-gdb/test_misc.py
+++ b/test/scylla-gdb/test_misc.py
@@ -147,4 +147,7 @@ def test_fiber(gdb, task):
 def test_sstable_summary(gdb, sstable):
     scylla(gdb, f'sstable-summary {sstable}')
 
+def test_sstable_summary(gdb, sstable):
+    scylla(gdb, f'sstable-index-cache {sstable}')
+
 # FIXME: need a simple test for lsa-segment

--- a/test/scylla-gdb/test_misc.py
+++ b/test/scylla-gdb/test_misc.py
@@ -109,6 +109,13 @@ def schema(gdb, scylla_gdb):
         table['_schema']['_p'].reinterpret_cast(gdb.lookup_type('schema').pointer()))
     yield '$schema'
 
+@pytest.fixture(scope="module")
+def sstable(gdb, scylla_gdb):
+    db = scylla_gdb.sharded(gdb.parse_and_eval('::debug::the_database')).local()
+    sst = next(scylla_gdb.find_sstables())
+    gdb.set_convenience_variable('sst', sst)
+    yield '$sst'
+
 def test_schema(gdb, schema):
     scylla(gdb, f'schema {schema}')
 


### PR DESCRIPTION
This series adds two commands:
* scylla sstable-summary
* scylla sstable-index-cache

The former dumps the content of the sstable summary. This component is kept in memory in its entirety, so this can be easily done. The latter command dumps the content of the sstable index cache. This contains all the index-pages that are currently cached. The promoted index is not dumped yet and there is no indication of whether a given entry is in the LRU or not, but this already allows at seeing what pages are in the cache and what aren't.