### PR TITLE
raft: refactor can_vote logic and type

### DIFF
--- a/idl/raft_storage.idl.hh
+++ b/idl/raft_storage.idl.hh
@@ -33,7 +33,7 @@ struct server_address {
 
 struct config_member {
     raft::server_address addr;
-    bool can_vote;
+    raft::is_voter can_vote;
 };
 
 struct configuration {

--- a/raft/tracker.hh
+++ b/raft/tracker.hh
@@ -31,8 +31,8 @@ public:
     // Highest read id the follower replied to
     read_id max_acked_read = read_id{0};
 
-    // True if the follower is a voting one
-    bool can_vote = true;
+    //is_voter::yes if the follower is a voting one
+    raft::is_voter can_vote = raft::is_voter::yes;
 
     enum class state {
         // In this state only one append entry is send until matching index is found

--- a/service/raft/group0_voter_calculator.hh
+++ b/service/raft/group0_voter_calculator.hh
@@ -39,7 +39,7 @@ public:
     struct node_descriptor {
         sstring datacenter;
         sstring rack;
-        bool is_voter;
+        raft::is_voter is_voter;
         bool is_alive;
         bool is_leader = false;
     };

--- a/service/raft/group0_voter_handler.cc
+++ b/service/raft/group0_voter_handler.cc
@@ -14,6 +14,7 @@
 
 #include "gms/feature_service.hh"
 #include "gms/gossiper.hh"
+#include "raft/raft.hh"
 #include "raft_group0.hh"
 
 namespace service {
@@ -513,7 +514,7 @@ future<> group0_voter_handler::update_nodes(
         for (const auto& host_id : nodes_set) {
             const raft::server_id id{host_id.uuid()};
             // We only allow transitioning nodes to be added if they are already voters.
-            const bool allow_transitioning = group0_config.can_vote(id);
+            const auto allow_transitioning = group0_config.can_vote(id) == raft::is_voter::yes;
             const auto* node = get_replica_state(id, allow_transitioning);
             if (!node) {
                 continue;

--- a/service/raft/raft_group0.hh
+++ b/service/raft/raft_group0.hh
@@ -12,6 +12,7 @@
 #include "service/raft/discovery.hh"
 #include "service/raft/group0_fwd.hh"
 #include "gms/feature.hh"
+#include "raft/raft.hh"
 #include "utils/updateable_value.hh"
 #include <seastar/core/gate.hh>
 
@@ -28,9 +29,6 @@ extern const char* const raft_upgrade_doc;
 class migration_manager;
 class raft_group0_client;
 class storage_service;
-
-struct can_vote_tag {};
-using can_vote = bool_class<can_vote_tag>;
 
 // Wrapper for `discovery` which persists the learned peers on disk.
 class persistent_discovery {
@@ -290,7 +288,7 @@ public:
     // It is meant to be used as a fallback when a proper handshake procedure
     // cannot be used (e.g. when completing the upgrade or group0 procedures
     // or when joining an old cluster which does not support JOIN_NODE RPC).
-    shared_ptr<group0_handshaker> make_legacy_handshaker(can_vote can_vote);
+    shared_ptr<group0_handshaker> make_legacy_handshaker(raft::is_voter can_vote);
 
     // Waits until all upgrade to raft group 0 finishes and all nodes switched
     // to use_post_raft_procedures.

--- a/service/raft/raft_sys_table_storage.cc
+++ b/service/raft/raft_sys_table_storage.cc
@@ -10,6 +10,7 @@
 #include "cql3/untyped_result_set.hh"
 #include "db/config.hh"
 #include "db/system_keyspace.hh"
+#include "raft/raft.hh"
 #include "utils/UUID.hh"
 #include "utils/error_injection.hh"
 
@@ -143,7 +144,7 @@ future<raft::snapshot_descriptor> raft_sys_table_storage::load_snapshot_descript
         cfg_part.insert(
             raft::config_member{
                 raft::server_address{raft::server_id{row.get_as<utils::UUID>("server_id")}, {}},
-                row.get_as<bool>("can_vote")}
+                raft::is_voter(row.get_as<bool>("can_vote"))}
         );
     }
 

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -121,6 +121,7 @@
 #include <csignal>
 #include "utils/labels.hh"
 #include "view_info.hh"
+#include "raft/raft.hh"
 
 #include <boost/algorithm/string/split.hpp>
 #include <boost/algorithm/string/classification.hpp>
@@ -1844,7 +1845,7 @@ future<> storage_service::join_topology(sharded<service::storage_proxy>& proxy,
     ::shared_ptr<group0_handshaker> handshaker =
             raft_topology_change_enabled() && !_db.local().get_config().recovery_leader.is_set()
             ? ::make_shared<join_node_rpc_handshaker>(*this, join_params)
-            : _group0->make_legacy_handshaker(can_vote::no);
+            : _group0->make_legacy_handshaker(raft::is_voter::no);
     co_await _group0->setup_group0(_sys_ks.local(), initial_contact_nodes, std::move(handshaker),
             raft_replace_info, *this, _qp, _migration_manager.local(), raft_topology_change_enabled(), join_params);
 

--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -3625,7 +3625,7 @@ future<> topology_coordinator::rollback_current_topology_op(group0_guard&& guard
             // The node was removed already. We need to add it back. Lets do it as non voter.
             // If it ever boots again it will make itself a voter.
             release_node(std::move(node));
-            co_await _group0.group0_server().modify_config({raft::config_member{{id, {}}, false}}, {}, &_as);
+            co_await _group0.group0_server().modify_config({raft::config_member{{id, {}}, raft::is_voter::no}}, {}, &_as);
             node = retake_node(co_await start_operation(), id);
         }
             [[fallthrough]];

--- a/test/raft/etcd_test.cc
+++ b/test/raft/etcd_test.cc
@@ -926,7 +926,7 @@ BOOST_AUTO_TEST_CASE(test_leader_transfer_one_node_cluster) {
 BOOST_AUTO_TEST_CASE(test_leader_transfer_one_voter) {
     discrete_failure_detector fd;
     raft::server_id A_id = id(), B_id = id();
-    raft::config_member_set set{{server_addr_from_id(A_id), true}, {server_addr_from_id(B_id), false}};
+    raft::config_member_set set{{server_addr_from_id(A_id), raft::is_voter::yes}, {server_addr_from_id(B_id), raft::is_voter::no}};
     raft::configuration cfg(set);
 
 

--- a/test/raft/helpers.cc
+++ b/test/raft/helpers.cc
@@ -10,6 +10,7 @@
 // Helper functions for raft tests
 //
 
+#include "raft/raft.hh"
 #include "utils/assert.hh"
 #include <seastar/core/sharded.hh>
 
@@ -152,7 +153,7 @@ raft::server_address to_server_address(size_t int_id) {
 }
 
 raft::config_member to_config_member(size_t int_id) {
-    return {to_server_address(int_id), true};
+    return {to_server_address(int_id), raft::is_voter::yes};
 }
 
 size_t to_int_id(utils::UUID uuid) {
@@ -214,7 +215,7 @@ raft::server_address server_addr_from_id(raft::server_id id) {
 }
 
 raft::config_member config_member_from_id(raft::server_id id) {
-    return raft::config_member{server_addr_from_id(id), true};
+    return raft::config_member{server_addr_from_id(id), raft::is_voter::yes};
 }
 
 raft::configuration config_from_ids(std::vector<raft::server_id> ids) {

--- a/test/raft/raft_sys_table_storage_test.cc
+++ b/test/raft/raft_sys_table_storage_test.cc
@@ -9,6 +9,7 @@
 #include <seastar/testing/test_case.hh>
 #include <seastar/core/coroutine.hh>
 
+#include "raft/raft.hh"
 #include "utils/UUID_gen.hh"
 
 #include "service/raft/raft_sys_table_storage.hh"
@@ -65,7 +66,7 @@ static std::vector<raft::log_entry_ptr> create_test_log() {
         make_lw_shared(raft::log_entry{
             .term = raft::term_t(2),
             .idx = raft::index_t(2),
-            .data = raft::configuration{{raft::config_member{raft::server_address{raft::server_id::create_random_id(), {}}, true}}}}),
+            .data = raft::configuration{{raft::config_member{raft::server_address{raft::server_id::create_random_id(), {}}, raft::is_voter::yes}}}}),
         // dummy
         make_lw_shared(raft::log_entry{
             .term = raft::term_t(3),
@@ -100,7 +101,7 @@ SEASTAR_TEST_CASE(test_store_load_snapshot) {
         raft::config_member srv{raft::server_address{
                 raft::server_id::create_random_id(),
                 ser::serialize_to_buffer<bytes>(gms::inet_address("localhost"))
-            }, true};
+            }, raft::is_voter::yes};
         raft::configuration snp_cfg({std::move(srv)});
         auto snp_id = raft::snapshot_id::create_random_id();
 
@@ -167,7 +168,7 @@ SEASTAR_TEST_CASE(test_store_snapshot_truncate_log_tail) {
         raft::config_member srv{raft::server_address{
                 raft::server_id::create_random_id(),
                 ser::serialize_to_buffer<bytes>(gms::inet_address("localhost"))
-            }, true};
+            }, raft::is_voter::yes};
         raft::configuration snp_cfg({std::move(srv)});
         auto snp_id = raft::snapshot_id::create_random_id();
 

--- a/test/raft/replication.hh
+++ b/test/raft/replication.hh
@@ -24,6 +24,7 @@
 #include <seastar/testing/random.hh>
 #include <seastar/testing/thread_test_case.hh>
 #include <seastar/testing/test_case.hh>
+#include "raft/raft.hh"
 #include "raft/server.hh"
 #include "serializer.hh"
 #include "serializer_impl.hh"
@@ -197,9 +198,9 @@ struct wait_log {
 
 struct set_config_entry {
     size_t node_idx;
-    bool can_vote;
+    raft::is_voter can_vote;
 
-    set_config_entry(size_t idx, bool can_vote = true)
+    set_config_entry(size_t idx, raft::is_voter can_vote = raft::is_voter::yes)
         : node_idx(idx), can_vote(can_vote)
     {}
 };

--- a/test/raft/replication_test.cc
+++ b/test/raft/replication_test.cc
@@ -349,7 +349,7 @@ RAFT_TEST_CASE(rpc_voter_non_voter_transision, (test_case{
                              rpc_address_set{node_id{0},node_id{1},node_id{2}}},
             rpc_reset_counters{{node_id{0},node_id{1},node_id{2}}},
             // Make C a non-voting member.
-            set_config{0, 1, set_config_entry(2, false)},
+            set_config{0, 1, set_config_entry(2, raft::is_voter::no)},
             // Check that RPC configuration didn't change.
             check_rpc_added{{node_id{0},node_id{1},node_id{2}},0},
             check_rpc_removed{{node_id{0},node_id{1},node_id{2}},0},

--- a/types/types.hh
+++ b/types/types.hh
@@ -18,6 +18,7 @@
 #include <seastar/core/shared_ptr.hh>
 #include "utils/UUID.hh"
 #include <seastar/net/byteorder.hh>
+#include <seastar/util/bool_class.hh>
 #include "db_clock.hh"
 #include "bytes.hh"
 #include "duration.hh"
@@ -254,6 +255,8 @@ public:
     data_value(std::optional<NativeType>);
     template <typename NativeType>
     data_value(const std::unordered_set<NativeType>&);
+    template <typename Tag>
+    data_value(bool_class<Tag>);
 
     data_value& operator=(const data_value&);
     data_value& operator=(data_value&&);
@@ -984,6 +987,12 @@ data_value::data_value(std::optional<bytes> v)
 template <typename NativeType>
 data_value::data_value(std::optional<NativeType> v)
         : data_value(v ? data_value(*v) : data_value::make_null(data_type_for<NativeType>())) {
+}
+
+//in this case we want to turn it automatically to bool 
+template <typename Tag> 
+data_value::data_value(bool_class<Tag> v) : data_value(bool(v)) {
+
 }
 
 template<>


### PR DESCRIPTION
This PR refactors the can_vote function in the Raft algorithms for improved clarity and maintainability by providing safer strong boolean types to the raft algorithm.

Fixes: #21937

Backport: No backport required 