### PR TITLE
Docs: move the consistency calculator to a dedicate page

### DIFF
--- a/docs/cql/consistency-calculator-raw.html
+++ b/docs/cql/consistency-calculator-raw.html
@@ -43,6 +43,8 @@
         </form>
         <div class="results"></div>
     </div>
+    <br/>
+    <br/>
 
     <script>
         function consistency(c, rf) {
@@ -79,17 +81,19 @@
                 resultsDiv.classList.add("warning", "admonition");
             } else {
                 const msg = [];
+                msg.push("<ul>")
                 if (writeConsistencyN + readConsistencyN > replicationFactor) {
-                    msg.push("Your reads are <b>consistent</b>");
+                    msg.push("<li>Your reads are <b>consistent</b></li>");
                 } else {
-                    msg.push("Your reads are <b>eventually consistent</b>");
+                    msg.push("<li>Your reads are <b>eventually consistent</b></li>");
                 }
-                msg.push(`You can lose ${replicationFactor - readConsistencyN} nodes without failing reads`);
-                msg.push(`You can lose ${writeConsistencyN - 1} nodes without data loss`);
-                msg.push(`Each node holds ~ ${Math.round(replicationFactor / nodes * 100)}% of your data`);
+                msg.push(`<li>You can lose ${replicationFactor - readConsistencyN} nodes without failing reads</li>`);
+                msg.push(`<li>You can lose ${writeConsistencyN - 1} nodes without data loss</li>`);
+                msg.push(`<li>Each node holds ~ ${Math.round(replicationFactor / nodes * 100)}% of your data</li>`);
+                msg.push("</ul>")
                 
                 resultsDiv.classList.remove("warning", "admonition");
-                resultsDiv.innerHTML = msg.join("<br/>");
+                resultsDiv.innerHTML = msg.join("<br/>"); 
             }
         }
 

--- a/docs/cql/consistency-calculator.rst
+++ b/docs/cql/consistency-calculator.rst
@@ -1,0 +1,17 @@
+=============================
+Consistency Level Calculator
+=============================
+
+.. raw:: html
+  :file: consistency-calculator-raw.html
+
+
+Additional Information
+----------------------
+
+* :doc:`Consistency Levels <consistency>`
+* :doc:`Fault Tolerance </architecture/architecture-fault-tolerance/>`
+* :doc:`Cluster membership changes and LWT consistency </operating-scylla/procedures/cluster-management/membership-changes/>`
+* :ref:`Consistency Level Compatibility <consistency-level-read-and-write>`
+* :doc:`Consistency Quiz </kb/quiz-administrators/>`
+* Take a course on `Consistency Levels at Scylla University <https://university.scylladb.com/courses/scylla-essentials-overview/lessons/high-availability/topic/consistency-level/>`_

--- a/docs/cql/consistency.rst
+++ b/docs/cql/consistency.rst
@@ -111,16 +111,10 @@ returns
    Current consistency level is ALL.
 
 
-Consistency level calculator
-----------------------------
-
-.. raw:: html
-  :file: consistency-calculator.html
-  
-
 Additional Information
 ----------------------
 
+* :doc:`Consistency Level Calculator <consistency-calculator>`
 * :doc:`Fault Tolerance </architecture/architecture-fault-tolerance/>`
 * :doc:`Cluster membership changes and LWT consistency </operating-scylla/procedures/cluster-management/membership-changes/>`
 * :ref:`Consistency Level Compatibility <consistency-level-read-and-write>`

--- a/docs/cql/index.rst
+++ b/docs/cql/index.rst
@@ -9,6 +9,7 @@ CQL Reference
    appendices
    compaction
    consistency
+   consistency-calculator
    ddl
    dml
    types
@@ -38,6 +39,7 @@ It allows you to create keyspaces and tables, insert and query tables, and more.
   * :doc:`Appendices </cql/appendices>`
   * :doc:`Compaction </cql/compaction>`
   * :doc:`Consistency Levels </cql/consistency>`
+  * :doc:`Consistency Levels Calculator</cql/consistency-calculator>`
   * :doc:`Data Definition </cql/ddl>`
   * :doc:`Data Manipulation </cql/dml>`
   * :doc:`Data Types </cql/types>`


### PR DESCRIPTION
Scylla consistency calculator is a small JS script embedded in a raw HTML file.
Until now, this file was placed at the bottom of the Consistency Levels page, which is easy to miss.
This PR moved it to a dedicated page and slightly improved its UX, putting the results in a bullet list.

Fix https://github.com/scylladb/scylla/issues/11126

### Now

![image](https://user-images.githubusercontent.com/170200/181477252-602f6bbc-965d-447d-94d4-4abbd8ea2ac7.png)


### After this PR

![image](https://user-images.githubusercontent.com/170200/181477301-37d0be6b-0eff-430e-b488-0308d9203c60.png)

