### PR TITLE
test/raft: fix race condition in failure_detector_test

### DIFF
--- a/test/raft/failure_detector_test.cc
+++ b/test/raft/failure_detector_test.cc
@@ -40,16 +40,8 @@ struct test_pinger: public direct_failure_detector::pinger {
                 co_return;
             }
 
-            promise<> p;
-            auto f = p.get_future();
-            auto sub = as.subscribe([&, p = std::move(p)] () mutable noexcept {
-                p.set_value();
-            });
-            if (!sub) {
-                throw abort_requested_exception{};
-            }
-            co_await std::move(f);
-            throw abort_requested_exception{};
+            // Simulate a blocking ping that only returns when aborted.
+            co_await sleep_abortable(std::chrono::hours(1), as);
         }, as);
         co_return ret;
     }


### PR DESCRIPTION
The test had a sporadic failure due to a broken promise exception. The issue was in `test_pinger::ping()` which captured the promise by move into the subscription lambda, causing the promise to be destroyed when the lambda was destroyed during coroutine unwinding.

Simplify `test_pinger::ping()` by replacing manual abort_source/promise logic with `seastar::sleep_abortable()`. 
This removes the risk of promise lifetime/race issues and makes the code simpler and more robust.

Fixes: scylladb/scylladb#27136

Backport to active branches: This fixes a CI test issue, so it is beneficial to backport the fix. As this is a test-only fix, it is a low risk change.