### PR TITLE
alternator: add explanation of internal tags

### DIFF
--- a/alternator/ttl.cc
+++ b/alternator/ttl.cc
@@ -56,14 +56,14 @@ static logging::logger tlogger("alternator_ttl");
 
 namespace alternator {
 
-// We write the expiration-time attribute enabled on a table using a
+// We write the expiration-time attribute enabled on a table in a
 // tag TTL_TAG_KEY.
 // Currently, the *value* of this tag is simply the name of the attribute,
 // and the expiration scanner interprets it as an Alternator attribute name -
 // It can refer to a real column or if that doesn't exist, to a member of
 // the ":attrs" map column. Although this is designed for Alternator, it may
 // be good enough for CQL as well (there, the ":attrs" column won't exist).
-static const sstring TTL_TAG_KEY("system:ttl_attribute");
+extern const sstring TTL_TAG_KEY;
 
 future<executor::request_return_type> executor::update_time_to_live(client_state& client_state, service_permit permit, rjson::value request) {
     _stats.api_operations.update_time_to_live++;


### PR DESCRIPTION
Alternator needs to store a few pieces of information for each table that it can't store in the existing CQL schema. We decided to store this information in hidden tags - tags named with the prefix "system:" - and we already have four of those: Provisioned RCU and WCU, table creation time, and TTL's expiration-time attribute.

This patch moves the definition of all four tags to one place in executor.cc, adds a short comment about the content of each tag, and adds a longer comment explaining why we have these hidden tags at all.

It is expected that more hidden tags will follow - e.g., to solve issue #5320. So we expect more tags to be added later in the same place in the code.

Code reorganization only, no need for backport.