### PR TITLE
Refine sstables_loader vs database dependency

### DIFF
--- a/message/messaging_service.cc
+++ b/message/messaging_service.cc
@@ -1453,4 +1453,8 @@ unsigned messaging_service::add_statement_tenant(sstring tenant_name, scheduling
     return idx;
 }
 
+bool messaging_service::supports_load_and_stream_abort_rpc_message() const noexcept {
+    return _feature_service.load_and_stream_abort_rpc_message;
+}
+
 } // namespace net

--- a/message/messaging_service.hh
+++ b/message/messaging_service.hh
@@ -483,6 +483,7 @@ public:
     unsigned add_statement_tenant(sstring tenant_name, scheduling_group sg);
 
     void init_feature_listeners();
+    bool supports_load_and_stream_abort_rpc_message() const noexcept;
 private:
     std::any _maintenance_tenant_enabled_listener;
 

--- a/sstables_loader.cc
+++ b/sstables_loader.cc
@@ -457,7 +457,7 @@ future<> sstable_streamer::stream_sstable_mutations(streaming::plan_id ops_uuid,
                     if (!metas.contains(node)) {
                         auto [sink, source] = co_await _ms.make_sink_and_source_for_stream_mutation_fragments(reader.schema()->version(),
                                 ops_uuid, cf_id, estimated_partitions, reason, service::default_session_id, node);
-                        bool abort_supported = _db.features().load_and_stream_abort_rpc_message;
+                        bool abort_supported = _ms.supports_load_and_stream_abort_rpc_message();
                         llog.debug("load_and_stream: ops_uuid={}, make sink and source for node={}", ops_uuid, node);
                         metas.emplace(node, send_meta_data(node, std::move(sink), std::move(source), abort_supported));
                         metas.at(node).receive();


### PR DESCRIPTION
There are two issues with it.

First, a small RPC helper struct carries database reference on board just to get feature state from it.
Second, sstable_streamer uses database as proxy to feature service.

This PR improves both.

Services dependencies improvement, not need to backport