### PR TITLE
Fix use-after-free when queue reader is destroyed before its handle

### DIFF
--- a/readers/mutation_readers.cc
+++ b/readers/mutation_readers.cc
@@ -1403,6 +1403,11 @@ public:
     explicit queue_reader_v2(schema_ptr s, reader_permit permit)
         : impl(std::move(s), std::move(permit)) {
     }
+    virtual ~queue_reader_v2() {
+        if (_handle) {
+            _handle->_reader = nullptr;
+        }
+    }
     virtual future<> fill_buffer() override {
         if (_ex) {
             return make_exception_future<>(_ex);


### PR DESCRIPTION
The handle must not point at this reader implementation after it's destroyed.

This fixes use-after-free when the queue_reader_v2
is destroyed first as repair_writer_impl::_queue_reader,
before repair_writer_impl::_mq is destroyed.
    
The issue was introduced in 39205917a8d77ebd4608f95afd0fb40ab38d6c0a
in the definition of `repair_writer_impl`.

Fixes #10528

While at it, fix also an ignored exceptional future seen in the test:
`repair_additional_test.py::TestRepairAdditional::test_repair_kill_3`