### PR TITLE
test/boost/view_build_test: increase number of retires

### DIFF
--- a/test/boost/view_build_test.cc
+++ b/test/boost/view_build_test.cc
@@ -395,7 +395,7 @@ SEASTAR_TEST_CASE(test_builder_with_concurrent_drop) {
             assert_that(msg).is_rows().is_empty();
             msg = e.execute_cql("select * from system_distributed.view_build_status").get();
             assert_that(msg).is_rows().is_empty();
-        });
+        }, 30);
     });
 }
 


### PR DESCRIPTION
Default number of retires in `eventually()` in `test_builder_with_concurrent_drop` sometimes is not enough to observe changes in system tables on aarch64 builds.

This patch increases the number of retries to 30.

Fixes scylladb/scylladb#27370

No backport needed.