### PR TITLE
doc: add support for Debian 12

### DIFF
--- a/docs/_static/data/os-support.json
+++ b/docs/_static/data/os-support.json
@@ -1,7 +1,7 @@
 {
     "Linux Distributions": {
       "Ubuntu": ["22.04", "24.04"],
-      "Debian": ["11"],
+      "Debian": ["11", "12"],
       "Rocky / CentOS / RHEL": ["8", "9", "10"],
       "Amazon Linux": ["2023"]
     },
@@ -10,7 +10,7 @@
         "version": "ScyllaDB 2025.3",
         "supported_OS": {
           "Ubuntu": ["22.04", "24.04"],
-          "Debian": ["11"],
+          "Debian": ["11", "12"],
           "Rocky / CentOS / RHEL": ["8", "9", "10"],
           "Amazon Linux": ["2023"]
         }
@@ -19,7 +19,7 @@
         "version": "ScyllaDB 2025.2",
         "supported_OS": {
           "Ubuntu": ["22.04", "24.04"],
-          "Debian": ["11"],
+          "Debian": ["11", "12"],
           "Rocky / CentOS / RHEL": ["8", "9"],
           "Amazon Linux": ["2023"]
         }
@@ -28,7 +28,7 @@
         "version": "ScyllaDB 2025.1",
         "supported_OS": {
           "Ubuntu": ["22.04", "24.04"],
-          "Debian": ["11"],
+          "Debian": ["11", "12"],
           "Rocky / CentOS / RHEL": ["8", "9"],
           "Amazon Linux": ["2023"]
         }


### PR DESCRIPTION
Fixes https://github.com/scylladb/scylladb/issues/26640

This PR adds information about support for Debian 12, which is missing from version 2025.1 and later, so it must be backported to all those versions.