### PR TITLE
doc: Update system.clients schema with scheduling_group cell

### DIFF
--- a/docs/dev/system_keyspace.md
+++ b/docs/dev/system_keyspace.md
@@ -536,6 +536,7 @@ CREATE TABLE system.clients (
     ssl_enabled boolean,
     ssl_protocol text,
     username text,
+    scheduling_group text,
     PRIMARY KEY (address, port, client_type)
 ) WITH CLUSTERING ORDER BY (port ASC, client_type ASC)
 ~~~


### PR DESCRIPTION
It was added by 9319d65971 (db/virtual_tables: add scheduling group column to system.clients) recently.

It's a dev documentation, so no real need in backporting (though it's going to be really simple)