### PR TITLE
vector_store_client: Refactor high availability and DNS logic

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1257,6 +1257,9 @@ scylla_core = (['message/messaging_service.cc',
                 'reader_concurrency_semaphore_group.cc',
                 'utils/disk_space_monitor.cc',
                 'service/vector_store_client.cc',
+                'service/vector_search/client.cc',
+                'service/vector_search/high_availability.cc',
+                'service/vector_search/dns.cc',
                 ] + [Antlr3Grammar('cql3/Cql.g')] \
                   + scylla_raft_core
                )

--- a/service/CMakeLists.txt
+++ b/service/CMakeLists.txt
@@ -34,7 +34,11 @@ target_sources(service
     topology_coordinator.cc
     topology_mutation.cc
     topology_state_machine.cc
-    vector_store_client.cc)
+    vector_store_client.cc
+    vector_search/high_availability.cc
+    vector_search/dns.cc
+    vector_search/client.cc
+    )
 target_include_directories(service
   PUBLIC
     ${CMAKE_SOURCE_DIR})

--- a/service/vector_search/client.cc
+++ b/service/vector_search/client.cc
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2025-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+ */
+
+#include "client.hh"
+#include "exception.hh"
+#include <seastar/core/format.hh>
+#include <seastar/http/request.hh>
+#include <seastar/http/common.hh>
+#include <seastar/http/short_streams.hh>
+#include <seastar/net/socket_defs.hh>
+#include <seastar/net/api.hh>
+#include "utils/rjson.hh"
+#include <chrono>
+
+using namespace seastar;
+using namespace std::chrono_literals;
+
+namespace service::vector_search {
+namespace {
+
+class client_connection_factory : public http::experimental::connection_factory {
+    socket_address _addr;
+
+public:
+    explicit client_connection_factory(socket_address addr)
+        : _addr(addr) {
+    }
+
+    future<connected_socket> make([[maybe_unused]] abort_source* as) override {
+        auto socket = co_await seastar::connect(_addr, {}, transport::TCP);
+        socket.set_nodelay(true);
+        socket.set_keepalive_parameters(net::tcp_keepalive_params{
+                .idle = 60s,
+                .interval = 60s,
+                .count = 10,
+        });
+        socket.set_keepalive(true);
+        co_return socket;
+    }
+};
+
+auto write_ann_json(std::vector<float> embedding, std::size_t limit) -> seastar::sstring {
+    return seastar::format(R"({{"embedding":[{}],"limit":{}}})", fmt::join(embedding, ","), limit);
+}
+
+sstring to_string(const std::vector<temporary_buffer<char>>& buffers) {
+    sstring result;
+    for (const auto& buf : buffers) {
+        result.append(buf.get(), buf.size());
+    }
+    return result;
+}
+
+} // namespace
+
+client::client(::service::vector_search::endpoint endpoint_)
+    : _endpoint(std::move(endpoint_))
+    , _http_client(std::make_unique<client_connection_factory>(socket_address(_endpoint.ip, _endpoint.port))) {
+}
+
+seastar::future<client::ann_result> client::ann(
+        seastar::sstring keyspace, seastar::sstring name, std::vector<float> embedding, std::size_t limit, seastar::abort_source* as) {
+    auto path = format("/api/v1/indexes/{}/{}/ann", keyspace, name);
+    auto content = write_ann_json(std::move(embedding), limit);
+    auto req = http::request::make(httpd::operation_type::POST, _endpoint.host, std::move(path));
+    req.write_body("json", std::move(content));
+
+    co_return co_await request(std::move(req), as);
+}
+
+seastar::future<std::vector<seastar::temporary_buffer<char>>> client::request(http::request req, seastar::abort_source* as) {
+    auto resp = std::vector<seastar::temporary_buffer<char>>{};
+    auto status = seastar::http::reply::status_type::ok;
+    auto handler = [&resp, &status](http::reply const& reply, input_stream<char> body) -> future<> {
+        status = reply._status;
+        resp = co_await util::read_entire_stream(body);
+    };
+
+    co_await _http_client.make_request(std::move(req), std::move(handler), std::nullopt, as);
+    if (status != seastar::http::reply::status_type::ok) {
+        throw service_status_exception(status, to_string(resp));
+    }
+    co_return resp;
+}
+
+} // namespace service::vector_search

