### PR TITLE
mutation_compactor: don't ignore consumer's stop request on range tombstone

### DIFF
--- a/mutation_compactor.hh
+++ b/mutation_compactor.hh
@@ -420,8 +420,7 @@ public:
             _last_pos = rtc.position();
         }
         ++_stats.range_tombstones;
-        do_consume(std::move(rtc), consumer, gc_consumer);
-        return stop_iteration::no;
+        return do_consume(std::move(rtc), consumer, gc_consumer);
     }
 
     template <typename Consumer, typename GCConsumer>


### PR DESCRIPTION
Broken since the v2 output support was introduced (ad435dc).
No known adverse affects, besides mutation reads stopping a little later
than desired (on the next non-range-tombstone-change fragment) and hence
consuming more memory than the limit set for them.

Fixes: #11138