### PR TITLE
main: defer_verbose_shutdown: do not abort on expected low-level exceptions

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -385,6 +385,14 @@ static auto defer_verbose_shutdown(const char* what, Func&& func) {
                         break;
                     }
                 }
+            } catch (const seastar::abort_requested_exception&) {
+                do_abort = false;
+            } catch (const seastar::broken_semaphore&) {
+                do_abort = false;
+            } catch (const seastar::gate_closed_exception&) {
+                do_abort = false;
+            } catch (const utils::barrier_aborted_exception&) {
+                do_abort = false;
             } catch (...) {
             }
             auto msg = fmt::format("Unexpected error shutting down {}: {}", what, ex);


### PR DESCRIPTION
We may hit spurious exceptions when shutting down
caused be broken or aborted semaphores, and/or closed gates.

Today scylla aborts in these case, leaving a core dump behind,
but that's not very useful since unfortunately these errors,
are rare and can be expected until the shutdown path is squeacky clean
and all such errors are handled and swallawed by each shutdown
path that may hit them.

Instead, let's just print the error (with a backtrace) and exit cleanly.

For example, see https://jenkins.scylladb.com/view/master/job/scylla-master/job/dtest-daily-debug/14/artifact/logs-full.debug.029/1653301262444_alternator_stream_tests.py%3A%3ATestAlternatorStreams%3A%3Atest_updated_shards_during_add_decommission_node/node6.log
```
ERROR 2022-05-23 10:20:54,106 [shard 0] init - Unexpected error shutting down database: seastar::named_semaphore_aborted (Semaphore aborted: off-strategy compaction): aborting
Aborting on shard 0.
```

Decoded:
```
operator() at ./main.cc:393
~deferred_action at ././seastar/include/seastar/util/defer.hh:63
~shared_ptr_count_for at ././seastar/include/seastar/core/shared_ptr.hh:464
~shared_ptr_count_for at ././seastar/include/seastar/core/shared_ptr.hh:464
~shared_ptr at ././seastar/include/seastar/core/shared_ptr.hh:537
operator() at ./main.cc:1541
```

Signed-off-by: Benny Halevy <bhalevy@scylladb.com>