### PR TITLE
streaming: Enable auto off strategy compaction trigger for all rbno ops

### DIFF
--- a/streaming/consumer.cc
+++ b/streaming/consumer.cc
@@ -59,8 +59,8 @@ std::function<future<> (flat_mutation_reader_v2)> make_streaming_consumer(sstrin
                                              cf->get_sstables_manager().configure_writer(origin),
                                              encoding_stats{}, pc).then([sst] {
                     return sst->open_data();
-                }).then([cf, sst, offstrategy, reason] {
-                    if (offstrategy && (reason == stream_reason::repair)) {
+                }).then([cf, sst, offstrategy, reason, origin] {
+                    if (offstrategy && sstables::repair_origin == origin) {
                         sstables::sstlog.debug("Enabled automatic off-strategy trigger for table {}.{}",
                                 cf->schema()->ks_name(), cf->schema()->cf_name());
                         cf->enable_off_strategy_trigger();


### PR DESCRIPTION
Since commit 3dc9a81d02a26d021ad1954d57b574ad4899561d (repair: Repair
table by table internally), a table is always repaired one after
another. This means a table will be repaired in a continuous manner.

Unlike before a table will be repaired again after other tables have
finished the same range.

```
for range in ranges
  for table in tables
      repair(range, table)
```

The wait interval can be large so we can not utilize the assumption if
there is no repair traffic, the whole table is finished.

After commit 3dc9a81d02a26d021ad1954d57b574ad4899561d, we can utilize
the fact that a table is repaired continuously property and trigger off
strategy automatically when no repair traffic for a table is present.

This is especially useful for decommission operation with multiple
tables. Currently, we only notify the peer node the decommission is done
and ask the peer to trigger off strategy compaction. With this
patch, the peer node will trigger automatically after a table is
finished, reducing the number of temporary sstables on disk.

Refs #10462