### PR TITLE
test.py: Fix boost logs

### DIFF
--- a/test/pylib/cpp/boost.py
+++ b/test/pylib/cpp/boost.py
@@ -96,8 +96,8 @@ class BoostTestFile(CppFile):
                     working_dir: {os.getcwd()}
                     Internal Error: calling {self.exe_path} for test {run_test} failed ({return_code=}):
                     output file: {stdout_file_path}
-                    log: {log_xml}
                     command to repeat: {subprocess.list2cmdline(process.args)}
+                    error: {results[0].lines}
                 """),
             )], ""
 


### PR DESCRIPTION
Write the boost logs into stdout in HRF format and in XML to the file. The XML file will be used for parsing and providing the error information in the summary section of the fail.

Fixes: https://github.com/scylladb/scylladb/issues/28045

Framework enhancements, no need to backport.