### PR TITLE
Implement a number of improvements in test.py

### DIFF
--- a/test.py
+++ b/test.py
@@ -420,7 +420,7 @@ class Test:
         self.suite = suite
         # Unique file name, which is also readable by human, as filename prefix
         self.uname = "{}.{}".format(self.shortname, self.id)
-        self.log_filename = os.path.join(suite.options.tmpdir, self.mode, self.uname + ".log")
+        self.log_filename = pathlib.Path(suite.options.tmpdir) / self.mode / (self.uname + ".log")
         self.is_flaky = self.shortname in suite.flaky_tests
         # True if the test was retried after it failed
         self.is_flaky_failure = False
@@ -453,7 +453,7 @@ class Test:
     def check_log(self, trim):
         """Check and trim logs and xml output for tests which have it"""
         if trim:
-            pathlib.Path(self.log_filename).unlink()
+            self.log_filename.unlink()
         pass
 
 
@@ -784,7 +784,7 @@ class TabularConsoleOutput:
 async def run_test(test, options, gentle_kill=False, env=dict()):
     """Run test program, return True if success else False"""
 
-    with open(test.log_filename, "wb") as log:
+    with test.log_filename.open("wb") as log:
 
         def report_error(error):
             msg = "=== TEST.PY SUMMARY START ===\n"
@@ -1055,10 +1055,10 @@ async def run_all_tests(signaled, options):
     console.print_end_blurb()
 
 
-def read_log(log_filename):
+def read_log(log_filename: pathlib.Path):
     """Intelligently read test log output"""
     try:
-        with open(log_filename, "r") as log:
+        with log_filename.open("r") as log:
             msg = log.read()
             return msg if len(msg) else "===Empty log output==="
     except FileNotFoundError:

--- a/test.py
+++ b/test.py
@@ -35,7 +35,7 @@ from test.pylib.artifact_registry import ArtifactRegistry
 from test.pylib.host_registry import HostRegistry
 from test.pylib.pool import Pool
 from test.pylib.scylla_server import ScyllaServer, ScyllaCluster
-from typing import Dict, List
+from typing import Dict, List, Callable, Any, Iterable, Optional, Awaitable
 
 output_is_a_tty = sys.stdout.isatty()
 
@@ -43,13 +43,13 @@ all_modes = set(['debug', 'release', 'dev', 'sanitize', 'coverage'])
 debug_modes = set(['debug', 'sanitize'])
 
 
-def create_formatter(*decorators):
+def create_formatter(*decorators) -> Callable[[Any], str]:
     """Return a function which decorates its argument with the given
     color/style if stdout is a tty, and leaves intact otherwise."""
-    def color(arg):
+    def color(arg: Any) -> str:
         return "".join(decorators) + str(arg) + colorama.Style.RESET_ALL
 
-    def nocolor(arg):
+    def nocolor(arg: Any) -> str:
         return str(arg)
     return color if output_is_a_tty else nocolor
 
