### PR TITLE
docs: Fix formatting of null value note in ddl.rst

### DIFF
--- a/docs/cql/ddl.rst
+++ b/docs/cql/ddl.rst
@@ -637,7 +637,7 @@ Some examples of primary key definition are:
   key), and ``c`` is the clustering column.
 
 
-.. note:: A *null* value is not allowed as any partition-key or clustering-key column. A Null value is *not* the same as an empty string.
+.. note:: A *null* value is not allowed as any partition-key or clustering-key column. A *null* value is *not* the same as an empty string.
 
 .. _partition-key:
 


### PR DESCRIPTION
Add consistent formatting of `null` within the same tip box