### PR TITLE
checked-file: Implement experimental_list_directory()

### DIFF
--- a/utils/checked-file-impl.hh
+++ b/utils/checked-file-impl.hh
@@ -104,6 +104,18 @@ public:
             return get_file_impl(_file)->dma_read_bulk(offset, range_size, intent);
         });
     }
+
+    virtual coroutine::experimental::generator<directory_entry> experimental_list_directory() override {
+        try {
+            auto gen = get_file_impl(_file)->experimental_list_directory();
+            while (auto de = co_await gen()) {
+                co_yield *de;
+            }
+        } catch (...) {
+            _error_handler(std::current_exception());
+            throw;
+        }
+    }
 private:
     const io_error_handler& _error_handler;
     file _file;


### PR DESCRIPTION
The method in question returns coroutine generator that co_yields directory_entry-s. In case the method is not implemented, seastar creates a fallback generator, that calls existing subscription-based list_directory() and co_yields them. And since checked file doesn't yet have it, fallback generator is used, thus skipping the lower file yielding lister. Not nice.

This patch implements the generator lister for checked file, thus making full use of lower file generator lister too.

A side note. It's not enough to implement it like

    return do_io_check([] {
        return lower_file->experimental_list_directory();
    });

like list_directory() does, since io-checking will _not_ happen on directory reading itself, as it's supposed to.

This is the problem of the check_file::list_directory() implementation -- it only checks for exception when creating the subscription (and it really never happens), but reading the directory itself happens without io checks.

New feature, no need to backport