### PR TITLE
Revert "Merge 'transport: service_level_controller: create and use `driver` service level' from Andrzej Jackowski"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,7 +96,7 @@ else()
     set(Seastar_EXCLUDE_APPS_FROM_ALL ON CACHE BOOL "" FORCE)
     set(Seastar_EXCLUDE_TESTS_FROM_ALL ON CACHE BOOL "" FORCE)
     set(Seastar_IO_URING ON CACHE BOOL "" FORCE)
-    set(Seastar_SCHEDULING_GROUPS_COUNT 20 CACHE STRING "" FORCE)
+    set(Seastar_SCHEDULING_GROUPS_COUNT 19 CACHE STRING "" FORCE)
     set(Seastar_UNUSED_RESULT_ERROR ON CACHE BOOL "" FORCE)
     add_subdirectory(seastar)
     target_compile_definitions (seastar

--- a/configure.py
+++ b/configure.py
@@ -1991,7 +1991,7 @@ def configure_seastar(build_dir, mode, mode_config):
         '-DSeastar_DEPRECATED_OSTREAM_FORMATTERS=OFF',
         '-DSeastar_UNUSED_RESULT_ERROR=ON',
         '-DCMAKE_EXPORT_COMPILE_COMMANDS=ON',
-        '-DSeastar_SCHEDULING_GROUPS_COUNT=20',
+        '-DSeastar_SCHEDULING_GROUPS_COUNT=19',
         '-DSeastar_IO_URING=ON',
     ]
 

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -3311,26 +3311,6 @@ future<mutation> system_keyspace::make_view_builder_version_mutation(api::timest
     co_return std::move(muts[0]);
 }
 
