### PR TITLE
dbuild: disable selinux instead of relabeling

### DIFF
--- a/tools/toolchain/dbuild
+++ b/tools/toolchain/dbuild
@@ -170,7 +170,7 @@ else
 fi
 
 if [ "$PWD" != "$toplevel" ]; then
-     docker_common_args+=(-v "$toplevel:$toplevel:z")
+     docker_common_args+=(-v "$toplevel:$toplevel")
 fi
 
 # podman cannot relabel system directories like /tmp, but it can
@@ -180,11 +180,12 @@ tmpdir=$(mktemp -d)
 
 docker_common_args+=(
        --security-opt seccomp=unconfined \
+       --security-opt label:disable \
        --network host \
        --cap-add SYS_PTRACE \
-       -v "$PWD:$PWD:z" \
-       -v "$tmpdir:/tmp:z" \
-       -v "$MAVEN_LOCAL_REPO:$MAVEN_LOCAL_REPO:z" \
+       -v "$PWD:$PWD" \
+       -v "$tmpdir:/tmp" \
+       -v "$MAVEN_LOCAL_REPO:$MAVEN_LOCAL_REPO" \
        -v /etc/localtime:/etc/localtime:ro \
        -w "$PWD" \
        -e HOME="$HOME" \


### PR DESCRIPTION
By default, Docker uses SELinux to prevent malicious code in the container
from "escaping" and touching files outside the container: The container
is only allowed to touch files with a special SELinux label, which the
outside files simply do not have. However, this means that if you want
to "mount" outside files into the container, Docker needs to add the
special label to them. This is why one needs to use the ":z" option
when mounting an outside file inside docker - it asks docker to "relabel"
the directory to be usable in Docker.

But this relabeling process is slow and potentially harmful if done to
large directories such as your home directory, where you may theoretically
have SELinux labels for other reasons. The relabling is also unnecessary -
we don't really need the SELinux protection in dbuild. Dbuild was meant
to provide a common toolchain - it was never meant to protect the build
host from a malicious build script.

The alternative we use in this patch is "--security-opt label=disable".
This allows the container to access any file in the host filesystem,
but as usual - only if it's explicitly "mounted" into the container.
All ":z" we added in the past can be removed.

Signed-off-by: Nadav Har'El <nyh@scylladb.com>