### PR TITLE
test/scylla_gdb: fix coro_task request usage, rename duplicate test

### DIFF
--- a/test/scylla_gdb/test_misc.py
+++ b/test/scylla_gdb/test_misc.py
@@ -169,7 +169,7 @@ def test_fiber(gdb, task):
 
 # Similar to task(), but looks for a coroutine frame.
 @pytest.fixture(scope="module")
-def coro_task(gdb, scylla_gdb):
+def coro_task(gdb, scylla_gdb, request):
     target = 'service::topology_coordinator::run() [clone .resume]'
     for obj_addr, vtable_addr in scylla_gdb.find_vptrs():
         name = scylla_gdb.resolve(vtable_addr)
@@ -205,7 +205,7 @@ def test_coro_frame(gdb, coro_task):
 def test_sstable_summary(gdb, sstable):
     scylla(gdb, f'sstable-summary {sstable}')
 
-def test_sstable_summary(gdb, sstable):
+def test_sstable_index_cache(gdb, sstable):
     scylla(gdb, f'sstable-index-cache {sstable}')
 
 def test_read_stats(gdb, sstable):


### PR DESCRIPTION
- Pass pytest request fixture into coro_task (used for scylla_tmp_dir and core dump path)
- Rename duplicate `test_sstable_summary` that runs sstable-index-cache to `test_sstable_index_cache` so both tests are collected

Refs https://github.com/scylladb/scylladb/issues/22501

Backport not needed. It corrects the usage of the pytest request fixture wrongly used by https://github.com/scylladb/scylladb/pull/27498. The latter is only on master.