### PR TITLE
.github/workflows/docs-pages.yaml: Potential fix for code scanning alert no. 144: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docs-pages.yaml
+++ b/.github/workflows/docs-pages.yaml
@@ -18,6 +18,8 @@ on:
 
 jobs:
   release:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
Potential fix for [https://github.com/scylladb/scylladb/security/code-scanning/144](https://github.com/scylladb/scylladb/security/code-scanning/144)

In general, the fix is to explicitly specify a `permissions` block for the workflow or for the individual job(s), so that the automatically generated `GITHUB_TOKEN` is restricted to the minimal scopes needed. This prevents the token from inheriting potentially broad default read-write permissions from the repository or organization.

For this workflow, the single `release` job checks out the repo, builds docs, and then deploys them via `./docs/_utils/deploy.sh` using `GITHUB_TOKEN`. The build steps only require read access to contents. The deploy step likely needs write privileges, either to push to a `gh-pages` branch (`contents: write`) or to manage GitHub Pages (`pages: write`, possibly `id-token: write` for OIDC-based deployments). Because we cannot see the `deploy.sh` implementation, the safest minimal explicit set that will not reduce existing functionality is to specify `contents: write` at the job level. This matches the prior implicit behavior while making the permissions explicit and satisfies CodeQL.

Concretely, in `.github/workflows/docs-pages.yaml`, under `jobs.release:` and before `runs-on: ubuntu-latest`, add a `permissions` block:

```yaml
jobs:
  release:
    permissions:
      contents: write
    runs-on: ubuntu-latest
    ...
```

No imports or additional definitions are needed; this is purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
