### PR TITLE
cql3: expr: unify binary operator left-hand-side and right-hand-side evaluation

### DIFF
--- a/cql3/expr/expression.cc
+++ b/cql3/expr/expression.cc
@@ -165,9 +165,8 @@ const column_value& get_subscripted_column(const column_maybe_subscripted& cms) 
 }
 
 managed_bytes_opt
-get_value(const subscript& sref, const evaluation_inputs& inputs) {
-    auto s = &sref;
-    const column_definition* cdef = get_subscripted_column(*s).col;
+get_value(const subscript& s, const evaluation_inputs& inputs) {
+    const column_definition* cdef = get_subscripted_column(s).col;
 
     auto col_type = static_pointer_cast<const collection_type_impl>(cdef->type);
     int32_t index = inputs.selection->index_of(*cdef);
@@ -182,7 +181,7 @@ get_value(const subscript& sref, const evaluation_inputs& inputs) {
         return std::nullopt;
     }
     const auto deserialized = cdef->type->deserialize(managed_bytes_view(*serialized));
-    const auto key = evaluate(s->sub, inputs);
+    const auto key = evaluate(s.sub, inputs);
     auto&& key_type = col_type->is_map() ? col_type->name_comparator() : int32_type;
     if (key.is_null()) {
         // For m[null] return null.

--- a/cql3/expr/expression.cc
+++ b/cql3/expr/expression.cc
@@ -1729,12 +1729,11 @@ constant evaluate(const expression& e, const evaluation_inputs& inputs) {
             on_internal_error(expr_logger, "Can't evaluate a field_selection");
         },
 
-        // TODO Should these be evaluable?
-        [](const column_value&) -> constant {
-            on_internal_error(expr_logger, "Can't evaluate a column_value");
+        [&](const column_value& cv) -> constant {
+            return constant(raw_value::make_value(get_value(cv, inputs)), cv.col->type);
         },
-        [](const subscript&) -> constant {
-            on_internal_error(expr_logger, "Can't evaluate a subscript");
+        [&](const subscript& s) -> constant {
+            return constant(raw_value::make_value(get_value(s, inputs)), s.type);
         },
         [](const untyped_constant&) -> constant {
             on_internal_error(expr_logger, "Can't evaluate a untyped_constant ");

--- a/cql3/expr/expression.cc
+++ b/cql3/expr/expression.cc
@@ -836,7 +836,7 @@ nonwrapping_range<clustering_key_prefix> to_range(oper_t op, const clustering_ke
 }
 
 value_set possible_lhs_values(const column_definition* cdef, const expression& expr, const query_options& options) {
-    const auto type = cdef ? get_value_comparator(cdef) : long_type.get();
+    const auto type = cdef ? &cdef->type->without_reversed() : long_type.get();
     return expr::visit(overloaded_functor{
             [] (const constant& constant_val) {
                 std::optional<bool> bool_val = get_bool_value(constant_val);

--- a/cql3/expr/expression.cc
+++ b/cql3/expr/expression.cc
@@ -164,13 +164,9 @@ const column_value& get_subscripted_column(const column_maybe_subscripted& cms) 
     }, cms);
 }
 
-/// Returns col's value from queried data.
-static managed_bytes_opt get_value(const column_maybe_subscripted& col, const evaluation_inputs& inputs) {
-    return std::visit(overloaded_functor {
-        [&](const column_value* cval) -> managed_bytes_opt {
-            return get_value(*cval, inputs);
-        },
-        [&](const subscript* s) -> managed_bytes_opt {
+managed_bytes_opt
+get_value(const subscript& sref, const evaluation_inputs& inputs) {
+            auto s = &sref;
             const column_definition* cdef = get_subscripted_column(*s).col;
 
             auto col_type = static_pointer_cast<const collection_type_impl>(cdef->type);
@@ -239,6 +235,16 @@ static managed_bytes_opt get_value(const column_maybe_subscripted& col, const ev
             } else {
                 throw exceptions::invalid_request_exception(format("subscripting non-map, non-list column {}", cdef->name_as_text()));
             }
+}
+
+/// Returns col's value from queried data.
+static managed_bytes_opt get_value(const column_maybe_subscripted& col, const evaluation_inputs& inputs) {
+    return std::visit(overloaded_functor {
+        [&](const column_value* cval) -> managed_bytes_opt {
+            return get_value(*cval, inputs);
+        },
+        [&](const subscript* s) -> managed_bytes_opt {
+            return get_value(*s, inputs);
         }
     }, col);
 }

--- a/cql3/expr/expression.cc
+++ b/cql3/expr/expression.cc
@@ -456,6 +456,8 @@ managed_bytes_opt next_value(query::result_row_view::iterator_type& iter, const 
     return std::nullopt;
 }
 
+} // anonymous namespace
+
 /// Returns values of non-primary-key columns from selection.  The kth element of the result
 /// corresponds to the kth column in selection.
 std::vector<managed_bytes_opt> get_non_pk_values(const selection& selection, const query::result_row_view& static_row,
@@ -480,6 +482,8 @@ std::vector<managed_bytes_opt> get_non_pk_values(const selection& selection, con
     }
     return vals;
 }
+
+namespace {
 
 /// True iff cv matches the CQL LIKE pattern.
 bool like(const column_value& cv, const raw_value_view& pattern, const column_value_eval_bag& bag) {
@@ -796,9 +800,12 @@ expression make_conjunction(expression a, expression b) {
 }
 
 bool is_satisfied_by(const expression& restr, const evaluation_inputs& inputs) {
-    const auto regulars = get_non_pk_values(*inputs.selection, *inputs.static_row, inputs.row);
+    static const auto dummy_static_and_regular_columns = std::vector<managed_bytes_opt>();
+    auto& static_and_regular_columns = inputs.static_and_regular_columns
+            ? *inputs.static_and_regular_columns
+            : dummy_static_and_regular_columns;
     return is_satisfied_by(
-            restr, {*inputs.options, row_data_from_partition_slice{*inputs.partition_key, *inputs.clustering_key, regulars, *inputs.selection}});
+            restr, {*inputs.options, row_data_from_partition_slice{*inputs.partition_key, *inputs.clustering_key, static_and_regular_columns, *inputs.selection}});
 }
 
 template<typename T>

--- a/cql3/expr/expression.cc
+++ b/cql3/expr/expression.cc
@@ -795,14 +795,10 @@ expression make_conjunction(expression a, expression b) {
     return conjunction{std::move(children)};
 }
 
-bool is_satisfied_by(
-        const expression& restr,
-        const std::vector<bytes>& partition_key, const std::vector<bytes>& clustering_key,
-        const query::result_row_view& static_row, const query::result_row_view* row,
-        const selection& selection, const query_options& options) {
-    const auto regulars = get_non_pk_values(selection, static_row, row);
+bool is_satisfied_by(const expression& restr, const evaluation_inputs& inputs) {
+    const auto regulars = get_non_pk_values(*inputs.selection, *inputs.static_row, inputs.row);
     return is_satisfied_by(
-            restr, {options, row_data_from_partition_slice{partition_key, clustering_key, regulars, selection}});
+            restr, {*inputs.options, row_data_from_partition_slice{*inputs.partition_key, *inputs.clustering_key, regulars, *inputs.selection}});
 }
 
 template<typename T>

--- a/cql3/expr/expression.hh
+++ b/cql3/expr/expression.hh
@@ -451,11 +451,14 @@ extern std::ostream& operator<<(std::ostream&, oper_t);
 struct evaluation_inputs {
     const std::vector<bytes>* partition_key = nullptr;
     const std::vector<bytes>* clustering_key = nullptr;
-    const query::result_row_view* static_row = nullptr;
-    const query::result_row_view* row = nullptr;
+    const std::vector<managed_bytes_opt>* static_and_regular_columns = nullptr; // indexes match `selection` member
     const cql3::selection::selection* selection = nullptr;
     const query_options* options = nullptr;
 };
+
+/// Helper for generating evaluation_inputs::static_and_regular_columns
+std::vector<managed_bytes_opt> get_non_pk_values(const cql3::selection::selection& selection, const query::result_row_view& static_row,
+                                         const query::result_row_view* row);
 
 /// True iff restr evaluates to true, given these inputs
 extern bool is_satisfied_by(

--- a/cql3/expr/expression.hh
+++ b/cql3/expr/expression.hh
@@ -446,6 +446,17 @@ extern expression make_conjunction(expression a, expression b);
 
 extern std::ostream& operator<<(std::ostream&, oper_t);
 
+// Input data needed to evaluate an expression. Individual members can be
+// null if not applicable (e.g. evaluating outside a row context)
+struct evaluation_inputs {
+    const std::vector<bytes>* partition_key = nullptr;
+    const std::vector<bytes>* clustering_key = nullptr;
+    const query::result_row_view* static_row = nullptr;
+    const query::result_row_view* row = nullptr;
+    const cql3::selection::selection* selection = nullptr;
+    const query_options* options = nullptr;
+};
+
 /// True iff restr is satisfied with respect to the row provided from a partition slice.
 extern bool is_satisfied_by(
         const expression& restr,

--- a/cql3/expr/expression.hh
+++ b/cql3/expr/expression.hh
@@ -673,6 +673,8 @@ data_type type_of(const expression& e);
 
 // Takes a prepared expression and calculates its value.
 // Evaluates bound values, calls functions and returns just the bytes and type.
+constant evaluate(const expression& e, const evaluation_inputs&);
+
 constant evaluate(const expression& e, const query_options&);
 
 utils::chunked_vector<managed_bytes> get_list_elements(const constant&);

--- a/cql3/expr/expression.hh
+++ b/cql3/expr/expression.hh
@@ -457,12 +457,10 @@ struct evaluation_inputs {
     const query_options* options = nullptr;
 };
 
-/// True iff restr is satisfied with respect to the row provided from a partition slice.
+/// True iff restr evaluates to true, given these inputs
 extern bool is_satisfied_by(
-        const expression& restr,
-        const std::vector<bytes>& partition_key, const std::vector<bytes>& clustering_key,
-        const query::result_row_view& static_row, const query::result_row_view* row,
-        const selection::selection&, const query_options&);
+        const expression& restr, const evaluation_inputs& inputs);
+
 
 /// A set of discrete values.
 using value_list = std::vector<managed_bytes>; // Sorted and deduped using value comparator.

--- a/cql3/expr/expression.hh
+++ b/cql3/expr/expression.hh
@@ -674,11 +674,6 @@ data_type type_of(const expression& e);
 // Takes a prepared expression and calculates its value.
 // Evaluates bound values, calls functions and returns just the bytes and type.
 constant evaluate(const expression& e, const query_options&);
-constant evaluate(const bind_variable&, const query_options&);
-constant evaluate(const tuple_constructor&, const query_options&);
-constant evaluate(const collection_constructor&, const query_options&);
-constant evaluate(const usertype_constructor&, const query_options&);
-constant evaluate(const function_call&, const query_options&);
 
 utils::chunked_vector<managed_bytes> get_list_elements(const constant&);
 utils::chunked_vector<managed_bytes> get_set_elements(const constant&);

--- a/cql3/expr/prepare_expr.cc
+++ b/cql3/expr/prepare_expr.cc
@@ -904,7 +904,8 @@ try_prepare_expression(const expression& expr, data_dictionary::database db, con
 
             return subscript {
                 .val = sub_col,
-                .sub = prepare_expression(sub.sub, db, schema.ks_name(), &schema, std::move(subscript_column_spec))
+                .sub = prepare_expression(sub.sub, db, schema.ks_name(), &schema, std::move(subscript_column_spec)),
+                .type = static_cast<const collection_type_impl&>(sub_col_type).value_comparator(),
             };
         },
         [&] (const token& tk) -> std::optional<expression> {

--- a/cql3/selection/selection.cc
+++ b/cql3/selection/selection.cc
@@ -428,7 +428,14 @@ bool result_set_builder::restrictions_filter::do_filter(const selection& selecti
         clustering_key_prefix ckey = clustering_key_prefix::from_exploded(clustering_key);
         return expr::is_satisfied_by(
                 clustering_columns_restrictions->expression,
-                partition_key, clustering_key, static_row, row, selection, _options);
+                expr::evaluation_inputs{
+                    .partition_key = &partition_key,
+                    .clustering_key = &clustering_key,
+                    .static_row = &static_row,
+                    .row = row,
+                    .selection = &selection,
+                    .options = &_options,
+                });
     }
 
     auto static_row_iterator = static_row.iterator();
@@ -448,7 +455,15 @@ bool result_set_builder::restrictions_filter::do_filter(const selection& selecti
             }
             restrictions::single_column_restriction& restriction = *restr_it->second;
             bool regular_restriction_matches = expr::is_satisfied_by(
-                    restriction.expression, partition_key, clustering_key, static_row, row, selection, _options);
+                    restriction.expression,
+                    expr::evaluation_inputs{
+                        .partition_key = &partition_key,
+                        .clustering_key = &clustering_key,
+                        .static_row = &static_row,
+                        .row = row,
+                        .selection = &selection,
+                        .options = &_options,
+                    });
             if (!regular_restriction_matches) {
                 _current_static_row_does_not_match = (cdef->kind == column_kind::static_column);
                 return false;
@@ -466,7 +481,15 @@ bool result_set_builder::restrictions_filter::do_filter(const selection& selecti
             }
             restrictions::single_column_restriction& restriction = *restr_it->second;
             if (!expr::is_satisfied_by(
-                        restriction.expression, partition_key, clustering_key, static_row, row, selection, _options)) {
+                        restriction.expression,
+                        expr::evaluation_inputs{
+                            .partition_key = &partition_key,
+                            .clustering_key = &clustering_key,
+                            .static_row = &static_row,
+                            .row = row,
+                            .selection = &selection,
+                            .options = &_options,
+                        })) {
                 _current_partition_key_does_not_match = true;
                 return false;
             }
@@ -486,7 +509,15 @@ bool result_set_builder::restrictions_filter::do_filter(const selection& selecti
             }
             restrictions::single_column_restriction& restriction = *restr_it->second;
             if (!expr::is_satisfied_by(
-                        restriction.expression, partition_key, clustering_key, static_row, row, selection, _options)) {
+                        restriction.expression,
+                        expr::evaluation_inputs{
+                            .partition_key = &partition_key,
+                            .clustering_key = &clustering_key,
+                            .static_row = &static_row,
+                            .row = row,
+                            .selection = &selection,
+                            .options = &_options,
+                        })) {
                 return false;
             }
             }

--- a/cql3/values.hh
+++ b/cql3/values.hh
@@ -198,6 +198,9 @@ public:
     static raw_value make_value(managed_bytes&& mb) {
         return raw_value{std::move(mb)};
     }
+    static raw_value make_value(managed_bytes_opt&& mbo) {
+        return mbo ? make_value(std::move(*mbo)) : make_null();
+    }
     static raw_value make_value(const managed_bytes& mb) {
         return raw_value{mb};
     }

--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -242,8 +242,18 @@ bool partition_key_matches(const schema& base, const view_info& view, const dht:
     auto selection = cql3::selection::selection::for_columns(base.shared_from_this(), pk_columns);
     uint64_t zero = 0;
     auto dummy_row = query::result_row_view(ser::qr_row_view{simple_memory_input_stream(reinterpret_cast<const char*>(&zero), 8)});
+    auto dummy_options = cql3::query_options({ });
+    // FIXME: pass nullptrs for some of theses dummies
     return cql3::expr::is_satisfied_by(
-            r->expression, exploded_pk, exploded_ck, dummy_row, &dummy_row, *selection, cql3::query_options({ }));
+            r->expression,
+            cql3::expr::evaluation_inputs{
+                .partition_key = &exploded_pk,
+                .clustering_key = &exploded_ck,
+                .static_row = &dummy_row,
+                .row = &dummy_row,
+                .selection = selection.get(),
+                .options = &dummy_options,
+            });
 }
 
 bool clustering_prefix_matches(const schema& base, const view_info& view, const partition_key& key, const clustering_key_prefix& ck) {
@@ -258,8 +268,18 @@ bool clustering_prefix_matches(const schema& base, const view_info& view, const 
     auto selection = cql3::selection::selection::for_columns(base.shared_from_this(), ck_columns);
     uint64_t zero = 0;
     auto dummy_row = query::result_row_view(ser::qr_row_view{simple_memory_input_stream(reinterpret_cast<const char*>(&zero), 8)});
+    auto dummy_options = cql3::query_options({ });
+    // FIXME: pass nullptrs for some of theses dummies
     return cql3::expr::is_satisfied_by(
-            r->expression, exploded_pk, exploded_ck, dummy_row, &dummy_row, *selection, cql3::query_options({ }));
+            r->expression,
+            cql3::expr::evaluation_inputs{
+                .partition_key = &exploded_pk,
+                .clustering_key = &exploded_ck,
+                .static_row = &dummy_row,
+                .row = &dummy_row,
+                .selection = selection.get(),
+                .options = &dummy_options,
+            });
 }
 
 bool may_be_affected_by(const schema& base, const view_info& view, const dht::decorated_key& key, const rows_entry& update) {
@@ -320,8 +340,18 @@ public:
         return boost::algorithm::all_of(
             _view.select_statement().get_restrictions()->get_non_pk_restriction() | boost::adaptors::map_values,
             [&] (auto&& r) {
+                // FIXME: pass dummy_options as nullptr
+                auto dummy_options = cql3::query_options({});
                 return cql3::expr::is_satisfied_by(
-                        r->expression, _pk, ck, static_row, &row, *_selection, cql3::query_options({ }));
+                        r->expression,
+                        cql3::expr::evaluation_inputs{
+                            .partition_key = &_pk,
+                            .clustering_key = &ck,
+                            .static_row = &static_row,
+                            .row = &row,
+                            .selection = _selection.get(),
+                            .options = &dummy_options,
+                        });
             }
         );
     }


### PR DESCRIPTION
The left-hand-side of a binary_operator is currently evaluated via 
a get_value() function that receives the row values. On the other hand,
the right hand side is evaluated via evaluate(), which receives query_options
in order to resolve bind variables.

This series unifies the two paths into evaluate(), and standardizes the different
inputs into a new evaluation_inputs struct. The old hacks column_value_eval_bag
and column_maybe_subscripted are removed.