### PR TITLE
Make test-only write_memtable_to_sstable() overloads shorter

### DIFF
--- a/replica/memtable-sstable.hh
+++ b/replica/memtable-sstable.hh
@@ -37,7 +37,6 @@ write_memtable_to_sstable(flat_mutation_reader_v2 reader,
 
 seastar::future<>
 write_memtable_to_sstable(memtable& mt,
-        sstables::shared_sstable sst,
-        sstables::sstable_writer_config cfg);
+        sstables::shared_sstable sst);
 
 }

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -2472,7 +2472,8 @@ write_memtable_to_sstable(flat_mutation_reader_v2 reader,
 }
 
 future<>
-write_memtable_to_sstable(memtable& mt, sstables::shared_sstable sst, sstables::sstable_writer_config cfg) {
+write_memtable_to_sstable(memtable& mt, sstables::shared_sstable sst) {
+    auto cfg = sst->manager().configure_writer("memtable");
     auto monitor = replica::permit_monitor(make_lw_shared(sstable_write_permit::unconditional()));
     auto semaphore = reader_concurrency_semaphore(reader_concurrency_semaphore::no_limits{}, "write_memtable_to_sstable");
     std::exception_ptr ex;

--- a/test/boost/sstable_directory_test.cc
+++ b/test/boost/sstable_directory_test.cc
@@ -93,7 +93,7 @@ make_sstable_for_all_shards(replica::database& db, replica::table& table, sstabl
     }
     data_dictionary::storage_options local;
     auto sst = table.get_sstables_manager().make_sstable(s, table.dir(), local, generation, state);
-    write_memtable_to_sstable(*mt, sst, table.get_sstables_manager().configure_writer("test")).get();
+    write_memtable_to_sstable(*mt, sst).get();
     mt->clear_gently().get();
     // We can't write an SSTable with bad sharding, so pretend
     // it came from Cassandra

--- a/test/lib/sstable_utils.cc
+++ b/test/lib/sstable_utils.cc
@@ -46,7 +46,7 @@ sstables::shared_sstable make_sstable_containing(std::function<sstables::shared_
 }
 
 sstables::shared_sstable make_sstable_containing(sstables::shared_sstable sst, lw_shared_ptr<replica::memtable> mt) {
-    write_memtable_to_sstable_for_test(*mt, sst).get();
+    write_memtable_to_sstable(*mt, sst).get();
     sstable_open_config cfg { .load_first_and_last_position_metadata = true };
     sst->open_data(cfg).get();
     return sst;

--- a/test/lib/sstable_utils.hh
+++ b/test/lib/sstable_utils.hh
@@ -33,10 +33,6 @@ sstables::shared_sstable make_sstable_containing(sstables::shared_sstable sst, l
 sstables::shared_sstable make_sstable_containing(std::function<sstables::shared_sstable()> sst_factory, std::vector<mutation> muts, validate do_validate = validate::yes);
 sstables::shared_sstable make_sstable_containing(sstables::shared_sstable sst, std::vector<mutation> muts, validate do_validate = validate::yes);
 
-inline future<> write_memtable_to_sstable_for_test(replica::memtable& mt, sstables::shared_sstable sst) {
-    return write_memtable_to_sstable(mt, sst, sst->manager().configure_writer("memtable"));
-}
-
 namespace sstables {
 
 using sstable_ptr = shared_sstable;

--- a/test/perf/memory_footprint_test.cc
+++ b/test/perf/memory_footprint_test.cc
@@ -208,7 +208,7 @@ static sizes calculate_sizes(cache_tracker& tracker, const mutation_settings& se
             auto sst = env.make_sstable(s, v);
             auto mt2 = make_lw_shared<replica::memtable>(s);
             mt2->apply(*mt, env.make_reader_permit()).get();
-            write_memtable_to_sstable_for_test(*mt2, sst).get();
+            write_memtable_to_sstable(*mt2, sst).get();
             sst->open_data().get();
             result.sstable[v] = sst->data_size();
         }

--- a/test/perf/perf_sstable.hh
+++ b/test/perf/perf_sstable.hh
@@ -198,7 +198,7 @@ public:
             auto sst = _env.make_sstable(s, dir(), sstables::generation_type(idx), sstables::get_highest_sstable_version(), sstable::format_types::big, _cfg.buffer_size);
 
             auto start = perf_sstable_test_env::now();
-            write_memtable_to_sstable_for_test(*_mt, sst).get();
+            write_memtable_to_sstable(*_mt, sst).get();
             auto end = perf_sstable_test_env::now();
 
             _mt->revert_flushed_memory();
@@ -218,7 +218,7 @@ public:
                 std::vector<shared_sstable> ssts;
                 for (auto i = 0u; i < _cfg.sstables; i++) {
                     auto sst = sst_gen();
-                    write_memtable_to_sstable_for_test(*_mt, sst).get();
+                    write_memtable_to_sstable(*_mt, sst).get();
                     sst->open_data().get();
                     _mt->revert_flushed_memory();
                     ssts.push_back(std::move(sst));


### PR DESCRIPTION
There are three of them, one is used by core, another by tests and the third one passes arguments between those two. And the ..._for_tests() helper in test utils. This PR leaves only one for tests out of three.