### PR TITLE
test/cluster: Add test_simulate_upgrade_legacy_to_raft_listener_registration

### DIFF
--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -2187,6 +2187,7 @@ future<> storage_service::track_upgrade_progress_to_topology_coordinator(sharded
             // First, wait for the feature to become enabled
             shared_promise<> p;
             auto sub = _feature_service.supports_consistent_topology_changes.when_enabled([&] () noexcept { p.set_value(); });
+            rtlogger.debug("Waiting for cluster feature `SUPPORTS_CONSISTENT_TOPOLOGY_CHANGES`");
             co_await p.get_shared_future(_group0_as);
             rtlogger.info("The cluster is ready to start upgrade to the raft topology. The procedure needs to be manually triggered. Refer to the documentation");
 

--- a/test/cluster/test_raft_cluster_features.py
+++ b/test/cluster/test_raft_cluster_features.py
@@ -9,6 +9,7 @@ Tests that are specific to the raft-based cluster feature implementation.
 import asyncio
 import time
 
+from test.cluster.conftest import skip_mode
 from test.pylib.manager_client import ManagerClient
 from test.pylib.util import wait_for_cql_and_get_hosts, wait_for_feature
 from test.cluster import test_cluster_features
@@ -84,3 +85,50 @@ async def test_cannot_disable_cluster_feature_after_all_declare_support(manager:
     cql = cql = manager.get_cql()
     hosts = await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
     await asyncio.gather(*(wait_for_feature('TEST_ONLY_FEATURE', cql, h, time.time() + 60) for h in hosts))
+
+@pytest.mark.asyncio
+@skip_mode("release", "error injections are not supported in release mode")
+async def test_simulate_upgrade_legacy_to_raft_listener_registration(manager: ManagerClient):
+    """
+    We simulate an upgrade from legacy mode to Raft. Our goal is
+    to make sure that the cluster successfully reaches the state
+    where it can start the upgrade procedure.
+
+    This test effectively reproduces the problem described
+    in scylladb/scylladb#18049.
+    """
+
+    # We need this so that the first logs we wait for appear.
+    cmdline = ["--logger-log-level", "raft_topology=debug"]
+    # Tablets and legacy mode are incompatible with each other.
+    config = {"force_gossip_topology_changes": True,
+              "tablets_mode_for_new_keyspaces": "disabled"}
+    
+    error_injection = { "name": "suppress_features", "value": "SUPPORTS_CONSISTENT_TOPOLOGY_CHANGES"}
+    bad_config = config | {"error_injections_at_startup": [error_injection]}
+
+    # We need to bootstrap the nodes one-by-one.
+    # We can't do it concurrently without Raft.
+    s1 = await manager.server_add(cmdline=cmdline, config=bad_config)
+    s2 = await manager.server_add(cmdline=cmdline, config=bad_config)
+
+    # Simulate upgrading node 1.
+    await manager.server_stop_gracefully(s1.server_id)
+    await manager.server_update_config(s1.server_id, "error_injections_at_startup", [])
+
+    log = await manager.server_open_log(s1.server_id)
+    mark = await log.mark()
+
+    await manager.server_start(s1.server_id)
+
+    # The node should block after this.
+    await log.wait_for("Waiting for cluster feature `SUPPORTS_CONSISTENT_TOPOLOGY_CHANGES`", from_mark=mark)
+    mark = await log.mark()
+
+    # Simulate upgrading node 2.
+    await manager.server_stop_gracefully(s2.server_id)
+    await manager.server_update_config(s2.server_id, "error_injections_at_startup", [])
+    await manager.server_start(s2.server_id)
+
+    # If everything went smoothly, we'll get to this.
+    await log.wait_for("The cluster is ready to start upgrade to the raft topology")


### PR DESCRIPTION
We provide a reproducer test of the bug described in
scylladb/scylladb#18049. It should fail before the fix introduced in
scylladb/scylladb@7ea6e1ec0ae4d651fefb888df5f0fff542d4a47c, and it
should succeed after it.

Refs scylladb/scylladb#18049
Fixes scylladb/scylladb#18071

Backport: not needed, but we can consider it.