### PR TITLE
test: Update cluster/object_store/ tests to use new S3 config format

### DIFF
--- a/test/cluster/object_store/conftest.py
+++ b/test/cluster/object_store/conftest.py
@@ -33,27 +33,28 @@ def format_tuples(tuples=None, **kwargs):
 class S3_Server:
     def __init__(self, tempdir: str, address: str, port: int, acc_key: str, secret_key: str, region: str, bucket_name):
         self.tempdir = tempdir
-        self.address = address
+        self.ip = address
         self.port = port
+        self.address = f'http://{self.ip}:{self.port}'
         self.acc_key = acc_key
         self.secret_key = secret_key
         self.region = region
         self.bucket_name = bucket_name
 
     def __repr__(self):
-        return f"[unknown] {self.address}:{self.port}/{self.bucket_name}"
+        return f"[unknown] {self.address}/{self.bucket_name}"
 
     @property
     def type(self):
         return 'S3'
 
     def create_endpoint_conf(self):
-        return MinioServer.create_conf(self.address, self.port, self.region)
+        return MinioServer.create_conf(self.address, self.region)
 
     def get_resource(self):
         """Creates boto3.resource object that can be used to communicate to the given server"""
         return boto3.resource('s3',
-            endpoint_url=f'http://{self.address}:{self.port}',
+            endpoint_url=self.address,
             aws_access_key_id=self.acc_key,
             aws_secret_access_key=self.secret_key,
             aws_session_token=None,
@@ -82,7 +83,7 @@ class MinioWrapper(S3_Server):
                 self.server.bucket_name)
 
     def create_endpoint_conf(self):
-        return MinioServer.create_conf(self.address, self.port, self.region)
+        return MinioServer.create_conf(self.address, self.region)
 
     async def start(self):
         return self.server.start()

--- a/test/pylib/minio_server.py
+++ b/test/pylib/minio_server.py
@@ -151,9 +151,8 @@ class MinioServer:
             yield random.randint(min_port, max_port)
 
     @staticmethod
-    def create_conf(address: str, port: int, region: str):
-        endpoint = {'name': address,
-                    'port': port,
+    def create_conf(url: str, region: str):
+        endpoint = {'name': url,
                     # don't put credentials here. We're exporing env vars, which should
                     # be picked up properly by scylla.
                     # https://github.com/scylladb/scylla-pkg/issues/3845
@@ -161,7 +160,7 @@ class MinioServer:
                     #'aws_secret_access_key': secret_key,
                     'aws_region': region,
                     'iam_role_arn': '',
-                    'use_https': False
+                    'type': 's3',
                     }
         return [endpoint]
 


### PR DESCRIPTION
This PR includes the #28112 one that leaves tests unmodified to show that old configuration still works.
This change updates the suite (mainly the MinioServer::create_conf() method) to generate endpoint config in new format.


Tests enhancement, no need to backport.