### PR TITLE
alternator: fix spurious MODIFY item when deleting empty item

### DIFF
--- a/test/alternator/test_streams.py
+++ b/test/alternator/test_streams.py
@@ -809,6 +809,47 @@ def test_streams_putitem_keys_only(test_table_ss_keys_only, dynamodb, dynamodbst
         return events
     do_test(test_table_ss_keys_only, dynamodb, dynamodbstreams, do_updates, 'KEYS_ONLY')
 
+# Reproduces #28368
+def test_streams_spurious_modify_when_update_expr_on_empty_item(test_table_ss_new_and_old_images, dynamodb, dynamodbstreams):
+    null = None
+    def do_updates(table, p, c):
+        events = [
+            ["INSERT",{"c":"c0","p":"p0"},null,{"c":"c0","e":166,"g":166,"p":"p0"}],
+        ]
+        
+        table.update_item(Key={'p': 'p0', 'c': 'c0'}, UpdateExpression='REMOVE g', )
+        v = table.get_item(Key={'p': 'p0', 'c': 'c0'}).get('Item', {})
+        assert v == {}
+        table.update_item(Key={'p': 'p0', 'c': 'c0'}, UpdateExpression="SET e = :e, g = :g", ExpressionAttributeValues={":e": 166, ":g": 166})
+        v = table.get_item(Key={'p': 'p0', 'c': 'c0'}).get('Item', {})
+        assert v == {"p": "p0", "c": "c0", "e": 166, "g": 166}
+
+        return events
+    
+    with scylla_config_temporary(dynamodb, 'alternator_streams_increased_compatibility', 'true', nop=is_aws(dynamodb)):
+        do_test(test_table_ss_new_and_old_images, dynamodb, dynamodbstreams, do_updates, 'NEW_AND_OLD_IMAGES')
+        
+# Test UpdateItem which does a PUT followed by a REMOVE - the single column value should be removed.
+# The failure occured when #28368 was fixed incompletely
+def test_streams_update_item_with_remove_doesnt_work(test_table_ss_new_and_old_images, dynamodb, dynamodbstreams):
+    null = None
+    def do_updates(table, p, c):
+        events = [
+            ["INSERT", {"p": "p0", "c": "c0"}, null, {"p": "p0", "c": "c0", "e": 0, "g": 0}],
+            ["MODIFY", {"p": "p0", "c": "c0"}, {"p": "p0", "c": "c0", "e": 0, "g": 0}, {"p": "p0", "c": "c0", "e": 0}],
+        ]
+
+        table.update_item(Key={'p': 'p0', 'c': 'c0'}, AttributeUpdates={'e': {'Value': 0, 'Action': 'PUT'}, 'g': {'Value': 0, 'Action': 'PUT'}})
+        v = table.get_item(Key={'p': 'p0', 'c': 'c0'}).get('Item', {})
+        assert v == {"p": "p0", "c": "c0", "e": 0, "g": 0}
+        table.update_item(Key={'p': 'p0', 'c': 'c0'}, UpdateExpression='REMOVE g', )
+        v = table.get_item(Key={'p': 'p0', 'c': 'c0'}).get('Item', {})
+        assert v == {"p": "p0", "c": "c0", "e": 0}
+
+        return events
+    with scylla_config_temporary(dynamodb, 'alternator_streams_increased_compatibility', 'true', nop=is_aws(dynamodb)):
+        do_test(test_table_ss_new_and_old_images, dynamodb, dynamodbstreams, do_updates, 'NEW_AND_OLD_IMAGES')
+
 # Replacing an item should result in a MODIFY, rather than REMOVE and MODIFY.
 # Moreover, the old item should be visible in OldImage. Reproduces #6930.
 def test_streams_putitem_new_items_override_old(test_table_ss_new_and_old_images, dynamodb, dynamodbstreams):


### PR DESCRIPTION
Fix executing UpdateItem with `UpdateExpression='REMOVE g'` (remove single column value) when item doesn't exist producing spurious MODIFY event in Streams output.
Add test.

Fixes #28368
