### PR TITLE
table: Do not move foreign string when writing snapshot

### DIFF
--- a/replica/table.cc
+++ b/replica/table.cc
@@ -3200,7 +3200,7 @@ db::replay_position table::highest_flushed_replay_position() const {
 }
 
 struct manifest_json : public json::json_base {
-    json::json_chunked_list<sstring> files;
+    json::json_chunked_list<std::string_view> files;
 
     manifest_json() {
         register_params();
@@ -3224,7 +3224,7 @@ table::seal_snapshot(sstring jsondir, std::vector<snapshot_file_set> file_sets) 
     manifest_json manifest;
     for (const auto& fsp : file_sets) {
         for (auto& rf : *fsp) {
-            manifest.files.push(std::move(rf));
+            manifest.files.push(std::string_view(rf));
         }
     }
     auto streamer = json::stream_object(std::move(manifest));


### PR DESCRIPTION
The table::seal_snapshot() accepts a vector of sstables filenames and writes them into manifest file. For that, it iterates over the vector and moves all filenames from it into the streamer object.

The problem is that the vector contains foreign pointers on sets with sstrings. Not only sets are foreign, sstrings in it are foreign too. It's not correct to std::move() them to local CPU.

The fix is to make streamer object work on string_view-s and populate it with non-owning references to the sstrings from aforementioned sets.

Appeared recently, no need to backport