### PR TITLE
.github/workflows/trigger-scylla-ci.yaml: Potential fix for code scanning alert no. 169: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/trigger-scylla-ci.yaml
+++ b/.github/workflows/trigger-scylla-ci.yaml
@@ -1,4 +1,6 @@
 name: Trigger Scylla CI Route
+permissions:
+  contents: read
 
 on:
   issue_comment:


### PR DESCRIPTION
Potential fix for [https://github.com/scylladb/scylladb/security/code-scanning/169](https://github.com/scylladb/scylladb/security/code-scanning/169)

In general, the fix is to add an explicit `permissions:` block to the workflow (at the root level or per job) so that the `GITHUB_TOKEN` has only the minimal scopes needed. Since this job only reads event data and uses secrets to talk to Jenkins, we can restrict `GITHUB_TOKEN` to read‑only repository contents.

The single best fix here is to add a top‑level `permissions:` block right under the `name:` (and before `on:`) in `.github/workflows/trigger-scylla-ci.yaml`, setting `contents: read`. This applies to all jobs in the workflow, including `trigger-jenkins`, and does not alter any existing steps or logic. No additional imports or methods are needed, as this is purely a YAML configuration change for GitHub Actions.

Concretely, edit `.github/workflows/trigger-scylla-ci.yaml` to insert:

```yaml
permissions:
  contents: read
```

after line 1. No other lines in the file need to change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
