### PR TITLE
repair: Fix deadlock when topology coordinator steps down in the middle

### DIFF
--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -1752,6 +1752,10 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
                         rtlogger.info("Finished tablet repair host={} tablet={} duration={} repair_time={}",
                                 dst, tablet, duration, res.repair_time);
                     })) {
+                        if (utils::get_local_injector().enter("delay_end_repair_update")) {
+                            break;
+                        }
+
                         auto& tinfo = tmap.get_tablet_info(gid.tablet);
                         bool valid = tinfo.repair_task_info.is_valid();
                         auto hosts_filter = tinfo.repair_task_info.repair_hosts_filter;

--- a/test/cluster/test_incremental_repair.py
+++ b/test/cluster/test_incremental_repair.py
@@ -9,6 +9,7 @@ from test.cluster.conftest import skip_mode
 from test.pylib.repair import load_tablet_sstables_repaired_at, create_table_insert_data_for_repair
 from test.pylib.tablets import get_all_tablet_replicas
 from test.cluster.tasks.task_manager_client import TaskManagerClient
+from test.cluster.util import find_server_by_host_id, get_topology_coordinator, new_test_keyspace, new_test_table, trigger_stepdown
 
 import pytest
 import asyncio
@@ -689,3 +690,77 @@ async def test_tablet_repair_tablet_time_metrics(manager: ManagerClient):
 
     assert time1 == 0
     assert time2 > 0
+
+# Reproducer for https://github.com/scylladb/scylladb/issues/26346
+@pytest.mark.asyncio
+@skip_mode('release', 'error injections are not supported in release mode')
+async def test_repair_finishes_when_tablet_skips_end_repair_stage(manager):
+    servers = await manager.servers_add(3, auto_rack_dc="dc1")
+
+    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3} AND tablets = {'initial': 1}") as ks:
+        async with new_test_table(manager, ks, "pk int PRIMARY KEY, t text") as cf:
+            table = cf.split('.')[-1]
+
+            coord = await get_topology_coordinator(manager)
+            coord_serv = await find_server_by_host_id(manager, servers, coord)
+            coord_log = await manager.server_open_log(coord_serv.server_id)
+            coord_mark = await coord_log.mark()
+
+            await manager.api.enable_injection(coord_serv.ip_addr, "delay_end_repair_update", one_shot=False)
+            response = await manager.api.tablet_repair(servers[0].ip_addr, ks, table, "all", await_completion=False, incremental_mode="incremental")
+            task_id = response['tablet_task_id']
+
+            await coord_log.wait_for("Finished tablet repair", from_mark=coord_mark)
+            await trigger_stepdown(manager, coord_serv)
+
+            # Disable injection in case, the same node is elected as coordinator
+            await manager.api.disable_injection(coord_serv.ip_addr, "delay_end_repair_update")
+            await manager.api.wait_task(servers[0].ip_addr, task_id)
+
+@pytest.mark.asyncio
+@skip_mode('release', 'error injections are not supported in release mode')
+async def test_repair_rejoin_do_tablet_operation(manager):
+    cmdline = ['--logger-log-level', 'raft_topology=debug']
+    servers = await manager.servers_add(3, auto_rack_dc="dc1", cmdline=cmdline)
+
+    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3} AND tablets = {'initial': 1}") as ks:
+        async with new_test_table(manager, ks, "pk int PRIMARY KEY, t text") as cf:
+            table = cf.split('.')[-1]
+
+            async def get_coord():
+                coord = await get_topology_coordinator(manager)
+                coord_serv = await find_server_by_host_id(manager, servers, coord)
+                coord_log = await manager.server_open_log(coord_serv.server_id)
+                return coord, coord_serv, coord_log
+
+            for s in servers:
+                await manager.api.enable_injection(s.ip_addr, "repair_finish_wait", one_shot=False)
+
+            coord, coord_serv, coord_log = await get_coord()
+
+            response = await manager.api.tablet_repair(servers[0].ip_addr, ks, table, "all", await_completion=False, incremental_mode="incremental")
+            task_id = response['tablet_task_id']
+
+            await coord_log.wait_for("Initiating tablet repair")
+            await trigger_stepdown(manager, coord_serv)
+
+            coord, coord_serv, coord_log = await get_coord()
+            await coord_log.wait_for("Initiating tablet repair")
+
+            found = False
+            for run in range(10):
+                for s in servers:
+                    log = await manager.server_open_log(s.server_id)
+                    res = await log.grep('Repair retry joining with existing session for tablet')
+                    if len(res) > 0:
+                        found = True
+                        break
+                if found:
+                    break
+                await asyncio.sleep(3)
+            assert found
+
+            for s in servers:
+                await manager.api.message_injection(s.ip_addr, "repair_finish_wait")
+                await manager.api.disable_injection(s.ip_addr, "repair_finish_wait")
+            await coord_log.wait_for("Finished tablet repair")

--- a/test/cluster/test_tablets_colocation.py
+++ b/test/cluster/test_tablets_colocation.py
@@ -393,6 +393,7 @@ async def test_create_colocated_table_while_base_is_migrating(manager: ManagerCl
 # 3. bring the node back up - it is now missing some data
 # 4. run tablet repair on the base table
 # 5. verify both the base table and the view contain the missing data on the node that was down
+@pytest.mark.skip(reason="https://github.com/scylladb/scylladb/issues/27119")
 @pytest.mark.asyncio
 async def test_repair_colocated_base_and_view(manager: ManagerClient):
     cfg = {'enable_tablets': True}


### PR DESCRIPTION
Consider this:

1) n1 is the topology coordinator
2) n1 schedules and executes a tablet repair with session id s1 for a tablet on n3 an n4.
3) n3 and n4 take and store the in _rs._repair_compaction_locks[s1] 4) n1 steps down before it executes
locator::tablet_transition_stage::end_repair
5) n2 becomes the new topology coordinator
6) n2 runs locator::tablet_transition_stage::repair again 7) n3 and n4 try to take the lock again and hangs since the lock is already taken.

To avoid the deadlock, we can throw in step 7 so that n2 will proceed to end_repair stage and release the lock. After that, the scheduler could schedule the tablet repair request again.

Fixes #26346

The relevant code is present in 2025.4 only. Backport to 2025.4.