### PR TITLE
repair: Add request type in the tablet repair log

### DIFF
--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -1817,7 +1817,8 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
                             .last_token  = dht::token::to_int64(tmap.get_last_token(gid.tablet)),
                             .table_uuid  = gid.table,
                         };
-                        rtlogger.info("Initiating tablet repair host={} tablet={}", dst, gid);
+                        auto request_type = tinfo.repair_task_info.request_type;
+                        rtlogger.info("Initiating tablet repair host={} tablet={} request_type={}", dst, gid, request_type);
                         auto session_id = utils::get_local_injector().enter("handle_tablet_migration_repair_random_session") ?
                             service::session_id::create_random_id() : trinfo->session_id;
                         auto res = co_await ser::storage_service_rpc_verbs::send_tablet_repair(&_messaging,
@@ -1829,8 +1830,8 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
                             entry.timestamp = db_clock::now();
                             tablet_state.repair_task_updates = co_await _sys_ks.get_update_repair_task_mutations(entry, api::new_timestamp());
                         }
-                        rtlogger.info("Finished tablet repair host={} tablet={} duration={} repair_time={}",
-                                dst, tablet, duration, res.repair_time);
+                        rtlogger.info("Finished tablet repair host={} tablet={} duration={} repair_time={} request_type={}",
+                                dst, tablet, duration, res.repair_time, request_type);
                     })) {
                         if (utils::get_local_injector().enter("delay_end_repair_update")) {
                             break;

--- a/test/storage/test_out_of_space_prevention.py
+++ b/test/storage/test_out_of_space_prevention.py
@@ -253,7 +253,7 @@ async def test_tablet_repair(manager: ManagerClient, volumes_factory: Callable) 
                     task_id = response['tablet_task_id']
 
                     for _ in range(await get_tablet_count(manager, servers[1], ks, table)):
-                        coord_mark, matches = await coord_log.wait_for("Initiating tablet repair host=(?P<host>.*) tablet=(?P<tablet>.*)", from_mark=coord_mark)
+                        coord_mark, matches = await coord_log.wait_for(r"Initiating tablet repair host=(?P<host>.*) tablet=(?P<tablet>.*) request_type=.*", from_mark=coord_mark)
                         dst_host, tablet = matches[0][1].group("host"), matches[0][1].group("tablet")
                         if host == dst_host:
                             # Tablet repair is triggered on the node with disk utilization above the critical level.


### PR DESCRIPTION
So we can know if the repair is an auto repair or a user repair.

Fixes SCYLLADB-395

Improvement. No backport. 