### PR TITLE
CODEOWNERS: add @psarna and @nyh as owners for docs/alternator

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -33,6 +33,7 @@ tests/counter_test* @jul-stas
 
 # DOCS
 docs/* @annastuchlik @tzach
+docs/alternator @annastuchlik @tzach @nyh @psarna
 
 # GOSSIP
 gms/* @tgrabiec @asias


### PR DESCRIPTION
Follow-up to https://github.com/scylladb/scylla/pull/11046, as requested by @nyh.