### PR TITLE
Update seastar submodule

### DIFF
--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -2029,7 +2029,8 @@ public:
         for (auto& ks_data : keyspace_names) {
             co_await result.emit_partition_start(ks_data.key);
 
-            const auto snapshots_by_tables = co_await _db.map_reduce(snapshot_reducer(), [ks_name = ks_data.name] (replica::database& db) -> future<snapshots_by_tables_map> {
+            const auto snapshots_by_tables = co_await _db.map_reduce(snapshot_reducer(), [ks_name_ = ks_data.name] (replica::database& db) mutable -> future<snapshots_by_tables_map> {
+                auto ks_name = std::move(ks_name_);
                 snapshots_by_tables_map snapshots_by_tables;
                 for (auto& [_, table] : db.get_column_families()) {
                     if (table->schema()->ks_name() != ks_name) {


### PR DESCRIPTION
* seastar 96bb3a1b8...2be9677d6 (37):
  > Merge 'stream_range_as_array: always close output stream' from Benny Halevy

Fixes #10592

  > net/api: add "server_socket::is_listening()"
  > src/net/proxy: remove unused variable
  > coroutine: parallel_for_each: relax contraints
  > native-stack: do not use 0 as ip address if !_dhcp
  > coroutine: fix a typo in comment
  > std-coroutine: include for LLVM-14
  > tutorial: use non-variadic version of when_all_succeed()
  > scripts: Fix build.sh to use new --c++-standard config option
  > core/thread: initialize work::pr and work::th explicitly
  > util/log-impl: remove "const" qualifier in return type
  > map_reduce: remove redundant move() in return statement
  > util: mark unused parameter with [[maybe_unused]]
  > drop unused parameters
  > build: use "20" for the default CMAKE_CXX_STANDARD
  > build: make CMAKE_CXX_STANDARD a string
  > utils: log: don't crash on allocation failure while extending log buffer
  > tests: unix_domain_test: fix thread/future confusion in client_round()
  > compat: do not use std::source_location if it is broken
  > build: use CMAKE_CXX_STANDARD instead of Seastar_CXX_DIALECT
  > Merge 'Add hello-world demo from tutorial' from Pavel
  > rpc_tester: Put client/server sides into correct sched groups
  > reactor_backend: Use _r reference, not engine() method
  > future.hh: #include std-compat.hh for SEASTAR_COROUTINES_ENABLED
  > Merge "Add more CPU-hog facilities to RPC-tester" from Pavel E
  > Merge "io: Enlighten queued_request" from Pavel E
  > Correct swapped AIO detection/setup calls
  > sharded: De-duplicate map-reduce overloads
  > file: don't trample on xfs flags when setting xfs size hint
  > Merge "Per-class IO bandwidth limits" from Pavel E
  > Merge 'sstring: fix format and optimize the performance of sstring::find().' from Jianyong Chen
  > reactor_backend: Mark reactor_backend_aio::poll() private
  > scripts/build.sh: Mind if not running on a terminal
  > test, rpc: Don't work with large buffers
  > test, futures: Don't expect ready future to resolve immediately
  > source_location compatibility: Fix an unused private field error when treat warning as errors
  > file: Remove try-catch around noexcept calls