### PR TITLE
Batchlog replay for decommission fix and cleanup

### DIFF
--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -2727,7 +2727,10 @@ future<std::unordered_multimap<dht::token_range, inet_address>> storage_service:
 }
 
 future<> storage_service::unbootstrap() {
+    slogger.info("Started batchlog replay for decommission");
     co_await get_batchlog_manager().local().do_batch_log_replay();
+    slogger.info("Finished batchlog replay for decommission");
+
     if (is_repair_based_node_ops_enabled(streaming::stream_reason::decommission)) {
         co_await _repair.local().decommission_with_repair(get_token_metadata_ptr());
     } else {

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -2753,8 +2753,6 @@ future<> storage_service::unbootstrap() {
 
         auto stream_success = stream_ranges(ranges_to_stream);
 
-        slogger.info("streaming hints to other nodes");
-
         // wait for the transfer runnables to signal the latch.
         slogger.debug("waiting for stream acks.");
         try {

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -2752,10 +2752,6 @@ future<> storage_service::unbootstrap() {
         set_mode(mode::LEAVING);
 
         auto stream_success = stream_ranges(ranges_to_stream);
-        // Wait for batch log to complete before streaming hints.
-        slogger.debug("waiting for batch log processing.");
-        // Start with BatchLog replay, which may create hints but no writes since this is no longer a valid endpoint.
-        co_await get_batchlog_manager().local().do_batch_log_replay();
 
         slogger.info("streaming hints to other nodes");
 


### PR DESCRIPTION
This patch set 
- adds log before and after batch log replay
- removes a duplicated call to trigger batch log replay
- removes obsoletes log 