### PR TITLE
test.py: remove unused global

### DIFF
--- a/test/pylib/random_tables.py
+++ b/test/pylib/random_tables.py
@@ -41,7 +41,6 @@ if TYPE_CHECKING:
 
 
 logger = logging.getLogger('random_tables')
-new_keyspace_id = itertools.count(start=1).__next__
 
 
 class ColumnNotFound(Exception):


### PR DESCRIPTION
random_tables gets the keyspace from caller so remove leftover counter.

Signed-off-by: Alejo Sanchez <alejo.sanchez@scylladb.com>