### PR TITLE
test: Enable RF-rack-valid keyspaces in all Python suites

### DIFF
--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -148,6 +148,8 @@ def make_scylla_conf(mode: str, workdir: pathlib.Path, host_addr: str, seed_addr
             'truststore': 'conf/scyllacadb.pem',
         },
 
+        'rf_rack_valid_keyspaces': True,
+
     }
 
 # Seastar options can not be passed through scylla.yaml, use command line


### PR DESCRIPTION
We're enabling the configuration option `rf_rack_valid_keyspaces`
in all Python test suites. All relevant tests have been adjusted
to work with it enabled.

That encompasses the following suites:

* alternator,
* broadcast_tables,
* cluster (already enabled in scylladb/scylladb@ee96f8dcfcf86374a0e09ef2492deb1add0f36ea),
* cql,
* cqlpy (already enabled in scylladb/scylladb@be0877ce69294cf0b2995583bcbcbac2776e7d59),
* nodetool,
* rest_api.

Two remaining suites that use tests written in Python, redis and scylla_gdb,
are not affected, at least not directly.

The redis suite requires creating an instance of Scylla manually, and the tests
don't do anything that could violate the restriction.

The scylla_gdb suite focuses on testing the capabilities of scylla-gdb.py, but
even then it reuses the `run` file from the cqlpy suite.

Fixes scylladb/scylladb#25126

Backport: Backporting to relevant versions: 2025.1, 2025.2, and 2025.3
since the configuration option is already in place there, and we'd like to
run tests with it enabled.