### PR TITLE
cql-pytest: fix a test to not fail on very slow machines

### DIFF
--- a/test/cql-pytest/cassandra_tests/validation/operations/select_test.py
+++ b/test/cql-pytest/cassandra_tests/validation/operations/select_test.py
@@ -677,7 +677,7 @@ def testFunctionsWithClusteringDesc(cql, test_keyspace):
 def testSelectWithAlias(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(id int PRIMARY KEY, name text)") as table:
         for id in range(5):
-            execute(cql, table, "INSERT INTO %s (id, name) VALUES (?, ?) USING TTL 100 AND TIMESTAMP 0", id, "name" + str(id))
+            execute(cql, table, "INSERT INTO %s (id, name) VALUES (?, ?) USING TTL 1000 AND TIMESTAMP 0", id, "name" + str(id))
 
         # test aliasing count( *)
         rs = execute(cql, table, "SELECT count(*) AS user_count FROM %s")
@@ -693,7 +693,7 @@ def testSelectWithAlias(cql, test_keyspace):
 
         # test aliasing ttl
         rs = execute(cql, table, "SELECT ttl(name) AS name_ttl FROM %s WHERE id = 0")
-        assert rs.one().name_ttl >= 70 and rs.one().name_ttl <= 100
+        assert rs.one().name_ttl >= 100 and rs.one().name_ttl <= 1000
 
         # test aliasing a regular function
         rs = execute(cql, table, "SELECT intAsBlob(id) AS id_blob FROM %s WHERE id = 0")


### PR DESCRIPTION
The cql-pytest cassandra_tests/validation/operations/select_test.py::
testSelectWithAlias uses a TTL but not because it wants to test the TTL
feature - it just wants to check the SELECT aliasing feature. The test
writes a TTL of 100 and then reads it back using an alias. We would
normally expect to read back 100 or 99, but to guard against a very slow
test machine, the test verified that we read back something between 70
and 100. I thought that allowing a ridiculous 30 second delay between
the write and the read requests was more than enough.

But in one run of the aarch64 debug build, this ridiculous 30 seconds
wasn't ridiculous enough - the delay ended up 35 seconds, and the
test failed!

So in this patch, I just make it even more ridiculous - we write 1000
and expect to read something over 100 - allowing a 900 second delay
in the test.

Note that neither the earlier 30-second or current 900-second delay
slows down the test in any way - this test will normally complete in
milliseconds.

Signed-off-by: Nadav Har'El <nyh@scylladb.com>