### PR TITLE
docs/alternator: list another unimplemented Alternator feature

### DIFF
--- a/docs/alternator/compatibility.md
+++ b/docs/alternator/compatibility.md
@@ -428,3 +428,7 @@ they should be easy to detect. Here is a list of these unimplemented features:
   that can be used to achieve consistent reads on global (multi-region) tables.
   This table option was added as a preview to DynamoDB in December 2024.
   <https://github.com/scylladb/scylladb/issues/21852>
+
+* Alternator does not support multi-attribute (composite) keys in GSIs.
+  This feature was added to DynamoDB in November 2025.
+  <https://github.com/scylladb/scylladb/issues/27182>


### PR DESCRIPTION
A new feature was announced this week for Amazon DynamoDB, "multi- attribute composite keys in global secondary indexes", which allows to create GSIs with composite keys (multiple columns). This feature already existed in CQL's materialized views, but didn't exist in DynamoDB until now.

So this patch adds a paragraph to our docs/alternator/compatibility.md mentioning that we don't support this DynamoDB feature yet.

See also issue #27182 which we opened to track this unimplemented feature.