### PR TITLE
.github/workflows/conflict_reminder: reduce the amount of conflict reminder for every push event

### DIFF
--- a/.github/workflows/conflict_reminder.yaml
+++ b/.github/workflows/conflict_reminder.yaml
@@ -89,6 +89,37 @@ jobs:
               if (prDetails.mergeable === false) {
                 const hasConflictLabel = pr.labels.some(label => label.name === conflictLabel);
                 console.log(`PR #${pr.number} has conflict label: ${hasConflictLabel}`);
+
+                if (
+                  isPushEvent &&
+                  pr.draft === true &&
+                  hasConflictLabel
+                ) {
+                  // Fetch comments to find last bot notification
+                  const comments = await github.paginate(github.rest.issues.listComments, {
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: pr.number,
+                    per_page: 100,
+                  });
+                  // Find last notification comment from the bot (by body and user)
+                  const botLogin = context.actor;
+                  const notificationPrefix = `@${pr.assignee.login}, this PR has merge conflicts with the base branch.`;
+                  const lastNotification = comments
+                    .filter(c =>
+                      c.user.type === "Bot" &&
+                      c.body.startsWith(notificationPrefix)
+                    )
+                    .sort((a, b) => new Date(b.created_at) - new Date(a.created_at))[0];
+                  if (lastNotification) {
+                    const lastNotified = new Date(lastNotification.created_at);
+                    if (lastNotified >= threeDaysAgo) {
+                      console.log(`PR #${pr.number} skipped: last notification was less than 3 days ago`);
+                      continue;
+                    }
+                  }
+                }
+
                 if (!hasConflictLabel) {
                   await github.rest.issues.addLabels({
                     owner: context.repo.owner,


### PR DESCRIPTION
In order to avoid spamming PR author about conflicts, added a logic to verify during push events, that in case PR is already in draft mode, we will check when was the last notification, if it's less then 3 days, we will skip it

**an improvement to conflict reminder, no need for backport, since it's fixing https://github.com/scylladb/scylladb/pull/24209 which is not in releases**

- [x] verified this change with https://github.com/yaronkaikov/trigger/actions/runs/15292739359/job/43015084536
![image](https://github.com/user-attachments/assets/5d6fee2e-b48a-45df-a96a-dc8367aea2ef)


Fixes: https://github.com/scylladb/scylla-pkg/issues/3319