### PR TITLE
alternator: add Describe operations even if a feature is not supported

### DIFF
--- a/alternator/error.hh
+++ b/alternator/error.hh
@@ -73,6 +73,9 @@ public:
     static api_error serialization(std::string msg) {
         return api_error("SerializationException", std::move(msg));
     }
+    static api_error table_not_found(std::string msg) {
+        return api_error("TableNotFoundException", std::move(msg));
+    }
     static api_error internal(std::string msg) {
         return api_error("InternalServerError", std::move(msg), reply::status_type::internal_server_error);
     }

--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -401,10 +401,6 @@ sstring executor::table_name(const schema& s) {
     return s.cf_name();
 }
 
-sstring executor::make_keyspace_name(const sstring& table_name) {
-    return sstring(KEYSPACE_NAME_PREFIX) + table_name;
-}
-
 future<executor::request_return_type> executor::describe_table(client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value request) {
     _stats.api_operations.describe_table++;
     elogger.trace("Describing table {}", request);

--- a/alternator/executor.hh
+++ b/alternator/executor.hh
@@ -196,6 +196,7 @@ public:
     future<request_return_type> describe_stream(client_state& client_state, service_permit permit, rjson::value request);
     future<request_return_type> get_shard_iterator(client_state& client_state, service_permit permit, rjson::value request);
     future<request_return_type> get_records(client_state& client_state, tracing::trace_state_ptr, service_permit permit, rjson::value request);
+    future<request_return_type> describe_continuous_backups(client_state& client_state, service_permit permit, rjson::value request);
 
     future<> start();
     future<> stop() { return make_ready_future<>(); }

--- a/alternator/executor.hh
+++ b/alternator/executor.hh
@@ -213,7 +213,6 @@ private:
     friend class rmw_operation;
 
     static bool is_alternator_keyspace(const sstring& ks_name);
-    static sstring make_keyspace_name(const sstring& table_name);
     static void describe_key_schema(rjson::value& parent, const schema&, std::unordered_map<std::string,std::string> * = nullptr);
     static void describe_key_schema(rjson::value& parent, const schema& schema, std::unordered_map<std::string,std::string>&);
     

--- a/alternator/server.cc
+++ b/alternator/server.cc
@@ -522,6 +522,9 @@ server::server(executor& exec, service::storage_proxy& proxy, gms::gossiper& gos
         {"GetRecords", [] (executor& e, executor::client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value json_request, std::unique_ptr<request> req) {
             return e.get_records(client_state, std::move(trace_state), std::move(permit), std::move(json_request));
         }},
+        {"DescribeContinuousBackups", [] (executor& e, executor::client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value json_request, std::unique_ptr<request> req) {
+            return e.describe_continuous_backups(client_state, std::move(permit), std::move(json_request));
+        }},
     } {
 }
 

--- a/alternator/ttl.cc
+++ b/alternator/ttl.cc
@@ -118,9 +118,6 @@ future<executor::request_return_type> executor::update_time_to_live(client_state
 
 future<executor::request_return_type> executor::describe_time_to_live(client_state& client_state, service_permit permit, rjson::value request) {
     _stats.api_operations.describe_time_to_live++;
-    if (!_proxy.data_dictionary().features().alternator_ttl) {
-        co_return api_error::unknown_operation("DescribeTimeToLive not yet supported. Experimental support is available if the 'alternator_ttl' experimental feature is enabled on all nodes.");
-    }
     schema_ptr schema = get_table(_proxy, request);
     std::map<sstring, sstring> tags_map = get_tags_of_table(schema);
     rjson::value desc = rjson::empty_object();

--- a/test/alternator/test_backup.py
+++ b/test/alternator/test_backup.py
@@ -1,0 +1,40 @@
+# Copyright 2022 ScyllaDB
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+# Tests for the different types of backup and restore features in
+# DynamoDB.
+# Because we didn't implementing this feature yet (see issue #5063), this
+# test suite is very partial.
+
+import pytest
+from botocore.exceptions import ClientError
+
+# Test the DescribeContinuousBackups operation on a table where the
+# continuous backup feature was *not* enabled.
+#
+# Oddly, as of May 2022, this can fail on AWS DynamoDB: Right after a
+# table is created, it has continuous backups disabled - but a few seconds
+# later, it suddenly reports that they are enabled! I don't know how to
+# explain this, but I believe this is not a behavior we should reproduce.
+def test_describe_continuous_backups_without_continuous_backups(test_table):
+    response = test_table.meta.client.describe_continuous_backups(TableName=test_table.name)
+    print(response)
+    assert 'ContinuousBackupsDescription' in response
+    assert 'ContinuousBackupsStatus' in response['ContinuousBackupsDescription']
+    assert response['ContinuousBackupsDescription']['ContinuousBackupsStatus'] == 'DISABLED'
+    assert 'PointInTimeRecoveryDescription' in response['ContinuousBackupsDescription']
+    assert response['ContinuousBackupsDescription']['PointInTimeRecoveryDescription'] == {'PointInTimeRecoveryStatus': 'DISABLED'}
+
+# Test the DescribeContinuousBackups operation on a table that doesn't
+# exist. It should report a TableNotFoundException - not that continuous
+# backups are disabled.
+def test_describe_continuous_backups_nonexistent(test_table):
+    with pytest.raises(ClientError, match='TableNotFoundException'):
+        test_table.meta.client.describe_continuous_backups(TableName=test_table.name+'nonexistent')
+
+# Test the DescribeContinuousBackups operation without a table name.
+# It should fail with ValidationException.
+def test_describe_continuous_backups_missing(test_table):
+    with pytest.raises(ClientError, match='ValidationException'):
+        test_table.meta.client.describe_continuous_backups()


### PR DESCRIPTION
This small series implements the DescribeTimeToLive and DescribeContinuousBackups operations in Alternator. Even if the corresponding features aren't implemented, it can help applications that we implement just the Describe operation that can say that this feature is in fact currently disabled.

Fixes  #10660