### PR TITLE
test: cluster: skip flaky test_raft_recovery_entry_lose test

### DIFF
--- a/test/cluster/test_raft_recovery_entry_loss.py
+++ b/test/cluster/test_raft_recovery_entry_loss.py
@@ -18,6 +18,7 @@ from test.cluster.util import check_system_topology_and_cdc_generations_v3_consi
 from test.cluster.test_group0_schema_versioning import get_group0_schema_version, get_local_schema_version
 
 
+@pytest.mark.skip(reason="https://github.com/scylladb/scylladb/issues/26534")
 @pytest.mark.asyncio
 async def test_raft_recovery_entry_lose(manager: ManagerClient):
     """


### PR DESCRIPTION
Unfortunately, the test became flaky and is blocking promotion. The cause of the flaky is not known yet but unrelated to other items currently queued on the `next` branch. The investigation continues on GitHub issue scylladb/scylladb#26534.

In the meantime, skip the test to unblock other work.

Refs: scylladb/scylladb#26534

The test was only observed to be flaky on master/next, so no need to backport to other branches.