### PR TITLE
repair: Add tablet repair progress report support

### DIFF
--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -137,6 +137,8 @@ namespace {
                 system_keyspace::ROLE_PERMISSIONS,
                 system_keyspace::DICTS,
                 system_keyspace::VIEW_BUILDING_TASKS,
+                // repair tasks
+                system_keyspace::REPAIR_TASKS,
             };
             if (ks_name == system_keyspace::NAME && tables.contains(cf_name)) {
                 props.is_group0_table = true;
@@ -456,6 +458,24 @@ schema_ptr system_keyspace::repair_history() {
             .with_column("keyspace_name", utf8_type, column_kind::static_column)
             .with_column("table_name", utf8_type, column_kind::static_column)
             .set_comment("Record repair history")
+            .with_hash_version()
+            .build();
+    }();
+    return schema;
+}
+
+schema_ptr system_keyspace::repair_tasks() {
+    static thread_local auto schema = [] {
+        auto id = generate_legacy_id(NAME, REPAIR_TASKS);
+        return schema_builder(NAME, REPAIR_TASKS, std::optional(id))
+            .with_column("task_uuid", uuid_type, column_kind::partition_key)
+            .with_column("operation", utf8_type, column_kind::clustering_key)
+            // First and last token for of the tablet
+            .with_column("first_token", long_type, column_kind::clustering_key)
+            .with_column("last_token", long_type, column_kind::clustering_key)
+            .with_column("timestamp", timestamp_type)
+            .with_column("table_uuid", uuid_type, column_kind::static_column)
+            .set_comment("Record tablet repair tasks")
             .with_hash_version()
             .build();
     }();
@@ -2599,6 +2619,7 @@ std::vector<schema_ptr> system_keyspace::all_tables(const db::config& cfg) {
                     corrupt_data(),
                     scylla_local(), db::schema_tables::scylla_table_schema_history(),
                     repair_history(),
+                    repair_tasks(),
                     v3::views_builds_in_progress(), v3::built_views(),
                     v3::scylla_views_builds_in_progress(),
                     v3::truncated(),
@@ -2842,6 +2863,32 @@ future<> system_keyspace::get_repair_history(::table_id table_id, repair_history
         ent.ks = row.get_as<sstring>("keyspace_name");
         ent.cf = row.get_as<sstring>("table_name");
         ent.ts = row.get_as<db_clock::time_point>("repair_time");
+        co_await f(std::move(ent));
+        co_return stop_iteration::no;
+    });
+}
+
+future<utils::chunked_vector<canonical_mutation>> system_keyspace::get_update_repair_task_mutations(const repair_task_entry& entry, api::timestamp_type ts) {
+    // Default to timeout the repair task entries in 10 days, this should be enough time for the management tools to query
+    constexpr int ttl = 10 * 24 * 3600;
+    sstring req = format("INSERT INTO system.{} (task_uuid, operation, first_token, last_token, timestamp, table_uuid) VALUES (?, ?, ?, ?, ?, ?) USING TTL {}", REPAIR_TASKS, ttl);
+    auto muts = co_await _qp.get_mutations_internal(req, internal_system_query_state(), ts,
+            {entry.task_uuid.uuid(), repair_task_operation_to_string(entry.operation),
+            entry.first_token, entry.last_token, entry.timestamp, entry.table_uuid.uuid()});
+    utils::chunked_vector<canonical_mutation> cmuts = {muts.begin(), muts.end()};
+    co_return cmuts;
+}
+
+future<> system_keyspace::get_repair_task(tasks::task_id task_uuid, repair_task_consumer f) {
+    sstring req = format("SELECT * from system.{} WHERE task_uuid = {}", REPAIR_TASKS, task_uuid);
+    co_await _qp.query_internal(req, [&f] (const cql3::untyped_result_set::row& row) mutable -> future<stop_iteration> {
+        repair_task_entry ent;
+        ent.task_uuid = tasks::task_id(row.get_as<utils::UUID>("task_uuid"));
+        ent.operation = repair_task_operation_from_string(row.get_as<sstring>("operation"));
+        ent.first_token = row.get_as<int64_t>("first_token");
+        ent.last_token = row.get_as<int64_t>("last_token");
+        ent.timestamp = row.get_as<db_clock::time_point>("timestamp");
+        ent.table_uuid = ::table_id(row.get_as<utils::UUID>("table_uuid"));
         co_await f(std::move(ent));
         co_return stop_iteration::no;
     });
@@ -4025,4 +4072,35 @@ future<> system_keyspace::apply_mutation(mutation m) {
     return _qp.proxy().mutate_locally(m, {}, db::commitlog::force_sync(m.schema()->static_props().wait_for_sync_to_commitlog), db::no_timeout);
 }
 
+// The names are persisted in system tables so should not be changed.
+static const std::unordered_map<system_keyspace::repair_task_operation, sstring> repair_task_operation_to_name = {
+    {system_keyspace::repair_task_operation::requested, "requested"},
+    {system_keyspace::repair_task_operation::finished, "finished"},
+};
+
+static const std::unordered_map<sstring, system_keyspace::repair_task_operation> repair_task_operation_from_name = std::invoke([] {
+    std::unordered_map<sstring, system_keyspace::repair_task_operation> result;
+    for (auto&& [v, s] : repair_task_operation_to_name) {
+        result.emplace(s, v);
+    }
+    return result;
+});
+
+sstring system_keyspace::repair_task_operation_to_string(system_keyspace::repair_task_operation op) {
+    auto i = repair_task_operation_to_name.find(op);
+    if (i == repair_task_operation_to_name.end()) {
+        on_internal_error(slogger, format("Invalid repair task operation: {}", static_cast<int>(op)));
+    }
+    return i->second;
+}
+
+system_keyspace::repair_task_operation system_keyspace::repair_task_operation_from_string(const sstring& name) {
+    return repair_task_operation_from_name.at(name);
+}
+
 } // namespace db
