### PR TITLE
Revert "Merge 'Add digests for all sstable components in scylla metadata' from Taras Veretilnyk"

### DIFF
--- a/ent/encryption/encryption.cc
+++ b/ent/encryption/encryption.cc
@@ -816,7 +816,6 @@ public:
     future<data_sink> wrap_sink(const sstables::sstable& sst, sstables::component_type type, data_sink sink) override {
         switch (type) {
         case sstables::component_type::Scylla:
-        case sstables::component_type::TemporaryScylla:
         case sstables::component_type::TemporaryTOC:
         case sstables::component_type::TOC:
             co_return sink;
@@ -845,7 +844,6 @@ public:
                                                          sstables::component_type type,
                                                          data_source src) override {
         switch (type) {
-        case sstables::component_type::TemporaryScylla:
         case sstables::component_type::Scylla:
         case sstables::component_type::TemporaryTOC:
         case sstables::component_type::TOC:

--- a/sstables/component_type.hh
+++ b/sstables/component_type.hh
@@ -27,7 +27,6 @@ enum class component_type {
     TemporaryTOC,
     TemporaryStatistics,
     Scylla,
-    TemporaryScylla,
     Rows,
     Partitions,
     TemporaryHashes,
@@ -77,8 +76,6 @@ struct fmt::formatter<sstables::component_type> : fmt::formatter<string_view> {
             return formatter<string_view>::format("TemporaryStatistics", ctx);
         case Scylla:
             return formatter<string_view>::format("Scylla", ctx);
-        case TemporaryScylla:
-            return formatter<string_view>::format("TemporaryScylla", ctx);
         case Partitions:
             return formatter<string_view>::format("Partitions", ctx);
         case Rows:

--- a/sstables/sstable_version.cc
+++ b/sstables/sstable_version.cc
@@ -44,7 +44,6 @@ sstable_version_constants::component_map_t sstable_version_constants::create_com
         { component_type::Filter, "Filter.db" },
         { component_type::Statistics, "Statistics.db" },
         { component_type::Scylla, "Scylla.db" },
-        { component_type::TemporaryScylla, "Scylla.db.tmp" },
         { component_type::TemporaryTOC, TEMPORARY_TOC_SUFFIX },
         { component_type::TemporaryStatistics, "Statistics.db.tmp" }
     };

--- a/tools/scylla-sstable.cc
+++ b/tools/scylla-sstable.cc
@@ -1356,7 +1356,6 @@ const char* to_string(sstables::scylla_metadata_type t) {
         case sstables::scylla_metadata_type::ExtTimestampStats: return "ext_timestamp_stats";
         case sstables::scylla_metadata_type::SSTableIdentifier: return "sstable_identifier";
         case sstables::scylla_metadata_type::Schema: return "schema";
-        case sstables::scylla_metadata_type::ComponentsDigests: return "components_digests";
     }
     std::abort();
 }
@@ -1413,28 +1412,6 @@ public:
             _writer.EndObject();
         }
         _writer.EndArray();
-    }
-    void operator()(const sstables::components_digests& val) const {
-        _writer.StartObject();
-
-        auto write_digest = [&](std::string_view key, const std::optional<uint32_t>& digest) {
-            if (digest) {
-                _writer.Key(key);
-                _writer.Uint(*digest);
-            }
-        };
-
-        write_digest("data_digest", val.data_digest);
-        write_digest("compression_digest", val.compression_digest);
-        write_digest("filter_digest",val.filter_digest);
-        write_digest("statistics_digest", val.statistics_digest);
-        write_digest("summary_digest", val.summary_digest);
-        write_digest("index_digest", val.index_digest);
-        write_digest("toc_digest", val.toc_digest);
-        write_digest("partitions_digest", val.partitions_digest);
-        write_digest("rows_digest", val.rows_digest);
-
-        _writer.EndObject();
     }
     void operator()(const sstables::sstable_enabled_features& val) const {
         std::pair<sstables::sstable_feature, const char*> all_features[] = {


### PR DESCRIPTION
This reverts commit 866c96f536b03dd3caaa7f314f639669bd155605, reversing changes made to 367633270ad7ca0aafae6ba0042d37b9dbcc2566.

This change caused all longevities to fail, with a crash in parsing scylla-metadata. The investigation is still ongoing, with no quick fix in sight yet.

Fixes: #27496

Only master is affected, no backport needed.