### PR TITLE
utils/config_file: do not ignore deprecated options

### DIFF
--- a/utils/config_file.cc
+++ b/utils/config_file.cc
@@ -317,7 +317,7 @@ void utils::config_file::read_from_yaml(const char* yaml, error_handler h) {
         switch (cfg.status()) {
         case value_status::Deprecated:
             h(label, "Option is deprecated", cfg.status());
-            continue;
+            break;
         case value_status::Invalid:
             h(label, "Option is not applicable", cfg.status());
             continue;


### PR DESCRIPTION
Unlike `Invalid` options, that are ignored if used,
`Deprecated` options should still function normally,
under the deprecation warning, until the server drops
support for them (and then they should transition to
`Invalid`).

Fixes #18969

Needs backport to 6.0 as the issue was introduced there and may cause unpleasant suprises to users that happen to still use the deprecated options