### PR TITLE
docs/dev/service_levels: update docs to service levels on raft

### DIFF
--- a/docs/dev/topology-over-raft.md
+++ b/docs/dev/topology-over-raft.md
@@ -862,6 +862,9 @@ From the admin's point of view, the steps are as follows:
   or via observing the logs
 - After all nodes report `done` via the GET endpoint, the upgrade has fully finished
 
+Note that during the upgrade no service levels or auth operations should be done,
+as those services are performing migrations to raft metadata.
+
 The `upgrade_state` static column in `system.topology` serves the key role
 in coordinating the upgrade. It goes through the following states in the following
 order:


### PR DESCRIPTION
Since Scylla 6.0, service levels are manged by Raft group0. This patch updates table name used by service levels and adds a paragraph describing service levels on raft.

Fixes scylladb/scylladb#18177

The patch should be backported to all versions with service levels on raft.