### PR TITLE
test/alternator: rename test with duplicate name

### DIFF
--- a/test/alternator/test_transact.py
+++ b/test/alternator/test_transact.py
@@ -998,7 +998,7 @@ def test_transact_get_items_projection_expression(test_table_s):
 
 # ProjectionExpression also supports ExpressionAttributeNames.
 @pytest.mark.xfail(reason="#5064 - transactions not yet supported")
-def test_transact_get_items_projection_expression(test_table_s):
+def test_transact_get_items_projection_expression_attribute_names(test_table_s):
     p = random_string()
     item = {'p': p, 'x': 1, 'y': 2, 'z': 3}
     test_table_s.put_item(Item=item)


### PR DESCRIPTION
The file test/alternator/test_transact.py accidentally had two tests with the same name, test_transact_get_items_projection_expression. This means the first of the two tests was ignored and never run.

This patch renames the second of the two to a more appropriate (and unique...) name.

I verified that after this change the number of tests in this file grows by one, and that still all tests pass on DynamoDB and fail (as expected by xfail) on Alternator.