-static constexpr auto SERVICE_LEVEL_DRIVER_CREATED_KEY = "service_level_driver_created";
-
-future<std::optional<mutation>> system_keyspace::get_service_level_driver_created_mutation() {
-    return get_scylla_local_mutation(_db, SERVICE_LEVEL_DRIVER_CREATED_KEY);
-}
-
-future<mutation> system_keyspace::make_service_level_driver_created_mutation(bool is_created, api::timestamp_type timestamp) {
-    static const sstring query = format("INSERT INTO {}.{} (key, value) VALUES (?, ?);", db::system_keyspace::NAME, db::system_keyspace::SCYLLA_LOCAL);
-    auto muts = co_await _qp.get_mutations_internal(query, internal_system_query_state(), timestamp, {SERVICE_LEVEL_DRIVER_CREATED_KEY, data_type_for<bool>()->to_string_impl(data_value(is_created))});
-
-    if (muts.size() != 1) {
-        on_internal_error(slogger, format("expecting single insert mutation, got {}", muts.size()));
-    }
-    co_return std::move(muts[0]);
-}
-
-future<std::optional<bool>> system_keyspace::get_service_level_driver_created() {
-    return get_scylla_local_param_as<bool>(SERVICE_LEVEL_DRIVER_CREATED_KEY);
-}
-
 static constexpr auto SERVICE_LEVELS_VERSION_KEY = "service_level_version";
 
 future<std::optional<mutation>> system_keyspace::get_service_levels_version_mutation() {

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -691,11 +691,8 @@ public:
     future<topology_requests_entries> get_node_ops_request_entries(db_clock::time_point end_time_limit);
 
 public:
-    future<std::optional<bool>> get_service_level_driver_created();
-    future<mutation> make_service_level_driver_created_mutation(bool is_created, api::timestamp_type timestamp);
-    future<std::optional<mutation>> get_service_level_driver_created_mutation();
-
     future<std::optional<int8_t>> get_service_levels_version();
+    
     future<mutation> make_service_levels_version_mutation(int8_t version, api::timestamp_type timestamp);
     future<std::optional<mutation>> get_service_levels_version_mutation();
 

--- a/docs/features/workload-prioritization.rst
+++ b/docs/features/workload-prioritization.rst
@@ -23,13 +23,9 @@ By assigning each service level to the different roles within your organization,
 
 .. _`role` : /operating-scylla/security/rbac_usecase/
 
-Initially ScyllaDB has two service levels:
- * ``'default'`` - Receives all load unassigned to any other service level.
- * ``'driver'`` - Isolates metadata operations (for example, driver schema and topology fetches) and handles new connections before the user is authenticated and authorized. This reduces the impact of connection handling on regular query traffic. In most deployments, you do not need to tune the ``'driver'`` service level.
-
 Prerequisites
 =============
-To create a new service level and assign it to a role, you need:
+To create a level of service and assign it to a role, you need:
 
 * An :doc:`authenticated </operating-scylla/security/runtime-authentication>` and :doc:`authorized </operating-scylla/security/enable-authorization>` user 
 * At least one :ref:`role created <create-role-statement>`.
@@ -80,7 +76,7 @@ Where:
 Example
 .......
 
-There are 4 service levels (OLAP, OLTP, driver, default) where: (the percentage of resources = (Assigned Shares / Total Shares) x 100). Total Shares in this case is the total of all allocated shares + the Default SLA (1000). The percentage of resources would be:
+There are 3 service levels (OLAP, OLTP, Default) where: (the percentage of resources = (Assigned Shares / Total Shares) x 100). Total Shares in this case is the total of all allocated shares + the Default SLA (1000). The percentage of resources would be:
 
 .. list-table::
    :widths: 30 30 30 
@@ -94,15 +90,12 @@ There are 4 service levels (OLAP, OLTP, driver, default) where: (the percentage 
      - 4%
    * - OLTP
      - 1000
-     - 44%
-   * - driver
-     - 200
-     - 8%
-   * - default
+     - 48%
+   * - Default
      - 1000
-     - 44%
+     - 48%
    * - Total 
-     - 2300
+     - 2100
      - 100%
 
 **Procedure**
@@ -122,12 +115,10 @@ There are 4 service levels (OLAP, OLTP, driver, default) where: (the percentage 
 
    service_level | shares
    --------------+-------
-          driver |    200
-   --------------+-------
             olap |    100
    --------------+-------
             oltp |   1000
-   (3 rows)
+   (2 rows)
 
 Change Resource Allocation for a Service Level 
 -----------------------------------------------
@@ -244,10 +235,9 @@ Run the following:
 
    service_level  | shares
    ---------------+--------
-           driver |     200
              olap |     100
              oltp |    1000
-   (3 rows)
+   (2 rows)
 
 
 Delete a Service Level
@@ -435,7 +425,7 @@ In order for workload prioritization to take effect, application users need to b
 
 Limits
 ======
-ScyllaDB is limited to 9 service levels, including the default and driver levels; this means you can create up to 7 service levels.
+ScyllaDB is limited to 8 service levels, including the default one; this means you can create up to 7 service levels.
 
 
 Additional References

--- a/generic_server.cc
+++ b/generic_server.cc
@@ -15,7 +15,6 @@
 #include <seastar/core/reactor.hh>
 #include <seastar/core/smp.hh>
 #include <seastar/coroutine/maybe_yield.hh>
-#include <seastar/coroutine/switch_to.hh>
 #include <utility>
 
 namespace generic_server {
@@ -367,7 +366,6 @@ server::listen(socket_address addr, std::shared_ptr<seastar::tls::credentials_bu
 }
 
 future<> server::do_accepts(int which, bool keepalive, socket_address server_addr, bool is_tls) {
-    co_await coroutine::switch_to(get_scheduling_group_for_new_connection());
     while (!_gate.is_closed()) {
         seastar::gate::holder holder(_gate);
         bool shed = false;
@@ -387,7 +385,6 @@ future<> server::do_accepts(int which, bool keepalive, socket_address server_add
                 }
             }
             accept_result cs_sa = co_await _listeners[which].accept();
-            co_await coroutine::switch_to(get_scheduling_group_for_new_connection());
             if (_gate.is_closed()) {
                 break;
             }

--- a/generic_server.hh
+++ b/generic_server.hh
@@ -23,7 +23,6 @@
 #include <seastar/net/api.hh>
 #include <seastar/net/tls.hh>
 #include <seastar/core/semaphore.hh>
-#include <seastar/core/scheduling.hh>
 
 namespace generic_server {
 
@@ -153,7 +152,6 @@ public:
 
 protected:
     virtual seastar::shared_ptr<connection> make_connection(socket_address server_addr, connected_socket&& fd, socket_address addr, named_semaphore& sem, semaphore_units<named_semaphore_exception_factory> initial_sem_units) = 0;
-    virtual scheduling_group get_scheduling_group_for_new_connection() const = 0;
 
     future<> for_each_gently(noncopyable_function<void(connection&)>);
 };

--- a/gms/feature_service.hh
+++ b/gms/feature_service.hh
@@ -171,7 +171,6 @@ public:
     gms::feature lwt_with_tablets { *this, "LWT_WITH_TABLETS"sv };
     gms::feature repair_msg_split { *this, "REPAIR_MSG_SPLIT"sv };
     gms::feature view_building_coordinator { *this, "VIEW_BUILDING_COORDINATOR"sv };
-    gms::feature driver_service_level { *this, "DRIVER_SERVICE_LEVEL"sv };
 public:
 
     const std::unordered_map<sstring, std::reference_wrapper<feature>>& registered_features() const;

--- a/service/client_state.hh
+++ b/service/client_state.hh
@@ -105,7 +105,6 @@ private:
     std::optional<sstring> _driver_name, _driver_version;
 
     auth_state _auth_state = auth_state::UNINITIALIZED;
-    bool _control_connection = false;
 
     // isInternal is used to mark ClientState as used by some internal component
     // that should have an ability to modify system keyspace.
@@ -141,14 +140,6 @@ public:
 
     void set_auth_state(auth_state new_state) noexcept {
         _auth_state = new_state;
-    }
-
-    bool is_control_connection() const noexcept {
-        return _control_connection;
-    }
-
-    bool set_control_connection() noexcept {
-        return _control_connection = true;
     }
 
     std::optional<sstring> get_driver_name() const {

--- a/service/qos/raft_service_level_distributed_data_accessor.hh
+++ b/service/qos/raft_service_level_distributed_data_accessor.hh
@@ -41,7 +41,6 @@ public:
     virtual bool is_v2() const override;
     virtual bool can_use_effective_service_level_cache() const override;
     virtual ::shared_ptr<service_level_distributed_data_accessor> upgrade_to_v2(cql3::query_processor& qp, service::raft_group0_client& group0_client) const override;
-    static future<utils::chunked_vector<mutation>> set_service_level_mutations(cql3::query_processor& qp, sstring service_level_name, qos::service_level_options slo, api::timestamp_type timestamp);
 };
 
 }

--- a/service/qos/service_level_controller.cc
+++ b/service/qos/service_level_controller.cc
@@ -407,53 +407,6 @@ future<> service_level_controller::update_cache(update_both_cache_levels update_
     }
 }
 
-static service_level_options get_driver_service_level_slo() {
-    service_level_options slo;
-    slo.shares = 200;
-    slo.workload = service_level_options::workload_type::batch;
-    return slo;
-}
-
-future<utils::chunked_vector<mutation>> service_level_controller::get_create_driver_service_level_mutations(db::system_keyspace& sys_ks, api::timestamp_type timestamp) {
-
-    utils::chunked_vector<mutation> mutations;
-
-    auto sl_mutations = co_await raft_service_level_distributed_data_accessor::set_service_level_mutations(sys_ks.query_processor(), service_level_controller::driver_service_level_name, get_driver_service_level_slo(), timestamp);
-    std::move(sl_mutations.begin(), sl_mutations.end(), std::back_inserter(mutations));
-
-    auto sys_ks_mutation = co_await sys_ks.make_service_level_driver_created_mutation(true, timestamp);
-    mutations.push_back(std::move(sys_ks_mutation));
-
-    co_return mutations;
-}
-
-future<std::optional<service::group0_guard>> service_level_controller::migrate_to_driver_service_level(service::group0_guard guard, db::system_keyspace& sys_ks) {
-    // Don't try creating driver service level too often if it already failed.
-    // We don't want to block the topology coordinator.
-    if (_last_unsuccessful_driver_sl_creation_attemp + 5min < seastar::lowres_clock::now()) {
-        sl_logger.info("migrate_to_driver_service_level: starting sl:{} creation", service_level_controller::driver_service_level_name);
-        try {
-            service::group0_batch mc{std::move(guard)};
-
-            constexpr bool if_not_exists = true;
-            co_await add_distributed_service_level(service_level_controller::driver_service_level_name, get_driver_service_level_slo(), if_not_exists, mc);
-
-            auto sys_ks_mutation = co_await sys_ks.make_service_level_driver_created_mutation(true, mc.write_timestamp());
-            mc.add_mutation(std::move(sys_ks_mutation), "set service_level_driver_created=true");
-
-            co_await commit_mutations(std::move(mc));
-            sl_logger.info("create_driver_service_level: sl:{} created", service_level_controller::driver_service_level_name);
-        } catch (service::group0_concurrent_modification&) {
-            throw; // Let caller handle `group0_concurrent_modification`
-        } catch (...) {
-            sl_logger.error("Failed to create service level for driver: {}. Removal of user service levels below the limit is necessary to allow sl:driver creation.", std::current_exception());
-            _last_unsuccessful_driver_sl_creation_attemp = seastar::lowres_clock::now();
-        }
-        co_return std::nullopt;
-    }
-    co_return std::move(guard); // return guard untouched
-}
-
 void service_level_controller::stop_legacy_update_from_distributed_data() {
     SCYLLA_ASSERT(this_shard_id() == global_controller);
 
@@ -1005,27 +958,7 @@ future<> service_level_controller::unregister_subscriber(qos_configuration_chang
     return _subscribers.remove(subscriber);
 }
 
-enum class describe_cmd: uint8_t {
-    CREATE,
-    CREATE_IF_NOT_EXISTS,
-    ALTER,
-    DROP_IF_EXISTS,
-};
-
-std::string_view describe_cmd_to_sstring(describe_cmd cmd_enum) {
-    switch (cmd_enum) {
-        case describe_cmd::CREATE:
-            return "CREATE SERVICE LEVEL";
-        case describe_cmd::CREATE_IF_NOT_EXISTS:
-            return "CREATE SERVICE LEVEL IF NOT EXISTS";
-        case describe_cmd::ALTER:
-            return "ALTER SERVICE LEVEL";
-        case describe_cmd::DROP_IF_EXISTS:
-            return "DROP SERVICE LEVEL IF EXISTS";
-    };
-}
-
-static sstring describe_service_level(std::string_view sl_name, const service_level_options& sl_opts, describe_cmd cmd=describe_cmd::CREATE) {
+static sstring describe_service_level(std::string_view sl_name, const service_level_options& sl_opts) {
     using slo = service_level_options;
 
     utils::small_vector<sstring, 3> opts{};
@@ -1059,44 +992,12 @@ static sstring describe_service_level(std::string_view sl_name, const service_le
     }
 
     if (opts.size() == 0) {
-        return seastar::format("{} {};", describe_cmd_to_sstring(cmd), sl_name_formatted);
+        return seastar::format("CREATE SERVICE LEVEL {};", sl_name_formatted);
     }
 
-    return seastar::format("{} {} WITH {};", describe_cmd_to_sstring(cmd), sl_name_formatted, fmt::join(opts, " AND "));
+    return seastar::format("CREATE SERVICE LEVEL {} WITH {};", sl_name_formatted, fmt::join(opts, " AND "));
 }
 
-utils::small_vector<cql3::description, 2> describe_driver_service_level(const std::optional<service_level_options>& driver_service_level_slo) {
-    utils::small_vector<cql3::description, 2> result;
-    const auto service_level_type = "service_level";
-    if (driver_service_level_slo.has_value()) {
-        // We need to use CREATE IF EXISTS because `driver` service level can be already created automatically
-        // We also need to ALTER because if driver exists, it can have different shares number
-        const sstring create_statement = describe_service_level(service_level_controller::driver_service_level_name, driver_service_level_slo.value(), describe_cmd::CREATE_IF_NOT_EXISTS);
-        const sstring alter_statement = describe_service_level(service_level_controller::driver_service_level_name, driver_service_level_slo.value(), describe_cmd::ALTER);
-
-        result.push_back(cql3::description {
-            .keyspace = std::nullopt,
-            .type = service_level_type,
-            .name = service_level_controller::driver_service_level_name,
-            .create_statement = managed_string(create_statement)
-        });
-        result.push_back(cql3::description {
-            .keyspace = std::nullopt,
-            .type = service_level_type,
-            .name = service_level_controller::driver_service_level_name,
-            .create_statement = managed_string(alter_statement)
-        });
-    } else {
-        const sstring drop_statement = describe_service_level(service_level_controller::driver_service_level_name, service_level_options{}, describe_cmd::DROP_IF_EXISTS);
-        result.push_back(cql3::description {
-            .keyspace = std::nullopt,
-            .type = service_level_type,
-            .name = service_level_controller::driver_service_level_name,
-            .create_statement = managed_string(drop_statement)
-        });
-    }
-    return result;
-}
 
 future<std::vector<cql3::description>> service_level_controller::describe_created_service_levels() const {
 
@@ -1112,14 +1013,8 @@ future<std::vector<cql3::description>> service_level_controller::describe_create
     //
     // If Raft is not used yet, updating the cache will happen every 10 seconds. We deem it
     // good enough if someone does attempt to make a backup in that state.
-
-    std::optional<service_level_options> driver_service_level_slo;
     for (const auto& [sl_name, sl] : _service_levels_db) {
         if (sl.is_static) {
-            continue;
-        }
-        if (sl_name == driver_service_level_name) {
-            driver_service_level_slo = sl.slo;
             continue;
         }
 
@@ -1137,13 +1032,8 @@ future<std::vector<cql3::description>> service_level_controller::describe_create
     }
 
     std::ranges::sort(result, std::less<>{}, std::mem_fn(&cql3::description::name));
-    auto driver_sl_description = describe_driver_service_level(driver_service_level_slo);
 
-    std::vector<cql3::description> combined;
-    combined.reserve(result.size() + driver_sl_description.size());
-    std::move(driver_sl_description.begin(), driver_sl_description.end(), std::back_inserter(combined));
-    std::move(result.begin(), result.end(), std::back_inserter(combined));
-    co_return combined;
+    co_return result;
 }
 
 future<std::vector<cql3::description>> service_level_controller::auth_integration::describe_attached_service_levels() {

--- a/service/qos/service_level_controller.hh
+++ b/service/qos/service_level_controller.hh
@@ -15,14 +15,12 @@
 #include <seastar/core/sharded.hh>
 #include <seastar/core/abort_source.hh>
 #include <seastar/core/with_scheduling_group.hh>
-#include <seastar/core/lowres_clock.hh>
 
 #include "seastarx.hh"
 #include "auth/service.hh"
 #include "cql3/description.hh"
 #include <map>
 #include "qos_common.hh"
-#include "mutation/mutation.hh"
 #include "service/endpoint_lifecycle_subscriber.hh"
 #include "qos_configuration_change_subscriber.hh"
 #include "service/raft/raft_group0_client.hh"
@@ -106,7 +104,6 @@ using update_both_cache_levels = bool_class<class update_both_cache_levels_tag>;
 class service_level_controller : public peering_sharded_service<service_level_controller>, public service::endpoint_lifecycle_subscriber {
 public:
     static inline const int32_t default_shares = 1000;
-    static constexpr auto driver_service_level_name = "driver";
 
     class service_level_distributed_data_accessor {
     public:
@@ -224,7 +221,6 @@ private:
     unsigned _logged_intervals;
     atomic_vector<qos_configuration_change_subscriber*> _subscribers;
     optimized_optional<abort_source::subscription> _early_abort_subscription;
-    seastar::lowres_clock::time_point _last_unsuccessful_driver_sl_creation_attemp = seastar::lowres_clock::time_point::min();
     void do_abort() noexcept;
 public:
     service_level_controller(sharded<auth::service>& auth_service, locator::shared_token_metadata& tm, abort_source& as, service_level_options default_service_level_config,
@@ -347,18 +343,6 @@ public:
      * @return a future that is resolved when the update loop stops.
      */
     void maybe_start_legacy_update_from_distributed_data(std::function<steady_clock_type::duration()> interval_f, service::storage_service& storage_service, service::raft_group0_client& group0_client);
-
-    /**
-     * Get mutations required to:
-     * 1. create `sl:driver`
-     * 2. store information that `sl:driver` was created in `system.scylla_local`
-     */
-    static future<utils::chunked_vector<mutation>> get_create_driver_service_level_mutations(db::system_keyspace& sys_ks, api::timestamp_type timestamp);
-    /**
-     * Create `sl:driver` using _sl_data_accessor if possible. If `sl:driver` exists or it's created, store
-       the information it was created in `system.scylla_local`.
-     */
-    future<std::optional<service::group0_guard>> migrate_to_driver_service_level(service::group0_guard guard, db::system_keyspace& sys_ks);
 
     /**
      * Request abort of update loop.

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -1197,7 +1197,6 @@ future<> storage_service::raft_state_monitor_fiber(raft::server& raft, gate::hol
                     get_ring_delay(),
                     _lifecycle_notifier,
                     _feature_service,
-                    _sl_controller.local(),
                     _topology_cmd_rpc_tracker);
         }
     } catch (...) {
@@ -1369,11 +1368,6 @@ future<> storage_service::raft_initialize_discovery_leader(const join_node_reque
     insert_join_request_mutations.emplace_back(std::move(sl_status_mutation));
 
     insert_join_request_mutations.emplace_back(co_await _sys_ks.local().make_auth_version_mutation(write_timestamp, db::system_keyspace::auth_version_t::v2));
-
-    auto sl_driver_mutations = co_await qos::service_level_controller::get_create_driver_service_level_mutations(_sys_ks.local(), write_timestamp);
-    for (auto& m : sl_driver_mutations) {
-        insert_join_request_mutations.emplace_back(m);
-    }
 
     if (!utils::get_local_injector().is_enabled("skip_vb_v2_version_mut")) {
         insert_join_request_mutations.emplace_back(
@@ -7546,11 +7540,6 @@ void storage_service::init_messaging_service() {
 
                 mutations.reserve(mutations.size() + muts.size());
                 std::move(muts.begin(), muts.end(), std::back_inserter(mutations));
-            }
-
-            auto sl_driver_created_mut = co_await ss._sys_ks.local().get_service_level_driver_created_mutation();
-            if (sl_driver_created_mut) {
-                mutations.push_back(canonical_mutation(*sl_driver_created_mut));
             }
 
             auto sl_version_mut = co_await ss._sys_ks.local().get_service_levels_version_mutation();

--- a/service/topology_coordinator.hh
+++ b/service/topology_coordinator.hh
@@ -19,7 +19,6 @@
 #include "service/endpoint_lifecycle_subscriber.hh"
 #include "service/topology_state_machine.hh"
 #include "db/view/view_building_state.hh"
-#include "service/qos/service_level_controller.hh"
 
 namespace db {
 class system_keyspace;
@@ -96,7 +95,6 @@ future<> run_topology_coordinator(
         std::chrono::milliseconds ring_delay,
         endpoint_lifecycle_notifier& lifecycle_notifier,
         gms::feature_service& feature_service,
-        qos::service_level_controller& sl_controller,
         topology_coordinator_cmd_rpc_tracker& topology_cmd_rpc_tracker);
 
 }

--- a/test/boost/auth_test.cc
+++ b/test/boost/auth_test.cc
@@ -225,10 +225,9 @@ SEASTAR_TEST_CASE(test_alter_with_timeouts) {
 
         auto sl_is_v2 = e.local_client_state().get_service_level_controller().is_v2();
 	    auto msg = cquery_nofail(e, format("SELECT timeout FROM {}", sl_is_v2 ? "system.service_levels_v2" : "system_distributed.service_levels"));
-        assert_that(msg).is_rows().with_rows({
-            {duration_type->from_string("5ms")},
-            {{}}, // `sl:driver`
-        });
+        assert_that(msg).is_rows().with_rows({{
+            duration_type->from_string("5ms")
+        }});
 
         cquery_nofail(e, "ALTER SERVICE LEVEL sl WITH timeout = 35s");
 
@@ -313,10 +312,9 @@ SEASTAR_TEST_CASE(test_alter_with_workload_type) {
 
         auto sl_is_v2 = e.local_client_state().get_service_level_controller().is_v2();
 	    auto msg = cquery_nofail(e, format("SELECT workload_type FROM {}", sl_is_v2 ? "system.service_levels_v2" : "system_distributed.service_levels"));
-        assert_that(msg).is_rows().with_rows({
-            {{}},
-            {"batch"}, // `sl:driver`
-        });
+        assert_that(msg).is_rows().with_rows({{
+            {}
+        }});
 
         e.refresh_client_state().get();
         // Default workload type is `unspecified`

--- a/test/boost/cql_query_test.cc
+++ b/test/boost/cql_query_test.cc
@@ -5202,16 +5202,14 @@ SEASTAR_TEST_CASE(test_user_based_sla_queries) {
         e.execute_cql("ALTER SERVICE_LEVEL sl_1 WITH SHARES = 111;").get();
         msg = e.execute_cql("LIST ALL SERVICE_LEVELS;").get();
         assert_that(msg).is_rows().with_rows({
-            {utf8_type->decompose("driver"), {}, {utf8_type->decompose("batch")}, int32_type->decompose(200), utf8_type->decompose("39.14%")},
-            {utf8_type->decompose("sl_1"), {}, {}, int32_type->decompose(111), utf8_type->decompose("21.72%")},
-            {utf8_type->decompose("sl_2"), {}, {}, int32_type->decompose(200), utf8_type->decompose("39.14%")},
+            {utf8_type->decompose("sl_1"), {}, {}, int32_type->decompose(111), utf8_type->decompose("35.69%")},
+            {utf8_type->decompose("sl_2"), {}, {}, int32_type->decompose(200), utf8_type->decompose("64.31%")},
         });
         //drop service levels
         e.execute_cql("DROP SERVICE_LEVEL sl_1;").get();
         msg = e.execute_cql("LIST ALL SERVICE_LEVELS;").get();
         assert_that(msg).is_rows().with_rows({
-            {utf8_type->decompose("driver"), {}, {utf8_type->decompose("batch")}, int32_type->decompose(200), utf8_type->decompose("50.00%")},
-            {utf8_type->decompose("sl_2"), {}, {}, int32_type->decompose(200), utf8_type->decompose("50.00%")},
+            {utf8_type->decompose("sl_2"), {}, {}, int32_type->decompose(200), utf8_type->decompose("100.00%")},
         });
 
         // validate exceptions (illegal requests)

--- a/test/boost/database_test.cc
+++ b/test/boost/database_test.cc
@@ -1302,7 +1302,7 @@ SEASTAR_THREAD_TEST_CASE(per_service_level_reader_concurrency_semaphore_test) {
         sharded<qos::service_level_controller>& sl_controller = e.service_level_controller_service();
         std::array<sstring, num_service_levels> sl_names;
         qos::service_level_options slo;
-        size_t expected_total_weight = 200; // 200 from `sl:driver`
+        size_t expected_total_weight = 0;
         auto index_to_weight = [] (size_t i) -> size_t {
             return (i + 1)*100;
         };
@@ -1328,8 +1328,6 @@ SEASTAR_THREAD_TEST_CASE(per_service_level_reader_concurrency_semaphore_test) {
             BOOST_REQUIRE_EQUAL(expected_total_weight, dbt.get_total_user_reader_concurrency_semaphore_weight());
             sl_names[i] = sl_name;
             size_t total_distributed_memory = 0;
-            // Include `sl:driver` in computations
-            total_distributed_memory += get_reader_concurrency_semaphore_for_sl("driver").available_resources().memory;
             for (unsigned j = 0 ; j <= i ; j++) {
                 reader_concurrency_semaphore& sem = get_reader_concurrency_semaphore_for_sl(sl_names[j]);
                 // Make sure that all semaphores that has been created until now - have the right amount of available memory

--- a/test/boost/generic_server_test.cc
+++ b/test/boost/generic_server_test.cc
@@ -29,7 +29,6 @@ protected:
     [[noreturn]] shared_ptr<connection> make_connection(socket_address, connected_socket&&, socket_address, named_semaphore& sem, semaphore_units<named_semaphore_exception_factory> initial_sem_units) override {
         SCYLLA_ASSERT(false);
     }
-    scheduling_group get_scheduling_group_for_new_connection() const override { return current_scheduling_group(); }
 };
 
 SEASTAR_TEST_CASE(stop_without_listening) {

--- a/test/cluster/auth_cluster/test_raft_service_levels.py
+++ b/test/cluster/auth_cluster/test_raft_service_levels.py
@@ -11,20 +11,16 @@ from test.pylib.rest_client import get_host_api_address, read_barrier
 from test.pylib.util import unique_name, wait_for_cql_and_get_hosts
 from test.pylib.manager_client import ManagerClient
 from test.cluster.util import trigger_snapshot, wait_until_topology_upgrade_finishes, enter_recovery_state, reconnect_driver, \
-        delete_raft_topology_state, delete_raft_data_and_upgrade_state, wait_until_upgrade_finishes, \
-        wait_for_token_ring_and_group0_consistency, wait_until_driver_service_level_created, get_topology_coordinator, \
-        find_server_by_host_id
+        delete_raft_topology_state, delete_raft_data_and_upgrade_state, wait_until_upgrade_finishes, wait_for_token_ring_and_group0_consistency
 from test.cluster.conftest import skip_mode
-from test.cqlpy.test_service_levels import MAX_USER_SERVICE_LEVELS
 from cassandra import ConsistencyLevel
 from cassandra.query import SimpleStatement
-from cassandra.protocol import InvalidRequest, QueryMessage
+from cassandra.protocol import InvalidRequest
 from cassandra.auth import PlainTextAuthProvider
 from test.cluster.auth_cluster import extra_scylla_config_options as auth_config
 
 
 logger = logging.getLogger(__name__)
-DRIVER_SL_NAME = "driver"
 
 @pytest.mark.asyncio
 async def test_service_levels_snapshot(manager: ManagerClient):
@@ -102,17 +98,16 @@ async def test_service_levels_upgrade(request, manager: ManagerClient, build_mod
 
     logging.info("Waiting until upgrade finishes")
     await asyncio.gather(*(wait_until_topology_upgrade_finishes(manager, h.address, time.time() + 60) for h in hosts))
-    await wait_until_driver_service_level_created(cql, time.time() + 60)
 
     result_v2 = await cql.run_async("SELECT service_level FROM system.service_levels_v2")
-    assert set([sl.service_level for sl in result_v2]) == set(sls + [DRIVER_SL_NAME])
+    assert set([sl.service_level for sl in result_v2]) == set(sls)
 
     sl_v2 = "sl" + unique_name()
     await cql.run_async(f"CREATE SERVICE LEVEL {sl_v2}")
 
     await asyncio.gather(*(read_barrier(manager.api, get_host_api_address(host)) for host in hosts))
     result_with_sl_v2 = await cql.run_async(f"SELECT service_level FROM system.service_levels_v2")
-    assert set([sl.service_level for sl in result_with_sl_v2]) == set(sls + [DRIVER_SL_NAME] + [sl_v2])
+    assert set([sl.service_level for sl in result_with_sl_v2]) == set(sls + [sl_v2])
 
 @pytest.mark.asyncio
 async def test_service_levels_work_during_recovery(manager: ManagerClient):
@@ -135,7 +130,7 @@ async def test_service_levels_work_during_recovery(manager: ManagerClient):
     logging.info("Validating service levels were created in v2 table")
     result = await cql.run_async("SELECT service_level FROM system.service_levels_v2")
     for sl in result:
-        assert sl.service_level in sls + [DRIVER_SL_NAME]
+        assert sl.service_level in sls
 
     logging.info(f"Restarting hosts {hosts} in recovery mode")
     await asyncio.gather(*(enter_recovery_state(cql, h) for h in hosts))
@@ -148,7 +143,7 @@ async def test_service_levels_work_during_recovery(manager: ManagerClient):
     logging.info("Checking service levels can be read and v2 table is used")
     recovery_result = await cql.run_async("LIST ALL SERVICE LEVELS")
     assert sl_v1 not in [sl.service_level for sl in recovery_result]
-    assert set([sl.service_level for sl in recovery_result]) == set(sls + [DRIVER_SL_NAME])
+    assert set([sl.service_level for sl in recovery_result]) == set(sls)
 
     logging.info("Checking changes to service levels are forbidden during recovery")
     with pytest.raises(InvalidRequest, match="The cluster is in recovery mode. Changes to service levels are not allowed."):
@@ -174,7 +169,6 @@ async def test_service_levels_work_during_recovery(manager: ManagerClient):
     await manager.servers_see_each_other(servers)
     await manager.api.upgrade_to_raft_topology(hosts[0].address)
     await asyncio.gather(*(wait_until_topology_upgrade_finishes(manager, h.address, time.time() + 60) for h in hosts))
-    await wait_until_driver_service_level_created(cql, time.time() + 60)
 
     logging.info("Validating service levels works in v2 mode after leaving recovery")
     new_sl = "sl" + unique_name()
@@ -182,7 +176,7 @@ async def test_service_levels_work_during_recovery(manager: ManagerClient):
 
     sls_list = await cql.run_async("LIST ALL SERVICE LEVELS")
     assert sl_v1 not in [sl.service_level for sl in sls_list]
-    assert set([sl.service_level for sl in sls_list]) == set(sls + [new_sl] + [DRIVER_SL_NAME])
+    assert set([sl.service_level for sl in sls_list]) == set(sls + [new_sl])
 
 def default_timeout(mode):
     if mode == "dev":
@@ -338,7 +332,7 @@ async def test_service_level_cache_after_restart(manager: ManagerClient):
     await cql.run_async(f"CREATE SERVICE LEVEL sl1 WITH timeout=500ms AND workload_type='batch'")
 
     sls_list_before = await cql.run_async("LIST ALL SERVICE LEVELS")
-    assert len(sls_list_before) == 2
+    assert len(sls_list_before) == 1
 
     await manager.rolling_restart(servers)
     cql = await reconnect_driver(manager)
@@ -354,7 +348,7 @@ async def test_service_level_cache_after_restart(manager: ManagerClient):
     await cql.run_async(f"ALTER SERVICE LEVEL sl1 WITH timeout = 400ms")
 
     result = await cql.run_async("SELECT workload_type FROM system.service_levels_v2")
-    assert len(result) == 2 and result[0].workload_type == 'batch' and result[1].workload_type == 'batch'
+    assert len(result) == 1 and result[0].workload_type == 'batch'
 
 @pytest.mark.asyncio
 @skip_mode('release', 'error injection is disabled in release mode')
@@ -439,8 +433,9 @@ async def test_service_levels_over_limit(manager: ManagerClient):
     cql = manager.get_cql()
     hosts = await wait_for_cql_and_get_hosts(cql, [srv], time.time() + 60)
 
+    SL_LIMIT = 7
     sls = []
-    for i in range(MAX_USER_SERVICE_LEVELS + 1):
+    for i in range(SL_LIMIT + 1):
         sl = f"sl_{i}_{unique_name()}"
         sls.append(sl)
         await cql.run_async(f"CREATE SERVICE LEVEL {sl}")
@@ -500,152 +495,3 @@ async def test_reload_service_levels_after_auth_service_is_stopped(manager: Mana
     config = {**auth_config, "error_injections_at_startup": ["reload_service_level_cache_after_auth_service_is_stopped"]}
     s1 = await manager.server_add(config=config)
     await manager.server_stop_gracefully(s1.server_id)
-
-@pytest.mark.asyncio
-async def test_driver_service_level(manager: ManagerClient) -> None:
-    servers = await manager.servers_add(2, config=auth_config, auto_rack_dc="dc1")
-
-    cql = manager.get_cql()
-    hosts = await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
-    await wait_for_token_ring_and_group0_consistency(manager, time.time() + 30)
-
-    logger.info("Verify that sl:driver is created properly on system startup")
-    service_levels = await cql.run_async("LIST ALL SERVICE LEVELS")
-    assert len(service_levels) == 1
-    assert service_levels[0].service_level == "driver"
-    assert service_levels[0].workload_type == "batch"
-    assert service_levels[0].shares == 200
-    assert (await cql.run_async("SELECT value FROM system.scylla_local WHERE key = 'service_level_driver_created'"))[0].value == "true"
-
-    logger.info("Verify that sl:driver can be removed")
-    await cql.run_async(f"DROP SERVICE LEVEL driver")
-    assert len(await cql.run_async("LIST ALL SERVICE LEVELS")) == 0
-
-    logger.info("Add a new server so that the Raft state machine snapshot is used")
-    new_servers = await manager.servers_add(1, config=auth_config, auto_rack_dc="dc1")
-
-    logger.info("Verify that sl:driver is not re-created even after topology coordinator reload")
-    coord = await get_topology_coordinator(manager)
-    coord_serv = await find_server_by_host_id(manager, servers, coord)
-    await manager.api.reload_raft_topology_state(coord_serv.ip_addr)
-
-    hosts = await wait_for_cql_and_get_hosts(cql, servers + new_servers, time.time() + 60)
-    for host in hosts:
-        assert len(await cql.run_async("LIST ALL SERVICE LEVELS", host=host)) == 0
-
-@pytest.mark.asyncio
-async def test_driver_service_creation_failure(manager: ManagerClient) -> None:
-    servers = await manager.servers_add(2, config=auth_config, auto_rack_dc="dc1")
-
-    cql = manager.get_cql()
-    hosts = await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
-    await wait_for_token_ring_and_group0_consistency(manager, time.time() + 30)
-
-    logger.info("Drop sl:driver to prepare the system state and re-create it later")
-    await cql.run_async(f"DROP SERVICE LEVEL driver")
-
-    logger.info("Create new service levels to occupy all slots, including the slot of the removed sl:driver")
-    for i in range(MAX_USER_SERVICE_LEVELS + 1):
-        await cql.run_async(f"CREATE SERVICE_LEVEL new_sl_{i}")
-
-    logger.info("Verify that all newly created service levels exist")
-    service_levels = await cql.run_async("LIST ALL SERVICE LEVELS")
-    service_level_names = [sl.service_level for sl in service_levels]
-    for i in range(MAX_USER_SERVICE_LEVELS + 1):
-        assert f"new_sl_{i}" in service_level_names
-    assert "driver" not in service_level_names
-
-    logger.info("Check the logs to see that sl:driver creation failed")
-    coord = await get_topology_coordinator(manager)
-    coord_serv = await find_server_by_host_id(manager, servers, coord)
-    log_file = await manager.server_open_log(coord_serv.server_id)
-    mark = await log_file.mark()
-
-    logger.info("Set service_level_driver_created=false in system.scylla_local and reload topology coordinator")
-    for host in hosts:
-        await cql.run_async(f"UPDATE system.scylla_local SET value = 'false' WHERE key = 'service_level_driver_created'", host=host)
-    await manager.api.reload_raft_topology_state(coord_serv.ip_addr)
-    await log_file.wait_for("Failed to create service level for driver", from_mark=mark)
-
-    logger.info("Verify topology coordinator is not blocked despite the failure")
-    mark = await log_file.mark()
-    await manager.api.reload_raft_topology_state(coord_serv.ip_addr)
-    await log_file.wait_for("topology coordinator fiber has nothing to do. Sleeping.", from_mark=mark)
-
-    logger.info("Double-check that the driver is not re-created")
-    for host in hosts:
-        service_levels = await cql.run_async("LIST ALL SERVICE LEVELS", host=host)
-        service_level_names = [sl.service_level for sl in service_levels]
-        assert "driver" not in service_level_names
-
-def get_processed_tasks_for_group(metrics, group):
-    res = metrics.get("scylla_scheduler_tasks_processed", {'group': group})
-    if res is None:
-        return 0
-    return res
-
-@pytest.mark.asyncio
-async def _verify_tasks_processed_metrics(manager, server, used_group, unused_group, func):
-    number_of_requests = 1000
-
-    def get_processed_tasks_for_group(metrics, group):
-        res = metrics.get("scylla_scheduler_tasks_processed", {'group': group})
-        if res is None:
-            return 0
-        return res
-
-    metrics = await manager.metrics.query(server.ip_addr)
-    initial_tasks_processed_by_used_group = get_processed_tasks_for_group(metrics, used_group)
-    initial_tasks_processed_by_unused_group = get_processed_tasks_for_group(metrics, unused_group)
-
-    await asyncio.gather(*[asyncio.to_thread(func) for i in range(number_of_requests)])
-
-    metrics = await manager.metrics.query(server.ip_addr)
-    assert get_processed_tasks_for_group(metrics, used_group) - initial_tasks_processed_by_used_group > number_of_requests
-    assert get_processed_tasks_for_group(metrics, unused_group) - initial_tasks_processed_by_unused_group < number_of_requests
-
-@pytest.mark.asyncio
-async def test_driver_service_level_not_used_for_user_queries(manager: ManagerClient) -> None:
-    server = await manager.server_add(config=auth_config)
-
-    cql = manager.get_cql()
-    [h] = await wait_for_cql_and_get_hosts(cql, [server], time.time() + 60)
-    await wait_for_token_ring_and_group0_consistency(manager, time.time() + 30)
-
-    func = lambda: cql.execute(f"SELECT * from system.peers")
-    await _verify_tasks_processed_metrics(manager, server, 'sl:default', 'sl:driver', func)
-
-    await cql.run_async(f"CREATE SERVICE LEVEL test", host=h)
-    await cql.run_async(f"ATTACH SERVICE LEVEL test TO cassandra", host=h)
-
-    func = lambda: cql.execute(f"SELECT * from system.peers")
-    await _verify_tasks_processed_metrics(manager, server, 'sl:test', 'sl:driver', func)
-
-@pytest.mark.asyncio
-async def test_driver_service_level_used_for_driver_queries(manager: ManagerClient) -> None:
-    server = await manager.server_add(config=auth_config)
-
-    cql = manager.get_cql()
-    [h] = await wait_for_cql_and_get_hosts(cql, [server], time.time() + 60)
-    await wait_for_token_ring_and_group0_consistency(manager, time.time() + 30)
-
-    await cql.run_async(f"CREATE SERVICE LEVEL test", host=h)
-    await cql.run_async(f"ATTACH SERVICE LEVEL test TO cassandra", host=h)
-
-    async def get_control_connection_query_function(manager):
-        await manager.driver_connect() # restart control connection
-        cql = manager.get_cql()
-        control_connection = cql.cluster.control_connection._connection
-        query = QueryMessage("select * from system.peers", 1)
-        return cql, lambda: control_connection.wait_for_response(query)
-
-    cql, func = await get_control_connection_query_function(manager)
-    await _verify_tasks_processed_metrics(manager, server, 'sl:driver', 'sl:test', func)
-
-    await cql.run_async(f"DROP SERVICE LEVEL driver", host=h)
-    cql, func = await get_control_connection_query_function(manager)
-    await _verify_tasks_processed_metrics(manager, server, 'sl:test', 'sl:driver', func)
-
-    await cql.run_async(f"CREATE SERVICE LEVEL driver", host=h)
-    cql, func = await get_control_connection_query_function(manager)
-    await _verify_tasks_processed_metrics(manager, server, 'sl:driver', 'sl:test', func)

--- a/test/cluster/util.py
+++ b/test/cluster/util.py
@@ -204,11 +204,6 @@ async def wait_until_topology_upgrade_finishes(manager: ManagerClient, ip_addr: 
         return status == "done" or None
     await wait_for(check, deadline=deadline, period=1.0)
 
-async def wait_until_driver_service_level_created(cql: Session, deadline: float):
-    async def check():
-        service_levels = await cql.run_async("LIST ALL SERVICE_LEVELS")
-        return ("driver" in [sl.service_level for sl in service_levels]) or None
-    await wait_for(check, deadline=deadline, period=1.0)
 
 async def delete_raft_topology_state(cql: Session, host: Host):
     await cql.run_async("truncate table system.topology", host=host)

--- a/test/cqlpy/test_describe.py
+++ b/test/cqlpy/test_describe.py
@@ -15,7 +15,6 @@ from contextlib import contextmanager, ExitStack
 from .util import new_type, unique_name, new_test_table, new_test_keyspace, new_function, new_aggregate, \
     new_cql, keyspace_has_tablets, unique_name_prefix, new_session, new_user, new_materialized_view, \
     new_secondary_index
-from .test_service_levels import MAX_USER_SERVICE_LEVELS
 from cassandra.protocol import InvalidRequest, Unauthorized
 from collections.abc import Iterable
 from typing import Any
@@ -47,12 +46,8 @@ def filter_grant_roles(desc_result_iter: Iterable[DescRowType]) -> Iterable[Desc
 def filter_grant_permissions(desc_result_iter: Iterable[DescRowType]) -> Iterable[DescRowType]:
     return filter(lambda result: result.type == "grant_permission", desc_result_iter)
 
-def filter_service_levels(desc_result_iter: Iterable[DescRowType], filter_driver: bool = True) -> Iterable[DescRowType]:
-    # Filter out driver service level, which is created by the system automatically
-    f = lambda result: result.type == "service_level"
-    if filter_driver:
-        f = (lambda result: result.type == "service_level" and result.name != "driver")
-    return filter(f, desc_result_iter)
+def filter_service_levels(desc_result_iter: Iterable[DescRowType]) -> Iterable[DescRowType]:
+    return filter(lambda result: result.type == "service_level", desc_result_iter)
 
 def filter_attached_service_levels(desc_result_iter: Iterable[DescRowType]) -> Iterable[DescRowType]:
     return filter(lambda result: result.type == "service_level_attachment", desc_result_iter)
@@ -1614,7 +1609,6 @@ class AuthSLContext:
     def __enter__(self):
         if self.ks:
             self.cql.execute(f"CREATE KEYSPACE {self.ks} WITH REPLICATION = {{ 'class': 'SimpleStrategy', 'replication_factor': 1 }}")
-        self.driver_sl = self.cql.execute("LIST SERVICE LEVEL driver").one()
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb) -> None:
@@ -1632,9 +1626,6 @@ class AuthSLContext:
             service_levels = [record.service_level for record in service_levels_iter]
             for sl in service_levels:
                 self.cql.execute(f"DROP SERVICE LEVEL {make_identifier(sl, quotation_mark='"')}")
-            # Restore driver service level if it was removed by the test
-            self.cql.execute(f"CREATE SERVICE LEVEL {self.driver_sl.service_level} WITH WORKLOAD_TYPE = '{self.driver_sl.workload_type}' AND SHARES = {self.driver_sl.shares}")
-
 
 class ServiceLevel:
     default_shares_value = 1000
@@ -2876,87 +2867,6 @@ def test_desc_auth_attach_service_levels(cql, scylla_only):
         desc_iter = extract_create_statements(desc_iter)
 
         assert set(sl_stmts) == set(desc_iter)
-
-# Marked as `scylla_only` because we verify that the output of `DESCRIBE SCHEMA`
-# contains information about service levels. That's not the case in Cassandra.
-def test_desc_driver_service_level(cql, scylla_only):
-    """
-    Driver service level is a special service level that is created automatically by
-    the system. Therefore, it requires special handling in DESC SCHEMA WITH INTERNALS -
-    if `sl:driver` exists, instead of just emiting `CREATE SERVICE LEVEL ...` we emit two
-    lines:
-      1. CREATE SERVICE LEVEL IF NOT EXISTS driver ...
-      2. ALTER SERVICE LEVEL driver ...
-
-    The reasons for this are:
-     1. We need to ensure CREATE SERVICE LEVEL doesn't fail if the service level already exists
-        (i.e. IF NOT EXISTS in CREATE) when restoring a backup from `DESC SCHEMA WITH INTERNALS`.
-     2. `ALTER SERVICE...` is needed to fully restore the configuration of `sl:driver`
-    """
-
-    with AuthSLContext(cql):
-        cql.execute(f"ALTER SERVICE LEVEL driver WITH SHARES=123")
-        cql.execute(f"ALTER SERVICE LEVEL driver WITH TIMEOUT=321s")
-
-        desc_iter = cql.execute("DESC SCHEMA WITH INTERNALS")
-        desc_iter = filter_service_levels(desc_iter, filter_driver=False)
-
-        [create, alter] = list(desc_iter)
-
-        assert create.keyspace_name == None
-        assert create.type == "service_level"
-        assert create.name == "driver"
-        assert create.create_statement == "CREATE SERVICE LEVEL IF NOT EXISTS driver WITH TIMEOUT = 321000ms AND WORKLOAD_TYPE = 'batch' AND SHARES = 123;"
-
-        assert alter.keyspace_name == None
-        assert alter.type == "service_level"
-        assert alter.name == "driver"
-        assert alter.create_statement == "ALTER SERVICE LEVEL driver WITH TIMEOUT = 321000ms AND WORKLOAD_TYPE = 'batch' AND SHARES = 123;"
-
-# Marked as `scylla_only` because we verify that the output of `DESCRIBE SCHEMA`
-# contains information about service levels. That's not the case in Cassandra.
-def test_desc_removed_driver_service_level(cql, scylla_only):
-    """
-    Driver service level is a special service level that is created automatically by
-    the system. Therefore, it requires special handling in DESC SCHEMA WITH INTERNALS -
-    if `sl:driver` doesn't exist we emit `DROP SERVICE LEVEL IF EXISTS ...` because that means
-    someone intentionally removed it.
-    """
-    with AuthSLContext(cql):
-        cql.execute("DROP SERVICE LEVEL driver")
-        desc_iter = cql.execute("DESC SCHEMA WITH INTERNALS")
-        desc_iter = filter_service_levels(desc_iter, filter_driver=False)
-
-        [drop] = list(desc_iter)
-
-        assert drop.keyspace_name == None
-        assert drop.type == "service_level"
-        assert drop.name == "driver"
-        assert drop.create_statement == "DROP SERVICE LEVEL IF EXISTS driver;"
-
-        # We need to ensure `DESC SCHEMA WITH INTERNALS` emits the `DROP ... driver` before
-        # any other service level is listed. Otherwise, restoring service level from the output
-        # of `DESC SCHEMA WITH INTERNALS` can fail, if there aren't sufficient slots to create
-        # all service levels. We test it with the following steps:
-        # 1. Create the maximal number of user scheduling groups + one to use the slot after `sl:driver`
-        # 2. Call `DESC SCHEMA WITH INTERNALS`, rembember the output
-        # 3. Drop all service levels
-        # 4. Execute statements from `DESC SCHEMA ...` output
-        for i in range(MAX_USER_SERVICE_LEVELS + 1): # sl:driver removed, so we can use an additional slot
-            # "a_sl" name to make sure "driver" service level will be listed in DESC SCHEMA even
-            # before service levels with lexicographically smaller name
-            cql.execute(f"CREATE SERVICE LEVEL a_sl{i}")
-
-        desc_iter = cql.execute("DESC SCHEMA WITH INTERNALS")
-        desc_iter = filter_service_levels(desc_iter, filter_driver=False)
-
-        service_levels_iter = cql.execute("LIST ALL SERVICE LEVELS")
-        service_levels = [record.service_level for record in service_levels_iter]
-        for sl in service_levels:
-            cql.execute(f"DROP SERVICE LEVEL {make_identifier(sl, quotation_mark='"')}")
-        cql.execute("CREATE SERVICE LEVEL driver WITH shares=200 AND workload_type='batch'")
-        for recreate_statement in desc_iter:
-            cql.execute(recreate_statement.create_statement)
 
 def test_desc_restore(cql):
     """

--- a/test/cqlpy/test_service_levels.py
+++ b/test/cqlpy/test_service_levels.py
@@ -18,11 +18,6 @@ from cassandra.util import Duration
 import pytest
 import time
 
-# MAX_USER_SERVICE_LEVELS represents the maximal number of service levels that users can create.
-# The value is documentented in `docs/features/workload-prioritization.rst`.
-# It's used for regression testing of user service level limit in this and other files.
-MAX_USER_SERVICE_LEVELS = 7
-
 @contextmanager
 def new_service_level(cql, timeout=None, workload_type=None, shares=None, role=None):
     params = ""
@@ -147,7 +142,7 @@ def test_list_effective_service_level_without_attached(scylla_only, cql):
         with pytest.raises(InvalidRequest, match=f"Role {role} doesn't have assigned any service level"):
             cql.execute(f"LIST EFFECTIVE SERVICE LEVEL OF {role}")
 
-# ScyllaDB limits the number of service levels to a small number (9 including 1 default and 1 driver service level).
+# Scylla Enterprise limits the number of service levels to a small number (8 including 1 default service level).
 # This test verifies that attempting to create more service levels than that results in an InvalidRequest error
 # and doesn't silently succeed. 
 # The test also has a regression check if a user can create exactly 7 service levels.
@@ -166,7 +161,7 @@ def test_scheduling_groups_limit(scylla_only, cql):
                 created_count = created_count + 1
 
     assert created_count > 0
-    assert created_count == MAX_USER_SERVICE_LEVELS # regression check
+    assert created_count == 7 # regression check
 
 def test_default_shares_in_listings(scylla_only, cql):
     with scylla_inject_error(cql, "create_service_levels_without_default_shares", one_shot=False), \

--- a/test/perf/perf_generic_server.cc
+++ b/test/perf/perf_generic_server.cc
@@ -70,7 +70,6 @@ public:
         return make_shared<test_connection>(*this, std::move(fd), sem, std::move(initial_sem_units), _conf);
     }
 
-    scheduling_group get_scheduling_group_for_new_connection() const override { return current_scheduling_group(); }
 
     test_server(const test_config& conf)
     : generic_server::server("test_server", plog,

--- a/test/pylib/rest_client.py
+++ b/test/pylib/rest_client.py
@@ -532,8 +532,6 @@ class ScyllaRESTAPIClient:
         params = {"cf": table, "key": key}
         return await self.client.get_json(f'/storage_service/natural_endpoints/{keyspace}', host=node_ip, params=params)
 
-    async def reload_raft_topology_state(self, node_ip: str):
-        await self.client.post("/storage_service/raft_topology/reload", node_ip)
 
 class ScyllaMetricsLine:
     def __init__(self, name: str, labels: dict, value: float):

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -12,7 +12,6 @@
 #include "cql3/statements/modification_statement.hh"
 #include <seastar/core/scheduling.hh>
 #include <seastar/core/semaphore.hh>
-#include "seastar/coroutine/switch_to.hh"
 #include "types/collection.hh"
 #include "types/list.hh"
 #include "types/set.hh"
@@ -639,7 +638,7 @@ cql_server::connection::connection(cql_server& server, socket_address server_add
     , _server(server)
     , _server_addr(server_addr)
     , _client_state(service::client_state::external_tag{}, server._auth_service, &server._sl_controller, server.timeout_config(), addr)
-    , _current_scheduling_group(server.get_scheduling_group_for_new_connection())
+    , _current_scheduling_group(default_scheduling_group())
 {
     _shedding_timer.set_callback([this] {
         clogger.debug("Shedding all incoming requests due to overload");
@@ -984,7 +983,6 @@ future<std::unique_ptr<cql_server::response>> cql_server::connection::process_st
             res = make_autheticate(stream, a.qualified_java_name(), trace_state);
         }
     } else {
-        update_scheduling_group();
         _ready = true;
         on_connection_ready();
         res = make_ready(stream, trace_state);
@@ -994,19 +992,11 @@ future<std::unique_ptr<cql_server::response>> cql_server::connection::process_st
 }
 
 void cql_server::connection::update_scheduling_group() {
-    if (_client_state.is_control_connection()) {
-        switch_tenant([this] (noncopyable_function<future<> ()> process_loop) -> future<> {
-            auto shg = _server._sl_controller.get_scheduling_group(qos::service_level_controller::driver_service_level_name);
-            _current_scheduling_group = shg;
-            co_return co_await _server._sl_controller.with_service_level(qos::service_level_controller::driver_service_level_name, std::move(process_loop));
-        });
-    } else {
-        switch_tenant([this] (noncopyable_function<future<> ()> process_loop) -> future<> {
-            auto shg = co_await _server._sl_controller.get_user_scheduling_group(_client_state.user());
-            _current_scheduling_group = shg;
-            co_return co_await _server._sl_controller.with_user_service_level(_client_state.user(), std::move(process_loop));
-        });
-    }
+    switch_tenant([this] (noncopyable_function<future<> ()> process_loop) -> future<> {
+        auto shg = co_await _server._sl_controller.get_user_scheduling_group(_client_state.user());
+        _current_scheduling_group = shg;
+        co_return co_await _server._sl_controller.with_user_service_level(_client_state.user(), std::move(process_loop));
+    });
 }
 
 future<std::unique_ptr<cql_server::response>> cql_server::connection::process_auth_response(uint16_t stream, request_reader in, service::client_state& client_state,
@@ -1445,13 +1435,6 @@ future<std::unique_ptr<cql_server::response>>
 cql_server::connection::process_register(uint16_t stream, request_reader in, service::client_state& client_state,
         tracing::trace_state_ptr trace_state) {
     using ret_type = std::unique_ptr<cql_server::response>;
-
-    if (!_client_state.is_control_connection()) {
-        if (_server._sl_controller.has_service_level(qos::service_level_controller::driver_service_level_name)) {
-            _client_state.set_control_connection();
-            update_scheduling_group();
-        }
-    }
 
     std::vector<sstring> event_types;
     auto sl = in.read_string_list(event_types);

--- a/transport/server.hh
+++ b/transport/server.hh
@@ -367,12 +367,6 @@ private:
 
 private:
     virtual shared_ptr<generic_server::connection> make_connection(socket_address server_addr, connected_socket&& fd, socket_address addr, named_semaphore& sem, semaphore_units<named_semaphore_exception_factory> initial_sem_units) override;
-    scheduling_group get_scheduling_group_for_new_connection() const override {
-        if (_sl_controller.has_service_level(qos::service_level_controller::driver_service_level_name)) {
-            return _sl_controller.get_scheduling_group(qos::service_level_controller::driver_service_level_name);
-        }
-        return default_scheduling_group();
-    }
 
     ::timeout_config timeout_config() const { return _config.timeout_config.current_values(); }
 };


### PR DESCRIPTION

This reverts commit fe7e63f109b2f5fda46cf743e817e3e9c1fd4de8, reversing changes made to b5f3f2f4c549d30fa04780e7ee31dfc106f5b834. It is causing test.py failures around cqlpy.

Fixes #26163

Since the commit being reverted is not present in any release branch, no backport is needed.