### PR TITLE
test: mv: skip test_view_building_scheduling_group in debug

### DIFF
--- a/test/cluster/mv/test_mv_building.py
+++ b/test/cluster/mv/test_mv_building.py
@@ -9,6 +9,7 @@ import logging
 from test.pylib.manager_client import ManagerClient
 from test.pylib.tablets import get_tablet_replica
 from test.pylib.util import unique_name, wait_for_view
+from test.cluster.conftest import skip_mode
 from test.cluster.util import new_test_keyspace
 
 logger = logging.getLogger(__name__)
@@ -19,6 +20,7 @@ logger = logging.getLogger(__name__)
 # much less than the streaming group.
 # Reproduces https://github.com/scylladb/scylladb/issues/21232
 @pytest.mark.asyncio
+@skip_mode('debug', 'the test needs to do some work which takes too much time in debug mode')
 async def test_view_building_scheduling_group(manager: ManagerClient):
     server = await manager.server_add()
     cql = manager.get_cql()


### PR DESCRIPTION
The test populates a table with 50k rows, creates a view on that table and then compares the time spent in streaming vs. gossip scheduling groups. It only takes 10s in dev mode on my machine, but is much slower in debug mode in CI - building the view doesn't finish within 2 minutes.

The bigger the view to build, the more accurrate the measurement; moreover, the test scenario isn't interesting enough to be worth running it in debug mode as this should be covered by other tests. Therefore, just skip this test in debug mode.

Fixes: scylladb/scylladb#23862

The issue most likely exists on all branches that have this test, so it needs to be backported to relevant branches (2025.1 and 2024.2).