### PR TITLE
cql3: support literals and bind variables in selectors

### DIFF
--- a/docs/cql/dml/select.rst
+++ b/docs/cql/dml/select.rst
@@ -25,6 +25,8 @@ Querying data from data is done using a ``SELECT`` statement:
            : | CAST '(' `selector` AS `cql_type` ')'
            : | `function_name` '(' [ `selector` ( ',' `selector` )* ] ')'
            : | COUNT '(' '*' ')'
+           : | literal
+           : | bind_marker
            : )
            : ( '.' `field_name` | '[' `term` ']' )*
    where_clause: `relation` ( AND `relation` )*
@@ -35,6 +37,8 @@ Querying data from data is done using a ``SELECT`` statement:
    operator: '=' | '<' | '>' | '<=' | '>=' | IN | NOT IN | CONTAINS | CONTAINS KEY
    ordering_clause: `column_name` [ ASC | DESC ] ( ',' `column_name` [ ASC | DESC ] )*
    timeout: `duration`
+   literal: number | 'string' | boolean | NULL | tuple_literal | list_literal | map_literal
+   bind_marker: '?' | ':' `identifier`
 
 For instance::
 
@@ -81,6 +85,13 @@ A :token:`selector` can be one of the following:
 - A casting, which allows you to convert a nested selector to a (compatible) type.
 - A function call, where the arguments are selector themselves.
 - A call to the :ref:`COUNT function <count-function>`, which counts all non-null results.
