### PR TITLE
tree: fix typos

### DIFF
--- a/db/batchlog_manager.cc
+++ b/db/batchlog_manager.cc
@@ -318,8 +318,8 @@ future<db::all_batches_replayed> db::batchlog_manager::replay_all_failed_batches
 
     std::unordered_map<int32_t, replay_stats> replay_stats_per_shard;
 
-    // Use a stable `now` accross all batches, so skip/replay decisions are the
-    // same accross a while prefix of written_at (accross all ids).
+    // Use a stable `now` across all batches, so skip/replay decisions are the
+    // same across a while prefix of written_at (across all ids).
     const auto now = db_clock::now();
 
     auto batch = [this, cleanup, limiter, schema, &all_replayed, &replay_stats_per_shard, now] (const cql3::untyped_result_set::row& row) -> future<stop_iteration> {

--- a/docs/operating-scylla/admin-tools/scylla-sstable.rst
+++ b/docs/operating-scylla/admin-tools/scylla-sstable.rst
@@ -667,7 +667,7 @@ write
 Writes an SStable based on a description of the content.
 The description can be provided in two formats: ``CQL`` and ``JSON``.
 The input format can be selected with the ``--input-format`` flag. Default is ``cql``.
-In both cases the input is expected to be provided via the file whoose path is passed to ``--input-file``.
+In both cases the input is expected to be provided via the file whose path is passed to ``--input-file``.
 
 CQL input format
 ~~~~~~~~~~~~~~~~

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -1369,7 +1369,7 @@ table::do_add_sstable_and_update_cache(compaction_group& cg, sstables::shared_ss
         if (trigger_compaction) {
             try_trigger_compaction(cg);
         }
-        // Reseting sstable ptr to inform the caller the sstable has been loaded successfully.
+        // Resetting sstable ptr to inform the caller the sstable has been loaded successfully.
         sst = nullptr;
     }), dht::partition_range::make({sst->get_first_decorated_key(), true}, {sst->get_last_decorated_key(), true}), [sst, schema = _schema] (const dht::decorated_key& key) {
         return sst->filter_has_key(sstables::key::from_partition_key(*schema, key.key()));
@@ -1413,7 +1413,7 @@ table::add_new_sstable_and_update_cache(sstables::shared_sstable new_sst,
         auto sstable_add_holder = cg.sstable_add_gate().hold();
 
         ret = ssts = co_await maybe_split_new_sstable(new_sst);
-        // on sucessful split, input sstable is unlinked.
+        // on successful split, input sstable is unlinked.
         new_sst = nullptr;
         for (auto& sst : ssts) {
             auto& cg = compaction_group_for_sstable(sst);
@@ -1436,7 +1436,7 @@ table::add_new_sstable_and_update_cache(sstables::shared_sstable new_sst,
             tlogger.error("Failed to load SSTable {} of origin {} due to {}, it will be unlinked...", new_sst->get_filename(), new_sst->get_origin(), ex);
             co_await new_sst->unlink();
         }
-        // on failure after sucessful split, sstables not attached yet will be unlinked
+        // on failure after successful split, sstables not attached yet will be unlinked
         co_await coroutine::parallel_for_each(ssts, [&ex] (sstables::shared_sstable sst) -> future<> {
             if (sst) {
                 tlogger.error("Failed to load SSTable {} of origin {} due to {}, it will be unlinked...", sst->get_filename(), sst->get_origin(), ex);
@@ -1454,7 +1454,7 @@ table::add_new_sstables_and_update_cache(std::vector<sstables::shared_sstable> n
     std::exception_ptr ex;
     std::vector<sstables::shared_sstable> ret;
 
-    // We rely on add_new_sstable_and_update_cache() to unlink the sstable feeded into it,
+    // We rely on add_new_sstable_and_update_cache() to unlink the sstable fed into it,
     // so the exception handling below will only have to unlink sstables not processed yet.
     try {
         for (auto& sst: new_ssts) {
@@ -3505,7 +3505,7 @@ future<table::snapshot_details> table::get_snapshot_details(fs::path snapshot_di
                 details.live += size;
                 continue;
             }
-            // If the number of linkes is greater than 1, it is still possible that the file is linked to another snapshot
+            // If the number of links is greater than 1, it is still possible that the file is linked to another snapshot
             // So check the datadir for the file too.
         } else {
             continue;

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -854,7 +854,7 @@ future<> storage_service::topology_state_load(state_change_hint hint) {
         }
     }
 
-    // Ban all left and ignord nodes. We do not allow them to go back online.
+    // Ban all left and ignored nodes. We do not allow them to go back online.
     co_await _messaging.local().ban_hosts(boost::join(topology.left_nodes, topology.ignored_nodes)
         | std::views::transform([] (auto id) { return locator::host_id{id.uuid()}; })
         | std::ranges::to<utils::chunked_vector<locator::host_id>>());


### PR DESCRIPTION
We get a warning about them under every single PR review. Resolve those that are indeed typos. There are some where the check is simply wrong, leave those as-is.

Typo fixes, no backport.