### PR TITLE
scripts: fixes flagged by CodeQL/PyLens

### DIFF
--- a/dist/common/kernel_conf/scylla_tune_sched
+++ b/dist/common/kernel_conf/scylla_tune_sched
@@ -7,7 +7,6 @@
 # SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
 
 import os
-import sys
 import errno
 import logging
 

--- a/dist/common/scripts/scylla-blocktune
+++ b/dist/common/scripts/scylla-blocktune
@@ -8,7 +8,7 @@
 # SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
 
 import argparse
-from scylla_blocktune import *
+from scylla_blocktune import tune_yaml, tune_fs, tune_dev
 
 if __name__ == "__main__":
     ap = argparse.ArgumentParser('Tune filesystems for ScyllaDB')

--- a/dist/common/scripts/scylla_coredump_setup
+++ b/dist/common/scripts/scylla_coredump_setup
@@ -14,7 +14,9 @@ import subprocess
 import time
 import tempfile
 import shutil
-from scylla_util import *
+import re
+import distro
+from scylla_util import out, is_debian_variant, is_suse_variant, pkg_install, is_redhat_variant, systemd_unit, is_gentoo
 from subprocess import run
 
 

--- a/dist/common/scripts/scylla_cpuscaling_setup
+++ b/dist/common/scripts/scylla_cpuscaling_setup
@@ -10,9 +10,8 @@
 import os
 import sys
 import argparse
