### PR TITLE
commitlog_test: Change timeout handling to do abort()

### DIFF
--- a/test/boost/commitlog_test.cc
+++ b/test/boost/commitlog_test.cc
@@ -791,8 +791,6 @@ SEASTAR_TEST_CASE(test_commitlog_deadlock_in_recycle) {
         }
     });
 
-    bool release = true;
-
     try {
         while (n < 10) {
             auto now = timeout_clock::now();            
@@ -802,14 +800,12 @@ SEASTAR_TEST_CASE(test_commitlog_deadlock_in_recycle) {
             rps.put(std::move(h));
         }
     } catch (timed_out_error&) {
-        BOOST_FAIL("log write timed out. maybe it is deadlocked... Will not free log. ASAN errors and leaks will follow...");
-        release = false;
+        BOOST_ERROR("log write timed out. maybe it is deadlocked... Will not free log. ASAN errors and leaks will follow...");
+        abort();
     }
 
-    if (release) {  
-        co_await log.shutdown();
-        co_await log.clear();
-    }
+    co_await log.shutdown();
+    co_await log.clear();
 }
 
 // Test for #8438 - ensure we can shut down (in orderly fashion)
@@ -877,7 +873,8 @@ SEASTAR_TEST_CASE(test_commitlog_shutdown_during_wait) {
         co_await with_timeout(now + 30s, log.shutdown());
         co_await log.clear();
     } catch (timed_out_error&) {
-        BOOST_FAIL("log shutdown timed out. maybe it is deadlocked... Will not free log. ASAN errors and leaks will follow...");
+        BOOST_ERROR("log shutdown timed out. maybe it is deadlocked... Will not free log. ASAN errors and leaks will follow...");
+        abort();
     }
 }
 
@@ -913,8 +910,6 @@ SEASTAR_TEST_CASE(test_commitlog_deadlock_with_flush_threshold) {
         done = true;
     });
 
-    bool release = true;
-
     try {
         while (!done) {
             auto now = timeout_clock::now();
@@ -924,14 +919,12 @@ SEASTAR_TEST_CASE(test_commitlog_deadlock_with_flush_threshold) {
             rps.put(std::move(h));
         }
     } catch (timed_out_error&) {
-        BOOST_FAIL("log write timed out. maybe it is deadlocked... Will not free log. ASAN errors and leaks will follow...");
-        release = false;
+        BOOST_ERROR("log write timed out. maybe it is deadlocked... Will not free log. ASAN errors and leaks will follow...");
+        abort();
     }
 
-    if (release) {
-        co_await log.shutdown();
-        co_await log.clear();
-    }
+    co_await log.shutdown();
+    co_await log.clear();
 }
 
 static future<> do_test_exception_in_allocate_ex(bool do_file_delete) {
@@ -1012,7 +1005,8 @@ static future<> do_test_exception_in_allocate_ex(bool do_file_delete) {
             rps.put(std::move(h));
         }
     } catch (...) {
-        BOOST_FAIL("log write timed out. maybe it is deadlocked... Will not free log. ASAN errors and leaks will follow...");
+        BOOST_ERROR("log write timed out. maybe it is deadlocked... Will not free log. ASAN errors and leaks will follow...");
+        abort();
     }
 
     co_await log.shutdown();


### PR DESCRIPTION
Refs #10805

To help debug spurious failures, ensure to do abort() for debugger/core
ease.