### PR TITLE
doc: audit: mention double audit sink in Enabling Audit section

### DIFF
--- a/docs/operating-scylla/security/auditing.rst
+++ b/docs/operating-scylla/security/auditing.rst
@@ -20,6 +20,7 @@ You can set the following options:
 * ``none`` - Audit is disabled (default).
 * ``table`` - Audit is enabled, and messages are stored in a Scylla table.
 * ``syslog`` - Audit is enabled, and messages are sent to Syslog.
+* ``syslog,table`` - Audit is enabled, and messages are stored in a Scylla table and sent to Syslog.
 
 Configuring any other value results in an error at Scylla startup.
 


### PR DESCRIPTION
Configuration of both table and syslog audit is possible since scylladb/scylladb#26613 was implemented. However, the "Enabling Audit" section of the documentation wasn't updated, which can be misleading.

Ref: scylladb/scylladb#26613

No backport, a documentation change needed for a feature that is only on `master`