### PR TITLE
code: Stop using seastar::compat::source_location

### DIFF
--- a/gms/gossiper.cc
+++ b/gms/gossiper.cc
@@ -846,7 +846,7 @@ future<> gossiper::do_status_check() {
     }
 }
 
-gossiper::endpoint_permit::endpoint_permit(endpoint_locks_map::entry_ptr&& ptr, locator::host_id addr, seastar::compat::source_location caller) noexcept
+gossiper::endpoint_permit::endpoint_permit(endpoint_locks_map::entry_ptr&& ptr, locator::host_id addr, std::source_location caller) noexcept
     : _ptr(std::move(ptr))
     , _permit_id(_ptr->pid)
     , _addr(std::move(addr))
@@ -892,7 +892,7 @@ gossiper::endpoint_lock_entry::endpoint_lock_entry() noexcept
     , pid(permit_id::create_null_id())
 {}
 
-future<gossiper::endpoint_permit> gossiper::lock_endpoint(locator::host_id ep, permit_id pid, seastar::compat::source_location l) {
+future<gossiper::endpoint_permit> gossiper::lock_endpoint(locator::host_id ep, permit_id pid, std::source_location l) {
     if (current_scheduling_group() != _gcfg.gossip_scheduling_group) {
         logger.warn("Incorrect scheduling group used for gossiper::lock_endpoint: {}, should be {}, backtrace {}", current_scheduling_group().name(), _gcfg.gossip_scheduling_group.name(), current_backtrace());
     }
@@ -931,10 +931,10 @@ future<gossiper::endpoint_permit> gossiper::lock_endpoint(locator::host_id ep, p
 
             // If we didn't rethrow above, the abort had to come from `abort_on_expiry`'s timer.
 
-            static constexpr auto fmt_loc = [] (const seastar::compat::source_location& l) {
+            static constexpr auto fmt_loc = [] (const std::source_location& l) {
                 return fmt::format("{}({}:{}) `{}`", l.file_name(), l.line(), l.column(), l.function_name());
             };
-            static constexpr auto fmt_loc_opt = [] (const std::optional<seastar::compat::source_location>& l) {
+            static constexpr auto fmt_loc_opt = [] (const std::optional<std::source_location>& l) {
                 if (!l) {
                     return "null"s;
                 }

--- a/gms/gossiper.hh
+++ b/gms/gossiper.hh
@@ -158,10 +158,10 @@ public:
         permit_id pid;
         semaphore_units<> units;
         size_t holders = 0;
-        std::optional<seastar::compat::source_location> first_holder;
+        std::optional<std::source_location> first_holder;
         // last_holder is the caller of endpoint_permit who last took this entry,
         // it might not be a current holder (the permit might've been destroyed)
-        std::optional<seastar::compat::source_location> last_holder;
+        std::optional<std::source_location> last_holder;
 
         endpoint_lock_entry() noexcept;
     };
@@ -170,16 +170,16 @@ public:
         endpoint_locks_map::entry_ptr _ptr;
         permit_id _permit_id;
         locator::host_id _addr;
-        seastar::compat::source_location _caller;
+        std::source_location _caller;
     public:
-        endpoint_permit(endpoint_locks_map::entry_ptr&& ptr, locator::host_id addr, seastar::compat::source_location caller) noexcept;
+        endpoint_permit(endpoint_locks_map::entry_ptr&& ptr, locator::host_id addr, std::source_location caller) noexcept;
         endpoint_permit(endpoint_permit&&) noexcept;
         ~endpoint_permit();
         bool release() noexcept;
         const permit_id& id() const noexcept { return _permit_id; }
     };
     // Must be called on shard 0
-    future<endpoint_permit> lock_endpoint(locator::host_id, permit_id pid, seastar::compat::source_location l = seastar::compat::source_location::current());
+    future<endpoint_permit> lock_endpoint(locator::host_id, permit_id pid, std::source_location l = std::source_location::current());
 
 private:
     void permit_internal_error(const locator::host_id& addr, permit_id pid);

--- a/raft/raft.hh
+++ b/raft/raft.hh
@@ -290,7 +290,7 @@ struct timeout_error : public error {
 };
 
 struct state_machine_error: public error {
-    state_machine_error(seastar::compat::source_location l = seastar::compat::source_location::current())
+    state_machine_error(std::source_location l = std::source_location::current())
         : error(fmt::format("State machine error at {}:{}", l.file_name(), l.line())) {}
 };
 
@@ -305,7 +305,7 @@ struct transport_error: public error {
 struct destination_not_alive_error: public transport_error {
     server_id destination;
 
-    destination_not_alive_error(server_id destination, seastar::compat::source_location l = seastar::compat::source_location::current())
+    destination_not_alive_error(server_id destination, std::source_location l = std::source_location::current())
             : transport_error(fmt::format("Failed to send {} to {}: node is not seen as alive by the failure detector", l.function_name(), destination)) {}
 };
 

--- a/service/address_map.hh
+++ b/service/address_map.hh
@@ -218,7 +218,7 @@ private:
         }
     }
 
-    void apply_to_all(locator::host_id id, entry_mutation m, seastar::compat::source_location l = seastar::compat::source_location::current());
+    void apply_to_all(locator::host_id id, entry_mutation m, std::source_location l = std::source_location::current());
 
 public: // Used by replicator
     static void prepare_apply(cluster_mutation& map, const host_mutation& mf) {
@@ -437,7 +437,7 @@ future<> address_map_t<Clock>::barrier() {
 }
 
 template <typename Clock>
-void address_map_t<Clock>::apply_to_all(locator::host_id id, entry_mutation m, seastar::compat::source_location l) {
+void address_map_t<Clock>::apply_to_all(locator::host_id id, entry_mutation m, std::source_location l) {
     if (this_shard_id() != 0) {
         on_internal_error(rslog, format("address_map::{}() called on shard {} != 0", l.function_name(), this_shard_id()));
     }

--- a/service/raft/raft_group0.cc
+++ b/service/raft/raft_group0.cc
@@ -1284,7 +1284,7 @@ struct sleep_with_exponential_backoff {
     std::chrono::seconds _retry_period{1};
     static constexpr std::chrono::seconds _max_retry_period{16};
     future<> operator()(abort_source& as,
-                        seastar::compat::source_location loc = seastar::compat::source_location::current()) {
+                        std::source_location loc = std::source_location::current()) {
         upgrade_log.info("{}: sleeping for {} seconds before retrying...", loc.function_name(), _retry_period);
         co_await sleep_abortable(_retry_period, as);
         _retry_period = std::min(_retry_period * 2, _max_retry_period);

--- a/service/raft/raft_group_registry.cc
+++ b/service/raft/raft_group_registry.cc
@@ -410,7 +410,7 @@ shared_ptr<raft::failure_detector> raft_group_registry::failure_detector() {
 raft_group_registry::~raft_group_registry() = default;
 
 namespace {
-    auto fmt_loc(const seastar::compat::source_location& l) {
+    auto fmt_loc(const std::source_location& l) {
         return fmt::format("{}({}:{}) `{}`", l.file_name(), l.line(), l.column(), l.function_name());
     };
 }

--- a/service/raft/raft_rpc.cc
+++ b/service/raft/raft_rpc.cc
@@ -21,7 +21,7 @@ namespace service {
 
 static seastar::logger rlogger("raft_rpc");
 
-using sloc = seastar::compat::source_location;
+using sloc = std::source_location;
 
 static constexpr size_t append_entries_semaphore_limit_bytes = 10_MiB;
 

--- a/service/raft/raft_rpc.hh
+++ b/service/raft/raft_rpc.hh
@@ -39,10 +39,10 @@ private:
     enum class one_way_kind { request, reply };
 
     template <one_way_kind rpc_kind, typename Verb, typename Msg> void
-    one_way_rpc(seastar::compat::source_location loc, raft::server_id id, Verb&& verb, Msg&& msg);
+    one_way_rpc(std::source_location loc, raft::server_id id, Verb&& verb, Msg&& msg);
 
     template <typename Verb, typename... Args> auto
-    two_way_rpc(seastar::compat::source_location loc, raft::server_id id, Verb&& verb, Args&&... args);
+    two_way_rpc(std::source_location loc, raft::server_id id, Verb&& verb, Args&&... args);
 
 public:
     future<raft::snapshot_reply> send_snapshot(raft::server_id server_id, const raft::install_snapshot& snap, seastar::abort_source& as) override;

--- a/service/raft/raft_timeout.hh
+++ b/service/raft/raft_timeout.hh
@@ -13,7 +13,7 @@
 namespace service {
 
 struct raft_timeout {
-    seastar::compat::source_location loc = seastar::compat::source_location::current();
+    std::source_location loc = std::source_location::current();
     std::optional<lowres_clock::time_point> value;
 };
 

--- a/stdafx.hh
+++ b/stdafx.hh
@@ -324,7 +324,6 @@
 #include <seastar/util/sampler.hh>
 #include <seastar/util/shared_token_bucket.hh>
 #include <seastar/util/short_streams.hh>
-#include <seastar/util/source_location-compat.hh>
 #include <seastar/util/spinlock.hh>
 #include <seastar/util/std-compat.hh>
 #include <seastar/util/string_utils.hh>

--- a/test/boost/cql_query_test.cc
+++ b/test/boost/cql_query_test.cc
@@ -1799,7 +1799,7 @@ SEASTAR_TEST_CASE(test_vectors_variable_length_elements) {
 
 namespace {
 
-using seastar::compat::source_location;
+using std::source_location;
 
 auto validate_request_failure(
         cql_test_env& env,
@@ -4449,7 +4449,7 @@ shared_ptr<cql_transport::messages::result_message> cql_func_require_nofail(
         const seastar::sstring& fct,
         const seastar::sstring& inp,
         std::unique_ptr<cql3::query_options>&& qo = nullptr,
-        const seastar::compat::source_location& loc = seastar::compat::source_location::current()) {
+        const std::source_location& loc = std::source_location::current()) {
     auto res = shared_ptr<cql_transport::messages::result_message>(nullptr);
     auto query = format("SELECT {}({}) FROM t;", fct, inp);
     try {
@@ -4474,7 +4474,7 @@ void cql_func_require_throw(
         const seastar::sstring& fct,
         const seastar::sstring& inp,
         std::unique_ptr<cql3::query_options>&& qo = nullptr,
-        const seastar::compat::source_location& loc = seastar::compat::source_location::current()) {
+        const std::source_location& loc = std::source_location::current()) {
     auto query = format("SELECT {}({}) FROM t;", fct, inp);
     try {
         if (qo) {
@@ -5658,11 +5658,11 @@ SEASTAR_TEST_CASE(test_null_and_unset_in_collections) {
         e.execute_cql("CREATE TABLE null_in_col (p int primary key, l list<int>, s set<int>, m map<int, int>);").get();
 
         // The predicate that checks the message has to be a lambda to preserve source_location
-        auto check_null_msg = [](compat::source_location loc = seastar::compat::source_location::current()) {
+        auto check_null_msg = [](compat::source_location loc = std::source_location::current()) {
             return exception_predicate::message_matches(".*(null|NULL).*", loc);
         };
 
-        auto check_unset_msg = [](compat::source_location loc = seastar::compat::source_location::current()) {
+        auto check_unset_msg = [](compat::source_location loc = std::source_location::current()) {
             return exception_predicate::message_contains("unset", loc);
         };
 
@@ -5829,7 +5829,7 @@ SEASTAR_TEST_CASE(test_bind_variable_type_checking) {
         e.execute_cql("CREATE TABLE tab1 (p int primary key, a int, b text, c int)").get();
 
         // The predicate that checks the message has to be a lambda to preserve source_location
-        auto check_type_conflict = [](compat::source_location loc = seastar::compat::source_location::current()) {
+        auto check_type_conflict = [](compat::source_location loc = std::source_location::current()) {
             return exception_predicate::message_contains("variable :var has type", loc);
         };
 

--- a/test/boost/multishard_query_test.cc
+++ b/test/boost/multishard_query_test.cc
@@ -175,7 +175,7 @@ static uint64_t aggregate_querier_cache_stat(sharded<replica::database>& db, uin
 }
 
 static void check_cache_population(sharded<replica::database>& db, size_t queriers,
-        seastar::compat::source_location sl = seastar::compat::source_location::current()) {
+        std::source_location sl = std::source_location::current()) {
     testlog.info("{}() called from {}() {}:{:d}", __FUNCTION__, sl.function_name(), sl.file_name(), sl.line());
 
     parallel_for_each(std::views::iota(0u, smp::count), [queriers, &db] (unsigned shard) {
@@ -187,7 +187,7 @@ static void check_cache_population(sharded<replica::database>& db, size_t querie
 }
 
 static void require_eventually_empty_caches(sharded<replica::database>& db,
-        seastar::compat::source_location sl = seastar::compat::source_location::current()) {
+        std::source_location sl = std::source_location::current()) {
     testlog.info("{}() called from {}() {}:{:d}", __FUNCTION__, sl.function_name(), sl.file_name(), sl.line());
 
     auto aggregated_population_is_zero = [&] () mutable {
@@ -750,7 +750,7 @@ SEASTAR_THREAD_TEST_CASE(test_evict_a_shard_reader_on_each_page) {
         auto [results2, npages] = read_all_partitions_with_paged_scan(env.db(), s, 4, stateful_query::yes, [&] (size_t page) {
             const auto new_lookups = aggregate_querier_cache_stat(env.db(), &replica::querier_cache::stats::lookups);
             if (page) {
-                tests::require(std::cmp_greater(new_lookups, lookups), seastar::compat::source_location::current());
+                tests::require(std::cmp_greater(new_lookups, lookups), std::source_location::current());
             }
             lookups = new_lookups;
 
@@ -764,8 +764,8 @@ SEASTAR_THREAD_TEST_CASE(test_evict_a_shard_reader_on_each_page) {
                 }
             }
 
-            tests::require(aggregate_querier_cache_stat(env.db(), &replica::querier_cache::stats::misses) >= page, seastar::compat::source_location::current());
-            tests::require_equal(aggregate_querier_cache_stat(env.db(), &replica::querier_cache::stats::drops), 0u, seastar::compat::source_location::current());
+            tests::require(aggregate_querier_cache_stat(env.db(), &replica::querier_cache::stats::misses) >= page, std::source_location::current());
+            tests::require_equal(aggregate_querier_cache_stat(env.db(), &replica::querier_cache::stats::drops), 0u, std::source_location::current());
         });
 
         check_results_are_equal(results1, results2);

--- a/test/boost/mutation_reader_test.cc
+++ b/test/boost/mutation_reader_test.cc
@@ -256,7 +256,7 @@ SEASTAR_THREAD_TEST_CASE(test_combined_reader_range_tombstone_change_merging) {
     struct output {
         std::vector<range_tombstone_change> rtcs;
     };
-    auto check = [&] (const char* desc, std::vector<input> in, output out, seastar::compat::source_location sl = seastar::compat::source_location::current()) {
+    auto check = [&] (const char* desc, std::vector<input> in, output out, std::source_location sl = std::source_location::current()) {
         testlog.info("check() {} @ {}:{}", desc, sl.file_name(), sl.line());
         std::vector<mutation_reader> readers;
         for (auto& i : in) {
@@ -1375,7 +1375,7 @@ SEASTAR_TEST_CASE(test_trim_clustering_row_ranges_to) {
             .build();
 
     const auto check = [](std::vector<range> ranges, key key, std::vector<range> output_ranges, schema_ptr schema,
-            seastar::compat::source_location sl = seastar::compat::source_location::current()) {
+            std::source_location sl = std::source_location::current()) {
         auto actual_ranges = ranges | std::views::transform(
                     [&] (const range& r) { return r.to_clustering_range(*schema); })
             | std::ranges::to<query::clustering_row_ranges>();
@@ -1395,12 +1395,12 @@ SEASTAR_TEST_CASE(test_trim_clustering_row_ranges_to) {
     };
 
     auto check_forward = [schema, &check] (std::vector<range> ranges, key key, std::vector<range> output_ranges,
-            seastar::compat::source_location sl = seastar::compat::source_location::current()) {
+            std::source_location sl = std::source_location::current()) {
         return check(std::move(ranges), std::move(key), std::move(output_ranges), std::move(schema), sl);
     };
 
     auto check_reversed = [schema = schema->make_reversed(), &check] (std::vector<range> ranges, key key, std::vector<range> output_ranges,
-            seastar::compat::source_location sl = seastar::compat::source_location::current()) {
+            std::source_location sl = std::source_location::current()) {
         return check(std::move(ranges), std::move(key), std::move(output_ranges), std::move(schema), sl);
     };
 
@@ -4457,7 +4457,7 @@ SEASTAR_TEST_CASE(test_multishard_reader_buffer_hint_large_partitions) {
         };
 
         auto run_test = [&] (size_t buffer_size, multishard_reader_buffer_hint buffer_hint,
-                seastar::compat::source_location sl = seastar::compat::source_location::current()) {
+                std::source_location sl = std::source_location::current()) {
             testlog.info("run_test(): buffer_size: {}, buffer_hint: {} @ {}:{}", buffer_size, bool(buffer_hint), sl.file_name(), sl.line());
 
             auto reader = make_multishard_combining_reader_for_tests(

--- a/test/boost/reader_concurrency_semaphore_test.cc
+++ b/test/boost/reader_concurrency_semaphore_test.cc
@@ -690,7 +690,7 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_stop_waits_on_permits
 } // reader_concurrency_semaphore_test namespace
 
 static void require_can_admit(schema_ptr schema, reader_concurrency_semaphore& semaphore, bool expected_can_admit, const char* description,
-        seastar::compat::source_location sl = seastar::compat::source_location::current()) {
+        std::source_location sl = std::source_location::current()) {
     testlog.trace("Running admission scenario {}, with exepcted_can_admit={}", description, expected_can_admit);
     const auto stats_before = semaphore.get_stats();
 
@@ -727,7 +727,7 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_admission) {
     auto stop_sem = deferred_stop(semaphore);
 
     auto require_can_admit = [&] (bool expected_can_admit, const char* description,
-            seastar::compat::source_location sl = seastar::compat::source_location::current()) {
+            std::source_location sl = std::source_location::current()) {
         ::require_can_admit(schema, semaphore, expected_can_admit, description, sl);
     };
 
@@ -1734,7 +1734,7 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_request_memory_preser
 
     uint64_t reads_enqueued_for_memory = 0;
 
-    auto do_check = [&] (reader_permit& permit, uint64_t need_cpu, uint64_t awaits, seastar::compat::source_location sl) {
+    auto do_check = [&] (reader_permit& permit, uint64_t need_cpu, uint64_t awaits, std::source_location sl) {
         testlog.info("do_check() {}:{}", sl.file_name(), sl.line());
 
         BOOST_REQUIRE_EQUAL(semaphore.get_stats().current_permits, 2);
@@ -1766,14 +1766,14 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_request_memory_preser
     // active
     {
         auto permit = semaphore.obtain_permit(nullptr, get_name(), 1024, db::no_timeout, {}).get();
-        do_check(permit, 0, 0, seastar::compat::source_location::current());
+        do_check(permit, 0, 0, std::source_location::current());
     }
 
     // need_cpu
     {
         auto permit = semaphore.obtain_permit(nullptr, get_name(), 1024, db::no_timeout, {}).get();
         reader_permit::need_cpu_guard ncpu_guard{permit};
-        do_check(permit, 1, 0, seastar::compat::source_location::current());
+        do_check(permit, 1, 0, std::source_location::current());
     }
 
     // awaits
@@ -1781,7 +1781,7 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_request_memory_preser
         auto permit = semaphore.obtain_permit(nullptr, get_name(), 1024, db::no_timeout, {}).get();
         reader_permit::need_cpu_guard ncpu_guard{permit};
         reader_permit::awaits_guard awaits_guard{permit};
-        do_check(permit, 1, 1, seastar::compat::source_location::current());
+        do_check(permit, 1, 1, std::source_location::current());
     }
 }
 
@@ -2226,7 +2226,7 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_live_update_cpu_concu
     auto stop_sem = deferred_stop(semaphore);
 
     auto require_can_admit = [&] (bool expected_can_admit, const char* description,
-            seastar::compat::source_location sl = seastar::compat::source_location::current()) {
+            std::source_location sl = std::source_location::current()) {
         ::require_can_admit(schema, semaphore, expected_can_admit, description, sl);
     };
 

--- a/test/boost/restrictions_test.cc
+++ b/test/boost/restrictions_test.cc
@@ -27,7 +27,7 @@ BOOST_AUTO_TEST_SUITE(restrictions_test)
 
 namespace {
 
-using seastar::compat::source_location;
+using std::source_location;
 
 std::unique_ptr<cql3::query_options> to_options(
         const cql3::cql_config& cfg,
@@ -46,7 +46,7 @@ void require_rows(cql_test_env& e,
                   std::optional<std::vector<std::string_view>> names,
                   const std::vector<bytes_opt>& values,
                   const std::vector<std::vector<bytes_opt>>& expected,
-                  const seastar::compat::source_location& loc = source_location::current()) {
+                  const std::source_location& loc = source_location::current()) {
     // This helps compiler pick the right overload for make_value:
     const auto rvals = values | std::views::transform([] (const bytes_opt& v) { return cql3::raw_value::make_value(v); });
     cql3::cql_config cfg(cql3::cql_config::default_tag{});

--- a/test/boost/secondary_index_test.cc
+++ b/test/boost/secondary_index_test.cc
@@ -1200,7 +1200,7 @@ SEASTAR_TEST_CASE(test_secondary_index_on_partition_key_with_filtering) {
 void assert_select_count_and_select_rows_has_size(
         cql_test_env& e, 
         const sstring& rest_of_query, int64_t expected_count, 
-        const seastar::compat::source_location& loc = seastar::compat::source_location::current()) {
+        const std::source_location& loc = std::source_location::current()) {
     eventually([&] { 
         require_rows(e, "SELECT count(*) " + rest_of_query, {
             { long_type->decompose(expected_count) }

--- a/test/boost/statement_restrictions_test.cc
+++ b/test/boost/statement_restrictions_test.cc
@@ -376,7 +376,7 @@ static bool expression_eq(const expr::expression& e1, const expr::expression& e2
 static void assert_expr_vec_eq(
     const std::vector<expr::expression>& v1,
     const std::vector<expr::expression>& v2,
-    const seastar::compat::source_location& loc = seastar::compat::source_location::current()) {
+    const std::source_location& loc = std::source_location::current()) {
 
     if (std::equal(v1.begin(), v1.end(), v2.begin(), v2.end(), expression_eq)) {
         return;

--- a/test/boost/token_metadata_test.cc
+++ b/test/boost/token_metadata_test.cc
@@ -239,7 +239,7 @@ SEASTAR_THREAD_TEST_CASE(test_endpoints_for_reading_when_bootstrap_with_replicas
 
     auto check_endpoints = [](mutable_static_erm_ptr erm, int64_t t,
         host_id_vector_replica_set expected_replicas,
-        seastar::compat::source_location sl = seastar::compat::source_location::current())
+        std::source_location sl = std::source_location::current())
     {
         BOOST_TEST_INFO("line: " << sl.line());
         const auto expected_set = std::unordered_set<locator::host_id>(expected_replicas.begin(),
@@ -251,7 +251,7 @@ SEASTAR_THREAD_TEST_CASE(test_endpoints_for_reading_when_bootstrap_with_replicas
     };
 
     auto check_no_endpoints = [](mutable_static_erm_ptr erm, int64_t t,
-        seastar::compat::source_location sl = seastar::compat::source_location::current())
+        std::source_location sl = std::source_location::current())
     {
         BOOST_TEST_INFO("line: " << sl.line());
         BOOST_REQUIRE_EQUAL(erm->get_replicas_for_reading(dht::token::from_int64(t)),

--- a/test/lib/cql_assertions.cc
+++ b/test/lib/cql_assertions.cc
@@ -236,7 +236,7 @@ rows_assertions rows_assertions::with_serialized_columns_count(size_t columns_co
 }
 
 shared_ptr<cql_transport::messages::result_message> cquery_nofail(
-        cql_test_env& env, std::string_view query, std::unique_ptr<cql3::query_options>&& qo, const seastar::compat::source_location& loc) {
+        cql_test_env& env, std::string_view query, std::unique_ptr<cql3::query_options>&& qo, const std::source_location& loc) {
     try {
         if (qo) {
             return env.execute_cql(query, std::move(qo)).get();
@@ -253,7 +253,7 @@ shared_ptr<cql_transport::messages::result_message> cquery_nofail(
 void require_rows(cql_test_env& e,
                   std::string_view qstr,
                   const std::vector<std::vector<bytes_opt>>& expected,
-                  const seastar::compat::source_location& loc) {
+                  const std::source_location& loc) {
     try {
         assert_that(cquery_nofail(e, qstr, nullptr, loc)).is_rows().with_rows_ignore_order(expected);
     }
@@ -264,7 +264,7 @@ void require_rows(cql_test_env& e,
 }
 
 void eventually_require_rows(cql_test_env& e, std::string_view qstr, const std::vector<std::vector<bytes_opt>>& expected,
-                             const seastar::compat::source_location& loc) {
+                             const std::source_location& loc) {
     try {
         eventually([&] {
             assert_that(cquery_nofail(e, qstr, nullptr, loc)).is_rows().with_rows_ignore_order(expected);
@@ -279,7 +279,7 @@ void require_rows(cql_test_env& e,
                   cql3::prepared_cache_key_type id,
                   const std::vector<cql3::raw_value>& values,
                   const std::vector<std::vector<bytes_opt>>& expected,
-                  const seastar::compat::source_location& loc) {
+                  const std::source_location& loc) {
     try {
         assert_that(e.execute_prepared(id, values).get()).is_rows().with_rows_ignore_order(expected);
     } catch (const std::exception& e) {

--- a/test/lib/cql_assertions.hh
+++ b/test/lib/cql_assertions.hh
@@ -118,25 +118,25 @@ shared_ptr<cql_transport::messages::result_message> cquery_nofail(
         cql_test_env& env,
         std::string_view query,
         std::unique_ptr<cql3::query_options>&& qo = nullptr,
-        const seastar::compat::source_location& loc = seastar::compat::source_location::current());
+        const std::source_location& loc = std::source_location::current());
 
 /// Asserts that cquery_nofail(e, qstr) contains expected rows, in any order.
 void require_rows(cql_test_env& e,
                   std::string_view qstr,
                   const std::vector<std::vector<bytes_opt>>& expected,
-                  const seastar::compat::source_location& loc = seastar::compat::source_location::current());
+                  const std::source_location& loc = std::source_location::current());
 
 /// Like require_rows, but wraps assertions in \c eventually.
 void eventually_require_rows(
         cql_test_env& e, std::string_view qstr, const std::vector<std::vector<bytes_opt>>& expected,
-        const seastar::compat::source_location& loc = seastar::compat::source_location::current());
+        const std::source_location& loc = std::source_location::current());
 
 /// Asserts that e.execute_prepared(id, values) contains expected rows, in any order.
 void require_rows(cql_test_env& e,
                   cql3::prepared_cache_key_type id,
                   const std::vector<cql3::raw_value>& values,
                   const std::vector<std::vector<bytes_opt>>& expected,
-                  const seastar::compat::source_location& loc = seastar::compat::source_location::current());
+                  const std::source_location& loc = std::source_location::current());
 
 /// Asserts that a cell at the given table.partition.row.column position contains expected data
 future<> require_column_has_value(cql_test_env&, const sstring& table_name,

--- a/test/lib/exception_utils.cc
+++ b/test/lib/exception_utils.cc
@@ -25,7 +25,7 @@ std::function<bool(const std::exception&)> exception_predicate::make(
 
 std::function<bool(const std::exception&)> exception_predicate::message_contains(
         const sstring& fragment,
-        const seastar::compat::source_location& loc) {
+        const std::source_location& loc) {
     return make([=] (const std::exception& e) { return sstring(e.what()).find(fragment) != sstring::npos; },
                 [=] (const std::exception& e) {
                     return fmt::format("Message '{}' doesn't contain '{}'\n{}:{}: invoked here",
@@ -35,7 +35,7 @@ std::function<bool(const std::exception&)> exception_predicate::message_contains
 
 std::function<bool(const std::exception&)> exception_predicate::message_equals(
         const sstring& text,
-        const seastar::compat::source_location& loc) {
+        const std::source_location& loc) {
     return make([=] (const std::exception& e) { return text == e.what(); },
                 [=] (const std::exception& e) {
                     return fmt::format("Message '{}' doesn't equal '{}'\n{}:{}: invoked here",
@@ -45,7 +45,7 @@ std::function<bool(const std::exception&)> exception_predicate::message_equals(
 
 std::function<bool(const std::exception&)> exception_predicate::message_matches(
         const std::string& regex,
-        const seastar::compat::source_location& loc) {
+        const std::source_location& loc) {
     // Use boost::regex since std::regex (with libstdc++ 12) uses too much stack
     return make([=] (const std::exception& e) { return boost::regex_search(e.what(), boost::regex(regex)); },
                 [=] (const std::exception& e) {

--- a/test/lib/exception_utils.hh
+++ b/test/lib/exception_utils.hh
@@ -10,7 +10,6 @@
 
 #include <functional>
 #include <seastar/core/sstring.hh>
-#include <seastar/util/source_location-compat.hh>
 
 #include "seastarx.hh"
 
@@ -25,16 +24,16 @@ extern std::function<bool(const std::exception&)> make(
 /// Returns a predicate that will check if the exception message contains the given fragment.
 extern std::function<bool(const std::exception&)> message_contains(
         const sstring& fragment,
-        const seastar::compat::source_location& loc = seastar::compat::source_location::current());
+        const std::source_location& loc = std::source_location::current());
 
 /// Returns a predicate that will check if the exception message equals the given text.
 extern std::function<bool(const std::exception&)> message_equals(
         const sstring& text,
-        const seastar::compat::source_location& loc = seastar::compat::source_location::current());
+        const std::source_location& loc = std::source_location::current());
 
 /// Returns a predicate that will check if the exception message matches the given regular expression.
 extern std::function<bool(const std::exception&)> message_matches(
         const std::string& regex,
-        const seastar::compat::source_location& loc = seastar::compat::source_location::current());
+        const std::source_location& loc = std::source_location::current());
 
 } // namespace exception_predicate

--- a/test/lib/test_utils.cc
+++ b/test/lib/test_utils.cc
@@ -22,13 +22,13 @@ namespace tests {
 
 namespace {
 
-std::string format_msg(std::string_view test_function_name, bool ok, seastar::compat::source_location sl, std::string_view msg) {
+std::string format_msg(std::string_view test_function_name, bool ok, std::source_location sl, std::string_view msg) {
     return fmt::format("{}(): {} @ {}() {}:{:d}{}{}", test_function_name, ok ? "OK" : "FAIL", sl.function_name(), sl.file_name(), sl.line(), msg.empty() ? "" : ": ", msg);
 }
 
 }
 
-bool do_check(bool condition, seastar::compat::source_location sl, std::string_view msg) {
+bool do_check(bool condition, std::source_location sl, std::string_view msg) {
     if (condition) {
         testlog.trace("{}", format_msg(__FUNCTION__, condition, sl, msg));
     } else {
@@ -37,7 +37,7 @@ bool do_check(bool condition, seastar::compat::source_location sl, std::string_v
     return condition;
 }
 
-void do_require(bool condition, seastar::compat::source_location sl, std::string_view msg) {
+void do_require(bool condition, std::source_location sl, std::string_view msg) {
     if (condition) {
         testlog.trace("{}", format_msg(__FUNCTION__, condition, sl, msg));
     } else {
@@ -48,7 +48,7 @@ void do_require(bool condition, seastar::compat::source_location sl, std::string
 
 }
 
-void fail(std::string_view msg, seastar::compat::source_location sl) {
+void fail(std::string_view msg, std::source_location sl) {
     throw_with_backtrace<std::runtime_error>(format_msg(__FUNCTION__, false, sl, msg));
 }
 

--- a/test/lib/test_utils.hh
+++ b/test/lib/test_utils.hh
@@ -11,7 +11,6 @@
 #include <filesystem>
 
 #include <seastar/core/future.hh>
-#include <seastar/util/source_location-compat.hh>
 #include <string>
 #include <boost/test/unit_test.hpp>
 #include <fmt/core.h>
@@ -32,21 +31,21 @@ namespace tests {
 
 namespace fs = std::filesystem;
 
-[[nodiscard]] bool do_check(bool condition, seastar::compat::source_location sl, std::string_view msg);
+[[nodiscard]] bool do_check(bool condition, std::source_location sl, std::string_view msg);
 
-[[nodiscard]] inline bool check(bool condition, seastar::compat::source_location sl = seastar::compat::source_location::current()) {
+[[nodiscard]] inline bool check(bool condition, std::source_location sl = std::source_location::current()) {
     return do_check(condition, sl, {});
 }
 
 template <typename LHS, typename RHS>
-[[nodiscard]] bool check_equal(const LHS& lhs, const RHS& rhs, seastar::compat::source_location sl = seastar::compat::source_location::current()) {
+[[nodiscard]] bool check_equal(const LHS& lhs, const RHS& rhs, std::source_location sl = std::source_location::current()) {
     const auto condition = (lhs == rhs);
     return do_check(condition, sl, fmt::format("{} {}= {}", lhs, condition ? "=" : "!", rhs));
 }
 
-void do_require(bool condition, seastar::compat::source_location sl, std::string_view msg);
+void do_require(bool condition, std::source_location sl, std::string_view msg);
 
-inline void require(bool condition, seastar::compat::source_location sl = seastar::compat::source_location::current()) {
+inline void require(bool condition, std::source_location sl = std::source_location::current()) {
     do_require(condition, sl, {});
 }
 
@@ -56,42 +55,42 @@ void do_require_relation(
         const RHS& rhs,
         const Compare& relation,
         const char* relation_operator,
-        seastar::compat::source_location sl) {
+        std::source_location sl) {
     const auto condition = relation(lhs, rhs);
     do_require(condition, sl, fmt::format("assertion {} {} {} failed", lhs, relation_operator, rhs));
 }
 
 template <typename LHS, typename RHS>
-void require_less(const LHS& lhs, const RHS& rhs, seastar::compat::source_location sl = seastar::compat::source_location::current()) {
+void require_less(const LHS& lhs, const RHS& rhs, std::source_location sl = std::source_location::current()) {
     do_require_relation(lhs, rhs, std::less<LHS>{}, "<", sl);
 }
 
 template <typename LHS, typename RHS>
-void require_less_equal(const LHS& lhs, const RHS& rhs, seastar::compat::source_location sl = seastar::compat::source_location::current()) {
+void require_less_equal(const LHS& lhs, const RHS& rhs, std::source_location sl = std::source_location::current()) {
     do_require_relation(lhs, rhs, std::less_equal<LHS>{}, "<=", sl);
 }
 
 template <typename LHS, typename RHS>
-void require_equal(const LHS& lhs, const RHS& rhs, seastar::compat::source_location sl = seastar::compat::source_location::current()) {
+void require_equal(const LHS& lhs, const RHS& rhs, std::source_location sl = std::source_location::current()) {
     do_require_relation(lhs, rhs, std::equal_to<LHS>{}, "==", sl);
 }
 
 template <typename LHS, typename RHS>
-void require_not_equal(const LHS& lhs, const RHS& rhs, seastar::compat::source_location sl = seastar::compat::source_location::current()) {
+void require_not_equal(const LHS& lhs, const RHS& rhs, std::source_location sl = std::source_location::current()) {
     do_require_relation(lhs, rhs, std::not_equal_to<LHS>{}, "!=", sl);
 }
 
 template <typename LHS, typename RHS>
-void require_greater_equal(const LHS& lhs, const RHS& rhs, seastar::compat::source_location sl = seastar::compat::source_location::current()) {
+void require_greater_equal(const LHS& lhs, const RHS& rhs, std::source_location sl = std::source_location::current()) {
     do_require_relation(lhs, rhs, std::greater_equal<LHS>{}, ">=", sl);
 }
 
 template <typename LHS, typename RHS>
-void require_greater(const LHS& lhs, const RHS& rhs, seastar::compat::source_location sl = seastar::compat::source_location::current()) {
+void require_greater(const LHS& lhs, const RHS& rhs, std::source_location sl = std::source_location::current()) {
     do_require_relation(lhs, rhs, std::greater<LHS>{}, ">", sl);
 }
 
-void fail(std::string_view msg, seastar::compat::source_location sl = seastar::compat::source_location::current());
+void fail(std::string_view msg, std::source_location sl = std::source_location::current());
 
 std::string getenv_safe(std::string_view name);
 std::string getenv_or_default(std::string_view name, std::string_view def = {});

--- a/tools/json_mutation_stream_parser.cc
+++ b/tools/json_mutation_stream_parser.cc
@@ -555,10 +555,10 @@ private:
         }
         return true;
     }
-    bool unexpected(seastar::compat::source_location sl = seastar::compat::source_location::current()) {
+    bool unexpected(std::source_location sl = std::source_location::current()) {
         return error("unexpected json event {} in state {}", sl.function_name(), stack_to_string());
     }
-    bool unexpected(std::string_view key, seastar::compat::source_location sl = seastar::compat::source_location::current()) {
+    bool unexpected(std::string_view key, std::source_location sl = std::source_location::current()) {
         return error("unexpected json event {}({}) in state {}", sl.function_name(), key, stack_to_string());
     }
 public:


### PR DESCRIPTION
And switch to std::source_location.
Upcoming seastar update will deprecate its compatibility layer.

The patch is

  for f in $(git grep -l 'seastar::compat::source_location'); do
    sed -e 's/seastar::compat::source_location/std::source_location/g' -i $f;
  done

and removal of few header includes.

Picking up upcoming seastar update, no need to backport