### PR TITLE
alternator: avoid duplicate parsing in put_item LWT shard bounce

### DIFF
--- a/alternator/executor.hh
+++ b/alternator/executor.hh
@@ -54,6 +54,10 @@ class gossiper;
 
 class schema_builder;
 
+struct put_item_lwt_args {
+    rjson::value full_request = rjson::empty_object();
+};
+
 namespace alternator {
 
 class rmw_operation;
@@ -183,6 +187,7 @@ public:
     future<request_return_type> delete_table(client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value request);
     future<request_return_type> update_table(client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value request);
     future<request_return_type> put_item(client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value request);
+    future<request_return_type> execute_parsed_put_item(service::client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, put_item_lwt_args args);
     future<request_return_type> get_item(client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value request);
     future<request_return_type> delete_item(client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value request);
     future<request_return_type> update_item(client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value request);


### PR DESCRIPTION
## What

This patch addresses issue #13254 by eliminating duplicate parsing when 
PutItem operations bounce between shards for LWT.

## Why

Currently, when a PutItem operation requires LWT and needs to execute on 
a different shard, the request JSON is parsed twice: once on the originating 
shard and again on the target shard. This wastes CPU cycles and increases 
latency.

## How

Introduces a lightweight transfer structure (`put_item_lwt_args`) that 
carries the already-parsed JSON request between shards, avoiding the 
redundant parsing step.

## Testing

- All alternator tests pass (45/45)
- Specifically verified with `test_put_item_expected`

## Notes

This is my first contribution to ScyllaDB. Happy to address any feedback.

Fixes #13254