### PR TITLE
Three small fixes to Alternator's handling of GSIs and LSIs

### DIFF
--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -393,6 +393,12 @@ static rjson::value generate_arn_for_table(const schema& schema) {
     return rjson::from_string(format("arn:scylla:alternator:{}:scylla:table/{}", schema.ks_name(), schema.cf_name()));
 }
 
+static rjson::value generate_arn_for_index(const schema& schema, std::string_view index_name) {
+    return rjson::from_string(format(
+        "arn:scylla:alternator:{}:scylla:table/{}/index/{}",
+        schema.ks_name(), schema.cf_name(), index_name));
+}
+
 bool executor::is_alternator_keyspace(const sstring& ks_name) {
     return ks_name.find(KEYSPACE_NAME_PREFIX) == 0;
 }
@@ -449,6 +455,7 @@ future<executor::request_return_type> executor::describe_table(client_state& cli
             }
             sstring index_name = cf_name.substr(delim_it + 1);
             rjson::add(view_entry, "IndexName", rjson::from_string(index_name));
+            rjson::add(view_entry, "IndexArn", generate_arn_for_index(*schema, index_name));
             // Add indexes's KeySchema and collect types for AttributeDefinitions:
             describe_key_schema(view_entry, *vptr, key_attribute_types);
             // Local secondary indexes are marked by an extra '!' sign occurring before the ':' delimiter

--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -46,6 +46,7 @@
 #include <seastar/core/coroutine.hh>
 #include <boost/range/adaptors.hpp>
 #include <boost/range/algorithm/find_end.hpp>
+#include <unordered_set>
 #include "service/storage_proxy.hh"
 #include "gms/gossiper.hh"
 #include "schema_registry.hh"
