### PR TITLE
streamed_mutation_freezer: use chunked_vector instead of std::deque for clustering rows

### DIFF
--- a/mutation/frozen_mutation.cc
+++ b/mutation/frozen_mutation.cc
@@ -178,7 +178,7 @@ class fragmenting_mutation_freezer {
 
     tombstone _partition_tombstone;
     std::optional<static_row> _sr;
-    std::deque<clustering_row> _crs;
+    utils::chunked_vector<clustering_row> _crs;
     range_tombstone_list _rts;
 
     frozen_mutation_consumer_fn _consumer;

--- a/mutation/frozen_mutation.hh
+++ b/mutation/frozen_mutation.hh
@@ -242,7 +242,7 @@ class streamed_mutation_freezer {
 
     tombstone _partition_tombstone;
     std::optional<static_row> _sr;
-    std::deque<clustering_row> _crs;
+    utils::chunked_vector<clustering_row> _crs;
     range_tombstone_list _rts;
 public:
     streamed_mutation_freezer(const schema& s, const partition_key& key)

--- a/mutation/mutation_partition_serializer.hh
+++ b/mutation/mutation_partition_serializer.hh
@@ -41,4 +41,4 @@ public:
 
 void serialize_mutation_fragments(const schema& s, tombstone partition_tombstone,
     std::optional<static_row> sr, range_tombstone_list range_tombstones,
-    std::deque<clustering_row> clustering_rows, ser::writer_of_mutation_partition<bytes_ostream>&&);
+    utils::chunked_vector<clustering_row> clustering_rows, ser::writer_of_mutation_partition<bytes_ostream>&&);


### PR DESCRIPTION

The streamed_mutation_freezer class uses a deque to avoid large allocations, but fails as seen in the referenced issue when the vector backing the deque grows too large. This may be a problem in itself, but the issue doesn't provide enough information to tell.

Fix the immediate problem by switching to chunked_vector, which is better in avoiding large allocations. We do lose some early-free in serialize_mutation_fragments(), but since most of the memory should be in the clustering row itself, not in the deque/chunked_vector holding it, it should not be a problem.

Fixes #28275

Very minor issue and usually not observed, so not backporting.