### PR TITLE
treewide: deprecate use of coroutine::make_exception

### DIFF
--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -1127,7 +1127,7 @@ future<executor::request_return_type> executor::update_table(client_state& clien
 
     for (auto& s : unsupported) {
         if (rjson::find(request, s)) {
-            co_return coroutine::make_exception(api_error::validation(s + " not supported"));
+            co_await coroutine::return_exception(api_error::validation(s + " not supported"));
         }
     }
 
@@ -1148,7 +1148,7 @@ future<executor::request_return_type> executor::update_table(client_state& clien
         // the ugly but harmless conversion to string_view here is because
         // Seastar's sstring is missing a find(std::string_view) :-()
         if (std::string_view(tab->cf_name()).find(INTERNAL_TABLE_PREFIX) == 0) {
-            co_return coroutine::make_exception(api_error::validation(format("Prefix {} is reserved for accessing internal tables", INTERNAL_TABLE_PREFIX)));
+            co_await coroutine::return_exception(api_error::validation(format("Prefix {} is reserved for accessing internal tables", INTERNAL_TABLE_PREFIX)));
         }
 
         schema_builder builder(tab);
@@ -3320,7 +3320,7 @@ future<executor::request_return_type> executor::batch_get_item(client_state& cli
     }
     elogger.trace("Unprocessed keys: {}", response["UnprocessedKeys"]);
     if (!some_succeeded && eptr) {
-        co_return coroutine::make_exception(std::move(eptr));
+        co_await coroutine::return_exception_ptr(std::move(eptr));
     }
     if (is_big(response)) {
         co_return make_streamed(std::move(response));

--- a/cql3/statements/alter_type_statement.cc
+++ b/cql3/statements/alter_type_statement.cc
@@ -117,7 +117,8 @@ alter_type_statement::prepare_schema_mutations(query_processor& qp, api::timesta
 
         co_return std::make_pair(std::move(ret), std::move(m));
     } catch(data_dictionary::no_such_keyspace& e) {
-        co_return coroutine::make_exception(exceptions::invalid_request_exception(format("Cannot alter type in unknown keyspace {}", keyspace())));
+        auto&& ex = std::make_exception_ptr(exceptions::invalid_request_exception(format("Cannot alter type in unknown keyspace {}", keyspace())));
+        co_return coroutine::exception(std::move(ex));
     }
 }
 

--- a/cql3/statements/create_type_statement.cc
+++ b/cql3/statements/create_type_statement.cc
@@ -134,7 +134,7 @@ future<std::pair<::shared_ptr<cql_transport::event::schema_change>, std::vector<
                 _name.get_string_type_name());
         } else {
             if (!_if_not_exists) {
-                co_return coroutine::make_exception(exceptions::invalid_request_exception(format("A user type of name {} already exists", _name.to_string())));
+                co_await coroutine::return_exception(exceptions::invalid_request_exception(format("A user type of name {} already exists", _name.to_string())));
             }
         }
     } catch (data_dictionary::no_such_keyspace& e) {

--- a/db/commitlog/commitlog.cc
+++ b/db/commitlog/commitlog.cc
@@ -1796,7 +1796,7 @@ future<db::commitlog::segment_manager::sseg_ptr> db::commitlog::segment_manager:
     gate::holder g(_gate);
 
     if (_shutdown) {
-        co_return coroutine::make_exception(std::runtime_error("Commitlog has been shut down. Cannot add data"));
+        co_await coroutine::return_exception(std::runtime_error("Commitlog has been shut down. Cannot add data"));
     }
 
     ++_new_counter;

--- a/service/migration_manager.cc
+++ b/service/migration_manager.cc
@@ -695,8 +695,9 @@ future<std::vector<mutation>> migration_manager::prepare_column_family_update_an
         });
         co_return co_await include_keyspace(*keyspace, std::move(mutations));
     } catch (const replica::no_such_column_family& e) {
-        co_return coroutine::make_exception(exceptions::configuration_exception(format("Cannot update non existing table '{}' in keyspace '{}'.",
+        auto&& ex = std::make_exception_ptr(exceptions::configuration_exception(format("Cannot update non existing table '{}' in keyspace '{}'.",
                                                          cfm->cf_name(), cfm->ks_name())));
+        co_return coroutine::exception(std::move(ex));
     }
 }
 
@@ -762,7 +763,7 @@ future<std::vector<mutation>> migration_manager::prepare_column_family_drop_anno
         auto& old_cfm = db.find_column_family(ks_name, cf_name);
         auto& schema = old_cfm.schema();
         if (schema->is_view()) {
-            co_return coroutine::make_exception(exceptions::invalid_request_exception("Cannot use DROP TABLE on Materialized View"));
+            co_await coroutine::return_exception(exceptions::invalid_request_exception("Cannot use DROP TABLE on Materialized View"));
         }
         auto keyspace = db.find_keyspace(ks_name).metadata();
 
@@ -774,7 +775,7 @@ future<std::vector<mutation>> migration_manager::prepare_column_family_drop_anno
             auto explicit_view_names = views
                                     | boost::adaptors::filtered([&old_cfm](const view_ptr& v) { return !old_cfm.get_index_manager().is_index(v); })
                                     | boost::adaptors::transformed([](const view_ptr& v) { return v->cf_name(); });
-            co_return coroutine::make_exception(exceptions::invalid_request_exception(format("Cannot drop table when materialized views still depend on it ({}.{{{}}})",
+            co_await coroutine::return_exception(exceptions::invalid_request_exception(format("Cannot drop table when materialized views still depend on it ({}.{{{}}})",
                         schema->ks_name(), ::join(", ", explicit_view_names))));
         }
         mlogger.info("Drop table '{}.{}'", schema->ks_name(), schema->cf_name());
@@ -800,7 +801,8 @@ future<std::vector<mutation>> migration_manager::prepare_column_family_drop_anno
         });
         co_return co_await include_keyspace(*keyspace, std::move(mutations));
     } catch (const replica::no_such_column_family& e) {
-        co_return coroutine::make_exception(exceptions::configuration_exception(format("Cannot drop non existing table '{}' in keyspace '{}'.", cf_name, ks_name)));
+        auto&& ex = std::make_exception_ptr(exceptions::configuration_exception(format("Cannot drop non existing table '{}' in keyspace '{}'.", cf_name, ks_name)));
+        co_return coroutine::exception(std::move(ex));
     }
 }
 
