### PR TITLE
doc: remove copyright from Cassandra Stress

### DIFF
--- a/docs/operating-scylla/admin-tools/cassandra-stress.rst
+++ b/docs/operating-scylla/admin-tools/cassandra-stress.rst
@@ -5,4 +5,3 @@ The cassandra-stress tool is used for benchmarking and load testing both ScyllaD
 
 Cassandra Stress is not part of ScyllaDB and it is not distributed along side it anymore. It has it's own separate repository and release cycle. More information about it can be found on `GitHub <https://github.com/scylladb/cassandra-stress>`_ or on `DockerHub <https://hub.docker.com/r/scylladb/cassandra-stress>`_.
 
-.. include:: /rst_include/apache-copyrights.rst


### PR DESCRIPTION
This PR removes the Apache copyright note from the Cassandra Stress page.

It's a follow-up to https://github.com/scylladb/scylladb/pull/21723, which missed that update (see https://github.com/scylladb/scylladb/pull/21723#discussion_r1944357143).

Cassandra Stress is a separate tool with a separate repo with the docs, so the copyright information on the page is incorrect.

Fixes https://github.com/scylladb/scylladb/issues/23240

This PR should be backported to branch-2025.1 and branch-2025.2 as it's a missing update to a PR that's already on those branches.