### PR TITLE
util: Re-use seastar::util::memory_data_sink

### DIFF
--- a/utils/s3/client.cc
+++ b/utils/s3/client.cc
@@ -1026,9 +1026,7 @@ public:
     {}
 
     virtual future<> put(std::span<temporary_buffer<char>> data) override {
-        for (auto&& buf : data) {
-            _bufs.put(std::move(buf));
-        }
+        append_buffers(_bufs, std::move(data));
         return maybe_flush();
     }
 


### PR DESCRIPTION
A data_sink that stores buffers into an in-memory collection had appeared in seastar recently. In Scylla there's similar thing that uses memory_data_sink_buffer as a container, so it's possible to drop the data_sink_impl iself in favor of seastar implementation.

For that to work there should be append_buffers() overload for the aforementioned container. For its nice implementation the container, in turn, needs to get push_back() method and value_type trait. The method already exists, but is called put(), so just rename it. There's one more user of it this method in S3 client, and it can enjoy the added append_buffers() helper.

Code enhancement, no backporting