### PR TITLE
cql3: expr: unify left-hand-side and right-hand-side of binary_operator prepares

### DIFF
--- a/cql3/attributes.cc
+++ b/cql3/attributes.cc
@@ -123,15 +123,15 @@ std::unique_ptr<attributes> attributes::raw::prepare(data_dictionary::database d
     std::optional<expr::expression> ts, ttl, to;
 
     if (timestamp.has_value()) {
-        ts = prepare_expression(*timestamp, db, ks_name, timestamp_receiver(ks_name, cf_name));
+        ts = prepare_expression(*timestamp, db, ks_name, nullptr, timestamp_receiver(ks_name, cf_name));
     }
 
     if (time_to_live.has_value()) {
-        ttl = prepare_expression(*time_to_live, db, ks_name, time_to_live_receiver(ks_name, cf_name));
+        ttl = prepare_expression(*time_to_live, db, ks_name, nullptr, time_to_live_receiver(ks_name, cf_name));
     }
 
     if (timeout.has_value()) {
-        to = prepare_expression(*timeout, db, ks_name, timeout_receiver(ks_name, cf_name));
+        to = prepare_expression(*timeout, db, ks_name, nullptr, timeout_receiver(ks_name, cf_name));
     }
 
     return std::unique_ptr<attributes>{new attributes{std::move(ts), std::move(ttl), std::move(to)}};

--- a/cql3/column_condition.cc
+++ b/cql3/column_condition.cc
@@ -283,13 +283,13 @@ column_condition::raw::prepare(data_dictionary::database db, const sstring& keys
             throw exceptions::invalid_request_exception(
                     format("Unsupported collection type {} in a condition with element access", ctype->cql3_type_name()));
         }
-        collection_element_expression = prepare_expression(*_collection_element, db, keyspace, element_spec);
+        collection_element_expression = prepare_expression(*_collection_element, db, keyspace, nullptr, element_spec);
     }
 
     if (is_compare(_op)) {
         validate_operation_on_durations(*receiver.type, _op);
         return column_condition::condition(receiver, std::move(collection_element_expression),
-                prepare_expression(*_value, db, keyspace, value_spec), nullptr, _op);
+                prepare_expression(*_value, db, keyspace, nullptr, value_spec), nullptr, _op);
     }
 
     if (_op == expr::oper_t::LIKE) {
@@ -298,14 +298,14 @@ column_condition::raw::prepare(data_dictionary::database db, const sstring& keys
             // Pass matcher object
             const sstring& pattern = literal_term->raw_text;
             return column_condition::condition(receiver, std::move(collection_element_expression),
-                    prepare_expression(*_value, db, keyspace, value_spec),
+                    prepare_expression(*_value, db, keyspace, nullptr, value_spec),
                     std::make_unique<like_matcher>(bytes_view(reinterpret_cast<const int8_t*>(pattern.data()), pattern.size())),
                     _op);
         } else {
             // Pass through rhs value, matcher object built on execution
             // TODO: caller should validate parametrized LIKE pattern
             return column_condition::condition(receiver, std::move(collection_element_expression),
-                    prepare_expression(*_value, db, keyspace, value_spec), nullptr, _op);
+                    prepare_expression(*_value, db, keyspace, nullptr, value_spec), nullptr, _op);
         }
     }
 
@@ -317,14 +317,14 @@ column_condition::raw::prepare(data_dictionary::database db, const sstring& keys
         assert(_in_values.empty());
         auto in_name = ::make_shared<column_identifier>(format("in({})", value_spec->name->text()), true);
         lw_shared_ptr<column_specification> in_list_receiver = make_lw_shared<column_specification>(value_spec->ks_name, value_spec->cf_name, in_name, list_type_impl::get_instance(receiver.type, false));
-        expr::expression multi_item_term = prepare_expression(*_in_marker, db, keyspace, in_list_receiver);
+        expr::expression multi_item_term = prepare_expression(*_in_marker, db, keyspace, nullptr, in_list_receiver);
         return column_condition::in_condition(receiver, collection_element_expression, std::move(multi_item_term), {});
     }
     // Both _in_values and in _in_marker can be missing in case of empty IN list: "a IN ()"
     std::vector<expr::expression> terms;
     terms.reserve(_in_values.size());
     for (auto&& value : _in_values) {
-        terms.push_back(prepare_expression(value, db, keyspace, value_spec));
+        terms.push_back(prepare_expression(value, db, keyspace, nullptr, value_spec));
     }
     return column_condition::in_condition(receiver, std::move(collection_element_expression),
                                           std::nullopt, std::move(terms));

