### PR TITLE
doc: fix the descriptions of config parameters

### DIFF
--- a/db/config.cc
+++ b/db/config.cc
@@ -329,35 +329,35 @@ db::config::config(std::shared_ptr<db::extensions> exts)
     , auto_adjust_flush_quota(this, "auto_adjust_flush_quota", value_status::Unused, false,
         "true: auto-adjust memtable shares for flush processes")
     , memtable_flush_static_shares(this, "memtable_flush_static_shares", liveness::LiveUpdate, value_status::Used, 0,
-        "If set to higher than 0, ignore the controller's output and set the memtable shares statically. Do not set this unless you know what you are doing and suspect a problem in the controller. This option will be retired when the controller reaches more maturity")
+        "If set to higher than 0, ignore the controller's output and set the memtable shares statically. Do not set this unless you know what you are doing and suspect a problem in the controller. This option will be retired when the controller reaches more maturity.")
     , compaction_static_shares(this, "compaction_static_shares", liveness::LiveUpdate, value_status::Used, 0,
-        "If set to higher than 0, ignore the controller's output and set the compaction shares statically. Do not set this unless you know what you are doing and suspect a problem in the controller. This option will be retired when the controller reaches more maturity")
+        "If set to higher than 0, ignore the controller's output and set the compaction shares statically. Do not set this unless you know what you are doing and suspect a problem in the controller. This option will be retired when the controller reaches more maturity.")
     , compaction_enforce_min_threshold(this, "compaction_enforce_min_threshold", liveness::LiveUpdate, value_status::Used, false,
-        "If set to true, enforce the min_threshold option for compactions strictly. If false (default), Scylla may decide to compact even if below min_threshold")
+        "If set to true, it enforces the min_threshold option for compactions strictly. If false (default), ScyllaDB may decide to compact even if below min_threshold.")
     /* Initialization properties */
     /* The minimal properties needed for configuring a cluster. */
     , cluster_name(this, "cluster_name", value_status::Used, "",
-        "The name of the cluster; used to prevent machines in one logical cluster from joining another. All nodes participating in a cluster must have the same value.")
+        "The name of the cluster. It is used to prevent machines in one logical cluster from joining another. All nodes participating in a cluster must have the same value.")
     , listen_address(this, "listen_address", value_status::Used, "localhost",
-        "The IP address or hostname that Scylla binds to for connecting to other Scylla nodes. You must change the default setting for multiple nodes to communicate. Do not set to 0.0.0.0, unless you have set broadcast_address to an address that other nodes can use to reach this node.")
+        "The IP address or hostname that ScyllaDB binds to for connecting to other ScyllaDB nodes. You must change the default setting for multiple nodes to communicate. Do not set it to 0.0.0.0 unless you have set broadcast_address to an address that other nodes can use to reach this node.")
     , listen_interface(this, "listen_interface", value_status::Unused, "eth0",
-        "The interface that Scylla binds to for connecting to other Scylla nodes. Interfaces must correspond to a single address, IP aliasing is not supported. See listen_address.")
+        "The interface that ScyllaDB binds to for connecting to other ScyllaDB nodes. Interfaces must correspond to a single address, IP aliasing is not supported. See listen_address.")
     , listen_interface_prefer_ipv6(this, "listen_interface_prefer_ipv6", value_status::Used, false,
-        "If you choose to specify the interface by name and the interface has an ipv4 and an ipv6 address\n"
-        "you can specify which should be chosen using listen_interface_prefer_ipv6. If false the first ipv4\n"
-        "address will be used. If true the first ipv6 address will be used. Defaults to false preferring\n"
-        "ipv4. If there is only one address it will be selected regardless of ipv4/ipv6."
+        "If you choose to specify the interface by name and the interface has an ipv4 and an ipv6 address,\n"
+        "you can specify which should be chosen using listen_interface_prefer_ipv6. If false, the first ipv4\n"
+        "address will be used. If true, the first ipv6 address will be used. Defaults to false, preferring\n"
+        "ipv4. If there is only one address, it will be selected regardless of ipv4/ipv6."
     )
     /* Default directories */
     /* If you have changed any of the default directories during installation, make sure you have root access and set these properties: */
     , work_directory(this, "workdir,W", value_status::Used, "/var/lib/scylla",
-        "The directory in which Scylla will put all its subdirectories. The location of individual subdirs can be overriden by the respective *_directory options.")
+        "The directory in which ScyllaDB will put all its subdirectories. The location of individual subdirs can be overridden by the respective *_directory options.")
     , commitlog_directory(this, "commitlog_directory", value_status::Used, "",
         "The directory where the commit log is stored. For optimal write performance, it is recommended the commit log be on a separate disk partition (ideally, a separate physical device) from the data file directories.")
     , schema_commitlog_directory(this, "schema_commitlog_directory", value_status::Used, "",
         "The directory where the schema commit log is stored. This is a special commitlog instance used for schema and system tables. For optimal write performance, it is recommended the commit log be on a separate disk partition (ideally, a separate physical device) from the data file directories.")
     , data_file_directories(this, "data_file_directories", "datadir", value_status::Used, { },
-        "The directory location where table data (SSTables) is stored")
+        "The directory location where table data (SSTables) is stored.")
     , hints_directory(this, "hints_directory", value_status::Used, "",
         "The directory where hints files are stored if hinted handoff is enabled.")
     , view_hints_directory(this, "view_hints_directory", value_status::Used, "",
@@ -378,29 +378,29 @@ db::config::config(std::shared_ptr<db::extensions> exts)
         "\tignore       Ignore fatal errors and let the batches fail."
         , {"die", "stop", "stop_commit", "ignore"})
     , disk_failure_policy(this, "disk_failure_policy", value_status::Unused, "stop",
-        "Sets how Scylla responds to disk failure. Recommend settings are stop or best_effort.\n"
+        "Sets how ScyllaDB responds to disk failure. Recommend settings are stop or best_effort.\n"
         "\n"
         "\tdie              Shut down gossip and Thrift and kill the JVM for any file system errors or single SSTable errors, so the node can be replaced.\n"
         "\tstop_paranoid    Shut down gossip and Thrift even for single SSTable errors.\n"
         "\tstop             Shut down gossip and Thrift, leaving the node effectively dead, but available for inspection using JMX.\n"
         "\tbest_effort      Stop using the failed disk and respond to requests based on the remaining available SSTables. This means you will see obsolete data at consistency level of ONE.\n"
-        "\tignore           Ignores fatal errors and lets the requests fail; all file system errors are logged but otherwise ignored. Scylla acts as in versions prior to Cassandra 1.2.\n"
+        "\tignore           Ignores fatal errors and lets the requests fail; all file system errors are logged but otherwise ignored. ScyllaDB acts as in versions prior to Cassandra 1.2.\n"
         "\n"
         "Related information: Handling Disk Failures In Cassandra 1.2 blog and Recovering from a single disk failure using JBOD.\n"
         , {"die", "stop_paranoid", "stop", "best_effort", "ignore"})
     , endpoint_snitch(this, "endpoint_snitch", value_status::Used, "org.apache.cassandra.locator.SimpleSnitch",
-        "Set to a class that implements the IEndpointSnitch. Scylla uses snitches for locating nodes and routing requests.\n\n"
+        "Specifies a class that implements the IEndpointSnitch. ScyllaDB uses snitches for locating nodes and routing requests.\n\n"
         "\tSimpleSnitch: Use for single-data center deployments or single-zone in public clouds. Does not recognize data center or rack information. It treats strategy order as proximity, which can improve cache locality when disabling read repair.\n\n"
         "\tGossipingPropertyFileSnitch: Recommended for production. The rack and data center for the local node are defined in the cassandra-rackdc.properties file and propagated to other nodes via gossip. To allow migration from the PropertyFileSnitch, it uses the cassandra-topology.properties file if it is present.\n\n"
         /*"\tPropertyFileSnitch: Determines proximity by rack and data center, which are explicitly configured in the cassandra-topology.properties file.\n\n"    */
-        "\tEc2Snitch: For EC2 deployments in a single region. Loads region and availability zone information from the EC2 API. The region is treated as the data center and the availability zone as the rack. Uses only private IPs. Subsequently it does not work across multiple regions.\n\n"
-        "\tEc2MultiRegionSnitch: Uses public IPs as the broadcast_address to allow cross-region connectivity. This means you must also set seed addresses to the public IP and open the storage_port or ssl_storage_port on the public IP firewall. For intra-region traffic, Scylla switches to the private IP after establishing a connection.\n\n"
-        "\tGoogleCloudSnitch: For deployments on Google Cloud Platform across one or more regions. The region is treated as a datacenter and the availability zone is treated as a rack within the datacenter. The communication should occur over private IPs within the same logical network.\n\n"
+        "\tEc2Snitch: For EC2 deployments in a single region. Loads region and availability zone information from the EC2 API. The region is treated as the data center, and the availability zone as the rack. Uses only private IPs. Subsequently, it does not work across multiple regions.\n\n"
+        "\tEc2MultiRegionSnitch: Uses public IPs as the broadcast_address to allow cross-region connectivity. This means you must also set seed addresses to the public IP and open the storage_port or ssl_storage_port on the public IP firewall. For intra-region traffic, ScyllaDB switches to the private IP after establishing a connection.\n\n"
+        "\tGoogleCloudSnitch: For deployments on Google Cloud Platform across one or more regions. The region is treated as a datacenter, and the availability zone is treated as a rack within the datacenter. The communication should occur over private IPs within the same logical network.\n\n"
         "\tRackInferringSnitch: Proximity is determined by rack and data center, which are assumed to correspond to the 3rd and 2nd octet of each node's IP address, respectively. This snitch is best used as an example for writing a custom snitch class (unless this happens to match your deployment conventions).\n"
         "\n"
         "Related information: Snitches\n")
     , rpc_address(this, "rpc_address", value_status::Used, "localhost",
-        "The listen address for client connections (Thrift RPC service and native transport).Valid values are:\n"
+        "The listen address for client connections (Thrift RPC service and native transport). Valid values are:\n"
         "\n"
         "\tunset:   Resolves the address using the hostname configuration of the node. If left unset, the hostname must resolve to the IP address of this node using /etc/hostname, /etc/hosts, or DNS.\n"
         "\t0.0.0.0 : Listens on all configured interfaces, but you must set the broadcast_rpc_address to a value other than 0.0.0.0.\n"
@@ -410,33 +410,33 @@ db::config::config(std::shared_ptr<db::extensions> exts)
     , rpc_interface(this, "rpc_interface", value_status::Unused, "eth1",
         "The listen address for client connections. Interfaces must correspond to a single address, IP aliasing is not supported. See rpc_address.")
     , rpc_interface_prefer_ipv6(this, "rpc_interface_prefer_ipv6", value_status::Used, false,
-        "If you choose to specify the interface by name and the interface has an ipv4 and an ipv6 address\n"
-        "you can specify which should be chosen using rpc_interface_prefer_ipv6. If false the first ipv4\n"
-        "address will be used. If true the first ipv6 address will be used. Defaults to false preferring\n"
-        "ipv4. If there is only one address it will be selected regardless of ipv4/ipv6"
+        "If you choose to specify the interface by name and the interface has an ipv4 and an ipv6 address,\n"
+        "you can specify which should be chosen using rpc_interface_prefer_ipv6. If false, the first ipv4\n"
+        "address will be used. If true, the first ipv6 address will be used. Defaults to false, preferring\n"
+        "ipv4. If there is only one address, it will be selected regardless of ipv4/ipv6"
     )
     , seed_provider(this, "seed_provider", value_status::Used, seed_provider_type("org.apache.cassandra.locator.SimpleSeedProvider"),
-        "The addresses of hosts deemed contact points. Scylla nodes use the -seeds list to find each other and learn the topology of the ring.\n"
+        "The addresses of hosts deemed contact points. ScyllaDB nodes use the -seeds list to find each other and learn the topology of the ring.\n"
         "\n"
         "  class_name (Default: org.apache.cassandra.locator.SimpleSeedProvider)\n"
-        "  \tThe class within Scylla that handles the seed logic. It can be customized, but this is typically not required.\n"
+        "  \tThe class within ScyllaDB that handles the seed logic. It can be customized, but this is typically not required.\n"
         "  \t- seeds (Default: 127.0.0.1)    A comma-delimited list of IP addresses used by gossip for bootstrapping new nodes joining a cluster. When running multiple nodes, you must change the list from the default value. In multiple data-center clusters, the seed list should include at least one node from each data center (replication group). More than a single seed node per data center is recommended for fault tolerance. Otherwise, gossip has to communicate with another data center when bootstrapping a node. Making every node a seed node is not recommended because of increased maintenance and reduced gossip performance. Gossip optimization is not critical, but it is recommended to use a small seed list (approximately three nodes per data center).\n"
         "\n"
         "Related information: Initializing a multiple node cluster (single data center) and Initializing a multiple node cluster (multiple data centers).")
     /* Common compaction settings */
     , compaction_throughput_mb_per_sec(this, "compaction_throughput_mb_per_sec", liveness::LiveUpdate, value_status::Used, 0,
-        "Throttles compaction to the specified total throughput across the entire system. The faster you insert data, the faster you need to compact in order to keep the SSTable count down. The recommended Value is 16 to 32 times the rate of write throughput (in MBs/second). Setting the value to 0 disables compaction throttling.\n"
+        "Throttles compaction to the specified total throughput across the entire system. The faster you insert data, the faster you need to compact in order to keep the SSTable count down. The recommended value is 16 to 32 times the rate of write throughput (in MBs/second). Setting the value to 0 disables compaction throttling.\n"
         "Related information: Configuring compaction")
     , compaction_large_partition_warning_threshold_mb(this, "compaction_large_partition_warning_threshold_mb", liveness::LiveUpdate, value_status::Used, 1000,
-        "Log a warning when writing partitions larger than this value")
+        "Logs a warning when writing partitions larger than this value")
     , compaction_large_row_warning_threshold_mb(this, "compaction_large_row_warning_threshold_mb", liveness::LiveUpdate, value_status::Used, 10,
-        "Log a warning when writing rows larger than this value")
+        "Logs a warning when writing rows larger than this value")
     , compaction_large_cell_warning_threshold_mb(this, "compaction_large_cell_warning_threshold_mb", liveness::LiveUpdate, value_status::Used, 1,
-        "Log a warning when writing cells larger than this value")
+        "Logs a warning when writing cells larger than this value")
     , compaction_rows_count_warning_threshold(this, "compaction_rows_count_warning_threshold", liveness::LiveUpdate, value_status::Used, 100000,
-        "Log a warning when writing a number of rows larger than this value")
+        "Logs a warning when writing a number of rows larger than this value")
     , compaction_collection_elements_count_warning_threshold(this, "compaction_collection_elements_count_warning_threshold", liveness::LiveUpdate, value_status::Used, 10000,
-        "Log a warning when writing a collection containing more elements than this value")
+        "Logs a warning when writing a collection containing more elements than this value")
     /* Common memtable settings */
     , memtable_total_space_in_mb(this, "memtable_total_space_in_mb", value_status::Invalid, 0,
         "Specifies the total memory used for all memtables on a node. This replaces the per-table storage settings memtable_operations_in_millions and memtable_throughput_in_mb.")
