### PR TITLE
Refactor group 0 operations (joining, leaving, removing).

### DIFF
--- a/service/raft/discovery.hh
+++ b/service/raft/discovery.hh
@@ -101,6 +101,7 @@ public:
     // is sent back to the requester, or before a new request is sent
     // based on the output of `tick`).
     //
+    // `seeds` may contain `self` but doesn't have to.
     discovery(raft::server_address self, const peer_list& seeds);
 
     // To be used on the receiving peer to generate a reply

--- a/service/raft/raft_group0.cc
+++ b/service/raft/raft_group0.cc
@@ -346,25 +346,14 @@ future<> raft_group0::become_voter() {
     }
 }
 
-future<> raft_group0::leave_group0(std::optional<gms::inet_address> node) {
+future<> raft_group0::leave_group0() {
     if (!_raft_gr.is_enabled()) {
         co_return;
     }
     assert(this_shard_id() == 0);
     raft::server_id remove_addr;
     auto my_id = raft::server_id{co_await db::system_keyspace::get_raft_server_id()};
-    if (node) {
-        if (my_id == raft::server_id{}) {
-            throw std::runtime_error("Can't invoke removenode on a node which is not part of the cluster");
-        }
-        auto opt_id= _raft_gr.address_map().find_replace_id(*node, my_id);
-        if (!opt_id) {
-            // The node being removed is not part of the
-            // configuration.
-            co_return;
-        }
-        remove_addr = *opt_id;
-    } else if (my_id) {
+    if (my_id) {
         remove_addr = my_id;
     } else {
         // Nothing to do
@@ -375,6 +364,40 @@ future<> raft_group0::leave_group0(std::optional<gms::inet_address> node) {
         co_return co_await _raft_gr.group0().modify_config({}, {remove_addr}, &_abort_source);
     }
     auto g0_info = co_await discover_group0(raft::server_address{my_id, raft::server_info{}});
+    if (g0_info.addr.id == my_id) {
+        co_return;
+    }
+    netw::msg_addr peer(raft_addr_to_inet_addr(g0_info.addr));
+    // During removenode, the client itself will retry or abort
+    // the operation if necessary, it's move important it's not
+    // "flaky" on slow network or CPU.
+    auto timeout = db::timeout_clock::now() + std::chrono::minutes{20};
+    // TODO: aborts?
+    co_return co_await ser::group0_rpc_verbs::send_group0_modify_config(&_ms, peer, timeout, g0_info.group0_id, {}, {remove_addr});
+}
+
+future<> raft_group0::remove_from_group0(gms::inet_address node) {
+    if (!_raft_gr.is_enabled()) {
+        co_return;
+    }
+    assert(this_shard_id() == 0);
+    auto my_id = raft::server_id{co_await db::system_keyspace::get_raft_server_id()};
+    if (my_id == raft::server_id{}) {
+        throw std::runtime_error("Can't invoke removenode on a node which is not part of the cluster");
+    }
+    auto opt_id = _raft_gr.address_map().find_replace_id(node, my_id);
+    if (!opt_id) {
+        // The node being removed is not part of the
+        // configuration.
+        co_return;
+    }
+    auto remove_addr = *opt_id;
+
+    auto pause_shutdown = _shutdown_gate.hold();
+    if (std::holds_alternative<raft::group_id>(_group0)) {
+        co_return co_await _raft_gr.group0().modify_config({}, {remove_addr}, &_abort_source);
+    }
+    auto g0_info = co_await discover_group0(my_id, raft::server_info{} /* XXX: apparently passing empty info works */);
     if (g0_info.addr.id == my_id) {
         co_return;
     }

--- a/service/raft/raft_group0.cc
+++ b/service/raft/raft_group0.cc
@@ -111,9 +111,6 @@ raft_group0::discover_group0(raft::server_address my_addr) {
     std::vector<raft::server_address> seeds;
     seeds.reserve(_gossiper.get_seeds().size());
     for (auto& seed : _gossiper.get_seeds()) {
-        if (seed == _gossiper.get_broadcast_address()) {
-            continue;
-        }
         seeds.emplace_back(raft::server_id{}, inet_addr_to_raft_addr(seed));
     }
 

--- a/service/raft/raft_group0.hh
+++ b/service/raft/raft_group0.hh
@@ -79,6 +79,7 @@ class raft_group0 {
     std::variant<std::monostate, service::persistent_discovery, raft::group_id> _group0;
 
 public:
+    // Assumes that the provided services are fully started.
     raft_group0(seastar::abort_source& abort_source,
         service::raft_group_registry& raft_gr,
         netw::messaging_service& ms,
@@ -87,6 +88,7 @@ public:
         migration_manager& mm,
         raft_group0_client& client);
 
+    // Call before destroying the object.
     future<> abort();
 
     // Call during the startup procedure.

--- a/service/raft/raft_group0.hh
+++ b/service/raft/raft_group0.hh
@@ -126,6 +126,17 @@ private:
     // Called by `discover_group0`.
     // Precondition: `_group0` contains `persistent_discovery`.
     future<group0_info> do_discover_group0(raft::server_address my_addr);
+
+    // Start an existing Raft server for the cluster-wide group 0.
+    // Assumes the server was already added to the group earlier so we don't attempt to join it again.
+    //
+    // `group0_id` must be non-null and equal to the ID of group 0 that we joined earlier.
+    // The existing group 0 server must not have been started yet after the last restart of Scylla.
+    //
+    // XXX: perhaps it would be good to make this function callable multiple times,
+    // if we want to handle crashes of the group 0 server without crashing the entire Scylla process
+    // (we could then try restarting the server internally).
+    future<> start_server_for_group0(raft::group_id group0_id);
 };
 
 } // end of namespace service

--- a/service/raft/raft_group0.hh
+++ b/service/raft/raft_group0.hh
@@ -112,6 +112,14 @@ private:
 
     raft_server_for_group create_server_for_group0(raft::group_id id, raft::server_address my_addr);
 
+    // Assumes server address for group 0 is already persisted and loads it from disk.
+    // It's a fatal error if the address is missing.
+    //
+    // Execute on shard 0 only.
+    //
+    // The returned ID is not empty.
+    future<raft::server_address> load_my_addr();
+
     // Loads server address for group 0 from disk if present, otherwise randomly generates a new one and persists it.
     // Execute on shard 0 only.
     future<raft::server_address> load_or_create_my_addr();

--- a/service/raft/raft_group0.hh
+++ b/service/raft/raft_group0.hh
@@ -106,6 +106,15 @@ public:
     future<> become_voter();
 
     // Remove ourselves from group 0.
+    //
+    // Assumes we've finished the startup procedure (`setup_group0()` finished earlier).
+    // Assumes to run during decommission, after the node entered LEFT status.
+    //
+    // FIXME: make it retryable and do nothing if we're not a member.
+    // Currently if we call leave_group0 twice, it will get stuck the second time
+    // (it will try to forward an entry to a leader but never find the leader).
+    // Not sure how easy or hard it is and whether it's a problem worth solving; if decommission crashes,
+    // one can simply call `removenode` on another node to make sure we areremoved (from group 0 too).
     future<> leave_group0();
 
     // Remove `host` from group 0.

--- a/service/raft/raft_group0.hh
+++ b/service/raft/raft_group0.hh
@@ -105,11 +105,11 @@ public:
     // Precondition: `setup_group0` successfully finished earlier.
     future<> become_voter();
 
-    // Remove the node from the cluster-wide raft group.
-    // This procedure is idempotent. In case of replace node,
-    // it removes the replaced node from the group, since
-    // it can't do it by itself (it's dead).
-    future<> leave_group0(std::optional<gms::inet_address> host = {});
+    // Remove ourselves from group 0.
+    future<> leave_group0();
+
+    // Remove `host` from group 0.
+    future<> remove_from_group0(gms::inet_address host);
 
 private:
     void init_rpc_verbs();

--- a/service/raft/raft_group0.hh
+++ b/service/raft/raft_group0.hh
@@ -118,6 +118,15 @@ public:
     future<> leave_group0();
 
     // Remove `host` from group 0.
+    //
+    // Assumes that either
+    // 1. we've finished bootstrapping and now running a `removenode` operation,
+    // 2. or we're currently bootstrapping and replacing an existing node.
+    //
+    // In both cases, `setup_group0()` must have finished earlier.
+    //
+    // The provided address may be our own - if we're replacing a node that had the same address as ours.
+    // We'll look for the other node's Raft ID in the group 0 configuration.
     future<> remove_from_group0(gms::inet_address host);
 
 private:

--- a/service/raft/raft_group0.hh
+++ b/service/raft/raft_group0.hh
@@ -108,7 +108,7 @@ private:
     // Handle peer_exchange RPC
     future<group0_peer_exchange> peer_exchange(discovery::peer_list peers);
 
-    raft_server_for_group create_server_for_group(raft::group_id id, raft::server_address my_addr);
+    raft_server_for_group create_server_for_group0(raft::group_id id, raft::server_address my_addr);
 
     // Loads server address for group 0 from disk if present, otherwise randomly generates a new one and persists it.
     // Execute on shard 0 only.

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -391,7 +391,7 @@ future<> storage_service::join_token_ring(cdc::generation_service& cdc_gen_servi
     co_await db::schema_tables::recalculate_schema_version(_sys_ks, proxy, _feature_service);
 
     assert(_group0);
-    co_await _group0->setup_group0(_sys_ks.local());
+    co_await _group0->setup_group0(_sys_ks.local(), initial_contact_nodes);
 
     app_states.emplace(gms::application_state::NET_VERSION, versioned_value::network_version());
     app_states.emplace(gms::application_state::HOST_ID, versioned_value::host_id(local_host_id));


### PR DESCRIPTION
A series of refactors to the `raft_group0` service.
Read the commits in topological order for best experience.

This PR is more or less equivalent to the second-to-last commit of PR https://github.com/scylladb/scylla/pull/10835, I split it so we could have an easier time reviewing and pushing it through.