### PR TITLE
doc: Fix broken links

### DIFF
--- a/docs/architecture/console-CL-full-demo.rst
+++ b/docs/architecture/console-CL-full-demo.rst
@@ -2,7 +2,7 @@ Consistency Level Console Demo
 ==============================
 In this demo, we'll bring up 3 nodes and demonstrate how writes and reads look, with tracing enabled in a cluster where our :term:`Replication Factor (RF)<Replication Factor (RF)>` is set to **3**.  We'll change the :term:`Consistency Level (CL)<Consistency Level (CL)>` between operations to show how messages are passed between nodes, and finally take down a few nodes to show failure conditions in a Scylla cluster.
 
-You can also learn more in the `High Availability lesson <https://university.scylladb.com/courses/scylla-essentials-overview/lessons/high-availability//>`_ on Scylla University.
+You can also learn more in the `High Availability lesson <https://university.scylladb.com/courses/scylla-essentials-overview/lessons/high-availability/>`_ on Scylla University.
 
 
 Note:  We use asciinema_ to generate the console casts used in this demo.  These asciicasts are more readable than embedded video, and allow you to copy the text or commands directly from the console to your clipboard.   We suggest viewing console casts in **fullscreen** to see the properly formatted output. 

--- a/docs/architecture/sstable/sstable3/sstables-3-data-file-format.rst
+++ b/docs/architecture/sstable/sstable3/sstables-3-data-file-format.rst
@@ -30,7 +30,7 @@ This document focuses on the data file format but also refers to other component
 
 Note that the file on-disk format applies both to the "mc" and "md" SSTable format versions.
 The "md" format only fixed the semantics of the (min|max)_clustering_key fields in the SSTable Statistics file, which are now valid for describing the accurate range of clustering prefixes present in the SSTable.
-See `SSTables 3.0 Statistics File Format <architecture/sstable/sstable3/sstables-3-statistics/>`_ for more details.
+See :doc:`SSTables 3.0 Statistics File Format </architecture/sstable/sstable3/sstables-3-statistics>` for more details.
 
 Overview
 ........

--- a/docs/contribute.rst
+++ b/docs/contribute.rst
@@ -22,7 +22,7 @@ The basic steps are:
 * Send a PR or use ``git format-patch`` and ``git send-email`` to send to the list
 
 
-The entire process is `documented here <https://scylla.docs.scylladb.com/master/contribute/index>`_.
+The entire process is `documented here <https://github.com/scylladb/scylla/blob/master/CONTRIBUTING.md>`_.
 
 Contribute to Scylla Docs
 -------------------------

--- a/docs/getting-started/install-scylla/index.rst
+++ b/docs/getting-started/install-scylla/index.rst
@@ -29,7 +29,7 @@ Install Scylla
   * :doc:`Create a Scylla Cluster - Multi Data Center (DC) </operating-scylla/procedures/cluster-management/create-cluster-multidc/>`
   * :doc:`Scylla Developer Mode </getting-started/install-scylla/dev-mod>`
   * :doc:`Scylla Configuration Command Reference </getting-started/install-scylla/config-commands>`
-  * `Scylla Housekeeping and how to disable it <disable-housekeeping>`_
+  * :doc:`Scylla Housekeeping and how to disable it <disable-housekeeping>`
 
 
   

--- a/docs/getting-started/scylla-in-a-shared-environment.rst
+++ b/docs/getting-started/scylla-in-a-shared-environment.rst
@@ -69,10 +69,7 @@ Other Restrictions
 ------------------
 
 When starting up, Scylla will check the hardware and operating system
-configuration to verify that it is compatible with Scylla's performance requirements. See `developer mode`_ for more instructions.
-
-..  _`developer mode`: /getting-started/install-scylla/dev_mod/
-
+configuration to verify that it is compatible with Scylla's performance requirements. See :doc:`developer mode </getting-started/install-scylla/dev-mod>` for more instructions.
 
 Summary
 -------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -89,7 +89,7 @@
 
 .. topic-box::
   :title: Scylla Alternator
-  :link: https://scylla.docs.scylladb.com/stable/alternator/alternator.html
+  :link: https://docs.scylladb.com/stable/alternator/alternator.html
   :image: /_static/img/mascots/scylla-alternator.svg
   :class: topic-box--product,large-3,small-6
 
@@ -113,7 +113,7 @@
 
 .. topic-box::
   :title: Scylla Drivers
-  :link: https://docs.scylladb.com/using-scylla/drivers/
+  :link: https://docs.scylladb.com/stable/using-scylla/drivers/
   :image: /_static/img/mascots/scylla-drivers.svg
   :class: topic-box--product,large-3,small-6
 

--- a/docs/kb/dpdk-hardware.rst
+++ b/docs/kb/dpdk-hardware.rst
@@ -33,5 +33,4 @@ Reference
 ---------
 `DPDK: Supported NICs <http://dpdk.org/doc/nics>`_
 
-`Knowledge Base 
-</kb/>`_
+:doc:`Knowledge Base </kb/index>`

--- a/docs/kb/gossip.rst
+++ b/docs/kb/gossip.rst
@@ -59,7 +59,7 @@ References
 
 `Gossip protocol on Wikipedia <https://en.wikipedia.org/wiki/Gossip_protocol>`_
 
-`Knowledge Base 
-</kb/>`_
+:doc:`Knowledge Base </kb/index>`
+
 
 .. include:: /rst_include/apache-copyrights.rst

--- a/docs/kb/memory-usage.rst
+++ b/docs/kb/memory-usage.rst
@@ -26,5 +26,5 @@ For example:
    SCYLLA_ARGS="--log-to-syslog 1 --log-to-stdout 0 --default-log-level info --collectd-address=127.0.0.1:25826 --collectd=1 --collectd-poll-period 3000 --network-stack posix --memory 2G --reserve-memory 2G
 
 
-`Knowledge Base 
-</kb/>`_
+:doc:`Knowledge Base </kb/index>`
+

--- a/docs/kb/ntp.rst
+++ b/docs/kb/ntp.rst
@@ -142,7 +142,7 @@ servers are working, have a look at the `instructions for joining the
 NTP pool <http://www.pool.ntp.org/join.html>`__ yourself, so that you
 can help share the correct time with others
 
-`Knowledge Base 
-</kb/>`_
+:doc:`Knowledge Base </kb/index>`
+
 
 .. include:: /rst_include/apache-copyrights.rst

--- a/docs/kb/posix.rst
+++ b/docs/kb/posix.rst
@@ -51,5 +51,5 @@ access <http://docs.datastax.com/en//cassandra/2.0/cassandra/security/secureFire
 `How to use, monitor, and disable transparent hugepages in Red Hat
 Enterprise Linux 6 <https://access.redhat.com/solutions/46111>`__
 
-`Knowledge Base 
-</kb/>`_
+:doc:`Knowledge Base </kb/index>`
+

--- a/docs/kb/quiz-administrators.rst
+++ b/docs/kb/quiz-administrators.rst
@@ -30,5 +30,5 @@ A: The acknowledgment will be sent to the user when two **local** replicas respo
 In this case, floor(local_RF/2 +1) = 2 , so LOCAL\_QUORUM is equal to RF per DC, which is why RF of 3 is usually better.
 
 
-`Knowledge Base 
-</kb/>`_
+:doc:`Knowledge Base </kb/index>`
+

--- a/docs/kb/scylla-and-spark-integration.rst
+++ b/docs/kb/scylla-and-spark-integration.rst
@@ -353,7 +353,8 @@ Scylla limitations
 
 For more compatibility information check `Scylla status <http://www.scylladb.com/technology/status/>`_
 
-`Knowledge Base 
-</kb/>`_
+:doc:`Knowledge Base </kb/index>`
+
+
 
 .. include:: /rst_include/apache-copyrights.rst

--- a/docs/operating-scylla/_common/networking-ports.rst
+++ b/docs/operating-scylla/_common/networking-ports.rst
@@ -27,4 +27,4 @@ Port    Description                                   Protocol
 19142   Native shard-aware transport port  (ssl)         TCP
 ======  ============================================  ========
 
-.. note:: For Scylla Manager ports, see `Scylla Manager <https://scylladb.github.io/scylla-manager/>`_.
+.. note:: For Scylla Manager ports, see `Scylla Manager <https://manager.docs.scylladb.com/>`.

--- a/docs/operating-scylla/admin-tools/sstable-index.rst
+++ b/docs/operating-scylla/admin-tools/sstable-index.rst
@@ -18,7 +18,7 @@ Where:
 * The ``--type`` or ``-t`` flag is used to specify the types making up the partition key of the table to which the index file belongs.
   This is needed so the tool can parse the SSTable keys found in the index. You will need to pass ``--type|-t`` for each type in the partition key.
   For the type names, the Cassandra type class notation has to be used. You can use the short form, i.e. without the org.apache.cassandra.db.marshal. prefix.
-  For a complete mapping of CQL types to their respective Cassandra type class notation, see `CQL3 Type Mapping <https://scylla.docs.scylladb.com/master/design-notes/cql3-type-mapping.html#cql3-type-mapping>`_.
+  For a complete mapping of CQL types to their respective Cassandra type class notation, see `CQL3 Type Mapping <https://github.com/scylladb/scylla/blob/master/docs/dev/cql3-type-mapping.md>`_.
 
 * The SSTable index file path can be passed both as a positional argument ``[path/to/scylla/datadir]``  or with the  ``--sstable`` flag.
 

