### PR TITLE
treewide: remove empty comments in top-of-files

### DIFF
--- a/auth/authenticated_user.cc
+++ b/auth/authenticated_user.cc
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2016-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/auth/authenticated_user.hh
+++ b/auth/authenticated_user.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2016-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/auth/authenticator.cc
+++ b/auth/authenticator.cc
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2016-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/auth/authenticator.hh
+++ b/auth/authenticator.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2016-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/auth/authorizer.hh
+++ b/auth/authorizer.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2016-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/auth/default_authorizer.cc
+++ b/auth/default_authorizer.cc
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2016-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/auth/default_authorizer.hh
+++ b/auth/default_authorizer.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2016-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/auth/password_authenticator.cc
+++ b/auth/password_authenticator.cc
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2016-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/auth/password_authenticator.hh
+++ b/auth/password_authenticator.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2016-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/auth/permission.cc
+++ b/auth/permission.cc
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2016-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/auth/permission.hh
+++ b/auth/permission.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2016-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/auth/resource.cc
+++ b/auth/resource.cc
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2016-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/auth/resource.hh
+++ b/auth/resource.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2016-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/auth/sasl_challenge.cc
+++ b/auth/sasl_challenge.cc
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2019-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/auth/sasl_challenge.hh
+++ b/auth/sasl_challenge.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2019-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/auth/transitional.cc
+++ b/auth/transitional.cc
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2017-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/compaction/date_tiered_compaction_strategy.hh
+++ b/compaction/date_tiered_compaction_strategy.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2016-present-2017 ScyllaDB
  *
  * Modified by ScyllaDB

--- a/compaction/leveled_manifest.hh
+++ b/compaction/leveled_manifest.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/compaction/time_window_compaction_strategy.hh
+++ b/compaction/time_window_compaction_strategy.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2017-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/abstract_marker.cc
+++ b/cql3/abstract_marker.cc
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/abstract_marker.hh
+++ b/cql3/abstract_marker.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/assignment_testable.hh
+++ b/cql3/assignment_testable.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2014-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/attributes.cc
+++ b/cql3/attributes.cc
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/attributes.hh
+++ b/cql3/attributes.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/cf_name.cc
+++ b/cql3/cf_name.cc
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/cf_name.hh
+++ b/cql3/cf_name.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/column_condition.cc
+++ b/cql3/column_condition.cc
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/column_condition.hh
+++ b/cql3/column_condition.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/column_identifier.hh
+++ b/cql3/column_identifier.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/column_specification.cc
+++ b/cql3/column_specification.cc
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2016-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/column_specification.hh
+++ b/cql3/column_specification.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/constants.cc
+++ b/cql3/constants.cc
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/constants.hh
+++ b/cql3/constants.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/cql3_type.hh
+++ b/cql3/cql3_type.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Modified by ScyllaDB
  *
  * Copyright (C) 2015-present ScyllaDB

--- a/cql3/cql_statement.hh
+++ b/cql3/cql_statement.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2014-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/error_collector.hh
+++ b/cql3/error_collector.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/error_listener.hh
+++ b/cql3/error_listener.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/functions/abstract_function.hh
+++ b/cql3/functions/abstract_function.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2014-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/functions/aggregate_fcts.cc
+++ b/cql3/functions/aggregate_fcts.cc
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2019-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/functions/aggregate_fcts.hh
+++ b/cql3/functions/aggregate_fcts.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2014-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/functions/aggregate_function.hh
+++ b/cql3/functions/aggregate_function.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Modified by ScyllaDB
  *
  * Copyright (C) 2014-present ScyllaDB

--- a/cql3/functions/as_json_function.hh
+++ b/cql3/functions/as_json_function.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2018-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/functions/bytes_conversion_fcts.hh
+++ b/cql3/functions/bytes_conversion_fcts.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Modified by ScyllaDB
  *
  * Copyright (C) 2015-present ScyllaDB

--- a/cql3/functions/castas_fcts.hh
+++ b/cql3/functions/castas_fcts.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Modified by ScyllaDB
  *
  * Copyright (C) 2017-present ScyllaDB

