### PR TITLE
just a couple of small tweaks

### DIFF
--- a/rust/.gitignore
+++ b/rust/.gitignore
@@ -1,0 +1,1 @@
+Cargo.lock

--- a/sstables/checksum_utils.hh
+++ b/sstables/checksum_utils.hh
@@ -65,6 +65,9 @@ struct zlib_crc32_checksummer {
     }
 
     inline static uint32_t checksum_combine(uint32_t first, uint32_t second, size_t input_len2) {
+        if (input_len2 == 0) {
+            return first;
+        }
         return crc32_combine(first, second, input_len2);
     }
 

--- a/utils/gz/crc_combine.cc
+++ b/utils/gz/crc_combine.cc
@@ -214,6 +214,9 @@ u32 fast_crc32_combine(u32 crc, u32 crc2, ssize_t len2) {
 #include <zlib.h>
 
 u32 fast_crc32_combine(u32 crc, u32 crc2, ssize_t len2) {
+    if (len2 == 0) {
+        return crc;
+    }
     return crc32_combine(crc, crc2, len2);
 }
 


### PR DESCRIPTION
- gitignore rust/Cargo.lock (it's generated)
- work around a change of behavior in zlib 1.2.12 (it's new)