### PR TITLE
repair: Rename incremental mode name

### DIFF
--- a/api/api-doc/storage_service.json
+++ b/api/api-doc/storage_service.json
@@ -2968,7 +2968,7 @@
                   },
                   {
                      "name":"incremental_mode",
-                     "description":"Set the incremental repair mode. Can be 'disabled', 'regular', or 'full'. 'regular': The incremental repair logic is enabled. Unrepaired sstables will be included for repair. Repaired sstables will be skipped. The incremental repair states will be updated after repair. 'full': The incremental repair logic is enabled. Both repaired and unrepaired sstables will be included for repair. The incremental repair states will be updated after repair. 'disabled': The incremental repair logic is disabled completely. The incremental repair states, e.g., repaired_at in sstables and sstables_repaired_at in the system.tablets table, will not be updated after repair. When the option is not provided, it defaults to regular.",
+                     "description":"Set the incremental repair mode. Can be 'disabled', 'incremental', or 'full'. 'incremental': The incremental repair logic is enabled. Unrepaired sstables will be included for repair. Repaired sstables will be skipped. The incremental repair states will be updated after repair. 'full': The incremental repair logic is enabled. Both repaired and unrepaired sstables will be included for repair. The incremental repair states will be updated after repair. 'disabled': The incremental repair logic is disabled completely. The incremental repair states, e.g., repaired_at in sstables and sstables_repaired_at in the system.tablets table, will not be updated after repair. When the option is not provided, it defaults to regular.",
                      "required":false,
                      "allowMultiple":false,
                      "type":"string",

--- a/docs/operating-scylla/nodetool-commands/cluster/repair.rst
+++ b/docs/operating-scylla/nodetool-commands/cluster/repair.rst
@@ -53,7 +53,7 @@ ScyllaDB nodetool cluster repair command supports the following options:
 
      nodetool cluster repair --tablet-tokens 1,10474535988
 
-- ``--incremental-mode`` specifies the incremental repair mode. Can be 'disabled', 'regular', or 'full'. 'regular': The incremental repair logic is enabled. Unrepaired sstables will be included for repair. Repaired sstables will be skipped. The incremental repair states will be updated after repair. 'full': The incremental repair logic is enabled. Both repaired and unrepaired sstables will be included for repair. The incremental repair states will be updated after repair. 'disabled': The incremental repair logic is disabled completely. The incremental repair states, e.g., repaired_at in sstables and sstables_repaired_at in the system.tablets table, will not be updated after repair. When the option is not provided, it defaults to regular.
+- ``--incremental-mode`` specifies the incremental repair mode. Can be 'disabled', 'incremental', or 'full'. 'incremental': The incremental repair logic is enabled. Unrepaired sstables will be included for repair. Repaired sstables will be skipped. The incremental repair states will be updated after repair. 'full': The incremental repair logic is enabled. Both repaired and unrepaired sstables will be included for repair. The incremental repair states will be updated after repair. 'disabled': The incremental repair logic is disabled completely. The incremental repair states, e.g., repaired_at in sstables and sstables_repaired_at in the system.tablets table, will not be updated after repair. When the option is not provided, it defaults to incremental.
 
   For example:
 

--- a/idl/repair.idl.hh
+++ b/idl/repair.idl.hh
@@ -76,7 +76,7 @@ struct repair_row_level_start_response {
 
 namespace locator {
 enum class tablet_repair_incremental_mode : uint8_t {
-    regular,
+    incremental,
     full,
     disabled,
 };

--- a/locator/tablets.cc
+++ b/locator/tablets.cc
@@ -754,7 +754,7 @@ tablet_task_type tablet_task_type_from_string(const sstring& name) {
 // The names are persisted in system tables so should not be changed.
 static const std::unordered_map<locator::tablet_repair_incremental_mode, sstring> tablet_repair_incremental_mode_to_name = {
     {locator::tablet_repair_incremental_mode::disabled, "disabled"},
-    {locator::tablet_repair_incremental_mode::regular, "regular"},
+    {locator::tablet_repair_incremental_mode::incremental, "incremental"},
     {locator::tablet_repair_incremental_mode::full, "full"},
 };
 

--- a/locator/tablets.hh
+++ b/locator/tablets.hh
@@ -178,11 +178,11 @@ sstring tablet_task_type_to_string(tablet_task_type);
 tablet_task_type tablet_task_type_from_string(const sstring&);
 
 
-// - regular (regular incremental repair): The incremental repair logic is enabled.
+// - incremental (incremental repair): The incremental repair logic is enabled.
 //   Unrepaired sstables will be included for repair. Repaired sstables will be
 //   skipped. The incremental repair states will be updated after repair.
 
-// - full (full incremental repair): The incremental repair logic is enabled.
+// - full (full repair): The incremental repair logic is enabled.
 //   Both repaired and unrepaired sstables will be included for repair. The
 //   incremental repair states will be updated after repair.
 
@@ -191,12 +191,12 @@ tablet_task_type tablet_task_type_from_string(const sstring&);
 //   sstables_repaired_at in system.tablets table, will not be updated after
 //   repair.
 enum class tablet_repair_incremental_mode : uint8_t {
-    regular,
+    incremental,
     full,
     disabled,
 };
 
-constexpr tablet_repair_incremental_mode default_tablet_repair_incremental_mode{tablet_repair_incremental_mode::regular};
+constexpr tablet_repair_incremental_mode default_tablet_repair_incremental_mode{tablet_repair_incremental_mode::incremental};
 
 sstring tablet_repair_incremental_mode_to_string(tablet_repair_incremental_mode);
 tablet_repair_incremental_mode tablet_repair_incremental_mode_from_string(const sstring&);

--- a/test/cluster/test_incremental_repair.py
+++ b/test/cluster/test_incremental_repair.py
@@ -655,7 +655,7 @@ async def test_tablet_repair_with_incremental_option(manager: ManagerClient):
         assert read1 == 0
         assert skip2 == 0
         assert read2 > 0
-    await do_repair_and_check(None, 1, rf'Starting tablet repair by API .* incremental_mode=regular.*', check1)
+    await do_repair_and_check(None, 1, rf'Starting tablet repair by API .* incremental_mode=incremental.*', check1)
 
     def check2(skip1, read1, skip2, read2):
         assert skip1 == skip2
@@ -665,7 +665,7 @@ async def test_tablet_repair_with_incremental_option(manager: ManagerClient):
     def check3(skip1, read1, skip2, read2):
         assert skip1 < skip2
         assert read1 == read2
-    await do_repair_and_check('regular', 1, rf'Starting tablet repair by API .* incremental_mode=regular.*', check3)
+    await do_repair_and_check('incremental', 1, rf'Starting tablet repair by API .* incremental_mode=incremental.*', check3)
 
     def check4(skip1, read1, skip2, read2):
         assert skip1 == skip2

--- a/test/nodetool/test_cluster_repair.py
+++ b/test/nodetool/test_cluster_repair.py
@@ -424,7 +424,7 @@ def test_repair_keyspace(nodetool):
         ]},
         ["error processing arguments: nodetool cluster repair repairs only tablet keyspaces. To repair vnode keyspaces use nodetool repair."])
 
-@pytest.mark.parametrize("mode", ["disabled", "regular", "full"])
+@pytest.mark.parametrize("mode", ["disabled", "incremental", "full"])
 def test_repair_incremenatal_repair(nodetool, mode):
     id1 = "ef1b7a61-66c8-494c-bb03-6f65724e6eee"
     res = nodetool("cluster", "repair", "--incremental-mode", mode, "ks", "table1", expected_requests=[

--- a/tools/scylla-nodetool.cc
+++ b/tools/scylla-nodetool.cc
@@ -583,9 +583,9 @@ void cluster_repair_operation(scylla_rest_client& client, const bpo::variables_m
 
     if (vm.contains("incremental-mode")) {
         auto mode = vm["incremental-mode"].as<sstring>();
-        const std::unordered_set<sstring> supported_mode{"disabled", "regular", "full"};
+        const std::unordered_set<sstring> supported_mode{"disabled", "incremental", "full"};
         if (!supported_mode.contains(mode)) {
-            throw std::invalid_argument("nodetool cluster repair --incremental-mode only supports: disabled, regular, full");
+            throw std::invalid_argument("nodetool cluster repair --incremental-mode only supports: disabled, incremental, full");
         }
         repair_params["incremental_mode"] = mode;
     }
@@ -3764,7 +3764,7 @@ For more information, see: {}
                             typed_option<std::vector<sstring>>("in-dc", "Constrain repair to specific datacenter(s)"),
                             typed_option<std::vector<sstring>>("in-hosts", "Constrain repair to the specific host(s)"),
                             typed_option<std::vector<sstring>>("tablet-tokens", "Tokens owned by the tablets to repair."),
-                            typed_option<sstring>("incremental-mode", "Specify the incremental repair mode: disabled, regular, full"),
+                            typed_option<sstring>("incremental-mode", "Specify the incremental repair mode: disabled, incremental, full"),
                         },
                         {
                             typed_option<sstring>("keyspace", "The keyspace to repair, if missing all keyspaces are repaired", 1),


### PR DESCRIPTION
Using the name regular as the incremental mode could be confusing, since regular might be interpreted as the non-incremental repair. It is better to use incremental directly.

Before:

- regular (standard incremental repair)
- full (full incremental repair)
- disabled (incremental repair disabled)

After:

- incremental (standard incremental repair)
- full (full incremental repair)
- disabled (incremental repair disabled)

Fixes #26503

Backport to 2025.4 only. 