### PR TITLE
readers/mutation_readers: queue_reader_handle_v2::push_end_of_stream() raise _ex if set

### DIFF
--- a/readers/queue.hh
+++ b/readers/queue.hh
@@ -29,6 +29,8 @@ private:
 
     void abandon() noexcept;
 
+    [[nodiscard]] std::exception_ptr check_abort() const noexcept;
+
 public:
     queue_reader_handle_v2(queue_reader_handle_v2&& o) noexcept;
     ~queue_reader_handle_v2();


### PR DESCRIPTION
Instead of raising std::runtime_error("Dangling queue_reader_handle_v2") unconditionally. push() already raises _ex if set, best to be consistent. Unconditionally raising std::runtime_error can cause an error to be logged, when aborting an operation involving a queue reader. Although the original exception passed to queue_reader_handle_v2::abort() is most likely handled by higher level code (not logged), the generic std::runtime_error raised is not and therefore is logged.

Fixes: https://github.com/scylladb/scylladb/issues/23550

Minor cosmetic bugfix, no backport required.