### PR TITLE
api: list of the user keyspaces contains only user keyspaces

### DIFF
--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -795,7 +795,7 @@ void set_storage_service(http_context& ctx, routes& r, sharded<service::storage_
     ss::get_keyspaces.set(r, [&ctx](const_req req) {
         auto type = req.get_query_param("type");
         if (type == "user") {
-            return ctx.db.local().get_non_system_keyspaces();
+            return ctx.db.local().get_user_keyspaces();
         } else if (type == "non_local_strategy") {
             return map_keys(ctx.db.local().get_keyspaces() | boost::adaptors::filtered([](const auto& p) {
                 return p.second.get_replication_strategy().get_type() != locator::replication_strategy_type::local;

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -1071,6 +1071,16 @@ std::vector<sstring>  database::get_non_system_keyspaces() const {
     return res;
 }
 
+std::vector<sstring> database::get_user_keyspaces() const {
+    std::vector<sstring> res;
+    for (auto const& i : _keyspaces) {
+        if (!is_internal_keyspace(i.first)) {
+            res.push_back(i.first);
+        }
+    }
+    return res;
+}
+
 std::vector<sstring> database::get_all_keyspaces() const {
     std::vector<sstring> res;
     res.reserve(_keyspaces.size());

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1496,6 +1496,7 @@ public:
     future<> update_keyspace(sharded<service::storage_proxy>& proxy, const sstring& name);
     void drop_keyspace(const sstring& name);
     std::vector<sstring> get_non_system_keyspaces() const;
+    std::vector<sstring> get_user_keyspaces() const;
     std::vector<sstring> get_all_keyspaces() const;
     column_family& find_column_family(std::string_view ks, std::string_view name);
     const column_family& find_column_family(std::string_view ks, std::string_view name) const;


### PR DESCRIPTION
storage_service/keyspaces?type=user along with user keyspaces returned
the keyspaces that were internal but non-system.

The list of the keyspaces for the user option (storage_service/keyspaces?type=user)
contains neither system nor internal but only user keyspaces.

Fixes: #11042