--- a/cql3/functions/function.hh
+++ b/cql3/functions/function.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2014-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/functions/function_name.hh
+++ b/cql3/functions/function_name.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2014-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/functions/functions.hh
+++ b/cql3/functions/functions.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Modified by ScyllaDB
  *
  * Copyright (C) 2015-present ScyllaDB

--- a/cql3/functions/native_aggregate_function.hh
+++ b/cql3/functions/native_aggregate_function.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Modified by ScyllaDB
  *
  * Copyright (C) 2014-present ScyllaDB

--- a/cql3/functions/native_function.hh
+++ b/cql3/functions/native_function.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Modified by ScyllaDB
  *
  * Copyright (C) 2014-present ScyllaDB

--- a/cql3/functions/native_scalar_function.hh
+++ b/cql3/functions/native_scalar_function.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Modified by ScyllaDB
  *
  * Copyright (C) 2014-present ScyllaDB

--- a/cql3/functions/scalar_function.hh
+++ b/cql3/functions/scalar_function.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2014-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/functions/time_uuid_fcts.hh
+++ b/cql3/functions/time_uuid_fcts.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Modified by ScyllaDB
  *
  * Copyright (C) 2015-present ScyllaDB

--- a/cql3/functions/token_fct.hh
+++ b/cql3/functions/token_fct.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Modified by ScyllaDB
  *
  * Copyright (C) 2015-present ScyllaDB

--- a/cql3/functions/uuid_fcts.hh
+++ b/cql3/functions/uuid_fcts.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Modified by ScyllaDB
  *
  * Copyright (C) 2015-present ScyllaDB

--- a/cql3/index_name.cc
+++ b/cql3/index_name.cc
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/index_name.hh
+++ b/cql3/index_name.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/keyspace_element_name.cc
+++ b/cql3/keyspace_element_name.cc
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/keyspace_element_name.hh
+++ b/cql3/keyspace_element_name.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/lists.hh
+++ b/cql3/lists.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/maps.cc
+++ b/cql3/maps.cc
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/maps.hh
+++ b/cql3/maps.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/multi_column_relation.hh
+++ b/cql3/multi_column_relation.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/operation.cc
+++ b/cql3/operation.cc
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  */
 

--- a/cql3/operation.hh
+++ b/cql3/operation.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/operation_impl.hh
+++ b/cql3/operation_impl.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/prepare_context.cc
+++ b/cql3/prepare_context.cc
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/prepare_context.hh
+++ b/cql3/prepare_context.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/query_options.cc
+++ b/cql3/query_options.cc
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/query_options.hh
+++ b/cql3/query_options.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2014-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/query_processor.cc
+++ b/cql3/query_processor.cc
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/query_processor.hh
+++ b/cql3/query_processor.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/relation.cc
+++ b/cql3/relation.cc
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/relation.hh
+++ b/cql3/relation.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/restrictions/bounds_slice.hh
+++ b/cql3/restrictions/bounds_slice.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/restrictions/multi_column_restriction.hh
+++ b/cql3/restrictions/multi_column_restriction.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/restrictions/primary_key_restrictions.hh
+++ b/cql3/restrictions/primary_key_restrictions.hh
@@ -1,8 +1,4 @@
 /*
- */
-
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/restrictions/restriction.hh
+++ b/cql3/restrictions/restriction.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2019-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/restrictions/restrictions.hh
+++ b/cql3/restrictions/restrictions.hh
@@ -1,8 +1,4 @@
 /*
- */
-
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/restrictions/single_column_primary_key_restrictions.hh
+++ b/cql3/restrictions/single_column_primary_key_restrictions.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/restrictions/single_column_restriction.hh
+++ b/cql3/restrictions/single_column_restriction.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/restrictions/single_column_restrictions.hh
+++ b/cql3/restrictions/single_column_restrictions.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/restrictions/statement_restrictions.hh
+++ b/cql3/restrictions/statement_restrictions.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/restrictions/token_restriction.hh
+++ b/cql3/restrictions/token_restriction.hh
@@ -1,6 +1,4 @@
 /*
- */
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/result_set.cc
+++ b/cql3/result_set.cc
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/result_set.hh
+++ b/cql3/result_set.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/role_name.cc
+++ b/cql3/role_name.cc
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2017-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/role_name.hh
+++ b/cql3/role_name.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2017-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/selection/abstract_function_selector.cc
+++ b/cql3/selection/abstract_function_selector.cc
@@ -1,6 +1,4 @@
 /*
- */
-/*
  * Modified by ScyllaDB
  * Copyright (C) 2015-present ScyllaDB
  */

