### PR TITLE
tools: toolchain: prepare: replace 'reg' with 'skopeo'

### DIFF
--- a/tools/toolchain/prepare
+++ b/tools/toolchain/prepare
@@ -24,12 +24,12 @@ if (( ! ok )); then
     exit 1
 fi
 
-if ! command -v reg > /dev/null; then
-    echo install the reg command for registry inspection
+if ! command -v skopeo > /dev/null; then
+    echo install the skopeo package for registry inspection
     exit 1
 fi
 
-if reg digest $(<tools/toolchain/image) > /dev/null; then
+if skopeo inspect "docker://$(<tools/toolchain/image)" > /dev/null 2>&1; then
     echo "Toolchain image $(<tools/toolchain/image) exists; select a new name"
     exit 1
 fi


### PR DESCRIPTION
The prepare scripts uses 'reg' to verify we're not going to overwrite an existing image. The 'reg' command is not available in Fedora 43. Use 'skopeo' instead. Skopeo is part of the podman ecosystem so hopefully will live longer.

Fixes #27178.

Minor maintainer-only change, but unbreaks preparing toolchains for older releases, so better to backport