### PR TITLE
service/memory_limiter.hh: correct license

### DIFF
--- a/service/memory_limiter.hh
+++ b/service/memory_limiter.hh
@@ -1,5 +1,5 @@
 /*
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: AGPL-3.0-or-later
  *
  * Copyright (C) 2021-present ScyllaDB
  *


### PR DESCRIPTION
When split from service/storage_service.hh (4ca2ae13) it accidentally
changed license. Change it back (since it does not contain
Apache derived code, constrain it to AGPL-3.0-or-later).