### PR TITLE
doc: add Scylla Doctor info for non-root users

### DIFF
--- a/docs/troubleshooting/report-scylla-problem.rst
+++ b/docs/troubleshooting/report-scylla-problem.rst
@@ -37,6 +37,13 @@ You need to run the tool **on every node in the cluster**.
 
       sudo ./scylla_doctor.pyz --save-vitals <unique-host-id>.vitals.json
  
+   If ScyllaDB is installed under a user without root privileges, you need to 
+   additionally provide the path to the ``python3`` binary under ``scylladb``:
+
+   .. code:: shell
+
+      sudo ~/scylladb/python3/bin/python3 ./scylla_doctor.pyz --save-vitals <unique-host-id>.vitals.json
+   
    Make sure you provide a unique host identifier in the filename, such as 
    the host IP. Scylla Doctor will generate:
    


### PR DESCRIPTION
This PR adds information on how to run Scylla Doctor if ScyllaDB was installed under a non-root user.

Fixes https://github.com/scylladb/scylladb/issues/18498.

- No backport. The info about Scylla Doctor is not available in previous versions.

