### PR TITLE
scripts: pull_github_pr.sh: support recovering from a failed cherry-pick

### DIFF
--- a/scripts/pull_github_pr.sh
+++ b/scripts/pull_github_pr.sh
@@ -61,8 +61,13 @@ if [[ $nr_commits == 1 ]]; then
 	message="$(git log -1 "$commit" --format="format:%s%n%n%b")"
 	if ! git cherry-pick $commit
 	then
-		git cherry-pick --abort
-		exit 1
+		echo "Cherry-pick failed. You are now in a subshell. Either resolve with git cherry-pick --continue or git cherry-pick --abort, then exit the subshell"
+		head_before=$(git rev-parse HEAD)
+		bash
+		head_after=$(git rev-parse HEAD)
+		if [[ "$head_before" = "$head_after" ]]; then
+			exit 1
+		fi
 	fi
 	git commit --amend -m "${message}${closes}"
 else


### PR DESCRIPTION
If a single-patch pull request fails cherry-picking, it's still possible
to recover it (if it's a simple conflict). Give the maintainer the option
by opening a subshell and instructing them to either complete the cherry-pick
or abort it.