### PR TITLE
audit/alternator: Make Alternator requests audited

### DIFF
--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -155,6 +155,24 @@ static std::string_view table_status_to_sstring(table_status tbl_status) {
     return "UNKNOWN";
 }
 
+void executor::maybe_audit(
+    std::unique_ptr<audit::audit_info_alternator>& audit_info,
+    audit::statement_category category,
+    std::string_view ks_name,
+    std::string_view table_name,
+    std::string_view operation_name,
+    const rjson::value& request,
+    std::optional<db::consistency_level> cl)
+{
+    if (_audit.local_is_initialized() && _audit.local().will_log(category, ks_name, table_name)) {
+        audit_info = std::make_unique<audit::audit_info_alternator>(
+            category, sstring(ks_name), sstring(table_name), cl);
+        // FIXME: rjson::print(request) serializes the entire JSON request body, which
+        // can be up to 16 MB for BatchWriteItem.
+        audit_info->set_query_string(sstring(rjson::print(request)), sstring(operation_name));
+    }
+}
+
 static lw_shared_ptr<keyspace_metadata> create_keyspace_metadata(std::string_view keyspace_name, service::storage_proxy& sp, gms::gossiper& gossiper, api::timestamp_type,
         const std::map<sstring, sstring>& tags_map, const gms::feature_service& feat, const db::tablets_mode_t::mode tablets_mode);
 
