### PR TITLE
http: Add missing thread_local specifier for static

### DIFF
--- a/utils/http.cc
+++ b/utils/http.cc
@@ -9,7 +9,7 @@
 #include "http.hh"
 
 future<shared_ptr<tls::certificate_credentials>> utils::http::dns_connection_factory::system_trust_credentials() {
-    static shared_ptr<tls::certificate_credentials> system_trust_credentials;
+    static thread_local shared_ptr<tls::certificate_credentials> system_trust_credentials;
     if (!system_trust_credentials) {
         // can race, and overwrite the object. that is fine.
         auto cred = make_shared<tls::certificate_credentials>();


### PR DESCRIPTION
Fixes #24447

Patch adding this somehow managed to leave out the thread_local specifier. While gnutls cert object can be shared across shards just fine, the actual shared_ptr here cannot, thus we could cause memory errors.
