### PR TITLE
test/cql-pytest: skip another test on older, buggy, drivers

### DIFF
--- a/test/cql-pytest/test_secondary_index.py
+++ b/test/cql-pytest/test_secondary_index.py
@@ -373,7 +373,7 @@ def test_index_in_restriction(cql, test_keyspace, cassandra_bug):
 # returned fewer than the requested number of rows.
 @pytest.mark.parametrize("use_index", [
         pytest.param(True, marks=pytest.mark.xfail(reason="#10649")), False])
-def test_filter_and_limit(cql, test_keyspace, use_index):
+def test_filter_and_limit(cql, test_keyspace, use_index, driver_bug_1):
     with new_test_table(cql, test_keyspace, 'pk int primary key, x int, y int') as table:
         if use_index:
             cql.execute(f'CREATE INDEX ON {table}(x)')


### PR DESCRIPTION
Older versions of the Python Cassandra driver had a bug where a single empty
page aborts a scan.
    
The test test_secondary_index.py::test_filter_and_limit uses filtering and deliberately 
tiny pages, so it turns out that some of them are  empty, so the test breaks on buggy
versions of the driver, which cause the test to fail when run by developers who happen
to have old versions of the driver.
    
So in this small series we skip this test when running on a buggy version of the driver.
    
Fixes #10763