### PR TITLE
alternator: Use summary for shard-level latencies.

### DIFF
--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -1824,7 +1824,7 @@ future<executor::request_return_type> executor::put_item(client_state& client_st
         });
     }
     return op->execute(_proxy, client_state, trace_state, std::move(permit), needs_read_before_write, _stats).finally([op, start_time, this] {
-        _stats.api_operations.put_item_latency.add(std::chrono::steady_clock::now() - start_time);
+        _stats.api_operations.put_item_latency.mark(std::chrono::steady_clock::now() - start_time);
     });
 }
 
@@ -1913,7 +1913,7 @@ future<executor::request_return_type> executor::delete_item(client_state& client
         });
     }
     return op->execute(_proxy, client_state, trace_state, std::move(permit), needs_read_before_write, _stats).finally([op, start_time, this] {
-        _stats.api_operations.delete_item_latency.add(std::chrono::steady_clock::now() - start_time);
+        _stats.api_operations.delete_item_latency.mark(std::chrono::steady_clock::now() - start_time);
     });
 }
 
@@ -3177,7 +3177,7 @@ future<executor::request_return_type> executor::update_item(client_state& client
         });
     }
     return op->execute(_proxy, client_state, trace_state, std::move(permit), needs_read_before_write, _stats).finally([op, start_time, this] {
-        _stats.api_operations.update_item_latency.add(std::chrono::steady_clock::now() - start_time);
+        _stats.api_operations.update_item_latency.mark(std::chrono::steady_clock::now() - start_time);
     });
 }
 
@@ -3261,7 +3261,7 @@ future<executor::request_return_type> executor::get_item(client_state& client_st
     return _proxy.query(schema, std::move(command), std::move(partition_ranges), cl,
             service::storage_proxy::coordinator_query_options(executor::default_timeout(), std::move(permit), client_state, trace_state)).then(
             [this, schema, partition_slice = std::move(partition_slice), selection = std::move(selection), attrs_to_get = std::move(attrs_to_get), start_time = std::move(start_time)] (service::storage_proxy::coordinator_query_result qr) mutable {
-        _stats.api_operations.get_item_latency.add(std::chrono::steady_clock::now() - start_time);
+        _stats.api_operations.get_item_latency.mark(std::chrono::steady_clock::now() - start_time);
         return make_ready_future<executor::request_return_type>(make_jsonable(describe_item(schema, partition_slice, *selection, *qr.query_result, std::move(attrs_to_get))));
     });
 }

--- a/alternator/stats.hh
+++ b/alternator/stats.hh
@@ -12,6 +12,7 @@
 
 #include <seastar/core/metrics_registration.hh>
 #include "utils/estimated_histogram.hh"
+#include "utils/histogram.hh"
 #include "cql3/stats.hh"
 
 namespace alternator {
@@ -65,11 +66,11 @@ public:
         uint64_t get_shard_iterator = 0;
         uint64_t get_records = 0;
 
-        utils::time_estimated_histogram put_item_latency;
-        utils::time_estimated_histogram get_item_latency;
-        utils::time_estimated_histogram delete_item_latency;
-        utils::time_estimated_histogram update_item_latency;
-        utils::time_estimated_histogram get_records_latency;
+        utils::timed_rate_moving_average_summary_and_histogram put_item_latency;
+        utils::timed_rate_moving_average_summary_and_histogram get_item_latency;
+        utils::timed_rate_moving_average_summary_and_histogram delete_item_latency;
+        utils::timed_rate_moving_average_summary_and_histogram update_item_latency;
+        utils::timed_rate_moving_average_summary_and_histogram get_records_latency;
     } api_operations;
     // Miscellaneous event counters
     uint64_t total_operations = 0;

--- a/alternator/streams.cc
+++ b/alternator/streams.cc
@@ -1016,7 +1016,7 @@ future<executor::request_return_type> executor::get_records(client_state& client
             // shard did end, then the next read will have nrecords == 0 and
             // will notice end end of shard and not return NextShardIterator.
             rjson::add(ret, "NextShardIterator", next_iter);
-            _stats.api_operations.get_records_latency.add(std::chrono::steady_clock::now() - start_time);
+            _stats.api_operations.get_records_latency.mark(std::chrono::steady_clock::now() - start_time);
             return make_ready_future<executor::request_return_type>(make_jsonable(std::move(ret)));
         }
 
@@ -1039,7 +1039,7 @@ future<executor::request_return_type> executor::get_records(client_state& client
                 shard_iterator next_iter(iter.table, iter.shard, utils::UUID_gen::min_time_UUID(high_ts.time_since_epoch()), true);
                 rjson::add(ret, "NextShardIterator", iter);
             }
-            _stats.api_operations.get_records_latency.add(std::chrono::steady_clock::now() - start_time);
+            _stats.api_operations.get_records_latency.mark(std::chrono::steady_clock::now() - start_time);
             if (is_big(ret)) {
                 return make_ready_future<executor::request_return_type>(make_streamed(std::move(ret)));
             }


### PR DESCRIPTION
Shard-level latencies generate a lot of metrics. This patch reduces the the number of latencies reported by Alternator while keeping the same functionality.

On the shard level, summaries will be reported instead of histograms. On the instance level, an aggregated histogram will be reported.

Summaries, histograms, and counters are marked with skip_when_empty.

Fixes #12230