### PR TITLE
s3_client: make memory semaphore acquisition abortable

### DIFF
--- a/utils/s3/client.hh
+++ b/utils/s3/client.hh
@@ -142,7 +142,7 @@ class client : public enable_shared_from_this<client> {
 
     struct private_tag {};
 
-    future<semaphore_units<>> claim_memory(size_t mem);
+    future<semaphore_units<>> claim_memory(size_t mem, seastar::abort_source* as);
 
     future<> update_credentials_and_rearm();
     future<> authorize(http::request&);


### PR DESCRIPTION
Add `abort_source` to the `get_units` call for the memory semaphore in the S3 client, allowing the acquisition process to be aborted.

Fixes: https://github.com/scylladb/scylladb/issues/25454

Should be ported to 2025.3 since the problem exists there too