### PR TITLE
scylla_prepare: describe error more correctly

### DIFF
--- a/dist/common/scripts/scylla_prepare
+++ b/dist/common/scripts/scylla_prepare
@@ -127,10 +127,17 @@ if __name__ == '__main__':
             run('hugeadm --create-mounts', shell=True, check=True)
     else:
         try:
-            if create_perftune_conf(cfg):
-                run("{} --options-file /etc/scylla.d/perftune.yaml".format(perftune_base_command()), shell=True, check=True)
+            res = create_perftune_conf(cfg)
         except Exception as e:
             print(f'Exception occurred while creating perftune.yaml:\n')
+            traceback.print_exc()
+            print('\nTo fix the error, please re-run scylla_setup.')
+            sys.exit(1)
+        try:
+            if res:
+                run("{} --options-file /etc/scylla.d/perftune.yaml".format(perftune_base_command()), shell=True, check=True)
+        except Exception as e:
+            print(f'Exception occurred while tuning system using perftune.yaml:\n')
             traceback.print_exc()
             print('\nTo fix the error, please re-run scylla_setup.')
             sys.exit(1)


### PR DESCRIPTION
Currently our error message on scylla_prepare says "Exception occurred
while creating perftune.yaml", even perftune.yaml is already generated,
and error occurred after that.
To describe error more correctly, add another error message after
perftune.yaml generated.

see scylladb/scylla-enterprise#2201