### PR TITLE
tools: toolchain: prepare: use buildah multi-arch build instead of bash hacks

### DIFF
--- a/tools/toolchain/prepare
+++ b/tools/toolchain/prepare
@@ -42,33 +42,7 @@ for arch in "${archs[@]}"; do
     fi
 done
 
-buildah manifest create "$(<tools/toolchain/image)"
-
-
-build_arch() {
-    local arch="$1"
-    image_id_file="$(mktemp)"
-    buildah bud --arch="$arch" --squash --no-cache --pull -f tools/toolchain/Dockerfile --iidfile "$image_id_file"
-    buildah manifest add --all "$(<tools/toolchain/image)" "$(<$image_id_file)"
-    rm "$image_id_file"
-}
-
-for arch in "${archs[@]}"; do
-    build_arch "$arch" &
-done
-
-fails=0
-
-for arch in "${archs[@]}"; do
-    if ! wait -n; then
-        (( fails += 1 ))
-    fi
-done
-
-if (( fails > 0 )); then
-    echo "$fails failures building arch-specific images"
-    exit 1
-fi
+buildah bud "${archs[@]/#/--platform=linux/}" --jobs 0 --squash --no-cache --pull -f tools/toolchain/Dockerfile --manifest "$(<tools/toolchain/image)"
 
 echo "Done building $(<tools/toolchain/image). You can now test it, and push with"
 echo ""


### PR DESCRIPTION
In 69af7a830b ("tools: toolchain: prepare: build arch images in parallel"),
we added parallel image generation. But it turns out that buildah can
do this natively (with the --platform option to specify architectures
and --jobs parameter to allow parallelism). This is simpler and likely
has better error handling than an ad-hoc bash script, so switch to it.