### PR TITLE
skip_mode: Allow multiple build modes in pytest skip_mode marker

### DIFF
--- a/test/pylib/runner.py
+++ b/test/pylib/runner.py
@@ -386,9 +386,12 @@ def modify_pytest_item(item: pytest.Item) -> None:
 
     for mark in skip_marks:
         def __skip_test(mode, reason, platform_key=None):
-            if mode == item.stash[BUILD_MODE]:
-                if platform_key is None or platform_key in platform.platform():
-                    item.add_marker(pytest.mark.skip(reason=reason))
+            modes = [mode] if isinstance(mode, str) else mode
+
+            for mode in modes:
+                if mode == item.stash[BUILD_MODE]:
+                    if platform_key is None or platform_key in platform.platform():
+                        item.add_marker(pytest.mark.skip(reason=reason))
         try:
             __skip_test(*mark.args, **mark.kwargs)
         except TypeError as e:


### PR DESCRIPTION
Enhance the skip_mode marker to accept either a single mode string or a list of modes, allowing tests to be skipped across multiple build configurations with a single marker.

Before:
```
  @pytest.mark.skip_mode("dev", reason="...")
  @pytest.mark.skip_mode("debug", reason="...")
```

After:
```
 @pytest.mark.skip_mode(["dev", "debug"], reason="...")
 ```

This reduces duplication when the same skip condition applies to multiple build modes.

No need to backport, as pytest mark `skip_mode` is relatively new.