### PR TITLE
docs: Clarify pre-requisites for "Update Topology Strategy From Simple to Network" sub-procedures

### DIFF
--- a/docs/operating-scylla/procedures/cluster-management/update-topology-strategy-from-simple-to-network.rst
+++ b/docs/operating-scylla/procedures/cluster-management/update-topology-strategy-from-simple-to-network.rst
@@ -4,24 +4,57 @@ Update Topology Strategy From Simple to Network
 The following procedure specifies how to update the replication strategy from ``SimpleStrategy`` to ``NetworkTopologyStrategy``.
 Note that ``SimpleStrategy`` is **not** recommended for production usage, and it is strongly advised to create new clusters with ``NetworkTopologyStrategy``.
 
-In case you are using ``SimpleStrategy``, there are two alternatives:
+In case you are using ``SimpleStrategy``, there are two possible procedures:
 
-* Nodes are all on the same rack (can be updated without downtime)
-* Nodes are on different racks (requires full shutdown)
+* **Procedure with no downtime**: This procedure can be used if any of the following conditions are met:
 
-To check which node is on which rack, use ``nodetool status``
+  * All nodes are on the same rack
 
-Note that if the Replication Factor (RF) of the relevant Keyspace is equal to the number of nodes, regardless of the number of racks, for example, RF=3, nodes=3, you can use the first procedure without downtime.
+  * Regardless of the number of racks, the Replication Factor (RF) of the ``SimpleStrategy`` keyspace is not changing, and the RF is also equal to the number of cluster nodes. For example, if the RF of a keyspace is 3 and the cluster has 3 nodes, and if the RF is not changing, then the number of racks does not matter.
 
-All nodes are on the same rack
-------------------------------
+* **Procedure with downtime**: This procedure should be used if any of the following conditions are met:
+
+  * Cluster nodes are on multiple racks, and the Replication Factor (RF) of the ``SimpleStrategy`` keyspace is not changing, and the RF is **not** equal to the number of nodes in the cluster.
+
+  * Cluster nodes are on multiple racks, and the Replication Factor (RF) of the ``SimpleStrategy`` keyspace is changing.
+
+To check which node is on which rack, use ``nodetool status`` (or ``sctool status`` from the Scylla Manager node)
+
+Check keyspaces
+---------------
+
+Check if the following keyspaces use ``SimpleStrategy``:
+
+* Any user-created keyspace.
+
+  To check the replication strategy of a specific user-created keyspace:
+
+  .. code-block:: cql
+
+     DESCRIBE KEYSPACE mykeyspace;
+
+  Or to check all user-created keyspaces:
+
+  .. code-block:: cql
+
+     DESCRIBE SCHEMA;
+
+* Certain system keyspaces, including ``system_distributed``, ``system_traces``, ``system_audit``.
+
+  To check the replication strategy of the above system keyspaces:
+
+  .. code-block:: cql
+
+     DESCRIBE KEYSPACE system_distributed;
+     DESCRIBE KEYSPACE system_traces;
+     DESCRIBE KEYSPACE system_audit;
+
+If any of the above keyspaces uses ``SimpleStrategy``, use the relevant procedure on this page to switch it to ``NetworkTopologyStategy``.
+
+Procedure with no downtime
+--------------------------
 
 Alter each Keyspace replication to use ``class : NetworkTopologyStrategy``.
-
-Alter the following:
-
-* Keyspace created by the user.
-* System: ``system_distributed``, ``system_traces``.
 
 For example:
 
@@ -30,27 +63,26 @@ Before
 .. code-block:: cql
 
    DESCRIBE KEYSPACE mykeyspace; 
-   CREATE KEYSPACE mykespace WITH replication = { 'class' : 'SimpleStrategy', 'replication_factor': '3'};
+   CREATE KEYSPACE mykeyspace WITH replication = { 'class' : 'SimpleStrategy', 'replication_factor': '3'};
 
 ALTER Command
 
 .. code-block:: cql
    
-   ALTER KEYSPACE mykespace WITH replication = { 'class' : 'NetworkTopologyStrategy', '<existing_dc>' : 3};
+   ALTER KEYSPACE mykeyspace WITH replication = { 'class' : 'NetworkTopologyStrategy', '<existing_dc>' : 3};
 
 After
 
 .. code-block:: cql
 
    DESCRIBE KEYSPACE mykeyspace;
-   CREATE KEYSPACE mykespace WITH replication = { 'class' : 'NetworkTopologyStrategy', '<existing_dc>' : 3};
+   CREATE KEYSPACE mykeyspace WITH replication = { 'class' : 'NetworkTopologyStrategy', '<existing_dc>' : 3};
 
 To complete the process, you need to :doc:`change the snitch </operating-scylla/procedures/config-change/switch-snitch/>`, edit the 
 ``cassandra-rackdc.properties`` file, and set the preferred data-center name.
 
-
-Nodes are on different racks
-----------------------------
+Procedure with downtime
+-----------------------
 
 This is a more complex scenario, as the new strategy may select different replicas depending on whether the nodes are on different racks.
 To fix that, you will need a **full shutdown of the cluster**.


### PR DESCRIPTION
Update update-topology-strategy-from-simple-to-network.rst: Changes the names of both sub-procedure sand clarifies the pre-requisites for each.

Since this is just a simple documentation change, it could probably be backported to any version we want.

Fixes #27077

Thanks!

**Please replace this line with justification for the backport/\* labels added to this PR**