### PR TITLE
cql: Add proper validation for null and unset inside collections send as bound values

### DIFF
--- a/types.cc
+++ b/types.cc
@@ -624,7 +624,13 @@ void write_collection_size(bytes::iterator& out, int size, cql_serialization_for
 }
 
 bytes_view read_collection_value(bytes_view& in, cql_serialization_format sf) {
-    auto size = sf.using_32_bits_for_collections() ? read_simple<int32_t>(in) : read_simple<uint16_t>(in);
+    int32_t size = sf.using_32_bits_for_collections() ? read_simple<int32_t>(in) : read_simple<uint16_t>(in);
+    if (size == -2) {
+        throw exceptions::invalid_request_exception("unset value is not supported inside collections");
+    }
+    if (size < 0) {
+        throw exceptions::invalid_request_exception("null is not supported inside collections");
+    }
     return read_simple_bytes(in, size);
 }
 

--- a/types.cc
+++ b/types.cc
@@ -734,6 +734,10 @@ void write_collection_value(managed_bytes_mutable_view& out, cql_serialization_f
     write_fragmented(out, val);
 }
 
+void write_int32(bytes::iterator& out, int32_t value) {
+    return serialize_int32(out, value);
+}
+
 shared_ptr<const abstract_type> abstract_type::underlying_type() const {
     struct visitor {
         shared_ptr<const abstract_type> operator()(const abstract_type& t) { return t.shared_from_this(); }

--- a/types.hh
+++ b/types.hh
@@ -1188,6 +1188,7 @@ void write_collection_size(managed_bytes_mutable_view&, int size, cql_serializat
 void write_collection_value(bytes::iterator& out, cql_serialization_format sf, bytes_view val_bytes);
 void write_collection_value(managed_bytes_mutable_view&, cql_serialization_format sf, bytes_view val_bytes);
 void write_collection_value(managed_bytes_mutable_view&, cql_serialization_format sf, const managed_bytes_view& val_bytes);
+void write_int32(bytes::iterator& out, int32_t value);
 
 // Splits a serialized collection into a vector of elements, but does not recursively deserialize the elements.
 // Does not perform validation.

--- a/types/listlike_partial_deserializing_iterator.hh
+++ b/types/listlike_partial_deserializing_iterator.hh
@@ -29,6 +29,12 @@ int read_collection_size(View& in, cql_serialization_format sf) {
 template <FragmentedView View>
 View read_collection_value(View& in, cql_serialization_format sf) {
     auto size = sf.using_32_bits_for_collections() ? read_simple<int32_t>(in) : read_simple<uint16_t>(in);
+    if (size == -2) {
+        throw exceptions::invalid_request_exception("unset value is not supported inside collections");
+    }
+    if (size < 0) {
+        throw exceptions::invalid_request_exception("null is not supported inside collections");
+    }
     return read_simple_bytes(in, size);
 }
 


### PR DESCRIPTION
Let's say we have a query like:
```cql
INSERT INTO ks.t (list_column) VALUES (?);
```
And the driver sends a list with null inside as the bound value, something like `[1, 2, null, 4]`.

In such case we should throw `invalid_request_exception` because `nulls` are not allowed inside collections.

Currently when a query like this gets executed Scylla throws an ugly marshalling error.
This is because the validation code reads size of the next element, interprets it as an unsigned integer and tries to read this much.
In case of `null` element the size is `-1`, which when converted to unsigned `size_t` gives 18446744073709551615 and it fails to read this much.

This PR adds proper validation checks to make the error message better.

I also added some tests.
I originally tried to write them in python, but python driver really doesn't like sending invalid values.
Trying to send `[1, None, 2]` results in a list with empty value instead of null.
Trying to send `[1, UNSET_VALUE, 2]` Fails before query even leaves the driver.

Fixes #10580