### PR TITLE
object_storage_endpoint_param: Make it formattable for real

### DIFF
--- a/db/object_storage_endpoint_param.cc
+++ b/db/object_storage_endpoint_param.cc
@@ -135,5 +135,5 @@ const std::string db::object_storage_endpoint_param::gs_type = "gs";
 
 auto fmt::formatter<db::object_storage_endpoint_param>::format(const db::object_storage_endpoint_param& e, fmt::format_context& ctx) const
     -> decltype(ctx.out()) {
-    return fmt::format_to(ctx.out(), "object_storage_endpoint_param{{}}", e.to_json_string());
+    return fmt::format_to(ctx.out(), "object_storage_endpoint_param{}", e.to_json_string());
 }


### PR DESCRIPTION
Currently the formatter converts it to json and then tries to emit into the output context with the "...{{}}" format string. The intent was to have the "...{\<json text\>}" output. However, the double curly brace in format string means "print a curly brace", so the output of the above formatting is "...{}", literally.

Fix by keeping a single curly brace. The "\<json text\>" thing will have its own surrounding curly braces.

Fixes #27718

Appeared in 2025.2, worth backporting