@@ -77,20 +77,20 @@ class TestSuite(ABC):
     E.g. it can be unit tests, boost tests, or CQL tests."""
 
     # All existing test suites, one suite per path/mode.
-    suites: Dict[str, ABC] = dict()
+    suites: Dict[str, 'TestSuite'] = dict()
     artifacts = ArtifactRegistry()
     hosts = HostRegistry()
     FLAKY_RETRIES = 5
     _next_id = 0
 
-    def __init__(self, path, cfg, options, mode):
+    def __init__(self, path: str, cfg: dict, options: argparse.Namespace, mode: str) -> None:
         self.path = path
         self.name = os.path.basename(self.path)
         self.cfg = cfg
         self.options = options
         self.mode = mode
         self.suite_key = os.path.join(path, mode)
-        self.tests = []
+        self.tests: List['Test'] = []
         self.pending_test_count = 0
         # The number of failed tests
         self.n_failed = 0
@@ -120,16 +120,16 @@ class TestSuite(ABC):
             self.disabled_tests.update(skip_in_m - run_in_m)
 
     @property
-    def next_id(self):
+    def next_id(self) -> int:
         TestSuite._next_id += 1
         return TestSuite._next_id
 
     @staticmethod
-    def test_count():
+    def test_count() -> int:
         return TestSuite._next_id
 
     @staticmethod
-    def load_cfg(path):
+    def load_cfg(path: str) -> dict:
         with open(os.path.join(path, "suite.yaml"), "r") as cfg_file:
             cfg = yaml.safe_load(cfg_file.read())
             if not isinstance(cfg, dict):
@@ -137,7 +137,7 @@ class TestSuite(ABC):
             return cfg
 
     @staticmethod
-    def opt_create(path, options, mode):
+    def opt_create(path: str, options: argparse.Namespace, mode: str) -> 'TestSuite':
         """Return a subclass of TestSuite with name cfg["type"].title + TestSuite.
         Ensures there is only one suite instance per path."""
         suite_key = os.path.join(path, mode)
@@ -159,24 +159,25 @@ class TestSuite(ABC):
             if not SpecificTestSuite:
                 raise RuntimeError("Failed to load tests in {}: suite type '{}' not found".format(path, kind))
             suite = SpecificTestSuite(path, cfg, options, mode)
+            assert suite is not None
             TestSuite.suites[suite_key] = suite
         return suite
 
     @staticmethod
-    def all_tests():
+    def all_tests() -> Iterable['Test']:
         return itertools.chain(*[suite.tests for suite in
                                  TestSuite.suites.values()])
 
     @property
     @abstractmethod
-    def pattern(self):
+    def pattern(self) -> str:
         pass
 
     @abstractmethod
-    async def add_test(self, shortname):
+    async def add_test(self, shortname: str) -> None:
         pass
 
-    async def run(self, test, options):
+    async def run(self, test: 'Test', options: argparse.Namespace):
         try:
             for i in range(1, self.FLAKY_RETRIES):
                 await test.run(options)
@@ -214,7 +215,7 @@ class TestSuite(ABC):
             if options.skip_pattern and options.skip_pattern in t:
                 continue
 
-            async def add_test(shortname):
+            async def add_test(shortname) -> None:
                 # Add variants of the same test sequentially
                 # so that case cache has a chance to populate
                 for i in range(options.repeat):
@@ -238,7 +239,7 @@ class TestSuite(ABC):
 class UnitTestSuite(TestSuite):
     """TestSuite instantiation for non-boost unit tests"""
 
-    def __init__(self, path, cfg, options, mode):
+    def __init__(self, path: str, cfg: dict, options: argparse.Namespace, mode: str) -> None:
         super().__init__(path, cfg, options, mode)
         # Map of custom test command line arguments, if configured
         self.custom_args = cfg.get("custom_args", {})
@@ -247,7 +248,7 @@ class UnitTestSuite(TestSuite):
         test = UnitTest(self.next_id, shortname, suite, args)
         self.tests.append(test)
 
-    async def add_test(self, shortname):
+    async def add_test(self, shortname) -> None:
         """Create a UnitTest class with possibly custom command line
         arguments and add it to the list of tests"""
         # Skip tests which are not configured, and hence are not built
@@ -261,7 +262,7 @@ class UnitTestSuite(TestSuite):
             await self.create_test(shortname, self, a)
 
     @property
-    def pattern(self):
+    def pattern(self) -> str:
         return "*_test.cc"
 
 
@@ -272,10 +273,10 @@ class BoostTestSuite(UnitTestSuite):
     # --list_content. Static to share across all modes.
     _case_cache: Dict[str, List[str]] = dict()
 
-    def __init__(self, path, cfg, options, mode):
+    def __init__(self, path, cfg: dict, options: argparse.Namespace, mode) -> None:
         super().__init__(path, cfg, options, mode)
 
-    async def create_test(self, shortname, suite, args):
+    async def create_test(self, shortname: str, suite, args) -> None:
         options = self.options
         if options.parallel_cases and (shortname not in self.no_parallel_cases):
             fqname = os.path.join(self.mode, self.name, shortname)
@@ -306,7 +307,7 @@ class BoostTestSuite(UnitTestSuite):
             test = BoostTest(self.next_id, shortname, suite, args, None)
             self.tests.append(test)
 
-    def junit_tests(self):
+    def junit_tests(self) -> Iterable['Test']:
         """Boost tests produce an own XML output, so are not included in a junit report"""
         return []
 
@@ -314,7 +315,7 @@ class BoostTestSuite(UnitTestSuite):
 class PythonTestSuite(TestSuite):
     """A collection of Python pytests against a single Scylla instance"""
 
-    def __init__(self, path, cfg, options, mode):
+    def __init__(self, path, cfg: dict, options: argparse.Namespace, mode: str) -> None:
         super().__init__(path, cfg, options, mode)
         self.scylla_exe = os.path.join("build", self.mode, "scylla")
         if self.mode == "coverage":
@@ -329,7 +330,7 @@ class PythonTestSuite(TestSuite):
 
         self.clusters = Pool(cfg.get("pool_size", 2), self.create_cluster)
 
-    def topology_for_class(self, class_name, cfg):
+    def topology_for_class(self, class_name: str, cfg: dict) -> Callable[[], Awaitable]:
 
         def create_server(cluster_name, seed):
             cmdline_options = self.cfg.get("extra_scylla_cmdline_options", [])
@@ -363,34 +364,34 @@ class PythonTestSuite(TestSuite):
         else:
             raise RuntimeError("Unsupported topology name")
 
-    async def add_test(self, shortname):
+    async def add_test(self, shortname) -> None:
         test = PythonTest(self.next_id, shortname, self)
         self.tests.append(test)
 
     @property
-    def pattern(self):
+    def pattern(self) -> str:
         return "test_*.py"
 
 
 class CQLApprovalTestSuite(PythonTestSuite):
     """Run CQL commands against a single Scylla instance"""
 
-    def __init__(self, path, cfg, options, mode):
+    def __init__(self, path, cfg, options: argparse.Namespace, mode) -> None:
         super().__init__(path, cfg, options, mode)
 
-    async def add_test(self, shortname):
+    async def add_test(self, shortname: str) -> None:
         test = CQLApprovalTest(self.next_id, shortname, self)
         self.tests.append(test)
 
     @property
-    def pattern(self):
+    def pattern(self) -> str:
         return "*test.cql"
 
 
 class RunTestSuite(TestSuite):
     """TestSuite for test directory with a 'run' script """
 
-    def __init__(self, path, cfg, options, mode):
+    def __init__(self, path: str, cfg, options: argparse.Namespace, mode: str) -> None:
         super().__init__(path, cfg, options, mode)
         self.scylla_exe = os.path.join("build", self.mode, "scylla")
         if self.mode == "coverage":
@@ -399,19 +400,21 @@ class RunTestSuite(TestSuite):
             self.scylla_env = dict()
         self.scylla_env['SCYLLA'] = self.scylla_exe
 
-    async def add_test(self, shortname):
+    async def add_test(self, shortname) -> None:
         test = RunTest(self.next_id, shortname, self)
         self.tests.append(test)
 
     @property
-    def pattern(self):
+    def pattern(self) -> str:
         return "run"
 
 
 class Test:
     """Base class for CQL, Unit and Boost tests"""
-    def __init__(self, test_no, shortname, suite):
+    def __init__(self, test_no: int, shortname: str, suite) -> None:
         self.id = test_no
+        self.path = ""
+        self.args: List[str] = []
         # Name with test suite name
         self.name = os.path.join(suite.name, shortname.split('.')[0])
         # Name within the suite
@@ -429,28 +432,31 @@ class Test:
         self.is_cancelled = False
         Test._reset(self)
 
-    def reset(self):
+    def reset(self) -> None:
         """Reset this object, including all derived state."""
         for cls in reversed(self.__class__.__mro__):
-            if hasattr(cls, "_reset"):
-                cls._reset(self)
+            _reset = getattr(cls, '_reset', None)
+            if _reset is not None:
+                _reset(self)
 
-    def _reset(self):
+    def _reset(self) -> None:
         """Reset the test before a retry, if it is retried as flaky"""
-        self.success = None
+        self.success = False
+        self.time_start: float = 0
+        self.time_end: float = 0
 
     @abstractmethod
-    async def run(self, options):
+    async def run(self, options: argparse.Namespace) -> 'Test':
         pass
 
     @abstractmethod
-    def print_summary(self):
+    def print_summary(self) -> None:
         pass
 
     def get_junit_etree(self):
         return None
 
-    def check_log(self, trim):
+    def check_log(self, trim: bool) -> None:
         """Check and trim logs and xml output for tests which have it"""
         if trim:
             self.log_filename.unlink()
@@ -463,7 +469,7 @@ class UnitTest(Test):
                                 "--blocked-reactor-notify-ms 2000000 --collectd 0 "
                                 "--max-networking-io-control-blocks=100 ")
 
-    def __init__(self, test_no, shortname, suite, args):
+    def __init__(self, test_no: int, shortname: str, suite, args: str) -> None:
         super().__init__(test_no, shortname, suite)
         self.path = os.path.join("build", self.mode, "test", self.name)
         self.args = shlex.split(args) + UnitTest.standard_args
@@ -473,15 +479,15 @@ class UnitTest(Test):
             self.env = dict()
         UnitTest._reset(self)
 
-    def _reset(self):
+    def _reset(self) -> None:
         """Reset the test before a retry, if it is retried as flaky"""
         pass
 
-    def print_summary(self):
+    def print_summary(self) -> None:
         print("Output of {} {}:".format(self.path, " ".join(self.args)))
         print(read_log(self.log_filename))
 
-    async def run(self, options):
+    async def run(self, options) -> Test:
         self.success = await run_test(self, options, env=self.env)
         logging.info("Test #%d %s", self.id, "succeeded" if self.success else "failed ")
         return self
@@ -490,7 +496,8 @@ class UnitTest(Test):
 class BoostTest(UnitTest):
     """A unit test which can produce its own XML output"""
 
-    def __init__(self, test_no, shortname, suite, args, casename):
+    def __init__(self, test_no: int, shortname: str, suite, args: str,
+                 casename: Optional[str]) -> None:
         boost_args = []
         if casename:
             shortname += '.' + casename
@@ -505,12 +512,13 @@ class BoostTest(UnitTest):
         self.args = boost_args + self.args
         self.casename = casename
         BoostTest._reset(self)
+        self.__junit_etree: Optional[ET.ElementTree] = None
 
-    def _reset(self):
+    def _reset(self) -> None:
         """Reset the test before a retry, if it is retried as flaky"""
         self.__junit_etree = None
 
-    def get_junit_etree(self):
+    def get_junit_etree(self) -> ET.ElementTree:
         def adjust_suite_name(name):
             # Normalize "path/to/file.cc" to "path.to.file" to conform to
             # Jenkins expectations that the suite name is a class name. ".cc"
@@ -535,7 +543,7 @@ class BoostTest(UnitTest):
             os.unlink(self.xmlout)
         return self.__junit_etree
 
-    def check_log(self, trim):
+    def check_log(self, trim: bool) -> None:
         self.get_junit_etree()
         super().check_log(trim)
 
@@ -547,7 +555,7 @@ class BoostTest(UnitTest):
 class CQLApprovalTest(Test):
     """Run a sequence of CQL commands against a standlone Scylla"""
 
-    def __init__(self, test_no, shortname, suite):
+    def __init__(self, test_no: int, shortname: str, suite) -> None:
         super().__init__(test_no, shortname, suite)
         # Path to cql_repl driver, in the given build mode
         self.path = "pytest"
@@ -562,22 +570,22 @@ class CQLApprovalTest(Test):
         ]
         CQLApprovalTest._reset(self)
 
-    def _reset(self):
+    def _reset(self) -> None:
         """Reset the test before a retry, if it is retried as flaky"""
         self.is_before_test_ok = False
         self.is_executed_ok = False
         self.is_new = False
         self.is_after_test_ok = False
-        self.is_equal_result = None
+        self.is_equal_result = False
         self.summary = "not run"
-        self.unidiff = None
+        self.unidiff: Optional[str] = None
         self.server_log = None
-        self.env = dict()
+        self.env: Dict[str, str] = dict()
         old_tmpfile = pathlib.Path(self.tmpfile)
         if old_tmpfile.exists():
             old_tmpfile.unlink()
 
-    async def run(self, options):
+    async def run(self, options: argparse.Namespace) -> Test:
         self.success = False
         self.summary = "failed"
 
@@ -612,6 +620,7 @@ Check test log at {}.""".format(self.log_filename))
                     if self.is_equal_result is False:
                         self.unidiff = format_unidiff(self.result, self.tmpfile)
                         set_summary("failed: test output does not match expected result")
