### PR TITLE
raft: split `can_vote` field form `server_address` to separate struct

### DIFF
--- a/idl/group0.idl.hh
+++ b/idl/group0.idl.hh
@@ -18,6 +18,6 @@ struct group0_peer_exchange {
 };
 
 verb [[with_client_info, with_timeout]] group0_peer_exchange (std::vector<raft::server_address> peers) -> service::group0_peer_exchange;
-verb [[with_client_info, with_timeout]] group0_modify_config (raft::group_id gid, std::vector<raft::server_address> add, std::vector<raft::server_id> del);
+verb [[with_client_info, with_timeout]] group0_modify_config (raft::group_id gid, std::vector<raft::config_member> add, std::vector<raft::server_id> del);
 
 } // namespace raft

--- a/idl/raft.idl.hh
+++ b/idl/raft.idl.hh
@@ -98,6 +98,6 @@ verb [[with_client_info, with_timeout, one_way]] raft_read_quorum (raft::group_i
 verb [[with_client_info, with_timeout, one_way]] raft_read_quorum_reply (raft::group_id, raft::server_id from_id, raft::server_id dst_id, raft::read_quorum_reply);
 verb [[with_client_info, with_timeout]] raft_execute_read_barrier_on_leader (raft::group_id, raft::server_id from_id, raft::server_id dst_id) -> raft::read_barrier_reply;
 verb [[with_client_info, with_timeout]] raft_add_entry (raft::group_id, raft::server_id from_id, raft::server_id dst_id, raft::command cmd) -> raft::add_entry_reply;
-verb [[with_client_info, with_timeout]] raft_modify_config (raft::group_id gid, raft::server_id from_id, raft::server_id dst_id, std::vector<raft::server_address> add, std::vector<raft::server_id> del) -> raft::add_entry_reply;
+verb [[with_client_info, with_timeout]] raft_modify_config (raft::group_id gid, raft::server_id from_id, raft::server_id dst_id, std::vector<raft::config_member> add, std::vector<raft::server_id> del) -> raft::add_entry_reply;
 
 } // namespace raft