--- a/cql3/selection/abstract_function_selector.hh
+++ b/cql3/selection/abstract_function_selector.hh
@@ -1,6 +1,4 @@
 /*
- */
-/*
  * Modified by ScyllaDB
  * Copyright (C) 2015-present ScyllaDB
  */

--- a/cql3/selection/aggregate_function_selector.hh
+++ b/cql3/selection/aggregate_function_selector.hh
@@ -1,6 +1,4 @@
 /*
- */
-/*
  * Modified by ScyllaDB
  * Copyright (C) 2015-present ScyllaDB
  */

--- a/cql3/selection/field_selector.hh
+++ b/cql3/selection/field_selector.hh
@@ -1,6 +1,4 @@
 /*
- */
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/selection/raw_selector.hh
+++ b/cql3/selection/raw_selector.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/selection/scalar_function_selector.hh
+++ b/cql3/selection/scalar_function_selector.hh
@@ -1,6 +1,4 @@
 /*
- */
-/*
  * Modified by ScyllaDB
  * Copyright (C) 2015-present ScyllaDB
  */

--- a/cql3/selection/selectable.hh
+++ b/cql3/selection/selectable.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/selection/selectable_with_field_selection.hh
+++ b/cql3/selection/selectable_with_field_selection.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/selection/selection.cc
+++ b/cql3/selection/selection.cc
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/selection/selection.hh
+++ b/cql3/selection/selection.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/selection/selector.hh
+++ b/cql3/selection/selector.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/selection/selector_factories.cc
+++ b/cql3/selection/selector_factories.cc
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/selection/selector_factories.hh
+++ b/cql3/selection/selector_factories.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/selection/simple_selector.cc
+++ b/cql3/selection/simple_selector.cc
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/selection/simple_selector.hh
+++ b/cql3/selection/simple_selector.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/selection/writetime_or_ttl.hh
+++ b/cql3/selection/writetime_or_ttl.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/selection/writetime_or_ttl_selector.hh
+++ b/cql3/selection/writetime_or_ttl_selector.hh
@@ -1,6 +1,4 @@
 /*
- */
-/*
  * Modified by ScyllaDB
  *
  * Copyright (C) 2015-present ScyllaDB

--- a/cql3/sets.hh
+++ b/cql3/sets.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/single_column_relation.cc
+++ b/cql3/single_column_relation.cc
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/single_column_relation.hh
+++ b/cql3/single_column_relation.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/statements/alter_keyspace_statement.cc
+++ b/cql3/statements/alter_keyspace_statement.cc
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/statements/alter_keyspace_statement.hh
+++ b/cql3/statements/alter_keyspace_statement.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/statements/alter_role_statement.hh
+++ b/cql3/statements/alter_role_statement.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright 2017-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/statements/alter_table_statement.cc
+++ b/cql3/statements/alter_table_statement.cc
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/statements/alter_table_statement.hh
+++ b/cql3/statements/alter_table_statement.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/statements/alter_type_statement.cc
+++ b/cql3/statements/alter_type_statement.cc
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright 2016-present ScyllaDB
  */
 

--- a/cql3/statements/alter_type_statement.hh
+++ b/cql3/statements/alter_type_statement.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/statements/alter_view_statement.cc
+++ b/cql3/statements/alter_view_statement.cc
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright 2016-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/statements/alter_view_statement.hh
+++ b/cql3/statements/alter_view_statement.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright 2016-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/statements/authentication_statement.cc
+++ b/cql3/statements/authentication_statement.cc
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright 2016-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/statements/authentication_statement.hh
+++ b/cql3/statements/authentication_statement.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright 2016-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/statements/authorization_statement.cc
+++ b/cql3/statements/authorization_statement.cc
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright 2016-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/statements/authorization_statement.hh
+++ b/cql3/statements/authorization_statement.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright 2016-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/statements/batch_statement.cc
+++ b/cql3/statements/batch_statement.cc
@@ -1,6 +1,4 @@
 /*
- */
-/*
  * Modified by ScyllaDB
  * Copyright (C) 2015-present ScyllaDB
  */

