### PR TITLE
test.py: apply the nightly label on test_topology_recovery_basic

### DIFF
--- a/test/cluster/test_topology_recovery_basic.py
+++ b/test/cluster/test_topology_recovery_basic.py
@@ -20,6 +20,7 @@ from test.cluster.util import enter_recovery_state, \
 from test.cluster.conftest import cluster_con
 
 
+@pytest.mark.nightly
 @pytest.mark.asyncio
 @log_run_time
 async def test_topology_recovery_basic(request, build_mode: str, manager: ManagerClient):


### PR DESCRIPTION
This test is for the old gossip-based recovery procedure, which is an almost obsolete feature that won't change anymore.