--- a/cql3/expr/expression.cc
+++ b/cql3/expr/expression.cc
@@ -2323,5 +2323,65 @@ size_t count_if(const expression& e, const noncopyable_function<bool (const bina
     return ret;
 }
 
+data_type
+type_of(const expression& e) {
+    return visit(overloaded_functor{
+        [] (const conjunction& e) {
+            return boolean_type;
+        },
+        [] (const binary_operator& e) {
+            // All our binary operators are relations
+            return boolean_type;
+        },
+        [] (const column_value& e) {
+            return e.col->type;
+        },
+        [] (const token& e) {
+            return long_type;
+        },
+        [] (const unresolved_identifier& e) -> data_type {
+            on_internal_error(expr_logger, "evaluating type of unresolved_identifier");
+        },
+        [] (const column_mutation_attribute& e) {
+            switch (e.kind) {
+            case column_mutation_attribute::attribute_kind::writetime:
+                return long_type;
+            case column_mutation_attribute::attribute_kind::ttl:
+                return int32_type;
+            }
+            on_internal_error(expr_logger, "evaluating type of illegal column mutation attribute kind");
+        },
+        [] (const function_call& e) {
+            return std::visit(overloaded_functor{
+                [] (const functions::function_name& unprepared) -> data_type {
+                    on_internal_error(expr_logger, "evaluating type of unprepared function call");
+                },
+                [] (const shared_ptr<functions::function>& f) {
+                    return f->return_type();
+                },
+            }, e.func);
+        },
+        [] (const bind_variable& e) {
+            return e.receiver->type;
+        },
+        [] (const untyped_constant& e) -> data_type {
+            on_internal_error(expr_logger, "evaluating type of untyped_constant call");
+        },
+        [] (const cast& e) {
+            return std::visit(overloaded_functor{
+                [] (const shared_ptr<cql3_type::raw>& unprepared) -> data_type {
+                    on_internal_error(expr_logger, "evaluating type of unprepared cast");
+                },
+                [] (const data_type& t) {
+                    return t;
+                },
+            }, e.type);
+        },
+        [] (const ExpressionElement auto& e) -> data_type {
+            return e.type;
+        }
+    }, e);
+}
+
 } // namespace expr
 } // namespace cql3

--- a/cql3/expr/expression.hh
+++ b/cql3/expr/expression.hh
@@ -616,7 +616,7 @@ extern expression replace_token(const expression&, const column_definition*);
 extern expression search_and_replace(const expression& e,
         const noncopyable_function<std::optional<expression> (const expression& candidate)>& replace_candidate);
 
-extern expression prepare_expression(const expression& expr, data_dictionary::database db, const sstring& keyspace, lw_shared_ptr<column_specification> receiver);
+extern expression prepare_expression(const expression& expr, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, lw_shared_ptr<column_specification> receiver);
 
 // Prepares a binary operator received from the parser.
 // Does some basic type checks but no advanced validation.

