### PR TITLE
messaging: add boilerplate to rpc_protocol_impl.hh

### DIFF
--- a/message/rpc_protocol_impl.hh
+++ b/message/rpc_protocol_impl.hh
@@ -1,3 +1,8 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright 2021-present ScyllaDB
+
+#pragma once
+
 #include <seastar/rpc/rpc.hh>
 #include "messaging_service.hh"
 #include "serializer.hh"


### PR DESCRIPTION
License, copyright, #pragma once.

The copyright is set to 2021 since that was when the file was created.