### PR TITLE
Support installing pip provided command symlinks to /usr/bin

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -83,6 +83,7 @@ i18n_xlat = {
 
 python3_dependencies = subprocess.run('./install-dependencies.sh --print-python3-runtime-packages', shell=True, capture_output=True, encoding='utf-8').stdout.strip()
 pip_dependencies = subprocess.run('./install-dependencies.sh --print-pip-runtime-packages', shell=True, capture_output=True, encoding='utf-8').stdout.strip()
+pip_symlinks = subprocess.run('./install-dependencies.sh --print-pip-symlinks', shell=True, capture_output=True, encoding='utf-8').stdout.strip()
 node_exporter_filename = subprocess.run('./install-dependencies.sh --print-node-exporter-filename', shell=True, capture_output=True, encoding='utf-8').stdout.strip()
 node_exporter_dirname = os.path.basename(node_exporter_filename).rstrip('.tar.gz')
 
@@ -2175,7 +2176,7 @@ with open(buildfile, 'w') as f:
 
         build tools/python3/build/{scylla_product}-python3-{arch}-package.tar.gz: build-submodule-reloc | build/SCYLLA-PRODUCT-FILE build/SCYLLA-VERSION-FILE build/SCYLLA-RELEASE-FILE
           reloc_dir = tools/python3
-          args = --packages "{python3_dependencies}" --pip-packages "{pip_dependencies}"
+          args = --packages "{python3_dependencies}" --pip-packages "{pip_dependencies}" --pip-symlinks "{pip_symlinks}"
         build dist-python3-rpm: build-submodule-rpm tools/python3/build/{scylla_product}-python3-{arch}-package.tar.gz
           dir = tools/python3
           artifact = $builddir/{scylla_product}-python3-{arch}-package.tar.gz

--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -128,6 +128,10 @@ pip_packages=(
     scylla-api-client
 )
 
+pip_symlinks=(
+    scylla-api-client
+)
+
 centos_packages=(
     gdb
     yaml-cpp-devel
@@ -223,12 +227,14 @@ print_usage() {
     echo ""
     echo "  --print-python3-runtime-packages Print required python3 packages for Scylla"
     echo "  --print-pip-runtime-packages Print required pip packages for Scylla"
+    echo "  --print-pip-symlinks Print list of pip provided commands which need to install to /usr/bin"
     echo "  --print-node-exporter-filename Print node_exporter filename"
     exit 1
 }
 
 PRINT_PYTHON3=false
 PRINT_PIP=false
+PRINT_PIP_SYMLINK=false
 PRINT_NODE_EXPORTER=false
 while [ $# -gt 0 ]; do
     case "$1" in
@@ -238,6 +244,10 @@ while [ $# -gt 0 ]; do
             ;;
         "--print-pip-runtime-packages")
             PRINT_PIP=true
+            shift 1
+            ;;
+        "--print-pip-symlinks")
+            PRINT_PIP_SYMLINK=true
             shift 1
             ;;
         "--print-node-exporter-filename")
@@ -261,6 +271,11 @@ fi
 
 if $PRINT_PIP; then
     echo "${pip_packages[@]}"
+    exit 0
+fi
+
+if $PRINT_PIP_SYMLINK; then
+    echo "${pip_symlinks[@]}"
     exit 0
 fi
 


### PR DESCRIPTION
This is part of support installing executables from PIP package,
now we support installing executable from PIP package but it will
install under /opt/scylladb/python3/bin.
To call these commands without speciying full path, we also need to install
symlink to /usr/bin.
To do this, we need new list which specifies command name for symlink.