### PR TITLE
cql3: refactor of native types parsing

### DIFF
--- a/cql3/Cql.g
+++ b/cql3/Cql.g
@@ -1859,7 +1859,7 @@ unreserved_keyword returns [sstring str]
 
 unreserved_function_keyword returns [sstring str]
     : u=basic_unreserved_keyword { $str = u; }
-    | t=native_or_internal_type[true]   { $str = t->as_cql3_type().to_string(); }
+    | u=type_unreserved_keyword  { $str = u; }
     ;
 
 basic_unreserved_keyword returns [sstring str]
@@ -1923,6 +1923,32 @@ basic_unreserved_keyword returns [sstring str]
         | K_LEVEL
         | K_LEVELS
         | K_PRUNE
+        ) { $str = $k.text; }
+    ;
+
+type_unreserved_keyword returns [sstring str]
+    : k=( K_ASCII
+        | K_BIGINT
+        | K_BLOB
+        | K_BOOLEAN
+        | K_COUNTER
+        | K_DECIMAL
+        | K_DOUBLE
+        | K_DURATION
+        | K_FLOAT
+        | K_INET
+        | K_INT
+        | K_SMALLINT
+        | K_TEXT
+        | K_TIMESTAMP
+        | K_TINYINT
+        | K_UUID
+        | K_VARCHAR
+        | K_VARINT
+        | K_TIMEUUID
+        | K_DATE
+        | K_TIME
+        | K_EMPTY
         ) { $str = $k.text; }
     ;
 

--- a/test/cql/varchar_as_table_name_test.cql
+++ b/test/cql/varchar_as_table_name_test.cql
@@ -1,0 +1,5 @@
+-- regression test for #10642
+CREATE KEYSPACE reproducer WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1};
+CREATE TABLE reproducer.varchar(pk int, ck int, PRIMARY KEY(pk, ck));
+CREATE TABLE reproducer.text(pk int, ck int, PRIMARY KEY(pk, ck));
+DROP KEYSPACE reproducer;

--- a/test/cql/varchar_as_table_name_test.result
+++ b/test/cql/varchar_as_table_name_test.result
@@ -1,0 +1,9 @@
+> -- regression test for #10642
+> CREATE KEYSPACE reproducer WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1};
+OK
+> CREATE TABLE reproducer.varchar(pk int, ck int, PRIMARY KEY(pk, ck));
+OK
+> CREATE TABLE reproducer.text(pk int, ck int, PRIMARY KEY(pk, ck));
+OK
+> DROP KEYSPACE reproducer;
+OK


### PR DESCRIPTION
Native types were parsed directly to data_type, where varchar and text were
parsed to utf8_type. To get the name of the type there was a call to
the data_type method thus getting the name of varchar type returns "text".

To fix this, added new nonterminal type_unreserved_keyword, which parse native
types to their names. It replaced native_or_internal_type in unreserved_function_keyword.

unreserved_function_keyword is also used to parse usernames, keyspace names, index names, column identifieres, service levels and role names, so this bug was repaired also in them.

Fixes: #10642