### PR TITLE
dist: detect corrupted NUMA topology information

### DIFF
--- a/dist/common/scripts/scylla_prepare
+++ b/dist/common/scripts/scylla_prepare
@@ -93,6 +93,10 @@ def create_perftune_conf(cfg):
     """
     params = ''
     if get_set_nic_and_disks_config_value(cfg) == 'yes':
+        if not check_sysfs_numa_topology_is_valid():
+            print('WARNING: NUMA topology information is corrupted, skip running perftune')
+            return False
+
         nic = cfg.get('IFNAME')
         if not nic:
             nic = 'eth0'
@@ -108,6 +112,10 @@ def create_perftune_conf(cfg):
         params += ' --write-back-cache=false'
 
     if len(params) > 0:
+        if not check_sysfs_numa_topology_is_valid():
+            print('WARNING: NUMA topology information is corrupted, skip running perftune')
+            return False
+
         if os.path.exists('/etc/scylla.d/perftune.yaml'):
             return True
 

--- a/dist/common/scripts/scylla_sysconfig_setup
+++ b/dist/common/scripts/scylla_sysconfig_setup
@@ -67,6 +67,9 @@ if __name__ == '__main__':
     network_mode = args.mode if args.mode else cfg.get('NETWORK_MODE')
 
     if args.setup_nic_and_disks:
+        if not check_sysfs_numa_topology_is_valid():
+            print('NUMA topology information is corrupted, not able to enable perftune feature.')
+            sys.exit(3)
         res = out('{} --tune net --nic {} --get-cpu-mask'.format(perftune_base_command(), ifname))
         # we need to extract CPU mask from output, since perftune.py may also print warning messages (#10082)
         match = re.match('(.*\n)?(0x[0-9a-f]+(?:,0x[0-9a-f]+)*)', res, re.DOTALL)
@@ -117,6 +120,9 @@ if __name__ == '__main__':
             cfg.set('SET_NIC_AND_DISKS', bool2str(args.setup_nic_and_disks))
 
     if cfg.has_option('SET_CLOCKSOURCE') and str2bool(cfg.get('SET_CLOCKSOURCE')) != args.set_clocksource:
+        if not check_sysfs_numa_topology_is_valid():
+            print('NUMA topology information is corrupted, not able to enable perftune feature.')
+            sys.exit(3)
         cfg.set('SET_CLOCKSOURCE', bool2str(args.set_clocksource))
 
     if cfg.has_option('DISABLE_WRITEBACK_CACHE') and str2bool(cfg.get('DISABLE_WRITEBACK_CACHE')) != args.disable_writeback_cache:

--- a/dist/common/scripts/scylla_util.py
+++ b/dist/common/scripts/scylla_util.py
@@ -296,6 +296,16 @@ def swap_exists():
     swaps = out('swapon --noheadings --raw')
     return True if swaps != '' else False
 
+def check_sysfs_numa_topology_is_valid():
+    # Verify that the sysfs entry exists correctly, same as the checks
+    # performed by hwloc code (check_sysfs_cpu_path() on topology-linux.c)
+    if os.path.isdir("/sys/devices/system/cpu"):
+        if os.path.exists("/sys/devices/system/cpu/cpu0/topology/package_cpus") or os.path.exists("/sys/devices/system/cpu/cpu0/topology/core_cpus"):
+            return True
+        if os.path.exists("/sys/devices/system/cpu/cpu0/topology/core_siblings") or os.path.exists("/sys/devices/system/cpu/cpu0/topology/thread_siblings"):
+            return True
+    return False
+
 def pkg_error_exit(pkg, offline_exit=True):
     print(f'Package "{pkg}" required.')
     if offline_exit:


### PR DESCRIPTION
There are some environment which has corrupted NUMA topology information, such as some instance types on AWS EC2 with specific Linux kernel images.
On such environment, we cannot get HW information correctly from hwloc, so we cannot proceed optimization on perftune.
To avoid causing script error, check NUMA topology information and skip running perftune if the information corrupted.

Related scylladb/seastar#2925

----

This is scylla-core part of https://github.com/scylladb/seastar/pull/2956