### PR TITLE
test: cdc_enable_disable_test: remove non-determinism

### DIFF
--- a/test/cql/cdc_enable_disable_test.cql
+++ b/test/cql/cdc_enable_disable_test.cql
@@ -1,3 +1,6 @@
+-- Important: using the same partition key for each row so the results of select from log table
+-- do not depend on how stream IDs are assigned to partition keys.
+
 -- Error messages contain a keyspace name. Make the output stable.
 CREATE KEYSPACE ks WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1};
 
@@ -5,30 +8,30 @@ CREATE KEYSPACE ks WITH replication = {'class': 'SimpleStrategy', 'replication_f
 create table ks.t (pk int, ck int, v int, primary key(pk, ck)) with cdc = {'enabled': true};
 
 -- this write goes to the log
-insert into ks.t (pk, ck, v) values (1, 1, 100);
+insert into ks.t (pk, ck, v) values (0, 1, 100);
 
 -- disable cdc. should retain the log
 alter table ks.t with cdc = {'enabled': false};
 
 -- add more data to base - should not generate log
-insert into ks.t (pk, ck, v) values (2, 2, 200);
+insert into ks.t (pk, ck, v) values (0, 2, 200);
 
--- should still work, and give one row (1, 1, 100)
+-- should still work, and give one row (0, 1, 100)
 select "cdc$batch_seq_no", "cdc$operation", "cdc$ttl", pk, ck, v from ks.t_scylla_cdc_log;
 
 -- lets add a column
 alter table ks.t add v2 text;
 
 -- add more data
-insert into ks.t (pk, ck, v, v2) values (3, 3, 300, 'apa');
+insert into ks.t (pk, ck, v, v2) values (0, 3, 300, 'apa');
 
 -- turn cdc back on
 alter table ks.t with cdc = {'enabled': true};
 
 -- more data - this should also go to log.
-insert into ks.t (pk, ck, v, v2) values (4, 4, 400, 'snus');
+insert into ks.t (pk, ck, v, v2) values (0, 4, 400, 'snus');
 
--- gives two rows (1, 1, 100)+(4, 4, 400, 'snus')
+-- gives two rows (0, 1, 100)+(0, 4, 400, 'snus')
 select "cdc$batch_seq_no", "cdc$operation", "cdc$ttl", pk, ck, v, v2 from ks.t_scylla_cdc_log;
 
 -- disable cdc. should retain the log
@@ -38,14 +41,14 @@ alter table ks.t with cdc = {'enabled': false};
 alter table ks.t drop v;
 
 -- add more data
-insert into ks.t (pk, ck, v2) values (5, 5, 'fisk');
+insert into ks.t (pk, ck, v2) values (0, 5, 'fisk');
 
 -- turn cdc back on
 alter table ks.t with cdc = {'enabled': true};
 
-insert into ks.t (pk, ck, v2) values (6, 6, 'aborre');
+insert into ks.t (pk, ck, v2) values (0, 6, 'aborre');
 
--- gives three rows (1, 1)+(4, 4, 'snus')+(6, 6, 'aborre')
+-- gives three rows (0, 1)+(0, 4, 'snus')+(0, 6, 'aborre')
 select "cdc$batch_seq_no", "cdc$operation", "cdc$ttl", pk, ck, v2 from ks.t_scylla_cdc_log;
 
 DROP KEYSPACE ks;

--- a/test/cql/cdc_enable_disable_test.result
+++ b/test/cql/cdc_enable_disable_test.result
@@ -1,3 +1,6 @@
+> -- Important: using the same partition key for each row so the results of select from log table
+> -- do not depend on how stream IDs are assigned to partition keys.
+> 
 > -- Error messages contain a keyspace name. Make the output stable.
 > CREATE KEYSPACE ks WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1};
 OK
@@ -7,7 +10,7 @@ OK
 OK
 > 
 > -- this write goes to the log
-> insert into ks.t (pk, ck, v) values (1, 1, 100);
+> insert into ks.t (pk, ck, v) values (0, 1, 100);
 OK
 > 
 > -- disable cdc. should retain the log
@@ -15,15 +18,15 @@ OK
 OK
 > 
 > -- add more data to base - should not generate log
-> insert into ks.t (pk, ck, v) values (2, 2, 200);
+> insert into ks.t (pk, ck, v) values (0, 2, 200);
 OK
 > 
