### PR TITLE
dbuild: add e2fsprogs, fuse3 to the dependencies

### DIFF
--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -62,6 +62,8 @@ debian_base_packages=(
     curl
     jq
     git-lfs
+    e2fsprogs
+    fuse3
 )
 
 fedora_packages=(
@@ -129,6 +131,8 @@ fedora_packages=(
     wabt
     binaryen
     lcov
+    e2fsprogs
+    fuse3
 
     lld
     llvm-bolt


### PR DESCRIPTION
The packages contain filesystem utilities to create volumes such that sudo/unshare are not required.

No backport is required. The tests using volumes have been added recently.