### PR TITLE
test/cluster/mv: Provide reason why test is skipped

### DIFF
--- a/test/cluster/mv/test_mv_topology_change.py
+++ b/test/cluster/mv/test_mv_topology_change.py
@@ -260,7 +260,7 @@ async def test_mv_pairing_during_replace(manager: ManagerClient):
 # `rf_rack_valid_keyspaces` is enabled. On the other hand, materialized views in tablet-based keyspaces
 # require the configuration option to be used.
 # Hence, we need to rewrite this test.
-@pytest.mark.skip
+@pytest.mark.skip(reason="scylladb/scylladb#26540")
 @skip_mode('release', 'error injections are not supported in release mode')
 async def test_mv_rf_change(manager: ManagerClient, delayed_replica: str, altered_dc: str):
     servers = []


### PR DESCRIPTION
We point to the issue explaining why the test was disabled
and what can be done about it.

Backport: no need. If someone wants to do something
about the test, they'll definitely look at `master` first.