### PR TITLE
test_user_writes_rejection: Disable speculative retries

### DIFF
--- a/test/storage/test_out_of_space_prevention.py
+++ b/test/storage/test_out_of_space_prevention.py
@@ -64,7 +64,7 @@ async def test_user_writes_rejection(manager: ManagerClient, volumes_factory: Ca
             for server in servers:
                 await manager.api.disable_autocompaction(server.ip_addr, ks)
 
-            async with new_test_table(manager, ks, "pk int PRIMARY KEY, t text") as cf:
+            async with new_test_table(manager, ks, "pk int PRIMARY KEY, t text", " WITH speculative_retry = 'NONE'") as cf:
 
                 logger.info("Create a big file on the target node to reach critical disk utilization level")
                 disk_info = psutil.disk_usage(workdir)


### PR DESCRIPTION
This test starts a 3-node cluster and creates a large blob file so that one node reaches critical disk utilization, triggering write rejections on that node. The test then writes data with CL=QUORUM and validates that the data:
- did not reach the critically utilized node
- did reach the remaining two nodes

By default, tables use speculative retries to determine when coordinators may query additional replicas.

Since the validation uses CL=ONE, it is possible that an additional request is sent to satisfy the consistency level. As a result:
- the first check may fail if the additional request is sent to a node that already contains data, making it appear as if data reached the critically utilized node
- the second check may fail if the additional request is sent to the critically utilized node, making it appear as if data did not reach the healthy node

The patch fixes the flakiness by disabling the speculative retries.

Fixes https://github.com/scylladb/scylladb/issues/27212

Backport to 2025.4 is required as the test was introduced then