### PR TITLE
test/result_utils: Do not assume map_reduce reducing order

### DIFF
--- a/test/boost/result_utils_test.cc
+++ b/test/boost/result_utils_test.cc
@@ -242,7 +242,8 @@ SEASTAR_THREAD_TEST_CASE(test_result_map_reduce) {
         auto bar_exc = [] () { return result<sstring>(bo::failure(bar_exception())); };
         auto foo_throw = [] () { return make_exception_future<result<sstring>>(foo_exception()); };
 
-        BOOST_REQUIRE_EQUAL(reduce(sstring("brown"), sstring("fox")).value(), "the brown fox");
+        auto res = reduce(sstring("brown"), sstring("fox")).value();
+        BOOST_REQUIRE(res == "the brown fox" || res == "the fox brown");
         BOOST_REQUIRE_EQUAL(reduce(foo_exc(), sstring("fox")).error(), exc_container(foo_exception()));
         BOOST_REQUIRE_EQUAL(reduce(sstring("brown"), foo_exc()).error(), exc_container(foo_exception()));
         BOOST_REQUIRE_EQUAL(reduce(foo_exc(), bar_exc()).error(), exc_container(foo_exception()));


### PR DESCRIPTION
When map_reduce is called on a collection, one shouldn't expect that it processes the elements of the collection in any specific order.

Current test of map-reduce over boost outcome assumes that if reduce function is the string concatenation, then it would concatenate the given vector of strings in the order they are listed. That requirement should be relaxed, and the result may have reversed concatentation.

fixes #24321

The test is in older versions and in may suffer from the same problem