### PR TITLE
build: enable io_uring

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1611,7 +1611,6 @@ def configure_seastar(build_dir, mode, mode_config):
         '-DSeastar_UNUSED_RESULT_ERROR=ON',
         '-DCMAKE_EXPORT_COMPILE_COMMANDS=ON',
         '-DSeastar_SCHEDULING_GROUPS_COUNT=16',
-        '-DSeastar_IO_URING=OFF', # io_uring backend is not stable enough
     ] + distro_extra_cmake_args
 
     if args.stack_guards is not None:


### PR DESCRIPTION
It was previously reverted on the suspicion that it destabilized repair-based node operations, but later it was shown that it fails even with io_uring disabled.