### PR TITLE
.github/workflows/backport-pr-fixes-validation.yaml: workflow does not contain permissions (Potential fix for code scanning alert no. 139 )

### DIFF
--- a/.github/workflows/backport-pr-fixes-validation.yaml
+++ b/.github/workflows/backport-pr-fixes-validation.yaml
@@ -8,6 +8,9 @@ on:
 jobs:
   check-fixes-prefix:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
     steps:
       - name: Check PR body for "Fixes" prefix patterns
         uses: actions/github-script@v7


### PR DESCRIPTION
Potential fix for [https://github.com/scylladb/scylladb/security/code-scanning/139](https://github.com/scylladb/scylladb/security/code-scanning/139)

To fix the problem, explicitly restrict the `GITHUB_TOKEN` permissions for this workflow/job so it has only what is needed. The script reads PR data and repository info (which is covered by `contents: read`/default read scopes) and posts a comment via `github.rest.issues.createComment`, which requires `issues: write`. No other write scopes (e.g., `contents: write`, `pull-requests: write`) are necessary.

The best fix without changing functionality is to add a `permissions` block scoped to this job (or at the workflow root). Since we only see a single job here, we’ll add it under `check-fixes-prefix`. Concretely, in `.github/workflows/backport-pr-fixes-validation.yaml`, between the `runs-on: ubuntu-latest` line (line 10) and `steps:` (line 11), add:

```yaml
    permissions:
      contents: read
      issues: write
```

This keeps the token minimally privileged while still allowing the script to create issue/PR comments.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
