### PR TITLE
sstables: writer: pass bytes_ostream by reference

### DIFF
--- a/sstables/writer.hh
+++ b/sstables/writer.hh
@@ -298,7 +298,7 @@ inline void write(sstable_version_types v, W& out, managed_bytes_view s) {
     }
 }
 
-inline void write(sstable_version_types v, file_writer& out, bytes_ostream s) {
+inline void write(sstable_version_types v, file_writer& out, const bytes_ostream& s) {
     for (bytes_view fragment : s) {
         write(v, out, fragment);
     }


### PR DESCRIPTION
The bytes_stream param is passed by value from `write_promoted_index`
(since 0d8463aba580cb3c84cb9cafa825e0e2eb16ebc1)
causing an uneeded copy.

This can lead to OOM if the promoted index is extremely large.

Pass the bytes_ostream by reference instead to prevent this copy.

Fixes #10569

Signed-off-by: Benny Halevy <bhalevy@scylladb.com>