### PR TITLE
compaction_manager: Quickly abort maintenance compaction waiting for its turn

### DIFF
--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -334,7 +334,7 @@ protected:
         co_await coroutine::switch_to(_cm._compaction_controller.sg());
 
         switch_state(state::pending);
-        auto units = co_await get_units(_cm._maintenance_ops_sem, 1);
+        auto units = co_await get_units(_cm._maintenance_ops_sem, 1, _compaction_data.abort);
         auto lock_holder = co_await _compaction_state.lock.hold_write_lock();
         if (!can_proceed()) {
             co_return;
@@ -383,7 +383,7 @@ protected:
             co_return;
         }
         switch_state(state::pending);
-        auto units = co_await get_units(_cm._maintenance_ops_sem, 1);
+        auto units = co_await get_units(_cm._maintenance_ops_sem, 1, _compaction_data.abort);
 
         if (!can_proceed(throw_if_stopping::yes)) {
             co_return;
@@ -997,7 +997,7 @@ protected:
                 co_return;
             }
             switch_state(state::pending);
-            auto units = co_await get_units(_cm._maintenance_ops_sem, 1);
+            auto units = co_await get_units(_cm._maintenance_ops_sem, 1, _compaction_data.abort);
             if (!can_proceed()) {
                 co_return;
             }
@@ -1045,7 +1045,7 @@ public:
 protected:
     virtual future<> do_run() override {
         switch_state(state::pending);
-        auto maintenance_permit = co_await seastar::get_units(_cm._maintenance_ops_sem, 1);
+        auto maintenance_permit = co_await seastar::get_units(_cm._maintenance_ops_sem, 1, _compaction_data.abort);
 
         while (!_sstables.empty() && can_proceed()) {
             auto sst = consume_sstable();
@@ -1207,7 +1207,7 @@ public:
 protected:
     virtual future<> do_run() override {
         switch_state(state::pending);
-        auto maintenance_permit = co_await seastar::get_units(_cm._maintenance_ops_sem, 1);
+        auto maintenance_permit = co_await seastar::get_units(_cm._maintenance_ops_sem, 1, _compaction_data.abort);
 
         while (!_pending_cleanup_jobs.empty() && can_proceed()) {
             auto active_job = std::move(_pending_cleanup_jobs.back());


### PR DESCRIPTION
Today, aborting a maintenance compaction like major, which is waiting for
its turn to run, can take lots of time because compaction manager will
only be able to bail out the task once it gets the "permit" from the
serialization mechanism, i.e. semaphore. Meaning that the command that
started the task will only complete after all this time waiting for
the "permit".

To allow a pending maintenance compaction to be quickly aborted, we
can use the abortable variant of get_units(). So when user submits an
abortion request, get_units() will be able to return earlier through
the abort exception.

Refs #10485.

Signed-off-by: Raphael S. Carvalho <raphaelsc@scylladb.com>