--- a/cql3/statements/batch_statement.hh
+++ b/cql3/statements/batch_statement.hh
@@ -1,6 +1,4 @@
 /*
- */
-/*
  * Modified by ScyllaDB
  * Copyright (C) 2015-present ScyllaDB
  */

--- a/cql3/statements/bound.hh
+++ b/cql3/statements/bound.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/statements/cas_request.cc
+++ b/cql3/statements/cas_request.cc
@@ -1,6 +1,4 @@
 /*
- */
-/*
  * Copyright (C) 2019-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/statements/cas_request.hh
+++ b/cql3/statements/cas_request.hh
@@ -1,6 +1,4 @@
 /*
- */
-/*
  * Copyright (C) 2019-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/statements/cf_prop_defs.cc
+++ b/cql3/statements/cf_prop_defs.cc
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/statements/cf_prop_defs.hh
+++ b/cql3/statements/cf_prop_defs.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/statements/cf_properties.hh
+++ b/cql3/statements/cf_properties.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright 2016-present ScyllaDB
  */
 

--- a/cql3/statements/cf_statement.cc
+++ b/cql3/statements/cf_statement.cc
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright 2014-present-2015 ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/statements/create_index_statement.cc
+++ b/cql3/statements/create_index_statement.cc
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/statements/create_index_statement.hh
+++ b/cql3/statements/create_index_statement.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/statements/create_keyspace_statement.cc
+++ b/cql3/statements/create_keyspace_statement.cc
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/statements/create_keyspace_statement.hh
+++ b/cql3/statements/create_keyspace_statement.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/statements/create_role_statement.hh
+++ b/cql3/statements/create_role_statement.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright 2017-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/statements/create_table_statement.cc
+++ b/cql3/statements/create_table_statement.cc
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/statements/create_table_statement.hh
+++ b/cql3/statements/create_table_statement.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/statements/create_type_statement.cc
+++ b/cql3/statements/create_type_statement.cc
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright 2016-present ScyllaDB
  */
 

--- a/cql3/statements/create_type_statement.hh
+++ b/cql3/statements/create_type_statement.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright 2016-present ScyllaDB
  */
 

--- a/cql3/statements/create_view_statement.cc
+++ b/cql3/statements/create_view_statement.cc
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2016-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/statements/delete_statement.cc
+++ b/cql3/statements/delete_statement.cc
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/statements/delete_statement.hh
+++ b/cql3/statements/delete_statement.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/statements/drop_index_statement.cc
+++ b/cql3/statements/drop_index_statement.cc
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2017-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/statements/drop_index_statement.hh
+++ b/cql3/statements/drop_index_statement.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2017-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/statements/drop_keyspace_statement.cc
+++ b/cql3/statements/drop_keyspace_statement.cc
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/statements/drop_keyspace_statement.hh
+++ b/cql3/statements/drop_keyspace_statement.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/statements/drop_role_statement.hh
+++ b/cql3/statements/drop_role_statement.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright 2017-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/statements/drop_table_statement.cc
+++ b/cql3/statements/drop_table_statement.cc
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/statements/drop_table_statement.hh
+++ b/cql3/statements/drop_table_statement.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/statements/drop_type_statement.cc
+++ b/cql3/statements/drop_type_statement.cc
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright 2016-present ScyllaDB
  */
 

--- a/cql3/statements/drop_type_statement.hh
+++ b/cql3/statements/drop_type_statement.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright 2016-present ScyllaDB
  */
 

