### PR TITLE
install-dependencies: strip libwasmtime.a from spurious debug symbols

### DIFF
--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -327,6 +327,10 @@ elif [ "$ID" = "fedora" ]; then
             echo "$(wasmtime_url) is unreachable, skipping"
         fi
     fi
+    # Issue #10863: the libwasmtime.a archive has debug symbols so when
+    # linking it into Scylla it makes it look like Scylla has debug symbols.
+    # So let's remove the debug symbols from this library.
+    strip --strip-debug /usr/lib64/libwasmtime.a
 elif [ "$ID" = "centos" ]; then
     dnf install -y "${centos_packages[@]}"
     echo -e "Configure example:\n\tpython3.4 ./configure.py --enable-dpdk --mode=release --static-boost --compiler=/opt/scylladb/bin/g++-7.3 --python python3.4 --ldflag=-Wl,-rpath=/opt/scylladb/lib64 --cflags=-I/opt/scylladb/include --with-antlr3=/opt/scylladb/bin/antlr3"


### PR DESCRIPTION
Traditionally, libraries are installed *without* debugging symbols.
The libwasmtime.a that we install in install-dependencies is an
exception - it does include some debug symbols.

As a result, when the linker links Scylla built *without* debug symbols
(e.g., dev build mode) with this libwasmtime.a library - the result has
*some* debugging symbols, so utilities like "file" and "gdb" believe
that it has debugging symbols - although they are useless for any sort
of real debugging so any such attempt will fail in unclear ways.
This is confusing and misleading.

So in this patch, we modify install-dependencies.sh to strip this
library from its debugging symbols.

Note that for this change to take effect, the developer must re-run
install-dependencies.sh. The stripping will happen even if the library
was already downloaded in the past.

Fixes #10863

Signed-off-by: Nadav Har'El <nyh@scylladb.com>