### PR TITLE
doc: remove Size Tiered Compaction Strategy (STCS) from the docs

### DIFF
--- a/docs/cql/ddl.rst
+++ b/docs/cql/ddl.rst
@@ -751,13 +751,13 @@ Compaction options
 ##################
 
 The ``compaction`` options must at least define the ``'class'`` sub-option, which defines the compaction strategy class
-to use. The default supported class are ``'SizeTieredCompactionStrategy'``,
-``'LeveledCompactionStrategy'``, and ``'IncrementalCompactionStrategy'``.
+to use. The default supported class are 
+``'LeveledCompactionStrategy'`` and ``'IncrementalCompactionStrategy'``.
 Custom strategy can be provided by specifying the full class name as a :ref:`string constant
 <constants>`.
 
 All default strategies support a number of common options, as well as options specific to
-the strategy chosen (see the section corresponding to your strategy for details: :ref:`STCS <stcs-options>`, :ref:`LCS <lcs-options>`, :ref:`ICS <ics-options>`, and :ref:`TWCS <twcs-options>`).
+the strategy chosen (see the section corresponding to your strategy for details: :ref:`ICS <ics-options>`, :ref:`LCS <lcs-options>`, :ref:`ICS <ics-options>`, and :ref:`TWCS <twcs-options>`).
 
 .. _cql-compression-options:
 

--- a/docs/dev/docker-hub.md
+++ b/docs/dev/docker-hub.md
@@ -123,13 +123,13 @@ docker-compose up -d
 
 ```console
 $ docker logs some-scylla | tail
-INFO  2016-08-04 06:57:40,836 [shard 5] database - Setting compaction strategy of system_traces.events to SizeTieredCompactionStrategy
-INFO  2016-08-04 06:57:40,836 [shard 3] database - Setting compaction strategy of system_traces.events to SizeTieredCompactionStrategy
-INFO  2016-08-04 06:57:40,836 [shard 1] database - Setting compaction strategy of system_traces.events to SizeTieredCompactionStrategy
-INFO  2016-08-04 06:57:40,836 [shard 2] database - Setting compaction strategy of system_traces.events to SizeTieredCompactionStrategy
-INFO  2016-08-04 06:57:40,836 [shard 4] database - Setting compaction strategy of system_traces.events to SizeTieredCompactionStrategy
-INFO  2016-08-04 06:57:40,836 [shard 7] database - Setting compaction strategy of system_traces.events to SizeTieredCompactionStrategy
-INFO  2016-08-04 06:57:40,837 [shard 6] database - Setting compaction strategy of system_traces.events to SizeTieredCompactionStrategy
+INFO  2016-08-04 06:57:40,836 [shard 5] database - Setting compaction strategy of system_traces.events to IncrementalCompactionStrategy
+INFO  2016-08-04 06:57:40,836 [shard 3] database - Setting compaction strategy of system_traces.events to IncrementalCompactionStrategy
+INFO  2016-08-04 06:57:40,836 [shard 1] database - Setting compaction strategy of system_traces.events to IncrementalCompactionStrategy
+INFO  2016-08-04 06:57:40,836 [shard 2] database - Setting compaction strategy of system_traces.events to IncrementalCompactionStrategy
+INFO  2016-08-04 06:57:40,836 [shard 4] database - Setting compaction strategy of system_traces.events to IncrementalCompactionStrategy
+INFO  2016-08-04 06:57:40,836 [shard 7] database - Setting compaction strategy of system_traces.events to IncrementalCompactionStrategy
+INFO  2016-08-04 06:57:40,837 [shard 6] database - Setting compaction strategy of system_traces.events to IncrementalCompactionStrategy
 INFO  2016-08-04 06:57:40,839 [shard 0] database - Schema version changed to fea14d93-9c5a-34f5-9d0e-2e49dcfa747e
 INFO  2016-08-04 06:57:40,839 [shard 0] storage_service - Starting listening for CQL clients on 172.17.0.2:9042...
 ```

--- a/docs/features/materialized-views.rst
+++ b/docs/features/materialized-views.rst
@@ -86,7 +86,7 @@ Compaction Strategies with Materialized Views
 Materialized views, just like regular tables, use one of the available :doc:`compaction strategies </architecture/compaction/compaction-strategies>`.
 When a materialized view is created, it does not inherit its base table compaction strategy settings, because the data model
 of a view does not necessarily have the same characteristics as the one from its base table.
