### PR TITLE
tools/scylla-sstable: introduce the dump-schema command

### DIFF
--- a/docs/operating-scylla/admin-tools/scylla-sstable.rst
+++ b/docs/operating-scylla/admin-tools/scylla-sstable.rst
@@ -555,6 +555,17 @@ The content is dumped in JSON, using the following schema:
         "above_threshold": Uint
     }
 
+dump-schema
+^^^^^^^^^^^
+
+Dump the schema of the table or sstable in CQL describe table format.
+
+Uses the regular `schema load <schema_>`_ mechanism to obtain the schema.
+With certain schema sources, the schema can be obtained without any sstables passed to the tool.
+
+Important note: the dumped schema will always be a `CREATE TABLE` statement, even if the table is in fact a materialized view or an index.
+This schema is enough to understand and parse the sstable data, but it may not be enough to recreate the table or write new sstables for it.
+
 .. _scylla-sstable-validate-operation:
 
 validate


### PR DESCRIPTION
There is a limited number of ways to obtain the schema of a table:
1) Use DESCRIBE TABLE in cqlsh
2) Find the schema definition in the code (for system tables)
3) Ask support/user to provide schema
4) Piece together the schema definition from the system tables

Option (1) is the most convenient but requires access to live cluster. (2) is limited to system tables only.
When investigating issues for customers, we have to rely on (3) and this often adds communication round-trips and delays. (4) requires knowledge of ScyllaDB internals and access to system tables.

The new dump-schema commands provides a convenient way to obtain the schema of tables, given that there is access to either an sstable or the system tables. It can dump the schema of system tables without either.

New command, no backport.