### PR TITLE
cleanup: Add missing `#pragma once`

### DIFF
--- a/utils/rest/client.hh
+++ b/utils/rest/client.hh
@@ -7,6 +7,7 @@
  * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
  */
 
+#pragma once
 #include <seastar/core/future.hh>
 #include <seastar/http/url.hh>
 #include <seastar/http/client.hh>


### PR DESCRIPTION
Add missing `#pragma once` to include header

No backport is needed, the change is not "functional"