### PR TITLE
test.py: migrate nodetool to run by pytest

### DIFF
--- a/test.py
+++ b/test.py
@@ -67,6 +67,7 @@ PYTEST_RUNNER_DIRECTORIES = [
     TEST_DIR / 'cql',
     TEST_DIR / 'cqlpy',
     TEST_DIR / 'rest_api',
+    TEST_DIR / 'nodetool',
 ]
 
 launch_time = time.monotonic()

--- a/test/nodetool/suite.yaml
+++ b/test/nodetool/suite.yaml
@@ -1,3 +1,0 @@
-type: Tool
-coverage: false
-launcher: unshare -rn pytest --run-within-unshare

--- a/test/nodetool/test_config.yaml
+++ b/test/nodetool/test_config.yaml
@@ -1,0 +1,2 @@
+type: Python
+coverage: false


### PR DESCRIPTION
As a next step of migration to the pytest runner, this PR moves responsibility for nodetool tests execution solely to the pytest.

Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-397

Framework enhancement, no need to backport.