### PR TITLE
test/cqlpy: fix run script for materialized views on tablets

### DIFF
--- a/test/cqlpy/run.py
+++ b/test/cqlpy/run.py
@@ -317,6 +317,8 @@ def run_scylla_cmd(pid, dir):
         '--experimental-features=views-with-tablets',
         '--enable-tablets=true',
         '--enable-user-defined-functions', '1',
+        # Views with tablets refuse to work if this option is not on :-(
+        '--rf-rack-valid-keyspaces=1',
         # Set up authentication in order to allow testing this module
         # and other modules dependent on it: e.g. service levels
         '--authenticator', 'PasswordAuthenticator',
@@ -395,6 +397,7 @@ def run_precompiled_scylla_cmd(exe, pid, dir):
         cmd.append('--force-schema-commit-log=true')
     if major < [2025,1]:
         cmd.remove('--tablets-initial-scale-factor=1')
+        cmd.remove('--rf-rack-valid-keyspaces=1')
     if major < [2025,2]:
         cmd.remove('--group0-raft-op-timeout-in-ms=300000')
     return (cmd, env)


### PR DESCRIPTION
Recently we enabled tablets by default, but it is necessary to enable rf_rack_valid_keyspaces if materialized views are to be used with tablets, and this option is *not* the default.

We did add this option in test/pylib/scylla_cluster.py which is used by test.py, but we didn't add it to test/cqlpy/run.py, so the test/cqlpy/run script is no longer able to run tests with materialized views. So this patch adds the missing configuration to run.py.

FIxes #26918
