### PR TITLE
set pre-release to be semantic versions

### DIFF
--- a/dist/debian/debian_files_gen.py
+++ b/dist/debian/debian_files_gen.py
@@ -29,7 +29,7 @@ with open('build/SCYLLA-PRODUCT-FILE') as f:
     product = f.read().strip()
 
 with open('build/SCYLLA-VERSION-FILE') as f:
-    version = f.read().strip().replace('.rc', '~rc').replace('_', '-')
+    version = f.read().strip()
 
 with open('build/SCYLLA-RELEASE-FILE') as f:
     release = f.read().strip()


### PR DESCRIPTION
Today we are not using semantic versioning for our pre-release, Let's switch to the following convention for both rpm and deb packages: 
```
4.5.0~rc0 .. 4.5.0~rc1 .. 4.5.0
```

For that we need to remove the replacing of `.rc` with `~rc`

Closes: https://github.com/scylladb/scylla/issues/9543