### PR TITLE
test: re-enable but mark as flaky cdc_with_lwt_test

### DIFF
--- a/test/cql/suite.yaml
+++ b/test/cql/suite.yaml
@@ -1,3 +1,3 @@
 type: Approval
-disable:
+flaky:
     - cdc_with_lwt_test


### PR DESCRIPTION
Running flaky tests prevents regressions from sneaking which is possible if the test is disabled.