### PR TITLE
doc: add OS support for version 2025.4

### DIFF
--- a/docs/_static/data/os-support.json
+++ b/docs/_static/data/os-support.json
@@ -7,6 +7,15 @@
     },
     "ScyllaDB Versions": [
       {
+        "version": "ScyllaDB 2025.4",
+        "supported_OS": {
+          "Ubuntu": ["22.04", "24.04"],
+          "Debian": ["11", "12"],
+          "Rocky / CentOS / RHEL": ["8", "9", "10"],
+          "Amazon Linux": ["2023"]
+        }
+      },
+      {
         "version": "ScyllaDB 2025.3",
         "supported_OS": {
           "Ubuntu": ["22.04", "24.04"],


### PR DESCRIPTION
Fixes https://github.com/scylladb/scylladb/issues/26450

This update is relevant in version 2025.4 and must be backported to branch-2025.4.