### PR TITLE
trigger-scylla-ci: ignore comment from scylladbbot

### DIFF
--- a/.github/workflows/trigger-scylla-ci.yaml
+++ b/.github/workflows/trigger-scylla-ci.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   trigger-jenkins:
-    if: contains(github.event.comment.body, '@scylladbbot') && contains(github.event.comment.body, 'trigger-ci')
+    if: github.event.comment.user.login != 'scylladbbot' && contains(github.event.comment.body, '@scylladbbot') && contains(github.event.comment.body, 'trigger-ci')
     runs-on: ubuntu-latest
     steps:
       - name: Trigger Scylla-CI-Route Jenkins Job


### PR DESCRIPTION
ignore comments posted by `scylladbbot`, to allow adding instruction in
CI completion report of how to re-trigger CI without causing a new run
