### PR TITLE
doc: update Cloud Instance Recommendations for GCP

### DIFF
--- a/docs/getting-started/cloud-instance-recommendations.rst
+++ b/docs/getting-started/cloud-instance-recommendations.rst
@@ -209,7 +209,7 @@ Image with NVMe disk interface is recommended.
 (`More info <https://cloud.google.com/compute/docs/disks/local-ssd>`_)
 
 Recommended instances types are `z3-highmem-highlssd, z3-highmem-standardlssd <https://cloud.google.com/compute/docs/storage-optimized-machines#z3_machine_types>`_,
-and `n2-highmem <https://cloud.google.com/compute/docs/general-purpose-machines#n2_machines>`_.
+and `n2-highmem <https://cloud.google.com/compute/docs/general-purpose-machines#n2_series>`_.
 
 
 .. list-table::
@@ -274,6 +274,10 @@ and `n2-highmem <https://cloud.google.com/compute/docs/general-purpose-machines#
      - 1,406
      - 36,000 
 
+* Storage: Each Z3 instance supports up to 36,000 GiB (~36 TiB) of local
+  Titanium SSD (or up to 72,000 GiB on bare-metal).
+* Z3 Processor: Sapphire Rapids
+
 .. list-table::
    :widths: 30 20 20 30
    :header-rows: 1
@@ -314,9 +318,15 @@ and `n2-highmem <https://cloud.google.com/compute/docs/general-purpose-machines#
      - 80
      - 640
      - 9,000
+   * - n2-highmem-96
+     - 96
+     - 768
+     - 9,000
 
-
-Storage: each instance can support  maximum of 24 local SSD of 375 GB partitions each for a total of `9 TB per instance <https://cloud.google.com/compute/docs/disks>`_       
+* Storage: Each instance can support  maximum of 24 local SSD of 375 GB
+  partitions each for a total of `9 TB per instance <https://cloud.google.com/compute/docs/disks>`_.
+* Processors: Ice Lake (the default for larger machine types) and Cascade Lake
+  (the default for machine types up to 80 vCPUs).
 
 .. _system-requirements-azure:
 


### PR DESCRIPTION
This PR:
- Removes n1-highmem instances from Recommended Instances.
- Adds missing support for n2-highmem-96.
- Updates the reference to n2 instances in the Google Cloud docs (fixes a broken link to GCP).
- Adds the missing information about processors for n2-highmem-instance - Ice Lake and Cascade Lake (requested by CX).

Fixes https://github.com/scylladb/scylladb/issues/25946
Fixes https://github.com/scylladb/scylladb/issues/24223
Fixes https://github.com/scylladb/scylladb/issues/23976

No backport needed if this PR is merged before 2025.4 branching.