### PR TITLE
Update seastar submodule

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1602,6 +1602,7 @@ def configure_seastar(build_dir, mode, mode_config):
         '-DSeastar_UNUSED_RESULT_ERROR=ON',
         '-DCMAKE_EXPORT_COMPILE_COMMANDS=ON',
         '-DSeastar_SCHEDULING_GROUPS_COUNT=16',
+        '-DSeastar_IO_URING=OFF', # Fedora 34's liburing is too old
     ] + distro_extra_cmake_args
 
     if args.stack_guards is not None:


### PR DESCRIPTION
* seastar 1424d34c93...443e6a9b77 (5):
  > reactor: re-raise fatal signals
Ref #9242
  > test: initialize _earliest_started and _latest_finished
  > reactor: add io_uring backend
  > semaphore: add semaphore_unit operator bool
  > Merge 'map reduce: save mapper' from Benny Halevy

io_uring is disabled since the frozen toolchain's liburing it too old.