### PR TITLE
doc: add the upgrade guide from 2021.1 to 2022.1

### DIFF
--- a/docs/upgrade/_common/upgrade-guide-from-2021.1-to-2022.1-ubuntu-and-debian.rst
+++ b/docs/upgrade/_common/upgrade-guide-from-2021.1-to-2022.1-ubuntu-and-debian.rst
@@ -7,7 +7,7 @@ This document is a step-by-step procedure for upgrading from ScyllaDB Enterprise
 
 Applicable Versions
 ===================
-This guide covers upgrading ScyllaDB from version **2021.1.8** or later to ScyllaDB Enterprise version 2021.1.y on the following platform:
+This guide covers upgrading ScyllaDB Enterprise from version 2021.1.x to ScyllaDB Enterprise version 2022.1.y on the following platform:
 
 * |OS|
 

--- a/docs/upgrade/_common/upgrade-guide-from-2021.1-to-2022.1-ubuntu-and-debian.rst
+++ b/docs/upgrade/_common/upgrade-guide-from-2021.1-to-2022.1-ubuntu-and-debian.rst
@@ -57,7 +57,7 @@ Before any major procedure, like an upgrade, it is recommended to backup all the
 
 Take note of the directory name that nodetool gives you, and copy all the directories having this name under ``/var/lib/scylla`` to a backup device.
 
-When the upgrade is completed on all nodes, the snapshot should be removed with the ``nodetool clearsnapshot -t <snapshot>``command to prevent running out of space.
+When the upgrade is completed on all nodes, the snapshot should be removed with the ``nodetool clearsnapshot -t <snapshot>`` command to prevent running out of space.
 
 Backup the configuration file
 ------------------------------

