### PR TITLE
replica/table: add_sstables_and_update_cache(): remove error log

### DIFF
--- a/replica/table.cc
+++ b/replica/table.cc
@@ -1369,12 +1369,7 @@ future<>
 table::add_sstables_and_update_cache(const std::vector<sstables::shared_sstable>& ssts) {
     constexpr bool do_not_trigger_compaction = false;
     for (auto& sst : ssts) {
-        try {
-            co_await do_add_sstable_and_update_cache(sst, sstables::offstrategy::no, do_not_trigger_compaction);
-        } catch (...) {
-            tlogger.error("Failed to load SSTable {}: {}", sst->toc_filename(), std::current_exception());
-            throw;
-        }
+        co_await do_add_sstable_and_update_cache(sst, sstables::offstrategy::no, do_not_trigger_compaction);
     }
     trigger_compaction();
 }


### PR DESCRIPTION
The plural overload of this method logs an error when the sstable add fails. This is unnecessary, the caller is expected to catch and handle exceptions. Furthermore, this unconditional error log results in sporadic test failures, due to the unexpected error in the logs on shutdown.

Fixes: #24850

Improves test stability, not a backport candidate, unless the test instability is observed on release branches.