--- a/cql3/expr/expression.hh
+++ b/cql3/expr/expression.hh
@@ -213,6 +213,7 @@ struct column_value {
 struct subscript {
     expression val;
     expression sub;
+    data_type type; // may be null before prepare
 };
 
 /// Gets the subscripted column_value out of the subscript.
@@ -315,9 +316,11 @@ struct cast {
 struct field_selection {
     expression structure;
     shared_ptr<column_identifier_raw> field;
+    data_type type; // may be null before prepare
 };
 
 struct null {
+    data_type type; // may be null before prepare
 };
 
 struct bind_variable {

--- a/cql3/expr/expression.hh
+++ b/cql3/expr/expression.hh
@@ -617,6 +617,7 @@ extern expression search_and_replace(const expression& e,
         const noncopyable_function<std::optional<expression> (const expression& candidate)>& replace_candidate);
 
 extern expression prepare_expression(const expression& expr, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, lw_shared_ptr<column_specification> receiver);
+std::optional<expression> try_prepare_expression(const expression& expr, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, lw_shared_ptr<column_specification> receiver);
 
 // Prepares a binary operator received from the parser.
 // Does some basic type checks but no advanced validation.

--- a/cql3/expr/expression.hh
+++ b/cql3/expr/expression.hh
@@ -309,7 +309,7 @@ struct function_call {
 
 struct cast {
     expression arg;
-    std::variant<cql3_type, shared_ptr<cql3_type::raw>> type;
+    std::variant<data_type, shared_ptr<cql3_type::raw>> type;
 };
 
 struct field_selection {

--- a/cql3/expr/expression.hh
+++ b/cql3/expr/expression.hh
@@ -656,6 +656,8 @@ std::vector<expression> extract_single_column_restrictions_for_column(const expr
 
 std::optional<bool> get_bool_value(const constant&);
 
+data_type type_of(const expression& e);
+
 // Takes a prepared expression and calculates its value.
 // Evaluates bound values, calls functions and returns just the bytes and type.
 constant evaluate(const expression& e, const query_options&);

--- a/cql3/expr/expression.hh
+++ b/cql3/expr/expression.hh
@@ -620,7 +620,7 @@ extern expression prepare_expression(const expression& expr, data_dictionary::da
 
 // Prepares a binary operator received from the parser.
 // Does some basic type checks but no advanced validation.
-extern binary_operator prepare_binary_operator(const binary_operator& binop, data_dictionary::database db, schema_ptr schema, prepare_context& ctx);
+extern binary_operator prepare_binary_operator(const binary_operator& binop, data_dictionary::database db, schema_ptr schema);
 
 
 /**

--- a/cql3/expr/prepare_expr.cc
+++ b/cql3/expr/prepare_expr.cc
@@ -683,7 +683,10 @@ cast_prepare_expression(const cast& c, data_dictionary::database db, const sstri
     if (!is_assignable(cast_test_assignment(c, db, keyspace, *receiver))) {
         throw exceptions::invalid_request_exception(format("Cannot assign value {} to {} of type {}", c, receiver->name, receiver->type->as_cql3_type()));
     }
-    return prepare_expression(c.arg, db, keyspace, receiver);
+    return cast{
+        .arg = prepare_expression(c.arg, db, keyspace, receiver),
+        .type = receiver->type,
+    };
 }
 
 expr::expression

--- a/cql3/expr/prepare_expr.cc
+++ b/cql3/expr/prepare_expr.cc
@@ -1147,7 +1147,7 @@ static lw_shared_ptr<column_specification> get_rhs_receiver(lw_shared_ptr<column
     }
 }
 
-binary_operator prepare_binary_operator(const binary_operator& binop, data_dictionary::database db, schema_ptr schema, prepare_context& ctx) {
+binary_operator prepare_binary_operator(const binary_operator& binop, data_dictionary::database db, schema_ptr schema) {
     expression prepared_lhs = prepare_binop_lhs(binop.lhs, db, *schema, binop);
     lw_shared_ptr<column_specification> lhs_receiver = get_lhs_receiver(prepared_lhs, *schema);
 

--- a/cql3/expr/prepare_expr.cc
+++ b/cql3/expr/prepare_expr.cc
@@ -993,7 +993,7 @@ static const column_value resolve_column(const unresolved_identifier& col_ident,
 
 // Resolves columns on LHS of binary_operator and prepares the index in case of a subscripted column.
 // Last argument is a relation to print in the error message in case of failure.
-static expression prepare_binop_lhs(const expression& lhs, data_dictionary::database db, const schema& schema, const binary_operator& printable_relation) {
+static expression prepare_binop_lhs(const expression& lhs, data_dictionary::database db, const schema& schema) {
     return expr::visit(overloaded_functor{
         [&](const unresolved_identifier& unin) -> expression {
             return resolve_column(unin, schema);
@@ -1004,7 +1004,7 @@ static expression prepare_binop_lhs(const expression& lhs, data_dictionary::data
             new_elements.reserve(tc.elements.size());
 
             for (const expression& elem : tc.elements) {
-                new_elements.emplace_back(prepare_binop_lhs(elem, db, schema, printable_relation));
+                new_elements.emplace_back(prepare_binop_lhs(elem, db, schema));
             }
 
             return tuple_constructor {
@@ -1016,7 +1016,7 @@ static expression prepare_binop_lhs(const expression& lhs, data_dictionary::data
             prepared_token_args.reserve(tk.args.size());
 
             for (const expression& arg : tk.args) {
-                prepared_token_args.emplace_back(prepare_binop_lhs(arg, db, schema, printable_relation));
+                prepared_token_args.emplace_back(prepare_binop_lhs(arg, db, schema));
             }
 
             return token(std::move(prepared_token_args));
@@ -1147,7 +1147,7 @@ static lw_shared_ptr<column_specification> get_rhs_receiver(lw_shared_ptr<column
 }
 
 binary_operator prepare_binary_operator(const binary_operator& binop, data_dictionary::database db, schema_ptr schema) {
-    expression prepared_lhs = prepare_binop_lhs(binop.lhs, db, *schema, binop);
+    expression prepared_lhs = prepare_binop_lhs(binop.lhs, db, *schema);
     lw_shared_ptr<column_specification> lhs_receiver = get_lhs_receiver(prepared_lhs, *schema);
 
     lw_shared_ptr<column_specification> rhs_receiver = get_rhs_receiver(lhs_receiver, binop.op);

--- a/cql3/expr/to_restriction.cc
+++ b/cql3/expr/to_restriction.cc
@@ -334,7 +334,7 @@ void preliminary_binop_vaidation_checks(const binary_operator& binop) {
         }
     }
 
-    binary_operator prepared_binop = prepare_binary_operator(binop_to_prepare, db, schema, ctx);
+    binary_operator prepared_binop = prepare_binary_operator(binop_to_prepare, db, schema);
 
     const column_value* lhs_pk_col_search_res = find_in_expression<column_value>(prepared_binop.lhs,
         [](const column_value& col) {

--- a/cql3/operation.cc
+++ b/cql3/operation.cc
@@ -37,19 +37,19 @@ operation::set_element::prepare(data_dictionary::database db, const sstring& key
     }
 
     if (rtype->get_kind() == abstract_type::kind::list) {
-        auto&& lval = prepare_expression(_value, db, keyspace, lists::value_spec_of(*receiver.column_specification));
+        auto&& lval = prepare_expression(_value, db, keyspace, nullptr, lists::value_spec_of(*receiver.column_specification));
         if (_by_uuid) {
-            auto&& idx = prepare_expression(_selector, db, keyspace, lists::uuid_index_spec_of(*receiver.column_specification));
+            auto&& idx = prepare_expression(_selector, db, keyspace, nullptr, lists::uuid_index_spec_of(*receiver.column_specification));
             return make_shared<lists::setter_by_uuid>(receiver, std::move(idx), std::move(lval));
         } else {
-            auto&& idx = prepare_expression(_selector, db, keyspace, lists::index_spec_of(*receiver.column_specification));
+            auto&& idx = prepare_expression(_selector, db, keyspace, nullptr, lists::index_spec_of(*receiver.column_specification));
             return make_shared<lists::setter_by_index>(receiver, std::move(idx), std::move(lval));
         }
     } else if (rtype->get_kind() == abstract_type::kind::set) {
         throw invalid_request_exception(format("Invalid operation ({}) for set column {}", to_string(receiver), receiver.name()));
     } else if (rtype->get_kind() == abstract_type::kind::map) {
-        auto key = prepare_expression(_selector, db, keyspace, maps::key_spec_of(*receiver.column_specification));
-        auto mval = prepare_expression(_value, db, keyspace, maps::value_spec_of(*receiver.column_specification));
+        auto key = prepare_expression(_selector, db, keyspace, nullptr, maps::key_spec_of(*receiver.column_specification));
+        auto mval = prepare_expression(_value, db, keyspace, nullptr, maps::value_spec_of(*receiver.column_specification));
         return make_shared<maps::setter_by_key>(receiver, std::move(key), std::move(mval));
     }
     abort();
@@ -84,7 +84,7 @@ operation::set_field::prepare(data_dictionary::database db, const sstring& keysp
                 format("UDT column {} does not have a field named {}", receiver.name_as_text(), *_field));
     }
 
-    auto val = prepare_expression(_value, db, keyspace, user_types::field_spec_of(*receiver.column_specification, *idx));
+    auto val = prepare_expression(_value, db, keyspace, nullptr, user_types::field_spec_of(*receiver.column_specification, *idx));
     return make_shared<user_types::setter_by_field>(receiver, *idx, std::move(val));
 }
 
@@ -130,7 +130,7 @@ operation::addition::to_string(const column_definition& receiver) const {
 
 shared_ptr<operation>
 operation::addition::prepare(data_dictionary::database db, const sstring& keyspace, const column_definition& receiver) const {
-    auto v = prepare_expression(_value, db, keyspace, receiver.column_specification);
+    auto v = prepare_expression(_value, db, keyspace, nullptr, receiver.column_specification);
 
     auto ctype = dynamic_pointer_cast<const collection_type_impl>(receiver.type);
     if (!ctype) {
@@ -170,7 +170,7 @@ operation::subtraction::prepare(data_dictionary::database db, const sstring& key
         if (!receiver.is_counter()) {
             throw exceptions::invalid_request_exception(format("Invalid operation ({}) for non counter column {}", to_string(receiver), receiver.name()));
         }
-        auto v = prepare_expression(_value, db, keyspace, receiver.column_specification);
+        auto v = prepare_expression(_value, db, keyspace, nullptr, receiver.column_specification);
         return make_shared<constants::subtracter>(receiver, std::move(v));
     }
     if (!ctype->is_multi_cell()) {
@@ -179,9 +179,9 @@ operation::subtraction::prepare(data_dictionary::database db, const sstring& key
     }
 
     if (ctype->get_kind() == abstract_type::kind::list) {
-        return make_shared<lists::discarder>(receiver, prepare_expression(_value, db, keyspace, receiver.column_specification));
+        return make_shared<lists::discarder>(receiver, prepare_expression(_value, db, keyspace, nullptr, receiver.column_specification));
     } else if (ctype->get_kind() == abstract_type::kind::set) {
-        return make_shared<sets::discarder>(receiver, prepare_expression(_value, db, keyspace, receiver.column_specification));
+        return make_shared<sets::discarder>(receiver, prepare_expression(_value, db, keyspace, nullptr, receiver.column_specification));
     } else if (ctype->get_kind() == abstract_type::kind::map) {
         auto&& mtype = dynamic_pointer_cast<const map_type_impl>(ctype);
         // The value for a map subtraction is actually a set
@@ -190,7 +190,7 @@ operation::subtraction::prepare(data_dictionary::database db, const sstring& key
                 receiver.column_specification->cf_name,
                 receiver.column_specification->name,
                 set_type_impl::get_instance(mtype->get_keys_type(), false));
-        return ::make_shared<sets::discarder>(receiver, prepare_expression(_value, db, keyspace, std::move(vr)));
+        return ::make_shared<sets::discarder>(receiver, prepare_expression(_value, db, keyspace, nullptr, std::move(vr)));
     }
     abort();
 }
@@ -207,7 +207,7 @@ operation::prepend::to_string(const column_definition& receiver) const {
 
 shared_ptr<operation>
 operation::prepend::prepare(data_dictionary::database db, const sstring& keyspace, const column_definition& receiver) const {
-    auto v = prepare_expression(_value, db, keyspace, receiver.column_specification);
+    auto v = prepare_expression(_value, db, keyspace, nullptr, receiver.column_specification);
 
     if (!dynamic_cast<const list_type_impl*>(receiver.type.get())) {
         throw exceptions::invalid_request_exception(format("Invalid operation ({}) for non list column {}", to_string(receiver), receiver.name()));
@@ -226,7 +226,7 @@ operation::prepend::is_compatible_with(const std::unique_ptr<raw_update>& other)
 
 ::shared_ptr <operation>
 operation::set_value::prepare(data_dictionary::database db, const sstring& keyspace, const column_definition& receiver) const {
-    auto v = prepare_expression(_value, db, keyspace, receiver.column_specification);
+    auto v = prepare_expression(_value, db, keyspace, nullptr, receiver.column_specification);
 
     if (receiver.type->is_counter()) {
         throw exceptions::invalid_request_exception(format("Cannot set the value of counter column {} (counters can only be incremented/decremented, not set)", receiver.name_as_text()));
@@ -264,7 +264,7 @@ operation::set_counter_value_from_tuple_list::prepare(data_dictionary::database 
     // We need to fake a column of list<tuple<...>> to prepare the value expression
     auto & os = receiver.column_specification;
     auto spec = make_lw_shared<cql3::column_specification>(os->ks_name, os->cf_name, os->name, counter_tuple_list_type);
-    auto v = prepare_expression(_value, db, keyspace, spec);
+    auto v = prepare_expression(_value, db, keyspace, nullptr, spec);
 
     // Will not be used elsewhere, so make it local.
     class counter_setter : public operation {
@@ -349,13 +349,13 @@ operation::element_deletion::prepare(data_dictionary::database db, const sstring
     }
     auto ctype = static_pointer_cast<const collection_type_impl>(receiver.type);
     if (ctype->get_kind() == abstract_type::kind::list) {
-        auto&& idx = prepare_expression(_element, db, keyspace, lists::index_spec_of(*receiver.column_specification));
+        auto&& idx = prepare_expression(_element, db, keyspace, nullptr, lists::index_spec_of(*receiver.column_specification));
         return make_shared<lists::discarder_by_index>(receiver, std::move(idx));
     } else if (ctype->get_kind() == abstract_type::kind::set) {
-        auto&& elt = prepare_expression(_element, db, keyspace, sets::value_spec_of(*receiver.column_specification));
+        auto&& elt = prepare_expression(_element, db, keyspace, nullptr, sets::value_spec_of(*receiver.column_specification));
         return make_shared<sets::element_discarder>(receiver, std::move(elt));
     } else if (ctype->get_kind() == abstract_type::kind::map) {
-        auto&& key = prepare_expression(_element, db, keyspace, maps::key_spec_of(*receiver.column_specification));
+        auto&& key = prepare_expression(_element, db, keyspace, nullptr, maps::key_spec_of(*receiver.column_specification));
         return make_shared<maps::discarder_by_key>(receiver, std::move(key));
     }
     abort();

--- a/cql3/selection/selectable.cc
+++ b/cql3/selection/selectable.cc
@@ -143,14 +143,14 @@ shared_ptr<selector::factory>
 selectable::with_cast::new_selector_factory(data_dictionary::database db, schema_ptr s, std::vector<const column_definition*>& defs) {
     std::vector<shared_ptr<selectable>> args{_arg};
     auto&& factories = selector_factories::create_factories_and_collect_column_definitions(args, db, s, defs);
-    auto&& fun = functions::castas_functions::get(_type.get_type(), factories->new_instances());
+    auto&& fun = functions::castas_functions::get(_type, factories->new_instances());
 
     return abstract_function_selector::new_factory(std::move(fun), std::move(factories));
 }
 
 sstring
 selectable::with_cast::to_string() const {
-    return format("cast({} as {})", _arg->to_string(), _type.to_string());
+    return format("cast({} as {})", _arg->to_string(), cql3_type(_type).to_string());
 }
 
 shared_ptr<selectable>
@@ -209,7 +209,7 @@ prepare_selectable(const schema& s, const expr::expression& raw_selectable) {
             }, fc.func);
         },
         [&] (const expr::cast& c) -> shared_ptr<selectable> {
-            auto t = std::get_if<cql3_type>(&c.type);
+            auto t = std::get_if<data_type>(&c.type);
             if (!t) {
                 // FIXME: adjust prepare_seletable() signature so we can prepare the type too
                 on_internal_error(slogger, "unprepared type in selector type cast");

--- a/cql3/selection/selectable.hh
+++ b/cql3/selection/selectable.hh
@@ -78,9 +78,9 @@ public:
 
 class selectable::with_cast : public selectable {
     ::shared_ptr<selectable> _arg;
-    cql3_type _type;
+    data_type _type;
 public:
-    with_cast(::shared_ptr<selectable> arg, cql3_type type)
+    with_cast(::shared_ptr<selectable> arg, data_type type)
         : _arg(std::move(arg)), _type(std::move(type)) {
     }
 

--- a/cql3/statements/create_aggregate_statement.cc
+++ b/cql3/statements/create_aggregate_statement.cc
@@ -54,7 +54,7 @@ shared_ptr<functions::function> create_aggregate_statement::create(query_process
     if (_ival) {
         auto dummy_ident = ::make_shared<column_identifier>("", true);
         auto column_spec = make_lw_shared<column_specification>("", "", dummy_ident, state_type);
-        auto initcond_term = expr::evaluate(prepare_expression(_ival.value(), db, _name.keyspace, {column_spec}), query_options::DEFAULT);
+        auto initcond_term = expr::evaluate(prepare_expression(_ival.value(), db, _name.keyspace, nullptr, {column_spec}), query_options::DEFAULT);
         initcond = std::move(initcond_term.value).to_bytes();
     }
 

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -1732,7 +1732,7 @@ select_statement::prepare_limit(data_dictionary::database db, prepare_context& c
         return std::nullopt;
     }
 
-    expr::expression prep_limit = prepare_expression(*limit, db, keyspace(), limit_receiver());
+    expr::expression prep_limit = prepare_expression(*limit, db, keyspace(), nullptr, limit_receiver());
     expr::fill_prepare_context(prep_limit, ctx);
     return prep_limit;
 }

--- a/cql3/statements/update_statement.cc
+++ b/cql3/statements/update_statement.cc
@@ -333,7 +333,7 @@ insert_json_statement::prepare_internal(data_dictionary::database db, schema_ptr
     (void)_if_not_exists;
     assert(expr::is<cql3::expr::untyped_constant>(_json_value) || expr::is<cql3::expr::bind_variable>(_json_value));
     auto json_column_placeholder = ::make_shared<column_identifier>("", true);
-    auto prepared_json_value = prepare_expression(_json_value, db, "", make_lw_shared<column_specification>("", "", json_column_placeholder, utf8_type));
+    auto prepared_json_value = prepare_expression(_json_value, db, "", nullptr, make_lw_shared<column_specification>("", "", json_column_placeholder, utf8_type));
     expr::fill_prepare_context(prepared_json_value, ctx);
     auto stmt = ::make_shared<cql3::statements::insert_prepared_json_statement>(ctx.bound_variables_size(), schema, std::move(attrs), stats, std::move(prepared_json_value), _default_unset);
     prepare_conditions(db, *schema, ctx, *stmt);


### PR DESCRIPTION
Currently, preparing the left-hand-side of a binary operator and the
right-hand-side use different code paths. The left-hand-side derives
the type of the expression from the expression itself, while the
right-hand-side imposes the type on the expression (allowing the types
of bind variables to be inferred).

This series unifies the two, by making the imposed type (the "receiver")
optional, and by allowing prepare to fail gracefully if we were not able
to infer the type. The old prepare_binop_lhs() is removed and replaced
with prepare_expression, already used for the right hand side.

There is one step remaining, and that is to replace prepare_binary_operator
with prepare_expression, but that is more involved and is left for a follow-up.