### PR TITLE
doc: enable faster builds

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -12,6 +12,7 @@ PAPEROPT_a4     := -D latex_paper_size=a4
 PAPEROPT_letter := -D latex_paper_size=letter
 ALLSPHINXOPTS   := -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) $(SOURCEDIR)
 TESTSPHINXOPTS  := $(ALLSPHINXOPTS) -W --keep-going
+PROD_OPTS       := -D html_theme_options.collapse_navigation='false' -D html_theme_options.navigation_depth=3
 
 # Windows variables
 ifeq ($(OS),Windows_NT)
@@ -67,7 +68,7 @@ epub3: setup
 
 .PHONY: multiversion
 multiversion: setup
-	$(POETRY) run sphinx-multiversion $(SOURCEDIR) $(BUILDDIR)/dirhtml
+	$(POETRY) run sphinx-multiversion $(SOURCEDIR) $(BUILDDIR)/dirhtml $(PROD_OPTS)
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/dirhtml."
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -104,6 +104,7 @@ html_theme_options = {
     "hide_version_dropdown": ["master"],
     "versions_unstable": UNSTABLE_VERSIONS,
     "versions_deprecated": DEPRECATED_VERSIONS,
+    "collapse_navigation": 'true',
 }
 
 # Last updated format


### PR DESCRIPTION
This is a configuration option we had enabled in the [scylladb/docs](https://github.com/scylladb/scylla-docs/blob/master/Makefile#L59) repository, but we didn't migrated it to this repository yet.

Disables the collapsible left navbar locally to have faster builds and limits the maximum depth to 3 in production.

## How to test this PR

1. Go to the docs folder.
2. Run `make multiversion`.
3. Docs build without errors.