### PR TITLE
cql3: support list subscripts in WHERE clause

### DIFF
--- a/cql3/expr/to_restriction.cc
+++ b/cql3/expr/to_restriction.cc
@@ -67,14 +67,14 @@ void validate_single_column_relation(const column_value& lhs, oper_t oper, const
     }
 
     if (is_lhs_subscripted) {
-        check_false(lhs_col_type.is_list(),
-                    "Indexes on list entries ({}[index] = value) are not currently supported.",
-                    lhs_col_name);
-        check_true(lhs_col_type.is_map(), "Column {} cannot be used as a map", lhs_col_name);
-        check_true(lhs_col_type.is_multi_cell(),
+        check_true(lhs_col_type.is_map() || lhs_col_type.is_list(), "Column {} cannot be subscripted", lhs_col_name);
+        check_true(!lhs_col_type.is_map() || lhs_col_type.is_multi_cell(),
                    "Map-entry equality predicates on frozen map column {} are not supported",
                    lhs_col_name);
-        check_true(oper == oper_t::EQ, "Only EQ relations are supported on map entries");
+        check_true(!lhs_col_type.is_list() || lhs_col_type.is_multi_cell(),
+                   "List element equality predicates on frozen list column {} are not supported",
+                   lhs_col_name);
+        check_true(oper == oper_t::EQ, "Only EQ relations are supported on map/list entries");
     }
 
     if (lhs_col_type.is_collection()) {

--- a/docs/design-notes/cql-extensions.md
+++ b/docs/design-notes/cql-extensions.md
@@ -130,3 +130,13 @@ in one go, but one can also specify specific primary keys or token ranges,
 which is recommended in order to make the operation less heavyweight
 and allow for running multiple parallel pruning statements for non-overlapping
 token ranges.
+
+## Expressions
+
+### Lists elements for filtering
+
+Subscripting a list in a WHERE clause is supported as are maps.
+
+```cql
+WHERE some_list[:index] = :value
+```

--- a/test/cql-pytest/test_filtering.py
+++ b/test/cql-pytest/test_filtering.py
@@ -194,7 +194,7 @@ def test_filtering_with_subscript(cql, test_keyspace, cassandra_bug):
         # expression - because there will be no rows to filter.
 
         # A subscript is not allowed on a non-map column (in this case, a set)
-        with pytest.raises(InvalidRequest, match='cannot be used as a map'):
+        with pytest.raises(InvalidRequest, match='cannot be subscripted'):
             cql.execute(f"SELECT p FROM {table} WHERE s[2] = 3 ALLOW FILTERING")
         # A wrong type is passed for the subscript is not allowed
         with pytest.raises(InvalidRequest, match=re.escape('key(m1)')):


### PR DESCRIPTION
I noticed that `column_condition` (used in LWT `IF` clause) supports lists.
As part of the Grand Expression Unification we'll need to migrate that to
expressions, so we'll need to support list subscripts.

Use the opportunity to relax the normal filtering to allow filtering on
list subscripts: `WHERE my_list[:index] = :value`.