### PR TITLE
Add table column to system_traces.sessions table

### DIFF
--- a/docs/dev/tracing.md
+++ b/docs/dev/tracing.md
@@ -125,6 +125,12 @@ Note that there is no guaranteed way to know when the tracing of a particular se
 * `request`: a short string describing the current query, like "Execute CQL3 query"
 * `started_at`: is a timestamp taken when tracing session has began
 
+##### Alternator specific
+Alternator commands will add following information to traces:
+* `alternator_op` key in `parameters` map - operation type, for example `CreateTable`
+* `table` key in `parameters` map - table used in given session if there was exactly one
+* `table[0]`, `table[1]`, ... in `parameters` map - tables used in given session, if there were more than one. Names will be sorted before inserting, names will not repeat
+
 ### Slow queries logging
 #### The motivation
 Many times in real life installations one of the most important parameters of the system is the longest response time. Naturally, the shorter it is - the better. Therefore capturing the request that take a long time and understanding why it took it so long is a very critical and challenging task.

--- a/tracing/trace_state.cc
+++ b/tracing/trace_state.cc
@@ -114,6 +114,7 @@ void trace_state::build_parameters_map() {
 
     auto& params_map = _records->session_rec.parameters;
     params_values& vals = *_params_ptr;
+    const auto &tables = _records->session_rec.tables;
 
     if (vals.batchlog_endpoints) {
         auto batch_endpoints = fmt::format("{}", fmt::join(*vals.batchlog_endpoints | std::views::transform([](locator::host_id ep) {return seastar::format("/{}", ep);}), ","));
@@ -130,6 +131,15 @@ void trace_state::build_parameters_map() {
 
     if (vals.page_size) {
         params_map.emplace("page_size", seastar::format("{:d}", *vals.page_size));
+    }
+
+    if (tables.size() == 1) {
+        params_map.emplace("table", *tables.begin());
+    } else {
+        size_t index = 0;
+        for (const auto& table : tables) {
+            params_map.emplace(format("table[{:d}]", index++), table);
+        }
     }
 
     auto& queries = vals.queries;

--- a/tracing/trace_state.hh
+++ b/tracing/trace_state.hh
@@ -501,6 +501,7 @@ private:
     friend void add_prepared_statement(const trace_state_ptr& p, prepared_checked_weak_ptr& prepared);
     friend void set_username(const trace_state_ptr& p, const std::optional<auth::authenticated_user>& user);
     friend void add_table_name(const trace_state_ptr& p, const sstring& ks_name, const sstring& cf_name);
+    friend void add_alternator_table_name(const trace_state_ptr& p, std::string_view table_name);
     friend void add_prepared_query_options(const trace_state_ptr& state, const cql3::query_options& prepared_options_ptr);
     friend void stop_foreground(const trace_state_ptr& state) noexcept;
 };
@@ -674,6 +675,12 @@ inline void set_username(const trace_state_ptr& p, const std::optional<auth::aut
 inline void add_table_name(const trace_state_ptr& p, const sstring& ks_name, const sstring& cf_name) {
     if (p) {
         p->add_table_name(ks_name + "." + cf_name);
+    }
+}
+
+inline void add_alternator_table_name(const trace_state_ptr& p, std::string_view table_name) {
+    if (p) {
+        p->add_table_name(sstring{ table_name });
     }
 }
 

--- a/tracing/tracing.hh
+++ b/tracing/tracing.hh
@@ -134,7 +134,7 @@ public:
     }
 };
 
-struct one_session_records;
+class one_session_records;
 using records_bulk = std::deque<lw_shared_ptr<one_session_records>>;
 
 struct backend_session_state_base {


### PR DESCRIPTION
Add table name to tracing in alternator

Add a table name to Alternator's tracing output, as some clients would
like to consistently receive this information.

- add missing `tracing::add_table_name` in `executor::scan`
- add emiting tables' names in `trace_state::build_parameters_map`
- update tests, so when tracing is looked for it is filtered by table's
  name, which confirms table is being outputed.

Refs #26618
Fixes #24031