### PR TITLE
test/cql-pytest: fix test that started failing after error message change

### DIFF
--- a/test/cql-pytest/cassandra_tests/validation/operations/select_test.py
+++ b/test/cql-pytest/cassandra_tests/validation/operations/select_test.py
@@ -1860,7 +1860,7 @@ def dotestContainsOnPartitionKey(cql, test_keyspace, schema):
         execute(cql, table, "INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?)", {5: 6}, 5, 5)
         execute(cql, table, "INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?)", {7: 8}, 6, 6)
 
-        assert_invalid_message(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
+        assert_invalid_message_re(cql, table, 'allow filtering|ALLOW FILTERING',
                              "SELECT * FROM %s WHERE pk CONTAINS KEY 1")
 
         for _ in before_and_after_flush(cql, table):


### PR DESCRIPTION
Recently a change to Scylla's expression implementation changed the standard
error message copied from Cassandra:

    Cannot execute this query as it might involve data filtering and thus
    may have unpredictable performance. If you want to execute this query
    despite the performance unpredictability, use ALLOW FILTERING

In the special case where the filter is on the partition key, we changed
the message to:

    Only EQ and IN relation are supported on the partition key (unless you
    use the token() function or allow filtering)

We had a cql-pytest test translated from Cassandra's unit test that checked
the old message, and started to fail. Unfortunately nobody noticed because
a bug in test.py caused it to stop running these translated unit tests.

So in this patch, we trivially fix the test to pass again. Instead of
insisting on the old message, we check jsut for the string "allow
filtering", in lowercase or uppercase. After this patch, the tests
passes as expected on both Scylla and Cassandra.

Refs #10918 (this test failing is one of the failures reported there)
Refs #10962 (test.py stopped running this test)

Signed-off-by: Nadav Har'El <nyh@scylladb.com>