### PR TITLE
build: add clang-tools-extra (for clang-include-cleaner) to frozen toolchain

### DIFF
--- a/.github/workflows/iwyu.yaml
+++ b/.github/workflows/iwyu.yaml
@@ -34,8 +34,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
-      - run: |
-          sudo dnf -y install clang-tools-extra
       - name: Generate compilation database
         run: |
           cmake                                         \

--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -31,6 +31,7 @@ fi
 
 debian_base_packages=(
     clang
+    clang-tools
     gdb
     cargo
     wabt
@@ -72,6 +73,7 @@ debian_base_packages=(
 
 fedora_packages=(
     clang
+    clang-tools-extra
     compiler-rt
     libasan
     libubsan

--- a/tools/toolchain/image
+++ b/tools/toolchain/image
@@ -1,1 +1,1 @@
-docker.io/scylladb/scylla-toolchain:fedora-43-20260113
+docker.io/scylladb/scylla-toolchain:fedora-43-20260128


### PR DESCRIPTION

clang-include-cleaner is used in the iwyu.yaml github workflow (include- what-you-use). Add it to the frozen toolchain so it can be made part of the regular build process.

The corresponding install command is removed from iwyu.yaml.

Regenerated frozen toolchain with optimized clang from

  https://devpkg.scylladb.com/clang/clang-21.1.8-Fedora-43-aarch64.tar.gz
  https://devpkg.scylladb.com/clang/clang-21.1.8-Fedora-43-x86_64.tar.gz

No backport: preparing for moving the iwyu workflow to regular ninja build, which won't be backported.