### PR TITLE
system_keyspace: Prune dropped tables from truncation on start/drop

### DIFF
--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -11,6 +11,7 @@
 #include <boost/functional/hash.hpp>
 #include <boost/icl/interval_map.hpp>
 #include <fmt/ranges.h>
+#include <ranges>
 
 #include <seastar/core/coroutine.hh>
 #include <seastar/coroutine/parallel_for_each.hh>
@@ -1787,9 +1788,15 @@ future<> system_keyspace::drop_truncation_rp_records() {
     auto rs = co_await execute_cql(req);
 
     bool any = false;
+    std::unordered_set<table_id> to_delete;
+    auto db = _qp.db();
     auto max_concurrency = std::min(1024u, smp::count * 8);
     co_await seastar::max_concurrent_for_each(*rs, max_concurrency, [&] (const cql3::untyped_result_set_row& row) -> future<> {
         auto table_uuid = table_id(row.get_as<utils::UUID>("table_uuid"));
+        if (!db.try_find_table(table_uuid)) {
+            to_delete.emplace(table_uuid);
+            co_return;
+        }
         auto shard = row.get_as<int32_t>("shard");
         auto segment_id = row.get_as<int64_t>("segment_id");
 
@@ -1799,9 +1806,24 @@ future<> system_keyspace::drop_truncation_rp_records() {
             co_await execute_cql(req);
         }
     });
+    if (!to_delete.empty()) {
+        // IN has a limit to how many values we can put into it.
+        for (auto&& chunk : to_delete | std::views::transform(&table_id::to_sstring) | std::views::chunk(100)) {
+            auto str = std::ranges::to<std::string>(chunk | std::views::join_with(','));
+            auto req = format("DELETE FROM system.{} WHERE table_uuid IN ({})", TRUNCATED, str);
+            co_await execute_cql(req);
+        }
+        any = true;
+    }
     if (any) {
         co_await force_blocking_flush(TRUNCATED);
     }
+}
+
+future<> system_keyspace::remove_truncation_records(table_id id) {
+    auto req = format("DELETE FROM system.{} WHERE table_uuid = {}", TRUNCATED, id);
+    co_await execute_cql(req);
+    co_await force_blocking_flush(TRUNCATED);
 }
 
 future<> system_keyspace::save_truncation_record(const replica::column_family& cf, db_clock::time_point truncated_at, db::replay_position rp) {

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -439,6 +439,7 @@ public:
     future<> save_truncation_record(const replica::column_family&, db_clock::time_point truncated_at, db::replay_position);
     future<replay_positions> get_truncated_positions(table_id);
     future<> drop_truncation_rp_records();
+    future<> remove_truncation_records(table_id);
 
     // Converts a `dht::token_range` object to the left-open integer range (x,y] form.
     //

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -1251,6 +1251,7 @@ future<> database::cleanup_drop_table_on_all_shards(sharded<database>& sharded_d
         return table_shards->stop();
     });
     f.get(); // re-throw exception from truncate() if any
+    co_await sys_ks.local().remove_truncation_records(table_shards->schema()->id());
     co_await table_shards->destroy_storage();
 }
 

--- a/test/cluster/test_truncate_with_drop.py
+++ b/test/cluster/test_truncate_with_drop.py
@@ -1,0 +1,90 @@
+#
+# Copyright (C) 2025-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+#
+import logging
+import asyncio
+
+from test.cluster.util import new_test_keyspace
+from test.pylib.manager_client import ManagerClient
+from cassandra.query import SimpleStatement, ConsistencyLevel
+
+import pytest
+
+logger = logging.getLogger(__name__)
+
+@pytest.mark.asyncio
+async def test_truncation_on_drop(manager: ManagerClient):
+    await manager.server_add()
+    cql = manager.get_cql()
+
+    # Create a keyspace
+    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1}") as ks:
+        await cql.run_async(f'CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);')
+        table_id = await cql.run_async(f"SELECT id FROM system_schema.tables WHERE keyspace_name = '{ks}' AND table_name = 'test'")
+        table_id = table_id[0].id
+
+        keys = range(1024)
+        await asyncio.gather(*[cql.run_async(f'INSERT INTO {ks}.test (pk, c) VALUES ({k}, {k});') for k in keys])
+        await cql.run_async(f'TRUNCATE TABLE {ks}.test')
+
+        # should have some truncation records now
+        row = await cql.run_async(SimpleStatement(f'SELECT COUNT(*) FROM system.truncated where table_uuid={table_id}'))
+        assert row[0].count > 0
+
+        await cql.run_async(f"DROP TABLE {ks}.test")
+
+        # should have no truncation records now
+        row = await cql.run_async(SimpleStatement(f'SELECT COUNT(*) FROM system.truncated where table_uuid={table_id}'))
+        assert row[0].count == 0
+
+@pytest.mark.asyncio
+async def test_truncation_records_pruned_on_dirty_restart(manager: ManagerClient):
+    server = await manager.server_add()
+    cql = manager.get_cql()
+
+    async def restart():
+        await manager.server_stop(server.server_id)
+        await manager.server_start(server.server_id)
+        manager.driver_close()
+        await manager.driver_connect()
+        return manager.cql
+    
+    # Create a keyspace
+    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1}") as ks:
+        await cql.run_async(f'CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);')
+        table_id = await cql.run_async(f"SELECT id FROM system_schema.tables WHERE keyspace_name = '{ks}' AND table_name = 'test'")
+        table_id = table_id[0].id
+
+        keys = range(1024)
+        await asyncio.gather(*[cql.run_async(f'INSERT INTO {ks}.test (pk, c) VALUES ({k}, {k});') for k in keys])
+        await cql.run_async(f'TRUNCATE TABLE {ks}.test')
+
+        # should have some truncation records now
+        row = await cql.run_async(SimpleStatement(f'SELECT COUNT(*) FROM system.truncated where table_uuid={table_id}'))
+        assert row[0].count > 0
+
+        logger.debug("Kill + restart the node")
+        cql = await restart()
+
+        # should still have same truncation records
+        row2 = await cql.run_async(SimpleStatement(f'SELECT COUNT(*) FROM system.truncated where table_uuid={table_id}'))
+        assert row2[0].count == row[0].count
+
+        # should _not_ have any data.
+        row2 = await cql.run_async(SimpleStatement(f'SELECT COUNT(*) FROM {ks}.test'))
+        assert row2[0].count == 0
+
+        logger.debug("Fake 'old' dropped table")
+        # don't do this at home kids.
+
+        await cql.run_async(f"DELETE FROM system_schema.tables WHERE keyspace_name = '{ks}' AND table_name = 'test'")
+        await cql.run_async(f"DELETE FROM system.tablets WHERE table_id = {table_id}")
+
+        logger.debug("Kill + restart the node again")
+        cql = await restart()
+
+        # should have no truncation records now
+        row = await cql.run_async(SimpleStatement(f'SELECT COUNT(*) FROM system.truncated where table_uuid={table_id}', consistency_level=ConsistencyLevel.ONE))
+        assert row[0].count == 0


### PR DESCRIPTION
Fixes #25683

Once a table drop is complete, there should be no reason to retain truncation records for it, as any replay should skip mutations anyway (no CF), and iff we somehow resurrect a dropped table, this replay-resurrected data is the least problem anyway.

Adds a prune phase to the startup drop_truncation_rp_records run, which ignores updating, and instead deletes records for non-existant tables (which should patch any existing servers with lingering data as well).

Also does an explicit delete of records on actual table DROP, to ensure we don't grow this table more than needed even in long uptime nodes.

Small unit test included.
