### PR TITLE
Revert "test.py: temporarily disable raft"

### DIFF
--- a/test/pylib/scylla_server.py
+++ b/test/pylib/scylla_server.py
@@ -32,8 +32,8 @@ developer_mode: true
 enable_user_defined_functions: true
 experimental: true
 experimental_features:
+    - raft
     - udf
-#    - raft
 
 data_file_directories:
     - {workdir}/data


### PR DESCRIPTION
This reverts commit 26128a222b7e8209600d4b95086f752aff19d86c.

The issue the commit depends on is fixed, so enable raft back.