### PR TITLE
mutation/mutation_compactor: compaction:stats: split partitions

### DIFF
--- a/mutation/mutation_compactor.hh
+++ b/mutation/mutation_compactor.hh
@@ -144,14 +144,19 @@ struct compaction_stats {
         return static_rows.cell_stats.dead_cells + clustering_rows.cell_stats.dead_cells +
             static_rows.cell_stats.collection_tombstones + clustering_rows.cell_stats.collection_tombstones;
     }
+    uint64_t dead_partitions() const {
+        return total_partitions - live_partitions;
+    }
 
-    uint64_t partitions = 0;
+    uint64_t total_partitions = 0;
+    uint64_t live_partitions = 0;
     row_stats static_rows;
     row_stats clustering_rows;
     uint64_t range_tombstones = 0;
 
     compaction_stats& operator+=(const compaction_stats& other) {
-        partitions += other.partitions;
+        total_partitions += other.total_partitions;
+        live_partitions += other.live_partitions;
         static_rows += other.static_rows;
         clustering_rows += other.clustering_rows;
         range_tombstones += other.range_tombstones;
@@ -253,7 +258,7 @@ private:
     void partition_is_not_empty(Consumer& consumer) {
         if (_empty_partition) {
             _empty_partition = false;
-            ++_stats.partitions;
+            ++_stats.live_partitions;
             consumer.consume_new_partition(*_dk);
             auto pt = _partition_tombstone;
             if (pt && !can_purge_tombstone(pt)) {
@@ -403,6 +408,8 @@ public:
         _effective_tombstone = {};
         _current_emitted_tombstone = {};
         _current_emitted_gc_tombstone = {};
+
+        ++_stats.total_partitions;
     }
 
     template <typename Consumer, typename GCConsumer>

--- a/replica/multishard_query.cc
+++ b/replica/multishard_query.cc
@@ -740,8 +740,10 @@ future<page_consume_result<ResultBuilder>> read_page(
             ResultBuilder::maybe_set_last_position(result, compaction_state->current_full_position());
         }
         const auto& cstats = compaction_state->stats();
-        tracing::trace(trace_state, "Page stats: {} partition(s), {} static row(s) ({} live, {} dead), {} clustering row(s) ({} live, {} dead) and {} range tombstone(s)",
-                cstats.partitions,
+        tracing::trace(trace_state, "Page stats: {} partition(s) ({} live, {} dead), {} static row(s) ({} live, {} dead), {} clustering row(s) ({} live, {} dead) and {} range tombstone(s)",
+                cstats.total_partitions,
+                cstats.live_partitions,
+                cstats.dead_partitions(),
                 cstats.static_rows.total(),
                 cstats.static_rows.live,
                 cstats.static_rows.dead,

--- a/replica/querier.hh
+++ b/replica/querier.hh
@@ -179,8 +179,10 @@ public:
         return ::replica::consume_page(std::get<mutation_reader>(_reader), _compaction_state, *_slice, std::move(consumer), row_limit,
                 partition_limit, query_time).then_wrapped([this, trace_ptr = std::move(trace_ptr)] (auto&& fut) {
             const auto& cstats = _compaction_state->stats();
-            tracing::trace(trace_ptr, "Page stats: {} partition(s), {} static row(s) ({} live, {} dead), {} clustering row(s) ({} live, {} dead), {} range tombstone(s) and {} cell(s) ({} live, {} dead)",
-                    cstats.partitions,
+            tracing::trace(trace_ptr, "Page stats: {} partition(s) ({} live, {} dead), {} static row(s) ({} live, {} dead), {} clustering row(s) ({} live, {} dead), {} range tombstone(s) and {} cell(s) ({} live, {} dead)",
+                    cstats.total_partitions,
+                    cstats.live_partitions,
+                    cstats.dead_partitions(),
                     cstats.static_rows.total(),
                     cstats.static_rows.live,
                     cstats.static_rows.dead,


### PR DESCRIPTION
Into total and live. Currently only live (those with live content) are counted. Report live and total seprately, just like we do for rows. This allows deducing the count of dead partitions as well, which is particularly interesting for scans.

Minor diagnostics improvement, no backport needed.