### PR TITLE
mv: handle mismatched base/view replica count caused by RF change

### DIFF
--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -1774,8 +1774,24 @@ bool should_generate_view_updates_on_this_shard(const schema_ptr& base, const lo
 //
 // If the assumption that the given base token belongs to this replica
 // does not hold, we return an empty optional.
-std::optional<locator::host_id>
-get_view_natural_endpoint(
+//
+// Aside from the paired replica, we may return another replica that we should
+// send the update to - the extra replica is then returned as the second replica
+// in the pair. The second replica is returned when it can't get paired with
+// any base replica. This can happen when the base table is undergoing
+// an increase in the replication factor. The view replica may finish the
+// RF change before the base replica, and since we only pair replicas that
+// finished the change, the view replica may not have a base replica to pair with.
+// To make sure it gets the update regardless, each base replica which detects such
+// a scenario will also send the update to the new view replica.
+// If this scenario does not occur, we return an empty optional as the
+// second replica.
+// We don't need to return the second replica if we have more base replicas than
+// view replicas - in that case the corresponding view replica will get the
+// update anyway, because either the streaming didn't start yet, so the update
+// will get streamed later, or it's still pending and it will get the update
+// because we also send updates from all base replicas to the pending view replicas.
+endpoints_to_update get_view_natural_endpoint(
         locator::host_id me,
         const locator::effective_replication_map_ptr& base_erm,
         const locator::effective_replication_map_ptr& view_erm,
@@ -1800,7 +1816,7 @@ get_view_natural_endpoint(
         if (auto* np = topology.find_node(ep)) {
             return *np;
         }
-        throw std::runtime_error(format("get_view_natural_endpoint: base replica {} not found in topology", ep));
+        throw std::runtime_error(format("get_view_natural_endpoint: {} replica {} not found in topology", is_view ? "view" : "base", ep));
     };
 
     // We need to use get_replicas() for pairing to be stable in case base or view tablet
@@ -1833,8 +1849,10 @@ get_view_natural_endpoint(
             auto it = std::ranges::find(base_endpoints, view_node.get().host_id(), std::mem_fn(&locator::node::host_id));
             // If this base replica is also one of the view replicas, we use
             // ourselves as the view replica.
+            // We don't return an extra endpoint, as it's only needed when
+            // using tablets (so !use_legacy_self_pairing)
             if (view_node.get().host_id() == me && it != base_endpoints.end()) {
-                return me;
+                return {.natural_endpoint = me};
             }
 
             // We have to remove any endpoint which is shared between the base
@@ -1853,7 +1871,9 @@ get_view_natural_endpoint(
     }
 
     // Try optimizing for simple rack-aware pairing
-    if (rack_aware_pairing) {
+    // If the numbers of base and view replica differ, that means an RF change is taking place
+    // and we can't use simple rack-aware pairing.
+    if (rack_aware_pairing && base_endpoints.size() == view_endpoints.size()) {
         auto dc_rf = network_topology->get_replication_factor(my_datacenter);
         const auto& racks = topology.get_datacenter_rack_nodes().at(my_datacenter);
         // Simple rack-aware pairing is possible when the datacenter replication factor
@@ -1870,6 +1890,11 @@ get_view_natural_endpoint(
                 }
             }
         }
+        if (dc_rf != base_endpoints.size()) {
+            // If the datacenter replication factor is not equal to the number of base replicas,
+            // we're in progress of a RF change and we can't use simple rack-aware pairing.
+            simple_rack_aware_pairing = false;
+        }
         if (simple_rack_aware_pairing) {
             std::erase_if(base_endpoints, [&] (const locator::node& node) { return node.dc_rack() != my_location; });
             std::erase_if(view_endpoints, [&] (const locator::node& node) { return node.dc_rack() != my_location; });
@@ -1882,6 +1907,7 @@ get_view_natural_endpoint(
     // For the complex rack_aware_pairing case, nodes are already filtered by datacenter
     // Use best-match, for the minimum number of base and view replicas in each rack,
     // and ordinal match for the rest.
+    std::optional<std::reference_wrapper<const locator::node>> paired_replica;
     if (rack_aware_pairing && !simple_rack_aware_pairing) {
         struct indexed_replica {
             size_t idx;
@@ -1903,12 +1929,18 @@ get_view_natural_endpoint(
         const auto& my_base_replicas = base_racks[my_location.rack];
         auto base_it = std::ranges::find(my_base_replicas, me, [] (const indexed_replica& ir) { return ir.node.get().host_id(); });
         if (base_it == my_base_replicas.end()) {
-            return std::nullopt;
+            return {};
         }
         const auto& my_view_replicas = view_racks[my_location.rack];
         size_t idx = base_it - my_base_replicas.begin();
         if (idx < my_view_replicas.size()) {
-            return my_view_replicas[idx].node.get().host_id();
+            if (orig_view_endpoints.size() <= orig_base_endpoints.size()) {
+                return {.natural_endpoint = my_view_replicas[idx].node.get().host_id()};
+            } else {
+                // If the number of view replicas is larger than the number of base replicas,
+                // we need to find the unpaired view replica, so we can't return yet.
+                paired_replica = my_view_replicas[idx].node;
+            }
         }
 
         // Collect all unpaired base and view replicas,
@@ -1939,7 +1971,7 @@ get_view_natural_endpoint(
     }
 
     auto base_it = std::ranges::find(base_endpoints, me, std::mem_fn(&locator::node::host_id));
-    if (base_it == base_endpoints.end()) {
+    if (!paired_replica && base_it == base_endpoints.end()) {
         // This node is not a base replica of this key, so we return empty
         // FIXME: This case shouldn't happen, and if it happens, a view update
         // would be lost.
@@ -1949,7 +1981,8 @@ get_view_natural_endpoint(
         return {};
     }
     size_t idx = base_it - base_endpoints.begin();
-    if (idx >= view_endpoints.size()) {
+    std::optional<std::reference_wrapper<const locator::node>> no_pairing_replica;
+    if (!paired_replica && idx >= view_endpoints.size()) {
         // There are fewer view replicas than base replicas
         // FIXME: This might still happen when reducing replication factor with tablets,
         // see https://github.com/scylladb/scylladb/issues/21492
@@ -1959,8 +1992,41 @@ get_view_natural_endpoint(
                 orig_base_endpoints | std::views::transform(std::mem_fn(&locator::node::host_id)),
                 orig_view_endpoints | std::views::transform(std::mem_fn(&locator::node::host_id)));
         return {};
+    } else if (base_endpoints.size() < view_endpoints.size()) {
+        // There are fewer base replicas than view replicas.
+        // This can happen as a result of an RF change when the view replica finishes streaming
+        // before the base replica.
+        // Because of this, a view replica might not get paired with any base replica, so we need
+        // to send an additional update to it.
+        ++cf_stats.total_view_updates_due_to_replica_count_mismatch;
+        no_pairing_replica = view_endpoints.back();
+        if (base_endpoints.size() < view_endpoints.size() - 1) {
+            // We only expect one extra replica to appear due to an RF change. If there's more, that's an error,
+            // but we'll still perform updates to the paired and last replicas to minimize degradation.
+            vlogger.warn("There are too many view endpoints for base-view pairing. View updates may get lost on view_endpoints={}",
+                    std::span(view_endpoints.begin() + base_endpoints.size(), view_endpoints.end() - 1) | std::views::transform(std::mem_fn(&locator::node::host_id)));
+        }
     }
 
+    if (!paired_replica) {
+        paired_replica = view_endpoints[idx];
+    }
+    if (!no_pairing_replica && base_nodes.size() < view_nodes.size()) {
+        // This can happen when the view replica with no pairing is in another DC.
+        // We need to send an update to it if there are no base replicas in that DC yet,
+        // as it won't receive updates otherwise.
+        std::unordered_set<sstring> dcs_with_base_replicas;
+        for (const auto& base_node : base_nodes) {
+            dcs_with_base_replicas.insert(base_node.get().dc());
+        }
+        for (const auto& view_node : view_nodes) {
+            if (!dcs_with_base_replicas.contains(view_node.get().dc())) {
+                ++cf_stats.total_view_updates_due_to_replica_count_mismatch;
+                no_pairing_replica = view_node;
+                break;
+            }
+        }
+    }
     // https://github.com/scylladb/scylladb/issues/19439
     // With tablets, a node being replaced might transition to "left" state
     // but still be kept as a replica.
@@ -1968,12 +2034,20 @@ get_view_natural_endpoint(
     // but are still replicas. Therefore, there is no other sensible option
     // right now but to give up attempt to send the update or write a hint
     // to the paired, permanently down replica.
-    const auto& node = view_endpoints[idx].get();
-    if (!node.left()) {
-        return node.host_id();
-    } else {
-        return std::nullopt;
-    }
+    // We use the same workaround for the extra replica.
+    auto return_host_id_if_not_left = [] (const auto& replica) -> std::optional<locator::host_id> {
+        if (!replica) {
+            return std::nullopt;
+        }
+        const auto& node = replica->get();
+        if (!node.left()) {
+            return node.host_id();
+        } else {
+            return std::nullopt;
+        }
+    };
+    return {.natural_endpoint = return_host_id_if_not_left(paired_replica),
+            .endpoint_with_no_pairing = return_host_id_if_not_left(no_pairing_replica)};
 }
 
 static future<> apply_to_remote_endpoints(service::storage_proxy& proxy, locator::effective_replication_map_ptr ermp,
@@ -2061,11 +2135,20 @@ future<> view_update_generator::mutate_MV(
     co_await max_concurrent_for_each(view_updates, max_concurrent_updates, [&] (frozen_mutation_and_schema mut) mutable -> future<> {
         auto view_token = dht::get_token(*mut.s, mut.fm.key());
         auto view_ermp = erms.at(mut.s->id());
-        auto target_endpoint = get_view_natural_endpoint(me, base_ermp, view_ermp, replication, base_token, view_token,
+        auto [target_endpoint, no_pairing_endpoint] = get_view_natural_endpoint(me, base_ermp, view_ermp, replication, base_token, view_token,
                 use_legacy_self_pairing, use_tablets_rack_aware_view_pairing, cf_stats);
         auto remote_endpoints = view_ermp->get_pending_replicas(view_token);
         auto sem_units = seastar::make_lw_shared<db::timeout_semaphore_units>(pending_view_updates.split(memory_usage_of(mut)));
-
+        if (no_pairing_endpoint) {
+            // The no_pairing_endpoint can appear during a replication factor increase when the base tablet migration finished after
+            // the corresponding (for current token) view tablet migration. In this case, the view replica is no longer
+            // in migration (so it's not present in the pending endpoints list), but the base replica didn't start the migration yet
+            // or is still pending. We don't pair pending replicas, so no base replica will pair with this view replica and we need
+            // to send the update to it.
+            // FIXME: Here we may unnecessarily send the update to the no_pairing_endpoint from many base replicas,
+            // similarly to https://github.com/scylladb/scylladb/issues/7711
+            remote_endpoints.push_back(std::move(*no_pairing_endpoint));
+        }
         const bool update_synchronously = should_update_synchronously(*mut.s);
         if (update_synchronously) {
             tracing::trace(tr_state, "Forcing {}.{} view update to be synchronous (synchronous_updates property was set)",

--- a/db/view/view.hh
+++ b/db/view/view.hh
@@ -293,7 +293,12 @@ size_t memory_usage_of(const frozen_mutation_and_schema& mut);
  */
  void create_virtual_column(schema_builder& builder, const bytes& name, const data_type& type);
 
-std::optional<locator::host_id> get_view_natural_endpoint(
+struct endpoints_to_update {
+    std::optional<locator::host_id> natural_endpoint;
+    std::optional<locator::host_id> endpoint_with_no_pairing;
+};
+
+endpoints_to_update get_view_natural_endpoint(
     locator::host_id node,
     const locator::effective_replication_map_ptr& base_erm,
     const locator::effective_replication_map_ptr& view_erm,

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -696,6 +696,11 @@ database::setup_metrics() {
 
         sm::make_total_operations("total_view_updates_failed_pairing", _cf_stats.total_view_updates_failed_pairing,
                 sm::description("Total number of view updates for which we failed base/view pairing.")).set_skip_when_empty(),
+
+        sm::make_total_operations("total_view_updates_due_to_replica_count_mismatch", _cf_stats.total_view_updates_due_to_replica_count_mismatch,
+                sm::description("Total number of view updates for which there were more view replicas than base replicas "
+                    "and we had to generate an extra view update because the additional view replica wouldn't get paired with any base replica."
+                    "Should only increase during RF change. Should stop increasing shortly after finishing the RF change.")).set_skip_when_empty(),
     });
     if (this_shard_id() == 0) {
         _metrics.add_group("database", {

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -379,6 +379,8 @@ struct cf_stats {
 
     // How many times we failed to resolve base/view pairing
     uint64_t total_view_updates_failed_pairing = 0;
+    // How many times we had to send additional view updates when there was more view replicas than base replicas during pairing.
+    uint64_t total_view_updates_due_to_replica_count_mismatch = 0;
 };
 
 class table;

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -6348,6 +6348,17 @@ future<> storage_service::clone_locally_tablet_storage(locator::global_tablet_id
 // Streams data to the pending tablet replica of a given tablet on this node.
 // The source tablet replica is determined from the current transition info of the tablet.
 future<> storage_service::stream_tablet(locator::global_tablet_id tablet) {
+    co_await utils::get_local_injector().inject("block_tablet_streaming", [this, &tablet] (auto& handler) -> future<> {
+        const auto keyspace = handler.get("keyspace");
+        const auto table = handler.get("table");
+        SCYLLA_ASSERT(keyspace);
+        SCYLLA_ASSERT(table);
+        auto s = _db.local().find_column_family(tablet.table).schema();
+        bool should_block = s->ks_name() == *keyspace && s->cf_name() == *table;
+        while (should_block && !handler.poll_for_message() && !_async_gate.is_closed()) {
+            co_await sleep(std::chrono::milliseconds(100));
+        }
+    });
     co_await do_tablet_operation(tablet, "Streaming", [this, tablet] (locator::tablet_metadata_guard& guard) -> future<tablet_operation_result> {
         auto tm = guard.get_token_metadata();
         auto& tmap = guard.get_tablet_map();

--- a/test/boost/network_topology_strategy_test.cc
+++ b/test/boost/network_topology_strategy_test.cc
@@ -1342,7 +1342,7 @@ SEASTAR_THREAD_TEST_CASE(tablets_simple_rack_aware_view_pairing_test) {
             view_token,
             use_legacy_self_pairing,
             use_tablets_basic_rack_aware_view_pairing,
-            cf_stats);
+            cf_stats).natural_endpoint;
 
         // view pair must be found
         BOOST_REQUIRE(view_ep_opt);
@@ -1497,7 +1497,7 @@ void test_complex_rack_aware_view_pairing_test(bool more_or_less) {
             view_token,
             use_legacy_self_pairing,
             use_tablets_basic_rack_aware_view_pairing,
-            cf_stats);
+            cf_stats).natural_endpoint;
 
         // view pair must be found
         if (!view_ep_opt) {


### PR DESCRIPTION
During an ALTER KEYSPACE statement execution where a table with a view
is present, we need to perform tablet migrations for both tables.
These migrations are not synchronized, so at some point the base may
have a different number of non-pending replicas than the view. Because
of that, we can't pair them correctly. If there is more non-pending
base replicas than view replicas, we don't need to do anything because
the view replica that didn't finish migrating is a pending replica
and will get view updates from all base replicas. But if there is more
non-pending view replicas than base replicas, we may currently lose
view updates to the new view replica.

This patch adds a workaround for this scenario. If after one migration
we have too more non-pending view replicas than base replicas, we add
it to the pending replica list so that it gets an update anyway.

This patch will also take effect if the base and view replica counts
differ due to some other bug. To track that, a new metric is added
to count such occurrences.

This patch also includes a test for this exact scenario, which is enforced by an injection.

Fixes https://github.com/scylladb/scylladb/issues/21492