### PR TITLE
main: Properly handle zero allocation warning threshold

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -462,9 +462,13 @@ verify_adequate_memory_per_shard(bool developer_mode) {
 }
 
 class memory_threshold_guard {
-    seastar::memory::scoped_large_allocation_warning_threshold _slawt;
+    std::optional<seastar::memory::scoped_large_allocation_warning_threshold> _slawt;
 public:
-    explicit memory_threshold_guard(size_t threshold) : _slawt(threshold)  {}
+    explicit memory_threshold_guard(size_t threshold) {
+        if (threshold != 0) {
+            _slawt.emplace(threshold);
+        }
+    }
     future<> stop() { return make_ready_future<>(); }
 };
 


### PR DESCRIPTION
The --help text says about --large-memory-allocation-warning-threshold:

"Warn about memory allocations above this size; set to zero to disable."

That's half-true: setting the value to zero spams logs with warnings of allocation of any size, as seastar treats zero threshold literaly.

Likely nobody tries to disable it like proposed, still worth backporting for safety