### PR TITLE
fix(test): minor typo fix, removing redundant param from logging

### DIFF
--- a/test/cluster/lwt/lwt_common.py
+++ b/test/cluster/lwt/lwt_common.py
@@ -156,7 +156,7 @@ class Worker:
                     applied = bool(res and res[0].applied)
                     if not applied:
                         logger.error(
-                            "LWT_NOT_APPLIED pk=%r worker=s%d new=%r guard=%r prev=%r ts_ms=%d",
+                            "LWT_NOT_APPLIED pk=%r worker=s%d new=%r guard=%r prev=%r",
                             pk,
                             self.worker_id,
                             new_val,


### PR DESCRIPTION
Fixes https://github.com/scylladb/scylladb/issues/24502 (to satisfy PR and backport rules) 