### PR TITLE
test/storage: speed up out-of-space prevention tests

### DIFF
--- a/test/storage/test_out_of_space_prevention.py
+++ b/test/storage/test_out_of_space_prevention.py
@@ -43,7 +43,7 @@ class random_content_file:
         os.unlink(self.filename)
 
 
-# Since we create 100M volumes, we need to reduce the commitlog segment size
+# Since we create 20M volumes, we need to reduce the commitlog segment size
 # otherwise we hit out of space.
 global_cmdline = ["--disk-space-monitor-normal-polling-interval-in-seconds", "1",
                   "--critical-disk-utilization-level", "0.8",
@@ -64,7 +64,7 @@ async def test_user_writes_rejection(manager: ManagerClient, volumes_factory: Ca
             res = await cql.run_async(stmt, host=host)
             assert not res, f"Data found on {host} but it shouldn't be there"
 
-    async with space_limited_servers(manager, volumes_factory, ["100M"]*3, cmdline=global_cmdline) as servers:
+    async with space_limited_servers(manager, volumes_factory, ["20M"]*3, cmdline=global_cmdline) as servers:
         cql, hosts = await manager.get_ready_cql(servers)
 
         workdir = await manager.server_get_workdir(servers[0].server_id)
@@ -115,7 +115,7 @@ async def test_user_writes_rejection(manager: ManagerClient, volumes_factory: Ca
 async def test_autotoogle_compaction(manager: ManagerClient, volumes_factory: Callable) -> None:
     cmdline = [*global_cmdline,
                "--logger-log-level", "compaction=debug"]
-    async with space_limited_servers(manager, volumes_factory, ["100M"]*3, cmdline=cmdline) as servers:
+    async with space_limited_servers(manager, volumes_factory, ["20M"]*3, cmdline=cmdline) as servers:
         cql, _ = await manager.get_ready_cql(servers)
 
         workdir = await manager.server_get_workdir(servers[0].server_id)
@@ -171,7 +171,7 @@ async def test_critical_utilization_during_decommission(manager: ManagerClient, 
                "--logger-log-level", "load_balancer=debug",
                "--logger-log-level", "debug_error_injection=debug"
                ]
-    async with space_limited_servers(manager, volumes_factory, ["100M"]*2, cmdline=cmdline,
+    async with space_limited_servers(manager, volumes_factory, ["20M"]*2, cmdline=cmdline,
                                      property_file=[{"dc": "dc1", "rack": "r1"}]*2) as servers:
         cql, _ = await manager.get_ready_cql(servers)
 
@@ -210,7 +210,7 @@ async def test_critical_utilization_during_decommission(manager: ManagerClient, 
 @pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_reject_split_compaction(manager: ManagerClient, volumes_factory: Callable) -> None:
-    async with space_limited_servers(manager, volumes_factory, ["100M"]*3, cmdline=global_cmdline) as servers:
+    async with space_limited_servers(manager, volumes_factory, ["20M"]*3, cmdline=global_cmdline) as servers:
         cql, _ = await manager.get_ready_cql(servers)
 
         workdir = await manager.server_get_workdir(servers[0].server_id)
@@ -239,7 +239,7 @@ async def test_reject_split_compaction(manager: ManagerClient, volumes_factory: 
 async def test_split_compaction_not_triggered(manager: ManagerClient, volumes_factory: Callable) -> None:
     cmd = [*global_cmdline,
            "--logger-log-level", "compaction=debug"]
-    async with space_limited_servers(manager, volumes_factory, ["100M"]*3, cmdline=cmd) as servers:
+    async with space_limited_servers(manager, volumes_factory, ["20M"]*3, cmdline=cmd) as servers:
         cql, _ = await manager.get_ready_cql(servers)
 
         workdir = await manager.server_get_workdir(servers[0].server_id)
@@ -270,7 +270,7 @@ async def test_split_compaction_not_triggered(manager: ManagerClient, volumes_fa
 
 @pytest.mark.asyncio
 async def test_tablet_repair(manager: ManagerClient, volumes_factory: Callable) -> None:
-    async with space_limited_servers(manager, volumes_factory, ["100M"]*3, cmdline=global_cmdline) as servers:
+    async with space_limited_servers(manager, volumes_factory, ["20M"]*3, cmdline=global_cmdline) as servers:
         cql, _ = await manager.get_ready_cql(servers)
 
         workdir = await manager.server_get_workdir(servers[0].server_id)
@@ -332,7 +332,7 @@ async def test_tablet_repair(manager: ManagerClient, volumes_factory: Callable) 
 
 @pytest.mark.asyncio
 async def test_autotoogle_reject_incoming_migrations(manager: ManagerClient, volumes_factory: Callable) -> None:
-    async with space_limited_servers(manager, volumes_factory, ["100M"]*3, cmdline=global_cmdline) as servers:
+    async with space_limited_servers(manager, volumes_factory, ["20M"]*3, cmdline=global_cmdline) as servers:
         await manager.disable_tablet_balancing()
 
         cql, _ = await manager.get_ready_cql(servers)
@@ -392,7 +392,7 @@ async def test_autotoogle_reject_incoming_migrations(manager: ManagerClient, vol
 async def test_node_restart_while_tablet_split(manager: ManagerClient, volumes_factory: Callable) -> None:
     cmd = [*global_cmdline,
            "--logger-log-level", "compaction=debug"]
-    async with space_limited_servers(manager, volumes_factory, ["100M"]*3, cmdline=cmd) as servers:
+    async with space_limited_servers(manager, volumes_factory, ["20M"]*3, cmdline=cmd) as servers:
         cql, _ = await manager.get_ready_cql(servers)
         workdir = await manager.server_get_workdir(servers[0].server_id)
         log = await manager.server_open_log(servers[0].server_id)
@@ -455,7 +455,7 @@ async def test_node_restart_while_tablet_split(manager: ManagerClient, volumes_f
 async def test_repair_failure_on_split_rejection(manager: ManagerClient, volumes_factory: Callable) -> None:
     cmd = [*global_cmdline,
            "--logger-log-level", "compaction=debug"]
-    async with space_limited_servers(manager, volumes_factory, ["100M"]*3, cmdline=cmd) as servers:
+    async with space_limited_servers(manager, volumes_factory, ["20M"]*3, cmdline=cmd) as servers:
         cql, _ = await manager.get_ready_cql(servers)
         workdir = await manager.server_get_workdir(servers[0].server_id)
         log = await manager.server_open_log(servers[0].server_id)


### PR DESCRIPTION
This PR reduces the runtime of `test_out_of_space_prevention.py` by addressing two main sources of overhead: slow “critical utilization” setup and delayed tablet load stats propagation. Combined, these changes cut the module’s total execution time from 324s to 185s.

Improvements. No backup is required.