### PR TITLE
service/storage_service: update service levels cache after upgrade to v2

### DIFF
--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -739,6 +739,7 @@ future<> storage_service::topology_state_load(state_change_hint hint) {
         co_await _sl_controller.invoke_on_all([this] (qos::service_level_controller& sl_controller) {
             sl_controller.upgrade_to_v2(_qp, _group0->client());
         });
+        co_await _sl_controller.local().update_cache(qos::update_both_cache_levels::yes, qos::query_context::group0);
     }
 
     // the view_builder is migrated to v2 in view_builder::migrate_to_v2.


### PR DESCRIPTION
Service levels cache is empty after upgrade to consistent topology
if no mutations are commited to `system.service_levels_v2` or rolling
restart is not done.

To fix the bug, this patch adds service levels cache reloading after
upgrading the SL data accessor to v2 in `storage_service::topology_state_load()`.

Fixes [SCYLLADB-90](https://scylladb.atlassian.net/browse/SCYLLADB-90)

This fix should be backported to all versions containing service levels on Raft.

[SCYLLADB-90]: https://scylladb.atlassian.net/browse/SCYLLADB-90?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