### PR TITLE
doc: add the upgrage guides from 2022.x.y to 2022.x.z

### DIFF
--- a/docs/upgrade/_common/upgrade-guide-from-2022.x.y-to-2022.x.z-ubuntu-and-debian.rst
+++ b/docs/upgrade/_common/upgrade-guide-from-2022.x.y-to-2022.x.z-ubuntu-and-debian.rst
@@ -1,0 +1,171 @@
+======================================================================
+Upgrade Guide - ScyllaDB Enterprise 2022.x.y to 2022.x.z for |OS|
+======================================================================
+
+This document is a step-by-step procedure for upgrading from ScyllaDB Enterprise 2022.x.y to 2022.x.z.
+
+
+Applicable versions
+===================
+This guide covers upgrading ScyllaDB Enterprise from version 2022.x.y to 2022.x.z on the following platform:
+
+* |OS|
+
+Upgrade Procedure
+=================
+.. include:: /upgrade/upgrade-enterprise/_common/enterprise_2022.1_warnings.rst
+
+A ScyllaDB Enterprise upgrade is a rolling procedure which does **not** require a full cluster shutdown.
+For each of the nodes in the cluster, you will:
+
+* Drain the node and backup the data
+* Check your current release
+* Backup the configuration file
+* Stop ScyllaDB
+* Download and install the new ScyllaDB packages
+* Start ScyllaDB
+* Validate that the upgrade was successful
+
+Apply the following procedure **serially** on each node. Do not move to the next node before validating that the node that you upgraded is up and running the new version.
+
+**During** the rolling upgrade, it is highly recommended:
+
+* Not to use new 2022.x.z features.
+* Not to run administration functions, like repairs, refresh, rebuild or add or remove nodes.
+* Not to apply schema changes.
+
+Upgrade Steps
+=============
+
+Drain the node and backup the data
+------------------------------------
+Before any major procedure, like an upgrade, it is recommended to backup all the data to an external device. In ScyllaDB, backup is done using the ``nodetool snapshot`` command. For **each** node in the cluster, run the following command:
+
+.. code:: sh
+
+   nodetool drain
+   nodetool snapshot
+
+Take note of the directory name that nodetool gives you, and copy all the directories having this name under ``/var/lib/scylla`` to a backup device.
+
+When the upgrade is completed on all nodes, the snapshot should be removed with the ``nodetool clearsnapshot -t <snapshot>`` command, or you risk running out of space.
+
+Backup the configuration file
+-------------------------------
+
+.. code:: sh
+
+   sudo cp -a /etc/scylla/scylla.yaml /etc/scylla/scylla.yaml.backup-2022.x.z
+
+Backup more config files.
+
+.. code:: sh
+
+   for conf in $(cat /var/lib/dpkg/info/scylla-*server.conffiles /var/lib/dpkg/info/scylla-*conf.conffiles /var/lib/dpkg/info/scylla-*jmx.conffiles | grep -v init ); do sudo cp -v $conf $conf.backup-2.1; done
+
+Gracefully stop the node
+------------------------
+
+.. code:: sh
+
+   sudo service scylla-enterprise-server stop
+
+Download and install the new release
+------------------------------------
+Before upgrading, check what version you are running now using ``dpkg -s scylla-enterprise-server``. You should use the same version in case you want to |ROLLBACK|_ the upgrade. If you are not running a 2022.x.y version, stop right here! This guide only covers 2022.x.y to 2022.x.z upgrades.
+
+To upgrade:
+
+#. Update the |APT|_ to **2022.x**.
+#. Install:
+
+    .. code:: sh
+
+       sudo apt-get clean all
+       sudo apt-get update
+       sudo apt-get dist-upgrade scylla-enterprise
+
+Answer ‘y’ to the first two questions.
+
+Start the node
+--------------
+
+.. code:: sh
+
+   sudo service scylla-enterprise-server start
+
+Validate
+--------
+1. Check cluster status with ``nodetool status`` and make sure **all** nodes, including the one you just upgraded, are in UN status.
+2. Use ``curl -X GET "http://localhost:10000/storage_service/scylla_release_version"`` to check the ScyllaDB version.
+3. Check scylla-enterprise-server log (by ``journalctl _COMM=scylla``) and ``/var/log/syslog`` to validate there are no errors.
+4. Check again after 2 minutes to validate no new issues are introduced.
+
+Once you are sure the node upgrade is successful, move to the next node in the cluster.
+
+Rollback Procedure
+==================
+
+.. include:: /upgrade/_common/warning_rollback.rst
+
+The following procedure describes a rollback from ScyllaDB Enterprise release 2022.x.z to 2022.x.y. Apply this procedure if an upgrade from 2022.x.y to 2022.x.z failed before completing on all nodes. Use this procedure only for nodes you upgraded to 2022.x.z.
+
+ScyllaDB rollback is a rolling procedure which does **not** require a full cluster shutdown.
+For each of the nodes rollback to 2022.x.y, you will:
+
+* Gracefully shutdown ScyllaDB
+* Downgrade to the previous release
+* Restore the configuration file
+* Restart ScyllaDB
+* Validate the rollback success
+
+Apply the following procedure **serially** on each node. Do not move to the next node before validating that the node is up and running the new version.
+
+Rollback Steps
+==============
+
+Gracefully shutdown ScyllaDB
+-----------------------------
+
+.. code:: sh
+
+   nodetool drain
+   sudo service scylla-enterprise-server stop
+
+Downgrade to the previous release
+----------------------------------
+
+Install:
+
+.. code:: sh
+
+   sudo apt-get install scylla-enterprise=2022.x.y\* scylla-enterprise-server=2022.x.y\* scylla-enterprise-jmx=2022.x.y\* scylla-enterprise-tools=2022.x.y\* scylla-enterprise-tools-core=2022.x.y\* scylla-enterprise-kernel-conf=2022.x.y\* scylla-enterprise-conf=2022.x.y\* scylla-enterprise-python3=2022.x.y\*
+   sudo apt-get install scylla-enterprise-machine-image=2022.x.y\*  # only execute on AMI instance
+
+Answer ‘y’ to the first two questions.
+
+Restore the configuration file
+------------------------------
+
+.. code:: sh
+
+   sudo rm -rf /etc/scylla/scylla.yaml
+   sudo cp -a /etc/scylla/scylla.yaml.backup-2022.x.z /etc/scylla/scylla.yaml
+
+Restore more config files.
+
+.. code:: sh
+
+   for conf in $(cat /var/lib/dpkg/info/scylla-*server.conffiles /var/lib/dpkg/info/scylla-*conf.conffiles /var/lib/dpkg/info/scylla-*jmx.conffiles | grep -v init ); do sudo cp -v $conf.backup-2.1 $conf; done
+   sudo systemctl daemon-reload
+
+Start the node
+--------------
+
+.. code:: sh
+
+   sudo service scylla-enterprise-server start
+
+Validate
+--------
+Check the upgrade instruction above for validation. Once you are sure the node rollback is successful, move to the next node in the cluster.

