### PR TITLE
Revert "Merge 'db/config: enable `ms` sstable format by default' from Michał Chojnowski"

### DIFF
--- a/api/api-doc/system.json
+++ b/api/api-doc/system.json
@@ -209,21 +209,6 @@
                "parameters":[]
             }
          ]
-      },
-      {
-         "path":"/system/chosen_sstable_version",
-         "operations":[
-            {
-               "method":"GET",
-               "summary":"Get sstable version currently chosen for use in new sstables",
-               "type":"string",
-               "nickname":"get_chosen_sstable_version",
-               "produces":[
-                  "application/json"
-               ],
-               "parameters":[]
-            }
-         ]
       }
    ]
 }

--- a/api/system.cc
+++ b/api/system.cc
@@ -190,13 +190,6 @@ void set_system(http_context& ctx, routes& r) {
             return make_ready_future<json::json_return_type>(seastar::to_sstring(format));
         });
     });
-
-    hs::get_chosen_sstable_version.set(r, [&ctx] (std::unique_ptr<request> req) {
-        return smp::submit_to(0, [&ctx] {
-            auto format = ctx.db.local().get_user_sstables_manager().get_preferred_sstable_version();
-            return make_ready_future<json::json_return_type>(seastar::to_sstring(format));
-        });
-    });
 }
 
 }

--- a/conf/scylla.yaml
+++ b/conf/scylla.yaml
@@ -399,17 +399,6 @@ commitlog_total_space_in_mb: -1
 #      you can cache more hot rows
 # column_index_size_in_kb: 64
 
-# sstable format version for newly written sstables.
-# Currently allowed values are `me` and `ms`.
-# If not specified in the config, this defaults to `me`.
-#
-# The difference between `me` and `ms` are the data structures used
-# in the primary index.
-# In short, `ms` needs more CPU during sstable writes,
-# but should behave better during reads,
-# although it might behave worse for very long clustering keys.
-sstable_format: ms
-
 # Auto-scaling of the promoted index prevents running out of memory
 # when the promoted index grows too large (due to partitions with many rows
 # vs. too small column_index_size_in_kb).  When the serialized representation

--- a/test/cluster/dtest/bypass_cache_test.py
+++ b/test/cluster/dtest/bypass_cache_test.py
@@ -12,7 +12,7 @@ from collections.abc import Callable
 
 import pytest
 
-from dtest_class import Tester, create_cf, create_ks, get_ip_from_node, chosen_sstable_format
+from dtest_class import Tester, create_cf, create_ks, get_ip_from_node, highest_supported_sstable_format
 from tools.data import create_c1c2_table, insert_c1c2
 from tools.metrics import get_node_metrics
 
@@ -69,7 +69,7 @@ class TestBypassCache(Tester):
             create_c1c2_table(session)
             insert_c1c2(session, n=NUM_OF_QUERY_EXECUTIONS, ks=keyspace_name)
 
-        self.sstable_format = chosen_sstable_format(node1)
+        self.sstable_format = highest_supported_sstable_format(node1)
 
         return session
 
@@ -103,7 +103,7 @@ class TestBypassCache(Tester):
         return metric_errors
 
     def cache_thresh(self):
