### PR TITLE
Add vector search documentation links to CQL docs

### DIFF
--- a/docs/cql/dml/select.rst
+++ b/docs/cql/dml/select.rst
@@ -241,8 +241,8 @@ Currently, the possible orderings are limited by the :ref:`clustering order <clu
 
 .. _vector-queries:
 
-Vector queries
-~~~~~~~~~~~~~~
+Vector queries :label-note:`ScyllaDB Cloud`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The ``ORDER BY`` clause can also be used with vector columns to perform the approximate nearest neighbor (ANN) search. 
 When using vector columns, the syntax is as follows:
@@ -293,10 +293,12 @@ The supported operations are equal relations (``=`` and ``IN``) with restriction
 
 Other filtering scenarios are currently not supported.
 
-.. warning:: 
+.. note::
 
-  Currently, vector queries do not support grouping with ``GROUP BY`` and paging. This will be added in the future releases.
-
+   Vector indexes are supported in ScyllaDB Cloud only in clusters that have the Vector Search feature enabled.
+   Vector indexes do not support all ScyllaDB features (e.g., tracing, TTL, paging, and grouping). More information
+   about Vector Search is available in the
+   `ScyllaDB Cloud documentation <https://cloud.docs.scylladb.com/stable/vector-search/>`_.
 
 .. _limit-clause:
 

--- a/docs/cql/secondary-indexes.rst
+++ b/docs/cql/secondary-indexes.rst
@@ -129,17 +129,15 @@ More on :doc:`Local Secondary Indexes </features/local-secondary-indexes>`
 
 .. _create-vector-index-statement:
 
-Vector Index :label-caution:`Experimental` :label-note:`ScyllaDB Cloud`
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Vector Index :label-note:`ScyllaDB Cloud`
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. note::
 
-   Vector indexes are supported in ScyllaDB Cloud only in the clusters that have the vector search feature enabled.
-   Moreover, vector indexes are an experimental feature that:
-   
-     * is not suitable for production use,
-     * does not guarantee backward compatibility between ScyllaDB versions,
-     * does not support all the features of ScyllaDB (e.g., tracing, TTL).
+   Vector indexes are supported in ScyllaDB Cloud only in clusters that have the Vector Search feature enabled.
+   Vector indexes do not support all ScyllaDB features (e.g., tracing, TTL, paging, and grouping). More information
+   about Vector Search is available in the
+   `ScyllaDB Cloud documentation <https://cloud.docs.scylladb.com/stable/vector-search/>`_.
 
 ScyllaDB supports creating vector indexes on tables, allowing queries on the table to use those indexes for efficient
 similarity search on vector data. 

--- a/docs/cql/types.rst
+++ b/docs/cql/types.rst
@@ -665,6 +665,14 @@ it is not possible to update only some elements of a vector (without updating th
 Types stored in a vector are not implicitly frozen, so if you want to store a frozen collection or
 frozen UDT in a vector, you need to explicitly wrap them using `frozen` keyword.
 
+.. note::
+
+   The main application of vectors is to support vector search capabilities, which
+   are supported in ScyllaDB Cloud only in clusters that have the Vector Search feature enabled.
+   Note that Vector Search clusters do not support all ScyllaDB features (e.g., tracing, TTL, paging, and grouping). More information
+   about Vector Search is available in the
+   `ScyllaDB Cloud documentation <https://cloud.docs.scylladb.com/stable/vector-search/>`_.
+
 .. .. _custom-types:
 
 .. Custom Types


### PR DESCRIPTION
This patch adds links to the Vector Search documentation that is hosted together with Scylla Cloud docs to the CQL documentation. It also make the note about supported capabilities consistent and removes the experimental label as the feature is GAed.

Fixes: SCYLLADB-371

Backport: 2025.4 as it is already GAed in this version and experimental label should be removed.