### PR TITLE
storage service: drain view builder before group0

### DIFF
--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -4704,6 +4704,10 @@ future<> storage_service::do_drain() {
     // Need to stop transport before group0, otherwise RPCs may fail with raft_group_not_found.
     co_await stop_transport();
 
+    // Drain view builder before group0, because the view builder uses group0 to coordinate view building.
+    // Drain after transport is stopped, because view_builder::drain aborts view writes for user writes as well.
+    co_await _view_builder.invoke_on_all(&db::view::view_builder::drain);
+
     // group0 persistence relies on local storage, so we need to stop group0 first.
     // This must be kept in sync with defer_verbose_shutdown for group0 in main.cc to
     // handle the case when initialization fails before reaching drain_on_shutdown for ss.
@@ -4719,7 +4723,6 @@ future<> storage_service::do_drain() {
         return bm.drain();
     });
 
-    co_await _view_builder.invoke_on_all(&db::view::view_builder::drain);
     co_await _db.invoke_on_all(&replica::database::drain);
     co_await _sys_ks.invoke_on_all(&db::system_keyspace::shutdown);
     co_await _repair.invoke_on_all(&repair_service::shutdown);


### PR DESCRIPTION
The view builder uses group0 operations to coordinate view building, so we should drain the view builder before stopping group0.

Fixes scylladb/scylladb#25096

backport to improve CI stability