### PR TITLE
test.py: remove deprecated skip_mode decorator

### DIFF
--- a/test/cluster/auth_cluster/test_auth_password_ensured.py
+++ b/test/cluster/auth_cluster/test_auth_password_ensured.py
@@ -9,7 +9,6 @@ import logging
 import time
 
 from cassandra.cluster import NoHostAvailable
-from test.cluster.conftest import skip_mode
 from test.pylib.manager_client import ManagerClient, ServerUpState
 from test.pylib.util import wait_for
 from test.cluster.auth_cluster import extra_scylla_config_options as auth_config

--- a/test/cluster/auth_cluster/test_raft_service_levels.py
+++ b/test/cluster/auth_cluster/test_raft_service_levels.py
@@ -14,7 +14,6 @@ from test.cluster.util import trigger_snapshot, wait_until_topology_upgrade_fini
         delete_raft_topology_state, delete_raft_data_and_upgrade_state, wait_until_upgrade_finishes, \
         wait_for_token_ring_and_group0_consistency, wait_until_driver_service_level_created, get_topology_coordinator, \
         find_server_by_host_id
-from test.cluster.conftest import skip_mode
 from test.cqlpy.test_service_levels import MAX_USER_SERVICE_LEVELS
 from cassandra import ConsistencyLevel
 from cassandra.query import SimpleStatement

--- a/test/cluster/conftest.py
+++ b/test/cluster/conftest.py
@@ -356,27 +356,6 @@ async def random_tables(request, manager):
     if not failed and not await manager.is_dirty():
         tables.drop_all()
 
-skipped_funcs = {}
-# Can be used to mark a test to be skipped for a specific mode=[release, dev, debug]
-# The reason to skip a test should be specified, used as a comment only.
-# Additionally, platform_key can be specified to limit the scope of the attribute
-# to the specified platform. Example platform_key-s: [aarch64, x86_64]
-@warnings.deprecated('Please use pytest.mark.skip_mode instead')
-def skip_mode(mode: str, reason: str, platform_key: str | None = None):
-    """DEPRECATED. Please use pytest.mark.skip_mode instead"""
-    def wrap(func):
-        skipped_funcs.setdefault((func, mode), []).append((reason, platform_key))
-        return func
-    return wrap
-
-@pytest.fixture(scope="function", autouse=True)
-@warnings.deprecated('Please use pytest.mark.skip_mode instead')
-def skip_mode_fixture(request, build_mode):
-    for reason, platform_key in skipped_funcs.get((request.function, build_mode), []):
-        if platform_key is None or platform_key in platform.platform():
-            pytest.skip(f'{request.node.name} skipped, reason: {reason}')
-
-
 @pytest.fixture(scope="function", autouse=True)
 async def prepare_3_nodes_cluster(request, manager):
     if request.node.get_closest_marker("prepare_3_nodes_cluster"):

--- a/test/cluster/lwt/test_lwt_during_tablets_migration.py
+++ b/test/cluster/lwt/test_lwt_during_tablets_migration.py
@@ -9,7 +9,6 @@ import logging
 import random
 
 import pytest
