### PR TITLE
treewide: #include Seastar headers with angle brackets

### DIFF
--- a/cdc/split.cc
+++ b/cdc/split.cc
@@ -15,7 +15,7 @@
 #include "mutation/tombstone.hh"
 #include "schema/schema.hh"
 
-#include "seastar/core/sstring.hh"
+#include <seastar/core/sstring.hh>
 #include "types/concrete_types.hh"
 #include "types/types.hh"
 #include "types/user.hh"

--- a/cql3/statements/alter_keyspace_statement.cc
+++ b/cql3/statements/alter_keyspace_statement.cc
@@ -19,7 +19,7 @@
 #include "locator/abstract_replication_strategy.hh"
 #include "mutation/canonical_mutation.hh"
 #include "prepared_statement.hh"
-#include "seastar/coroutine/exception.hh"
+#include <seastar/coroutine/exception.hh>
 #include "service/migration_manager.hh"
 #include "service/storage_proxy.hh"
 #include "service/topology_mutation.hh"

--- a/cql3/statements/ks_prop_defs.cc
+++ b/cql3/statements/ks_prop_defs.cc
@@ -8,8 +8,8 @@
  * SPDX-License-Identifier: (LicenseRef-ScyllaDB-Source-Available-1.0 and Apache-2.0)
  */
 
-#include "seastar/core/format.hh"
-#include "seastar/core/sstring.hh"
+#include <seastar/core/format.hh>
+#include <seastar/core/sstring.hh>
 #include "utils/assert.hh"
 #include "cql3/statements/ks_prop_defs.hh"
 #include "cql3/statements/request_validations.hh"

--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -57,7 +57,7 @@
 #include "locator/network_topology_strategy.hh"
 #include "mutation/mutation.hh"
 #include "mutation/mutation_partition.hh"
-#include "seastar/core/on_internal_error.hh"
+#include <seastar/core/on_internal_error.hh>
 #include "service/migration_manager.hh"
 #include "service/raft/raft_group0_client.hh"
 #include "service/storage_proxy.hh"

--- a/db/view/view_building_worker.hh
+++ b/db/view/view_building_worker.hh
@@ -17,7 +17,7 @@
 #include "locator/abstract_replication_strategy.hh"
 #include "locator/tablets.hh"
 #include "raft/raft.hh"
-#include "seastar/core/gate.hh"
+#include <seastar/core/gate.hh>
 #include "db/view/view_building_state.hh"
 #include "sstables/shared_sstable.hh"
 #include "utils/UUID.hh"

--- a/index/secondary_index_manager.hh
+++ b/index/secondary_index_manager.hh
@@ -15,8 +15,8 @@
 #include "data_dictionary/data_dictionary.hh"
 #include "cql3/statements/index_target.hh"
 #include "cql3/statements/index_prop_defs.hh"
-#include "seastar/core/metrics.hh"
-#include "seastar/core/shared_ptr.hh"
+#include <seastar/core/metrics.hh>
+#include <seastar/core/shared_ptr.hh>
 #include "utils/estimated_histogram.hh"
 
 #include <string_view>

--- a/service/direct_failure_detector/failure_detector.cc
+++ b/service/direct_failure_detector/failure_detector.cc
@@ -6,7 +6,7 @@
  * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
  */
 
-#include "seastar/core/scheduling.hh"
+#include <seastar/core/scheduling.hh>
 #include "utils/assert.hh"
 #include <unordered_set>
 

--- a/service/migration_manager.cc
+++ b/service/migration_manager.cc
@@ -18,7 +18,7 @@
 #include "locator/host_id.hh"
 #include "schema/schema_registry.hh"
 #include "service/migration_manager.hh"
-#include "seastar/core/on_internal_error.hh"
+#include <seastar/core/on_internal_error.hh>
 #include "service/storage_proxy.hh"
 #include "service/raft/group0_state_machine.hh"
 

--- a/service/raft/raft_group_registry.cc
+++ b/service/raft/raft_group_registry.cc
@@ -16,7 +16,7 @@
 #include "idl/raft.dist.hh"
 #include "utils/composite_abort_source.hh"
 #include "utils/error_injection.hh"
-#include "seastar/core/shared_future.hh"
+#include <seastar/core/shared_future.hh>
 
 #include <chrono>
 #include <seastar/core/coroutine.hh>

--- a/test/boost/bti_index_test.cc
+++ b/test/boost/bti_index_test.cc
@@ -16,10 +16,10 @@
 #include <generator>
 #include <seastar/testing/thread_test_case.hh>
 #include <seastar/testing/test_case.hh>
-#include "seastar/core/fstream.hh"
-#include "seastar/core/seastar.hh"
-#include "seastar/util/closeable.hh"
-#include "seastar/util/defer.hh"
+#include <seastar/core/fstream.hh>
+#include <seastar/core/seastar.hh>
+#include <seastar/util/closeable.hh>
+#include <seastar/util/defer.hh>
 #include "sstables/mx/types.hh"
 #include "sstables/trie/bti_index.hh"
 #include "sstables/trie/bti_index_internal.hh"