--- a/cql3/statements/drop_view_statement.cc
+++ b/cql3/statements/drop_view_statement.cc
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright 2016-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/statements/drop_view_statement.hh
+++ b/cql3/statements/drop_view_statement.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright 2016-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/statements/grant_role_statement.hh
+++ b/cql3/statements/grant_role_statement.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright 2017-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/statements/grant_statement.cc
+++ b/cql3/statements/grant_statement.cc
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright 2016-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/statements/grant_statement.hh
+++ b/cql3/statements/grant_statement.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright 2016-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/statements/index_prop_defs.cc
+++ b/cql3/statements/index_prop_defs.cc
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/statements/index_prop_defs.hh
+++ b/cql3/statements/index_prop_defs.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/statements/index_target.cc
+++ b/cql3/statements/index_target.cc
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/statements/index_target.hh
+++ b/cql3/statements/index_target.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/statements/ks_prop_defs.cc
+++ b/cql3/statements/ks_prop_defs.cc
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/statements/ks_prop_defs.hh
+++ b/cql3/statements/ks_prop_defs.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/statements/list_permissions_statement.cc
+++ b/cql3/statements/list_permissions_statement.cc
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright 2016-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/statements/list_permissions_statement.hh
+++ b/cql3/statements/list_permissions_statement.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright 2016-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/statements/list_roles_statement.hh
+++ b/cql3/statements/list_roles_statement.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright 2017-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/statements/list_users_statement.cc
+++ b/cql3/statements/list_users_statement.cc
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright 2016-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/statements/list_users_statement.hh
+++ b/cql3/statements/list_users_statement.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright 2016-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/statements/modification_statement.cc
+++ b/cql3/statements/modification_statement.cc
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/statements/modification_statement.hh
+++ b/cql3/statements/modification_statement.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/statements/permission_altering_statement.cc
+++ b/cql3/statements/permission_altering_statement.cc
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright 2016-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/statements/permission_altering_statement.hh
+++ b/cql3/statements/permission_altering_statement.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright 2016-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/statements/prepared_statement.hh
+++ b/cql3/statements/prepared_statement.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2016-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/statements/property_definitions.cc
+++ b/cql3/statements/property_definitions.cc
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/statements/property_definitions.hh
+++ b/cql3/statements/property_definitions.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/statements/raw/batch_statement.hh
+++ b/cql3/statements/raw/batch_statement.hh
@@ -1,6 +1,4 @@
 /*
- */
-/*
  * Modified by ScyllaDB
  * Copyright (C) 2015-present ScyllaDB
  */

--- a/cql3/statements/raw/cf_statement.hh
+++ b/cql3/statements/raw/cf_statement.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2014-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/statements/raw/delete_statement.hh
+++ b/cql3/statements/raw/delete_statement.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/statements/raw/insert_statement.hh
+++ b/cql3/statements/raw/insert_statement.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/statements/raw/modification_statement.hh
+++ b/cql3/statements/raw/modification_statement.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/statements/raw/parsed_statement.cc
+++ b/cql3/statements/raw/parsed_statement.cc
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2014-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/statements/raw/parsed_statement.hh
+++ b/cql3/statements/raw/parsed_statement.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2016-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/statements/raw/select_statement.hh
+++ b/cql3/statements/raw/select_statement.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/statements/raw/update_statement.hh
+++ b/cql3/statements/raw/update_statement.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/statements/raw/use_statement.hh
+++ b/cql3/statements/raw/use_statement.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2014-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/statements/request_validations.hh
+++ b/cql3/statements/request_validations.hh
@@ -1,6 +1,4 @@
 /*
- */
-/*
  * Modified by ScyllaDB
  *
  * Copyright (C) 2015-present ScyllaDB

--- a/cql3/statements/revoke_role_statement.hh
+++ b/cql3/statements/revoke_role_statement.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright 2017-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/statements/revoke_statement.cc
+++ b/cql3/statements/revoke_statement.cc
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright 2016-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/statements/revoke_statement.hh
+++ b/cql3/statements/revoke_statement.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright 2016-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/statements/role-management-statements.cc
+++ b/cql3/statements/role-management-statements.cc
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright 2017-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/statements/schema_altering_statement.cc
+++ b/cql3/statements/schema_altering_statement.cc
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/statements/schema_altering_statement.hh
+++ b/cql3/statements/schema_altering_statement.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2014-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/statements/select_statement.hh
+++ b/cql3/statements/select_statement.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/statements/statement_type.hh
+++ b/cql3/statements/statement_type.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2017-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/statements/truncate_statement.cc
+++ b/cql3/statements/truncate_statement.cc
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2014-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/statements/truncate_statement.hh
+++ b/cql3/statements/truncate_statement.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2014-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/statements/update_statement.cc
+++ b/cql3/statements/update_statement.cc
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/statements/update_statement.hh
+++ b/cql3/statements/update_statement.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/statements/use_statement.cc
+++ b/cql3/statements/use_statement.cc
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/statements/use_statement.hh
+++ b/cql3/statements/use_statement.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2014-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/token_relation.cc
+++ b/cql3/token_relation.cc
@@ -1,6 +1,4 @@
 /*
- */
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/token_relation.hh
+++ b/cql3/token_relation.hh
@@ -1,6 +1,4 @@
 /*
- */
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/untyped_result_set.cc
+++ b/cql3/untyped_result_set.cc
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/untyped_result_set.hh
+++ b/cql3/untyped_result_set.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/update_parameters.cc
+++ b/cql3/update_parameters.cc
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/update_parameters.hh
+++ b/cql3/update_parameters.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/user_types.cc
+++ b/cql3/user_types.cc
@@ -1,6 +1,4 @@
 /*
- */
-/*
  * Modified by ScyllaDB
  *
  * Copyright (C) 2015-present ScyllaDB

--- a/cql3/user_types.hh
+++ b/cql3/user_types.hh
@@ -1,6 +1,4 @@
 /*
- */
-/*
  * Modified by ScyllaDB
  *
  * Copyright (C) 2015-present ScyllaDB

--- a/cql3/ut_name.cc
+++ b/cql3/ut_name.cc
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/cql3/ut_name.hh
+++ b/cql3/ut_name.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/db/batchlog_manager.cc
+++ b/db/batchlog_manager.cc
@@ -1,6 +1,4 @@
 /*
- */
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/db/batchlog_manager.hh
+++ b/db/batchlog_manager.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/db/commitlog/commitlog.cc
+++ b/db/commitlog/commitlog.cc
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Modified by ScyllaDB
  * Copyright (C) 2015-present ScyllaDB
  */

