### PR TITLE
test: perf: allow testing timeouts in perf_simple_query

### DIFF
--- a/test/perf/perf.cc
+++ b/test/perf/perf.cc
@@ -49,8 +49,8 @@ std::ostream& operator<<(std::ostream& out, const scheduling_latency_measurer& s
 
 std::ostream&
 operator<<(std::ostream& os, const perf_result& result) {
-    fmt::print(os, "{:.2f} tps ({:5.1f} allocs/op, {:5.1f} tasks/op, {:7.0f} insns/op)",
-            result.throughput, result.mallocs_per_op, result.tasks_per_op, result.instructions_per_op);
+    fmt::print(os, "{:.2f} tps ({:5.1f} allocs/op, {:5.1f} tasks/op, {:7.0f} insns/op, {:8} errors)",
+            result.throughput, result.mallocs_per_op, result.tasks_per_op, result.instructions_per_op, result.errors);
     return os;
 }
 
@@ -65,8 +65,8 @@ void aio_writes_result_mixin::update(aio_writes_result_mixin& result, const exec
 }
 
 std::ostream& operator<<(std::ostream& os, const perf_result_with_aio_writes& result) {
-    fmt::print(os, "{:.2f} tps ({:5.1f} allocs/op, {:5.1f} tasks/op, {:7.0f} insns/op, {:7.2f} bytes/op, {:5.1f} writes/op)",
-            result.throughput, result.mallocs_per_op, result.tasks_per_op, result.instructions_per_op, result.aio_write_bytes, result.aio_writes);
+    fmt::print(os, "{:.2f} tps ({:5.1f} allocs/op, {:5.1f} tasks/op, {:7.0f} insns/op, {:8} errors, {:7.2f} bytes/op, {:5.1f} writes/op)",
+            result.throughput, result.mallocs_per_op, result.tasks_per_op, result.instructions_per_op, result.errors, result.aio_write_bytes, result.aio_writes);
     return os;
 }
 

--- a/test/perf/perf.hh
+++ b/test/perf/perf.hh
@@ -89,12 +89,10 @@ class executor {
 private:
     executor_shard_stats executor_shard_stats_snapshot();
     future<> run_worker() {
-        return do_until([this] {
-            return _end_at_count ? _count == _end_at_count : lowres_clock::now() >= _end_at;
-        }, [this] () mutable {
+        while (_end_at_count ? _count < _end_at_count : lowres_clock::now() < _end_at) {
             ++_count;
-            return _func();
-        });
+            co_await _func();
+        }
     }
 public:
     executor(unsigned n_workers, Func func, lowres_clock::time_point end_at, uint64_t end_at_count = 0)

--- a/test/perf/perf_commitlog.cc
+++ b/test/perf/perf_commitlog.cc
@@ -146,7 +146,7 @@ static std::vector<clperf_result> do_commitlog_test(distributed<commitlog_servic
         }).then([](db::rp_handle h) {
             h.release();
         });
-    }, cfg.concurrency, cfg.duration_in_seconds, cfg.operations_per_shard, &clperf_result::update);
+    }, cfg.concurrency, cfg.duration_in_seconds, cfg.operations_per_shard, true, &clperf_result::update);
 }
 
 int main(int argc, char** argv) {

--- a/test/perf/perf_simple_query.cc
+++ b/test/perf/perf_simple_query.cc
@@ -72,6 +72,7 @@ struct test_config {
     bool flush_memtables;
     unsigned operations_per_shard = 0;
     bool stop_on_error;
+    sstring timeout;
 };
 
 std::ostream& operator<<(std::ostream& os, const test_config::run_mode& m) {
@@ -127,7 +128,11 @@ static bytes make_random_key(test_config& cfg) {
 
 static std::vector<perf_result> test_read(cql_test_env& env, test_config& cfg) {
     create_partitions(env, cfg);
-    auto id = env.prepare("select \"C0\", \"C1\", \"C2\", \"C3\", \"C4\" from cf where \"KEY\" = ?").get0();
+    sstring query = "select \"C0\", \"C1\", \"C2\", \"C3\", \"C4\" from cf where \"KEY\" = ?";
+    if (!cfg.timeout.empty()) {
+        query += " using timeout " + cfg.timeout;
+    }
+    auto id = env.prepare(query).get0();
     return time_parallel([&env, &cfg, id] {
             bytes key = make_random_key(cfg);
             return env.execute_prepared(id, {{cql3::raw_value::make_value(std::move(key))}}).discard_result();
@@ -135,13 +140,18 @@ static std::vector<perf_result> test_read(cql_test_env& env, test_config& cfg) {
 }
 
 static std::vector<perf_result> test_write(cql_test_env& env, test_config& cfg) {
-    auto id = env.prepare("UPDATE cf SET "
-                           "\"C0\" = 0x8f75da6b3dcec90c8a404fb9a5f6b0621e62d39c69ba5758e5f41b78311fbb26cc7a,"
-                           "\"C1\" = 0xa8761a2127160003033a8f4f3d1069b7833ebe24ef56b3beee728c2b686ca516fa51,"
-                           "\"C2\" = 0x583449ce81bfebc2e1a695eb59aad5fcc74d6d7311fc6197b10693e1a161ca2e1c64,"
-                           "\"C3\" = 0x62bcb1dbc0ff953abc703bcb63ea954f437064c0c45366799658bd6b91d0f92908d7,"
-                           "\"C4\" = 0x222fcbe31ffa1e689540e1499b87fa3f9c781065fccd10e4772b4c7039c2efd0fb27 "
-                           "WHERE \"KEY\" = ?;").get0();
+    sstring usings;
+    if (!cfg.timeout.empty()) {
+        usings += "USING TIMEOUT " + cfg.timeout;
+    }
+    sstring query = format("UPDATE cf {}SET "
+            "\"C0\" = 0x8f75da6b3dcec90c8a404fb9a5f6b0621e62d39c69ba5758e5f41b78311fbb26cc7a,"
+            "\"C1\" = 0xa8761a2127160003033a8f4f3d1069b7833ebe24ef56b3beee728c2b686ca516fa51,"
+            "\"C2\" = 0x583449ce81bfebc2e1a695eb59aad5fcc74d6d7311fc6197b10693e1a161ca2e1c64,"
+            "\"C3\" = 0x62bcb1dbc0ff953abc703bcb63ea954f437064c0c45366799658bd6b91d0f92908d7,"
+            "\"C4\" = 0x222fcbe31ffa1e689540e1499b87fa3f9c781065fccd10e4772b4c7039c2efd0fb27 "
+            "WHERE \"KEY\" = ?", usings);
+    auto id = env.prepare(query).get0();
     return time_parallel([&env, &cfg, id] {
             bytes key = make_random_key(cfg);
             return env.execute_prepared(id, {{cql3::raw_value::make_value(std::move(key))}}).discard_result();
@@ -150,7 +160,12 @@ static std::vector<perf_result> test_write(cql_test_env& env, test_config& cfg) 
 
 static std::vector<perf_result> test_delete(cql_test_env& env, test_config& cfg) {
     create_partitions(env, cfg);
-    auto id = env.prepare("DELETE \"C0\", \"C1\", \"C2\", \"C3\", \"C4\" FROM cf WHERE \"KEY\" = ?").get0();
+    sstring usings;
+    if (!cfg.timeout.empty()) {
+        usings += "USING TIMEOUT " + cfg.timeout;
+    }
+    sstring query = format("DELETE \"C0\", \"C1\", \"C2\", \"C3\", \"C4\" FROM cf {}WHERE \"KEY\" = ?", usings);
+    auto id = env.prepare(query).get0();
     return time_parallel([&env, &cfg, id] {
             bytes key = make_random_key(cfg);
             return env.execute_prepared(id, {{cql3::raw_value::make_value(std::move(key))}}).discard_result();
@@ -158,13 +173,18 @@ static std::vector<perf_result> test_delete(cql_test_env& env, test_config& cfg)
 }
 
 static std::vector<perf_result> test_counter_update(cql_test_env& env, test_config& cfg) {
-    auto id = env.prepare("UPDATE cf SET "
-                           "\"C0\" = \"C0\" + 1,"
-                           "\"C1\" = \"C1\" + 2,"
-                           "\"C2\" = \"C2\" + 3,"
-                           "\"C3\" = \"C3\" + 4,"
-                           "\"C4\" = \"C4\" + 5 "
-                           "WHERE \"KEY\" = ?;").get0();
+    sstring usings;
+    if (!cfg.timeout.empty()) {
+        usings += "USING TIMEOUT " + cfg.timeout;
+    }
+    sstring query = format("UPDATE cf {}SET "
+            "\"C0\" = \"C0\" + 1,"
+            "\"C1\" = \"C1\" + 2,"
+            "\"C2\" = \"C2\" + 3,"
+            "\"C3\" = \"C3\" + 4,"
+            "\"C4\" = \"C4\" + 5 "
+            "WHERE \"KEY\" = ?", usings);
+    auto id = env.prepare(query).get0();
     return time_parallel([&env, &cfg, id] {
             bytes key = make_random_key(cfg);
             return env.execute_prepared(id, {{cql3::raw_value::make_value(std::move(key))}}).discard_result();
@@ -493,6 +513,7 @@ int main(int argc, char** argv) {
         ("enable-cache", bpo::value<bool>()->default_value(true), "enable row cache")
         ("alternator", bpo::value<std::string>(), "use alternator frontend instead of CQL with given write isolation")
         ("stop-on-error", bpo::value<bool>()->default_value(true), "stop after encountering the first error")
+        ("timeout", bpo::value<std::string>()->default_value(""), "use timeout")
         ;
 
     set_abort_on_internal_error(true);
@@ -537,6 +558,7 @@ int main(int argc, char** argv) {
                 cfg.operations_per_shard = app.configuration()["operations-per-shard"].as<unsigned>();
             }
             cfg.stop_on_error = app.configuration()["stop-on-error"].as<bool>();
+            cfg.timeout = app.configuration()["timeout"].as<std::string>();
             auto results = cfg.frontend == test_config::frontend_type::cql
                     ? do_cql_test(env, cfg)
                     : do_alternator_test(app.configuration()["alternator"].as<std::string>(),


### PR DESCRIPTION
This PR adds necessary modifications to perf_simple_query so that it can be used to test performance of the timeout handling path. With an appropriate combination of flags, it is possible to consistently trigger timeouts on every operation.

The following flags are added:
- `--stop-on-error` - if true (which is the default), the test stops after encountering the first exception and reports it; otherwise it causes errors to be counted and reported at the end.
- `--timeout <x>` - allows to use `USE TIMEOUT <x>` in the benchmark query/statement.
- `--bypass-cache` - uses `BYPASS CACHE` in the benchmark query (relevant only to reads).

Examples:

```
# Writes without timeouts
./build/release/test/perf/perf_simple_query --smp=1 --operations-per-shard=1000000 --write
131023.65 tps ( 56.2 allocs/op,  13.2 tasks/op,   49784 insns/op,        0 errors)

# Writes with timeouts
./build/release/test/perf/perf_simple_query --smp=1 --operations-per-shard=1000000 --write --stop-on-error=false --timeout=0s
97163.73 tps ( 53.1 allocs/op,   5.1 tasks/op,   78687 insns/op,  1000000 errors)

# Reads without timeouts
./build/release/test/perf/perf_simple_query --smp=1 --operations-per-shard=1000000
154060.36 tps ( 63.1 allocs/op,  12.1 tasks/op,   42998 insns/op,        0 errors)

# Reads with timeouts (+ bypass cache, necessary for consistent timeouts)
./build/release/test/perf/perf_simple_query --smp=1 --operations-per-shard=1000000 --stop-on-error=false --flush --bypass-cache --timeout=0s
30127.43 tps ( 48.2 allocs/op,  14.3 tasks/op,  312416 insns/op,  1000000 errors)
```

Refs: #2363