### PR TITLE
util: Remove lister::rmdir()

### DIFF
--- a/db/hints/manager.cc
+++ b/db/hints/manager.cc
@@ -26,6 +26,7 @@
 #include <seastar/core/smp.hh>
 #include <seastar/coroutine/exception.hh>
 #include <seastar/coroutine/parallel_for_each.hh>
+#include <seastar/util/file.hh>
 
 // Boost features.
 
@@ -899,7 +900,7 @@ future<> manager::migrate_ip_directories() {
     co_await coroutine::parallel_for_each(dirs_to_remove, [] (auto& directory) -> future<> {
         try {
             manager_logger.warn("Removing hint directory {}", directory.native());
-            co_await lister::rmdir(directory);
+            co_await seastar::recursive_remove_directory(directory);
         } catch (...) {
             on_internal_error(manager_logger,
                     seastar::format("Removing a hint directory has failed. Reason: {}", std::current_exception()));

--- a/sstables/sstable_directory.cc
+++ b/sstables/sstable_directory.cc
@@ -719,7 +719,7 @@ future<> sstable_directory::filesystem_components_lister::cleanup_column_family_
             fs::path dirpath = _directory / de->name;
             if (dirpath.extension().string() == tempdir_extension) {
                 dirlog.info("Found temporary sstable directory: {}, removing", dirpath);
-                futures.push_back(io_check([dirpath = std::move(dirpath)] () { return lister::rmdir(dirpath); }));
+                futures.push_back(io_check([dirpath = std::move(dirpath)] () { return seastar::recursive_remove_directory(dirpath); }));
             }
         }
         co_return futures;

--- a/utils/lister.cc
+++ b/utils/lister.cc
@@ -72,22 +72,6 @@ future<> lister::scan_dir(fs::path dir, lister::dir_entry_types type, lister::sh
     });
 }
 
-future<> lister::rmdir(fs::path dir) {
-    // first, kill the contents of the directory
-    return lister::scan_dir(dir, {}, show_hidden::yes, [] (fs::path parent_dir, directory_entry de) mutable {
-        fs::path current_entry_path(parent_dir / de.name.c_str());
-
-        if (de.type.value() == directory_entry_type::directory) {
-            return rmdir(std::move(current_entry_path));
-        } else {
-            return remove_file(current_entry_path.native());
-        }
-    }).then([dir] {
-        // ...then kill the directory itself
-        return remove_file(dir.native());
-    });
-}
-
 directory_lister::~directory_lister() {
     if (_gen) {
         on_internal_error(llogger, "directory_lister not closed when destroyed");

--- a/utils/lister.hh
+++ b/utils/lister.hh
@@ -87,14 +87,6 @@ public:
     }
 
     /**
-     * Removes the given directory with all its contents (like 'rm -rf <dir>' shell command).
-     *
-     * @param dir Directory to remove.
-     * @return A future that resolves when the operation is complete or an error occurs.
-     */
-    static future<> rmdir(fs::path dir);
-
-    /**
      * Constructor
      *
      * @param f A file instance for the directory to scan.


### PR DESCRIPTION
There's seastar helper that does the same, no need to carry yet another implementation

Code cleanup, no need to backport