### PR TITLE
Revert "Merge 'auth: move passwords::check call to alien thread' from Andrzej Jackowski"

### DIFF
--- a/auth/allow_all_authenticator.cc
+++ b/auth/allow_all_authenticator.cc
@@ -9,7 +9,6 @@
 #include "auth/allow_all_authenticator.hh"
 
 #include "service/migration_manager.hh"
-#include "utils/alien_worker.hh"
 #include "utils/class_registrator.hh"
 
 namespace auth {
@@ -22,7 +21,6 @@ static const class_registrator<
         allow_all_authenticator,
         cql3::query_processor&,
         ::service::raft_group0_client&,
-        ::service::migration_manager&,
-        utils::alien_worker&> registration("org.apache.cassandra.auth.AllowAllAuthenticator");
+        ::service::migration_manager&> registration("org.apache.cassandra.auth.AllowAllAuthenticator");
 
 }

--- a/auth/allow_all_authenticator.hh
+++ b/auth/allow_all_authenticator.hh
@@ -13,7 +13,6 @@
 #include "auth/authenticated_user.hh"
 #include "auth/authenticator.hh"
 #include "auth/common.hh"
-#include "utils/alien_worker.hh"
 
 namespace cql3 {
 class query_processor;
@@ -29,7 +28,7 @@ extern const std::string_view allow_all_authenticator_name;
 
 class allow_all_authenticator final : public authenticator {
 public:
-    allow_all_authenticator(cql3::query_processor&, ::service::raft_group0_client&, ::service::migration_manager&, utils::alien_worker&) {
+    allow_all_authenticator(cql3::query_processor&, ::service::raft_group0_client&, ::service::migration_manager&) {
     }
 
     virtual future<> start() override {

--- a/auth/certificate_authenticator.cc
+++ b/auth/certificate_authenticator.cc
@@ -33,14 +33,13 @@ static const class_registrator<auth::authenticator
     , auth::certificate_authenticator
     , cql3::query_processor&
     , ::service::raft_group0_client&
-    , ::service::migration_manager&
-    , utils::alien_worker&> cert_auth_reg(CERT_AUTH_NAME);
+    , ::service::migration_manager&> cert_auth_reg(CERT_AUTH_NAME);
 
 enum class auth::certificate_authenticator::query_source {
     subject, altname
 };
 
-auth::certificate_authenticator::certificate_authenticator(cql3::query_processor& qp, ::service::raft_group0_client&, ::service::migration_manager&, utils::alien_worker&)
+auth::certificate_authenticator::certificate_authenticator(cql3::query_processor& qp, ::service::raft_group0_client&, ::service::migration_manager&)
     : _queries([&] {
         auto& conf = qp.db().get_config();
         auto queries = conf.auth_certificate_role_queries();

--- a/auth/certificate_authenticator.hh
+++ b/auth/certificate_authenticator.hh
@@ -10,7 +10,6 @@
 #pragma once
 
 #include "auth/authenticator.hh"
-#include "utils/alien_worker.hh"
 #include <boost/regex_fwd.hpp>  // IWYU pragma: keep
 
 namespace cql3 {
@@ -32,7 +31,7 @@ class certificate_authenticator : public authenticator {
     enum class query_source;
     std::vector<std::pair<query_source, boost::regex>> _queries;
 public:
-    certificate_authenticator(cql3::query_processor&, ::service::raft_group0_client&, ::service::migration_manager&, utils::alien_worker&);
+    certificate_authenticator(cql3::query_processor&, ::service::raft_group0_client&, ::service::migration_manager&);
     ~certificate_authenticator();
 
     future<> start() override;

--- a/auth/password_authenticator.cc
+++ b/auth/password_authenticator.cc
@@ -48,14 +48,14 @@ static const class_registrator<
         password_authenticator,
         cql3::query_processor&,
         ::service::raft_group0_client&,
-        ::service::migration_manager&,
-        utils::alien_worker&> password_auth_reg("org.apache.cassandra.auth.PasswordAuthenticator");
+        ::service::migration_manager&> password_auth_reg("org.apache.cassandra.auth.PasswordAuthenticator");
 
 static thread_local auto rng_for_salt = std::default_random_engine(std::random_device{}());
 
 static std::string_view get_config_value(std::string_view value, std::string_view def) {
     return value.empty() ? def : value;
 }
+
 std::string password_authenticator::default_superuser(const db::config& cfg) {
     return std::string(get_config_value(cfg.auth_superuser_name(), DEFAULT_USER_NAME));
 }
@@ -63,13 +63,12 @@ std::string password_authenticator::default_superuser(const db::config& cfg) {
 password_authenticator::~password_authenticator() {
 }
 
-password_authenticator::password_authenticator(cql3::query_processor& qp, ::service::raft_group0_client& g0, ::service::migration_manager& mm, utils::alien_worker& hashing_worker)
+password_authenticator::password_authenticator(cql3::query_processor& qp, ::service::raft_group0_client& g0, ::service::migration_manager& mm)
     : _qp(qp)
     , _group0_client(g0)
     , _migration_manager(mm)
     , _stopped(make_ready_future<>()) 
     , _superuser(default_superuser(qp.db().get_config()))
-    , _hashing_worker(hashing_worker)
 {}
 
 static bool has_salted_hash(const cql3::untyped_result_set_row& row) {
@@ -126,7 +125,7 @@ future<> password_authenticator::legacy_create_default_if_missing() {
     }
     std::string salted_pwd(get_config_value(_qp.db().get_config().auth_superuser_salted_password(), ""));
     if (salted_pwd.empty()) {
-        salted_pwd = passwords::hash(DEFAULT_USER_PASSWORD, rng_for_salt, _scheme);
+        salted_pwd = passwords::hash(DEFAULT_USER_PASSWORD, rng_for_salt);
     }
     const auto query = update_row_query();
     co_await _qp.execute_internal(
@@ -173,7 +172,7 @@ future<> password_authenticator::maybe_create_default_password() {
     // Set default superuser's password.
     std::string salted_pwd(get_config_value(_qp.db().get_config().auth_superuser_salted_password(), ""));
     if (salted_pwd.empty()) {
-        salted_pwd = passwords::hash(DEFAULT_USER_PASSWORD, rng_for_salt, _scheme);
+        salted_pwd = passwords::hash(DEFAULT_USER_PASSWORD, rng_for_salt);
     }
     const auto update_query = update_row_query();
     co_await collect_mutations(_qp, batch, update_query, {salted_pwd, _superuser});
@@ -203,10 +202,6 @@ future<> password_authenticator::maybe_create_default_password_with_retries() {
 
 future<> password_authenticator::start() {
     return once_among_shards([this] {
-        // Verify that at least one hashing scheme is supported.
-        passwords::detail::verify_scheme(_scheme);
-        plogger.info("Using password hashing scheme: {}", passwords::detail::prefix_for_scheme(_scheme));
-
         _stopped = do_after_system_ready(_as, [this] {
             return async([this] {
                 if (legacy_mode(_qp)) {
@@ -285,13 +280,7 @@ future<authenticated_user> password_authenticator::authenticate(
 
     try {
         const std::optional<sstring> salted_hash = co_await get_password_hash(username);
-        if (!salted_hash) {
-            throw exceptions::authentication_exception("Username and/or password are incorrect");
-        }
-        const bool password_match = co_await _hashing_worker.submit<bool>([password = std::move(password), salted_hash = std::move(salted_hash)]{
-            return passwords::check(password, *salted_hash);
-        });
-        if (!password_match) {
+        if (!salted_hash || !passwords::check(password, *salted_hash)) {
             throw exceptions::authentication_exception("Username and/or password are incorrect");
         }
         co_return username;
@@ -315,7 +304,7 @@ future<> password_authenticator::create(std::string_view role_name, const authen
     auto maybe_hash = options.credentials.transform([&] (const auto& creds) -> sstring {
         return std::visit(make_visitor(
                 [&] (const password_option& opt) {
-                    return passwords::hash(opt.password, rng_for_salt, _scheme);
+                    return passwords::hash(opt.password, rng_for_salt);
                 },
                 [] (const hashed_password_option& opt) {
                     return opt.hashed_password;
@@ -358,11 +347,11 @@ future<> password_authenticator::alter(std::string_view role_name, const authent
                 query,
                 consistency_for_user(role_name),
                 internal_distributed_query_state(),
-                {passwords::hash(password, rng_for_salt, _scheme), sstring(role_name)},
+                {passwords::hash(password, rng_for_salt), sstring(role_name)},
                 cql3::query_processor::cache_internal::no).discard_result();
     } else {
         co_await collect_mutations(_qp, mc, query,
-                {passwords::hash(password, rng_for_salt, _scheme), sstring(role_name)});
+                {passwords::hash(password, rng_for_salt), sstring(role_name)});
     }
 }
 

--- a/auth/password_authenticator.hh
+++ b/auth/password_authenticator.hh
@@ -14,9 +14,7 @@
 
 #include "db/consistency_level_type.hh"
 #include "auth/authenticator.hh"
-#include "auth/passwords.hh"
 #include "service/raft/raft_group0_client.hh"
-#include "utils/alien_worker.hh"
 
 namespace db {
     class config;
@@ -43,15 +41,12 @@ class password_authenticator : public authenticator {
     future<> _stopped;
     abort_source _as;
     std::string _superuser; // default superuser name from the config (may or may not be present in roles table)
-    // We used to also support bcrypt, SHA-256, and MD5 (ref. scylladb#24524).
-    constexpr static auth::passwords::scheme _scheme = passwords::scheme::sha_512;
-    utils::alien_worker& _hashing_worker;
 
 public:
     static db::consistency_level consistency_for_user(std::string_view role_name);
     static std::string default_superuser(const db::config&);
 
-    password_authenticator(cql3::query_processor&, ::service::raft_group0_client&, ::service::migration_manager&, utils::alien_worker&);
+    password_authenticator(cql3::query_processor&, ::service::raft_group0_client&, ::service::migration_manager&);
 
     ~password_authenticator();
 

--- a/auth/passwords.cc
+++ b/auth/passwords.cc
@@ -21,14 +21,18 @@ static thread_local crypt_data tlcrypt = {};
 
 namespace detail {
 
-void verify_scheme(scheme scheme) {
+scheme identify_best_supported_scheme() {
+    const auto all_schemes = { scheme::bcrypt_y, scheme::bcrypt_a, scheme::sha_512, scheme::sha_256, scheme::md5 };
+    // "Random", for testing schemes.
     const sstring random_part_of_salt = "aaaabbbbccccdddd";
 
-    const sstring salt = sstring(prefix_for_scheme(scheme)) + random_part_of_salt;
-    const char* e = crypt_r("fisk", salt.c_str(), &tlcrypt);
+    for (scheme c : all_schemes) {
+        const sstring salt = sstring(prefix_for_scheme(c)) + random_part_of_salt;
+        const char* e = crypt_r("fisk", salt.c_str(), &tlcrypt);
 
-    if (e && (e[0] != '*')) {
-        return;
+        if (e && (e[0] != '*')) {
+            return c;
+        }
     }
 
     throw no_supported_schemes();

--- a/auth/passwords.hh
+++ b/auth/passwords.hh
@@ -21,11 +21,10 @@ class no_supported_schemes : public std::runtime_error {
 public:
     no_supported_schemes();
 };
+
 ///
-/// Apache Cassandra uses a library to provide the bcrypt scheme. In ScyllaDB, we use SHA-512
-/// instead of bcrypt for performance and for historical reasons (see scylladb#24524).
-/// Currently, SHA-512 is always chosen as the hashing scheme for new passwords, but the other
-/// algorithms remain supported for CREATE ROLE WITH HASHED PASSWORD and backward compatibility.
+/// Apache Cassandra uses a library to provide the bcrypt scheme. Many Linux implementations do not support bcrypt, so
+/// we support alternatives. The cost is loss of direct compatibility with Apache Cassandra system tables.
 ///
 enum class scheme {
     bcrypt_y,
@@ -52,11 +51,11 @@ sstring generate_random_salt_bytes(RandomNumberEngine& g) {
 }
 
 ///
-/// Test given hashing scheme on the current system.
+/// Test each allowed hashing scheme and report the best supported one on the current system.
 ///
-/// \throws \ref no_supported_schemes when scheme is unsupported.
+/// \throws \ref no_supported_schemes when none of the known schemes is supported.
 ///
-void verify_scheme(scheme scheme);
+scheme identify_best_supported_scheme();
 
 std::string_view prefix_for_scheme(scheme) noexcept;
 
@@ -68,7 +67,8 @@ std::string_view prefix_for_scheme(scheme) noexcept;
 /// \throws \ref no_supported_schemes when no known hashing schemes are supported on the system.
 ///
 template <typename RandomNumberEngine>
-sstring generate_salt(RandomNumberEngine& g, scheme scheme) {
+sstring generate_salt(RandomNumberEngine& g) {
+    static const scheme scheme = identify_best_supported_scheme();
     static const sstring prefix = sstring(prefix_for_scheme(scheme));
     return prefix + generate_random_salt_bytes(g);
 }
@@ -93,8 +93,8 @@ sstring hash_with_salt(const sstring& pass, const sstring& salt);
 /// \throws \ref std::system_error when the implementation-specific implementation fails to hash the cleartext.
 ///
 template <typename RandomNumberEngine>
-sstring hash(const sstring& pass, RandomNumberEngine& g, scheme scheme) {
-    return detail::hash_with_salt(pass, detail::generate_salt(g, scheme));
+sstring hash(const sstring& pass, RandomNumberEngine& g) {
+    return detail::hash_with_salt(pass, detail::generate_salt(g));
 }
 
 ///

--- a/auth/saslauthd_authenticator.cc
+++ b/auth/saslauthd_authenticator.cc
@@ -34,10 +34,9 @@ static const class_registrator<
         saslauthd_authenticator,
         cql3::query_processor&,
         ::service::raft_group0_client&,
-        ::service::migration_manager&,
-        utils::alien_worker&> saslauthd_auth_reg("com.scylladb.auth.SaslauthdAuthenticator");
+        ::service::migration_manager&> saslauthd_auth_reg("com.scylladb.auth.SaslauthdAuthenticator");
 
-saslauthd_authenticator::saslauthd_authenticator(cql3::query_processor& qp, ::service::raft_group0_client&, ::service::migration_manager&, utils::alien_worker&)
+saslauthd_authenticator::saslauthd_authenticator(cql3::query_processor& qp, ::service::raft_group0_client&, ::service::migration_manager&)
     : _socket_path(qp.db().get_config().saslauthd_socket_path())
 {}
 

--- a/auth/saslauthd_authenticator.hh
+++ b/auth/saslauthd_authenticator.hh
@@ -11,7 +11,6 @@
 #pragma once
 
 #include "auth/authenticator.hh"
-#include "utils/alien_worker.hh"
 
 namespace cql3 {
 class query_processor;
@@ -29,7 +28,7 @@ namespace auth {
 class saslauthd_authenticator : public authenticator {
     sstring _socket_path; ///< Path to the domain socket on which saslauthd is listening.
 public:
-    saslauthd_authenticator(cql3::query_processor&, ::service::raft_group0_client&, ::service::migration_manager&, utils::alien_worker&);
+    saslauthd_authenticator(cql3::query_processor&, ::service::raft_group0_client&, ::service::migration_manager&);
 
     future<> start() override;
 

--- a/auth/service.cc
+++ b/auth/service.cc
@@ -187,15 +187,14 @@ service::service(
         ::service::migration_notifier& mn,
         ::service::migration_manager& mm,
         const service_config& sc,
-        maintenance_socket_enabled used_by_maintenance_socket,
-        utils::alien_worker& hashing_worker)
+        maintenance_socket_enabled used_by_maintenance_socket)
             : service(
                       std::move(c),
                       qp,
                       g0,
                       mn,
                       create_object<authorizer>(sc.authorizer_java_name, qp, g0, mm),
-                      create_object<authenticator>(sc.authenticator_java_name, qp, g0, mm, hashing_worker),
+                      create_object<authenticator>(sc.authenticator_java_name, qp, g0, mm),
                       create_object<role_manager>(sc.role_manager_java_name, qp, g0, mm),
                       used_by_maintenance_socket) {
 }

--- a/auth/service.hh
+++ b/auth/service.hh
@@ -26,7 +26,6 @@
 #include "cql3/description.hh"
 #include "seastarx.hh"
 #include "service/raft/raft_group0_client.hh"
-#include "utils/alien_worker.hh"
 #include "utils/observable.hh"
 #include "utils/serialized_action.hh"
 #include "service/maintenance_mode.hh"
@@ -127,8 +126,7 @@ public:
             ::service::migration_notifier&,
             ::service::migration_manager&,
             const service_config&,
-            maintenance_socket_enabled,
-            utils::alien_worker&);
+            maintenance_socket_enabled);
 
     future<> start(::service::migration_manager&, db::system_keyspace&);
 

--- a/auth/transitional.cc
+++ b/auth/transitional.cc
@@ -37,8 +37,8 @@ class transitional_authenticator : public authenticator {
 public:
     static const sstring PASSWORD_AUTHENTICATOR_NAME;
 
-    transitional_authenticator(cql3::query_processor& qp, ::service::raft_group0_client& g0, ::service::migration_manager& mm, utils::alien_worker& hashing_worker)
-            : transitional_authenticator(std::make_unique<password_authenticator>(qp, g0, mm, hashing_worker)) {
+    transitional_authenticator(cql3::query_processor& qp, ::service::raft_group0_client& g0, ::service::migration_manager& mm)
+            : transitional_authenticator(std::make_unique<password_authenticator>(qp, g0, mm)) {
     }
     transitional_authenticator(std::unique_ptr<authenticator> a)
             : _authenticator(std::move(a)) {
@@ -235,8 +235,7 @@ static const class_registrator<
         auth::transitional_authenticator,
         cql3::query_processor&,
         ::service::raft_group0_client&,
-        ::service::migration_manager&,
-        utils::alien_worker&> transitional_authenticator_reg(auth::PACKAGE_NAME + "TransitionalAuthenticator");
+        ::service::migration_manager&> transitional_authenticator_reg(auth::PACKAGE_NAME + "TransitionalAuthenticator");
 
 static const class_registrator<
         auth::authorizer,

--- a/main.cc
+++ b/main.cc
@@ -828,9 +828,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
     // Note: we are creating this thread before app.run so that it doesn't
     // inherit Seastar's CPU affinity masks. We want this thread to be free
     // to migrate between CPUs; we think that's what makes the most sense.
-    auto rpc_dict_training_worker = utils::alien_worker(startlog, 19, "rpc-dict");
-    // niceness=10 is ~10% of normal process time
-    auto hashing_worker = utils::alien_worker(startlog, 10, "pwd-hash");
+    auto rpc_dict_training_worker = utils::alien_worker(startlog, 19);
 
     return app.run(ac, av, [&] () -> future<int> {
 
@@ -860,8 +858,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
         return seastar::async([&app, cfg, ext, &disk_space_monitor_shard0, &cm, &sstm, &db, &qp, &bm, &proxy, &mapreduce_service, &mm, &mm_notifier, &ctx, &opts, &dirs,
                 &prometheus_server, &cf_cache_hitrate_calculator, &load_meter, &feature_service, &gossiper, &snitch,
                 &token_metadata, &erm_factory, &snapshot_ctl, &messaging, &sst_dir_semaphore, &raft_gr, &service_memory_limiter,
-                &repair, &sst_loader, &ss, &lifecycle_notifier, &stream_manager, &task_manager, &rpc_dict_training_worker,
-                &hashing_worker] {
+                &repair, &sst_loader, &ss, &lifecycle_notifier, &stream_manager, &task_manager, &rpc_dict_training_worker] {
           try {
               if (opts.contains("relabel-config-file") && !opts["relabel-config-file"].as<sstring>().empty()) {
                   // calling update_relabel_config_from_file can cause an exception that would stop startup
@@ -2060,7 +2057,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
                 maintenance_auth_config.authenticator_java_name = sstring{auth::allow_all_authenticator_name};
                 maintenance_auth_config.role_manager_java_name = sstring{auth::maintenance_socket_role_manager_name};
 
-                maintenance_auth_service.start(perm_cache_config, std::ref(qp), std::ref(group0_client),  std::ref(mm_notifier), std::ref(mm), maintenance_auth_config, maintenance_socket_enabled::yes, std::ref(hashing_worker)).get();
+                maintenance_auth_service.start(perm_cache_config, std::ref(qp), std::ref(group0_client),  std::ref(mm_notifier), std::ref(mm), maintenance_auth_config, maintenance_socket_enabled::yes).get();
 
                 cql_maintenance_server_ctl.emplace(maintenance_auth_service, mm_notifier, gossiper, qp, service_memory_limiter, sl_controller, lifecycle_notifier, *cfg, maintenance_cql_sg_stats_key, maintenance_socket_enabled::yes, dbcfg.statement_scheduling_group);
 
@@ -2273,7 +2270,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             auth_config.authenticator_java_name = qualified_authenticator_name;
             auth_config.role_manager_java_name = qualified_role_manager_name;
 
-            auth_service.start(std::move(perm_cache_config), std::ref(qp), std::ref(group0_client), std::ref(mm_notifier), std::ref(mm), auth_config, maintenance_socket_enabled::no, std::ref(hashing_worker)).get();
+            auth_service.start(std::move(perm_cache_config), std::ref(qp), std::ref(group0_client), std::ref(mm_notifier), std::ref(mm), auth_config, maintenance_socket_enabled::no).get();
 
             std::any stop_auth_service;
             // Has to be called after node joined the cluster (join_cluster())

--- a/test/boost/auth_passwords_test.cc
+++ b/test/boost/auth_passwords_test.cc
@@ -29,7 +29,7 @@ BOOST_AUTO_TEST_CASE(passwords_are_salted) {
     std::unordered_set<sstring> observed_passwords{};
 
     for (int i = 0; i < 10; ++i) {
-        const sstring e = auth::passwords::hash(cleartext, rng_for_salt, auth::passwords::scheme::sha_512);
+        const sstring e = auth::passwords::hash(cleartext, rng_for_salt);
         BOOST_REQUIRE(!observed_passwords.contains(e));
         observed_passwords.insert(e);
     }
@@ -47,7 +47,7 @@ BOOST_AUTO_TEST_CASE(correct_passwords_authenticate) {
     };
 
     for (const char* p : passwords) {
-        BOOST_REQUIRE(auth::passwords::check(p, auth::passwords::hash(p, rng_for_salt, auth::passwords::scheme::sha_512)));
+        BOOST_REQUIRE(auth::passwords::check(p, auth::passwords::hash(p, rng_for_salt)));
     }
 }
 
@@ -55,6 +55,6 @@ BOOST_AUTO_TEST_CASE(correct_passwords_authenticate) {
 // A hashed password that does not match the password in cleartext does not authenticate.
 //
 BOOST_AUTO_TEST_CASE(incorrect_passwords_do_not_authenticate) {
-    const sstring hashed_password = auth::passwords::hash("actual_password", rng_for_salt,auth::passwords::scheme::sha_512);
+    const sstring hashed_password = auth::passwords::hash("actual_password", rng_for_salt);
     BOOST_REQUIRE(!auth::passwords::check("password_guess", hashed_password));
 }

--- a/test/cqlpy/test_service_level_api.py
+++ b/test/cqlpy/test_service_level_api.py
@@ -42,17 +42,6 @@ def count_opened_connections_from_table(cql):
     
     return result
 
-def wait_for_clients(cql, username, clients_num, wait_s = 1, timeout_s = 30):
-    start_time = time.time()
-    while time.time() - start_time < timeout_s:
-        result = cql.execute(f"SELECT COUNT(*) FROM system.clients WHERE username='{username}' ALLOW FILTERING")
-        if result.one()[0] == clients_num:
-            return
-        else:
-            time.sleep(wait_s)
-
-    raise RuntimeError(f"Awaiting for {clients_num} clients timed out.")
-
 def wait_until_all_connections_authenticated(cql, wait_s = 1, timeout_s = 30):
     start_time = time.time()
     while time.time() - start_time < timeout_s:
@@ -90,7 +79,6 @@ def test_count_opened_cql_connections(cql):
 
     try:
         with new_session(cql, user):
-            wait_for_clients(cql, user, 3) # 3 from smp=2 + control connection
             wait_until_all_connections_authenticated(cql)
             verify_scheduling_group_assignment(cql, user, sl, get_shard_count(cql))
 
@@ -126,7 +114,6 @@ def test_switch_tenants(cql):
 
     try:
         with new_session(cql, user) as user_session:
-            wait_for_clients(cql, user, 3) # 3 from smp=2 + control connection
             wait_until_all_connections_authenticated(cql)
             verify_scheduling_group_assignment(cql, user, sl1, shard_count)
 

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -1050,11 +1050,7 @@ private:
             auth_config.authenticator_java_name = qualified_authenticator_name;
             auth_config.role_manager_java_name = qualified_role_manager_name;
 
-
-
-            const uint64_t niceness = 19;
-            auto hashing_worker = utils::alien_worker(startlog, niceness, "pwd-hash");
-            _auth_service.start(perm_cache_config, std::ref(_qp), std::ref(group0_client), std::ref(_mnotifier), std::ref(_mm), auth_config, maintenance_socket_enabled::no, std::ref(hashing_worker)).get();
+            _auth_service.start(perm_cache_config, std::ref(_qp), std::ref(group0_client), std::ref(_mnotifier), std::ref(_mm), auth_config, maintenance_socket_enabled::no).get();
             _auth_service.invoke_on_all([this] (auth::service& auth) {
                 return auth.start(_mm.local(), _sys_ks.local());
             }).get();

--- a/utils/alien_worker.cc
+++ b/utils/alien_worker.cc
@@ -13,24 +13,14 @@ using namespace seastar;
 
 namespace utils {
 
-std::thread alien_worker::spawn(seastar::logger& log, int niceness, const seastar::sstring& name_suffix) {
+std::thread alien_worker::spawn(seastar::logger& log, int niceness) {
     sigset_t newset;
     sigset_t oldset;
     sigfillset(&newset);
     auto r = ::pthread_sigmask(SIG_SETMASK, &newset, &oldset);
     assert(r == 0);
-    auto thread_name = fmt::format("alien-{}", name_suffix);
-    if (thread_name.size() > 15) {
-        log.warn("Thread name '{}' is longer than 15 characters, truncating to fit", thread_name);
-        thread_name.resize(15); // pthread_setname_np requires name to be <= 15 characters
-    }
-    auto thread = std::thread([this, &log, niceness, thread_name] () noexcept {
+    auto thread = std::thread([this, &log, niceness] () noexcept {
         errno = 0;
-        int setname_value = pthread_setname_np(pthread_self(), thread_name.c_str());
-        if (setname_value != 0) {
-            log.error("Unable to set worker thread name '{}', setname_value={}", thread_name, setname_value);
-            std::abort();
-        }
         int nice_value = nice(niceness);
         if (nice_value == -1 && errno != 0) {
             log.warn("Unable to renice worker thread (system error number {}); the thread will compete with reactor, which can cause latency spikes. Try adding CAP_SYS_NICE", errno);
@@ -53,8 +43,8 @@ std::thread alien_worker::spawn(seastar::logger& log, int niceness, const seasta
     return thread;
 }
 
-alien_worker::alien_worker(seastar::logger& log, int niceness, const seastar::sstring& name_suffix)
-    : _thread(spawn(log, niceness, name_suffix))
+alien_worker::alien_worker(seastar::logger& log, int niceness)
+    : _thread(spawn(log, niceness))
 {}
 
 alien_worker::~alien_worker() {

--- a/utils/alien_worker.hh
+++ b/utils/alien_worker.hh
@@ -29,9 +29,9 @@ class alien_worker {
     // Note: initialization of _thread uses other fields, so it must be performed last.
     std::thread _thread;
 
-    std::thread spawn(seastar::logger&, int niceness, const seastar::sstring& name_suffix);
+    std::thread spawn(seastar::logger&, int niceness);
 public:
-    alien_worker(seastar::logger&, int niceness, const seastar::sstring& name_suffix);
+    alien_worker(seastar::logger&, int niceness);
     ~alien_worker();
     // The worker captures `this`, so `this` must have a stable address.
     alien_worker(const alien_worker&) = delete;


### PR DESCRIPTION
This reverts commit 1fd82d32e09df55d8bdcb91b66be330e61d89488. It causes connection storms to snowball into a node crash via this mechanism:

1. large node suffers mild connection storm
2. password hash requests queue up on alien hash thread
3. incoming hash requests queue faster than the alien thread can retire them.
4. auth latency grows without bounds
5. this encourages the clients to create new connections
6. problem grows

Reverting the patch restores the hash stall, but at least prevents node crashes.

Fixes scylladb/scylla-enterprise#5711 (2025.1)

This is a direct revert on 2025.1. Not backporting on master since it may already be fixed there.