### PR TITLE
schema_registry: fix learning a schema with cdc schema

### DIFF
--- a/schema/schema.hh
+++ b/schema/schema.hh
@@ -593,7 +593,7 @@ private:
     v3_columns _v3_columns;
     mutable schema_registry_entry* _registry_entry = nullptr;
     std::unique_ptr<::view_info> _view_info;
-    schema_ptr _cdc_schema;
+    mutable schema_ptr _cdc_schema;
 
     const std::array<column_count_type, 3> _offsets;
 
@@ -957,6 +957,7 @@ public:
     friend bool operator==(const schema&, const schema&);
     const column_mapping& get_column_mapping() const;
     friend class schema_registry_entry;
+    friend class schema_registry;
     // May be called from different shard
     schema_registry_entry* registry_entry() const noexcept;
     // Returns true iff this schema version was synced with on current node.


### PR DESCRIPTION
When learning a schema that has a linked cdc schema, we need to learn also the cdc schema, and at the end the schema should point to the learned cdc schema.

This is needed because the linked cdc schema is used for generating cdc mutations, and when we process the mutations later it is assumed in some places that the mutation's schema has a schema registry entry.

We fix a scenario where we could end up with a schema that points to a cdc schema that doesn't have a schema registry entry. This could happen for example if the schema is loaded before it is learned, so when we learn it we see that it already has an entry. In that case, we need to set the cdc schema to the learned cdc schema as well, because it could have been loaded previously with a cdc schema that was not learned.

Fixes scylladb/scylladb#27610

no backport - the issue doesn't exist in previous releases