### PR TITLE
raft topology: make the voter handler consider only group 0 members

### DIFF
--- a/service/raft/group0_voter_handler.cc
+++ b/service/raft/group0_voter_handler.cc
@@ -497,7 +497,15 @@ future<> group0_voter_handler::update_nodes(
     };
 
     // Helper for adding a single node to the nodes list
-    auto add_node = [&nodes, &group0_config, &leader_id](const raft::server_id& id, const replica_state& rs, bool is_alive) {
+    auto add_node = [this, &nodes, &group0_config, &leader_id](const raft::server_id& id, const replica_state& rs, bool is_alive) {
+        // Some topology members may not belong to the new group 0 in the Raft-based recovery procedure.
+        if (!group0_config.contains(id)) {
+            if (!_gossiper.get_recovery_leader()) {
+                rvlogger.warn("node {} in state {} is not a part of the group 0 configuration {}, ignoring",
+                        id, rs.state, group0_config);
+            }
+            return;
+        }
         const auto is_voter = group0_config.can_vote(id);
         const auto is_leader = (id == leader_id);
         nodes.emplace(id, group0_voter_calculator::node_descriptor{


### PR DESCRIPTION
raft topology: make the voter handler consider only group 0 members

In the Raft-based recovery procedure, we create a new group 0 and add
live nodes to it one by one. This means that for some time there are
nodes which belong to the topology, but not to the new group 0. The
voter handler running on the recovery leader incorrectly considers these
nodes while choosing voters.

The consequences:
- misleading logs, for example, "making servers {`<ID of a non-member>`}
  voters", where the non-member won't become a voter anyway,
- increased chance of majority loss during the recovery procedure, for
  example, all 3 nodes that first joined the new group 0 are in the same
  dc and rack, but only one of them becomes a voter because the voter
  handler tries to make non-members in other dcs/racks voters.

Fixes #26321

Not a critical bug, but the fix is very low risk (simple, affects only the
recovery procedure), so we can backport it to 2025.2 and newer
branches (2025.1 doesn't have the voter handler and the recovery
procedure).