### PR TITLE
test/cluster: fix missing await in test_group0_tombstone_gc

### DIFF
--- a/test/cluster/test_tombstone_gc.py
+++ b/test/cluster/test_tombstone_gc.py
@@ -107,7 +107,7 @@ async def test_group0_tombstone_gc(manager: ManagerClient):
     async def alter_system_schema(keyspace=None, table_count=3):
         if not keyspace:
             async with new_test_keyspace(manager, "with replication = { 'class': 'NetworkTopologyStrategy', 'replication_factor': 2}", host=host_primary) as keyspace:
-                alter_system_schema(keyspace, table_count)
+                await alter_system_schema(keyspace, table_count)
                 return
 
         for _ in range(table_count):


### PR DESCRIPTION
The recursive call to alter_system_schema() was missing the await keyword, which meant the coroutine was never actually executed and the test wasn't doing what it was supposed to do.

Not backporting: Test fix only.