@@ -449,24 +449,24 @@ db::config::config(std::shared_ptr<db::extensions> exts)
         "Counter writes read the current values before incrementing and writing them back. The recommended value is (16 × number_of_drives) .")
     /* Common automatic backup settings */
     , incremental_backups(this, "incremental_backups", value_status::Used, false,
-        "Backs up data updated since the last snapshot was taken. When enabled, Scylla creates a hard link to each SSTable flushed or streamed locally in a backups/ subdirectory of the keyspace data. Removing these links is the operator's responsibility.\n"
+        "Backs up data updated since the last snapshot was taken. When enabled, ScyllaDB creates a hard link to each SSTable flushed or streamed locally in a backups/ subdirectory of the keyspace data. Removing these links is the operator's responsibility.\n"
         "Related information: Enabling incremental backups")
     , snapshot_before_compaction(this, "snapshot_before_compaction", value_status::Unused, false,
         "Enable or disable taking a snapshot before each compaction. This option is useful to back up data when there is a data format change. Be careful using this option because Cassandra does not clean up older snapshots automatically.\n"
         "Related information: Configuring compaction")
     /* Common fault detection setting */
     , phi_convict_threshold(this, "phi_convict_threshold", value_status::Used, 8,
-        "Adjusts the sensitivity of the failure detector on an exponential scale. Generally this setting never needs adjusting.\n"
+        "Adjusts the sensitivity of the failure detector on an exponential scale. Generally, this setting never needs adjusting.\n"
         "Related information: Failure detection and recovery")
     , failure_detector_timeout_in_ms(this, "failure_detector_timeout_in_ms", liveness::LiveUpdate, value_status::Used, 20 * 1000, "Maximum time between two successful echo message before gossip mark a node down in milliseconds.\n")
     /* Performance tuning properties */
     /* Tuning performance and system reso   urce utilization, including commit log, compaction, memory, disk I/O, CPU, reads, and writes. */
     /* Commit log settings */
     , commitlog_sync(this, "commitlog_sync", value_status::Used, "periodic",
-        "The method that Scylla uses to acknowledge writes in milliseconds:\n"
+        "The method that ScyllaDB uses to acknowledge writes in milliseconds:\n"
         "\n"
         "\tperiodic : Used with commitlog_sync_period_in_ms (Default: 10000 - 10 seconds ) to control how often the commit log is synchronized to disk. Periodic syncs are acknowledged immediately.\n"
-        "\tbatch : Used with commitlog_sync_batch_window_in_ms (Default: disabled **) to control how long Scylla waits for other writes before performing a sync. When using this method, writes are not acknowledged until fsynced to disk.\n"
+        "\tbatch : Used with commitlog_sync_batch_window_in_ms (Default: disabled **) to control how long ScyllaDB waits for other writes before performing a sync. When using this method, writes are not acknowledged until fsynced to disk.\n"
         "Related information: Durability")
     , commitlog_segment_size_in_mb(this, "commitlog_segment_size_in_mb", value_status::Used, 64,
         "Sets the size of the individual commitlog file segments. A commitlog segment may be archived, deleted, or recycled after all its data has been flushed to SSTables. This amount of data can potentially include commitlog segments from every table in the system. The default size is usually suitable for most commitlog archiving, but if you want a finer granularity, 8 or 16 MB is reasonable. See Commit log archive configuration.\n"
@@ -481,17 +481,17 @@ db::config::config(std::shared_ptr<db::extensions> exts)
     , commitlog_sync_batch_window_in_ms(this, "commitlog_sync_batch_window_in_ms", value_status::Used, 10000,
         "Controls how long the system waits for other writes before performing a sync in \"batch\" mode.")
     , commitlog_total_space_in_mb(this, "commitlog_total_space_in_mb", value_status::Used, -1,
-        "Total space used for commitlogs. If the used space goes above this value, Scylla rounds up to the next nearest segment multiple and flushes memtables to disk for the oldest commitlog segments, removing those log segments. This reduces the amount of data to replay on startup, and prevents infrequently-updated tables from indefinitely keeping commitlog segments. A small total commitlog space tends to cause more flush activity on less-active tables.\n"
+        "Total space used for commitlogs. If the used space goes above this value, ScyllaDB rounds up to the next nearest segment multiple and flushes memtables to disk for the oldest commitlog segments, removing those log segments. This reduces the amount of data to replay on startup and prevents infrequently-updated tables from indefinitely keeping commitlog segments. A small total commitlog space tends to cause more flush activity on less-active tables.\n"
         "Related information: Configuring memtable throughput")
     /* Note: Unused. Retained for upgrade compat. Deprecate and remove in a cycle or two. */
     , commitlog_reuse_segments(this, "commitlog_reuse_segments", value_status::Unused, true,
         "Whether or not to re-use commitlog segments when finished instead of deleting them. Can improve commitlog latency on some file systems.\n")        
     , commitlog_flush_threshold_in_mb(this, "commitlog_flush_threshold_in_mb", value_status::Used, -1,
-        "Threshold for commitlog disk usage. When used disk space goes above this value, Scylla initiates flushes of memtables to disk for the oldest commitlog segments, removing those log segments. Adjusting this affects disk usage vs. write latency. Default is (approximately) commitlog_total_space_in_mb - <num shards>*commitlog_segment_size_in_mb.")
+        "Threshold for commitlog disk usage. When used disk space goes above this value, ScyllaDB initiates flushes of memtables to disk for the oldest commitlog segments, removing those log segments. Adjusting this affects disk usage vs. write latency. Default is (approximately) commitlog_total_space_in_mb - <num shards>*commitlog_segment_size_in_mb.")
     , commitlog_use_o_dsync(this, "commitlog_use_o_dsync", value_status::Used, true,
-        "Whether or not to use O_DSYNC mode for commitlog segments IO. Can improve commitlog latency on some file systems.\n")
+        "Specifies whether or not to use O_DSYNC mode for commitlog segments IO. It can improve commitlog latency on some file systems.\n")
     , commitlog_use_hard_size_limit(this, "commitlog_use_hard_size_limit", value_status::Used, false,
-        "Whether or not to use a hard size limit for commitlog disk usage. Default is false. Enabling this can cause latency spikes, whereas the default can lead to occasional disk usage peaks.\n")
+        "Specifies whether or not to  a hard size limit for commitlog disk usage. Default is false. Enabling this can cause latency spikes, whereas the default can lead to occasional disk usage peaks.\n")
     /* Compaction settings */
     /* Related information: Configuring compaction */
     , compaction_preheat_key_cache(this, "compaction_preheat_key_cache", value_status::Unused, true,
@@ -504,7 +504,7 @@ db::config::config(std::shared_ptr<db::extensions> exts)
         "Enable or disable kernel page cache preheating from contents of the key cache after compaction. When enabled it preheats only first page (4KB) of each row to optimize for sequential access. It can be harmful for fat rows, see CASSANDRA-4937 for more details.")
     , sstable_preemptive_open_interval_in_mb(this, "sstable_preemptive_open_interval_in_mb", value_status::Unused, 50,
         "When compacting, the replacement opens SSTables before they are completely written and uses in place of the prior SSTables for any range previously written. This setting helps to smoothly transfer reads between the SSTables by reducing page cache churn and keeps hot rows hot.")
