### PR TITLE
utils::gcp::object_storage: Fix buffer alignment reordering trailing data

### DIFF
--- a/utils/gcp/object_storage.cc
+++ b/utils/gcp/object_storage.cc
@@ -157,12 +157,12 @@ public:
                     auto& buf = bufs.back();
                     if (buf.size() > rem) {
                         auto keep = buf.size() - rem;
-                        _buffers.emplace_back(buf.share(keep, rem));
+                        _buffers.emplace(_buffers.begin(), buf.share(keep, rem));
                         buf.trim(keep);
                         break;
                     } else {
                         rem -= buf.size();
-                        _buffers.emplace_back(std::move(buf));
+                        _buffers.emplace(_buffers.begin(), std::move(buf));
                         bufs.pop_back();
                     }
                 }


### PR DESCRIPTION
Fixes #26874
    
Due to certain people (me) not being able to tell forward from backward, the data alignment to ensure partial uploads adhere to the 256k-align rule would potentially _reorder_ trailing buffers generated iff the source buffers input into the sink are small enough. Which, as a fun fact, they are in backup upload.
    
Change the unit test to use raw sink IO and add two unit tests (of which the smaller size provokes the bug) that checks the same 64k buf segmented upload backup uses.
