### PR TITLE
table: snapshot: coroutine::return_exception_ptr

### DIFF
--- a/replica/table.cc
+++ b/replica/table.cc
@@ -1423,7 +1423,7 @@ future<> table::snapshot(database& db, sstring name) {
         co_await snapshot->manifest_write.wait(1);
         tlogger.debug("snapshot {}: done: error={}", jsondir, ex);
         if (ex) {
-            co_await coroutine::return_exception(std::move(ex));
+            co_await coroutine::return_exception_ptr(std::move(ex));
         }
     });
 }


### PR DESCRIPTION
Otherwise, we lose the returned exception_ptr type.

Signed-off-by: Benny Halevy <bhalevy@scylladb.com>