### PR TITLE
main: remove confusing duplicated auth start message

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -2073,7 +2073,6 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             perm_cache_config.refresh = std::chrono::milliseconds(cfg->permissions_update_interval_in_ms());
 
             auto start_auth_service = [&mm] (sharded<auth::service>& auth_service, std::any& stop_auth_service, const char* what) {
-                supervisor::notify(fmt::format("starting {}", what));
                 auth_service.invoke_on_all(&auth::service::start, std::ref(mm), std::ref(sys_ks)).get();
 
                 stop_auth_service = defer_verbose_shutdown(what, [&auth_service] {


### PR DESCRIPTION
Before we could observe two exactly the same
"starting auth service" messages in the log.
One from checkpoint() the other from notify().
We remove the second one to stay consistent
with other services.

Backport: no, cosmetic fix.