### PR TITLE
.github/workflows/call_sync_milestone_to_jira.yml: Potential fix for code scanning alert no. 171: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/call_sync_milestone_to_jira.yml
+++ b/.github/workflows/call_sync_milestone_to_jira.yml
@@ -1,5 +1,7 @@
 name: Call Jira release creation for new milestone
 
+permissions: read-all
+
 on:
   milestone:
     types: [created]


### PR DESCRIPTION
Potential fix for [https://github.com/scylladb/scylladb/security/code-scanning/171](https://github.com/scylladb/scylladb/security/code-scanning/171)

In general, the fix is to introduce an explicit `permissions` block that restricts the `GITHUB_TOKEN` to the minimal access needed. For workflows that only react to events and call external systems (like Jira) using custom secrets, read-only or even no repository permissions are often sufficient.

For this specific workflow in `.github/workflows/call_sync_milestone_to_jira.yml`, the job only triggers a reusable workflow when a milestone is created and passes a Jira auth secret. There is no evidence that this caller workflow itself needs to write to the repository. A safe, minimal change is to set `permissions: read-all` at the workflow root (top-level, alongside `name` and `on`). This ensures that all jobs in this workflow, including the reusable workflow call, run with a `GITHUB_TOKEN` that only has read access to repository resources by default, without altering existing functionality.

Concretely:
- Edit `.github/workflows/call_sync_milestone_to_jira.yml`.
- Insert a `permissions:` block between `name: ...` and `on:` so that the workflow uses read-only permissions:
  ```yaml
  permissions:
    contents: read
  ```
  or, more broadly but still read-only:
  ```yaml
  permissions: read-all
  ```
- Since we cannot see what specific scopes the called workflow needs, `permissions: read-all` is a simple and safe baseline that still addresses the CodeQL warning by avoiding default write permissions, and does not require any imports or additional definitions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
