### PR TITLE
compaction/twcs: use on_internal_error() for invalid timestamp resolution

### DIFF
--- a/compaction/time_window_compaction_strategy.hh
+++ b/compaction/time_window_compaction_strategy.hh
@@ -96,9 +96,8 @@ private:
             return api::timestamp_type(timestamp_from_sstable);
         case time_window_compaction_strategy_options::timestamp_resolutions::millisecond:
             return std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::milliseconds(timestamp_from_sstable)).count();
-        default:
-            throw std::runtime_error("Timestamp resolution invalid for TWCS");
         };
+        on_internal_error(clogger, std::format("Timestamp resolution invalid for TWCS : {}", static_cast<int>(resolution)));
     }
 
     // Returns true if bucket is the last, most active one.


### PR DESCRIPTION
When the `time_window_compaction_strategy::to_timestamp_type` encounters an invalid timestamp resolution it throws an `std::runtime_error`. This patch replaces it with `on_internal_error()` and also logs the invalid timestamp resolution for easier debugging.

Refs #25913

Backport to older versions as this will help debug the issue if it occurs on them