### PR TITLE
sstables/trie: fix an assertion violation in bti_partition_index_writer_impl::write_last_key

### DIFF
--- a/sstables/trie/bti_partition_index_writer.cc
+++ b/sstables/trie/bti_partition_index_writer.cc
@@ -127,7 +127,7 @@ void bti_partition_index_writer_impl::write_last_key(size_t needed_prefix) {
     for (auto frag : **_last_key) {
         // The first fragment contains the entire token,
         // and token collisions are rare, hence [[unlikely]].
-        if (i + frag.size() < _last_key_mismatch) [[unlikely]] {
+        if (i + frag.size() <= _last_key_mismatch) [[unlikely]] {
             i += frag.size();
             continue;
         }

--- a/test/boost/bti_index_test.cc
+++ b/test/boost/bti_index_test.cc
@@ -183,8 +183,14 @@ index_entry_dataset generate_random_dataset(const schema& the_schema, const rand
 
     // Generate a few partition keys.
     std::vector<partition_key> pks;
-    for (int i = 0; i < cfg.partition_key_component_values; ++i) {
-        pks.push_back(partition_key::from_deeply_exploded(s, std::vector<data_value>{data_value(int16_t(i))}));
+    {
+        std::set<int16_t> pks_set;
+        while (pks_set.size() < static_cast<size_t>(cfg.partition_key_component_values)) {
+            pks_set.insert(tests::random::get_int<int16_t>());
+        }
+        for (auto& x : pks_set) {
+            pks.push_back(partition_key::from_deeply_exploded(s, std::vector<data_value>{data_value(x)}));
+        }
     }
 
     // Generate the set of decorated keys participating in the test.


### PR DESCRIPTION
_last_key is a multi-fragment buffer.

Some prefix of _last_key (up to _last_key_mismatch) is unneeded because it's already a part of the trie.
Some suffix of _last_key (after needed_prefix) is unneeded because _last_key can be differentiated from its neighbors even without it.

The job of write_last_key() is to find the middle fragments, (containing the range `[_last_key_mismatch, needed_prefix)`) trim the first and last of the middle fragments appropriately, and feed them to the trie writer.

But there's an error in the current logic,
in the case where `_last_key_mismatch` falls on a fragment boundary. To describe it with an example, if the key is fragmented like `aaa|bbb|ccc`, `_last_key_mismatch == 3`, and `needed_prefix == 7`, then the intended output to the trie writer is `bbb|c`, but the actual output is `|bbb|c`. (I.e. the first fragment is empty).

Technically the trie writer could handle empty fragments, but it has an assertion against them, because they are a questionable thing.

Fix that.

We also extend bti_index_test so that it's able to hit the assert violation (before the patch). The reason why it wasn't able to do that before the patch is that the violation requires decorated keys to differ on the _first_ byte of a partition key column, but the keys generated by the test only differed on the last byte of the column. (Because the test was using sequential integers to make the values more human-readable during debugging). So we modify the key generation to use random values that can differ on any position.

Fixes scylladb/scylladb#26819

Bugfix, needs backport to 2025.4