### PR TITLE
build: avoid ccache masquarading when choosing ccache too

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -391,9 +391,9 @@ def find_compiler(name):
     return None
 
 
-def resolve_compilers_for_sccache(args, compiler_cache):
+def resolve_compilers_for_compiler_cache(args, compiler_cache):
     """
-    When using sccache, resolve compiler paths to avoid ccache directories.
+    When using a compiler cache, resolve compiler paths to avoid ccache directories.
 
     This prevents double-caching when ccache symlinks are in PATH.
 
@@ -401,7 +401,7 @@ def resolve_compilers_for_sccache(args, compiler_cache):
         args: The argument namespace with cc and cxx attributes.
         compiler_cache: Path to the compiler cache binary, or None.
     """
-    if not compiler_cache or 'sccache' not in compiler_cache:
+    if not compiler_cache:
         return
     if not os.path.isabs(args.cxx):
         real_cxx = find_compiler(args.cxx)
@@ -3026,7 +3026,7 @@ def create_build_system(args):
     os.makedirs(outdir, exist_ok=True)
 
     compiler_cache = find_compiler_cache(args.compiler_cache)
-    resolve_compilers_for_sccache(args, compiler_cache)
+    resolve_compilers_for_compiler_cache(args, compiler_cache)
 
     scylla_product, scylla_version, scylla_release = generate_version(args.date_stamp)
 
@@ -3113,7 +3113,7 @@ def configure_using_cmake(args):
                                 in selected_modes)
 
     compiler_cache = find_compiler_cache(args.compiler_cache)
-    resolve_compilers_for_sccache(args, compiler_cache)
+    resolve_compilers_for_compiler_cache(args, compiler_cache)
 
     settings = {
         'CMAKE_CONFIGURATION_TYPES': selected_configs,


### PR DESCRIPTION
In 12dcf79c601586b, we avoid the ccache masquarate directory when choosing sccache, as that would give us a double-caching effect: first sccache is called, then clang++ is looked up finding ccache masquarading as clang++. We solved that by converting the name clang++ to the absolute path /usr/bin/clang++ (or whatever), skipping over the masquarade directory in $PATH.

It turns out that we need to do the same for ccache. That commit changed the compile command to 'ccache clang++', and ccache will look up clang++ in $PATH, finding itself in the masquarade directory.

Fix that by avoiding the masquarade directory if a compiler cache is specified explicitly or is found with --compiler-cache=auto.

Fix for a very recent change, so no need to backport.