### PR TITLE
test/cqlpy: restore LWT tests marked XFAIL for tablets

### DIFF
--- a/test/cqlpy/cassandra_tests/validation/entities/secondary_index_test.py
+++ b/test/cqlpy/cassandra_tests/validation/entities/secondary_index_test.py
@@ -96,9 +96,8 @@ def dotestCreateAndDropIndex(cql, table, indexName, addKeyspaceOnDrop):
         f"DROP INDEX {KEYSPACE}.{indexName}")
 
 @pytest.fixture(scope="module")
-# FIXME: LWT is not supported with tablets yet. See #18066
-def table1(cql, test_keyspace_vnodes):
-    with create_table(cql, test_keyspace_vnodes, "(a int primary key, b int)") as table:
+def table1(cql, test_keyspace):
+    with create_table(cql, test_keyspace, "(a int primary key, b int)") as table:
         yield table
 
 # Reproduces #8717 (CREATE INDEX IF NOT EXISTS was broken):
@@ -454,7 +453,7 @@ TOO_BIG = 1024 * 65
 # Reproduces #8627
 @pytest.mark.xfail(reason="issue #8627")
 @pytest.mark.parametrize("test_keyspace",
-                         [pytest.param("tablets", marks=[pytest.mark.xfail(reason="issue #18066")]), "vnodes"],
+                         ["tablets", "vnodes"],
                          indirect=True)
 def testIndexOnCompositeValueOver64k(cql, test_keyspace):
     too_big = bytearray([1])*TOO_BIG
@@ -476,7 +475,7 @@ def testIndexOnCompositeValueOver64k(cql, test_keyspace):
                    too_big)
 
 @pytest.mark.parametrize("test_keyspace",
-                         [pytest.param("tablets", marks=[pytest.mark.xfail(reason="issue #18066")]), "vnodes"],
+                         ["tablets", "vnodes"],
                          indirect=True)
 def testIndexOnPartitionKeyInsertValueOver64k(cql, test_keyspace):
     too_big = bytearray([1])*TOO_BIG
@@ -533,7 +532,7 @@ def testIndexOnPartitionKeyWithStaticColumnAndNoRows(cql, test_keyspace):
         assert_rows(execute(cql, table, "SELECT * FROM %s WHERE pk2 = ?", 20), [1, 20, None, 9, None])
 
 @pytest.mark.parametrize("test_keyspace",
-                         [pytest.param("tablets", marks=[pytest.mark.xfail(reason="issue #18066")]), "vnodes"],
+                         ["tablets", "vnodes"],
                          indirect=True)
 def testIndexOnClusteringColumnInsertValueOver64k(cql, test_keyspace):
     too_big = bytearray([1])*TOO_BIG
@@ -568,7 +567,7 @@ def testIndexOnClusteringColumnInsertValueOver64k(cql, test_keyspace):
 # Reproduces #8627
 @pytest.mark.xfail(reason="issue #8627")
 @pytest.mark.parametrize("test_keyspace",
-                         [pytest.param("tablets", marks=[pytest.mark.xfail(reason="issue #18066")]), "vnodes"],
+                         ["tablets", "vnodes"],
                          indirect=True)
 def testIndexOnFullCollectionEntryInsertCollectionValueOver64k(cql, test_keyspace):
     too_big = bytearray([1])*TOO_BIG

--- a/test/cqlpy/cassandra_tests/validation/entities/timestamp_test.py
+++ b/test/cqlpy/cassandra_tests/validation/entities/timestamp_test.py
@@ -62,7 +62,7 @@ def testTimestampTTL(cql, test_keyspace):
 
 # Migrated from cql_tests.py:TestCQL.invalid_custom_timestamp_test()
 @pytest.mark.parametrize("test_keyspace",
-                         [pytest.param("tablets", marks=[pytest.mark.xfail(reason="issue #18066")]), "vnodes"],
+                         ["tablets", "vnodes"],
                          indirect=True)
 def testInvalidCustomTimestamp(cql, test_keyspace):
     # Conditional updates

