### PR TITLE
test: increase timeout for adding a server in test_mv_topology_change

### DIFF
--- a/test/topology_custom/mv/test_mv_topology_change.py
+++ b/test/topology_custom/mv/test_mv_topology_change.py
@@ -34,7 +34,7 @@ async def test_mv_topology_change(manager: ManagerClient):
            'enable_tablets': False,
            'error_injections_at_startup': ['delay_before_get_view_natural_endpoint']}
 
-    servers = [await manager.server_add(config=cfg, timeout=60) for _ in range(3)]
+    servers = [await manager.server_add(config=cfg) for _ in range(3)]
 
     cql = manager.get_cql()
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3}") as ks:


### PR DESCRIPTION
Currently, when we add servers to the cluster in the test, we use a 60s timeout which proved to be not enough in one of the debug runs. There is no reason for this test to use a shorter timeout than all the other tests, so in this patch we reset it to the higher default.

Fixes https://github.com/scylladb/scylladb/issues/23047