+
+auto fmt::formatter<db::system_keyspace::repair_task_operation>::format(const db::system_keyspace::repair_task_operation& op, fmt::format_context& ctx) const
+        -> decltype(ctx.out()) {
+    return fmt::format_to(ctx.out(), "{}", db::system_keyspace::repair_task_operation_to_string(op));
+}

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -57,6 +57,8 @@ namespace paxos {
 struct topology_request_state;
 
 class group0_guard;
+
+class raft_group0_client;
 }
 
 namespace netw {
@@ -184,6 +186,7 @@ public:
     static constexpr auto RAFT_SNAPSHOTS = "raft_snapshots";
     static constexpr auto RAFT_SNAPSHOT_CONFIG = "raft_snapshot_config";
     static constexpr auto REPAIR_HISTORY = "repair_history";
+    static constexpr auto REPAIR_TASKS = "repair_tasks";
     static constexpr auto GROUP0_HISTORY = "group0_history";
     static constexpr auto DISCOVERY = "discovery";
     static constexpr auto BROADCAST_KV_STORE = "broadcast_kv_store";
@@ -282,6 +285,7 @@ public:
     static schema_ptr raft();
     static schema_ptr raft_snapshots();
     static schema_ptr repair_history();
+    static schema_ptr repair_tasks();
     static schema_ptr group0_history();
     static schema_ptr discovery();
     static schema_ptr broadcast_kv_store();
@@ -420,6 +424,22 @@ public:
         int64_t range_end;
     };
 
+    enum class repair_task_operation {
+        requested,
+        finished,
+    };
+    static sstring repair_task_operation_to_string(repair_task_operation op);
+    static repair_task_operation repair_task_operation_from_string(const sstring& name);
+
+    struct repair_task_entry {
+        tasks::task_id task_uuid;
+        repair_task_operation operation;
+        int64_t first_token;
+        int64_t last_token;
+        db_clock::time_point timestamp;
+        table_id table_uuid;
+    };
+
     struct topology_requests_entry {
         utils::UUID id;
         utils::UUID initiating_host;
@@ -440,6 +460,10 @@ public:
     future<> update_repair_history(repair_history_entry);
     using repair_history_consumer = noncopyable_function<future<>(const repair_history_entry&)>;
     future<> get_repair_history(table_id, repair_history_consumer f);
+
+    future<utils::chunked_vector<canonical_mutation>> get_update_repair_task_mutations(const repair_task_entry& entry, api::timestamp_type ts);
+    using repair_task_consumer = noncopyable_function<future<>(const repair_task_entry&)>;
+    future<> get_repair_task(tasks::task_id task_uuid, repair_task_consumer f);
 
     future<> save_truncation_record(const replica::column_family&, db_clock::time_point truncated_at, db::replay_position);
     future<replay_positions> get_truncated_positions(table_id);
@@ -749,3 +773,8 @@ public:
 }; // class system_keyspace
 
 } // namespace db
