### PR TITLE
types: time_point_to_string: harden against out of range timestamps

### DIFF
--- a/test/boost/types_test.cc
+++ b/test/boost/types_test.cc
@@ -278,6 +278,26 @@ void test_timestamp_like_string_conversions(data_type timestamp_type) {
 
     BOOST_REQUIRE_EQUAL(timestamp_type->to_string(timestamp_type->decompose(tp)), "2015-07-03T00:00:00");
 
+    // test fractional milliseconds
+    tp = db_clock::time_point(db_clock::duration(1435881600123));
+    BOOST_REQUIRE_EQUAL(timestamp_type->to_string(timestamp_type->decompose(tp)), "2015-07-03T00:00:00.123000");
+
+    // test time_stamps around the unix epoch time
+    tp = db_clock::time_point(db_clock::duration(0));
+    BOOST_REQUIRE_EQUAL(timestamp_type->to_string(timestamp_type->decompose(tp)), "1970-01-01T00:00:00");
+    tp = db_clock::time_point(db_clock::duration(456));
+    BOOST_REQUIRE_EQUAL(timestamp_type->to_string(timestamp_type->decompose(tp)), "1970-01-01T00:00:00.456000");
+    tp = db_clock::time_point(db_clock::duration(-456));
+    BOOST_REQUIRE_EQUAL(timestamp_type->to_string(timestamp_type->decompose(tp)), "1969-12-31T23:59:59.544000");
+
+    // test time_stamps around year 0
+    tp = db_clock::time_point(db_clock::duration(-62167219200000));
+    BOOST_REQUIRE_EQUAL(timestamp_type->to_string(timestamp_type->decompose(tp)), "0-01-01T00:00:00");
+    tp = db_clock::time_point(db_clock::duration(-62167219199211));
+    BOOST_REQUIRE_EQUAL(timestamp_type->to_string(timestamp_type->decompose(tp)), "0-01-01T00:00:00.789000");
+    tp = db_clock::time_point(db_clock::duration(-62167219200789));
+    BOOST_REQUIRE_EQUAL(timestamp_type->to_string(timestamp_type->decompose(tp)), "-1-12-31T23:59:59.211000");
+
     auto now = time(nullptr);
     ::tm local_now;
     ::localtime_r(&now, &local_now);

--- a/types.cc
+++ b/types.cc
@@ -27,6 +27,9 @@
 #include <string>
 #include <regex>
 #include <concepts>
+#include <ctime>
+#include <cstdlib>
+#include <fmt/chrono.h>
 #include <boost/iterator/transform_iterator.hpp>
 #include <boost/range/adaptor/filtered.hpp>
 #include <boost/range/numeric.hpp>
@@ -67,14 +70,26 @@ requires requires {
 sstring
 time_point_to_string(const T& tp)
 {
-    int64_t count = tp.time_since_epoch().count();
-    auto time = boost::posix_time::from_time_t(0) + boost::posix_time::milliseconds(count);
-    constexpr std::string_view units = "milliseconds";
-  try {
-    return boost::posix_time::to_iso_extended_string(time);
-  } catch (const std::exception& e) {
-    return format("{} {} ({})", count, units, e.what());
-  }
+    auto count = tp.time_since_epoch().count();
+    auto d = std::div(int64_t(count), int64_t(1000));
+    std::time_t seconds = d.quot;
+    std::tm tm;
+    if (!gmtime_r(&seconds, &tm)) {
+        return fmt::format("{} milliseconds (out of range)", count);
+    }
+    auto millis = d.rem;
+    if (!millis) {
+        return fmt::format("{:%Y-%m-%dT%H:%M:%S}", tm);
+    }
+    // adjust seconds for time points earlier than posix epoch
+    // to keep the fractional millis positive
+    if (millis < 0) {
+        millis += 1000;
+        seconds--;
+        gmtime_r(&seconds, &tm);
+    }
+    auto micros = millis * 1000;
+    return fmt::format("{:%Y-%m-%dT%H:%M:%S}.{:06d}", tm, micros);
 }
 
 sstring simple_date_to_string(const uint32_t days_count) {


### PR DESCRIPTION
The time point is multiplied by an adjustment factor of 1000
for boost::posix_time::time_duration::ticks_per_second() = 1000000
when calling boost::posix_time::milliseconds(count)
and that may lead to integer overflow as reported
by the UndefinedBehaviorSanitizer.

See https://github.com/scylladb/scylla/issues/10830#issuecomment-1158899187

This change checks for possible overflow in advance and
prints the raw counter value in this case, along with
an explanation.

Refs #10830

Signed-off-by: Benny Halevy <bhalevy@scylladb.com>