### PR TITLE
repair: Fix rwlock in compaction_state and lock holder lifecycle

### DIFF
--- a/compaction/compaction_manager.hh
+++ b/compaction/compaction_manager.hh
@@ -36,6 +36,7 @@
 #include "utils/pluggable.hh"
 #include "compaction/compaction_reenabler.hh"
 #include "utils/disk_space_monitor.hh"
+#include "utils/lock_holder.hh"
 
 namespace db {
 class compaction_history_entry;
@@ -394,8 +395,8 @@ public:
 
     future<compaction_reenabler> await_and_disable_compaction(compaction::compaction_group_view& t);
 
-    future<seastar::rwlock::holder> get_incremental_repair_read_lock(compaction::compaction_group_view& t, const sstring& reason);
-    future<seastar::rwlock::holder> get_incremental_repair_write_lock(compaction::compaction_group_view& t, const sstring& reason);
+    future<utils::rwlock_holder> get_incremental_repair_read_lock(compaction::compaction_group_view& t, const sstring& reason);
+    future<utils::rwlock_holder> get_incremental_repair_write_lock(compaction::compaction_group_view& t, const sstring& reason);
 
     // Run a function with compaction temporarily disabled for a table T.
     future<> run_with_compaction_disabled(compaction::compaction_group_view& t, std::function<future<> ()> func, sstring reason = "custom operation");

--- a/compaction/compaction_state.hh
+++ b/compaction/compaction_state.hh
@@ -39,7 +39,7 @@ struct compaction_state {
     // compactions. This lock guarantees that no sstables are being repaired.
     // Note that the minor compactions do not need to take this lock because
     // they ignore sstables that are being repaired.
-    seastar::rwlock incremental_repair_lock;
+    seastar::lw_shared_ptr<seastar::rwlock> incremental_repair_lock;
 
     // Raised by any function running under run_with_compaction_disabled();
     long compaction_disabled_counter = 0;

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -1240,6 +1240,8 @@ private:
         // compaction.
         reenablers_and_holders.cres.clear();
         rlogger.info("Re-enabled compaction for range={} for incremental repair", _range);
+
+        co_await utils::get_local_injector().inject("wait_after_prepare_sstables_for_incremental_repair", utils::wait_for_message(5min));
     }
 
     // Read rows from sstable until the size of rows exceeds _max_row_buf_size  - current_size

--- a/repair/row_level.hh
+++ b/repair/row_level.hh
@@ -23,6 +23,7 @@
 #include "locator/tablet_metadata_guard.hh"
 #include "utils/chunked_vector.hh"
 #include "utils/disk_space_monitor.hh"
+#include "utils/lock_holder.hh"
 
 using namespace seastar;
 
@@ -163,7 +164,7 @@ class repair_service : public seastar::peering_sharded_service<repair_service> {
             std::unordered_set<locator::host_id> ignore_nodes);
 
 public:
-    std::unordered_map<locator::global_tablet_id, std::vector<seastar::rwlock::holder>> _repair_compaction_locks;
+    std::unordered_map<locator::global_tablet_id, std::vector<utils::rwlock_holder>> _repair_compaction_locks;
 
 public:
     repair_service(sharded<service::topology_state_machine>& tsm,

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -74,6 +74,7 @@
 #include "replica/tables_metadata_lock.hh"
 #include "service/topology_guard.hh"
 #include "utils/disk_space_monitor.hh"
+#include "utils/lock_holder.hh"
 
 class cell_locker;
 class cell_locker_stats;
@@ -177,7 +178,7 @@ namespace replica {
 
 struct compaction_reenablers_and_lock_holders {
     std::vector<std::unique_ptr<compaction::compaction_reenabler>> cres;
-    std::vector<seastar::rwlock::holder> lock_holders;
+    std::vector<utils::rwlock_holder> lock_holders;
 };
 
 using shared_memtable = lw_shared_ptr<memtable>;
@@ -1368,8 +1369,6 @@ public:
     future<compaction_reenablers_and_lock_holders> get_compaction_reenablers_and_lock_holders_for_repair(replica::database& db,
             const service::frozen_topology_guard& guard, dht::token_range range);
     future<uint64_t> estimated_partitions_in_range(dht::token_range tr) const;
-private:
-    future<std::vector<compaction::compaction_group_view*>> get_compaction_group_views_for_repair(dht::token_range range);
 };
 
 lw_shared_ptr<sstables::sstable_set> make_tablet_sstable_set(schema_ptr, const storage_group_manager& sgm, const locator::tablet_map&);

--- a/utils/lock_holder.hh
+++ b/utils/lock_holder.hh
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) 2025-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+ */
+
+#pragma once
+
+#include <seastar/core/rwlock.hh>
+#include <seastar/core/shared_ptr.hh>
+
+namespace utils {
+    struct rwlock_holder {
+        seastar::lw_shared_ptr<seastar::rwlock> lock;
+        seastar::rwlock::holder holder;
+    };
+}
+


### PR DESCRIPTION
repair: Fix rwlock in compaction_state and lock holder lifecycle

Consider this:

- repair takes the lock holder
- tablet merge filber destories the compaction group and the compaction state
- repair fails
- repair destroy the lock holder

This is observed in the test:

```
repair - repair[5d73d094-72ee-4570-a3cc-1cd479b2a036] Repair 1 out of 1 tablets: table=sec_index.users range=(432345564227567615,504403158265495551] replicas=[0e9d51a5-9c99-4d6e-b9db-ad36a148b0ea:15, 498e354c-1254-4d8d-a565-2f5c6523845a:9, 5208598c-84f0-4526-bb7f-573728592172:28]

...

repair - repair[5d73d094-72ee-4570-a3cc-1cd479b2a036]: Started to repair 1 out of 1 tables in keyspace=sec_index, table=users, table_id=ea2072d0-ccd9-11f0-8dba-c5ab01bffb77, repair_reason=repair
repair - Enable incremental repair for table=sec_index.users range=(432345564227567615,504403158265495551]
table - Disabled compaction for range=(432345564227567615,504403158265495551] session_id=a13a72cc-cd2d-11f0-8e9b-76d54580ab09 for incremental repair
table - Got unrepaired compaction and repair lock for range=(432345564227567615,504403158265495551] session_id=a13a72cc-cd2d-11f0-8e9b-76d54580ab09 for incremental repair
table - Disabled compaction for range=(432345564227567615,504403158265495551] session_id=a13a72cc-cd2d-11f0-8e9b-76d54580ab09 for incremental repair
table - Got unrepaired compaction and repair lock for range=(432345564227567615,504403158265495551] session_id=a13a72cc-cd2d-11f0-8e9b-76d54580ab09 for incremental repair
repair - repair[5d73d094-72ee-4570-a3cc-1cd479b2a036]: get_sync_boundary: got error from node=0e9d51a5-9c99-4d6e-b9db-ad36a148b0ea, keyspace=sec_index, table=users, range=(432345564227567615,504403158265495551], error=seastar::rpc::remote_verb_error (Compaction state for table [0x60f008fa34c0] not found)
compaction_manager - Stopping 1 tasks for 1 ongoing compactions for table sec_index.users compaction_group=238 due to tablet merge
compaction_manager - Stopping 1 tasks for 1 ongoing compactions for table sec_index.users compaction_group=238 due to tablet merge

....

scylla[10793] Segmentation fault on shard 28, in scheduling group streaming
```

The rwlock in compaction_state could be destroyed before the lock holder
of the rwlock is destroyed. This causes user after free when the lock
the holder is destroyed.

To fix, we make the rwlock a shared pointer and hold a reference where
the lock locker is stored.

This patch does not intend to serialize the dropping of a compaction
group and repair. Such serialization will couple compaction and repair
too more tightly than necessary. It is OK that a compaction group is
gone in the middle of a repair, similar to the case a table could be
dropped in the middle of a repair.

The issue can be reproduced using sanitize build consistently and can not
be reproduced after the fix.

Fixes #27365