### PR TITLE
db/hints: Prevent draining hints before hint replay is allowed

### DIFF
--- a/db/hints/manager.cc
+++ b/db/hints/manager.cc
@@ -643,6 +643,12 @@ future<> manager::drain_for(endpoint_id host_id, gms::inet_address ip) noexcept 
         co_return;
     }
 
+    if (!replay_allowed()) {
+        auto reason = seastar::format("Precondition violdated while trying to drain {} / {}: "
+                "hint replay is not allowed", host_id, ip);
+        on_internal_error(manager_logger, std::move(reason));
+    }
+
     manager_logger.info("Draining starts for {}", host_id);
 
     const auto holder = seastar::gate::holder{_draining_eps_gate};

--- a/db/hints/manager.hh
+++ b/db/hints/manager.hh
@@ -318,6 +318,10 @@ public:
     /// In both cases - removes the corresponding hints' directories after all hints have been drained and erases the
     /// corresponding hint_endpoint_manager objects.
     ///
+    /// Preconditions:
+    /// * Hint replay must be allowed (i.e. `replay_allowed()` must be true) throughout
+    ///   the execution of this function.
+    ///
     /// \param host_id host ID of the node that left the cluster
     /// \param ip the IP of the node that left the cluster
     future<> drain_for(endpoint_id host_id, gms::inet_address ip) noexcept;
@@ -342,13 +346,13 @@ public:
         return _state.contains(state::started);
     }
 
