### PR TITLE
doc: fix the license information on DockerHub

### DIFF
--- a/docs/dev/docker-hub.md
+++ b/docs/dev/docker-hub.md
@@ -2,8 +2,11 @@
 
 ## What is ScyllaDB?
 
-ScyllaDB is a high-performance NoSQL database system, fully compatible with Apache Cassandra.
-ScyllaDB is released under the GNU Affero General Public License version 3 and the Apache License, ScyllaDB is free and open-source software.
+ScyllaDB is a high-performance NoSQL database optimized for speed and scalability.
+It is designed to efficiently handle large volumes of data with minimal latency,
+making it ideal for data-intensive applications.
+
+ScyllaDB is distributed under the [ScyllaDB Source Available License](https://github.com/scylladb/scylladb/blob/master/LICENSE-ScyllaDB-Source-Available.md).
 
 > [ScyllaDB](http://www.scylladb.com/)
 


### PR DESCRIPTION
This PR removes the OSS-related information from DockerHub. It adds the link to the Source Available license.

Fixes https://github.com/scylladb/scylladb/issues/22440

I don't think it needs to be backported. I assume we publish the [description on DockerHub](https://hub.docker.com/r/scylladb/scylla) from master.
@yaronkaikov @mykaul Can you confirm?