### PR TITLE
alternator: require rf_rack_valid_keyspaces when creating index

### DIFF
--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -1799,6 +1799,11 @@ static future<executor::request_return_type> create_table_on_shard0(service::cli
                 }
             }
         }
+        // Creating an index in tablets mode requires the rf_rack_valid_keyspaces option to be enabled.
+        // GSI and LSI indexes are based on materialized views which require this option to avoid consistency issues.
+        if (!view_builders.empty() && ksm->uses_tablets() && !sp.data_dictionary().get_config().rf_rack_valid_keyspaces()) {
+            co_return api_error::validation("GlobalSecondaryIndexes and LocalSecondaryIndexes with tablets require the rf_rack_valid_keyspaces option to be enabled.");
+        }
         try {
             schema_mutations = service::prepare_new_keyspace_announcement(sp.local_db(), ksm, ts);
         } catch (exceptions::already_exists_exception&) {
@@ -2018,6 +2023,10 @@ future<executor::request_return_type> executor::update_table(client_state& clien
                         if (p.local().data_dictionary().has_schema(keyspace_name, lsi_name(table_name, index_name, false))) {
                             co_return api_error::validation(fmt::format(
                                 "LSI {} already exists in table {}, can't use same name for GSI", index_name, table_name));
+                        }
+                        if (p.local().local_db().find_keyspace(keyspace_name).get_replication_strategy().uses_tablets() &&
+                                !p.local().data_dictionary().get_config().rf_rack_valid_keyspaces()) {
+                            co_return api_error::validation("GlobalSecondaryIndexes with tablets require the rf_rack_valid_keyspaces option to be enabled.");
                         }
 
                         elogger.trace("Adding GSI {}", index_name);

--- a/test/cluster/test_alternator.py
+++ b/test/cluster/test_alternator.py
@@ -570,6 +570,90 @@ async def test_alternator_enforce_authorization_true(manager: ManagerClient):
     # We could further test how GRANT works, but this would be unnecessary
     # repeating of the tests in test/alternator/test_cql_rbac.py.
 
+@pytest.mark.asyncio
+async def test_index_requires_rf_rack_valid(manager: ManagerClient):
+    """
+    Verify that creating a table with GSI or LSI fails with an appropriate error if
+    it's tablets based and rf_rack_valid_keyspaces is disabled.
+    Adding a GSI to an existing table with tablets should fail as well.
+    """
+    servers = await manager.servers_add(1, config=alternator_config | {"rf_rack_valid_keyspaces": False})
+    alternator = get_alternator(servers[0].ip_addr)
+
+    expected_err_create = "GlobalSecondaryIndexes and LocalSecondaryIndexes with tablets require the rf_rack_valid_keyspaces option to be enabled."
+    expected_err_update_add_gsi = "GlobalSecondaryIndexes with tablets require the rf_rack_valid_keyspaces option to be enabled."
+
+    def create_table_with_index(alternator, table_name, index_type, initial_tablets):
+        create_table_args = dict(
+            TableName=table_name,
+            BillingMode='PAY_PER_REQUEST',
+            Tags=[{'Key': 'system:initial_tablets', 'Value': initial_tablets}],
+            KeySchema=[
+                {'AttributeName': 'p', 'KeyType': 'HASH'},
+                {'AttributeName': 'c', 'KeyType': 'RANGE'}
+            ],
+            AttributeDefinitions=[
+                {'AttributeName': 'p', 'AttributeType': 'S'},
+                {'AttributeName': 'c', 'AttributeType': 'S'}
+            ],
+        )
+        if index_type == "GSI":
+            create_table_args["GlobalSecondaryIndexes"] = [
+                {
+                    'IndexName': 'gsi1',
+                    'KeySchema': [
+                        {'AttributeName': 'c', 'KeyType': 'HASH'},
+                        {'AttributeName': 'p', 'KeyType': 'RANGE'},
+                    ],
+                    'Projection': {'ProjectionType': 'ALL'}
+                }
+            ]
+        elif index_type == "LSI":
+            create_table_args["LocalSecondaryIndexes"] = [
+                {
+                    'IndexName': 'lsi1',
+                    'KeySchema': [
+                        {'AttributeName': 'p', 'KeyType': 'HASH'},
+                        {'AttributeName': 'c', 'KeyType': 'RANGE'},
+                    ],
+                    'Projection': {'ProjectionType': 'ALL'}
+                }
+            ]
+        alternator.create_table(**create_table_args)
+
+    # Create a table with tablets and GSI or LSI - should fail because rf_rack_valid_keyspaces is disabled
+    for index_type in ["GSI", "LSI"]:
+        with pytest.raises(ClientError, match=expected_err_create):
+            create_table_with_index(alternator, unique_table_name(), index_type, initial_tablets='1')
+
+    # Now create the table without tablets - should succeed
+    for index_type in ["GSI", "LSI"]:
+        create_table_with_index(alternator, unique_table_name(), index_type, initial_tablets='none')
+
+    # Create a table with tablets and no indexes, then add a GSI - the update should fail
+    table_name = unique_table_name()
+    create_table_with_index(alternator, table_name, index_type=None, initial_tablets='1')
+    with pytest.raises(ClientError, match=expected_err_update_add_gsi):
+        alternator.meta.client.update_table(
+            TableName=table_name,
+            AttributeDefinitions=[
+                {'AttributeName': 'c', 'AttributeType': 'S'},
+                {'AttributeName': 'p', 'AttributeType': 'S'},
+            ],
+            GlobalSecondaryIndexUpdates=[
+                {
+                    'Create': {
+                        'IndexName': 'gsi1',
+                        'KeySchema': [
+                            {'AttributeName': 'c', 'KeyType': 'HASH'},
+                            {'AttributeName': 'p', 'KeyType': 'RANGE'},
+                        ],
+                        'Projection': {'ProjectionType': 'ALL'}
+                    }
+                }
+            ]
+        )
+
 # Unfortunately by default a Python thread print the exception that kills
 # it (e.g., pytest assert failures) but it doesn't propagate the exception
 # to the join() - so the overall test doesn't fail. The following ThreadWrapper


### PR DESCRIPTION
When creating an alternator table with tablets, if it has an index, LSI or GSI, require the config option rf_rack_valid_keyspaces to be enabled.

The option is required for materialized views in tablets keyspaces to function properly and avoid consistency issues that could happen due to cross-rack migrations and pairing switches when RF-rack validity is not enforced.

Currently the option is validated when creating a materialized view via the CQL interface, but it's missing from the alternator interface. Since alternator indexes are based on materialized views, the same check should be added there as well.

Fixes scylladb/scylladb#27612

backport to 2025.4 - MVs with tablets are supported starting from 2025.4 and the option should be enforced there