### PR TITLE
storage_proxy: retry paxos repair even if repair write succeeded

### DIFF
--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -2130,8 +2130,8 @@ paxos_response_handler::begin_and_repair_paxos(client_state& cs, unsigned& conte
                 co_await std::move(f);
             } catch(...) {
                 paxos::paxos_state::logger.debug("CAS[{}] Failure during commit repair {}", _id, std::current_exception());
-                continue;
             }
+            continue;
         }
         co_return ballot_and_data{ballot, std::move(summary.data)};
     }


### PR DESCRIPTION
After paxos state is repaired in begin_and_repair_paxos we need to re-check the state regardless if write back succeeded or not. This is how the code worked originally but it was unintentionally changed when co-routinized in 61b2e41a23eacdf549d7745cca4cf65f5d996219.

Fixes #24630

Backport since this is a regression