### PR TITLE
replica: Fix race between drop table and merge completion handling

### DIFF
--- a/replica/compaction_group.hh
+++ b/replica/compaction_group.hh
@@ -139,6 +139,8 @@ public:
     // flushing memtable(s), so all data can be found in the SSTable set.
     future<> stop(sstring reason) noexcept;
 
+    bool stopped() const noexcept;
+
     bool empty() const noexcept;
 
     // This removes all the storage belonging to the group. In order to avoid data


### PR DESCRIPTION
Consider this:
1) merge finishes, wakes up fiber to merge compaction groups
2) drop table happens, which in turn invokes truncate underneath
3) merge fiber stops old groups
4) truncate disables compaction on all groups, but the ones stopped
5) truncate performs a check that compaction has been disabled on all groups, including the ones stopped
6) the check fails because groups being stopped didn't have compaction explicitly disabled on them

To fix it, the check on step 6 will ignore groups that have been stopped, since those are not eligible for having compaction explicitly disabled on them. The compaction check is there, so ongoing compaction will not propagate data being truncated, but here it happens in the context of drop table which doesn't leave anything behind. Also, a group stopped is somewhat equivalent to compaction disabled on it, since the procedure to stop a group stops all ongoing compaction and eventually removes its state from compaction manager.

Fixes #25551.

Backport it to vulnerable versions since it's a preexisting issue.