### PR TITLE
sstables_loader: Don't bypass synchronization with busy topology

### DIFF
--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -8266,6 +8266,20 @@ void storage_service::set_topology_change_kind(topology_change_kind kind) {
     _gossiper.set_topology_state_machine(kind == topology_change_kind::raft ? & _topology_state_machine : nullptr);
 }
 
+bool storage_service::raft_topology_change_enabled() const {
+    if (this_shard_id() != 0) {
+        on_internal_error(slogger, "raft_topology_change_enabled() must run on shard 0");
+    }
+    return _topology_change_kind_enabled == topology_change_kind::raft;
+}
+
+bool storage_service::legacy_topology_change_enabled() const {
+    if (this_shard_id() != 0) {
+        on_internal_error(slogger, "legacy_topology_change_enabled() must run on shard 0");
+    }
+    return _topology_change_kind_enabled == topology_change_kind::legacy;
+}
+
 future<> storage_service::register_protocol_server(protocol_server& server, bool start_instantly) {
     _protocol_servers.push_back(&server);
     if (start_instantly) {

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -915,12 +915,8 @@ private:
     topology_change_kind upgrade_state_to_topology_op_kind(topology::upgrade_state_type upgrade_state) const;
 
 public:
-    bool raft_topology_change_enabled() const {
-        return _topology_change_kind_enabled == topology_change_kind::raft;
-    }
-    bool legacy_topology_change_enabled() const {
-        return _topology_change_kind_enabled == topology_change_kind::legacy;
-    }
+    bool raft_topology_change_enabled() const;
+    bool legacy_topology_change_enabled() const;
 
 private:
     future<> _raft_state_monitor = make_ready_future<>();

--- a/test/cluster/test_tablets2.py
+++ b/test/cluster/test_tablets2.py
@@ -1727,7 +1727,6 @@ async def test_tablet_load_and_stream_and_split_synchronization(manager: Manager
     cmdline = [
         '--logger-log-level', 'storage_service=debug',
         '--logger-log-level', 'table=debug',
-        '--smp', '1',
     ]
     servers = [await manager.server_add(config={
         'tablet_load_stats_refresh_interval_in_seconds': 1


### PR DESCRIPTION
The patch c543059f86 fixed the synchronization issue between tablet split and load-and-stream. The synchronization worked only with raft topology, and therefore was disabled with gossip. To do the check, storage_service::raft_topology_change_enabled() but the topology kind is only available/set on shard 0, so it caused the synchronization to be bypassed when load-and-stream runs on any shard other than 0.

The reason the reproducer didn't catch it is that it was restricted to single cpu. It will now run with multi cpu and catch the problem observed.

Fixes #22707

Will be backported to vulnerable branches along with c543059f86