### PR TITLE
[Backport 2025.2] tools/scylla-nodetool: fix crash when rows_merged cells contain null

### DIFF
--- a/tools/scylla-nodetool.cc
+++ b/tools/scylla-nodetool.cc
@@ -664,9 +664,11 @@ void compactionhistory_operation(scylla_rest_client& client, const bpo::variable
         const auto& history_entry_json_object = history_entry_json.GetObject();
 
         std::map<int32_t, int64_t> rows_merged;
-        for (const auto& rows_merged_json : history_entry_json_object["rows_merged"].GetArray()) {
-            const auto& rows_merged_json_object = rows_merged_json.GetObject();
-            rows_merged.emplace(rows_merged_json_object["key"].GetInt64(), rows_merged_json_object["value"].GetInt64());
+        if (history_entry_json_object.HasMember("rows_merged")) {
+            for (const auto& rows_merged_json : history_entry_json_object["rows_merged"].GetArray()) {
+                const auto& rows_merged_json_object = rows_merged_json.GetObject();
+                rows_merged.emplace(rows_merged_json_object["key"].GetInt(), rows_merged_json_object["value"].GetInt64());
+            }
         }
 
         history.emplace_back(history_entry{


### PR DESCRIPTION
Any empty object of the json::json_list type has its internal _set variable assigned to false which results in such objects being skipped by the json::json_builder.

Hence, the json returned by the api GET//compaction_manager/compaction_history does not contain the field `rows_merged` if a cell in the system.compaction_history table is null or an empty list.

In such cases, executing the command `nodetool compactionhistory` will result in a crash with the following error message: `error running operation: rjson::error (JSON assert failed on condition 'false'`

The patch fixes it by checking if the json object contains the `rows_merged` element before processing. If the element does not exist, the nodetool will now produce an empty list.

Fixes https://github.com/scylladb/scylladb/issues/23540

(cherry picked from commit 113647550f1aaae0cb1529d4c17d6a7b34825702)

Parent PR: https://github.com/scylladb/scylladb/pull/23514

Refs: CUSTOMER-17