### PR TITLE
secondary_index: disallow multiple vector indexes on the same column

### DIFF
--- a/index/vector_index.cc
+++ b/index/vector_index.cc
@@ -162,6 +162,18 @@ bool vector_index::has_vector_index(const schema& s) {
     });
 }
 
+bool vector_index::has_vector_index_on_column(const schema& s, const sstring& target_name) {
+    for (const auto& index : s.indices()) {
+        auto class_it = index.options().find(db::index::secondary_index::custom_class_option_name);
+        auto target_it = index.options().find(cql3_parser::index_target::target_option_name);
+        if (class_it != index.options().end() && target_it != index.options().end()) {
+            auto custom_class = secondary_index_manager::get_custom_class_factory(class_it->second);
+            return custom_class && dynamic_cast<vector_index*>((*custom_class)().get()) && target_it->second == target_name;
+        }
+    }
+    return false;
+}
+
 /// Returns the schema version of the base table at which the index was created.
 /// This is used to determine if the index needs to be rebuilt after a schema change.
 /// The CREATE INDEX and DROP INDEX statements does change the schema version.

--- a/index/vector_index.hh
+++ b/index/vector_index.hh
@@ -31,6 +31,7 @@ public:
     void validate(const schema &schema, cql3::statements::index_prop_defs &properties, const std::vector<::shared_ptr<cql3::statements::index_target>> &targets, const gms::feature_service& fs) override;
     table_schema_version index_version(const schema& schema) override;
     static bool has_vector_index(const schema& s);
+    static bool has_vector_index_on_column(const schema& s, const sstring& target_name);
     static void check_cdc_options(const schema& schema);
 private:
     void check_cdc_not_explicitly_disabled(const schema& schema);


### PR DESCRIPTION
We currently allow creating multiple vector indexes on one column. This doesn't make much sense as we do not support picking one when making ann queries.

To make this less confusing and to make our behavior similar to Cassandra we disallow the creation of multiple vector indexes on one column.

We also add a test that checks this behavior.

Fixes: VECTOR-254
Fixes: https://github.com/scylladb/scylladb/issues/26672