-from test.cluster.conftest import skip_mode
 from test.cluster.lwt.lwt_common import (
     BaseLWTTester,
     get_token_for_pk,

--- a/test/cluster/lwt/test_lwt_during_tablets_resize.py
+++ b/test/cluster/lwt/test_lwt_during_tablets_resize.py
@@ -9,7 +9,6 @@ import logging
 import random
 
 import pytest
-from test.cluster.conftest import skip_mode
 from test.cluster.lwt.lwt_common import (
     BaseLWTTester,
     wait_for_tablet_count,

--- a/test/cluster/lwt/test_lwt_with_counters_during_tablets_resize_and_migrations.py
+++ b/test/cluster/lwt/test_lwt_with_counters_during_tablets_resize_and_migrations.py
@@ -9,7 +9,6 @@ import time
 from typing import Dict
 
 import pytest
-from test.cluster.conftest import skip_mode
 from test.cluster.lwt.lwt_common import (
     BaseLWTTester,
     DEFAULT_WORKERS,

--- a/test/cluster/mv/tablets/test_mv_tablets.py
+++ b/test/cluster/mv/tablets/test_mv_tablets.py
@@ -11,7 +11,6 @@ from test.pylib.rest_client import read_barrier
 from test.pylib.tablets import get_tablet_replicas, get_tablet_count
 from test.pylib.util import wait_for_cql_and_get_hosts
 from test.pylib.internal_types import ServerInfo
-from test.cluster.conftest import skip_mode
 from test.cluster.util import new_test_keyspace
 
 from test.cluster.test_alternator import get_alternator, alternator_config, full_query

--- a/test/cluster/mv/tablets/test_mv_tablets_empty_ip.py
+++ b/test/cluster/mv/tablets/test_mv_tablets_empty_ip.py
@@ -13,7 +13,6 @@ from cassandra.cluster import ConnectionException, NoHostAvailable  # type: igno
 
 from test.pylib.scylla_cluster import ReplaceConfig
 from test.pylib.manager_client import ManagerClient
-from test.cluster.conftest import skip_mode
 from test.cluster.util import new_test_keyspace
 
 

--- a/test/cluster/mv/tablets/test_mv_tablets_replace.py
+++ b/test/cluster/mv/tablets/test_mv_tablets_replace.py
@@ -16,7 +16,6 @@ import asyncio
 import logging
 import time
 
-from test.cluster.conftest import skip_mode
 from test.cluster.util import get_topology_coordinator, find_server_by_host_id
 from test.cluster.mv.tablets.test_mv_tablets import get_tablet_replicas
 from test.cluster.util import new_test_keyspace, wait_for

--- a/test/cluster/mv/test_mv_admission_control.py
+++ b/test/cluster/mv/test_mv_admission_control.py
@@ -10,7 +10,6 @@ import pytest
 import time
 import logging
 
-from test.cluster.conftest import skip_mode
 from test.pylib.util import wait_for_view
 from test.cluster.mv.tablets.test_mv_tablets import pin_the_only_tablet, get_tablet_replicas
 from test.cluster.util import new_test_keyspace

--- a/test/cluster/mv/test_mv_backlog.py
+++ b/test/cluster/mv/test_mv_backlog.py
@@ -9,7 +9,6 @@ import logging
 import time
 import asyncio
 import pytest
-from test.cluster.conftest import skip_mode
 from test.pylib.util import wait_for_view, wait_for
 from test.cluster.mv.tablets.test_mv_tablets import pin_the_only_tablet
 from test.pylib.tablets import get_tablet_replica

--- a/test/cluster/mv/test_mv_building.py
+++ b/test/cluster/mv/test_mv_building.py
@@ -11,7 +11,6 @@ import time
 from test.pylib.manager_client import ManagerClient, wait_for_cql_and_get_hosts
 from test.pylib.tablets import get_tablet_replica
 from test.pylib.util import wait_for, wait_for_view
-from test.cluster.conftest import skip_mode
 from test.cluster.util import get_topology_coordinator, new_test_keyspace, reconnect_driver
 
 logger = logging.getLogger(__name__)

--- a/test/cluster/mv/test_mv_delete_partitions.py
+++ b/test/cluster/mv/test_mv_delete_partitions.py
@@ -9,7 +9,6 @@ import asyncio
 import pytest
 import time
 import logging
-from test.cluster.conftest import skip_mode
 from test.pylib.util import wait_for_view
 from test.cluster.util import new_test_keyspace, new_test_table, new_materialized_view
 from cassandra.cqltypes import Int32Type

--- a/test/cluster/mv/test_mv_fail_building.py
+++ b/test/cluster/mv/test_mv_fail_building.py
@@ -5,7 +5,6 @@
 #
 import asyncio
 import pytest
-from test.cluster.conftest import skip_mode
 from test.pylib.manager_client import ManagerClient
 from test.pylib.util import wait_for_view
 from test.cluster.util import new_test_keyspace, reconnect_driver

--- a/test/cluster/mv/test_mv_read_concurrency.py
+++ b/test/cluster/mv/test_mv_read_concurrency.py
@@ -9,7 +9,6 @@ import asyncio
 import pytest
 import logging
 
-from test.cluster.conftest import skip_mode
 from test.pylib.util import wait_for_view
 from test.cluster.util import new_test_keyspace
 from cassandra import ReadTimeout, WriteTimeout

--- a/test/cluster/mv/test_mv_staging.py
+++ b/test/cluster/mv/test_mv_staging.py
@@ -7,7 +7,6 @@
 from cassandra.query import SimpleStatement, ConsistencyLevel
 
 from test.pylib.manager_client import ManagerClient
-from test.cluster.conftest import skip_mode
 from test.pylib.util import wait_for_view
 from test.pylib.internal_types import ServerInfo
 from test.cluster.util import new_test_keyspace, wait_for_cql_and_get_hosts
@@ -46,7 +45,7 @@ async def delete_table_sstables(manager: ManagerClient, server: ServerInfo, ks: 
         break # break unconditionally here to remove only files in `table_dir`
 
 @pytest.mark.asyncio
-@skip_mode('release', 'error injections are not supported in release mode')
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_staging_backlog_processed_after_restart(manager: ManagerClient):
     """
     Verifies that staging sstables are processed after node restart.

--- a/test/cluster/mv/test_mv_topology_change.py
+++ b/test/cluster/mv/test_mv_topology_change.py
@@ -13,7 +13,6 @@ import re
 from cassandra.cluster import ConnectionException, NoHostAvailable  # type: ignore
 from cassandra.query import SimpleStatement, ConsistencyLevel
 
-from test.cluster.conftest import skip_mode
 from test.cluster.util import new_test_keyspace
 
 from test.pylib.manager_client import ManagerClient

--- a/test/cluster/mv/test_mv_with_tablets_restrictions.py
+++ b/test/cluster/mv/test_mv_with_tablets_restrictions.py
@@ -11,7 +11,6 @@ import pytest
 from cassandra.cluster import Session as CassandraSession
 from cassandra.protocol import InvalidRequest
 
-from test.cluster.conftest import skip_mode
 from test.pylib.async_cql import _wrap_future
 from test.pylib.manager_client import ManagerClient
 
@@ -19,7 +18,7 @@ logger = logging.getLogger(__name__)
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("rf_kind", ["numeric", "rack_list"])
-@skip_mode('release', 'error injections are not supported in release mode')
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_create_mv_and_index_restrictions_in_tablet_keyspaces(manager: ManagerClient, rf_kind: str):
     """
     Verify that creating a materialized view or a secondary index in a tablet-based keyspace
@@ -99,7 +98,7 @@ async def test_create_mv_and_index_restrictions_in_tablet_keyspaces(manager: Man
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("rf_kind", ["numeric", "rack_list"])
-@skip_mode('release', 'error injections are not supported in release mode')
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_alter_keyspace_rf_rack_restriction_with_mv_and_index(manager: ManagerClient, rf_kind: str):
     """
     Verify that ALTER KEYSPACE fails if it changes RF so that RF != number of racks
@@ -178,7 +177,7 @@ async def test_alter_keyspace_rf_rack_restriction_with_mv_and_index(manager: Man
 
 
 @pytest.mark.asyncio
-@skip_mode('release', 'error injections are not supported in release mode')
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_add_node_in_new_rack_restriction_with_mv(manager: ManagerClient):
     """
     Test adding a node to a new rack is rejected when there is a keyspace with RF=Racks and a materialized view
@@ -210,7 +209,7 @@ async def test_add_node_in_new_rack_restriction_with_mv(manager: ManagerClient):
 
 @pytest.mark.parametrize("op", ["remove", "decommission"])
 @pytest.mark.asyncio
-@skip_mode('release', 'error injections are not supported in release mode')
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_remove_node_violating_rf_rack(manager: ManagerClient, op: str):
     """
     Test removing a node is rejected when there is a keyspace with RF=Racks and a materialized view

--- a/test/cluster/object_store/test_backup.py
+++ b/test/cluster/object_store/test_backup.py
@@ -13,7 +13,6 @@ import random
 from test.cqlpy.util import local_process_id
 from test.pylib.manager_client import ManagerClient
 from test.cluster.object_store.conftest import format_tuples
-from test.cluster.conftest import skip_mode
 from test.cluster.util import wait_for_cql_and_get_hosts, get_replication, new_test_keyspace
 from test.pylib.rest_client import read_barrier
 from test.pylib.util import unique_name, wait_all
@@ -514,7 +513,7 @@ async def do_abort_restore(manager: ManagerClient, object_storage):
         assert failed, "Expected at least one restore task to fail after aborting"
 
 @pytest.mark.asyncio
-@skip_mode('release', 'error injections are not supported in release mode')
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_abort_restore_with_rpc_error(manager: ManagerClient, object_storage):
     await do_abort_restore(manager, object_storage)
 

--- a/test/cluster/random_failures/test_random_failures.py
+++ b/test/cluster/random_failures/test_random_failures.py
@@ -21,7 +21,6 @@ from cassandra.cluster import NoHostAvailable
 
 from test.pylib.util import wait_for, wait_for_cql_and_get_hosts
 from test.cluster.util import wait_for_token_ring_and_group0_consistency, get_coordinator_host
-from test.cluster.conftest import skip_mode
 from test.pylib.internal_types import ServerUpState
 from test.cluster.random_failures.cluster_events import CLUSTER_EVENTS, TOPOLOGY_TIMEOUT, feed_rack_seed, get_random_rack
 from test.cluster.random_failures.error_injections import ERROR_INJECTIONS, ERROR_INJECTIONS_NODE_MAY_HANG

--- a/test/cluster/tasks/test_tablet_tasks.py
+++ b/test/cluster/tasks/test_tablet_tasks.py
@@ -13,7 +13,6 @@ from test.pylib.internal_types import ServerInfo
 from test.pylib.manager_client import ManagerClient
 from test.pylib.repair import create_table_insert_data_for_repair, get_tablet_task_id
 from test.pylib.tablets import get_all_tablet_replicas
-from test.cluster.conftest import skip_mode
 from test.cluster.util import create_new_test_keyspace, new_test_keyspace
 from test.cluster.test_tablets2 import inject_error_on
 from test.cluster.tasks.task_manager_client import TaskManagerClient

--- a/test/cluster/test_aggregation.py
+++ b/test/cluster/test_aggregation.py
@@ -14,7 +14,6 @@ from cassandra.cluster import NoHostAvailable  # type: ignore
 from test.pylib.manager_client import ManagerClient
 from test.pylib.rest_client import inject_error
 from test.pylib.util import wait_for, wait_for_cql_and_get_hosts
-from test.cluster.conftest import skip_mode
 from test.cluster.util import new_test_keyspace, new_test_table
 
 logger = logging.getLogger(__name__)

--- a/test/cluster/test_alternator.py
+++ b/test/cluster/test_alternator.py
@@ -31,7 +31,6 @@ from test.cluster.util import get_replication
 from test.pylib.manager_client import ManagerClient
 from test.pylib.util import wait_for
 from test.pylib.tablets import get_all_tablet_replicas
-from test.cluster.conftest import skip_mode
 from test.pylib.tablets import get_tablet_replica
 
 logger = logging.getLogger(__name__)

--- a/test/cluster/test_alternator_proxy_protocol.py
+++ b/test/cluster/test_alternator_proxy_protocol.py
@@ -25,7 +25,6 @@ import pytest
 
 from test.pylib.manager_client import ManagerClient
 from test.pylib.rest_client import inject_error
-from test.cluster.conftest import skip_mode
 
 logger = logging.getLogger(__name__)
 
@@ -325,7 +324,7 @@ async def test_alternator_no_proxy_header_to_proxy_port_fails(alternator_proxy_s
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("use_ssl", [False, True], ids=["http", "https"])
-@skip_mode('release', 'error injections are not supported in release mode')
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_alternator_proxy_protocol_address_in_system_clients(alternator_proxy_server, use_ssl):
     """Test that the source address from the proxy protocol header is correctly
     reported in system.clients.

--- a/test/cluster/test_automatic_cleanup.py
+++ b/test/cluster/test_automatic_cleanup.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
 #
 from test.pylib.manager_client import ManagerClient
-from test.cluster.conftest import skip_mode
 from test.cluster.util import new_test_keyspace
 from cassandra import WriteFailure
 import pytest

--- a/test/cluster/test_batchlog_manager.py
+++ b/test/cluster/test_batchlog_manager.py
@@ -11,7 +11,6 @@ import time
 from test.pylib.manager_client import ManagerClient
 from test.pylib.util import wait_for
 from test.cluster.util import new_test_keyspace, reconnect_driver, wait_for_cql_and_get_hosts
-from test.cluster.conftest import skip_mode
 
 
 logger = logging.getLogger(__name__)

--- a/test/cluster/test_blocked_bootstrap.py
+++ b/test/cluster/test_blocked_bootstrap.py
@@ -4,7 +4,6 @@
 #
 from test.pylib.scylla_cluster import ReplaceConfig
 from test.pylib.manager_client import ManagerClient
-from test.cluster.conftest import skip_mode
 
 import pytest
 import logging

--- a/test/cluster/test_bti_index.py
+++ b/test/cluster/test_bti_index.py
@@ -11,7 +11,6 @@ import glob
 import json
 import logging
 from typing import Any
-from test.cluster.conftest import skip_mode
 from test.pylib.internal_types import ServerInfo
 from test.pylib.manager_client import ManagerClient
 from test.pylib.rest_client import ScyllaMetrics

--- a/test/cluster/test_cdc_generation_clearing.py
+++ b/test/cluster/test_cdc_generation_clearing.py
@@ -8,7 +8,6 @@ from test.pylib.manager_client import ManagerClient
 from test.pylib.util import wait_for, wait_for_cql_and_get_hosts
 from test.cluster.util import wait_for_cdc_generations_publishing, \
         check_system_topology_and_cdc_generations_v3_consistency
-from test.cluster.conftest import skip_mode
 
 from cassandra.cluster import ConsistencyLevel # type: ignore # pylint: disable=no-name-in-module
 from cassandra.pool import Host # type: ignore # pylint: disable=no-name-in-module

--- a/test/cluster/test_cdc_generation_data.py
+++ b/test/cluster/test_cdc_generation_data.py
@@ -1,7 +1,6 @@
 from test.pylib.manager_client import ManagerClient
 from test.pylib.rest_client import inject_error
 from test.cluster.util import check_token_ring_and_group0_consistency
-from test.cluster.conftest import skip_mode
 import logging
 import pytest
 import asyncio

--- a/test/cluster/test_cdc_generation_publishing.py
+++ b/test/cluster/test_cdc_generation_publishing.py
@@ -6,7 +6,6 @@
 from test.pylib.manager_client import ManagerClient, ServerInfo
 from test.pylib.rest_client import inject_error
 from test.pylib.util import wait_for, wait_for_cql_and_get_hosts
-from test.cluster.conftest import skip_mode
 
 from cassandra.cluster import ConsistencyLevel # type: ignore # pylint: disable=no-name-in-module
 from cassandra.query import SimpleStatement # type: ignore # pylint: disable=no-name-in-module

--- a/test/cluster/test_cdc_with_tablets.py
+++ b/test/cluster/test_cdc_with_tablets.py
@@ -12,7 +12,6 @@ from test.pylib.rest_client import read_barrier
 from test.pylib.util import wait_for
 from test.pylib.tablets import get_tablet_count, get_base_table, get_tablet_replicas
 from test.cluster.util import new_test_keyspace
-from test.cluster.conftest import skip_mode
 
 import asyncio
 import logging

--- a/test/cluster/test_client_routes.py
+++ b/test/cluster/test_client_routes.py
@@ -7,7 +7,6 @@ import logging
 import time
 import uuid
 
-from test.cluster.conftest import skip_mode
 from test.pylib.manager_client import ManagerClient
 from test.pylib.rest_client import HTTPError
 from test.pylib.util import wait_for

--- a/test/cluster/test_commitlog.py
+++ b/test/cluster/test_commitlog.py
@@ -12,7 +12,6 @@ from test.pylib.manager_client import ManagerClient
 from test.pylib.random_tables import RandomTables
 from test.pylib.util import wait_for_cql_and_get_hosts
 from test.cluster.util import reconnect_driver
-from test.cluster.conftest import skip_mode
 from test.pylib.random_tables import Column, TextType
 
 logger = logging.getLogger(__name__)

--- a/test/cluster/test_coordinator_queue_management.py
+++ b/test/cluster/test_coordinator_queue_management.py
@@ -5,7 +5,6 @@
 #
 from test.pylib.manager_client import ManagerClient
 from test.pylib.util import wait_for_first_completed
-from test.cluster.conftest import skip_mode
 from collections.abc import Coroutine
 import pytest
 import logging

--- a/test/cluster/test_counter_write_timeout_metric.py
+++ b/test/cluster/test_counter_write_timeout_metric.py
@@ -14,7 +14,6 @@ were not being counted in the coordinator write_timeouts metric.
 import asyncio
 import pytest
 
-from test.cluster.conftest import skip_mode
 from test.pylib.manager_client import ManagerClient
 from test.pylib.rest_client import inject_error
 
@@ -24,7 +23,7 @@ from .util import new_test_keyspace, new_test_table
 COORDINATOR_WRITE_TIMEOUTS_METRIC = "scylla_storage_proxy_coordinator_write_timeouts"
 
 
-@skip_mode("release", "error injections are not supported in release mode")
+@pytest.mark.skip_mode(mode="release", reason="error injections are not supported in release mode")
 async def test_counter_write_timeout_updates_coordinator_metric(manager: ManagerClient):
     """
     Test that when a counter write times out, the coordinator write_timeouts

--- a/test/cluster/test_counters_with_tablets.py
+++ b/test/cluster/test_counters_with_tablets.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
 #
 
-from test.cluster.conftest import skip_mode
 from test.pylib.manager_client import ManagerClient
 from test.cluster.util import new_test_keyspace
 from test.pylib.tablets import get_tablet_replica

--- a/test/cluster/test_crash_coordinator_before_streaming.py
+++ b/test/cluster/test_crash_coordinator_before_streaming.py
@@ -10,7 +10,6 @@ import pytest
 
 from test.pylib.manager_client import ManagerClient
 from test.pylib.scylla_cluster import ReplaceConfig
-from test.cluster.conftest import skip_mode
 from test.cluster.util import (check_token_ring_and_group0_consistency, wait_for_token_ring_and_group0_consistency,
                                get_coordinator_host, get_coordinator_host_ids, wait_new_coordinator_elected)
 

--- a/test/cluster/test_create_table_during_node_shutdown.py
+++ b/test/cluster/test_create_table_during_node_shutdown.py
@@ -5,7 +5,6 @@
 #
 import asyncio
 import pytest
-from test.cluster.conftest import skip_mode
 from test.pylib.manager_client import ManagerClient
 from test.cluster.util import new_test_keyspace, reconnect_driver
 

--- a/test/cluster/test_data_resurrection_after_cleanup.py
+++ b/test/cluster/test_data_resurrection_after_cleanup.py
@@ -6,7 +6,6 @@
 
 from test.pylib.manager_client import ManagerClient
 from test.pylib.rest_client import inject_error_one_shot
-from test.cluster.conftest import skip_mode
 from test.cluster.util import new_test_keyspace, wait_for_token_ring_and_group0_consistency
 
 import pytest

--- a/test/cluster/test_data_resurrection_in_memtable.py
+++ b/test/cluster/test_data_resurrection_in_memtable.py
@@ -12,7 +12,6 @@ import time
 from cassandra.cluster import ConsistencyLevel  # type: ignore
 from cassandra.query import SimpleStatement  # type: ignore
 
-from test.cluster.conftest import skip_mode
 from test.cluster.util import new_test_keyspace
 from test.pylib.manager_client import ManagerClient
 from test.pylib.util import wait_for_cql_and_get_hosts, execute_with_tracing

--- a/test/cluster/test_decommission_kill_then_replace.py
+++ b/test/cluster/test_decommission_kill_then_replace.py
@@ -11,7 +11,6 @@ from contextlib import suppress
 
 import pytest
 
-from test.cluster.conftest import skip_mode
 from test.cluster.util import (
     get_topology_coordinator,
     find_server_by_host_id,
@@ -25,7 +24,7 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.mark.asyncio
-@skip_mode('release', 'error injections are not supported in release mode')
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_decommission_kill_then_replace(manager: ManagerClient) -> None:
     """
     Boots a 3-node cluster, pauses the topology coordinator before processing backlog,

--- a/test/cluster/test_fencing.py
+++ b/test/cluster/test_fencing.py
@@ -12,7 +12,6 @@ from test.pylib.rest_client import ScyllaMetrics
 from test.pylib.tablets import get_all_tablet_replicas
 from cassandra.pool import Host # type: ignore # pylint: disable=no-name-in-module
 from cassandra.query import SimpleStatement
-from test.cluster.conftest import skip_mode
 from test.cluster.util import new_test_keyspace, reconnect_driver
 from test.pylib.scylla_cluster import ScyllaVersionDescription
 import pytest

--- a/test/cluster/test_gossip_boot.py
+++ b/test/cluster/test_gossip_boot.py
@@ -1,7 +1,6 @@
 import pytest
 
 from test.pylib.manager_client import ManagerClient
-from test.cluster.conftest import skip_mode
 
 @pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')

--- a/test/cluster/test_gossiper_empty_self_id_on_shadow_round.py
+++ b/test/cluster/test_gossiper_empty_self_id_on_shadow_round.py
@@ -10,7 +10,6 @@ import pytest
 import asyncio
 import logging
 
-from test.cluster.conftest import skip_mode
 from test.cluster.util import get_coordinator_host
 from test.pylib.manager_client import ManagerClient
 

--- a/test/cluster/test_gossiper_orphan_remover.py
+++ b/test/cluster/test_gossiper_orphan_remover.py
@@ -9,7 +9,6 @@ import time
 import pytest
 import logging
 from test.pylib.manager_client import ManagerClient
-from test.cluster.conftest import skip_mode
 
 logger = logging.getLogger(__name__)
 

--- a/test/cluster/test_gossiper_race.py
+++ b/test/cluster/test_gossiper_race.py
@@ -8,7 +8,6 @@
 from aiohttp import ServerDisconnectedError
 import pytest
 
-from test.cluster.conftest import skip_mode
 from test.cluster.util import get_coordinator_host
 from test.pylib.manager_client import ManagerClient
 

--- a/test/cluster/test_group0_recovers_after_partial_command_application.py
+++ b/test/cluster/test_group0_recovers_after_partial_command_application.py
@@ -7,7 +7,6 @@ import pytest
 
 from test.pylib.manager_client import ManagerClient
 from test.pylib.rest_client import inject_error
-from test.cluster.conftest import skip_mode
 from test.cluster.util import wait_for_cdc_generations_publishing
 
 import time

--- a/test/cluster/test_hints.py
+++ b/test/cluster/test_hints.py
@@ -20,7 +20,6 @@ from test.pylib.tablets import get_tablet_replicas
 from test.pylib.scylla_cluster import ReplaceConfig
 from test.pylib.util import wait_for
 
-from test.cluster.conftest import skip_mode
 from test.cluster.util import get_topology_coordinator, find_server_by_host_id, new_test_keyspace
 
 

--- a/test/cluster/test_incremental_repair.py
+++ b/test/cluster/test_incremental_repair.py
@@ -5,7 +5,6 @@
 #
 
 from test.pylib.manager_client import ManagerClient
-from test.cluster.conftest import skip_mode
 from test.pylib.repair import load_tablet_sstables_repaired_at, create_table_insert_data_for_repair
 from test.pylib.tablets import get_all_tablet_replicas
 from test.cluster.tasks.task_manager_client import TaskManagerClient

--- a/test/cluster/test_ip_mappings.py
+++ b/test/cluster/test_ip_mappings.py
@@ -12,7 +12,6 @@ from uuid import UUID
 from test.pylib.rest_client import inject_error_one_shot, read_barrier
 from test.pylib.scylla_cluster import ReplaceConfig
 from test.pylib.util import gather_safely
-from test.cluster.conftest import skip_mode
 from test.cluster.util import disable_schema_agreement_wait, new_test_keyspace, reconnect_driver
 
 from cassandra.cluster import ConsistencyLevel, SimpleStatement
@@ -51,7 +50,7 @@ async def test_broken_bootstrap(manager: ManagerClient):
 
 
 @pytest.mark.asyncio
-@skip_mode('release', 'error injections are not supported in release mode')
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 @pytest.mark.parametrize('reuse_ip', [False, True])
 async def test_full_shutdown_during_replace(manager: ManagerClient, reuse_ip: bool):
     """

--- a/test/cluster/test_long_query_timeout_erm.py
+++ b/test/cluster/test_long_query_timeout_erm.py
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
 from cassandra.policies import WhiteListRoundRobinPolicy
-from test.cluster.conftest import skip_mode
 from test.pylib.manager_client import ManagerClient
 from test.pylib.random_tables import RandomTables, Column, IntType
 from test.pylib.rest_client import inject_error_one_shot

--- a/test/cluster/test_lwt_semaphore.py
+++ b/test/cluster/test_lwt_semaphore.py
@@ -10,7 +10,6 @@ from test.pylib.rest_client import inject_error
 from test.pylib.util import wait_for_cql_and_get_hosts
 import pytest
 from cassandra.protocol import WriteTimeout
-from test.cluster.conftest import skip_mode
 from test.cluster.util import new_test_keyspace
 
 

--- a/test/cluster/test_major_compaction.py
+++ b/test/cluster/test_major_compaction.py
@@ -10,7 +10,6 @@ import asyncio
 
 from test.pylib.manager_client import ManagerClient
 from test.pylib.rest_client import inject_error_one_shot
-from test.cluster.conftest import skip_mode
 from test.cluster.util import new_test_keyspace, reconnect_driver
 
 logger = logging.getLogger(__name__)

--- a/test/cluster/test_node_shutdown_waits_for_pending_requests.py
+++ b/test/cluster/test_node_shutdown_waits_for_pending_requests.py
@@ -9,7 +9,6 @@ from cassandra.query import SimpleStatement # type: ignore
 from cassandra.cluster import ConsistencyLevel # type: ignore
 from cassandra.protocol import ReadTimeout # type: ignore
 from test.pylib.util import wait_for_cql_and_get_hosts
-from test.cluster.conftest import skip_mode
 from test.cluster.util import new_test_keyspace, reconnect_driver
 
 

--- a/test/cluster/test_nodetool.py
+++ b/test/cluster/test_nodetool.py
@@ -3,7 +3,6 @@ import asyncio
 import subprocess
 from test.pylib.manager_client import ManagerClient
 from test.pylib.util import wait_for_first_completed
-from test.cluster.conftest import skip_mode
 
 pytestmark = pytest.mark.prepare_3_nodes_cluster
 

--- a/test/cluster/test_raft_cluster_features.py
+++ b/test/cluster/test_raft_cluster_features.py
@@ -9,7 +9,6 @@ Tests that are specific to the raft-based cluster feature implementation.
 import asyncio
 import time
 
-from test.cluster.conftest import skip_mode
 from test.pylib.manager_client import ManagerClient
 from test.pylib.util import wait_for_cql_and_get_hosts, wait_for_feature
 from test.cluster import test_cluster_features

--- a/test/cluster/test_raft_fix_broken_snapshot.py
+++ b/test/cluster/test_raft_fix_broken_snapshot.py
@@ -13,7 +13,6 @@ from test.pylib.util import wait_for_cql_and_get_hosts
 from test.cluster.util import reconnect_driver, enter_recovery_state, \
         delete_raft_data_and_upgrade_state, wait_until_upgrade_finishes, \
         wait_for_token_ring_and_group0_consistency, new_test_keyspace
-from test.cluster.conftest import skip_mode
 
 
 logger = logging.getLogger(__name__)

--- a/test/cluster/test_raft_no_quorum.py
+++ b/test/cluster/test_raft_no_quorum.py
@@ -8,7 +8,6 @@ import logging
 import pytest
 import asyncio
 from test.pylib.manager_client import ManagerClient
-from test.cluster.conftest import skip_mode
 from test.pylib.rest_client import inject_error_one_shot, InjectionHandler, read_barrier
 from test.cluster.util import create_new_test_keyspace
 

--- a/test/cluster/test_raft_recovery_during_join.py
+++ b/test/cluster/test_raft_recovery_during_join.py
@@ -14,7 +14,6 @@ from test.pylib.internal_types import ServerInfo
 from test.pylib.manager_client import ManagerClient
 from test.pylib.rest_client import read_barrier
 from test.pylib.util import wait_for_cql_and_get_hosts
-from test.cluster.conftest import skip_mode
 from test.cluster.util import check_system_topology_and_cdc_generations_v3_consistency, \
         check_token_ring_and_group0_consistency, delete_discovery_state_and_group0_id, delete_raft_group_data, \
         reconnect_driver, wait_for_cdc_generations_publishing

--- a/test/cluster/test_raft_recovery_stuck.py
+++ b/test/cluster/test_raft_recovery_stuck.py
@@ -11,7 +11,6 @@ import time
 from test.pylib.manager_client import ManagerClient
 from test.pylib.random_tables import RandomTables
 from test.pylib.util import unique_name, wait_for_cql_and_get_hosts
-from test.cluster.conftest import skip_mode
 from test.cluster.util import (delete_raft_data_and_upgrade_state, enter_recovery_state, log_run_time,
                                reconnect_driver, wait_for_upgrade_state, wait_until_upgrade_finishes)
 

--- a/test/cluster/test_raft_voters.py
+++ b/test/cluster/test_raft_voters.py
@@ -14,7 +14,7 @@ from cassandra.policies import WhiteListRoundRobinPolicy
 from test.pylib.internal_types import ServerInfo
 from test.pylib.manager_client import ManagerClient
 from test.pylib.rest_client import read_barrier
-from test.cluster.conftest import cluster_con, skip_mode
+from test.cluster.conftest import cluster_con
 from test.cluster.util import get_coordinator_host_ids, get_current_group0_config
 
 

--- a/test/cluster/test_read_repair.py
+++ b/test/cluster/test_read_repair.py
@@ -18,7 +18,6 @@ from cassandra.pool import Host  # type: ignore
 from test.pylib.util import wait_for_cql_and_get_hosts, execute_with_tracing
 from test.pylib.internal_types import ServerInfo
 from test.pylib.manager_client import ManagerClient
-from test.cluster.conftest import skip_mode
 from test.cluster.util import new_test_keyspace
 
 

--- a/test/cluster/test_repair.py
+++ b/test/cluster/test_repair.py
@@ -17,7 +17,6 @@ from cassandra.query import SimpleStatement
 
 from test.pylib.manager_client import ManagerClient
 from test.pylib.util import wait_for_cql_and_get_hosts
-from test.cluster.conftest import skip_mode
 from test.cluster.util import new_test_keyspace
 
 

--- a/test/cluster/test_replica_exceptions.py
+++ b/test/cluster/test_replica_exceptions.py
@@ -8,7 +8,6 @@ from typing import Any, Callable, NamedTuple
 
 import pytest
 
-from test.cluster.conftest import skip_mode
 from test.pylib.manager_client import ManagerClient
 from test.pylib.repair import ServerInfo
 from test.pylib.rest_client import ScyllaMetrics, inject_error

--- a/test/cluster/test_resurrection.py
+++ b/test/cluster/test_resurrection.py
@@ -5,7 +5,6 @@
 #
 from test.pylib.manager_client import ManagerClient
 from test.pylib.tablets import get_tablet_replica
-from test.cluster.conftest import skip_mode
 import pytest
 import logging
 import asyncio

--- a/test/cluster/test_reversed_queries_during_simulated_upgrade_process.py
+++ b/test/cluster/test_reversed_queries_during_simulated_upgrade_process.py
@@ -7,7 +7,6 @@ from itertools import zip_longest
 
 from cassandra.query import SimpleStatement, ConsistencyLevel
 from test.pylib.manager_client import ManagerClient
-from test.cluster.conftest import skip_mode
 from test.cluster.util import new_test_keyspace
 
 

--- a/test/cluster/test_shutdown_hang.py
+++ b/test/cluster/test_shutdown_hang.py
@@ -15,7 +15,6 @@ from cassandra.protocol import WriteTimeout # type: ignore
 
 from test.pylib.manager_client import ManagerClient
 from test.cluster.util import wait_for_token_ring_and_group0_consistency, new_test_keyspace, reconnect_driver
-from test.cluster.conftest import skip_mode
 
 
 logger = logging.getLogger(__name__)

--- a/test/cluster/test_size_based_load_balancing.py
+++ b/test/cluster/test_size_based_load_balancing.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
 #
 from test.pylib.manager_client import ManagerClient
-from test.cluster.conftest import skip_mode
 from test.cluster.util import new_test_keyspace
 from collections import defaultdict
 import pytest

--- a/test/cluster/test_sstable_cleanup_stop.py
+++ b/test/cluster/test_sstable_cleanup_stop.py
@@ -6,7 +6,6 @@
 
 from test.pylib.manager_client import ManagerClient
 from test.pylib.rest_client import inject_error_one_shot
-from test.cluster.conftest import skip_mode
 from test.cluster.util import check_token_ring_and_group0_consistency, new_test_keyspace
 
 import pytest

--- a/test/cluster/test_sstable_set.py
+++ b/test/cluster/test_sstable_set.py
@@ -10,7 +10,6 @@ import logging
 from test.pylib.manager_client import ManagerClient
 from test.pylib.util import wait_for_cql_and_get_hosts
 from test.cluster.util import create_new_test_keyspace
-from test.cluster.conftest import skip_mode
 
 logger = logging.getLogger(__name__)
 

--- a/test/cluster/test_table_desc_read_barrier.py
+++ b/test/cluster/test_table_desc_read_barrier.py
@@ -9,7 +9,6 @@ import pytest
 
 from test.pylib.manager_client import ManagerClient
 from test.pylib.rest_client import inject_error, read_barrier
-from test.cluster.conftest import skip_mode
 from test.cluster.util import new_test_keyspace
 
 

--- a/test/cluster/test_tablet_repair_scheduler.py
+++ b/test/cluster/test_tablet_repair_scheduler.py
@@ -7,7 +7,6 @@
 from test.pylib.internal_types import ServerInfo
 from test.pylib.manager_client import ManagerClient
 from test.pylib.util import wait_for_cql_and_get_hosts, Host
-from test.cluster.conftest import skip_mode
 from test.pylib.repair import load_tablet_repair_time, create_table_insert_data_for_repair, create_table_insert_data_for_repair_multiple_rows, get_tablet_task_id, load_tablet_repair_task_infos
 from test.pylib.rest_client import inject_error_one_shot, read_barrier
 from test.cluster.util import create_new_test_keyspace
@@ -107,19 +106,19 @@ async def do_test_tablet_repair_progress_split_merge(manager: ManagerClient, do_
     await inject_error_off(manager, "tablet_repair_skip_sched", servers)
     await wait_task_progress(nr_tablets, nr_tablets)
 
-@skip_mode('release', 'error injections are not supported in release mode')
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 @pytest.mark.asyncio
 async def test_tablet_repair_progress(manager: ManagerClient):
     await do_test_tablet_repair_progress_split_merge(manager, do_split=False, do_merge=False)
 
-@skip_mode('release', 'error injections are not supported in release mode')
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 @pytest.mark.asyncio
 async def test_tablet_repair_progress_split(manager: ManagerClient):
     await do_test_tablet_repair_progress_split_merge(manager, do_split=True)
 
 @pytest.mark.asyncio
 @pytest.mark.skip(reason="https://github.com/scylladb/scylladb/issues/26844")
-@skip_mode('release', 'error injections are not supported in release mode')
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tablet_repair_progress_merge(manager: ManagerClient):
     await do_test_tablet_repair_progress_split_merge(manager, do_merge=True)
 
@@ -509,7 +508,7 @@ async def config_auto_repair(manager, servers, ks, table, auto_repair_enabled, a
         raise NotImplementedError("Per-table auto-repair configuration is not supported yet.")
 
 @pytest.mark.asyncio
-@skip_mode('release', 'error injections are not supported in release mode')
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tablet_auto_repair(manager: ManagerClient):
     servers, cql, hosts, ks, table_id = await create_table_insert_data_for_repair(manager, fast_stats_refresh=True, disable_flush_cache_time=True)
 
@@ -646,7 +645,7 @@ def verify_sort_order(plans):
     return is_sorted
 
 @pytest.mark.asyncio
-@skip_mode('release', 'error injections are not supported in release mode')
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tablet_user_and_auto_repair_priority(manager: ManagerClient):
     servers, cql, hosts, ks, table_id = await create_table_insert_data_for_repair(manager, fast_stats_refresh=True, disable_flush_cache_time=True)
 

--- a/test/cluster/test_tablet_stats.py
+++ b/test/cluster/test_tablet_stats.py
@@ -3,7 +3,6 @@
 #
 # SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
 #
-from test.cluster.conftest import skip_mode
 from test.pylib.manager_client import ManagerClient
 from test.cluster.util import get_topology_coordinator, trigger_stepdown
 

--- a/test/cluster/test_tablets.py
+++ b/test/cluster/test_tablets.py
@@ -16,7 +16,6 @@ from test.pylib.rest_client import HTTPError, read_barrier
 from test.pylib.scylla_cluster import ReplaceConfig
 from test.pylib.tablets import get_tablet_replica, get_all_tablet_replicas
 from test.pylib.util import unique_name, wait_for, wait_for_first_completed
-from test.cluster.conftest import skip_mode
 from test.cluster.util import wait_for_cql_and_get_hosts, create_new_test_keyspace, new_test_keyspace, reconnect_driver, \
     get_topology_coordinator, parse_replication_options, get_replication, get_replica_count, find_server_by_host_id
 from contextlib import nullcontext as does_not_raise
@@ -1684,7 +1683,7 @@ async def test_moving_replica_within_single_rack(manager: ManagerClient):
         token=tablet_token)
 
 @pytest.mark.asyncio
-@skip_mode('release', 'error injections are not supported in release mode')
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_disabling_balancing_preempts_balancer(manager: ManagerClient):
     servers = await manager.servers_add(2, auto_rack_dc="dc1")
     coord_srv = servers[0]

--- a/test/cluster/test_tablets2.py
+++ b/test/cluster/test_tablets2.py
@@ -12,7 +12,6 @@ from test.pylib.manager_client import ManagerClient
 from test.pylib.rest_client import inject_error_one_shot, HTTPError, read_barrier
 from test.pylib.util import wait_for_cql_and_get_hosts, unique_name, wait_for
 from test.pylib.tablets import get_tablet_replica, get_all_tablet_replicas, get_tablet_count, TabletReplicas
-from test.cluster.conftest import skip_mode
 from test.cluster.util import reconnect_driver, create_new_test_keyspace, new_test_keyspace
 from test.cqlpy.cassandra_tests.validation.entities.secondary_index_test import dotestCreateAndDropIndex
 

--- a/test/cluster/test_tablets_colocation.py
+++ b/test/cluster/test_tablets_colocation.py
@@ -8,7 +8,6 @@ from test.pylib.manager_client import ManagerClient
 from test.pylib.rest_client import inject_error_one_shot, read_barrier
 from test.pylib.tablets import get_tablet_replica, get_base_table, get_tablet_count, get_tablet_info
 from test.pylib.util import wait_for, wait_for_cql_and_get_hosts, wait_for_view
-from test.cluster.conftest import skip_mode
 from test.cluster.util import new_test_keyspace, new_test_table, new_materialized_view
 import time
 import pytest

--- a/test/cluster/test_tablets_cql.py
+++ b/test/cluster/test_tablets_cql.py
@@ -11,7 +11,6 @@ from cassandra.protocol import InvalidRequest
 
 from test.pylib.manager_client import ManagerClient
 from test.pylib.rest_client import inject_error_one_shot
-from test.cluster.conftest import skip_mode
 from test.cluster.util import disable_schema_agreement_wait, parse_replication_options, create_new_test_keyspace, \
     new_test_keyspace, get_replication
 

--- a/test/cluster/test_tablets_intranode.py
+++ b/test/cluster/test_tablets_intranode.py
@@ -8,7 +8,6 @@ from cassandra.cluster import Session, ConsistencyLevel
 from test.pylib.manager_client import ManagerClient
 from test.pylib.util import wait_for_cql_and_get_hosts, start_writes
 from test.pylib.tablets import get_tablet_replica, get_all_tablet_replicas
-from test.cluster.conftest import skip_mode
 from test.cluster.util import new_test_keyspace
 
 

--- a/test/cluster/test_tablets_lwt.py
+++ b/test/cluster/test_tablets_lwt.py
@@ -15,7 +15,6 @@ from test.cluster.lwt.lwt_common import wait_for_tablet_count
 from test.cluster.util import new_test_keyspace, unique_name, reconnect_driver
 from test.pylib.manager_client import ManagerClient
 from test.pylib.util import wait_for_cql_and_get_hosts
-from test.cluster.conftest import skip_mode
 from test.pylib.internal_types import ServerInfo
 from test.pylib.tablets import get_all_tablet_replicas
 from test.pylib.scylla_cluster import ReplaceConfig

--- a/test/cluster/test_tablets_merge.py
+++ b/test/cluster/test_tablets_merge.py
@@ -9,7 +9,6 @@ from test.pylib.manager_client import ManagerClient
 from test.pylib.rest_client import inject_error_one_shot, read_barrier
 from test.pylib.tablets import get_tablet_replica, get_all_tablet_replicas, get_tablet_count
 from test.pylib.util import wait_for
-from test.cluster.conftest import skip_mode
 from test.cluster.util import new_test_keyspace, create_new_test_keyspace
 
 import pytest

--- a/test/cluster/test_tablets_migration.py
+++ b/test/cluster/test_tablets_migration.py
@@ -10,7 +10,6 @@ from test.pylib.manager_client import ManagerClient
 from test.pylib.rest_client import HTTPError, read_barrier
 from test.pylib.tablets import get_tablet_replica, get_all_tablet_replicas, get_tablet_info
 from test.pylib.util import start_writes
-from test.cluster.conftest import skip_mode
 from test.cluster.util import wait_for_cql_and_get_hosts, new_test_keyspace, reconnect_driver, wait_for
 import time
 import pytest

--- a/test/cluster/test_tombstone_gc.py
+++ b/test/cluster/test_tombstone_gc.py
@@ -14,7 +14,6 @@ import pytest
 from test.pylib.internal_types import ServerInfo
 from test.pylib.manager_client import ManagerClient
 from test.pylib.util import wait_for, wait_for_cql_and_get_hosts
-from test.cluster.conftest import skip_mode
 from test.cluster.util import delete_discovery_state_and_group0_id, delete_raft_group_data, disable_schema_agreement_wait, new_test_keyspace, new_test_table, reconnect_driver
 
 logger = logging.getLogger(__name__)

--- a/test/cluster/test_topology_failure_recovery.py
+++ b/test/cluster/test_topology_failure_recovery.py
@@ -6,7 +6,6 @@
 from test.pylib.manager_client import ManagerClient
 from test.pylib.internal_types import ServerInfo
 from test.pylib.scylla_cluster import ReplaceConfig
-from test.cluster.conftest import skip_mode
 from test.cluster.util import new_test_keyspace
 import pytest
 import logging

--- a/test/cluster/test_topology_ops_with_rf_rack_valid.py
+++ b/test/cluster/test_topology_ops_with_rf_rack_valid.py
@@ -3,7 +3,6 @@
 #
 # SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
 #
-from test.cluster.conftest import skip_mode
 from test.pylib.manager_client import ManagerClient
 
 
@@ -17,7 +16,7 @@ logger = logging.getLogger(__name__)
 
 @pytest.mark.parametrize("enforce", [True, False])
 @pytest.mark.asyncio
-@skip_mode('release', 'error injections are not supported in release mode')
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_add_node_in_new_rack_violating_rf_rack(manager: ManagerClient, enforce: bool):
     """
     Test adding a node to a new rack when it would violate RF-rack constraints.
@@ -63,7 +62,7 @@ async def test_add_node_in_new_rack_violating_rf_rack(manager: ManagerClient, en
 @pytest.mark.parametrize("enforce", [True, False])
 @pytest.mark.parametrize("op", ["remove", "decommission"])
 @pytest.mark.asyncio
-@skip_mode('release', 'error injections are not supported in release mode')
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_remove_node_violating_rf_rack(manager: ManagerClient, enforce: bool, op: str):
     """
     Test removing a node when it would violate RF-rack constraints.
@@ -122,7 +121,7 @@ async def test_remove_node_violating_rf_rack(manager: ManagerClient, enforce: bo
 
 @pytest.mark.parametrize("injection", ["before_bootstrap", "after_bootstrap"])
 @pytest.mark.asyncio
-@skip_mode('release', 'error injections are not supported in release mode')
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_keyspace_creation_during_node_join(manager: ManagerClient, injection: str):
     """
     Test keyspace creation behavior during node join at different stages.
@@ -231,7 +230,7 @@ async def test_keyspace_creation_during_node_join(manager: ManagerClient, inject
 
 @pytest.mark.parametrize("op", ["remove", "decommission"])
 @pytest.mark.asyncio
-@skip_mode('release', 'error injections are not supported in release mode')
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_keyspace_creation_during_node_remove(manager: ManagerClient, op: str):
     """
     Test keyspace creation behavior during node removal or decommission.

--- a/test/cluster/test_topology_remove_decom.py
+++ b/test/cluster/test_topology_remove_decom.py
@@ -11,7 +11,6 @@ import asyncio
 import random
 import time
 from test import pylib
-from test.cluster.conftest import skip_mode
 from test.pylib.util import wait_for
 from test.pylib.manager_client import ManagerClient
 from test.pylib.random_tables import RandomTables

--- a/test/cluster/test_topology_upgrade_not_stuck_after_recent_removal.py
+++ b/test/cluster/test_topology_upgrade_not_stuck_after_recent_removal.py
@@ -12,7 +12,6 @@ import time
 from test.pylib.manager_client import ManagerClient
 from test.pylib.rest_client import inject_error
 from test.pylib.util import wait_for_cql_and_get_hosts
-from test.cluster.conftest import skip_mode
 from test.cluster.util import wait_until_topology_upgrade_finishes, \
         wait_for_cdc_generations_publishing, \
         check_system_topology_and_cdc_generations_v3_consistency

--- a/test/cluster/test_topology_upgrade_stuck.py
+++ b/test/cluster/test_topology_upgrade_stuck.py
@@ -15,7 +15,6 @@ from test.pylib.log_browsing import ScyllaLogFile
 from test.pylib.manager_client import ManagerClient
 from test.pylib.scylla_cluster import gather_safely
 from test.pylib.util import wait_for_cql_and_get_hosts, wait_for_first_completed
-from test.cluster.conftest import skip_mode
 from test.cluster.util import reconnect_driver, enter_recovery_state, \
         delete_raft_data_and_upgrade_state, log_run_time, wait_until_upgrade_finishes as wait_until_schema_upgrade_finishes, \
         wait_until_topology_upgrade_finishes, delete_raft_topology_state, wait_for_cdc_generations_publishing, \

--- a/test/cluster/test_truncate_concurrent_writes.py
+++ b/test/cluster/test_truncate_concurrent_writes.py
@@ -6,7 +6,6 @@
 
 from test.pylib.manager_client import ManagerClient
 from test.pylib.rest_client import inject_error_one_shot, read_barrier
-from test.cluster.conftest import skip_mode
 from test.cluster.util import create_new_test_keyspace
 from cassandra.query import SimpleStatement, ConsistencyLevel
 

--- a/test/cluster/test_truncate_with_tablets.py
+++ b/test/cluster/test_truncate_with_tablets.py
@@ -8,7 +8,6 @@ from cassandra.protocol import InvalidRequest
 from cassandra.cluster import TruncateError
 from cassandra.policies import FallthroughRetryPolicy
 from test.pylib.manager_client import ManagerClient
-from test.cluster.conftest import skip_mode
 from test.cluster.util import get_topology_coordinator, new_test_keyspace
 from test.pylib.tablets import get_all_tablet_replicas
 from test.pylib.util import wait_for_cql_and_get_hosts

--- a/test/cluster/test_unfinished_writes_during_shutdown.py
+++ b/test/cluster/test_unfinished_writes_during_shutdown.py
@@ -19,7 +19,6 @@ from test.cluster.test_tablets2 import inject_error_on
 from test.pylib.scylla_cluster import ReplaceConfig
 from test.cluster.util import get_topology_coordinator
 from cassandra.cluster import ConnectionException, NoHostAvailable  # type: ignore
-from test.cluster.conftest import skip_mode
 
 logger = logging.getLogger(__name__)
 

--- a/test/cluster/test_view_build_status.py
+++ b/test/cluster/test_view_build_status.py
@@ -13,7 +13,6 @@ from test.pylib.scylla_cluster import ReplaceConfig
 from test.pylib.internal_types import ServerInfo
 from test.cluster.util import trigger_snapshot, wait_until_topology_upgrade_finishes, enter_recovery_state, reconnect_driver, \
         delete_raft_topology_state, delete_raft_data_and_upgrade_state, wait_until_upgrade_finishes, wait_for, create_new_test_keyspace
-from test.cluster.conftest import skip_mode
 from cassandra import ConsistencyLevel
 from cassandra.query import SimpleStatement
 from cassandra.protocol import InvalidRequest

--- a/test/cluster/test_view_building_coordinator.py
+++ b/test/cluster/test_view_building_coordinator.py
@@ -12,7 +12,6 @@ import time
 import logging
 import re
 
-from test.cluster.conftest import skip_mode
 from test.pylib.util import wait_for_view, wait_for_first_completed, gather_safely, wait_for
 from test.pylib.internal_types import ServerInfo, HostID
 from test.pylib.tablets import get_all_tablet_replicas, get_tablet_replica, get_tablet_replicas, get_tablet_count

--- a/test/cluster/test_write_query_during_cql_server_shutdown.py
+++ b/test/cluster/test_write_query_during_cql_server_shutdown.py
@@ -15,7 +15,6 @@ from test.pylib.util import wait_for_cql_and_get_hosts
 from test.cluster.util import new_test_keyspace
 from test.cluster.test_tablets2 import inject_error_on
 from cassandra.cluster import ConnectionException, NoHostAvailable  # type: ignore
-from test.cluster.conftest import skip_mode
 
 logger = logging.getLogger(__name__)
 

--- a/test/cluster/test_writes_to_previous_cdc_generations.py
+++ b/test/cluster/test_writes_to_previous_cdc_generations.py
@@ -5,7 +5,6 @@
 #
 from test.pylib.manager_client import ManagerClient, ServerInfo
 from test.pylib.util import wait_for, wait_for_cql_and_get_hosts
-from test.cluster.conftest import skip_mode
 
 from cassandra.cluster import ConsistencyLevel, NoHostAvailable, Session
 from cassandra.protocol import InvalidRequest

--- a/test/storage/test_out_of_space_prevention.py
+++ b/test/storage/test_out_of_space_prevention.py
@@ -15,7 +15,6 @@ from cassandra.cluster import ConsistencyLevel
 from cassandra.query import SimpleStatement
 from typing import Callable
 
-from test.cluster.conftest import skip_mode
 from test.cluster.util import get_topology_coordinator, find_server_by_host_id, new_test_keyspace, new_test_table
 from test.pylib.manager_client import ManagerClient
 from test.pylib.tablets import get_tablet_count


### PR DESCRIPTION
Finishing the deprecation of the skip_mode function in favor of pytest.mark.skip_mode. This PR is only cleaning and migrating leftover tests that are still used and old way of skip_mode.

No backport needed, because it's only framework enhancement.