### PR TITLE
test: Extend API consistency test with tokens_endpoint endpoint

### DIFF
--- a/test/pylib/rest_client.py
+++ b/test/pylib/rest_client.py
@@ -541,6 +541,15 @@ class ScyllaRESTAPIClient:
     async def reload_raft_topology_state(self, node_ip: str):
         await self.client.post("/storage_service/raft_topology/reload", node_ip)
 
+    async def tokens_endpoint(self, node_ip: str, keyspace: Optional[str] = None, table: Optional[str] = None) -> Any:
+        params = {}
+        if keyspace:
+            params['keyspace'] = keyspace
+        if table:
+            params['cf'] = table
+        return await self.client.get_json('/storage_service/tokens_endpoint', host=node_ip, params=params)
+
+
 class ScyllaMetricsLine:
     def __init__(self, name: str, labels: dict, value: float):
         self.name = name


### PR DESCRIPTION
Recently (#26231) there was added a test to check that several API endpoints, that return tokens and corresponding replica nodes, are consistent with tablet map. This patch adds one more API endpoint to the validation -- the /storage_service/tokens_endpoint one.

The extention is pretty straightforward, but the new endpoint returns back a single (primary) replica for a token, so the test check is slightly modified to account for that.

No backport, since the original test was not backported