### PR TITLE
Populate all sl:* groups into dedicated top-level supergroup

### DIFF
--- a/service/qos/service_level_controller.hh
+++ b/service/qos/service_level_controller.hh
@@ -198,6 +198,7 @@ private:
         future<> distributed_data_update = make_ready_future();
         abort_source dist_data_update_aborter;
         abort_source group0_aborter;
+        scheduling_supergroup user_ssg;
         scheduling_group default_sg;
         bool destroy_default_sg;
         // a counter for making unique temp scheduling groups names
@@ -232,7 +233,7 @@ private:
     void do_abort() noexcept;
 public:
     service_level_controller(sharded<auth::service>& auth_service, locator::shared_token_metadata& tm, abort_source& as, service_level_options default_service_level_config,
-            scheduling_group default_scheduling_group, bool destroy_default_sg_on_drain = false);
+            scheduling_supergroup user_supergroup, scheduling_group default_scheduling_group, bool destroy_default_sg_on_drain = false);
 
     /**
      * this function must be called *once* from any shard before any other functions are called.

--- a/test/boost/service_level_controller_test.cc
+++ b/test/boost/service_level_controller_test.cc
@@ -113,7 +113,7 @@ SEASTAR_THREAD_TEST_CASE(subscriber_simple) {
     sharded<abort_source> as;
     as.start().get();
     auto stop_as = defer([&as] { as.stop().get(); });
-    sl_controller.start(std::ref(auth_service), std::ref(tm), std::ref(as), sl_options, default_scheduling_group).get();
+    sl_controller.start(std::ref(auth_service), std::ref(tm), std::ref(as), sl_options, scheduling_supergroup(), default_scheduling_group).get();
     qos_configuration_change_suscriber_simple ccss;
     sl_controller.local().register_subscriber(&ccss);
     sl_controller.local().add_service_level("sl1", sl_options).get();
@@ -190,7 +190,7 @@ SEASTAR_THREAD_TEST_CASE(too_many_service_levels) {
     sharded<abort_source> as;
     as.start().get();
     auto stop_as = defer([&as] { as.stop().get(); });
-    sl_controller.start(std::ref(auth_service), std::ref(tm), std::ref(as), sl_options, default_scheduling_group, true).get();
+    sl_controller.start(std::ref(auth_service), std::ref(tm), std::ref(as), sl_options, scheduling_supergroup(), default_scheduling_group, true).get();
     sl_controller.local().set_distributed_data_accessor(test_accessor);
     int service_level_id = 0;
     unsigned service_level_count = 0;
@@ -242,7 +242,7 @@ SEASTAR_THREAD_TEST_CASE(too_many_service_levels) {
     // the current configuration.
     sharded<service_level_controller> new_sl_controller;
     default_scheduling_group = create_scheduling_group("sl_default_sg2", 1.0).get();
-    new_sl_controller.start(std::ref(auth_service), std::ref(tm), std::ref(as), sl_options, default_scheduling_group, true).get();
+    new_sl_controller.start(std::ref(auth_service), std::ref(tm), std::ref(as), sl_options, scheduling_supergroup(), default_scheduling_group, true).get();
     new_sl_controller.local().set_distributed_data_accessor(test_accessor);
     try {
         new_sl_controller.local().update_service_levels_cache().get();
@@ -267,7 +267,7 @@ SEASTAR_THREAD_TEST_CASE(add_remove_bad_sequence) {
     sharded<abort_source> as;
     as.start().get();
     auto stop_as = defer([&as] { as.stop().get(); });
-    sl_controller.start(std::ref(auth_service), std::ref(tm), std::ref(as), sl_options, default_scheduling_group, true).get();
+    sl_controller.start(std::ref(auth_service), std::ref(tm), std::ref(as), sl_options, scheduling_supergroup(), default_scheduling_group, true).get();
     service_level_options slo;
     slo.shares.emplace<int32_t>(500);
     slo.workload = service_level_options::workload_type::interactive;
@@ -295,7 +295,7 @@ SEASTAR_THREAD_TEST_CASE(verify_unset_shares_in_cache_when_service_level_created
 
     as.start().get();
     auto stop_as = defer([&as] { as.stop().get(); });
-    sl_controller.start(std::ref(auth_service), std::ref(tm), std::ref(as), sl_options, default_scheduling_group).get();
+    sl_controller.start(std::ref(auth_service), std::ref(tm), std::ref(as), sl_options, scheduling_supergroup(), default_scheduling_group).get();
 
     using timeout_duration = typename seastar::lowres_clock::duration;
     using workload_type = typename service_level_options::workload_type;

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -664,7 +664,7 @@ private:
             _sstm.start(std::ref(*cfg), sstables::storage_manager::config{}).get();
             auto stop_sstm = deferred_stop(_sstm);
 
-            _sl_controller.start(std::ref(_auth_service), std::ref(_token_metadata), std::ref(abort_sources), qos::service_level_options{.shares = 1000}, scheduling_groups.statement_scheduling_group).get();
+            _sl_controller.start(std::ref(_auth_service), std::ref(_token_metadata), std::ref(abort_sources), qos::service_level_options{.shares = 1000}, scheduling_supergroup(), scheduling_groups.statement_scheduling_group).get();
             auto stop_sl_controller = defer_verbose_shutdown("service level controller", [this] { _sl_controller.stop().get(); });
             _sl_controller.invoke_on_all(&qos::service_level_controller::start).get();
 

--- a/test/manual/gossip.cc
+++ b/test/manual/gossip.cc
@@ -82,7 +82,7 @@ int main(int ac, char ** av) {
             sharded<abort_source> as;
             as.start().get();
             auto stop_as = defer([&as] { as.stop().get(); });
-            sl_controller.start(std::ref(auth_service), std::ref(tm), std::ref(as), qos::service_level_options{.shares = 1000}, default_scheduling_group).get();
+            sl_controller.start(std::ref(auth_service), std::ref(tm), std::ref(as), qos::service_level_options{.shares = 1000}, scheduling_supergroup(), default_scheduling_group).get();
             compressor_tracker.start([] { return netw::walltime_compressor_tracker::config{}; }).get();
             auto stop_compressor_tracker = deferred_stop(compressor_tracker);
 

--- a/test/manual/message.cc
+++ b/test/manual/message.cc
@@ -199,7 +199,7 @@ int main(int ac, char ** av) {
             sharded<abort_source> as;
             as.start().get();
             auto stop_as = defer([&as] { as.stop().get(); });
-            sl_controller.start(std::ref(auth_service), std::ref(tm), std::ref(as), qos::service_level_options{.shares = 1000}, default_scheduling_group).get();
+            sl_controller.start(std::ref(auth_service), std::ref(tm), std::ref(as), qos::service_level_options{.shares = 1000}, scheduling_supergroup(), default_scheduling_group).get();
             seastar::sharded<netw::walltime_compressor_tracker> compressor_tracker;
             compressor_tracker.start([] { return netw::walltime_compressor_tracker::config{}; }).get();
             auto stop_compressor_tracker = deferred_stop(compressor_tracker);


### PR DESCRIPTION
This patch changes the layout of user-facing scheduling groups from

/
`- statement
`- sl:default
`- sl:*
`- other groups (compaction, streaming, etc.)

into

/
`- user (supergroup)
   `- statement
   `- sl:default
   `- sl:*
`- other groups (compaction, streaming, etc.)

The new supergroup has 1000 static shares and is name-less, in a sense that it only have a variable in the code to refer to and is not exported via metrics (should be fixed in seastar if we want to).

The moved groups don't change their names or shares, only move inside the scheduling hierarchy.

The goal of the change is to improve resource consumption of sl:* groups. Right now activities in low-shares service levels are scheduled on-par with e.g. streaming activity, which is considered to be low-prio one. By moving all sl:* groups into their own supergroup with 1000 shares changes the meaning of sl:* shares. From now on these shares values describe preirities of service level between each-other, and the user activities compete with the rest of the system with 1000 shares, regardless of how many service levels are there.

Unit tests keep their user groups under root supergroup (for simplicity)

"New feature", not backporting