### PR TITLE
view: exclude using static columns in the view filter

### DIFF
--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -313,7 +313,11 @@ public:
     view_filter_checking_visitor(const schema& base, const view_info& view)
         : _base(base)
         , _view(view)
-        , _selection(cql3::selection::selection::wildcard(_base.shared_from_this()))
+        , _selection(cql3::selection::selection::for_columns(_base.shared_from_this(),
+            boost::copy_range<std::vector<const column_definition*>>(
+                _base.regular_columns() | boost::adaptors::transformed([] (const column_definition& cdef) { return &cdef; }))
+            )
+        )
     {}
 
     void accept_new_partition(const partition_key& key, uint64_t row_count) {

--- a/test/cql-pytest/test_materialized_view.py
+++ b/test/cql-pytest/test_materialized_view.py
@@ -192,3 +192,17 @@ def test_mv_is_not_null(cql, test_keyspace):
             assert list(cql.execute(f"SELECT * FROM {mv}")) == [('cat', 123)]
             cql.execute(f"DELETE v FROM {table} WHERE p=123")
             assert list(cql.execute(f"SELECT * FROM {mv}")) == []
+
+# Refs #10851. The code used to create a wildcard selection for all columns,
+# which erroneously also includes static columns if such are present in the
+# base table. Currently views only operate on regular columns and the filtering
+# code assumes that. TODO: once we implement static column support for materialized
+# views, this test case will be a nice regression test to ensure that everything still
+# works if the static columns are *not* used in the view.
+def test_filter_with_unused_static_column(cql, test_keyspace):
+    schema = 'p int, c int, v int, s int static, primary key (p,c)'
+    with new_test_table(cql, test_keyspace, schema) as table:
+        with new_materialized_view(cql, table, select='p,c,v', pk='p,c,v', where='p IS NOT NULL and c IS NOT NULL and v = 44') as mv:
+            cql.execute(f"INSERT INTO {table} (p,c,v) VALUES (42,43,44)")
+            cql.execute(f"INSERT INTO {table} (p,c,v) VALUES (1,2,3)")
+            assert list(cql.execute(f"SELECT * FROM {mv}")) == [(42, 43, 44)]


### PR DESCRIPTION
The code which applied view filtering (i.e. a condition placed
on a view column, e.g. "WHERE v = 42") erroneously used a wildcard
selection, which also assumes that static columns are needed,
if the base table contains any such columns.
The filtering code currently assumes that no such columns are fetched,
so the selection is amended to only ask for regular columns
(primary key columns are sent anyway, because they are enabled
via slice options, so no need to ask for them explicitly).

Fixes #10851