### PR TITLE
refactor: vector_search: move filter logic to vector_search namespace

### DIFF
--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -2033,7 +2033,7 @@ future<shared_ptr<cql_transport::messages::result_message>> vector_indexed_table
 
         auto timeout = db::timeout_clock::now() + get_timeout(state.get_client_state(), options);
         auto aoe = abort_on_expiry(timeout);
-        auto filter_json = restrictions::to_json(*_restrictions, options, _parameters->allow_filtering());
+        auto filter_json = vector_search::to_json(*_restrictions, options, _parameters->allow_filtering());
         uint64_t fetch = static_cast<uint64_t>(std::ceil(limit * secondary_index::vector_index::get_oversampling(_index.metadata().options())));
         auto pkeys = co_await qp.vector_store_client().ann(
                 _schema->ks_name(), _index.metadata().name(), _schema, get_ann_ordering_vector(options), fetch, filter_json, aoe.abort_source());

--- a/test/vector_search/filter_test.cc
+++ b/test/vector_search/filter_test.cc
@@ -36,7 +36,7 @@ restrictions::statement_restrictions make_restrictions(
 
 /// Helper to get JSON string from restrictions
 sstring get_restrictions_json(const restrictions::statement_restrictions& restr, bool allow_filtering = false) {
-    return rjson::print(restrictions::to_json(restr, query_options({}), allow_filtering));
+    return rjson::print(vector_search::to_json(restr, query_options({}), allow_filtering));
 }
 
 } // anonymous namespace
@@ -47,7 +47,7 @@ SEASTAR_TEST_CASE(to_json_empty_restrictions) {
 
         auto schema = e.local_db().find_schema("ks", "t");
         restrictions::statement_restrictions restr(schema, false);
-        auto json = rjson::print(restrictions::to_json(restr, query_options({}), false));
+        auto json = rjson::print(vector_search::to_json(restr, query_options({}), false));
 
         BOOST_CHECK_EQUAL(json, "{}");
     });

--- a/vector_search/filter.hh
+++ b/vector_search/filter.hh
@@ -18,10 +18,14 @@ namespace restrictions {
 
 class statement_restrictions;
 
+}
+} // namespace cql3
+
+namespace vector_search {
+
 /// Converts CQL statement restrictions to JSON format for the Vector Store service.
 /// This function extracts primary key restrictions from the statement_restrictions
 /// and serializes them to JSON compatible to Vector Store service filtering API.
-rjson::value to_json(const statement_restrictions& restrictions, const query_options& options, bool allow_filtering);
+rjson::value to_json(const cql3::restrictions::statement_restrictions& restrictions, const cql3::query_options& options, bool allow_filtering);
 
-} // namespace restrictions
-} // namespace cql3
+} // namespace vector_search


### PR DESCRIPTION
Move Vector Search filter functions from `cql3::restrictions` to `vector_search` namespace as it's a better place according to it's purpose.
The effective name has now changed from `cql3::restrictions::to_json` to `vector_search::to_json` which clearly mentions that the JSON object will be used for Vector Search.

Rename the auxilary functions to use `to_json` suffix instead of variety of verbs as those functions logic focuses on building JSON object from different structures. The late naming emphasized too much distinction between those functions, while they do pretty much the same thing.

Follow-up: #28109