### PR TITLE
test: test_raft_recovery_stuck: ensure mutual visibility before using driver

### DIFF
--- a/test/cluster/test_raft_recovery_stuck.py
+++ b/test/cluster/test_raft_recovery_stuck.py
@@ -69,6 +69,10 @@ async def test_recover_stuck_raft_recovery(request, manager: ManagerClient):
 
     logging.info(f"Starting {others}")
     await asyncio.gather(*(manager.server_start(srv.server_id) for srv in others))
+
+    logging.info(f"Waiting until {servers} see each other as alive")
+    await manager.servers_see_each_other(servers)
+
     cql = await reconnect_driver(manager)
 
     logging.info(f"Cluster restarted, waiting until driver reconnects to {others}")


### PR DESCRIPTION
Not waiting for nodes to see each other as alive can cause the driver to
fail the request sent in `wait_for_upgrade_state()`.

scylladb/scylladb#19771 has already replaced concurrent restarts with
`ManagerClient.rolling_restart()`, but it has missed this single place,
probably because we do concurrent starts here.

Fixes #27055

This PR is a CI stability improvement that changes only the test, so it
can be backported to all branches.