### PR TITLE
repair: Add await_completion option for tablet_repair api

### DIFF
--- a/api/api-doc/storage_service.json
+++ b/api/api-doc/storage_service.json
@@ -2872,6 +2872,14 @@
                      "allowMultiple":false,
                      "type":"string",
                      "paramType":"query"
+                  },
+                  {
+                     "name":"await_completion",
+                     "description":"Set true to wait for the repair to complete. Set false to skip waiting for the repair to complete. When the option is not provided, it defaults to false.",
+                     "required":false,
+                     "allowMultiple":false,
+                     "type":"string",
+                     "paramType":"query"
                   }
                ]
             }

--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -1689,6 +1689,11 @@ rest_repair_tablet(http_context& ctx, sharded<service::storage_service>& ss, std
         }
         auto ks = req->get_query_param("ks");
         auto table = req->get_query_param("table");
+        bool await_completion = false;
+        auto await = req->get_query_param("await_completion");
+        if (!await.empty()) {
+            await_completion = validate_bool(await);
+        }
         validate_table(ctx, ks, table);
         auto table_id = ctx.db.local().find_column_family(ks, table).schema()->id();
         std::variant<utils::chunked_vector<dht::token>, service::storage_service::all_tokens_tag> tokens_variant;
@@ -1698,7 +1703,7 @@ rest_repair_tablet(http_context& ctx, sharded<service::storage_service>& ss, std
             tokens_variant = tokens;
         }
 
-        auto res = co_await ss.local().add_repair_tablet_request(table_id, tokens_variant);
+        auto res = co_await ss.local().add_repair_tablet_request(table_id, tokens_variant, await_completion);
         co_return json::json_return_type(res);
 }
 

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -933,7 +933,7 @@ private:
     future<bool> exec_tablet_update(service::group0_guard guard, std::vector<canonical_mutation> updates, sstring reason);
 public:
     struct all_tokens_tag {};
-    future<std::unordered_map<sstring, sstring>> add_repair_tablet_request(table_id table, std::variant<utils::chunked_vector<dht::token>, all_tokens_tag> tokens_variant);
+    future<std::unordered_map<sstring, sstring>> add_repair_tablet_request(table_id table, std::variant<utils::chunked_vector<dht::token>, all_tokens_tag> tokens_variant, bool await_completion);
     future<> del_repair_tablet_request(table_id table, locator::tablet_task_id);
     future<> move_tablet(table_id, dht::token, locator::tablet_replica src, locator::tablet_replica dst, loosen_constraints force = loosen_constraints::no);
     future<> add_tablet_replica(table_id, dht::token, locator::tablet_replica dst, loosen_constraints force = loosen_constraints::no);

--- a/test/pylib/rest_client.py
+++ b/test/pylib/rest_client.py
@@ -273,12 +273,14 @@ class ScyllaRESTAPIClient():
             "token": str(token)
         })
 
-    async def tablet_repair(self, node_ip: str, ks: str, table: str, token : int, timeout: Optional[float] = None) -> None:
-        await self.client.post(f"/storage_service/tablets/repair", host=node_ip, timeout=timeout, params={
+    async def tablet_repair(self, node_ip: str, ks: str, table: str, token : int, timeout: Optional[float] = None, await_completion: bool = True) -> None:
+        res = await self.client.post_json(f"/storage_service/tablets/repair", host=node_ip, timeout=timeout, params={
             "ks": ks,
             "table": table,
-            "tokens": str(token)
+            "tokens": str(token),
+            "await_completion": str(await_completion).lower()
         })
+        return res
 
     async def enable_tablet_balancing(self, node_ip: str) -> None:
         await self.client.post(f"/storage_service/tablets/balancing", host=node_ip, params={"enabled": "true"})


### PR DESCRIPTION
Set true to wait for the repair to complete. Set false to skip waiting for the repair to complete. When the option is not provided, it is default to true.

It is useful for management tool that wants the api to be async.

Fixes #22418

Code is not released yet. No backport is needed. 