+
+template <>
+struct fmt::formatter<db::system_keyspace::repair_task_operation> : fmt::formatter<string_view> {
+    auto format(const db::system_keyspace::repair_task_operation&, fmt::format_context& ctx) const -> decltype(ctx.out());
+};

--- a/gms/feature_service.hh
+++ b/gms/feature_service.hh
@@ -143,6 +143,7 @@ public:
 
     gms::feature tablet_incremental_repair { *this, "TABLET_INCREMENTAL_REPAIR"sv };
     gms::feature tablet_repair_scheduler { *this, "TABLET_REPAIR_SCHEDULER"sv };
+    gms::feature tablet_repair_tasks_table { *this, "TABLET_REPAIR_TASKS_TABLE"sv };
     gms::feature tablet_merge { *this, "TABLET_MERGE"sv };
     gms::feature tablet_rack_aware_view_pairing { *this, "TABLET_RACK_AWARE_VIEW_PAIRING"sv };
 

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -3826,3 +3826,83 @@ future<uint32_t> repair_service::get_next_repair_meta_id() {
 locator::host_id repair_service::my_host_id() const noexcept {
     return _gossiper.local().my_host_id();
 }
+
+future<size_t> count_finished_tablets(utils::chunked_vector<tablet_token_range> ranges1, utils::chunked_vector<tablet_token_range> ranges2) {
+    if (ranges1.empty() || ranges2.empty()) {
+        co_return 0;
+    }
+
+    auto sort = [] (utils::chunked_vector<tablet_token_range>& ranges) {
+        std::sort(ranges.begin(), ranges.end(), [] (const auto& a, const auto& b) {
+            if (a.first_token != b.first_token) {
+                return a.first_token < b.first_token;
+            }
+            return a.last_token < b.last_token;
+        });
+    };
+
+    // First, merge overlapping and adjacent ranges in ranges2.
+    sort(ranges2);
+    utils::chunked_vector<tablet_token_range> merged;
+    merged.push_back(ranges2[0]);
+    for (size_t i = 1; i < ranges2.size(); ++i) {
+        co_await coroutine::maybe_yield();
+        // To avoid overflow with max() + 1, we check adjacency with `a - 1 <= b` instead of `a <= b + 1`
+        if (ranges2[i].first_token - 1 <= merged.back().last_token) {
+            merged.back().last_token = std::max(merged.back().last_token, ranges2[i].last_token);
+        } else {
+            merged.push_back(ranges2[i]);
+        }
+    }
+
+    // Count covered ranges using a linear scan
+    size_t covered_count = 0;
+    auto it = merged.begin();
+    auto end = merged.end();
+    sort(ranges1);
+    for (const auto& r1 : ranges1) {
+        co_await coroutine::maybe_yield();
+        // Advance the merged iterator only if the current merged range ends
+        // before the current r1 starts.
+        while (it != end && it->last_token < r1.first_token) {
+            co_await coroutine::maybe_yield();
+            ++it;
+        }
+        // If we have exhausted the merged ranges, no further r1 can be covered
+        if (it == end) {
+            break;
+        }
+        // Check if the current merged range covers r1.
+        if (it->first_token <= r1.first_token && r1.last_token <= it->last_token) {
+            covered_count++;
+        }
+    }
+
+    co_return covered_count;
+}
+
+future<std::optional<repair_task_progress>> repair_service::get_tablet_repair_task_progress(tasks::task_id task_uuid) {
+    utils::chunked_vector<tablet_token_range> requested_tablets;
+    utils::chunked_vector<tablet_token_range> finished_tablets;
+    table_id tid;
+    if (!_db.local().features().tablet_repair_tasks_table) {
+        co_return std::nullopt;
+    }
+    co_await _sys_ks.local().get_repair_task(task_uuid, [&tid, &requested_tablets, &finished_tablets] (const db::system_keyspace::repair_task_entry& entry) -> future<> {
+        rlogger.debug("repair_task_progress: Get entry operation={} first_token={} last_token={}", entry.operation, entry.first_token, entry.last_token);
+        if (entry.operation == db::system_keyspace::repair_task_operation::requested) {
+            requested_tablets.push_back({entry.first_token, entry.last_token});
+        } else if (entry.operation == db::system_keyspace::repair_task_operation::finished) {
+            finished_tablets.push_back({entry.first_token, entry.last_token});
+        }
+        tid = entry.table_uuid;
+        co_return;
+    });
+    auto requested = requested_tablets.size();
+    auto finished_nomerge = finished_tablets.size();
+    auto finished = co_await count_finished_tablets(std::move(requested_tablets), std::move(finished_tablets));
+    auto progress = repair_task_progress{requested, finished, tid};
+    rlogger.debug("repair_task_progress: task_uuid={} table_uuid={} requested_tablets={} finished_tablets={} progress={} finished_nomerge={}",
+            task_uuid, tid, requested, finished, progress.progress(), finished_nomerge);
+    co_return progress;
+}

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -6792,6 +6792,7 @@ future<std::unordered_map<sstring, sstring>> storage_service::add_repair_tablet_
             });
         }
 