--- a/docs/upgrade/_common/upgrade-guide-from-2021.1-to-2022.1-ubuntu-and-debian.rst
+++ b/docs/upgrade/_common/upgrade-guide-from-2021.1-to-2022.1-ubuntu-and-debian.rst
@@ -1,0 +1,206 @@
+=============================================================================
+Upgrade Guide - ScyllaDB Enterprise 2021.1 to 2022.1 for |OS|
+=============================================================================
+
+This document is a step-by-step procedure for upgrading from ScyllaDB Enterprise 2021.1 to ScyllaDB Enterprise 2022.1, and rollback to 2021.1 if required.
+
+
+Applicable Versions
+===================
+This guide covers upgrading ScyllaDB from version **2021.1.8** or later to ScyllaDB Enterprise version 2021.1.y on the following platform:
+
+* |OS|
+
+Upgrade Procedure
+=================
+.. include:: /upgrade/upgrade-enterprise/_common/enterprise_2022.1_warnings.rst
+
+A ScyllaDB upgrade is a rolling procedure that does **not** require a full cluster shutdown.
+For each of the nodes in the cluster, you will:
+
+* Check the cluster schema
+* Drain the node and backup the data
+* Backup the configuration file
+* Stop ScyllaDB
+* Download and install the new ScyllaDB packages
+* Start ScyllaDB
+* Validate that the upgrade was successful
+
+Apply the following procedure **serially** on each node. Do not move to the next node before validating the node that you upgraded is up and running the new version.
+
+**During** the rolling upgrade, it is highly recommended:
+
+* Not to use new 2022.1 features.
+* Not to run administration functions, like repairs, refresh, rebuild, or add or remove nodes. See :doc:`here </operating-scylla/manager/2.1/sctool>` for suspending ScyllaDB Manager's scheduled or running repairs.
+* Not to apply schema changes.
+
+.. include:: /upgrade/_common/upgrade_to_2022_warning.rst
+  
+Upgrade Steps
+=============
+Check the cluster schema
+-------------------------
+Make sure that all nodes have the schema synched before the upgrade. The upgrade will fail if there is a schema disagreement between nodes.
+
+.. code:: sh
+
+       nodetool describecluster
+
+Drain the nodes and backup the data
+-------------------------------------
+Before any major procedure, like an upgrade, it is recommended to backup all the data to an external device. In ScyllaDB, backup is done using the ``nodetool snapshot`` command. For **each** node in the cluster, run the following command:
+
+.. code:: sh
+
+   nodetool drain
+   nodetool snapshot
+
+Take note of the directory name that nodetool gives you, and copy all the directories having this name under ``/var/lib/scylla`` to a backup device.
+
+When the upgrade is completed on all nodes, the snapshot should be removed with the ``nodetool clearsnapshot -t <snapshot>``command to prevent running out of space.
+
+Backup the configuration file
+------------------------------
+
+.. code:: sh
+
+   sudo cp -a /etc/scylla/scylla.yaml /etc/scylla/scylla.yaml.backup-2021.1
+
+Gracefully stop the node
+------------------------
+
+.. code:: sh
+
+   sudo service scylla-server stop
+
+Download and install the new release
+------------------------------------
+Before upgrading, check what version you are running now using ``dpkg -l scylla\*server``. You should use the same version in case you want to |ROLLBACK|_ the upgrade. If you are not running a 2021.1.x version, stop right here! This guide only covers 2021.1.x to 2022.1.y upgrades.
+
+**To upgrade ScyllaDB:**
+
+#. Update the |APT|_ to **2022.1** and enable scylla/ppa repo.
+
+   .. code:: sh
+
+       Ubuntu 16:
+       sudo add-apt-repository -y ppa:scylladb/ppa
+
+#. Configure Java 1.8, which is requested by ScyllaDB Enterprise 2022.1.
+
+   .. code:: sh
+ 
+      sudo apt-get update
+      sudo apt-get install -y openjdk-8-jre-headless
+      sudo update-java-alternatives -s java-1.8.0-openjdk-amd64
+
+#. Install:
+
+   .. code:: sh
+
+      sudo apt-get clean all
+      sudo apt-get update
+      sudo apt-get dist-upgrade scylla-enterprise
+
+Answer ‘y’ to the first two questions.
+
+Start the node
+--------------
+
+A new io.conf format was introduced in Scylla 2.3 and 2019.1. If your io.conf doesn't contain `--io-properties-file` option, then it's still the old format. You need to re-run the io setup to generate new io.conf.
+
+.. code:: sh
+
+    sudo scylla_io_setup
+
+.. code:: sh
+
+   sudo service scylla-server start
+
+Validate
+--------
+#. Check cluster status with ``nodetool status`` and make sure **all** nodes, including the one you just upgraded, are in UN status.
+#. Use ``curl -X GET "http://localhost:10000/storage_service/scylla_release_version"`` to check the ScyllaDB version.
+#. Check scylla-server log (by ``journalctl _COMM=scylla``) and ``/var/log/syslog`` to validate there are no errors.
+#. Check again after two minutes to validate no new issues are introduced.
+
+Once you are sure the node upgrade is successful, move to the next node in the cluster.
+
+See :doc:`Scylla Metrics Update - Scylla Enterprise 2021.1 to 2022.1<metric-update-2021.1-to-2022.1>` for more information.
+
+Rollback Procedure
+==================
+
+.. include:: /upgrade/_common/warning_rollback.rst
+
+The following procedure describes a rollback from ScyllaDB Enterprise release 2022.1.x to 2022.1.y. Apply this procedure if an upgrade from 2021.1 to 2022.1 failed before completing on all nodes. Use this procedure only for nodes you upgraded to 2022.1
+
+ScyllaDB rollback is a rolling procedure that does **not** require a full cluster shutdown.
+For each of the nodes you rollback to 2021.1, you will:
+
+* Drain the node and stop ScyllaDB
+* Retrieve the old Scylla packages
+* Restore the configuration file
+* Restart ScyllaDB
+* Validate the rollback success
+
+Apply the following procedure **serially** on each node. Do not move to the next node before validating the node is up and running with the new version.
+
+Rollback Steps
+==============
+Gracefully shutdown ScyllaDB
+----------------------------
+
+.. code:: sh
+
+   nodetool drain
+   sudo service scylla-server stop
+
+Download and install the old release
+------------------------------------
+#. Remove the old repo file.
+
+    .. code:: sh
+
+       sudo rm -rf /etc/apt/sources.list.d/scylla.list
+
+#. Update the |APT|_ to **2021.1**.
+#. Install:
+
+    .. code:: sh
+
+       sudo apt-get clean all
+       sudo apt-get update
+       sudo apt-get remove scylla\* -y
+       sudo apt-get install scylla-enterprise
+
+Answer ‘y’ to the first two questions.
+
+Restore the configuration file
+------------------------------
+.. code:: sh
+
+   sudo rm -rf /etc/scylla/scylla.yaml
+   sudo cp -a /etc/scylla/scylla.yaml.backup-2021.1 /etc/scylla/scylla.yaml
+
+Restore system tables
+---------------------
+
+Restore all tables of **system** and **system_schema** from the previous snapshot - 2022.1 uses a different set of system tables. Reference doc: :doc:`Restore from a Backup and Incremental Backup </operating-scylla/procedures/backup-restore/restore/>`.
+
+.. code:: sh
+
+    cd /var/lib/scylla/data/keyspace_name/table_name-UUID/snapshots/<snapshot_name>/
+    sudo cp -r * /var/lib/scylla/data/keyspace_name/table_name-UUID/
+    sudo chown -R scylla:scylla /var/lib/scylla/data/keyspace_name/table_name-UUID/
+
+Start the node
+--------------
+
+.. code:: sh
+
+   sudo service scylla-server start
+
+Validate
+--------
+Check the upgrade instructions above for validation. Once you are sure the node rollback is successful, move to the next node in the cluster.

--- a/docs/upgrade/_common/upgrade_to_2022_warning.rst
+++ b/docs/upgrade/_common/upgrade_to_2022_warning.rst
@@ -1,3 +1,3 @@
-.. note:: Before upgrading to 2022.1, make sure to use `Scylla Monitoring 3.6 <https://github.com/scylladb/scylla-monitoring/releases/tag/scylla-monitoring-3.6>`_ or newer for the 2022.1 d.ashboards.
+.. note:: Before upgrading to 2022.1, make sure to use `Scylla Monitoring 4.0 <https://github.com/scylladb/scylla-monitoring/releases/tag/scylla-monitoring-4.0.0>`_ or newer for the 2022.1 dashboards.
 
           

--- a/docs/upgrade/_common/upgrade_to_2022_warning.rst
+++ b/docs/upgrade/_common/upgrade_to_2022_warning.rst
@@ -1,0 +1,3 @@
+.. note:: Before upgrading to 2022.1, make sure to use `Scylla Monitoring 3.6 <https://github.com/scylladb/scylla-monitoring/releases/tag/scylla-monitoring-3.6>`_ or newer for the 2022.1 d.ashboards.
+
+          

