### PR TITLE
replica/database: Fix description of `validate_tablet_views_indexes`

### DIFF
--- a/replica/database.hh
+++ b/replica/database.hh
@@ -2097,16 +2097,13 @@ public:
     /// We consider a materialized view valid if one of the following
     /// conditions is satisfied:
     /// * it resides in a vnode-based keyspace,
-    /// * it resides in a tablet-based keyspace, the experimental feature `views-with-tablets`
+    /// * it resides in a tablet-based keyspace, the cluster feature `VIEWS_WITH_TABLETS`
     ///   is enabled, and the configuration option `rf_rack_valid_keyspaces` is enabled.
     ///
     /// Result:
-    /// * If all of the existing materialized views are valid, there is no side effect
-    ///   (aside from logging).
-    /// * If there are invalid materialized views, the function throws an exception.
-    ///   The type of the exception is intentionally not specified and the callers
-    ///   should not assume it. The exception message will be written in a way that
-    ///   can be directly passed on to the end user.
+    /// * Depending on whether there are invalid materialized views, the function will
+    ///   log that either everything's OK, or that there are some keyspaces that violate
+    ///   the requirement.
     void validate_tablet_views_indexes() const;
 private:
     // SSTable sampling might require considerable amounts of memory,


### PR DESCRIPTION
The current description is not accurate: the function doesn't throw an exception if there's an invalid materialized view. Instead, it simply logs the keyspaces that violate the requirement.

Furthermore, the experimental feature `views-with-tablets` is no longer necessary for considering a materialized view as valid. It was dropped in scylladb/scylladb@b409e85c207e72fd7ed73fc5ed8bf1316ec33e89. The replacement for it is the cluster feature `VIEWS_WITH_TABLETS`.

Fixes scylladb/scylladb#26420

Backport: let's backport the change to 2025.4 to avoid confusion. The function didn't make it to any previous version.