### PR TITLE
test: pylib: resource_gather: don't take ownership of /sys/fs/cgroup under podman

### DIFF
--- a/test/pylib/resource_gather.py
+++ b/test/pylib/resource_gather.py
@@ -279,9 +279,9 @@ def setup_cgroup(is_required: bool) -> None:
                 check=True,
             )
 
-        if is_podman or is_docker:
-            cmd = ["chown", "-R", f"{getpass.getuser()}:{getpass.getuser()}", '/sys/fs/cgroup']
-            subprocess.run(["sudo"] + cmd if is_docker else cmd,check=True)
+        if is_docker:
+            cmd = ["sudo", "chown", "-R", f"{getpass.getuser()}:{getpass.getuser()}", '/sys/fs/cgroup']
+            subprocess.run(cmd, check=True)
 
         configured = False
         for directory in [CGROUP_INITIAL, CGROUP_TESTS]:


### PR DESCRIPTION

Under podman, we already own /sys/fs/cgroup. Run the chown command only under docker where the container does not map the host user to the container root user.

The chown process is sometimes observed to fail with EPERM (see issue). But it's not needed, so avoid it.

Fixes #27837.

Problem not observed in branches so far. Will backport if we see it (not unlikely).