### PR TITLE
RFC: commitlog allocation/deletion/flush request rate counters + footprint projection

### DIFF
--- a/db/commitlog/commitlog.cc
+++ b/db/commitlog/commitlog.cc
@@ -1446,49 +1446,49 @@ void db::commitlog::segment_manager::create_counters(const sstring& metrics_cate
                                        "A non-zero value indicates that the disk write path became temporary slow.")),
 
         sm::make_counter("alloc", totals.allocation_count,
-                       sm::description("Counts a number of times a new mutation has been added to a segment. "
+                       sm::description("Counts number of times a new mutation has been added to a segment. "
                                        "Divide bytes_written by this value to get the average number of bytes per mutation written to the disk.")),
 
         sm::make_counter("cycle", totals.cycle_count,
-                       sm::description("Counts a number of commitlog write cycles - when the data is written from the internal memory buffer to the disk.")),
+                       sm::description("Counts number of commitlog write cycles - when the data is written from the internal memory buffer to the disk.")),
 
         sm::make_counter("flush", totals.flush_count,
-                       sm::description("Counts a number of times the flush() method was called for a file.")),
+                       sm::description("Counts number of times the flush() method was called for a file.")),
 
         sm::make_counter("bytes_written", totals.bytes_written,
-                       sm::description("Counts a number of bytes written to the disk. "
+                       sm::description("Counts number of bytes written to the disk. "
                                        "Divide this value by \"alloc\" to get the average number of bytes per mutation written to the disk.")),
 
         sm::make_counter("slack", totals.bytes_slack,
-                       sm::description("Counts a number of unused bytes written to the disk due to disk segment alignment.")),
+                       sm::description("Counts number of unused bytes written to the disk due to disk segment alignment.")),
 
         sm::make_gauge("pending_flushes", totals.pending_flushes,
-                       sm::description("Holds a number of currently pending flushes. See the related flush_limit_exceeded metric.")),
+                       sm::description("Holds number of currently pending flushes. See the related flush_limit_exceeded metric.")),
 
         sm::make_gauge("pending_allocations", [this] { return pending_allocations(); },
-                       sm::description("Holds a number of currently pending allocations. "
+                       sm::description("Holds number of currently pending allocations. "
                                        "A non-zero value indicates that we have a bottleneck in the disk write flow.")),
 
         sm::make_counter("requests_blocked_memory", totals.requests_blocked_memory,
-                       sm::description("Counts a number of requests blocked due to memory pressure. "
+                       sm::description("Counts number of requests blocked due to memory pressure. "
                                        "A non-zero value indicates that the commitlog memory quota is not enough to serve the required amount of requests.")),
 
         sm::make_counter("flush_limit_exceeded", totals.flush_limit_exceeded,
                        sm::description(
-                           seastar::format("Counts a number of times a flush limit was exceeded. "
+                           seastar::format("Counts number of times a flush limit was exceeded. "
                                            "A non-zero value indicates that there are too many pending flush operations (see pending_flushes) and some of "
                                            "them will be blocked till the total amount of pending flush operations drops below {}.", cfg.max_active_flushes))),
 
         sm::make_gauge("disk_total_bytes", totals.total_size_on_disk,
-                       sm::description("Holds a size of disk space in bytes reserved for data so far. "
+                       sm::description("Holds size of disk space in bytes reserved for data so far. "
                                        "A too high value indicates that we have some bottleneck in the writing to sstables path.")),
 
         sm::make_gauge("disk_active_bytes", totals.active_size_on_disk,
-                       sm::description("Holds a size of disk space in bytes used for data so far. "
+                       sm::description("Holds size of disk space in bytes used for data so far. "
                                        "A too high value indicates that we have some bottleneck in the writing to sstables path.")),
 
         sm::make_gauge("disk_slack_end_bytes", totals.wasted_size_on_disk,
-                       sm::description("Holds a size of disk space in bytes unused because of segment switching (end slack). "
+                       sm::description("Holds size of disk space in bytes unused because of segment switching (end slack). "
                                        "A too high value indicates that we do not write enough data to each segment.")),
 
         sm::make_gauge("memory_buffer_bytes", totals.buffer_list_bytes,


### PR DESCRIPTION
Adds measuring the apparent delta vector of footprint added/removed within
the timer time slice, and potentially include this (if influx is greater
than data removed) in threshold calculation. The idea is to anticipate
crossing usage threshold within a time slice, so request a flush slightly
earlier, hoping this will give all involved more time to do their disk
work.

Obviously, this is very akin to just adjusting the threshold downwards,
but the slight difference is that we take actual transaction rate vs.
segment free rate into account, not just static footprint.

Note: this is a very simplistic version of this anticipation scheme,
we just use the "raw" delta for the timer slice.
A more sophisiticated approach would perhaps do either a lowpass
filtered rate (adjust over longer time), or a regression or whatnot.
But again, the default persiod of 10s is something of an eternity,
so maybe that is superfluous...