### PR TITLE
test/cqlpy: Remove redundant pytest.register_assert_rewrite call

### DIFF
--- a/test/cqlpy/cassandra_tests/validation/operations/insert_update_if_condition_test.py
+++ b/test/cqlpy/cassandra_tests/validation/operations/insert_update_if_condition_test.py
@@ -8,10 +8,6 @@
 # Modifications: Copyright 2026-present ScyllaDB
 # SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
 
-# Before importing porting.py, enable pytest's nice assertion rewrite in
-# its functions such as assert_rows():
-import pytest
-pytest.register_assert_rewrite('test.cqlpy.cassandra_tests.porting')
 from ...porting import *
 
 from cassandra.util import Duration


### PR DESCRIPTION
During test.py run, noticed this warning:
```
10:38:22  test/cqlpy/cassandra_tests/validation/operations/insert_update_if_condition_test.py:14: 32 warnings
10:38:22    /jenkins/workspace/releng-testing/scylla-ci/scylla/test/cqlpy/cassandra_tests/validation/operations/insert_update_if_condition_test.py:14: PytestAssertRewriteWarning: Module already imported so cannot be rewritten: test.cqlpy.cassandra_tests.porting
10:38:22      pytest.register_assert_rewrite('test.cqlpy.cassandra_tests.porting')
```

The insert_update_if_condition_test.py was calling pytest.register_assert_rewrite() for the porting module, but this registration is already handled by cassandra_tests/__init__.py which is automatically loaded before any test runs.

**Fix a warning, no need for backport**