### PR TITLE
test.py: set worksteal distribution

### DIFF
--- a/test.py
+++ b/test.py
@@ -331,6 +331,7 @@ def run_pytest(options: argparse.Namespace) -> tuple[int, list[SimpleNamespace]]
             f'--tmpdir={temp_dir}',
             f'--maxfail={options.max_failures}',
             f'--alluredir={report_dir / f"allure_{HOST_ID}"}',
+            f'--dist=worksteal',
         ])
     if options.verbose:
         args.append('-v')


### PR DESCRIPTION
set **worksteal** [disribution](https://pytest-xdist.readthedocs.io/en/stable/distribution.html) for xdist(new sheduler)
Because now it shows better test distribution than standard **load** in CI, due to a big imbalance(from 1ms to several minutes) in the single test and the whole file duration

Better distribution is observed well in debug mode (about 22min vs about 1h )

worksteal:
<img width="3588" height="1274" alt="image" src="https://github.com/user-attachments/assets/43889a58-a171-4cfc-865f-ca226b22f758" />

load:
<img width="3588" height="1274" alt="image" src="https://github.com/user-attachments/assets/1b759e9e-1411-4ac3-86c6-a51099d03e92" />

