### PR TITLE
doc: fix the links to Alternator

### DIFF
--- a/docs/using-scylla/alternator/index.rst
+++ b/docs/using-scylla/alternator/index.rst
@@ -4,7 +4,7 @@ Scylla Alternator
 
 .. include:: /using-scylla/_common/alternator-description.rst
 
-* `Scylla Alternator Documentation <https://scylladb.github.io/scylla/stable/alternator/alternator.html>`_
+* :doc:`Scylla Alternator Documentation </alternator/alternator/>`
 * `Scylla Alternator project <https://github.com/scylladb/scylla/tree/master/alternator>`_ - Part of the Scylla project
 * `Scylla Alternator course <https://university.scylladb.com/courses/scylla-alternator/>`_ on Scylla University
 

--- a/docs/using-scylla/features-open-source.rst
+++ b/docs/using-scylla/features-open-source.rst
@@ -37,7 +37,7 @@ Scylla Open Source Features
     by removing a tombstone only after the range that covers the tombstone is repaired. This feature is 
     experimental in version 5.0 and needs to be explicitly enabled by configuring the ``tombstone_gc`` option.
 
-  * `Expiration service in Scylla Alternator <https://scylla.docs.scylladb.com/stable/alternator/compatibility.html>`_ - Support 
+  * :doc:`Expiration service in Scylla Alternator </alternator/alternator/>` - Support 
     for DynamoDB's TTL feature for detecting and deleting expired items in the table. This feature is experimental in version 5.0 
 
   See the `Release Notes <https://www.scylladb.com/product/release-notes/>`_ for more information. 

--- a/docs/using-scylla/features-open-source.rst
+++ b/docs/using-scylla/features-open-source.rst
@@ -37,7 +37,7 @@ Scylla Open Source Features
     by removing a tombstone only after the range that covers the tombstone is repaired. This feature is 
     experimental in version 5.0 and needs to be explicitly enabled by configuring the ``tombstone_gc`` option.
 
-  * :doc:`Expiration service in Scylla Alternator </alternator/alternator/>` - Support 
+  * :doc:`Expiration service in Scylla Alternator </alternator/compatibility>` - Support 
     for DynamoDB's TTL feature for detecting and deleting expired items in the table. This feature is experimental in version 5.0 
 
   See the `Release Notes <https://www.scylladb.com/product/release-notes/>`_ for more information. 


### PR DESCRIPTION
The Scylla Alternator documentation is now part of the Scylla user documentation (previously it was dev documentation).
This PR updates the links to the Alternator documentation.