--- a/docs/upgrade/upgrade-enterprise/index.rst
+++ b/docs/upgrade/upgrade-enterprise/index.rst
@@ -6,6 +6,7 @@ Upgrade Scylla Enterprise
    :hidden:
    :titlesonly:
 
+   Scylla Enterprise 2022 <upgrade-guide-from-2022.x.y-to-2022.x.z/index>
    Scylla Enterprise 2021 <upgrade-guide-from-2021.x.y-to-2021.x.z/index>
    Scylla Enterprise 2020 <upgrade-guide-from-2020.x.y-to-2020.x.z/index>
    Scylla Enterprise 2019 <upgrade-guide-from-2019.x.y-to-2019.x.z/index>
@@ -27,6 +28,7 @@ Upgrade Scylla Enterprise
 
   Patch Release Upgrade
 
+  * :doc:`Upgrade Guide - ScyllaDB Enterprise 2022.x </upgrade/upgrade-enterprise/upgrade-guide-from-2022.x.y-to-2022.x.z/index>`
   * `Upgrade Guide - Scylla Enterprise 2021.x <upgrade-guide-from-2021.x.y-to-2021.x.z/>`_
   * `Upgrade Guide - Scylla Enterprise 2020.x <upgrade-guide-from-2020.x.y-to-2020.x.z/>`_
   * `Upgrade Guide - Scylla Enterprise 2019.x <upgrade-guide-from-2019.x.y-to-2019.x.z/>`_

