### PR TITLE
setup: add the lazytime XFS mount option

### DIFF
--- a/dist/common/scripts/scylla_raid_setup
+++ b/dist/common/scripts/scylla_raid_setup
@@ -302,6 +302,9 @@ if __name__ == '__main__':
     opt_discard = ''
     if args.online_discard:
         opt_discard = ',discard'
+    opt_lazytime = ''
+    if is_kernel_version_at_least(4, 17):
+        opt_lazytime = ',lazytime'
     unit_data = f'''
 [Unit]
 Description=Scylla data directory
@@ -314,7 +317,7 @@ DefaultDependencies=no
 What={mount_dev}
 Where={mount_at}
 Type=xfs
-Options=noatime{opt_discard}
+Options=noatime{opt_discard}{opt_lazytime}
 
 [Install]
 WantedBy=local-fs.target


### PR DESCRIPTION
In f828fe0d591d75 ("setup: add the lazytime XFS version") we added the lazytime mount option to /var/lib/scylla, but it was quickly reverted (8f5e80e61a5) as it caused a regression on CentOS 7.

We reinstate it now with a kernel version check. This will avoid the lazytime mount option on CentOS 7, which is unsupported anyway.

The lazytime option avoids marking the inode as dirty if it's only for the purpose of updating mtime/ctime. This won't help much while writing sstables (since the write also updates extent information), but may help a little with with commitlog writes, since those are pure overwrites.

It likely won't help with the RWF_NOWAIT violations seen in [1], since those are likely due to in-memory locking, not flushing dirty inodes to disk.

Tested with an install to Ubuntu 24.04 LTS followed by a scylla_setup run. The lazytime option was added the the .mount file and showed up in the live mount.

[1] https://github.com/scylladb/seastar/issues/2974

Fixes #26002

Not backporting as this isn't expected to solve a major problem.