### PR TITLE
boot_strapper: Allow config the max nr of nodes to stream for bootstrap

### DIFF
--- a/db/config.cc
+++ b/db/config.cc
@@ -892,6 +892,7 @@ db::config::config(std::shared_ptr<db::extensions> exts)
     , stream_plan_ranges_fraction(this, "stream_plan_ranges_fraction", liveness::LiveUpdate, value_status::Used, 0.1,
         "Specify the fraction of ranges to stream in a single stream plan. Value is between 0 and 1.")
     , enable_file_stream(this, "enable_file_stream", liveness::LiveUpdate, value_status::Used, true, "Set true to use file based stream for tablet instead of mutation based stream")
+    , max_stream_nodes_for_bootstrap(this, "max_stream_nodes_for_bootstrap", liveness::LiveUpdate, value_status::Used, 16, "Set the max number of nodes to stream data from in parallel for bootstrap")
     , trickle_fsync(this, "trickle_fsync", value_status::Unused, false,
         "When doing sequential writing, enabling this option tells fsync to force the operating system to flush the dirty buffers at a set interval trickle_fsync_interval_in_kb. Enable this parameter to avoid sudden dirty buffer flushing from impacting read latencies. Recommended to use on SSDs, but not on HDDs.")
     , trickle_fsync_interval_in_kb(this, "trickle_fsync_interval_in_kb", value_status::Unused, 10240,

--- a/db/config.hh
+++ b/db/config.hh
@@ -261,6 +261,7 @@ public:
     named_value<uint32_t> stream_io_throughput_mb_per_sec;
     named_value<double> stream_plan_ranges_fraction;
     named_value<bool> enable_file_stream;
+    named_value<uint32_t> max_stream_nodes_for_bootstrap;
     named_value<bool> trickle_fsync;
     named_value<uint32_t> trickle_fsync_interval_in_kb;
     named_value<bool> auto_bootstrap;

--- a/dht/boot_strapper.cc
+++ b/dht/boot_strapper.cc
@@ -41,7 +41,9 @@ future<> boot_strapper::bootstrap(streaming::stream_reason reason, gms::gossiper
         throw std::runtime_error("Wrong stream_reason provided: it can only be replace or bootstrap");
     }
     try {
-        auto streamer = make_lw_shared<range_streamer>(_db, _stream_manager, _token_metadata_ptr, _abort_source, _tokens, _address, _dr, description, reason, topo_guard);
+        size_t max_peer_node = _db.local().get_config().max_stream_nodes_for_bootstrap();
+        blogger.info("Use max_stream_nodes_for_bootstrap={} for bootstrap", max_peer_node);
+        auto streamer = make_lw_shared<range_streamer>(_db, _stream_manager, _token_metadata_ptr, _abort_source, _tokens, _address, _dr, description, reason, topo_guard, std::vector<sstring>(), max_peer_node);
         auto nodes_to_filter = gossiper.get_unreachable_members();
         if (reason == streaming::stream_reason::replace) {
             nodes_to_filter.insert(std::move(replace_address));


### PR DESCRIPTION
This option sets the max number of nodes to stream data from in parallel for bootstrap.

It is currently hard-coded. This patch allows user to set the number than the default 16 nodes.

It could help to reduce the number of tcp connections to the new joining node.

Fixes #27253

New feature. No backports for now. 