### PR TITLE
test/cqlpy: remove test_describe.py from cluster reuse blacklist

### DIFF
--- a/test/cqlpy/test_config.yaml
+++ b/test/cqlpy/test_config.yaml
@@ -1,7 +1,6 @@
 type: Python
 dirties_cluster:
   - test_native_transport
-  - test_describe # Broke CQL connections for next tests
 extra_scylla_cmdline_options:
   - '--rf-rack-valid-keyspaces=1'
   - '--experimental-features=udf'


### PR DESCRIPTION
The way that test.py runs test/cqlpy tests requires that tests end their session with all keyspaces deleted. If we forget to delete a keyspace, test.py suspects some test fails and reports a failure. As reported in issue #26291, the test file test/cqlpy/test_describe.py caused this check to trigger, so this file was added to the blacklist "dirties_cluster" in suite.yaml to force test.py to ignore this problem.

I believe the cause of the problem was as follows: test_describe.py didn't really leave any undeleted keyspace. Rather, test_describe.py had one test which used "USE" and this broke DESC KEYSPACES (Refs #26334) - which test.py used to see which keyspaces remained.

We solved this problem not just once, but twice:
1. In pull request #26345, I fixed the test not to use "USE" on the main CQL session.
2. In pull request #27971, I fixed DESC KEYSPACES implementation so even if "USE" was in effect, it will return the correct results.

I checked manually, and after removing test_describe.py from the dirties_cluster blacklist, all cqlpy tests now pass, without spurious failures in the test following test_describe.py. So it's time to remove it from the blacklist.

Fixes #26291
