### PR TITLE
tracing: API to set write_on_close

### DIFF
--- a/api/api-doc/storage_service.json
+++ b/api/api-doc/storage_service.json
@@ -2228,6 +2228,14 @@
                      "allowMultiple":false,
                      "type":"double",
                      "paramType":"query"
+                  },
+                  {
+                     "name":"write_on_close",
+                     "description":"traces will be written immediatly after the request is completed",
+                     "required":false,
+                     "allowMultiple":false,
+                     "type":"boolean",
+                     "paramType":"query"
                   }
                ]
             },

--- a/test/alternator/test_tracing.py
+++ b/test/alternator/test_tracing.py
@@ -36,7 +36,7 @@ def with_tracing(rest_api):
     if probability_resp.status_code != 200:
         pytest.skip('Failed to fetch tracing probability')
     probability = probability_resp.text
-    response = requests.post(rest_api+'/storage_service/trace_probability?probability=1')
+    response = requests.post(rest_api+'/storage_service/trace_probability?probability=1&&write_on_close=true')
     if response.status_code != 200:
         pytest.skip('Failed to enable tracing')
     # verify that tracing is really enabled

--- a/tools/scylla-nodetool.cc
+++ b/tools/scylla-nodetool.cc
@@ -2160,7 +2160,11 @@ void settraceprobability_operation(scylla_rest_client& client, const bpo::variab
     if (value < 0.0 or value > 1.0) {
         throw std::invalid_argument("trace probability must be between 0 and 1");
     }
-    client.post("/storage_service/trace_probability", {{"probability", fmt::to_string(value)}});
+    if (vm.contains("write_on_close") && vm["write_on_close"].as<bool>()) {
+        client.post("/storage_service/trace_probability", {{"probability", fmt::to_string(value)}, {"write_on_close", "true"}});
+    } else {
+        client.post("/storage_service/trace_probability", {{"probability", fmt::to_string(value)}});
+    }
 }
 
 void snapshot_operation(scylla_rest_client& client, const bpo::variables_map& vm) {
@@ -4387,6 +4391,7 @@ For more information, see: {}"
                 { },
                 {
                     typed_option<double>("trace_probability", "trace probability value, must between 0 and 1, e.g. 0.2", 1),
+                    typed_option<bool>("write_on_close", false, "write traces immediatly after session closed"),
                 },
             },
             {

--- a/tracing/tracing.cc
+++ b/tracing/tracing.cc
@@ -102,6 +102,8 @@ trace_state_ptr tracing::create_session(trace_type type, trace_state_props_set p
         // Ignore events if they are disabled and this is not a full tracing request (probability tracing or user request)
         props.set_if<trace_state_props::ignore_events>(!props.contains<trace_state_props::full_tracing>() && ignore_trace_events_enabled());
 
+        props.set_if<trace_state_props::write_on_close>(write_on_close_enabled());
+
         ++_active_sessions;
         return make_lw_shared<trace_state>(type, props);
     } catch (...) {

--- a/tracing/tracing.hh
+++ b/tracing/tracing.hh
@@ -380,6 +380,7 @@ private:
     // track tracing sessions only. This is used to implement lightweight
     // slow query tracing.
     bool _ignore_trace_events = false;
+    bool _write_on_close = false;
     std::unique_ptr<i_tracing_backend_helper> _tracing_backend_helper_ptr;
     sstring _thread_name;
     sstring _tracing_backend_helper_class_name;
@@ -580,6 +581,14 @@ public:
 
     bool ignore_trace_events_enabled() const {
         return _ignore_trace_events;
+    }
+
+    void set_write_on_close(bool enable = true) {
+        _write_on_close = enable;
+    }
+
+    bool write_on_close_enabled() const {
+        return _write_on_close;
     }
 
     /**


### PR DESCRIPTION
Adds API to enable immediate write after tracing session ends.
It is useful for testing and profiling, allowing better predictability of traces flushing.
With this option single node tests based on tracing shouldn't need an additional waiting or repeating trace queries.
It still may be necessary for mulitnode tests (see https://github.com/scylladb/scylladb/issues/25491)

For now it is just a draft - there are still more places to update (e.g. docs).
And this option is added to setting trace probability, but maybe it should be a separate endpoint.

New feature - no backporting