### PR TITLE
test/scylla-gdb: detect Scylla compiled without debugging information

### DIFF
--- a/test/scylla-gdb/conftest.py
+++ b/test/scylla-gdb/conftest.py
@@ -18,6 +18,13 @@ except:
     print('This test must be run inside gdb. Run ./run instead.')
     exit(1)
 
+try:
+    gdb_library.lookup_type('size_t')
+except:
+    print(f'ERROR: Scylla executable was compiled without debugging information (-g)')
+    print(f'so cannot be used to test gdb. Please set SCYLLA environment variable.')
+    exit(1)
+
 def pytest_addoption(parser):
     parser.addoption('--scylla-pid', action='store', default=None,
         help='Process ID of running Scylla to attach gdb to')
@@ -39,7 +46,10 @@ def scylla_gdb(request):
     # Unfortunately, the file's name includes a dash which requires some
     # funky workarounds to import.
     import importlib
-    mod = importlib.import_module("scylla-gdb")
+    try:
+        mod = importlib.import_module("scylla-gdb")
+    except Exception as e:
+        pytest.exit(f'Failed to load scylla-gdb: {e}')
     sys.path = save_sys_path
     yield mod
 


### PR DESCRIPTION
test/scylla-gdb tests Scylla's gdb debugging tools, and cannot work if
Scylla was compiled without debug information (i.e, the "dev" build mode).
In the past, test/scylla-gdb/run detected this case and printed a clear error:

   Scylla executable was compiled without debugging information (-g)
   so cannot be used to test gdb. Please set SCYLLA environment variable.

Unfortunately, since recently this detection fails, because even when
Scylla is compiled without debug information we link into it a library
(libwasmtime.a) which has *some* debug information. As a result, instead
of one clear error message, we get all scylla-gdb tests running -
and each of them failing separately. This is ugly and unhelpful.

Each of the tests fail because our "gdb" test fixture tries to load
scylla-gdb.py and fails when the symbols it needs (e.g., "size_t")
cannot be found. So in this patch, we check once for the existance
of this symbol - and if missing we exit pytest instead of failing each
individual test.

Moreover, if loading scylla-gdb.py fails for some other unexpected
reason, let's exit the test as well, instead of failing each individual
test.

Fixes #10863.

Signed-off-by: Nadav Har'El <nyh@scylladb.com>