-Instead, the default compaction strategy (SizeTieredCompactionStrategy) is used.
+Instead, the default compaction strategy (IncrementalCompactionStrategy) is used.
 
 A compaction strategy for a new materialized view can be explicitly set during its creation, using the following command:
 

--- a/docs/getting-started/system-requirements.rst
+++ b/docs/getting-started/system-requirements.rst
@@ -90,8 +90,6 @@ Use the following table as a guidelines for the minimum disk space requirements 
 ======================================  ===========  ============  
 Compaction Strategy                     Recommended  Minimum
 ======================================  ===========  ============  
-Size Tiered Compaction Strategy (STCS)  50%          70% 
---------------------------------------  -----------  ------------  
 Leveled Compaction Strategy (LCS)       50%          80% 
 --------------------------------------  -----------  ------------  
 Time-window Compaction Strategy (TWCS)  50%          70%

--- a/docs/kb/garbage-collection-ics.rst
+++ b/docs/kb/garbage-collection-ics.rst
@@ -12,32 +12,13 @@ tombstone cannot be purged unless it's compacted with the data it shadows. For e
 tombstone sits on level 1, whereas its shadowed data is on level 2. You'll only be able to purge that tombstone once compaction
 promotes it to level 2.
 
-Size-tiered compaction inefficiently handles this problem with a process known as tombstone compaction. The process works as follows:
-
-#. First, it searches for an SSTable with droppable tombstone density higher than N% (estimates density using tombstone histogram, which lives in Statistics.db).
-
-     * The search starts from the highest level, as droppable tombstones in high levels are less likely to find shadowed data.
-     * The threshold can be configured through the ``tombstone_threshold`` option (the default is 0.2). 
-#. If it finds such an SSTable, it compacts that single file individually, hoping that the droppable tombstones can be purged.
-
-     * The ``tombstone_compaction_interval`` option prevents the data in an SSTable from going through the procedure multiple times in a short interval.
-
-
-The process above has several drawbacks; for example:
-
-* It doesn't take into account out-of-order writes, so shadowed data may be sitting in lower levels rather than higher ones.
-* It can take an unpredictable amount of time for a droppable tombstone to reach the shadowed data counterpart in the LSM tree.
-
-Making Garbage Collection Efficient in ICS
+Garbage Collection Efficient in ICS
 ---------------------------------------------
 
-As a remedy to the known problem described above, a new process was introduced to ScyllaDB with `this commit <https://github.com/scylladb/scylladb/commit/c97325436237516fcec97eeb1f283674ea1fef1c>`_.
 The process inherits the cross-tier compaction idea from SAG, but instead of using a space-amplification-based trigger, 
 it uses a tombstone-density trigger instead. It can co-exist with SAG, if enabled.
 
-The only similarity to STCS 'tombstone compaction' is the trigger, i.e., **when** to start the garbage collection procedure. The difference is **how** it is performed.
-
-Instead of individually compacting an SSTable run (as it happens in STCS), ICS picks a tier where any of the runs meet 
+ICS picks a tier where any of the runs meet 
 the tombstone density threshold and compacts that tier with the next bigger tier (or the next smaller one if the largest tier 
 was picked), resulting in cross-tier compaction.
 
@@ -52,8 +33,7 @@ How to Use It
 ---------------
 
 ICS garbage collection is enabled by default.
-
-As in STCS, you can use the compaction options ``tombstone_threshold`` and ``tombstone_compaction_interval`` to tweak the behavior 
+You can use the compaction options ``tombstone_threshold`` and ``tombstone_compaction_interval`` to tweak the behavior 
 of the GC process.
 
 See the ScyllaDB documentation for a full description of :doc:`Compaction </cql/compaction>`.

--- a/docs/operating-scylla/procedures/config-change/change-compaction.rst
+++ b/docs/operating-scylla/procedures/config-change/change-compaction.rst
@@ -26,7 +26,7 @@ Procedure
        player_jersy_number int,
        player_position text,
        team text
-   ) AND compaction = {'class': 'SizeTieredCompactionStrategy'};
+   ) AND compaction = {'class': 'IncrementalCompactionStrategy'};
      
 2. Change the compaction strategy to a new one. If you are unsure of which strategy to use, refer to :ref:`Choose a Compaction Strategy <which-strategy-is-best>` for more information. 
 

