### PR TITLE
service: attach storage_service to migration_manager using pluggable

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -1702,7 +1702,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
 
             checkpoint(stop_signal, "starting migration manager");
             debug::the_migration_manager = &mm;
-            mm.start(std::ref(mm_notifier), std::ref(feature_service), std::ref(messaging), std::ref(proxy), std::ref(ss), std::ref(gossiper), std::ref(group0_client), std::ref(sys_ks)).get();
+            mm.start(std::ref(mm_notifier), std::ref(feature_service), std::ref(messaging), std::ref(proxy), std::ref(gossiper), std::ref(group0_client), std::ref(sys_ks)).get();
             auto stop_migration_manager = defer_verbose_shutdown("migration manager", [&mm] {
                 mm.stop().get();
             });

--- a/service/migration_manager.cc
+++ b/service/migration_manager.cc
@@ -54,7 +54,7 @@ const std::chrono::milliseconds migration_manager::migration_delay = 60000ms;
 static future<schema_ptr> get_schema_definition(table_schema_version v, locator::host_id dst, unsigned shard, netw::messaging_service& ms, service::storage_proxy& sp);
 
 migration_manager::migration_manager(migration_notifier& notifier, gms::feature_service& feat, netw::messaging_service& ms,
-            service::storage_proxy& storage_proxy, sharded<service::storage_service>& ss, gms::gossiper& gossiper, service::raft_group0_client& group0_client, sharded<db::system_keyspace>& sysks) :
+            service::storage_proxy& storage_proxy, gms::gossiper& gossiper, service::raft_group0_client& group0_client, sharded<db::system_keyspace>& sysks) :
           _notifier(notifier)
         , _group0_barrier(this_shard_id() == 0 ?
             std::function<future<>()>([this] () -> future<> {
@@ -75,7 +75,7 @@ migration_manager::migration_manager(migration_notifier& notifier, gms::feature_
             })
         )
         , _background_tasks("migration_manager::background_tasks")
-        , _feat(feat), _messaging(ms), _storage_proxy(storage_proxy), _ss(ss), _gossiper(gossiper), _group0_client(group0_client)
+        , _feat(feat), _messaging(ms), _storage_proxy(storage_proxy), _ss("migration_manager::storage_service"), _gossiper(gossiper), _group0_client(group0_client)
         , _sys_ks(sysks)
         , _schema_push([this] { return passive_announce(); })
         , _concurrent_ddl_retries{10}
@@ -92,6 +92,14 @@ future<> migration_manager::stop() {
     } catch (...) {
         mlogger.error("schema_push failed: {}", std::current_exception());
     }
+}
+
+void migration_manager::plug_storage_service(service::storage_service& ss) {
+    _ss.plug(ss.shared_from_this());
+}
+
+future<> migration_manager::unplug_storage_service() {
+    return _ss.unplug();
 }
 
 future<> migration_manager::drain()
