### PR TITLE
doc: add OS support for ScyllaDB 2025.2

### DIFF
--- a/docs/_static/data/os-support.json
+++ b/docs/_static/data/os-support.json
@@ -1,15 +1,24 @@
 {
     "Linux Distributions": {
-      "Ubuntu": ["20.04", "22.04", "24.04"],
+      "Ubuntu": ["20.04 (deprecated)", "22.04", "24.04"],
       "Debian": ["11"],
       "Rocky / CentOS / RHEL": ["8", "9"],
       "Amazon Linux": ["2023"]
     },
     "ScyllaDB Versions": [
       {
+        "version": "ScyllaDB 2025.2",
+        "supported_OS": {
+          "Ubuntu": ["20.04 (deprecated)", "22.04", "24.04"],
+          "Debian": ["11"],
+          "Rocky / CentOS / RHEL": ["8", "9"],
+          "Amazon Linux": ["2023"]
+        }
+      },
+      {
         "version": "ScyllaDB 2025.1",
         "supported_OS": {
-          "Ubuntu": ["20.04", "22.04", "24.04"],
+          "Ubuntu": ["20.04 (deprecated)", "22.04", "24.04"],
           "Debian": ["11"],
           "Rocky / CentOS / RHEL": ["8", "9"],
           "Amazon Linux": ["2023"]
@@ -18,7 +27,7 @@
       {
         "version": "Enterprise 2024.2",
         "supported_OS": {
-          "Ubuntu": ["20.04", "22.04", "24.04"],
+          "Ubuntu": ["20.04 (deprecated)", "22.04", "24.04"],
           "Debian": ["11"],
           "Rocky / CentOS / RHEL": ["8", "9"],
           "Amazon Linux": ["2023"]
@@ -27,19 +36,10 @@
       {
         "version": "Enterprise 2024.1",
         "supported_OS": {
-          "Ubuntu": ["20.04", "22.04", "24.04*"],
+          "Ubuntu": ["20.04 (deprecated)", "22.04", "24.04*"],
           "Debian": ["11"],
           "Rocky / CentOS / RHEL": ["8", "9"],
           "Amazon Linux": []
-        }
-      },
-      {
-        "version": "Open Source 6.2",
-        "supported_OS": {
-          "Ubuntu": ["20.04", "22.04", "24.04"],
-          "Debian": ["11"],
-          "Rocky / CentOS / RHEL": ["8", "9"],
-          "Amazon Linux": ["2023"]
         }
       }
     ]

--- a/docs/getting-started/os-support.rst
+++ b/docs/getting-started/os-support.rst
@@ -4,6 +4,9 @@ OS Support by Linux Distributions and Version
 The following matrix shows which Linux distributions, containers, and images
 are :ref:`supported <os-support-definition>` with which versions of ScyllaDB.
 
+Note that support for Ubuntu 20.04 is deprecated and will be removed in
+a future release.
+
 .. datatemplate:json:: /_static/data/os-support.json
   :template: platforms.tmpl
 


### PR DESCRIPTION
This PR adds the information about support for platforms in ScyllaDB version 20252.

Fixes https://github.com/scylladb/scylladb/issues/24180

This PR adds the information related to version 2025.2 and should be backported to branch-2025.2.