### PR TITLE
alternator: Correct RCU undercount in BatchGetItem

### DIFF
--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -3614,16 +3614,16 @@ future<std::vector<rjson::value>> executor::describe_multi_item(schema_ptr schem
         shared_ptr<cql3::selection::selection> selection,
         foreign_ptr<lw_shared_ptr<query::result>> query_result,
         shared_ptr<const std::optional<attrs_to_get>> attrs_to_get,
-        uint64_t& rcu_half_units) {
+        noncopyable_function<void(uint64_t)> item_callback) {
     cql3::selection::result_set_builder builder(*selection, gc_clock::now());
     query::result_view::consume(*query_result, slice, cql3::selection::result_set_builder::visitor(builder, *schema, *selection));
     auto result_set = builder.build();
     std::vector<rjson::value> ret;
     for (auto& result_row : result_set->rows()) {
         rjson::value item = rjson::empty_object();
-        rcu_consumed_capacity_counter consumed_capacity;
-        describe_single_item(*selection, result_row, *attrs_to_get, item, &consumed_capacity._total_bytes);
-        rcu_half_units += consumed_capacity.get_half_units();
+        uint64_t item_length_in_bytes = 0;
+        describe_single_item(*selection, result_row, *attrs_to_get, item, &item_length_in_bytes);
+        item_callback(item_length_in_bytes);
         ret.push_back(std::move(item));
         co_await coroutine::maybe_yield();
     }
@@ -4565,7 +4565,6 @@ future<executor::request_return_type> executor::batch_get_item(client_state& cli
         }
     };
     std::vector<table_requests> requests;
