### PR TITLE
storage_service: Use stream_manager group for streaming

### DIFF
--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -6275,7 +6275,7 @@ future<raft_topology_cmd_result> storage_service::raft_topology_cmd_handler(raft
             }
             break;
             case raft_topology_cmd::command::stream_ranges: {
-                co_await with_scheduling_group(_db.local().get_streaming_scheduling_group(), coroutine::lambda([&] () -> future<> {
+                co_await with_scheduling_group(_stream_manager.local().get_scheduling_group(), coroutine::lambda([&] () -> future<> {
                     const auto rs = _topology_state_machine._topology.find(id)->second;
                     auto tstate = _topology_state_machine._topology.tstate;
                     auto session = _topology_state_machine._topology.session;

--- a/streaming/stream_manager.hh
+++ b/streaming/stream_manager.hh
@@ -196,6 +196,8 @@ public:
     }
 
     future<> fail_stream_plan(streaming::plan_id plan_id);
+
+    scheduling_group get_scheduling_group() const noexcept { return _streaming_group; }
 };
 
 } // namespace streaming


### PR DESCRIPTION
The hander of raft_topology_cmd::command::stream_ranges switches to streaming scheduling group to perform data streaming in it. It grabs the group from database db_config, which's not great. There's streaming manager at hand in storage service handlers, since it's using its functionality, it should use _its_ scheduling group.

This will help splitting the streaming scheduling group into more elaborated groups under the maintenance supergroup: SCYLLADB-351

New feature (nested scheduling groups), no backporting