### PR TITLE
test: cluster: test_topology_ops[_encrypted]: Fix failures due to background migrations fencing out writes

### DIFF
--- a/test/cluster/test_topology_ops.py
+++ b/test/cluster/test_topology_ops.py
@@ -32,6 +32,11 @@ async def test_topology_ops(request, manager: ManagerClient, tablets_enabled: bo
     logger.info("Bootstrapping first node")
     servers = [await manager.server_add(config=cfg)]
 
+    # Background migrations concurrent with node shutdown can cause background (after CL is met)
+    # replica-side writes to fail due to barriers fencing out the node which is shutting down.
+    # This trips check_node_log_for_failed_mutations().
+    await manager.api.disable_tablet_balancing(servers[0].ip_addr)
+
     logger.info(f"Restarting node {servers[0]}")
     await manager.server_stop_gracefully(servers[0].server_id)
     await manager.server_start(servers[0].server_id)

--- a/test/cluster/test_topology_ops_encrypted.py
+++ b/test/cluster/test_topology_ops_encrypted.py
@@ -39,6 +39,11 @@ async def test_topology_ops_encrypted(request, manager: ManagerClient, tablets_e
     logger.info("Bootstrapping first node")
     servers = [await manager.server_add(config=cfg)]
 
+    # Background migrations concurrent with node shutdown can cause background (after CL is met)
+    # replica-side writes to fail due to barriers fencing out the node which is shutting down.
+    # This trips check_node_log_for_failed_mutations().
+    await manager.api.disable_tablet_balancing(servers[0].ip_addr)
+
     logger.info(f"Restarting node {servers[0]}")
     await manager.server_stop_gracefully(servers[0].server_id)
     await manager.server_start(servers[0].server_id)


### PR DESCRIPTION
The test is flaky, with failures in:

```
        for server in servers:
>           await check_node_log_for_failed_mutations(manager, server)

test/cluster/test_topology_ops_encrypted.py:84:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

manager = <test.pylib.manager_client.ManagerClient object at 0xffff602e8590> server = ServerInfo(server_id=1769, ip_addr='127.82.127.43', rpc_address='127.82.127.43', datacenter='DEFAULT_DC', rack='DEFAULT_RACK', pid=186578)

    async def check_node_log_for_failed_mutations(manager: ManagerClient, server: ServerInfo):
        logging.info(f"Checking that node {server} had no failed mutations")
        log = await manager.server_open_log(server.server_id)
        occurrences = await log.grep(expr="Failed to apply mutation from", filter_expr="(TRACE|DEBUG|INFO)")
>       assert len(occurrences) == 0
E       AssertionError

test/cluster/util.py:319: AssertionError
```

As diagnosed by Gleb in https://github.com/scylladb/scylladb/issues/27942#issuecomment-3710013625:

"The fencing errors here look legit given that we do not wait for all requests to complete while shutting down the storage proxy. The scenario is this:

Test does writes to rf=3 keyspace with cl=one. One node is shutting down while there is a tablet migration. Tablet migration executes barrier and drain which fails on a node that is been shutdown. The topology coordinator proceeds fencing the old topology, but there still can be un-handled mutation requests from the shutting down node on other nodes and they will generate fencing errors like they should.

They way to avoid it (though it is benign) is to wait for all outgoing storage proxy requests to complete during shutdown, but even then the error may still happen since a request may timeout before it is processed by the other side, so it may be completed by a storage proxy coordinator side, but still not handled by replica side. This what we have fencing for in the first place."

Fix by disabling background tablet migrations, so that we have no topology barriers concurrent with node shutdown.

Fixes #27942

backport/none because flakiness increased after size-based load balancing, which is in master.
