### PR TITLE
scylla-gdb.py: fix for `__iter__` method returns a non-iterator

### DIFF
--- a/scylla-gdb.py
+++ b/scylla-gdb.py
@@ -818,6 +818,9 @@ class std_list:
                 self._node = node_header['_M_next']
                 self._end = node_header['_M_next']['_M_prev']
 
+            def __iter__(self):
+                return self
+
             def __next__(self):
                 if self._node == self._end:
                     raise StopIteration()


### PR DESCRIPTION
To fix this issue, the `std_list_iterator` class defined within `std_list.__iter__` should implement the full iterator protocol by defining an `__iter__()` method that returns `self`. This change ensures any instance of `std_list_iterator` can be used as an iterator in Python `for` loops and other iteration contexts, as required. The fix is to add a small method definition inside the `std_list_iterator` class, ideally after the `__init__` or in a logical place with the other dunder methods.

Only the code inside the `std_list` class's `__iter__` function (lines around the definition of the inner class and its methods) needs to be edited.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._