### PR TITLE
test: Implement JSON format for listing Boost tests

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1695,6 +1695,18 @@ deps['test/vector_search/vector_store_client_test'] =  ['test/vector_search/vect
 deps['test/vector_search/load_balancer_test'] = ['test/vector_search/load_balancer_test.cc'] + scylla_tests_dependencies
 deps['test/vector_search/client_test'] = ['test/vector_search/client_test.cc'] + scylla_tests_dependencies
 
+boost_tests_prefixes = ["test/boost/", "test/vector_search/", "test/raft/", "test/manual/", "test/ldap/"]
+
+# We need to link these files to all Boost tests to make sure that
+# we can execute `--list_json_content` on them. That will produce
+# a similar result as calling `--list_content={HRF,DOT}`.
+# Unfortunately, to be able to do that, we're forced to link the
+# relevant code by hand.
+for key in deps.keys():
+    for prefix in boost_tests_prefixes:
+        if key.startswith(prefix):
+            deps[key] += ["test/lib/boost_tree_lister_injector.cc", "test/lib/boost_test_tree_lister.cc"]
+
 wasm_deps = {}
 
 wasm_deps['wasm/return_input.wat'] = 'test/resource/wasm/rust/return_input.rs'

--- a/test/lib/CMakeLists.txt
+++ b/test/lib/CMakeLists.txt
@@ -1,5 +1,8 @@
 add_library(test-lib STATIC)
 target_sources(test-lib
+  PUBLIC
+    boost_test_tree_lister.cc
+    boost_tree_lister_injector.cc
   PRIVATE
     cql_assertions.cc
     dummy_sharder.cc

--- a/test/lib/boost_test_tree_lister.cc
+++ b/test/lib/boost_test_tree_lister.cc
@@ -1,0 +1,422 @@
+/*
+ * Copyright (C) 2025-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+ */
+
+#include "test/lib/boost_test_tree_lister.hh"
+
+#include <boost/algorithm/string/replace.hpp>
+#include <fmt/ranges.h>
+
+#include <memory>
+#include <ranges>
+
+namespace {
+
+using label_info = internal::label_info;
+
+using test_case_info = internal::test_case_info;
+using test_suite_info = internal::test_suite_info;
+using test_file_info = internal::test_file_info;
+
+} // anonymous namespace
+
+/// --------------------
+///
+/// Implementation notes
+///
+/// --------------------
+///
+/// The structure of the Boost.Test's test tree consists solely
+/// of nodes representing test suites and test cases. It ignores
+/// information like, for instance, the name of the file those
+/// entities reside [1].
+///
+/// What's more, a test suite can span multiple files as long
+/// as it has the same name [2].
+///
+/// We'd like to re-visualize the tree in a different manner:
+/// have a forest, where each tree represents the internal structure
+/// of a specific file. The non-leaf nodes represent test suites,
+/// and the leaves -- test cases.
+///
+/// This type achieves that very goal (albeit in a bit ugly manner).
+///
+/// ---
+///
+/// Note that the implementation suffers from the same problems
+/// Boost.Test itself does. For instance, when parametrizing tests
+/// with `boost::unit_test::data`, the test will appear as a test suite,
+/// while cases for each of the data instances -- as test cases.
+/// There's no way to overcome that, so we're stuck with it.
+///
+/// -----------
+///
+/// Assumptions
+///
+/// -----------
+///
+/// We rely on the following assumptions:
+///
+/// 1. The tree traversal is performed pre-order. That's the case for
+///    Boost.Test 1.89.0.
+/// 2. If a test case TC belong to a test suite TS (directly or indirectly),
+///    the following execution order holds:
+///    i.   `test_suite_start(TC)`,
+///    ii.  `visit(TC)`,
+///    iii. `test_suite_finish(TC)`.
+/// 3. If test suite TS1 is nested within test suite TS2, the following
+///    execution order holds:
+///    i.   `test_suite_start(TS1)`,
+///    ii.  `test_suite_start(TS2)`,
+///    iii. `test_suite_finish(TS2)`,
+///    iv.  `test_suite_finish(TS1)`.
+///
+/// ----------
+///
+/// References
+///
+/// ----------
+///
+/// [1] https://www.boost.org/doc/libs/1_89_0/libs/test/doc/html/boost_test/tests_organization/test_tree.html
+/// [2] https://www.boost.org/doc/libs/1_89_0/libs/test/doc/html/boost_test/tests_organization/test_tree/test_suite.html
+///
+/// ----------------------------
+///
+/// Example of high-level output
+///
+/// ----------------------------
+///
+/// Let's consider the following organization of tests.
+///
+/// TestFile1.cc:
+/// - Suite A:
+///   - Suite A1:
+///     - Test A1.1 (labels: L1)
+///     - Test A1.2
+///   - Suite A2:
+///     - Test A2.1
+///   - Test A.1
+/// - Suite B:
+///   - Test B1
+///   - Test B2 (labels: L2, L3)
+/// - Test 1
+///
+/// TestFile2.cc:
+/// - Suite A:
+///   - Suite A3
+///     - Test A3.1
+///   - Test A.2
+/// - Suite C:
+///   - Test C.1
+/// - Test 2
+///
+/// This structure will be translated into the following JSON (we're
+/// omitting some details to make it cleaner and easier to read):
+///
+/// [
+///   {
+///     "file": "TestFile1.cc",
+///     "content": {
+///       "suites": [
+///         {
+///           "name": "A",
+///           "suites": [
+///             {
+///               "name": "A1",
+///               "suites": [],
+///               "tests": [
+///                 {
+///                   "name": "Test A1.1",
+///                   "labels": "L1"
+///                 },
+///                 {
+///                   "name": "Test A1.2",
+///                   "labels": ""
+///                 }
+///               ]
+///             }
+///           ],
+///           "tests": [
+///             {
+///               "name": "Test1",
+///               "labels": ""
+///             }
+///           ]
+///         },
+///         {
+///           "name": "B",
+///           "suites": [],
+///           "tests": [
+///             {
+///               "name": "Test B1",
+///               "labels": ""
+///             },
+///             {
+///               "name": "Test B2",
+///               "labels": "L2,L3"
+///             },
+///           ]
+///         }
+///       ],
+///       "tests": [
+///         {
+///           "name": "Test 1",
+///           "labels": ""
+///         }
+///       ]
+///     }
+///   },
+///   {
+///     "file": "TestFile2.cc",
+///     "content": {
+///       "suites": [
+///         {
+///           "name": "A",
+///           "suites": [
+///             {
+///               "name": "A3",
+///               "suites": [],
+///               "tests": [
+///                 {
+///                   "name": "Test A3.1",
+///                   "labels": ""
+///                 }
+///               ]
+///             }
+///           ],
+///           "tests": [
+///             {
+///               "name": "Test A.2",
+///               "labels": ""
+///             }
+///           ]
+///         },
+///         {
+///           "name": "C",
+///           "suites": [],
+///           "tests": [
+///             {
+///               "name": "Test C.1",
+///               "labels": ""
+///             }
+///           ]
+///         }
+///       ],
+///       "tests": [
+///         {
+///           "name": "Test 2",
+///           "labels": ""
+///         }
+///       ]
+///     }
+///   }
+/// ]
+///
+/// Note that although Boost.Test treats Suite A in TestFile1.cc
+/// and Suite A in TestFile2.cc as the SAME suite, we consider it
+/// separately for each of the files it resides in.
+struct boost_test_tree_lister::impl {
+public:
+    /// The final result we're building while traversing the test tree.
+    test_file_forest file_forest;
+    /// The path from the root to the current suite.
+    std::vector<std::string> active_suites;
+
+public:
+    void process_test_case(const boost::unit_test::test_case& tc) {
+        const std::string_view filename = {tc.p_file_name.begin(), tc.p_file_name.end()};
+        test_file_info& test_file = get_file_info(filename);
+
+        std::string test_name = tc.p_name;
+        std::vector<label_info> labels = tc.p_labels.get();
+
+        test_case_info test_info {.name = std::move(test_name), .labels = std::move(labels)};
+
+        if (active_suites.empty()) {
+            test_file.free_tests.push_back(std::move(test_info));
+        } else {
+            test_suite_info& suite_info = get_active_suite(filename);
+            suite_info.tests.push_back(std::move(test_info));
+        }
+    }
+
+    bool test_suite_start(const boost::unit_test::test_suite& ts) {
+        // The suite is the master test suite, so let's ignore it
+        // because it doesn't represent any actual test suite.
+        if (ts.p_parent_id == boost::unit_test::INV_TEST_UNIT_ID) {
+            assert(active_suites.empty());
+            return true;
+        }
+
+        std::string suite_name = ts.p_name.value;
+        add_active_suite(std::move(suite_name));
+
+        return true;
+    }
+
+    void test_suite_finish(const boost::unit_test::test_suite& ts) {
+        // The suite is the master test suite, so let's ignore it
+        // because it doesn't represent any actual test suite.
+        if (ts.p_parent_id == boost::unit_test::INV_TEST_UNIT_ID) {
+            assert(active_suites.empty());
+            return;
+        }
+
+        drop_active_suite();
+    }
+
+private:
+    test_file_info& get_file_info(std::string_view filename) {
+        auto& test_files = file_forest.test_files;
+
+        auto it = test_files.find(filename);
+        if (it == test_files.end()) {
+            std::tie(it, std::ignore) = test_files.emplace(filename, std::vector<test_suite_info>{});
+        }
+
+        return it->second;
+    }
+
+    void add_active_suite(std::string suite_name) {
+        active_suites.push_back(std::move(suite_name));
+    }
+
+    void drop_active_suite() {
+        assert(!active_suites.empty());
+        active_suites.pop_back();
+    }
+
+    test_suite_info& get_active_suite(std::string_view filename) {
+        assert(!active_suites.empty());
+
+        test_file_info& file_info = get_file_info(filename);
+        test_suite_info* last = &get_root_suite(file_info, active_suites[0]);
+
+        for (const auto& suite_name : active_suites | std::views::drop(1)) {
+            last = &get_subsuite(*last, suite_name);
+        }
+
+        return *last;
+    }
+
+    test_suite_info& get_root_suite(test_file_info& file_info, std::string_view suite_name) {
+        auto suite_it = std::ranges::find(file_info.suites, suite_name, &test_suite_info::name);
+        if (suite_it != file_info.suites.end()) {
+            return *suite_it;
+        }
+
+        test_suite_info suite_info {.name = std::string(suite_name)};
+        file_info.suites.push_back(std::move(suite_info));
+
+        return *file_info.suites.rbegin();
+    }
+
+    test_suite_info& get_subsuite(test_suite_info& parent, std::string_view suite_name) {
+        auto suite_it = std::ranges::find(parent.subsuites, suite_name, [] (auto&& suite_ptr) -> std::string_view {
+            return suite_ptr->name;
+        });
+
+        if (suite_it != parent.subsuites.end()) {
+            return **suite_it;
+        }
+
+        auto suite = std::make_unique<test_suite_info>(std::string(suite_name));
+        parent.subsuites.push_back(std::move(suite));
+
+        return **parent.subsuites.rbegin();
+    }
+};
+
+boost_test_tree_lister::boost_test_tree_lister() : _impl(std::make_unique<impl>()) {}
+boost_test_tree_lister::~boost_test_tree_lister() noexcept = default;
+
+const test_file_forest& boost_test_tree_lister::get_result() const {
+    return _impl->file_forest;
+}
+
+void boost_test_tree_lister::visit(const boost::unit_test::test_case& tc) {
+    return _impl->process_test_case(tc);
+}
+
+bool boost_test_tree_lister::test_suite_start(const boost::unit_test::test_suite& ts) {
+    return _impl->test_suite_start(ts);
+}
+
+void boost_test_tree_lister::test_suite_finish(const boost::unit_test::test_suite& ts) {
+    return _impl->test_suite_finish(ts);
+}
+
+// Replace every occurrenace of a double quotation mark (`"`) with a string `\"`.
+static std::string escape_quotation_marks(std::string_view str) {
+    const std::size_t double_quotation_count = std::ranges::count(str, '"');
+    std::string result(str.size() + double_quotation_count, '\\');
+
+    std::size_t offset = 0;
+    for (std::size_t i = 0; i < str.size(); ++i) {
+        if (str[i] == '"') {
+            result[i + offset] = '\\';
+            ++offset;
+        }
+        result[i + offset] = str[i];
+    }
+
+    return result;
+}
+
+auto fmt::formatter<internal::test_case_info>::format(
+        const internal::test_case_info& test_info,
+        fmt::format_context& ctx) const -> decltype(ctx.out())
+{
+    // Sanity check. The names of tests are expected to comprise only of alphanumeric characters.
+    assert(std::ranges::count(test_info.name, '"') == 0);
+    auto label_range = test_info.labels | std::views::transform(escape_quotation_marks);
+
+    return fmt::format_to(ctx.out(), R"({{"name":"{}","labels":"{}"}})",
+            test_info.name, fmt::join(label_range, ","));
+}
+
+auto fmt::formatter<internal::test_suite_info>::format(
+        const internal::test_suite_info& suite_info,
+        fmt::format_context& ctx) const -> decltype(ctx.out())
+{
+    auto actual_suite_range = suite_info.subsuites | std::views::transform([] (auto&& ptr) -> const test_suite_info& {
+        return *ptr;
+    });
+    auto suite_range = fmt::join(actual_suite_range, ",");
+    auto test_range = fmt::join(suite_info.tests, ",");
+    return fmt::format_to(ctx.out(), R"({{"name":"{}","suites":[{}],"tests":[{}]}})",
+            suite_info.name, std::move(suite_range), std::move(test_range));
+}
+
+auto fmt::formatter<internal::test_file_info>::format(
+        const internal::test_file_info& file_info,
+        fmt::format_context& ctx) const -> decltype(ctx.out())
+{
+    auto suite_range = fmt::join(file_info.suites, ",");
+    auto test_range = fmt::join(file_info.free_tests, ",");
+    return fmt::format_to(ctx.out(), R"({{"suites":[{}],"tests":[{}]}})",
+            std::move(suite_range), std::move(test_range));
+}
+
+auto fmt::formatter<internal::test_file_forest>::format(
+        const internal::test_file_forest& forest_info,
+        fmt::format_context& ctx) const -> decltype(ctx.out())
+{
+    std::size_t files_left = forest_info.test_files.size();
+
+    fmt::format_to(ctx.out(), "[");
+    for (const auto& [file, content] : forest_info.test_files) {
+        fmt::format_to(ctx.out(), R"({{"file":"{}","content":{}}})",
+                file, content);
+        if (files_left > 1) {
+            fmt::format_to(ctx.out(), ",");
+        }
+        --files_left;
+
+    }
+    return fmt::format_to(ctx.out(), "]");
+}

--- a/test/lib/boost_test_tree_lister.hh
+++ b/test/lib/boost_test_tree_lister.hh
@@ -1,0 +1,117 @@
+/*
+ * Copyright (C) 2025-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+ */
+
+#pragma once
+
+#include <boost/test/tree/visitor.hpp>
+
+#include <fmt/base.h>
+
+#include <memory>
+
+namespace internal {
+
+using label_info = std::string;
+
+/// Type representing a single Boost test case.
+struct test_case_info {
+    /// The name of the test case.
+    std::string name;
+    /// The labels the test was marked with.
+    std::vector<label_info> labels;
+};
+
+/// Type representing a single Boost test suite within a single file.
+///
+/// Note that a single suite can span multiple files (as of Boost.Test 1.89.0); see:
+/// https://www.boost.org/doc/libs/1_89_0/libs/test/doc/html/boost_test/tests_organization/test_tree/test_suite.html.
+///
+/// We turn away from that convention and list suites from different files separately.
+/// However, that doesn't change the fact that it's still the same suite from the
+/// perspective of Boost.Test. In particular, if a suite is marked with a label,
+/// it's applied to it globally.
+struct test_suite_info {
+    std::string name;
+    std::vector<std::unique_ptr<test_suite_info>> subsuites;
+    /// The tests belonging directly to this suite.
+    std::vector<test_case_info> tests;
+};
+
+struct test_file_info {
+    std::vector<test_suite_info> suites;
+    std::vector<test_case_info> free_tests;
+};
+
+struct test_file_forest {
+    std::map<std::string, test_file_info, std::less<>> test_files;
+};
+
+} // namespace internal
+
+using test_file_forest = internal::test_file_forest;
+
+/// Implementation of the `boost::unit_test::test_tree_visitor` that
+/// produces a similar result to running a Boost.Test executable with
+/// `--list_content=HRF` or `--list_content=DOT`. This type results
+/// in the JSON format of the output.
+///
+/// The crucial difference between this implementation and the built-in
+/// HRF and DOT ones is that the result obtained by a call to `get_result()`
+/// (after the traversal has finished) is going to have a different structure.
+///
+/// The type `boost_test_tree_lister` will treat the same suite from different
+/// files as separate ones, even if they share the name. Boost.Test would treat
+/// them as the same one and group the results by suites. In other words,
+/// this type groups results by (in order):
+///
+/// 1. File
+/// 2. Suite(s)
+/// 3. Test cases
+class boost_test_tree_lister : public boost::unit_test::test_tree_visitor {
+private:
+    struct impl;
+
+private:
+    std::unique_ptr<impl> _impl;
+
+public:
+    boost_test_tree_lister();
+    ~boost_test_tree_lister() noexcept;
+
+public:
+    const test_file_forest& get_result() const;
+
+private:
+    virtual void visit(const boost::unit_test::test_case&) override;
+    virtual bool test_suite_start(const boost::unit_test::test_suite&) override;
+    virtual void test_suite_finish(const boost::unit_test::test_suite&) override;
+};
+
+template <>
+struct fmt::formatter<internal::test_case_info> {
+    constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+    auto format(const internal::test_case_info&, fmt::format_context& ctx) const -> decltype(ctx.out());
+};
+
+template <>
+struct fmt::formatter<internal::test_suite_info> {
+    constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+    auto format(const internal::test_suite_info&, fmt::format_context& ctx) const -> decltype(ctx.out());
+};
+
+template <>
+struct fmt::formatter<internal::test_file_info> {
+    constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+    auto format(const internal::test_file_info&, fmt::format_context& ctx) const -> decltype(ctx.out());
+};
+
+template <>
+struct fmt::formatter<internal::test_file_forest> {
+    constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+    auto format(const internal::test_file_forest&, fmt::format_context& ctx) const -> decltype(ctx.out());
+};

--- a/test/lib/boost_tree_lister_injector.cc
+++ b/test/lib/boost_tree_lister_injector.cc
@@ -1,0 +1,115 @@
+/*
+ * Copyright (C) 2025-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+ */
+
+#include "test/lib/boost_test_tree_lister.hh"
+
+#include <boost/test/framework.hpp>
+#include <boost/test/tree/traverse.hpp>
+#include <boost/test/unit_test_suite.hpp>
+
+#include <fmt/core.h>
+
+namespace {
+
+/// Traverse the test tree and collect information about
+/// its structure and the tests.
+///
+/// The output is going to be in the JSON format.
+/// For more details, see the implementation of
+/// `boost_test_tree_lister`.
+void print_boost_tests() {
+    namespace but = boost::unit_test;
+
+    but::framework::finalize_setup_phase();
+
+    boost_test_tree_lister traverser;
+    but::traverse_test_tree(but::framework::master_test_suite().p_id, traverser, true);
+
+    fmt::print("{}", traverser.get_result());
+}
+
+/// --------
+/// Examples
+/// --------
+///
+/// # This will NOT list the tests because Boost.Test
+/// # will interpret it as an argument to the framework.
+/// $ ./path/to/my/test/exec --list_json_content
+///
+/// # This will NOT list the tests because Boost.Test requires
+/// # that all non-Boost.Test arguments be provided AFTER
+/// # a `--` sequence (cf. example below).
+/// $ ./path/to/my/test/exec list_json_content
+///
+/// # This will NOT list the tests because Boost.Test because
+/// # the option simply doesn't match the exepected one.
+/// $ ./path/to/my/test/exec list_json_content
+///
+/// # This DOES work and DOES what we expect, i.e. it lists the tests.
+/// $ ./path/to/my/test/exec -- --list_json_content
+bool list_tests(int argc, char** argv) {
+    for (int i = 1; i < argc; ++i) {
+        std::string_view option = argv[i];
+        if (option == "--list_json_content") {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+struct boost_tree_lister_injector {
+    boost_tree_lister_injector() {
+        const auto& master_suite = boost::unit_test::framework::master_test_suite();
+        /// The arguments here don't include Boost.Test-specific arguments.
+        /// Those present correspond to the path to the binary and options
+        /// specified for the "end-code".
+        ///
+        /// --------
+        /// Examples
+        /// --------
+        /// $ ./path/to/my/test/exec my_custom_arg
+        /// Arguments: [<path>, "my_custom_arg"]
+        ///
+        /// $ ./path/to/my/test/exec -- my_custom_arg
+        /// Arguments: [<path>, "my_custom_arg"]
+        ///
+        /// $ ./path/to/my/test/exec --auto_start_dbg=0 -- my_custom_arg
+        /// Arguments: [<path>, "my_custom_arg"]
+        ///
+        /// $ ./path/to/my/test/exec --auto_start_dbg=0 my_custom_arg
+        /// Arguments: [<path>, "my_custom_arg"]
+        ///
+        /// ------------------------------------------
+        /// Interaction with some Boost.Test arguments
+        /// ------------------------------------------
+        ///
+        /// Note, however, that some Boost.Test options may prevent us
+        /// from accessing this code. For instance, if the user runs
+        ///
+        /// $ ./path/to/my/test/exec --list_content -- my_custom_arg
+        ///
+        /// then Boost.Test will immediately move to its own code and not
+        /// execute this one (because it's only called by a global fixture).
+        auto&& [argc, argv] = std::make_pair(master_suite.argc, master_suite.argv);
+
+        if (list_tests(argc, argv)) {
+            print_boost_tests();
+
+            // At this point, it's impossible to prevent Boost.Test
+            // from executing the tests it collected. This is all
+            // we can do (at least without writing a lot more code.
+            // I don't know if it would still be possible to avoid it).
+            std::exit(0);
+        }
+    }
+};
+
+} // anonymous namespace
+
+BOOST_GLOBAL_FIXTURE(boost_tree_lister_injector);


### PR DESCRIPTION
The Boost.Test framework offers a way to describe tests written in it
by running them with the option `--list_content`. It can be
parametrized by either HRF (Human Readable Format) or DOT (the Graphviz
graph format) [1]. Thanks to that, we can learn the test tree structure
and collect additional information about the tests (e.g. labels [2]).

We currently emply that feature of the framework to collect and run
Boost tests in Scylla. Unfortunately, both formats have their
shortcomings:

* HRF: the format is simple to parse, but it doesn't contain all
       relevant information, e.g. labels.
* DOT: the format is designed for creating graphical visualizations,
       and it's relatively difficult to parse.

To amend those problems, we implement a custom extension of the feature.
It produces output in the JSON format and contains more than the most
basic information about the tests; at the same time, it's easy to browse
and parse.

To obtain that output, the user needs to call a Boost.Test executable
with the option `--list_json_content`. For example:

```
$ ./path/to/test/exec -- --list_json_content
```

Note that the argument should be prepended with a `--` to indicate that
it targets user code, not Boost.Test itself.

---

The structure of the new format looks like this (top-level downwards):

- File name
- Test suite(s) & free test cases
- Test cases wrapped in test suites

Note that it's different from the output the default Boost.Test formats
produce: they organize information within test suites, which can
potentially span multiple files [3]. The JSON format makes test files
the primary object of interest and test suites from different files
are always considered distinct.

Example of the output (after applying some formatting):

```
$ ./build/dev/test/boost/canonical_mutation_test -- --list_json_content
[{"file":"test/boost/canonical_mutation_test.cc", "content": {
  "suites": [],
  "tests": [
    {"name": "test_conversion_back_and_forth", "labels": ""},
    {"name": "test_reading_with_different_schemas", "labels": ""}
  ]
}}]
```

---

The implementation may be seen as a bit ugly, and it's effectively
a hack. It's based on registering a global fixture [4] and linking
that code to every Boost.Test executable.

Unfortunately, there doesn't seem to be any better way. That would
require more extensive changes in the test files (e.g. enforcing
going through the same entry point in all of them).

This implementation is a compromise between simplicity and
effectiveness. The changes are kept minimal, while the developers
writing new tests shouldn't need to remember to do anything special.
Everything should work out of the box (at least as long as there's
no non-trivial linking involved).

Fixes scylladb/scylladb#25415

---

References:
[1] https://www.boost.org/doc/libs/1_89_0/libs/test/doc/html/boost_test/utf_reference/rt_param_reference/list_content.html
[2] https://www.boost.org/doc/libs/1_89_0/libs/test/doc/html/boost_test/tests_organization/tests_grouping.html
[3] https://www.boost.org/doc/libs/1_89_0/libs/test/doc/html/boost_test/tests_organization/test_tree/test_suite.html
[4] https://www.boost.org/doc/libs/1_89_0/libs/test/doc/html/boost_test/tests_organization/fixtures/global.html

Backport: not necessary. This is an enhancement.