### PR TITLE
docs: add liveness::MustRestart support

### DIFF
--- a/docs/_ext/scylladb_cc_properties.py
+++ b/docs/_ext/scylladb_cc_properties.py
@@ -95,11 +95,12 @@ class DBConfigParser:
 
         for match in config_matches:
             name = match[1].strip()
+            liveness_value = match[3].strip() if match[3] else ""
             property_data = {
                 "name": name,
                 "value_status": match[4].strip(),
                 "default": match[5].strip(),
-                "liveness": "True" if match[3] else "False",
+                "liveness": "True" if liveness_value == "LiveUpdate" else "False",
                 "description": match[6].strip(),
             }
             properties.append(property_data)
@@ -135,7 +136,7 @@ class DBConfigParser:
 
             end_pos = next_group_match.start() if next_group_match else len(config_content)
             config_group_content = config_content[group_match.end():end_pos]
-            
+
             current_group = self._parse_group(group_match, config_group_content)
             groups.append(current_group)
 


### PR DESCRIPTION
Fixes https://github.com/scylladb/scylladb/issues/27059

Fixes https://github.com/scylladb/scylladb/issues/24826

Adds support for properties with the `liveness::MustRestart` parameter.

Fixes an issue where these properties were incorrectly showing Liveness as true.

No need to backport, it will be applied to previous versions once merged.

## How to test

1. Build the documentation.

2. Open [http://127.0.0.1:5500/reference/configuration-parameters/#confval-internode_compression_enable_advanced](http://127.0.0.1:5500/reference/configuration-parameters/#confval-internode_compression_enable_advanced)

3. Verify that **Liveness** is set to false:

<img width="3024" height="1714" alt="image" src="https://github.com/user-attachments/assets/8a8d51ec-a1eb-4795-b4cb-49e9be1138a7" />
