### PR TITLE
vector_search: Restrict vector index tests to tablets only

### DIFF
--- a/test/boost/cdc_test.cc
+++ b/test/boost/cdc_test.cc
@@ -49,6 +49,16 @@ api::timestamp_type find_timestamp(const mutation&);
 utils::UUID generate_timeuuid(api::timestamp_type);
 }
 
+namespace {
+
+cql_test_config enable_tablets() {
+    cql_test_config cfg;
+    cfg.initial_tablets = 1;
+    return cfg;
+}
+
+} // namespace
+
 BOOST_AUTO_TEST_SUITE(cdc_test)
 
 SEASTAR_THREAD_TEST_CASE(test_find_mutation_timestamp) {
@@ -201,62 +211,73 @@ SEASTAR_THREAD_TEST_CASE(test_detecting_conflict_of_cdc_log_table_with_existing_
         BOOST_REQUIRE_THROW(e.execute_cql("CREATE TABLE ks.tbl (a int PRIMARY KEY) WITH cdc = {'enabled': true}").get(), exceptions::invalid_request_exception);
         BOOST_REQUIRE(!e.local_db().has_schema("ks", "tbl"));
 
-        e.execute_cql("CREATE TABLE ks.tbl (a int PRIMARY KEY, b vector<float, 3>)").get();
+        e.execute_cql("CREATE TABLE ks.tbl (a int PRIMARY KEY)").get();
         BOOST_REQUIRE(e.local_db().has_schema("ks", "tbl"));
 
         // Conflict on ALTER which enables cdc log
         BOOST_REQUIRE_THROW(e.execute_cql("ALTER TABLE ks.tbl WITH cdc = {'enabled': true}").get(), exceptions::invalid_request_exception);
-
-        // Conflict on CREATE INDEX which enables cdc log for vector search
-        BOOST_REQUIRE_THROW(e.execute_cql("CREATE INDEX ON ks.tbl (b) USING 'vector_index'").get(), exceptions::invalid_request_exception);
     }).get();
 }
 
