### PR TITLE
scylla-gdb.py: make scylla-threads more flexible

### DIFF
--- a/scylla-gdb.py
+++ b/scylla-gdb.py
@@ -2957,15 +2957,53 @@ class scylla_unthread(gdb.Command):
 
 
 class scylla_threads(gdb.Command):
-    """Find and list all seastar::threads on all shards."""
+    """Find and list seastar::threads
+
+    Without any arguments, lists threads on the current shard. You can also list
+    threads on a given shard with `-s $shard` or on all shards with `-a` (old
+    behaviour).
+    Pass `-v` to also add the functor vtable symbol to the listing, this might
+    or might not tell you what the main function of the thread is.
+    Invoke with `--help` to see all available options.
+    """
     def __init__(self):
         gdb.Command.__init__(self, 'scylla threads', gdb.COMMAND_USER, gdb.COMPLETE_NONE, True)
 
+    def _do_list_threads(self, shard, include_vtable):
+        for t in seastar_threads_on_current_shard():
+            stack = std_unique_ptr(t['_stack']).get()
+            if include_vtable:
+                maybe_vtable = ' vtable: {}'.format(t['_func']['_vtable'])
+            else:
+                maybe_vtable = ''
+            gdb.write('[shard {}] (seastar::thread_context*) 0x{:x}, stack: 0x{:x}{}\n'.format(
+                shard, int(t.address), int(stack), maybe_vtable))
+
     def invoke(self, arg, for_tty):
+        parser = argparse.ArgumentParser(description="scylla threads")
+        parser.add_argument("-a", "--all", action="store_true",
+                help="list threads on all shards")
+        parser.add_argument("-s", "--shard", action="store", type=int, default=-1,
+                help="list threads on the specified shard")
+        parser.add_argument("-v", "--vtable", action="store_true",
+                help="include functor vtable in the printout; could be useful for identifying the thread, but makes the output very verbose")
+
+        try:
+            args = parser.parse_args(arg.split())
+        except SystemExit:
+            return
+
+        if args.all:
+            shards = list(range(cpus()))
+        elif args.shard != -1:
+            shards = [args.shard]
+        else:
+            shards = [int(gdb.parse_and_eval('seastar::local_engine._id'))]
+
         for r in reactors():
-            shard = r['_id']
-            for t in seastar_threads_on_current_shard():
-                gdb.write('[shard %2d] (seastar::thread_context*) 0x%x\n' % (shard, int(t.address)))
+            shard = int(r['_id'])
+            if shard in shards:
+                self._do_list_threads(shard, args.vtable)
 
 
 class circular_buffer(object):


### PR DESCRIPTION
Currently the scylla-threads command just lists all threads on all shards. This is usually more than what one wants. This patch adds support for listing threads only on the current shard (new default), on a specific shard or all shards (old default).
Also, optionally the thread functor's vtable symbol can be added to the listing. This makes the listing more informative but much more bloated as well. Which is why it's opt-in.

