### PR TITLE
utils/stream_compressor: allocate memory for zstd compressors (in RPC compression) manually

### DIFF
--- a/utils/stream_compressor.hh
+++ b/utils/stream_compressor.hh
@@ -57,7 +57,7 @@ struct raw_stream final : public stream_compressor, public stream_decompressor {
 class zstd_dstream final : public stream_decompressor {
     struct ctx_deleter {
         void operator()(ZSTD_DStream* stream) const noexcept {
-            ZSTD_freeDStream(stream);
+            free(stream);
         }
     };
     std::unique_ptr<ZSTD_DStream, ctx_deleter> _ctx;
@@ -76,7 +76,7 @@ public:
 class zstd_cstream final : public stream_compressor {
     struct ctx_deleter {
         void operator()(ZSTD_CStream* stream) const noexcept {
-            ZSTD_freeCStream(stream);
+            free(stream);
         }
     };
     std::unique_ptr<ZSTD_CStream, ctx_deleter> _ctx;


### PR DESCRIPTION
The default and recommended way to use zstd compressors is to let zstd allocate and free memory for compressors on its own.

That's what we did for zstd compressors used in RPC compression. But it turns out that it generates allocation patterns we dislike.

We expected zstd not to generate allocations after the context object is initialized, but it turns out that it tries to downsize the context sometimes (by reallocation). We don't want that because the allocations generated by zstd are large (1 MiB with the parameters we use), so repeating them periodically stresses the reclaimer.

We can avoid this by using the "static context" API of zstd, in which the memory for context is allocated manually by the user of the library. In this mode, zstd doesn't allocate anything on its own.

The implementation details of this patch adds a consideration for forward compatibility: later versions of Scylla can't use a window size greater than the one we hardcoded in this patch when talking to the old version of the decompressor.

(This is not a problem, since those compressors are only used for RPC compression at the moment, where cross-version communication can be prevented by bumping COMPRESSOR_NAME. But it's something that the developer who changes the window size must _remember_ to do).

Fixes #24160
Fixes #24183

The feature was added in 2024.1, so this is a candidate for backporting up to 2024.1. But this is a performance fix/improvement, so the backport is optional.