--- a/db/commitlog/commitlog.hh
+++ b/db/commitlog/commitlog.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Modified by ScyllaDB
  * Copyright (C) 2015-present ScyllaDB
  */

--- a/db/commitlog/commitlog_replayer.cc
+++ b/db/commitlog/commitlog_replayer.cc
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Modified by ScyllaDB
  * Copyright (C) 2015-present ScyllaDB
  */

--- a/db/commitlog/commitlog_replayer.hh
+++ b/db/commitlog/commitlog_replayer.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Modified by ScyllaDB
  * Copyright (C) 2015-present ScyllaDB
  */

--- a/db/commitlog/replay_position.hh
+++ b/db/commitlog/replay_position.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Modified by ScyllaDB
  * Copyright (C) 2015-present ScyllaDB
  */

--- a/db/commitlog/rp_set.hh
+++ b/db/commitlog/rp_set.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Modified by ScyllaDB
  * Copyright (C) 2016-present ScyllaDB
  */

--- a/db/consistency_level.cc
+++ b/db/consistency_level.cc
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/db/consistency_level.hh
+++ b/db/consistency_level.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/db/consistency_level_type.hh
+++ b/db/consistency_level_type.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/db/consistency_level_validations.hh
+++ b/db/consistency_level_validations.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2018-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/db/cql_type_parser.cc
+++ b/db/cql_type_parser.cc
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Modified by ScyllaDB
  * Copyright (C) 2017-present ScyllaDB
  */

--- a/db/cql_type_parser.hh
+++ b/db/cql_type_parser.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Modified by ScyllaDB
  * Copyright (C) 2017-present ScyllaDB
  */

--- a/db/extensions.hh
+++ b/db/extensions.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Modified by ScyllaDB
  * Copyright (C) 2017-present ScyllaDB
  */

--- a/db/legacy_schema_migrator.cc
+++ b/db/legacy_schema_migrator.cc
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Modified by ScyllaDB
  * Copyright (C) 2017-present ScyllaDB
  */

--- a/db/legacy_schema_migrator.hh
+++ b/db/legacy_schema_migrator.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Modified by ScyllaDB
  * Copyright (C) 2017-present ScyllaDB
  */

