### PR TITLE
tests(lwt): new test for LWT testing during tablet resize

### DIFF
--- a/test/cluster/lwt/test_lwt_during_tablets_resize.py
+++ b/test/cluster/lwt/test_lwt_during_tablets_resize.py
@@ -131,6 +131,7 @@ async def run_random_resizes(
     }
 
 
+@pytest.mark.nightly_unstable  # marked to run as unstable and highlight new possible issues before #26801 is closed
 @pytest.mark.asyncio
 @skip_mode("release", "error injections are not supported in release mode")
 @skip_mode("debug", "debug mode is too slow for this test")


### PR DESCRIPTION
Workload: N workers perform CAS updates

- UPDATE … SET s{i}=new WHERE pk=? IF (∀j≠i: s{j}>=guard_j) AND s{i}=prev
at CL=LOCAL_QUORUM / SERIAL=LOCAL_SERIAL. Non-apply without timeout is treated
contention; “uncertainty” timeouts are resolved via LOCAL_SERIAL read.
- Enable balancing and increase min_tablet_count to force split, flush and lower min_tablet_count to merge.
- “Uncertainty” timeouts (write timeout due to uncertainty) are resolved via a LOCAL_SERIAL read to determine whether the CAS actually applied.
- Invariants: after the run, for every pk and column s{i}, the stored value equals the number of confirmed CAS by worker i (no lost or phantom updates) despite ongoing tablet moves.

NOTE: Test marked as `pytestmark = pytest.mark.nightly_unstable` to run as unstable and highlight new possible issues before https://github.com/scylladb/scylladb/issues/26801 is closed

Fixes: https://github.com/scylladb/qa-tasks/issues/1918