--- a/docs/upgrade/upgrade-enterprise/_common/enterprise_2022.1_warnings.rst
+++ b/docs/upgrade/upgrade-enterprise/_common/enterprise_2022.1_warnings.rst
@@ -1,0 +1,8 @@
+.. note:: The note is only useful when CDC is GA supported in the target ScyllaDB. Execute the following commands one node at a time, moving to the next node only **after** the upgrade procedure completed successfully.
+
+.. warning::
+
+   If you are using CDC and upgrading ScyllaDB 2021.1 to 2022.1, please review the API updates in :doc:`querying CDC streams </using-scylla/cdc/cdc-querying-streams>` and :doc:`CDC stream generations </using-scylla/cdc/cdc-stream-generations>`.
+   In particular, you should update applications that use CDC according to :ref:`CDC Upgrade notes <scylla-4-3-to-4-4-upgrade>` **before** upgrading the cluster to 2022.1.
+
+.. include:: /upgrade/upgrade-enterprise/_common/mv_si_rebuild_warning.rst

--- a/docs/upgrade/upgrade-enterprise/_common/enterprise_2022.1_warnings.rst
+++ b/docs/upgrade/upgrade-enterprise/_common/enterprise_2022.1_warnings.rst
@@ -4,5 +4,3 @@
 
    If you are using CDC and upgrading ScyllaDB 2021.1 to 2022.1, please review the API updates in :doc:`querying CDC streams </using-scylla/cdc/cdc-querying-streams>` and :doc:`CDC stream generations </using-scylla/cdc/cdc-stream-generations>`.
    In particular, you should update applications that use CDC according to :ref:`CDC Upgrade notes <scylla-4-3-to-4-4-upgrade>` **before** upgrading the cluster to 2022.1.
-
-.. include:: /upgrade/upgrade-enterprise/_common/mv_si_rebuild_warning.rst

--- a/docs/upgrade/upgrade-enterprise/index.rst
+++ b/docs/upgrade/upgrade-enterprise/index.rst
@@ -11,6 +11,7 @@ Upgrade Scylla Enterprise
    Scylla Enterprise 2019 <upgrade-guide-from-2019.x.y-to-2019.x.z/index>
    Scylla Enterprise 2018 <upgrade-guide-from-2018.x.y-to-2018.x.z/index>
    Scylla Enterprise 2017 <upgrade-guide-from-2017.x.y-to-2017.x.z/index>
+   Scylla Enterprise 2021.1 to Scylla Enterprise 2022.1 <upgrade-guide-from-2021.1-to-2022.1/index>
    Scylla Enterprise 2020.1 to Scylla Enterprise 2021.1 <upgrade-guide-from-2020.1-to-2021.1/index>
    Scylla Enterprise 2019.1 to Scylla Enterprise 2020.1 <upgrade-guide-from-2019.1-to-2020.1/index>
    Scylla Enterprise 2018.1 to Scylla Enterprise 2019.1 <upgrade-guide-from-2018.1-to-2019.1/index>
@@ -34,6 +35,7 @@ Upgrade Scylla Enterprise
 
   Major Release Upgrade
 
+  * `Upgrade Guide - From Scylla Enterprise 2021.1 to Scylla Enterprise 2022.1 <upgrade-guide-from-2021.1-to-2022.1/>`_
   * `Upgrade Guide - From Scylla Enterprise 2020.1 to Scylla Enterprise 2021.1 <upgrade-guide-from-2020.1-to-2021.1/>`_
   * `Upgrade Guide - From Scylla Enterprise 2019.1 to Scylla Enterprise 2020.1 <upgrade-guide-from-2019.1-to-2020.1/>`_
   * `Upgrade Guide - From Scylla Enterprise 2018.1 to Scylla Enterprise 2019.1 <upgrade-guide-from-2018.1-to-2019.1/>`_

