### PR TITLE
checksum_utils_test: supply valid input to crc32_combine()

### DIFF
--- a/test/boost/checksum_utils_test.cc
+++ b/test/boost/checksum_utils_test.cc
@@ -16,9 +16,14 @@
 template<typename ReferenceImpl, typename Impl>
 static
 void test_combine() {
-    auto check = [](size_t len) {
-        auto c1 = Impl::checksum_combine(0x12381237, 0x73747474, len);
-        auto c2 = ReferenceImpl::checksum_combine(0x12381237, 0x73747474, len);
+    auto check = [](size_t len2) {
+        constexpr auto crc1 = 0x12381237;
+        // len2==0 implies crc2==0. Newer zlib versions don't hold the
+        // caller's hands anymore in this case, so make sure we don't
+        // supply invalid input:
+        const auto crc2 = len2 == 0 ? 0 : 0x73747474;
+        auto c1 = Impl::checksum_combine(crc1, crc2, len2);
+        auto c2 = ReferenceImpl::checksum_combine(crc1, crc2, len2);
         BOOST_REQUIRE_EQUAL(c1, c2);
     };
 

--- a/utils/gz/crc_combine.cc
+++ b/utils/gz/crc_combine.cc
@@ -214,6 +214,9 @@ u32 fast_crc32_combine(u32 crc, u32 crc2, ssize_t len2) {
 #include <zlib.h>
 
 u32 fast_crc32_combine(u32 crc, u32 crc2, ssize_t len2) {
+    if (len2 == 0) {
+        return crc;
+    }
     return crc32_combine(crc, crc2, len2);
 }
 


### PR DESCRIPTION
If the len2 argument to crc32_combine() is zero, then the crc2
argument must also be zero.

fast_crc32_combine() explicitly checks for len2==0, in which case it
ignores crc2 (which is the same as if it were zero).

zlib's crc32_combine() used to have that check prior to version
1.2.12, but then lost it, making its necessary for callers to be more
careful.

Also add the len2==0 check to the dummy fast_crc32_combine()
implementation, because it delegates to zlib's.

Signed-off-by: Michael Livshin <michael.livshin@scylladb.com>