### PR TITLE
[5.2 backport] doc: remove recommended image upgrade with OS

### DIFF
--- a/docs/upgrade/ami-upgrade.rst
+++ b/docs/upgrade/ami-upgrade.rst
@@ -2,21 +2,13 @@
 Upgrade ScyllaDB Image: EC2 AMI, GCP, and Azure Images
 ======================================================
 
-Upgrading ScyllaDB images requires updating:
+To upgrade ScyllaDB images, you need to update:
 
-* ScyllaDB packages.
-* Underlying OS packages. Starting with ScyllaDB 4.6, each ScyllaDB version includes a list of 3rd party and 
-  OS packages tested with the ScyllaDB release. The list depends on the base OS:
-  
-  * ScyllaDB Open Source **5.0 and 5.1** and ScyllaDB Enterprise **2021.1, 2022.1, and 2022.2** are based on **Ubuntu 20.04**.
-  * ScyllaDB Open Source **5.2** and ScyllaDB Enterprise **2023.1** are based on **Ubuntu 22.04**.
-
-If you're running ScyllaDB Open Source 5.0 or later or ScyllaDB Enterprise 2021.1.10 or later, you can 
-automatically update 3rd party and OS packages together with the ScyllaDB packages - by running one command. 
-
-In earlier ScyllaDB versions, you have to first update the ScyllaDB packages and then update the OS packages 
-in the next step.
-
-See the relevant :doc:`upgrade guide <./index>` for detailed instructions for upgrading your ScyllaDB version.
+#. ScyllaDB packages. Since ScyllaDB Open Source **5.2** and ScyllaDB 
+   Enterprise **2023.1**, the images are based on **Ubuntu 22.04**. 
+   See the :doc:`upgrade guide <./index>` for your ScyllaDB version 
+   for instructions for updating ScyllaDB packages on Ubuntu.
+#. Underlying OS packages. ScyllaDB includes a list of 3rd party and OS packages 
+   tested with the ScyllaDB release. 
 
 To check your Scylla version, run the ``scylla --version`` command.

--- a/docs/upgrade/index.rst
+++ b/docs/upgrade/index.rst
@@ -6,9 +6,9 @@ Upgrade ScyllaDB
    :titlesonly:
    :hidden:
 
-   ScyllaDB Open Source <upgrade-opensource/index>
-   ScyllaDB Open Source to ScyllaDB Enterprise <upgrade-to-enterprise/index>
-   ScyllaDB AMI <ami-upgrade>
+   ScyllaDB Open Source Upgrade <upgrade-opensource/index>
+   ScyllaDB Open Source to ScyllaDB Enterprise Upgrade <upgrade-to-enterprise/index>
+   ScyllaDB Image <ami-upgrade>
    ScyllaDB Enterprise <https://enterprise.docs.scylladb.com/stable/upgrade/upgrade-enterprise/index.html>
 
 .. raw:: html
@@ -27,7 +27,7 @@ Procedures for upgrading Scylla.
 
 * :doc:`Upgrade from ScyllaDB Open Source to Scylla Enterprise <upgrade-to-enterprise/index>`
 
-* :doc:`Upgrade ScyllaDB AMI <ami-upgrade>`
+* :doc:`Upgrade ScyllaDB Image <ami-upgrade>`
 
 * `Upgrade ScyllaDB Enterprise <https://enterprise.docs.scylladb.com/stable/upgrade/upgrade-enterprise/index.html>`_
 

--- a/docs/upgrade/upgrade-opensource/upgrade-guide-from-5.1-to-5.2/upgrade-guide-from-5.1-to-5.2-generic.rst
+++ b/docs/upgrade/upgrade-opensource/upgrade-guide-from-5.1-to-5.2/upgrade-guide-from-5.1-to-5.2-generic.rst
@@ -147,72 +147,16 @@ Download and install the new release
                sudo yum clean all
                sudo yum update scylla\* -y
 
-   .. group-tab:: EC2/GCP/Azure Ubuntu Image
+.. note::
 
