### PR TITLE
vector_search: allow full secondary indexes syntax while creating the vector index

### DIFF
--- a/docs/cql/dml/select.rst
+++ b/docs/cql/dml/select.rst
@@ -281,7 +281,8 @@ For example::
       ORDER BY embedding ANN OF [0.1, 0.2, 0.3, 0.4] LIMIT 5;
 
 
-Vector queries also support filtering with ``WHERE`` clauses on columns that are part of the primary key.
+Vector queries also support filtering with ``WHERE`` clauses on columns that are part of the primary key
+or columns provided in a definition of the index.
 
 For example::
 


### PR DESCRIPTION
Vector Search feature needs to support creating vector indexes with additional filtering column. There will be two types of indexes: global which indexes vectors per table, and local which indexes vectors per partition key. The new syntaxes are based on ScyllaDB's Global Secondary Index and Local Secondary Index. Vector indexes don't use secondary indexes functionalities in any way - all indexing, filtering and processing data will be done on Vector Store side.

This patch allows creating vector indexes using this CQL syntax:

```
CREATE TABLE IF NOT EXISTS cycling.comments_vs (
  commenter text,
  comment text,
  comment_vector VECTOR <FLOAT, 5>,
  created_at timestamp,
  discussion_board_id int,
  country text,
  lang text,
  PRIMARY KEY ((commenter, discussion_board_id), created_at)
);

CREATE CUSTOM INDEX IF NOT EXISTS global_ann_index
  ON cycling.comments_vs(comment_vector, country, lang) USING 'vector_index'
  WITH OPTIONS = { 'similarity_function': 'DOT_PRODUCT' };

CREATE CUSTOM INDEX IF NOT EXISTS local_ann_index
  ON cycling.comments_vs((commenter, discussion_board_id), comment_vector, country, lang) 
  USING 'vector_index'
  WITH OPTIONS = { 'similarity_function': 'DOT_PRODUCT' };
```

Currently, if we run these queries to create indexes we will receive such errors:

```
InvalidRequest: Error from server: code=2200 [Invalid query] message="Vector index can only be created on a single column"
InvalidRequest: Error from server: code=2200 [Invalid query] message="Local index definition must contain full partition key only. Redundant column: XYZ"
```

This commit refactors `vector_index::check_target` to correctly validate columns building the index. Vector-store currently support filtering by native types, so the type of columns is checked. The first column from the list must be a vector (to build index based on these vectors), so it is also checked.

Allowed types for columns are native types without counter (it is not possible to create a table with counter and vector) and without duration (it is not possible to correctly compare durations, this type is even not allowed in secondary indexes).

This commits adds cqlpy test to check errors while creating indexes.

Fixes: SCYLLADB-298

This needs to be backported to version 2026.1 as this is a fix for filtering support.