### PR TITLE
test: get rid of consistent_cluster_management usage in test

### DIFF
--- a/test/boost/encryption_at_rest_test.cc
+++ b/test/boost/encryption_at_rest_test.cc
@@ -113,9 +113,6 @@ static future<> test_provider(const test_provider_args& args) {
         auto cfg = seastar::make_shared<db::config>(ext);
         cfg->data_file_directories({args.tmp.path().string()});
 
-        // Currently the test fails with consistent_cluster_management = true. See #2995.
-        cfg->consistent_cluster_management(false);
-
         {
             boost::program_options::options_description desc;
             boost::program_options::options_description_easy_init init(&desc);
@@ -198,9 +195,6 @@ static auto make_commitlog_config(const test_provider_args& args, const std::uno
     auto cfg = seastar::make_shared<db::config>(ext);
     cfg->data_file_directories({args.tmp.path().string()});
     cfg->commitlog_sync("batch"); // just to make sure files are written
-
-    // Currently the test fails with consistent_cluster_management = true. See #2995.
-    cfg->consistent_cluster_management(false);
 
     boost::program_options::options_description desc;
     boost::program_options::options_description_easy_init init(&desc);

--- a/test/cqlpy/conftest.py
+++ b/test/cqlpy/conftest.py
@@ -163,27 +163,6 @@ def cassandra_bug(cql):
     if not any('scylla' in name for name in names):
         pytest.xfail('A known Cassandra bug')
 
-# Consistent schema change feature is optionally enabled and
-# some tests are expected to fail on Scylla without this
-# option enabled, and pass with it enabled (and also pass on Cassandra).
-# These tests should use the "fails_without_consistent_cluster_management"
-# fixture. When consistent mode becomes the default, this fixture can be removed.
-@pytest.fixture(scope="function")
-def check_pre_consistent_cluster_management(cql):
-    # If not running on Scylla, return false.
-    names = [row.table_name for row in cql.execute("SELECT * FROM system_schema.tables WHERE keyspace_name = 'system'")]
-    if not any('scylla' in name for name in names):
-        return False
-    # In Scylla, we check Raft mode by inspecting the configuration via CQL.
-    consistent = list(cql.execute("SELECT value FROM system.config WHERE name = 'consistent_cluster_management'"))
-    return len(consistent) == 0 or consistent[0].value == "false"
-
-
-@pytest.fixture(scope="function")
-def fails_without_consistent_cluster_management(request, check_pre_consistent_cluster_management):
-    if check_pre_consistent_cluster_management:
-        request.node.add_marker(pytest.mark.xfail(reason="Test expected to fail without consistent cluster management "
-                                                         "feature on"))
 # Older versions of the Cassandra driver had a bug where if Scylla returns
 # an empty page, the driver would immediately stop reading even if this was
 # not the last page. Some tests which filter out most of the results can end

--- a/test/cqlpy/test_keyspace.py
+++ b/test/cqlpy/test_keyspace.py
@@ -249,7 +249,7 @@ def test_alter_keyspace_double_with(cql):
 # deleted. But we expect that at the end of the test the database remains in
 # some valid state - the keyspace should either exist or not exist. It
 # shouldn't be in some broken immortal state as reported in issue #8968.
-def test_concurrent_create_and_drop_keyspace(cql, this_dc, fails_without_consistent_cluster_management):
+def test_concurrent_create_and_drop_keyspace(cql, this_dc):
     ksdef = "WITH REPLICATION = { 'class' : 'NetworkTopologyStrategy', '" + this_dc + "' : 1 }"
     cfdef = "(a int PRIMARY KEY)"
     with new_test_keyspace(cql, ksdef) as keyspace:


### PR DESCRIPTION
consistent_cluster_management is deprecated since scylla-5.2 and no longer used by Scylladb, so it should not be used by test either.

No backport needed, just a cleanup.