### PR TITLE
load_balancer: include dead nodes when calculating rack load

### DIFF
--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -2126,12 +2126,12 @@ public:
 
             for (auto&& r : tmap.get_tablet_info(tablet.tablet).replicas) {
                 viable_targets.erase(r.host);
-                auto i = nodes.find(r.host);
-                if (i != nodes.end()) {
-                    auto& node = i->second;
-                    if (node.dc() == src_info.dc()) {
-                        rack_load[node.rack()] += 1;
-                    }
+                auto* node = _tm->get_topology().find_node(r.host);
+                if (!node) {
+                    on_internal_error(lblogger, format("Node {} not found in topology", r.host));
+                }
+                if (node->dc() == src_info.dc()) {
+                    rack_load[node->rack()] += 1;
                 }
             }
 


### PR DESCRIPTION
Load balancer aims to preserve a balance in rack loads when generating tablet migrations. However, this balance might get broken when dead nodes are present. Currently, these nodes aren't include in rack load calculations, even if they own tablet replicas. As a result, load balancer treats racks with dead nodes as racks with a lower load, so I generates migrations to these racks.
This is incorrect, because a dead node might come back alive, which would result in having multiple tablet replicas on the same rack. It's also inefficient even if we know that the node won't come back - when it's being replaced or removed. In that case we know we are going to rebuild the lost tablet replicas so migrating tablets to this rack just doubles the work. Allowing such migrations to happen would also require adjustments in the materialized view pairing code because we'd temporarily allow having multiple tablet replicas on the same rack. So in this patch we include dead nodes when calculating rack loads in the load balancer. The dead nodes still aren't treated as potential migration sources or destinations.
We also add a test which verifies that no migrations are performed by doing a node replace with a mv workload in parallel. Before the patch, we'd get pairing errors and after the patch, no pairing errors are detected.

Fixes https://github.com/scylladb/scylladb/issues/24485
