### PR TITLE
batchlog_manager: warn when a batch fails to replay

### DIFF
--- a/db/batchlog_manager.cc
+++ b/db/batchlog_manager.cc
@@ -11,6 +11,7 @@
  */
 
 #include <chrono>
+#include <exception>
 #include <seastar/core/future-util.hh>
 #include <seastar/core/do_with.hh>
 #include <seastar/core/semaphore.hh>
@@ -252,6 +253,7 @@ future<> db::batchlog_manager::replay_all_failed_batches() {
             } catch (data_dictionary::no_such_keyspace& ex) {
                 // should probably ignore and drop the batch
             } catch (...) {
+                blogger.warn("Replay failed (will retry): {}", std::current_exception());
                 // timeout, overload etc.
                 // Do _not_ remove the batch, assuning we got a node write error.
                 // Since we don't have hints (which origin is satisfied with),


### PR DESCRIPTION
Only for reasons other than "no such KS", i.e. when the failure is
presumed transient and the batch in question is not deleted from
batchlog and will be retried in the future.

(Would info be more appropriate here than warning?)