### PR TITLE
alternator: use position-in-partition in paging cookie only when reading CQL tables

### DIFF
--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -400,8 +400,8 @@ static rjson::value generate_arn_for_index(const schema& schema, std::string_vie
         schema.ks_name(), schema.cf_name(), index_name));
 }
 
-bool executor::is_alternator_keyspace(const sstring& ks_name) {
-    return ks_name.find(KEYSPACE_NAME_PREFIX) == 0;
+bool is_alternator_keyspace(const sstring& ks_name) {
+    return ks_name.find(executor::KEYSPACE_NAME_PREFIX) == 0;
 }
 
 sstring executor::table_name(const schema& s) {

--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -3616,10 +3616,17 @@ static rjson::value encode_paging_state(const schema& schema, const service::pag
             ++exploded_ck_it;
         }
     }
-    rjson::add_with_string_name(last_evaluated_key, scylla_paging_region, rjson::empty_object());
-    rjson::add(last_evaluated_key[scylla_paging_region.data()], "S", rjson::from_string(to_string(pos.region())));
-    rjson::add_with_string_name(last_evaluated_key, scylla_paging_weight, rjson::empty_object());
-    rjson::add(last_evaluated_key[scylla_paging_weight.data()], "N", static_cast<int>(pos.get_bound_weight()));
+    // To avoid possible conflicts (and thus having to reserve these names) we
+    // avoid adding the weight and region fields of the position to the paging
+    // state. Alternator will never need these as it doesn't have range
+    // tombstones (the only thing that can generate a position other than at(row)).
+    // We conditionally include these fields when reading CQL tables through alternator.
+    if (!is_alternator_keyspace(schema.ks_name()) && (!pos.has_key() || pos.get_bound_weight() != bound_weight::equal)) {
+        rjson::add_with_string_name(last_evaluated_key, scylla_paging_region, rjson::empty_object());
+        rjson::add(last_evaluated_key[scylla_paging_region.data()], "S", rjson::from_string(to_string(pos.region())));
+        rjson::add_with_string_name(last_evaluated_key, scylla_paging_weight, rjson::empty_object());
+        rjson::add(last_evaluated_key[scylla_paging_weight.data()], "N", static_cast<int>(pos.get_bound_weight()));
+    }
     return last_evaluated_key;
 }
 

--- a/alternator/executor.hh
+++ b/alternator/executor.hh
@@ -85,6 +85,7 @@ const std::map<sstring, sstring>& get_tags_of_table(schema_ptr schema);
 std::optional<std::string> find_tag(const schema& s, const sstring& tag);
 future<> update_tags(service::migration_manager& mm, schema_ptr schema, std::map<sstring, sstring>&& tags_map);
 schema_ptr get_table(service::storage_proxy& proxy, const rjson::value& request);
+bool is_alternator_keyspace(const sstring& ks_name);
 
 // An attribute_path_map object is used to hold data for various attributes
 // paths (parsed::path) in a hierarchy of attribute paths. Each attribute path
@@ -212,7 +213,6 @@ public:
 private:
     friend class rmw_operation;
 
-    static bool is_alternator_keyspace(const sstring& ks_name);
     static void describe_key_schema(rjson::value& parent, const schema&, std::unordered_map<std::string,std::string> * = nullptr);
     static void describe_key_schema(rjson::value& parent, const schema& schema, std::unordered_map<std::string,std::string>&);
     


### PR DESCRIPTION
Recently, we added full position-in-partition support to alternator's
paging cookie, so it can support stopping at arbitrary positions. This
support however is only really needed when tables have range tombstones
and alternator tables never have them. So to avoid having to make the
new fields in 'ExclusiveStartKey' reserved, we avoid filling these in
when reading an alternator table, as in this case it is safe to assume
the position is `after_key($clustring_key)`. We do include these new
members however when reading CQL tables through alternator. As this is
only supported for system tables, we can also be sure that the elaborate
names we used for these fields are enough to avoid naming clashes.

Fixes: https://github.com/scylladb/scylla/issues/10903
