### PR TITLE
cql3: grammar: make the whereClause production return a single expression

### DIFF
--- a/cql3/Cql.g
+++ b/cql3/Cql.g
@@ -383,6 +383,7 @@ selectStatement returns [std::unique_ptr<raw::select_statement> expr]
         raw::select_statement::parameters::statement_subtype statement_subtype = raw::select_statement::parameters::statement_subtype::REGULAR;
         bool bypass_cache = false;
         auto attrs = std::make_unique<cql3::attributes::raw>();
+        expression wclause = conjunction{};
     }
     : K_SELECT (
                 ( K_JSON { statement_subtype = raw::select_statement::parameters::statement_subtype::JSON; } )?
@@ -390,7 +391,7 @@ selectStatement returns [std::unique_ptr<raw::select_statement> expr]
                 sclause=selectClause
                )
       K_FROM cf=columnFamilyName
-      ( K_WHERE wclause=whereClause )?
+      ( K_WHERE w=whereClause { wclause = std::move(w); } )?
       ( K_GROUP K_BY gbcolumns=listOfIdentifiers)?
       ( K_ORDER K_BY orderByClause[orderings] ( ',' orderByClause[orderings] )* )?
       ( K_PER K_PARTITION K_LIMIT rows=intValue { per_partition_limit = rows; } )?
@@ -445,8 +446,10 @@ countArgument
                 } }
     ;
 
-whereClause returns [std::vector<expression> clause]
-    : e1=relation { $clause.push_back(std::move(e1)); } (K_AND en=relation { $clause.push_back(std::move(en)); })*
+whereClause returns [expression clause]
+    @init { std::vector<expression> terms; }
+    : e1=relation { terms.push_back(std::move(e1)); } (K_AND en=relation { terms.push_back(std::move(en)); })*
+        { clause = conjunction{std::move(terms)}; }
     ;
 
 orderByClause[raw::select_statement::parameters::orderings_type& orderings]
@@ -595,8 +598,9 @@ pruneMaterializedViewStatement returns [std::unique_ptr<raw::select_statement> e
         raw::select_statement::parameters::statement_subtype statement_subtype = raw::select_statement::parameters::statement_subtype::PRUNE_MATERIALIZED_VIEW;
         bool bypass_cache = false;
         auto attrs = std::make_unique<cql3::attributes::raw>();
+        expression wclause = conjunction{};
     }
