### PR TITLE
test.py: fix flaky LDAP tests

### DIFF
--- a/test/ldap/ldap_common.hh
+++ b/test/ldap/ldap_common.hh
@@ -18,8 +18,10 @@ constexpr auto base_dn = "dc=example,dc=com";
 constexpr auto manager_dn = "cn=root,dc=example,dc=com";
 constexpr auto manager_password = "secret";
 const auto ldap_envport = std::getenv("SEASTAR_LDAP_PORT");
+const auto ldap_envhost = std::getenv("SEASTAR_LDAP_HOST");
 const std::string ldap_port(ldap_envport ? ldap_envport : "389");
-const seastar::socket_address local_ldap_address(seastar::ipv4_addr("127.0.0.1", std::stoi(ldap_port)));
-const seastar::socket_address local_fail_inject_address(seastar::ipv4_addr("127.0.0.1", std::stoi(ldap_port) + 2));
+const std::string ldap_host(ldap_envhost ? ldap_envhost : "127.0.0.1");
+const seastar::socket_address local_ldap_address(seastar::ipv4_addr(ldap_host, std::stoi(ldap_port)));
+const seastar::socket_address local_fail_inject_address(seastar::ipv4_addr(ldap_host, std::stoi(ldap_port) + 2));
 
 } // anonymous namespace

--- a/test/ldap/saslauthd_authenticator_test.cc
+++ b/test/ldap/saslauthd_authenticator_test.cc
@@ -80,9 +80,10 @@ bool authorize_against_this_response(temporary_buffer<char> resp, sstring socket
     return result.get();
 }
 
+int pid = getpid();
 /// Temp file name unique to this test run and this suffix.
 sstring tmpfile(const sstring& suffix) {
-    return seastar::format("saslauthd_authenticator_test.tmpfile.{}.{}", ldap_port, suffix);
+    return seastar::format("saslauthd_authenticator_test.tmpfile.{}.{}.{}", ldap_port, suffix, pid);
 }
 
 shared_ptr<db::config> make_config() {


### PR DESCRIPTION
The issue with current approach is that LDAP server starting on localhost where ports can be busy. This PR migrate using HostRegistry() instead of localhost where no busy ports.
This fix has the same idea that was on master #23235. Simple backport is not possible due to huge differences between the branches.
Additionally, Minio's host fixed as well, to avoid flakiness.

Fixes: #26295
