### PR TITLE
storage_service: Increase watchdog_interval for node ops

### DIFF
--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -101,7 +101,7 @@ class node_ops_meta_data {
     std::function<void ()> _signal;
     shared_ptr<node_ops_info> _ops;
     seastar::timer<lowres_clock> _watchdog;
-    std::chrono::seconds _watchdog_interval{30};
+    std::chrono::seconds _watchdog_interval{120};
     bool _aborted = false;
 public:
     explicit node_ops_meta_data(


### PR DESCRIPTION
The node operations using node_ops_cmd have the following procedure:

1) Send node_ops_cmd::replace_prepare to all nodes
2) Send node_ops_cmd::replace_heartbeat to all nodes

In a large cluster 1) might take a long time to finish, as a result when
the node starts to perform 2), the heartbeat timer on the peer nodes which
is 30s might have already timed out. This fails the whole node
opeartions.

We have patches to make 1) more efficient and faster.

https://github.com/scylladb/scylla/pull/10850
https://github.com/scylladb/scylla/pull/10822

In addition to that, this patch increases the heartbeat timeout to reduce
the false positive of timeout.

Refs #10337
Refs #11078