### PR TITLE
A bunch of refactors related to Raft group 0

### DIFF
--- a/cql3/statements/schema_altering_statement.cc
+++ b/cql3/statements/schema_altering_statement.cc
@@ -64,7 +64,7 @@ schema_altering_statement::execute0(query_processor& qp, service::query_state& s
     auto& mm = qp.get_migration_manager();
     ::shared_ptr<cql_transport::event::schema_change> ce;
 
-    if (mm.is_raft_enabled() && this_shard_id() != 0) {
+    if (this_shard_id() != 0) {
         // execute all schema altering statements on a shard zero since this is where raft group 0 is
         co_return ::make_shared<cql_transport::messages::result_message::bounce_to_shard>(0,
                     std::move(const_cast<cql3::query_options&>(options).take_cached_pk_function_calls()));

--- a/idl-compiler.py
+++ b/idl-compiler.py
@@ -543,15 +543,9 @@ class RpcVerb(ASTBase):
         return res
 
     def send_message_argument_list(self):
-        res = f'ms, '
-        if self.with_timeout and self.one_way:
-            # For some reason the timeout argument position in
-            # `send_message_oneway_timeout` is different from `send_message_timeout`.
-            res += f'timeout, {self.messaging_verb_enum_case()}, id'
-        else:
-            res += f'{self.messaging_verb_enum_case()}, id'
-            if self.with_timeout:
-                res += ', timeout'
+        res = f'ms, {self.messaging_verb_enum_case()}, id'
+        if self.with_timeout:
+            res += ', timeout'
         if self.params:
             for idx, p in enumerate(self.params):
                 res += ', ' + f'std::move({p.name if p.name else f"_{idx + 1}"})'

--- a/idl/group0.idl.hh
+++ b/idl/group0.idl.hh
@@ -17,4 +17,7 @@ struct group0_peer_exchange {
     std::variant<std::monostate, service::group0_info, std::vector<raft::server_address>> info;
 };
 
+verb [[with_client_info, with_timeout]] group0_peer_exchange (std::vector<raft::server_address> peers) -> service::group0_peer_exchange;
+verb [[with_client_info, with_timeout]] group0_modify_config (raft::group_id gid, std::vector<raft::server_address> add, std::vector<raft::server_id> del);
+
 } // namespace raft

--- a/main.cc
+++ b/main.cc
@@ -1002,7 +1002,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             // engine().at_exit([&proxy] { return proxy.stop(); });
 
             raft_gr.start(cfg->check_experimental(db::experimental_features_t::RAFT),
-                std::ref(messaging), std::ref(gossiper), std::ref(feature_service), std::ref(fd)).get();
+                std::ref(messaging), std::ref(gossiper), std::ref(fd)).get();
 
             // gropu0 client exists only on shard 0
             // The client has to be created before `stop_raft` since during

--- a/main.cc
+++ b/main.cc
@@ -1217,7 +1217,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             });
 
             supervisor::notify("starting storage service", true);
-            ss.local().init_messaging_service_part(raft_gr).get();
+            ss.local().init_messaging_service_part().get();
             auto stop_ss_msg = defer_verbose_shutdown("storage service messaging", [&ss] {
                 ss.local().uninit_messaging_service_part().get();
             });

