### PR TITLE
build: support (and prefer) sccache as the compiler cache

### DIFF
--- a/rust/CMakeLists.txt
+++ b/rust/CMakeLists.txt
@@ -1,6 +1,13 @@
 find_program(CARGO cargo
   REQUIRED)
 
+# Set up RUSTC_WRAPPER for sccache support if configured
+if(Scylla_RUSTC_WRAPPER)
+  set(RUSTC_WRAPPER_ENV "RUSTC_WRAPPER=${Scylla_RUSTC_WRAPPER}")
+else()
+  set(RUSTC_WRAPPER_ENV "")
+endif()
+
 function(add_rust_library name)
   # used for profiles defined in Cargo.toml
   if(CMAKE_CONFIGURATION_TYPES)
@@ -16,7 +23,7 @@ function(add_rust_library name)
   set(library ${target_dir}/lib${name}.a)
   add_custom_command(
     OUTPUT ${library}
-    COMMAND ${CMAKE_COMMAND} -E env CARGO_BUILD_DEP_INFO_BASEDIR=. ${CARGO} build --locked --target-dir=${target_dir} --profile=${profile}
+    COMMAND ${CMAKE_COMMAND} -E env CARGO_BUILD_DEP_INFO_BASEDIR=. ${RUSTC_WRAPPER_ENV} ${CARGO} build --locked --target-dir=${target_dir} --profile=${profile}
     COMMAND ${CMAKE_COMMAND} -E copy ${target_dir}/${profile}/lib${name}.a ${library}
     DEPENDS Cargo.lock
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}

--- a/test/resource/wasm/rust/CMakeLists.txt
+++ b/test/resource/wasm/rust/CMakeLists.txt
@@ -3,6 +3,13 @@ find_program(CARGO cargo
 find_program(RUSTC rustc
   REQUIRED)
 
+# Set up RUSTC_WRAPPER for sccache support if configured
+if(Scylla_RUSTC_WRAPPER)
+  set(RUSTC_WRAPPER_ENV "RUSTC_WRAPPER=${Scylla_RUSTC_WRAPPER}")
+else()
+  set(RUSTC_WRAPPER_ENV "")
+endif()
+
 function(pick_rustc_target output_var candidates)
   execute_process(
     COMMAND
@@ -33,6 +40,7 @@ function(compile_rust_to_wasm target input)
   add_custom_command(
     OUTPUT ${output}
     COMMAND
+      ${CMAKE_COMMAND} -E env ${RUSTC_WRAPPER_ENV}
       ${CARGO} build
       --target=${target}
       --example=${basename}


### PR DESCRIPTION
Currently, we support ccache as the compiler cache. Since it is transparent, nothing
much is needed to support it.

This series adds support to sccache[1] and prefers it over ccache when it is installed.

sccache brings the following benefits over ccache:
1. Integrated distributed build support similar to distcc, but with automatic toolchain packaging and a scheduler
2. Rust support
3. C++20 modules (upcoming[2])

It is the C++20 modules support that motivates the series. C++20 modules have the potential to reduce
build times, but without a compiler cache and distributed build support, they come with too large
a penalty. This removes the penalty.

The series detects that sccache is installed, selects it if so (and if not overridden
by a new option), enables it for C++ and Rust, and disables ccache transparent
caching if sccache is selected.

Note: this series doesn't add sccache to the frozen toolchain or add dbuild support. That
is left for later.

[1] https://github.com/mozilla/sccache
[2] https://github.com/mozilla/sccache/pull/2516

Toolchain improvement, won't be backported.