### PR TITLE
tools/schema_loader: add support for CDC tables

### DIFF
--- a/cdc/log.cc
+++ b/cdc/log.cc
@@ -408,7 +408,7 @@ static const sstring cdc_meta_column_prefix = "cdc$";
 static const sstring cdc_deleted_column_prefix = cdc_meta_column_prefix + "deleted_";
 static const sstring cdc_deleted_elements_column_prefix = cdc_meta_column_prefix + "deleted_elements_";
 
-static bool is_log_name(const std::string_view& table_name) {
+bool is_log_name(const std::string_view& table_name) {
     return boost::ends_with(table_name, cdc_log_suffix);
 }
 

--- a/cdc/log.hh
+++ b/cdc/log.hh
@@ -60,6 +60,8 @@ struct operation_result_tracker;
 class db_context;
 class metadata;
 
+bool is_log_name(const std::string_view& table_name);
+
 /// \brief CDC service, responsible for schema listeners
 ///
 /// CDC service will listen for schema changes and iff CDC is enabled/changed


### PR DESCRIPTION
CDC tables use a custom partitioner, which is not reflected in schema dumps (`CREATE TABLE ...`) and currently it is not possible to fix this properly, as we have no syntax to set the partitioner for a table. To work around this, the schema loader determines whether a table is a cdc table based on its name (does it end with `_scylla_cdc_table`) and sets the partitioner manually if it is the case.
Fixes: https://github.com/scylladb/scylla/issues/9840
