### PR TITLE
Add test cases for granting and revoking data permissions

### DIFF
--- a/test/cql-pytest/run-cassandra
+++ b/test/cql-pytest/run-cassandra
@@ -81,6 +81,8 @@ def run_cassandra_cmd(pid, dir):
               'enable_user_defined_functions: true\n' +
               'authenticator: PasswordAuthenticator\n' +
               'authorizer: CassandraAuthorizer\n' +
+              'permissions_update_interval_in_ms: 100\n' +
+              'permissions_validity_in_ms: 100\n' +
               'enable_materialized_views: true\n', file=f)
     print('Booting Cassandra on ' + ip + ' in ' + dir + '...')
     logsdir = os.path.join(dir, 'logs')

--- a/test/cql-pytest/run.py
+++ b/test/cql-pytest/run.py
@@ -241,6 +241,8 @@ def run_scylla_cmd(pid, dir):
         '--authenticator', 'PasswordAuthenticator',
         '--authorizer', 'CassandraAuthorizer',
         '--strict-allow-filtering', 'true',
+        '--permissions-update-interval-in-ms', '100',
+        '--permissions-validity-in-ms', '100',
         ], env)
 
 # Same as run_scylla_cmd, just use SSL encryption for the CQL port (same

--- a/test/cql-pytest/test_permissions.py
+++ b/test/cql-pytest/test_permissions.py
@@ -7,8 +7,9 @@
 #############################################################################
 
 import pytest
-from cassandra.protocol import SyntaxException, InvalidRequest
-from util import new_test_table
+import time
+from cassandra.protocol import SyntaxException, InvalidRequest, Unauthorized
+from util import new_test_table, new_user, new_session, new_test_keyspace, unique_name
 
 # Test that granting permissions to various resources works for the default user.
 # This case does not include functions, because due to differences in implementation
@@ -39,3 +40,86 @@ def test_grant_applicable_data_and_role_permissions(cql, test_keyspace, cassandr
             for permission in all_permissions.difference(set(permissions)):
                 with pytest.raises((InvalidRequest, SyntaxException), match="support.*permissions"):
                     cql.execute(f"GRANT {permission} ON {resource} TO {user}")
+
+
+def eventually_authorized(fun, timeout_s=10):
+    for i in range(timeout_s * 10):
+        try:
+            return fun()
+        except Unauthorized as e:
+            time.sleep(0.1)
+    return fun()
+
+def eventually_unauthorized(fun, timeout_s=10):
+    for i in range(timeout_s * 10):
+        try:
+            fun()
+            time.sleep(0.1)
+        except Unauthorized as e:
+            return
+    try:
+        fun()
+        pytest.fail(f"Function {fun} was not refused as unauthorized")
+    except Unauthorized as e:
+        return
+
+def grant(cql, permission, resource, username):
+    cql.execute(f"GRANT {permission} ON {resource} TO {username}")
+
+def revoke(cql, permission, resource, username):
+    cql.execute(f"REVOKE {permission} ON {resource} FROM {username}")
+
+# Helper function for checking that given `function` can only be executed
+# with given `permission` granted, and returns an unauthorized error
+# with the `permission` revoked.
+def check_enforced(cql, username, permission, resource, function):
+    eventually_unauthorized(function)
+    grant(cql, permission, resource, username)
+    eventually_authorized(function)
+    revoke(cql, permission, resource, username)
+    eventually_unauthorized(function)
+
+# Test that data permissions can be granted and revoked, and that they're effective
+def test_grant_revoke_data_permissions(cql, test_keyspace):
+    with new_user(cql) as username:
+        with new_session(cql, username) as user_session:
+            ks = unique_name()
+            # Permissions on all keyspaces
+            def create_keyspace_idempotent():
+                user_session.execute(f"CREATE KEYSPACE IF NOT EXISTS {ks} WITH REPLICATION = {{ 'class' : 'SimpleStrategy', 'replication_factor' : 1 }}")
+                user_session.execute(f"DROP KEYSPACE IF EXISTS {ks}")
+            check_enforced(cql, username, permission='CREATE', resource='ALL KEYSPACES', function=create_keyspace_idempotent)
+            # Permissions for a specific keyspace
+            with new_test_keyspace(cql, "WITH REPLICATION = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 }") as keyspace:
+                t = unique_name()
+                def create_table_idempotent():
+                    user_session.execute(f"CREATE TABLE IF NOT EXISTS {keyspace}.{t}(id int primary key)")
+                    cql.execute(f"DROP TABLE IF EXISTS {keyspace}.{t}")
+                eventually_unauthorized(create_table_idempotent)
+                grant(cql, 'CREATE', f'KEYSPACE {keyspace}', username)
+                eventually_authorized(create_table_idempotent)
+                cql.execute(f"CREATE TABLE {keyspace}.{t}(id int primary key)")
+                # Permissions for a specific table
+                check_enforced(cql, username, permission='ALTER', resource=f'{keyspace}.{t}',
+                        function=lambda: user_session.execute(f"ALTER TABLE {keyspace}.{t} WITH comment = 'hey'"))
+                check_enforced(cql, username, permission='SELECT', resource=f'{keyspace}.{t}',
+                        function=lambda: user_session.execute(f"SELECT * FROM {keyspace}.{t}"))
+                check_enforced(cql, username, permission='MODIFY', resource=f'{keyspace}.{t}',
+                        function=lambda: user_session.execute(f"INSERT INTO {keyspace}.{t}(id) VALUES (42)"))
+                cql.execute(f"DROP TABLE {keyspace}.{t}")
+                revoke(cql, 'CREATE', f'KEYSPACE {keyspace}', username)
+                eventually_unauthorized(create_table_idempotent)
+
+                def drop_table_idempotent():
+                    user_session.execute(f"DROP TABLE IF EXISTS {keyspace}.{t}")
+                    cql.execute(f"CREATE TABLE IF NOT EXISTS {keyspace}.{t}(id int primary key)")
+
+                cql.execute(f"CREATE TABLE {keyspace}.{t}(id int primary key)")
+                check_enforced(cql, username, permission='DROP', resource=f'KEYSPACE {keyspace}', function=drop_table_idempotent)
+                cql.execute(f"DROP TABLE {keyspace}.{t}")
+
+                # CREATE permission on all keyspaces also implies creating any tables in any keyspace
+                check_enforced(cql, username, permission='CREATE', resource='ALL KEYSPACES', function=create_table_idempotent)
+                # Same for DROP
+                cql.execute(f"CREATE TABLE IF NOT EXISTS {keyspace}.{t}(id int primary key)")
+                check_enforced(cql, username, permission='DROP', resource='ALL KEYSPACES', function=drop_table_idempotent)

--- a/test/pylib/scylla_server.py
+++ b/test/pylib/scylla_server.py
@@ -80,6 +80,9 @@ request_timeout_in_ms: 300000
 authenticator: PasswordAuthenticator
 authorizer: CassandraAuthorizer
 strict_allow_filtering: true
+
+permissions_update_interval_in_ms: 100
+permissions_validity_in_ms: 100
 """
 
 # Seastar options can not be passed through scylla.yaml, use command line


### PR DESCRIPTION
This series adds the infrastructure needed for testing user permissions, like the ability to create temporary roles and CQL sessions which log in as different users, and a few initial test cases for granting and revoking permissions.