-    , defragment_memory_on_idle(this, "defragment_memory_on_idle", value_status::Used, false, "When set to true, will defragment memory when the cpu is idle.  This reduces the amount of work Scylla performs when processing client requests.")
+    , defragment_memory_on_idle(this, "defragment_memory_on_idle", value_status::Used, false, "When set to true, it will defragment memory when the CPU is idle.  This reduces the amount of work ScyllaDB performs when processing client requests.")
     /* Memtable settings */
     , memtable_allocation_type(this, "memtable_allocation_type", value_status::Invalid, "heap_buffers",
         "Specify the way Cassandra allocates and manages memtable memory. See Off-heap memtables in Cassandra 2.1. Options are:\n"
@@ -528,7 +528,7 @@ db::config::config(std::shared_ptr<db::extensions> exts)
     , column_index_size_in_kb(this, "column_index_size_in_kb", value_status::Used, 64,
         "Granularity of the index of rows within a partition. For huge rows, decrease this setting to improve seek time. If you use key cache, be careful not to make this setting too large because key cache will be overwhelmed. If you're unsure of the size of the rows, it's best to use the default setting.")
     , column_index_auto_scale_threshold_in_kb(this, "column_index_auto_scale_threshold_in_kb", liveness::LiveUpdate, value_status::Used, 10240,
-        "Auto-reduce the promoted index granularity by half when reaching this threshold, to prevent promoted index bloating due to partitions with too many rows. Set to 0 to disable this feature.")
+        "Auto-reduce the promoted index granularity by half when reaching this threshold to prevent promoted index bloating due to partitions with too many rows. Set to 0 to disable this feature.")
     , index_summary_capacity_in_mb(this, "index_summary_capacity_in_mb", value_status::Unused, 0,
         "Fixed memory pool size in MB for SSTable index summaries. If the memory usage of all index summaries exceeds this limit, any SSTables with low read rates shrink their index summaries to meet this limit. This is a best-effort process. In extreme conditions, Cassandra may need to use more than this amount of memory.")
     , index_summary_resize_interval_in_minutes(this, "index_summary_resize_interval_in_minutes", value_status::Unused, 60,
@@ -554,23 +554,23 @@ db::config::config(std::shared_ptr<db::extensions> exts)
     /* Properties for advanced users or properties that are less commonly used. */
     /* Advanced initialization properties */
     , auto_bootstrap(this, "auto_bootstrap", value_status::Used, true,
-        "This setting has been removed from default configuration. It makes new (non-seed) nodes automatically migrate the right data to themselves. Do not set this to false unless you really know what you are doing.\n"
+        "This setting has been removed from the default configuration. It makes new (non-seed) nodes automatically migrate the right data to themselves. Do not set this to false unless you really know what you are doing.\n"
         "Related information: Initializing a multiple node cluster (single data center) and Initializing a multiple node cluster (multiple data centers).")
     , batch_size_warn_threshold_in_kb(this, "batch_size_warn_threshold_in_kb", value_status::Used, 128,
-        "Log WARN on any batch size exceeding this value in kilobytes. Caution should be taken on increasing the size of this threshold as it can lead to node instability.")
+        "Logs WARN on any batch size exceeding this value in kilobytes. Caution should be taken on increasing the size of this threshold as it can lead to node instability.")
     , batch_size_fail_threshold_in_kb(this, "batch_size_fail_threshold_in_kb", value_status::Used, 1024,
-        "Fail any multiple-partition batch exceeding this value. 1 MiB (8x warn threshold) by default.")
+        "Fails any multiple-partition batch exceeding this value. 1 MiB (8x warn threshold) by default.")
     , broadcast_address(this, "broadcast_address", value_status::Used, {/* listen_address */},
-        "The IP address a node tells other nodes in the cluster to contact it by. It allows public and private address to be different. For example, use the broadcast_address parameter in topologies where not all nodes have access to other nodes by their private IP addresses.\n"
-        "If your Scylla cluster is deployed across multiple Amazon EC2 regions and you use the EC2MultiRegionSnitch , set the broadcast_address to public IP address of the node and the listen_address to the private IP.")
+        "The IP address a node tells other nodes in the cluster to contact it by. It allows public and private addresses to be different. For example, use the broadcast_address parameter in topologies where not all nodes have access to other nodes by their private IP addresses.\n"
+        "If your ScyllaDB cluster is deployed across multiple Amazon EC2 regions and you use the EC2MultiRegionSnitch , set the broadcast_address to public IP address of the node and the listen_address to the private IP.")
     , listen_on_broadcast_address(this, "listen_on_broadcast_address", value_status::Used, false, "When using multiple physical network interfaces, set this to true to listen on broadcast_address in addition to the listen_address, allowing nodes to communicate in both interfaces.  Ignore this property if the network configuration automatically routes between the public and private networks such as EC2."
     )
     , initial_token(this, "initial_token", value_status::Used, {/* N/A */},
         "Used in the single-node-per-token architecture, where a node owns exactly one contiguous range in the ring space. Setting this property overrides num_tokens.\n"
-        "If you not using vnodes or have num_tokens set it to 1 or unspecified (#num_tokens), you should always specify this parameter when setting up a production cluster for the first time and when adding capacity. For more information, see this parameter in the Cassandra 1.1 Node and Cluster Configuration documentation.\n"
-        "This parameter can be used with num_tokens (vnodes ) in special cases such as Restoring from a snapshot.")
+        "If you're not using vnodes or have num_tokens set to 1 or unspecified (#num_tokens), you should always specify this parameter when setting up a production cluster for the first time and when adding capacity. For more information, see this parameter in the Cassandra 1.1 Node and Cluster Configuration documentation.\n"
+        "This parameter can be used with num_tokens (vnodes ) in special cases, such as restoring from a snapshot.")
     , num_tokens(this, "num_tokens", value_status::Used, 1,
-        "Defines the number of tokens randomly assigned to this node on the ring when using virtual nodes (vnodes). The more tokens, relative to other nodes, the larger the proportion of data that the node stores. Generally all nodes should have the same number of tokens assuming equal hardware capability. The recommended value is 256. If unspecified (#num_tokens), Scylla uses 1 (equivalent to #num_tokens : 1) for legacy compatibility and uses the initial_token setting.\n"
+        "Defines the number of tokens randomly assigned to this node on the ring when using virtual nodes (vnodes). The more tokens relative to other nodes, the larger the proportion of data that the node stores. Generally, all nodes should have the same number of tokens, assuming equal hardware capability. The recommended value is 256. If unspecified (#num_tokens), ScyllaDB uses 1 (equivalent to #num_tokens : 1) for legacy compatibility and uses the initial_token setting.\n"
         "If not using vnodes, comment #num_tokens : 256 or set num_tokens : 1 and use initial_token. If you already have an existing cluster with one token per node and wish to migrate to vnodes, see Enabling virtual nodes on an existing production cluster.\n"
         "Note: If using DataStax Enterprise, the default setting of this property depends on the type of node and type of install.")
     , partitioner(this, "partitioner", value_status::Used, "org.apache.cassandra.dht.Murmur3Partitioner",
@@ -582,7 +582,7 @@ db::config::config(std::shared_ptr<db::extensions> exts)
         "The port for inter-node communication.")
     /* Advanced automatic backup setting */
     , auto_snapshot(this, "auto_snapshot", value_status::Used, true,
-        "Enable or disable whether a snapshot is taken of the data before keyspace truncation or dropping of tables. To prevent data loss, using the default setting is strongly advised. If you set to false, you will lose data on truncation or drop.")
+        "Specifies whether a snapshot is taken of the data before keyspace truncation or dropping of tables. To prevent data loss, using the default setting is strongly advised. If you set to false, you will lose data on truncation or drop.")
     /* Key caches and global row properties */
     /* When creating or modifying tables, you enable or disable the key cache (partition key cache) or row cache for that table by setting the caching parameter. Other row and key cache tuning and configuration options are set at the global (node) level. Cassandra uses these settings to automatically distribute memory for each table on the node based on the overall workload and specific table usage. You can also configure the save periods for these caches globally. */
     /* Related information: Configuring caches */
