### PR TITLE
Block flush until compaction finishes if sstables accumulate

### DIFF
--- a/replica/database.hh
+++ b/replica/database.hh
@@ -495,6 +495,7 @@ private:
 
     class table_state;
     std::unique_ptr<table_state> _table_state;
+    condition_variable _sstables_changed;
 public:
     data_dictionary::table as_data_dictionary() const;
 
@@ -559,6 +560,7 @@ private:
     void backlog_tracker_adjust_charges(const std::vector<sstables::shared_sstable>& old_sstables, const std::vector<sstables::shared_sstable>& new_sstables);
     lw_shared_ptr<memtable> new_memtable();
     future<stop_iteration> try_flush_memtable_to_sstable(lw_shared_ptr<memtable> memt, sstable_write_permit&& permit);
+    future<> maybe_wait_for_sstable_count_reduction();
     // Caller must keep m alive.
     future<> update_cache(lw_shared_ptr<memtable> m, std::vector<sstables::shared_sstable> ssts);
     struct merge_comparator;

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -102,6 +102,7 @@ lw_shared_ptr<sstables::sstable_set> table::make_maintenance_sstable_set() const
 
 void table::refresh_compound_sstable_set() {
     _sstables = make_compound_sstable_set();
+    _sstables_changed.signal();
 }
 
 // Exposed for testing, not performance critical.
@@ -697,6 +698,7 @@ table::try_flush_memtable_to_sstable(lw_shared_ptr<memtable> old, sstable_write_
             co_return stop_iteration(_async_gate.is_closed());
         }
 
+        co_await maybe_wait_for_sstable_count_reduction();
         auto f = consumer(std::move(reader));
 
         // Switch back to default scheduling group for post-flush actions, to avoid them being staved by the memtable flush
@@ -731,6 +733,35 @@ table::try_flush_memtable_to_sstable(lw_shared_ptr<memtable> old, sstable_write_
         co_return co_await with_scheduling_group(default_scheduling_group(), std::ref(post_flush));
     };
     co_return co_await with_scheduling_group(_config.memtable_scheduling_group, std::ref(try_flush));
+}
+
+future<> table::maybe_wait_for_sstable_count_reduction() {
+    if (_async_gate.is_closed() || is_auto_compaction_disabled_by_user()) {
+        co_return;
+    }
+    auto sstable_count_below_threshold = [this] {
+        const auto sstable_runs_with_memtable_origin = boost::copy_range<std::unordered_set<utils::UUID>>(
+            *_main_sstables->all()
+            | boost::adaptors::filtered([] (const sstables::shared_sstable& sst) {
+                return sst->get_origin() == "memtable";
+            })
+            | boost::adaptors::transformed(std::mem_fn(&sstables::sstable::run_identifier)));
+        const auto threshold = std::max(schema()->max_compaction_threshold(), 32);
+        return sstable_runs_with_memtable_origin.size() <= threshold;
+    };
+    if (sstable_count_below_threshold()) {
+        co_return;
+    }
+    // Reduce the chances of falling into an endless wait, if compaction
+    // wasn't scheduled for the table due to a problem.
+    trigger_compaction();
+    using namespace std::chrono_literals;
+    auto start = db_clock::now();
+    co_await _sstables_changed.wait(sstable_count_below_threshold);
+    auto end = db_clock::now();
+    auto elapsed_ms = (end - start) / 1ms;
+    tlogger.warn("Memtable flush of {}.{} was blocked for {}ms waiting for compaction to catch up on newly created files",
+            schema()->ks_name(), schema()->cf_name(), elapsed_ms);
 }
 
 void

--- a/test/boost/memtable_test.cc
+++ b/test/boost/memtable_test.cc
@@ -31,6 +31,7 @@
 #include "test/lib/reader_concurrency_semaphore.hh"
 #include "test/lib/simple_schema.hh"
 #include "utils/error_injection.hh"
+#include "db/commitlog/commitlog.hh"
 
 static api::timestamp_type next_timestamp() {
     static thread_local api::timestamp_type next_timestamp = 1;
@@ -813,5 +814,80 @@ SEASTAR_TEST_CASE(failed_flush_prevents_writes) {
         }));
     });
 #endif
