### PR TITLE
mutation_compactor: remove emit only live rows parameter

### DIFF
--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -2036,7 +2036,7 @@ public:
 // Called in the context of a seastar::thread.
 void view_builder::execute(build_step& step, exponential_backoff_retry r) {
     gc_clock::time_point now = gc_clock::now();
-    auto consumer = compact_for_query_v2<emit_only_live_rows::no, view_builder::consumer>(
+    auto consumer = compact_for_query_v2<view_builder::consumer>(
             *step.reader.schema(),
             now,
             step.pslice,

--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -380,7 +380,6 @@ static query::partition_slice make_partition_slice(const schema& s) {
 class data_query_result_builder {
 public:
     using result_type = query::result;
-    static constexpr emit_only_live_rows only_live = emit_only_live_rows::yes;
 
 private:
     query::result::builder _res_builder;
@@ -1958,8 +1957,11 @@ public:
         return stop_iteration::no;
     }
 
-    stop_iteration consume(clustering_row&& cr, row_tombstone, bool) {
+    stop_iteration consume(clustering_row&& cr, row_tombstone, bool is_live) {
         inject_failure("view_builder_consume_clustering_row");
+        if (!is_live) {
+            return stop_iteration::no;
+        }
         if (_views_to_build.empty() || _builder._as.abort_requested()) {
             return stop_iteration::yes;
         }
@@ -2034,7 +2036,7 @@ public:
 // Called in the context of a seastar::thread.
 void view_builder::execute(build_step& step, exponential_backoff_retry r) {
     gc_clock::time_point now = gc_clock::now();
-    auto consumer = compact_for_query_v2<emit_only_live_rows::yes, view_builder::consumer>(
+    auto consumer = compact_for_query_v2<emit_only_live_rows::no, view_builder::consumer>(
             *step.reader.schema(),
             now,
             step.pslice,

--- a/multishard_mutation_query.cc
+++ b/multishard_mutation_query.cc
@@ -609,18 +609,15 @@ future<> read_context::save_readers(flat_mutation_reader_v2::tracked_buffer unco
 
 namespace {
 
-template <typename ResultType>
-using compact_for_result_state = compact_for_query_state_v2;
-
 template <typename ResultBuilder>
 requires std::is_nothrow_move_constructible_v<typename ResultBuilder::result_type>
 struct page_consume_result {
     typename ResultBuilder::result_type result;
     flat_mutation_reader_v2::tracked_buffer unconsumed_fragments;
-    lw_shared_ptr<compact_for_result_state<ResultBuilder>> compaction_state;
+    lw_shared_ptr<compact_for_query_state_v2> compaction_state;
 
     page_consume_result(typename ResultBuilder::result_type&& result, flat_mutation_reader_v2::tracked_buffer&& unconsumed_fragments,
-            lw_shared_ptr<compact_for_result_state<ResultBuilder>>&& compaction_state) noexcept
+            lw_shared_ptr<compact_for_query_state_v2>&& compaction_state) noexcept
         : result(std::move(result))
         , unconsumed_fragments(std::move(unconsumed_fragments))
         , compaction_state(std::move(compaction_state)) {
@@ -697,8 +694,8 @@ future<page_consume_result<ResultBuilder>> read_page(
         const query::read_command& cmd,
         const dht::partition_range_vector& ranges,
         tracing::trace_state_ptr trace_state,
-        noncopyable_function<ResultBuilder(const compact_for_result_state<ResultBuilder>&)> result_builder_factory) {
-    auto compaction_state = make_lw_shared<compact_for_result_state<ResultBuilder>>(*s, cmd.timestamp, cmd.slice, cmd.get_row_limit(),
+        noncopyable_function<ResultBuilder(const compact_for_query_state_v2&)> result_builder_factory) {
+    auto compaction_state = make_lw_shared<compact_for_query_state_v2>(*s, cmd.timestamp, cmd.slice, cmd.get_row_limit(),
             cmd.partition_limit);
 
     auto reader = make_multishard_combining_reader_v2(ctx, s, ctx->permit(), ranges.front(), cmd.slice,
@@ -741,7 +738,7 @@ future<typename ResultBuilder::result_type> do_query(
         const dht::partition_range_vector& ranges,
         tracing::trace_state_ptr trace_state,
         db::timeout_clock::time_point timeout,
-        noncopyable_function<ResultBuilder(const compact_for_result_state<ResultBuilder>&)> result_builder_factory) {
+        noncopyable_function<ResultBuilder(const compact_for_query_state_v2&)> result_builder_factory) {
     auto ctx = seastar::make_shared<read_context>(db, s, cmd, ranges, trace_state, timeout);
 
     // Use coroutine::as_future to prevent exception on timesout.
@@ -769,7 +766,7 @@ static future<std::tuple<foreign_ptr<lw_shared_ptr<typename ResultBuilder::resul
         const dht::partition_range_vector& ranges,
         tracing::trace_state_ptr trace_state,
         db::timeout_clock::time_point timeout,
-        std::function<ResultBuilder(query::result_memory_accounter&&, const compact_for_result_state<ResultBuilder>&)> result_builder_factory) {
+        std::function<ResultBuilder(query::result_memory_accounter&&, const compact_for_query_state_v2&)> result_builder_factory) {
     if (cmd.get_row_limit() == 0 || cmd.slice.partition_row_limit() == 0 || cmd.partition_limit == 0) {
         co_return std::tuple(
                 make_foreign(make_lw_shared<typename ResultBuilder::result_type>()),
@@ -784,7 +781,7 @@ static future<std::tuple<foreign_ptr<lw_shared_ptr<typename ResultBuilder::resul
         auto accounter = co_await local_db.get_result_memory_limiter().new_mutation_read(*cmd.max_result_size, short_read_allowed);
 
         auto result = co_await do_query<ResultBuilder>(db, s, cmd, ranges, std::move(trace_state), timeout,
-                [result_builder_factory, accounter = std::move(accounter)] (const compact_for_result_state<ResultBuilder>& compaction_state) mutable {
+                [result_builder_factory, accounter = std::move(accounter)] (const compact_for_query_state_v2& compaction_state) mutable {
 			return result_builder_factory(std::move(accounter), compaction_state);
 		});
 
@@ -825,13 +822,13 @@ public:
     using result_type = query::result;
 
 private:
-    const compact_for_result_state<data_query_result_builder>& _compaction_state;
+    const compact_for_query_state_v2& _compaction_state;
     std::unique_ptr<query::result::builder> _res_builder;
     query_result_builder _builder;
 
 public:
     data_query_result_builder(const schema& s, const query::partition_slice& slice, query::result_options opts,
-            query::result_memory_accounter&& accounter, const compact_for_result_state<data_query_result_builder>& compaction_state)
+            query::result_memory_accounter&& accounter, const compact_for_query_state_v2& compaction_state)
         : _compaction_state(compaction_state)
         , _res_builder(std::make_unique<query::result::builder>(slice, opts, std::move(accounter)))
         , _builder(s, *_res_builder) { }
@@ -863,7 +860,7 @@ future<std::tuple<foreign_ptr<lw_shared_ptr<reconcilable_result>>, cache_tempera
     schema_ptr query_schema = cmd.slice.is_reversed() ? table_schema->make_reversed() : table_schema;
 
     return do_query_on_all_shards<mutation_query_result_builder>(db, query_schema, cmd, ranges, std::move(trace_state), timeout,
-            [table_schema, &cmd] (query::result_memory_accounter&& accounter, const compact_for_result_state<mutation_query_result_builder>& compaction_state) {
+            [table_schema, &cmd] (query::result_memory_accounter&& accounter, const compact_for_query_state_v2& compaction_state) {
         return mutation_query_result_builder(*table_schema, cmd.slice, std::move(accounter));
     });
 }
@@ -879,7 +876,7 @@ future<std::tuple<foreign_ptr<lw_shared_ptr<query::result>>, cache_temperature>>
     schema_ptr query_schema = cmd.slice.is_reversed() ? table_schema->make_reversed() : table_schema;
 
     return do_query_on_all_shards<data_query_result_builder>(db, query_schema, cmd, ranges, std::move(trace_state), timeout,
-            [table_schema, &cmd, opts] (query::result_memory_accounter&& accounter, const compact_for_result_state<data_query_result_builder>& compaction_state) {
+            [table_schema, &cmd, opts] (query::result_memory_accounter&& accounter, const compact_for_query_state_v2& compaction_state) {
         return data_query_result_builder(*table_schema, cmd.slice, opts, std::move(accounter), compaction_state);
     });
 }

--- a/multishard_mutation_query.cc
+++ b/multishard_mutation_query.cc
@@ -610,7 +610,7 @@ future<> read_context::save_readers(flat_mutation_reader_v2::tracked_buffer unco
 namespace {
 
 template <typename ResultType>
-using compact_for_result_state = compact_for_query_state_v2<emit_only_live_rows::no>;
+using compact_for_result_state = compact_for_query_state_v2;
 
 template <typename ResultBuilder>
 requires std::is_nothrow_move_constructible_v<typename ResultBuilder::result_type>

--- a/multishard_mutation_query.cc
+++ b/multishard_mutation_query.cc
@@ -610,7 +610,7 @@ future<> read_context::save_readers(flat_mutation_reader_v2::tracked_buffer unco
 namespace {
 
 template <typename ResultType>
-using compact_for_result_state = compact_for_query_state_v2<ResultType::only_live>;
+using compact_for_result_state = compact_for_query_state_v2<emit_only_live_rows::no>;
 
 template <typename ResultBuilder>
 requires std::is_nothrow_move_constructible_v<typename ResultBuilder::result_type>
@@ -803,7 +803,6 @@ namespace {
 class mutation_query_result_builder {
 public:
     using result_type = reconcilable_result;
-    static constexpr emit_only_live_rows only_live = emit_only_live_rows::no;
 
 private:
     reconcilable_result_builder _builder;
@@ -824,7 +823,6 @@ public:
 class data_query_result_builder {
 public:
     using result_type = query::result;
-    static constexpr emit_only_live_rows only_live = emit_only_live_rows::yes;
 
 private:
     const compact_for_result_state<data_query_result_builder>& _compaction_state;

--- a/multishard_mutation_query.cc
+++ b/multishard_mutation_query.cc
@@ -520,7 +520,7 @@ future<> read_context::save_reader(shard_id shard, const dht::decorated_key& las
                     last_pkey,
                     position_in_partition(last_pos));
 
-            db.get_querier_cache().insert(query_uuid, std::move(querier), gts.get());
+            db.get_querier_cache().insert_shard_querier(query_uuid, std::move(querier), gts.get());
 
             db.get_stats().multishard_query_unpopped_fragments += fragments;
             db.get_stats().multishard_query_unpopped_bytes += (size_after - size_before);

--- a/mutation_compactor.hh
+++ b/mutation_compactor.hh
@@ -269,11 +269,6 @@ private:
     };
 
 public:
-    struct parameters {
-        static constexpr emit_only_live_rows only_live = OnlyLive;
-        static constexpr compact_for_sstables sstable_compaction = SSTableCompaction;
-    };
-
     compact_mutation_state(compact_mutation_state&&) = delete; // Because 'this' is captured
 
     compact_mutation_state(const schema& s, gc_clock::time_point query_time, const query::partition_slice& slice, uint64_t limit,

--- a/mutation_partition.cc
+++ b/mutation_partition.cc
@@ -2206,7 +2206,7 @@ to_data_query_result(const reconcilable_result& r, schema_ptr s, const query::pa
         query::result_options opts) {
     // This result was already built with a limit, don't apply another one.
     query::result::builder builder(slice, opts, query::result_memory_accounter{ query::result_memory_limiter::unlimited_result_size });
-    auto consumer = compact_for_query_v2<emit_only_live_rows::no, query_result_builder>(*s, gc_clock::time_point::min(), slice, max_rows,
+    auto consumer = compact_for_query_v2<query_result_builder>(*s, gc_clock::time_point::min(), slice, max_rows,
             max_partitions, query_result_builder(*s, builder));
     auto compaction_state = consumer.get_state();
     const auto reverse = slice.options.contains(query::partition_slice::option::reversed) ? consume_in_reverse::legacy_half_reverse : consume_in_reverse::no;
@@ -2238,7 +2238,7 @@ to_data_query_result(const reconcilable_result& r, schema_ptr s, const query::pa
 query::result
 query_mutation(mutation&& m, const query::partition_slice& slice, uint64_t row_limit, gc_clock::time_point now, query::result_options opts) {
     query::result::builder builder(slice, opts, query::result_memory_accounter{ query::result_memory_limiter::unlimited_result_size });
-    auto consumer = compact_for_query_v2<emit_only_live_rows::no, query_result_builder>(*m.schema(), now, slice, row_limit,
+    auto consumer = compact_for_query_v2<query_result_builder>(*m.schema(), now, slice, row_limit,
             query::max_partitions, query_result_builder(*m.schema(), builder));
     auto compaction_state = consumer.get_state();
     const auto reverse = slice.options.contains(query::partition_slice::option::reversed) ? consume_in_reverse::legacy_half_reverse : consume_in_reverse::no;
@@ -2468,7 +2468,7 @@ future<mutation_opt> counter_write_query(schema_ptr s, const mutation_source& so
     // do_with() doesn't support immovable objects
     auto r_a_r = std::make_unique<range_and_reader>(s, source, std::move(permit), dk, slice, std::move(trace_ptr));
     auto cwqrb = counter_write_query_result_builder(*s);
-    auto cfq = compact_for_query_v2<emit_only_live_rows::yes, counter_write_query_result_builder>(
+    auto cfq = compact_for_query_v2<counter_write_query_result_builder>(
             *s, gc_clock::now(), slice, query::max_rows, query::max_partitions, std::move(cwqrb));
     auto f = r_a_r->reader.consume(std::move(cfq));
     return f.finally([r_a_r = std::move(r_a_r)] {

--- a/mutation_partition.cc
+++ b/mutation_partition.cc
@@ -2072,11 +2072,17 @@ void query_result_builder::consume_new_partition(const dht::decorated_key& dk) {
 void query_result_builder::consume(tombstone t) {
     _mutation_consumer->consume(t);
 }
-stop_iteration query_result_builder::consume(static_row&& sr, tombstone t, bool) {
+stop_iteration query_result_builder::consume(static_row&& sr, tombstone t, bool is_live) {
+    if (!is_live) {
+        return _stop;
+    }
     _stop = _mutation_consumer->consume(std::move(sr), t);
     return _stop;
 }
-stop_iteration query_result_builder::consume(clustering_row&& cr, row_tombstone t,  bool) {
+stop_iteration query_result_builder::consume(clustering_row&& cr, row_tombstone t,  bool is_live) {
+    if (!is_live) {
+        return _stop;
+    }
     _stop = _mutation_consumer->consume(std::move(cr), t);
     return _stop;
 }
@@ -2200,7 +2206,7 @@ to_data_query_result(const reconcilable_result& r, schema_ptr s, const query::pa
         query::result_options opts) {
     // This result was already built with a limit, don't apply another one.
     query::result::builder builder(slice, opts, query::result_memory_accounter{ query::result_memory_limiter::unlimited_result_size });
-    auto consumer = compact_for_query_v2<emit_only_live_rows::yes, query_result_builder>(*s, gc_clock::time_point::min(), slice, max_rows,
+    auto consumer = compact_for_query_v2<emit_only_live_rows::no, query_result_builder>(*s, gc_clock::time_point::min(), slice, max_rows,
             max_partitions, query_result_builder(*s, builder));
     auto compaction_state = consumer.get_state();
     const auto reverse = slice.options.contains(query::partition_slice::option::reversed) ? consume_in_reverse::legacy_half_reverse : consume_in_reverse::no;
@@ -2232,7 +2238,7 @@ to_data_query_result(const reconcilable_result& r, schema_ptr s, const query::pa
 query::result
 query_mutation(mutation&& m, const query::partition_slice& slice, uint64_t row_limit, gc_clock::time_point now, query::result_options opts) {
     query::result::builder builder(slice, opts, query::result_memory_accounter{ query::result_memory_limiter::unlimited_result_size });
-    auto consumer = compact_for_query_v2<emit_only_live_rows::yes, query_result_builder>(*m.schema(), now, slice, row_limit,
+    auto consumer = compact_for_query_v2<emit_only_live_rows::no, query_result_builder>(*m.schema(), now, slice, row_limit,
             query::max_partitions, query_result_builder(*m.schema(), builder));
     auto compaction_state = consumer.get_state();
     const auto reverse = slice.options.contains(query::partition_slice::option::reversed) ? consume_in_reverse::legacy_half_reverse : consume_in_reverse::no;
@@ -2249,11 +2255,17 @@ public:
         _mutation = mutation(_schema.shared_from_this(), dk);
     }
     void consume(tombstone) { }
-    stop_iteration consume(static_row&& sr, tombstone, bool) {
+    stop_iteration consume(static_row&& sr, tombstone, bool is_live) {
+        if (!is_live) {
+            return stop_iteration::no;
+        }
         _mutation->partition().static_row().maybe_create() = std::move(sr.cells());
         return stop_iteration::no;
     }
-    stop_iteration consume(clustering_row&& cr, row_tombstone,  bool) {
+    stop_iteration consume(clustering_row&& cr, row_tombstone,  bool is_live) {
+        if (!is_live) {
+            return stop_iteration::no;
+        }
         _mutation->partition().insert_row(_schema, cr.key(), std::move(cr).as_deletable_row());
         return stop_iteration::no;
     }

--- a/querier.cc
+++ b/querier.cc
@@ -287,15 +287,15 @@ void querier_cache::insert_querier(
   }
 }
 
-void querier_cache::insert(utils::UUID key, data_querier&& q, tracing::trace_state_ptr trace_state) {
+void querier_cache::insert_data_querier(utils::UUID key, data_querier&& q, tracing::trace_state_ptr trace_state) {
     insert_querier(key, _data_querier_index, _stats, std::move(q), _entry_ttl, std::move(trace_state));
 }
 
-void querier_cache::insert(utils::UUID key, mutation_querier&& q, tracing::trace_state_ptr trace_state) {
+void querier_cache::insert_mutation_querier(utils::UUID key, mutation_querier&& q, tracing::trace_state_ptr trace_state) {
     insert_querier(key, _mutation_querier_index, _stats, std::move(q), _entry_ttl, std::move(trace_state));
 }
 
-void querier_cache::insert(utils::UUID key, shard_mutation_querier&& q, tracing::trace_state_ptr trace_state) {
+void querier_cache::insert_shard_querier(utils::UUID key, shard_mutation_querier&& q, tracing::trace_state_ptr trace_state) {
     insert_querier(key, _shard_mutation_querier_index, _stats, std::move(q), _entry_ttl, std::move(trace_state));
 }
 

--- a/querier.cc
+++ b/querier.cc
@@ -287,11 +287,11 @@ void querier_cache::insert_querier(
   }
 }
 
-void querier_cache::insert_data_querier(utils::UUID key, data_querier&& q, tracing::trace_state_ptr trace_state) {
+void querier_cache::insert_data_querier(utils::UUID key, querier&& q, tracing::trace_state_ptr trace_state) {
     insert_querier(key, _data_querier_index, _stats, std::move(q), _entry_ttl, std::move(trace_state));
 }
 
-void querier_cache::insert_mutation_querier(utils::UUID key, mutation_querier&& q, tracing::trace_state_ptr trace_state) {
+void querier_cache::insert_mutation_querier(utils::UUID key, querier&& q, tracing::trace_state_ptr trace_state) {
     insert_querier(key, _mutation_querier_index, _stats, std::move(q), _entry_ttl, std::move(trace_state));
 }
 
@@ -348,22 +348,22 @@ std::optional<Querier> querier_cache::lookup_querier(
     return std::nullopt;
 }
 
-std::optional<data_querier> querier_cache::lookup_data_querier(utils::UUID key,
+std::optional<querier> querier_cache::lookup_data_querier(utils::UUID key,
         const schema& s,
         const dht::partition_range& range,
         const query::partition_slice& slice,
         tracing::trace_state_ptr trace_state,
         db::timeout_clock::time_point timeout) {
-    return lookup_querier<data_querier>(_data_querier_index, key, s, range, slice, std::move(trace_state), timeout);
+    return lookup_querier<querier>(_data_querier_index, key, s, range, slice, std::move(trace_state), timeout);
 }
 
-std::optional<mutation_querier> querier_cache::lookup_mutation_querier(utils::UUID key,
+std::optional<querier> querier_cache::lookup_mutation_querier(utils::UUID key,
         const schema& s,
         const dht::partition_range& range,
         const query::partition_slice& slice,
         tracing::trace_state_ptr trace_state,
         db::timeout_clock::time_point timeout) {
-    return lookup_querier<mutation_querier>(_mutation_querier_index, key, s, range, slice, std::move(trace_state), timeout);
+    return lookup_querier<querier>(_mutation_querier_index, key, s, range, slice, std::move(trace_state), timeout);
 }
 
 std::optional<shard_mutation_querier> querier_cache::lookup_shard_mutation_querier(utils::UUID key,

--- a/querier.hh
+++ b/querier.hh
@@ -334,11 +334,11 @@ public:
     querier_cache(querier_cache&&) = delete;
     querier_cache& operator=(querier_cache&&) = delete;
 
-    void insert(utils::UUID key, data_querier&& q, tracing::trace_state_ptr trace_state);
+    void insert_data_querier(utils::UUID key, data_querier&& q, tracing::trace_state_ptr trace_state);
 
-    void insert(utils::UUID key, mutation_querier&& q, tracing::trace_state_ptr trace_state);
+    void insert_mutation_querier(utils::UUID key, mutation_querier&& q, tracing::trace_state_ptr trace_state);
 
-    void insert(utils::UUID key, shard_mutation_querier&& q, tracing::trace_state_ptr trace_state);
+    void insert_shard_querier(utils::UUID key, shard_mutation_querier&& q, tracing::trace_state_ptr trace_state);
 
     /// Lookup a data querier in the cache.
     ///

--- a/querier.hh
+++ b/querier.hh
@@ -183,7 +183,7 @@ public:
     }
 };
 
-using data_querier = querier<emit_only_live_rows::yes>;
+using data_querier = querier<emit_only_live_rows::no>;
 using mutation_querier = querier<emit_only_live_rows::no>;
 
 /// Local state of a multishard query.

--- a/querier.hh
+++ b/querier.hh
@@ -182,9 +182,6 @@ public:
     }
 };
 
-using data_querier = querier;
-using mutation_querier = querier;
-
 /// Local state of a multishard query.
 ///
 /// This querier is not intended to be used directly to read pages. Instead it
@@ -333,9 +330,9 @@ public:
     querier_cache(querier_cache&&) = delete;
     querier_cache& operator=(querier_cache&&) = delete;
 
-    void insert_data_querier(utils::UUID key, data_querier&& q, tracing::trace_state_ptr trace_state);
+    void insert_data_querier(utils::UUID key, querier&& q, tracing::trace_state_ptr trace_state);
 
-    void insert_mutation_querier(utils::UUID key, mutation_querier&& q, tracing::trace_state_ptr trace_state);
+    void insert_mutation_querier(utils::UUID key, querier&& q, tracing::trace_state_ptr trace_state);
 
     void insert_shard_querier(utils::UUID key, shard_mutation_querier&& q, tracing::trace_state_ptr trace_state);
 
@@ -352,7 +349,7 @@ public:
     /// The found querier is checked for a matching position and schema version.
     /// The start position of the querier is checked against the start position
     /// of the page using the `range' and `slice'.
-    std::optional<data_querier> lookup_data_querier(utils::UUID key,
+    std::optional<querier> lookup_data_querier(utils::UUID key,
             const schema& s,
             const dht::partition_range& range,
             const query::partition_slice& slice,
@@ -362,7 +359,7 @@ public:
     /// Lookup a mutation querier in the cache.
     ///
     /// See \ref lookup_data_querier().
-    std::optional<mutation_querier> lookup_mutation_querier(utils::UUID key,
+    std::optional<querier> lookup_mutation_querier(utils::UUID key,
             const schema& s,
             const dht::partition_range& range,
             const query::partition_slice& slice,

--- a/readers/mutation_readers.cc
+++ b/readers/mutation_readers.cc
@@ -1380,11 +1380,11 @@ std::pair<flat_mutation_reader_v2, queue_reader_handle_v2> make_queue_reader_v2(
 namespace {
 
 class compacting_reader : public flat_mutation_reader_v2::impl {
-    friend class compact_mutation_state<emit_only_live_rows::no, compact_for_sstables::yes>;
+    friend class compact_mutation_state<compact_for_sstables::yes>;
 
 private:
     flat_mutation_reader_v2 _reader;
-    compact_mutation_state<emit_only_live_rows::no, compact_for_sstables::yes> _compactor;
+    compact_mutation_state<compact_for_sstables::yes> _compactor;
     noop_compacted_fragments_consumer _gc_consumer;
 
     // Uncompacted stream

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -1475,7 +1475,7 @@ database::query(schema_ptr s, const query::read_command& cmd, query::result_opti
 
         if (!f.failed()) {
             if (cmd.query_uuid != utils::UUID{} && querier_opt) {
-                _querier_cache.insert(cmd.query_uuid, std::move(*querier_opt), std::move(trace_state));
+                _querier_cache.insert_data_querier(cmd.query_uuid, std::move(*querier_opt), std::move(trace_state));
             }
         } else {
             ex = f.get_exception();
@@ -1541,7 +1541,7 @@ database::query_mutations(schema_ptr s, const query::read_command& cmd, const dh
 
         if (!f.failed()) {
             if (cmd.query_uuid != utils::UUID{} && querier_opt) {
-                _querier_cache.insert(cmd.query_uuid, std::move(*querier_opt), std::move(trace_state));
+                _querier_cache.insert_mutation_querier(cmd.query_uuid, std::move(*querier_opt), std::move(trace_state));
             }
         } else {
             ex = f.get_exception();

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -1446,7 +1446,7 @@ database::query(schema_ptr s, const query::read_command& cmd, query::result_opti
     auto& semaphore = get_reader_concurrency_semaphore();
     auto max_result_size = cmd.max_result_size ? *cmd.max_result_size : get_unlimited_query_max_result_size();
 
-    std::optional<query::data_querier> querier_opt;
+    std::optional<query::querier> querier_opt;
     lw_shared_ptr<query::result> result;
     std::exception_ptr ex;
 
@@ -1512,7 +1512,7 @@ database::query_mutations(schema_ptr s, const query::read_command& cmd, const dh
     auto accounter = co_await get_result_memory_limiter().new_mutation_read(max_result_size, short_read_allwoed);
     column_family& cf = find_column_family(cmd.cf_id);
 
-    std::optional<query::mutation_querier> querier_opt;
+    std::optional<query::querier> querier_opt;
     reconcilable_result result;
     std::exception_ptr ex;
 

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -812,7 +812,7 @@ public:
         tracing::trace_state_ptr trace_state,
         query::result_memory_limiter& memory_limiter,
         db::timeout_clock::time_point timeout,
-        std::optional<query::data_querier>* saved_querier = { });
+        std::optional<query::querier>* saved_querier = { });
 
     // Performs a query on given data source returning data in reconcilable form.
     //
@@ -838,7 +838,7 @@ public:
             tracing::trace_state_ptr trace_state,
             query::result_memory_accounter accounter,
             db::timeout_clock::time_point timeout,
-            std::optional<query::mutation_querier>* saved_querier = { });
+            std::optional<query::querier>* saved_querier = { });
 
     void start();
     future<> stop();

--- a/test/boost/database_test.cc
+++ b/test/boost/database_test.cc
@@ -1093,7 +1093,7 @@ SEASTAR_TEST_CASE(database_drop_column_family_clears_querier_cache) {
 
         // we add a querier to the querier cache while the drop is ongoing
         auto& qc = db.get_querier_cache();
-        qc.insert(utils::make_random_uuid(), std::move(q), nullptr);
+        qc.insert_data_querier(utils::make_random_uuid(), std::move(q), nullptr);
         BOOST_REQUIRE_EQUAL(qc.get_stats().population, 1);
 
         op.reset(); // this should allow the drop to finish

--- a/test/boost/database_test.cc
+++ b/test/boost/database_test.cc
@@ -1078,7 +1078,7 @@ SEASTAR_TEST_CASE(database_drop_column_family_clears_querier_cache) {
 
         auto op = std::optional(tbl.read_in_progress());
         auto s = tbl.schema();
-        auto q = query::data_querier(
+        auto q = query::querier(
                 tbl.as_mutation_source(),
                 tbl.schema(),
                 database_test(db).get_user_read_concurrency_semaphore().make_tracking_only_permit(s.get(), "test", db::no_timeout),

--- a/test/boost/mutation_query_test.cc
+++ b/test/boost/mutation_query_test.cc
@@ -82,7 +82,7 @@ query::result_set to_result_set(const reconcilable_result& r, schema_ptr s, cons
 static reconcilable_result mutation_query(schema_ptr s, reader_permit permit, const mutation_source& source, const dht::partition_range& range,
         const query::partition_slice& slice, uint64_t row_limit, uint32_t partition_limit, gc_clock::time_point query_time) {
 
-    auto querier = query::mutation_querier(source, s, std::move(permit), range, slice, service::get_local_sstable_query_read_priority(), {});
+    auto querier = query::querier(source, s, std::move(permit), range, slice, service::get_local_sstable_query_read_priority(), {});
     auto close_querier = deferred_close(querier);
     auto table_schema = slice.options.contains(query::partition_slice::option::reversed) ? s->make_reversed() : s;
     auto rrb = reconcilable_result_builder(*table_schema, slice, make_accounter());
@@ -533,7 +533,7 @@ SEASTAR_TEST_CASE(test_partition_limit) {
 
 static void data_query(schema_ptr s, reader_permit permit, const mutation_source& source, const dht::partition_range& range,
         const query::partition_slice& slice, query::result::builder& builder) {
-    auto querier = query::data_querier(source, s, std::move(permit), range, slice, service::get_local_sstable_query_read_priority(), {});
+    auto querier = query::querier(source, s, std::move(permit), range, slice, service::get_local_sstable_query_read_priority(), {});
     auto close_querier = deferred_close(querier);
     auto qrb = query_result_builder(*s, builder);
     querier.consume_page(std::move(qrb), std::numeric_limits<uint32_t>::max(), std::numeric_limits<uint32_t>::max(), gc_clock::now()).get();

--- a/test/boost/querier_cache_test.cc
+++ b/test/boost/querier_cache_test.cc
@@ -255,7 +255,7 @@ public:
 
     entry_info produce_first_page_and_save_data_querier(unsigned key, const dht::partition_range& range,
             const query::partition_slice& slice, uint64_t row_limit = 5) {
-        return produce_first_page_and_save_querier<query::data_querier>(&query::querier_cache::insert_data_querier, key, range, slice, row_limit);
+        return produce_first_page_and_save_querier<query::querier>(&query::querier_cache::insert_data_querier, key, range, slice, row_limit);
     }
 
     entry_info produce_first_page_and_save_data_querier(unsigned key, const dht::partition_range& range, uint64_t row_limit = 5) {
@@ -279,7 +279,7 @@ public:
 
     entry_info produce_first_page_and_save_mutation_querier(unsigned key, const dht::partition_range& range,
             const query::partition_slice& slice, uint64_t row_limit = 5) {
-        return produce_first_page_and_save_querier<query::mutation_querier>(&query::querier_cache::insert_mutation_querier, key, range, slice, row_limit);
+        return produce_first_page_and_save_querier<query::querier>(&query::querier_cache::insert_mutation_querier, key, range, slice, row_limit);
     }
 
     entry_info produce_first_page_and_save_mutation_querier(unsigned key, const dht::partition_range& range, uint64_t row_limit = 5) {

--- a/test/boost/querier_cache_test.cc
+++ b/test/boost/querier_cache_test.cc
@@ -205,8 +205,8 @@ public:
     }
 
     template <typename Querier>
-    entry_info produce_first_page_and_save_querier(unsigned key, const dht::partition_range& range,
-            const query::partition_slice& slice, uint64_t row_limit) {
+    entry_info produce_first_page_and_save_querier(void(query::querier_cache::*insert_mem_ptr)(utils::UUID, Querier&&, tracing::trace_state_ptr), unsigned key,
+            const dht::partition_range& range, const query::partition_slice& slice, uint64_t row_limit) {
         const auto cache_key = make_cache_key(key);
 
         auto querier = make_querier<Querier>(range);
@@ -214,7 +214,8 @@ public:
         auto&& dk = dk_ck.first;
         auto&& ck = dk_ck.second;
         auto permit = querier.permit();
-        _cache.insert(cache_key, std::move(querier), nullptr);
+        auto insert_fn = std::mem_fn(insert_mem_ptr);
+        insert_fn(_cache, cache_key, std::move(querier), nullptr);
 
         // Either no keys at all (nothing read) or at least partition key.
         BOOST_REQUIRE((dk && ck) || !ck);
@@ -254,7 +255,7 @@ public:
 
     entry_info produce_first_page_and_save_data_querier(unsigned key, const dht::partition_range& range,
             const query::partition_slice& slice, uint64_t row_limit = 5) {
-        return produce_first_page_and_save_querier<query::data_querier>(key, range, slice, row_limit);
+        return produce_first_page_and_save_querier<query::data_querier>(&query::querier_cache::insert_data_querier, key, range, slice, row_limit);
     }
 
     entry_info produce_first_page_and_save_data_querier(unsigned key, const dht::partition_range& range, uint64_t row_limit = 5) {
@@ -278,7 +279,7 @@ public:
 
     entry_info produce_first_page_and_save_mutation_querier(unsigned key, const dht::partition_range& range,
             const query::partition_slice& slice, uint64_t row_limit = 5) {
-        return produce_first_page_and_save_querier<query::mutation_querier>(key, range, slice, row_limit);
+        return produce_first_page_and_save_querier<query::mutation_querier>(&query::querier_cache::insert_mutation_querier, key, range, slice, row_limit);
     }
 
     entry_info produce_first_page_and_save_mutation_querier(unsigned key, const dht::partition_range& range, uint64_t row_limit = 5) {

--- a/test/perf/perf_row_cache_reads.cc
+++ b/test/perf/perf_row_cache_reads.cc
@@ -191,8 +191,7 @@ void test_scan_with_range_delete_over_rows() {
 
         auto d = duration_in_seconds([&] {
             auto slice = partition_slice_builder(*s).build();
-            auto q = query::querier<emit_only_live_rows::yes>(cache_ms, s, semaphore.make_permit(), pr, slice,
-                                                              default_priority_class(), nullptr);
+            auto q = query::querier<emit_only_live_rows::no>(cache_ms, s, semaphore.make_permit(), pr, slice, default_priority_class(), nullptr);
             auto close_q = deferred_close(q);
             q.consume_page(noop_compacted_fragments_consumer(),
                            std::numeric_limits<uint32_t>::max(),

--- a/test/perf/perf_row_cache_reads.cc
+++ b/test/perf/perf_row_cache_reads.cc
@@ -191,7 +191,7 @@ void test_scan_with_range_delete_over_rows() {
 
         auto d = duration_in_seconds([&] {
             auto slice = partition_slice_builder(*s).build();
-            auto q = query::querier<emit_only_live_rows::no>(cache_ms, s, semaphore.make_permit(), pr, slice, default_priority_class(), nullptr);
+            auto q = query::querier(cache_ms, s, semaphore.make_permit(), pr, slice, default_priority_class(), nullptr);
             auto close_q = deferred_close(q);
             q.consume_page(noop_compacted_fragments_consumer(),
                            std::numeric_limits<uint32_t>::max(),


### PR DESCRIPTION
Said parameter is a convenience so downstream consumers of the
mutation compactors don't have to check the `bool is_live` already
passed to them. This convenience however causes a template parameter and
additional logic for the compactor. As the most prominent of these
consumers (the query result builder) will soon have to switch to
`emit_only_live_rows::no` for other reasons anyway (it will want to count
tombstones), we take the opportunity to switch everybody to ::no. This
can be done with very little additional complexity to these consumers --
basically an additional if or two. With everybody using the `::no` variant
of the compactor, we can remove this template parameter and the logic
associated with it altogether.