### PR TITLE
test: unskip test_raft_recovery_entry_loss 

### DIFF
--- a/test/cluster/test_raft_recovery_entry_loss.py
+++ b/test/cluster/test_raft_recovery_entry_loss.py
@@ -18,7 +18,6 @@ from test.cluster.util import check_system_topology_and_cdc_generations_v3_consi
 from test.cluster.test_group0_schema_versioning import get_group0_schema_version, get_local_schema_version
 
 
-@pytest.mark.skip(reason="https://github.com/scylladb/scylladb/issues/26534")
 @pytest.mark.asyncio
 async def test_raft_recovery_entry_loss(manager: ManagerClient):
     """


### PR DESCRIPTION
The issue has been fixed in #26612.

No backport: the test is skipped only on master.