--- a/service/vector_search/client.hh
+++ b/service/vector_search/client.hh
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2025-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+ */
+
+#pragma once
+
+#include "endpoint.hh"
+#include <vector>
+#include <seastar/core/future.hh>
+#include <seastar/core/sstring.hh>
+#include <seastar/core/abort_source.hh>
+#include <seastar/http/client.hh>
+#include <boost/noncopyable.hpp>
+
+namespace service::vector_search {
+
+class client : private boost::noncopyable {
+public:
+    using ann_result = std::vector<seastar::temporary_buffer<char>>;
+
+    explicit client(endpoint endpoint_);
+
+    const endpoint& endpoint() const {
+        return _endpoint;
+    }
+
+    seastar::future<ann_result> ann(
+            seastar::sstring keyspace, seastar::sstring name, std::vector<float> embedding, std::size_t limit, seastar::abort_source* as);
+
+    seastar::future<> close() {
+        return _http_client.close();
+    }
+
+private:
+    seastar::future<std::vector<seastar::temporary_buffer<char>>> request(seastar::http::request req, seastar::abort_source* as);
+
+    ::service::vector_search::endpoint _endpoint;
+    seastar::http::experimental::client _http_client;
+};
+
+} // namespace service::vector_search

--- a/service/vector_search/dns.cc
+++ b/service/vector_search/dns.cc
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2025-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+ */
+
+#include "dns.hh"
+#include <seastar/core/coroutine.hh>
+
+namespace service::vector_search {
+
+dns::dns(dns_resolver resolver)
+    : _resolver(std::move(resolver)) {
+}
+
+seastar::future<std::optional<seastar::net::inet_address>> dns::resolve(seastar::sstring host) {
+    auto now = seastar::lowres_clock::now();
+    auto current_duration = now - _last_refresh;
+    if (current_duration >= _refresh_interval) {
+        _last_refresh = now;
+        _addr = co_await _resolver(host);
+    }
+    co_return _addr;
+}
+
+} // namespace service::vector_search

--- a/service/vector_search/dns.hh
+++ b/service/vector_search/dns.hh
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2025-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+ */
+
+#pragma once
+
+#include <functional>
+#include <optional>
+#include <seastar/core/sstring.hh>
+#include <seastar/core/future.hh>
+#include <seastar/net/inet_address.hh>
+#include <seastar/core/lowres_clock.hh>
+#include <boost/noncopyable.hpp>
+
+namespace service::vector_search {
+
+// Ensures not to query the dns server too often.
+class dns : private boost::noncopyable {
+public:
+    using dns_resolver = std::function<seastar::future<std::optional<seastar::net::inet_address>>(seastar::sstring const&)>;
+
+    explicit dns(dns_resolver resolver);
+
+    seastar::future<std::optional<seastar::net::inet_address>> resolve(seastar::sstring host);
+
+    void set_resolver(dns_resolver resolver) {
+        _resolver = std::move(resolver);
+    }
+
+    void set_refresh_interval(std::chrono::milliseconds interval) {
+        _refresh_interval = interval;
+    }
+
+private:
+    dns_resolver _resolver;
+    seastar::lowres_clock::time_point _last_refresh;
+    std::optional<seastar::net::inet_address> _addr;
+    std::chrono::milliseconds _refresh_interval{std::chrono::seconds(5)};
+};
+
+} // namespace service::vector_search

--- a/service/vector_search/endpoint.hh
+++ b/service/vector_search/endpoint.hh
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2025-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+ */
+
+#pragma once
+
+#include <seastar/core/sstring.hh>
+#include <seastar/net/inet_address.hh>
+#include <cstdint>
+
+namespace service::vector_search {
+
+struct endpoint {
+    seastar::sstring host;
+    std::uint16_t port;
+    seastar::net::inet_address ip;
+};
+
+} // namespace service::vector_search

--- a/service/vector_search/exception.hh
+++ b/service/vector_search/exception.hh
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2025-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+ */
+
+#pragma once
+
+#include <seastar/http/reply.hh>
+#include <stdexcept>
+#include <fmt/format.h>
+
+namespace service::vector_search {
+
+class service_status_exception : public std::runtime_error {
+public:
+    explicit service_status_exception(seastar::http::reply::status_type status, seastar::sstring content)
+        : std::runtime_error(fmt::format("Vector Store error: HTTP status {}", status))
+        , _status{status}
+        , _content{std::move(content)} {
+    }
+
+    const seastar::http::reply::status_type& status() const noexcept {
+        return _status;
+    }
+
+    const seastar::sstring& content() const noexcept {
+        return _content;
+    }
+
+private:
+    seastar::http::reply::status_type _status;
+    seastar::sstring _content;
+};
+
+class service_reply_format_exception : public std::runtime_error {
+public:
+    explicit service_reply_format_exception()
+        : std::runtime_error("Vector Store returned an invalid JSON") {
+    }
+
+    const seastar::http::reply::status_type& status() const noexcept {
+        return _status;
+    }
+
+private:
+    seastar::http::reply::status_type _status;
+};
+
+class service_unavailable_exception : public std::runtime_error {
+public:
+    explicit service_unavailable_exception()
+        : std::runtime_error("Vector Store service is unavailable") {
+    }
+};
+
+class service_disabled_exception : public std::runtime_error {
+public:
+    explicit service_disabled_exception()
+        : std::runtime_error("Vector Store is disabled") {
+    }
+};
+
+class service_address_unavailable_exception : public std::runtime_error {
+public:
+    explicit service_address_unavailable_exception()
+        : std::runtime_error("Vector Store service address could not be fetched from DNS") {
+    }
+};
+
+} // namespace service::vector_search

