### PR TITLE
view_building_coordinator: rollback tasks on the leaving tablet replica

### DIFF
--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -1473,10 +1473,8 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
                         utils::get_local_injector().inject("stream_tablet_fail_on_drain",
                                         [] { throw std::runtime_error("stream_tablet failed due to error injection"); });
                     }
-                    utils::get_local_injector().inject("stream_tablet_fail",
-                                        [] { throw std::runtime_error("stream_tablet failed due to error injection"); });
 
-                    if (action_failed(tablet_state.streaming)) {
+                    if (action_failed(tablet_state.streaming) || utils::get_local_injector().enter("stream_tablet_fail")) {
                         const bool cleanup = utils::get_local_injector().enter("stream_tablet_move_to_cleanup");
                         bool critical_disk_utilization = false;
                         if (auto stats = _tablet_allocator.get_load_stats()) {
@@ -1621,8 +1619,9 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
                                 .del_transition(last_token)
                                 .del_migration_task_info(last_token, _feature_service)
                                 .build());
-                        if (trinfo.pending_replica) {
-                            _vb_coordinator->rollback_aborted_tasks(updates, guard, gid.table, *trinfo.pending_replica, last_token);
+                        auto leaving_replica = get_leaving_replica(tmap.get_tablet_info(gid.tablet), trinfo);
+                        if (leaving_replica) {
+                            _vb_coordinator->rollback_aborted_tasks(updates, guard, gid.table, *leaving_replica, last_token);
                         }
                     }
                     break;

--- a/test/cluster/test_view_building_coordinator.py
+++ b/test/cluster/test_view_building_coordinator.py
@@ -533,7 +533,8 @@ async def test_view_building_while_tablet_streaming_fail(manager: ManagerClient)
 
         tablet_token = 0 # Doesn't matter since there is one tablet
         replica = await get_tablet_replica(manager, servers[0], ks, 'tab', tablet_token)
-        await manager.api.enable_injection(servers[0].ip_addr, "stream_tablet_fail", one_shot=True)
+        await manager.api.enable_injection(servers[0].ip_addr, "stream_tablet_fail", one_shot=False)
+        await manager.api.enable_injection(servers[0].ip_addr, "stream_tablet_move_to_cleanup", one_shot=False)
         await asyncio.gather(*(manager.api.disable_injection(s.ip_addr, VIEW_BUILDING_WORKER_PAUSE_BUILD_RANGE_TASK) for s in servers))
         await manager.api.move_tablet(servers[0].ip_addr, ks, "tab", replica[0], replica[1], s1_host_id, 0, tablet_token)
 


### PR DESCRIPTION
When a tablet migration is started, we abort the corresponding view building tasks (i.e. we change the state of those tasks to "ABORTED"). However, we don't change the host and shard of these tasks until the migration successfully completes. When for some reason we have to rollback the migration, that means the migration didn't finish and the aborted task still has the host and shard of the migration source. So when we recreate tasks that should no longer be aborted due to a rolled-back migration, we should look at the aborted tasks of the source (leaving) replica. But we don't do it and we look at the aborted tasks of the target replica.
In this patch we adjust the rollback mechanism to recreate tasks for the migration source instead of destination. We also fix the test that should have detected this issue - the injection that the test was using didn't make us rollback, but we simply retried a stage of the tablet migration. By using one_shot=False and adding a second injection, we can now guarantee that the migration will eventually fail and we'll continue to the 'cleanup_target' and 'revert_migration' stages.

Fixes https://github.com/scylladb/scylladb/issues/26691
