### PR TITLE
Backport 5.0: handle errors during snapshot

### DIFF
--- a/api/api-doc/storage_service.json
+++ b/api/api-doc/storage_service.json
@@ -624,7 +624,7 @@
                   },
                   {
                      "name":"kn",
-                     "description":"Comma seperated keyspaces name to snapshot",
+                     "description":"Keyspace(s) to snapshot. Multiple keyspaces can be provided using a comma-separated list. If omitted, snapshot all keyspaces.",
                      "required":false,
                      "allowMultiple":false,
                      "type":"string",
@@ -632,7 +632,7 @@
                   },
                   {
                      "name":"cf",
-                     "description":"the column family to snapshot",
+                     "description":"Table(s) to snapshot. Multiple tables (in a single keyspace) can be provided using a comma-separated list. If omitted, snapshot all tables in the given keyspace(s).",
                      "required":false,
                      "allowMultiple":false,
                      "type":"string",

--- a/db/legacy_schema_migrator.cc
+++ b/db/legacy_schema_migrator.cc
@@ -574,12 +574,8 @@ public:
     }
 
     future<> flush_schemas() {
-        return _qp.proxy().get_db().invoke_on_all([this] (replica::database& db) {
-            return parallel_for_each(db::schema_tables::all_table_names(schema_features::full()), [this, &db](const sstring& cf_name) {
-                auto& cf = db.find_column_family(db::schema_tables::NAME, cf_name);
-                return cf.flush();
-            });
-        });
+        auto& db = _qp.db().real_database();
+        return db.flush_on_all(db::schema_tables::NAME, db::schema_tables::all_table_names(schema_features::full()));
     }
 
     future<> migrate() {

--- a/db/snapshot-ctl.cc
+++ b/db/snapshot-ctl.cc
@@ -11,6 +11,8 @@
  */
 
 #include <boost/range/adaptors.hpp>
+#include <seastar/core/coroutine.hh>
+#include <seastar/coroutine/maybe_yield.hh>
 #include "db/snapshot-ctl.hh"
 #include "replica/database.hh"
 
@@ -59,20 +61,17 @@ future<> snapshot_ctl::take_snapshot(sstring tag, std::vector<sstring> keyspace_
         boost::copy(_db.local().get_keyspaces() | boost::adaptors::map_keys, std::back_inserter(keyspace_names));
     };
 
-    return run_snapshot_modify_operation([tag = std::move(tag), keyspace_names = std::move(keyspace_names), sf, this] {
-        return parallel_for_each(keyspace_names, [tag, this] (auto& ks_name) {
-            return check_snapshot_not_exist(ks_name, tag);
-        }).then([this, tag, keyspace_names, sf] {
-            return _db.invoke_on_all([tag = std::move(tag), keyspace_names, sf] (replica::database& db) {
-                return parallel_for_each(keyspace_names, [&db, tag = std::move(tag), sf] (auto& ks_name) {
-                    auto& ks = db.find_keyspace(ks_name);
-                    return parallel_for_each(ks.metadata()->cf_meta_data(), [&db, tag = std::move(tag), sf] (auto& pair) {
-                        auto& cf = db.find_column_family(pair.second);
-                        return cf.snapshot(db, tag, bool(sf));
-                    });
-                });
-            });
-        });
+    return run_snapshot_modify_operation([tag = std::move(tag), keyspace_names = std::move(keyspace_names), sf, this] () mutable {
+        return do_take_snapshot(std::move(tag), std::move(keyspace_names), sf);
+    });
+}
+
+future<> snapshot_ctl::do_take_snapshot(sstring tag, std::vector<sstring> keyspace_names, skip_flush sf) {
+    co_await parallel_for_each(keyspace_names, [tag, this] (const auto& ks_name) {
+        return check_snapshot_not_exist(ks_name, tag);
+    });
+    co_await parallel_for_each(keyspace_names, [this, tag = std::move(tag), sf] (const auto& ks_name) {
+        return _db.local().snapshot_on_all(ks_name, tag, bool(sf));
     });
 }
 
@@ -87,21 +86,21 @@ future<> snapshot_ctl::take_column_family_snapshot(sstring ks_name, std::vector<
         throw std::runtime_error("You must supply a snapshot name.");
     }
 
-    return run_snapshot_modify_operation([this, ks_name = std::move(ks_name), tables = std::move(tables), tag = std::move(tag), sf] {
-        return check_snapshot_not_exist(ks_name, tag, tables).then([this, ks_name, tables, tag, sf] {
-            return do_with(std::vector<sstring>(std::move(tables)),[this, ks_name, tag, sf](const std::vector<sstring>& tables) {
-                return do_for_each(tables, [ks_name, tag, sf, this] (const sstring& table_name) {
-                    if (table_name.find(".") != sstring::npos) {
-                        throw std::invalid_argument("Cannot take a snapshot of a secondary index by itself. Run snapshot on the table that owns the index.");
-                    }
-                    return _db.invoke_on_all([ks_name, table_name, tag, sf] (replica::database &db) {
-                        auto& cf = db.find_column_family(ks_name, table_name);
-                        return cf.snapshot(db, tag, bool(sf));
-                    });
-                });
-            });
-        });
+    return run_snapshot_modify_operation([this, ks_name = std::move(ks_name), tables = std::move(tables), tag = std::move(tag), sf] () mutable {
+        return do_take_column_family_snapshot(std::move(ks_name), std::move(tables), std::move(tag), sf);
     });
+}
+
+future<> snapshot_ctl::do_take_column_family_snapshot(sstring ks_name, std::vector<sstring> tables, sstring tag, skip_flush sf) {
+    co_await check_snapshot_not_exist(ks_name, tag, tables);
+
+    for (const auto& table_name : tables) {
+        auto& cf = _db.local().find_column_family(ks_name, table_name);
+        if (cf.schema()->is_view()) {
+            throw std::invalid_argument("Do not take a snapshot of a materialized view or a secondary index by itself. Run snapshot on the base table instead.");
+        }
+    }
+    co_await _db.local().snapshot_on_all(ks_name, std::move(tables), std::move(tag), bool(sf));
 }
 
 future<> snapshot_ctl::take_column_family_snapshot(sstring ks_name, sstring cf_name, sstring tag, skip_flush sf) {

--- a/db/snapshot-ctl.hh
+++ b/db/snapshot-ctl.hh
@@ -97,6 +97,9 @@ private:
 
     template <typename Func>
     std::result_of_t<Func()> run_snapshot_list_operation(Func&&);
+
+    future<> do_take_snapshot(sstring tag, std::vector<sstring> keyspace_names, skip_flush sf = skip_flush::no);
+    future<> do_take_column_family_snapshot(sstring ks_name, std::vector<sstring> tables, sstring tag, skip_flush sf = skip_flush::no);
 };
 
 }

--- a/test/boost/database_test.cc
+++ b/test/boost/database_test.cc
@@ -391,11 +391,14 @@ future<> do_with_some_data(std::function<future<> (cql_test_env& env)> func, lw_
     });
 }
 
