### PR TITLE
dist: housekeeping: set python.multiprocessing fork mode to "fork"

### DIFF
--- a/dist/common/scripts/scylla-housekeeping
+++ b/dist/common/scripts/scylla-housekeeping
@@ -21,6 +21,11 @@ import urllib.request
 from pkg_resources import parse_version
 import multiprocessing as mp
 
+# Python 3.14 changed the default to 'forkserver', which is not compatible
+# with our relocatable python. It execs our Python binary, but without our
+# ld.so. Change it back to 'fork' to avoid issues.
+mp.set_start_method('fork')
+
 VERSION = "1.0"
 quiet = False
 # Temporary url for the review


### PR DESCRIPTION
Python 3.14 changed the multiprocessing fork mode to "forkserver", presumably for good reasons. However, it conflicts with our relocatable Python system. "forkserver" forks and execs a Python process at startup, but it does this without supplying our relocated ld.so. The system ld.so detects a conflict and crashes.

Fix this by switching back to "fork", which is sufficient for housekeeping's modest needs.

Since we won't be backporting Python 3.14 to any release branch, we won't need this compatibility patch.