--- a/docs/upgrade/upgrade-enterprise/upgrade-guide-from-2021.1-to-2022.1/index.rst
+++ b/docs/upgrade/upgrade-enterprise/upgrade-guide-from-2021.1-to-2022.1/index.rst
@@ -1,0 +1,43 @@
+====================================================
+Upgrade from ScyllaDB Enterprise 2021.1 to 2022.1
+====================================================
+
+.. toctree::
+   :hidden:
+   :titlesonly:
+
+   Red Hat Enterprise Linux and CentOS <upgrade-guide-from-2021.1-to-2022.1-rpm>
+   Ubuntu 16.04 <upgrade-guide-from-2021.1-to-2022.1-ubuntu-16-04>
+   Ubuntu 18.04 <upgrade-guide-from-2021.1-to-2022.1-ubuntu-18-04>
+   Ubuntu 20.04 <upgrade-guide-from-2021.1-to-2022.1-ubuntu-20-04>
+   Debian <upgrade-guide-from-2021.1-to-2022.1-debian>
+   Metrics <metric-update-2021.1-to-2022.1>
+
+.. raw:: html
+
+
+   <div class="panel callout radius animated">
+            <div class="row">
+              <div class="medium-3 columns">
+                <h5 id="getting-started">Upgrade to ScyllaDB Enterprise 2022.1</h5>
+              </div>
+              <div class="medium-9 columns">
+
+Upgrade guides are available for:
+
+* :doc:`Upgrade ScyllaDB Enterprise from 2021.1.x to 2022.1.y on Red Hat Enterprise Linux and CentOS <upgrade-guide-from-2021.1-to-2022.1-rpm>`
+* :doc:`Upgrade ScyllaDB Enterprise from 2021.1.x to 2022.1.y on Ubuntu 16.04 <upgrade-guide-from-2021.1-to-2022.1-ubuntu-16-04>`
+* :doc:`Upgrade ScyllaDB Enterprise from 2021.1.x to 2022.1.y on Ubuntu 18.04 <upgrade-guide-from-2021.1-to-2022.1-ubuntu-18-04>`
+* :doc:`Upgrade ScyllaDB Enterprise from 2021.1.x to 2022.1.y on Ubuntu 20.04 <upgrade-guide-from-2021.1-to-2022.1-ubuntu-20-04>`
+* :doc:`Upgrade ScyllaDB Enterprise from 2021.1.x to 2022.1.y on Debian <upgrade-guide-from-2021.1-to-2022.1-debian>`
+* :doc:`ScyllaDB Enterprise Metrics Update - Scylla 2021.1 to 2022.1<metric-update-2021.1-to-2022.1>`
+
+
+.. raw:: html
+
+   </div>
+   </div>
+   </div>
+
+
+

--- a/docs/upgrade/upgrade-enterprise/upgrade-guide-from-2021.1-to-2022.1/index.rst
+++ b/docs/upgrade/upgrade-enterprise/upgrade-guide-from-2021.1-to-2022.1/index.rst
@@ -7,7 +7,6 @@ Upgrade from ScyllaDB Enterprise 2021.1 to 2022.1
    :titlesonly:
 
    Red Hat Enterprise Linux and CentOS <upgrade-guide-from-2021.1-to-2022.1-rpm>
-   Ubuntu 16.04 <upgrade-guide-from-2021.1-to-2022.1-ubuntu-16-04>
    Ubuntu 18.04 <upgrade-guide-from-2021.1-to-2022.1-ubuntu-18-04>
    Ubuntu 20.04 <upgrade-guide-from-2021.1-to-2022.1-ubuntu-20-04>
    Debian <upgrade-guide-from-2021.1-to-2022.1-debian>
@@ -26,7 +25,6 @@ Upgrade from ScyllaDB Enterprise 2021.1 to 2022.1
 Upgrade guides are available for:
 
 * :doc:`Upgrade ScyllaDB Enterprise from 2021.1.x to 2022.1.y on Red Hat Enterprise Linux and CentOS <upgrade-guide-from-2021.1-to-2022.1-rpm>`
-* :doc:`Upgrade ScyllaDB Enterprise from 2021.1.x to 2022.1.y on Ubuntu 16.04 <upgrade-guide-from-2021.1-to-2022.1-ubuntu-16-04>`
 * :doc:`Upgrade ScyllaDB Enterprise from 2021.1.x to 2022.1.y on Ubuntu 18.04 <upgrade-guide-from-2021.1-to-2022.1-ubuntu-18-04>`
 * :doc:`Upgrade ScyllaDB Enterprise from 2021.1.x to 2022.1.y on Ubuntu 20.04 <upgrade-guide-from-2021.1-to-2022.1-ubuntu-20-04>`
 * :doc:`Upgrade ScyllaDB Enterprise from 2021.1.x to 2022.1.y on Debian <upgrade-guide-from-2021.1-to-2022.1-debian>`

--- a/docs/upgrade/upgrade-enterprise/upgrade-guide-from-2021.1-to-2022.1/metric-update-2021.1-to-2022.1.rst
+++ b/docs/upgrade/upgrade-enterprise/upgrade-guide-from-2021.1-to-2022.1/metric-update-2021.1-to-2022.1.rst
@@ -1,0 +1,43 @@
+=========================================================================
+ScyllaDB Enterprise Metric Update - ScyllaDB Enterprise 2021.1 to 2022.1
+=========================================================================
+
+The following metrics are new in 2022.1 compared to 2021.1:
+
+* scylla_commitlog_disk_slack_end_bytes
+* scylla_cql_authorized_prepared_statements_unprivileged_entries_evictions_on_size
+* scylla_cql_unprivileged_entries_evictions_on_size
+* scylla_database_reads_shed_due_to_overload
+* scylla_database_sstable_read_queue_overloads
+* scylla_io_queue_disk_queue_length
+* scylla_io_queue_starvation_time_sec
+* scylla_io_queue_total_delay_sec
+* scylla_io_queue_total_exec_sec
+* scylla_io_queue_total_read_bytes
+* scylla_io_queue_total_read_ops
+* scylla_io_queue_total_write_bytes
+* scylla_io_queue_total_write_ops
+* scylla_node_ops_finished_percentage
+* scylla_scheduler_starvetime_ms
+* scylla_scheduler_waittime_ms
+* scylla_sstables_index_page_cache_bytes_in_std
+* scylla_sstables_index_page_evictions
+* scylla_sstables_index_page_populations
+* scylla_sstables_index_page_used_bytes
+* scylla_storage_proxy_coordinator_total_write_attempts_remote_node
+* scylla_storage_proxy_coordinator_writes_failed_due_to_too_many_in_flight_hints
+* scylla_transport_auth_responses
+* scylla_transport_batch_requests
+* scylla_transport_cql_errors_total
+* scylla_transport_execute_requests
+* scylla_transport_options_requests
+* scylla_transport_prepare_requests
+* scylla_transport_query_requests
+* scylla_transport_register_requests
+* scylla_transport_startups
+
+The following metrics are not longer available in 2022.1 compared to 2021.1:
+
+* scylla_memory_streaming_dirty_bytes
+* scylla_memory_streaming_virtual_dirty_bytes
+* querier_cache_memory_based_evictions

