### PR TITLE
sstables: Enforce disjoint invariant in sstable_run

### DIFF
--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -811,6 +811,10 @@ public:
     // This will change sstable level only in memory.
     void set_sstable_level(uint32_t);
 
+    void generate_new_run_identifier() {
+        _run_identifier = utils::make_random_uuid();
+    }
+
     double get_compression_ratio() const;
 
     const sstables::compression& get_compression() const {

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -1056,6 +1056,42 @@ SEASTAR_TEST_CASE(check_overlapping) {
   });
 }
 
+SEASTAR_TEST_CASE(sstable_run_disjoint_invariant_test) {
+    return test_env::do_with([] (test_env& env) {
+        simple_schema ss;
+        auto s = ss.schema();
+
+        auto key_and_token_pair = token_generation_for_current_shard(6);
+        auto next_gen = [gen = make_lw_shared<unsigned>(1)] { return (*gen)++; };
+
+        sstables::sstable_run run;
+
+        auto insert = [&] (int first_key_idx, int last_key_idx) {
+            auto sst = sstable_for_overlapping_test(env, s, next_gen(),
+                key_and_token_pair[first_key_idx].first, key_and_token_pair[last_key_idx].first);
+            return run.insert(sst);
+        };
+
+        // insert ranges [0, 0], [1, 1], [3, 4]
+        BOOST_REQUIRE(insert(0, 0) == true);
+        BOOST_REQUIRE(insert(1, 1) == true);
+        BOOST_REQUIRE(insert(3, 4) == true);
+        BOOST_REQUIRE(run.all().size() == 3);
+
+        // check overlapping candidates won't be inserted
+        BOOST_REQUIRE(insert(0, 4) == false);
+        BOOST_REQUIRE(insert(4, 5) == false);
+        BOOST_REQUIRE(run.all().size() == 3);
+
+        // check non-overlapping candidates will be inserted
+        BOOST_REQUIRE(insert(2, 2) == true);
+        BOOST_REQUIRE(insert(5, 5) == true);
+        BOOST_REQUIRE(run.all().size() == 5);
+
+        return make_ready_future<>();
+    });
+}
+
 SEASTAR_TEST_CASE(tombstone_purge_test) {
     BOOST_REQUIRE(smp::count == 1);
     return test_env::do_with_async([] (test_env& env) {
@@ -3514,10 +3550,6 @@ SEASTAR_TEST_CASE(incremental_compaction_data_resurrection_test) {
 
         auto non_expired_sst = make_sstable_containing(sst_gen, {mut1, mut2, mut3});
         auto expired_sst = make_sstable_containing(sst_gen, {mut1_deletion});
-        // make ssts belong to same run for compaction to enable incremental approach
-        utils::UUID run_id = utils::make_random_uuid();
-        sstables::test(non_expired_sst).set_run_identifier(run_id);
-        sstables::test(expired_sst).set_run_identifier(run_id);
 
         std::vector<shared_sstable> sstables = {
                 non_expired_sst,
@@ -3570,6 +3602,12 @@ SEASTAR_TEST_CASE(incremental_compaction_data_resurrection_test) {
             // force compaction failure after sstable containing expired tombstone is removed from set.
             throw std::runtime_error("forcing compaction failure on early replacement");
         };
+
+        // make ssts belong to same run for compaction to enable incremental approach.
+        // That needs to happen after fragments were inserted into sstable_set, as they'll placed into different runs due to detected overlapping.
+        utils::UUID run_id = utils::make_random_uuid();
+        sstables::test(non_expired_sst).set_run_identifier(run_id);
+        sstables::test(expired_sst).set_run_identifier(run_id);
 
         bool swallowed = false;
         try {


### PR DESCRIPTION
We know that sstable_run is supposed to contain disjoint files only,
but this assumption can temporarily break when switching strategies
as TWCS, for example, can incorrectly pick the same run id for
sstables in different windows during segregation. So when switching
from TWCS to ICS, it could happen a sstable_run won't contain disjoint
files. We should definitely fix TWCS and any other strategy doing
that, but sstable_run should have disjointness as actual invariant,
not be relaxed on it. Otherwise, we cannot build readers on this
assumption, so more complicated logic have to be added to merge
overlapping files.
After this patch, sstable_run will reject insertion of a file that
will cause the invariant to break, so caller will have to check
that and push that file into a different sstable run.