### PR TITLE
docs: add new `--list-active-releases` flag

### DIFF
--- a/docs/getting-started/installation-common/scylla-web-installer.rst
+++ b/docs/getting-started/installation-common/scylla-web-installer.rst
@@ -14,6 +14,12 @@ See :doc:`OS Support by Platform and Version </getting-started/os-support/>`.
 
 Install ScyllaDB with Web Installer
 ---------------------------------------
+To get the list of supported release versions:
+
+.. code:: console
+
+    curl -sSf get.scylladb.com/server | sudo bash -s -- --list-active-releases
+
 To install ScyllaDB with Web Installer, run:
 
 .. code:: console


### PR DESCRIPTION
adding to docs new option to get available releases

Need https://github.com/scylladb/scylladb-web-install/pull/84 to get in first before merging

**No need for backport as the doc is updated in central place**