### PR TITLE
cql: Remove support for null inside lists of IN values

### DIFF
--- a/cql3/expr/expression.hh
+++ b/cql3/expr/expression.hh
@@ -653,10 +653,6 @@ std::vector<expression> extract_single_column_restrictions_for_column(const expr
 
 std::optional<bool> get_bool_value(const constant&);
 
-// Similar to evaluate(), but ignores any NULL values in the final list value.
-// In an IN restriction nulls can be ignored, because nothing equals NULL.
-constant evaluate_IN_list(const expression&, const query_options&);
-
 // Takes a prepared expression and calculates its value.
 // Evaluates bound values, calls functions and returns just the bytes and type.
 constant evaluate(const expression& e, const query_options&);

--- a/test/boost/restrictions_test.cc
+++ b/test/boost/restrictions_test.cc
@@ -657,7 +657,6 @@ SEASTAR_THREAD_TEST_CASE(scalar_in) {
         require_rows(e, "select r from t where r in (22,25) and s>='25' allow filtering", {{F(25), T("35")}});
         require_rows(e, "select r from t where r in (25) and s>='25' allow filtering", {{F(25), T("35")}});
         require_rows(e, "select r from t where r in (25) allow filtering", {{F(25)}});
-        require_rows(e, "select r from t where r in (null,25) allow filtering", {{F(25)}});
         cquery_nofail(e, "delete from t where p=2");
         require_rows(e, "select r from t where r in (22,25) allow filtering", {{F(25)}});
         require_rows(e, "select s from t where s in ('34','35') allow filtering", {{T("34")}, {T("34")}, {T("35")}});
@@ -728,8 +727,6 @@ SEASTAR_THREAD_TEST_CASE(map_in) {
                          {{c1a}, {c1b}});
         require_rows(e, "select c from t where c in ({10:11}, {10:10}, {10:10,11:11}) and r=12 allow filtering",
                          {{c1b, I(12)}});
-        require_rows(e, "select c from t where c in ({10:11}, {10:10}, {10:10,11:11}) and r in (12,null) "
-                         "allow filtering", {{c1b, I(12)}});
         require_rows(e, "select c from t where c in ({10:11}, {10:10}, {10:10,11:11}) and p in ({1:1},{2:2})",
                      {{c1a}, {c1b}});
     }).get();


### PR DESCRIPTION
Currently we support queries like:
```cql
SELECT * FROM ks.tab WHERE p IN (1, 2, null, 4);
```
Nothing can be equal to null so this is equivalent to:
```cql
SELECT * FROM ks.tab WHERE p IN (1, 2, 4);
```

Cassandra doesn't support it at all.
```cql
> SELECT * FROM ks.tab WHERE p IN (1, 2, null, 4)
Error: DbError(Invalid, "Invalid null value in condition for column p")

> SELECT * FROM ks.tab WHERE p IN (1, 2, ?, 4) # ? is NULL
Error: DbError(Invalid, "Invalid null value in condition for column p")

> SELECT * FROM ks.tab WHERE p IN ? # ? is (1, 2, null, 4)
Error: DbError(Invalid, "Invalid null value in condition for column p")
```
It makes little sense to send a null inside list of IN values and supporting it is a bit cumbersome.

Supporting it causes trouble because internally the values are represented as a list, not a tuple, and lists can't contain nulls.
Because of that code requires exceptions because in this single case there can be a null inside of a collection.

This PR starts treating a llist of IN values the same as any other list and as result nulls are forbidden inside them.

In case of a null the message is the same as any other collection:
```
null is not supported inside collections
```
I'm not entirely happy about it - someone could be confused if they received this message after a query that didn't involve any collections.
The problem with making a prettier error message is that once again we would have to give `evaluate` additional information that it's now evaluating a list of IN values. And we would end up back with `evaluate_IN_list`

I think we could consider adding some kind of generic context to evaluate. The context would contain the whole expression and a mark on the part that we are currently evaluating. Then in case of error we could use this context and use it to create more helpful error messages, e.g. point to the part of the expression where a problem occured. But that's outside of the scope of this PR.

Fixes #10579