### PR TITLE
test: audit: add logging of get_audit_log_list and set_of_rows_before

### DIFF
--- a/test/cluster/dtest/audit_test.py
+++ b/test/cluster/dtest/audit_test.py
@@ -307,7 +307,9 @@ class TestCQLAudit(AuditTester):
         with the node as tie breaker.
         """
         consistency_level = ConsistencyLevel.QUORUM if len(self.cluster.nodelist()) > 1 else ConsistencyLevel.ONE
-        return self.helper.get_audit_log_list(session, consistency_level)
+        log_list = self.helper.get_audit_log_list(session, consistency_level)
+        logger.debug(f"get_audit_log_list: {log_list}")
+        return log_list
 
     # This assert is added just in order to still fail the test if the order of columns is changed, this is an implied assumption
     def assert_audit_row_fields(self, row):
@@ -478,7 +480,7 @@ class TestCQLAudit(AuditTester):
 
             nonlocal new_rows
             new_rows = rows_after[len(rows_before) :]
-            assert set(new_rows) == set_of_rows_after - set_of_rows_before, f"new rows are not the last rows in the audit table: {rows_after}"
+            assert set(new_rows) == set_of_rows_after - set_of_rows_before, f"new rows are not the last rows in the audit table: rows_after={rows_after}, set_of_rows_after={set_of_rows_after}, set_of_rows_before={set_of_rows_before}"
 
             if merge_duplicate_rows:
                 new_rows = self.deduplicate_audit_entries(new_rows)


### PR DESCRIPTION
Add logging of get_audit_log_list and set_of_rows_before. Without those logs, analysing some test failures is difficult.

Refs: scylladb/scylladb#25442
Fixes: https://github.com/scylladb/scylladb/issues/25442

Backport to 2025.3 and 2025.2 in case a failure similar to scylladb/scylladb#25442 happens on older branches.