### PR TITLE
test/cqlpy: remove unused imports

### DIFF
--- a/test/cqlpy/cassandra_tests/distinct_query_paging_test.py
+++ b/test/cqlpy/cassandra_tests/distinct_query_paging_test.py
@@ -7,9 +7,6 @@
 
 from .porting import *
 
-from cassandra.query import BatchStatement, BatchType
-from cassandra.protocol import InvalidRequest
-
 # Migrated from cql_tests.py:TestCQL.test_select_distinct()
 def testSelectDistinct(cql, test_keyspace):
     # Test a regular (CQL3) table.

--- a/test/cqlpy/cassandra_tests/functions/cast_fcts_test.py
+++ b/test/cqlpy/cassandra_tests/functions/cast_fcts_test.py
@@ -8,8 +8,8 @@
 from ...cassandra_tests.porting import *
 from decimal import Decimal
 from ctypes import c_float
-from datetime import datetime, timezone
-from cassandra.util import Date, Time, Duration, uuid_from_time, ms_timestamp_from_datetime
+from datetime import datetime
+from cassandra.util import Date, uuid_from_time
 
 def testInvalidQueries(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a int primary key, b text, c double)") as table:

--- a/test/cqlpy/cassandra_tests/porting.py
+++ b/test/cqlpy/cassandra_tests/porting.py
@@ -16,7 +16,6 @@ import time
 from ..util import unique_name
 from contextlib import contextmanager
 from cassandra.protocol import SyntaxException, InvalidRequest
-from cassandra.protocol import ConfigurationException
 from cassandra.util import SortedSet, OrderedMapSerializedKey
 from cassandra.query import UNSET_VALUE
 

--- a/test/cqlpy/cassandra_tests/validation/entities/counters_test.py
+++ b/test/cqlpy/cassandra_tests/validation/entities/counters_test.py
@@ -7,7 +7,7 @@
 
 from ...porting import  *
 
-from cassandra.protocol import SyntaxException, AlreadyExists, InvalidRequest, ConfigurationException
+from cassandra.protocol import InvalidRequest, ConfigurationException
 from cassandra.query import UNSET_VALUE
 
 # Test for the validation bug of CASSANDRA-4706,

--- a/test/cqlpy/cassandra_tests/validation/entities/frozen_collections_test.py
+++ b/test/cqlpy/cassandra_tests/validation/entities/frozen_collections_test.py
@@ -7,7 +7,7 @@
 
 from ...porting import *
 
-from cassandra.protocol import SyntaxException, AlreadyExists, InvalidRequest, ConfigurationException
+from cassandra.protocol import SyntaxException, InvalidRequest, ConfigurationException
 from cassandra.util import OrderedMap
 
 

--- a/test/cqlpy/cassandra_tests/validation/entities/secondary_index_test.py
+++ b/test/cqlpy/cassandra_tests/validation/entities/secondary_index_test.py
@@ -41,7 +41,7 @@
 # * testDroppingIndexInvalidatesPreparedStatements
 
 from ...porting import *
-from cassandra.protocol import SyntaxException, AlreadyExists, InvalidRequest, ConfigurationException
+from cassandra.protocol import SyntaxException, InvalidRequest, ConfigurationException
 from uuid import UUID
 
 # Test creating and dropping an index with the specified name.

--- a/test/cqlpy/cassandra_tests/validation/operations/alter_test.py
+++ b/test/cqlpy/cassandra_tests/validation/operations/alter_test.py
@@ -20,6 +20,7 @@
 # limitations under the License.
 
 from ...porting import *
