### PR TITLE
Ensure gossip is enabled on all shards before starting the failure_detector_loop

### DIFF
--- a/gms/gossiper.cc
+++ b/gms/gossiper.cc
@@ -1814,8 +1814,15 @@ future<> gossiper::start_gossiping(int generation_nbr, std::map<application_stat
     _enabled = true;
     _nr_run = 0;
     _scheduled_gossip_task.arm(INTERVAL);
+    if (!_background_msg.is_closed()) {
+        co_await _background_msg.close();
+    }
+    _background_msg = seastar::gate();
+    /* Ensure all shards have enabled gossip before starting the failure detector loop */
     co_await container().invoke_on_all([] (gms::gossiper& g) {
         g._enabled = true;
+    });
+    co_await container().invoke_on_all([] (gms::gossiper& g) {
         g._failure_detector_loop_done = g.failure_detector_loop();
     });
 }


### PR DESCRIPTION
Fix #10547 