--- a/docs/upgrade/upgrade-enterprise/upgrade-guide-from-2022.x.y-to-2022.x.z/index.rst
+++ b/docs/upgrade/upgrade-enterprise/upgrade-guide-from-2022.x.y-to-2022.x.z/index.rst
@@ -1,0 +1,37 @@
+=====================================================
+Upgrade ScyllaDB Enterprise 2022
+=====================================================
+
+.. toctree::
+   :titlesonly:
+   :hidden:
+
+   Red Hat Enterprise Linux and CentOS <upgrade-guide-from-2022.x.y-to-2022.x.z-rpm>
+   Ubuntu 18.04 <upgrade-guide-from-2022.x.y-to-2022.x.z-ubuntu-18-04>
+   Ubuntu 20.04 <upgrade-guide-from-2022.x.y-to-2022.x.z-ubuntu-20-04>
+   Debian 10 <upgrade-guide-from-2022.x.y-to-2022.x.z-debian-10>
+
+.. raw:: html
+
+
+   <div class="panel callout radius animated">
+            <div class="row">
+              <div class="medium-3 columns">
+                <h5 id="getting-started">Upgrade ScyllaDB Enterprise</h5>
+              </div>
+              <div class="medium-9 columns">
+
+Upgrade guides are available for:
+
+* :doc:`Upgrade ScyllaDB Enterprise from 2022.x.y to 2022.x.z on Red Hat Enterprise Linux and CentOS <upgrade-guide-from-2022.x.y-to-2022.x.z-rpm>`
+* :doc:`Upgrade ScyllaDB Enterprise from 2022.x.y to 2022.x.z on Ubuntu 18.04 <upgrade-guide-from-2022.x.y-to-2022.x.z-ubuntu-18-04>`
+* :doc:`Upgrade ScyllaDB Enterprise from 2022.x.y to 2022.x.z on Ubuntu 20.04 <upgrade-guide-from-2022.x.y-to-2022.x.z-ubuntu-20-04>`
+* :doc:`Upgrade ScyllaDB Enterprise from 2022.x.y to 2022.x.z on Debian 10 <upgrade-guide-from-2022.x.y-to-2022.x.z-debian-10>`
+
+
+.. raw:: html
+
+   </div>
+   </div>
+   </div>
+

--- a/docs/upgrade/upgrade-enterprise/upgrade-guide-from-2022.x.y-to-2022.x.z/upgrade-guide-from-2022.x.y-to-2022.x.z-debian-10.rst
+++ b/docs/upgrade/upgrade-enterprise/upgrade-guide-from-2022.x.y-to-2022.x.z/upgrade-guide-from-2022.x.y-to-2022.x.z-debian-10.rst
@@ -1,0 +1,6 @@
+.. |OS| replace:: Debian 10 
+.. |ROLLBACK| replace:: rollback
+.. _ROLLBACK: /upgrade/upgrade-enterprise/upgrade-guide-from-2022.x.y-to-2022.x.z/upgrade-guide-from-2022.x.y-to-2022.x.z-debian/#rollback-procedure
+.. |APT| replace:: ScyllaDB Enterprise deb repo
+.. _APT: https://www.scylladb.com/customer-portal/?product=ent&platform=debian-10&version=stable-release-2022.1
+.. include:: /upgrade/_common/upgrade-guide-from-2022.x.y-to-2022.x.z-ubuntu-and-debian.rst