+                        assert self.unidiff is not None
                         logging.info("\n{}".format(palette.nocolor(self.unidiff)))
                     else:
                         self.success = True
@@ -642,7 +651,7 @@ Check test log at {}.""".format(self.log_filename))
 
         return self
 
-    def print_summary(self):
+    def print_summary(self) -> None:
         print("Test {} ({}) {}".format(palette.path(self.name), self.mode,
                                        self.summary))
         if self.is_executed_ok is False:
@@ -657,7 +666,7 @@ Check test log at {}.""".format(self.log_filename))
 class RunTest(Test):
     """Run tests in a directory started by a run script"""
 
-    def __init__(self, test_no, shortname, suite):
+    def __init__(self, test_no: int, shortname: str, suite) -> None:
         super().__init__(test_no, shortname, suite)
         self.path = os.path.join(suite.path, shortname)
         self.xmlout = os.path.join(suite.options.tmpdir, self.mode, "xml", self.uname + ".xunit.xml")
@@ -668,11 +677,11 @@ class RunTest(Test):
         """Reset the test before a retry, if it is retried as flaky"""
         pass
 
-    def print_summary(self):
+    def print_summary(self) -> None:
         print("Output of {} {}:".format(self.path, " ".join(self.args)))
         print(read_log(self.log_filename))
 
