### PR TITLE
test/cqlpy: Add our copyright/license to translated Cassandra tests

### DIFF
--- a/test/cqlpy/cassandra_tests/__init__.py
+++ b/test/cqlpy/cassandra_tests/__init__.py
@@ -1,3 +1,7 @@
+# Copyright 2020-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+
 # This file is automatically imported before importing porting.py, and
 # causes pytest to rewrite (i.e., improve) assert calls in utility
 # functions in porting.py.

--- a/test/cqlpy/cassandra_tests/batch_test.py
+++ b/test/cqlpy/cassandra_tests/batch_test.py
@@ -4,6 +4,9 @@
 # The original Apache Cassandra license:
 #
 # SPDX-License-Identifier: Apache-2.0
+#
+# Modifications: Copyright 2023-present ScyllaDB
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
 
 from .porting import *
 

--- a/test/cqlpy/cassandra_tests/distinct_query_paging_test.py
+++ b/test/cqlpy/cassandra_tests/distinct_query_paging_test.py
@@ -4,6 +4,9 @@
 # The original Apache Cassandra license:
 #
 # SPDX-License-Identifier: Apache-2.0
+#
+# Modifications: Copyright 2024-present ScyllaDB
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
 
 from .porting import *
 

--- a/test/cqlpy/cassandra_tests/functions/cast_fcts_test.py
+++ b/test/cqlpy/cassandra_tests/functions/cast_fcts_test.py
@@ -4,6 +4,9 @@
 # The original Apache Cassandra license:
 #
 # SPDX-License-Identifier: Apache-2.0
+#
+# Modifications: Copyright 2023-present ScyllaDB
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
 
 from ...cassandra_tests.porting import *
 from decimal import Decimal

--- a/test/cqlpy/cassandra_tests/functions/operation_fcts_test.py
+++ b/test/cqlpy/cassandra_tests/functions/operation_fcts_test.py
@@ -4,6 +4,9 @@
 # The original Apache Cassandra license:
 #
 # SPDX-License-Identifier: Apache-2.0
+#
+# Modifications: Copyright 2024-present ScyllaDB
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
 
 from ...cassandra_tests.porting import *
 

--- a/test/cqlpy/cassandra_tests/validation/entities/collections_test.py
+++ b/test/cqlpy/cassandra_tests/validation/entities/collections_test.py
@@ -4,6 +4,9 @@
 # The original Apache Cassandra license:
 #
 # SPDX-License-Identifier: Apache-2.0
+#
+# Modifications: Copyright 2020-present ScyllaDB
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
 
 from ...porting import  *
 from cassandra.query import UNSET_VALUE

--- a/test/cqlpy/cassandra_tests/validation/entities/counters_test.py
+++ b/test/cqlpy/cassandra_tests/validation/entities/counters_test.py
@@ -4,6 +4,9 @@
 # The original Apache Cassandra license:
 #
 # SPDX-License-Identifier: Apache-2.0
+#
+# Modifications: Copyright 2020-present ScyllaDB
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
 
 from ...porting import  *
 

--- a/test/cqlpy/cassandra_tests/validation/entities/date_type_test.py
+++ b/test/cqlpy/cassandra_tests/validation/entities/date_type_test.py
@@ -4,6 +4,9 @@
 # The original Apache Cassandra license:
 #
 # SPDX-License-Identifier: Apache-2.0
+#
+# Modifications: Copyright 2020-present ScyllaDB
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
 
 from ...porting import create_table, execute, assert_invalid
 

--- a/test/cqlpy/cassandra_tests/validation/entities/frozen_collections_test.py
+++ b/test/cqlpy/cassandra_tests/validation/entities/frozen_collections_test.py
@@ -4,6 +4,9 @@
 # The original Apache Cassandra license:
 #
 # SPDX-License-Identifier: Apache-2.0
+#
+# Modifications: Copyright 2021-present ScyllaDB
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
 
 from ...porting import *
 

--- a/test/cqlpy/cassandra_tests/validation/entities/json_test.py
+++ b/test/cqlpy/cassandra_tests/validation/entities/json_test.py
@@ -4,6 +4,9 @@
 # The original Apache Cassandra license:
 #
 # SPDX-License-Identifier: Apache-2.0
+#
+# Modifications: Copyright 2021-present ScyllaDB
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
 
 from ...porting import *
 

--- a/test/cqlpy/cassandra_tests/validation/entities/secondary_index_on_map_entries_test.py
+++ b/test/cqlpy/cassandra_tests/validation/entities/secondary_index_on_map_entries_test.py
@@ -4,6 +4,9 @@
 # The original Apache Cassandra license:
 #
 # SPDX-License-Identifier: Apache-2.0
+#
+# Modifications: Copyright 2021-present ScyllaDB
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
 
 from ...porting import *
 

