### PR TITLE
topology_coordinator: Ensure repair_update_compaction_ctrl is executed

### DIFF
--- a/repair/row_level.hh
+++ b/repair/row_level.hh
@@ -154,7 +154,7 @@ class repair_service : public seastar::peering_sharded_service<repair_service> {
             std::unordered_set<locator::host_id> ignore_nodes);
 
 public:
-    std::unordered_map<service::session_id, std::vector<seastar::rwlock::holder>> _repair_compaction_locks;
+    std::unordered_map<locator::global_tablet_id, std::vector<seastar::rwlock::holder>> _repair_compaction_locks;
 
 public:
     repair_service(sharded<service::topology_state_machine>& tsm,


### PR DESCRIPTION
Consider this:

- n1 is a coordinator and schedules tablet repair
- n1 detects tablet repair failed, so it schedules tablet transition to end_repair state
- n1 loses leadership and n2 becomes the new topology coordinator
- n2 runs end_repair on the tablet with session_id=00000000-0000-0000-0000-000000000000
- when a new tablet repair is scheduled, it hangs since the lock is already taken because it was not removed in previous step

To fix, we use the global_tablet_id to index the lock instead of the session id.

In addition, we retry the repair_update_compaction_ctrl verb in case of error to ensure the verb is eventually executed.

Fixes #26346

The code in question is in 2025.4 only. The issue causes dead lock in some cases. We need to backport to 2025.4 branch. 