### PR TITLE
storage_proxy: safely handle deleted response handler before mutate_begin

### DIFF
--- a/service/storage_proxy.hh
+++ b/service/storage_proxy.hh
@@ -350,6 +350,7 @@ private:
             coordinator_query_options optional_params);
     response_id_type register_response_handler(shared_ptr<abstract_write_response_handler>&& h);
     void remove_response_handler(response_id_type id);
+    void remove_response_handler_if_exists(response_id_type id);
     void remove_response_handler_entry(response_handlers_map::iterator entry);
     void got_response(response_id_type id, locator::host_id from, std::optional<db::view::update_backlog> backlog);
     void got_failure_response(response_id_type id, locator::host_id from, size_t count, std::optional<db::view::update_backlog> backlog, error err, std::optional<sstring> msg);


### PR DESCRIPTION
The storage proxy tracks progress of a write operation via response handlers. Most commonly they are initialized in `mutate_prepare`, and the write operations start in `mutate_begin`.

When the response handler is initialized, it is registered and inserted into the `_response_handlers` map, and a
`unique_response_handler_vector` is returned with the response ids. The following code, until `mutate_begin`, assumes that a `unique_response_handler` points to an existing entry in `_response_handlers`.

However, it is possible that the response handler is removed during a preemption point. For example, in `storage_proxy::on_down` we remove all cancellable response handlers for a node that is detected down.

This could cause a crash or undefined behavior when we try to access the response handler and it's not guaranteed to be found. This could happen between `mutate_prepare` and `mutate_begin`, in
`register_cdc_operation_result_tracker`, and also in the destructor of `unique_response_handler`. After that, in `mutate_begin`, the code is prepared to handle the case that a response handler doesn't exist.

We fix the problematic accesses to check and handle a deleted response handler:
* `register_cdc_operation_result_tracker` attaches an object to the response handler that's used for updating cdc metrics about the operation. if the response handler is not found, probably because it failed earlier, we ignore it. we can't update the cdc metrics reliably because we don't know if the response handler's schema has cdc enabled. it's acceptable to ignore because this should happen very rarely and only affect cdc metrics.
* the destructor of `unique_response_handler` removes the response handler that it points to. it is safe to relax it to ignore it if it's not found instead of asserting.

Fixes scylladb/scylladb#26664

backport is possible but not required - it's a rare race condition that wasn't observed in practice