### PR TITLE
auth: fix cache::prune_all roles iteration

### DIFF
--- a/auth/cache.cc
+++ b/auth/cache.cc
@@ -100,10 +100,12 @@ future<lw_shared_ptr<cache::role_record>> cache::fetch_role(const role_name_t& r
 }
 
 future<> cache::prune_all() noexcept {
-    for (auto it = _roles.begin(); it != _roles.end(); it++) {
+    for (auto it = _roles.begin(); it != _roles.end(); ) {
         if (it->second->version != _current_version) {
-            _roles.erase(it);
+            _roles.erase(it++);
             co_await coroutine::maybe_yield();
+        } else {
+            ++it;
         }
     }
     co_return;


### PR DESCRIPTION
During b9199e8b2490add2013355049e07426e471d0fed
reivew it was suggested to use standard for loop
but when erasing element it causes increment on
invalid iterator, as role could have been erased
before.

This change brings back original code.

Fixes: https://github.com/scylladb/scylladb/issues/27422
Backport: no, offending commit not released yet