### PR TITLE
toolchain: set the PATH for the dbuild image includes ccache

### DIFF
--- a/tools/toolchain/Dockerfile
+++ b/tools/toolchain/Dockerfile
@@ -14,4 +14,5 @@ RUN dnf -y update \
     && echo 'Defaults !requiretty' >> /etc/sudoers
 RUN mkdir -p /root/.m2/repository
 ENV JAVA8_HOME=/usr/lib/jvm/java-1.8.0-openjdk
+ENV PATH=/usr/lib64/ccache:$PATH
 CMD /bin/bash


### PR DESCRIPTION
ccache is added to the PATH by the `/etc/profile.d/ccache.sh` script (locates in dbuild)
but currently there is an issue with the dbuild script that fails to load the
bash env. and ccache is missing from the PATH,

```shell
$ ./tools/toolchain/dbuild bash -c 'echo "$PATH"'
/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
beni.peled@fedora ~/repos/scylla (dbuild_declare_path) $ ./tools/toolchain/dbuild -it -- bash
bash-5.1# 
```

This commit makes sure that ccache will always be included in the PATH
regardless of the dbuild script,