### PR TITLE
alternator: fix update of stats from wrong shard

### DIFF
--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -1865,10 +1865,10 @@ future<executor::request_return_type> executor::create_table(client_state& clien
     _stats.api_operations.create_table++;
     elogger.trace("Creating table {}", request);
 
-    co_return co_await _mm.container().invoke_on(0, [&, tr = tracing::global_trace_state_ptr(trace_state), request = std::move(request), &sp = _proxy.container(), &g = _gossiper.container(), client_state_other_shard = client_state.move_to_other_shard(), enforce_authorization = bool(_enforce_authorization), warn_authorization = bool(_warn_authorization)]
+    co_return co_await _mm.container().invoke_on(0, [&, tr = tracing::global_trace_state_ptr(trace_state), request = std::move(request), &sp = _proxy.container(), &g = _gossiper.container(), &e = this->container(), client_state_other_shard = client_state.move_to_other_shard(), enforce_authorization = bool(_enforce_authorization), warn_authorization = bool(_warn_authorization)]
                                         (service::migration_manager& mm) mutable -> future<executor::request_return_type> {
         const db::tablets_mode_t::mode tablets_mode = _proxy.data_dictionary().get_config().tablets_mode_for_new_keyspaces(); // type cast
-        co_return co_await create_table_on_shard0(client_state_other_shard.get(), tr, std::move(request), sp.local(), mm, g.local(), enforce_authorization, warn_authorization, _stats, std::move(tablets_mode));
+        co_return co_await create_table_on_shard0(client_state_other_shard.get(), tr, std::move(request), sp.local(), mm, g.local(), enforce_authorization, warn_authorization, e.local()._stats, std::move(tablets_mode));
     });
 }
 


### PR DESCRIPTION
In commit 51186b2 (PR #25457) we introduced new statistics for authentication errors, and among other places we modified executor::create_table() to update them when necessary.

This function runs its real work (create_table_on_shard0()) on shard 0, but incorrectly updates "_stats" from the original shard. It doesn't really matter which shard's stats we update - but it does matter that code running on shard 0 shouldn't touch some other shard's objects. Since all we do on these stats is to increment an integer, the risk of updating it on the wrong shard is minimal to non-existant, but it's still wrong and can cause bigger trouble in the future as the code continues to evolve.

The fix is simple - we should pass to create_table_on_shard0() the _stats object from the acutal shard running it (shard 0).

Fixes #26942

This patch needs to be backported to whichever branches got commit 51186b2 (PR #25457) backported.