### PR TITLE
cmake: introduce `Scylla_WITH_DEBUG_INFO` option

### DIFF
--- a/cmake/mode.common.cmake
+++ b/cmake/mode.common.cmake
@@ -135,6 +135,8 @@ function(maybe_limit_stack_usage_in_KB stack_usage_threshold_in_KB config)
   endif()
 endfunction()
 
+option(Scylla_WITH_DEBUG_INFO "Enable debug info" OFF)
+
 macro(update_build_flags config)
   cmake_parse_arguments (
     parsed_args
@@ -150,7 +152,7 @@ macro(update_build_flags config)
   set(linker_flags "CMAKE_EXE_LINKER_FLAGS_${CONFIG}")
   string(APPEND ${cxx_flags}
     " -O${parsed_args_OPTIMIZATION_LEVEL}")
-  if(parsed_args_WITH_DEBUG_INFO)
+  if(parsed_args_WITH_DEBUG_INFO OR ${Scylla_WITH_DEBUG_INFO})
     string(APPEND ${cxx_flags} " -g -gz")
   else()
     # If Scylla is compiled without debug info, strip the debug symbols from

--- a/configure.py
+++ b/configure.py
@@ -2927,6 +2927,7 @@ def configure_using_cmake(args):
         'Scylla_TEST_TIMEOUT': args.test_timeout,
         'Scylla_TEST_REPEAT': args.test_repeat,
         'Scylla_ENABLE_LTO': 'ON' if args.lto else 'OFF',
+        'Scylla_WITH_DEBUG_INFO' : 'ON' if args.debuginfo else 'OFF',
     }
     if args.date_stamp:
         settings['Scylla_DATE_STAMP'] = args.date_stamp


### PR DESCRIPTION
The `configure.py` script has an `--debuginfo` option that allows overriding compiler debug information generation, regardless of the build mode. Add a similar option to CMake, and ensure it is set when CMake is invoked from `configure.py` with `--debuginfo` enabled.

CMake improvement. Backport not required.