### PR TITLE
test/raft: fix `test_joining_old_node_fails` flakiness

### DIFF
--- a/test/cluster/test_cluster_features.py
+++ b/test/cluster/test_cluster_features.py
@@ -146,13 +146,13 @@ async def test_joining_old_node_fails(manager: ManagerClient) -> None:
 
     # Try to add a node that doesn't support the feature - should fail
     new_server_info = await manager.server_add(start=False, property_file=servers[0].property_file())
-    await manager.server_start(new_server_info.server_id, expected_error="Feature check failed")
+    await manager.server_start(new_server_info.server_id, expected_error="Feature check failed|received notification of being banned from the cluster from")
 
     # Try to replace with a node that doesn't support the feature - should fail
     await manager.server_stop_gracefully(servers[0].server_id)
     replace_cfg = ReplaceConfig(replaced_id=servers[0].server_id, reuse_ip_addr=False, use_host_id=False)
     new_server_info = await manager.server_add(start=False, replace_cfg=replace_cfg, property_file=servers[0].property_file())
-    await manager.server_start(new_server_info.server_id, expected_error="Feature check failed")
+    await manager.server_start(new_server_info.server_id, expected_error="Feature check failed|received notification of being banned from the cluster from")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
When a node without the required feature attempts to join a Raft-based cluster with the feature enabled, there is a race between the join rejection response ("Feature check failed") and the ban notification ("received notification of being banned"). Depending on timing, either message may appear in the joining node's log.

This starts to happen after 39cec4a (which introduced informing the nodes about being banned).

Updated the test to accept both error messages as valid, making the test robust against this race condition, which is more likely in debug mode or under slow execution.

Fixes: scylladb/scylladb#27603

No backport: This failure is only present in master.