### PR TITLE
topology_coordinator: consistently rethrow `raft::request_aborted` for direct/global commands

### DIFF
--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -2719,6 +2719,8 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
                     node.guard = co_await exec_global_command(std::move(node.guard),raft_topology_cmd::command::barrier_and_drain, get_excluded_nodes(node), drop_guard_and_retake::yes);
                 } catch (term_changed_error&) {
                     throw;
+                } catch (raft::request_aborted&) {
+                    throw;
                 } catch(...) {
                     rtlogger.warn("failed to run barrier_and_drain during rollback of {} after {} failure: {}",
                             node.id, state, std::current_exception());
@@ -2797,6 +2799,8 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
                                     exclude_nodes);
                             }
                         } catch (term_changed_error&) {
+                            throw;
+                        } catch (raft::request_aborted&) {
                             throw;
                         } catch(...) {
                             wait_for_ip_error = std::current_exception();


### PR DESCRIPTION
Ensure all direct and global topology commands rethrow the `raft::request_aborted` exception when aborted, typically due to leadership changes. This makes abortion explicit to callers, enabling proper handling such as retries or workflow termination.

This change completes the work started in PR scylladb/scylladb#23962, covering all remaining cases where the exception was not rethrown.

Fixes: scylladb/scylladb#23589

No backport: No related issues observed in previous versions; backport not required.