### PR TITLE
test.py: change the name of the test in failed directory

### DIFF
--- a/test/cluster/conftest.py
+++ b/test/cluster/conftest.py
@@ -268,7 +268,7 @@ async def manager(request: pytest.FixtureRequest,
         # Save scylladb logs for failed tests in a separate directory and copy XML report to the same directory to have
         # all related logs in one dir.
         # Then add property to the XML report with the path to the directory, so it can be visible in Jenkins
-        failed_test_dir_path = testpy_test.suite.log_dir / "failed_test" / test_case_name
+        failed_test_dir_path = testpy_test.suite.log_dir / "failed_test" / test_case_name.translate(str.maketrans('[]', '()'))
         failed_test_dir_path.mkdir(parents=True, exist_ok=True)
         await manager_client.gather_related_logs(
             failed_test_dir_path,


### PR DESCRIPTION
Generally square brackets are non allowed in URI, while pytest uses it the test name to show that there were additional parameters for the same test. When such a test fail it shows the directory correctly in Jenkins, however attempt to download only this will fail, because of the square brackets in URI. This change substitute the square brackets with round brackets.

No backport because it's only framework enhancement.