### PR TITLE
memtable flush error handling

### DIFF
--- a/db/commitlog/commitlog.cc
+++ b/db/commitlog/commitlog.cc
@@ -459,9 +459,9 @@ public:
     future<> do_pending_deletes();
     future<> delete_segments(std::vector<sstring>);
 
-    void discard_unused_segments();
-    void discard_completed_segments(const cf_id_type&);
-    void discard_completed_segments(const cf_id_type&, const rp_set&);
+    void discard_unused_segments() noexcept;
+    void discard_completed_segments(const cf_id_type&) noexcept;
+    void discard_completed_segments(const cf_id_type&, const rp_set&) noexcept;
     void on_timer();
     void sync();
     void arm(uint32_t extra = 0) {
@@ -1261,7 +1261,7 @@ public:
         _segment_manager->account_memory_usage(fill_size);
         return size;
     }
-    void mark_clean(const cf_id_type& id, uint64_t count) {
+    void mark_clean(const cf_id_type& id, uint64_t count) noexcept {
         auto i = _cf_dirty.find(id);
         if (i != _cf_dirty.end()) {
             assert(i->second >= count);
@@ -1271,10 +1271,10 @@ public:
             }
         }
     }
-    void mark_clean(const cf_id_type& id) {
+    void mark_clean(const cf_id_type& id) noexcept {
         _cf_dirty.erase(id);
     }
-    void mark_clean() {
+    void mark_clean() noexcept {
         _cf_dirty.clear();
     }
     bool is_still_allocating() const noexcept {
@@ -1855,7 +1855,7 @@ future<db::commitlog::segment_manager::sseg_ptr> db::commitlog::segment_manager:
  * go through all segments, clear id up to pos. if segment becomes clean and unused by this,
  * it is discarded.
  */
-void db::commitlog::segment_manager::discard_completed_segments(const cf_id_type& id, const rp_set& used) {
+void db::commitlog::segment_manager::discard_completed_segments(const cf_id_type& id, const rp_set& used) noexcept {
     auto& usage = used.usage();
 
     clogger.debug("Discarding {}: {}", id, usage);
@@ -1869,7 +1869,7 @@ void db::commitlog::segment_manager::discard_completed_segments(const cf_id_type
     discard_unused_segments();
 }
 
-void db::commitlog::segment_manager::discard_completed_segments(const cf_id_type& id) {
+void db::commitlog::segment_manager::discard_completed_segments(const cf_id_type& id) noexcept {
     clogger.debug("Discard all data for {}", id);
     for (auto&s : _segments) {
         s->mark_clean(id);
@@ -1893,7 +1893,7 @@ std::ostream& operator<<(std::ostream& out, const db::replay_position& p) {
 
 }
 
-void db::commitlog::segment_manager::discard_unused_segments() {
+void db::commitlog::segment_manager::discard_unused_segments() noexcept {
     clogger.trace("Checking for unused segments ({} active)", _segments.size());
 
     std::erase_if(_segments, [=](sseg_ptr s) {

--- a/db_clock.hh
+++ b/db_clock.hh
@@ -33,13 +33,13 @@ public:
     static constexpr time_point from_time_t(std::time_t t) {
         return time_point(std::chrono::duration_cast<duration>(std::chrono::seconds(t)));
     }
-    static time_point now() {
+    static time_point now() noexcept {
         return time_point(std::chrono::duration_cast<duration>(base::now().time_since_epoch())) + get_clocks_offset();
     }
 };
 
 static inline
-gc_clock::time_point to_gc_clock(db_clock::time_point tp) {
+gc_clock::time_point to_gc_clock(db_clock::time_point tp) noexcept {
     // Converting time points through `std::time_t` means that we don't have to make any assumptions about the epochs
     // of `gc_clock` and `db_clock`, though we require that that the period of `gc_clock` is also 1 s like
     // `std::time_t` to avoid loss of information.

--- a/dirty_memory_manager.cc
+++ b/dirty_memory_manager.cc
@@ -46,11 +46,11 @@ region_evictable_occupancy_ascending_less_comparator::operator()(size_tracked_re
 
 region_group_reclaimer region_group::no_reclaimer;
 
-uint64_t region_group::top_region_evictable_space() const {
+uint64_t region_group::top_region_evictable_space() const noexcept {
     return _regions.empty() ? 0 : _regions.top()->evictable_occupancy().total_space();
 }
 
-dirty_memory_manager_logalloc::size_tracked_region* region_group::get_largest_region() {
+dirty_memory_manager_logalloc::size_tracked_region* region_group::get_largest_region() noexcept {
     if (!_maximal_rg || _maximal_rg->_regions.empty()) {
         return nullptr;
     }
@@ -91,7 +91,7 @@ region_group::moved(region* old_address, region* new_address) {
 
 bool
 region_group::execution_permitted() noexcept {
-    return do_for_each_parent(this, [] (auto rg) {
+    return do_for_each_parent(this, [] (auto rg) noexcept {
         return rg->under_pressure() ? stop_iteration::yes : stop_iteration::no;
     }) == nullptr;
 }

--- a/dirty_memory_manager.hh
+++ b/dirty_memory_manager.hh
@@ -575,7 +575,7 @@ public:
         return _virtual_region_group.memory_used();
     }
 
-    future<> flush_one(replica::memtable_list& cf, flush_permit&& permit);
+    future<> flush_one(replica::memtable_list& cf, flush_permit&& permit) noexcept;
 
     future<flush_permit> get_flush_permit() noexcept {
         return get_units(_background_work_flush_serializer, 1).then([this] (auto&& units) {

--- a/dirty_memory_manager.hh
+++ b/dirty_memory_manager.hh
@@ -66,11 +66,11 @@ protected:
     virtual void start_reclaiming() noexcept {}
     virtual void stop_reclaiming() noexcept {}
 public:
-    bool under_pressure() const {
+    bool under_pressure() const noexcept {
         return _under_pressure;
     }
 
-    bool over_soft_limit() const {
+    bool over_soft_limit() const noexcept {
         return _under_soft_pressure;
     }
 
@@ -96,21 +96,21 @@ public:
         _under_pressure = false;
     }
 
-    region_group_reclaimer()
+    region_group_reclaimer() noexcept
         : _threshold(std::numeric_limits<size_t>::max()), _soft_limit(std::numeric_limits<size_t>::max()) {}
-    region_group_reclaimer(size_t threshold)
+    region_group_reclaimer(size_t threshold) noexcept
         : _threshold(threshold), _soft_limit(threshold) {}
-    region_group_reclaimer(size_t threshold, size_t soft)
+    region_group_reclaimer(size_t threshold, size_t soft) noexcept
         : _threshold(threshold), _soft_limit(soft) {
         assert(_soft_limit <= _threshold);
     }
 
     virtual ~region_group_reclaimer() {}
 
-    size_t throttle_threshold() const {
+    size_t throttle_threshold() const noexcept {
         return _threshold;
     }
-    size_t soft_limit_threshold() const {
+    size_t soft_limit_threshold() const noexcept {
         return _soft_limit;
     }
 };

--- a/dirty_memory_manager.hh
+++ b/dirty_memory_manager.hh
@@ -428,7 +428,7 @@ public:
 class flush_permit {
     friend class dirty_memory_manager;
     dirty_memory_manager* _manager;
-    sstable_write_permit _sstable_write_permit;
+    std::optional<sstable_write_permit> _sstable_write_permit;
     semaphore_units<> _background_permit;
 
     flush_permit(dirty_memory_manager* manager, sstable_write_permit&& sstable_write_permit, semaphore_units<>&& background_permit)
@@ -441,7 +441,7 @@ public:
     flush_permit& operator=(flush_permit&&) noexcept = default;
 
     sstable_write_permit release_sstable_write_permit() {
-        return std::move(_sstable_write_permit);
+        return std::exchange(_sstable_write_permit, std::nullopt).value();
     }
 
     future<flush_permit> reacquire_sstable_write_permit() &&;

--- a/dirty_memory_manager.hh
+++ b/dirty_memory_manager.hh
@@ -256,7 +256,7 @@ public:
     }
     region_group& operator=(const region_group&) = delete;
     region_group& operator=(region_group&&) = delete;
-    size_t memory_used() const {
+    size_t memory_used() const noexcept {
         return _total_memory;
     }
     void update(ssize_t delta);
@@ -325,21 +325,21 @@ public:
     // returns a pointer to the largest region (in terms of memory usage) that sits below this
     // region group. This includes the regions owned by this region group as well as all of its
     // children.
-    size_tracked_region* get_largest_region();
+    size_tracked_region* get_largest_region() noexcept;
 
     // Shutdown is mandatory for every user who has set a threshold
     // Can be called at most once.
-    future<> shutdown() {
+    future<> shutdown() noexcept {
         _shutdown_requested = true;
         _relief.signal();
         return std::move(_releaser);
     }
 
-    size_t blocked_requests() {
+    size_t blocked_requests() const noexcept {
         return _blocked_requests.size();
     }
 
-    uint64_t blocked_requests_counter() const {
+    uint64_t blocked_requests_counter() const noexcept {
         return _blocked_requests_counter;
     }
 private:
@@ -355,7 +355,7 @@ private:
     // This method returns a pointer to the region_group that was processed last, or nullptr if the
     // root was reached.
     template <typename Func>
-    static region_group* do_for_each_parent(region_group *node, Func&& func) {
+    static region_group* do_for_each_parent(region_group *node, Func&& func) noexcept(noexcept(func(node))) {
         auto rg = node;
         while (rg) {
             if (func(rg) == stop_iteration::yes) {
@@ -366,13 +366,13 @@ private:
         return nullptr;
     }
 
-    inline bool under_pressure() const {
+    inline bool under_pressure() const noexcept {
         return _reclaimer.under_pressure();
     }
 
-    uint64_t top_region_evictable_space() const;
+    uint64_t top_region_evictable_space() const noexcept;
 
-    uint64_t maximal_score() const {
+    uint64_t maximal_score() const noexcept {
         return _maximal_score;
     }
 

--- a/dirty_memory_manager.hh
+++ b/dirty_memory_manager.hh
@@ -444,6 +444,10 @@ public:
         return std::exchange(_sstable_write_permit, std::nullopt).value();
     }
 
+    bool has_sstable_write_permit() const noexcept {
+        return _sstable_write_permit.has_value();
+    }
+
     future<flush_permit> reacquire_sstable_write_permit() &&;
 };
 

--- a/dirty_memory_manager.hh
+++ b/dirty_memory_manager.hh
@@ -483,7 +483,7 @@ class dirty_memory_manager: public dirty_memory_manager_logalloc::region_group_r
     future<> _waiting_flush;
     virtual void start_reclaiming() noexcept override;
 
-    bool has_pressure() const {
+    bool has_pressure() const noexcept {
         return over_soft_limit();
     }
 
@@ -535,15 +535,15 @@ public:
         , _flush_serializer(1)
         , _waiting_flush(make_ready_future<>()) {}
 
-    static dirty_memory_manager& from_region_group(dirty_memory_manager_logalloc::region_group *rg) {
+    static dirty_memory_manager& from_region_group(dirty_memory_manager_logalloc::region_group *rg) noexcept {
         return *(boost::intrusive::get_parent_from_member(rg, &dirty_memory_manager::_virtual_region_group));
     }
 
-    dirty_memory_manager_logalloc::region_group& region_group() {
+    dirty_memory_manager_logalloc::region_group& region_group() noexcept {
         return _virtual_region_group;
     }
 
-    const dirty_memory_manager_logalloc::region_group& region_group() const {
+    const dirty_memory_manager_logalloc::region_group& region_group() const noexcept {
         return _virtual_region_group;
     }
 
@@ -567,41 +567,41 @@ public:
         _real_region_group.update(-delta);
     }
 
-    size_t real_dirty_memory() const {
+    size_t real_dirty_memory() const noexcept {
         return _real_region_group.memory_used();
     }
 
-    size_t virtual_dirty_memory() const {
+    size_t virtual_dirty_memory() const noexcept {
         return _virtual_region_group.memory_used();
     }
 
     future<> flush_one(replica::memtable_list& cf, flush_permit&& permit);
 
-    future<flush_permit> get_flush_permit() {
+    future<flush_permit> get_flush_permit() noexcept {
         return get_units(_background_work_flush_serializer, 1).then([this] (auto&& units) {
             return this->get_flush_permit(std::move(units));
         });
     }
 
-    future<flush_permit> get_all_flush_permits() {
+    future<flush_permit> get_all_flush_permits() noexcept {
         return get_units(_background_work_flush_serializer, _max_background_work).then([this] (auto&& units) {
             return this->get_flush_permit(std::move(units));
         });
     }
 
-    bool has_extraneous_flushes_requested() const {
+    bool has_extraneous_flushes_requested() const noexcept {
         return _extraneous_flushes > 0;
     }
 
-    void start_extraneous_flush() {
+    void start_extraneous_flush() noexcept {
         ++_extraneous_flushes;
     }
 
-    void finish_extraneous_flush() {
+    void finish_extraneous_flush() noexcept {
         --_extraneous_flushes;
     }
 private:
-    future<flush_permit> get_flush_permit(semaphore_units<>&& background_permit) {
+    future<flush_permit> get_flush_permit(semaphore_units<>&& background_permit) noexcept {
         return get_units(_flush_serializer, 1).then([this, background_permit = std::move(background_permit)] (auto&& units) mutable {
             return flush_permit(this, sstable_write_permit(std::move(units)), std::move(background_permit));
         });

--- a/dirty_memory_manager.hh
+++ b/dirty_memory_manager.hh
@@ -440,7 +440,7 @@ public:
     flush_permit(flush_permit&&) noexcept = default;
     flush_permit& operator=(flush_permit&&) noexcept = default;
 
-    sstable_write_permit release_sstable_write_permit() {
+    sstable_write_permit release_sstable_write_permit() noexcept {
         return std::exchange(_sstable_write_permit, std::nullopt).value();
     }
 

--- a/dirty_memory_manager.hh
+++ b/dirty_memory_manager.hh
@@ -238,8 +238,8 @@ public:
     // at the time the call to run_when_memory_available() was made.
     region_group(sstring name = "(unnamed region_group)",
             region_group_reclaimer& reclaimer = no_reclaimer,
-            scheduling_group deferred_work_sg = default_scheduling_group())
-        : region_group(name, nullptr, reclaimer, deferred_work_sg) {}
+            scheduling_group deferred_work_sg = default_scheduling_group()) noexcept
+        : region_group(std::move(name), nullptr, reclaimer, deferred_work_sg) {}
     region_group(sstring name, region_group* parent, region_group_reclaimer& reclaimer = no_reclaimer,
             scheduling_group deferred_work_sg = default_scheduling_group());
     region_group(region_group&& o) = delete;

--- a/encoding_stats.hh
+++ b/encoding_stats.hh
@@ -46,31 +46,31 @@ private:
     min_tracker<gc_clock::duration> min_ttl;
 
 public:
-    encoding_stats_collector()
+    encoding_stats_collector() noexcept
         : min_timestamp(api::max_timestamp)
         , min_local_deletion_time(gc_clock::time_point::max())
         , min_ttl(gc_clock::duration::max())
     {}
 
-    void update_timestamp(api::timestamp_type ts) {
+    void update_timestamp(api::timestamp_type ts) noexcept {
         min_timestamp.update(ts);
     }
 
-    void update_local_deletion_time(gc_clock::time_point local_deletion_time) {
+    void update_local_deletion_time(gc_clock::time_point local_deletion_time) noexcept {
         min_local_deletion_time.update(local_deletion_time);
     }
 
-    void update_ttl(gc_clock::duration ttl) {
+    void update_ttl(gc_clock::duration ttl) noexcept {
         min_ttl.update(ttl);
     }
 
-    void update(const encoding_stats& other) {
+    void update(const encoding_stats& other) noexcept {
         update_timestamp(other.min_timestamp);
         update_local_deletion_time(other.min_local_deletion_time);
         update_ttl(other.min_ttl);
     }
 
-    encoding_stats get() const {
+    encoding_stats get() const noexcept {
         return { min_timestamp.get(), min_local_deletion_time.get(), min_ttl.get() };
     }
 };

--- a/gc_clock.hh
+++ b/gc_clock.hh
@@ -34,7 +34,7 @@ public:
         return time_point(std::chrono::duration_cast<duration>(std::chrono::seconds(t)));
     }
 
-    static time_point now() {
+    static time_point now() noexcept {
         return time_point(std::chrono::duration_cast<duration>(base::now().time_since_epoch())) + get_clocks_offset();
     }
 
@@ -63,7 +63,7 @@ std::ostream& operator<<(std::ostream& os, gc_clock::time_point tp);
 template<>
 struct appending_hash<gc_clock::time_point> {
     template<typename Hasher>
-    void operator()(Hasher& h, gc_clock::time_point t) const {
+    void operator()(Hasher& h, gc_clock::time_point t) const noexcept {
         // Remain backwards-compatible with the 32-bit duration::rep (refs #4460).
         uint64_t d64 = t.time_since_epoch().count();
         feed_hash(h, uint32_t(d64 & 0xffff'ffff));

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -1752,12 +1752,11 @@ future<> dirty_memory_manager::flush_when_needed() {
     if (!_db) {
         return make_ready_future<>();
     }
-    auto r = make_lw_shared<exponential_backoff_retry>(100ms, 10s);
     // If there are explicit flushes requested, we must wait for them to finish before we stop.
-    return do_until([this] { return _db_shutdown_requested; }, [this, r] {
+    return do_until([this] { return _db_shutdown_requested; }, [this] {
         auto has_work = [this] { return has_pressure() || _db_shutdown_requested; };
-        return _should_flush.wait(std::move(has_work)).then([this, r] {
-            return get_flush_permit().then([this, r] (auto permit) {
+        return _should_flush.wait(std::move(has_work)).then([this] {
+            return get_flush_permit().then([this] (auto permit) {
                 // We give priority to explicit flushes. They are mainly user-initiated flushes,
                 // flushes coming from a DROP statement, or commitlog flushes.
                 if (_flush_serializer.waiters()) {
@@ -1788,31 +1787,8 @@ future<> dirty_memory_manager::flush_when_needed() {
                 // Do not wait. The semaphore will protect us against a concurrent flush. But we
                 // want to start a new one as soon as the permits are destroyed and the semaphore is
                 // made ready again, not when we are done with the current one.
-                (void)this->flush_one(mtlist, std::move(permit)).then_wrapped([this, r](future<> f) {
-                    if (f.failed()) {
-                        auto e = f.get_exception();
-                        _db->cf_stats()->failed_memtables_flushes_count++;
-                        try {
-                            std::rethrow_exception(e);
-                        } catch (const std::bad_alloc& e) {
-                            // There is a chance something else will free the memory, so we can try again
-                            dblog.error("Flush failed due to low memory. Retrying again in {}ms", r->sleep_time().count());
-                        } catch (...) {
-                            try {
-                                // At this point we don't know what has happened and it's better to potentially
-                                // take the node down and rely on commitlog to replay.
-                                on_internal_error(dblog, e);
-                            } catch (const std::exception& ex) {
-                                // If the node is configured to not abort on internal error,
-                                // but propagate it up the chain, we can't do anything reasonable
-                                // at this point. The error is logged and we can try again later
-                            }
-                        }
-                        return r->retry();
-                    }
-                    // Clear the retry timer if the flush succeeds
-                    r->reset();
-                    return make_ready_future<>();
+                (void)this->flush_one(mtlist, std::move(permit)).handle_exception([this] (std::exception_ptr ex) {
+                    dblog.error("Flushing memtable returned unexpected error: {}", ex);
                 });
                 return make_ready_future<>();
             });

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -567,7 +567,7 @@ private:
     // Update compaction backlog tracker with the same changes applied to the underlying sstable set.
     void backlog_tracker_adjust_charges(const std::vector<sstables::shared_sstable>& old_sstables, const std::vector<sstables::shared_sstable>& new_sstables);
     lw_shared_ptr<memtable> new_memtable();
-    future<stop_iteration> try_flush_memtable_to_sstable(lw_shared_ptr<memtable> memt, sstable_write_permit&& permit);
+    future<> try_flush_memtable_to_sstable(lw_shared_ptr<memtable> memt, sstable_write_permit&& permit);
     // Caller must keep m alive.
     future<> update_cache(lw_shared_ptr<memtable> m, std::vector<sstables::shared_sstable> ssts);
     struct merge_comparator;

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -195,15 +195,15 @@ public:
         : memtable_list({}, std::move(cs), dirty_memory_manager, table_stats, compaction_scheduling_group) {
     }
 
-    bool may_flush() const {
+    bool may_flush() const noexcept {
         return bool(_seal_immediate_fn);
     }
 
-    bool can_flush() const {
+    bool can_flush() const noexcept {
         return may_flush() && !empty();
     }
 
-    bool empty() const {
+    bool empty() const noexcept {
         for (auto& m : _memtables) {
            if (!m->empty()) {
                return false;
@@ -211,13 +211,13 @@ public:
         }
         return true;
     }
-    shared_memtable back() {
+    shared_memtable back() const noexcept {
         return _memtables.back();
     }
 
     // # 8904 - this method is akin to std::set::erase(key_type), not
     // erase(iterator). Should be tolerant against non-existing.
-    void erase(const shared_memtable& element) {
+    void erase(const shared_memtable& element) noexcept {
         auto i = boost::range::find(_memtables, element);
         if (i != _memtables.end()) {
             _memtables.erase(i);
@@ -229,7 +229,7 @@ public:
     // Exception safe.
     std::vector<replica::shared_memtable> clear_and_add();
 
-    size_t size() const {
+    size_t size() const noexcept {
         return _memtables.size();
     }
 
@@ -253,7 +253,7 @@ public:
         return _memtables.end();
     }
 
-    memtable& active_memtable() {
+    memtable& active_memtable() noexcept {
         return *_memtables.back();
     }
 
@@ -261,7 +261,7 @@ public:
         _memtables.emplace_back(new_memtable());
     }
 
-    dirty_memory_manager_logalloc::region_group& region_group() {
+    dirty_memory_manager_logalloc::region_group& region_group() noexcept {
         return _dirty_memory_manager->region_group();
     }
     // This is used for explicit flushes. Will queue the memtable for flushing and proceed when the

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -233,7 +233,7 @@ public:
         return _memtables.size();
     }
 
-    future<> seal_active_memtable(flush_permit&& permit) {
+    future<> seal_active_memtable(flush_permit&& permit) noexcept {
         return _seal_immediate_fn(std::move(permit));
     }
 
@@ -1080,7 +1080,7 @@ private:
     // But it is possible to synchronously wait for the seal to complete by
     // waiting on this future. This is useful in situations where we want to
     // synchronously flush data to disk.
-    future<> seal_active_memtable(flush_permit&&);
+    future<> seal_active_memtable(flush_permit&&) noexcept;
 
     void check_valid_rp(const db::replay_position&) const;
 public:

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -162,7 +162,6 @@ using shared_memtable = lw_shared_ptr<memtable>;
 class memtable_list {
 public:
     using seal_immediate_fn_type = std::function<future<> (flush_permit&&)>;
-    using seal_delayed_fn_type = std::function<future<> ()>;
 private:
     std::vector<shared_memtable> _memtables;
     seal_immediate_fn_type _seal_immediate_fn;

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1080,6 +1080,9 @@ private:
     // But it is possible to synchronously wait for the seal to complete by
     // waiting on this future. This is useful in situations where we want to
     // synchronously flush data to disk.
+    //
+    // The function never fails.
+    // It either succeeds eventually after retrying or aborts.
     future<> seal_active_memtable(flush_permit&&) noexcept;
 
     void check_valid_rp(const db::replay_position&) const;

--- a/replica/memtable.cc
+++ b/replica/memtable.cc
@@ -803,7 +803,7 @@ memtable::apply(const frozen_mutation& m, const schema_ptr& m_schema, db::rp_han
     update(std::move(h));
 }
 
-logalloc::occupancy_stats memtable::occupancy() const {
+logalloc::occupancy_stats memtable::occupancy() const noexcept {
     return logalloc::region::occupancy();
 }
 
@@ -835,11 +835,11 @@ void memtable::mark_flushed(mutation_source underlying) noexcept {
     _underlying = std::move(underlying);
 }
 
-bool memtable::is_flushed() const {
+bool memtable::is_flushed() const noexcept {
     return bool(_underlying);
 }
 
-bool memtable::has_any_tombstones() const {
+bool memtable::has_any_tombstones() const noexcept {
     return _table_stats.memtable_app_stats.has_any_tombstones;
 }
 

--- a/replica/memtable.cc
+++ b/replica/memtable.cc
@@ -29,18 +29,18 @@ static flat_mutation_reader_v2 make_partition_snapshot_flat_reader_from_snp_sche
         std::any pointer_to_container,
         streamed_mutation::forwarding fwd, memtable& memtable);
 
-void memtable::memtable_encoding_stats_collector::update_timestamp(api::timestamp_type ts) {
+void memtable::memtable_encoding_stats_collector::update_timestamp(api::timestamp_type ts) noexcept {
     if (ts != api::missing_timestamp) {
         encoding_stats_collector::update_timestamp(ts);
         min_max_timestamp.update(ts);
     }
 }
 
-memtable::memtable_encoding_stats_collector::memtable_encoding_stats_collector()
+memtable::memtable_encoding_stats_collector::memtable_encoding_stats_collector() noexcept
     : min_max_timestamp(0, 0)
 {}
 
-void memtable::memtable_encoding_stats_collector::update(atomic_cell_view cell) {
+void memtable::memtable_encoding_stats_collector::update(atomic_cell_view cell) noexcept {
     update_timestamp(cell.timestamp());
     if (cell.is_live_and_has_ttl()) {
         update_ttl(cell.ttl());
@@ -50,7 +50,7 @@ void memtable::memtable_encoding_stats_collector::update(atomic_cell_view cell) 
     }
 }
 
-void memtable::memtable_encoding_stats_collector::update(tombstone tomb) {
+void memtable::memtable_encoding_stats_collector::update(tombstone tomb) noexcept {
     if (tomb) {
         update_timestamp(tomb.timestamp);
         update_local_deletion_time(tomb.deletion_time);
@@ -78,11 +78,11 @@ void memtable::memtable_encoding_stats_collector::update(const ::schema& s, cons
     });
 }
 
-void memtable::memtable_encoding_stats_collector::update(const range_tombstone& rt) {
+void memtable::memtable_encoding_stats_collector::update(const range_tombstone& rt) noexcept {
     update(rt.tomb);
 }
 
-void memtable::memtable_encoding_stats_collector::update(const row_marker& marker) {
+void memtable::memtable_encoding_stats_collector::update(const row_marker& marker) noexcept {
     update_timestamp(marker.timestamp());
     if (!marker.is_missing()) {
         if (!marker.is_live()) {

--- a/replica/memtable.hh
+++ b/replica/memtable.hh
@@ -182,7 +182,7 @@ public:
     // Clears this memtable gradually without consuming the whole CPU.
     // Never resolves with a failed future.
     future<> clear_gently() noexcept;
-    schema_ptr schema() const { return _schema; }
+    schema_ptr schema() const noexcept { return _schema; }
     void set_schema(schema_ptr) noexcept;
     future<> apply(memtable&, reader_permit);
     // Applies mutation to this memtable.
@@ -192,42 +192,42 @@ public:
     void apply(const frozen_mutation& m, const schema_ptr& m_schema, db::rp_handle&& = {});
     void evict_entry(memtable_entry& e, mutation_cleaner& cleaner) noexcept;
 
-    static memtable& from_region(logalloc::region& r) {
+    static memtable& from_region(logalloc::region& r) noexcept {
         return static_cast<memtable&>(r);
     }
 
-    const logalloc::region& region() const {
+    const logalloc::region& region() const noexcept {
         return *this;
     }
 
-    logalloc::region& region() {
+    logalloc::region& region() noexcept {
         return *this;
     }
 
-    encoding_stats get_encoding_stats() const {
+    encoding_stats get_encoding_stats() const noexcept {
         return _stats_collector.get();
     }
 
-    api::timestamp_type get_min_timestamp() const {
+    api::timestamp_type get_min_timestamp() const noexcept {
         return _stats_collector.get_min_timestamp();
     }
 
-    api::timestamp_type get_max_timestamp() const {
+    api::timestamp_type get_max_timestamp() const noexcept {
         return _stats_collector.get_max_timestamp();
     }
 
-    mutation_cleaner& cleaner() {
+    mutation_cleaner& cleaner() noexcept {
         return _cleaner;
     }
-    bool has_any_tombstones() const;
+    bool has_any_tombstones() const noexcept;
 
 public:
-    memtable_list* get_memtable_list() {
+    memtable_list* get_memtable_list() noexcept {
         return _memtable_list;
     }
 
-    size_t partition_count() const { return nr_partitions; }
-    logalloc::occupancy_stats occupancy() const;
+    size_t partition_count() const noexcept { return nr_partitions; }
+    logalloc::occupancy_stats occupancy() const noexcept;
 
     // Creates a reader of data in this memtable for given partition range.
     //
@@ -272,13 +272,13 @@ public:
 
     mutation_source as_data_source();
 
-    bool empty() const { return partitions.empty(); }
+    bool empty() const noexcept { return partitions.empty(); }
     void mark_flushed(mutation_source) noexcept;
-    bool is_flushed() const;
+    bool is_flushed() const noexcept;
     void on_detach_from_region_group() noexcept;
     void revert_flushed_memory() noexcept;
 
-    const db::replay_position& replay_position() const {
+    const db::replay_position& replay_position() const noexcept {
         return _replay_position;
     }
     /**
@@ -287,12 +287,12 @@ public:
      * purposes, to one-shot report discarded rp:s
      * to commitlog
      */
-    db::rp_set get_and_discard_rp_set() {
+    db::rp_set get_and_discard_rp_set() noexcept {
         return std::exchange(_rp_set, {});
     }
     friend class iterator_reader;
 
-    dirty_memory_manager& get_dirty_memory_manager() {
+    dirty_memory_manager& get_dirty_memory_manager() noexcept {
         return _dirty_mgr;
     }
 

--- a/replica/memtable.hh
+++ b/replica/memtable.hh
@@ -135,25 +135,25 @@ private:
     private:
         min_max_tracker<api::timestamp_type> min_max_timestamp;
 
-        void update_timestamp(api::timestamp_type ts);
+        void update_timestamp(api::timestamp_type ts) noexcept;
 
     public:
-        memtable_encoding_stats_collector();
-        void update(atomic_cell_view cell);
+        memtable_encoding_stats_collector() noexcept;
+        void update(atomic_cell_view cell) noexcept;
 
-        void update(tombstone tomb);
+        void update(tombstone tomb) noexcept;
 
         void update(const ::schema& s, const row& r, column_kind kind);
-        void update(const range_tombstone& rt);
-        void update(const row_marker& marker);
+        void update(const range_tombstone& rt) noexcept;
+        void update(const row_marker& marker) noexcept;
         void update(const ::schema& s, const deletable_row& dr);
         void update(const ::schema& s, const mutation_partition& mp);
 
-        api::timestamp_type get_min_timestamp() const {
+        api::timestamp_type get_min_timestamp() const noexcept {
             return min_max_timestamp.min();
         }
 
-        api::timestamp_type get_max_timestamp() const {
+        api::timestamp_type get_max_timestamp() const noexcept {
             return min_max_timestamp.max();
         }
     } _stats_collector;

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -13,6 +13,7 @@
 #include <seastar/coroutine/parallel_for_each.hh>
 #include <seastar/coroutine/as_future.hh>
 #include <seastar/util/closeable.hh>
+#include <seastar/util/defer.hh>
 
 #include "replica/database.hh"
 #include "replica/data_dictionary_impl.hh"
@@ -588,15 +589,11 @@ table::seal_active_memtable(flush_permit&& flush_permit) noexcept {
     size_t memtable_size;
     future<> previous_flush = make_ready_future<>();
 
-    // FIXME: the retried func returns a stop_iteration value for now,
-    // since try_flush_memtable_to_sstable is still doing some error handling on its own.
-    auto with_retry = [&] (std::function<future<stop_iteration>()> func) -> future<> {
+    auto with_retry = [&] (std::function<future<>()> func) -> future<> {
         for (;;) {
             std::exception_ptr ex;
             try {
-                if ((co_await func()) == stop_iteration::yes) {
-                    co_return;
-                }
+                co_return co_await func();
             } catch (...) {
                 ex = std::current_exception();
                 _config.cf_stats->failed_memtables_flushes_count++;
@@ -608,6 +605,10 @@ table::seal_active_memtable(flush_permit&& flush_permit) noexcept {
                     // This is a temporary measure just to make this patch that
                     // moved this error handling code from flush_when_needed
                     // easier to review
+                    //
+                    // FIXME: enter maintenance mode when available.
+                    // since replaying the commitlog with a corrupt mutation
+                    // may end up in an infinite crash loop.
                     try {
                         // At this point we don't know what has happened and it's better to potentially
                         // take the node down and rely on commitlog to replay.
@@ -618,6 +619,11 @@ table::seal_active_memtable(flush_permit&& flush_permit) noexcept {
                         // at this point. The error is logged and we can try again later
                     }
                 }
+            }
+            if (_async_gate.is_closed()) {
+                tlogger.warn("Memtable flush failed due to: {}. Dropped due to shutdown", ex);
+                co_await std::move(previous_flush);
+                co_await coroutine::return_exception_ptr(std::move(ex));
             }
             tlogger.warn("Memtable flush failed due to: {}. Will retry in {}ms", ex, r.sleep_time().count());
             co_await r.retry();
@@ -642,7 +648,7 @@ table::seal_active_memtable(flush_permit&& flush_permit) noexcept {
             old->region().ground_evictable_occupancy();
             memtable_size = old->occupancy().total_space();
         }();
-        return make_ready_future<stop_iteration>(stop_iteration::yes);
+        return make_ready_future<>();
     });
 
     co_await with_retry([&] {
@@ -653,10 +659,16 @@ table::seal_active_memtable(flush_permit&& flush_permit) noexcept {
         _stats.pending_flushes++;
         _config.cf_stats->pending_memtables_flushes_count++;
         _config.cf_stats->pending_memtables_flushes_bytes += memtable_size;
-        return make_ready_future<stop_iteration>(stop_iteration::yes);
+        return make_ready_future<>();
     });
 
-    co_await with_retry([&] () -> future<stop_iteration> {
+    auto undo_stats = std::make_optional(deferred_action([this, memtable_size] () noexcept {
+        _stats.pending_flushes--;
+        _config.cf_stats->pending_memtables_flushes_count--;
+        _config.cf_stats->pending_memtables_flushes_bytes -= memtable_size;
+    }));
+
+    co_await with_retry([&] () -> future<> {
         // Reacquiring the write permit might be needed if retrying flush
         if (!permit.has_sstable_write_permit()) {
             tlogger.debug("seal_active_memtable: reacquiring write permit");
@@ -667,9 +679,7 @@ table::seal_active_memtable(flush_permit&& flush_permit) noexcept {
         co_return co_await this->try_flush_memtable_to_sstable(old, std::move(write_permit));
     });
 
-    _stats.pending_flushes--;
-    _config.cf_stats->pending_memtables_flushes_count--;
-    _config.cf_stats->pending_memtables_flushes_bytes -= memtable_size;
+    undo_stats.reset();
 
     if (_commitlog) {
         _commitlog->discard_completed_segments(_schema->id(), old->get_and_discard_rp_set());
@@ -681,9 +691,9 @@ table::seal_active_memtable(flush_permit&& flush_permit) noexcept {
     // FIXME: provide back-pressure to upper layers
 }
 
-future<stop_iteration>
+future<>
 table::try_flush_memtable_to_sstable(lw_shared_ptr<memtable> old, sstable_write_permit&& permit) {
-    auto try_flush = [this, old = std::move(old), permit = make_lw_shared(std::move(permit))] () mutable -> future<stop_iteration> {
+    auto try_flush = [this, old = std::move(old), permit = make_lw_shared(std::move(permit))] () mutable -> future<> {
         // Note that due to our sharded architecture, it is possible that
         // in the face of a value change some shards will backup sstables
         // while others won't.
@@ -742,7 +752,7 @@ table::try_flush_memtable_to_sstable(lw_shared_ptr<memtable> old, sstable_write_
             if (!fragment) {
                 co_await reader.close();
                 _memtables->erase(old);
-                co_return stop_iteration::yes;
+                co_return;
             }
         } catch (...) {
             err = std::current_exception();
@@ -750,7 +760,7 @@ table::try_flush_memtable_to_sstable(lw_shared_ptr<memtable> old, sstable_write_
         if (err) {
             tlogger.error("failed to flush memtable for {}.{}: {}", old->schema()->ks_name(), old->schema()->cf_name(), err);
             co_await reader.close();
-            co_return stop_iteration(_async_gate.is_closed());
+            co_await coroutine::return_exception_ptr(std::move(err));
         }
 
         auto f = consumer(std::move(reader));
@@ -758,7 +768,7 @@ table::try_flush_memtable_to_sstable(lw_shared_ptr<memtable> old, sstable_write_
         // Switch back to default scheduling group for post-flush actions, to avoid them being staved by the memtable flush
         // controller. Cache update does not affect the input of the memtable cpu controller, so it can be subject to
         // priority inversion.
-        auto post_flush = [this, old = std::move(old), &newtabs, f = std::move(f)] () mutable -> future<stop_iteration> {
+        auto post_flush = [this, old = std::move(old), &newtabs, f = std::move(f)] () mutable -> future<> {
             try {
                 co_await std::move(f);
                 co_await coroutine::parallel_for_each(newtabs, [] (auto& newtab) -> future<> {
@@ -766,12 +776,12 @@ table::try_flush_memtable_to_sstable(lw_shared_ptr<memtable> old, sstable_write_
                     tlogger.debug("Flushing to {} done", newtab->get_filename());
                 });
 
-                co_await with_scheduling_group(_config.memtable_to_cache_scheduling_group, [this, old, &newtabs] () -> future<> {
+                co_await with_scheduling_group(_config.memtable_to_cache_scheduling_group, [this, old, &newtabs] {
                     return update_cache(old, newtabs);
                 });
                 _memtables->erase(old);
                 tlogger.debug("Memtable for {}.{} replaced, into {} sstables", old->schema()->ks_name(), old->schema()->cf_name(), newtabs.size());
-                co_return stop_iteration::yes;
+                co_return;
             } catch (const std::exception& e) {
                 for (auto& newtab : newtabs) {
                     newtab->mark_for_deletion();
@@ -781,7 +791,7 @@ table::try_flush_memtable_to_sstable(lw_shared_ptr<memtable> old, sstable_write_
                 // If we failed this write we will try the write again and that will create a new flush reader
                 // that will decrease dirty memory again. So we need to reset the accounting.
                 old->revert_flushed_memory();
-                co_return stop_iteration(_async_gate.is_closed());
+                throw;
             }
         };
         co_return co_await with_scheduling_group(default_scheduling_group(), std::ref(post_flush));

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -630,7 +630,7 @@ table::seal_active_memtable(flush_permit&& flush_permit) noexcept {
 
     co_await with_retry([&] {
         tlogger.debug("seal_active_memtable: adding memtable");
-        utils::get_local_injector().inject("table_seal_active_memtable_pre_flush", []() {
+        utils::get_local_injector().inject("table_seal_active_memtable_add_memtable", []() {
             throw std::bad_alloc();
         });
 
@@ -651,6 +651,9 @@ table::seal_active_memtable(flush_permit&& flush_permit) noexcept {
 
     co_await with_retry([&] {
         previous_flush = _flush_barrier.advance_and_await();
+        utils::get_local_injector().inject("table_seal_active_memtable_start_op", []() {
+            throw std::bad_alloc();
+        });
         op = _flush_barrier.start();
 
         // no exceptions allowed (nor expected) from this point on
@@ -670,10 +673,16 @@ table::seal_active_memtable(flush_permit&& flush_permit) noexcept {
         // Reacquiring the write permit might be needed if retrying flush
         if (!permit.has_sstable_write_permit()) {
             tlogger.debug("seal_active_memtable: reacquiring write permit");
+            utils::get_local_injector().inject("table_seal_active_memtable_reacquire_write_permit", []() {
+                throw std::bad_alloc();
+            });
             permit = co_await std::move(permit).reacquire_sstable_write_permit();
         }
         auto write_permit = permit.release_sstable_write_permit();
 
+        utils::get_local_injector().inject("table_seal_active_memtable_try_flush", []() {
+            throw std::bad_alloc();
+        });
         co_return co_await this->try_flush_memtable_to_sstable(old, std::move(write_permit));
     });
 

--- a/test/boost/memtable_test.cc
+++ b/test/boost/memtable_test.cc
@@ -980,17 +980,22 @@ SEASTAR_TEST_CASE(failed_flush_prevents_writes) {
         }
         t.apply(mt);
 
-        utils::get_local_injector().enable("table_seal_active_memtable_pre_flush");
+        auto failed_memtables_flushes_count = db.cf_stats()->failed_memtables_flushes_count;
+
+        utils::get_local_injector().enable("table_seal_active_memtable_add_memtable", true /* oneshot */);
+        utils::get_local_injector().enable("table_seal_active_memtable_start_op", true /* oneshot */);
+        utils::get_local_injector().enable("table_seal_active_memtable_try_flush", true /* oneshot */);
+        utils::get_local_injector().enable("table_seal_active_memtable_reacquire_write_permit");
 
         BOOST_ASSERT(eventually_true([&] {
             // Trigger flush
             dmm.notify_soft_pressure();
-            return db.cf_stats()->failed_memtables_flushes_count != 0;
+            return db.cf_stats()->failed_memtables_flushes_count - failed_memtables_flushes_count >= 4;
         }));
 
         // The flush failed, make sure there is still data in memtable.
         BOOST_ASSERT(t.min_memtable_timestamp() < api::max_timestamp);
-        utils::get_local_injector().disable("table_seal_active_memtable_pre_flush");
+        utils::get_local_injector().disable("table_seal_active_memtable_reacquire_write_permit");
 
         // Release pressure, so that we can trigger flush again
         dmm.notify_soft_relief();

--- a/test/boost/memtable_test.cc
+++ b/test/boost/memtable_test.cc
@@ -997,13 +997,9 @@ SEASTAR_TEST_CASE(failed_flush_prevents_writes) {
         BOOST_ASSERT(t.min_memtable_timestamp() < api::max_timestamp);
         utils::get_local_injector().disable("table_seal_active_memtable_reacquire_write_permit");
 
-        // Release pressure, so that we can trigger flush again
-        dmm.notify_soft_relief();
-
         BOOST_ASSERT(eventually_true([&] {
-            // Trigger pressure, the error above is no longer being injected, so flush
-            // should be triggerred and succeed
-            dmm.notify_soft_pressure();
+            // The error above is no longer being injected, so
+            // seal_active_memtable retry loop should eventually succeed
             return t.min_memtable_timestamp() == api::max_timestamp;
         }));
     });

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -4055,8 +4055,7 @@ SEASTAR_TEST_CASE(test_twcs_interposer_on_memtable_flush) {
             }
         }
 
-        auto ret = column_family_test(cf).try_flush_memtable_to_sstable(mt).get0();
-        BOOST_REQUIRE(ret == stop_iteration::yes);
+        column_family_test(cf).try_flush_memtable_to_sstable(mt).get();
 
         auto expected_ssts = (split_during_flush) ? target_windows_span : 1;
         testlog.info("split_during_flush={}, actual={}, expected={}", split_during_flush, cf->get_sstables()->size(), expected_ssts);

--- a/test/boost/sstable_test.hh
+++ b/test/boost/sstable_test.hh
@@ -58,7 +58,7 @@ public:
         return replica::column_family::calculate_shard_from_sstable_generation(generation_from_value(generation));
     }
 
-    future<stop_iteration> try_flush_memtable_to_sstable(lw_shared_ptr<replica::memtable> mt) {
+    auto try_flush_memtable_to_sstable(lw_shared_ptr<replica::memtable> mt) {
         return _cf->try_flush_memtable_to_sstable(mt, sstable_write_permit::unconditional());
     }
 };

--- a/utils/dynamic_bitset.cc
+++ b/utils/dynamic_bitset.cc
@@ -16,7 +16,7 @@
 
 namespace utils {
 
-void dynamic_bitset::set(size_t n) {
+void dynamic_bitset::set(size_t n) noexcept {
     for (auto& level : _bits) {
         auto idx = n / bits_per_int;
         auto old = level[idx];
@@ -28,7 +28,7 @@ void dynamic_bitset::set(size_t n) {
     }
 }
 
-void dynamic_bitset::clear(size_t n) {
+void dynamic_bitset::clear(size_t n) noexcept {
     for (auto& level : _bits) {
         auto idx = n / bits_per_int;
         auto old = level[idx];
@@ -40,7 +40,7 @@ void dynamic_bitset::clear(size_t n) {
     }
 }
 
-size_t dynamic_bitset::find_first_set() const
+size_t dynamic_bitset::find_first_set() const noexcept
 {
     size_t pos = 0;
     for (auto& vv : _bits | boost::adaptors::reversed) {
@@ -55,7 +55,7 @@ size_t dynamic_bitset::find_first_set() const
     return pos;
 }
 
-size_t dynamic_bitset::find_next_set(size_t n) const
+size_t dynamic_bitset::find_next_set(size_t n) const noexcept
 {
     ++n;
 
@@ -91,7 +91,7 @@ size_t dynamic_bitset::find_next_set(size_t n) const
     return n;
 }
 
-size_t dynamic_bitset::find_last_set() const
+size_t dynamic_bitset::find_last_set() const noexcept
 {
     size_t pos = 0;
     for (auto& vv : _bits | boost::adaptors::reversed) {

--- a/utils/dynamic_bitset.hh
+++ b/utils/dynamic_bitset.hh
@@ -26,19 +26,19 @@ private:
     size_t _bits_count = 0;
 private:
     // For n in range 0..(bits_per_int-1), produces a mask with all bits < n set
-    static int_type mask_lower_bits(size_t n) {
+    static int_type mask_lower_bits(size_t n) noexcept {
         return (int_type(1) << n) - 1;
     }
     // For n in range 0..(bits_per_int-1), produces a mask with all bits >= n set
-    static int_type mask_higher_bits(size_t n) {
+    static int_type mask_higher_bits(size_t n) noexcept {
         return ~mask_lower_bits(n);
     }
     // For bit n, produce index into _bits[level]
-    static size_t level_idx(unsigned level, size_t n) {
+    static size_t level_idx(unsigned level, size_t n) noexcept {
         return n >> ((level + 1) * level_shift);
     }
     // For bit n, produce bit number in _bits[level][level_idx]
-    static unsigned level_remainder(unsigned level, size_t n) {
+    static unsigned level_remainder(unsigned level, size_t n) noexcept {
         return (n >> (level * level_shift)) & (bits_per_int - 1);
     }
 public:
@@ -48,18 +48,21 @@ public:
 public:
     explicit dynamic_bitset(size_t nr_bits);
 
-    bool test(size_t n) const {
+    // undefined if n >= size
+    bool test(size_t n) const noexcept {
         auto idx = n / bits_per_int;
         return _bits[0][idx] & (int_type(1u) << (n % bits_per_int));
     }
-    void set(size_t n);
-    void clear(size_t n);
+    // undefined if n >= size
+    void set(size_t n) noexcept;
+    // undefined if n >= size
+    void clear(size_t n) noexcept;
 
-    size_t size() const { return _bits_count; }
+    size_t size() const noexcept { return _bits_count; }
 
-    size_t find_first_set() const;
-    size_t find_next_set(size_t n) const;
-    size_t find_last_set() const;
+    size_t find_first_set() const noexcept;
+    size_t find_next_set(size_t n) const noexcept;
+    size_t find_last_set() const noexcept;
 };
 
 }

--- a/utils/dynamic_bitset.hh
+++ b/utils/dynamic_bitset.hh
@@ -24,7 +24,6 @@ class dynamic_bitset {
 private:
     std::vector<std::vector<int_type>> _bits; // level n+1 = 64:1 summary of level n
     size_t _bits_count = 0;
-    unsigned _nlevels = 0;
 private:
     // For n in range 0..(bits_per_int-1), produces a mask with all bits < n set
     static int_type mask_lower_bits(size_t n) {
@@ -42,7 +41,6 @@ private:
     static unsigned level_remainder(unsigned level, size_t n) {
         return (n >> (level * level_shift)) & (bits_per_int - 1);
     }
-    void do_resize(size_t n, bool set);
 public:
     enum : size_t {
         npos = std::numeric_limits<size_t>::max()

--- a/utils/extremum_tracking.hh
+++ b/utils/extremum_tracking.hh
@@ -15,27 +15,28 @@
 namespace detail {
 
 template<typename T, typename Comparator>
+requires std::is_nothrow_copy_constructible_v<T> && std::is_nothrow_move_constructible_v<T>
 class extremum_tracker {
     T _default_value;
     std::optional<T> _value;
 public:
-    explicit extremum_tracker(const T& default_value)
+    explicit extremum_tracker(const T& default_value) noexcept
         : _default_value(default_value)
     {}
 
-    void update(const T& value) {
+    void update(const T& value) noexcept {
         if (!_value || Comparator{}(value, *_value)) {
             _value = value;
         }
     }
 
-    void update(const extremum_tracker& other) {
+    void update(const extremum_tracker& other) noexcept {
         if (other._value) {
             update(*other._value);
         }
     }
 
-    const T& get() const {
+    const T& get() const noexcept {
         return _value ? *_value : _default_value;
     }
 };
@@ -49,35 +50,36 @@ template <typename T>
 using max_tracker = detail::extremum_tracker<T, std::greater<T>>;
 
 template <typename T>
+requires std::is_nothrow_copy_constructible_v<T> && std::is_nothrow_move_constructible_v<T>
 class min_max_tracker {
     min_tracker<T> _min_tracker;
     max_tracker<T> _max_tracker;
 public:
-    min_max_tracker()
+    min_max_tracker() noexcept
         : _min_tracker(std::numeric_limits<T>::min())
         , _max_tracker(std::numeric_limits<T>::max())
     {}
 
-    min_max_tracker(const T& default_min, const T& default_max)
+    min_max_tracker(const T& default_min, const T& default_max) noexcept
         : _min_tracker(default_min)
         , _max_tracker(default_max)
     {}
 
-    void update(const T& value) {
+    void update(const T& value) noexcept {
         _min_tracker.update(value);
         _max_tracker.update(value);
     }
 
-    void update(const min_max_tracker<T>& other) {
+    void update(const min_max_tracker<T>& other) noexcept {
         _min_tracker.update(other._min_tracker);
         _max_tracker.update(other._max_tracker);
     }
 
-    const T& min() const {
+    const T& min() const noexcept {
         return _min_tracker.get();
     }
 
-    const T& max() const {
+    const T& max() const noexcept {
         return _max_tracker.get();
     }
 };

--- a/utils/log_heap.hh
+++ b/utils/log_heap.hh
@@ -129,7 +129,7 @@ private:
     using bucket = typename traits::bucket_type;
 
     struct hist_size_less_compare {
-        inline bool operator()(const T& v1, const T& v2) const {
+        inline bool operator()(const T& v1, const T& v2) const noexcept {
             return traits::hist_key(v1) < traits::hist_key(v2);
         }
     };
@@ -154,20 +154,20 @@ public:
         iterator_type _it;
     public:
         struct end_tag {};
-        hist_iterator(hist_type& h)
+        hist_iterator(hist_type& h) noexcept
             : _h(h)
             , _b(h._watermark)
             , _it(_b >= 0 ? h._buckets[_b].begin() : h._buckets[0].end()) {
         }
-        hist_iterator(hist_type& h, end_tag)
+        hist_iterator(hist_type& h, end_tag) noexcept
             : _h(h)
             , _b(-1)
             , _it(h._buckets[0].end()) {
         }
-        std::conditional_t<IsConst, const T, T>& operator*() {
+        std::conditional_t<IsConst, const T, T>& operator*() noexcept {
             return *_it;
         }
-        hist_iterator& operator++() {
+        hist_iterator& operator++() noexcept {
             if (++_it == _h._buckets[_b].end()) {
                 do {
                     --_b;
@@ -175,51 +175,51 @@ public:
             }
             return *this;
         }
-        bool operator==(const hist_iterator& other) const {
+        bool operator==(const hist_iterator& other) const noexcept {
             return _b == other._b && _it == other._it;
         }
-        bool operator!=(const hist_iterator& other) const {
+        bool operator!=(const hist_iterator& other) const noexcept {
             return !(*this == other);
         }
     };
     using iterator = hist_iterator<false>;
     using const_iterator = hist_iterator<true>;
 public:
-    bool empty() const {
+    bool empty() const noexcept {
         return _watermark == -1;
     }
     // Returns true if and only if contains any value >= opts.min_size.
-    bool contains_above_min() const {
+    bool contains_above_min() const noexcept {
         return _watermark > 0;
     }
-    const_iterator begin() const {
+    const_iterator begin() const noexcept {
         return const_iterator(*this);
     }
-    const_iterator end() const {
+    const_iterator end() const noexcept {
         return const_iterator(*this, typename const_iterator::end_tag());
     }
-    iterator begin() {
+    iterator begin() noexcept {
         return iterator(*this);
     }
-    iterator end() {
+    iterator end() noexcept {
         return iterator(*this, typename iterator::end_tag());
     }
     // Returns a range of buckets starting from that with the smaller values.
     // Each bucket is a range of const T&.
-    const auto& buckets() const {
+    const auto& buckets() const noexcept {
         return _buckets;
     }
     // Pops one of the largest elements in the histogram.
-    void pop_one_of_largest() {
+    void pop_one_of_largest() noexcept {
         _buckets[_watermark].pop_front();
         maybe_adjust_watermark();
     }
     // Returns one of the largest elements in the histogram.
-    const T& one_of_largest() const {
+    const T& one_of_largest() const noexcept {
         return _buckets[_watermark].front();
     }
     // Returns one of the largest elements in the histogram.
-    T& one_of_largest() {
+    T& one_of_largest() noexcept {
         return _buckets[_watermark].front();
     }
     // Pushes a new element onto the histogram.
@@ -240,7 +240,7 @@ public:
         }
     }
     // Removes the specified element from the histogram.
-    void erase(T& v) {
+    void erase(T& v) noexcept {
         auto& b = _buckets[traits::cached_bucket(v)];
         b.erase(b.iterator_to(v));
         maybe_adjust_watermark();
@@ -254,7 +254,7 @@ public:
         other._watermark = -1;
     }
 private:
-    void maybe_adjust_watermark() {
+    void maybe_adjust_watermark() noexcept {
         while (_buckets[_watermark].empty() && --_watermark >= 0) ;
     }
 };

--- a/utils/logalloc.cc
+++ b/utils/logalloc.cc
@@ -835,6 +835,10 @@ public:
     segment_pool();
     void prime(size_t available_memory, size_t min_free_memory);
     segment* new_segment(region::impl* r);
+    const segment_descriptor& descriptor(const segment* seg) const noexcept {
+        uintptr_t index = idx_from_segment(seg);
+        return _segments[index];
+    }
     segment_descriptor& descriptor(segment* seg) noexcept {
         uintptr_t index = idx_from_segment(seg);
         return _segments[index];

--- a/utils/logalloc.cc
+++ b/utils/logalloc.cc
@@ -683,7 +683,7 @@ public:
     segment* segment_from_idx(size_t idx) noexcept {
         return reinterpret_cast<segment*>(_segments_base) + idx;
     }
-    size_t idx_from_segment(segment* seg) const noexcept {
+    size_t idx_from_segment(const segment* seg) const noexcept {
         return seg - reinterpret_cast<segment*>(_segments_base);
     }
     size_t new_idx_for_segment(segment* seg) noexcept {
@@ -724,9 +724,9 @@ public:
         assert(idx < _segments.size());
         return _segments[idx];
     }
-    size_t idx_from_segment(segment* seg) const noexcept {
+    size_t idx_from_segment(const segment* seg) const noexcept {
         // segment 0 is a marker for no segment
-        auto i = _segment_indexes.find(seg);
+        auto i = _segment_indexes.find(const_cast<segment*>(seg));
         if (i == _segment_indexes.end()) {
             return 0;
         }
@@ -822,7 +822,7 @@ private:
     segment* segment_from_idx(size_t idx) noexcept {
         return _store.segment_from_idx(idx);
     }
-    size_t idx_from_segment(segment* seg) {
+    size_t idx_from_segment(const segment* seg) const noexcept {
         return _store.idx_from_segment(seg);
     }
     size_t max_segments() const {

--- a/utils/logalloc.cc
+++ b/utils/logalloc.cc
@@ -690,7 +690,7 @@ public:
     size_t max_segments() const noexcept {
         return (_layout.end - _segments_base) / segment::size;
     }
-    bool can_allocate_more_segments() noexcept {
+    bool can_allocate_more_segments() const noexcept {
         return memory::stats().free_memory() >= non_lsa_reserve + segment::size;
     }
 };
@@ -702,6 +702,10 @@ class segment_store {
     std::vector<segment*>::iterator find_empty() noexcept {
         // segment 0 is a marker for no segment
         return std::find(_segments.begin() + 1, _segments.end(), nullptr);
+    }
+    std::vector<segment*>::const_iterator find_empty() const noexcept {
+        // segment 0 is a marker for no segment
+        return std::find(_segments.cbegin() + 1, _segments.cend(), nullptr);
     }
 
 public:
@@ -746,7 +750,7 @@ public:
     size_t max_segments() const noexcept {
         return _std_memory_available / segment::size;
     }
-    bool can_allocate_more_segments() noexcept {
+    bool can_allocate_more_segments() const noexcept {
         auto i = find_empty();
         return i != _segments.end();
     }

--- a/utils/logalloc.cc
+++ b/utils/logalloc.cc
@@ -530,15 +530,15 @@ size_t tracker::reclaim(size_t bytes) {
     return _impl->reclaim(bytes, is_preemptible::no);
 }
 
-occupancy_stats tracker::region_occupancy() {
+occupancy_stats tracker::region_occupancy() const noexcept {
     return _impl->region_occupancy();
 }
 
-occupancy_stats tracker::occupancy() {
+occupancy_stats tracker::occupancy() const noexcept {
     return _impl->occupancy();
 }
 
-size_t tracker::non_lsa_used_space() const {
+size_t tracker::non_lsa_used_space() const noexcept {
     return _impl->non_lsa_used_space();
 }
 
@@ -2104,11 +2104,11 @@ lsa_buffer::~lsa_buffer() {
     }
 }
 
-size_t tracker::reclamation_step() const {
+size_t tracker::reclamation_step() const noexcept {
     return _impl->reclamation_step();
 }
 
-bool tracker::should_abort_on_bad_alloc() {
+bool tracker::should_abort_on_bad_alloc() const noexcept {
     return _impl->should_abort_on_bad_alloc();
 }
 

--- a/utils/logalloc.cc
+++ b/utils/logalloc.cc
@@ -785,7 +785,7 @@ class segment_pool {
     struct allocation_lock {
         segment_pool& _pool;
         bool _prev;
-        allocation_lock(segment_pool& p)
+        allocation_lock(segment_pool& p) noexcept
             : _pool(p)
             , _prev(p._allocation_enabled)
         {
@@ -810,7 +810,7 @@ class segment_pool {
     //     - clear everywhere
 private:
     segment* allocate_segment(size_t reserve);
-    void deallocate_segment(segment* seg);
+    void deallocate_segment(segment* seg) noexcept;
     friend void* segment::operator new(size_t);
     friend void segment::operator delete(void*);
 
@@ -824,10 +824,10 @@ private:
     size_t idx_from_segment(const segment* seg) const noexcept {
         return _store.idx_from_segment(seg);
     }
-    size_t max_segments() const {
+    size_t max_segments() const noexcept {
         return _store.max_segments();
     }
-    bool can_allocate_more_segments() {
+    bool can_allocate_more_segments() const noexcept {
         return _allocation_enabled && _store.can_allocate_more_segments();
     }
     bool compact_segment(segment* seg);
@@ -835,41 +835,41 @@ public:
     segment_pool();
     void prime(size_t available_memory, size_t min_free_memory);
     segment* new_segment(region::impl* r);
-    segment_descriptor& descriptor(segment*);
+    segment_descriptor& descriptor(segment*) noexcept;
     // Returns segment containing given object or nullptr.
-    segment* containing_segment(const void* obj);
-    segment* segment_from(const segment_descriptor& desc);
+    segment* containing_segment(const void* obj) noexcept;
+    segment* segment_from(const segment_descriptor& desc) noexcept;
     void free_segment(segment*) noexcept;
     void free_segment(segment*, segment_descriptor&) noexcept;
-    size_t segments_in_use() const;
-    size_t current_emergency_reserve_goal() const { return _current_emergency_reserve_goal; }
-    void set_emergency_reserve_max(size_t new_size) { _emergency_reserve_max = new_size; }
-    size_t emergency_reserve_max() { return _emergency_reserve_max; }
-    void set_current_emergency_reserve_goal(size_t goal) { _current_emergency_reserve_goal = goal; }
-    void clear_allocation_failure_flag() { _allocation_failure_flag = false; }
-    bool allocation_failure_flag() { return _allocation_failure_flag; }
+    size_t segments_in_use() const noexcept;
+    size_t current_emergency_reserve_goal() const noexcept { return _current_emergency_reserve_goal; }
+    void set_emergency_reserve_max(size_t new_size) noexcept { _emergency_reserve_max = new_size; }
+    size_t emergency_reserve_max() const noexcept { return _emergency_reserve_max; }
+    void set_current_emergency_reserve_goal(size_t goal) noexcept { _current_emergency_reserve_goal = goal; }
+    void clear_allocation_failure_flag() noexcept { _allocation_failure_flag = false; }
+    bool allocation_failure_flag() const noexcept { return _allocation_failure_flag; }
     void refill_emergency_reserve();
-    void add_non_lsa_memory_in_use(size_t n) {
+    void add_non_lsa_memory_in_use(size_t n) noexcept {
         _non_lsa_memory_in_use += n;
     }
-    void subtract_non_lsa_memory_in_use(size_t n) {
+    void subtract_non_lsa_memory_in_use(size_t n) noexcept {
         assert(_non_lsa_memory_in_use >= n);
         _non_lsa_memory_in_use -= n;
     }
-    size_t non_lsa_memory_in_use() const {
+    size_t non_lsa_memory_in_use() const noexcept {
         return _non_lsa_memory_in_use;
     }
-    size_t total_memory_in_use() const {
+    size_t total_memory_in_use() const noexcept {
         return _non_lsa_memory_in_use + _segments_in_use * segment::size;
     }
-    size_t total_free_memory() const {
+    size_t total_free_memory() const noexcept {
         return _free_segments * segment::size;
     }
     struct reservation_goal;
-    void set_region(segment* seg, region::impl* r) {
+    void set_region(segment* seg, region::impl* r) noexcept {
         set_region(descriptor(seg), r);
     }
-    void set_region(segment_descriptor& desc, region::impl* r) {
+    void set_region(segment_descriptor& desc, region::impl* r) noexcept {
         desc._region = r;
     }
     size_t reclaim_segments(size_t target, is_preemptible preempt);
@@ -917,13 +917,13 @@ public:
 private:
     stats _stats{};
 public:
-    const stats& statistics() const { return _stats; }
-    void on_segment_compaction(size_t used_size);
-    void on_memory_allocation(size_t size);
-    void on_memory_deallocation(size_t size);
-    void on_memory_eviction(size_t size);
-    size_t unreserved_free_segments() const { return _free_segments - std::min(_free_segments, _emergency_reserve_max); }
-    size_t free_segments() const { return _free_segments; }
+    const stats& statistics() const noexcept { return _stats; }
+    inline void on_segment_compaction(size_t used_size) noexcept;
+    inline void on_memory_allocation(size_t size) noexcept;
+    inline void on_memory_deallocation(size_t size) noexcept;
+    inline void on_memory_eviction(size_t size) noexcept;
+    size_t unreserved_free_segments() const noexcept { return _free_segments - std::min(_free_segments, _emergency_reserve_max); }
+    size_t free_segments() const noexcept { return _free_segments; }
 };
 
 struct reclaim_timer {
@@ -1110,7 +1110,7 @@ segment* segment_pool::allocate_segment(size_t reserve)
     return nullptr;
 }
 
-void segment_pool::deallocate_segment(segment* seg)
+void segment_pool::deallocate_segment(segment* seg) noexcept
 {
     assert(_lsa_owned_segments_bitmap.test(idx_from_segment(seg)));
     _lsa_free_segments_bitmap.set(idx_from_segment(seg));
@@ -1129,13 +1129,13 @@ void segment_pool::refill_emergency_reserve() {
 }
 
 segment_descriptor&
-segment_pool::descriptor(segment* seg) {
+segment_pool::descriptor(segment* seg) noexcept {
     uintptr_t index = idx_from_segment(seg);
     return _segments[index];
 }
 
 segment*
-segment_pool::containing_segment(const void* obj) {
+segment_pool::containing_segment(const void* obj) noexcept {
     auto addr = reinterpret_cast<uintptr_t>(obj);
     auto offset = addr & (segment::size - 1);
     auto seg = reinterpret_cast<segment*>(addr - offset);
@@ -1149,7 +1149,7 @@ segment_pool::containing_segment(const void* obj) {
 }
 
 segment*
-segment_pool::segment_from(const segment_descriptor& desc) {
+segment_pool::segment_from(const segment_descriptor& desc) noexcept {
     assert(desc._region);
     auto index = &desc - &_segments[0];
     return segment_from_idx(index);
@@ -1214,20 +1214,20 @@ void segment_pool::prime(size_t available_memory, size_t min_free_memory) {
     reclaim_segments(_store.non_lsa_reserve / segment::size, is_preemptible::no);
 }
 
-void segment_pool::on_segment_compaction(size_t used_size) {
+inline void segment_pool::on_segment_compaction(size_t used_size) noexcept {
     _stats.segments_compacted++;
     _stats.memory_compacted += used_size;
 }
 
-void segment_pool::on_memory_allocation(size_t size) {
+inline void segment_pool::on_memory_allocation(size_t size) noexcept {
     _stats.memory_allocated += size;
 }
 
-void segment_pool::on_memory_deallocation(size_t size) {
+inline void segment_pool::on_memory_deallocation(size_t size) noexcept {
     _stats.memory_freed += size;
 }
 
-void segment_pool::on_memory_eviction(size_t size) {
+inline void segment_pool::on_memory_eviction(size_t size) noexcept {
     _stats.memory_evicted += size;
 }
 
@@ -1236,7 +1236,7 @@ class segment_pool::reservation_goal {
     segment_pool& _sp;
     size_t _old_goal;
 public:
-    reservation_goal(segment_pool& sp, size_t goal)
+    reservation_goal(segment_pool& sp, size_t goal) noexcept
             : _sp(sp), _old_goal(_sp.current_emergency_reserve_goal()) {
         _sp.set_current_emergency_reserve_goal(goal);
     }
@@ -1245,7 +1245,7 @@ public:
     }
 };
 
-size_t segment_pool::segments_in_use() const {
+size_t segment_pool::segments_in_use() const noexcept {
     return _segments_in_use;
 }
 

--- a/utils/logalloc.cc
+++ b/utils/logalloc.cc
@@ -677,7 +677,10 @@ public:
         : _layout(memory::get_memory_layout())
         , _segments_base(align_down(_layout.start, (uintptr_t)segment::size)) {
     }
-    segment* segment_from_idx(size_t idx) const noexcept {
+    const segment* segment_from_idx(size_t idx) const noexcept {
+        return reinterpret_cast<segment*>(_segments_base) + idx;
+    }
+    segment* segment_from_idx(size_t idx) noexcept {
         return reinterpret_cast<segment*>(_segments_base) + idx;
     }
     size_t idx_from_segment(segment* seg) const noexcept {
@@ -713,7 +716,11 @@ public:
     segment_store() : _segments(max_segments()) {
         _segment_indexes.reserve(max_segments());
     }
-    segment* segment_from_idx(size_t idx) const noexcept {
+    const segment* segment_from_idx(size_t idx) const noexcept {
+        assert(idx < _segments.size());
+        return _segments[idx];
+    }
+    segment* segment_from_idx(size_t idx) noexcept {
         assert(idx < _segments.size());
         return _segments[idx];
     }
@@ -809,7 +816,10 @@ private:
 
     segment* allocate_or_fallback_to_reserve();
     void free_or_restore_to_reserve(segment* seg) noexcept;
-    segment* segment_from_idx(size_t idx) const {
+    const segment* segment_from_idx(size_t idx) const noexcept {
+        return _store.segment_from_idx(idx);
+    }
+    segment* segment_from_idx(size_t idx) noexcept {
         return _store.segment_from_idx(idx);
     }
     size_t idx_from_segment(segment* seg) {

--- a/utils/logalloc.cc
+++ b/utils/logalloc.cc
@@ -2656,7 +2656,7 @@ bool segment_pool::compact_segment(segment* seg) {
     return true;
 }
 
-allocating_section::guard::guard()
+allocating_section::guard::guard() noexcept
     : _prev(shard_segment_pool.emergency_reserve_max())
 { }
 

--- a/utils/logalloc.cc
+++ b/utils/logalloc.cc
@@ -483,9 +483,9 @@ public:
     size_t compact_and_evict(size_t reserve_segments, size_t bytes, is_preemptible p);
     void full_compaction();
     void reclaim_all_free_segments();
-    occupancy_stats region_occupancy() noexcept;
-    occupancy_stats occupancy() noexcept;
-    size_t non_lsa_used_space() noexcept;
+    occupancy_stats region_occupancy() const noexcept;
+    occupancy_stats occupancy() const noexcept;
+    size_t non_lsa_used_space() const noexcept;
     // Set the minimum number of segments reclaimed during single reclamation cycle.
     void set_reclamation_step(size_t step_in_segments) noexcept { _reclamation_step = step_in_segments; }
     size_t reclamation_step() const noexcept { return _reclamation_step; }
@@ -2261,7 +2261,7 @@ std::ostream& operator<<(std::ostream& out, const occupancy_stats& stats) {
 // Note: allocation is disallowed in this path
 // since we don't instantiate reclaiming_lock
 // while traversing _regions
-occupancy_stats tracker::impl::region_occupancy() noexcept {
+occupancy_stats tracker::impl::region_occupancy() const noexcept {
     occupancy_stats total{};
     for (auto&& r: _regions) {
         total += r->occupancy();
@@ -2269,7 +2269,7 @@ occupancy_stats tracker::impl::region_occupancy() noexcept {
     return total;
 }
 
-occupancy_stats tracker::impl::occupancy() noexcept {
+occupancy_stats tracker::impl::occupancy() const noexcept {
     auto occ = region_occupancy();
     {
         auto s = shard_segment_pool.free_segments() * segment::size;
@@ -2278,7 +2278,7 @@ occupancy_stats tracker::impl::occupancy() noexcept {
     return occ;
 }
 
-size_t tracker::impl::non_lsa_used_space() noexcept {
+size_t tracker::impl::non_lsa_used_space() const noexcept {
 #ifdef SEASTAR_DEFAULT_ALLOCATOR
     return 0;
 #else

--- a/utils/logalloc.cc
+++ b/utils/logalloc.cc
@@ -444,7 +444,7 @@ private:
     // object is not re-entered while inside one of the tracker's methods.
     struct reclaiming_lock {
         impl& _ref;
-        reclaiming_lock(impl& ref)
+        reclaiming_lock(impl& ref) noexcept
             : _ref(ref)
         {
             _ref.disable_reclaim();
@@ -464,10 +464,10 @@ public:
             return make_ready_future<>();
         }
     }
-    void disable_reclaim() {
+    void disable_reclaim() noexcept {
         ++_reclaiming_disabled_depth;
     }
-    void enable_reclaim() {
+    void enable_reclaim() noexcept {
         --_reclaiming_disabled_depth;
     }
     void register_region(region::impl*);
@@ -483,15 +483,15 @@ public:
     size_t compact_and_evict(size_t reserve_segments, size_t bytes, is_preemptible p);
     void full_compaction();
     void reclaim_all_free_segments();
-    occupancy_stats region_occupancy();
-    occupancy_stats occupancy();
-    size_t non_lsa_used_space();
+    occupancy_stats region_occupancy() noexcept;
+    occupancy_stats occupancy() noexcept;
+    size_t non_lsa_used_space() noexcept;
     // Set the minimum number of segments reclaimed during single reclamation cycle.
-    void set_reclamation_step(size_t step_in_segments) { _reclamation_step = step_in_segments; }
-    size_t reclamation_step() const { return _reclamation_step; }
+    void set_reclamation_step(size_t step_in_segments) noexcept { _reclamation_step = step_in_segments; }
+    size_t reclamation_step() const noexcept { return _reclamation_step; }
     // Abort on allocation failure from LSA
-    void enable_abort_on_bad_alloc() { _abort_on_bad_alloc = true; }
-    bool should_abort_on_bad_alloc() const { return _abort_on_bad_alloc; }
+    void enable_abort_on_bad_alloc() noexcept { _abort_on_bad_alloc = true; }
+    bool should_abort_on_bad_alloc() const noexcept { return _abort_on_bad_alloc; }
     void setup_background_reclaim(scheduling_group sg) {
         assert(!_background_reclaimer);
         _background_reclaimer.emplace(sg, [this] (size_t target) {
@@ -2252,7 +2252,7 @@ std::ostream& operator<<(std::ostream& out, const occupancy_stats& stats) {
         stats.used_fraction() * 100, stats.used_space(), stats.total_space());
 }
 
-occupancy_stats tracker::impl::region_occupancy() {
+occupancy_stats tracker::impl::region_occupancy() noexcept {
     reclaiming_lock _(*this);
     occupancy_stats total{};
     for (auto&& r: _regions) {
@@ -2261,7 +2261,7 @@ occupancy_stats tracker::impl::region_occupancy() {
     return total;
 }
 
-occupancy_stats tracker::impl::occupancy() {
+occupancy_stats tracker::impl::occupancy() noexcept {
     reclaiming_lock _(*this);
     auto occ = region_occupancy();
     {
@@ -2271,7 +2271,7 @@ occupancy_stats tracker::impl::occupancy() {
     return occ;
 }
 
-size_t tracker::impl::non_lsa_used_space() {
+size_t tracker::impl::non_lsa_used_space() noexcept {
 #ifdef SEASTAR_DEFAULT_ALLOCATOR
     return 0;
 #else

--- a/utils/logalloc.cc
+++ b/utils/logalloc.cc
@@ -505,7 +505,7 @@ private:
     size_t reclaim_locked(size_t bytes, is_preemptible p);
 };
 
-tracker_reclaimer_lock::tracker_reclaimer_lock() : _tracker_impl(shard_tracker().get_impl()) {
+tracker_reclaimer_lock::tracker_reclaimer_lock() noexcept : _tracker_impl(shard_tracker().get_impl()) {
     _tracker_impl.disable_reclaim();
 }
 

--- a/utils/logalloc.cc
+++ b/utils/logalloc.cc
@@ -677,20 +677,20 @@ public:
         : _layout(memory::get_memory_layout())
         , _segments_base(align_down(_layout.start, (uintptr_t)segment::size)) {
     }
-    segment* segment_from_idx(size_t idx) const {
+    segment* segment_from_idx(size_t idx) const noexcept {
         return reinterpret_cast<segment*>(_segments_base) + idx;
     }
-    size_t idx_from_segment(segment* seg) const {
+    size_t idx_from_segment(segment* seg) const noexcept {
         return seg - reinterpret_cast<segment*>(_segments_base);
     }
-    size_t new_idx_for_segment(segment* seg) {
+    size_t new_idx_for_segment(segment* seg) noexcept {
         return idx_from_segment(seg);
     }
-    void free_segment(segment *seg) { }
-    size_t max_segments() const {
+    void free_segment(segment *seg) noexcept { }
+    size_t max_segments() const noexcept {
         return (_layout.end - _segments_base) / segment::size;
     }
-    bool can_allocate_more_segments() {
+    bool can_allocate_more_segments() noexcept {
         return memory::stats().free_memory() >= non_lsa_reserve + segment::size;
     }
 };
@@ -699,7 +699,7 @@ class segment_store {
     std::vector<segment*> _segments;
     std::unordered_map<segment*, size_t> _segment_indexes;
     static constexpr size_t _std_memory_available = size_t(1) << 30; // emulate 1GB per shard
-    std::vector<segment*>::iterator find_empty() {
+    std::vector<segment*>::iterator find_empty() noexcept {
         // segment 0 is a marker for no segment
         return std::find(_segments.begin() + 1, _segments.end(), nullptr);
     }
@@ -709,11 +709,11 @@ public:
     segment_store() : _segments(max_segments()) {
         _segment_indexes.reserve(max_segments());
     }
-    segment* segment_from_idx(size_t idx) const {
+    segment* segment_from_idx(size_t idx) const noexcept {
         assert(idx < _segments.size());
         return _segments[idx];
     }
-    size_t idx_from_segment(segment* seg) {
+    size_t idx_from_segment(segment* seg) const noexcept {
         // segment 0 is a marker for no segment
         auto i = _segment_indexes.find(seg);
         if (i == _segment_indexes.end()) {
@@ -721,7 +721,7 @@ public:
         }
         return i->second;
     }
-    size_t new_idx_for_segment(segment* seg) {
+    size_t new_idx_for_segment(segment* seg) noexcept {
         auto i = find_empty();
         assert(i != _segments.end());
         *i = seg;
@@ -729,7 +729,7 @@ public:
         _segment_indexes[seg] = ret;
         return ret;
     }
-    void free_segment(segment *seg) {
+    void free_segment(segment *seg) noexcept {
         size_t i = idx_from_segment(seg);
         assert(i != 0);
         _segment_indexes.erase(seg);
@@ -743,10 +743,10 @@ public:
             }
         }
     }
-    size_t max_segments() const {
+    size_t max_segments() const noexcept {
         return _std_memory_available / segment::size;
     }
-    bool can_allocate_more_segments() {
+    bool can_allocate_more_segments() noexcept {
         auto i = find_empty();
         return i != _segments.end();
     }

--- a/utils/logalloc.cc
+++ b/utils/logalloc.cc
@@ -835,7 +835,10 @@ public:
     segment_pool();
     void prime(size_t available_memory, size_t min_free_memory);
     segment* new_segment(region::impl* r);
-    segment_descriptor& descriptor(segment*) noexcept;
+    segment_descriptor& descriptor(segment* seg) noexcept {
+        uintptr_t index = idx_from_segment(seg);
+        return _segments[index];
+    }
     // Returns segment containing given object or nullptr.
     segment* containing_segment(const void* obj) noexcept;
     segment* segment_from(const segment_descriptor& desc) noexcept;
@@ -1126,12 +1129,6 @@ void segment_pool::refill_emergency_reserve() {
         ++_segments_in_use;
         free_segment(seg);
     }
-}
-
-segment_descriptor&
-segment_pool::descriptor(segment* seg) noexcept {
-    uintptr_t index = idx_from_segment(seg);
-    return _segments[index];
 }
 
 segment*

--- a/utils/logalloc.cc
+++ b/utils/logalloc.cc
@@ -2664,7 +2664,7 @@ allocating_section::guard::~guard() {
     shard_segment_pool.set_emergency_reserve_max(_prev);
 }
 
-void allocating_section::maybe_decay_reserve() {
+void allocating_section::maybe_decay_reserve() noexcept {
     // The decay rate is inversely proportional to the reserve
     // (every (s_segments_per_decay/_lsa_reserve) allocations).
     //
@@ -2729,11 +2729,11 @@ void allocating_section::on_alloc_failure(logalloc::region& r) {
     reserve();
 }
 
-void allocating_section::set_lsa_reserve(size_t reserve) {
+void allocating_section::set_lsa_reserve(size_t reserve) noexcept {
     _lsa_reserve = reserve;
 }
 
-void allocating_section::set_std_reserve(size_t reserve) {
+void allocating_section::set_std_reserve(size_t reserve) noexcept {
     _std_reserve = reserve;
 }
 

--- a/utils/logalloc.cc
+++ b/utils/logalloc.cc
@@ -617,19 +617,19 @@ struct segment_descriptor : public log_heap_hook<segment_descriptor_hist_options
     segment::size_type _free_space;
     region::impl* _region;
 
-    segment::size_type free_space() const {
+    segment::size_type free_space() const noexcept {
         return _free_space & free_space_mask;
     }
 
-    void set_free_space(segment::size_type free_space) {
+    void set_free_space(segment::size_type free_space) noexcept {
         _free_space = (_free_space & ~free_space_mask) | free_space;
     }
 
-    segment_kind kind() const {
+    segment_kind kind() const noexcept {
         return static_cast<segment_kind>((_free_space & segment_kind_mask) >> shift_for_segment_kind);
     }
 
-    void set_kind(segment_kind kind) {
+    void set_kind(segment_kind kind) noexcept {
         _free_space = (_free_space & ~segment_kind_mask)
                 | static_cast<segment::size_type>(kind) << shift_for_segment_kind;
     }
@@ -643,23 +643,23 @@ struct segment_descriptor : public log_heap_hook<segment_descriptor_hist_options
     // Also, not all entangled objects may be engaged.
     std::vector<entangled> _buf_pointers;
 
-    segment_descriptor()
+    segment_descriptor() noexcept
         : _region(nullptr)
     { }
 
-    bool is_empty() const {
+    bool is_empty() const noexcept {
         return free_space() == segment::size;
     }
 
-    occupancy_stats occupancy() const {
+    occupancy_stats occupancy() const noexcept {
         return { free_space(), segment::size };
     }
 
-    void record_alloc(segment::size_type size) {
+    void record_alloc(segment::size_type size) noexcept {
         _free_space -= size;
     }
 
-    void record_free(segment::size_type size) {
+    void record_free(segment::size_type size) noexcept {
         _free_space += size;
     }
 };

--- a/utils/logalloc.cc
+++ b/utils/logalloc.cc
@@ -2147,14 +2147,14 @@ region::unlisten() {
     get_impl().unlisten();
 }
 
-region_impl& region::get_impl() {
+region_impl& region::get_impl() noexcept {
     return *static_cast<region_impl*>(_impl.get());
 }
-const region_impl& region::get_impl() const {
+const region_impl& region::get_impl() const noexcept {
     return *static_cast<const region_impl*>(_impl.get());
 }
 
-region::region(region&& other) {
+region::region(region&& other) noexcept {
     this->_impl = std::move(other._impl);
     get_impl()._region = this;
     if (_impl) {
@@ -2165,7 +2165,7 @@ region::region(region&& other) {
     }
 }
 
-region& region::operator=(region&& other) {
+region& region::operator=(region&& other) noexcept {
     if (this == &other || _impl == other._impl) {
         return *this;
     }
@@ -2199,7 +2199,7 @@ region::~region() {
     }
 }
 
-occupancy_stats region::occupancy() const {
+occupancy_stats region::occupancy() const noexcept {
     return get_impl().occupancy();
 }
 
@@ -2233,7 +2233,7 @@ memory::reclaiming_result region::evict_some() {
     return memory::reclaiming_result::reclaimed_nothing;
 }
 
-void region::make_evictable(eviction_fn fn) {
+void region::make_evictable(eviction_fn fn) noexcept {
     get_impl().make_evictable(std::move(fn));
 }
 
@@ -2241,15 +2241,15 @@ void region::ground_evictable_occupancy() {
     get_impl().ground_evictable_occupancy();
 }
 
-occupancy_stats region::evictable_occupancy() {
+occupancy_stats region::evictable_occupancy() const noexcept {
     return get_impl().evictable_occupancy();
 }
 
-const eviction_fn& region::evictor() const {
+const eviction_fn& region::evictor() const noexcept {
     return get_impl().evictor();
 }
 
-uint64_t region::id() const {
+uint64_t region::id() const noexcept {
     return get_impl().id();
 }
 

--- a/utils/logalloc.cc
+++ b/utils/logalloc.cc
@@ -2743,23 +2743,23 @@ future<> prime_segment_pool(size_t available_memory, size_t min_free_memory) {
     });
 }
 
-uint64_t memory_allocated() {
+uint64_t memory_allocated() noexcept {
     return shard_segment_pool.statistics().memory_allocated;
 }
 
-uint64_t memory_freed() {
+uint64_t memory_freed() noexcept {
     return shard_segment_pool.statistics().memory_freed;
 }
 
-uint64_t memory_compacted() {
+uint64_t memory_compacted() noexcept {
     return shard_segment_pool.statistics().memory_compacted;
 }
 
-uint64_t memory_evicted() {
+uint64_t memory_evicted() noexcept {
     return shard_segment_pool.statistics().memory_evicted;
 }
 
-occupancy_stats lsa_global_occupancy_stats() {
+occupancy_stats lsa_global_occupancy_stats() noexcept {
     return occupancy_stats(shard_segment_pool.total_free_memory(), shard_segment_pool.total_memory_in_use());
 }
 

--- a/utils/logalloc.cc
+++ b/utils/logalloc.cc
@@ -1501,7 +1501,7 @@ private:
     struct compaction_lock {
         region_impl& _region;
         bool _prev;
-        compaction_lock(region_impl& r)
+        compaction_lock(region_impl& r) noexcept
             : _region(r)
             , _prev(r._reclaiming_enabled)
         {
@@ -1734,7 +1734,7 @@ private:
         _buf_active_offset = 0;
     }
 
-    static uint64_t next_id() {
+    static uint64_t next_id() noexcept {
         static std::atomic<uint64_t> id{0};
         return id.fetch_add(1);
     }
@@ -1845,7 +1845,7 @@ public:
     //
     //    while (is_compactible()) { compact(); }
     //
-    bool is_compactible() const {
+    bool is_compactible() const noexcept {
         return _reclaiming_enabled
             // We require 2 segments per allocation segregation group to ensure forward progress during compaction.
             // There are currently two fixed groups, one for the allocation_strategy implementation and one for lsa_buffer:s.
@@ -1853,7 +1853,7 @@ public:
             && _segment_descs.contains_above_min();
     }
 
-    bool is_idle_compactible() {
+    bool is_idle_compactible() const noexcept {
         return is_compactible();
     }
 
@@ -2011,7 +2011,7 @@ public:
     }
 
     // Returns occupancy of the sparsest compactible segment.
-    occupancy_stats min_occupancy() const {
+    occupancy_stats min_occupancy() const noexcept {
         if (_segment_descs.empty()) {
             return {};
         }
@@ -2019,7 +2019,7 @@ public:
     }
 
     // Compacts a single segment, most appropriate for it
-    void compact() {
+    void compact() noexcept {
         compaction_lock _(*this);
         auto& desc = _segment_descs.one_of_largest();
         _segment_descs.pop_one_of_largest();
@@ -2058,16 +2058,16 @@ public:
         compact_segment_locked(seg, desc);
     }
 
-    allocation_strategy& allocator() {
+    allocation_strategy& allocator() noexcept {
         return *this;
     }
 
-    uint64_t id() const {
+    uint64_t id() const noexcept {
         return _id;
     }
 
     // Returns true if this pool is evictable, so that evict_some() can be called.
-    bool is_evictable() const {
+    bool is_evictable() const noexcept {
         return _evictable && _reclaiming_enabled;
     }
 
@@ -2079,17 +2079,17 @@ public:
         return ret;
     }
 
-    void make_not_evictable() {
+    void make_not_evictable() noexcept {
         _evictable = false;
         _eviction_fn = {};
     }
 
-    void make_evictable(eviction_fn fn) {
+    void make_evictable(eviction_fn fn) noexcept {
         _evictable = true;
         _eviction_fn = std::move(fn);
     }
 
-    const eviction_fn& evictor() const {
+    const eviction_fn& evictor() const noexcept {
         return _eviction_fn;
     }
 

--- a/utils/logalloc.cc
+++ b/utils/logalloc.cc
@@ -1400,58 +1400,58 @@ class region_impl final : public basic_region_impl {
     private:
         uint32_t _n;
     private:
-        explicit object_descriptor(uint32_t n) : _n(n) {}
+        explicit object_descriptor(uint32_t n) noexcept : _n(n) {}
     public:
-        object_descriptor(allocation_strategy::migrate_fn migrator)
+        object_descriptor(allocation_strategy::migrate_fn migrator) noexcept
                 : _n(migrator->index() * 2 + 1)
         { }
 
-        static object_descriptor make_dead(size_t size) {
+        static object_descriptor make_dead(size_t size) noexcept {
             return object_descriptor(size * 2);
         }
 
-        allocation_strategy::migrate_fn migrator() const {
+        allocation_strategy::migrate_fn migrator() const noexcept {
             return static_migrators()[_n / 2];
         }
 
-        uint8_t alignment() const {
+        uint8_t alignment() const noexcept {
             return migrator()->align();
         }
 
         // excluding descriptor
-        segment::size_type live_size(const void* obj) const {
+        segment::size_type live_size(const void* obj) const noexcept {
             return migrator()->size(obj);
         }
 
         // including descriptor
-        segment::size_type dead_size() const {
+        segment::size_type dead_size() const noexcept {
             return _n / 2;
         }
 
-        bool is_live() const {
+        bool is_live() const noexcept {
             return (_n & 1) == 1;
         }
 
-        segment::size_type encoded_size() const {
+        segment::size_type encoded_size() const noexcept {
             return utils::uleb64_encoded_size(_n); // 0 is illegal
         }
 
-        void encode(char*& pos) const {
+        void encode(char*& pos) const noexcept {
             utils::uleb64_encode(pos, _n, poison<char>, unpoison);
         }
 
         // non-canonical encoding to allow padding (for alignment); encoded_size must be
         // sufficient (greater than this->encoded_size()), _n must be the migrator's
         // index() (i.e. -- suitable for express encoding)
-        void encode(char*& pos, size_t encoded_size, size_t size) const {
+        void encode(char*& pos, size_t encoded_size, size_t size) const noexcept {
             utils::uleb64_express_encode(pos, _n, encoded_size, size, poison<char>, unpoison);
         }
 
-        static object_descriptor decode_forwards(const char*& pos) {
+        static object_descriptor decode_forwards(const char*& pos) noexcept {
             return object_descriptor(utils::uleb64_decode_forwards(pos, poison<char>, unpoison));
         }
 
-        static object_descriptor decode_backwards(const char*& pos) {
+        static object_descriptor decode_backwards(const char*& pos) noexcept {
             return object_descriptor(utils::uleb64_decode_bacwards(pos, poison<char>, unpoison));
         }
 

--- a/utils/logalloc.cc
+++ b/utils/logalloc.cc
@@ -1790,7 +1790,7 @@ public:
     region_impl(region_impl&&) = delete;
     region_impl(const region_impl&) = delete;
 
-    bool empty() const {
+    bool empty() const noexcept {
         return occupancy().used_space() == 0;
     }
 
@@ -1812,7 +1812,7 @@ public:
     // Note: allocation is disallowed in this path
     // since we don't instantiate reclaiming_lock
     // while traversing _regions
-    occupancy_stats occupancy() const {
+    occupancy_stats occupancy() const noexcept {
         occupancy_stats total = _non_lsa_occupancy;
         total += _closed_occupancy;
         if (_active) {
@@ -1824,11 +1824,11 @@ public:
         return total;
     }
 
-    occupancy_stats compactible_occupancy() const {
+    occupancy_stats compactible_occupancy() const noexcept {
         return _closed_occupancy;
     }
 
-    occupancy_stats evictable_occupancy() const {
+    occupancy_stats evictable_occupancy() const noexcept {
         return occupancy_stats(0, _evictable_space & _evictable_space_mask);
     }
 

--- a/utils/logalloc.cc
+++ b/utils/logalloc.cc
@@ -815,7 +815,6 @@ private:
     friend void segment::operator delete(void*);
 
     segment* allocate_or_fallback_to_reserve();
-    void free_or_restore_to_reserve(segment* seg) noexcept;
     const segment* segment_from_idx(size_t idx) const noexcept {
         return _store.segment_from_idx(idx);
     }

--- a/utils/logalloc.cc
+++ b/utils/logalloc.cc
@@ -565,19 +565,19 @@ struct alignas(segment_size) segment {
     segment() noexcept { }
 
     template<typename T = void>
-    const T* at(size_t offset) const {
+    const T* at(size_t offset) const noexcept {
         return reinterpret_cast<const T*>(data + offset);
     }
 
     template<typename T = void>
-    T* at(size_t offset) {
+    T* at(size_t offset) noexcept {
         return reinterpret_cast<T*>(data + offset);
     }
 
-    bool is_empty();
-    void record_alloc(size_type size);
-    void record_free(size_type size);
-    occupancy_stats occupancy();
+    bool is_empty() const noexcept;
+    void record_alloc(size_type size) noexcept;
+    void record_free(size_type size) noexcept;
+    occupancy_stats occupancy() const noexcept;
 
     static void* operator new(size_t size) = delete;
     static void* operator new(size_t, void* ptr) noexcept { return ptr; }
@@ -1258,20 +1258,20 @@ static segment_pool& get_shard_segment_pool() noexcept {
 
 static thread_local segment_pool& shard_segment_pool = get_shard_segment_pool();
 
-void segment::record_alloc(segment::size_type size) {
+void segment::record_alloc(segment::size_type size) noexcept {
     shard_segment_pool.descriptor(this).record_alloc(size);
 }
 
-void segment::record_free(segment::size_type size) {
+void segment::record_free(segment::size_type size) noexcept {
     shard_segment_pool.descriptor(this).record_free(size);
 }
 
-bool segment::is_empty() {
+bool segment::is_empty() const noexcept {
     return shard_segment_pool.descriptor(this).is_empty();
 }
 
 occupancy_stats
-segment::occupancy() {
+segment::occupancy() const noexcept {
     return { shard_segment_pool.descriptor(this).free_space(), segment::size };
 }
 

--- a/utils/logalloc.cc
+++ b/utils/logalloc.cc
@@ -550,7 +550,7 @@ void tracker::reclaim_all_free_segments() {
     return _impl->reclaim_all_free_segments();
 }
 
-tracker& shard_tracker() {
+tracker& shard_tracker() noexcept {
     return tracker_instance;
 }
 

--- a/utils/logalloc.hh
+++ b/utils/logalloc.hh
@@ -97,20 +97,20 @@ public:
     void reclaim_all_free_segments();
 
     // Returns aggregate statistics for all pools.
-    occupancy_stats region_occupancy();
+    occupancy_stats region_occupancy() const noexcept;
 
     // Returns statistics for all segments allocated by LSA on this shard.
-    occupancy_stats occupancy();
+    occupancy_stats occupancy() const noexcept;
 
     // Returns amount of allocated memory not managed by LSA
-    size_t non_lsa_used_space() const;
+    size_t non_lsa_used_space() const noexcept;
 
-    impl& get_impl() { return *_impl; }
+    impl& get_impl() noexcept { return *_impl; }
 
     // Returns the minimum number of segments reclaimed during single reclamation cycle.
-    size_t reclamation_step() const;
+    size_t reclamation_step() const noexcept;
 
-    bool should_abort_on_bad_alloc();
+    bool should_abort_on_bad_alloc() const noexcept;
 };
 
 class tracker_reclaimer_lock {

--- a/utils/logalloc.hh
+++ b/utils/logalloc.hh
@@ -120,7 +120,7 @@ public:
     ~tracker_reclaimer_lock();
 };
 
-tracker& shard_tracker();
+tracker& shard_tracker() noexcept;
 
 class segment_descriptor;
 

--- a/utils/logalloc.hh
+++ b/utils/logalloc.hh
@@ -392,12 +392,12 @@ private:
         ~guard();
     };
     void reserve();
-    void maybe_decay_reserve();
+    void maybe_decay_reserve() noexcept;
     void on_alloc_failure(logalloc::region&);
 public:
 
-    void set_lsa_reserve(size_t);
-    void set_std_reserve(size_t);
+    void set_lsa_reserve(size_t) noexcept;
+    void set_std_reserve(size_t) noexcept;
 
     //
     // Reserves standard allocator and LSA memory for subsequent operations that

--- a/utils/logalloc.hh
+++ b/utils/logalloc.hh
@@ -388,7 +388,7 @@ class allocating_section {
 private:
     struct guard {
         size_t _prev;
-        guard();
+        guard() noexcept;
         ~guard();
     };
     void reserve();

--- a/utils/logalloc.hh
+++ b/utils/logalloc.hh
@@ -471,11 +471,11 @@ public:
 
 future<> prime_segment_pool(size_t available_memory, size_t min_free_memory);
 
-uint64_t memory_allocated();
-uint64_t memory_freed();
-uint64_t memory_compacted();
-uint64_t memory_evicted();
+uint64_t memory_allocated() noexcept;
+uint64_t memory_freed() noexcept;
+uint64_t memory_compacted() noexcept;
+uint64_t memory_evicted() noexcept;
 
-occupancy_stats lsa_global_occupancy_stats();
+occupancy_stats lsa_global_occupancy_stats() noexcept;
 
 }

--- a/utils/logalloc.hh
+++ b/utils/logalloc.hh
@@ -174,11 +174,11 @@ public:
 
     /// Returns a pointer to the first element of the buffer.
     /// Valid only when engaged.
-    char_type* get() { return _buf; }
-    const char_type* get() const { return _buf; }
+    char_type* get() noexcept { return _buf; }
+    const char_type* get() const noexcept { return _buf; }
 
     /// Returns the number of bytes in the buffer.
-    size_t size() const { return _size; }
+    size_t size() const noexcept { return _size; }
 
     /// Returns true iff the pointer is engaged.
     explicit operator bool() const noexcept { return bool(_link); }

--- a/utils/logalloc.hh
+++ b/utils/logalloc.hh
@@ -283,19 +283,19 @@ public:
 private:
     shared_ptr<basic_region_impl> _impl;
 private:
-    region_impl& get_impl();
-    const region_impl& get_impl() const;
+    region_impl& get_impl() noexcept;
+    const region_impl& get_impl() const noexcept;
 public:
     region();
     ~region();
-    region(region&& other);
-    region& operator=(region&& other);
+    region(region&& other) noexcept;
+    region& operator=(region&& other) noexcept;
     region(const region& other) = delete;
 
     void listen(region_listener* listener);
     void unlisten();
 
-    occupancy_stats occupancy() const;
+    occupancy_stats occupancy() const noexcept;
 
     allocation_strategy& allocator() noexcept {
         return *_impl;
@@ -323,15 +323,15 @@ public:
     // Changes the reclaimability state of this region. When region is not
     // reclaimable, it won't be considered by tracker::reclaim(). By default region is
     // reclaimable after construction.
-    void set_reclaiming_enabled(bool e) { _impl->set_reclaiming_enabled(e); }
+    void set_reclaiming_enabled(bool e) noexcept { _impl->set_reclaiming_enabled(e); }
 
     // Returns the reclaimability state of this region.
-    bool reclaiming_enabled() const { return _impl->reclaiming_enabled(); }
+    bool reclaiming_enabled() const noexcept { return _impl->reclaiming_enabled(); }
 
     // Returns a value which is increased when this region is either compacted or
     // evicted from, which invalidates references into the region.
     // When the value returned by this method doesn't change, references remain valid.
-    uint64_t reclaim_counter() const {
+    uint64_t reclaim_counter() const noexcept {
         return allocator().invalidate_counter();
     }
 
@@ -340,16 +340,16 @@ public:
 
     // Follows region's occupancy in the parent region group. Less fine-grained than occupancy().
     // After ground_evictable_occupancy() is called returns 0.
-    occupancy_stats evictable_occupancy();
+    occupancy_stats evictable_occupancy() const noexcept;
 
     // Makes this region an evictable region. Supplied function will be called
     // when data from this region needs to be evicted in order to reclaim space.
     // The function should free some space from this region.
-    void make_evictable(eviction_fn);
+    void make_evictable(eviction_fn) noexcept;
 
-    const eviction_fn& evictor() const;
+    const eviction_fn& evictor() const noexcept;
 
-    uint64_t id() const;
+    uint64_t id() const noexcept;
 
     friend class allocating_section;
 };

--- a/utils/logalloc.hh
+++ b/utils/logalloc.hh
@@ -191,56 +191,56 @@ class occupancy_stats {
     size_t _free_space;
     size_t _total_space;
 public:
-    occupancy_stats() : _free_space(0), _total_space(0) {}
+    occupancy_stats() noexcept : _free_space(0), _total_space(0) {}
 
-    occupancy_stats(size_t free_space, size_t total_space)
+    occupancy_stats(size_t free_space, size_t total_space) noexcept
         : _free_space(free_space), _total_space(total_space) { }
 
-    bool operator<(const occupancy_stats& other) const {
+    bool operator<(const occupancy_stats& other) const noexcept {
         return used_fraction() < other.used_fraction();
     }
 
-    friend occupancy_stats operator+(const occupancy_stats& s1, const occupancy_stats& s2) {
+    friend occupancy_stats operator+(const occupancy_stats& s1, const occupancy_stats& s2) noexcept {
         occupancy_stats result(s1);
         result += s2;
         return result;
     }
 
-    friend occupancy_stats operator-(const occupancy_stats& s1, const occupancy_stats& s2) {
+    friend occupancy_stats operator-(const occupancy_stats& s1, const occupancy_stats& s2) noexcept {
         occupancy_stats result(s1);
         result -= s2;
         return result;
     }
 
-    occupancy_stats& operator+=(const occupancy_stats& other) {
+    occupancy_stats& operator+=(const occupancy_stats& other) noexcept {
         _total_space += other._total_space;
         _free_space += other._free_space;
         return *this;
     }
 
-    occupancy_stats& operator-=(const occupancy_stats& other) {
+    occupancy_stats& operator-=(const occupancy_stats& other) noexcept {
         _total_space -= other._total_space;
         _free_space -= other._free_space;
         return *this;
     }
 
-    size_t used_space() const {
+    size_t used_space() const noexcept {
         return _total_space - _free_space;
     }
 
-    size_t free_space() const {
+    size_t free_space() const noexcept {
         return _free_space;
     }
 
-    size_t total_space() const {
+    size_t total_space() const noexcept {
         return _total_space;
     }
 
-    float used_fraction() const {
+    float used_fraction() const noexcept {
         return _total_space ? float(used_space()) / total_space() : 0;
     }
 
-    explicit operator bool() const {
+    explicit operator bool() const noexcept {
         return _total_space > 0;
     }
 

--- a/utils/logalloc.hh
+++ b/utils/logalloc.hh
@@ -116,7 +116,7 @@ public:
 class tracker_reclaimer_lock {
     tracker::impl& _tracker_impl;
 public:
-    tracker_reclaimer_lock();
+    tracker_reclaimer_lock() noexcept;
     ~tracker_reclaimer_lock();
 };
 

--- a/utils/logalloc.hh
+++ b/utils/logalloc.hh
@@ -252,12 +252,12 @@ protected:
     bool _reclaiming_enabled = true;
     seastar::shard_id _cpu = this_shard_id();
 public:
-    void set_reclaiming_enabled(bool enabled) {
+    void set_reclaiming_enabled(bool enabled) noexcept {
         assert(this_shard_id() == _cpu);
         _reclaiming_enabled = enabled;
     }
 
-    bool reclaiming_enabled() const {
+    bool reclaiming_enabled() const noexcept {
         return _reclaiming_enabled;
     }
 };

--- a/utils/logalloc.hh
+++ b/utils/logalloc.hh
@@ -360,7 +360,7 @@ public:
 struct reclaim_lock {
     region& _region;
     bool _prev;
-    reclaim_lock(region& r)
+    reclaim_lock(region& r) noexcept
         : _region(r)
         , _prev(r.reclaiming_enabled())
     {


### PR DESCRIPTION
The series unifies memtable flush error handling into table::seal_active_memtable
following up on f6d9d6175fad11bc1dbf0aa06e587953c0ba8dad.

The goal here is to prevent an infinite retry loop as in #10498
by aborting on any error that is not bad_alloc.

Fixes #10498