### PR TITLE
sstables/trie/trie_writer: free nodes after they are flushed

### DIFF
--- a/sstables/trie/trie_writer.hh
+++ b/sstables/trie/trie_writer.hh
@@ -324,6 +324,7 @@ inline void trie_writer<Output>::compact_after_writing_children(ptr<writer_node>
         // Check that we aren't freeing things still in use.
         expensive_assert(x._global_pos < x->_transition._global_pos);
     #endif
+    _allocator.discard(x->_transition.offset(x->_transition_length));
     // Step 3.
     x->reserve_children(n_children, _allocator);
     // Even though only the 4 copied child fields are needed after this point,


### PR DESCRIPTION
Somehow, the line of code responsible for freeing flushed nodes in `trie_writer` is missing from the implementation.

This effectively means that `trie_writer` keeps the whole index in memory until the index writer is closed, which for many dataset is a guaranteed OOM.

Fix that, and add some test that catches this.

Fixes scylladb/scylladb#27082

Bugfix, has to be backported to 2025.4.