### PR TITLE
doc: add the Elixir driver to the docs

### DIFF
--- a/docs/using-scylla/drivers/cql-drivers/index.rst
+++ b/docs/using-scylla/drivers/cql-drivers/index.rst
@@ -52,6 +52,7 @@ Scylla supports the CQL binary protocol version 3, so any Apache Cassandra/CQL d
   * `He4rt PHP Driver (Supported versions: 8.1 and 8.2)  <https://github.com/he4rt/scylladb-php-driver/>`_
   * `Rust <https://github.com/AlexPikalov/cdrs>`_
   * `Scala Phantom Project <https://github.com/outworkers/phantom>`_
+  * `Xandra Elixir Driver <https://github.com/lexhide/xandra>`_
 
 .. panel-box::
   :title: Lessons on Scylla University


### PR DESCRIPTION
This PR adds the link to the Exlixir driver to the list of third-party drivers.
The driver actively supports ScyllaDB.

This is v2 of https://github.com/scylladb/scylladb/pull/13701