@@ -662,12 +662,12 @@ db::config::config(std::shared_ptr<db::extensions> exts)
         "\tdc : Traffic between data centers is compressed.\n"
         "\tnone : No compression.")
     , inter_dc_tcp_nodelay(this, "inter_dc_tcp_nodelay", value_status::Used, false,
-        "Enable or disable tcp_nodelay for inter-data center communication. When disabled larger, but fewer, network packets are sent. This reduces overhead from the TCP protocol itself. However, if cross data-center responses are blocked, it will increase latency.")
+        "Enables or disables tcp_nodelay for inter-data center communication. When disabled, larger but fewer, network packets are sent. This reduces overhead from the TCP protocol itself. However, if cross-datacenter responses are blocked, it will increase latency.")
     , streaming_socket_timeout_in_ms(this, "streaming_socket_timeout_in_ms", value_status::Unused, 0,
         "Enable or disable socket timeout for streaming operations. When a timeout occurs during streaming, streaming is retried from the start of the current file. Avoid setting this value too low, as it can result in a significant amount of data re-streaming.")
     /* Native transport (CQL Binary Protocol) */
     , start_native_transport(this, "start_native_transport", value_status::Used, true,
-        "Enable or disable the native transport server. Uses the same address as the rpc_address, but the port is different from the rpc_port. See native_transport_port.")
+        "Enables or disables the native transport server. Uses the same address as the rpc_address, but the port is different from the rpc_port. See native_transport_port.")
     , native_transport_port(this, "native_transport_port", "cql_port", value_status::Used, 9042,
         "Port on which the CQL native transport listens for clients.")
     , native_transport_port_ssl(this, "native_transport_port_ssl", value_status::Used, 9142,
@@ -677,9 +677,9 @@ db::config::config(std::shared_ptr<db::extensions> exts)
         "from native_transport_port will use encryption for native_transport_port_ssl while"
         "keeping native_transport_port unencrypted")
     , native_shard_aware_transport_port(this, "native_shard_aware_transport_port", value_status::Used, 19042,
-        "Like native_transport_port, but clients-side port number (modulo smp) is used to route the connection to the specific shard.")
+        "Like native_transport_port, but the client side port number (modulo smp) is used to route the connection to the specific shard.")
     , native_shard_aware_transport_port_ssl(this, "native_shard_aware_transport_port_ssl", value_status::Used, 19142,
-        "Like native_transport_port_ssl, but clients-side port number (modulo smp) is used to route the connection to the specific shard.")
+        "Like native_transport_port_ssl, but the client side port number (modulo smp) is used to route the connection to the specific shard.")
     , native_transport_max_threads(this, "native_transport_max_threads", value_status::Invalid, 128,
         "The maximum number of thread handling requests. The meaning is the same as rpc_max_threads.\n"
         "Default is different (128 versus unlimited).\n"
@@ -690,13 +690,13 @@ db::config::config(std::shared_ptr<db::extensions> exts)
     /* RPC (remote procedure call) settings */
     /* Settings for configuring and tuning client connections. */
     , broadcast_rpc_address(this, "broadcast_rpc_address", value_status::Used, {/* unset */},
-        "RPC address to broadcast to drivers and other Scylla nodes. This cannot be set to 0.0.0.0. If blank, it is set to the value of the rpc_address or rpc_interface. If rpc_address or rpc_interfaceis set to 0.0.0.0, this property must be set.\n")
+        "RPC address to broadcast to drivers and other ScyllaDB nodes. This cannot be set to 0.0.0.0. If blank, it is set to the value of the rpc_address or rpc_interface. If rpc_address or rpc_interfaceis set to 0.0.0.0, this property must be set.\n")
     , rpc_port(this, "rpc_port", "thrift_port", value_status::Used, 9160,
         "Thrift port for client connections.")
     , start_rpc(this, "start_rpc", value_status::Used, false,
         "Starts the Thrift RPC server")
     , rpc_keepalive(this, "rpc_keepalive", value_status::Used, true,
-        "Enable or disable keepalive on client connections (RPC or native).")
+        "Enables or disables keepalive on client connections (RPC or native).")
     , rpc_max_threads(this, "rpc_max_threads", value_status::Invalid, 0,
         "Regardless of your choice of RPC server (rpc_server_type), the number of maximum requests in the RPC thread pool dictates how many concurrent requests are possible. However, if you are using the parameter sync in the rpc_server_type, it also dictates the number of clients that can be connected. For a large number of client connections, this could cause excessive memory usage for the thread stack. Connection pooling on the client side is highly recommended. Setting a maximum thread pool size acts as a safeguard against misbehaved clients. If the maximum is reached, Cassandra blocks additional connections until a client disconnects.")
     , rpc_min_threads(this, "rpc_min_threads", value_status::Invalid, 16,
@@ -713,7 +713,7 @@ db::config::config(std::shared_ptr<db::extensions> exts)
         "\t         Note: When selecting this option, you must change the default value (unlimited) of rpc_max_threads.\n"
         "\tYour own RPC server: You must provide a fully-qualified class name of an o.a.c.t.TServerFactory that can create a server instance.")
     , cache_hit_rate_read_balancing(this, "cache_hit_rate_read_balancing", value_status::Used, true,
-        "This boolean controls whether the replicas for read query will be choosen based on cache hit ratio")
+        "This boolean controls whether the replicas for read query will be chosen based on the cache hit ratio.")
     /* Advanced fault detection settings */
     /* Settings to handle poorly performing or failing nodes. */
     , dynamic_snitch_badness_threshold(this, "dynamic_snitch_badness_threshold", value_status::Unused, 0,
@@ -723,14 +723,14 @@ db::config::config(std::shared_ptr<db::extensions> exts)
     , dynamic_snitch_update_interval_in_ms(this, "dynamic_snitch_update_interval_in_ms", value_status::Unused, 100,
         "The time interval for how often the snitch calculates node scores. Because score calculation is CPU intensive, be careful when reducing this interval.")
     , hinted_handoff_enabled(this, "hinted_handoff_enabled", value_status::Used, db::config::hinted_handoff_enabled_type(db::config::hinted_handoff_enabled_type::enabled_for_all_tag()),
-        "Enable or disable hinted handoff. To enable per data center, add data center list. For example: hinted_handoff_enabled: DC1,DC2. A hint indicates that the write needs to be replayed to an unavailable node. "
+        "Enables or disables hinted handoff. To enable per datacenter, add a datacenter list. For example: hinted_handoff_enabled: DC1,DC2. A hint indicates that the write needs to be replayed to an unavailable node. "
         "Related information: About hinted handoff writes")
     , max_hinted_handoff_concurrency(this, "max_hinted_handoff_concurrency", liveness::LiveUpdate, value_status::Used, 0,
-        "Maximum concurrency allowed for sending hints. The concurrency is divided across shards and rounded up if not divisible by the number of shards. By default (or when set to 0), concurrency of 8*shard_count will be used.")
+        "The maximum concurrency allowed for sending hints. The concurrency is divided across shards and rounded up if not divisible by the number of shards. By default (or when set to 0), concurrency of 8*shard_count will be used.")
     , hinted_handoff_throttle_in_kb(this, "hinted_handoff_throttle_in_kb", value_status::Unused, 1024,
         "Maximum throttle per delivery thread in kilobytes per second. This rate reduces proportionally to the number of nodes in the cluster. For example, if there are two nodes in the cluster, each delivery thread will use the maximum rate. If there are three, each node will throttle to half of the maximum, since the two nodes are expected to deliver hints simultaneously.")
     , max_hint_window_in_ms(this, "max_hint_window_in_ms", value_status::Used, 10800000,
-        "Maximum amount of time that hints are generates hints for an unresponsive node. After this interval, new hints are no longer generated until the node is back up and responsive. If the node goes down again, a new interval begins. This setting can prevent a sudden demand for resources when a node is brought back online and the rest of the cluster attempts to replay a large volume of hinted writes.\n"
+        "The maximum amount of time that hints are generated for an unresponsive node. After this interval, new hints are no longer generated until the node is back up and responsive. If the node goes down again, a new interval begins. This setting can prevent a sudden demand for resources when a node is brought back online and the rest of the cluster attempts to replay a large volume of hinted writes.\n"
         "Related information: Failure detection and recovery")
     , max_hints_delivery_threads(this, "max_hints_delivery_threads", value_status::Invalid, 2,
         "Number of threads with which to deliver hints. In multiple data-center deployments, consider increasing this number because cross data-center handoff is generally slower.")
