### PR TITLE
database_test: Wait for the index to be created

### DIFF
--- a/test/boost/database_test.cc
+++ b/test/boost/database_test.cc
@@ -596,9 +596,10 @@ future<> do_with_some_data(std::vector<sstring> cf_names, std::function<future<>
                                                   cf_name))
                         .get();
                     f1.get();
-                    e.get_system_keyspace().local().load_built_views().get();
 
+                    auto f2 = e.local_view_builder().wait_until_built("ks", "index_cf_index");
                     e.execute_cql(seastar::format("CREATE INDEX index_{0} ON {0} (r1);", cf_name)).get();
+                    f2.get();
                 }
             }
 


### PR DESCRIPTION
Just call `wait_until_built` for the index in question

fix: https://github.com/scylladb/scylladb/issues/24059
