### PR TITLE
scripts: make pull_github_pr.sh more universally usable

### DIFF
--- a/scripts/pull_github_pr.sh
+++ b/scripts/pull_github_pr.sh
@@ -24,8 +24,10 @@ done
 NL=$'\n'
 
 PR_NUM=$1
-# convert full repo URL to its project/repo part:
-REMOTE_SLASH_BRANCH="$(git rev-parse --abbrev-ref --symbolic-full-name  @{upstream})"
+# convert full repo URL to its project/repo part, in case of failure default to origin/master:
+REMOTE_SLASH_BRANCH="$(git rev-parse --abbrev-ref --symbolic-full-name  @{upstream} \
+     || git rev-parse --abbrev-ref --symbolic-full-name master@{upstream} \
+     || echo 'origin/master')"
 REMOTE="${REMOTE_SLASH_BRANCH%/*}"
 REMOTE_URL="$(git config --get "remote.$REMOTE.url")"
 PROJECT=`sed 's/git@github.com://;s#https://github.com/##;s/\.git$//;' <<<"${REMOTE_URL}"`


### PR DESCRIPTION
After 93b765f655, our pull_github_pr.sh script tries to detect
a non-orthodox remote repo name, but it also adds an assumption
which breaks on some configurations (by some I mean mine).
Namely, the script tries to parse the repo name from the upstream
branch, assuming that current HEAD actually points to a branch,
which is not the way some users (by some I mean me) work with
remote repositories. Therefore, to make the script also work
with detached HEAD, it now has two fallback mechanisms:
1. If parsing @{upstream} failed, the script tries to parse
   master@{upstream}, under the assumption that the master branch
   was at least once used to track the remote repo.
2. If that fails, `origin/master` is used as last resort solution.

This patch allows some users (guess who) to get back to using
scripts/pull_github_pr.sh again without using a custom patched version.