@@ -762,7 +762,7 @@ db::config::config(std::shared_ptr<db::extensions> exts)
     /* Security properties */
     /* Server and client security settings. */
     , authenticator(this, "authenticator", value_status::Used, "org.apache.cassandra.auth.AllowAllAuthenticator",
-        "The authentication backend, used to identify users. The available authenticators are:\n"
+        "The authentication backend used to identify users. The available authenticators are:\n"
         "\n"
         "\torg.apache.cassandra.auth.AllowAllAuthenticator : Disables authentication; no checks are performed.\n"
         "\torg.apache.cassandra.auth.PasswordAuthenticator : Authenticates users with user names and hashed passwords stored in the system_auth.credentials table. If you use the default, 1, and the node with the lone replica goes down, you will not be able to log into the cluster because the system_auth keyspace was not replicated.\n"
@@ -781,27 +781,27 @@ db::config::config(std::shared_ptr<db::extensions> exts)
         "Related information: Object permissions"
         , {"AllowAllAuthorizer", "CassandraAuthorizer", "org.apache.cassandra.auth.AllowAllAuthorizer", "org.apache.cassandra.auth.CassandraAuthorizer", "com.scylladb.auth.TransitionalAuthorizer"})
     , role_manager(this, "role_manager", value_status::Used, "org.apache.cassandra.auth.CassandraRoleManager",
-        "The role-management backend, used to maintain grantts and memberships between roles.\n"
+        "The role-management backend used to maintain grants and memberships between roles.\n"
         "The available role-managers are:\n"
         "\tCassandraRoleManager : Stores role data in the system_auth keyspace.")
     , permissions_validity_in_ms(this, "permissions_validity_in_ms", liveness::LiveUpdate, value_status::Used, 10000,
         "How long permissions in cache remain valid. Depending on the authorizer, such as CassandraAuthorizer, fetching permissions can be resource intensive. Permissions caching is disabled when this property is set to 0 or when AllowAllAuthorizer is used. The cached value is considered valid as long as both its value is not older than the permissions_validity_in_ms "
-        "and the cached value has been read at least once during the permissions_validity_in_ms time frame. If any of these two conditions doesn't hold the cached value is going to be evicted from the cache.\n"
+        "and the cached value has been read at least once during the permissions_validity_in_ms time frame. If any of these two conditions doesn't hold, the cached value is going to be evicted from the cache.\n"
         "Related information: Object permissions")
     , permissions_update_interval_in_ms(this, "permissions_update_interval_in_ms", liveness::LiveUpdate, value_status::Used, 2000,
         "Refresh interval for permissions cache (if enabled). After this interval, cache entries become eligible for refresh. An async reload is scheduled every permissions_update_interval_in_ms time period and the old value is returned until it completes. If permissions_validity_in_ms has a non-zero value, then this property must also have a non-zero value. It's recommended to set this value to be at least 3 times smaller than the permissions_validity_in_ms.")
     , permissions_cache_max_entries(this, "permissions_cache_max_entries", liveness::LiveUpdate, value_status::Used, 1000,
         "Maximum cached permission entries. Must have a non-zero value if permissions caching is enabled (see a permissions_validity_in_ms description).")
     , server_encryption_options(this, "server_encryption_options", value_status::Used, {/*none*/},
-        "Enable or disable inter-node encryption. You must also generate keys and provide the appropriate key and trust store locations and passwords. The available options are:\n"
+        "Enables or disables inter-node encryption. You must also generate keys and provide the appropriate key and trust store locations and passwords. The available options are:\n"
         "\n"
-        "internode_encryption : (Default: none) Enable or disable encryption of inter-node communication using the TLS_RSA_WITH_AES_128_CBC_SHA cipher suite for authentication, key exchange, and encryption of data transfers. The available inter-node options are:\n"
+        "internode_encryption : (Default: none) Enables or disables encryption of inter-node communication using the TLS_RSA_WITH_AES_128_CBC_SHA cipher suite for authentication, key exchange, and encryption of data transfers. The available inter-node options are:\n"
         "\tall : Encrypt all inter-node communications.\n"
         "\tnone : No encryption.\n"
-        "\tdc : Encrypt the traffic between the data centers (server only).\n"
-        "\track : Encrypt the traffic between the racks(server only).\n"
+        "\tdc : Encrypts the traffic between the data centers (server only).\n"
+        "\track : Encrypts the traffic between the racks(server only).\n"
         "certificate : (Default: conf/scylla.crt) The location of a PEM-encoded x509 certificate used to identify and encrypt the internode communication.\n"
-        "keyfile : (Default: conf/scylla.key) PEM Key file associated with certificate.\n"
+        "keyfile : (Default: conf/scylla.key) PEM Key file associated with a certificate.\n"
         "truststore : (Default: <not set, use system truststore> ) Location of the truststore containing the trusted certificate for authenticating remote servers.\n"
         "certficate_revocation_list : (Default: <not set>) PEM encoded certificate revocation list.\n"
         "\n"
@@ -811,7 +811,7 @@ db::config::config(std::shared_ptr<db::extensions> exts)
         "\trequire_client_auth : (Default: false ) Enables or disables certificate authentication.\n"
         "Related information: Node-to-node encryption")
     , client_encryption_options(this, "client_encryption_options", value_status::Used, {/*none*/},
-        "Enable or disable client-to-node encryption. You must also generate keys and provide the appropriate key and certificate. The available options are:\n"
+        "Enables or disables client-to-node encryption. You must also generate keys and provide the appropriate key and certificate. The available options are:\n"
         "\n"
         "\tenabled : (Default: false) To enable, set to true.\n"
         "\tcertificate: (Default: conf/scylla.crt) The location of a PEM-encoded x509 certificate used to identify and encrypt the client/server communication.\n"
@@ -844,121 +844,121 @@ db::config::config(std::shared_ptr<db::extensions> exts)
     , api_ui_dir(this, "api_ui_dir", value_status::Used, "swagger-ui/dist/", "The directory location of the API GUI")
     , api_doc_dir(this, "api_doc_dir", value_status::Used, "api/api-doc/", "The API definition file directory")
     , load_balance(this, "load_balance", value_status::Unused, "none", "CQL request load balancing: 'none' or round-robin'")
-    , consistent_rangemovement(this, "consistent_rangemovement", value_status::Used, true, "When set to true, range movements will be consistent. It means: 1) it will refuse to bootstrap a new node if other bootstrapping/leaving/moving nodes detected. 2) data will be streamed to a new node only from the node which is no longer responsible for the token range. Same as -Dcassandra.consistent.rangemovement in cassandra")
+    , consistent_rangemovement(this, "consistent_rangemovement", value_status::Used, true, "When set to true, range movements will be consistent. It means that: 1) A new node will not bootstrap if other bootstrapping/leaving/moving nodes are detected; 2) Data will be streamed to a new node only from a node that is no longer responsible for the token range. This parameter is the same as -Dcassandra.consistent.rangemovement in Cassandra.")
     , join_ring(this, "join_ring", value_status::Unused, true, "When set to true, a node will join the token ring. When set to false, a node will not join the token ring. User can use nodetool join to initiate ring joinging later. Same as -Dcassandra.join_ring in cassandra.")
-    , load_ring_state(this, "load_ring_state", value_status::Used, true, "When set to true, load tokens and host_ids previously saved. Same as -Dcassandra.load_ring_state in cassandra.")
+    , load_ring_state(this, "load_ring_state", value_status::Used, true, "When set to true, load tokens and host_ids previously saved. This parameter is the same as -Dcassandra.load_ring_state in Cassandra.")
     , replace_node_first_boot(this, "replace_node_first_boot", value_status::Used, "", "The Host ID of a dead node to replace. If the replacing node has already been bootstrapped successfully, this option will be ignored.")
-    , replace_address(this, "replace_address", value_status::Used, "", "[[deprecated]] The listen_address or broadcast_address of the dead node to replace. Same as -Dcassandra.replace_address.")
-    , replace_address_first_boot(this, "replace_address_first_boot", value_status::Used, "", "[[deprecated]] Like replace_address option, but if the node has been bootstrapped successfully it will be ignored. Same as -Dcassandra.replace_address_first_boot.")
-    , ignore_dead_nodes_for_replace(this, "ignore_dead_nodes_for_replace", value_status::Used, "", "List dead nodes to ignore for replace operation using a comma-separated list of host IDs. E.g., scylla --ignore-dead-nodes-for-replace 8d5ed9f4-7764-4dbd-bad8-43fddce94b7c,125ed9f4-7777-1dbn-mac8-43fddce9123e")
-    , override_decommission(this, "override_decommission", value_status::Used, false, "Set true to force a decommissioned node to join the cluster (cannot be set if consistent-cluster-management is enabled")
-    , enable_repair_based_node_ops(this, "enable_repair_based_node_ops", liveness::LiveUpdate, value_status::Used, true, "Set true to use enable repair based node operations instead of streaming based")
-    , allowed_repair_based_node_ops(this, "allowed_repair_based_node_ops", liveness::LiveUpdate, value_status::Used, "replace,removenode,rebuild,bootstrap,decommission", "A comma separated list of node operations which are allowed to enable repair based node operations. The operations can be bootstrap, replace, removenode, decommission and rebuild")
-    , enable_compacting_data_for_streaming_and_repair(this, "enable_compacting_data_for_streaming_and_repair", liveness::LiveUpdate, value_status::Used, true, "Enable the compacting reader, which compacts the data for streaming and repair (load'n'stream included) before sending it to, or synchronizing it with peers. Can reduce the amount of data to be processed by removing dead data, but adds CPU overhead.")
-    , ring_delay_ms(this, "ring_delay_ms", value_status::Used, 30 * 1000, "Time a node waits to hear from other nodes before joining the ring in milliseconds. Same as -Dcassandra.ring_delay_ms in cassandra.")
-    , shadow_round_ms(this, "shadow_round_ms", value_status::Used, 300 * 1000, "The maximum gossip shadow round time. Can be used to reduce the gossip feature check time during node boot up.")
-    , fd_max_interval_ms(this, "fd_max_interval_ms", value_status::Used, 2 * 1000, "The maximum failure_detector interval time in milliseconds. Interval larger than the maximum will be ignored. Larger cluster may need to increase the default.")
-    , fd_initial_value_ms(this, "fd_initial_value_ms", value_status::Used, 2 * 1000, "The initial failure_detector interval time in milliseconds.")
-    , shutdown_announce_in_ms(this, "shutdown_announce_in_ms", value_status::Used, 2 * 1000, "Time a node waits after sending gossip shutdown message in milliseconds. Same as -Dcassandra.shutdown_announce_in_ms in cassandra.")
-    , developer_mode(this, "developer_mode", value_status::Used, DEVELOPER_MODE_DEFAULT, "Relax environment checks. Setting to true can reduce performance and reliability significantly.")
-    , skip_wait_for_gossip_to_settle(this, "skip_wait_for_gossip_to_settle", value_status::Used, -1, "An integer to configure the wait for gossip to settle. -1: wait normally, 0: do not wait at all, n: wait for at most n polls. Same as -Dcassandra.skip_wait_for_gossip_to_settle in cassandra.")
-    , force_gossip_generation(this, "force_gossip_generation", liveness::LiveUpdate, value_status::Used, -1 , "Force gossip to use the generation number provided by user")
+    , replace_address(this, "replace_address", value_status::Used, "", "[[deprecated]] The listen_address or broadcast_address of the dead node to replace. This parameter is the same as -Dcassandra.replace_address.")
+    , replace_address_first_boot(this, "replace_address_first_boot", value_status::Used, "", "[[deprecated]] Similar to the replace_address parameter, but if the node has been bootstrapped successfully, this parameter will be ignored. This parameter is the same as -Dcassandra.replace_address_first_boot.")
+    , ignore_dead_nodes_for_replace(this, "ignore_dead_nodes_for_replace", value_status::Used, "", "Lists dead nodes to ignore during the replace operation. Use a comma-separated list of host IDs. E.g., scylla --ignore-dead-nodes-for-replace 8d5ed9f4-7764-4dbd-bad8-43fddce94b7c,125ed9f4-7777-1dbn-mac8-43fddce9123e")
+    , override_decommission(this, "override_decommission", value_status::Used, false, "If set to true, forces a decommissioned node to join the cluster (cannot be set if consistent-cluster-management is enabled.")
+    , enable_repair_based_node_ops(this, "enable_repair_based_node_ops", liveness::LiveUpdate, value_status::Used, true, "If set to true to enable repair-based node operations node operations (instead of streaming-based node operations.")
+    , allowed_repair_based_node_ops(this, "allowed_repair_based_node_ops", liveness::LiveUpdate, value_status::Used, "replace,removenode,rebuild,bootstrap,decommission", "A comma-separated list of node operations that are allowed to enable repair-based node operations. The operations can be bootstrap, replace, removenode, decommission, and rebuild.")
+    , enable_compacting_data_for_streaming_and_repair(this, "enable_compacting_data_for_streaming_and_repair", liveness::LiveUpdate, value_status::Used, true, "Enables the compacting reader, which compacts the data for streaming and repair (load and stream included) before sending it to or synchronizing it with peers. It can reduce the amount of data to be processed by removing dead data, but adds CPU overhead.")
+    , ring_delay_ms(this, "ring_delay_ms", value_status::Used, 30 * 1000, " The time a node waits to hear from other nodes before joining the ring (in milliseconds). This parameter is the same as -Dcassandra.ring_delay_ms in Cassandra.")
+    , shadow_round_ms(this, "shadow_round_ms", value_status::Used, 300 * 1000, "The maximum gossip shadow round time. It can be used to reduce the gossip feature check time during node boot up.")
+    , fd_max_interval_ms(this, "fd_max_interval_ms", value_status::Used, 2 * 1000, "The maximum failure_detector interval time (in milliseconds). An interval larger than the maximum will be ignored. Larger clusters may need to increase the default.")
+    , fd_initial_value_ms(this, "fd_initial_value_ms", value_status::Used, 2 * 1000, "The initial failure_detector interval time (in milliseconds).")
+    , shutdown_announce_in_ms(this, "shutdown_announce_in_ms", value_status::Used, 2 * 1000, "The time a node waits after sending gossip shutdown message in milliseconds. This parameter is the same as -Dcassandra.shutdown_announce_in_ms in Cassandra.")
+    , developer_mode(this, "developer_mode", value_status::Used, DEVELOPER_MODE_DEFAULT, "Relaxes environment checks. Setting this parameter to true can reduce performance and reliability significantly.")
+    , skip_wait_for_gossip_to_settle(this, "skip_wait_for_gossip_to_settle", value_status::Used, -1, "An integer to configure the wait for gossip to settle. -1: wait normally; 0: do not wait at all; n: wait for at most n polls. This parameter is the same as -Dcassandra.skip_wait_for_gossip_to_settle in Cassandra.")
+    , force_gossip_generation(this, "force_gossip_generation", liveness::LiveUpdate, value_status::Used, -1 , "Forces gossip to use the generation number provided by the user.")
     , experimental_features(this, "experimental_features", value_status::Used, {}, experimental_features_help_string())
-    , lsa_reclamation_step(this, "lsa_reclamation_step", value_status::Used, 1, "Minimum number of segments to reclaim in a single step")
-    , prometheus_port(this, "prometheus_port", value_status::Used, 9180, "Prometheus port, set to zero to disable")
-    , prometheus_address(this, "prometheus_address", value_status::Used, {/* listen_address */}, "Prometheus listening address, defaulting to listen_address if not explicitly set")
-    , prometheus_prefix(this, "prometheus_prefix", value_status::Used, "scylla", "Set the prefix of the exported Prometheus metrics. Changing this will break Scylla's dashboard compatibility, do not change unless you know what you are doing.")
-    , abort_on_lsa_bad_alloc(this, "abort_on_lsa_bad_alloc", value_status::Used, false, "Abort when allocation in LSA region fails")
-    , murmur3_partitioner_ignore_msb_bits(this, "murmur3_partitioner_ignore_msb_bits", value_status::Used, default_murmur3_partitioner_ignore_msb_bits, "Number of most siginificant token bits to ignore in murmur3 partitioner; increase for very large clusters")
-    , unspooled_dirty_soft_limit(this, "unspooled_dirty_soft_limit", value_status::Used, 0.6, "Soft limit of unspooled dirty memory expressed as a portion of the hard limit")
+    , lsa_reclamation_step(this, "lsa_reclamation_step", value_status::Used, 1, "The minimum number of segments to reclaim in a single step.")
+    , prometheus_port(this, "prometheus_port", value_status::Used, 9180, "Prometheus port. Set to zero to disable.")
+    , prometheus_address(this, "prometheus_address", value_status::Used, {/* listen_address */}, "Prometheus listening address. Defaults to listen_address if not explicitly set.")
+    , prometheus_prefix(this, "prometheus_prefix", value_status::Used, "scylla", "Sets the prefix of the exported Prometheus metrics. Changing this parameter will break Scylla's dashboard compatibility. Do not change it unless you know what you are doing.")
+    , abort_on_lsa_bad_alloc(this, "abort_on_lsa_bad_alloc", value_status::Used, false, "Abort when allocation in LSA region fails.")
+    , murmur3_partitioner_ignore_msb_bits(this, "murmur3_partitioner_ignore_msb_bits", value_status::Used, default_murmur3_partitioner_ignore_msb_bits, "Number of most significant token bits to ignore in murmur3 partitioner. Increase it for very large clusters.")
+    , unspooled_dirty_soft_limit(this, "unspooled_dirty_soft_limit", value_status::Used, 0.6, "The soft limit of unspooled dirty memory expressed as a portion of the hard limit.")
     , sstable_summary_ratio(this, "sstable_summary_ratio", value_status::Used, 0.0005, "Enforces that 1 byte of summary is written for every N (2000 by default) "
-        "bytes written to data file. Value must be between 0 and 1.")
-    , large_memory_allocation_warning_threshold(this, "large_memory_allocation_warning_threshold", value_status::Used, size_t(1) << 20, "Warn about memory allocations above this size; set to zero to disable")
-    , enable_deprecated_partitioners(this, "enable_deprecated_partitioners", value_status::Used, false, "Enable the byteordered and random partitioners. These partitioners are deprecated and will be removed in a future version.")
-    , enable_keyspace_column_family_metrics(this, "enable_keyspace_column_family_metrics", value_status::Used, false, "Enable per keyspace and per column family metrics reporting")
-    , enable_node_aggregated_table_metrics(this, "enable_node_aggregated_table_metrics", value_status::Used, true, "Enable aggregated per node, per keyspace and per table metrics reporting, applicable if enable_keyspace_column_family_metrics is false")
-    , enable_sstable_data_integrity_check(this, "enable_sstable_data_integrity_check", value_status::Used, false, "Enable interposer which checks for integrity of every sstable write."
-        " Performance is affected to some extent as a result. Useful to help debugging problems that may arise at another layers.")
-    , enable_sstable_key_validation(this, "enable_sstable_key_validation", value_status::Used, ENABLE_SSTABLE_KEY_VALIDATION, "Enable validation of partition and clustering keys monotonicity"
-        " Performance is affected to some extent as a result. Useful to help debugging problems that may arise at another layers.")
-    , cpu_scheduler(this, "cpu_scheduler", value_status::Used, true, "Enable cpu scheduling")
-    , view_building(this, "view_building", value_status::Used, true, "Enable view building; should only be set to false when the node is experience issues due to view building")
+        "bytes written to a data file. The value must be between 0 and 1.")
+    , large_memory_allocation_warning_threshold(this, "large_memory_allocation_warning_threshold", value_status::Used, size_t(1) << 20, "Warns about memory allocations above this size. Set to zero to disable.")
+    , enable_deprecated_partitioners(this, "enable_deprecated_partitioners", value_status::Used, false, "Enables the byteorder and random partitioners. These partitioners are deprecated and will be removed in a future version.")
+    , enable_keyspace_column_family_metrics(this, "enable_keyspace_column_family_metrics", value_status::Used, false, "Enables per keyspace and per column family metrics reporting.")
+    , enable_node_aggregated_table_metrics(this, "enable_node_aggregated_table_metrics", value_status::Used, true, "Enables aggregated per node, per keyspace, and per table metrics reporting. Applicable if enable_keyspace_column_family_metrics is false.")
+    , enable_sstable_data_integrity_check(this, "enable_sstable_data_integrity_check", value_status::Used, false, "Enables interposer that checks for integrity of every SStable write."
+        " Performance is affected to some extent as a result. Useful to help debug problems that may arise at other layers.")
+    , enable_sstable_key_validation(this, "enable_sstable_key_validation", value_status::Used, ENABLE_SSTABLE_KEY_VALIDATION, "Enables validation of partition and clustering keys monotonicity."
+        " Performance is affected to some extent as a result. Useful to help debug problems that may arise at other layers.")
+    , cpu_scheduler(this, "cpu_scheduler", value_status::Used, true, "Enables CPU scheduling.")
+    , view_building(this, "view_building", value_status::Used, true, "Enables view building. It should only be set to false when the node experience issues due to view building.")
     , enable_sstables_mc_format(this, "enable_sstables_mc_format", value_status::Unused, true, "Enable SSTables 'mc' format to be used as the default file format.  Deprecated, please use \"sstable_format\" instead.")
     , enable_sstables_md_format(this, "enable_sstables_md_format", value_status::Unused, true, "Enable SSTables 'md' format to be used as the default file format.  Deprecated, please use \"sstable_format\" instead.")
