### PR TITLE
Reads from cache lack preemption check when scanning over range tombstones

### DIFF
--- a/cache_flat_mutation_reader.hh
+++ b/cache_flat_mutation_reader.hh
@@ -851,8 +851,9 @@ inline
 void cache_flat_mutation_reader::do_add_to_buffer(range_tombstone_change&& rtc) {
     clogger.trace("csm {}: push({})", fmt::ptr(this), rtc);
     position_in_partition::less_compare less(*_schema);
+    auto lower_bound_changed = less(_lower_bound, rtc.position());
     _lower_bound = position_in_partition(rtc.position());
-    _lower_bound_changed = less(_lower_bound, rtc.position());
+    _lower_bound_changed = lower_bound_changed;
     push_mutation_fragment(*_schema, _permit, std::move(rtc));
     _read_context.cache()._tracker.on_range_tombstone_read();
 }


### PR DESCRIPTION
A scan over range tombstones will ignore preemption, which may cause
reactor stalls or read failure due to std::bad_alloc.

This is a regression introduced in 5e97fb9fc4508a978525d0a44a23cd30a9736f56.  _lower_bound_changed was
always set to false, which is later checked at preemption point and
inhibits yielding.