### PR TITLE
aws_error: fix nested exception handling

### DIFF
--- a/utils/s3/aws_error.hh
+++ b/utils/s3/aws_error.hh
@@ -106,7 +106,7 @@ public:
     static std::optional<aws_error> parse(seastar::sstring&& body);
     static aws_error from_http_code(seastar::http::reply::status_type http_code);
     static aws_error from_system_error(const std::system_error& system_error);
-    static aws_error from_maybe_nested_exception(const std::exception& maybe_nested_error);
+    static aws_error from_maybe_nested_exception(std::exception_ptr maybe_nested_error);
     static aws_error from_exception_ptr(std::exception_ptr exception);
     static const aws_errors& get_errors();
 };


### PR DESCRIPTION
The loop that unwraps nested exception, rethrows nested exception and saves pointer to the temporary std::exception& inner on stack, then continues. This pointer is, thus, pointing to a released temporary

Fixes: https://github.com/scylladb/scylladb/issues/28144

Should be ported to 2025.3/4  since this code is already running in production and can lead to undefined behavior