### PR TITLE
.github/workflows/docs-pr.yaml: Potential fix for code scanning alert no. 145: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docs-pr.yaml
+++ b/.github/workflows/docs-pr.yaml
@@ -2,6 +2,9 @@ name: "Docs / Build PR"
 # For more information,
 # see https://sphinx-theme.scylladb.com/stable/deployment/production.html#available-workflows
 
+permissions:
+  contents: read
+
 env:
   FLAG: ${{ github.repository == 'scylladb/scylla-enterprise' && 'enterprise' || 'opensource' }}
 


### PR DESCRIPTION
Potential fix for [https://github.com/scylladb/scylladb/security/code-scanning/145](https://github.com/scylladb/scylladb/security/code-scanning/145)

To fix this, explicitly declare minimal `GITHUB_TOKEN` permissions in the workflow. Since this workflow only needs to read the repository contents to check out the code, we can set `contents: read`. The cleanest approach is to add a `permissions` block at the workflow (root) level so it applies to all jobs, just below the `name` and comments and before `env`/`on`. This does not change functionality because all used actions (`actions/checkout`, `actions/setup-python`) work with read-only contents for PR builds.

Concretely:
- Edit `.github/workflows/docs-pr.yaml`.
- Insert:

```yaml
permissions:
  contents: read
```

after the initial header (e.g., after the comments or immediately after `name:`) and before the existing `env:` section. No imports or additional definitions are needed; this is purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
