### PR TITLE
tools: toolchain: optimized_clang: remove unused variable CLANG_SUFFIX

### DIFF
--- a/tools/toolchain/optimized_clang.sh
+++ b/tools/toolchain/optimized_clang.sh
@@ -66,7 +66,6 @@ SCYLLA_NINJA_FILE_FULLPATH="${SCYLLA_DIR}"/"${SCYLLA_NINJA_FILE}"
 
 # Which LLVM release to build in order to compile Scylla
 LLVM_CLANG_TAG=20.1.8
-CLANG_SUFFIX=20
 
 CLANG_ARCHIVE=$(cd "${SCYLLA_DIR}" && realpath -m "${CLANG_ARCHIVE}")
 


### PR DESCRIPTION
The variable was unused since cae999c0949693a6 ("toolchain: change optimized clang install method to standard one"), and now causes the differential shellcheck continuous integration test to fail whenever it is changed. Remove it.

Since this variable won't change in release branches, no reason to backport this.