### PR TITLE
Always register fully expired sstables for compaction

### DIFF
--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -164,6 +164,10 @@ bool compaction_manager::can_register_compaction(replica::table* t, int weight, 
     if (!t->get_compaction_strategy().parallel_compaction() && has_table_ongoing_compaction(t)) {
         return false;
     }
+    // Weightless compaction doesn't have to be serialized, and won't dillute overall efficiency.
+    if (!weight) {
+        return true;
+    }
     // TODO: Maybe allow only *smaller* compactions to start? That can be done
     // by returning true only if weight is not in the set and is lower than any
     // entry in the set.

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -4578,7 +4578,8 @@ SEASTAR_TEST_CASE(max_ongoing_compaction_test) {
             return max_ongoing_compaction;
         };
 
-        BOOST_REQUIRE_EQUAL(compact_all_tables(1, 0), 1);
+        // Allow fully expired sstables to be compacted in parallel
+        BOOST_REQUIRE_LE(compact_all_tables(1, 0), num_tables);
 
         auto add_sstables_to_table = [&] (auto idx, size_t num_sstables) {
             auto s = schemas[idx];

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -4529,7 +4529,9 @@ SEASTAR_TEST_CASE(max_ongoing_compaction_test) {
                 t->stop().get();
             }
         });
-        for (auto i = 0; i < 100; i++) {
+
+        constexpr size_t num_tables = 10;
+        for (auto i = 0; i < num_tables; i++) {
             tables.push_back(make_table_with_single_fully_expired_sstable(i));
         }
 


### PR DESCRIPTION
If the compaction_descriptor returned by `time_window_compaction_strategy::get_sstables_for_compaction`
is marked with `has_only_fully_expired::yes` it should always be compacted
since `time_window_compaction_strategy::get_sstables_for_compaction` is not idempotent.

It sets `_last_expired_check` and if compaction is postponed and retried before
`expired_sstable_check_frequency` has passed, it will not look for those fully-expired
sstables again. Plus, compacting them is the cheapest possible as it does not require
reading anything, just deleting the input sstables, so there's no reason not postpone it.

Also, extend `max_ongoing_compaction_test` to test serialization of compaction jobs with the same weight.

Fixes #10989