### PR TITLE
Attach names to allocating sections for better debuggability

### DIFF
--- a/db/row_cache.cc
+++ b/db/row_cache.cc
@@ -1287,6 +1287,15 @@ row_cache::row_cache(schema_ptr s, snapshot_source src, cache_tracker& tracker, 
     , _partitions(dht::raw_token_less_comparator{})
     , _underlying(src())
     , _snapshot_source(std::move(src))
+    , _update_section(abstract_formatter([this] (fmt::context& ctx) {
+        fmt::format_to(ctx.out(), "cache.update {}.{}", _schema->ks_name(), _schema->cf_name());
+    }))
+    , _populate_section(abstract_formatter([this] (fmt::context& ctx) {
+        fmt::format_to(ctx.out(), "cache.populate {}.{}", _schema->ks_name(), _schema->cf_name());
+    }))
+    , _read_section(abstract_formatter([this] (fmt::context& ctx) {
+        fmt::format_to(ctx.out(), "cache.read {}.{}", _schema->ks_name(), _schema->cf_name());
+    }))
 {
   try {
     with_allocator(_tracker.allocator(), [this, cont] {

--- a/sstables/index_reader.hh
+++ b/sstables/index_reader.hh
@@ -57,7 +57,10 @@ public:
     index_list indexes;
 
     index_consumer(logalloc::region& r, schema_ptr s)
-        : _s(std::move(s))
+        : _s(s)
+        , _alloc_section(abstract_formatter([s] (fmt::format_context& ctx) {
+            fmt::format_to(ctx.out(), "index_consumer {}.{}", s->ks_name(), s->cf_name());
+        }))
         , _region(r)
     { }
 
@@ -785,6 +788,9 @@ public:
                                                       _sstable->manager().get_cache_tracker().region(),
                                                       _sstable->manager().get_cache_tracker().get_partition_index_cache_stats()))
         , _index_cache(caching ? *_sstable->_index_cache : *_local_index_cache)
+        , _alloc_section(abstract_formatter([sst = _sstable] (fmt::format_context& ctx) {
+            fmt::format_to(ctx.out(), "index_reader {}", sst->get_filename());
+        }))
         , _region(_sstable->manager().get_cache_tracker().region())
         , _use_caching(caching)
         , _single_page_read(single_partition_read) // all entries for a given partition are within a single page

--- a/sstables/mx/bsearch_clustered_cursor.hh
+++ b/sstables/mx/bsearch_clustered_cursor.hh
@@ -284,6 +284,9 @@ public:
         , _clustering_parser(s, permit, _ctr.clustering_column_value_fix_legths(), true)
         , _block_parser(s, permit, _ctr.clustering_column_value_fix_legths())
         , _permit(std::move(permit))
+        , _as(abstract_formatter([s] (fmt::format_context& ctx) {
+            fmt::format_to(ctx.out(), "cached_promoted_index {}.{}", s.ks_name(), s.cf_name());
+        }))
     { }
 
     ~cached_promoted_index() {

--- a/utils/abstract_formatter.hh
+++ b/utils/abstract_formatter.hh
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2025-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+ */
+
+#pragma once
+
+#include <fmt/format.h>
+#include <functional>
+
+/// Type-erased formatter.
+/// Allows passing formattable objects without exposing their types.
+class abstract_formatter {
+    std::function<void(fmt::format_context&)> _formatter;
+public:
+    abstract_formatter() = default;
+
+    template<typename Func>
+    requires std::is_invocable_v<Func, fmt::format_context&>
+    explicit abstract_formatter(Func&& f) : _formatter(std::forward<Func>(f)) {}
+
+    fmt::format_context::iterator format_to(fmt::format_context& ctx) const {
+        if (_formatter) {
+            _formatter(ctx);
+        }
+        return ctx.out();
+    }
+
+    explicit operator bool() const noexcept { return bool(_formatter); }
+};
+
+template <> struct fmt::formatter<abstract_formatter> {
+    constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+
+    auto format(const abstract_formatter& formatter, fmt::format_context& ctx) const {
+        return formatter.format_to(ctx);
+    }
+};

--- a/utils/cached_file.hh
+++ b/utils/cached_file.hh
@@ -461,6 +461,9 @@ public:
         , _metrics(m)
         , _lru(l)
         , _region(reg)
+        , _as(abstract_formatter([this] (fmt::format_context& ctx) {
+            fmt::format_to(ctx.out(), "cached_file {}", _file_name);
+        }))
         , _cache(page_idx_less_comparator())
         , _size(size)
     {

--- a/utils/logalloc.cc
+++ b/utils/logalloc.cc
@@ -2948,10 +2948,10 @@ void allocating_section::on_alloc_failure(logalloc::region& r) {
     r.allocator().invalidate_references();
     if (r.get_tracker().get_impl().segment_pool().allocation_failure_flag()) {
         _lsa_reserve *= 2;
-        llogger.info("LSA allocation failure, increasing reserve in section {} to {} segments; trace: {}", fmt::ptr(this), _lsa_reserve, current_backtrace());
+        llogger.info("LSA allocation failure, increasing reserve in section {} ({}) to {} segments; trace: {}", fmt::ptr(this), _name, _lsa_reserve, current_backtrace());
     } else {
         _std_reserve *= 2;
-        llogger.info("Standard allocator failure, increasing head-room in section {} to {} [B]; trace: {}", fmt::ptr(this), _std_reserve, current_backtrace());
+        llogger.info("Standard allocator failure, increasing head-room in section {} ({}) to {} [B]; trace: {}", fmt::ptr(this), _name, _std_reserve, current_backtrace());
     }
     reserve(r.get_tracker().get_impl());
 }

--- a/utils/logalloc.hh
+++ b/utils/logalloc.hh
@@ -17,6 +17,7 @@
 #include "utils/assert.hh"
 #include "utils/entangled.hh"
 #include "utils/memory_limit_reached.hh"
+#include "utils/abstract_formatter.hh"
 
 namespace logalloc {
 
@@ -442,6 +443,7 @@ class allocating_section {
     size_t _minimum_lsa_emergency_reserve = 0;
     int64_t _remaining_std_bytes_until_decay = s_bytes_per_decay;
     int _remaining_lsa_segments_until_decay = s_segments_per_decay;
+    abstract_formatter _name;
 private:
     struct guard {
         tracker::impl& _tracker;
@@ -453,6 +455,8 @@ private:
     void maybe_decay_reserve() noexcept;
     void on_alloc_failure(logalloc::region&);
 public:
+    allocating_section() = default;
+    explicit allocating_section(abstract_formatter name) : _name(std::move(name)) {}
 
     void set_lsa_reserve(size_t) noexcept;
     void set_std_reserve(size_t) noexcept;


### PR DESCRIPTION
Large reserves in allocating_section can cause stalls. We already log reserve increase, but we don't know which table it belongs to:

  lsa - LSA allocation failure, increasing reserve in section 0x600009f94590 to 128 segments;

Allocating sections used for updating row cache on memtable flush are notoriously problematic. Each table has its own row_cache, so its own allocating_section(s). If we attached table name to those sections, we could identify which table is causing problems. In some issues we suspected system.raft, but we can't be sure.

This patch allows naming allocating_sections for the purpose of identifying them in such log messages. I use abstract_formatter for this purpose to avoid the cost of formatting strings on the hot path (e.g. index_reader). And also to avoid duplicating strings which are already stored elsewhere.

Fixes #25799
