### PR TITLE
doc: remove the limitation for disabling CDC

### DIFF
--- a/docs/features/cdc/cdc-intro.rst
+++ b/docs/features/cdc/cdc-intro.rst
@@ -67,9 +67,6 @@ You can enable CDC when creating or altering a table using the ``cdc`` option, f
 
     CREATE TABLE ks.t (pk int, ck int, v int, PRIMARY KEY (pk, ck, v)) WITH cdc = {'enabled':true};
 
-.. note::
-   If you enabled CDC and later decide to disable it, you need to **stop all writes** to the base table before issuing the ``ALTER TABLE ... WITH cdc = {'enabled':false};`` command.
-
 .. include:: /features/cdc/_common/cdc-params.rst
 
 Using CDC with Applications


### PR DESCRIPTION
This PR removes the instruction to stop all writes before disabling CDC with ALTER.

Fixes https://github.com/scylladb/scylla-docs/issues/4020

Fixes https://github.com/scylladb/scylladb/issues/24474 

**About backport:**
This PR fixes an issue reported by customers for various versions, and it affects versions as old as 2022.
For this reason, it should be backported to all release branches we're currently supporting: **2025.2** (required, next release), **2025.1** (required, LTS), **2024.1** (required, LTS), 2024.2 (optional, end of support when 2025.2 is released).

2024.1 and 2024.2 are in the https://github.com/scylladb/scylla-enterprise repository, so I assume this PR will have to be manually backported there.