### PR TITLE
test: rename duplicate tests

### DIFF
--- a/test/nodetool/test_cluster_repair.py
+++ b/test/nodetool/test_cluster_repair.py
@@ -385,7 +385,7 @@ def test_repair_options_hosts_and_dcs_tablets(nodetool, datacenter, hosts):
                                    [("--tablet-tokens", "1")],
                                    [("--tablet-tokens", "-1,2")],
                                    [("--tablet-tokens", "-1"), ("--tablet-tokens", "2")]])
-def test_repair_options_hosts_tablets(nodetool, tokens):
+def test_repair_options_tokens_tablets(nodetool, tokens):
     _do_test_repair_options_tablets(nodetool, tokens=tokens)
 
 def test_repair_all_with_vnode_keyspace(nodetool):

--- a/test/nodetool/test_repair.py
+++ b/test/nodetool/test_repair.py
@@ -623,7 +623,7 @@ Repair session 1
 Repair session 1 finished
 """
 
-def test_repair_keyspace(nodetool):
+def test_repair_keyspace_failure(nodetool):
     check_nodetool_fails_with(
         nodetool,
         ("repair", "ks"),


### PR DESCRIPTION
There are two test with name test_repair_options_hosts_tablets in test/nodetool/test_cluster_repair.py and and two test_repair_keyspace in test/nodetool/test_repair.py. Due to that one of each pair is ignored.

Rename the tests so that they are unique.

Fixes: https://github.com/scylladb/scylladb/issues/27701.

Needs backports to all versions