--- a/db/marshal/type_parser.cc
+++ b/db/marshal/type_parser.cc
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/db/marshal/type_parser.hh
+++ b/db/marshal/type_parser.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/db/read_repair_decision.hh
+++ b/db/read_repair_decision.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Modified by ScyllaDB
  * Copyright (C) 2015-present ScyllaDB
  */

--- a/db/schema_tables.hh
+++ b/db/schema_tables.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Modified by ScyllaDB
  * Copyright (C) 2015-present ScyllaDB
  */

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Modified by ScyllaDB
  * Copyright (C) 2015-present ScyllaDB
  */

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Modified by ScyllaDB
  * Copyright (C) 2015-present ScyllaDB
  */

--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2017-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/db/virtual_table.cc
+++ b/db/virtual_table.cc
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Modified by ScyllaDB
  * Copyright (C) 2021-present ScyllaDB
  */

--- a/db/write_type.hh
+++ b/db/write_type.hh
@@ -1,6 +1,4 @@
 /*
- */
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/dht/i_partitioner.hh
+++ b/dht/i_partitioner.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Modified by ScyllaDB
  * Copyright (C) 2015-present ScyllaDB
  */

--- a/exceptions/exceptions.cc
+++ b/exceptions/exceptions.cc
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/exceptions/exceptions.hh
+++ b/exceptions/exceptions.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/exceptions/unrecognized_entity_exception.hh
+++ b/exceptions/unrecognized_entity_exception.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/gms/application_state.cc
+++ b/gms/application_state.cc
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Modified by ScyllaDB
  * Copyright 2015-present ScyllaDB
  */

--- a/index/secondary_index.cc
+++ b/index/secondary_index.cc
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/index/secondary_index.hh
+++ b/index/secondary_index.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/index/secondary_index_manager.cc
+++ b/index/secondary_index_manager.cc
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2017-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/index/secondary_index_manager.hh
+++ b/index/secondary_index_manager.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2017-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/index/target_parser.hh
+++ b/index/target_parser.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2017-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/locator/azure_snitch.cc
+++ b/locator/azure_snitch.cc
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * SPDX-License-Identifier: (AGPL-3.0-or-later and Apache-2.0)
  */
 

--- a/locator/azure_snitch.hh
+++ b/locator/azure_snitch.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * SPDX-License-Identifier: (AGPL-3.0-or-later and Apache-2.0)
  */
 

--- a/locator/gce_snitch.cc
+++ b/locator/gce_snitch.cc
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * SPDX-License-Identifier: (AGPL-3.0-or-later and Apache-2.0)
  */
 

--- a/locator/gce_snitch.hh
+++ b/locator/gce_snitch.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * SPDX-License-Identifier: (AGPL-3.0-or-later and Apache-2.0)
  */
 

--- a/locator/production_snitch_base.cc
+++ b/locator/production_snitch_base.cc
@@ -1,8 +1,4 @@
 /*
- *
- */
-
-/*
  * Modified by ScyllaDB
  * Copyright (C) 2018-present ScyllaDB
  */

--- a/service/client_state.cc
+++ b/service/client_state.cc
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2016-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/service/client_state.hh
+++ b/service/client_state.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/service/endpoint_lifecycle_subscriber.hh
+++ b/service/endpoint_lifecycle_subscriber.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/service/load_broadcaster.hh
+++ b/service/load_broadcaster.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Modified by ScyllaDB
  * Copyright 2015-present ScyllaDB
  */

--- a/service/migration_listener.hh
+++ b/service/migration_listener.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/service/migration_manager.cc
+++ b/service/migration_manager.cc
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/service/migration_manager.hh
+++ b/service/migration_manager.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/service/misc_services.cc
+++ b/service/misc_services.cc
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Modified by ScyllaDB
  * Copyright 2015-present ScyllaDB
  */

