### PR TITLE
sstables/processing_result_generator.hh: refine check for coroutine standard

### DIFF
--- a/sstables/processing_result_generator.hh
+++ b/sstables/processing_result_generator.hh
@@ -11,7 +11,8 @@
 #include <seastar/core/coroutine.hh>
 #include "sstables/consumer.hh"
 
-#if __cpp_impl_coroutine >= 201902L
+// Clang < 15 only supports the TS
+#if __has_include(<coroutine>) && (!defined(__clang__) || __clang_major__ >= 15)
 #  define COROUTINE_NS std
 #else
 #  define COROUTINE_NS std::experimental


### PR DESCRIPTION
We have a check for whether we can use standard coroutines (in namespace
std) or the technical specification (in std::experimental), but it doesn't
work since Clang doesn't report the correct standard version. Use a
compiler versionspecific check, inspired by Seastar's check.

This allows building with clang 14.