### PR TITLE
migration_manager: Add missing validations for schema extensions

### DIFF
--- a/service/migration_manager.cc
+++ b/service/migration_manager.cc
@@ -715,6 +715,13 @@ future<> prepare_new_column_family_announcement(utils::chunked_vector<mutation>&
 
 future<> prepare_new_column_families_announcement(utils::chunked_vector<mutation>& mutations,
         storage_proxy& sp, const keyspace_metadata& ksm, std::vector<schema_ptr> cfms, api::timestamp_type timestamp) {
+    for (auto cfm : cfms) {
+        try {
+            co_await validate(cfm);
+        } catch (...) {
+            std::throw_with_nested(std::runtime_error(seastar::format("Validation of schema extensions failed for ColumnFamily: {}", cfm)));
+        }
+    }
     auto& db = sp.local_db();
     // If the keyspace exists, ensure that we use the current metadata.
     const auto& current_ksm = db.has_keyspace(ksm.name()) ? *db.find_keyspace(ksm.name()).metadata() : ksm;


### PR DESCRIPTION
The migration manager offers some free functions to prepare mutations for a new/updated table/view. Most of them include a validation check for the schema extensions, but in the following ones it's missing:

* `prepare_new_column_family_announcement` (overload with vector as out parameter)
* `prepare_new_column_families_announcement`

Presumably, this was just an omission. It's also not a very important one since the only extension having validation logic is the `encryption_schema_extension`, but none of these functions is connected to user queries where encryption options can be provided in the schema. User queries go through the other
`prepare_new_column_family_announcement` overload, which does perform a validation check.

Add validation in the missing places.

Fixes #26470.

Minor improvement with no user-visible effect. No need to backport.