### PR TITLE
storage_service: Check raft rpc scheduling group from debug namespace

### DIFF
--- a/debug.cc
+++ b/debug.cc
@@ -12,5 +12,6 @@ namespace debug {
 
 seastar::sharded<replica::database>* volatile the_database = nullptr;
 seastar::scheduling_group streaming_scheduling_group;
+seastar::scheduling_group gossip_scheduling_group;
 
 }

--- a/debug.hh
+++ b/debug.hh
@@ -18,6 +18,7 @@ namespace debug {
 
 extern seastar::sharded<replica::database>* volatile the_database;
 extern seastar::scheduling_group streaming_scheduling_group;
+extern seastar::scheduling_group gossip_scheduling_group;
 
 }
 

--- a/main.cc
+++ b/main.cc
@@ -1150,6 +1150,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             dbcfg.memtable_scheduling_group = create_scheduling_group("memtable", "mt", 1000).get();
             dbcfg.memtable_to_cache_scheduling_group = create_scheduling_group("memtable_to_cache", "mt2c", 200).get();
             dbcfg.gossip_scheduling_group = create_scheduling_group("gossip", "gms", 1000).get();
+            debug::gossip_scheduling_group = dbcfg.gossip_scheduling_group;
             dbcfg.commitlog_scheduling_group = create_scheduling_group("commitlog", "clog", 1000).get();
             dbcfg.schema_commitlog_scheduling_group = create_scheduling_group("schema_commitlog", "sclg", 1000).get();
             dbcfg.available_memory = memory::stats().total_memory();

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -125,6 +125,7 @@
 #include "utils/labels.hh"
 #include "view_info.hh"
 #include "raft/raft.hh"
+#include "debug.hh"
 
 #include <boost/algorithm/string/split.hpp>
 #include <boost/algorithm/string/classification.hpp>
@@ -173,11 +174,10 @@ void check_raft_rpc_scheduling_group(const replica::database& db, const gms::fea
         return;
     }
 
-    const auto gossip_scheduling_group = db.get_gossip_scheduling_group();
-    if (current_scheduling_group() != gossip_scheduling_group) {
+    if (current_scheduling_group() != debug::gossip_scheduling_group) {
         on_internal_error_noexcept(
-                slogger, seastar::format("Raft group0 RPCs should be executed in the gossip scheduling group [{}], current group is [{}], operation [{}].",
-                                 gossip_scheduling_group.name(), current_scheduling_group().name(), rpc_name));
+                slogger, seastar::format("Raft group0 RPCs should be executed in the gossip scheduling group, current group is [{}], operation [{}].",
+                                 current_scheduling_group().name(), rpc_name));
     }
 }
 

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -578,6 +578,7 @@ private:
 
             auto scheduling_groups = get_scheduling_groups().get();
             debug::streaming_scheduling_group = scheduling_groups.streaming_scheduling_group;
+            debug::gossip_scheduling_group = scheduling_groups.streaming_scheduling_group;
 
             auto notify_set = init_configurables
                 ? configurable::init_all(*cfg, init_configurables->extensions, service_set(


### PR DESCRIPTION
Some storage_service rpc verbs may checks that a handler is executed inside gossiper scheduling group. For that, the expected group is grabbed from database.

This patch puts the gossiper sched group into debug namespace and makes this check use it from there. It removes one more place that uses database as config provider.

Refs #28410

Refining debugging code, not backporting