--- a/message/messaging_service.cc
+++ b/message/messaging_service.cc
@@ -994,7 +994,7 @@ future<> messaging_service::send_gossip_echo(msg_addr id, int64_t generation_num
     return send_message_timeout<void>(this, messaging_verb::GOSSIP_ECHO, std::move(id), timeout, generation_number);
 }
 future<> messaging_service::send_gossip_echo(msg_addr id, int64_t generation_number, abort_source& as) {
-    return send_message_abortable<void>(this, messaging_verb::GOSSIP_ECHO, std::move(id), as, generation_number);
+    return send_message_cancellable<void>(this, messaging_verb::GOSSIP_ECHO, std::move(id), as, generation_number);
 }
 
 void messaging_service::register_gossip_shutdown(std::function<rpc::no_wait_type (inet_address from, rpc::optional<int64_t> generation_number)>&& func) {

--- a/message/messaging_service.cc
+++ b/message/messaging_service.cc
@@ -1226,28 +1226,6 @@ future<node_ops_cmd_response> messaging_service::send_node_ops_cmd(msg_addr id, 
     return send_message<future<node_ops_cmd_response>>(this, messaging_verb::NODE_OPS_CMD, std::move(id), std::move(req));
 }
 
-void messaging_service::register_group0_peer_exchange(std::function<future<service::group0_peer_exchange>(const rpc::client_info&, rpc::opt_time_point, std::vector<raft::server_address>)>&& func) {
-   register_handler(this, netw::messaging_verb::GROUP0_PEER_EXCHANGE, std::move(func));
-}
-future<> messaging_service::unregister_group0_peer_exchange() {
-   return unregister_handler(netw::messaging_verb::GROUP0_PEER_EXCHANGE);
-}
-future<service::group0_peer_exchange> messaging_service::send_group0_peer_exchange(msg_addr id, clock_type::time_point timeout, const std::vector<raft::server_address>& peers) {
-   return send_message_timeout<service::group0_peer_exchange>(this, messaging_verb::GROUP0_PEER_EXCHANGE, std::move(id), timeout, peers);
-}
-
-void messaging_service::register_group0_modify_config(std::function<future<>(const rpc::client_info&, rpc::opt_time_point, raft::group_id gid, std::vector<raft::server_address> add, std::vector<raft::server_id> del)>&& func) {
-   register_handler(this, netw::messaging_verb::GROUP0_MODIFY_CONFIG, std::move(func));
-}
-
-future<> messaging_service::unregister_group0_modify_config() {
-   return unregister_handler(netw::messaging_verb::GROUP0_MODIFY_CONFIG);
-}
-
-future<> messaging_service::send_group0_modify_config(msg_addr id, clock_type::time_point timeout, raft::group_id gid, const std::vector<raft::server_address>& add, const std::vector<raft::server_id>& del) {
-   return send_message_timeout<void>(this, messaging_verb::GROUP0_MODIFY_CONFIG, std::move(id), timeout, std::move(gid), add, del);
-}
-
 void init_messaging_service(sharded<messaging_service>& ms,
                 messaging_service::config mscfg, netw::messaging_service::scheduling_config scfg, const db::config& db_config) {
     using encrypt_what = messaging_service::encrypt_what;

--- a/message/messaging_service.hh
+++ b/message/messaging_service.hh
@@ -108,20 +108,6 @@ class group0_peer_exchange;
 
 }
 
-namespace raft {
-
-namespace internal {
-
-template <typename T> class tagged_id;
-
-}
-
-class server_address;
-using group_id = internal::tagged_id<struct group_id_tag>;
-using server_id = internal::tagged_id<struct server_id_tag>;
-
-}
-
 namespace netw {
 
 /* All verb handler identifiers */
@@ -507,15 +493,6 @@ public:
     void register_replication_finished(std::function<future<> (inet_address from)>&& func);
     future<> unregister_replication_finished();
     future<> send_replication_finished(msg_addr id, inet_address from);
-
-    // RAFT verbs
-    void register_group0_peer_exchange(std::function<future<service::group0_peer_exchange> (const rpc::client_info&, rpc::opt_time_point, std::vector<raft::server_address>)>&& func);
-    future<> unregister_group0_peer_exchange();
-    future<service::group0_peer_exchange> send_group0_peer_exchange(msg_addr id, clock_type::time_point timeout, const std::vector<raft::server_address>& peers);
-
-    void register_group0_modify_config(std::function<future<>(const rpc::client_info&, rpc::opt_time_point, raft::group_id gid, std::vector<raft::server_address> add, std::vector<raft::server_id> del)>&& func);
-    future<> unregister_group0_modify_config();
-    future<> send_group0_modify_config(msg_addr id, clock_type::time_point timeout, raft::group_id gid, const std::vector<raft::server_address>& add, const std::vector<raft::server_id>& del);
 
     void foreach_server_connection_stats(std::function<void(const rpc::client_info&, const rpc::stats&)>&& f) const;
 private:

--- a/message/rpc_protocol_impl.hh
+++ b/message/rpc_protocol_impl.hh
@@ -177,9 +177,11 @@ auto send_message_timeout(messaging_service* ms, messaging_verb verb, msg_addr i
     });
 }
 
