### PR TITLE
doc: remove references to ScyllaDB versions 4.3 and 4.4

### DIFF
--- a/docs/features/cdc/cdc-stream-changes.rst
+++ b/docs/features/cdc/cdc-stream-changes.rst
@@ -29,9 +29,6 @@ A CDC generation consists of:
 
 This is the mapping used to decide on which stream IDs to use when making writes, as explained in the :doc:`./cdc-streams` document. It is a global property of the cluster: it doesn't depend on the table you're making writes to.
 
-.. caution::
-   The tables mentioned in the following sections: ``system_distributed.cdc_generation_timestamps`` and ``system_distributed.cdc_streams_descriptions_v2`` have been introduced in ScyllaDB 4.4. It is highly recommended to upgrade to 4.4 for efficient CDC usage. The last section explains how to run the below examples in ScyllaDB 4.3.
-
 When CDC generations change
 ---------------------------
 


### PR DESCRIPTION
We should never refer to unsupported OSS versions. This is a leftover - other mentions were removed a long time ago.
Especially, the "last section" this caution mentions, entitled "Differences in ScyllaDB 4.3" was removed.

Fixes https://github.com/scylladb/scylladb/issues/19569

This PR should be backported to 2025.4, as it's a follow-up to https://github.com/scylladb/scylladb/pull/23795, where the referred section "Differences in ScyllaDB 4.3" was removed; see https://github.com/scylladb/scylladb/pull/23795/commits/acd0eebd5485a7be269ec09b74f3b28919cd019c 


