### PR TITLE
[Backport 2025.3] pylib: extract upgrade helpers from test_sstable_compression_dictionaries_upgrade.py

### DIFF
--- a/test/cluster/conftest.py
+++ b/test/cluster/conftest.py
@@ -21,7 +21,7 @@ from test.pylib.random_tables import RandomTables
 from test.pylib.util import unique_name
 from test.pylib.manager_client import ManagerClient
 from test.pylib.async_cql import run_async
-from test.pylib.scylla_cluster import ScyllaClusterManager
+from test.pylib.scylla_cluster import ScyllaClusterManager, ScyllaVersionDescription, get_scylla_2025_1_description
 from test.pylib.suite.base import get_testpy_test
 from test.pylib.suite.python import add_cql_connection_options
 import logging
@@ -36,6 +36,7 @@ from cassandra.policies import TokenAwarePolicy                          # type:
 from cassandra.policies import WhiteListRoundRobinPolicy                 # type: ignore
 from cassandra.connection import DRIVER_NAME       # type: ignore # pylint: disable=no-name-in-module
 from cassandra.connection import DRIVER_VERSION    # type: ignore # pylint: disable=no-name-in-module
+from collections.abc import AsyncIterator
 
 if TYPE_CHECKING:
     from collections.abc import AsyncGenerator
@@ -326,3 +327,14 @@ async def prepare_3_nodes_cluster(request, manager):
 async def prepare_3_racks_cluster(request, manager):
     if request.node.get_closest_marker("prepare_3_racks_cluster"):
         await manager.servers_add(3, auto_rack_dc="dc1")
+
+
+@pytest.fixture(scope="function")
+def internet_dependency_enabled(request) -> None:
+    if request.config.getoption('skip_internet_dependent_tests'):
+        pytest.skip(reason="skip_internet_dependent_tests is set")
+
+
+@pytest.fixture(scope="function")
+async def scylla_2025_1(request, build_mode, internet_dependency_enabled) -> AsyncIterator[ScyllaVersionDescription]:
+    yield await get_scylla_2025_1_description(build_mode)

--- a/test/pylib/manager_client.py
+++ b/test/pylib/manager_client.py
@@ -329,6 +329,14 @@ class ManagerClient:
         data = {"path": path}
         await self.client.put_json(f"/cluster/server/{server_id}/switch_executable", data)
 
+    async def server_change_version(self, server_id: ServerNum, exe: str):
+        """ Upgrades a running Scylla node by switching it to a new binary version 
+            specified by the 'exe' parameter.
+        """
+        await self.server_stop_gracefully(server_id)
+        await self.server_switch_executable(server_id, exe)
+        await self.server_start(server_id)
+
     async def server_wipe_sstables(self, server_id: ServerNum, keyspace: str, table: str) -> None:
         """Delete all files for the given table from the data directory"""
         logger.debug("ManagerClient wiping sstables on %s, keyspace=%s, table=%s", server_id, keyspace, table)


### PR DESCRIPTION
The cherry-picked patch was originally introduced in 2025.4 to reuse the helpers for testing upgrades for LWT fencing (368d70ee15).

Later, it was also used to test the default SSTable compression algorithm (adf9c426c2).

Backport this patch so that we can later backport the PR for the default SSTable compression algorithm.

(cherry picked from commit 49b036cf2bcd8582eaf55517fdd2c1f3c4531555)