### PR TITLE
scripts: fetch the name of the author of the PR

### DIFF
--- a/scripts/pull_github_pr.sh
+++ b/scripts/pull_github_pr.sh
@@ -136,7 +136,7 @@ fi
 PR_TITLE=$(jq -r .title <<< $PR_DATA)
 echo "    $PR_TITLE"
 PR_DESCR=$(jq -r .body <<< $PR_DATA)
-PR_LOGIN=$(jq -r .head.user.login <<< $PR_DATA)
+PR_LOGIN=$(jq -r .user.login <<< $PR_DATA)
 echo -n "Fetching full name of author $PR_LOGIN... "
 USER_NAME=$(curl -s "https://api.github.com/users/$PR_LOGIN" | jq -r .name)
 echo "$USER_NAME"


### PR DESCRIPTION
The `pull_github_pr.sh` script has been fetching the username from the owner of the source branch.
The owner of the branch is not always the author of the PR. For example the branch might come from a fork managed by organization or group of people.
This lead to having the author in merge commits refered to as `null` (if the name was not set for the group) or it mentioned a name not belonging to the author of the patch.

Instead looking for the owner of the source branch, the script should look for the name of the PR's author.