--- a/docs/operating-scylla/admin.rst
+++ b/docs/operating-scylla/admin.rst
@@ -104,7 +104,7 @@ Compression between the client and the node is set by the driver that the applic
 
 For example:
 
-* `Scylla Python Driver <https://scylladb.github.io/python-driver/master/api/cassandra/cluster.html#cassandra.cluster.Cluster.compression>`_
+* `Scylla Python Driver <https://python-driver.docs.scylladb.com/master/api/cassandra/cluster.html#cassandra.cluster.Cluster.compression>`_
 * `Scylla Java Driver <https://github.com/scylladb/java-driver/tree/3.7.1-scylla/manual/compression>`_
 * `Go Driver <https://godoc.org/github.com/gocql/gocql#Compressor>`_
 
@@ -137,7 +137,7 @@ Networking
 
 .. image:: /operating-scylla/security/Scylla-Ports2.png
 
-The Scylla ports are detailed in the table below. For Scylla Manager ports, see the `Scylla Manager Documentation <https://scylladb.github.io/scylla-manager>`_.
+The Scylla ports are detailed in the table below. For Scylla Manager ports, see the `Scylla Manager Documentation <https://manager.docs.scylladb.com/>`_.
 
 .. include:: /operating-scylla/_common/networking-ports.rst
 

--- a/docs/operating-scylla/manager/2.1/add-a-cluster.rst
+++ b/docs/operating-scylla/manager/2.1/add-a-cluster.rst
@@ -96,9 +96,9 @@ Create a Managed Cluster
 
    You will see 3 tasks which are created by adding the cluster:
 
-   * Healthcheck - which checks the Scylla CQL, starting immediately, repeating every 15 seconds. See `Scylla Health Check <../health-check>`_
-   * Healthcheck REST - which checks the Scylla REST API, starting immediately, repeating every hour. See `Scylla Health Check <../health-check>`_
-   * Repair - an automated repair task, starting at midnight tonight, repeating every seven days at midnight. See `Run a Repair <../repair/>`_
+   * Healthcheck - which checks the Scylla CQL, starting immediately, repeating every 15 seconds. See :doc:`Scylla Health Check <health-check>`
+   * Healthcheck REST - which checks the Scylla REST API, starting immediately, repeating every hour. See :doc:`Scylla Health Check <health-check>`
+   * Repair - an automated repair task, starting at midnight tonight, repeating every seven days at midnight. See :doc:`Run a Repair <repair>`
 
    .. note:: If you want to change the schedule for the repair, see :ref:`Reschedule a repair <manager-2.1-reschedule-a-repair>`.
 
@@ -127,7 +127,7 @@ Although Scylla Manager is aware of all topology changes made within every clust
 
 **Procedure**
 
-#. `Add Scylla Manager Agent <../install-agent>`_ to the new node. Use the **same** authentication token as you did for the other nodes in this cluster. Do not generate a new token. 
+#. :doc:`Add Scylla Manager Agent <install-agent>` to the new node. Use the **same** authentication token as you did for the other nodes in this cluster. Do not generate a new token. 
 
 #. Confirm the node / datacenter was added by checking its :ref:`status <sctool_status>`. From the node running the Scylla Manager server, run the ``sctool status`` command, using the name of the managed cluster.
  
@@ -156,7 +156,7 @@ There is no need to perform any action in Scylla Manager after removing a node o
 See Also
 ========
 
-* `sctool Reference <../sctool>`_
+* :doc:`sctool Reference <sctool>`
 * :doc:`Remove a node from a Scylla Cluster </operating-scylla/procedures/cluster-management/remove-node>` 
 * :doc:`Scylla Monitoring </operating-scylla/monitoring/index>`
 

--- a/docs/operating-scylla/manager/2.1/agent-configuration-file.rst
+++ b/docs/operating-scylla/manager/2.1/agent-configuration-file.rst
@@ -202,4 +202,4 @@ Advanced settings
 Additional resources
 ====================
 
-Scylla Manager `Configuration file <../configuration-file>`_
+Scylla Manager :doc:`Configuration file <configuration-file>`

--- a/docs/operating-scylla/manager/2.1/architecture.rst
+++ b/docs/operating-scylla/manager/2.1/architecture.rst
@@ -18,7 +18,7 @@ Scylla Manager consists of three components:
 * Agent - a small executable, installed on each Scylla node. The Server communicates with the Agent over REST HTTPS. The Agent communicates with the local Scylla node over the REST HTTP.
 
 The Server persists its data to a Scylla cluster that can run locally or run on an external cluster
-(see `Use a remote database for Scylla Manager <../use-a-remote-db>`_ for details).
+(see :doc:`Use a remote database for Scylla Manager <use-a-remote-db>` for details).
 
 Optionally (but recommended), you can add Scylla Monitoring Stack to enable reporting of Scylla Manager metrics and alerts. 
 
@@ -28,7 +28,7 @@ The diagram below presents a logical view of Scylla Manager with a remote backen
 Each node has two connections with the Scylla Manager Server:
 
 * REST API connection - used for Scylla Manager and Scylla Manager Agent activities
-* CQL connection - used for the Scylla `Health Check <../health-check>`_
+* CQL connection - used for the Scylla :doc:`Health Check <health-check>`
 
 Scylla Manager uses the following ports:
 
@@ -52,6 +52,6 @@ Port    Description                                   Protocol
 Additional Resources
 ====================
 
-* `Install Scylla Manager <../install>`_
-* `Install Scylla Manager Agent <../install-agent>`_
-* `sctool Reference <../sctool>`_
+* :doc:`Install Scylla Manager <install>`
+* :doc:`Install Scylla Manager Agent <install-agent>`
+* :doc:`sctool Reference <sctool>`

--- a/docs/operating-scylla/manager/2.1/configuration-file.rst
+++ b/docs/operating-scylla/manager/2.1/configuration-file.rst
@@ -70,7 +70,7 @@ Logging settings specify log output and level.
 Database settings
 =================
 
-Database settings allow for `using a remote cluster <../use-a-remote-db>`_ to store Scylla Manager data.
+Database settings allow for :doc:`using a remote cluster <use-a-remote-db>` to store Scylla Manager data.
 
 .. code-block:: yaml
 
@@ -138,6 +138,8 @@ Backup settings let you specify backup parameters.
    # the same snapshot. If exceeded, a new run with a new snapshot will be created.
    # Zero means no limit.
    #  age_max: 12h
+
+.. _repair-settings:
 
 Repair settings
 ===============

--- a/docs/operating-scylla/manager/2.1/extract-schema-from-backup.rst
+++ b/docs/operating-scylla/manager/2.1/extract-schema-from-backup.rst
@@ -8,7 +8,7 @@ Extract schema from the backup
 
 The first step to restoring a Scylla Manager backup is to restore the CQL schema from a text file.
 Scylla Manager version 2.1 creates a backup up of matching schema along with the snapshot.
-If you created the backup with Scylla Manager version 2.0 or you didn't provide credentials for a schema backup in Scylla Manager version 2.1, follow the instructions in `how to restore your schema from system table <../../2.0/extract-schema-from-system-table/>`_.
+If you created the backup with Scylla Manager version 2.0 or you didn't provide credentials for a schema backup in Scylla Manager version 2.1, follow the instructions in how to restore your schema from system table(deleted document).
 
 If not, follow these steps to restore the schema from the Scylla Manager backup that has the schema stored along with the snapshot:
 

--- a/docs/operating-scylla/manager/2.1/install-agent.rst
+++ b/docs/operating-scylla/manager/2.1/install-agent.rst
@@ -178,4 +178,4 @@ Adding the cluster to Scylla Manager automatically creates a backup task. Valida
 Register a cluster
 ------------------
 
-Continue with `Add a Cluster <../add-a-cluster>`_.
+Continue with :doc:`Add a Cluster <add-a-cluster>`.

--- a/docs/operating-scylla/manager/2.1/install.rst
+++ b/docs/operating-scylla/manager/2.1/install.rst
@@ -55,7 +55,7 @@ It can be run in non-interactive mode if you'd like to script it.
 There are three decisions you need to make:
 
 * Do you want to enable the service to start automatically? If not, you will have to start the service manually each time you want to use it.
-* Do you want to set up and enable a local Scylla backend? If not, you will need to set up a `remote DB <../use-a-remote-db>`_
+* Do you want to set up and enable a local Scylla backend? If not, you will need to set up a :doc:`remote DB <use-a-remote-db>`
 * Do you want Scylla Manager to check periodically if updates are available? If not, you will need to check yourself.
 
 .. code-block:: none
@@ -129,4 +129,4 @@ Scylla Manager integrates with ``systemd`` and can be started and stopped using 
 Install Scylla Manager Agent
 ============================
 
-Continue with `Setup Scylla Manager Agent <../install-agent>`_
+Continue with :doc:`Setup Scylla Manager Agent <install-agent>`

