### PR TITLE
test: fix typo in vector_index test

### DIFF
--- a/test/cqlpy/test_vector_index.py
+++ b/test/cqlpy/test_vector_index.py
@@ -198,7 +198,7 @@ def test_two_same_name_indexes_on_different_tables_with_if_not_exists(cql, test_
         schema = "p int primary key, v vector<float, 3>"
         with new_test_table(cql, test_keyspace, schema) as table2:
             cql.execute(f"CREATE CUSTOM INDEX IF NOT EXISTS ann_index ON {table}(v) USING 'vector_index'")
-            cql.execute(f"CREATE CUSTOM INDEX IF NOT EXISTS ann_indes ON {table2}(v) USING 'vector_index'")
+            cql.execute(f"CREATE CUSTOM INDEX IF NOT EXISTS ann_index ON {table2}(v) USING 'vector_index'")
 
 ###############################################################################
 # Tests for CDC with vector indexes


### PR DESCRIPTION
Unfortunately in https://github.com/scylladb/scylladb/pull/26508
a typo than changes a behavior of a test was introduced.
This patch fixes the typo.