### PR TITLE
raft topology: skip non-idempotent steps in decommission path to avoid problems during races

### DIFF
--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -2681,6 +2681,39 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
             case topology::transition_state::left_token_ring: {
                 auto node = get_node_to_work_on(std::move(guard));
 
+                auto finish_left_token_ring_transition = [&](node_to_work_on& node) -> future<> {
+                    // Remove the node from group0 here - in general, it won't be able to leave on its own
+                    // because we'll ban it as soon as we tell it to shut down.
+                    node = retake_node(co_await remove_from_group0(std::move(node.guard), node.id), node.id);
+
+                    utils::get_local_injector().inject("finish_left_token_ring_transition_throw", [] {
+                        throw std::runtime_error("finish_left_token_ring_transition failed due to error injection");
+                    });
+
+                    utils::chunked_vector<canonical_mutation> muts;
+
+                    topology_mutation_builder builder(node.guard.write_timestamp());
+                    cleanup_ignored_nodes_on_left(builder, node.id);
+                    builder.del_transition_state()
+                            .with_node(node.id)
+                            .set("node_state", node_state::left);
+                    muts.push_back(builder.build());
+                    co_await remove_view_build_statuses_on_left_node(muts, node.guard, node.id);
+                    co_await db::view::view_builder::generate_mutations_on_node_left(_db, _sys_ks, node.guard.write_timestamp(), locator::host_id(node.id.uuid()), muts);
+                    auto str = node.rs->state == node_state::decommissioning
+                            ? ::format("finished decommissioning node {}", node.id)
+                            : ::format("finished rollback of {} after {} failure", node.id, node.rs->state);
+                    co_await update_topology_state(take_guard(std::move(node)), std::move(muts), std::move(str));
+                };
+
+                // Denotes the case when this path is already executed before and first topology state update was successful.
+                // So we can skip all steps and perform the second topology state update operation (which modifies node state to left)
+                // and remove node conditionally from group0.
+                if (auto [done, error] = co_await _sys_ks.get_topology_request_state(node.rs->request_id, false); done) {
+                    co_await finish_left_token_ring_transition(node);
+                    break;
+                }
+
                 if (node.id == _raft.id()) {
                     // Someone else needs to coordinate the rest of the decommission process,
                     // because the decommissioning node is going to shut down in the middle of this state.
@@ -2753,24 +2786,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
                     node = retake_node(co_await start_operation(), node_id);
                 }
 
-                // Remove the node from group0 here - in general, it won't be able to leave on its own
-                // because we'll ban it as soon as we tell it to shut down.
-                node = retake_node(co_await remove_from_group0(std::move(node.guard), node.id), node.id);
-
-                utils::chunked_vector<canonical_mutation> muts;
-
-                topology_mutation_builder builder(node.guard.write_timestamp());
-                cleanup_ignored_nodes_on_left(builder, node.id);
-                builder.del_transition_state()
-                       .with_node(node.id)
-                       .set("node_state", node_state::left);
-                muts.push_back(builder.build());
-                co_await remove_view_build_statuses_on_left_node(muts, node.guard, node.id);
-                co_await db::view::view_builder::generate_mutations_on_node_left(_db, _sys_ks, node.guard.write_timestamp(), locator::host_id(node.id.uuid()), muts);
-                auto str = node.rs->state == node_state::decommissioning
-                        ? ::format("finished decommissioning node {}", node.id)
-                        : ::format("finished rollback of {} after {} failure", node.id, node.rs->state);
-                co_await update_topology_state(take_guard(std::move(node)), std::move(muts), std::move(str));
+                co_await finish_left_token_ring_transition(node);
             }
                 break;
             case topology::transition_state::rollback_to_normal: {


### PR DESCRIPTION
In the present scenario, there are issues in left_token_ring transition state
execution in the decommissioning path. In case of concurrent mutation race
conditions, we enter left_token_ring more than once, and apparently if
we enter left token ring second time, we try to barrier the decommisioned
node, which at this point is no longer possible. That's what causes the errors.

This pr resolves the issue by adding a check right in the start of
left_token_ring to check if the first topology state update, which marks
the request as done is completed. In this case, its confirmed that this
is the second time flow is entering left_token_ring and the steps preceding
the request status update should be skipped. In such cases, all the rest
steps are skipped and topology node status update( which threw error in
previous trial) is executed directly. Node removal status from group0 is
also checked and remove operation is retried if failed last time.

Although these changes are done with regard to the decommission operation
behavior in `left_token_ring` transition state, but since the pr doesn't
interfere with the core logic, it should not derail any rollback specific
logic. The changes just prevent some non-idempotent operations from
re-occuring in case of failures. Rest of the core logic remain intact.

Test is also added to confirm the proper working of the same.

Fixes: scylladb/scylladb#20865

Backport is not needed, since this is not a super critical bug fix.