### PR TITLE
test: test_refresh: add test_refresh_deletes_uploaded_sstables

### DIFF
--- a/test/cluster/test_refresh.py
+++ b/test/cluster/test_refresh.py
@@ -14,11 +14,12 @@ import time
 import random
 import shutil
 import uuid
+from collections import defaultdict
 
 from test.pylib.minio_server import MinioServer
 from test.pylib.manager_client import ManagerClient
 from test.cluster.object_store.conftest import format_tuples
-from test.cluster.object_store.test_backup import topo, create_cluster, take_snapshot, create_dataset, compute_scope, check_data_is_back
+from test.cluster.object_store.test_backup import topo, create_cluster, take_snapshot, create_dataset, compute_scope, check_data_is_back, check_mutation_replicas
 from test.cluster.util import wait_for_cql_and_get_hosts
 from test.pylib.rest_client import read_barrier
 from test.pylib.util import unique_name
@@ -111,3 +112,76 @@ async def test_refresh_with_streaming_scopes(manager: ManagerClient, topology_rf
 
     shutil.rmtree(tmpbackup)
 
+async def test_refresh_deletes_uploaded_sstables(manager: ManagerClient):
+    '''
+    Check that refreshing a cluster deletes the sstable files from the upload directory after loading
+    '''
+
+    topology = topo(rf = 1, nodes = 2, racks = 1, dcs = 1)
+
+    servers, host_ids = await create_cluster(topology, True, manager, logger)
+
+    cql = manager.get_cql()
+
+    await manager.api.disable_tablet_balancing(servers[0].ip_addr)
+
+    ks = 'ks'
+    cf = 'cf'
+    _, keys, _ = create_dataset(manager, ks, cf, topology, logger)
+
+    _, sstables = await take_snapshot(ks, servers, manager, logger)
+
+    dirs = defaultdict(dict)
+
+    logger.info(f'Move sstables to tmp dir')
+    tmpdir = f'tmpbackup-{str(uuid.uuid4())}'
+    for s in servers:
+        workdir = await manager.server_get_workdir(s.server_id)
+        cf_dir = os.listdir(f'{workdir}/data/{ks}')[0]
+        cf_dir = os.path.join(f'{workdir}/data/{ks}', cf_dir)
+        tmpbackup = os.path.join(workdir, f'../{tmpdir}')
+        dirs[s.server_id]["workdir"] = workdir
+        dirs[s.server_id]["cf_dir"] = cf_dir
+        dirs[s.server_id]["tmpbackup"] = tmpbackup
+        os.makedirs(tmpbackup, exist_ok=True)
+
+        snapshots_dir = os.path.join(cf_dir, 'snapshots')
+        snapshots_dir = os.path.join(snapshots_dir, os.listdir(snapshots_dir)[0])
+        exclude_list = ['manifest.json', 'schema.cql']
+
+        for item in os.listdir(snapshots_dir):
+            src_path = os.path.join(snapshots_dir, item)
+            dst_path = os.path.join(tmpbackup, item)
+            if item not in exclude_list:
+                shutil.copy2(src_path, dst_path)
+
+    logger.info(f'Clear data by truncating')
+    cql.execute(f'TRUNCATE TABLE {ks}.{cf};')
+
+    logger.info(f'Copy sstables to upload dir (with shuffling)')
+    shuffled = list(range(len(servers)))
+    random.shuffle(shuffled)
+    for i, s in enumerate(servers):
+        other = servers[shuffled[i]]
+        cf_dir = dirs[other.server_id]["cf_dir"]
+        tmpbackup = dirs[s.server_id]["tmpbackup"]
+        shutil.copytree(tmpbackup, os.path.join(cf_dir, 'upload'), dirs_exist_ok=True)
+
+    logger.info(f'Refresh')
+    async def do_refresh(s, toc_names, scope):
+        logger.info(f'Refresh {s.ip_addr} with {toc_names}, scope={scope}')
+        await manager.api.load_new_sstables(s.ip_addr, ks, cf, scope=scope, load_and_stream=True)
+
+    scope = 'rack'
+    r_servers = servers
+
+    await asyncio.gather(*(do_refresh(s, sstables, scope) for s in r_servers))
+
+    await check_mutation_replicas(cql, manager, servers, keys, topology, logger, ks, cf)
+
+    for s in r_servers:
+        cf_dir = dirs[s.server_id]["cf_dir"]
+        files = os.listdir(os.path.join(cf_dir, 'upload'))
+        assert files == [], f'Upload dir not empty on server {s.server_id}: {files}'
+
+    shutil.rmtree(tmpbackup)


### PR DESCRIPTION
The refresh api is expected to automatically delete the sstable files from the uploads/ dir.  Verify that.

The code that does that is currently called by
sstables_loader::load_new_sstables:
```c++
        if (load_and_stream) {
...
                co_await loader.load_and_stream(ks_name, cf_name, table_id, std::move(sstables_on_shards[this_shard_id()]), primary_replica_only(primary), true /* unlink */, scope, {});
```

* no backport required