### PR TITLE
Update insert example by removing 'year' column

### DIFF
--- a/docs/cql/dml/insert.rst
+++ b/docs/cql/dml/insert.rst
@@ -67,9 +67,9 @@ Please refer to the :ref:`update parameters <update-parameters>` section for mor
 
 .. code-block:: none
 
-   movie    | director      | main_actor | year
-   ----------+---------------+------------+------
-   Serenity | Joseph Whedon |    Unknown | null
+   movie    | director      | main_actor
+   ----------+---------------+------------
+   Serenity | Joseph Whedon |    Unknown
 
 
 ``INSERT`` is not required to assign all columns, so if two


### PR DESCRIPTION
Removed 'year' column from the insert example table.

The select doesn't contain the year column so it doesn't make sense that it's in the result table