### PR TITLE
docs/alternator: document that Streams needs vnodes

### DIFF
--- a/docs/alternator/compatibility.md
+++ b/docs/alternator/compatibility.md
@@ -290,6 +290,14 @@ experimental:
   considered experimental so needs to be enabled explicitly with the
   `--experimental-features=alternator-streams` configuration option.
 
+  In this version, Alternator Streams is only supported if the base table
+  uses vnodes instead of tablets. However, by default new tables use tablets
+  so to create a table that can be used with Streams, you must set the tag
+  `system:initial_tablets` set to `none` during CreateTable - so that the
+  new table will use vnodes. Streams cannot be enabled on an already-existing
+  table that uses tablets.
+  See <https://github.com/scylladb/scylla/issues/23838>.
+
   Alternator streams also differ in some respects from DynamoDB Streams:
   * The number of separate "shards" in Alternator's streams is significantly
     larger than is typical on DynamoDB.


### PR DESCRIPTION
The current state (after PR #26836) is that Alternator tables are created by default using tablets. But due to issue #23838, Alternator Streams cannot be enabled on a table that uses tablets... An attempt to enable Streams on such a table results in a clear error:

    "Streams not yet supported on a table using tablets (issue #23838).
    If you want to use streams, create a table with vnodes by setting
    the tag 'system:initial_tablets' set to 'none'."

But users should be able to learn this fact from the documentation - not just retroactively from an error message. This is especially important because a user might create and fill a table using tablets, and only get this error when attempting to enable Streams on the existing table - when it is too late to change anything.

So this patch adds a paragraph on this to compatibility.md, where several other requirements of Alternator Streams are already mentioned.

We should backport this patch to 2025.4, since it documents PR #26836, which is backported to 2025.4.