### PR TITLE
doc: remove references to Open Source from README

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,9 +1,9 @@
 # ScyllaDB Documentation
 
-This repository contains the source files for ScyllaDB Open Source documentation.
+This repository contains the source files for ScyllaDB documentation.
 
 - The `dev` folder contains developer-oriented documentation related to the ScyllaDB code base. It is not published and is only available via GitHub.
-- All other folders and files contain user-oriented documentation related to ScyllaDB Open Source and are sources for [opensource.docs.scylladb.com](https://opensource.docs.scylladb.com/).
+- All other folders and files contain user-oriented documentation related to ScyllaDB and are sources for [docs.scylladb.com/manual](https://docs.scylladb.com/manual/).
 
 To report a documentation bug or suggest an improvement, open an issue in [GitHub issues](https://github.com/scylladb/scylla/issues) for this project.
 


### PR DESCRIPTION
This commit removes the references to ScyllaDB Open Source from the README file for documentation. In addition, it updates the link where the documentation is currently published.

We've removed Open Source from all the documentation, but the README was missed. This commit fixes that.

