### PR TITLE
gms: gossiper: fix `direct_fd_pinger::_generation_number` initialization

### DIFF
--- a/gms/gossiper.hh
+++ b/gms/gossiper.hh
@@ -635,7 +635,7 @@ public:
         std::unordered_map<inet_address, direct_failure_detector::pinger::endpoint_id> _addr_to_id;
 
         // This node's gossip generation number, updated by gossiper's loop and replicated to every shard.
-        int64_t _generation_number;
+        int64_t _generation_number{0};
 
         future<> update_generation_number(int64_t n);
 


### PR DESCRIPTION
It's an `int64_t` that needs to be explicitly initialized, otherwise the
value is undefined.

This is probably the cause of #10639, although I'm not sure - I couldn't
reproduce it (the bug is dependent on how the binary is compiled, so
that's probably it). We'll see if it reproduces with this fix, and if
it will, close the issue.