### PR TITLE
gms/gossiper.cc: fix gossip log to show host-id/ip instead of host-id…

### DIFF
--- a/gms/gossiper.cc
+++ b/gms/gossiper.cc
@@ -781,7 +781,7 @@ future<> gossiper::remove_endpoint(locator::host_id endpoint, permit_id pid) {
 
     if (was_alive) {
         try {
-            logger.info("InetAddress {}/{} is now DOWN, status = {}", state->get_host_id(), endpoint, get_gossip_status(*state));
+            logger.info("InetAddress {}/{} is now DOWN, status = {}", state->get_host_id(), ip, get_gossip_status(*state));
             co_await do_on_dead_notifications(ip, std::move(state), pid);
         } catch (...) {
             logger.warn("Fail to call on_dead callback: {}", std::current_exception());


### PR DESCRIPTION
…/host-id

Probably a copy-paste error, fixes the log to print host-id/ip.

Backport: no need, benign log issue.

Fixes: https://github.com/scylladb/scylladb/issues/27113

