### PR TITLE
sstables: generation_type tidy-up

### DIFF
--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -1183,7 +1183,7 @@ void set_storage_service(http_context& ctx, routes& r, sharded<service::storage_
                             ss::sstable info;
 
                             info.timestamp = t;
-                            info.generation = sstable->generation();
+                            info.generation = sstables::generation_value(sstable->generation());
                             info.level = sstable->get_sstable_level();
                             info.size = sstable->bytes_on_disk();
                             info.data_size = sstable->ondisk_data_size();

--- a/sstables/generation_type.hh
+++ b/sstables/generation_type.hh
@@ -6,8 +6,12 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+#pragma once
+
 #include <cstdint>
 
 namespace sstables {
 using generation_type = int64_t;
+constexpr int64_t generation_value(generation_type generation) { return generation; }
+constexpr generation_type generation_from_value(int64_t value) { return value; }
 }

--- a/sstables/generation_type.hh
+++ b/sstables/generation_type.hh
@@ -9,9 +9,61 @@
 #pragma once
 
 #include <cstdint>
+#include <compare>
+#include <limits>
+#include <iostream>
+#include <seastar/core/sstring.hh>
 
 namespace sstables {
-using generation_type = int64_t;
-constexpr int64_t generation_value(generation_type generation) { return generation; }
-constexpr generation_type generation_from_value(int64_t value) { return value; }
+
+class generation_type {
+    int64_t _value;
+public:
+    generation_type() = delete;
+
+    explicit constexpr generation_type(int64_t value) noexcept: _value(value) {}
+    constexpr int64_t value() const noexcept { return _value; }
+
+    constexpr bool operator==(const generation_type& other) const noexcept { return _value == other._value; }
+    constexpr std::strong_ordering operator<=>(const generation_type& other) const noexcept { return _value <=> other._value; }
+};
+
+constexpr generation_type generation_from_value(int64_t value) {
+    return generation_type{value};
 }
+constexpr int64_t generation_value(generation_type generation) {
+    return generation.value();
+}
+
+} //namespace sstables
+
+namespace seastar {
+template <typename string_type = sstring>
+string_type to_sstring(sstables::generation_type generation) {
+    return to_sstring(sstables::generation_value(generation));
+}
+} //namespace seastar
+
+namespace std {
+template <>
+struct hash<sstables::generation_type> {
+    constexpr size_t operator()(const sstables::generation_type& generation) const noexcept {
+        return hash<int64_t>{}(generation.value());
+    }
+};
+
+// for min_max_tracker
+template <>
+struct numeric_limits<sstables::generation_type> : public numeric_limits<int64_t> {
+    static constexpr sstables::generation_type min() noexcept {
+        return sstables::generation_type{numeric_limits<int64_t>::min()};
+    }
+    static constexpr sstables::generation_type max() noexcept {
+        return sstables::generation_type{numeric_limits<int64_t>::max()};
+    }
+};
+
+[[maybe_unused]] static ostream& operator<<(ostream& s, const sstables::generation_type& generation) {
+    return s << generation.value();
+}
+} //namespace std

--- a/sstables/sstable_directory.hh
+++ b/sstables/sstable_directory.hh
@@ -85,7 +85,7 @@ private:
     // How to create an SSTable object from an existing SSTable file (respecting generation, etc)
     sstable_object_from_existing_fn _sstable_object_from_existing_sstable;
 
-    int64_t _max_generation_seen = 0;
+    generation_type _max_generation_seen = generation_from_value(0);
     sstables::sstable_version_types _max_version_seen = sstables::sstable_version_types::ka;
 
     // SSTables that are unshared and belong to this shard. They are already stored as an
@@ -137,7 +137,7 @@ public:
     future<> move_foreign_sstables(sharded<sstable_directory>& source_directory);
 
     // returns what is the highest generation seen in this directory.
-    int64_t highest_generation_seen() const;
+    generation_type highest_generation_seen() const;
 
     // returns what is the highest version seen in this directory.
     sstables::sstable_version_types highest_version_seen() const;

--- a/sstables/sstable_set.cc
+++ b/sstables/sstable_set.cc
@@ -623,7 +623,7 @@ class incremental_reader_selector : public reader_selector {
     lw_shared_ptr<const sstable_set> _sstables;
     tracing::trace_state_ptr _trace_state;
     std::optional<sstable_set::incremental_selector> _selector;
-    std::unordered_set<int64_t> _read_sstable_gens;
+    std::unordered_set<generation_type> _read_sstable_gens;
     sstable_reader_factory_type _fn;
 
     flat_mutation_reader_v2 create_reader(shared_sstable sst) {

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -2256,7 +2256,7 @@ static entry_descriptor make_entry_descriptor(sstring sstdir, sstring fname, sst
     } else {
         throw malformed_sstable_exception(seastar::format("invalid version for file {}. Name doesn't match any known version.", fname));
     }
-    return entry_descriptor(sstdir, ks, cf, boost::lexical_cast<unsigned long>(generation), version, sstable::format_from_sstring(format), sstable::component_from_sstring(version, component));
+    return entry_descriptor(sstdir, ks, cf, generation_from_value(boost::lexical_cast<unsigned long>(generation)), version, sstable::format_from_sstring(format), sstable::component_from_sstring(version, component));
 }
 
 entry_descriptor entry_descriptor::make_descriptor(sstring sstdir, sstring fname) {

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -504,7 +504,7 @@ private:
     schema_ptr _schema;
     sstring _dir;
     std::optional<sstring> _temp_dir; // Valid while the sstable is being created, until sealed
-    generation_type _generation = 0;
+    generation_type _generation{0};
 
     version_types _version;
     format_types _format;

--- a/test/boost/database_test.cc
+++ b/test/boost/database_test.cc
@@ -253,25 +253,25 @@ SEASTAR_THREAD_TEST_CASE(test_distributed_loader_with_incomplete_sstables) {
         require_exist(file_name, true);
     };
 
-    auto temp_sst_dir = sst::temp_sst_dir(sst_dir, 2);
+    auto temp_sst_dir = sst::temp_sst_dir(sst_dir, generation_from_value(2));
     touch_dir(temp_sst_dir);
 
-    temp_sst_dir = sst::temp_sst_dir(sst_dir, 3);
+    temp_sst_dir = sst::temp_sst_dir(sst_dir, generation_from_value(3));
     touch_dir(temp_sst_dir);
-    auto temp_file_name = sst::filename(temp_sst_dir, ks, cf, sst::version_types::mc, 3, sst::format_types::big, component_type::TemporaryTOC);
+    auto temp_file_name = sst::filename(temp_sst_dir, ks, cf, sst::version_types::mc, generation_from_value(3), sst::format_types::big, component_type::TemporaryTOC);
     touch_file(temp_file_name);
 
-    temp_file_name = sst::filename(sst_dir, ks, cf, sst::version_types::mc, 4, sst::format_types::big, component_type::TemporaryTOC);
+    temp_file_name = sst::filename(sst_dir, ks, cf, sst::version_types::mc, generation_from_value(4), sst::format_types::big, component_type::TemporaryTOC);
     touch_file(temp_file_name);
-    temp_file_name = sst::filename(sst_dir, ks, cf, sst::version_types::mc, 4, sst::format_types::big, component_type::Data);
+    temp_file_name = sst::filename(sst_dir, ks, cf, sst::version_types::mc, generation_from_value(4), sst::format_types::big, component_type::Data);
     touch_file(temp_file_name);
 
     do_with_cql_env_thread([&sst_dir, &ks, &cf, &require_exist] (cql_test_env& e) {
-        require_exist(sst::temp_sst_dir(sst_dir, 2), false);
-        require_exist(sst::temp_sst_dir(sst_dir, 3), false);
+        require_exist(sst::temp_sst_dir(sst_dir, generation_from_value(2)), false);
+        require_exist(sst::temp_sst_dir(sst_dir, generation_from_value(3)), false);
 
-        require_exist(sst::filename(sst_dir, ks, cf, sst::version_types::mc, 4, sst::format_types::big, component_type::TemporaryTOC), false);
-        require_exist(sst::filename(sst_dir, ks, cf, sst::version_types::mc, 4, sst::format_types::big, component_type::Data), false);
+        require_exist(sst::filename(sst_dir, ks, cf, sst::version_types::mc, generation_from_value(4), sst::format_types::big, component_type::TemporaryTOC), false);
+        require_exist(sst::filename(sst_dir, ks, cf, sst::version_types::mc, generation_from_value(4), sst::format_types::big, component_type::Data), false);
     }, db_cfg_ptr).get();
 }
 
@@ -320,11 +320,11 @@ SEASTAR_THREAD_TEST_CASE(test_distributed_loader_with_pending_delete) {
     };
 
     auto component_basename = [&ks, &cf] (int64_t gen, component_type ctype) {
-        return sst::component_basename(ks, cf, sst::version_types::mc, gen, sst::format_types::big, ctype);
+        return sst::component_basename(ks, cf, sst::version_types::mc, generation_from_value(gen), sst::format_types::big, ctype);
     };
 
     auto gen_filename = [&sst_dir, &ks, &cf] (int64_t gen, component_type ctype) {
-        return sst::filename(sst_dir, ks, cf, sst::version_types::mc, gen, sst::format_types::big, ctype);
+        return sst::filename(sst_dir, ks, cf, sst::version_types::mc, generation_from_value(gen), sst::format_types::big, ctype);
     };
 
     touch_dir(pending_delete_dir);

--- a/test/boost/mutation_reader_test.cc
+++ b/test/boost/mutation_reader_test.cc
@@ -3876,7 +3876,7 @@ static future<> do_test_clustering_order_merger_sstable_set(bool reversed) {
                 return sst.make_reader(query_schema, permit, pr,
                                           query_slice, seastar::default_priority_class(), nullptr, fwd);
             },
-            [included_gens] (const sstable& sst) { return included_gens.contains(sst.generation()); },
+            [included_gens] (const sstable& sst) { return included_gens.contains(generation_value(sst.generation())); },
             pk, query_schema, permit, fwd, reversed);
         return make_clustering_combined_reader(query_schema, permit, fwd, std::move(q));
     };