--- a/idl/raft_storage.idl.hh
+++ b/idl/raft_storage.idl.hh
@@ -24,13 +24,17 @@ struct tagged_uint64 {
 
 struct server_address {
     raft::server_id id;
-    bool can_vote;
     bytes info;
 };
 
+struct config_member {
+    raft::server_address addr;
+    bool can_vote;
+};
+
 struct configuration {
-    std::unordered_set<raft::server_address> current;
-    std::unordered_set<raft::server_address> previous;
+    std::unordered_set<raft::config_member, raft::config_member_hash, std::equal_to<void>> current;
+    std::unordered_set<raft::config_member, raft::config_member_hash, std::equal_to<void>> previous;
 };
 
 struct log_entry {

--- a/raft/fsm.cc
+++ b/raft/fsm.cc
@@ -847,6 +847,7 @@ static size_t entry_size(const log_entry& e) {
             for (auto& s : c.current) {
                 size += sizeof(s.addr.id);
                 size += s.addr.info.size();
+                size += sizeof(s.can_vote);
             }
             return size;
         }

--- a/raft/fsm.cc
+++ b/raft/fsm.cc
@@ -208,7 +208,7 @@ void fsm::become_candidate(bool is_prevote, bool is_leadership_transfer) {
     auto& votes = candidate_state().votes;
 
     const auto& voters = votes.voters();
-    if (!voters.contains(server_address{_my_id})) {
+    if (!voters.contains(_my_id)) {
         // We're not a voter in the current configuration (perhaps we completely left it).
         //
         // But sometimes, if we're transitioning between configurations
@@ -595,11 +595,11 @@ void fsm::tick() {
         // Non leaders will ignore the append reply.
         auto& cfg = get_configuration();
         // If conf is joint it means a leader will send us a non joint one eventually
-        if (!cfg.is_joint() && cfg.current.contains(raft::server_address{_my_id})) {
+        if (!cfg.is_joint() && cfg.current.contains(_my_id)) {
             for (auto s : cfg.current) {
-                if (s.can_vote && s.id != _my_id && _failure_detector.is_alive(s.id)) {
-                    logger.trace("tick[{}]: searching for a leader. Pinging {}", _my_id, s.id);
-                    send_to(s.id, append_reply{_current_term, _commit_idx, append_reply::rejected{index_t{0}, index_t{0}}});
+                if (s.can_vote && s.addr.id != _my_id && _failure_detector.is_alive(s.addr.id)) {
+                    logger.trace("tick[{}]: searching for a leader. Pinging {}", _my_id, s.addr.id);
+                    send_to(s.addr.id, append_reply{_current_term, _commit_idx, append_reply::rejected{index_t{0}, index_t{0}}});
                 }
             }
         }
@@ -845,8 +845,8 @@ static size_t entry_size(const log_entry& e) {
         size_t operator()(const configuration& c) {
             size_t size = 0;
             for (auto& s : c.current) {
-                size += sizeof(s.id);
-                size += s.info.size();
+                size += sizeof(s.addr.id);
+                size += s.addr.info.size();
             }
             return size;
         }

--- a/raft/fsm.hh
+++ b/raft/fsm.hh
@@ -30,7 +30,7 @@ struct fsm_output {
     std::optional<applied_snapshot> snp;
     // Latest configuration obtained from the log in case it has changed
     // since last fsm output poll.
-    std::optional<server_address_set> configuration;
+    std::optional<config_member_set> configuration;
     std::optional<read_id> max_read_id_with_quorum;
     // Set to true if a leadership transfer was aborted since the last output
     bool abort_leadership_transfer;

--- a/raft/raft.cc
+++ b/raft/raft.cc
@@ -13,7 +13,11 @@ namespace raft {
 seastar::logger logger("raft");
 
 std::ostream& operator<<(std::ostream& os, const raft::server_address& addr) {
-    return os << format("{{.id={} .can_vote={}}}", addr.id, addr.can_vote);
+    return os << format("{{.id={}}}", addr.id);
+}
+
+std::ostream& operator<<(std::ostream& os, const raft::config_member& s) {
+    return os << format("{{.id={} .can_vote={}}}", s.addr.id, s.can_vote);
 }
 
 std::ostream& operator<<(std::ostream& os, const raft::configuration& cfg) {

--- a/raft/server.hh
+++ b/raft/server.hh
@@ -93,7 +93,7 @@ public:
     //
     // The caller may pass a pointer to an abort_source to make the operation abortable.
     // If abort is requested before the operation finishes, the future will contain `raft::request_aborted` exception.
-    virtual future<> set_configuration(server_address_set c_new, seastar::abort_source* as = nullptr) = 0;
+    virtual future<> set_configuration(config_member_set c_new, seastar::abort_source* as = nullptr) = 0;
 
     // A simplified wrapper around set_configuration() which adds
     // and deletes servers. Unlike set_configuration(),
@@ -116,7 +116,7 @@ public:
     //
     // The caller may pass a pointer to an abort_source to make the operation abortable.
     // If abort is requested before the operation finishes, the future will contain `raft::request_aborted` exception.
-    virtual future<> modify_config(std::vector<server_address> add,
+    virtual future<> modify_config(std::vector<config_member> add,
         std::vector<server_id> del, seastar::abort_source* as = nullptr) = 0;
 
     // Return the currently known configuration

--- a/raft/tracker.hh
+++ b/raft/tracker.hh
@@ -155,10 +155,10 @@ class election_tracker {
     std::unordered_set<server_id> _responded;
     size_t _granted = 0;
 public:
-    election_tracker(const server_address_set& configuration) {
-        for (const auto& a : configuration) {
-            if (a.can_vote) {
-                _suffrage.emplace(a.id);
+    election_tracker(const config_member_set& configuration) {
+        for (const auto& s : configuration) {
+            if (s.can_vote) {
+                _suffrage.emplace(s.addr.id);
             }
         }
     }

--- a/serializer_impl.hh
+++ b/serializer_impl.hh
@@ -86,11 +86,11 @@ struct container_traits<absl::btree_set<T>> {
     };
 };
 
-template<typename T>
-struct container_traits<std::unordered_set<T>> {
+template<typename T, typename... Args>
+struct container_traits<std::unordered_set<T, Args...>> {
     struct back_emplacer {
-        std::unordered_set<T>& c;
-        back_emplacer(std::unordered_set<T>& c_) : c(c_) {}
+        std::unordered_set<T, Args...>& c;
+        back_emplacer(std::unordered_set<T, Args...>& c_) : c(c_) {}
         void operator()(T&& v) {
             c.emplace(std::move(v));
         }
@@ -279,18 +279,18 @@ struct serializer<absl::btree_set<T>> {
     }
 };
 
-template<typename T>
-struct serializer<std::unordered_set<T>> {
+template<typename T, typename... Args>
+struct serializer<std::unordered_set<T, Args...>> {
     template<typename Input>
-    static std::unordered_set<T> read(Input& in) {
+    static std::unordered_set<T, Args...> read(Input& in) {
         auto sz = deserialize(in, boost::type<uint32_t>());
-        std::unordered_set<T> v;
+        std::unordered_set<T, Args...> v;
         v.reserve(sz);
         deserialize_array_helper<false, T>::doit(in, v, sz);
         return v;
     }
     template<typename Output>
-    static void write(Output& out, const std::unordered_set<T>& v) {
+    static void write(Output& out, const std::unordered_set<T, Args...>& v) {
         safe_serialize_as_uint32(out, v.size());
         serialize_array_helper<false, T>::doit(out, v);
     }

--- a/service/raft/raft_address_map.hh
+++ b/service/raft/raft_address_map.hh
@@ -357,9 +357,7 @@ public:
         return *it;
     }
     raft::server_address get_server_address(raft::server_id id) const {
-        return raft::server_address{.id = id,
-                .info = ser::serialize_to_buffer<bytes>(get_inet_address(id))
-        };
+        return raft::server_address{id, ser::serialize_to_buffer<bytes>(get_inet_address(id))};
     }
 };
 

--- a/service/raft/raft_group_registry.cc
+++ b/service/raft/raft_group_registry.cc
@@ -169,7 +169,7 @@ void raft_group_registry::init_rpc_verbs() {
 
     ser::raft_rpc_verbs::register_raft_modify_config(&_ms, [handle_raft_rpc] (const rpc::client_info& cinfo, rpc::opt_time_point timeout,
             raft::group_id gid, raft::server_id from, raft::server_id dst,
-            std::vector<raft::server_address> add, std::vector<raft::server_id> del) mutable {
+            std::vector<raft::config_member> add, std::vector<raft::server_id> del) mutable {
         return handle_raft_rpc(cinfo, gid, from, dst,
             [from, add = std::move(add), del = std::move(del)] (raft_rpc& rpc) mutable {
 

--- a/service/raft/raft_rpc.cc
+++ b/service/raft/raft_rpc.cc
@@ -127,7 +127,7 @@ future<raft::add_entry_reply> raft_rpc::send_add_entry(raft::server_id id, const
 }
 
 future<raft::add_entry_reply> raft_rpc::send_modify_config(raft::server_id id,
-    const std::vector<raft::server_address>& add,
+    const std::vector<raft::config_member>& add,
     const std::vector<raft::server_id>& del) {
    return ser::raft_rpc_verbs::send_raft_modify_config(&_messaging, netw::msg_addr(_address_map.get_inet_address(id)),
        db::no_timeout, _group_id, _server_id, id, add, del);
@@ -137,17 +137,17 @@ future<raft::read_barrier_reply> raft_rpc::execute_read_barrier_on_leader(raft::
    return ser::raft_rpc_verbs::send_raft_execute_read_barrier_on_leader(&_messaging, netw::msg_addr(_address_map.get_inet_address(id)), db::no_timeout, _group_id, _server_id, id);
 }
 
-void raft_rpc::add_server(raft::server_id id, raft::server_info info) {
-    auto addr = raft_addr_to_inet_addr(info);
+void raft_rpc::add_server(raft::server_address addr) {
+    auto inet_addr = raft_addr_to_inet_addr(addr.info);
     // Entries explicitly managed via `rpc::add_server` and `rpc::remove_server` should never expire
     // while entries learnt upon receiving an rpc message should be expirable.
-    _address_map.set(id, addr, false);
-    _on_server_update(addr, id, true);
+    _address_map.set(addr.id, inet_addr, false);
+    _on_server_update(inet_addr, addr.id, true);
 }
 
 void raft_rpc::remove_server(raft::server_id id) {
-    if (auto addr = _address_map.erase(id)) {
-        _on_server_update(*addr, id, false);
+    if (auto inet_addr = _address_map.erase(id)) {
+        _on_server_update(*inet_addr, id, false);
     }
 }
 
@@ -212,7 +212,7 @@ future<raft::add_entry_reply> raft_rpc::execute_add_entry(raft::server_id from, 
 }
 
 future<raft::add_entry_reply> raft_rpc::execute_modify_config(raft::server_id from,
-    std::vector<raft::server_address> add,
+    std::vector<raft::config_member> add,
     std::vector<raft::server_id> del) {
     return raft_with_gate(_shutdown_gate, [&] {
         return _client->execute_modify_config(from, std::move(add), std::move(del), nullptr);

--- a/service/raft/raft_rpc.hh
+++ b/service/raft/raft_rpc.hh
@@ -50,10 +50,10 @@ public:
     future<raft::read_barrier_reply> execute_read_barrier_on_leader(raft::server_id id) override;
     future<raft::add_entry_reply> send_add_entry(raft::server_id id, const raft::command& cmd) override;
     future<raft::add_entry_reply> send_modify_config(raft::server_id id,
-        const std::vector<raft::server_address>& add,
+        const std::vector<raft::config_member>& add,
         const std::vector<raft::server_id>& del) override;
 
-    void add_server(raft::server_id id, raft::server_info info) override;
+    void add_server(raft::server_address) override;
     void remove_server(raft::server_id id) override;
     future<> abort() override;
 
@@ -70,7 +70,7 @@ public:
     future<raft::snapshot_reply> apply_snapshot(raft::server_id from, raft::install_snapshot snp);
     future<raft::add_entry_reply> execute_add_entry(raft::server_id from, raft::command cmd);
     future<raft::add_entry_reply> execute_modify_config(raft::server_id from,
-        std::vector<raft::server_address> add,
+        std::vector<raft::config_member> add,
         std::vector<raft::server_id> del);
 };
 

--- a/test/raft/discovery_test.cc
+++ b/test/raft/discovery_test.cc
@@ -54,11 +54,11 @@ void run_discovery(Args&&... args) {
 
 BOOST_AUTO_TEST_CASE(test_basic) {
 
-    server_address addr1 = {.id = id()};
+    server_address addr1 = {id(), {}};
 
     // Must supply an Internet address for self
     BOOST_CHECK_THROW(discovery(addr1, {}), std::logic_error);
-    server_address addr2 = {.id = id(), .info = "192.168.1.2"};
+    server_address addr2 = {id(), "192.168.1.2"};
     BOOST_CHECK_NO_THROW(discovery(addr2, {}));
     // Must supply an Internet address for each peer
     BOOST_CHECK_THROW(discovery(addr2, {addr1}), std::logic_error);
@@ -74,8 +74,8 @@ BOOST_AUTO_TEST_CASE(test_basic) {
 
 BOOST_AUTO_TEST_CASE(test_discovery) {
 
-    server_address addr1 = {.id = id(), .info = "192.168.1.1"};
-    server_address addr2 = {.id = id(), .info = "192.168.1.2"};
+    server_address addr1 = {id(), "192.168.1.1"};
+    server_address addr2 = {id(), "192.168.1.2"};
 
     discovery d1(addr1, {addr2});
     discovery d2(addr2, {addr1});
@@ -86,9 +86,9 @@ BOOST_AUTO_TEST_CASE(test_discovery) {
 
 BOOST_AUTO_TEST_CASE(test_discovery_fullmesh) {
 
-    server_address addr1 = {.id = id(), .info = "127.0.0.13"};
-    server_address addr2 = {.id = id(), .info = "127.0.0.19"};
-    server_address addr3 = {.id = id(), .info = "127.0.0.21"};
+    server_address addr1 = {id(), "127.0.0.13"};
+    server_address addr2 = {id(), "127.0.0.19"};
+    server_address addr3 = {id(), "127.0.0.21"};
 
     auto seeds = std::vector<server_address>({addr1, addr2, addr3});
 

--- a/test/raft/etcd_test.cc
+++ b/test/raft/etcd_test.cc
@@ -34,7 +34,7 @@ BOOST_AUTO_TEST_CASE(test_progress_leader) {
 
     server_id id1{utils::UUID(0, 1)}, id2{utils::UUID(0, 2)};
 
-    raft::configuration cfg({id1, id2});                 // 2 nodes
+    raft::configuration cfg = config_from_ids({id1, id2}); // 2 nodes
     raft::log log{raft::snapshot_descriptor{.config = cfg}};
 
     fsm_debug fsm(id1, term_t{}, server_id{}, std::move(log), trivial_failure_detector, fsm_cfg);
@@ -85,7 +85,7 @@ BOOST_AUTO_TEST_CASE(test_progress_resume_by_append_resp) {
 
     server_id id1{utils::UUID(0, 1)}, id2{utils::UUID(0, 2)};
 
-    raft::configuration cfg({id1, id2});                 // 2 nodes
+    raft::configuration cfg = config_from_ids({id1, id2}); // 2 nodes
     raft::log log{raft::snapshot_descriptor{.config = cfg}};
 
     fsm_debug fsm(id1, term_t{}, server_id{}, std::move(log), trivial_failure_detector, fsm_cfg);
@@ -124,7 +124,7 @@ BOOST_AUTO_TEST_CASE(test_progress_resume_by_append_resp) {
 BOOST_AUTO_TEST_CASE(test_progress_paused) {
 
     server_id id1{utils::UUID(0, 1)}, id2{utils::UUID(0, 2)};
-    raft::configuration cfg({id1, id2});                 // 2 nodes
+    raft::configuration cfg = config_from_ids({id1, id2});
     raft::log log{raft::snapshot_descriptor{.config = cfg}};
 
     fsm_debug fsm(id1, term_t{}, server_id{}, std::move(log), trivial_failure_detector, fsm_cfg);
@@ -147,7 +147,7 @@ BOOST_AUTO_TEST_CASE(test_progress_paused) {
 BOOST_AUTO_TEST_CASE(test_progress_flow_control) {
 
     server_id id1{utils::UUID(0, 1)}, id2{utils::UUID(0, 2)};
-    raft::configuration cfg({id1, id2});                 // 2 nodes
+    raft::configuration cfg = config_from_ids({id1, id2}); // 2 nodes
     raft::log log{raft::snapshot_descriptor{.config = cfg}};
 
     // Fit 2 x 1000 sized blobs
@@ -239,7 +239,7 @@ BOOST_AUTO_TEST_CASE(test_leader_election_overwrite_newer_logs) {
     // 5 nodes
     server_id id1{utils::UUID(0, 1)}, id2{utils::UUID(0, 2)}, id3{utils::UUID(0, 3)},
             id4{utils::UUID(0, 4)}, id5{utils::UUID(0, 5)};
-    raft::configuration cfg({id1, id2, id3, id4, id5});
+    raft::configuration cfg = config_from_ids({id1, id2, id3, id4, id5});
     //                        idx  term
     // node 1:    log entries  1:   1                 won first got logs
     // node 2:    log entries  1:   1                 got logs from node 1
@@ -296,7 +296,7 @@ BOOST_AUTO_TEST_CASE(test_vote_from_any_state) {
     discrete_failure_detector fd;
 
     server_id id1{utils::UUID(0, 1)}, id2{utils::UUID(0, 2)}, id3{utils::UUID(0, 3)};
-    raft::configuration cfg({id1, id2, id3});
+    raft::configuration cfg = config_from_ids({id1, id2, id3});
     raft::log log{raft::snapshot_descriptor{.config = cfg}};
     raft::fsm fsm(id1, term_t{}, server_id{}, std::move(log), fd, fsm_cfg);
 
@@ -358,7 +358,7 @@ BOOST_AUTO_TEST_CASE(test_log_replication_1) {
     raft::index_t idx;
 
     server_id id1{utils::UUID(0, 1)}, id2{utils::UUID(0, 2)}, id3{utils::UUID(0, 3)};
-    raft::configuration cfg({id1, id2, id3});
+    raft::configuration cfg = config_from_ids({id1, id2, id3});
     raft::log log{raft::snapshot_descriptor{.config = cfg}};
     raft::fsm fsm(id1, term_t{}, server_id{}, std::move(log), trivial_failure_detector, fsm_cfg);
 
@@ -423,7 +423,7 @@ BOOST_AUTO_TEST_CASE(test_log_replication_2) {
     raft::index_t idx;
 
     server_id id1{utils::UUID(0, 1)}, id2{utils::UUID(0, 2)}, id3{utils::UUID(0, 3)};
-    raft::configuration cfg({id1, id2, id3});
+    raft::configuration cfg = config_from_ids({id1, id2, id3});
     raft::log log{raft::snapshot_descriptor{.config = cfg}};
     raft::fsm fsm(id1, term_t{}, server_id{}, std::move(log), trivial_failure_detector, fsm_cfg);
 
@@ -483,7 +483,7 @@ BOOST_AUTO_TEST_CASE(test_single_node_commit) {
     raft::log_entry_ptr lep;
 
     server_id id1{utils::UUID(0, 1)};
-    raft::configuration cfg({id1});
+    raft::configuration cfg = config_from_ids({id1});
     raft::log log{raft::snapshot_descriptor{.config = cfg}};
     raft::fsm fsm(id1, term_t{}, server_id{}, std::move(log), trivial_failure_detector, fsm_cfg);
 
@@ -520,7 +520,7 @@ BOOST_AUTO_TEST_CASE(test_cannot_commit_without_new_term_entry) {
 
     server_id id1{utils::UUID(0, 1)}, id2{utils::UUID(0, 2)}, id3{utils::UUID(0, 3)},
               id4{utils::UUID(0, 4)}, id5{utils::UUID(0, 5)};
-    raft::configuration cfg({id1, id2, id3, id4, id5});
+    raft::configuration cfg = config_from_ids({id1, id2, id3, id4, id5});
     raft::log log1{raft::snapshot_descriptor{.config = cfg}};
     fsm_debug fsm1(id1, term_t{}, server_id{}, std::move(log1), fd, fsm_cfg);
     raft::log log2{raft::snapshot_descriptor{.config = cfg}};
@@ -576,7 +576,7 @@ BOOST_AUTO_TEST_CASE(test_cannot_commit_without_new_term_entry) {
 BOOST_AUTO_TEST_CASE(test_dueling_candidates) {
 
     server_id id1{utils::UUID(0, 1)}, id2{utils::UUID(0, 2)}, id3{utils::UUID(0, 3)};
-    raft::configuration cfg({id1, id2, id3});
+    raft::configuration cfg = config_from_ids({id1, id2, id3});
     raft::log log1{raft::snapshot_descriptor{.config = cfg}};
     raft::fsm fsm1(id1, term_t{}, server_id{}, std::move(log1), trivial_failure_detector, fsm_cfg);
     raft::log log2{raft::snapshot_descriptor{.config = cfg}};
@@ -619,7 +619,7 @@ BOOST_AUTO_TEST_CASE(test_dueling_candidates) {
 BOOST_AUTO_TEST_CASE(test_dueling_pre_candidates) {
 
     server_id id1{utils::UUID(0, 1)}, id2{utils::UUID(0, 2)}, id3{utils::UUID(0, 3)};
-    raft::configuration cfg({id1, id2, id3});
+    raft::configuration cfg = config_from_ids({id1, id2, id3});
     raft::log log1{raft::snapshot_descriptor{.config = cfg}};
     raft::fsm fsm1(id1, term_t{}, server_id{}, std::move(log1), trivial_failure_detector, fsm_cfg_pre);
     raft::log log2{raft::snapshot_descriptor{.config = cfg}};
@@ -665,7 +665,7 @@ BOOST_AUTO_TEST_CASE(test_single_node_pre_candidate) {
     raft::fsm_output output1;
 
     server_id id1{utils::UUID(0, 1)};
-    raft::configuration cfg({id1});
+    raft::configuration cfg = config_from_ids({id1});
     raft::log log1{raft::snapshot_descriptor{.config = cfg}};
     raft::fsm fsm1(id1, term_t{}, server_id{}, std::move(log1), trivial_failure_detector, fsm_cfg_pre);
 
@@ -677,7 +677,7 @@ BOOST_AUTO_TEST_CASE(test_old_messages) {
 
     discrete_failure_detector fd;
     server_id id1{utils::UUID(0, 1)}, id2{utils::UUID(0, 2)}, id3{utils::UUID(0, 3)};
-    raft::configuration cfg({id1, id2, id3});
+    raft::configuration cfg = config_from_ids({id1, id2, id3});
     raft::log log1{raft::snapshot_descriptor{.config = cfg}};
     fsm_debug fsm1(id1, term_t{}, server_id{}, std::move(log1), fd, fsm_cfg);
     raft::log log2{raft::snapshot_descriptor{.config = cfg}};
@@ -736,12 +736,12 @@ void handle_proposal(unsigned nodes, std::vector<int> accepting_int) {
         accepting.insert(raft::server_id{utils::UUID(0, id)});
     }
 
-    server_address_set ids;     // ids of leader 1 .. #nodes
+    std::vector<raft::server_id> ids;     // ids of leader 1 .. #nodes
     for (unsigned i = 1; i < nodes + 1; ++i) {
-        ids.insert({.id = raft::server_id{utils::UUID(0, i)}});
+        ids.push_back(raft::server_id{utils::UUID(0, i)});
     }
 
-    raft::configuration cfg(ids);
+    raft::configuration cfg = config_from_ids(ids);
     raft::log log1{raft::snapshot_descriptor{.config = cfg}};
     raft::fsm fsm1(raft::server_id{utils::UUID(0, 1)}, term_t{}, server_id{}, std::move(log1),
             trivial_failure_detector, fsm_cfg);
@@ -835,7 +835,7 @@ BOOST_AUTO_TEST_CASE(test_leader_transfer_ignore_proposal) {
 
     raft::server_id A_id = id(), B_id = id();
     raft::log log(raft::snapshot_descriptor{.idx = raft::index_t{0},
-        .config = raft::configuration({A_id, B_id})});
+        .config = config_from_ids({A_id, B_id})});
     auto A = create_follower(A_id, log);
     auto B = create_follower(B_id, log);
 
@@ -863,7 +863,7 @@ BOOST_AUTO_TEST_CASE(test_transfer_non_member) {
 
     raft::server_id A_id = id(), B_id = id(), C_id = id(), D_id = id();
     raft::log log(raft::snapshot_descriptor{.idx = raft::index_t{0},
-        .config = raft::configuration({B_id, C_id, D_id})});
+        .config = config_from_ids({B_id, C_id, D_id})});
     auto A = create_follower(A_id, log);
 
     A.step(B_id, timeout_now{A.get_current_term()});
@@ -878,7 +878,7 @@ BOOST_AUTO_TEST_CASE(test_leader_transfer_timeout) {
     raft::server_id A_id = id(), B_id = id(), C_id = id();
 
     raft::log log(raft::snapshot_descriptor{.idx = raft::index_t{0},
-        .config = raft::configuration{A_id, B_id, C_id}});
+        .config = config_from_ids({A_id, B_id, C_id})});
     auto A = create_follower(A_id, log, fd);
     auto B = create_follower(B_id, log, fd);
     auto C = create_follower(C_id, log, fd);
@@ -913,7 +913,7 @@ BOOST_AUTO_TEST_CASE(test_leader_transfer_one_node_cluster) {
     discrete_failure_detector fd;
     raft::server_id A_id = id();
 
-    raft::log log(raft::snapshot_descriptor{.idx = raft::index_t{0}, .config = raft::configuration{A_id}});
+    raft::log log(raft::snapshot_descriptor{.idx = raft::index_t{0}, .config = config_from_ids({A_id})});
     auto A = create_follower(A_id, log, fd);
     // Elect A leader.
     election_timeout(A);
@@ -926,7 +926,7 @@ BOOST_AUTO_TEST_CASE(test_leader_transfer_one_node_cluster) {
 BOOST_AUTO_TEST_CASE(test_leader_transfer_one_voter) {
     discrete_failure_detector fd;
     raft::server_id A_id = id(), B_id = id();
-    raft::server_address_set set{raft::server_address{A_id, true}, raft::server_address{B_id, false}};
+    raft::config_member_set set{{server_addr_from_id(A_id), true}, {server_addr_from_id(B_id), false}};
     raft::configuration cfg(set);
 
 

--- a/test/raft/helpers.cc
+++ b/test/raft/helpers.cc
@@ -118,7 +118,15 @@ raft::server_id id() {
 raft::server_address_set address_set(std::vector<raft::server_id> ids) {
     raft::server_address_set set;
     for (auto id : ids) {
-        set.emplace(raft::server_address{.id = id});
+        set.emplace(server_addr_from_id(id));
+    }
+    return set;
+}
+
+raft::config_member_set config_set(std::vector<raft::server_id> ids) {
+    raft::config_member_set set;
+    for (auto id : ids) {
+        set.emplace(config_member_from_id(id));
     }
     return set;
 }
@@ -138,9 +146,12 @@ raft::server_id to_raft_id(size_t int_id) {
     return raft::server_id{to_raft_uuid(int_id)};
 }
 
-// NOTE: can_vote = true
 raft::server_address to_server_address(size_t int_id) {
-    return raft::server_address{raft::server_id{to_raft_uuid(int_id)}};
+    return server_addr_from_id(raft::server_id{to_raft_uuid(int_id)});
+}
+
+raft::config_member to_config_member(size_t int_id) {
+    return {to_server_address(int_id), true};
 }
 
 size_t to_int_id(utils::UUID uuid) {
@@ -195,4 +206,16 @@ future<> invoke_abortable_on(unsigned shard, noncopyable_function<future<>(abort
     }
 
     std::rethrow_exception(ep);
+}
+
+raft::server_address server_addr_from_id(raft::server_id id) {
+    return raft::server_address{id, {}};
+}
+
+raft::config_member config_member_from_id(raft::server_id id) {
+    return raft::config_member{server_addr_from_id(id), true};
+}
+
+raft::configuration config_from_ids(std::vector<raft::server_id> ids) {
+    return raft::configuration{config_set(std::move(ids))};
 }

--- a/test/raft/helpers.hh
+++ b/test/raft/helpers.hh
@@ -129,6 +129,7 @@ raft::fsm* select_leader(Args&&... args) {
 
 raft::server_id id();
 raft::server_address_set address_set(std::vector<raft::server_id> ids);
+raft::config_member_set config_set(std::vector<raft::server_id> ids);
 fsm_debug create_follower(raft::server_id id, raft::log log,
         raft::failure_detector& fd = trivial_failure_detector);
 
@@ -138,8 +139,10 @@ fsm_debug create_follower(raft::server_id id, raft::log log,
 utils::UUID to_raft_uuid(size_t int_id);
 raft::server_id to_raft_id(size_t int_id);
 
-// NOTE: can_vote = true
 raft::server_address to_server_address(size_t int_id);
+// NOTE: can_vote = true
+raft::config_member to_config_member(size_t int_id);
+
 size_t to_int_id(utils::UUID uuid);
 // Return true upon a random event with given probability
 bool rolladice(float probability = 1.0/2.0);
@@ -148,3 +151,11 @@ bool rolladice(float probability = 1.0/2.0);
 // It's not safe to use `as` directly on a different shard. This function routes the abort requests
 // from `as` to the other shard.
 future<> invoke_abortable_on(unsigned shard, noncopyable_function<future<>(abort_source&)> f, abort_source& as);
+
+// Server address with given ID and empty `info`.
+raft::server_address server_addr_from_id(raft::server_id);
+// Config member with given ID, empty `info`, a voter.
+raft::config_member config_member_from_id(raft::server_id);
+
+// Make a non-joint configuration from a given set of IDs by setting empty `server_info`s and `can_vote = true`.
+raft::configuration config_from_ids(std::vector<raft::server_id>);

--- a/test/raft/raft_sys_table_storage_test.cc
+++ b/test/raft/raft_sys_table_storage_test.cc
@@ -65,7 +65,7 @@ static std::vector<raft::log_entry_ptr> create_test_log() {
         make_lw_shared(raft::log_entry{
             .term = raft::term_t(2),
             .idx = raft::index_t(2),
-            .data = raft::configuration({raft::server_id::create_random_id()})}),
+            .data = raft::configuration{{raft::config_member{raft::server_address{raft::server_id::create_random_id(), {}}, true}}}}),
         // dummy
         make_lw_shared(raft::log_entry{
             .term = raft::term_t(3),
@@ -97,9 +97,11 @@ SEASTAR_TEST_CASE(test_store_load_snapshot) {
 
         raft::term_t snp_term(1);
         raft::index_t snp_idx(1);
-        raft::server_address srv_addr{raft::server_id::create_random_id()};
-        srv_addr.info = ser::serialize_to_buffer<bytes>(gms::inet_address("localhost"));
-        raft::configuration snp_cfg({std::move(srv_addr)});
+        raft::config_member srv{raft::server_address{
+                raft::server_id::create_random_id(),
+                ser::serialize_to_buffer<bytes>(gms::inet_address("localhost"))
+            }, true};
+        raft::configuration snp_cfg({std::move(srv)});
         auto snp_id = raft::snapshot_id::create_random_id();
 
         raft::snapshot_descriptor snp{
@@ -162,9 +164,11 @@ SEASTAR_TEST_CASE(test_store_snapshot_truncate_log_tail) {
 
         raft::term_t snp_term(3);
         raft::index_t snp_idx(3);
-        raft::server_address srv_addr{raft::server_id::create_random_id()};
-        srv_addr.info = ser::serialize_to_buffer<bytes>(gms::inet_address("localhost"));
-        raft::configuration snp_cfg({std::move(srv_addr)});
+        raft::config_member srv{raft::server_address{
+                raft::server_id::create_random_id(),
+                ser::serialize_to_buffer<bytes>(gms::inet_address("localhost"))
+            }, true};
+        raft::configuration snp_cfg({std::move(srv)});
         auto snp_id = raft::snapshot_id::create_random_id();
 
         raft::snapshot_descriptor snp{

--- a/test/raft/replication.cc
+++ b/test/raft/replication.cc
@@ -29,6 +29,10 @@ raft::server_address_set address_set(std::vector<node_id> nodes) noexcept {
     return address_set(to_raft_id_vec(nodes));
 }
 
+raft::config_member_set config_set(std::vector<node_id> nodes) noexcept {
+    return config_set(to_raft_id_vec(nodes));
+}
+
 size_t test_case::get_first_val() {
     // Count existing leader snap index and entries, if present
     size_t first_val = 0;

--- a/test/raft/replication_test.cc
+++ b/test/raft/replication_test.cc
@@ -267,7 +267,7 @@ RAFT_TEST_CASE(etcd_test_leader_cycle, (test_case{
 RAFT_TEST_CASE(rpc_load_conf_from_snapshot, (test_case{
          .nodes = 1, .total_values = 0,
          .initial_snapshots = {{.snap = {
-                .config = raft::configuration{to_raft_id(0)}}}},
+                .config = config_from_ids({to_raft_id(0)})}}},
          .updates = {check_rpc_config{node_id{0},
                      rpc_address_set{node_id{0}}}
          }}));
@@ -276,7 +276,7 @@ RAFT_TEST_CASE(rpc_load_conf_from_snapshot, (test_case{
 // Initial configuration is taken from the persisted log.
 RAFT_TEST_CASE(rpc_load_conf_from_log, (test_case{
          .nodes = 1, .total_values = 0,
-         .initial_states = {{.le = {{1, raft::configuration{to_raft_id(0)}}}}},
+         .initial_states = {{.le = {{1, config_from_ids({to_raft_id(0)})}}}},
          .updates = {check_rpc_config{node_id{0},
                      rpc_address_set{node_id{0}}}
          }}));
@@ -375,7 +375,7 @@ RAFT_TEST_CASE(rpc_configuration_truncate_restore_from_snp, (test_case{
                 .log = { raft::log_entry{raft::term_t(1), raft::index_t(1),
                         config{.curr = {node_id{0},node_id{1},node_id{2},node_id{3}},
                                .prev = {node_id{0},node_id{1},node_id{2}}}}},
-                .snapshot = {.config  = raft::configuration{address_set({node_id{0},node_id{1},node_id{2}})}
+                .snapshot = {.config  = raft::configuration{config_set({node_id{0},node_id{1},node_id{2}})}
                 }
             }},
             // A should see {A, B, C, D} as RPC config since
@@ -472,7 +472,7 @@ RAFT_TEST_CASE(rpc_configuration_truncate_restore_from_log, (test_case{
                         },
                 },
                 // all nodes in snapshot config {A, B, C, D} (original)
-                .snapshot = {.config  = raft::configuration{address_set({node_id{0},node_id{1},node_id{2},node_id{3}})}
+                .snapshot = {.config  = raft::configuration{config_set({node_id{0},node_id{1},node_id{2},node_id{3}})}
                 }
             }},
 
@@ -522,7 +522,7 @@ RAFT_TEST_CASE(rpc_configuration_truncate_restore_from_log, (test_case{
                         },
                 },
                 // all nodes in snapshot config {A, B, C, D} (original)
-                .snapshot = {.config  = raft::configuration{address_set({node_id{0},node_id{1},node_id{2},node_id{3}})}
+                .snapshot = {.config  = raft::configuration{config_set({node_id{0},node_id{1},node_id{2},node_id{3}})}
                 }
             }},
 

--- a/to_string.hh
+++ b/to_string.hh
@@ -100,8 +100,8 @@ std::ostream& operator<<(std::ostream& os, const std::tuple<T...>& p) {
     return print_tuple(os, p, std::make_index_sequence<sizeof...(T)>());
 }
 
-template <typename T>
-std::ostream& operator<<(std::ostream& os, const std::unordered_set<T>& items) {
+template <typename T, typename... Args>
+std::ostream& operator<<(std::ostream& os, const std::unordered_set<T, Args...>& items) {
     os << "{" << join(", ", items) << "}";
     return os;
 }


### PR DESCRIPTION
Whether a server can vote in a Raft configuration is not part of the
address. `server_address` was used in many context where `can_vote` is
irrelevant.

Split the struct: `server_address` now contains only `id` and
`server_info` as it did before `can_vote` was introduced. Instead we
have a `config_member` struct that contains a `server_address` and the
`can_vote` field.

Also remove an "unsafe" constructor from `server_address` where `id` was
provided but `server_info` was not. The constructor was used for tests
where `server_info` is irrelevant, but it's important not to forget
about the info in production code. Replace the constructor with helper
functions which specify in comments that they are supposed to be used in
tests or in contexts where `info` doesn't matter (e.g. when checking
presence in an `unordered_set`, where the equality operator and hash
operate only on the `id`).

