### PR TITLE
cql: document and test permissions on materialized views

### DIFF
--- a/docs/operating-scylla/security/authorization.rst
+++ b/docs/operating-scylla/security/authorization.rst
@@ -369,6 +369,12 @@ granting ``SELECT`` on a ``KEYSPACE`` automatically grants it on all ``TABLES`` 
 
 .. Likewise, granting a permission on ``ALL FUNCTIONS`` grants it on every defined function, regardless of which keyspace it is scoped in. It is also possible to grant permissions on all functions scoped to a particular keyspace.
 
+Materialized views and CDC logs cannot be granted separate permissions -
+they inherit the permissions from the base table. Specifically,
+granting ``SELECT`` on a table allows to read also from all its
+materialized views and CDC log. It is not possible to make only
+one materialized view of several materialized views readable.
+
 Modifications to permissions are visible to existing client sessions; that is, connections need not be re-established
 following permissions changes.
 

--- a/docs/operating-scylla/security/rbac-usecase.rst
+++ b/docs/operating-scylla/security/rbac-usecase.rst
@@ -41,6 +41,11 @@ When creating a role, you grant it permissions and resources. The permission is 
    * "ALL ROLES"
    * Note that An unqualified table name  assumes the current keyspace
 
+Materialized views and CDC logs cannot be granted separate permissions -
+they inherit their permissions from the base table. It is not possible
+to give different permissions to different materialized views of the
+same base table.
+
 .. _rbac-usecase-use-case:
 
 Use case


### PR DESCRIPTION
We were recently surprised (in pull request #25797) to "discover" that Scylla does not allow granting SELECT permissions on individual materialized views - and instead all materialized views of a base table are readable if the base table is readable.

In this patch we document this fact, and also add a test to verify that it is indeed true. As usual for cqlpy tests, this test can also be run on Cassandra - and it passes showing that Cassandra also implemented it the same way (which isn't surprising, given that we probably copied our initial implementation from them).

The test demonstrates that neither Scylla nor Cassandra prints an error when attempting to GRANT permissions on a specific materialized view - but this GRANT is simply ignored. This is not ideal, but it is the existing behavior in both and it's not important now to change it.

Fixes #25800

Test and documentation only, no real need to backport, but wouldn't hurt either as there is no risk involved, so let's backport to the latest release.