--- a/test/boost/sstable_3_x_test.cc
+++ b/test/boost/sstable_3_x_test.cc
@@ -3211,9 +3211,9 @@ static void compare_sstables(const std::filesystem::path& result_path, sstring t
                            component_type::Filter}) {
         auto orig_filename =
                 sstable::filename(get_write_test_path(table_name),
-                                  "ks", table_name, sstables::sstable_version_types::mc, 1, big, file_type);
+                                  "ks", table_name, sstables::sstable_version_types::mc, generation_from_value(1), big, file_type);
         auto result_filename =
-                sstable::filename(result_path.string(), "ks", table_name, version, 1, big, file_type);
+                sstable::filename(result_path.string(), "ks", table_name, version, generation_from_value(1), big, file_type);
         compare_files(orig_filename, result_filename);
     }
 }
@@ -5194,7 +5194,7 @@ static void test_sstable_write_large_row_f(schema_ptr s, reader_permit permit, r
     auto stop_manager = defer([&] { manager.close().get(); });
     tmpdir dir;
     auto sst = manager.make_sstable(
-            s, dir.path().string(), 1 /* generation */, version, sstables::sstable::format_types::big);
+            s, dir.path().string(), generation_from_value(1), version, sstables::sstable::format_types::big);
 
     // The test provides thresholds values for the large row handler. Whether the handler gets
     // trigger depends on the size of rows after they are written in the MC format and that size
