### PR TITLE
replica: database: change type of tables_metadata::_ks_cf_to_uuid

### DIFF
--- a/replica/database.cc
+++ b/replica/database.cc
@@ -3290,7 +3290,7 @@ table& database::tables_metadata::get_table(table_id id) const {
 }
 
 table_id database::tables_metadata::get_table_id(const std::pair<std::string_view, std::string_view>& kscf) const {
-    return _ks_cf_to_uuid.at(kscf);
+    return _ks_cf_to_uuid.at(ks_cf_t{kscf});
 }
 
 lw_shared_ptr<table> database::tables_metadata::get_table_if_exists(table_id id) const {

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1535,7 +1535,7 @@ public:
 
     using ks_cf_t = std::pair<sstring, sstring>;
     using ks_cf_to_uuid_t =
-        flat_hash_map<ks_cf_t, table_id, utils::tuple_hash, string_pair_eq>;
+        std::unordered_map<ks_cf_t, table_id, utils::tuple_hash, string_pair_eq>;
     class tables_metadata {
         rwlock _cf_lock;
         std::unordered_map<table_id, lw_shared_ptr<column_family>> _column_families;


### PR DESCRIPTION
If there is a lot of tables, a node reports oversized allocation in _ks_cf_to_uuid of type flat_hash_map.

Change the type to std::unordered_map to prevent oversized allocations.

Fixes: https://github.com/scylladb/scylladb/issues/26787.

Needs backport to 2025.{1,2,3,4} as they are all affected.