### PR TITLE
[Backport 2025.1] load_sketch: Allow populating load_sketch with normalized current load

### DIFF
--- a/locator/network_topology_strategy.cc
+++ b/locator/network_topology_strategy.cc
@@ -348,6 +348,7 @@ future<tablet_map> network_topology_strategy::allocate_tablets_for_new_table(sch
 future<tablet_map> network_topology_strategy::reallocate_tablets(schema_ptr s, token_metadata_ptr tm, tablet_map tablets) const {
     natural_endpoints_tracker::check_enough_endpoints(*tm, _dc_rep_factor);
     load_sketch load(tm);
+    co_await load.populate_with_normalized_load();
     co_await load.populate(std::nullopt, s->id());
 
     tablet_logger.debug("Allocating tablets for {}.{} ({}): dc_rep_factor={} tablet_count={}", s->ks_name(), s->cf_name(), s->id(), _dc_rep_factor, tablets.tablet_count());

--- a/test/boost/tablets_test.cc
+++ b/test/boost/tablets_test.cc
@@ -3003,6 +3003,51 @@ SEASTAR_THREAD_TEST_CASE(test_imbalance_in_hetero_cluster_with_two_tables_imbala
     }).get();
 }
 
+static future<> run_imbalance_when_creating_plenty_of_tables_test(bool rf_rack_valid_keyspaces) {
+    cql_test_config cfg{};
+    cfg.db_config->rf_rack_valid_keyspaces.set(std::move(rf_rack_valid_keyspaces));
+
+    return do_with_cql_env_thread([] (auto& e) {
+        topology_builder topo(e);
+
+        auto rack1 = topo.rack();
+        auto rack2 = topo.start_new_rack();
+        auto rack3 = topo.start_new_rack();
+
+        topo.add_i4i_2xlarge(rack1);
+        topo.add_i4i_2xlarge(rack2);
+        topo.add_i4i_2xlarge(rack3);
+
+        auto& stm = e.shared_token_metadata().local();
+        auto ks_name = add_keyspace(e, {{topo.dc(), 3}}, 1);
+
+        for (int _ : std::views::iota(1, 100)) {
+            add_table(e, ks_name).get();
+        }
+        testlog.info("Initial cluster ready");
+
+        {
+            load_sketch load(stm.get());
+            load.populate().get();
+
+            for (auto h: topo.hosts()) {
+                auto node_utilization = load.get_shard_minmax(h);
+                testlog.info("host {}: min={}, max={}", h, node_utilization.min(), node_utilization.max());
+                BOOST_REQUIRE_LT(node_utilization.max() - node_utilization.min(), 1.1);
+            }
+        }
+    }, std::move(cfg));
+}
+
+// Reproduces https://github.com/scylladb/scylladb/issues/27620
+SEASTAR_THREAD_TEST_CASE(test_imbalance_when_creating_plenty_of_tables_with_RF_rack_valid_keyspaces_enforced) {
+    run_imbalance_when_creating_plenty_of_tables_test(true).get();
+}
+
+SEASTAR_THREAD_TEST_CASE(test_imbalance_when_creating_plenty_of_tables_with_RF_rack_valid_keyspaces_disabled) {
+    run_imbalance_when_creating_plenty_of_tables_test(false).get();
+}
+
 SEASTAR_TEST_CASE(test_tablet_id_and_range_side) {
     static constexpr size_t tablet_count = 128;
     locator::tablet_map tmap(tablet_count);


### PR DESCRIPTION
Currently, tablet allocation intentionally ignores current load ( introduced by the commit #1e407ab) which could cause identical shard selection when allocating a small number of tablets in the same topology. When a tablet allocator is asked to allocate N tablets (where N is smaller than the number of shards on a node), it selects the first N lowest shards. If multiple such tables are created, each allocator run picks the same shards, leading to tablet imbalance across shards.

This change initializes the load sketch with the current shard load, scaled into the [0,1] range, ensuring allocation still remains even while starting from globally least-loaded shards.

Fixes https://github.com/scylladb/scylladb/issues/27620

Closes https://github.com/scylladb/scylladb/pull/27802

Parent PR https://github.com/scylladb/scylladb/pull/27802