### PR TITLE
memtable, cache: Eagerly compact data with tombstones

### DIFF
--- a/db/cache_tracker.hh
+++ b/db/cache_tracker.hh
@@ -78,6 +78,7 @@ private:
     lru _lru;
     mutation_cleaner _garbage;
     mutation_cleaner _memtable_cleaner;
+    mutation_application_stats& _app_stats;
 private:
     void setup_metrics();
 public:

--- a/mutation.cc
+++ b/mutation.cc
@@ -172,6 +172,12 @@ mutation mutation::sliced(const query::clustering_row_ranges& ranges) const {
     return mutation(schema(), decorated_key(), partition().sliced(*schema(), ranges));
 }
 
+mutation mutation::compacted() const {
+    auto m = *this;
+    m.partition().compact_for_compaction(*schema(), always_gc, m.decorated_key(), gc_clock::time_point::min());
+    return m;
+}
+
 mutation reverse(mutation mut) {
     auto reverse_schema = mut.schema()->make_reversed();
     mutation_rebuilder_v2 reverse_rebuilder(reverse_schema);

--- a/mutation.hh
+++ b/mutation.hh
@@ -191,6 +191,12 @@ public:
     unsigned shard_of() const {
         return dht::shard_of(*schema(), token());
     }
+
+    // Returns a mutation which contains the same writes but in a minimal form.
+    // Drops data covered by tombstones.
+    // Does not drop expired tombstones.
+    // Does not expire TTLed data.
+    mutation compacted() const;
 private:
     friend std::ostream& operator<<(std::ostream& os, const mutation& m);
 };

--- a/mutation_cleaner.hh
+++ b/mutation_cleaner.hh
@@ -32,19 +32,23 @@ private:
     lw_shared_ptr<worker> _worker_state;
     mutation_application_stats& _app_stats;
     seastar::scheduling_group _scheduling_group;
+    std::function<void(size_t)> _on_space_freed;
 private:
     stop_iteration merge_some(partition_snapshot& snp) noexcept;
     stop_iteration merge_some() noexcept;
     void start_worker();
 public:
     mutation_cleaner_impl(logalloc::region& r, cache_tracker* t, mutation_cleaner* cleaner,
-            mutation_application_stats& app_stats, seastar::scheduling_group sg = seastar::current_scheduling_group())
+            mutation_application_stats& app_stats,
+            seastar::scheduling_group sg = seastar::current_scheduling_group(),
+            std::function<void(size_t)> on_space_freed = nullptr)
         : _region(r)
         , _tracker(t)
         , _cleaner(cleaner)
         , _worker_state(make_lw_shared<worker>())
         , _app_stats(app_stats)
         , _scheduling_group(sg)
+        , _on_space_freed(std::move(on_space_freed))
     {
         start_worker();
     }
@@ -104,8 +108,9 @@ class mutation_cleaner final {
     lw_shared_ptr<mutation_cleaner_impl> _impl;
 public:
     mutation_cleaner(logalloc::region& r, cache_tracker* t, mutation_application_stats& app_stats,
-            seastar::scheduling_group sg = seastar::current_scheduling_group())
-        : _impl(make_lw_shared<mutation_cleaner_impl>(r, t, this, app_stats, sg)) {
+            seastar::scheduling_group sg = seastar::current_scheduling_group(),
+            std::function<void(size_t)> on_space_freed = nullptr)
+        : _impl(make_lw_shared<mutation_cleaner_impl>(r, t, this, app_stats, sg, std::move(on_space_freed))) {
     }
 
     mutation_cleaner(mutation_cleaner&&) = delete;

--- a/mutation_compactor.hh
+++ b/mutation_compactor.hh
@@ -194,7 +194,7 @@ private:
             }
         }
         // If we have a previous active tombstone we emit the current one even if it is purged.
