### PR TITLE
test.py: add pexpect to the dependencies

### DIFF
--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -43,6 +43,7 @@ debian_base_packages=(
     python3-pytest-asyncio
     python3-pytest-timeout
     python3-pytest-sugar
+    python3-pexpect
     libsnappy-dev
     libjsoncpp-dev
     rapidjson-dev
@@ -103,6 +104,7 @@ fedora_packages=(
     python3-jinja2
     python3-deepdiff
     python3-cryptography
+    python3-pexpect
     dnf-utils
     pigz
     net-tools


### PR DESCRIPTION
This is required for https://github.com/scylladb/scylladb/pull/24804

Use pexpect to control a persistent GDB process with pattern reads and timeouts. This makes 'scylla_gdb' tests faster and less flaky. Added python3-pexpect in 'install-dependencies.sh'.

`pexpect` is used only in newly proposed GDB tests. Nothing else will be impacted by this addition.