+from cassandra.protocol import ConfigurationException
 
 def testDropColumnAsPreparedStatement(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(key int PRIMARY KEY, value int)") as table:

--- a/test/cqlpy/cassandra_tests/validation/operations/compact_storage_test.py
+++ b/test/cqlpy/cassandra_tests/validation/operations/compact_storage_test.py
@@ -7,8 +7,6 @@
 
 from ...porting import *
 from uuid import UUID
-from cassandra.query import UNSET_VALUE
-from cassandra.util import Duration
 
 compactOption = " WITH COMPACT STORAGE"
 

--- a/test/cqlpy/cassandra_tests/validation/operations/insert_update_if_condition_collections_test.py
+++ b/test/cqlpy/cassandra_tests/validation/operations/insert_update_if_condition_collections_test.py
@@ -6,7 +6,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from ...porting import *
-import random
 
 # InsertUpdateIfConditionCollectionsTest class has been split into multiple ones because of timeout issues (CASSANDRA-16670)
 # Any changes here check if they apply to the other classes

--- a/test/cqlpy/conftest.py
+++ b/test/cqlpy/conftest.py
@@ -10,14 +10,10 @@
 # and automatically setting up the fixtures they need.
 
 import pytest
-import logging
-import pathlib
-import boto3
-from cassandra.cluster import Cluster, NoHostAvailable
+from cassandra.cluster import NoHostAvailable
 from cassandra.connection import DRIVER_NAME, DRIVER_VERSION
 import json
 import os
-import ssl
 import subprocess
 import tempfile
 import time

--- a/test/cqlpy/run.py
+++ b/test/cqlpy/run.py
@@ -7,7 +7,6 @@ import time
 import shutil
 import signal
 import atexit
-import tempfile
 import requests
 
 # run_with_temporary_dir() is a utility function for running a process, such

--- a/test/cqlpy/test_allow_filtering.py
+++ b/test/cqlpy/test_allow_filtering.py
@@ -28,7 +28,7 @@ import pytest
 import re
 import time
 
-from cassandra.protocol import SyntaxException, AlreadyExists, InvalidRequest, ConfigurationException, ReadFailure
+from cassandra.protocol import InvalidRequest, ConfigurationException
 
 from .util import unique_name, new_test_table
 

--- a/test/cqlpy/test_bad_grammar.py
+++ b/test/cqlpy/test_bad_grammar.py
@@ -7,7 +7,7 @@
 
 import pytest
 from .util import new_test_table
-from cassandra.protocol import InvalidRequest, SyntaxException
+from cassandra.protocol import SyntaxException
 
 
 # table1 is just there so we can execute bad queries against it.

--- a/test/cqlpy/test_describe.py
+++ b/test/cqlpy/test_describe.py
@@ -11,7 +11,7 @@ import pytest
 import random
 import re
 import textwrap
-from contextlib import contextmanager, ExitStack
+from contextlib import ExitStack
 from .util import new_type, unique_name, new_test_table, new_test_keyspace, new_function, new_aggregate, \
     new_cql, keyspace_has_tablets, unique_name_prefix, new_session, new_user, new_materialized_view, \
     new_secondary_index

--- a/test/cqlpy/test_distinct.py
+++ b/test/cqlpy/test_distinct.py
@@ -7,7 +7,7 @@
 #############################################################################
 
 import pytest
-from .util import new_test_table, unique_key_int, random_string
+from .util import new_test_table, unique_key_int
 from cassandra.protocol import InvalidRequest
 
 @pytest.fixture(scope="module")

--- a/test/cqlpy/test_frozen_collection.py
+++ b/test/cqlpy/test_frozen_collection.py
@@ -11,7 +11,7 @@
 #############################################################################
 
 import pytest
-from cassandra.util import SortedSet, OrderedMapSerializedKey
+from cassandra.util import OrderedMapSerializedKey
 from .util import unique_name, new_test_table, unique_key_int
 
 

--- a/test/cqlpy/test_json.py
+++ b/test/cqlpy/test_json.py
@@ -11,9 +11,9 @@
 # to reproduce bugs discovered by bigger Cassandra tests.
 #############################################################################
 
-from .util import unique_name, new_test_table, unique_key_int
+from .util import unique_name, unique_key_int
 
-from cassandra.protocol import FunctionFailure, InvalidRequest
+from cassandra.protocol import FunctionFailure
 from cassandra.util import Date, Time
 
 import pytest

--- a/test/cqlpy/test_keyspace.py
+++ b/test/cqlpy/test_keyspace.py
@@ -10,7 +10,7 @@ import pytest
 from cassandra.protocol import SyntaxException, AlreadyExists, InvalidRequest, ConfigurationException
 from threading import Thread
 
-from test.cluster.util import parse_replication_options, get_replication, get_replica_count
+from test.cluster.util import get_replication, get_replica_count
 
 
 # A basic tests for successful CREATE KEYSPACE and DROP KEYSPACE

--- a/test/cqlpy/test_large_cells_rows.py
+++ b/test/cqlpy/test_large_cells_rows.py
@@ -4,7 +4,6 @@
 
 from .util import new_test_table
 
-import requests
 from . import nodetool
 
 def test_create_large_static_cells_and_rows(cql, test_keyspace):

--- a/test/cqlpy/test_materialized_view.py
+++ b/test/cqlpy/test_materialized_view.py
@@ -5,11 +5,10 @@
 # Tests for materialized views
 
 import time
-import re
 import pytest
 from . import rest_api
 
-from .util import new_test_table, unique_name, new_materialized_view, ScyllaMetrics, new_secondary_index
+from .util import new_test_table, unique_name, new_materialized_view, new_secondary_index
 from cassandra.protocol import ConfigurationException, InvalidRequest, SyntaxException
 from cassandra.cluster import ConsistencyLevel
 from cassandra.query import SimpleStatement

--- a/test/cqlpy/test_name.py
+++ b/test/cqlpy/test_name.py
@@ -7,7 +7,6 @@
 #############################################################################
 
 import pytest
-import re
 from contextlib import contextmanager
 from cassandra.protocol import InvalidRequest
 from .util import unique_name, new_test_table, new_secondary_index, new_function, is_scylla

--- a/test/cqlpy/test_prepare.py
+++ b/test/cqlpy/test_prepare.py
@@ -12,7 +12,6 @@
 
 import pytest
 from .util import new_test_table, unique_key_int, config_value_context
-from cassandra.protocol import InvalidRequest
 
 @pytest.fixture(scope="module")
 def table1(cql, test_keyspace):

--- a/test/cqlpy/test_scan.py
+++ b/test/cqlpy/test_scan.py
@@ -12,7 +12,7 @@
 #############################################################################
 
 import pytest
-from .util import new_test_table, new_type, user_type
+from .util import new_test_table
 from cassandra.protocol import InvalidRequest
 from cassandra.query import SimpleStatement
 

--- a/test/cqlpy/test_secondary_index.py
+++ b/test/cqlpy/test_secondary_index.py
@@ -12,9 +12,9 @@ import pytest
 import os
 from contextlib import ExitStack
 from . import rest_api
-from cassandra.protocol import SyntaxException, AlreadyExists, InvalidRequest, ConfigurationException, ReadFailure, WriteFailure
+from cassandra.protocol import InvalidRequest, ConfigurationException, ReadFailure
 from cassandra.query import SimpleStatement
-from .cassandra_tests.porting import assert_rows, assert_row_count, assert_rows_ignoring_order, assert_empty
+from .cassandra_tests.porting import assert_rows, assert_row_count, assert_rows_ignoring_order
 
 from .util import new_test_table, unique_name, unique_key_int, is_scylla, ScyllaMetrics, config_value_context
 

--- a/test/cqlpy/test_select_collection_element.py
+++ b/test/cqlpy/test_select_collection_element.py
@@ -7,10 +7,8 @@
 #############################################################################
 
 import pytest
-import re
-import time
 from cassandra.protocol import InvalidRequest
-from .util import unique_name, unique_key_int, unique_key_string, new_test_table, new_type, new_function
+from .util import unique_name, unique_key_int, new_test_table, new_type, new_function
 
 
 @pytest.fixture(scope="module")

--- a/test/cqlpy/test_service_levels.py
+++ b/test/cqlpy/test_service_levels.py
@@ -9,14 +9,13 @@
 #############################################################################
 
 from contextlib import contextmanager, ExitStack
-from .util import unique_name, new_test_table, new_user
+from .util import unique_name, new_user
 from .rest_api import scylla_inject_error
 
-from cassandra.protocol import InvalidRequest, ReadTimeout
+from cassandra.protocol import InvalidRequest
 from cassandra.util import Duration
 
 import pytest
-import time
 
 # MAX_USER_SERVICE_LEVELS represents the maximal number of service levels that users can create.
 # The value is documentented in `docs/features/workload-prioritization.rst`.

--- a/test/cqlpy/test_tools.py
+++ b/test/cqlpy/test_tools.py
@@ -32,7 +32,6 @@ from cassandra.util import Duration
 import yaml
 
 from test.cluster.object_store.conftest import s3_server
-from test.pylib.minio_server import MinioServer
 
 
 def simple_no_clustering_table(cql, keyspace):

--- a/test/cqlpy/test_type_timestamp.py
+++ b/test/cqlpy/test_type_timestamp.py
@@ -12,7 +12,7 @@
 
 from .util import new_test_table, unique_key_int
 from datetime import datetime
-from cassandra.protocol import SyntaxException, InvalidRequest
+from cassandra.protocol import InvalidRequest
 import pytest
 
 @pytest.fixture(scope="module")

--- a/test/cqlpy/test_unset.py
+++ b/test/cqlpy/test_unset.py
@@ -12,7 +12,6 @@
 import pytest
 from .util import new_test_table, unique_key_int
 from cassandra.query import UNSET_VALUE
-from cassandra.cluster import NoHostAvailable
 from cassandra.protocol import InvalidRequest
 
 @pytest.fixture(scope="module")

--- a/test/cqlpy/test_using_service_level.py
+++ b/test/cqlpy/test_using_service_level.py
@@ -4,11 +4,9 @@
 
 # Tests for USING SERVICE LEVEL extension
 
-from .util import new_test_keyspace, unique_name, unique_key_int
+from .util import unique_name
 import pytest
-from cassandra.protocol import InvalidRequest, ReadTimeout, WriteTimeout, SyntaxException
-from cassandra.cluster import NoHostAvailable
-from cassandra.util import Duration
+from cassandra.protocol import InvalidRequest, ReadTimeout
 
 # yields list of (service level name, bool if non-zero timeout)
 @pytest.fixture(scope="module")

--- a/test/cqlpy/test_using_timeout.py
+++ b/test/cqlpy/test_using_timeout.py
@@ -4,7 +4,7 @@
 
 # Tests for USING TIMEOUT extension
 
-from .util import new_test_keyspace, unique_name, unique_key_int
+from .util import unique_name, unique_key_int
 import pytest
 from cassandra.protocol import InvalidRequest, ReadTimeout, WriteTimeout, SyntaxException
 from cassandra.cluster import NoHostAvailable

--- a/test/cqlpy/test_using_timestamp.py
+++ b/test/cqlpy/test_using_timestamp.py
@@ -10,8 +10,8 @@
 # aiming to reproduce bugs discovered by bigger Cassandra tests.
 #############################################################################
 
-from .util import unique_name, new_test_table, unique_key_int
-from cassandra.protocol import FunctionFailure, InvalidRequest
+from .util import unique_name, unique_key_int
+from cassandra.protocol import InvalidRequest
 import pytest
 import time
 

--- a/test/cqlpy/test_utf8.py
+++ b/test/cqlpy/test_utf8.py
@@ -11,7 +11,7 @@
 
 import pytest
 import unicodedata
-from cassandra.protocol import SyntaxException, AlreadyExists, InvalidRequest, ConfigurationException, ReadFailure
+from cassandra.protocol import SyntaxException, InvalidRequest, ConfigurationException
 from .util import unique_name, unique_key_string
 
 

--- a/test/cqlpy/test_validation.py
+++ b/test/cqlpy/test_validation.py
@@ -12,7 +12,7 @@
 import pytest
 import re
 import random
-from cassandra.protocol import SyntaxException, AlreadyExists, InvalidRequest, ConfigurationException, ReadFailure
+from cassandra.protocol import InvalidRequest
 from .util import unique_name, unique_key_int, new_test_table
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
Remove many unused "import" statements or parts of import statement. All of them were detected by Copilot, but I verified each one manually and prepared this patch.