--- a/service/vector_search/high_availability.cc
+++ b/service/vector_search/high_availability.cc
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2025-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+ */
+
+#include "high_availability.hh"
+#include "exception.hh"
+#include "seastar/core/abort_source.hh"
+#include <boost/algorithm/string.hpp>
+#include <seastar/core/when_all.hh>
+#include <seastar/core/loop.hh>
+
+using namespace seastar;
+
+namespace service::vector_search {
+namespace {
+
+constexpr auto HTTP_REQUEST_RETRIES = 3;
+
+bool is_server_error(seastar::http::reply::status_type status) {
+    return status >= seastar::http::reply::status_type(500) && status < seastar::http::reply::status_type(600);
+}
+
+} // namespace
+
+seastar::future<client::ann_result> high_availability::ann(
+        seastar::sstring keyspace, seastar::sstring name, std::vector<float> embedding, std::size_t limit, seastar::abort_source* as) {
+
+    if (!_uri) {
+        throw service_disabled_exception{};
+    }
+
+    for (size_t i = 0; i < HTTP_REQUEST_RETRIES; i++) {
+        auto client = co_await get_client(as);
+        try {
+            co_return co_await client->ann(std::move(keyspace), std::move(name), std::move(embedding), limit, as);
+        } catch (const abort_requested_exception& e) {
+            // Stop retrying if the request was aborted
+            throw;
+        } catch (const service_status_exception& e) {
+            // Stop retrying if the error is not a server error
+            // This means that client performed a bad request
+            if (!is_server_error(e.status())) {
+                throw;
+            }
+        } catch (...) {
+        }
+        // Refresh client address and retry
+        co_await refresh_client_address(as);
+        client = co_await get_client(as);
+    }
+    throw service_unavailable_exception();
+}
+
+seastar::future<> high_availability::set_uri(std::optional<uri> uri) {
+    _uri = std::move(uri);
+    co_await refresh_client_address(nullptr);
+}
+
+seastar::future<> high_availability::refresh_client_address(seastar::abort_source* as) {
+    if (_uri) {
+        auto addr = co_await _dns.resolve(_uri->host);
+        if (addr) {
+            co_await stop();
+            _client = seastar::make_lw_shared<client>(endpoint{_uri->host, _uri->port, *addr});
+            co_return;
+        }
+    }
+    _client = nullptr;
+    if (as && as->abort_requested()) {
+
+        throw abort_requested_exception{};
+    }
+}
+
+seastar::future<seastar::lw_shared_ptr<client>> high_availability::get_client(seastar::abort_source* as) {
+    if (_client) {
+        co_return _client;
+    }
+    co_await refresh_client_address(as);
+    if (!_client) {
+        throw service_address_unavailable_exception{};
+    }
+    co_return _client;
+}
+
+seastar::future<> high_availability::stop() {
+    if (_client) {
+        co_await _client->close();
+    }
+}
+
+} // namespace service::vector_search

--- a/service/vector_search/high_availability.hh
+++ b/service/vector_search/high_availability.hh
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2025-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+ */
+
+#pragma once
+
+#include "client.hh"
+#include "dns.hh"
+#include "seastar/core/future.hh"
+#include <seastar/core/sstring.hh>
+#include <vector>
+#include <cstdint>
+#include <boost/noncopyable.hpp>
+
+namespace service::vector_search {
+
+class high_availability : private boost::noncopyable {
+public:
+    struct uri {
+        seastar::sstring host;
+        std::uint16_t port;
+    };
+
+    using dns_resolver = std::function<seastar::future<std::optional<seastar::net::inet_address>>(seastar::sstring const&)>;
+
+    explicit high_availability(dns_resolver resolver)
+        : _dns(std::move(resolver)) {
+    }
+
+    seastar::future<client::ann_result> ann(
+            seastar::sstring keyspace, seastar::sstring name, std::vector<float> embedding, std::size_t limit, seastar::abort_source* as);
+
+    seastar::future<> set_uri(std::optional<uri> uri);
+
+    void set_dns_resolver(dns_resolver resolver) {
+        _dns.set_resolver(resolver);
+    }
+
+    void set_dns_refresh_interval(std::chrono::milliseconds interval) {
+        _dns.set_refresh_interval(interval);
+    }
+
+    seastar::future<> stop();
+
+private:
+    seastar::future<> refresh_client_address(seastar::abort_source* as);
+    seastar::future<seastar::lw_shared_ptr<client>> get_client(seastar::abort_source* as);
+
+    std::optional<uri> _uri;
+    seastar::lw_shared_ptr<client> _client;
+    dns _dns;
+};
+
+} // namespace service::vector_search

