### PR TITLE
tools: optimized_clang: make it work in the presence of a scylladb profile

### DIFF
--- a/tools/toolchain/optimized_clang.sh
+++ b/tools/toolchain/optimized_clang.sh
@@ -103,6 +103,7 @@ SCYLLA_OPTS=(
     --compiler="${CLANG_BUILD_DIR}/build/bin/clang++"
     --build-dir="${SCYLLA_BUILD_DIR}"
     --out="${SCYLLA_NINJA_FILE}"
+    --use-profile=""
 )
 
 # Utilizing LLVM_DISTRIBUTION_COMPONENTS to avoid


### PR DESCRIPTION
optimized_clang.sh trains the compiler using profile-guided optimization (pgo). However, while doing that, it builds scylladb using its own profile stored in pgo/profiles and decompressed into build/profile.profdata. Due to the funky directory structure used for training the compiler, that path is invalid during the training and the build fails.

The workaround was to build on a cloud machine instead of a workstation - this worked because the cloud machine didn't have git-lfs installed, and therefore did not see the stored profile, and the whole mess was averted.

To make this work on a machine that does have access to stored profiles, disable use of the stored profile even if it exists.

Fixes #22713

Marking for backport; while it's just an inconvenience, it's a big time waster in case we have to regenerate the toolchain on a branch.