### PR TITLE
replica: add abort polling to memtable and cache readers

### DIFF
--- a/db/cache_mutation_reader.hh
+++ b/db/cache_mutation_reader.hh
@@ -323,6 +323,9 @@ void cache_mutation_reader::touch_partition() {
 
 inline
 future<> cache_mutation_reader::fill_buffer() {
+    if (const auto& ex = get_abort_exception(); ex) {
+        return make_exception_future<>(ex);
+    }
     if (_state == state::before_static_row) {
         touch_partition();
         auto after_static_row = [this] {

--- a/partition_snapshot_reader.hh
+++ b/partition_snapshot_reader.hh
@@ -250,6 +250,9 @@ public:
     }
 
     virtual future<> fill_buffer() override {
+        if (const auto& ex = get_abort_exception(); ex) {
+            return make_exception_future<>(ex);
+        }
         return do_until([this] { return is_end_of_stream() || is_buffer_full(); }, [this] {
             _reader.with_reserve([&] {
                 if (!_static_row_done) {


### PR DESCRIPTION
Continuing the read once it is aborted (e.g. due to timeout) is a waste of resources, as the produced results will be discarded. Poll the permit's abort exception in the memtable and cache reader's fill_buffer(). This results in one poll per buffer filled (8KB of data).

We already have similar poll for sstable readers, as disk reads are usually much heavier and therefore it is more important to stop them ASAP after abort. Cache and memtable reads are usually quick but not always, hence it is important to also have polling in the cache and memtable readers.

Refs: #11469
Fixes: #28148

Improvement, normally not a backport candidate.