--- a/service/vector_store_client.cc
+++ b/service/vector_store_client.cc
@@ -7,6 +7,8 @@
  */
 
 #include "vector_store_client.hh"
+#include "vector_search/high_availability.hh"
+#include "vector_search/exception.hh"
 #include "cql3/statements/select_statement.hh"
 #include "cql3/type_json.hh"
 #include "db/config.hh"
@@ -51,18 +53,6 @@ using service_reply_format_error = service::vector_store_client::service_reply_f
 using tcp_keepalive_params = net::tcp_keepalive_params;
 using time_point = lowres_clock::time_point;
 
-// Wait time before retrying after an exception occurred
-constexpr auto EXCEPTION_OCCURED_WAIT = std::chrono::seconds(5);
-
-// Minimum interval between dns name refreshes
-constexpr auto DNS_REFRESH_INTERVAL = std::chrono::seconds(5);
-
-/// Timeout for waiting for a new client to be available
-constexpr auto WAIT_FOR_CLIENT_TIMEOUT = std::chrono::seconds(5);
-
-/// How many retries to do for HTTP requests
-constexpr auto HTTP_REQUEST_RETRIES = 3;
-
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 logging::logger vslogger("vector_store_client");
 
@@ -75,10 +65,7 @@ auto parse_port(std::string const& port_txt) -> std::optional<port_number> {
     return port;
 }
 
