### PR TITLE
test/nodetool: add missing "assert"

### DIFF
--- a/test/nodetool/test_status.py
+++ b/test/nodetool/test_status.py
@@ -109,7 +109,7 @@ def validate_status_output(res, keyspace, nodes, ownership, resolve, effective_o
                 assert load_unit is not None
                 assert load == "{:.2f}".format(int(node.load) / load_multiplier[load_unit])
             if token_count_unknown:
-                tokens == "?"
+                assert tokens == "?"
             else:
                 assert int(tokens) == len(node.tokens)
             if effective_ownership_unknown:


### PR DESCRIPTION
This problem and its fix was suggested by copilot, I'm just writing the cover letter.

`test/nodetool/test_status.py` has the silly statement `tokens == "?"` which has no effect. Looking around the code suggested to me (and also to Copilot, nice) that the correct intent was `assert tokens == "?"` and not, say, `tokens = "?"`.