### PR TITLE
Add documentation about lack of returning similarity distances

### DIFF
--- a/docs/cql/dml/select.rst
+++ b/docs/cql/dml/select.rst
@@ -274,8 +274,8 @@ in this case ``[0.1, 0.2, 0.3, 0.4]``.
 
 .. warning:: 
 
-  Currently, vector queries do not support filtering with ``WHERE`` clause, grouping with ``GROUP BY`` and paging.
-  This will be added in the future releases.
+  Currently, vector queries do not support filtering with ``WHERE`` clause, returning similarity distances,
+  grouping with ``GROUP BY`` and paging. This will be added in the future releases.
 
 
 .. _limit-clause:


### PR DESCRIPTION
This PR adds the missing warning about the lack of possibility to return the similarity distance. This will be added in the next iteration.

Fixes #27086

It has to be backported to 2025.4 as this is the limitation in 2025.4.