### PR TITLE
docs: Amend limitations for keyspace RF changes

### DIFF
--- a/docs/cql/ddl.rst
+++ b/docs/cql/ddl.rst
@@ -365,7 +365,7 @@ Modifying a keyspace with tablets enabled is possible and doesn't require any sp
 
 - The replication factor (RF) can be increased or decreased by at most 1 at a time. To reach the desired RF value, modify the RF repeatedly.
 - The ``ALTER`` statement rejects the ``replication_factor`` tag. List the DCs explicitly when altering a keyspace. See :ref:`NetworkTopologyStrategy <replication-strategy>`.
-- If there's any other ongoing global topology operation, executing the ``ALTER`` statement will fail (with an explicit and specific error) and needs to be repeated.
+- An RF change cannot be requested while another RF change is pending for the same keyspace. Attempting to execute an ``ALTER`` statement in this scenario will fail with an explicit error. Wait for the ongoing RF change to complete before issuing another ``ALTER`` statement.
 - The ``ALTER`` statement may take longer than the regular query timeout, and even if it times out, it will continue to execute in the background.
 - The replication strategy cannot be modified, as keyspaces with tablets only support ``NetworkTopologyStrategy``.
 - The ``ALTER`` statement will fail if it would make the keyspace :term:`RF-rack-invalid <RF-rack-valid keyspace>`.


### PR DESCRIPTION
The doc about DDL statements claims that an `ALTER KEYSPACE` will fail in the presence of an ongoing global topology operation.

This limitation was specifically referring to RF changes, which Scylla implements as global topology requests (`keyspace_rf_change`), and it was true when it was first introduced (1b913dd880c) because there was no global topology request queue at that time, so only one ongoing global request was allowed in the cluster.

This limitation was lifted with the introduction of the global topology request queue (6489308ebc), and it was re-introduced again very recently (2e7ba1f8ce) in a slightly different form; it now applies only to RF changes (not to any request type) and only those that affect the same keyspace. None of these two changes were ever reflected in the doc.

Synchronize the doc with the current state.

Fixes #27776.

Needs to be backported to 2025.3 and 2025.4, but it must be done manually because the limitations are different due to the absence of 2e7ba1f8ce.