### PR TITLE
mutation_partition_v2: fix a minor bug in printer

### DIFF
--- a/mutation/mutation_partition_v2.cc
+++ b/mutation/mutation_partition_v2.cc
@@ -825,7 +825,7 @@ operator<<(std::ostream& os, const mutation_partition_v2::printer& p) {
             os << indent << indent << indent << "tombstone: " << row.deleted_at() << ",\n";
         }
         if (re.range_tombstone()) {
-            fmt::print("{:6}rt: {},\n", "", re.range_tombstone());
+            fmt::print(os, "{:6}rt: {},\n", "", re.range_tombstone());
         }
 
         position_in_partition pip(re.position());


### PR DESCRIPTION
Commit 1cb95b8cf caused a small regression in the debug printer. After that commit, range tombstones are printed to stdout, instead of the target stream.
In practice, this causes range tombstones to appear in test logs out of order with respect to other parts of the debug message.

Fix that.