### PR TITLE
treewide: Replace __builtin_expect with (un)likely 

### DIFF
--- a/bytes_ostream.hh
+++ b/bytes_ostream.hh
@@ -139,7 +139,7 @@ private:
     // size must not be zero.
     [[gnu::always_inline]]
     value_type* alloc(size_type size) {
-        if (__builtin_expect(size <= current_space_left(), true)) {
+        if (size <= current_space_left()) [[likely]] {
             auto ret = _current->data + _current->frag_size;
             _current->frag_size += size;
             _size += size;
@@ -249,7 +249,7 @@ public:
         }
 
         auto this_size = std::min(v.size(), size_t(current_space_left()));
-        if (__builtin_expect(this_size, true)) {
+        if (this_size) [[likely]] {
             memcpy(_current->data + _current->frag_size, v.begin(), this_size);
             _current->frag_size += this_size;
             _size += this_size;

--- a/db/large_data_handler.hh
+++ b/db/large_data_handler.hh
@@ -81,7 +81,7 @@ public:
     future<bool> maybe_record_large_rows(const sstables::sstable& sst, const sstables::key& partition_key,
             const clustering_key_prefix* clustering_key, uint64_t row_size) {
         SCYLLA_ASSERT(running());
-        if (__builtin_expect(row_size > _row_threshold_bytes, false)) {
+        if (row_size > _row_threshold_bytes) [[unlikely]] {
             return with_sem([&sst, &partition_key, clustering_key, row_size, this] {
                 return record_large_rows(sst, partition_key, clustering_key, row_size);
             }).then([] {
@@ -101,7 +101,7 @@ public:
     future<bool> maybe_record_large_cells(const sstables::sstable& sst, const sstables::key& partition_key,
             const clustering_key_prefix* clustering_key, const column_definition& cdef, uint64_t cell_size, uint64_t collection_elements) {
         SCYLLA_ASSERT(running());
-        if (__builtin_expect(cell_size > _cell_threshold_bytes || collection_elements > _collection_elements_count_threshold, false)) {
+        if (cell_size > _cell_threshold_bytes || collection_elements > _collection_elements_count_threshold) [[unlikely]] {
             return with_sem([&sst, &partition_key, clustering_key, &cdef, cell_size, collection_elements, this] {
                 return record_large_cells(sst, partition_key, clustering_key, cdef, cell_size, collection_elements);
             }).then([] {

--- a/mutation/mutation_fragment_stream_validator.cc
+++ b/mutation/mutation_fragment_stream_validator.cc
@@ -325,7 +325,7 @@ bool mutation_fragment_stream_validating_filter::operator()(mutation_fragment_v2
         res = _validator(kind, new_current_tombstone);
     }
 
-    if (__builtin_expect(!res->is_valid(), false)) {
+    if (!res->is_valid()) [[unlikely]] {
         return on_validation_error(validator_log, *this, *res);
     }
 

--- a/readers/mutation_reader.hh
+++ b/readers/mutation_reader.hh
@@ -639,7 +639,7 @@ public:
     // Causes this reader to conform to s.
     // Multiple calls of upgrade_schema() compose, effects of prior calls on the stream are preserved.
     void upgrade_schema(const schema_ptr& s) {
-        if (__builtin_expect(s != schema(), false)) {
+        if (s != schema()) [[unlikely]] {
             do_upgrade_schema(s);
         }
     }

--- a/sstables/consumer.hh
+++ b/sstables/consumer.hh
@@ -344,7 +344,7 @@ public:
     // Feeds data into the state machine.
     // After the call, when data is not empty then active() can be assumed to be false.
     read_status consume(Buffer& data) {
-        if (__builtin_expect(_prestate == prestate::NONE, true)) {
+        if (_prestate == prestate::NONE) [[likely]] {
             return read_status::ready;
         }
         // We're in the middle of reading a basic type, which crossed
@@ -556,12 +556,12 @@ public:
     inline processing_result process(temporary_buffer<char>& data) {
         while (data || (!primitive_consumer::active() && non_consuming())) {
             // The primitive_consumer must finish before the enclosing state machine can continue.
-            if (__builtin_expect(primitive_consumer::consume(data) == read_status::waiting, false)) {
+            if (primitive_consumer::consume(data) == read_status::waiting) [[unlikely]] {
                 sstables::parse_assert(data.size() == 0);
                 return proceed::yes;
             }
             auto ret = state_processor().process_state(data);
-            if (__builtin_expect(ret != proceed::yes, 0)) {
+            if (ret != proceed::yes) [[unlikely]] {
                 return ret;
             }
         }

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -1618,7 +1618,7 @@ std::unique_ptr<cql_server::response>
 make_result(int16_t stream, messages::result_message& msg, const tracing::trace_state_ptr& tr_state,
         cql_protocol_version_type version, cql_metadata_id_wrapper&& metadata_id, bool skip_metadata) {
     auto response = std::make_unique<cql_server::response>(stream, cql_binary_opcode::RESULT, tr_state);
-    if (__builtin_expect(!msg.warnings().empty() && version > 3, false)) {
+    if (!msg.warnings().empty() && version > 3) [[unlikely]] {
         response->set_frame_flag(cql_frame_flags::warning);
         response->write_string_list(msg.warnings());
     }

--- a/utils/fragment_range.hh
+++ b/utils/fragment_range.hh
@@ -136,7 +136,7 @@ decltype(auto) with_linearized(const FragmentedBuffer& buffer, Function&& fn)
 {
     bytes b;
     bytes_view bv;
-    if (__builtin_expect(!buffer.empty() && std::next(buffer.begin()) == buffer.end(), true)) {
+    if (!buffer.empty() && std::next(buffer.begin()) == buffer.end()) [[likely]] {
         bv = *buffer.begin();
     } else if (!buffer.empty()) {
         b = linearized(buffer);

--- a/utils/fragmented_temporary_buffer.hh
+++ b/utils/fragmented_temporary_buffer.hh
@@ -337,7 +337,7 @@ private:
     template<typename ExceptionThrower>
     requires fragmented_temporary_buffer_concepts::ExceptionThrower<ExceptionThrower>
     void check_out_of_range(ExceptionThrower& exceptions, size_t n) {
-        if (__builtin_expect(bytes_left() < n, false)) {
+        if (bytes_left() < n) [[unlikely]] {
             exceptions.throw_out_of_range(n, bytes_left());
             // Let's allow skipping this check if the user trusts its input
             // data.
@@ -398,7 +398,7 @@ public:
     }
 
     void skip(size_t n) noexcept {
-        if (__builtin_expect(contig_remain() < n, false)) {
+        if (contig_remain() < n) [[unlikely]] {
             return skip_slow(n);
         }
         _current_position += n;
@@ -407,7 +407,7 @@ public:
     template<typename T, typename ExceptionThrower = default_exception_thrower>
     requires fragmented_temporary_buffer_concepts::ExceptionThrower<ExceptionThrower>
     T read(ExceptionThrower&& exceptions = default_exception_thrower()) {
-        if (__builtin_expect(contig_remain() < sizeof(T), false)) {
+        if (contig_remain() < sizeof(T)) [[unlikely]] {
             return read_slow<T>(std::forward<ExceptionThrower>(exceptions));
         }
         T obj;
@@ -419,7 +419,7 @@ public:
     template<typename Output, typename ExceptionThrower = default_exception_thrower>
     requires fragmented_temporary_buffer_concepts::ExceptionThrower<ExceptionThrower>
     Output read_to(size_t n, Output out, ExceptionThrower&& exceptions = default_exception_thrower()) {
-        if (__builtin_expect(contig_remain() >= n, true)) {
+        if (contig_remain() >= n) [[likely]] {
             out = std::copy_n(_current_position, n, out);
             _current_position += n;
             return out;
@@ -441,7 +441,7 @@ public:
     template<typename ExceptionThrower = default_exception_thrower>
     requires fragmented_temporary_buffer_concepts::ExceptionThrower<ExceptionThrower>
     view read_view(size_t n, ExceptionThrower&& exceptions = default_exception_thrower()) {
-        if (__builtin_expect(contig_remain() >= n, true)) {
+        if (contig_remain() >= n) [[likely]] {
             auto v = view(_current, _current_position - _current->get(), n);
             _current_position += n;
             return v;
@@ -461,7 +461,7 @@ public:
     template<typename ExceptionThrower = default_exception_thrower>
     requires fragmented_temporary_buffer_concepts::ExceptionThrower<ExceptionThrower>
     bytes_view read_bytes_view(size_t n, bytes_ostream& linearization_buffer, ExceptionThrower&& exceptions = default_exception_thrower()) {
-        if (__builtin_expect(contig_remain() >= n, true)) {
+        if (contig_remain() >= n) [[likely]] {
             auto v = bytes_view(reinterpret_cast<const bytes::value_type*>(_current_position), n);
             _current_position += n;
             return v;

--- a/utils/gz/crc_combine.cc
+++ b/utils/gz/crc_combine.cc
@@ -136,7 +136,7 @@ u32 mul_by_x_pow_mul8(u32 p, u64 e) {
 
     u32 x0 = crc32_x_pow_radix_8_table_base_0[e & 0xff];
 
-    if (__builtin_expect(e < 0x100, false)) {
+    if (e < 0x100) [[unlikely]] {
         return pmul_mod(p, x0);
     }
 
@@ -148,14 +148,14 @@ u32 mul_by_x_pow_mul8(u32 p, u64 e) {
     u32 z0 = crc32_fold_barrett_u64(y0);
     u32 z1 = crc32_fold_barrett_u64(y1);
 
-    if (__builtin_expect(e < 0x1000000, true)) {
+    if (e < 0x1000000) [[likely]] {
         return pmul_mod(z0, z1);
     }
 
     u32 x3 = crc32_x_pow_radix_8_table_base_24[(e >> 24) & 0xff];
     z1 = pmul_mod(z1, x3);
 
-    if (__builtin_expect(e < 0x100000000, true)) {
+    if (e < 0x100000000) [[likely]] {
         return pmul_mod(z0, z1);
     }
 

--- a/utils/result_try.hh
+++ b/utils/result_try.hh
@@ -567,7 +567,7 @@ result_futurize_try(Fun&& fun, Handlers&&... handlers) {
         }, handlers...);
     });
 
-    if (!__builtin_expect(no_exceptions, true)) {
+    if (!no_exceptions) [[unlikely]] {
         // There were C++ exceptions, and we handled them already
         return f;
     }

--- a/utils/small_vector.hh
+++ b/utils/small_vector.hh
@@ -106,7 +106,7 @@ private:
     }
 
     void reserve_at_least(size_t n) {
-        if (__builtin_expect(n > capacity(), false)) {
+        if (n > capacity()) [[unlikely]] {
             expand(std::max(n, capacity() * 2));
         }
     }
@@ -202,7 +202,7 @@ public:
     small_vector& operator=(small_vector&& other) noexcept {
         clear();
         if (other.uses_internal_storage()) {
-            if (__builtin_expect(!uses_internal_storage(), false)) {
+            if (!uses_internal_storage()) [[unlikely]] {
                 std::free(_begin);
                 _begin = _internal.storage;
             }
@@ -222,7 +222,7 @@ public:
             }
             other._end = other._internal.storage;
         } else {
-            if (__builtin_expect(!uses_internal_storage(), false)) {
+            if (!uses_internal_storage()) [[unlikely]] {
                 std::free(_begin);
             }
             _begin = std::exchange(other._begin, other._internal.storage);
@@ -246,7 +246,7 @@ public:
 
     ~small_vector() {
         clear();
-        if (__builtin_expect(!uses_internal_storage(), false)) {
+        if (!uses_internal_storage()) [[unlikely]] {
             std::free(_begin);
         }
     }
@@ -263,7 +263,7 @@ public:
     }
 
     void reserve(size_t n) {
-        if (__builtin_expect(n > capacity(), false)) {
+        if (n > capacity()) [[unlikely]] {
             expand(n);
         }
     }
@@ -302,13 +302,13 @@ public:
     const T& operator[](size_t idx) const noexcept { return data()[idx]; }
 
     T& at(size_t idx) {
-        if (__builtin_expect(idx >= size(), false)) {
+        if (idx >= size()) [[unlikely]] {
             throw_out_of_range();
         }
         return operator[](idx);
     }
     const T& at(size_t idx) const {
-        if (__builtin_expect(idx >= size(), false)) {
+        if (idx >= size()) [[unlikely]] {
             throw_out_of_range();
         }
         return operator[](idx);
@@ -320,7 +320,7 @@ public:
 
     template<typename... Args>
     T& emplace_back(Args&&... args) {
-        if (__builtin_expect(_end == _capacity_end, false)) {
+        if (_end == _capacity_end) [[unlikely]] {
             expand(std::max<size_t>(capacity() * 2, 1));
         }
         auto& ref = *new (_end) T(std::forward<Args>(args)...);
@@ -347,7 +347,7 @@ public:
             reserve_at_least(size() + new_count);
             auto pos = _begin + idx;
             auto after = std::distance(pos, end());
-            if (__builtin_expect(pos == end(), true)) {
+            if (pos == end()) [[likely]] {
                 _end = std::uninitialized_copy(first, last, end());
                 return pos;
             } else if (after > new_count) {

--- a/vint-serialization.cc
+++ b/vint-serialization.cc
@@ -122,7 +122,7 @@ uint64_t unsigned_vint::deserialize(bytes_view v) {
     uint64_t value;
     // If we can overread do that. It is cheaper to have a single 64-bit read and
     // then mask out the unneeded part than to do 8x 1 byte reads.
-    if (__builtin_expect(len >= sizeof(uint64_t) + 1, true)) {
+    if (len >= sizeof(uint64_t) + 1) [[likely]] {
         std::copy_n(src + 1, sizeof(uint64_t), reinterpret_cast<int8_t*>(&value));
     } else {
         value = 0;


### PR DESCRIPTION
C++20 introduced two new attributes--likely and unlikely--that
function as a built-in replacement for __builtin_expect implemented
in various compilers. Since it makes code easier to read and it's
an integral part of the language, there's no reason to not use it
instead.

Backport: not needed. This is a code cleanup.