### PR TITLE
doc: update the links that are false external links and result in 404

### DIFF
--- a/docs/using-scylla/features.rst
+++ b/docs/using-scylla/features.rst
@@ -1,5 +1,5 @@
-Scylla Features
-===============
+ScyllaDB Features
+==================
 
 
 .. toctree::
@@ -14,5 +14,5 @@ Scylla Features
   :id: "getting-started"
   :class: my-panel
 
-  * `Scylla Open Source Features <../features-open-source/>`_
-  * `Scylla Enterprise Features <../features-ent/>`_
+  * :doc:`ScyllaDB Open Source Features </using-scylla/features-open-source/>`
+  * :doc:`ScyllaDB Enterprise Features </using-scylla/features-ent/>`


### PR DESCRIPTION
This PR fixes two links that were incorrectly configured (they followed the syntax of external links, while they were internal links). As a result, they didn't work - they returned 404.

Using this opportunity, I replaced "Scylla" with "ScyllaDB".