@@ -150,16 +151,16 @@ static void validate_table_name(const std::string& name) {
 // instead of each component individually as DynamoDB does.
 // The view_name() function assumes the table_name has already been validated
 // but validates the legality of index_name and the combination of both.
-static std::string view_name(const std::string& table_name, const std::string& index_name, const std::string& delim = ":") {
+static std::string view_name(const std::string& table_name, std::string_view index_name, const std::string& delim = ":") {
     static const std::regex valid_index_name_chars ("[a-zA-Z0-9_.-]*");
     if (index_name.length() < 3) {
         throw api_error::validation("IndexName must be at least 3 characters long");
     }
-    if (!std::regex_match(index_name.c_str(), valid_index_name_chars)) {
+    if (!std::regex_match(index_name.data(), valid_index_name_chars)) {
         throw api_error::validation(
                 format("IndexName '{}' must satisfy regular expression pattern: [a-zA-Z0-9_.-]+", index_name));
     }
-    std::string ret = table_name + delim + index_name;
+    std::string ret = table_name + delim + std::string(index_name);
     if (ret.length() > max_table_name_length) {
         throw api_error::validation(
                 format("The total length of TableName ('{}') and IndexName ('{}') cannot exceed {} characters",
@@ -168,7 +169,7 @@ static std::string view_name(const std::string& table_name, const std::string& i
     return ret;
 }
 
-static std::string lsi_name(const std::string& table_name, const std::string& index_name) {
+static std::string lsi_name(const std::string& table_name, std::string_view index_name) {
     return view_name(table_name, index_name, "!:");
 }
 
@@ -275,16 +276,16 @@ get_table_or_view(service::storage_proxy& proxy, const rjson::value& request) {
     if (index_name) {
         if (index_name->IsString()) {
             orig_table_name = std::move(table_name);
-            table_name = view_name(orig_table_name, index_name->GetString());
+            table_name = view_name(orig_table_name, rjson::to_string_view(*index_name));
             type = table_or_view_type::gsi;
         } else {
             throw api_error::validation(
-                    format("Non-string IndexName '{}'", index_name->GetString()));
+                    format("Non-string IndexName '{}'", rjson::to_string_view(*index_name)));
         }
         // If no tables for global indexes were found, the index may be local
         if (!proxy.data_dictionary().has_schema(keyspace_name, table_name)) {
             type = table_or_view_type::lsi;
-            table_name = lsi_name(orig_table_name, index_name->GetString());
+            table_name = lsi_name(orig_table_name, rjson::to_string_view(*index_name));
         }
     }
 
@@ -897,17 +898,23 @@ static future<executor::request_return_type> create_table_on_shard0(tracing::tra
     const rjson::value* gsi = rjson::find(request, "GlobalSecondaryIndexes");
     std::vector<schema_builder> view_builders;
     std::vector<sstring> where_clauses;
+    std::unordered_set<std::string> index_names;
     if (gsi) {
         if (!gsi->IsArray()) {
             co_return api_error::validation("GlobalSecondaryIndexes must be an array.");
         }
         for (const rjson::value& g : gsi->GetArray()) {
-            const rjson::value* index_name = rjson::find(g, "IndexName");
-            if (!index_name || !index_name->IsString()) {
+            const rjson::value* index_name_v = rjson::find(g, "IndexName");
+            if (!index_name_v || !index_name_v->IsString()) {
                 co_return api_error::validation("GlobalSecondaryIndexes IndexName must be a string.");
             }
-            std::string vname(view_name(table_name, index_name->GetString()));
-            elogger.trace("Adding GSI {}", index_name->GetString());
+            std::string_view index_name = rjson::to_string_view(*index_name_v);
+            auto [it, added] = index_names.emplace(index_name);
+            if (!added) {
+                co_return api_error::validation(format("Duplicate IndexName '{}', ", index_name));
+            }
+            std::string vname(view_name(table_name, index_name));
+            elogger.trace("Adding GSI {}", index_name);
             // FIXME: read and handle "Projection" parameter. This will
             // require the MV code to copy just parts of the attrs map.
             schema_builder view_builder(keyspace_name, vname);
@@ -955,12 +962,17 @@ static future<executor::request_return_type> create_table_on_shard0(tracing::tra
             throw api_error::validation("LocalSecondaryIndexes must be an array.");
         }
         for (const rjson::value& l : lsi->GetArray()) {
-            const rjson::value* index_name = rjson::find(l, "IndexName");
-            if (!index_name || !index_name->IsString()) {
+            const rjson::value* index_name_v = rjson::find(l, "IndexName");
+            if (!index_name_v || !index_name_v->IsString()) {
                 throw api_error::validation("LocalSecondaryIndexes IndexName must be a string.");
             }
-            std::string vname(lsi_name(table_name, index_name->GetString()));
-            elogger.trace("Adding LSI {}", index_name->GetString());
+            std::string_view index_name = rjson::to_string_view(*index_name_v);
+            auto [it, added] = index_names.emplace(index_name);
+            if (!added) {
+                co_return api_error::validation(format("Duplicate IndexName '{}', ", index_name));
+            }
+            std::string vname(lsi_name(table_name, index_name));
+            elogger.trace("Adding LSI {}", index_name);
             if (range_key.empty()) {
                 co_return api_error::validation("LocalSecondaryIndex requires that the base table have a range key");
             }

--- a/test/alternator/test_gsi.py
+++ b/test/alternator/test_gsi.py
@@ -168,7 +168,7 @@ def test_gsi_empty_value(test_table_gsi_2):
         test_table_gsi_2.put_item(Item={'p': random_string(), 'x': ''})
 
 # Verify that a GSI is correctly listed in describe_table
-@pytest.mark.xfail(reason="DescribeTable provides index names only, no size or item count")
+@pytest.mark.xfail(reason="DescribeTable for GSI misses IndexSizeBytes, ItemCount, Projection, IndexStatus")
 def test_gsi_describe(test_table_gsi_1):
     desc = test_table_gsi_1.meta.client.describe_table(TableName=test_table_gsi_1.name)
     assert 'Table' in desc
@@ -183,7 +183,9 @@ def test_gsi_describe(test_table_gsi_1):
     assert gsi['IndexStatus'] == 'ACTIVE'
     assert gsi['KeySchema'] == [{'KeyType': 'HASH', 'AttributeName': 'c'},
                                 {'KeyType': 'RANGE', 'AttributeName': 'p'}]
-    # TODO: check also ProvisionedThroughput, IndexArn
+    # The index's ARN should look like the table's ARN followed by /index/<indexname>.
+    assert gsi['IndexArn'] == desc['Table']['TableArn'] + '/index/hello'
+    # TODO: check also ProvisionedThroughput
 
 # When a GSI's key includes an attribute not in the base table's key, we
 # need to remember to add its type to AttributeDefinitions.

--- a/test/alternator/test_lsi.py
+++ b/test/alternator/test_lsi.py
@@ -477,3 +477,40 @@ def test_lsi_filter_expression_and_projection_expression(test_table_lsi_1):
         ProjectionExpression='b',
         ExpressionAttributeValues={':p': p, ':y': 'cat'})
     assert(got_items == [{'b': 'dog'}])
+
+# We tested above that a table can have both an LSI and a GSI.
+# Although Alternator makes a distinction in how it stores the two types of
+# indexes, they cannot have the same name - because if they are created with
+# the same name, only one will be usable (the index is chosen via the
+# IndexName request attribute, which doesn't say if it's an LSI or GSI).
+# DynamoDB reports: "One or more parameter values were invalid:
+# Duplicate index name: samename"
+# Reproduces issue #10789.
+def test_lsi_and_gsi_same_name(dynamodb):
+    with pytest.raises(ClientError, match='ValidationException.*Duplicate'):
+        table = create_test_table(dynamodb,
+            KeySchema=[ { 'AttributeName': 'p', 'KeyType': 'HASH' }, { 'AttributeName': 'c', 'KeyType': 'RANGE' } ],
+            AttributeDefinitions=[
+                    { 'AttributeName': 'p', 'AttributeType': 'S' },
+                    { 'AttributeName': 'c', 'AttributeType': 'S' },
+                    { 'AttributeName': 'x1', 'AttributeType': 'S' },
+            ],
+            GlobalSecondaryIndexes=[
+                {   'IndexName': 'samename',
+                    'KeySchema': [
+                        { 'AttributeName': 'p', 'KeyType': 'HASH' },
+                        { 'AttributeName': 'x1', 'KeyType': 'RANGE' }
+                    ],
+                    'Projection': { 'ProjectionType': 'KEYS_ONLY' }
+                }
+            ],
+            LocalSecondaryIndexes=[
+                {   'IndexName': 'samename',
+                    'KeySchema': [
+                        { 'AttributeName': 'p', 'KeyType': 'HASH' },
+                        { 'AttributeName': 'x1', 'KeyType': 'RANGE' }
+                    ],
+                    'Projection': { 'ProjectionType': 'KEYS_ONLY' }
+                }
+            ])
+        table.delete()

--- a/test/alternator/test_lsi.py
+++ b/test/alternator/test_lsi.py
@@ -240,8 +240,10 @@ def test_lsi_describe(test_table_lsi_4):
     assert 'LocalSecondaryIndexes' in desc['Table']
     lsis = desc['Table']['LocalSecondaryIndexes']
     assert(sorted([lsi['IndexName'] for lsi in lsis]) == ['hello_x1', 'hello_x2', 'hello_x3', 'hello_x4'])
+    for lsi in lsis:
+        assert lsi['IndexArn'] == desc['Table']['TableArn'] + '/index/' + lsi['IndexName']
     # TODO: check projection and key params
-    # TODO: check also ProvisionedThroughput, IndexArn
+    # TODO: check also ProvisionedThroughput
 
 # A table with selective projection - only keys are projected into the index
 @pytest.fixture(scope="module")


### PR DESCRIPTION
This series includes three small fixes (and of course, tests) for various edge cases of GSI and LSI handling in Alternator:

1. We add the IndexArn that were missing in DescribeTable for indexes (GSI and LSI)
2. We forbid the same name to be used for both GSI and LSI (allowing it was a bug, not a feature)
3. We improve the error handling when trying to tag a GSI or LSI, which is not currently allowed (it's also not allowed in DynamoDB).