--- a/test/boost/bti_key_translation_test.cc
+++ b/test/boost/bti_key_translation_test.cc
@@ -9,7 +9,7 @@
 #define BOOST_TEST_MODULE core
 
 #include <boost/test/unit_test.hpp>
-#include "seastar/util/defer.hh"
+#include <seastar/util/defer.hh>
 #include "schema/schema_builder.hh"
 #include "sstables/trie/bti_key_translation.hh"
 #include "test/lib/key_utils.hh"

--- a/test/boost/tablets_test.cc
+++ b/test/boost/tablets_test.cc
@@ -20,7 +20,7 @@
 #include "service/storage_service.hh"
 #include <fmt/ranges.h>
 #include <seastar/testing/thread_test_case.hh>
-#include "seastar/testing/on_internal_error.hh"
+#include <seastar/testing/on_internal_error.hh>
 #include "test/lib/cql_test_env.hh"
 #include "test/lib/log.hh"
 #include "test/lib/simple_schema.hh"

--- a/test/boost/token_metadata_test.cc
+++ b/test/boost/token_metadata_test.cc
@@ -11,8 +11,8 @@
 #include <chrono>
 #include <fmt/ranges.h>
 #include <seastar/util/closeable.hh>
-#include "seastar/core/future.hh"
-#include "seastar/core/sleep.hh"
+#include <seastar/core/future.hh>
+#include <seastar/core/sleep.hh>
 #include "test/lib/scylla_test_case.hh"
 #include "test/lib/test_utils.hh"
 #include "locator/token_metadata.hh"

--- a/test/vector_search/client_test.cc
+++ b/test/vector_search/client_test.cc
@@ -6,7 +6,7 @@
  * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
  */
 
-#include "seastar/http/common.hh"
+#include <seastar/http/common.hh>
 #include "vector_search/client.hh"
 #include "vector_search/utils.hh"
 #include "vs_mock_server.hh"

--- a/test/vector_search/vector_store_client_test.cc
+++ b/test/vector_search/vector_store_client_test.cc
@@ -12,8 +12,8 @@
 #include "vs_mock_server.hh"
 #include "unavailable_server.hh"
 #include "certificates.hh"
-#include "seastar/core/future.hh"
-#include "seastar/core/when_all.hh"
+#include <seastar/core/future.hh>
+#include <seastar/core/when_all.hh>
 #include "db/config.hh"
 #include "exceptions/exceptions.hh"
 #include "cql3/statements/select_statement.hh"

--- a/test/vector_search/vs_mock_server.hh
+++ b/test/vector_search/vs_mock_server.hh
@@ -10,7 +10,7 @@
 
 #include "utils.hh"
 #include "utils/rjson.hh"
-#include "seastar/http/request.hh"
+#include <seastar/http/request.hh>
 #include <chrono>
 #include <seastar/core/future.hh>
 #include <seastar/core/seastar.hh>

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -12,7 +12,7 @@
 #include "cql3/statements/modification_statement.hh"
 #include <seastar/core/scheduling.hh>
 #include <seastar/core/semaphore.hh>
-#include "seastar/coroutine/switch_to.hh"
+#include <seastar/coroutine/switch_to.hh>
 #include "types/collection.hh"
 #include "types/list.hh"
 #include "types/set.hh"

--- a/utils/lru_string_map.hh
+++ b/utils/lru_string_map.hh
@@ -13,12 +13,12 @@
 #include <optional>
 #include <string>
 #include <string_view>
-#include "seastar/core/loop.hh"
+#include <seastar/core/loop.hh>
 #include "seastarx.hh"
 #include <seastar/core/future.hh>
 #include <seastar/core/on_internal_error.hh>
 #include <seastar/core/coroutine.hh>
-#include "seastar/coroutine/maybe_yield.hh"
+#include <seastar/coroutine/maybe_yield.hh>
 #include "utils/log.hh"
 
 // A simple LRU cache, mapping strings to values of type Value.

--- a/utils/s3/default_aws_retry_strategy.cc
+++ b/utils/s3/default_aws_retry_strategy.cc
@@ -8,9 +8,9 @@
 
 #include "default_aws_retry_strategy.hh"
 #include "aws_error.hh"
-#include "seastar/core/sleep.hh"
-#include "seastar/http/exception.hh"
-#include "seastar/util/short_streams.hh"
+#include <seastar/core/sleep.hh>
+#include <seastar/http/exception.hh>
+#include <seastar/util/short_streams.hh>
 #include "utils/log.hh"
 
 namespace seastar::http::experimental {

--- a/vector_search/clients.hh
+++ b/vector_search/clients.hh
@@ -11,7 +11,7 @@
 #include "client.hh"
 #include "dns.hh"
 #include "truststore.hh"
-#include "seastar/core/future.hh"
+#include <seastar/core/future.hh>
 #include "uri.hh"
 #include "utils/sequential_producer.hh"
 #include "vector_search/error.hh"

--- a/vector_search/load_balancer.hh
+++ b/vector_search/load_balancer.hh
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include "seastar/core/shared_ptr.hh"
+#include <seastar/core/shared_ptr.hh>
 #include <vector>
 
 namespace vector_search {


### PR DESCRIPTION
Seastar is an external library from the point of view of ScyllaDB, so should be included with angle brackets.

Minor code cleanup, no point to backport.