--- a/docs/upgrade/upgrade-enterprise/upgrade-guide-from-2021.1-to-2022.1/metric-update-2021.1-to-2022.1.rst
+++ b/docs/upgrade/upgrade-enterprise/upgrade-guide-from-2021.1-to-2022.1/metric-update-2021.1-to-2022.1.rst
@@ -2,41 +2,85 @@
 ScyllaDB Enterprise Metric Update - ScyllaDB Enterprise 2021.1 to 2022.1
 =========================================================================
 
-The following metrics are new in 2022.1 compared to 2021.1:
+New Metrics
+------------
 
-* scylla_commitlog_disk_slack_end_bytes
-* scylla_cql_authorized_prepared_statements_unprivileged_entries_evictions_on_size
-* scylla_cql_unprivileged_entries_evictions_on_size
-* scylla_database_reads_shed_due_to_overload
-* scylla_database_sstable_read_queue_overloads
-* scylla_io_queue_disk_queue_length
-* scylla_io_queue_starvation_time_sec
-* scylla_io_queue_total_delay_sec
-* scylla_io_queue_total_exec_sec
-* scylla_io_queue_total_read_bytes
-* scylla_io_queue_total_read_ops
-* scylla_io_queue_total_write_bytes
-* scylla_io_queue_total_write_ops
-* scylla_node_ops_finished_percentage
-* scylla_scheduler_starvetime_ms
-* scylla_scheduler_waittime_ms
-* scylla_sstables_index_page_cache_bytes_in_std
-* scylla_sstables_index_page_evictions
-* scylla_sstables_index_page_populations
-* scylla_sstables_index_page_used_bytes
-* scylla_storage_proxy_coordinator_total_write_attempts_remote_node
-* scylla_storage_proxy_coordinator_writes_failed_due_to_too_many_in_flight_hints
-* scylla_transport_auth_responses
-* scylla_transport_batch_requests
-* scylla_transport_cql_errors_total
-* scylla_transport_execute_requests
-* scylla_transport_options_requests
-* scylla_transport_prepare_requests
-* scylla_transport_query_requests
-* scylla_transport_register_requests
-* scylla_transport_startups
+The following metrics were added in ScyllaDB 2022.1:
 
-The following metrics are not longer available in 2022.1 compared to 2021.1:
+
+.. list-table::
+   :widths: 25 150
+   :header-rows: 1
+
+   * - Metric
+     - Description
+   * - scylla_commitlog_disk_slack_end_bytes
+     - Holds a size of disk space in bytes unused because of segment switching (end slack). A too high value indicates that we do not write enough data to each segment.
+   * - scylla_cql_authorized_prepared_statements_unprivileged_entries_evictions_on_size
+     - Counts a number of evictions of prepared statements from the authorized prepared statements cache after they have been used only once. An increasing counter suggests the user may be preparing a different statement for each request instead of reusing the same prepared statement with parameters.
+   * - scylla_cql_unprivileged_entries_evictions_on_size
+     - Counts a number of evictions of prepared statements from the prepared statements cache after they have been used only once. An increasing counter suggests the user may be preparing a different statement for each request instead of reusing the same prepared statement with parameters.
+   * - scylla_database_reads_shed_due_to_overload
+     - The number of reads shed because the admission queue reached its max capacity. When the queue is full, excessive reads are shed to avoid overload.
+   * - scylla_database_sstable_read_queue_overloads
+     - Counts the number of times the sstable read queue was overloaded. A non-zero value indicates that we have to drop read requests because they arrive faster than we can serve them.
+   * - scylla_io_queue_disk_queue_length
+     - Number of requests in the disk.
+   * - scylla_io_queue_starvation_time_sec
+     - Total time spent starving for disk.
+   * - scylla_io_queue_total_delay_sec
+     - Total time spent in the queue.
+   * - scylla_io_queue_total_exec_sec
+     - Total time spent in disk.
+   * - scylla_io_queue_total_read_bytes
+     - Total read bytes passed in the queue.
+   * - scylla_io_queue_total_read_ops
+     - Total read operations passed in the queue.
+   * - scylla_io_queue_total_write_bytes
+     - Total write bytes passed in the queue.
+   * - scylla_io_queue_total_write_ops
+     - Total write operations passed in the queue.
+   * - scylla_node_ops_finished_percentage
+     - Finished percentage of node operation on this shard.
+   * - scylla_scheduler_starvetime_ms
+     - Accumulated starvation time of this task queue; an increment rate of 1000ms per second indicates the scheduler feels really bad.
+   * - scylla_scheduler_waittime_ms
+     - Accumulated waittime of this task queue; an increment rate of 1000ms per second indicates queue is waiting for something (e.g. IO).
+   * - scylla_sstables_index_page_cache_bytes_in_std
+     - Total number of bytes in temporary buffers which live in the std allocator.
+   * - scylla_sstables_index_page_evictions
+     - Index pages which got evicted from memory.
+   * - scylla_sstables_index_page_populations
+     - Index pages which got populated into memory.
+   * - scylla_sstables_index_page_used_bytes
+     - Amount of bytes used by index pages in memory.
+   * - scylla_storage_proxy_coordinator_total_write_attempts_remote_node
+     - Total number of write requests when communicating with external Nodes in DC datacenter1.
+   * - scylla_storage_proxy_coordinator_writes_failed_due_to_too_many_in_flight_hints
+     - Number of CQL write requests which failed because the hinted handoff mechanism is overloaded and cannot store any more in-flight hints.
+   * - scylla_transport_auth_responses
+     - Counts the total number of received CQL AUTH messages.
+   * - scylla_transport_batch_requests
+     - Counts the total number of received CQL BATCH messages.
+   * - scylla_transport_cql_errors_total
+     - Counts the total number of returned CQL errors.
+   * - scylla_transport_execute_requests
+     - Counts the total number of received CQL EXECUTE messages.
+   * - scylla_transport_options_requests
+     - Counts the total number of received CQL OPTIONS messages.
+   * - scylla_transport_prepare_requests
+     - Counts the total number of received CQL PREPARE messages.
+   * - scylla_transport_query_requests
+     - Counts the total number of received CQL QUERY messages.
+   * - scylla_transport_register_requests
+     - Counts the total number of received CQL REGISTER messages.
+   * - scylla_transport_startups
+     - Counts the total number of received CQL STARTUP messages.
+
+Removed Metrics
+-----------------
+
+The following metrics are no longer available in ScyllaDB 2022.1:
 
 * scylla_memory_streaming_dirty_bytes
 * scylla_memory_streaming_virtual_dirty_bytes

