### PR TITLE
scripts: restore PRODUCT import in scylla_util.py

### DIFF
--- a/dist/common/scripts/scylla_util.py
+++ b/dist/common/scripts/scylla_util.py
@@ -16,6 +16,7 @@ from datetime import datetime, timedelta
 
 import distro
 from scylla_sysconfdir import SYSCONFDIR
+from scylla_product import PRODUCT
 
 from multiprocessing import cpu_count
 


### PR DESCRIPTION
This commit restores the 'from scylla_product import PRODUCT' import that was incorrectly removed in commit 377c3ac072 (scripts: benign fixes flagged by CodeQL/PyLens). Which now failing all artifact tests

The import was flagged as unused by the static analyzer (CodeQL/PyLens), but this was a false positive. The PRODUCT variable is used by scylla_setup which imports everything from scylla_util using 'from scylla_util import *', and then uses PRODUCT in f-strings to dynamically generate package names:
  - f'{PRODUCT}-tools'
  - f'{PRODUCT}-node-exporter'

Without this import, scylla_setup fails with:
  NameError: name 'PRODUCT' is not defined

**The change only merged recently to master, not affecting other branches. No backport is needed**