### PR TITLE
.github/workflows/read-toolchain.yaml: hardening for code scanning alert no. 146: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/read-toolchain.yaml
+++ b/.github/workflows/read-toolchain.yaml
@@ -10,6 +10,8 @@ on:
 jobs:
   read-toolchain:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       image: ${{ steps.read.outputs.image }}
     steps:


### PR DESCRIPTION
Hardening improvement for [https://github.com/scylladb/scylladb/security/code-scanning/146](https://github.com/scylladb/scylladb/security/code-scanning/146)

To fix the problem, add an explicit `permissions` block that grants only the minimal needed access to the `GITHUB_TOKEN`. This workflow merely checks out the repository and reads a file, so it only needs read access to repository contents.

The best fix without changing functionality is to add `permissions: contents: read` at the job level under `read-toolchain`. This keeps the restriction scoped only to this job and aligns exactly with CodeQL’s recommendation. Concretely, in `.github/workflows/read-toolchain.yaml`, insert a `permissions:` mapping between `runs-on: ubuntu-latest` (line 12) and `outputs:` (line 13):

- Add:
  ```yaml
  permissions:
    contents: read
  ```
- No new imports, methods, or additional definitions are required, since this is purely a workflow configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
