### PR TITLE
vector_search: Fix status response parsing

### DIFF
--- a/test/vector_search/vs_mock_server.hh
+++ b/test/vector_search/vs_mock_server.hh
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "utils.hh"
+#include "utils/rjson.hh"
 #include "seastar/http/request.hh"
 #include <seastar/core/future.hh>
 #include <seastar/core/seastar.hh>
@@ -140,7 +141,7 @@ private:
     std::vector<request> _ann_requests;
     std::vector<request> _status_requests;
     response _next_ann_response{seastar::http::reply::status_type::ok, CORRECT_RESPONSE_FOR_TEST_TABLE};
-    response _next_status_response{seastar::http::reply::status_type::ok, "SERVING"};
+    response _next_status_response{seastar::http::reply::status_type::ok, rjson::quote_json_string("SERVING")};
     const seastar::sstring INDEXES_PATH = "/api/v1/indexes";
 };
 

--- a/vector_search/client.cc
+++ b/vector_search/client.cc
@@ -10,6 +10,7 @@
 #include "utils.hh"
 #include "utils/exceptions.hh"
 #include "utils/exponential_backoff_retry.hh"
+#include "utils/rjson.hh"
 #include <seastar/http/request.hh>
 #include <seastar/http/short_streams.hh>
 #include <seastar/net/socket_defs.hh>
@@ -128,7 +129,8 @@ seastar::future<bool> client::check_status() {
         co_return false;
     }
     auto resp = co_await std::move(f);
-    co_return response_content_to_sstring(resp.content) == "SERVING";
+    auto json = rjson::parse(std::move(resp.content));
+    co_return json.IsString() && json.GetString() == std::string_view("SERVING");
 }
 
 seastar::future<> client::close() {


### PR DESCRIPTION
The response was incorrectly parsed as a plain string and compared directly with C++ string. However, the body contains a JSON string, which includes escaped quotes that caused comparison failures.

Fixes: SCYLLADB-50

No backport needed as this problem occurs on master only.