-    async def run(self, options):
+    async def run(self, options: argparse.Namespace) -> Test:
         # This test can and should be killed gently, with SIGTERM, not with SIGKILL
         self.success = await run_test(self, options, gentle_kill=True, env=self.suite.scylla_env)
         logging.info("Test #%d %s", self.id, "succeeded" if self.success else "failed ")
@@ -682,7 +691,7 @@ class RunTest(Test):
 class PythonTest(Test):
     """Run a pytest collection of cases against a standalone Scylla"""
 
-    def __init__(self, test_no, shortname, suite):
+    def __init__(self, test_no: int, shortname: str, suite) -> None:
         super().__init__(test_no, shortname, suite)
         self.path = "pytest"
         self.xmlout = os.path.join(self.suite.options.tmpdir, self.mode, "xml", self.uname + ".xunit.xml")
@@ -691,20 +700,20 @@ class PythonTest(Test):
                      os.path.join(suite.path, shortname + ".py")]
         PythonTest._reset(self)
 
-    def _reset(self):
+    def _reset(self) -> None:
         """Reset the test before a retry, if it is retried as flaky"""
         self.server_log = None
         self.is_before_test_ok = False
         self.is_after_test_ok = False
 
-    def print_summary(self):
+    def print_summary(self) -> None:
         print("Output of {} {}:".format(self.path, " ".join(self.args)))
         print(read_log(self.log_filename))
         if self.server_log:
             print("Server log of the first server:")
             print(self.server_log)
 
-    async def run(self, options):
+    async def run(self, options: argparse.Namespace) -> Test:
         async with self.suite.clusters.instance() as cluster:
             self.args.insert(0, "--host={}".format(cluster[0].host))
             try:
@@ -729,24 +738,24 @@ class PythonTest(Test):
 class TabularConsoleOutput:
     """Print test progress to the console"""
 
-    def __init__(self, verbose, test_count):
+    def __init__(self, verbose: bool, test_count: int) -> None:
         self.verbose = verbose
         self.test_count = test_count
         self.print_newline = False
         self.last_test_no = 0
         self.last_line_len = 1
 
-    def print_start_blurb(self):
+    def print_start_blurb(self) -> None:
         print("="*80)
         print("{:10s} {:^8s} {:^7s} {:8s} {}".format("[N/TOTAL]", "SUITE", "MODE", "RESULT", "TEST"))
         print("-"*78)
 
-    def print_end_blurb(self):
+    def print_end_blurb(self) -> None:
         if self.print_newline:
             print("")
         print("-"*78)
 
-    def print_progress(self, test):
+    def print_progress(self, test: Test) -> None:
         self.last_test_no += 1
         status = ""
         if test.success:
@@ -776,12 +785,11 @@ class TabularConsoleOutput:
                 print(msg)
                 self.print_newline = False
         else:
-            if hasattr(test, 'time_end') and test.time_end > 0:
-                msg += " {:.2f}s".format(test.time_end - test.time_start)
+            msg += " {:.2f}s".format(test.time_end - test.time_start)
             print(msg)
 
 
-async def run_test(test, options, gentle_kill=False, env=dict()):
+async def run_test(test: Test, options: argparse.Namespace, gentle_kill=False, env=dict()) -> bool:
     """Run test program, return True if success else False"""
 
     with test.log_filename.open("wb") as log:
