### PR TITLE
dbuild: fix --security-opt syntax

### DIFF
--- a/tools/toolchain/dbuild
+++ b/tools/toolchain/dbuild
@@ -180,7 +180,7 @@ tmpdir=$(mktemp -d)
 
 docker_common_args+=(
        --security-opt seccomp=unconfined \
-       --security-opt label:disable \
+       --security-opt label=disable \
        --network host \
        --cap-add SYS_PTRACE \
        -v "$PWD:$PWD" \


### PR DESCRIPTION
A recent change added `--security-opt label:disable` to the docker
options. There are examples of this syntax on the web, but podman
and docker manuals don't mention it and it doesn't work on my machine.

Fix it into `--security-opt label=disable`, as described by the manuals.