### PR TITLE
service/storage_service: Mark nodes excluded on shard0

### DIFF
--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -4292,6 +4292,13 @@ future<> storage_service::raft_removenode(locator::host_id host_id, locator::hos
 }
 
 future<> storage_service::mark_excluded(const std::vector<locator::host_id>& hosts) {
+    if (this_shard_id() != 0) {
+        // group0 is only set on shard 0.
+        co_return co_await container().invoke_on(0, [&] (auto& ss) {
+            return ss.mark_excluded(hosts);
+        });
+    }
+
     while (true) {
         auto guard = co_await _group0->client().start_operation(_group0_as, raft_timeout{});
 


### PR DESCRIPTION
Marking nodes as excluded is a group0 operation and as such it needs
to be executed on shard0 only. In case, the method `mark_excluded` is
invoked on a different shard, redirect the request to shard0.

Fixes https://github.com/scylladb/scylladb/issues/27129

Backport is not required. `nodetool excludenode` command has been
introduced recently and is not part of any release yet.