--- a/docs/upgrade/upgrade-enterprise/upgrade-guide-from-2021.1-to-2022.1/upgrade-guide-from-2021.1-to-2022.1-debian.rst
+++ b/docs/upgrade/upgrade-enterprise/upgrade-guide-from-2021.1-to-2022.1/upgrade-guide-from-2021.1-to-2022.1-debian.rst
@@ -1,0 +1,7 @@
+.. |OS| replace:: Debian 9
+.. |ROLLBACK| replace:: rollback
+.. _ROLLBACK: /upgrade/upgrade-enterprise/upgrade-guide-from-2021.1-to-2022.1/upgrade-guide-from-2021.1-to-2022.1-debian/#rollback-procedure
+.. |APT| replace:: ScyllaDB Enterprise Deb repo
+.. _APT: https://www.scylladb.com/customer-portal/?product=ent&platform=debian-9&version=stable-release-2022.1
+.. |OPENJDK| replace:: openjdk-8-jre-headless
+.. include:: /upgrade/_common/upgrade-guide-from-2021.1-to-2022.1-ubuntu-and-debian.rst

--- a/docs/upgrade/upgrade-enterprise/upgrade-guide-from-2021.1-to-2022.1/upgrade-guide-from-2021.1-to-2022.1-rpm.rst
+++ b/docs/upgrade/upgrade-enterprise/upgrade-guide-from-2021.1-to-2022.1/upgrade-guide-from-2021.1-to-2022.1-rpm.rst
@@ -1,0 +1,191 @@
+===============================================================================================
+Upgrade Guide - ScyllaDB Enterprise 2021.1 to 2022.1 for Red Hat Enterprise Linux 7 or CentOS 7
+===============================================================================================
+
+This document is a step-by-step procedure for upgrading from ScyllaDB Enterprise 2021.1 to Scylla Enterprise 2022.1, and rollback to 2021.1 if required.
+
+
+Applicable Versions
+===================
+This guide covers upgrading ScyllaDB from version **2021.1.8** or later to ScyllaDB Enterprise version 2021.1.y, on the following platforms:
+
+* Red Hat Enterprise Linux, version 7 and later
+* CentOS, version 7 and later
+
+We no longer provide packages for Fedora.
+
+Upgrade Procedure
+=================
+
+A ScyllaDB upgrade is a rolling procedure that does **not** require a full cluster shutdown. For each of the nodes in the cluster, serially (i.e. one at a time), you will:
+
+* Check the cluster schema
+* Drain the node and backup the data
+* Backup the configuration file
+* Stop ScyllaDB
+* Download and install the new ScyllaDB packages
+* Start ScyllaDB
+* Validate that the upgrade was successful
+
+Apply the following procedure **serially** on each node. Do not move to the next node before validating that the node you upgraded is up and running the new version.
+
+**During** the rolling upgrade, it is highly recommended:
+
+* Not to use new 2022.1 features.
+* Not to run administration functions, like repairs, refresh, rebuild or add or remove nodes. See :doc:`here </operating-scylla/manager/2.1/sctool>` for suspending ScyllaDB Manager's scheduled or running repairs.
+* Not to apply schema changes.
+
+.. include:: /upgrade/_common/upgrade_to_2022_warning.rst
+  
+
+Upgrade Steps
+=============
+Check the cluster schema
+-------------------------
+Make sure that all nodes have the schema synched before the upgrade. The upgrade will fail if there is a schema disagreement between nodes.
+
+.. code:: sh
+
+       nodetool describecluster
+
+Drain the nodes and backup the data
+-------------------------------------
+Before any major procedure, like an upgrade, it is recommended to backup all the data to an external device. In Scylla, backup is done using the ``nodetool snapshot`` command. For **each** node in the cluster, run the following command:
+
+.. code:: sh
+
+   nodetool drain
+   nodetool snapshot
+
+Take note of the directory name that nodetool gives you, and copy all the directories having this name under ``/var/lib/scylla`` to a backup device.
+
+When the upgrade is completed on all nodes, the snapshot should be removed with the ``nodetool clearsnapshot -t <snapshot>`` command to prevent running out of space.
+
+Backup the configuration file
+------------------------------
+.. code:: sh
+
+   sudo cp -a /etc/scylla/scylla.yaml /etc/scylla/scylla.yaml.backup-2021.1
+
+Stop ScyllaDB
+-------------
+.. code:: sh
+
+   sudo systemctl stop scylla-server
+
+Download and install the new release
+------------------------------------
+Before upgrading, check what version you are running now using ``rpm -qa scylla\*server``. You should use the same version in case you want to :ref:`rollback <upgrade-2021.1-2022.1-rpm-rollback-procedure>` the upgrade. If you are not running a 2021.1.x version, stop right here! This guide only covers 2021.1.x to 2022.1.y upgrades.
+
+**To upgrade ScyllaDB:**
+
+#. Update the `Scylla RPM Enterprise repo <https://www.scylladb.com/customer-portal/?product=ent&platform=centos7&version=stable-release-2022.1>`_  to **2022.1**.
+#. Install:
+
+  .. code:: sh
+
+     sudo yum clean all
+     sudo yum update scylla\* -y
+
+Start the node
+--------------
+
+A new io.conf format was introduced in ScyllaDB 2.3 and 2019.1. If your io.conf doesn't contain `--io-properties-file` option, then it's still the old format. You need to re-run the io setup to generate new io.conf.
+
+.. code:: sh
+
+    sudo scylla_io_setup
+
+.. code:: sh
+
+   sudo systemctl start scylla-server
+
+Validate
+--------
+#. Check cluster status with ``nodetool status`` and make sure **all** nodes, including the one you just upgraded, are in UN status.
+#. Use ``curl -X GET "http://localhost:10000/storage_service/scylla_release_version"`` to check the ScyllaDB version.
+#. Use ``journalctl _COMM=scylla`` to validate there are no new errors in the log.
+#. Check again after 2 minutes to validate no new issues are introduced.
+
+Once you are sure the node upgrade is successful, move to the next node in the cluster.
+
+See :doc:`Scylla Metrics Update - Scylla Enterprise 2021.1 to 2022.1<metric-update-2021.1-to-2022.1>` for more information.
+
+.. _upgrade-2021.1-2022.1-rpm-rollback-procedure:
+
+Rollback Procedure
+==================
+
+.. include:: /upgrade/_common/warning_rollback.rst
+
+The following procedure describes a rollback from ScyllaDB Enterprise release 2022.1.x to 2021.1.y. Apply this procedure if an upgrade from 2021.1 to 2022.1 failed before completing on all nodes. Use this procedure only for nodes you upgraded to 2022.1
+
+
+ScyllaDB rollback is a rolling procedure that does **not** require a  full cluster shutdown.
+For each of the nodes you rollback to 2021.1, you will:
+
+* Drain the node and stop ScyllaDB
+* Retrieve the old ScyllaDB packages
+* Restore the configuration file
+* Restart ScyllaDB
+* Validate the rollback success
+
+Apply the following procedure **serially** on each node. Do not move to the next node before validating the node is up and running the new version.
+
+Rollback Steps
+==============
+Gracefully shutdown ScyllaDB
+----------------------------
+  .. code:: sh
+
+     nodetool drain
+     sudo systemctl stop scylla-server
+
+Download and install the new release
+------------------------------------
+#. Remove the old repo file:
+
+.. code:: sh
+
+   sudo rm -rf /etc/yum.repos.d/scylla.repo
+
+#. Update the `Scylla RPM Enterprise 2022.1 repo <https://www.scylladb.com/customer-portal/?product=ent&platform=centos7&version=stable-release-2022.1>`_  to **2022.1**
+#. Install:
+
+  .. code:: sh
+
+     sudo yum clean all
+     sudo rm -rf /var/cache/yum
+     sudo yum remove scylla\*tools-core
+     sudo yum downgrade scylla\* -y
+     sudo yum install scylla-enterprise
+
+Restore the configuration file
+------------------------------
+
+.. code:: sh
+
+   sudo rm -rf /etc/scylla/scylla.yaml
+   sudo cp -a /etc/scylla/scylla.yaml.backup-2021.1 /etc/scylla/scylla.yaml
+
+Restore system tables
+---------------------
+
+Restore all tables of **system** and **system_schema** from the previous snapshot - 2022.1 uses a different set of system tables. Reference doc: :doc:`Restore from a Backup and Incremental Backup </operating-scylla/procedures/backup-restore/restore/>`.
+
+.. code:: sh
+
+    cd /var/lib/scylla/data/keyspace_name/table_name-UUID/snapshots/<snapshot_name>/
+    sudo cp -r * /var/lib/scylla/data/keyspace_name/table_name-UUID/
+    sudo chown -R scylla:scylla /var/lib/scylla/data/keyspace_name/table_name-UUID/
+
+Start the node
+--------------
+
+.. code:: sh
+
+   sudo systemctl start scylla-server
+
+Validate
+--------
+Check the upgrade instructions above for validation. Once you are sure the node rollback is successful, move to the next node in the cluster.

