### PR TITLE
test: disable test_start_bootstrapped_with_invalid_seed

### DIFF
--- a/test/cluster/test_start_bootstrapped_with_invalid_seed.py
+++ b/test/cluster/test_start_bootstrapped_with_invalid_seed.py
@@ -16,6 +16,7 @@ pytestmark = pytest.mark.prepare_3_nodes_cluster
 
 
 @pytest.mark.asyncio
+@pytest.mark.skip(reason="Test is disabled due to scylladb/scylladb#28153")
 async def test_start_bootstrapped_with_invalid_seed(manager: ManagerClient):
     """
     Issue https://github.com/scylladb/scylladb/issues/14945.


### PR DESCRIPTION
The test intermittently fails when an invalid DNS name is resolved, likely due to ISP DNS error hijacking (see scylladb/scylladb#28153).

Disable this test to unblock CI.

Fixes scylladb/scylladb#28153

Since this issue disrupts CI, we need to port it everywhere. 