### PR TITLE
service: raft: raft_group0: don't call `_abort_source.request_abort()`

### DIFF
--- a/service/raft/raft_group0.cc
+++ b/service/raft/raft_group0.cc
@@ -183,6 +183,11 @@ raft_group0::do_discover_group0(raft::server_address my_addr) {
     }
 }
 
+future<> raft_group0::abort() {
+    return _shutdown_gate.close();
+}
+
+
 future<> raft_group0::join_group0() {
     assert(this_shard_id() == 0);
     // do nothing either if raft group registry is not enabled or we've already

--- a/service/raft/raft_group0.hh
+++ b/service/raft/raft_group0.hh
@@ -92,13 +92,7 @@ public:
         migration_manager& mm,
         raft_group0_client& client);
 
-    future<> abort() {
-        if (!_abort_source.abort_requested()) {
-            _abort_source.request_abort();
-        }
-        return _shutdown_gate.close();
-    }
-
+    future<> abort();
 
     // Join this node to the cluster-wide Raft group
     // Called during bootstrap. Is idempotent - it


### PR DESCRIPTION
`raft_group0` does not own the source and is not responsible for calling
`request_abort`. The source comes from top-level `stop_signal` (see
main.cc) and that's where it's aborted.

Fixes #10668.