### PR TITLE
test: extend view filtering test case

### DIFF
--- a/test/cql-pytest/test_materialized_view.py
+++ b/test/cql-pytest/test_materialized_view.py
@@ -196,13 +196,20 @@ def test_mv_is_not_null(cql, test_keyspace):
 # Refs #10851. The code used to create a wildcard selection for all columns,
 # which erroneously also includes static columns if such are present in the
 # base table. Currently views only operate on regular columns and the filtering
-# code assumes that. TODO: once we implement static column support for materialized
+# code assumes that. Once we implement static column support for materialized
 # views, this test case will be a nice regression test to ensure that everything still
 # works if the static columns are *not* used in the view.
-def test_filter_with_unused_static_column(cql, test_keyspace):
+# This test goes over all combinations of filters for partition, clustering and regular
+# base columns.
+def test_filter_with_unused_static_column(cql, test_keyspace, scylla_only):
     schema = 'p int, c int, v int, s int static, primary key (p,c)'
     with new_test_table(cql, test_keyspace, schema) as table:
-        with new_materialized_view(cql, table, select='p,c,v', pk='p,c,v', where='p IS NOT NULL and c IS NOT NULL and v = 44') as mv:
-            cql.execute(f"INSERT INTO {table} (p,c,v) VALUES (42,43,44)")
-            cql.execute(f"INSERT INTO {table} (p,c,v) VALUES (1,2,3)")
-            assert list(cql.execute(f"SELECT * FROM {mv}")) == [(42, 43, 44)]
+        for p_condition in ['p = 42', 'p IS NOT NULL']:
+            for c_condition in ['c = 43', 'c IS NOT NULL']:
+                for v_condition in ['v = 44', 'v IS NOT NULL']:
+                    where = f"{p_condition} AND {c_condition} AND {v_condition}"
+                    with new_materialized_view(cql, table, select='p,c,v', pk='p,c,v', where=where) as mv:
+                        cql.execute(f"INSERT INTO {table} (p,c,v) VALUES (42,43,44)")
+                        cql.execute(f"INSERT INTO {table} (p,c,v) VALUES (1,2,3)")
+                        expected = [(42,43,44)] if '4' in where else [(42,43,44),(1,2,3)]
+                        assert list(cql.execute(f"SELECT * FROM {mv}")) == expected


### PR DESCRIPTION
In order to cover more code paths, the test case
now places filtering on various combinations of base columns,
including both primary keys and regular columns.
It also makes the test scylla_only, as filtering is an extension
not supported in Cassandra right now.