### PR TITLE
system_keyspace: overwrite, not add tokens in topology_node_mutation_builder::set

### DIFF
--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -608,6 +608,7 @@ topology_node_mutation_builder& topology_node_mutation_builder::set(const char* 
             cm.cells.emplace_back(vtype->decompose(value.to_sstring()), atomic_cell::make_live(*bytes_type, _builder._ts, bytes_view()));
         }
 
+        cm.tomb = tombstone(_builder._ts - 1, gc_clock::now());
         _r.cells().apply(*cdef, cm.serialize(*cdef->type));
     } else {
         del(cell);


### PR DESCRIPTION
The `topology_node_mutation_builder::set` function, when passed a non-empty set of tokens, will construct a mutation that adds given tokens to the column instead of overwriting them. This is not a problem today because we are always calling `set` on an empty column, but given the fact that the function is called `set` not `add` and other overloads of `set` do overwrite, the function might be misused in the future.

This commit fixes the problem by initializing the tombstone in `collection_mutation_description` properly, causing the previous state to be dropped before applying new tokens. The tombstone has a timestamp which is one less than the timestamp of the added cells, mimicking the CQL behavior which happens when a non-frozen collection is overwritten.