### PR TITLE
.github/workflows/trigger_jenkins.yaml: Potential fix for code scanning alert no. 147: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/trigger_jenkins.yaml
+++ b/.github/workflows/trigger_jenkins.yaml
@@ -1,5 +1,8 @@
 name: Trigger next gating
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/scylladb/scylladb/security/code-scanning/147](https://github.com/scylladb/scylladb/security/code-scanning/147)

To fix the problem, add an explicit `permissions:` block to the workflow (either at the top level or inside the `trigger-jenkins` job) that constrains the `GITHUB_TOKEN` to the minimal necessary privileges. This codifies least-privilege in the workflow itself instead of relying on repository or organization defaults.

The best minimal, non‑breaking change is to define a root‑level `permissions:` block with read‑only contents access because the job does not perform any write operations to the repository, nor does it interact with issues, pull requests, or other GitHub resources. A conservative, widely accepted baseline is `contents: read`. If later steps require more permissions, they can be added explicitly, but for this snippet, no such need is visible.

Concretely, in `.github/workflows/trigger_jenkins.yaml`, insert:

```yaml
permissions:
  contents: read
```

between the `name:` block and the `on:` block (e.g., after line 2). No additional methods, imports, or definitions are needed since this is a pure YAML configuration change and does not alter runtime behavior of the existing shell steps.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
