### PR TITLE
removenode: add warning in case of exception

### DIFF
--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -2397,6 +2397,8 @@ future<> storage_service::removenode(sstring host_id_string, std::list<gms::inet
 
                 slogger.info("removenode[{}]: Finished removenode operation, removing node={}, sync_nodes={}, ignore_nodes={}", uuid, endpoint, nodes, ignore_nodes);
             } catch (...) {
+                slogger.warn("removenode[{}]: removing node={}, sync_nodes={}, ignore_nodes={} failed, error {}",
+                             uuid, endpoint, nodes, ignore_nodes, std::current_exception());
                 // we need to revert the effect of prepare verb the removenode ops is failed
                 req.cmd = node_ops_cmd::removenode_abort;
                 parallel_for_each(nodes, [&ss, &req, &nodes_unknown_verb, &nodes_down, uuid] (const gms::inet_address& node) {


### PR DESCRIPTION
The `removenode_abort` logic that follows the warning may throw, in which case information about
the original exception was lost.