--- a/test/cqlpy/cassandra_tests/validation/entities/secondary_index_on_static_column_test.py
+++ b/test/cqlpy/cassandra_tests/validation/entities/secondary_index_on_static_column_test.py
@@ -4,6 +4,9 @@
 # The original Apache Cassandra license:
 #
 # SPDX-License-Identifier: Apache-2.0
+#
+# Modifications: Copyright 2021-present ScyllaDB
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
 
 from ...porting import *
 

--- a/test/cqlpy/cassandra_tests/validation/entities/secondary_index_test.py
+++ b/test/cqlpy/cassandra_tests/validation/entities/secondary_index_test.py
@@ -4,6 +4,9 @@
 # The original Apache Cassandra license:
 #
 # SPDX-License-Identifier: Apache-2.0
+#
+# Modifications: Copyright 2021-present ScyllaDB
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
 
 
 # SCYLLA NOTE (FIXME): The following tests, originally written for Cassandra,

--- a/test/cqlpy/cassandra_tests/validation/entities/static_columns_test.py
+++ b/test/cqlpy/cassandra_tests/validation/entities/static_columns_test.py
@@ -4,6 +4,9 @@
 # The original Apache Cassandra license:
 #
 # SPDX-License-Identifier: Apache-2.0
+#
+# Modifications: Copyright 2021-present ScyllaDB
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
 
 from ...porting import *
 

--- a/test/cqlpy/cassandra_tests/validation/entities/timestamp_test.py
+++ b/test/cqlpy/cassandra_tests/validation/entities/timestamp_test.py
@@ -4,6 +4,9 @@
 # The original Apache Cassandra license:
 #
 # SPDX-License-Identifier: Apache-2.0
+#
+# Modifications: Copyright 2021-present ScyllaDB
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
 
 from ...porting import *
 

--- a/test/cqlpy/cassandra_tests/validation/entities/timeuuid_test.py
+++ b/test/cqlpy/cassandra_tests/validation/entities/timeuuid_test.py
@@ -4,6 +4,9 @@
 # The original Apache Cassandra license:
 #
 # SPDX-License-Identifier: Apache-2.0
+#
+# Modifications: Copyright 2020-present ScyllaDB
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
 
 from ...porting import *
 

--- a/test/cqlpy/cassandra_tests/validation/entities/tuple_type_test.py
+++ b/test/cqlpy/cassandra_tests/validation/entities/tuple_type_test.py
@@ -4,6 +4,9 @@
 # The original Apache Cassandra license:
 #
 # SPDX-License-Identifier: Apache-2.0
+#
+# Modifications: Copyright 2021-present ScyllaDB
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
 
 from ...porting import *
 from cassandra.query import UNSET_VALUE

--- a/test/cqlpy/cassandra_tests/validation/entities/type_test.py
+++ b/test/cqlpy/cassandra_tests/validation/entities/type_test.py
@@ -4,6 +4,9 @@
 # The original Apache Cassandra license:
 #
 # SPDX-License-Identifier: Apache-2.0
+#
+# Modifications: Copyright 2021-present ScyllaDB
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
 
 from ...porting import *
 

--- a/test/cqlpy/cassandra_tests/validation/entities/uf_types_test.py
+++ b/test/cqlpy/cassandra_tests/validation/entities/uf_types_test.py
@@ -4,6 +4,9 @@
 # The original Apache Cassandra license:
 #
 # SPDX-License-Identifier: Apache-2.0
+#
+# Modifications: Copyright 2023-present ScyllaDB
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
 
 import datetime
 import uuid

--- a/test/cqlpy/cassandra_tests/validation/entities/user_types_test.py
+++ b/test/cqlpy/cassandra_tests/validation/entities/user_types_test.py
@@ -4,6 +4,9 @@
 # The original Apache Cassandra license:
 #
 # SPDX-License-Identifier: Apache-2.0
+#
+# Modifications: Copyright 2021-present ScyllaDB
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
 
 from ...porting import *
 from cassandra.query import UNSET_VALUE

--- a/test/cqlpy/cassandra_tests/validation/entities/vectors_test.py
+++ b/test/cqlpy/cassandra_tests/validation/entities/vectors_test.py
@@ -4,6 +4,9 @@
 # The original Apache Cassandra license:
 #
 # SPDX-License-Identifier: Apache-2.0
+#
+# Modifications: Copyright 2024-present ScyllaDB
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
 
 from ...porting import *
 

--- a/test/cqlpy/cassandra_tests/validation/operations/alter_test.py
+++ b/test/cqlpy/cassandra_tests/validation/operations/alter_test.py
@@ -18,6 +18,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+#
+# Modifications: Copyright 2022-present ScyllaDB
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
 
 from ...porting import *
 from cassandra.protocol import ConfigurationException

