### PR TITLE
aws_error: handle all restartable nested exception types

### DIFF
--- a/utils/s3/aws_error.cc
+++ b/utils/s3/aws_error.cc
@@ -160,43 +160,9 @@ aws_error aws_error::from_system_error(const std::system_error& system_error) {
     }
 }
 
-aws_error aws_error::from_maybe_nested_exception(std::exception_ptr eptr) {
-    std::string original_message;
-    while (eptr) {
-        try {
-            std::rethrow_exception(eptr);
-        } catch (const std::exception& e) {
-            if (original_message.empty()) {
-                original_message = e.what();
-            }
-
-            if (auto* sys = dynamic_cast<const std::system_error*>(&e)) {
-                return from_system_error(*sys);
-            }
-
-            try {
-                std::rethrow_if_nested(e);
-            } catch (...) {
-                eptr = std::current_exception();
-                continue;
-            }
-            break;
-        } catch (...) {
-            // Non-std::exception, should not happen in general
-            break;
-        }
-    }
-
-    if (original_message.empty()) {
-        original_message = fmt::format("No error message was provided, exception content: {}", eptr);
-    }
-
-    return {aws_error_type::UNKNOWN, std::move(original_message), retryable::no};
-}
-
-
 aws_error aws_error::from_exception_ptr(std::exception_ptr exception) {
-    if (exception) {
+    std::string original_message;
+    while (exception) {
         try {
             std::rethrow_exception(exception);
         } catch (const aws_exception& ex) {
@@ -205,10 +171,20 @@ aws_error aws_error::from_exception_ptr(std::exception_ptr exception) {
             return from_http_code(ex.status());
         } catch (const std::system_error& ex) {
             return from_system_error(ex);
-        } catch (const std::exception&) {
-            return from_maybe_nested_exception(std::current_exception());
+        } catch (const std::exception& ex) {
+            if (original_message.empty()) {
+                original_message = ex.what();
+            }
+
+            try {
+                std::rethrow_if_nested(ex);
+            } catch (...) {
+                exception = std::current_exception();
+                continue;
+            }
+            return aws_error{aws_error_type::UNKNOWN, std::move(original_message), retryable::no};
         } catch (...) {
-            return aws_error{aws_error_type::UNKNOWN, seastar::format("{}", std::current_exception()), retryable::no};
+            return aws_error{aws_error_type::UNKNOWN, seastar::format("No error message was provided, exception content: {}", std::current_exception()), retryable::no};
         }
     }
     return aws_error{aws_error_type::UNKNOWN, "No exception was provided to `aws_error::from_exception_ptr` function call", retryable::no};

--- a/utils/s3/aws_error.hh
+++ b/utils/s3/aws_error.hh
@@ -106,7 +106,6 @@ public:
     static std::optional<aws_error> parse(seastar::sstring&& body);
     static aws_error from_http_code(seastar::http::reply::status_type http_code);
     static aws_error from_system_error(const std::system_error& system_error);
-    static aws_error from_maybe_nested_exception(std::exception_ptr maybe_nested_error);
     static aws_error from_exception_ptr(std::exception_ptr exception);
     static const aws_errors& get_errors();
 };


### PR DESCRIPTION
Previously we only inspected std::system_error inside std::nested_exception to support a specific TLS-related failure mode. However, nested exceptions may contain any type, including other restartable (retryable) errors. This change unwraps one nested exception per iteration and re-applies all known handlers until a match is found or the chain is exhausted.

backports needed: 2026.1, 2025.4 as the issue is hit in the field with release as early as 2025.3 

Fixes: SCYLLADB-400