### PR TITLE
Get sstables for compaction idempotency

### DIFF
--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -353,7 +353,7 @@ protected:
         // candidates are sstables that aren't being operated on by other compaction types.
         // those are eligible for major compaction.
         auto* t = _compacting_table;
-        sstables::compaction_strategy cs = t->get_compaction_strategy();
+        auto& cs = t->get_compaction_strategy();
         sstables::compaction_descriptor descriptor = cs.get_major_compaction_job(t->as_table_state(), _cm.get_candidates(*t));
         auto compacting = compacting_sstable_registration(_cm, descriptor.sstables);
         auto release_exhausted = [&compacting] (const std::vector<sstables::shared_sstable>& exhausted_sstables) {
@@ -886,7 +886,7 @@ protected:
             }
 
             replica::table& t = *_compacting_table;
-            sstables::compaction_strategy cs = t.get_compaction_strategy();
+            auto& cs = t.get_compaction_strategy();
             sstables::compaction_descriptor descriptor = cs.get_sstables_for_compaction(t.as_table_state(), _cm.get_strategy_control(), _cm.get_candidates(t));
             int weight = calculate_weight(descriptor);
 

--- a/compaction/leveled_manifest.hh
+++ b/compaction/leveled_manifest.hh
@@ -141,7 +141,7 @@ public:
 
 
     sstables::compaction_descriptor get_descriptor_for_level(int level, const std::vector<std::optional<dht::decorated_key>>& last_compacted_keys,
-                                                             std::vector<int>& compaction_counter) {
+                                                             const std::vector<int>& compaction_counter) {
         auto info = get_candidates_for(level, last_compacted_keys);
         if (!info.candidates.empty()) {
             int next_level = get_next_level(info.candidates, info.can_promote);
@@ -162,7 +162,7 @@ public:
      * If no compactions are necessary, will return null
      */
     sstables::compaction_descriptor get_compaction_candidates(const std::vector<std::optional<dht::decorated_key>>& last_compacted_keys,
-        std::vector<int>& compaction_counter) {
+        const std::vector<int>& compaction_counter) {
         // LevelDB gives each level a score of how much data it contains vs its ideal amount, and
         // compacts the level with the highest score. But this falls apart spectacularly once you
         // get behind.  Consider this set of levels:

--- a/compaction/time_window_compaction_strategy.cc
+++ b/compaction/time_window_compaction_strategy.cc
@@ -221,20 +221,22 @@ time_window_compaction_strategy::get_sstables_for_compaction(table_state& table_
         return compaction_descriptor();
     }
 
-    // Find fully expired SSTables. Those will be included no matter what.
-    std::unordered_set<shared_sstable> expired;
-
     if (db_clock::now() - _last_expired_check > _options.expired_sstable_check_frequency) {
         clogger.debug("[{}] TWCS expired check sufficiently far in the past, checking for fully expired SSTables", fmt::ptr(this));
+
+        // Find fully expired SSTables. Those will be included no matter what.
+        std::unordered_set<shared_sstable> expired;
         expired = table_s.fully_expired_sstables(candidates, compaction_time);
+        if (!expired.empty()) {
+            clogger.debug("[{}] Going to compact {} expired sstables", fmt::ptr(this), expired.size());
+            return compaction_descriptor(has_only_fully_expired::yes, std::vector<shared_sstable>(expired.begin(), expired.end()), service::get_local_compaction_priority());
+        }
+        // Keep checking for fully_expired_sstables until we don't find
+        // any among the candidates, meaning they are either already compacted
+        // or registered for compaction.
         _last_expired_check = db_clock::now();
     } else {
         clogger.debug("[{}] TWCS skipping check for fully expired SSTables", fmt::ptr(this));
-    }
-
-    if (!expired.empty()) {
-        clogger.debug("[{}] Going to compact {} expired sstables", fmt::ptr(this), expired.size());
-        return compaction_descriptor(has_only_fully_expired::yes, std::vector<shared_sstable>(expired.begin(), expired.end()), service::get_local_compaction_priority());
     }
 
     auto compaction_candidates = get_next_non_expired_sstables(table_s, control, std::move(candidates), compaction_time);

--- a/compaction/time_window_compaction_strategy.cc
+++ b/compaction/time_window_compaction_strategy.cc
@@ -225,19 +225,20 @@ time_window_compaction_strategy::get_sstables_for_compaction(table_state& table_
     std::unordered_set<shared_sstable> expired;
 
     if (db_clock::now() - _last_expired_check > _options.expired_sstable_check_frequency) {
-        clogger.debug("TWCS expired check sufficiently far in the past, checking for fully expired SSTables");
+        clogger.debug("[{}] TWCS expired check sufficiently far in the past, checking for fully expired SSTables", fmt::ptr(this));
         expired = table_s.fully_expired_sstables(candidates, compaction_time);
         _last_expired_check = db_clock::now();
     } else {
-        clogger.debug("TWCS skipping check for fully expired SSTables");
+        clogger.debug("[{}] TWCS skipping check for fully expired SSTables", fmt::ptr(this));
     }
 
     if (!expired.empty()) {
-        clogger.debug("Going to compact {} expired sstables", expired.size());
+        clogger.debug("[{}] Going to compact {} expired sstables", fmt::ptr(this), expired.size());
         return compaction_descriptor(has_only_fully_expired::yes, std::vector<shared_sstable>(expired.begin(), expired.end()), service::get_local_compaction_priority());
     }
 
     auto compaction_candidates = get_next_non_expired_sstables(table_s, control, std::move(candidates), compaction_time);
+    clogger.debug("[{}] Going to compact {} non-expired sstables", fmt::ptr(this), compaction_candidates.size());
     return compaction_descriptor(std::move(compaction_candidates), service::get_local_compaction_priority());
 }
 

--- a/locator/abstract_replication_strategy.hh
+++ b/locator/abstract_replication_strategy.hh
@@ -77,6 +77,16 @@ public:
         const replication_strategy_config_options& config_options,
         replication_strategy_type my_type);
 
+    abstract_replication_strategy(abstract_replication_strategy&&) = default;
+    abstract_replication_strategy& operator=(abstract_replication_strategy&&) = default;
+
+    // Delete the copy constructor and assignment operator
+    // as some strategies must keep state in the "master" instance
+    // kept in the table shard, and copying it unintentionally might
+    // cause the state changes to be applied on a temporary copy.
+    abstract_replication_strategy(const abstract_replication_strategy&) = delete;
+    abstract_replication_strategy& operator=(const abstract_replication_strategy&) = delete;
+
     // The returned vector has size O(number of normal token owners), which is O(number of nodes in the cluster).
     // Note: it is not guaranteed that the function will actually yield. If the complexity of a particular implementation
     // is small, that implementation may not yield since by itself it won't cause a reactor stall (assuming practical


### PR DESCRIPTION
This series makes `time_window_compaction_strategy::get_sstables_for_compaction` idempotent by setting its `_last_expired_check` member only when it find no fully expired sstables.

With that, "compaction_manager: do not copy the table compaction_strategy object" fixes a potential inefficiency (see #11051)

Applies on top of e1e4a73793c50c9f9aa0ee0fcf0b484bcca24b2d

Fixes #11051