--- a/test/cqlpy/cassandra_tests/validation/operations/batch_test.py
+++ b/test/cqlpy/cassandra_tests/validation/operations/batch_test.py
@@ -4,6 +4,9 @@
 # The original Apache Cassandra license:
 #
 # SPDX-License-Identifier: Apache-2.0
+#
+# Modifications: Copyright 2022-present ScyllaDB
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
 
 from ...porting import *
 from cassandra.query import UNSET_VALUE

--- a/test/cqlpy/cassandra_tests/validation/operations/compact_storage_test.py
+++ b/test/cqlpy/cassandra_tests/validation/operations/compact_storage_test.py
@@ -4,6 +4,9 @@
 # The original Apache Cassandra license:
 #
 # SPDX-License-Identifier: Apache-2.0
+#
+# Modifications: Copyright 2023-present ScyllaDB
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
 
 from ...porting import *
 from uuid import UUID

--- a/test/cqlpy/cassandra_tests/validation/operations/compact_table_test.py
+++ b/test/cqlpy/cassandra_tests/validation/operations/compact_table_test.py
@@ -18,6 +18,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+#
+# Modifications: Copyright 2022-present ScyllaDB
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
 
 from ...porting import *
 

--- a/test/cqlpy/cassandra_tests/validation/operations/cql_vector_test.py
+++ b/test/cqlpy/cassandra_tests/validation/operations/cql_vector_test.py
@@ -4,6 +4,9 @@
 # The original Apache Cassandra license:
 #
 # SPDX-License-Identifier: Apache-2.0
+#
+# Modifications: Copyright 2024-present ScyllaDB
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
 
 from ...porting import *
 from cassandra.connection import DRIVER_NAME, DRIVER_VERSION

--- a/test/cqlpy/cassandra_tests/validation/operations/create_test.py
+++ b/test/cqlpy/cassandra_tests/validation/operations/create_test.py
@@ -18,6 +18,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+#
+# Modifications: Copyright 2023-present ScyllaDB
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
 
 from ...porting import *
 from cassandra.util import Duration

--- a/test/cqlpy/cassandra_tests/validation/operations/delete_test.py
+++ b/test/cqlpy/cassandra_tests/validation/operations/delete_test.py
@@ -4,6 +4,9 @@
 # The original Apache Cassandra license:
 #
 # SPDX-License-Identifier: Apache-2.0
+#
+# Modifications: Copyright 2023-present ScyllaDB
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
 
 from ...porting import *
 import random

--- a/test/cqlpy/cassandra_tests/validation/operations/drop_test.py
+++ b/test/cqlpy/cassandra_tests/validation/operations/drop_test.py
@@ -18,6 +18,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+#
+# Modifications: Copyright 2022-present ScyllaDB
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
 
 from ...porting import *
 

--- a/test/cqlpy/cassandra_tests/validation/operations/insert_invalidate_sized_records_test.py
+++ b/test/cqlpy/cassandra_tests/validation/operations/insert_invalidate_sized_records_test.py
@@ -18,6 +18,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+#
+# Modifications: Copyright 2026-present ScyllaDB
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
 
 from ...porting import *
 

--- a/test/cqlpy/cassandra_tests/validation/operations/insert_test.py
+++ b/test/cqlpy/cassandra_tests/validation/operations/insert_test.py
@@ -18,6 +18,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+#
+# Modifications: Copyright 2022-present ScyllaDB
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
 
 from ...porting import *
 

--- a/test/cqlpy/cassandra_tests/validation/operations/insert_update_if_condition_collections_test.py
+++ b/test/cqlpy/cassandra_tests/validation/operations/insert_update_if_condition_collections_test.py
@@ -4,6 +4,9 @@
 # The original Apache Cassandra license:
 #
 # SPDX-License-Identifier: Apache-2.0
+#
+# Modifications: Copyright 2023-present ScyllaDB
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
 
 from ...porting import *
 

--- a/test/cqlpy/cassandra_tests/validation/operations/insert_update_if_condition_statics_test.py
+++ b/test/cqlpy/cassandra_tests/validation/operations/insert_update_if_condition_statics_test.py
@@ -4,6 +4,9 @@
 # The original Apache Cassandra license:
 #
 # SPDX-License-Identifier: Apache-2.0
+#
+# Modifications: Copyright 2024-present ScyllaDB
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
 
 from ...porting import *
 

--- a/test/cqlpy/cassandra_tests/validation/operations/select_group_by_test.py
+++ b/test/cqlpy/cassandra_tests/validation/operations/select_group_by_test.py
@@ -4,6 +4,9 @@
 # The original Apache Cassandra license:
 #
 # SPDX-License-Identifier: Apache-2.0
