### PR TITLE
nodetool: increase precision of compression ratio output from 1 to 2 decimal places

### DIFF
--- a/test/nodetool/test_tablestats.py
+++ b/test/nodetool/test_tablestats.py
@@ -269,7 +269,7 @@ Space used (live): {self.live_disk_space_used}
 Space used (total): {self.total_disk_space_used}
 Space used by snapshots (total): {self.snapshots_size}
 Off heap memory used (total): {self.total_off_heap_memory_used}
-SSTable Compression Ratio: {self.compression_ratio:.1f}
+SSTable Compression Ratio: {self.compression_ratio:.2f}
 Number of partitions (estimate): {self.estimated_row_count}
 Memtable cell count: {self.memtable_columns_count}
 Memtable data size: {self.memtable_live_data_size}

--- a/tools/scylla-nodetool.cc
+++ b/tools/scylla-nodetool.cc
@@ -2918,7 +2918,7 @@ public:
                                     index_summary_off_heap_mem_size +
                                     compression_metadata_off_heap_mem_size);
         fmt::print("\t\tOff heap memory used (total): {}\n", file_size_printer(total_off_heap_size, human_readable));
-        fmt::print("\t\tSSTable Compression Ratio: {:.1f}\n", compression_ratio());
+        fmt::print("\t\tSSTable Compression Ratio: {:.2f}\n", compression_ratio());
         fmt::print("\t\tNumber of partitions (estimate): {}\n", estimated_partition_count());
         fmt::print("\t\tMemtable cell count: {}\n", memtable_columns_count());
         fmt::print("\t\tMemtable data size: {}\n", memtable_live_data_size());


### PR DESCRIPTION
Fixes: https://github.com/scylladb/scylladb/issues/27962

Improvement, no need to backport.
Signed-off-by: Yaniv Kaul <yaniv.kaul@scylladb.com>