### PR TITLE
treewide: use coroutine::maybe_yield in coroutines

### DIFF
--- a/api/task_manager.cc
+++ b/api/task_manager.cc
@@ -9,6 +9,7 @@
 #include <seastar/core/chunked_fifo.hh>
 #include <seastar/core/coroutine.hh>
 #include <seastar/coroutine/exception.hh>
+#include <seastar/coroutine/maybe_yield.hh>
 #include <seastar/http/exception.hh>
 
 #include "task_manager.hh"
@@ -264,7 +265,7 @@ void set_task_manager(http_context& ctx, routes& r, sharded<tasks::task_manager>
                 if (id) {
                     module->unregister_task(id);
                 }
-                co_await maybe_yield();
+                co_await coroutine::maybe_yield();
             }
         });
         co_return json_void();

--- a/cdc/generation.cc
+++ b/cdc/generation.cc
@@ -204,7 +204,7 @@ future<topology_description> topology_description::clone_async() const {
 
     for (const auto& entry : _entries) {
         vec.push_back(entry);
-        co_await seastar::maybe_yield();
+        co_await coroutine::maybe_yield();
     }
 
     co_return topology_description{std::move(vec)};

--- a/db/batchlog_manager.cc
+++ b/db/batchlog_manager.cc
@@ -16,6 +16,7 @@
 #include <seastar/core/semaphore.hh>
 #include <seastar/core/metrics.hh>
 #include <seastar/core/coroutine.hh>
+#include <seastar/coroutine/maybe_yield.hh>
 #include <seastar/core/sleep.hh>
 #include <seastar/coroutine/parallel_for_each.hh>
 
@@ -377,7 +378,7 @@ future<db::all_batches_replayed> db::batchlog_manager::replay_all_failed_batches
 
             for (const auto& [fm, s] : fms) {
                 mutations.emplace_back(fm.to_mutation(s));
-                co_await maybe_yield();
+                co_await coroutine::maybe_yield();
             }
 
             if (!mutations.empty()) {

--- a/db/schema_applier.cc
+++ b/db/schema_applier.cc
@@ -961,15 +961,15 @@ public:
 
         auto include_pending_changes = [&table_schemas](schema_diff_per_shard d) -> future<> {
             for (auto& schema : d.dropped) {
-                co_await maybe_yield();
+                co_await coroutine::maybe_yield();
                 table_schemas.erase(schema->id());
             }
             for (auto& change : d.altered) {
-                co_await maybe_yield();
+                co_await coroutine::maybe_yield();
                 table_schemas.insert_or_assign(change.new_schema->id(), change.new_schema);
             }
             for (auto& schema : d.created) {
-                co_await maybe_yield();
+                co_await coroutine::maybe_yield();
                 table_schemas.insert_or_assign(schema->id(), schema);
             }
         };

--- a/test/boost/alternator_unit_test.cc
+++ b/test/boost/alternator_unit_test.cc
@@ -16,6 +16,7 @@
 
 #include "alternator/expressions.hh"
 #include <seastar/core/coroutine.hh>
+#include <seastar/coroutine/maybe_yield.hh>
 #include <seastar/core/sleep.hh>
 
 static std::map<std::string, std::string> strings {
@@ -407,14 +408,14 @@ SEASTAR_TEST_CASE(test_parsed_expression_cache_resize) {
     cache.max_cache_entries.set(large_size);
     for (size_t i = 0; i < large_size; i++) {
         cache.try_parse(seastar::format("expr{}", i), exp_type::PROJECTION_EXPRESSION, miss);
-        co_await maybe_yield();
+        co_await coroutine::maybe_yield();
     }
     cache.max_cache_entries.set(first_reduce);
     cache.expected_stats.expression_cache.evictions += (large_size - first_reduce);
     co_await cache.wait_check_stats("async, after resizing cache");
     for (size_t i = 0; i < first_reduce; i++) {
         cache.try_parse(seastar::format("expr{}", i), exp_type::PROJECTION_EXPRESSION, eviction_miss);
-        co_await maybe_yield();
+        co_await coroutine::maybe_yield();
     }
     cache.max_cache_entries.set(0);
     cache.expected_stats.expression_cache.evictions += first_reduce;
@@ -423,7 +424,7 @@ SEASTAR_TEST_CASE(test_parsed_expression_cache_resize) {
     cache.max_cache_entries.set(large_size);
     for (size_t i = 0; i < large_size; i++) {
         cache.try_parse(seastar::format("expr{}", i), exp_type::PROJECTION_EXPRESSION, miss);
-        co_await maybe_yield();
+        co_await coroutine::maybe_yield();
     }
     cache.max_cache_entries.set(1000);
     co_await cache.cache->stop();

--- a/test/boost/rate_limiter_test.cc
+++ b/test/boost/rate_limiter_test.cc
@@ -11,6 +11,7 @@
 #include <seastar/core/manual_clock.hh>
 #include <seastar/core/sleep.hh>
 #include <seastar/core/coroutine.hh>
+#include <seastar/coroutine/maybe_yield.hh>
 #include <seastar/util/later.hh>
 #include <seastar/testing/test_case.hh>
 
@@ -40,7 +41,7 @@ SEASTAR_TEST_CASE(test_rate_limiter_no_rejections_on_sequential) {
 
     for (uint64_t token = 0; token < token_count; token++) {
         BOOST_REQUIRE_LE(limiter.increase_and_get_counter(lbl, token), 1);
-        co_await maybe_yield();
+        co_await coroutine::maybe_yield();
     }
 }
 
@@ -55,7 +56,7 @@ SEASTAR_TEST_CASE(test_rate_limiter_partition_label_separation) {
         for (uint64_t token = 0; token < token_count; token++) {
             for (auto& l : labels) {
                 BOOST_REQUIRE_EQUAL(limiter.increase_and_get_counter(l, token), i + 1);
-                co_await maybe_yield();
+                co_await coroutine::maybe_yield();
             }
         }
     }
@@ -123,7 +124,7 @@ SEASTAR_TEST_CASE(test_rate_limiter_account_operation) {
             encountered_rejection = true;
             break;
         }
-        co_await maybe_yield();
+        co_await coroutine::maybe_yield();
     }
     BOOST_REQUIRE(encountered_rejection);
 }


### PR DESCRIPTION
It's more efficient since coroutine::maybe_yield returns a lightweight struct (awaitable), not the future.

small optimisation, no need to backport