### PR TITLE
forward_service: uncoroutinize dispatch_to_shards method

### DIFF
--- a/query-request.hh
+++ b/query-request.hh
@@ -384,7 +384,7 @@ struct forward_result {
     // vector storing query result for each selected column
     std::vector<bytes_opt> query_results;
 
-    void merge(const forward_result& other, const std::vector<forward_request::reduction_type>& types);
+    forward_result& merge(const forward_result& other, const std::vector<forward_request::reduction_type>& types);
 
     struct printer {
         const std::vector<forward_request::reduction_type>& types;

--- a/query.cc
+++ b/query.cc
@@ -403,7 +403,12 @@ static bytes_opt merge_singular_results(bytes_opt r1, bytes_opt r2, forward_requ
 
 void forward_result::merge(const forward_result& other, const std::vector<forward_request::reduction_type>& reduction_types) {
     if (query_results.empty()) {
-        query_results.resize(other.query_results.size());
+        // Merging empty result (this) with a non empty one (other) requires copying the other
+        query_results = other.query_results;
+        return;
+    } else if (other.query_results.empty()) {
+        // Merging non empty result (this) with an empty one (other) is a noop
+        return;
     }
 
     if (query_results.size() != other.query_results.size() || query_results.size() != reduction_types.size()) {

--- a/query.cc
+++ b/query.cc
@@ -401,14 +401,14 @@ static bytes_opt merge_singular_results(bytes_opt r1, bytes_opt r2, forward_requ
     throw std::runtime_error("unknown reduction type");
 }
 
-void forward_result::merge(const forward_result& other, const std::vector<forward_request::reduction_type>& reduction_types) {
+forward_result& forward_result::merge(const forward_result& other, const std::vector<forward_request::reduction_type>& reduction_types) {
     if (query_results.empty()) {
         // Merging empty result (this) with a non empty one (other) requires copying the other
         query_results = other.query_results;
-        return;
+        return *this;
     } else if (other.query_results.empty()) {
         // Merging non empty result (this) with an empty one (other) is a noop
-        return;
+        return *this;
     }
 
     if (query_results.size() != other.query_results.size() || query_results.size() != reduction_types.size()) {
@@ -425,6 +425,8 @@ void forward_result::merge(const forward_result& other, const std::vector<forwar
     for (size_t i = 0; i < query_results.size(); i++) {
         query_results[i] = merge_singular_results(query_results[i], other.query_results[i], reduction_types[i]);
     }
+
+    return *this;
 }
 
 std::ostream& operator<<(std::ostream& out, const query::forward_result::printer& p) {

--- a/service/forward_service.cc
+++ b/service/forward_service.cc
@@ -205,16 +205,9 @@ future<query::forward_result> forward_service::dispatch_to_shards(
         [req, tr_info] (auto& fs) {
             return fs.execute_on_this_shard(req, tr_info);
         },
-        std::optional<query::forward_result>(),
-        [reduction_types = req.reduction_types] (std::optional<query::forward_result> partial, query::forward_result mapped) -> std::optional<query::forward_result>{
-            if (partial) {
-                mapped.merge(*partial, reduction_types);
-            }
-            return {mapped};
-        }
-    ).then(
-        [] (std::optional<query::forward_result> result) {
-            return *result;
+        query::forward_result(),
+        [reduction_types = req.reduction_types] (query::forward_result partial, query::forward_result mapped) -> query::forward_result {
+            return mapped.merge(partial, reduction_types);
         }
     );
 }


### PR DESCRIPTION
This pull request refactores a `forwrd_service::dispatch_to_shards` method. 
Following changes were made:

#### Uncoroutinize

Done to avoid potential misscompilations, requested by @psarna.

Ref: #10446

Backtrace from the referenced issue contained `_ZN7seastar12continuationINS_8internal22promise_base_with_typeIvEEZNS_10map_reduceIN5boost12range_detail16integer_iteratorIjEEZNS_7shardedIN7service15forward_serviceEE11map_reduce0IZNSB_18dispatch_to_shardsEN5query15forward_requestESt8optionalIN7tracing10trace_infoEEE3`. This coroutine is our only suspect left.

#### Change a `map_reduce0` capture list

Capture list now captures only the reduction types.

#### Remove `std::optional` wrapping of initial `map_reduce0` value

Initial value type used to be `std::optional<query::forward_result>`. The optional wrapping caused necessity to unwrap reduced value after completion of the `map_reduce0`. By leveraging the fact that `query::forward_result` can also represent an empty result the code could be refactored to remove `std::optional` wrapping, and thus get rid of `.then()` continuation that only unwrapped the optional.