### PR TITLE
test/cqlpy: remove commented-out code

### DIFF
--- a/test/cqlpy/test_materialized_view.py
+++ b/test/cqlpy/test_materialized_view.py
@@ -144,10 +144,6 @@ def test_mv_quoted_column_names_build(cql, test_keyspace):
                 # which we don't). This means, unfortunately, that a failure
                 # of this test is slow - it needs to wait for a timeout.
                 wait_for_view_built(cql, mv)
-                # start_time = time.time()
-                # while time.time() < start_time + 30:
-                #     if list(cql.execute(f'SELECT * from {mv}')) == [(2, 1)]:
-                #         break
                 assert list(cql.execute(f'SELECT * from {mv}')) == [(2, 1)]
 
 # The previous test (test_mv_empty_string_partition_key) verifies that a


### PR DESCRIPTION
This patch was suggested and prepared by copilot, I am writing the commit message because the original one was worthless.

In commit cf138da853afbf93dd72121de6e45c30b2e30bbe, for an an unexplained reason, a loop waiting until the expected value appears in a materialized view was replaced by a call for wait_for_view_built(). The old loop code was left behind in a comment, and this commented-out code is now bothering our AI. So let's delete the commented-out code.