### PR TITLE
raft: test `read_barrier`s in `randomized_nemesis_test`

### DIFF
--- a/raft/fsm.cc
+++ b/raft/fsm.cc
@@ -1044,7 +1044,7 @@ void fsm::broadcast_read_quorum(read_id id) {
             if (p.id == _my_id) {
                 handle_read_quorum_reply(_my_id, read_quorum_reply{_current_term, _commit_idx, id});
             } else {
-                send_to(p.id, read_quorum{_current_term, _commit_idx, id});
+                send_to(p.id, read_quorum{_current_term, std::min(p.match_idx, _commit_idx), id});
             }
         }
     }


### PR DESCRIPTION
Introduce a new operation, `raft_read`, which calls `read_barrier`
on a server, reads the state of the server's state machine, and returns
that state.

Extend the generator in `basic_generator_test` to generate `raft_read`s.
Only do it if forwarding is enabled (although it may make sense to test
read barriers in non-forwarding scenario as well - we may think about it
and do it in a follow-up).

Check the consistency of the read results by comparing them with the model
and using the result to extend the model with any newly observed elements.

The patchset includes some fixes for correctness (#10578)
and liveness (handling aborts correctly).