-        Before upgrading, check what version you are running now using ``dpkg -s scylla-server``. You should use the same version as this version in case you want to |ROLLBACK|_ the upgrade. If you are not running a |SRC_VERSION|.x version, stop right here! This guide only covers |SRC_VERSION|.x to |NEW_VERSION|.y upgrades.
+   If you are running a ScyllaDB official image (for EC2 AMI, GCP, or Azure), 
+   you need to:
+   
+    * Download and install the new ScyllaDB release for Ubuntu; see 
+      the Debian/Ubuntu tab above for instructions.
+    * Update underlying OS packages.
 
-        There are two alternative upgrade procedures:
-
-        * :ref:`Upgrading ScyllaDB and simultaneously updating 3rd party and OS packages <upgrade-image-recommended-procedure>`. It is recommended if you are running a ScyllaDB official image (EC2 AMI, GCP, and Azure images), which is based on Ubuntu 20.04.
-
-        * :ref:`Upgrading ScyllaDB without updating any external packages <upgrade-image-upgrade-guide-regular-procedure>`.
-
-        .. _upgrade-image-recommended-procedure:
-
-        **To upgrade ScyllaDB and update 3rd party and OS packages (RECOMMENDED):**
-
-        Choosing this upgrade procedure allows you to upgrade your ScyllaDB version and update the 3rd party and OS packages using one command.
-
-        #. Update the |SCYLLA_DEB_NEW_REPO| to |NEW_VERSION|.
-
-        #. Load the new repo:
-
-            .. code:: sh
-
-               sudo apt-get update
-
-
-        #. Run the following command to update the manifest file:
-
-            .. code:: sh
-
-               cat scylla-packages-<version>-<arch>.txt | sudo xargs -n1 apt-get install -y
-
-            Where:
-
-              * ``<version>`` - The ScyllaDB version to which you are upgrading ( |NEW_VERSION| ).
-              * ``<arch>`` - Architecture type: ``x86_64`` or ``aarch64``.
-
-            The file is included in the ScyllaDB packages downloaded in the previous step. The file location is ``http://downloads.scylladb.com/downloads/scylla/aws/manifest/scylla-packages-<version>-<arch>.txt``
-
-            Example:
-
-                .. code:: sh
-
-                   cat scylla-packages-5.2.0-x86_64.txt | sudo xargs -n1 apt-get install -y
-
-                .. note::
-
-                   Alternatively, you can update the manifest file with the following command:
-
-                   ``sudo apt-get install $(awk '{print $1'} scylla-packages-<version>-<arch>.txt) -y``
-
-        .. _upgrade-image-upgrade-guide-regular-procedure:
-
-        **To upgrade ScyllaDB:**
-
-        #. Update the |SCYLLA_DEB_NEW_REPO| to |NEW_VERSION|.
-
-        #. Install the new ScyllaDB version:
-
-            .. code-block:: console
-
-               sudo apt-get clean all
-               sudo apt-get update
-               sudo apt-get dist-upgrade scylla
-
-
-        Answer ‘y’ to the first two questions.
+   See :doc:`Upgrade ScyllaDB Image </upgrade/ami-upgrade>` for details.
 
 (Optional) Enable consistent cluster management in the node's configuration file
 --------------------------------------------------------------------------------


### PR DESCRIPTION
This is a backport of PR https://github.com/scylladb/scylladb/pull/15739.

This commit removes the information about
the recommended way of upgrading ScyllaDB
images - by updating ScyllaDB and OS packages
in one step.
This upgrade procedure is not supported
(it was implemented, but then reverted).

The scope of this commit:
- Remove the information from the 5.1-to.-5.2 upgrade guide and replace with general info.
- Remove the information from the Image Upgrade page.
- Remove outdated info (about previous releases) from the Image Upgrade page.
- Rename "AMI Upgrade" as "Image Upgrade" in the page tree.

Refs: https://github.com/scylladb/scylladb/issues/15733 (cherry picked from commit f6767f6d6eaefd93c1476000cd6e285f197d002a)