### PR TITLE
Remove const & from tags_extension constructor

### DIFF
--- a/db/tags/extension.hh
+++ b/db/tags/extension.hh
@@ -22,7 +22,7 @@ public:
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
     tags_extension() = default;
-    explicit tags_extension(const std::map<sstring, sstring>& tags) : _tags(std::move(tags)) {}
+    explicit tags_extension(std::map<sstring, sstring> tags) : _tags(std::move(tags)) {}
     explicit tags_extension(bytes b) : _tags(tags_extension::deserialize(b)) {}
     explicit tags_extension(const sstring& s) {
         throw std::logic_error("Cannot create tags from string");


### PR DESCRIPTION
`tags_extension` constructor unnecesarily takes `std::map` by const ref, forcing a copy. This patch removes const ref for performance reasons.
