### PR TITLE
Update report-scylla-problem.rst , replacing old S3 url by new GCP bucket, hostname was incorrect

### DIFF
--- a/docs/troubleshooting/report-scylla-problem.rst
+++ b/docs/troubleshooting/report-scylla-problem.rst
@@ -216,7 +216,7 @@ The script contents is  as follows:
    export report_uuid=$(uuidgen)
    echo $report_uuid
    tar c report | xz > report.tar.xz
-   curl --request PUT --upload-file report.tar.xz "scylladb-users-upload.s3.amazonaws.com/$report_uuid/report.tar.xz"
+   curl --request PUT --upload-file report.tar.xz "upload.scylladb.com/$report_uuid/report.tar.xz"
    echo $report_uuid
 
 You can also see the results in `./report` dir


### PR DESCRIPTION
wrong url / hostname pointing to deprecated S3 bucket we use GCP bucket now for uploads

**Please replace this line with justification for the backport/\* labels added to this PR**