### PR TITLE
utils: fix get_random_time_UUID_from_micros to generate correct time …

### DIFF
--- a/test/boost/UUID_test.cc
+++ b/test/boost/UUID_test.cc
@@ -286,3 +286,20 @@ BOOST_AUTO_TEST_CASE(test_null_uuid) {
     BOOST_CHECK(!uuid.is_null());
     BOOST_CHECK(uuid);
 }
+
+BOOST_AUTO_TEST_CASE(check_get_random_time_UUID_from_micros_variant) {
+    using namespace std::chrono;
+
+    for (int i = 0; i < 100; i++) {
+        auto tp = system_clock::now();
+        auto micros = duration_cast<microseconds>(tp.time_since_epoch());
+
+        auto uuid = utils::UUID_gen::get_random_time_UUID_from_micros(micros);
+        // check that generated UUID is timeuuid
+        BOOST_CHECK(uuid.is_timestamp());
+        // check that generated UUID preserves the original microsecond time
+        BOOST_CHECK_EQUAL(utils::UUID_gen::micros_timestamp(uuid), micros.count());
+        // check that variant is RFC 4122 (IETF)
+        BOOST_CHECK_EQUAL((uuid.get_least_significant_bits() >> 62) & 0x3, 2);
+    }
+}

--- a/utils/UUID_gen.hh
+++ b/utils/UUID_gen.hh
@@ -169,7 +169,10 @@ public:
         static thread_local std::mt19937_64 rand_gen(std::random_device().operator()());
         static thread_local std::uniform_int_distribution<int64_t> rand_dist(std::numeric_limits<int64_t>::min());
 
-        auto uuid = UUID(create_time(from_unix_timestamp(when_in_micros)), rand_dist(rand_gen));
+        auto lsb = rand_dist(rand_gen);
+        lsb &= ~0xC000000000000000L; // clear variant bits
+        lsb |= 0x8000000000000000L; // set variant to IETF variant
+        auto uuid = UUID(create_time(from_unix_timestamp(when_in_micros)), lsb);
         SCYLLA_ASSERT(uuid.is_timestamp());
         return uuid;
     }


### PR DESCRIPTION
…uuid

According to the IETF spec uuid variant bits should be set to '10'. All others are either invalid or reserved. The patch change the code to follow the spec.

No need to backport. Minor issue.