### PR TITLE
test/cqlpy: fix two tests that couldn't fail because of typo

### DIFF
--- a/test/cqlpy/test_guardrail_compact_storage.py
+++ b/test/cqlpy/test_guardrail_compact_storage.py
@@ -15,7 +15,7 @@ def test_create_table_with_compact_storage_default_config(cql, test_keyspace):
     # enable_create_table_with_compact_storage is now disabled in db/config
     try:
         with new_test_table(cql, test_keyspace, schema="p int PRIMARY KEY, v int", extra="WITH COMPACT STORAGE") as test_table:
-            pytest.fail
+            pytest.fail()
     except InvalidRequest:
         pass
 
@@ -25,9 +25,9 @@ def test_create_table_with_compact_storage_config(cql, test_keyspace, enable_com
         try:
             with new_test_table(cql, test_keyspace, schema="p int PRIMARY KEY, v int", extra="WITH COMPACT STORAGE") as test_table:
                 if not enable_compact_storage:
-                    pytest.fail
+                    pytest.fail()
         except InvalidRequest:
             # expected to throw InvalidRequest only when
             # enable_create_table_with_compact_storage=false
             if enable_compact_storage:
-                pytest.fail
+                pytest.fail()


### PR DESCRIPTION
As noticed by copilot, two tests in test_guardrail_compact_storage.py could never fail, because they used `pytest.fail` instead of the correct `pytest.fail()` to fail. Unfortunately, Python has a footgun where if it sees a bare function name without parenthesis, instead of complaining it evaluates the function object and then ignores it, and absolutely nothing happens.

So let's add the missing `()`. The test still passes, but now it at least has a chance of failing if we have a regression.