### PR TITLE
cql: improve error message for static column in materialized view

### DIFF
--- a/cql3/statements/create_view_statement.cc
+++ b/cql3/statements/create_view_statement.cc
@@ -235,7 +235,7 @@ view_ptr create_view_statement::prepare_view(data_dictionary::database db) const
     for (auto& def : schema->all_columns()) {
         bool included_def = included.empty() || included.contains(&def);
         if (included_def && def.is_static()) {
-            throw exceptions::invalid_request_exception(format("Unable to include static column '{}' which would be included by Materialized View SELECT * statement", def));
+            throw exceptions::invalid_request_exception(format("Unable to include static column '{}' which would be included by Materialized View SELECT * statement", def.name_as_text()));
         }
 
         bool def_in_target_pk = target_primary_keys.contains(&def);


### PR DESCRIPTION
Static columns are not currently allowed in a materialized view. If the
base table has a static column and one tries to create a view with a
"SELECT *", the following error message is printed today:

  Unable to include static column 'ColumnDefinition{name=s,
  type=org.apache.cassandra.db.marshal.Int32Type, kind=STATIC,
  componentIndex=null, droppedAt=-9223372036854775808}' which would
  be included by Materialized View SELECT * statement

It is completely unnecessary to include all these details about the
column definition - just its name would have sufficed. In other words,
we should print def.name_as_text(), not the entire def. This is what
other error messages in the same file do as well.

After this patch the error message becomes nicer and clearer:

  Unable to include static column 's' which would be included by
  Materialized View SELECT * statement

Signed-off-by: Nadav Har'El <nyh@scylladb.com>