### PR TITLE
tablet_allocator: Avoid load balancer failure when replacing the last node in a rack with rack-list RF

### DIFF
--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -1263,7 +1263,13 @@ public:
                 }
             } else {
                 for (auto rack : rf_in_dc->get_rack_list()) {
-                    auto shards = shards_per_rack.at(endpoint_dc_rack{dc, rack});
+                    size_t shards = 0;
+                    auto dc_rack = endpoint_dc_rack{dc, rack};
+                    if (!shards_per_rack.contains(dc_rack)) {
+                        lblogger.warn("No shards for rack {}, but table {}.{} replicates there", rack, s.ks_name(), s.cf_name());
+                    } else {
+                        shards = shards_per_rack.at(dc_rack);
+                    }
                     size_t tablets_in_rack = std::ceil(min_per_shard_tablet_count * shards);
                     lblogger.debug("Estimated {} tablets due to min_per_shard_tablet_count={:.3f} for table={}.{} in rack {} ({} shards) in DC {}",
                                    tablets_in_rack, min_per_shard_tablet_count, s.ks_name(), s.cf_name(), rack, shards, dc);


### PR DESCRIPTION
Introduced in 9ebdeb2

The problem is specific to node replacing and rack-list RF. The
culprit is in the part of the load balancer which determines rack's
shard count. If we're replacing the last node, the rack will contain
no normal nodes, and shards_per_rack will have no entry for the rack,
on which the table still has replicas. This throws std::out_of_range
and fails the tablet draining stage, and node replace is failed.

No backport because the problem exists only on master.

Fixes #26768
