### PR TITLE
compaction_manager: Allow off-strategy to proceed in parallel to "in-strategy" compactions

### DIFF
--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -921,8 +921,6 @@ public:
         // by the fact that off-strategy is serialized across all tables, meaning that the
         // actual requirement is the size of the largest table's maintenance set.
 
-        auto sem_unit = co_await seastar::get_units(_compaction_state.off_strategy_sem, 1);
-
         replica::table& t = *_compacting_table;
         const auto& maintenance_sstables = t.maintenance_sstable_set();
 
@@ -997,7 +995,7 @@ protected:
                 co_return;
             }
             switch_state(state::pending);
-            auto units = co_await get_units(_cm._maintenance_ops_sem, 1, _compaction_data.abort);
+            auto units = co_await get_units(_cm._off_strategy_sem, 1, _compaction_data.abort);
             if (!can_proceed()) {
                 co_return;
             }

--- a/compaction/compaction_manager.hh
+++ b/compaction/compaction_manager.hh
@@ -68,10 +68,6 @@ private:
         // Raised by any function running under run_with_compaction_disabled();
         long compaction_disabled_counter = 0;
 
-        // This semaphore ensures that off-strategy compaction will be serialized for
-        // a given table, protecting against candidates being picked more than once.
-        seastar::named_semaphore off_strategy_sem = {1, named_semaphore_exception_factory{"off-strategy compaction"}};
-
         bool compaction_disabled() const noexcept {
             return compaction_disabled_counter > 0;
         }
@@ -268,6 +264,11 @@ private:
     // Purpose is to serialize all maintenance (non regular) compaction activity to reduce aggressiveness and space requirement.
     // If the operation must be serialized with regular, then the per-table write lock must be taken.
     seastar::named_semaphore _maintenance_ops_sem = {1, named_semaphore_exception_factory{"maintenance operation"}};
+
+    // This semaphore ensures that off-strategy compaction will be serialized for
+    // all tables, to limit space requirement and protect against candidates
+    // being picked more than once.
+    seastar::named_semaphore _off_strategy_sem = {1, named_semaphore_exception_factory{"off-strategy compaction"}};
 
     std::function<void()> compaction_submission_callback();
     // all registered tables are reevaluated at a constant interval.


### PR DESCRIPTION
Off-strategy works on maintenance sstable set using maintenance
scheduling group, whereas "in-strategy" works on main sstable set
and uses compaction group.

Today, it can happen that off-strategy has to wait for an "in-strategy"
maintenance compaction, e.g. cleanup, to complete before getting
a chance to run. But that's not desired behavior as off-strategy uses
maintenance group, and its candidates don't add to the backlog that
influences "in-strategy" bandwidth. Therefore, "in-strategy" and
off-strategy should be decoupled, with off-strategy having its own
semaphore for guaranteeing serialization across tables.

Signed-off-by: Raphael S. Carvalho <raphaelsc@scylladb.com>