### PR TITLE
test: deflake driver reconnections in the recovery procedure tests

### DIFF
--- a/test/cluster/test_raft_recovery_during_join.py
+++ b/test/cluster/test_raft_recovery_during_join.py
@@ -99,6 +99,9 @@ async def test_raft_recovery_during_join(manager: ManagerClient):
     logging.info(f'Restarting {live_servers}')
     await manager.rolling_restart(live_servers)
 
+    await reconnect_driver(manager)
+    cql, _ = await manager.get_ready_cql(live_servers)
+
     logging.info(f'Deleting the persistent discovery state and group 0 ID on {live_servers}')
     for h in hosts:
         await delete_discovery_state_and_group0_id(cql, h)

--- a/test/cluster/test_raft_recovery_entry_loss.py
+++ b/test/cluster/test_raft_recovery_entry_loss.py
@@ -100,6 +100,9 @@ async def test_raft_recovery_entry_lose(manager: ManagerClient):
     logging.info(f'Restarting {live_servers}')
     await manager.rolling_restart(live_servers)
 
+    await reconnect_driver(manager)
+    cql, _ = await manager.get_ready_cql(live_servers)
+
     logging.info(f'Deleting the persistent discovery state and group 0 ID on {live_servers}')
     for h in hosts:
         await delete_discovery_state_and_group0_id(cql, h)


### PR DESCRIPTION
All three tests could hit
https://github.com/scylladb/python-driver/issues/295. We use the
standard workaround for this issue: reconnecting the driver after
the rolling restart, and before sending any requests to local tables
(that can fail if the driver closes a connection to the node that
restarted last).

All three tests perform two rolling restarts, but the latter ones
already have the workaround.

Fixes #26005

This PR improves CI stability and changes only tests, so it should be
backported to all branches containing these tests: 2025.2 and 2025.3.