### PR TITLE
test/alternator: remove unused imports

### DIFF
--- a/test/alternator/run
+++ b/test/alternator/run
@@ -6,9 +6,6 @@ import run
 
 import os
 import requests
-import time
-import cassandra.cluster
-import cassandra.auth
 
 # When tests are to be run against AWS (the "--aws" option), it is not
 # necessary to start Scylla at all. All we need to do is to run pytest.

--- a/test/alternator/test_compressed_request.py
+++ b/test/alternator/test_compressed_request.py
@@ -33,7 +33,6 @@ import botocore
 import gzip
 import requests
 import pytest
-from contextlib import contextmanager
 
 from .util import random_string
 from .test_manual_requests import get_signed_request

--- a/test/alternator/test_cql_rbac.py
+++ b/test/alternator/test_cql_rbac.py
@@ -21,7 +21,7 @@ from functools import cache
 
 import re
 
-from .util import is_aws, unique_table_name, random_string, new_test_table
+from .util import unique_table_name, random_string, new_test_table
 from .test_gsi_updatetable import wait_for_gsi, wait_for_gsi_gone
 from .test_gsi import assert_index_query
 

--- a/test/alternator/test_describe_table.py
+++ b/test/alternator/test_describe_table.py
@@ -17,8 +17,8 @@
 import pytest
 from botocore.exceptions import ClientError
 import re
-import time, datetime
-from test.alternator.util import multiset, create_test_table, new_test_table
+import time
+from test.alternator.util import multiset, new_test_table
 
 # Test that DescribeTable correctly returns the table's name and state
 def test_describe_table_basic(test_table):

--- a/test/alternator/test_gsi_updatetable.py
+++ b/test/alternator/test_gsi_updatetable.py
@@ -9,7 +9,6 @@
 # various cases of that issue.
 
 import pytest
-import time
 from botocore.exceptions import ClientError
 from .util import random_string, full_scan, full_query, multiset, \
     new_test_table, wait_for_gsi, wait_for_gsi_gone

--- a/test/alternator/test_provisioned_throughput.py
+++ b/test/alternator/test_provisioned_throughput.py
@@ -8,8 +8,7 @@
 
 import pytest
 from botocore.exceptions import ClientError
-from decimal import Decimal
-from test.alternator.util import random_string, random_bytes, new_test_table
+from test.alternator.util import new_test_table
 
 # When creating a table with PROVISIONED billing mode, ProvisionedThroughput must be explicitly set,
 # and the same values should be reflected when the table is described.

--- a/test/alternator/test_returnconsumedcapacity.py
+++ b/test/alternator/test_returnconsumedcapacity.py
@@ -7,7 +7,6 @@
 import pytest
 from botocore.exceptions import ClientError
 from test.alternator.util import random_string, random_bytes, new_test_table
-import decimal
 from decimal import Decimal
 KB = 1024
 

--- a/test/alternator/test_scan.py
+++ b/test/alternator/test_scan.py
@@ -5,7 +5,6 @@
 # Tests for the Scan operation
 
 import pytest
-import time
 from boto3.dynamodb.conditions import Attr
 from botocore.exceptions import ClientError
 

--- a/test/alternator/test_service_levels.py
+++ b/test/alternator/test_service_levels.py
@@ -5,13 +5,9 @@
 import pytest
 from test.alternator.test_metrics import metrics, get_metrics, check_increases_metric
 from contextlib import contextmanager
-from cassandra.auth import PlainTextAuthProvider
-from cassandra.cluster import Cluster, ExecutionProfile, EXEC_PROFILE_DEFAULT, ConsistencyLevel
-from cassandra.policies import RoundRobinPolicy
 import time
-import re
 
-from .util import random_string, is_aws, unique_table_name
+from .util import random_string, unique_table_name
 from .test_cql_rbac import new_role, new_dynamodb
 
 # new_service_level() is a context manager for temporarily creating a new

--- a/test/alternator/test_system_tables.py
+++ b/test/alternator/test_system_tables.py
@@ -11,7 +11,7 @@ import requests
 from botocore.exceptions import ClientError
 from boto3.dynamodb.conditions import Key
 
-from .util import full_scan, scylla_config_read, scylla_config_write, scylla_config_temporary
+from .util import full_scan, scylla_config_read, scylla_config_temporary
 
 internal_prefix = '.scylla.alternator.'
 

--- a/test/alternator/test_table.py
+++ b/test/alternator/test_table.py
@@ -14,7 +14,7 @@ from re import fullmatch
 import pytest
 from botocore.exceptions import ClientError
 
-from test.alternator.util import list_tables, multiset, unique_table_name, create_test_table, random_string, new_test_table, is_aws, scylla_config_read
+from .util import list_tables, unique_table_name, create_test_table, random_string, new_test_table, is_aws, scylla_config_read
 
 
 # Utility function for create a table with a given name and some valid

--- a/test/alternator/test_tablets.py
+++ b/test/alternator/test_tablets.py
@@ -14,10 +14,9 @@
 # will probably go away eventually.
 
 import pytest
-import boto3
 from botocore.exceptions import ClientError
 
-from .util import new_test_table, wait_for_gsi, random_string, full_scan, full_query, multiset, scylla_config_read, scylla_config_temporary
+from .util import new_test_table, scylla_config_read, scylla_config_temporary
 
 # All tests in this file are scylla-only
 @pytest.fixture(scope="function", autouse=True)

--- a/test/alternator/util.py
+++ b/test/alternator/util.py
@@ -8,7 +8,6 @@ import string
 import random
 import collections
 import time
-import re
 import requests
 import pytest
 from contextlib import contextmanager


### PR DESCRIPTION
Remove many unused "import" statements or parts of import statement. All of them were detected by Copilot, but I verified each one manually and prepared this patch.