### PR TITLE
.github/workflows/docs-validate-metrics.yml: Potential fix for code scanning alert no. 167: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docs-validate-metrics.yml
+++ b/.github/workflows/docs-validate-metrics.yml
@@ -1,5 +1,8 @@
 name: Docs / Validate metrics
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/scylladb/scylladb/security/code-scanning/167](https://github.com/scylladb/scylladb/security/code-scanning/167)

To fix the problem, explicitly scope the GITHUB_TOKEN permissions for this workflow to the least privilege needed. Since the job only checks out code and runs a validation script, it should suffice to grant read-only access to repository contents.

The best minimal fix without changing existing functionality is to add a `permissions` block at the workflow root (top level, alongside `name` and `on`). This will apply to all jobs in this workflow (currently only `validate-metrics`) and restrict the GITHUB_TOKEN to `contents: read`. No other permissions appear necessary because there are no steps that push commits, modify issues, or interact with pull requests through the API.

Concretely:
- Edit `.github/workflows/docs-validate-metrics.yml`.
- After the `name: Docs / Validate metrics` line (line 1) and before the `on:` block (line 3), insert:

```yaml
permissions:
  contents: read
```

No imports or additional methods are required; this is purely a configuration change in the workflow file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
