### PR TITLE
idl: don't redefine bound_weight and partition_region in paging_state.idl.hh

### DIFF
--- a/idl/paging_state.idl.hh
+++ b/idl/paging_state.idl.hh
@@ -13,6 +13,7 @@
 #include "idl/token.idl.hh"
 #include "idl/keys.idl.hh"
 #include "idl/uuid.idl.hh"
+#include "idl/position_in_partition.idl.hh"
 
 namespace db {
 enum class read_repair_decision : uint8_t {
@@ -21,19 +22,6 @@ enum class read_repair_decision : uint8_t {
   DC_LOCAL,
 };
 }
-
-enum class bound_weight : int8_t {
-    before_all_prefixed = -1,
-    equal = 0,
-    after_all_prefixed = 1,
-}
-
-enum class partition_region : uint8_t {
-    partition_start,
-    static_row,
-    clustered,
-    partition_end,
-};
 
 namespace service {
 namespace pager {


### PR DESCRIPTION
Bound_weight and partition_region are defined in both the paging_state.idl.hh and in position_in_partition.idl.hh. This isn't currently causing any issues, but if a future RPC will use both the paging_state and position_in_partition, after including both files we'll get a duplica error.
In this patch we prevent this by removing the definitions from paging_state.idl.hh and including position_in_partition.idl.hh in their place.
