### PR TITLE
test/cqlpy: make a test faster

### DIFF
--- a/test/cqlpy/cassandra_tests/validation/entities/collections_test.py
+++ b/test/cqlpy/cassandra_tests/validation/entities/collections_test.py
@@ -530,8 +530,6 @@ def testDropAndReaddDroppedCollection(cql, test_keyspace):
         execute(cql, table, "alter table %s drop v")
         execute(cql, table, "alter table %s add v set<text>")
 
-# FIXME: this test is 20 times slower than the rest (run pytest with "--durations=5"
-# to see the 5 slowest tests). Is it checking anything worth this slowness??
 def testMapWithLargePartition(cql, test_keyspace):
     seed = time.time()
     print(f"Seed {seed}")
@@ -540,7 +538,7 @@ def testMapWithLargePartition(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(userid text PRIMARY KEY, properties map<int, text>) with compression = {}") as table:
         numKeys = 200
         for i in range(numKeys):
-            s = ''.join(random.choice(string.ascii_uppercase) for x in range(length))
+            s = 'x'*length
             execute(cql, table,"UPDATE %s SET properties[?] = ? WHERE userid = 'user'", i, s)
 
         flush(cql, table)


### PR DESCRIPTION
Right now the slowest test in the test/cqlpy directory is

   `cassandra_tests/validation/entities/collections_test.py::testMapWithLargePartition`

This test (translated from Cassandra's unit test), just wants to verify that we can write and flush a partition with a single large map - with 200 items totalling around 2MB in size.

200 items totalling 2MB is large, but not huge, and is not the reason why this test was so so slow (around 9 seconds). It turns out that most of the test time was spent in Python code, preparing a 2MB random string the slowest possible way. But there is no need for this string to be random at all - we only care about the large size of the value, not the specific characters in it!

Making the characters written in this text constant instead of random made it 20 times fast - it now takes less than half a second.