### PR TITLE
test: error_injection: test_inject_noop: do no rely on wall clock timing

### DIFF
--- a/test/boost/error_injection_test.cc
+++ b/test/boost/error_injection_test.cc
@@ -40,11 +40,9 @@ SEASTAR_TEST_CASE(test_inject_noop) {
     BOOST_ASSERT(errinj.enter("error") == false);
 
     auto start_time = steady_clock::now();
-    return errinj.inject("noop2", sleep_msec).then([start_time] {
-        auto wait_time = std::chrono::duration_cast<milliseconds>(steady_clock::now() - start_time);
-        BOOST_REQUIRE_LT(wait_time.count(), sleep_msec.count());
-        return make_ready_future<>();
-    });
+    auto f = errinj.inject("noop2", sleep_msec);
+    BOOST_REQUIRE(f.available() && !f.failed());
+    return make_ready_future<>();
 }
 
 SEASTAR_TEST_CASE(test_is_enabled) {


### PR DESCRIPTION
This unit test may fail in debug mode
since .then may yield, even if inject returns
a ready future, so the wall clock timing has no basis.

As seen in https://jenkins.scylladb.com/job/releng/job/Scylla-CI/932/testReport/junit/boost.error_injection_test.debug/test_boost_error_injection_test/test_inject_noop/
```
[Exception] - critical check wait_time.count() < sleep_msec.count() has failed [47 >= 10]
 == [File] - test/boost/error_injection_test.cc
 == [Line] -45
 ```

Instead, just verify that inject returns
a successful, ready future, when using
a non-existing errr injection name.

Signed-off-by: Benny Halevy <bhalevy@scylladb.com>