### PR TITLE
utils/alien_worker: fix a data race in submit()

### DIFF
--- a/utils/alien_worker.hh
+++ b/utils/alien_worker.hh
@@ -45,15 +45,14 @@ public:
     template <typename T>
     seastar::future<T> submit(seastar::noncopyable_function<T()> f) {
         auto p = seastar::promise<T>();
-        auto fut = p.get_future();
-        auto wrapper = [p = std::move(p), f = std::move(f), shard = seastar::this_shard_id(), &alien = seastar::engine().alien()] () mutable noexcept {
+        auto wrapper = [&p, f = std::move(f), shard = seastar::this_shard_id(), &alien = seastar::engine().alien()] () mutable noexcept {
             try {
                 auto v = f();
-                seastar::alien::run_on(alien, shard, [v = std::move(v), p = std::move(p)] () mutable noexcept {
+                seastar::alien::run_on(alien, shard, [&p, v = std::move(v)] () mutable noexcept {
                     p.set_value(std::move(v));
                 });
             } catch (...) {
-                seastar::alien::run_on(alien, shard, [p = std::move(p), ep = std::current_exception()] () mutable noexcept {
+                seastar::alien::run_on(alien, shard, [&p, ep = std::current_exception()] () mutable noexcept {
                     p.set_exception(ep);
                 });
             }
@@ -63,7 +62,7 @@ public:
             _pending.push(std::move(wrapper));
         }
         _cv.notify_one();
-        return fut;
+        co_return co_await p.get_future();
     }
 };
 


### PR DESCRIPTION
We move a `seastar::promise` on the external worker thread, after the matching `seastar::future` was returned to the shard.

That's illegal. If the `promise` move occurs concurrently with some operation (move, await) on the `future`, it becomes a data race which could cause various kinds of corruption.

This patch fixes that by keeping the promise at a stable address on the shard (inside a coroutine frame) and only passing through the worker.

Fixes #24751

Should be backported to all supported releases.