### PR TITLE
cql3/statements/batch_statement: make size error message more verbose

### DIFF
--- a/cql3/statements/batch_statement.hh
+++ b/cql3/statements/batch_statement.hh
@@ -116,7 +116,7 @@ public:
      * Checks batch size to ensure threshold is met. If not, a warning is logged.
      * @param cfs ColumnFamilies that will store the batch's mutations.
      */
-    static void verify_batch_size(query_processor& qp, const utils::chunked_vector<mutation>& mutations);
+    void verify_batch_size(query_processor& qp, const utils::chunked_vector<mutation>& mutations) const;
 
     virtual future<shared_ptr<cql_transport::messages::result_message>> execute(
             query_processor& qp, service::query_state& state, const query_options& options, std::optional<service::group0_guard> guard) const override;

--- a/test/cqlpy/test_logs.py
+++ b/test/cqlpy/test_logs.py
@@ -136,7 +136,7 @@ def table_batch(cql, test_keyspace):
 
 def test_warning_message_for_batch_exceeding_warning_threshold(cql, table_batch, logfile):
     """Batch size above threshold should add warning message to scylla logs"""
-    warning_pattern = r"WARN .+BatchStatement - Batch modifying [\d]+ partitions in [_\w.]+ is of size [\d]+ bytes, "\
+    warning_pattern = r"WARN .+BatchStatement - Logged batch modifying [\d]+ partitions in [_\w.]+ is of size [\d]+ bytes, "\
                       r"exceeding specified WARN threshold of"
     cql.execute(generate_big_batch(table_batch, 256))
     wait_for_log(logfile, warning_pattern, timeout=1)
@@ -147,7 +147,7 @@ def test_error_message_for_batch_exceeding_fail_threshold(cql, table_batch, logf
     try:
         cql.execute(generate_big_batch(table_batch, 1025))
     except InvalidRequest:
-        err_pattern = r"ERROR .+ BatchStatement - Batch modifying [\d]+ partitions in [_\w.]+ is of size [\d]+ bytes, "\
+        err_pattern = r"ERROR .+ BatchStatement - Logged batch modifying [\d]+ partitions in [_\w.]+ is of size [\d]+ bytes, "\
                           r"exceeding specified FAIL threshold of"
         wait_for_log(logfile, err_pattern, timeout=1)
     else:


### PR DESCRIPTION
Mention the type of batch: Logged or Unlogged. The size (warn/fail on too large size) error has different significance depending on the type.

Refs: #27605

Minor error message improvement, no backport.