### PR TITLE
alternator: fix CDC events for TTL expiration

### DIFF
--- a/alternator/streams.cc
+++ b/alternator/streams.cc
@@ -1002,9 +1002,9 @@ future<executor::request_return_type> executor::get_records(client_state& client
             case cdc::operation::service_row_delete:
             case cdc::operation::service_partition_delete:
             {
-                auto user_identity = rjson::value();
-                rjson::add(user_identity, "type", "Service");
-                rjson::add(user_identity, "principalId", "dynamodb.amazonaws.com");
+                auto user_identity = rjson::empty_object();
+                rjson::add(user_identity, "Type", "Service");
+                rjson::add(user_identity, "PrincipalId", "dynamodb.amazonaws.com");
                 rjson::add(record, "userIdentity", std::move(user_identity));
                 rjson::add(record, "eventName", "REMOVE");
                 break;

--- a/docs/alternator/compatibility.md
+++ b/docs/alternator/compatibility.md
@@ -211,11 +211,6 @@ In Alternator, the expiration delay is configurable - it can be set
 with the `--alternator-ttl-period-in-seconds` configuration option.
 The default is 24 hours.
 
-One thing the implementation is missing is that expiration
-events appear in the Streams API as normal deletions - without the
-distinctive marker on deletions which are really expirations.
-See <https://github.com/scylladb/scylla/issues/5060>.
-
 ## Scan ordering
 
 In DynamoDB, scanning the _entire_ table returns the partitions sorted by

--- a/test/alternator/test_ttl.py
+++ b/test/alternator/test_ttl.py
@@ -655,9 +655,14 @@ def test_ttl_expiration_lsi_key(dynamodb, waits_for_expiration):
 # becoming expired. This event should contain be a REMOVE event, contain
 # the appropriate information about the expired item (its key and/or its
 # content), and a special userIdentity flag saying that this is not a regular
-# REMOVE but an expiration.
-@pytest.mark.veryslow
-def test_ttl_expiration_streams(dynamodb, dynamodbstreams):
+# REMOVE but an expiration. Reproduces issue #11523.
+def test_ttl_expiration_streams(dynamodb, dynamodbstreams, waits_for_expiration):
+    # Alternator Streams currently doesn't work with tablets, so until
+    # #23838 is solved, skip this test on tablets.
+    for tag in TAGS:
+        if tag['Key'] == 'experimental:initial_tablets' and tag['Value'].isdigit():
+            pytest.skip("Streams test skipped on tablets due to #23838")
+
     # In my experiments, a 30-minute (1800 seconds) is the typical
     # expiration delay in this test. If the test doesn't finish within
     # max_duration, we report a failure.


### PR DESCRIPTION
In commit a3ec6c7d1dc5cd95eb9e01925cfd264663395b8e we supposedly implemented the feature of telling TTL experation events from regular user-sent deletions. However, that implementation did not actually work at all, and had two bugs:

 1. It created an null rjson::value() instead of an empty dictionary rjson::empty_object(), so GetRecords failed every time such a TTL expiration event was generated.
 2. In the output it used lowercase field names "type" and "principalId" instead of the upper case Type and PrincipalId. This is not the correct capitalization, and when boto3 recieves such incorrect fields it silently deletes them and never passes them to the user's get_records() call...

This patch fixes those two bugs, and importantly - enables a test for this feature. We did already have such a test but it was marked as "veryslow" so doesn't run in CI and apparently not even run once to check the new feature. This test is not actually very long on Alternator when the TTL period is set very low (as we do in our tests), so replaced the "veryslow" marker by "waits_for_expiration" (meaning that the test is still very slow - as much as half an hour - on DynamoDB, but runs quickly on Scylla in our test setup).

The enabled test failed badly before this patch (a server error during GetRecords), and passes with this patch.

Also, the aforementioned commit forgot to remove the paragraph in Alternator's compatibility.md that claims we don't have that feature yet. So we do it now.
