### PR TITLE
scylla-gdb.py: assortment of task filtering improvements, scylla fiber going backwards

### DIFF
--- a/docs/dev/debugging.md
+++ b/docs/dev/debugging.md
@@ -588,34 +588,26 @@ of task, there are other kinds of tasks as well. Many seastar primites,
 like `do_with()`, `repeat()`, `do_until()`, etc. have their own task
 types.
 
-##### Traversing the continuation chain forward
+##### Traversing the continuation chain
 
-Or in other words finding out what are the continuations waiting on this one.
-This involves searching for all outbound references in the task and identifying
+Or in other words finding out what are the continuations waited on by this one as
+well as the ones waiting on this one.
+This involves searching for inbound and outbound references in the task and identifying
 the one which is also a task. As this is quite a labour-intensive task, there is
 a command in scylla-gdb.py which automates it, called `scylla fiber`. Example
 usage:
 
-    (gdb) scylla fiber 0x60001a305910
-    Starting task: (task*) 0x000060001a305910 0x0000000004aa5260 vtable for seastar::continuation<...> + 16
+    (gdb) scylla fiber 0x0000600016217c80
+    #-1 (task*) 0x000060001a305910 0x0000000004aa5260 vtable for seastar::continuation<...> + 16
     #0  (task*) 0x0000600016217c80 0x0000000004aa5288 vtable for seastar::continuation<...> + 16
     #1  (task*) 0x000060000ac42940 0x0000000004aa2aa0 vtable for seastar::continuation<...> + 16
     #2  (task*) 0x0000600023f59a50 0x0000000004ac1b30 vtable for seastar::continuation<...> + 16
 
-This is somewhat similar to a backtrace, in that it shows tasks that are waiting
+This is somewhat similar to a backtrace, in that it shows tasks that are waited
+on by this continuation and tasks that are waiting
 for this continuation to finish, similar to how upstream functions are waiting
 for the called function to finish before continuing their own execution.
 See `help scylla fiber` and `scylla fiber --help` for more information on usage.
-
-##### Traversing the continuation chain backward
-
-Or in other words find the continuations the current continuation is waiting on.
-This involves searching for all references to the task and identifying the one
-which is also a task. This is made quite easy with the `scylla find` command
-from `scylla-gdb.py`. By using the `--resolve` flag, the vtable symbol will be
-printed next to each inbound reference, making spotting the other task easy.
-Once found, repeat the same with the pointer of the other task, until a
-non-continuation future is found, e.g. a I/O, `smp::submit()`, etc.
 
 ##### Seastar threads
 

--- a/scylla-gdb.py
+++ b/scylla-gdb.py
@@ -4150,6 +4150,8 @@ class scylla_smp_queues(gdb.Command):
         from: the shard, from which the message was sent (this shard);
         to: the shard, to which the message is sent;
         ++++: visual illustration of the relative size of this queue;
+
+    See `scylla smp-queues --help` for more details on usage.
     """
     def __init__(self):
         gdb.Command.__init__(self, 'scylla smp-queues', gdb.COMMAND_USER, gdb.COMPLETE_COMMAND)
@@ -4171,6 +4173,17 @@ class scylla_smp_queues(gdb.Command):
         if not self.queues:
             self._init()
 
+        parser = argparse.ArgumentParser(description="scylla smp-queues")
+        parser.add_argument("-f", "--from", action="store", type=int, required=False, dest="from_cpu",
+                help="Filter for queues going from the given CPU")
+        parser.add_argument("-t", "--to", action="store", type=int, required=False, dest="to_cpu",
+                help="Filter for queues going to the given CPU")
+
+        try:
+            args = parser.parse_args(arg.split())
+        except SystemExit:
+            return
+
         def formatter(q):
             a, b = q
             return '{:2} -> {:2}'.format(a, b)
@@ -4180,6 +4193,10 @@ class scylla_smp_queues(gdb.Command):
         for q in self.queues:
             a = int(q['_completed']['remote']['_id'])
             b = int(q['_pending']['remote']['_id'])
+            if args.from_cpu is not None and a != args.from_cpu:
+                continue
+            if args.to_cpu is not None and b != args.to_cpu:
+                continue
 
             tx_queue = std_deque(q['_tx']['a']['pending_fifo'])
             pending_queue = q['_pending']

--- a/scylla-gdb.py
+++ b/scylla-gdb.py
@@ -1229,7 +1229,10 @@ class histogram:
             else:
                 indicator = ''
             for item in items:
-                lines.append('{:9d} {} {}'.format(count, self._formatter(item), indicator))
+                try:
+                    lines.append('{:9d} {} {}'.format(count, self._formatter(item), indicator))
+                except:
+                    gdb.write("error: failed to format item `{}': {}\n".format(item, sys.exc_info()[1]))
 
         return '\n'.join(lines)
 

--- a/scylla-gdb.py
+++ b/scylla-gdb.py
@@ -128,7 +128,7 @@ class intrusive_slist:
         return self.__nonzero__()
 
     def __len__(self):
-        return len(list(self))
+        return len(list(iter(self)))
 
 
 class std_optional:

--- a/scylla-gdb.py
+++ b/scylla-gdb.py
@@ -1164,7 +1164,7 @@ class histogram:
     """
     _column_count = 40
 
-    def __init__(self, counts = None, print_indicators = True, formatter=None):
+    def __init__(self, counts = None, print_indicators = True, formatter=None, limit=None):
         """Constructor.
 
         Params:
@@ -1175,6 +1175,7 @@ class histogram:
         * formatter: a callable that receives the item as its argument and is
             expected to return the string to be printed in the second column.
             By default, items are printed verbatim.
+        * limit: limit the number of printed items to the top limit ones.
         """
         if counts is None:
             self._counts = defaultdict(int)
@@ -1188,6 +1189,11 @@ class histogram:
             self._formatter = default_formatter
         else:
             self._formatter = formatter
+
+        if limit is None:
+            self._limit = -1
+        else:
+            self._limit = limit
 
     def __len__(self):
         return len(self._counts)
@@ -1221,6 +1227,7 @@ class histogram:
             count_per_column = self._column_count / max_count
 
         lines = []
+        limit = self._limit
 
         for count in counts_sorted:
             items = by_counts[count]
@@ -1233,6 +1240,9 @@ class histogram:
                     lines.append('{:9d} {} {}'.format(count, self._formatter(item), indicator))
                 except:
                     gdb.write("error: failed to format item `{}': {}\n".format(item, sys.exc_info()[1]))
+            limit -= 1
+            if not limit:
+                break
 
         return '\n'.join(lines)
 


### PR DESCRIPTION
This series includes an assortment of loosely related improvements developed for a recent investigation. The changes include:
* Fix broken `std_deque` wrapper.
* Make `scylla smp-queues` fast.
* Teach `scylla smp-queues` to filter for both sender CPU (`--from`) and receiver CPU (`--to`) or both.
* Teach `scylla smp-queues` to make histogram over content of the queues -- i.e. the type of tasks in the smp queues.
* Teach `scylla smp-queues` to filter for tasks belonging to a certain scheduling group.
* Teach `scylla task_histogram` to include only tasks in the histogram.
* Teach `scylla task_histogram` to filter for tasks belonging to a certain scheduling group.
* Teach `scylla-fiber` to walk in both directions.

And some refactoring.

Fixes: https://github.com/scylladb/scylla/issues/7059