### PR TITLE
doc: set 5.4 as the latest stable version

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,10 +17,10 @@ BASE_URL = 'https://opensource.docs.scylladb.com'
 # Build documentation for the following tags and branches.
 TAGS = []
 BRANCHES = ["master", "branch-5.1", "branch-5.2", "branch-5.4"]
-# Set the latest version.
-LATEST_VERSION = "branch-5.2"
+# Set the latest version. 
+LATEST_VERSION = "branch-5.4"
 # Set which versions are not released yet.
-UNSTABLE_VERSIONS = ["master", "branch-5.4"]
+UNSTABLE_VERSIONS = ["master"]
 # Set which versions are deprecated.
 DEPRECATED_VERSIONS = [""]
 


### PR DESCRIPTION
This PR updates the configuration for ScyllaDB documentation so that:
- 5.4 is the latest version.
- 5.4 is removed from the list of unstable versions.

It must be merged when ScyllaDB 5.4 is released.

No backport is required.