### PR TITLE
test/cql-pytest: avoid leaving behind temporary files

### DIFF
--- a/test/cql-pytest/test_tools.py
+++ b/test/cql-pytest/test_tools.py
@@ -139,10 +139,10 @@ def table_with_counters(cql, keyspace):
         clustering_table_with_udt,
         table_with_counters,
 ])
-def scylla_sstable(request, tmp_path_factory, cql, test_keyspace, scylla_path, scylla_data_dir):
+def scylla_sstable(request, cql, test_keyspace, scylla_path, scylla_data_dir):
     table, schema = request.param(cql, test_keyspace)
 
-    schema_file = os.path.join(tmp_path_factory.getbasetemp(), "schema.cql")
+    schema_file = os.path.join(scylla_data_dir, "..", "test_tools_schema.cql")
     with open(schema_file, "w") as f:
         f.write(schema)
 
@@ -152,6 +152,7 @@ def scylla_sstable(request, tmp_path_factory, cql, test_keyspace, scylla_path, s
         yield (scylla_path, schema_file, sstables)
     finally:
         cql.execute(f"DROP TABLE {test_keyspace}.{table}")
+        os.unlink(schema_file)
 
 
 def one_sstable(sstables):


### PR DESCRIPTION
Before this patch, the test cql-pytest/test_tools.py left behind
a temporary file in /tmp. It used pytest's "tmp_path_factory" feature,
but it doesn't remove temporary files it creates.

This patch removes the temporary file when the fixture using it ends,
but moreover, it puts the temporary file not in /tmp but rather next
to Scylla's data directory. That directory will be eventually removed
entirely, so even if we accidentally leave a file there, it will
eventually be deleted.

Fixes #10924

Signed-off-by: Nadav Har'El <nyh@scylladb.com>