@@ -827,7 +829,8 @@ future<std::vector<mutation>> migration_manager::prepare_new_view_announcement(v
         auto mutations = db::schema_tables::make_create_view_mutations(keyspace, std::move(view), ts);
         co_return co_await include_keyspace(*keyspace, std::move(mutations));
     } catch (const replica::no_such_keyspace& e) {
-        co_return coroutine::make_exception(exceptions::configuration_exception(format("Cannot add view '{}' to non existing keyspace '{}'.", view->cf_name(), view->ks_name())));
+        auto&& ex = std::make_exception_ptr(exceptions::configuration_exception(format("Cannot add view '{}' to non existing keyspace '{}'.", view->cf_name(), view->ks_name())));
+        co_return coroutine::exception(std::move(ex));
     }
 }
 
@@ -840,7 +843,7 @@ future<std::vector<mutation>> migration_manager::prepare_view_update_announcemen
         auto&& keyspace = db.find_keyspace(view->ks_name()).metadata();
         auto& old_view = keyspace->cf_meta_data().at(view->cf_name());
         if (!old_view->is_view()) {
-            co_return coroutine::make_exception(exceptions::invalid_request_exception("Cannot use ALTER MATERIALIZED VIEW on Table"));
+            co_await coroutine::return_exception(exceptions::invalid_request_exception("Cannot use ALTER MATERIALIZED VIEW on Table"));
         }
 #if 0
         oldCfm.validateCompatility(cfm);
@@ -849,8 +852,9 @@ future<std::vector<mutation>> migration_manager::prepare_view_update_announcemen
         auto mutations = db::schema_tables::make_update_view_mutations(keyspace, view_ptr(old_view), std::move(view), ts, true);
         co_return co_await include_keyspace(*keyspace, std::move(mutations));
     } catch (const std::out_of_range& e) {
-        co_return coroutine::make_exception(exceptions::configuration_exception(format("Cannot update non existing materialized view '{}' in keyspace '{}'.",
+        auto&& ex = std::make_exception_ptr(exceptions::configuration_exception(format("Cannot update non existing materialized view '{}' in keyspace '{}'.",
                                                          view->cf_name(), view->ks_name())));
+        co_return coroutine::exception(std::move(ex));
     }
 }
 


### PR DESCRIPTION
Convert most use sites from `co_return coroutine::make_exception`
to `co_await coroutine::return_exception{,_ptr}` where possible.

In cases this is done in a catch clause, convert to
`co_return coroutine::exception`, generating an exception_ptr
if needed.

Signed-off-by: Benny Halevy <bhalevy@scylladb.com>