### PR TITLE
configure.py: speed up and simplify compdb generation

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -2238,17 +2238,29 @@ with open(buildfile, 'w') as f:
         build help: print_help | always
         ''').format(**globals()))
 
-# create compdbs
 compdb = 'compile_commands.json'
-for mode in selected_modes:
-    mode_out = outdir + '/' + mode
-    submodule_compdbs = [mode_out + '/' + sm + '/' + compdb
-                         for sm in ['abseil', 'seastar']]
-    subprocess.run(['/bin/sh', '-c',
-                    ninja + ' -f ' + buildfile + ' -t compdb ' +
-                    '| ./scripts/merge-compdb.py build/' + mode + ' - ' +
-                    ' '.join(submodule_compdbs) +
-                    '> ' + mode_out + '/' + compdb])
+# per-mode compdbs are built by taking the relevant entries from the
+# output of "ninja -t compdb" and combining them with the CMake-made
+# compdbs for Seastar and Abseil in the relevant mode.
+#
+# "ninja -t compdb" output has to be filtered because
+# - it contains rules for all selected modes, and several entries for
+#   the same source file usually confuse indexers
+# - it contains lots of irrelevant entries (for linker invocations,
+#   header-only compilations, etc.)
+ensure_tmp_dir_exists()
+with tempfile.NamedTemporaryFile() as ninja_compdb:
+    subprocess.run([ninja, '-f', buildfile, '-t', 'compdb'], stdout=ninja_compdb.file.fileno())
+    ninja_compdb.file.flush()
+
+    # build mode-specific compdbs
+    for mode in selected_modes:
+        mode_out = outdir + '/' + mode
+        submodule_compdbs = [mode_out + '/' + submodule + '/' + compdb for submodule in ['abseil', 'seastar']]
+        with open(mode_out + '/' + compdb, 'w+b') as combined_mode_specific_compdb:
+            subprocess.run(['./scripts/merge-compdb.py', 'build/' + mode,
+                            ninja_compdb.name] + submodule_compdbs, stdout=combined_mode_specific_compdb)
+
 # make sure there is a valid compile_commands.json link in the source root
 if not os.path.exists(compdb):
     # sort modes by supposed indexing speed

--- a/scripts/merge-compdb.py
+++ b/scripts/merge-compdb.py
@@ -27,7 +27,6 @@
 #
 
 import json
-import logging
 import re
 import sys
 
@@ -35,28 +34,17 @@ prefix = sys.argv[1]
 inputs = sys.argv[2:]
 
 def read_input(fname):
-    try:
-        if fname == '-':
-            f = sys.stdin
-        else:
-            f = open(fname)
-
+    with open(fname) as f:
         return json.load(f)
-    except Exception as e:
-        logging.error('failed to parse %s: %s', fname, e)
-        return [];
-    finally:
-        if fname != '-':
-            f.close()
 
 def is_indexable(e):
     return any(e['file'].endswith('.' + suffix) for suffix in ['c', 'C', 'cc', 'cxx'])
 
 # We can only definitely say whether an entry is built under the right
 # prefix when it has an "output" field, so those without are assumed
-# to be OK.  This works for our usage, where only the "-" input (which
-# results from "ninja -t compdb") has 'output' entries _and_ needs to
-# be filtered in the first place.
+# to be OK.  This works for our usage, where only "ninja -t compdb"
+# creates entries with an 'output' field _and_ needs to be filtered in
+# the first place.
 def is_relevant(e):
     return ('output' not in e) or (e['output'].startswith(prefix))
 


### PR DESCRIPTION
The most time-consuming part is invoking "ninja -t compdb", and there
is no need to repeat that for every mode.

Signed-off-by: Michael Livshin <michael.livshin@scylladb.com>