### PR TITLE
db/batchlog_manager: add missing <seastar/coroutine/parallel_for_each.hh> include

### DIFF
--- a/db/batchlog_manager.cc
+++ b/db/batchlog_manager.cc
@@ -17,6 +17,7 @@
 #include <seastar/core/metrics.hh>
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/sleep.hh>
+#include <seastar/coroutine/parallel_for_each.hh>
 
 #include "batchlog_manager.hh"
 #include "batchlog.hh"


### PR DESCRIPTION
Build only fails if `--disable-precompiled-header` is passed to `configure.py`. Not sure why.

Problem is only present on master, no backport needed.