### PR TITLE
paxos_state: get_replica_lock: remove shard check

### DIFF
--- a/service/paxos/paxos_state.cc
+++ b/service/paxos/paxos_state.cc
@@ -66,19 +66,6 @@ future<paxos_state::replica_guard> paxos_state::get_replica_lock(const schema& s
     // Once the global barrier completes, no requests remain on the old shard,
     // so we can safely switch to acquiring locks only on the new shard.
     auto shards = s.table().get_effective_replication_map()->shards_ready_for_reads(s, token);
-
-    if (const auto it = std::ranges::find(shards, this_shard_id()); it == shards.end()) {
-        const auto& erm = s.table().get_effective_replication_map();
-        const auto& rs = erm->get_replication_strategy();
-        sstring tablet_map_desc;
-        if (rs.uses_tablets()) {
-            const auto& tablet_map = erm->get_token_metadata().tablets().get_tablet_map(s.id());
-            tablet_map_desc = ::format(", tablet id {}, tablet map {}",
-                tablet_map.get_tablet_id(token), tablet_map);
-        }
-        on_internal_error(paxos_state::logger,
-            format("invalid shard, shards {}, token {}{}", shards, token, tablet_map_desc));
-    }
     std::ranges::sort(shards);
 
     replica_guard replica_guard;


### PR DESCRIPTION
This check is incorrect: the current shard may be looking at the old version of tablets map:
* an accept RPC comes to replica shard 0, which is already at write_both_read_new
* the new shard is shard 1, so paxos_state::accept is called on shard 1
* shard 1 is still at "streaming" -> shards_ready_for_reads() returns old shard 0

Fixes scylladb/scylladb#26801

backport: need to backport to 2025.4