### PR TITLE
raft: test non-voters in `randomized_nemesis_test`

### DIFF
--- a/raft/raft.cc
+++ b/raft/raft.cc
@@ -13,7 +13,7 @@ namespace raft {
 seastar::logger logger("raft");
 
 std::ostream& operator<<(std::ostream& os, const raft::server_address& addr) {
-    return os << addr.id;
+    return os << format("{{.id={} .can_vote={}}}", addr.id, addr.can_vote);
 }
 
 std::ostream& operator<<(std::ostream& os, const raft::configuration& cfg) {

--- a/raft/server.hh
+++ b/raft/server.hh
@@ -59,6 +59,13 @@ public:
     //
     // The caller may pass a pointer to an abort_source to make the operation abortable.
     // If abort is requested before the operation finishes, the future will contain `raft::request_aborted` exception.
+    //
+    // Successfull `add_entry` with `wait_type::committed` does not guarantee that `state_machine::apply` will be called
+    // locally for this entry. Between the commit and the application we may receive a snapshot containing this entry,
+    // so the state machine's state 'jumps' forward in time, skipping the entry application.
+    // However, for `wait_type::applied`, we guarantee that the entry will be applied locally with `state_machine::apply`.
+    // If a snapshot causes the state machine to jump over the entry, `add_entry` will return `commit_status_unknown`
+    // (even if the snapshot included that entry).
     virtual future<> add_entry(command command, wait_type type, seastar::abort_source* as = nullptr) = 0;
 
     // Set a new cluster configuration. If the configuration is

--- a/raft/tracker.cc
+++ b/raft/tracker.cc
@@ -216,15 +216,15 @@ template index_t tracker::committed(index_t);
 template read_id tracker::committed(read_id);
 
 votes::votes(configuration configuration)
-        :_voters(configuration.current)
-        , _current(configuration.current) {
+        : _current(configuration.current) {
+    for (auto* cfg: {&configuration.previous, &configuration.current}) {
+        std::copy_if(cfg->begin(), cfg->end(), std::inserter(_voters, _voters.end()),
+                [] (const server_address& srv) { return srv.can_vote; });
+    }
 
     if (configuration.is_joint()) {
         _previous.emplace(configuration.previous);
-        _voters.insert(configuration.previous.begin(), configuration.previous.end());
     }
-    // Filter out non voting members
-    std::erase_if(_voters, [] (const server_address& s) { return !s.can_vote; });
 }
 
 void votes::register_vote(server_id from, bool granted) {

--- a/raft/tracker.hh
+++ b/raft/tracker.hh
@@ -193,6 +193,8 @@ class votes {
 public:
     votes(configuration configuration);
 
+    // A server is a member of this set iff
+    // it is a voter in the current or previous configuration.
     const server_address_set& voters() const {
         return _voters;
     }


### PR DESCRIPTION
We modify the `reconfigure` and `modify_config` APIs to take a vector of
<server_id, bool> pairs (instead of just a vector of server_ids), where
the bool indicates whether the server is a voter in the modified config.

The `reconfiguration` operation would previously shuffle the set of
servers and split it into two parts: members and non-members. Now it
partitions it into three parts: voters, non-voters, and non-members.

The PR also includes fixes for some liveness problems stumbled upon
during testing.