### PR TITLE
alternator: More accurate WCU calculation for UpdateItem

### DIFF
--- a/alternator/consumed_capacity.hh
+++ b/alternator/consumed_capacity.hh
@@ -63,4 +63,11 @@ public:
     static uint64_t get_units(uint64_t total_bytes) noexcept;
 };
 
+inline size_t dynamo_field_size(const bytes& value) {
+    // ScyllaDB uses one extra byte compared to DynamoDB for the bytes length
+    return value.length() ? value.length() - 1 : 0;
+}
+inline size_t dynamo_field_size(const sstring& value) {
+    return value.length();
+}
 }

--- a/alternator/rmw_operation.hh
+++ b/alternator/rmw_operation.hh
@@ -107,7 +107,7 @@ public:
     // violating this). We mark apply() "const" to let the compiler validate
     // this for us. The output-only field _return_attributes is marked
     // "mutable" above so that apply() can still write to it.
-    virtual std::optional<mutation> apply(std::unique_ptr<rjson::value> previous_item, api::timestamp_type ts) const = 0;
+    virtual std::optional<mutation> apply(std::unique_ptr<rjson::value> previous_item, uint64_t size, api::timestamp_type ts) const = 0;
     // Convert the above apply() into the signature needed by cas_request:
     virtual std::optional<mutation> apply(foreign_ptr<lw_shared_ptr<query::result>> qr, const query::partition_slice& slice, api::timestamp_type ts) override;
     virtual ~rmw_operation() = default;


### PR DESCRIPTION
According to DynamoDB documentation on UpdateItem WCU consumption: DynamoDB considers the size of the item as it appears before and after the update, but the current implementation took into account the old item size and the updated parameters' size.

Fixes: https://github.com/scylladb/scylladb/issues/25848