+        auto ts = db_clock::now();
         for (const auto& token : tokens) {
             auto tid = tmap.get_tablet_id(token);
             auto& tinfo = tmap.get_tablet_info(tid);
@@ -6805,6 +6806,20 @@ future<std::unordered_map<sstring, sstring>> storage_service::add_repair_tablet_
                 tablet_mutation_builder_for_base_table(guard.write_timestamp(), table)
                     .set_repair_task_info(last_token, repair_task_info, _feature_service)
                     .build());
+            db::system_keyspace::repair_task_entry entry{
+                .task_uuid   = tasks::task_id(repair_task_info.tablet_task_id.uuid()),
+                .operation   = db::system_keyspace::repair_task_operation::requested,
+                .first_token = dht::token::to_int64(tmap.get_first_token(tid)),
+                .last_token  = dht::token::to_int64(tmap.get_last_token(tid)),
+                .timestamp   = ts,
+                .table_uuid  = table,
+            };
+            if (_feature_service.tablet_repair_tasks_table) {
+                auto cmuts = co_await _sys_ks.local().get_update_repair_task_mutations(entry, guard.write_timestamp());
+                for (auto& m : cmuts) {
+                    updates.push_back(std::move(m));
+                }
+            }
         }
 
         sstring reason = format("Repair tablet by API request tokens={} tablet_task_id={}", tokens, repair_task_info.tablet_task_id);

--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -136,6 +136,17 @@ db::tablet_options combine_tablet_options(R&& opts) {
     return combined_opts;
 }
 
