### PR TITLE
doc: remove cassandra-stress from installation instructions

### DIFF
--- a/docs/getting-started/_common/setup-after-install.rst
+++ b/docs/getting-started/_common/setup-after-install.rst
@@ -45,10 +45,3 @@ Run cqlsh:
      
      cqlsh
 
-Run cassandra-stress:
-
-.. code-block:: console
-     
-     cassandra-stress write -mode cql3 native 
-
-


### PR DESCRIPTION
The cassandra-stress tool is no longer part of the default package and cannot be run in the way described.

This PR removes the instruction to run cassandra-stress.

Fixes https://github.com/scylladb/scylladb/issues/24994

Please backport to 2025.1 and later as cassandra-stress has not been part of the default package since then.