### PR TITLE
test/scylla_cluster: fix the check that a process failed to start

### DIFF
--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -789,7 +789,7 @@ class ScyllaServer:
 
         while time.time() < self.start_time + self.TOPOLOGY_TIMEOUT and not self.stop_event.is_set():
             assert self.cmd is not None
-            if self.cmd.returncode:
+            if self.cmd.returncode is not None:
                 self.cmd = None
                 if expected_error is not None:
                     with self.log_filename.open("r", encoding="utf-8") as log_file:


### PR DESCRIPTION
If the process is running returncode will be None, otherwise it will have some value (which can be 0 s well) and the current code treats 0 as if the process is still running.

Fixes #27320
