### PR TITLE
error_injection: Add template parameter default for in release mode

### DIFF
--- a/utils/error_injection.hh
+++ b/utils/error_injection.hh
@@ -654,13 +654,13 @@ public:
         return make_ready_future<>();
     }
 
-    template <typename T>
+    template <typename T = std::string_view>
     [[gnu::always_inline]]
     std::optional<T> inject_parameter(const std::string_view& name, const std::string_view param_name) {
         return std::nullopt;
     }
 
-    template <typename T>
+    template <typename T = std::string_view>
     [[gnu::always_inline]]
     std::optional<T> inject_parameter(const std::string_view& name) {
         return std::nullopt;


### PR DESCRIPTION
The std::optional<T> inject_parameter(...) method is a template, and in dev/debug modes this parameter is defaulted to std::string_view, but for release mode it's not. This patch makes it symmetrical.

Small improvement, no need to backport