### PR TITLE
test/boost: fix flaky test_inject_future_disabled

### DIFF
--- a/test/boost/error_injection_test.cc
+++ b/test/boost/error_injection_test.cc
@@ -152,9 +152,14 @@ SEASTAR_TEST_CASE(test_inject_future_disabled) {
     utils::error_injection<true> errinj;
 
     auto start_time = steady_clock::now();
-    return errinj.inject("futid", sleep_msec).then([start_time] {
+    static constexpr milliseconds long_sleep_msec(10000);
+    return errinj.inject("futid", long_sleep_msec).then([start_time] {
         auto wait_time = steady_clock::now() - start_time;
-        BOOST_REQUIRE_LT(wait_time, sleep_msec);
+        // Because the injection "futid" was not enabled, we expect the
+        // sleep to have not happened. If we measure the time that passed,
+        // it's obviously not zero (especially in a slow debug build on a
+        // busy test machine), but certainly not the full long_sleep_msec.
+        BOOST_REQUIRE_LT(wait_time, long_sleep_msec);
         return make_ready_future<>();
     });
 }


### PR DESCRIPTION
The test boost/error_injection_test.cc::test_inject_future_disabled checks what happens when a sleep injection is *disabled*: The test has a 10-millisecond-sleep injection and measures how much it takes. The test expects it to take less than 10 milliseconds - in fact it should take almost zero. But this is not guaranteed - on a slow debug build and an overcommitted server this do-nothing injection can take some time, and in one run (#27798) it took 14 milliseconds - and the test failed.

The solution is easy - make the sleep-that-doesn't-happen much longer - e.g., 10 whole seconds. Since this sleep still doesn't happen, we expect the injection to return in less - much less - than 10 seconds. This 10 seconds is so ridiculously high we don't expect the do-nothing injection to take 10 seconds, not even a ridiculously busy test machine.

Fixes #27798

This patch fixes an old test so it makes sense to backport it, but just not worth it because the test failure seems to be extremely rare (we only saw it fail once).