### PR TITLE
test.py: fail test when timeout reached for boost test

### DIFF
--- a/test/pylib/resource_gather.py
+++ b/test/pylib/resource_gather.py
@@ -109,6 +109,7 @@ class ResourceGather(ABC):
         except subprocess.TimeoutExpired:
             logger.critical(f"Process {args} timed out")
             p.kill()
+            p.communicate()
         except KeyboardInterrupt:
             p.kill()
             raise


### PR DESCRIPTION
There is a bug in current pytest's boost implementation. When timeout reached process will be killed, but it was not correctly propagated, that lead to a false positive result. This will fail the test case when timeout for the process is reached.
This is to prevent issues like this #27237


Small framework change, not worth backporting.