### PR TITLE
everywhere: use utils::chunked_vector for list of mutations

### DIFF
--- a/alternator/ttl.cc
+++ b/alternator/ttl.cc
@@ -286,7 +286,7 @@ static future<> expire_item(service::storage_proxy& proxy,
         auto ck = clustering_key::from_exploded(exploded_ck);
         m.partition().clustered_row(*schema, ck).apply(tombstone(ts, gc_clock::now()));
     }
-    std::vector<mutation> mutations;
+    utils::chunked_vector<mutation> mutations;
     mutations.push_back(std::move(m));
     return proxy.mutate(std::move(mutations),
         db::consistency_level::LOCAL_QUORUM,

--- a/auth/common.cc
+++ b/auth/common.cc
@@ -126,7 +126,7 @@ future<> create_legacy_metadata_table_if_missing(
 
 static future<> announce_mutations_with_guard(
         ::service::raft_group0_client& group0_client,
-        std::vector<canonical_mutation> muts,
+        utils::chunked_vector<canonical_mutation> muts,
         ::service::group0_guard group0_guard,
         seastar::abort_source& as,
         std::optional<::service::raft_timeout> timeout) {
@@ -154,7 +154,7 @@ future<> announce_mutations_with_batching(
     });
 
     size_t memory_usage = 0;
-    std::vector<canonical_mutation> muts;
+    utils::chunked_vector<canonical_mutation> muts;
 
     // guard has to be taken before we execute code in gen as
     // it can do read-before-write and we want announce_mutations
@@ -204,7 +204,7 @@ future<> announce_mutations(
             internal_distributed_query_state(),
             timestamp,
             std::move(values));
-    std::vector<canonical_mutation> cmuts = {muts.begin(), muts.end()};
+    utils::chunked_vector<canonical_mutation> cmuts = {muts.begin(), muts.end()};
     co_await announce_mutations_with_guard(group0_client, std::move(cmuts), std::move(group0_guard), as, timeout);
 }
 

--- a/cdc/log.hh
+++ b/cdc/log.hh
@@ -75,13 +75,13 @@ public:
     // appropriate augments to set the log entries.
     // Iff post-image is enabled for any of these, a non-empty callback is also
     // returned to be invoked post the mutation query.
-    future<std::tuple<std::vector<mutation>, lw_shared_ptr<operation_result_tracker>>> augment_mutation_call(
+    future<std::tuple<utils::chunked_vector<mutation>, lw_shared_ptr<operation_result_tracker>>> augment_mutation_call(
         lowres_clock::time_point timeout,
-        std::vector<mutation>&& mutations,
+        utils::chunked_vector<mutation>&& mutations,
         tracing::trace_state_ptr tr_state,
         db::consistency_level write_cl
         );
-    bool needs_cdc_augmentation(const std::vector<mutation>&) const;
+    bool needs_cdc_augmentation(const utils::chunked_vector<mutation>&) const;
 };
 
 struct db_context final {

--- a/cql3/query_processor.cc
+++ b/cql3/query_processor.cc
@@ -939,7 +939,7 @@ query_processor::execute_internal(
     }
 }
 
-future<std::vector<mutation>> query_processor::get_mutations_internal(
+future<utils::chunked_vector<mutation>> query_processor::get_mutations_internal(
         const sstring query_string,
         service::query_state& query_state,
         api::timestamp_type timestamp,

--- a/cql3/query_processor.hh
+++ b/cql3/query_processor.hh
@@ -384,7 +384,7 @@ public:
     // function enables putting multiple CQL queries into a single raft command
     // and vice versa, split mutations from one query into separate commands.
     // It supports write-only queries, read-modified-writes not supported.
-    future<std::vector<mutation>> get_mutations_internal(
+    future<utils::chunked_vector<mutation>> get_mutations_internal(
         const sstring query_string,
         service::query_state& query_state,
         api::timestamp_type timestamp,

--- a/cql3/statements/alter_keyspace_statement.cc
+++ b/cql3/statements/alter_keyspace_statement.cc
@@ -201,7 +201,7 @@ cql3::statements::alter_keyspace_statement::prepare_schema_mutations(query_proce
         const auto tmptr = qp.proxy().get_token_metadata_ptr();
         const auto& feat = qp.proxy().features();
         auto ks_md_update = _attrs->as_ks_metadata_update(ks_md, *tmptr, feat);
-        std::vector<mutation> muts;
+        utils::chunked_vector<mutation> muts;
         std::vector<sstring> warnings;
         auto old_ks_options = get_old_options_flattened(ks);
         auto ks_options = get_current_options_flattened(_attrs, feat);

--- a/cql3/statements/alter_table_statement.cc
+++ b/cql3/statements/alter_table_statement.cc
@@ -411,7 +411,7 @@ std::pair<schema_ptr, std::vector<view_ptr>> alter_table_statement::prepare_sche
     return make_pair(cfm.build(), std::move(view_updates));
 }
 
-future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, std::vector<mutation>, cql3::cql_warnings_vec>>
+future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, utils::chunked_vector<mutation>, cql3::cql_warnings_vec>>
 alter_table_statement::prepare_schema_mutations(query_processor& qp, const query_options& options, api::timestamp_type ts) const {
   data_dictionary::database db = qp.db();
   auto [s, view_updates] = prepare_schema_update(db, options);

--- a/cql3/statements/alter_table_statement.hh
+++ b/cql3/statements/alter_table_statement.hh
@@ -64,7 +64,7 @@ public:
     virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats) override;
     virtual future<::shared_ptr<messages::result_message>> execute(query_processor& qp, service::query_state& state, const query_options& options, std::optional<service::group0_guard> guard) const override;
 
-    future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, std::vector<mutation>, cql3::cql_warnings_vec>> prepare_schema_mutations(query_processor& qp, const query_options& options, api::timestamp_type) const override;
+    future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, utils::chunked_vector<mutation>, cql3::cql_warnings_vec>> prepare_schema_mutations(query_processor& qp, const query_options& options, api::timestamp_type) const override;
 private:
     void add_column(const query_options& options, const schema& schema, data_dictionary::table cf, schema_builder& cfm, std::vector<view_ptr>& view_updates, const column_identifier& column_name, const cql3_type validator, const column_definition* def, bool is_static) const;
     void alter_column(const query_options& options, const schema& schema, data_dictionary::table cf, schema_builder& cfm, std::vector<view_ptr>& view_updates, const column_identifier& column_name, const cql3_type validator, const column_definition* def, bool is_static) const;

--- a/cql3/statements/alter_type_statement.cc
+++ b/cql3/statements/alter_type_statement.cc
@@ -46,8 +46,8 @@ const sstring& alter_type_statement::keyspace() const
     return _name.get_keyspace();
 }
 
-future<std::vector<mutation>> alter_type_statement::prepare_announcement_mutations(service::storage_proxy& sp, api::timestamp_type ts) const {
-    std::vector<mutation> m;
+future<utils::chunked_vector<mutation>> alter_type_statement::prepare_announcement_mutations(service::storage_proxy& sp, api::timestamp_type ts) const {
+    utils::chunked_vector<mutation> m;
     auto&& ks = sp.data_dictionary().find_keyspace(keyspace());
     auto&& all_types = ks.metadata()->user_types().get_all_types();
     auto to_update = all_types.find(_name.get_user_type_name());
@@ -96,7 +96,7 @@ future<std::vector<mutation>> alter_type_statement::prepare_announcement_mutatio
     co_return m;
 }
 
-future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, std::vector<mutation>, cql3::cql_warnings_vec>>
+future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, utils::chunked_vector<mutation>, cql3::cql_warnings_vec>>
 alter_type_statement::prepare_schema_mutations(query_processor& qp, const query_options&, api::timestamp_type ts) const {
     try {
         auto m = co_await prepare_announcement_mutations(qp.proxy(), ts);

--- a/cql3/statements/alter_type_statement.hh
+++ b/cql3/statements/alter_type_statement.hh
@@ -35,14 +35,14 @@ public:
     virtual const sstring& keyspace() const override;
 
 
-    future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, std::vector<mutation>, cql3::cql_warnings_vec>> prepare_schema_mutations(query_processor& qp, const query_options& options, api::timestamp_type) const override;
+    future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, utils::chunked_vector<mutation>, cql3::cql_warnings_vec>> prepare_schema_mutations(query_processor& qp, const query_options& options, api::timestamp_type) const override;
 
     class add_or_alter;
     class renames;
 protected:
     virtual user_type make_updated_type(data_dictionary::database db, user_type to_update) const = 0;
 private:
-    future<std::vector<mutation>> prepare_announcement_mutations(service::storage_proxy& sp, api::timestamp_type) const;
+    future<utils::chunked_vector<mutation>> prepare_announcement_mutations(service::storage_proxy& sp, api::timestamp_type) const;
 };
 
 class alter_type_statement::add_or_alter : public alter_type_statement {

--- a/cql3/statements/alter_view_statement.cc
+++ b/cql3/statements/alter_view_statement.cc
@@ -75,7 +75,7 @@ view_ptr alter_view_statement::prepare_view(data_dictionary::database db) const 
     return view_ptr(builder.build());
 }
 
-future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, std::vector<mutation>, cql3::cql_warnings_vec>> alter_view_statement::prepare_schema_mutations(query_processor& qp, const query_options&, api::timestamp_type ts) const {
+future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, utils::chunked_vector<mutation>, cql3::cql_warnings_vec>> alter_view_statement::prepare_schema_mutations(query_processor& qp, const query_options&, api::timestamp_type ts) const {
     auto m = co_await service::prepare_view_update_announcement(qp.proxy(), prepare_view(qp.db()), ts);
 
     using namespace cql_transport;

--- a/cql3/statements/alter_view_statement.hh
+++ b/cql3/statements/alter_view_statement.hh
@@ -33,7 +33,7 @@ public:
 
     virtual future<> check_access(query_processor& qp, const service::client_state& state) const override;
 
-    future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, std::vector<mutation>, cql3::cql_warnings_vec>> prepare_schema_mutations(query_processor& qp, const query_options& options, api::timestamp_type) const override;
+    future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, utils::chunked_vector<mutation>, cql3::cql_warnings_vec>> prepare_schema_mutations(query_processor& qp, const query_options& options, api::timestamp_type) const override;
 
     virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats) override;
 };

--- a/cql3/statements/batch_statement.hh
+++ b/cql3/statements/batch_statement.hh
@@ -108,7 +108,7 @@ public:
 
     const std::vector<single_statement>& get_statements();
 private:
-    future<std::vector<mutation>> get_mutations(query_processor& qp, const query_options& options, db::timeout_clock::time_point timeout,
+    future<utils::chunked_vector<mutation>> get_mutations(query_processor& qp, const query_options& options, db::timeout_clock::time_point timeout,
             bool local, api::timestamp_type now, service::query_state& query_state) const;
 
 public:
@@ -116,7 +116,7 @@ public:
      * Checks batch size to ensure threshold is met. If not, a warning is logged.
      * @param cfs ColumnFamilies that will store the batch's mutations.
      */
-    static void verify_batch_size(query_processor& qp, const std::vector<mutation>& mutations);
+    static void verify_batch_size(query_processor& qp, const utils::chunked_vector<mutation>& mutations);
 
     virtual future<shared_ptr<cql_transport::messages::result_message>> execute(
             query_processor& qp, service::query_state& state, const query_options& options, std::optional<service::group0_guard> guard) const override;
@@ -132,7 +132,7 @@ private:
 
     future<exceptions::coordinator_result<>> execute_without_conditions(
             query_processor& qp,
-            std::vector<mutation> mutations,
+            utils::chunked_vector<mutation> mutations,
             db::consistency_level cl,
             db::timeout_clock::time_point timeout,
             tracing::trace_state_ptr tr_state,

--- a/cql3/statements/cas_request.cc
+++ b/cql3/statements/cas_request.cc
@@ -44,7 +44,7 @@ std::optional<mutation> cas_request::apply_updates(api::timestamp_type ts) const
     for (const cas_row_update& op: _updates) {
         update_parameters params(_schema, op.options, ts, op.statement.get_time_to_live(op.options), _rows);
 
-        std::vector<mutation> statement_mutations = op.statement.apply_updates(_key, op.ranges, params, op.json_cache);
+        auto statement_mutations = op.statement.apply_updates(_key, op.ranges, params, op.json_cache);
         // Append all mutations (in fact only one) to the consolidated one.
         for (mutation& m : statement_mutations) {
             if (mutation_set.has_value() == false) {

--- a/cql3/statements/create_aggregate_statement.cc
+++ b/cql3/statements/create_aggregate_statement.cc
@@ -82,10 +82,10 @@ std::unique_ptr<prepared_statement> create_aggregate_statement::prepare(data_dic
     return std::make_unique<prepared_statement>(audit_info(), make_shared<create_aggregate_statement>(*this));
 }
 
-future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, std::vector<mutation>, cql3::cql_warnings_vec>>
+future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, utils::chunked_vector<mutation>, cql3::cql_warnings_vec>>
 create_aggregate_statement::prepare_schema_mutations(query_processor& qp, const query_options&, api::timestamp_type ts) const {
     ::shared_ptr<cql_transport::event::schema_change> ret;
-    std::vector<mutation> m;
+    utils::chunked_vector<mutation> m;
 
     auto aggregate = dynamic_pointer_cast<functions::user_aggregate>(co_await validate_while_executing(qp));
     if (aggregate) {

--- a/cql3/statements/create_aggregate_statement.hh
+++ b/cql3/statements/create_aggregate_statement.hh
@@ -25,7 +25,7 @@ namespace statements {
 
 class create_aggregate_statement final : public create_function_statement_base {
     virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats) override;
-    future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, std::vector<mutation>, cql3::cql_warnings_vec>> prepare_schema_mutations(query_processor& qp, const query_options& options, api::timestamp_type) const override;
+    future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, utils::chunked_vector<mutation>, cql3::cql_warnings_vec>> prepare_schema_mutations(query_processor& qp, const query_options& options, api::timestamp_type) const override;
     virtual future<> check_access(query_processor& qp, const service::client_state& state) const override;
 
     virtual seastar::future<shared_ptr<db::functions::function>> create(query_processor& qp, db::functions::function* old) const override;

--- a/cql3/statements/create_function_statement.cc
+++ b/cql3/statements/create_function_statement.cc
@@ -58,10 +58,10 @@ std::unique_ptr<prepared_statement> create_function_statement::prepare(data_dict
     return std::make_unique<prepared_statement>(audit_info(), make_shared<create_function_statement>(*this));
 }
 
-future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, std::vector<mutation>, cql3::cql_warnings_vec>>
+future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, utils::chunked_vector<mutation>, cql3::cql_warnings_vec>>
 create_function_statement::prepare_schema_mutations(query_processor& qp, const query_options&, api::timestamp_type ts) const {
     ::shared_ptr<cql_transport::event::schema_change> ret;
-    std::vector<mutation> m;
+    utils::chunked_vector<mutation> m;
 
     auto func = dynamic_pointer_cast<functions::user_function>(co_await validate_while_executing(qp));
 

--- a/cql3/statements/create_function_statement.hh
+++ b/cql3/statements/create_function_statement.hh
@@ -24,7 +24,7 @@ namespace statements {
 
 class create_function_statement final : public create_function_statement_base {
     virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats) override;
-    future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, std::vector<mutation>, cql3::cql_warnings_vec>> prepare_schema_mutations(query_processor& qp, const query_options& options, api::timestamp_type) const override;
+    future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, utils::chunked_vector<mutation>, cql3::cql_warnings_vec>> prepare_schema_mutations(query_processor& qp, const query_options& options, api::timestamp_type) const override;
 
     virtual seastar::future<shared_ptr<db::functions::function>> create(query_processor& qp, db::functions::function* old) const override;
     sstring _language;

--- a/cql3/statements/create_index_statement.cc
+++ b/cql3/statements/create_index_statement.cc
@@ -388,13 +388,13 @@ std::optional<create_index_statement::base_schema_with_new_index> create_index_s
     return base_schema_with_new_index{builder.build(), index};
 }
 
-future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, std::vector<mutation>, cql3::cql_warnings_vec>>
+future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, utils::chunked_vector<mutation>, cql3::cql_warnings_vec>>
 create_index_statement::prepare_schema_mutations(query_processor& qp, const query_options&, api::timestamp_type ts) const {
     using namespace cql_transport;
     auto res = build_index_schema(qp.db());
 
     ::shared_ptr<event::schema_change> ret;
-    std::vector<mutation> m;
+    utils::chunked_vector<mutation> m;
 
     if (res) {
         m = co_await service::prepare_column_family_update_announcement(qp.proxy(), std::move(res->schema), {}, ts);

--- a/cql3/statements/create_index_statement.hh
+++ b/cql3/statements/create_index_statement.hh
@@ -44,7 +44,7 @@ public:
 
     future<> check_access(query_processor& qp, const service::client_state& state) const override;
     void validate(query_processor&, const service::client_state& state) const override;
-    future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, std::vector<mutation>, cql3::cql_warnings_vec>> prepare_schema_mutations(query_processor& qp, const query_options& options, api::timestamp_type) const override;
+    future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, utils::chunked_vector<mutation>, cql3::cql_warnings_vec>> prepare_schema_mutations(query_processor& qp, const query_options& options, api::timestamp_type) const override;
 
 
     virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats) override;

--- a/cql3/statements/create_keyspace_statement.cc
+++ b/cql3/statements/create_keyspace_statement.cc
@@ -90,12 +90,12 @@ void create_keyspace_statement::validate(query_processor& qp, const service::cli
 #endif
 }
 
-future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, std::vector<mutation>, cql3::cql_warnings_vec>> create_keyspace_statement::prepare_schema_mutations(query_processor& qp, const query_options&, api::timestamp_type ts) const {
+future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, utils::chunked_vector<mutation>, cql3::cql_warnings_vec>> create_keyspace_statement::prepare_schema_mutations(query_processor& qp, const query_options&, api::timestamp_type ts) const {
     using namespace cql_transport;
     const auto tmptr = qp.proxy().get_token_metadata_ptr();
     const auto& feat = qp.proxy().features();
     const auto& cfg = qp.db().get_config();
-    std::vector<mutation> m;
+    utils::chunked_vector<mutation> m;
     std::vector<sstring> warnings;
 
     try {

--- a/cql3/statements/create_keyspace_statement.hh
+++ b/cql3/statements/create_keyspace_statement.hh
@@ -69,7 +69,7 @@ public:
     virtual void validate(query_processor&, const service::client_state& state) const override;
 
 
-    future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, std::vector<mutation>, cql3::cql_warnings_vec>> prepare_schema_mutations(query_processor& qp, const query_options& options, api::timestamp_type) const override;
+    future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, utils::chunked_vector<mutation>, cql3::cql_warnings_vec>> prepare_schema_mutations(query_processor& qp, const query_options& options, api::timestamp_type) const override;
 
     virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats) override;
 

--- a/cql3/statements/create_table_statement.cc
+++ b/cql3/statements/create_table_statement.cc
@@ -70,9 +70,9 @@ std::vector<column_definition> create_table_statement::get_columns() const
     return column_defs;
 }
 
-future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, std::vector<mutation>, cql3::cql_warnings_vec>>
+future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, utils::chunked_vector<mutation>, cql3::cql_warnings_vec>>
 create_table_statement::prepare_schema_mutations(query_processor& qp, const query_options&, api::timestamp_type ts) const {
-    std::vector<mutation> m;
+    utils::chunked_vector<mutation> m;
 
     try {
         m = co_await service::prepare_new_column_family_announcement(qp.proxy(), get_cf_meta_data(qp.db()), ts);

--- a/cql3/statements/create_table_statement.hh
+++ b/cql3/statements/create_table_statement.hh
@@ -69,7 +69,7 @@ public:
 
     virtual future<> check_access(query_processor& qp, const service::client_state& state) const override;
 
-    future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, std::vector<mutation>, cql3::cql_warnings_vec>> prepare_schema_mutations(query_processor& qp, const query_options& options, api::timestamp_type) const override;
+    future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, utils::chunked_vector<mutation>, cql3::cql_warnings_vec>> prepare_schema_mutations(query_processor& qp, const query_options& options, api::timestamp_type) const override;
 
     virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats) override;
 

--- a/cql3/statements/create_type_statement.cc
+++ b/cql3/statements/create_type_statement.cc
@@ -118,8 +118,8 @@ std::optional<user_type> create_type_statement::make_type(query_processor& qp) c
     return type;
 }
 
-future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, std::vector<mutation>, cql3::cql_warnings_vec>> create_type_statement::prepare_schema_mutations(query_processor& qp, const query_options&, api::timestamp_type ts) const {
-    std::vector<mutation> m;
+future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, utils::chunked_vector<mutation>, cql3::cql_warnings_vec>> create_type_statement::prepare_schema_mutations(query_processor& qp, const query_options&, api::timestamp_type ts) const {
+    utils::chunked_vector<mutation> m;
     try {
         auto t = make_type(qp);
         if (t) {

--- a/cql3/statements/create_type_statement.hh
+++ b/cql3/statements/create_type_statement.hh
@@ -41,7 +41,7 @@ public:
 
     virtual const sstring& keyspace() const override;
 
-    future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, std::vector<mutation>, cql3::cql_warnings_vec>> prepare_schema_mutations(query_processor& qp, const query_options& options, api::timestamp_type) const override;
+    future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, utils::chunked_vector<mutation>, cql3::cql_warnings_vec>> prepare_schema_mutations(query_processor& qp, const query_options& options, api::timestamp_type) const override;
 
     virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats) override;
 

--- a/cql3/statements/create_view_statement.cc
+++ b/cql3/statements/create_view_statement.cc
@@ -383,9 +383,9 @@ std::pair<view_ptr, cql3::cql_warnings_vec> create_view_statement::prepare_view(
     return std::make_pair(view_ptr(builder.build()), std::move(warnings));
 }
 
-future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, std::vector<mutation>, cql3::cql_warnings_vec>>
+future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, utils::chunked_vector<mutation>, cql3::cql_warnings_vec>>
 create_view_statement::prepare_schema_mutations(query_processor& qp, const query_options&, api::timestamp_type ts) const {
-    std::vector<mutation> m;
+    utils::chunked_vector<mutation> m;
     auto [definition, warnings] = prepare_view(qp.db());
     try {
         m = co_await service::prepare_new_view_announcement(qp.proxy(), std::move(definition), ts);

--- a/cql3/statements/create_view_statement.hh
+++ b/cql3/statements/create_view_statement.hh
@@ -56,7 +56,7 @@ public:
 
     // Functions we need to override to subclass schema_altering_statement
     virtual future<> check_access(query_processor& qp, const service::client_state& state) const override;
-    future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, std::vector<mutation>, cql3::cql_warnings_vec>> prepare_schema_mutations(query_processor& qp, const query_options& options, api::timestamp_type) const override;
+    future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, utils::chunked_vector<mutation>, cql3::cql_warnings_vec>> prepare_schema_mutations(query_processor& qp, const query_options& options, api::timestamp_type) const override;
 
     virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats) override;
 

--- a/cql3/statements/drop_index_statement.cc
+++ b/cql3/statements/drop_index_statement.cc
@@ -71,10 +71,10 @@ schema_ptr drop_index_statement::make_drop_idex_schema(query_processor& qp) cons
     return builder.build();
 }
 
-future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, std::vector<mutation>, cql3::cql_warnings_vec>>
+future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, utils::chunked_vector<mutation>, cql3::cql_warnings_vec>>
 drop_index_statement::prepare_schema_mutations(query_processor& qp, const query_options&, api::timestamp_type ts) const {
     ::shared_ptr<cql_transport::event::schema_change> ret;
-    std::vector<mutation> m;
+    utils::chunked_vector<mutation> m;
     auto cfm = make_drop_idex_schema(qp);
 
     if (cfm) {

--- a/cql3/statements/drop_index_statement.hh
+++ b/cql3/statements/drop_index_statement.hh
@@ -44,7 +44,7 @@ public:
 
     virtual void validate(query_processor&, const service::client_state& state) const override;
 
-    future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, std::vector<mutation>, cql3::cql_warnings_vec>> prepare_schema_mutations(query_processor& qp, const query_options& options, api::timestamp_type) const override;
+    future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, utils::chunked_vector<mutation>, cql3::cql_warnings_vec>> prepare_schema_mutations(query_processor& qp, const query_options& options, api::timestamp_type) const override;
 
     virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats) override;
 private:

--- a/cql3/statements/drop_type_statement.cc
+++ b/cql3/statements/drop_type_statement.cc
@@ -124,10 +124,10 @@ const sstring& drop_type_statement::keyspace() const
     return _name.get_keyspace();
 }
 
-future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, std::vector<mutation>, cql3::cql_warnings_vec>>
+future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, utils::chunked_vector<mutation>, cql3::cql_warnings_vec>>
 drop_type_statement::prepare_schema_mutations(query_processor& qp, const query_options&, api::timestamp_type ts) const {
     ::shared_ptr<cql_transport::event::schema_change> ret;
-    std::vector<mutation> m;
+    utils::chunked_vector<mutation> m;
 
     if (validate_while_executing(qp)) {
         data_dictionary::database db = qp.db();

--- a/cql3/statements/drop_type_statement.hh
+++ b/cql3/statements/drop_type_statement.hh
@@ -29,7 +29,7 @@ public:
 
     virtual const sstring& keyspace() const override;
 
-    future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, std::vector<mutation>, cql3::cql_warnings_vec>> prepare_schema_mutations(query_processor& qp, const query_options& options, api::timestamp_type) const override;
+    future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, utils::chunked_vector<mutation>, cql3::cql_warnings_vec>> prepare_schema_mutations(query_processor& qp, const query_options& options, api::timestamp_type) const override;
 
 
     virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats) override;

--- a/cql3/statements/drop_view_statement.cc
+++ b/cql3/statements/drop_view_statement.cc
@@ -41,10 +41,10 @@ future<> drop_view_statement::check_access(query_processor& qp, const service::c
     return make_ready_future<>();
 }
 
-future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, std::vector<mutation>, cql3::cql_warnings_vec>>
+future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, utils::chunked_vector<mutation>, cql3::cql_warnings_vec>>
 drop_view_statement::prepare_schema_mutations(query_processor& qp, const query_options&, api::timestamp_type ts) const {
     ::shared_ptr<cql_transport::event::schema_change> ret;
-    std::vector<mutation> m;
+    utils::chunked_vector<mutation> m;
 
     try {
         m = co_await service::prepare_view_drop_announcement(qp.proxy(), keyspace(), column_family(), ts);

--- a/cql3/statements/drop_view_statement.hh
+++ b/cql3/statements/drop_view_statement.hh
@@ -32,7 +32,7 @@ public:
 
     virtual future<> check_access(query_processor& qp, const service::client_state& state) const override;
 
-    future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, std::vector<mutation>, cql3::cql_warnings_vec>> prepare_schema_mutations(query_processor& qp, const query_options& options, api::timestamp_type) const override;
+    future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, utils::chunked_vector<mutation>, cql3::cql_warnings_vec>> prepare_schema_mutations(query_processor& qp, const query_options& options, api::timestamp_type) const override;
 
     virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats) override;
 };

--- a/cql3/statements/modification_statement.hh
+++ b/cql3/statements/modification_statement.hh
@@ -200,7 +200,7 @@ public:
     // A single mutation object for lightweight transactions, which can only span one partition, or a vector
     // of mutations, one per partition key, for statements which affect multiple partition keys,
     // e.g. DELETE FROM table WHERE pk  IN (1, 2, 3).
-    std::vector<mutation> apply_updates(
+    utils::chunked_vector<mutation> apply_updates(
             const std::vector<dht::partition_range>& keys,
             const std::vector<query::clustering_range>& ranges,
             const update_parameters& params,
@@ -252,7 +252,7 @@ public:
      * @return vector of the mutations
      * @throws invalid_request_exception on invalid requests
      */
-    future<std::vector<mutation>> get_mutations(query_processor& qp, const query_options& options, db::timeout_clock::time_point timeout, bool local, int64_t now, service::query_state& qs, json_cache_opt& json_cache, std::vector<dht::partition_range> keys) const;
+    future<utils::chunked_vector<mutation>> get_mutations(query_processor& qp, const query_options& options, db::timeout_clock::time_point timeout, bool local, int64_t now, service::query_state& qs, json_cache_opt& json_cache, std::vector<dht::partition_range> keys) const;
 
     virtual json_cache_opt maybe_prepare_json_cache(const query_options& options) const;
 

--- a/cql3/statements/schema_altering_statement.cc
+++ b/cql3/statements/schema_altering_statement.cc
@@ -80,10 +80,10 @@ schema_altering_statement::execute(query_processor& qp, service::query_state& st
     co_return std::move(result);
 }
 
-future<std::tuple<::shared_ptr<schema_altering_statement::event_t>, std::vector<mutation>, cql3::cql_warnings_vec>> schema_altering_statement::prepare_schema_mutations(query_processor& qp, const query_options& options, api::timestamp_type) const {
+future<std::tuple<::shared_ptr<schema_altering_statement::event_t>, utils::chunked_vector<mutation>, cql3::cql_warnings_vec>> schema_altering_statement::prepare_schema_mutations(query_processor& qp, const query_options& options, api::timestamp_type) const {
     // derived class must implement one of prepare_schema_mutations overloads
     on_internal_error(logger, "not implemented");
-    co_return std::make_tuple(::shared_ptr<event_t>(nullptr), std::vector<mutation>{}, cql3::cql_warnings_vec{});
+    co_return std::make_tuple(::shared_ptr<event_t>(nullptr), utils::chunked_vector<mutation>{}, cql3::cql_warnings_vec{});
 }
 
 future<std::tuple<::shared_ptr<schema_altering_statement::event_t>, cql3::cql_warnings_vec>> schema_altering_statement::prepare_schema_mutations(query_processor& qp, service::query_state& state, const query_options& options, service::group0_batch& mc) const {

--- a/cql3/statements/schema_altering_statement.hh
+++ b/cql3/statements/schema_altering_statement.hh
@@ -65,7 +65,7 @@ public:
     virtual future<> grant_permissions_to_creator(const service::client_state&, service::group0_batch&) const;
 
     using event_t = cql_transport::event::schema_change;
-    virtual future<std::tuple<::shared_ptr<event_t>, std::vector<mutation>, cql3::cql_warnings_vec>> prepare_schema_mutations(query_processor& qp, const query_options& options, api::timestamp_type) const;
+    virtual future<std::tuple<::shared_ptr<event_t>, utils::chunked_vector<mutation>, cql3::cql_warnings_vec>> prepare_schema_mutations(query_processor& qp, const query_options& options, api::timestamp_type) const;
     virtual future<std::tuple<::shared_ptr<event_t>, cql3::cql_warnings_vec>> prepare_schema_mutations(query_processor& qp, service::query_state& state, const query_options& options, service::group0_batch& mc) const;
 };
 

--- a/db/batchlog_manager.cc
+++ b/db/batchlog_manager.cc
@@ -201,14 +201,14 @@ future<> db::batchlog_manager::replay_all_failed_batches(post_replay_cleanup cle
             const auto& cf = _qp.proxy().local_db().find_column_family(fm.column_family_id());
             return make_ready_future<canonical_mutation*>(written_at > cf.get_truncation_time() ? &fm : nullptr);
         },
-        std::vector<mutation>(),
-        [this] (std::vector<mutation> mutations, canonical_mutation* fm) {
+        utils::chunked_vector<mutation>(),
+        [this] (utils::chunked_vector<mutation> mutations, canonical_mutation* fm) {
             if (fm) {
                 schema_ptr s = _qp.db().find_schema(fm->column_family_id());
                 mutations.emplace_back(fm->to_mutation(s));
             }
             return mutations;
-        }).then([this, limiter, written_at, size, fms] (std::vector<mutation> mutations) {
+        }).then([this, limiter, written_at, size, fms] (utils::chunked_vector<mutation> mutations) {
             if (mutations.empty()) {
                 return make_ready_future<>();
             }

--- a/db/legacy_schema_migrator.cc
+++ b/db/legacy_schema_migrator.cc
@@ -536,7 +536,7 @@ public:
         mlogger.info("Moving {} keyspaces from legacy schema tables to the new schema keyspace ({})",
                         _keyspaces.size(), db::schema_tables::v3::NAME);
 
-        std::vector<mutation> mutations;
+        utils::chunked_vector<mutation> mutations;
 
         for (auto& ks : _keyspaces) {
             auto ksm = ::make_lw_shared<keyspace_metadata>(ks.name

--- a/db/schema_applier.cc
+++ b/db/schema_applier.cc
@@ -752,7 +752,7 @@ static future<> merge_aggregates(distributed<service::storage_proxy>& proxy, con
     });
 }
 
-static future<> do_merge_schema(distributed<service::storage_proxy>& proxy, sharded<db::system_keyspace>& sys_ks, std::vector<mutation> mutations, bool reload)
+static future<> do_merge_schema(distributed<service::storage_proxy>& proxy, sharded<db::system_keyspace>& sys_ks, utils::chunked_vector<mutation> mutations, bool reload)
 {
     slogger.trace("do_merge_schema: {}", mutations);
     schema_ptr s = keyspaces();
@@ -848,7 +848,7 @@ static future<> do_merge_schema(distributed<service::storage_proxy>& proxy, shar
  * @throws ConfigurationException If one of metadata attributes has invalid value
  * @throws IOException If data was corrupted during transportation or failed to apply fs operations
  */
-future<> merge_schema(sharded<db::system_keyspace>& sys_ks, distributed<service::storage_proxy>& proxy, gms::feature_service& feat, std::vector<mutation> mutations, bool reload)
+future<> merge_schema(sharded<db::system_keyspace>& sys_ks, distributed<service::storage_proxy>& proxy, gms::feature_service& feat, utils::chunked_vector<mutation> mutations, bool reload)
 {
     if (this_shard_id() != 0) {
         // mutations must be applied on the owning shard (0).

--- a/db/schema_applier.hh
+++ b/db/schema_applier.hh
@@ -20,7 +20,7 @@ namespace db {
 
 namespace schema_tables {
 
-future<> merge_schema(sharded<db::system_keyspace>& sys_ks, distributed<service::storage_proxy>& proxy, gms::feature_service& feat, std::vector<mutation> mutations, bool reload = false);
+future<> merge_schema(sharded<db::system_keyspace>& sys_ks, distributed<service::storage_proxy>& proxy, gms::feature_service& feat, utils::chunked_vector<mutation> mutations, bool reload = false);
 
 }
 

--- a/db/schema_tables.hh
+++ b/db/schema_tables.hh
@@ -227,22 +227,22 @@ future<std::optional<table_schema_version>> get_group0_schema_version(db::system
 // of feature_service and schema tables.
 future<> recalculate_schema_version(sharded<db::system_keyspace>& sys_ks, distributed<service::storage_proxy>& proxy, gms::feature_service& feat);
 
-future<std::vector<canonical_mutation>> convert_schema_to_mutations(distributed<service::storage_proxy>& proxy, schema_features);
-std::vector<mutation> adjust_schema_for_schema_features(std::vector<mutation> schema, schema_features features);
+future<utils::chunked_vector<canonical_mutation>> convert_schema_to_mutations(distributed<service::storage_proxy>& proxy, schema_features);
+utils::chunked_vector<mutation> adjust_schema_for_schema_features(utils::chunked_vector<mutation> schema, schema_features features);
 
 future<schema_result_value_type>
 read_schema_partition_for_keyspace(distributed<service::storage_proxy>& proxy, sstring schema_table_name, sstring keyspace_name);
 future<mutation> read_keyspace_mutation(distributed<service::storage_proxy>&, const sstring& keyspace_name);
 
-std::vector<mutation> make_create_keyspace_mutations(schema_features features, lw_shared_ptr<keyspace_metadata> keyspace, api::timestamp_type timestamp, bool with_tables_and_types_and_functions = true);
+utils::chunked_vector<mutation> make_create_keyspace_mutations(schema_features features, lw_shared_ptr<keyspace_metadata> keyspace, api::timestamp_type timestamp, bool with_tables_and_types_and_functions = true);
 
-std::vector<mutation> make_drop_keyspace_mutations(schema_features features, lw_shared_ptr<keyspace_metadata> keyspace, api::timestamp_type timestamp);
+utils::chunked_vector<mutation> make_drop_keyspace_mutations(schema_features features, lw_shared_ptr<keyspace_metadata> keyspace, api::timestamp_type timestamp);
 
 future<lw_shared_ptr<keyspace_metadata>> create_keyspace_from_schema_partition(distributed<service::storage_proxy>& proxy, const schema_result_value_type& partition, lw_shared_ptr<query::result_set> scylla_specific_rs = nullptr);
 
 future<lw_shared_ptr<query::result_set>> extract_scylla_specific_keyspace_info(distributed<service::storage_proxy>& proxy, const schema_result_value_type& partition);
 
-std::vector<mutation> make_create_type_mutations(lw_shared_ptr<keyspace_metadata> keyspace, user_type type, api::timestamp_type timestamp);
+utils::chunked_vector<mutation> make_create_type_mutations(lw_shared_ptr<keyspace_metadata> keyspace, user_type type, api::timestamp_type timestamp);
 
 // Given a set of rows that is sorted by keyspace, create types for each keyspace.
 // The topological sort in each keyspace is necessary when creating types, since we can only create a type when the
@@ -261,21 +261,21 @@ shared_ptr<cql3::functions::user_aggregate> create_aggregate(replica::database& 
 
 std::vector<shared_ptr<cql3::functions::user_aggregate>> create_aggregates_from_schema_partition(replica::database& db, lw_shared_ptr<query::result_set> result, lw_shared_ptr<query::result_set> scylla_result, cql3::functions::change_batch& batch);
 
-std::vector<mutation> make_create_function_mutations(shared_ptr<cql3::functions::user_function> func, api::timestamp_type timestamp);
+utils::chunked_vector<mutation> make_create_function_mutations(shared_ptr<cql3::functions::user_function> func, api::timestamp_type timestamp);
 
-std::vector<mutation> make_drop_function_mutations(shared_ptr<cql3::functions::user_function> func, api::timestamp_type timestamp);
+utils::chunked_vector<mutation> make_drop_function_mutations(shared_ptr<cql3::functions::user_function> func, api::timestamp_type timestamp);
 
-std::vector<mutation> make_create_aggregate_mutations(schema_features features, shared_ptr<cql3::functions::user_aggregate> func, api::timestamp_type timestamp);
+utils::chunked_vector<mutation> make_create_aggregate_mutations(schema_features features, shared_ptr<cql3::functions::user_aggregate> func, api::timestamp_type timestamp);
 
-std::vector<mutation> make_drop_aggregate_mutations(schema_features features, shared_ptr<cql3::functions::user_aggregate> aggregate, api::timestamp_type timestamp);
+utils::chunked_vector<mutation> make_drop_aggregate_mutations(schema_features features, shared_ptr<cql3::functions::user_aggregate> aggregate, api::timestamp_type timestamp);
 
-std::vector<mutation> make_drop_type_mutations(lw_shared_ptr<keyspace_metadata> keyspace, user_type type, api::timestamp_type timestamp);
+utils::chunked_vector<mutation> make_drop_type_mutations(lw_shared_ptr<keyspace_metadata> keyspace, user_type type, api::timestamp_type timestamp);
 
-void add_type_to_schema_mutation(user_type type, api::timestamp_type timestamp, std::vector<mutation>& mutations);
+void add_type_to_schema_mutation(user_type type, api::timestamp_type timestamp, utils::chunked_vector<mutation>& mutations);
 
-std::vector<mutation> make_create_table_mutations(schema_ptr table, api::timestamp_type timestamp);
+utils::chunked_vector<mutation> make_create_table_mutations(schema_ptr table, api::timestamp_type timestamp);
 
-std::vector<mutation> make_update_table_mutations(
+utils::chunked_vector<mutation> make_update_table_mutations(
     replica::database& db,
     lw_shared_ptr<keyspace_metadata> keyspace,
     schema_ptr old_table,
@@ -284,7 +284,7 @@ std::vector<mutation> make_update_table_mutations(
 
 future<std::map<sstring, schema_ptr>> create_tables_from_tables_partition(distributed<service::storage_proxy>& proxy, const schema_result::mapped_type& result);
 
-std::vector<mutation> make_drop_table_mutations(lw_shared_ptr<keyspace_metadata> keyspace, schema_ptr table, api::timestamp_type timestamp);
+utils::chunked_vector<mutation> make_drop_table_mutations(lw_shared_ptr<keyspace_metadata> keyspace, schema_ptr table, api::timestamp_type timestamp);
 
 schema_ptr create_table_from_mutations(const schema_ctxt&, schema_mutations, std::optional<table_schema_version> version = {});
 
@@ -296,13 +296,13 @@ future<std::vector<view_ptr>> create_views_from_schema_partition(distributed<ser
 schema_mutations make_schema_mutations(schema_ptr s, api::timestamp_type timestamp, bool with_columns);
 mutation make_scylla_tables_mutation(schema_ptr, api::timestamp_type timestamp);
 
-void add_table_or_view_to_schema_mutation(schema_ptr view, api::timestamp_type timestamp, bool with_columns, std::vector<mutation>& mutations);
+void add_table_or_view_to_schema_mutation(schema_ptr view, api::timestamp_type timestamp, bool with_columns, utils::chunked_vector<mutation>& mutations);
 
-std::vector<mutation> make_create_view_mutations(lw_shared_ptr<keyspace_metadata> keyspace, view_ptr view, api::timestamp_type timestamp);
+utils::chunked_vector<mutation> make_create_view_mutations(lw_shared_ptr<keyspace_metadata> keyspace, view_ptr view, api::timestamp_type timestamp);
 
-std::vector<mutation> make_update_view_mutations(lw_shared_ptr<keyspace_metadata> keyspace, view_ptr old_view, view_ptr new_view, api::timestamp_type timestamp, bool include_base);
+utils::chunked_vector<mutation> make_update_view_mutations(lw_shared_ptr<keyspace_metadata> keyspace, view_ptr old_view, view_ptr new_view, api::timestamp_type timestamp, bool include_base);
 
-std::vector<mutation> make_drop_view_mutations(lw_shared_ptr<keyspace_metadata> keyspace, view_ptr view, api::timestamp_type timestamp);
+utils::chunked_vector<mutation> make_drop_view_mutations(lw_shared_ptr<keyspace_metadata> keyspace, view_ptr view, api::timestamp_type timestamp);
 
 void check_no_legacy_secondary_index_mv_schema(replica::database& db, const view_ptr& v, schema_ptr base_schema);
 

--- a/db/size_estimates_virtual_reader.cc
+++ b/db/size_estimates_virtual_reader.cc
@@ -243,7 +243,7 @@ future<> size_estimates_mutation_reader::get_next_partition() {
         auto estimates = this->estimates_for_current_keyspace(std::move(ranges));
         auto mutations = db::system_keyspace::make_size_estimates_mutation(*_current_partition, std::move(estimates));
         ++_current_partition;
-        std::vector<mutation> ms;
+        utils::chunked_vector<mutation> ms;
         ms.emplace_back(std::move(mutations));
         auto reader = make_mutation_reader_from_mutations(_schema, _permit, std::move(ms), _fwd);
         auto close_partition_reader = _partition_reader ? _partition_reader->close() : make_ready_future<>();

--- a/db/system_distributed_keyspace.cc
+++ b/db/system_distributed_keyspace.cc
@@ -268,7 +268,7 @@ future<> system_distributed_keyspace::create_tables(std::vector<schema_ptr> tabl
 
         auto group0_guard = co_await _mm.start_group0_operation();
         auto ts = group0_guard.write_timestamp();
-        std::vector<mutation> mutations;
+        utils::chunked_vector<mutation> mutations;
         sstring description;
 
         auto sd_ksm = keyspace_metadata::new_keyspace(
@@ -582,14 +582,14 @@ system_distributed_keyspace::read_cdc_generation(utils::UUID id) {
     co_return std::optional{cdc::topology_description(std::move(entries))};
 }
 
-static future<std::vector<mutation>> get_cdc_streams_descriptions_v2_mutation(
+static future<utils::chunked_vector<mutation>> get_cdc_streams_descriptions_v2_mutation(
         const replica::database& db,
         db_clock::time_point time,
         const cdc::topology_description& desc) {
     auto s = db.find_schema(system_distributed_keyspace::NAME, system_distributed_keyspace::CDC_DESC_V2);
 
     auto ts = api::new_timestamp();
-    std::vector<mutation> res;
+    utils::chunked_vector<mutation> res;
     res.emplace_back(s, partition_key::from_singular(*s, time));
     size_t size_estimate = 0;
     for (auto& e : desc.entries()) {

--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -2532,7 +2532,7 @@ static future<> announce_with_raft(
                 view_builder_query_state(),
                 timestamp,
                 values);
-        std::vector<canonical_mutation> cmuts = {muts.begin(), muts.end()};
+        utils::chunked_vector<canonical_mutation> cmuts = {muts.begin(), muts.end()};
 
         auto group0_cmd = group0_client.prepare_command(
             ::service::write_mutations{
@@ -2785,7 +2785,7 @@ future<> view_builder::do_build_step() {
     });
 }
 
-future<> view_builder::generate_mutations_on_node_left(replica::database& db, db::system_keyspace& sys_ks, api::timestamp_type timestamp, locator::host_id host_id, std::vector<canonical_mutation>& muts) {
+future<> view_builder::generate_mutations_on_node_left(replica::database& db, db::system_keyspace& sys_ks, api::timestamp_type timestamp, locator::host_id host_id, utils::chunked_vector<canonical_mutation>& muts) {
     // When a node is removed, we delete all its rows from the view_build_status table together with
     // the topology update operation.
 
@@ -2859,7 +2859,7 @@ future<> view_builder::migrate_to_v2(locator::token_metadata_ptr tmptr, db::syst
         val_binders_str += ", ?";
     }
 
-    std::vector<mutation> migration_muts;
+    utils::chunked_vector<mutation> migration_muts;
     migration_muts.reserve(rows->size() + 1);
 
     // Insert all valid rows into the new table.

--- a/db/view/view_builder.hh
+++ b/db/view/view_builder.hh
@@ -218,7 +218,7 @@ public:
      */
     future<> stop();
 
-    static future<> generate_mutations_on_node_left(replica::database& db, db::system_keyspace& sys_ks, api::timestamp_type timestamp, locator::host_id host_id, std::vector<canonical_mutation>& muts);
+    static future<> generate_mutations_on_node_left(replica::database& db, db::system_keyspace& sys_ks, api::timestamp_type timestamp, locator::host_id host_id, utils::chunked_vector<canonical_mutation>& muts);
 
     static future<> migrate_to_v1_5(locator::token_metadata_ptr tmptr, db::system_keyspace& sys_ks, cql3::query_processor& qp, service::raft_group0_client& group0_client, abort_source& as, service::group0_guard guard);
     static future<> migrate_to_v2(locator::token_metadata_ptr tmptr, db::system_keyspace& sys_ks, cql3::query_processor& qp, service::raft_group0_client& group0_client, abort_source& as, service::group0_guard guard);

--- a/db/virtual_tables.cc
+++ b/db/virtual_tables.cc
@@ -75,12 +75,12 @@ public:
     }
 
     future<> execute(std::function<void(mutation)> mutation_sink) override {
-        auto muts = co_await _dist_ss.invoke_on(0, [this] (service::storage_service& ss) -> future<std::vector<frozen_mutation>> {
+        auto muts = co_await _dist_ss.invoke_on(0, [this] (service::storage_service& ss) -> future<utils::chunked_vector<frozen_mutation>> {
             auto& gossiper = _dist_gossiper.local();
             auto ownership = co_await ss.get_ownership();
             const locator::token_metadata& tm = ss.get_token_metadata();
 
-            std::vector<frozen_mutation> muts;
+            utils::chunked_vector<frozen_mutation> muts;
             muts.reserve(gossiper.num_endpoints());
 
             gossiper.for_each_endpoint_state([&] (const gms::endpoint_state& eps) {

--- a/idl/group0_state_machine.idl.hh
+++ b/idl/group0_state_machine.idl.hh
@@ -8,6 +8,7 @@
 
 #include "raft/raft.hh"
 #include "gms/inet_address_serializer.hh"
+#include "utils/chunked_vector.hh"
 
 #include "idl/frozen_schema.idl.hh"
 #include "idl/uuid.idl.hh"
@@ -16,7 +17,7 @@
 namespace service {
 
 struct schema_change {
-    std::vector<canonical_mutation> mutations;
+    utils::chunked_vector<canonical_mutation> mutations;
 };
 
 struct broadcast_table_query {
@@ -24,15 +25,15 @@ struct broadcast_table_query {
 };
 
 struct topology_change {
-    std::vector<canonical_mutation> mutations;
+    utils::chunked_vector<canonical_mutation> mutations;
 };
 
 struct mixed_change {
-    std::vector<canonical_mutation> mutations;
+    utils::chunked_vector<canonical_mutation> mutations;
 };
 
 struct write_mutations {
-    std::vector<canonical_mutation> mutations;
+    utils::chunked_vector<canonical_mutation> mutations;
 };
 
 struct group0_command {

--- a/idl/migration_manager.idl.hh
+++ b/idl/migration_manager.idl.hh
@@ -6,11 +6,13 @@
  * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
  */
 
+#include "utils/chunked_vector.hh"
+
 #include "idl/frozen_mutation.idl.hh"
 #include "idl/frozen_schema.idl.hh"
 #include "idl/messaging_service.idl.hh"
 
-verb [[with_client_info, cancellable]] migration_request (netw::schema_pull_options options [[version 3.2.0]]) -> std::vector<frozen_mutation>, std::vector<canonical_mutation> [[version 3.2.0]]
+verb [[with_client_info, cancellable]] migration_request (netw::schema_pull_options options [[version 3.2.0]]) -> utils::chunked_vector<frozen_mutation>, utils::chunked_vector<canonical_mutation> [[version 3.2.0]]
 verb get_schema_version (unsigned shard, table_schema_version version) -> frozen_schema
 verb [[cancellable]] schema_check () -> table_schema_version
-verb [[with_client_info, one_way]] definitions_update (std::vector<frozen_mutation> fm, std::vector<canonical_mutation> cm [[version 3.2.0]])
+verb [[with_client_info, one_way]] definitions_update (utils::chunked_vector<frozen_mutation> fm, utils::chunked_vector<canonical_mutation> cm [[version 3.2.0]])

--- a/idl/storage_proxy.idl.hh
+++ b/idl/storage_proxy.idl.hh
@@ -10,6 +10,7 @@
 #include "message/messaging_service.hh"
 
 #include "gms/inet_address_serializer.hh"
+#include "utils/chunked_vector.hh"
 
 #include "idl/frozen_mutation.idl.hh"
 #include "idl/tracing.idl.hh"
@@ -27,7 +28,7 @@
 verb [[with_client_info, with_timeout, one_way]] mutation (frozen_mutation fm [[ref]], inet_address_vector_replica_set forward [[ref]], gms::inet_address reply_to, unsigned shard, uint64_t response_id, std::optional<tracing::trace_info> trace_info [[ref]] [[version 1.3.0]], db::per_partition_rate_limit::info rate_limit_info [[version 5.1.0]], service::fencing_token fence [[version 5.4.0]], host_id_vector_replica_set forward_id [[ref, version 6.3.0]], locator::host_id reply_to_id [[version 6.3.0]]);
 verb [[with_client_info, one_way]] mutation_done (unsigned shard, uint64_t response_id, db::view::update_backlog backlog [[version 3.1.0]]);
 verb [[with_client_info, one_way]] mutation_failed (unsigned shard, uint64_t response_id, size_t num_failed, db::view::update_backlog backlog [[version 3.1.0]], replica::exception_variant exception [[version 5.1.0]]);
-verb [[with_client_info, with_timeout]] counter_mutation (std::vector<frozen_mutation> fms, db::consistency_level cl, std::optional<tracing::trace_info> trace_info [[ref]], service::fencing_token fence [[version 5.4.0]]) -> replica::exception_variant [[version 5.4.0]];
+verb [[with_client_info, with_timeout]] counter_mutation (utils::chunked_vector<frozen_mutation> fms, db::consistency_level cl, std::optional<tracing::trace_info> trace_info [[ref]], service::fencing_token fence [[version 5.4.0]]) -> replica::exception_variant [[version 5.4.0]];
 verb [[with_client_info, with_timeout, one_way]] hint_mutation (frozen_mutation fm [[ref]], inet_address_vector_replica_set forward [[ref]], gms::inet_address reply_to, unsigned shard, uint64_t response_id, std::optional<tracing::trace_info> trace_info [[ref]] [[version 1.3.0]] /* this verb was mistakenly introduced with optional trace_info */, service::fencing_token fence [[version 5.4.0]], host_id_vector_replica_set forward_id [[ref, version 6.3.0]], locator::host_id reply_to_id [[version 6.3.0]]);
 verb [[with_client_info, with_timeout]] read_data (query::read_command cmd [[ref]], ::compat::wrapping_partition_range pr, query::digest_algorithm digest [[version 3.0.0]], db::per_partition_rate_limit::info rate_limit_info [[version 5.1.0]], service::fencing_token fence [[version 5.4.0]]) -> query::result [[lw_shared_ptr]], cache_temperature [[version 2.0.0]], replica::exception_variant [[version 5.1.0]];
 verb [[with_client_info, with_timeout]] read_mutation_data (query::read_command cmd [[ref]], ::compat::wrapping_partition_range pr, service::fencing_token fence [[version 5.4.0]]) -> reconcilable_result [[lw_shared_ptr]], cache_temperature [[version 2.0.0]], replica::exception_variant [[version 5.1.0]];

--- a/main.cc
+++ b/main.cc
@@ -1677,7 +1677,7 @@ sharded<locator::shared_token_metadata> token_metadata;
                 ~sstable_dict_deleter() {
                     _mn.unregister_listener(this).get();
                 }
-                void on_before_drop_column_family(const schema& s, std::vector<mutation>& mutations, api::timestamp_type) override {
+                void on_before_drop_column_family(const schema& s, utils::chunked_vector<mutation>& mutations, api::timestamp_type) override {
                     if (_feat.sstable_compression_dicts) {
                         mutations.push_back(db::system_keyspace::get_delete_dict_mutation(fmt::format("sstables/{}", s.id()), api::max_timestamp));
                     }

--- a/mutation/async_utils.cc
+++ b/mutation/async_utils.cc
@@ -144,8 +144,8 @@ unfreeze_gently(const frozen_mutation& fm, schema_ptr schema) {
     co_return m;
 }
 
-future<std::vector<mutation>> unfreeze_gently(std::span<frozen_mutation> muts) {
-    std::vector<mutation> result;
+future<utils::chunked_vector<mutation>> unfreeze_gently(const utils::chunked_vector<frozen_mutation>& muts) {
+    utils::chunked_vector<mutation> result;
     result.reserve(muts.size());
     for (auto& fm : muts) {
         result.push_back(co_await unfreeze_gently(fm, local_schema_registry().get(fm.schema_version())));

--- a/mutation/async_utils.hh
+++ b/mutation/async_utils.hh
@@ -42,4 +42,4 @@ future<canonical_mutation> make_canonical_mutation_gently(const mutation& m);
 future<frozen_mutation> freeze_gently(const mutation& m);
 future<mutation> unfreeze_gently(const frozen_mutation& fm, schema_ptr schema);
 // Caller is responsible for keeping the argument stable in memory
-future<std::vector<mutation>> unfreeze_gently(std::span<frozen_mutation>);
+future<utils::chunked_vector<mutation>> unfreeze_gently(const utils::chunked_vector<frozen_mutation>&);

--- a/mutation/frozen_mutation.cc
+++ b/mutation/frozen_mutation.cc
@@ -117,16 +117,16 @@ frozen_mutation freeze(const mutation& m) {
     return frozen_mutation{ m };
 }
 
-std::vector<frozen_mutation> freeze(const std::vector<mutation>& muts) {
+utils::chunked_vector<frozen_mutation> freeze(const utils::chunked_vector<mutation>& muts) {
     return muts | std::views::transform([] (const mutation& m) {
         return freeze(m);
-    }) | std::ranges::to<std::vector<frozen_mutation>>();
+    }) | std::ranges::to<utils::chunked_vector<frozen_mutation>>();
 }
 
-std::vector<mutation> unfreeze(const std::vector<frozen_mutation>& muts) {
+utils::chunked_vector<mutation> unfreeze(const utils::chunked_vector<frozen_mutation>& muts) {
     return muts | std::views::transform([] (const frozen_mutation& fm) {
         return fm.unfreeze(local_schema_registry().get(fm.schema_version()));
-    }) | std::ranges::to<std::vector<mutation>>();
+    }) | std::ranges::to<utils::chunked_vector<mutation>>();
 }
 
 

--- a/mutation/frozen_mutation.hh
+++ b/mutation/frozen_mutation.hh
@@ -228,8 +228,8 @@ public:
 };
 
 frozen_mutation freeze(const mutation& m);
-std::vector<frozen_mutation> freeze(const std::vector<mutation>&);
-std::vector<mutation> unfreeze(const std::vector<frozen_mutation>&);
+utils::chunked_vector<frozen_mutation> freeze(const utils::chunked_vector<mutation>&);
+utils::chunked_vector<mutation> unfreeze(const utils::chunked_vector<frozen_mutation>&);
 
 struct frozen_mutation_and_schema {
     frozen_mutation fm;

--- a/mutation/mutation.cc
+++ b/mutation/mutation.cc
@@ -107,8 +107,8 @@ mutation_decorated_key_less_comparator::operator()(const mutation& m1, const mut
     return m1.decorated_key().less_compare(*m1.schema(), m2.decorated_key());
 }
 
-std::ranges::subrange<std::vector<mutation>::const_iterator>
-slice(const std::vector<mutation>& partitions, const dht::partition_range& r) {
+std::ranges::subrange<utils::chunked_vector<mutation>::const_iterator>
+slice(const utils::chunked_vector<mutation>& partitions, const dht::partition_range& r) {
     struct cmp {
         bool operator()(const dht::ring_position& pos, const mutation& m) const {
             return m.decorated_key().tri_compare(*m.schema(), pos) > 0;
@@ -212,7 +212,7 @@ class mutation_by_size_splitter {
         }
     };
     const schema_ptr _schema;
-    std::vector<mutation>& _target;
+    utils::chunked_vector<mutation>& _target;
     const size_t _max_size;
     std::optional<partition_state> _state;
     template <typename T>
@@ -234,7 +234,7 @@ class mutation_by_size_splitter {
         return stop_iteration::no;
     }
 public:
-    mutation_by_size_splitter(schema_ptr schema, std::vector<mutation>& target, size_t max_size)
+    mutation_by_size_splitter(schema_ptr schema, utils::chunked_vector<mutation>& target, size_t max_size)
         : _schema(std::move(schema))
         , _target(target)
         , _max_size(max_size)
@@ -278,7 +278,7 @@ public:
 };
 }
 
-future<> split_mutation(mutation source, std::vector<mutation>& target, size_t max_size) {
+future<> split_mutation(mutation source, utils::chunked_vector<mutation>& target, size_t max_size) {
     reader_concurrency_semaphore sem(reader_concurrency_semaphore::no_limits{}, "split_mutation",
         reader_concurrency_semaphore::register_metrics::no);
     {

--- a/mutation/mutation.hh
+++ b/mutation/mutation.hh
@@ -185,8 +185,8 @@ public:
     size_t memory_usage(const ::schema& s) const;
 };
 
-inline std::vector<mutation> make_mutation_vector(mutation&& m) {
-    std::vector<mutation> ret;
+inline utils::chunked_vector<mutation> make_mutation_vector(mutation&& m) {
+    utils::chunked_vector<mutation> ret;
     ret.emplace_back(std::move(m));
     return ret;
 }
@@ -452,8 +452,8 @@ void apply(mutation& dst, const mutation_opt& src) {
 // Returns a range into partitions containing mutations covered by the range.
 // partitions must be sorted according to decorated key.
 // range must not wrap around.
-std::ranges::subrange<std::vector<mutation>::const_iterator> slice(
-    const std::vector<mutation>& partitions,
+std::ranges::subrange<utils::chunked_vector<mutation>::const_iterator> slice(
+    const utils::chunked_vector<mutation>& partitions,
     const dht::partition_range&);
 
 // Reverses the mutation as if it was created with a schema with reverse
@@ -474,4 +474,4 @@ template <> struct fmt::formatter<mutation> : fmt::formatter<string_view> {
 // the actual size of the output mutation may be larger than max_size. It is recommended
 // to pass half of the required value as max_size; such a margin should ensure
 // that the condition is met.
-future<> split_mutation(mutation source, std::vector<mutation>& target, size_t max_size);
+future<> split_mutation(mutation source, utils::chunked_vector<mutation>& target, size_t max_size);

--- a/readers/from_mutations.hh
+++ b/readers/from_mutations.hh
@@ -43,7 +43,7 @@ make_mutation_reader_from_mutations(
 mutation_reader make_mutation_reader_from_mutations(
     schema_ptr schema,
     reader_permit permit,
-    std::vector<mutation>,
+    utils::chunked_vector<mutation>,
     const dht::partition_range& pr,
     streamed_mutation::forwarding fwd = streamed_mutation::forwarding::no);
 
@@ -51,7 +51,7 @@ mutation_reader make_mutation_reader_from_mutations(
 inline mutation_reader make_mutation_reader_from_mutations(
     schema_ptr schema,
     reader_permit permit,
-    std::vector<mutation> ms,
+    utils::chunked_vector<mutation> ms,
     streamed_mutation::forwarding fwd = streamed_mutation::forwarding::no) {
     if (ms.size() == 1) {
         return make_mutation_reader_from_mutations(std::move(schema), std::move(permit), std::move(ms.back()), fwd);
@@ -64,7 +64,7 @@ mutation_reader
 make_mutation_reader_from_mutations(
     schema_ptr schema,
     reader_permit permit,
-    std::vector<mutation> ms,
+    utils::chunked_vector<mutation> ms,
     const dht::partition_range& pr,
     const query::partition_slice& slice,
     streamed_mutation::forwarding fwd = streamed_mutation::forwarding::no);
@@ -74,7 +74,7 @@ inline mutation_reader
 make_mutation_reader_from_mutations(
     schema_ptr schema,
     reader_permit permit,
-    std::vector<mutation> ms,
+    utils::chunked_vector<mutation> ms,
     const query::partition_slice& slice,
     streamed_mutation::forwarding fwd = streamed_mutation::forwarding::no) {
     if (ms.size() == 1) {

--- a/redis/keyspace_utils.cc
+++ b/redis/keyspace_utils.cc
@@ -194,7 +194,7 @@ future<> create_keyspace_if_not_exists_impl(seastar::sharded<service::storage_pr
 
         auto group0_guard = co_await mml.start_group0_operation();
         auto ts = group0_guard.write_timestamp();
-        std::vector<mutation> mutations;
+        utils::chunked_vector<mutation> mutations;
 
         for (auto ksm: ksms) {
             if (db.has_keyspace(ksm->name())) {
@@ -206,7 +206,7 @@ future<> create_keyspace_if_not_exists_impl(seastar::sharded<service::storage_pr
         }
 
         auto table_gen = std::bind_front(
-                [] (data_dictionary::database db, service::storage_proxy& sp, std::vector<mutation>& mutations,
+                [] (data_dictionary::database db, service::storage_proxy& sp, utils::chunked_vector<mutation>& mutations,
                     api::timestamp_type ts, const keyspace_metadata& ksm, sstring cf_name, schema_ptr schema) -> future<> {
             if (db.has_schema(ksm.name(), cf_name)) {
                 co_return;

--- a/redis/mutation_utils.cc
+++ b/redis/mutation_utils.cc
@@ -50,7 +50,7 @@ future<> write_hashes(service::storage_proxy& proxy, redis::redis_options& optio
     m.set_clustered_cell(ckey, column, std::move(cell));
 
     auto write_consistency_level = options.get_write_consistency_level();
-    return proxy.mutate(std::vector<mutation> {std::move(m)}, write_consistency_level, timeout, nullptr, permit, db::allow_per_partition_rate_limit::yes);
+    return proxy.mutate(utils::chunked_vector<mutation> {std::move(m)}, write_consistency_level, timeout, nullptr, permit, db::allow_per_partition_rate_limit::yes);
 }
 
 
@@ -68,7 +68,7 @@ future<> write_strings(service::storage_proxy& proxy, redis::redis_options& opti
     db::timeout_clock::time_point timeout = db::timeout_clock::now() + options.get_write_timeout();
     auto m = make_mutation(proxy, options, std::move(key), std::move(data), ttl);
     auto write_consistency_level = options.get_write_consistency_level();
-    return proxy.mutate(std::vector<mutation> {std::move(m)}, write_consistency_level, timeout, nullptr, permit, db::allow_per_partition_rate_limit::yes);
+    return proxy.mutate(utils::chunked_vector<mutation> {std::move(m)}, write_consistency_level, timeout, nullptr, permit, db::allow_per_partition_rate_limit::yes);
 }
 
 
@@ -87,7 +87,7 @@ future<> delete_objects(service::storage_proxy& proxy, redis::redis_options& opt
     auto remove = [&proxy, timeout, write_consistency_level, permit, &options, keys = std::move(keys)] (const sstring& cf_name) {
         return parallel_for_each(keys.begin(), keys.end(), [&proxy, timeout, write_consistency_level, &options, permit, cf_name] (const bytes& key) {
             auto m = make_tombstone(proxy, options, cf_name, key);
-            return proxy.mutate(std::vector<mutation> {std::move(m)}, write_consistency_level, timeout, nullptr, permit, db::allow_per_partition_rate_limit::yes);
+            return proxy.mutate(utils::chunked_vector<mutation> {std::move(m)}, write_consistency_level, timeout, nullptr, permit, db::allow_per_partition_rate_limit::yes);
         });
     };  
     return parallel_for_each(tables.begin(), tables.end(), remove);
@@ -100,7 +100,7 @@ future<> delete_fields(service::storage_proxy& proxy, redis::redis_options& opti
     auto pkey = partition_key::from_single_value(*schema, key);
     auto ts = api::new_timestamp();
     auto clk = gc_clock::now();
-    std::vector<mutation> mutations;
+    utils::chunked_vector<mutation> mutations;
     for (auto& field : fields) {
         auto ckey = clustering_key::from_single_value(*schema, field);
         auto m = mutation(schema, pkey);

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -1968,7 +1968,7 @@ future<> database::apply_with_commitlog(column_family& cf, const mutation& m, db
     }
 }
 
-future<> database::apply(const std::vector<frozen_mutation>& muts, db::timeout_clock::time_point timeout) {
+future<> database::apply(const utils::chunked_vector<frozen_mutation>& muts, db::timeout_clock::time_point timeout) {
     if (timeout <= db::timeout_clock::now()) {
         update_write_metrics_for_timed_out_write();
         return make_exception_future<>(timed_out_error{});
@@ -1976,7 +1976,7 @@ future<> database::apply(const std::vector<frozen_mutation>& muts, db::timeout_c
     return update_write_metrics(do_apply_many(muts, timeout));
 }
 
-future<> database::do_apply_many(const std::vector<frozen_mutation>& muts, db::timeout_clock::time_point timeout) {
+future<> database::do_apply_many(const utils::chunked_vector<frozen_mutation>& muts, db::timeout_clock::time_point timeout) {
     std::vector<commitlog_entry_writer> writers;
     db::commitlog* cl = nullptr;
 

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1651,7 +1651,7 @@ private:
     auto sum_read_concurrency_sem_stat(std::invocable<reader_concurrency_semaphore::stats&> auto stats_member);
 
     future<> do_apply(schema_ptr, const frozen_mutation&, tracing::trace_state_ptr tr_state, db::timeout_clock::time_point timeout, db::commitlog_force_sync sync, db::per_partition_rate_limit::info rate_limit_info);
-    future<> do_apply_many(const std::vector<frozen_mutation>&, db::timeout_clock::time_point timeout);
+    future<> do_apply_many(const utils::chunked_vector<frozen_mutation>&, db::timeout_clock::time_point timeout);
     future<> apply_with_commitlog(column_family& cf, const mutation& m, db::timeout_clock::time_point timeout);
 
     future<mutation> do_apply_counter_update(column_family& cf, const frozen_mutation& fm, schema_ptr m_schema, db::timeout_clock::time_point timeout,
@@ -1821,7 +1821,7 @@ public:
     // All mutations must be owned by the current shard.
     // Mutations may be partially visible to reads during the call.
     // Mutations may be partially visible to reads until restart on exception (FIXME).
-    future<> apply(const std::vector<frozen_mutation>&, db::timeout_clock::time_point timeout);
+    future<> apply(const utils::chunked_vector<frozen_mutation>&, db::timeout_clock::time_point timeout);
     future<> apply_hint(schema_ptr, const frozen_mutation&, tracing::trace_state_ptr tr_state, db::timeout_clock::time_point timeout);
     future<mutation> apply_counter_update(schema_ptr, const frozen_mutation& m, db::timeout_clock::time_point timeout, tracing::trace_state_ptr trace_state);
     const sstring& get_snitch_name() const;

--- a/replica/tablets.hh
+++ b/replica/tablets.hh
@@ -77,7 +77,7 @@ future<> save_tablet_metadata(replica::database&, const locator::tablet_metadata
 /// Extract a tablet metadata change hint from the tablet mutations.
 ///
 /// Mutations which don't mutate the tablet table are ignored.
-std::optional<locator::tablet_metadata_change_hint> get_tablet_metadata_change_hint(const std::vector<canonical_mutation>&);
+std::optional<locator::tablet_metadata_change_hint> get_tablet_metadata_change_hint(const utils::chunked_vector<canonical_mutation>&);
 
 /// Update the tablet metadata change hint, with the changes represented by the tablet mutation.
 ///
@@ -100,12 +100,12 @@ future<std::unordered_set<locator::host_id>> read_required_hosts(cql3::query_pro
 future<> update_tablet_metadata(replica::database& db, cql3::query_processor&, locator::tablet_metadata&, const locator::tablet_metadata_change_hint&);
 
 /// Reads tablet metadata from system.tablets in the form of mutations.
-future<std::vector<canonical_mutation>> read_tablet_mutations(seastar::sharded<database>&);
+future<utils::chunked_vector<canonical_mutation>> read_tablet_mutations(seastar::sharded<database>&);
 
 /// Reads tablet transition stage (if any)
 future<std::optional<locator::tablet_transition_stage>> read_tablet_transition_stage(cql3::query_processor& qp, table_id tid, dht::token last_token);
 
 /// Validates changes to system.tablets represented by mutations
-void validate_tablet_metadata_change(const locator::tablet_metadata& tm, const std::vector<canonical_mutation>& mutations);
+void validate_tablet_metadata_change(const locator::tablet_metadata& tm, const utils::chunked_vector<canonical_mutation>& mutations);
 
 } // namespace replica

--- a/schema_mutations.cc
+++ b/schema_mutations.cc
@@ -29,7 +29,7 @@ schema_mutations::schema_mutations(canonical_mutation columnfamilies,
     , _scylla_tables(scylla_tables ? mutation_opt{scylla_tables.value().to_mutation(db::schema_tables::scylla_tables())} : std::nullopt)
 {}
 
-void schema_mutations::copy_to(std::vector<mutation>& dst) const {
+void schema_mutations::copy_to(utils::chunked_vector<mutation>& dst) const {
     dst.push_back(_columnfamilies);
     dst.push_back(_columns);
     if (_view_virtual_columns) {

--- a/schema_mutations.hh
+++ b/schema_mutations.hh
@@ -49,7 +49,7 @@ public:
     schema_mutations(const schema_mutations&) = default;
     schema_mutations& operator=(const schema_mutations&) = default;
 
-    void copy_to(std::vector<mutation>& dst) const;
+    void copy_to(utils::chunked_vector<mutation>& dst) const;
 
     const mutation& columnfamilies_mutation() const {
         return _columnfamilies;

--- a/service/migration_listener.hh
+++ b/service/migration_listener.hh
@@ -14,6 +14,7 @@
 #include <seastar/core/sstring.hh>
 #include <seastar/core/shared_ptr.hh>
 #include "utils/atomic_vector.hh"
+#include "utils/chunked_vector.hh"
 
 namespace data_dictionary {
 class keyspace_metadata;
@@ -80,11 +81,11 @@ public:
     // of the column family's keyspace. The reason for this is that we sometimes create a keyspace
     // and its column families together. Therefore, listeners can't load the keyspace from the
     // database. Instead, they should use the `ksm` parameter if needed.
-    virtual void on_before_create_column_family(const keyspace_metadata& ksm, const schema&, std::vector<mutation>&, api::timestamp_type) {}
-    virtual void on_before_create_column_families(const keyspace_metadata& ksm, const std::vector<schema_ptr>& cfms, std::vector<mutation>& mutations, api::timestamp_type timestamp);
-    virtual void on_before_update_column_family(const schema& new_schema, const schema& old_schema, std::vector<mutation>&, api::timestamp_type) {}
-    virtual void on_before_drop_column_family(const schema&, std::vector<mutation>&, api::timestamp_type) {}
-    virtual void on_before_drop_keyspace(const sstring& keyspace_name, std::vector<mutation>&, api::timestamp_type) {}
+    virtual void on_before_create_column_family(const keyspace_metadata& ksm, const schema&, utils::chunked_vector<mutation>&, api::timestamp_type) {}
+    virtual void on_before_create_column_families(const keyspace_metadata& ksm, const std::vector<schema_ptr>& cfms, utils::chunked_vector<mutation>& mutations, api::timestamp_type timestamp);
+    virtual void on_before_update_column_family(const schema& new_schema, const schema& old_schema, utils::chunked_vector<mutation>&, api::timestamp_type) {}
+    virtual void on_before_drop_column_family(const schema&, utils::chunked_vector<mutation>&, api::timestamp_type) {}
+    virtual void on_before_drop_keyspace(const sstring& keyspace_name, utils::chunked_vector<mutation>&, api::timestamp_type) {}
 
     class only_view_notifications;
     class empty_listener;
@@ -147,11 +148,11 @@ public:
     future<> drop_function(const db::functions::function_name& fun_name, const std::vector<data_type>& arg_types);
     future<> drop_aggregate(const db::functions::function_name& fun_name, const std::vector<data_type>& arg_types);
 
-    void before_create_column_family(const keyspace_metadata& ksm, const schema&, std::vector<mutation>&, api::timestamp_type);
-    void before_create_column_families(const keyspace_metadata& ksm, const std::vector<schema_ptr>&, std::vector<mutation>&, api::timestamp_type);
-    void before_update_column_family(const schema& new_schema, const schema& old_schema, std::vector<mutation>&, api::timestamp_type);
-    void before_drop_column_family(const schema&, std::vector<mutation>&, api::timestamp_type);
-    void before_drop_keyspace(const sstring& keyspace_name, std::vector<mutation>&, api::timestamp_type);
+    void before_create_column_family(const keyspace_metadata& ksm, const schema&, utils::chunked_vector<mutation>&, api::timestamp_type);
+    void before_create_column_families(const keyspace_metadata& ksm, const std::vector<schema_ptr>&, utils::chunked_vector<mutation>&, api::timestamp_type);
+    void before_update_column_family(const schema& new_schema, const schema& old_schema, utils::chunked_vector<mutation>&, api::timestamp_type);
+    void before_drop_column_family(const schema&, utils::chunked_vector<mutation>&, api::timestamp_type);
+    void before_drop_keyspace(const sstring& keyspace_name, utils::chunked_vector<mutation>&, api::timestamp_type);
 };
 
 }

--- a/service/migration_manager.hh
+++ b/service/migration_manager.hh
@@ -117,7 +117,7 @@ public:
 
     // Merge mutations received from src.
     // Keep mutations alive around whole async operation.
-    future<> merge_schema_from(locator::host_id src, const std::vector<canonical_mutation>& mutations);
+    future<> merge_schema_from(locator::host_id src, const utils::chunked_vector<canonical_mutation>& mutations);
     // Incremented each time the function above is called. Needed by tests.
     size_t canonical_mutation_merge_count = 0;
 
@@ -137,7 +137,7 @@ public:
     // Apply a group 0 change.
     // The future resolves after the change is applied locally.
     template<typename mutation_type = schema_change>
-    future<> announce(std::vector<mutation> schema, group0_guard, std::string_view description);
+    future<> announce(utils::chunked_vector<mutation> schema, group0_guard, std::string_view description);
 
     void passive_announce(table_schema_version version);
 
@@ -157,7 +157,7 @@ private:
     void init_messaging_service();
     future<> uninit_messaging_service();
 
-    future<> push_schema_mutation(locator::host_id endpoint, const std::vector<mutation>& schema);
+    future<> push_schema_mutation(locator::host_id endpoint, const utils::chunked_vector<mutation>& schema);
 
     future<> passive_announce();
 
@@ -166,8 +166,8 @@ private:
     future<> maybe_schedule_schema_pull(const table_schema_version& their_version, locator::host_id endpoint);
 
     template<typename mutation_type = schema_change>
-    future<> announce_with_raft(std::vector<mutation> schema, group0_guard, std::string_view description);
-    future<> announce_without_raft(std::vector<mutation> schema, group0_guard);
+    future<> announce_with_raft(utils::chunked_vector<mutation> schema, group0_guard, std::string_view description);
+    future<> announce_without_raft(utils::chunked_vector<mutation> schema, group0_guard);
 
 public:
     future<> maybe_sync(const schema_ptr& s, locator::host_id endpoint);
@@ -193,61 +193,61 @@ public:
 };
 
 extern template
-future<> migration_manager::announce_with_raft<schema_change>(std::vector<mutation> schema, group0_guard, std::string_view description);
+future<> migration_manager::announce_with_raft<schema_change>(utils::chunked_vector<mutation> schema, group0_guard, std::string_view description);
 extern template
-future<> migration_manager::announce_with_raft<topology_change>(std::vector<mutation> schema, group0_guard, std::string_view description);
+future<> migration_manager::announce_with_raft<topology_change>(utils::chunked_vector<mutation> schema, group0_guard, std::string_view description);
 
 extern template
-future<> migration_manager::announce<schema_change>(std::vector<mutation> schema, group0_guard, std::string_view description);
+future<> migration_manager::announce<schema_change>(utils::chunked_vector<mutation> schema, group0_guard, std::string_view description);
 extern template
-future<> migration_manager::announce<topology_change>(std::vector<mutation> schema, group0_guard, std::string_view description);
+future<> migration_manager::announce<topology_change>(utils::chunked_vector<mutation> schema, group0_guard, std::string_view description);
 
 
 future<column_mapping> get_column_mapping(db::system_keyspace& sys_ks, table_id, table_schema_version v);
 
-std::vector<mutation> prepare_keyspace_update_announcement(replica::database& db, lw_shared_ptr<keyspace_metadata> ksm, api::timestamp_type ts);
+utils::chunked_vector<mutation> prepare_keyspace_update_announcement(replica::database& db, lw_shared_ptr<keyspace_metadata> ksm, api::timestamp_type ts);
 
-std::vector<mutation> prepare_new_keyspace_announcement(replica::database& db, lw_shared_ptr<keyspace_metadata> ksm, api::timestamp_type timestamp);
+utils::chunked_vector<mutation> prepare_new_keyspace_announcement(replica::database& db, lw_shared_ptr<keyspace_metadata> ksm, api::timestamp_type timestamp);
 
 // The timestamp parameter can be used to ensure that all nodes update their internal tables' schemas
 // with identical timestamps, which can prevent an undeeded schema exchange
-future<std::vector<mutation>> prepare_column_family_update_announcement(storage_proxy& sp,
+future<utils::chunked_vector<mutation>> prepare_column_family_update_announcement(storage_proxy& sp,
         schema_ptr cfm, std::vector<view_ptr> view_updates, api::timestamp_type ts);
 
-future<std::vector<mutation>> prepare_new_column_family_announcement(storage_proxy& sp, schema_ptr cfm, api::timestamp_type timestamp);
+future<utils::chunked_vector<mutation>> prepare_new_column_family_announcement(storage_proxy& sp, schema_ptr cfm, api::timestamp_type timestamp);
 // The ksm parameter can describe a keyspace that hasn't been created yet.
 // This function allows announcing a new keyspace together with its tables at once.
-future<> prepare_new_column_family_announcement(std::vector<mutation>& mutations,
+future<> prepare_new_column_family_announcement(utils::chunked_vector<mutation>& mutations,
         storage_proxy& sp, const keyspace_metadata& ksm, schema_ptr cfm, api::timestamp_type timestamp);
 // Announce multiple tables in one operation
-future<> prepare_new_column_families_announcement(std::vector<mutation>& mutations,
+future<> prepare_new_column_families_announcement(utils::chunked_vector<mutation>& mutations,
         storage_proxy& sp, const keyspace_metadata& ksm, std::vector<schema_ptr> cfms, api::timestamp_type timestamp);
 
-future<std::vector<mutation>> prepare_new_type_announcement(storage_proxy& sp, user_type new_type, api::timestamp_type ts);
+future<utils::chunked_vector<mutation>> prepare_new_type_announcement(storage_proxy& sp, user_type new_type, api::timestamp_type ts);
 
-future<std::vector<mutation>> prepare_new_function_announcement(storage_proxy& sp, shared_ptr<cql3::functions::user_function> func, api::timestamp_type ts);
+future<utils::chunked_vector<mutation>> prepare_new_function_announcement(storage_proxy& sp, shared_ptr<cql3::functions::user_function> func, api::timestamp_type ts);
 
-future<std::vector<mutation>> prepare_new_aggregate_announcement(storage_proxy& sp, shared_ptr<cql3::functions::user_aggregate> aggregate, api::timestamp_type ts);
+future<utils::chunked_vector<mutation>> prepare_new_aggregate_announcement(storage_proxy& sp, shared_ptr<cql3::functions::user_aggregate> aggregate, api::timestamp_type ts);
 
-future<std::vector<mutation>> prepare_function_drop_announcement(storage_proxy& sp, shared_ptr<cql3::functions::user_function> func, api::timestamp_type ts);
+future<utils::chunked_vector<mutation>> prepare_function_drop_announcement(storage_proxy& sp, shared_ptr<cql3::functions::user_function> func, api::timestamp_type ts);
 
-future<std::vector<mutation>> prepare_aggregate_drop_announcement(storage_proxy& sp, shared_ptr<cql3::functions::user_aggregate> aggregate, api::timestamp_type ts);
+future<utils::chunked_vector<mutation>> prepare_aggregate_drop_announcement(storage_proxy& sp, shared_ptr<cql3::functions::user_aggregate> aggregate, api::timestamp_type ts);
 
-future<std::vector<mutation>> prepare_update_type_announcement(storage_proxy& sp, user_type updated_type, api::timestamp_type ts);
+future<utils::chunked_vector<mutation>> prepare_update_type_announcement(storage_proxy& sp, user_type updated_type, api::timestamp_type ts);
 
-future<std::vector<mutation>> prepare_keyspace_drop_announcement(replica::database& db, const sstring& ks_name, api::timestamp_type ts);
+future<utils::chunked_vector<mutation>> prepare_keyspace_drop_announcement(replica::database& db, const sstring& ks_name, api::timestamp_type ts);
 
 class drop_views_tag;
 using drop_views = bool_class<drop_views_tag>;
-future<std::vector<mutation>> prepare_column_family_drop_announcement(storage_proxy& sp,
+future<utils::chunked_vector<mutation>> prepare_column_family_drop_announcement(storage_proxy& sp,
         const sstring& ks_name, const sstring& cf_name, api::timestamp_type ts, drop_views drop_views = drop_views::no);
 
-future<std::vector<mutation>> prepare_type_drop_announcement(storage_proxy& sp, user_type dropped_type, api::timestamp_type ts);
+future<utils::chunked_vector<mutation>> prepare_type_drop_announcement(storage_proxy& sp, user_type dropped_type, api::timestamp_type ts);
 
-future<std::vector<mutation>> prepare_new_view_announcement(storage_proxy& sp, view_ptr view, api::timestamp_type ts);
+future<utils::chunked_vector<mutation>> prepare_new_view_announcement(storage_proxy& sp, view_ptr view, api::timestamp_type ts);
 
-future<std::vector<mutation>> prepare_view_update_announcement(storage_proxy& sp, view_ptr view, api::timestamp_type ts);
+future<utils::chunked_vector<mutation>> prepare_view_update_announcement(storage_proxy& sp, view_ptr view, api::timestamp_type ts);
 
-future<std::vector<mutation>> prepare_view_drop_announcement(storage_proxy& sp, const sstring& ks_name, const sstring& cf_name, api::timestamp_type ts);
+future<utils::chunked_vector<mutation>> prepare_view_drop_announcement(storage_proxy& sp, const sstring& ks_name, const sstring& cf_name, api::timestamp_type ts);
 
 }

--- a/service/qos/service_level_controller.cc
+++ b/service/qos/service_level_controller.cc
@@ -831,7 +831,7 @@ future<> service_level_controller::migrate_to_v2(size_t nodes_count, db::system_
     
     auto guard = co_await group0_client.start_operation(as);
 
-    std::vector<mutation> migration_muts;
+    utils::chunked_vector<mutation> migration_muts;
     for (const auto& row: *rows) {
         std::vector<data_value_or_unset> values;
         for (const auto& col: schema->all_columns()) {

--- a/service/raft/group0_state_machine.hh
+++ b/service/raft/group0_state_machine.hh
@@ -34,7 +34,7 @@ struct group0_state_machine_merger;
 struct schema_change {
     // Mutations of schema tables (such as `system_schema.keyspaces`, `system_schema.tables` etc.)
     // e.g. computed from a DDL statement (keyspace/table/type create/drop/alter etc.)
-    std::vector<canonical_mutation> mutations;
+    utils::chunked_vector<canonical_mutation> mutations;
 };
 
 struct broadcast_table_query {
@@ -42,20 +42,20 @@ struct broadcast_table_query {
 };
 
 struct topology_change {
-    std::vector<canonical_mutation> mutations;
+    utils::chunked_vector<canonical_mutation> mutations;
 };
 
 // Allows executing combined topology & schema mutations under a single RAFT command.
 // The order of the mutations doesn't matter.
 struct mixed_change {
-    std::vector<canonical_mutation> mutations;
+    utils::chunked_vector<canonical_mutation> mutations;
 };
 
 // This command is used to write data to tables other than topology or
 // schema tables. and it updates any in-memory data structures based on
 // mutations' table_id.
 struct write_mutations {
-    std::vector<canonical_mutation> mutations;
+    utils::chunked_vector<canonical_mutation> mutations;
 };
 
 struct group0_command {
@@ -113,7 +113,7 @@ class group0_state_machine : public raft_state_machine {
     gms::feature_service& _feature_service;
     gms::feature::listener_registration _topology_on_raft_support_listener;
 
-    modules_to_reload get_modules_to_reload(const std::vector<canonical_mutation>& mutations);
+    modules_to_reload get_modules_to_reload(const utils::chunked_vector<canonical_mutation>& mutations);
     future<> reload_modules(modules_to_reload modules);
     future<> merge_and_apply(group0_state_machine_merger& merger);
 public:
@@ -130,6 +130,6 @@ public:
 bool should_flush_system_topology_after_applying(const mutation& mut, const data_dictionary::database db);
 
 // Used to write data to topology and other tables except schema tables.
-future<> write_mutations_to_database(storage_proxy& proxy, gms::inet_address from, std::vector<canonical_mutation> cms);
+future<> write_mutations_to_database(storage_proxy& proxy, gms::inet_address from, utils::chunked_vector<canonical_mutation> cms);
 
 } // end of namespace service

--- a/service/raft/group0_state_machine_merger.cc
+++ b/service/raft/group0_state_machine_merger.cc
@@ -67,21 +67,21 @@ void group0_state_machine_merger::add(group0_command&& cmd, size_t added_size) {
     }
 }
 
-std::vector<canonical_mutation>& group0_state_machine_merger::get_command_mutations(group0_command& cmd) {
+utils::chunked_vector<canonical_mutation>& group0_state_machine_merger::get_command_mutations(group0_command& cmd) {
     return std::visit(make_visitor(
-        [] (schema_change& chng) -> std::vector<canonical_mutation>& {
+        [] (schema_change& chng) -> utils::chunked_vector<canonical_mutation>& {
             return chng.mutations;
         },
-        [] (broadcast_table_query& query) -> std::vector<canonical_mutation>& {
+        [] (broadcast_table_query& query) -> utils::chunked_vector<canonical_mutation>& {
             on_internal_error(slogger, "trying to merge broadcast table command");
         },
-        [] (topology_change& chng) -> std::vector<canonical_mutation>& {
+        [] (topology_change& chng) -> utils::chunked_vector<canonical_mutation>& {
             return chng.mutations;
         },
-        [] (mixed_change& chng) -> std::vector<canonical_mutation>& {
+        [] (mixed_change& chng) -> utils::chunked_vector<canonical_mutation>& {
             return chng.mutations;
         },
-        [] (write_mutations& muts) -> std::vector<canonical_mutation>& {
+        [] (write_mutations& muts) -> utils::chunked_vector<canonical_mutation>& {
             return muts.mutations;
         }
     ), cmd.change);
@@ -109,7 +109,7 @@ std::pair<group0_command, mutation> group0_state_machine_merger::merge() {
             }
         }
 
-        std::vector<canonical_mutation> ms;
+        utils::chunked_vector<canonical_mutation> ms;
         for (auto&& tables : mutations) {
             for (auto&& partitions : tables.second) {
                 ms.push_back(canonical_mutation(partitions));

--- a/service/raft/group0_state_machine_merger.hh
+++ b/service/raft/group0_state_machine_merger.hh
@@ -57,7 +57,7 @@ public:
 
     // Returns mutations stored in the command.
     // It must not be called for broadcast table commands.
-    static std::vector<canonical_mutation>& get_command_mutations(group0_command& cmd);
+    static utils::chunked_vector<canonical_mutation>& get_command_mutations(group0_command& cmd);
 
     // Returns a command that contains all mutations from the current batch and
     // merged history mutation.

--- a/service/raft/raft_group0_client.hh
+++ b/service/raft/raft_group0_client.hh
@@ -230,7 +230,7 @@ class group0_batch {
 public:
     using generator_func = std::function<mutations_generator(api::timestamp_type t)>;
 private:
-    std::vector<mutation> _muts;
+    utils::chunked_vector<mutation> _muts;
     std::vector<generator_func> _generators;
     std::vector<sstring> _descriptions;
     std::optional<::service::group0_guard> _guard;
@@ -259,13 +259,13 @@ public:
     utils::UUID new_group0_state_id() const;
 
     void add_mutation(mutation m, std::string_view description = "");
-    void add_mutations(std::vector<mutation> ms, std::string_view description = "");
+    void add_mutations(utils::chunked_vector<mutation> ms, std::string_view description = "");
     void add_generator(generator_func f, std::string_view description = "");
 
     // Commits the data, nop if there was no guard provided.
     future<> commit(::service::raft_group0_client& group0_client, seastar::abort_source& as, std::optional<::service::raft_timeout> timeout) &&;
     // For rare cases where collector is used but announce logic is replaced with a custom one.
-    future<std::pair<std::vector<mutation>, ::service::group0_guard>> extract() &&;
+    future<std::pair<utils::chunked_vector<mutation>, ::service::group0_guard>> extract() &&;
 
     // Checks if any mutations or generators were added. Note that when generator is
     // added it still can return no mutations.

--- a/service/storage_proxy.hh
+++ b/service/storage_proxy.hh
@@ -287,7 +287,7 @@ private:
     inheriting_concrete_execution_stage<
             future<result<>>,
             storage_proxy*,
-            std::vector<mutation>,
+            utils::chunked_vector<mutation>,
             db::consistency_level,
             clock_type::time_point,
             tracing::trace_state_ptr,
@@ -438,14 +438,14 @@ private:
             schema_ptr s, lw_shared_ptr<query::read_command> cmd, const dht::partition_range_vector&& pr, query::result_options opts,
             tracing::trace_state_ptr trace_state, clock_type::time_point timeout);
 
-    future<> mutate_counters_on_leader(std::vector<frozen_mutation_and_schema> mutations, db::consistency_level cl, clock_type::time_point timeout,
+    future<> mutate_counters_on_leader(utils::chunked_vector<frozen_mutation_and_schema> mutations, db::consistency_level cl, clock_type::time_point timeout,
                                        tracing::trace_state_ptr trace_state, service_permit permit);
     future<> mutate_counter_on_leader_and_replicate(const schema_ptr& s, frozen_mutation m, db::consistency_level cl, clock_type::time_point timeout,
                                                     tracing::trace_state_ptr trace_state, service_permit permit);
 
     locator::host_id find_leader_for_counter_update(const mutation& m, const locator::effective_replication_map& erm, db::consistency_level cl);
 
-    future<result<>> do_mutate(std::vector<mutation> mutations, db::consistency_level cl, clock_type::time_point timeout, tracing::trace_state_ptr tr_state, service_permit permit, bool, db::allow_per_partition_rate_limit allow_limit, lw_shared_ptr<cdc::operation_result_tracker> cdc_tracker);
+    future<result<>> do_mutate(utils::chunked_vector<mutation> mutations, db::consistency_level cl, clock_type::time_point timeout, tracing::trace_state_ptr tr_state, service_permit permit, bool, db::allow_per_partition_rate_limit allow_limit, lw_shared_ptr<cdc::operation_result_tracker> cdc_tracker);
 
     future<> send_to_endpoint(
             std::unique_ptr<mutation_holder> m,
@@ -540,7 +540,7 @@ private:
             smp_service_group smp_grp, db::per_partition_rate_limit::info rate_limit_info);
     // Applies mutations on this node.
     // Resolves with timed_out_error when timeout is reached.
-    future<> mutate_locally(std::vector<mutation> mutation, tracing::trace_state_ptr tr_state, clock_type::time_point timeout, smp_service_group smp_grp, db::per_partition_rate_limit::info rate_limit_info);
+    future<> mutate_locally(utils::chunked_vector<mutation> mutation, tracing::trace_state_ptr tr_state, clock_type::time_point timeout, smp_service_group smp_grp, db::per_partition_rate_limit::info rate_limit_info);
     // Confirm whether the topology version from the token is greater than or equal
     // to the current fencing_version sourced from shared_token_metadata.
     // If it is not, the function will return an engaged optional.
@@ -557,7 +557,7 @@ private:
         return _pending_writes_phaser.start();
     }
 
-    mutation do_get_batchlog_mutation_for(schema_ptr schema, const std::vector<mutation>& mutations, const utils::UUID& id, int32_t version, db_clock::time_point now);
+    mutation do_get_batchlog_mutation_for(schema_ptr schema, const utils::chunked_vector<mutation>& mutations, const utils::UUID& id, int32_t version, db_clock::time_point now);
     future<> drain_on_shutdown();
 public:
     // Applies mutation on this node.
@@ -577,10 +577,10 @@ public:
     }
     // Applies mutations on this node.
     // Resolves with timed_out_error when timeout is reached.
-    future<> mutate_locally(std::vector<mutation> mutation, tracing::trace_state_ptr tr_state, clock_type::time_point timeout = clock_type::time_point::max(), db::per_partition_rate_limit::info rate_limit_info = std::monostate());
+    future<> mutate_locally(utils::chunked_vector<mutation> mutation, tracing::trace_state_ptr tr_state, clock_type::time_point timeout = clock_type::time_point::max(), db::per_partition_rate_limit::info rate_limit_info = std::monostate());
     // Applies a vector of frozen_mutation:s and their schemas on this node, in parallel.
     // Resolves with timed_out_error when timeout is reached.
-    future<> mutate_locally(std::vector<frozen_mutation_and_schema> mutations, tracing::trace_state_ptr tr_state, db::commitlog::force_sync sync, clock_type::time_point timeout = clock_type::time_point::max(), db::per_partition_rate_limit::info rate_limit_info = std::monostate());
+    future<> mutate_locally(utils::chunked_vector<frozen_mutation_and_schema> mutations, tracing::trace_state_ptr tr_state, db::commitlog::force_sync sync, clock_type::time_point timeout = clock_type::time_point::max(), db::per_partition_rate_limit::info rate_limit_info = std::monostate());
 
     future<> mutate_hint(const schema_ptr&, const frozen_mutation& m, tracing::trace_state_ptr tr_state, clock_type::time_point timeout = clock_type::time_point::max());
 
@@ -594,14 +594,14 @@ public:
     * @param consistency_level the consistency level for the operation
     * @param tr_state trace state handle
     */
-    future<> mutate(std::vector<mutation> mutations, db::consistency_level cl, clock_type::time_point timeout, tracing::trace_state_ptr tr_state, service_permit permit, db::allow_per_partition_rate_limit allow_limit, bool raw_counters = false);
+    future<> mutate(utils::chunked_vector<mutation> mutations, db::consistency_level cl, clock_type::time_point timeout, tracing::trace_state_ptr tr_state, service_permit permit, db::allow_per_partition_rate_limit allow_limit, bool raw_counters = false);
 
     /**
     * See mutate. Does the same, but returns some exceptions
     * through the result<>, which allows for efficient inspection
     * of the exception on the exception handling path.
     */
-    future<result<>> mutate_result(std::vector<mutation> mutations, db::consistency_level cl, clock_type::time_point timeout, tracing::trace_state_ptr tr_state, service_permit permit, db::allow_per_partition_rate_limit allow_limit, bool raw_counters = false);
+    future<result<>> mutate_result(utils::chunked_vector<mutation> mutations, db::consistency_level cl, clock_type::time_point timeout, tracing::trace_state_ptr tr_state, service_permit permit, db::allow_per_partition_rate_limit allow_limit, bool raw_counters = false);
 
     paxos_participants
     get_paxos_participants(const sstring& ks_name, const locator::effective_replication_map& erm, const dht::token& token, db::consistency_level consistency_for_paxos);
@@ -609,7 +609,7 @@ public:
     future<> replicate_counter_from_leader(mutation m, db::consistency_level cl, tracing::trace_state_ptr tr_state,
                                            clock_type::time_point timeout, service_permit permit);
 
-    future<result<>> mutate_with_triggers(std::vector<mutation> mutations, db::consistency_level cl, clock_type::time_point timeout,
+    future<result<>> mutate_with_triggers(utils::chunked_vector<mutation> mutations, db::consistency_level cl, clock_type::time_point timeout,
                                           bool should_mutate_atomically, tracing::trace_state_ptr tr_state, service_permit permit,
                                           db::allow_per_partition_rate_limit allow_limit, bool raw_counters = false);
 
@@ -623,14 +623,14 @@ public:
     * @param consistency_level the consistency level for the operation
     * @param tr_state trace state handle
     */
-    future<> mutate_atomically(std::vector<mutation> mutations, db::consistency_level cl, clock_type::time_point timeout, tracing::trace_state_ptr tr_state, service_permit permit);
+    future<> mutate_atomically(utils::chunked_vector<mutation> mutations, db::consistency_level cl, clock_type::time_point timeout, tracing::trace_state_ptr tr_state, service_permit permit);
 
     /**
     * See mutate_atomically. Does the same, but returns some exceptions
     * through the result<>, which allows for efficient inspection
     * of the exception on the exception handling path.
     */
-    future<result<>> mutate_atomically_result(std::vector<mutation> mutations, db::consistency_level cl, clock_type::time_point timeout, tracing::trace_state_ptr tr_state, service_permit permit);
+    future<result<>> mutate_atomically_result(utils::chunked_vector<mutation> mutations, db::consistency_level cl, clock_type::time_point timeout, tracing::trace_state_ptr tr_state, service_permit permit);
 
     future<> send_hint_to_all_replicas(frozen_mutation_and_schema fm_a_s);
 
@@ -702,7 +702,7 @@ public:
             db::consistency_level cl_for_paxos, db::consistency_level cl_for_learn,
             clock_type::time_point write_timeout, clock_type::time_point cas_timeout, bool write = true);
 
-    mutation get_batchlog_mutation_for(const std::vector<mutation>& mutations, const utils::UUID& id, int32_t version, db_clock::time_point now);
+    mutation get_batchlog_mutation_for(const utils::chunked_vector<mutation>& mutations, const utils::UUID& id, int32_t version, db_clock::time_point now);
 
     future<> stop();
     future<> start_hints_manager();

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -959,9 +959,9 @@ private:
     future<> _upgrade_to_topology_coordinator_fiber = make_ready_future<>();
     future<> track_upgrade_progress_to_topology_coordinator(sharded<service::storage_proxy>& proxy);
 
-    future<> transit_tablet(table_id, dht::token, noncopyable_function<std::tuple<std::vector<canonical_mutation>, sstring>(const locator::tablet_map& tmap, api::timestamp_type)> prepare_mutations);
+    future<> transit_tablet(table_id, dht::token, noncopyable_function<std::tuple<utils::chunked_vector<canonical_mutation>, sstring>(const locator::tablet_map& tmap, api::timestamp_type)> prepare_mutations);
     future<service::group0_guard> get_guard_for_tablet_update();
-    future<bool> exec_tablet_update(service::group0_guard guard, std::vector<canonical_mutation> updates, sstring reason);
+    future<bool> exec_tablet_update(service::group0_guard guard, utils::chunked_vector<canonical_mutation> updates, sstring reason);
 public:
     struct all_tokens_tag {};
     future<std::unordered_map<sstring, sstring>> add_repair_tablet_request(table_id table, std::variant<utils::chunked_vector<dht::token>, all_tokens_tag> tokens_variant, std::unordered_set<locator::host_id> hosts_filter, std::unordered_set<sstring> dcs_filter, bool await_completion);
@@ -999,8 +999,8 @@ public:
     // from across the entire cluster.
     future<utils::chunked_vector<temporary_buffer<char>>> do_sample_sstables(table_id, uint64_t chunk_size, uint64_t n_chunks);
 private:
-    future<std::vector<canonical_mutation>> get_system_mutations(schema_ptr schema);
-    future<std::vector<canonical_mutation>> get_system_mutations(const sstring& ks_name, const sstring& cf_name);
+    future<utils::chunked_vector<canonical_mutation>> get_system_mutations(schema_ptr schema);
+    future<utils::chunked_vector<canonical_mutation>> get_system_mutations(const sstring& ks_name, const sstring& cf_name);
 
     struct nodes_to_notify_after_sync {
         std::vector<std::pair<gms::inet_address, locator::host_id>> left;
@@ -1025,7 +1025,7 @@ private:
     // raft_group0_client::_read_apply_mutex must be held
     future<> merge_topology_snapshot(raft_snapshot snp);
 
-    std::vector<canonical_mutation> build_mutation_from_join_params(const join_node_request_params& params, api::timestamp_type write_timestamp);
+    utils::chunked_vector<canonical_mutation> build_mutation_from_join_params(const join_node_request_params& params, api::timestamp_type write_timestamp);
     std::unordered_set<raft::server_id> ignored_nodes_from_join_params(const join_node_request_params& params);
 
     future<join_node_request_result> join_node_request_handler(join_node_request_params params);

--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -3202,7 +3202,7 @@ public:
     }
 
     // Allocate tablets for multiple new tables, which may be co-located with each other, or co-located with an existing base table.
-    void allocate_tablets_for_new_tables(const keyspace_metadata& ksm, const std::vector<schema_ptr>& cfms, std::vector<mutation>& muts, api::timestamp_type ts) {
+    void allocate_tablets_for_new_tables(const keyspace_metadata& ksm, const std::vector<schema_ptr>& cfms, utils::chunked_vector<mutation>& muts, api::timestamp_type ts) {
         locator::replication_strategy_params params(ksm.strategy_options(), ksm.initial_tablets());
         auto rs = abstract_replication_strategy::create_replication_strategy(ksm.strategy_name(), params);
         if (auto&& tablet_rs = rs->maybe_as_tablet_aware()) {
@@ -3247,15 +3247,15 @@ public:
         }
     }
 
-    void on_before_create_column_families(const keyspace_metadata& ksm, const std::vector<schema_ptr>& cfms, std::vector<mutation>& muts, api::timestamp_type ts) override {
+    void on_before_create_column_families(const keyspace_metadata& ksm, const std::vector<schema_ptr>& cfms, utils::chunked_vector<mutation>& muts, api::timestamp_type ts) override {
         allocate_tablets_for_new_tables(ksm, cfms, muts, ts);
     }
 
-    void on_before_create_column_family(const keyspace_metadata& ksm, const schema& s, std::vector<mutation>& muts, api::timestamp_type ts) override {
+    void on_before_create_column_family(const keyspace_metadata& ksm, const schema& s, utils::chunked_vector<mutation>& muts, api::timestamp_type ts) override {
         allocate_tablets_for_new_tables(ksm, {s.shared_from_this()}, muts, ts);
     }
 
-    void on_before_drop_column_family(const schema& s, std::vector<mutation>& muts, api::timestamp_type ts) override {
+    void on_before_drop_column_family(const schema& s, utils::chunked_vector<mutation>& muts, api::timestamp_type ts) override {
         keyspace& ks = _db.find_keyspace(s.ks_name());
         auto&& rs = ks.get_replication_strategy();
         if (rs.uses_tablets()) {
@@ -3265,7 +3265,7 @@ public:
         }
     }
 
-    void on_before_drop_keyspace(const sstring& keyspace_name, std::vector<mutation>& muts, api::timestamp_type ts) override {
+    void on_before_drop_keyspace(const sstring& keyspace_name, utils::chunked_vector<mutation>& muts, api::timestamp_type ts) override {
         keyspace& ks = _db.find_keyspace(keyspace_name);
         auto&& rs = ks.get_replication_strategy();
         if (rs.uses_tablets()) {

--- a/table_helper.cc
+++ b/table_helper.cc
@@ -190,7 +190,7 @@ future<> table_helper::setup_keyspace(cql3::query_processor& qp, service::migrat
     while (std::any_of(tables.begin(), tables.end(), [db] (table_helper* t) { return !db.has_schema(t->_keyspace, t->_name); })) {
         auto group0_guard = co_await mm.start_group0_operation();
         auto ts = group0_guard.write_timestamp();
-        std::vector<mutation> table_mutations;
+        utils::chunked_vector<mutation> table_mutations;
 
         co_await coroutine::parallel_for_each(tables, [&] (auto&& table) -> future<> {
             auto schema = parse_new_cf_statement(qp, table->_create_cql);

--- a/test/boost/bloom_filter_test.cc
+++ b/test/boost/bloom_filter_test.cc
@@ -207,7 +207,7 @@ SEASTAR_TEST_CASE(test_bloom_filters_with_bad_partition_estimate) {
         utils::filter_ptr optimal_filter = utils::i_filter::get_filter(actual_partition_count, schema->bloom_filter_fp_chance(), utils::filter_format::m_format);
 
         // Generate mutations for the table and add the keys to the bloom filter
-        std::vector<mutation> mutations;
+        utils::chunked_vector<mutation> mutations;
         auto pks = ss.make_pkeys(actual_partition_count);
         mutations.reserve(actual_partition_count);
         for (auto pk : pks) {
@@ -293,7 +293,7 @@ SEASTAR_TEST_CASE(test_bloom_filter_reclaim_after_unlink) {
         simple_schema ss;
         auto schema = ss.schema();
 
-        std::vector<mutation> mutations;
+        utils::chunked_vector<mutation> mutations;
         for (int i = 0; i < 10; i++) {
             auto mut = mutation(schema, ss.make_pkey(i));
             mut.partition().apply_insert(*schema, ss.make_ckey(1), ss.new_timestamp());

--- a/test/boost/commitlog_test.cc
+++ b/test/boost/commitlog_test.cc
@@ -986,7 +986,7 @@ SEASTAR_TEST_CASE(test_commitlog_add_entry) {
             constexpr auto n = 10;
             for (auto fs : { force_sync(false), force_sync(true) }) {
                 std::vector<commitlog_entry_writer> writers;
-                std::vector<frozen_mutation> mutations;
+                utils::chunked_vector<frozen_mutation> mutations;
                 std::vector<replay_position> rps;
 
                 writers.reserve(n);
@@ -1049,7 +1049,7 @@ SEASTAR_TEST_CASE(test_commitlog_add_entries) {
             constexpr auto n = 10;
             for (auto fs : { force_sync(false), force_sync(true) }) {
                 std::vector<commitlog_entry_writer> writers;
-                std::vector<frozen_mutation> mutations;
+                utils::chunked_vector<frozen_mutation> mutations;
                 std::vector<replay_position> rps;
 
                 writers.reserve(n);
@@ -1850,7 +1850,7 @@ static future<> do_test_oversized_entry(size_t max_size_mb) {
         auto size = log.max_record_size() * 2;
 
         std::vector<commitlog_entry_writer> writers;
-        std::vector<frozen_mutation> mutations;
+        utils::chunked_vector<frozen_mutation> mutations;
 
         size_t tot = 0; 
         // generate a bunch of mutation until we have more data than allowed.

--- a/test/boost/compaction_group_test.cc
+++ b/test/boost/compaction_group_test.cc
@@ -40,7 +40,7 @@ static sstables::shared_sstable generate_sstable(schema_ptr s, std::function<sha
     };
 
     auto keys = tests::generate_partition_keys(100, s);
-    std::vector<mutation> muts;
+    utils::chunked_vector<mutation> muts;
 
     muts.reserve(keys.size());
     for (auto& k : keys) {

--- a/test/boost/database_test.cc
+++ b/test/boost/database_test.cc
@@ -301,7 +301,7 @@ SEASTAR_TEST_CASE(test_querying_with_limits) {
 
 static void test_database(void (*run_tests)(populate_fn_ex, bool), unsigned cgs) {
     do_with_cql_env_and_compaction_groups_cgs(cgs, [run_tests] (cql_test_env& e) {
-        run_tests([&] (schema_ptr s, const std::vector<mutation>& partitions, gc_clock::time_point) -> mutation_source {
+        run_tests([&] (schema_ptr s, const utils::chunked_vector<mutation>& partitions, gc_clock::time_point) -> mutation_source {
             auto& mm = e.migration_manager().local();
             try {
                 auto group0_guard = mm.start_group0_operation().get();

--- a/test/boost/group0_cmd_merge_test.cc
+++ b/test/boost/group0_cmd_merge_test.cc
@@ -33,7 +33,7 @@ static service::group0_command create_command(utils::UUID id) {
     auto mut = canonical_mutation{mutation{db::system_keyspace::group0_history(), partition_key::make_empty()}};
 
     return service::group0_command {
-        .change{service::write_mutations{std::vector<canonical_mutation>{mut}}},
+        .change{service::write_mutations{utils::chunked_vector<canonical_mutation>{mut}}},
         .history_append{db::system_keyspace::make_group0_history_state_id_mutation(
                         id, std::nullopt, "test")},
         .new_state_id = id,
@@ -92,7 +92,7 @@ SEASTAR_TEST_CASE(test_group0_cmd_merge) {
             .creator_addr{env.db().local().get_token_metadata().get_topology().my_address()},
             .creator_id{group0.id()}
         };
-        std::vector<canonical_mutation> cms;
+        utils::chunked_vector<canonical_mutation> cms;
         size_t size = 0;
         auto muts = service::prepare_keyspace_drop_announcement(env.local_db(), "ks", api::new_timestamp()).get();
         // Maximum mutation size is 1/3 of commitlog segment size which we set

--- a/test/boost/incremental_compaction_test.cc
+++ b/test/boost/incremental_compaction_test.cc
@@ -311,7 +311,7 @@ SEASTAR_TEST_CASE(basic_garbage_collection_test) {
             m.set_clustered_cell(c_key, *s->get_column_definition("r1"), std::move(live_cell));
             return m;
         };
-        std::vector<mutation> mutations;
+        utils::chunked_vector<mutation> mutations;
         mutations.reserve(total_keys);
 
         auto expired_keys = total_keys*expired;

--- a/test/boost/mutation_fragment_test.cc
+++ b/test/boost/mutation_fragment_test.cc
@@ -37,7 +37,7 @@
 SEASTAR_TEST_CASE(test_mutation_merger_conforms_to_mutation_source) {
     return seastar::async([] {
         tests::reader_concurrency_semaphore_wrapper semaphore;
-        run_mutation_source_tests([&](schema_ptr s, const std::vector<mutation>& partitions) -> mutation_source {
+        run_mutation_source_tests([&](schema_ptr s, const utils::chunked_vector<mutation>& partitions) -> mutation_source {
             // We create a mutation source which combines N memtables.
             // The input fragments are spread among the memtables according to some selection logic,
 

--- a/test/boost/mutation_test.cc
+++ b/test/boost/mutation_test.cc
@@ -595,7 +595,7 @@ SEASTAR_TEST_CASE(test_flush_in_the_middle_of_a_scan) {
                 return m;
             };
 
-            std::vector<mutation> mutations;
+            utils::chunked_vector<mutation> mutations;
             for (int i = 0; i < 1000; ++i) {
                 auto m = make_mutation();
                 cf.apply(m);
@@ -1221,7 +1221,7 @@ SEASTAR_THREAD_TEST_CASE(test_split_mutations) {
             if (max_size == 0) {
                 continue;
             }
-            std::vector<mutation> splitted;
+            utils::chunked_vector<mutation> splitted;
             split_mutation(mut, splitted, max_size / 2).get();
             BOOST_REQUIRE(!splitted.empty());
             for (const auto& m: splitted) {
@@ -2681,8 +2681,8 @@ SEASTAR_THREAD_TEST_CASE(test_row_size_is_immune_to_application_order) {
 }
 
 SEASTAR_THREAD_TEST_CASE(test_schema_changes) {
-    for_each_schema_change([] (schema_ptr base, const std::vector<mutation>& base_mutations,
-                               schema_ptr changed, const std::vector<mutation>& changed_mutations) {
+    for_each_schema_change([] (schema_ptr base, const utils::chunked_vector<mutation>& base_mutations,
+                               schema_ptr changed, const utils::chunked_vector<mutation>& changed_mutations) {
         BOOST_REQUIRE_EQUAL(base_mutations.size(), changed_mutations.size());
         for (auto bc : boost::range::combine(base_mutations, changed_mutations)) {
             auto b = boost::get<0>(bc);
@@ -2740,7 +2740,7 @@ class basic_compacted_fragments_consumer_base {
     max_purgeable_fn _get_max_purgeable;
     max_purgeable _max_purgeable;
 
-    std::vector<mutation> _mutations;
+    utils::chunked_vector<mutation> _mutations;
     mutation_rebuilder_v2 _mutation;
 
 private:
@@ -2858,7 +2858,7 @@ public:
 
         return stop_iteration::no;
     }
-    std::vector<mutation> consume_end_of_stream() {
+    utils::chunked_vector<mutation> consume_end_of_stream() {
         return _mutations;
     }
 };
@@ -2867,7 +2867,7 @@ using survived_compacted_fragments_consumer = basic_compacted_fragments_consumer
 using purged_compacted_fragments_consumer = basic_compacted_fragments_consumer_base<true>;
 
 void run_compaction_data_stream_split_test(const schema& schema, reader_permit permit, gc_clock::time_point query_time,
-        std::vector<mutation> mutations) {
+        utils::chunked_vector<mutation> mutations) {
     for (auto& mut : mutations) {
         mut.partition().compact_for_compaction(schema, never_gc, mut.decorated_key(), query_time, tombstone_gc_state(nullptr));
     }

--- a/test/boost/querier_cache_test.cc
+++ b/test/boost/querier_cache_test.cc
@@ -79,15 +79,15 @@ private:
     simple_schema _s;
     reader_concurrency_semaphore _sem;
     query::querier_cache _cache;
-    const std::vector<mutation> _mutations;
+    const utils::chunked_vector<mutation> _mutations;
     const mutation_source _mutation_source;
 
     static sstring make_value(size_t i) {
         return format("value{:010d}", i);
     }
 
-    static std::vector<mutation> make_mutations(simple_schema& s, const noncopyable_function<sstring(size_t)>& make_value) {
-        std::vector<mutation> mutations;
+    static utils::chunked_vector<mutation> make_mutations(simple_schema& s, const noncopyable_function<sstring(size_t)>& make_value) {
+        utils::chunked_vector<mutation> mutations;
         mutations.reserve(10);
 
         for (uint32_t i = 0; i != 10; ++i) {

--- a/test/boost/repair_test.cc
+++ b/test/boost/repair_test.cc
@@ -85,7 +85,7 @@ lw_shared_ptr<repair_writer> make_test_repair_writer(schema_ptr schema, reader_p
 
 repair_rows_on_wire make_random_repair_rows_on_wire(random_mutation_generator& gen, schema_ptr s, reader_permit permit, lw_shared_ptr<replica::memtable> m) {
     repair_rows_on_wire input;
-    std::vector<mutation> muts = gen(100);
+    utils::chunked_vector<mutation> muts = gen(100);
 
     for (mutation& mut : muts) {
         partition_key pk = mut.key();

--- a/test/boost/schema_change_test.cc
+++ b/test/boost/schema_change_test.cc
@@ -143,7 +143,7 @@ SEASTAR_TEST_CASE(test_tombstones_are_ignored_in_version_calculation) {
                 mutation m(s, pkey);
                 auto ckey = clustering_key::from_exploded(*s, {utf8_type->decompose(table_schema->cf_name()), "v1"});
                 m.partition().apply_delete(*s, ckey, tombstone(api::min_timestamp, gc_clock::now()));
-                mm.announce(std::vector<mutation>({m}), mm.start_group0_operation().get(), "").get();
+                mm.announce(utils::chunked_vector<mutation>({m}), mm.start_group0_operation().get(), "").get();
             }
 
             auto new_table_version = e.db().local().find_schema(table_schema->id())->version();
@@ -461,7 +461,7 @@ SEASTAR_TEST_CASE(test_merging_does_not_alter_tables_which_didnt_change) {
                 return e.db().local().find_column_family("ks", "table1");
             };
 
-            std::vector<mutation> muts1;
+            utils::chunked_vector<mutation> muts1;
             {
                 auto group0_guard = mm.start_group0_operation().get();
                 muts1 = db::schema_tables::make_create_table_mutations(s0, group0_guard.write_timestamp());
@@ -509,7 +509,7 @@ SEASTAR_TEST_CASE(test_merging_creates_a_table_even_if_keyspace_was_recreated) {
                 return e.db().local().find_column_family("ks", "table1");
             };
 
-            std::vector<mutation> all_muts;
+            utils::chunked_vector<mutation> all_muts;
 
             {
                 auto group0_guard = mm.start_group0_operation().get();

--- a/test/boost/schema_changes_test.cc
+++ b/test/boost/schema_changes_test.cc
@@ -34,8 +34,8 @@ static_assert(writable_sstable_versions[2] == expected_writable_sstable_versions
 future <> test_schema_changes_int(sstable_version_types sstable_vtype) {
   return sstables::test_env::do_with_async([] (sstables::test_env& env) {
     std::map<schema_ptr, shared_sstable> cache;
-    for_each_schema_change([&] (schema_ptr base, const std::vector<mutation>& base_mutations,
-                                schema_ptr changed, const std::vector<mutation>& changed_mutations) {
+    for_each_schema_change([&] (schema_ptr base, const utils::chunked_vector<mutation>& base_mutations,
+                                schema_ptr changed, const utils::chunked_vector<mutation>& changed_mutations) {
         auto it = cache.find(base);
 
         shared_sstable created_with_base_schema;

--- a/test/boost/schema_loader_test.cc
+++ b/test/boost/schema_loader_test.cc
@@ -284,7 +284,7 @@ SEASTAR_THREAD_TEST_CASE(test_mv_index) {
             {view_type::view, view_type::index, view_type::view, view_type::index});
 }
 
-void check_sstable_schema(sstables::test_env& env, std::filesystem::path sst_path, const std::vector<mutation>& mutations) {
+void check_sstable_schema(sstables::test_env& env, std::filesystem::path sst_path, const utils::chunked_vector<mutation>& mutations) {
     db::config dbcfg;
 
     auto schema = tools::load_schema_from_sstable(dbcfg, sst_path).get();

--- a/test/boost/schema_registry_test.cc
+++ b/test/boost/schema_registry_test.cc
@@ -172,7 +172,7 @@ SEASTAR_THREAD_TEST_CASE(test_table_is_attached) {
         // Use schema mutations so that table id is the same as in s0.
         {
             auto sm0 = db::schema_tables::make_schema_mutations(s0, api::new_timestamp(), true);
-            std::vector<mutation> muts;
+            utils::chunked_vector<mutation> muts;
             sm0.copy_to(muts);
             db::schema_tables::merge_schema(e.get_system_keyspace(), e.get_storage_proxy(),
                                             e.get_feature_service().local(), muts).get();

--- a/test/boost/sstable_3_x_test.cc
+++ b/test/boost/sstable_3_x_test.cc
@@ -3218,7 +3218,7 @@ static sstables::shared_sstable write_and_compare_sstables(test_env& env, schema
     return sst;
 }
 
-static sstable_assertions validate_read(test_env& env, shared_sstable input_sst, std::vector<mutation> mutations) {
+static sstable_assertions validate_read(test_env& env, shared_sstable input_sst, utils::chunked_vector<mutation> mutations) {
     sstable_assertions sst(env, input_sst);
     sst.load();
 
@@ -3346,7 +3346,7 @@ static void write_mut_and_validate(test_env& env, schema_ptr s, const sstring& t
     }
 }
 
-static void write_mut_and_validate_version(test_env& env, schema_ptr s, const sstring& table_name, std::vector<mutation> muts,
+static void write_mut_and_validate_version(test_env& env, schema_ptr s, const sstring& table_name, utils::chunked_vector<mutation> muts,
         sstable_version_types version, validate_stats_metadata validate_flag) {
     lw_shared_ptr<replica::memtable> mt = make_memtable(s, muts);
     auto sst = write_and_compare_sstables(env, s, mt, table_name, version);
@@ -3356,7 +3356,7 @@ static void write_mut_and_validate_version(test_env& env, schema_ptr s, const ss
     }
 }
 
-static void write_mut_and_validate(test_env& env, schema_ptr s, const sstring& table_name, std::vector<mutation> muts,
+static void write_mut_and_validate(test_env& env, schema_ptr s, const sstring& table_name, utils::chunked_vector<mutation> muts,
         validate_stats_metadata validate_flag = validate_stats_metadata::no) {
     for (auto version : test_sstable_versions) {
         write_mut_and_validate_version(env, s, table_name, muts, version, validate_flag);
@@ -3653,7 +3653,7 @@ SEASTAR_TEST_CASE(test_write_multiple_partitions) {
     // INSERT INTO multiple_partitions (pk, rc1) VALUES (1, 10) USING TIMESTAMP 1525385507816568;
     // INSERT INTO multiple_partitions (pk, rc2) VALUES (2, 20) USING TIMESTAMP 1525385507816578;
     // INSERT INTO multiple_partitions (pk, rc3) VALUES (3, 30) USING TIMESTAMP 1525385507816588;
-    std::vector<mutation> muts;
+    utils::chunked_vector<mutation> muts;
     for (auto i : std::views::iota(1, 4)) {
         auto key = partition_key::from_deeply_exploded(*s, {i});
         muts.emplace_back(s, key);
@@ -3676,7 +3676,7 @@ static future<> test_write_many_partitions(sstring table_name, tombstone partiti
     builder.set_compressor_params(cp);
     schema_ptr s = builder.build(schema_builder::compact_storage::no);
 
-    std::vector<mutation> muts;
+    utils::chunked_vector<mutation> muts;
     for (auto i : std::views::iota(0, 65536)) {
         auto key = partition_key::from_deeply_exploded(*s, {i});
         muts.emplace_back(s, key);

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -1780,7 +1780,7 @@ SEASTAR_TEST_CASE(time_window_strategy_correctness_test) {
         auto num_sstables = 40;
         for (int r = 5; r < num_sstables; r++) {
             auto key = partition_key::from_exploded(*s, {to_bytes("key" + to_sstring(r))});
-            std::vector<mutation> mutations;
+            utils::chunked_vector<mutation> mutations;
             for (int i = 0 ; i < r ; i++) {
                 mutations.push_back(make_insert(key, tstamp + r));
             }
@@ -2213,7 +2213,7 @@ SEASTAR_TEST_CASE(sstable_cleanup_correctness_test) {
             auto local_keys = tests::generate_partition_keys(total_partitions, s);
             dht::decorated_key::less_comparator cmp(s);
             std::sort(local_keys.begin(), local_keys.end(), cmp);
-            std::vector<mutation> mutations;
+            utils::chunked_vector<mutation> mutations;
             for (auto i = 0U; i < total_partitions; i++) {
                 mutations.push_back(make_insert(local_keys.at(i)));
             }
@@ -2265,7 +2265,7 @@ future<> foreach_table_state_with_thread(table_for_tests& table, std::function<v
     });
 }
 
-static std::deque<mutation_fragment_v2> explode(reader_permit permit, std::vector<mutation> muts) {
+static std::deque<mutation_fragment_v2> explode(reader_permit permit, utils::chunked_vector<mutation> muts) {
     if (muts.empty()) {
         return {};
     }
@@ -2391,7 +2391,7 @@ public:
         BOOST_REQUIRE(found_sstable);
     }
 
-    void run(schema_ptr schema, std::vector<mutation> muts, test_func func) {
+    void run(schema_ptr schema, utils::chunked_vector<mutation> muts, test_func func) {
         run(std::move(schema), explode(env().make_reader_permit(), std::move(muts)), std::move(func));
     }
 };
@@ -3017,7 +3017,7 @@ SEASTAR_THREAD_TEST_CASE(sstable_scrub_skip_mode_test) {
     std::swap(cr1, cr2);
 
     // prepare the expected post-scrub version of "corrupt_fragments"
-    std::vector<mutation> scrubbed_muts;
+    utils::chunked_vector<mutation> scrubbed_muts;
     scrubbed_muts.push_back(corrupt_muts.front());
     std::copy(corrupt_muts.begin() + 2, corrupt_muts.end(), std::back_inserter(scrubbed_muts));
     auto scrubbed_fragments = explode(test.env().make_reader_permit(), std::move(scrubbed_muts));
@@ -4097,7 +4097,7 @@ SEASTAR_TEST_CASE(test_bug_6472) {
         cf->start();
 
         // Make 100 expiring cells which belong to different time windows
-        std::vector<mutation> muts;
+        utils::chunked_vector<mutation> muts;
         muts.reserve(101);
         for (auto i = 1; i < 101; i++) {
             muts.push_back(make_expiring_cell(std::chrono::hours(i)));
@@ -4579,10 +4579,10 @@ SEASTAR_TEST_CASE(twcs_reshape_with_disjoint_set_test) {
             // create set of 64 files which size is either small or big. as STCS reshape logic reused by TWCS favor compaction of smaller files
             // first, verify that only 32 small (similar-sized) files are returned
 
-            std::vector<mutation> mutations_for_small_files;
+            utils::chunked_vector<mutation> mutations_for_small_files;
             mutations_for_small_files.push_back(make_row(0, std::chrono::hours(1)));
 
-            std::vector<mutation> mutations_for_big_files;
+            utils::chunked_vector<mutation> mutations_for_big_files;
             for (unsigned i = 0; i < keys.size(); i++) {
                 mutations_for_big_files.push_back(make_row(i, std::chrono::hours(1)));
             }
@@ -4626,7 +4626,7 @@ SEASTAR_TEST_CASE(twcs_reshape_with_disjoint_set_test) {
             std::vector<sstables::shared_sstable> sstables;
             sstables.reserve(disjoint_sstable_count);
             for (auto i = 0U; i < disjoint_sstable_count; i++) {
-                std::vector<mutation> muts;
+                utils::chunked_vector<mutation> muts;
                 muts.reserve(5);
                 for (auto j = 0; j < 5; j++) {
                     muts.push_back(make_row(i, std::chrono::hours(j * 8)));
@@ -5450,7 +5450,7 @@ SEASTAR_TEST_CASE(test_large_partition_splitting_on_compaction) {
             return m;
         }();
 
-        std::vector<mutation> mutations;
+        utils::chunked_vector<mutation> mutations;
         static constexpr size_t rows = 20;
         mutations.reserve(1 + rows);
         mutations.push_back(std::move(deletion_mut));
@@ -6028,7 +6028,7 @@ SEASTAR_TEST_CASE(produces_optimal_filter_by_estimating_correctly_partitions_per
 
         const sstring shared_key_prefix = "832193982198319823hsdjahdashjdsa81923189381931829sdajidjkas812938219jdsalljdadsajk319820";
 
-        std::vector<mutation> muts;
+        utils::chunked_vector<mutation> muts;
         constexpr int keys = 200;
         muts.reserve(keys);
         for (auto i = 0; i < keys; i++) {
@@ -6078,7 +6078,7 @@ SEASTAR_TEST_CASE(splitting_compaction_test) {
         };
 
         auto keys = tests::generate_partition_keys(100, s);
-        std::vector<mutation> muts;
+        utils::chunked_vector<mutation> muts;
 
         muts.reserve(keys.size() * 2);
         for (auto& k : keys) {

--- a/test/boost/sstable_conforms_to_mutation_source_test.cc
+++ b/test/boost/sstable_conforms_to_mutation_source_test.cc
@@ -30,7 +30,7 @@ static db_clock::time_point to_db_clock(gc_clock::time_point tp) {
 }
 
 static
-mutation_source make_sstable_mutation_source(sstables::test_env& env, schema_ptr s, sstring dir, std::vector<mutation> mutations,
+mutation_source make_sstable_mutation_source(sstables::test_env& env, schema_ptr s, sstring dir, utils::chunked_vector<mutation> mutations,
         sstable_writer_config cfg, sstables::sstable::version_types version, gc_clock::time_point query_time = gc_clock::now()) {
     auto sst = env.make_sstable(s, dir, env.new_generation(), version, sstable_format_types::big, default_sstable_buffer_size, to_db_clock(query_time));
     auto mt = make_memtable(s, mutations);
@@ -68,7 +68,7 @@ void test_cache_population_with_range_tombstone_adjacent_to_population_range(pop
     cache_mt->apply(m1);
 
     cache_tracker tracker;
-    auto ms = populate(s.schema(), std::vector<mutation>({m1}), gc_clock::now());
+    auto ms = populate(s.schema(), utils::chunked_vector<mutation>({m1}), gc_clock::now());
     row_cache cache(s.schema(), snapshot_source_from_snapshot(std::move(ms)), tracker);
 
     auto pr = dht::partition_range::make_singular(pkey);
@@ -99,7 +99,7 @@ static future<> test_sstable_conforms_to_mutation_source(sstable_version_types v
         cfg.promoted_index_block_size = index_block_size;
 
         std::vector<tmpdir> dirs;
-        auto populate = [&env, &dirs, &cfg, version] (schema_ptr s, const std::vector<mutation>& partitions,
+        auto populate = [&env, &dirs, &cfg, version] (schema_ptr s, const utils::chunked_vector<mutation>& partitions,
                                                       gc_clock::time_point query_time) -> mutation_source {
             dirs.emplace_back();
             return make_sstable_mutation_source(env, s, dirs.back().path().string(), partitions, cfg, version, query_time);
@@ -207,7 +207,7 @@ SEASTAR_THREAD_TEST_CASE(test_sstable_reversing_reader_random_schema) {
 
     auto muts = tests::generate_random_mutations(random_schema).get();
 
-    std::vector<mutation> reversed_muts;
+    utils::chunked_vector<mutation> reversed_muts;
     for (auto& m : muts) {
         reversed_muts.push_back(reverse(m));
     }

--- a/test/boost/sstable_datafile_test.cc
+++ b/test/boost/sstable_datafile_test.cc
@@ -1707,7 +1707,7 @@ SEASTAR_TEST_CASE(test_skipping_using_index) {
         }
         std::sort(keys.begin(), keys.end(), dht::decorated_key::less_comparator(table.schema()));
 
-        std::vector<mutation> partitions;
+        utils::chunked_vector<mutation> partitions;
         uint32_t row_id = 0;
         for (auto&& key : keys) {
             mutation m(table.schema(), key);
@@ -1987,7 +1987,7 @@ SEASTAR_TEST_CASE(sstable_tombstone_histogram_test) {
                 return m;
             };
 
-            std::vector<mutation> mutations;
+            utils::chunked_vector<mutation> mutations;
             for (auto i = 0; i < sstables::TOMBSTONE_HISTOGRAM_BIN_SIZE * 2; i++) {
                 auto key = partition_key::from_exploded(*s, {to_bytes("key" + to_sstring(i))});
                 mutations.push_back(make_delete(key));
@@ -2039,7 +2039,7 @@ SEASTAR_TEST_CASE(sstable_owner_shards) {
             };
             auto muts = shards
                 | std::views::transform([&] (auto shard) { return mut(shard); })
-                | std::ranges::to<std::vector<mutation>>();
+                | std::ranges::to<utils::chunked_vector<mutation>>();
             auto sst_gen = [&] () mutable {
                 auto schema = schema_builder(s).with_sharder(1, ignore_msb).build();
                 auto sst = env.make_sstable(std::move(schema));
@@ -2090,7 +2090,7 @@ SEASTAR_TEST_CASE(test_summary_entry_spanning_more_keys_than_min_interval) {
                     .with_column("r1", int32_type)
                     .build();
         const column_definition& r1_col = *s->get_column_definition("r1");
-        std::vector<mutation> mutations;
+        utils::chunked_vector<mutation> mutations;
         auto keys_written = 0;
         for (auto i = 0; i < s->min_index_interval()*1.5; i++) {
             auto key = partition_key::from_exploded(*s, {int32_type->decompose(i)});
@@ -2294,7 +2294,7 @@ SEASTAR_TEST_CASE(summary_rebuild_sanity) {
             return m;
         };
 
-        std::vector<mutation> mutations;
+        utils::chunked_vector<mutation> mutations;
         for (auto i = 0; i < s->min_index_interval()*2; i++) {
             auto key = to_bytes("key" + to_sstring(i));
             mutations.push_back(make_insert(partition_key::from_exploded(*s, {std::move(key)})));
@@ -2344,7 +2344,7 @@ SEASTAR_TEST_CASE(sstable_partition_estimation_sanity_test) {
         {
             auto total_partitions = s->min_index_interval()*2;
 
-            std::vector<mutation> mutations;
+            utils::chunked_vector<mutation> mutations;
             for (auto i = 0; i < total_partitions; i++) {
                 auto key = to_bytes("key" + to_sstring(i));
                 mutations.push_back(make_large_partition(partition_key::from_exploded(*s, {std::move(key)})));
@@ -2357,7 +2357,7 @@ SEASTAR_TEST_CASE(sstable_partition_estimation_sanity_test) {
         {
             auto total_partitions = s->min_index_interval()*2;
 
-            std::vector<mutation> mutations;
+            utils::chunked_vector<mutation> mutations;
             for (auto i = 0; i < total_partitions; i++) {
                 auto key = to_bytes("key" + to_sstring(i));
                 mutations.push_back(make_small_partition(partition_key::from_exploded(*s, {std::move(key)})));
@@ -2454,7 +2454,7 @@ SEASTAR_TEST_CASE(sstable_run_clustering_disjoint_invariant_test) {
         auto pks = ss.make_pkeys(1);
 
         auto make_sstable = [&] (int first_ckey_idx, int last_ckey_idx) {
-            std::vector<mutation> muts;
+            utils::chunked_vector<mutation> muts;
             auto mut = mutation(s, pks[0]);
 
             auto first_ckey_prefix = ss.make_ckey(first_ckey_idx);
@@ -3070,7 +3070,7 @@ SEASTAR_TEST_CASE(find_first_position_in_partition_from_sstable_test) {
             auto pks = ss.make_pkeys(partitions);
             auto tmp = env.tempdir().make_sweeper();
 
-            std::vector<mutation> muts;
+            utils::chunked_vector<mutation> muts;
             std::optional<position_in_partition> first_position, last_position;
 
             static constexpr size_t ckeys_per_partition = 10;

--- a/test/boost/sstable_mutation_test.cc
+++ b/test/boost/sstable_mutation_test.cc
@@ -348,7 +348,7 @@ SEASTAR_TEST_CASE(read_partial_range_2) {
 }
 
 static
-mutation_source make_sstable_mutation_source(sstables::test_env& env, schema_ptr s, std::vector<mutation> mutations,
+mutation_source make_sstable_mutation_source(sstables::test_env& env, schema_ptr s, utils::chunked_vector<mutation> mutations,
         sstables::sstable::version_types version, db_clock::time_point query_time = db_clock::now()) {
     return make_sstable_easy(env, make_memtable(s, mutations), env.manager().configure_writer(), version, mutations.size(), query_time)->as_mutation_source();
 }
@@ -1455,7 +1455,7 @@ SEASTAR_TEST_CASE(test_static_compact_tables_are_read) {
             m2.set_clustered_cell(clustering_key::make_empty(), *s->get_column_definition("v2"),
                 atomic_cell::make_live(*int32_type, 1511270919978347, int32_type->decompose(6), {}));
 
-            std::vector<mutation> muts = {m1, m2};
+            utils::chunked_vector<mutation> muts = {m1, m2};
             std::ranges::sort(muts, mutation_decorated_key_less_comparator{});
 
             auto ms = make_sstable_mutation_source(env, s, muts, version);

--- a/test/boost/sstable_resharding_test.cc
+++ b/test/boost/sstable_resharding_test.cc
@@ -50,7 +50,7 @@ void run_sstable_resharding_test(sstables::test_env& env) {
     auto cf = env.make_table_for_tests(s);
     auto close_cf = deferred_stop(cf);
     auto sst_gen = env.make_sst_factory(s, version);
-    std::unordered_map<shard_id, std::vector<mutation>> muts;
+    std::unordered_map<shard_id, utils::chunked_vector<mutation>> muts;
     static constexpr auto keys_per_shard = 1000u;
 
     // create sst shared by all shards
@@ -170,7 +170,7 @@ SEASTAR_TEST_CASE(sstable_is_shared_correctness) {
             auto sst_gen = env.make_sst_factory(s, version);
 
             const auto keys = tests::generate_partition_keys(smp::count * 10, s);
-            std::vector<mutation> muts;
+            utils::chunked_vector<mutation> muts;
             for (auto& k : keys) {
                 muts.push_back(get_mutation(s, k, 0));
             }
@@ -187,7 +187,7 @@ SEASTAR_TEST_CASE(sstable_is_shared_correctness) {
             auto single_sharded_s = get_schema(1, cfg->murmur3_partitioner_ignore_msb_bits());
             auto sst_gen = env.make_sst_factory(single_sharded_s, version);
 
-            std::vector<mutation> muts;
+            utils::chunked_vector<mutation> muts;
             for (shard_id shard : std::views::iota(0u, smp::count)) {
                 const auto keys = tests::generate_partition_keys(10, key_s, shard);
                 for (auto& k : keys) {

--- a/test/boost/tablets_test.cc
+++ b/test/boost/tablets_test.cc
@@ -65,7 +65,7 @@ void verify_tablet_metadata_persistence(cql_test_env& env, const tablet_metadata
 }
 
 static
-void verify_tablet_metadata_update(cql_test_env& env, tablet_metadata& tm, std::vector<mutation> muts) {
+void verify_tablet_metadata_update(cql_test_env& env, tablet_metadata& tm, utils::chunked_vector<mutation> muts) {
     testlog.trace("verify_tablet_metadata_update(): {}", muts);
 
     auto& db = env.local_db();
@@ -601,7 +601,7 @@ SEASTAR_TEST_CASE(test_tablet_metadata_update) {
 
             const auto& tmap = tm.get_tablet_map(table2);
 
-            std::vector<mutation> muts;
+            utils::chunked_vector<mutation> muts;
             for (std::optional<tablet_id> tb = tmap.first_tablet(); tb; tb = tmap.next_tablet(*tb)) {
                 replica::tablet_mutation_builder builder(ts++, table2);
 
@@ -627,7 +627,7 @@ SEASTAR_TEST_CASE(test_tablet_metadata_update) {
 
             const auto& tmap = tm.get_tablet_map(table2);
 
-            std::vector<mutation> muts;
+            utils::chunked_vector<mutation> muts;
             for (std::optional<tablet_id> tb = tmap.first_tablet(); tb; tb = tmap.next_tablet(*tb)) {
                 replica::tablet_mutation_builder builder(ts++, table2);
 
@@ -671,7 +671,7 @@ SEASTAR_TEST_CASE(test_tablet_metadata_hint) {
         tablet_metadata tm = read_tablet_metadata(e.local_qp()).get();
         auto ts = current_timestamp(e);
 
-        auto check_hint = [&] (locator::tablet_metadata_change_hint& incremental_hint, std::vector<canonical_mutation>& muts, mutation new_mut,
+        auto check_hint = [&] (locator::tablet_metadata_change_hint& incremental_hint, utils::chunked_vector<canonical_mutation>& muts, mutation new_mut,
                 const locator::tablet_metadata_change_hint& expected_hint, std::source_location sl = std::source_location::current()) {
             testlog.info("check_hint() called from {}:{}", sl.file_name(), sl.line());
 
@@ -699,7 +699,7 @@ SEASTAR_TEST_CASE(test_tablet_metadata_hint) {
 
         // Unrelated mutation generates no hint
         {
-            std::vector<canonical_mutation> muts;
+            utils::chunked_vector<canonical_mutation> muts;
             locator::tablet_metadata_change_hint hint;
 
             simple_schema s;
@@ -711,7 +711,7 @@ SEASTAR_TEST_CASE(test_tablet_metadata_hint) {
 
         // Incremental update of hint
         {
-            std::vector<canonical_mutation> muts;
+            utils::chunked_vector<canonical_mutation> muts;
             locator::tablet_metadata_change_hint hint;
 
             const auto& tmap = tm.get_tablet_map(table1);
@@ -740,7 +740,7 @@ SEASTAR_TEST_CASE(test_tablet_metadata_hint) {
         auto check_delete_scenario = [&] (const char* scenario, std::function<void(table_id, mutation&, api::timestamp_type)> apply_delete) {
             testlog.info("check_delete_scenario({})", scenario);
 
-            std::vector<canonical_mutation> muts;
+            utils::chunked_vector<canonical_mutation> muts;
             locator::tablet_metadata_change_hint hint;
 
             // Check that a deletion generates only a partiton hint

--- a/test/boost/view_build_test.cc
+++ b/test/boost/view_build_test.cc
@@ -696,7 +696,7 @@ SEASTAR_THREAD_TEST_CASE(test_view_update_generator_buffering) {
         schema_ptr _schema;
         reader_concurrency_semaphore& _semaphore;
         const partition_size_map& _partition_rows;
-        std::vector<mutation>& _collected_muts;
+        utils::chunked_vector<mutation>& _collected_muts;
         std::unique_ptr<row_locker> _rl;
         std::unique_ptr<row_locker::stats> _rl_stats;
         clustering_key::less_compare _less_cmp;
@@ -765,7 +765,7 @@ SEASTAR_THREAD_TEST_CASE(test_view_update_generator_buffering) {
         }
 
     public:
-        consumer_verifier(schema_ptr schema, reader_concurrency_semaphore& sem, const partition_size_map& partition_rows, std::vector<mutation>& collected_muts, bool& ok)
+        consumer_verifier(schema_ptr schema, reader_concurrency_semaphore& sem, const partition_size_map& partition_rows, utils::chunked_vector<mutation>& collected_muts, bool& ok)
             : _schema(std::move(schema))
             , _semaphore(sem)
             , _partition_rows(partition_rows)
@@ -811,7 +811,7 @@ SEASTAR_THREAD_TEST_CASE(test_view_update_generator_buffering) {
     for (auto partition_sizes_100kb : partition_size_sets) {
         testlog.debug("partition_sizes_100kb={}", partition_sizes_100kb);
         partition_size_map partition_rows{dht::ring_position_less_comparator(*schema)};
-        std::vector<mutation> muts;
+        utils::chunked_vector<mutation> muts;
         auto pk = 0;
         for (auto partition_size_100kb : partition_sizes_100kb) {
             auto mut_desc = tests::data_model::mutation_description(pkeys.at(pk++).key().explode(*schema));
@@ -843,7 +843,7 @@ SEASTAR_THREAD_TEST_CASE(test_view_update_generator_buffering) {
         auto& staging_reader_handle = std::get<1>(p);
         auto close_staging_reader = deferred_close(staging_reader);
 
-        std::vector<mutation> collected_muts;
+        utils::chunked_vector<mutation> collected_muts;
         bool ok = true;
 
         staging_reader.consume_in_thread(db::view::view_updating_consumer(schema, permit, as, staging_reader_handle,
@@ -883,7 +883,7 @@ SEASTAR_THREAD_TEST_CASE(test_view_update_generator_buffering_with_random_mutati
     // Collects the mutations produced by the tested view_updating_consumer into a vector.
     class consumer_verifier {
         schema_ptr _schema;
-        std::vector<mutation>& _collected_muts;
+        utils::chunked_vector<mutation>& _collected_muts;
         std::unique_ptr<row_locker> _rl;
         std::unique_ptr<row_locker::stats> _rl_stats;
         bool& _ok;
@@ -895,7 +895,7 @@ SEASTAR_THREAD_TEST_CASE(test_view_update_generator_buffering_with_random_mutati
         }
 
     public:
-        consumer_verifier(schema_ptr schema, std::vector<mutation>& collected_muts, bool& ok)
+        consumer_verifier(schema_ptr schema, utils::chunked_vector<mutation>& collected_muts, bool& ok)
             : _schema(std::move(schema))
             , _collected_muts(collected_muts)
             , _rl(std::make_unique<row_locker>(_schema))
@@ -944,7 +944,7 @@ SEASTAR_THREAD_TEST_CASE(test_view_update_generator_buffering_with_random_mutati
 
     // Feed the random valid mutation fragment stream to the view_updating_consumer,
     // and collect its outputs.
-    std::vector<mutation> collected_muts;
+    utils::chunked_vector<mutation> collected_muts;
     bool ok = true;
     auto vuc = db::view::view_updating_consumer(schema, permit, as, staging_reader_handle,
                     consumer_verifier(schema, collected_muts, ok));

--- a/test/boost/virtual_table_mutation_source_test.cc
+++ b/test/boost/virtual_table_mutation_source_test.cc
@@ -16,9 +16,9 @@
 #include "test/lib/scylla_test_case.hh"
 
 class memtable_filling_test_vt : public db::memtable_filling_virtual_table {
-    std::vector<mutation> _mutations;
+    utils::chunked_vector<mutation> _mutations;
 public:
-    memtable_filling_test_vt(schema_ptr s, std::vector<mutation> mutations)
+    memtable_filling_test_vt(schema_ptr s, utils::chunked_vector<mutation> mutations)
             : memtable_filling_virtual_table(s)
             , _mutations(std::move(mutations)) {}
 
@@ -29,9 +29,9 @@ public:
 
 class streaming_test_vt : public db::streaming_virtual_table {
     schema_ptr _s;
-    std::vector<mutation> _mutations;
+    utils::chunked_vector<mutation> _mutations;
 public:
-    streaming_test_vt(schema_ptr s, std::vector<mutation> mutations)
+    streaming_test_vt(schema_ptr s, utils::chunked_vector<mutation> mutations)
             : streaming_virtual_table(s)
             , _s(s)
             , _mutations(std::move(mutations)) {}
@@ -51,7 +51,7 @@ public:
 SEASTAR_THREAD_TEST_CASE(test_memtable_filling_vt_as_mutation_source) {
     std::unique_ptr<memtable_filling_test_vt> table; // Used to prolong table's life
 
-    run_mutation_source_tests([&table] (schema_ptr s, const std::vector<mutation>& mutations, gc_clock::time_point) -> mutation_source {
+    run_mutation_source_tests([&table] (schema_ptr s, const utils::chunked_vector<mutation>& mutations, gc_clock::time_point) -> mutation_source {
         table = std::make_unique<memtable_filling_test_vt>(s, mutations);
         return table->as_mutation_source();
     });
@@ -60,7 +60,7 @@ SEASTAR_THREAD_TEST_CASE(test_memtable_filling_vt_as_mutation_source) {
 SEASTAR_THREAD_TEST_CASE(test_streaming_vt_as_mutation_source) {
     std::unique_ptr<streaming_test_vt> table; // Used to prolong table's life
 
-    run_mutation_source_tests([&table] (schema_ptr s, const std::vector<mutation>& mutations, gc_clock::time_point) -> mutation_source {
+    run_mutation_source_tests([&table] (schema_ptr s, const utils::chunked_vector<mutation>& mutations, gc_clock::time_point) -> mutation_source {
         table = std::make_unique<streaming_test_vt>(s, mutations);
         return mutation_source([ms = table->as_mutation_source()] (schema_ptr s,
                 reader_permit permit,

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -294,7 +294,7 @@ public:
             });
     }
 
-    virtual future<std::vector<mutation>> get_modification_mutations(const sstring& text) override {
+    virtual future<utils::chunked_vector<mutation>> get_modification_mutations(const sstring& text) override {
         auto qs = make_query_state();
         auto cql_stmt = local_qp().get_statement(text, qs->get_client_state(), test_dialect())->statement;
         auto modif_stmt = dynamic_pointer_cast<cql3::statements::modification_statement>(std::move(cql_stmt));

--- a/test/lib/cql_test_env.hh
+++ b/test/lib/cql_test_env.hh
@@ -139,7 +139,7 @@ public:
         cql3::prepared_cache_key_type id,
         std::unique_ptr<cql3::query_options> qo) = 0;
 
-    virtual future<std::vector<mutation>> get_modification_mutations(const sstring& text) = 0;
+    virtual future<utils::chunked_vector<mutation>> get_modification_mutations(const sstring& text) = 0;
 
     virtual future<> create_table(std::function<schema(std::string_view)> schema_maker) = 0;
 

--- a/test/lib/data_model.cc
+++ b/test/lib/data_model.cc
@@ -272,10 +272,10 @@ schema_ptr table_description::build_schema() const {
     return sb.build();
 }
 
-std::vector<mutation> table_description::build_mutations(schema_ptr s) const {
+utils::chunked_vector<mutation> table_description::build_mutations(schema_ptr s) const {
     auto ms = _mutations | std::views::transform([&] (const mutation_description& md) {
             return md.build(s);
-        }) | std::ranges::to<std::vector<mutation>>();
+        }) | std::ranges::to<utils::chunked_vector<mutation>>();
     std::ranges::sort(ms, mutation_decorated_key_less_comparator());
     return ms;
 }

--- a/test/lib/data_model.hh
+++ b/test/lib/data_model.hh
@@ -118,7 +118,7 @@ private:
 
     std::vector<removed_column> _removed_columns;
 
-    std::vector<mutation_description> _mutations;
+    utils::chunked_vector<mutation_description> _mutations;
 
     std::vector<sstring> _change_log;
 
@@ -131,7 +131,7 @@ private:
 
     schema_ptr build_schema() const;
 
-    std::vector<mutation> build_mutations(schema_ptr s) const;
+    utils::chunked_vector<mutation> build_mutations(schema_ptr s) const;
 public:
     explicit table_description(std::vector<column> partition_key, std::vector<column> clustering_key);
 
@@ -153,13 +153,13 @@ public:
     void rename_partition_column(const sstring& from, const sstring& to);
     void rename_clustering_column(const sstring& from, const sstring& to);
 
-    std::vector<mutation_description>& unordered_mutations() { return _mutations; }
-    const std::vector<mutation_description>& unordered_mutations() const { return _mutations; }
+    utils::chunked_vector<mutation_description>& unordered_mutations() { return _mutations; }
+    const utils::chunked_vector<mutation_description>& unordered_mutations() const { return _mutations; }
 
     struct table {
         sstring schema_changes_log;
         schema_ptr schema;
-        std::vector<mutation> mutations;
+        utils::chunked_vector<mutation> mutations;
     };
     table build() const;
 };

--- a/test/lib/mutation_source_test.cc
+++ b/test/lib/mutation_source_test.cc
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
  */
 
+#include <iterator>
 #include <set>
 #include <boost/test/unit_test.hpp>
 #include <fmt/ranges.h>
@@ -36,7 +37,7 @@
 #include "utils/UUID_gen.hh"
 
 // partitions must be sorted by decorated key
-static void require_no_token_duplicates(const std::vector<mutation>& partitions) {
+static void require_no_token_duplicates(const utils::chunked_vector<mutation>& partitions) {
     std::optional<dht::token> last_token;
     for (auto&& p : partitions) {
         const dht::decorated_key& key = p.decorated_key();
@@ -87,7 +88,7 @@ static void test_slicing_and_fast_forwarding(tests::reader_concurrency_semaphore
 
     auto dkeys = s.make_pkeys(128);
     auto dkeys_pos = 0;
-    std::vector<mutation> mutations;
+    utils::chunked_vector<mutation> mutations;
 
     {   // All clustered rows and a static row, range tombstones covering each row
         auto m = mutation(s.schema(), dkeys.at(dkeys_pos++));
@@ -158,7 +159,7 @@ static void test_slicing_and_fast_forwarding(tests::reader_concurrency_semaphore
 
     mutation_source ms = populate(s.schema(), mutations, gc_clock::now());
 
-    auto test_ckey = [&] (std::vector<dht::partition_range> pranges, std::vector<mutation> mutations, mutation_reader::forwarding fwd_mr) {
+    auto test_ckey = [&] (std::vector<dht::partition_range> pranges, utils::chunked_vector<mutation> mutations, mutation_reader::forwarding fwd_mr) {
         for (auto range_size = 1u; range_size <= ckey_count + 1; range_size++) {
             for (auto start = 0u; start <= ckey_count; start++) {
                 auto range = range_size == 1
@@ -319,7 +320,7 @@ static void test_slicing_and_fast_forwarding(tests::reader_concurrency_semaphore
 
     for (auto prange_size = 1u; prange_size < mutations.size(); prange_size += 2) {
         for (auto pstart = 0u; pstart + prange_size <= mutations.size(); pstart++) {
-            auto ms = mutations | std::views::drop(pstart) | std::views::take(prange_size) | std::ranges::to<std::vector>();
+            auto ms = mutations | std::views::drop(pstart) | std::views::take(prange_size) | std::ranges::to<utils::chunked_vector<mutation>>();
             if (prange_size == 1) {
                 test_ckey({dht::partition_range::make_singular(mutations[pstart].decorated_key())}, ms, mutation_reader::forwarding::yes);
                 test_ckey({dht::partition_range::make_singular(mutations[pstart].decorated_key())}, ms, mutation_reader::forwarding::no);
@@ -419,7 +420,7 @@ static void test_streamed_mutation_forwarding_guarantees(tests::reader_concurren
 
     table.add_static_row(m, "static_value");
 
-    mutation_source ms = populate(s, std::vector<mutation>({m}), gc_clock::now());
+    mutation_source ms = populate(s, utils::chunked_vector<mutation>({m}), gc_clock::now());
 
     auto new_stream = [&ms, s, &semaphore, &m] () -> mutation_reader_assertions {
         testlog.info("Creating new streamed_mutation");
@@ -532,7 +533,7 @@ static void test_fast_forwarding_across_partitions_to_empty_range(tests::reader_
     simple_schema table;
     schema_ptr s = table.schema();
 
-    std::vector<mutation> partitions;
+    utils::chunked_vector<mutation> partitions;
 
     const unsigned ckeys_per_part = 100;
     auto keys = table.make_pkeys(10);
@@ -646,7 +647,7 @@ static void test_streamed_mutation_slicing_returns_only_relevant_tombstones(test
     table.add_row(m, keys[10], "value");
 
     auto pr = dht::partition_range::make_singular(m.decorated_key());
-    mutation_source ms = populate(s, std::vector<mutation>({m}), gc_clock::now());
+    mutation_source ms = populate(s, utils::chunked_vector<mutation>({m}), gc_clock::now());
 
     {
         auto slice = partition_slice_builder(*s)
@@ -746,7 +747,7 @@ static void test_streamed_mutation_forwarding_across_range_tombstones(tests::rea
     );
     auto rt5 = table.delete_range(m, rt5_range);
 
-    mutation_source ms = populate(s, std::vector<mutation>({m}), gc_clock::now());
+    mutation_source ms = populate(s, utils::chunked_vector<mutation>({m}), gc_clock::now());
     auto rd = assert_that(ms.make_mutation_reader(s,
         semaphore.make_permit(),
         query::full_partition_range,
@@ -828,20 +829,21 @@ static void test_range_queries(tests::reader_concurrency_semaphore_wrapper& sema
 
     auto keys = tests::generate_partition_keys(partition_count, s);
 
-    std::vector<mutation> partitions;
+    utils::chunked_vector<mutation> sorted_partitions;
     for (int i = 0; i < partition_count; ++i) {
-        partitions.emplace_back(
+        sorted_partitions.emplace_back(
             make_partition_mutation(keys[i]));
     }
 
-    std::sort(partitions.begin(), partitions.end(), mutation_decorated_key_less_comparator());
-    require_no_token_duplicates(partitions);
+    std::sort(sorted_partitions.begin(), sorted_partitions.end(), mutation_decorated_key_less_comparator());
+    require_no_token_duplicates(sorted_partitions);
 
-    dht::decorated_key key_before_all = partitions.front().decorated_key();
-    partitions.erase(partitions.begin());
+    dht::decorated_key key_before_all = sorted_partitions.front().decorated_key();
 
-    dht::decorated_key key_after_all = partitions.back().decorated_key();
-    partitions.pop_back();
+    dht::decorated_key key_after_all = sorted_partitions.back().decorated_key();
+
+    utils::chunked_vector<mutation> partitions;
+    std::move(std::make_move_iterator(sorted_partitions.begin()) + 1, std::make_move_iterator(sorted_partitions.end()) - 1, std::back_inserter(partitions));
 
     auto ds = populate(s, partitions, gc_clock::now());
 
@@ -1367,7 +1369,7 @@ void test_range_tombstones_v2(tests::reader_concurrency_semaphore_wrapper& semap
     simple_schema s;
     auto pkey = s.make_pkey();
 
-    std::vector<mutation> mutations;
+    utils::chunked_vector<mutation> mutations;
 
     mutation m(s.schema(), pkey);
     s.add_row(m, s.make_ckey(0), "v1");
@@ -1566,7 +1568,7 @@ void test_reader_conversions(tests::reader_concurrency_semaphore_wrapper& semaph
     testlog.info(__PRETTY_FUNCTION__);
 
     for_each_mutation([&] (const mutation& m) mutable {
-        std::vector<mutation> mutations = { m };
+        utils::chunked_vector<mutation> mutations = { m };
         auto ms = populate(m.schema(), mutations, gc_clock::now());
 
         // Query time must be fetched after populate. If compaction is executed
@@ -1634,7 +1636,7 @@ void test_next_partition(tests::reader_concurrency_semaphore_wrapper& semaphore,
     simple_schema s;
     auto pkeys = s.make_pkeys(4);
 
-    std::vector<mutation> mutations;
+    utils::chunked_vector<mutation> mutations;
     for (auto key : pkeys) {
         mutation m(s.schema(), key);
         s.add_static_row(m, "s1");
@@ -1664,7 +1666,7 @@ void test_next_partition(tests::reader_concurrency_semaphore_wrapper& semaphore,
 }
 
 void run_mutation_source_tests(populate_fn populate, bool with_partition_range_forwarding) {
-    auto populate_ex = [populate = std::move(populate)] (schema_ptr s, const std::vector<mutation>& muts, gc_clock::time_point) {
+    auto populate_ex = [populate = std::move(populate)] (schema_ptr s, const utils::chunked_vector<mutation>& muts, gc_clock::time_point) {
         return populate(std::move(s), muts);
     };
     run_mutation_source_tests(std::move(populate_ex), with_partition_range_forwarding);
@@ -1708,10 +1710,10 @@ void run_mutation_source_tests_plain_read_back(populate_fn_ex populate, bool wit
 
 // read in reverse
 static mutation_source make_mutation_source(populate_fn_ex populate, schema_ptr s,
-        const std::vector<mutation>& m, gc_clock::time_point t) {
+        const utils::chunked_vector<mutation>& m, gc_clock::time_point t) {
     auto table_schema = s->make_reversed();
 
-    std::vector<mutation> reversed_mutations;
+    utils::chunked_vector<mutation> reversed_mutations;
     reversed_mutations.reserve(m.size());
     for (const auto& mut : m) {
         reversed_mutations.emplace_back(reverse(mut));
@@ -1737,7 +1739,7 @@ static mutation_source make_mutation_source(populate_fn_ex populate, schema_ptr 
 
 void run_mutation_source_tests_reverse(populate_fn_ex populate, bool with_partition_range_forwarding) {
     testlog.info(__PRETTY_FUNCTION__);
-    run_mutation_reader_tests_all([&populate] (schema_ptr s, const std::vector<mutation>& m, gc_clock::time_point t) -> mutation_source {
+    run_mutation_reader_tests_all([&populate] (schema_ptr s, const utils::chunked_vector<mutation>& m, gc_clock::time_point t) -> mutation_source {
         return make_mutation_source(populate, s, m, t);
     }, false); // FIXME: pass with_partition_range_forwarding after all natively reversing sources have fast-forwarding support
 }
@@ -1745,7 +1747,7 @@ void run_mutation_source_tests_reverse(populate_fn_ex populate, bool with_partit
 void run_mutation_source_tests_reverse_basic(populate_fn_ex populate, bool with_partition_range_forwarding) {
     testlog.info(__PRETTY_FUNCTION__);
     tests::reader_concurrency_semaphore_wrapper semaphore;
-    run_mutation_reader_tests_basic(semaphore, [&populate] (schema_ptr s, const std::vector<mutation>& m, gc_clock::time_point t) -> mutation_source {
+    run_mutation_reader_tests_basic(semaphore, [&populate] (schema_ptr s, const utils::chunked_vector<mutation>& m, gc_clock::time_point t) -> mutation_source {
         return make_mutation_source(populate, s, m, t);
     }, false); // FIXME: pass with_partition_range_forwarding after all natively reversing sources have fast-forwarding support
 }
@@ -1753,7 +1755,7 @@ void run_mutation_source_tests_reverse_basic(populate_fn_ex populate, bool with_
 void run_mutation_source_tests_reverse_reader_conversion(populate_fn_ex populate, bool with_partition_range_forwarding) {
     testlog.info(__PRETTY_FUNCTION__);
     tests::reader_concurrency_semaphore_wrapper semaphore;
-    test_reader_conversions(semaphore, [&populate] (schema_ptr s, const std::vector<mutation>& m, gc_clock::time_point t) -> mutation_source {
+    test_reader_conversions(semaphore, [&populate] (schema_ptr s, const utils::chunked_vector<mutation>& m, gc_clock::time_point t) -> mutation_source {
         return make_mutation_source(populate, s, m, t);
     });
 }
@@ -1761,7 +1763,7 @@ void run_mutation_source_tests_reverse_reader_conversion(populate_fn_ex populate
 void run_mutation_source_tests_reverse_fragments_monotonic(populate_fn_ex populate, bool with_partition_range_forwarding) {
     testlog.info(__PRETTY_FUNCTION__);
     tests::reader_concurrency_semaphore_wrapper semaphore;
-    test_mutation_reader_fragments_have_monotonic_positions(semaphore, [&populate] (schema_ptr s, const std::vector<mutation>& m, gc_clock::time_point t) -> mutation_source {
+    test_mutation_reader_fragments_have_monotonic_positions(semaphore, [&populate] (schema_ptr s, const utils::chunked_vector<mutation>& m, gc_clock::time_point t) -> mutation_source {
         return make_mutation_source(populate, s, m, t);
     });
 }
@@ -1769,14 +1771,14 @@ void run_mutation_source_tests_reverse_fragments_monotonic(populate_fn_ex popula
 void run_mutation_source_tests_reverse_read_back(populate_fn_ex populate, bool with_partition_range_forwarding) {
     testlog.info(__PRETTY_FUNCTION__);
     tests::reader_concurrency_semaphore_wrapper semaphore;
-    test_all_data_is_read_back(semaphore, [&populate] (schema_ptr s, const std::vector<mutation>& m, gc_clock::time_point t) -> mutation_source {
+    test_all_data_is_read_back(semaphore, [&populate] (schema_ptr s, const utils::chunked_vector<mutation>& m, gc_clock::time_point t) -> mutation_source {
         return make_mutation_source(populate, s, m, t);
     });
 }
 
 struct mutation_sets {
-    std::vector<std::vector<mutation>> equal;
-    std::vector<std::vector<mutation>> unequal;
+    std::vector<utils::chunked_vector<mutation>> equal;
+    std::vector<utils::chunked_vector<mutation>> unequal;
     mutation_sets(){}
 };
 
@@ -1785,7 +1787,7 @@ static tombstone new_tombstone() {
 }
 
 static mutation_sets generate_mutation_sets() {
-    using mutations = std::vector<mutation>;
+    using mutations = utils::chunked_vector<mutation>;
     mutation_sets result;
 
     {
@@ -2384,9 +2386,9 @@ public:
         return tests::generate_partition_keys(n, _schema, _local_shard_only);
     }
 
-    std::vector<mutation> operator()(size_t n) {
+    utils::chunked_vector<mutation> operator()(size_t n) {
         auto keys = make_partition_keys(n);
-        std::vector<mutation> mutations;
+        utils::chunked_vector<mutation> mutations;
         for (auto&& dkey : keys) {
             auto m = operator()();
             mutations.emplace_back(_schema, std::move(dkey), std::move(m.partition()));
@@ -2405,7 +2407,7 @@ mutation random_mutation_generator::operator()() {
     return (*_impl)();
 }
 
-std::vector<mutation> random_mutation_generator::operator()(size_t n) {
+utils::chunked_vector<mutation> random_mutation_generator::operator()(size_t n) {
     return (*_impl)(n);
 }
 
@@ -2433,8 +2435,8 @@ void random_mutation_generator::set_key_cardinality(size_t n_keys) {
     _impl->set_key_cardinality(n_keys);
 }
 
-void for_each_schema_change(std::function<void(schema_ptr, const std::vector<mutation>&,
-                                               schema_ptr, const std::vector<mutation>&)> fn) {
+void for_each_schema_change(std::function<void(schema_ptr, const utils::chunked_vector<mutation>&,
+                                               schema_ptr, const utils::chunked_vector<mutation>&)> fn) {
     auto map_of_int_to_int = map_type_impl::get_instance(int32_type, int32_type, true);
     auto map_of_int_to_bytes = map_type_impl::get_instance(int32_type, bytes_type, true);
     auto frozen_map_of_int_to_int = map_type_impl::get_instance(int32_type, int32_type, false);
@@ -2814,7 +2816,7 @@ mutation forwardable_reader_to_mutation(mutation_reader r, const std::vector<pos
     return std::move(*m);
 }
 
-std::vector<mutation> squash_mutations(std::vector<mutation> mutations) {
+utils::chunked_vector<mutation> squash_mutations(utils::chunked_vector<mutation> mutations) {
     if (mutations.empty()) {
         return {};
     }
@@ -2826,5 +2828,5 @@ std::vector<mutation> squash_mutations(std::vector<mutation> mutations) {
             it->second.apply(mut);
         }
     }
-    return merged_muts | std::views::values | std::ranges::to<std::vector>();
+    return merged_muts | std::views::values | std::ranges::to<utils::chunked_vector<mutation>>();
 }

--- a/test/lib/mutation_source_test.hh
+++ b/test/lib/mutation_source_test.hh
@@ -11,8 +11,8 @@
 #include "readers/mutation_reader_fwd.hh"
 #include "test/lib/simple_schema.hh"
 
-using populate_fn = std::function<mutation_source(schema_ptr s, const std::vector<mutation>&)>;
-using populate_fn_ex = std::function<mutation_source(schema_ptr s, const std::vector<mutation>&, gc_clock::time_point)>;
+using populate_fn = std::function<mutation_source(schema_ptr s, const utils::chunked_vector<mutation>&)>;
+using populate_fn_ex = std::function<mutation_source(schema_ptr s, const utils::chunked_vector<mutation>&, gc_clock::time_point)>;
 
 // Must be run in a seastar thread
 void run_mutation_source_tests(populate_fn populate, bool with_partition_range_forwarding = true);
@@ -46,7 +46,7 @@ inline bool can_upgrade_schema(schema_ptr from, schema_ptr to) {
 // The returned vector has mutations with unique keys.
 // run_mutation_source_tests() might pass in multiple mutations for the same key.
 // Some tests need these deduplicated, which is what this method does.
-std::vector<mutation> squash_mutations(std::vector<mutation> mutations);
+utils::chunked_vector<mutation> squash_mutations(utils::chunked_vector<mutation> mutations);
 
 class random_mutation_generator {
     class impl;
@@ -67,7 +67,7 @@ public:
     ~random_mutation_generator();
     mutation operator()();
     // Generates n mutations sharing the same schema nad sorted by their decorated keys.
-    std::vector<mutation> operator()(size_t n);
+    utils::chunked_vector<mutation> operator()(size_t n);
     schema_ptr schema() const;
     clustering_key make_random_key();
     range_tombstone make_random_range_tombstone();
@@ -79,8 +79,8 @@ public:
 
 bytes make_blob(size_t blob_size);
 
-void for_each_schema_change(std::function<void(schema_ptr, const std::vector<mutation>&,
-                                               schema_ptr, const std::vector<mutation>&)>);
+void for_each_schema_change(std::function<void(schema_ptr, const utils::chunked_vector<mutation>&,
+                                               schema_ptr, const utils::chunked_vector<mutation>&)>);
 
 void compare_readers(const schema&, mutation_reader authority, mutation_reader tested, bool exact = false);
 void compare_readers(const schema&, mutation_reader authority, mutation_reader tested, const std::vector<position_range>& fwd_ranges);

--- a/test/lib/random_schema.hh
+++ b/test/lib/random_schema.hh
@@ -256,7 +256,7 @@ public:
 /// ignored if the schema has no clustering columns.
 /// Mutations are returned in ring order. Does not contain duplicate partitions.
 /// Futurized to avoid stalls.
-future<std::vector<mutation>> generate_random_mutations(
+future<utils::chunked_vector<mutation>> generate_random_mutations(
         uint32_t seed,
         tests::random_schema& random_schema,
         timestamp_generator ts_gen = default_timestamp_generator(),
@@ -265,7 +265,7 @@ future<std::vector<mutation>> generate_random_mutations(
         std::uniform_int_distribution<size_t> clustering_row_count_dist = std::uniform_int_distribution<size_t>(16, 128),
         std::uniform_int_distribution<size_t> range_tombstone_count_dist = std::uniform_int_distribution<size_t>(4, 16));
 
-future<std::vector<mutation>> generate_random_mutations(
+future<utils::chunked_vector<mutation>> generate_random_mutations(
         tests::random_schema& random_schema,
         timestamp_generator ts_gen = default_timestamp_generator(),
         expiry_generator exp_gen = no_expiry_expiry_generator(),
@@ -274,6 +274,6 @@ future<std::vector<mutation>> generate_random_mutations(
         std::uniform_int_distribution<size_t> range_tombstone_count_dist = std::uniform_int_distribution<size_t>(4, 16));
 
 /// Generate exactly partition_count partitions. See the more general overload above.
-future<std::vector<mutation>> generate_random_mutations(tests::random_schema& random_schema, size_t partition_count);
+future<utils::chunked_vector<mutation>> generate_random_mutations(tests::random_schema& random_schema, size_t partition_count);
 
 } // namespace tests

--- a/test/lib/sstable_utils.cc
+++ b/test/lib/sstable_utils.cc
@@ -23,7 +23,7 @@
 using namespace sstables;
 using namespace std::chrono_literals;
 
-lw_shared_ptr<replica::memtable> make_memtable(schema_ptr s, const std::vector<mutation>& muts) {
+lw_shared_ptr<replica::memtable> make_memtable(schema_ptr s, const utils::chunked_vector<mutation>& muts) {
     auto mt = make_lw_shared<replica::memtable>(s);
 
     std::size_t i{0};
@@ -58,11 +58,11 @@ sstables::shared_sstable make_sstable_containing(sstables::shared_sstable sst, l
     return sst;
 }
 
-sstables::shared_sstable make_sstable_containing(std::function<sstables::shared_sstable()> sst_factory, std::vector<mutation> muts, validate do_validate) {
+sstables::shared_sstable make_sstable_containing(std::function<sstables::shared_sstable()> sst_factory, utils::chunked_vector<mutation> muts, validate do_validate) {
     return make_sstable_containing(sst_factory(), std::move(muts), do_validate);
 }
 
-sstables::shared_sstable make_sstable_containing(sstables::shared_sstable sst, std::vector<mutation> muts, validate do_validate) {
+sstables::shared_sstable make_sstable_containing(sstables::shared_sstable sst, utils::chunked_vector<mutation> muts, validate do_validate) {
     schema_ptr s = muts[0].schema();
     make_sstable_containing(sst, make_memtable(s, muts));
 

--- a/test/lib/sstable_utils.hh
+++ b/test/lib/sstable_utils.hh
@@ -29,8 +29,8 @@ using validate = bool_class<struct validate_tag>;
 // Must be called in a seastar thread.
 sstables::shared_sstable make_sstable_containing(std::function<sstables::shared_sstable()> sst_factory, lw_shared_ptr<replica::memtable> mt);
 sstables::shared_sstable make_sstable_containing(sstables::shared_sstable sst, lw_shared_ptr<replica::memtable> mt);
-sstables::shared_sstable make_sstable_containing(std::function<sstables::shared_sstable()> sst_factory, std::vector<mutation> muts, validate do_validate = validate::yes);
-sstables::shared_sstable make_sstable_containing(sstables::shared_sstable sst, std::vector<mutation> muts, validate do_validate = validate::yes);
+sstables::shared_sstable make_sstable_containing(std::function<sstables::shared_sstable()> sst_factory, utils::chunked_vector<mutation> muts, validate do_validate = validate::yes);
+sstables::shared_sstable make_sstable_containing(sstables::shared_sstable sst, utils::chunked_vector<mutation> muts, validate do_validate = validate::yes);
 
 namespace sstables {
 
@@ -256,5 +256,5 @@ inline shared_sstable make_sstable_easy(test_env& env, lw_shared_ptr<replica::me
     return make_sstable_easy(env, std::move(mt), std::move(cfg), env.new_generation(), version, estimated_partitions, query_time);
 }
 
-lw_shared_ptr<replica::memtable> make_memtable(schema_ptr s, const std::vector<mutation>& muts);
+lw_shared_ptr<replica::memtable> make_memtable(schema_ptr s, const utils::chunked_vector<mutation>& muts);
 std::vector<replica::memtable*> active_memtables(replica::table& t);

--- a/test/perf/perf_tablets.cc
+++ b/test/perf/perf_tablets.cc
@@ -125,7 +125,7 @@ static future<> test_basic_operations(app_template& app) {
 
         testlog.info("Read in {:.6f} [ms]", time_to_read.count() * 1000);
 
-        std::vector<canonical_mutation> muts;
+        utils::chunked_vector<canonical_mutation> muts;
         auto time_to_read_muts = duration_in_seconds([&] {
             muts = replica::read_tablet_mutations(e.local_qp().proxy().get_db()).get();
         });
@@ -169,7 +169,7 @@ static future<> test_basic_operations(app_template& app) {
             builder.set_stage(token, tablet_transition_stage::streaming);
             builder.set_transition(token, tablet_transition_kind::migration);
 
-            std::vector<mutation> muts;
+            utils::chunked_vector<mutation> muts;
             muts.push_back(builder.build());
             e.local_db().apply(freeze(muts), db::no_timeout).get();
             replica::update_tablet_metadata_change_hint(hint, muts.front());


### PR DESCRIPTION
Currently, we use std::vector<*mutation> to keep
a list of mutations for processing.
This can lead to large allocation, e.g. when the vector size is a function of the number of tables.

Use a chunked vector instead to prevent oversized allocations.

Fixes #24815

* Improvement for rare corner cases so no backport required