### PR TITLE
repair: throw if flush failed in get_flush_time

### DIFF
--- a/repair/task_manager_module.hh
+++ b/repair/task_manager_module.hh
@@ -112,7 +112,8 @@ private:
     optimized_optional<abort_source::subscription> _abort_subscription;
     std::optional<int> _ranges_parallelism;
     size_t _metas_size = 0;
-    std::optional<gc_clock::time_point> _flush_time = gc_clock::time_point();
+    gc_clock::time_point _flush_time = gc_clock::time_point();
+    bool _should_flush_and_flush_failed = false;
     service::frozen_topology_guard _topo_guard;
     bool _skip_flush;
 public:
@@ -134,7 +135,12 @@ public:
         return tasks::is_abortable(!_abort_subscription);
     }
 
-    std::optional<gc_clock::time_point> get_flush_time() const { return _flush_time; }
+    gc_clock::time_point get_flush_time() const {
+        if (_should_flush_and_flush_failed) {
+            throw std::runtime_error(fmt::format("Flush is needed for repair {} with parent {}, but failed", id(), _parent_id));
+        }
+        return _flush_time;
+    }
 
     tasks::is_user_task is_user_task() const noexcept override;
     virtual future<> release_resources() noexcept override;


### PR DESCRIPTION
Currently, _flush_time was stored as a std::optional<gc_clock::time_point> and std::nullopt indicates that the flush was needed but failed. It's confusing for the caller and does not work as expected since the _flush_time is initialized with value (not optional).

Change _flush_time type to gc_clock::time_point. If a flush is needed but failed, get_flush_time() throws an exception.

This was suppose to be a part of https://github.com/scylladb/scylladb/pull/26319 but it was mistakenly overwritten during rebases.

Refs: https://github.com/scylladb/scylladb/issues/24415.

No backport needed; backports of https://github.com/scylladb/scylladb/pull/26319 will have this fix cherry-picked