### PR TITLE
[Backport 2025.4] db/view/view_building_coordinator: skip work if no view is built

### DIFF
--- a/db/view/view_building_coordinator.cc
+++ b/db/view/view_building_coordinator.cc
@@ -363,6 +363,7 @@ future<> view_building_coordinator::update_views_statuses(const service::group0_
 future<> view_building_coordinator::work_on_view_building(service::group0_guard guard) {
     if (!_vb_sm.building_state.currently_processed_base_table) {
         vbc_logger.debug("No base table is selected, nothing to do.");
+        co_return;
     }
 
     // Acquire unique lock of `_finished_tasks` to ensure each replica has its own entry in it

--- a/test/cluster/test_view_building_coordinator.py
+++ b/test/cluster/test_view_building_coordinator.py
@@ -900,3 +900,39 @@ async def test_staging_sstables_with_tablet_merge(manager: ManagerClient):
         # And also fails here because not all staging sstables are processed after tablet merge. (#2)
         await assert_row_count_on_host(cql, new_hosts[0], ks, "mv", 1000)
         await manager.server_start(servers[1].server_id)
+
+
+# Reproduces scylladb/scylladb#27363.
+#
+# The bug in the issue caused the view building coordinator to read the contents
+# of a disengaged optional, causing undefined behavior. This also caused
+# the in-memory state of the view building coordinator's task map to be polluted
+# with a garbage key, which triggered a warning in view_building_state_observer.
+#
+# This would happen when a node becomes up - the view building coordinator
+# is notified in that case so that it can send tasks to a node which was
+# previously down, but it would misbehave in that case if there were no views
+# to be built.
+#
+# We check that the observed bad behavior no longer occurs by checking that
+# the view_building_state_observer no longer prints warnings.
+@pytest.mark.asyncio
+async def test_all_good_on_node_restart(manager: ManagerClient):
+    node_count = 2
+    servers = await manager.servers_add(node_count, cmdline=cmdline_loggers, property_file=[
+        {"dc": "dc1", "rack": "r1"},
+        {"dc": "dc1", "rack": "r2"},
+    ])
+
+    # Just bootstrapping two nodes is sufficient to reproduce the issue -
+    # the first node receives an "up" notification when the other node
+    # finishes bootstrap.
+
+    # This sleep is unfortunate, but without it the check that follows happens
+    # too quickly, before the node has the chance to reload the view build
+    # coordinator state and print the error.
+    await asyncio.sleep(5)
+
+    log = await manager.server_open_log(servers[0].server_id)
+    warnings = await log.grep(expr="view_building_state_observer failed with")
+    assert len(warnings) == 0, f"Found view building state observer warnings: {warnings}"


### PR DESCRIPTION
Even though that `view_building_coordinator::work_on_view_building` has an `if` at the very beginning which checks whether the currently processed base table is set, it only prints a message and continues executing the rest of the function regardless of the result of the check. However, some of the logic in the function assumes that the currently processed base table field is set and tries to access the value of the field. This can lead to the view building coordinator accessing a disengaged optional, which is undefined behavior.

Fix the function by adding the clearly missing `co_await` to the check. A regression test is added which checks that the view building state observer - a different fiber which used to print a weird message due to erroneus view building coordinator behavior - does not print a warning.

Fixes: scylladb/scylladb#27363

(cherry picked from commit 654ac9099b84a790410ab3fc20184026b17125b7)

Parent PR: scylladb/scylladb#27373