### PR TITLE
treewide: replace parallel_for_each with coroutine::parallel_for_each in coroutines

### DIFF
--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -15,6 +15,7 @@
 #include <seastar/core/metrics.hh>
 #include <seastar/core/coroutine.hh>
 #include <seastar/coroutine/switch_to.hh>
+#include <seastar/coroutine/parallel_for_each.hh>
 #include "sstables/exceptions.hh"
 #include "locator/abstract_replication_strategy.hh"
 #include "utils/fb_utilities.hh"
@@ -700,7 +701,7 @@ future<> compaction_manager::stop_tasks(std::vector<shared_ptr<task>> tasks, sst
         cmlog.debug("Stopping {}", *t);
         t->stop(reason);
     }
-    co_await parallel_for_each(tasks, [this] (auto& task) -> future<> {
+    co_await coroutine::parallel_for_each(tasks, [this] (auto& task) -> future<> {
         try {
             co_await task->compaction_done();
         } catch (sstables::compaction_stopped_exception&) {

--- a/db/commitlog/commitlog.cc
+++ b/db/commitlog/commitlog.cc
@@ -34,6 +34,7 @@
 #include <seastar/core/queue.hh>
 #include <seastar/core/sleep.hh>
 #include <seastar/core/coroutine.hh>
+#include <seastar/coroutine/parallel_for_each.hh>
 #include <seastar/net/byteorder.hh>
 #include <seastar/util/defer.hh>
 
@@ -1853,7 +1854,7 @@ future<> db::commitlog::segment_manager::sync_all_segments() {
     // #8952 - calls that do sync/cycle can end up altering
     // _segments (end_flush()->discard_unused())
     auto def_copy = _segments;
-    co_await parallel_for_each(def_copy, [] (sseg_ptr s) -> future<> {
+    co_await coroutine::parallel_for_each(def_copy, [] (sseg_ptr s) -> future<> {
         co_await s->sync();
         clogger.debug("Synced segment {}", *s);
     });
@@ -1864,7 +1865,7 @@ future<> db::commitlog::segment_manager::shutdown_all_segments() {
     // #8952 - calls that do sync/cycle can end up altering
     // _segments (end_flush()->discard_unused())
     auto def_copy = _segments;
-    co_await parallel_for_each(def_copy, [] (sseg_ptr s) -> future<> {
+    co_await coroutine::parallel_for_each(def_copy, [] (sseg_ptr s) -> future<> {
         co_await s->shutdown();
         clogger.debug("Shutdown segment {}", *s);
     });

--- a/db/hints/manager.cc
+++ b/db/hints/manager.cc
@@ -14,6 +14,7 @@
 #include <seastar/core/gate.hh>
 #include <seastar/core/abort_source.hh>
 #include <seastar/core/coroutine.hh>
+#include <seastar/coroutine/parallel_for_each.hh>
 #include <boost/range/adaptors.hpp>
 #include "utils/div_ceil.hh"
 #include "db/extensions.hh"
@@ -183,7 +184,7 @@ future<> manager::wait_for_sync_point(abort_source& as, const sync_point::shard_
     }
 
     bool was_aborted = false;
-    co_await parallel_for_each(_ep_managers, [this, &was_aborted, &rps, &local_as] (auto& p) {
+    co_await coroutine::parallel_for_each(_ep_managers, [this, &was_aborted, &rps, &local_as] (auto& p) {
         const auto addr = p.first;
         auto& ep_man = p.second;
 

--- a/direct_failure_detector/failure_detector.cc
+++ b/direct_failure_detector/failure_detector.cc
@@ -14,6 +14,7 @@
 #include <seastar/core/sleep.hh>
 #include <seastar/core/on_internal_error.hh>
 #include <seastar/core/condition-variable.hh>
+#include <seastar/coroutine/parallel_for_each.hh>
 #include <seastar/util/defer.hh>
 
 #include "log.hh"
@@ -620,7 +621,7 @@ future<> endpoint_worker::notify_fiber() noexcept {
             endpoint_liveness.marked_alive = alive;
 
             try {
-                co_await parallel_for_each(listeners.begin(), listeners.end(), [this, endpoint = _id, alive] (const listener_info& listener) {
+                co_await coroutine::parallel_for_each(listeners.begin(), listeners.end(), [this, endpoint = _id, alive] (const listener_info& listener) {
                     return _fd._parent.container().invoke_on(listener.shard, [listener = listener.id, endpoint, alive] (failure_detector& fd) {
                         return fd._impl->mark(listener, endpoint, alive);
                     });

--- a/redis/keyspace_utils.cc
+++ b/redis/keyspace_utils.cc
@@ -7,6 +7,7 @@
  */
 
 #include <seastar/core/coroutine.hh>
+#include <seastar/coroutine/parallel_for_each.hh>
 #include "redis/keyspace_utils.hh"
 #include "schema_builder.hh"
 #include "types.hh"
@@ -219,7 +220,7 @@ future<> create_keyspace_if_not_exists_impl(seastar::sharded<service::storage_pr
         std::move(muts.begin(), muts.end(), std::back_inserter(table_mutations));
     }, db, std::ref(mml), std::ref(table_mutations), group0_guard.write_timestamp());
 
-    co_await parallel_for_each(ks_names, [table_gen = std::move(table_gen)] (const sstring& ks_name) mutable {
+    co_await coroutine::parallel_for_each(ks_names, [table_gen = std::move(table_gen)] (const sstring& ks_name) mutable {
         return parallel_for_each(tables, [ks_name, table_gen = std::move(table_gen)] (table t) {
             return table_gen(ks_name, t.name, t.schema(ks_name));
         }).discard_result();

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -24,6 +24,7 @@
 #include <seastar/util/bool_class.hh>
 #include <seastar/core/metrics_registration.hh>
 #include <seastar/core/coroutine.hh>
+#include <seastar/coroutine/parallel_for_each.hh>
 #include <list>
 #include <vector>
 #include <algorithm>
@@ -2690,7 +2691,7 @@ private:
         repair_update_system_table_request req{_ri.id.uuid, _table_id, _ri.keyspace, _cf_name, _range, repair_time};
         auto all_nodes = _all_live_peer_nodes;
         all_nodes.push_back(utils::fb_utilities::get_broadcast_address());
-        co_await parallel_for_each(all_nodes, [this, req] (gms::inet_address node) -> future<> {
+        co_await coroutine::parallel_for_each(all_nodes, [this, req] (gms::inet_address node) -> future<> {
             try {
                 auto& ms = _ri.messaging.local();
                 repair_update_system_table_response resp = co_await ser::partition_checksum_rpc_verbs::send_repair_update_system_table(&ms, netw::messaging_service::msg_addr(node), req);

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -765,7 +765,7 @@ do_parse_schema_tables(distributed<service::storage_proxy>& proxy, const sstring
         auto keyspace_name = r.template get_nonnull<sstring>("keyspace_name");
         names.emplace(keyspace_name);
     }
-    co_await parallel_for_each(names.begin(), names.end(), [&] (sstring name) mutable -> future<> {
+    co_await coroutine::parallel_for_each(names.begin(), names.end(), [&] (sstring name) mutable -> future<> {
         if (is_system_keyspace(name)) {
             co_return;
         }
@@ -803,7 +803,7 @@ future<> database::parse_system_tables(distributed<service::storage_proxy>& prox
     });
     co_await do_parse_schema_tables(proxy, db::schema_tables::TABLES, [&] (schema_result_value_type &v) -> future<> {
         std::map<sstring, schema_ptr> tables = co_await create_tables_from_tables_partition(proxy, v.second);
-        co_await parallel_for_each(tables.begin(), tables.end(), [&] (auto& t) -> future<> {
+        co_await coroutine::parallel_for_each(tables.begin(), tables.end(), [&] (auto& t) -> future<> {
             co_await this->add_column_family_and_make_directory(t.second);
             auto s = t.second;
             // Recreate missing column mapping entries in case
@@ -817,7 +817,7 @@ future<> database::parse_system_tables(distributed<service::storage_proxy>& prox
     });
     co_await do_parse_schema_tables(proxy, db::schema_tables::VIEWS, [&] (schema_result_value_type &v) -> future<> {
         std::vector<view_ptr> views = co_await create_views_from_schema_partition(proxy, v.second);
-        co_await parallel_for_each(views.begin(), views.end(), [&] (auto&& v) -> future<> {
+        co_await coroutine::parallel_for_each(views.begin(), views.end(), [&] (auto&& v) -> future<> {
             // TODO: Remove once computed columns are guaranteed to be featured in the whole cluster.
             // we fix here the schema in place in oreder to avoid races (write commands comming from other coordinators).
             view_ptr fixed_v = maybe_fix_legacy_secondary_index_mv_schema(*this, v, nullptr, preserve_version::yes);
@@ -1981,7 +1981,7 @@ schema_ptr database::find_indexed_table(const sstring& ks_name, const sstring& i
 
 future<> database::close_tables(table_kind kind_to_close) {
     auto b = defer([this] { _stop_barrier.abort(); });
-    co_await parallel_for_each(_column_families, [this, kind_to_close](auto& val_pair) -> future<> {
+    co_await coroutine::parallel_for_each(_column_families, [this, kind_to_close](auto& val_pair) -> future<> {
         table_kind k = is_system_table(*val_pair.second->schema()) ? table_kind::system : table_kind::user;
         if (k == kind_to_close) {
             co_await val_pair.second->stop();
@@ -2134,7 +2134,7 @@ future<> database::truncate(const keyspace& ks, column_family& cf, timestamp_fun
     cres.reserve(1 + cf.views().size());
 
     cres.emplace_back(co_await _compaction_manager->stop_and_disable_compaction(&cf));
-    co_await parallel_for_each(cf.views(), [&, this] (view_ptr v) -> future<> {
+    co_await coroutine::parallel_for_each(cf.views(), [&, this] (view_ptr v) -> future<> {
         auto& vcf = find_column_family(v);
         cres.emplace_back(co_await _compaction_manager->stop_and_disable_compaction(&vcf));
     });
@@ -2170,7 +2170,7 @@ future<> database::truncate(const keyspace& ks, column_family& cf, timestamp_fun
     // creating the sstables that would create them.
     assert(!did_flush || low_mark <= rp || rp == db::replay_position());
     rp = std::max(low_mark, rp);
-    co_await parallel_for_each(cf.views(), [this, truncated_at, should_flush] (view_ptr v) -> future<> {
+    co_await coroutine::parallel_for_each(cf.views(), [this, truncated_at, should_flush] (view_ptr v) -> future<> {
         auto& vcf = find_column_family(v);
             if (should_flush) {
                 co_await vcf.flush();

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -1059,7 +1059,7 @@ future<paxos::prepare_summary> paxos_response_handler::prepare_ballot(utils::UUI
             };
             std::visit(on_prepare_response, std::move(response));
         };
-        co_return co_await parallel_for_each(_live_endpoints, handle_one_msg);
+        co_return co_await coroutine::parallel_for_each(_live_endpoints, handle_one_msg);
     });
 
     return f;
@@ -1199,7 +1199,7 @@ future<bool> paxos_response_handler::accept_proposal(lw_shared_ptr<paxos::propos
                 }
             } // wait for more replies
         };
-        co_return co_await parallel_for_each(_live_endpoints, handle_one_msg);
+        co_return co_await coroutine::parallel_for_each(_live_endpoints, handle_one_msg);
     }); // do_with
 
     return f;
@@ -5420,7 +5420,7 @@ future<db::hints::sync_point> storage_proxy::create_hint_sync_point(const std::v
     spoint.regular_per_shard_rps.resize(smp::count);
     spoint.mv_per_shard_rps.resize(smp::count);
     spoint.host_id = _db.local().get_config().host_id;
-    co_await parallel_for_each(boost::irange<unsigned>(0, smp::count), [this, &target_hosts, &spoint] (unsigned shard) {
+    co_await coroutine::parallel_for_each(boost::irange<unsigned>(0, smp::count), [this, &target_hosts, &spoint] (unsigned shard) {
         const auto& sharded_sp = container();
         // sharded::invoke_on does not have a const-method version, so we cannot use it here
         return smp::submit_to(shard, [&sharded_sp, &target_hosts] {

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -61,6 +61,7 @@
 #include "utils/generation-number.hh"
 #include <seastar/core/coroutine.hh>
 #include <seastar/coroutine/maybe_yield.hh>
+#include <seastar/coroutine/parallel_for_each.hh>
 #include "utils/stall_free.hh"
 
 #include <boost/algorithm/string/split.hpp>
@@ -1829,14 +1830,17 @@ future<> storage_service::node_ops_cmd_heartbeat_updater(node_ops_cmd cmd, utils
     slogger.info("{}[{}]: Started heartbeat_updater", ops, uuid);
     while (!(*heartbeat_updater_done)) {
         auto req = node_ops_cmd_request{cmd, uuid, {}, {}, {}};
-        co_await parallel_for_each(nodes, [this, ops, uuid, &req] (const gms::inet_address& node) {
+        try {
+          co_await coroutine::parallel_for_each(nodes, [this, ops, uuid, &req] (const gms::inet_address& node) {
             return _messaging.local().send_node_ops_cmd(netw::msg_addr(node), req).then([ops, uuid, node] (node_ops_cmd_response resp) {
                 slogger.debug("{}[{}]: Got heartbeat response from node={}", ops, uuid, node);
                 return make_ready_future<>();
             });
-        }).handle_exception([ops, uuid] (std::exception_ptr ep) {
+          });
+        } catch (...) {
+            auto ep = std::current_exception();
             slogger.warn("{}[{}]: Failed to send heartbeat: {}", ops, uuid, ep);
-        });
+        }
         int nr_seconds = 10;
         while (!(*heartbeat_updater_done) && nr_seconds--) {
             co_await sleep(std::chrono::seconds(1));

--- a/table_helper.cc
+++ b/table_helper.cc
@@ -8,6 +8,7 @@
  */
 
 #include <seastar/core/coroutine.hh>
+#include <seastar/coroutine/parallel_for_each.hh>
 #include "table_helper.hh"
 #include "cql3/query_processor.hh"
 #include "cql3/statements/create_table_statement.hh"
@@ -145,7 +146,7 @@ future<> table_helper::setup_keyspace(cql3::query_processor& qp, std::string_vie
     qs.get_client_state().set_keyspace(db.real_database(), keyspace_name);
 
     // Create tables
-    co_await parallel_for_each(tables, [&qp] (table_helper* t) {
+    co_await coroutine::parallel_for_each(tables, [&qp] (table_helper* t) {
         return table_helper::setup_table(qp, t->_create_cql);
     });
 }

--- a/test/raft/generator.hh
+++ b/test/raft/generator.hh
@@ -14,6 +14,7 @@
 #include <boost/mp11/algorithm.hpp>
 #include <boost/implicit_cast.hpp>
 
+#include <seastar/coroutine/parallel_for_each.hh>
 #include <seastar/util/variant_utils.hh>
 #include "utils/chunked_vector.hh"
 
@@ -396,7 +397,7 @@ public:
 private:
     future<> exit() {
         auto fs = _invocations.release();
-        co_await parallel_for_each(fs, [this] (future<std::pair<operation::execute_result<Op>, operation::thread_id>>& f) -> future<> {
+        co_await coroutine::parallel_for_each(fs, [this] (future<std::pair<operation::execute_result<Op>, operation::thread_id>>& f) -> future<> {
             auto [res, tid] = co_await std::move(f);
             _record(operation::completion<Op>{
                 .result = std::move(res),

--- a/test/raft/replication.hh
+++ b/test/raft/replication.hh
@@ -16,6 +16,7 @@
 #include <seastar/core/sleep.hh>
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/loop.hh>
+#include <seastar/coroutine/parallel_for_each.hh>
 #include <seastar/util/log.hh>
 #include <seastar/util/later.hh>
 #include <seastar/util/variant_utils.hh>
@@ -848,7 +849,7 @@ future<> raft_cluster<Clock>::reset_server(size_t id, initial_state state) {
 
 template <typename Clock>
 future<> raft_cluster<Clock>::start_all() {
-    co_await parallel_for_each(_servers, [] (auto& r) {
+    co_await coroutine::parallel_for_each(_servers, [] (auto& r) {
         return r.server->start();
     });
     co_await init_raft_tickers();
@@ -924,7 +925,7 @@ void raft_cluster<Clock>::pause_tickers() {
 template <typename Clock>
 future<> raft_cluster<Clock>::restart_tickers() {
     if (_tick_delays.size()) {
-        co_await parallel_for_each(_in_configuration, [&] (size_t s) -> future<> {
+        co_await coroutine::parallel_for_each(_in_configuration, [&] (size_t s) -> future<> {
             co_await seastar::sleep(_tick_delays[s]);
             _tickers[s].rearm_periodic(_tick_delta);
         });


### PR DESCRIPTION
coroutine::parallel_for_each avoids an allocation and is therefore preferred. The lifetime
of the function object is less ambiguous, and so it is safer. Replace all eligible
occurences (i.e. caller is a coroutine).

One case (storage_service::node_ops_cmd_heartbeat_updater()) needed a little extra
attention since there was a handle_exception() continuation attached. It is converted
to a try/catch.