### PR TITLE
test/cql-pytest: have new_test_table() recycle table names

### DIFF
--- a/test/cql-pytest/util.py
+++ b/test/cql-pytest/util.py
@@ -62,17 +62,26 @@ def new_test_keyspace(cql, opts):
         cql.execute("DROP KEYSPACE " + keyspace)
 
 # A utility function for creating a new temporary table with a given schema.
-# It can be used in a "with", as:
-#   with new_test_table(cql, keyspace, '...') as table:
-# This is not a fixture - see those in conftest.py.
+# Because Scylla becomes slower when a huge number of uniquely-named tables
+# are created and deleted (see https://github.com/scylladb/scylla/issues/7620)
+# we keep here a list of previously used but now deleted table names, and
+# reuse one of these names when possible.
+# This function can be used in a "with", as:
+#   with create_table(cql, test_keyspace, '...') as table:
+previously_used_table_names = []
 @contextmanager
 def new_test_table(cql, keyspace, schema, extra=""):
-    table = keyspace + "." + unique_name()
+    global previously_used_table_names
+    if not previously_used_table_names:
+        previously_used_table_names.append(unique_name())
+    table_name = previously_used_table_names.pop()
+    table = keyspace + "." + table_name
     cql.execute("CREATE TABLE " + table + "(" + schema + ")" + extra)
     try:
         yield table
     finally:
         cql.execute("DROP TABLE " + table)
+        previously_used_table_names.append(table_name)
 
 
 # A utility function for creating a new temporary user-defined function.


### PR DESCRIPTION
Scylla has a long-standing bug (issue #7620) where having many
tombstones in the schema table significantly slows down further
schema operations.

Many cql-pytest tests use new_test_table() to create a temporary test
table with a specific schema. Before this patch, each temporary table
was created with a random name, and deleted after the test. When
running many tests on the same Scylla server, this results in a lot
of tombstones in the schema tables, and really slow schema operations.
For example, look at home much time it takes to run the same test file
N times:

$ test/cql-pytest/run --count N test_filtering.py

 N=25 -  16 seconds (total time for the N repetitions)
 N=50 -  41 seconds
N=100 - 122 seconds

Notice how progressively slower each repetition is becoming - the
total test time should have been linear in N, but it isn't!

In this patch, we keep a cache of already-deleted table names (not the
tables, just their names!) so as to reuse the same name when we can
instead of inventing a new random name. With this patch, the performance
improvement after some repetitions is amazing (compare to the table above):

 N=25 - 14 seconds
 N=50 - 29 seconds
N=100 - 46 seconds

Note how the testing time is now more-or-less linear in the number of
repetitions, as expected.

The table-name recycling trick is the same trick I already used in the
past for the translated Cassandra tests (test/cql-pytest/cassandra_tests).
The problem was even more obvious there because those tests create a
lot of different tables. But the same problem also exists in cql-pytest
in general, so let's solve it here too.

Refs #7620

Signed-off-by: Nadav Har'El <nyh@scylladb.com>