### PR TITLE
Update launch-on-gcp.rst

### DIFF
--- a/docs/getting-started/install-scylla/launch-on-gcp.rst
+++ b/docs/getting-started/install-scylla/launch-on-gcp.rst
@@ -30,7 +30,7 @@ Launching ScyllaDB on GCP
 
    .. code-block:: console
       
-        gcloud compute instances create <name of new instance> --image <ScyllaDB image name> --image-project < ScyllaDB project name> --local-ssd interface=nvme --zone <GCP zone - optional> --machine-type=<machine type>
+        gcloud compute instances create <name of new instance> --image <ScyllaDB image name> --image-project < ScyllaDB project name> --local-ssd interface=nvme --zone=<GCP zone - optional> --machine-type=<machine type>
    
    For example:
 


### PR DESCRIPTION
Add the missing '=' mark in --zone option. Otherwise the command complains.

This PR should be backported to versions 2025.3, 2025.2, and 2025.1, as it fixes a bug present in those versions, too.

The corresponding issue is -> https://github.com/scylladb/scylladb/issues/25642

Fixes: https://github.com/scylladb/scylladb/issues/25642