### PR TITLE
tablets: fix creating colocated table of colocated table

### DIFF
--- a/locator/tablets.cc
+++ b/locator/tablets.cc
@@ -370,6 +370,10 @@ future<> tablet_metadata::set_colocated_table(table_id id, table_id base_id) {
         _table_groups.erase(it);
     }
 
+    if (!_table_groups.contains(base_id)) {
+        on_internal_error(tablet_logger, format("Trying to set co-located table {} with base table {} but it's not a base table.", id, base_id));
+    }
+
     if (auto it = _base_table.find(id); it == _base_table.end()) {
         _base_table[id] = base_id;
         _table_groups[base_id].push_back(id);

--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -3268,7 +3268,11 @@ public:
             for (auto s : cfms) {
                 std::optional<table_id> base_id;
                 if (colocated_tablets_enabled) {
-                    base_id = _db.get_base_table_for_tablet_colocation(*s, new_cfms_map);
+                    // choose base table for colocation.
+                    // if our base table is a colocated table, take its base table as our base table, because we
+                    // want to have only a single level of colocation.
+                    base_id = _db.get_base_table_for_tablet_colocation(*s, new_cfms_map)
+                        .transform([&] (table_id id) { return tm->tablets().get_base_table(id); });
                 }
                 table_groups[base_id.value_or(s->id())].push_back(s);
             }


### PR DESCRIPTION
With colocated tables, a table can be created as colocated with another base table. It is assumed that that the base table itself is a normal non-colocated table.

This was assumed implicitly until now and it relied on some assumptions about how colocated tables are used in practice, but it turned out that there are scenarios where a colocated table of a colocated table would be created - for example if performing LWT reads on a colocated MV table, this would create a colocated paxos table for the MV.

We fix this by checking if the candidate base table of a new table is a colocated table itself, and if so we take its base table as the new table's base table, and this way we always maintain a single level of colocation.

Fixes scylladb/scylladb#26258

no backport - colocated tablets is not released yet