--- a/docs/operating-scylla/manager/2.1/repair.rst
+++ b/docs/operating-scylla/manager/2.1/repair.rst
@@ -116,7 +116,7 @@ When scheduling repair, you may specify ``--intensity`` flag, the intensity mean
 * For values > 1 intensity specifies the number of segments repaired by Scylla in a single repair command. Higher values result in higher speed and may increase cluster load.
 * For values < 1 intensity specifies what percent of node's shards repaired in parallel.
 * For intensity equal to 1 it will repair one segment in each repair command on all shards in parallel.
-* For zero intensity it uses limits specified in Scylla Manager `configuration <../configuration-file#repair-settings>`_.
+* For zero intensity it uses limits specified in Scylla Manager :ref:`configuration <repair-settings>`.
 
   Please note that this only works with versions that are **not** :doc:`row-level-repair enabled </upgrade/upgrade-manager/upgrade-guide-from-2.x.a-to-2.y.b/upgrade-row-level-repair>`.
 

--- a/docs/operating-scylla/manager/2.1/restore-a-backup.rst
+++ b/docs/operating-scylla/manager/2.1/restore-a-backup.rst
@@ -40,7 +40,7 @@ If you need help, you can check official documentation on :doc:`operational proc
 Install Scylla Manager
 ----------------------
 
-You need a working Scylla Manager setup to list backups. If you don't have it installed, please follow official instructions on `how to install Scylla Manager <../install/>`_ first.
+You need a working Scylla Manager setup to list backups. If you don't have it installed, please follow official instructions on :doc:`how to install Scylla Manager <install>` first.
 
 Nodes must have access to the locations of the backups as per instructions in the official documentation for :ref:`installing Scylla Manager Agent <manager-2.1-prepare-nodes-for-backup>`.
 
@@ -111,7 +111,7 @@ Restore the schema
 ------------------
 
 Scylla Manager 2.1 can store schema with your backup.
-To extract schema files for each keyspace from the backup, please refer to the official documentation for `extracting schema from the backup <../../2.1/extract-schema-from-backup>`_. For convenience, here is the continuation of our example with the list of steps for restoring schema:
+To extract schema files for each keyspace from the backup, please refer to the official documentation for :doc:`extracting schema from the backup <extract-schema-from-backup>`. For convenience, here is the continuation of our example with the list of steps for restoring schema:
 
 #. Download schema from the backup store to the current dir. It's in the first line of the ``backup_files.out`` output:
 

--- a/docs/operating-scylla/manager/2.1/sctool.rst
+++ b/docs/operating-scylla/manager/2.1/sctool.rst
@@ -225,7 +225,7 @@ Example: backup
 This example backs up the entire cluster named prod-cluster.
 The backup begins on December 9, 2019 at 16:05 and will repeat at this time every 24 hours.
 The backup is stored in s3 in a directory named ``my-backups``.
-Additional examples are available in `Backup Scylla Clusters <../backup/>`_
+Additional examples are available in :doc:`Backup Scylla Clusters <backup>`
 
 .. code-block:: none
 
@@ -433,7 +433,7 @@ From this information we know the following:
 * Delimiter - whitespace character (ie '  ')
 * Keyspace / table name - system_sec/table
 
-See `Restore <restore>`_ on information how to use these files to restore a backup.
+See :doc:`Restore </operating-scylla/procedures/backup-restore/restore>` on information how to use these files to restore a backup.
 
 backup delete
 =============
@@ -516,7 +516,7 @@ This command adds the specified cluster to the manager.
 Once a Scylla cluster is added, a weekly repair task is also added.
 
 Before continuing, make sure the cluster that you want to add is prepared for it,
-see `Add a cluster to Scylla Manager <../add-a-cluster>`_ for instructions.
+see :doc:`Add a cluster to Scylla Manager <add-a-cluster>` for instructions.
 
 **Syntax:**
 
@@ -539,7 +539,7 @@ Example: cluster add
 ....................
 
 This example is only the command that you use to add the cluster to Scylla Manager, not the entire procedure for adding a cluster.
-The procedure is detailed in `Add a cluster to Scylla Manager <../add-a-cluster>`_.
+The procedure is detailed in :doc:`Add a cluster to Scylla Manager <add-a-cluster>`.
 
 .. code-block:: none
 

--- a/docs/operating-scylla/monitoring/2.4/monitor-without-docker.2.1.rst
+++ b/docs/operating-scylla/monitoring/2.4/monitor-without-docker.2.1.rst
@@ -1,7 +1,7 @@
 Deploying Scylla Monitoring Without Docker
 ==========================================
 
-The following instructions will help to deploy `Scylla Monitoring Stack <../monitoring-stack>`_ in the case you can not use the docker version.
+The following instructions will help to deploy :doc:`Scylla Monitoring Stack <monitoring-stack>` in the case you can not use the docker version.
 
 Please note, Scylla recommends you use the docker version as it will provide you with most updated, current scylla monitoring system.
 

--- a/docs/operating-scylla/monitoring/3.0/monitor-without-docker.rst
+++ b/docs/operating-scylla/monitoring/3.0/monitor-without-docker.rst
@@ -1,7 +1,7 @@
 Deploying Scylla Monitoring Without Docker
 ==========================================
 
-The following instructions will help to deploy `Scylla Monitoring Stack <../monitoring-stack>`_ in cases where you can not use the recommended Docker version.
+The following instructions will help to deploy :doc:`Scylla Monitoring Stack <monitoring-stack>` in cases where you can not use the recommended Docker version.
 
 Please note, Scylla recommends you use the Docker version as it will provide you with the most updated, current Scylla Monitoring system.
 

--- a/docs/operating-scylla/monitoring/3.0/monitoring-stack.rst
+++ b/docs/operating-scylla/monitoring/3.0/monitoring-stack.rst
@@ -14,7 +14,7 @@ For evaluation systems, you can run the Scylla Monitoring stack on any server (o
 Prerequisites
 -------------
 
-* Follow the Installation Guide and install `docker`_ on the Scylla Monitoring Server. This server can be the same server that is running a Scylla Manager. Alternatively, you can `Deploy Scylla Monitoring Without Docker <monitor-without-docker>`_ . 
+* Follow the Installation Guide and install `docker`_ on the Scylla Monitoring Server. This server can be the same server that is running a Scylla Manager. Alternatively, you can :doc:`Deploy Scylla Monitoring Without Docker <monitor-without-docker>`. 
 
 .. _`docker`: https://docs.docker.com/install/
 

--- a/docs/operating-scylla/monitoring/3.1/monitor-without-docker.rst
+++ b/docs/operating-scylla/monitoring/3.1/monitor-without-docker.rst
@@ -1,7 +1,7 @@
 Deploying Scylla Monitoring Without Docker
 ==========================================
 
-The following instructions will help to deploy `Scylla Monitoring Stack <../monitoring-stack>`_ in cases where you can not use the recommended Docker version.
+The following instructions will help to deploy :doc:`Scylla Monitoring Stack <monitoring-stack>` in cases where you can not use the recommended Docker version.
 
 Please note, Scylla recommends you use the Docker version as it will provide you with the most updated, current Scylla Monitoring system.
 

--- a/docs/operating-scylla/monitoring/3.1/monitoring-apis.rst
+++ b/docs/operating-scylla/monitoring/3.1/monitoring-apis.rst
@@ -8,7 +8,7 @@ Prometheus
 ----------
 By default, Scylla listens on port 9180 for `Prometheus <https://prometheus.io/>`_ requests. To connect a Prometheus server to Scylla in your prometheus.yaml configuration file, add Scylla as a target with :code:`your-ip:9180`
 
-For more information on monitoring Scylla with Prometheus see `Scylla Monitoring Stack <../monitoring-stack>`_
+For more information on monitoring Scylla with Prometheus see :doc:`Scylla Monitoring Stack <monitoring-stack>`
 
 You can change the Prometheus listening address and port in scylla.yaml file
 

