### PR TITLE
topology coordinator: set session id for streaming at the correct time

### DIFF
--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -5263,7 +5263,6 @@ future<> storage_service::raft_rebuild(utils::optional_param sdc_param) {
 
         rtlogger.info("request rebuild for: {} source_dc={}", raft_server.id(), sdc_param);
         topology_mutation_builder builder(guard.write_timestamp());
-        builder.set_session(session_id(guard.new_group0_state_id()));
         sstring source_dc = sdc_param.value_or("");
         if (sdc_param.force() && !source_dc.empty()) {
             source_dc += ":force";

--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -3158,7 +3158,8 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
                         }
                     case topology_request::rebuild: {
                         topology_mutation_builder builder(node.guard.write_timestamp());
-                        builder.with_node(node.id)
+                        builder.set_session(session_id(node.guard.new_group0_state_id()))
+                               .with_node(node.id)
                                .set("node_state", node_state::rebuilding)
                                .del("topology_request");
                         co_await update_topology_state(take_guard(std::move(node)), {builder.build(), rtbuilder.build()},


### PR DESCRIPTION
Commit d3efb3ab6f5ab94dc added streaming session for rebuild, but it set the session and request submission time. The session should be set when request starts the execution, so this patch moved it to the correct place.

Fixes https://scylladb.atlassian.net/browse/CUSTOMER-106
Fixes https://github.com/scylladb/scylladb/issues/27804

Backport since rebuild api is broken without it.