@@ -867,7 +875,7 @@ async def run_test(test, options, gentle_kill=False, env=dict()):
     return False
 
 
-def setup_signal_handlers(loop, signaled):
+def setup_signal_handlers(loop, signaled) -> None:
 
     async def shutdown(loop, signo, signaled):
         print("\nShutdown requested... Aborting tests:"),
@@ -882,7 +890,7 @@ def setup_signal_handlers(loop, signaled):
         loop.add_signal_handler(signo, lambda: asyncio.create_task(shutdown(loop, signo, signaled)))
 
 
-def parse_cmd_line():
+def parse_cmd_line() -> argparse.Namespace:
     """ Print usage and process command line options. """
 
     parser = argparse.ArgumentParser(description="Scylla test runner")
@@ -989,7 +997,7 @@ def parse_cmd_line():
     return args
 
 
-async def find_tests(options):
+async def find_tests(options: argparse.Namespace) -> None:
 
     for f in glob.glob(os.path.join("test", "*")):
         if os.path.isdir(f) and os.path.isfile(os.path.join(f, "suite.yaml")):
@@ -1010,7 +1018,7 @@ async def find_tests(options):
     print("Found {} tests.".format(TestSuite.test_count()))
 
 
-async def run_all_tests(signaled, options):
+async def run_all_tests(signaled: asyncio.Event, options: argparse.Namespace) -> None:
     console = TabularConsoleOutput(options.verbose, TestSuite.test_count())
     signaled_task = asyncio.create_task(signaled.wait())
     pending = set([signaled_task])
@@ -1055,7 +1063,7 @@ async def run_all_tests(signaled, options):
     console.print_end_blurb()
 
 
-def read_log(log_filename: pathlib.Path):
+def read_log(log_filename: pathlib.Path) -> str:
     """Intelligently read test log output"""
     try:
         with log_filename.open("r") as log:
@@ -1067,7 +1075,7 @@ def read_log(log_filename: pathlib.Path):
         return "===Error reading log {}===".format(e)
 
 
-def print_summary(failed_tests, options):
+def print_summary(failed_tests, options: argparse.Namespace) -> None:
     if failed_tests:
         print("The following test(s) have failed: {}".format(
             palette.path(" ".join([t.name for t in failed_tests]))))
@@ -1079,7 +1087,7 @@ def print_summary(failed_tests, options):
             len(failed_tests), TestSuite.test_count()))
 
 
