### PR TITLE
test.py: fix race condition in initizlization of cqlpy tests

### DIFF
--- a/test/cqlpy/util.py
+++ b/test/cqlpy/util.py
@@ -308,9 +308,12 @@ def local_process_id(cql):
         dir = f'/proc/{proc}/fd/'
         try:
             for fd in os.listdir(dir):
-                if os.readlink(dir + fd) == target:
-                    # Found the process!
-                    return proc
+                try:
+                    if os.readlink(dir + fd) == target:
+                        # Found the process!
+                        return proc
+                except:
+                    pass
         except:
             # Ignore errors. We can't check processes we don't own.
             pass


### PR DESCRIPTION
Fix the race condition when the process finished, while test is trying to check its descriptors. Now instead of failing the whole loop, it will continue to iterate the rest of the process to find the needed process. 

This is a cherry-pick from https://github.com/scylladb/scylladb/pull/26395

No backport, because it's framework fix.