### PR TITLE
install-dependencies.sh: add zlib

### DIFF
--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -55,6 +55,7 @@ debian_base_packages=(
     librapidxml-dev
     libcrypto++-dev
     libxxhash-dev
+    zlib1g-dev
     slapd
     ldap-utils
     libcpp-jwt-dev
@@ -117,6 +118,7 @@ fedora_packages=(
     makeself
     libzstd-static libzstd-devel
     lz4-static lz4-devel
+    zlib-ng-compat-devel
     rpm-build
     devscripts
     debhelper


### PR DESCRIPTION
Scylla uses zlib, through the header <zlib.h>, in sstable compression. We also want to use it in Alternator for gzip-compressed requests.

We never actually required zlib explicltly in install-dependencies.sh, we only get it through transitive dependencies. But it's better to require it explicitly so this is what we do in this patch.

In Fedora, we use the newer, more efficient, zlib-ng which is API- compatible with the classic zlib. Unfortunately, the Debian zlib-ng package is *not* drop-in compatible with zlib (you need to include a different header file <zlib-ng.h>) so we use the classic zlib.