### PR TITLE
Add max trace size output configuration variable

### DIFF
--- a/alternator/controller.cc
+++ b/alternator/controller.cc
@@ -136,6 +136,7 @@ future<> controller::start_server() {
                 [this, addr, alternator_port, alternator_https_port, creds = std::move(creds)] (server& server) mutable {
             return server.init(addr, alternator_port, alternator_https_port, creds,
                     _config.alternator_enforce_authorization,
+                    _config.alternator_max_users_query_size_in_trace_output,
                     &_memory_limiter.local().get_semaphore(),
                     _config.max_concurrent_requests_per_shard);
         }).handle_exception([this, addr, alternator_port, alternator_https_port] (std::exception_ptr ep) {

--- a/alternator/server.hh
+++ b/alternator/server.hh
@@ -43,6 +43,7 @@ class server : public peering_sharded_service<server> {
 
     key_cache _key_cache;
     utils::updateable_value<bool> _enforce_authorization;
+    utils::updateable_value<uint64_t> _max_users_query_size_in_trace_output;
     utils::small_vector<std::reference_wrapper<seastar::httpd::http_server>, 2> _enabled_servers;
     named_gate _pending_requests;
     // In some places we will need a CQL updateable_timeout_config object even
@@ -94,7 +95,8 @@ public:
     server(executor& executor, service::storage_proxy& proxy, gms::gossiper& gossiper, auth::service& service, qos::service_level_controller& sl_controller);
 
     future<> init(net::inet_address addr, std::optional<uint16_t> port, std::optional<uint16_t> https_port, std::optional<tls::credentials_builder> creds,
-            utils::updateable_value<bool> enforce_authorization, semaphore* memory_limiter, utils::updateable_value<uint32_t> max_concurrent_requests);
+            utils::updateable_value<bool> enforce_authorization, utils::updateable_value<uint64_t> max_users_query_size_in_trace_output,
+            semaphore* memory_limiter, utils::updateable_value<uint32_t> max_concurrent_requests);
     future<> stop();
     // get_client_data() is called (on each shard separately) when the virtual
     // table "system.clients" is read. It is expected to generate a list of

--- a/db/config.cc
+++ b/db/config.cc
@@ -1447,6 +1447,8 @@ db::config::config(std::shared_ptr<db::extensions> exts)
         false,
         "Allow writing to system tables using the .scylla.alternator.system prefix")
     , alternator_max_expression_cache_entries_per_shard(this, "alternator_max_expression_cache_entries_per_shard", liveness::LiveUpdate, value_status::Used, 2000, "Maximum number of cached parsed request expressions, per shard.")
+    , alternator_max_users_query_size_in_trace_output(this, "alternator_max_users_query_size_in_trace_output", liveness::LiveUpdate, value_status::Used, uint64_t(4096),
+            "Maximum size of user's command in trace output (`alternator_op` entry). Larger traces will be truncated and have `<truncated>` message appended - which doesn't count to the maximum limit.")
     , vector_store_primary_uri(this, "vector_store_primary_uri", liveness::LiveUpdate, value_status::Used, "", "A comma-separated list of vector store node URIs. If not set, vector search is disabled.")
     , abort_on_ebadf(this, "abort_on_ebadf", value_status::Used, true, "Abort the server on incorrect file descriptor access. Throws exception when disabled.")
     , sanitizer_report_backtrace(this, "sanitizer_report_backtrace", value_status::Used, false,

--- a/db/config.hh
+++ b/db/config.hh
@@ -466,6 +466,7 @@ public:
     named_value<uint32_t> alternator_max_items_in_batch_write;
     named_value<bool> alternator_allow_system_table_write;
     named_value<uint32_t> alternator_max_expression_cache_entries_per_shard;
+    named_value<uint64_t> alternator_max_users_query_size_in_trace_output;
 
     named_value<sstring> vector_store_primary_uri;
 

--- a/test/alternator/util.py
+++ b/test/alternator/util.py
@@ -327,7 +327,7 @@ def scylla_config_read(dynamodb, name):
             ExpressionAttributeNames={'#key': 'name'},
             ExpressionAttributeValues={':val': name}
         )
-    if not 'Items' in r:
+    if not 'Items' in r or not r['Items']:
         return None
     return r['Items'][0]['value']
 

--- a/tracing/trace_state.cc
+++ b/tracing/trace_state.cc
@@ -75,8 +75,12 @@ void trace_state::set_response_size(size_t s) noexcept {
     _records->session_rec.response_size = s;
 }
 
-void trace_state::add_query(std::string_view val) {
+void trace_state::add_query(sstring &&val) {
     _params_ptr->queries.emplace_back(std::move(val));
+}
+
+void trace_state::add_query(std::string_view val) {
+    _params_ptr->queries.emplace_back(sstring{ val });
 }
 
 void trace_state::add_session_param(std::string_view key, std::string_view val) {

--- a/tracing/trace_state.hh
+++ b/tracing/trace_state.hh
@@ -362,6 +362,16 @@ private:
      *
      * @param val the query string
      */
+    void add_query(sstring &&val);
+
+    /**
+     * Store a query string.
+     *
+     * This value will eventually be stored in a params<string, string> map of a tracing session
+     * with a 'query' key.
+     *
+     * @param val the query string
+     */
     void add_query(std::string_view val);
 
     /**
@@ -483,6 +493,7 @@ private:
     friend void set_request_size(const trace_state_ptr& p, size_t s) noexcept;
     friend void set_response_size(const trace_state_ptr& p, size_t s) noexcept;
     friend void set_batchlog_endpoints(const trace_state_ptr& p, const host_id_vector_replica_set& val);
+    friend void add_query(const trace_state_ptr& p, sstring &&val);
     friend void add_query(const trace_state_ptr& p, std::string_view val);
     friend void add_session_param(const trace_state_ptr& p, std::string_view key, std::string_view val);
     friend void set_common_query_parameters(const trace_state_ptr& p, db::consistency_level consistency,
@@ -608,9 +619,15 @@ inline void set_batchlog_endpoints(const trace_state_ptr& p, const host_id_vecto
     }
 }
 
-inline void add_query(const trace_state_ptr& p, std::string_view val) {
+inline void add_query(const trace_state_ptr& p, sstring &&val) {
     if (p) {
         p->add_query(std::move(val));
+    }
+}
+
+inline void add_query(const trace_state_ptr& p, std::string_view val) {
+    if (p) {
+        p->add_query(val);
     }
 }
 


### PR DESCRIPTION
Alternator will truncate tracing messages to 1024 by default. Some clients would prefer to retrieve full tracing messages. This patch intruduces configuration variable, which sets maximum size of tracing message.

- add configuration varable `alternator_max_size_trace_output` with default value of 1024 (old default).
- modify `truncated_content_view` function to use new configuration variable for truncation limit
- update `truncated_content_view` to consistently truncate at given size, previously trunctation would also happen when data arrived in more than one chunk
- update `truncated_content_view` to better handle truncated value (limit number of copies)
- small fix in `scylla_config_read` python function
- add test

Refs #26634
Refs #24031