### PR TITLE
test/cluster/object_store/conftest.py: fix for Missing call to superclass `__init__` during object initialization

### DIFF
--- a/test/cluster/object_store/conftest.py
+++ b/test/cluster/object_store/conftest.py
@@ -72,13 +72,15 @@ class MinioWrapper(S3_Server):
         self.server = MinioServer(tempdir,
                                   '127.0.0.1',
                                   logging.getLogger('minio'))
-        self.tempdir = tempdir
-        self.address = self.server.address
-        self.port = self.server.port
-        self.acc_key = self.server.access_key
-        self.secret_key = self.server.access_key
-        self.region = MinioServer.DEFAULT_REGION
-        self.bucket_name = self.server.bucket_name
+        super().__init__(
+            tempdir,
+            self.server.address,
+            self.server.port,
+            self.server.access_key,
+            self.server.access_key,
+            MinioServer.DEFAULT_REGION,
+            self.server.bucket_name
+        )
 
     def create_endpoint_conf(self):
         return MinioServer.create_conf(self.address, self.port, self.region)


### PR DESCRIPTION
The best fix is to call `super().__init__` inside MinioWrapper's `__init__`, passing in the correct values to its parameters.  
- This means replacing the manual assignments for attributes (`self.tempdir`, etc.) with a call to the S3_Server constructor, ensuring all initialization happens via the base class, maintaining DRY and future-proofing the code.
- The parameters required by S3_Server's `__init__` are: `tempdir`, `address`, `port`, `acc_key`, `secret_key`, `region`, and `bucket_name`. All of these can be constructed or retrieved from the MinioServer object.
- The lines that assign these attributes manually in MinioWrapper should be removed, replaced by the `super()` call.

Change only what's needed within the range shown in test/cluster/object_store/conftest.py, specifically in the `MinioWrapper.__init__` method.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._