### PR TITLE
test: fix Python warnings in regular expressions

### DIFF
--- a/test/cluster/object_store/test_backup.py
+++ b/test/cluster/object_store/test_backup.py
@@ -531,7 +531,7 @@ async def do_abort_restore(manager: ManagerClient, object_storage):
         print(f"Restore task status on server {server.server_id}: {final_status}")
         assert (final_status is not None) and (final_status['state'] == 'failed')
     logs = [await manager.server_open_log(server.server_id) for server in servers]
-    await wait_for_first_completed([l.wait_for("Failed to handle STREAM_MUTATION_FRAGMENTS \(receive and distribute phase\) for .+: Streaming aborted", timeout=10) for l in logs])
+    await wait_for_first_completed([l.wait_for(r"Failed to handle STREAM_MUTATION_FRAGMENTS \(receive and distribute phase\) for .+: Streaming aborted", timeout=10) for l in logs])
 
 @pytest.mark.asyncio
 @pytest.mark.skip(reason="a very slow test (20+ seconds), skipping it")

--- a/test/cluster/test_major_compaction.py
+++ b/test/cluster/test_major_compaction.py
@@ -194,7 +194,7 @@ async def test_shutdown_drain_during_compaction(manager: ManagerClient):
         await stop_task
         # During shutdown, errors mentioning 'seastar::abort_requested_exception' is expected as we do abort the compaction midway.
         # Verify that the shutdown completed without any other unexpected errors
-        assert len(await log.grep(expr="ERROR .*", filter_expr=".* seastar::abort_requested_exception \(abort requested\)", from_mark=mark)) == 0
+        assert len(await log.grep(expr="ERROR .*", filter_expr=r".* seastar::abort_requested_exception \(abort requested\)", from_mark=mark)) == 0
 
         # For dropping the keyspace
         await manager.server_start(server.server_id)

--- a/test/cluster/test_tablets.py
+++ b/test/cluster/test_tablets.py
@@ -1534,7 +1534,7 @@ async def test_repair_with_invalid_session_id(manager: ManagerClient):
     [await manager.api.enable_injection(s.ip_addr, injection, one_shot=True) for s in servers]
     await manager.api.tablet_repair(servers[0].ip_addr, ks, "test", token)
 
-    matches = [await log.grep("std::runtime_error \(Session not found", from_mark=mark) for log, mark in zip(logs, marks)]
+    matches = [await log.grep(r"std::runtime_error \(Session not found", from_mark=mark) for log, mark in zip(logs, marks)]
     assert sum(len(x) for x in matches) > 0
 
 @pytest.mark.asyncio

--- a/test/cluster/test_tablets_cql.py
+++ b/test/cluster/test_tablets_cql.py
@@ -63,7 +63,7 @@ async def test_alter_dropped_tablets_keyspace(manager: ManagerClient) -> None:
     await injection_handler.message()
 
     matches = await leader_log_file.grep("topology change coordinator fiber got error "
-                                         f"data_dictionary::no_such_keyspace \(Can't find a keyspace {ks}\)")
+                                         fr"data_dictionary::no_such_keyspace \(Can't find a keyspace {ks}\)")
     assert not matches
 
     with pytest.raises(InvalidRequest, match=f"Can't ALTER keyspace {ks}, keyspace doesn't exist|Can't find a keyspace {ks}") as e:

--- a/test/cluster/test_tablets_lwt.py
+++ b/test/cluster/test_tablets_lwt.py
@@ -317,15 +317,15 @@ async def test_no_lwt_with_tablets_feature(manager: ManagerClient):
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 1}") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.test (key int PRIMARY KEY, val int)")
         await cql.run_async(f"INSERT INTO {ks}.test (key, val) VALUES(1, 0)")
-        with pytest.raises(InvalidRequest, match=f"{ks}\.test.*LWT is not yet supported with tablets"):
+        with pytest.raises(InvalidRequest, match=fr"{ks}\.test.*LWT is not yet supported with tablets"):
             await cql.run_async(f"INSERT INTO {ks}.test (key, val) VALUES(1, 1) IF NOT EXISTS")
         # The query is rejected during the execution phase,
         # so preparing the LWT query is expected to succeed.
         stmt = cql.prepare(
             f"UPDATE {ks}.test SET val = 1 WHERE KEY = ? IF EXISTS")
-        with pytest.raises(InvalidRequest, match=f"{ks}\.test.*LWT is not yet supported with tablets"):
+        with pytest.raises(InvalidRequest, match=fr"{ks}\.test.*LWT is not yet supported with tablets"):
             await cql.run_async(stmt, [1])
-        with pytest.raises(InvalidRequest, match=f"{ks}\.test.*LWT is not yet supported with tablets"):
+        with pytest.raises(InvalidRequest, match=fr"{ks}\.test.*LWT is not yet supported with tablets"):
             await cql.run_async(f"DELETE FROM {ks}.test WHERE key = 1 IF EXISTS")
         res = await cql.run_async(f"SELECT val FROM {ks}.test WHERE key = 1")
         assert res[0].val == 0

--- a/test/cqlpy/test_describe.py
+++ b/test/cqlpy/test_describe.py
@@ -800,7 +800,7 @@ def test_udt_sorting(scylla_only, cql, test_keyspace, random_seed):
                     if row.type == "type":
                         # Extract UDTs used in current UDT
                         # Names of all UDTs begin with `unique_name_prefix`
-                        for it in re.finditer(f"<({unique_name_prefix}[^\s\>]+)>", row.create_statement):
+                        for it in re.finditer(fr"<({unique_name_prefix}[^\s\>]+)>", row.create_statement):
                             assert f"{test_keyspace}.{it.group(1)}" in visited_udts
                         visited_udts.add(f"{row.keyspace_name}.{row.name}")
                 


### PR DESCRIPTION
Like C, Python supports some escape sequences in strings such as the familiar "\n" that converts to a newline character. Originally, when backslash was used before a random character, for example, "\.", Python used to just use these literal characters backslash and dot, in the string - and not make a fuss about it. This made it ok to use a string like "hi\.there" as a regular expression. We have a few instances of this in our Python tests.

But recent releases of Python started to produce ugly warnings about these cases. The error message looks like:

    SyntaxWarning: "\." is an invalid escape sequence. Such sequences
    will not work in the future. Did you mean "\\."? A raw string is
    also an option.

Indeed in most cases the easiest solution is to use a "raw string", a string literal preceded with r. For example, r"hi\.there". In such strings Python doesn't replace escape sequences like \n in the string, and also leaves the \. unchanged for the regular expression to see.

So in this patch we use raw strings in all places in test/ where Python warns have this problem.