### PR TITLE
Add child shards filtering

### DIFF
--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -67,7 +67,7 @@
 
 using namespace std::chrono_literals;
 
-logging::logger elogger("alternator-executor");
+static logging::logger elogger("alternator-executor");
 
 namespace std {
     template <> struct hash<std::pair<sstring, sstring>> {

--- a/alternator/streams.cc
+++ b/alternator/streams.cc
@@ -7,6 +7,8 @@
  */
 
 #include <type_traits>
+#include <ranges>
+#include <generator>
 #include <boost/lexical_cast.hpp>
 #include <boost/io/ios_state.hpp>
 #include <boost/multiprecision/cpp_int.hpp>
@@ -24,12 +26,14 @@
 #include "cql3/selection/selection.hh"
 #include "cql3/result_set.hh"
 #include "cql3/column_identifier.hh"
+#include "replica/database.hh"
 #include "schema/schema_builder.hh"
 #include "service/storage_proxy.hh"
 #include "gms/feature.hh"
 #include "gms/feature_service.hh"
 
 #include "executor.hh"
+#include "streams.hh"
 #include "data_dictionary/data_dictionary.hh"
 #include "utils/rjson.hh"
 
@@ -90,6 +94,22 @@ static sstring stream_label(const schema& log_schema) {
     ::localtime_r(&tt, &tm);
     return seastar::json::formatter::to_json(tm);
 }
+
+// Debug printer for cdc::stream_id - used only for logging/debugging, not for
+// serialization or user-visible output. We print both signed and unsigned value
+// as we use both.
+template <>
+struct fmt::formatter<cdc::stream_id> : fmt::formatter<string_view> {
+    template <typename FormatContext>
+    auto format(const cdc::stream_id &id, FormatContext& ctx) const {
+        fmt::format_to(ctx.out(), "{} ", id.token());
+
+        for (auto b : id.to_bytes()) {
+            fmt::format_to(ctx.out(), "{:02x}", (unsigned char)b);
+        }
+        return ctx.out();
+    }
+};
 
 namespace alternator {
 // stream arn has certain format (see https://docs.aws.amazon.com/IAM/latest/UserGuide/reference-arns.html)
@@ -484,7 +504,7 @@ using namespace std::chrono_literals;
 // Dynamo docs says no data shall live longer than 24h.
 static constexpr auto dynamodb_streams_max_window = 24h;
 
-// find the parent shard in previous generation for the given child shard
+// find the parent Streams shard in previous generation for the given child Streams shard
 // takes care of wrap-around case in vnodes
 // prev_streams must be sorted by token
 const cdc::stream_id& find_parent_shard_in_previous_generation(db_clock::time_point prev_timestamp, const utils::chunked_vector<cdc::stream_id> &prev_streams, const cdc::stream_id &child) {
@@ -501,6 +521,304 @@ const cdc::stream_id& find_parent_shard_in_previous_generation(db_clock::time_po
         it = prev_streams.begin();
     }
     return *it;
+}
+
+// The function compare_lexicographically() below sorts stream shard ids in the
+// way we need to present them in our output. However, when processing lists of
+// shards internally, especially for finding child shards, it's more convenient
+// for us to sort the shard ids by the different function defined here -
+// compare_by_token(). It sorts the ids by numeric token (the end token of the
+// token range belonging to this shard), and makes algorithms like lower_bound()
+// possible.
+static bool compare_by_token(const cdc::stream_id& id1, const cdc::stream_id& id2) {
+    return id1.token() < id2.token();
+}
+
+// #7409 - shards must be returned in lexicographical order.
+// Normal bytes compare is string_traits<int8_t>::compare,
+// thus bytes 0x8000 is less than 0x0000. Instead, we need to use unsigned compare.
+// KCL depends on this ordering, so we need to adhere.
+static bool compare_lexicographically(const cdc::stream_id& id1, const cdc::stream_id& id2) {
+    return compare_unsigned(id1.to_bytes(), id2.to_bytes()) < 0;
+}
+
+stream_id_range::stream_id_range(
+        utils::chunked_vector<cdc::stream_id> &items,
+        utils::chunked_vector<cdc::stream_id>::iterator lo1,
+        utils::chunked_vector<cdc::stream_id>::iterator end1) : stream_id_range(items, lo1, end1, items.end(), items.end()) {}
+stream_id_range::stream_id_range(
+        utils::chunked_vector<cdc::stream_id> &items,
+        utils::chunked_vector<cdc::stream_id>::iterator lo1,
+        utils::chunked_vector<cdc::stream_id>::iterator end1,
+        utils::chunked_vector<cdc::stream_id>::iterator lo2,
+        utils::chunked_vector<cdc::stream_id>::iterator end2)
+    : _lo1(lo1)
+    , _end1(end1)
+    , _lo2(lo2)
+    , _end2(end2)
+{
+    if (_lo2 != items.end()) {
+        if (_lo1 != items.begin()) {
+            on_internal_error(slogger, fmt::format("Invalid stream_id_range: _lo1 != items.begin()"));
+        }
+        if (_end2 != items.end()) {
+            on_internal_error(slogger, fmt::format("Invalid stream_id_range: _end2 != items.end()"));
+        }
+    }
+    if (_end1 > _lo2)
+        on_internal_error(slogger, fmt::format("Invalid stream_id_range: _end1 > _lo2"));
+}
+
+void stream_id_range::set_starting_position(const cdc::stream_id &update_to) {
+    _skip_to = &update_to;
+}
+
+void stream_id_range::prepare_for_iterating()
+{
+    if (_prepared) return;
+    _prepared = true;
+    // here we deal with unfortunate possibility of wrap around range - in which case we actually have
+    // two ranges (lo1, end1) and (lo2, end2), where lo1 will be begin() and end2 will be end().
+    // the whole range needs to be sorted by `compare_lexicographically`, so we have to manually merge two ranges together and then sort them.
+    // We also need to apply starting position update, if it was set, after merging and sorting.
+    if (_end1 > _lo2)
+        on_internal_error(slogger, fmt::format("Invalid stream_id_range: _end1 > _lo2"));
+
+    auto tgt = _end1;
+    auto src = _lo2;
+    // just try to move second range just after first one - if we have only one range,
+    // second range will be empty and nothing will happen here
+    for(; src != _end2; ++src, ++tgt) {
+        std::swap(*tgt, *src);
+    }
+    // sort merged ranges by compare_lexicographically
+    std::sort(_lo1, tgt, compare_lexicographically);
+
+    // apply starting position update if it was set
+    // as a sanity check we require to find EXACT token match
+    if (_skip_to) {
+        auto it = std::lower_bound(_lo1, tgt, *_skip_to, compare_lexicographically);
+        if (it == tgt || it->token() != _skip_to->token()) {
+            slogger.info("Could not find starting position update shard id {}", *_skip_to);
+        } else {
+            _lo1 = std::next(it);
+        }
+    }
+    _end1 = tgt;
+}
+
+// the function returns `stream_id_range` that will allow iteration over children Streams shards for the Streams shard `parent`
+// a child Streams shard is defined as a Streams shard that touches token range that was previously covered by `parent` Streams shard
+// Streams shard contains a token, that represents end of the token range for that Streams shard (inclusive)
+// begginning of the token range is defined by previous Streams shard's token + 1
+// NOTE: With vnodes, ranges of Streams' shards wrap, while with tablets the biggest allowed token number is always a range end.
+// NOTE: both streams generation are guaranteed to cover whole range and be non-empty
+// NOTE: it's possible to get more than one stream shard with the same token value (thus some of those stream shards will be empty) -
+// for simplicity we will emit empty stream shards as well.
+//
+// to find children we will first find parent Streams shard in parent_streams by its token
+// then we will find previous Streams shard in parent stream - that will determine range
+// then based on the range we will find children Streams shards in current_streams
+// NOTE: function sorts / reorders current_streams
+// NOTE: function assumes parent_streams is sorted by compare_by_token and it doesn't modify it
+stream_id_range find_children_range_from_parent_token(
+    const utils::chunked_vector<cdc::stream_id>& parent_streams,
+    utils::chunked_vector<cdc::stream_id>& current_streams,
+    cdc::stream_id parent,
+    bool uses_tablets
+) {
+    // sanity checks for required preconditions
+    if (parent_streams.empty()) {
+        on_internal_error(slogger, fmt::format("parent_streams is empty") );
+    }
+    if (current_streams.empty()) {
+        on_internal_error(slogger, fmt::format("current_streams is empty") );
+    }
+
+    // first let's cover obvious cases
+    // if we have only one parent Streams shard, then all children belong to it
+    if (parent_streams.size() == 1) {
+        return stream_id_range{ current_streams, current_streams.begin(), current_streams.end() };
+    }
+    // if we have only one current Streams shard, then every parent maps to it
+    if (current_streams.size() == 1) {
+        return stream_id_range{ current_streams, current_streams.begin(), current_streams.end() };
+    }
+
+    // find parent Streams shard in parent_streams, it must be present and have exact match
+    auto parent_shard_end_it = std::lower_bound(parent_streams.begin(), parent_streams.end(), parent.token(), [](const cdc::stream_id& id, const dht::token& t) {
+        return id.token() < t;
+    });
+    if (parent_shard_end_it == parent_streams.end() || parent_shard_end_it->token() != parent.token()) {
+        throw api_error::validation(fmt::format("Invalid ShardFilter.ShardId value - shard {} not found", parent));
+    }
+
+    std::sort(current_streams.begin(), current_streams.end(), compare_by_token);
+
+    utils::chunked_vector<cdc::stream_id>::iterator child_shard_begin_it;
+    // upper_bound gives us the first element with token strictly greater than
+    // parent's end token - this is the correct one-past-end for an inclusive
+    // boundary and handles duplicate tokens (multiple children sharing a token)
+    auto child_shard_end_it = std::upper_bound(current_streams.begin(), current_streams.end(), parent_shard_end_it->token(), [](const dht::token& t, const cdc::stream_id& id) {
+            return t < id.token();
+    });
+
+    if (uses_tablets) {
+        // tablets version - tablets don't wrap around and last token is always present
+        // let's assume we've parent (first line) and child generation (second line):
+        // NOTE: token space doesn't wrap around - instead we have a guarantee that last token
+        // will be present as one of the shards
+        // P=|    1    2    3    4|
+        // C=| a  b    c       d e|
+        // we want to find children for each token from parent:
+        // 1 -> a,b
+        // 2 -> c
+        // 3 -> d
+        // 4 -> d, e
+        // first we find token in P that is end of range of parent - parent_shard_end_it
+        // - if parent_shard_end_it - 1 exists
+        //   - we take it as parent_shard_begin_it
+        //   - find the first child with token > parent_shard_begin_it and set it to child_shard_begin_it
+        // - else previous one to parent_shard_end_it does not exist
+        //   - set child_shard_begin_it = C.begin()
+        // - find the first child with token > parent_shard_end_it and set it to child_shard_end_it
+        // - range [child_shard_begin_it, child_shard_end_it) represents children
+
+        // When the parent's end token is not directly present in the children
+        // (merge scenario: several parent shards merged into fewer children),
+        // the child whose range absorbs the parent's end is the first child
+        // with token > parent_end_token.  upper_bound already points there,
+        // so we advance past it to include it in the [begin, end) range.
+        if (child_shard_end_it == current_streams.begin() || std::prev(child_shard_end_it)->token() != parent_shard_end_it->token()) {
+            if (child_shard_end_it == current_streams.end()) {
+                on_internal_error(slogger, fmt::format("parent end token not present in children tokens and no child with greater token exists, for parent shard id {}, got parent shards [{}] and children shards [{}]",
+                    parent, fmt::join(parent_streams, "; "), fmt::join(current_streams, "; ")));
+            }
+            ++child_shard_end_it;
+        }
+
+        // end of parent token is also first token in parent streams - it means beginning of the parent's range
+        // is the beginning of the token space - this means first child stream will be start of the children range
+        if (parent_shard_end_it == parent_streams.begin()) {
+            child_shard_begin_it = current_streams.begin();
+        } else {
+            // normal case - we have previous parent Streams shard that determines beginning of the range (exclusive)
+            // upper_bound skips past all children at the previous parent's token (including duplicates)
+            auto parent_shard_begin_it = std::prev(parent_shard_end_it);
+            child_shard_begin_it = std::upper_bound(current_streams.begin(), current_streams.end(), parent_shard_begin_it->token(), [](const dht::token& t, const cdc::stream_id& id) {
+                return t < id.token();
+            });
+        }
+
+        // simple range
+        return stream_id_range{ current_streams, child_shard_begin_it, child_shard_end_it };
+    } else {
+        // vnodes version - vnodes wrap around
+        // wrapping around make whole algorithm extremely confusing, because we wrap around on two levels,
+        // both parent Streams shard might wrap around and children range might wrap around as well
+
+        // helper function to find a range in current_streams based on range from parent_streams, but without wrap around
+        // if lo is not set, it means start from beginning of current_streams
+        // if end is not set, it means go until end of current_streams
+        auto find_range_in_children = [&](std::optional<utils::chunked_vector<cdc::stream_id>::const_iterator> lo, std::optional<utils::chunked_vector<cdc::stream_id>::const_iterator> end) -> std::pair<utils::chunked_vector<cdc::stream_id>::iterator, utils::chunked_vector<cdc::stream_id>::iterator> {
+            utils::chunked_vector<cdc::stream_id>::iterator res_lo, res_end;
+            if (!lo) {
+                // beginning of the range
+                res_lo = current_streams.begin();
+            } else {
+                // we use upper_bound as beginning of the range is exclusive
+                res_lo = std::upper_bound(current_streams.begin(), current_streams.end(), (*lo)->token(), [](const dht::token& t, const cdc::stream_id& id) {
+                    return t < id.token();
+                });
+            }
+            if (!end) {
+                // end of the range
+                res_end = current_streams.end();
+            } else {
+                // end of the range is inclusive, so we use upper_bound to find the first element
+                // with token strictly greater than the end token - this correctly handles the case
+                // where multiple children share the same token (e.g. small vnodes where several
+                // shards fall back to the vnode-end token)
+                res_end = std::upper_bound(current_streams.begin(), current_streams.end(), (*end)->token(), [](const dht::token& t, const cdc::stream_id& id) {
+                    return t < id.token();
+                });
+                // When the parent's end token is not directly present in the
+                // children (merge scenario), the child whose range absorbs the
+                // parent's end is at res_end.  Advance past it so that the
+                // half-open range [res_lo, res_end) includes it.
+                if (res_end != current_streams.end() &&
+                        (res_end == current_streams.begin() || std::prev(res_end)->token() != (*end)->token())) {
+                    ++res_end;
+                }
+            }
+            return { res_lo, res_end };
+        };
+        auto parent_shard_begin_it = parent_shard_end_it;
+        if (parent_shard_begin_it == parent_streams.begin()) {
+            // end of the parent Streams shard is also first token in parent streams - it means wrap around case for parent
+            // beginning of the parent's range is the last token in the parent streams
+            // for example:
+            // P=|         0 10    |
+            // C=| -20 -10         |
+            // searching for parent Streams shard at 0 will get us here - end of the parent is the first parent Streams shard
+            // so beginning of the parent's range is the last parent Streams shard (10)
+            parent_shard_begin_it = std::prev(parent_streams.end());
+
+            // we find two unwrapped ranges here - from beginning of current_streams to the end of the parent's range
+            // (end is inclusive) - in our example it's (-inf, 0]
+            auto [ lo1, end1 ] = find_range_in_children(std::nullopt, parent_shard_end_it);
+            // and from the beginning of the parent's range (exclusive) to the end of current_streams
+            // our example is (10, +inf)
+            auto [ lo2, end2 ] = find_range_in_children(parent_shard_begin_it, std::nullopt);
+
+            // in rare cases those two ranges might overlap - so we check and merge if needed
+            // for example:
+            // P=|     -30 -20      |
+            // C=| -40          -10 |
+            // searching for parent Streams shard at -30 will get us here - end of the parent is -30, beginning is -20
+            // first search will give us (-inf, +inf) with end1 pointing to current_streams.end()
+            // (because the range needs to include -10 position, so the iterator will point to the next one after - end of the current_streams)
+            // second search will give us [-10, +inf) with lo2 pointing to current_streams[1]
+            // which is less then end1 - so we need to merge those two ranges
+            if (lo2 < end1) {
+                assert(lo1 <= lo2);
+                assert(end1 <= end2);
+                end1 = end2;
+                lo2 = end2 = current_streams.end();
+            }
+            return stream_id_range{ current_streams, lo1, end1, lo2, end2 };
+        } else {
+            // simpler case - parent doesn't wrap around and we have both begin and end in normal order
+            // we search for single unwrapped range and adjust later if needed
+            --parent_shard_begin_it;
+            auto [ lo1, end1 ] = find_range_in_children(parent_shard_begin_it, parent_shard_end_it);
+            auto lo2 = current_streams.end();
+            auto end2 = current_streams.end();
+
+            // it's possible for simple case to still wrap around, when parent range lies after all children Streams shards
+            // for example:
+            // P=|         0 10    |
+            // C=| -20 -10         |
+            // when searching for parent shart at 0, we get parent range [0, 10)
+            // unwrapped search will produce empty range and miss -20 child Streams shard, which is actually
+            // owner of [0, 10) range (and is also a first Streams shard in current generation)
+            // note, that searching for 0 parent will give correct result, but because algorithm in that case
+            // detects wrap around case and chooses different if
+            if (parent_shard_end_it->token() > current_streams.back().token() && lo1 != current_streams.begin()) {
+                // wrap around case - children at the beginning of the sorted array
+                // wrap around the ring and cover the parent's range.  Include all
+                // children sharing the first token (duplicate tokens are possible
+                // for small vnodes where multiple shards fall back to the same token)
+                end2 = lo2 = current_streams.begin();
+                while(end2 != current_streams.end() && end2->token() == current_streams.front().token()) {
+                    ++end2;
+                }
+                std::swap(lo1, lo2);
+                std::swap(end1, end2);
+            }
+            return stream_id_range{ current_streams, lo1, end1, lo2, end2 };
+        }
+    }
 }
 
 future<executor::request_return_type> executor::describe_stream(client_state& client_state, service_permit permit, rjson::value request, std::unique_ptr<audit::audit_info_alternator>& audit_info) {
@@ -581,7 +899,32 @@ future<executor::request_return_type> executor::describe_stream(client_state& cl
     auto low_ts = std::max(as_timepoint(schema->id()), db_clock::now() - ttl);
 
     std::map<db_clock::time_point, cdc::streams_version> topologies = co_await _sdks.cdc_get_versioned_streams(low_ts, { normal_token_owners });
-    auto e = topologies.end();
+    const auto e = topologies.end();
+    std::optional<shard_id> shard_filter;
+
+    if (const rjson::value *shard_filter_obj = rjson::find(request, "ShardFilter")) {
+        if (!shard_filter_obj->IsObject()) {
+            throw api_error::validation("Invalid ShardFilter value - must be object");
+        }
+        std::string type;
+        try {
+            type = rjson::get<std::string>(*shard_filter_obj, "Type");
+        } catch (...) {
+            throw api_error::validation("Invalid ShardFilter.Type value - must be string `CHILD_SHARDS`");
+        }
+        if (type != "CHILD_SHARDS") {
+            throw api_error::validation("Invalid ShardFilter.Type value - must be string `CHILD_SHARDS`");
+        }
+        try {
+            shard_filter = rjson::get<shard_id>(*shard_filter_obj, "ShardId");
+        } catch (const std::exception &e) {
+            throw api_error::validation(fmt::format("Invalid ShardFilter.ShardId value - not a valid ShardId: {}", e.what()));
+        }
+        if (topologies.find(shard_filter->time) == topologies.end()) {
+            throw api_error::validation(fmt::format("Invalid ShardFilter.ShardId value - corresponding generation not found: {}", shard_filter->id));
+        }
+    }
+
     auto prev = e;
     auto shards = rjson::empty_array();
 
@@ -593,25 +936,6 @@ future<executor::request_return_type> executor::describe_stream(client_state& cl
         i = topologies.find(shard_start->time);
     }
 
-    // for parent-child stuff we need id:s to be sorted by token
-    // (see explanation above) since we want to find closest
-    // token boundary when determining parent.
-    // #7346 - we processed and searched children/parents in
-    // stored order, which is not necessarily token order,
-    // so the finding of "closest" token boundary (using upper bound)
-    // could give somewhat weird results.
-    static auto token_cmp = [](const cdc::stream_id& id1, const cdc::stream_id& id2) {
-        return id1.token() < id2.token();
-    };
-
-    // #7409 - shards must be returned in lexicographical order,
-    // normal bytes compare is string_traits<int8_t>::compare.
-    // thus bytes 0x8000 is less than 0x0000. By doing unsigned
-    // compare instead we inadvertently will sort in string lexical.
-    static auto id_cmp = [](const cdc::stream_id& id1, const cdc::stream_id& id2) {
-        return compare_unsigned(id1.to_bytes(), id2.to_bytes()) < 0;
-    };
-
     // need a prev even if we are skipping stuff
     if (i != topologies.begin()) {
         prev = std::prev(i);
@@ -620,24 +944,18 @@ future<executor::request_return_type> executor::describe_stream(client_state& cl
     for (; limit > 0 && i != e; prev = i, ++i) {
         auto& [ts, sv] = *i;
 
+        if (shard_filter && (prev == e || prev->first != shard_filter->time)) {
+            shard_start = std::nullopt;
+            continue;
+        }
         last = std::nullopt;
 
-        auto lo = sv.streams.begin();
-        auto end = sv.streams.end();
-
         // #7409 - shards must be returned in lexicographical order,
-        std::sort(lo, end, id_cmp);
-
-        if (shard_start) {
-            // find next shard position
-            lo = std::upper_bound(lo, end, shard_start->id, id_cmp);
-            shard_start = std::nullopt;
-        }
-
-        if (lo != end && prev != e) {
+        std::sort(sv.streams.begin(), sv.streams.end(), compare_lexicographically);
+        if (prev != e) {
             // We want older stuff sorted in token order so we can find matching
-            // token range when determining parent shard.
-            std::stable_sort(prev->second.streams.begin(), prev->second.streams.end(), token_cmp);
+            // token range when determining parent Streams shard.
+            std::stable_sort(prev->second.streams.begin(), prev->second.streams.end(), compare_by_token);
         }
 
         auto expired = [&]() -> std::optional<db_clock::time_point> {
@@ -650,9 +968,29 @@ future<executor::request_return_type> executor::describe_stream(client_state& cl
             return j->first + confidence_interval(db);
         }();
 
-        while (lo != end) {
-            auto& id = *lo++;
+        std::optional<stream_id_range> shard_range;
 
+        if (shard_filter) {
+            // sanity check - we should never get here as there is if above (`shard_filter && prev == e` => `continue`)
+            if (prev == e) {
+                on_internal_error(slogger, fmt::format("Could not find parent generation for shard id {}, got generations [{}]", shard_filter->id, fmt::join(topologies | std::ranges::views::keys, "; ")));
+            }
+
+            const bool uses_tablets = schema->table().uses_tablets();
+            shard_range = find_children_range_from_parent_token(
+                prev->second.streams,
+                i->second.streams,
+                shard_filter->id,
+                uses_tablets
+            );
+        } else {
+            shard_range = stream_id_range{ i->second.streams, i->second.streams.begin(), i->second.streams.end() };
+        }
+        if (shard_start) {
+            shard_range->set_starting_position(shard_start->id);
+        }
+        shard_range->prepare_for_iterating();
+        for(const auto &id : *shard_range) {
             auto shard = rjson::empty_object();
 
             if (prev != e) {
@@ -677,6 +1015,7 @@ future<executor::request_return_type> executor::describe_stream(client_state& cl
 
             last = std::nullopt;
         }
+        shard_start = std::nullopt;
     }
 
     if (last) {

--- a/alternator/streams.hh
+++ b/alternator/streams.hh
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2026-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+ */
+
+#pragma once
+
+#include "utils/chunked_vector.hh"
+#include "cdc/generation.hh"
+#include <generator>
+
+namespace cdc {
+    class stream_id;
+}
+
+namespace alternator {
+    class stream_id_range {
+        // helper class for manipulating (possibly wrapped around) range of stream_ids
+        // it holds one or two ranges [lo1, end1) and [lo2, end2)
+        // if the range doesn't wrap around, then lo2 == end2 == items.end()
+        // if the range wraps around, then
+        // `lo1 == items.begin() and end2 == items.end()` must be true
+        // the object doesn't own `items`, but it does manipulate it - it will
+        // reorder elements (so both ranges were next to each other) and sort them by unsigned comparison
+        // usage - create an object with needed ranges. before iteration call `prepare_for_iterating` method -
+        // it will reorder elements of `items` array to what is needed and then call begin / end pair.
+        // note - `items` array will be modified - elements will be reordered, but no elements will be added or removed.
+        // `items` array must stay intact as long as iteration is in progress.
+        utils::chunked_vector<cdc::stream_id>::iterator _lo1 = {}, _end1 = {}, _lo2 = {}, _end2 = {};
+        const cdc::stream_id* _skip_to = nullptr;
+        bool _prepared = false;
+    public:
+        stream_id_range(
+                utils::chunked_vector<cdc::stream_id> &items,
+                utils::chunked_vector<cdc::stream_id>::iterator lo1,
+                utils::chunked_vector<cdc::stream_id>::iterator end1);
+        stream_id_range(
+                utils::chunked_vector<cdc::stream_id> &items,
+                utils::chunked_vector<cdc::stream_id>::iterator lo1,
+                utils::chunked_vector<cdc::stream_id>::iterator end1,
+                utils::chunked_vector<cdc::stream_id>::iterator lo2,
+                utils::chunked_vector<cdc::stream_id>::iterator end2);
+
+        void set_starting_position(const cdc::stream_id &update_to);
+        // Must be called after construction and after set_starting_position()
+        // (if used), but before begin()/end() iteration.
+        void prepare_for_iterating();
+
+        utils::chunked_vector<cdc::stream_id>::iterator begin() const { return _lo1; }
+        utils::chunked_vector<cdc::stream_id>::iterator end() const { return _end1; }
+    };
+
+    stream_id_range find_children_range_from_parent_token(
+        const utils::chunked_vector<cdc::stream_id>& parent_streams,
+        utils::chunked_vector<cdc::stream_id>& current_streams,
+        cdc::stream_id parent,
+        bool uses_tablets
+    );
+}

--- a/test/alternator/test_streams.py
+++ b/test/alternator/test_streams.py
@@ -2218,6 +2218,76 @@ def test_streams_multiple_items_one_partition(dynamodb, dynamodbstreams, scylla_
             return [['INSERT', {'p': p, 'c': cc}, None, {'p': p, 'c': cc, 'x': cc}] for cc in cs]
         do_test(stream, dynamodb, dynamodbstreams, do_updates, 'NEW_AND_OLD_IMAGES')
 
+# Test the CHILD_SHARDS shard filter. In a simple case where the table
+# hasn't been modified since the stream was created, there is just one
+# generation so asking for child shards of the only shard returns nothing.
+# NOTE: a more complete test that actually creates new stream shard
+# generations will be added in a later patch.
+def test_stream_shard_filtering_simple_no_children(test_table_ss_keys_only, dynamodbstreams):
+    table, _ = test_table_ss_keys_only
+    streams = dynamodbstreams.list_streams(TableName=table.name)
+    arn = streams['Streams'][0]['StreamArn']
+    desc = dynamodbstreams.describe_stream(StreamArn=arn)
+    shard_id = desc['StreamDescription']['Shards'][0]['ShardId']
+    desc_filtered = dynamodbstreams.describe_stream(StreamArn=arn, ShardFilter={
+        'ShardId': shard_id,
+        'Type': 'CHILD_SHARDS'
+    })
+    assert desc_filtered
+    assert desc_filtered.get('StreamDescription')
+    assert desc_filtered['StreamDescription']['StreamArn'] == arn
+    assert desc_filtered['StreamDescription']['StreamStatus'] != 'DISABLED'
+    assert desc_filtered['StreamDescription']['StreamViewType'] == 'KEYS_ONLY'
+    assert desc_filtered['StreamDescription']['TableName'] == table.name
+    assert not desc_filtered['StreamDescription']['Shards']
+
+# Test that DescribeStream with an unsupported ShardFilter Type returns
+# an error. Currently only 'CHILD_SHARDS' is supported.
+def test_stream_shard_filtering_wrong_type(test_table_ss_keys_only, dynamodbstreams):
+    table, _ = test_table_ss_keys_only
+    streams = dynamodbstreams.list_streams(TableName=table.name)
+    arn = streams['Streams'][0]['StreamArn']
+    desc = dynamodbstreams.describe_stream(StreamArn=arn)
+    shard_id = desc['StreamDescription']['Shards'][0]['ShardId']
+    with pytest.raises(ClientError, match='ValidationException'):
+        dynamodbstreams.describe_stream(StreamArn=arn, ShardFilter={
+            'ShardId': shard_id,
+            'Type': 'foo'
+        })
+
+# test for correct error handling of DescribeStream when using ShardFilter with shard id (wrong format)
+def test_stream_shard_filtering_wrong_shard_id(test_table_ss_keys_only, dynamodbstreams):
+    table, _ = test_table_ss_keys_only
+    streams = dynamodbstreams.list_streams(TableName=table.name)
+    arn = streams['Streams'][0]['StreamArn']
+    with pytest.raises(ClientError, match='ValidationException.*[sS]hardFilter[.][sS]hardId'):
+        dynamodbstreams.describe_stream(StreamArn=arn, ShardFilter={
+            'ShardId': "qwerty",
+            'Type': 'CHILD_SHARDS'
+        })
+
+# test for correct error handling of DescribeStream when using ShardFilter with missing type
+def test_stream_shard_filtering_missing_type(test_table_ss_keys_only, dynamodbstreams):
+    table, _ = test_table_ss_keys_only
+    streams = dynamodbstreams.list_streams(TableName=table.name)
+    arn = streams['Streams'][0]['StreamArn']
+    desc = dynamodbstreams.describe_stream(StreamArn=arn)
+    shard_id = desc['StreamDescription']['Shards'][0]['ShardId']
+    with pytest.raises(ClientError, match='ValidationException'):
+        dynamodbstreams.describe_stream(StreamArn=arn, ShardFilter={
+            'ShardId': shard_id,
+        })
+
+# test for correct error handling of DescribeStream when using ShardFilter with missing shard id
+def test_stream_shard_filtering_missing_shard_id(test_table_ss_keys_only, dynamodbstreams):
+    table, _ = test_table_ss_keys_only
+    streams = dynamodbstreams.list_streams(TableName=table.name)
+    arn = streams['Streams'][0]['StreamArn']
+    with pytest.raises(ClientError, match='ValidationException'):
+        dynamodbstreams.describe_stream(StreamArn=arn, ShardFilter={
+            'Type': 'CHILD_SHARDS'
+        })
+
 # TODO: tests on multiple partitions
 # TODO: write a test that disabling the stream and re-enabling it works, but
 #   requires the user to wait for the first stream to become DISABLED before

--- a/test/boost/alternator_unit_test.cc
+++ b/test/boost/alternator_unit_test.cc
@@ -15,9 +15,11 @@
 #include "alternator/serialization.hh"
 #include "alternator/error.hh"
 
-#include "alternator/expressions.hh"
 #include "cdc/generation.hh"
 #include "alternator/executor.hh"
+#include "dht/token-sharding.hh"
+#include "alternator/expressions.hh"
+#include "alternator/streams.hh"
 #include <seastar/core/coroutine.hh>
 #include <seastar/coroutine/maybe_yield.hh>
 #include <seastar/core/sleep.hh>
@@ -526,4 +528,924 @@ BOOST_AUTO_TEST_CASE(find_parent_shard_in_previous_generation_one_value) {
     BOOST_CHECK(alternator::find_parent_shard_in_previous_generation({}, gen, generate_stream_id_from_int(-20)) == gen[0]);
     BOOST_CHECK(alternator::find_parent_shard_in_previous_generation({}, gen, generate_stream_id_from_int(-10)) == gen[0]);
     BOOST_CHECK(alternator::find_parent_shard_in_previous_generation({}, gen, generate_stream_id_from_int(0)) == gen[0]);
+}
+
+namespace {
+    auto sid(std::int64_t token) {
+        return cdc::stream_id{ dht::token{ token }, 0 };
+    }
+    auto stream_ids(std::initializer_list<cdc::stream_id> ids) {
+        utils::chunked_vector<cdc::stream_id> result;
+        result.reserve(ids.size());
+        for (const auto& id : ids) {
+            result.push_back(id);
+        }
+        return result;
+    }
+    auto sids(std::initializer_list<std::int64_t> tokens) {
+        utils::chunked_vector<cdc::stream_id> result;
+        for (auto t : tokens) {
+            result.push_back(sid(t));
+        }
+        return result;
+    }
+    utils::chunked_vector<cdc::stream_id> to_sids(alternator::stream_id_range range) {
+        utils::chunked_vector<cdc::stream_id> result;
+        range.prepare_for_iterating();
+        for (auto &sid : range) {
+            result.push_back(sid);
+        }
+        return result;
+    }
+    utils::chunked_vector<cdc::stream_id> vec(const utils::chunked_vector<cdc::stream_id> &vec, int start = 0, int end = 0x7fffffff, int start2 = 0, int end2 = 0) {
+        auto update_start_end = [&](int &start, int &end) {
+            if (start < 0) start += (int)vec.size();
+            if (end < 0) end += (int)vec.size();
+            if (start < 0) start = 0;
+            if (start > (int)vec.size()) start = (int)vec.size();
+            if (end < 0) end = 0;
+            if (end > (int)vec.size()) end = (int)vec.size();
+        };
+        update_start_end(start, end);
+        update_start_end(start2, end2);
+        utils::chunked_vector<cdc::stream_id> result;
+        while(start < end) {
+            result.push_back(vec[start++]);
+        }
+        while(start2 < end2) {
+            result.push_back(vec[start2++]);
+        }
+        return result;
+    }
+    utils::chunked_vector<cdc::stream_id> sorted_vec(utils::chunked_vector<cdc::stream_id> v, int start = 0, int end = 0x7fffffff, int start2 = 0, int end2 = 0) {
+        std::sort(v.begin(), v.end(), [](const cdc::stream_id &a, const cdc::stream_id &b) {
+            return a.token() < b.token();
+        });
+        auto v2 = vec(v, start, end, start2, end2);
+        std::sort(v2.begin(), v2.end(), [](const cdc::stream_id &a, const cdc::stream_id &b) {
+            return compare_unsigned(a.to_bytes(), b.to_bytes()) < 0;
+        });
+        return v2;
+    }
+}
+
+namespace cdc {
+    // must be in cdc namespace so ADL could work and BOOST could find it
+    std::ostream & operator <<(std::ostream &os, const std::vector<stream_id> &vec) {
+        os << "[";
+        bool first = true;
+        for (auto &sid : vec) {
+            if (!first) {
+                os << ", ";
+            }
+            first = false;
+            os << sid.token();
+        }
+        os << "]";
+        return os;
+    }
+}
+namespace utils {
+    std::ostream & operator <<(std::ostream &os, const utils::chunked_vector<cdc::stream_id> &vec) {
+        os << "[";
+        bool first = true;
+        for (auto &sid : vec) {
+            if (!first) {
+                os << ", ";
+            }
+            first = false;
+            os << sid.token();
+        }
+        os << "]";
+        return os;
+    }
+}
+
+BOOST_AUTO_TEST_CASE(test_find_children_range_from_parent_tablets_simple) {
+    auto parent_streams = sids({ -50, 50, std::numeric_limits<std::int64_t>::max() });
+    auto current_streams = sids({ -50, 50, std::numeric_limits<std::int64_t>::max() });
+
+    auto range = to_sids(alternator::find_children_range_from_parent_token(parent_streams, current_streams, parent_streams[0], true));
+    BOOST_REQUIRE(vec(range) == sorted_vec(current_streams, 0, 1));
+
+    range = to_sids(alternator::find_children_range_from_parent_token(parent_streams, current_streams, parent_streams[1], true));
+    BOOST_REQUIRE(vec(range) == sorted_vec(current_streams, 1, 2));
+
+    range = to_sids(alternator::find_children_range_from_parent_token(parent_streams, current_streams, parent_streams[2], true));
+    BOOST_REQUIRE(vec(range) == sorted_vec(current_streams, 2, 3));
+}
+
+BOOST_AUTO_TEST_CASE(test_find_children_range_from_parent_tablets_starting_pos_1) {
+    auto parent_streams = sids({ -150, 200, std::numeric_limits<std::int64_t>::max() });
+    auto current_streams = sids({ -200, -150, -100, -50, 0, 50, 100, 150, 200, 250, std::numeric_limits<std::int64_t>::max() });
+    auto starting_pos = current_streams[5]; // 50, we need to pick it now, because find_children_range_from_parent_token will sort and move current_streams
+
+    // we expect to get 100, 150, 200, -100, -50
+    auto expected_result = sorted_vec(current_streams, 2, 4, 6, 9);
+
+    // we search for children of parent at token 200, which means all children that touch range (-150, 200]
+    // the range will be (-150, 200], but sorted unsigned, so (0, 200] and (-150, 0) -> 0, 50, 100, 150, 200, -100, -50
+    auto range = alternator::find_children_range_from_parent_token(parent_streams, current_streams, parent_streams[1], true);
+
+    // let's start from 50 - this skips 0 and 50 as starting point is exclusive
+    range.set_starting_position(starting_pos);
+
+    // we should get 100, 150, 200, -100, -50
+    auto range_sids = to_sids(range);
+    BOOST_REQUIRE(range_sids == expected_result);
+}
+
+BOOST_AUTO_TEST_CASE(test_find_children_range_from_parent_tablets_starting_pos_2) {
+    auto parent_streams = sids({ -150, 200, std::numeric_limits<std::int64_t>::max() });
+    auto current_streams = sids({ -200, -150, -100, -50, 0, 50, 100, 150, 200, 250, std::numeric_limits<std::int64_t>::max() });
+    auto starting_pos = current_streams[2]; // -100, we need to pick it now, because find_children_range_from_parent_token will sort and move current_streams
+
+    // we expect to get -50
+    auto expected_result = sorted_vec(current_streams, 3, 4);
+
+    // we search for children of parent at token 200, which means all children that touch range (-150, 200]
+    // the range will be (-150, 200], but sorted unsigned, so (0, 200] and (-150, 0) -> 0, 50, 100, 150, 200, -100, -50
+    auto range = alternator::find_children_range_from_parent_token(parent_streams, current_streams, parent_streams[1], true);
+
+    // let's start from -100 - this leaves only -50 and skips everything before it
+    range.set_starting_position(starting_pos);
+
+    // we should get -50
+    auto range_sids = to_sids(range);
+    BOOST_REQUIRE(range_sids == expected_result);
+}
+
+BOOST_AUTO_TEST_CASE(test_find_children_range_from_parent_tablets_merge_1) {
+    auto parent_streams = sids({ 0, 50, std::numeric_limits<std::int64_t>::max() });
+    auto current_streams = sids({ 0, std::numeric_limits<std::int64_t>::max() });
+
+    auto range = to_sids(alternator::find_children_range_from_parent_token(parent_streams, current_streams, parent_streams[0], true));
+    BOOST_REQUIRE(vec(range) == sorted_vec(current_streams, 0, 1));
+
+    range = to_sids(alternator::find_children_range_from_parent_token(parent_streams, current_streams, parent_streams[1], true));
+    BOOST_REQUIRE(vec(range) == sorted_vec(current_streams, 1, 2));
+
+    range = to_sids(alternator::find_children_range_from_parent_token(parent_streams, current_streams, parent_streams[2], true));
+    BOOST_REQUIRE(vec(range) == sorted_vec(current_streams, 1, 2));
+}
+
+BOOST_AUTO_TEST_CASE(test_find_children_range_from_parent_tablets_merge_2) {
+    auto parent_streams = sids({ 0, 50, std::numeric_limits<std::int64_t>::max() });
+    auto current_streams = sids({ 50, std::numeric_limits<std::int64_t>::max() });
+
+    auto range = to_sids(alternator::find_children_range_from_parent_token(parent_streams, current_streams, parent_streams[0], true));
+    BOOST_REQUIRE(vec(range) == sorted_vec(current_streams, 0, 1));
+
+    range = to_sids(alternator::find_children_range_from_parent_token(parent_streams, current_streams, parent_streams[1], true));
+    BOOST_REQUIRE(vec(range) == sorted_vec(current_streams, 0, 1));
+
+    range = to_sids(alternator::find_children_range_from_parent_token(parent_streams, current_streams, parent_streams[2], true));
+    BOOST_REQUIRE(vec(range) == sorted_vec(current_streams, 1, 2));
+}
+
+BOOST_AUTO_TEST_CASE(test_find_children_range_from_parent_tablets_merge_into_one) {
+    auto parent_streams = sids({ -100, -50, 25, 50, std::numeric_limits<std::int64_t>::max() });
+    auto current_streams = sids({ std::numeric_limits<std::int64_t>::max() });
+
+    auto range = to_sids(alternator::find_children_range_from_parent_token(parent_streams, current_streams, parent_streams[0], true));
+    BOOST_REQUIRE(vec(range) == sorted_vec(current_streams, 0, 1));
+
+    range = to_sids(alternator::find_children_range_from_parent_token(parent_streams, current_streams, parent_streams[1], true));
+    BOOST_REQUIRE(vec(range) == sorted_vec(current_streams, 0, 1));
+
+    range = to_sids(alternator::find_children_range_from_parent_token(parent_streams, current_streams, parent_streams[2], true));
+    BOOST_REQUIRE(vec(range) == sorted_vec(current_streams, 0, 1));
+
+    range = to_sids(alternator::find_children_range_from_parent_token(parent_streams, current_streams, parent_streams[3], true));
+    BOOST_REQUIRE(vec(range) == sorted_vec(current_streams, 0, 1));
+
+    range = to_sids(alternator::find_children_range_from_parent_token(parent_streams, current_streams, parent_streams[4], true));
+    BOOST_REQUIRE(vec(range) == sorted_vec(current_streams, 0, 1));
+}
+
+BOOST_AUTO_TEST_CASE(test_find_children_range_from_parent_tablets_split_1) {
+    auto parent_streams = sids({ 0, 50, std::numeric_limits<std::int64_t>::max() });
+    auto current_streams = sids({ 0, 25, 50, std::numeric_limits<std::int64_t>::max() });
+
+    auto range = to_sids(alternator::find_children_range_from_parent_token(parent_streams, current_streams, parent_streams[0], true));
+    BOOST_REQUIRE(vec(range) == sorted_vec(current_streams, 0, 1));
+
+    range = to_sids(alternator::find_children_range_from_parent_token(parent_streams, current_streams, parent_streams[1], true));
+    BOOST_REQUIRE(vec(range) == sorted_vec(current_streams, 1, 3));
+
+    range = to_sids(alternator::find_children_range_from_parent_token(parent_streams, current_streams, parent_streams[2], true));
+    BOOST_REQUIRE(vec(range) == sorted_vec(current_streams, 3, 4));
+}
+
+BOOST_AUTO_TEST_CASE(test_find_children_range_from_parent_tablets_split_2) {
+    auto parent_streams = sids({ 0, 50, std::numeric_limits<std::int64_t>::max() });
+    auto current_streams = sids({ -25, 0, 50, std::numeric_limits<std::int64_t>::max() });
+
+    auto range = to_sids(alternator::find_children_range_from_parent_token(parent_streams, current_streams, parent_streams[0], true));
+    BOOST_REQUIRE(vec(range) == sorted_vec(current_streams, 0, 2));
+
+    range = to_sids(alternator::find_children_range_from_parent_token(parent_streams, current_streams, parent_streams[1], true));
+    BOOST_REQUIRE(vec(range) == sorted_vec(current_streams, 2, 3));
+
+    range = to_sids(alternator::find_children_range_from_parent_token(parent_streams, current_streams, parent_streams[2], true));
+    BOOST_REQUIRE(vec(range) == sorted_vec(current_streams, 3, 4));
+}
+
+BOOST_AUTO_TEST_CASE(test_find_children_range_from_parent_tablets_split_3) {
+    auto parent_streams = sids({ 0, 50, std::numeric_limits<std::int64_t>::max() });
+    auto current_streams = sids({ 0, 50, 75, std::numeric_limits<std::int64_t>::max() });
+
+    auto range = to_sids(alternator::find_children_range_from_parent_token(parent_streams, current_streams, parent_streams[0], true));
+    BOOST_REQUIRE(vec(range) == sorted_vec(current_streams, 0, 1));
+
+    range = to_sids(alternator::find_children_range_from_parent_token(parent_streams, current_streams, parent_streams[1], true));
+    BOOST_REQUIRE(vec(range) == sorted_vec(current_streams, 1, 2));
+
+    range = to_sids(alternator::find_children_range_from_parent_token(parent_streams, current_streams, parent_streams[2], true));
+    BOOST_REQUIRE(vec(range) == sorted_vec(current_streams, 2, 4));
+}
+
+BOOST_AUTO_TEST_CASE(test_find_children_range_from_parent_tablets_split_from_one) {
+    auto parent_streams = sids({ std::numeric_limits<std::int64_t>::max() });
+    auto current_streams = sids({ -100, -50, 50, 75, std::numeric_limits<std::int64_t>::max() });
+
+    auto range = to_sids(alternator::find_children_range_from_parent_token(parent_streams, current_streams, parent_streams[0], true));
+    BOOST_REQUIRE(vec(range) == sorted_vec(current_streams, 0, 5));
+}
+
+BOOST_AUTO_TEST_CASE(test_find_children_range_from_parent_tablets_split_and_merge) {
+    auto parent_streams = sids({ 0, 50, 100, std::numeric_limits<std::int64_t>::max() });
+    auto current_streams = sids({ 25, 75, std::numeric_limits<std::int64_t>::max() });
+
+    auto range = to_sids(alternator::find_children_range_from_parent_token(parent_streams, current_streams, parent_streams[0], true));
+    BOOST_REQUIRE(vec(range) == sorted_vec(current_streams, 0, 1));
+
+    range = to_sids(alternator::find_children_range_from_parent_token(parent_streams, current_streams, parent_streams[1], true));
+    BOOST_REQUIRE(vec(range) == sorted_vec(current_streams, 0, 2));
+
+    range = to_sids(alternator::find_children_range_from_parent_token(parent_streams, current_streams, parent_streams[2], true));
+    BOOST_REQUIRE(vec(range) == sorted_vec(current_streams, 1, 3));
+
+    range = to_sids(alternator::find_children_range_from_parent_token(parent_streams, current_streams, parent_streams[3], true));
+    BOOST_REQUIRE(vec(range) == sorted_vec(current_streams, 2, 3));
+}
+
+
+
+
+
+
+
+BOOST_AUTO_TEST_CASE(test_find_children_range_from_parent_vnodes_simple) {
+    auto parent_streams = sids({ -50, 50 });
+    auto current_streams = sids({ -50, 50 });
+
+    auto range = to_sids(alternator::find_children_range_from_parent_token(parent_streams, current_streams, parent_streams[0], false));
+    BOOST_REQUIRE(vec(range) == sorted_vec(current_streams, 0, 1));
+
+    range = to_sids(alternator::find_children_range_from_parent_token(parent_streams, current_streams, parent_streams[1], false));
+    BOOST_REQUIRE(vec(range) == sorted_vec(current_streams, 1, 2));
+}
+
+BOOST_AUTO_TEST_CASE(test_find_children_range_from_parent_vnodes_starting_pos_1) {
+    auto parent_streams = sids({ -150, 200 });
+    auto current_streams = sids({ -200, -150, -100, -50, 0, 50, 100, 150, 200, 250 });
+    auto starting_pos = current_streams[5]; // 50, we need to pick it now, because find_children_range_from_parent_token will sort and move current_streams
+
+    // we expect to get 100, 150, 200, -100, -50
+    auto expected_result = sorted_vec(current_streams, 2, 4, 6, 9);
+
+    // we search for children of parent at token 200, which means all children that touch range (-150, 200]
+    // the range will be (-150, 200], but sorted unsigned, so (0, 200] and (-150, 0) -> 0, 50, 100, 150, 200, -100, -50
+    auto range = alternator::find_children_range_from_parent_token(parent_streams, current_streams, parent_streams[1], false);
+
+    // let's start from 50 - this skips 0 and 50 as starting point is exclusive
+    range.set_starting_position(starting_pos);
+
+    // we should get 100, 150, 200, -100, -50
+    auto range_sids = to_sids(range);
+    BOOST_REQUIRE(range_sids == expected_result);
+}
+
+BOOST_AUTO_TEST_CASE(test_find_children_range_from_parent_vnodes_starting_pos_2) {
+    auto parent_streams = sids({ -150, 200 });
+    auto current_streams = sids({ -200, -150, -100, -50, 0, 50, 100, 150, 200, 250 });
+    auto starting_pos = current_streams[2]; // -100, we need to pick it now, because find_children_range_from_parent_token will sort and move current_streams
+
+    // we expect to get -50
+    auto expected_result = sorted_vec(current_streams, 3, 4);
+
+    // we search for children of parent at token 200, which means all children that touch range (-150, 200]
+    // the range will be (-150, 200], but sorted unsigned, so (0, 200] and (-150, 0) -> 0, 50, 100, 150, 200, -100, -50
+    auto range = alternator::find_children_range_from_parent_token(parent_streams, current_streams, parent_streams[1], false);
+
+    // let's start from -100 - this leaves only -50 and skips everything before it
+    range.set_starting_position(starting_pos);
+
+    // we should get -50
+    auto range_sids = to_sids(range);
+    BOOST_REQUIRE(range_sids == expected_result);
+}
+
+BOOST_AUTO_TEST_CASE(test_find_children_range_from_parent_vnodes_starting_pos_3_wrap_around) {
+    auto parent_streams = sids({ -50, 50 });
+    auto current_streams = sids({ -200, -150, -100, -50, 0, 50, 100, 150, 200, 250 });
+    auto starting_pos = current_streams[1]; // -150, we need to pick it now, because find_children_range_from_parent_token will sort and move current_streams
+
+    // we expect to get -100, -50
+    auto expected_result = sorted_vec(current_streams, 2, 4);
+
+    // we search for children of parent at token -50, which means all children that touch range (-inf, -50] and (50, +inf) - wraps around
+    // sorted unsigned -> (50, +inf) (-inf, -50] -> -> 50, 100, 150, 200, 250, -200, -150, -100, -50
+    auto range = alternator::find_children_range_from_parent_token(parent_streams, current_streams, parent_streams[0], false);
+
+    // let's start from -150 - this leaves only -100 and -50 and skips everything before it
+    range.set_starting_position(starting_pos);
+
+    // we should get -100, -50
+    auto range_sids = to_sids(range);
+    BOOST_REQUIRE(range_sids == expected_result);
+}
+
+BOOST_AUTO_TEST_CASE(test_find_children_range_from_parent_vnodes_starting_pos_4_wrap_around) {
+    auto parent_streams = sids({ -50, 50 });
+    auto current_streams = sids({ -200, -150, -100, -50, 0, 50, 100, 150, 200, 250 });
+    auto starting_pos = current_streams[6]; // 100, we need to pick it now, because find_children_range_from_parent_token will sort and move current_streams
+
+    // we expect to get 150, 200, 250, -200, -150, -100, -50
+    auto expected_result = sorted_vec(current_streams, 7, 10, 0, 4);
+
+    // we search for children of parent at token -50, which means all children that touch range (-inf, -50] and (50, +inf) - wraps around
+    // sorted unsigned -> (50, +inf) (-inf, -50] -> -> 50, 100, 150, 200, 250, -200, -150, -100, -50
+    auto range = alternator::find_children_range_from_parent_token(parent_streams, current_streams, parent_streams[0], false);
+
+    // let's start from 100 - this leaves only 150, 200, 250, -200, -150, -100, -50
+    range.set_starting_position(starting_pos);
+
+    // we should get 150, 200, 250, -200, -150, -100, -50
+    auto range_sids = to_sids(range);
+
+    BOOST_REQUIRE(range_sids == expected_result);
+}
+
+BOOST_AUTO_TEST_CASE(test_find_children_range_from_parent_vnodes_merge_1) {
+    auto parent_streams = sids({ 0, 25, 50, 75 });
+    auto current_streams = sids({ 25, 50, 75 });
+
+    auto range = to_sids(alternator::find_children_range_from_parent_token(parent_streams, current_streams, parent_streams[0], false));
+    BOOST_REQUIRE(vec(range) == sorted_vec(current_streams, 0, 1));
+
+    range = to_sids(alternator::find_children_range_from_parent_token(parent_streams, current_streams, parent_streams[1], false));
+    BOOST_REQUIRE(vec(range) == sorted_vec(current_streams, 0, 1));
+
+    range = to_sids(alternator::find_children_range_from_parent_token(parent_streams, current_streams, parent_streams[2], false));
+    BOOST_REQUIRE(vec(range) == sorted_vec(current_streams, 1, 2));
+
+    range = to_sids(alternator::find_children_range_from_parent_token(parent_streams, current_streams, parent_streams[3], false));
+    BOOST_REQUIRE(vec(range) == sorted_vec(current_streams, 2, 3));
+}
+
+BOOST_AUTO_TEST_CASE(test_find_children_range_from_parent_vnodes_merge_2) {
+    auto parent_streams = sids({ 0, 25, 50, 75 });
+    auto current_streams = sids({ 0, 50, 75 });
+
+    auto range = to_sids(alternator::find_children_range_from_parent_token(parent_streams, current_streams, parent_streams[0], false));
+    BOOST_REQUIRE(vec(range) == sorted_vec(current_streams, 0, 1));
+
+    range = to_sids(alternator::find_children_range_from_parent_token(parent_streams, current_streams, parent_streams[1], false));
+    BOOST_REQUIRE(vec(range) == sorted_vec(current_streams, 1, 2));
+
+    range = to_sids(alternator::find_children_range_from_parent_token(parent_streams, current_streams, parent_streams[2], false));
+    BOOST_REQUIRE(vec(range) == sorted_vec(current_streams, 1, 2));
+
+    range = to_sids(alternator::find_children_range_from_parent_token(parent_streams, current_streams, parent_streams[3], false));
+    BOOST_REQUIRE(vec(range) == sorted_vec(current_streams, 2, 3));
+}
+
+BOOST_AUTO_TEST_CASE(test_find_children_range_from_parent_vnodes_merge_3) {
+    auto parent_streams = sids({ 0, 25, 50, 75 });
+    auto current_streams = sids({ 0, 25, 75 });
+
+    auto range = to_sids(alternator::find_children_range_from_parent_token(parent_streams, current_streams, parent_streams[0], false));
+    BOOST_REQUIRE(vec(range) == sorted_vec(current_streams, 0, 1));
+
+    range = to_sids(alternator::find_children_range_from_parent_token(parent_streams, current_streams, parent_streams[1], false));
+    BOOST_REQUIRE(vec(range) == sorted_vec(current_streams, 1, 2));
+
+    range = to_sids(alternator::find_children_range_from_parent_token(parent_streams, current_streams, parent_streams[2], false));
+    BOOST_REQUIRE(vec(range) == sorted_vec(current_streams, 2, 3));
+
+    range = to_sids(alternator::find_children_range_from_parent_token(parent_streams, current_streams, parent_streams[3], false));
+    BOOST_REQUIRE(vec(range) == sorted_vec(current_streams, 2, 3));
+}
+
+BOOST_AUTO_TEST_CASE(test_find_children_range_from_parent_vnodes_merge_4) {
+    auto parent_streams = sids({ 0, 25, 50, 75 });
+    auto current_streams = sids({ 0, 25, 50 });
+
+    auto range = to_sids(alternator::find_children_range_from_parent_token(parent_streams, current_streams, parent_streams[0], false));
+    BOOST_REQUIRE(vec(range) == sorted_vec(current_streams, 0, 1));
+
+    range = to_sids(alternator::find_children_range_from_parent_token(parent_streams, current_streams, parent_streams[1], false));
+    BOOST_REQUIRE(vec(range) == sorted_vec(current_streams, 1, 2));
+
+    range = to_sids(alternator::find_children_range_from_parent_token(parent_streams, current_streams, parent_streams[2], false));
+    BOOST_REQUIRE(vec(range) == sorted_vec(current_streams, 2, 3));
+
+    range = to_sids(alternator::find_children_range_from_parent_token(parent_streams, current_streams, parent_streams[3], false));
+    BOOST_REQUIRE(vec(range) == sorted_vec(current_streams, 0, 1));
+}
+
+BOOST_AUTO_TEST_CASE(test_find_children_range_from_parent_vnodes_merge_into_one_1) {
+    auto parent_streams = sids({ 0, 25, 50 });
+    auto current_streams = sids({ -50 });
+
+    auto range = to_sids(alternator::find_children_range_from_parent_token(parent_streams, current_streams, parent_streams[0], false));
+    BOOST_REQUIRE(vec(range) == sorted_vec(current_streams, 0, 1));
+
+    range = to_sids(alternator::find_children_range_from_parent_token(parent_streams, current_streams, parent_streams[1], false));
+    BOOST_REQUIRE(vec(range) == sorted_vec(current_streams, 0, 1));
+
+    range = to_sids(alternator::find_children_range_from_parent_token(parent_streams, current_streams, parent_streams[2], false));
+    BOOST_REQUIRE(vec(range) == sorted_vec(current_streams, 0, 1));
+}
+
+BOOST_AUTO_TEST_CASE(test_find_children_range_from_parent_vnodes_merge_into_one_2) {
+    auto parent_streams = sids({ 0, 25, 50 });
+    auto current_streams = sids({ 0 });
+
+    auto range = to_sids(alternator::find_children_range_from_parent_token(parent_streams, current_streams, parent_streams[0], false));
+    BOOST_REQUIRE(vec(range) == sorted_vec(current_streams, 0, 1));
+
+    range = to_sids(alternator::find_children_range_from_parent_token(parent_streams, current_streams, parent_streams[1], false));
+    BOOST_REQUIRE(vec(range) == sorted_vec(current_streams, 0, 1));
+
+    range = to_sids(alternator::find_children_range_from_parent_token(parent_streams, current_streams, parent_streams[2], false));
+    BOOST_REQUIRE(vec(range) == sorted_vec(current_streams, 0, 1));
+}
+
+BOOST_AUTO_TEST_CASE(test_find_children_range_from_parent_vnodes_merge_into_one_3) {
+    auto parent_streams = sids({ 0, 25, 50 });
+    auto current_streams = sids({ 10 });
+
+    auto range = to_sids(alternator::find_children_range_from_parent_token(parent_streams, current_streams, parent_streams[0], false));
+    BOOST_REQUIRE(vec(range) == sorted_vec(current_streams, 0, 1));
+
+    range = to_sids(alternator::find_children_range_from_parent_token(parent_streams, current_streams, parent_streams[1], false));
+    BOOST_REQUIRE(vec(range) == sorted_vec(current_streams, 0, 1));
+
+    range = to_sids(alternator::find_children_range_from_parent_token(parent_streams, current_streams, parent_streams[2], false));
+    BOOST_REQUIRE(vec(range) == sorted_vec(current_streams, 0, 1));
+}
+
+BOOST_AUTO_TEST_CASE(test_find_children_range_from_parent_vnodes_merge_into_one_4) {
+    auto parent_streams = sids({ 0, 25, 50 });
+    auto current_streams = sids({ 25 });
+
+    auto range = to_sids(alternator::find_children_range_from_parent_token(parent_streams, current_streams, parent_streams[0], false));
+    BOOST_REQUIRE(vec(range) == sorted_vec(current_streams, 0, 1));
+
+    range = to_sids(alternator::find_children_range_from_parent_token(parent_streams, current_streams, parent_streams[1], false));
+    BOOST_REQUIRE(vec(range) == sorted_vec(current_streams, 0, 1));
+
+    range = to_sids(alternator::find_children_range_from_parent_token(parent_streams, current_streams, parent_streams[2], false));
+    BOOST_REQUIRE(vec(range) == sorted_vec(current_streams, 0, 1));
+}
+
+BOOST_AUTO_TEST_CASE(test_find_children_range_from_parent_vnodes_merge_into_one_5) {
+    auto parent_streams = sids({ 0, 25, 50 });
+    auto current_streams = sids({ 50 });
+
+    auto range = to_sids(alternator::find_children_range_from_parent_token(parent_streams, current_streams, parent_streams[0], false));
+    BOOST_REQUIRE(vec(range) == sorted_vec(current_streams, 0, 1));
+
+    range = to_sids(alternator::find_children_range_from_parent_token(parent_streams, current_streams, parent_streams[1], false));
+    BOOST_REQUIRE(vec(range) == sorted_vec(current_streams, 0, 1));
+
+    range = to_sids(alternator::find_children_range_from_parent_token(parent_streams, current_streams, parent_streams[2], false));
+    BOOST_REQUIRE(vec(range) == sorted_vec(current_streams, 0, 1));
+}
+
+BOOST_AUTO_TEST_CASE(test_find_children_range_from_parent_vnodes_merge_into_one_6) {
+    auto parent_streams = sids({ 0, 25, 50 });
+    auto current_streams = sids({ 110 });
+
+    auto range = to_sids(alternator::find_children_range_from_parent_token(parent_streams, current_streams, parent_streams[0], false));
+    BOOST_REQUIRE(vec(range) == sorted_vec(current_streams, 0, 1));
+
+    range = to_sids(alternator::find_children_range_from_parent_token(parent_streams, current_streams, parent_streams[1], false));
+    BOOST_REQUIRE(vec(range) == sorted_vec(current_streams, 0, 1));
+
+    range = to_sids(alternator::find_children_range_from_parent_token(parent_streams, current_streams, parent_streams[2], false));
+    BOOST_REQUIRE(vec(range) == sorted_vec(current_streams, 0, 1));
+}
+
+
+BOOST_AUTO_TEST_CASE(test_find_children_range_from_parent_vnodes_split_1) {
+    auto parent_streams = sids({ 0, 50, 100 });
+    auto current_streams = sids({ -25, 0, 50, 100 });
+
+    auto range = to_sids(alternator::find_children_range_from_parent_token(parent_streams, current_streams, parent_streams[0], false));
+    BOOST_REQUIRE(vec(range) == sorted_vec(current_streams, 0, 2));
+
+    range = to_sids(alternator::find_children_range_from_parent_token(parent_streams, current_streams, parent_streams[1], false));
+    BOOST_REQUIRE(vec(range) == sorted_vec(current_streams, 2, 3));
+
+    range = to_sids(alternator::find_children_range_from_parent_token(parent_streams, current_streams, parent_streams[2], false));
+    BOOST_REQUIRE(vec(range) == sorted_vec(current_streams, 3, 4));
+}
+
+BOOST_AUTO_TEST_CASE(test_find_children_range_from_parent_vnodes_split_2) {
+    auto parent_streams = sids({ 0, 50, 100 });
+    auto current_streams = sids({ 0, 25, 50, 100 });
+
+    auto range = to_sids(alternator::find_children_range_from_parent_token(parent_streams, current_streams, parent_streams[0], false));
+    BOOST_REQUIRE(vec(range) == sorted_vec(current_streams, 0, 1));
+
+    range = to_sids(alternator::find_children_range_from_parent_token(parent_streams, current_streams, parent_streams[1], false));
+    BOOST_REQUIRE(vec(range) == sorted_vec(current_streams, 1, 3));
+
+    range = to_sids(alternator::find_children_range_from_parent_token(parent_streams, current_streams, parent_streams[2], false));
+    BOOST_REQUIRE(vec(range) == sorted_vec(current_streams, 3, 4));
+}
+
+BOOST_AUTO_TEST_CASE(test_find_children_range_from_parent_vnodes_split_3) {
+    auto parent_streams = sids({ 0, 50, 100 });
+    auto current_streams = sids({ 0, 50, 75, 100 });
+
+    auto range = to_sids(alternator::find_children_range_from_parent_token(parent_streams, current_streams, parent_streams[0], false));
+    BOOST_REQUIRE(vec(range) == sorted_vec(current_streams, 0, 1));
+
+    range = to_sids(alternator::find_children_range_from_parent_token(parent_streams, current_streams, parent_streams[1], false));
+    BOOST_REQUIRE(vec(range) == sorted_vec(current_streams, 1, 2));
+
+    range = to_sids(alternator::find_children_range_from_parent_token(parent_streams, current_streams, parent_streams[2], false));
+    BOOST_REQUIRE(vec(range) == sorted_vec(current_streams, 2, 4));
+}
+
+// Regression test for duplicate-token CHILD_SHARDS selection.
+//
+// Multiple current-generation stream ids can legitimately share the same token
+// in CDC generation for small vnodes.  This test verifies that
+// find_children_range_from_parent_token returns all such children rather than
+// collapsing them to one.
+//
+// Setup: a static_sharder with 3 shards and ignore_msb=0 (one contiguous
+// shard-pattern repetition across the ring).  We pick the tiny vnode at the
+// very end of the ring — range (max-1, max] — which is so small that only
+// shard 2 actually owns the single token inside it (last_token() maps to
+// shard 2).  For shards 0 and 1, find_first_token_for_shard finds no token
+// in the range and falls back to the vnode-end token (last_token()).  This is
+// the standard CDC behaviour for shard slots without a token in a small vnode:
+// their representative stream id uses the vnode end token.  The result is
+// three distinct stream ids that all share the same token, which is exactly
+// the scenario this regression test covers.
+BOOST_AUTO_TEST_CASE(test_find_children_range_from_parent_vnodes_duplicate_end_token_realistic) {
+
+    auto prev_token = [] (dht::token t) {
+        return dht::token::from_int64(dht::token::to_int64(t) - 1);
+    };
+
+    dht::static_sharder sharder(3, 0); // 3 shards, ignore_msb=0 → single shard-pattern repetition
+    auto end = dht::last_token();
+    auto start = prev_token(end);
+    auto current_streams = stream_ids({
+        cdc::stream_id(dht::find_first_token_for_shard(sharder, start, end, 0), 7),
+        cdc::stream_id(dht::find_first_token_for_shard(sharder, start, end, 1), 7),
+        cdc::stream_id(dht::find_first_token_for_shard(sharder, start, end, 2), 7),
+    });
+
+    BOOST_REQUIRE(current_streams.size() == 3);
+    BOOST_REQUIRE_EQUAL(current_streams[0].token(), end);
+    BOOST_REQUIRE_EQUAL(current_streams[1].token(), end);
+    BOOST_REQUIRE_EQUAL(current_streams[2].token(), end);
+
+    auto parent_streams = sids({ 0, std::numeric_limits<std::int64_t>::max() });
+
+    // CHILD_SHARDS orders equal-token children by full stream id, so sort the
+    // expected result the same way before comparing.
+    auto expected = current_streams;
+    std::sort(expected.begin(), expected.end(), [](const cdc::stream_id& a, const cdc::stream_id& b) {
+        return compare_unsigned(a.to_bytes(), b.to_bytes()) < 0;
+    });
+
+    auto got = to_sids(alternator::find_children_range_from_parent_token(
+            parent_streams,
+            current_streams,
+            parent_streams[1],
+            false));
+
+    BOOST_REQUIRE_MESSAGE(
+            got == expected,
+            format("The parent shard should include all {} current shard streams for this one-token vnode, but the selection returned only {} of them.",
+                    expected.size(), got.size()));
+}
+
+BOOST_AUTO_TEST_CASE(test_find_children_range_from_parent_vnodes_split_4) {
+    auto parent_streams = sids({ 0, 50, 100 });
+    auto current_streams = sids({ 0, 50, 100, 125 });
+
+    auto range = to_sids(alternator::find_children_range_from_parent_token(parent_streams, current_streams, parent_streams[0], false));
+    BOOST_REQUIRE(vec(range) == sorted_vec(current_streams, 0, 1, 3, 4));
+
+    range = to_sids(alternator::find_children_range_from_parent_token(parent_streams, current_streams, parent_streams[1], false));
+    BOOST_REQUIRE(vec(range) == sorted_vec(current_streams, 1, 2));
+
+    range = to_sids(alternator::find_children_range_from_parent_token(parent_streams, current_streams, parent_streams[2], false));
+    BOOST_REQUIRE(vec(range) == sorted_vec(current_streams, 2, 3));
+}
+
+BOOST_AUTO_TEST_CASE(test_find_children_range_from_parent_vnodes_split_from_one_1) {
+    auto parent_streams = sids({ -10 });
+    auto current_streams = sids({ 0, 50, 75 });
+
+    auto range = to_sids(alternator::find_children_range_from_parent_token(parent_streams, current_streams, parent_streams[0], false));
+    BOOST_REQUIRE(vec(range) == sorted_vec(current_streams, 0, 3));
+}
+
+BOOST_AUTO_TEST_CASE(test_find_children_range_from_parent_vnodes_split_from_one_2) {
+    auto parent_streams = sids({ 0 });
+    auto current_streams = sids({ 0, 50, 75 });
+
+    auto range = to_sids(alternator::find_children_range_from_parent_token(parent_streams, current_streams, parent_streams[0], false));
+    BOOST_REQUIRE(vec(range) == sorted_vec(current_streams, 0, 3));
+}
+
+BOOST_AUTO_TEST_CASE(test_find_children_range_from_parent_vnodes_split_from_one_3) {
+    auto parent_streams = sids({ 25 });
+    auto current_streams = sids({ 0, 50, 75 });
+
+    auto range = to_sids(alternator::find_children_range_from_parent_token(parent_streams, current_streams, parent_streams[0], false));
+    BOOST_REQUIRE(vec(range) == sorted_vec(current_streams, 0, 3));
+}
+
+BOOST_AUTO_TEST_CASE(test_find_children_range_from_parent_vnodes_split_from_one_4) {
+    auto parent_streams = sids({ 50 });
+    auto current_streams = sids({ 0, 50, 75 });
+
+    auto range = to_sids(alternator::find_children_range_from_parent_token(parent_streams, current_streams, parent_streams[0], false));
+    BOOST_REQUIRE(vec(range) == sorted_vec(current_streams, 0, 3));
+}
+
+BOOST_AUTO_TEST_CASE(test_find_children_range_from_parent_vnodes_split_from_one_5) {
+    auto parent_streams = sids({ 60 });
+    auto current_streams = sids({ 0, 50, 75 });
+
+    auto range = to_sids(alternator::find_children_range_from_parent_token(parent_streams, current_streams, parent_streams[0], false));
+    BOOST_REQUIRE(vec(range) == sorted_vec(current_streams, 0, 3));
+}
+
+BOOST_AUTO_TEST_CASE(test_find_children_range_from_parent_vnodes_split_from_one_6) {
+    auto parent_streams = sids({ 75 });
+    auto current_streams = sids({ 0, 50, 75 });
+
+    auto range = to_sids(alternator::find_children_range_from_parent_token(parent_streams, current_streams, parent_streams[0], false));
+    BOOST_REQUIRE(vec(range) == sorted_vec(current_streams, 0, 3));
+}
+
+BOOST_AUTO_TEST_CASE(test_find_children_range_from_parent_vnodes_split_from_one_7) {
+    auto parent_streams = sids({ 100 });
+    auto current_streams = sids({ 0, 50, 75 });
+
+    auto range = to_sids(alternator::find_children_range_from_parent_token(parent_streams, current_streams, parent_streams[0], false));
+    BOOST_REQUIRE(vec(range) == sorted_vec(current_streams, 0, 3));
+}
+
+BOOST_AUTO_TEST_CASE(test_find_children_range_from_parent_vnodes_split_and_merge_1) {
+    auto parent_streams = sids({ 0, 50, 100 });
+    auto current_streams = sids({ 25, 75 });
+
+    auto range = to_sids(alternator::find_children_range_from_parent_token(parent_streams, current_streams, parent_streams[0], false));
+    BOOST_REQUIRE(vec(range) == sorted_vec(current_streams, 0, 1));
+
+    range = to_sids(alternator::find_children_range_from_parent_token(parent_streams, current_streams, parent_streams[1], false));
+    BOOST_REQUIRE(vec(range) == sorted_vec(current_streams, 0, 2));
+
+    range = to_sids(alternator::find_children_range_from_parent_token(parent_streams, current_streams, parent_streams[2], false));
+    BOOST_REQUIRE(vec(range) == sorted_vec(current_streams, 0, 2));
+}
+
+BOOST_AUTO_TEST_CASE(test_find_children_range_from_parent_vnodes_split_and_merge_2) {
+    auto parent_streams = sids({ -100, -50, 25, 50, 100, 200 });
+    auto current_streams = sids({ 25, 75 });
+
+    auto range = to_sids(alternator::find_children_range_from_parent_token(parent_streams, current_streams, parent_streams[0], false));
+    BOOST_REQUIRE(vec(range) == sorted_vec(current_streams, 0, 1));
+
+    range = to_sids(alternator::find_children_range_from_parent_token(parent_streams, current_streams, parent_streams[1], false));
+    BOOST_REQUIRE(vec(range) == sorted_vec(current_streams, 0, 1));
+
+    range = to_sids(alternator::find_children_range_from_parent_token(parent_streams, current_streams, parent_streams[2], false));
+    BOOST_REQUIRE(vec(range) == sorted_vec(current_streams, 0, 1));
+
+    range = to_sids(alternator::find_children_range_from_parent_token(parent_streams, current_streams, parent_streams[3], false));
+    BOOST_REQUIRE(vec(range) == sorted_vec(current_streams, 1, 2));
+
+    range = to_sids(alternator::find_children_range_from_parent_token(parent_streams, current_streams, parent_streams[4], false));
+    BOOST_REQUIRE(vec(range) == sorted_vec(current_streams, 0, 2));
+
+    range = to_sids(alternator::find_children_range_from_parent_token(parent_streams, current_streams, parent_streams[5], false));
+    BOOST_REQUIRE(vec(range) == sorted_vec(current_streams, 0, 1));
+}
+
+BOOST_AUTO_TEST_CASE(test_find_children_range_from_parent_vnodes_split_and_merge_3) {
+    auto parent_streams = sids({ -275, -75 });
+    auto current_streams = sids({ -400, -300, -200, -100, -50, -10, 0, 10, 50, 100, 200, 300, 400 });
+
+    auto range = to_sids(alternator::find_children_range_from_parent_token(parent_streams, current_streams, parent_streams[0], false));
+    BOOST_REQUIRE(vec(range) == sorted_vec(current_streams, 0, 3, 4, 13));
+
+    range = to_sids(alternator::find_children_range_from_parent_token(parent_streams, current_streams, parent_streams[1], false));
+    BOOST_REQUIRE(vec(range) == sorted_vec(current_streams, 2, 5));
+}
+
+BOOST_AUTO_TEST_CASE(test_find_children_range_from_parent_vnodes_split_and_merge_4) {
+    auto parent_streams = sids({ 75, 275 });
+    auto current_streams = sids({ -100, -50, -10, 0, 10, 50, 100, 200, 300, 400 });
+
+    auto range = to_sids(alternator::find_children_range_from_parent_token(parent_streams, current_streams, parent_streams[0], false));
+    BOOST_REQUIRE(vec(range) == sorted_vec(current_streams, 0, 7, 8, 10));
+
+    range = to_sids(alternator::find_children_range_from_parent_token(parent_streams, current_streams, parent_streams[1], false));
+    BOOST_REQUIRE(vec(range) == sorted_vec(current_streams, 6, 9));
+}
+
+BOOST_AUTO_TEST_CASE(test_find_children_range_from_parent_vnodes_split_and_merge_5) {
+    auto parent_streams = sids({ 0, 10 });
+    auto current_streams = sids({ -20, -10 });
+
+    auto range = to_sids(alternator::find_children_range_from_parent_token(parent_streams, current_streams, parent_streams[0], false));
+    BOOST_REQUIRE(vec(range) == sorted_vec(current_streams, 0, 2));
+
+    range = to_sids(alternator::find_children_range_from_parent_token(parent_streams, current_streams, parent_streams[1], false));
+    BOOST_REQUIRE(vec(range) == sorted_vec(current_streams, 0, 1));
+}
+
+BOOST_AUTO_TEST_CASE(test_find_children_range_from_parent_vnodes_split_and_merge_6) {
+    auto parent_streams = sids({ -20 });
+    auto current_streams = sids({ -20, 0 });
+
+    auto range = to_sids(alternator::find_children_range_from_parent_token(parent_streams, current_streams, parent_streams[0], false));
+    BOOST_REQUIRE(vec(range) == sorted_vec(current_streams, 0, 2));
+}
+
+BOOST_AUTO_TEST_CASE(test_find_children_range_from_parent_vnodes_split_and_merge_7) {
+    auto parent_streams = sids({ -20, -10 });
+    auto current_streams = sids({ -20, 0 });
+
+    auto range = to_sids(alternator::find_children_range_from_parent_token(parent_streams, current_streams, parent_streams[0], false));
+    BOOST_REQUIRE(vec(range) == sorted_vec(current_streams, 0, 2));
+
+    range = to_sids(alternator::find_children_range_from_parent_token(parent_streams, current_streams, parent_streams[1], false));
+    BOOST_REQUIRE(vec(range) == sorted_vec(current_streams, 1, 2));
+}
+
+namespace {
+    struct encapsulated_range {
+        const int from, to;
+
+        explicit operator bool () const {
+            return from < to;
+        }
+        encapsulated_range operator & (encapsulated_range other) const {
+            auto f = std::max(from, other.from);
+            auto t = std::min(to, other.to);
+            if (f >= t) {
+                return {0, 0};
+            }
+            return {f, t};
+        }
+        // friend std::ostream &operator << (std::ostream &o, const encapsulated_range &r) {
+        //     o << "[" << r.from << ", " << r.to << ")";
+        //     return o;
+        // }
+    };
+}
+
+BOOST_AUTO_TEST_CASE(test_find_children_range_from_parent_vnodes_brute_force_all_combinations) {
+    constexpr int N = 8;
+    constexpr int S = -(N / 2);
+    std::vector<int> parent_streams_values, current_streams_values;
+    utils::chunked_vector<cdc::stream_id> parent_streams, current_streams, expected;
+    size_t prepare_iteration = std::numeric_limits<size_t>::max();
+
+    auto get_encapsulated_range = [](const std::vector<int>& v, size_t index) -> std::pair<encapsulated_range, encapsulated_range>{
+        auto end = v[index];
+        if (index > 0) {
+            auto start = v[index - 1];
+            return { encapsulated_range{start, end} , encapsulated_range{end, end} };
+        }
+        auto start = v.back();
+        return { encapsulated_range{start, std::numeric_limits<int>::max()}, encapsulated_range{std::numeric_limits<int>::min(), end} };
+    };
+    auto prepare = [&](size_t iteration) {
+        if (prepare_iteration != iteration) {
+            parent_streams_values.clear();
+            current_streams_values.clear();
+            parent_streams.clear();
+            current_streams.clear();
+            for(auto i = 0; i < N; ++i) {
+                if (iteration & (1 << i)) {
+                    parent_streams_values.push_back((S + i) * 10);
+                    parent_streams.push_back(sid(parent_streams_values.back()));
+                }
+                if (iteration & (1 << (N + i))) {
+                    current_streams_values.push_back((S + i) * 10);
+                    current_streams.push_back(sid(current_streams_values.back()));
+                }
+            }
+            prepare_iteration = iteration;
+        }
+    };
+
+    auto run = [&](size_t iteration, size_t parent_index) {
+        prepare(iteration);
+        if (current_streams.empty() || parent_streams.empty()) {
+            return;
+        }
+        // std::cout << "running iteration " << iteration << " parent_index " << parent_index << std::endl;
+        // std::cout << "parents [";
+        // for(auto v : parent_streams_values) {
+        //     if (v != parent_streams_values.front()) {
+        //         std::cout << ", ";
+        //     }
+        //     std::cout << v;
+        // }
+        // std::cout << "]" << std::endl;
+        // std::cout << "currents [";
+        // for(auto v : current_streams_values) {
+        //     if (v != current_streams_values.front()) {
+        //         std::cout << ", ";
+        //     }
+        //     std::cout << v;
+        // }
+        //std::cout << "]" << std::endl;
+        auto [ range1, range2 ] = get_encapsulated_range(parent_streams_values, parent_index);
+
+        expected.clear();
+        for(auto i = 0u; i < current_streams_values.size(); ++i) {
+            auto [ range3, range4 ] = get_encapsulated_range(current_streams_values, i);
+
+            if (range1 & range3 || range1 & range4 || range2 & range3 || range2 & range4) {
+                expected.push_back(current_streams[i]);
+                // std::cout << "range1 " << range1 << " range2 " << range2 << " range3 " << range3 << " range4 " << range4 << " range1 & range3 " << (range1 & range3) << " range1 & range4 " << (range1 & range4) << " range2 & range3 " << (range2 & range3) << " range2 & range4 " << (range2 & range4) << std::endl;
+            }
+        }
+        std::sort(expected.begin(), expected.end(), [](const cdc::stream_id &a, const cdc::stream_id &b) {
+            return compare_unsigned(a.to_bytes(), b.to_bytes()) < 0;
+        });
+        BOOST_REQUIRE(!expected.empty());
+
+        auto old_current_streams = current_streams;
+        auto old_parent_streams = parent_streams;
+        utils::chunked_vector<cdc::stream_id> range;
+        try {
+            range = to_sids(alternator::find_children_range_from_parent_token(parent_streams, current_streams, parent_streams[parent_index], false));
+        }
+        catch(...) {
+
+            BOOST_REQUIRE_MESSAGE(false,
+                                "iteration " << iteration << " parent_index " << parent_index
+                            );
+        }
+        auto produced = vec(range);
+
+        if (produced != expected) {
+            std::cout << "produced " << produced << std::endl;
+            std::cout << "expected " << expected << std::endl;
+
+            BOOST_REQUIRE_MESSAGE(produced == expected,
+                                "produced " << produced << "\n" <<
+                                "expected " << expected << "\n" <<
+                                "iteration " << iteration << " parent_index " << parent_index
+                            );
+        }
+
+        std::sort(parent_streams.begin(), parent_streams.end(), [](const cdc::stream_id &a, const cdc::stream_id &b) {
+            return a.token() < b.token();
+        });
+        std::sort(current_streams.begin(), current_streams.end(), [](const cdc::stream_id &a, const cdc::stream_id &b) {
+            return a.token() < b.token();
+        });
+        BOOST_REQUIRE_MESSAGE(parent_streams == old_parent_streams,
+                            "parent streams modified!\n" <<
+                            "produced " << parent_streams << "\n" <<
+                            "expected " << old_parent_streams << "\n" <<
+                            "iteration " << iteration << " parent_index " << parent_index
+                        );
+        BOOST_REQUIRE_MESSAGE(current_streams == old_current_streams,
+                            "current streams modified!\n" <<
+                            "produced " << current_streams << "\n" <<
+                            "expected " << old_current_streams << "\n" <<
+                            "iteration " << iteration << " parent_index " << parent_index
+                        );
+    };
+
+    // run(2310, 0); // if you need to debug a specific case
+    for(auto iteration = 0u; iteration < (1 << (2 * N)); ++iteration) {
+        prepare(iteration);
+        for(auto parent_index = 0u; parent_index < parent_streams.size(); ++parent_index) {
+            run(iteration, parent_index);
+        }
+    }
 }


### PR DESCRIPTION
Add a `CHILD_SHARDS` filter to `DescribeStream` command.
The user needs to pass a parent stream shard id, Streams will then fetch cdc generations, find children and return them to the caller. By children we understand any stream shard, that have at least one token common with parent stream shard. There might be any number of children, but must be at least one.

Add unit tests.

Fixes: #25160
Fixes SCYLLADB-532