-	: K_PRUNE K_MATERIALIZED K_VIEW cf=columnFamilyName (K_WHERE wclause=whereClause)? ( usingClause[attrs] )?
+	: K_PRUNE K_MATERIALIZED K_VIEW cf=columnFamilyName (K_WHERE w=whereClause { wclause = std::move(w); } )? ( usingClause[attrs] )?
 	  {
 	        auto params = make_lw_shared<raw::select_statement::parameters>(std::move(orderings), is_distinct, allow_filtering, statement_subtype, bypass_cache);
 	        return std::make_unique<raw::select_statement>(std::move(cf), std::move(params),
@@ -874,10 +878,11 @@ createViewStatement returns [std::unique_ptr<create_view_statement> expr]
         bool if_not_exists = false;
         std::vector<::shared_ptr<cql3::column_identifier::raw>> partition_keys;
         std::vector<::shared_ptr<cql3::column_identifier::raw>> composite_keys;
+        expression wclause = conjunction{};
     }
     : K_CREATE K_MATERIALIZED K_VIEW (K_IF K_NOT K_EXISTS { if_not_exists = true; })? cf=columnFamilyName K_AS
         K_SELECT sclause=selectClause K_FROM basecf=columnFamilyName
-        (K_WHERE wclause=whereClause)?
+        (K_WHERE w=whereClause { wclause = std::move(w); } )?
         K_PRIMARY K_KEY (
         '(' '(' k1=cident { partition_keys.push_back(k1); } ( ',' kn=cident { partition_keys.push_back(kn); } )* ')' ( ',' c1=cident { composite_keys.push_back(c1); } )* ')'
     |   '(' k1=cident { partition_keys.push_back(k1); } ( ',' cn=cident { composite_keys.push_back(cn); } )* ')'

--- a/cql3/expr/expression.cc
+++ b/cql3/expr/expression.cc
@@ -46,6 +46,20 @@ logging::logger expr_logger("cql_expression");
 using boost::adaptors::filtered;
 using boost::adaptors::transformed;
 
+bool operator==(const expression& e1, const expression& e2) {
+    if (e1._v->v.index() != e2._v->v.index()) {
+        return false;
+    }
+    return expr::visit([&] <typename T> (const T& e1_element) {
+        const T& e2_element = expr::as<T>(e2);
+        return e1_element == e2_element;
+    }, e1);
+}
+
+bool operator!=(const expression& e1, const expression& e2) {
+    return !(e1 == e2);
+}
+
 expression::expression(const expression& o)
         : _v(std::make_unique<impl>(*o._v)) {
 }

--- a/cql3/expr/expression.cc
+++ b/cql3/expr/expression.cc
@@ -741,6 +741,25 @@ expression make_conjunction(expression a, expression b) {
     return conjunction{std::move(children)};
 }
 
+static
+void
+do_factorize(std::vector<expression>& factors, expression e) {
+    if (auto c = expr::as_if<conjunction>(&e)) {
+        for (auto&& element : c->children) {
+            do_factorize(factors, std::move(element));
+        }
+    } else {
+        factors.push_back(std::move(e));
+    }
+}
+
+std::vector<expression>
+boolean_factors(expression e) {
+    std::vector<expression> ret;
+    do_factorize(ret, std::move(e));
+    return ret;
+}
+
 template<typename T>
 nonwrapping_range<std::remove_cvref_t<T>> to_range(oper_t op, T&& val) {
     using U = std::remove_cvref_t<T>;

--- a/cql3/expr/expression.hh
+++ b/cql3/expr/expression.hh
@@ -186,7 +186,14 @@ public:
         const expression& expr_to_print;
         bool debug_mode = true;
     };
+
+    friend bool operator==(const expression& e1, const expression& e2);
 };
+
+/// Checks if two expressions are equal. If they are, they definitely
+/// perform the same computation. If they are unequal, they may perform
+/// the same computation or different computations.
+bool operator==(const expression& e1, const expression& e2);
 
 // An expression that doesn't contain subexpressions
 template <typename E>
@@ -207,6 +214,8 @@ struct column_value {
     const column_definition* col;
 
     column_value(const column_definition* col) : col(col) {}
+
+    friend bool operator==(const column_value&, const column_value&) = default;
 };
 
 /// A subscripted value, eg list_colum[2], val[sub]
@@ -214,6 +223,8 @@ struct subscript {
     expression val;
     expression sub;
     data_type type; // may be null before prepare
+
+    friend bool operator==(const subscript&, const subscript&) = default;
 };
 
 /// Gets the subscripted column_value out of the subscript.
@@ -232,6 +243,8 @@ struct token {
     explicit token(std::vector<expression>);
     explicit token(const std::vector<const column_definition*>&);
     explicit token(const std::vector<::shared_ptr<column_identifier_raw>>&);
+
+    friend bool operator==(const token&, const token&) = default;
 };
 
 enum class oper_t { EQ, NEQ, LT, LTE, GTE, GT, IN, CONTAINS, CONTAINS_KEY, IS_NOT, LIKE };
@@ -250,11 +263,15 @@ struct binary_operator {
     comparison_order order;
 
     binary_operator(expression lhs, oper_t op, expression rhs, comparison_order order = comparison_order::cql);
+
+    friend bool operator==(const binary_operator&, const binary_operator&) = default;
 };
 
 /// A conjunction of restrictions.
 struct conjunction {
     std::vector<expression> children;
+
+    friend bool operator==(const conjunction&, const conjunction&) = default;
 };
 
 // Gets resolved eventually into a column_value.
@@ -262,6 +279,8 @@ struct unresolved_identifier {
     ::shared_ptr<column_identifier_raw> ident;
 
     ~unresolved_identifier();
+
+    friend bool operator==(const unresolved_identifier&, const unresolved_identifier&) = default;
 };
 
 // An attribute attached to a column mutation: writetime or ttl
@@ -272,6 +291,8 @@ struct column_mutation_attribute {
     // note: only unresolved_identifier is legal here now. One day, when prepare()
     // on expressions yields expressions, column_value will also be legal here.
     expression column;
+
+    friend bool operator==(const column_mutation_attribute&, const column_mutation_attribute&) = default;
 };
 
 struct function_call {
@@ -306,21 +327,29 @@ struct function_call {
     //
     // This field can be nullptr, it means that there is no cache id set.
     ::shared_ptr<std::optional<uint8_t>> lwt_cache_id;
+
+    friend bool operator==(const function_call&, const function_call&) = default;
 };
 
 struct cast {
     expression arg;
     std::variant<data_type, shared_ptr<cql3_type::raw>> type;
+
+    friend bool operator==(const cast&, const cast&) = default;
 };
 
 struct field_selection {
     expression structure;
     shared_ptr<column_identifier_raw> field;
     data_type type; // may be null before prepare
+
+    friend bool operator==(const field_selection&, const field_selection&) = default;
 };
 
 struct null {
     data_type type; // may be null before prepare
+
+    friend bool operator==(const null&, const null&) = default;
 };
 
 struct bind_variable {
@@ -329,6 +358,8 @@ struct bind_variable {
     // Describes where this bound value will be assigned.
     // Contains value type and other useful information.
     ::lw_shared_ptr<column_specification> receiver;
+
+    friend bool operator==(const bind_variable&, const bind_variable&) = default;
 };
 
 // A constant which does not yet have a date type. It is partially typed
@@ -337,6 +368,8 @@ struct untyped_constant {
     enum type_class { integer, floating_point, string, boolean, duration, uuid, hex };
     type_class partial_type;
     sstring raw_text;
+
+    friend bool operator==(const untyped_constant&, const untyped_constant&) = default;
 };
 
 // Represents a constant value with known value and type
@@ -359,6 +392,8 @@ struct constant {
     bool has_empty_value_bytes() const;
 
     cql3::raw_value_view view() const;
+
+    friend bool operator==(const constant&, const constant&) = default;
 };
 
 // Denotes construction of a tuple from its elements, e.g.  ('a', ?, some_column) in CQL.
@@ -368,6 +403,8 @@ struct tuple_constructor {
     // Might be nullptr before prepare.
     // After prepare always holds a valid type, although it might be reversed_type(tuple_type).
     data_type type;
+
+    friend bool operator==(const tuple_constructor&, const tuple_constructor&) = default;
 };
 
 // Constructs a collection of same-typed elements
@@ -379,6 +416,8 @@ struct collection_constructor {
     // Might be nullptr before prepare.
     // After prepare always holds a valid type, although it might be reversed_type(collection_type).
     data_type type;
+
+    friend bool operator==(const collection_constructor&, const collection_constructor&) = default;
 };
 
 // Constructs an object of a user-defined type
@@ -389,6 +428,8 @@ struct usertype_constructor {
     // Might be nullptr before prepare.
     // After prepare always holds a valid type, although it might be reversed_type(user_type).
     data_type type;
+
+    friend bool operator==(const usertype_constructor&, const usertype_constructor&) = default;
 };
 
 // now that all expression types are fully defined, we can define expression::impl

--- a/cql3/expr/expression.hh
+++ b/cql3/expr/expression.hh
@@ -661,6 +661,11 @@ inline auto find_clustering_order(const expression& e) {
     return find_binop(e, is_clustering_order);
 }
 
+/// Given a Boolean expression, compute its factors such as e=f1 AND f2 AND f3 ...
+/// If the expression is TRUE, may return no factors (happens today for an
+/// empty conjunction).
+std::vector<expression> boolean_factors(expression e);
+
 /// True iff binary_operator involves a collection.
 extern bool is_on_collection(const binary_operator&);
 

--- a/cql3/restrictions/statement_restrictions.cc
+++ b/cql3/restrictions/statement_restrictions.cc
@@ -333,20 +333,18 @@ statement_restrictions::statement_restrictions(data_dictionary::database db,
         bool allow_filtering)
     : statement_restrictions(schema, allow_filtering)
 {
-    if (!where_clause.empty()) {
-        for (auto&& relation_expr : where_clause) {
-            const expr::binary_operator* relation_binop = expr::as_if<expr::binary_operator>(&relation_expr);
+    for (auto&& relation_expr : where_clause) {
+        const expr::binary_operator* relation_binop = expr::as_if<expr::binary_operator>(&relation_expr);
 
-            if (relation_binop == nullptr) {
-                on_internal_error(rlogger, format("statement_restrictions: where clause has non-binop element: {}", relation_expr));
-            }
+        if (relation_binop == nullptr) {
+            on_internal_error(rlogger, format("statement_restrictions: where clause has non-binop element: {}", relation_expr));
+        }
 
-            expr::binary_operator prepared_restriction = expr::validate_and_prepare_new_restriction(*relation_binop, db, schema, ctx);
-            add_restriction(prepared_restriction, schema, allow_filtering, for_view);
+        expr::binary_operator prepared_restriction = expr::validate_and_prepare_new_restriction(*relation_binop, db, schema, ctx);
+        add_restriction(prepared_restriction, schema, allow_filtering, for_view);
 
-            if (prepared_restriction.op != expr::oper_t::IS_NOT) {
-                _where = _where.has_value() ? make_conjunction(std::move(*_where), prepared_restriction) : prepared_restriction;
-            }
+        if (prepared_restriction.op != expr::oper_t::IS_NOT) {
+            _where = _where.has_value() ? make_conjunction(std::move(*_where), prepared_restriction) : prepared_restriction;
         }
     }
     if (_where.has_value()) {

--- a/cql3/restrictions/statement_restrictions.cc
+++ b/cql3/restrictions/statement_restrictions.cc
@@ -326,14 +326,14 @@ static std::vector<expr::expression> extract_clustering_prefix_restrictions(
 statement_restrictions::statement_restrictions(data_dictionary::database db,
         schema_ptr schema,
         statements::statement_type type,
-        const std::vector<expr::expression>& where_clause,
+        const expr::expression& where_clause,
         prepare_context& ctx,
         bool selects_only_static_columns,
         bool for_view,
         bool allow_filtering)
     : statement_restrictions(schema, allow_filtering)
 {
-    for (auto&& relation_expr : where_clause) {
+    for (auto&& relation_expr : boolean_factors(where_clause)) {
         const expr::binary_operator* relation_binop = expr::as_if<expr::binary_operator>(&relation_expr);
 
         if (relation_binop == nullptr) {

--- a/cql3/restrictions/statement_restrictions.hh
+++ b/cql3/restrictions/statement_restrictions.hh
@@ -122,7 +122,7 @@ public:
     statement_restrictions(data_dictionary::database db,
         schema_ptr schema,
         statements::statement_type type,
-        const std::vector<expr::expression>& where_clause,
+        const expr::expression& where_clause,
         prepare_context& ctx,
         bool selects_only_static_columns,
         bool for_view = false,

--- a/cql3/statements/create_view_statement.cc
+++ b/cql3/statements/create_view_statement.cc
@@ -46,7 +46,7 @@ create_view_statement::create_view_statement(
         cf_name view_name,
         cf_name base_name,
         std::vector<::shared_ptr<selection::raw_selector>> select_clause,
-        std::vector<expr::expression> where_clause,
+        expr::expression where_clause,
         std::vector<::shared_ptr<cql3::column_identifier::raw>> partition_keys,
         std::vector<::shared_ptr<cql3::column_identifier::raw>> clustering_keys,
         bool if_not_exists)
@@ -312,7 +312,7 @@ view_ptr create_view_statement::prepare_view(data_dictionary::database db) const
                 "the corresponding data in the parent table.");
     }
 
-    auto where_clause_text = util::relations_to_where_clause(expr::conjunction{_where_clause});
+    auto where_clause_text = util::relations_to_where_clause(_where_clause);
     builder.with_view_info(schema->id(), schema->cf_name(), included.empty(), std::move(where_clause_text));
 
     return view_ptr(builder.build());

--- a/cql3/statements/create_view_statement.cc
+++ b/cql3/statements/create_view_statement.cc
@@ -312,7 +312,7 @@ view_ptr create_view_statement::prepare_view(data_dictionary::database db) const
                 "the corresponding data in the parent table.");
     }
 
-    auto where_clause_text = util::relations_to_where_clause(_where_clause);
+    auto where_clause_text = util::relations_to_where_clause(expr::conjunction{_where_clause});
     builder.with_view_info(schema->id(), schema->cf_name(), included.empty(), std::move(where_clause_text));
 
     return view_ptr(builder.build());

--- a/cql3/statements/create_view_statement.hh
+++ b/cql3/statements/create_view_statement.hh
@@ -33,7 +33,7 @@ class create_view_statement : public schema_altering_statement {
 private:
     mutable cf_name _base_name;
     std::vector<::shared_ptr<selection::raw_selector>> _select_clause;
-    std::vector<expr::expression> _where_clause;
+    expr::expression _where_clause;
     std::vector<::shared_ptr<cql3::column_identifier::raw>> _partition_keys;
     std::vector<::shared_ptr<cql3::column_identifier::raw>> _clustering_keys;
     cf_properties _properties;
@@ -46,7 +46,7 @@ public:
             cf_name view_name,
             cf_name base_name,
             std::vector<::shared_ptr<selection::raw_selector>> select_clause,
-            std::vector<expr::expression> where_clause,
+            expr::expression where_clause,
             std::vector<::shared_ptr<cql3::column_identifier::raw>> partition_keys,
             std::vector<::shared_ptr<cql3::column_identifier::raw>> clustering_keys,
             bool if_not_exists);

--- a/cql3/statements/delete_statement.cc
+++ b/cql3/statements/delete_statement.cc
@@ -92,7 +92,7 @@ delete_statement::prepare_internal(data_dictionary::database db, schema_ptr sche
 delete_statement::delete_statement(cf_name name,
                                  std::unique_ptr<attributes::raw> attrs,
                                  std::vector<std::unique_ptr<operation::raw_deletion>> deletions,
-                                 std::vector<expr::expression> where_clause,
+                                 expr::expression where_clause,
                                  conditions_vector conditions,
                                  bool if_exists)
     : raw::modification_statement(std::move(name), std::move(attrs), std::move(conditions), false, if_exists)

--- a/cql3/statements/modification_statement.cc
+++ b/cql3/statements/modification_statement.cc
@@ -373,7 +373,7 @@ void modification_statement::build_cas_result_set_metadata() {
 
 void
 modification_statement::process_where_clause(data_dictionary::database db, std::vector<expr::expression> where_clause, prepare_context& ctx) {
-    _restrictions = restrictions::statement_restrictions(db, s, type, where_clause, ctx,
+    _restrictions = restrictions::statement_restrictions(db, s, type, expr::conjunction{where_clause}, ctx,
             applies_only_to_static_columns(), _selects_a_collection, false);
     /*
      * If there's no clustering columns restriction, we may assume that EXISTS

--- a/cql3/statements/modification_statement.cc
+++ b/cql3/statements/modification_statement.cc
@@ -372,8 +372,8 @@ void modification_statement::build_cas_result_set_metadata() {
 }
 
 void
-modification_statement::process_where_clause(data_dictionary::database db, std::vector<expr::expression> where_clause, prepare_context& ctx) {
-    _restrictions = restrictions::statement_restrictions(db, s, type, expr::conjunction{where_clause}, ctx,
+modification_statement::process_where_clause(data_dictionary::database db, expr::expression where_clause, prepare_context& ctx) {
+    _restrictions = restrictions::statement_restrictions(db, s, type, where_clause, ctx,
             applies_only_to_static_columns(), _selects_a_collection, false);
     /*
      * If there's no clustering columns restriction, we may assume that EXISTS

--- a/cql3/statements/modification_statement.hh
+++ b/cql3/statements/modification_statement.hh
@@ -162,7 +162,7 @@ public:
         return _is_raw_counter_shard_write.value_or(false);
     }
 
-    void process_where_clause(data_dictionary::database db, std::vector<expr::expression> where_clause, prepare_context& ctx);
+    void process_where_clause(data_dictionary::database db, expr::expression where_clause, prepare_context& ctx);
 
     // CAS statement returns a result set. Prepare result set metadata
     // so that get_result_metadata() returns a meaningful value.

--- a/cql3/statements/raw/delete_statement.hh
+++ b/cql3/statements/raw/delete_statement.hh
@@ -28,12 +28,12 @@ namespace raw {
 class delete_statement : public modification_statement {
 private:
     std::vector<std::unique_ptr<operation::raw_deletion>> _deletions;
-    std::vector<expr::expression> _where_clause;
+    expr::expression _where_clause;
 public:
     delete_statement(cf_name name,
            std::unique_ptr<attributes::raw> attrs,
            std::vector<std::unique_ptr<operation::raw_deletion>> deletions,
-           std::vector<expr::expression> where_clause,
+           expr::expression where_clause,
            conditions_vector conditions,
            bool if_exists);
 protected:

--- a/cql3/statements/raw/select_statement.hh
+++ b/cql3/statements/raw/select_statement.hh
@@ -82,7 +82,7 @@ private:
 private:
     lw_shared_ptr<const parameters> _parameters;
     std::vector<::shared_ptr<selection::raw_selector>> _select_clause;
-    std::vector<expr::expression> _where_clause;
+    expr::expression _where_clause;
     std::optional<expr::expression> _limit;
     std::optional<expr::expression> _per_partition_limit;
     std::vector<::shared_ptr<cql3::column_identifier::raw>> _group_by_columns;
@@ -91,7 +91,7 @@ public:
     select_statement(cf_name cf_name,
             lw_shared_ptr<const parameters> parameters,
             std::vector<::shared_ptr<selection::raw_selector>> select_clause,
-            std::vector<expr::expression> where_clause,
+            expr::expression where_clause,
             std::optional<expr::expression> limit,
             std::optional<expr::expression> per_partition_limit,
             std::vector<::shared_ptr<cql3::column_identifier::raw>> group_by_columns,

--- a/cql3/statements/raw/update_statement.hh
+++ b/cql3/statements/raw/update_statement.hh
@@ -31,7 +31,7 @@ class update_statement : public raw::modification_statement {
 private:
     // Provided for an UPDATE
     std::vector<std::pair<::shared_ptr<column_identifier::raw>, std::unique_ptr<operation::raw_update>>> _updates;
-    std::vector<expr::expression> _where_clause;
+    expr::expression _where_clause;
 public:
     /**
      * Creates a new UpdateStatement from a column family name, columns map, consistency
@@ -45,7 +45,7 @@ public:
     update_statement(cf_name name,
         std::unique_ptr<attributes::raw> attrs,
         std::vector<std::pair<::shared_ptr<column_identifier::raw>, std::unique_ptr<operation::raw_update>>> updates,
-        std::vector<expr::expression> where_clause,
+        expr::expression where_clause,
         conditions_vector conditions, bool if_exists);
 protected:
     virtual ::shared_ptr<cql3::statements::modification_statement> prepare_internal(data_dictionary::database db, schema_ptr schema,

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -1719,7 +1719,7 @@ select_statement::prepare_restrictions(data_dictionary::database db,
                                        bool allow_filtering)
 {
     try {
-        return ::make_shared<restrictions::statement_restrictions>(db, schema, statement_type::SELECT, std::move(_where_clause), ctx,
+        return ::make_shared<restrictions::statement_restrictions>(db, schema, statement_type::SELECT, _where_clause, ctx,
             selection->contains_only_static_columns(), for_view, allow_filtering);
     } catch (const exceptions::unrecognized_entity_exception& e) {
         if (contains_alias(e.entity)) {

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -1537,7 +1537,7 @@ static void validate_attrs(const cql3::attributes::raw& attrs) {
 select_statement::select_statement(cf_name cf_name,
                                    lw_shared_ptr<const parameters> parameters,
                                    std::vector<::shared_ptr<selection::raw_selector>> select_clause,
-                                   std::vector<expr::expression> where_clause,
+                                   expr::expression where_clause,
                                    std::optional<expr::expression> limit,
                                    std::optional<expr::expression> per_partition_limit,
                                    std::vector<::shared_ptr<cql3::column_identifier::raw>> group_by_columns,
@@ -1719,7 +1719,7 @@ select_statement::prepare_restrictions(data_dictionary::database db,
                                        bool allow_filtering)
 {
     try {
-        return ::make_shared<restrictions::statement_restrictions>(db, schema, statement_type::SELECT, expr::conjunction{_where_clause}, ctx,
+        return ::make_shared<restrictions::statement_restrictions>(db, schema, statement_type::SELECT, _where_clause, ctx,
             selection->contains_only_static_columns(), for_view, allow_filtering);
     } catch (const exceptions::unrecognized_entity_exception& e) {
         if (contains_alias(e.entity)) {
@@ -2013,8 +2013,8 @@ namespace {
 
 /// True iff one of \p relations is a single-column EQ involving \p def.
 bool equality_restricted(
-        const column_definition& def, const schema& schema, const std::vector<expr::expression>& relations) {
-    for (const auto& relation : relations) {
+        const column_definition& def, const schema& schema, const expr::expression& relations) {
+    for (const auto& relation : boolean_factors(relations)) {
         if (auto binop = expr::as_if<expr::binary_operator>(&relation)) {
             if (binop->op != expr::oper_t::EQ) {
                 continue;

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -1719,7 +1719,7 @@ select_statement::prepare_restrictions(data_dictionary::database db,
                                        bool allow_filtering)
 {
     try {
-        return ::make_shared<restrictions::statement_restrictions>(db, schema, statement_type::SELECT, _where_clause, ctx,
+        return ::make_shared<restrictions::statement_restrictions>(db, schema, statement_type::SELECT, expr::conjunction{_where_clause}, ctx,
             selection->contains_only_static_columns(), for_view, allow_filtering);
     } catch (const exceptions::unrecognized_entity_exception& e) {
         if (contains_alias(e.entity)) {

--- a/cql3/statements/update_statement.cc
+++ b/cql3/statements/update_statement.cc
@@ -310,7 +310,7 @@ insert_statement::prepare_internal(data_dictionary::database db, schema_ptr sche
         };
     }
     prepare_conditions(db, *schema, ctx, *stmt);
-    stmt->process_where_clause(db, relations, ctx);
+    stmt->process_where_clause(db, expr::conjunction{relations}, ctx);
     return stmt;
 }
 
@@ -343,7 +343,7 @@ insert_json_statement::prepare_internal(data_dictionary::database db, schema_ptr
 update_statement::update_statement(cf_name name,
                                    std::unique_ptr<attributes::raw> attrs,
                                    std::vector<std::pair<::shared_ptr<column_identifier::raw>, std::unique_ptr<operation::raw_update>>> updates,
-                                   std::vector<expr::expression> where_clause,
+                                   expr::expression where_clause,
                                    conditions_vector conditions, bool if_exists)
     : raw::modification_statement(std::move(name), std::move(attrs), std::move(conditions), false, if_exists)
     , _updates(std::move(updates))

--- a/cql3/util.cc
+++ b/cql3/util.cc
@@ -120,5 +120,46 @@ void validate_timestamp(const query_options& options, const std::unique_ptr<attr
     }
 }
 
+sstring relations_to_where_clause(const expr::expression& e) {
+    auto expr_to_pretty_string = [](const expr::expression& e) -> sstring {
+        expr::expression::printer p {
+            .expr_to_print = e,
+            .debug_mode = false,
+        };
+        return fmt::format("{}", p);
+    };
+    auto relations = expr::boolean_factors(e);
+    auto expressions = relations | boost::adaptors::transformed(expr_to_pretty_string);
+    return boost::algorithm::join(expressions, " AND ");
+}
+
+expr::expression where_clause_to_relations(const sstring_view& where_clause) {
+    return expr::conjunction{do_with_parser(where_clause, std::mem_fn(&cql3_parser::CqlParser::whereClause))};
+}
+
+sstring rename_column_in_where_clause(const sstring_view& where_clause, column_identifier::raw from, column_identifier::raw to) {
+    std::vector<expr::expression> relations = boolean_factors(where_clause_to_relations(where_clause));
+    std::vector<expr::expression> new_relations;
+    new_relations.reserve(relations.size());
+
+    for (const expr::expression& old_relation : relations) {
+        expr::expression new_relation = expr::search_and_replace(old_relation,
+            [&](const expr::expression& e) -> std::optional<expr::expression> {
+                if (auto ident = expr::as_if<expr::unresolved_identifier>(&e)) {
+                    if (*ident->ident == from) {
+                        return expr::unresolved_identifier{
+                            ::make_shared<column_identifier::raw>(to)
+                        };
+                    }
+                }
+                return std::nullopt;
+            }
+        );
+
+        new_relations.emplace_back(std::move(new_relation));
+    }
+
+    return relations_to_where_clause(expr::conjunction{std::move(new_relations)});
+}
 
 }

--- a/cql3/util.cc
+++ b/cql3/util.cc
@@ -134,7 +134,7 @@ sstring relations_to_where_clause(const expr::expression& e) {
 }
 
 expr::expression where_clause_to_relations(const sstring_view& where_clause) {
-    return expr::conjunction{do_with_parser(where_clause, std::mem_fn(&cql3_parser::CqlParser::whereClause))};
+    return do_with_parser(where_clause, std::mem_fn(&cql3_parser::CqlParser::whereClause));
 }
 
 sstring rename_column_in_where_clause(const sstring_view& where_clause, column_identifier::raw from, column_identifier::raw to) {

--- a/cql3/util.hh
+++ b/cql3/util.hh
@@ -38,48 +38,11 @@ Result do_with_parser(const sstring_view& cql, Func&& f) {
     return std::move(*ret);
 }
 
-inline
-sstring relations_to_where_clause(const expr::expression& e) {
-    auto expr_to_pretty_string = [](const expr::expression& e) -> sstring {
-        expr::expression::printer p {
-            .expr_to_print = e,
-            .debug_mode = false,
-        };
-        return fmt::format("{}", p);
-    };
-    auto relations = expr::boolean_factors(e);
-    auto expressions = relations | boost::adaptors::transformed(expr_to_pretty_string);
-    return boost::algorithm::join(expressions, " AND ");
-}
+sstring relations_to_where_clause(const expr::expression& e);
 
-static expr::expression where_clause_to_relations(const sstring_view& where_clause) {
-    return expr::conjunction{do_with_parser(where_clause, std::mem_fn(&cql3_parser::CqlParser::whereClause))};
-}
+expr::expression where_clause_to_relations(const sstring_view& where_clause);
 
-inline sstring rename_column_in_where_clause(const sstring_view& where_clause, column_identifier::raw from, column_identifier::raw to) {
-    std::vector<expr::expression> relations = boolean_factors(where_clause_to_relations(where_clause));
-    std::vector<expr::expression> new_relations;
-    new_relations.reserve(relations.size());
-
-    for (const expr::expression& old_relation : relations) {
-        expr::expression new_relation = expr::search_and_replace(old_relation,
-            [&](const expr::expression& e) -> std::optional<expr::expression> {
-                if (auto ident = expr::as_if<expr::unresolved_identifier>(&e)) {
-                    if (*ident->ident == from) {
-                        return expr::unresolved_identifier{
-                            ::make_shared<column_identifier::raw>(to)
-                        };
-                    }
-                }
-                return std::nullopt;
-            }
-        );
-
-        new_relations.emplace_back(std::move(new_relation));
-    }
-
-    return relations_to_where_clause(expr::conjunction{std::move(new_relations)});
-}
+sstring rename_column_in_where_clause(const sstring_view& where_clause, column_identifier::raw from, column_identifier::raw to);
 
 /// build a CQL "select" statement with the desired parameters.
 /// If select_all_columns==true, all columns are selected and the value of

--- a/cql3/util.hh
+++ b/cql3/util.hh
@@ -38,8 +38,8 @@ Result do_with_parser(const sstring_view& cql, Func&& f) {
     return std::move(*ret);
 }
 
-template<typename Range> // Range<expr::expression>
-sstring relations_to_where_clause(Range&& relations) {
+inline
+sstring relations_to_where_clause(const expr::expression& e) {
     auto expr_to_pretty_string = [](const expr::expression& e) -> sstring {
         expr::expression::printer p {
             .expr_to_print = e,
@@ -47,16 +47,17 @@ sstring relations_to_where_clause(Range&& relations) {
         };
         return fmt::format("{}", p);
     };
+    auto relations = expr::boolean_factors(e);
     auto expressions = relations | boost::adaptors::transformed(expr_to_pretty_string);
     return boost::algorithm::join(expressions, " AND ");
 }
 
-static std::vector<expr::expression> where_clause_to_relations(const sstring_view& where_clause) {
-    return do_with_parser(where_clause, std::mem_fn(&cql3_parser::CqlParser::whereClause));
+static expr::expression where_clause_to_relations(const sstring_view& where_clause) {
+    return expr::conjunction{do_with_parser(where_clause, std::mem_fn(&cql3_parser::CqlParser::whereClause))};
 }
 
 inline sstring rename_column_in_where_clause(const sstring_view& where_clause, column_identifier::raw from, column_identifier::raw to) {
-    std::vector<expr::expression> relations = where_clause_to_relations(where_clause);
+    std::vector<expr::expression> relations = boolean_factors(where_clause_to_relations(where_clause));
     std::vector<expr::expression> new_relations;
     new_relations.reserve(relations.size());
 
@@ -77,7 +78,7 @@ inline sstring rename_column_in_where_clause(const sstring_view& where_clause, c
         new_relations.emplace_back(std::move(new_relation));
     }
 
-    return relations_to_where_clause(std::move(new_relations));
+    return relations_to_where_clause(expr::conjunction{std::move(new_relations)});
 }
 
 /// build a CQL "select" statement with the desired parameters.

--- a/cql3/values.cc
+++ b/cql3/values.cc
@@ -58,4 +58,24 @@ raw_value_view::raw_value_view(managed_bytes&& tmp) {
     _data = managed_bytes_view(*_temporary_storage);
 }
 
+bool operator==(const raw_value& v1, const raw_value& v2) {
+    if (v1.is_unset_value() && v2.is_unset_value()) {
+        return true;
+    }
+
+    if (v1.is_null() && v2.is_null()) {
+        return true; // note: this is not CQL comparison which would return NULL here
+    }
+
+    if (v1.is_value() && v2.is_value()) {
+        return v1.view().with_value([&] (const FragmentedView auto& v1v) {
+            return v2.view().with_value([&] (const FragmentedView auto& v2v) {
+                return compare_unsigned(v1v, v2v) == 0;
+            });
+        });
+    }
+
+    return false;
+}
+
 }

--- a/cql3/values.hh
+++ b/cql3/values.hh
@@ -23,9 +23,11 @@
 namespace cql3 {
 
 struct null_value {
+    friend bool operator==(const null_value&, const null_value) { return true; }
 };
 
 struct unset_value {
+    friend bool operator==(const unset_value&, const unset_value) { return true; }
 };
 
 class raw_value;
@@ -269,6 +271,8 @@ public:
     }
     raw_value_view view() const;
     friend class raw_value_view;
+
+    friend bool operator==(const raw_value& v1, const raw_value& v2);
 };
 
 }

--- a/test/boost/expr_test.cc
+++ b/test/boost/expr_test.cc
@@ -336,7 +336,7 @@ BOOST_AUTO_TEST_CASE(expr_printer_parse_and_print_test) {
     };
 
     for(const char* test : tests) {
-        std::vector<expression> parsed_where = cql3::util::where_clause_to_relations(test);
+        expression parsed_where = cql3::util::where_clause_to_relations(test);
         sstring printed_where = cql3::util::relations_to_where_clause(parsed_where);
 
         BOOST_REQUIRE_EQUAL(sstring(test), printed_where);

--- a/test/boost/expr_test.cc
+++ b/test/boost/expr_test.cc
@@ -342,3 +342,37 @@ BOOST_AUTO_TEST_CASE(expr_printer_parse_and_print_test) {
         BOOST_REQUIRE_EQUAL(sstring(test), printed_where);
     }
 }
+
+BOOST_AUTO_TEST_CASE(boolean_factors_test) {
+    BOOST_REQUIRE_EQUAL(boolean_factors(constant::make_bool(true)), std::vector<expression>({constant::make_bool(true)}));
+
+    BOOST_REQUIRE_EQUAL(boolean_factors(constant::make_null(boolean_type)), std::vector<expression>({constant::make_null(boolean_type)}));
+
+    bind_variable bv1{0};
+    bind_variable bv2{1};
+    bind_variable bv3{2};
+    bind_variable bv4{3};
+
+    BOOST_REQUIRE_EQUAL(
+        boolean_factors(
+            conjunction{std::vector<expression>({bv1, bv2, bv3, bv4})}
+        ),
+        std::vector<expression>(
+            {bv1, bv2, bv3, bv4}
+        )
+    );
+
+    BOOST_REQUIRE_EQUAL(
+        boolean_factors(
+            conjunction{
+                std::vector<expression>({
+                    make_conjunction(bv1, bv2),
+                    make_conjunction(bv3, bv4)
+                })
+            }
+        ),
+        std::vector<expression>(
+            {bv1, bv2, bv3, bv4}
+        )
+    );
+}

--- a/test/boost/statement_restrictions_test.cc
+++ b/test/boost/statement_restrictions_test.cc
@@ -30,7 +30,7 @@ query::clustering_row_ranges slice(
             env.data_dictionary(),
             env.local_db().find_schema(keyspace_name, table_name),
             statements::statement_type::SELECT,
-            where_clause,
+            expr::conjunction{where_clause},
             ctx,
             /*contains_only_static_columns=*/false,
             /*for_view=*/false,

--- a/test/boost/statement_restrictions_test.cc
+++ b/test/boost/statement_restrictions_test.cc
@@ -43,7 +43,7 @@ query::clustering_row_ranges slice(
 query::clustering_row_ranges slice_parse(
         sstring_view where_clause, cql_test_env& env,
         const sstring& table_name = "t", const sstring& keyspace_name = "ks") {
-    return slice(cql3::util::where_clause_to_relations(where_clause), env, table_name, keyspace_name);
+    return slice(boolean_factors(cql3::util::where_clause_to_relations(where_clause)), env, table_name, keyspace_name);
 }
 
 auto I(int32_t x) { return int32_type->decompose(x); }


### PR DESCRIPTION
Currently, the WHERE clause grammar is constrained to a conjunction of
relations: `WHERE a = ? AND b = ? AND c > ?`. The restriction happens in three
places:

1. the grammar will refuse to parse anything else
2. our filtering code isn't prepared for generic expressions
3. the interface between the grammar and the rest of the cql3 layer is via a vector of terms rather than an expression

While most of the work will be in extending the filtering code, this series tackles the
interface; it changes the `whereClause` production to return an expression rather than
a vector. Since much of cql3 layer is interested in terms, a new boolean_factors() function
is introduced to convert an expression to its boolean terms.