### PR TITLE
compaction_manager: task: acquire_semaphore: handle abort_requested_exception

### DIFF
--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -565,7 +565,7 @@ sstables::shared_sstable compaction_manager::sstables_task::consume_sstable() {
 }
 
 future<semaphore_units<named_semaphore_exception_factory>> compaction_manager::task::acquire_semaphore(named_semaphore& sem, size_t units) {
-    return seastar::get_units(sem, units, _compaction_data.abort).handle_exception_type([this] (const semaphore_aborted& e) {
+    return seastar::get_units(sem, units, _compaction_data.abort).handle_exception_type([this] (const abort_requested_exception& e) {
         auto s = _compacting_table->schema();
         return make_exception_future<semaphore_units<named_semaphore_exception_factory>>(
                 sstables::compaction_stopped_exception(s->ks_name(), s->cf_name(), e.what()));


### PR DESCRIPTION
Change 8f39547d89991dc251256fc9a57b3eeea5175e2b added
`handle_exception_type([] (const semaphore_aborted& e) {})`,
but it turned out that `named_semaphore_aborted` isn't
derived from `semaphore_aborted`, but rather from
`abort_requested_exception` so handle the base exception
instead.

Fixes #10666

Signed-off-by: Benny Halevy <bhalevy@scylladb.com>