### PR TITLE
vector_store_client: Rename setting vector_store_uri to vector_store_primary_uri

### DIFF
--- a/conf/scylla.yaml
+++ b/conf/scylla.yaml
@@ -888,9 +888,9 @@ rf_rack_valid_keyspaces: false
 #
 # Vector Store options
 #
-# Uri for the vector store using dns name. Only http schema is supported. Port number is mandatory.
+# A comma-separated list of URIs for the vector store using DNS name. Only HTTP schema is supported. Port number is mandatory.
 # Default is empty, which means that the vector store is not used.
-# vector_store_uri: http://vector-store.dns.name:{port}
+# vector_store_primary_uri: http://vector-store.dns.name:{port}
 
 # 
 # io-streaming rate limiting

--- a/db/config.cc
+++ b/db/config.cc
@@ -1395,7 +1395,7 @@ db::config::config(std::shared_ptr<db::extensions> exts)
     , alternator_allow_system_table_write(this, "alternator_allow_system_table_write", liveness::LiveUpdate, value_status::Used,
         false,
         "Allow writing to system tables using the .scylla.alternator.system prefix")
-    , vector_store_uri(this, "vector_store_uri", liveness::LiveUpdate, value_status::Used, "", "The URI of the vector store to use for vector search. If not set, vector search is disabled.")
+    , vector_store_primary_uri(this, "vector_store_primary_uri", liveness::LiveUpdate, value_status::Used, "", "A comma-separated list of vector store node URIs. If not set, vector search is disabled.")
     , abort_on_ebadf(this, "abort_on_ebadf", value_status::Used, true, "Abort the server on incorrect file descriptor access. Throws exception when disabled.")
     , sanitizer_report_backtrace(this, "sanitizer_report_backtrace", value_status::Used, false,
             "In debug mode, report log-structured allocator sanitizer violations with a backtrace. Slow.")

--- a/db/config.hh
+++ b/db/config.hh
@@ -484,7 +484,7 @@ public:
     named_value<uint32_t> alternator_max_items_in_batch_write;
     named_value<bool> alternator_allow_system_table_write;
 
-    named_value<sstring> vector_store_uri;
+    named_value<sstring> vector_store_primary_uri;
 
     named_value<bool> abort_on_ebadf;
 


### PR DESCRIPTION
vector_store_client: Rename vector_store_uri to vector_store_primary_uri

The configuration setting vector_store_uri is renamed to
vector_store_primary_uri according to the final design.
In the future, the vector_store_secondary_uri setting will
be introduced.

This setting now also accepts a comma-separated list of URIs to prepare
for future support for redundancy and load balancing. Currently, only the
first URI in the list is used.

This change must be included before the next release.
Otherwise, users will be affected by a breaking change.

References: VECTOR-187

No backport is needed as this is a new feature.