### PR TITLE
Fix query order in example for currentDate function

### DIFF
--- a/docs/cql/functions.rst
+++ b/docs/cql/functions.rst
@@ -188,7 +188,7 @@ Function name         Output type
 
 For example, to retrieve data up to today, run the following query::
 
-   SELECT * FROM myTable WHERE currentDate() >= date
+   SELECT * FROM myTable WHERE date <= currentDate()
 
 Time conversion functions
 #########################


### PR DESCRIPTION
Fix invalid example shown in cql functions regarding currentDate