### PR TITLE
Coroutinize distributed loader

### DIFF
--- a/replica/distributed_loader.cc
+++ b/replica/distributed_loader.cc
@@ -245,11 +245,11 @@ distributed_loader::reshape(sharded<sstables::sstable_directory>& dir, sharded<r
         auto& iop = service::get_local_streaming_priority();
         return d.reshape(cm, table, creator, iop, mode, filter);
     }, uint64_t(0), std::plus<uint64_t>());
-    // FIXME: indentation
-        if (total_size > 0) {
-            auto duration = std::chrono::duration_cast<std::chrono::duration<float>>(std::chrono::steady_clock::now() - start);
-            dblog.info("{}", fmt::format("Reshaped {} in {:.2f} seconds, {}", sstables::pretty_printed_data_size(total_size), duration.count(), sstables::pretty_printed_throughput(total_size, duration)));
-        }
+
+    if (total_size > 0) {
+        auto duration = std::chrono::duration_cast<std::chrono::duration<float>>(std::chrono::steady_clock::now() - start);
+        dblog.info("{}", fmt::format("Reshaped {} in {:.2f} seconds, {}", sstables::pretty_printed_data_size(total_size), duration.count(), sstables::pretty_printed_throughput(total_size, duration)));
+    }
 }
 
 // Loads SSTables into the main directory (or staging) and returns how many were loaded

--- a/replica/distributed_loader.cc
+++ b/replica/distributed_loader.cc
@@ -530,26 +530,28 @@ future<> distributed_loader::populate_keyspace(distributed<replica::database>& d
     auto i = keyspaces.find(ks_name);
     if (i == keyspaces.end()) {
         dblog.warn("Skipping undefined keyspace: {}", ks_name);
-        return make_ready_future<>();
-    } else {
+        co_return;
+    }
+
+    // FIXME: reindent
         dblog.info("Populating Keyspace {}", ks_name);
         auto& ks = i->second;
         auto& column_families = db.local().get_column_families();
 
-        return parallel_for_each(ks.metadata()->cf_meta_data() | boost::adaptors::map_values,
-            [ks_name, ksdir, &ks, &column_families, &db] (schema_ptr s) {
+        co_await coroutine::parallel_for_each(ks.metadata()->cf_meta_data() | boost::adaptors::map_values, [&] (schema_ptr s) -> future<> {
                 utils::UUID uuid = s->id();
                 lw_shared_ptr<replica::column_family> cf = column_families[uuid];
                 sstring cfname = cf->schema()->cf_name();
                 auto sstdir = ks.column_family_directory(ksdir, cfname, uuid);
                 dblog.info("Keyspace {}: Reading CF {} id={} version={}", ks_name, cfname, uuid, s->version());
-                return ks.make_directory_for_column_family(cfname, uuid).then([&db, sstdir, uuid, ks_name, cfname] {
-                    return distributed_loader::populate_column_family(db, sstdir + "/" + sstables::staging_dir, ks_name, cfname, allow_offstrategy_compaction::no);
-                }).then([&db, sstdir, ks_name, cfname] {
-                    return distributed_loader::populate_column_family(db, sstdir + "/" + sstables::quarantine_dir, ks_name, cfname, allow_offstrategy_compaction::no, must_exist::no);
-                }).then([&db, sstdir, uuid, ks_name, cfname] {
-                    return distributed_loader::populate_column_family(db, sstdir, ks_name, cfname, allow_offstrategy_compaction::yes);
-                }).handle_exception([ks_name, cfname, sstdir](std::exception_ptr eptr) {
+
+            try {
+                co_await ks.make_directory_for_column_family(cfname, uuid);
+                    co_await distributed_loader::populate_column_family(db, sstdir + "/" + sstables::staging_dir, ks_name, cfname, allow_offstrategy_compaction::no);
+                    co_await distributed_loader::populate_column_family(db, sstdir + "/" + sstables::quarantine_dir, ks_name, cfname, allow_offstrategy_compaction::no, must_exist::no);
+                    co_await distributed_loader::populate_column_family(db, sstdir, ks_name, cfname, allow_offstrategy_compaction::yes);
+            } catch (...) {
+                    std::exception_ptr eptr = std::current_exception();
                     std::string msg =
                         format("Exception while populating keyspace '{}' with column family '{}' from file '{}': {}",
                                ks_name, cfname, sstdir, eptr);
@@ -562,9 +564,8 @@ future<> distributed_loader::populate_keyspace(distributed<replica::database>& d
                     } catch (...) {
                         throw std::runtime_error(msg.c_str());
                     }
-                });
-            });
-    }
+            }
+        });
 }
 
 future<> distributed_loader::init_system_keyspace(distributed<replica::database>& db, distributed<service::storage_service>& ss, sharded<gms::gossiper>& g, db::config& cfg) {

--- a/replica/distributed_loader.cc
+++ b/replica/distributed_loader.cc
@@ -189,21 +189,21 @@ future<> run_resharding_jobs(sharded<sstables::sstable_directory>& dir, std::vec
         co_return;
     }
 
-    // FIXME: indentation
-        auto start = std::chrono::steady_clock::now();
-        dblog.info("{}", fmt::format("Resharding {} for {}.{}", sstables::pretty_printed_data_size(total_size), ks_name, table_name));
+    auto start = std::chrono::steady_clock::now();
+    dblog.info("{}", fmt::format("Resharding {} for {}.{}", sstables::pretty_printed_data_size(total_size), ks_name, table_name));
 
-        co_await dir.invoke_on_all([&] (sstables::sstable_directory& d) -> future<> {
-            auto& table = db.local().find_column_family(ks_name, table_name);
-            auto info_vec = std::move(reshard_jobs[this_shard_id()].info_vec);
-            auto& cm = db.local().get_compaction_manager();
-            auto max_threshold = table.schema()->max_compaction_threshold();
-            auto& iop = service::get_local_streaming_priority();
-            co_await d.reshard(std::move(info_vec), cm, table, max_threshold, creator, iop);
-                co_await d.move_foreign_sstables(dir);
-        });
-            auto duration = std::chrono::duration_cast<std::chrono::duration<float>>(std::chrono::steady_clock::now() - start);
-            dblog.info("{}", fmt::format("Resharded {} for {}.{} in {:.2f} seconds, {}", sstables::pretty_printed_data_size(total_size), ks_name, table_name, duration.count(), sstables::pretty_printed_throughput(total_size, duration)));
+    co_await dir.invoke_on_all([&] (sstables::sstable_directory& d) -> future<> {
+        auto& table = db.local().find_column_family(ks_name, table_name);
+        auto info_vec = std::move(reshard_jobs[this_shard_id()].info_vec);
+        auto& cm = db.local().get_compaction_manager();
+        auto max_threshold = table.schema()->max_compaction_threshold();
+        auto& iop = service::get_local_streaming_priority();
+        co_await d.reshard(std::move(info_vec), cm, table, max_threshold, creator, iop);
+        co_await d.move_foreign_sstables(dir);
+    });
+
+    auto duration = std::chrono::duration_cast<std::chrono::duration<float>>(std::chrono::steady_clock::now() - start);
+    dblog.info("{}", fmt::format("Resharded {} for {}.{} in {:.2f} seconds, {}", sstables::pretty_printed_data_size(total_size), ks_name, table_name, duration.count(), sstables::pretty_printed_throughput(total_size, duration)));
 }
 
 // Global resharding function. Done in two parts:

--- a/replica/distributed_loader.cc
+++ b/replica/distributed_loader.cc
@@ -533,39 +533,38 @@ future<> distributed_loader::populate_keyspace(distributed<replica::database>& d
         co_return;
     }
 
-    // FIXME: reindent
-        dblog.info("Populating Keyspace {}", ks_name);
-        auto& ks = i->second;
-        auto& column_families = db.local().get_column_families();
+    dblog.info("Populating Keyspace {}", ks_name);
+    auto& ks = i->second;
+    auto& column_families = db.local().get_column_families();
 
-        co_await coroutine::parallel_for_each(ks.metadata()->cf_meta_data() | boost::adaptors::map_values, [&] (schema_ptr s) -> future<> {
-                utils::UUID uuid = s->id();
-                lw_shared_ptr<replica::column_family> cf = column_families[uuid];
-                sstring cfname = cf->schema()->cf_name();
-                auto sstdir = ks.column_family_directory(ksdir, cfname, uuid);
-                dblog.info("Keyspace {}: Reading CF {} id={} version={}", ks_name, cfname, uuid, s->version());
+    co_await coroutine::parallel_for_each(ks.metadata()->cf_meta_data() | boost::adaptors::map_values, [&] (schema_ptr s) -> future<> {
+        utils::UUID uuid = s->id();
+        lw_shared_ptr<replica::column_family> cf = column_families[uuid];
+        sstring cfname = cf->schema()->cf_name();
+        auto sstdir = ks.column_family_directory(ksdir, cfname, uuid);
+        dblog.info("Keyspace {}: Reading CF {} id={} version={}", ks_name, cfname, uuid, s->version());
 
+        try {
+            co_await ks.make_directory_for_column_family(cfname, uuid);
+            co_await distributed_loader::populate_column_family(db, sstdir + "/" + sstables::staging_dir, ks_name, cfname, allow_offstrategy_compaction::no);
+            co_await distributed_loader::populate_column_family(db, sstdir + "/" + sstables::quarantine_dir, ks_name, cfname, allow_offstrategy_compaction::no, must_exist::no);
+            co_await distributed_loader::populate_column_family(db, sstdir, ks_name, cfname, allow_offstrategy_compaction::yes);
+        } catch (...) {
+            std::exception_ptr eptr = std::current_exception();
+            std::string msg =
+                format("Exception while populating keyspace '{}' with column family '{}' from file '{}': {}",
+                        ks_name, cfname, sstdir, eptr);
+            dblog.error("Exception while populating keyspace '{}' with column family '{}' from file '{}': {}",
+                        ks_name, cfname, sstdir, eptr);
             try {
-                co_await ks.make_directory_for_column_family(cfname, uuid);
-                    co_await distributed_loader::populate_column_family(db, sstdir + "/" + sstables::staging_dir, ks_name, cfname, allow_offstrategy_compaction::no);
-                    co_await distributed_loader::populate_column_family(db, sstdir + "/" + sstables::quarantine_dir, ks_name, cfname, allow_offstrategy_compaction::no, must_exist::no);
-                    co_await distributed_loader::populate_column_family(db, sstdir, ks_name, cfname, allow_offstrategy_compaction::yes);
+                std::rethrow_exception(eptr);
+            } catch (sstables::compaction_stopped_exception& e) {
+                // swallow compaction stopped exception, to allow clean shutdown.
             } catch (...) {
-                    std::exception_ptr eptr = std::current_exception();
-                    std::string msg =
-                        format("Exception while populating keyspace '{}' with column family '{}' from file '{}': {}",
-                               ks_name, cfname, sstdir, eptr);
-                    dblog.error("Exception while populating keyspace '{}' with column family '{}' from file '{}': {}",
-                                ks_name, cfname, sstdir, eptr);
-                    try {
-                        std::rethrow_exception(eptr);
-                    } catch (sstables::compaction_stopped_exception& e) {
-                        // swallow compaction stopped exception, to allow clean shutdown.
-                    } catch (...) {
-                        throw std::runtime_error(msg.c_str());
-                    }
+                throw std::runtime_error(msg.c_str());
             }
-        });
+        }
+    });
 }
 
 future<> distributed_loader::init_system_keyspace(distributed<replica::database>& db, distributed<service::storage_service>& ss, sharded<gms::gossiper>& g, db::config& cfg) {

--- a/replica/distributed_loader.cc
+++ b/replica/distributed_loader.cc
@@ -91,15 +91,14 @@ distributed_loader::process_sstable_dir(sharded<sstables::sstable_directory>& di
         return utils::directories::verify_owner_and_mode(d.sstable_dir());
     });
 
