### PR TITLE
add python3-pytest-asyncio

### DIFF
--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -76,6 +76,7 @@ fedora_packages=(
     python3-tabulate
     python3-boto3
     python3-pytest
+    python3-pytest-asyncio
     python3-redis
     dnf-utils
     pigz


### PR DESCRIPTION
Add package pytest-asyncio for async pytest support.

Signed-off-by: Alejo Sanchez <alejo.sanchez@scylladb.com>