-        return 300 if not self.tablets else 150
+        return 800 if not self.tablets else 150
 
     def metric_name_for_index_cache_hits(self):
         """

--- a/test/cluster/dtest/ccmlib/scylla_node.py
+++ b/test/cluster/dtest/ccmlib/scylla_node.py
@@ -363,7 +363,6 @@ class ScyllaNode:
             "--commitlog-use-o-dsync": ["0"],
             "--max-networking-io-control-blocks": ["1000"],
             "--unsafe-bypass-fsync": ["1"],
-            "--num-tokens": ["16"],
         }
 
         if self.scylla_mode() == "debug":

--- a/test/cluster/dtest/dtest_class.py
+++ b/test/cluster/dtest/dtest_class.py
@@ -247,9 +247,9 @@ def is_autocompaction_enabled(node, ks_name, table_name):
     response.raise_for_status()
     return response.json()
 
-def chosen_sstable_format(node):
+def highest_supported_sstable_format(node):
     node_ip = get_ip_from_node(node=node)
-    response = requests.get(f"http://{node_ip}:10000/system/chosen_sstable_version")
+    response = requests.get(f"http://{node_ip}:10000/system/highest_supported_sstable_version")
     response.raise_for_status()
     return response.json()
 

--- a/test/cluster/dtest/dtest_setup.py
+++ b/test/cluster/dtest/dtest_setup.py
@@ -505,7 +505,6 @@ class DTestSetup:
             "cas_contention_timeout_in_ms": timeout,
             "request_timeout_in_ms": timeout,
             "num_tokens": None,
-            "sstable_format": "ms",
         }
 
         if self.setup_overrides is not None and self.setup_overrides.cluster_options:

--- a/test/cluster/object_store/test_backup.py
+++ b/test/cluster/object_store/test_backup.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-import glob
 import json
 import os
 import logging
@@ -825,14 +824,13 @@ async def test_backup_broken_streaming(manager: ManagerClient, s3_storage):
                 for file in files:
                     local_path = os.path.join(root, file)
                     print("Processing file:", local_path)
-                    sst_generation = subprocess.check_output(
+                    sst = subprocess.check_output(
                         [scylla_path, "sstable", "write", "--schema-file", schema_file, "--input-format", "json",
-                         "--output-dir", tmp_dir, "--input-file", local_path]).decode().strip()
-                    sst_path = glob.glob(f"{tmp_dir}/??-{sst_generation}-???-TOC.txt")[0]
+                         "--output-dir", tmp_dir, "--input-file", local_path])
                     expected_rows += json.loads(subprocess.check_output(
                         [scylla_path, "sstable", "query", "-q", f"SELECT COUNT(*) FROM scylla_sstable.{table}",
                          "--output-format", "json", "--sstables",
-                         sst_path]).decode())[0]['count']
+                         os.path.join(tmp_dir, f"me-{sst.decode().strip()}-big-TOC.txt")]).decode())[0]['count']
 
             prefix = unique_name('/test/streaming_')
             s3_resource = s3_storage.get_resource()

--- a/test/cqlpy/test_tools.py
+++ b/test/cqlpy/test_tools.py
@@ -471,7 +471,7 @@ def test_scylla_sstable_write_cql_large_input(scylla_path):
         generations = out.strip().split("\n")
         assert len(generations) == math.ceil(total_size / memory_limit)
 
-        sstable_files = glob.glob(os.path.join(tmp_dir, f"??-*-???-Data.db"))
+        sstable_files = glob.glob(os.path.join(tmp_dir, f"me-*-big-Data.db"))
 
         assert(len(sstable_files) == len(generations))
 
@@ -561,7 +561,7 @@ def test_scylla_sstable_write_json(cql, test_keyspace, scylla_path, scylla_data_
 
             subprocess.check_call([scylla_path, "sstable", "write", "--schema-file", schema_file, "--input-format", "json", "--input-file", input_file, "--output-dir", tmp_dir, '--logger-log-level', 'scylla-sstable=trace'])
 
-            sstable_files = glob.glob(os.path.join(tmp_dir, f"??-*-???-Data.db"))
+            sstable_files = glob.glob(os.path.join(tmp_dir, f"me-*-big-Data.db"))
             assert len(sstable_files) == 1
             sstable_file = sstable_files[0]
 
@@ -1615,8 +1615,8 @@ def test_scylla_sstable_format_version(cql, test_keyspace, scylla_data_dir):
             matched = sstable_re.match(stem)
             assert matched is not None, f"unmatched sstable component path: {fn}"
             sstable_version = matched["version"]
-            # "ms" is currently the default sstable format version.
-            assert sstable_version == "ms", f"unexpected sstable format: {sstable_version}"
+            # "me" is currently the default sstable format version.
+            assert sstable_version == "me", f"unexpected sstable format: {sstable_version}"
 
 def test_create_local_key_file(scylla_path):
     with tempfile.TemporaryDirectory() as dir:

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -152,7 +152,6 @@ def make_scylla_conf(mode: str, workdir: pathlib.Path, host_addr: str, seed_addr
         'rf_rack_valid_keyspaces': True,
 
         'alternator_allow_system_table_write': True,
-        'sstable_format': 'ms',
     }
 
 # Seastar options can not be passed through scylla.yaml, use command line

--- a/test/rest_api/test_system.py
+++ b/test/rest_api/test_system.py
@@ -15,11 +15,6 @@ def test_system_highest_sstable_format(rest_api):
     resp.raise_for_status()
     assert resp.json() == "me"
 
-def test_chosen_sstable_format(rest_api):
-    resp = rest_api.send('GET', "system/chosen_sstable_version")
-    resp.raise_for_status()
-    assert resp.json() == "ms"
-
 @pytest.mark.parametrize("params", [
     ("storage_service/compaction_throughput", "value"),
     ("storage_service/stream_throughput", "value")


### PR DESCRIPTION
This reverts commit b0643f89596f3a0238dc140ebc7a77337758af8d, reversing changes made to e8b0f8faa9c881e53734a0adccce005059375e36.

The change forgot to update
sstables_manager::get_highest_supported_format(), which results in /system/highest_supported_sstable_version still returning me, confusing and breaking tests.

Fixes: scylladb/scylla-dtest#6435

Fixes CI problem, no backport