### PR TITLE
code: Use tls_options::bye_timeout instead of deprecated switch

### DIFF
--- a/ent/encryption/azure_host.cc
+++ b/ent/encryption/azure_host.cc
@@ -392,7 +392,7 @@ future<rjson::value> azure_host::impl::send_request(const sstring& host, unsigne
         // may appear only in testing.
         bool is_numeric_host = seastar::net::inet_address::parse_numerical(host).has_value();
         sstring server_name = is_numeric_host ? sstring{} : host;
-        options = { .wait_for_eof_on_shutdown = false, .server_name = server_name };
+        options = { .server_name = server_name, .bye_timeout = std::chrono::seconds(0) };
     }
 
     rest::httpclient client(host, port, std::move(creds), options);

--- a/utils/azure/identity/service_principal_credentials.cc
+++ b/utils/azure/identity/service_principal_credentials.cc
@@ -164,7 +164,7 @@ future<sstring> service_principal_credentials::post(const sstring& body) {
 
     if (_is_secured) {
         creds = co_await make_creds(_truststore, _priority_string);
-        options = { .wait_for_eof_on_shutdown = false, .server_name = _host };
+        options = { .server_name = _host, .bye_timeout = std::chrono::seconds(0) };
     }
 
     rest::httpclient client{_host, _port, std::move(creds), options};


### PR DESCRIPTION
Some code wants its TLS sockets to close immediately without sending BYE message and waiting for the response. Recent seastar update changed the way this functionality is requested (scylladb/seastar#2986)

Related to seastar update, so no backport needed (unless that seastar TLS fix is itself backported)