### PR TITLE
docs: fix a parameter name in API calls in sstable-dictionary-compression.rst

### DIFF
--- a/docs/operating-scylla/procedures/config-change/sstable-dictionary-compression.rst
+++ b/docs/operating-scylla/procedures/config-change/sstable-dictionary-compression.rst
@@ -38,14 +38,14 @@ Manual Dictionary Training
 
 You can manually trigger dictionary training using the REST API::
 
-    curl -X POST "http://node-address:10000/storage_service/retrain_dict?keyspace=mykeyspace&table=mytable"
+    curl -X POST "http://node-address:10000/storage_service/retrain_dict?keyspace=mykeyspace&cf=mytable"
 
 Estimating Compression Ratios
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 To choose the best compression configuration, you can estimate compression ratios using the REST API::
 
-    curl -X GET "http://node-address:10000/storage_service/estimate_compression_ratios?keyspace=mykeyspace&table=mytable"
+    curl -X GET "http://node-address:10000/storage_service/estimate_compression_ratios?keyspace=mykeyspace&cf=mytable"
 
 This will return a report with estimated compression ratios for various combinations of compression
 parameters (algorithm, chunk size, zstd level, dictionary).


### PR DESCRIPTION
The correct argument name is `cf`, not `table`.

Fixes scylladb/scylladb#25275

Relevant to all supported releases, should be backported.