### PR TITLE
unittest: fix vector_store_client_test_dns_refresh_aborted hangs

### DIFF
--- a/test/vector_search/vector_store_client_test.cc
+++ b/test/vector_search/vector_store_client_test.cc
@@ -274,9 +274,13 @@ SEASTAR_TEST_CASE(vector_store_client_test_dns_refresh_aborted) {
     seastar::condition_variable wait_for_abort;
     auto as = abort_source_timeout(milliseconds(10));
     auto vs = vector_store_client{cfg};
+    auto should_wait = true;
     configure(vs).with_dns_refresh_interval(milliseconds(10)).with_dns_resolver([&](auto const& host) -> future<std::optional<inet_address>> {
         BOOST_CHECK_EQUAL(host, "good.authority.here");
-        co_await wait_for_abort.when();
+        if (should_wait) {
+            should_wait = false;
+            co_await wait_for_abort.when();
+        }
         co_return inet_address("127.0.0.1");
     });
 


### PR DESCRIPTION
The root cause for the hanging test is a concurrency deadlock. `vector_store_client` runs dns refresh time and it is waiting for the condition variable.After aborting dns request the test signals the condition variable. Stopping the vector_store_client takes time enough to trigger the next dns refresh - and this time the condition variable won't be signalled - so vector_store_client will wait forever for finish dns refresh fiber.

The commit fixes the problem by waiting for the condition variable only once.

Fixes: #27237
Fixes: VECTOR-370

It needs to be backported to 2025.4