### PR TITLE
scripts: refresh-submodules: don't omit last (first) commit

### DIFF
--- a/scripts/refresh-submodules.sh
+++ b/scripts/refresh-submodules.sh
@@ -41,7 +41,7 @@ for ent in "${@:-${submodules[@]}}"; do
     # create a summary using the output format of "git submodule summary"
     SUMMARY="
 * ${submodule} ${head_ref}...${branch_ref} (${count}):
-$(git log --pretty='format: %H %s' --first-parent HEAD..${bump_to} | while IFS= read -r line; do
+$(git log --pretty='tformat: %H %s' --first-parent HEAD..${bump_to} | while IFS= read -r line; do
         SUBJECT=$(echo $line | cut -d' ' -f2-)
         echo "  > ${SUBJECT}"
         if [[ "$SUBJECT" == "Merge "* ]]; then


### PR DESCRIPTION
`git log --format` doesn't add a newline after the last line. This causes `read` to ignore that line, losing the last line (corresponding to the first commit).

Use `git log --tformat` instead, which terminates the last line.

Cosmetic, so no backport.