### PR TITLE
gdb: simplify and future-proof looking up coroutine frame type

### DIFF
--- a/scylla-gdb.py
+++ b/scylla-gdb.py
@@ -6551,9 +6551,7 @@ class scylla_gdb_func_coro_frame(gdb.Function):
         block = gdb.block_for_pc((ptr - 2).dereference())
 
         # Look up the coroutine frame type.
-        # I don't understand why, but gdb has problems looking up the coro_frame_ty type if demangling is enabled.
-        with gdb.with_parameter("demangle-style", "none"):
-            coro_ty = gdb.lookup_type(f"{block.function.linkage_name}.coro_frame_ty").pointer()
+        coro_ty = block['__coro_frame'].type.pointer()
 
         return (ptr - 2).cast(coro_ty)
 


### PR DESCRIPTION
llvm recently updated [1] their coroutine debugging instructions. They now recommend looking up the variable __coro_frame in the coroutine function rather than constructing the name of the coroutine frame type from the ramp function plus __coro_frame_ty.

Since the latter method no longer works with Clang 21 (I did not check why), and since the former method is blessed as being more compatible, switch to the recommended method. Since it works with both Clang 20 and Clang 21, it future proofs the script.

[1] https://github.com/llvm/llvm-project/commit/6e784afcb5a75b60ccb9bd74f9e0033787a01282

This make scylla-gdb works with clang 21, but since we have no plans to backport clang 21 to any release, this need not be backported either.