### PR TITLE
utils: error_injection: wait_for_message: print injection_name and caller source_location on timeout

### DIFF
--- a/utils/error_injection.hh
+++ b/utils/error_injection.hh
@@ -204,7 +204,7 @@ public:
 
     public:
         template <typename Clock, typename Duration>
-        future<> wait_for_message(std::chrono::time_point<Clock, Duration> timeout, abort_source* as = nullptr) {
+        future<> wait_for_message(std::chrono::time_point<Clock, Duration> timeout, abort_source* as = nullptr, std::source_location loc = std::source_location::current()) {
             if (!_shared_data) {
                 on_internal_error(errinj_logger, "injection_shared_data is not initialized");
             }
@@ -234,7 +234,8 @@ public:
                 throw;
             }
             catch (const std::exception& e) {
-                on_internal_error(errinj_logger, "Error injection wait_for_message timeout: " + std::string(e.what()));
+                on_internal_error(errinj_logger, fmt::format("Error injection [{}] wait_for_message timeout: Called from `{}` @ {}:{}:{:d}: {}",
+                        _shared_data->injection_name, loc.function_name(), loc.file_name(), loc.line(), loc.column(), e.what()));
             }
             ++_read_messages_counter;
         }


### PR DESCRIPTION
When waiting for the condition variable times out
we call on_internal_error, but unfortunately, the backtrace it generates is obfuscated by
`coroutine_handle<seastar::internal::coroutine_traits_base<void>::promise_type>::resume`.

To make the log more useful, print the error injection name
and the caller's source_location in the timeout error message.

Fixes #27531

* Backport to all live releases to improve debuggability.  Change does not impact production.
