### PR TITLE
.github/workflows/call_jira_status_in_progress.yml: Potential fix for code scanning alert no. 138: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/call_jira_status_in_progress.yml
+++ b/.github/workflows/call_jira_status_in_progress.yml
@@ -6,6 +6,8 @@ on:
 
 jobs:
   call-jira-status-in-progress:
+    permissions:
+      contents: read
     uses: scylladb/github-automation/.github/workflows/main_update_jira_status_to_in_progress.yml@main
     secrets:
       caller_jira_auth: ${{ secrets.USER_AND_KEY_FOR_JIRA_AUTOMATION }}


### PR DESCRIPTION
Potential fix for [https://github.com/scylladb/scylladb/security/code-scanning/138](https://github.com/scylladb/scylladb/security/code-scanning/138)

To fix the problem, the workflow must explicitly set `permissions` so the `GITHUB_TOKEN` is restricted to the minimal scope required. This can be done at the root of the workflow (affecting all jobs) or on the specific job. Since this workflow has only one job, either is acceptable; defining it at the job level keeps the change tightly scoped and preserves behavior if other jobs are added later.

The best minimal fix without changing existing functionality is to add a `permissions` block to the `call-jira-status-in-progress` job. Because this job’s logic is entirely in the reusable workflow, we cannot know the exact permissions it needs; however, a safe, conservative starting point that satisfies the CodeQL rule is `permissions: { contents: read }`. If the reusable workflow requires additional scopes (e.g., to update issues or pull requests), those should be added explicitly later. Concretely, in `.github/workflows/call_jira_status_in_progress.yml`, under `jobs:`, within the `call-jira-status-in-progress:` job, insert a `permissions:` section (properly indented) before `uses:`.

No new imports or external methods are needed; this is purely a YAML configuration change within the workflow file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
