### PR TITLE
docs: unconfuse doc test checker wrt gdbinit file

### DIFF
--- a/docs/guides/debugging.md
+++ b/docs/guides/debugging.md
@@ -149,8 +149,9 @@ places. You can always load it by hand if GDB refuses or fails to load it:
 
     (gdb) source /path/to/your/.gdbinit
 
-Scylla provides the following [gdbinit](../../gdbinit) file helpful for debugging scylla
-at the root of the source tree.
+Scylla provides a `gdbinit` file helpful for debugging scylla
+at the root of the source tree. You can `source` it from your
+local `.gdbinit` file if you wish.
 
 #### TUI
 


### PR DESCRIPTION
The docs test dislike the gdbinit link because it refers out of
the source tree. Unconfuse the tests by removing the link. It's
sad, but the file is more easily used by referring to it rather
than viewing it, so give a hint about that too.