--- a/docs/upgrade/upgrade-enterprise/upgrade-guide-from-2022.x.y-to-2022.x.z/upgrade-guide-from-2022.x.y-to-2022.x.z-rpm.rst
+++ b/docs/upgrade/upgrade-enterprise/upgrade-guide-from-2022.x.y-to-2022.x.z/upgrade-guide-from-2022.x.y-to-2022.x.z-rpm.rst
@@ -1,0 +1,156 @@
+=====================================================================================================
+Upgrade Guide - ScyllaDB Enterprise 2022.x.y to 2022.x.z for Red Hat Enterprise 7, 8 or CentOS 7, 8
+=====================================================================================================
+
+This document is a step-by-step procedure for upgrading from ScyllaDB Enterprise 2022.x.y to 2022.x.z.
+
+
+Applicable versions
+===================
+This guide covers upgrading ScyllaDB Enterprise from version 2022.x.y to 2022.x.z, on the following platforms:
+
+* Red Hat Enterprise Linux 7 and later
+* CentOS 7 and later
+
+Packages for Fedora are no longer provided.
+
+Upgrade Procedure
+=================
+
+A ScyllaDB upgrade is a rolling procedure which does not require a full cluster shutdown. For each of the nodes in the cluster, you will:
+
+* Drain the node and backup the data
+* Check your current release
+* Backup the configuration file
+* Stop ScyllaDB
+* Download and install the new ScyllaDB packages
+* Start ScyllaDB
+* Validate that the upgrade was successful
+
+Apply the following procedure **serially** on each node. Do not move to the next node before validating that the node that you upgraded is up and running the new version.
+
+**During** the rolling upgrade, it is highly recommended:
+
+* Not to use new 2022.x.z features.
+* Not to run administration functions, like repairs, refresh, rebuild or add or remove nodes.
+* Not to apply schema changes.
+
+Upgrade Steps
+=============
+
+Drain the node and backup the data
+-----------------------------------
+Before any major procedure, like an upgrade, it is recommended to backup all the data to an external device. In ScyllaDB, backup is done using the ``nodetool snapshot`` command. For **each** node in the cluster, run the following command:
+
+.. code:: sh
+
+   nodetool drain
+   nodetool snapshot
+
+Take note of the directory name that nodetool gives you, and copy all the directories having this name under ``/var/lib/scylla`` to a backup device.
+
+When the upgrade is completed on all nodes, the snapshot should be removed with the ``nodetool clearsnapshot -t <snapshot>`` command, or you risk running out of space.
+
+Backup the configuration file
+------------------------------
+
+.. code:: sh
+
+   sudo cp -a /etc/scylla/scylla.yaml /etc/scylla/scylla.yaml.backup-2021.x.z
+
+Stop ScyllaDB
+--------------
+
+.. code:: sh
+
+   sudo systemctl stop scylla-enterprise-server
+
+Download and install the new release
+------------------------------------
+Before upgrading, check what version you are running now using ``rpm -qa | grep scylla-enterprise-server``. You should use the same version in case you want to :ref:`rollback <upgrade-2022.x.y-to-2022.x.z-rpm-rollback-procedure>` the upgrade. If you are not running a 2022.x.y version, stop right here! This guide only covers 2022.x.y to 2022.x.z upgrades.
+
+To upgrade:
+
+#. Update the `ScyllaDB Enterprise RPM repo <https://www.scylladb.com/customer-portal/?product=ent&platform=centos7&version=stable-release-2021.1>`_ to **2022.x**.
+#. Install:
+
+    .. code:: sh
+
+       sudo yum clean all
+       sudo yum update scylla\* -y
+
+Start the node
+--------------
+
+.. code:: sh
+
+   sudo systemctl start scylla-enterprise-server
+
+Validate
+--------
+1. Check cluster status with ``nodetool status`` and make sure **all** nodes, including the one you just upgraded, are in UN status.
+2. Use ``curl -X GET "http://localhost:10000/storage_service/scylla_release_version"`` to check the ScyllaDB version.
+3. Use ``journalctl _COMM=scylla`` to check there are no new errors in the log.
+4. Check again after 2 minutes to validate no new issues are introduced.
+
+Once you are sure the node upgrade is successful, move to the next node in the cluster.
+
+.. _upgrade-2022.x.y-to-2022.x.z-rpm-rollback-procedure:
+
+Rollback Procedure
+==================
+
+.. include:: /upgrade/_common/warning_rollback.rst
+
+The following procedure describes a rollback from ScyllaDB Enterprise release 2022.x.z to 2022.x.y. Apply this procedure if an upgrade from 2022.x.y to 2022.x.z failed before completing on all nodes. Use this procedure only for nodes you upgraded to 2022.x.z.
+
+ScyllaDB rollback is a rolling procedure which does **not** require a full cluster shutdown.
+For each of the nodes rollback to 2022.x.y, you will:
+
+* Drain the node and stop ScyllaDB
+* Downgrade to the previous release
+* Restore the configuration file
+* Restart ScyllaDB
+* Validate the rollback success
+
+Apply the following procedure **serially** on each node. Do not move to the next node before validating that the node is up and running the new version.
+
+
+Rollback Steps
+==============
+
+Gracefully shutdown ScyllaDB
+-----------------------------
+
+.. code:: sh
+
+   nodetool drain
+   sudo systemctl stop scylla-enterprise-server
+
+Downgrade to the previous release
+-----------------------------------
+
+Install:
+
+.. code:: sh
+
+   sudo yum downgrade scylla\*-2022.x.y-\* -y
+
+Restore the configuration file
+------------------------------
+
+.. code:: sh
+
+   sudo rm -rf /etc/scylla/scylla.yaml
+   sudo cp -a /etc/scylla/scylla.yaml.backup-2022.x.z /etc/scylla/scylla.yaml
+
+Start the node
+--------------
+
+.. code:: sh
+
+   sudo systemctl start scylla-enterprise-server
+
+Validate
+--------
+Check the upgrade instruction above for validation. Once you are sure the node rollback is successful, move to the next node in the cluster.

