### PR TITLE
bytes_ostream: base on managed_bytes

### DIFF
--- a/test/boost/bytes_ostream_test.cc
+++ b/test/boost/bytes_ostream_test.cc
@@ -325,3 +325,12 @@ BOOST_AUTO_TEST_CASE(test_remove_suffix) {
         test(std::max(a, b), std::min(a, b));
     }
 }
+
+BOOST_AUTO_TEST_CASE(test_conversion_to_managed_bytes) {
+    bytes_ostream buf;
+    append_sequence(buf, 1024);
+    auto mb = std::move(buf).to_managed_bytes();
+    bytes_ostream buf2;
+    buf2.write(to_bytes(mb));
+    assert_sequence(buf2, 1024);
+}


### PR DESCRIPTION
bytes_ostream is an incremental builder for a discontiguous byte container.
managed_bytes is a non-incremental (size must be known up front) byte
container, that is also compatible with LSA. So far, conversion between
them involves copying. This is unfortunate, since query_result is generated
as a bytes_ostream, but is later converted to managed_bytes (today, this
is done in cql3::expr::get_non_pk_values() and
compound_view_wrapper::explode(). If the two types could be made compatible,
we could use managed_bytes_view instead of creating new objects and avoid
a copy. It's also nicer to have one less vocabulary type.

This patch makes bytes_ostream use managed_bytes' internal representation
(blob_storage instead of bytes_ostream::chunk) and provides a conversion
to managed_bytes. All bytes_ostream users are left in place, but the goal
is to make bytes_ostream a write-only type with the only observer a conversion
to managed_bytes.

It turns out to be relatively simple. The internal representations were
already similar. I made blob_storage::ref_type self-initializing to
reduce churn (good practice anyway) and added a private constructor
to managed_bytes for the conversion.

Note that bytes_ostream can only be used to construct a non-LSA managed_bytes,
but LSA uses of managed_bytes are very strictly controlled (the entry
points to memtable and cache) so that's not a problem.

A unit test is added.