+}
+
+SEASTAR_TEST_CASE(flushing_rate_is_reduced_if_compaction_doesnt_keep_up) {
+    BOOST_ASSERT(smp::count == 2);
+    // The test simulates a situation where 2 threads issue flushes to 2
+    // tables. Both issue small flushes, but one has injected reactor stalls.
+    // This can lead to a situation where lots of small sstables accumulate on
+    // disk, and, if compaction never has a chance to keep up, resources can be
+    // exhausted.
+    return do_with_cql_env([](cql_test_env& env) -> future<> {
+        struct flusher {
+            cql_test_env& env;
+            const int num_flushes;
+            const int sleep_ms;
+
+            static sstring cf_name(unsigned thread_id) {
+                return format("cf_{}", thread_id);
+            }
+
+            static sstring ks_name() {
+                return "ks";
+            }
+
+            future<> create_table(schema_ptr s) {
+                service::migration_manager& mm = env.migration_manager().local();
+                auto group0_guard = co_await mm.start_group0_operation();
+                auto ts = group0_guard.write_timestamp();
+                auto announcement = co_await mm.prepare_new_column_family_announcement(s, ts);
+                co_await mm.announce(std::move(announcement), std::move(group0_guard));
+            }
+
+            future<> drop_table() {
+                service::migration_manager& mm = env.migration_manager().local();
+                auto group0_guard = co_await mm.start_group0_operation();
+                auto ts = group0_guard.write_timestamp();
+                auto announcement = co_await mm.prepare_column_family_drop_announcement(ks_name(), cf_name(this_shard_id()), api::new_timestamp());
+                co_await mm.announce(std::move(announcement), std::move(group0_guard));
+            }
+
+            future<> operator()() {
+                const sstring ks_name = this->ks_name();
+                const sstring cf_name = this->cf_name(this_shard_id());
+                random_mutation_generator gen{
+                    random_mutation_generator::generate_counters::no,
+                    local_shard_only::yes,
+                    random_mutation_generator::generate_uncompactable::no,
+                    std::nullopt,
+                    ks_name.c_str(),
+                    cf_name.c_str()
+                };
+                schema_ptr s = gen.schema();
+
+                co_await create_table(s);
+                replica::database& db = env.local_db();
+                replica::table& t = db.find_column_family(ks_name, cf_name);
+
+                for (int value : boost::irange<int>(0, num_flushes)) {
+                    ::usleep(sleep_ms * 1000);
+                    co_await db.apply(t.schema(), freeze(gen()), tracing::trace_state_ptr(), db::commitlog::force_sync::yes, db::no_timeout);
+                    co_await t.flush();
+                    BOOST_ASSERT(t.sstables_count() < t.schema()->max_compaction_threshold() * 2);
+                }
+                co_await drop_table();
+            }
+        };
+
+        int sleep_ms = 2;
+        for (int i : boost::irange<int>(8)) {
+            future<> f0 = smp::submit_to(0, flusher{.env=env, .num_flushes=100, .sleep_ms=0});
+            future<> f1 = smp::submit_to(1, flusher{.env=env, .num_flushes=3, .sleep_ms=sleep_ms});
+            co_await std::move(f0);
+            co_await std::move(f1);
+            sleep_ms *= 2;
+        }
+    });
 }
 

--- a/test/lib/mutation_source_test.hh
+++ b/test/lib/mutation_source_test.hh
@@ -52,7 +52,7 @@ public:
     // tombstone will cover data, i.e. compacting the mutation will not result
     // in any changes.
     explicit random_mutation_generator(generate_counters, local_shard_only lso = local_shard_only::yes,
-            generate_uncompactable uc = generate_uncompactable::no, std::optional<uint32_t> seed_opt = std::nullopt);
+            generate_uncompactable uc = generate_uncompactable::no, std::optional<uint32_t> seed_opt = std::nullopt, const char* ks_name="ks", const char* cf_name="cf");
     random_mutation_generator(generate_counters gc, uint32_t seed)
             : random_mutation_generator(gc, local_shard_only::yes, generate_uncompactable::no, seed) {}
     ~random_mutation_generator();


### PR DESCRIPTION
If we reach a situation where flush rate exceeds compaction rate, we may
end up with arbitrarily large number of sstables on disk. If a read is
executed in such case, the amount of memory required is proportional to
the number of sstables for the given shard, which in extreme cases can
lead to OOM.

In the wild, this was observed in 2 scenarios:
- A node with >10 shards creates a keyspace with thousands of tables,
  drops the keyspace and shuts down before compaction finishes. Dropping
  keyspace drops tables, and each dropped table is smp::count writes to
  system.local table with flush after write, which creates tens of
  thousands of sstables. Bootstrap read from system.local will run OOM.
- A failure to agree on table schema (due to a code bug) between nodes
  during repair resulted in excessive flushing of small sstables which
  compaction couldn't keep up with.

In the unit test introduced in this patch series it can be proved that
even hard setting maximum shares for compaction and minimum shares for
flushing doesn't tilt the balance towards compaction enough to prevent
the problem. Since it's a fast producer, slow consumer problem, the
remaining solution is to block producer until the consumer catches up.
If there are too many table runs originating from memtable, we block the
current flush until the number of sstables is reduced (via ongoing
compaction or a truncate operation).

Fixes https://github.com/scylladb/scylla/issues/4116

Changelog:
v5:
- added a nicer way of timing the stalls caused by waiting for flush
- added predicate on signal when waiting for reduction of the number of sstables to correctly handle spurious wake ups
- added comment why we trigger compaction before waiting for sstable count reduction
- removed unnecessary cv.signal from table::stop

v4:
- removed conversion of table::stop to coroutines. It's an orthogonal change and doesn't need to go into this patchset

v3:
- removed unnecessary change to scheduling groups from v2
- moved sstables_changed signalling to suggested place in table::stop
- added log how long the table flush was blocked for
- changed the threshold to max(schema()->max_compaction_threshold(), 32) and comparison to <=

v2:
- Reimplemented waiting algorithm based on reviewers' feedback. It's confined to the table class and it waits in a loop until the number of sstable runs goes below threshold. It uses condition variable which is signaled on sstable set refresh. It handles node shutdown as well.
- Converted table::stop to coroutines.
- Reordered commits so that test is committed after fix, so it doesn't trip up bisection.