### PR TITLE
test: disable test_mv_tablets_empty_ip

### DIFF
--- a/test/cluster/mv/tablets/test_mv_tablets_empty_ip.py
+++ b/test/cluster/mv/tablets/test_mv_tablets_empty_ip.py
@@ -27,6 +27,7 @@ logger = logging.getLogger(__name__)
 # RF needs to be smaller than the cluster size in order ensure appearance of
 # remote view updates.
 @pytest.mark.asyncio
+@pytest.mark.skip(reason="https://github.com/scylladb/scylladb/issues/22677")
 @skip_mode('release', 'error injections are not supported in release mode')
 @skip_mode('debug', 'node replace needs to wait for tablet rebuild, which takes a lot of time in debug mode')
 async def test_mv_tablets_empty_ip(manager: ManagerClient):


### PR DESCRIPTION
disabling test for 2025.1 2025.2 2025.3
due to https://github.com/scylladb/scylladb/issues/22677

**Please replace this line with justification for the backport/\* labels added to this PR**