### PR TITLE
vector_search: test: Fix flaky vector_store_client_https_rewrite_ca_cert

### DIFF
--- a/test/vector_search/vector_store_client_test.cc
+++ b/test/vector_search/vector_store_client_test.cc
@@ -986,6 +986,7 @@ SEASTAR_TEST_CASE(vector_store_client_https_rewrite_ca_cert) {
     auto cfg = make_config();
     cfg.db_config->vector_store_primary_uri.set(format("https://{}:{}", certs.server_cert_cn(), server->port()));
     cfg.db_config->vector_store_encryption_options.set({{"truststore", broken_cert.get_path().string()}});
+    cfg.db_config->request_timeout_in_ms.set(1000); // 1 seconds
     co_await do_with_cql_env(
             [&](cql_test_env& env) -> future<> {
                 co_await create_test_table(env, "ks", "idx");


### PR DESCRIPTION
The vector_store_client_https_rewrite_ca_cert test occasionally fails because ANN requests can hang for up to 60 seconds.

Since the test logic expects to recover within a 10-second retry window after a certificate rewrite, these long hangs trigger an overall test timeout. Setting a 1-second request timeout allows the client to fail fast and proceed to the next retry attempt, ensuring test stability.

Fixes: #28012

A backport to 2025.4 is needed as this test is also present in that branch, which could cause flaky test results there as well.