### PR TITLE
cql: fail with a better error when null vector is passed to ann query

### DIFF
--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -1217,7 +1217,13 @@ indexed_table_select_statement::actually_do_execute(query_processor& qp,
 
         auto [ann_column, ann_vector_expr] = _prepared_ann_ordering.value();
 
-        auto values = value_cast<vector_type_impl::native_type>(ann_column->type->deserialize(expr::evaluate(ann_vector_expr, options).to_bytes()));
+        auto expr_value = expr::evaluate(ann_vector_expr, options);
+
+        if (expr_value.is_null()) {
+            throw exceptions::invalid_request_exception(fmt::format("Unsupported null value for column {}", _prepared_ann_ordering->first->name_as_text()));
+        }
+
+        auto values = value_cast<vector_type_impl::native_type>(ann_column->type->deserialize(std::move(expr_value).to_bytes()));
         auto ann_vector = util::to_vector<float>(values);
 
         auto as = abort_source();


### PR DESCRIPTION
Currently when a null vector is passed to an ANN query we fail with a quite confusing error ("NoHostAvailable: ('Unable to complete the operation against any hosts', {<Host: 127.0.0.1:9042 datacenter1>: <Error from server: code=0000 [Server error] message="to_bytes() called on raw value that is null">})").

This patch fixes that by throwing an InvalidRequestException with an appropriate message instead.
We also add a test case that validates this behavior.

Fixes: VECTOR-257