### PR TITLE
sstable: add _mutate_sem to serialize link/move with components rewrite

### DIFF
--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -1371,6 +1371,7 @@ int64_t sstable::update_repaired_at(int64_t repaired_at) {
 void sstable::rewrite_statistics() {
     sstlog.debug("Rewriting statistics component of sstable {}", get_filename());
 
+    auto lock = get_units(_mutate_sem, 1).get();
     file_output_stream_options options;
     options.buffer_size = sstable_buffer_size;
     auto w = make_digests_component_file_writer(component_type::TemporaryStatistics, std::move(options),
@@ -2536,15 +2537,19 @@ std::vector<std::pair<component_type, sstring>> sstable::all_components() const 
 }
 
 future<> sstable::snapshot(const sstring& dir) const {
-    return _storage->snapshot(*this, dir, storage::absolute_path::yes);
+    auto lock = co_await get_units(_mutate_sem, 1);
+    co_await _storage->snapshot(*this, dir, storage::absolute_path::yes);
 }
 
 future<> sstable::change_state(sstable_state to, delayed_commit_changes* delay_commit) {
+    auto lock = co_await get_units(_mutate_sem, 1);
     co_await _storage->change_state(*this, to, _generation, delay_commit);
     _state = to;
 }
 
 future<> sstable::pick_up_from_upload(sstable_state to, generation_type new_generation) {
+    // just in case, not really needed as the sstable is not yet in use while in the upload dir
+    auto lock = co_await get_units(_mutate_sem, 1);
     co_await _storage->change_state(*this, to, new_generation, nullptr);
     _generation = std::move(new_generation);
     _state = to;
@@ -3479,6 +3484,9 @@ utils::hashed_key sstable::make_hashed_key(const schema& s, const partition_key&
 
 future<>
 sstable::unlink(storage::sync_dir sync) noexcept {
+    // Serialize with other calls to unlink or potentially ongoing mutations.
+    auto lock = co_await get_units(_mutate_sem, 1);
+
     _unlinked = true;
     _on_delete(*this);
 

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -630,6 +630,10 @@ private:
     bool _unlinked{false};
 
     components_digests _components_digests;
+
+    // The mutate semaphore is used to serialize operations like rewrite_statistics
+    // with linking or moving the sstable between directories.
+    mutable named_semaphore _mutate_sem{1, named_semaphore_exception_factory{"sstable mutate"}};
 public:
     bool has_component(component_type f) const;
     sstables_manager& manager() { return _manager; }


### PR DESCRIPTION
We currently have races, like between moving an sstable from staging using change_state, or when taking a snapshot, to e.g. rewrite_statistics that replaces one of the sstable component files when called, for example, from update_repaired_at by incremental repair.

Use a semaphore as a mutex to serialize those functions. Note that there is no need for rwlock since the operations are rare and read-only operations like snapshot don't need to run in parallel.

Fixes #25919

* backport/2025.4 as per https://github.com/scylladb/scylladb/commit/611918056a0bfe5243680db69c5b19f2dd754c76