### PR TITLE
Alternator Streams: Support userIdentity field for TTL deletions

### DIFF
--- a/alternator/ttl.cc
+++ b/alternator/ttl.cc
@@ -17,6 +17,7 @@
 #include <seastar/core/lowres_clock.hh>
 #include <seastar/coroutine/maybe_yield.hh>
 
+#include "cdc/log.hh"
 #include "exceptions/exceptions.hh"
 #include "gms/gossiper.hh"
 #include "gms/inet_address.hh"
@@ -292,7 +293,12 @@ static future<> expire_item(service::storage_proxy& proxy,
         db::consistency_level::LOCAL_QUORUM,
         executor::default_timeout(), // FIXME - which timeout?
         qs.get_trace_state(), qs.get_permit(),
-        db::allow_per_partition_rate_limit::no);
+        db::allow_per_partition_rate_limit::no,
+        false,
+        cdc::per_request_options{
+            .is_system_originated = true,
+        }
+    );
 }
 
 static size_t random_offset(size_t min, size_t max) {

--- a/cdc/log.hh
+++ b/cdc/log.hh
@@ -59,6 +59,9 @@ enum class operation : int8_t {
     pre_image = 0, update = 1, insert = 2, row_delete = 3, partition_delete = 4,
     range_delete_start_inclusive = 5, range_delete_start_exclusive = 6, range_delete_end_inclusive = 7, range_delete_end_exclusive = 8,
     post_image = 9,
+
+    // Operations initiated internally by Scylla. Currently used only by Alternator
+    service_row_delete = -3, service_partition_delete = -4,
 };
 
 struct per_request_options {
@@ -66,6 +69,10 @@ struct per_request_options {
     // layers than CDC. We assume that CDC could have seen the row in this
     // state, i.e. the value isn't 'stale'/'too recent'.
     lw_shared_ptr<cql3::untyped_result_set> preimage;
+    // Whether this mutation is a result of an internal operation initiated by
+    // Scylla. Currently, only TTL expiration implementation for Alternator
+    // uses this.
+    const bool is_system_originated = false;
 };
 
 struct operation_result_tracker;

--- a/test/alternator/test_ttl.py
+++ b/test/alternator/test_ttl.py
@@ -657,7 +657,6 @@ def test_ttl_expiration_lsi_key(dynamodb, waits_for_expiration):
 # content), and a special userIdentity flag saying that this is not a regular
 # REMOVE but an expiration.
 @pytest.mark.veryslow
-@pytest.mark.xfail(reason="TTL expiration event in streams not yet marked")
 def test_ttl_expiration_streams(dynamodb, dynamodbstreams):
     # In my experiments, a 30-minute (1800 seconds) is the typical
     # expiration delay in this test. If the test doesn't finish within


### PR DESCRIPTION
UserIdentity is a map of two fields in GetRecords responses, which
always has the same value. It may be empty, or contain a constant
object with value `{"type": "Service", "principalId":
"dynamodb.amazonaws.com"}`. Currently, the latter is set only for
`REMOVE`s triggered by TTL.

This commit introduces two new CDC operation types: `service_row_delete`
and `service_partition_delete`, emitted in place of `row_delete` and
`partition_delete`. Alternator Streams treats them as regular `REMOVE`s,
but in addition adds the `userIdentity` field to the record.

This change may break existing Scylla libraries for reading raw CDC
tables, but we doubt that anybody has this use case.

No backport - it's a feature.

Refs https://github.com/scylladb/scylladb/pull/26149
Fixes https://github.com/scylladb/scylladb/issues/11523