### PR TITLE
doc: fix the syntax of internal links

### DIFF
--- a/docs/getting-started/index.rst
+++ b/docs/getting-started/index.rst
@@ -59,4 +59,5 @@ Getting Started
   
   * `Build an IoT App with sensor simulator and a REST API <https://iot.scylladb.com/stable/>`_ - ScyllaDB Tutorial
   * `Implement CRUD operations with a TODO App <https://github.com/scylladb/scylla-cloud-getting-started/>`_ - ScyllaDB Cloud Tutorial
-  * `Build a machine learning (ML) feature store with ScyllaDB <https://feature-store.scylladb.com/stable/>`_ - ScyllaDB Cloud Tutorial  ` <>`_
+  * `Build a machine learning (ML) feature store with ScyllaDB <https://feature-store.scylladb.com/stable/>`_ - ScyllaDB Cloud Tutorial
+  

--- a/docs/kb/consistency.rst
+++ b/docs/kb/consistency.rst
@@ -83,7 +83,7 @@ Additional References
 
 * `Jepsen and ScyllaDB: Putting Consistency to the Test blog post <https://www.scylladb.com/2020/12/23/jepsen-and-scylla-putting-consistency-to-the-test/>`_ 
 * `Nauto: Achieving Consistency in an Eventually Consistent Environment blog post <https://www.scylladb.com/2020/02/20/nauto-achieving-consistency-in-an-eventually-consistent-environment/>`_ 
-* `Consistency Levels documentation <https://docs.scylladb.com/manual/stable/cql/consistency.html>`_ 
+* :doc:`Consistency Levels documentation </cql/consistency/>`
 * `High Availability lesson on ScyllaDB University <https://university.scylladb.com/courses/scylla-essentials-overview/lessons/high-availability/>`_ 
 * `Lightweight Transactions lesson on ScyllaDB University <https://university.scylladb.com/courses/data-modeling/lessons/lightweight-transactions/>`_ 
 * `Getting the Most out of Lightweight Transactions in ScyllaDB blog post <https://www.scylladb.com/2020/07/15/getting-the-most-out-of-lightweight-transactions-in-scylla/>`_ 

--- a/docs/kb/tombstones-flush.rst
+++ b/docs/kb/tombstones-flush.rst
@@ -38,7 +38,7 @@ Steps:
 
 4. Run compaction (this will remove big partitions with tombstones from specified table)
 
-.. note:: By default, major compaction runs on all the keyspaces and tables, so if we want to specyfy e.g. only one table, we should point at it using arguments: ``<keyspace>.<mytable>``. For more information, please refer to `this article <https://docs.scylladb.com/operating-scylla/nodetool-commands/compact/>`_.
+.. note:: By default, major compaction runs on all the keyspaces and tables, so if we want to specyfy e.g. only one table, we should point at it using arguments: ``<keyspace>.<mytable>``. For more information, please see :doc:`Nodetool compact </operating-scylla/nodetool-commands/compact/>`.
 
 .. code-block:: sh
    

--- a/docs/operating-scylla/admin-tools/scylla-sstable.rst
+++ b/docs/operating-scylla/admin-tools/scylla-sstable.rst
@@ -860,7 +860,7 @@ Alternatively, you can provide each key-value pair via a separate ``--script-arg
 
 Command line arguments will be received by the :ref:`consume_stream_start() <scylla-consume-stream-start-method>` API method.
 
-See the `scripting API </operating-scylla/admin-tools/scylla-sstable-script-api/>`_ for more details.
+See the :doc:`scripting API </operating-scylla/admin-tools/scylla-sstable-script-api/>` for more details.
 
 Examples
 ~~~~~~~~
@@ -870,7 +870,7 @@ You can find example scripts at https://github.com/scylladb/scylladb/tree/master
 upgrade
 ^^^^^^^
 
-Offline, scylla-sstable variant of `nodetool upgradesstables </operating-scylla/nodetool-commands/upgradesstables/>`_.
+Offline, scylla-sstable variant of :doc:`nodetool upgradesstables </operating-scylla/nodetool-commands/upgradesstables/>`.
 Rewrites the input SSTable(s) to the latest supported version and latest schema version.
 The SSTable version to be used can be overridden with the ``--version`` flag, allowing for switching sstables between all versions supported for writing (some SSTable versions are supported for reading only).
 

--- a/docs/operating-scylla/diagnostics.rst
+++ b/docs/operating-scylla/diagnostics.rst
@@ -11,7 +11,7 @@ Logs
 
 The most obvious source of information to find out more about why ScyllaDB is misbehaving.
 On production systems, ScyllaDB logs to syslog; thus logs can usually be viewed via ``journalctl``.
-See `Logging </getting-started/logging/>`_ on more information on how to access the logs.
+See :doc:`Logging </getting-started/logging/>` on more information on how to access the logs.
 
 
 ScyllaDB has the following log levels: ``trace``, ``debug``, ``info``, ``warn``, ``error``.
@@ -64,21 +64,21 @@ Tracing
 Tracing allows you to retrieve the internal log of events happening in the context of a single query.
 Therefore, tracing is only useful to diagnose problems related to a certain query and cannot be used to diagnose generic problems.
 That said, when it comes to diagnosing problems with a certain query, tracing is an excellent tool, allowing you to have a peek at what happens when that query is processed, including the timestamp of each event.
-For more details, see `Tracing </using-scylla/tracing>`_.
+For more details, see :doc:`Tracing </using-scylla/tracing>`.
 
 Nodetool
 --------
 
 Although ``nodetool`` is primarily an administration tool, it has various commands that retrieve and display useful information about the state of a certain ScyllaDB node.
 Look for commands with "stats", "info", "describe", "get", "histogram" in their names.
-For a comprehensive list of all available nodetool commands, see the `Nodetool Reference </operating-scylla/nodetool>`_.
+For a comprehensive list of all available nodetool commands, see the :doc:`Nodetool Reference </operating-scylla/nodetool>`.
 
 REST API
 --------
 
 ScyllaDB has a REST API which is a superset of all ``nodetool`` commands, in the sense that it is the backend serving all of them.
 It has many more endpoints, many of which can supply valuable information about the internal state of ScyllaDB.
-For more information, see `REST API </operating-scylla/rest>`_.
+For more information, see :doc:`REST API </operating-scylla/rest>`.
 
 System Tables
 -------------
@@ -102,9 +102,9 @@ Other Tools
 ScyllaDB has various other tools, mainly to work with sstables.
 If you are diagnosing a problem that is related to sstables misbehaving or being corrupt, you may find these useful:
 
-* `sstabledump </operating-scylla/admin-tools/sstabledump/>`_
-* `ScyllaDB SStable </operating-scylla/admin-tools/scylla-sstable/>`_
-* `ScyllaDB Types </operating-scylla/admin-tools/scylla-types/>`_
+* :doc:`sstabledump </operating-scylla/admin-tools/sstabledump/>`
+* :doc:`ScyllaDB SStable </operating-scylla/admin-tools/scylla-sstable/>`
+* :doc:`ScyllaDB Types </operating-scylla/admin-tools/scylla-types/>`
 
 GDB
 ---


### PR DESCRIPTION
Some internal links had the wrong syntax: they were formatted as external links.
As a result, they redirected the user to the outdated Open Source documentation.
This PR fixes that bug.

Fixes https://github.com/scylladb/scylladb/issues/25899

This PR should be backported to all supported Source Available versions in this repo, as the links are broken in all versions.