--- a/docs/operating-scylla/monitoring/3.1/monitoring-stack.rst
+++ b/docs/operating-scylla/monitoring/3.1/monitoring-stack.rst
@@ -14,7 +14,7 @@ For evaluation, you can run the Scylla Monitoring stack on any server (or laptop
 Prerequisites
 -------------
 
-* Follow the Installation Guide and install `docker`_ on the Scylla Monitoring Server. This server can be the same server that is running a Scylla Manager. Alternatively, you can `Deploy Scylla Monitoring Without Docker <../monitor-without-docker>`_ .
+* Follow the Installation Guide and install `docker`_ on the Scylla Monitoring Server. This server can be the same server that is running a Scylla Manager. Alternatively, you can :doc:`Deploy Scylla Monitoring Without Docker <monitor-without-docker>`.
 
 .. _`docker`: https://docs.docker.com/install/
 

--- a/docs/operating-scylla/monitoring/3.2/monitor-without-docker.rst
+++ b/docs/operating-scylla/monitoring/3.2/monitor-without-docker.rst
@@ -1,7 +1,7 @@
 Deploying Scylla Monitoring Without Docker
 ==========================================
 
-The following instructions will help to deploy `Scylla Monitoring Stack <../monitoring-stack>`_ in cases where you can not use the recommended Docker version.
+The following instructions will help to deploy :doc:`Scylla Monitoring Stack <monitoring-stack>` in cases where you can not use the recommended Docker version.
 
 Please note, Scylla recommends you use the Docker version as it will provide you with the most updated, current Scylla Monitoring system.
 

--- a/docs/operating-scylla/monitoring/3.2/monitoring-apis.rst
+++ b/docs/operating-scylla/monitoring/3.2/monitoring-apis.rst
@@ -8,7 +8,7 @@ Prometheus
 ----------
 By default, Scylla listens on port 9180 for `Prometheus <https://prometheus.io/>`_ requests. To connect a Prometheus server to Scylla in your prometheus.yaml configuration file, add Scylla as a target with :code:`your-ip:9180`
 
-For more information on monitoring Scylla with Prometheus see `Scylla Monitoring Stack <../monitoring-stack>`_
+For more information on monitoring Scylla with Prometheus see :doc:`Scylla Monitoring Stack <monitoring-stack>`
 
 You can change the Prometheus listening address and port in scylla.yaml file
 

--- a/docs/operating-scylla/monitoring/3.2/monitoring-stack.rst
+++ b/docs/operating-scylla/monitoring/3.2/monitoring-stack.rst
@@ -14,7 +14,7 @@ For evaluation, you can run the Scylla Monitoring stack on any server (or laptop
 Prerequisites
 -------------
 
-* Follow the Installation Guide and install `docker`_ on the Scylla Monitoring Server. This server can be the same server that is running a Scylla Manager. Alternatively, you can `Deploy Scylla Monitoring Without Docker <../monitor-without-docker>`_ .
+* Follow the Installation Guide and install `docker`_ on the Scylla Monitoring Server. This server can be the same server that is running a Scylla Manager. Alternatively, you can :doc:`Deploy Scylla Monitoring Without Docker <monitor-without-docker>`.
 
 .. _`docker`: https://docs.docker.com/install/
 

--- a/docs/operating-scylla/monitoring/3.3/monitor-without-docker.rst
+++ b/docs/operating-scylla/monitoring/3.3/monitor-without-docker.rst
@@ -1,7 +1,7 @@
 Deploying Scylla Monitoring Without Docker
 ==========================================
 
-The following instructions will help to deploy `Scylla Monitoring Stack <../monitoring-stack>`_ in cases where you can not use the recommended Docker version.
+The following instructions will help to deploy :doc:`Scylla Monitoring Stack <monitoring-stack>` in cases where you can not use the recommended Docker version.
 
 Please note, Scylla recommends you use the Docker version as it will provide you with the most updated, current Scylla Monitoring system.
 

--- a/docs/operating-scylla/monitoring/3.3/monitoring-apis.rst
+++ b/docs/operating-scylla/monitoring/3.3/monitoring-apis.rst
@@ -8,7 +8,7 @@ Prometheus
 ----------
 By default, Scylla listens on port 9180 for `Prometheus <https://prometheus.io/>`_ requests. To connect a Prometheus server to Scylla in your prometheus.yaml configuration file, add Scylla as a target with :code:`your-ip:9180`
 
-For more information on monitoring Scylla with Prometheus see `Scylla Monitoring Stack <../monitoring-stack>`_
+For more information on monitoring Scylla with Prometheus see :doc:`Scylla Monitoring Stack <monitoring-stack>`.
 
 You can change the Prometheus listening address and port in scylla.yaml file
 

--- a/docs/operating-scylla/monitoring/3.3/monitoring-stack.rst
+++ b/docs/operating-scylla/monitoring/3.3/monitoring-stack.rst
@@ -14,7 +14,7 @@ For evaluation, you can run the Scylla Monitoring stack on any server (or laptop
 Prerequisites
 -------------
 
-* Follow the Installation Guide and install `docker`_ on the Scylla Monitoring Server. This server can be the same server that is running the Scylla Manager. Alternatively, you can `Deploy Scylla Monitoring Without Docker <../monitor-without-docker>`_ .
+* Follow the Installation Guide and install `docker`_ on the Scylla Monitoring Server. This server can be the same server that is running the Scylla Manager. Alternatively, you can :doc:`Deploy Scylla Monitoring Without Docker <monitor-without-docker>`.
 
 .. _`docker`: https://docs.docker.com/install/
 

--- a/docs/operating-scylla/monitoring/3.4/monitor-without-docker.rst
+++ b/docs/operating-scylla/monitoring/3.4/monitor-without-docker.rst
@@ -3,7 +3,7 @@ Deploying Scylla Monitoring Stack Without Docker
 
 .. include:: /operating-scylla/monitoring/_common/note-versions.rst
 
-The following instructions will help to deploy `Scylla Monitoring Stack <../monitoring-stack>`_ in cases where you can not use the recommended Docker version.
+The following instructions will help to deploy :doc:`Scylla Monitoring Stack <monitoring-stack>` in cases where you can not use the recommended Docker version.
 
 Please note, Scylla recommends you use the Docker version as it will provide you with the most updated, current Scylla Monitoring system.
 

--- a/docs/operating-scylla/monitoring/3.4/monitoring-apis.rst
+++ b/docs/operating-scylla/monitoring/3.4/monitoring-apis.rst
@@ -9,7 +9,7 @@ Prometheus
 ----------
 By default, Scylla listens on port 9180 for `Prometheus <https://prometheus.io/>`_ requests. To connect a Prometheus server to Scylla in your prometheus.yaml configuration file, add Scylla as a target with :code:`your-ip:9180`
 
-For more information on monitoring Scylla with Prometheus see `Scylla Monitoring Stack <../monitoring-stack>`_
+For more information on monitoring Scylla with Prometheus see :doc:`Scylla Monitoring Stack <monitoring-stack>`
 
 You can change the Prometheus listening address and port in scylla.yaml file
 

--- a/docs/operating-scylla/monitoring/3.4/monitoring-stack.rst
+++ b/docs/operating-scylla/monitoring/3.4/monitoring-stack.rst
@@ -16,7 +16,7 @@ For evaluation, you can run the Scylla Monitoring Stack on any server (or laptop
 Prerequisites
 -------------
 
-* Follow the Installation Guide and install `docker`_ on the Scylla Monitoring Stack Server. This server can be the same server that is running a Scylla Manager. Alternatively, you can `Deploy Scylla Monitoring Without Docker <../monitor-without-docker>`_ .
+* Follow the Installation Guide and install `docker`_ on the Scylla Monitoring Stack Server. This server can be the same server that is running a Scylla Manager. Alternatively, you can :doc:`Deploy Scylla Monitoring Without Docker <monitor-without-docker>` .
 
 .. _`docker`: https://docs.docker.com/install/
 

--- a/docs/operating-scylla/monitoring/_common/monitor-index.rst
+++ b/docs/operating-scylla/monitoring/_common/monitor-index.rst
@@ -10,5 +10,5 @@
 
 **Additional Information**:
 
-* `Scylla Monitoring Stack Support Matrix <matrix>`_
+* :doc:`Scylla Monitoring Stack Support Matrix <matrix>`
 * :doc:`Upgrade Scylla Monitoring Stack </upgrade/upgrade-monitor>`

--- a/docs/operating-scylla/monitoring/index.rst
+++ b/docs/operating-scylla/monitoring/index.rst
@@ -5,7 +5,7 @@ Scylla Monitoring Stack
    :hidden:
    :maxdepth: 2 
 
-   Latest Version <https://scylladb.github.io/scylla-monitoring>
+   Latest Version <https://monitoring.docs.scylladb.com/>
    Upgrade Scylla Monitoring Stack </upgrade/upgrade-monitor/index/>
    Monitoring Support Matrix <https://monitoring.docs.scylladb.com/stable/reference/matrix.html>
 
@@ -13,7 +13,7 @@ Scylla Monitoring Stack
 
 .. note::
 
-   For the **latest** versions click `here <https://scylladb.github.io/scylla-monitoring>`_.
+   For the **latest** versions click `here <https://monitoring.docs.scylladb.com/>`_.
 
 Additional Information
 

--- a/docs/operating-scylla/procedures/cluster-management/index.rst
+++ b/docs/operating-scylla/procedures/cluster-management/index.rst
@@ -47,9 +47,9 @@ Cluster Management Procedures
 
   * :doc:`Upscale a Cluster </operating-scylla/procedures/cluster-management/scale-up-cluster/>`
 
-  * `Safely Shutdown Your Cluster <safe-shutdown>`_
+  * :doc:`Safely Shutdown Your Cluster <safe-shutdown>`
 
-  * `Safely Start or Restart Your Cluster <safe-start>`_
+  * :doc:`Safely Start or Restart Your Cluster <safe-start>`
 
 .. panel-box::
   :title: Node Management

--- a/docs/operating-scylla/procedures/cluster-management/remove-node.rst
+++ b/docs/operating-scylla/procedures/cluster-management/remove-node.rst
@@ -24,7 +24,7 @@ Removing a Running Node
    to remove the node you are connected to. Using ``nodetool decommission`` is the recommended method for cluster scale-down operations. It prevents data loss
    by ensuring that the node you're removing streams its data to the remaining nodes in the cluster.
 
-   If the node is **Joining**, see `Safely Remove a Joining Node <../safely-removing-joining-node>`_.
+   If the node is **Joining**, see :doc:`Safely Remove a Joining Node <safely-removing-joining-node>`.
 
    If the node status is **Down**, see `Removing an Unavailable Node`_.
 
@@ -78,7 +78,7 @@ the ``nodetool removenode`` operation will fail. To ensure successful operation 
 * Make sure the status of all other nodes in the cluster is Up Normal (UN). If one or more nodes are unavailable, see :doc:`nodetool removenode </operating-scylla/nodetool-commands/removenode>` for instructions.
 * Run a full cluster repair **before** ``nodetool removenode``, so all existing replicas have the most up-to-date data.
 * In the case of node failures during the ``removenode`` operation, re-run repair before running
-  ``nodetool removenode`` (not required when `Repair Based Node Operations (RBNO) <../repair-based-node-operation>`_ for ``removenode`` 
+  ``nodetool removenode`` (not required when :doc:`Repair Based Node Operations (RBNO) <repair-based-node-operation>` for ``removenode`` 
   is enabled).
 
 

--- a/docs/operating-scylla/procedures/cluster-management/safe-shutdown.rst
+++ b/docs/operating-scylla/procedures/cluster-management/safe-shutdown.rst
@@ -20,4 +20,4 @@ On each node, in parallel:
    
    .. include:: /rst_include/scylla-commands-stop-index.rst
 
-#. To start the nodes again safely, proceed to the `Start Clusters Cleanly <../safe-start>`_ procedure.
+#. To start the nodes again safely, proceed to the :doc:`Start Clusters Cleanly <safe-start>` procedure.

--- a/docs/operating-scylla/procedures/cluster-management/safe-start.rst
+++ b/docs/operating-scylla/procedures/cluster-management/safe-start.rst
@@ -6,7 +6,7 @@ In cases where you needed to shut down your cluster, use this procedure to bring
 
 **Before you begin**
 
-* Confirm that the cluster was shut down using the `shutdown procedure <../safe-shutdown>`_.
+* Confirm that the cluster was shut down using the :doc:`shutdown procedure <safe-shutdown>`.
 * (Only for versions prior to Scylla Open Source 4.3 and Scylla Enterprise 2021.1) Confirm that you know which nodes are the seed nodes. Seed nodes are specified in the ``scylla.yaml`` file.
 
 **Procedure**

--- a/docs/operating-scylla/procedures/tips/benchmark-tips.rst
+++ b/docs/operating-scylla/procedures/tips/benchmark-tips.rst
@@ -41,7 +41,7 @@ With the recent addition of the `Scylla Advisor <http://monitoring.docs.scylladb
 Install Scylla Manager
 ----------------------
 
-Install and use `Scylla Manager <https://scylladb.github.io/scylla-manager>`_ together with the `Scylla Monitoring Stack <http://monitoring.docs.scylladb.com/>`_.
+Install and use `Scylla Manager <https://manager.docs.scylladb.com>` together with the `Scylla Monitoring Stack <http://monitoring.docs.scylladb.com/>`_.
 Scylla Manager provides automated backups and repairs of your database.
 Scylla Manager can manage multiple Scylla clusters and run cluster-wide tasks in a controlled and predictable way.
 For example, with Scylla Manager you can control the intensity of a repair, increasing it to speed up the process, or lower the intensity to ensure it minimizes impact on ongoing operations.

--- a/docs/operating-scylla/procedures/tips/production-readiness.rst
+++ b/docs/operating-scylla/procedures/tips/production-readiness.rst
@@ -160,7 +160,7 @@ Repair
 ......
 
 Run repairs preferably once a week and run them exclusively from Scylla Manager.
-Refer to `Repair a Cluster <https://scylladb.github.io/scylla-manager/2.2/repair/index.html>`_
+Refer to `Repair a Cluster <https://manager.docs.scylladb.com/branch-2.2/repair/index.html>`_
 
 Backup and Restore
 ..................
@@ -169,13 +169,13 @@ We recommend the following:
 
 * Run a full weekly backup from Scylla Manager
 * Run a daily backup from Scylla Manager
-* Check the bucket used for restore. This can be done by performing a `restore <https://scylladb.github.io/scylla-manager/2.2/restore/index.html>`_ and making sure the data is valid. This action should be done once a month, or more frequently if needed. Ask our Support team to help you with this.
+* Check the bucket used for restore. This can be done by performing a `restore <https://manager.docs.scylladb.com/branch-2.2/restore/index.html>`_ and making sure the data is valid. This action should be done once a month, or more frequently if needed. Ask our Support team to help you with this.
 * Save backup to a bucket supported by Scylla Manager.
 
 For additional information:
 
-* `Backup <https://scylladb.github.io/scylla-manager/2.2/backup/index.html>`_
-* `Restore a Backup <https://scylladb.github.io/scylla-manager/2.2/restore/index.html>`_
+* `Backup <https://manager.docs.scylladb.com/branch-2.2/backup/index.html>`_
+* `Restore a Backup <https://manager.docs.scylladb.com/branch-2.2/restore/index.html>`_
 
 Scylla Monitor
 ==============
@@ -224,6 +224,6 @@ HA testing in multi DC - for example:
 Additional Topics
 -----------------
 * :doc:`Add a Node </operating-scylla/procedures/cluster-management/add-node-to-cluster/>`
-* `Repair <https://scylladb.github.io/scylla-manager/2.2/repair/index.html>`_
+* `Repair <https://manager.docs.scylladb.com/branch-2.2/repair/index.html>`_
 * :doc:`Cleanup </operating-scylla/nodetool-commands/cleanup/>`
 * Tech Talk: `How to be successful with Scylla <https://www.scylladb.com/tech-talk/how-to-be-successful-with-scylla/>`_

--- a/docs/operating-scylla/security/client-node-encryption.rst
+++ b/docs/operating-scylla/security/client-node-encryption.rst
@@ -75,7 +75,7 @@ Validate the Clients
 
 In order for cqlsh to work in client to node encryption SSL mode, you need to generate cqlshrc file.
 
-For Complete instructions, see `Generate a cqlshrc File <../gen-cqlsh-file>`_
+For Complete instructions, see :doc:`Generate a cqlshrc File <gen-cqlsh-file>`
 
 **Procedure**
 

--- a/docs/operating-scylla/security/security-checklist.rst
+++ b/docs/operating-scylla/security/security-checklist.rst
@@ -58,7 +58,7 @@ Also, see the list of ports used by Scylla.
 
 .. image:: Scylla-Ports2.png
 
-The Scylla ports are detailed in the table below. For Scylla Manager ports, see the `Scylla Manager Documentation <https://scylladb.github.io/scylla-manager>`_.
+The Scylla ports are detailed in the table below. For Scylla Manager ports, see the `Scylla Manager Documentation <https://manager.docs.scylladb.com>`_.
 
 .. include:: /operating-scylla/_common/networking-ports.rst
 

--- a/docs/upgrade/_common/upgrade-guide-v1-rpm.rst
+++ b/docs/upgrade/_common/upgrade-guide-v1-rpm.rst
@@ -75,7 +75,7 @@ Stop Scylla
 
 Download and install the new release
 ------------------------------------
-Before upgrading, check what version you are running now using ``rpm -qa | grep scylla-server``. You should use the same version in case you want to `rollback <#rollback-procedure>`_ the upgrade. If you are not running a |SRC_VERSION|.x version, stop right here! This guide only covers |SRC_VERSION|.x to |NEW_VERSION|.y upgrades.
+Before upgrading, check what version you are running now using ``rpm -qa | grep scylla-server``. You should use the same version in case you want to :ref:`rollback <rollback-procedure>` the upgrade. If you are not running a |SRC_VERSION|.x version, stop right here! This guide only covers |SRC_VERSION|.x to |NEW_VERSION|.y upgrades.
 
 To upgrade:
 
@@ -102,6 +102,8 @@ Validate
 Once you are sure the node upgrade is successful, move to the next node in the cluster.
 
 * More on |Scylla_METRICS|_
+
+.. _rollback-procedure:
 
 Rollback Procedure
 ==================

--- a/docs/upgrade/_common/upgrade-guide-v2-rpm.rst
+++ b/docs/upgrade/_common/upgrade-guide-v2-rpm.rst
@@ -75,7 +75,7 @@ Stop Scylla
 
 Download and install the new release
 ------------------------------------
-Before upgrading, check what version you are running now using ``rpm -qa | grep scylla-server``. You should use the same version in case you want to `rollback <#rollback-procedure>`_ the upgrade. If you are not running a |SRC_VERSION|.x version, stop right here! This guide only covers |SRC_VERSION|.x to |NEW_VERSION|.y upgrades.
+Before upgrading, check what version you are running now using ``rpm -qa | grep scylla-server``. You should use the same version in case you want to :ref:`rollback <rollback-procedure>` the upgrade. If you are not running a |SRC_VERSION|.x version, stop right here! This guide only covers |SRC_VERSION|.x to |NEW_VERSION|.y upgrades.
 
 To upgrade:
 

--- a/docs/upgrade/_common/upgrade-guide-v3-rpm.rst
+++ b/docs/upgrade/_common/upgrade-guide-v3-rpm.rst
@@ -72,7 +72,7 @@ Stop Scylla
 
 Download and install the new release
 ------------------------------------
-Before upgrading, check what Scylla version you are currently running with ``rpm -qa | grep scylla-server``. You should use the same version as this version in case you want to `rollback <#rollback-procedure>`_ the upgrade. If you are not running a |SRC_VERSION|.x version, stop right here! This guide only covers |SRC_VERSION|.x to |NEW_VERSION|.y upgrades.
+Before upgrading, check what Scylla version you are currently running with ``rpm -qa | grep scylla-server``. You should use the same version as this version in case you want to :ref:`rollback <rollback-procedure>` the upgrade. If you are not running a |SRC_VERSION|.x version, stop right here! This guide only covers |SRC_VERSION|.x to |NEW_VERSION|.y upgrades.
 
 To upgrade:
 

--- a/docs/upgrade/_common/upgrade-guide-v4-rpm.rst
+++ b/docs/upgrade/_common/upgrade-guide-v4-rpm.rst
@@ -70,7 +70,7 @@ Stop Scylla
 
 Download and install the new release
 ------------------------------------
-Before upgrading, check what Scylla version you are currently running with ``rpm -qa | grep scylla-server``. You should use the same version as this version in case you want to `rollback <#rollback-procedure>`_ the upgrade. If you are not running a |SRC_VERSION|.x version, stop right here! This guide only covers |SRC_VERSION|.x to |NEW_VERSION|.y upgrades.
+Before upgrading, check what Scylla version you are currently running with ``rpm -qa | grep scylla-server``. You should use the same version as this version in case you want to :ref:`rollback <rollback-procedure>` the upgrade. If you are not running a |SRC_VERSION|.x version, stop right here! This guide only covers |SRC_VERSION|.x to |NEW_VERSION|.y upgrades.
 
 To upgrade:
 

--- a/docs/upgrade/_common/upgrade-guide-v5-ubuntu-and-debian-p1.rst
+++ b/docs/upgrade/_common/upgrade-guide-v5-ubuntu-and-debian-p1.rst
@@ -103,5 +103,5 @@ Answer ‘y’ to the first two questions.
 
 .. note::
 
-   Alternator users upgrading from Scylla 4.0 to 4.1 need to set `default isolation level </upgrade/upgrade-opensource/upgrade-guide-from-4.0-to-4.1/alternator>`_.
+   Alternator users upgrading from Scylla 4.0 to 4.1 need to set :doc:`default isolation level </upgrade/upgrade-opensource/upgrade-guide-from-4.0-to-4.1/alternator>`.
 

--- a/docs/upgrade/index.rst
+++ b/docs/upgrade/index.rst
@@ -25,17 +25,17 @@ Upgrade Scylla
 
 Procedures for upgrading Scylla.
 
-* `Upgrade Scylla Enterprise <upgrade-enterprise/>`_
+* :doc:`Upgrade Scylla Enterprise <upgrade-enterprise/index>`
 
-* `Upgrade Scylla Open Source <upgrade-opensource/>`_
+* :doc:`Upgrade Scylla Open Source <upgrade-opensource/index>`
 
-* `Upgrade from Scylla Open Source to Scylla Enterprise <upgrade-to-enterprise/>`_
+* :doc:`Upgrade from Scylla Open Source to Scylla Enterprise <upgrade-to-enterprise/index>`
 
-* `Upgrade Scylla Manager <upgrade-manager/>`_
+* :doc:`Upgrade Scylla Manager <upgrade-manager/index>`
 
-* `Upgrade Scylla Monitoring Stack <upgrade-monitor/>`_
+* :doc:`Upgrade Scylla Monitoring Stack <upgrade-monitor/index>`
 
-* `Upgrade Scylla AMI <ami-upgrade>`_
+* :doc:`Upgrade Scylla AMI <ami-upgrade>`
 
 
 .. raw:: html

--- a/docs/upgrade/upgrade-enterprise/index.rst
+++ b/docs/upgrade/upgrade-enterprise/index.rst
@@ -29,20 +29,20 @@ Upgrade Scylla Enterprise
   Patch Release Upgrade
 
   * :doc:`Upgrade Guide - ScyllaDB Enterprise 2022.x </upgrade/upgrade-enterprise/upgrade-guide-from-2022.x.y-to-2022.x.z/index>`
-  * `Upgrade Guide - Scylla Enterprise 2021.x <upgrade-guide-from-2021.x.y-to-2021.x.z/>`_
-  * `Upgrade Guide - Scylla Enterprise 2020.x <upgrade-guide-from-2020.x.y-to-2020.x.z/>`_
-  * `Upgrade Guide - Scylla Enterprise 2019.x <upgrade-guide-from-2019.x.y-to-2019.x.z/>`_
-  * `Upgrade Guide - Scylla Enterprise 2018.x <upgrade-guide-from-2018.x.y-to-2018.x.z/>`_
-  * `Upgrade Guide - Scylla Enterprise 2017.x <upgrade-guide-from-2017.x.y-to-2017.x.z/>`_
+  * :doc:`Upgrade Guide - Scylla Enterprise 2021.x <upgrade-guide-from-2021.x.y-to-2021.x.z/index>`
+  * :doc:`Upgrade Guide - Scylla Enterprise 2020.x <upgrade-guide-from-2020.x.y-to-2020.x.z/index>`
+  * :doc:`Upgrade Guide - Scylla Enterprise 2019.x <upgrade-guide-from-2019.x.y-to-2019.x.z/index>`
+  * :doc:`Upgrade Guide - Scylla Enterprise 2018.x <upgrade-guide-from-2018.x.y-to-2018.x.z/index>`
+  * :doc:`Upgrade Guide - Scylla Enterprise 2017.x <upgrade-guide-from-2017.x.y-to-2017.x.z/index>`
 
   Major Release Upgrade
 
-  * `Upgrade Guide - From Scylla Enterprise 2021.1 to Scylla Enterprise 2022.1 <upgrade-guide-from-2021.1-to-2022.1/>`_
-  * `Upgrade Guide - From Scylla Enterprise 2020.1 to Scylla Enterprise 2021.1 <upgrade-guide-from-2020.1-to-2021.1/>`_
-  * `Upgrade Guide - From Scylla Enterprise 2019.1 to Scylla Enterprise 2020.1 <upgrade-guide-from-2019.1-to-2020.1/>`_
-  * `Upgrade Guide - From Scylla Enterprise 2018.1 to Scylla Enterprise 2019.1 <upgrade-guide-from-2018.1-to-2019.1/>`_
-  * `Upgrade Guide - From Scylla Enterprise 2017.1 to Scylla Enterprise 2018.1 <upgrade-guide-from-2017.1-to-2018.1/>`_
-  * `Upgrade Guide - Ubuntu 14.04 to 16.04 <upgrade-guide-from-ubuntu-14-to-16/>`_
+  * :doc:`Upgrade Guide - From Scylla Enterprise 2021.1 to Scylla Enterprise 2022.1 <upgrade-guide-from-2021.1-to-2022.1/index>`
+  * :doc:`Upgrade Guide - From Scylla Enterprise 2020.1 to Scylla Enterprise 2021.1 <upgrade-guide-from-2020.1-to-2021.1/index>`
+  * :doc:`Upgrade Guide - From Scylla Enterprise 2019.1 to Scylla Enterprise 2020.1 <upgrade-guide-from-2019.1-to-2020.1/index>`
+  * :doc:`Upgrade Guide - From Scylla Enterprise 2018.1 to Scylla Enterprise 2019.1 <upgrade-guide-from-2018.1-to-2019.1/index>`
+  * :doc:`Upgrade Guide - From Scylla Enterprise 2017.1 to Scylla Enterprise 2018.1 <upgrade-guide-from-2017.1-to-2018.1/index>`
+  * :doc:`Upgrade Guide - Ubuntu 14.04 to 16.04 <upgrade-guide-from-ubuntu-14-to-16>`
 
 
   * :ref:`Upgrade Unified Installer (relocatable executable) install <unified-installed-upgrade>`

--- a/docs/upgrade/upgrade-manager/upgrade-guide-from-2.x.a-to-2.y.b/index.rst
+++ b/docs/upgrade/upgrade-manager/upgrade-guide-from-2.x.a-to-2.y.b/index.rst
@@ -17,5 +17,5 @@ Upgrade Scylla Manager 2.x.a to 2.y.b
 
   Procedures for upgrading to a new version of Scylla Manager.
 
-  * `Scylla Manager Upgrade - Scylla Manager 2.x.a to 2.y.b <upgrade-2.x.a-to-2.y.b/>`_
-  * `Fix for row-level repairs <upgrade-row-level-repair/>`_
+  * :doc:`Scylla Manager Upgrade - Scylla Manager 2.x.a to 2.y.b <upgrade-2.x.a-to-2.y.b/>`
+  * :doc:`Fix for row-level repairs <upgrade-row-level-repair/>`

--- a/docs/upgrade/upgrade-opensource/index.rst
+++ b/docs/upgrade/upgrade-opensource/index.rst
@@ -35,24 +35,24 @@ Upgrade ScyllaDB Open Source
 
   Procedures for upgrading to a newer version of ScyllaDB Open Source.
 
-  * `Upgrade Guide - ScyllaDB 5.x maintenance releases <upgrade-guide-from-5.x.y-to-5.x.z/>`_
-  * `Upgrade Guide - ScyllaDB 4.6 to 5.0 <upgrade-guide-from-4.6-to-5.0/>`_
-  * `Upgrade Guide - ScyllaDB 4.5 to 4.6 <upgrade-guide-from-4.5-to-4.6/>`_
-  * `Upgrade Guide - ScyllaDB 4.4 to 4.5 <upgrade-guide-from-4.4-to-4.5/>`_
-  * `Upgrade Guide - ScyllaDB 4.3 to 4.4 <upgrade-guide-from-4.3-to-4.4/>`_
-  * `Upgrade Guide - ScyllaDB 4.2 to 4.3 <upgrade-guide-from-4.2-to-4.3/>`_
-  * `Upgrade Guide - ScyllaDB 4.1 to 4.2 <upgrade-guide-from-4.1-to-4.2/>`_
-  * `Upgrade Guide - ScyllaDB 4.x maintenance release <upgrade-guide-from-4.x.y-to-4.x.z/>`_
-  * `Upgrade Guide - ScyllaDB 4.0 to 4.1 <upgrade-guide-from-4.0-to-4.1/>`_
-  * `Upgrade Guide - ScyllaDB 3.x maintenance release <upgrade-guide-from-3.x.y-to-3.x.z/>`_
-  * `Upgrade Guide - ScyllaDB 3.3 to 4.0 <upgrade-guide-from-3.3-to-4.0/>`_
-  * `Upgrade Guide - ScyllaDB 3.2 to 3.3 <upgrade-guide-from-3.2-to-3.3/>`_
-  * `Upgrade Guide - ScyllaDB 3.1 to 3.2 <upgrade-guide-from-3.1-to-3.2/>`_
-  * `Upgrade Guide - ScyllaDB 3.0 to 3.1 <upgrade-guide-from-3.0-to-3.1/>`_
-  * `Upgrade Guide - ScyllaDB 2.3 to 3.0 <upgrade-guide-from-2.3-to-3.0/>`_
-  * `Upgrade Guide - ScyllaDB 2.2 to 2.3 <upgrade-guide-from-2.2-to-2.3/>`_
-  * `Upgrade Guide - ScyllaDB 2.1 to 2.2 <upgrade-guide-from-2.1-to-2.2/>`_
-  * `Upgrade Guide - ScyllaDB 2.x maintenance release <upgrade-guide-from-2.x.y-to-2.x.z/>`_
-  * `Upgrade Guide - older versions <upgrade-archive/>`_
-  * `Upgrade Guide - Ubuntu 14.04 to 16.04 <upgrade-guide-from-ubuntu-14-to-16/>`_
+  * :doc:`Upgrade Guide - ScyllaDB 5.x maintenance releases <upgrade-guide-from-5.x.y-to-5.x.z/index>`
+  * :doc:`Upgrade Guide - ScyllaDB 4.6 to 5.0 <upgrade-guide-from-4.6-to-5.0/index>`
+  * :doc:`Upgrade Guide - ScyllaDB 4.5 to 4.6 <upgrade-guide-from-4.5-to-4.6/index>`
+  * :doc:`Upgrade Guide - ScyllaDB 4.4 to 4.5 <upgrade-guide-from-4.4-to-4.5/index>`
+  * :doc:`Upgrade Guide - ScyllaDB 4.3 to 4.4 <upgrade-guide-from-4.3-to-4.4/index>`
+  * :doc:`Upgrade Guide - ScyllaDB 4.2 to 4.3 <upgrade-guide-from-4.2-to-4.3/index>`
+  * :doc:`Upgrade Guide - ScyllaDB 4.1 to 4.2 <upgrade-guide-from-4.1-to-4.2/index>`
+  * :doc:`Upgrade Guide - ScyllaDB 4.x maintenance release <upgrade-guide-from-4.x.y-to-4.x.z/index>`
+  * :doc:`Upgrade Guide - ScyllaDB 4.0 to 4.1 <upgrade-guide-from-4.0-to-4.1/index>`
+  * :doc:`Upgrade Guide - ScyllaDB 3.x maintenance release <upgrade-guide-from-3.x.y-to-3.x.z/index>`
+  * :doc:`Upgrade Guide - ScyllaDB 3.3 to 4.0 <upgrade-guide-from-3.3-to-4.0/index>`
+  * :doc:`Upgrade Guide - ScyllaDB 3.2 to 3.3 <upgrade-guide-from-3.2-to-3.3/index>`
+  * :doc:`Upgrade Guide - ScyllaDB 3.1 to 3.2 <upgrade-guide-from-3.1-to-3.2/index>`
+  * :doc:`Upgrade Guide - ScyllaDB 3.0 to 3.1 <upgrade-guide-from-3.0-to-3.1/index>`
+  * :doc:`Upgrade Guide - ScyllaDB 2.3 to 3.0 <upgrade-guide-from-2.3-to-3.0/index>`
+  * :doc:`Upgrade Guide - ScyllaDB 2.2 to 2.3 <upgrade-guide-from-2.2-to-2.3/index>`
+  * :doc:`Upgrade Guide - ScyllaDB 2.1 to 2.2 <upgrade-guide-from-2.1-to-2.2/index>`
+  * :doc:`Upgrade Guide - ScyllaDB 2.x maintenance release <upgrade-guide-from-2.x.y-to-2.x.z/index>`
+  * :doc:`Upgrade Guide - older versions <upgrade-archive>`
+  * :doc:`Upgrade Guide - Ubuntu 14.04 to 16.04 <upgrade-guide-from-ubuntu-14-to-16>`
   * :ref:`Upgrade Unified Installer (relocatable executable) install <unified-installed-upgrade>`

--- a/docs/using-scylla/alternator/index.rst
+++ b/docs/using-scylla/alternator/index.rst
@@ -4,7 +4,7 @@ Scylla Alternator
 
 .. include:: /using-scylla/_common/alternator-description.rst
 
-* :doc:`Scylla Alternator Documentation </alternator/alternator/>`
+* :doc:`Scylla Alternator Documentation </alternator/alternator>`
 * `Scylla Alternator project <https://github.com/scylladb/scylla/tree/master/alternator>`_ - Part of the Scylla project
 * `Scylla Alternator course <https://university.scylladb.com/courses/scylla-alternator/>`_ on Scylla University
 

--- a/docs/using-scylla/drivers/cql-drivers/scylla-go-driver.rst
+++ b/docs/using-scylla/drivers/cql-drivers/scylla-go-driver.rst
@@ -7,7 +7,7 @@ It is is a fork of the `GoCQL Driver <https://github.com/gocql/gocql>`_ but has 
 Using this policy, the driver can select a connection to a particular shard based on the shard’s token. 
 As a result, latency is significantly reduced because there is no need to pass data between the shards. 
 
-The protocol extension spec is `available here <https://scylla.docs.scylladb.com/master/design-notes/protocol-extensions>`_. 
+The protocol extension spec is `available here <https://github.com/scylladb/scylla/blob/master/docs/dev/protocol-extensions.md>`_. 
 The Scylla Go Driver is a drop-in replacement for gocql. 
 As such, no code changes are needed to use this driver. 
 All you need to do is rebuild using the ``replace`` directive in your ``mod`` file.

--- a/docs/using-scylla/drivers/cql-drivers/scylla-python-driver.rst
+++ b/docs/using-scylla/drivers/cql-drivers/scylla-python-driver.rst
@@ -6,7 +6,7 @@ The Scylla Python driver is shard aware and contains extensions for a ``tokenAwa
 Using this policy, the driver can select a connection to a particular shard based on the shard’s token. 
 As a result, latency is significantly reduced because there is no need to pass data between the shards. 
 
-Read the `documentation <https://scylladb.github.io/python-driver/>`_ to get started or visit the Github project `Scylla Python driver <https://github.com/scylladb/python-driver/>`_.
+Read the `documentation <https://python-driver.docs.scylladb.com/>`_ to get started or visit the Github project `Scylla Python driver <https://github.com/scylladb/python-driver/>`_.
 
 As the Scylla Python Driver is a drop-in replacement for DataStax Python Driver, no code changes are needed to use the driver. 
 Use the Scylla Python driver for better compatibility and support for Scylla with Python-based applications.
@@ -15,6 +15,6 @@ Use the Scylla Python driver for better compatibility and support for Scylla wit
 More information 
 ----------------
 
-* `Scylla Python Driver Documentation <https://scylladb.github.io/python-driver/>`_
+* `Scylla Python Driver Documentation <https://python-driver.docs.scylladb.com/>`_
 * `Scylla Python Driver on GitHub <https://github.com/scylladb/python-driver/>`_
 * `Scylla University: Coding with Python <https://university.scylladb.com/courses/the-mutant-monitoring-system-training-course/lessons/coding-with-python/>`_ 

--- a/docs/using-scylla/integrations/index.rst
+++ b/docs/using-scylla/integrations/index.rst
@@ -33,18 +33,18 @@ Scylla Integrations and Connectors
   If you have tested your application with Scylla and want to publish the results, contact us using the `mailing list <https://groups.google.com/d/forum/scylladb-users>`_.
 
 
-  * `Integrate Scylla with Spark <integration-spark>`_
-  * `Integrate Scylla with KairosDB <integration-kairos>`_
-  * `Integrate Scylla with Presto <integration-presto>`_
-  * `Integrate Scylla with Elasticsearch <integration-elasticsearch>`_
-  * `Integrate Scylla with Kubernetes <integration-k8>`_
-  * `Integrate Scylla with JanusGraph <integration-janus>`_
-  * `Integrate Scylla with DataDog <integration-datadog>`_
-  * `Integrate Scylla with Apache Kafka <integration-kafka>`_
-  * `Integrate Scylla with IOTA <integration-iota>`_
-  * `Integrate Scylla with Spring <integration-spring>`_
-  * `Install Scylla with Ansible <integration-ansible>`_
-  * `Integrate Scylla with Databricks <integration-databricks>`_
+  * :doc:`Integrate Scylla with Spark <integration-spark>`
+  * :doc:`Integrate Scylla with KairosDB <integration-kairos>`
+  * :doc:`Integrate Scylla with Presto <integration-presto>`
+  * :doc:`Integrate Scylla with Elasticsearch <integration-elasticsearch>`
+  * :doc:`Integrate Scylla with Kubernetes <integration-k8>`
+  * :doc:`Integrate Scylla with JanusGraph <integration-janus>`
+  * :doc:`Integrate Scylla with DataDog <integration-datadog>`
+  * :doc:`Integrate Scylla with Apache Kafka <integration-kafka>`
+  * :doc:`Integrate Scylla with IOTA <integration-iota>`
+  * :doc:`Integrate Scylla with Spring <integration-spring>`
+  * :doc:`Install Scylla with Ansible <integration-ansible>`
+  * :doc:`Integrate Scylla with Databricks <integration-databricks>`
 
 .. panel-box::
   :title: Scylla Connectors

--- a/docs/using-scylla/integrations/scylla-cdc-source-connector-quickstart.rst
+++ b/docs/using-scylla/integrations/scylla-cdc-source-connector-quickstart.rst
@@ -7,7 +7,7 @@ Synopsis
 --------
 
 This quickstart will show you how to setup the Scylla CDC Source Connector to replicate changes made in 
-a Scylla table using `Scylla CDC <../../cdc/cdc-intro>`_.
+a Scylla table using :doc:`Scylla CDC <../cdc/cdc-intro>`.
 
 Scylla setup
 ------------
@@ -19,7 +19,7 @@ Scylla installation
 
 For the purpose of this quickstart, we will configure a Scylla instance using Docker. You can skip this 
 section if you have already installed Scylla. To learn more about installing Scylla in production
-environments, please refer to the `Install Scylla page <../../../getting-started/install-scylla/>`_.
+environments, please refer to the :doc:`Install Scylla page </getting-started/install-scylla/index>`.
 
 #. Using `Docker <https://hub.docker.com/r/scylladb/scylla/>`_, follow the instructions to launch Scylla.
 #. Start the Docker container, replacing the ``--name`` and ``--host name`` parameters with your own information. For example:
@@ -62,7 +62,7 @@ If you already have a table you wish to use, but it does not have CDC enabled, y
 
    ALTER TABLE keyspace.table_name with cdc = {'enabled': true};
 
-To learn more about Scylla CDC, visit `Change Data Capture (CDC) page <../../cdc/>`_.
+To learn more about Scylla CDC, visit :doc:`Change Data Capture (CDC) page <../cdc/index>`.
 
 Kafka setup
 -----------

--- a/docs/using-scylla/integrations/scylla-cdc-source-connector.rst
+++ b/docs/using-scylla/integrations/scylla-cdc-source-connector.rst
@@ -9,14 +9,14 @@ Scylla CDC Source Connector
 
 Scylla CDC Source Connector is a source connector capturing row-level changes in the tables of a Scylla cluster. It is a Debezium connector, compatible with Kafka Connect (with Kafka 2.6.0+) and built on top of scylla-cdc-java library. The source code of the connector is available at `GitHub <https://github.com/scylladb/scylla-cdc-source-connector>`_.
 
-The connector reads the CDC log for specified tables and produces Kafka messages for each row-level ``INSERT``, ``UPDATE`` or ``DELETE`` operation. The connector is able to split reading the CDC log accross multiple processes: the connector can start a separate Kafka Connect task for reading each `Vnode of Scylla cluster <../../../architecture/ringarchitecture/>`_ allowing for high throughput. You can limit the number of started tasks by using ``tasks.max`` property.
+The connector reads the CDC log for specified tables and produces Kafka messages for each row-level ``INSERT``, ``UPDATE`` or ``DELETE`` operation. The connector is able to split reading the CDC log accross multiple processes: the connector can start a separate Kafka Connect task for reading each :doc:`Vnode of Scylla cluster </architecture/ringarchitecture/index>` allowing for high throughput. You can limit the number of started tasks by using ``tasks.max`` property.
 
 Scylla CDC Source Connector seamlessly handles schema changes and topology changes (adding, removing nodes from Scylla cluster). The connector is fault-tolerant, retrying reading data from Scylla in case of failure. It periodically saves the current position in Scylla CDC log using Kafka Connect offset tracking (configurable by ``offset.flush.interval.ms`` parameter). If the connector is stopped, it is able to resume reading from previously saved offset. Scylla CDC Source Connector has at-least-once semantics.
 
 The connector has the following capabilities:
 
 * Kafka Connect connector using Debezium framework
-* Replication of row-level changes from Scylla using `Scylla CDC <../../cdc/cdc-intro>`_. The connector replicates the following operations: ``INSERT``, ``UPDATE``, ``DELETE`` (single row deletes)
+* Replication of row-level changes from Scylla using :doc:`Scylla CDC <../cdc/cdc-intro>`. The connector replicates the following operations: ``INSERT``, ``UPDATE``, ``DELETE`` (single row deletes)
 * High scalability - able to split work accross multiple Kafka Connect workers
 * Fault tolerant - connector periodically saves its progress and can resume from previously saved offset (with at-least-once semantics)
 * Support for many standard Kafka Connect converters, such as JSON and Avro
@@ -33,4 +33,4 @@ The connector has the following limitations:
 
 The following documents will help you get started with Scylla CDC Source Connector:
 
-* `Scylla CDC Source Connector Quickstart <../scylla-cdc-source-connector-quickstart>`_
+* :doc:`Scylla CDC Source Connector Quickstart <scylla-cdc-source-connector-quickstart>`

--- a/docs/using-scylla/integrations/sink-kafka-connector.rst
+++ b/docs/using-scylla/integrations/sink-kafka-connector.rst
@@ -13,8 +13,8 @@ The connector allows you to use Apache Kafka and the Confluent platform while ta
 
 The following documents will get you started with the Kafka Connector:
 
-* `Kafka Sink Connector Quickstart <../kafka-connector/>`_
-* `Kafka Sink Connector Configuration <../sink-config/>`_
+* :doc:`Kafka Sink Connector Quickstart <kafka-connector>`
+* :doc:`Kafka Sink Connector Configuration <sink-config>`
 * `Introducing the Kafka Scylla Connector <https://www.scylladb.com/2020/02/18/introducing-the-kafka-scylla-connector/>`_ - Scylla Users blog
 
 

--- a/docs/using-scylla/learn.rst
+++ b/docs/using-scylla/learn.rst
@@ -12,7 +12,7 @@ Learn To Use Scylla
    Basic Data Modeling <https://university.scylladb.com/courses/data-modeling/lessons/basic-data-modeling-2/>
    Advanced Data Modeling <https://university.scylladb.com/courses/data-modeling/lessons/advanced-data-modeling/>
    MMS - Learn by Example <https://university.scylladb.com/courses/the-mutant-monitoring-system-training-course/>
-   Care-Pet an IoT Use Case and Example <https://scylladb.github.io/care-pet/master/>
+   Care-Pet an IoT Use Case and Example <https://iot.scylladb.com/>
 
 .. panel-box::
   :title: Scylla University
@@ -66,7 +66,7 @@ Learn To Use Scylla
   :class: my-panel
 
   * MMS Course: Mutants have emerged from the shadows and are wreaking havoc on Earth! `Learn Scylla step by step <https://university.scylladb.com/courses/the-mutant-monitoring-system-training-course/>`_ though examples based on a "true story".
-  * Care-Pet: an IoT Use case example. `Learn to Use Scylla <https://scylladb.github.io/care-pet/master/>`_ using this use case.
+  * Care-Pet: an IoT Use case example. `Learn to Use Scylla <https://iot.scylladb.com/>`_ using this use case.
 
 .. panel-box::
   :title: Tech Talks and Scylla Summit Sessions


### PR DESCRIPTION
This PR fixes some links that stopped working when changing the domain from https://docs.scylladb.com/ to `https://docs.scylladb.com/<version_name>`

## How to test this PR

1. Run ``make preview``. The build should complete without errors.

2. Open the preview and click on some of the links replaced.