### PR TITLE
transport: unify lambda capture lifetime for control connections

### DIFF
--- a/transport/server.cc
+++ b/transport/server.cc
@@ -1028,7 +1028,7 @@ void cql_server::connection::update_user_scheduling_group_v2(const std::optional
 void cql_server::connection::update_control_connection_scheduling_group() {
     auto shg_grp = _server._sl_controller.get_scheduling_group(qos::service_level_controller::driver_service_level_name);
     _current_scheduling_group = shg_grp;
-    switch_tenant([this] (noncopyable_function<future<> ()> process_loop) -> future<> {
+    switch_tenant([this] (this auto self, noncopyable_function<future<> ()> process_loop) -> future<> {
         co_return co_await _server._sl_controller.with_service_level(qos::service_level_controller::driver_service_level_name, std::move(process_loop));
     });
 }


### PR DESCRIPTION
Workload prioritization was added in scylladb/scylladb#22031. The functionality of updating service levels was implemented as a lambda coroutine, leaving room for the lambda coroutine fiasco.

The problem was noticed and addressed in scylladb/scylladb#26404. There are currently three functions that call switch_tenant:
 - update_user_scheduling_group_v1 and update_user_scheduling_group_v2 use the deducing this (this auto self) to ensure the proper lifecycle of the lambda capture.
 - update_control_connection_scheduling_group doesn’t use the deducing this, but the lambda captures only `this`, which is used before the first possible coroutine preemption. Therefore, it doesn’t seem that any memory corruption or undefined behavior is possible here.

Nevertheless, it seems better to start using the deducing this in update_control_connection_scheduling_group as well, to avoid problems in the future if someone modifies the code and forgets to add it.

Fixes: SCYLLADB-284

No backport, just a cosmetic fix.