@@ -5253,7 +5253,7 @@ static void test_sstable_log_too_many_rows_f(int rows, uint64_t threshold, bool 
     sstables_manager manager(handler, test_db_config, test_feature_service, tracker);
     auto close_manager = defer([&] { manager.close().get(); });
     tmpdir dir;
-    auto sst = manager.make_sstable(sc, dir.path().string(), 1, version, sstables::sstable::format_types::big);
+    auto sst = manager.make_sstable(sc, dir.path().string(), generation_from_value(1), version, sstables::sstable::format_types::big);
     sst->write_components(mt->make_flat_reader(sc, semaphore.make_permit()), 1, sc, manager.configure_writer("test"), encoding_stats{}).get();
 
     BOOST_REQUIRE_EQUAL(logged, expected);

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -555,7 +555,7 @@ static void add_sstable_for_leveled_test(test_env& env, lw_shared_ptr<replica::c
     assert(sst->data_size() == fake_data_size);
     assert(sst->get_sstable_level() == sstable_level);
     assert(sst->get_stats_metadata().max_timestamp == max_timestamp);
-    assert(sst->generation() == gen);
+    assert(generation_value(sst->generation()) == gen);
     column_family_test(cf).add_sstable(sst);
 }
 
@@ -583,9 +583,9 @@ static bool key_range_overlaps(column_family_for_tests& cf, sstring a, sstring b
 
 static shared_sstable get_sstable(const lw_shared_ptr<replica::column_family>& cf, int64_t generation) {
     auto sstables = cf->get_sstables();
-    auto entry = boost::range::find_if(*sstables, [generation] (shared_sstable sst) { return generation == sst->generation(); });
+    auto entry = boost::range::find_if(*sstables, [generation] (shared_sstable sst) { return generation == generation_value(sst->generation()); });
     assert(entry != sstables->end());
-    assert((*entry)->generation() == generation);
+    assert(generation_value((*entry)->generation()) == generation);
     return *entry;
 }
 
@@ -631,8 +631,8 @@ SEASTAR_TEST_CASE(leveled_01) {
 
     std::set<unsigned long> gens = { 1, 2 };
     for (auto& sst : candidate.sstables) {
-        BOOST_REQUIRE(gens.contains(sst->generation()));
-        gens.erase(sst->generation());
+        BOOST_REQUIRE(gens.contains(generation_value(sst->generation())));
+        gens.erase(generation_value(sst->generation()));
         BOOST_REQUIRE(sst->get_sstable_level() == 0);
     }
     BOOST_REQUIRE(gens.empty());
@@ -685,8 +685,8 @@ SEASTAR_TEST_CASE(leveled_02) {
 
     std::set<unsigned long> gens = { 1, 2, 3 };
     for (auto& sst : candidate.sstables) {
-        BOOST_REQUIRE(gens.contains(sst->generation()));
-        gens.erase(sst->generation());
+        BOOST_REQUIRE(gens.contains(generation_value(sst->generation())));
+        gens.erase(generation_value(sst->generation()));
         BOOST_REQUIRE(sst->get_sstable_level() == 0);
     }
     BOOST_REQUIRE(gens.empty());
@@ -741,7 +741,7 @@ SEASTAR_TEST_CASE(leveled_03) {
 
     std::set<std::pair<unsigned long, uint32_t>> gen_and_level = { {1,0}, {2,0}, {3,1} };
     for (auto& sst : candidate.sstables) {
-        std::pair<unsigned long, uint32_t> pair(sst->generation(), sst->get_sstable_level());
+        std::pair<unsigned long, uint32_t> pair(generation_value(sst->generation()), sst->get_sstable_level());
         auto it = gen_and_level.find(pair);
         BOOST_REQUIRE(it != gen_and_level.end());
         BOOST_REQUIRE(sst->get_sstable_level() == it->second);
@@ -831,7 +831,7 @@ SEASTAR_TEST_CASE(leveled_05) {
 
             return seastar::async([&, generations = std::move(generations), tmpdir_path] {
                 for (auto gen : generations) {
-                    auto fname = sstable::filename(tmpdir_path, "ks", "cf", sstables::get_highest_sstable_version(), gen, big, component_type::Data);
+                    auto fname = sstable::filename(tmpdir_path, "ks", "cf", sstables::get_highest_sstable_version(), generation_from_value(gen), big, component_type::Data);
                     BOOST_REQUIRE(file_size(fname).get0() >= 1024*1024);
                 }
             });
@@ -867,7 +867,7 @@ SEASTAR_TEST_CASE(leveled_06) {
     BOOST_REQUIRE(candidate.sstables.size() == 1);
     auto& sst = (candidate.sstables)[0];
     BOOST_REQUIRE(sst->get_sstable_level() == 1);
-    BOOST_REQUIRE(sst->generation() == 1);
+    BOOST_REQUIRE(generation_value(sst->generation()) == 1);
 
     return cf.stop_and_keep_alive();
   });
@@ -928,7 +928,7 @@ SEASTAR_TEST_CASE(leveled_invariant_fix) {
     BOOST_REQUIRE(candidate.level == 1);
     BOOST_REQUIRE(candidate.sstables.size() == size_t(sstables_no-1));
     BOOST_REQUIRE(boost::algorithm::all_of(candidate.sstables, [] (auto& sst) {
-        return sst->generation() != 0;
+        return generation_value(sst->generation()) != 0;
     }));
 
     return cf.stop_and_keep_alive();
@@ -971,7 +971,7 @@ SEASTAR_TEST_CASE(leveled_stcs_on_L0) {
         BOOST_REQUIRE(candidate.level == 0);
         BOOST_REQUIRE(candidate.sstables.size() == size_t(l0_sstables_no));
         BOOST_REQUIRE(boost::algorithm::all_of(candidate.sstables, [] (auto& sst) {
-            return sst->generation() != 0;
+            return generation_value(sst->generation()) != 0;
         }));
     }
     {
@@ -1039,7 +1039,7 @@ SEASTAR_TEST_CASE(check_overlapping) {
 
     auto overlapping_sstables = leveled_manifest::overlapping(*cf.schema(), compacting, uncompacting);
     BOOST_REQUIRE(overlapping_sstables.size() == 1);
-    BOOST_REQUIRE(overlapping_sstables.front()->generation() == 4);
+    BOOST_REQUIRE(generation_value(overlapping_sstables.front()->generation()) == 4);
 
     return cf.stop_and_keep_alive();
   });
@@ -1283,7 +1283,7 @@ SEASTAR_TEST_CASE(sstable_rewrite) {
             return compact_sstables(cf.get_compaction_manager(), sstables::compaction_descriptor(std::move(sstables), default_priority_class()), *cf, creator).then([&env, s, key, new_tables] (auto) {
                 BOOST_REQUIRE(new_tables->size() == 1);
                 auto newsst = (*new_tables)[0];
-                BOOST_REQUIRE(newsst->generation() == 52);
+                BOOST_REQUIRE(generation_value(newsst->generation()) == 52);
                 auto reader = make_lw_shared<flat_mutation_reader_v2>(sstable_reader(newsst, s, env.make_reader_permit()));
                 return (*reader)().then([s, reader, key] (mutation_fragment_v2_opt m) {
                     BOOST_REQUIRE(m);
@@ -1404,7 +1404,7 @@ SEASTAR_TEST_CASE(get_fully_expired_sstables_test) {
         auto expired = get_fully_expired_sstables(cf->as_table_state(), compacting, /*gc before*/gc_clock::from_time_t(25) + cf->schema()->gc_grace_seconds());
         BOOST_REQUIRE(expired.size() == 1);
         auto expired_sst = *expired.begin();
-        BOOST_REQUIRE(expired_sst->generation() == 1);
+        BOOST_REQUIRE(generation_value(expired_sst->generation()) == 1);
     }
   });
 }
@@ -1443,7 +1443,7 @@ SEASTAR_TEST_CASE(compaction_with_fully_expired_table) {
         auto expired = get_fully_expired_sstables(cf->as_table_state(), ssts, gc_clock::now());
         BOOST_REQUIRE(expired.size() == 1);
         auto expired_sst = *expired.begin();
-        BOOST_REQUIRE(expired_sst->generation() == 1);
+        BOOST_REQUIRE(generation_value(expired_sst->generation()) == 1);
 
         auto ret = compact_sstables(cf.get_compaction_manager(), sstables::compaction_descriptor(ssts, default_priority_class()), *cf, sst_gen).get0();
         BOOST_REQUIRE(ret.new_sstables.empty());
@@ -1483,7 +1483,7 @@ SEASTAR_TEST_CASE(basic_date_tiered_strategy_test) {
     auto sstables = manifest.get_next_sstables(*table_s, candidates, gc_before);
     BOOST_REQUIRE(sstables.size() == 4);
     for (auto& sst : sstables) {
-        BOOST_REQUIRE(sst->generation() != (min_threshold + 1));
+        BOOST_REQUIRE(generation_value(sst->generation()) != (min_threshold + 1));
     }
 
     return cf.stop_and_keep_alive();
@@ -1535,7 +1535,7 @@ SEASTAR_TEST_CASE(date_tiered_strategy_test_2) {
     auto sstables = manifest.get_next_sstables(*table_s, candidates, gc_before);
     std::unordered_set<int64_t> gens;
     for (auto sst : sstables) {
-        gens.insert(sst->generation());
+        gens.insert(generation_value(sst->generation()));
     }
     BOOST_REQUIRE(sstables.size() == size_t(min_threshold + 1));
     BOOST_REQUIRE(gens.contains(min_threshold + 1));
@@ -3052,14 +3052,14 @@ SEASTAR_TEST_CASE(sstable_run_based_compaction_test) {
             BOOST_REQUIRE(old_sstables.size() == 1);
             BOOST_REQUIRE(new_sstables.size() == 1);
             // check that sstable replacement follows token order
-            BOOST_REQUIRE(*expected_sst == old_sstables.front()->generation());
+            BOOST_REQUIRE(*expected_sst == generation_value(old_sstables.front()->generation()));
             expected_sst++;
             // check that previously released sstables were already closed
-            if (old_sstables.front()->generation() % 4 == 0) {
+            if (generation_value(old_sstables.front()->generation()) % 4 == 0) {
                 // Due to performance reasons, sstables are not released immediately, but in batches.
                 // At the time of writing, mutation_reader_merger releases it's sstable references
                 // in batches of 4. That's why we only perform this check every 4th sstable. 
-                BOOST_REQUIRE(*closed_sstables_tracker == old_sstables.front()->generation());
+                BOOST_REQUIRE(*closed_sstables_tracker == generation_value(old_sstables.front()->generation()));
             }
 
             do_replace(old_sstables, new_sstables);
@@ -3089,7 +3089,7 @@ SEASTAR_TEST_CASE(sstable_run_based_compaction_test) {
 
             BOOST_REQUIRE(desc.sstables.size() == expected_input);
             auto sstable_run = boost::copy_range<std::set<int64_t>>(desc.sstables
-                | boost::adaptors::transformed([] (auto& sst) { return sst->generation(); }));
+                | boost::adaptors::transformed([] (auto& sst) { return generation_value(sst->generation()); }));
             auto expected_sst = sstable_run.begin();
             auto closed_sstables_tracker = sstable_run.begin();
             auto replacer = [&] (sstables::compaction_completion_desc desc) {
@@ -3273,15 +3273,15 @@ SEASTAR_TEST_CASE(partial_sstable_run_filtered_out_test) {
         auto partial_sstable_run_sst = make_sstable_easy(env, tmp.path(), make_flat_mutation_reader_from_mutations_v2(s, env.make_reader_permit(), { std::move(mut) }), sst_cfg);
 
         column_family_test(cf).add_sstable(partial_sstable_run_sst);
-        column_family_test::update_sstables_known_generation(*cf, partial_sstable_run_sst->generation());
+        column_family_test::update_sstables_known_generation(*cf, generation_value(partial_sstable_run_sst->generation()));
 
         auto generation_exists = [&cf] (int64_t generation) {
             auto sstables = cf->get_sstables();
-            auto entry = boost::range::find_if(*sstables, [generation] (shared_sstable sst) { return generation == sst->generation(); });
+            auto entry = boost::range::find_if(*sstables, [generation] (shared_sstable sst) { return generation == generation_value(sst->generation()); });
             return entry != sstables->end();
         };
 
-        BOOST_REQUIRE(generation_exists(partial_sstable_run_sst->generation()));
+        BOOST_REQUIRE(generation_exists(generation_value(partial_sstable_run_sst->generation())));
 
         // register partial sstable run
         auto cm_test = compaction_manager_test(*cm);
@@ -3290,7 +3290,7 @@ SEASTAR_TEST_CASE(partial_sstable_run_filtered_out_test) {
         }).get();
 
         // make sure partial sstable run has none of its fragments compacted.
-        BOOST_REQUIRE(generation_exists(partial_sstable_run_sst->generation()));
+        BOOST_REQUIRE(generation_exists(generation_value(partial_sstable_run_sst->generation())));
     });
 }
 
@@ -4310,7 +4310,7 @@ SEASTAR_TEST_CASE(twcs_reshape_with_disjoint_set_test) {
                 //
                 if (i % 2 == 0) {
                     sst = make_sstable_containing(sst_gen, mutations_for_small_files);
-                    generations_for_small_files.insert(sst->generation());
+                    generations_for_small_files.insert(generation_value(sst->generation()));
                 } else {
                     sst = make_sstable_containing(sst_gen, mutations_for_big_files);
                 }
@@ -4322,7 +4322,7 @@ SEASTAR_TEST_CASE(twcs_reshape_with_disjoint_set_test) {
                 BOOST_REQUIRE_EQUAL(ret.sstables.size(), uint64_t(s->max_compaction_threshold()));
                 // fail if any file doesn't belong to set of small files
                 bool has_big_sized_files = boost::algorithm::any_of(ret.sstables, [&] (const sstables::shared_sstable& sst) {
-                    return !generations_for_small_files.contains(sst->generation());
+                    return !generations_for_small_files.contains(generation_value(sst->generation()));
                 });
                 BOOST_REQUIRE(!has_big_sized_files);
             };
@@ -4597,7 +4597,7 @@ SEASTAR_TEST_CASE(compound_sstable_set_incremental_selector_test) {
             auto sstables = selector.select(key).sstables;
             BOOST_REQUIRE_EQUAL(sstables.size(), expected_gens.size());
             for (auto& sst : sstables) {
-                BOOST_REQUIRE(expected_gens.contains(sst->generation()));
+                BOOST_REQUIRE(expected_gens.contains(generation_value(sst->generation())));
             }
         };
 
@@ -4989,7 +4989,7 @@ SEASTAR_TEST_CASE(test_compaction_strategy_cleanup_method) {
             auto [candidates, descriptors] = get_cleanup_jobs(compaction_strategy_type, std::forward<decltype(args)>(args)...);
             testlog.info("get_cleanup_jobs() returned {} descriptors; expected={}", descriptors.size(), target_job_count);
             BOOST_REQUIRE(descriptors.size() == target_job_count);
-            auto generations = boost::copy_range<std::unordered_set<unsigned>>(candidates | boost::adaptors::transformed(std::mem_fn(&sstables::sstable::generation)));
+            auto generations = boost::copy_range<std::unordered_set<generation_type>>(candidates | boost::adaptors::transformed(std::mem_fn(&sstables::sstable::generation)));
             auto check_desc = [&] (const auto& desc) {
                 BOOST_REQUIRE(desc.sstables.size() == per_job_files);
                 for (auto& sst: desc.sstables) {

--- a/test/boost/sstable_test.hh
+++ b/test/boost/sstable_test.hh
@@ -47,15 +47,15 @@ public:
     }
 
     static void update_sstables_known_generation(replica::column_family& cf, unsigned generation) {
-        cf.update_sstables_known_generation(generation);
+        cf.update_sstables_known_generation(generation_from_value(generation));
     }
 
     static uint64_t calculate_generation_for_new_table(replica::column_family& cf) {
-        return cf.calculate_generation_for_new_table();
+        return generation_value(cf.calculate_generation_for_new_table());
     }
 
     static int64_t calculate_shard_from_sstable_generation(int64_t generation) {
-        return replica::column_family::calculate_shard_from_sstable_generation(generation);
+        return replica::column_family::calculate_shard_from_sstable_generation(generation_from_value(generation));
     }
 
     future<stop_iteration> try_flush_memtable_to_sstable(lw_shared_ptr<replica::memtable> mt) {

--- a/test/lib/sstable_test_env.hh
+++ b/test/lib/sstable_test_env.hh
@@ -47,7 +47,7 @@ public:
     shared_sstable make_sstable(schema_ptr schema, sstring dir, unsigned long generation,
             sstable::version_types v = sstables::get_highest_sstable_version(), sstable::format_types f = sstable::format_types::big,
             size_t buffer_size = default_sstable_buffer_size, gc_clock::time_point now = gc_clock::now()) {
-        return _mgr->make_sstable(std::move(schema), dir, generation, v, f, now, default_io_error_handler_gen(), buffer_size);
+        return _mgr->make_sstable(std::move(schema), dir, generation_from_value(generation), v, f, now, default_io_error_handler_gen(), buffer_size);
     }
 
     struct sst_not_found : public std::runtime_error {

--- a/test/lib/sstable_utils.cc
+++ b/test/lib/sstable_utils.cc
@@ -180,7 +180,7 @@ std::vector<std::pair<sstring, dht::token>> token_generation_for_current_shard(u
 }
 
 static sstring toc_filename(const sstring& dir, schema_ptr schema, unsigned int generation, sstable_version_types v) {
-    return sstable::filename(dir, schema->ks_name(), schema->cf_name(), v, generation,
+    return sstable::filename(dir, schema->ks_name(), schema->cf_name(), v, generation_from_value(generation),
                              sstable_format_types::big, component_type::TOC);
 }
 

--- a/test/lib/sstable_utils.hh
+++ b/test/lib/sstable_utils.hh
@@ -164,7 +164,7 @@ public:
     }
 
     void change_generation_number(int64_t generation) {
-        _sst->_generation = generation;
+        _sst->_generation = generation_from_value(generation);
     }
 
     void change_dir(sstring dir) {

--- a/utils/extremum_tracking.hh
+++ b/utils/extremum_tracking.hh
@@ -10,41 +10,33 @@
 
 #include <functional>
 #include <limits>
+#include <optional>
 
 namespace detail {
 
 template<typename T, typename Comparator>
 class extremum_tracker {
     T _default_value;
-    bool _is_set = false;
-    T _value;
+    std::optional<T> _value;
 public:
-    explicit extremum_tracker(T default_value) {
-        _default_value = default_value;
-    }
+    explicit extremum_tracker(const T& default_value)
+        : _default_value(default_value)
+    {}
 
-    void update(T value) {
-        if (!_is_set) {
+    void update(const T& value) {
+        if (!_value || Comparator{}(value, *_value)) {
             _value = value;
-            _is_set = true;
-        } else {
-            if (Comparator{}(value,_value)) {
-                _value = value;
-            }
         }
     }
 
     void update(const extremum_tracker& other) {
-        if (other._is_set) {
-            update(other._value);
+        if (other._value) {
+            update(*other._value);
         }
     }
 
-    T get() const {
-        if (_is_set) {
-            return _value;
-        }
-        return _default_value;
+    const T& get() const {
+        return _value ? *_value : _default_value;
     }
 };
 
@@ -66,12 +58,12 @@ public:
         , _max_tracker(std::numeric_limits<T>::max())
     {}
 
-    min_max_tracker(T default_min, T default_max)
+    min_max_tracker(const T& default_min, const T& default_max)
         : _min_tracker(default_min)
         , _max_tracker(default_max)
     {}
 
-    void update(T value) {
+    void update(const T& value) {
         _min_tracker.update(value);
         _max_tracker.update(value);
     }
@@ -81,11 +73,11 @@ public:
         _max_tracker.update(other._max_tracker);
     }
 
-    T min() const {
+    const T& min() const {
         return _min_tracker.get();
     }
 
-    T max() const {
+    const T& max() const {
         return _max_tracker.get();
     }
 };


### PR DESCRIPTION
- Use `sstables::generation_type` in more places
- Enforce conceptual separation of `sstables::generation_type` and `int64_t`
- Fix `extremum_tracker` so that `sstables::generation_type` can be non-default-constructible

Fixes #10796.