-    // FIXME: indentation
-      co_await dir.invoke_on_all([&dir, sort_sstables_according_to_owner] (sstables::sstable_directory& d) -> future<> {
+    co_await dir.invoke_on_all([&dir, sort_sstables_according_to_owner] (sstables::sstable_directory& d) -> future<> {
         // Supposed to be called with the node either down or on behalf of maintenance tasks
         // like nodetool refresh
         co_await d.process_sstable_dir(service::get_local_streaming_priority(), sort_sstables_according_to_owner);
-            co_await d.move_foreign_sstables(dir);
-      });
+        co_await d.move_foreign_sstables(dir);
+    });
 
-        co_await dir.invoke_on_all(&sstables::sstable_directory::commit_directory_changes);
+    co_await dir.invoke_on_all(&sstables::sstable_directory::commit_directory_changes);
 }
 
 future<>

--- a/sstables/sstable_directory.cc
+++ b/sstables/sstable_directory.cc
@@ -430,9 +430,9 @@ sstable_directory::do_for_each_sstable(std::function<future<>(sstables::shared_s
 template <typename Container, typename Func>
 future<>
 sstable_directory::parallel_for_each_restricted(Container&& C, Func&& func) {
-    return do_with(std::move(C), [this, func = std::move(func)] (Container& c) mutable {
-      return max_concurrent_for_each(c, _load_parallelism, [this, func = std::move(func)] (auto& el) mutable {
-        return with_semaphore(_load_semaphore, 1, [this, func,  el = std::move(el)] () mutable {
+    return do_with(std::move(C), std::move(func), [this] (Container& c, Func& func) mutable {
+      return max_concurrent_for_each(c, _load_parallelism, [this, &func] (auto& el) mutable {
+        return with_semaphore(_load_semaphore, 1, [this, &func,  el = std::move(el)] () mutable {
             return func(el);
         });
       });


### PR DESCRIPTION
Before touching any of this code for https://github.com/scylladb/scylla/issues/9559,
that requires a change when loading sstables from the staging subdirectory,
simplify it using coroutines.