--- a/docs/upgrade/upgrade-enterprise/upgrade-guide-from-2021.1-to-2022.1/upgrade-guide-from-2021.1-to-2022.1-ubuntu-16-04.rst
+++ b/docs/upgrade/upgrade-enterprise/upgrade-guide-from-2021.1-to-2022.1/upgrade-guide-from-2021.1-to-2022.1-ubuntu-16-04.rst
@@ -1,7 +1,0 @@
-.. |OS| replace:: 16.04
-.. |ROLLBACK| replace:: rollback
-.. _ROLLBACK: /upgrade/upgrade-enterprise/upgrade-guide-from-2021.1-to-2022.1/upgrade-guide-from-2021.1-to-2022.1-ubuntu-16-04/#rollback-procedure
-.. |APT| replace:: ScyllaDB Enterprise Deb repo
-.. _APT: https://www.scylladb.com/customer-portal/?product=ent&platform=ubuntu-16.04&version=stable-release-2022.1
-.. |OPENJDK| replace:: openjdk-8-jre-headless
-.. include:: /upgrade/_common/upgrade-guide-from-2021.1-to-2022.1-ubuntu-and-debian.rst

--- a/docs/upgrade/upgrade-enterprise/upgrade-guide-from-2021.1-to-2022.1/upgrade-guide-from-2021.1-to-2022.1-ubuntu-16-04.rst
+++ b/docs/upgrade/upgrade-enterprise/upgrade-guide-from-2021.1-to-2022.1/upgrade-guide-from-2021.1-to-2022.1-ubuntu-16-04.rst
@@ -1,0 +1,7 @@
+.. |OS| replace:: 16.04
+.. |ROLLBACK| replace:: rollback
+.. _ROLLBACK: /upgrade/upgrade-enterprise/upgrade-guide-from-2021.1-to-2022.1/upgrade-guide-from-2021.1-to-2022.1-ubuntu-16-04/#rollback-procedure
+.. |APT| replace:: ScyllaDB Enterprise Deb repo
+.. _APT: https://www.scylladb.com/customer-portal/?product=ent&platform=ubuntu-16.04&version=stable-release-2022.1
+.. |OPENJDK| replace:: openjdk-8-jre-headless
+.. include:: /upgrade/_common/upgrade-guide-from-2021.1-to-2022.1-ubuntu-and-debian.rst