Example listing (no vtable symbols):
```
(gdb) scylla threads 
[shard 5] (seastar::thread_context*) 0x60100035c900, stack: 0x60100bd20000
[shard 5] (seastar::thread_context*) 0x6010084a3800, stack: 0x601008c80000
[shard 5] (seastar::thread_context*) 0x60100037c900, stack: 0x60100c640000
[shard 5] (seastar::thread_context*) 0x60100035d200, stack: 0x60100d9e0000
[shard 5] (seastar::thread_context*) 0x60100372d980, stack: 0x60100ad60000
[shard 5] (seastar::thread_context*) 0x601000110d80, stack: 0x601009be0000
[shard 5] (seastar::thread_context*) 0x6010084cd680, stack: 0x60100a160000
[shard 5] (seastar::thread_context*) 0x6010000dc780, stack: 0x60100a2e0000
[shard 5] (seastar::thread_context*) 0x6010084cca80, stack: 0x60100a1c0000
[shard 5] (seastar::thread_context*) 0x6010084cc000, stack: 0x60100ab40000
[shard 5] (seastar::thread_context*) 0x60100038ca80, stack: 0x601009860000
[shard 5] (seastar::thread_context*) 0x60100037db00, stack: 0x60100a820000
```
Example listing with vtable symbols:
```
(gdb) scylla threads -v
[shard 5] (seastar::thread_context*) 0x60100035c900, stack: 0x60100bd20000 vtable: 0x478520 <seastar::noncopyable_function<void ()>::direct_vtable_for<seastar::async<sstables::compaction::consume_without_gc_writer(std::chrono::time_point<gc_clock, std::chrono::duration<long, std::ratio<1l, 1l> > >)::{lambda(flat_mutation_reader_v2)#1}::operator()(flat_mutation_reader_v2)::{lambda()#1}>(seastar::thread_attributes, sstables::compaction::consume_without_gc_writer(std::chrono::time_point<gc_clock, std::chrono::duration<long, std::ratio<1l, 1l> > >)::{lambda(flat_mutation_reader_v2)#1}::operator()(flat_mutation_reader_v2)::{lambda()#1}&&)::{lambda()#1}>::s_vtable>
[shard 5] (seastar::thread_context*) 0x6010084a3800, stack: 0x601008c80000 vtable: 0x478520 <seastar::noncopyable_function<void ()>::direct_vtable_for<seastar::async<sstables::compaction::consume_without_gc_writer(std::chrono::time_point<gc_clock, std::chrono::duration<long, std::ratio<1l, 1l> > >)::{lambda(flat_mutation_reader_v2)#1}::operator()(flat_mutation_reader_v2)::{lambda()#1}>(seastar::thread_attributes, sstables::compaction::consume_without_gc_writer(std::chrono::time_point<gc_clock, std::chrono::duration<long, std::ratio<1l, 1l> > >)::{lambda(flat_mutation_reader_v2)#1}::operator()(flat_mutation_reader_v2)::{lambda()#1}&&)::{lambda()#1}>::s_vtable>
[shard 5] (seastar::thread_context*) 0x60100037c900, stack: 0x60100c640000 vtable: 0x478520 <seastar::noncopyable_function<void ()>::direct_vtable_for<seastar::async<sstables::compaction::consume_without_gc_writer(std::chrono::time_point<gc_clock, std::chrono::duration<long, std::ratio<1l, 1l> > >)::{lambda(flat_mutation_reader_v2)#1}::operator()(flat_mutation_reader_v2)::{lambda()#1}>(seastar::thread_attributes, sstables::compaction::consume_without_gc_writer(std::chrono::time_point<gc_clock, std::chrono::duration<long, std::ratio<1l, 1l> > >)::{lambda(flat_mutation_reader_v2)#1}::operator()(flat_mutation_reader_v2)::{lambda()#1}&&)::{lambda()#1}>::s_vtable>
[shard 5] (seastar::thread_context*) 0x60100035d200, stack: 0x60100d9e0000 vtable: 0x4784f0 <seastar::noncopyable_function<void ()>::direct_vtable_for<seastar::async<sstables::compaction::run(std::unique_ptr<sstables::compaction, std::default_delete<sstables::compaction> >)::$_1>(seastar::thread_attributes, sstables::compaction::run(std::unique_ptr<sstables::compaction, std::default_delete<sstables::compaction> >)::$_1&&)::{lambda()#1}>::s_vtable>
[shard 5] (seastar::thread_context*) 0x60100372d980, stack: 0x60100ad60000 vtable: 0x5649a8 <seastar::noncopyable_function<void ()>::direct_vtable_for<seastar::async<db::hints::manager::end_point_hints_manager::sender::start()::$_20>(seastar::thread_attributes, db::hints::manager::end_point_hints_manager::sender::start()::$_20&&)::{lambda()#1}>::s_vtable>
[shard 5] (seastar::thread_context*) 0x601000110d80, stack: 0x601009be0000 vtable: 0x5649a8 <seastar::noncopyable_function<void ()>::direct_vtable_for<seastar::async<db::hints::manager::end_point_hints_manager::sender::start()::$_20>(seastar::thread_attributes, db::hints::manager::end_point_hints_manager::sender::start()::$_20&&)::{lambda()#1}>::s_vtable>
[shard 5] (seastar::thread_context*) 0x6010084cd680, stack: 0x60100a160000 vtable: 0x5649a8 <seastar::noncopyable_function<void ()>::direct_vtable_for<seastar::async<db::hints::manager::end_point_hints_manager::sender::start()::$_20>(seastar::thread_attributes, db::hints::manager::end_point_hints_manager::sender::start()::$_20&&)::{lambda()#1}>::s_vtable>
[shard 5] (seastar::thread_context*) 0x6010000dc780, stack: 0x60100a2e0000 vtable: 0x5649a8 <seastar::noncopyable_function<void ()>::direct_vtable_for<seastar::async<db::hints::manager::end_point_hints_manager::sender::start()::$_20>(seastar::thread_attributes, db::hints::manager::end_point_hints_manager::sender::start()::$_20&&)::{lambda()#1}>::s_vtable>
[shard 5] (seastar::thread_context*) 0x6010084cca80, stack: 0x60100a1c0000 vtable: 0x582ca8 <seastar::noncopyable_function<void ()>::direct_vtable_for<seastar::async<db::view::view_update_generator::start()::$_0>(seastar::thread_attributes, db::view::view_update_generator::start()::$_0&&)::{lambda()#1}>::s_vtable>
[shard 5] (seastar::thread_context*) 0x6010084cc000, stack: 0x60100ab40000 vtable: 0x5649a8 <seastar::noncopyable_function<void ()>::direct_vtable_for<seastar::async<db::hints::manager::end_point_hints_manager::sender::start()::$_20>(seastar::thread_attributes, db::hints::manager::end_point_hints_manager::sender::start()::$_20&&)::{lambda()#1}>::s_vtable>
[shard 5] (seastar::thread_context*) 0x60100038ca80, stack: 0x601009860000 vtable: 0x8c6088 <seastar::noncopyable_function<void ()>::direct_vtable_for<seastar::async<std::_Bind<void (seastar::tls::reloadable_credentials_base::reloading_builder::*(seastar::tls::reloadable_credentials_base::reloading_builder*))()>>(seastar::thread_attributes, std::_Bind<void (seastar::tls::reloadable_credentials_base::reloading_builder::*(seastar::tls::reloadable_credentials_base::reloading_builder*))()>&&)::{lambda()#1}>::s_vtable>
[shard 5] (seastar::thread_context*) 0x60100037db00, stack: 0x60100a820000 vtable: 0x569bd8 <seastar::noncopyable_function<void ()>::direct_vtable_for<seastar::async<db::hints::space_watchdog::start()::$_2>(seastar::thread_attributes, db::hints::space_watchdog::start()::$_2&&)::{lambda()#1}>::s_vtable>
```