### PR TITLE
service/CMakeLists.txt: Add cql3 as private library

### DIFF
--- a/service/CMakeLists.txt
+++ b/service/CMakeLists.txt
@@ -41,6 +41,7 @@ target_link_libraries(service
     Seastar::seastar
     xxHash::xxhash
   PRIVATE
+    cql3
     mutation
     node_ops
     raft


### PR DESCRIPTION
Before these changes, trying to compile Scylla with CMake fails with the following message:

```
In file included from $HOME/src/scylla/service/qos/service_level_controller.cc:9:
$HOME/src/scylla/cql3/util.hh:21:10: fatal error: 'cql3/CqlParser.hpp' file not found
   21 | #include "cql3/CqlParser.hpp"
      |          ^~~~~~~~~~~~~~~~~~~~
1 error generated.
```

Said file is auto-generated and we need to indicate the dependency in the appropriate CMake file.
That's what we do in this commit.

Fixes scylladb/scylladb#20821

Backport: not needed as the offending commit didn't make it to the previous versions.