### PR TITLE
s3_client: track memory starvation in background filling fiber

### DIFF
--- a/utils/s3/client.hh
+++ b/utils/s3/client.hh
@@ -131,6 +131,7 @@ class client : public enable_shared_from_this<client> {
         io_stats read_stats;
         io_stats write_stats;
         uint64_t prefetch_bytes = 0;
+        uint64_t downloads_blocked_on_memory = 0;
         seastar::metrics::metric_groups metrics;
         group_client(std::unique_ptr<http::experimental::connection_factory> f, unsigned max_conn, const aws::retry_strategy& retry_strategy);
         void register_metrics(std::string class_name, std::string host);


### PR DESCRIPTION
Introduce a counter metric to monitor instances where the background filling fiber is blocked due to insufficient memory in the S3 client.

Fixes: https://github.com/scylladb/scylladb/issues/26465

Should be backported to 2025.3 and 2025.4 to improve s3 client visibility in monitorin