### PR TITLE
docs: do not show any version warning for upgrade guide pages

### DIFF
--- a/docs/_templates/version-warning.html
+++ b/docs/_templates/version-warning.html
@@ -1,4 +1,6 @@
-{% if flag != "manual" %}
+{% if 'upgrade/upgrade-guides/' in pagename %}
+    {# Do not show any version warning for upgrade guide pages #}
+{% elif flag != "manual" %}
 <div class="admonition caution">
     <p class="admonition-title">Caution</p>
     <p>


### PR DESCRIPTION
This change removes the warning banner from upgrade pages, since these pages are maintained per version and the notice is unnecessary.

## How to test

Open http://previews.docs.scylladb.com/scylladb/25562/upgrade/upgrade-guides/upgrade-guide-from-2025.2-to-2025.3/upgrade-guide-from-2025.2-to-2025.3/, see warning does not show.