### PR TITLE
[Backport 6.0] doc: replace a link on the CDC+Kafka page

### DIFF
--- a/docs/using-scylla/integrations/scylla-cdc-source-connector-quickstart.rst
+++ b/docs/using-scylla/integrations/scylla-cdc-source-connector-quickstart.rst
@@ -17,9 +17,9 @@ First, let's setup a Scylla cluster and create a CDC-enabled table.
 Scylla installation
 ^^^^^^^^^^^^^^^^^^^
 
-For the purpose of this quickstart, we will configure a Scylla instance using Docker. You can skip this 
-section if you have already installed Scylla. To learn more about installing Scylla in production
-environments, please refer to the :doc:`Install Scylla page </getting-started/install-scylla/index>`.
+For the purpose of this quickstart, we will configure a ScyllaDB instance using Docker. You can skip this 
+section if you have already installed ScyllaDB. To learn more about installing and configuring ScyllaDB in production
+environments, please refer to the :doc:`Getting Started guide </getting-started/index>`.
 
 #. Using `Docker <https://hub.docker.com/r/scylladb/scylla/>`_, follow the instructions to launch Scylla.
 #. Start the Docker container, replacing the ``--name`` and ``--host name`` parameters with your own information. For example:


### PR DESCRIPTION
This commit replaces a link to the installation section with a link to the getting started section.

(cherry picked from commit f90867c74086d047da46b6f7e4a1b274e01a5252)
