### PR TITLE
dist: scylla_coredump_setup: force unmount /var/lib/systemd/coredump before setup

### DIFF
--- a/dist/common/scripts/scylla_coredump_setup
+++ b/dist/common/scripts/scylla_coredump_setup
@@ -114,6 +114,10 @@ WantedBy=local-fs.target scylla-server.service
 '''[1:-1]
             with open('/etc/systemd/system/var-lib-systemd-coredump.mount', 'w') as f:
                 f.write(dot_mount)
+            # in case we have old mounts in deleted state hanging around from older installation
+            # systemd doesn't seem to be able to deal with those properly, and assume they are still active
+            # and doesn't do anything about them
+            run('umount  /var/lib/systemd/coredump', shell=True, check=False)
             os.makedirs('/var/lib/scylla/coredump', exist_ok=True)
             systemd_unit.reload()
             systemd_unit('var-lib-systemd-coredump.mount').enable()


### PR DESCRIPTION
When setting up coredump handling, if there are old mounts in a deleted state (e.g. from an older installation), systemd might fail to activate the new `.mount` unit properly because it assumes the path is already mounted.

Explicitly unmount `/var/lib/systemd/coredump` before proceeding with the setup to ensure a clean state.

Fixes: scylladb/scylla-enterprise#5692

We should backport this to all of the live releases, since this is affecting upgrades from 2024.1/2024.2 to any  of them 