### PR TITLE
CDC - do not remove log table on CDC disable

### DIFF
--- a/cdc/cdc_partitioner.cc
+++ b/cdc/cdc_partitioner.cc
@@ -14,12 +14,12 @@
 #include "cdc/generation.hh"
 #include "keys.hh"
 
-static const sstring cdc_partitioner_name = "com.scylladb.dht.CDCPartitioner";
-
 namespace cdc {
 
+const sstring cdc_partitioner::classname = "com.scylladb.dht.CDCPartitioner";
+
 const sstring cdc_partitioner::name() const {
-    return cdc_partitioner_name;
+    return classname;
 }
 
 static dht::token to_token(int64_t value) {
@@ -48,7 +48,7 @@ cdc_partitioner::get_token(const schema& s, partition_key_view key) const {
 }
 
 using registry = class_registrator<dht::i_partitioner, cdc_partitioner>;
-static registry registrator(cdc_partitioner_name);
+static registry registrator(cdc::cdc_partitioner::classname);
 static registry registrator_short_name("CDCPartitioner");
 
 }

--- a/cdc/cdc_partitioner.hh
+++ b/cdc/cdc_partitioner.hh
@@ -25,6 +25,8 @@ class key_view;
 namespace cdc {
 
 struct cdc_partitioner final : public dht::i_partitioner {
+    static const sstring classname;
+
     cdc_partitioner() = default;
     virtual const sstring name() const override;
     virtual dht::token get_token(const schema& s, partition_key_view key) const override;

--- a/test/boost/cdc_test.cc
+++ b/test/boost/cdc_test.cc
@@ -149,8 +149,6 @@ SEASTAR_THREAD_TEST_CASE(test_with_cdc_parameter) {
                     e.local_db().find_schema("ks", "tbl")->cdc_options().enabled());
             if (exp.enabled) {
                 e.require_table_exists("ks", cdc::log_name("tbl")).get();
-            } else {
-                e.require_table_does_not_exist("ks", cdc::log_name("tbl")).get();
             }
             BOOST_REQUIRE_EQUAL(exp.preimage,
                     e.local_db().find_schema("ks", "tbl")->cdc_options().preimage());

--- a/test/cql/cdc_enable_disable_test.cql
+++ b/test/cql/cdc_enable_disable_test.cql
@@ -1,0 +1,51 @@
+-- Error messages contain a keyspace name. Make the output stable.
+CREATE KEYSPACE ks WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1};
+
+-- create cdc enabled table
+create table ks.t (pk int, ck int, v int, primary key(pk, ck)) with cdc = {'enabled': true};
+
+-- this write goes to the log
+insert into ks.t (pk, ck, v) values (1, 1, 100);
+
+-- disable cdc. should retain the log
+alter table ks.t with cdc = {'enabled': false};
+
+-- add more data to base - should not generate log
+insert into ks.t (pk, ck, v) values (2, 2, 200);
+
+-- should still work, and give one row (1, 1, 100)
+select "cdc$batch_seq_no", "cdc$operation", "cdc$ttl", pk, ck, v from ks.t_scylla_cdc_log;
+
+-- lets add a column
+alter table ks.t add v2 text;
+
+-- add more data
+insert into ks.t (pk, ck, v, v2) values (3, 3, 300, 'apa');
+
+-- turn cdc back on
+alter table ks.t with cdc = {'enabled': true};
+
+-- more data - this should also go to log.
+insert into ks.t (pk, ck, v, v2) values (4, 4, 400, 'snus');
+
+-- gives two rows (1, 1, 100)+(4, 4, 400, 'snus')
+select "cdc$batch_seq_no", "cdc$operation", "cdc$ttl", pk, ck, v, v2 from ks.t_scylla_cdc_log;
+
+-- disable cdc. should retain the log
+alter table ks.t with cdc = {'enabled': false};
+
+-- remove older column
+alter table ks.t drop v;
+
+-- add more data
+insert into ks.t (pk, ck, v2) values (5, 5, 'fisk');
+
+-- turn cdc back on
+alter table ks.t with cdc = {'enabled': true};
+
+insert into ks.t (pk, ck, v2) values (6, 6, 'aborre');
+
+-- gives three rows (1, 1)+(4, 4, 'snus')+(6, 6, 'aborre')
+select "cdc$batch_seq_no", "cdc$operation", "cdc$ttl", pk, ck, v2 from ks.t_scylla_cdc_log;
+
+DROP KEYSPACE ks;

--- a/test/cql/cdc_enable_disable_test.result
+++ b/test/cql/cdc_enable_disable_test.result
@@ -1,0 +1,84 @@
+> -- Error messages contain a keyspace name. Make the output stable.
+> CREATE KEYSPACE ks WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1};
+OK
+> 
+> -- create cdc enabled table
+> create table ks.t (pk int, ck int, v int, primary key(pk, ck)) with cdc = {'enabled': true};
+OK
+> 
+> -- this write goes to the log
+> insert into ks.t (pk, ck, v) values (1, 1, 100);
+OK
+> 
+> -- disable cdc. should retain the log
+> alter table ks.t with cdc = {'enabled': false};
+OK
+> 
+> -- add more data to base - should not generate log
+> insert into ks.t (pk, ck, v) values (2, 2, 200);
+OK
+> 
+> -- should still work, and give one row (1, 1, 100)
+> select "cdc$batch_seq_no", "cdc$operation", "cdc$ttl", pk, ck, v from ks.t_scylla_cdc_log;
++--------------------+-----------------+-----------+------+------+-----+
+|   cdc$batch_seq_no |   cdc$operation | cdc$ttl   |   pk |   ck |   v |
+|--------------------+-----------------+-----------+------+------+-----|
+|                  0 |               2 | null      |    1 |    1 | 100 |
++--------------------+-----------------+-----------+------+------+-----+
+> 
+> -- lets add a column
+> alter table ks.t add v2 text;
+OK
+> 
+> -- add more data
+> insert into ks.t (pk, ck, v, v2) values (3, 3, 300, 'apa');
+OK
+> 
+> -- turn cdc back on
+> alter table ks.t with cdc = {'enabled': true};
+OK
+> 
+> -- more data - this should also go to log.
+> insert into ks.t (pk, ck, v, v2) values (4, 4, 400, 'snus');
+OK
+> 
+> -- gives two rows (1, 1, 100)+(4, 4, 400, 'snus')
+> select "cdc$batch_seq_no", "cdc$operation", "cdc$ttl", pk, ck, v, v2 from ks.t_scylla_cdc_log;
++--------------------+-----------------+-----------+------+------+-----+------+
+|   cdc$batch_seq_no |   cdc$operation | cdc$ttl   |   pk |   ck |   v | v2   |
+|--------------------+-----------------+-----------+------+------+-----+------|
+|                  0 |               2 | null      |    1 |    1 | 100 | null |
+|                  0 |               2 | null      |    4 |    4 | 400 | snus |
++--------------------+-----------------+-----------+------+------+-----+------+
+> 
+> -- disable cdc. should retain the log
+> alter table ks.t with cdc = {'enabled': false};
+OK
+> 
+> -- remove older column
+> alter table ks.t drop v;
+OK
+> 
+> -- add more data
+> insert into ks.t (pk, ck, v2) values (5, 5, 'fisk');
+OK
+> 
+> -- turn cdc back on
+> alter table ks.t with cdc = {'enabled': true};
+OK
+> 
+> insert into ks.t (pk, ck, v2) values (6, 6, 'aborre');
+OK
+> 
+> -- gives three rows (1, 1)+(4, 4, 'snus')+(6, 6, 'aborre')
+> select "cdc$batch_seq_no", "cdc$operation", "cdc$ttl", pk, ck, v2 from ks.t_scylla_cdc_log;
++--------------------+-----------------+-----------+------+------+--------+
+|   cdc$batch_seq_no |   cdc$operation | cdc$ttl   |   pk |   ck | v2     |
+|--------------------+-----------------+-----------+------+------+--------|
+|                  0 |               2 | null      |    1 |    1 | null   |
+|                  0 |               2 | null      |    4 |    4 | snus   |
+|                  0 |               2 | null      |    6 |    6 | aborre |
++--------------------+-----------------+-----------+------+------+--------+
+> 
+> DROP KEYSPACE ks;
+OK


### PR DESCRIPTION
Fixes #10489

Killing the CDC log table on CDC disable is unhelpful in many ways,
partly because it can cause random exceptions on nodes trying to
do a CDC-enabled write at the same time as log table is dropped,
but also because it makes it impossible to collect data generated
before CDC was turned off, but which is not yet consumed.

Since data should be TTL:ed anyway, retaining the table should not
really add any overhead beyond the compaction to eventually clear
it. And user did set TTL=0 (disabled), then he is already responsible
for clearing out the data.

This also has the nice feature of meshing with the alternator streams
semantics.