### PR TITLE
test/cql-pytest: avoid deprecation message

### DIFF
--- a/test/cql-pytest/test_secondary_index.py
+++ b/test/cql-pytest/test_secondary_index.py
@@ -79,7 +79,7 @@ def test_order_of_indexes(scylla_only, cql, test_keyspace):
         # server restart), but some of them fail. Once a proper ordering
         # is implemented, all cases below should succeed.
         def index_used(query, index_name):
-            assert any([index_name in event.description for event in cql.execute(query, trace=True).get_query_trace().events])
+            assert any([index_name in event.description for event in cql.execute(query, trace=True).one().get_query_trace().events])
         index_used(f"SELECT * FROM {table} WHERE v3 = 1", "my_v3_idx")
         index_used(f"SELECT * FROM {table} WHERE v3 = 1 and v1 = 2 allow filtering", "my_v3_idx")
         index_used(f"SELECT * FROM {table} WHERE p = 1 and v1 = 1 and v3 = 2 allow filtering", "my_v1_idx")


### PR DESCRIPTION
When running test/cql-pytest, pytest prints one warning at the end:

   /home/nyh/scylla/test/cql-pytest/test_secondary_index.py:82: DeprecationWarning: ResultSet indexing support will be removed in 4.0.
   Consider using ResultSet.one() to get a single row.
   assert any([index_name in event.description for event in cql.execute(query, trace=True).get_query_trace().events])

So in this patch I do exactly what the warning recommends - use one().

Signed-off-by: Nadav Har'El <nyh@scylladb.com>