### PR TITLE
Don't leave pre-scrub snapshot on API error

### DIFF
--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -228,7 +228,7 @@ seastar::future<json::json_return_type> run_toppartitions_query(db::toppartition
     });
 }
 
-future<scrub_info> parse_scrub_options(const http_context& ctx, sharded<db::snapshot_ctl>& snap_ctl, std::unique_ptr<http::request> req) {
+scrub_info parse_scrub_options(const http_context& ctx, std::unique_ptr<http::request> req) {
     scrub_info info;
     auto [ keyspace, table_infos ] = parse_table_infos(ctx, *req, "cf");
     info.keyspace = std::move(keyspace);
@@ -274,7 +274,7 @@ future<scrub_info> parse_scrub_options(const http_context& ctx, sharded<db::snap
         throw httpd::bad_param_exception(fmt::format("Unknown argument for 'quarantine_mode' parameter: {}", quarantine_mode_str));
     }
 
-    co_return info;
+    return info;
 }
 
 void set_transport_controller(http_context& ctx, routes& r, cql_transport::controller& ctl) {
@@ -2097,7 +2097,7 @@ void set_snapshot(http_context& ctx, routes& r, sharded<db::snapshot_ctl>& snap_
 
     ss::scrub.set(r, [&ctx, &snap_ctl] (std::unique_ptr<http::request> req) -> future<json::json_return_type> {
         auto& db = ctx.db;
-        auto info = co_await parse_scrub_options(ctx, snap_ctl, std::move(req));
+        auto info = parse_scrub_options(ctx, std::move(req));
 
         if (!info.snapshot_tag.empty()) {
             co_await snap_ctl.local().take_column_family_snapshot(info.keyspace, info.column_families, info.snapshot_tag, db::snapshot_ctl::skip_flush::no);

--- a/api/storage_service.hh
+++ b/api/storage_service.hh
@@ -64,7 +64,7 @@ struct scrub_info {
     sstring snapshot_tag;
 };
 
-future<scrub_info> parse_scrub_options(const http_context& ctx, sharded<db::snapshot_ctl>& snap_ctl, std::unique_ptr<http::request> req);
+scrub_info parse_scrub_options(const http_context& ctx, std::unique_ptr<http::request> req);
 
 void set_storage_service(http_context& ctx, httpd::routes& r, sharded<service::storage_service>& ss, service::raft_group0_client&);
 void unset_storage_service(http_context& ctx, httpd::routes& r);

--- a/api/tasks.cc
+++ b/api/tasks.cc
@@ -91,7 +91,7 @@ void set_tasks_compaction_module(http_context& ctx, routes& r, sharded<service::
 
     t::scrub_async.set(r, [&ctx, &snap_ctl] (std::unique_ptr<http::request> req) -> future<json::json_return_type> {
         auto& db = ctx.db;
-        auto info = co_await parse_scrub_options(ctx, snap_ctl, std::move(req));
+        auto info = parse_scrub_options(ctx, std::move(req));
 
         if (!info.snapshot_tag.empty()) {
             co_await snap_ctl.local().take_column_family_snapshot(info.keyspace, info.column_families, info.snapshot_tag, db::snapshot_ctl::skip_flush::no);


### PR DESCRIPTION
The pre-srcub snapshot is taken in the middle of parsing options from the request. In case post-snapshot part of the parsing throws (it can do so if "quarantine_mode" value is not recognized), the snapshot remains on disk, but the API call fails.

The fix is to move snapshot taking out of the parse_scrub_options() helper. It could be moved at the end of it, but the helper name doesn't tell that it also takes a snapshot, so no. After the fix the helper in question can be simplified further.

The issue exists in older versions, but likely doesn't reveal itself for real, so it doesn't look worthwhile to backport it.