### PR TITLE
gdb: handle zero-size reads in managed_bytes

### DIFF
--- a/scylla-gdb.py
+++ b/scylla-gdb.py
@@ -999,6 +999,8 @@ class managed_bytes:
         inf = gdb.selected_inferior()
 
         def to_bytes(data, size):
+            if size == 0:
+                return b''
             return bytes(inf.read_memory(data, size))
 
         if self.is_inline():


### PR DESCRIPTION
Fixes: https://github.com/scylladb/scylladb/issues/25048

Simple fix, where I check the size parameter that is passed to `inf.read_memory(data, size)`. If 0, then return an empty byte string.

`scylla-gdb.py` improvement, no backport needed.