### PR TITLE
cql-pytest: add test_permissions.py

### DIFF
--- a/test/cql-pytest/run-cassandra
+++ b/test/cql-pytest/run-cassandra
@@ -80,6 +80,7 @@ def run_cassandra_cmd(pid, dir):
               'enable_sasi_indexes: true\n' +
               'enable_user_defined_functions: true\n' +
               'authenticator: PasswordAuthenticator\n' +
+              'authorizer: CassandraAuthorizer\n' +
               'enable_materialized_views: true\n', file=f)
     print('Booting Cassandra on ' + ip + ' in ' + dir + '...')
     logsdir = os.path.join(dir, 'logs')

--- a/test/cql-pytest/run.py
+++ b/test/cql-pytest/run.py
@@ -239,6 +239,7 @@ def run_scylla_cmd(pid, dir):
         # Set up authentication in order to allow testing this module
         # and other modules dependent on it: e.g. service levels
         '--authenticator', 'PasswordAuthenticator',
+        '--authorizer', 'CassandraAuthorizer',
         '--strict-allow-filtering', 'true',
         ], env)
 

--- a/test/cql-pytest/test_permissions.py
+++ b/test/cql-pytest/test_permissions.py
@@ -1,0 +1,41 @@
+# Copyright 2021-present ScyllaDB
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+#############################################################################
+# Tests for managing permissions
+#############################################################################
+
+import pytest
+from cassandra.protocol import SyntaxException, InvalidRequest
+from util import new_test_table
+
+# Test that granting permissions to various resources works for the default user.
+# This case does not include functions, because due to differences in implementation
+# the tests will diverge between Scylla and Cassandra (e.g. there's no common language)
+# to create a user-defined function in.
+# Marked cassandra_bug, because Cassandra allows granting a DESCRIBE permission
+# to a specific ROLE, in contradiction to its own documentation:
+# https://cassandra.apache.org/doc/latest/cassandra/cql/security.html#cql-permissions
+def test_grant_applicable_data_and_role_permissions(cql, test_keyspace, cassandra_bug):
+    schema = "a int primary key"
+    user = "cassandra"
+    with new_test_table(cql, test_keyspace, schema) as table:
+        # EXECUTE is not listed, as it only applies to functions, which aren't covered in this test case
+        all_permissions = set(['create', 'alter', 'drop', 'select', 'modify', 'authorize', 'describe'])
+        applicable_permissions = {
+            'all keyspaces': ['create', 'alter', 'drop', 'select', 'modify', 'authorize'],
+            f'keyspace {test_keyspace}': ['create', 'alter', 'drop', 'select', 'modify', 'authorize'],
+            f'table {table}': ['alter', 'drop', 'select', 'modify', 'authorize'],
+            'all roles': ['create', 'alter', 'drop', 'authorize', 'describe'],
+            f'role {user}': ['alter', 'drop', 'authorize'],
+        }
+        for resource, permissions in applicable_permissions.items():
+            # Applicable permissions can be legally granted
+            for permission in permissions:
+                cql.execute(f"GRANT {permission} ON {resource} TO {user}")
+            # Only applicable permissions can be granted - nonsensical combinations
+            # are refused with an error
+            for permission in all_permissions.difference(set(permissions)):
+                with pytest.raises((InvalidRequest, SyntaxException), match="support.*permissions"):
+                    cql.execute(f"GRANT {permission} ON {resource} TO {user}")

--- a/test/pylib/scylla_server.py
+++ b/test/pylib/scylla_server.py
@@ -78,6 +78,7 @@ request_timeout_in_ms: 300000
 # and other modules dependent on it: e.g. service levels
 
 authenticator: PasswordAuthenticator
+authorizer: CassandraAuthorizer
 strict_allow_filtering: true
 """
 


### PR DESCRIPTION
This new test suite is expected to gather all kinds of permissions
tests - granting, revoking, authorizing, and so on.
Right now it contains a single minimal test which ensures that
the default superuser can be granted applicable permissions,
which they already have anyway.

The test suite added in this pull request will also be useful
when developing #10633 - permissions for UDF/UDA infrastructure.
