### PR TITLE
test/pylib/suite/python.py: Handle extra_cmdline_options correctly

### DIFF
--- a/test.py
+++ b/test.py
@@ -228,7 +228,7 @@ def parse_cmd_line() -> argparse.Namespace:
     scylla_additional_options = parser.add_argument_group('Additional options for Scylla tests')
     scylla_additional_options.add_argument('--x-log2-compaction-groups', action="store", default="0", type=int,
                              help="Controls number of compaction groups to be used by Scylla tests. Value of 3 implies 8 groups.")
-    scylla_additional_options.add_argument('--extra-scylla-cmdline-options', action="store", default=[], type=str,
+    scylla_additional_options.add_argument('--extra-scylla-cmdline-options', action="store", default="", type=str,
                                            help="Passing extra scylla cmdline options for all tests. Options should be space separated:"
                                                 "'--logger-log-level raft=trace --default-log-level error'")
 
@@ -278,9 +278,6 @@ def parse_cmd_line() -> argparse.Namespace:
 
     args.tmpdir = os.path.abspath(args.tmpdir)
     prepare_dirs(tempdir_base=pathlib.Path(args.tmpdir), modes=args.modes, gather_metrics=args.gather_metrics, save_log_on_success=args.save_log_on_success)
-
-    if args.extra_scylla_cmdline_options:
-        args.extra_scylla_cmdline_options = args.extra_scylla_cmdline_options.split()
 
     return args
 

--- a/test/pylib/runner.py
+++ b/test/pylib/runner.py
@@ -86,7 +86,7 @@ def pytest_addoption(parser: pytest.Parser) -> None:
     parser.addoption("--cluster-pool-size", type=int,
                      help="Set the pool_size for PythonTest and its descendants.  Alternatively environment variable "
                           "CLUSTER_POOL_SIZE can be used to achieve the same")
-    parser.addoption("--extra-scylla-cmdline-options", default=[],
+    parser.addoption("--extra-scylla-cmdline-options", default='',
                      help="Passing extra scylla cmdline options for all tests.  Options should be space separated:"
                           " '--logger-log-level raft=trace --default-log-level error'")
     parser.addoption('--x-log2-compaction-groups', action="store", default="0", type=int,

--- a/test/pylib/suite/python.py
+++ b/test/pylib/suite/python.py
@@ -76,7 +76,7 @@ class PythonTestSuite(TestSuite):
             if type(cmdline_options) == str:
                 cmdline_options = [cmdline_options]
             cmdline_options = merge_cmdline_options(cmdline_options, create_cfg.cmdline_from_test)
-            cmdline_options = merge_cmdline_options(cmdline_options, options.extra_scylla_cmdline_options)
+            cmdline_options = merge_cmdline_options(cmdline_options, options.extra_scylla_cmdline_options.split())
             # There are multiple sources of config options, with increasing priority
             # (if two sources provide the same config option, the higher priority one wins):
             # 1. the defaults


### PR DESCRIPTION
runner.py defines a command-line option `--extra-scylla-cmdline-options` with the default type=str. However, the function `merge_cmdline_options`, which consumes this value to merge command-line options from multiple sources, expects a list of strings.

This mismatch results in the following exception:
```
raise ValueError(f'invalid argument name {name}, all args {args}')
ValueError: invalid argument name o, all args --logger-log-level repair=debug --default-log-level=error
```
when a test is run with pytest using:
`--extra-scylla-cmdline-options='--logger-log-level repair=debug --default-log-level=error'`

Fix this by handling the option consistently and calling `.split()`. Also change the default value from an empty list to an empty string to avoid confusion both in runner.py and test.py.

No need to backport. CI uses test.py and there the problem does not exist.