### PR TITLE
build: update toolchain to Fedora 43 with clang 21.1.6

### DIFF
--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -38,6 +38,7 @@ debian_base_packages=(
     python3-aiohttp
     python3-pyparsing
     python3-colorama
+    python3-dev
     python3-tabulate
     python3-pytest
     python3-pytest-asyncio
@@ -65,6 +66,7 @@ debian_base_packages=(
     git-lfs
     e2fsprogs
     fuse3
+    libev-dev # for python driver
 )
 
 fedora_packages=(
@@ -90,6 +92,7 @@ fedora_packages=(
     patchelf
     python3
     python3-aiohttp
+    python3-devel
     python3-pip
     python3-file-magic
     python3-colorama
@@ -154,6 +157,8 @@ fedora_packages=(
     https://github.com/scylladb/cassandra-stress/releases/download/v3.18.1/cassandra-stress-java21-3.18.1-1.noarch.rpm
     elfutils
     jq
+
+    libev-devel # for python driver
 )
 
 fedora_python3_packages=(

--- a/tools/toolchain/Dockerfile
+++ b/tools/toolchain/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/fedora:42
+FROM registry.fedoraproject.org/fedora:43
 
 ARG CLANG_BUILD="SKIP"
 ARG CLANG_ARCHIVES

--- a/tools/toolchain/image
+++ b/tools/toolchain/image
@@ -1,1 +1,1 @@
-docker.io/scylladb/scylla-toolchain:fedora-42-20251122
+docker.io/scylladb/scylla-toolchain:fedora-43-20251208

--- a/tools/toolchain/optimized_clang.sh
+++ b/tools/toolchain/optimized_clang.sh
@@ -65,7 +65,7 @@ SCYLLA_BUILD_DIR_FULLPATH="${SCYLLA_DIR}"/"${SCYLLA_BUILD_DIR}"
 SCYLLA_NINJA_FILE_FULLPATH="${SCYLLA_DIR}"/"${SCYLLA_NINJA_FILE}"
 
 # Which LLVM release to build in order to compile Scylla
-LLVM_CLANG_TAG=20.1.8
+LLVM_CLANG_TAG=21.1.6
 
 CLANG_ARCHIVE=$(cd "${SCYLLA_DIR}" && realpath -m "${CLANG_ARCHIVE}")
 
@@ -186,7 +186,3 @@ if [[ $? -ne 0 ]]; then
 fi
 set -e
 tar -C / -xpzf "${CLANG_ARCHIVE}"
-dnf remove -y clang clang-libs
-# above package removal might have removed those symbolic links, which will cause ccache not to work later on. Manually restore them.
-ln -sf /usr/bin/ccache /usr/lib64/ccache/clang
-ln -sf /usr/bin/ccache /usr/lib64/ccache/clang++


### PR DESCRIPTION
Rebase to Fedora 43 with clang 21.1 and libstdc++ 15.

Fedora container image registry moved to registry.fedoraproject.org as it seems to be updated more regularly.

Optimized clang binaries generates and stored in

  https://devpkg.scylladb.com/clang/clang-21.1.6-Fedora-43-aarch64.tar.gz
  https://devpkg.scylladb.com/clang/clang-21.1.6-Fedora-43-x86_64.tar.gz

With ./scripts/refresh-pgo-profiles.sh, the new compiler shows a small performance improvement (instructions_per_op) in perf-simple-query:

clang 21:

259353.60 tps ( 64.1 allocs/op,   0.0 logallocs/op,  14.1 tasks/op,   35720 insns/op,   17427 cycles/op,        0 errors)
265940.08 tps ( 64.1 allocs/op,   0.0 logallocs/op,  14.1 tasks/op,   35725 insns/op,   17042 cycles/op,        0 errors)
262650.01 tps ( 64.1 allocs/op,   0.0 logallocs/op,  14.1 tasks/op,   35720 insns/op,   17240 cycles/op,        0 errors)
262881.22 tps ( 64.1 allocs/op,   0.0 logallocs/op,  14.1 tasks/op,   35675 insns/op,   17222 cycles/op,        0 errors)
264898.68 tps ( 64.1 allocs/op,   0.0 logallocs/op,  14.1 tasks/op,   35732 insns/op,   17070 cycles/op,        0 errors)
throughput:
	mean=   263144.72 standard-deviation=2528.69
	median= 262881.22 median-absolute-deviation=1753.96
	maximum=265940.08 minimum=259353.60
instructions_per_op:
	mean=   35714.47 standard-deviation=22.34
	median= 35720.38 median-absolute-deviation=10.20
	maximum=35732.14 minimum=35675.50
cpu_cycles_per_op:
	mean=   17200.12 standard-deviation=154.62
	median= 17221.70 median-absolute-deviation=129.77
	maximum=17427.33 minimum=17041.57

clang 20:

254431.39 tps ( 64.1 allocs/op,   0.0 logallocs/op,  14.1 tasks/op,   35883 insns/op,   17708 cycles/op,        0 errors)
259701.02 tps ( 64.1 allocs/op,   0.0 logallocs/op,  14.1 tasks/op,   35883 insns/op,   17351 cycles/op,        0 errors)
261166.92 tps ( 64.1 allocs/op,   0.0 logallocs/op,  14.1 tasks/op,   35912 insns/op,   17270 cycles/op,        0 errors)
260656.31 tps ( 64.1 allocs/op,   0.0 logallocs/op,  14.1 tasks/op,   35869 insns/op,   17289 cycles/op,        0 errors)
259628.13 tps ( 64.1 allocs/op,   0.0 logallocs/op,  14.1 tasks/op,   35946 insns/op,   17370 cycles/op,        0 errors)
throughput:
	mean=   259116.75 standard-deviation=2698.56
	median= 259701.02 median-absolute-deviation=1539.55
	maximum=261166.92 minimum=254431.39
instructions_per_op:
	mean=   35898.42 standard-deviation=30.69
	median= 35882.97 median-absolute-deviation=15.90
	maximum=35945.63 minimum=35869.02
cpu_cycles_per_op:
	mean=   17397.49 standard-deviation=178.35
	median= 17351.35 median-absolute-deviation=108.79
	maximum=17707.63 minimum=17269.68

Will not backport a new toolchain to older release branches.