### PR TITLE
test.py: rewrite the wait_for_first_completed

### DIFF
--- a/test/cluster/test_hints.py
+++ b/test/cluster/test_hints.py
@@ -408,6 +408,10 @@ async def test_hint_to_pending(manager: ManagerClient):
         assert await_sync_point(servers[0], sync_point, 30)
 
         await manager.api.message_injection(servers[0].ip_addr, "pause_after_streaming_tablet")
-        await asyncio.wait([tablet_migration])
+        done, pending = await asyncio.wait([tablet_migration])
+        for task in pending:
+            task.cancel()
+        for task in done:
+            task.result()
 
         assert list(await cql.run_async(f"SELECT v FROM {table} WHERE pk = 0")) == [(0,)]

--- a/test/cluster/test_long_query_timeout_erm.py
+++ b/test/cluster/test_long_query_timeout_erm.py
@@ -6,7 +6,7 @@ from test.cluster.conftest import skip_mode
 from test.pylib.manager_client import ManagerClient
 from test.pylib.random_tables import RandomTables, Column, IntType
 from test.pylib.rest_client import inject_error_one_shot
-from test.pylib.util import wait_for_cql_and_get_hosts
+from test.pylib.util import wait_for_first_completed
 
 import asyncio
 from datetime import datetime, timedelta
@@ -177,11 +177,7 @@ async def test_long_query_timeout_without_failure_erm(request, manager: ManagerC
         server_log = await manager.server_open_log(server.server_id)
         await server_log.wait_for("mapreduce_pause_parallel_dispatch: waiting for message")
 
-    async with asyncio.TaskGroup() as tg:
-        log_watch_tasks = [tg.create_task(wait_for_log_on_any_node(server)) for server in servers]
-        _, pending = await asyncio.wait(log_watch_tasks, return_when=asyncio.FIRST_COMPLETED)
-        for t in pending:
-            t.cancel()
+    await wait_for_first_completed([wait_for_log_on_any_node(server) for server in servers])
 
     if enable_tablets:
         logger.info("Add new node - ERM should not be blocked")

--- a/test/cluster/test_tablets.py
+++ b/test/cluster/test_tablets.py
@@ -1124,9 +1124,7 @@ async def test_two_tablets_concurrent_repair_and_migration(manager: ManagerClien
         await manager.api.tablet_repair(servers[0].ip_addr, ks, "test", repair_replicas.last_token)
 
     async def migration_task():
-        done, pending = await asyncio.wait([asyncio.create_task(log.wait_for('Started to repair', from_mark=mark)) for log, mark in zip(logs, marks)], return_when=asyncio.FIRST_COMPLETED)
-        for task in pending:
-            task.cancel()
+        await wait_for_first_completed([log.wait_for('Started to repair', from_mark=mark) for log, mark in zip(logs, marks)])
         await manager.api.move_tablet(servers[0].ip_addr, ks, "test", migration_replicas.replicas[0][0], migration_replicas.replicas[0][1], migration_replicas.replicas[0][0], 0 if migration_replicas.replicas[0][1] != 0 else 1, migration_replicas.last_token)
         [await manager.api.message_injection(s.ip_addr, injection) for s in servers]
         [await manager.api.disable_injection(s.ip_addr, injection) for s in servers]

--- a/test/pylib/util.py
+++ b/test/pylib/util.py
@@ -261,12 +261,31 @@ async def wait_for_view(cql: Session, name: str, node_count: int, timeout: int =
     await wait_for(view_is_built, deadline)
 
 
-async def wait_for_first_completed(coros: list[Coroutine]):
-    done, pending = await asyncio.wait([asyncio.create_task(c) for c in coros], return_when=asyncio.FIRST_COMPLETED)
-    for t in pending:
-        t.cancel()
-    for t in done:
-        await t
+async def wait_for_first_completed(coros: list[Coroutine], timeout: int|None = None):
+    tasks = [asyncio.create_task(c) for c in coros]
+    done, pending = await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED, timeout=timeout)
+    if not done:
+        # Timeout occurred, cancel all
+        for task in tasks:
+            task.cancel()
+        await asyncio.gather(*tasks, return_exceptions=True)
+        raise asyncio.TimeoutError("No task completed within timeout")
+
+    # Cancel pending tasks
+    for task in pending:
+        task.cancel()
+
+    # Get first result
+    list_done = list(done)
+    first_task = list_done.pop(0)
+    result = await first_task
+
+    # Clean up
+    cleanup = list(pending) + list_done
+    if cleanup:
+        await asyncio.gather(*cleanup, return_exceptions=True)
+
+    return result
 
 
 def ninja(target: str) -> str:


### PR DESCRIPTION
Rewrite wait_for first_completed to return only first completed task guarantee of awaiting (disappearing) all cancelled and finished tasks
Use wait_for_first_completed to avoid false pass tests in the future and issues like https://github.com/scylladb/scylladb/issues/26148
Use gather_safely to await tasks and removing warning that coroutine was not awaited

Test fix only, backporting to 2025.4

Fixes: https://github.com/scylladb/qa-tasks/issues/1959

Fixes: #26643