### PR TITLE
test: database_test: Fix serialization of partition key

### DIFF
--- a/test/boost/database_test.cc
+++ b/test/boost/database_test.cc
@@ -592,9 +592,7 @@ future<> do_with_some_data_in_thread(std::vector<sstring> cf_names, std::functio
                 auto stmt = e.prepare(fmt::format("insert into {} (p1, c1, c2, r1) values (?, ?, ?, ?)", cf_name)).get();
                 auto make_key = [] (int64_t k) {
                     std::string s = fmt::format("key{}", k);
-                    bytes b(bytes::initialized_later(), sizeof(s.size()));
-                    std::ranges::copy(s, b.begin());
-                    return cql3::raw_value::make_value(b);
+                    return cql3::raw_value::make_value(utf8_type->decompose(s));
                 };
                 auto make_val = [] (int64_t x) {
                     return cql3::raw_value::make_value(int32_type->decompose(int32_t{x}));


### PR DESCRIPTION
The `make_key` lambda erroneously allocates a fixed 8-byte buffer (`sizeof(s.size())`) for variable-length strings, potentially causing uninitialized bytes to be included. If such bytes exist and they are not valid UTF-8 characters, deserialization fails:

```
ERROR 2026-01-16 08:18:26,062 [shard 0:main] testlog - snapshot_list_contains_dropped_tables: cql env callback failed, error: exceptions::invalid_request_exception (Exception while binding column p1: marshaling error: Validation failed - non-UTF8 character in a UTF8 string, at byte offset 7)
```

Fixes #28195.