### PR TITLE
cql3: fix PER PARTITION LIMIT with secondary indexes

### DIFF
--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -758,7 +758,12 @@ indexed_table_select_statement::do_execute_base_query(
     auto cmd = prepare_command_for_base_query(qp, options, state, now, bool(paging_state));
     auto timeout = db::timeout_clock::now() + get_timeout(state.get_client_state(), options);
 
-    query::result_merger merger(cmd->get_row_limit(), query::max_partitions);
+    const auto per_partition_limit = [&] {
+        std::optional<uint64_t> limit = get_limit(options, _per_partition_limit, true);
+        return limit == query::max_rows ? std::nullopt : limit;
+    }();
+
+    query::result_merger merger(cmd->get_row_limit(), query::max_partitions, per_partition_limit);
     std::vector<primary_key> keys = std::move(primary_keys);
     std::vector<primary_key>::iterator key_it(keys.begin());
     size_t previous_result_size = 0;
@@ -778,7 +783,7 @@ indexed_table_select_statement::do_execute_base_query(
         auto key_it_end = key_it + next_iteration_size;
         auto command = ::make_lw_shared<query::read_command>(*cmd);
 
-        query::result_merger oneshot_merger(cmd->get_row_limit(), query::max_partitions);
+        query::result_merger oneshot_merger(cmd->get_row_limit(), query::max_partitions, per_partition_limit);
         coordinator_result<foreign_ptr<lw_shared_ptr<query::result>>> rresult = co_await utils::result_map_reduce(key_it, key_it_end, coroutine::lambda([&] (auto& key)
                 -> future<coordinator_result<foreign_ptr<lw_shared_ptr<query::result>>>> {
             auto command = ::make_lw_shared<query::read_command>(*cmd);

--- a/query_result_merger.hh
+++ b/query_result_merger.hh
@@ -19,10 +19,12 @@ class result_merger {
     std::vector<foreign_ptr<lw_shared_ptr<query::result>>> _partial;
     const uint64_t _max_rows;
     const uint32_t _max_partitions;
+    const std::optional<uint64_t> _per_partition_limit;
 public:
-    explicit result_merger(uint64_t max_rows, uint32_t max_partitions)
+    explicit result_merger(uint64_t max_rows, uint32_t max_partitions, std::optional<uint64_t> per_partition_limit = std::nullopt)
             : _max_rows(max_rows)
             , _max_partitions(max_partitions)
+            , _per_partition_limit(per_partition_limit)
     { }
 
     void reserve(size_t size) {

--- a/test/cqlpy/test_secondary_index.py
+++ b/test/cqlpy/test_secondary_index.py
@@ -1720,8 +1720,7 @@ def test_index_non_eq_relation(cql, test_keyspace):
 # With issue #12762, this test used to pass without an index (use_index=False)
 # but failed with an index (use_index=True) - it seems the PER PARTITION LIMIT
 # request was just ignored.
-@pytest.mark.parametrize("use_index", [
-        pytest.param(True, marks=pytest.mark.xfail(reason="#12762")), False])
+@pytest.mark.parametrize("use_index", [True, False])
 def test_index_filtering_scan_and_per_partition_limit(cql, test_keyspace, use_index):
     with new_test_table(cql, test_keyspace, "p int, c int, v int, PRIMARY KEY (p, c)") as table:
         if use_index:
@@ -1735,7 +1734,7 @@ def test_index_filtering_scan_and_per_partition_limit(cql, test_keyspace, use_in
         # use the index when it's available (otherwise the query v=0 won't
         # be efficient), but shouldn't forget also the PER PARTITION LIMIT.
         allow_filtering = '' if use_index else 'ALLOW FILTERING'
-        assert {(0,0,0), (1, 0, 0)} == set(cql.execute(f'SELECT * FROM {table} WHERE v=0 PER PARTITION LIMIT 1 {allow_filtering}'))
+        assert {(0, 0), (1, 0)} == set(cql.execute(f'SELECT p, v FROM {table} WHERE v=0 PER PARTITION LIMIT 1 {allow_filtering}'))
 
 # Similar to above test with PER PARTITION LIMIT, but also adds further
 # filtering which eliminates some result candidates retrieved by the index.


### PR DESCRIPTION
This change makes query::result_merger respect PER PARTITION LIMIT. It is achieved by keeping track of outputted partitions if PER PARTITION LIMIT is present.

There is a caveat that due to the indeterministic order of incoming results, the limited results appear in an indeterministic order as well

Before this patch PER PARTITION LIMIT had no effect on queries using secondary indexes. For example:

```
CREATE TABLE ks.foo (p int, c int, v int) PRIMARY KEY (p, c);
CREATE INDEX foo_v_idx ON ks.foo(v);
```
(add rows)

```
cassandra@cqlsh> select * from ks.foo;

 p | c | v
---+---+---
 1 | 0 | 0
 1 | 1 | 0
 0 | 0 | 0
 0 | 1 | 0

(4 rows)
```

Before behavior:
```
cassandra@cqlsh> SELECT * FROM ks.foo WHERE v=0 PER PARTITION LIMIT 1;

 p | c | v
---+---+---
 1 | 0 | 0
 1 | 1 | 0
 0 | 0 | 0
 0 | 1 | 0

(4 rows)
```

Possible after behavior:
```
cassandra@cqlsh> SELECT * FROM ks.foo WHERE v=0 PER PARTITION LIMIT 1;

 p | c | v
---+---+---
 1 | 0 | 0
 0 | 1 | 0

(2 rows)
```

Fixes https://github.com/scylladb/scylladb/issues/12762

I don't think there's a specific reason for a backport to be necessary.