### PR TITLE
cql-pytest: remove "xfail" mark from two passing tests

### DIFF
--- a/test/cql-pytest/cassandra_tests/validation/entities/secondary_index_test.py
+++ b/test/cql-pytest/cassandra_tests/validation/entities/secondary_index_test.py
@@ -527,8 +527,6 @@ def testIndexOnPartitionKeyWithStaticColumnAndNoRows(cql, test_keyspace):
         execute(cql, table, "UPDATE %s SET s=? WHERE pk1=? AND pk2=?", 9, 1, 20)
         assert_rows(execute(cql, table, "SELECT * FROM %s WHERE pk2 = ?", 20), [1, 20, None, 9, None])
 
-# Reproduces #8627
-@pytest.mark.xfail(reason="issue #8627")
 def testIndexOnClusteringColumnInsertValueOver64k(cql, test_keyspace):
     too_big = bytearray([1])*TOO_BIG
     with create_table(cql, test_keyspace, "(a int, b int, c blob, PRIMARY KEY ((a, b)))") as table:

--- a/test/cql-pytest/test_lwt.py
+++ b/test/cql-pytest/test_lwt.py
@@ -27,7 +27,6 @@ def table1(cql, test_keyspace):
 # As discovered in issue #10081, if the row determined by WHERE does NOT
 # exist, Scylla still needs to read the static column, but forgets to do so.
 # this test reproduces this issue.
-@pytest.mark.xfail(reason="Issue #10081")
 def test_lwt_missing_row_with_static(cql, table1):
     p = unique_key_int()
     # Insert into partition p just the static column - and no clustering rows.


### PR DESCRIPTION
Fix two cql-pytest that have been "XPASS"ing (unexpectedly passing)
by removing the "xfail" (expecting failure) mark from them:

One test was for an issue that has already been fixed (refs #10081).
The second test was a translated Cassandra test that should never
have failed because it doesn't trigger the issue that supposedly failed
it (that test sets a large value for a non-indexed column, so doesn't
trigger the problem we have with large values in an indexed column).