### PR TITLE
tools: toolchain: dbuild: bind-mount full ~/.cache to container

### DIFF
--- a/tools/toolchain/dbuild
+++ b/tools/toolchain/dbuild
@@ -76,7 +76,7 @@ ENVIRONMENT
 
     SCYLLADB_DBUILD this variable, which can be a string or a bash
                     array, is prepended to the parmeters passed to
-                    docker. This can be used to mount the ccache
+                    docker. This can be used to mount old-style ccache
                     directory (~/.ccache) and set up environment
                     variables (e.g. CCACHE_PREFIX)
 
@@ -144,7 +144,9 @@ if [[ -z "$CARGO_HOME" ]]; then
 fi
 
 export XDG_CACHE_HOME="${XDG_CACHE_HOME:-$HOME/.cache}"
-mkdir -p "$XDG_CACHE_HOME/scylladb"
+export XDG_CONFIG_HOME="${XDG_CONFIG_HOME:-$HOME/.config}"
+mkdir -p "$XDG_CACHE_HOME"
+mkdir -p "$XDG_CONFIG_HOME"
 
 is_podman="$($tool --help | grep -o podman)"
 
@@ -252,7 +254,9 @@ docker_common_args+=(
        --env CARGO_HOME \
        -v "${CARGO_HOME}:${CARGO_HOME}" \
        --env XDG_CACHE_HOME \
-       -v "${XDG_CACHE_HOME}/scylladb:${XDG_CACHE_HOME}/scylladb" \
+       -v "${XDG_CACHE_HOME}:${XDG_CACHE_HOME}" \
+       --env XDG_CONFIG_HOME \
+       -v "${XDG_CONFIG_HOME}:${XDG_CONFIG_HOME}" \
        -w "$PWD" \
        -e HOME="$HOME" \
        --env DBUILD_TOOLCHAIN=1 \


### PR DESCRIPTION
In afb96b6387200436ced, we added support for sccache. As a side effect it changed the method of invoking ccache from transparent via PATH (if it contains /usr/lib64/ccache) to explicit, by changing the compiler command line from 'clang++' (which may or may not resolve the the ccache binary) to 'ccache /usr/local/bin/clang++', which always invokes ccache.

In the default dbuild configuration, PATH does not contain /usr/lib64/ccache, so ccache isn't invoked by default. Users can change this via the SCYLLADB_DBUILD environment variable.

As a result of ccache being suddenly enabled for dbuild builds, ccache will now attempt to create ~/.cache/ccache. Under docker, this does not work, because we bind-mount ~/.cache/dbuild. Docker will create the intermediate ~/.cache, but under the root user, not $USER. The intermediate directory being root-owned prevents ~/.cache/ccache from being created.

Under podman, this does work, because everything runs under the container's root user.

The fix is to bind-mount the entire ~/.ccache into the container. This not only lets ccache create the directory, it will also find an existing ~/.cache/ccache directory and use it, enabling reuse across invocations.

Since ccache will now respect configuration changes without access to its configuration file (notably, the maximum cache size), we also bind-mount ~/.config.

Note that the ccache directory used to be ~/.ccache, but was later changed. Had the author known, we would have bind-mounted ~/.cache much earlier.

Fixes #27919.

Fix for a recent bug, not present in branches, so not marking for backport.