### PR TITLE
test/cql_query_test: Use string_view by value

### DIFF
--- a/test/boost/cql_query_test.cc
+++ b/test/boost/cql_query_test.cc
@@ -4903,11 +4903,11 @@ SEASTAR_THREAD_TEST_CASE(test_query_limit) {
 
 // reproduces https://github.com/scylladb/scylla/issues/3552
 // when clustering-key filtering is enabled in filter_sstable_for_reader
-static future<> test_clustering_filtering_with_compaction_strategy(const std::string_view& cs) {
+static future<> test_clustering_filtering_with_compaction_strategy(std::string_view cs) {
     auto db_config = make_shared<db::config>();
     db_config->sstable_format("me");
 
-    return do_with_cql_env_thread([&cs] (cql_test_env& e) {
+    return do_with_cql_env_thread([cs] (cql_test_env& e) {
         cquery_nofail(e, format("CREATE TABLE cf(pk text, ck int, v text, PRIMARY KEY(pk, ck)) WITH COMPACTION = {{'class': '{}'}}", cs));
         cquery_nofail(e, "INSERT INTO  cf(pk, ck, v) VALUES ('a', 1, 'a1')");
         e.db().invoke_on_all([] (replica::database& db) { return db.flush_all_memtables(); }).get();
@@ -4927,11 +4927,11 @@ SEASTAR_TEST_CASE(test_clustering_filtering) {
             test_clustering_filtering_with_compaction_strategy);
 }
 
-static future<> test_clustering_filtering_2_with_compaction_strategy(const std::string_view& cs) {
+static future<> test_clustering_filtering_2_with_compaction_strategy(std::string_view cs) {
     auto db_config = make_shared<db::config>();
     db_config->sstable_format("me");
 
-    return do_with_cql_env_thread([&cs] (cql_test_env& e) {
+    return do_with_cql_env_thread([cs] (cql_test_env& e) {
         cquery_nofail(e, format("CREATE TABLE cf(pk text, ck int, v text, PRIMARY KEY(pk, ck)) WITH COMPACTION = {{'class': '{}'}}", cs));
         cquery_nofail(e, "INSERT INTO  cf(pk, ck, v) VALUES ('a', 1, 'a1')");
         cquery_nofail(e, "INSERT INTO  cf(pk, ck, v) VALUES ('b', 2, 'b2')");
@@ -4952,11 +4952,11 @@ SEASTAR_TEST_CASE(test_clustering_filtering_2) {
             test_clustering_filtering_2_with_compaction_strategy);
 }
 
-static future<> test_clustering_filtering_3_with_compaction_strategy(const std::string_view& cs) {
+static future<> test_clustering_filtering_3_with_compaction_strategy(std::string_view cs) {
     auto db_config = make_shared<db::config>();
     db_config->sstable_format("me");
 
-    return do_with_cql_env_thread([&cs] (cql_test_env& e) {
+    return do_with_cql_env_thread([cs] (cql_test_env& e) {
         cquery_nofail(e, format("CREATE TABLE cf(pk text, ck int, v text, PRIMARY KEY(pk, ck)) WITH COMPACTION = {{'class': '{}'}}", cs));
         e.db().invoke_on_all([] (replica::database& db) {
             auto& table = db.find_column_family("ks", "cf");


### PR DESCRIPTION
The test carries const std::string_view& around, but the type is lightweight class that can be copied around at the same cost as its reference.