### PR TITLE
cql3: raw_value: deduplicate view() and to_view()

### DIFF
--- a/cql3/expr/expression.cc
+++ b/cql3/expr/expression.cc
@@ -1061,7 +1061,7 @@ std::ostream& operator<<(std::ostream& os, const expression::printer& pr) {
                     } else if (v.value.is_unset_value()) {
                         os << "unset";
                     } else {
-                        v.value.to_view().with_value([&](const FragmentedView auto& bytes_view) {
+                        v.value.view().with_value([&](const FragmentedView auto& bytes_view) {
                             data_value deser_val = v.type->deserialize(bytes_view);
                             os << deser_val.to_parsable_string();
                         });
@@ -1595,7 +1595,7 @@ bool constant::has_empty_value_bytes() const {
         return false;
     }
 
-    return value.to_view().size_bytes() == 0;
+    return value.view().size_bytes() == 0;
 }
 
 bool constant::is_null_or_unset() const {
@@ -1603,7 +1603,7 @@ bool constant::is_null_or_unset() const {
 }
 
 cql3::raw_value_view constant::view() const {
-    return value.to_view();
+    return value.view();
 }
 
 std::optional<bool> get_bool_value(const constant& constant_val) {

--- a/cql3/query_options.cc
+++ b/cql3/query_options.cc
@@ -148,7 +148,7 @@ void query_options::prepare(const std::vector<lw_shared_ptr<column_specification
 void query_options::fill_value_views()
 {
     for (auto&& value : _values) {
-        _value_views.emplace_back(value.to_view());
+        _value_views.emplace_back(value.view());
     }
 }
 

--- a/cql3/values.cc
+++ b/cql3/values.cc
@@ -25,7 +25,7 @@ std::ostream& operator<<(std::ostream& os, const raw_value_view& value) {
     return os;
 }
 
-raw_value_view raw_value::to_view() const {
+raw_value_view raw_value::view() const {
     switch (_data.index()) {
     case 0:  return raw_value_view::make_value(managed_bytes_view(bytes_view(std::get<bytes>(_data))));
     case 1:  return raw_value_view::make_value(managed_bytes_view(std::get<managed_bytes>(_data)));

--- a/cql3/values.hh
+++ b/cql3/values.hh
@@ -267,10 +267,7 @@ public:
             }
         }, std::move(_data));
     }
-    raw_value_view to_view() const;
-    raw_value_view view() const {
-        return to_view();
-    }
+    raw_value_view view() const;
     friend class raw_value_view;
 };
 
@@ -291,5 +288,5 @@ inline bytes_opt to_bytes_opt(const cql3::raw_value_view& view) {
 }
 
 inline bytes_opt to_bytes_opt(const cql3::raw_value& value) {
-    return to_bytes_opt(value.to_view());
+    return to_bytes_opt(value.view());
 }

--- a/service/raft/raft_sys_table_storage.cc
+++ b/service/raft/raft_sys_table_storage.cc
@@ -234,7 +234,7 @@ future<> raft_sys_table_storage::do_store_log_entries(const std::vector<raft::lo
         std::vector<cql3::raw_value_view> value_views;
         value_views.reserve(4); // 4 is the number of required values for the insertion query 
         for (const cql3::raw_value& raw : stmt_values.back()) {
-            value_views.push_back(raw.to_view());
+            value_views.push_back(raw.view());
         }
         value_views.emplace_back(
             cql3::raw_value_view::make_value(

--- a/test/boost/cql_query_test.cc
+++ b/test/boost/cql_query_test.cc
@@ -5072,7 +5072,7 @@ cql3::raw_value make_collection_raw_value(size_t size_to_write, const std::vecto
     for (const cql3::raw_value& val : elements_to_write) {
         serialized_len += collection_value_len(sf);
         if (val.is_value()) {
-            serialized_len += val.to_view().with_value([](const FragmentedView auto& view) {
+            serialized_len += val.view().with_value([](const FragmentedView auto& view) {
                 return view.size_bytes();
             });
         }
@@ -5088,7 +5088,7 @@ cql3::raw_value make_collection_raw_value(size_t size_to_write, const std::vecto
         } else if (val.is_unset_value()) {
                 write_int32(out, -2);
         } else {
-            val.to_view().with_value([&](const FragmentedView auto& val_view) {
+            val.view().with_value([&](const FragmentedView auto& val_view) {
                 write_collection_value(out, sf, linearized(val_view));
             });
         }


### PR DESCRIPTION
Commit e739f2b779 ("cql3: expr: make evaluate() return a
cql3::raw_value rather than an expr::constant") introduced
raw_value::view() as a synonym to raw_value::to_view() to reduce
churn. To fix this duplication, we now remove raw_value::to_view().

raw_value::to_view() was picked for removal because is has fewer
call sites, reducing churn again.