### PR TITLE
test/pylib/s3_proxy.py: fix warning: SyntaxWarning: 'return' in a 'fi…

### DIFF
--- a/test/pylib/s3_proxy.py
+++ b/test/pylib/s3_proxy.py
@@ -148,8 +148,7 @@ class InjectingHandler(BaseHTTPRequestHandler):
                 self.request.shutdown_request()
             except OSError:
                 pass
-            finally:
-                return
+            return
         code, error_name = self.get_retryable_http_codes()
         self.send_response(code)
         self.send_header('Content-Type', 'text/plain; charset=utf-8')


### PR DESCRIPTION
…nally' block

Backport: none, benign warning.