-    std::vector<std::vector<uint64_t>> responses_sizes;
     uint batch_size = 0;
     for (auto it = request_items.MemberBegin(); it != request_items.MemberEnd(); ++it) {
         table_requests rs(get_table_from_batch_request(_proxy, it));
@@ -4593,11 +4592,10 @@ future<executor::request_return_type> executor::batch_get_item(client_state& cli
     // If we got here, all "requests" are valid, so let's start the
     // requests for the different partitions all in parallel.
     std::vector<future<std::vector<rjson::value>>> response_futures;
-    responses_sizes.resize(requests.size());
-    size_t responses_sizes_pos = 0;
-    for (const auto& rs : requests) {
-        responses_sizes[responses_sizes_pos].resize(rs.requests.size());
-        size_t pos = 0;
+    std::vector<uint64_t> consumed_rcu_half_units_per_table(requests.size());
+    for (size_t i = 0; i < requests.size(); i++) {
+        const table_requests& rs = requests[i];
+        bool is_quorum = rs.cl == db::consistency_level::LOCAL_QUORUM;
         lw_shared_ptr<stats> per_table_stats = get_stats_from_schema(_proxy, *rs.schema);
         per_table_stats->api_operations.batch_get_item_histogram.add(rs.requests.size());
         for (const auto &r : rs.requests) {
@@ -4620,16 +4618,17 @@ future<executor::request_return_type> executor::batch_get_item(client_state& cli
             auto command = ::make_lw_shared<query::read_command>(rs.schema->id(), rs.schema->version(), partition_slice, _proxy.get_max_result_size(partition_slice),
                     query::tombstone_limit(_proxy.get_tombstone_limit()));
             command->allow_limit = db::allow_per_partition_rate_limit::yes;
+            const auto item_callback = [is_quorum, &rcus_per_table = consumed_rcu_half_units_per_table[i]](uint64_t size) {
+                rcus_per_table += rcu_consumed_capacity_counter::get_half_units(size, is_quorum);
+            };
             future<std::vector<rjson::value>> f = _proxy.query(rs.schema, std::move(command), std::move(partition_ranges), rs.cl,
                     service::storage_proxy::coordinator_query_options(executor::default_timeout(), permit, client_state, trace_state)).then(
-                    [schema = rs.schema, partition_slice = std::move(partition_slice), selection = std::move(selection), attrs_to_get = rs.attrs_to_get, &response_size = responses_sizes[responses_sizes_pos][pos]] (service::storage_proxy::coordinator_query_result qr) mutable {
+                    [schema = rs.schema, partition_slice = std::move(partition_slice), selection = std::move(selection), attrs_to_get = rs.attrs_to_get, item_callback = std::move(item_callback)] (service::storage_proxy::coordinator_query_result qr) mutable {
                 utils::get_local_injector().inject("alternator_batch_get_item", [] { throw std::runtime_error("batch_get_item injection"); });
-                return describe_multi_item(std::move(schema), std::move(partition_slice), std::move(selection), std::move(qr.query_result), std::move(attrs_to_get), response_size);
+                return describe_multi_item(std::move(schema), std::move(partition_slice), std::move(selection), std::move(qr.query_result), std::move(attrs_to_get), std::move(item_callback));
             });
-            pos++;
             response_futures.push_back(std::move(f));
         }
-        responses_sizes_pos++;
     }
 
     // Wait for all requests to complete, and then return the response.
@@ -4641,14 +4640,11 @@ future<executor::request_return_type> executor::batch_get_item(client_state& cli
     rjson::value response = rjson::empty_object();
     rjson::add(response, "Responses", rjson::empty_object());
     rjson::add(response, "UnprocessedKeys", rjson::empty_object());
-    size_t rcu_half_units;
     auto fut_it = response_futures.begin();
-    responses_sizes_pos = 0;
     rjson::value consumed_capacity = rjson::empty_array();
-    for (const auto& rs : requests) {
+    for (size_t i = 0; i < requests.size(); i++) {
+        const table_requests& rs = requests[i];
         std::string table = table_name(*rs.schema);
-        size_t pos = 0;
-        rcu_half_units = 0;
         for (const auto &r : rs.requests) {
             auto& pk = r.first;
             auto& cks = r.second;
@@ -4663,7 +4659,6 @@ future<executor::request_return_type> executor::batch_get_item(client_state& cli
                 for (rjson::value& json : results) {
                     rjson::push_back(response["Responses"][table], std::move(json));
                 }
-                rcu_half_units += rcu_consumed_capacity_counter::get_half_units(responses_sizes[responses_sizes_pos][pos], rs.cl == db::consistency_level::LOCAL_QUORUM);
             } catch(...) {
                 eptr = std::current_exception();
                 // This read of potentially several rows in one partition,
@@ -4687,8 +4682,8 @@ future<executor::request_return_type> executor::batch_get_item(client_state& cli
                     rjson::push_back(response["UnprocessedKeys"][table]["Keys"], std::move(*ck.second));
                 }
             }
-            pos++;
         }
+        uint64_t rcu_half_units = consumed_rcu_half_units_per_table[i];
         _stats.rcu_half_units_total += rcu_half_units;
         lw_shared_ptr<stats> per_table_stats = get_stats_from_schema(_proxy, *rs.schema);
         per_table_stats->rcu_half_units_total += rcu_half_units;
@@ -4698,7 +4693,6 @@ future<executor::request_return_type> executor::batch_get_item(client_state& cli
             rjson::add(entry, "CapacityUnits", rcu_half_units*0.5);
             rjson::push_back(consumed_capacity, std::move(entry));
         }
-        responses_sizes_pos++;
     }
 
     if (should_add_rcu) {

--- a/alternator/executor.hh
+++ b/alternator/executor.hh
@@ -230,12 +230,15 @@ public:
         const std::optional<attrs_to_get>&,
         uint64_t* = nullptr);
 
+    // Converts a multi-row selection result to JSON compatible with DynamoDB.
+    // For each row, this method calls item_callback, which takes the size of
+    // the item as the parameter.
     static future<std::vector<rjson::value>> describe_multi_item(schema_ptr schema,
         const query::partition_slice&& slice,
         shared_ptr<cql3::selection::selection> selection,
         foreign_ptr<lw_shared_ptr<query::result>> query_result,
         shared_ptr<const std::optional<attrs_to_get>> attrs_to_get,
-        uint64_t& rcu_half_units);
+        noncopyable_function<void(uint64_t)> item_callback = {});
 
     static void describe_single_item(const cql3::selection::selection&,
         const std::vector<managed_bytes_opt>&,

--- a/test/alternator/test_returnconsumedcapacity.py
+++ b/test/alternator/test_returnconsumedcapacity.py
@@ -335,6 +335,85 @@ def test_simple_batch_get_items(test_table_sb):
     assert response['ConsumedCapacity'][0]['TableName'] == test_table_sb.name
     assert 2 == response['ConsumedCapacity'][0]['CapacityUnits']
 
+# This test reproduces a bug where the consumed capacity was divided by 16 MB,
+# instead of 4 KB. The general formula for RCU per item is the same as for
+# GetItem, namely:
+#
+# CEIL(ItemSizeInBytes / 4096) * (1 if strong consistency, 0.5 if eventual
+# consistency)
+#
+# The RCU is calculated for each item individually, and the results are summed
+# for the total cost of the BatchGetItem. In this case, the larger item is
+# rounded up to 68KB, giving 17 RCUs, and the smaller item to 20KB, which
+# results in 5 RCUs, making the total consumed capacity for this operation
+# 22 RCUs.
+def test_batch_get_items_large(test_table_sb):
+    p1 = random_string()
+    c1 = random_bytes()
+    test_table_sb.put_item(Item={'p': p1, 'c': c1, 'a': 'a' * 64 * KB})
+
+    p2 = random_string()
+    c2 = random_bytes()
+    test_table_sb.put_item(Item={'p': p2, 'c': c2, 'a': 'a' * 16 * KB})
+
+    response = test_table_sb.meta.client.batch_get_item(RequestItems = {
+        test_table_sb.name: {'Keys': [{'p': p1, 'c': c1}, {'p': p2, 'c': c2}], 'ConsistentRead': True}}, ReturnConsumedCapacity='TOTAL')
+    assert 'ConsumedCapacity' in response
+    assert 'TableName' in response['ConsumedCapacity'][0]
+    assert response['ConsumedCapacity'][0]['TableName'] == test_table_sb.name
+    assert 22 == response['ConsumedCapacity'][0]['CapacityUnits']
+
+# Helper function to generate item_count items and batch write them to the
+# table. Returns the list of generated items.
+def prepare_items(table, item_factory, item_count=10):
+    items = []
+    with table.batch_writer() as writer:
+        for i in range(item_count):
+            item = item_factory(i)
+            items.append(item)
+            writer.put_item(Item=item)
+    return items
+
+# This test verifies if querying two tables, each containing multiple ~30 byte
+# items, reports the RCU correctly. A single item should consume 1 RCU, because
+# the items' sizes are rounded up separately to 1 KB (ConsistentReads), and
+# RCU should be reported per table. A variant of test_batch_get_items_large.
+def test_batch_get_items_many_small(test_table_s, test_table_sb):
+    # Each item should be about 30 bytes.
+    items_sb = prepare_items(test_table_sb, lambda i: {'p': f'item_{i}_' + random_string(), 'c': random_bytes()})
+    items_s = prepare_items(test_table_s, lambda i: {'p': f'item_{i}_' + random_string()})
+
+    response = test_table_sb.meta.client.batch_get_item(RequestItems = {
+        test_table_sb.name: {'Keys': items_sb, 'ConsistentRead': True},
+        test_table_s.name: {'Keys': items_s, 'ConsistentRead': True},
+    }, ReturnConsumedCapacity='TOTAL')
+
+    assert 'ConsumedCapacity' in response
+    assert len(response['ConsumedCapacity']) == 2
+    expected_tables = {test_table_sb.name, test_table_s.name}
+    for consumption_per_table in response['ConsumedCapacity']:
+        assert 'TableName' in consumption_per_table
+        assert consumption_per_table['CapacityUnits'] == 10, f"Table {consumption_per_table['TableName']} reported {consumption_per_table['CapacityUnits']} RCUs, expected 10"
+        assert consumption_per_table['TableName'] in expected_tables
+        expected_tables.remove(consumption_per_table['TableName'])
+    assert not expected_tables
+
+# This test verifies if querying a single partition reports the RCU correctly.
+# This test is similar to test_batch_get_items_many_small.
+def test_batch_get_items_many_small_single_partition(test_table_sb):
+    # Each item should be about 20 bytes.
+    pk = random_string()
+    items_sb = prepare_items(test_table_sb, lambda _: {'p': pk, 'c': random_bytes()})
+
+    response = test_table_sb.meta.client.batch_get_item(RequestItems = {
+        test_table_sb.name: {'Keys': items_sb, 'ConsistentRead': True},
+    }, ReturnConsumedCapacity='TOTAL')
+
+    assert 'ConsumedCapacity' in response
+    assert 'TableName' in response['ConsumedCapacity'][0]
+    assert response['ConsumedCapacity'][0]['TableName'] == test_table_sb.name
+    assert 10 == response['ConsumedCapacity'][0]['CapacityUnits']
+
 # Validate that when getting a batch of requests
 # From multiple tables we get an RCU for each of the tables
 # We also validate that the eventual consistency return half the units


### PR DESCRIPTION
The `describe_multi_item` function treated the last reference-captured argument as the number of used RCU half units. The caller `batch_get_item`, however, expected this parameter to hold an item size. This RCU value was then passed to
`rcu_consumed_capacity_counter::get_half_units`, treating the already-calculated RCU integer as if it were a size in bytes.

This caused a second conversion that undercounted the true RCU. During conversion, the number of bytes is divided by `RCU_BLOCK_SIZE_LENGTH` (=4KB), so the double conversion divided the number of bytes by 16 MB.

The fix removes the second conversion in `describe_multi_item` and changes the API of `describe_multi_item`.

The tests pass if run against DynamoDB.

Fixes https://github.com/scylladb/scylladb/issues/25847