### PR TITLE
build: harden create-relocatable-package.py against changes in libthread-db.so name

### DIFF
--- a/scripts/create-relocatable-package.py
+++ b/scripts/create-relocatable-package.py
@@ -98,7 +98,7 @@ for exe in executables:
     libs.update(ldd(exe))
 
 # manually add libthread_db for debugging thread
-libs.update({'libthread_db.so.1': '/lib64/libthread_db-1.0.so'})
+libs.update({'libthread_db.so.1': os.path.realpath('/lib64/libthread_db.so')})
 
 ld_so = libs['ld.so']
 


### PR DESCRIPTION
create-relocatable-package.py collects shared libraries used by executables for packaging. It also adds libthread-db.so to make debugging possible. However, the name it uses has changed in glibc, so packaging fails in Fedora 37.

Switch to the version-agnostic names, libthread-db.so. This happens to be a symlink, so resolve it.