--- a/service/pager/paging_state.cc
+++ b/service/pager/paging_state.cc
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/service/pager/paging_state.hh
+++ b/service/pager/paging_state.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/service/pager/query_pager.hh
+++ b/service/pager/query_pager.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/service/pager/query_pagers.cc
+++ b/service/pager/query_pagers.cc
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/service/pager/query_pagers.hh
+++ b/service/pager/query_pagers.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/service/paxos/paxos_state.hh
+++ b/service/paxos/paxos_state.hh
@@ -1,8 +1,4 @@
 /*
- *
- *
- */
-/*
  * Copyright (C) 2019-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/service/paxos/prepare_response.cc
+++ b/service/paxos/prepare_response.cc
@@ -1,8 +1,4 @@
 /*
- *
- *
- */
-/*
  * Copyright (C) 2019-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/service/paxos/prepare_response.hh
+++ b/service/paxos/prepare_response.hh
@@ -1,8 +1,4 @@
 /*
- *
- *
- */
-/*
  * Copyright (C) 2019-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/service/paxos/prepare_summary.cc
+++ b/service/paxos/prepare_summary.cc
@@ -1,8 +1,4 @@
 /*
- *
- *
- */
-/*
  * Copyright (C) 2019-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/service/paxos/prepare_summary.hh
+++ b/service/paxos/prepare_summary.hh
@@ -1,8 +1,4 @@
 /*
- *
- *
- */
-/*
  * Copyright (C) 2019-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/service/paxos/proposal.cc
+++ b/service/paxos/proposal.cc
@@ -1,8 +1,4 @@
 /*
- *
- *
- */
-/*
  * Copyright (C) 2019-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/service/paxos/proposal.hh
+++ b/service/paxos/proposal.hh
@@ -1,8 +1,4 @@
 /*
- *
- *
- */
-/*
  * Copyright (C) 2019-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/service/storage_proxy.hh
+++ b/service/storage_proxy.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/sstables/downsampling.hh
+++ b/sstables/downsampling.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/sstables/metadata_collector.hh
+++ b/sstables/metadata_collector.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/streaming/stream_session_state.cc
+++ b/streaming/stream_session_state.cc
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Modified by ScyllaDB.
  * Copyright 2015-present ScyllaDB.
  */

--- a/test/manual/streaming_histogram_test.cc
+++ b/test/manual/streaming_histogram_test.cc
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2017-present ScyllaDB
  */
 

--- a/thrift/thrift_validation.cc
+++ b/thrift/thrift_validation.cc
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/thrift/thrift_validation.hh
+++ b/thrift/thrift_validation.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/tracing/trace_keyspace_helper.cc
+++ b/tracing/trace_keyspace_helper.cc
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2016-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/tracing/trace_keyspace_helper.hh
+++ b/tracing/trace_keyspace_helper.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2016-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/tracing/trace_state.cc
+++ b/tracing/trace_state.cc
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2016-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/tracing/trace_state.hh
+++ b/tracing/trace_state.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2016-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/tracing/tracing.cc
+++ b/tracing/tracing.cc
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2016-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/tracing/tracing.hh
+++ b/tracing/tracing.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2016-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/transport/event.cc
+++ b/transport/event.cc
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/transport/event.hh
+++ b/transport/event.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/utils/bloom_calculations.cc
+++ b/utils/bloom_calculations.cc
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/utils/bloom_calculations.hh
+++ b/utils/bloom_calculations.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/utils/bloom_filter.cc
+++ b/utils/bloom_filter.cc
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/utils/bloom_filter.hh
+++ b/utils/bloom_filter.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/utils/estimated_histogram.hh
+++ b/utils/estimated_histogram.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/utils/fb_utilities.hh
+++ b/utils/fb_utilities.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Modified by ScyllaDB
  * Copyright (C) 2015-present ScyllaDB
  */

--- a/utils/i_filter.hh
+++ b/utils/i_filter.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/utils/streaming_histogram.hh
+++ b/utils/streaming_histogram.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/validation.cc
+++ b/validation.cc
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/validation.hh
+++ b/validation.hh
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright (C) 2015-present ScyllaDB
  *
  * Modified by ScyllaDB

--- a/vint-serialization.cc
+++ b/vint-serialization.cc
@@ -1,7 +1,4 @@
 /*
- */
-
-/*
  * Copyright 2017-present ScyllaDB
  *
  * Modified by ScyllaDB


### PR DESCRIPTION
After fcb8d040 ("treewide: use Software Package Data Exchange
(SPDX) license identifiers"), many dual-licensed files were
left with empty comments on top. Remove them to avoid visual
noise.