### PR TITLE
cql3: expr: Fix handling reversed types in limits()

### DIFF
--- a/cql3/expr/expression.cc
+++ b/cql3/expr/expression.cc
@@ -265,7 +265,7 @@ bool limits(const expression& col, oper_t op, const expression& rhs, const evalu
         return false;
     }
     const auto b = evaluate(rhs, inputs).to_managed_bytes_opt();
-    return b ? limits(*lhs, op, *b, *type_of(col)) : false;
+    return b ? limits(*lhs, op, *b, type_of(col)->without_reversed()) : false;
 }
 
 /// True iff the column values are limited by t in the manner prescribed by op.
@@ -291,7 +291,7 @@ bool limits(const tuple_constructor& columns_tuple, const oper_t op, const expre
             // NULL = always fails comparison
             return false;
         }
-        const auto cmp = type_of(cv)->compare(
+        const auto cmp = type_of(cv)->without_reversed().compare(
                 *lhs,
                 *rhs[i]);
         // If the components aren't equal, then we just learned the LHS/RHS order.


### PR DESCRIPTION
There was a bug which caused incorrect results of `limits()` for columns with reversed clustering order.
Such columns have `reversed_type` as their type and this needs to be taken into account when comparing them.

It was introduced in 6d943e6cd024eb36a6ff2b8779d2760d3a74fa22.
This commit replaced uses of `get_value_comparator` with `type_of`.
The difference between them is that `get_value_comparator` applied `->without_reversed()` on the result type.

Because the type was reversed, comparisons like `1 < 2` evaluated to false.

This caused the test `testIndexOnKeyWithReverseClustering` to fail, but sadly it wasn't caught by CI because the CI itself has a bug that makes it skip some tests (#10962).
The test passes now, although it has to be run manually to check that.

Fixes: #10918