### PR TITLE
.github/workflows/urgent_issue_reminder.yml: Potential fix for code scanning alert no. 149: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/urgent_issue_reminder.yml
+++ b/.github/workflows/urgent_issue_reminder.yml
@@ -6,6 +6,8 @@ on:
 
 jobs:
   reminder:
+    permissions:
+      issues: write
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/scylladb/scylladb/security/code-scanning/149](https://github.com/scylladb/scylladb/security/code-scanning/149)

To fix this, explicitly scope the `GITHUB_TOKEN` permissions for the workflow/job so it has only the minimum required privileges. The script needs to read and write issues (listing open issues and posting comments), so it requires `issues: write`. It does not need to modify repository contents, pull requests, or other resources, so all other permissions can be implicitly set to `none` by only specifying `issues: write`.

The best way to fix this without changing existing functionality is to add a `permissions` block scoped to the `reminder` job. This keeps the change localized and clear. Insert under `reminder:` and above `runs-on:`:

```yaml
permissions:
  issues: write
```

This will ensure the job’s `GITHUB_TOKEN` has only issue write access, while leaving the rest of the workflow unchanged. No imports or additional methods are required, since this is purely a YAML configuration change within `.github/workflows/urgent_issue_reminder.yml`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
