### PR TITLE
tools/schema_loader: load_schemas(): add note about CDC table names

### DIFF
--- a/tools/schema_loader.hh
+++ b/tools/schema_loader.hh
@@ -19,6 +19,8 @@ namespace tools {
 /// The schema string is expected to contain everything that is needed to
 /// create the table(s): keyspace, UDTs, etc. Definitions are expected to be
 /// separated by `;`. A keyspace will be automatically generated if missing.
+/// Tables whose name ends in "_scylla_cdc_log" are interpreted as CDC tables,
+/// meaning they will be configured with the CDC partitioner.
 /// Loading the schema(s) has no side-effect [1]. Nothing is written to disk,
 /// it is all in memory, kept alive by the returned `schema_ptr`.
 /// This is intended to be used by tools, which don't want to meddle with the


### PR DESCRIPTION
Explaining how the code determines what tables are CDC tables when parsing schema statements.

Follow-up for https://github.com/scylladb/scylla/pull/10774.

@kbr- 