### PR TITLE
cmake: link crypto lib to utils

### DIFF
--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -78,6 +78,7 @@ target_link_libraries(utils
     xxHash::xxhash
   PRIVATE
     Boost::regex
+	crypto
     cryptopp::cryptopp
     rapidxml::rapidxml
     yaml-cpp::yaml-cpp


### PR DESCRIPTION
The utils library requires OpenSSL's libcrypto for cryptographic operations and without linking libcrypto, builds fail with undefined symbol errors. Fix that by linking `crypto` to `utils` library when compiled with cmake. The build files generated with configure.py already have `crypto` lib linked, so they do not have this issue.

Fix #26705 

Fixes Cmake issue. No need to backport.