### PR TITLE
db: system_keyspace: get_group0_history: unfreeze_gently

### DIFF
--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -55,6 +55,7 @@
 #include "message/shared_dict.hh"
 #include "replica/database.hh"
 #include "db/compaction_history_entry.hh"
+#include "mutation/async_utils.hh"
 
 #include <unordered_map>
 
@@ -2999,7 +3000,9 @@ future<mutation> system_keyspace::get_group0_history(sharded<replica::database>&
     SCYLLA_ASSERT(rs);
     auto& ps = rs->partitions();
     for (auto& p: ps) {
-        auto mut = p.mut().unfreeze(s);
+        // Note: we could decorate the frozen_mutation's key to check if it's the expected one
+        // but since this is a single partition table, we can just check after unfreezing the whole mutation.
+        auto mut = co_await unfreeze_gently(p.mut(), s);
         auto partition_key = value_cast<sstring>(utf8_type->deserialize(mut.key().get_component(*s, 0)));
         if (partition_key == GROUP0_HISTORY_KEY) {
             co_return mut;


### PR DESCRIPTION
Prevent stall when the group0 history is too long using unfreeze_gently
rather than the synchronous unfreeze() function

Fixes #27872

* The issue exists since the inception of this function (fad72daeb42) and it can be triggered with large number of tablets. Since the stall we saw are pretty significant (65ms), I suggest backporting to all versions that support tablets (2025.1 and up)