-struct host_port {
-    host_name host;
-    port_number port;
-};
+using host_port = service::vector_search::high_availability::uri;
 
 auto parse_service_uri(std::string_view uri) -> std::optional<host_port> {
     constexpr auto URI_REGEX = R"(^http:\/\/([a-z0-9._-]+):([0-9]+)$)";
@@ -97,31 +84,6 @@ auto parse_service_uri(std::string_view uri) -> std::optional<host_port> {
     return {{host, *port}};
 }
 
-/// Wait for a timeout ar abort signal.
-auto wait_for_timeout(duration timeout, abort_source& as) -> future<bool> {
-    auto result = co_await coroutine::as_future(sleep_abortable(timeout, as));
-    if (result.failed()) {
-        auto err = result.get_exception();
-        if (as.abort_requested()) {
-            co_return false;
-        }
-        co_await coroutine::return_exception_ptr(std::move(err));
-    }
-    co_return true;
-}
-
-/// Wait for a condition variable to be signaled or timeout.
-auto wait_for_signal(condition_variable& cv, time_point timeout) -> future<bool> {
-    auto result = co_await coroutine::as_future(cv.wait(timeout));
-    if (result.failed()) {
-        auto err = result.get_exception();
-        if (try_catch<condition_variable_timed_out>(err) != nullptr) {
-            co_return false;
-        }
-        co_await coroutine::return_exception_ptr(std::move(err));
-    }
-    co_return true;
-}
 
 auto get_key_column_value(const rjson::value& item, std::size_t idx, const column_definition& column) -> std::expected<bytes, ann_error> {
     auto const& column_name = column.name_as_text();
@@ -172,10 +134,6 @@ auto ck_from_json(rjson::value const& item, std::size_t idx, schema_ptr const& s
     return clustering_key_prefix::from_exploded(raw_ck);
 }
 
-auto write_ann_json(embedding embedding, limit limit) -> json_content {
-    return seastar::format(R"({{"embedding":[{}],"limit":{}}})", fmt::join(embedding, ","), limit);
-}
-
 auto read_ann_json(rjson::value const& json, schema_ptr const& schema) -> std::expected<primary_keys, ann_error> {
     if (!json.HasMember("primary_keys")) {
         vslogger.error("Vector Store returned invalid JSON: missing 'primary_keys'");
@@ -214,63 +172,6 @@ auto read_ann_json(rjson::value const& json, schema_ptr const& schema) -> std::e
     return std::move(keys);
 }
 
-class client_connection_factory : public http::experimental::connection_factory {
-    socket_address _addr;
-
-public:
-    explicit client_connection_factory(socket_address addr)
-        : _addr(addr) {
-    }
-
-    future<connected_socket> make([[maybe_unused]] abort_source* as) override {
-        auto socket = co_await seastar::connect(_addr, {}, transport::TCP);
-        socket.set_nodelay(true);
-        socket.set_keepalive_parameters(tcp_keepalive_params{
-                .idle = 60s,
-                .interval = 60s,
-                .count = 10,
-        });
-        socket.set_keepalive(true);
-        co_return socket;
-    }
-};
-
-class http_client {
-
-    host_port _host_port;
-    inet_address _addr;
-
-    http::experimental::client impl;
-
-public:
-    http_client(host_port host_port_, inet_address addr)
-        : _host_port(std::move(host_port_))
-        , _addr(std::move(addr))
-        , impl(std::make_unique<client_connection_factory>(socket_address(addr, _host_port.port))) {
-    }
-
-    bool connects_to(inet_address const& a, port_number p) const {
-        return _addr == a && _host_port.port == p;
-    }
-
-    seastar::future<> make_request(
-            operation_type method, http_path path, std::optional<json_content> content, http::experimental::client::reply_handler&& handle, abort_source* as) {
-        auto req = http::request::make(method, _host_port.host, std::move(path));
-        if (content) {
-            req.write_body("json", std::move(*content));
-        }
-        return impl.make_request(std::move(req), std::move(handle), std::nullopt, as);
-    }
-
-    seastar::future<> close() {
-        return impl.close();
-    }
-
-    const inet_address& addr() const {
-        return _addr;
-    }
-};
-
 bool should_vector_store_service_be_disabled(std::string_view const& uri) {
     return uri.empty();
 }
@@ -288,14 +189,6 @@ auto get_host_port(std::string_view uri) -> std::optional<host_port> {
     return *parsed;
 }
 
-sstring response_content_to_sstring(const std::vector<temporary_buffer<char>>& buffers) {
-    sstring result;
-    for (const auto& buf : buffers) {
-        result.append(buf.get(), buf.size());
-    }
-    return result;
-}
-
 } // namespace
 
 namespace service {
@@ -303,32 +196,20 @@ namespace service {
 struct vector_store_client::impl {
 
     utils::observer<sstring> uri_observer;
-    lw_shared_ptr<http_client> current_client;
-    std::vector<lw_shared_ptr<http_client>> old_clients;
-    std::optional<host_port> _host_port;
-    time_point last_dns_refresh;
-    gate tasks_gate;
-    condition_variable refresh_cv;
-    condition_variable refresh_client_cv;
-    abort_source abort_refresh;
-    milliseconds dns_refresh_interval = DNS_REFRESH_INTERVAL;
-    milliseconds wait_for_client_timeout = WAIT_FOR_CLIENT_TIMEOUT;
-    unsigned http_request_retries = HTTP_REQUEST_RETRIES;
-    std::function<future<std::optional<inet_address>>(sstring const&)> dns_resolver;
-    sequential_producer<lw_shared_ptr<http_client>> client_producer;
+    vector_search::high_availability ha;
+    std::optional<host_port> _uri;
 
     impl(utils::config_file::named_value<sstring> cfg)
-        : uri_observer(cfg.observe([this](std::string_view uri) {
+        : uri_observer(cfg.observe([this](std::string_view uri) -> future<> {
             try {
-                _host_port = get_host_port(uri);
-                trigger_dns_refresh();
+                _uri = get_host_port(uri);
             } catch (const configuration_exception& e) {
                 vslogger.error("Failed to parse Vector Store service URI: {}", e.what());
-                _host_port = std::nullopt;
+                _uri = std::nullopt;
             }
+            co_await ha.set_uri(_uri);
         }))
-        , _host_port(get_host_port(cfg()))
-        , dns_resolver([](auto const& host) -> future<std::optional<inet_address>> {
+        , ha([](auto const& host) -> future<std::optional<inet_address>> {
             auto addr = co_await coroutine::as_future(net::dns::resolve_name(host));
             if (addr.failed()) {
                 auto err = addr.get_exception();
@@ -339,210 +220,7 @@ struct vector_store_client::impl {
             }
             co_return co_await std::move(addr);
         })
-        , client_producer([&]() -> future<lw_shared_ptr<http_client>> {
-            trigger_dns_refresh();
-            co_await wait_for_signal(refresh_client_cv, lowres_clock::now() + wait_for_client_timeout);
-            co_return current_client;
-        }) {
-    }
-
-    auto is_disabled() const -> bool {
-        return !bool{_host_port};
-    }
-
-    auto host() const -> std::expected<host_name, disabled> {
-        if (is_disabled()) {
-            return std::unexpected{disabled{}};
-        }
-        return _host_port->host;
-    }
-
-    auto port() const -> std::expected<port_number, disabled> {
-        if (is_disabled()) {
-            return std::unexpected{disabled{}};
-        }
-        return _host_port->port;
-    }
-
-    /// Refresh the http client with a new address resolved from the DNS name.
-    /// If the DNS resolution fails, the current client is set to nullptr.
-    /// If the address is the same as the current one, do nothing.
-    /// Old clients are saved for later cleanup in a specific task.
-    auto refresh_addr() -> future<> {
-        if (is_disabled()) {
-            current_client = nullptr;
-            co_return;
-        }
-        auto [host, port] = *_host_port;
-        auto new_addr = co_await dns_resolver(host);
-        if (!new_addr) {
-            current_client = nullptr;
-            co_return;
-        }
-
-        // Check if the new address and port is the same as the current one
-        if (current_client && current_client->connects_to(*new_addr, port)) {
-            co_return;
-        }
-
-        old_clients.emplace_back(current_client);
-        current_client = make_lw_shared<http_client>(*_host_port, std::move(*new_addr));
-    }
-
-    /// A task for refreshing the vector store http client.
-    auto refresh_addr_task() -> future<> {
-        for (;;) {
-            auto exception_occured = false;
-            try {
-                if (abort_refresh.abort_requested()) {
-                    break;
-                }
-
-                // Do not refresh the service address too often
-                auto now = lowres_clock::now();
-                auto current_duration = now - last_dns_refresh;
-                if (current_duration > dns_refresh_interval) {
-                    last_dns_refresh = now;
-                    co_await refresh_addr();
-                } else {
-                    // Wait till the end of the refreshing interval
-                    if (co_await wait_for_timeout(dns_refresh_interval - current_duration, abort_refresh)) {
-                        continue;
-                    }
-                    // If the wait was aborted, we stop refreshing
-                    break;
-                }
-
-                if (abort_refresh.abort_requested()) {
-                    break;
-                }
-
-                // new client is available
-                refresh_client_cv.broadcast();
-
-                co_await cleanup_old_clients();
-
-                co_await refresh_cv.when();
-            } catch (const std::exception& e) {
-                vslogger.error("Vector Store Client refresh task failed: {}", e.what());
-                exception_occured = true;
-            } catch (...) {
-                vslogger.error("Vector Store Client refresh task failed with unknown exception");
-                exception_occured = true;
-            }
-            if (exception_occured) {
-                // If an exception occurred, we wait for the next signal to refresh the address
-                co_await wait_for_timeout(EXCEPTION_OCCURED_WAIT, abort_refresh);
-            }
-        }
-
-        co_await cleanup_old_clients();
-        co_await cleanup_current_client();
-    }
-
-    /// Request a DNS refresh in the specific task.
-    void trigger_dns_refresh() {
-        refresh_cv.signal();
-    }
-
-    /// Cleanup current client
-    auto cleanup_current_client() -> future<> {
-        if (current_client) {
-            co_await current_client->close();
-        }
-        current_client = nullptr;
-    }
-
-    /// Cleanup old clients that are no longer used.
-    auto cleanup_old_clients() -> future<> {
-        // iterate over old clients and close them. There is a co_await in the loop
-        // so we need to use [] accessor and copying clients to avoid dangling references of iterators.
-        // NOLINTNEXTLINE(modernize-loop-convert)
-        for (auto it = 0U; it < old_clients.size(); ++it) {
-            auto& client = old_clients[it];
-            if (client && client.owned()) {
-                auto client_cloned = client;
-                co_await client_cloned->close();
-                client_cloned = nullptr;
-            }
-        }
-        std::erase_if(old_clients, [](auto const& client) {
-            return !client;
-        });
-    }
-
-    using get_client_error = std::variant<aborted, addr_unavailable, disabled>;
-
-    /// Get the current http client or wait for a new one to be available.
-    auto get_client(abort_source& as) -> future<std::expected<lw_shared_ptr<http_client>, get_client_error>> {
-        if (is_disabled()) {
-            co_return std::unexpected{disabled{}};
-        }
-        if (current_client) {
-            co_return current_client;
-        }
-
-        auto current_client = co_await coroutine::as_future(client_producer(as));
-
-        if (current_client.failed()) {
-            auto err = current_client.get_exception();
-            if (as.abort_requested()) {
-                co_return std::unexpected{aborted{}};
-            }
-            co_await coroutine::return_exception_ptr(std::move(err));
-        }
-        auto client = co_await std::move(current_client);
-        if (!client) {
-            co_return std::unexpected{addr_unavailable{}};
-        }
-        co_return client;
-    }
-
-    struct make_request_response {
-        http::reply::status_type status;             ///< The HTTP status of the response.
-        std::vector<temporary_buffer<char>> content; ///< The content of the response.
-    };
-
-    using make_request_error = std::variant<aborted, addr_unavailable, service_unavailable, disabled>;
-
-    auto make_request(operation_type method, http_path path, std::optional<json_content> content, abort_source& as)
-            -> future<std::expected<make_request_response, make_request_error>> {
-        auto resp = make_request_response{.status = http::reply::status_type::ok, .content = std::vector<temporary_buffer<char>>()};
-
-        for (auto retries = 0; retries < HTTP_REQUEST_RETRIES; ++retries) {
-            auto client = co_await get_client(as);
-            if (!client) {
-                co_return std::unexpected{std::visit(
-                        [](auto&& err) {
-                            return make_request_error{err};
-                        },
-                        client.error())};
-            }
-
-            auto result = co_await coroutine::as_future(client.value()->make_request(
-                    method, std::move(path), std::move(content),
-                    [&resp](http::reply const& reply, input_stream<char> body) -> future<> {
-                        resp.status = reply._status;
-                        resp.content = co_await util::read_entire_stream(body);
-                    },
-                    &as));
-            if (result.failed()) {
-                auto err = result.get_exception();
-                if (as.abort_requested()) {
-                    co_return std::unexpected{aborted{}};
-                }
-                if (try_catch<std::system_error>(err) == nullptr) {
-                    co_await coroutine::return_exception_ptr(std::move(err));
-                }
-                // std::system_error means that the server is unavailable, so we retry
-            } else {
-                co_return resp;
-            }
-
-            trigger_dns_refresh();
-        }
-
-        co_return std::unexpected{service_unavailable{}};
+        , _uri(get_host_port(cfg())) {
     }
 };
 
@@ -553,91 +231,52 @@ vector_store_client::vector_store_client(config const& cfg)
 vector_store_client::~vector_store_client() = default;
 
 void vector_store_client::start_background_tasks() {
-    /// start the background task to refresh the service address
-    (void)try_with_gate(_impl->tasks_gate, [this] {
-        return _impl->refresh_addr_task();
-    }).handle_exception([](std::exception_ptr eptr) {
-        on_internal_error_noexcept(vslogger, format("The Vector Store Client refresh task failed: {}", eptr));
-    });
+    auto f = start();
+}
+
+auto vector_store_client::start() -> future<> {
+    return _impl->ha.set_uri(_impl->_uri);
 }
 
 auto vector_store_client::stop() -> future<> {
-    _impl->abort_refresh.request_abort();
-    _impl->refresh_cv.signal();
-    co_await _impl->tasks_gate.close();
-}
-
-auto vector_store_client::is_disabled() const -> bool {
-    return _impl->is_disabled();
-}
-
-auto vector_store_client::host() const -> std::expected<host_name, disabled> {
-    return _impl->host();
-}
-
-auto vector_store_client::port() const -> std::expected<port_number, disabled> {
-    return _impl->port();
+    return _impl->ha.stop();
 }
 
 auto vector_store_client::ann(keyspace_name keyspace, index_name name, schema_ptr schema, embedding embedding, limit limit, abort_source& as)
         -> future<std::expected<primary_keys, ann_error>> {
-    if (is_disabled()) {
-        vslogger.error("Disabled Vector Store while calling ann");
-        co_return std::unexpected{disabled{}};
-    }
-
-    auto path = format("/api/v1/indexes/{}/{}/ann", keyspace, name);
-    auto content = write_ann_json(std::move(embedding), limit);
-
-    auto resp = co_await _impl->make_request(operation_type::POST, std::move(path), std::move(content), as);
-    if (!resp) {
-        co_return std::unexpected{std::visit(
-                [](auto&& err) {
-                    return ann_error{err};
-                },
-                resp.error())};
-    }
-
-    if (resp->status != status_type::ok) {
-        vslogger.error("Vector Store returned error: HTTP status {}: {}", resp->status,
-                       seastar::value_of([&resp] {return response_content_to_sstring(resp->content);}));
-        co_return std::unexpected{service_error{resp->status}};
-    }
-
     try {
-        co_return read_ann_json(rjson::parse(std::move(resp->content)), schema);
+        auto content = co_await _impl->ha.ann(std::move(keyspace), std::move(name), std::move(embedding), limit, &as);
+        co_return read_ann_json(rjson::parse(std::move(content)), schema);
     } catch (const rjson::error& e) {
-        vslogger.error("Vector Store returned invalid JSON: {}", e.what());
+        vslogger.error("{}", e.what());
         co_return std::unexpected{service_reply_format_error{}};
+    } catch (const vector_search::service_address_unavailable_exception& e) {
+        vslogger.error("{}", e.what());
+        co_return std::unexpected{addr_unavailable{}};
+    } catch (const vector_search::service_disabled_exception& e) {
+        vslogger.error("{}", e.what());
+        co_return std::unexpected{disabled{}};
+    } catch (const vector_search::service_status_exception& e) {
+        vslogger.error("{}: {}", e.what(), e.content());
+        co_return std::unexpected{service_error{e.status()}};
+    } catch (const seastar::abort_requested_exception& e) {
+        vslogger.error("{}", e.what());
+        co_return std::unexpected{aborted{}};
+    } catch (const std::exception& e) {
+        vslogger.error("{}", e.what());
+        co_return std::unexpected{service_unavailable{}};
+    } catch (...) {
+        vslogger.error("Vector Store ann request failed with unknown exception");
+        co_return std::unexpected{service_unavailable{}};
     }
 }
 
 void vector_store_client_tester::set_dns_refresh_interval(vector_store_client& vsc, std::chrono::milliseconds interval) {
-    vsc._impl->dns_refresh_interval = interval;
-}
-
-void vector_store_client_tester::set_wait_for_client_timeout(vector_store_client& vsc, std::chrono::milliseconds timeout) {
-    vsc._impl->wait_for_client_timeout = timeout;
-}
-
-void vector_store_client_tester::set_http_request_retries(vector_store_client& vsc, unsigned retries) {
-    vsc._impl->http_request_retries = retries;
+    vsc._impl->ha.set_dns_refresh_interval(interval);
 }
 
 void vector_store_client_tester::set_dns_resolver(vector_store_client& vsc, std::function<future<std::optional<inet_address>>(sstring const&)> resolver) {
-    vsc._impl->dns_resolver = std::move(resolver);
-}
-
-void vector_store_client_tester::trigger_dns_resolver(vector_store_client& vsc) {
-    vsc._impl->trigger_dns_refresh();
-}
-
-auto vector_store_client_tester::resolve_hostname(vector_store_client& vsc, abort_source& as) -> future<std::optional<inet_address>> {
-    auto client = co_await vsc._impl->get_client(as);
-    if (!client) {
-        co_return std::nullopt;
-    }
-    co_return client.value()->addr();
+    vsc._impl->ha.set_dns_resolver(std::move(resolver));
 }
 
 } // namespace service

--- a/service/vector_store_client.hh
+++ b/service/vector_store_client.hh
@@ -97,17 +97,11 @@ public:
     /// Start background tasks.
     void start_background_tasks();
 
+    /// Start the service.
+    auto start() -> future<>;
+
     /// Stop the service.
     auto stop() -> future<>;
-
-    /// Check if the vector_store_client is disabled.
-    auto is_disabled() const -> bool;
-
-    /// Get the current host name.
-    [[nodiscard]] auto host() const -> std::expected<host_name, disabled>;
-
-    /// Get the current port number.
-    [[nodiscard]] auto port() const -> std::expected<port_number, disabled>;
 
     /// Request the vector store service for the primary keys of the nearest neighbors
     auto ann(keyspace_name keyspace, index_name name, schema_ptr schema, embedding embedding, limit limit, abort_source& as)
@@ -120,11 +114,7 @@ private:
 /// A tester for the vector_store_client, used for testing purposes.
 struct vector_store_client_tester {
     static void set_dns_refresh_interval(vector_store_client& vsc, std::chrono::milliseconds interval);
-    static void set_wait_for_client_timeout(vector_store_client& vsc, std::chrono::milliseconds timeout);
-    static void set_http_request_retries(vector_store_client& vsc, unsigned retries);
     static void set_dns_resolver(vector_store_client& vsc, std::function<future<std::optional<net::inet_address>>(sstring const&)> resolver);
-    static void trigger_dns_resolver(vector_store_client& vsc);
-    static auto resolve_hostname(vector_store_client& vsc, abort_source& as) -> future<std::optional<net::inet_address>>;
 };
 
 } // namespace service


### PR DESCRIPTION
vector_store_client: Refactor high availability and DNS logic

Extract the high availability and DNS resolution logic from
`vector_store_client` into dedicated classes. This is a preparatory
refactoring for supporting multiple vector store endpoints.

Key changes include:
- High availability logic is now encapsulated in a new `high_availability`
    class.
- DNS refresh logic is simplified and moved to a new `dns` class,
    eliminating the background refresh task.
- Internal APIs used only for testing have been removed from the
    `vector_store_client`.

References: VECTOR-187

No backport needed as this is a refactoring.