+- A literal value (constant).
+- A bind variable (`?` or `:name`).
+
+Note that due to a quirk of the type system, literals and bind markers cannot be
+used as top-level selectors, as the parser cannot infer their type. However, they can be used
+when nested inside functions, as the function formal parameter types provide the
+necessary context.
 
 Aliases
 ```````

--- a/test/cqlpy/test_selector_literals.py
+++ b/test/cqlpy/test_selector_literals.py
@@ -1,0 +1,91 @@
+# -*- coding: utf-8 -*-
+# Copyright 2026-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+
+# Tests literals in the SELECT clause.
+#
+# Originally, the CQL grammar allowed literals (constants, bind markers, and
+# collections/tuples/UDTs of literals) only in the WHERE clause. This test suite
+# tests literals in the SELECT clause, which were added later [1].
+#
+# The simplest example, "SELECT 1" actually doesn't work since its type cannot
+# be inferred (is it a tinyint, int, or bigint?), so we use UDFs and other functions
+# that accept known types instead. We do test that "SELECT 1" and similar fail
+# in the expected way due to type inference failure.
+#
+# [1]: https://scylladb.atlassian.net/browse/SCYLLADB-296
+
+from contextlib import contextmanager
+import pytest
+from .util import unique_name, new_function
+from .conftest import scylla_only
+from cassandra.protocol import InvalidRequest
+
+want_lua = scylla_only
+
+def test_simple_literal_selectors(cql, test_keyspace, want_lua):
+    @contextmanager
+    def new_sum_function(name: str, type: str, op: str):
+        body = f"(i {type}, j {type}) RETURNS NULL ON NULL INPUT RETURNS {type} LANGUAGE lua AS 'return i {op} j;'"
+        with new_function(cql, test_keyspace, body, name=name, args=f"{type}, {type}") as f:
+            yield f
+
+    # Create two different functions with the same name fun, but a
+    # different signature (different parameters):
+    fun = unique_name()
+    ksfun = f"{test_keyspace}.{fun}"
+    with new_sum_function(name=fun, type="int", op="+"):
+        rows = cql.execute(f"SELECT {ksfun}(1, 2) AS sum_int FROM system.local")
+        assert rows.one().sum_int == 3
+        stmt = cql.prepare(f"SELECT {ksfun}(?, ?) AS sum_int FROM system.local")
+        rows = cql.execute(stmt, (10, 20))
+        assert rows.one().sum_int == 30
+        with pytest.raises(InvalidRequest, match="Type error"):
+            cql.execute(f"SELECT {ksfun}(1, 'asf') AS sum_int FROM system.local")
+    with new_sum_function(name=fun, type="text", op=".."):
+        rows = cql.execute(f"SELECT {ksfun}('hello, ', 'world!') AS sum_text FROM system.local")
+        assert rows.one().sum_text == "hello, world!"
+        stmt = cql.prepare(f"SELECT {ksfun}(?, ?) AS sum_text FROM system.local")
+        rows = cql.execute(stmt, ('foo', 'bar'))
+        assert rows.one().sum_text == "foobar"
+        with pytest.raises(InvalidRequest, match="Type error"):
+            cql.execute(f"SELECT {ksfun}('asf', 1) AS sum_text FROM system.local")
+
+# scylla-only due to set_intersection function
+def test_set_literal_selector(cql, test_keyspace, scylla_only):
+    cql.execute(f"CREATE TABLE IF NOT EXISTS {test_keyspace}.sets (id int PRIMARY KEY, vals set<int>, vals2 set<frozen<map<text, int>>>)")
+    cql.execute(f"INSERT INTO {test_keyspace}.sets (id, vals) VALUES (1, {{1, 2, 3, 4, 5}})")
+    rows = cql.execute(f"SELECT set_intersection(vals, {{3,4,5,6,7}}) AS intersection FROM {test_keyspace}.sets WHERE id=1")
+    assert rows.one().intersection == {3,4,5}
+
+    cql.execute(f"INSERT INTO {test_keyspace}.sets (id, vals2) VALUES (1, {{ {{ 'aa': 1, 'bb': 2 }}, {{ 'cc': 3, 'dd': 4 }} }})")
+    rows = cql.execute(f"SELECT set_intersection(vals2, {{ {{ 'cc': 3, 'dd': 4 }}, {{ 'cc': 3, 'dd': 5 }} }}) AS intersection FROM {test_keyspace}.sets WHERE id=1")
+    assert rows.one().intersection == {frozenset([('cc', 3), ('dd', 4)])}
+
+# Test that simple literals without type hints fail as expected due to type inference failure.
+def test_simple_literal_type_inference_failure(cql, test_keyspace):
+    with pytest.raises(InvalidRequest, match="infer type"):
+        cql.execute("SELECT 1 AS one FROM system.local")
+    with pytest.raises(InvalidRequest, match="infer type"):
+        cql.execute("SELECT 'hello' AS greeting FROM system.local")
+    with pytest.raises(InvalidRequest, match="infer type"):
+        cql.execute("SELECT [1, 2, 3] AS lst FROM system.local")
+    with pytest.raises(InvalidRequest, match="infer type"):
+        cql.execute("SELECT { 'a': 1, 'b': 2 } AS mp FROM system.local")
+    with pytest.raises(InvalidRequest, match="infer type"):
+        cql.execute("SELECT (1, 'a', 3.0) AS tpl FROM system.local")
+    with pytest.raises(InvalidRequest, match="infer type"):
+        cql.execute("SELECT ? AS qm FROM system.local")
+    with pytest.raises(InvalidRequest, match="infer type"):
+        cql.execute("SELECT :bindvar AS bv FROM system.local")
+
+# Test that count(2) fails as expected. We're likely to relax this restriction later
+# as it is quite artificial. scylla_only because Cassandra does allow it.
+def test_count_literal_only_1(cql, test_keyspace, scylla_only):
+    with pytest.raises(InvalidRequest, match="expects a column or the literal 1 as an argument"):
+        cql.execute("SELECT count(2) AS cnt FROM system.local")
+    # Error message here is not the best, but tightening error messages
+    # here is quite a hassle and we plan to relax the restriction later anyway.
+    with pytest.raises(InvalidRequest, match="only valid when argument types are known"):
+        cql.execute("SELECT count(?) AS cnt FROM system.local")


### PR DESCRIPTION
Add support for literals in the SELECT clause. This allows
SELECT fn(column, 4) or SELECT fn(column, ?).

Note, "SELECT 7 FROM tab" becomes valid in the grammar, but is still
not accepted because of failed type inference - we cannot infer the
type of 7, and don't have a favored type for literals (like C favors
int). We might relax this later.

In the WHERE clause, and Cassandra in the SELECT clause, type hints
can also resolve type ambiguity: (bigint)7 or (text)?. But this is
deferred to a later patch.

A few changes to the grammar are needed on top of adding a `value`
alternative to `unaliasedSelector`:

 - vectorSimilarityArg gained access to `value` via `unaliasedSelector`,
   so it loses that alternate to avoid ambiguity. We may drop
   `vectorSimilarityArg` later.
 - COUNT(1) became ambiguous via the general function path (since
   function arguments can now be literals), so we remove this case
   from the COUNT special cases, remaining with count(*).
 - SELECT JSON and SELECT DISTINCT became "ambiguous enough" for
   ANTLR to complain, though as far as I can tell `value` does not
   add real ambiguity. The solution is to commit early (via "=>") to
   a parsing path.

Due to the loss of count(1) recognition in the parser, we have to
special-case it in prepare. We may relax it to count any expression
later, like modern Cassandra and SQL.

Testing is awkward because of the type inference problem in top-level.
We test via the set_intersection() function and via lua functions.

Example:

```
cqlsh> CREATE FUNCTION ks.sum(a int, b int) RETURNS NULL ON NULL INPUT RETURNS int  LANGUAGE LUA AS 'return a + b';
cqlsh> SELECT ks.sum(1, 2) FROM system.local;

 ks.sum(1, 2)
--------------
            3

(1 rows)
cqlsh>
```

(There are no suitable system functions!)

Fixes https://scylladb.atlassian.net/browse/SCYLLADB-296