### PR TITLE
db/view: add missing include for coroutine::all to fix build without precompiled headers

### DIFF
--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -23,6 +23,7 @@
 
 #include <seastar/core/future-util.hh>
 #include <seastar/core/coroutine.hh>
+#include <seastar/coroutine/all.hh>
 #include <seastar/coroutine/maybe_yield.hh>
 #include <flat_map>
 


### PR DESCRIPTION
When building with `--disable-precompiled-header`, view.cc failed to compile due to missing <seastar/coroutine/all.hh> include, which provides `coroutine::all`.

The problem doesn't manifest when precompiled headers are used, which is the default. So that's likely why it was missed by the CI.

Adding the explicit include fixes the build.

Fixes: scylladb/scylladb#28378
Ref: scylladb/scylladb#28093

No backport: This problem is only present in master.