--- a/test/cqlpy/cassandra_tests/validation/operations/compact_storage_test.py
+++ b/test/cqlpy/cassandra_tests/validation/operations/compact_storage_test.py
@@ -1239,7 +1239,7 @@ def testInsertWithCompactStorageAndTwoClusteringColumns(cql, test_keyspace, forc
 # Test for CAS with compact storage table, and CASSANDRA-6813 in particular,
 # migrated from cql_tests.py:TestCQL.cas_and_compact_test()
 @pytest.mark.parametrize("test_keyspace",
-                         [pytest.param("tablets", marks=[pytest.mark.xfail(reason="issue #18066")]), "vnodes"],
+                         ["tablets", "vnodes"],
                          indirect=True)
 def testCompactStorage(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(partition text, key text, owner text, PRIMARY KEY (partition, key)) WITH COMPACT STORAGE") as table:

--- a/test/cqlpy/cassandra_tests/validation/operations/insert_update_if_condition_collections_test.py
+++ b/test/cqlpy/cassandra_tests/validation/operations/insert_update_if_condition_collections_test.py
@@ -28,7 +28,7 @@ def is_scylla(cql):
     yield any('scylla' in name for name in names)
 
 @pytest.mark.parametrize("test_keyspace",
-                         [pytest.param("tablets", marks=[pytest.mark.xfail(reason="issue #18066")]), "vnodes"],
+                         ["tablets", "vnodes"],
                          indirect=True)
 def testInsertSetIfNotExists(cql, test_keyspace, is_scylla):
     with create_table(cql, test_keyspace, "(k int PRIMARY KEY, s set<int>)") as table:
@@ -478,7 +478,7 @@ def check_invalid_list(cql, table, condition, expected):
 
 # Migrated from cql_tests.py:TestCQL.list_item_conditional_test()
 @pytest.mark.parametrize("test_keyspace",
-                         [pytest.param("tablets", marks=[pytest.mark.xfail(reason="issue #18066")]), "vnodes"],
+                         ["tablets", "vnodes"],
                          indirect=True)
 def testListItem(cql, test_keyspace):
     for frozen in [False, True]:   
@@ -505,7 +505,7 @@ def testListItem(cql, test_keyspace):
 # Test expanded functionality from CASSANDRA-6839,
 # migrated from cql_tests.py:TestCQL.expanded_list_item_conditional_test()
 @pytest.mark.parametrize("test_keyspace",
-                         [pytest.param("tablets", marks=[pytest.mark.xfail(reason="issue #18066")]), "vnodes"],
+                         ["tablets", "vnodes"],
                          indirect=True)
 def testExpandedListItem(cql, test_keyspace):
     for frozen in [False, True]:   
@@ -682,7 +682,7 @@ def testWholeMap(cql, test_keyspace):
 
 # Migrated from cql_tests.py:TestCQL.map_item_conditional_test()
 @pytest.mark.parametrize("test_keyspace",
-                         [pytest.param("tablets", marks=[pytest.mark.xfail(reason="issue #18066")]), "vnodes"],
+                         ["tablets", "vnodes"],
                          indirect=True)
 def testMapItem(cql, test_keyspace):
     for frozen in [False, True]:   
@@ -711,7 +711,7 @@ def testMapItem(cql, test_keyspace):
                 assert list(execute(cql, table, "UPDATE %s set m['foo'] = 'bar', m['bar'] = 'foo' WHERE k = 1 IF m[?] IN (?, ?)", "foo", "blah", None))[0][0] == True
 
 @pytest.mark.parametrize("test_keyspace",
-                         [pytest.param("tablets", marks=[pytest.mark.xfail(reason="issue #18066")]), "vnodes"],
+                         ["tablets", "vnodes"],
                          indirect=True)
 def testFrozenWithNullValues(cql, test_keyspace):
     with create_table(cql, test_keyspace, f"(k int PRIMARY KEY, m frozen<list<text>>)") as table:
@@ -732,7 +732,7 @@ def testFrozenWithNullValues(cql, test_keyspace):
 # Test expanded functionality from CASSANDRA-6839,
 # migrated from cql_tests.py:TestCQL.expanded_map_item_conditional_test()
 @pytest.mark.parametrize("test_keyspace",
-                         [pytest.param("tablets", marks=[pytest.mark.xfail(reason="issue #18066")]), "vnodes"],
+                         ["tablets", "vnodes"],
                          indirect=True)
 def testExpandedMapItem(cql, test_keyspace):
     for frozen in [False, True]:   

--- a/test/cqlpy/cassandra_tests/validation/operations/insert_update_if_condition_statics_test.py
+++ b/test/cqlpy/cassandra_tests/validation/operations/insert_update_if_condition_statics_test.py
@@ -32,7 +32,7 @@ def is_scylla(cql):
 
 # Migrated from cql_tests.py:TestCQL.static_columns_cas_test()
 @pytest.mark.parametrize("test_keyspace",
-                         [pytest.param("tablets", marks=[pytest.mark.xfail(reason="issue #18066")]), "vnodes"],
+                         ["tablets", "vnodes"],
                          indirect=True)
 def testStaticColumnsCas(cql, test_keyspace, is_scylla):
     with create_table(cql, test_keyspace, "(id int, k text, version int static, v text, PRIMARY KEY (id, k))") as table:
@@ -153,7 +153,7 @@ def testStaticColumnsCas(cql, test_keyspace, is_scylla):
 
 # Test CASSANDRA-10532
 @pytest.mark.parametrize("test_keyspace",
-                         [pytest.param("tablets", marks=[pytest.mark.xfail(reason="issue #18066")]), "vnodes"],
+                         ["tablets", "vnodes"],
                          indirect=True)
 def testStaticColumnsCasDelete(cql, test_keyspace, is_scylla):
     with create_table(cql, test_keyspace, "(pk int, ck int, static_col int static, value int, PRIMARY KEY (pk, ck))") as table:
@@ -216,7 +216,7 @@ def testStaticColumnsCasDelete(cql, test_keyspace, is_scylla):
                    row(1, 7, null, 8))
 
 @pytest.mark.parametrize("test_keyspace",
-                         [pytest.param("tablets", marks=[pytest.mark.xfail(reason="issue #18066")]), "vnodes"],
+                         ["tablets", "vnodes"],
                          indirect=True)
 def testStaticColumnsCasUpdate(cql, test_keyspace, is_scylla):
     with create_table(cql, test_keyspace, "(pk int, ck int, static_col int static, value int, PRIMARY KEY (pk, ck))") as table:
@@ -271,7 +271,7 @@ def testStaticColumnsCasUpdate(cql, test_keyspace, is_scylla):
                    row(1, 7, 1, 8))
 
 @pytest.mark.parametrize("test_keyspace",
-                         [pytest.param("tablets", marks=[pytest.mark.xfail(reason="issue #18066")]), "vnodes"],
+                         ["tablets", "vnodes"],
                          indirect=True)
 def testConditionalUpdatesOnStaticColumns(cql, test_keyspace, is_scylla):
     with create_table(cql, test_keyspace, "(a int, b int, s int static, d text, PRIMARY KEY (a, b))") as table:
@@ -305,7 +305,7 @@ def testConditionalUpdatesOnStaticColumns(cql, test_keyspace, is_scylla):
                    row(8, null, 8, null))
 
 @pytest.mark.parametrize("test_keyspace",
-                         [pytest.param("tablets", marks=[pytest.mark.xfail(reason="issue #18066")]), "vnodes"],
+                         ["tablets", "vnodes"],
                          indirect=True)
 def testStaticsWithMultipleConditions(cql, test_keyspace, is_scylla):
     with create_table(cql, test_keyspace, "(a int, b int, s1 int static, s2 int static, d int, PRIMARY KEY (a, b))") as table:
@@ -343,7 +343,7 @@ def testStaticsWithMultipleConditions(cql, test_keyspace, is_scylla):
                    [row(false,None,None,None,None,None),row(false,None,None,None,None,None),row(false,None,None,None,None,None),row(false,None,None,None,None,None)] if is_scylla else [row(false)])
 
 @pytest.mark.parametrize("test_keyspace",
-                         [pytest.param("tablets", marks=[pytest.mark.xfail(reason="issue #18066")]), "vnodes"],
+                         ["tablets", "vnodes"],
                          indirect=True)
 def testStaticColumnsCasUpdateWithNullStaticColumn(cql, test_keyspace, is_scylla):
     with create_table(cql, test_keyspace, "(pk int, ck int, s1 int static, s2 int static, value int, PRIMARY KEY (pk, ck))") as table:
@@ -363,7 +363,7 @@ def testStaticColumnsCasUpdateWithNullStaticColumn(cql, test_keyspace, is_scylla
         assertRows(execute(cql, table, "SELECT * FROM %s WHERE pk = ?", 2), row(2, null, 2, 1, null))
 
 @pytest.mark.parametrize("test_keyspace",
-                         [pytest.param("tablets", marks=[pytest.mark.xfail(reason="issue #18066")]), "vnodes"],
+                         ["tablets", "vnodes"],
                          indirect=True)
 def testStaticColumnsCasDeleteWithNullStaticColumn(cql, test_keyspace, is_scylla):
     with create_table(cql, test_keyspace, "(pk int, ck int, s1 int static, s2 int static, value int, PRIMARY KEY (pk, ck))") as table:

--- a/test/cqlpy/test_lwt.py
+++ b/test/cqlpy/test_lwt.py
@@ -15,10 +15,9 @@ from cassandra.protocol import InvalidRequest
 from .util import new_test_table, unique_key_int
 
 @pytest.fixture(scope="module")
-# FIXME: LWT is not supported with tablets yet. See #18066
-def table1(cql, test_keyspace_vnodes):
+def table1(cql, test_keyspace):
     schema='p int, c int, r int, s int static, PRIMARY KEY(p, c)'
-    with new_test_table(cql, test_keyspace_vnodes, schema) as table:
+    with new_test_table(cql, test_keyspace, schema) as table:
         yield table
 
 # An LWT UPDATE whose condition uses non-static columns begins by reading

--- a/test/cqlpy/test_non_deterministic_functions.py
+++ b/test/cqlpy/test_non_deterministic_functions.py
@@ -47,31 +47,31 @@ def lwt_nondeterm_fn_repeated_execute(cql, test_keyspace, pk_type, fn):
         assert len(rows) == num_iterations * 2
 
 @pytest.mark.parametrize("test_keyspace",
-                         [pytest.param("tablets", marks=[pytest.mark.xfail(reason="issue #18066")]), "vnodes"],
+                         ["tablets", "vnodes"],
                          indirect=True)
 def test_lwt_uuid_fn_pk_insert(cql, test_keyspace):
     lwt_nondeterm_fn_repeated_execute(cql, test_keyspace, "uuid", "uuid")
 
 @pytest.mark.parametrize("test_keyspace",
-                         [pytest.param("tablets", marks=[pytest.mark.xfail(reason="issue #18066")]), "vnodes"],
+                         ["tablets", "vnodes"],
                          indirect=True)
 def test_lwt_currenttimestamp_fn_pk_insert(cql, test_keyspace):
     lwt_nondeterm_fn_repeated_execute(cql, test_keyspace, "timestamp", "currenttimestamp")
 
 @pytest.mark.parametrize("test_keyspace",
-                         [pytest.param("tablets", marks=[pytest.mark.xfail(reason="issue #18066")]), "vnodes"],
+                         ["tablets", "vnodes"],
                          indirect=True)
 def test_lwt_currenttime_fn_pk_insert(cql, test_keyspace):
     lwt_nondeterm_fn_repeated_execute(cql, test_keyspace, "time", "currenttime")
 
 @pytest.mark.parametrize("test_keyspace",
-                         [pytest.param("tablets", marks=[pytest.mark.xfail(reason="issue #18066")]), "vnodes"],
+                         ["tablets", "vnodes"],
                          indirect=True)
 def test_lwt_currenttimeuuid_fn_pk_insert(cql, test_keyspace):
     lwt_nondeterm_fn_repeated_execute(cql, test_keyspace, "timeuuid", "currenttimeuuid")
 
 @pytest.mark.parametrize("test_keyspace",
-                         [pytest.param("tablets", marks=[pytest.mark.xfail(reason="issue #18066")]), "vnodes"],
+                         ["tablets", "vnodes"],
                          indirect=True)
 def test_lwt_now_fn_pk_insert(cql, test_keyspace):
     lwt_nondeterm_fn_repeated_execute(cql, test_keyspace, "timeuuid", "now")

--- a/test/cqlpy/test_unset.py
+++ b/test/cqlpy/test_unset.py
@@ -201,12 +201,9 @@ def test_unset_insert_where(cql, table2):
 # NOT EXISTS"). Test that using an UNSET_VALUE in an LWT condition causes
 # a clear error, not silent skip and not a crash as in issue #13001.
 @pytest.mark.parametrize("test_keyspace",
-                         [pytest.param("tablets", marks=[pytest.mark.xfail(reason="issue #18066")]), "vnodes"],
+                         ["tablets", "vnodes"],
                          indirect=True)
-def test_unset_insert_where_lwt(cql, test_keyspace):
-  # FIXME: new_test_table is used here due to https://github.com/scylladb/scylladb/issues/18066
-  # When fixed, this test can go back to using the `table2` fixture.
-  with new_test_table(cql, test_keyspace, "p int, c int, PRIMARY KEY (p, c)") as table2:
+def test_unset_insert_where_lwt(cql, table2):
     p = unique_key_int()
     stmt = cql.prepare(f'INSERT INTO {table2} (p, c) VALUES ({p}, ?) IF NOT EXISTS')
     with pytest.raises(InvalidRequest, match="unset"):
@@ -225,12 +222,9 @@ def test_unset_update_where(cql, table3):
 # Python driver doesn't allow sending an UNSET_VALUE for the partition key,
 # so only the clustering key is tested.
 @pytest.mark.parametrize("test_keyspace",
-                         [pytest.param("tablets", marks=[pytest.mark.xfail(reason="issue #18066")]), "vnodes"],
+                         ["tablets", "vnodes"],
                          indirect=True)
-def test_unset_update_where_lwt(cql, test_keyspace):
-  # FIXME: new_test_table is used here due to https://github.com/scylladb/scylladb/issues/18066
-  # When fixed, this test can go back to using the `table3` fixture.
-  with new_test_table(cql, test_keyspace, "p int, c int, r int, PRIMARY KEY (p, c)") as table3:
+def test_unset_update_where_lwt(cql, table3):
     stmt = cql.prepare(f"UPDATE {table3} SET r = 42 WHERE p = 0 AND c = ? IF r = ?")
 
     with pytest.raises(InvalidRequest, match="unset"):


### PR DESCRIPTION
Commit 0156e9756090d ("storage_proxy: cas: reject for tablets-enabled tables") marked a bunch of LWT tests as XFAIL with tablets enabled, pending resolution of #18066. But since that event is now in the past, we undo the XFAIL markings (or in some cases, use an any-keyspace fixture instead of a vnodes-only fixture).

Ref #18066.

Marking for backport to 2025.4 and 2026.1. While this doesn't fix anything, it adds protection in the form of more tests. 2025.4 is the first release where LWT is supported for tablets.

Fixes https://scylladb.atlassian.net/browse/SCYLLADB-402