### PR TITLE
index: allow vector indexes without rf_rack_valid_keyspces

### DIFF
--- a/cql3/statements/create_index_statement.cc
+++ b/cql3/statements/create_index_statement.cc
@@ -279,11 +279,15 @@ std::vector<::shared_ptr<index_target>> create_index_statement::validate_while_e
         throw exceptions::invalid_request_exception(format("index names shouldn't be more than {:d} characters long (got \"{}\")", schema::NAME_LENGTH, _index_name.c_str()));
     }
 
-    try {
-        db::view::validate_view_keyspace(db, keyspace());
-    } catch (const std::exception& e) {
-        // The type of the thrown exception is not specified, so we need to wrap it here.
-        throw exceptions::invalid_request_exception(e.what());
+    // Regular secondary indexes require rf-rack-validity.
+    // Custom indexes need to validate this property themselves, if they need it.
+    if (!_properties || !_properties->custom_class) {
+        try {
+            db::view::validate_view_keyspace(db, keyspace());
+        } catch (const std::exception& e) {
+            // The type of the thrown exception is not specified, so we need to wrap it here.
+            throw exceptions::invalid_request_exception(e.what());
+        }
     }
 
     validate_for_local_index(*schema);

--- a/test/cluster/test_vector_store.py
+++ b/test/cluster/test_vector_store.py
@@ -1,0 +1,39 @@
+#
+# Copyright (C) 2025-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+#
+
+import logging
+import pytest
+
+from test.pylib.manager_client import ManagerClient
+
+logger = logging.getLogger(__name__)
+
+
+# Regression test for SCYLLADB-81.
+# 
+# Unlike regular secondary indexes, vector indexes do not use materialized views
+# in their implementation, therefore they do not need the keyspace
+# to be rf-rack-valid in order to function properly.
+# 
+# In this test, we check that creating a vector index without
+# rf_rack_valid_keyspaces being set is possible.
+@pytest.mark.asyncio
+async def test_vector_store_can_be_created_without_rf_rack_valid(manager: ManagerClient):
+    # Explicitly disable the rf_rack_valid_keyspaces option.
+    config = {"rf_rack_valid_keyspaces": False}
+    srv = await manager.server_add(config=config)
+    cql, _ = await manager.get_ready_cql([srv])
+
+    # Explicitly create a keyspace with tablets.
+    await cql.run_async("CREATE KEYSPACE ks WITH replication = "
+                        "{'class': 'NetworkTopologyStrategy', 'replication_factor': 1} "
+                        "AND tablets = {'enabled': true}")
+    
+    await cql.run_async("CREATE TABLE ks.t (pk int PRIMARY KEY, v vector<float, 3>)")
+
+    # Creating a vector store index should succeed.
+    await cql.run_async("CREATE CUSTOM INDEX ON ks.t(v) USING 'vector_index'")
+    


### PR DESCRIPTION
The rf_rack_valid_keyspaces option needs to be turned on in order to allow creating materialized views in tablet keyspaces with numeric RF per DC. This is also necessary for secondary indexes because they use materialized views underneath. However, this option is _not_ necessary for vector store indexes because those use the external vector store service for querying the list of keys to fetch from the main table, they do not create a materialized view. The rf_rack_valid_keyspaces was, by accident, required for vector indexes, too.

Remove the restriction for vector store indexes as it is completely unnecessary.

Fixes: SCYLLADB-81

Should be backported to 2025.4, as the option is mostly relevant to that release.