### PR TITLE
sstables: writer: avoid recursion in variadic write()

### DIFF
--- a/sstables/writer.hh
+++ b/sstables/writer.hh
@@ -248,7 +248,8 @@ template<typename W, typename First, typename Second, typename... Rest>
 requires Writer<W>
 inline void write(sstable_version_types v, W& out, const First& first, const Second& second, Rest&&... rest) {
     write(v, out, first);
-    write(v, out, second, std::forward<Rest>(rest)...);
+    write(v, out, second);
+    (..., write(v, out, std::forward<Rest>(rest)));
 }
 
 template <class T, typename W>


### PR DESCRIPTION
Following 9b6ce030d0c6 ("sstables: remove quadratic (and possibly exponential) compile time in parse()"), where we removed recursion in reading, we do the same here for variadic write. This results in a small reduction in compile time.

Note the problem isn't very bad here. This is tail-recursion, so likely removed by the compiler during optimization, and we don't have additional amplification due to future::then() double-compiling the ready-future and unready-future paths. Still, better to avoid quadratic compile times.

Minor compile-time improvement, no backport justified.