-> -- should still work, and give one row (1, 1, 100)
+> -- should still work, and give one row (0, 1, 100)
 > select "cdc$batch_seq_no", "cdc$operation", "cdc$ttl", pk, ck, v from ks.t_scylla_cdc_log;
 +--------------------+-----------------+-----------+------+------+-----+
 |   cdc$batch_seq_no |   cdc$operation | cdc$ttl   |   pk |   ck |   v |
 |--------------------+-----------------+-----------+------+------+-----|
-|                  0 |               2 | null      |    1 |    1 | 100 |
+|                  0 |               2 | null      |    0 |    1 | 100 |
 +--------------------+-----------------+-----------+------+------+-----+
 > 
 > -- lets add a column
@@ -31,7 +34,7 @@ OK
 OK
 > 
 > -- add more data
-> insert into ks.t (pk, ck, v, v2) values (3, 3, 300, 'apa');
+> insert into ks.t (pk, ck, v, v2) values (0, 3, 300, 'apa');
 OK
 > 
 > -- turn cdc back on
@@ -39,16 +42,16 @@ OK
 OK
 > 
 > -- more data - this should also go to log.
-> insert into ks.t (pk, ck, v, v2) values (4, 4, 400, 'snus');
+> insert into ks.t (pk, ck, v, v2) values (0, 4, 400, 'snus');
 OK
 > 
-> -- gives two rows (1, 1, 100)+(4, 4, 400, 'snus')
+> -- gives two rows (0, 1, 100)+(0, 4, 400, 'snus')
 > select "cdc$batch_seq_no", "cdc$operation", "cdc$ttl", pk, ck, v, v2 from ks.t_scylla_cdc_log;
 +--------------------+-----------------+-----------+------+------+-----+------+
 |   cdc$batch_seq_no |   cdc$operation | cdc$ttl   |   pk |   ck |   v | v2   |
 |--------------------+-----------------+-----------+------+------+-----+------|
-|                  0 |               2 | null      |    1 |    1 | 100 | null |
-|                  0 |               2 | null      |    4 |    4 | 400 | snus |
+|                  0 |               2 | null      |    0 |    1 | 100 | null |
+|                  0 |               2 | null      |    0 |    4 | 400 | snus |
 +--------------------+-----------------+-----------+------+------+-----+------+
 > 
 > -- disable cdc. should retain the log
@@ -60,24 +63,24 @@ OK
 OK
 > 
 > -- add more data
-> insert into ks.t (pk, ck, v2) values (5, 5, 'fisk');
+> insert into ks.t (pk, ck, v2) values (0, 5, 'fisk');
 OK
 > 
 > -- turn cdc back on
 > alter table ks.t with cdc = {'enabled': true};
 OK
 > 
-> insert into ks.t (pk, ck, v2) values (6, 6, 'aborre');
+> insert into ks.t (pk, ck, v2) values (0, 6, 'aborre');
 OK
 > 
-> -- gives three rows (1, 1)+(4, 4, 'snus')+(6, 6, 'aborre')
+> -- gives three rows (0, 1)+(0, 4, 'snus')+(0, 6, 'aborre')
 > select "cdc$batch_seq_no", "cdc$operation", "cdc$ttl", pk, ck, v2 from ks.t_scylla_cdc_log;
 +--------------------+-----------------+-----------+------+------+--------+
 |   cdc$batch_seq_no |   cdc$operation | cdc$ttl   |   pk |   ck | v2     |
 |--------------------+-----------------+-----------+------+------+--------|
-|                  0 |               2 | null      |    1 |    1 | null   |
-|                  0 |               2 | null      |    4 |    4 | snus   |
-|                  0 |               2 | null      |    6 |    6 | aborre |
+|                  0 |               2 | null      |    0 |    1 | null   |
+|                  0 |               2 | null      |    0 |    4 | snus   |
+|                  0 |               2 | null      |    0 |    6 | aborre |
 +--------------------+-----------------+-----------+------+------+--------+
 > 
 > DROP KEYSPACE ks;


### PR DESCRIPTION
The test sometimes fails because the order of rows in the SELECT results
depends on how stream IDs for the different partition keys get generated.
In some runs the stream ID for pk=1 may go before the stream ID for
pk=4, in some runs the other way.

The fix is to use the same partition key but different clustering keys
for the different rows.

Refs: #10601