### PR TITLE
gossiper: eliminate duplicate code in do_shadow_round

### DIFF
--- a/gms/gossiper.cc
+++ b/gms/gossiper.cc
@@ -2204,19 +2204,6 @@ future<> gossiper::do_shadow_round(std::unordered_set<gms::inet_address> nodes, 
         sleep_abortable(std::chrono::seconds(1), _abort_source).get();
         logger.info("Connect nodes={} again ... ({} seconds passed)",
                 nodes, std::chrono::duration_cast<std::chrono::seconds>(clk::now() - start_time).count());
-        if (!nodes_talked.empty()) {
-            break;
-        }
-        if (nodes_down == nodes.size() && !is_mandatory) {
-            logger.warn("All nodes={} are down for get_endpoint_states verb. Skip ShadowRound.", nodes);
-            break;
-        }
-        if (clk::now() > start_time + std::chrono::milliseconds(_gcfg.shadow_round_ms)) {
-            throw std::runtime_error(fmt::format("Unable to gossip with any nodes={} (ShadowRound).", nodes));
-        }
-        sleep_abortable(std::chrono::seconds(1), _abort_source).get();
-        logger.info("Connect nodes={} again ... ({} seconds passed)",
-                nodes, std::chrono::duration_cast<std::chrono::seconds>(clk::now() - start_time).count());
     }
     logger.info("Gossip shadow round finished with nodes_talked={}", nodes_talked);
 }


### PR DESCRIPTION
Remove a redundant code block inadvertently introduced in commit 4b3d160f34c9f16d59868b9bb21d06bbd364c874. While the duplicate did not affect functionality, its presence could cause confusion and maintenance issues.

This change does not alter behavior and is purely a cleanup.

Fixes: scylladb/scylladb#25999

Backport: Not required as it's a code cleanup.