### PR TITLE
row_level: Release locks when tablet repair is retried

### DIFF
--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -1736,6 +1736,10 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
                         rtlogger.info("Finished tablet repair host={} tablet={} duration={} repair_time={}",
                                 dst, tablet, duration, res.repair_time);
                     })) {
+                        if (utils::get_local_injector().enter("delay_end_repair_update")) {
+                            break;
+                        }
+
                         auto& tinfo = tmap.get_tablet_info(gid.tablet);
                         bool valid = tinfo.repair_task_info.is_valid();
                         auto hosts_filter = tinfo.repair_task_info.repair_hosts_filter;


### PR DESCRIPTION
Currently, if incremental repair is enabled, the repair operation acquires locks (stored per session id) and later releases them in the RPC handler for the verb REPAIR_UPDATE_COMPACTION_CTRL, which is triggered by the topology coordinator when the tablet is moved to the end_repair state.

However, when the topology coordinator loses leadership, it is possible that the tablet transition to the `end_repair` state is skipped leading to a deadlock in repair.

Consider the following scenario:
- node 1 is a topology coordinator that schedules tablet repair
- node 2 is the repair master and creates a task
- node 1 loses leadership
- repair operation completes (fails or succeeds)
- node N gains leadership and schedules tablet repair

In such a case, the tablet will not be transitioned to the `end_repair` stage. As a consequence, the acquired locks are not released. When a new coordinator retries tablet repair, the new repair gets stuck.

In this patch, the locks are released when tablet repair is retried with the same session id.

Fixes https://github.com/scylladb/scylladb/issues/26346

Incremental repair was introduced in 2025.4. This fix needs a backport.