### PR TITLE
Secondary index: Respect limit and page size, do not skip clustering ranges after short reads

### DIFF
--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -1490,7 +1490,8 @@ view_indexed_table_select_statement::find_index_partition_ranges(query_processor
         // to avoid outputting the same partition key twice, but luckily in
         // the sorted order, these will be adjacent.
         std::optional<dht::decorated_key> last_dk;
-        if (_options.get_paging_state()) {
+        if (_index.target_type() == cql3::statements::index_target::target_type::collection_values &&
+                _options.get_paging_state()) {
             auto paging_state = _options.get_paging_state();
             auto base_pk = generate_base_key_from_index_pk<partition_key>(paging_state->get_partition_key(),
                 paging_state->get_clustering_key(), *_schema, *_view_schema);

--- a/cql3/statements/select_statement.hh
+++ b/cql3/statements/select_statement.hh
@@ -230,8 +230,8 @@ private:
     future<::shared_ptr<cql_transport::messages::result_message>> actually_do_execute(query_processor& qp,
             service::query_state& state, const query_options& options) const;
 
-    lw_shared_ptr<const service::pager::paging_state> generate_view_paging_state_from_base_query_results(lw_shared_ptr<const service::pager::paging_state> paging_state,
-            const foreign_ptr<lw_shared_ptr<query::result>>& results, service::query_state& state, const query_options& options, uint32_t internal_page_size) const;
+    lw_shared_ptr<const service::pager::paging_state> generate_view_paging_state_from_base_query_results(uint64_t remaining_from_prev_page, lw_shared_ptr<const service::pager::paging_state> paging_state,
+            const foreign_ptr<lw_shared_ptr<query::result>>& results, service::query_state& state, const query_options& options) const;
 
     future<coordinator_result<std::tuple<dht::partition_range_vector, lw_shared_ptr<const service::pager::paging_state>>>> find_index_partition_ranges(query_processor& qp,
                                                                     service::query_state& state,
@@ -248,8 +248,7 @@ private:
             service::query_state& state,
             const query_options& options,
             gc_clock::time_point now,
-            lw_shared_ptr<const service::pager::paging_state> paging_state,
-            uint32_t internal_page_size) const;
+            lw_shared_ptr<const service::pager::paging_state> paging_state) const;
 
     lw_shared_ptr<query::read_command>
     prepare_command_for_base_query(query_processor& qp, const query_options& options, service::query_state& state, gc_clock::time_point now,

--- a/query/query-request.hh
+++ b/query/query-request.hh
@@ -111,6 +111,15 @@ typedef std::vector<clustering_range> clustering_row_ranges;
 
 /// Trim the clustering ranges.
 ///
+/// Equivalent of intersecting each clustering range with (-inf, pos] position
+/// in partition range. Ranges that do not intersect are dropped. Ranges that
+/// partially overlap are trimmed.
+/// Result: each range will overlap fully with (-inf, pos].
+/// Works both with forward schema and ranges, and reversed schema and native reversed ranges
+void trim_clustering_row_ranges_from(const schema& s, clustering_row_ranges& ranges, position_in_partition pos);
+
+/// Trim the clustering ranges.
+///
 /// Equivalent of intersecting each clustering range with [pos, +inf) position
 /// in partition range. Ranges that do not intersect are dropped. Ranges that
 /// partially overlap are trimmed.

--- a/query/query.cc
+++ b/query/query.cc
@@ -362,10 +362,6 @@ static void write_partial_partition(ser::writer_of_qr_partition<bytes_ostream>&&
 }
 
 foreign_ptr<lw_shared_ptr<query::result>> result_merger::get() {
-    if (_partial.size() == 1) {
-        return std::move(_partial[0]);
-    }
-
     bytes_ostream w;
     auto partitions = ser::writer_of_query_result<bytes_ostream>(w).start_partitions();
     uint64_t row_count = 0;

--- a/test/cqlpy/test_secondary_index.py
+++ b/test/cqlpy/test_secondary_index.py
@@ -2061,7 +2061,6 @@ def test_index_in_API(cql, test_keyspace):
 # from the index view (where the LIMIT is correctly applied). A mismatch is
 # always interpreted as more pages being available, which in this case is incorrect.
 # See `generate_view_paging_state_from_base_query_results()` for more details.
-@pytest.mark.xfail(reason="issue #22158")
 @pytest.mark.parametrize("use_paging", [False, True])
 def test_limit_partition(cql, test_keyspace, use_paging):
     with new_test_table(cql, test_keyspace, 'pk1 int, pk2 int, ck int, primary key ((pk1, pk2), ck)') as table:
@@ -2094,7 +2093,6 @@ def test_limit_partition(cql, test_keyspace, use_paging):
 # Same as test_limit_partition above, except that it uses partition slices
 # instead of whole partitions. This is achieved by indexing the first clustering
 # key column.
-@pytest.mark.xfail(reason="issue #22158")
 @pytest.mark.parametrize("use_paging", [False, True])
 def test_limit_partition_slice(cql, test_keyspace, use_paging):
     with new_test_table(cql, test_keyspace, 'pk int, ck1 int, ck2 int, primary key (pk, ck1, ck2)') as table:
@@ -2127,7 +2125,6 @@ def test_limit_partition_slice(cql, test_keyspace, use_paging):
 
 # Same as test_limit_partition_slice above, except that the indexed column is static.
 # Reproduces #22158.
-@pytest.mark.xfail(reason="issue #22158")
 @pytest.mark.parametrize("use_paging", [False, True])
 def test_static_column_index_with_limit(cql, test_keyspace, use_paging):
     with new_test_table(cql, test_keyspace, 'pk int, ck int, s int STATIC, primary key (pk, ck)') as table:

--- a/test/cqlpy/test_secondary_index.py
+++ b/test/cqlpy/test_secondary_index.py
@@ -1287,7 +1287,6 @@ def test_index_paging_pk_only(cql, test_keyspace):
 # one component), the restriction can match the entire partition, but paging
 # still needs to page through it - and not return the entire partition as one
 # page! Reproduces #7432.
-@pytest.mark.xfail(reason="issue #7432")
 def test_index_paging_match_partition(cql, test_keyspace):
     schema = 'p1 int, p2 int, c int, primary key (p1,p2,c)'
     with new_test_table(cql, test_keyspace, schema) as table:
@@ -2176,7 +2175,6 @@ def test_static_column_index_with_limit(cql, test_keyspace, use_paging):
 #     Can also happen if the coordinator's accumulated result exceeds 1MiB
 #     (enforced in `do_execute_base_query()`).
 #
-@pytest.mark.xfail(reason="issue #22158")
 def test_limit_partition_slice_across_pages(cql, test_keyspace):
     with new_test_table(cql, test_keyspace, 'pk int, ck1 int, ck2 int, primary key (pk, ck1, ck2)') as table:
         cql.execute(f'CREATE INDEX ON {table}(ck1)')
@@ -2241,7 +2239,6 @@ def test_short_read(cql, test_keyspace):
 # The test is also affected by #25839, which causes the last row of the
 # first partition to be missing from the result, but this is not the main point
 # of this test.
-@pytest.mark.xfail(reason="issue #22158")
 def test_limit_partition_slice_short_read(cql, test_keyspace):
     page_memory_limit = 1024 * 1024  # 1MiB
     row_size = page_memory_limit // 2  # will cause short read after 2 rows


### PR DESCRIPTION
This PR attempts to strike three interrelated bugs at once:

* https://github.com/scylladb/scylladb/issues/25839
* https://github.com/scylladb/scylladb/issues/7432
* https://github.com/scylladb/scylladb/issues/22158

The PR starts by adding some additional test cases for #22158, and then fixes those issues incrementally as follows:

1. [Index view read] Restrict partition key deduplication across pages
    * Description: When a page stops in the midst of a partition (e.g., short read), do not skip this last partition from the next page, except for the very special case where the index is on a map column's values. Essentially, narrow down the skipping logic so that it applies only to the very special case that it was supposed to solve in the first place.
    * Effect: Fixes 25839 (except for a corner case with an index on map values of a static column; explained later in this cover letter). Required for 7432 and 22158.
2. [Index view read] Fix remaining rows when adjusting paging state
    * Description: When adjusting the index view's paging state after a base table read, do not bust the "remaining" field.
    * Effect: Required for 7432 and 22158.
3. [Base table read] Limit base table reads to match index view rows
    * Description: When reading partitions from the base table, apply an upper bound to the clustering ranges being read, so that the read stops at the same clustering key as the index view.
    * Effect: Fixes 7432 for the non-group-by case. Fixes 22158 for paged queries.
4. [Base table read] Fix limit for result merger in fast path
    * Description: Apply a stricter limit to the result merger that merges the results from the base table.
    * Effect: Fixes 22158 for the remaining cases (unpaged queries, queries on static columns).

State of issues after this PR (with references to cqlpy tests):
* #25839
   * Resolved when indexed column is not a map (`test_secondary_index::test_short_read`).
   * NOT resolved for index on map values of static column (`test_secondary_index::test_short_read_static_column_map_values`).
* #7432
   * Resolved for non-static non-group-by case (`test_secondary_index::test_index_paging_match_partition`).
   * NOT resolved for static case (`test_secondary_index::test_index_paging_static_column`).
   * NOT resolved for group-by case (`test_secondary_index::test_index_paging_group_by`).
* #22158
   * Fully resolved (`test_limit_partition`, `test_limit_partition_slice`, `test_limit_partition_slice_across_pages`, `test_limit_partition_slice_short_read`, `test_static_column_index_with_limit`).

Fixes #22158.
Refs #25839.
Refs #7432.

Intrusive changes, do not backport. 