### PR TITLE
cql3: expr: make evaluate() return a cql3::raw_value rather than an expr::constant

### DIFF
--- a/cql3/attributes.cc
+++ b/cql3/attributes.cc
@@ -42,7 +42,7 @@ int64_t attributes::get_timestamp(int64_t now, const query_options& options) {
         return now;
     }
 
-    expr::constant tval = expr::evaluate(*_timestamp, options);
+    cql3::raw_value tval = expr::evaluate(*_timestamp, options);
     if (tval.is_null()) {
         throw exceptions::invalid_request_exception("Invalid null value of timestamp");
     }
@@ -60,7 +60,7 @@ int32_t attributes::get_time_to_live(const query_options& options) {
     if (!_time_to_live.has_value())
         return 0;
 
-    expr::constant tval = expr::evaluate(*_time_to_live, options);
+    cql3::raw_value tval = expr::evaluate(*_time_to_live, options);
     if (tval.is_null()) {
         throw exceptions::invalid_request_exception("Invalid null value of TTL");
     }
@@ -90,7 +90,7 @@ int32_t attributes::get_time_to_live(const query_options& options) {
 
 
 db::timeout_clock::duration attributes::get_timeout(const query_options& options) const {
-    expr::constant timeout = expr::evaluate(*_timeout, options);
+    cql3::raw_value timeout = expr::evaluate(*_timeout, options);
     if (timeout.is_null() || timeout.is_unset_value()) {
         throw exceptions::invalid_request_exception("Timeout value cannot be unset/null");
     }

--- a/cql3/column_condition.cc
+++ b/cql3/column_condition.cc
@@ -137,7 +137,7 @@ bool column_condition::applies_to(const data_value* cell_value, const query_opti
         assert(cell_value->type()->is_collection());
         const collection_type_impl& cell_type = static_cast<const collection_type_impl&>(*cell_value->type());
 
-        expr::constant key_constant = expr::evaluate(*_collection_element, options);
+        cql3::raw_value key_constant = expr::evaluate(*_collection_element, options);
         cql3::raw_value_view key = key_constant.view();
         if (key.is_unset_value()) {
             throw exceptions::invalid_request_exception(
@@ -194,7 +194,7 @@ bool column_condition::applies_to(const data_value* cell_value, const query_opti
 
     if (is_compare(_op)) {
         // <, >, >=, <=, !=
-        expr::constant param = expr::evaluate(*_value, options);
+        cql3::raw_value param = expr::evaluate(*_value, options);
 
         if (param.is_unset_value()) {
             throw exceptions::invalid_request_exception("Invalid 'unset' value in condition");
@@ -241,11 +241,11 @@ bool column_condition::applies_to(const data_value* cell_value, const query_opti
     std::vector<bytes_opt> in_values;
 
     if (_value.has_value()) {
-        expr::constant lval = expr::evaluate(*_value, options);
+        cql3::raw_value lval = expr::evaluate(*_value, options);
         if (lval.is_null()) {
             throw exceptions::invalid_request_exception("Invalid null value for IN condition");
         }
-        for (const managed_bytes_opt& v : expr::get_elements(lval)) {
+        for (const managed_bytes_opt& v : expr::get_elements(lval, *type_of(*_value))) {
             if (v) {
                 in_values.push_back(to_bytes(*v));
             } else {

--- a/cql3/expr/expression.hh
+++ b/cql3/expr/expression.hh
@@ -673,22 +673,23 @@ data_type type_of(const expression& e);
 
 // Takes a prepared expression and calculates its value.
 // Evaluates bound values, calls functions and returns just the bytes and type.
-constant evaluate(const expression& e, const evaluation_inputs&);
+cql3::raw_value evaluate(const expression& e, const evaluation_inputs&);
 
-constant evaluate(const expression& e, const query_options&);
+cql3::raw_value evaluate(const expression& e, const query_options&);
 
-utils::chunked_vector<managed_bytes> get_list_elements(const constant&);
-utils::chunked_vector<managed_bytes> get_set_elements(const constant&);
-std::vector<managed_bytes_opt> get_tuple_elements(const constant&);
-std::vector<managed_bytes_opt> get_user_type_elements(const constant&);
-std::vector<std::pair<managed_bytes, managed_bytes>> get_map_elements(const constant&);
+utils::chunked_vector<managed_bytes> get_list_elements(const cql3::raw_value&);
+utils::chunked_vector<managed_bytes> get_set_elements(const cql3::raw_value&);
+std::vector<managed_bytes_opt> get_tuple_elements(const cql3::raw_value&, const abstract_type& type);
+std::vector<managed_bytes_opt> get_user_type_elements(const cql3::raw_value&, const abstract_type& type);
+std::vector<std::pair<managed_bytes, managed_bytes>> get_map_elements(const cql3::raw_value&);
 
 // Gets the elements of a constant which can be a list, set, tuple or user type
-std::vector<managed_bytes_opt> get_elements(const constant&);
+std::vector<managed_bytes_opt> get_elements(const cql3::raw_value&, const abstract_type& type);
 
 // Get elements of list<tuple<>> as vector<vector<managed_bytes_opt>
 // It is useful with IN restrictions like (a, b) IN [(1, 2), (3, 4)].
-utils::chunked_vector<std::vector<managed_bytes_opt>> get_list_of_tuples_elements(const constant&);
+// `type` parameter refers to the list<tuple<>> type.
+utils::chunked_vector<std::vector<managed_bytes_opt>> get_list_of_tuples_elements(const cql3::raw_value&, const abstract_type& type);
 
 // Retrieves information needed in prepare_context.
 // Collects the column specification for the bind variables in this expression.

--- a/cql3/expr/prepare_expr.cc
+++ b/cql3/expr/prepare_expr.cc
@@ -152,7 +152,7 @@ usertype_constructor_prepare_expression(const usertype_constructor& u, data_dict
     };
 
     if (all_terminal) {
-        return evaluate(value, query_options::DEFAULT);
+        return constant(evaluate(value, query_options::DEFAULT), value.type);
     } else {
         return value;
     }
@@ -274,7 +274,7 @@ map_prepare_expression(const collection_constructor& c, data_dictionary::databas
         .type = receiver->type
     };
     if (all_terminal) {
-        return evaluate(map_value, query_options::DEFAULT);
+        return constant(evaluate(map_value, query_options::DEFAULT), map_value.type);
     } else {
         return map_value;
     }
@@ -357,7 +357,7 @@ set_prepare_expression(const collection_constructor& c, data_dictionary::databas
                 .elements = {},
                 .type = receiver->type
             };
-            return expr::evaluate(map_value, query_options::DEFAULT);
+            return constant(expr::evaluate(map_value, query_options::DEFAULT), map_value.type);
         }
     }
 
@@ -383,7 +383,7 @@ set_prepare_expression(const collection_constructor& c, data_dictionary::databas
     };
     
     if (all_terminal) {
-        return evaluate(value, query_options::DEFAULT);
+        return constant(evaluate(value, query_options::DEFAULT), value.type);
     } else {
         return value;
     }
@@ -465,7 +465,7 @@ list_prepare_expression(const collection_constructor& c, data_dictionary::databa
         .type = receiver->type
     };
     if (all_terminal) {
-        return evaluate(value, query_options::DEFAULT);
+        return constant(evaluate(value, query_options::DEFAULT), value.type);
     } else {
         return value;
     }
@@ -549,7 +549,7 @@ tuple_constructor_prepare_nontuple(const tuple_constructor& tc, data_dictionary:
         .type = std::move(type),
     };
     if (all_terminal) {
-        return evaluate(value, query_options::DEFAULT);
+        return constant(evaluate(value, query_options::DEFAULT), value.type);
     } else {
         return value;
     }
@@ -830,7 +830,7 @@ prepare_function_call(const expr::function_call& fc, data_dictionary::database d
         .lwt_cache_id = fc.lwt_cache_id
     };
     if (all_terminal && scalar_fun->is_pure()) {
-        return expr::evaluate(fun_call, query_options::DEFAULT);
+        return constant(expr::evaluate(fun_call, query_options::DEFAULT), fun->return_type());
     } else {
         return fun_call;
     }

--- a/cql3/expr/to_restriction.cc
+++ b/cql3/expr/to_restriction.cc
@@ -220,7 +220,7 @@ void validate_multi_column_relation(const std::vector<const column_definition*>&
             const list_type_impl* list_type = dynamic_cast<const list_type_impl*>(&rhs_list->type->without_reversed());
             const data_type& elements_type = list_type->get_elements_type();
 
-            utils::chunked_vector<managed_bytes> raw_elems = get_list_elements(*rhs_list);
+            utils::chunked_vector<managed_bytes> raw_elems = get_list_elements(rhs_list->value);
             std::vector<expression> list_elems;
             list_elems.reserve(raw_elems.size());
 

--- a/cql3/lists.hh
+++ b/cql3/lists.hh
@@ -33,7 +33,7 @@ public:
                 : operation(column, std::move(e)) {
         }
         virtual void execute(mutation& m, const clustering_key_prefix& prefix, const update_parameters& params) override;
-        static void execute(mutation& m, const clustering_key_prefix& prefix, const update_parameters& params, const column_definition& column, const expr::constant& value);
+        static void execute(mutation& m, const clustering_key_prefix& prefix, const update_parameters& params, const column_definition& column, const cql3::raw_value& value);
     };
 
     class setter_by_index : public operation {
@@ -63,7 +63,7 @@ public:
         virtual void execute(mutation& m, const clustering_key_prefix& prefix, const update_parameters& params) override;
     };
 
-    static void do_append(const expr::constant& list_value,
+    static void do_append(const cql3::raw_value& list_value,
             mutation& m,
             const clustering_key_prefix& prefix,
             const column_definition& column,

--- a/cql3/maps.hh
+++ b/cql3/maps.hh
@@ -34,7 +34,7 @@ public:
         }
 
         virtual void execute(mutation& m, const clustering_key_prefix& row_key, const update_parameters& params) override;
-        static void execute(mutation& m, const clustering_key_prefix& row_key, const update_parameters& params, const column_definition& column, const expr::constant& value);
+        static void execute(mutation& m, const clustering_key_prefix& row_key, const update_parameters& params, const column_definition& column, const cql3::raw_value& value);
     };
 
     class setter_by_key : public operation {
@@ -56,7 +56,7 @@ public:
     };
 
     static void do_put(mutation& m, const clustering_key_prefix& prefix, const update_parameters& params,
-            const expr::constant& value, const column_definition& column);
+            const cql3::raw_value& value, const column_definition& column);
 
     class discarder_by_key : public operation {
     public:

--- a/cql3/operation.cc
+++ b/cql3/operation.cc
@@ -275,12 +275,8 @@ operation::set_counter_value_from_tuple_list::prepare(data_dictionary::database 
             return true;
         }
         void execute(mutation& m, const clustering_key_prefix& prefix, const update_parameters& params) override {
-            expr::constant list_value = expr::evaluate(*_e, params._options);
+            cql3::raw_value list_value = expr::evaluate(*_e, params._options);
             if (list_value.is_null()) {
-                throw std::invalid_argument("Invalid input data to counter set");
-            }
-
-            if (!list_value.type->is_list()) {
                 throw std::invalid_argument("Invalid input data to counter set");
             }
 

--- a/cql3/restrictions/multi_column_restriction.hh
+++ b/cql3/restrictions/multi_column_restriction.hh
@@ -198,8 +198,8 @@ public:
 #endif
 
     clustering_key_prefix composite_value(const query_options& options) const {
-        expr::constant t = expr::evaluate(_value, options);
-        auto values = expr::get_tuple_elements(t);
+        cql3::raw_value t = expr::evaluate(_value, options);
+        auto values = expr::get_tuple_elements(t, *type_of(_value));
         std::vector<managed_bytes> components;
         for (unsigned i = 0; i < values.size(); i++) {
             auto component = statements::request_validations::check_not_null(values[i],

--- a/cql3/restrictions/statement_restrictions.cc
+++ b/cql3/restrictions/statement_restrictions.cc
@@ -1004,7 +1004,7 @@ struct multi_column_range_accumulator {
 
     void operator()(const binary_operator& binop) {
         if (is_compare(binop.op)) {
-            auto opt_values = expr::get_tuple_elements(expr::evaluate(binop.rhs, options));
+            auto opt_values = expr::get_tuple_elements(expr::evaluate(binop.rhs, options), *type_of(binop.rhs));
             auto& lhs = expr::as<tuple_constructor>(binop.lhs);
             std::vector<managed_bytes> values(lhs.elements.size());
             for (size_t i = 0; i < lhs.elements.size(); ++i) {
@@ -1015,9 +1015,9 @@ struct multi_column_range_accumulator {
             }
             intersect_all(to_range(binop.op, clustering_key_prefix(std::move(values))));
         } else if (binop.op == oper_t::IN) {
-            const expr::constant tup = expr::evaluate(binop.rhs, options);
+            const cql3::raw_value tup = expr::evaluate(binop.rhs, options);
             statements::request_validations::check_false(tup.is_null(), "Invalid null value for IN restriction");
-            process_in_values(expr::get_list_of_tuples_elements(tup));
+            process_in_values(expr::get_list_of_tuples_elements(tup, *type_of(binop.rhs)));
         } else {
             on_internal_error(rlogger, format("multi_column_range_accumulator: unexpected atom {}", binop));
         }
@@ -1433,13 +1433,13 @@ query::clustering_range range_from_raw_bounds(
     opt_bound lb, ub;
     for (const auto& e : exprs) {
         if (auto b = find_clustering_order(e)) {
-            expr::constant tup_val = expr::evaluate(b->rhs, options);
+            cql3::raw_value tup_val = expr::evaluate(b->rhs, options);
             if (tup_val.is_null()) {
                 on_internal_error(rlogger, format("range_from_raw_bounds: unexpected atom {}", *b));
             }
 
             const auto r = to_range(
-                    b->op, clustering_key_prefix::from_optional_exploded(schema, expr::get_tuple_elements(tup_val)));
+                    b->op, clustering_key_prefix::from_optional_exploded(schema, expr::get_tuple_elements(tup_val, *type_of(b->rhs))));
             if (r.start()) {
                 lb = r.start();
             }

--- a/cql3/sets.cc
+++ b/cql3/sets.cc
@@ -15,12 +15,12 @@
 namespace cql3 {
 void
 sets::setter::execute(mutation& m, const clustering_key_prefix& row_key, const update_parameters& params) {
-    expr::constant value = expr::evaluate(*_e, params._options);
+    cql3::raw_value value = expr::evaluate(*_e, params._options);
     execute(m, row_key, params, column, std::move(value));
 }
 
 void
-sets::setter::execute(mutation& m, const clustering_key_prefix& row_key, const update_parameters& params, const column_definition& column, const expr::constant& value) {
+sets::setter::execute(mutation& m, const clustering_key_prefix& row_key, const update_parameters& params, const column_definition& column, const cql3::raw_value& value) {
     if (value.is_unset_value()) {
         return;
     }
@@ -35,7 +35,7 @@ sets::setter::execute(mutation& m, const clustering_key_prefix& row_key, const u
 
 void
 sets::adder::execute(mutation& m, const clustering_key_prefix& row_key, const update_parameters& params) {
-    const expr::constant value = expr::evaluate(*_e, params._options);
+    const cql3::raw_value value = expr::evaluate(*_e, params._options);
     if (value.is_unset_value()) {
         return;
     }
@@ -45,7 +45,7 @@ sets::adder::execute(mutation& m, const clustering_key_prefix& row_key, const up
 
 void
 sets::adder::do_add(mutation& m, const clustering_key_prefix& row_key, const update_parameters& params,
-        const expr::constant& value, const column_definition& column) {
+        const cql3::raw_value& value, const column_definition& column) {
     auto& set_type = dynamic_cast<const set_type_impl&>(column.type->without_reversed());
     if (column.type->is_multi_cell()) {
         if (value.is_null()) {
@@ -78,13 +78,12 @@ void
 sets::discarder::execute(mutation& m, const clustering_key_prefix& row_key, const update_parameters& params) {
     assert(column.type->is_multi_cell()); // "Attempted to remove items from a frozen set";
 
-    expr::constant svalue = expr::evaluate(*_e, params._options);
+    cql3::raw_value svalue = expr::evaluate(*_e, params._options);
     if (svalue.is_null_or_unset()) {
         return;
     }
 
     collection_mutation_description mut;
-    assert(svalue.type->is_set());
     utils::chunked_vector<managed_bytes> set_elements = expr::get_set_elements(svalue);
     mut.cells.reserve(set_elements.size());
     for (auto&& e : set_elements) {
@@ -96,12 +95,12 @@ sets::discarder::execute(mutation& m, const clustering_key_prefix& row_key, cons
 void sets::element_discarder::execute(mutation& m, const clustering_key_prefix& row_key, const update_parameters& params)
 {
     assert(column.type->is_multi_cell() && "Attempted to remove items from a frozen set");
-    expr::constant elt = expr::evaluate(*_e, params._options);
+    cql3::raw_value elt = expr::evaluate(*_e, params._options);
     if (elt.is_null()) {
         throw exceptions::invalid_request_exception("Invalid null set element");
     }
     collection_mutation_description mut;
-    mut.cells.emplace_back(std::move(elt.value).to_bytes(), params.make_dead_cell());
+    mut.cells.emplace_back(std::move(elt).to_bytes(), params.make_dead_cell());
     m.set_cell(row_key, column, mut.serialize(*column.type));
 }
 

--- a/cql3/sets.hh
+++ b/cql3/sets.hh
@@ -33,7 +33,7 @@ public:
                 : operation(column, std::move(e)) {
         }
         virtual void execute(mutation& m, const clustering_key_prefix& row_key, const update_parameters& params) override;
-        static void execute(mutation& m, const clustering_key_prefix& row_key, const update_parameters& params, const column_definition& column, const expr::constant& value);
+        static void execute(mutation& m, const clustering_key_prefix& row_key, const update_parameters& params, const column_definition& column, const cql3::raw_value& value);
     };
 
     class adder : public operation {
@@ -43,7 +43,7 @@ public:
         }
         virtual void execute(mutation& m, const clustering_key_prefix& row_key, const update_parameters& params) override;
         static void do_add(mutation& m, const clustering_key_prefix& row_key, const update_parameters& params,
-                const expr::constant& value, const column_definition& column);
+                const cql3::raw_value& value, const column_definition& column);
     };
 
     // Note that this is reused for Map subtraction too (we subtract a set from a map)

--- a/cql3/statements/create_aggregate_statement.cc
+++ b/cql3/statements/create_aggregate_statement.cc
@@ -55,7 +55,7 @@ shared_ptr<functions::function> create_aggregate_statement::create(query_process
         auto dummy_ident = ::make_shared<column_identifier>("", true);
         auto column_spec = make_lw_shared<column_specification>("", "", dummy_ident, state_type);
         auto initcond_term = expr::evaluate(prepare_expression(_ival.value(), db, _name.keyspace, nullptr, {column_spec}), query_options::DEFAULT);
-        initcond = std::move(initcond_term.value).to_bytes();
+        initcond = std::move(initcond_term).to_bytes();
     }
 
     return ::make_shared<functions::user_aggregate>(_name, initcond, std::move(state_func), std::move(final_func));

--- a/cql3/statements/update_statement.cc
+++ b/cql3/statements/update_statement.cc
@@ -149,7 +149,7 @@ void update_statement::add_update_for_key(mutation& m, const query::clustering_r
 }
 
 modification_statement::json_cache_opt insert_prepared_json_statement::maybe_prepare_json_cache(const query_options& options) const {
-    expr::constant c = expr::evaluate(_value, options);
+    cql3::raw_value c = expr::evaluate(_value, options);
     sstring json_string = utf8_type->to_string(to_bytes(c.view()));
     return json_helpers::parse(std::move(json_string), s->all_columns(), cql_serialization_format::internal());
 }
@@ -161,16 +161,16 @@ insert_prepared_json_statement::execute_set_value(mutation& m, const clustering_
     if (!value) {
         visit(*column.type, make_visitor(
         [&] (const list_type_impl&) {
-            lists::setter::execute(m, prefix, params, column, expr::constant::make_null());
+            lists::setter::execute(m, prefix, params, column, cql3::raw_value::make_null());
         },
         [&] (const set_type_impl&) {
-            sets::setter::execute(m, prefix, params, column, expr::constant::make_null());
+            sets::setter::execute(m, prefix, params, column, cql3::raw_value::make_null());
         },
         [&] (const map_type_impl&) {
-            maps::setter::execute(m, prefix, params, column, expr::constant::make_null());
+            maps::setter::execute(m, prefix, params, column, cql3::raw_value::make_null());
         },
         [&] (const user_type_impl&) {
-            user_types::setter::execute(m, prefix, params, column, expr::constant::make_null());
+            user_types::setter::execute(m, prefix, params, column, cql3::raw_value::make_null());
         },
         [&] (const abstract_type& type) {
             if (type.is_collection()) {
@@ -183,7 +183,7 @@ insert_prepared_json_statement::execute_set_value(mutation& m, const clustering_
     }
 
 
-    expr::constant val(raw_value::make_value(*value), column.type);
+    auto val = raw_value::make_value(*value);
     visit(*column.type, make_visitor(
     [&] (const list_type_impl& ltype) {
         lists::setter::execute(m, prefix, params, column, val);

--- a/cql3/user_types.cc
+++ b/cql3/user_types.cc
@@ -20,11 +20,11 @@
 
 namespace cql3 {
 void user_types::setter::execute(mutation& m, const clustering_key_prefix& row_key, const update_parameters& params) {
-    const expr::constant value = expr::evaluate(*_e, params._options);
+    const cql3::raw_value value = expr::evaluate(*_e, params._options);
     execute(m, row_key, params, column, value);
 }
 
-void user_types::setter::execute(mutation& m, const clustering_key_prefix& row_key, const update_parameters& params, const column_definition& column, const expr::constant& ut_value) {
+void user_types::setter::execute(mutation& m, const clustering_key_prefix& row_key, const update_parameters& params, const column_definition& column, const cql3::raw_value& ut_value) {
     if (ut_value.is_unset_value()) {
         return;
     }
@@ -49,7 +49,7 @@ void user_types::setter::execute(mutation& m, const clustering_key_prefix& row_k
         mut.tomb = params.make_tombstone_just_before();
 
         if (!ut_value.is_null()) {
-            const auto& elems = expr::get_user_type_elements(ut_value);
+            const auto& elems = expr::get_user_type_elements(ut_value, type);
             // There might be fewer elements given than fields in the type
             // (e.g. when the user uses a short tuple literal), but never more.
             assert(elems.size() <= type.size());

--- a/cql3/user_types.hh
+++ b/cql3/user_types.hh
@@ -31,7 +31,7 @@ public:
         using operation::operation;
 
         virtual void execute(mutation& m, const clustering_key_prefix& row_key, const update_parameters& params) override;
-        static void execute(mutation& m, const clustering_key_prefix& prefix, const update_parameters& params, const column_definition& column, const expr::constant& value);
+        static void execute(mutation& m, const clustering_key_prefix& prefix, const update_parameters& params, const column_definition& column, const cql3::raw_value& value);
     };
 
     class setter_by_field : public operation {

--- a/cql3/values.hh
+++ b/cql3/values.hh
@@ -228,6 +228,9 @@ public:
     bool is_unset_value() const {
         return std::holds_alternative<unset_value>(_data);
     }
+    bool is_null_or_unset() const {
+        return !is_value();
+    }
     bool is_value() const {
         return _data.index() <= 1;
     }
@@ -265,6 +268,9 @@ public:
         }, std::move(_data));
     }
     raw_value_view to_view() const;
+    raw_value_view view() const {
+        return to_view();
+    }
     friend class raw_value_view;
 };
 

--- a/test/boost/expr_test.cc
+++ b/test/boost/expr_test.cc
@@ -104,6 +104,10 @@ static sstring expr_print(const expression& e) {
     return format("{}", p);
 }
 
+static sstring value_print(const cql3::raw_value& v, const expression& e) {
+    return expr_print(constant(v, type_of(e)));
+}
+
 static constant make_int(int value) {
     return constant(raw_value::make_value(int32_type->decompose(value)), int32_type);
 }
@@ -194,11 +198,11 @@ BOOST_AUTO_TEST_CASE(expr_printer_list_test) {
     };
     BOOST_REQUIRE_EQUAL(expr_print(frozen_int_list), "[13, 45, 90]");
 
-    constant int_list_constant = evaluate(int_list, query_options::DEFAULT);
-    BOOST_REQUIRE_EQUAL(expr_print(int_list_constant), "[13, 45, 90]");
+    cql3::raw_value int_list_constant = evaluate(int_list, query_options::DEFAULT);
+    BOOST_REQUIRE_EQUAL(value_print(int_list_constant, int_list), "[13, 45, 90]");
 
-    constant frozen_int_list_constant = evaluate(frozen_int_list, query_options::DEFAULT);
-    BOOST_REQUIRE_EQUAL(expr_print(frozen_int_list_constant), "[13, 45, 90]");
+    cql3::raw_value frozen_int_list_constant = evaluate(frozen_int_list, query_options::DEFAULT);
+    BOOST_REQUIRE_EQUAL(value_print(frozen_int_list_constant, frozen_int_list), "[13, 45, 90]");
 }
 
 BOOST_AUTO_TEST_CASE(expr_printer_set_test) {
@@ -216,11 +220,11 @@ BOOST_AUTO_TEST_CASE(expr_printer_set_test) {
     };
     BOOST_REQUIRE_EQUAL(expr_print(frozen_int_set), "{13, 45, 90}");
 
-    constant int_set_constant = evaluate(int_set, query_options::DEFAULT);
-    BOOST_REQUIRE_EQUAL(expr_print(int_set_constant), "{13, 45, 90}");
+    cql3::raw_value int_set_constant = evaluate(int_set, query_options::DEFAULT);
+    BOOST_REQUIRE_EQUAL(value_print(int_set_constant, int_set), "{13, 45, 90}");
 
-    constant frozen_int_set_constant = evaluate(frozen_int_set, query_options::DEFAULT);
-    BOOST_REQUIRE_EQUAL(expr_print(frozen_int_set_constant), "{13, 45, 90}");
+    cql3::raw_value frozen_int_set_constant = evaluate(frozen_int_set, query_options::DEFAULT);
+    BOOST_REQUIRE_EQUAL(value_print(frozen_int_set_constant, frozen_int_set), "{13, 45, 90}");
 }
 
 BOOST_AUTO_TEST_CASE(expr_printer_map_test) {
@@ -245,11 +249,11 @@ BOOST_AUTO_TEST_CASE(expr_printer_map_test) {
     };
     BOOST_REQUIRE_EQUAL(expr_print(frozen_int_int_map), "{12:34, 56:78}");
 
-    constant int_int_map_const = evaluate(int_int_map, query_options::DEFAULT);
-    BOOST_REQUIRE_EQUAL(expr_print(int_int_map_const), "{12:34, 56:78}");
+    cql3::raw_value int_int_map_const = evaluate(int_int_map, query_options::DEFAULT);
+    BOOST_REQUIRE_EQUAL(value_print(int_int_map_const, int_int_map), "{12:34, 56:78}");
 
-    constant frozen_int_int_map_const = evaluate(frozen_int_int_map, query_options::DEFAULT);
-    BOOST_REQUIRE_EQUAL(expr_print(frozen_int_int_map_const), "{12:34, 56:78}");
+    cql3::raw_value frozen_int_int_map_const = evaluate(frozen_int_int_map, query_options::DEFAULT);
+    BOOST_REQUIRE_EQUAL(value_print(frozen_int_int_map_const, frozen_int_int_map), "{12:34, 56:78}");
 }
 
 BOOST_AUTO_TEST_CASE(expr_printer_tuple_test) {
@@ -259,8 +263,8 @@ BOOST_AUTO_TEST_CASE(expr_printer_tuple_test) {
     };
     BOOST_REQUIRE_EQUAL(expr_print(int_int_tuple), "(456, 789)");
 
-    constant int_int_tuple_const = evaluate(int_int_tuple, query_options::DEFAULT);
-    BOOST_REQUIRE_EQUAL(expr_print(int_int_tuple_const), "(456, 789)");
+    cql3::raw_value int_int_tuple_const = evaluate(int_int_tuple, query_options::DEFAULT);
+    BOOST_REQUIRE_EQUAL(value_print(int_int_tuple_const, int_int_tuple), "(456, 789)");
 }
 
 BOOST_AUTO_TEST_CASE(expr_printer_usertype_test) {
@@ -275,8 +279,8 @@ BOOST_AUTO_TEST_CASE(expr_printer_usertype_test) {
     };
     BOOST_REQUIRE_EQUAL(expr_print(user_typ), "{b:666, a:333}");
 
-    constant user_typ_const = evaluate(user_typ, query_options::DEFAULT);
-    BOOST_REQUIRE_EQUAL(expr_print(user_typ_const), "{a:333, b:666}");
+    cql3::raw_value user_typ_const = evaluate(user_typ, query_options::DEFAULT);
+    BOOST_REQUIRE_EQUAL(value_print(user_typ_const, user_typ), "{a:333, b:666}");
 }
 
 // When a list is printed as RHS of an IN binary_operator it should be printed as a tuple.
@@ -294,12 +298,12 @@ BOOST_AUTO_TEST_CASE(expr_printer_in_test) {
     };
     BOOST_REQUIRE_EQUAL(expr_print(a_in_int_list), "a IN (13, 45, 90)");
 
-    constant int_list_const = evaluate(int_list, query_options::DEFAULT);
+    cql3::raw_value int_list_const = evaluate(int_list, query_options::DEFAULT);
 
     binary_operator a_in_int_list_const {
         make_column("a"),
         oper_t::IN,
-        int_list_const
+        constant(int_list_const, type_of(int_list))
     };
     BOOST_REQUIRE_EQUAL(expr_print(a_in_int_list_const), "a IN (13, 45, 90)");
 }


### PR DESCRIPTION
An expr::constant is an expression that happens to represent a constant,
so it's too heavyweight to be used for evaluation. Right now the extra
weight is just a type (which causes extra work by having to maintain
the shared_ptr reference count), but it will grow in the future to include
source location (for error reporting) and maybe other things.

Prior to e9b6171b5 ("Merge 'cql3: expr: unify left-hand-side and
right-hand-side of binary_operator prepares' from Avi Kivity"), we had
to use expr::constant since there was not enough type infomation in
expressions. But now every expression carries its type (in programming
language terms, expressions are now statically typed), so carrying types
in values is not needed.

So change evaluate() to return cql3::raw_value. The majority of the
patch just changes that. The rest deals with some fallout:

 - cql3::raw_value gains a view() helper to convert to a raw_value_view,
   and is_null_or_unset() to match with expr::constant and reduce further
   churn.
 - some helpers that worked on expr::constant and now receive a
   raw_value now need the type passed via an additional argument. The
   type is computed from the expression by the caller.
 - many type checks during expression evaluation were dropped. This is
   a consequence of static typing - we must trust the expression prepare
   phase to perform full type checking since values no longer carry type
   information.