### PR TITLE
dist/docker: add configurable blocked-reactor-notify-ms parameter

### DIFF
--- a/dist/docker/commandlineparser.py
+++ b/dist/docker/commandlineparser.py
@@ -31,4 +31,5 @@ def parse():
     parser.add_argument('--replace-address-first-boot', default=None, dest='replaceAddressFirstBoot', help="[[deprecated]] IP address of a dead node to replace.")
     parser.add_argument('--dc', default=None, dest='dc', help="The datacenter name for this node, for use with the snitch GossipingPropertyFileSnitch.")
     parser.add_argument('--rack', default=None, dest='rack', help="The rack name for this node, for use with the snitch GossipingPropertyFileSnitch.")
+    parser.add_argument('--blocked-reactor-notify-ms', default='25', dest='blocked_reactor_notify_ms', help="Set the blocked reactor notification timeout in milliseconds. Defaults to 25.")
     return parser.parse_known_args()

--- a/dist/docker/scyllasetup.py
+++ b/dist/docker/scyllasetup.py
@@ -46,6 +46,7 @@ class ScyllaSetup:
         self._extra_args = extra_arguments
         self._dc = arguments.dc
         self._rack = arguments.rack
+        self._blocked_reactor_notify_ms = arguments.blocked_reactor_notify_ms
 
     def _run(self, *args, **kwargs):
         logging.info('running: {}'.format(args))
@@ -205,7 +206,7 @@ class ScyllaSetup:
         elif self._replaceAddressFirstBoot is not None:
             args += ["--replace-address-first-boot %s" % self._replaceAddressFirstBoot]
 
-        args += ["--blocked-reactor-notify-ms 999999999"]
+        args += ["--blocked-reactor-notify-ms %s" % self._blocked_reactor_notify_ms]
 
         with open("/etc/scylla.d/docker.conf", "w") as cqlshrc:
             cqlshrc.write("SCYLLA_DOCKER_ARGS=\"%s\"\n" % (" ".join(args) + " " + " ".join(self._extra_args)))


### PR DESCRIPTION
Add `--blocked-reactor-notify-ms` argument to allow overriding the default blocked reactor notification timeout value of 25 ms.

This change maintains backward compatibility while providing users the flexibility to customize the reactor notification timeout as needed.

Fixes: https://github.com/scylladb/scylla-enterprise/issues/5525
