### PR TITLE
[Backport 2025.1] changed the string literals into the correct ones

### DIFF
--- a/ent/encryption/kmip_host.cc
+++ b/ent/encryption/kmip_host.cc
@@ -868,8 +868,8 @@ future<std::vector<kmip_host::id_type>> kmip_host::impl::find_matching_keys(cons
 
     auto [kdl_attrs, crypt_alg] = make_attributes(info, false);
 
-    static const char kmip_tag_cryptographic_length[] = KMIP_TAG_CRYPTOGRAPHIC_LENGTH_STR;
-    static const char kmip_tag_cryptographic_usage_mask[] = KMIP_TAG_CRYPTOGRAPHIC_USAGE_MASK_STR;
+    static const char kmip_tag_cryptographic_length[] = KMIP_TAGSTR_CRYPTOGRAPHIC_LENGTH;
+    static const char kmip_tag_cryptographic_usage_mask[] = KMIP_TAGSTR_CRYPTOGRAPHIC_USAGE_MASK;
 
     // #1079. Query mask apparently ignores things like cryptographic 
     // attribute set of options, instead we must specify the query 


### PR DESCRIPTION
Fixes: #23970

use correct string literals:
KMIP_TAG_CRYPTOGRAPHIC_LENGTH_STR --> KMIP_TAGSTR_CRYPTOGRAPHIC_LENGTH KMIP_TAG_CRYPTOGRAPHIC_USAGE_MASK_STR --> KMIP_TAGSTR_CRYPTOGRAPHIC_USAGE_MASK

From #23970 description of the problem (emphasizes are mine):

When transparent data encryption at rest is enabled with KMIP as a key provider, the observation is that before creating a new key, Scylla tries to locate an existing key with provided specifications (key algorithm & length), with the intention to re-use existing key, **but the attributes sent in the request have minor spelling mistakes** which are rejected by the KMIP server key provider, and hence scylla assumes that a key with these specifications doesn't exist, and creates a new key in the KMIP server. The issue here is that for every new table, ScyllaDB will create a key in the KMIP server, which could clutter the KMS, and make key lifecycle management difficult for DBAs.

(cherry picked from commit 37854acc927c796a519de9f73b70f37f472f206a)

Rebased #24302