-import shlex
-import distro
-from scylla_util import *
+import shutil
+from scylla_util import is_debian_variant, pkg_install, systemd_unit, sysconfig_parser, is_gentoo, is_arch, is_amzn2, is_suse_variant, is_redhat_variant
 
 UNIT_DATA= '''
 [Unit]

--- a/dist/common/scripts/scylla_cpuset_setup
+++ b/dist/common/scripts/scylla_cpuset_setup
@@ -10,7 +10,7 @@
 import os
 import sys
 import argparse
-from scylla_util import *
+from scylla_util import is_container, sysconfig_parser
 
 if __name__ == '__main__':
     if not is_container() and os.getuid() > 0:

--- a/dist/common/scripts/scylla_dev_mode_setup
+++ b/dist/common/scripts/scylla_dev_mode_setup
@@ -10,7 +10,7 @@
 import os
 import sys
 import argparse
-from scylla_util import *
+from scylla_util import is_nonroot, is_container, etcdir, sysconfig_parser
 
 if __name__ == '__main__':
     if not is_nonroot() and not is_container() and os.getuid() > 0:

--- a/dist/common/scripts/scylla_fstrim
+++ b/dist/common/scripts/scylla_fstrim
@@ -8,8 +8,6 @@
 # SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
 
 import os
-import sys
-import yaml
 import argparse
 import subprocess
 

--- a/dist/common/scripts/scylla_fstrim_setup
+++ b/dist/common/scripts/scylla_fstrim_setup
@@ -8,9 +8,8 @@
 # SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
 
 import os
-import subprocess
-import shutil
-from scylla_util import *
+import sys
+from scylla_util import systemd_unit
 
 if __name__ == '__main__':
     if os.getuid() > 0:

--- a/dist/common/scripts/scylla_io_setup
+++ b/dist/common/scripts/scylla_io_setup
@@ -9,7 +9,7 @@
 
 import os
 import re
-from scylla_util import *
+from scylla_util import etcdir, datadir, bindir, scriptsdir, is_nonroot, is_container, is_developer_mode
 import resource
 import subprocess
 import argparse

--- a/dist/common/scripts/scylla_kernel_check
+++ b/dist/common/scripts/scylla_kernel_check
@@ -10,7 +10,7 @@
 import os
 import sys
 import shutil
-from scylla_util import *
+from scylla_util import pkg_install
 from subprocess import run, DEVNULL
 
 if __name__ == '__main__':

--- a/dist/common/scripts/scylla_logrotate
+++ b/dist/common/scripts/scylla_logrotate
@@ -7,9 +7,8 @@
 #
 # SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
 
-from pathlib import Path
 from datetime import datetime
-from scylla_util import *
+from scylla_util import scylladir_p
 
 if __name__ == '__main__':
     log = scylladir_p() / 'scylla-server.log'

--- a/dist/common/scripts/scylla_memory_setup
+++ b/dist/common/scripts/scylla_memory_setup
@@ -10,7 +10,7 @@
 import os
 import sys
 import argparse
-from scylla_util import *
+from scylla_util import etcdir_p
 
 if __name__ == '__main__':
     if os.getuid() > 0:

--- a/dist/common/scripts/scylla_ntp_setup
+++ b/dist/common/scripts/scylla_ntp_setup
@@ -11,10 +11,9 @@ import os
 import sys
 import argparse
 import re
-import distro
 import shutil
 
-from scylla_util import *
+from scylla_util import systemd_unit, is_redhat_variant, pkg_install
 from subprocess import run
 from pathlib import Path
 

--- a/dist/common/scripts/scylla_prepare
+++ b/dist/common/scripts/scylla_prepare
@@ -12,8 +12,10 @@ import sys
 import glob
 import platform
 import distro
+import re
+import traceback
 
-from scylla_util import *
+from scylla_util import sysconfig_parser, out, get_set_nic_and_disks_config_value, check_sysfs_numa_topology_is_valid, sysconfdir_p, scylla_excepthook, perftune_base_command
 from subprocess import run
 
 def get_cur_cpuset():

--- a/dist/common/scripts/scylla_raid_setup
+++ b/dist/common/scripts/scylla_raid_setup
@@ -9,7 +9,6 @@
 
 import os
 import argparse
-import distutils.util
 import pwd
 import grp
 import sys
@@ -18,11 +17,21 @@ import logging
 import pyudev
 import psutil
 import platform
+import shutil
 from pathlib import Path
-from scylla_util import *
-from subprocess import run, SubprocessError
+from scylla_util import is_unused_disk, out, pkg_install, systemd_unit, SystemdException, is_debian_variant, is_redhat_variant, is_offline
+from subprocess import run, SubprocessError, Popen
 
 LOGGER = logging.getLogger(__name__)
+
+def strtobool(val):
+    val = val.lower()
+    if val in ('y', 'yes', 't', 'true', 'on', '1'):
+        return 1
+    elif val in ('n', 'no', 'f', 'false', 'off', '0'):
+        return 0
+    else:
+        raise ValueError(f"invalid truth value {val!r}")
 
 class UdevInfo:
     def __init__(self, device_file):
@@ -145,7 +154,7 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     # Allow args.online_discard to be used as a boolean value
-    args.online_discard = distutils.util.strtobool(args.online_discard)
+    args.online_discard = strtobool(args.online_discard)
 
     root = args.root.rstrip('/')
     if args.volume_role == 'all':
@@ -227,7 +236,7 @@ if __name__ == '__main__':
                 with open(discard_path) as f:
                     discard = f.read().strip()
                 if discard != '0':
-                    proc = subprocess.Popen(['blkdiscard', disk])
+                    proc = Popen(['blkdiscard', disk])
                     procs.append(proc)
         for proc in procs:
             proc.wait()

--- a/dist/common/scripts/scylla_rsyslog_setup
+++ b/dist/common/scripts/scylla_rsyslog_setup
@@ -8,8 +8,9 @@
 # SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
 
 import os
+import sys
 import argparse
-from scylla_util import *
+from scylla_util import systemd_unit
 
 def update_rsysconf(rsyslog_server):
     if ':' not in rsyslog_server:

--- a/dist/common/scripts/scylla_selinux_setup
+++ b/dist/common/scripts/scylla_selinux_setup
@@ -9,8 +9,7 @@
 
 import os
 import sys
-import subprocess
-from scylla_util import *
+from scylla_util import is_redhat_variant, out, sysconfig_parser
 from subprocess import run
 
 if __name__ == '__main__':

--- a/dist/common/scripts/scylla_setup
+++ b/dist/common/scripts/scylla_setup
@@ -12,11 +12,13 @@ import sys
 import argparse
 import glob
 import shutil
-import io
 import stat
-import distro
-from scylla_util import *
+import re
+from scylla_util import colorprint, is_valid_nic, scylladir_p, is_offline, is_debian_variant, is_redhat_variant, is_suse_variant, is_gentoo, out, is_unused_disk, scriptsdir, is_nonroot, sysconfdir_p, sysconfig_parser, systemd_unit, swap_exists, get_product, etcdir
 from subprocess import run, DEVNULL
+
+PRODUCT = get_product(etcdir())
+
 
 interactive = False
 HOUSEKEEPING_TIMEOUT = 60
@@ -294,11 +296,9 @@ if __name__ == '__main__':
                     sys.exit(1)
 
     disks = args.disks
-    nic = args.nic
     set_nic_and_disks = args.setup_nic_and_disks
     swap_directory = args.swap_directory
     swap_size = args.swap_size
-    ec2_check = not args.no_ec2_check
     kernel_check = not args.no_kernel_check
     verify_package = not args.no_verify_package
     enable_service = not args.no_enable_service

--- a/dist/common/scripts/scylla_stop
+++ b/dist/common/scripts/scylla_stop
@@ -9,7 +9,7 @@
 
 import os
 import sys
-from scylla_util import *
+from scylla_util import sysconfig_parser, sysconfdir_p
 from subprocess import run
 
 if __name__ == '__main__':

--- a/dist/common/scripts/scylla_swap_setup
+++ b/dist/common/scripts/scylla_swap_setup
@@ -12,7 +12,7 @@ import sys
 import argparse
 import psutil
 from pathlib import Path
-from scylla_util import *
+from scylla_util import swap_exists, out, systemd_unit
 from subprocess import run
 
 def GB(n):

--- a/dist/common/scripts/scylla_sysconfig_setup
+++ b/dist/common/scripts/scylla_sysconfig_setup
@@ -10,9 +10,8 @@
 import os
 import sys
 import argparse
-import subprocess
 import re
-from scylla_util import *
+from scylla_util import sysconfig_parser, sysconfdir_p, get_set_nic_and_disks_config_value, is_valid_nic, check_sysfs_numa_topology_is_valid, out, perftune_base_command, hex2list
 from subprocess import run
 
 def bool2str(val):

--- a/dist/common/scripts/scylla_util.py
+++ b/dist/common/scripts/scylla_util.py
@@ -3,12 +3,9 @@
 # SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
 
 import configparser
-import glob
 import io
 import os
 import re
-import shlex
-import shutil
 import subprocess
 import yaml
 import sys
@@ -19,7 +16,6 @@ from datetime import datetime, timedelta
 
 import distro
 from scylla_sysconfdir import SYSCONFDIR
-from scylla_product import PRODUCT
 
 from multiprocessing import cpu_count
 
@@ -338,7 +334,7 @@ def apt_install(pkg, offline_exit=True):
         if apt_is_updated():
             break
         try:
-            res = run('apt-get update', shell=True, check=True, stderr=PIPE, encoding='utf-8')
+            run('apt-get update', shell=True, check=True, stderr=PIPE, encoding='utf-8')
             break
         except CalledProcessError as e:
             print(e.stderr, end='')
@@ -519,3 +515,12 @@ class sysconfig_parser:
     def commit(self):
         with open(self._filename, 'w') as f:
             f.write(self._data)
+
+def get_product(dir):
+    if dir is None:
+        dir = etcdir()
+    try:
+        with open(os.path.join(dir, 'SCYLLA-PRODUCT-FILE')) as f:
+            return f.read().strip()
+    except FileNotFoundError:
+        return 'scylla'

--- a/dist/docker/docker-entrypoint.py
+++ b/dist/docker/docker-entrypoint.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-import os
 import sys
 import signal
 import subprocess

--- a/install.sh
+++ b/install.sh
@@ -273,8 +273,6 @@ fi
 # change directory to the package's root directory
 cd "$(dirname "$0")"
 
-product="$(cat ./SCYLLA-PRODUCT-FILE)"
-
 if [ -z "$p11_trust_paths" ]; then
     # our package builder is cross-distro, so we cannot detect distro by os-release
     if $packaging; then
@@ -515,11 +513,6 @@ install -m755 bin/nodetool "$rprefix/bin"
 
 SBINFILES=$(cd dist/common/scripts/; ls scylla_*setup node_health_check scylla_kernel_check)
 SBINFILES+=" $(cd seastar/scripts; ls seastar-cpu-map.sh)"
-
-cat << EOS > "$rprefix"/scripts/scylla_product.py
-PRODUCT="$product"
-EOS
-chmod 644 "$rprefix"/scripts/scylla_product.py
 
 if ! $nonroot && ! $without_systemd; then
     install -d -m755 "$retc"/systemd/system/scylla-server.service.d

--- a/scripts/base36-uuid.py
+++ b/scripts/base36-uuid.py
@@ -205,7 +205,7 @@ def main():
     default_fields = ['date', 'decimicro_seconds', 'lsb']
     parser.add_argument('--field',
                         action='append',
-                        choices=['lsb', 'msb', 'date', 'decimicro_seconds' 'time', 'node'],
+                        choices=['lsb', 'msb', 'date', 'decimicro_seconds', 'time', 'node'],
                         help='Field to be printed (default: {})'.format(
                             ", ".join(default_fields)),
                         dest='fields')

--- a/tools/scyllatop/scyllatop.py
+++ b/tools/scyllatop/scyllatop.py
@@ -54,7 +54,7 @@ if __name__ == '__main__':
                              'Keyboard shortcuts: S - simple view, M - aggregate over multiple cores, Q -quits',
                              '',
                              'By default it would work with the Prometheus API and does not require configuration.',
-                             'For collectd, you need to configure the unix-sock plugin for collectd'
+                             'For collectd, you need to configure the unix-sock plugin for collectd',
                              'before you can use this, use the --print-config option to give you a configuration example',
                              'enjoy!'])
     parser = argparse.ArgumentParser(description=description)


### PR DESCRIPTION
Unused imports, unused variables and such.
Initially, there were no functional changes, just to get rid of some standard CodeQL warnings.

I've then broken the CI, as apparently there's a install time(!?) Python script creation for the sole purpose of product naming. I changed it - we have it in etcdir, as SCYLLA-PRODUCT-FILE. So added (copied from a different script) a get_product() helper function in scylla_util.py and used it instead.

While at it, also fixed the too broad import from scylla_util, which 'forced' me to also fix other specific imports (such as shutil).

Improvement - no need to backport.