### PR TITLE
topology_coordinator: handle seastar::abort_requested_exception alongside raft::request_aborted

### DIFF
--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -2402,6 +2402,8 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
                     throw;
                 } catch (raft::request_aborted&) {
                     throw;
+                } catch (seastar::abort_requested_exception&) {
+                    throw;
                 } catch (...) {
                     rtlogger.error("transition_state::commit_cdc_generation, "
                                     "raft_topology_cmd::command::barrier failed, error {}", std::current_exception());
@@ -2497,6 +2499,8 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
                     throw;
                 } catch (raft::request_aborted&) {
                     throw;
+                } catch (seastar::abort_requested_exception&) {
+                    throw;
                 } catch (...) {
                     rtlogger.error("tablets draining failed with {}. Aborting the topology operation", std::current_exception());
                     _rollback = fmt::format("Failed to drain tablets: {}", std::current_exception());
@@ -2513,6 +2517,8 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
                 } catch (group0_concurrent_modification&) {
                     throw;
                 } catch (raft::request_aborted&) {
+                    throw;
+                } catch (seastar::abort_requested_exception&) {
                     throw;
                 } catch (...) {
                     rtlogger.error("transition_state::write_both_read_old, "
@@ -2562,6 +2568,8 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
                     throw;
                 } catch (raft::request_aborted&) {
                     throw;
+                } catch (seastar::abort_requested_exception&) {
+                    throw;
                 } catch (...) {
                     rtlogger.error("send_raft_topology_cmd(stream_ranges) failed with exception"
                                     " (node state is {}): {}", state, std::current_exception());
@@ -2597,6 +2605,8 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
                 } catch (group0_concurrent_modification&) {
                     throw;
                 } catch (raft::request_aborted&) {
+                    throw;
+                } catch (seastar::abort_requested_exception&) {
                     throw;
                 } catch (...) {
                     rtlogger.error("transition_state::write_both_read_new, "
@@ -2776,6 +2786,8 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
                     throw;
                 } catch (raft::request_aborted&) {
                     throw;
+                } catch (seastar::abort_requested_exception&) {
+                    throw;
                 } catch (...) {
                     rtlogger.error("transition_state::left_token_ring, "
                                     "raft_topology_cmd::command::barrier failed, error {}",
@@ -2842,7 +2854,9 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
                     throw;
                 } catch (raft::request_aborted&) {
                     throw;
-                } catch(...) {
+                } catch (seastar::abort_requested_exception&) {
+                    throw;
+                } catch (...) {
                     rtlogger.warn("failed to run barrier_and_drain during rollback of {} after {} failure: {}",
                             node.id, state, std::current_exception());
                     barrier_failed = true;
@@ -2923,7 +2937,9 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
                             throw;
                         } catch (raft::request_aborted&) {
                             throw;
-                        } catch(...) {
+                        } catch (seastar::abort_requested_exception&) {
+                            throw;
+                        } catch (...) {
                             wait_for_ip_error = std::current_exception();
                             rtlogger.warn("raft_topology_cmd::command::wait_for_ip failed, error {}",
                                 wait_for_ip_error);
@@ -3045,7 +3061,9 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
                     rtbuilder.done();
                 } catch (term_changed_error&) {
                     throw;
-                } catch (raft::request_aborted& e) {
+                } catch (raft::request_aborted&) {
+                    throw;
+                } catch (seastar::abort_requested_exception&) {
                     throw;
                 } catch (...) {
                     rtlogger.error("send_raft_topology_cmd(stream_ranges) failed with exception"
@@ -3194,6 +3212,8 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
             } catch (group0_concurrent_modification&) {
                 throw;
             } catch (raft::request_aborted&) {
+                throw;
+            } catch (seastar::abort_requested_exception&) {
                 throw;
             } catch (...) {
                 // The barrier does its best to ensure no data plane requests are affected
@@ -3753,6 +3773,10 @@ future<> topology_coordinator::fence_previous_coordinator() {
             // If we failed to write because of concurrent modification lets retry
             continue;
         } catch (raft::request_aborted&) {
+            // Abort was requested. Break the loop
+            rtlogger.debug("request to fence previous coordinator was aborted");
+            break;
+        } catch (seastar::abort_requested_exception&) {
             // Abort was requested. Break the loop
             rtlogger.debug("request to fence previous coordinator was aborted");
             break;


### PR DESCRIPTION
In several exception handlers, only `raft::request_aborted` was being caught and rethrown, while `seastar::abort_requested_exception` was falling through to the generic catch(...) block. This caused the exception to be incorrectly treated as a failure that triggers rollback, instead of being recognized as an abort signal.

For example, during tablet draining, the error log showed: "tablets draining failed with seastar::abort_requested_exception (abort requested). Aborting the topology operation"

This change adds `seastar::abort_requested_exception` handling alongside `raft::request_aborted` in all places where it was missing. When rethrown, these exceptions propagate up to the main `run()` loop where `handle_topology_coordinator_error()` recognizes them as normal abort signals and allows the coordinator to exit gracefully without triggering unnecessary rollback operations.

Fixes: scylladb/scylladb#27255

Backport: The problem causes CI issues with older branches, so it will be backported therefore.