### PR TITLE
build: "dev" build should be without any debug symbols

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -322,7 +322,7 @@ modes = {
     },
     'dev': {
         'cxxflags': '-DDEVEL -DSEASTAR_ENABLE_ALLOC_FAILURE_INJECTION -DSCYLLA_ENABLE_ERROR_INJECTION',
-        'cxx_ld_flags': '',
+        'cxx_ld_flags': '-Wl,--strip-debug',
         'stack-usage-threshold': 1024*21,
         'optimization-level': '2',
         'per_src_extra_cxxflags': {},


### PR DESCRIPTION
Our "dev" build mode builds Scylla without any debug symbols.
"file build/dev/scylla" should not say "with debug_info", and
"readelf -wl build/dev/scylla" should output nothing. Trying to
debug it with "gdb" should complain that the debug symbols are
missing.

However, recently we started fetching a pre-compiled library
libwasmtime.a and linking it into Scylla. It turns out that unlike
most libraries, this library was compiled with some debug symbols.
When we link it into Scylla, the result falsely claims that it has
debug symbols -  although it doesn't really have debug symbols for
any symbol we care about for debugging Scylla.

So in this patch, we add the --strip-debug linking option to the "dev"
build. Any debugging symbols that came in from libwasmtime.a are
removed from the final executable (the Scylla code itself already
has no debug symbols in the "dev" build, so nothing needs to be
removed from it).

Fixes #10863.

Signed-off-by: Nadav Har'El <nyh@scylladb.com>