### PR TITLE
alternator: Get feature service from proxy directly

### DIFF
--- a/alternator/streams.cc
+++ b/alternator/streams.cc
@@ -1073,9 +1073,7 @@ bool executor::add_stream_options(const rjson::value& stream_specification, sche
     }
 
     if (stream_enabled->GetBool()) {
-        auto db = sp.data_dictionary();
-
-        if (!db.features().alternator_streams) {
+        if (!sp.features().alternator_streams) {
             throw api_error::validation("StreamSpecification: alternator streams feature not enabled in cluster.");
         }
 

--- a/alternator/ttl.cc
+++ b/alternator/ttl.cc
@@ -68,7 +68,7 @@ extern const sstring TTL_TAG_KEY;
 
 future<executor::request_return_type> executor::update_time_to_live(client_state& client_state, service_permit permit, rjson::value request) {
     _stats.api_operations.update_time_to_live++;
-    if (!_proxy.data_dictionary().features().alternator_ttl) {
+    if (!_proxy.features().alternator_ttl) {
         co_return api_error::unknown_operation("UpdateTimeToLive not yet supported. Experimental support is available if the 'alternator-ttl' experimental feature is enabled on all nodes.");
     }
 


### PR DESCRIPTION
The executor::add_stream_options() obtains local database reference from proxy just to get feature service from it. 

Similar chain is used in executor::update_time_to_live().

It's shorter to get features from proxy itself.

Small cleanup, no need to backport