### PR TITLE
docs: expose alternator metrics

### DIFF
--- a/scripts/metrics-config.yml
+++ b/scripts/metrics-config.yml
@@ -67,5 +67,6 @@
         "_queue_name + \"_tx_frags\"": ["queue"]
         "_queue_name + \"_rx_frags\"": ["queue"]
 "alternator/stats.cc":
+  allowmismatch: true
   params:
-    group_name:  "alternator"
+    group_name: "alternator"


### PR DESCRIPTION
Render in the docs the metrics introduced in https://github.com/scylladb/scylladb/pull/24046/files, which were not previously displayed in https://docs.scylladb.com/manual/stable/reference/metrics.html.

## How to test

1. Build the docs.

2. Open http://127.0.0.1:5500/reference/metrics

3. See the new metrics under "stats":

    <img width="3024" height="1714" alt="image" src="https://github.com/user-attachments/assets/0503bf7e-c05c-4562-81af-1056811c9e6d" />


Fixes https://github.com/scylladb/scylladb/issues/25585

This PR enables publishing Alternator metrics, which were added in version 2025.3, so it must be backported to branch-2025.3.
