### PR TITLE
doc: Correct reference to C* issue in dev/audit.md

### DIFF
--- a/docs/dev/audit.md
+++ b/docs/dev/audit.md
@@ -1,6 +1,6 @@
 # Introduction
 
-Similar to the approach described in CASSANDRA-14471, we add the
+Similar to the approach described in CASSANDRA-12151, we add the
 concept of an audit specification.  An audit has a target (syslog or a
 table) and a set of events/actions that it wants recorded.  We
 introduce new CQL syntax for Scylla users to describe and manipulate


### PR DESCRIPTION
Fix reference to the source Cassandra issue.

It's not an official user documentation, so it's not worth to backport. 