### PR TITLE
replica/database: setup_scylla_memory_diagnostics_producer() un-static semaphore dump lambda

### DIFF
--- a/replica/database.cc
+++ b/replica/database.cc
@@ -221,7 +221,7 @@ void database::setup_scylla_memory_diagnostics_producer() {
 
         writeln("  Read Concurrency Semaphores:\n");
 
-        static auto semaphore_dump = [&writeln] (const sstring& name, const reader_concurrency_semaphore& sem) {
+        auto semaphore_dump = [&writeln] (const sstring& name, const reader_concurrency_semaphore& sem) {
             const auto initial_res = sem.initial_resources();
             const auto available_res = sem.available_resources();
             if (sem.is_unlimited()) {
@@ -244,10 +244,10 @@ void database::setup_scylla_memory_diagnostics_producer() {
         semaphore_dump("streaming", _streaming_concurrency_sem);
         semaphore_dump("system", _system_read_concurrency_sem);
         semaphore_dump("compaction", _compaction_concurrency_sem);
-        _reader_concurrency_semaphores_group.foreach_semaphore([] (scheduling_group sg, reader_concurrency_semaphore& sem) {
+        _reader_concurrency_semaphores_group.foreach_semaphore([&semaphore_dump] (scheduling_group sg, reader_concurrency_semaphore& sem) {
              semaphore_dump(sg.name(), sem);
         });
-        _view_update_read_concurrency_semaphores_group.foreach_semaphore([] (scheduling_group sg, reader_concurrency_semaphore& sem) {
+        _view_update_read_concurrency_semaphores_group.foreach_semaphore([&semaphore_dump] (scheduling_group sg, reader_concurrency_semaphore& sem) {
              semaphore_dump(sg.name(), sem);
         });
 


### PR DESCRIPTION
The lambda which dumps the diagnostics for each semaphore, is static. Considering that said lambda captures a local (writeln) by reference, this is wrong on two levels:
* The writeln captured on the shard which happens to initialize this static, will be used on all shards.
* The writeln captured on the first dump, will be used on later dumps, possibly triggering a segfault.

Drop the `static` to make the lambda local and resolve this problem.

Fixes: scylladb/scylladb#22756

Introduced by source-available feature migration, needs backport to 2025.1