### PR TITLE
[WiP] s3_perf: Test pure download in the context of restore

### DIFF
--- a/test/cluster/object_store/conftest.py
+++ b/test/cluster/object_store/conftest.py
@@ -296,7 +296,7 @@ class GSServer(GSFront):
             self.logfile.close()
         self.unpublish()
 
-@pytest.fixture(scope="function", params=['s3','gs'])
+@pytest.fixture(scope="function", params=['s3'])
 async def object_storage(request, pytestconfig, tmpdir):
     server = None
 

--- a/test/cluster/object_store/test_backup.py
+++ b/test/cluster/object_store/test_backup.py
@@ -335,7 +335,7 @@ async def do_test_simple_backup_and_restore(manager: ManagerClient, object_stora
     #    - ...
     suffix = 'suffix'
     old_files = list_sstables();
-    toc_names = [f'{suffix}/{entry.name}' for entry in old_files if entry.name.endswith('TOC.txt')]
+    toc_names = [f'{entry.name}' for entry in old_files if entry.name.endswith('TOC.txt')]
 
     prefix = f'{cf}/{snap_name}'
     tid = await manager.api.backup(server.ip_addr, ks, cf, snap_name, object_storage.address, object_storage.bucket_name, f'{prefix}/{suffix}')
@@ -352,7 +352,7 @@ async def do_test_simple_backup_and_restore(manager: ManagerClient, object_stora
     assert len(objects) > 0
 
     print('Try to restore')
-    tid = await manager.api.restore(server.ip_addr, ks, cf, object_storage.address, object_storage.bucket_name, prefix, toc_names)
+    tid = await manager.api.restore(server.ip_addr, ks, cf, object_storage.address, object_storage.bucket_name, f'{prefix}/{suffix}', toc_names)
 
     if do_abort:
         await manager.api.abort_task(server.ip_addr, tid)


### PR DESCRIPTION
This PR introduces a mechanism to measure pure S3 download speed by emulating a restore process that performs downloads only—without executing full load or stream flow operations. The approach leverages the SCT restore test, which uses pre-created backups. The new flow repeatedly downloads all components of all SSTables over a defined time period, providing a consistent and isolated benchmark for S3 throughput.

Refs: https://github.com/scylladb/scylladb/issues/26721
