### PR TITLE
cql3_type::raw_collection: handle unknown types first

### DIFF
--- a/test/boost/user_types_test.cc
+++ b/test/boost/user_types_test.cc
@@ -111,16 +111,16 @@ SEASTAR_TEST_CASE(test_invalid_user_type_statements) {
 
         // non-frozen UDTs can't be inside collections, in create table statements...
         REQUIRE_INVALID(e, "create table bad (a int primary key, b list<ut1>)",
-                "Non-frozen user types or collections are not allowed inside collections: list<ut1>");
+                "Non-frozen user types or collections are not allowed inside collections: list<ks.ut1>");
         REQUIRE_INVALID(e, "create table bad (a int primary key, b set<ut1>)",
-                "Non-frozen user types or collections are not allowed inside collections: set<ut1>");
+                "Non-frozen user types or collections are not allowed inside collections: set<ks.ut1>");
         REQUIRE_INVALID(e, "create table bad (a int primary key, b map<int, ut1>)",
-                "Non-frozen user types or collections are not allowed inside collections: map<int, ut1>");
+                "Non-frozen user types or collections are not allowed inside collections: map<int, ks.ut1>");
         REQUIRE_INVALID(e, "create table bad (a int primary key, b map<ut1, int>)",
-                "Non-frozen user types or collections are not allowed inside collections: map<ut1, int>");
+                "Non-frozen user types or collections are not allowed inside collections: map<ks.ut1, int>");
         // ... and in user type definitions
         REQUIRE_INVALID(e, "create type ut2 (a int, b list<ut1>)",
-                "Non-frozen user types or collections are not allowed inside collections: list<ut1>");
+                "Non-frozen user types or collections are not allowed inside collections: list<ks.ut1>");
         //
         // non-frozen UDTs can't be inside UDTs
         REQUIRE_INVALID(e, "create type ut2 (a int, b ut1)",
@@ -139,6 +139,8 @@ SEASTAR_TEST_CASE(test_invalid_user_type_statements) {
         // can't reference non-existing UDT
         REQUIRE_INVALID(e, "create table bad (a int primary key, b ut2)",
                 "Unknown type ks.ut2");
+        REQUIRE_INVALID(e, "create type ut3 (a int, b list<ut2>)",
+                        "Unknown type ks.ut2");
 
         // can't delete fields of frozen UDT or non-UDT columns
         e.execute_cql("create table cf1 (a int primary key, b frozen<ut1>, c int)").discard_result().get();


### PR DESCRIPTION
cql3_type::raw_collection: handle unknown types first

The issue is about handling errors when the user specifies something strange instead of a type, e.g. `CREATE TABLE try1 (a int PRIMARY KEY, b list<zzz>)`:
* the error message only talks about collections, while zzz could also be an UDT;
* the same error message is given even when zzz is not a valid collection or UDT name.
The first point has already been fixed, now Scylla says 'Non-frozen user types or collections are not allowed inside collections: `list<zzz>`'. This commit fixes the second.

Whether the type is a valid UDT or not is checked in cql3_type::raw_ut::prepare_internal, but 'non-frozen' check triggers first in cql3_type::raw_collection::prepare_internal, before we recursively get to the argument types of the collection. The patch reverses the order here, first thing we recurse and ensure that the collection argument types are valid, and only then we apply the collection checks.

The patch affects the validation order, so is case of `list<zzz<xxx>>` the message could be different, but it doesn't seem to be possible according to the Cql grammar.

Fixes: #3541

Signed-off-by: Petr Gusev <petr.gusev@scylladb.com>