### PR TITLE
locator/token_metadata: Remove get_host_id()

### DIFF
--- a/locator/token_metadata.hh
+++ b/locator/token_metadata.hh
@@ -235,9 +235,6 @@ public:
     const topology& get_topology() const;
     void debug_show() const;
 
-    /** Return the unique host ID for an end-point. */
-    host_id get_host_id(inet_address endpoint) const;
-
     /** @return a copy of the endpoint-to-id map for read-only operations */
     std::unordered_set<host_id> get_host_ids() const;
 


### PR DESCRIPTION
The function is declared, but it's not defined or used anywhere.

Backport: not needed. This is a cleanup.