### PR TITLE
gms: gossiper::apply_state_locally(): make waiter list bounded

### DIFF
--- a/gms/gossiper.hh
+++ b/gms/gossiper.hh
@@ -103,6 +103,9 @@ private:
     using messaging_service = netw::messaging_service;
     using msg_addr = netw::msg_addr;
 
+    static constexpr std::chrono::minutes apply_timeout{1};
+    static constexpr size_t apply_max_queue_size{10000};
+
     void init_messaging_service_handler();
     future<> uninit_messaging_service_handler();
     future<> handle_syn_msg(msg_addr from, gossip_digest_syn syn_msg);


### PR DESCRIPTION
Currently waiter list on the _apply_state_locally_semaphore is unbounded
and not just theoretically, recently we've seen 4.4M waiters accumulate
in a customer node, eventually killing it via OOM.
This patch applies limits on the number of waiters by adding a timeout
on the wait as well as a max waiter queue limit.

Fixes: #10967

Discussion questions:
1. I don't know what (if any) impact this will have on gossip state internal consistency. In particular this patch can kill apply jobs for some of the endpoints but not for others (in the frame of a single ack message).
2. Numbers were pulled from thin-air, maybe they need to be smaller/larger.

@asias please review.