### PR TITLE
misc_services: Fix cache hitrate update

### DIFF
--- a/service/cache_hitrate_calculator.hh
+++ b/service/cache_hitrate_calculator.hh
@@ -38,6 +38,8 @@ class cache_hitrate_calculator : public seastar::async_sharded_service<cache_hit
     std::unordered_map<utils::UUID, stat> _rates;
     size_t _slen = 0;
     std::string _gstate;
+    uint64_t _published_nr = 0;
+    lowres_clock::time_point _published_time;
     future<> _done = make_ready_future();
 
     future<lowres_clock::duration> recalculate_hitrates();


### PR DESCRIPTION
This patch avoids unncessary CACHE_HITRATES updates through gossip.

After this patch:

Publish CACHE_HITRATES in case:

- We haven't published it at all
- The diff is bigger than 1% and we haven't published in the last 5 seconds
- The diff is really big 10%


Note: A peer node can know the cache hitrate through read_data
read_mutation_data and read_digest RPC verbs which have cache_temperature in
the response. So there is no need to update CACHE_HITRATES through gossip in
high frequency.

We do the recalculation faster if the diff is bigger than 0.01. It is useful to
do the calculation even if we do not publish the CACHE_HITRATES though gossip,
since the recalculation will call the table->set_global_cache_hit_rate to set
the hitrate.

Fixes #5971