### PR TITLE
test_gossiper_unreachable_endpoints is defined twice (remove one definition which is redundant)

### DIFF
--- a/test/rest_api/test_gossiper.py
+++ b/test/rest_api/test_gossiper.py
@@ -20,12 +20,6 @@ def test_gossiper_unreachable_endpoints(cql, rest_api):
     resp = rest_api.send("GET", f"gossiper/endpoint/down")
     resp.raise_for_status()
     unreachable_endpoints = set(resp.json())
-    assert not unreachable_endpoints
-
-def test_gossiper_unreachable_endpoints(cql, rest_api):
-    resp = rest_api.send("GET", f"gossiper/endpoint/down")
-    resp.raise_for_status()
-    unreachable_endpoints = set(resp.json())
     for ep in unreachable_endpoints:
         resp = rest_api.send("GET", f"gossiper/downtime/{ep}")
         resp.raise_for_status()


### PR DESCRIPTION
To fix the problem, we need to remove the first, redundant definition of `test_gossiper_unreachable_endpoints` (lines 19-24). The second definition (lines 25-40) should be retained as it has more substantial test logic. No other code changes or imports are needed, as the test logic is preserved fully in the retained definition.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._