-future<> take_snapshot(sharded<replica::database>& db, bool skip_flush = false) {
-    return db.invoke_on_all([skip_flush] (replica::database& db) {
-        auto& cf = db.find_column_family("ks", "cf");
-        return cf.snapshot(db, "test", skip_flush);
-    });
+future<> take_snapshot(sharded<replica::database>& db, bool skip_flush = false, sstring ks_name = "ks", sstring cf_name = "cf", sstring snapshot_name = "test") {
+    try {
+        co_await db.local().snapshot_on_all(ks_name, {cf_name}, snapshot_name, skip_flush);
+    } catch (...) {
+        testlog.error("Could not take snapshot for {}.{} snapshot_name={} skip_flush={}: {}",
+                ks_name, cf_name, snapshot_name, skip_flush, std::current_exception());
+        throw;
+    }
 }
 
 future<> take_snapshot(cql_test_env& e, bool skip_flush = false) {

--- a/test/boost/extensions_test.cc
+++ b/test/boost/extensions_test.cc
@@ -89,10 +89,7 @@ SEASTAR_TEST_CASE(simple_sstable_extension) {
             // minimal data
             return e.execute_cql("insert into ks.cf (id, value) values (1, 100);").discard_result().then([&e] {
                 // flush all shards
-                return e.db().invoke_on_all([](replica::database& db) {
-                    auto& cf = db.find_column_family("ks", "cf");
-                    return cf.flush();
-                }).then([] {
+                return e.db().local().flush_on_all("ks", "cf").then([] {
                     BOOST_REQUIRE(counter > 1);
                 });
             });

--- a/test/cql-pytest/util.py
+++ b/test/cql-pytest/util.py
@@ -105,6 +105,19 @@ def new_materialized_view(cql, table, select, pk, where):
     finally:
         cql.execute(f"DROP MATERIALIZED VIEW {mv}")
 
+# A utility function for creating a new temporary secondary index of
+# an existing table.
+@contextmanager
+def new_secondary_index(cql, table, column, name='', extra=''):
+    keyspace = table.split('.')[0]
+    if not name:
+        name = unique_name()
+    cql.execute(f"CREATE INDEX {name} ON {table} ({column}) {extra}")
+    try:
+        yield f"{keyspace}.{name}"
+    finally:
+        cql.execute(f"DROP INDEX {keyspace}.{name}")
+
 def project(column_name_string, rows):
     """Returns a list of column values from each of the rows."""
     return [getattr(r, column_name_string) for r in rows]

--- a/test/rest_api/rest_util.py
+++ b/test/rest_api/rest_util.py
@@ -1,0 +1,32 @@
+import time
+
+from contextlib import contextmanager
+
+# A utility function for creating a new temporary snapshot.
+# If no keyspaces are given, a snapshot is taken over all keyspaces and tables.
+# If no tables are given, a snapshot is taken over all tables in the keyspace.
+# If no tag is given, a unique tag will be computed using the current time, in milliseconds.
+# It can be used in a "with", as:
+#   with new_test_snapshot(cql, tag, keyspace, [table(s)]) as snapshot:
+# This is not a fixture - see those in conftest.py.
+@contextmanager
+def new_test_snapshot(rest_api, keyspaces=[], tables=[], tag=""):
+    if not tag:
+        tag = f"test_snapshot_{int(time.time() * 1000)}"
+    params = { "tag": tag }
+    if type(keyspaces) is str:
+        params["kn"] = keyspaces
+    else:
+        params["kn"] = ",".join(keyspaces)
+    if tables:
+        if type(tables) is str:
+            params["cf"] = tables
+        else:
+            params["cf"] = ",".join(tables)
+    resp = rest_api.send("POST", "storage_service/snapshots", params)
+    resp.raise_for_status()
+    try:
+        yield tag
+    finally:
+        resp = rest_api.send("DELETE", "storage_service/snapshots", params)
+        resp.raise_for_status()

--- a/test/rest_api/test_storage_service.py
+++ b/test/rest_api/test_storage_service.py
@@ -8,7 +8,8 @@ import requests
 
 # Use the util.py library from ../cql-pytest:
 sys.path.insert(1, sys.path[0] + '/../cql-pytest')
-from util import unique_name, new_test_table
+from util import unique_name, new_test_table, new_test_keyspace, new_materialized_view, new_secondary_index
+from rest_util import new_test_snapshot
 
 # "keyspace" function: Creates and returns a temporary keyspace to be
 # used in tests that need a keyspace. The keyspace is created with RF=1,
@@ -95,3 +96,110 @@ def test_storage_service_keyspace_offstrategy_compaction_tables(cql, this_dc, re
             assert resp.status_code == requests.codes.bad_request
 
     cql.execute(f"DROP KEYSPACE {keyspace}")
+
+def test_storage_service_snapshot(cql, this_dc, rest_api):
+    resp = rest_api.send("GET", "storage_service/snapshots")
+    resp.raise_for_status()
+
+    def verify_snapshot_details(expected):
+        resp = rest_api.send("GET", "storage_service/snapshots")
+        found = False
+        for data in resp.json():
+            if data['key'] == expected['key']:
+                assert not found
+                found = True
+                sort_key = lambda v: f"{v['ks']}-{v['cf']}"
+                value = sorted([v for v in data['value'] if not v['ks'].startswith('system')], key=sort_key)
+                expected_value = sorted(expected['value'], key=sort_key)
+                assert len(value) == len(expected_value), f"length mismatch: expected {expected_value} but got {value}"
+                for i in range(len(value)):
+                    v = value[i]
+                    # normalize `total` and `live`
+                    # since we care only if they are zero or not
+                    v['total'] = 1 if v['total'] else 0
+                    v['live'] = 1 if v['live'] else 0
+                    ev = expected_value[i]
+                    assert v == ev
+        assert found, f"key='{expected['key']}' not found in {resp.json()}"
+
+    with new_test_keyspace(cql, f"WITH REPLICATION = {{ 'class' : 'NetworkTopologyStrategy', '{this_dc}' : 1 }}") as keyspace0:
+        with new_test_table(cql, keyspace0, "p text PRIMARY KEY") as table00:
+            ks0, cf00 = table00.split('.')
+            stmt = cql.prepare(f"INSERT INTO {table00} (p) VALUES (?)")
+            cql.execute(stmt, ["pk0"])
+
+            # single keyspace / table
+            with new_test_snapshot(rest_api, ks0, cf00) as snapshot0:
+                verify_snapshot_details({
+                    'key': snapshot0,
+                    'value': [{'ks': ks0, 'cf': cf00, 'total': 1, 'live': 0}]
+                })
+
+                cql.execute(f"TRUNCATE {table00}")
+                verify_snapshot_details({
+                    'key': snapshot0,
+                    'value': [{'ks': ks0, 'cf': cf00, 'total': 1, 'live': 1}]
+                })
+
+            with new_test_table(cql, keyspace0, "p text PRIMARY KEY") as table01:
+                _, cf01 = table01.split('.')
+                stmt = cql.prepare(f"INSERT INTO {table01} (p) VALUES (?)")
+                cql.execute(stmt, ["pk1"])
+
+                # single keyspace / multiple tables
+                with new_test_snapshot(rest_api, ks0, [cf00, cf01]) as snapshot1:
+                    verify_snapshot_details({
+                        'key': snapshot1,
+                        'value': [
+                            {'ks': ks0, 'cf': cf00, 'total': 0, 'live': 0},
+                            {'ks': ks0, 'cf': cf01, 'total': 1, 'live': 0}
+                        ]
+                    })
+
+                with new_test_keyspace(cql, f"WITH REPLICATION = {{ 'class' : 'NetworkTopologyStrategy', '{this_dc}' : 1 }}") as keyspace1:
+                    with new_test_table(cql, keyspace1, "p text PRIMARY KEY") as table10:
+                        ks1, cf10 = table10.split('.')
+
+                        # multiple keyspaces
+                        with new_test_snapshot(rest_api, [ks0, ks1]) as snapshot2:
+                            verify_snapshot_details({
+                                'key': snapshot2,
+                                'value': [
+                                    {'ks': ks0, 'cf': cf00, 'total': 0, 'live': 0},
+                                    {'ks': ks0, 'cf': cf01, 'total': 1, 'live': 0},
+                                    {'ks': ks1, 'cf': cf10, 'total': 0, 'live': 0}
+                                ]
+                            })
+
+                        # all keyspaces
+                        with new_test_snapshot(rest_api, ) as snapshot3:
+                            verify_snapshot_details({
+                                'key': snapshot3,
+                                'value': [
+                                    {'ks': ks0, 'cf': cf00, 'total': 0, 'live': 0},
+                                    {'ks': ks0, 'cf': cf01, 'total': 1, 'live': 0},
+                                    {'ks': ks1, 'cf': cf10, 'total': 0, 'live': 0}
+                                ]
+                            })
+
+# Verify that snapshots of materialized views and secondary indexes are disallowed.
+def test_storage_service_snapshot_mv_si(cql, this_dc, rest_api):
+    resp = rest_api.send("GET", "storage_service/snapshots")
+    resp.raise_for_status()
+
+    with new_test_keyspace(cql, f"WITH REPLICATION = {{ 'class' : 'NetworkTopologyStrategy', '{this_dc}' : 1 }}") as keyspace:
+        schema = 'p int, v text, primary key (p)'
+        with new_test_table(cql, keyspace, schema) as table:
+            with new_materialized_view(cql, table, '*', 'v, p', 'v is not null and p is not null') as mv:
+                try:
+                    with new_test_snapshot(rest_api, keyspace, mv.split('.')[1]) as snap:
+                        pytest.fail(f"Snapshot of materialized view {mv} should have failed")
+                except requests.HTTPError:
+                    pass
+
+            with new_secondary_index(cql, table, 'v') as si:
+                try:
+                    with new_test_snapshot(rest_api, keyspace, si.split('.')[1]) as snap:
+                        pytest.fail(f"Snapshot of secondary index {si} should have failed")
+                except requests.HTTPError:
+                    pass


### PR DESCRIPTION
This change backports 2c39c4c284bbcfc814ceda1a46ab8a681ac5f67a to 5.0
as per https://github.com/scylladb/scylla/issues/10500#issuecomment-1173065419

We've seen snapshot operations silently hanging in the field due to transient errors (e.g bad_alloc) on one of the shards
causing it to bail out, while other shards may wait for it forever to finish table::snapshot.
There is no indication in the logs about the error and further snpashot operation are block in snapshot-ctl.

This fix hardens the snapshot function so it either passes on all shards or aborts in the extreme edge case where we cannot allocate the structure needed for synchronization.