### PR TITLE
sstables: save Scylla version & build id in metadata

### DIFF
--- a/sstables/types.hh
+++ b/sstables/types.hh
@@ -525,6 +525,8 @@ enum class scylla_metadata_type : uint32_t {
     RunIdentifier = 4,
     LargeDataStats = 5,
     SSTableOrigin = 6,
+    ScyllaBuildId = 7,
+    ScyllaVersion = 8,
 };
 
 struct run_identifier {
@@ -560,6 +562,8 @@ struct scylla_metadata {
     using extension_attributes = disk_hash<uint32_t, disk_string<uint32_t>, disk_string<uint32_t>>;
     using large_data_stats = disk_hash<uint32_t, large_data_type, large_data_stats_entry>;
     using sstable_origin = disk_string<uint32_t>;
+    using scylla_build_id = disk_string<uint32_t>;
+    using scylla_version = disk_string<uint32_t>;
 
     disk_set_of_tagged_union<scylla_metadata_type,
             disk_tagged_union_member<scylla_metadata_type, scylla_metadata_type::Sharding, sharding_metadata>,
@@ -567,7 +571,9 @@ struct scylla_metadata {
             disk_tagged_union_member<scylla_metadata_type, scylla_metadata_type::ExtensionAttributes, extension_attributes>,
             disk_tagged_union_member<scylla_metadata_type, scylla_metadata_type::RunIdentifier, run_identifier>,
             disk_tagged_union_member<scylla_metadata_type, scylla_metadata_type::LargeDataStats, large_data_stats>,
-            disk_tagged_union_member<scylla_metadata_type, scylla_metadata_type::SSTableOrigin, sstable_origin>
+            disk_tagged_union_member<scylla_metadata_type, scylla_metadata_type::SSTableOrigin, sstable_origin>,
+            disk_tagged_union_member<scylla_metadata_type, scylla_metadata_type::ScyllaBuildId, scylla_build_id>,
+            disk_tagged_union_member<scylla_metadata_type, scylla_metadata_type::ScyllaVersion, scylla_version>
             > data;
 
     sstable_enabled_features get_features() const {

--- a/tools/scylla-sstable.cc
+++ b/tools/scylla-sstable.cc
@@ -1296,6 +1296,8 @@ const char* to_string(sstables::scylla_metadata_type t) {
         case sstables::scylla_metadata_type::RunIdentifier: return "run_identifier";
         case sstables::scylla_metadata_type::LargeDataStats: return "large_data_stats";
         case sstables::scylla_metadata_type::SSTableOrigin: return "sstable_origin";
+        case sstables::scylla_metadata_type::ScyllaVersion: return "scylla_version";
+        case sstables::scylla_metadata_type::ScyllaBuildId: return "scylla_build_id";
     }
     std::abort();
 }


### PR DESCRIPTION
To provide a reasonably-definitive answer to "what exact version of
Scylla wrote this?".

Signed-off-by: Michael Livshin <michael.livshin@scylladb.com>