### PR TITLE
storage_service: track restore_replica_count

### DIFF
--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -1486,6 +1486,7 @@ future<> storage_service::stop() {
     } catch (...) {
         slogger.error("failed to stop Raft Group 0: {}", std::current_exception());
     }
+    co_await _async_gate.close();
     co_await std::move(_node_ops_abort_thread);
 }
 

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -1104,9 +1104,11 @@ future<> storage_service::handle_state_removing(inet_address endpoint, std::vect
             // will be removed from _replicating_nodes on the
             // removal_coordinator.
             auto notify_endpoint = ep.value();
-            //FIXME: discarded future.
-            (void)restore_replica_count(endpoint, notify_endpoint).handle_exception([endpoint, notify_endpoint] (auto ep) {
+            // OK to discard future since _async_gate is closed on stop()
+            (void)with_gate(_async_gate, [this, endpoint, notify_endpoint] {
+              return restore_replica_count(endpoint, notify_endpoint).handle_exception([endpoint, notify_endpoint] (auto ep) {
                 slogger.info("Failed to restore_replica_count for node {}, notify_endpoint={} : {}", endpoint, notify_endpoint, ep);
+              });
             });
         }
     } else { // now that the gossiper has told us about this nonexistent member, notify the gossiper to remove it

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -157,6 +157,7 @@ private:
     using client_shutdown_hook = noncopyable_function<void()>;
     std::vector<protocol_server*> _protocol_servers;
     std::vector<std::any> _listeners;
+    gate _async_gate;
 
     std::unordered_map<utils::UUID, node_ops_meta_data> _node_ops;
     std::list<std::optional<utils::UUID>> _node_ops_abort_queue;


### PR DESCRIPTION
This mini-series adds an _async_gate to storage_service that is closed on stop()
and it performs restore_replica_count under this gate so it can be orderly waited on in stop()

Fixes #10672