### PR TITLE
dist: systemd: drop deprecated CPU and I/O shares/weight from scylla-server.slice

### DIFF
--- a/dist/common/systemd/scylla-server.slice
+++ b/dist/common/systemd/scylla-server.slice
@@ -6,13 +6,7 @@ Before=slices.target
 MemoryAccounting=true
 IOAccounting=true
 CPUAccounting=true
-# Systemd deprecated settings BlockIOWeight and CPUShares. But they are still the ones used in RHEL7
-# Newer SystemD wants IOWeight and CPUWeight instead. Luckily both newer and older SystemD seem to
-# ignore the unwanted option so safest to get both. Using just the old versions would work too but
-# seems less future proof. Using just the new versions does not work at all for RHEL7/
-BlockIOWeight=1000
 IOWeight=1000
 MemorySwapMax=0
-CPUShares=1000
 CPUWeight=1000
 


### PR DESCRIPTION

The BlockIOWeight and CPUShares are deprecated. They are only used on RHEL 7, which has reached end-of-life. Their replacements, IOWeight and CPUWeight, are already set in the file.

Remove the deprecated settings to reduce noise in the logs.

Minor quality of life improvement, no backport needed.