### PR TITLE
main: shutdown: do not abort on storage_io_error

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -385,6 +385,8 @@ static auto defer_verbose_shutdown(const char* what, Func&& func) {
                         break;
                     }
                 }
+            } catch (const storage_io_error& e) {
+                do_abort = false;
             } catch (...) {
             }
             auto msg = fmt::format("Unexpected error shutting down {}: {}", what, ex);


### PR DESCRIPTION
Do not abort in defer_verbose_shutdown if the callback
throws storage_io_error, similar and in addition to
the system errors handling that was added in
132c9d593378b42bb1c38de80ecd3a1b04e3ee39

As seen in https://github.com/scylladb/scylla/issues/9573#issuecomment-1148238291

Fixes #9573

Signed-off-by: Benny Halevy <bhalevy@scylladb.com>