### PR TITLE
Add range deserializer

### DIFF
--- a/idl-compiler.py
+++ b/idl-compiler.py
@@ -1434,7 +1434,7 @@ def add_view(cout, cls):
         if is_vector(m.type):
             elem_type = element_type(m.type)
             fprintln(cout, reindent(4, """
-                auto {name}_range() const {{
+                auto {name}() const {{
                   return seastar::with_serialized_stream(v, [this] (auto& v) {{
                    auto in = v;
                    {skip}
@@ -1442,16 +1442,16 @@ def add_view(cout, cls):
                   }});
                 }}
             """).format(f=DESERIALIZER, **locals()))
-
-        fprintln(cout, reindent(4, """
-            auto {name}() const {{
-              return seastar::with_serialized_stream(v, [this] (auto& v) -> decltype({f}(std::declval<utils::input_stream&>(), boost::type<{full_type}>())) {{
-               auto in = v;
-               {skip}
-               return {deser};
-              }});
-            }}
-        """).format(f=DESERIALIZER, **locals()))
+        else:
+            fprintln(cout, reindent(4, """
+                auto {name}() const {{
+                  return seastar::with_serialized_stream(v, [this] (auto& v) -> decltype({f}(std::declval<utils::input_stream&>(), boost::type<{full_type}>())) {{
+                   auto in = v;
+                   {skip}
+                   return {deser};
+                  }});
+                }}
+            """).format(f=DESERIALIZER, **locals()))
 
         skip = skip + f"\n       ser::skip(in, boost::type<{full_type}>());"
 

--- a/idl-compiler.py
+++ b/idl-compiler.py
@@ -1353,6 +1353,13 @@ def param_view_type(t):
         return t.name + join_template_view(t.template_parameters, additional_types)
 
 
+def element_type(t):
+    assert isinstance(t, TemplateType)
+    assert len(t.template_parameters) == 1
+    assert t.name != "boost::variant" and t.name != "std::variant"
+    return param_view_type(t.template_parameters[0])
+
+
 read_sizes = set()
 
 
@@ -1423,6 +1430,18 @@ def add_view(cout, cls):
             deser = f"(in.size()>0) ? {DESERIALIZER}(in, boost::type<{full_type}>()) : {deflt}"
         else:
             deser = f"{DESERIALIZER}(in, boost::type<{full_type}>())"
