### PR TITLE
process_sstables_dir: close directory_lister on error

### DIFF
--- a/sstables/sstable_directory.cc
+++ b/sstables/sstable_directory.cc
@@ -171,9 +171,22 @@ sstable_directory::process_sstable_dir(const ::io_priority_class& iop, bool sort
     scan_state state;
 
     directory_lister sstable_dir_lister(_sstable_dir, { directory_entry_type::regular }, &manifest_json_filter);
+    std::exception_ptr ex;
+    try {
+    // FIXME: indentation
     while (auto de = co_await sstable_dir_lister.get()) {
         auto comps = sstables::entry_descriptor::make_descriptor(_sstable_dir.native(), de->name);
         handle_component(state, std::move(comps), _sstable_dir / de->name);
+    }
+    } catch (...) {
+        ex = std::current_exception();
+    }
+    co_await sstable_dir_lister.close();
+    if (ex) {
+        dirlog.debug("Could not process sstable directory {}: {}", _sstable_dir, ex);
+        // FIXME: waiting for https://github.com/scylladb/seastar/pull/1090
+        // co_await coroutine::return_exception(std::move(ex));
+        std::rethrow_exception(std::move(ex));
     }
 
     // Always okay to delete files with a temporary TOC. We want to do it before we process

--- a/sstables/sstable_directory.cc
+++ b/sstables/sstable_directory.cc
@@ -173,11 +173,10 @@ sstable_directory::process_sstable_dir(const ::io_priority_class& iop, bool sort
     directory_lister sstable_dir_lister(_sstable_dir, { directory_entry_type::regular }, &manifest_json_filter);
     std::exception_ptr ex;
     try {
-    // FIXME: indentation
-    while (auto de = co_await sstable_dir_lister.get()) {
-        auto comps = sstables::entry_descriptor::make_descriptor(_sstable_dir.native(), de->name);
-        handle_component(state, std::move(comps), _sstable_dir / de->name);
-    }
+        while (auto de = co_await sstable_dir_lister.get()) {
+            auto comps = sstables::entry_descriptor::make_descriptor(_sstable_dir.native(), de->name);
+            handle_component(state, std::move(comps), _sstable_dir / de->name);
+        }
     } catch (...) {
         ex = std::current_exception();
     }


### PR DESCRIPTION
`sstable_directory::process_sstables_dir` may hit an exception when calling `handle_component`.
In this case we currently destroy the `sstable_dir_lister` variable without closing the `directory_lister` first -
leading to terminate in `~directory_lister` as seen in #10697.

This mini-series handles this exception and always closes the `directory_lister`.
    
Add unit test to reproduce this issue.
    
Fixes #10697