### PR TITLE
test/boost/reader_concurrency_semaphore_test: un-flake memory limit engages test

### DIFF
--- a/test/boost/reader_concurrency_semaphore_test.cc
+++ b/test/boost/reader_concurrency_semaphore_test.cc
@@ -1663,7 +1663,7 @@ SEASTAR_TEST_CASE(test_reader_concurrency_semaphore_memory_limit_engages) {
     db_cfg.reader_concurrency_semaphore_kill_limit_multiplier.set(4, utils::config_file::config_source::CommandLine);
 
     return do_with_cql_env_thread([] (cql_test_env& env) {
-        auto tbl = create_memory_limit_table(env, 64);
+        auto tbl = create_memory_limit_table(env, 54);
 
         auto& db = env.local_db();
         auto& semaphore = db.get_reader_concurrency_semaphore();


### PR DESCRIPTION
This test was observed to fail multiple times recently in promotion, because there were successful reads. The failure only reproduces on arm64, it doesn't reproduce on x86.
The suspected reason is that the data set is too close to the edge, where all reads fail due to too high memory consumption. Reduce the number of sstables used by this test to 54 (from 64).

Fixes: #27248

Test was only observed to fail on master, no backport.