### PR TITLE
service: Support adding/removing a datacenter with tablets by changing RF

### DIFF
--- a/cql3/statements/alter_keyspace_statement.cc
+++ b/cql3/statements/alter_keyspace_statement.cc
@@ -90,6 +90,20 @@ void cql3::statements::alter_keyspace_statement::validate(query_processor& qp, c
                 auto& current_rf_per_dc = ks.metadata()->strategy_options();
                 auto new_rf_per_dc = _attrs->get_replication_options();
                 new_rf_per_dc.erase(ks_prop_defs::REPLICATION_STRATEGY_CLASS_KEY);
+                // Check if multi-RF change is allowed: all DC changes must be 0->N or N->0.
+                auto all_changes_are_0_N = [&] {
+                    for (const auto& [dc, new_rf] : new_rf_per_dc) {
+                        auto old_rf_val = size_t(0);
+                        if (auto it = current_rf_per_dc.find(dc); it != current_rf_per_dc.end()) {
+                            old_rf_val = locator::get_replication_factor(it->second);
+                        }
+                        auto new_rf_val = locator::get_replication_factor(new_rf);
+                        if (old_rf_val != new_rf_val && old_rf_val != 0 && new_rf_val != 0) {
+                            return false;
+                        }
+                    }
+                    return true;
+                };
                 unsigned total_abs_rfs_diff = 0;
                 for (const auto& [new_dc, new_rf] : new_rf_per_dc) {
                     auto old_rf = locator::replication_strategy_config_option(sstring("0"));
@@ -103,7 +117,9 @@ void cql3::statements::alter_keyspace_statement::validate(query_processor& qp, c
                         // first we need to report non-existing DCs, then if RFs aren't changed by too much.
                         continue;
                     }
-                    if (total_abs_rfs_diff += get_abs_rf_diff(old_rf, new_rf); total_abs_rfs_diff >= 2) {
+                    if (total_abs_rfs_diff += get_abs_rf_diff(old_rf, new_rf); total_abs_rfs_diff >= 2 &&
+                            !(qp.proxy().features().keyspace_multi_rf_change && locator::uses_rack_list_exclusively(current_rf_per_dc)
+                            && locator::uses_rack_list_exclusively(new_ks->strategy_options()) && all_changes_are_0_N())) {
                         throw exceptions::invalid_request_exception("Only one DC's RF can be changed at a time and not by more than 1");
                     }
                 }

--- a/cql3/statements/ks_prop_defs.cc
+++ b/cql3/statements/ks_prop_defs.cc
@@ -440,7 +440,7 @@ lw_shared_ptr<data_dictionary::keyspace_metadata> ks_prop_defs::as_ks_metadata_u
         sc = old->strategy_name();
         options = old_options;
     }
-    return data_dictionary::keyspace_metadata::new_keyspace(old->name(), *sc, options, initial_tablets, get_consistency_option(), get_boolean(KW_DURABLE_WRITES, true), get_storage_options());
+    return data_dictionary::keyspace_metadata::new_keyspace(old->name(), *sc, options, initial_tablets, get_consistency_option(), get_boolean(KW_DURABLE_WRITES, true), get_storage_options(), {}, old->next_strategy_options_opt());
 }
 
 namespace {

--- a/data_dictionary/data_dictionary.cc
+++ b/data_dictionary/data_dictionary.cc
@@ -224,10 +224,12 @@ keyspace_metadata::keyspace_metadata(std::string_view name,
              bool durable_writes,
              std::vector<schema_ptr> cf_defs,
              user_types_metadata user_types,
-             storage_options storage_opts)
+             storage_options storage_opts,
+             std::optional<locator::replication_strategy_config_options> next_options)
     : _name{name}
     , _strategy_name{locator::abstract_replication_strategy::to_qualified_class_name(strategy_name.empty() ? "NetworkTopologyStrategy" : strategy_name)}
     , _strategy_options{std::move(strategy_options)}
+    , _next_strategy_options{std::move(next_options)}
     , _initial_tablets(initial_tablets)
     , _durable_writes{durable_writes}
     , _user_types{std::move(user_types)}
