### PR TITLE
sstable_writer: Fix mutation order violation

### DIFF
--- a/sstables/mx/writer.cc
+++ b/sstables/mx/writer.cc
@@ -1360,6 +1360,9 @@ stop_iteration writer::consume(range_tombstone_change&& rtc) {
     ensure_tombstone_is_written();
     ensure_static_row_is_written_if_needed();
     position_in_partition_view pos = rtc.position();
+    if (!_current_tombstone && !rtc.tombstone()) {
+        return stop_iteration::no;
+    }
     tombstone prev_tombstone = std::exchange(_current_tombstone, rtc.tombstone());
     if (!prev_tombstone) { // start bound
         auto bv = pos.as_start_bound_view();

--- a/test/boost/sstable_mutation_test.cc
+++ b/test/boost/sstable_mutation_test.cc
@@ -36,6 +36,7 @@
 #include "test/lib/log.hh"
 
 #include <boost/range/algorithm/sort.hpp>
+#include "readers/from_fragments_v2.hh"
 
 using namespace sstables;
 using namespace std::chrono_literals;
@@ -1622,3 +1623,67 @@ SEASTAR_TEST_CASE(test_static_compact_tables_are_read) {
         }
     });
 }
+
+SEASTAR_TEST_CASE(writer_handles_subsequent_range_tombstone_changes_without_tombstones) {
+    // This test exposes a problem of a peculiar setup of tombstones that trigger
+    // a mutation fragment stream validation exception if stream is compacted.
+    //
+    // Applying tombstones in the order:
+    //
+    // range_tombstone_change pos(ck1), after_all_prefixed, tombstone_timestamp=1
+    // range_tombstone_change pos(ck2), before_all_prefixed, tombstone=NONE
+    // range_tombstone_change pos(NONE), after_all_prefixed, tombstone=NONE
+    //
+    // Can lead to swapping the order of mutations when written and read from
+    // disk via sstable writer. This is caused by conversion of
+    // range_tombstone_change (in memory representation) to range tombstone
+    // marker (on disk representation) and back.
+    //
+    // When this mutation stream is written to disk, the range tombstone
+    // markers type is calculated based on the relationship between
+    // range_tombstone_changes. The RTC series as above produces markers
+    // (start, end, start). When the last marker is loaded from disk, it's kind
+    // gets incorrectly loaded as before_all_prefixed instead of
+    // after_all_prefixed. This leads to incorrect order of mutations.
+    return test_env::do_with_async([] (test_env& env) {
+        for (const auto version : writable_sstable_versions) {
+            schema_ptr s = schema_builder("ks", "cf")
+                .with_column("pk", bytes_type, column_kind::partition_key)
+                .with_column("ck1", bytes_type, column_kind::clustering_key)
+                .with_column("ck2", bytes_type, column_kind::clustering_key)
+                .build();
+            tests::reader_concurrency_semaphore_wrapper sem;
+            partition_key pk{std::vector<bytes>{serialized(make_local_key(s))}};
+            reader_permit p = sem.make_permit();
+            auto make_rtc = [s, p](bound_weight bw, std::vector<bytes>&& ck, tombstone t) {
+                return mutation_fragment_v2(*s, p, range_tombstone_change(
+                    position_in_partition(partition_region::clustered, bw, clustering_key_prefix{std::move(ck)}),
+                    std::move(t)));
+            };
+            std::deque<mutation_fragment_v2> fragments;
+            fragments.emplace_back(*s, p, partition_start(dht::decorate_key(*s, pk), {}));
+            fragments.push_back(make_rtc(bound_weight::after_all_prefixed, {serialized(1l)}, {api::min_timestamp + 1, {}}));
+            fragments.push_back(make_rtc(bound_weight::before_all_prefixed, {serialized(2l)}, {}));
+            fragments.push_back(make_rtc(bound_weight::after_all_prefixed, {}, {}));
+            fragments.emplace_back(*s, p, partition_end{});
+
+            flat_mutation_reader_v2 input_reader = make_flat_mutation_reader_from_fragments(s, p, std::move(fragments));
+            deferred_close dc1{input_reader};
+            sstable_writer_config cfg = env.manager().configure_writer();
+            tmpdir dir;
+            shared_sstable sstable = env.make_sstable(s, dir.path().string(), 0);
+            encoding_stats es;
+            sstable->write_components(std::move(input_reader), 1, s, cfg, es).get();
+            sstable->load().get();
+
+            mutation_fragment_stream_validating_filter f{"mutation_order_violation_test", *s, mutation_fragment_stream_validation_level::clustering_key};
+            auto sstable_reader = sstable->make_reader(s, sem.make_permit(), query::full_partition_range, s->full_slice());
+            deferred_close dc{sstable_reader};
+            sstable_reader.consume_pausable([&f](mutation_fragment_v2 mf) {
+                f(mf);
+                return stop_iteration::no;
+            }).get();
+        }
+    });
+}
+


### PR DESCRIPTION
The change
- adds a test which exposes a problem of a peculiar setup of
tombstones that trigger a mutation fragment stream validation exception
- fixes the problem

Applying tombstones in the order:

range_tombstone_change pos(ck1), after_all_prefixed, tombstone_timestamp=1
range_tombstone_change pos(ck2), before_all_prefixed, tombstone=NONE
range_tombstone_change pos(NONE), after_all_prefixed, tombstone=NONE

Leads to swapping the order of mutations when written and read from
disk via sstable writer. This is caused by conversion of
range_tombstone_change (in memory representation) to range tombstone
marker (on disk representation) and back.

When this mutation stream is written to disk, the range tombstone
markers type is calculated based on the relationship between
range_tombstone_changes. The RTC series as above produces markers
(start, end, start). When the last marker is loaded from disk, it's kind
gets incorrectly loaded as before_all_prefixed instead of
after_all_prefixed. This leads to incorrect order of mutations.

The solution is to skip writing a new range_tombstone_change with empty
tombstone if the last range_tombstone_change already has empty
tombstone. This is redundant information and can be safely removed,
while the logic of encoding RTCs as markers doesn't handle such
redundancy well.

Changelog:
v3
- Moved the test to sstables specific file
- Rewritten the test to explicitly generate the problematic mutation fragments

v2
- skipped writing an RTC if both current and previous RTC have empty tombstone instead of fixing up the tombstone during compaction
- updated commit message

v1
- updated test comment and commit message to properly reflect the operations happening in the test
- updated the commit message with the explanation of the solution