-def format_unidiff(fromfile, tofile):
+def format_unidiff(fromfile: str, tofile: str) -> str:
     with open(fromfile, "r") as frm, open(tofile, "r") as to:
         buf = StringIO()
         diff = difflib.unified_diff(
@@ -1104,7 +1112,7 @@ def format_unidiff(fromfile, tofile):
         return buf.getvalue()
 
 
-def write_junit_report(tmpdir, mode):
+def write_junit_report(tmpdir: str, mode: str) -> None:
     junit_filename = os.path.join(tmpdir, mode, "xml", "junit.xml")
     total = 0
     failed = 0
@@ -1132,7 +1140,7 @@ def write_junit_report(tmpdir, mode):
         ET.ElementTree(xml_results).write(f, encoding="unicode")
 
 
-def write_consolidated_boost_junit_xml(tmpdir, mode):
+def write_consolidated_boost_junit_xml(tmpdir: str, mode: str) -> None:
     xml = ET.Element("TestLog")
     for suite in TestSuite.suites.values():
         for test in suite.tests:
@@ -1145,7 +1153,7 @@ def write_consolidated_boost_junit_xml(tmpdir, mode):
     et.write(f'{tmpdir}/{mode}/xml/boost.xunit.xml', encoding='unicode')
 
 
-def open_log(tmpdir):
+def open_log(tmpdir: str) -> None:
     pathlib.Path(tmpdir).mkdir(parents=True, exist_ok=True)
     logging.basicConfig(
         filename=os.path.join(tmpdir, "test.py.log"),
@@ -1157,7 +1165,7 @@ def open_log(tmpdir):
     logging.critical("Started %s", " ".join(sys.argv))
 
 
-async def main():
+async def main() -> int:
 
     options = parse_cmd_line()
 
@@ -1179,7 +1187,7 @@ async def main():
         raise
 
     if signaled.is_set():
-        return -signaled.signo
+        return -signaled.signo      # type: ignore
 
     failed_tests = [t for t in TestSuite.all_tests() if t.success is not True]
 
@@ -1197,7 +1205,7 @@ async def main():
     return 0 if not failed_tests else 1
 
 
-async def workaround_python26789():
+async def workaround_python26789() -> int:
     """Workaround for https://bugs.python.org/issue26789.
     We'd like to print traceback if there is an internal error
     in test.py. However, traceback module calls asyncio

--- a/test.py
+++ b/test.py
@@ -939,6 +939,13 @@ def parse_cmd_line() -> argparse.Namespace:
     parser.add_argument('--cpus', action="store",
                         help="Run the tests on those CPUs only (in taskset"
                         " acceptable format). Consider using --jobs too")
+    parser.add_argument('--log-level', action="store",
+                        help="Log level for Python logging module. The log "
+                        "is in {tmpdir}/test.py.log. Default: INFO",
+                        default="INFO",
+                        choices=["CRITICAL", "ERROR", "WARNING", "INFO",
+                                 "DEBUG"],
+                        dest="log_level")
 
     boost_group = parser.add_argument_group('boost suite options')
     boost_group.add_argument('--random-seed', action="store",
@@ -1157,12 +1164,12 @@ def write_consolidated_boost_junit_xml(tmpdir: str, mode: str) -> None:
     et.write(f'{tmpdir}/{mode}/xml/boost.xunit.xml', encoding='unicode')
 
 
-def open_log(tmpdir: str) -> None:
+def open_log(tmpdir: str, log_level: str) -> None:
     pathlib.Path(tmpdir).mkdir(parents=True, exist_ok=True)
     logging.basicConfig(
         filename=os.path.join(tmpdir, "test.py.log"),
         filemode="w",
-        level=logging.INFO,
+        level=log_level,
         format="%(asctime)s.%(msecs)03d %(levelname)s> %(message)s",
         datefmt="%H:%M:%S",
     )
@@ -1173,7 +1180,7 @@ async def main() -> int:
 
     options = parse_cmd_line()
 
-    open_log(options.tmpdir)
+    open_log(options.tmpdir, options.log_level)
 
     await find_tests(options)
     if options.list_tests:

--- a/test.py
+++ b/test.py
@@ -30,11 +30,12 @@ import yaml
 
 from abc import ABC, abstractmethod
 from io import StringIO
-from scripts import coverage
+from scripts import coverage    # type: ignore
 from test.pylib.artifact_registry import ArtifactRegistry
-from test.pylib.pool import Pool
 from test.pylib.host_registry import HostRegistry
+from test.pylib.pool import Pool
 from test.pylib.scylla_server import ScyllaServer, ScyllaCluster
+from typing import Dict, List
 
 output_is_a_tty = sys.stdout.isatty()
 
@@ -76,7 +77,7 @@ class TestSuite(ABC):
     E.g. it can be unit tests, boost tests, or CQL tests."""
 
     # All existing test suites, one suite per path/mode.
-    suites = dict()
+    suites: Dict[str, ABC] = dict()
     artifacts = ArtifactRegistry()
     hosts = HostRegistry()
     FLAKY_RETRIES = 5
@@ -269,7 +270,7 @@ class BoostTestSuite(UnitTestSuite):
 
     # A cache of individual test cases, for which we have called
     # --list_content. Static to share across all modes.
-    _case_cache = dict()
+    _case_cache: Dict[str, List[str]] = dict()
 
     def __init__(self, path, cfg, options, mode):
         super().__init__(path, cfg, options, mode)
@@ -812,7 +813,7 @@ async def run_test(test, options, gentle_kill=False, env=dict()):
             log.write("export ASAN_OPTIONS='{}'\n".format(
                 ":".join(filter(None, ASAN_OPTIONS))).encode(encoding="UTF-8"))
             log.write("{} {}\n".format(test.path, " ".join(test.args)).encode(encoding="UTF-8"))
-            log.write("=== TEST.PY TEST OUTPUT ===\n".format(test.id).encode(encoding="UTF-8"))
+            log.write("=== TEST.PY TEST #{} OUTPUT ===\n".format(test.id).encode(encoding="UTF-8"))
             log.flush()
             test.time_start = time.time()
             test.time_end = 0

--- a/test.py
+++ b/test.py
@@ -597,6 +597,7 @@ class CQLApprovalTest(Test):
                 logging.info("Server log:\n%s", self.server_log)
 
         async with self.suite.clusters.instance() as cluster:
+            logging.info("Leasing Scylla cluster %s for test %s", cluster, self.uname)
             self.args.insert(1, "--host={}".format(cluster[0].host))
             # If pre-check fails, e.g. because Scylla failed to start
             # or crashed between two tests, fail entire test.py
@@ -719,6 +720,7 @@ class PythonTest(Test):
 
     async def run(self, options: argparse.Namespace) -> Test:
         async with self.suite.clusters.instance() as cluster:
+            logging.info("Leasing Scylla cluster %s for test %s", cluster, self.uname)
             self.args.insert(0, "--host={}".format(cluster[0].host))
             try:
                 cluster.before_test(self.uname)

--- a/test.py
+++ b/test.py
@@ -564,6 +564,7 @@ class CQLApprovalTest(Test):
         self.tmpfile = os.path.join(suite.options.tmpdir, self.mode, self.uname + ".reject")
         self.reject = os.path.join(suite.path, self.shortname + ".reject")
         self.args = [
+            "-s",  # don't capture print() inside pytest
             "test/pylib/cql_repl/cql_repl.py",
             "--input={}".format(self.cql),
             "--output={}".format(self.tmpfile),
@@ -695,9 +696,12 @@ class PythonTest(Test):
         super().__init__(test_no, shortname, suite)
         self.path = "pytest"
         self.xmlout = os.path.join(self.suite.options.tmpdir, self.mode, "xml", self.uname + ".xunit.xml")
-        self.args = ["-o", "junit_family=xunit2",
-                     "--junit-xml={}".format(self.xmlout),
-                     os.path.join(suite.path, shortname + ".py")]
+        self.args = [
+            "-s",  # don't capture print() output inside pytest
+            "-o",
+            "junit_family=xunit2",
+            "--junit-xml={}".format(self.xmlout),
+            os.path.join(suite.path, shortname + ".py")]
         PythonTest._reset(self)
 
     def _reset(self) -> None:

--- a/test.py
+++ b/test.py
@@ -163,7 +163,7 @@ class TestSuite(ABC):
         return suite
 
     @staticmethod
-    def tests():
+    def all_tests():
         return itertools.chain(*[suite.tests for suite in
                                  TestSuite.suites.values()])
 
@@ -1034,7 +1034,7 @@ async def run_all_tests(signaled, options):
     console.print_start_blurb()
     try:
         TestSuite.artifacts.add_exit_artifact(None, TestSuite.hosts.cleanup)
-        for test in TestSuite.tests():
+        for test in TestSuite.all_tests():
             # +1 for 'signaled' event
             if len(pending) > options.jobs:
                 # Wait for some task to finish
@@ -1165,7 +1165,7 @@ async def main():
 
     await find_tests(options)
     if options.list_tests:
-        print('\n'.join([t.name for t in TestSuite.tests()]))
+        print('\n'.join([t.name for t in TestSuite.all_tests()]))
         return 0
 
     signaled = asyncio.Event()
@@ -1181,7 +1181,7 @@ async def main():
     if signaled.is_set():
         return -signaled.signo
 
-    failed_tests = [t for t in TestSuite.tests() if t.success is not True]
+    failed_tests = [t for t in TestSuite.all_tests() if t.success is not True]
 
     print_summary(failed_tests, options)
 

--- a/test/pylib/scylla_server.py
+++ b/test/pylib/scylla_server.py
@@ -13,11 +13,12 @@ import time
 import uuid
 from typing import Optional, List, Callable
 from cassandra import InvalidRequest                    # type: ignore
+from cassandra import OperationTimedOut                 # type: ignore
 from cassandra.auth import PlainTextAuthProvider        # type: ignore
 from cassandra.cluster import Cluster, NoHostAvailable  # type: ignore
 from cassandra.cluster import Session                   # type: ignore
 from cassandra.cluster import ExecutionProfile, EXEC_PROFILE_DEFAULT     # type: ignore
-from cassandra.policies import RoundRobinPolicy                          # type: ignore
+from cassandra.policies import WhiteListRoundRobinPolicy  # type: ignore
 
 #
 # Put all Scylla options in a template file. Sic: if you make a typo in the
@@ -96,6 +97,8 @@ SCYLLA_CMDLINE_OPTIONS = [
 
 
 class ScyllaServer:
+    START_TIMEOUT = 300     # seconds
+
     def __init__(self, exe: str, vardir: str,
                  host_registry,
                  cluster_name: str, seed: str,
@@ -106,7 +109,7 @@ class ScyllaServer:
         self.cmdline_options = cmdline_options
         self.cluster_name = cluster_name
         self.hostname = ""
-        self.seeds = seed
+        self.seed = seed
         self.cmd: Optional[asyncio.subprocess.Process] = None
         self.log_savepoint = 0
         self.control_cluster: Optional[Cluster] = None
@@ -153,8 +156,8 @@ class ScyllaServer:
         # Scylla assumes all instances of a cluster use the same port,
         # so each instance needs an own IP address.
         self.hostname = await self.host_registry.lease_host()
-        if not self.seeds:
-            self.seeds = self.hostname
+        if not self.seed:
+            self.seed = self.hostname
         # Use the last part in host IP 127.151.3.27 -> 27
         # There can be no duplicates within the same test run
         # thanks to how host registry registers subnets, and
@@ -179,7 +182,7 @@ class ScyllaServer:
         fmt = {
               "cluster_name": self.cluster_name,
               "host": self.hostname,
-              "seeds": self.seeds,
+              "seeds": self.seed,
               "workdir": self.workdir,
         }
         with self.config_filename.open('w') as config_file:
@@ -216,25 +219,35 @@ class ScyllaServer:
         # Be quiet about connection failures.
         caslog.setLevel('CRITICAL')
         auth = PlainTextAuthProvider(username='cassandra', password='cassandra')
-        profile = ExecutionProfile(load_balancing_policy=RoundRobinPolicy())
+        # auth::standard_role_manager creates "cassandra" role in an
+        # async loop auth::do_after_system_ready(), which retries
+        # role creation with an exponential back-off. In other
+        # words, even after CQL port is up, Scylla may still be
+        # initializing. When the role is ready, queries begin to
+        # work, so rely on this "side effect".
+        profile = ExecutionProfile(load_balancing_policy=WhiteListRoundRobinPolicy([self.hostname]),
+                                   request_timeout=self.START_TIMEOUT)
         try:
+            # In a cluster setup, it's possible that the CQL
+            # here is directed to a node different from the initial contact
+            # point, so make sure we execute the checks strictly via
+            # this connection
             with Cluster(execution_profiles={EXEC_PROFILE_DEFAULT: profile},
-                         contact_points=[self.hostname], auth_provider=auth) as cluster:
+                         contact_points=[self.hostname],
+                         # This is the latest version Scylla supports
+                         protocol_version=4,
+                         auth_provider=auth) as cluster:
                 with cluster.connect() as session:
-                    # auth::standard_role_manager creates "cassandra" role in an
-                    # async loop auth::do_after_system_ready(), which retries
-                    # role creation with an exponential back-off. In other
-                    # words, even after CQL port is up, Scylla may still be
-                    # initializing. When the role is ready, queries begin to
-                    # work, so rely on this "side effect".
-                    session.execute("CREATE KEYSPACE k WITH REPLICATION = {" +
+                    session.execute("CREATE KEYSPACE IF NOT EXISTS k WITH REPLICATION = {" +
                                     "'class' : 'SimpleStrategy', 'replication_factor' : 1 }")
                     session.execute("DROP KEYSPACE k")
                     self.control_cluster = Cluster(execution_profiles={EXEC_PROFILE_DEFAULT: profile},
-                                                   contact_points=[self.hostname], auth_provider=auth)
+                                                   contact_points=[self.hostname],
+                                                   auth_provider=auth)
                     self.control_connection = self.control_cluster.connect()
                     return True
-        except (NoHostAvailable, InvalidRequest):
+        except (NoHostAvailable, InvalidRequest, OperationTimedOut) as e:
+            logging.info("Exception when checking if CQL is up: {}".format(e))
             return False
         finally:
             caslog.setLevel(oldlevel)
@@ -254,7 +267,6 @@ class ScyllaServer:
 
     async def start(self) -> None:
         """Start an installed server. May be used for restarts."""
-        START_TIMEOUT = 300     # seconds
 
         # Add suite-specific command line options
         scylla_args = SCYLLA_CMDLINE_OPTIONS + self.cmdline_options
@@ -271,8 +283,9 @@ class ScyllaServer:
         )
 
         self.start_time = time.time()
+        sleep_interval = 0.1
 
-        while time.time() < self.start_time + START_TIMEOUT:
+        while time.time() < self.start_time + self.START_TIMEOUT:
             if self.cmd.returncode:
                 with self.log_filename.open('r') as log_file:
                     logging.error("failed to start server at host %s", self.hostname)
@@ -290,10 +303,8 @@ Check the log files:
                 if await self.cql_is_up():
                     return
 
-            # Sleep 10 milliseconds and retry
-            await asyncio.sleep(0.1)
-            if self.seeds != self.hostname:
-                await self.force_schema_migration()
+            # Sleep and retry
+            await asyncio.sleep(sleep_interval)
 
         raise RuntimeError("failed to start server {}, check server log at {}".format(
             self.host, self.log_filename))
@@ -304,9 +315,16 @@ Check the log files:
         state. Helps quickly propagate tokens and speed up node boot if the
         previous state propagation was missed."""
         auth = PlainTextAuthProvider(username='cassandra', password='cassandra')
-        with Cluster(contact_points=[self.seeds], auth_provider=auth) as cluster:
+        profile = ExecutionProfile(load_balancing_policy=WhiteListRoundRobinPolicy([self.seed]),
+                                   request_timeout=self.START_TIMEOUT)
+        with Cluster(execution_profiles={EXEC_PROFILE_DEFAULT: profile},
+                     contact_points=[self.seed],
+                     auth_provider=auth,
+                     # This is the latest version Scylla supports
+                     protocol_version=4,
+                     ) as cluster:
             with cluster.connect() as session:
-                session.execute("CREATE KEYSPACE k WITH REPLICATION = {" +
+                session.execute("CREATE KEYSPACE IF NOT EXISTS k WITH REPLICATION = {" +
                                 "'class' : 'SimpleStrategy', 'replication_factor' : 1 }")
                 session.execute("DROP KEYSPACE k")
 
@@ -375,7 +393,7 @@ class ScyllaCluster:
                 self.cluster.append(server)
                 await server.install_and_start()
             self.keyspace_count = self._get_keyspace_count()
-        except (RuntimeError, NoHostAvailable, InvalidRequest) as e:
+        except (RuntimeError, NoHostAvailable, InvalidRequest, OperationTimedOut) as e:
             # If start fails, swallow the error to throw later,
             # at test time.
             self.start_exception = e
@@ -386,6 +404,7 @@ class ScyllaCluster:
     def _get_keyspace_count(self) -> int:
         """Get the current keyspace count"""
         assert(self.start_exception is None)
+        assert self.cluster[0].control_connection is not None
         rows = self.cluster[0].control_connection.execute(
             "select count(*) as c from system_schema.keyspaces")
         keyspace_count = int(rows.one()[0])

--- a/test/pylib/scylla_server.py
+++ b/test/pylib/scylla_server.py
@@ -379,6 +379,9 @@ Check the log files:
         self.log_file.write(msg.encode())
         self.log_file.flush()
 
+    def __str__(self):
+        return self.hostname
+
 
 class ScyllaCluster:
     def __init__(self, replicas: int,
@@ -407,9 +410,13 @@ class ScyllaCluster:
             # If start fails, swallow the error to throw later,
             # at test time.
             self.start_exception = e
+        logging.info("Created cluster %s", self)
 
     def __getitem__(self, i: int) -> ScyllaServer:
         return self.cluster[i]
+
+    def __str__(self):
+        return "{" + ", ".join(str(c) for c in self.cluster) + "}"
 
     def _get_keyspace_count(self) -> int:
         """Get the current keyspace count"""


### PR DESCRIPTION
A number of improvements in test.py as requested by maintainers:

* don't capture pytest output 
* stick to the specific server in control connections 
* support --log-level option and pass it to logging module 
* when checking if CQL is up, ignore timeout errors 
* no longer force schema migration when starting the server 
* use test uname, not id, in log output 
* improve logging of ScyllaServer
* log what cluster is used for a test
* extend xml output with logs 

On the same token, remove mypy warnings and make linter pass on test.py, as well as add some type checking.

Fixes #10871
Fixes #10785