### PR TITLE
Use generation_type for SSTable ancestors

### DIFF
--- a/compaction/compaction.cc
+++ b/compaction/compaction.cc
@@ -1757,7 +1757,7 @@ get_fully_expired_sstables(const table_state& table_s, const std::vector<sstable
         // Get ancestors from sstable which is empty after restart. It works for this purpose because
         // we only need to check that a sstable compacted *in this instance* hasn't an ancestor undeleted.
         // Not getting it from sstable metadata because mc format hasn't it available.
-        return boost::algorithm::any_of(candidate->compaction_ancestors(), [&compacted_undeleted_gens] (auto gen) {
+        return boost::algorithm::any_of(candidate->compaction_ancestors(), [&compacted_undeleted_gens] (const generation_type& gen) {
             return compacted_undeleted_gens.contains(gen);
         });
     };

--- a/sstables/mx/writer.cc
+++ b/sstables/mx/writer.cc
@@ -1419,7 +1419,7 @@ void writer::consume_end_of_stream() {
     _sst.set_first_and_last_keys();
 
     _sst._components->statistics.contents[metadata_type::Serialization] = std::make_unique<serialization_header>(std::move(_sst_schema.header));
-    seal_statistics(_sst.get_version(), _sst._components->statistics, _collector, _sst.compaction_ancestors(),
+    seal_statistics(_sst.get_version(), _sst._components->statistics, _collector,
         _sst._schema->get_partitioner().name(), _schema.bloom_filter_fp_chance(),
         _sst._schema, _sst.get_first_decorated_key(), _sst.get_last_decorated_key(), _enc_stats);
     close_data_writer();

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -1510,9 +1510,10 @@ create_sharding_metadata(schema_ptr schema, const dht::decorated_key& first_key,
 
 // In the beginning of the statistics file, there is a disk_hash used to
 // map each metadata type to its correspondent position in the file.
-void seal_statistics(sstable_version_types v, statistics& s, metadata_collector& collector, const std::set<int>& _compaction_ancestors,
+void seal_statistics(sstable_version_types v, statistics& s, metadata_collector& collector,
         const sstring partitioner, double bloom_filter_fp_chance, schema_ptr schema,
-        const dht::decorated_key& first_key, const dht::decorated_key& last_key, const encoding_stats& enc_stats) {
+        const dht::decorated_key& first_key, const dht::decorated_key& last_key,
+        const encoding_stats& enc_stats, const std::set<int>& compaction_ancestors) {
     validation_metadata validation;
     compaction_metadata compaction;
     stats_metadata stats;
@@ -1522,8 +1523,8 @@ void seal_statistics(sstable_version_types v, statistics& s, metadata_collector&
     s.contents[metadata_type::Validation] = std::make_unique<validation_metadata>(std::move(validation));
 
     collector.construct_compaction(compaction);
-    if (v < sstable_version_types::mc && !_compaction_ancestors.empty()) {
-        compaction.ancestors.elements = utils::chunked_vector<uint32_t>(_compaction_ancestors.begin(), _compaction_ancestors.end());
+    if (v < sstable_version_types::mc && !compaction_ancestors.empty()) {
+        compaction.ancestors.elements = utils::chunked_vector<uint32_t>(compaction_ancestors.begin(), compaction_ancestors.end());
     }
     s.contents[metadata_type::Compaction] = std::make_unique<compaction_metadata>(std::move(compaction));
 

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -282,7 +282,7 @@ public:
         return _marked_for_deletion == mark_for_deletion::marked;
     }
 
-    const std::set<int>& compaction_ancestors() const {
+    const std::set<generation_type>& compaction_ancestors() const {
         return _compaction_ancestors;
     }
 
@@ -482,7 +482,7 @@ private:
     std::optional<open_flags> _open_mode;
     // _compaction_ancestors track which sstable generations were used to generate this sstable.
     // it is then used to generate the ancestors metadata in the statistics or scylla components.
-    std::set<int> _compaction_ancestors;
+    std::set<generation_type> _compaction_ancestors;
     file _index_file;
     seastar::shared_ptr<cached_file> _cached_index_file;
     file _data_file;

--- a/sstables/writer.hh
+++ b/sstables/writer.hh
@@ -608,9 +608,10 @@ future<> seal_summary(summary& s,
     std::optional<key>&& last_key,
     const index_sampling_state& state);
 
-void seal_statistics(sstable_version_types, statistics&, metadata_collector&, const std::set<int>& _compaction_ancestors,
+void seal_statistics(sstable_version_types, statistics&, metadata_collector&,
     const sstring partitioner, double bloom_filter_fp_chance, schema_ptr,
-    const dht::decorated_key& first_key, const dht::decorated_key& last_key, const encoding_stats& enc_stats = {});
+    const dht::decorated_key& first_key, const dht::decorated_key& last_key,
+    const encoding_stats& enc_stats = {}, const std::set<int>& compaction_ancestors = {});
 
 void write(sstable_version_types, file_writer&, const utils::estimated_histogram&);
 void write(sstable_version_types, file_writer&, const utils::streaming_histogram&);


### PR DESCRIPTION
To avoid a discrepancy about underlying generation type once something other than integer is allowed for the sstable generation.
Also simplifies one generic writer interface for sealing sstable statistics.