+    bool replay_allowed() const noexcept {
+        return _state.contains(state::replay_allowed);
+    }
+
 private:
     void set_started() noexcept {
         _state.set(state::started);
-    }
-
-    bool replay_allowed() const noexcept {
-        return _state.contains(state::replay_allowed);
     }
 
     void set_draining_all() noexcept {

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -7266,20 +7266,36 @@ future<> storage_proxy::wait_for_hint_sync_point(const db::hints::sync_point spo
 
 void storage_proxy::on_leave_cluster(const gms::inet_address& endpoint, const locator::host_id& hid) {
     // Discarding these futures is safe. They're awaited by db::hints::manager::stop().
-    if (!_hints_manager.uses_host_id()) {
+    //
+    // Hint replay must be allowed throughout the execution of `drain_for`
+    // (it's a precondition of it). Once enabled in `main.cc`, it stays true
+    // throughout the life of the node.
+    //
+    // Note that if we don't perform draining here because hint replay is not
+    // allowed yet, it'll be conducted by a call to `db::hints::manager::drain_left_nodes()`,
+    // which is called by `main.cc` after hint replay is turned on.
+    if (_hints_manager.replay_allowed() && !_hints_manager.uses_host_id()) {
         (void) _hints_manager.drain_for(hid, endpoint);
     }
-    if (!_hints_for_views_manager.uses_host_id()) {
+    if (_hints_for_views_manager.replay_allowed() && !_hints_for_views_manager.uses_host_id()) {
         (void) _hints_for_views_manager.drain_for(hid, endpoint);
     }
 }
 
 void storage_proxy::on_released(const locator::host_id& hid) {
     // Discarding these futures is safe. They're awaited by db::hints::manager::stop().
-    if (_hints_manager.uses_host_id()) {
+    //
+    // Hint replay must be allowed throughout the execution of `drain_for`
+    // (it's a precondition of it). Once enabled in `main.cc`, it stays true
+    // throughout the life of the node.
+    //
+    // Note that if we don't perform draining here because hint replay is not
+    // allowed yet, it'll be conducted by a call to `db::hints::manager::drain_left_nodes()`,
+    // which is called by `main.cc` after hint replay is turned on.
+    if (_hints_manager.replay_allowed() && _hints_manager.uses_host_id()) {
         (void) _hints_manager.drain_for(hid, {});
     }
-    if (_hints_for_views_manager.uses_host_id()) {
+    if (_hints_for_views_manager.replay_allowed() && _hints_for_views_manager.uses_host_id()) {
         (void) _hints_for_views_manager.drain_for(hid, {});
     }
 }


### PR DESCRIPTION
Context
-------
The procedure of hint draining boils down to the following steps:

1. Drain a hint sender. That should get rid of all hints stored for the corresponding endpoint.
2. Remove the hint directory corresponding to that endpoint.

Obviously, it gets more complex than this high-level perspective. Without blurring the view, the relevant information is that step 1 in the algorithm above may not be executed.

Breaking it down, it comprises of two calls to
`hint_sender::send_hints_maybe()`. The function is responsible for sending out hints, but it's not unconditional and will not be performed if any of the following bullets is not satisfied:

* `hint_sender::replay_allowed()` is not `true`. This can happen when hint replay hasn't been turned on yet.
* `hint_sender::can_send()` is not `true`. This can happen if the corresponding endpoint is not alive AND it hasn't left the cluster AND it's still a normal token owner.

There is one more relevant point: sending hints can be stopped if replaying hints fails and `hint_sender::send_hints_maybe()` returns `false`. However, that's not not possible in the case of draining. In that case, if Scylla comes across any failure, it'll simply delete the corresponding hint segment. Because of that, we ignore it and only focus on the two bullets.

---

Why is it a problem?
--------------------
If a hint directory is not purged of all hint segments in it, any attempt to remove it will fail and we'll observe an error like this:

```
Exception when draining <host ID>: std::filesystem::__cxx11::filesystem_error
(error system:39, filesystem error: remove failed: Directory not empty [<path>])
```

The folder with the remaining hints will also stay on disk, which is, of course, undesired.

---

When can it happen?
-------------------
As highlighted in the Context section of this commit message, the key part of the code that can lead to a dangerous situation like that is `hint_sender::send_hints_maybe()`. The function is called twice when draining a hint endpoint manager: once to purge all of the existing hints, and another time after flushing all hints stored in a commitlog instances, but not listed by `hint_sender` yet. If any of those calls misbehaves, we may end up with a problem. That's why it's crucial to ensure that the function always goes through ALL of the hints.

Dangerous situations:

1. We try to drain hints before hint replay is allowed. That will violate the first bullet above.
2. The node we're draining is dead, but it hasn't left the cluster, and it still possesses some tokens.

---

How do we solve that?
---------------------
Hint replay is turned on in `main.cc`. Once enabled, it cannot be disabled. So to address the first bullet above, it suffices to ensure that no draining occurs beforehand. It's perfectly fine to prevent it. Soon after hint replay is allowed, `main.cc` also asks the hint manager to drain all of the endpoint managers whose endpoints are no longer normal token owners (cf. `db::hints::manager::drain_left_nodes()`).

The other bullet is more tricky. It's important here to know that draining only initiated in three situations:

1. As part of the call to `storage_service::notify_left()`.
2. As part of the call to `storage_service::notify_released()`.
3. As part of the call to `db::hints::manager::drain_left_nodes()`.

The last one is trivially non-problematic. The nodes that it'll try to drain are no longer normal token owners, so `can_send()` must always return `true`.

The second situation is similar. As we read in the commit message of scylladb/scylladb@eb92f50413ed6ff63c36bbdc9842c58732e576e3, which introduced the notion of released nodes, the nodes are no longer normal token owners:

> In this patch we postpone the hint draining for the "left" nodes to
> the time when we know that the target nodes no longer hold ownership
> of any tokens - so they're no longer referenced in topology. I'm
> calling such nodes "released".

I suggest reading the full commit message there because the problems there are somewhat similar these changes try to solve.

Finally, the first situation: unfortunately, it's more tricky. The same commit message says:

> When a node is being replaced, it enters a "left" state while still
> owning tokens. Before this patch, this is also the time when we start
> draining hints targeted to this node, so the hints may get sent before
> the token ownership gets migrated to another replica, and these hints
> may get lost.

This suggests that `storage_service::notify_left()` may be called when the corresponding node still has some tokens! That's something that may prevent properly draining hints.

Fortunately, no hope is lost. We only drain hints via `notify_left()` when hinted handoff hasn't been upgraded to being host-ID-based yet. If it has, draining always happens via `notify_released()`.

When I write this commit message, all of the supported versions of Scylla 2025.1+ use host-ID-based hinted handoff. That means that problems can only arise when upgrading from an older version of Scylla (2024.1 downwards). Because of that, we don't cover it. It would most likely require more extensive changes.

---

Non-issues
----------
There are notions that are closely related to sending hints. One of them is the host filter that hinted handoff uses. It decides which endpoints are eligible for receiving hints, and which are not. Fortunately, all endpoints rejected by the host filter lose their hint endpoint managers -- they're stopped as part of that procedure. What's more, draining hints and changing the host filter cannot be happening at the same time, so it cannot lead to any problems.

The solution
------------
To solve the described issue, we simply prevent draining hints before hint replay is allowed. No reproducer test is attached because it's not feasible to write one.

Fixes scylladb/scylladb#27693

Backport: The issue exists in 2025.4. I haven't been able to determine if it's present in the previous versions.