### PR TITLE
streaming:: add more logging

### DIFF
--- a/sstables_loader.cc
+++ b/sstables_loader.cc
@@ -612,8 +612,8 @@ future<> sstables_loader::load_new_sstables(sstring ks_name, sstring cf_name,
         throw std::runtime_error("Skipping reshape is not possible when doing load-and-stream");
     }
 
-    llog.info("Loading new SSTables for keyspace={}, table={}, load_and_stream={}, primary_replica_only={}, skip_cleanup={}",
-            ks_name, cf_name, load_and_stream_desc, primary, skip_cleanup);
+    llog.info("Loading new SSTables for keyspace={}, table={}, load_and_stream={}, primary_replica_only={}, skip_cleanup={}, skip_reshape={}, scope={}",
+            ks_name, cf_name, load_and_stream_desc, primary, skip_cleanup, skip_reshape, scope);
     try {
         if (load_and_stream) {
             ::table_id table_id;
@@ -826,7 +826,7 @@ future<tasks::task_id> sstables_loader::download_new_sstables(sstring ks_name, s
     if (!_storage_manager.is_known_endpoint(endpoint)) {
         throw std::invalid_argument(format("endpoint {} not found", endpoint));
     }
-    llog.info("Restore sstables from {}({}) to {}", endpoint, prefix, ks_name);
+    llog.info("Restore sstables from {}({}) to {}.{} using scope={}, primary_replica={}", endpoint, prefix, ks_name, cf_name, scope, primary_replica);
 
     auto task = co_await _task_manager_module->make_and_start_task<download_task_impl>({}, container(), std::move(endpoint), std::move(bucket), std::move(ks_name), std::move(cf_name),
                                                                                        std::move(prefix), std::move(sstables), scope, primary_replica_only(primary_replica));

--- a/sstables_loader.hh
+++ b/sstables_loader.hh
@@ -134,3 +134,21 @@ public:
 
     class download_task_impl;
 };
+
+template <>
+struct fmt::formatter<sstables_loader::stream_scope> : fmt::formatter<string_view> {
+    template <typename FormatContext>
+    auto format(const sstables_loader::stream_scope a, FormatContext& ctx) const {
+        using enum sstables_loader::stream_scope;
+        switch (a) {
+        case all:
+            return formatter<string_view>::format("all", ctx);
+        case dc:
+            return formatter<string_view>::format("dc", ctx);
+        case rack:
+            return formatter<string_view>::format("rack", ctx);
+        case node:
+            return formatter<string_view>::format("node", ctx);
+        }
+    }
+};


### PR DESCRIPTION
Start logging all missed streaming options like `scope`, `primary_replica` and `skip_reshape` flags

Fixes: https://github.com/scylladb/scylladb/issues/27299

Should be backported to 2025.[1,4] for better log readability