### PR TITLE
forward_service: reduce allocations in forward_service

### DIFF
--- a/service/forward_service.cc
+++ b/service/forward_service.cc
@@ -69,15 +69,17 @@ public:
 
     template<typename Func>
     auto with_thread_if_needed(Func&& func) const {
-        bool required = std::any_of(_funcs.cbegin(), _funcs.cend(), [](const ::shared_ptr<db::functions::aggregate_function>& f) { 
-            return f->requires_thread(); 
-        });
-
-        if (required) {
+        if (requires_thread()) {
             return async(std::move(func));
         } else {
             return futurize_invoke(std::move(func));
         }
+    }
+
+    bool requires_thread() const {
+        return std::any_of(_funcs.cbegin(), _funcs.cend(), [](const ::shared_ptr<db::functions::aggregate_function>& f) {
+            return f->requires_thread();
+        });
     }
 };
 


### PR DESCRIPTION
This series refactors the code to get rid of unnecessary
allocations by extracing a helper requires_thread() function,
as well as by removing std::optional usage in forward_result,
now that it's possible to merge empty results with each other,
both ways (#11064).
