### PR TITLE
topology: let banned node know that it is banned

### DIFF
--- a/idl/join_node.idl.hh
+++ b/idl/join_node.idl.hh
@@ -66,5 +66,6 @@ struct join_node_response_result {};
 verb [[ip]] join_node_query (raft::server_id dst_id, service::join_node_query_params) -> service::join_node_query_result;
 verb [[ip]] join_node_request (raft::server_id dst_id, service::join_node_request_params) -> service::join_node_request_result;
 verb join_node_response (raft::server_id dst_id, service::join_node_response_params) -> service::join_node_response_result;
+verb [[with_client_info, one_way, ip]] notify_banned (raft::server_id dst_id);
 
 }

--- a/message/messaging_service.cc
+++ b/message/messaging_service.cc
@@ -9,6 +9,7 @@
 #include "gms/generation-number.hh"
 #include "gms/inet_address.hh"
 #include <seastar/core/shard_id.hh>
+#include "message/msg_addr.hh"
 #include "utils/assert.hh"
 #include <fmt/ranges.h>
 #include <seastar/core/coroutine.hh>
@@ -514,7 +515,10 @@ messaging_service::messaging_service(config cfg, scheduling_config scfg, std::sh
             auto peer_host_id = locator::host_id(*host_id);
             if (is_host_banned(peer_host_id)) {
                 ci.server.abort_connection(ci.conn_id);
-                return make_ready_future<rpc::no_wait_type>(rpc::no_wait);
+                return ser::join_node_rpc_verbs::send_notify_banned(this, msg_addr{broadcast_address}, raft::server_id{*host_id}).then_wrapped([] (future<> f) {
+                    f.ignore_ready_future();
+                    return rpc::no_wait;
+                });
             }
             ci.attach_auxiliary("host_id", peer_host_id);
             ci.attach_auxiliary("baddr", broadcast_address);
@@ -675,6 +679,7 @@ static constexpr unsigned do_get_rpc_client_idx(messaging_verb verb) {
     case messaging_verb::RAFT_ADD_ENTRY:
     case messaging_verb::RAFT_MODIFY_CONFIG:
     case messaging_verb::RAFT_PULL_SNAPSHOT:
+    case messaging_verb::NOTIFY_BANNED:
         // See comment above `TOPOLOGY_INDEPENDENT_IDX`.
         // DO NOT put any 'hot' (e.g. data path) verbs in this group,
         // only verbs which are 'rare' and 'cheap'.

--- a/message/messaging_service.hh
+++ b/message/messaging_service.hh
@@ -210,7 +210,8 @@ enum class messaging_verb : int32_t {
     REPAIR_UPDATE_COMPACTION_CTRL = 81,
     REPAIR_UPDATE_REPAIRED_AT_FOR_MERGE = 82,
     WORK_ON_VIEW_BUILDING_TASKS = 83,
-    LAST = 84,
+    NOTIFY_BANNED = 84,
+    LAST = 85,
 };
 
 } // namespace netw


### PR DESCRIPTION
Currently if a banned node tries to connect to a cluster it fails to create connections, but has no idea why, so from inside the node it looks like it has communication problems. This patch adds new rpc NOTIFY_BANNED which is sent back to the node when its connection is dropped. On receiving the rpc the node isolates itself and print an informative message about why it did so.

No need to backport since this is a new feature.