### PR TITLE
tools: dbuild: avoid `test -v` incompatibility with MacOS shell

### DIFF
--- a/tools/toolchain/dbuild
+++ b/tools/toolchain/dbuild
@@ -261,7 +261,8 @@ docker_common_args+=(
 )
 cleanup() {
     rm -rf "$tmpdir"
-    if [ -v TMP_PASSWD ]; then
+    # don't use `test -v` for MacOS compatibility
+    if [ "${TMP_PASSWD+var_is_set}" = "var_is_set" ]; then
         rm -f "$TMP_PASSWD"
     fi
     rm -f "${tmpfiles[@]}"


### PR DESCRIPTION
`test -v` isn't present on the MacOS shell. Since dbuild is intended as a compatibility bridge between the host environment and the build environment, don't use it there.

Use ${var+text_if_set} expansion as a workaround.

Fixes #26937

No backport, this is just a minor compatibility problem with MacOS which isn't even used by regular developers.