### PR TITLE
mutation: Ignore dummy rows when consuming clustering fragments

### DIFF
--- a/test/boost/mutation_test.cc
+++ b/test/boost/mutation_test.cc
@@ -2567,6 +2567,49 @@ SEASTAR_THREAD_TEST_CASE(test_mutation_consume_position_monotonicity) {
     }
 }
 
+SEASTAR_TEST_CASE(mutation_with_dummy_clustering_row_is_consumed_monotonically) {
+    return seastar::async([] {
+        tests::reader_concurrency_semaphore_wrapper semaphore;
+        schema_ptr s = schema_builder{"ks", "cf"}
+            .with_column("pk", bytes_type, column_kind::partition_key)
+            .with_column("ck1", bytes_type, column_kind::clustering_key)
+            .build();
+
+        clustering_key ck_e{std::vector<bytes>{}};
+        clustering_key ck_0{{serialized((int32_t)0)}};
+        clustering_key ck_1{{serialized((int32_t)1)}};
+        clustering_key ck_2{{serialized((int32_t)2)}};
+        clustering_key ck_3{{serialized((int32_t)3)}};
+        mutation m{s, dht::decorate_key(*s, partition_key{{"pk"}})};
+        reader_permit p = semaphore.make_permit();
+        api::timestamp_type ts = api::min_timestamp;
+        gc_clock::time_point tp{};
+        m.partition().apply(tombstone{api::min_timestamp + 2, gc_clock::time_point{}});
+        range_tombstone rt1{ck_e, bound_kind::incl_start, ck_1, bound_kind::incl_end, tombstone{ts + 0, tp}};
+        range_tombstone rt2{ck_1, bound_kind::excl_start, ck_e, bound_kind::incl_end, tombstone{ts + 1, tp}};
+        clustering_row cr1{*s, rows_entry{*s, position_in_partition{partition_region::clustered, bound_weight::equal, ck_0}, is_dummy::no, is_continuous::no}};
+        clustering_row cr2{*s, rows_entry{*s, position_in_partition{partition_region::clustered, bound_weight::equal, ck_2}, is_dummy::no, is_continuous::no}};
+        clustering_row cr3{*s, rows_entry{*s, position_in_partition{partition_region::clustered, bound_weight::equal, ck_3}, is_dummy::no, is_continuous::no}};
+        m.apply(mutation_fragment(*s, p, std::move(rt1)));
+        m.apply(mutation_fragment(*s, p, std::move(rt2)));
+        m.apply(mutation_fragment(*s, p, std::move(cr1)));
+        m.apply(mutation_fragment(*s, p, std::move(cr2)));
+        m.apply(mutation_fragment(*s, p, std::move(cr3)));
+        m.partition().ensure_last_dummy(*s);
+        mutation m1{m};
+        {
+            schema_ptr reverse_schema = s->make_reversed();
+            validating_consumer consumer{*reverse_schema};
+            std::move(m).consume(consumer, consume_in_reverse::yes);
+        }
+        {
+            validating_consumer consumer{*s};
+            std::move(m1).consume(consumer, consume_in_reverse::no);
+        }
+    });
+}
+
+
 SEASTAR_THREAD_TEST_CASE(test_position_in_partition_reversal) {
     using p_i_p = position_in_partition;
 

--- a/test/lib/mutation_assertions.hh
+++ b/test/lib/mutation_assertions.hh
@@ -11,6 +11,7 @@
 #include <boost/test/unit_test.hpp>
 
 #include "mutation.hh"
+#include "mutation_fragment_stream_validator.hh"
 
 class mutation_partition_assertion {
     schema_ptr _schema;
@@ -192,3 +193,35 @@ static inline
 mutation_opt_assertions assert_that(mutation_opt mo) {
     return { std::move(mo) };
 }
+
+class validating_consumer {
+    mutation_fragment_stream_validator _validator;
+
+public:
+    explicit validating_consumer(const schema& s) : _validator(s) { }
+
+    void consume_new_partition(const dht::decorated_key&) {
+        BOOST_REQUIRE(_validator(mutation_fragment_v2::kind::partition_start, position_in_partition_view(position_in_partition_view::partition_start_tag_t{})));
+    }
+    void consume(tombstone) { }
+    stop_iteration consume(static_row&& sr) {
+        BOOST_REQUIRE(_validator(mutation_fragment_v2::kind::static_row, sr.position()));
+        return stop_iteration::no;
+    }
+    stop_iteration consume(clustering_row&& cr) {
+        BOOST_REQUIRE(_validator(mutation_fragment_v2::kind::clustering_row, cr.position()));
+        return stop_iteration::no;
+    }
+    stop_iteration consume(range_tombstone_change&& rtc) {
+        BOOST_REQUIRE(_validator(mutation_fragment_v2::kind::range_tombstone_change, rtc.position()));
+        return stop_iteration::no;
+    }
+    stop_iteration consume_end_of_partition() {
+        BOOST_REQUIRE(_validator(mutation_fragment_v2::kind::partition_end, position_in_partition_view(position_in_partition_view::end_of_partition_tag_t{})));
+        return stop_iteration::no;
+    }
+    void consume_end_of_stream() {
+        BOOST_REQUIRE(_validator.on_end_of_stream());
+    }
+};
+


### PR DESCRIPTION
consume_clustering_fragments already ignores dummy rows, but does it in
the wrong place. Currently they're ignored after comparing them with
range tombstones. This change skips them before any useful work is done
with them.

Consider a simplified mutation reversal scenario scenario (ckp is
clustering key prefix, -1, 0, 1 are bound_weights):

schema_ptr s = schema_builder{"ks", "cf"}
    .with_column("pk", bytes_type, column_kind::partition_key)
    .with_column("ck1", bytes_type, column_kind::clustering_key)
    .build();

Input range tombstone positions:
    {clustered, ckp{}, before}
    {clustered, ckp{1}, after}

Clustering rows:
    {clustered, ckp{2}, equal}
    {clustered, ckp{}, after} // dummy row

During reversal, clustering rows are read backwards, and reversed range
tombstone positions are read forwards (because the range tombstones are
reversed and applied backwards). The read order in the example above is:

Reversed range tombstone positions:
    1: {clustered, ckp{}, before}
    2: {clustered, ckp{1}, before}

Clustering rows read backwards:
    3: {clustered, ckp{}, after} // dummy row
    4: {clustered, ckp{2}, equal}

Then we effectively do the merge part of merge sort, trying to put all
fragments in order according to their positions from the two lists
above. However, the dummy row is used in the comparison, and it compares
to be gt each of the reversed range tombstone positions. Then we
try to emit the clustering row, but only at that point we notice it's
dummy and should be skipped. Subsequent row with ckp{2} is compared to
the last used range tombstone position and the fragments are out of
order (in reversed schema, ckp{2} should come before ckp{1}).

The solution is to move the logic skipping the dummy clustering rows to
the beginning of the loop, so they can be ignored before they're used.

Fixes: https://github.com/scylladb/scylla/issues/11147