@@ -392,6 +400,10 @@ future<> migration_manager::merge_schema_from(locator::host_id src, const utils:
     mlogger.debug("Applying schema mutations from {}", src);
     auto& proxy = _storage_proxy;
     const auto& db = proxy.get_db().local();
+    auto ss = _ss.get_permit();
+    if (!ss) {
+        co_return;
+    }
 
     if (_as.abort_requested()) {
         throw abort_requested_exception{};
@@ -409,13 +421,17 @@ future<> migration_manager::merge_schema_from(locator::host_id src, const utils:
         mlogger.error("Error while applying schema mutations from {}: {}", src, e);
         throw std::runtime_error(fmt::format("Error while applying schema mutations: {}", e));
     }
-    co_await db::schema_tables::merge_schema(_sys_ks, proxy.container(), _ss, _feat, std::move(mutations));
+    co_await db::schema_tables::merge_schema(_sys_ks, proxy.container(), ss.get()->container(), _feat, std::move(mutations));
 }
 
 future<> migration_manager::reload_schema() {
     mlogger.info("Reloading schema");
+    auto ss = _ss.get_permit();
+    if (!ss) {
+        co_return;
+    }
     utils::chunked_vector<mutation> mutations;
-    co_await db::schema_tables::merge_schema(_sys_ks, _storage_proxy.container(), _ss, _feat, std::move(mutations), true);
+    co_await db::schema_tables::merge_schema(_sys_ks, _storage_proxy.container(), ss.get()->container(), _feat, std::move(mutations), true);
 }
 
 bool migration_manager::has_compatible_schema_tables_version(const locator::host_id& endpoint) {
@@ -1080,7 +1096,11 @@ future<> migration_manager::announce_with_raft(utils::chunked_vector<mutation> s
 }
 
 future<> migration_manager::announce_without_raft(utils::chunked_vector<mutation> schema, group0_guard guard) {
-    auto f = db::schema_tables::merge_schema(_sys_ks, _storage_proxy.container(), _ss, _feat, schema);
+    auto ss = _ss.get_permit();
+    if (!ss) {
+        co_return;
+    }
+    auto f = db::schema_tables::merge_schema(_sys_ks, _storage_proxy.container(), ss.get()->container(), _feat, schema);
 
     try {
         using namespace std::placeholders;

--- a/service/migration_manager.hh
+++ b/service/migration_manager.hh
@@ -19,6 +19,7 @@
 #include "gms/i_endpoint_state_change_subscriber.hh"
 #include "schema/schema_fwd.hh"
 #include "service/storage_service.hh"
+#include "utils/pluggable.hh"
 #include "utils/serialized_action.hh"
 #include "service/raft/raft_group_registry.hh"
 #include "service/raft/raft_group0_client.hh"
@@ -63,7 +64,7 @@ private:
     gms::feature_service& _feat;
     netw::messaging_service& _messaging;
     service::storage_proxy& _storage_proxy;
-    sharded<service::storage_service>& _ss;
+    utils::pluggable<storage_service> _ss;
     gms::gossiper& _gossiper;
     seastar::abort_source _as;
     service::raft_group0_client& _group0_client;
@@ -89,7 +90,9 @@ private:
     friend class group0_state_machine; // needed for access to _messaging
     size_t _concurrent_ddl_retries;
 public:
-    migration_manager(migration_notifier&, gms::feature_service&, netw::messaging_service& ms, service::storage_proxy&, sharded<service::storage_service>& ss, gms::gossiper& gossiper, service::raft_group0_client& group0_client, sharded<db::system_keyspace>& sysks);
+    migration_manager(migration_notifier&, gms::feature_service&, netw::messaging_service& ms, service::storage_proxy&, gms::gossiper& gossiper, service::raft_group0_client& group0_client, sharded<db::system_keyspace>& sysks);
+    void plug_storage_service(service::storage_service& ss);
+    future<> unplug_storage_service();
 
     migration_notifier& get_notifier() { return _notifier; }
     const migration_notifier& get_notifier() const { return _notifier; }

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -265,6 +265,7 @@ storage_service::storage_service(abort_source& abort_source,
     }
 
     init_messaging_service();
+    _migration_manager.local().plug_storage_service(*this);
 }
 
 storage_service::~storage_service() = default;
@@ -3423,6 +3424,7 @@ future<> storage_service::replicate_to_all_cores(mutable_token_metadata_ptr tmpt
 }
 
 future<> storage_service::stop() {
+    co_await _migration_manager.local().unplug_storage_service();
     // if there is a background "isolate" shutdown
     // in progress, we need to sync with it. Mostly
     // relevant for tests

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -895,7 +895,7 @@ private:
             // gropu0 client exists only on shard 0
             service::raft_group0_client group0_client(_group0_registry.local(), _sys_ks.local(), _token_metadata.local(), maintenance_mode_enabled::no);
 
-            _mm.start(std::ref(_mnotifier), std::ref(_feature_service), std::ref(_ms), std::ref(_proxy), std::ref(_ss), std::ref(_gossiper), std::ref(group0_client), std::ref(_sys_ks)).get();
+            _mm.start(std::ref(_mnotifier), std::ref(_feature_service), std::ref(_ms), std::ref(_proxy), std::ref(_gossiper), std::ref(group0_client), std::ref(_sys_ks)).get();
             auto stop_mm = defer_verbose_shutdown("migration manager", [this] { _mm.stop().get(); });
 
             _tablet_allocator.start(service::tablet_allocator::config{}, std::ref(_mnotifier), std::ref(_db)).get();


### PR DESCRIPTION
Migration manager depends on storage service. For instance,
it has a reload_schema_in_bg background task which calls
_ss.local() so it expects that storage service is not stopped
before it stops.

To solve this we use permit approach, and during storage_service
stop:
- we ignore *new* code execution in migration_manager which'd use
  storage_service
- but wait with storage_service shutdown until all *existing*
  executions are done

Fixes scylladb/scylladb#26734

Backport: no need, problem existed since very long time, code restructure in https://github.com/scylladb/scylladb/commit/389afcd (and following commits) made
it hitting more often, as _ss was called earlier, but it's not released yet.