+#
+# Modifications: Copyright 2023-present ScyllaDB
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
 
 from ...porting import *
 

--- a/test/cqlpy/cassandra_tests/validation/operations/select_limit_test.py
+++ b/test/cqlpy/cassandra_tests/validation/operations/select_limit_test.py
@@ -4,6 +4,9 @@
 # The original Apache Cassandra license:
 #
 # SPDX-License-Identifier: Apache-2.0
+#
+# Modifications: Copyright 2023-present ScyllaDB
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
 
 from ...porting import *
 

--- a/test/cqlpy/cassandra_tests/validation/operations/select_multi_column_relation_test.py
+++ b/test/cqlpy/cassandra_tests/validation/operations/select_multi_column_relation_test.py
@@ -4,6 +4,9 @@
 # The original Apache Cassandra license:
 #
 # SPDX-License-Identifier: Apache-2.0
+#
+# Modifications: Copyright 2023-present ScyllaDB
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
 
 from ...porting import *
 

--- a/test/cqlpy/cassandra_tests/validation/operations/select_order_by_test.py
+++ b/test/cqlpy/cassandra_tests/validation/operations/select_order_by_test.py
@@ -4,6 +4,9 @@
 # The original Apache Cassandra license:
 #
 # SPDX-License-Identifier: Apache-2.0
+#
+# Modifications: Copyright 2021-present ScyllaDB
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
 
 from ...porting import *
 

--- a/test/cqlpy/cassandra_tests/validation/operations/select_single_column_relation_test.py
+++ b/test/cqlpy/cassandra_tests/validation/operations/select_single_column_relation_test.py
@@ -4,6 +4,9 @@
 # The original Apache Cassandra license:
 #
 # SPDX-License-Identifier: Apache-2.0
+#
+# Modifications: Copyright 2022-present ScyllaDB
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
 
 from ...porting import *
 from cassandra.query import UNSET_VALUE

--- a/test/cqlpy/cassandra_tests/validation/operations/select_test.py
+++ b/test/cqlpy/cassandra_tests/validation/operations/select_test.py
@@ -4,6 +4,9 @@
 # The original Apache Cassandra license:
 #
 # SPDX-License-Identifier: Apache-2.0
+#
+# Modifications: Copyright 2022-present ScyllaDB
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
 
 from ...porting import *
 from uuid import UUID

--- a/test/cqlpy/cassandra_tests/validation/operations/truncate_test.py
+++ b/test/cqlpy/cassandra_tests/validation/operations/truncate_test.py
@@ -18,6 +18,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+#
+# Modifications: Copyright 2022-present ScyllaDB
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
 
 from ...porting import *
 

--- a/test/cqlpy/cassandra_tests/validation/operations/tuples_with_nulls_comparison_test.py
+++ b/test/cqlpy/cassandra_tests/validation/operations/tuples_with_nulls_comparison_test.py
@@ -18,6 +18,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+#
+# Modifications: Copyright 2022-present ScyllaDB
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
 
 from ...porting import *
 

--- a/test/cqlpy/cassandra_tests/validation/operations/update_test.py
+++ b/test/cqlpy/cassandra_tests/validation/operations/update_test.py
@@ -4,6 +4,9 @@
 # The original Apache Cassandra license:
 #
 # SPDX-License-Identifier: Apache-2.0
+#
+# Modifications: Copyright 2023-present ScyllaDB
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
 
 from ...porting import *
 import re

--- a/test/cqlpy/cassandra_tests/validation/operations/use_test.py
+++ b/test/cqlpy/cassandra_tests/validation/operations/use_test.py
@@ -18,6 +18,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+#
+# Modifications: Copyright 2022-present ScyllaDB
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
 
 from ...porting import *
 

--- a/test/cqlpy/cassandra_tests/vector_invalid_query_test.py
+++ b/test/cqlpy/cassandra_tests/vector_invalid_query_test.py
@@ -4,6 +4,9 @@
 # The original Apache Cassandra license:
 #
 # SPDX-License-Identifier: Apache-2.0
+#
+# Modifications: Copyright 2025-present ScyllaDB
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
 
 from .porting import *
 from ..util import is_scylla


### PR DESCRIPTION
All the tests under test/cqlpy/cassandra_tests/ were translated from Cassandra's unit tests originally written in Java into our own test framework, and accordinly carry a clear mention of their origin and original license.

However, we did modify these original tests - even if the modification was slight and mostly straightforward. Therefore I was asked to also mention our own copyright (and license) for these modifications.

So this patch adds to every file in test/cqlpy/cassandra_tests/ text like:

```
   # Modifications: Copyright 2026-present ScyllaDB
   # SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
```

with the appropriate year instead of 2026.

Fixes #28215