### PR TITLE
audit: Stop using deprecated seastar UDP sending API

### DIFF
--- a/audit/audit_syslog_storage_helper.hh
+++ b/audit/audit_syslog_storage_helper.hh
@@ -26,7 +26,7 @@ class audit_syslog_storage_helper : public storage_helper {
     net::datagram_channel _sender;
     seastar::semaphore _semaphore;
 
-    future<> syslog_send_helper(const sstring& msg);
+    future<> syslog_send_helper(seastar::temporary_buffer<char> msg);
 public:
     explicit audit_syslog_storage_helper(cql3::query_processor&, service::migration_manager&);
     virtual ~audit_syslog_storage_helper();


### PR DESCRIPTION
The datagram_channel::send() method that sends net::packet-s is deprecated in favor of using span<temporary_buffer> one. Auditing code still uses the former one -- it constructs a packet by using formatted string by copying the string into the packet's fragment, then sends it. This patch releases string into temporary_buffer and then passes one-element span to send().

Adopting newer seastar API, not backporting