### PR TITLE
Make object storage config truly updateable

### DIFF
--- a/test/cluster/object_store/test_backup.py
+++ b/test/cluster/object_store/test_backup.py
@@ -166,7 +166,6 @@ async def test_backup_with_non_existing_parameters(manager: ManagerClient, objec
 
 
 @pytest.mark.asyncio
-@pytest.mark.xfail
 async def test_backup_endpoint_config_is_live_updateable(manager: ManagerClient, object_storage):
     '''backup should fail if the endpoint is invalid/inaccessible
        after updating the config, it should succeed'''


### PR DESCRIPTION
The db::config::object_storage_endpoints parameter is live-updateable, but when the update really happens, the new endpoints may fail to propagate to non-zero shards because of the way db::config sharding is implemented.

Refs: #7316
Fixes: #26509

Backport to 2025.3 and 2025.4, AFAIK there are set ups with object storage configs for native backup