### PR TITLE
doc: add info about file-based streaming to a separate file

### DIFF
--- a/docs/architecture/_common/file-based-streaming.rst
+++ b/docs/architecture/_common/file-based-streaming.rst
@@ -1,0 +1,7 @@
+File-based Streaming
+========================
+
+File-based stremaing is a ScyllaDB Enterprise-only feature that optimizes
+tablet migration by streaming entire SStables.
+See `Data Distribution with Tablets <https://enterprise.docs.scylladb.com/branch-2024.2/architecture/tablets.html>`_
+in the ScyllaDB Enterprise documentation for details.

--- a/docs/architecture/tablets.rst
+++ b/docs/architecture/tablets.rst
@@ -72,6 +72,8 @@ to a new node.
 
 .. image:: images/tablets-load-balancing.png
 
+.. scylladb_include_flag:: file-based-streaming.rst
+
 .. _tablets-enable-tablets: 
 
 Enabling Tablets


### PR DESCRIPTION
This PR adds a file with information about file-based streaming to the `_common` folder. The file is then included using the `scylladb_include_flag` directive.

The major purpose of this commit is to make it possible to include a different file in the _scylla-enterprise_ repo - with different content (feature documentation).

Refs https://github.com/scylladb/scylla-enterprise/issues/4585
Refs https://github.com/scylladb/scylla-enterprise/issues/4254

This PR must be backported to both branch-6.1 and branch-6.0, as it is critical for version 6.0.