@@ -324,6 +342,7 @@ executor::executor(gms::gossiper& gossiper,
       _cdc_metadata(cdc_metadata),
       _enforce_authorization(_proxy.data_dictionary().get_config().alternator_enforce_authorization),
       _warn_authorization(_proxy.data_dictionary().get_config().alternator_warn_authorization),
+      _audit(audit::audit::audit_instance()),
       _ssg(ssg),
       _parsed_expression_cache(std::make_unique<parsed::expression_cache>(
         parsed::expression_cache::config{_proxy.data_dictionary().get_config().alternator_max_expression_cache_entries_per_shard},
@@ -974,11 +993,14 @@ sstring executor::table_name(const schema& s) {
     return s.cf_name();
 }
 
-future<executor::request_return_type> executor::describe_table(client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value request) {
+future<executor::request_return_type> executor::describe_table(client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value request, std::unique_ptr<audit::audit_info_alternator>& audit_info) {
     _stats.api_operations.describe_table++;
     elogger.trace("Describing table {}", request);
 
     schema_ptr schema = get_table(_proxy, request);
+
+    maybe_audit(audit_info, audit::statement_category::QUERY, schema->ks_name(), schema->cf_name(), "DescribeTable", request);
+
     get_stats_from_schema(_proxy, *schema)->api_operations.describe_table++;
     tracing::add_alternator_table_name(trace_state, schema->cf_name());
 
@@ -1074,13 +1096,15 @@ static future<> verify_create_permission(bool enforce_authorization, bool warn_a
     }
 }
 
-future<executor::request_return_type> executor::delete_table(client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value request) {
+future<executor::request_return_type> executor::delete_table(client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value request, std::unique_ptr<audit::audit_info_alternator>& audit_info) {
     _stats.api_operations.delete_table++;
     elogger.trace("Deleting table {}", request);
 
     std::string table_name = get_table_name(request);
-
     std::string keyspace_name = executor::KEYSPACE_NAME_PREFIX + table_name;
+
+    maybe_audit(audit_info, audit::statement_category::DDL, keyspace_name, table_name, "DeleteTable", request);
+
     tracing::add_alternator_table_name(trace_state, table_name);
     auto& p = _proxy.container();
 
@@ -1481,7 +1505,7 @@ const std::map<sstring, sstring>& get_tags_of_table_or_throw(schema_ptr schema) 
     }
 }
 
-future<executor::request_return_type> executor::tag_resource(client_state& client_state, service_permit permit, rjson::value request) {
+future<executor::request_return_type> executor::tag_resource(client_state& client_state, service_permit permit, rjson::value request, std::unique_ptr<audit::audit_info_alternator>& audit_info) {
     _stats.api_operations.tag_resource++;
 
     const rjson::value* arn = rjson::find(request, "ResourceArn");
@@ -1489,6 +1513,9 @@ future<executor::request_return_type> executor::tag_resource(client_state& clien
         co_return api_error::access_denied("Incorrect resource identifier");
     }
     schema_ptr schema = get_table_from_arn(_proxy, rjson::to_string_view(*arn));
+
+    maybe_audit(audit_info, audit::statement_category::DDL, schema->ks_name(), schema->cf_name(), "TagResource", request);
+
     get_stats_from_schema(_proxy, *schema)->api_operations.tag_resource++;
     const rjson::value* tags = rjson::find(request, "Tags");
     if (!tags || !tags->IsArray()) {
@@ -1504,19 +1531,22 @@ future<executor::request_return_type> executor::tag_resource(client_state& clien
     co_return ""; // empty response
 }
 
-future<executor::request_return_type> executor::untag_resource(client_state& client_state, service_permit permit, rjson::value request) {
+future<executor::request_return_type> executor::untag_resource(client_state& client_state, service_permit permit, rjson::value request, std::unique_ptr<audit::audit_info_alternator>& audit_info) {
     _stats.api_operations.untag_resource++;
 
     const rjson::value* arn = rjson::find(request, "ResourceArn");
     if (!arn || !arn->IsString()) {
         co_return api_error::access_denied("Incorrect resource identifier");
     }
+
     const rjson::value* tags = rjson::find(request, "TagKeys");
     if (!tags || !tags->IsArray()) {
         co_return api_error::validation(format("Cannot parse tag keys"));
     }
 
     schema_ptr schema = get_table_from_arn(_proxy, rjson::to_string_view(*arn));
+    maybe_audit(audit_info, audit::statement_category::DDL, schema->ks_name(), schema->cf_name(), "UntagResource", request);
+
     get_stats_from_schema(_proxy, *schema)->api_operations.untag_resource++;
     co_await verify_permission(_enforce_authorization, _warn_authorization, client_state, schema, auth::permission::ALTER, _stats);
     co_await db::modify_tags(_mm, schema->ks_name(), schema->cf_name(), [tags](std::map<sstring, sstring>& tags_map) {
@@ -1525,13 +1555,16 @@ future<executor::request_return_type> executor::untag_resource(client_state& cli
     co_return ""; // empty response
 }
 
-future<executor::request_return_type> executor::list_tags_of_resource(client_state& client_state, service_permit permit, rjson::value request) {
+future<executor::request_return_type> executor::list_tags_of_resource(client_state& client_state, service_permit permit, rjson::value request, std::unique_ptr<audit::audit_info_alternator>& audit_info) {
     _stats.api_operations.list_tags_of_resource++;
     const rjson::value* arn = rjson::find(request, "ResourceArn");
     if (!arn || !arn->IsString()) {
         return make_ready_future<request_return_type>(api_error::access_denied("Incorrect resource identifier"));
     }
     schema_ptr schema = get_table_from_arn(_proxy, rjson::to_string_view(*arn));
+
+    maybe_audit(audit_info, audit::statement_category::QUERY, schema->ks_name(), schema->cf_name(), "ListTagsOfResource", request);
+
     get_stats_from_schema(_proxy, *schema)->api_operations.list_tags_of_resource++;
     auto tags_map = get_tags_of_table_or_throw(schema);
     rjson::value ret = rjson::empty_object();
@@ -1721,7 +1754,8 @@ static future<> mark_view_schemas_as_built(utils::chunked_vector<mutation>& out,
     }
 }
 
-future<executor::request_return_type> executor::create_table_on_shard0(service::client_state&& client_state, tracing::trace_state_ptr trace_state, rjson::value request, bool enforce_authorization, bool warn_authorization, const db::tablets_mode_t::mode tablets_mode) {
+future<executor::request_return_type> executor::create_table_on_shard0(service::client_state&& client_state, tracing::trace_state_ptr trace_state, rjson::value request, bool enforce_authorization, bool warn_authorization,
+            const db::tablets_mode_t::mode tablets_mode, std::unique_ptr<audit::audit_info_alternator>& audit_info) {
     throwing_assert(this_shard_id() == 0);
 
     // We begin by parsing and validating the content of the CreateTable
@@ -1735,6 +1769,9 @@ future<executor::request_return_type> executor::create_table_on_shard0(service::
         co_return api_error::validation(fmt::format("Prefix {} is reserved for accessing internal tables", executor::INTERNAL_TABLE_PREFIX));
     }
     std::string keyspace_name = executor::KEYSPACE_NAME_PREFIX + table_name;
+
+    maybe_audit(audit_info, audit::statement_category::DDL, keyspace_name, table_name, "CreateTable", request);
+
     const rjson::value* attribute_definitions = rjson::find(request, "AttributeDefinitions");
     if (attribute_definitions == nullptr) {
         co_return api_error::validation("Missing AttributeDefinitions in CreateTable request");
@@ -2040,15 +2077,19 @@ future<executor::request_return_type> executor::create_table_on_shard0(service::
     co_return rjson::print(std::move(status));
 }
 
-future<executor::request_return_type> executor::create_table(client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value request) {
+future<executor::request_return_type> executor::create_table(client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value request, std::unique_ptr<audit::audit_info_alternator>& audit_info) {
     _stats.api_operations.create_table++;
     elogger.trace("Creating table {}", request);
 
+    // Note: audit_info is captured by reference into the invoke_on() lambda and written on shard 0.
+    // This is safe because co_await keeps the caller's coroutine frame (and audit_info) alive for
+    // the entire duration of invoke_on(). Only the unique_ptr itself is read/written cross-shard —
+    // no concurrent access occurs since the caller is suspended during invoke_on().
     co_return co_await _mm.container().invoke_on(0, [&, tr = tracing::global_trace_state_ptr(trace_state), request = std::move(request), &e = this->container(), client_state_other_shard = client_state.move_to_other_shard(), enforce_authorization = bool(_enforce_authorization), warn_authorization = bool(_warn_authorization)]
                                         (service::migration_manager& mm) mutable -> future<executor::request_return_type> {
         const db::tablets_mode_t::mode tablets_mode = _proxy.data_dictionary().get_config().tablets_mode_for_new_keyspaces(); // type cast
         // `invoke_on` hopped us to shard 0, but `this` points to `executor` is from 'old' shard, we need to hop it too.
-        co_return co_await e.local().create_table_on_shard0(client_state_other_shard.get(), tr, std::move(request), enforce_authorization, warn_authorization, std::move(tablets_mode));
+        co_return co_await e.local().create_table_on_shard0(client_state_other_shard.get(), tr, std::move(request), enforce_authorization, warn_authorization, std::move(tablets_mode), audit_info);
     });
 }
 
@@ -2078,7 +2119,7 @@ future<executor::request_return_type> executor::create_table(client_state& clien
     }
 }
 
-future<executor::request_return_type> executor::update_table(client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value request) {
+future<executor::request_return_type> executor::update_table(client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value request, std::unique_ptr<audit::audit_info_alternator>& audit_info) {
     _stats.api_operations.update_table++;
     elogger.trace("Updating table {}", request);
 
@@ -2101,7 +2142,12 @@ future<executor::request_return_type> executor::update_table(client_state& clien
         verify_billing_mode(request);
     }
 
-    co_return co_await _mm.container().invoke_on(0, [&p = _proxy.container(), request = std::move(request), gt = tracing::global_trace_state_ptr(std::move(trace_state)), enforce_authorization = bool(_enforce_authorization), warn_authorization = bool(_warn_authorization), client_state_other_shard = client_state.move_to_other_shard(), empty_request, &e = this->container()]
+    // Note: audit_info is captured by reference into the invoke_on() lambda and written on shard 0.
+    // This is safe because co_await keeps the caller's coroutine frame (and audit_info) alive for
+    // the entire duration of invoke_on(). Only the unique_ptr itself is read/written cross-shard —
+    // no concurrent access occurs since the caller is suspended during invoke_on().
+    co_return co_await _mm.container().invoke_on(0, [&p = _proxy.container(), request = std::move(request), gt = tracing::global_trace_state_ptr(std::move(trace_state)), enforce_authorization = bool(_enforce_authorization),
+                warn_authorization = bool(_warn_authorization), client_state_other_shard = client_state.move_to_other_shard(), empty_request, &e = this->container(), &audit_info]
                                                 (service::migration_manager& mm) mutable -> future<executor::request_return_type> {
         schema_ptr schema;
         size_t retries = mm.get_concurrent_ddl_retries();
@@ -2109,6 +2155,8 @@ future<executor::request_return_type> executor::update_table(client_state& clien
             auto group0_guard = co_await mm.start_group0_operation();
 
             schema_ptr tab = get_table(p.local(), request);
+
+            e.local().maybe_audit(audit_info, audit::statement_category::DDL, tab->ks_name(), tab->cf_name(), "UpdateTable", request);
 
             tracing::add_alternator_table_name(gt, tab->cf_name());
 
@@ -3038,12 +3086,22 @@ public:
     virtual ~put_item_operation() = default;
 };
 
-future<executor::request_return_type> executor::put_item(client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value request) {
+future<executor::request_return_type> executor::put_item(client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value request, std::unique_ptr<audit::audit_info_alternator>& audit_info) {
     _stats.api_operations.put_item++;
     auto start_time = std::chrono::steady_clock::now();
     elogger.trace("put_item {}", request);
 
     auto op = make_shared<put_item_operation>(*_parsed_expression_cache, _proxy, std::move(request));
+
+    if (!audit_info) {
+        // On LWT shard bounce, audit_info is already set on the originating shard.
+        // The reference captured in the bounce lambda points back to the original
+        // coroutine frame, which remains alive for the entire cross-shard call.
+        // Only reads of this pointer occur on the target shard — no writes or frees.
+        maybe_audit(audit_info, audit::statement_category::DML, op->schema()->ks_name(),
+                    op->schema()->cf_name(), "PutItem", op->request(), db::consistency_level::LOCAL_QUORUM);
+    }
+
     tracing::add_alternator_table_name(trace_state, op->schema()->cf_name());
     const bool needs_read_before_write = op->needs_read_before_write();
 
@@ -3055,14 +3113,14 @@ future<executor::request_return_type> executor::put_item(client_state& client_st
         _stats.api_operations.put_item--; // uncount on this shard, will be counted in other shard
         _stats.shard_bounce_for_lwt++;
         co_return co_await container().invoke_on(cas_shard->shard(), _ssg,
-                [request = std::move(*op).move_request(), cs = client_state.move_to_other_shard(), gt = tracing::global_trace_state_ptr(trace_state), permit = std::move(permit)]
+                [request = std::move(*op).move_request(), cs = client_state.move_to_other_shard(), gt = tracing::global_trace_state_ptr(trace_state), permit = std::move(permit), &audit_info]
                 (executor& e) mutable {
-            return do_with(cs.get(), [&e, request = std::move(request), trace_state = tracing::trace_state_ptr(gt)]
+            return do_with(cs.get(), [&e, request = std::move(request), trace_state = tracing::trace_state_ptr(gt), &audit_info]
                                      (service::client_state& client_state) mutable {
                 //FIXME: Instead of passing empty_service_permit() to the background operation,
                 // the current permit's lifetime should be prolonged, so that it's destructed
                 // only after all background operations are finished as well.
-                return e.put_item(client_state, std::move(trace_state), empty_service_permit(), std::move(request));
+                return e.put_item(client_state, std::move(trace_state), empty_service_permit(), std::move(request), audit_info);
             });
         });
     }
@@ -3141,12 +3199,22 @@ public:
     virtual ~delete_item_operation() = default;
 };
 
-future<executor::request_return_type> executor::delete_item(client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value request) {
+future<executor::request_return_type> executor::delete_item(client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value request, std::unique_ptr<audit::audit_info_alternator>& audit_info) {
     _stats.api_operations.delete_item++;
     auto start_time = std::chrono::steady_clock::now();
     elogger.trace("delete_item {}", request);
 
     auto op = make_shared<delete_item_operation>(*_parsed_expression_cache, _proxy, std::move(request));
+
+    if (!audit_info) {
+        // On LWT shard bounce, audit_info is already set on the originating shard.
+        // The reference captured in the bounce lambda points back to the original
+        // coroutine frame, which remains alive for the entire cross-shard call.
+        // Only reads of this pointer occur on the target shard — no writes or frees.
+        maybe_audit(audit_info, audit::statement_category::DML, op->schema()->ks_name(),
+                    op->schema()->cf_name(), "DeleteItem", op->request(), db::consistency_level::LOCAL_QUORUM);
+    }
+
     lw_shared_ptr<stats> per_table_stats = get_stats_from_schema(_proxy, *(op->schema()));
     tracing::add_alternator_table_name(trace_state, op->schema()->cf_name());
     const bool needs_read_before_write = _proxy.data_dictionary().get_config().alternator_force_read_before_write() || op->needs_read_before_write();
@@ -3160,14 +3228,14 @@ future<executor::request_return_type> executor::delete_item(client_state& client
         _stats.shard_bounce_for_lwt++;
         per_table_stats->shard_bounce_for_lwt++;
         co_return co_await container().invoke_on(cas_shard->shard(), _ssg,
-                [request = std::move(*op).move_request(), cs = client_state.move_to_other_shard(), gt = tracing::global_trace_state_ptr(trace_state), permit = std::move(permit)]
+                [request = std::move(*op).move_request(), cs = client_state.move_to_other_shard(), gt = tracing::global_trace_state_ptr(trace_state), permit = std::move(permit), &audit_info]
                 (executor& e) mutable {
-            return do_with(cs.get(), [&e, request = std::move(request), trace_state = tracing::trace_state_ptr(gt)]
+            return do_with(cs.get(), [&e, request = std::move(request), trace_state = tracing::trace_state_ptr(gt), &audit_info]
                                      (service::client_state& client_state) mutable {
                 //FIXME: Instead of passing  empty_service_permit() to the background operation,
                 // the current permit's lifetime should be prolonged, so that it's destructed
                 // only after all background operations are finished as well.
-                return e.delete_item(client_state, std::move(trace_state), empty_service_permit(), std::move(request));
+                return e.delete_item(client_state, std::move(trace_state), empty_service_permit(), std::move(request), audit_info);
             });
         });
     }
@@ -3383,7 +3451,19 @@ future<> executor::do_batch_write(
     }
 }
 
-future<executor::request_return_type> executor::batch_write_item(client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value request) {
+sstring print_names_for_audit(const std::set<sstring>& names) {
+    sstring res;
+    // Might have been useful to loop twice, with the 1st loop learning the total size of the names for the res to then reserve()
+    for(const auto& name : names) {
+        if (!res.empty()) {
+            res += "|";
+        }
+        res += name;
+    }
+    return res;
+}
+
+future<executor::request_return_type> executor::batch_write_item(client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value request, std::unique_ptr<audit::audit_info_alternator>& audit_info) {
     _stats.api_operations.batch_write_item++;
     auto start_time = std::chrono::steady_clock::now();
     const rjson::value& request_items = get_member(request, "RequestItems", "BatchWriteItem content");
@@ -3414,6 +3494,10 @@ future<executor::request_return_type> executor::batch_write_item(client_state& c
     // For each table, we need its stats and schema.
     std::vector<std::pair<lw_shared_ptr<stats>, schema_ptr>> per_table_wcu;
 
+    std::set<sstring> table_names; // for auditing
+    // FIXME: will_log() here doesn't pass keyspace/table, so keyspace-level audit
+    // filtering is bypassed — a batch spanning multiple tables is audited as a whole.
+    bool should_audit = _audit.local_is_initialized() && _audit.local().will_log(audit::statement_category::DML);
     mutation_builders.reserve(request_items.MemberCount());
     per_table_wcu.reserve(request_items.MemberCount());
     for (auto it = request_items.MemberBegin(); it != request_items.MemberEnd(); ++it) {
@@ -3423,6 +3507,9 @@ future<executor::request_return_type> executor::batch_write_item(client_state& c
         per_table_stats->api_operations.batch_write_item_batch_total += it->value.Size();
         per_table_stats->api_operations.batch_write_item_histogram.add(it->value.Size());
         tracing::add_alternator_table_name(trace_state, schema->cf_name());
+        if (should_audit) {
+            table_names.insert(schema->cf_name());
+        }
 
         std::unordered_set<primary_key, primary_key_hash, primary_key_equal> used_keys(
                 1, primary_key_hash{schema}, primary_key_equal{schema});
@@ -3540,6 +3627,8 @@ future<executor::request_return_type> executor::batch_write_item(client_state& c
     for (const auto& w : per_table_wcu) {
         w.first->api_operations.batch_write_item_latency.mark(duration);
     }
+    maybe_audit(audit_info, audit::statement_category::DML, "",
+                print_names_for_audit(table_names), "BatchWriteItem", request, db::consistency_level::LOCAL_QUORUM);
     co_return rjson::print(std::move(ret));
 }
 
@@ -4680,12 +4769,22 @@ std::optional<mutation> update_item_operation::apply(std::unique_ptr<rjson::valu
     return m;
 }
 
-future<executor::request_return_type> executor::update_item(client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value request) {
+future<executor::request_return_type> executor::update_item(client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value request, std::unique_ptr<audit::audit_info_alternator>& audit_info) {
     _stats.api_operations.update_item++;
     auto start_time = std::chrono::steady_clock::now();
     elogger.trace("update_item {}", request);
 
     auto op = make_shared<update_item_operation>(*_parsed_expression_cache, _proxy, std::move(request));
+
+    if (!audit_info) {
+        // On LWT shard bounce, audit_info is already set on the originating shard.
+        // The reference captured in the bounce lambda points back to the original
+        // coroutine frame, which remains alive for the entire cross-shard call.
+        // Only reads of this pointer occur on the target shard — no writes or frees.
+        maybe_audit(audit_info, audit::statement_category::DML, op->schema()->ks_name(),
+                    op->schema()->cf_name(), "UpdateItem", op->request(), db::consistency_level::LOCAL_QUORUM);
+    }
+
     tracing::add_alternator_table_name(trace_state, op->schema()->cf_name());
     const bool needs_read_before_write = _proxy.data_dictionary().get_config().alternator_force_read_before_write() || op->needs_read_before_write();
 
@@ -4697,14 +4796,14 @@ future<executor::request_return_type> executor::update_item(client_state& client
         _stats.api_operations.update_item--; // uncount on this shard, will be counted in other shard
         _stats.shard_bounce_for_lwt++;
         co_return co_await container().invoke_on(cas_shard->shard(), _ssg,
-                [request = std::move(*op).move_request(), cs = client_state.move_to_other_shard(), gt = tracing::global_trace_state_ptr(trace_state), permit = std::move(permit)]
+                [request = std::move(*op).move_request(), cs = client_state.move_to_other_shard(), gt = tracing::global_trace_state_ptr(trace_state), permit = std::move(permit), &audit_info]
                 (executor& e) mutable {
-            return do_with(cs.get(), [&e, request = std::move(request), trace_state = tracing::trace_state_ptr(gt)]
+            return do_with(cs.get(), [&e, request = std::move(request), trace_state = tracing::trace_state_ptr(gt), &audit_info]
                                      (service::client_state& client_state) mutable {
                 //FIXME: Instead of passing empty_service_permit() to the background operation,
                 // the current permit's lifetime should be prolonged, so that it's destructed
                 // only after all background operations are finished as well.
-                return e.update_item(client_state, std::move(trace_state), empty_service_permit(), std::move(request));
+                return e.update_item(client_state, std::move(trace_state), empty_service_permit(), std::move(request), audit_info);
             });
         });
     }
@@ -4759,7 +4858,7 @@ static rjson::value describe_item(schema_ptr schema,
     return item_descr;
 }
 
-future<executor::request_return_type> executor::get_item(client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value request) {
+future<executor::request_return_type> executor::get_item(client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value request, std::unique_ptr<audit::audit_info_alternator>& audit_info) {
     _stats.api_operations.get_item++;
     auto start_time = std::chrono::steady_clock::now();
     elogger.trace("Getting item {}", request);
@@ -4771,6 +4870,8 @@ future<executor::request_return_type> executor::get_item(client_state& client_st
 
     rjson::value& query_key = request["Key"];
     db::consistency_level cl = get_read_consistency(request);
+
+    maybe_audit(audit_info, audit::statement_category::QUERY, schema->ks_name(), schema->cf_name(), "GetItem", request, cl);
 
     partition_key pk = pk_from_json(query_key, schema);
     dht::partition_range_vector partition_ranges{dht::partition_range(dht::decorate_key(*schema, pk))};
@@ -4871,7 +4972,7 @@ static void check_big_object(const rjson::value& val, int& size_left) {
     }
 }
 
-future<executor::request_return_type> executor::batch_get_item(client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value request) {
+future<executor::request_return_type> executor::batch_get_item(client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value request, std::unique_ptr<audit::audit_info_alternator>& audit_info) {
     // FIXME: In this implementation, an unbounded batch size can cause
     // unbounded response JSON object to be buffered in memory, unbounded
     // parallelism of the requests, and unbounded amount of non-preemptable
@@ -4986,7 +5087,10 @@ future<executor::request_return_type> executor::batch_get_item(client_state& cli
     // from one of the operations will be returned.
     bool some_succeeded = false;
     std::exception_ptr eptr;
-
+    std::set<sstring> table_names; // for auditing
+    // FIXME: will_log() here doesn't pass keyspace/table, so keyspace-level audit
+    // filtering is bypassed — a batch spanning multiple tables is audited as a whole.
+    bool should_audit = _audit.local_is_initialized() && _audit.local().will_log(audit::statement_category::QUERY);
     rjson::value response = rjson::empty_object();
     rjson::add(response, "Responses", rjson::empty_object());
     rjson::add(response, "UnprocessedKeys", rjson::empty_object());
@@ -4995,6 +5099,9 @@ future<executor::request_return_type> executor::batch_get_item(client_state& cli
     for (size_t i = 0; i < requests.size(); i++) {
         const table_requests& rs = requests[i];
         std::string table = table_name(*rs.schema);
+        if (should_audit) {
+            table_names.insert(table);
+        }
         for (const auto& [_, cks] : rs.requests) {
             auto& fut = *fut_it;
             ++fut_it;
@@ -5047,6 +5154,12 @@ future<executor::request_return_type> executor::batch_get_item(client_state& cli
         rjson::add(response, "ConsumedCapacity", std::move(consumed_capacity));
     }
     elogger.trace("Unprocessed keys: {}", response["UnprocessedKeys"]);
+    // NOTE: Each table in the batch has its own CL (set by get_read_consistency()),
+    // but the audit entry records a single CL for the whole batch. We use ANY as a
+    // placeholder to indicate "mixed / not applicable".
+    // FIXME: Auditing is executed only for a complete success
+    maybe_audit(audit_info, audit::statement_category::QUERY, "",
+                print_names_for_audit(table_names), "BatchGetItem", request, db::consistency_level::ANY);
     if (!some_succeeded && eptr) {
         co_await coroutine::return_exception_ptr(std::move(eptr));
     }
@@ -5520,11 +5633,15 @@ static dht::partition_range get_range_for_segment(int segment, int total_segment
     }
 }
 
-future<executor::request_return_type> executor::scan(client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value request) {
+future<executor::request_return_type> executor::scan(client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value request, std::unique_ptr<audit::audit_info_alternator>& audit_info) {
     _stats.api_operations.scan++;
     elogger.trace("Scanning {}", request);
 
     auto [schema, table_type] = get_table_or_view(_proxy, request);
+    db::consistency_level cl = get_read_consistency(request);
+
+    maybe_audit(audit_info, audit::statement_category::QUERY, schema->ks_name(), schema->cf_name(), "Scan", request, cl);
+
     tracing::add_alternator_table_name(trace_state, schema->cf_name());
     get_stats_from_schema(_proxy, *schema)->api_operations.scan++;
     auto segment = get_int_attribute(request, "Segment");
@@ -5546,7 +5663,6 @@ future<executor::request_return_type> executor::scan(client_state& client_state,
 
     rjson::value* exclusive_start_key = rjson::find(request, "ExclusiveStartKey");
 
-    db::consistency_level cl = get_read_consistency(request);
     if (table_type == table_or_view_type::gsi && cl != db::consistency_level::LOCAL_ONE) {
         return make_ready_future<request_return_type>(api_error::validation(
                 "Consistent reads are not allowed on global indexes (GSI)"));
@@ -5999,16 +6115,19 @@ calculate_bounds_condition_expression(schema_ptr schema,
     return {std::move(partition_ranges), std::move(ck_bounds)};
 }
 
-future<executor::request_return_type> executor::query(client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value request) {
+future<executor::request_return_type> executor::query(client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value request, std::unique_ptr<audit::audit_info_alternator>& audit_info) {
     _stats.api_operations.query++;
     elogger.trace("Querying {}", request);
 
     auto [schema, table_type] = get_table_or_view(_proxy, request);
+    db::consistency_level cl = get_read_consistency(request);
+
+    maybe_audit(audit_info, audit::statement_category::QUERY, schema->ks_name(), schema->cf_name(), "Query", request, cl);
+
     get_stats_from_schema(_proxy, *schema)->api_operations.query++;
     tracing::add_alternator_table_name(trace_state, schema->cf_name());
 
     rjson::value* exclusive_start_key = rjson::find(request, "ExclusiveStartKey");
-    db::consistency_level cl = get_read_consistency(request);
     if (table_type == table_or_view_type::gsi && cl != db::consistency_level::LOCAL_ONE) {
         return make_ready_future<request_return_type>(api_error::validation(
                 "Consistent reads are not allowed on global indexes (GSI)"));
@@ -6077,9 +6196,11 @@ future<executor::request_return_type> executor::query(client_state& client_state
             std::move(filter), opts, client_state, _stats, std::move(trace_state), std::move(permit), _enforce_authorization, _warn_authorization);
 }
 
-future<executor::request_return_type> executor::list_tables(client_state& client_state, service_permit permit, rjson::value request) {
+future<executor::request_return_type> executor::list_tables(client_state& client_state, service_permit permit, rjson::value request, std::unique_ptr<audit::audit_info_alternator>& audit_info) {
     _stats.api_operations.list_tables++;
     elogger.trace("Listing tables {}", request);
+
+    maybe_audit(audit_info, audit::statement_category::QUERY, "", "", "ListTables", request);
 
     co_await utils::get_local_injector().inject("alternator_list_tables", [] (auto& handler) -> future<> {
         handler.set("waiting", true);
@@ -6136,8 +6257,11 @@ future<executor::request_return_type> executor::list_tables(client_state& client
     co_return rjson::print(std::move(response));
 }
 
-future<executor::request_return_type> executor::describe_endpoints(client_state& client_state, service_permit permit, rjson::value request, std::string host_header) {
+future<executor::request_return_type> executor::describe_endpoints(client_state& client_state, service_permit permit, rjson::value request, std::string host_header, std::unique_ptr<audit::audit_info_alternator>& audit_info) {
     _stats.api_operations.describe_endpoints++;
+
+    maybe_audit(audit_info, audit::statement_category::QUERY, "", "", "DescribeEndpoints", request);
+
     // The alternator_describe_endpoints configuration can be used to disable
     // the DescribeEndpoints operation, or set it to return a fixed string
     std::string override = _proxy.data_dictionary().get_config().alternator_describe_endpoints();
@@ -6174,15 +6298,17 @@ static locator::replication_strategy_config_options get_network_topology_options
     return options;
 }
 
-future<executor::request_return_type> executor::describe_continuous_backups(client_state& client_state, service_permit permit, rjson::value request) {
+future<executor::request_return_type> executor::describe_continuous_backups(client_state& client_state, service_permit permit, rjson::value request, std::unique_ptr<audit::audit_info_alternator>& audit_info) {
     _stats.api_operations.describe_continuous_backups++;
     // Unlike most operations which return ResourceNotFound when the given
     // table doesn't exists, this operation returns a TableNoteFoundException.
     // So we can't use the usual get_table() wrapper and need a bit more code:
     std::string table_name = get_table_name(request);
+    sstring ks_name = sstring(executor::KEYSPACE_NAME_PREFIX) + table_name;
+    maybe_audit(audit_info, audit::statement_category::QUERY, ks_name, table_name, "DescribeContinuousBackups", request);
     schema_ptr schema;
     try {
-        schema = _proxy.data_dictionary().find_schema(sstring(executor::KEYSPACE_NAME_PREFIX) + table_name, table_name);
+        schema = _proxy.data_dictionary().find_schema(ks_name, table_name);
     } catch(data_dictionary::no_such_column_family&) {
         // DynamoDB returns validation error even when table does not exist
         // and the table name is invalid.

--- a/alternator/executor.hh
+++ b/alternator/executor.hh
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <seastar/core/future.hh>
+#include "audit/audit.hh"
 #include "seastarx.hh"
 #include <seastar/core/sharded.hh>
 #include <seastar/util/noncopyable_function.hh>
@@ -29,6 +30,10 @@
 
 namespace db {
     class system_distributed_keyspace;
+}
+
+namespace audit {
+class audit_info_alternator;
 }
 
 namespace query {
@@ -147,6 +152,7 @@ class executor : public peering_sharded_service<executor> {
     cdc::metadata& _cdc_metadata;
     utils::updateable_value<bool> _enforce_authorization;
     utils::updateable_value<bool> _warn_authorization;
+    seastar::sharded<audit::audit>& _audit;
     // An smp_service_group to be used for limiting the concurrency when
     // forwarding Alternator request between shards - if necessary for LWT.
     smp_service_group _ssg;
@@ -191,30 +197,30 @@ public:
              utils::updateable_value<uint32_t> default_timeout_in_ms);
     ~executor();
 
-    future<request_return_type> create_table(client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value request);
-    future<request_return_type> describe_table(client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value request);
-    future<request_return_type> delete_table(client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value request);
-    future<request_return_type> update_table(client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value request);
-    future<request_return_type> put_item(client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value request);
-    future<request_return_type> get_item(client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value request);
-    future<request_return_type> delete_item(client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value request);
-    future<request_return_type> update_item(client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value request);
-    future<request_return_type> list_tables(client_state& client_state, service_permit permit, rjson::value request);
-    future<request_return_type> scan(client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value request);
-    future<request_return_type> describe_endpoints(client_state& client_state, service_permit permit, rjson::value request, std::string host_header);
-    future<request_return_type> batch_write_item(client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value request);
-    future<request_return_type> batch_get_item(client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value request);
-    future<request_return_type> query(client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value request);
-    future<request_return_type> tag_resource(client_state& client_state, service_permit permit, rjson::value request);
-    future<request_return_type> untag_resource(client_state& client_state, service_permit permit, rjson::value request);
-    future<request_return_type> list_tags_of_resource(client_state& client_state, service_permit permit, rjson::value request);
-    future<request_return_type> update_time_to_live(client_state& client_state, service_permit permit, rjson::value request);
-    future<request_return_type> describe_time_to_live(client_state& client_state, service_permit permit, rjson::value request);
-    future<request_return_type> list_streams(client_state& client_state, service_permit permit, rjson::value request);
-    future<request_return_type> describe_stream(client_state& client_state, service_permit permit, rjson::value request);
-    future<request_return_type> get_shard_iterator(client_state& client_state, service_permit permit, rjson::value request);
-    future<request_return_type> get_records(client_state& client_state, tracing::trace_state_ptr, service_permit permit, rjson::value request);
-    future<request_return_type> describe_continuous_backups(client_state& client_state, service_permit permit, rjson::value request);
+    future<request_return_type> create_table(client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value request, std::unique_ptr<audit::audit_info_alternator>& audit_info);
+    future<request_return_type> describe_table(client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value request, std::unique_ptr<audit::audit_info_alternator>& audit_info);
+    future<request_return_type> delete_table(client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value request, std::unique_ptr<audit::audit_info_alternator>& audit_info);
+    future<request_return_type> update_table(client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value request, std::unique_ptr<audit::audit_info_alternator>& audit_info);
+    future<request_return_type> put_item(client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value request, std::unique_ptr<audit::audit_info_alternator>& audit_info);
+    future<request_return_type> get_item(client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value request, std::unique_ptr<audit::audit_info_alternator>& audit_info);
+    future<request_return_type> delete_item(client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value request, std::unique_ptr<audit::audit_info_alternator>& audit_info);
+    future<request_return_type> update_item(client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value request, std::unique_ptr<audit::audit_info_alternator>& audit_info);
+    future<request_return_type> list_tables(client_state& client_state, service_permit permit, rjson::value request, std::unique_ptr<audit::audit_info_alternator>& audit_info);
+    future<request_return_type> scan(client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value request, std::unique_ptr<audit::audit_info_alternator>& audit_info);
+    future<request_return_type> describe_endpoints(client_state& client_state, service_permit permit, rjson::value request, std::string host_header, std::unique_ptr<audit::audit_info_alternator>& audit_info);
+    future<request_return_type> batch_write_item(client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value request, std::unique_ptr<audit::audit_info_alternator>& audit_info);
+    future<request_return_type> batch_get_item(client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value request, std::unique_ptr<audit::audit_info_alternator>& audit_info);
+    future<request_return_type> query(client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value request, std::unique_ptr<audit::audit_info_alternator>& audit_info);
+    future<request_return_type> tag_resource(client_state& client_state, service_permit permit, rjson::value request, std::unique_ptr<audit::audit_info_alternator>& audit_info);
+    future<request_return_type> untag_resource(client_state& client_state, service_permit permit, rjson::value request, std::unique_ptr<audit::audit_info_alternator>& audit_info);
+    future<request_return_type> list_tags_of_resource(client_state& client_state, service_permit permit, rjson::value request, std::unique_ptr<audit::audit_info_alternator>& audit_info);
+    future<request_return_type> update_time_to_live(client_state& client_state, service_permit permit, rjson::value request, std::unique_ptr<audit::audit_info_alternator>& audit_info);
+    future<request_return_type> describe_time_to_live(client_state& client_state, service_permit permit, rjson::value request, std::unique_ptr<audit::audit_info_alternator>& audit_info);
+    future<request_return_type> list_streams(client_state& client_state, service_permit permit, rjson::value request, std::unique_ptr<audit::audit_info_alternator>& audit_info);
+    future<request_return_type> describe_stream(client_state& client_state, service_permit permit, rjson::value request, std::unique_ptr<audit::audit_info_alternator>& audit_info);
+    future<request_return_type> get_shard_iterator(client_state& client_state, service_permit permit, rjson::value request, std::unique_ptr<audit::audit_info_alternator>& audit_info);
+    future<request_return_type> get_records(client_state& client_state, tracing::trace_state_ptr, service_permit permit, rjson::value request, std::unique_ptr<audit::audit_info_alternator>& audit_info);
+    future<request_return_type> describe_continuous_backups(client_state& client_state, service_permit permit, rjson::value request, std::unique_ptr<audit::audit_info_alternator>& audit_info);
 
     future<> start();
     future<> stop();
@@ -230,9 +236,21 @@ public:
 private:
     friend class rmw_operation;
 
+    // Helper to set up auditing for an Alternator operation. Checks whether
+    // the operation should be audited (via will_log()) and if so, allocates
+    // and populates audit_info. No allocation occurs when auditing is disabled.
+    void maybe_audit(std::unique_ptr<audit::audit_info_alternator>& audit_info,
+                     audit::statement_category category,
+                     std::string_view ks_name,
+                     std::string_view table_name,
+                     std::string_view operation_name,
+                     const rjson::value& request,
+                     std::optional<db::consistency_level> cl = std::nullopt);
+
     static void describe_key_schema(rjson::value& parent, const schema&, std::unordered_map<std::string,std::string> * = nullptr, const std::map<sstring, sstring> *tags = nullptr);
     future<rjson::value> fill_table_description(schema_ptr schema, table_status tbl_status, service::client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit);
-    future<executor::request_return_type> create_table_on_shard0(service::client_state&& client_state, tracing::trace_state_ptr trace_state, rjson::value request, bool enforce_authorization, bool warn_authorization, const db::tablets_mode_t::mode tablets_mode);
+    future<executor::request_return_type> create_table_on_shard0(service::client_state&& client_state, tracing::trace_state_ptr trace_state, rjson::value request, bool enforce_authorization,
+            bool warn_authorization, const db::tablets_mode_t::mode tablets_mode, std::unique_ptr<audit::audit_info_alternator>& audit_info);
 
     future<> do_batch_write(
         std::vector<std::pair<schema_ptr, put_or_delete_item>> mutation_builders,
@@ -323,5 +341,8 @@ struct arn_parts {
 //    If is empty - then postfix value must be empty as well
 //    if not empty - postfix value must start with expected_postfix, but might be longer
 arn_parts parse_arn(std::string_view arn, std::string_view arn_field_name, std::string_view type_name, std::string_view expected_postfix);
+
+// The format is ks1|ks2|ks3... and table1|table2|table3...
+sstring print_names_for_audit(const std::set<sstring>& names);
 
 }

--- a/alternator/server.cc
+++ b/alternator/server.cc
@@ -7,6 +7,7 @@
  */
 
 #include "alternator/server.hh"
+#include "audit/audit.hh"
 #include "gms/application_state.hh"
 #include "utils/log.hh"
 #include <fmt/ranges.h>
@@ -785,12 +786,25 @@ future<executor::request_return_type> server::handle_api_request(std::unique_ptr
     auto f = [this, content = std::move(content), &callback = callback_it->second,
             client_state = std::move(client_state), trace_state = std::move(trace_state),
             units = std::move(units), req = std::move(req)] () mutable -> future<executor::request_return_type> {
-                rjson::value json_request = co_await _json_parser.parse(std::move(content));
-                if (!json_request.IsObject()) {
-                    co_return api_error::validation("Request content must be an object");
-                }
-                co_return co_await callback(_executor, client_state, trace_state,
-                    make_service_permit(std::move(units)), std::move(json_request), std::move(req));
+        rjson::value json_request = co_await _json_parser.parse(std::move(content));
+        if (!json_request.IsObject()) {
+            co_return api_error::validation("Request content must be an object");
+        }
+        std::unique_ptr<audit::audit_info_alternator> audit_info;
+        std::exception_ptr ex = {};
+        executor::request_return_type ret;
+        try {
+            ret = co_await callback(_executor, client_state, trace_state, make_service_permit(std::move(units)), std::move(json_request), std::move(req), audit_info);
+        } catch (...) {
+            ex = std::current_exception();
+        }
+        if (audit_info) {
+            co_await audit::inspect(*audit_info, client_state, ex != nullptr);
+        }
+        if (ex) {
+            co_return coroutine::exception(std::move(ex));
+        }
+        co_return ret;
     };
     co_return co_await _sl_controller.with_user_service_level(user, std::ref(f));
 }
@@ -834,77 +848,77 @@ server::server(executor& exec, service::storage_proxy& proxy, gms::gossiper& gos
         , _pending_requests("alternator::server::pending_requests")
         , _timeout_config(_proxy.data_dictionary().get_config())
       , _callbacks{
-        {"CreateTable", [] (executor& e, executor::client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value json_request, std::unique_ptr<request> req) {
-            return e.create_table(client_state, std::move(trace_state), std::move(permit), std::move(json_request));
+        {"CreateTable", [] (executor& e, executor::client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value json_request, std::unique_ptr<request> req, std::unique_ptr<audit::audit_info_alternator>& audit_info) {
+            return e.create_table(client_state, std::move(trace_state), std::move(permit), std::move(json_request), audit_info);
         }},
-        {"DescribeTable", [] (executor& e, executor::client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value json_request, std::unique_ptr<request> req) {
-            return e.describe_table(client_state, std::move(trace_state), std::move(permit), std::move(json_request));
+        {"DescribeTable", [] (executor& e, executor::client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value json_request, std::unique_ptr<request> req, std::unique_ptr<audit::audit_info_alternator>& audit_info) {
+            return e.describe_table(client_state, std::move(trace_state), std::move(permit), std::move(json_request), audit_info);
         }},
-        {"DeleteTable", [] (executor& e, executor::client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value json_request, std::unique_ptr<request> req) {
-            return e.delete_table(client_state, std::move(trace_state), std::move(permit), std::move(json_request));
+        {"DeleteTable", [] (executor& e, executor::client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value json_request, std::unique_ptr<request> req, std::unique_ptr<audit::audit_info_alternator>& audit_info) {
+            return e.delete_table(client_state, std::move(trace_state), std::move(permit), std::move(json_request), audit_info);
         }},
-        {"UpdateTable", [] (executor& e, executor::client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value json_request, std::unique_ptr<request> req) {
-            return e.update_table(client_state, std::move(trace_state), std::move(permit), std::move(json_request));
+        {"UpdateTable", [] (executor& e, executor::client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value json_request, std::unique_ptr<request> req, std::unique_ptr<audit::audit_info_alternator>& audit_info) {
+            return e.update_table(client_state, std::move(trace_state), std::move(permit), std::move(json_request), audit_info);
         }},
-        {"PutItem", [] (executor& e, executor::client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value json_request, std::unique_ptr<request> req) {
-            return e.put_item(client_state, std::move(trace_state), std::move(permit), std::move(json_request));
+        {"PutItem", [] (executor& e, executor::client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value json_request, std::unique_ptr<request> req, std::unique_ptr<audit::audit_info_alternator>& audit_info) {
+            return e.put_item(client_state, std::move(trace_state), std::move(permit), std::move(json_request), audit_info);
         }},
-        {"UpdateItem", [] (executor& e, executor::client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value json_request, std::unique_ptr<request> req) {
-            return e.update_item(client_state, std::move(trace_state), std::move(permit), std::move(json_request));
+        {"UpdateItem", [] (executor& e, executor::client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value json_request, std::unique_ptr<request> req, std::unique_ptr<audit::audit_info_alternator>& audit_info) {
+            return e.update_item(client_state, std::move(trace_state), std::move(permit), std::move(json_request), audit_info);
         }},
-        {"GetItem", [] (executor& e, executor::client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value json_request, std::unique_ptr<request> req) {
-            return e.get_item(client_state, std::move(trace_state), std::move(permit), std::move(json_request));
+        {"GetItem", [] (executor& e, executor::client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value json_request, std::unique_ptr<request> req, std::unique_ptr<audit::audit_info_alternator>& audit_info) {
+            return e.get_item(client_state, std::move(trace_state), std::move(permit), std::move(json_request), audit_info);
         }},
-        {"DeleteItem", [] (executor& e, executor::client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value json_request, std::unique_ptr<request> req) {
-            return e.delete_item(client_state, std::move(trace_state), std::move(permit), std::move(json_request));
+        {"DeleteItem", [] (executor& e, executor::client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value json_request, std::unique_ptr<request> req, std::unique_ptr<audit::audit_info_alternator>& audit_info) {
+            return e.delete_item(client_state, std::move(trace_state), std::move(permit), std::move(json_request), audit_info);
         }},
-        {"ListTables", [] (executor& e, executor::client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value json_request, std::unique_ptr<request> req) {
-            return e.list_tables(client_state, std::move(permit), std::move(json_request));
+        {"ListTables", [] (executor& e, executor::client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value json_request, std::unique_ptr<request> req, std::unique_ptr<audit::audit_info_alternator>& audit_info) {
+            return e.list_tables(client_state, std::move(permit), std::move(json_request), audit_info);
         }},
-        {"Scan", [] (executor& e, executor::client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value json_request, std::unique_ptr<request> req) {
-            return e.scan(client_state, std::move(trace_state), std::move(permit), std::move(json_request));
+        {"Scan", [] (executor& e, executor::client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value json_request, std::unique_ptr<request> req, std::unique_ptr<audit::audit_info_alternator>& audit_info) {
+            return e.scan(client_state, std::move(trace_state), std::move(permit), std::move(json_request), audit_info);
         }},
-        {"DescribeEndpoints", [] (executor& e, executor::client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value json_request, std::unique_ptr<request> req) {
-            return e.describe_endpoints(client_state, std::move(permit), std::move(json_request), req->get_header("Host"));
+        {"DescribeEndpoints", [] (executor& e, executor::client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value json_request, std::unique_ptr<request> req, std::unique_ptr<audit::audit_info_alternator>& audit_info) {
+            return e.describe_endpoints(client_state, std::move(permit), std::move(json_request), req->get_header("Host"), audit_info);
         }},
-        {"BatchWriteItem", [] (executor& e, executor::client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value json_request, std::unique_ptr<request> req) {
-            return e.batch_write_item(client_state, std::move(trace_state), std::move(permit), std::move(json_request));
+        {"BatchWriteItem", [] (executor& e, executor::client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value json_request, std::unique_ptr<request> req, std::unique_ptr<audit::audit_info_alternator>& audit_info) {
+            return e.batch_write_item(client_state, std::move(trace_state), std::move(permit), std::move(json_request), audit_info);
         }},
-        {"BatchGetItem", [] (executor& e, executor::client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value json_request, std::unique_ptr<request> req) {
-            return e.batch_get_item(client_state, std::move(trace_state), std::move(permit), std::move(json_request));
+        {"BatchGetItem", [] (executor& e, executor::client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value json_request, std::unique_ptr<request> req, std::unique_ptr<audit::audit_info_alternator>& audit_info) {
+            return e.batch_get_item(client_state, std::move(trace_state), std::move(permit), std::move(json_request), audit_info);
         }},
-        {"Query", [] (executor& e, executor::client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value json_request, std::unique_ptr<request> req) {
-            return e.query(client_state, std::move(trace_state), std::move(permit), std::move(json_request));
+        {"Query", [] (executor& e, executor::client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value json_request, std::unique_ptr<request> req, std::unique_ptr<audit::audit_info_alternator>& audit_info) {
+            return e.query(client_state, std::move(trace_state), std::move(permit), std::move(json_request), audit_info);
         }},
-        {"TagResource", [] (executor& e, executor::client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value json_request, std::unique_ptr<request> req) {
-            return e.tag_resource(client_state, std::move(permit), std::move(json_request));
+        {"TagResource", [] (executor& e, executor::client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value json_request, std::unique_ptr<request> req, std::unique_ptr<audit::audit_info_alternator>& audit_info) {
+            return e.tag_resource(client_state, std::move(permit), std::move(json_request), audit_info);
         }},
-        {"UntagResource", [] (executor& e, executor::client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value json_request, std::unique_ptr<request> req) {
-            return e.untag_resource(client_state, std::move(permit), std::move(json_request));
+        {"UntagResource", [] (executor& e, executor::client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value json_request, std::unique_ptr<request> req, std::unique_ptr<audit::audit_info_alternator>& audit_info) {
+            return e.untag_resource(client_state, std::move(permit), std::move(json_request), audit_info);
         }},
-        {"ListTagsOfResource", [] (executor& e, executor::client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value json_request, std::unique_ptr<request> req) {
-            return e.list_tags_of_resource(client_state, std::move(permit), std::move(json_request));
+        {"ListTagsOfResource", [] (executor& e, executor::client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value json_request, std::unique_ptr<request> req, std::unique_ptr<audit::audit_info_alternator>& audit_info) {
+            return e.list_tags_of_resource(client_state, std::move(permit), std::move(json_request), audit_info);
         }},
-        {"UpdateTimeToLive", [] (executor& e, executor::client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value json_request, std::unique_ptr<request> req) {
-            return e.update_time_to_live(client_state, std::move(permit), std::move(json_request));
+        {"UpdateTimeToLive", [] (executor& e, executor::client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value json_request, std::unique_ptr<request> req, std::unique_ptr<audit::audit_info_alternator>& audit_info) {
+            return e.update_time_to_live(client_state, std::move(permit), std::move(json_request), audit_info);
         }},
-        {"DescribeTimeToLive", [] (executor& e, executor::client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value json_request, std::unique_ptr<request> req) {
-            return e.describe_time_to_live(client_state, std::move(permit), std::move(json_request));
+        {"DescribeTimeToLive", [] (executor& e, executor::client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value json_request, std::unique_ptr<request> req, std::unique_ptr<audit::audit_info_alternator>& audit_info) {
+            return e.describe_time_to_live(client_state, std::move(permit), std::move(json_request), audit_info);
         }},
-        {"ListStreams", [] (executor& e, executor::client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value json_request, std::unique_ptr<request> req) {
-            return e.list_streams(client_state, std::move(permit), std::move(json_request));
+        {"ListStreams", [] (executor& e, executor::client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value json_request, std::unique_ptr<request> req, std::unique_ptr<audit::audit_info_alternator>& audit_info) {
+            return e.list_streams(client_state, std::move(permit), std::move(json_request), audit_info);
         }},
-        {"DescribeStream", [] (executor& e, executor::client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value json_request, std::unique_ptr<request> req) {
-            return e.describe_stream(client_state, std::move(permit), std::move(json_request));
+        {"DescribeStream", [] (executor& e, executor::client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value json_request, std::unique_ptr<request> req, std::unique_ptr<audit::audit_info_alternator>& audit_info) {
+            return e.describe_stream(client_state, std::move(permit), std::move(json_request), audit_info);
         }},
-        {"GetShardIterator", [] (executor& e, executor::client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value json_request, std::unique_ptr<request> req) {
-            return e.get_shard_iterator(client_state, std::move(permit), std::move(json_request));
+        {"GetShardIterator", [] (executor& e, executor::client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value json_request, std::unique_ptr<request> req, std::unique_ptr<audit::audit_info_alternator>& audit_info) {
+            return e.get_shard_iterator(client_state, std::move(permit), std::move(json_request), audit_info);
         }},
-        {"GetRecords", [] (executor& e, executor::client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value json_request, std::unique_ptr<request> req) {
-            return e.get_records(client_state, std::move(trace_state), std::move(permit), std::move(json_request));
+        {"GetRecords", [] (executor& e, executor::client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value json_request, std::unique_ptr<request> req, std::unique_ptr<audit::audit_info_alternator>& audit_info) {
+            return e.get_records(client_state, std::move(trace_state), std::move(permit), std::move(json_request), audit_info);
         }},
-        {"DescribeContinuousBackups", [] (executor& e, executor::client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value json_request, std::unique_ptr<request> req) {
-            return e.describe_continuous_backups(client_state, std::move(permit), std::move(json_request));
+        {"DescribeContinuousBackups", [] (executor& e, executor::client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value json_request, std::unique_ptr<request> req, std::unique_ptr<audit::audit_info_alternator>& audit_info) {
+            return e.describe_continuous_backups(client_state, std::move(permit), std::move(json_request), audit_info);
         }},
     } {
 }

--- a/alternator/server.hh
+++ b/alternator/server.hh
@@ -34,7 +34,7 @@ class server : public peering_sharded_service<server> {
     // DynamoDB also has the same limit set to 16 MB.
     static constexpr size_t request_content_length_limit = 16*MB;
     using alternator_callback = std::function<future<executor::request_return_type>(executor&, executor::client_state&,
-            tracing::trace_state_ptr, service_permit, rjson::value, std::unique_ptr<http::request>)>;
+            tracing::trace_state_ptr, service_permit, rjson::value, std::unique_ptr<http::request>, std::unique_ptr<audit::audit_info_alternator>&)>;
     using alternator_callbacks_map = std::unordered_map<std::string_view, alternator_callback>;
 
     httpd::http_server _http_server;

--- a/alternator/streams.cc
+++ b/alternator/streams.cc
@@ -190,7 +190,7 @@ struct rapidjson::internal::TypeHelper<ValueType, alternator::stream_arn>
 
 namespace alternator {
 
-future<alternator::executor::request_return_type> alternator::executor::list_streams(client_state& client_state, service_permit permit, rjson::value request) {
+future<alternator::executor::request_return_type> alternator::executor::list_streams(client_state& client_state, service_permit permit, rjson::value request, std::unique_ptr<audit::audit_info_alternator>& audit_info) {
     _stats.api_operations.list_streams++;
 
     auto limit = rjson::get_opt<int>(request, "Limit").value_or(100);
@@ -201,6 +201,11 @@ future<alternator::executor::request_return_type> alternator::executor::list_str
     if (limit < 1) {
         throw api_error::validation("Limit must be 1 or more");
     }
+
+    // Audit the input table name (if specified), not the output table names.
+    maybe_audit(audit_info, audit::statement_category::QUERY,
+                table ? table->ks_name() : "", table ? table->cf_name() : "",
+                "ListStreams", request);
 
     std::vector<data_dictionary::table> cfs;
 
@@ -242,27 +247,23 @@ future<alternator::executor::request_return_type> alternator::executor::list_str
 
     auto ret = rjson::empty_object();
     auto streams = rjson::empty_array();
-
     std::optional<stream_shard_id> last;
 
     for (;limit > 0 && i != e; ++i) {
         auto s = i->schema();
         auto& ks_name = s->ks_name();
         auto& cf_name = s->cf_name();
-
         if (!is_alternator_keyspace(ks_name)) {
             continue;
         }
         if (cdc::is_log_for_some_table(db.real_database(), ks_name, cf_name)) {
             rjson::value new_entry = rjson::empty_object();
-
             last = i->schema()->id();
             auto arn = stream_arn{ i->schema(), cdc::get_base_table(db.real_database(), *i->schema()) };
             rjson::add(new_entry, "StreamArn", arn);
             rjson::add(new_entry, "StreamLabel", rjson::from_string(stream_label(*s)));
             rjson::add(new_entry, "TableName", rjson::from_string(cdc::base_name(table_name(*s))));
             rjson::push_back(streams, std::move(new_entry));
-
             --limit;
         }
     }
@@ -272,7 +273,6 @@ future<alternator::executor::request_return_type> alternator::executor::list_str
     if (last) {
         rjson::add(ret, "LastEvaluatedStreamArn", *last);
     }
-
     return make_ready_future<executor::request_return_type>(rjson::print(std::move(ret)));
 }
 
@@ -503,7 +503,7 @@ const cdc::stream_id& find_parent_shard_in_previous_generation(db_clock::time_po
     return *it;
 }
 
-future<executor::request_return_type> executor::describe_stream(client_state& client_state, service_permit permit, rjson::value request) {
+future<executor::request_return_type> executor::describe_stream(client_state& client_state, service_permit permit, rjson::value request, std::unique_ptr<audit::audit_info_alternator>& audit_info) {
     _stats.api_operations.describe_stream++;
 
     auto limit = rjson::get_opt<int>(request, "Limit").value_or(100); // according to spec
@@ -525,6 +525,12 @@ future<executor::request_return_type> executor::describe_stream(client_state& cl
     if (!schema || !bs || !is_alternator_keyspace(schema->ks_name())) {
         throw api_error::resource_not_found("Invalid StreamArn");
     }
+    auto normal_token_owners = _proxy.get_token_metadata_ptr()->count_normal_token_owners();
+
+    // _sdks.cdc_get_versioned_streams() uses quorum_if_many() underneath, which uses CL=QUORUM for many token owners and CL=ONE otherwise.
+    auto describe_cl = (normal_token_owners > 1) ? db::consistency_level::QUORUM : db::consistency_level::ONE;
+    maybe_audit(audit_info, audit::statement_category::QUERY, schema->ks_name(),
+                bs->cf_name() + "|" + schema->cf_name(), "DescribeStream", request, describe_cl);
 
     if (limit < 1) {
         throw api_error::validation("Limit must be 1 or more");
@@ -570,8 +576,6 @@ future<executor::request_return_type> executor::describe_stream(client_state& cl
 
     // TODO: label
     // TODO: creation time
-
-    auto normal_token_owners = _proxy.get_token_metadata_ptr()->count_normal_token_owners();
 
     // filter out cdc generations older than the table or now() - cdc::ttl (typically dynamodb_streams_max_window - 24h)
     auto low_ts = std::max(as_timepoint(schema->id()), db_clock::now() - ttl);
@@ -773,7 +777,7 @@ struct rapidjson::internal::TypeHelper<ValueType, alternator::shard_iterator_typ
 
 namespace alternator {
 
-future<executor::request_return_type> executor::get_shard_iterator(client_state& client_state, service_permit permit, rjson::value request) {
+future<executor::request_return_type> executor::get_shard_iterator(client_state& client_state, service_permit permit, rjson::value request, std::unique_ptr<audit::audit_info_alternator>& audit_info) {
     _stats.api_operations.get_shard_iterator++;
 
     auto type = rjson::get<shard_iterator_type>(request, "ShardIteratorType");
@@ -791,13 +795,20 @@ future<executor::request_return_type> executor::get_shard_iterator(client_state&
 
     std::optional<shard_id> sid;
     auto schema = get_schema_from_arn(_proxy, stream_arn);
+    schema_ptr base_schema = nullptr;
     try {
+        base_schema = cdc::get_base_table(db.real_database(), *schema);
         sid = rjson::get<shard_id>(request, "ShardId");
     } catch (...) {
     }
-    if (!schema || !cdc::get_base_table(db.real_database(), *schema) || !is_alternator_keyspace(schema->ks_name())) {
+    if (!schema || !base_schema || !is_alternator_keyspace(schema->ks_name())) {
         throw api_error::resource_not_found("Invalid StreamArn");
     }
+
+    // Uses only node-local context (the metadata) to generate response
+    maybe_audit(audit_info, audit::statement_category::QUERY, schema->ks_name(),
+                base_schema->cf_name() + "|" + schema->cf_name(), "GetShardIterator", request);
+
     if (!sid) {
         throw api_error::resource_not_found("Invalid ShardId");
     }
@@ -830,7 +841,6 @@ future<executor::request_return_type> executor::get_shard_iterator(client_state&
 
     auto ret = rjson::empty_object();
     rjson::add(ret, "ShardIterator", iter);
-
     return make_ready_future<executor::request_return_type>(rjson::print(std::move(ret)));
 }
 
@@ -873,7 +883,7 @@ namespace alternator {
         };
     }
 
-future<executor::request_return_type> executor::get_records(client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value request) {
+future<executor::request_return_type> executor::get_records(client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value request, std::unique_ptr<audit::audit_info_alternator>& audit_info) {
     _stats.api_operations.get_records++;
     auto start_time = std::chrono::steady_clock::now();
 
@@ -899,16 +909,17 @@ future<executor::request_return_type> executor::get_records(client_state& client
     if (!schema || !base || !is_alternator_keyspace(schema->ks_name())) {
         co_return api_error::resource_not_found(fmt::to_string(iter.table));
     }
+    db::consistency_level cl = db::consistency_level::LOCAL_QUORUM;
+
+    maybe_audit(audit_info, audit::statement_category::QUERY, schema->ks_name(),
+                base->cf_name() + "|" + schema->cf_name(), "GetRecords", request, cl);
 
     tracing::add_table_name(trace_state, schema->ks_name(), schema->cf_name());
 
     co_await verify_permission(_enforce_authorization, _warn_authorization, client_state, schema, auth::permission::SELECT, _stats);
 
-    db::consistency_level cl = db::consistency_level::LOCAL_QUORUM;
     partition_key pk = iter.shard.id.to_partition_key(*schema);
-
     dht::partition_range_vector partition_ranges{ dht::partition_range::make_singular(dht::decorate_key(*schema, pk)) };
-
     auto high_ts = db_clock::now() - confidence_interval(db);
     auto high_uuid = utils::UUID_gen::min_time_UUID(high_ts.time_since_epoch());
     auto lo = clustering_key_prefix::from_exploded(*schema, { iter.threshold.serialize() });
@@ -988,17 +999,17 @@ future<executor::request_return_type> executor::get_records(client_state& client
 
     auto& metadata = result_set->get_metadata();
 
-    auto op_index = std::distance(metadata.get_names().begin(), 
+    auto op_index = std::distance(metadata.get_names().begin(),
         std::find_if(metadata.get_names().begin(), metadata.get_names().end(), [](const lw_shared_ptr<cql3::column_specification>& cdef) {
             return cdef->name->name() == op_column_name;
         })
     );
-    auto ts_index = std::distance(metadata.get_names().begin(), 
+    auto ts_index = std::distance(metadata.get_names().begin(),
         std::find_if(metadata.get_names().begin(), metadata.get_names().end(), [](const lw_shared_ptr<cql3::column_specification>& cdef) {
             return cdef->name->name() == timestamp_column_name;
         })
     );
-    auto eor_index = std::distance(metadata.get_names().begin(), 
+    auto eor_index = std::distance(metadata.get_names().begin(),
         std::find_if(metadata.get_names().begin(), metadata.get_names().end(), [](const lw_shared_ptr<cql3::column_specification>& cdef) {
             return cdef->name->name() == eor_column_name;
         })
@@ -1043,19 +1054,19 @@ future<executor::request_return_type> executor::get_records(client_state& client
         /**
          * We merge rows with same timestamp into a single event.
          * This is pretty much needed, because a CDC row typically
-         * encodes ~half the info of an alternator write. 
-         * 
+         * encodes ~half the info of an alternator write.
+         *
          * A big, big downside to how alternator records are written
          * (i.e. CQL), is that the distinction between INSERT and UPDATE
-         * is somewhat lost/unmappable to actual eventName. 
+         * is somewhat lost/unmappable to actual eventName.
          * A write (currently) always looks like an insert+modify
-         * regardless whether we wrote existing record or not. 
-         * 
-         * Maybe RMW ops could be done slightly differently so 
+         * regardless whether we wrote existing record or not.
+         *
+         * Maybe RMW ops could be done slightly differently so
          * we can distinguish them here...
-         * 
+         *
          * For now, all writes will become MODIFY.
-         * 
+         *
          * Note: we do not check the current pre/post
          * flags on CDC log, instead we use data to 
          * drive what is returned. This is (afaict)

--- a/alternator/ttl.cc
+++ b/alternator/ttl.cc
@@ -58,13 +58,17 @@ static logging::logger tlogger("alternator_ttl");
 
 namespace alternator {
 
-future<executor::request_return_type> executor::update_time_to_live(client_state& client_state, service_permit permit, rjson::value request) {
+future<executor::request_return_type> executor::update_time_to_live(client_state& client_state, service_permit permit, rjson::value request, std::unique_ptr<audit::audit_info_alternator>& audit_info) {
     _stats.api_operations.update_time_to_live++;
     if (!_proxy.features().alternator_ttl) {
         co_return api_error::unknown_operation("UpdateTimeToLive not yet supported. Upgrade all nodes to a version that supports it.");
     }
 
     schema_ptr schema = get_table(_proxy, request);
+
+    maybe_audit(audit_info, audit::statement_category::DDL,
+                schema->ks_name(), schema->cf_name(), "UpdateTimeToLive", request);
+
     rjson::value* spec = rjson::find(request, "TimeToLiveSpecification");
     if (!spec || !spec->IsObject()) {
         co_return api_error::validation("UpdateTimeToLive missing mandatory TimeToLiveSpecification");
@@ -114,9 +118,13 @@ future<executor::request_return_type> executor::update_time_to_live(client_state
     co_return rjson::print(std::move(response));
 }
 
-future<executor::request_return_type> executor::describe_time_to_live(client_state& client_state, service_permit permit, rjson::value request) {
+future<executor::request_return_type> executor::describe_time_to_live(client_state& client_state, service_permit permit, rjson::value request, std::unique_ptr<audit::audit_info_alternator>& audit_info) {
     _stats.api_operations.describe_time_to_live++;
     schema_ptr schema = get_table(_proxy, request);
+    
+    maybe_audit(audit_info, audit::statement_category::QUERY,
+                schema->ks_name(), schema->cf_name(), "DescribeTimeToLive", request);
+
     std::map<sstring, sstring> tags_map = get_tags_of_table_or_throw(schema);
     rjson::value desc = rjson::empty_object();
     auto i = tags_map.find(TTL_TAG_KEY);

--- a/audit/audit.cc
+++ b/audit/audit.cc
@@ -228,25 +228,53 @@ future<> audit::shutdown() {
     return make_ready_future<>();
 }
 
-future<> audit::log(const audit_info* audit_info, service::query_state& query_state, const cql3::query_options& options, bool error) {
-    const service::client_state& client_state = query_state.get_client_state();
-    socket_address node_ip = _token_metadata.get()->get_topology().my_address().addr();
-    db::consistency_level cl = options.get_consistency();
+future<> audit::log(const audit_info& audit_info, const service::client_state& client_state, std::optional<db::consistency_level> cl, bool error) {
     thread_local static sstring no_username("undefined");
     static const sstring anonymous_username("anonymous");
     const sstring& username = client_state.user() ? client_state.user()->name.value_or(anonymous_username) : no_username;
     socket_address client_ip = client_state.get_client_address().addr();
+    socket_address node_ip = _token_metadata.get()->get_topology().my_address().addr();
     if (logger.is_enabled(logging::log_level::debug)) {
         logger.debug("Log written: node_ip {} category {} cl {} error {} keyspace {} query '{}' client_ip {} table {} username {}",
-            node_ip, audit_info->category_string(), cl, error, audit_info->keyspace(),
-            audit_info->query(), client_ip, audit_info->table(), username);
+            node_ip, audit_info.category_string(), cl, error, audit_info.keyspace(),
+            audit_info.query(), client_ip, audit_info.table(), username);
     }
-    return futurize_invoke(std::mem_fn(&storage_helper::write), _storage_helper_ptr, audit_info, node_ip, client_ip, cl, username, error)
+    return futurize_invoke(std::mem_fn(&storage_helper::write), _storage_helper_ptr, &audit_info, node_ip, client_ip, cl, username, error)
         .handle_exception([audit_info, node_ip, client_ip, cl, username, error] (auto ep) {
             logger.error("Unexpected exception when writing log with: node_ip {} category {} cl {} error {} keyspace {} query '{}' client_ip {} table {} username {} exception {}",
-                node_ip, audit_info->category_string(), cl, error, audit_info->keyspace(),
-                audit_info->query(), client_ip, audit_info->table(),username, ep);
+                node_ip, audit_info.category_string(), cl, error, audit_info.keyspace(),
+                audit_info.query(), client_ip, audit_info.table(), username, ep);
     });
+}
+
+static future<> maybe_log(const audit_info& audit_info, const service::client_state& client_state, std::optional<db::consistency_level> cl, bool error) {
+    if(audit::audit_instance().local_is_initialized() && audit::local_audit_instance().should_log(audit_info)) {
+        return audit::local_audit_instance().log(audit_info, client_state, cl, error);
+    }
+    return make_ready_future<>();
+}
+
+static future<> inspect(const audit_info& audit_info, const service::query_state& query_state, const cql3::query_options& options, bool error) {
+    return maybe_log(audit_info, query_state.get_client_state(), options.get_consistency(), error);
+}
+
+future<> inspect(shared_ptr<cql3::cql_statement> statement, const service::query_state& query_state, const cql3::query_options& options, bool error) {
+    const auto audit_info = statement->get_audit_info();
+    if (audit_info == nullptr) {
+        return make_ready_future<>();
+    }
+    if (audit_info->batch()) {
+        cql3::statements::batch_statement* batch = dynamic_cast<cql3::statements::batch_statement*>(statement.get());
+        return do_for_each(batch->statements().begin(), batch->statements().end(), [&query_state, &options, error] (auto&& m) {
+            return inspect(m.statement, query_state, options, error);
+        });
+    } else {
+        return inspect(*audit_info, query_state, options, error);
+    }
+}
+
+future<> inspect(const audit_info_alternator& ai, const service::client_state& client_state, bool error) {
+    return maybe_log(static_cast<const audit_info&>(ai), client_state, ai.get_cl(), error);
 }
 
 future<> audit::log_login(const sstring& username, socket_address client_ip, bool error) noexcept {
@@ -262,24 +290,6 @@ future<> audit::log_login(const sstring& username, socket_address client_ip, boo
     });
 }
 
-future<> inspect(shared_ptr<cql3::cql_statement> statement, service::query_state& query_state, const cql3::query_options& options, bool error) {
-    auto audit_info = statement->get_audit_info();
-    if (!audit_info) {
-        return make_ready_future<>();
-    }
-    if (audit_info->batch()) {
-        cql3::statements::batch_statement* batch = static_cast<cql3::statements::batch_statement*>(statement.get());
-        return do_for_each(batch->statements().begin(), batch->statements().end(), [&query_state, &options, error] (auto&& m) {
-            return inspect(m.statement, query_state, options, error);
-        });
-    } else {
-        if (audit::local_audit_instance().should_log(audit_info)) {
-            return audit::local_audit_instance().log(audit_info, query_state, options, error);
-        }
-        return make_ready_future<>();
-    }
-}
-
 future<> inspect_login(const sstring& username, socket_address client_ip, bool error) {
     if (!audit::audit_instance().local_is_initialized() || !audit::local_audit_instance().should_log_login()) {
         return make_ready_future<>();
@@ -292,13 +302,21 @@ bool audit::should_log_table(const sstring& keyspace, const sstring& name) const
     return keyspace_it != _audited_tables.cend() && keyspace_it->second.find(name) != keyspace_it->second.cend();
 }
 
-bool audit::should_log(const audit_info* audit_info) const {
-    return _audited_categories.contains(audit_info->category())
-           && (_audited_keyspaces.find(audit_info->keyspace()) != _audited_keyspaces.cend()
-                         || should_log_table(audit_info->keyspace(), audit_info->table())
-                         || audit_info->category() == statement_category::AUTH
-                         || audit_info->category() == statement_category::ADMIN
-                         || audit_info->category() == statement_category::DCL);
+bool audit::should_log(const audit_info& audit_info) const {
+    return will_log(audit_info.category(), audit_info.keyspace(), audit_info.table());
+}
+
+bool audit::will_log(statement_category cat, std::string_view keyspace, std::string_view table) const {
+    // If keyspace is empty (e.g., ListTables, or batch operations spanning
+    // multiple tables), the operation cannot be filtered by keyspace/table,
+    // so it is logged whenever the category matches.
+    return _audited_categories.contains(cat)
+           && (keyspace.empty()
+                         || _audited_keyspaces.find(sstring(keyspace)) != _audited_keyspaces.cend()
+                         || should_log_table(sstring(keyspace), sstring(table))
+                         || cat == statement_category::AUTH
+                         || cat == statement_category::ADMIN
+                         || cat == statement_category::DCL);
 }
 
 template<class T>

--- a/audit/audit.cc
+++ b/audit/audit.cc
@@ -126,6 +126,13 @@ static std::map<sstring, std::set<sstring>> parse_audit_tables(const sstring& da
             }
             boost::trim(parts[0]);
             boost::trim(parts[1]);
+            // The real keyspace name of an Alternator table T is
+            // "alternator_T". The audit_tables config flag uses the format
+            // "alternator.T" to refer to such tables, so we expand it here
+            // to the real keyspace name.
+            if (parts[0] == "alternator") {
+                parts[0] = "alternator_" + parts[1];
+            }
             result[parts[0]].insert(std::move(parts[1]));
         }
     }

--- a/audit/audit.hh
+++ b/audit/audit.hh
@@ -10,14 +10,15 @@
 #include "seastarx.hh"
 #include "utils/log.hh"
 #include "utils/observable.hh"
-#include "db/consistency_level.hh"
-#include "locator/token_metadata_fwd.hh"
+#include "service/client_state.hh"
+#include "db/consistency_level_type.hh"
 #include <seastar/core/sharded.hh>
 #include <seastar/util/log.hh>
 
 #include "enum_set.hh"
 
 #include <memory>
+#include <optional>
 
 namespace db {
 
@@ -70,12 +71,15 @@ using category_set = enum_set<super_enum<statement_category, statement_category:
                                                              statement_category::AUTH,
                                                              statement_category::ADMIN>>;
 
-class audit_info final {
+// Holds the audit metadata for a single request: the operation category,
+// target keyspace/table, and the query string to be logged.
+class audit_info {
+protected:
     statement_category _category;
     sstring _keyspace;
     sstring _table;
     sstring _query;
-    bool _batch;
+    bool _batch; // used only for unpacking batches in CQL, not relevant for Alternator
 public:
     audit_info(statement_category cat, sstring keyspace, sstring table, bool batch)
         : _category(cat)
@@ -83,8 +87,17 @@ public:
         , _table(std::move(table))
         , _batch(batch)
     { }
-    void set_query_string(const std::string_view& query_string) {
-        _query = sstring(query_string);
+    // 'operation' is for the cases where the query string does not contain it, like with Alternator
+    audit_info& set_query_string(std::string_view query_string, std::string_view operation = {}) {
+        return set_query_string(sstring(query_string), sstring(operation));
+    }
+    audit_info& set_query_string(const sstring& query_string, const sstring& operation = "") {
+        if(!operation.empty()) {
+            _query = operation + "|" + query_string;
+        } else {
+            _query = query_string;
+        }
+        return *this;
     }
     const sstring& keyspace() const { return _keyspace; }
     const sstring& table() const { return _table; }
@@ -95,6 +108,23 @@ public:
 };
 
 using audit_info_ptr = std::unique_ptr<audit_info>;
+
+// Audit info for Alternator requests.
+// Unlike CQL, where the consistency level is available from query_options and
+// passed separately to audit::log(), Alternator has no query_options, so we
+// store the CL inside the audit_info object.
+// Consistency level is optional: only data read/write operations (GetItem,
+// PutItem, Query, Scan, etc.) have a meaningful CL. Schema operations and
+// metadata queries pass std::nullopt.
+class audit_info_alternator final : public audit_info {
+    std::optional<db::consistency_level> _cl;
+public:
+    audit_info_alternator(statement_category cat, sstring keyspace, sstring table, std::optional<db::consistency_level> cl = std::nullopt)
+        : audit_info(cat, std::move(keyspace), std::move(table), false), _cl(cl)
+    {}
+
+    std::optional<db::consistency_level> get_cl() const { return _cl; }
+};
 
 class storage_helper;
 
@@ -142,13 +172,15 @@ public:
     future<> start(const db::config& cfg);
     future<> stop();
     future<> shutdown();
-    bool should_log(const audit_info* audit_info) const;
+    bool should_log(const audit_info& audit_info) const;
+    bool will_log(statement_category cat, std::string_view keyspace = {}, std::string_view table = {}) const;
     bool should_log_login() const { return _audited_categories.contains(statement_category::AUTH); }
-    future<> log(const audit_info* audit_info, service::query_state& query_state, const cql3::query_options& options, bool error);
+    future<> log(const audit_info& audit_info, const service::client_state& client_state, std::optional<db::consistency_level> cl, bool error);
     future<> log_login(const sstring& username, socket_address client_ip, bool error) noexcept;
 };
 
-future<> inspect(shared_ptr<cql3::cql_statement> statement, service::query_state& query_state, const cql3::query_options& options, bool error);
+future<> inspect(const audit_info_alternator& audit_info, const service::client_state& client_state, bool error);
+future<> inspect(shared_ptr<cql3::cql_statement> statement, const service::query_state& query_state, const cql3::query_options& options, bool error);
 
 future<> inspect_login(const sstring& username, socket_address client_ip, bool error);
 

--- a/audit/audit_cf_storage_helper.cc
+++ b/audit/audit_cf_storage_helper.cc
@@ -129,7 +129,7 @@ future<> audit_cf_storage_helper::stop() {
 future<> audit_cf_storage_helper::write(const audit_info* audit_info,
                                     socket_address node_ip,
                                     socket_address client_ip,
-                                    db::consistency_level cl,
+                                    std::optional<db::consistency_level> cl,
                                     const sstring& username,
                                     bool error) {
     return _table.insert(_qp, _mm, _dummy_query_state, make_data, audit_info, node_ip, client_ip, cl, username, error);
@@ -145,7 +145,7 @@ future<> audit_cf_storage_helper::write_login(const sstring& username,
 cql3::query_options audit_cf_storage_helper::make_data(const audit_info* audit_info,
                                                        socket_address node_ip,
                                                        socket_address client_ip,
-                                                       db::consistency_level cl,
+                                                       std::optional<db::consistency_level> cl,
                                                        const sstring& username,
                                                        bool error) {
     auto time = std::chrono::system_clock::now();
@@ -154,7 +154,7 @@ cql3::query_options audit_cf_storage_helper::make_data(const audit_info* audit_i
     auto date = millis_since_epoch / ticks_per_day * ticks_per_day;
     thread_local static int64_t last_nanos = 0;
     auto time_id = utils::UUID_gen::get_time_UUID(table_helper::make_monotonic_UUID_tp(last_nanos, time));
-    auto consistency_level = fmt::format("{}", cl);
+    auto consistency_level = cl ? format("{}", *cl) : sstring("");
     std::vector<cql3::raw_value> values {
         cql3::raw_value::make_value(timestamp_type->decompose(date)),
         cql3::raw_value::make_value(inet_addr_type->decompose(node_ip.addr())),

--- a/audit/audit_cf_storage_helper.hh
+++ b/audit/audit_cf_storage_helper.hh
@@ -37,7 +37,7 @@ class audit_cf_storage_helper : public storage_helper {
     static cql3::query_options make_data(const audit_info* audit_info,
                                          socket_address node_ip,
                                          socket_address client_ip,
-                                         db::consistency_level cl,
+                                         std::optional<db::consistency_level> cl,
                                          const sstring& username,
                                          bool error);
     static cql3::query_options make_login_data(socket_address node_ip,
@@ -55,7 +55,7 @@ public:
     virtual future<> write(const audit_info* audit_info,
                            socket_address node_ip,
                            socket_address client_ip,
-                           db::consistency_level cl,
+                           std::optional<db::consistency_level> cl,
                            const sstring& username,
                            bool error) override;
     virtual future<> write_login(const sstring& username,

--- a/audit/audit_composite_storage_helper.cc
+++ b/audit/audit_composite_storage_helper.cc
@@ -42,7 +42,7 @@ future<> audit_composite_storage_helper::stop() {
 future<> audit_composite_storage_helper::write(const audit_info* audit_info,
                                                socket_address node_ip,
                                                socket_address client_ip,
-                                               db::consistency_level cl,
+                                               std::optional<db::consistency_level> cl,
                                                const sstring& username,
                                                bool error) {
     return seastar::parallel_for_each(

--- a/audit/audit_composite_storage_helper.hh
+++ b/audit/audit_composite_storage_helper.hh
@@ -25,7 +25,7 @@ public:
     virtual future<> write(const audit_info* audit_info,
                            socket_address node_ip,
                            socket_address client_ip,
-                           db::consistency_level cl,
+                           std::optional<db::consistency_level> cl,
                            const sstring& username,
                            bool error) override;
     virtual future<> write_login(const sstring& username,

--- a/audit/audit_syslog_storage_helper.cc
+++ b/audit/audit_syslog_storage_helper.cc
@@ -101,18 +101,19 @@ future<> audit_syslog_storage_helper::stop() {
 future<> audit_syslog_storage_helper::write(const audit_info* audit_info,
                                             socket_address node_ip,
                                             socket_address client_ip,
-                                            db::consistency_level cl,
+                                            std::optional<db::consistency_level> cl,
                                             const sstring& username,
                                             bool error) {
     auto now = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
     tm time;
     localtime_r(&now, &time);
+    auto cl_str = cl ? format("{}", *cl) : sstring("");
     sstring msg = seastar::format(R"(<{}>{:%h %e %T} scylla-audit: node="{}", category="{}", cl="{}", error="{}", keyspace="{}", query="{}", client_ip="{}", table="{}", username="{}")",
                                     LOG_NOTICE | LOG_USER,
                                     time,
                                     node_ip,
                                     audit_info->category_string(),
-                                    cl,
+                                    cl_str,
                                     (error ? "true" : "false"),
                                     audit_info->keyspace(),
                                     json_escape(audit_info->query()),

--- a/audit/audit_syslog_storage_helper.hh
+++ b/audit/audit_syslog_storage_helper.hh
@@ -35,7 +35,7 @@ public:
     virtual future<> write(const audit_info* audit_info,
                            socket_address node_ip,
                            socket_address client_ip,
-                           db::consistency_level cl,
+                           std::optional<db::consistency_level> cl,
                            const sstring& username,
                            bool error) override;
     virtual future<> write_login(const sstring& username,

--- a/audit/storage_helper.hh
+++ b/audit/storage_helper.hh
@@ -22,7 +22,7 @@ public:
     virtual future<> write(const audit_info* audit_info,
                            socket_address node_ip,
                            socket_address client_ip,
-                           db::consistency_level cl,
+                           std::optional<db::consistency_level> cl,
                            const sstring& username,
                            bool error) = 0;
     virtual future<> write_login(const sstring& username,

--- a/test/alternator/test_audit.py
+++ b/test/alternator/test_audit.py
@@ -148,6 +148,19 @@ def _assert_audit_entries(rows, expected, ks_name=None, table_name=None):
             assert fragment in actual_operation, f"Expected substring '{fragment}' not found in operation {actual_operation}"
 
 
+# Assert that no entries in `rows` match the given filters.
+# Used by negative (unhappy-path) tests to verify that operations which should
+# NOT be audited did not produce any audit entries.
+def _assert_no_audit_entries_for(rows, ks_name=None, table_name=None, category=None):
+    matching = [r for r in rows if
+        (ks_name is None or r.keyspace_name == ks_name) and
+        (table_name is None or r.table_name == table_name) and
+        (category is None or r.category == category)]
+    assert len(matching) == 0, (
+        f"Expected no audit entries matching ks={ks_name}, table={table_name}, "
+        f"category={category}, but found {len(matching)}: {_simplify_rows(matching)}")
+
+
 # system.config stores values as JSON-encoded strings with surrounding quotes.
 # Strip them so that writing back via a parameterized UPDATE doesn't double-quote.
 def _strip_config_quotes(val):
@@ -501,3 +514,156 @@ def test_audit_streams_operations(dynamodb, dynamodbstreams, cql, alternator_aud
         # Each individual Alternator call above must be audited.
         new_rows = _get_new_audit_log_rows(cql, before_rows, expected_new_row_count=len(expected))
         _assert_audit_entries(new_rows, expected)
+
+
+# --- Unhappy-path / negative tests ---
+# The tests below verify that audit entries are NOT generated when the audit
+# configuration should filter them out, and that error entries are recorded
+# correctly.
+
+
+# Test that operations whose category is excluded from audit_categories are NOT logged.
+# Each phase enables only one category and performs both a positive (should-be-logged)
+# and a negative (should-NOT-be-logged) operation. The negative event is performed first;
+# once the positive event's audit entry arrives, the absence of the negative entry is
+# conclusive — they share the same audit pipeline.
+def test_audit_category_filtering(dynamodb, cql, alternator_audit_enabled):
+    with new_test_table(dynamodb, **HASH_AND_RANGE_SCHEMA) as table:
+        ks_name = f"alternator_{table.name}"
+        client = table.meta.client
+        # Pre-populate so reads return data.
+        table.put_item(Item={"p": "pk_0", "c": "ck_0", "v": "val"})
+        cql.execute("UPDATE system.config SET value=%s WHERE name='audit_keyspaces'", (ks_name,))
+
+        # Phase A: DML excluded (only QUERY enabled).
+        cql.execute("UPDATE system.config SET value=%s WHERE name='audit_categories'", ("QUERY",))
+        before_rows = _get_audit_log_rows(cql)
+        # Negative: PutItem is DML — should NOT be logged.
+        table.put_item(Item={"p": "pk_neg", "c": "ck_neg", "v": "neg"})
+        # Positive: GetItem is QUERY — should be logged.
+        table.get_item(Key={"p": "pk_0", "c": "ck_0"})
+        expected_a = [("QUERY", "LOCAL_ONE", False, ks_name, table.name, ["GetItem", "pk_0", "ck_0"])]
+        new_rows = _get_new_audit_log_rows(cql, before_rows, expected_new_row_count=1)
+        _assert_audit_entries(new_rows, expected_a, ks_name, table.name)
+        _assert_no_audit_entries_for(new_rows, category="DML")
+        with pytest.raises(AssertionError):
+            _assert_no_audit_entries_for(new_rows, category="QUERY")  # sanity check
+
+        # Phase B: QUERY excluded (only DML enabled).
+        cql.execute("UPDATE system.config SET value=%s WHERE name='audit_categories'", ("DML",))
+        before_rows = _get_audit_log_rows(cql)
+        # Negative: GetItem is QUERY — should NOT be logged.
+        table.get_item(Key={"p": "pk_0", "c": "ck_0"})
+        # Positive: PutItem is DML — should be logged.
+        table.put_item(Item={"p": "pk_pos_b", "c": "ck_pos_b", "v": "pos_b"})
+        expected_b = [("DML", "LOCAL_QUORUM", False, ks_name, table.name, ["PutItem", "pk_pos_b"])]
+        new_rows = _get_new_audit_log_rows(cql, before_rows, expected_new_row_count=1)
+        _assert_audit_entries(new_rows, expected_b, ks_name, table.name)
+        _assert_no_audit_entries_for(new_rows, category="QUERY")
+        with pytest.raises(AssertionError):
+            _assert_no_audit_entries_for(new_rows, category="DML")  # sanity check
+
+        # Phase C: DDL excluded (only DML and QUERY enabled).
+        cql.execute("UPDATE system.config SET value=%s WHERE name='audit_categories'", ("DML,QUERY",))
+        before_rows = _get_audit_log_rows(cql)
+        # Get table ARN for TagResource (a DDL operation).
+        desc = client.describe_table(TableName=table.name)
+        table_arn = desc['Table']['TableArn']
+        # Negative: TagResource is DDL — should NOT be logged.
+        client.tag_resource(ResourceArn=table_arn, Tags=[{"Key": "env", "Value": "test"}])
+        # Positive: PutItem is DML — should be logged.
+        # Note: DescribeTable above is QUERY and will also be logged.
+        table.put_item(Item={"p": "pk_pos_c", "c": "ck_pos_c", "v": "pos_c"})
+        expected_c = [
+            ("QUERY", "", False, ks_name, table.name, ["DescribeTable", table.name]),
+            ("DML", "LOCAL_QUORUM", False, ks_name, table.name, ["PutItem", "pk_pos_c"]),
+        ]
+        new_rows = _get_new_audit_log_rows(cql, before_rows, expected_new_row_count=2)
+        _assert_audit_entries(new_rows, expected_c, ks_name, table.name)
+        _assert_no_audit_entries_for(new_rows, category="DDL")
+        with pytest.raises(AssertionError):
+            _assert_no_audit_entries_for(new_rows, category="DML")  # sanity check
+        with pytest.raises(AssertionError):
+            _assert_no_audit_entries_for(new_rows, category="QUERY")  # sanity check
+
+
+# Test that operations on a keyspace NOT listed in audit_keyspaces are NOT logged.
+# Two tables are created; audit_keyspaces is set to only one table's keyspace.
+# Operations on the non-audited table should produce no entries, while operations
+# on the audited table (positive canary) confirm the audit pipeline is working.
+def test_audit_keyspace_filtering(dynamodb, cql, alternator_audit_enabled):
+    with new_test_table(dynamodb, **HASH_ONLY_SCHEMA) as table_a:
+        with new_test_table(dynamodb, **HASH_ONLY_SCHEMA) as table_b:
+            ks_a = f"alternator_{table_a.name}"
+            ks_b = f"alternator_{table_b.name}"
+            # Audit only table_a's keyspace.
+            cql.execute("UPDATE system.config SET value=%s WHERE name='audit_keyspaces'", (ks_a,))
+            before_rows = _get_audit_log_rows(cql)
+            # Negative: operations on table_b (wrong keyspace) — should NOT be logged.
+            table_b.put_item(Item={"p": "pk_b"})
+            table_b.get_item(Key={"p": "pk_b"})
+            # Positive: PutItem on table_a (correct keyspace) — should be logged.
+            table_a.put_item(Item={"p": "pk_a"})
+            expected = [("DML", "LOCAL_QUORUM", False, ks_a, table_a.name, ["PutItem", "pk_a"])]
+            new_rows = _get_new_audit_log_rows(cql, before_rows, expected_new_row_count=1)
+            _assert_audit_entries(new_rows, expected, ks_a, table_a.name)
+            _assert_no_audit_entries_for(new_rows, ks_name=ks_b)
+            with pytest.raises(AssertionError):
+                _assert_no_audit_entries_for(new_rows, ks_name=ks_a)  # sanity check
+
+
+# Test that a failed operation (one that throws after audit_info is set) generates
+# an audit entry with error=True.
+# GetItem with an extra bogus key attribute passes table lookup (audit_info is set)
+# but then check_key() throws ValidationException. A normal GetItem follows as the
+# positive canary (error=False). Both entries should be present.
+def test_audit_error_entry(dynamodb, cql, alternator_audit_enabled):
+    with new_test_table(dynamodb, **HASH_ONLY_SCHEMA) as table:
+        ks_name = f"alternator_{table.name}"
+        # Insert data so the successful GetItem has something to return.
+        table.put_item(Item={"p": "pk_0"})
+        cql.execute("UPDATE system.config SET value=%s WHERE name='audit_keyspaces'", (ks_name,))
+        before_rows = _get_audit_log_rows(cql)
+        # Negative operation: GetItem with an extra key attribute beyond the schema.
+        # The table has only "p" as the hash key, so passing "bogus" triggers check_key()
+        # which throws api_error::validation after audit_info is already set.
+        with pytest.raises(ClientError, match='ValidationException'):
+            table.get_item(Key={"p": "pk_0", "bogus": "junk"})
+        # Positive operation: normal GetItem — should succeed and produce error=False entry.
+        table.get_item(Key={"p": "pk_0"})
+        expected = [
+            ("QUERY", "LOCAL_ONE", True, ks_name, table.name, ["GetItem", "pk_0", "bogus"]),
+            ("QUERY", "LOCAL_ONE", False, ks_name, table.name, ["GetItem", "pk_0"]),
+        ]
+        new_rows = _get_new_audit_log_rows(cql, before_rows, expected_new_row_count=2)
+        _assert_audit_entries(new_rows, expected, ks_name, table.name)
+
+
+# Test that operations with empty keyspace (ListTables, DescribeEndpoints) are
+# logged regardless of what audit_keyspaces is configured to, because the
+# should_log() function short-circuits on keyspace().empty().
+# Meanwhile, operations with a non-empty keyspace that is NOT in audit_keyspaces
+# should NOT be logged.
+def test_audit_empty_keyspace_bypass(dynamodb, cql, alternator_audit_enabled):
+    with new_test_table(dynamodb, **HASH_ONLY_SCHEMA) as table:
+        ks_name = f"alternator_{table.name}"
+        client = table.meta.client
+        # Set audit_keyspaces to an unrelated keyspace — NOT the table's keyspace
+        # and NOT an empty string. This means table-scoped operations on our table
+        # should be filtered out, but empty-keyspace operations should still pass.
+        cql.execute("UPDATE system.config SET value=%s WHERE name='audit_keyspaces'", ("nonexistent_ks",))
+        before_rows = _get_audit_log_rows(cql)
+        # Negative: PutItem on the table (non-empty keyspace, not in audit_keyspaces) — should NOT be logged.
+        table.put_item(Item={"p": "pk_0"})
+        # Positive: ListTables and DescribeEndpoints (empty keyspace) — should be logged.
+        client.list_tables()
+        client.describe_endpoints()
+        expected = [
+            ("QUERY", "", False, "", "", ["ListTables"]),
+            ("QUERY", "", False, "", "", ["DescribeEndpoints"]),
+        ]
+        new_rows = _get_new_audit_log_rows(cql, before_rows, expected_new_row_count=2)
+        _assert_audit_entries(new_rows, expected)
+        _assert_no_audit_entries_for(new_rows, ks_name=ks_name)
+        with pytest.raises(AssertionError):
+            _assert_no_audit_entries_for(new_rows, ks_name="")  # sanity check

--- a/test/alternator/test_audit.py
+++ b/test/alternator/test_audit.py
@@ -174,8 +174,8 @@ def _strip_config_quotes(val):
 # After the test, the previous audit settings are restored.
 @pytest.fixture(scope="function")
 def alternator_audit_enabled(cql):
-    # Store current values of "audit_categories", "audit_keyspaces" in the system.config table
-    names = ("audit_categories", "audit_keyspaces")
+    # Store current values of audit config keys in the system.config table
+    names = ("audit_categories", "audit_keyspaces", "audit_tables")
     names_in_clause = ", ".join(f"'{n}'" for n in names)
     rows = cql.execute(f"SELECT name, value FROM system.config WHERE name IN ({names_in_clause})")
     original_config_vals = {row.name: row.value for row in rows}
@@ -667,3 +667,30 @@ def test_audit_empty_keyspace_bypass(dynamodb, cql, alternator_audit_enabled):
         _assert_no_audit_entries_for(new_rows, ks_name=ks_name)
         with pytest.raises(AssertionError):
             _assert_no_audit_entries_for(new_rows, ks_name="")  # sanity check
+
+
+# Test the audit_tables=alternator.<table> shorthand. When the user configures
+# audit_tables=alternator.<table_a>, the parser expands this to the internal
+# keyspace name alternator_<table_a> with table <table_a>. Only operations on
+# table_a should be audited; operations on table_b should NOT appear.
+def test_audit_tables_filtering(dynamodb, cql, alternator_audit_enabled):
+    with new_test_table(dynamodb, **HASH_ONLY_SCHEMA) as table_a:
+        with new_test_table(dynamodb, **HASH_ONLY_SCHEMA) as table_b:
+            ks_a = f"alternator_{table_a.name}"
+            ks_b = f"alternator_{table_b.name}"
+            # Use the alternator.<table> shorthand in audit_tables.
+            cql.execute("UPDATE system.config SET value=%s WHERE name='audit_tables'",
+                        (f"alternator.{table_a.name}",))
+            # Clear audit_keyspaces so it doesn't interfere with the test.
+            cql.execute("UPDATE system.config SET value=%s WHERE name='audit_keyspaces'", ("",))
+            before_rows = _get_audit_log_rows(cql)
+            # Negative: PutItem on table_b — should NOT be logged.
+            table_b.put_item(Item={"p": "pk_b"})
+            # Positive canary: PutItem on table_a — should be logged.
+            table_a.put_item(Item={"p": "pk_a"})
+            expected = [("DML", "LOCAL_QUORUM", False, ks_a, table_a.name, ["PutItem", "pk_a"])]
+            new_rows = _get_new_audit_log_rows(cql, before_rows, expected_new_row_count=1)
+            _assert_audit_entries(new_rows, expected, ks_a, table_a.name)
+            _assert_no_audit_entries_for(new_rows, ks_name=ks_b)
+            with pytest.raises(AssertionError):
+                _assert_no_audit_entries_for(new_rows, ks_name=ks_a)  # sanity check

--- a/test/alternator/test_audit.py
+++ b/test/alternator/test_audit.py
@@ -1,0 +1,503 @@
+# Copyright 2026-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+
+# Tests for Alternator integration with Scylla's audit logging.
+# Audit is a Scylla-only feature, so every test in this file is
+# Scylla-only (will be skipped when running against AWS DynamoDB).
+
+import time
+
+from botocore.exceptions import ClientError
+import pytest
+from cassandra import ConsistencyLevel, InvalidRequest
+from cassandra.query import SimpleStatement
+
+from test.alternator.util import new_test_table, unique_table_name
+
+
+# Skip the entire module when running against AWS DynamoDB.
+@pytest.fixture(autouse=True)
+def _scylla_only(scylla_only):
+    pass
+
+
+# Shared table schemas reused across audit tests.
+HASH_AND_RANGE_SCHEMA = {
+    "KeySchema": [
+        {"AttributeName": "p", "KeyType": "HASH"},
+        {"AttributeName": "c", "KeyType": "RANGE"},
+    ],
+    "AttributeDefinitions": [
+        {"AttributeName": "p", "AttributeType": "S"},
+        {"AttributeName": "c", "AttributeType": "S"},
+    ],
+}
+
+HASH_ONLY_SCHEMA = {
+    "KeySchema": [{"AttributeName": "p", "KeyType": "HASH"}],
+    "AttributeDefinitions": [{"AttributeName": "p", "AttributeType": "S"}],
+}
+
+
+# Returns the number of entries in the audit log table.
+def _get_audit_log_count(cql):
+    try:
+        row = cql.execute(SimpleStatement("SELECT count(*) FROM audit.audit_log",
+                                         consistency_level=ConsistencyLevel.ONE)).one()
+    except InvalidRequest:
+        return 0
+    return row[0]
+
+
+def _get_audit_log_rows(cql):
+    try:
+        return list(cql.execute(SimpleStatement("SELECT * FROM audit.audit_log",
+                                               consistency_level=ConsistencyLevel.ONE)))
+    except InvalidRequest:
+        # Auditing table may not exist yet
+        return []
+
+
+# Waits until the audit log has grown by at least `min_delta` entries, or fails after `timeout` seconds.
+# Although audit is currently synchronous (the HTTP response is sent only after audit::inspect()
+# completes), we use polling rather than a single read to avoid coupling the test to that
+# implementation detail — if audit ever becomes asynchronous, these tests should still pass.
+def _wait_for_audit_log_growth(cql, initial_count, min_delta=1, timeout=10):
+    deadline = time.time() + timeout
+    last = initial_count
+    while time.time() < deadline:
+        current = _get_audit_log_count(cql)
+        if current - initial_count >= min_delta:
+            return
+        last = current
+        time.sleep(0.1)
+    pytest.fail(f"Audit log did not grow by at least {min_delta} entries (before={initial_count}, after={last})")
+
+
+def _get_new_audit_log_rows(cql, rows_before, expected_new_row_count, timeout=10):
+    before_count = len(rows_before)
+    before_set = set(rows_before)
+    _wait_for_audit_log_growth(cql, before_count, min_delta=expected_new_row_count, timeout=timeout)
+    rows_after = _get_audit_log_rows(cql)
+    new_rows = [row for row in rows_after if row not in before_set]
+    return new_rows
+
+
+def _simplify_rows(rows):
+    # Map raw audit rows to a subset of fields we care about.
+    simplified = []
+    for row in rows:
+        simplified.append(
+            (
+                row.category,
+                row.consistency,
+                bool(row.error),
+                row.keyspace_name,
+                row.table_name,
+                row.operation,
+            )
+        )
+    return simplified
+
+
+# Verify audit entries against expected values:
+# 1) Optionally filter rows by ks_name/table_name when provided (not None).
+# 2) Check that the count of relevant entries matches the expected count.
+# 3) Compare category, consistency, error (bool), keyspace_name and table_name field-by-field.
+# 4) When table_name is provided and non-empty, assert it appears in the operation text.
+# 5) Assert that all fragment strings from the expected tuple appear in the operation text.
+def _assert_audit_entries(rows, expected, ks_name=None, table_name=None):
+    # When ks_name or table_name is provided, filter to matching entries only.
+    if ks_name is not None or table_name is not None:
+        def is_relevant(r):
+            if ks_name is not None and r.keyspace_name != ks_name:
+                return False
+            if table_name is not None and r.table_name != table_name:
+                return False
+            return True
+        irrelevant = [(idx, row) for idx, row in enumerate(rows) if not is_relevant(row)]
+        if len(irrelevant) > 0:
+            print(f"Found {len(irrelevant)} irrelevant audit entries at indices {[idx for idx, _ in irrelevant]}: {irrelevant}")
+        relevant = [row for row in rows if is_relevant(row)]
+    else:
+        relevant = list(rows)
+    assert len(relevant) == len(expected), f"Expected {len(expected)} audit entries, got {len(relevant)}: {relevant}"
+
+    # Include the operation text in the simplified actual rows, and keep the
+    # expected structure as (category, consistency, error, keyspace_name,
+    # table_name, [fragments...]). Sort both lists by the first five fields
+    # and then compare element-by-element, treating the last field specially.
+    actual_simple = sorted(_simplify_rows(relevant), key=lambda r: r[:5])
+    expected_simple = sorted(expected, key=lambda e: e[:5])
+
+    assert len(actual_simple) == len(expected_simple), f"Unexpected audit entries: expected={expected_simple}, actual={actual_simple}"
+
+    for actual_entry, expected_entry in zip(actual_simple, expected_simple):
+        # Compare the basic audit fields one-to-one.
+        assert actual_entry[:5] == expected_entry[:5], f"Unexpected audit entry fields: expected={expected_entry[:5]}, actual={actual_entry[:5]}"
+        actual_operation = actual_entry[5]
+        expected_fragments = expected_entry[5]
+        # Basic sanity for the recorded operation text.
+        assert actual_operation, "Audit entry has empty operation string"
+        if table_name:
+            assert table_name in actual_operation, f"Table name {table_name} not found in operation {actual_operation}"
+        # The last element of the expected tuple is a list of fragments
+        # that should all appear in the operation text.
+        for fragment in expected_fragments:
+            assert fragment in actual_operation, f"Expected substring '{fragment}' not found in operation {actual_operation}"
+
+
+# system.config stores values as JSON-encoded strings with surrounding quotes.
+# Strip them so that writing back via a parameterized UPDATE doesn't double-quote.
+def _strip_config_quotes(val):
+    if val and val.startswith('"') and val.endswith('"'):
+        return val[1:-1]
+    return val
+
+
+# A fixture to enable auditing for all audit categories for the duration of the test.
+# The main config flag "audit" is not live updatable, so it is required to be already enabled.
+# After the test, the previous audit settings are restored.
+@pytest.fixture(scope="function")
+def alternator_audit_enabled(cql):
+    # Store current values of "audit_categories", "audit_keyspaces" in the system.config table
+    names = ("audit_categories", "audit_keyspaces")
+    names_in_clause = ", ".join(f"'{n}'" for n in names)
+    rows = cql.execute(f"SELECT name, value FROM system.config WHERE name IN ({names_in_clause})")
+    original_config_vals = {row.name: row.value for row in rows}
+
+    def get_original_config_vals(name, default):
+        val = original_config_vals[name] if name in original_config_vals and original_config_vals[name] is not None else default
+        return _strip_config_quotes(val)
+
+    # Enable auditing for all categories of operations
+    # Note: "audit" itself is not changed here, assuming that auditing is already enabled
+    cql.execute(
+        "UPDATE system.config SET value=%s WHERE name='audit_categories'",
+        ("ADMIN,AUTH,QUERY,DML,DDL,DCL",),
+    )
+    yield
+    # Restore previous values of "audit_categories", "audit_keyspaces" in the system.config table and verify the restoration
+    for name in names:
+        if name in original_config_vals:
+            original_val = get_original_config_vals(name, "")
+            cql.execute("UPDATE system.config SET value=%s WHERE name=%s", (original_val, name))
+            restored = cql.execute("SELECT value FROM system.config WHERE name=%s", (name,)).one()
+            restored_value = _strip_config_quotes(restored.value) if restored else None
+            assert restored_value == original_val, (
+                f"Config '{name}' not properly restored: expected '{original_val}', got '{restored_value}'"
+            )
+        else:
+            # If the key wasn't present before the test, remove it so we don't leave test artifacts behind
+            cql.execute("DELETE FROM system.config WHERE name=%s", (name,))
+
+def _wait_for_active_stream(client, table_name, timeout=10):
+    # Wait until the table has an active stream and return the stream ARN.
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        desc = client.describe_table(TableName=table_name)
+        stream_spec = desc['Table'].get('StreamSpecification', {})
+        if stream_spec.get('StreamEnabled'):
+            latest_arn = desc['Table'].get('LatestStreamArn')
+            if latest_arn:
+                return latest_arn
+        time.sleep(0.1)
+    pytest.fail(f"Stream did not become active for table {table_name} within {timeout}s")
+
+
+# Test auditing of DML item operations: PutItem, UpdateItem, DeleteItem.
+# One call per operation type, producing 3 audit entries total.
+def test_audit_dml_operations(dynamodb, cql, alternator_audit_enabled):
+    # Use a schema with both hash and range keys, to allow more varied Query-s.
+    with new_test_table(dynamodb, **HASH_AND_RANGE_SCHEMA) as table:
+        ks_name = f"alternator_{table.name}"
+        # Enable audit for the current table's keyspace. The `alternator_audit_enabled` fixture
+        # ensures that `audit_keyspaces` in system.config has been already stored too and will be
+        # restored after the test.
+        cql.execute("UPDATE system.config SET value=%s WHERE name='audit_keyspaces'", (ks_name,))
+        before_rows = _get_audit_log_rows(cql)
+        # The format inside expected is: (category, consistency, error(bool), keyspace_name, table_name, [fragments that should appear in the operation text])
+        expected = []
+        # PutItem
+        table.put_item(Item={"p": "pk_0", "c": "ck_0", "v": "val_0"})
+        expected.append(("DML", "LOCAL_QUORUM", False, ks_name, table.name, ["PutItem", "pk_0", "ck_0", "val_0"]))
+        # UpdateItem
+        table.update_item(Key={"p": "pk_0", "c": "ck_0"}, AttributeUpdates={"v": {"Value": "updated_0", "Action": "PUT"}})
+        expected.append(("DML", "LOCAL_QUORUM", False, ks_name, table.name, ["UpdateItem", "pk_0", "ck_0", "updated_0"]))
+        # DeleteItem
+        table.delete_item(Key={"p": "pk_0", "c": "ck_0"})
+        expected.append(("DML", "LOCAL_QUORUM", False, ks_name, table.name, ["DeleteItem", "pk_0", "ck_0"]))
+        # Each individual Alternator call above must be audited.
+        new_rows = _get_new_audit_log_rows(cql, before_rows, expected_new_row_count=len(expected))
+        _assert_audit_entries(new_rows, expected, ks_name, table.name)
+
+
+# Test auditing of the DML batch operation: BatchWriteItem.
+# A single BatchWriteItem call produces one audit entry regardless of the number of items in the batch.
+# Batch operations leave keyspace_name empty because they can span multiple tables.
+def test_audit_dml_batch_operations(dynamodb, cql, alternator_audit_enabled):
+    with new_test_table(dynamodb, **HASH_ONLY_SCHEMA) as table:
+        ks_name = f"alternator_{table.name}"
+        # Enable audit for the current table's keyspace. The `alternator_audit_enabled` fixture
+        # ensures that `audit_keyspaces` in system.config has been already stored too and will be
+        # restored after the test.
+        cql.execute("UPDATE system.config SET value=%s WHERE name='audit_keyspaces'", (ks_name,))
+        before_rows = _get_audit_log_rows(cql)
+        client = table.meta.client
+        # BatchWriteItem with PutRequest items targeting a single table.
+        client.batch_write_item(RequestItems={
+            table.name: [{"PutRequest": {"Item": {"p": f"pk_{i}", "v": f"val_{i}"}}} for i in range(4)]
+        })
+        # The format inside expected is: (category, consistency, error(bool), keyspace_name, table_name, [fragments that should appear in the operation text])
+        expected = [
+            ("DML", "LOCAL_QUORUM", False, "", table.name, ["BatchWriteItem", "pk_0", "val_0", "pk_1", "val_1", "pk_2", "val_2", "pk_3", "val_3"]),
+        ]
+        # Each individual Alternator call above must be audited.
+        new_rows = _get_new_audit_log_rows(cql, before_rows, expected_new_row_count=len(expected))
+        _assert_audit_entries(new_rows, expected, table_name=table.name)
+
+
+# Test auditing of QUERY item operations: GetItem, Query, Scan.
+# Exercises both ConsistentRead=True (LOCAL_QUORUM) and False (LOCAL_ONE),
+# as well as range vs. exact Query predicates and Scan with/without FilterExpression.
+def test_audit_query_item_operations(dynamodb, cql, alternator_audit_enabled):
+    # Use a schema with both hash and range keys, to allow more varied Query-s.
+    with new_test_table(dynamodb, **HASH_AND_RANGE_SCHEMA) as table:
+        ks_name = f"alternator_{table.name}"
+        # Enable audit for the current table's keyspace. The `alternator_audit_enabled` fixture
+        # ensures that `audit_keyspaces` in system.config has been already stored too and will be
+        # restored after the test.
+        cql.execute("UPDATE system.config SET value=%s WHERE name='audit_keyspaces'", (ks_name,))
+        before_rows = _get_audit_log_rows(cql)
+        # The format inside expected is: (category, consistency, error(bool), keyspace_name, table_name, [fragments that should appear in the operation text])
+        expected = []
+        # GetItem: one strongly consistent, one eventually consistent.
+        table.get_item(Key={"p": "pk_0", "c": "ck_0"}, ConsistentRead=True)
+        expected.append(("QUERY", "LOCAL_QUORUM", False, ks_name, table.name, ["GetItem", "pk_0", "ck_0"]))
+        table.get_item(Key={"p": "pk_0", "c": "ck_1"})
+        expected.append(("QUERY", "LOCAL_ONE", False, ks_name, table.name, ["GetItem", "pk_0", "ck_1"]))
+        # Query: one range predicate, one exact predicate.
+        table.query(
+            KeyConditionExpression="#p = :pval AND #c BETWEEN :cmin AND :cmax",
+            ExpressionAttributeNames={"#p": "p", "#c": "c"},
+            ExpressionAttributeValues={
+                ":pval": "pk_0",
+                ":cmin": "ck_0",
+                ":cmax": "ck_2",
+            },
+            ConsistentRead=True,
+            Limit=2,
+        )
+        expected.append(("QUERY", "LOCAL_QUORUM", False, ks_name, table.name, ["Query", "BETWEEN", "pk_0", "ck_0", "ck_2"]))
+        table.query(
+            KeyConditionExpression="#p = :pval AND #c = :cval",
+            ExpressionAttributeNames={"#p": "p", "#c": "c"},
+            ExpressionAttributeValues={
+                ":pval": "pk_0",
+                ":cval": "ck_1",
+            },
+            Limit=1,
+        )
+        expected.append(("QUERY", "LOCAL_ONE", False, ks_name, table.name, ["Query", "pk_0", "ck_1"]))
+        # Scan: one with FilterExpression, one without.
+        table.scan(
+            FilterExpression="#v = :vval",
+            ExpressionAttributeNames={"#v": "v"},
+            ExpressionAttributeValues={":vval": "item_0_0"},
+            ConsistentRead=True,
+        )
+        expected.append(("QUERY", "LOCAL_QUORUM", False, ks_name, table.name, ["Scan", "item_0_0"]))
+        table.scan()
+        expected.append(("QUERY", "LOCAL_ONE", False, ks_name, table.name, ["Scan"]))
+        # Each individual Alternator call above must be audited.
+        new_rows = _get_new_audit_log_rows(cql, before_rows, expected_new_row_count=len(expected))
+        _assert_audit_entries(new_rows, expected, ks_name, table.name)
+
+
+# Test auditing of the QUERY batch operation: BatchGetItem.
+# A single BatchGetItem call produces one audit entry.
+# The audit entry records CL=ANY as a placeholder; per-item consistency is set individually.
+# Batch operations leave keyspace_name empty because they can span multiple tables.
+def test_audit_query_batch_operations(dynamodb, cql, alternator_audit_enabled):
+    with new_test_table(dynamodb, **HASH_ONLY_SCHEMA) as table:
+        ks_name = f"alternator_{table.name}"
+        # Pre-populate the table.
+        for i in range(4):
+            table.put_item(Item={"p": f"pk_{i}"})
+        # Enable audit for the current table's keyspace. The `alternator_audit_enabled` fixture
+        # ensures that `audit_keyspaces` in system.config has been already stored too and will be
+        # restored after the test.
+        cql.execute("UPDATE system.config SET value=%s WHERE name='audit_keyspaces'", (ks_name,))
+        before_rows = _get_audit_log_rows(cql)
+        client = table.meta.client
+        client.batch_get_item(RequestItems={table.name: {"Keys": [{"p": f"pk_{i}"} for i in range(4)]}})
+        expected = [("QUERY", "ANY", False, "", table.name, ["BatchGetItem", "pk_0", "pk_1", "pk_2", "pk_3"]),]
+        # Each individual Alternator call above must be audited.
+        new_rows = _get_new_audit_log_rows(cql, before_rows, expected_new_row_count=len(expected))
+        _assert_audit_entries(new_rows, expected, table_name=table.name)
+
+
+# Test auditing of DDL operations: CreateTable, UpdateTable (with GSI),
+# TagResource, UntagResource, UpdateTimeToLive, DeleteTable.
+# DDL and metadata-query operations have no meaningful CL (stored as "").
+# The DescribeTable call (used to fetch the TableArn) also produces a QUERY entry.
+# Produces 7 audit entries.
+def test_audit_ddl_operations(dynamodb, cql, alternator_audit_enabled):
+    client = dynamodb.meta.client
+    table_name = unique_table_name()
+    ks_name = f"alternator_{table_name}"
+    # Enable audit for the current table's keyspace. The `alternator_audit_enabled` fixture
+    # ensures that `audit_keyspaces` in system.config has been already stored too and will be
+    # restored after the test.
+    cql.execute("UPDATE system.config SET value=%s WHERE name='audit_keyspaces'", (ks_name,))
+    before_rows = _get_audit_log_rows(cql)
+    # The format inside expected is: (category, consistency, error(bool), keyspace_name, table_name, [fragments that should appear in the operation text])
+    expected = []
+    try:
+        # CreateTable
+        client.create_table(
+            TableName=table_name,
+            KeySchema=HASH_ONLY_SCHEMA["KeySchema"],
+            AttributeDefinitions=HASH_ONLY_SCHEMA["AttributeDefinitions"],
+            BillingMode='PAY_PER_REQUEST',
+        )
+        expected.append(("DDL", "", False, ks_name, table_name, ["CreateTable", table_name]))
+        # Get TableArn via describe_table (CreateTable response may omit it in Alternator).
+        desc = client.describe_table(TableName=table_name)
+        table_arn = desc['Table']['TableArn']
+        expected.append(("QUERY", "", False, ks_name, table_name, ["DescribeTable", table_name]))
+        # UpdateTable - add a GSI which requires a new attribute definition.
+        # AttributeDefinitions declares only the new GSI key attribute ("x").
+        # Re-declaring existing table key attributes (e.g. "p") in
+        # AttributeDefinitions is rejected by Scylla as spurious.
+        client.update_table(
+            TableName=table_name,
+            AttributeDefinitions=[
+                {"AttributeName": "x", "AttributeType": "S"},
+            ],
+            GlobalSecondaryIndexUpdates=[{
+                "Create": {
+                    "IndexName": "x_index",
+                    "KeySchema": [{"AttributeName": "x", "KeyType": "HASH"}],
+                    "Projection": {"ProjectionType": "ALL"},
+                }
+            }],
+        )
+        expected.append(("DDL", "", False, ks_name, table_name, ["UpdateTable", table_name, "x_index"]))
+        # TagResource
+        client.tag_resource(ResourceArn=table_arn, Tags=[{"Key": "env", "Value": "test"}])
+        expected.append(("DDL", "", False, ks_name, table_name, ["TagResource", "env", "test"]))
+        # UntagResource
+        client.untag_resource(ResourceArn=table_arn, TagKeys=["env"])
+        expected.append(("DDL", "", False, ks_name, table_name, ["UntagResource", "env"]))
+        # UpdateTimeToLive
+        client.update_time_to_live(
+            TableName=table_name,
+            TimeToLiveSpecification={"Enabled": True, "AttributeName": "ttl"},
+        )
+        expected.append(("DDL", "", False, ks_name, table_name, ["UpdateTimeToLive", table_name, "ttl"]))
+        # DeleteTable
+        client.delete_table(TableName=table_name)
+        expected.append(("DDL", "", False, ks_name, table_name, ["DeleteTable", table_name]))
+        # Each individual Alternator call above must be audited.
+        new_rows = _get_new_audit_log_rows(cql, before_rows, expected_new_row_count=len(expected))
+        _assert_audit_entries(new_rows, expected, ks_name, table_name)
+    finally:
+        try:
+            client.delete_table(TableName=table_name)
+        except ClientError:
+            pass  # Table was already deleted by the test
+
+
+# Test auditing of QUERY table-level operations: DescribeTable, ListTagsOfResource,
+# DescribeTimeToLive, DescribeContinuousBackups, ListTables, DescribeEndpoints.
+# ListTables and DescribeEndpoints have empty keyspace/table.
+# Produces 6 audit entries.
+def test_audit_query_table_operations(dynamodb, cql, alternator_audit_enabled):
+    with new_test_table(dynamodb, **HASH_ONLY_SCHEMA) as table:
+        ks_name = f"alternator_{table.name}"
+        # Enable audit for the current table's keyspace. The `alternator_audit_enabled` fixture
+        # ensures that `audit_keyspaces` in system.config has been already stored too and will be
+        # restored after the test.
+        cql.execute("UPDATE system.config SET value=%s WHERE name='audit_keyspaces'", (ks_name,))
+        before_rows = _get_audit_log_rows(cql)
+        expected = []
+        client = table.meta.client
+        # DescribeTable
+        desc = client.describe_table(TableName=table.name)
+        table_arn = desc['Table']['TableArn']
+        expected.append(("QUERY", "", False, ks_name, table.name, ["DescribeTable", table.name]))
+        # ListTagsOfResource
+        client.list_tags_of_resource(ResourceArn=table_arn)
+        expected.append(("QUERY", "", False, ks_name, table.name, ["ListTagsOfResource", table_arn]))
+        # DescribeTimeToLive
+        client.describe_time_to_live(TableName=table.name)
+        expected.append(("QUERY", "", False, ks_name, table.name, ["DescribeTimeToLive", table.name]))
+        # DescribeContinuousBackups
+        client.describe_continuous_backups(TableName=table.name)
+        expected.append(("QUERY", "", False, ks_name, table.name, ["DescribeContinuousBackups", table.name]))
+        # ListTables (empty keyspace)
+        client.list_tables()
+        expected.append(("QUERY", "", False, "", "", ["ListTables"]))
+        # DescribeEndpoints (empty keyspace)
+        client.describe_endpoints()
+        expected.append(("QUERY", "", False, "", "", ["DescribeEndpoints"]))
+        # Each individual Alternator call above must be audited.
+        new_rows = _get_new_audit_log_rows(cql, before_rows, expected_new_row_count=len(expected))
+        _assert_audit_entries(new_rows, expected)
+
+
+# Test auditing of DynamoDB Streams operations: ListStreams, DescribeStream, GetShardIterator, GetRecords.
+# Each operation's audit entry uses different keyspace/table naming conventions:
+#   - ListStreams: audits the input table name (if specified), or empty
+#     keyspace/table when no TableName is given; CL is empty
+#     (metadata-only operation).
+#   - DescribeStream: keyspace is the CDC log table's keyspace,
+#     table is pipe-separated "base_table|cdc_table".
+#     CL is QUORUM for multi-node clusters, ONE for single-node (tests run single-node).
+#   - GetShardIterator: keyspace is the CDC log table's keyspace,
+#     table is pipe-separated "base_table|cdc_table". CL is empty
+#     (uses only node-local metadata).
+#   - GetRecords: keyspace is the CDC log table's keyspace,
+#     table is pipe-separated "base_table|cdc_table". CL=LOCAL_QUORUM.
+# Produces 5 audit entries.
+def test_audit_streams_operations(dynamodb, dynamodbstreams, cql, alternator_audit_enabled):
+    # With #23838 open, we will explicitly ask for a table with vnodes.
+    with new_test_table(dynamodb, StreamSpecification={"StreamEnabled": True, "StreamViewType": "NEW_AND_OLD_IMAGES"}, Tags=[{'Key': 'system:initial_tablets', 'Value': 'none'}], **HASH_ONLY_SCHEMA) as table:
+        ks_name = f"alternator_{table.name}"
+        client = table.meta.client
+        # Write data so that stream records exist.
+        table.put_item(Item={"p": "pk_0"})
+        stream_arn = _wait_for_active_stream(client, table.name)
+        # Naming for audit entries: CDC log table names and pipe-separated base|cdc names.
+        # In Alternator the base and CDC tables share the same keyspace.
+        cdc_table = f"{table.name}_scylla_cdc_log"
+        piped_table = f"{table.name}|{cdc_table}"
+        # Enable audit for the current table's keyspace.
+        # The `alternator_audit_enabled` fixture ensures that `audit_keyspaces` in system.config
+        # has been already stored too and will be restored after the test.
+        cql.execute("UPDATE system.config SET value=%s WHERE name='audit_keyspaces'", (ks_name,))
+        before_rows = _get_audit_log_rows(cql)
+        expected = []
+        # ListStreams - audits the input table name when TableName is given.
+        dynamodbstreams.list_streams(TableName=table.name)
+        expected.append(("QUERY", "", False, ks_name, table.name, ["ListStreams", table.name]))
+        # ListStreams without TableName - audits with empty keyspace/table.
+        dynamodbstreams.list_streams()
+        expected.append(("QUERY", "", False, "", "", ["ListStreams"]))
+        # DescribeStream - keyspace is the CDC log table's keyspace, table is pipe-separated base|cdc.
+        # CL is QUORUM for multi-node clusters, ONE for single-node (our test environment).
+        desc_resp = dynamodbstreams.describe_stream(StreamArn=stream_arn)
+        shards = desc_resp['StreamDescription']['Shards']
+        expected.append(("QUERY", "ONE", False, ks_name, piped_table, ["DescribeStream", stream_arn]))
+        # GetShardIterator - keyspace is the CDC log table's keyspace, table is pipe-separated base|cdc.
+        iter_resp = dynamodbstreams.get_shard_iterator(
+            StreamArn=stream_arn, ShardId=shards[0]['ShardId'], ShardIteratorType='LATEST')
+        expected.append(("QUERY", "", False, ks_name, piped_table, ["GetShardIterator", stream_arn]))
+        # GetRecords - keyspace is the CDC log table's keyspace, table is pipe-separated base|cdc. CL=LOCAL_QUORUM.
+        dynamodbstreams.get_records(ShardIterator=iter_resp['ShardIterator'])
+        expected.append(("QUERY", "LOCAL_QUORUM", False, ks_name, piped_table, ["GetRecords"]))
+        # Each individual Alternator call above must be audited.
+        new_rows = _get_new_audit_log_rows(cql, before_rows, expected_new_row_count=len(expected))
+        _assert_audit_entries(new_rows, expected)


### PR DESCRIPTION
Each Alternator API call results in the request being audited, provided the auditing is enabled.
Both successful as well as the failed requests are audited, with few exceptions.

The chosen audit types for the operations:
- CreateTable - DDL
- DescribeTable - QUERY
- DeleteTable - DDL
- UpdateTable - DDL
- PutItem - DML
- UpdateItem - DML
- GetItem - QUERY
- DeleteItem - DML
- ListTables - QUERY
- Scan - QUERY
- DescribeEndpoints - QUERY
- BatchWriteItem - DML
- BatchGetItem - QUERY
- Query - QUERY
- TagResource - DDL
- UntagResource - DDL
- ListTagsOfResource - QUERY
- UpdateTimeToLive - DDL
- DescribeTimeToLive - QUERY
- ListStreams - QUERY
- DescribeStream - QUERY
- GetShardIterator - QUERY
- GetRecords - QUERY
- DescribeContinuousBackups - QUERY

FIXME: The tests are now covering the new functionality only partially.

Fixes: scylladb/scylla-enterprise#3796
Fixes: SCYLLADB-467

No need to backport, new functionality.