### PR TITLE
code: Replace distributed<> with sharded<>

### DIFF
--- a/api/api.hh
+++ b/api/api.hh
@@ -73,7 +73,7 @@ inline std::vector<sstring> split(const sstring& text, const char* separator) {
  *
  */
 template<class T, class F, class V>
-future<json::json_return_type>  sum_stats(distributed<T>& d, V F::*f) {
+future<json::json_return_type>  sum_stats(sharded<T>& d, V F::*f) {
     return d.map_reduce0([f](const T& p) {return p.get_stats().*f;}, 0,
             std::plus<V>()).then([](V val) {
         return make_ready_future<json::json_return_type>(val);
@@ -106,7 +106,7 @@ httpd::utils_json::rate_moving_average_and_histogram timer_to_json(const utils::
 }
 
 template<class T, class F>
-future<json::json_return_type>  sum_histogram_stats(distributed<T>& d, utils::timed_rate_moving_average_and_histogram F::*f) {
+future<json::json_return_type>  sum_histogram_stats(sharded<T>& d, utils::timed_rate_moving_average_and_histogram F::*f) {
 
     return d.map_reduce0([f](const T& p) {return (p.get_stats().*f).hist;}, utils::ihistogram(),
             std::plus<utils::ihistogram>()).then([](const utils::ihistogram& val) {
@@ -115,7 +115,7 @@ future<json::json_return_type>  sum_histogram_stats(distributed<T>& d, utils::ti
 }
 
 template<class T, class F>
-future<json::json_return_type>  sum_timer_stats(distributed<T>& d, utils::timed_rate_moving_average_and_histogram F::*f) {
+future<json::json_return_type>  sum_timer_stats(sharded<T>& d, utils::timed_rate_moving_average_and_histogram F::*f) {
 
     return d.map_reduce0([f](const T& p) {return (p.get_stats().*f).rate();}, utils::rate_moving_average_and_histogram(),
             std::plus<utils::rate_moving_average_and_histogram>()).then([](const utils::rate_moving_average_and_histogram& val) {
@@ -124,7 +124,7 @@ future<json::json_return_type>  sum_timer_stats(distributed<T>& d, utils::timed_
 }
 
 template<class T, class F>
-future<json::json_return_type>  sum_timer_stats(distributed<T>& d, utils::timed_rate_moving_average_summary_and_histogram F::*f) {
+future<json::json_return_type>  sum_timer_stats(sharded<T>& d, utils::timed_rate_moving_average_summary_and_histogram F::*f) {
     return d.map_reduce0([f](const T& p) {return (p.get_stats().*f).rate();}, utils::rate_moving_average_and_histogram(),
             std::plus<utils::rate_moving_average_and_histogram>()).then([](const utils::rate_moving_average_and_histogram& val) {
         return make_ready_future<json::json_return_type>(timer_to_json(val));

--- a/api/api_init.hh
+++ b/api/api_init.hh
@@ -83,9 +83,9 @@ struct http_context {
     sstring api_dir;
     sstring api_doc;
     httpd::http_server_control http_server;
-    distributed<replica::database>& db;
+    sharded<replica::database>& db;
 
-    http_context(distributed<replica::database>& _db)
+    http_context(sharded<replica::database>& _db)
             : db(_db)
     {
     }

--- a/db/data_listeners.cc
+++ b/db/data_listeners.cc
@@ -111,7 +111,7 @@ toppartitions_data_listener::localize(const global_top_k::results& r) {
     return n;
 }
 
-toppartitions_query::toppartitions_query(distributed<replica::database>& xdb, std::unordered_set<std::tuple<sstring, sstring>, utils::tuple_hash>&& table_filters,
+toppartitions_query::toppartitions_query(sharded<replica::database>& xdb, std::unordered_set<std::tuple<sstring, sstring>, utils::tuple_hash>&& table_filters,
         std::unordered_set<sstring>&& keyspace_filters, std::chrono::milliseconds duration, size_t list_size, size_t capacity)
         : _xdb(xdb), _table_filters(std::move(table_filters)), _keyspace_filters(std::move(keyspace_filters)), _duration(duration), _list_size(list_size), _capacity(capacity),
           _query(std::make_unique<sharded<toppartitions_data_listener>>()) {

--- a/db/data_listeners.hh
+++ b/db/data_listeners.hh
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include <seastar/core/distributed.hh>
+#include <seastar/core/sharded.hh>
 #include <seastar/core/future.hh>  // IWYU pragma: keep
 #include <seastar/core/weak_ptr.hh>
 
@@ -138,7 +138,7 @@ public:
 };
 
 class toppartitions_query {
-    distributed<replica::database>& _xdb;
+    sharded<replica::database>& _xdb;
     std::unordered_set<std::tuple<sstring, sstring>, utils::tuple_hash> _table_filters;
     std::unordered_set<sstring> _keyspace_filters;
     std::chrono::milliseconds _duration;
@@ -147,7 +147,7 @@ class toppartitions_query {
     std::unique_ptr<sharded<toppartitions_data_listener>> _query;
 
 public:
-    toppartitions_query(seastar::distributed<replica::database>& xdb, std::unordered_set<std::tuple<sstring, sstring>, utils::tuple_hash>&& table_filters,
+    toppartitions_query(seastar::sharded<replica::database>& xdb, std::unordered_set<std::tuple<sstring, sstring>, utils::tuple_hash>&& table_filters,
         std::unordered_set<sstring>&& keyspace_filters, std::chrono::milliseconds duration, size_t list_size, size_t capacity);
 
     struct results {

--- a/db/hints/manager.cc
+++ b/db/hints/manager.cc
@@ -141,7 +141,7 @@ future<> directory_initializer::ensure_rebalanced() {
 }
 
 manager::manager(service::storage_proxy& proxy, sstring hints_directory, host_filter filter, int64_t max_hint_window_ms,
-        resource_manager& res_manager, distributed<replica::database>& db)
+        resource_manager& res_manager, sharded<replica::database>& db)
     : _hints_dir(fs::path(hints_directory) / fmt::to_string(this_shard_id()))
     , _host_filter(std::move(filter))
     , _proxy(proxy)

--- a/db/schema_applier.hh
+++ b/db/schema_applier.hh
@@ -22,14 +22,14 @@
 #include "replica/global_table_ptr.hh"
 #include "replica/tables_metadata_lock.hh"
 
-#include <seastar/core/distributed.hh>
+#include <seastar/core/sharded.hh>
 #include <unordered_map>
 
 namespace db {
 
 namespace schema_tables {
 
-future<> merge_schema(sharded<db::system_keyspace>& sys_ks, distributed<service::storage_proxy>& proxy, distributed<service::storage_service>& ss, gms::feature_service& feat, utils::chunked_vector<mutation> mutations, bool reload = false);
+future<> merge_schema(sharded<db::system_keyspace>& sys_ks, sharded<service::storage_proxy>& proxy, sharded<service::storage_service>& ss, gms::feature_service& feat, utils::chunked_vector<mutation> mutations, bool reload = false);
 
 enum class table_kind { table, view };
 
@@ -99,7 +99,7 @@ class in_progress_types_storage {
     std::vector<foreign_ptr<shared_ptr<in_progress_types_storage_per_shard>>> shards;
 public:
     in_progress_types_storage() : shards(smp::count) {}
-    future<> init(distributed<replica::database>& sharded_db, const affected_keyspaces& affected_keyspaces, const affected_user_types& affected_types);
+    future<> init(sharded<replica::database>& sharded_db, const affected_keyspaces& affected_keyspaces, const affected_user_types& affected_types);
     in_progress_types_storage_per_shard& local();
 };
 

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -23,7 +23,7 @@
 #include "mutation_query.hh"
 #include "system_keyspace_view_types.hh"
 #include "sstables/sstables_registry.hh"
-#include <seastar/core/distributed.hh>
+#include <seastar/core/sharded.hh>
 #include "cdc/generation_id.hh"
 #include "cdc/generation.hh"
 #include "locator/host_id.hh"
@@ -363,16 +363,16 @@ public:
     /// overloads
 
     future<foreign_ptr<lw_shared_ptr<reconcilable_result>>>
-    static query_mutations(distributed<replica::database>& db,
+    static query_mutations(sharded<replica::database>& db,
                     schema_ptr schema);
 
     future<foreign_ptr<lw_shared_ptr<reconcilable_result>>>
-    static query_mutations(distributed<replica::database>& db,
+    static query_mutations(sharded<replica::database>& db,
                     const sstring& ks_name,
                     const sstring& cf_name);
 
     future<foreign_ptr<lw_shared_ptr<reconcilable_result>>>
-    static query_mutations(distributed<replica::database>& db,
+    static query_mutations(sharded<replica::database>& db,
                     const sstring& ks_name,
                     const sstring& cf_name,
                     const dht::partition_range& partition_range,
@@ -380,14 +380,14 @@ public:
 
     // Returns all data from given system table.
     // Intended to be used by code which is not performance critical.
-    static future<lw_shared_ptr<query::result_set>> query(distributed<replica::database>& db,
+    static future<lw_shared_ptr<query::result_set>> query(sharded<replica::database>& db,
                     const sstring& ks_name,
                     const sstring& cf_name);
 
     // Returns a slice of given system table.
     // Intended to be used by code which is not performance critical.
     static future<lw_shared_ptr<query::result_set>> query(
-        distributed<replica::database>& db,
+        sharded<replica::database>& db,
         const sstring& ks_name,
         const sstring& cf_name,
         const dht::decorated_key& key,
@@ -648,7 +648,7 @@ public:
 
     // Obtain the contents of the group 0 history table in mutation form.
     // Assumes that the history table exists, i.e. Raft feature is enabled.
-    static future<mutation> get_group0_history(distributed<replica::database>&);
+    static future<mutation> get_group0_history(sharded<replica::database>&);
 
     // If the `group0_schema_version` key in `system.scylla_local` is present (either live or tombstone),
     // returns the corresponding mutation. Otherwise returns nullopt.

--- a/db/virtual_tables.cc
+++ b/db/virtual_tables.cc
@@ -54,11 +54,11 @@ logging::logger vtlog("virtual_tables");
 
 class cluster_status_table : public memtable_filling_virtual_table {
 private:
-    distributed<service::storage_service>& _dist_ss;
-    distributed<gms::gossiper>& _dist_gossiper;
+    sharded<service::storage_service>& _dist_ss;
+    sharded<gms::gossiper>& _dist_gossiper;
 
 public:
-    cluster_status_table(distributed<service::storage_service>& ss, distributed<gms::gossiper>& g)
+    cluster_status_table(sharded<service::storage_service>& ss, sharded<gms::gossiper>& g)
             : memtable_filling_virtual_table(build_schema())
             , _dist_ss(ss), _dist_gossiper(g) {}
 
@@ -234,9 +234,9 @@ public:
 };
 
 class snapshots_table : public streaming_virtual_table {
-    distributed<replica::database>& _db;
+    sharded<replica::database>& _db;
 public:
-    explicit snapshots_table(distributed<replica::database>& db)
+    explicit snapshots_table(sharded<replica::database>& db)
             : streaming_virtual_table(build_schema())
             , _db(db)
     {
@@ -373,7 +373,7 @@ public:
 
 class runtime_info_table : public memtable_filling_virtual_table {
 private:
-    distributed<replica::database>& _db;
+    sharded<replica::database>& _db;
     service::storage_service& _ss;
     std::optional<dht::decorated_key> _generic_key;
 
@@ -456,7 +456,7 @@ private:
     }
 
 public:
-    explicit runtime_info_table(distributed<replica::database>& db, service::storage_service& ss)
+    explicit runtime_info_table(sharded<replica::database>& db, service::storage_service& ss)
         : memtable_filling_virtual_table(build_schema())
         , _db(db)
         , _ss(ss) {
@@ -1320,8 +1320,8 @@ private:
 }
 
 future<> initialize_virtual_tables(
-        distributed<replica::database>& dist_db, distributed<service::storage_service>& dist_ss,
-        sharded<gms::gossiper>& dist_gossiper, distributed<service::raft_group_registry>& dist_raft_gr,
+        sharded<replica::database>& dist_db, sharded<service::storage_service>& dist_ss,
+        sharded<gms::gossiper>& dist_gossiper, sharded<service::raft_group_registry>& dist_raft_gr,
         sharded<db::system_keyspace>& sys_ks,
         sharded<service::tablet_allocator>& tablet_allocator,
         sharded<netw::messaging_service>& ms,

--- a/db/virtual_tables.hh
+++ b/db/virtual_tables.hh
@@ -9,7 +9,7 @@
 
 #pragma once
 
-#include <seastar/core/distributed.hh>
+#include <seastar/core/sharded.hh>
 #include <map>
 #include "schema/schema_fwd.hh"
 
@@ -37,8 +37,8 @@ class config;
 class system_keyspace;
 
 future<> initialize_virtual_tables(
-    distributed<replica::database>&,
-    distributed<service::storage_service>&,
+    sharded<replica::database>&,
+    sharded<service::storage_service>&,
     sharded<gms::gossiper>&,
     sharded<service::raft_group_registry>&,
     sharded<db::system_keyspace>&,

--- a/dht/boot_strapper.hh
+++ b/dht/boot_strapper.hh
@@ -15,7 +15,7 @@
 #include "replica/database_fwd.hh"
 #include "streaming/stream_reason.hh"
 #include "service/topology_guard.hh"
-#include <seastar/core/distributed.hh>
+#include <seastar/core/sharded.hh>
 #include <seastar/core/abort_source.hh>
 
 namespace streaming { class stream_manager; }
@@ -31,7 +31,7 @@ class boot_strapper {
     using token_metadata = locator::token_metadata;
     using token_metadata_ptr = locator::token_metadata_ptr;
     using token = dht::token;
-    distributed<replica::database>& _db;
+    sharded<replica::database>& _db;
     sharded<streaming::stream_manager>& _stream_manager;
     abort_source& _abort_source;
     /* endpoint that needs to be bootstrapped */
@@ -42,7 +42,7 @@ class boot_strapper {
     std::unordered_set<token> _tokens;
     const locator::token_metadata_ptr _token_metadata_ptr;
 public:
-    boot_strapper(distributed<replica::database>& db, sharded<streaming::stream_manager>& sm, abort_source& abort_source,
+    boot_strapper(sharded<replica::database>& db, sharded<streaming::stream_manager>& sm, abort_source& abort_source,
             locator::host_id addr, locator::endpoint_dc_rack dr, std::unordered_set<token> tokens, const token_metadata_ptr tmptr)
         : _db(db)
         , _stream_manager(sm)

--- a/dht/range_streamer.hh
+++ b/dht/range_streamer.hh
@@ -16,7 +16,7 @@
 #include "streaming/stream_reason.hh"
 #include "service/topology_guard.hh"
 #include "gms/inet_address.hh"
-#include <seastar/core/distributed.hh>
+#include <seastar/core/sharded.hh>
 #include <seastar/core/abort_source.hh>
 #include <unordered_map>
 #include <memory>
@@ -76,7 +76,7 @@ public:
         }
     };
 
-    range_streamer(distributed<replica::database>& db, sharded<streaming::stream_manager>& sm, const token_metadata_ptr tmptr, abort_source& abort_source, std::unordered_set<token> tokens,
+    range_streamer(sharded<replica::database>& db, sharded<streaming::stream_manager>& sm, const token_metadata_ptr tmptr, abort_source& abort_source, std::unordered_set<token> tokens,
             locator::host_id address, locator::endpoint_dc_rack dr, sstring description, streaming::stream_reason reason,
             service::frozen_topology_guard topo_guard,
             std::vector<sstring> tables = {})
@@ -95,7 +95,7 @@ public:
         _abort_source.check();
     }
 
-    range_streamer(distributed<replica::database>& db, sharded<streaming::stream_manager>& sm, const token_metadata_ptr tmptr, abort_source& abort_source,
+    range_streamer(sharded<replica::database>& db, sharded<streaming::stream_manager>& sm, const token_metadata_ptr tmptr, abort_source& abort_source,
             locator::host_id address, locator::endpoint_dc_rack dr, sstring description, streaming::stream_reason reason, service::frozen_topology_guard topo_guard, std::vector<sstring> tables = {})
         : range_streamer(db, sm, std::move(tmptr), abort_source, std::unordered_set<token>(), address, std::move(dr), description, reason, std::move(topo_guard), std::move(tables)) {
     }
@@ -151,7 +151,7 @@ public:
     future<> stream_async();
     size_t nr_ranges_to_stream();
 private:
-    distributed<replica::database>& _db;
+    sharded<replica::database>& _db;
     sharded<streaming::stream_manager>& _stream_manager;
     token_metadata_ptr _token_metadata_ptr;
     abort_source& _abort_source;

--- a/ent/encryption/encryption.cc
+++ b/ent/encryption/encryption.cc
@@ -437,16 +437,16 @@ public:
         }
         return *t;
     }
-    distributed<cql3::query_processor>& get_query_processor() const override {
+    sharded<cql3::query_processor>& get_query_processor() const override {
         return check_service_object(_qp);
     }
-    distributed<service::storage_service>& get_storage_service() const override {
+    sharded<service::storage_service>& get_storage_service() const override {
         return check_service_object(_ss);
     }
-    distributed<replica::database>& get_database() const override {
+    sharded<replica::database>& get_database() const override {
         return check_service_object(_db);
     }
-    distributed<service::migration_manager>& get_migration_manager() const override {
+    sharded<service::migration_manager>& get_migration_manager() const override {
         return check_service_object(_mm);
     }
 

--- a/ent/encryption/encryption.hh
+++ b/ent/encryption/encryption.hh
@@ -14,7 +14,7 @@
 #include <seastar/core/future.hh>
 #include <seastar/core/sstring.hh>
 #include <seastar/core/shared_ptr.hh>
-#include <seastar/core/distributed.hh>
+#include <seastar/core/sharded.hh>
 
 #include <fmt/core.h>
 #include <fmt/ostream.h>
@@ -177,10 +177,10 @@ public:
     virtual const encryption_config& config() const = 0;
     virtual shared_ptr<symmetric_key> get_config_encryption_key() const = 0;
 
-    virtual distributed<cql3::query_processor>& get_query_processor() const = 0;
-    virtual distributed<service::storage_service>& get_storage_service() const = 0;
-    virtual distributed<replica::database>& get_database() const = 0;
-    virtual distributed<service::migration_manager>& get_migration_manager() const = 0;
+    virtual sharded<cql3::query_processor>& get_query_processor() const = 0;
+    virtual sharded<service::storage_service>& get_storage_service() const = 0;
+    virtual sharded<replica::database>& get_database() const = 0;
+    virtual sharded<service::migration_manager>& get_migration_manager() const = 0;
 
     sstring maybe_decrypt_config_value(const sstring&) const;
 

--- a/init.hh
+++ b/init.hh
@@ -11,7 +11,7 @@
 
 #include <seastar/core/sstring.hh>
 #include <seastar/core/future.hh>
-#include <seastar/core/distributed.hh>
+#include <seastar/core/sharded.hh>
 #include <seastar/core/abort_source.hh>
 #include "utils/log.hh"
 #include "utils/s3/creds.hh"

--- a/locator/snitch_base.hh
+++ b/locator/snitch_base.hh
@@ -18,7 +18,7 @@
 #include "locator/types.hh"
 #include "gms/inet_address.hh"
 #include <seastar/core/thread.hh>
-#include <seastar/core/distributed.hh>
+#include <seastar/core/sharded.hh>
 #include "utils/log.hh"
 
 namespace gms {
@@ -215,7 +215,7 @@ private:
  * @return ready future when the transition is complete
  *
  * The flow goes as follows:
- *  1) Create a new distributed<snitch_ptr> and initialize it with the new
+ *  1) Create a new sharded<snitch_ptr> and initialize it with the new
  *     snitch.
  *  2) Start the new snitches above - this will initialize the snitches objects
  *     and will make them ready to be used.
@@ -223,15 +223,15 @@ private:
  *  4) Pause the per-shard snitch objects from (1) - this will stop the async
  *     I/O parts of the snitches if any.
  *  5) Assign the per-shard snitch_ptr's from new distributed from (1) to the
- *     global one and update the distributed<> pointer in the new snitch
+ *     global one and update the sharded<> pointer in the new snitch
  *     instances.
  *  6) Start the new snitches.
- *  7) Stop() the temporary distributed<snitch_ptr> from (1).
+ *  7) Stop() the temporary sharded<snitch_ptr> from (1).
  */
 inline future<> i_endpoint_snitch::reset_snitch(sharded<snitch_ptr>& snitch, snitch_config cfg) {
     return seastar::async([cfg = std::move(cfg), &snitch] {
         // (1) create a new snitch
-        distributed<snitch_ptr> tmp_snitch;
+        sharded<snitch_ptr> tmp_snitch;
         try {
             tmp_snitch.start(cfg).get();
 

--- a/main.cc
+++ b/main.cc
@@ -31,7 +31,7 @@
 #include "replica/database.hh"
 #include <seastar/core/reactor.hh>
 #include <seastar/core/app-template.hh>
-#include <seastar/core/distributed.hh>
+#include <seastar/core/sharded.hh>
 #include "transport/server.hh"
 #include <seastar/http/httpd.hh>
 #include "api/api_init.hh"
@@ -724,7 +724,7 @@ sharded<locator::shared_token_metadata> token_metadata;
     std::optional<utils::disk_space_monitor> disk_space_monitor_shard0;
     sharded<compaction_manager> cm;
     sharded<sstables::storage_manager> sstm;
-    distributed<replica::database> db;
+    sharded<replica::database> db;
     seastar::sharded<service::cache_hitrate_calculator> cf_cache_hitrate_calculator;
     service::load_meter load_meter;
     sharded<service::storage_proxy> proxy;
@@ -1680,7 +1680,7 @@ sharded<locator::shared_token_metadata> token_metadata;
 
             checkpoint(stop_signal, "starting tablet allocator");
             service::tablet_allocator::config tacfg;
-            distributed<service::tablet_allocator> tablet_allocator;
+            sharded<service::tablet_allocator> tablet_allocator;
             tablet_allocator.start(tacfg, std::ref(mm_notifier), std::ref(db)).get();
             auto stop_tablet_allocator = defer_verbose_shutdown("tablet allocator", [&tablet_allocator] {
                 tablet_allocator.stop().get();

--- a/message/messaging_service.cc
+++ b/message/messaging_service.cc
@@ -18,7 +18,7 @@
 #include <seastar/coroutine/all.hh>
 
 #include "message/messaging_service.hh"
-#include <seastar/core/distributed.hh>
+#include <seastar/core/sharded.hh>
 #include "gms/gossiper.hh"
 #include "service/storage_service.hh"
 #include "service/qos/service_level_controller.hh"

--- a/multishard_mutation_query.cc
+++ b/multishard_mutation_query.cc
@@ -178,7 +178,7 @@ class read_context : public reader_lifecycle_policy {
         }
     };
 
-    distributed<replica::database>& _db;
+    sharded<replica::database>& _db;
     schema_ptr _schema;
     locator::effective_replication_map_ptr _erm;
     reader_permit _permit;
@@ -199,7 +199,7 @@ class read_context : public reader_lifecycle_policy {
     friend fmt::formatter<dismantle_buffer_stats>;
 
 public:
-    read_context(distributed<replica::database>& db, schema_ptr s, locator::effective_replication_map_ptr erm,
+    read_context(sharded<replica::database>& db, schema_ptr s, locator::effective_replication_map_ptr erm,
                  const query::read_command& cmd, const dht::partition_range_vector& ranges,
                  tracing::trace_state_ptr trace_state, db::timeout_clock::time_point timeout)
             : _db(db)
@@ -228,7 +228,7 @@ public:
     read_context& operator=(read_context&&) = delete;
     read_context& operator=(const read_context&) = delete;
 
-    distributed<replica::database>& db() {
+    sharded<replica::database>& db() {
         return _db;
     }
 
@@ -755,7 +755,7 @@ future<page_consume_result<ResultBuilder>> read_page(
 
 template <typename ResultBuilder>
 future<foreign_ptr<lw_shared_ptr<typename ResultBuilder::result_type>>> do_query_vnodes(
-        distributed<replica::database>& db,
+        sharded<replica::database>& db,
         schema_ptr s,
         const query::read_command& cmd,
         const dht::partition_range_vector& ranges,
@@ -786,7 +786,7 @@ future<foreign_ptr<lw_shared_ptr<typename ResultBuilder::result_type>>> do_query
 
 template <typename ResultBuilder>
 future<foreign_ptr<lw_shared_ptr<typename ResultBuilder::result_type>>> do_query_tablets(
-        distributed<replica::database>& db,
+        sharded<replica::database>& db,
         schema_ptr s,
         const query::read_command& cmd,
         const dht::partition_range_vector& ranges,
@@ -824,7 +824,7 @@ future<foreign_ptr<lw_shared_ptr<typename ResultBuilder::result_type>>> do_query
 
 template <typename ResultBuilder>
 static future<std::tuple<foreign_ptr<lw_shared_ptr<typename ResultBuilder::result_type>>, cache_temperature>> do_query_on_all_shards(
-        distributed<replica::database>& db,
+        sharded<replica::database>& db,
         schema_ptr s,
         const query::read_command& cmd,
         const dht::partition_range_vector& ranges,
@@ -982,7 +982,7 @@ public:
 } // anonymous namespace
 
 future<std::tuple<foreign_ptr<lw_shared_ptr<reconcilable_result>>, cache_temperature>> query_mutations_on_all_shards(
-        distributed<replica::database>& db,
+        sharded<replica::database>& db,
         schema_ptr query_schema,
         const query::read_command& cmd,
         const dht::partition_range_vector& ranges,
@@ -995,7 +995,7 @@ future<std::tuple<foreign_ptr<lw_shared_ptr<reconcilable_result>>, cache_tempera
 }
 
 future<std::tuple<foreign_ptr<lw_shared_ptr<query::result>>, cache_temperature>> query_data_on_all_shards(
-        distributed<replica::database>& db,
+        sharded<replica::database>& db,
         schema_ptr query_schema,
         const query::read_command& cmd,
         const dht::partition_range_vector& ranges,

--- a/multishard_mutation_query.hh
+++ b/multishard_mutation_query.hh
@@ -14,7 +14,7 @@
 #include "db/timeout_clock.hh"
 #include "dht/i_partitioner_fwd.hh"
 
-#include <seastar/core/distributed.hh>
+#include <seastar/core/sharded.hh>
 
 #include "seastarx.hh"
 
@@ -66,7 +66,7 @@ namespace tracing {
 /// \see multishard_combined_reader
 /// \see querier_cache
 future<std::tuple<foreign_ptr<lw_shared_ptr<reconcilable_result>>, cache_temperature>> query_mutations_on_all_shards(
-        distributed<replica::database>& db,
+        sharded<replica::database>& db,
         schema_ptr s,
         const query::read_command& cmd,
         const dht::partition_range_vector& ranges,
@@ -78,7 +78,7 @@ future<std::tuple<foreign_ptr<lw_shared_ptr<reconcilable_result>>, cache_tempera
 /// Identical to `query_mutations_on_all_shards()` except that it builds results
 /// in the `query::result` format instead of in the `reconcilable_result` one.
 future<std::tuple<foreign_ptr<lw_shared_ptr<query::result>>, cache_temperature>> query_data_on_all_shards(
-        distributed<replica::database>& db,
+        sharded<replica::database>& db,
         schema_ptr s,
         const query::read_command& cmd,
         const dht::partition_range_vector& ranges,

--- a/query/query_result_merger.hh
+++ b/query/query_result_merger.hh
@@ -8,13 +8,13 @@
 
 #pragma once
 
-#include <seastar/core/distributed.hh>
+#include <seastar/core/sharded.hh>
 #include "query-result.hh"
 
 namespace query {
 
 // Merges non-overlapping results into one
-// Implements @Reducer concept from distributed.hh
+// Implements @Reducer concept from sharded.hh
 class result_merger {
     std::vector<foreign_ptr<lw_shared_ptr<query::result>>> _partial;
     const uint64_t _max_rows;

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -3522,7 +3522,7 @@ public:
 };
 
 repair_service::repair_service(sharded<service::topology_state_machine>& tsm,
-        distributed<gms::gossiper>& gossiper,
+        sharded<gms::gossiper>& gossiper,
         netw::messaging_service& ms,
         sharded<replica::database>& db,
         sharded<service::storage_proxy>& sp,

--- a/repair/row_level.hh
+++ b/repair/row_level.hh
@@ -16,7 +16,7 @@
 #include "service/topology_guard.hh"
 #include "tasks/task_manager.hh"
 #include "locator/abstract_replication_strategy.hh"
-#include <seastar/core/distributed.hh>
+#include <seastar/core/sharded.hh>
 #include <seastar/util/bool_class.hh>
 #include <seastar/core/rwlock.hh>
 #include "utils/user_provided_param.hh"
@@ -101,7 +101,7 @@ using host2ip_t = std::function<future<gms::inet_address> (locator::host_id)>;
 
 class repair_service : public seastar::peering_sharded_service<repair_service> {
     sharded<service::topology_state_machine>& _tsm;
-    distributed<gms::gossiper>& _gossiper;
+    sharded<gms::gossiper>& _gossiper;
     netw::messaging_service& _messaging;
     sharded<replica::database>& _db;
     sharded<service::storage_proxy>& _sp;
@@ -158,7 +158,7 @@ public:
 
 public:
     repair_service(sharded<service::topology_state_machine>& tsm,
-            distributed<gms::gossiper>& gossiper,
+            sharded<gms::gossiper>& gossiper,
             netw::messaging_service& ms,
             sharded<replica::database>& db,
             sharded<service::storage_proxy>& sp,

--- a/replica/distributed_loader.hh
+++ b/replica/distributed_loader.hh
@@ -10,7 +10,7 @@
 
 
 #include <seastar/core/future.hh>
-#include <seastar/core/distributed.hh>
+#include <seastar/core/sharded.hh>
 #include <seastar/core/sstring.hh>
 #include <vector>
 #include <functional>
@@ -76,24 +76,24 @@ class distributed_loader {
     static future<size_t> make_sstables_available(sstables::sstable_directory& dir,
             sharded<replica::database>& db, sharded<db::view::view_builder>& vb, sharded<db::view::view_building_worker>& vbw,
             db::view::sstable_destination_decision needs_view_update, sstring ks, sstring cf);
-    static future<> populate_keyspace(distributed<replica::database>& db, sharded<db::system_keyspace>& sys_ks, keyspace& ks, sstring ks_name);
+    static future<> populate_keyspace(sharded<replica::database>& db, sharded<db::system_keyspace>& sys_ks, keyspace& ks, sstring ks_name);
     static future<std::tuple<table_id, std::vector<std::vector<sstables::shared_sstable>>>>
-        get_sstables_from(distributed<replica::database>& db, sstring ks, sstring cf, sstables::sstable_open_config cfg,
+        get_sstables_from(sharded<replica::database>& db, sstring ks, sstring cf, sstables::sstable_open_config cfg,
         noncopyable_function<future<>(global_table_ptr&, sharded<sstables::sstable_directory>&)> start_dir);
 
 public:
-    static future<> init_system_keyspace(sharded<db::system_keyspace>&, distributed<locator::effective_replication_map_factory>&, distributed<replica::database>&);
-    static future<> init_non_system_keyspaces(distributed<replica::database>& db, distributed<service::storage_proxy>& proxy, sharded<db::system_keyspace>& sys_ks);
+    static future<> init_system_keyspace(sharded<db::system_keyspace>&, sharded<locator::effective_replication_map_factory>&, sharded<replica::database>&);
+    static future<> init_non_system_keyspaces(sharded<replica::database>& db, sharded<service::storage_proxy>& proxy, sharded<db::system_keyspace>& sys_ks);
 
     // Scan sstables under upload directory. Return a vector with smp::count entries.
     // Each entry with index of idx should be accessed on shard idx only.
     // Each entry contains a vector of sstables for this shard.
     // The table UUID is returned too.
     static future<std::tuple<table_id, std::vector<std::vector<sstables::shared_sstable>>>>
-            get_sstables_from_upload_dir(distributed<replica::database>& db, sstring ks, sstring cf, sstables::sstable_open_config cfg);
+            get_sstables_from_upload_dir(sharded<replica::database>& db, sstring ks, sstring cf, sstables::sstable_open_config cfg);
     static future<std::tuple<table_id, std::vector<std::vector<sstables::shared_sstable>>>>
-            get_sstables_from_object_store(distributed<replica::database>& db, sstring ks, sstring cf, std::vector<sstring> sstables, sstring endpoint, sstring bucket, sstring prefix, sstables::sstable_open_config cfg, std::function<seastar::abort_source*()> = {});
-    static future<> process_upload_dir(distributed<replica::database>& db, sharded<db::view::view_builder>& vb, sharded<db::view::view_building_worker>& vbw, sstring ks_name, sstring cf_name, bool skip_cleanup, bool skip_reshape);
+            get_sstables_from_object_store(sharded<replica::database>& db, sstring ks, sstring cf, std::vector<sstring> sstables, sstring endpoint, sstring bucket, sstring prefix, sstables::sstable_open_config cfg, std::function<seastar::abort_source*()> = {});
+    static future<> process_upload_dir(sharded<replica::database>& db, sharded<db::view::view_builder>& vb, sharded<db::view::view_building_worker>& vbw, sstring ks_name, sstring cf_name, bool skip_cleanup, bool skip_reshape);
 };
 
 }

--- a/replica/mutation_dump.cc
+++ b/replica/mutation_dump.cc
@@ -404,7 +404,7 @@ future<mutation_reader> make_partition_mutation_dump_reader(
         schema_ptr output_schema,
         schema_ptr underlying_schema,
         reader_permit permit,
-        distributed<replica::database>& db,
+        sharded<replica::database>& db,
         const dht::decorated_key& dk,
         const query::partition_slice& ps,
         tracing::trace_state_ptr ts,
@@ -446,7 +446,7 @@ future<mutation_reader> make_partition_mutation_dump_reader(
 }
 
 class multi_range_partition_generator {
-    distributed<replica::database>& _db;
+    sharded<replica::database>& _db;
     schema_ptr _schema;
     circular_buffer<dht::partition_range> _prs;
     tracing::trace_state_ptr _ts;
@@ -500,7 +500,7 @@ private:
         co_await read_next_page();
     }
 public:
-    multi_range_partition_generator(distributed<replica::database>& db, schema_ptr schema, const dht::partition_range_vector& prs,
+    multi_range_partition_generator(sharded<replica::database>& db, schema_ptr schema, const dht::partition_range_vector& prs,
             tracing::trace_state_ptr ts, db::timeout_clock::time_point timeout)
         : _db(db)
         , _schema(std::move(schema))
@@ -536,7 +536,7 @@ public:
 };
 
 noncopyable_function<future<std::optional<dht::decorated_key>>()>
-make_partition_key_generator(distributed<replica::database>& db, schema_ptr schema, const dht::partition_range_vector& prs,
+make_partition_key_generator(sharded<replica::database>& db, schema_ptr schema, const dht::partition_range_vector& prs,
         tracing::trace_state_ptr ts, db::timeout_clock::time_point timeout) {
     if (prs.size() == 1 && prs.front().is_singular()) {
         auto dk_opt = std::optional(prs.front().start()->value().as_decorated_key());

--- a/service/load_broadcaster.hh
+++ b/service/load_broadcaster.hh
@@ -9,7 +9,7 @@
 
 #pragma once
 
-#include <seastar/core/distributed.hh>
+#include <seastar/core/sharded.hh>
 #include "utils/assert.hh"
 #include "replica/database_fwd.hh"
 #include "gms/i_endpoint_state_change_subscriber.hh"
@@ -22,7 +22,7 @@ public:
     static constexpr std::chrono::milliseconds BROADCAST_INTERVAL{60 * 1000};
 
 private:
-    distributed<replica::database>& _db;
+    sharded<replica::database>& _db;
     gms::gossiper& _gossiper;
     std::unordered_map<locator::host_id, double> _load_info;
     timer<> _timer;
@@ -30,7 +30,7 @@ private:
     bool _stopped = false;
 
 public:
-    load_broadcaster(distributed<replica::database>& db, gms::gossiper& g) : _db(db), _gossiper(g) {
+    load_broadcaster(sharded<replica::database>& db, gms::gossiper& g) : _db(db), _gossiper(g) {
         _gossiper.register_(shared_from_this());
     }
     ~load_broadcaster() {

--- a/service/load_meter.hh
+++ b/service/load_meter.hh
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include <seastar/core/distributed.hh>
+#include <seastar/core/sharded.hh>
 #include "service/load_broadcaster.hh"
 
 using namespace seastar;
@@ -31,7 +31,7 @@ private:
 public:
     future<std::map<sstring, double>> get_load_map();
 
-    future<> init(distributed<replica::database>& db, gms::gossiper& gossiper);
+    future<> init(sharded<replica::database>& db, gms::gossiper& gossiper);
     future<> exit();
 };
 

--- a/service/mapreduce_service.hh
+++ b/service/mapreduce_service.hh
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include <seastar/core/distributed.hh>
+#include <seastar/core/sharded.hh>
 #include <seastar/core/future.hh>
 #include <seastar/core/sharded.hh>
 
@@ -143,7 +143,7 @@ class retrying_dispatcher;
 class mapreduce_service : public seastar::peering_sharded_service<mapreduce_service> {
     netw::messaging_service& _messaging;
     service::storage_proxy& _proxy;
-    distributed<replica::database>& _db;
+    sharded<replica::database>& _db;
     abort_source _abort_outgoing_tasks;
 
     struct stats {
@@ -157,7 +157,7 @@ class mapreduce_service : public seastar::peering_sharded_service<mapreduce_serv
     bool _shutdown = false;
 
 public:
-    mapreduce_service(netw::messaging_service& ms, service::storage_proxy& p, distributed<replica::database> &db,
+    mapreduce_service(netw::messaging_service& ms, service::storage_proxy& p, sharded<replica::database> &db,
         abort_source& as)
         : _messaging(ms)
         , _proxy(p)

--- a/service/misc_services.cc
+++ b/service/misc_services.cc
@@ -27,7 +27,7 @@ constexpr std::chrono::milliseconds load_broadcaster::BROADCAST_INTERVAL;
 
 logging::logger llogger("load_broadcaster");
 
-future<> load_meter::init(distributed<replica::database>& db, gms::gossiper& gms) {
+future<> load_meter::init(sharded<replica::database>& db, gms::gossiper& gms) {
     _lb = make_shared<load_broadcaster>(db, gms);
     _lb->start_broadcasting();
     return make_ready_future<>();

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -3189,7 +3189,7 @@ storage_proxy::~storage_proxy() {
     SCYLLA_ASSERT(!_remote);
 }
 
-storage_proxy::storage_proxy(distributed<replica::database>& db, storage_proxy::config cfg, db::view::node_update_backlog& max_view_update_backlog,
+storage_proxy::storage_proxy(sharded<replica::database>& db, storage_proxy::config cfg, db::view::node_update_backlog& max_view_update_backlog,
         scheduling_group_key stats_key, gms::feature_service& feat, const locator::shared_token_metadata& stm, locator::effective_replication_map_factory& erm_factory)
     : _db(db)
     , _shared_token_metadata(stm)

--- a/service/storage_proxy.hh
+++ b/service/storage_proxy.hh
@@ -14,7 +14,7 @@
 #include "inet_address_vectors.hh"
 #include "replica/database_fwd.hh"
 #include "message/messaging_service_fwd.hh"
-#include <seastar/core/distributed.hh>
+#include <seastar/core/sharded.hh>
 #include <seastar/core/execution_stage.hh>
 #include <seastar/core/scheduling_specific.hh>
 #include "db/read_repair_decision.hh"
@@ -265,7 +265,7 @@ public:
     future<utils::chunked_vector<dht::token_range_endpoints>> describe_ring(const sstring& keyspace, bool include_only_local_dc = false) const;
 
 private:
-    distributed<replica::database>& _db;
+    sharded<replica::database>& _db;
     const locator::shared_token_metadata& _shared_token_metadata;
     locator::effective_replication_map_factory& _erm_factory;
     smp_service_group _read_smp_service_group;
@@ -514,15 +514,15 @@ private:
         host_id_vector_replica_set& l2) const;
 
 public:
-    storage_proxy(distributed<replica::database>& db, config cfg, db::view::node_update_backlog& max_view_update_backlog,
+    storage_proxy(sharded<replica::database>& db, config cfg, db::view::node_update_backlog& max_view_update_backlog,
             scheduling_group_key stats_key, gms::feature_service& feat, const locator::shared_token_metadata& stm,
             locator::effective_replication_map_factory& erm_factory);
     ~storage_proxy();
 
-    const distributed<replica::database>& get_db() const {
+    const sharded<replica::database>& get_db() const {
         return _db;
     }
-    distributed<replica::database>& get_db() {
+    sharded<replica::database>& get_db() {
         return _db;
     }
     const replica::database& local_db() const noexcept {

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -31,7 +31,7 @@
 #include <exception>
 #include <optional>
 #include <fmt/ranges.h>
-#include <seastar/core/distributed.hh>
+#include <seastar/core/sharded.hh>
 #include <seastar/util/defer.hh>
 #include <seastar/coroutine/as_future.hh>
 #include "gms/endpoint_state.hh"
@@ -182,7 +182,7 @@ void check_raft_rpc_scheduling_group(const replica::database& db, const gms::fea
 static constexpr std::chrono::seconds wait_for_live_nodes_timeout{30};
 
 storage_service::storage_service(abort_source& abort_source,
-    distributed<replica::database>& db, gms::gossiper& gossiper,
+    sharded<replica::database>& db, gms::gossiper& gossiper,
     sharded<db::system_keyspace>& sys_ks,
     sharded<db::system_distributed_keyspace>& sys_dist_ks,
     gms::feature_service& feature_service,

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -24,7 +24,7 @@
 #include "locator/tablets.hh"
 #include "locator/tablet_metadata_guard.hh"
 #include "inet_address_vectors.hh"
-#include <seastar/core/distributed.hh>
+#include <seastar/core/sharded.hh>
 #include <seastar/core/condition-variable.hh>
 #include "dht/token_range_endpoints.hh"
 #include "gms/application_state.hh"
@@ -33,7 +33,7 @@
 #include <seastar/core/gate.hh>
 #include "replica/database_fwd.hh"
 #include "streaming/stream_reason.hh"
-#include <seastar/core/distributed.hh>
+#include <seastar/core/sharded.hh>
 #include "service/migration_listener.hh"
 #include <seastar/core/metrics_registration.hh>
 #include <seastar/core/shared_ptr.hh>
@@ -169,7 +169,7 @@ private:
 
     abort_source& _abort_source;
     gms::feature_service& _feature_service;
-    distributed<replica::database>& _db;
+    sharded<replica::database>& _db;
     gms::gossiper& _gossiper;
     sharded<netw::messaging_service>& _messaging;
     sharded<service::migration_manager>& _migration_manager;
@@ -225,7 +225,7 @@ private:
     void register_tablet_split_candidate(table_id) noexcept;
     future<> run_tablet_split_monitor();
 public:
-    storage_service(abort_source& as, distributed<replica::database>& db,
+    storage_service(abort_source& as, sharded<replica::database>& db,
         gms::gossiper& gossiper,
         sharded<db::system_keyspace>&,
         sharded<db::system_distributed_keyspace>&,
@@ -254,7 +254,7 @@ public:
     ~storage_service();
 
     node_ops::task_manager_module& get_node_ops_module() noexcept;
-    // Needed by distributed<>
+    // Needed by sharded<>
     future<> stop();
     void init_messaging_service();
     future<> uninit_messaging_service();

--- a/streaming/stream_manager.cc
+++ b/streaming/stream_manager.cc
@@ -8,7 +8,7 @@
  * SPDX-License-Identifier: (LicenseRef-ScyllaDB-Source-Available-1.0 and Apache-2.0)
  */
 
-#include <seastar/core/distributed.hh>
+#include <seastar/core/sharded.hh>
 #include "db/view/view_building_worker.hh"
 #include "gms/gossiper.hh"
 #include "streaming/stream_manager.hh"

--- a/streaming/stream_manager.hh
+++ b/streaming/stream_manager.hh
@@ -13,7 +13,7 @@
 #include "streaming/progress_info.hh"
 #include "streaming/stream_reason.hh"
 #include <seastar/core/shared_ptr.hh>
-#include <seastar/core/distributed.hh>
+#include <seastar/core/sharded.hh>
 #include "utils/updateable_value.hh"
 #include "utils/serialized_action.hh"
 #include "gms/i_endpoint_state_change_subscriber.hh"

--- a/streaming/stream_session.hh
+++ b/streaming/stream_session.hh
@@ -10,7 +10,7 @@
 
 #pragma once
 
-#include <seastar/core/distributed.hh>
+#include <seastar/core/sharded.hh>
 #include "message/messaging_service_fwd.hh"
 #include "streaming/stream_session_state.hh"
 #include "streaming/stream_transfer_task.hh"

--- a/test/boost/incremental_compaction_test.cc
+++ b/test/boost/incremental_compaction_test.cc
@@ -12,7 +12,7 @@
 #include <seastar/core/sstring.hh>
 #include <seastar/core/future-util.hh>
 #include <seastar/core/do_with.hh>
-#include <seastar/core/distributed.hh>
+#include <seastar/core/sharded.hh>
 #include <seastar/testing/test_case.hh>
 #include <seastar/testing/thread_test_case.hh>
 #include "sstables/sstables.hh"

--- a/test/boost/sstable_resharding_test.cc
+++ b/test/boost/sstable_resharding_test.cc
@@ -6,7 +6,7 @@
 #include <seastar/core/sstring.hh>
 #include <seastar/core/future-util.hh>
 #include <seastar/core/do_with.hh>
-#include <seastar/core/distributed.hh>
+#include <seastar/core/sharded.hh>
 #include "sstables/sstables.hh"
 #include "test/lib/scylla_test_case.hh"
 #include "schema/schema.hh"

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -22,7 +22,7 @@
 #include "cql3/statements/modification_statement.hh"
 #include "cql3/cql_config.hh"
 #include <fmt/ranges.h>
-#include <seastar/core/distributed.hh>
+#include <seastar/core/sharded.hh>
 #include <seastar/core/abort_source.hh>
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/core/scheduling.hh>
@@ -196,7 +196,7 @@ private:
             return make_ready_future<>();
         }
     };
-    distributed<core_local_state> _core_local;
+    sharded<core_local_state> _core_local;
 private:
     cql3::dialect test_dialect() {
         return cql3::dialect{
@@ -346,7 +346,7 @@ public:
         return _db;
     }
 
-    distributed<cql3::query_processor>& qp() override {
+    sharded<cql3::query_processor>& qp() override {
         return _qp;
     }
 
@@ -354,7 +354,7 @@ public:
         return _auth_service.local();
     }
 
-    virtual distributed<db::view::view_builder>& view_builder() override {
+    virtual sharded<db::view::view_builder>& view_builder() override {
         return _view_builder;
     }
 
@@ -366,7 +366,7 @@ public:
         return _view_update_generator.local();
     }
 
-    virtual distributed<db::view::view_building_worker>& view_building_worker() override {
+    virtual sharded<db::view::view_building_worker>& view_building_worker() override {
         return _view_building_worker;
     }
 

--- a/test/lib/cql_test_env.hh
+++ b/test/lib/cql_test_env.hh
@@ -11,7 +11,7 @@
 #include <functional>
 #include <vector>
 
-#include <seastar/core/distributed.hh>
+#include <seastar/core/sharded.hh>
 #include <seastar/core/sstring.hh>
 #include <seastar/core/future.hh>
 #include <seastar/core/shared_ptr.hh>
@@ -152,16 +152,16 @@ public:
 
     virtual cql3::query_processor& local_qp() = 0;
 
-    virtual distributed<replica::database>& db() = 0;
+    virtual sharded<replica::database>& db() = 0;
 
-    virtual distributed<cql3::query_processor> & qp() = 0;
+    virtual sharded<cql3::query_processor> & qp() = 0;
 
     virtual auth::service& local_auth_service() = 0;
 
-    virtual distributed<db::view::view_builder>& view_builder() = 0;
+    virtual sharded<db::view::view_builder>& view_builder() = 0;
     virtual db::view::view_builder& local_view_builder() = 0;
 
-    virtual distributed<db::view::view_building_worker>& view_building_worker() = 0;
+    virtual sharded<db::view::view_building_worker>& view_building_worker() = 0;
 
     virtual db::view::view_update_generator& local_view_update_generator() = 0;
 

--- a/test/manual/gossip.cc
+++ b/test/manual/gossip.cc
@@ -48,7 +48,7 @@ namespace bpo = boost::program_options;
 // DEBUG [shard 0] gossip - ep=127.0.0.2, eps=HeartBeatState = { generation = 1446454380, version = 27 }, AppStateMap = { LOAD : Value(0.5005,26) }
 
 int main(int ac, char ** av) {
-    distributed<replica::database> db;
+    sharded<replica::database> db;
     app_template app;
     app.add_options()
         ("seed", bpo::value<std::vector<std::string>>(), "IP address of seed node")

--- a/test/manual/message.cc
+++ b/test/manual/message.cc
@@ -179,10 +179,10 @@ int main(int ac, char ** av) {
         ("stay-alive", bpo::value<bool>()->default_value(false), "Do not kill the test server after the test")
         ("cpuid", bpo::value<uint32_t>()->default_value(0), "Server cpuid");
 
-    distributed<replica::database> db;
+    sharded<replica::database> db;
     sharded<auth::service> auth_service;
     locator::shared_token_metadata tm({}, {});
-    distributed<qos::service_level_controller> sl_controller;
+    sharded<qos::service_level_controller> sl_controller;
 
     return app.run_deprecated(ac, av, [&app, &auth_service, &tm, &sl_controller] {
         return seastar::async([&app, &auth_service, &tm, &sl_controller] {

--- a/test/perf/logalloc.cc
+++ b/test/perf/logalloc.cc
@@ -6,7 +6,7 @@
  * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
  */
 
-#include <seastar/core/distributed.hh>
+#include <seastar/core/sharded.hh>
 #include <seastar/core/app-template.hh>
 #include <seastar/core/sstring.hh>
 #include <seastar/core/thread.hh>

--- a/test/perf/perf.hh
+++ b/test/perf/perf.hh
@@ -11,7 +11,7 @@
 #include <ranges>
 #include <seastar/core/format.hh>
 #include <seastar/core/future-util.hh>
-#include <seastar/core/distributed.hh>
+#include <seastar/core/sharded.hh>
 #include <seastar/core/weak_ptr.hh>
 #include <seastar/coroutine/as_future.hh>
 #include "seastarx.hh"
@@ -231,7 +231,7 @@ std::vector<Res> time_parallel_ex(Func func, unsigned concurrency_per_core, int 
     for (int i = 0; i < iterations; ++i) {
         auto start = clk::now();
         auto end_at = lowres_clock::now() + std::chrono::seconds(1);
-        distributed<executor<Func>> exec;
+        sharded<executor<Func>> exec;
         Res result;
         exec.start(concurrency_per_core, func, std::move(end_at), operations_per_shard, stop_on_error, operations_count_per_iteration).get();
         auto stop_exec = defer([&exec] {

--- a/test/perf/perf_commitlog.cc
+++ b/test/perf/perf_commitlog.cc
@@ -138,7 +138,7 @@ struct commitlog_service {
     }
 };
 
-static std::vector<clperf_result> do_commitlog_test(distributed<commitlog_service>& cls, test_config& cfg) {
+static std::vector<clperf_result> do_commitlog_test(sharded<commitlog_service>& cls, test_config& cfg) {
     auto uuid = table_id(utils::UUID_gen::get_time_UUID());
 
     return time_parallel_ex<clperf_result>([&] {
@@ -233,7 +233,7 @@ int main(int argc, char** argv) {
         tmpdir tmp;
         cl_cfg.commit_log_location = tmp.path().string();
 
-        distributed<commitlog_service> test_commitlog;
+        sharded<commitlog_service> test_commitlog;
 
         //logging::logger_registry().set_logger_level("commitlog", logging::log_level::debug);
 

--- a/test/perf/perf_row_cache_reads.cc
+++ b/test/perf/perf_row_cache_reads.cc
@@ -6,7 +6,7 @@
  * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
  */
 
-#include <seastar/core/distributed.hh>
+#include <seastar/core/sharded.hh>
 #include <seastar/core/app-template.hh>
 #include <seastar/core/sstring.hh>
 #include <seastar/core/thread.hh>

--- a/test/perf/perf_row_cache_update.cc
+++ b/test/perf/perf_row_cache_update.cc
@@ -6,7 +6,7 @@
  * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
  */
 
-#include <seastar/core/distributed.hh>
+#include <seastar/core/sharded.hh>
 #include <seastar/core/app-template.hh>
 #include <seastar/core/sstring.hh>
 #include <seastar/core/thread.hh>

--- a/test/perf/perf_sstable.cc
+++ b/test/perf/perf_sstable.cc
@@ -7,7 +7,7 @@
  */
 
 #include <boost/program_options/errors.hpp>
-#include <seastar/core/distributed.hh>
+#include <seastar/core/sharded.hh>
 #include <seastar/core/app-template.hh>
 #include <seastar/core/sstring.hh>
 #include <seastar/core/reactor.hh>
@@ -20,7 +20,7 @@ using namespace sstables;
 static unsigned iterations = 30;
 static unsigned parallelism = 1;
 
-future<> test_write(distributed<perf_sstable_test_env>& dt) {
+future<> test_write(sharded<perf_sstable_test_env>& dt) {
     return seastar::async([&dt] {
         dt.invoke_on_all([] (perf_sstable_test_env &t) {
             return t.fill_memtable();
@@ -30,7 +30,7 @@ future<> test_write(distributed<perf_sstable_test_env>& dt) {
     });
 }
 
-future<> test_compaction(distributed<perf_sstable_test_env>& dt) {
+future<> test_compaction(sharded<perf_sstable_test_env>& dt) {
     return seastar::async([&dt] {
         dt.invoke_on_all([] (perf_sstable_test_env &t) {
             return t.fill_memtable();
@@ -40,19 +40,19 @@ future<> test_compaction(distributed<perf_sstable_test_env>& dt) {
     });
 }
 
-future<> test_index_read(distributed<perf_sstable_test_env>& dt) {
+future<> test_index_read(sharded<perf_sstable_test_env>& dt) {
     return time_runs(iterations, parallelism, dt, &perf_sstable_test_env::read_all_indexes);
 }
 
-future<> test_sequential_read(distributed<perf_sstable_test_env>& dt) {
+future<> test_sequential_read(sharded<perf_sstable_test_env>& dt) {
     return time_runs(iterations, parallelism, dt, &perf_sstable_test_env::read_sequential_partitions);
 }
 
-future<> test_full_scan_streaming(distributed<perf_sstable_test_env>& dt) {
+future<> test_full_scan_streaming(sharded<perf_sstable_test_env>& dt) {
     return time_runs(iterations, parallelism, dt, &perf_sstable_test_env::full_scan_streaming);
 }
 
-future<> test_partitioned_streaming(distributed<perf_sstable_test_env>& dt) {
+future<> test_partitioned_streaming(sharded<perf_sstable_test_env>& dt) {
     return time_runs(iterations, parallelism, dt, &perf_sstable_test_env::partitioned_streaming);
 }
 
@@ -118,7 +118,7 @@ int scylla_sstable_main(int argc, char** argv) {
 
     return app.run(argc, argv, [&app] {
         return async([&app] {
-            distributed<perf_sstable_test_env> test;
+            sharded<perf_sstable_test_env> test;
 
             auto cfg = perf_sstable_test_env::conf();
             iterations = app.configuration()["iterations"].as<unsigned>();

--- a/test/perf/perf_sstable.hh
+++ b/test/perf/perf_sstable.hh
@@ -356,7 +356,7 @@ public:
 // The function func should carry on with the test, and return the number of partitions processed.
 // time_runs will then map reduce it, and return the aggregate partitions / sec for the whole system.
 template <typename Func>
-future<> time_runs(unsigned iterations, unsigned parallelism, distributed<perf_sstable_test_env>& dt, Func func) {
+future<> time_runs(unsigned iterations, unsigned parallelism, sharded<perf_sstable_test_env>& dt, Func func) {
     using namespace boost::accumulators;
     auto acc = make_lw_shared<accumulator_set<double, features<tag::mean, tag::error_of<tag::mean>>>>();
     auto idx = std::views::iota(0, int(iterations));

--- a/test/perf/perf_tablets.cc
+++ b/test/perf/perf_tablets.cc
@@ -9,7 +9,7 @@
 #include "utils/assert.hh"
 #include <fmt/ranges.h>
 
-#include <seastar/core/distributed.hh>
+#include <seastar/core/sharded.hh>
 #include <seastar/core/app-template.hh>
 #include <seastar/core/sstring.hh>
 #include <seastar/core/thread.hh>

--- a/test/perf/tablet_load_balancing.cc
+++ b/test/perf/tablet_load_balancing.cc
@@ -9,7 +9,7 @@
 #include <fmt/ranges.h>
 #include <bit>
 
-#include <seastar/core/distributed.hh>
+#include <seastar/core/sharded.hh>
 #include <seastar/core/app-template.hh>
 #include <seastar/core/sstring.hh>
 #include <seastar/core/thread.hh>

--- a/test/unit/lsa_async_eviction_test.cc
+++ b/test/unit/lsa_async_eviction_test.cc
@@ -6,7 +6,7 @@
  * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
  */
 
-#include <seastar/core/distributed.hh>
+#include <seastar/core/sharded.hh>
 #include <seastar/core/app-template.hh>
 #include <seastar/core/sstring.hh>
 #include <seastar/core/thread.hh>

--- a/test/unit/lsa_sync_eviction_test.cc
+++ b/test/unit/lsa_sync_eviction_test.cc
@@ -6,7 +6,7 @@
  * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
  */
 
-#include <seastar/core/distributed.hh>
+#include <seastar/core/sharded.hh>
 #include <seastar/core/app-template.hh>
 #include <seastar/core/sstring.hh>
 #include <seastar/core/thread.hh>

--- a/test/unit/row_cache_alloc_stress_test.cc
+++ b/test/unit/row_cache_alloc_stress_test.cc
@@ -6,7 +6,7 @@
  * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
  */
 
-#include <seastar/core/distributed.hh>
+#include <seastar/core/sharded.hh>
 #include <seastar/core/app-template.hh>
 #include <seastar/core/sstring.hh>
 #include <seastar/core/thread.hh>

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -254,7 +254,7 @@ void cql_sg_stats::rename_metrics() {
     }
 }
 
-cql_server::cql_server(distributed<cql3::query_processor>& qp, auth::service& auth_service,
+cql_server::cql_server(sharded<cql3::query_processor>& qp, auth::service& auth_service,
         service::memory_limiter& ml, cql_server_config config,
         qos::service_level_controller& sl_controller, gms::gossiper& g, scheduling_group_key stats_key,
         maintenance_socket_enabled used_by_maintenance_socket)
@@ -1053,7 +1053,7 @@ template <typename Process>
     requires std::is_invocable_r_v<future<cql_server::process_fn_return_type>,
                                    Process,
                                    service::client_state&,
-                                   distributed<cql3::query_processor>&,
+                                   sharded<cql3::query_processor>&,
                                    request_reader,
                                    uint16_t,
                                    cql_protocol_version_type,
@@ -1086,7 +1086,7 @@ template <typename Process>
     requires std::is_invocable_r_v<future<cql_server::process_fn_return_type>,
                                    Process,
                                    service::client_state&,
-                                   distributed<cql3::query_processor>&,
+                                   sharded<cql3::query_processor>&,
                                    request_reader,
                                    uint16_t,
                                    cql_protocol_version_type,
@@ -1118,7 +1118,7 @@ cql_server::connection::process(uint16_t stream, request_reader in, service::cli
 }
 
 static future<cql_server::process_fn_return_type>
-process_query_internal(service::client_state& client_state, distributed<cql3::query_processor>& qp, request_reader in,
+process_query_internal(service::client_state& client_state, sharded<cql3::query_processor>& qp, request_reader in,
         uint16_t stream, cql_protocol_version_type version,
         service_permit permit, tracing::trace_state_ptr trace_state, bool init_trace, cql3::computed_function_values cached_pk_fn_calls,
         cql3::dialect dialect) {
@@ -1196,7 +1196,7 @@ future<std::unique_ptr<cql_server::response>> cql_server::connection::process_pr
 }
 
 static future<cql_server::process_fn_return_type>
-process_execute_internal(service::client_state& client_state, distributed<cql3::query_processor>& qp, request_reader in,
+process_execute_internal(service::client_state& client_state, sharded<cql3::query_processor>& qp, request_reader in,
         uint16_t stream, cql_protocol_version_type version,
         service_permit permit, tracing::trace_state_ptr trace_state, bool init_trace, cql3::computed_function_values cached_pk_fn_calls,
         cql3::dialect dialect) {
@@ -1289,7 +1289,7 @@ future<cql_server::result_with_foreign_response_ptr> cql_server::connection::pro
 }
 
 static future<cql_server::process_fn_return_type>
-process_batch_internal(service::client_state& client_state, distributed<cql3::query_processor>& qp, request_reader in,
+process_batch_internal(service::client_state& client_state, sharded<cql3::query_processor>& qp, request_reader in,
         uint16_t stream, cql_protocol_version_type version,
         service_permit permit, tracing::trace_state_ptr trace_state, bool init_trace, cql3::computed_function_values cached_pk_fn_calls, cql3::dialect dialect) {
     const utils::result_with_exception_ptr<int8_t> type = in.read_byte();

--- a/transport/server.hh
+++ b/transport/server.hh
@@ -15,7 +15,7 @@
 #include "service/endpoint_lifecycle_subscriber.hh"
 #include "service/migration_listener.hh"
 #include "auth/authenticator.hh"
-#include <seastar/core/distributed.hh>
+#include <seastar/core/sharded.hh>
 #include "service/qos/qos_configuration_change_subscriber.hh"
 #include "timeout_config.hh"
 #include <seastar/core/semaphore.hh>
@@ -199,7 +199,7 @@ private:
 
     static constexpr cql_protocol_version_type current_version = cql_serialization_format::latest_version;
 
-    distributed<cql3::query_processor>& _query_processor;
+    sharded<cql3::query_processor>& _query_processor;
     cql_server_config _config;
     semaphore& _memory_available;
     seastar::metrics::metric_groups _metrics;
@@ -211,7 +211,7 @@ private:
     gms::gossiper& _gossiper;
     scheduling_group_key _stats_key;
 public:
-    cql_server(distributed<cql3::query_processor>& qp, auth::service&,
+    cql_server(sharded<cql3::query_processor>& qp, auth::service&,
             service::memory_limiter& ml,
             cql_server_config config,
             qos::service_level_controller& sl_controller,
@@ -328,7 +328,7 @@ private:
             requires std::is_invocable_r_v<future<cql_server::process_fn_return_type>,
                                            Process,
                                            service::client_state&,
-                                           distributed<cql3::query_processor>&,
+                                           sharded<cql3::query_processor>&,
                                            request_reader,
                                            uint16_t,
                                            cql_protocol_version_type,
@@ -345,7 +345,7 @@ private:
             requires std::is_invocable_r_v<future<cql_server::process_fn_return_type>,
                                            Process,
                                            service::client_state&,
-                                           distributed<cql3::query_processor>&,
+                                           sharded<cql3::query_processor>&,
                                            request_reader,
                                            uint16_t,
                                            cql_protocol_version_type,


### PR DESCRIPTION
The latter is recommended in seastar, and the former was left as compatibility alias. Latest seastar explicitly marks it as deprecated so once the submodule is updated, compilation logs will explode.

Most of the patch is generated with

    for f in $(git grep -l '\<distributed<[A-Za-z0-9:_]*>') ; do sed -e 's/\<distributed<\([A-Za-z0-9:_]*\)>/sharded<\1>/g' -i $f; done
    for f in $(git grep -l distributed.hh); do sed -e 's/distributed.hh/sharded.hh/' -i $f ; done

and a small manual change in test/perf/perf.hh

**Please replace this line with justification for the backport/\* labels added to this PR**