### PR TITLE
test: dtest: audit_test.py: fix audit error log detection

### DIFF
--- a/test/cluster/dtest/audit_test.py
+++ b/test/cluster/dtest/audit_test.py
@@ -25,7 +25,7 @@ from typing import Any, Optional, override
 import pytest
 import requests
 from cassandra import AlreadyExists, AuthenticationFailed, ConsistencyLevel, InvalidRequest, Unauthorized, Unavailable, WriteFailure
-from cassandra.cluster import NoHostAvailable, Session
+from cassandra.cluster import NoHostAvailable, Session, EXEC_PROFILE_DEFAULT
 from cassandra.query import SimpleStatement, named_tuple_factory
 from ccmlib.scylla_node import ScyllaNode, NodeError
 
@@ -1135,6 +1135,14 @@ class TestCQLAudit(AuditTester):
 
             session.execute("DROP TABLE test1")
 
+    def _get_attempt_count(self, session: Session, *, execution_profile=EXEC_PROFILE_DEFAULT, consistency_level: ConsistencyLevel = ConsistencyLevel.ONE) -> int:
+        # dtest env is using FlakyRetryPolicy which has `max_retries` attribute
+        cl_profile = session.execution_profile_clone_update(execution_profile, consistency_level=consistency_level)
+        policy = cl_profile.retry_policy
+        retries = getattr(policy, "max_retries", None)
+        assert retries is not None
+        return 1 + retries
+
     def _test_insert_failure_doesnt_report_success_assign_nodes(self, session: Session = None):
         all_nodes: set[ScyllaNode] = set(self.cluster.nodelist())
         assert len(all_nodes) == 7
@@ -1154,6 +1162,7 @@ class TestCQLAudit(AuditTester):
         for i in range(256):
             stmt = SimpleStatement(f"INSERT INTO ks.test1 (k, v1) VALUES ({i}, 1337)", consistency_level=ConsistencyLevel.THREE)
             session.execute(stmt)
+            attempt_count = self._get_attempt_count(session, consistency_level=ConsistencyLevel.THREE)
 
             token = rows_to_list(session.execute(f"SELECT token(k) FROM ks.test1 WHERE k = {i}"))[0][0]
 
@@ -1168,9 +1177,9 @@ class TestCQLAudit(AuditTester):
                     audit_partition_nodes = [address_to_node[address] for address in audit_nodes]
                     insert_node = address_to_node[insert_node.pop()]
                     kill_node = address_to_node[partitions.pop()]
-                    return audit_partition_nodes, insert_node, kill_node, stmt.query_string
+                    return audit_partition_nodes, insert_node, kill_node, stmt.query_string, attempt_count
 
-        return [], [], None, None
+        return [], [], None, None, None
 
     @pytest.mark.exclude_errors("audit - Unexpected exception when writing log with: node_ip")
     def test_insert_failure_doesnt_report_success(self):
@@ -1192,7 +1201,7 @@ class TestCQLAudit(AuditTester):
             with self.assert_exactly_n_audit_entries_were_added(session, 1):
                 conn.execute(stmt)
 
-        audit_paritition_nodes, insert_node, node_to_stop, query_to_fail = self._test_insert_failure_doesnt_report_success_assign_nodes(session=session)
+        audit_paritition_nodes, insert_node, node_to_stop, query_to_fail, query_fail_count = self._test_insert_failure_doesnt_report_success_assign_nodes(session=session)
 
         # TODO: remove the loop when scylladb#24473 is fixed
         # We call get_host_id only to cache host_id
@@ -1231,8 +1240,8 @@ class TestCQLAudit(AuditTester):
             # If any audit mode is not done yet, continue polling.
             all_modes_done = True
             for mode, rows in rows_dict.items():
-                rows_with_error = list(filter(lambda r: r.error, rows))
-                if len(rows_with_error) == 6:
+                rows_with_error = [row for row in rows if row.error and row.operation == query_to_fail]
+                if len(rows_with_error) == query_fail_count:
                     logger.info(f"audit mode {mode} log updated after {i} iterations ({i / 10}s)")
                     assert rows_with_error[0].error is True
                     assert rows_with_error[0].consistency == "THREE"


### PR DESCRIPTION
`test_insert_failure_doesnt_report_success` test in `test/cluster/dtest/audit_test.py` has an insert statement that is expected to fail. Dtest environment uses `FlakyRetryPolicy`, which has `max_retries = 5`. 1 initial fail and 5 retry fails means we expect 6 error audit logs.

The test failed because `create keyspace ks` failed once, then succeeded on retry. It allowed the test to proceed properly, but the last part of the test that expects exactly 6 failed queries actually had 7.

The goal of this patch is to make sure there are exactly 6 = 1 + `max_retries` failed queries, counting only the query expected to fail. If other queries fail with successful retry, it's fine. If other queries fail without successful retry, the test will fail, as it should in such situations. They are not related to this expected failed insert statement.

Fixes #27322

This test is migrated to scylladb repo starting from branch-2025.3. Backport is not expected to need any manual intervention in the code. Backport to versions 2025.4 and 2025.3.