### PR TITLE
query-result: move last_pos up to query::result

### DIFF
--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -989,7 +989,7 @@ lw_shared_ptr<const service::pager::paging_state> indexed_table_select_statement
         return paging_state;
     }
 
-    auto&& last_pos = result_view.get_last_position();
+    auto&& last_pos = results->get_or_calculate_last_position();
     auto& last_base_pk = last_pos.partition;
     auto* last_base_ck = last_pos.position.has_key() ? &last_pos.position.key() : nullptr;
 

--- a/idl/query.idl.hh
+++ b/idl/query.idl.hh
@@ -27,7 +27,6 @@ class qr_partition stub [[writable]] {
 
 class query_result stub [[writable]] {
     utils::chunked_vector<qr_partition> partitions; // in ring order
-    std::optional<full_position> last_position [[version 5.1]];
 };
 
 enum class digest_algorithm : uint8_t {

--- a/idl/result.idl.hh
+++ b/idl/result.idl.hh
@@ -20,6 +20,7 @@ class result {
     std::optional<uint32_t> row_count_low_bits() [[version 2.1]];
     std::optional<uint32_t> partition_count() [[version 2.1]];
     std::optional<uint32_t> row_count_high_bits() [[version 4.3]];
+    std::optional<full_position> last_position() [[version 5.1]];
 };
 
 }

--- a/query-result-reader.hh
+++ b/query-result-reader.hh
@@ -193,10 +193,7 @@ public:
         return std::make_tuple(ps.size(), rows);
     }
 
-    full_position get_last_position() const {
-        if (_v.last_position()) {
-            return *_v.last_position();
-        }
+    full_position calculate_last_position() const {
         auto ps = _v.partitions();
         assert(!ps.empty());
         auto pit = ps.begin();

--- a/service/pager/query_pagers.cc
+++ b/service/pager/query_pagers.cc
@@ -405,9 +405,9 @@ void query_pager::handle_result(
             if (_last_pkey) {
                 update_slice(*_last_pkey);
             }
-            auto last_pos = view.get_last_position();
-            _last_pkey = last_pos.partition;
-            _last_pos = last_pos.position;
+            auto last_pos = results->get_or_calculate_last_position();
+            _last_pkey = std::move(last_pos.partition);
+            _last_pos = std::move(last_pos.position);
         }
     }
 


### PR DESCRIPTION
query_result was the wrong place to put last position into. It is only
included in data-responses, but not on digest-responses. If we want to
support empty pages from replicas, both data and digest responses have
to include the last position. So hoist up the last position to the
parent structure: query::result. This is a breaking change inter-node
ABI wise, but it is fine: the current code wasn't released yet.

This commit is part of https://github.com/scylladb/scylla/pull/11053. Submitting it as a separate PR to fast-track its inclusion, before a branch can be cut and therefore the ABI breakage becomes a problem.