-SEASTAR_THREAD_TEST_CASE(test_permissions_of_cdc_log_table) {
+SEASTAR_THREAD_TEST_CASE(test_detecting_conflict_of_cdc_log_table_with_existing_table_when_vector_index_created) {
     do_with_cql_env_thread([] (cql_test_env& e) {
-        auto assert_unauthorized = [&e] (const sstring& stmt) {
-            testlog.info("Must throw unauthorized_exception: {}", stmt);
-            BOOST_REQUIRE_THROW(e.execute_cql(stmt).get(), exceptions::unauthorized_exception);
-        };
+        // Conflict on CREATE which enables cdc log
+        e.execute_cql("CREATE TABLE ks.tbl_scylla_cdc_log (a int PRIMARY KEY)").get();
 
-        // Allow MODIFY, SELECT, ALTER
-        auto log_table = "ks." + cdc::log_name("tbl");
-        auto stream_id = cdc::log_meta_column_name("stream_id");
-        auto time = cdc::log_meta_column_name("time");
-        auto batch_seq_no = cdc::log_meta_column_name("batch_seq_no");
-        auto ttl = cdc::log_meta_column_name("ttl");
+        e.execute_cql("CREATE TABLE ks.tbl (a int PRIMARY KEY, b vector<float, 3>)").get();
+        BOOST_REQUIRE(e.local_db().has_schema("ks", "tbl"));
 
-        auto cdc_enablement_queries = {
-            "ALTER TABLE ks.tbl WITH cdc = {'enabled': true}",
-            "CREATE INDEX ON ks.tbl (b) USING 'vector_index'",
-        };
+        // Conflict on CREATE INDEX which enables cdc log for vector search
+        BOOST_REQUIRE_THROW(e.execute_cql("CREATE INDEX ON ks.tbl (b) USING 'vector_index'").get(), exceptions::invalid_request_exception);
+    }, enable_tablets()).get();
+}
 
-        for (auto& q : cdc_enablement_queries) {
-            e.execute_cql("CREATE TABLE ks.tbl (a int PRIMARY KEY, b vector<float, 3>)").get();
-            BOOST_REQUIRE(e.local_db().has_schema("ks", "tbl"));
+SEASTAR_THREAD_TEST_CASE(test_permissions_of_cdc_log_table) {
 
-            e.execute_cql(q).get();
-            BOOST_REQUIRE(e.local_db().has_schema("ks", cdc::log_name("tbl")));
+    std::vector<std::pair<sstring, cql_test_config>> cdc_enablement_queries = {
+            {"ALTER TABLE ks.tbl WITH cdc = {'enabled': true}", cql_test_config{}},
+            {"CREATE INDEX ON ks.tbl (b) USING 'vector_index'", enable_tablets()},
+    };
 
-            e.execute_cql(format("INSERT INTO {} (\"{}\", \"{}\", \"{}\") VALUES (0x00000000000000000000000000000000, now(), 0)",
-                log_table, stream_id, time, batch_seq_no
-            )).get();
-            e.execute_cql(format("UPDATE {} SET \"{}\"= 100 WHERE \"{}\" = 0x00000000000000000000000000000000 AND \"{}\" = now() AND \"{}\" = 0",
-                log_table, ttl, stream_id, time, batch_seq_no
-            )).get();
-            e.execute_cql(format("DELETE FROM {} WHERE \"{}\" = 0x00000000000000000000000000000000 AND \"{}\" = now() AND \"{}\" = 0",
-                log_table, stream_id, time, batch_seq_no
-            )).get();
-            e.execute_cql("SELECT * FROM " + log_table).get();
-            e.execute_cql("ALTER TABLE " + log_table + " WITH comment = 'some not very interesting comment'").get();
+    for (auto& [q, cfg] : cdc_enablement_queries) {
+        do_with_cql_env_thread([&] (cql_test_env& e) {
+            auto assert_unauthorized = [&e] (const sstring& stmt) {
+                testlog.info("Must throw unauthorized_exception: {}", stmt);
+                BOOST_REQUIRE_THROW(e.execute_cql(stmt).get(), exceptions::unauthorized_exception);
+            };
 
-            // Disallow DROP
-            assert_unauthorized("DROP TABLE " + log_table);
+            // Allow MODIFY, SELECT, ALTER
+            auto log_table = "ks." + cdc::log_name("tbl");
+            auto stream_id = cdc::log_meta_column_name("stream_id");
+            auto time = cdc::log_meta_column_name("time");
+            auto batch_seq_no = cdc::log_meta_column_name("batch_seq_no");
+            auto ttl = cdc::log_meta_column_name("ttl");
 
-            e.execute_cql("DROP TABLE ks.tbl").get();
-        }
 
-    }).get();
+                e.execute_cql("CREATE TABLE ks.tbl (a int PRIMARY KEY, b vector<float, 3>)").get();
+                BOOST_REQUIRE(e.local_db().has_schema("ks", "tbl"));
+
+                e.execute_cql(q).get();
+                BOOST_REQUIRE(e.local_db().has_schema("ks", cdc::log_name("tbl")));
+
+                e.execute_cql(format("INSERT INTO {} (\"{}\", \"{}\", \"{}\") VALUES (0x00000000000000000000000000000000, now(), 0)",
+                    log_table, stream_id, time, batch_seq_no
+                )).get();
+                e.execute_cql(format("UPDATE {} SET \"{}\"= 100 WHERE \"{}\" = 0x00000000000000000000000000000000 AND \"{}\" = now() AND \"{}\" = 0",
+                    log_table, ttl, stream_id, time, batch_seq_no
+                )).get();
+                e.execute_cql(format("DELETE FROM {} WHERE \"{}\" = 0x00000000000000000000000000000000 AND \"{}\" = now() AND \"{}\" = 0",
+                    log_table, stream_id, time, batch_seq_no
+                )).get();
+                e.execute_cql("SELECT * FROM " + log_table).get();
+                e.execute_cql("ALTER TABLE " + log_table + " WITH comment = 'some not very interesting comment'").get();
+
+                // Disallow DROP
+                assert_unauthorized("DROP TABLE " + log_table);
+
+                e.execute_cql("DROP TABLE ks.tbl").get();
+        }, cfg).get();
+    }
 }
 
 SEASTAR_THREAD_TEST_CASE(test_disallow_cdc_on_materialized_view) {
@@ -314,18 +335,17 @@ SEASTAR_THREAD_TEST_CASE(test_permissions_of_cdc_description) {
 }
 
 SEASTAR_THREAD_TEST_CASE(test_cdc_log_schema) {
-    do_with_cql_env_thread([] (cql_test_env& e) {
-        int required_column_count = 0;
+    const auto base_tbl_name = "tbl";
+    std::vector<std::pair<sstring, cql_test_config>> cdc_enablement_queries = {
+            {format("ALTER TABLE {} WITH cdc = {{'enabled': true}}", base_tbl_name), cql_test_config{}},
+            {format("CREATE INDEX ON {} (c_vec) USING 'vector_index'", base_tbl_name), enable_tablets()},
+    };
+    for (auto& [q, cfg] : cdc_enablement_queries) {
+        do_with_cql_env_thread([&] (cql_test_env& e) {
+            int required_column_count = 0;
 
-        const auto base_tbl_name = "tbl";
-        e.execute_cql(format("CREATE TYPE {} (x int)", "typ")).get();
+            e.execute_cql(format("CREATE TYPE {} (x int)", "typ")).get();
 
-        auto cdc_enablement_queries = {
-            format("ALTER TABLE {} WITH cdc = {{'enabled': true}}", base_tbl_name),
-            format("CREATE INDEX ON {} (c_vec) USING 'vector_index'", base_tbl_name),
-        };
-
-        for (auto& q : cdc_enablement_queries) {
             e.execute_cql(format("CREATE TABLE {} (pk int, ck int, s int static, c int, "
                 "c_list list<int>, c_map map<int, int>, c_set set<int>, c_typ typ, c_vec vector<float, 3>,"
                 "PRIMARY KEY (pk, ck))", base_tbl_name)).get();
@@ -412,8 +432,9 @@ SEASTAR_THREAD_TEST_CASE(test_cdc_log_schema) {
 
             e.execute_cql("DROP TABLE ks.tbl").get();
             required_column_count = 0;
-        }
-    }).get();
+
+        }, cfg).get();
+    }
 }
 
 } // cdc_test namespace

--- a/test/boost/cql_auth_query_test.cc
+++ b/test/boost/cql_auth_query_test.cc
@@ -47,6 +47,11 @@ static shared_ptr<db::config> db_config_with_auth() {
     return config_ptr;
 }
 
+static cql_test_config enable_tablets(cql_test_config cfg) {
+    cfg.initial_tablets = 1;
+    return cfg;
+}
+
 //
 // These functions must be called inside Seastar threads.
 //
@@ -379,7 +384,7 @@ SEASTAR_TEST_CASE(select_from_vector_indexed_table) {
                             exception_predicate::message_contains("User bob has no SELECT permission"));
                 });
             },
