### PR TITLE
Fix oversized allocation in paxos under pressure

### DIFF
--- a/service/paxos/paxos_state.cc
+++ b/service/paxos/paxos_state.cc
@@ -36,6 +36,13 @@ logging::logger paxos_state::logger("paxos");
 thread_local paxos_state::key_lock_map paxos_state::_paxos_table_lock;
 thread_local paxos_state::key_lock_map paxos_state::_coordinator_lock;
 
+paxos_state::key_lock_map::key_lock_map() {
+    // preallocate 8K pointers and set max_load_factor to 8 to support around 1M outstanding requests
+    // without re-allocations
+    _locks.reserve(8 * 1024);
+    _locks.max_load_factor(8);
+}
+
 paxos_state::key_lock_map::semaphore& paxos_state::key_lock_map::get_semaphore_for_key(const dht::token& key) {
     return _locks.try_emplace(key, 1).first->second;
 }

--- a/service/paxos/paxos_state.hh
+++ b/service/paxos/paxos_state.hh
@@ -53,6 +53,8 @@ private:
         map _locks;
     public:
 
+        key_lock_map();
+        
         friend class guard;
     };
 


### PR DESCRIPTION
When cpu pressured, `_locks` structure in paxos might grow and cause oversized allocations and performance drops. We reserve memory ahead of time.

Fixes #25559 