### PR TITLE
tablets: scheduler: Run plan-maker in maintenance scheduling group

### DIFF
--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -25,6 +25,7 @@
 #include <utility>
 #include <fmt/ranges.h>
 #include <seastar/coroutine/maybe_yield.hh>
+#include <seastar/coroutine/switch_to.hh>
 #include <absl/container/flat_hash_map.h>
 
 using namespace locator;
@@ -3178,6 +3179,7 @@ public:
 
     future<migration_plan> balance_tablets(token_metadata_ptr tm, locator::load_stats_ptr table_load_stats, std::unordered_set<host_id> skiplist) {
         auto lb = make_load_balancer(tm, table_load_stats ? table_load_stats : _load_stats, std::move(skiplist));
+        co_await coroutine::switch_to(_db.get_streaming_scheduling_group());
         co_return co_await lb.make_plan();
     }
 


### PR DESCRIPTION
Currently, it runs in the gossiper scheduling group, because it's invoked by the topology coordinator. That scheduling group has the same amount of shares as user workload. Plan-making can take significant amount of time during rebalancing, and we don't want that to impact user workload which happens to run on the same shard.

Reduce impact by running in the maintenance scheduling group.

Fixes #26037

Backport because it may cause significant performance problems during scale-out.