### PR TITLE
test.py: fix bugs, add support for flaky tests

### DIFF
--- a/test/pylib/artifact_registry.py
+++ b/test/pylib/artifact_registry.py
@@ -47,7 +47,7 @@ class ArtifactRegistry:
         the suite. Executing exit artifacts right away is a good idea
         because it kills running processes and frees their resources
         early."""
-        logging.info("Cleaning up after suite %s...", suite)
+        logging.info("Cleaning up after suite %s...", suite.suite_key)
         # Only drop suite artifacts if the suite executed successfully.
         if not failed and suite in self.suite_artifacts:
             await asyncio.gather(*self.suite_artifacts[suite])
@@ -55,7 +55,7 @@ class ArtifactRegistry:
         if suite in self.exit_artifacts:
             await asyncio.gather(*self.exit_artifacts[suite])
             del self.exit_artifacts[suite]
-        logging.info("Done cleaning up after suite %s...", suite)
+        logging.info("Done cleaning up after suite %s...", suite.suite_key)
 
     def add_suite_artifact(self, suite: Suite, artifact: Callable[[], Artifact]) -> None:
         self.suite_artifacts.setdefault(suite, []).append(artifact())


### PR DESCRIPTION
Marking a test as flaky allows to keep running it in CI rather than disable it when it's discovered that a test is flaky.
Flaky tests, if they fail, show up as flaky in the output, but don't fail the CI.
```
kostja@hulk:~/work/scylla/scylla$ ./test.py cdc_with --repeat=30 --verbose
Found 30 tests.
================================================================================
[N/TOTAL]   SUITE    MODE   RESULT   TEST
------------------------------------------------------------------------------
[1/30]       cql     debug  [ FLKY ] cdc_with_lwt_test.2 9.36s
[2/30]       cql     debug  [ FLKY ] cdc_with_lwt_test.1 9.53s
[3/30]       cql     debug  [ PASS ] cdc_with_lwt_test.7 9.37s
[4/30]       cql     debug  [ PASS ] cdc_with_lwt_test.8 9.41s
[5/30]       cql     debug  [ PASS ] cdc_with_lwt_test.10 9.76s
[6/30]       cql     debug  [ FLKY ] cdc_with_lwt_test.9 9.71s
```