### PR TITLE
conf/scylla.yaml: set maintenance-socket option to workdir

### DIFF
--- a/conf/scylla.yaml
+++ b/conf/scylla.yaml
@@ -585,7 +585,7 @@ strict_is_not_null_in_views: true
 # * workdir: the node will open the maintenance socket on the path <scylla's workdir>/cql.m,
 #            where <scylla's workdir> is a path defined by the workdir configuration option,
 # * <socket path>: the node will open the maintenance socket on the path <socket path>.
-maintenance_socket: ignore
+maintenance_socket: workdir
 
 # If set to true, configuration parameters defined with LiveUpdate option can be updated in runtime with CQL
 # by updating system.config virtual table. If we don't want any configuration parameter to be changed in runtime


### PR DESCRIPTION
When the maintenance socket was introduced, scylla-ccm didn't use the `workdir` option - it set an option for each subdirectory of the work directory. If the maintenance-socket option had been set to workdir, the socket would have been created in the default work directory: /var/lib/scylla. In dtests, it would result in a disaster, where each node would try to create a socket in /var/lib/scylla/cql.m.
After setting the `workdir` option in scylla-ccm, the maintenance-socket option can be set to `workdir`. With this, the maintenance socket will be enabled in dtests by default, allowing us to test it better.

Enable maintenance socket in new clusters by default.