### PR TITLE
Take into account current load when allocating tablets

### DIFF
--- a/test/boost/tablets_test.cc
+++ b/test/boost/tablets_test.cc
@@ -3906,6 +3906,7 @@ SEASTAR_THREAD_TEST_CASE(test_imbalance_in_hetero_cluster_with_two_tables) {
         auto ks_name = add_keyspace(e, {{topo.dc(), 3}}, 128);
         auto table1 = add_table(e, ks_name).get();
         load_stats.set_size(table1, 0);
+        load_stats.set_default_tablet_sizes(stm.get());
         testlog.info("Initial cluster ready");
 
         topo.add_i4i_large(rack1);
@@ -4111,6 +4112,51 @@ SEASTAR_THREAD_TEST_CASE(test_size_based_load_balancing_table_load) {
         check_balance();
 
     }, std::move(cfg)).get();
+}
+
+static future<> run_imbalance_when_creating_plenty_of_tables_test(bool rf_rack_valid_keyspaces) {
+    cql_test_config cfg{};
+    cfg.db_config->rf_rack_valid_keyspaces.set(std::move(rf_rack_valid_keyspaces));
+
+    return do_with_cql_env_thread([] (auto& e) {
+        topology_builder topo(e);
+
+        auto rack1 = topo.rack();
+        auto rack2 = topo.start_new_rack();
+        auto rack3 = topo.start_new_rack();
+
+        topo.add_i4i_2xlarge(rack1);
+        topo.add_i4i_2xlarge(rack2);
+        topo.add_i4i_2xlarge(rack3);
+
+        auto& stm = e.shared_token_metadata().local();
+        auto ks_name = add_keyspace(e, {{topo.dc(), 3}}, 1);
+
+        for (int _ : std::views::iota(1, 100)) {
+            add_table(e, ks_name, {{"min_per_shard_tablet_count", "10.0"}}).get();
+        }
+        testlog.info("Initial cluster ready");
+
+        {
+            load_sketch load(stm.get());
+            load.populate().get();
+
+            for (auto h: topo.hosts()) {
+                auto node_utilization = load.get_shard_minmax_tablet_count(h);
+                testlog.info("host {}: min={}, max={}", h, node_utilization.min(), node_utilization.max());
+                BOOST_REQUIRE_LT(node_utilization.max() - node_utilization.min(), 1.1);
+            }
+        }
+    }, std::move(cfg));
+}
+
+// Reproduces https://github.com/scylladb/scylladb/issues/27620
+SEASTAR_THREAD_TEST_CASE(test_imbalance_when_creating_plenty_of_tables_with_RF_rack_valid_keyspaces_enforced) {
+    run_imbalance_when_creating_plenty_of_tables_test(true).get();
+}
+
+SEASTAR_THREAD_TEST_CASE(test_imbalance_when_creating_plenty_of_tables_with_RF_rack_valid_keyspaces_disabled) {
+    run_imbalance_when_creating_plenty_of_tables_test(false).get();
 }
 
 SEASTAR_THREAD_TEST_CASE(test_per_shard_goal_mixed_dc_rf) {


### PR DESCRIPTION
Currently, tablet allocation intentionally ignores current load (introduced by the commit https://github.com/scylladb/scylladb/commit/1e407ab) which could cause identical shard selection when allocating a small number of tablets in the same topology. When a tablet allocator is asked to allocate N tablets (where N is smaller
than the number of shards on a node), it selects the first N lowest shards. If multiple such tables are created, each allocator run picks the same shards, leading to tablet imbalance across shards.

This change initializes the load sketch with the current shard load, scaled into the [0,1] range, ensuring allocation still remains even while starting from globally least-loaded shards.

Fixes https://github.com/scylladb/scylladb/issues/27620

Needs a backport to all 2025.x versions. In all of them we ignore  the current load.