### PR TITLE
utils: chunked_vector: mark destructor noexcept

### DIFF
--- a/utils/chunked_vector.hh
+++ b/utils/chunked_vector.hh
@@ -110,7 +110,7 @@ public:
 
     chunked_vector(std::initializer_list<T> x);
     explicit chunked_vector(size_t n, const T& value = T());
-    ~chunked_vector();
+    ~chunked_vector() noexcept;
     chunked_vector& operator=(const chunked_vector& x);
     // Moving a chunked_vector invalidates all iterators to it
     chunked_vector& operator=(chunked_vector&& x) noexcept;
@@ -446,7 +446,7 @@ chunked_vector<T, max_contiguous_allocation>::operator=(chunked_vector&& x) noex
 }
 
 template <typename T, size_t max_contiguous_allocation>
-chunked_vector<T, max_contiguous_allocation>::~chunked_vector() {
+chunked_vector<T, max_contiguous_allocation>::~chunked_vector() noexcept {
     // This assert logically belongs as a constraint on T, but then
     // we can't forward-declare typedefs that use chunked_vector<T> on
     // an incomplete type T.


### PR DESCRIPTION
The destructor doesn't throw (well, at least if T's destructor doesn't throw, but that's a given), so mark it as such.

Practically all code assumes destructors don't throw, so this doesn't make much of a difference, but it's cleaner this way.

This minor bug was present since chunked_vector was introduced (3ba2c0652d6) and hasn't caused problems, so no need to backport it.