### PR TITLE
cql3/select_statement: reject aggregate functions when PER PARTITION LIMIT is present

### DIFF
--- a/docs/cql/dml/select.rst
+++ b/docs/cql/dml/select.rst
@@ -246,6 +246,9 @@ The ``LIMIT`` option to a ``SELECT`` statement limits the number of rows returne
 LIMIT``  option (introduced in ScyllaDB 3.1) limits the number of rows returned for a given **partition** by the query. Note that both types of limit can be
 used in the same statement.
 
+.. note::
+    The ``LIMIT`` and ``PER PARTITION LIMIT`` are applied to the output of the aggregate functions.
+
 Examples:
 
 The Partition Key in the following table is ``client_id``, and the clustering key is ``when``.
@@ -396,7 +399,7 @@ of the SELECT statement.
  - GROUP BY is then applied to create groups.
  - Aggregate functions in the SELECT clause are applied to groups, or to the entire query if GROUP BY was not specified.
  - If there are selectors that are not aggregate functions, then the first value in the group is selected.
- - If specified, PER PARTITION LIMIT is applied to each partition.
+ - If specified, PER PARTITION LIMIT is applied to each partition result.
  - If specified, LIMIT is applied to the entire query result.
 
 .. note:: The server may use a different execution plan, as long as it arrives at the same result. For

--- a/test/cqlpy/cassandra_tests/validation/operations/select_limit_test.py
+++ b/test/cqlpy/cassandra_tests/validation/operations/select_limit_test.py
@@ -16,7 +16,7 @@ def testSparseTable(cql, test_keyspace):
                 execute(cql, table, "INSERT INTO %s (userid, url, day, month, year) VALUES (?, ?, 1, 'jan', 2012)", i, f"http://foo.{tld}")
         assertRowCount(execute(cql, table, "SELECT * FROM %s LIMIT 4"), 4)
 
-@pytest.mark.xfail(reason="issues #9879, #15099")
+@pytest.mark.xfail(reason="issues #15099")
 def testPerPartitionLimit(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a int, b int, c int, PRIMARY KEY (a, b))") as table:
         for i in range(5):
@@ -110,7 +110,6 @@ def testPerPartitionLimit(cql, test_keyspace):
         assertInvalidMessage(cql, table, "PER PARTITION LIMIT is not allowed with aggregate queries.",
                              "SELECT COUNT(*) FROM %s PER PARTITION LIMIT ?", 3)
 
-@pytest.mark.xfail(reason="issues #9879")
 def testPerPartitionLimitWithStaticDataAndPaging(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a int, b int, s int static, c int, PRIMARY KEY (a, b))") as table:
         for i in range(5):


### PR DESCRIPTION
Before this patch we silently allowed and ignored PER PARTITION LIMIT. While using aggregate functions in conjunction with PER PARTITION LIMIT
can make sense, we want to disable it until we can offer proper implementation, see https://github.com/scylladb/scylladb/issues/9879 for discussion.

We want to match Cassandra, and for queries with aggregate functions it behaves as follows:
- it silently ignores PER PARTITION LIMIT if GROUP BY is present, which matches our previous implementation.
- rejects PER PARTITION LIMIT when GROUP BY is *not* present.

This patch adds rejection of the second group.

Fixes https://github.com/scylladb/scylladb/issues/9879

Backport: not necessary, we'll reject working but invalid queries.