### PR TITLE
tablet_allocator: Have its own explicit background scheduling group

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -1677,7 +1677,9 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
                     gossiper.local(), feature_service.local(), sys_ks.local(), group0_client, dbcfg.gossip_scheduling_group};
 
             checkpoint(stop_signal, "starting tablet allocator");
-            service::tablet_allocator::config tacfg;
+            service::tablet_allocator::config tacfg {
+                .background_sg = maintenance_scheduling_group,
+            };
             sharded<service::tablet_allocator> tablet_allocator;
             tablet_allocator.start(tacfg, std::ref(mm_notifier), std::ref(db)).get();
             auto stop_tablet_allocator = defer_verbose_shutdown("tablet allocator", [&tablet_allocator] {

--- a/service/tablet_allocator.hh
+++ b/service/tablet_allocator.hh
@@ -257,6 +257,7 @@ class migration_notifier;
 class tablet_allocator {
 public:
     struct config {
+        scheduling_group background_sg;
     };
     class impl {
     public:


### PR DESCRIPTION
Currently, tablet_allocator switches to streaming scheduling group that it gets from database. It's not nice to use database as provider of configs/scheduling_groups.

This patch adds a background scheduling group for tablet allocator configured via its config and sets it to streaming group in main.cc code.

This will help splitting the streaming scheduling group into more elaborated groups under the maintenance supergroup: SCYLLADB-351

New feature (nested scheduling groups), not backporting