### PR TITLE
db/view/view_building_coordinator: skip work if no view is built

### DIFF
--- a/db/view/view_building_coordinator.cc
+++ b/db/view/view_building_coordinator.cc
@@ -361,6 +361,7 @@ future<> view_building_coordinator::update_views_statuses(const service::group0_
 future<> view_building_coordinator::work_on_view_building(service::group0_guard guard) {
     if (!_vb_sm.building_state.currently_processed_base_table) {
         vbc_logger.debug("No base table is selected, nothing to do.");
+        co_return;
     }
 
     // Acquire unique lock of `_finished_tasks` to ensure each replica has its own entry in it


### PR DESCRIPTION
Even though that `view_building_coordinator::work_on_view_building` has an `if` at the very beginning which checks whether the currently processed base table is set, it only prints a message and continues executing the rest of the function regardless of the result of the check. However, some of the logic in the function assumes that the currently processed base table field is set and tries to access the value of the field. This can lead to the view building coordinator accessing a disengaged optional, which is undefined behavior.

Fix the function by adding the clearly missing `co_await` to the check. A regression test is added which checks that the view building state observer - a different fiber which used to print a weird message due to erroneus view building coordinator behavior - does not print a warning.

Fixes: scylladb/scylladb#27363

Needs to be backported to 2025.4 - it's a relatively serious bug that blocks the release.