### PR TITLE
index/vector_index: require tablets for vector indexes

### DIFF
--- a/cql3/statements/create_index_statement.cc
+++ b/cql3/statements/create_index_statement.cc
@@ -292,7 +292,7 @@ std::vector<::shared_ptr<index_target>> create_index_statement::validate_while_e
             throw exceptions::invalid_request_exception(format("Non-supported custom class \'{}\' provided", *(_properties->custom_class)));
         }
         auto custom_index = (*custom_index_factory)();
-        custom_index->validate(*schema, *_properties, targets, db.features());
+        custom_index->validate(*schema, *_properties, targets, db.features(), db);
         _properties->index_version = custom_index->index_version(*schema);
     }
 

--- a/index/secondary_index_manager.hh
+++ b/index/secondary_index_manager.hh
@@ -104,7 +104,8 @@ public:
     virtual std::optional<cql3::description> describe(const index_metadata& im, const schema& base_schema) const = 0;
     virtual bool view_should_exist() const = 0;
     virtual void validate(const schema &schema, const cql3::statements::index_prop_defs &properties,
-            const std::vector<::shared_ptr<cql3::statements::index_target>> &targets, const gms::feature_service& fs) const = 0;
+            const std::vector<::shared_ptr<cql3::statements::index_target>> &targets, const gms::feature_service& fs,
+        const data_dictionary::database& db) const = 0;
     virtual table_schema_version index_version(const schema& schema) = 0;
 };
 

--- a/index/vector_index.cc
+++ b/index/vector_index.cc
@@ -143,10 +143,21 @@ void vector_index::check_index_options(const cql3::statements::index_prop_defs& 
     }
 }
 
+void vector_index::check_uses_tablets(const schema& schema, const data_dictionary::database& db) const {
+    const auto& keyspace = db.find_keyspace(schema.ks_name());
+    if (!keyspace.uses_tablets()) {
+        throw exceptions::invalid_request_exception(
+            "Vector index requires the base table's keyspace to use tablets.\n"
+            "Please alter the keyspace to use tablets and try again.");
+    }
+}
+
 void vector_index::validate(const schema &schema, const cql3::statements::index_prop_defs &properties,
         const std::vector<::shared_ptr<cql3::statements::index_target>> &targets,
-        const gms::feature_service& fs) const
+        const gms::feature_service& fs,
+        const data_dictionary::database& db) const
 {
+    check_uses_tablets(schema, db);
     check_target(schema, targets);
     check_cdc_not_explicitly_disabled(schema);
     check_cdc_options(schema);

--- a/index/vector_index.hh
+++ b/index/vector_index.hh
@@ -29,12 +29,14 @@ public:
     std::optional<cql3::description> describe(const index_metadata& im, const schema& base_schema) const override;
     bool view_should_exist() const override;
     void validate(const schema &schema, const cql3::statements::index_prop_defs &properties,
-            const std::vector<::shared_ptr<cql3::statements::index_target>> &targets, const gms::feature_service& fs) const override;
+            const std::vector<::shared_ptr<cql3::statements::index_target>> &targets, const gms::feature_service& fs,
+        const data_dictionary::database& db) const override;
     table_schema_version index_version(const schema& schema) override;
     static bool has_vector_index(const schema& s);
     static bool has_vector_index_on_column(const schema& s, const sstring& target_name);
     static void check_cdc_options(const schema& schema);
 private:
+    void check_uses_tablets(const schema& schema, const data_dictionary::database& db) const;
     void check_cdc_not_explicitly_disabled(const schema& schema) const;
     void check_target(const schema& schema, const std::vector<::shared_ptr<cql3::statements::index_target>>& targets) const;
     void check_index_options(const cql3::statements::index_prop_defs& properties) const;


### PR DESCRIPTION
This patch enforces that vector indexes can only be created on keyspaces that use tablets. During index validation, `check_uses_tablets()` verifies the base keyspace configuration and rejects creation otherwise.

To support this, the `custom_index::validate()` API now receives a `const data_dictionary::database&` parameter, allowing index implementations to access keyspace-level settings during DDL validation.

Fixes https://scylladb.atlassian.net/browse/VECTOR-322

Part of 2025.4 vector effort