### PR TITLE
service/storage_proxy: send batches with CL=EACH_QUORUM

### DIFF
--- a/db/batchlog_manager.cc
+++ b/db/batchlog_manager.cc
@@ -245,12 +245,6 @@ future<> db::batchlog_manager::replay_all_failed_batches(post_replay_cleanup cle
             // FIXME: verify that the above is reasonably true.
             return limiter->reserve(size).then([this, mutations = std::move(mutations)] {
                 _stats.write_attempts += mutations.size();
-                // #1222 - change cl level to ALL, emulating origins behaviour of sending/hinting
-                // to all natural end points.
-                // Note however that origin uses hints here, and actually allows for this
-                // send to partially or wholly fail in actually sending stuff. Since we don't
-                // have hints (yet), send with CL=ALL, and hope we can re-do this soon.
-                // See below, we use retry on write failure.
                 auto timeout = db::timeout_clock::now() + write_timeout;
                 return _qp.proxy().send_batchlog_replay_to_all_replicas(std::move(mutations), timeout);
             });

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -4398,7 +4398,7 @@ future<> storage_proxy::send_batchlog_replay_to_all_replicas(utils::chunked_vect
             return batchlog_replay_mutation(std::move(m));
         }) | std::ranges::to<utils::chunked_vector<batchlog_replay_mutation>>();
 
-    return mutate_internal(std::move(ms), db::consistency_level::ALL, nullptr, empty_service_permit(), timeout, db::write_type::BATCH)
+    return mutate_internal(std::move(ms), db::consistency_level::EACH_QUORUM, nullptr, empty_service_permit(), timeout, db::write_type::BATCH)
             .then(utils::result_into_future<result<>>);
 }
 


### PR DESCRIPTION
Batches that fail on the initial send are retired later, until they succeed. These retires happen with CL=ALL, regardless of what the original CL of the batch was. This is unnecessarily strict. We tried to follow Cassandra here, but Cassandra has a big caveat in their use of CL=ALL for batches. They accept saving just a hint for any/all of the endpoints, so a batch which was just logged in hints is good enough for them.
We do not plan on replicating this usage of hints at this time, so as a middle ground, the CL is changed to EACH_QUORUM.

Fixes: scylladb/scylladb#25432

Minor improvement, no backport required, unless we find a case on the field to justify it.