### PR TITLE
Fix formatting of deprecated initial sub-option

### DIFF
--- a/docs/cql/ddl.rst
+++ b/docs/cql/ddl.rst
@@ -289,7 +289,7 @@ with tablets enabled. Keyspaces using tablets must also remain :term:`RF-rack-va
 throughout their lifetime. See :ref:`Limitations and Unsupported Features <tablets-limitations>`
 for details.
 
-**The ``initial`` sub-option (deprecated)**
+**The** ``initial`` **sub-option (deprecated)**
 
 A good rule of thumb to calculate initial tablets is to divide the expected total storage used
 by tables in this keyspace by (``replication_factor`` * 5GB). For example, if you expect a 30TB


### PR DESCRIPTION
Rendered it's not written as code:
<img width="331" height="53" alt="image" src="https://github.com/user-attachments/assets/3e4f0417-3903-48c2-8bdb-f9e56ea0b320" />