-    , sstable_format(this, "sstable_format", value_status::Used, "me", "Default sstable file format", {"md", "me"})
+    , sstable_format(this, "sstable_format", value_status::Used, "me", "The default SStable file format.", {"md", "me"})
     , uuid_sstable_identifiers_enabled(this,
-            "uuid_sstable_identifiers_enabled", liveness::LiveUpdate, value_status::Used, true, "If set to true, each newly created sstable will have a UUID "
-            "based generation identifier, and such files are not readable by previous Scylla versions.")
+            "uuid_sstable_identifiers_enabled", liveness::LiveUpdate, value_status::Used, true, "If set to true, each newly created SStable will have  "
+            " a UUID-based generation identifier.")
     , table_digest_insensitive_to_expiry(this, "table_digest_insensitive_to_expiry", liveness::MustRestart, value_status::Used, true,
             "When enabled, per-table schema digest calculation ignores empty partitions.")
-    , enable_dangerous_direct_import_of_cassandra_counters(this, "enable_dangerous_direct_import_of_cassandra_counters", value_status::Used, false, "Only turn this option on if you want to import tables from Cassandra containing counters, and you are SURE that no counters in that table were created in a version earlier than Cassandra 2.1."
-        " It is not enough to have ever since upgraded to newer versions of Cassandra. If you EVER used a version earlier than 2.1 in the cluster where these SSTables come from, DO NOT TURN ON THIS OPTION! You will corrupt your data. You have been warned.")
-    , enable_shard_aware_drivers(this, "enable_shard_aware_drivers", value_status::Used, true, "Enable native transport drivers to use connection-per-shard for better performance")
-    , enable_ipv6_dns_lookup(this, "enable_ipv6_dns_lookup", value_status::Used, false, "Use IPv6 address resolution")
-    , abort_on_internal_error(this, "abort_on_internal_error", liveness::LiveUpdate, value_status::Used, false, "Abort the server instead of throwing exception when internal invariants are violated")
+    , enable_dangerous_direct_import_of_cassandra_counters(this, "enable_dangerous_direct_import_of_cassandra_counters", value_status::Used, false, "You should only enable  this option if you want to import tables containing counters from Cassandra, and you are SURE that no counters in those tables were created in a version earlier than Cassandra 2.1."
+        " It is not enough to have ever since upgraded to newer versions of Cassandra. If you EVER used a version earlier than 2.1 in the cluster where these SSTables come from, DO NOT TURN ON THIS OPTION! You will corrupt your data.")
+    , enable_shard_aware_drivers(this, "enable_shard_aware_drivers", value_status::Used, true, "Enables native transport drivers to use connection-per-shard for better performance.")
+    , enable_ipv6_dns_lookup(this, "enable_ipv6_dns_lookup", value_status::Used, false, "Enables using IPv6 address resolution.")
+    , abort_on_internal_error(this, "abort_on_internal_error", liveness::LiveUpdate, value_status::Used, false, "Aborts the server instead of throwing an exception when internal invariants are violated.")
     , max_partition_key_restrictions_per_query(this, "max_partition_key_restrictions_per_query", liveness::LiveUpdate, value_status::Used, 100,
-            "Maximum number of distinct partition keys restrictions per query. This limit places a bound on the size of IN tuples, "
+            "The maximum number of distinct partition keys restrictions per query. This limit places a bound on the size of IN tuples, "
             "especially when multiple partition key columns have IN restrictions. Increasing this value can result in server instability.")
     , max_clustering_key_restrictions_per_query(this, "max_clustering_key_restrictions_per_query", liveness::LiveUpdate, value_status::Used, 100,
-            "Maximum number of distinct clustering key restrictions per query. This limit places a bound on the size of IN tuples, "
+            "The maximum number of distinct clustering key restrictions per query. This limit places a bound on the size of IN tuples, "
             "especially when multiple clustering key columns have IN restrictions. Increasing this value can result in server instability.")
     , max_memory_for_unlimited_query_soft_limit(this, "max_memory_for_unlimited_query_soft_limit", liveness::LiveUpdate, value_status::Used, uint64_t(1) << 20,
-            "Maximum amount of memory a query, whose memory consumption is not naturally limited, is allowed to consume, e.g. non-paged and reverse queries. "
-            "This is the soft limit, there will be a warning logged for queries violating this limit.")
+            "The maximum amount of memory a query, whose memory consumption is not naturally limited, is allowed to consume, e.g.; non-paged and reverse queries. "
+            "This is the soft limit - there will be a warning logged for queries violating this limit.")
     , max_memory_for_unlimited_query_hard_limit(this, "max_memory_for_unlimited_query_hard_limit", "max_memory_for_unlimited_query", liveness::LiveUpdate, value_status::Used, (uint64_t(100) << 20),
-            "Maximum amount of memory a query, whose memory consumption is not naturally limited, is allowed to consume, e.g. non-paged and reverse queries. "
-            "This is the hard limit, queries violating this limit will be aborted.")
+            "The maximum amount of memory a query, whose memory consumption is not naturally limited, is allowed to consume, e.g.; non-paged and reverse queries. "
+            "This is the hard limit - queries violating this limit will be aborted.")
     , reader_concurrency_semaphore_serialize_limit_multiplier(this, "reader_concurrency_semaphore_serialize_limit_multiplier", liveness::LiveUpdate, value_status::Used, 2,
-            "Start serializing reads after their collective memory consumption goes above $normal_limit * $multiplier.")
+            "Starts serializing reads after their collective memory consumption goes above $normal_limit * $multiplier.")
     , reader_concurrency_semaphore_kill_limit_multiplier(this, "reader_concurrency_semaphore_kill_limit_multiplier", liveness::LiveUpdate, value_status::Used, 4,
-            "Start killing reads after their collective memory consumption goes above $normal_limit * $multiplier.")
+            "Starts killing reads after their collective memory consumption goes above $normal_limit * $multiplier.")
     , twcs_max_window_count(this, "twcs_max_window_count", liveness::LiveUpdate, value_status::Used, 50,
-            "The maximum number of compaction windows allowed when making use of TimeWindowCompactionStrategy. A setting of 0 effectively disables the restriction.")
+            "The maximum number of compaction windows allowed when making use of TimeWindowCompactionStrategy. Setting 0 effectively disables the restriction.")
     , initial_sstable_loading_concurrency(this, "initial_sstable_loading_concurrency", value_status::Used, 4u,
-            "Maximum amount of sstables to load in parallel during initialization. A higher number can lead to more memory consumption. You should not need to touch this")
+            "The maximum amount of SStables to load in parallel during initialization. A higher number can lead to more memory consumption. You should not need to touch this.")
     , enable_3_1_0_compatibility_mode(this, "enable_3_1_0_compatibility_mode", value_status::Used, false,
         "Set to true if the cluster was initially installed from 3.1.0. If it was upgraded from an earlier version,"
-        " or installed from a later version, leave this set to false. This adjusts the communication protocol to"
-        " work around a bug in Scylla 3.1.0")
-    , enable_user_defined_functions(this, "enable_user_defined_functions", value_status::Used, false,  "Enable user defined functions. You must also set experimental-features=udf")
-    , user_defined_function_time_limit_ms(this, "user_defined_function_time_limit_ms", value_status::Used, 10, "The time limit for each UDF invocation")
-    , user_defined_function_allocation_limit_bytes(this, "user_defined_function_allocation_limit_bytes", value_status::Used, 1024*1024, "How much memory each UDF invocation can allocate")
-    , user_defined_function_contiguous_allocation_limit_bytes(this, "user_defined_function_contiguous_allocation_limit_bytes", value_status::Used, 1024*1024, "How much memory each UDF invocation can allocate in one chunk")
+        " or installed from a later version, leave this parameter set to false. This adjusts the communication protocol to"
+        " work around a bug in Scylla 3.1.0.")
+    , enable_user_defined_functions(this, "enable_user_defined_functions", value_status::Used, false,  "Enables user-defined functions. You must also set experimental-features=udf.")
+    , user_defined_function_time_limit_ms(this, "user_defined_function_time_limit_ms", value_status::Used, 10, "The time limit for each UDF invocation.")
+    , user_defined_function_allocation_limit_bytes(this, "user_defined_function_allocation_limit_bytes", value_status::Used, 1024*1024, "Specifies how much memory each UDF invocation can allocate.")
+    , user_defined_function_contiguous_allocation_limit_bytes(this, "user_defined_function_contiguous_allocation_limit_bytes", value_status::Used, 1024*1024, "Specifies how much memory each UDF invocation can allocate in one chunk.")
     , schema_registry_grace_period(this, "schema_registry_grace_period", value_status::Used, 1,
-        "Time period in seconds after which unused schema versions will be evicted from the local schema registry cache. Default is 1 second.")
+        "The time (in seconds) after which unused schema versions will be evicted from the local schema registry cache. The default is 1 second.")
     , max_concurrent_requests_per_shard(this, "max_concurrent_requests_per_shard", liveness::LiveUpdate, value_status::Used, std::numeric_limits<uint32_t>::max(),
-        "Maximum number of concurrent requests a single shard can handle before it starts shedding extra load. By default, no requests will be shed.")
+        "The maximum number of concurrent requests a single shard can handle before it starts shedding extra load. By default, no requests will be shed.")
     , cdc_dont_rewrite_streams(this, "cdc_dont_rewrite_streams", value_status::Used, false,
-            "Disable rewriting streams from cdc_streams_descriptions to cdc_streams_descriptions_v2. Should not be necessary, but the procedure is expensive and prone to failures; this config option is left as a backdoor in case some user requires manual intervention.")
-    , strict_allow_filtering(this, "strict_allow_filtering", liveness::LiveUpdate, value_status::Used, strict_allow_filtering_default(), "Match Cassandra in requiring ALLOW FILTERING on slow queries. Can be true, false, or warn. When false, Scylla accepts some slow queries even without ALLOW FILTERING that Cassandra rejects. Warn is same as false, but with warning.")
+            "Disables rewriting streams from cdc_streams_descriptions to cdc_streams_descriptions_v2. It should not be necessary, but the procedure is expensive and prone to failures. This config option is a backdoor in case manual intervention is required.")
+    , strict_allow_filtering(this, "strict_allow_filtering", liveness::LiveUpdate, value_status::Used, strict_allow_filtering_default(), "Matches Cassandra in requiring ALLOW FILTERING on slow queries. It can be set  to true, false, or warn. When false, ScyllaDB accepts some slow queries even without ALLOW FILTERING that Cassandra rejects. Warn is same as false, but with a warning.")
     , strict_is_not_null_in_views(this, "strict_is_not_null_in_views", liveness::LiveUpdate, value_status::Used,db::tri_mode_restriction_t::mode::WARN, 
         "In materialized views, restrictions are allowed only on the view's primary key columns.\n"
-        "In old versions Scylla mistakenly allowed IS NOT NULL restrictions on columns which were not part of the view's"
+        "In old versions, ScyllaDB mistakenly allowed IS NOT NULL restrictions on columns that were not part of the view's"
         " primary key. These invalid restrictions were ignored.\n"
         "This option controls the behavior when someone tries to create a view with such invalid IS NOT NULL restrictions.\n\n"
-        "Can be true, false, or warn:\n"
+        "It can be set to true, false, or warn:\n"
         " * `true`: IS NOT NULL is allowed only on the view's primary key columns, "
         "trying to use it on other columns will cause an error, as it should.\n"
-        " * `false`: Scylla accepts IS NOT NULL restrictions on regular columns, but they're silently ignored. "
-        "It's useful for backwards compatibility.\n"
+        " * `false`: ScyllaDB accepts IS NOT NULL restrictions on regular columns, but they're silently ignored. "
+        "It's useful for backward compatibility.\n"
         " * `warn`: The same as false, but there's a warning about invalid view restrictions.\n\n"
-        "To preserve backwards compatibility on old clusters, Scylla's default setting is `warn`. "
-        "New clusters have this option set to `true` by scylla.yaml (which overrides the default `warn`), "
+        "To preserve backward compatibility on old clusters, Scylla's default setting is `warn`. "
+        "New clusters have this option set to `true` by scylla.yaml (which overrides the default `warn`) "
         "to make sure that trying to create an invalid view causes an error.")
     , reversed_reads_auto_bypass_cache(this, "reversed_reads_auto_bypass_cache", liveness::LiveUpdate, value_status::Used, false,
-            "Bypass in-memory data cache (the row cache) when performing reversed queries.")
+            "Bypasses in-memory data cache (the row cache) when performing reversed queries.")
     , enable_optimized_reversed_reads(this, "enable_optimized_reversed_reads", liveness::LiveUpdate, value_status::Used, true,
-            "Use a new optimized algorithm for performing reversed reads.")
+            "Enables a new optimized algorithm for performing reversed reads.")
     , enable_cql_config_updates(this, "enable_cql_config_updates", liveness::LiveUpdate, value_status::Used, true,
-            "Make the system.config table UPDATEable")
+            "Makes the system.config table UPDATEable.")
     , enable_parallelized_aggregation(this, "enable_parallelized_aggregation", liveness::LiveUpdate, value_status::Used, true,
-            "Use on a new, parallel algorithm for performing aggregate queries.")
-    , alternator_port(this, "alternator_port", value_status::Used, 0, "Alternator API port")
-    , alternator_https_port(this, "alternator_https_port", value_status::Used, 0, "Alternator API HTTPS port")
-    , alternator_address(this, "alternator_address", value_status::Used, "0.0.0.0", "Alternator API listening address")
-    , alternator_enforce_authorization(this, "alternator_enforce_authorization", value_status::Used, false, "Enforce checking the authorization header for every request in Alternator")
-    , alternator_write_isolation(this, "alternator_write_isolation", value_status::Used, "", "Default write isolation policy for Alternator")
-    , alternator_streams_time_window_s(this, "alternator_streams_time_window_s", value_status::Used, 10, "CDC query confidence window for alternator streams")
+            "Enables a new, parallel algorithm for performing aggregate queries.")
+    , alternator_port(this, "alternator_port", value_status::Used, 0, "Alternator API port.")
+    , alternator_https_port(this, "alternator_https_port", value_status::Used, 0, "Alternator API HTTPS port.")
+    , alternator_address(this, "alternator_address", value_status::Used, "0.0.0.0", "Alternator API listening address.")
+    , alternator_enforce_authorization(this, "alternator_enforce_authorization", value_status::Used, false, "Enforces checking the authorization header for every request in Alternator.")
+    , alternator_write_isolation(this, "alternator_write_isolation", value_status::Used, "", "The default write isolation policy for Alternator.")
+    , alternator_streams_time_window_s(this, "alternator_streams_time_window_s", value_status::Used, 10, "CDC query confidence window for alternator streams.")
     , alternator_timeout_in_ms(this, "alternator_timeout_in_ms", liveness::LiveUpdate, value_status::Used, 10000,
         "The server-side timeout for completing Alternator API requests.")
     , alternator_ttl_period_in_seconds(this, "alternator_ttl_period_in_seconds", value_status::Used,
@@ -971,57 +971,57 @@ db::config::config(std::shared_ptr<db::extensions> exts)
         "the same endpoint used in the request. The string 'disabled' "
         "disables the DescribeEndpoints operation. Any other string is the "
         "fixed value that will be returned by DescribeEndpoints operations.")
