### PR TITLE
test: test_zero_token_nodes_multidc: properly handle reads with CL=LOCAL_ONE

### DIFF
--- a/test/cluster/test_zero_token_nodes_multidc.py
+++ b/test/cluster/test_zero_token_nodes_multidc.py
@@ -107,8 +107,11 @@ async def test_zero_token_nodes_multidc_basic(manager: ManagerClient, zero_token
             dc2_result_set = await dc2_cql.run_async(select_queries[1])
             # With CL=ONE we don't have a guarantee that the replicas written to and read from have a non-empty
             # intersection. Hence, reads could miss the written rows.
-            assert cl == ConsistencyLevel.ONE or (dc1_result_set and dc2_result_set)
-            if dc1_result_set:
+            if cl == ConsistencyLevel.ONE:
+                continue
+            # The comment above is also true with CL=LOCAL_ONE, but only for dc1 that has RF=2.
+            if cl != ConsistencyLevel.LOCAL_ONE:
+                assert len(dc1_result_set) == 1
                 assert list(dc1_result_set[0]) == [cl, False, cl]
-            if dc2_result_set:
-                assert list(dc2_result_set[0]) == [cl, True, cl]
+            assert len(dc2_result_set) == 1
+            assert list(dc2_result_set[0]) == [cl, True, cl]


### PR DESCRIPTION
The test is currently flaky. It incorrectly assumes that a read with
CL=LOCAL_ONE will see the data inserted by a preceding write with
CL=LOCAL_ONE in the same datacenter with RF=2.

The same issue has already been fixed for CL=ONE in
21edec1acec3abbf9e78dd6185d1b075ffa7c651. The difference is that
for CL=LOCAL_ONE, only dc1 is problematic, as dc2 has RF=1.

We fix the issue for CL=LOCAL_ONE by skipping the check for dc1.

Fixes #28253

The fix addresses CI flakiness and only changes the test, so it
should be backported.