### PR TITLE
test/cluster: fix missing racks in xfailing Alternator test

### DIFF
--- a/test/cluster/test_alternator.py
+++ b/test/cluster/test_alternator.py
@@ -917,7 +917,7 @@ async def test_alternator_concurrent_rmw_same_partition_different_server(manager
        almost immediately, not after a cas_contention_timeout_in_ms timeout
        (1 second).
     """
-    servers = await manager.servers_add(3, config=alternator_config)
+    servers = await manager.servers_add(3, config=alternator_config, auto_rack_dc='dc1')
     alternator = get_alternator(servers[0].ip_addr)
     ips = [server.ip_addr for server in await manager.running_servers()]
     table = alternator.create_table(TableName=unique_table_name(),


### PR DESCRIPTION
Since Alternator is now using tablets by default, it's no longer possible to create an Alternator table on a 3-node cluster with a single rack - you need to have 3 racks to support RF=3.

Most of the multi-node Alternator tests in test/cluster/test_alternator.py were already fixed to use a 3-rack cluster, but one test was missed because it was marked "xfail" so its new failure to create the table was missed. This patch adds the missing 3-rack setup, so the xfailing test returns to failing on the real bug - not on the table creation.