-            db_config_with_auth());
+            enable_tablets(db_config_with_auth()));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/cql/vs_cdc_enable_disable_test.cql
+++ b/test/cql/vs_cdc_enable_disable_test.cql
@@ -2,10 +2,9 @@
 -- do not depend on how stream IDs are assigned to partition keys.
 
 -- Error messages contain a keyspace name. Make the output stable.
--- CDC and tablets are not working together yet, turn them off.
 CREATE KEYSPACE ks
     WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND
-    tablets = {'enabled': false};
+    tablets = {'enabled': true};
 
 -- create table with vector column
 create table ks.t (pk int, ck int, v vector<float, 3>, primary key(pk, ck));

--- a/test/cql/vs_cdc_enable_disable_test.result
+++ b/test/cql/vs_cdc_enable_disable_test.result
@@ -2,10 +2,9 @@
 > -- do not depend on how stream IDs are assigned to partition keys.
 > 
 > -- Error messages contain a keyspace name. Make the output stable.
-> -- CDC and tablets are not working together yet, turn them off.
 > CREATE KEYSPACE ks
 >     WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND
->     tablets = {'enabled': false};
+>     tablets = {'enabled': true};
 OK
 > 
 > -- create table with vector column

--- a/test/vector_search/vector_store_client_test.cc
+++ b/test/vector_search/vector_store_client_test.cc
@@ -122,6 +122,12 @@ public:
     }
 };
 
