### PR TITLE
scylla-nodetool: Add --incremental-mode option to cluster repair

### DIFF
--- a/docs/operating-scylla/nodetool-commands/cluster/repair.rst
+++ b/docs/operating-scylla/nodetool-commands/cluster/repair.rst
@@ -53,6 +53,14 @@ ScyllaDB nodetool cluster repair command supports the following options:
 
      nodetool cluster repair --tablet-tokens 1,10474535988
 
+- ``--incremental-mode`` specifies the incremental repair mode. Can be 'disabled', 'regular', or 'full'. 'regular': The incremental repair logic is enabled. Unrepaired sstables will be included for repair. Repaired sstables will be skipped. The incremental repair states will be updated after repair. 'full': The incremental repair logic is enabled. Both repaired and unrepaired sstables will be included for repair. The incremental repair states will be updated after repair. 'disabled': The incremental repair logic is disabled completely. The incremental repair states, e.g., repaired_at in sstables and sstables_repaired_at in the system.tablets table, will not be updated after repair. When the option is not provided, it defaults to regular.
+
+  For example:
+
+  ::
+
+     nodetool cluster repair --incremental-mode regular
+
 - ``keyspace`` executes a repair on a specific keyspace. The default is all keyspaces.
 
   For example:

--- a/tools/scylla-nodetool.cc
+++ b/tools/scylla-nodetool.cc
@@ -557,6 +557,15 @@ void cluster_repair_operation(scylla_rest_client& client, const bpo::variables_m
         repair_params["dcs_filter"] = std::move(dcs.value());
     }
 
+    if (vm.contains("incremental-mode")) {
+        auto mode = vm["incremental-mode"].as<sstring>();
+        const std::unordered_set<sstring> supported_mode{"disabled", "regular", "full"};
+        if (!supported_mode.contains(mode)) {
+            throw std::invalid_argument("nodetool cluster repair --incremental-mode only supports: disabled, regular, full");
+        }
+        repair_params["incremental_mode"] = mode;
+    }
+
     auto log = [&]<typename... Args> (fmt::format_string<Args...> fmt, Args&&... param) {
         const auto msg = fmt::format(fmt, param...);
         using clock = std::chrono::system_clock;
@@ -3709,6 +3718,7 @@ For more information, see: {}"
                             typed_option<std::vector<sstring>>("in-dc", "Constrain repair to specific datacenter(s)"),
                             typed_option<std::vector<sstring>>("in-hosts", "Constrain repair to the specific host(s)"),
                             typed_option<std::vector<sstring>>("tablet-tokens", "Tokens owned by the tablets to repair."),
+                            typed_option<sstring>("incremental-mode", "Specify the incremental repair mode: disabled, regular, full"),
                         },
                         {
                             typed_option<sstring>("keyspace", "The keyspace to repair, if missing all keyspaces are repaired", 1),


### PR DESCRIPTION
The `--incremental-mode` option specifies the incremental repair mode. Can be 'disabled', 'regular', or 'full'.

'regular': The incremental repair logic is enabled. Unrepaired sstables will be included for repair.  Repaired sstables will be skipped. The incremental repair states will be updated after repair.

'full': The incremental repair logic is enabled. Both repaired and unrepaired sstables will be included for repair. The incremental repair states will be updated after repair.

'disabled': The incremental repair logic is disabled completely. The incremental repair states, e.g., repaired_at in sstables and sstables_repaired_at in the system.tablets table, will not be updated after repair.

When the option is not provided, it defaults to regular.

Fixes #25931

No backport is needed. This should be release as part of 2025.4 with the main incremental repair PR. 