--- a/docs/operating-scylla/procedures/tips/best-practices-scylla-on-docker.rst
+++ b/docs/operating-scylla/procedures/tips/best-practices-scylla-on-docker.rst
@@ -50,10 +50,10 @@ To access ScyllaDB server logs, you can use the ``docker logs`` command:
 
  docker logs some-scylla  | tail
 
- INFO  2016-11-09 10:27:48,191 [shard 6] database - Setting compaction strategy of system_traces.node_slow_log to SizeTieredCompactionStrategy
- INFO  2016-11-09 10:27:48,191 [shard 4] database - Setting compaction strategy of system_traces.node_slow_log to SizeTieredCompactionStrategy
- INFO  2016-11-09 10:27:48,191 [shard 3] database - Setting compaction strategy of system_traces.node_slow_log to SizeTieredCompactionStrategy
- INFO  2016-11-09 10:27:48,191 [shard 1] database - Setting compaction strategy of system_traces.node_slow_log to SizeTieredCompactionStrategy
+ INFO  2016-11-09 10:27:48,191 [shard 6] database - Setting compaction strategy of system_traces.node_slow_log to IncrementalCompactionStrategy
+ INFO  2016-11-09 10:27:48,191 [shard 4] database - Setting compaction strategy of system_traces.node_slow_log to IncrementalCompactionStrategy
+ INFO  2016-11-09 10:27:48,191 [shard 3] database - Setting compaction strategy of system_traces.node_slow_log to IncrementalCompactionStrategy
+ INFO  2016-11-09 10:27:48,191 [shard 1] database - Setting compaction strategy of system_traces.node_slow_log to IncrementalCompactionStrategy
 
 Checking Server Status with Nodetool
 ++++++++++++++++++++++++++++++++++++

--- a/docs/reference/glossary.rst
+++ b/docs/reference/glossary.rst
@@ -8,7 +8,7 @@ Glossary
     :sorted:
 
     Bootstrap 
-      When a new node is added to a cluster, the bootstrap process ensures that the data in the cluster is automatically redistributed to the new node. A new node in this case is an empty node without system tables or data. See :ref:`bootstrap <temporary-fallback-to-stcs>`.
+      When a new node is added to a cluster, the bootstrap process ensures that the data in the cluster is automatically redistributed to the new node. A new node in this case is an empty node without system tables or data.
 
     Anti-entropy
       A state where data is in order and organized. ScyllaDB has processes in place to make sure that data is antientropic where all replicas contain the most recent data and that data is consistent between replicas. See :doc:`ScyllaDB Anti-Entropy </architecture/anti-entropy/index>`.
@@ -131,9 +131,6 @@ Glossary
       Each ScyllaDB node is internally split into *shards*, an independent thread bound to a dedicated core.
       Each shard of data is allotted CPU, RAM, persistent storage, and networking resources which it uses as efficiently as possible.
       See `ScyllaDB Shard per Core Architecture <https://www.scylladb.com/product/technology/shard-per-core-architecture/>`_ for more information.
-
-    Size-tiered compaction strategy
-      Triggers when the system has enough (four by default) similarly sized SSTables.  See :doc:`Compaction Strategies</architecture/compaction/compaction-strategies/>`.
 
     Snapshot
       Snapshots in ScyllaDB are an essential part of the backup and restore mechanism. Whereas in other databases a backup starts with creating a copy of a data file (cold backup, hot backup, shadow copy backup), in ScyllaDB the process starts with creating a table or keyspace snapshot.  See :doc:`ScyllaDB Snapshots </kb/snapshots>`.

--- a/docs/troubleshooting/large-partition-table.rst
+++ b/docs/troubleshooting/large-partition-table.rst
@@ -14,7 +14,7 @@ If you are experiencing any of the above, search to see if you have large partit
 
 Note that large partitions are detected only when they are stored in a single SSTable.
 ScyllaDB does not account for data belonging to the same logical partition, but spread across multiple SSTables, as long as any single partition in each SSTable does not cross the large partitions warning threshold.
-However, note that over time, compaction, and Size-Tiered Compaction Strategy in particular, may collect the dispersed partition data from several SSTables and store it in a single SSTable, thus crossing the large partitions threshold.
+However, note that over time, compaction may collect the dispersed partition data from several SSTables and store it in a single SSTable, thus crossing the large partitions threshold.
 
 Viewing - Find Large Partitions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/troubleshooting/large-rows-large-cells-tables.rst
