### PR TITLE
cross-tree: fix header file self-sufficiency

### DIFF
--- a/db/per_partition_rate_limit_extension.hh
+++ b/db/per_partition_rate_limit_extension.hh
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "db/per_partition_rate_limit_options.hh"
+#include "schema.hh"
 
 namespace db {
 

--- a/db/per_partition_rate_limit_options.hh
+++ b/db/per_partition_rate_limit_options.hh
@@ -12,7 +12,6 @@
 
 #include "operation_type.hh"
 #include "serializer.hh"
-#include "schema.hh"
 #include "log.hh"
 
 namespace db {

--- a/sstables/downsampling.hh
+++ b/sstables/downsampling.hh
@@ -13,6 +13,7 @@
 #include <list>
 #include <map>
 #include <vector>
+#include <array>
 #include <algorithm>
 #include <iterator>
 #include <cassert>

--- a/utils/sequenced_set.hh
+++ b/utils/sequenced_set.hh
@@ -10,6 +10,7 @@
 
 #include <vector>
 #include <unordered_set>
+#include <cstddef>
 
 namespace utils {
 /**


### PR DESCRIPTION
Scylla's coding standard requires that each header is self-sufficient,
i.e., it includes whatever other headers it needs - so it can be included
without having to include any other header before it.

We have a test for this, "ninja dev-headers", but it isn't run very
frequently, and it turns out our code deviated from this requirement
in a few places. This patch fixes those places, and after it
"ninja dev-headers" succeeds again.

Fixes #10995

Signed-off-by: Nadav Har'El <nyh@scylladb.com>