### PR TITLE
test: Remove useless compaction group testing in database_test

### DIFF
--- a/test.py
+++ b/test.py
@@ -252,8 +252,6 @@ def parse_cmd_line() -> argparse.Namespace:
                         default=None, dest="pytest_arg",
                         help="Additional command line arguments to pass to pytest, for example ./test.py --pytest-arg=\"-v -x\"")
     scylla_additional_options = parser.add_argument_group('Additional options for Scylla tests')
-    scylla_additional_options.add_argument('--x-log2-compaction-groups', action="store", default="0", type=int,
-                             help="Controls number of compaction groups to be used by Scylla tests. Value of 3 implies 8 groups.")
     scylla_additional_options.add_argument('--extra-scylla-cmdline-options', action="store", default="", type=str,
                                            help="Passing extra scylla cmdline options for all tests. Options should be space separated:"
                                                 "'--logger-log-level raft=trace --default-log-level error'")
@@ -364,8 +362,6 @@ def run_pytest(options: argparse.Namespace) -> tuple[int, list[SimpleNamespace]]
         args.extend(shlex.split(options.pytest_arg))
     if options.random_seed:
         args.append(f'--random-seed={options.random_seed}')
-    if options.x_log2_compaction_groups:
-        args.append(f'--x-log2-compaction-groups={options.x_log2_compaction_groups}')
     if options.gather_metrics:
         args.append('--gather-metrics')
     if options.timeout:

--- a/test/lib/test_services.cc
+++ b/test/lib/test_services.cc
@@ -637,8 +637,7 @@ std::pair<int, char**> scylla_tests_cmdline_options_processor::process_cmdline_o
 
     po::options_description desc("Scylla tests additional options");
     desc.add_options()
-            ("help", "Produces help message")
-            ("x-log2-compaction-groups", po::value<unsigned>()->default_value(0), "Controls static number of compaction groups per table per shard. For X groups, set the option to log (base 2) of X. Example: Value of 3 implies 8 groups.");
+            ("help", "Produces help message");
     po::variables_map vm;
 
     po::parsed_options parsed = po::command_line_parser(new_argc, new_argv).
@@ -652,14 +651,6 @@ std::pair<int, char**> scylla_tests_cmdline_options_processor::process_cmdline_o
     if (vm.count("help")) {
         std::cout << desc << std::endl;
         return std::make_pair(argc, argv);
-    }
-
-    unsigned x_log2_compaction_groups = vm["x-log2-compaction-groups"].as<unsigned>();
-    if (x_log2_compaction_groups) {
-        std::cout << "Setting x_log2_compaction_groups to " << x_log2_compaction_groups << std::endl;
-        // TODO: perhaps we can later map it into initial_tablets.
-        auto [_new_argc, _new_argv] = rebuild_arg_list_without(argc, argv, "--x-log2-compaction-groups", true);
-        return std::make_pair(_new_argc, _new_argv);
     }
 
     return std::make_pair(argc, argv);


### PR DESCRIPTION
This compaction group testing is useless because the machinery for it to work was removed. This was useful in the early tablet days, where we wanted to test compaction groups directly. Today groups are stressed and tested on every tablet test.

I see a ~40% reduction time after this patch, since database_test is one of the most (if not the most) time consuming in boost suite.

Not a regression, so not backporting.