### PR TITLE
main.cc: add trailing backslash to the API directories

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -676,7 +676,15 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             utils::fb_utilities::set_broadcast_rpc_address(broadcast_rpc_addr);
 
             ctx.api_dir = cfg->api_ui_dir();
+            if (!ctx.api_dir.empty() && ctx.api_dir.back() != '/') {
+                // The api_dir should end with a backslash, add it if it's missing
+                ctx.api_dir.append("/", 1);
+            }
             ctx.api_doc = cfg->api_doc_dir();
+            if (!ctx.api_doc.empty() && ctx.api_doc.back() != '/') {
+                // The api_doc should end with a backslash, add it if it's missing
+                ctx.api_doc.append("/", 1);
+            }
             const auto hinted_handoff_enabled = cfg->hinted_handoff_enabled();
 
             supervisor::notify("starting prometheus API server");


### PR DESCRIPTION
The API uses the http server to serve two directories: the api_ui_dir
where the swagger-ui directory is found and the api_doc_dir where the
swagger definition files are found.

Internally, the API uses the httpd::directory_handler that append the
files it gets from the path to the base directory name.
A user can override the default configuration and set a directory name
that will not end with a backslash. This will result with files not
found.

This patch check if that backslash is missing, and if it is, adds it to
the API configuration.

Fixes #10700

Signed-off-by: Amnon Heiman <amnon@scylladb.com>