### PR TITLE
Submodules: allow "Scylla only" fork

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,23 +1,23 @@
 [submodule "seastar"]
 	path = seastar
-	url = ../seastar
+	url = ../../scylladb/seastar
 	ignore = dirty
 [submodule "swagger-ui"]
 	path = swagger-ui
-	url = ../scylla-swagger-ui
+	url = ../../scylladb/scylla-swagger-ui
 	ignore = dirty
 [submodule "libdeflate"]
 	path = libdeflate
-	url = ../libdeflate
+	url = ../../scylladb/libdeflate
 [submodule "abseil"]
 	path = abseil
-	url = ../abseil-cpp
+	url = ../../scylladb/abseil-cpp
 [submodule "scylla-jmx"]
 	path = tools/jmx
-	url = ../scylla-jmx
+	url = ../../scylladb/scylla-jmx
 [submodule "scylla-tools"]
 	path = tools/java
-	url = ../scylla-tools-java
+	url = ../../scylladb/scylla-tools-java
 [submodule "scylla-python3"]
 	path = tools/python3
-	url = ../scylla-python3
+	url = ../../scylladb/scylla-python3


### PR DESCRIPTION
When scylla is forked, the modules are referenced in such a way that
forces forking all of the corresponding submodules too.
This commit changes this by directing the submodules at scylladb repos
instead of the sepcific user.

Tests:
Cloning scylla with ssh and https protocols and making sure the
submodules are checked out correctly (from scylladb).

Signed-off-by: Eliran Sinvani <eliransin@scylladb.com>