-        if (!can_purge || _current_emitted_tombstone) {
+        if (_current_emitted_tombstone || (rtc.tombstone() && !can_purge)) {
             partition_is_not_empty(consumer);
             _current_emitted_tombstone = rtc.tombstone();
             consumer_stop = consumer.consume(std::move(rtc));

--- a/mutation_partition.cc
+++ b/mutation_partition.cc
@@ -2442,6 +2442,12 @@ stop_iteration mutation_cleaner_impl::merge_some(partition_snapshot& snp) noexce
                 return stop_iteration::no;
             }
             try {
+                auto notify = defer([&, dirty_before = region.occupancy().total_space()] {
+                    auto dirty_after = region.occupancy().total_space();
+                    if (_on_space_freed && dirty_before > dirty_after) {
+                        _on_space_freed(dirty_before - dirty_after);
+                    }
+                });
                 return _worker_state->alloc_section(region, [&] {
                     return snp.merge_partition_versions(_app_stats);
                 });

--- a/mutation_partition.cc
+++ b/mutation_partition.cc
@@ -322,6 +322,7 @@ stop_iteration mutation_partition::apply_monotonically(const schema& s, mutation
             rows_entry& e = *i;
             can_gc_fn never_gc = [](tombstone) { return false; };
 
+            ++app_stats.rows_compacted_with_tombstones;
             bool all_dead = e.dummy() || !e.row().compact_and_expire(s,
                                                                      tomb,
                                                                      gc_clock::time_point::min(),  // no TTL expiration
@@ -333,6 +334,7 @@ stop_iteration mutation_partition::apply_monotonically(const schema& s, mutation
                     (e.continuous() && (next_i != _rows.end() && next_i->continuous()));
 
             if (all_dead && e.row().empty() && inside_continuous_range) {
+                ++app_stats.rows_dropped_by_tombstones;
                 i = _rows.erase(i);
                 if (tracker) {
                     tracker->on_remove();

--- a/mutation_partition.hh
+++ b/mutation_partition.hh
@@ -1033,11 +1033,15 @@ public:
 struct mutation_application_stats {
     uint64_t row_hits = 0;
     uint64_t row_writes = 0;
+    uint64_t rows_compacted_with_tombstones = 0;
+    uint64_t rows_dropped_by_tombstones = 0;
     bool has_any_tombstones = false;
 
     mutation_application_stats& operator+=(const mutation_application_stats& other) {
         row_hits += other.row_hits;
         row_writes += other.row_writes;
+        rows_compacted_with_tombstones += other.rows_compacted_with_tombstones;
+        rows_dropped_by_tombstones += other.rows_dropped_by_tombstones;
         has_any_tombstones |= other.has_any_tombstones;
         return *this;
     }

--- a/mutation_partition.hh
+++ b/mutation_partition.hh
@@ -1046,6 +1046,10 @@ struct mutation_application_stats {
 struct apply_resume {
     enum class stage {
         start,
+        range_tombstone_compaction,
+        merging_range_tombstones,
+        partition_tombstone_compaction,
+        merging_rows,
         done
     };
 
@@ -1081,6 +1085,14 @@ struct apply_resume {
     }
 
     operator bool() const { return _stage != stage::done; }
+
+    static apply_resume merging_rows() {
+        return {stage::merging_rows, position_in_partition::for_partition_start()};
+    }
+
+    static apply_resume merging_range_tombstones() {
+        return {stage::merging_range_tombstones, position_in_partition::for_partition_start()};
+    }
 
     static apply_resume done() {
         return {stage::done, position_in_partition::for_partition_start()};

--- a/mutation_partition.hh
+++ b/mutation_partition.hh
@@ -866,6 +866,19 @@ public:
     bool empty() const { return !_deleted_at && _marker.is_missing() && !_cells.size(); }
     deletable_row difference(const schema&, column_kind, const deletable_row& other) const;
 
+    // Expires cells and tombstones. Removes items covered by higher level
+    // tombstones.
+    // Returns true iff the row is still alive.
+    // When empty() after the call, the row can be removed without losing writes
+    // given that tomb will be still in effect for the row after it is removed,
+    // as a range tombstone, partition tombstone, etc.
+    bool compact_and_expire(const schema&,
+                            tombstone tomb,
+                            gc_clock::time_point query_time,
+                            can_gc_fn& can_gc,
+                            gc_clock::time_point gc_before,
+                            compaction_garbage_collector* collector = nullptr);
+
     class printer {
         const schema& _schema;
         const deletable_row& _deletable_row;

--- a/partition_version.cc
+++ b/partition_version.cc
@@ -176,20 +176,30 @@ stop_iteration partition_snapshot::merge_partition_versions(mutation_application
         // This is good for performance because in case we were at the latest version
         // we leave it for incoming writes and they don't have to create a new one.
         partition_version* current = &*v;
+        version_number_type version_no = 0;
         while (current->next() && !current->next()->is_referenced()) {
             current = current->next();
+            ++version_no;
             _version = partition_version_ref(*current);
         }
         while (auto prev = current->prev()) {
             region().allocator().invalidate_references();
             // Here we count writes that overwrote rows from a previous version. Total number of writes does not change.
             mutation_application_stats local_app_stats;
+            // Versions within a snapshot are only removed by this routine so if version
+            // number did not change then we're looking at the same version object.
+            // If the version number changed, it means we now work with a different "current"
+            // due to different conditions of is_referenced() within the version chain.
+            if (!_version_merging_state || version_no != _version_merging_state->first) {
+                _version_merging_state = std::make_pair(version_no, apply_resume());
+            }
             const auto do_stop_iteration = current->partition().apply_monotonically(*schema(),
-                    std::move(prev->partition()), _tracker, local_app_stats, is_preemptible::yes);
+                std::move(prev->partition()), _tracker, local_app_stats, is_preemptible::yes, _version_merging_state->second);
             app_stats.row_hits += local_app_stats.row_hits;
             if (do_stop_iteration == stop_iteration::no) {
                 return stop_iteration::no;
             }
+            _version_merging_state.reset();
             if (prev->is_referenced()) {
                 _version.release();
                 prev->back_reference() = partition_version_ref(*current, prev->back_reference().is_unique_owner());
@@ -197,6 +207,7 @@ stop_iteration partition_snapshot::merge_partition_versions(mutation_application
                 return stop_iteration::yes;
             }
             current_allocator().destroy(prev);
+            --version_no;
         }
     }
     return stop_iteration::yes;
@@ -342,16 +353,19 @@ void partition_entry::apply(logalloc::region& r, mutation_cleaner& cleaner, cons
     partition_snapshot_ptr snp; // Should die after new_version is inserted
     if (!_snapshot) {
         try {
+            apply_resume res;
             if (_version->partition().apply_monotonically(s,
                       std::move(new_version->partition()),
                       no_cache_tracker,
                       app_stats,
-                      is_preemptible::yes) == stop_iteration::yes) {
+                      is_preemptible::yes,
+                      res) == stop_iteration::yes) {
                 current_allocator().destroy(new_version);
                 return;
             } else {
                 // Apply was preempted. Let the cleaner finish the job when snapshot dies
                 snp = read(r, cleaner, s.shared_from_this(), no_cache_tracker);
+                // FIXME: Store res in the snapshot as an optimization to resume from where we left off.
             }
         } catch (...) {
             // fall through

--- a/partition_version.hh
+++ b/partition_version.hh
@@ -256,6 +256,9 @@ public:
     static constexpr phase_type default_phase = 0; // For use with non-evictable snapshots
     static constexpr phase_type min_phase = 1; // Use 1 to prevent underflow on apply_to_incomplete()
     static constexpr phase_type max_phase = std::numeric_limits<phase_type>::max();
+
+    // Ordinal number of a partition version within a snapshot. Starts with 0.
+    using version_number_type = size_t;
 public:
     // Used for determining reference stability.
     // References and iterators into versions owned by the snapshot
@@ -292,6 +295,7 @@ private:
     mutation_cleaner* _cleaner;
     cache_tracker* _tracker;
     boost::intrusive::slist_member_hook<> _cleaner_hook;
+    std::optional<std::pair<version_number_type, apply_resume>> _version_merging_state;
     bool _locked = false;
     friend class partition_entry;
     friend class mutation_cleaner_impl;

--- a/partition_version.hh
+++ b/partition_version.hh
@@ -538,8 +538,19 @@ public:
     // Assumes this instance and mp are fully continuous.
     // Use only on non-evictable entries.
     // Must not be called when is_locked().
-    void apply(const schema& s, const mutation_partition& mp, const schema& mp_schema, mutation_application_stats& app_stats);
-    void apply(const schema& s, mutation_partition&& mp, const schema& mp_schema, mutation_application_stats& app_stats);
+    void apply(logalloc::region&,
+               mutation_cleaner&,
+               const schema& s,
+               const mutation_partition& mp,
+               const schema& mp_schema,
+               mutation_application_stats& app_stats);
+
+    void apply(logalloc::region&,
+               mutation_cleaner&,
+               const schema& s,
+               mutation_partition&& mp,
+               const schema& mp_schema,
+               mutation_application_stats& app_stats);
 
     // Adds mutation_partition represented by "other" to the one represented
     // by this entry.

--- a/replica/memtable.cc
+++ b/replica/memtable.cc
@@ -118,7 +118,8 @@ memtable::memtable(schema_ptr schema, dirty_memory_manager& dmm, replica::table_
     memtable_list* memtable_list, seastar::scheduling_group compaction_scheduling_group)
         : logalloc::region(dmm.region_group())
         , _dirty_mgr(dmm)
-        , _cleaner(*this, no_cache_tracker, table_stats.memtable_app_stats, compaction_scheduling_group)
+        , _cleaner(*this, no_cache_tracker, table_stats.memtable_app_stats, compaction_scheduling_group,
+                   [this] (size_t freed) { remove_flushed_memory(freed); })
         , _memtable_list(memtable_list)
         , _schema(std::move(schema))
         , partitions(dht::raw_token_less_comparator{})

--- a/replica/memtable.cc
+++ b/replica/memtable.cc
@@ -778,7 +778,7 @@ memtable::apply(const mutation& m, db::rp_handle&& h) {
         _allocating_section(*this, [&, this] {
             auto& p = find_or_create_partition(m.decorated_key());
             _stats_collector.update(*m.schema(), m.partition());
-            p.apply(*_schema, m.partition(), *m.schema(), _table_stats.memtable_app_stats);
+            p.apply(region(), cleaner(), *_schema, m.partition(), *m.schema(), _table_stats.memtable_app_stats);
         });
     });
     update(std::move(h));
@@ -793,7 +793,7 @@ memtable::apply(const frozen_mutation& m, const schema_ptr& m_schema, db::rp_han
             partition_builder pb(*m_schema, mp);
             m.partition().accept(*m_schema, pb);
             _stats_collector.update(*m_schema, mp);
-            p.apply(*_schema, std::move(mp), *m_schema, _table_stats.memtable_app_stats);
+            p.apply(region(), cleaner(), *_schema, std::move(mp), *m_schema, _table_stats.memtable_app_stats);
         });
     });
     update(std::move(h));

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -776,6 +776,8 @@ void table::set_metrics() {
                 ms::make_counter("memtable_partition_hits", _stats.memtable_partition_hits, ms::description("Number of times a write operation was issued on an existing partition in memtables"))(cf)(ks),
                 ms::make_counter("memtable_row_writes", _stats.memtable_app_stats.row_writes, ms::description("Number of row writes performed in memtables"))(cf)(ks),
                 ms::make_counter("memtable_row_hits", _stats.memtable_app_stats.row_hits, ms::description("Number of rows overwritten by write operations in memtables"))(cf)(ks),
+                ms::make_counter("memtable_rows_dropped_by_tombstones", _stats.memtable_app_stats.rows_dropped_by_tombstones, ms::description("Number of rows dropped in memtables by a tombstone write"))(cf)(ks),
+                ms::make_counter("memtable_rows_compacted_with_tombstones", _stats.memtable_app_stats.rows_compacted_with_tombstones, ms::description("Number of rows scanned during write of a tombstone for the purpose of compaction in memtables"))(cf)(ks),
                 ms::make_counter("memtable_range_tombstone_reads", _stats.memtable_range_tombstone_reads, ms::description("Number of range tombstones read from memtables"))(cf)(ks),
                 ms::make_counter("memtable_row_tombstone_reads", _stats.memtable_row_tombstone_reads, ms::description("Number of row tombstones read from memtables"))(cf)(ks),
                 ms::make_gauge("pending_tasks", ms::description("Estimated number of tasks pending for this column family"), _stats.pending_flushes)(cf)(ks),

--- a/row_cache.cc
+++ b/row_cache.cc
@@ -60,6 +60,7 @@ static thread_local cache_tracker* current_tracker;
 cache_tracker::cache_tracker(mutation_application_stats& app_stats, register_metrics with_metrics)
     : _garbage(_region, this, app_stats)
     , _memtable_cleaner(_region, nullptr, app_stats)
+    , _app_stats(app_stats)
 {
     if (with_metrics) {
         setup_metrics();
@@ -114,6 +115,8 @@ cache_tracker::setup_metrics() {
         sm::make_counter("row_insertions", sm::description("total number of rows added to cache"), _stats.row_insertions),
         sm::make_counter("row_evictions", sm::description("total number of rows evicted from cache"), _stats.row_evictions),
         sm::make_counter("row_removals", sm::description("total number of invalidated rows"), _stats.row_removals),
+        sm::make_counter("rows_dropped_by_tombstones", _app_stats.rows_dropped_by_tombstones, sm::description("Number of rows dropped in cache by a tombstone write")),
+        sm::make_counter("rows_compacted_with_tombstones", _app_stats.rows_compacted_with_tombstones, sm::description("Number of rows scanned during write of a tombstone for the purpose of compaction in cache")),
         sm::make_counter("static_row_insertions", sm::description("total number of static rows added to cache"), _stats.static_row_insertions),
         sm::make_counter("concurrent_misses_same_key", sm::description("total number of operation with misses same key"), _stats.concurrent_misses_same_key),
         sm::make_counter("partition_merges", sm::description("total number of partitions merged"), _stats.partition_merges),

--- a/test/boost/flat_mutation_reader_test.cc
+++ b/test/boost/flat_mutation_reader_test.cc
@@ -37,6 +37,7 @@
 #include "readers/from_mutations_v2.hh"
 #include "readers/from_fragments_v2.hh"
 #include "readers/forwardable_v2.hh"
+#include "readers/compacting.hh"
 
 struct mock_consumer {
     struct result {
@@ -907,9 +908,17 @@ SEASTAR_THREAD_TEST_CASE(test_reverse_reader_reads_in_native_reverse_order) {
         reverse_mt->apply(mut.build(reverse_schema));
     }
 
-    auto reversed_forward_reader = assert_that(make_reversing_reader(forward_mt->make_flat_reader(forward_schema, permit), query::max_result_size(1 << 20)));
+    auto compacted = [] (flat_mutation_reader_v2 rd) {
+        return make_compacting_reader(std::move(rd),
+                                      gc_clock::time_point::max(),
+                                      [] (const dht::decorated_key&) { return api::max_timestamp; });
+    };
 
-    auto reverse_reader = reverse_mt->make_flat_reader(reverse_schema, permit);
+    auto reversed_forward_reader = assert_that(compacted(
+            make_reversing_reader(forward_mt->make_flat_reader(forward_schema, permit),
+                                  query::max_result_size(1 << 20))));
+
+    auto reverse_reader = compacted(reverse_mt->make_flat_reader(reverse_schema, permit));
     auto deferred_reverse_close = deferred_close(reverse_reader);
 
     while (auto mf_opt = reverse_reader().get()) {

--- a/test/boost/memtable_test.cc
+++ b/test/boost/memtable_test.cc
@@ -793,10 +793,11 @@ SEASTAR_TEST_CASE(failed_flush_prevents_writes) {
 
         utils::get_local_injector().enable("table_seal_active_memtable_pre_flush");
 
-        // Trigger flush
-        dmm.notify_soft_pressure();
-
-        BOOST_ASSERT(eventually_true([&db]() { return db.cf_stats()->failed_memtables_flushes_count != 0; }));
+        BOOST_ASSERT(eventually_true([&] {
+            // Trigger flush
+            dmm.notify_soft_pressure();
+            return db.cf_stats()->failed_memtables_flushes_count != 0;
+        }));
 
         // The flush failed, make sure there is still data in memtable.
         BOOST_ASSERT(!t.active_memtable().empty());

--- a/test/boost/mutation_reader_test.cc
+++ b/test/boost/mutation_reader_test.cc
@@ -2660,6 +2660,37 @@ SEASTAR_THREAD_TEST_CASE(test_compacting_reader_next_partition) {
     reader_assertions.produces_end_of_stream();
 }
 
+SEASTAR_THREAD_TEST_CASE(test_compacting_reader_is_consistent_with_compaction) {
+    simple_schema ss;
+    schema_ptr s = ss.schema();
+    tests::reader_concurrency_semaphore_wrapper semaphore;
+    auto permit = semaphore.make_permit();
+
+    auto m = ss.new_mutation("pk");
+
+    auto r = ss.make_ckey_range(1, 2);
+    auto rt = ss.new_tombstone();
+    ss.delete_range(m, r, rt);
+
+    auto p_tomb = ss.new_tombstone();
+    m.partition().apply(p_tomb);
+
+    auto read_m = [&] {
+        return make_flat_mutation_reader_from_mutations_v2(m.schema(), permit, m);
+    };
+
+    assert_that(read_m())
+        .produces_partition_start(m.decorated_key(), p_tomb)
+        .produces_range_tombstone_change({position_in_partition::for_range_start(r), rt})
+        .produces_range_tombstone_change({position_in_partition::for_range_end(r), {}})
+        .produces_partition_end();
+
+    assert_that(make_compacting_reader(read_m(), gc_clock::time_point::min(), [] (const dht::decorated_key&) { return api::min_timestamp; }))
+            .exact()
+            .produces_partition_start(m.decorated_key(), p_tomb)
+            .produces_partition_end();
+}
+
 SEASTAR_THREAD_TEST_CASE(test_auto_paused_evictable_reader_is_mutation_source) {
     auto make_populate = [] (schema_ptr s, const std::vector<mutation>& mutations, gc_clock::time_point query_time) {
         auto mt = make_lw_shared<replica::memtable>(s);

--- a/test/boost/mvcc_test.cc
+++ b/test/boost/mvcc_test.cc
@@ -627,7 +627,7 @@ SEASTAR_TEST_CASE(test_apply_to_incomplete_respects_continuity) {
 
                 e += to_apply;
                 assert_that(s, e.squashed())
-                    .is_equal_to(expected, e_continuity.to_clustering_row_ranges())
+                    .is_equal_to_compacted(expected, e_continuity.to_clustering_row_ranges())
                     .has_same_continuity(before);
             };
 
@@ -685,7 +685,7 @@ SEASTAR_TEST_CASE(test_snapshot_cursor_is_consistent_with_merging) {
                 actual.compact_for_compaction(*s, never_gc, m1.decorated_key(), gc_clock::now());
                 expected.compact_for_compaction(*s, never_gc, m1.decorated_key(), gc_clock::now());
 
-                assert_that(s, actual).is_equal_to(expected);
+                assert_that(s, actual).is_equal_to_compacted(expected);
             }
         }
     });
@@ -725,7 +725,7 @@ SEASTAR_TEST_CASE(test_snapshot_cursor_is_consistent_with_merging_for_nonevictab
                 BOOST_REQUIRE(actual.is_fully_continuous());
 
                 assert_that(s, actual)
-                    .is_equal_to(expected);
+                    .is_equal_to_compacted(expected);
             }
         });
     });
@@ -765,10 +765,10 @@ SEASTAR_TEST_CASE(test_continuity_merging_in_evictable) {
 
                 assert_that(s, actual)
                     .has_same_continuity(expected)
-                    .is_equal_to(expected);
+                    .is_equal_to_compacted(expected);
                 assert_that(s, actual2)
                     .has_same_continuity(expected)
-                    .is_equal_to(expected);
+                    .is_equal_to_compacted(expected);
             }
         });
     });
@@ -1376,15 +1376,15 @@ SEASTAR_TEST_CASE(test_apply_is_atomic) {
                 } catch (const std::bad_alloc&) {
                     mutation_application_stats app_stats;
                     assert_that(mutation(target.schema(), target.decorated_key(), e.squashed(*target.schema())))
-                        .is_equal_to(target)
+                        .is_equal_to_compacted(target)
                         .has_same_continuity(target);
                     e.apply(r, cleaner, *target.schema(), std::move(m2), *second.schema(), app_stats);
                     assert_that(mutation(target.schema(), target.decorated_key(), e.squashed(*target.schema())))
-                        .is_equal_to(expected)
+                        .is_equal_to_compacted(expected)
                         .has_same_continuity(expected);
                 }
                 assert_that(mutation(target.schema(), target.decorated_key(), e.squashed(*target.schema())))
-                    .is_equal_to(expected)
+                    .is_equal_to_compacted(expected)
                     .has_same_continuity(expected);
             }
         });
@@ -1429,7 +1429,7 @@ SEASTAR_TEST_CASE(test_versions_are_merged_when_snapshots_go_away) {
                 cleaner.drain().get();
 
                 BOOST_REQUIRE_EQUAL(1, boost::size(e.versions()));
-                assert_that(s, e.squashed(*s)).is_equal_to((m1 + m2).partition());
+                assert_that(s, e.squashed(*s)).is_equal_to_compacted((m1 + m2).partition());
             }
 
             {
@@ -1450,7 +1450,7 @@ SEASTAR_TEST_CASE(test_versions_are_merged_when_snapshots_go_away) {
                 cleaner.drain().get();
 
                 BOOST_REQUIRE_EQUAL(1, boost::size(e.versions()));
-                assert_that(s, e.squashed(*s)).is_equal_to((m1 + m2).partition());
+                assert_that(s, e.squashed(*s)).is_equal_to_compacted((m1 + m2).partition());
             }
         });
     });

--- a/test/boost/row_cache_test.cc
+++ b/test/boost/row_cache_test.cc
@@ -762,8 +762,8 @@ SEASTAR_TEST_CASE(test_reading_from_random_partial_partition) {
         auto rd2 = cache.make_reader(gen.schema(), semaphore.make_permit());
         rd2.fill_buffer().get();
 
-        assert_that(std::move(rd1)).next_mutation().is_equal_to(m1);
-        assert_that(std::move(rd2)).next_mutation().is_equal_to(m1 + m2);
+        assert_that(std::move(rd1)).next_mutation().is_equal_to_compacted(m1);
+        assert_that(std::move(rd2)).next_mutation().is_equal_to_compacted(m1 + m2);
     });
 }
 
@@ -1645,7 +1645,7 @@ SEASTAR_TEST_CASE(test_mvcc) {
                 assert(mt1_reader_opt);
                 auto mt1_reader_mutation = read_mutation_from_flat_mutation_reader(*mt1_reader_opt).get0();
                 BOOST_REQUIRE(mt1_reader_mutation);
-                assert_that(*mt1_reader_mutation).is_equal_to(m2);
+                assert_that(*mt1_reader_mutation).is_equal_to_compacted(m2);
             }
 
             assert_that(std::move(rd4)).produces(m12);
@@ -3405,6 +3405,7 @@ SEASTAR_TEST_CASE(test_concurrent_reads_and_eviction) {
 
                     auto&& ranges = native_slice.row_ranges(*rd.schema(), actual.key());
                     actual.partition().mutable_row_tombstones().trim(*rd.schema(), ranges);
+                    actual = std::move(actual).compacted();
 
                     auto n_to_consider = last_generation - oldest_generation + 1;
                     auto possible_versions = boost::make_iterator_range(versions.end() - n_to_consider, versions.end());
@@ -3413,6 +3414,7 @@ SEASTAR_TEST_CASE(test_concurrent_reads_and_eviction) {
                         if (reversed) {
                             m2 = reverse(std::move(m2));
                         }
+                        m2 = std::move(m2).compacted();
                         if (n_to_consider == 1) {
                             assert_that(actual).is_equal_to(m2);
                         }

--- a/test/lib/flat_mutation_reader_assertions.hh
+++ b/test/lib/flat_mutation_reader_assertions.hh
@@ -395,7 +395,7 @@ public:
             BOOST_FAIL(format("Expected {}, but got end of stream, at: {}", m, seastar::current_backtrace()));
         }
         memory::scoped_critical_alloc_section dfg;
-        assert_that(*mo).is_equal_to(m, ck_ranges);
+        assert_that(*mo).is_equal_to_compacted(m, ck_ranges);
         return *this;
     }
 

--- a/test/lib/flat_mutation_reader_assertions.hh
+++ b/test/lib/flat_mutation_reader_assertions.hh
@@ -45,6 +45,7 @@ class flat_reader_assertions_v2 {
     flat_mutation_reader_v2 _reader;
     dht::partition_range _pr;
     bool _ignore_deletion_time = false;
+    bool _exact = false; // Don't ignore irrelevant fragments
     tombstone _rt;
 private:
     mutation_fragment_v2* peek_next() {
@@ -68,7 +69,9 @@ private:
         return nullptr;
     }
     mutation_fragment_v2_opt read_next() {
-        peek_next();
+        if (!_exact) {
+            peek_next();
+        }
         return _reader().get0();
     }
     range_tombstone_change maybe_drop_deletion_time(const range_tombstone_change& rt) const {
@@ -109,6 +112,11 @@ public:
 
     flat_reader_assertions_v2&& ignore_deletion_time(bool ignore = true) {
         _ignore_deletion_time = ignore;
+        return std::move(*this);
+    }
+
+    flat_reader_assertions_v2&& exact(bool exact = true) {
+        _exact = exact;
         return std::move(*this);
     }
 

--- a/test/lib/mutation_assertions.hh
+++ b/test/lib/mutation_assertions.hh
@@ -15,6 +15,13 @@
 class mutation_partition_assertion {
     schema_ptr _schema;
     const mutation_partition& _m;
+private:
+    static mutation_partition compacted(const schema& s, const mutation_partition& m) {
+        mutation_partition res(s, m);
+        auto key = dht::decorate_key(s, partition_key::make_empty());
+        res.compact_for_compaction(s, always_gc, key, gc_clock::time_point::min());
+        return res;
+    }
 public:
     mutation_partition_assertion(schema_ptr s, const mutation_partition& m)
         : _schema(s)
@@ -44,6 +51,19 @@ public:
                               mutation_partition::printer(s, other), mutation_partition::printer(*_schema, _m)));
         }
         return *this;
+    }
+
+    mutation_partition_assertion& is_equal_to_compacted(const schema& s,
+                                                        const mutation_partition& other,
+                                                        const std::optional<query::clustering_row_ranges>& ck_ranges = {}) {
+        mutation_partition_assertion(s.shared_from_this(), compacted(s, _m))
+            .is_equal_to(compacted(s, other), ck_ranges);
+        return *this;
+    }
+
+    mutation_partition_assertion& is_equal_to_compacted(const mutation_partition& other,
+                                                        const std::optional<query::clustering_row_ranges>& ck_ranges = {}) {
+        return is_equal_to_compacted(*_schema, other, ck_ranges);
     }
 
     mutation_partition_assertion& is_not_equal_to(const mutation_partition& other) {
@@ -97,6 +117,11 @@ public:
         if (other != _m) {
             BOOST_FAIL(format("Mutation inequality is not symmetric for {}\n ...and: {}", other, _m));
         }
+        return *this;
+    }
+
+    mutation_assertion& is_equal_to_compacted(const mutation& other, const std::optional<query::clustering_row_ranges>& ck_ranges = {}) {
+        mutation_assertion(_m.compacted()).is_equal_to(other.compacted(), ck_ranges);
         return *this;
     }
 


### PR DESCRIPTION
When memtable receives a tombstone it can happen under some workloads
that it covers data which is still in the memtable. Some workloads may
insert and delete data within a short time frame. We could reduce the
rate of memtable flushes if we eagerly drop tombstoned data.

One workload which benefits is the raft log. It stores a row for each
uncommitted raft entry. When entries are committed they are
deleted. So the live set is expected to be short under normal
conditions.

Fixes #652.