### PR TITLE
doc: fix the example of UDT in the SELECT statement

### DIFF
--- a/docs/getting-started/types.rst
+++ b/docs/getting-started/types.rst
@@ -568,7 +568,7 @@ result::
 Note that if you provide a subset of the UDT, for example, just the ``first`` name in the example below, **null** will be used for the missing values.
 For example::
 
-    SELECT * from superheroes WHERE name={first: 'Al', last: 'Bundy'};
+    SELECT * from superheroes WHERE name={first: 'Al'};
     
 result::
 


### PR DESCRIPTION
This PR adds the update from the PR opened in the deprecated scylla-docs repo: https://github.com/scylladb/scylla-docs/pull/4136 