### PR TITLE
.github/workflows/call_jira_status_in_review.yml: Potential fix for code scanning alert no. 142: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/call_jira_status_in_review.yml
+++ b/.github/workflows/call_jira_status_in_review.yml
@@ -6,6 +6,8 @@ on:
 
 jobs:
   call-jira-status-in-review:
+    permissions:
+      contents: read
     uses: scylladb/github-automation/.github/workflows/main_update_jira_status_to_in_review.yml@main
     secrets:
       caller_jira_auth: ${{ secrets.USER_AND_KEY_FOR_JIRA_AUTOMATION }}


### PR DESCRIPTION
Potential fix for [https://github.com/scylladb/scylladb/security/code-scanning/142](https://github.com/scylladb/scylladb/security/code-scanning/142)

In general, the fix is to explicitly declare a `permissions` block so that the `GITHUB_TOKEN` used by this workflow has only the minimal scopes required. This can be done at the workflow root (applies to all jobs) or inside the specific job. Since this workflow has a single job that delegates to a reusable workflow, the safest, non‑breaking change is to set conservative permissions at the job level. Because we cannot see what the reusable workflow needs, the standard minimal starting point recommended by CodeQL and GitHub is `contents: read`, which is sufficient for most read-only operations while being much safer than inheriting potential write access.

Concretely, in `.github/workflows/call_jira_status_in_review.yml`, under the `call-jira-status-in-review` job and before `uses: ...`, add a `permissions:` block setting `contents: read`. This preserves existing behavior for secrets and the job call, but ensures `GITHUB_TOKEN` cannot be used for unintended write operations unless the called workflow explicitly requests more. No imports or additional methods are needed, just the YAML change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
