### PR TITLE
test.py: fixes for connection handling

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -63,7 +63,8 @@ def cql(request):
                       auth_provider=PlainTextAuthProvider(username='cassandra', password='cassandra'),
                       ssl_context=ssl_context,
                       )
-    return cluster.connect()
+    yield cluster.connect()
+    cluster.shutdown()
 
 
 # A function-scoped autouse=True fixture allows us to test after every test

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -54,7 +54,7 @@ def cql(request):
         ssl_context = None
     cluster = Cluster(execution_profiles={EXEC_PROFILE_DEFAULT: profile},
                       contact_points=[request.config.getoption('host')],
-                      port=request.config.getoption('port'),
+                      port=int(request.config.getoption('port')),
                       # TODO: make the protocol version an option, to allow testing with
                       # different versions. If we drop this setting completely, it will
                       # mean pick the latest version supported by the client and the server.


### PR DESCRIPTION
Change port type passed to Cassandra Python driver to int to avoid format errors in exceptions.

Manually shutdown connections to avoid reconnects after tests are done (required by upcoming async pytests).

Tests: (dev)