+// Requesting abort on the provided abort_source drops the message from the outgoing queue (if it's still there)
+// and causes the returned future to resolve exceptionally with `abort_requested_exception`.
 // TODO: Remove duplicated code in send_message
 template <typename MsgIn, typename... MsgOut>
-auto send_message_abortable(messaging_service* ms, messaging_verb verb, msg_addr id, abort_source& as, MsgOut&&... msg) {
+auto send_message_cancellable(messaging_service* ms, messaging_verb verb, msg_addr id, abort_source& as, MsgOut&&... msg) {
     auto rpc_handler = ms->rpc()->make_client<MsgIn(MsgOut...)>(verb);
     if (ms->is_shutting_down()) {
         using futurator = futurize<std::result_of_t<decltype(rpc_handler)(rpc_protocol::client&, MsgOut...)>>;

--- a/message/rpc_protocol_impl.hh
+++ b/message/rpc_protocol_impl.hh
@@ -227,7 +227,7 @@ auto send_message_oneway(messaging_service* ms, messaging_verb verb, msg_addr id
 
 // Send one way message for verb
 template <typename Timeout, typename... MsgOut>
-auto send_message_oneway_timeout(messaging_service* ms, Timeout timeout, messaging_verb verb, msg_addr id, MsgOut&&... msg) {
+auto send_message_oneway_timeout(messaging_service* ms, messaging_verb verb, msg_addr id, Timeout timeout, MsgOut&&... msg) {
     return send_message_timeout<rpc::no_wait_type>(ms, std::move(verb), std::move(id), timeout, std::forward<MsgOut>(msg)...);
 }
 

--- a/service/migration_manager.cc
+++ b/service/migration_manager.cc
@@ -132,7 +132,7 @@ void migration_manager::init_messaging_service()
         auto features = self._feat.cluster_schema_features();
         auto& proxy = self._storage_proxy.container();
         auto cm = co_await db::schema_tables::convert_schema_to_mutations(proxy, features);
-        if (self.is_raft_enabled() && options->group0_snapshot_transfer) {
+        if (options->group0_snapshot_transfer) {
             // if `group0_snapshot_transfer` is `true`, the sender must also understand canonical mutations
             // (`group0_snapshot_transfer` was added more recently).
             if (!cm_retval_supported) {

--- a/service/raft/messaging.hh
+++ b/service/raft/messaging.hh
@@ -7,10 +7,13 @@
  */
 #pragma once
 #include "raft/raft.hh"
-/////////////////////////////////////////
-// Discovery RPC supporting message types
+#include "gms/inet_address.hh"
 
 namespace service {
+
+gms::inet_address raft_addr_to_inet_addr(const raft::server_info&);
+gms::inet_address raft_addr_to_inet_addr(const raft::server_address&);
+raft::server_info inet_addr_to_raft_addr(const gms::inet_address&);
 
 // Used in a bootstrapped Scylla cluster, provides group  0
 // identifier and the current group leader address.

--- a/service/raft/raft_group0.cc
+++ b/service/raft/raft_group0.cc
@@ -79,14 +79,16 @@ raft_server_for_group raft_group0::create_server_for_group(raft::group_id gid,
     _raft_gr.address_map().set(my_addr);
     auto state_machine = std::make_unique<group0_state_machine>(_client, _mm, _qp.proxy());
     auto rpc = std::make_unique<raft_rpc>(*state_machine, _ms, _raft_gr.address_map(), gid, my_addr.id,
-            [this] (gms::inet_address addr, bool added) {
+            [this] (gms::inet_address addr, raft::server_id raft_id, bool added) {
                 // FIXME: we should eventually switch to UUID-based (not IP-based) node identification/communication scheme.
                 // See #6403.
-                auto id = _gossiper.get_direct_fd_pinger().allocate_id(addr);
+                auto fd_id = _gossiper.get_direct_fd_pinger().allocate_id(addr);
                 if (added) {
-                    _raft_gr.direct_fd().add_endpoint(id);
+                    rslog.info("Added {} (address: {}) to group 0 RPC map", raft_id, addr);
+                    _raft_gr.direct_fd().add_endpoint(fd_id);
                 } else {
-                    _raft_gr.direct_fd().remove_endpoint(id);
+                    rslog.info("Removed {} (address: {}) from group 0 RPC map", raft_id, addr);
+                    _raft_gr.direct_fd().remove_endpoint(fd_id);
                 }
             });
     // Keep a reference to a specific RPC class.

--- a/service/raft/raft_group0.hh
+++ b/service/raft/raft_group0.hh
@@ -110,6 +110,9 @@ public:
     // it can't do it by itself (it's dead).
     future<> leave_group0(std::optional<gms::inet_address> host = {});
 
+    void init_rpc_verbs();
+    future<> uninit_rpc_verbs();
+
     // Handle peer_exchange RPC
     future<group0_peer_exchange> peer_exchange(discovery::peer_list peers);
 };

--- a/service/raft/raft_group_registry.cc
+++ b/service/raft/raft_group_registry.cc
@@ -11,7 +11,6 @@
 #include "gms/gossiper.hh"
 #include "serializer_impl.hh"
 #include "idl/raft.dist.hh"
-#include "gms/feature_service.hh"
 #include "gms/gossiper.hh"
 
 #include <seastar/core/coroutine.hh>
@@ -66,14 +65,11 @@ public:
 };
 
 raft_group_registry::raft_group_registry(bool is_enabled, netw::messaging_service& ms,
-        gms::gossiper& gossiper, gms::feature_service& feat, direct_failure_detector::failure_detector& fd)
+        gms::gossiper& gossiper, direct_failure_detector::failure_detector& fd)
     : _is_enabled(is_enabled)
     , _ms(ms)
     , _direct_fd(fd)
     , _direct_fd_proxy(make_shared<direct_fd_proxy>(gossiper.get_direct_fd_pinger(), _srv_address_mappings))
-    , _raft_support_listener(feat.uses_raft_cluster_mgmt.when_enabled([] {
-        // TODO: join group 0 on upgrade
-    }))
 {
 }
 

--- a/service/raft/raft_group_registry.cc
+++ b/service/raft/raft_group_registry.cc
@@ -244,11 +244,18 @@ raft_rpc& raft_group_registry::get_rpc(raft::group_id gid) {
 }
 
 raft::server& raft_group_registry::get_server(raft::group_id gid) {
-    return *(server_for_group(gid).server);
+    auto ptr = server_for_group(gid).server.get();
+    if (!ptr) {
+        on_internal_error(rslog, format("get_server(): no server for group {}", gid));
+    }
+    return *ptr;
 }
 
 raft::server& raft_group_registry::group0() {
-    return *(server_for_group(*_group0_id).server);
+    if (!_group0_id) {
+        on_internal_error(rslog, "group0(): _group0_id not present");
+    }
+    return get_server(*_group0_id);
 }
 
 future<> raft_group_registry::start_server_for_group(raft_server_for_group new_grp) {

--- a/service/raft/raft_group_registry.hh
+++ b/service/raft/raft_group_registry.hh
@@ -18,7 +18,7 @@
 #include "gms/feature.hh"
 #include "direct_failure_detector/failure_detector.hh"
 
-namespace gms { class gossiper; class feature_service; }
+namespace gms { class gossiper; }
 
 namespace service {
 
@@ -74,11 +74,9 @@ private:
     // Group 0 id, valid only on shard 0 after boot is over
     std::optional<raft::group_id> _group0_id;
 
-    gms::feature::listener_registration _raft_support_listener;
-
 public:
-    raft_group_registry(bool is_enabled, netw::messaging_service& ms, gms::gossiper& gs,
-            gms::feature_service& feat, direct_failure_detector::failure_detector& fd);
+    // `is_enabled` must be `true` iff the local RAFT feature is enabled.
+    raft_group_registry(bool is_enabled, netw::messaging_service& ms, gms::gossiper& gs, direct_failure_detector::failure_detector& fd);
     ~raft_group_registry();
 
     // Called manually at start

--- a/service/raft/raft_rpc.hh
+++ b/service/raft/raft_rpc.hh
@@ -26,7 +26,7 @@ class raft_rpc : public raft::rpc {
     raft::server_id _server_id;
     netw::messaging_service& _messaging;
     raft_address_map<>& _address_map;
-    noncopyable_function<void(gms::inet_address, bool added)> _on_server_update;
+    noncopyable_function<void(gms::inet_address, raft::server_id, bool added)> _on_server_update;
     seastar::gate _shutdown_gate;
 
     raft_ticker_type::time_point timeout() {
@@ -37,7 +37,7 @@ public:
     explicit raft_rpc(raft_state_machine& sm, netw::messaging_service& ms,
             raft_address_map<>& address_map, raft::group_id gid, raft::server_id srv_id,
             // Called when a server is added or removed from the RPC configuration.
-            noncopyable_function<void(gms::inet_address, bool added)> on_server_update);
+            noncopyable_function<void(gms::inet_address, raft::server_id, bool added)> on_server_update);
 
     future<raft::snapshot_reply> send_snapshot(raft::server_id server_id, const raft::install_snapshot& snap, seastar::abort_source& as) override;
     future<> send_append_entries(raft::server_id id, const raft::append_request& append_request) override;

--- a/service/raft/raft_rpc.hh
+++ b/service/raft/raft_rpc.hh
@@ -16,16 +16,6 @@
 
 namespace service {
 
-inline gms::inet_address
-raft_addr_to_inet_addr(const raft::server_address& addr) {
-    return ser::deserialize_from_buffer(addr.info, boost::type<gms::inet_address>{});
-}
-
-inline bytes
-inet_addr_to_raft_addr(gms::inet_address addr) {
-    return ser::serialize_to_buffer<bytes>(addr);
-}
-
 // Scylla-specific implementation of raft RPC module.
 //
 // Uses `netw::messaging_service` as an underlying implementation for

--- a/service/raft/raft_sys_table_storage.cc
+++ b/service/raft/raft_sys_table_storage.cc
@@ -5,6 +5,7 @@
 /*
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
+#include "service/raft/messaging.hh"
 #include "service/raft/raft_sys_table_storage.hh"
 
 #include "cql3/untyped_result_set.hh"
@@ -170,13 +171,13 @@ future<> raft_sys_table_storage::store_snapshot_descriptor(const raft::snapshot_
         for (const raft::server_address& srv_addr : snap.config.current) {
             co_await _qp.execute_internal(store_raft_cfg_cql,
                 {_group_id.id, _server_id.id, srv_addr.id.id, "CURRENT", srv_addr.can_vote,
-                    ser::deserialize_from_buffer(srv_addr.info, boost::type<gms::inet_address>()).addr()},
+                    raft_addr_to_inet_addr(srv_addr).addr()},
                     cql3::query_processor::cache_internal::yes);
         }
         for (const raft::server_address& srv_addr : snap.config.previous) {
             co_await _qp.execute_internal(store_raft_cfg_cql,
                 {_group_id.id, _server_id.id, srv_addr.id.id, "PREVIOUS", srv_addr.can_vote,
-                    ser::deserialize_from_buffer(srv_addr.info, boost::type<gms::inet_address>()).addr()},
+                    raft_addr_to_inet_addr(srv_addr).addr()},
                     cql3::query_processor::cache_internal::yes);
         }
         // Also update the latest snapshot id in `system.raft` table

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -47,9 +47,6 @@ class node_ops_cmd_response;
 class node_ops_info;
 enum class node_ops_cmd : uint32_t;
 class repair_service;
-namespace service {
-class raft_group_registry;
-}
 
 namespace cql3 { class query_processor; }
 
@@ -187,7 +184,7 @@ public:
 
     // Needed by distributed<>
     future<> stop();
-    void init_messaging_service(raft_group_registry& raft_gr);
+    void init_messaging_service();
     future<> uninit_messaging_service();
 
 private:
@@ -327,7 +324,7 @@ public:
      * API.
      * \see init_server_without_the_messaging_service_part
      */
-    future<> init_messaging_service_part(sharded<raft_group_registry>& raft_gr);
+    future<> init_messaging_service_part();
     /*!
      * \brief Uninit the messaging service part of the service.
      */

--- a/test/boost/cdc_test.cc
+++ b/test/boost/cdc_test.cc
@@ -751,28 +751,6 @@ SEASTAR_THREAD_TEST_CASE(test_add_columns) {
     }).get();
 }
 
-// #5582 - just quickly test that we can create the cdc enabled table on a different shard
-// and still get the logs proper.
-SEASTAR_THREAD_TEST_CASE(test_cdc_across_shards) {
-    do_with_cql_env_thread([](cql_test_env& e) {
-        if (smp::count < 2) {
-            testlog.warn("This test case requires at least 2 shards");
-            return;
-        }
-        smp::submit_to(1, [&e] {
-            // this is actually ok. there is no members of cql_test_env actually used in call
-            return seastar::async([&] {
-                cquery_nofail(e, "CREATE TABLE ks.tbl (pk int, pk2 int, ck int, ck2 int, val int, PRIMARY KEY((pk, pk2), ck, ck2)) WITH cdc = {'enabled':'true'}");
-            });
-        }).get();
-        cquery_nofail(e, "INSERT INTO ks.tbl(pk, pk2, ck, ck2, val) VALUES(1, 11, 111, 1111, 11111)");
-
-        auto rows = select_log(e, "tbl");
-
-        BOOST_REQUIRE(!to_bytes_filtered(*rows, cdc::operation::insert).empty());
-    }).get();
-}
-
 SEASTAR_THREAD_TEST_CASE(test_negative_ttl_fail) {
     do_with_cql_env_thread([](cql_test_env& e) {
         BOOST_REQUIRE_EXCEPTION(e.execute_cql("CREATE TABLE ks.fail (a int PRIMARY KEY, b int) WITH cdc = {'enabled':true,'ttl':'-1'}").get0(),

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -62,6 +62,7 @@
 #include "debug.hh"
 #include "db/schema_tables.hh"
 #include "service/raft/raft_group0_client.hh"
+#include "service/raft/raft_group0.hh"
 
 #include <sys/time.h>
 #include <sys/resource.h>
@@ -781,8 +782,15 @@ public:
                 cdc.stop().get();
             });
 
+            service::raft_group0 group0_service{
+                    abort_sources.local(), raft_gr.local(), ms.local(),
+                    gossiper.local(), qp.local(), mm.local(), group0_client};
+            auto stop_group0_service = defer([&group0_service] {
+                group0_service.abort().get();
+            });
+
             try {
-                ss.local().join_cluster(qp.local(), group0_client, cdc_generation_service.local(), sys_dist_ks, proxy, raft_gr.local()).get();
+                ss.local().join_cluster(cdc_generation_service.local(), sys_dist_ks, proxy, group0_service).get();
             } catch (std::exception& e) {
                 // if any of the defers crashes too, we'll never see
                 // the error

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -616,7 +616,7 @@ public:
             });
 
             raft_gr.start(cfg->check_experimental(db::experimental_features_t::RAFT),
-                std::ref(ms), std::ref(gossiper), std::ref(feature_service), std::ref(fd)).get();
+                std::ref(ms), std::ref(gossiper), std::ref(fd)).get();
             auto stop_raft_gr = deferred_stop(raft_gr);
             raft_gr.invoke_on_all(&service::raft_group_registry::start).get();
 


### PR DESCRIPTION
The commits here were extracted from PR https://github.com/scylladb/scylla/pull/10835 which implements upgrade procedure for Raft group 0.

They are mostly refactors which don't affect the behavior of the system, except one: the commit https://github.com/scylladb/scylla/commit/4d439a16b31ce4cddd0052320c9c5893dec38390 causes all schema changes to be bounced to shard 0. Previously, they would only be bounced when the local Raft feature was enabled. I do that because:
1. eventually, we want this to be the default behavior
2. in the upgrade PR I remove the `is_raft_enabled()` function - the function was basically created with the mindset "Raft is either enabled or not" - which was right when we didn't support upgrade, but will be incorrect when we introduce intermediate states (when we upgrade from non-raft-based to raft-based operations); the upgrade PR introduces another mechanism to dispatch based on the upgrade state, but for the case of bouncing to shard 0, dispatching is simply not necessary.