### PR TITLE
db/system_keyspace: Remove the FIXME related to caching of large tables

### DIFF
--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -766,9 +766,6 @@ schema_ptr system_keyspace::size_estimates() {
         "partitions larger than specified threshold"
         );
         builder.set_gc_grace_seconds(0);
-        // FIXME re-enable caching for this and the other two
-        // system.large_* tables once
-        // https://github.com/scylladb/scylla/issues/3288 is fixed
         builder.set_caching_options(caching_options::get_disabled_caching_options());
         builder.with_hash_version();
         return builder.build(schema_builder::compact_storage::no);


### PR DESCRIPTION
Remove the FIXME comment for re-enabling caching of the large tables
since the tables are used infrequently [1].

[1] : github.com/pull/26789#issuecomment-3477540364

Fixes #26032