--- a/docs/upgrade/upgrade-enterprise/upgrade-guide-from-2021.1-to-2022.1/upgrade-guide-from-2021.1-to-2022.1-ubuntu-18-04.rst
+++ b/docs/upgrade/upgrade-enterprise/upgrade-guide-from-2021.1-to-2022.1/upgrade-guide-from-2021.1-to-2022.1-ubuntu-18-04.rst
@@ -1,0 +1,7 @@
+.. |OS| replace:: 18.04
+.. |ROLLBACK| replace:: rollback
+.. _ROLLBACK: /upgrade/upgrade-enterprise/upgrade-guide-from-2021.1-to-2022.1/upgrade-guide-from-2021.1-to-2022.1-ubuntu-18-04/#rollback-procedure
+.. |APT| replace:: ScyllaDB Enterprise Deb repo
+.. _APT: https://www.scylladb.com/customer-portal/?product=ent&platform=ubuntu-18.04&version=stable-release-2022.1
+.. |OPENJDK| replace:: openjdk-8-jre-headless
+.. include:: /upgrade/_common/upgrade-guide-from-2021.1-to-2022.1-ubuntu-and-debian.rst

--- a/docs/upgrade/upgrade-enterprise/upgrade-guide-from-2021.1-to-2022.1/upgrade-guide-from-2021.1-to-2022.1-ubuntu-20-04.rst
+++ b/docs/upgrade/upgrade-enterprise/upgrade-guide-from-2021.1-to-2022.1/upgrade-guide-from-2021.1-to-2022.1-ubuntu-20-04.rst
@@ -1,0 +1,7 @@
+.. |OS| replace:: 20.04
+.. |ROLLBACK| replace:: rollback
+.. _ROLLBACK: /upgrade/upgrade-enterprise/upgrade-guide-from-2021.1-to-2022.1/upgrade-guide-from-2021.1-to-2022.1-ubuntu-18-04/#rollback-procedure
+.. |APT| replace:: ScyllaDB Enterprise Deb repo
+.. _APT: https://www.scylladb.com/customer-portal/?product=ent&platform=ubuntu-20.04&version=stable-release-2022.1
+.. |OPENJDK| replace:: openjdk-8-jre-headless
+.. include:: /upgrade/_common/upgrade-guide-from-2021.1-to-2022.1-ubuntu-and-debian.rst


### PR DESCRIPTION
Fix https://github.com/scylladb/scylla-docs/issues/4040
Fix https://github.com/scylladb/scylla-docs/issues/4128

This PR adds the upgrade guides from ScyllaDB Enterprise 2021.1 to 2022.1. They are based on the previous guides. 