### PR TITLE
repair_reader: construct _reader_handle before _reader

### DIFF
--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -270,9 +270,9 @@ private:
     // Only needed for local readers, the multishard reader takes care
     // of pinning tables on used shards.
     std::optional<utils::phased_barrier::operation> _local_read_op;
+    std::optional<evictable_reader_handle_v2> _reader_handle;
     // Fragment stream of either local or multishard reader for the range
     mutation_fragment_v1_stream _reader;
-    std::optional<evictable_reader_handle_v2> _reader_handle;
     // Current partition read from disk
     lw_shared_ptr<const decorated_key_with_hash> _current_dk;
     uint64_t _reads_issued = 0;


### PR DESCRIPTION
Currently, the `_reader` member is explicitly
initialized with the result of the call to `make_reader`.
And `make_reader`, as a side effect, assigns a value
to the `_reader_handle` member.
    
Since C++ initializes class members sequentially,
in the order they are defined, the assignment to `_reader_handle`
in `make_reader()` happens before `_reader_handle` is initialized.
    
This patch fixes that by changing the definition order,
and consequently, the member initialization order
in the constructor so that `_reader_handle` will be (default-)initialized
before the call to `make_reader()`, avoiding the undefined behavior.
    
Fixes #10882

Signed-off-by: Benny Halevy <bhalevy@scylladb.com>