+static std::unordered_set<locator::tablet_id> split_string_to_tablet_id(std::string_view s, char delimiter) {
+    auto tokens_view = s | std::views::split(delimiter)
+		 | std::views::transform([](auto&& range) {
+			 return std::string_view(&*range.begin(), std::ranges::distance(range));
+		 })
+		 | std::views::transform([](std::string_view sv) {
+			 return locator::tablet_id(std::stoul(std::string(sv)));
+		 });
+    return std::unordered_set<locator::tablet_id>{tokens_view.begin(), tokens_view.end()};
+}
+
 // Used to compare different migration choices in regard to impact on load imbalance.
 // There is a total order on migration_badness such that better migrations are ordered before worse ones.
 struct migration_badness {
@@ -893,6 +904,8 @@ public:
             co_await coroutine::maybe_yield();
             auto& config = tmap.repair_scheduler_config();
             auto now = db_clock::now();
+            auto skip = utils::get_local_injector().inject_parameter<std::string_view>("tablet_repair_skip_sched");
+            auto skip_tablets = skip ? split_string_to_tablet_id(*skip, ',') : std::unordered_set<locator::tablet_id>();
             co_await tmap.for_each_tablet([&] (locator::tablet_id id, const locator::tablet_info& info) -> future<> {
                 auto gid = locator::global_tablet_id{table, id};
                 // Skip tablet that is in transitions.
@@ -910,6 +923,11 @@ public:
                 // Skip the tablet that has excluded replica node.
                 auto& tinfo = tmap.get_tablet_info(id);
                 if (tablet_has_excluded_node(topo, tinfo)) {
+                    co_return;
+                }
+
+                if (skip_tablets.contains(id)) {
+                    lblogger.debug("Skipped tablet repair for tablet={} by error injector", gid);
                     co_return;
                 }
 

--- a/service/task_manager_module.cc
+++ b/service/task_manager_module.cc
@@ -10,6 +10,7 @@
 #include "replica/database.hh"
 #include "service/migration_manager.hh"
 #include "service/storage_service.hh"
+#include "repair/row_level.hh"
 #include "service/task_manager_module.hh"
 #include "tasks/task_handler.hh"
 #include "tasks/virtual_task_hint.hh"
@@ -108,6 +109,16 @@ future<std::optional<tasks::virtual_task_hint>> tablet_virtual_task::contains(ta
             co_await coroutine::maybe_yield();
             tid = tmap.next_tablet(*tid);
         }
+    }
+
+    // Check if the task id is present in the repair task table
+    auto progress = co_await _ss._repair.local().get_tablet_repair_task_progress(task_id);
+    if (progress && progress->requested > 0) {
+        co_return tasks::virtual_task_hint{
+            .table_id = progress->table_uuid,
+            .task_type = locator::tablet_task_type::user_repair,
+            .tablet_id = std::nullopt,
+        };
     }
     co_return std::nullopt;
 }
@@ -243,7 +254,20 @@ future<std::optional<status_helper>> tablet_virtual_task::get_status_helper(task
     size_t sched_nr = 0;
     auto tmptr = _ss.get_token_metadata_ptr();
     auto& tmap = tmptr->tablets().get_tablet_map(table);
+    bool repair_task_finished = false;
+    bool repair_task_pending = false;
     if (is_repair_task(task_type)) {
+        auto progress = co_await _ss._repair.local().get_tablet_repair_task_progress(id);
+        if (progress) {
+            res.status.progress.completed = progress->finished;
+            res.status.progress.total = progress->requested;
+            res.status.progress_units = "tablets";
+            if (progress->requested > 0 && progress->requested == progress->finished) {
+                repair_task_finished = true;
+            } if (progress->requested > 0 && progress->requested > progress->finished) {
+                repair_task_pending = true;
+            }
+        }
         co_await tmap.for_each_tablet([&] (locator::tablet_id tid, const locator::tablet_info& info) {
             auto& task_info = info.repair_task_info;
             if (task_info.tablet_task_id.uuid() == id.uuid()) {
@@ -275,7 +299,17 @@ future<std::optional<status_helper>> tablet_virtual_task::get_status_helper(task
         res.status.state = sched_nr == 0 ? tasks::task_manager::task_state::created : tasks::task_manager::task_state::running;
         co_return res;
     }
-    // FIXME: Show finished tasks.
+
+    if (repair_task_pending) {
+        // When repair_task_pending is true, the res.tablets will be empty iff the request is aborted by user.
+        res.status.state = res.tablets.empty() ? tasks::task_manager::task_state::failed : tasks::task_manager::task_state::running;
+        co_return res;
+    }
+    if (repair_task_finished) {
+        res.status.state = tasks::task_manager::task_state::done;
+        co_return res;
+    }
+
     co_return std::nullopt;
 }
 

--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -1190,6 +1190,8 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
         std::unordered_map<locator::tablet_transition_stage, background_action_holder> barriers;
         // Record the repair_time returned by the repair_tablet rpc call
         db_clock::time_point repair_time;
+        // Record the repair task update muations
+        utils::chunked_vector<canonical_mutation> repair_task_updates;
         service::session_id session_id;
     };
 
@@ -1722,6 +1724,14 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
                             }
                             dst = dst_opt.value().host;
                         }
+                        // Update repair task
+                        db::system_keyspace::repair_task_entry entry{
+                            .task_uuid   = tasks::task_id(tinfo.repair_task_info.tablet_task_id.uuid()),
+                            .operation   = db::system_keyspace::repair_task_operation::finished,
+                            .first_token = dht::token::to_int64(tmap.get_first_token(gid.tablet)),
+                            .last_token  = dht::token::to_int64(tmap.get_last_token(gid.tablet)),
+                            .table_uuid  = gid.table,
+                        };
                         rtlogger.info("Initiating tablet repair host={} tablet={}", dst, gid);
                         auto session_id = utils::get_local_injector().enter("handle_tablet_migration_repair_random_session") ?
                             service::session_id::create_random_id() : trinfo->session_id;
@@ -1733,6 +1743,10 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
                         auto duration = std::chrono::duration<float>(db_clock::now() - sched_time);
                         auto& tablet_state = _tablets[tablet];
                         tablet_state.repair_time = db_clock::from_time_t(gc_clock::to_time_t(res.repair_time));
+                        if (_feature_service.tablet_repair_tasks_table) {
+                            entry.timestamp = db_clock::now();
+                            tablet_state.repair_task_updates = co_await _sys_ks.get_update_repair_task_mutations(entry, api::new_timestamp());
+                        }
                         rtlogger.info("Finished tablet repair host={} tablet={} duration={} repair_time={}",
                                 dst, tablet, duration, res.repair_time);
                     })) {
@@ -1747,6 +1761,9 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
                                         .set_stage(last_token, locator::tablet_transition_stage::end_repair)
                                         .del_repair_task_info(last_token, _feature_service)
                                         .del_session(last_token);
+                        for (auto& m : tablet_state.repair_task_updates) {
+                            updates.push_back(std::move(m));
+                        }
                         // Skip update repair time in case hosts filter or dcs filter is set.
                         if (valid && is_filter_off) {
                             auto sched_time = tinfo.repair_task_info.sched_time;

--- a/test/boost/repair_test.cc
+++ b/test/boost/repair_test.cc
@@ -275,4 +275,60 @@ SEASTAR_TEST_CASE(repair_rows_size_considers_external_memory) {
     });
 }
 
