### PR TITLE
test_cdc_generation_publishing: fix to read monotonically

### DIFF
--- a/test/cluster/test_cdc_generation_publishing.py
+++ b/test/cluster/test_cdc_generation_publishing.py
@@ -82,7 +82,7 @@ async def test_multiple_unpublished_cdc_generations(request, manager: ManagerCli
     """Test that the CDC generation publisher works correctly when there is more than one unpublished CDC generation."""
     query_gen_timestamps = SimpleStatement(
         "select time from system_distributed.cdc_generation_timestamps where key = 'timestamps'",
-        consistency_level = ConsistencyLevel.ONE)
+        consistency_level = ConsistencyLevel.ALL)
 
     logger.info("Bootstrapping first node")
     servers = [await manager.server_add()]


### PR DESCRIPTION
The test test_multiple_unpublished_cdc_generations reads the CDC generation timestamps to verify they are published in the correct order. To do so it issues reads in a loop with a short sleep period and checks the differences between consecutive reads, assuming they are monotonic.

However the assumption that the reads are monotonic is not valid, because the reads are issued with consistency_level=ONE, thus we may read timestamps {A,B} from some node, then read timestamps {A} from another node that didn't apply the write of the new timestamp B yet. This will trigger the assert in the test and fail.

To ensure the reads are monotonic we change the test to use consistency level ALL for the reads.

Fixes scylladb/scylladb#24262

tested before: failed 2/128
tested after: passed 512/512

backport can be done to improve CI stability but I'm not sure there's need because I don't see that it fails much