### PR TITLE
Remove dropped table directory

### DIFF
--- a/db/legacy_schema_migrator.cc
+++ b/db/legacy_schema_migrator.cc
@@ -537,9 +537,7 @@ public:
         return parallel_for_each(legacy_schema_tables, [this](const sstring& cfname) {
             return do_with(utils::make_joinpoint([] { return db_clock::now();}),[this, cfname](auto& tsf) {
                 auto with_snapshot = !_keyspaces.empty();
-                return _db.invoke_on_all([&tsf, cfname, with_snapshot](replica::database& db) {
-                    return db.drop_column_family(db::system_keyspace::NAME, cfname, [&tsf] { return tsf.value(); }, with_snapshot);
-                });
+                return replica::database::drop_table_on_all_shards(_db, db::system_keyspace::NAME, cfname, [&tsf] { return tsf.value(); }, with_snapshot);
             });
         });
     }

--- a/db/legacy_schema_migrator.cc
+++ b/db/legacy_schema_migrator.cc
@@ -534,11 +534,10 @@ public:
 
     future<> drop_legacy_tables() {
         mlogger.info("Dropping legacy schema tables");
-        return parallel_for_each(legacy_schema_tables, [this](const sstring& cfname) {
-            return do_with(utils::make_joinpoint([] { return db_clock::now();}),[this, cfname](auto& tsf) {
-                auto with_snapshot = !_keyspaces.empty();
-                return replica::database::drop_table_on_all_shards(_db, db::system_keyspace::NAME, cfname, [&tsf] { return tsf.value(); }, with_snapshot);
-            });
+        auto ts = db_clock::now();
+        auto with_snapshot = !_keyspaces.empty();
+        return parallel_for_each(legacy_schema_tables, [this, ts, with_snapshot](const sstring& cfname) {
+            return replica::database::drop_table_on_all_shards(_db, db::system_keyspace::NAME, cfname, [ts] { return make_ready_future<db_clock::time_point>(ts); }, with_snapshot);
         });
     }
 

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -1029,6 +1029,13 @@ future<> database::drop_column_family(const sstring& ks_name, const sstring& cf_
     f.get(); // re-throw exception from truncate() if any
 }
 
+future<> database::drop_table_on_all_shards(sharded<database>& sharded_db, sstring ks_name, sstring cf_name, timestamp_func tsf, bool with_snapshot) {
+    co_await sharded_db.invoke_on_all([&] (database& db) {
+        return db.drop_column_family(ks_name, cf_name, tsf, with_snapshot);
+    });
+    // FIXME: remove the table directory if it has no snapshots (#10896)
+}
+
 const utils::UUID& database::find_uuid(std::string_view ks, std::string_view cf) const {
     try {
         return _ks_cf_to_uuid.at(std::make_pair(ks, cf));

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -59,6 +59,7 @@
 #include <seastar/core/shared_ptr_incomplete.hh>
 #include <seastar/coroutine/as_future.hh>
 #include <seastar/util/memory_diagnostics.hh>
+#include <seastar/util/file.hh>
 
 #include "locator/abstract_replication_strategy.hh"
 #include "timeout_config.hh"
@@ -2536,64 +2537,79 @@ future<std::vector<database::snapshot_details_result>> database::get_snapshot_de
 // (as we have been doing for a lot of the other operations, like the snapshot itself).
 future<> database::clear_snapshot(sstring tag, std::vector<sstring> keyspace_names, const sstring& table_name) {
     std::vector<sstring> data_dirs = _cfg.data_file_directories();
-    auto dirs_only_entries_ptr =
-        make_lw_shared<lister::dir_entry_types>(lister::dir_entry_types{directory_entry_type::directory});
-    lw_shared_ptr<sstring> tag_ptr = make_lw_shared<sstring>(std::move(tag));
     std::unordered_set<sstring> ks_names_set(keyspace_names.begin(), keyspace_names.end());
+    auto table_name_param = table_name;
 
-    return parallel_for_each(data_dirs, [this, tag_ptr, ks_names_set = std::move(ks_names_set), dirs_only_entries_ptr, table_name = table_name] (const sstring& parent_dir) {
-        std::unique_ptr<lister::filter_type> filter = std::make_unique<lister::filter_type>([] (const fs::path& parent_dir, const directory_entry& dir_entry) { return true; });
-
-        lister::filter_type table_filter = (table_name.empty()) ? lister::filter_type([] (const fs::path& parent_dir, const directory_entry& dir_entry) mutable { return true; }) :
-                lister::filter_type([table_name = get_snapshot_table_dir_prefix(table_name)] (const fs::path& parent_dir, const directory_entry& dir_entry) mutable {
-                    return dir_entry.name.find(table_name) == 0;
-                });
-        // if specific keyspaces names were given - filter only these keyspaces directories
-        if (!ks_names_set.empty()) {
-            filter = std::make_unique<lister::filter_type>([ks_names_set = std::move(ks_names_set)] (const fs::path& parent_dir, const directory_entry& dir_entry) {
+    // if specific keyspaces names were given - filter only these keyspaces directories
+    auto filter = ks_names_set.empty()
+            ? lister::filter_type([] (const fs::path&, const directory_entry&) { return true; })
+            : lister::filter_type([&] (const fs::path&, const directory_entry& dir_entry) {
                 return ks_names_set.contains(dir_entry.name);
             });
-        }
 
-        //
-        // The keyspace data directories and their snapshots are arranged as follows:
-        //
-        //  <data dir>
-        //  |- <keyspace name1>
-        //  |  |- <column family name1>
-        //  |     |- snapshots
-        //  |        |- <snapshot name1>
-        //  |          |- <snapshot file1>
-        //  |          |- <snapshot file2>
-        //  |          |- ...
-        //  |        |- <snapshot name2>
-        //  |        |- ...
-        //  |  |- <column family name2>
-        //  |  |- ...
-        //  |- <keyspace name2>
-        //  |- ...
-        //
-        return lister::scan_dir(parent_dir, *dirs_only_entries_ptr, [this, tag_ptr, dirs_only_entries_ptr, table_filter = std::move(table_filter)] (fs::path parent_dir, directory_entry de) mutable {
-            // KS directory
-            return lister::scan_dir(parent_dir / de.name, *dirs_only_entries_ptr, [this, tag_ptr, dirs_only_entries_ptr] (fs::path parent_dir, directory_entry de) mutable {
-                // CF directory
-                return lister::scan_dir(parent_dir / de.name, *dirs_only_entries_ptr, [this, tag_ptr, dirs_only_entries_ptr] (fs::path parent_dir, directory_entry de) mutable {
-                    // "snapshots" directory
-                    fs::path snapshots_dir(parent_dir / de.name);
-                    if (tag_ptr->empty()) {
-                        dblog.info("Removing {}", snapshots_dir.native());
-                        // kill the whole "snapshots" subdirectory
-                        return lister::rmdir(std::move(snapshots_dir));
+    // if specific table name was given - filter only these table directories
+    auto table_filter = table_name.empty()
+            ? lister::filter_type([] (const fs::path&, const directory_entry& dir_entry) { return true; })
+            : lister::filter_type([table_name = get_snapshot_table_dir_prefix(table_name)] (const fs::path&, const directory_entry& dir_entry) {
+                return dir_entry.name.find(table_name) == 0;
+            });
+
+    co_await coroutine::parallel_for_each(data_dirs, [&, this] (const sstring& parent_dir) {
+        return async([&] {
+            //
+            // The keyspace data directories and their snapshots are arranged as follows:
+            //
+            //  <data dir>
+            //  |- <keyspace name1>
+            //  |  |- <column family name1>
+            //  |     |- snapshots
+            //  |        |- <snapshot name1>
+            //  |          |- <snapshot file1>
+            //  |          |- <snapshot file2>
+            //  |          |- ...
+            //  |        |- <snapshot name2>
+            //  |        |- ...
+            //  |  |- <column family name2>
+            //  |  |- ...
+            //  |- <keyspace name2>
+            //  |- ...
+            //
+            auto data_dir = fs::path(parent_dir);
+            auto data_dir_lister = directory_lister(data_dir, {directory_entry_type::directory}, filter);
+            auto close_data_dir_lister = deferred_close(data_dir_lister);
+            dblog.debug("clear_snapshot: listing data dir {} with filter={}", data_dir, ks_names_set.empty() ? "none" : fmt::format("{}", ks_names_set));
+            while (auto ks_ent = data_dir_lister.get().get0()) {
+                auto ks_name = ks_ent->name;
+                auto ks_dir = data_dir / ks_name;
+                auto ks_dir_lister = directory_lister(ks_dir, {directory_entry_type::directory}, table_filter);
+                auto close_ks_dir_lister = deferred_close(ks_dir_lister);
+                dblog.debug("clear_snapshot: listing keyspace dir {} with filter={}", ks_dir, table_name_param.empty() ? "none" : fmt::format("{}", table_name_param));
+                while (auto table_ent = ks_dir_lister.get().get0()) {
+                    auto table_dir = ks_dir / table_ent->name;
+                    auto snapshots_dir = table_dir / sstables::snapshots_dir;
+                    auto has_snapshots = file_exists(snapshots_dir.native()).get0();
+                    if (has_snapshots) {
+                        if (tag.empty()) {
+                            dblog.info("Removing {}", snapshots_dir);
+                            recursive_remove_directory(std::move(snapshots_dir)).get();
+                        } else {
+                            // if specific snapshots tags were given - filter only these snapshot directories
+                            auto snapshots_dir_lister = directory_lister(snapshots_dir, {directory_entry_type::directory},
+                                    [&] (const fs::path&, const directory_entry& dir_entry) { return dir_entry.name == tag; });
+                            auto close_snapshots_dir_lister = deferred_close(snapshots_dir_lister);
+                            dblog.debug("clear_snapshot: listing snapshots dir {} with filter={}", snapshots_dir, tag);
+                            while (auto snapshot_ent = snapshots_dir_lister.get().get0()) {
+                                auto snapshot_dir = snapshots_dir / snapshot_ent->name;
+                                dblog.info("Removing {}", snapshot_dir);
+                                recursive_remove_directory(std::move(snapshot_dir)).get();
+                            }
+                        }
                     } else {
-                        return lister::scan_dir(std::move(snapshots_dir), *dirs_only_entries_ptr, [this, tag_ptr] (fs::path parent_dir, directory_entry de) {
-                            fs::path snapshot_dir(parent_dir / de.name);
-                            dblog.info("Removing {}", snapshot_dir.native());
-                            return lister::rmdir(std::move(snapshot_dir));
-                        }, [tag_ptr] (const fs::path& parent_dir, const directory_entry& dir_entry) { return dir_entry.name == *tag_ptr; });
+                        dblog.debug("clear_snapshot: {} not found", snapshots_dir);
                     }
-                 }, [] (const fs::path& parent_dir, const directory_entry& dir_entry) { return dir_entry.name == sstables::snapshots_dir; });
-            }, table_filter);
-        }, *filter);
+                }
+            }
+        });
     });
 }
 

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -2355,7 +2355,7 @@ future<> database::truncate(sstring ksname, sstring cfname, timestamp_func tsf) 
 }
 
 future<> database::truncate(const keyspace& ks, column_family& cf, timestamp_func tsf, bool with_snapshot) {
-    dblog.debug("Truncating {}.{}", cf.schema()->ks_name(), cf.schema()->cf_name());
+    dblog.debug("Truncating {}.{}: with_snapshot={} auto_snapshot={}", cf.schema()->ks_name(), cf.schema()->cf_name(), with_snapshot, get_config().auto_snapshot());
     auto holder = cf.async_gate().hold();
 
     const auto auto_snapshot = with_snapshot && get_config().auto_snapshot();

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -1030,10 +1030,11 @@ future<> database::drop_column_family(const sstring& ks_name, const sstring& cf_
 }
 
 future<> database::drop_table_on_all_shards(sharded<database>& sharded_db, sstring ks_name, sstring cf_name, timestamp_func tsf, bool with_snapshot) {
+    auto table_dir = fs::path(sharded_db.local().find_column_family(ks_name, cf_name).dir());
     co_await sharded_db.invoke_on_all([&] (database& db) {
         return db.drop_column_family(ks_name, cf_name, tsf, with_snapshot);
     });
-    // FIXME: remove the table directory if it has no snapshots (#10896)
+    co_await sstables::remove_table_directory_if_has_no_snapshots(table_dir);
 }
 
 const utils::UUID& database::find_uuid(std::string_view ks, std::string_view cf) const {

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1648,6 +1648,9 @@ public:
     bool update_column_family(schema_ptr s);
     future<> drop_column_family(const sstring& ks_name, const sstring& cf_name, timestamp_func, bool with_snapshot = true);
 
+    // drops the table on all shards and removes the table directory if there are no snapshots
+    static future<> drop_table_on_all_shards(sharded<database>& db, sstring ks_name, sstring cf_name, timestamp_func, bool with_snapshot = true);
+
     const logalloc::region_group& dirty_memory_region_group() const {
         return _dirty_memory_manager.region_group();
     }

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1646,8 +1646,9 @@ public:
     future<> truncate(const keyspace& ks, column_family& cf, timestamp_func, bool with_snapshot = true);
 
     bool update_column_family(schema_ptr s);
+private:
     future<> drop_column_family(const sstring& ks_name, const sstring& cf_name, timestamp_func, bool with_snapshot = true);
-
+public:
     // drops the table on all shards and removes the table directory if there are no snapshots
     static future<> drop_table_on_all_shards(sharded<database>& db, sstring ks_name, sstring cf_name, timestamp_func, bool with_snapshot = true);
 

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -3320,7 +3320,62 @@ gc_clock::time_point sstable::get_gc_before_for_fully_expire(const gc_clock::tim
     return res.knows_entire_range ? res.min_gc_before : gc_clock::time_point::min();
 }
 
+// Returns error code, 0 is success
+static future<int> remove_dir(fs::path dir, bool recursive) {
+    std::exception_ptr ex;
+    int error_code;
+    try {
+        co_await (recursive ? recursive_remove_directory(dir) : remove_file(dir.native()));
+        co_return 0;
+    } catch (const std::system_error& e) {
+        ex = std::current_exception();
+        error_code = e.code().value();
+        if (error_code == ENOENT) {
+            // Ignore missing directories
+            co_return 0;
+        }
+        if (error_code == EEXIST && !recursive) {
+            // Just return failure if the directory is not empty
+            // Let the caller decide what to do about it.
+            co_return error_code;
+        }
+    } catch (...) {
+        ex = std::current_exception();
+        error_code = -1;
+    }
+    sstlog.warn("Could not remove table directory {}: {}. Ignored.", dir, ex);
+    co_return error_code;
 }
+
+future<> remove_table_directory_if_has_no_snapshots(fs::path table_dir) {
+    // Be paranoid about risky paths
+    if (table_dir == "" || table_dir == "/") {
+        on_internal_error_noexcept(sstlog, format("Invalid table directory for removal: {}", table_dir));
+        abort();
+    }
+
+    int error = 0;
+    for (auto subdir : sstables::table_subdirectories) {
+        // Remove the snapshot directory only if empty
+        // while other subdirectories are removed recusresively.
+        auto ec = co_await remove_dir(table_dir / subdir, subdir != sstables::snapshots_dir);
+        if (subdir == sstables::snapshots_dir && ec == EEXIST) {
+            sstlog.info("Leaving table directory {} behind as it has snapshots", table_dir);
+        }
+        if (!error) {
+            error = ec;
+        }
+    }
+
+    if (!error) {
+        // Remove the table directory recursively
+        // since it may still hold leftover temporary
+        // sstable files and directories
+        co_await remove_dir(table_dir, true);
+    }
+}
+
+} // namespace sstables
 
 namespace seastar {
 

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -121,6 +121,7 @@ constexpr const char* staging_dir = "staging";
 constexpr const char* upload_dir = "upload";
 constexpr const char* snapshots_dir = "snapshots";
 constexpr const char* quarantine_dir = "quarantine";
+constexpr const char* pending_delete_dir = "pending_delete";
 
 constexpr const char* repair_origin = "repair";
 
@@ -374,7 +375,7 @@ public:
     }
 
     static sstring pending_delete_dir_basename() {
-        return "pending_delete";
+        return pending_delete_dir;
     }
 
     static bool is_pending_delete_dir(const fs::path& dirpath)

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -953,4 +953,8 @@ public:
     }
 };
 
-}
+// safely removes the table directory.
+// swallows all errors and just reports them to the log.
+future<> remove_table_directory_if_has_no_snapshots(fs::path table_dir);
+
+} // namespace sstables

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -123,6 +123,14 @@ constexpr const char* snapshots_dir = "snapshots";
 constexpr const char* quarantine_dir = "quarantine";
 constexpr const char* pending_delete_dir = "pending_delete";
 
+constexpr auto table_subdirectories = std::to_array({
+    staging_dir,
+    upload_dir,
+    snapshots_dir,
+    quarantine_dir,
+    pending_delete_dir,
+});
+
 constexpr const char* repair_origin = "repair";
 
 class sstable : public enable_lw_shared_from_this<sstable> {

--- a/test/boost/database_test.cc
+++ b/test/boost/database_test.cc
@@ -1087,9 +1087,7 @@ SEASTAR_TEST_CASE(database_drop_column_family_clears_querier_cache) {
                 default_priority_class(),
                 nullptr);
 
-        auto f = e.db().invoke_on_all([ts] (replica::database& db) {
-            return db.drop_column_family("ks", "cf", [ts] { return make_ready_future<db_clock::time_point>(ts); });
-        });
+        auto f = replica::database::drop_table_on_all_shards(e.db(), "ks", "cf", [ts] { return make_ready_future<db_clock::time_point>(ts); });
 
         // we add a querier to the querier cache while the drop is ongoing
         auto& qc = db.get_querier_cache();

--- a/test/boost/database_test.cc
+++ b/test/boost/database_test.cc
@@ -653,6 +653,16 @@ SEASTAR_TEST_CASE(clear_multiple_snapshots) {
         replica::database::drop_table_on_all_shards(e.db(), ks_name, table_name, [ts = db_clock::now()] { return make_ready_future<db_clock::time_point>(ts); }).get();
         BOOST_REQUIRE_EQUAL(fs::exists(snapshots_dir / snapshot_name(num_snapshots)), true);
 
+        // clear all tags
+        testlog.debug("Clearing all snapshots in {}.{} after it had been dropped", ks_name, table_name);
+        e.local_db().clear_snapshot("", {ks_name}, table_name).get();
+
+        assert(!fs::exists(table_dir));
+
+        // after all snapshots had been cleared,
+        // the dropped table directory is expected to be removed.
+        BOOST_REQUIRE_EQUAL(fs::exists(table_dir), false);
+
         return make_ready_future<>();
     });
 }

--- a/test/boost/database_test.cc
+++ b/test/boost/database_test.cc
@@ -645,6 +645,14 @@ SEASTAR_TEST_CASE(clear_multiple_snapshots) {
             BOOST_REQUIRE_EQUAL(fs::exists(snapshots_dir / snapshot_name(i)), false);
         }
 
+        testlog.debug("Taking an extra {} of {}.{}", snapshot_name(num_snapshots), ks_name, table_name);
+        take_snapshot(e, ks_name, table_name, snapshot_name(num_snapshots)).get();
+
+        // existing snapshots expected to remain after dropping the table
+        testlog.debug("Dropping table {}.{}", ks_name, table_name);
+        replica::database::drop_table_on_all_shards(e.db(), ks_name, table_name, [ts = db_clock::now()] { return make_ready_future<db_clock::time_point>(ts); }).get();
+        BOOST_REQUIRE_EQUAL(fs::exists(snapshots_dir / snapshot_name(num_snapshots)), true);
+
         return make_ready_future<>();
     });
 }


### PR DESCRIPTION
This series adds removal of dropped table directory when it has no remaining snapshots.

There are 2 code paths that take of that:
1. when the table is dropped and there are no active snapshots for it (typically when auto_snapshot disabled).
2. or when the last snapshot is cleared, leaving no other snapshot for a dropped table.

Unit tests were extended to covert these scenarios.

Fixes #10896