+SEASTAR_TEST_CASE(test_tablet_token_range_count) {
+    {
+        // Simple case: one large range covers a smaller one
+        utils::chunked_vector<tablet_token_range> r1 = {{10, 20}};
+        utils::chunked_vector<tablet_token_range> r2 = {{0, 100}};
+        BOOST_REQUIRE(co_await count_finished_tablets(r1, r2) == 1);
+    }
+    {
+        // r2 ranges overlap and should merge to cover r1
+        // r2: [0, 50] + [40, 100] -> merges to [0, 100]
+        // r1: [10, 90] should be covered
+        utils::chunked_vector<tablet_token_range> r1 = {{10, 90}};
+        utils::chunked_vector<tablet_token_range> r2 = {{0, 50}, {40, 100}};
+        BOOST_REQUIRE(co_await count_finished_tablets(r1, r2) == 1);
+    }
+    {
+        // r2 ranges are adjacent (contiguous) and should merge
+        // r2: [0, 10] + [11, 20] -> merges to [0, 20]
+        // r1: [5, 15] should be covered
+        utils::chunked_vector<tablet_token_range> r1 = {{5, 15}};
+        utils::chunked_vector<tablet_token_range> r2 = {{0, 10}, {11, 20}};
+        BOOST_REQUIRE(co_await count_finished_tablets(r1, r2) == 1);
+    }
+    {
+        // r1 overlaps r2 but is not FULLY contained
+        // r2: [0, 10]
+        // r1: [5, 15] (Ends too late), [ -5, 5 ] (Starts too early)
+        utils::chunked_vector<tablet_token_range> r1 = {{5, 15}, {-5, 5}};
+        utils::chunked_vector<tablet_token_range> r2 = {{0, 10}};
+        BOOST_REQUIRE(co_await count_finished_tablets(r1, r2) == 0);
+    }
+    {
+        // A single merged range in r2 covers multiple distinct ranges in r1
+        utils::chunked_vector<tablet_token_range> r1 = {{10, 20}, {30, 40}, {50, 60}};
+        utils::chunked_vector<tablet_token_range> r2 = {{0, 100}};
+        BOOST_REQUIRE(co_await count_finished_tablets(r1, r2) == 3);
+    }
+    {
+        // Inputs are provided in random order, ensuring the internal sort works
+        utils::chunked_vector<tablet_token_range> r1 = {{50, 60}, {10, 20}};
+        utils::chunked_vector<tablet_token_range> r2 = {{50, 100}, {0, 40}};
+        // r2 merges effectively to [0, 40] and [50, 100]
+        // Both r1 items are covered
+        BOOST_REQUIRE(co_await count_finished_tablets(r1, r2) == 2);
+    }
+    {
+        utils::chunked_vector<tablet_token_range> r1 = {{10, 20}};
+        utils::chunked_vector<tablet_token_range> r2_empty = {};
+        utils::chunked_vector<tablet_token_range> r1_empty = {};
+        utils::chunked_vector<tablet_token_range> r2 = {{0, 100}};
+
+        BOOST_REQUIRE(co_await count_finished_tablets(r1, r2_empty) == 0);
+        BOOST_REQUIRE(co_await count_finished_tablets(r1_empty, r2) == 0);
+    }
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This patch adds tablet repair progress report support so that the user could use the /task_manager/task_status API to query the progress.

In order to support this, a new system table is introduced to record the user request related info, i.e, start of the request and end of the request.

The progress is accurate when tablet split or merge happens in the middle of the request, since the tokens of the tablet are recorded when the request is started and when repair of each tablet is finished. The original tablet repair is considered as finished when the finished ranges cover the original tablet token ranges.

After this patch, the /task_manager/task_status API will report correct progress_total and progress_completed.

Fixes #26896

We want to backport to 2025.4.x after the 2025.4.0 is released. 