### PR TITLE
main: replace p11-kit hack for trust paths override with gnutls hack

### DIFF
--- a/dist/debian/debian/scylla-server.install
+++ b/dist/debian/debian/scylla-server.install
@@ -2,7 +2,6 @@ etc/default/scylla-server
 etc/default/scylla-housekeeping
 etc/scylla.d/*.conf
 etc/bash_completion.d/nodetool-completion
-opt/scylladb/share/p11-kit/modules/*
 opt/scylladb/share/doc/scylla/*
 opt/scylladb/share/doc/scylla/licenses/
 usr/lib/systemd/system/*.timer

--- a/dist/redhat/scylla.spec
+++ b/dist/redhat/scylla.spec
@@ -122,7 +122,6 @@ ln -sfT /etc/scylla /var/lib/scylla/conf
 %config(noreplace) %{_sysconfdir}/sysconfig/scylla-housekeeping
 %attr(0755,root,root) %dir %{_sysconfdir}/scylla.d
 %config(noreplace) %{_sysconfdir}/scylla.d/*.conf
-/opt/scylladb/share/p11-kit/modules/*
 /opt/scylladb/share/doc/scylla/*
 %{_unitdir}/scylla-fstrim.service
 %{_unitdir}/scylla-housekeeping-daily.service


### PR DESCRIPTION
p11-kit has hardcoded paths for the trust paths. Of course, each Linux distribution hardcodes those paths differently. As a result, our relocatable gnutls, which uses p11-kit-trust.so to process the trust paths, needs some overrides to select the right paths.

Currently, we use p11_kit_override_system_files(), a p11-kit API intended for testing, but which worked well enough for our purpose, to override the trust module configuration.

Unfortunately, starting (presumably [1]) in gnutls 3.8.11, gnutls changed how it works with p11-kit and our override is now ignored.

This was likely unintentional, but there appears to be a better way: instead of letting gnutls auto-load the trust module from a hacked configuration, we load the modules outselves using gnutls_pkcs11_init(GNUTLS_PKCS11_FLAG_MANUAL) and
gnutls_pkcs11_add_provider(). These appear to be intended for the purpose.

We communicate the paths to the scylla executable using an environment variable. This isn't optimal, but is much easier than adding a command line variable since there are multiple levels of command line parsing due to the subtool mechanism.

With this, we unlock the possibility to upgrade gnutls to newer versions.

[1] https://gitlab.com/gnutls/gnutls/-/commit/aa5f15a872e62e54abe58624ee393e68d1faf689

Marking for backport in branches that use a Fedora 42 toolchain, since it will receive gnutls 3.8.11 soon.