### PR TITLE
test/pylib/cpp: increase max-networking-io-control-blocks value

### DIFF
--- a/test/pylib/cpp/base.py
+++ b/test/pylib/cpp/base.py
@@ -55,7 +55,7 @@ DEFAULT_SCYLLA_ARGS = [
     "--kernel-page-cache=1",
     "--blocked-reactor-notify-ms=2000000",
     "--collectd=0",
-    "--max-networking-io-control-blocks=100",
+    "--max-networking-io-control-blocks=1000",
 ]
 DEFAULT_CUSTOM_ARGS = ["-c2 -m2G"]
 


### PR DESCRIPTION
Increase the value of the max-networking-io-control-blocks option for the cpp tests as it is too low and causes flakiness as seen in vector_search.vector_store_client_test.vector_store_client_single_status_check_after_concurrent_failures:
```
seastar/src/core/reactor_backend.cc:342: void seastar::aio_general_context::queue(linux_abi::iocb *): Assertion `last < end` failed.
```

See also https://github.com/scylladb/seastar/issues/976

Fixes #27056

* Introduced in e44b26b8094, so needs backport all the way back to 2025.2