+++ b/docs/troubleshooting/large-rows-large-cells-tables.rst
@@ -128,7 +128,7 @@ Large rows and large cells are stored in system tables with the following schema
       AND bloom_filter_fp_chance = 0.01
       AND caching = {'keys': 'ALL', 'rows_per_partition': 'ALL'}
       AND comment = 'rows larger than specified threshold'
-      AND compaction = {'class': 'SizeTieredCompactionStrategy'}
+      AND compaction = {'class': 'IncrementalCompactionStrategy'}
       AND compression = {'sstable_compression': 'org.apache.cassandra.io.compress.LZ4Compressor'}
       AND crc_check_chance = 1.0
       AND default_time_to_live = 0
@@ -153,7 +153,7 @@ Large rows and large cells are stored in system tables with the following schema
       AND bloom_filter_fp_chance = 0.01
       AND caching = {'keys': 'ALL', 'rows_per_partition': 'ALL'}
       AND comment = 'cells larger than specified threshold'
-      AND compaction = {'class': 'SizeTieredCompactionStrategy'}
+      AND compaction = {'class': 'IncrementalCompactionStrategy'}
       AND compression = {'sstable_compression': 'org.apache.cassandra.io.compress.LZ4Compressor'}
       AND crc_check_chance = 1.0
       AND default_time_to_live = 0

--- a/docs/troubleshooting/pointless-compactions.rst
+++ b/docs/troubleshooting/pointless-compactions.rst
@@ -57,7 +57,7 @@ For example this will change it to 4 days:
 
 .. code-block:: shell
 
-    ALTER table <your table name> with compaction = { 'class' : 'SizeTieredCompactionStrategy', 'tombstone_compaction_interval' : 345600 };
+    ALTER table <your table name> with compaction = { 'class' : 'IncrementalCompactionStrategy', 'tombstone_compaction_interval' : 345600 };
 
 
 2. Make sure `unchecked_tombstone_compaction` is set to false. If it is set to true, `tombstone_threshold` will be ignored,
@@ -65,6 +65,6 @@ and compaction will be run whenever `tombstone_compaction_interval` has elapsed.
 
 .. code-block:: shell
 
-    ALTER table <your table name> with compaction = { 'class' : 'SizeTieredCompactionStrategy', 'unchecked_tombstone_compaction' : false };
+    ALTER table <your table name> with compaction = { 'class' : 'IncrementalCompactionStrategy', 'unchecked_tombstone_compaction' : false };
 
 .. include:: /troubleshooting/_common/ts-return.rst

--- a/docs/using-scylla/cassandra-compatibility.rst
+++ b/docs/using-scylla/cassandra-compatibility.rst
@@ -351,16 +351,18 @@ Create Table Compaction
 +----------------------------------------------------+-------------------------------------+
 | Feature                                            | Support                             |
 +====================================================+=====================================+
-| :ref:`SizeTieredCompactionStrategy <STCS>` (STCS)  | |v|                                 |
+| SizeTieredCompactionStrategy (STCS)                | |x|      :sup:`*`                   |
 +----------------------------------------------------+-------------------------------------+
 |:ref:`LeveledCompactionStrategy <LCS>` (LCS)        | |v|                                 |
 +----------------------------------------------------+-------------------------------------+
-|DateTieredCompactionStrategy (DTCS)                 | |x|     :sup:`*`                    |
+|DateTieredCompactionStrategy (DTCS)                 | |x|     :sup:`**`                   |
 +----------------------------------------------------+-------------------------------------+
 |:ref:`TimeWindowCompactionStrategy <TWCS>` (TWCS)   | |v|                                 |
 +----------------------------------------------------+-------------------------------------+
 
-:sup:`*` No longer supported. Use TimeWindowCompactionStrategy (TWCS) instead.
+:sup:`*` No longer supported. Use :ref:`IncrementalCompactionStrategy (ICS) <ICS>` instead.
+
+:sup:`**` No longer supported. Use TimeWindowCompactionStrategy (TWCS) instead.
 
 Create Table Compression
 ........................


### PR DESCRIPTION
This PR removes references to STCS from the documentation. STCS options are removed, and examples are updated to show IncrementalCompactionStrategy.

The information about STCS should be added to the 2025.1 release notes, but we should no longer present STCS as a valid option in the documentation.

Fixes https://github.com/scylladb/scylladb/issues/22562
Refs https://github.com/scylladb/scylladb/issues/22306

This PR should be backported to branch-2025.1 as it's related to the updates in version 2025.1.