--- a/docs/upgrade/upgrade-enterprise/upgrade-guide-from-2022.x.y-to-2022.x.z/upgrade-guide-from-2022.x.y-to-2022.x.z-ubuntu-18-04.rst
+++ b/docs/upgrade/upgrade-enterprise/upgrade-guide-from-2022.x.y-to-2022.x.z/upgrade-guide-from-2022.x.y-to-2022.x.z-ubuntu-18-04.rst
@@ -1,0 +1,6 @@
+.. |OS| replace:: Ubuntu 16.04
+.. |ROLLBACK| replace:: rollback
+.. _ROLLBACK: /upgrade/upgrade-enterprise/upgrade-guide-from-2022.x.y-to-2022.x.z/upgrade-guide-from-2022.x.y-to-2022.x.z-ubuntu/#rollback-procedure
+.. |APT| replace:: ScyllaDB Enterprise deb repo
+.. _APT: https://www.scylladb.com/customer-portal/?product=ent&platform=ubuntu-16.04&version=stable-release-2022.1
+.. include:: /upgrade/_common/upgrade-guide-from-2022.x.y-to-2022.x.z-ubuntu-and-debian.rst

--- a/docs/upgrade/upgrade-enterprise/upgrade-guide-from-2022.x.y-to-2022.x.z/upgrade-guide-from-2022.x.y-to-2022.x.z-ubuntu-20-04.rst
+++ b/docs/upgrade/upgrade-enterprise/upgrade-guide-from-2022.x.y-to-2022.x.z/upgrade-guide-from-2022.x.y-to-2022.x.z-ubuntu-20-04.rst
@@ -1,0 +1,6 @@
+.. |OS| replace:: Ubuntu 20.04
+.. |ROLLBACK| replace:: rollback
+.. _ROLLBACK: /upgrade/upgrade-enterprise/upgrade-guide-from-2022.x.y-to-2022.x.z/upgrade-guide-from-2022.x.y-to-2022.x.z-ubuntu/#rollback-procedure
+.. |APT| replace:: ScyllaDB Enterprise deb repo
+.. _APT: https://www.scylladb.com/customer-portal/?product=ent&platform=ubuntu-20.04&version=stable-release-2022.1
+.. include:: /upgrade/_common/upgrade-guide-from-2022.x.y-to-2022.x.z-ubuntu-and-debian.rst


### PR DESCRIPTION
Fix https://github.com/scylladb/scylla-docs/issues/4041

I've added the upgrade guides from 2022.x.y to 2022.x.z. They are based on the previous upgrade guides for patch releases.