### PR TITLE
test: test_raft_recovery_user_data: prevent repeated ALTER KEYSPACE request

### DIFF
--- a/test/cluster/test_raft_recovery_user_data.py
+++ b/test/cluster/test_raft_recovery_user_data.py
@@ -189,6 +189,8 @@ async def test_raft_recovery_user_data(manager: ManagerClient, remove_dead_nodes
     logging.info(f'Adding {new_servers_num} new servers to dc2')
     new_servers += await manager.servers_add(new_servers_num, config=cfg, property_file=property_file_dc2)
 
+    # Reconnect the driver as a workaround for https://github.com/scylladb/scylladb/issues/27862.
+    await reconnect_driver(manager)
     cql, hosts = await manager.get_ready_cql(live_servers + new_servers)
 
     if remove_dead_nodes_with == "remove":


### PR DESCRIPTION
The test is currently flaky. With `remove_dead_nodes_with == "remove"`,
it sends several ALTER KEYSPACE requests. The request performed just
after adding 3 new nodes can unexpectedly be sent twice to two
different nodes by the driver. The second receiver rejects the request
through the new guardrail added in 2e7ba1f8ce7fc3e3e2680f846fe193026ef5a16e,
and the test fails.

This has been acknowledged as a bug in the Python driver. It shouldn't
retry non-idempotent requests with the default retry policy. There could
be one more bug in the driver, as it looks like the driver decides to
resend the request after it disconnects from the first receiver. The
first receiver has just bootstrapped, so the driver shouldn't disconnect.

We deflake the test by reconnecting the driver before performing the
problematic ALTER KEYSPACE request.

The change has been tested in byo, as the failure reproduces only in CI.
Without the change, the test fails once in ~250 runs in dev mode. With
the change, all 2000 runs passed.

Fixes #27862

No backport needed as 2e7ba1f8ce7fc3e3e2680f846fe193026ef5a16e is only
in master.