### PR TITLE
vector_search: Fix requests hanging on unreachable nodes

### DIFF
--- a/vector_search/client.cc
+++ b/vector_search/client.cc
@@ -20,6 +20,7 @@
 #include <seastar/core/with_timeout.hh>
 #include <chrono>
 #include <fmt/format.h>
+#include <netinet/tcp.h>
 
 using namespace seastar;
 using namespace std::chrono_literals;
@@ -45,6 +46,8 @@ public:
         socket.set_nodelay(true);
         socket.set_keepalive_parameters(get_keepalive_parameters(timeout()));
         socket.set_keepalive(true);
+        unsigned int timeout_ms = timeout().count();
+        socket.set_sockopt(IPPROTO_TCP, TCP_USER_TIMEOUT, &timeout_ms, sizeof(timeout_ms));
         co_return socket;
     }
 


### PR DESCRIPTION
vector_search: Fix requests hanging on unreachable nodes

When a vector store node becomes unreachable, a client request sent
before the keep-alive timer fires would hang until the CQL query
timeout was reached.

This occurred because the HTTP request writes to the TCP buffer and then
waits for a response. While data is in the buffer, TCP retransmissions
prevent the keep-alive timer from detecting the dead connection.

This patch resolves the issue by setting the `TCP_USER_TIMEOUT` socket
option, which applies an effective timeout to TCP retransmissions,
allowing the connection to fail faster.

Fixes: SCYLLADB-76

Backport to 2025.4 is needed as this issue occurs on this branch.