### PR TITLE
test/alternator: fix typo in test_returnvalues.py

### DIFF
--- a/test/alternator/test_returnvalues.py
+++ b/test/alternator/test_returnvalues.py
@@ -155,11 +155,11 @@ def test_delete_item_returnvalues(test_table_s):
     # Other ReturnValue options - UPDATED_OLD, ALL_NEW, UPDATED_NEW,
     # are supported by other operations but not by PutItem:
     with pytest.raises(ClientError, match='ValidationException'):
-        test_table_s.delete_item(Key={'p': p}, ReturnValues='UPDATE_OLD')
+        test_table_s.delete_item(Key={'p': p}, ReturnValues='UPDATED_OLD')
     with pytest.raises(ClientError, match='ValidationException'):
         test_table_s.delete_item(Key={'p': p}, ReturnValues='ALL_NEW')
     with pytest.raises(ClientError, match='ValidationException'):
-        test_table_s.delete_item(Key={'p': p}, ReturnValues='UPDATE_NEW')
+        test_table_s.delete_item(Key={'p': p}, ReturnValues='UPDATED_NEW')
     # Also, obviously, a non-supported setting "DOG" also returns in error:
     with pytest.raises(ClientError, match='ValidationException'):
         test_table_s.delete_item(Key={'p': p}, ReturnValues='DOG')


### PR DESCRIPTION
Different DynamoDB operations have different settings allowed for their "ReturnValues" argument. In particular, some operations allow ReturnValues=UPDATED_OLD but the DeleteItem operation *does not*.

We have a test, test_delete_item_returnvalues, aimed to verify this but it had a typo and didn't actually check "UPDATED_OLD". This patch fixes this typo.

The test still passes because the code itself (executor.cc, delete_item_operation's constructor) has the correct check - it was just the test that was wrong.
