### PR TITLE
Fix use-after-free in encode_paging_state in Alternator

### DIFF
--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -5130,13 +5130,15 @@ static rjson::value encode_paging_state(const schema& schema, const service::pag
     }
     auto pos = paging_state.get_position_in_partition();
     if (pos.has_key()) {
-        auto exploded_ck = pos.key().explode();
-        auto exploded_ck_it = exploded_ck.begin();
-        for (const column_definition& cdef : schema.clustering_key_columns()) {
-            rjson::add_with_string_name(last_evaluated_key, std::string_view(cdef.name_as_text()), rjson::empty_object());
-            rjson::value& key_entry = last_evaluated_key[cdef.name_as_text()];
-            rjson::add_with_string_name(key_entry, type_to_string(cdef.type), json_key_column_value(*exploded_ck_it, cdef));
-            ++exploded_ck_it;
+        // Alternator itself allows at most one column in clustering key, but 
+        // user can use Alternator api to access system tables which might have
+        // multiple clustering key columns. So we need to handle that case here.
+        auto cdef_it = schema.clustering_key_columns().begin();        
+        for(const auto &exploded_ck : pos.key().explode()) {
+            rjson::add_with_string_name(last_evaluated_key, std::string_view(cdef_it->name_as_text()), rjson::empty_object());
+            rjson::value& key_entry = last_evaluated_key[cdef_it->name_as_text()];
+            rjson::add_with_string_name(key_entry, type_to_string(cdef_it->type), json_key_column_value(exploded_ck, *cdef_it));
+            ++cdef_it;
         }
     }
     // To avoid possible conflicts (and thus having to reserve these names) we

--- a/test/alternator/test_system_tables.py
+++ b/test/alternator/test_system_tables.py
@@ -15,6 +15,57 @@ from .util import full_scan, scylla_config_read, scylla_config_write, scylla_con
 
 internal_prefix = '.scylla.alternator.'
 
+# reproduces scylladb/scylladb#26960
+# page break over range tombstone was causing use-after-free, because `encode_paging_state`
+# assumed position had always data for each column in clustering key
+# which is not true for range tombstones - if clustering key has two columns,
+# use can range delete by specify only first column, which produces key prefix with only first column filled.
+# we use scylla_table_schema_history here, because it has a composite clustering key (schema_version, column_name)
+def test_page_break_over_range_tombstone_asan(scylla_only, dynamodb, rest_api, cql):
+    client = dynamodb.meta.client
+
+    # scylla_table_schema_history has a primary key of (cf_id, schema_version, column_name)
+    # insert some rows with same cf_id, but different schema_version (column_name is unimportant)
+    # any number greater than 2 should do
+    count = 20
+
+    # any uuid will work here for s and c, but values inserted must follow ordering in such a way, that
+    # first and last value was alive and those in middle were deleted.
+    s = f'72f224cf0000'
+    for y in range(0, count):
+        c = f'82f224cf{y:04}'
+        cql.execute(f"INSERT INTO system.scylla_table_schema_history (cf_id, schema_version, column_name, clustering_order, column_name_bytes, kind, position, type) VALUES (eee7eb26-a372-4eb4-aeaa-{s}, eee7eb26-a372-4eb4-aeaa-{c}, 'a', 'a', 0x1234, 'k', 1, 't');")
+    # range delete previously created rows by specifing only schema_version (first column of clustering key),
+    # skipping second column (column_name) - this will create range tombstone per each delete.
+    # we delete each row separately to create multiple range tombstones.
+    # leave first and last row intact
+    for y in range(1, count - 1):
+        c = f'82f224cf{y:04}'
+        cql.execute(f'delete from system.scylla_table_schema_history where cf_id = eee7eb26-a372-4eb4-aeaa-{s} and schema_version = eee7eb26-a372-4eb4-aeaa-{c};')
+
+    qualified_name = f"{internal_prefix}system.scylla_table_schema_history"
+    pos = None
+    args = {}
+
+    # update tombstone page limit to be smaller than tombstone count between two values.
+    # this will force scan to break page over range tombstone
+    # should return 1 item on first iteration and break over tombstone
+    # then resume and return second one.
+    with scylla_config_temporary(dynamodb, 'query_tombstone_page_limit', str(count - 2)):
+        items_found = []
+        while True:
+            response = client.scan(TableName=qualified_name, Limit=10, **args)
+            pos = response.get('LastEvaluatedKey', None)
+            cnt = 0
+            for i in response['Items']:
+                if i['cf_id'] == 'eee7eb26-a372-4eb4-aeaa-72f224cf0000':
+                    items_found.append(i['schema_version'])
+            if not pos:
+                break
+            args['ExclusiveStartKey'] = pos
+
+    assert items_found == [ 'eee7eb26-a372-4eb4-aeaa-82f224cf0000', 'eee7eb26-a372-4eb4-aeaa-82f224cf0019' ]
+
 # Test that fetching key columns from system tables works
 def test_fetch_from_system_tables(scylla_only, dynamodb, rest_api):
     client = dynamodb.meta.client


### PR DESCRIPTION
Fix unlikely use-after-free in `encode_paging_state`. The function incorrectly assumes that current position to encode will always have data for all clustering columns the schema defines. It's possible to encounter current position having less than all columns specified, for eample in case of range tombstone. Those don't happen in Alternator tables as DynamoDB doesn't allow range deletions. Alternator api can be used to read scylla system tables and those do have range tombstones.

The fix is to stop trying to encode columns, that don't have the value - they are not needed anyway, as there's no possible position with those values (range tombstone made sure of that).

Fixes #27001
Fixes #27125 