### PR TITLE
alternator: streams: Address minor incompatibilities with DynamoDB in GetRecords response.

### DIFF
--- a/alternator/streams.cc
+++ b/alternator/streams.cc
@@ -32,6 +32,7 @@
 
 #include "executor.hh"
 #include "data_dictionary/data_dictionary.hh"
+#include "utils/rjson.hh"
 
 /**
  * Base template type to implement  rapidjson::internal::TypeHelper<...>:s
@@ -925,6 +926,7 @@ future<executor::request_return_type> executor::get_records(client_state& client
         std::optional<utils::UUID> timestamp;
         auto dynamodb = rjson::empty_object();
         auto record = rjson::empty_object();
+        const auto dc_name = _proxy.get_token_metadata_ptr()->get_topology().get_datacenter();
 
         using op_utype = std::underlying_type_t<cdc::operation>;
 
@@ -934,9 +936,10 @@ future<executor::request_return_type> executor::get_records(client_state& client
                 dynamodb = rjson::empty_object();
             }
             if (!record.ObjectEmpty()) {
-                // TODO: awsRegion?
+                rjson::add(record, "awsRegion", rjson::from_string(dc_name));
                 rjson::add(record, "eventID", event_id(iter.shard.id, *timestamp));
                 rjson::add(record, "eventSource", "scylladb:alternator");
+                rjson::add(record, "eventVersion", "1.0");
                 rjson::push_back(records, std::move(record));
                 record = rjson::empty_object();
                 --limit;
@@ -955,7 +958,7 @@ future<executor::request_return_type> executor::get_records(client_state& client
                 rjson::add(dynamodb, "ApproximateCreationDateTime", utils::UUID_gen::unix_timestamp_in_sec(ts).count());
                 rjson::add(dynamodb, "SequenceNumber", sequence_number(ts));
                 rjson::add(dynamodb, "StreamViewType", type);
-                //TODO: SizeInBytes
+                // TODO: SizeBytes
             }
 
             /**

--- a/docs/alternator/compatibility.md
+++ b/docs/alternator/compatibility.md
@@ -282,6 +282,10 @@ experimental:
     instead of just a single MODIFY or INSERT.
     <https://github.com/scylladb/scylla/issues/6930>
     <https://github.com/scylladb/scylla/issues/6918>
+  * In GetRecords responses, Alternator sets `eventSource` to
+    `scylladb:alternator`, rather than `aws:dynamodb`, and doesn't set the
+    `SizeBytes` subfield inside the `dynamodb` field.
+    <https://github.com/scylladb/scylla/issues/6931>
   * The optional ShardFilter parameter to DescribeStream, added to DynamoDB
     in July 2025 to optimize shard discovery, is not yet implemented in
     Alternator.

--- a/test/alternator/util.py
+++ b/test/alternator/util.py
@@ -224,6 +224,16 @@ def client_no_transform(client):
 def is_aws(dynamodb):
     return dynamodb.meta.client._endpoint.host.endswith('.amazonaws.com')
 
+# Return the AWS region name, or the Scylla data center name.
+def get_region(dynamodb):
+    if is_aws(dynamodb):
+        dc_name = dynamodb.meta.client.meta.region_name
+        # Make sure we got a non-empty region name.
+        assert len(dc_name) > 0
+        return dc_name
+    system_local = dynamodb.Table('.scylla.alternator.system.local')
+    return system_local.scan(AttributesToGet=['data_center'])['Items'][0]['data_center']
+
 # Tries to inject an error via Scylla REST API. It only works on Scylla,
 # and only in specific build modes (dev, debug, sanitize), so this function
 # will trigger a test to be skipped if it cannot be executed.


### PR DESCRIPTION
This commit adds missing fields to GetRecords responses: `awsRegion` and
`eventVersion`. We also considered changing `eventSource` from
`scylladb:alternator` to `aws:dynamodb` and setting `SizeBytes` subfield
inside the `dynamodb` field.

We set `awsRegion` to the datacenter's name of the node that received
the request. This is in line with the AWS documentation, except that
Scylla has no direct equivalent of a region, so we use the datacenter's
name, which is analogous to DynamoDB's concept of region.

The field `eventVersion` determines the structure of a Record. It is
updated whenever the structure changes. We think that adding a field
`userIdentity` bumped the version from `1.0` to `1.1`. Currently, Scylla
doesn't support this field (https://github.com/scylladb/scylladb/issues/11523), hence we use the older 1.0 version.

We have decided to leave `eventSource` as is, since it's easy to modify
it in case of problems to `aws:dynamodb` used by DynamoDB.

Not setting `SizeBytes` subfield inside the `dynamodb` field was
dictated by the lack of apparent use cases. The documentation is unclear
about how `SizeBytes` is calculated and after experimenting a little
bit, I haven't found an obvious pattern.

Fixes: #6931