### PR TITLE
transport: fix enum-class which is no longer printable by fmt

### DIFF
--- a/transport/cql_protocol_extension.cc
+++ b/transport/cql_protocol_extension.cc
@@ -33,7 +33,7 @@ std::vector<seastar::sstring> additional_options_for_proto_ext(cql_protocol_exte
         case cql_protocol_extension::LWT_ADD_METADATA_MARK:
             return {format("LWT_OPTIMIZATION_META_BIT_MASK={:d}", cql3::prepared_metadata::LWT_FLAG_MASK)};
         case cql_protocol_extension::RATE_LIMIT_ERROR:
-            return {format("ERROR_CODE={:d}", exceptions::exception_code::RATE_LIMIT_ERROR)};
+            return {format("ERROR_CODE={:d}", (int)exceptions::exception_code::RATE_LIMIT_ERROR)};
         default:
             return {};
     }


### PR DESCRIPTION
Starting with version 8.1 of fmt, one can no longer print an enum
class and assume automatic conversion to the integer underlying type.
See https://github.com/fmtlib/fmt/issues/1841 for this change.

In this patch we fix the one place where we assumed this implicit
conversion works, and make the conversion explicit.

Fixes #10884

Signed-off-by: Nadav Har'El <nyh@scylladb.com>