### PR TITLE
fix: remove return from finally block in s3_proxy.py

### DIFF
--- a/test/pylib/s3_proxy.py
+++ b/test/pylib/s3_proxy.py
@@ -148,8 +148,7 @@ class InjectingHandler(BaseHTTPRequestHandler):
                 self.request.shutdown_request()
             except OSError:
                 pass
-            finally:
-                return
+            return
         code, error_name = self.get_retryable_http_codes()
         self.send_response(code)
         self.send_header('Content-Type', 'text/plain; charset=utf-8')


### PR DESCRIPTION
during any jenkins job that trigger `test.py` we get:
```
/jenkins/workspace/releng-testing/byo/byo_build_tests_dtest/scylla/test/pylib/s3_proxy.py:152: SyntaxWarning: 'return' in a 'finally' block
```

The 'return' statement in the finally block was causing a SyntaxWarning. Moving the return outside the finally block ensures proper exception handling while maintaining the intended behavior.

**Just a warning , no need for backport**