### PR TITLE
s3: Add metrics to show S3 prefetch bytes

### DIFF
--- a/utils/s3/client.hh
+++ b/utils/s3/client.hh
@@ -130,6 +130,7 @@ class client : public enable_shared_from_this<client> {
         aws::retryable_http_client retryable_client;
         io_stats read_stats;
         io_stats write_stats;
+        uint64_t prefetch_bytes = 0;
         seastar::metrics::metric_groups metrics;
         group_client(std::unique_ptr<http::experimental::connection_factory> f, unsigned max_conn, const aws::retry_strategy& retry_strategy);
         void register_metrics(std::string class_name, std::string host);


### PR DESCRIPTION
The chunked download source sends large GET requests and then consumes data as it arrives. Sometimes it can stop reading from socket early and drop the in-flight data. The existing read-bytes metrics show only the number of consumed bytes, we we also want to know the number of requested bytes

Refs #25770 (accounting of read-bytes)
Fixes #25876

Backporting to 2025.3 as chunked download source only appeared there