### PR TITLE
db/commitlog: Extend segment truncation error messages

### DIFF
--- a/db/commitlog/commitlog.cc
+++ b/db/commitlog/commitlog.cc
@@ -3475,7 +3475,8 @@ db::commitlog::read_log_file(const replay_state& state, sstring filename, sstrin
 
                 if (tmp.size_bytes() == 0) {
                     eof = true;
-                    auto reason = fmt::format("read 0 bytes, while tried to read {}", block_size);
+                    auto reason = fmt::format("read 0 bytes, while tried to read {} bytes. rem={}, size={}",
+                            block_size, rem, size);
                     throw segment_truncation(std::move(reason), block_boundry);
                 }
 
@@ -3511,11 +3512,13 @@ db::commitlog::read_log_file(const replay_state& state, sstring filename, sstrin
                     auto checksum = crc.checksum();
 
                     if (check != checksum) {
-                        auto reason = fmt::format("checksums do not match: {:x} vs. {:x}", check, checksum);
+                        auto reason = fmt::format("checksums do not match: {:x} vs. {:x}. rem={}, size={}",
+                                check, checksum, rem, size);
                         throw segment_data_corruption_error(std::move(reason), alignment);
                     }
                     if (id != this->id) {
-                        auto reason = fmt::format("IDs do not match: {} vs. {}", id, this->id);
+                        auto reason = fmt::format("IDs do not match: {} vs. {}. rem={}, size={}",
+                                id, this->id, rem, size);
                         throw segment_truncation(std::move(reason), pos + rem);
                     }
                 }


### PR DESCRIPTION
We include more relevant information for debugging purposes:
the remaining bytes and the size. It might be useful to determine
where exactly an error occurred and help reason about it.

Backport: not needed. It might be useful, but for now let's not do that.