### PR TITLE
.github/workflows/backport-pr-fixes-validation: support Atlassian URL format in backport PR fixes validation

### DIFF
--- a/.github/workflows/backport-pr-fixes-validation.yaml
+++ b/.github/workflows/backport-pr-fixes-validation.yaml
@@ -18,7 +18,7 @@ jobs:
             
             // Regular expression pattern to check for "Fixes" prefix
             // Adjusted to dynamically insert the repository full name
-            const pattern = `Fixes:? ((?:#|${repo.replace('/', '\\/')}#|https://github\\.com/${repo.replace('/', '\\/')}/issues/)(\\d+)|([A-Z]+-\\d+))`;
+            const pattern = `Fixes:? ((?:#|${repo.replace('/', '\\/')}#|https://github\\.com/${repo.replace('/', '\\/')}/issues/)(\\d+)|(?:https://scylladb\\.atlassian\\.net/browse/)?([A-Z]+-\\d+))`;
             const regex = new RegExp(pattern);
             
             if (!regex.test(body)) {


### PR DESCRIPTION
Add support for matching full Atlassian JIRA URLs in the format https://scylladb.atlassian.net/browse/SCYLLADB-400 in addition to the bare JIRA key format (SCYLLADB-400).

This makes the validation more flexible by accepting both formats that developers commonly use when referencing JIRA issues.

Fixes: https://github.com/scylladb/scylladb/issues/28373

**Issue exist in all releases, backport is needed to all releases**