### PR TITLE
test: memtable: Make failed_flush_prevents_writes() immune to background merging

### DIFF
--- a/test/boost/memtable_test.cc
+++ b/test/boost/memtable_test.cc
@@ -793,10 +793,11 @@ SEASTAR_TEST_CASE(failed_flush_prevents_writes) {
 
         utils::get_local_injector().enable("table_seal_active_memtable_pre_flush");
 
-        // Trigger flush
-        dmm.notify_soft_pressure();
-
-        BOOST_ASSERT(eventually_true([&db]() { return db.cf_stats()->failed_memtables_flushes_count != 0; }));
+        BOOST_ASSERT(eventually_true([&] {
+            // Trigger flush
+            dmm.notify_soft_pressure();
+            return db.cf_stats()->failed_memtables_flushes_count != 0;
+        }));
 
         // The flush failed, make sure there is still data in memtable.
         BOOST_ASSERT(t.min_memtable_timestamp() < api::max_timestamp);


### PR DESCRIPTION
Before the change, the test artificiallu set the soft pressure
condition hoping that the background flusher will flush the
memtable. It won't happen if by the time the background flusher runs
the LSA region is updated and soft pressure (which is not really
there) is lifted. Once apply() becomes preemptibe, backgroun partition
version merging can lift the soft pressure, making the memtable flush
not occur and making the test fail.

Fix by triggering soft pressure on retries.

Fixes #10801
Refs #10793

(cherry picked from commit 0e78ad50ea52f3aecb6380527da4152eeab0881e)