### PR TITLE
test: Keep test_gossiper_live_endpoints checks togethger

### DIFF
--- a/test/rest_api/test_gossiper.py
+++ b/test/rest_api/test_gossiper.py
@@ -15,6 +15,10 @@ def test_gossiper_live_endpoints(cql, rest_api):
     live_endpoints = set(resp.json())
     all_hosts_endpoints = set([host.address for host in cql.cluster.metadata.all_hosts()])
     assert live_endpoints == all_hosts_endpoints
+    for ep in live_endpoints:
+        resp = rest_api.send("GET", f"gossiper/downtime/{ep}")
+        resp.raise_for_status()
+        assert int(resp.json()) == 0
 
 def test_gossiper_unreachable_endpoints(cql, rest_api):
     resp = rest_api.send("GET", f"gossiper/endpoint/down")
@@ -24,11 +28,3 @@ def test_gossiper_unreachable_endpoints(cql, rest_api):
         resp = rest_api.send("GET", f"gossiper/downtime/{ep}")
         resp.raise_for_status()
         assert int(resp.json()) > 0
-
-    resp = rest_api.send("GET", f"gossiper/endpoint/live")
-    resp.raise_for_status()
-    live_endpoints = set(resp.json())
-    for ep in live_endpoints:
-        resp = rest_api.send("GET", f"gossiper/downtime/{ep}")
-        resp.raise_for_status()
-        assert int(resp.json()) == 0


### PR DESCRIPTION
There are two checks for live endpoints performed in test_gossiper.py, but one of those sits in test_gossiper_unreachable_endpoints somehow. This patch moves live endpoints check into live endpoints test.

Test enhancement, not backporting