### PR TITLE
test/cqlpy: remove unused statement from run.py

### DIFF
--- a/test/cqlpy/run.py
+++ b/test/cqlpy/run.py
@@ -182,7 +182,6 @@ def cleanup_all():
             sys.stdout.flush()
             shutil.copyfileobj(f, sys.stdout.buffer)
         f.close()
-    scylla_set = set()
     print(summary)
 
 # We run the cleanup_all() function on exit for any reason - successful finish


### PR DESCRIPTION
Problem found and fixed by copilot. The commit message below was started by copilot, but I had to fix it a bit:

Remove the redundant unused variable declaration: `scylla_set = set()`. Just delete this line. This change is safe because the variable has no effect on program behavior, output, or state, and its removal cannot change the program's functionality. 