### PR TITLE
compaction::setup: yield to prevent stalls with large number of sstables

### DIFF
--- a/compaction/compaction.cc
+++ b/compaction/compaction.cc
@@ -624,6 +624,7 @@ private:
         auto fully_expired = _table_s.fully_expired_sstables(_sstables, gc_clock::now());
         min_max_tracker<api::timestamp_type> timestamp_tracker;
 
+        _input_sstable_generations.reserve(_sstables.size());
         for (auto& sst : _sstables) {
             co_await coroutine::maybe_yield();
             auto& sst_stats = sst->get_stats_metadata();

--- a/compaction/compaction.cc
+++ b/compaction/compaction.cc
@@ -618,13 +618,14 @@ private:
         return _table_s.get_compaction_strategy().make_sstable_set(_schema);
     }
 
-    void setup() {
+    future<> setup() {
         auto ssts = make_lw_shared<sstables::sstable_set>(make_sstable_set_for_input());
         formatted_sstables_list formatted_msg;
         auto fully_expired = _table_s.fully_expired_sstables(_sstables, gc_clock::now());
         min_max_tracker<api::timestamp_type> timestamp_tracker;
 
         for (auto& sst : _sstables) {
+            co_await coroutine::maybe_yield();
             auto& sst_stats = sst->get_stats_metadata();
             timestamp_tracker.update(sst_stats.min_timestamp);
             timestamp_tracker.update(sst_stats.max_timestamp);
@@ -1572,7 +1573,7 @@ public:
 
 future<compaction_result> compaction::run(std::unique_ptr<compaction> c) {
     return seastar::async([c = std::move(c)] () mutable {
-        c->setup();
+        c->setup().get();
         auto consumer = c->consume();
 
         auto start_time = db_clock::now();


### PR DESCRIPTION
As seen in https://github.com/scylladb/scylla/issues/10738,
compaction::setup might stall when processing a large number of sstables.

Make it a coroutine and maybe_yield to prevent those stalls.