@@ -273,14 +275,15 @@ keyspace_metadata::new_keyspace(std::string_view name,
                                 std::optional<consistency_config_option> consistency_option,
                                 bool durables_writes,
                                 storage_options storage_opts,
-                                std::vector<schema_ptr> cf_defs)
+                                std::vector<schema_ptr> cf_defs,
+                                std::optional<locator::replication_strategy_config_options> next_options)
 {
-    return ::make_lw_shared<keyspace_metadata>(name, strategy_name, options, initial_tablets, consistency_option, durables_writes, cf_defs, user_types_metadata{}, storage_opts);
+    return ::make_lw_shared<keyspace_metadata>(name, strategy_name, options, initial_tablets, consistency_option, durables_writes, cf_defs, user_types_metadata{}, storage_opts, next_options);
 }
 
 lw_shared_ptr<keyspace_metadata>
 keyspace_metadata::new_keyspace(const keyspace_metadata& ksm) {
-    return new_keyspace(ksm.name(), ksm.strategy_name(), ksm.strategy_options(), ksm.initial_tablets(), ksm.consistency_option(), ksm.durable_writes(), ksm.get_storage_options());
+    return new_keyspace(ksm.name(), ksm.strategy_name(), ksm.strategy_options(), ksm.initial_tablets(), ksm.consistency_option(), ksm.durable_writes(), ksm.get_storage_options(), {}, ksm.next_strategy_options_opt());
 }
 
 void keyspace_metadata::add_user_type(const user_type ut) {
@@ -649,8 +652,8 @@ struct fmt::formatter<data_dictionary::user_types_metadata> {
 };
 
 auto fmt::formatter<data_dictionary::keyspace_metadata>::format(const data_dictionary::keyspace_metadata& m, fmt::format_context& ctx) const -> decltype(ctx.out()) {
-    fmt::format_to(ctx.out(), "KSMetaData{{name={}, strategyClass={}, strategyOptions={}, cfMetaData={}, durable_writes={}, tablets=",
-            m.name(), m.strategy_name(), m.strategy_options(), m.cf_meta_data(), m.durable_writes());
+    fmt::format_to(ctx.out(), "KSMetaData{{name={}, strategyClass={}, strategyOptions={}, nextStrategyOptions={}, cfMetaData={}, durable_writes={}, tablets=",
+            m.name(), m.strategy_name(), m.strategy_options(), m.next_strategy_options_opt(), m.cf_meta_data(), m.durable_writes());
     if (m.initial_tablets()) {
         if (auto initial_tablets = m.initial_tablets().value()) {
             fmt::format_to(ctx.out(), "{{\"initial\":{}}}", initial_tablets);

--- a/data_dictionary/keyspace_metadata.hh
+++ b/data_dictionary/keyspace_metadata.hh
@@ -28,7 +28,9 @@ namespace data_dictionary {
 class keyspace_metadata final {
     sstring _name;
     sstring _strategy_name;
+    // If _next_strategy_options has value, there is ongoing rf change of this keyspace.
     locator::replication_strategy_config_options _strategy_options;
+    std::optional<locator::replication_strategy_config_options> _next_strategy_options;
     std::optional<unsigned> _initial_tablets;
     std::unordered_map<sstring, schema_ptr> _cf_meta_data;
     bool _durable_writes;
@@ -44,7 +46,8 @@ public:
                  bool durable_writes,
                  std::vector<schema_ptr> cf_defs = std::vector<schema_ptr>{},
                  user_types_metadata user_types = user_types_metadata{},
-                 storage_options storage_opts = storage_options{});
+                 storage_options storage_opts = storage_options{},
+                 std::optional<locator::replication_strategy_config_options> next_options = std::nullopt);
     static lw_shared_ptr<keyspace_metadata>
     new_keyspace(std::string_view name,
                  std::string_view strategy_name,
@@ -53,7 +56,8 @@ public:
                  std::optional<consistency_config_option> consistency_option,
                  bool durables_writes = true,
                  storage_options storage_opts = {},
-                 std::vector<schema_ptr> cf_defs = {});
+                 std::vector<schema_ptr> cf_defs = {},
+                 std::optional<locator::replication_strategy_config_options> next_options = std::nullopt);
     static lw_shared_ptr<keyspace_metadata>
     new_keyspace(const keyspace_metadata& ksm);
     void validate(const gms::feature_service&, const locator::topology&) const;
@@ -65,6 +69,18 @@ public:
     }
     const locator::replication_strategy_config_options& strategy_options() const {
         return _strategy_options;
+    }
+    void set_strategy_options(const locator::replication_strategy_config_options& options) {
+        _strategy_options = options;
+    }
+    const std::optional<locator::replication_strategy_config_options>& next_strategy_options_opt() const {
+        return _next_strategy_options;
+    }
+    void set_next_strategy_options(const locator::replication_strategy_config_options& options) {
+        _next_strategy_options = options;
+    }
+    void clear_next_strategy_options() {
+        _next_strategy_options = std::nullopt;
     }
     locator::replication_strategy_config_options strategy_options_v1() const;
     std::optional<unsigned> initial_tablets() const {

--- a/db/schema_features.hh
+++ b/db/schema_features.hh
@@ -33,6 +33,11 @@ enum class schema_feature {
 
     // Per-table tablet options
     TABLET_OPTIONS,
+
+    // When enabled, `system_schema.keyspaces` will keep three replication values:
+    // the initial, the current, and the target replication factor,
+    // which reflect the phases of the multi RF change.
+    KEYSPACE_MULTI_RF_CHANGE,
 };
 
 using schema_features = enum_set<super_enum<schema_feature,
@@ -43,7 +48,8 @@ using schema_features = enum_set<super_enum<schema_feature,
     schema_feature::TABLE_DIGEST_INSENSITIVE_TO_EXPIRY,
     schema_feature::GROUP0_SCHEMA_VERSIONING,
     schema_feature::IN_MEMORY_TABLES,
-    schema_feature::TABLET_OPTIONS
+    schema_feature::TABLET_OPTIONS,
+    schema_feature::KEYSPACE_MULTI_RF_CHANGE
     >>;
 
 }

--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -216,6 +216,7 @@ schema_ptr keyspaces() {
             {"durable_writes", boolean_type},
             {"replication", map_type_impl::get_instance(utf8_type, utf8_type, false)},
             {"replication_v2", map_type_impl::get_instance(utf8_type, utf8_type, false)}, // with rack list RF
+            {"next_replication", map_type_impl::get_instance(utf8_type, utf8_type, false)}, // target rack list RF for this RF change
         },
         // static columns
         {},
@@ -1178,6 +1179,14 @@ utils::chunked_vector<mutation> make_create_keyspace_mutations(schema_features f
         // If the maps are different, the upgrade must be already done.
         store_map(m, ckey, "replication_v2", timestamp, cql3::statements::to_flattened_map(map));
     }
+    if (features.contains<schema_feature::KEYSPACE_MULTI_RF_CHANGE>()) {
+        const auto& next_map_opt = keyspace->next_strategy_options_opt();
+        if (next_map_opt) {
+            auto next_map = *next_map_opt;
+            next_map["class"] = keyspace->strategy_name();
+            store_map(m, ckey, "next_replication", timestamp, cql3::statements::to_flattened_map(next_map));
+        }
+    }
 
     if (features.contains<schema_feature::SCYLLA_KEYSPACES>()) {
         schema_ptr scylla_keyspaces_s = scylla_keyspaces();
@@ -1251,6 +1260,7 @@ future<lw_shared_ptr<keyspace_metadata>> create_keyspace_metadata(
     // (or screw up shared pointers)
     const auto& replication = row.get_nonnull<map_type_impl::native_type>("replication");
     const auto& replication_v2 = row.get<map_type_impl::native_type>("replication_v2");
+    const auto& next_replication = row.get<map_type_impl::native_type>("next_replication");
 
     cql3::statements::property_definitions::map_type flat_strategy_options;
     for (auto& p : replication_v2 ? *replication_v2 : replication) {
@@ -1259,6 +1269,17 @@ future<lw_shared_ptr<keyspace_metadata>> create_keyspace_metadata(
     auto strategy_options = cql3::statements::from_flattened_map(flat_strategy_options);
     auto strategy_name = std::get<sstring>(strategy_options["class"]);
     strategy_options.erase("class");
+
+    std::optional<cql3::statements::property_definitions::extended_map_type> next_strategy_options = std::nullopt;
+    if (next_replication) {
+        cql3::statements::property_definitions::map_type flat_next_replication;
+        for (auto& p : *next_replication) {
+            flat_next_replication.emplace(value_cast<sstring>(p.first), value_cast<sstring>(p.second));
+        }
+        next_strategy_options = cql3::statements::from_flattened_map(flat_next_replication);
+        next_strategy_options->erase("class");
+    }
+
     bool durable_writes = row.get_nonnull<bool>("durable_writes");
 
     data_dictionary::storage_options storage_opts;
@@ -1284,7 +1305,7 @@ future<lw_shared_ptr<keyspace_metadata>> create_keyspace_metadata(
             }
         }
     }
-    co_return keyspace_metadata::new_keyspace(keyspace_name, strategy_name, strategy_options, initial_tablets, consistency, durable_writes, storage_opts);
+    co_return keyspace_metadata::new_keyspace(keyspace_name, strategy_name, strategy_options, initial_tablets, consistency, durable_writes, storage_opts, {}, next_strategy_options);
 }
 
 template<typename V>

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -299,6 +299,7 @@ schema_ptr system_keyspace::topology() {
             .with_column("upgrade_state", utf8_type, column_kind::static_column)
             .with_column("global_requests", set_type_impl::get_instance(timeuuid_type, true), column_kind::static_column)
             .with_column("paused_rf_change_requests", set_type_impl::get_instance(timeuuid_type, true), column_kind::static_column)
+            .with_column("ongoing_rf_changes", set_type_impl::get_instance(timeuuid_type, true), column_kind::static_column)
             .set_comment("Current state of topology change machine")
             .with_hash_version()
             .build();
@@ -3285,6 +3286,12 @@ future<service::topology> system_keyspace::load_topology_state(const std::unorde
         if (some_row.has("paused_rf_change_requests")) {
             for (auto&& v : deserialize_set_column(*topology(), some_row, "paused_rf_change_requests")) {
                 ret.paused_rf_change_requests.insert(value_cast<utils::UUID>(v));
+            }
+        }
+
+        if (some_row.has("ongoing_rf_changes")) {
+            for (auto&& v : deserialize_set_column(*topology(), some_row, "ongoing_rf_changes")) {
+                ret.ongoing_rf_changes.insert(value_cast<utils::UUID>(v));
             }
         }
 

--- a/docs/dev/system_schema_keyspace.md
+++ b/docs/dev/system_schema_keyspace.md
@@ -12,7 +12,9 @@ Schema:
 CREATE TABLE system_schema.keyspaces (
     keyspace_name text PRIMARY KEY,
     durable_writes boolean,
-    replication frozen<map<text, text>>
+    replication frozen<map<text, text>>,
+    replication_v2 frozen<map<text, text>>,
+    next_replication frozen<map<text, text>>
 )
 ```
 
@@ -31,6 +33,8 @@ Columns:
    stored as a flattened map of the extended options map (see below).
 
    For `SimpleStrategy` there is a single option `"replication_factor"` specifying the replication factor.
+* `next_replication` - the target replication factor for the keyspace during rf change.
+   If there is no ongoing rf change, `next_replication` value is not set.
 
 Extended options map used by NetworkTopologyStrategy is a map where values can be either strings or lists of strings.
 

--- a/docs/operating-scylla/procedures/cluster-management/add-dc-to-existing-dc.rst
+++ b/docs/operating-scylla/procedures/cluster-management/add-dc-to-existing-dc.rst
@@ -231,6 +231,46 @@ Add New DC
 
          Consider :ref:`upgrading rf_rack_valid_keyspaces option to enforce_rack_list option <keyspace-rf-rack-valid-to-enforce-rack-list>` to ensure all tablet keyspaces use rack lists.
 
+   If the keyspace uses rack list replication, update the replication factor in one ``ALTER KEYSPACE`` statement, under the following rules:
+      * Existing datacenters must keep their current replication factor.
+      * A new datacenter can be assigned a replication factor (**0 to N**).
+      * An existing datacenter can be removed (**N to 0**).
+
+   .. warning::
+
+      While adding a new datacenter and altering keyspaces, do **not** perform any reads or writes that involve the new datacenter.
+      In particular, avoid using global consistency levels (such as ``ALL``, ``EACH_QUORUM``) that would include the new datacenter in the operation.
+      Use ``LOCAL_*`` consistency levels (e.g., ``LOCAL_QUORUM``, ``LOCAL_ONE``) until the new datacenter is fully operational.
+
+   Before
+
+   .. code-block:: cql
+
+      DESCRIBE KEYSPACE mykeyspace4;
+
+      CREATE KEYSPACE mykeyspace4 WITH replication = { 'class' : 'NetworkTopologyStrategy', '<existing_dc>' : ['<existing_rack1>', '<existing_rack2>', '<existing_rack3>']} AND tablets = { 'enabled': true };
+
+   The following is **not** allowed because it changes the replication factor of ``<existing_dc>`` (adds ``<existing_rack4>``) and adds ``<new_dc>`` in the same statement:
+
+   .. code-block:: cql
+
+      ALTER KEYSPACE mykeyspace4 WITH replication = { 'class' : 'NetworkTopologyStrategy', '<existing_dc>' : ['<existing_rack1>', '<existing_rack2>', '<existing_rack3>', '<existing_rack4>'], '<new_dc>' : ['<new_rack1>', '<new_rack2>', '<new_rack3>']} AND tablets = { 'enabled': true };
+
+   Add all the nodes to the new datacenter and then:
+
+   .. code-block:: cql
+
+      ALTER KEYSPACE mykeyspace4 WITH replication = { 'class' : 'NetworkTopologyStrategy', '<existing_dc>' : ['<existing_rack1>', '<existing_rack2>', '<existing_rack3>'], '<new_dc>' : ['<new_rack1>', '<new_rack2>', '<new_rack3>']} AND tablets = { 'enabled': true };
+
+   After
+
+   .. code-block:: cql
+
+      DESCRIBE KEYSPACE mykeyspace4;
+      CREATE KEYSPACE mykeyspace4 WITH REPLICATION = {'class': 'NetworkTopologyStrategy', '<existing_dc>' : ['<existing_rack1>', '<existing_rack2>', '<existing_rack3>'], '<new_dc>' : ['<new_rack1>', '<new_rack2>', '<new_rack3>']} AND tablets = { 'enabled': true };
+
+   You can abort the keyspace alteration using :doc:`Task manager </operating-scylla/admin-tools/task-manager>`.
+
 #. If any vnode keyspace was altered, run ``nodetool rebuild`` on each node in the new datacenter, specifying the existing datacenter name in the rebuild command.
 
    For example:

--- a/docs/operating-scylla/procedures/cluster-management/decommissioning-data-center.rst
+++ b/docs/operating-scylla/procedures/cluster-management/decommissioning-data-center.rst
@@ -102,6 +102,34 @@ Procedure
 
          Consider :ref:`upgrading rf_rack_valid_keyspaces option to enforce_rack_list option <keyspace-rf-rack-valid-to-enforce-rack-list>` to ensure all tablet keyspaces use rack lists.
 
+   If the keyspace uses rack list replication, update the replication factor in one ``ALTER KEYSPACE`` statement, under the following rules:
+      * Existing datacenters must keep their current replication factor.
+      * An existing datacenter can be removed (**N to 0**).
+      * A new datacenter can be assigned a replication factor (**0 to N**).
+
+   .. warning::
+
+      While removing a datacenter and altering keyspaces, do **not** perform any reads or writes that involve the datacenter being removed.
+      In particular, avoid using global consistency levels (such as ``ALL``, ``EACH_QUORUM``) that would include the decommissioned datacenter in the operation.
+      Use ``LOCAL_*`` consistency levels (e.g., ``LOCAL_QUORUM``, ``LOCAL_ONE``) until the datacenter is fully decommissioned.
+
+   .. code-block:: shell
+
+      cqlsh> DESCRIBE nba4
+      cqlsh> CREATE KEYSPACE nba4 WITH REPLICATION = {'class' : 'NetworkTopologyStrategy', 'US-DC' : ['RAC1', 'RAC2', 'RAC3'], 'ASIA-DC' : ['RAC4', 'RAC5'], 'EUROPE-DC' : ['RAC6', 'RAC7', 'RAC8']} AND tablets = { 'enabled': true };
+
+   The following is **not** allowed because it changes the replication factor of ``EUROPE-DC`` (adds ``RAC9``) and removes ``ASIA-DC`` in the same statement:
+
+   .. code-block:: shell
+
+      cqlsh> ALTER KEYSPACE nba4 WITH REPLICATION = {'class' : 'NetworkTopologyStrategy', 'US-DC' : ['RAC1', 'RAC2', 'RAC3'], 'ASIA-DC' : [], 'EUROPE-DC' : ['RAC6', 'RAC7', 'RAC8', 'RAC9']} AND tablets = { 'enabled': true };
+
+   Remove all replicas from the decommissioned datacenter:
+
+   .. code-block:: shell
+
+      cqlsh> ALTER KEYSPACE nba4 WITH REPLICATION = {'class' : 'NetworkTopologyStrategy', 'US-DC' : ['RAC1', 'RAC2', 'RAC3'], 'ASIA-DC' : [], 'EUROPE-DC' : ['RAC6', 'RAC7', 'RAC8']} AND tablets = { 'enabled': true };
+
    .. note::
 
       If table audit is enabled, the ``audit`` keyspace is automatically created with ``NetworkTopologyStrategy``.
@@ -112,6 +140,10 @@ Procedure
          cqlsh> ALTER KEYSPACE audit WITH REPLICATION = {'class' : 'NetworkTopologyStrategy', 'US-DC' : 3, 'ASIA-DC' : 0, 'EUROPE-DC' : 3};
 
       Failure to do so will result in decommission errors such as "zero replica after the removal".
+
+   .. warning::
+
+         Removal of replicas from a datacenter cannot be aborted. To get back to the previous replication, wait until the ALTER KEYSPACE finishes and then add the replicas back by running another ALTER KEYSPACE statement.
 
 #. Run :doc:`nodetool decommission </operating-scylla/nodetool-commands/decommission>` on every node in the data center that is to be removed.
    Refer to :doc:`Remove a Node from a ScyllaDB Cluster - Down Scale </operating-scylla/procedures/cluster-management/remove-node>` for further information.

--- a/gms/feature_service.cc
+++ b/gms/feature_service.cc
@@ -7,6 +7,7 @@
 #include <seastar/core/sstring.hh>
 #include <seastar/core/seastar.hh>
 #include <seastar/core/smp.hh>
+#include "db/schema_features.hh"
 #include "utils/log.hh"
 #include "gms/feature.hh"
 #include "gms/feature_service.hh"
@@ -179,6 +180,7 @@ db::schema_features feature_service::cluster_schema_features() const {
     f.set<db::schema_feature::GROUP0_SCHEMA_VERSIONING>();
     f.set_if<db::schema_feature::IN_MEMORY_TABLES>(bool(in_memory_tables));
     f.set_if<db::schema_feature::TABLET_OPTIONS>(bool(tablet_options));
+    f.set_if<db::schema_feature::KEYSPACE_MULTI_RF_CHANGE>(bool(keyspace_multi_rf_change));
     return f;
 }
 

--- a/gms/feature_service.hh
+++ b/gms/feature_service.hh
@@ -182,6 +182,7 @@ public:
     gms::feature writetime_ttl_individual_element { *this, "WRITETIME_TTL_INDIVIDUAL_ELEMENT"sv };
     gms::feature arbitrary_tablet_boundaries { *this, "ARBITRARY_TABLET_BOUNDARIES"sv };
     gms::feature large_data_virtual_tables { *this, "LARGE_DATA_VIRTUAL_TABLES"sv };
+    gms::feature keyspace_multi_rf_change { *this, "KEYSPACE_MULTI_RF_CHANGE"sv };
 public:
 
     const std::unordered_map<sstring, std::reference_wrapper<feature>>& registered_features() const;

--- a/locator/load_sketch.hh
+++ b/locator/load_sketch.hh
@@ -381,6 +381,10 @@ public:
         return _nodes.at(node)._du.capacity;
     }
 
+    bool has_node(host_id node) const {
+        return _nodes.contains(node);
+    }
+
     shard_id get_shard_count(host_id node) const {
         if (!_nodes.contains(node)) {
             return 0;

--- a/locator/tablets.hh
+++ b/locator/tablets.hh
@@ -153,18 +153,26 @@ struct hash<locator::range_based_tablet_id> {
 
 namespace locator {
 
-/// Creates a new replica set with old_replica replaced by new_replica.
-/// If there is no old_replica, the set is returned unchanged.
+/// Returns a copy of the replica set with the following modifications:
+/// - If both old_replica and new_replica are set, old_replica is substituted
+///   with new_replica. If old_replica is not found in rs, the set is returned as-is.
+/// - If only old_replica is set, it is removed from the result.
+/// - If only new_replica is set, it is appended to the result.
 inline
-tablet_replica_set replace_replica(const tablet_replica_set& rs, tablet_replica old_replica, tablet_replica new_replica) {
+tablet_replica_set replace_replica(const tablet_replica_set& rs, std::optional<tablet_replica> old_replica, std::optional<tablet_replica> new_replica) {
     tablet_replica_set result;
     result.reserve(rs.size());
     for (auto&& r : rs) {
-        if (r == old_replica) {
-            result.push_back(new_replica);
+        if (old_replica.has_value() && r == old_replica.value()) {
+            if (new_replica.has_value()) {
+                result.push_back(new_replica.value());
+            }
         } else {
             result.push_back(r);
         }
+    }
+    if (!old_replica.has_value() && new_replica.has_value()) {
+        result.push_back(new_replica.value());
     }
     return result;
 }
@@ -383,8 +391,8 @@ bool is_post_cleanup(tablet_replica replica, const tablet_info& tinfo, const tab
 struct tablet_migration_info {
     locator::tablet_transition_kind kind;
     locator::global_tablet_id tablet;
-    locator::tablet_replica src;
-    locator::tablet_replica dst;
+    std::optional<locator::tablet_replica> src;
+    std::optional<locator::tablet_replica> dst;
 };
 
 class tablet_map;

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -1005,7 +1005,7 @@ future<database::keyspace_change_per_shard> database::prepare_update_keyspace_on
     co_await modify_keyspace_on_all_shards(sharded_db, [&] (replica::database& db) -> future<> {
         auto& ks = db.find_keyspace(ksm.name());
         auto new_ksm = ::make_lw_shared<keyspace_metadata>(ksm.name(), ksm.strategy_name(), ksm.strategy_options(), ksm.initial_tablets(), ksm.consistency_option(), ksm.durable_writes(),
-                ks.metadata()->cf_meta_data() | std::views::values | std::ranges::to<std::vector>(), ks.metadata()->user_types(), ksm.get_storage_options());
+                ks.metadata()->cf_meta_data() | std::views::values | std::ranges::to<std::vector>(), ks.metadata()->user_types(), ksm.get_storage_options(), ksm.next_strategy_options_opt());
 
         auto change = co_await db.prepare_update_keyspace(ks, new_ksm, pending_token_metadata.local());
         changes[this_shard_id()] = make_foreign(std::make_unique<keyspace_change>(std::move(change)));

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -3108,13 +3108,13 @@ future<> storage_service::wait_for_topology_not_busy() {
     }
 }
 
-future<> storage_service::abort_paused_rf_change(utils::UUID request_id) {
+future<> storage_service::abort_rf_change(utils::UUID request_id) {
     auto holder = _async_gate.hold();
 
     if (this_shard_id() != 0) {
         // group0 is only set on shard 0.
         co_return co_await container().invoke_on(0, [&] (auto& ss) {
-            return ss.abort_paused_rf_change(request_id);
+            return ss.abort_rf_change(request_id);
         });
     }
 
@@ -3125,20 +3125,81 @@ future<> storage_service::abort_paused_rf_change(utils::UUID request_id) {
     while (true) {
         auto guard = co_await _group0->client().start_operation(_group0_as, raft_timeout{});
 
-        bool found = std::ranges::contains(_topology_state_machine._topology.paused_rf_change_requests, request_id);
-        if (!found) {
-            slogger.warn("RF change request with id '{}' is not paused, so it can't be aborted", request_id);
+        utils::chunked_vector<canonical_mutation> updates;
+        if (std::ranges::contains(_topology_state_machine._topology.paused_rf_change_requests, request_id)) {    // keyspace_rf_change_kind::conversion_to_rack_list
+            updates.push_back(canonical_mutation(topology_mutation_builder(guard.write_timestamp())
+                                .resume_rf_change_request(_topology_state_machine._topology.paused_rf_change_requests, request_id).build()));
+            updates.push_back(canonical_mutation(topology_request_tracking_mutation_builder(request_id)
+                                .done("Aborted by user request")
+                                .build()));
+        } else if (std::ranges::contains(_topology_state_machine._topology.ongoing_rf_changes, request_id)) {    // keyspace_rf_change_kind::multi_rf_change
+            auto req_entry = co_await _sys_ks.local().get_topology_request_entry(request_id);
+            if (!req_entry.error.empty()) {
+                slogger.warn("RF change request with id '{}' was already aborted", request_id);
+                co_return;
+            }
+            sstring ks_name = *req_entry.new_keyspace_rf_change_ks_name;
+            if (!_db.local().has_keyspace(ks_name)) {
+                co_return;
+            }
+            auto& ks = _db.local().find_keyspace(ks_name);
+            // Check the tablet maps: if any tablet still has a missing replica
+            // (i.e., needs extending), we can abort. Otherwise, we're in the
+            // replica removal phase and aborting would require a rollback.
+            auto next_replication = ks.metadata()->next_strategy_options_opt().value()
+                | std::views::transform([] (const auto& pair) {
+                    return std::make_pair(pair.first, std::get<locator::rack_list>(pair.second));
+                }) | std::ranges::to<std::unordered_map<sstring, std::vector<sstring>>>();
+
+            const auto& tm = *get_token_metadata_ptr();
+            bool has_missing_replica = false;
+            auto all_tables = ks.metadata()->tables();
+            auto all_views = ks.metadata()->views()
+                | std::views::transform([] (const auto& view) { return schema_ptr(view); })
+                | std::ranges::to<std::vector<schema_ptr>>();
+            all_tables.insert(all_tables.end(), all_views.begin(), all_views.end());
+            for (const auto& table : all_tables) {
+                if (!tm.tablets().has_tablet_map(table->id()) || !tm.tablets().is_base_table(table->id())) {
+                    continue;
+                }
+                const auto& tmap = tm.tablets().get_tablet_map(table->id());
+                for (const auto& ti : tmap.tablets()) {
+                    std::unordered_map<sstring, std::vector<sstring>> dc_to_racks;
+                    for (const auto& r : ti.replicas) {
+                        const auto& node_dc_rack = tm.get_topology().get_node(r.host).dc_rack();
+                        dc_to_racks[node_dc_rack.dc].push_back(node_dc_rack.rack);
+                    }
+                    auto diff = subtract_replication(next_replication, dc_to_racks);
+                    if (!diff.empty()) {
+                        has_missing_replica = true;
+                        break;
+                    }
+                }
+                if (has_missing_replica) {
+                    break;
+                }
+            }
+
+            if (has_missing_replica) {
+                auto ks_md = make_lw_shared<data_dictionary::keyspace_metadata>(*ks.metadata());
+                ks_md->set_next_strategy_options(ks_md->strategy_options());
+                auto schema_muts = prepare_keyspace_update_announcement(_db.local(), ks_md, guard.write_timestamp());
+                for (auto& m : schema_muts) {
+                    updates.push_back(canonical_mutation(m));
+                }
+                updates.push_back(canonical_mutation(topology_request_tracking_mutation_builder(request_id)
+                                    .abort("Aborted by user request")
+                                    .build()));
+            } else {
+                slogger.warn("RF change request with id '{}' is ongoing, but it started removing replicas, so it can't be aborted", request_id);
+                co_return;
+            }
+        } else {
+            slogger.warn("RF change request with id '{}' can't be aborted", request_id);
             co_return;
         }
 
-        utils::chunked_vector<canonical_mutation> updates;
-        updates.push_back(canonical_mutation(topology_mutation_builder(guard.write_timestamp())
-                                .resume_rf_change_request(_topology_state_machine._topology.paused_rf_change_requests, request_id).build()));
-        updates.push_back(canonical_mutation(topology_request_tracking_mutation_builder(request_id)
-                                                    .done("Aborted by user request")
-                                                    .build()));
-
-        topology_change change{std::move(updates)};
+        mixed_change change{std::move(updates)};
         group0_command g0_cmd = _group0->client().prepare_command(std::move(change), guard,
                 format("aborting rf change request {}", request_id));
 

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -1339,6 +1339,11 @@ future<bool> storage_service::ongoing_rf_change(const group0_guard& guard, sstri
             co_return true;
         }
     }
+    for (auto request_id : _topology_state_machine._topology.ongoing_rf_changes) {
+        if (co_await ongoing_ks_rf_change(request_id)) {
+            co_return true;
+        }
+    }
     co_return false;
 }
 

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -967,7 +967,7 @@ public:
 
     future<> wait_for_topology_not_busy();
 
-    future<> abort_paused_rf_change(utils::UUID request_id);
+    future<> abort_rf_change(utils::UUID request_id);
 
 private:
     semaphore _do_sample_sstables_concurrency_limiter{1};

--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -552,6 +552,19 @@ static std::unordered_map<sstring, std::vector<sstring>> subtract_replication(co
     return res;
 }
 
+bool rf_count_per_dc_equals(const locator::replication_strategy_config_options& current, const locator::replication_strategy_config_options& next) {
+    if (current.size() != next.size()) {
+        return false;
+    }
+    for (const auto& [dc, current_rf_value] : current) {
+        auto it = next.find(dc);
+        if (it == next.end() || get_replication_factor(it->second) != get_replication_factor(current_rf_value)) {
+            return false;
+        }
+    }
+    return true;
+}
+
 /// The algorithm aims to equalize tablet count on each shard.
 /// This goal is based on the assumption that every shard has similar processing power and space capacity,
 /// and that each tablet has equal consumption of those resources. So by equalizing tablet count per shard we

--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -534,7 +534,7 @@ struct hash<migration_tablet_set> {
 namespace service {
 
 // Subtract right from left. The result contains only keys from left.
-static std::unordered_map<sstring, std::vector<sstring>> subtract_replication(const std::unordered_map<sstring, std::vector<sstring>>& left, const std::unordered_map<sstring, std::vector<sstring>>& right) {
+std::unordered_map<sstring, std::vector<sstring>> subtract_replication(const std::unordered_map<sstring, std::vector<sstring>>& left, const std::unordered_map<sstring, std::vector<sstring>>& right) {
     std::unordered_map<sstring, std::vector<sstring>> res;
     for (const auto& [dc, rf_value] : left) {
         auto it = right.find(dc);

--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -2642,14 +2642,13 @@ public:
         src_shard.dusage->used -= tablet_sizes;
     }
 
-    // Adjusts the load of the source and destination (host:shard) that were picked for the migration.
-    void update_node_load_on_migration(node_load_map& nodes, tablet_replica src, tablet_replica dst, const migration_tablet_set& tablet_set) {
+    void increase_node_load(node_load_map& nodes, tablet_replica replica, const migration_tablet_set& tablet_set) {
         auto tablet_count = tablet_set.tablets().size();
         auto tablet_sizes = tablet_set.tablet_set_disk_size;
         auto table = tablet_set.tablets().front().table;
 
-        auto& dst_node = nodes[dst.host];
-        auto& dst_shard = dst_node.shards[dst.shard];
+        auto& dst_node = nodes[replica.host];
+        auto& dst_shard = dst_node.shards[replica.shard];
         dst_shard.tablet_count += tablet_count;
         dst_shard.tablet_count_per_table[table] += tablet_count;
         dst_shard.tablet_sizes_per_table[table] += tablet_sizes;
@@ -2659,9 +2658,15 @@ public:
         dst_node.tablet_count += tablet_count;
         dst_node.dusage->used += tablet_sizes;
         dst_node.update();
+    }
 
-        auto& src_node = nodes[src.host];
-        auto& src_shard = src_node.shards[src.shard];
+    void decrease_node_load(node_load_map& nodes, tablet_replica replica, const migration_tablet_set& tablet_set) {
+        auto tablet_count = tablet_set.tablets().size();
+        auto tablet_sizes = tablet_set.tablet_set_disk_size;
+        auto table = tablet_set.tablets().front().table;
+
+        auto& src_node = nodes[replica.host];
+        auto& src_shard = src_node.shards[replica.shard];
         src_shard.tablet_count -= tablet_count;
         src_shard.tablet_count_per_table[table] -= tablet_count;
         src_shard.tablet_sizes_per_table[table] -= tablet_sizes;
@@ -2675,6 +2680,12 @@ public:
             src_node.dusage->used -= tablet_sizes;
         }
         src_node.update();
+    }
+
+    // Adjusts the load of the source and destination (host:shard) that were picked for the migration.
+    void update_node_load_on_migration(node_load_map& nodes, tablet_replica src, tablet_replica dst, const migration_tablet_set& tablet_set) {
+        increase_node_load(nodes, dst, tablet_set);
+        decrease_node_load(nodes, src, tablet_set);
     }
 
     static void unload(locator::load_sketch& sketch, host_id host, shard_id shard, const migration_tablet_set& tablet_set) {

--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -1560,6 +1560,11 @@ public:
             co_return prep;
         }
 
+        if (utils::get_local_injector().enter("determine_rf_change_actions_per_rack_throw")) {
+            lblogger.info("determine_rf_change_actions_per_rack_throw: entered");
+            throw std::runtime_error("determine_rf_change_actions_per_rack_throw injection");
+        }
+
         // Extend views.
         if (auto prep = co_await scan_tables(views, rf_change_state::needs_extending, process_views::yes); !prep.actions.empty()) {
             co_return prep;

--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -1049,6 +1049,10 @@ public:
         return _topology != nullptr && _sys_ks != nullptr && !_topology->paused_rf_change_requests.empty();
     }
 
+    bool ongoing_rf_change() const {
+        return _topology != nullptr && _sys_ks != nullptr && !_topology->ongoing_rf_changes.empty();
+    }
+
     future<migration_plan> make_plan() {
         const locator::topology& topo = _tm->get_topology();
         migration_plan plan;

--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -30,6 +30,7 @@
 #include <ranges>
 #include <utility>
 #include <fmt/ranges.h>
+#include <seastar/core/on_internal_error.hh>
 #include <seastar/coroutine/maybe_yield.hh>
 #include <seastar/coroutine/switch_to.hh>
 #include <absl/container/flat_hash_map.h>
@@ -531,6 +532,25 @@ struct hash<migration_tablet_set> {
 }
 
 namespace service {
+
+// Subtract right from left. The result contains only keys from left.
+static std::unordered_map<sstring, std::vector<sstring>> subtract_replication(const std::unordered_map<sstring, std::vector<sstring>>& left, const std::unordered_map<sstring, std::vector<sstring>>& right) {
+    std::unordered_map<sstring, std::vector<sstring>> res;
+    for (const auto& [dc, rf_value] : left) {
+        auto it = right.find(dc);
+        if (it == right.end()) {
+            res[dc] = rf_value;
+        } else {
+            std::vector<sstring> diff = rf_value | std::views::filter([&] (const sstring& rack) {
+                return std::find(it->second.begin(), it->second.end(), rack) == it->second.end();
+            }) | std::ranges::to<std::vector<sstring>>();
+            if (!diff.empty()) {
+                res[dc] = diff;
+            }
+        }
+    }
+    return res;
+}
 
 /// The algorithm aims to equalize tablet count on each shard.
 /// This goal is based on the assumption that every shard has similar processing power and space capacity,
@@ -1058,12 +1078,13 @@ public:
         migration_plan plan;
 
         auto rack_list_colocation = ongoing_rack_list_colocation();
+        auto rf_change_prep = co_await prepare_per_rack_rf_change_plan(plan);
 
         // Prepare plans for each DC separately and combine them to be executed in parallel.
         for (auto&& dc : topo.get_datacenters()) {
-            if (_db.get_config().rf_rack_valid_keyspaces() || _db.get_config().enforce_rack_list() || rack_list_colocation) {
+            if (_db.get_config().rf_rack_valid_keyspaces() || _db.get_config().enforce_rack_list() || rack_list_colocation || !rf_change_prep.actions.empty()) {
                 for (auto rack : topo.get_datacenter_racks().at(dc) | std::views::keys) {
-                    auto rack_plan = co_await make_plan(dc, rack);
+                    auto rack_plan = co_await make_plan(dc, rack, rf_change_prep.actions[{dc, rack}]);
                     auto level = rack_plan.empty() ? seastar::log_level::debug : seastar::log_level::info;
                     lblogger.log(level, "Plan for {}/{}: {}", dc, rack, plan_summary(rack_plan));
                     plan.merge(std::move(rack_plan));
@@ -1451,6 +1472,382 @@ public:
         }
         plan.set_rack_list_colocation_plan(std::move(rack_list_plan));
         co_return std::move(plan);
+    }
+
+    enum class rf_change_state {
+        ready,              // RF change is ready (succeed or failed).
+        needs_extending,
+        needs_shrinking,
+    };
+
+    using process_views = bool_class<struct process_views_tag>;
+    struct rf_change_action {
+        sstring keyspace;
+        rf_change_state state;
+        process_views pv = process_views::no;
+    };
+    using rf_change_actions = std::unordered_map<locator::endpoint_dc_rack, std::vector<rf_change_action>>;
+    struct rf_change_preparation {
+        rf_change_actions actions;
+    };
+
+    // Determines which dc+rack combinations need RF change actions for a given keyspace,
+    // by comparing current tablet replicas against the target replication configuration.
+    // Scans in priority order: extend tables, extend views, shrink views, shrink tables.
+    // Returns the first non-empty set of per-rack actions; colocated tables are skipped.
+    // An empty result means all tablets already match the target configuration.
+    future<rf_change_preparation> determine_rf_change_actions_per_rack(const sstring& ks_name, const std::vector<schema_ptr>& tables, const std::vector<schema_ptr>& views, const locator::replication_strategy_config_options& next) {
+        auto add_entry = [&ks_name] (rf_change_preparation& prep, const sstring& dc, const sstring& rack, rf_change_state state, process_views pv) {
+            locator::endpoint_dc_rack key{dc, rack};
+            auto& actions = prep.actions[key];
+            if (std::none_of(actions.begin(), actions.end(), [&](const rf_change_action& a) { return a.keyspace == ks_name; })) {
+                actions.push_back(rf_change_action{.keyspace = ks_name, .state = state, .pv = pv});
+            }
+        };
+
+        auto next_replication = next | std::views::transform([] (const auto& pair) {
+            return std::make_pair(pair.first, std::get<rack_list>(pair.second));
+        }) | std::ranges::to<std::unordered_map<sstring, std::vector<sstring>>>();
+
+        auto scan_tables = [&] (const std::vector<schema_ptr>& table_list, rf_change_state target_state, process_views pv) -> future<rf_change_preparation> {
+            rf_change_preparation prep;
+            for (const auto& table : table_list) {
+                if (!_tm->tablets().is_base_table(table->id())) {
+                    continue;
+                }
+                const auto& tmap = _tm->tablets().get_tablet_map(table->id());
+                for (const tablet_info& ti : tmap.tablets()) {
+                    std::unordered_map<sstring, std::vector<sstring>> dc_to_racks;
+                    for (const auto& r : ti.replicas) {
+                        const auto& node_dc_rack = _tm->get_topology().get_node(r.host).dc_rack();
+                        dc_to_racks[node_dc_rack.dc].push_back(node_dc_rack.rack);
+                    }
+
+                    auto diff = (target_state == rf_change_state::needs_extending ?
+                        subtract_replication(next_replication, dc_to_racks) : subtract_replication(dc_to_racks, next_replication))
+                        | std::views::filter([] (const auto& pair) {
+                            return !pair.second.empty();
+                        }
+                    ) | std::ranges::to<std::unordered_map<sstring, std::vector<sstring>>>();
+
+                    for (const auto& [dc, racks] : diff) {
+                        for (const auto& rack : racks) {
+                            add_entry(prep, dc, rack, target_state, pv);
+                        }
+                    }
+
+                    co_await coroutine::maybe_yield();
+                }
+            }
+            co_return prep;
+        };
+
+        // Extend base tables.
+        if (auto prep = co_await scan_tables(tables, rf_change_state::needs_extending, process_views::no); !prep.actions.empty()) {
+            co_return prep;
+        }
+
+        // Extend views.
+        if (auto prep = co_await scan_tables(views, rf_change_state::needs_extending, process_views::yes); !prep.actions.empty()) {
+            co_return prep;
+        }
+
+        // Shrink views.
+        if (auto prep = co_await scan_tables(views, rf_change_state::needs_shrinking, process_views::yes); !prep.actions.empty()) {
+            co_return prep;
+        }
+
+        // Shrink base tables.
+        if (auto prep = co_await scan_tables(tables, rf_change_state::needs_shrinking, process_views::no); !prep.actions.empty()) {
+            co_return prep;
+        }
+
+        co_return rf_change_preparation{};
+    }
+
+    future<rf_change_preparation> prepare_per_rack_rf_change_plan(migration_plan& mplan) {
+        lblogger.debug("In prepare_per_rack_rf_change_plan");
+
+        rf_change_preparation res;
+        keyspace_rf_change_plan plan;
+        if (!ongoing_rf_change()) {
+            co_return res;
+        }
+
+        for (const auto& request_id : _topology->ongoing_rf_changes) {
+            auto req_entry = co_await _sys_ks->get_topology_request_entry(request_id);
+            sstring ks_name = *req_entry.new_keyspace_rf_change_ks_name;
+
+            if (!_db.has_keyspace(ks_name)) {
+                if (!plan.completion) {
+                    plan.completion = rf_change_completion_info{
+                        .request_id = request_id,
+                        .ks_name = ks_name,
+                        .error = format("Keyspace {} not found", ks_name),
+                        .saved_ks_props = req_entry.new_keyspace_rf_change_data.value(),
+                    };
+                }
+                continue;
+            }
+            auto& ks = _db.find_keyspace(ks_name);
+            if (!ks.metadata()->next_strategy_options_opt()) {
+                on_internal_error(lblogger, format("There is an ongoing rf change request {} for keyspace {}, "
+                    "but the keyspace does not have next replication settings", request_id, ks_name));
+            }
+
+            auto tables = ks.metadata()->tables();
+            auto views = ks.metadata()->views() | std::views::transform([] (const auto& view) { return schema_ptr(view); }) | std::ranges::to<std::vector<schema_ptr>>();
+            auto rf_change_prep = co_await determine_rf_change_actions_per_rack(ks_name, tables, views, *ks.metadata()->next_strategy_options_opt());
+            if (rf_change_prep.actions.empty()) {
+                if (!plan.completion) {
+                    plan.completion = rf_change_completion_info{
+                        .request_id = request_id,
+                        .ks_name = ks_name,
+                        .error = req_entry.error,
+                        .saved_ks_props = req_entry.new_keyspace_rf_change_data.value()
+                    };
+                }
+                continue;
+            }
+
+            // Check if any extending action targets a dc+rack with no available nodes.
+            // If so, the RF change can never complete and should be aborted.
+            sstring error_msg = "";
+            const auto& topo = _tm->get_topology();
+            const auto& dc_rack_nodes = topo.get_datacenter_rack_nodes();
+            for (const auto& [dc_rack, actions] : rf_change_prep.actions) {
+                bool needs_extending = std::ranges::any_of(actions, [] (const rf_change_action& a) {
+                    return a.state == rf_change_state::needs_extending;
+                });
+                if (!needs_extending) {
+                    break;
+                }
+                bool has_live_node = false;
+                bool has_down_node = false;
+                auto dc_it = dc_rack_nodes.find(dc_rack.dc);
+                if (dc_it != dc_rack_nodes.end()) {
+                    auto rack_it = dc_it->second.find(dc_rack.rack);
+                    if (rack_it != dc_it->second.end()) {
+                        for (const auto& node_ref : rack_it->second) {
+                            const auto& node = node_ref.get();
+                            if (_skiplist.contains(node.host_id())) {
+                                has_down_node = true;
+                                break;
+                            }
+                            if (!node.is_excluded()) {
+                                has_live_node = true;
+                            }
+                        }
+                    }
+                }
+                if (has_down_node) {
+                    lblogger.warn("RF change for keyspace {} requires extending to {}/{} but there are down nodes there; aborting",
+                                  ks_name, dc_rack.dc, dc_rack.rack);
+                    error_msg = format("RF change aborted: there are down nodes in required rack {}/{}", dc_rack.dc, dc_rack.rack);
+                    break;
+                }
+                if (!has_live_node) {
+                    lblogger.warn("RF change for keyspace {} requires extending to {}/{} but no available nodes exist there; aborting",
+                                  ks_name, dc_rack.dc, dc_rack.rack);
+                    error_msg = format("RF change aborted: no available nodes in required rack {}/{}", dc_rack.dc, dc_rack.rack);
+                    break;
+                }
+            }
+
+            if (!error_msg.empty()) {
+                plan.aborts.push_back(rf_change_abort_info{
+                    .request_id = request_id,
+                    .ks_name = ks_name,
+                    .error = error_msg,
+                    .current_replication = ks.metadata()->strategy_options(),
+                });
+                continue;
+            }
+
+            for (auto& [dc_rack, actions] : rf_change_prep.actions) {
+                auto& dst = res.actions[dc_rack];
+                dst.insert(dst.end(), std::make_move_iterator(actions.begin()), std::make_move_iterator(actions.end()));
+            }
+        }
+        mplan.set_rf_change_plan(std::move(plan));
+        co_return res;
+    }
+
+    future<migration_plan> make_rf_change_plan(node_load_map& nodes, std::vector<rf_change_action> actions, sstring dc, sstring rack) {
+        lblogger.debug("In make_rf_change_plan");
+
+        migration_plan mplan;
+        keyspace_rf_change_plan plan;
+
+        auto nodes_by_load_dst = nodes | std::views::filter([&] (const auto& host_load) {
+            auto& [host, load] = host_load;
+            auto& node = *load.node;
+            return node.dc_rack().dc == dc && node.dc_rack().rack == rack;
+        }) | std::views::keys | std::ranges::to<std::vector<host_id>>();
+
+        bool has_extending = std::ranges::any_of(actions, [] (const rf_change_action& a) {
+            return a.state == rf_change_state::needs_extending;
+        });
+        if (has_extending) {
+            // Check that all normal, non-excluded nodes in the target dc/rack are present in the
+            // balanced node set. If any such node is missing, extending cannot safely proceed.
+            const auto& topo = _tm->get_topology();
+            const auto& dc_rack_nodes = topo.get_datacenter_rack_nodes();
+            bool missing_node = false;
+            auto dc_it = dc_rack_nodes.find(dc);
+            if (dc_it != dc_rack_nodes.end()) {
+                auto rack_it = dc_it->second.find(rack);
+                if (rack_it != dc_it->second.end()) {
+                    for (const auto& node_ref : rack_it->second) {
+                        const auto& node = node_ref.get();
+                        if (node.is_normal() && !node.is_excluded() && !nodes.contains(node.host_id())) {
+                            missing_node = true;
+                            break;
+                        }
+                    }
+                }
+            }
+            if (missing_node || nodes_by_load_dst.empty()) {
+                lblogger.warn("Not all non-excluded nodes are available for RF change extending plan in dc {}, rack {}", dc, rack);
+                // Filter out extending actions since not all nodes are available.
+                // Shrinking actions can still proceed without target nodes.
+                std::erase_if(actions, [] (const rf_change_action& a) {
+                    return a.state == rf_change_state::needs_extending;
+                });
+                if (actions.empty()) {
+                    co_return mplan;
+                }
+            }
+        }
+
+        auto nodes_cmp = nodes_by_load_cmp(nodes);
+        auto nodes_dst_cmp = [&] (const host_id& a, const host_id& b) {
+            return nodes_cmp(b, a);
+        };
+
+        // Ascending load heap of candidate target nodes.
+        std::make_heap(nodes_by_load_dst.begin(), nodes_by_load_dst.end(), nodes_dst_cmp);
+
+        const locator::topology& topo = _tm->get_topology();
+        locator::endpoint_dc_rack location{dc, rack};
+
+        for (const auto& action : actions) {
+            const auto& ks_name = action.keyspace;
+            const auto& rf_change_state = action.state;
+
+            auto& ks = _db.find_keyspace(ks_name);
+            auto table_list = action.pv
+                ? ks.metadata()->views() | std::views::transform([] (const auto& view) { return schema_ptr(view); }) | std::ranges::to<std::vector<schema_ptr>>()
+                : ks.metadata()->tables();
+            for (const auto& table_or_mv : table_list) {
+                const auto& tmap = _tm->tablets().get_tablet_map(table_or_mv->id());
+                co_await tmap.for_each_tablet([&] (tablet_id tid, const tablet_info& ti) -> future<> {
+                    if (!_tm->tablets().is_base_table(table_or_mv->id())) {
+                        return make_ready_future<>();
+                    }
+
+                    auto gid = locator::global_tablet_id{table_or_mv->id(), tid};
+
+                    auto it = std::find_if(ti.replicas.begin(), ti.replicas.end(), [&] (const tablet_replica& r) {
+                        return topo.get_node(r.host).dc_rack() == location;
+                    });
+
+                    auto replica = it != ti.replicas.end() ? std::optional<tablet_replica>{*it} : std::nullopt;
+
+                    auto* tti = tmap.get_tablet_transition_info(tid);
+                    bool pending_replica_in_this_rack = false;
+                    bool leaving_replica_in_this_rack = false;
+                    if (tti) {
+                        auto leaving_replica = get_leaving_replica(ti, *tti);
+                        leaving_replica_in_this_rack = leaving_replica.has_value() && topo.get_node(leaving_replica->host).dc_rack() == location;
+                        pending_replica_in_this_rack = tti->pending_replica.has_value() && topo.get_node(tti->pending_replica->host).dc_rack() == location;
+                    }
+
+                    if ((rf_change_state == rf_change_state::needs_extending && (replica && !leaving_replica_in_this_rack)) ||
+                            (rf_change_state == rf_change_state::needs_shrinking && (!replica && !pending_replica_in_this_rack))) {
+                        return make_ready_future<>();
+                    }
+
+                    // Skip tablet that is in transitions.
+                    if (tti) {
+                        lblogger.debug("Skipped rf change extending for tablet={} which is already in transition={} stage={}", gid, tti->transition, tti->stage);
+                        return make_ready_future<>();
+                    }
+
+                    // Skip tablet that is about to be in transition.
+                    if (_scheduled_tablets.contains(gid)) {
+                        return make_ready_future<>();
+                    }
+
+                    migration_tablet_set source_tablets {
+                        .tablet_s = gid,     // Ignore the merge co-location.
+                    };
+                    if (rf_change_state == rf_change_state::needs_extending) {
+                        // Pick the least loaded node as target.
+                        std::pop_heap(nodes_by_load_dst.begin(), nodes_by_load_dst.end(), nodes_dst_cmp);
+                        auto target = nodes_by_load_dst.back();
+
+                        lblogger.debug("target node: {}, avg_load={}", target, nodes[target].avg_load);
+
+                        auto dst = global_shard_id {target, _load_sketch->get_least_loaded_shard(target)};
+
+                        lblogger.trace("target shard: {}, tablets={}, load={}", dst.shard,
+                                    nodes[target].shards[dst.shard].tablet_count,
+                                    nodes[target].shard_load(dst.shard, _target_tablet_size));
+
+                        tablet_replica pending_replica{
+                            .host = target,
+                            .shard = dst.shard,
+                        };
+                        auto next = ti.replicas;
+                        next.push_back(pending_replica);
+                        tablet_migration_info mig{
+                            .kind = locator::tablet_transition_kind::rebuild_v2,
+                            .tablet = gid,
+                            .src = std::nullopt,
+                            .dst = pending_replica,
+                        };
+                        auto mig_streaming_info = get_migration_streaming_info(topo, ti, mig);
+                        pick(*_load_sketch, dst.host, dst.shard, source_tablets);
+                        if (can_accept_load(nodes, mig_streaming_info)) {
+                            lblogger.debug("Starting rebuild_v2 transition to {}.{} of tablet {}; new_replica = {}", dc, rack, gid, pending_replica);
+                            apply_load(nodes, mig_streaming_info);
+                            mark_as_scheduled(mig);
+                            mplan.add(std::move(mig));
+                        }
+                        increase_node_load(nodes, dst, source_tablets);
+                        std::push_heap(nodes_by_load_dst.begin(), nodes_by_load_dst.end(), nodes_dst_cmp);
+                    } else {
+                        auto next = ti.replicas | std::views::filter([&] (const tablet_replica& r) {
+                            return r != *replica;
+                        }) |  std::ranges::to<tablet_replica_set>();
+                        tablet_migration_info mig{
+                            .kind = locator::tablet_transition_kind::rebuild_v2,
+                            .tablet = gid,
+                            .src = *replica,
+                            .dst = std::nullopt,
+                        };
+                        auto mig_streaming_info = get_migration_streaming_info(topo, ti, mig);
+                        // The node being shrunk may be excluded/down and lack complete tablet stats.
+                        // Since we're removing a replica (not placing one), accurate load data isn't needed.
+                        if (_load_sketch->has_node(replica->host)) {
+                            unload(*_load_sketch, replica->host, replica->shard, source_tablets);
+                        }
+                        if (can_accept_load(nodes, mig_streaming_info)) {
+                            apply_load(nodes, mig_streaming_info);
+                            mark_as_scheduled(mig);
+                            mplan.add(std::move(mig));
+                        }
+                        if (nodes.contains(replica->host)) {
+                            decrease_node_load(nodes, *replica, source_tablets);
+                        }
+                    }
+                    return make_ready_future<>();
+                });
+            }
+        }
+        mplan.set_rf_change_plan(std::move(plan));
+        co_return mplan;
     }
 
     // Returns true if a table has replicas of all its sibling tablets co-located.
@@ -3642,7 +4039,7 @@ public:
         }
     }
 
-    future<migration_plan> make_plan(dc_name dc, std::optional<sstring> rack = std::nullopt) {
+    future<migration_plan> make_plan(dc_name dc, std::optional<sstring> rack = std::nullopt, std::vector<rf_change_action> rf_change_actions = {}) {
         migration_plan plan;
 
         if (utils::get_local_injector().enter("tablet_migration_bypass")) {
@@ -3760,12 +4157,6 @@ public:
             });
         }
 
-        if (nodes.empty()) {
-            lblogger.debug("No nodes to balance.");
-            _current_stats->stop_balance++;
-            co_return plan;
-        }
-
         // Detect finished drain.
 
         for (auto i = nodes_to_drain.begin(); i != nodes_to_drain.end();) {
@@ -3840,7 +4231,6 @@ public:
             }
             lblogger.debug("No candidate nodes");
             _current_stats->stop_no_candidates++;
-            co_return plan;
         }
 
         // We want to saturate the target node so we migrate several tablets in parallel, one for each shard
@@ -4002,7 +4392,7 @@ public:
 
         print_node_stats(nodes, only_active::yes);
 
-        if (!nodes_to_drain.empty() || (_tm->tablets().balancing_enabled() && (shuffle || !is_balanced(min_load, max_load)))) {
+        if (has_dest_nodes && (!nodes_to_drain.empty() || (_tm->tablets().balancing_enabled() && (shuffle || !is_balanced(min_load, max_load)))) && !nodes.empty()) {
             host_id target = *min_load_node;
             lblogger.info("target node: {}, avg_load: {}, max: {}", target, min_load, max_load);
             plan.merge(co_await make_internode_plan(nodes, nodes_to_drain, target));
@@ -4012,6 +4402,10 @@ public:
 
         if (_tm->tablets().balancing_enabled()) {
             plan.merge(co_await make_intranode_plan(nodes, nodes_to_drain));
+        }
+
+        if (!rf_change_actions.empty() && rack.has_value()) {
+            plan.merge(co_await make_rf_change_plan(nodes, rf_change_actions, dc, rack.value()));
         }
 
         if (_tm->tablets().balancing_enabled() && plan.empty() && !ongoing_rack_list_colocation()) {

--- a/service/tablet_allocator.hh
+++ b/service/tablet_allocator.hh
@@ -11,6 +11,7 @@
 #include "locator/abstract_replication_strategy.hh"
 #include "replica/database_fwd.hh"
 #include "locator/tablets.hh"
+#include "locator/abstract_replication_strategy.hh"
 #include "tablet_allocator_fwd.hh"
 #include "locator/token_metadata_fwd.hh"
 #include <seastar/core/metrics.hh>
@@ -355,6 +356,8 @@ future<bool> requires_rack_list_colocation(
         locator::token_metadata_ptr tmptr,
         db::system_keyspace* sys_ks,
         utils::UUID request_id);
+
+bool rf_count_per_dc_equals(const locator::replication_strategy_config_options& current, const locator::replication_strategy_config_options& next);
 
 }
 

--- a/service/tablet_allocator.hh
+++ b/service/tablet_allocator.hh
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "locator/abstract_replication_strategy.hh"
 #include "replica/database_fwd.hh"
 #include "locator/tablets.hh"
 #include "tablet_allocator_fwd.hh"
@@ -181,6 +182,34 @@ struct tablet_rack_list_colocation_plan {
     }
 };
 
+struct rf_change_completion_info {
+    utils::UUID request_id;
+    sstring ks_name;
+    sstring error;
+    std::unordered_map<sstring, sstring> saved_ks_props;
+};
+
+struct rf_change_abort_info {
+    utils::UUID request_id;
+    sstring ks_name;
+    sstring error;
+    locator::replication_strategy_config_options current_replication;
+};
+
+struct keyspace_rf_change_plan {
+    std::optional<rf_change_completion_info> completion;
+    std::vector<rf_change_abort_info> aborts;
+
+    size_t size() const { return (completion ? 1 : 0) + aborts.size(); };
+
+    void merge(keyspace_rf_change_plan&& other) {
+        if (!completion) {
+            completion = std::move(other.completion);
+        }
+        std::move(other.aborts.begin(), other.aborts.end(), std::back_inserter(aborts));
+    }
+};
+
 class migration_plan {
 public:
     using migrations_vector = utils::chunked_vector<tablet_migration_info>;
@@ -189,19 +218,22 @@ private:
     table_resize_plan _resize_plan;
     tablet_repair_plan _repair_plan;
     tablet_rack_list_colocation_plan _rack_list_colocation_plan;
+    keyspace_rf_change_plan _rf_change_plan;
     bool _has_nodes_to_drain = false;
     std::vector<drain_failure> _drain_failures;
 public:
     /// Returns true iff there are decommissioning nodes which own some tablet replicas.
     bool has_nodes_to_drain() const { return _has_nodes_to_drain; }
+    bool requires_schema_changes() const { return _rf_change_plan.size() > 0; }
 
     const migrations_vector& migrations() const { return _migrations; }
     bool empty() const { return !size(); }
-    size_t size() const { return _migrations.size() + _resize_plan.size() + _repair_plan.size() + _rack_list_colocation_plan.size() + _drain_failures.size(); }
+    size_t size() const { return _migrations.size() + _resize_plan.size() + _repair_plan.size() + _rack_list_colocation_plan.size() + _drain_failures.size() + _rf_change_plan.size(); }
     size_t tablet_migration_count() const { return _migrations.size(); }
     size_t resize_decision_count() const { return _resize_plan.size(); }
     size_t tablet_repair_count() const { return _repair_plan.size(); }
     size_t tablet_rack_list_colocation_count() const { return _rack_list_colocation_plan.size(); }
+    size_t keyspace_rf_change_count() const { return _rf_change_plan.size(); }
     const std::vector<drain_failure>& drain_failures() const { return _drain_failures; }
 
     void add(tablet_migration_info info) {
@@ -225,6 +257,7 @@ public:
         _resize_plan.merge(std::move(other._resize_plan));
         _repair_plan.merge(std::move(other._repair_plan));
         _rack_list_colocation_plan.merge(std::move(other._rack_list_colocation_plan));
+        _rf_change_plan.merge(std::move(other._rf_change_plan));
     }
 
     void set_has_nodes_to_drain(bool b) {
@@ -247,6 +280,12 @@ public:
 
     void set_rack_list_colocation_plan(tablet_rack_list_colocation_plan rack_list_colocation_plan) {
         _rack_list_colocation_plan = std::move(rack_list_colocation_plan);
+    }
+
+    const keyspace_rf_change_plan& rf_change_plan() const { return _rf_change_plan; }
+
+    void set_rf_change_plan(keyspace_rf_change_plan rf_change_plan) {
+        _rf_change_plan = std::move(rf_change_plan);
     }
 
     future<std::unordered_set<locator::global_tablet_id>> get_migration_tablet_ids() const;

--- a/service/tablet_allocator.hh
+++ b/service/tablet_allocator.hh
@@ -358,6 +358,7 @@ future<bool> requires_rack_list_colocation(
         utils::UUID request_id);
 
 bool rf_count_per_dc_equals(const locator::replication_strategy_config_options& current, const locator::replication_strategy_config_options& next);
+std::unordered_map<sstring, std::vector<sstring>> subtract_replication(const std::unordered_map<sstring, std::vector<sstring>>& left, const std::unordered_map<sstring, std::vector<sstring>>& right);
 
 }
 

--- a/service/task_manager_module.cc
+++ b/service/task_manager_module.cc
@@ -451,7 +451,7 @@ future<std::optional<tasks::task_status>> global_topology_request_virtual_task::
 }
 
 future<> global_topology_request_virtual_task::abort(tasks::task_id id, tasks::virtual_task_hint) noexcept {
-    return _ss.abort_paused_rf_change(id.uuid());
+    return _ss.abort_rf_change(id.uuid());
 }
 
 future<std::vector<tasks::task_stats>> global_topology_request_virtual_task::get_stats() {

--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -413,6 +413,20 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
         }
     };
 
+    future<> update_topology_state_with_mixed_change(
+            group0_guard guard, utils::chunked_vector<canonical_mutation>&& updates, const sstring& reason) {
+        try {
+            rtlogger.info("updating topology state with mixed change: {}", reason);
+            rtlogger.trace("update_topology_state mutations: {}", updates);
+            mixed_change change{std::move(updates)};
+            group0_command g0_cmd = _group0.client().prepare_command(std::move(change), guard, reason);
+            co_await _group0.client().add_entry(std::move(g0_cmd), std::move(guard), _as);
+        } catch (group0_concurrent_modification&) {
+            rtlogger.info("race while changing state: {}. Retrying", reason);
+            throw;
+        }
+    }
+
     raft::server_id parse_replaced_node(const std::optional<request_param>& req_param) const {
         return service::topology::parse_replaced_node(req_param);
     }
@@ -1644,6 +1658,83 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
                 .build());
     }
 
+    // Updates keyspace properties; removes system_schema.keyspaces::next_replication;
+    // finishes RF change request; Removes request from system.topology::ongoing_rf_changes.
+    void generate_rf_change_completion_update(utils::chunked_vector<canonical_mutation>& out, const group0_guard& guard, const rf_change_completion_info& completion) {
+        if (rtlogger.is_enabled(seastar::log_level::debug)) {
+            sstring props_str;
+            for (const auto& [key, value] : completion.saved_ks_props) {
+                props_str += fmt::format(" {}={};", key, value);
+            }
+            rtlogger.debug("generate_rf_change_completion_update: request_id={}, ks_name={}, error='{}', saved_ks_props:{}",
+                           completion.request_id, completion.ks_name, completion.error, props_str);
+        }
+        sstring error = completion.error;
+        if (_db.has_keyspace(completion.ks_name)) {
+            auto& ks = _db.find_keyspace(completion.ks_name);
+            if (error.empty()) {
+                cql3::statements::ks_prop_defs new_ks_props{std::map<sstring, sstring>{completion.saved_ks_props.begin(), completion.saved_ks_props.end()}};
+                new_ks_props.validate();
+                auto ks_md = new_ks_props.as_ks_metadata_update(ks.metadata(), *get_token_metadata_ptr(), _db.features(), _db.get_config());
+                ks_md->clear_next_strategy_options();
+
+                auto schema_muts = prepare_keyspace_update_announcement(_db, ks_md, guard.write_timestamp());
+                for (auto& m: schema_muts) {
+                    out.emplace_back(m);
+                }
+            } else {
+                auto ks_md = make_lw_shared<data_dictionary::keyspace_metadata>(*ks.metadata());
+                ks_md->clear_next_strategy_options();
+
+                auto schema_muts = prepare_keyspace_update_announcement(_db, ks_md, guard.write_timestamp());
+                for (auto& m: schema_muts) {
+                    out.emplace_back(m);
+                }
+            }
+        }
+
+        out.emplace_back(topology_mutation_builder(guard.write_timestamp())
+                .finish_rf_change_migrations(_topo_sm._topology.ongoing_rf_changes, completion.request_id)
+                .build());
+
+        out.push_back(canonical_mutation(topology_request_tracking_mutation_builder(completion.request_id)
+                .done(error)
+                .build()));
+    }
+
+    // Sets next_replication to current_replication and sets error on the topology request.
+    // Similar to storage_service::abort_rf_change for the ongoing_rf_changes case.
+    void generate_rf_change_abort_update(utils::chunked_vector<canonical_mutation>& out, const group0_guard& guard, const rf_change_abort_info& abort_info) {
+        rtlogger.debug("generate_rf_change_abort_update: request_id={}, ks_name={}, error='{}'", abort_info.request_id, abort_info.ks_name, abort_info.error);
+
+        if (!_db.has_keyspace(abort_info.ks_name)) {
+            return;
+        }
+
+        auto& ks = _db.find_keyspace(abort_info.ks_name);
+        auto ks_md = make_lw_shared<data_dictionary::keyspace_metadata>(*ks.metadata());
+        ks_md->set_next_strategy_options(abort_info.current_replication);
+
+        auto schema_muts = prepare_keyspace_update_announcement(_db, ks_md, guard.write_timestamp());
+        for (auto& m : schema_muts) {
+            out.emplace_back(m);
+        }
+
+        out.push_back(canonical_mutation(topology_request_tracking_mutation_builder(abort_info.request_id)
+                .abort(abort_info.error)
+                .build()));
+    }
+
+    future<> generate_rf_change_updates(utils::chunked_vector<canonical_mutation>& out, const group0_guard& guard, const keyspace_rf_change_plan& rf_change_plan) {
+        for (const auto& abort_info : rf_change_plan.aborts) {
+            co_await coroutine::maybe_yield();
+            generate_rf_change_abort_update(out, guard, abort_info);
+        }
+        if (rf_change_plan.completion.has_value()) {
+            generate_rf_change_completion_update(out, guard, *rf_change_plan.completion);
+        }
+    }
+
     future<> generate_migration_updates(utils::chunked_vector<canonical_mutation>& out, const group0_guard& guard, const migration_plan& plan) {
         if (plan.resize_plan().finalize_resize.empty() || plan.has_nodes_to_drain()) {
             // schedule tablet migration only if there are no pending resize finalisations or if the node is draining.
@@ -1666,6 +1757,8 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
             if (auto request_to_resume = plan.rack_list_colocation_plan().request_to_resume(); request_to_resume) {
                 generate_rf_change_resume_update(out, guard, request_to_resume);
             }
+
+            co_await generate_rf_change_updates(out, guard, plan.rf_change_plan());
         }
 
         auto sched_time = db_clock::now();
@@ -2254,9 +2347,11 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
         }
 
         bool has_nodes_to_drain = false;
+        bool requires_schema_changes = false;
         if (!preempt) {
             auto plan = co_await _tablet_allocator.balance_tablets(get_token_metadata_ptr(), &_topo_sm._topology, &_sys_ks, {}, get_dead_nodes());
             has_nodes_to_drain = plan.has_nodes_to_drain();
+            requires_schema_changes = plan.requires_schema_changes();
             if (!drain || plan.has_nodes_to_drain()) {
                 co_await generate_migration_updates(updates, guard, plan);
             }
@@ -2272,7 +2367,11 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
                 topology_mutation_builder(guard.write_timestamp())
                     .set_version(_topo_sm._topology.version + 1)
                     .build());
-            co_await update_topology_state(std::move(guard), std::move(updates), format("Tablet migration"));
+            if (requires_schema_changes) {
+                co_await update_topology_state_with_mixed_change(std::move(guard), std::move(updates), format("Tablet migration"));
+            } else {
+                co_await update_topology_state(std::move(guard), std::move(updates), format("Tablet migration"));
+            }
         }
 
         if (needs_barrier) {
@@ -4139,7 +4238,11 @@ future<std::optional<group0_guard>> topology_coordinator::maybe_start_tablet_mig
             .set_version(_topo_sm._topology.version + 1)
             .build());
 
-    co_await update_topology_state(std::move(guard), std::move(updates), "Starting tablet migration");
+    if (plan.requires_schema_changes()) {
+        co_await update_topology_state_with_mixed_change(std::move(guard), std::move(updates), "Starting tablet migration");
+    } else {
+        co_await update_topology_state(std::move(guard), std::move(updates), "Starting tablet migration");
+    }
     co_return std::nullopt;
 }
 

--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -960,6 +960,40 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
         }
     }
 
+    enum class keyspace_rf_change_kind {
+        default_rf_change,
+        conversion_to_rack_list,
+    };
+
+    future<keyspace_rf_change_kind> choose_keyspace_rf_change_kind(utils::UUID req_id,
+            lw_shared_ptr<keyspace_metadata> old_ks_md,
+            lw_shared_ptr<keyspace_metadata> new_ks_md,
+            const std::vector<schema_ptr>& tables_with_mvs) {
+        const auto& new_replication_strategy_config = new_ks_md->strategy_options();
+        const auto& old_replication_strategy_config = old_ks_md->strategy_options();
+        auto check_needs_colocation = [&] () -> future<bool> {
+            bool rack_list_conversion = false;
+            for (const auto& [dc, rf_value] : new_replication_strategy_config) {
+                if (std::holds_alternative<locator::rack_list>(rf_value)) {
+                    auto it = old_replication_strategy_config.find(dc);
+                    if (it != old_replication_strategy_config.end() && std::holds_alternative<sstring>(it->second)) {
+                        rack_list_conversion = true;
+                        break;
+                    }
+                }
+            }
+            co_return rack_list_conversion ? co_await requires_rack_list_colocation(_db, get_token_metadata_ptr(), &_sys_ks, req_id) : false;
+        };
+
+        if (tables_with_mvs.empty()) {
+            co_return keyspace_rf_change_kind::default_rf_change;
+        }
+        if (co_await check_needs_colocation()) {
+            co_return keyspace_rf_change_kind::conversion_to_rack_list;
+        }
+        co_return keyspace_rf_change_kind::default_rf_change;
+    }
+
     // Precondition: there is no node request and no ongoing topology transition
     // (checked under the guard we're holding).
     future<> handle_global_request(group0_guard guard) {
@@ -1015,9 +1049,18 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
                 saved_ks_props = *req_entry.new_keyspace_rf_change_data;
             }
 
+            auto tbuilder_with_request_drop = [&] () {
+                topology_mutation_builder tbuilder(guard.write_timestamp());
+                tbuilder.set_transition_state(topology::transition_state::tablet_migration)
+                        .set_version(_topo_sm._topology.version + 1)
+                        .del_global_topology_request()
+                        .del_global_topology_request_id()
+                        .drop_first_global_topology_request_id(_topo_sm._topology.global_requests_queue, req_id);
+                return tbuilder;
+            };
+
             utils::chunked_vector<canonical_mutation> updates;
             sstring error;
-            bool needs_colocation = false;
             if (_db.has_keyspace(ks_name)) {
                 try {
                     auto& ks = _db.find_keyspace(ks_name);
@@ -1029,34 +1072,18 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
                     size_t unimportant_init_tablet_count = 2; // must be a power of 2
                     locator::tablet_map new_tablet_map{unimportant_init_tablet_count};
 
-                    auto schedule_migrations = [&] () -> future<> {
                         auto tables_with_mvs = ks.metadata()->tables();
                         auto views = ks.metadata()->views();
                         tables_with_mvs.insert(tables_with_mvs.end(), views.begin(), views.end());
+                        auto rf_change_kind = co_await choose_keyspace_rf_change_kind(req_id, ks.metadata(), ks_md, tables_with_mvs);
+                    switch (rf_change_kind) {
+                      case keyspace_rf_change_kind::default_rf_change: {
                         if (!tables_with_mvs.empty()) {
                             auto table = tables_with_mvs.front();
                             auto tablet_count = tmptr->tablets().get_tablet_map(table->id()).tablet_count();
                             locator::replication_strategy_params params{ks_md->strategy_options(), tablet_count, ks.metadata()->consistency_option()};
                             auto new_strategy = locator::abstract_replication_strategy::create_replication_strategy("NetworkTopologyStrategy", params, tmptr->get_topology());
 
-                            auto check_needs_colocation = [&] () -> future<bool> {
-                                const auto& new_replication_strategy_config = new_strategy->get_config_options();
-                                const auto& old_replication_strategy_config = ks.metadata()->strategy_options();
-                                bool rack_list_conversion = false;
-                                for (const auto& [dc, rf_value] : new_replication_strategy_config) {
-                                    if (std::holds_alternative<locator::rack_list>(rf_value)) {
-                                        auto it = old_replication_strategy_config.find(dc);
-                                        if (it != old_replication_strategy_config.end() && std::holds_alternative<sstring>(it->second)) {
-                                            rack_list_conversion = true;
-                                            break;
-                                        }
-                                    }
-                                }
-                                co_return rack_list_conversion ? co_await requires_rack_list_colocation(_db, tmptr, &_sys_ks, req_id) : false;
-                            };
-                            if (needs_colocation = co_await check_needs_colocation(); needs_colocation) {
-                                co_return;
-                            }
                             for (const auto& table_or_mv : tables_with_mvs) {
                                 if (!tmptr->tablets().is_base_table(table_or_mv->id())) {
                                     // Apply the transition only on base tables.
@@ -1103,8 +1130,21 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
                         for (auto& m: schema_muts) {
                             updates.emplace_back(m);
                         }
-                    };
-                    co_await schedule_migrations();
+
+                            updates.push_back(canonical_mutation(tbuilder_with_request_drop().build()));
+                            updates.push_back(canonical_mutation(topology_request_tracking_mutation_builder(req_id)
+                                                         .done()
+                                                         .build()));
+                            break;
+                      }
+                      case keyspace_rf_change_kind::conversion_to_rack_list: {
+                            rtlogger.info("keyspace_rf_change for keyspace {} postponed for colocation", ks_name);
+                            topology_mutation_builder tbuilder = tbuilder_with_request_drop();
+                            tbuilder.pause_rf_change_request(req_id);
+                            updates.push_back(canonical_mutation(tbuilder.build()));
+                            break;
+                      }
+                    }
                 } catch (const std::exception& e) {
                     error = e.what();
                     rtlogger.error("Couldn't process global_topology_request::keyspace_rf_change, desired new ks opts: {}, error: {}",
@@ -1115,22 +1155,12 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
                 error = "Can't ALTER keyspace " + ks_name + ", keyspace doesn't exist";
             }
 
-            bool pause_request = needs_colocation && error.empty();
-            topology_mutation_builder tbuilder(guard.write_timestamp());
-            tbuilder.set_transition_state(topology::transition_state::tablet_migration)
-                                                         .set_version(_topo_sm._topology.version + 1)
-                                                         .del_global_topology_request()
-                                                         .del_global_topology_request_id()
-                                                         .drop_first_global_topology_request_id(_topo_sm._topology.global_requests_queue, req_id);
-            if (pause_request) {
-                rtlogger.info("keyspace_rf_change for keyspace {} postponed for colocation", ks_name);
-                tbuilder.pause_rf_change_request(req_id);
-            } else {
+            if (error != "") {
+                updates.push_back(canonical_mutation(tbuilder_with_request_drop().build()));
                 updates.push_back(canonical_mutation(topology_request_tracking_mutation_builder(req_id)
                                                          .done(error)
                                                          .build()));
             }
-            updates.push_back(canonical_mutation(tbuilder.build()));
 
             sstring reason = seastar::format("ALTER tablets KEYSPACE called with options: {}", saved_ks_props);
             rtlogger.trace("do update {} reason {}", updates, reason);

--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -1109,79 +1109,79 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
                     size_t unimportant_init_tablet_count = 2; // must be a power of 2
                     locator::tablet_map new_tablet_map{unimportant_init_tablet_count};
 
-                        auto tables_with_mvs = ks.metadata()->tables();
-                        auto views = ks.metadata()->views();
-                        tables_with_mvs.insert(tables_with_mvs.end(), views.begin(), views.end());
-                        auto rf_change_kind = co_await choose_keyspace_rf_change_kind(req_id, ks.metadata(), ks_md, tables_with_mvs);
+                    auto tables_with_mvs = ks.metadata()->tables();
+                    auto views = ks.metadata()->views();
+                    tables_with_mvs.insert(tables_with_mvs.end(), views.begin(), views.end());
+                    auto rf_change_kind = co_await choose_keyspace_rf_change_kind(req_id, ks.metadata(), ks_md, tables_with_mvs);
                     switch (rf_change_kind) {
-                      case keyspace_rf_change_kind::default_rf_change: {
-                        if (!tables_with_mvs.empty()) {
-                            auto table = tables_with_mvs.front();
-                            auto tablet_count = tmptr->tablets().get_tablet_map(table->id()).tablet_count();
-                            locator::replication_strategy_params params{ks_md->strategy_options(), tablet_count, ks.metadata()->consistency_option()};
-                            auto new_strategy = locator::abstract_replication_strategy::create_replication_strategy("NetworkTopologyStrategy", params, tmptr->get_topology());
+                        case keyspace_rf_change_kind::default_rf_change: {
+                            if (!tables_with_mvs.empty()) {
+                                auto table = tables_with_mvs.front();
+                                auto tablet_count = tmptr->tablets().get_tablet_map(table->id()).tablet_count();
+                                locator::replication_strategy_params params{ks_md->strategy_options(), tablet_count, ks.metadata()->consistency_option()};
+                                auto new_strategy = locator::abstract_replication_strategy::create_replication_strategy("NetworkTopologyStrategy", params, tmptr->get_topology());
 
-                            for (const auto& table_or_mv : tables_with_mvs) {
-                                if (!tmptr->tablets().is_base_table(table_or_mv->id())) {
-                                    // Apply the transition only on base tables.
-                                    // If this table has a base table then the transition will be applied on the base table, and
-                                    // the base table will coordinate the transition for the entire group.
-                                    continue;
-                                }
-                                auto old_tablets = co_await tmptr->tablets().get_tablet_map(table_or_mv->id()).clone_gently();
-                                new_tablet_map = co_await new_strategy->maybe_as_tablet_aware()->reallocate_tablets(table_or_mv, tmptr, co_await old_tablets.clone_gently());
-
-                                replica::tablet_mutation_builder tablet_mutation_builder(guard.write_timestamp(), table_or_mv->id());
-                                co_await new_tablet_map.for_each_tablet([&](locator::tablet_id tablet_id, const locator::tablet_info& tablet_info) -> future<> {
-                                    auto last_token = new_tablet_map.get_last_token(tablet_id);
-                                    auto old_tablet_info = old_tablets.get_tablet_info(last_token);
-                                    auto abandoning_replicas = locator::substract_sets(old_tablet_info.replicas, tablet_info.replicas);
-                                    auto new_replicas = locator::substract_sets(tablet_info.replicas, old_tablet_info.replicas);
-                                    if (abandoning_replicas.size() + new_replicas.size() > 1) {
-                                        throw std::runtime_error(fmt::format("Invalid state of a tablet {} of a table {}.{}. Expected replication factor: {}, but the tablet has replicas only on {}. "
-                                            "Try again later or use the \"Fixing invalid replica state with RF change\" procedure to fix the problem.", tablet_id, ks_name, table_or_mv->cf_name(),
-                                            ks.get_replication_strategy().get_replication_factor(*tmptr), old_tablet_info.replicas));
+                                for (const auto& table_or_mv : tables_with_mvs) {
+                                    if (!tmptr->tablets().is_base_table(table_or_mv->id())) {
+                                        // Apply the transition only on base tables.
+                                        // If this table has a base table then the transition will be applied on the base table, and
+                                        // the base table will coordinate the transition for the entire group.
+                                        continue;
                                     }
+                                    auto old_tablets = co_await tmptr->tablets().get_tablet_map(table_or_mv->id()).clone_gently();
+                                    new_tablet_map = co_await new_strategy->maybe_as_tablet_aware()->reallocate_tablets(table_or_mv, tmptr, co_await old_tablets.clone_gently());
 
-                                    updates.emplace_back(co_await make_canonical_mutation_gently(
-                                            replica::tablet_mutation_builder(guard.write_timestamp(), table_or_mv->id())
-                                                    .set_new_replicas(last_token, tablet_info.replicas)
-                                                    .set_stage(last_token, locator::tablet_transition_stage::allow_write_both_read_old)
-                                                    .set_transition(last_token, locator::choose_rebuild_transition_kind(_feature_service))
-                                                    .build()
-                                    ));
-
-                                    // Calculate abandoning replica and abort view building tasks on them
-                                    if (!abandoning_replicas.empty()) {
-                                        if (abandoning_replicas.size() != 1) {
-                                            on_internal_error(rtlogger, fmt::format("Keyspace RF abandons {} replicas for table {} and tablet id {}", abandoning_replicas.size(), table_or_mv->id(), tablet_id));
+                                    replica::tablet_mutation_builder tablet_mutation_builder(guard.write_timestamp(), table_or_mv->id());
+                                    co_await new_tablet_map.for_each_tablet([&](locator::tablet_id tablet_id, const locator::tablet_info& tablet_info) -> future<> {
+                                        auto last_token = new_tablet_map.get_last_token(tablet_id);
+                                        auto old_tablet_info = old_tablets.get_tablet_info(last_token);
+                                        auto abandoning_replicas = locator::substract_sets(old_tablet_info.replicas, tablet_info.replicas);
+                                        auto new_replicas = locator::substract_sets(tablet_info.replicas, old_tablet_info.replicas);
+                                        if (abandoning_replicas.size() + new_replicas.size() > 1) {
+                                            throw std::runtime_error(fmt::format("Invalid state of a tablet {} of a table {}.{}. Expected replication factor: {}, but the tablet has replicas only on {}. "
+                                                "Try again later or use the \"Fixing invalid replica state with RF change\" procedure to fix the problem.", tablet_id, ks_name, table_or_mv->cf_name(),
+                                                ks.get_replication_strategy().get_replication_factor(*tmptr), old_tablet_info.replicas));
                                         }
-                                        _vb_coordinator->abort_tasks(updates, guard, table_or_mv->id(), *abandoning_replicas.begin(), last_token);
-                                    }
 
-                                    co_await coroutine::maybe_yield();
-                                });
+                                        updates.emplace_back(co_await make_canonical_mutation_gently(
+                                                replica::tablet_mutation_builder(guard.write_timestamp(), table_or_mv->id())
+                                                        .set_new_replicas(last_token, tablet_info.replicas)
+                                                        .set_stage(last_token, locator::tablet_transition_stage::allow_write_both_read_old)
+                                                        .set_transition(last_token, locator::choose_rebuild_transition_kind(_feature_service))
+                                                        .build()
+                                        ));
+
+                                        // Calculate abandoning replica and abort view building tasks on them
+                                        if (!abandoning_replicas.empty()) {
+                                            if (abandoning_replicas.size() != 1) {
+                                                on_internal_error(rtlogger, fmt::format("Keyspace RF abandons {} replicas for table {} and tablet id {}", abandoning_replicas.size(), table_or_mv->id(), tablet_id));
+                                            }
+                                            _vb_coordinator->abort_tasks(updates, guard, table_or_mv->id(), *abandoning_replicas.begin(), last_token);
+                                        }
+
+                                        co_await coroutine::maybe_yield();
+                                    });
+                                }
                             }
-                        }
-                        auto schema_muts = prepare_keyspace_update_announcement(_db, ks_md, guard.write_timestamp());
-                        for (auto& m: schema_muts) {
-                            updates.emplace_back(m);
-                        }
+                            auto schema_muts = prepare_keyspace_update_announcement(_db, ks_md, guard.write_timestamp());
+                            for (auto& m: schema_muts) {
+                                updates.emplace_back(m);
+                            }
 
                             updates.push_back(canonical_mutation(tbuilder_with_request_drop().build()));
                             updates.push_back(canonical_mutation(topology_request_tracking_mutation_builder(req_id)
-                                                         .done()
-                                                         .build()));
+                                                        .done()
+                                                        .build()));
                             break;
-                      }
-                      case keyspace_rf_change_kind::conversion_to_rack_list: {
+                        }
+                        case keyspace_rf_change_kind::conversion_to_rack_list: {
                             rtlogger.info("keyspace_rf_change for keyspace {} postponed for colocation", ks_name);
                             topology_mutation_builder tbuilder = tbuilder_with_request_drop();
                             tbuilder.pause_rf_change_request(req_id);
                             updates.push_back(canonical_mutation(tbuilder.build()));
                             break;
-                      }
-                      case keyspace_rf_change_kind::multi_rf_change: {
+                        }
+                        case keyspace_rf_change_kind::multi_rf_change: {
                             rtlogger.info("keyspace_rf_change for keyspace {} will use multi-rf change procedure", ks_name);
                             ks_md->set_next_strategy_options(ks_md->strategy_options());
                             ks_md->set_strategy_options(ks.metadata()->strategy_options()); // start from the old strategy
@@ -1194,7 +1194,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
                             tbuilder.start_rf_change_migrations(req_id);
                             updates.push_back(canonical_mutation(tbuilder.build()));
                             break;
-                      }
+                        }
                     }
                 } catch (const std::exception& e) {
                     error = e.what();

--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -977,6 +977,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
     enum class keyspace_rf_change_kind {
         default_rf_change,
         conversion_to_rack_list,
+        multi_rf_change
     };
 
     future<keyspace_rf_change_kind> choose_keyspace_rf_change_kind(utils::UUID req_id,
@@ -998,12 +999,34 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
             }
             co_return rack_list_conversion ? co_await requires_rack_list_colocation(_db, get_token_metadata_ptr(), &_sys_ks, req_id) : false;
         };
+        auto all_changes_are_0_N = [&] {
+            auto all_dcs = old_replication_strategy_config | std::views::keys;
+            auto new_dcs = new_replication_strategy_config | std::views::keys;
+            std::set<sstring> dcs(all_dcs.begin(), all_dcs.end());
+            dcs.insert(new_dcs.begin(), new_dcs.end());
+            for (const auto& dc : dcs) {
+                auto old_it = old_replication_strategy_config.find(dc);
+                auto new_it = new_replication_strategy_config.find(dc);
+                size_t old_rf = (old_it != old_replication_strategy_config.end()) ? locator::get_replication_factor(old_it->second) : 0;
+                size_t new_rf = (new_it != new_replication_strategy_config.end()) ? locator::get_replication_factor(new_it->second) : 0;
+                if (old_rf == new_rf) {
+                    continue;
+                }
+                if (old_rf != 0 && new_rf != 0) {
+                    return false;
+                }
+            }
+            return true;
+        };
 
         if (tables_with_mvs.empty()) {
             co_return keyspace_rf_change_kind::default_rf_change;
         }
         if (co_await check_needs_colocation()) {
             co_return keyspace_rf_change_kind::conversion_to_rack_list;
+        }
+        if (_feature_service.keyspace_multi_rf_change && locator::uses_rack_list_exclusively(old_replication_strategy_config) && locator::uses_rack_list_exclusively(new_replication_strategy_config) && !rf_count_per_dc_equals(old_replication_strategy_config, new_replication_strategy_config) && all_changes_are_0_N()) {
+            co_return keyspace_rf_change_kind::multi_rf_change;
         }
         co_return keyspace_rf_change_kind::default_rf_change;
     }
@@ -1155,6 +1178,20 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
                             rtlogger.info("keyspace_rf_change for keyspace {} postponed for colocation", ks_name);
                             topology_mutation_builder tbuilder = tbuilder_with_request_drop();
                             tbuilder.pause_rf_change_request(req_id);
+                            updates.push_back(canonical_mutation(tbuilder.build()));
+                            break;
+                      }
+                      case keyspace_rf_change_kind::multi_rf_change: {
+                            rtlogger.info("keyspace_rf_change for keyspace {} will use multi-rf change procedure", ks_name);
+                            ks_md->set_next_strategy_options(ks_md->strategy_options());
+                            ks_md->set_strategy_options(ks.metadata()->strategy_options()); // start from the old strategy
+                            auto schema_muts = prepare_keyspace_update_announcement(_db, ks_md, guard.write_timestamp());
+                            for (auto& m: schema_muts) {
+                                updates.emplace_back(m);
+                            }
+
+                            topology_mutation_builder tbuilder = tbuilder_with_request_drop();
+                            tbuilder.start_rf_change_migrations(req_id);
                             updates.push_back(canonical_mutation(tbuilder.build()));
                             break;
                       }

--- a/service/topology_mutation.cc
+++ b/service/topology_mutation.cc
@@ -367,6 +367,10 @@ topology_request_tracking_mutation_builder& topology_request_tracking_mutation_b
     return _set_type ? builder_base::set(cell, value) : *this;
 }
 
+topology_request_tracking_mutation_builder& topology_request_tracking_mutation_builder::abort(sstring error) {
+    return set("error", error);
+}
+
 topology_request_tracking_mutation_builder& topology_request_tracking_mutation_builder::done(std::optional<sstring> error) {
     set("end_time", db_clock::now());
     if (error) {

--- a/service/topology_mutation.cc
+++ b/service/topology_mutation.cc
@@ -283,6 +283,20 @@ topology_mutation_builder& topology_mutation_builder::resume_rf_change_request(c
     }
 }
 
+topology_mutation_builder& topology_mutation_builder::start_rf_change_migrations(const utils::UUID& id) {
+    return apply_set("ongoing_rf_changes", collection_apply_mode::update, std::vector<data_value>{id});
+}
+
+topology_mutation_builder& topology_mutation_builder::finish_rf_change_migrations(const std::unordered_set<utils::UUID>& values, const utils::UUID& id) {
+    if (values.contains(id)) {
+        auto new_values = values;
+        new_values.erase(id);
+        return apply_set("ongoing_rf_changes", collection_apply_mode::overwrite, new_values | std::views::transform([] (const auto& id) { return data_value{id}; }));
+    } else {
+        return *this;
+    }
+}
+
 topology_mutation_builder& topology_mutation_builder::set_upgrade_state_done() {
     return apply_atomic("upgrade_state", "done");
 }

--- a/service/topology_mutation.hh
+++ b/service/topology_mutation.hh
@@ -158,6 +158,7 @@ public:
     using builder_base::del;
     topology_request_tracking_mutation_builder& set(const char* cell, topology_request value);
     topology_request_tracking_mutation_builder& set(const char* cell, global_topology_request value);
+    topology_request_tracking_mutation_builder& abort(sstring error);
     topology_request_tracking_mutation_builder& done(std::optional<sstring> error = std::nullopt);
     topology_request_tracking_mutation_builder& set_truncate_table_data(const table_id& table_id);
     topology_request_tracking_mutation_builder& set_new_keyspace_rf_change_data(const sstring& ks_name, const std::map<sstring, sstring>& rf_per_dc);

--- a/service/topology_mutation.hh
+++ b/service/topology_mutation.hh
@@ -132,6 +132,8 @@ public:
     topology_mutation_builder& drop_first_global_topology_request_id(const std::vector<utils::UUID>&, const utils::UUID&);
     topology_mutation_builder& pause_rf_change_request(const utils::UUID&);
     topology_mutation_builder& resume_rf_change_request(const std::unordered_set<utils::UUID>&, const utils::UUID&);
+    topology_mutation_builder& start_rf_change_migrations(const utils::UUID&);
+    topology_mutation_builder& finish_rf_change_migrations(const std::unordered_set<utils::UUID>&, const utils::UUID&);
     topology_node_mutation_builder& with_node(raft::server_id);
     canonical_mutation build() { return canonical_mutation{std::move(_m)}; }
 };

--- a/service/topology_state_machine.hh
+++ b/service/topology_state_machine.hh
@@ -208,6 +208,10 @@ struct topology {
     // It may happen during altering from numerical RF to rack list.
     std::unordered_set<utils::UUID> paused_rf_change_requests;
 
+    // The ids of ongoing RF change requests.
+    // Here we keep the ids only for rf-changes using rack_lists.
+    std::unordered_set<utils::UUID> ongoing_rf_changes;
+
     // The IDs of the committed yet unpublished CDC generations sorted by timestamps.
     std::vector<cdc::generation_id> unpublished_cdc_generations;
 

--- a/test/boost/tablets_test.cc
+++ b/test/boost/tablets_test.cc
@@ -1997,10 +1997,10 @@ static
 future<> apply_plan(token_metadata& tm, const migration_plan& plan, service::topology& topology, shared_load_stats* load_stats) {
     for (auto&& mig : plan.migrations()) {
         co_await tm.tablets().mutate_tablet_map_async(mig.tablet.table, [&] (tablet_map& tmap) {
-            if (load_stats) {
+            if (load_stats && mig.src && mig.dst) {
                 global_tablet_id gid {mig.tablet.table, mig.tablet.tablet};
                 dht::token_range trange {tmap.get_token_range(mig.tablet.tablet)};
-                auto new_stats = load_stats->stats.migrate_tablet_size(mig.src.host, mig.dst.host, gid, trange);
+                auto new_stats = load_stats->stats.migrate_tablet_size(mig.src->host, mig.dst->host, gid, trange);
                 if (new_stats) {
                     load_stats->stats = std::move(*new_stats);
                 }
@@ -2661,13 +2661,13 @@ SEASTAR_THREAD_TEST_CASE(test_rack_list_conversion) {
         for (auto& mig : plan.migrations()) {
             testlog.info("Rack list colocation migration: {}", mig);
             BOOST_REQUIRE(mig.kind == locator::tablet_transition_kind::migration);
-            BOOST_REQUIRE(mig.src.host == host3 || mig.src.host == host4);
-            if (mig.src.host == host3) {
+            BOOST_REQUIRE(mig.src && (mig.src->host == host3 || mig.src->host == host4));
+            if (mig.src->host == host3) {
                 BOOST_REQUIRE(mig.tablet.tablet == A);
-                BOOST_REQUIRE(mig.dst.host == host5 || mig.dst.host == host6);
+                BOOST_REQUIRE(mig.dst && (mig.dst->host == host5 || mig.dst->host == host6));
             } else {
                 BOOST_REQUIRE(mig.tablet.tablet == B);
-                BOOST_REQUIRE(mig.dst.host == host1 || mig.dst.host == host2);
+                BOOST_REQUIRE(mig.dst && (mig.dst->host == host1 || mig.dst->host == host2));
             }
         }
     }).get();
@@ -2745,8 +2745,9 @@ SEASTAR_THREAD_TEST_CASE(test_colocation_skipped_on_excluded_nodes) {
         rebalance_tablets_as_in_progress(e, topo.get_shared_load_stats(), [&] (const migration_plan& plan) {
             // Verify that only rebuilding migrations involve the excluded host.
             for (auto&& mig : plan.migrations()) {
-                BOOST_REQUIRE_NE(mig.dst.host, host1);
-                if (mig.src.host == host1) {
+                BOOST_REQUIRE(mig.src && mig.dst);
+                BOOST_REQUIRE_NE(mig.dst->host, host1);
+                if (mig.src->host == host1) {
                     BOOST_REQUIRE(mig.kind == tablet_transition_kind::rebuild_v2);
                 }
             }
@@ -2790,8 +2791,9 @@ SEASTAR_THREAD_TEST_CASE(test_no_intranode_migration_on_draining_node) {
         rebalance_tablets_as_in_progress(e, topo.get_shared_load_stats(), [&] (const migration_plan& plan) {
             // Verify no intra-node migrations on the draining host.
             for (auto&& mig : plan.migrations()) {
-                if (mig.src.host == host1) {
-                    BOOST_REQUIRE_NE(mig.dst.host, host1);
+                BOOST_REQUIRE(mig.src && mig.dst);
+                if (mig.src->host == host1) {
+                    BOOST_REQUIRE_NE(mig.dst->host, host1);
                 }
             }
             return false;
@@ -4945,7 +4947,8 @@ SEASTAR_THREAD_TEST_CASE(test_load_balancer_ignores_hosts_with_incomplete_stats)
             BOOST_REQUIRE(!plan.empty());
             BOOST_REQUIRE(!plan.migrations().empty());
             for (auto&& mig : plan.migrations()) {
-                BOOST_REQUIRE_EQUAL(mig.src.host, host2);
+                BOOST_REQUIRE(mig.src);
+                BOOST_REQUIRE_EQUAL(mig.src->host, host2);
             }
         }
     }).get();

--- a/test/cluster/mv/test_mv_topology_change.py
+++ b/test/cluster/mv/test_mv_topology_change.py
@@ -334,7 +334,7 @@ async def test_mv_first_replica_in_dc(manager: ManagerClient, delayed_replica: s
     # If we run the test with more than 1 shard and the tablet for the view table gets allocated on the same shard as the tablet of the base table,
     # we'll perform an intranode migration of one of these tablets to the other shard. This migration can be confused with the migration to the
     # new dc in the "first_migration_done()" below. To avoid this, run servers with only 1 shard.
-    servers.append(await manager.server_add(cmdline=['--smp', '1'], property_file={'dc': f'dc1', 'rack': 'myrack1'}))
+    servers.append(await manager.server_add(cmdline=['--smp', '1'], config={"rf_rack_valid_keyspaces": "false"}, property_file={'dc': f'dc1', 'rack': 'myrack1'}))
     servers.append(await manager.server_add(cmdline=['--smp', '1'], property_file={'dc': f'dc2', 'rack': 'myrack1'}))
 
     cql = manager.get_cql()

--- a/test/cluster/test_tablets.py
+++ b/test/cluster/test_tablets.py
@@ -327,6 +327,71 @@ async def test_singledc_alter_tablets_rf(manager: ManagerClient):
             await change_rf(0) # Trying to decrease the RF by more than 2 should fail.
 
 @pytest.mark.asyncio
+async def test_arbitrary_multi_rf_change_fails(manager: ManagerClient):
+    config = {"rf_rack_valid_keyspaces": "false", "enable_tablets": "true", "tablet_load_stats_refresh_interval_in_seconds": 1}
+    cmdline = ['--logger-log-level', 'raft_topology=debug', '--logger-log-level', 'load_balancer=debug']
+    await manager.server_add(config=config, cmdline=cmdline, property_file={"dc": "dc1", "rack": "r1"})
+    await manager.server_add(config=config, cmdline=cmdline, property_file={"dc": "dc1", "rack": "r2"})
+    await manager.server_add(config=config, cmdline=cmdline, property_file={"dc": "dc1", "rack": "r3"})
+    await manager.server_add(config=config, cmdline=cmdline, property_file={"dc": "dc2", "rack": "r4"})
+    await manager.server_add(config=config, cmdline=cmdline, property_file={"dc": "dc3", "rack": "r7"})
+
+    cql = manager.get_cql()
+
+    err_msg = "Only one DC's RF can be changed at a time and not by more than 1"
+
+    # RF change by more than 1 in a single DC (1->3)
+    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 1}") as ks:
+        with pytest.raises(InvalidRequest, match=err_msg):
+            await cql.run_async(f"ALTER KEYSPACE {ks} WITH replication = {{'class': 'NetworkTopologyStrategy', 'dc1': 3}}")
+
+    # RF change by more than 1 in a single DC (3->1)
+    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 3}") as ks:
+        with pytest.raises(InvalidRequest, match=err_msg):
+            await cql.run_async(f"ALTER KEYSPACE {ks} WITH replication = {{'class': 'NetworkTopologyStrategy', 'dc1': 1}}")
+
+    # Adding a DC while also changing RF in another DC
+    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 1}") as ks:
+        with pytest.raises(InvalidRequest, match=err_msg):
+            await cql.run_async(f"ALTER KEYSPACE {ks} WITH replication = {{'class': 'NetworkTopologyStrategy', 'dc1': 2, 'dc2': 1}}")
+
+    # Removing a DC while also changing RF in another DC
+    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 2, 'dc2': 1}") as ks:
+        with pytest.raises(InvalidRequest, match=err_msg):
+            await cql.run_async(f"ALTER KEYSPACE {ks} WITH replication = {{'class': 'NetworkTopologyStrategy', 'dc1': 1, 'dc2': 0}}")
+
+    # Adding one DC and removing another at the same time
+    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 1, 'dc2': 1}") as ks:
+        with pytest.raises(InvalidRequest, match=err_msg):
+            await cql.run_async(f"ALTER KEYSPACE {ks} WITH replication = {{'class': 'NetworkTopologyStrategy', 'dc1': 1, 'dc2': 0, 'dc3': 1}}")
+
+    # ---- Rack list variants ----
+
+    # RF change by more than 1 in a single DC using rack lists (1->3)
+    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': ['r1']}") as ks:
+        with pytest.raises(InvalidRequest, match=err_msg):
+            await cql.run_async(f"ALTER KEYSPACE {ks} WITH replication = {{'class': 'NetworkTopologyStrategy', 'dc1': ['r1', 'r2', 'r3']}}")
+
+    # RF change by more than 1 in a single DC using rack lists (3->1)
+    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': ['r1', 'r2', 'r3']}") as ks:
+        with pytest.raises(InvalidRequest, match=err_msg):
+            await cql.run_async(f"ALTER KEYSPACE {ks} WITH replication = {{'class': 'NetworkTopologyStrategy', 'dc1': ['r1']}}")
+
+    # Adding a DC while also changing RF in another DC, using rack lists
+    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': ['r1']}") as ks:
+        with pytest.raises(InvalidRequest, match=err_msg):
+            await cql.run_async(f"ALTER KEYSPACE {ks} WITH replication = {{'class': 'NetworkTopologyStrategy', 'dc1': ['r1', 'r2'], 'dc2': ['r4']}}")
+
+    # Removing a DC while also changing RF in another DC, using rack lists
+    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': ['r1', 'r2'], 'dc2': ['r4']}") as ks:
+        with pytest.raises(InvalidRequest, match=err_msg):
+            await cql.run_async(f"ALTER KEYSPACE {ks} WITH replication = {{'class': 'NetworkTopologyStrategy', 'dc1': ['r1'], 'dc2': 0}}")
+
+    # Adding one DC and removing another at the same time (with rack lists)
+    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': ['r1'], 'dc2': ['r4']}") as ks:
+        await cql.run_async(f"ALTER KEYSPACE {ks} WITH replication = {{'class': 'NetworkTopologyStrategy', 'dc1': ['r1'], 'dc2': 0, 'dc3': ['r7']}}")
+
+@pytest.mark.asyncio
 async def test_alter_tablets_rf_dc_drop(request: pytest.FixtureRequest, manager: ManagerClient) -> None:
     config = {"endpoint_snitch": "GossipingPropertyFileSnitch", "tablets_mode_for_new_keyspaces": "enabled"}
 
@@ -545,6 +610,497 @@ async def test_enforce_rack_list_option(request: pytest.FixtureRequest, manager:
     await manager.server_add(config=config, cmdline=["--enforce-rack-list", "true", "--smp", "2"], property_file={'dc': 'dc2', 'rack': 'rack2b'})
 
     await cql.run_async("alter keyspace ksv with replication = {'class': 'NetworkTopologyStrategy', 'dc1': 2, 'dc2': 1};")
+
+async def check_system_schema_keyspaces(manager, keyspace, replication, next_replication):
+    def compare_replications(r1, r2):
+        assert len(r1) == len(r2)
+        for k, v in r1.items():
+            assert k in r2
+            is_list = isinstance(r2[k], list)
+            if is_list:
+                assert len(v) == len(r2[k])
+                assert all([rack in r2[k] for rack in v])
+                assert all([rack in v for rack in r2[k]])
+            else:
+                assert len(v) == r2[k]
+
+    await asyncio.gather(*[read_barrier(manager.api, s.ip_addr) for s in await manager.running_servers()])
+
+    cql = manager.get_cql()
+    res = await cql.run_async(f"select * from system_schema.keyspaces where keyspace_name = '{keyspace}';")
+
+    repl = parse_replication_options(res[0].replication_v2 or res[0].replication)
+    repl.pop('class')
+    compare_replications(repl, replication)
+
+    if next_replication is not None:
+        next_repl = parse_replication_options(res[0].next_replication)
+        next_repl.pop('class')
+        compare_replications(next_repl, next_replication)
+    else:
+        assert res[0].next_replication is None
+
+@pytest.mark.asyncio
+async def test_multi_rf_change_multi_dc_0_N(request: pytest.FixtureRequest, manager: ManagerClient) -> None:
+    """Test RF changes where each DC transitions only between 0 and N replicas."""
+    config = {"tablets_mode_for_new_keyspaces": "enabled", "rf_rack_valid_keyspaces": "false", "tablet_load_stats_refresh_interval_in_seconds": 1}
+    cmdline = ["--enforce-rack-list", "true", "--smp", "2", '--logger-log-level', 'load_balancer=debug', '--logger-log-level', 'raft_topology=debug']
+
+    servers = [await manager.server_add(config=config, cmdline=cmdline, property_file={'dc': 'dc1', 'rack': 'rack1a'}),
+                await manager.server_add(config=config, cmdline=cmdline, property_file={'dc': 'dc1', 'rack': 'rack1b'}),
+                await manager.server_add(config=config, cmdline=cmdline, property_file={'dc': 'dc1', 'rack': 'rack1c'}),
+                await manager.server_add(config=config, cmdline=cmdline, property_file={'dc': 'dc2', 'rack': 'rack2a'}),
+                await manager.server_add(config=config, cmdline=cmdline, property_file={'dc': 'dc2', 'rack': 'rack2b'}),
+                await manager.server_add(config=config, cmdline=cmdline, property_file={'dc': 'dc2', 'rack': 'rack2c'})]
+
+    dc1_host_ids = [await manager.get_host_id(s.server_id) for s in servers[0:3]]
+    dc2_host_ids = [await manager.get_host_id(s.server_id) for s in servers[3:6]]
+
+    cql = manager.get_cql()
+    dc1_host = (await wait_for_cql_and_get_hosts(cql, [servers[0]], time.time() + 30))[0]
+
+    # Create keyspace with RF=3 in dc1 only.
+    await cql.run_async(f"create keyspace ks1 with replication = {{'class': 'NetworkTopologyStrategy', 'dc1': ['rack1a', 'rack1b', 'rack1c']}} and tablets = {{'initial': 4}};")
+    await cql.run_async("create table ks1.t (pk int primary key);")
+    await asyncio.gather(*[cql.run_async(f"INSERT INTO ks1.t (pk) VALUES ({k});", host=dc1_host) for k in range(10)])
+    await check_system_schema_keyspaces(manager, "ks1", {'dc1': ['rack1a', 'rack1b', 'rack1c']}, None)
+    replicas = await get_all_tablet_replicas(manager, servers[0], "ks1", "t")
+    assert len(replicas) > 0
+    for t in replicas:
+        assert len(t.replicas) == 3
+        for rep in t.replicas:
+            assert rep[0] in dc1_host_ids
+
+    # Move all replicas from dc1 to dc2 (dc1: 3->0, dc2: 0->3).
+    await cql.run_async("alter keyspace ks1 with replication = {'class': 'NetworkTopologyStrategy', 'dc1': [], 'dc2': ['rack2a', 'rack2b', 'rack2c']};")
+    await check_system_schema_keyspaces(manager, "ks1", {'dc2': ['rack2a', 'rack2b', 'rack2c']}, None)
+    replicas = await get_all_tablet_replicas(manager, servers[0], "ks1", "t")
+    assert len(replicas) > 0
+    for t in replicas:
+        assert len(t.replicas) == 3
+        for rep in t.replicas:
+            assert rep[0] in dc2_host_ids
+        assert all(host in [r[0] for r in t.replicas] for host in dc2_host_ids)
+
+    # Move replicas from dc2 to dc1 with different RF (dc1: 0->2, dc2: 3->0).
+    await cql.run_async("alter keyspace ks1 with replication = {'class': 'NetworkTopologyStrategy', 'dc1': ['rack1a', 'rack1b'], 'dc2': []};")
+    await check_system_schema_keyspaces(manager, "ks1", {'dc1': ['rack1a', 'rack1b']}, None)
+    replicas = await get_all_tablet_replicas(manager, servers[0], "ks1", "t")
+    assert len(replicas) > 0
+    for t in replicas:
+        assert len(t.replicas) == 2
+        for rep in t.replicas:
+            assert rep[0] in dc1_host_ids
+
+    # Move replicas from dc1 to dc2 with RF=1 (dc1: 2->0, dc2: 0->1).
+    await cql.run_async("alter keyspace ks1 with replication = {'class': 'NetworkTopologyStrategy', 'dc1': [], 'dc2': ['rack2a']};")
+    await check_system_schema_keyspaces(manager, "ks1", {'dc2': ['rack2a']}, None)
+    replicas = await get_all_tablet_replicas(manager, servers[0], "ks1", "t")
+    assert len(replicas) > 0
+    for t in replicas:
+        assert len(t.replicas) == 1
+        assert t.replicas[0][0] in dc2_host_ids
+
+@pytest.mark.asyncio
+async def test_multi_rf_change_colocated_tables_0_N(request: pytest.FixtureRequest, manager: ManagerClient) -> None:
+    """Test RF changes with colocated tables where each DC transitions only between 0 and N replicas."""
+    config = {"tablets_mode_for_new_keyspaces": "enabled", "rf_rack_valid_keyspaces": "false", "tablet_load_stats_refresh_interval_in_seconds": 1}
+    cmdline = ["--enforce-rack-list", "true", "--smp", "2", '--logger-log-level', 'raft_topology=debug', '--logger-log-level', 'load_balancer=debug']
+
+    servers = [await manager.server_add(config=config, cmdline=cmdline, property_file={'dc': 'dc1', 'rack': 'rack1a'}),
+                await manager.server_add(config=config, cmdline=cmdline, property_file={'dc': 'dc1', 'rack': 'rack1b'}),
+                await manager.server_add(config=config, cmdline=cmdline, property_file={'dc': 'dc1', 'rack': 'rack1c'}),
+                await manager.server_add(config=config, cmdline=cmdline, property_file={'dc': 'dc2', 'rack': 'rack2a'}),
+                await manager.server_add(config=config, cmdline=cmdline, property_file={'dc': 'dc2', 'rack': 'rack2b'}),
+                await manager.server_add(config=config, cmdline=cmdline, property_file={'dc': 'dc2', 'rack': 'rack2c'})]
+
+    cql = manager.get_cql()
+
+    dc1_host = (await wait_for_cql_and_get_hosts(cql, [servers[0]], time.time() + 30))[0]
+
+    await cql.run_async("create keyspace ks1 with replication = {'class': 'NetworkTopologyStrategy', 'dc1': ['rack1a']} and tablets = {'initial': 4};")
+    await cql.run_async("create table ks1.t (pk int primary key, v int);")
+    await cql.run_async("create materialized view ks1.tv as select * from ks1.t where pk is not null and v is not null primary key (pk, v)")
+    await asyncio.gather(*[cql.run_async(f"INSERT INTO ks1.t (pk, v) VALUES ({k}, {k});", host=dc1_host) for k in range(10)])
+
+    async def check_replicas(expected_rf: int):
+        base_replicas = await get_all_tablet_replicas(manager, servers[0], "ks1", "t")
+        view_replicas = await get_all_tablet_replicas(manager, servers[0], "ks1", "tv", is_view=True)
+        assert len(base_replicas) > 0
+        assert len(view_replicas) > 0
+        for r in base_replicas:
+            logger.info(f"base: {r.replicas}")
+            assert len(r.replicas) == expected_rf
+        for r in view_replicas:
+            logger.info(f"view: {r.replicas}")
+            assert len(r.replicas) == expected_rf
+
+    await check_system_schema_keyspaces(manager, "ks1", {'dc1': ['rack1a']}, None)
+    await check_replicas(1)
+
+    # dc1: 1->0, dc2: 0->3.
+    await cql.run_async("alter keyspace ks1 with replication = {'class': 'NetworkTopologyStrategy', 'dc1': [], 'dc2': ['rack2a', 'rack2b', 'rack2c']};")
+    await check_system_schema_keyspaces(manager, "ks1", {'dc2': ['rack2a', 'rack2b', 'rack2c']}, None)
+    await check_replicas(3)
+
+    # dc1: 0->1, dc2: 3->0.
+    await cql.run_async("alter keyspace ks1 with replication = {'class': 'NetworkTopologyStrategy', 'dc1': ['rack1a'], 'dc2': []};")
+    await check_system_schema_keyspaces(manager, "ks1", {'dc1': ['rack1a']}, None)
+    await check_replicas(1)
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("enforce_rack_list", ['false', 'true'])
+async def test_multi_rf_change_0_N(request: pytest.FixtureRequest, manager: ManagerClient, enforce_rack_list) -> None:
+    config = {"tablets_mode_for_new_keyspaces": "enabled", "rf_rack_valid_keyspaces": "false", "tablet_load_stats_refresh_interval_in_seconds": 1}
+    cmdline = ["--enforce-rack-list", enforce_rack_list, "--smp", "2", '--logger-log-level', 'raft_topology=debug', '--logger-log-level', 'load_balancer=debug']
+
+    servers = [await manager.server_add(config=config, cmdline=cmdline, property_file={'dc': 'dc1', 'rack': 'rack1a'}),
+                await manager.server_add(config=config, cmdline=cmdline, property_file={'dc': 'dc1', 'rack': 'rack1b'}),
+                await manager.server_add(config=config, cmdline=cmdline, property_file={'dc': 'dc2', 'rack': 'rack2a'}),
+                await manager.server_add(config=config, cmdline=cmdline, property_file={'dc': 'dc2', 'rack': 'rack2b'})]
+
+    cql = manager.get_cql()
+
+    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': ['rack1a', 'rack1b']} AND tablets = {'initial': 4}") as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.t (pk int PRIMARY KEY)")
+        await asyncio.gather(*[cql.run_async(SimpleStatement(f"INSERT INTO {ks}.t (pk) VALUES ({k})", consistency_level=ConsistencyLevel.QUORUM)) for k in range(10)])
+
+        await cql.run_async(f"ALTER KEYSPACE {ks} WITH replication = {{'class': 'NetworkTopologyStrategy', 'dc1': 2, 'dc2': ['rack2a', 'rack2b']}}")
+        replicas = await get_all_tablet_replicas(manager, servers[0], ks, "t")
+        assert len(replicas) > 0
+        for r in replicas:
+            assert len(r.replicas) == 4
+
+        await cql.run_async(f"ALTER KEYSPACE {ks} WITH replication = {{'class': 'NetworkTopologyStrategy', 'dc1': 0, 'dc2': ['rack2a', 'rack2b']}}")
+        replicas = await get_all_tablet_replicas(manager, servers[0], ks, "t")
+        assert len(replicas) > 0
+        for r in replicas:
+            assert len(r.replicas) == 2
+
+@pytest.mark.asyncio
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
+async def test_multi_rf_increase_abort_0_N(request: pytest.FixtureRequest, manager: ManagerClient) -> None:
+    """Test aborting a 0->N RF increase (adding a new DC)."""
+    config = {"tablets_mode_for_new_keyspaces": "enabled", "rf_rack_valid_keyspaces": "false", "tablet_load_stats_refresh_interval_in_seconds": 1}
+    cmdline = ["--enforce-rack-list", "true", "--smp", "2", '--logger-log-level', 'raft_topology=debug', '--logger-log-level', 'load_balancer=debug']
+    injection = "determine_rf_change_actions_per_rack_throw"
+
+    servers = [await manager.server_add(config=config, cmdline=cmdline, property_file={'dc': 'dc1', 'rack': 'rack1a'}),
+                await manager.server_add(config=config, cmdline=cmdline, property_file={'dc': 'dc1', 'rack': 'rack1b'}),
+                await manager.server_add(config=config, cmdline=cmdline, property_file={'dc': 'dc1', 'rack': 'rack1c'}),
+                await manager.server_add(config=config, cmdline=cmdline, property_file={'dc': 'dc2', 'rack': 'rack2a'}),
+                await manager.server_add(config=config, cmdline=cmdline, property_file={'dc': 'dc2', 'rack': 'rack2b'}),
+                await manager.server_add(config=config, cmdline=cmdline, property_file={'dc': 'dc2', 'rack': 'rack2c'})]
+
+    dc1_host_ids = [await manager.get_host_id(s.server_id) for s in servers[0:3]]
+
+    cql = manager.get_cql()
+
+    dc1_host = (await wait_for_cql_and_get_hosts(cql, [servers[0]], time.time() + 30))[0]
+
+    await cql.run_async(f"create keyspace ks1 with replication = {{'class': 'NetworkTopologyStrategy', 'dc1': ['rack1a', 'rack1b', 'rack1c']}} and tablets = {{'initial': 4}};")
+    await cql.run_async("create table ks1.t (pk int primary key, v int);")
+    await cql.run_async("create materialized view ks1.tv as select * from ks1.t where pk is not null and v is not null primary key (v, pk)")
+    await asyncio.gather(*[cql.run_async(f"INSERT INTO ks1.t (pk, v) VALUES ({k}, {k});", host=dc1_host) for k in range(10)])
+
+    coord = await get_topology_coordinator(manager)
+    coord_serv = await find_server_by_host_id(manager, servers, coord)
+    log = await manager.server_open_log(coord_serv.server_id)
+    mark = await log.mark()
+
+    for s in servers:
+        await manager.api.enable_injection(s.ip_addr, injection, one_shot=False)
+
+    # Add dc2 (dc2: 0->3).
+    async def alter_keyspace():
+        await cql.run_async("alter keyspace ks1 with replication = {'class': 'NetworkTopologyStrategy', 'dc1': ['rack1a', 'rack1b', 'rack1c'], 'dc2': ['rack2a', 'rack2b', 'rack2c']};")
+
+    alter_task = asyncio.create_task(alter_keyspace())
+
+    await log.wait_for(f'{injection}: entered', from_mark=mark)
+    await check_system_schema_keyspaces(manager, "ks1", {'dc1': ['rack1a', 'rack1b', 'rack1c']}, {'dc1': ['rack1a', 'rack1b', 'rack1c'], 'dc2': ['rack2a', 'rack2b', 'rack2c']})
+
+    task_manager_client = TaskManagerClient(manager.api)
+    tasks = await task_manager_client.list_tasks(servers[0].ip_addr, "global_topology_requests")
+    rf_change_tasks = [t for t in tasks if t.type == "keyspace_rf_change"]
+    assert len(rf_change_tasks) == 1
+    task_id = rf_change_tasks[0].task_id
+    await task_manager_client.abort_task(servers[0].ip_addr, task_id)
+
+    for s in servers:
+        await manager.api.message_injection(s.ip_addr, injection)
+        await manager.api.disable_injection(s.ip_addr, injection)
+
+    task = await task_manager_client.wait_for_task(servers[0].ip_addr, task_id)
+    assert task.state == "failed"
+
+    failed = False
+    try:
+        await alter_task
+    except Exception as e:
+        failed = True
+    assert failed
+
+    await check_system_schema_keyspaces(manager, "ks1", {'dc1': ['rack1a', 'rack1b', 'rack1c']}, None)
+    replicas = await get_all_tablet_replicas(manager, servers[0], "ks1", "t")
+    assert len(replicas) > 0
+    for t in replicas:
+        assert len(t.replicas) == 3
+        for rep in t.replicas:
+            assert rep[0] in dc1_host_ids
+    view_replicas = await get_all_tablet_replicas(manager, servers[0], "ks1", "tv", is_view=True)
+    assert len(view_replicas) > 0
+    for t in view_replicas:
+        assert len(t.replicas) == 3
+        for rep in t.replicas:
+            assert rep[0] in dc1_host_ids
+
+@pytest.mark.asyncio
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
+async def test_multi_rf_decrease_abort_0_N(request: pytest.FixtureRequest, manager: ManagerClient) -> None:
+    """Test aborting an N->0 RF decrease (removing a DC). Abort should not be allowed."""
+    config = {"tablets_mode_for_new_keyspaces": "enabled", "rf_rack_valid_keyspaces": "false", "tablet_load_stats_refresh_interval_in_seconds": 1}
+    cmdline = ["--enforce-rack-list", "true", "--smp", "2", '--logger-log-level', 'raft_topology=debug', '--logger-log-level', 'load_balancer=debug']
+    injection = "determine_rf_change_actions_per_rack_throw"
+
+    servers = [await manager.server_add(config=config, cmdline=cmdline, property_file={'dc': 'dc1', 'rack': 'rack1a'}),
+                await manager.server_add(config=config, cmdline=cmdline, property_file={'dc': 'dc1', 'rack': 'rack1b'}),
+                await manager.server_add(config=config, cmdline=cmdline, property_file={'dc': 'dc1', 'rack': 'rack1c'}),
+                await manager.server_add(config=config, cmdline=cmdline, property_file={'dc': 'dc2', 'rack': 'rack2a'}),
+                await manager.server_add(config=config, cmdline=cmdline, property_file={'dc': 'dc2', 'rack': 'rack2b'}),
+                await manager.server_add(config=config, cmdline=cmdline, property_file={'dc': 'dc2', 'rack': 'rack2c'})]
+
+    dc1_host_ids = [await manager.get_host_id(s.server_id) for s in servers[0:3]]
+
+    cql = manager.get_cql()
+
+    await cql.run_async(f"create keyspace ks1 with replication = {{'class': 'NetworkTopologyStrategy', 'dc1': ['rack1a', 'rack1b', 'rack1c'], 'dc2': ['rack2a', 'rack2b', 'rack2c']}} and tablets = {{'initial': 4}};")
+    await cql.run_async("create table ks1.t (pk int primary key, v int);")
+    await cql.run_async("create materialized view ks1.tv as select * from ks1.t where pk is not null and v is not null primary key (v, pk)")
+    await asyncio.gather(*[cql.run_async(f"INSERT INTO ks1.t (pk, v) VALUES ({k}, {k});") for k in range(10)])
+
+    coord = await get_topology_coordinator(manager)
+    coord_serv = await find_server_by_host_id(manager, servers, coord)
+    log = await manager.server_open_log(coord_serv.server_id)
+    mark = await log.mark()
+
+    for s in servers:
+        await manager.api.enable_injection(s.ip_addr, injection, one_shot=False)
+
+    # Remove dc2 (dc2: 3->0).
+    async def alter_keyspace():
+        await cql.run_async("alter keyspace ks1 with replication = {'class': 'NetworkTopologyStrategy', 'dc1': ['rack1a', 'rack1b', 'rack1c'], 'dc2': []};")
+
+    alter_task = asyncio.create_task(alter_keyspace())
+
+    await log.wait_for(f'{injection}: entered', from_mark=mark)
+    await check_system_schema_keyspaces(manager, "ks1", {'dc1': ['rack1a', 'rack1b', 'rack1c'], 'dc2': ['rack2a', 'rack2b', 'rack2c']}, {'dc1': ['rack1a', 'rack1b', 'rack1c']})
+
+    task_manager_client = TaskManagerClient(manager.api)
+    tasks = await task_manager_client.list_tasks(servers[0].ip_addr, "global_topology_requests")
+    rf_change_tasks = [t for t in tasks if t.type == "keyspace_rf_change"]
+    assert len(rf_change_tasks) == 1
+    task_id = rf_change_tasks[0].task_id
+    await task_manager_client.abort_task(servers[0].ip_addr, task_id)
+
+    for s in servers:
+        await manager.api.message_injection(s.ip_addr, injection)
+        await manager.api.disable_injection(s.ip_addr, injection)
+
+    # Aborting a rf change that removed replicas isn't allowed.
+    task = await task_manager_client.wait_for_task(servers[0].ip_addr, task_id)
+    assert task.state == "done"
+
+    await alter_task
+
+    await check_system_schema_keyspaces(manager, "ks1", {'dc1': ['rack1a', 'rack1b', 'rack1c']}, None)
+    replicas = await get_all_tablet_replicas(manager, servers[0], "ks1", "t")
+    assert len(replicas) > 0
+    for t in replicas:
+        assert len(t.replicas) == 3
+        for rep in t.replicas:
+            assert rep[0] in dc1_host_ids
+    view_replicas = await get_all_tablet_replicas(manager, servers[0], "ks1", "tv", is_view=True)
+    assert len(view_replicas) > 0
+    for t in view_replicas:
+        assert len(t.replicas) == 3
+        for rep in t.replicas:
+            assert rep[0] in dc1_host_ids
+
+@pytest.mark.asyncio
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
+async def test_multi_rf_of_many_keyspaces_0_N(request: pytest.FixtureRequest, manager: ManagerClient) -> None:
+    """Test concurrent 0->N RF changes across multiple keyspaces."""
+    config = {"tablets_mode_for_new_keyspaces": "enabled", "rf_rack_valid_keyspaces": "false", "tablet_load_stats_refresh_interval_in_seconds": 1}
+    cmdline = ["--enforce-rack-list", "true", "--smp", "2", '--logger-log-level', 'raft_topology=debug', '--logger-log-level', 'load_balancer=debug']
+    injection = "determine_rf_change_actions_per_rack_throw"
+
+    servers = [await manager.server_add(config=config, cmdline=cmdline, property_file={'dc': 'dc1', 'rack': 'rack1a'}),
+                await manager.server_add(config=config, cmdline=cmdline, property_file={'dc': 'dc1', 'rack': 'rack1b'}),
+                await manager.server_add(config=config, cmdline=cmdline, property_file={'dc': 'dc1', 'rack': 'rack1c'}),
+                await manager.server_add(config=config, cmdline=cmdline, property_file={'dc': 'dc2', 'rack': 'rack2a'}),
+                await manager.server_add(config=config, cmdline=cmdline, property_file={'dc': 'dc2', 'rack': 'rack2b'}),
+                await manager.server_add(config=config, cmdline=cmdline, property_file={'dc': 'dc2', 'rack': 'rack2c'})]
+
+    dc2_host_ids = [await manager.get_host_id(s.server_id) for s in servers[3:6]]
+
+    cql = manager.get_cql()
+
+    dc1_host = (await wait_for_cql_and_get_hosts(cql, [servers[0]], time.time() + 30))[0]
+
+    await cql.run_async(f"create keyspace ks1 with replication = {{'class': 'NetworkTopologyStrategy', 'dc1': ['rack1a']}} and tablets = {{'initial': 4}};")
+    await cql.run_async("create table ks1.t (pk int primary key, v int);")
+    await cql.run_async("create materialized view ks1.tv as select * from ks1.t where pk is not null and v is not null primary key (v, pk)")
+    await asyncio.gather(*[cql.run_async(f"INSERT INTO ks1.t (pk, v) VALUES ({k}, {k});", host=dc1_host) for k in range(10)])
+
+    await cql.run_async(f"create keyspace ks2 with replication = {{'class': 'NetworkTopologyStrategy', 'dc1': ['rack1b']}} and tablets = {{'initial': 4}};")
+    await cql.run_async("create table ks2.t (pk int primary key, v int);")
+    await cql.run_async("create materialized view ks2.tv as select * from ks2.t where pk is not null and v is not null primary key (v, pk)")
+    await asyncio.gather(*[cql.run_async(f"INSERT INTO ks2.t (pk, v) VALUES ({k}, {k});", host=dc1_host) for k in range(10)])
+
+    await cql.run_async(f"create keyspace ks3 with replication = {{'class': 'NetworkTopologyStrategy', 'dc1': ['rack1c']}} and tablets = {{'initial': 4}};")
+    await cql.run_async("create table ks3.t (pk int primary key, v int);")
+    await cql.run_async("create materialized view ks3.tv as select * from ks3.t where pk is not null and v is not null primary key (v, pk)")
+    await asyncio.gather(*[cql.run_async(f"INSERT INTO ks3.t (pk, v) VALUES ({k}, {k});", host=dc1_host) for k in range(10)])
+
+    coord = await get_topology_coordinator(manager)
+    coord_serv = await find_server_by_host_id(manager, servers, coord)
+    log = await manager.server_open_log(coord_serv.server_id)
+    mark = await log.mark()
+
+    for s in servers:
+        await manager.api.enable_injection(s.ip_addr, injection, one_shot=False)
+
+    # Move each keyspace from dc1 to dc2 (dc1: 1->0, dc2: 0->3).
+    async def alter_keyspace1():
+        await cql.run_async("alter keyspace ks1 with replication = {'class': 'NetworkTopologyStrategy', 'dc1': [], 'dc2': ['rack2a', 'rack2b', 'rack2c']};")
+
+    async def alter_keyspace2():
+        await cql.run_async("alter keyspace ks2 with replication = {'class': 'NetworkTopologyStrategy', 'dc1': [], 'dc2': ['rack2a', 'rack2b', 'rack2c']};")
+
+    async def alter_keyspace3():
+        await cql.run_async("alter keyspace ks3 with replication = {'class': 'NetworkTopologyStrategy', 'dc1': [], 'dc2': ['rack2a', 'rack2b', 'rack2c']};")
+
+    alter_task1 = asyncio.create_task(alter_keyspace1())
+    alter_task2 = asyncio.create_task(alter_keyspace2())
+    alter_task3 = asyncio.create_task(alter_keyspace3())
+
+    await log.wait_for(*[f'{injection}: entered' for _ in range(3)], from_mark=mark)
+
+    for s in servers:
+        await manager.api.message_injection(s.ip_addr, injection)
+        await manager.api.disable_injection(s.ip_addr, injection)
+
+    await alter_task1
+    await alter_task2
+    await alter_task3
+
+    for ks in ["ks1", "ks2", "ks3"]:
+        await check_system_schema_keyspaces(manager, ks, {'dc2': ['rack2a', 'rack2b', 'rack2c']}, None)
+        replicas = await get_all_tablet_replicas(manager, servers[0], ks, "t")
+        assert len(replicas) > 0
+        for t in replicas:
+            assert len(t.replicas) == 3
+            for rep in t.replicas:
+                assert rep[0] in dc2_host_ids
+            for host_id in dc2_host_ids:
+                assert host_id in [r[0] for r in t.replicas]
+        view_replicas = await get_all_tablet_replicas(manager, servers[0], ks, "tv", is_view=True)
+        assert len(view_replicas) > 0
+        for t in view_replicas:
+            assert len(t.replicas) == 3
+            for rep in t.replicas:
+                assert rep[0] in dc2_host_ids
+            for host_id in dc2_host_ids:
+                assert host_id in [r[0] for r in t.replicas]
+
+@pytest.mark.asyncio
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
+async def test_multi_rf_increase_before_decrease_0_N(request: pytest.FixtureRequest, manager: ManagerClient) -> None:
+    """Test aborting an RF change that involves both 0->N increase and N->0 decrease across DCs."""
+    config = {"tablets_mode_for_new_keyspaces": "enabled", "rf_rack_valid_keyspaces": "false", "tablet_load_stats_refresh_interval_in_seconds": 1}
+    cmdline = ["--enforce-rack-list", "true", "--smp", "2", '--logger-log-level', 'raft_topology=debug', '--logger-log-level', 'load_balancer=debug']
+    injection = "determine_rf_change_actions_per_rack_throw"
+
+    servers = [await manager.server_add(config=config, cmdline=cmdline, property_file={'dc': 'dc1', 'rack': 'rack1a'}),
+                await manager.server_add(config=config, cmdline=cmdline, property_file={'dc': 'dc1', 'rack': 'rack1b'}),
+                await manager.server_add(config=config, cmdline=cmdline, property_file={'dc': 'dc1', 'rack': 'rack1c'}),
+                await manager.server_add(config=config, cmdline=cmdline, property_file={'dc': 'dc2', 'rack': 'rack2a'}),
+                await manager.server_add(config=config, cmdline=cmdline, property_file={'dc': 'dc2', 'rack': 'rack2b'}),
+                await manager.server_add(config=config, cmdline=cmdline, property_file={'dc': 'dc2', 'rack': 'rack2c'})]
+
+    host_ids = [await manager.get_host_id(s.server_id) for s in servers]
+
+    cql = manager.get_cql()
+
+    dc1_host = (await wait_for_cql_and_get_hosts(cql, [servers[0]], time.time() + 30))[0]
+
+    # Start with dc1 only (dc2: 0).
+    await cql.run_async(f"create keyspace ks1 with replication = {{'class': 'NetworkTopologyStrategy', 'dc1': ['rack1a', 'rack1b', 'rack1c']}} and tablets = {{'initial': 4}};")
+    await cql.run_async("create table ks1.t (pk int primary key, v int);")
+    await cql.run_async("create materialized view ks1.tv as select * from ks1.t where pk is not null and v is not null primary key (v, pk)")
+    await asyncio.gather(*[cql.run_async(f"INSERT INTO ks1.t (pk, v) VALUES ({k}, {k});", host=dc1_host) for k in range(10)])
+
+    coord = await get_topology_coordinator(manager)
+    coord_serv = await find_server_by_host_id(manager, servers, coord)
+    log = await manager.server_open_log(coord_serv.server_id)
+    mark = await log.mark()
+
+    for s in servers:
+        await manager.api.enable_injection(s.ip_addr, injection, one_shot=False)
+
+    # Move all replicas from dc1 to dc2 (dc1: 3->0, dc2: 0->3).
+    async def alter_keyspace():
+        await cql.run_async("alter keyspace ks1 with replication = {'class': 'NetworkTopologyStrategy', 'dc1': [], 'dc2': ['rack2a', 'rack2b', 'rack2c']};")
+
+    alter_task = asyncio.create_task(alter_keyspace())
+
+    await log.wait_for(f'{injection}: entered', from_mark=mark)
+
+    dc1_host_ids = set(host_ids[0:3])
+    replicas_mid = await get_all_tablet_replicas(manager, servers[0], "ks1", "t")
+    assert len(replicas_mid) > 0
+    for t in replicas_mid:
+        t_dc1 = [r for r in t.replicas if r[0] in dc1_host_ids]
+        # dc1 replicas must not have decreased (still 3)
+        assert len(t_dc1) == 3, f"Expected 3 dc1 replicas, got {len(t_dc1)}"
+
+    task_manager_client = TaskManagerClient(manager.api)
+    tasks = await task_manager_client.list_tasks(servers[0].ip_addr, "global_topology_requests")
+    rf_change_tasks = [t for t in tasks if t.type == "keyspace_rf_change"]
+    assert len(rf_change_tasks) == 1
+    task_id = rf_change_tasks[0].task_id
+    await task_manager_client.abort_task(servers[0].ip_addr, task_id)
+
+    for s in servers:
+        await manager.api.message_injection(s.ip_addr, injection)
+        await manager.api.disable_injection(s.ip_addr, injection)
+
+    task = await task_manager_client.wait_for_task(servers[0].ip_addr, task_id)
+    assert task.state == "failed"
+
+    failed = False
+    try:
+        await alter_task
+    except Exception as e:
+        failed = True
+    assert failed
+
+    await check_system_schema_keyspaces(manager, "ks1", {'dc1': ['rack1a', 'rack1b', 'rack1c']}, None)
+    replicas = await get_all_tablet_replicas(manager, servers[0], "ks1", "t")
+    assert len(replicas) > 0
+    for t in replicas:
+        assert len(t.replicas) == 3
+        for rep in t.replicas:
+            assert rep[0] in host_ids[0:3]
+        assert all(host in [r[0] for r in t.replicas] for host in host_ids[0:3])
+    view_replicas = await get_all_tablet_replicas(manager, servers[0], "ks1", "tv", is_view=True)
+    assert len(view_replicas) > 0
+    for t in view_replicas:
+        assert len(t.replicas) == 3
+        for rep in t.replicas:
+            assert rep[0] in host_ids[0:3]
+        assert all(host in [r[0] for r in t.replicas] for host in host_ids[0:3])
 
 @pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
@@ -1173,6 +1729,48 @@ async def test_excludenode(manager: ManagerClient):
         await manager.remove_node(live_node.server_id, server_id=node_to_remove.server_id)
 
 @pytest.mark.asyncio
+async def test_excludenode_shrink_rf(manager: ManagerClient):
+    """
+    Verifies that ALTER keyspace removing replicas from a DC succeeds when the only
+    node in that DC is down and marked as excluded.
+
+    1. Create a 2-DC cluster: dc1 with 2 nodes, dc2 with 1 node.
+    2. Create keyspace replicated to both DCs.
+    3. Stop the dc2 node (the only node in dc2).
+    4. Mark the dc2 node as excluded.
+    5. ALTER keyspace to remove dc2 from replication.
+    6. Verify the ALTER succeeds without timing out.
+    """
+    config = {"tablet_load_stats_refresh_interval_in_seconds": 1}
+    cmdline = ['--logger-log-level', 'raft_topology=debug', '--logger-log-level', 'load_balancer=debug']
+    dc1_servers = await manager.servers_add(servers_num=2, config=config, cmdline=cmdline, property_file={'dc': 'dc1', 'rack': 'rack1'})
+    dc2_server = await manager.server_add(config=config, cmdline=cmdline, property_file={'dc': 'dc2', 'rack': 'rack2'})
+
+    cql = manager.get_cql()
+    async with new_test_keyspace(manager, "WITH replication = { 'class': 'NetworkTopologyStrategy', "
+                                          "'dc1': 1, 'dc2': 1} AND tablets = { 'initial': 4 }") as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);")
+
+        # Stop the only node in dc2
+        await manager.server_stop(dc2_server.server_id)
+        await manager.others_not_see_server(dc2_server.ip_addr)
+
+        # Mark the dc2 node as excluded
+        live_node = dc1_servers[0]
+        await manager.api.exclude_node(live_node.ip_addr, hosts=[await manager.get_host_id(dc2_server.server_id)])
+
+        # ALTER keyspace to remove dc2 from replication.
+        # This should succeed without timing out, even though the excluded node
+        # has tablet replicas that need to be shrunk away.
+        await cql.run_async(f"ALTER KEYSPACE {ks} WITH REPLICATION = {{ 'class': 'NetworkTopologyStrategy', 'dc1': 1, 'dc2': 0}}")
+
+        await asyncio.gather(*(read_barrier(manager.api, s.ip_addr) for s in dc1_servers))
+
+        # Verify dc2 is no longer in the replication settings
+        repl = get_replication(cql, ks)
+        assert 'dc2' not in repl or get_replica_count(repl.get('dc2', '0')) == 0
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("with_zero_token_node", [False, True])
 async def test_remove_failure_then_replace(manager: ManagerClient, with_zero_token_node: bool):
     """
@@ -1744,3 +2342,119 @@ async def test_table_creation_wakes_up_balancer(manager: ManagerClient):
         # up to stats refresh period, which is 60s. So use a small timeout.
         await manager.api.message_injection(server.ip_addr, 'wait-before-topology-coordinator-goes-to-sleep')
         await log.wait_for('wait-after-topology-coordinator-gets-event: wait', from_mark=mark, timeout=5)
+
+@pytest.mark.asyncio
+async def test_multi_rf_increase_auto_abort_excluded_node(request: pytest.FixtureRequest, manager: ManagerClient) -> None:
+    """Test that an RF change is automatically aborted when a required rack has no available nodes.
+
+    Setup:
+    - dc1 has 1 node in rack1 (holds the initial replica)
+    - dc2 has 2 racks: rack1 (1 node) and rack2 (1 node)
+
+    Steps:
+    1. Create a keyspace with replication in dc1 only.
+    2. Stop the node in dc2/rack1 and mark it as excluded.
+    3. ALTER KEYSPACE to add replicas in dc2: ['rack1', 'rack2'].
+       This requires extending to dc2/rack1 which has no available node.
+    4. Verify that the RF change is rolled back automatically by the load balancer.
+    """
+    config = {"tablets_mode_for_new_keyspaces": "enabled", "rf_rack_valid_keyspaces": "false", "tablet_load_stats_refresh_interval_in_seconds": 1}
+    cmdline = ["--enforce-rack-list", "true", "--smp", "2", '--logger-log-level', 'raft_topology=debug', '--logger-log-level', 'load_balancer=debug']
+
+    dc1_server = await manager.server_add(config=config, cmdline=cmdline, property_file={'dc': 'dc1', 'rack': 'rack1'})
+    dc2_rack1_server = await manager.server_add(config=config, cmdline=cmdline, property_file={'dc': 'dc2', 'rack': 'rack1'})
+    dc2_rack2_server = await manager.server_add(config=config, cmdline=cmdline, property_file={'dc': 'dc2', 'rack': 'rack2'})
+
+    servers = [dc1_server, dc2_rack1_server, dc2_rack2_server]
+    dc1_host_id = await manager.get_host_id(dc1_server.server_id)
+
+    cql = manager.get_cql()
+    dc1_host = (await wait_for_cql_and_get_hosts(cql, [dc1_server], time.time() + 30))[0]
+
+    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': ['rack1']} AND tablets = {'initial': 4}") as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.t (pk int PRIMARY KEY, v int);")
+        await asyncio.gather(*[cql.run_async(f"INSERT INTO {ks}.t (pk, v) VALUES ({k}, {k});", host=dc1_host) for k in range(10)])
+
+        # Verify initial state: all replicas in dc1
+        replicas = await get_all_tablet_replicas(manager, dc1_server, ks, "t")
+        assert len(replicas) > 0
+        for t in replicas:
+            assert len(t.replicas) == 1
+            assert t.replicas[0][0] == dc1_host_id
+
+        # Stop dc2/rack1 node and mark it as excluded
+        await manager.server_stop(dc2_rack1_server.server_id)
+        await manager.others_not_see_server(dc2_rack1_server.ip_addr)
+        await manager.api.exclude_node(dc1_server.ip_addr, hosts=[await manager.get_host_id(dc2_rack1_server.server_id)])
+
+        # ALTER KEYSPACE to add replicas in dc2 (rack1 and rack2).
+        # dc2/rack1 has no available node, so the RF change should be auto-aborted.
+        failed = False
+        try:
+            await cql.run_async(f"ALTER KEYSPACE {ks} WITH replication = {{'class': 'NetworkTopologyStrategy', 'dc1': ['rack1'], 'dc2': ['rack1', 'rack2']}};")
+        except Exception:
+            failed = True
+        assert failed
+
+        # Verify the replication was rolled back: next_replication should be cleared
+        await check_system_schema_keyspaces(manager, ks, {'dc1': ['rack1']}, None)
+
+        # Verify tablet replicas are unchanged — still only in dc1
+        replicas = await get_all_tablet_replicas(manager, dc1_server, ks, "t")
+        assert len(replicas) > 0
+        for t in replicas:
+            assert len(t.replicas) == 1
+            assert t.replicas[0][0] == dc1_host_id
+
+@pytest.mark.asyncio
+async def test_rf_extend_abort_with_down_node(request: pytest.FixtureRequest, manager: ManagerClient) -> None:
+    """Test that an RF extend is aborted when a required rack has a down (not excluded) node.
+
+    Setup:
+    - dc1 has 1 node in rack1
+    - dc2 has 2 racks: rack1 (1 node) and rack2 (1 node)
+
+    Steps:
+    1. Create a keyspace with replication in dc1 only.
+    2. Stop the node in dc2/rack1 (do NOT exclude it).
+    3. ALTER KEYSPACE to add replicas in dc2: ['rack1', 'rack2'].
+    4. Verify that the RF change is aborted because of the down node.
+    """
+    config = {"tablets_mode_for_new_keyspaces": "enabled", "rf_rack_valid_keyspaces": "false", "tablet_load_stats_refresh_interval_in_seconds": 1}
+    cmdline = ["--enforce-rack-list", "true", "--smp", "2", '--logger-log-level', 'raft_topology=debug', '--logger-log-level', 'load_balancer=debug']
+
+    dc1_server = await manager.server_add(config=config, cmdline=cmdline, property_file={'dc': 'dc1', 'rack': 'rack1'})
+    dc2_rack1_server = await manager.server_add(config=config, cmdline=cmdline, property_file={'dc': 'dc2', 'rack': 'rack1'})
+    dc2_rack2_server = await manager.server_add(config=config, cmdline=cmdline, property_file={'dc': 'dc2', 'rack': 'rack2'})
+
+    dc1_host_id = await manager.get_host_id(dc1_server.server_id)
+
+    cql = manager.get_cql()
+    dc1_host = (await wait_for_cql_and_get_hosts(cql, [dc1_server], time.time() + 30))[0]
+
+    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': ['rack1']} AND tablets = {'initial': 4}") as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.t (pk int PRIMARY KEY, v int);")
+        await asyncio.gather(*[cql.run_async(f"INSERT INTO {ks}.t (pk, v) VALUES ({k}, {k});", host=dc1_host) for k in range(10)])
+
+        # Stop dc2/rack1 node but do NOT exclude it
+        await manager.server_stop(dc2_rack1_server.server_id)
+        await manager.others_not_see_server(dc2_rack1_server.ip_addr)
+
+        # ALTER KEYSPACE to add replicas in dc2 (rack1 and rack2).
+        # dc2/rack1 has a down node, so the RF change should be auto-aborted.
+        failed = False
+        try:
+            await cql.run_async(f"ALTER KEYSPACE {ks} WITH replication = {{'class': 'NetworkTopologyStrategy', 'dc1': ['rack1'], 'dc2': ['rack1', 'rack2']}};")
+        except Exception:
+            failed = True
+        assert failed
+
+        # Verify the replication was rolled back: next_replication should be cleared
+        await check_system_schema_keyspaces(manager, ks, {'dc1': ['rack1']}, None)
+
+        # Verify tablet replicas are unchanged — still only in dc1
+        replicas = await get_all_tablet_replicas(manager, dc1_server, ks, "t")
+        assert len(replicas) > 0
+        for t in replicas:
+            assert len(t.replicas) == 1
+            assert t.replicas[0][0] == dc1_host_id

--- a/test/cluster/test_tablets.py
+++ b/test/cluster/test_tablets.py
@@ -326,56 +326,6 @@ async def test_singledc_alter_tablets_rf(manager: ManagerClient):
         with pytest.raises(InvalidRequest):
             await change_rf(0) # Trying to decrease the RF by more than 2 should fail.
 
-
-# ALTER tablets KS cannot change RF of any DC by more than 1 at a time.
-# In a multi-dc environment, we can create replicas in a DC that didn't have replicas before,
-# but the above requirement should still be honoured, because we'd be changing RF from 0 to N in the new DC.
-# Reproduces https://github.com/scylladb/scylladb/issues/20039#issuecomment-2271365060
-# See also `test_singledc_alter_tablets_rf` above for basic scenarios tested
-@pytest.mark.asyncio
-async def test_multidc_alter_tablets_rf(request: pytest.FixtureRequest, manager: ManagerClient) -> None:
-    config = {"endpoint_snitch": "GossipingPropertyFileSnitch", "tablets_mode_for_new_keyspaces": "enabled"}
-
-    logger.info("Creating a new cluster of 2 nodes in 1st DC and 2 nodes in 2nd DC")
-    # we have to have at least 2 nodes in each DC if we want to try setting RF to 2 in each DC
-    await manager.servers_add(2, config=config, auto_rack_dc="dc1")
-    await manager.servers_add(2, config=config, auto_rack_dc="dc2")
-
-    cql = manager.get_cql()
-    async with new_test_keyspace(manager, "with replication = {'class': 'NetworkTopologyStrategy', 'dc1': 1}") as ks:
-        # need to create a table to not change only the schema, but also tablets replicas
-        await cql.run_async(f"create table {ks}.t (pk int primary key)")
-        with pytest.raises(InvalidRequest, match="Only one DC's RF can be changed at a time and not by more than 1"):
-            # changing RF of dc2 from 0 to 2 should fail
-            await cql.run_async(f"alter keyspace {ks} with replication = {{'class': 'NetworkTopologyStrategy', 'dc1': 1, 'dc2': ['rack1', 'rack2']}}")
-
-        # changing RF of dc2 from 0 to 1 should succeed
-        await cql.run_async(f"alter keyspace {ks} with replication = {{'class': 'NetworkTopologyStrategy', 'dc1': 1, 'dc2': ['rack1']}}")
-        # ensure that RFs of both DCs are equal to 1 now, i.e. that omitting dc1 in above command didn't change it
-        repl = get_replication(cql, ks)
-        logger.info(f"repl = {repl}")
-        assert len(repl['dc1']) == 1
-        assert repl['dc2'] == ['rack1']
-
-        # incrementing RF of 2 DCs at once should NOT succeed, because it'd leave 2 pending tablets replicas
-        with pytest.raises(InvalidRequest, match="Only one DC's RF can be changed at a time and not by more than 1"):
-            await cql.run_async(f"alter keyspace {ks} with replication = {{'class': 'NetworkTopologyStrategy', 'dc1': ['rack1', 'rack2'], 'dc2': ['rack1', 'rack2']}}")
-        # as above, but decrementing
-        with pytest.raises(InvalidRequest, match="Only one DC's RF can be changed at a time and not by more than 1"):
-            await cql.run_async(f"alter keyspace {ks} with replication = {{'class': 'NetworkTopologyStrategy', 'dc1': 0, 'dc2': 0}}")
-        # as above, but decrement 1 RF and increment the other
-        with pytest.raises(InvalidRequest, match="Only one DC's RF can be changed at a time and not by more than 1"):
-            await cql.run_async(f"alter keyspace {ks} with replication = {{'class': 'NetworkTopologyStrategy', 'dc1': ['rack1','rack2'], 'dc2': 0}}")
-        # as above, but RFs are swapped
-        with pytest.raises(InvalidRequest, match="Only one DC's RF can be changed at a time and not by more than 1"):
-            await cql.run_async(f"alter keyspace {ks} with replication = {{'class': 'NetworkTopologyStrategy', 'dc1': 0, 'dc2': ['rack1', 'rack2']}}")
-
-        # check that we can remove all replicas from dc2 by changing RF from 1 to 0
-        await cql.run_async(f"alter keyspace {ks} with replication = {{'class': 'NetworkTopologyStrategy', 'dc1': 1, 'dc2': 0}}")
-        # check that we can remove all replicas from the cluster, i.e. change RF of dc1 from 1 to 0 as well:
-        await cql.run_async(f"alter keyspace {ks} with replication = {{'class': 'NetworkTopologyStrategy', 'dc1': 0}}")
-
-
 @pytest.mark.asyncio
 async def test_alter_tablets_rf_dc_drop(request: pytest.FixtureRequest, manager: ManagerClient) -> None:
     config = {"endpoint_snitch": "GossipingPropertyFileSnitch", "tablets_mode_for_new_keyspaces": "enabled"}

--- a/test/cql/cassandra_cql_test.result
+++ b/test/cql/cassandra_cql_test.result
@@ -18,11 +18,11 @@ OK
 > ALTER KEYSPACE ks1 WITH replication = { 'class' : 'NetworkTopologyStrategy', 'datacenter1' : 1 };
 OK
 > SELECT * FROM system_schema.keyspaces WHERE keyspace_name = 'ks1';
-+-----------------+------------------+--------------------------+------------------+
-| keyspace_name   | durable_writes   | replication              | replication_v2   |
-|-----------------+------------------+--------------------------+------------------|
-| ks1             | True             | ['class', 'datacenter1'] | null             |
-+-----------------+------------------+--------------------------+------------------+
++-----------------+------------------+--------------------+--------------------------+------------------+
+| keyspace_name   | durable_writes   | next_replication   | replication              | replication_v2   |
+|-----------------+------------------+--------------------+--------------------------+------------------|
+| ks1             | True             | null               | ['class', 'datacenter1'] | null             |
++-----------------+------------------+--------------------+--------------------------+------------------+
 > USE ks1;
 OK
 > 

--- a/test/perf/tablet_load_balancing.cc
+++ b/test/perf/tablet_load_balancing.cc
@@ -122,10 +122,10 @@ future<> apply_plan(token_metadata& tm, const migration_plan& plan, locator::loa
             return make_ready_future();
         });
         // Move tablet size in load_stats to account for the migration
-        if (mig.src.host != mig.dst.host) {
+        if (mig.src && mig.dst && mig.src->host != mig.dst->host) {
             auto& tmap = tm.tablets().get_tablet_map(mig.tablet.table);
             const dht::token_range trange = tmap.get_token_range(mig.tablet.tablet);
-            lw_shared_ptr<locator::load_stats> new_stats = load_stats.migrate_tablet_size(mig.src.host, mig.dst.host, mig.tablet, trange);
+            lw_shared_ptr<locator::load_stats> new_stats = load_stats.migrate_tablet_size(mig.src->host, mig.dst->host, mig.tablet, trange);
 
             if (new_stats) {
                 load_stats = std::move(*new_stats);


### PR DESCRIPTION
With this change, you can add or remove a DC(s) in a single ALTER KEYSPACE statement. It requires the keyspace to use rack list replication factor.

In existing approach, during RF change all tablet replicas are rebuilt at once. This isn't the case now. In global_topology_request::keyspace_rf_change the request is added to a ongoing_rf_changes - a new column in system.topology table. In a new column in system_schema.keyspaces - next_replication - we keep the target RF.

In make_rf_change_plan, load balancer schedules necessary migrations, considering the load of nodes and other pending tablet transitions. Requests from ongoing_rf_changes are processed concurrently, independently from one another. In each request racks are processed concurrently. No tablet replica will be removed until all required replicas are added. While adding replicas to each rack we always start with base tables and won't proceed with views until they are done (while removing - the other way around). The intermediary steps aren't reflected in schema. When the Rf change is finished:
- in system_schema.keyspaces:
  - next_replication is cleared;
  - new keyspace properties are saved;
- request is removed from ongoing_rf_changes;
- the request is marked as done in system.topology_requests.

Until the request is done, DESCRIBE KEYSPACE shows the replication_v2.

If a request hasn't started to remove replicas, it can be aborted using task manager. system.topology_requests::error is set (but the request isn't marked as done) and next_replication = replication_v2. This will be interpreted by load balancer, that will start the rollback of the request. After the rollback is done, we set the relevant system.topology_requests entry as done (failed), clear the request id from system.topology::ongoing_rf_changes, and remove next_replication.

Fixes: SCYLLADB-567.

No backport needed; new feature.