### PR TITLE
test.py: Fix the boost output file name

### DIFF
--- a/test/pylib/cpp/boost/boost_facade.py
+++ b/test/pylib/cpp/boost/boost_facade.py
@@ -102,7 +102,7 @@ class BoostTestFacade(CppTestFacade):
             except IOError:
                 return ''
         root_log_dir = self.temp_dir / mode
-        log_xml = root_log_dir / f"{test_name}.log"
+        log_xml = root_log_dir / f"{test_name}.{self.run_id}.log"
         args = [ str(executable),
                  '--report_level=no',
                  '--output_format=XML',


### PR DESCRIPTION
File name for the boost test do not use run_id, so each consequent run will overwrite the logs from the previous one. If the first repeat fails, and the second will pass, it overwrites the failed log. This PR allows saving the failed one.

No backport needed, since changes that will lead to this behavior are not there.