### PR TITLE
streaming: Get streaming sched group from debug:: namespace

### DIFF
--- a/debug.cc
+++ b/debug.cc
@@ -11,5 +11,6 @@
 namespace debug {
 
 seastar::sharded<replica::database>* volatile the_database = nullptr;
+seastar::scheduling_group streaming_scheduling_group;
 
 }

--- a/debug.hh
+++ b/debug.hh
@@ -17,7 +17,7 @@ class database;
 namespace debug {
 
 extern seastar::sharded<replica::database>* volatile the_database;
-
+extern seastar::scheduling_group streaming_scheduling_group;
 
 }
 

--- a/main.cc
+++ b/main.cc
@@ -906,6 +906,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
 
             auto background_reclaim_scheduling_group = create_scheduling_group("background_reclaim", "bgre", 50).get();
             auto maintenance_scheduling_group = create_scheduling_group("streaming", "strm", 200).get();
+            debug::streaming_scheduling_group = maintenance_scheduling_group;
 
             smp::invoke_on_all([&cfg, background_reclaim_scheduling_group] {
                 logalloc::tracker::config st_cfg;

--- a/streaming/consumer.cc
+++ b/streaming/consumer.cc
@@ -18,6 +18,7 @@
 #include "db/view/view_update_checks.hh"
 #include "sstables/sstables.hh"
 #include "sstables/sstables_manager.hh"
+#include "debug.hh"
 
 namespace streaming {
 
@@ -33,7 +34,7 @@ mutation_reader_consumer make_streaming_consumer(sstring origin,
     return [&db, &vb = vb.container(), &vbw, estimated_partitions, reason, offstrategy, origin = std::move(origin), frozen_guard, on_sstable_written] (mutation_reader reader) -> future<> {
         std::exception_ptr ex;
         try {
-            if (current_scheduling_group() != db.local().get_streaming_scheduling_group()) {
+            if (current_scheduling_group() != debug::streaming_scheduling_group) {
                 on_internal_error(sstables::sstlog, format("The stream consumer is not running in streaming group current_scheduling_group={}",
                         current_scheduling_group().name()));
             }

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -577,6 +577,7 @@ private:
             }
 
             auto scheduling_groups = get_scheduling_groups().get();
+            debug::streaming_scheduling_group = scheduling_groups.streaming_scheduling_group;
 
             auto notify_set = init_configurables
                 ? configurable::init_all(*cfg, init_configurables->extensions, service_set(


### PR DESCRIPTION
In a lambda returned from make_streaming_consumer() there's a check for current scheudling group being streaming one. It came from #17090 where streaming code was launched in wrong sched group thus affecting user groups in a bad way.

The check is nice and useful, but it abuses replica::database by getting unrelated information from it.

To preserve the check and to stop using database as provider of configs, keep the streaming scheduling group handle in the debug namespace. This emphasises that this global variable is purely for debugging purposes.

Refining debugging code, not backporting