### PR TITLE
cql3: grammar: move semantic check for incompatible UPDATEs to prepar…

### DIFF
--- a/cql3/Cql.g
+++ b/cql3/Cql.g
@@ -235,17 +235,6 @@ struct uninitialized {
         return to_lower(s) == "true";
     }
 
-    void add_raw_update(std::vector<std::pair<::shared_ptr<cql3::column_identifier::raw>, std::unique_ptr<cql3::operation::raw_update>>>& operations,
-        ::shared_ptr<cql3::column_identifier::raw> key, std::unique_ptr<cql3::operation::raw_update> update)
-    {
-        for (auto&& p : operations) {
-            if (*p.first == *key && !p.second->is_compatible_with(update)) {
-                add_recognition_error(format("Multiple incompatible setting of column {}", *key));
-            }
-        }
-        operations.emplace_back(std::move(key), std::move(update));
-    }
-
     TokenType* getMissingSymbol(IntStreamType* istream, ExceptionBaseType* e,
                                 ANTLR_UINT32 expectedTokenType, BitsetListType* follow) {
         auto token = BaseType::getMissingSymbol(istream, e, expectedTokenType, follow);
@@ -1539,12 +1528,12 @@ normalColumnOperation[operations_type& operations, ::shared_ptr<cql3::column_ide
     : t=term ('+' c=cident )?
       {
           if (!c) {
-              add_raw_update(operations, key, std::make_unique<cql3::operation::set_value>(t));
+              operations.emplace_back(std::move(key), std::make_unique<cql3::operation::set_value>(t));
           } else {
               if (*key != *c) {
                 add_recognition_error("Only expressions of the form X = <value> + X are supported.");
               }
-              add_raw_update(operations, key, std::make_unique<cql3::operation::prepend>(t));
+              operations.emplace_back(std::move(key), std::make_unique<cql3::operation::prepend>(t));
           }
       }
     | c=cident sig=('+' | '-') t=term
@@ -1558,7 +1547,7 @@ normalColumnOperation[operations_type& operations, ::shared_ptr<cql3::column_ide
           } else {
               op = std::make_unique<cql3::operation::subtraction>(t);
           }
-          add_raw_update(operations, key, std::move(op));
+          operations.emplace_back(std::move(key), std::move(op));
       }
     | c=cident i=INTEGER
       {
@@ -1567,11 +1556,11 @@ normalColumnOperation[operations_type& operations, ::shared_ptr<cql3::column_ide
               // We don't yet allow a '+' in front of an integer, but we could in the future really, so let's be future-proof in our error message
               add_recognition_error("Only expressions of the form X = X " + sstring($i.text[0] == '-' ? "-" : "+") + " <value> are supported.");
           }
-          add_raw_update(operations, key, std::make_unique<cql3::operation::addition>(untyped_constant{untyped_constant::integer, $i.text}));
+          operations.emplace_back(std::move(key), std::make_unique<cql3::operation::addition>(untyped_constant{untyped_constant::integer, $i.text}));
       }
     | K_SCYLLA_COUNTER_SHARD_LIST '(' t=term ')'
       {
-          add_raw_update(operations, key, std::make_unique<cql3::operation::set_counter_value_from_tuple_list>(t));
+          operations.emplace_back(std::move(key), std::make_unique<cql3::operation::set_counter_value_from_tuple_list>(t));
       }
     ;
 
@@ -1581,7 +1570,7 @@ collectionColumnOperation[operations_type& operations,
                           bool by_uuid]
     : '=' t=term
       {
-          add_raw_update(operations, key, std::make_unique<cql3::operation::set_element>(std::move(k), std::move(t), by_uuid));
+          operations.emplace_back(std::move(key), std::make_unique<cql3::operation::set_element>(std::move(k), std::move(t), by_uuid));
       }
     ;
 
@@ -1590,7 +1579,7 @@ udtColumnOperation[operations_type& operations,
                    shared_ptr<cql3::column_identifier> field]
     : '=' t=term
       {
-          add_raw_update(operations, std::move(key), std::make_unique<cql3::operation::set_field>(std::move(field), std::move(t)));
+          operations.emplace_back(std::move(key), std::make_unique<cql3::operation::set_field>(std::move(field), std::move(t)));
       }
     ;
 


### PR DESCRIPTION
The grammar now checks that UPDATEs don't clash (for example,
updates to the same column). The checks are good, but the grammar
isn't the right place for them - better to concentrate all the checks
in the prepare() code so it's easy to see all the checks.

Move the checks to raw::update_statement::prepare_internal(). This
exposes that the checks are quadratic, so add a comment. It could be
fixed with a stable_sort() first, but that is left to later.