-    , abort_on_ebadf(this, "abort_on_ebadf", value_status::Used, true, "Abort the server on incorrect file descriptor access. Throws exception when disabled.")
+    , abort_on_ebadf(this, "abort_on_ebadf", value_status::Used, true, "Aborts the server on incorrect file descriptor access. Throws an exception when disabled.")
     , redis_port(this, "redis_port", value_status::Used, 0, "Port on which the REDIS transport listens for clients.")
     , redis_ssl_port(this, "redis_ssl_port", value_status::Used, 0, "Port on which the REDIS TLS native transport listens for clients.")
-    , redis_read_consistency_level(this, "redis_read_consistency_level", value_status::Used, "LOCAL_QUORUM", "Consistency level for read operations for redis.")
-    , redis_write_consistency_level(this, "redis_write_consistency_level", value_status::Used, "LOCAL_QUORUM", "Consistency level for write operations for redis.")
-    , redis_database_count(this, "redis_database_count", value_status::Used, 16, "Database count for the redis. You can use the default settings (16).")
+    , redis_read_consistency_level(this, "redis_read_consistency_level", value_status::Used, "LOCAL_QUORUM", "Consistency level for read operations for Redis.")
+    , redis_write_consistency_level(this, "redis_write_consistency_level", value_status::Used, "LOCAL_QUORUM", "Consistency level for write operations for Redis.")
+    , redis_database_count(this, "redis_database_count", value_status::Used, 16, "Database count for Redis. You can use the default settings (16).")
     , redis_keyspace_replication_strategy_options(this, "redis_keyspace_replication_strategy", value_status::Used, {}, 
-        "Set the replication strategy for the redis keyspace. The setting is used by the first node in the boot phase when the keyspace is not exists to create keyspace for redis.\n"
-        "The replication strategy determines how many copies of the data are kept in a given data center. This setting impacts consistency, availability and request speed.\n"
+        "Sets the replication strategy for the Redis keyspace. The setting is used by the first node in the boot phase to create a keyspace for Redis when the keyspace does not exist.\n"
+        "The replication strategy determines how many copies of the data are kept in a given data center. This setting impacts consistency, availability, and request speed.\n"
         "Two strategies are available: SimpleStrategy and NetworkTopologyStrategy.\n\n"
-        "\tclass: (Default: SimpleStrategy ). Set the replication strategy for redis keyspace.\n"
-        "\t'replication_factor':N, (Default: 'replication_factor':1) IFF the class is SimpleStrategy, assign the same replication factor to the entire cluster.\n"
-        "\t'datacenter_name':N [,...], (Default: 'dc1:1') IFF the class is NetworkTopologyStrategy, assign replication factors to each data center in a comma separated list.\n"
+        "\tclass: (Default: SimpleStrategy ). Set the replication strategy for the Redis keyspace.\n"
+        "\t'replication_factor':N, (Default: 'replication_factor':1). If the class is SimpleStrategy, assigns the same replication factor to the entire cluster.\n"
+        "\t'datacenter_name':N [,...], (Default: 'dc1:1'). If the class is NetworkTopologyStrategy, assigns replication factors to each data center in a comma-separated list.\n"
         "\n"
         "Related information: About replication strategy.")
     , sanitizer_report_backtrace(this, "sanitizer_report_backtrace", value_status::Used, false,
-            "In debug mode, report log-structured allocator sanitizer violations with a backtrace. Slow.")
+            "In debug mode, reports log-structured allocator sanitizer violations with a backtrace. Slow.")
     , flush_schema_tables_after_modification(this, "flush_schema_tables_after_modification", liveness::LiveUpdate, value_status::Used, true,
-        "Flush tables in the system_schema keyspace after schema modification. This is required for crash recovery, but slows down tests and can be disabled for them")
-    , restrict_replication_simplestrategy(this, "restrict_replication_simplestrategy", liveness::LiveUpdate, value_status::Used, db::tri_mode_restriction_t::mode::FALSE, "Controls whether to disable SimpleStrategy replication. Can be true, false, or warn.")
-    , restrict_dtcs(this, "restrict_dtcs", liveness::LiveUpdate, value_status::Unused, db::tri_mode_restriction_t::mode::TRUE, "Controls whether to prevent setting DateTieredCompactionStrategy. Can be true, false, or warn.")
+        "Flushes tables in the system_schema keyspace after schema modification. This is required for crash recovery, but slows down tests and can be disabled for them.")
+    , restrict_replication_simplestrategy(this, "restrict_replication_simplestrategy", liveness::LiveUpdate, value_status::Used, db::tri_mode_restriction_t::mode::FALSE, "Controls whether to disable SimpleStrategy replication. It can be set to true, false, or warn.")
+    , restrict_dtcs(this, "restrict_dtcs", liveness::LiveUpdate, value_status::Unused, db::tri_mode_restriction_t::mode::TRUE, "Controls whether to prevent setting DateTieredCompactionStrategy. It can be set to true, false, or warn.")
     , restrict_twcs_without_default_ttl(this, "restrict_twcs_without_default_ttl", liveness::LiveUpdate, value_status::Used, db::tri_mode_restriction_t::mode::WARN, "Controls whether to prevent creating TimeWindowCompactionStrategy tables without a default TTL. Can be true, false, or warn.")
     , restrict_future_timestamp(this, "restrict_future_timestamp",liveness::LiveUpdate, value_status::Used, true, "Controls whether to detect and forbid unreasonable USING TIMESTAMP, more than 3 days into the future.")
     , ignore_truncation_record(this, "unsafe_ignore_truncation_record", value_status::Used, false,
-        "Ignore truncation record stored in system tables as if tables were never truncated.")
+        "Ignores the truncation record stored in system tables as if tables were never truncated.")
     , force_schema_commit_log(this, "force_schema_commit_log", value_status::Used, false,
-        "Use separate schema commit log unconditionally rater than after restart following discovery of cluster-wide support for it.")
-    , task_ttl_seconds(this, "task_ttl_in_seconds", liveness::LiveUpdate, value_status::Used, 0, "Time for which information about finished task stays in memory.")
-    , nodeops_watchdog_timeout_seconds(this, "nodeops_watchdog_timeout_seconds", liveness::LiveUpdate, value_status::Used, 120, "Time in seconds after which node operations abort when not hearing from the coordinator")
-    , nodeops_heartbeat_interval_seconds(this, "nodeops_heartbeat_interval_seconds", liveness::LiveUpdate, value_status::Used, 10, "Period of heartbeat ticks in node operations")
+        "Enables using a separate schema commit log unconditionally rather than after restart, following discovery of cluster-wide support for it.")
+    , task_ttl_seconds(this, "task_ttl_in_seconds", liveness::LiveUpdate, value_status::Used, 0, "Specifies how long information about finished task stays in memory.")
+    , nodeops_watchdog_timeout_seconds(this, "nodeops_watchdog_timeout_seconds", liveness::LiveUpdate, value_status::Used, 120, "The time (in seconds) after which node operations abort when not hearing from the coordinator.")
+    , nodeops_heartbeat_interval_seconds(this, "nodeops_heartbeat_interval_seconds", liveness::LiveUpdate, value_status::Used, 10, "The period of heartbeat ticks in node operations.")
     , cache_index_pages(this, "cache_index_pages", liveness::LiveUpdate, value_status::Used, true,
-        "Keep SSTable index pages in the global cache after a SSTable read. Expected to improve performance for workloads with big partitions, but may degrade performance for workloads with small partitions. The amount of memory usable by index cache is limited with `index_cache_fraction`.")
+        "Enables keeping SSTable index pages in the global cache after an SSTable read. Expected to improve performance for workloads with big partitions, but may degrade performance for workloads with small partitions. The amount of memory usable by index cache is limited with `index_cache_fraction`.")
     , index_cache_fraction(this, "index_cache_fraction", liveness::LiveUpdate, value_status::Used, 0.2,
-        "The maximum fraction of cache memory permitted for use by index cache. Clamped to the [0.0; 1.0] range. Must be small enough to not deprive the row cache of memory, but should be big enough to fit a large fraction of the index. The default value 0.2 means that at least 80\% of cache memory is reserved for the row cache, while at most 20\% is usable by the index cache.")
-     , consistent_cluster_management(this, "consistent_cluster_management", value_status::Used, true, "Use RAFT for cluster management and DDL")
-    , wasm_cache_memory_fraction(this, "wasm_cache_memory_fraction", value_status::Used, 0.01, "Maximum total size of all WASM instances stored in the cache as fraction of total shard memory")
-    , wasm_cache_timeout_in_ms(this, "wasm_cache_timeout_in_ms", value_status::Used, 5000, "Time after which an instance is evicted from the cache")
-    , wasm_cache_instance_size_limit(this, "wasm_cache_instance_size_limit", value_status::Used, 1024*1024, "Instances with size above this limit will not be stored in the cache")
-    , wasm_udf_yield_fuel(this, "wasm_udf_yield_fuel", value_status::Used, 100000, "Wasmtime fuel a WASM UDF can consume before yielding")
-    , wasm_udf_total_fuel(this, "wasm_udf_total_fuel", value_status::Used, 100000000, "Wasmtime fuel a WASM UDF can consume before termination")
-    , wasm_udf_memory_limit(this, "wasm_udf_memory_limit", value_status::Used, 2*1024*1024, "How much memory each WASM UDF can allocate at most")
-    , relabel_config_file(this, "relabel_config_file", value_status::Used, "", "Optionally, read relabel config from file")
-    , object_storage_config_file(this, "object_storage_config_file", value_status::Used, "", "Optionally, read object-storage endpoints config from file")
-    , live_updatable_config_params_changeable_via_cql(this, "live_updatable_config_params_changeable_via_cql", liveness::MustRestart, value_status::Used, true, "If set to true, configuration parameters defined with LiveUpdate can be updated in runtime via CQL (by updating system.config virtual table), otherwise they can't.")
+        "The maximum fraction of cache memory permitted for use by index cache. Clamped to the [0.0; 1.0] range. It must be small enough to not deprive the row cache of memory, but should be big enough to fit a large fraction of the index. The default value 0.2 means that at least 80\% of cache memory is reserved for the row cache, while at most 20\% is usable by the index cache.")
+     , consistent_cluster_management(this, "consistent_cluster_management", value_status::Used, true, "Enables using RAFT for cluster management and DDL.")
+    , wasm_cache_memory_fraction(this, "wasm_cache_memory_fraction", value_status::Used, 0.01, "The maximum total size of all WASM instances stored in the cache as a fraction of total shard memory.")
+    , wasm_cache_timeout_in_ms(this, "wasm_cache_timeout_in_ms", value_status::Used, 5000, "The time after which an instance is evicted from the cache.")
+    , wasm_cache_instance_size_limit(this, "wasm_cache_instance_size_limit", value_status::Used, 1024*1024, "Instances with size above this limit will not be stored in the cache.")
+    , wasm_udf_yield_fuel(this, "wasm_udf_yield_fuel", value_status::Used, 100000, "Wasmtime fuel a WASM UDF can consume before yielding.")
+    , wasm_udf_total_fuel(this, "wasm_udf_total_fuel", value_status::Used, 100000000, "Wasmtime fuel a WASM UDF can consume before termination.")
+    , wasm_udf_memory_limit(this, "wasm_udf_memory_limit", value_status::Used, 2*1024*1024, "Specifies how much memory each WASM UDF can allocate at most.")
+    , relabel_config_file(this, "relabel_config_file", value_status::Used, "", "Optionally, reads relabel config from a file.")
+    , object_storage_config_file(this, "object_storage_config_file", value_status::Used, "", "Optionally, reads object-storage endpoints config from a file.")
+    , live_updatable_config_params_changeable_via_cql(this, "live_updatable_config_params_changeable_via_cql", liveness::MustRestart, value_status::Used, true, "If set to true, configuration parameters defined with LiveUpdate can be updated in runtime via CQL (by updating system.config virtual table); otherwise, they can't.")
     , auth_superuser_name(this, "auth_superuser_name", value_status::Used, "",
-        "Initial authentication super username. Ignored if authentication tables already contain a super user")
+        "Initial authentication superuser name. Ignored if authentication tables already contain a superuser.")
     , auth_superuser_salted_password(this, "auth_superuser_salted_password", value_status::Used, "", 
-        "Initial authentication super user salted password. Create using mkpassword or similar. The hashing algorithm used must be available on the node host. "
-        "Ignored if authentication tables already contain a super user password.")
+        "Initial authentication superuser salted password (create using mkpassword or similar). The hashing algorithm used must be available on the node host. "
+        "Ignored if authentication tables already contain a superuser password.")
     , auth_certificate_role_queries(this, "auth_certificate_role_queries", value_status::Used, { { { "source", "SUBJECT" }, {"query", "CN=([^,]+)" } } },
-        "Regular expression used by CertificateAuthenticator to extract role name from an accepted transport authentication certificate subject info.")
+        "The regular expression used by CertificateAuthenticator to extract the role name from an accepted transport authentication certificate subject info.")
     , minimum_replication_factor_fail_threshold(this, "minimum_replication_factor_fail_threshold", liveness::LiveUpdate, value_status::Used, -1, "")
     , minimum_replication_factor_warn_threshold(this, "minimum_replication_factor_warn_threshold", liveness::LiveUpdate, value_status::Used,  3, "")
     , maximum_replication_factor_warn_threshold(this, "maximum_replication_factor_warn_threshold", liveness::LiveUpdate, value_status::Used, -1, "")


### PR DESCRIPTION
This PR fixes the descriptions of configuration parameters in the `config.cc` file in terms of language correctness, especially typos, punctuation, grammar, capitalization, and minor wording changes.

This commit DOES NOT alter the parameter descriptions in a way that may change their meaning (such updates will be added with follow-up PRs, as they need to be reviewed by subject matter experts.

Background:
The descriptions of the parameters from the `config.cc file` are now published and available in user-facing documentation, so we need to ensure they are both correct and clear.