### PR TITLE
test: test_gossiper_orphan_remover: get host ID of the bootstrapping node before it crashes

### DIFF
--- a/test/cluster/test_gossiper_orphan_remover.py
+++ b/test/cluster/test_gossiper_orphan_remover.py
@@ -29,6 +29,7 @@ async def test_crashed_node_substitution(manager: ManagerClient):
 
     log = await manager.server_open_log(failed_server.server_id)
     await log.wait_for("finished do_send_ack2_msg")
+    failed_id = await manager.get_host_id(failed_server.server_id)
     await manager.api.message_injection(failed_server.ip_addr, 'crash_before_group0_join')
     
     await task
@@ -49,7 +50,6 @@ async def test_crashed_node_substitution(manager: ManagerClient):
     [await manager.api.message_injection(s.ip_addr, 'fast_orphan_removal_fiber') for s in servers]
 
     log = await manager.server_open_log(servers[0].server_id)
-    failed_id = await  manager.get_host_id(failed_server.server_id)
     await log.wait_for(f"Finished to force remove node {failed_id}")
 
     post_wait_live_eps = await manager.api.client.get_json("/gossiper/endpoint/live", host=servers[0].ip_addr)


### PR DESCRIPTION
The test is currently flaky. It tries to get the host ID of the bootstrapping
node via the REST API after the node crashes. This can obviously fail. The
test usually doesn't fail, though, as it relies on the host ID being saved
in `ScyllaServer._host_id` at this point by `ScyllaServer.try_get_host_id()`
repeatedly called in `ScyllaServer.start()`. However, with a very fast crash
and unlucky timings, no such call may succeed.

We deflake the test by getting the host ID before the crash. Note that at this
point, the bootstrapping node must be serving the REST API requests because
`await log.wait_for("finished do_send_ack2_msg")` above guarantees that the
node has started the gossip shadow round, which happens after starting the REST
API.

Fixes #28385

This PR improves the CI stability and changes only a test, so it can be
backported.