+
+        if is_vector(m.type):
+            elem_type = element_type(m.type)
+            fprintln(cout, reindent(4, """
+                auto {name}_range() const {{
+                  return seastar::with_serialized_stream(v, [this] (auto& v) {{
+                   auto in = v;
+                   {skip}
+                   return vector_deserializer<{elem_type}>(in);
+                  }});
+                }}
+            """).format(f=DESERIALIZER, **locals()))
 
         fprintln(cout, reindent(4, """
             auto {name}() const {{

--- a/mutation_partition_view.cc
+++ b/mutation_partition_view.cc
@@ -259,12 +259,12 @@ future<> mutation_partition_view::do_accept_gently(const column_mapping& cm, Vis
     read_and_visit_row(mpv.static_row(), cm, column_kind::static_column, static_row_cell_visitor{visitor});
     co_await coroutine::maybe_yield();
 
-    for (auto&& rt : mpv.range_tombstones()) {
+    for (auto rt : mpv.range_tombstones_range()) {
         visitor.accept_row_tombstone(rt);
         co_await coroutine::maybe_yield();
     }
 
-    for (auto&& cr : mpv.rows()) {
+    for (auto cr : mpv.rows_range()) {
         auto t = row_tombstone(cr.deleted_at(), shadowable_tombstone(cr.shadowable_deleted_at()));
         auto key = cr.key();
         visitor.accept_row(position_in_partition_view::for_key(key), t, read_row_marker(cr.marker()), is_dummy::no, is_continuous::yes);

--- a/mutation_partition_view.cc
+++ b/mutation_partition_view.cc
@@ -259,12 +259,12 @@ future<> mutation_partition_view::do_accept_gently(const column_mapping& cm, Vis
     read_and_visit_row(mpv.static_row(), cm, column_kind::static_column, static_row_cell_visitor{visitor});
     co_await coroutine::maybe_yield();
 
-    for (auto rt : mpv.range_tombstones_range()) {
+    for (auto rt : mpv.range_tombstones()) {
         visitor.accept_row_tombstone(rt);
         co_await coroutine::maybe_yield();
     }
 
-    for (auto cr : mpv.rows_range()) {
+    for (auto cr : mpv.rows()) {
         auto t = row_tombstone(cr.deleted_at(), shadowable_tombstone(cr.shadowable_deleted_at()));
         auto key = cr.key();
         visitor.accept_row(position_in_partition_view::for_key(key), t, read_row_marker(cr.marker()), is_dummy::no, is_continuous::yes);
@@ -318,7 +318,7 @@ std::optional<clustering_key> mutation_partition_view::first_row_key() const
     if (rows.empty()) {
         return { };
     }
-    return rows.front().key();
+    return (*rows.begin()).key();
 }
 
 std::optional<clustering_key> mutation_partition_view::last_row_key() const
@@ -329,7 +329,12 @@ std::optional<clustering_key> mutation_partition_view::last_row_key() const
     if (rows.empty()) {
         return { };
     }
-    return rows.back().key();
+    auto it = rows.begin();
+    auto next = it;
+    while (++next != rows.end()) {
+        it = next;
+    }
+    return (*it).key();
 }
 
 mutation_partition_view mutation_partition_view::from_view(ser::mutation_partition_view v)

--- a/test/boost/frozen_mutation_test.cc
+++ b/test/boost/frozen_mutation_test.cc
@@ -56,7 +56,10 @@ SEASTAR_TEST_CASE(test_writing_and_reading) {
 
 SEASTAR_TEST_CASE(test_writing_and_reading_gently) {
     return _test_freeze_unfreeze([] (const frozen_mutation& fm, schema_ptr s) {
-        return fm.unfreeze_gently(std::move(s)).get();
+        return fm.unfreeze_gently(std::move(s)).handle_exception([] (std::exception_ptr ex) {
+            testlog.error("test_writing_and_reading_gently: {}", ex);
+            return make_exception_future<mutation>(std::move(ex));
+        }).get();
     });
 }
 

--- a/test/boost/idl_test.cc
+++ b/test/boost/idl_test.cc
@@ -227,7 +227,9 @@ BOOST_AUTO_TEST_CASE(test_vector)
     auto bv2 = buf2.linearize();
     auto in2 = ser::as_input_stream(bv2);
     auto voc_view = ser::deserialize(in2, boost::type<ser::writable_vectors_of_compounds_view>());
-    auto&& first_view = voc_view.first();
+
+    auto first_range = voc_view.first();
+    auto first_view = std::vector<ser::writable_simple_compound_view>(first_range.begin(), first_range.end());
     BOOST_REQUIRE_EQUAL(vec1.size(), first_view.size());
     for (size_t i = 0; i < first_view.size(); i++) {
         auto fv = first_view[i];
@@ -236,7 +238,8 @@ BOOST_AUTO_TEST_CASE(test_vector)
         BOOST_REQUIRE_EQUAL(vec1[i].bar, first_view[i].bar());
     }
 
-    auto&& second_view = voc_view.second().vector();
+    auto second_range = voc_view.second().vector();
+    auto second_view = std::vector<simple_compound>(second_range.begin(), second_range.end());
     BOOST_REQUIRE_EQUAL(vec2.size(), second_view.size());
     for (size_t i = 0; i < second_view.size(); i++) {
         BOOST_REQUIRE_EQUAL(vec2[i], second_view[i]);
@@ -291,7 +294,8 @@ BOOST_AUTO_TEST_CASE(test_variant)
 
     struct expect_vector : boost::static_visitor<std::vector<simple_compound>> {
         std::vector<simple_compound> operator()(ser::writable_vector_view& wvv) const {
-            return wvv.vector();
+            auto range = wvv.vector();
+            return std::vector<simple_compound>(range.begin(), range.end());
         }
         std::vector<simple_compound> operator()(simple_compound&) const {
             throw std::runtime_error("got simple_compound, expected writable_vector");

--- a/test/boost/serialization_test.cc
+++ b/test/boost/serialization_test.cc
@@ -200,3 +200,68 @@ BOOST_AUTO_TEST_CASE(inet_address) {
     }
 }
 
+template <typename T>
+static void test_vector_deserializer(const std::vector<T>& v) {
+    auto buf = ser::serialize_to_buffer<bytes>(v);
+    auto in = simple_input_stream((const char*)buf.data(), buf.size());
+    auto range = ser::vector_deserializer<T>(in);
+
+    auto test_equal = [] (const T& lhs, const T& rhs) {
+        if (lhs != rhs) {
+            throw std::runtime_error("compared values differ");
+        }
+    };
+
+    auto required = [] (bool x) {
+        if (!x) {
+            throw std::runtime_error(format("failed requirment"));
+        }
+    };
+
+    {
+        auto vit = v.begin();
+        auto rit = range.begin();
+        while (rit != range.end()) {
+            test_equal(*rit, *vit);
+            ++rit;
+            ++vit;
+        }
+        required(vit == v.end());
+    }
+
+    {
+        auto vit = v.begin();
+        auto rit = range.begin();
+        while (rit != range.end()) {
+            test_equal(*rit++, *vit++);
+        }
+        required(vit == v.end());
+    }
+
+    {
+        auto cvit = v.cbegin();
+        auto crit = range.cbegin();
+        while (crit != range.cend()) {
+            test_equal(*crit++, *cvit++);
+        }
+        required(cvit == v.cend());
+    }
+
+    {
+        auto vit = v.begin();
+        for (auto i : range) {
+            test_equal(i, *vit++);
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE(vector_deserializer) {
+    std::vector<int> int_vect = { 3, 1, 4 };
+    test_vector_deserializer(int_vect);
+
+    std::vector<sstring> sstring_vect = { "testing", "one", "two", "three" };
+    test_vector_deserializer(sstring_vect);
+
+    std::vector<std::optional<bool>> opt_bool_vect = { true, false, {}, false, true };
+    test_vector_deserializer(opt_bool_vect);
+}


### PR DESCRIPTION
Currently, the idl-generated deserialization code, e.g. mutation_partition_view::rows() deserializes and returns a complete utils::chunked_vector<deletable_row_view> . And that could be arbitrarily long.

To consume it gently, we don't need the whole vector in advance, but rather we can consume it one element at a time (and in a nested way for cells in a row in the future).

Use `range_deserializer` to consume range tombstones and rows one item at a time.
    
We may consider in the future also gently iterating over cells
in a row and then dipping into collection cells that might also
contain a large number of items.
    
Fixes #10558
