### PR TITLE
test: Remove unused operator<<(radix_tree_test::test_data)

### DIFF
--- a/test/boost/radix_tree_test.cc
+++ b/test/boost/radix_tree_test.cc
@@ -37,11 +37,6 @@ public:
     }
 };
 
-std::ostream& operator<<(std::ostream& out, const test_data& d) {
-    out << d.value();
-    return out;
-}
-
 using test_tree = tree<test_data>;
 
 SEASTAR_TEST_CASE(test_exception_safety_of_emplace) {


### PR DESCRIPTION
It was used while debugging the test

Small code cleanup, no need to backport