### PR TITLE
reader_concurrency_semaphore: add protection against negative count resource leaks

### DIFF
--- a/test/boost/test_config.yaml
+++ b/test/boost/test_config.yaml
@@ -38,7 +38,7 @@ custom_args:
     cql_query_test:
         - '-c2 -m2G --fail-on-abandoned-failed-futures=true'
     reader_concurrency_semaphore_test:
-        - '-c1 -m256M'
+        - '-c1 -m256M --logger-log-level testlog=trace:reader_concurrency_semaphore=trace'
     multishard_query_test:
         - '-c2 -m3G'
     cache_algorithm_test:


### PR DESCRIPTION
The semaphore has detection and protection against regular resource leaks, where some resources go unaccounted for and are not released by the time the semaphore is destroyed. There is no detection or protection against negative leaks: where resources are "made up" of thin air. This kind of leaks looks benign at first sight, a few extra resources won't hurt anyone so long as this is a small amount. But turns out that even a single extra count resource can defeat a very important anti-deadlock protection in can_admit_read(): the special case which admits a new permit regardless of memory resources, when all original count resources all available. This check uses ==, so if resource > original, the protection is defeated indefinitely. Instead of just changing == to >=, we add detection of such negative leaks to signal(), via on_internal_error_noexcept().
At this time I still don't now how this negative leak happens (the code doesn't confess), with this detection, hopefully we'll get a clue from tests or the field. Note that on_internal_error_noexcept() will not generate a coredump, unless ScyllaDB is explicitely configured to do so. In production, it will just generate an error log with a backtrace. The detection also clams the _resources to _initial_resources, to prevent any damage from the negativae leak.

I just noticed that there is no unit test for the deadlock protection described above, so one is added in this PR, even if only loosely related to the rest of the patch.

Fixes: SCYLLADB-163

Needs backport to all releases, we have observed this leak in the wild, causing repair deadlock.