### PR TITLE
build: disable the -fextend-variable-liveness clang option

### DIFF
--- a/cmake/mode.common.cmake
+++ b/cmake/mode.common.cmake
@@ -117,6 +117,9 @@ add_compile_options("-ffile-prefix-map=${CMAKE_BINARY_DIR}=.")
 cmake_path(GET CMAKE_BINARY_DIR FILENAME build_dir_name)
 add_compile_options("-ffile-prefix-map=${CMAKE_BINARY_DIR}/=${build_dir_name}")
 
+# https://github.com/llvm/llvm-project/issues/163007
+add_compile_options("-fextend-variable-liveness=none")
+
 default_target_arch(target_arch)
 if(target_arch)
   add_compile_options("-march=${target_arch}")

--- a/configure.py
+++ b/configure.py
@@ -1812,6 +1812,9 @@ user_cflags = args.user_cflags + f" -ffile-prefix-map={curdir}=."
 # Since gcc 13, libgcc doesn't need the exception workaround
 user_cflags += ' -DSEASTAR_NO_EXCEPTION_HACK'
 
+# https://github.com/llvm/llvm-project/issues/163007
+user_cflags += ' -fextend-variable-liveness=none'
+
 if args.target != '':
     user_cflags += ' -march=' + args.target
 


### PR DESCRIPTION
In clang 21, the -fextend-variable-liveness option was made default [1] with -Og. It helps reduce "optimized out" problems while debugging.

However, it conflicts [2] with coroutines.

To prevent problems during the upgrade to Clang 21, disable the option.

[1] https://github.com/llvm/llvm-project/commit/36af7345dfb8e84a1f2971db34089b63321e8467
[2] https://github.com/llvm/llvm-project/issues/163007

Since we aren't thinking of using clang 21 with a release branch, there is no need to backport.