### PR TITLE
sstables: processing_result_generator: prefer standard coroutines over the technical specification with clang 14

### DIFF
--- a/sstables/processing_result_generator.hh
+++ b/sstables/processing_result_generator.hh
@@ -11,8 +11,8 @@
 #include <seastar/core/coroutine.hh>
 #include "sstables/consumer.hh"
 
-// Clang < 15 only supports the TS
-#if __has_include(<coroutine>) && (!defined(__clang__) || __clang_major__ >= 15)
+// Clang < 14 only supports the TS
+#if __has_include(<coroutine>) && (!defined(__clang__) || __clang_major__ >= 14)
 #  define COROUTINE_NS std
 #else
 #  define COROUTINE_NS std::experimental


### PR DESCRIPTION
Clang up to version 13 supports the coroutines technical specification
(in std::experimental). 15 and above support standard coroutines (in
namespace std). Clang 14 supports both, but with a warning for the
technical specification coroutines.

To avoid the warning, change the threshold for selecting standard
coroutines from clang 15 to clang 14. This follow seastar commit
070ab101e2.