### PR TITLE
test/{alternator,redis}: stop using deprecated "disutils" package

### DIFF
--- a/test/alternator/conftest.py
+++ b/test/alternator/conftest.py
@@ -30,8 +30,8 @@ urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 # In particular, the BillingMode feature was added in botocore 1.12.54.
 import botocore
 import sys
-from distutils.version import LooseVersion
-if (LooseVersion(botocore.__version__) < LooseVersion('1.12.54')):
+from packaging.version import Version
+if (Version(botocore.__version__) < Version('1.12.54')):
     pytest.exit("Your Boto library is too old. Please upgrade it,\ne.g. using:\n    sudo pip{} install --upgrade boto3".format(sys.version_info[0]))
 
 # By default, tests run against a local Scylla installation on localhost:8080/.

--- a/test/alternator/test_tag.py
+++ b/test/alternator/test_tag.py
@@ -13,6 +13,7 @@ from botocore.exceptions import ClientError
 import re
 import time
 from util import multiset, create_test_table, unique_table_name, random_string
+from packaging.version import Version
 
 def delete_tags(table, arn):
     got = table.meta.client.list_tags_of_resource(ResourceArn=arn)
@@ -95,8 +96,7 @@ def test_table_tags(dynamodb):
     # https://aws.amazon.com/about-aws/whats-new/2019/04/now-you-can-tag-amazon-dynamodb-tables-when-you-create-them/
     # so older versions of the library cannot run this test.
     import botocore
-    from distutils.version import LooseVersion
-    if (LooseVersion(botocore.__version__) < LooseVersion('1.12.136')):
+    if (Version(botocore.__version__) < Version('1.12.136')):
         pytest.skip("Botocore version 1.12.136 or above required to run this test")
 
     table = create_test_table(dynamodb,
@@ -151,8 +151,7 @@ def test_too_long_tags_from_creation(dynamodb):
     # DynamoDB in April 2019, and to the botocore library in version 1.12.136
     # so older versions of the library cannot run this test.
     import botocore
-    from distutils.version import LooseVersion
-    if (LooseVersion(botocore.__version__) < LooseVersion('1.12.136')):
+    if (Version(botocore.__version__) < Version('1.12.136')):
         pytest.skip("Botocore version 1.12.136 or above required to run this test")
     name = unique_table_name()
     # Setting 100 tags is not allowed, the following table creation should fail:
@@ -177,8 +176,7 @@ def test_forbidden_tags_from_creation(scylla_only, dynamodb):
     # DynamoDB in April 2019, and to the botocore library in version 1.12.136
     # so older versions of the library cannot run this test.
     import botocore
-    from distutils.version import LooseVersion
-    if (LooseVersion(botocore.__version__) < LooseVersion('1.12.136')):
+    if (Version(botocore.__version__) < Version('1.12.136')):
         pytest.skip("Botocore version 1.12.136 or above required to run this test")
     name = unique_table_name()
     # It is not allowed to set the system:write_isolation to "dog", so the

--- a/test/redis/test_hashes.py
+++ b/test/redis/test_hashes.py
@@ -6,6 +6,7 @@ import pytest
 import redis
 import logging
 from util import random_string, connect
+from packaging.version import Version
 
 logger = logging.getLogger('redis-test')
 
@@ -40,8 +41,7 @@ def test_hset_multiple_key_field(redis_host, redis_port):
     # This test requires the library to support multiple mappings in one
     # command, or we cannot test this feature. This was added to redis-py
     # in version 3.5.0, in April 29, 2020.
-    from distutils.version import LooseVersion
-    if LooseVersion(redis.__version__) < LooseVersion('3.5.0'):
+    if Version(redis.__version__) < Version('3.5.0'):
         pytest.skip('redis-py library too old to run this test')
     r = connect(redis_host, redis_port)
     key = random_string(10)


### PR DESCRIPTION
Python has deprecated the distutils package. In several places in the
Alternator and Redis test suites, we used distutils.version to check if
the library is new enough for running the test (and skip the test if
it's too old). On new versions of Python, we started getting deprecation
warnings such as:

    DeprecationWarning: The distutils package is deprecated and slated for
    removal in Python 3.12. Use setuptools or check PEP 632 for potential
    alternatives

PEP 632 recommends using package.version instead of distutils.version,
and indeed it works well. After applying this patch, Alternator and
Redis test runs no long end in silly deprecation warnings.

Signed-off-by: Nadav Har'El <nyh@scylladb.com>