### PR TITLE
view_build_worker: Do not switch scheduling groups inside work_on_view_building_tasks

### DIFF
--- a/db/view/view_building_worker.cc
+++ b/db/view/view_building_worker.cc
@@ -588,11 +588,7 @@ future<> view_building_worker::do_build_range(table_id base_id, std::vector<tabl
     utils::get_local_injector().inject("do_build_range_fail",
             [] { throw std::runtime_error("do_build_range failed due to error injection"); });
 
-    // Run the view building in the streaming scheduling group
-    // so that it doesn't impact other tasks with higher priority.
-    seastar::thread_attributes attr;
-    attr.sched_group = _db.get_streaming_scheduling_group();
-    return seastar::async(std::move(attr), [this, base_id, views_ids = std::move(views_ids), last_token, &as] {
+    return seastar::async([this, base_id, views_ids = std::move(views_ids), last_token, &as] {
         gc_clock::time_point now = gc_clock::now();
         auto base_cf = _db.find_column_family(base_id).shared_from_this();
         reader_permit permit = _db.get_reader_concurrency_semaphore().make_tracking_only_permit(nullptr, "build_views_range", db::no_timeout, {});


### PR DESCRIPTION
The handler appeared back in c9e710dca3. In this commit it performed the "core" part of the task -- the do_build_range() method -- inside the streaming sched group. The setup code looks seemingly was copied from the view_builder::do_build_step() method and got the explicit switch of the scheduling group.

The switch looks both -- justified and not. On one hand, it makes it explicit that the activity runs in the streaming scheduling group. On the other hand, the verb already uses RPC index on 1, which is negotiated to be run in streaming group anyway. On the "third hand", even though being explicit the switch happens too late, as there exists a lot of other activities performed by the handler that seems to also belong to the same scheduling group, but which is not switched into explicitly.

By and large, it seems better to avoid the explict switch and rely on the RPC-level negotiation-based sched group switching.

Preparations for the new feature (nested scheduling groups), not backporting