### PR TITLE
test/alternator: verify that DeleteItem returns an empty object

### DIFF
--- a/test/alternator/test_item.py
+++ b/test/alternator/test_item.py
@@ -404,6 +404,21 @@ def test_delete_item_sort(test_table):
     test_table.delete_item(Key=key)
     assert not 'Item' in test_table.get_item(Key=key, ConsistentRead=True)
 
+# DeleteItem should return an empty response object if none of the options
+# ReturnValues, ReturnConsumedCapacity or ReturnItemCollectionMetrics are requested.
+# We have tests elsewhere (see test_returnvalues.py, test_returnconsumedcapacity.py)
+# for testing DeleteItem with those optional features.
+def test_delete_item_return(test_table_s):
+    p = random_string()
+    test_table_s.put_item(Item={'p': p})
+    assert 'Item' in test_table_s.get_item(Key={'p': p}, ConsistentRead=True)
+    ret = test_table_s.delete_item(Key={'p': p})
+    assert not 'Item' in test_table_s.get_item(Key={'p': p}, ConsistentRead=True)
+    # boto3 always adds a "ResponseMetadata" item to the reponse object. Remove
+    # it and verify an empty object is left:
+    del ret['ResponseMetadata']
+    assert ret == {}
+
 # Test that PutItem completely replaces an existing item. It shouldn't merge
 # it with a previously existing value, as UpdateItem does!
 # We test for a table with just hash key, and for a table with both hash and


### PR DESCRIPTION
A user on StackOverflow (https://stackoverflow.com/questions/79650278) reported that DeleteItem returns the apropriate response (an empty object) on DynamoDB, but doesn't on "DynamoDB Local" (Amazon's local mock of DynamoDB). I wrote the test in this patch to make sure that Alternator doesn't have this bug, and indeed it doesn't: When DeleteItem is used without any option that asks for additional output, its reponse is, as expected, an empty object.

As usual, the new test passes on both Alternator and AWS DynamoDB. (I didn't actually test on DynamoDB Local, I have some problems with running that, but it doesn't matter, we have no intention of testing DynamoDB Local).

Backport not needed - this is just a new test.