+cql_test_config make_config() {
+    cql_test_config cfg;
+    cfg.initial_tablets = 1;
+    return cfg;
+}
+
 } // namespace
 
 BOOST_AUTO_TEST_CASE(vector_store_client_test_ctor) {
@@ -296,7 +302,7 @@ SEASTAR_TEST_CASE(vector_store_client_ann_test_disabled) {
 }
 
 SEASTAR_TEST_CASE(vector_store_client_test_ann_addr_unavailable) {
-    auto cfg = cql_test_config();
+    auto cfg = make_config();
     cfg.db_config->vector_store_primary_uri.set("http://bad.authority.here:6080");
     co_await do_with_cql_env(
             [](cql_test_env& env) -> future<> {
@@ -315,7 +321,7 @@ SEASTAR_TEST_CASE(vector_store_client_test_ann_addr_unavailable) {
 }
 
 SEASTAR_TEST_CASE(vector_store_client_test_ann_service_unavailable) {
-    auto cfg = cql_test_config();
+    auto cfg = make_config();
     auto server = co_await make_unavailable_server();
     cfg.db_config->vector_store_primary_uri.set(format("http://good.authority.here:{}", server->port()));
     co_await do_with_cql_env(
@@ -338,7 +344,7 @@ SEASTAR_TEST_CASE(vector_store_client_test_ann_service_unavailable) {
 }
 
 SEASTAR_TEST_CASE(vector_store_client_test_ann_service_aborted) {
-    auto cfg = cql_test_config();
+    auto cfg = make_config();
     auto server = co_await make_unavailable_server();
     cfg.db_config->vector_store_primary_uri.set(format("http://good.authority.here:{}", server->port()));
     co_await do_with_cql_env(
@@ -367,7 +373,7 @@ SEASTAR_TEST_CASE(vector_store_client_test_ann_service_aborted) {
 
 SEASTAR_TEST_CASE(vector_store_client_test_ann_request) {
     auto server = co_await make_vs_mock_server();
-    auto cfg = cql_test_config();
+    auto cfg = make_config();
     cfg.db_config->vector_store_primary_uri.set(format("http://good.authority.here:{}", server->port()));
     co_await do_with_cql_env(
             [&server](cql_test_env& env) -> future<> {
@@ -515,7 +521,7 @@ SEASTAR_TEST_CASE(vector_store_client_uri_update) {
     auto s1 = co_await make_vs_mock_server();
     auto s2 = co_await make_vs_mock_server();
 
-    auto cfg = cql_test_config();
+    auto cfg = make_config();
     cfg.db_config->vector_store_primary_uri.set(format("http://good.authority.here:{}", s1->port()));
     co_await do_with_cql_env(
             [&](cql_test_env& env) -> future<> {
@@ -549,7 +555,7 @@ SEASTAR_TEST_CASE(vector_store_client_multiple_ips_high_availability) {
     auto responding_s = co_await make_vs_mock_server();
     auto unavail_s = co_await make_unavailable_server(responding_s->port());
 
-    auto cfg = cql_test_config();
+    auto cfg = make_config();
     cfg.db_config->vector_store_primary_uri.set(format("http://good.authority.here:{}", responding_s->port()));
     co_await do_with_cql_env(
             [&](cql_test_env& env) -> future<> {
@@ -583,7 +589,7 @@ SEASTAR_TEST_CASE(vector_store_client_multiple_ips_load_balancing) {
     auto s1 = co_await make_vs_mock_server();
     auto s2 = co_await make_vs_mock_server(s1->port());
 
-    auto cfg = cql_test_config();
+    auto cfg = make_config();
     cfg.db_config->vector_store_primary_uri.set(format("http://good.authority.here:{}", s1->port()));
     co_await do_with_cql_env(
             [&](cql_test_env& env) -> future<> {
@@ -613,7 +619,7 @@ SEASTAR_TEST_CASE(vector_store_client_multiple_uris_high_availability) {
     auto responding_s = co_await make_vs_mock_server();
     auto unavail_s = co_await make_unavailable_server();
 
-    auto cfg = cql_test_config();
+    auto cfg = make_config();
     cfg.db_config->vector_store_primary_uri.set(format("http://s1.node:{},http://s2.node:{}", unavail_s->port(), responding_s->port()));
     co_await do_with_cql_env(
             [&](cql_test_env& env) -> future<> {
@@ -647,7 +653,7 @@ SEASTAR_TEST_CASE(vector_store_client_multiple_uris_load_balancing) {
     auto s1 = co_await make_vs_mock_server();
     auto s2 = co_await make_vs_mock_server();
 
-    auto cfg = cql_test_config();
+    auto cfg = make_config();
     cfg.db_config->vector_store_primary_uri.set(format("http://s1.node:{},http://s2.node:{}", s1->port(), s2->port()));
     co_await do_with_cql_env(
             [&](cql_test_env& env) -> future<> {
@@ -674,7 +680,7 @@ SEASTAR_TEST_CASE(vector_store_client_multiple_uris_load_balancing) {
 
 SEASTAR_TEST_CASE(vector_search_metrics_test) {
 
-    auto cfg = cql_test_config();
+    auto cfg = make_config();
     cfg.db_config->vector_store_primary_uri.set("http://good.authority.here:6080");
     co_await do_with_cql_env(
             [](cql_test_env& env) -> future<> {
@@ -697,7 +703,7 @@ SEASTAR_TEST_CASE(vector_search_metrics_test) {
 SEASTAR_TEST_CASE(vector_store_client_test_paging_warning) {
     auto s1 = co_await make_vs_mock_server();
 
-    auto cfg = cql_test_config();
+    auto cfg = make_config();
     cfg.db_config->vector_store_primary_uri.set(format("http://s1.node:{}", s1->port()));
     co_await do_with_cql_env(
             [&s1](cql_test_env& env) -> future<> {
@@ -723,7 +729,7 @@ SEASTAR_TEST_CASE(vector_store_client_test_paging_warning) {
 SEASTAR_TEST_CASE(vector_store_client_test_paging_warning_doesnt_show_when_paging_disabled) {
     auto s1 = co_await make_vs_mock_server();
 
-    auto cfg = cql_test_config();
+    auto cfg = make_config();
     cfg.db_config->vector_store_primary_uri.set(format("http://s1.node:{}", s1->port()));
     co_await do_with_cql_env(
             [&s1](cql_test_env& env) -> future<> {
@@ -748,7 +754,7 @@ SEASTAR_TEST_CASE(vector_store_client_test_paging_warning_doesnt_show_when_pagin
 SEASTAR_TEST_CASE(vector_store_client_test_paging_warning_doesnt_show_when_limit_less_than_page_size) {
     auto s1 = co_await make_vs_mock_server();
 
-    auto cfg = cql_test_config();
+    auto cfg = make_config();
     cfg.db_config->vector_store_primary_uri.set(format("http://s1.node:{}", s1->port()));
     co_await do_with_cql_env(
             [&s1](cql_test_env& env) -> future<> {
@@ -775,7 +781,7 @@ SEASTAR_TEST_CASE(vector_store_client_node_recovery_after_backoff) {
     std::unique_ptr<vs_mock_server> avail_server;
     constexpr auto HOSTNAME = "server.node";
 
-    auto cfg = cql_test_config();
+    auto cfg = make_config();
     cfg.db_config->vector_store_primary_uri.set(format("http://{}:{}", HOSTNAME, unavail_server->port()));
     co_await do_with_cql_env(
             [&](cql_test_env& env) -> future<> {
@@ -814,7 +820,7 @@ SEASTAR_TEST_CASE(vector_store_client_single_status_check_after_concurrent_failu
     using keys = std::expected<vector_store_client::primary_keys, vector_store_client::ann_error>;
 
     auto unavail_s = co_await make_unavailable_server();
-    auto cfg = cql_test_config();
+    auto cfg = make_config();
     cfg.db_config->vector_store_primary_uri.set(format("http://unavail.node:{}", unavail_s->port()));
     co_await do_with_cql_env(
             [&](cql_test_env& env) -> future<> {
@@ -857,7 +863,7 @@ SEASTAR_TEST_CASE(vector_store_client_single_status_check_after_concurrent_failu
 
 SEASTAR_TEST_CASE(vector_store_client_updates_backoff_max_time_from_read_request_timeout_cfg) {
     auto unavail_s = co_await make_unavailable_server();
-    auto cfg = cql_test_config();
+    auto cfg = make_config();
     cfg.db_config->vector_store_primary_uri.set(format("http://unavail.node:{}", unavail_s->port()));
     co_await do_with_cql_env(
             [&](cql_test_env& env) -> future<> {
@@ -901,7 +907,7 @@ SEASTAR_TEST_CASE(vector_store_client_updates_backoff_max_time_from_read_request
 SEASTAR_TEST_CASE(vector_store_client_secondary_uri) {
     auto primary = co_await make_unavailable_server();
     auto secondary = co_await make_vs_mock_server();
-    auto cfg = cql_test_config();
+    auto cfg = make_config();
     cfg.db_config->vector_store_primary_uri.set(format("http://primary.node:{}", primary->port()));
     cfg.db_config->vector_store_secondary_uri.set(format("http://secondary.node:{}", secondary->port()));
     co_await do_with_cql_env(
@@ -926,7 +932,7 @@ SEASTAR_TEST_CASE(vector_store_client_secondary_uri) {
 
 SEASTAR_TEST_CASE(vector_store_client_secondary_uri_only) {
     auto secondary = co_await make_vs_mock_server();
-    auto cfg = cql_test_config();
+    auto cfg = make_config();
     cfg.db_config->vector_store_secondary_uri.set(format("http://secondary.node:{}", secondary->port()));
     co_await do_with_cql_env(
             [&](cql_test_env& env) -> future<> {
@@ -949,7 +955,7 @@ SEASTAR_TEST_CASE(vector_store_client_secondary_uri_only) {
 SEASTAR_TEST_CASE(vector_store_client_https) {
     certificates certs;
     auto server = co_await make_vs_mock_server(co_await make_server_credentials(certs));
-    auto cfg = cql_test_config();
+    auto cfg = make_config();
     cfg.db_config->vector_store_primary_uri.set(format("https://{}:{}", certs.server_cert_cn(), server->port()));
     cfg.db_config->vector_store_encryption_options.set({{"truststore", certs.ca_cert_file()}});
     co_await do_with_cql_env(
@@ -975,7 +981,7 @@ SEASTAR_TEST_CASE(vector_store_client_https_rewrite_ca_cert) {
     auto broken_cert = co_await seastar::make_tmp_file();
     certificates certs;
     auto server = co_await make_vs_mock_server(co_await make_server_credentials(certs));
-    auto cfg = cql_test_config();
+    auto cfg = make_config();
     cfg.db_config->vector_store_primary_uri.set(format("https://{}:{}", certs.server_cert_cn(), server->port()));
     cfg.db_config->vector_store_encryption_options.set({{"truststore", broken_cert.get_path().string()}});
     co_await do_with_cql_env(
@@ -1021,7 +1027,7 @@ SEASTAR_TEST_CASE(vector_store_client_https_wrong_hostname) {
     certificates certs;
     auto server = co_await make_vs_mock_server(co_await make_server_credentials(certs));
     const auto hostname = fmt::format("wrong.{}", certs.server_cert_cn());
-    auto cfg = cql_test_config();
+    auto cfg = make_config();
     cfg.db_config->vector_store_primary_uri.set(format("https://{}:{}", hostname, server->port()));
     cfg.db_config->vector_store_encryption_options.set({{"truststore", certs.ca_cert_file()}});
     co_await do_with_cql_env(
@@ -1047,7 +1053,7 @@ SEASTAR_TEST_CASE(vector_store_client_https_different_ca_cert_verification_error
     auto broken_cert = co_await seastar::make_tmp_file();
     certificates certs;
     auto server = co_await make_vs_mock_server(co_await make_server_credentials(certs));
-    auto cfg = cql_test_config();
+    auto cfg = make_config();
     cfg.db_config->vector_store_primary_uri.set(format("https://{}:{}", certs.server_cert_cn(), server->port()));
     cfg.db_config->vector_store_encryption_options.set({{"truststore", broken_cert.get_path().string()}});
     co_await do_with_cql_env(


### PR DESCRIPTION
vector_search: Restrict vector index tests to tablets only

Vector indexes are going to be supported only for tablets (see VECTOR-322).
As a result, tests using vector indexes will be failing when run with `vnodes`.

This change ensures vector index tests run exclusively with `tablets`.

Fixes: VECTOR-49

Must be backported to the same branch as https://github.com/scylladb/scylladb/pull/26786: 2025.4