### PR TITLE
Fix stalls during repair with rbno

### DIFF
--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -1270,6 +1270,8 @@ private:
         // Repair rows in row_diff will be flushed to disk by flush_rows_in_working_row_buf,
         // so we skip calling do_apply_rows here.
         _dirty_on_master = is_dirty_on_master::yes;
+        // Clear gently to avoid stalls
+        utils::clear_gently(row_diff).get();
     }
 public:
     // Must run inside a seastar thread

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -892,9 +892,9 @@ public:
     future<repair_hash_set>
     working_row_hashes() {
         return do_with(repair_hash_set(), [this] (repair_hash_set& hashes) {
-            return do_for_each(_working_row_buf, [&hashes] (repair_row& r) {
+            return do_for_each(_working_row_buf, [&hashes] (repair_row& r) mutable {
                 hashes.emplace(r.hash());
-            }).then([&hashes] {
+            }).then([&hashes] () mutable {
                 return std::move(hashes);
             });
         });


### PR DESCRIPTION
Found with scylla --blocked-reactor-notify-ms 1 during replace operation with rbno turned on. 
The stalls showed without this patch were gone after this path set. 