### PR TITLE
test/cqlpy: fix "assertion rewriting" in translated Cassandra tests

### DIFF
--- a/test/cqlpy/cassandra_tests/__init__.py
+++ b/test/cqlpy/cassandra_tests/__init__.py
@@ -6,4 +6,4 @@
 # causes pytest to rewrite (i.e., improve) assert calls in utility
 # functions in porting.py.
 import pytest
-pytest.register_assert_rewrite("cassandra_tests.porting")
+pytest.register_assert_rewrite("test.cqlpy.cassandra_tests.porting")


### PR DESCRIPTION
One of the best features of the pytest framework is "assertion rewriting": If your test does for example "assert a + 1 == b", the assertion is "rewritten" so that if it fails it tells you not only that "a+1" and "b" are not equal, what the non-equal values are, how they are not equal (e.g., find different elements of arrays) and how each side of the equality was calculated.

But pytest can only "rewrite" assertion that it sees. If you call a utility function checksomething() from another module and that utility function calls assert, it will not be able to rewrite it, and you'll get ugly, hard-to-debug, assertion failures.

This problem is especially noticable in tests we translated from Cassandra, in test/cqlpy/cassandra_tests. Those tests use a bunch of assertion-performing utility functions like assertRows() et al. Those utility functions are defined in a separate source file, porting.py, so by default do not get their assertions rewritten.

We had a solution for this: test/cqlpy/cassandra_test/__init__.py had:

    pytest.register_assert_rewrite("cassandra_tests.porting")

This tells pytest to rewrite assertions in porting.py the first time that it is imported.

It used to work well, but recently it stopped working. This is because we change the module paths recently, and it should be written as test.cqlpy.cassandra_tests.porting.

I verified by editing one of the cassandra_tests to make a bad check that indeed this statement stopped working, and fixing the module path in this way solves it, and makes assertion rewriting work again.
