### PR TITLE
test.py: fix the file name in test summary

### DIFF
--- a/test/pylib/cpp/boost.py
+++ b/test/pylib/cpp/boost.py
@@ -90,7 +90,7 @@ class BoostTestFile(CppFile):
         if return_code := process.returncode:
             allure.attach(stdout_file_path.read_bytes(), name="output", attachment_type=allure.attachment_type.TEXT)
             return [CppTestFailure(
-                file_name=self.path.name,
+                file_name=results[0].file_name if results else self.path.name,
                 line_num=results[0].line_num if results else -1,
                 content=dedent(f"""\
                     working_dir: {os.getcwd()}


### PR DESCRIPTION
Current way is always assumed that the error happened in the test file, but that not always true. This PR will show the error from the boost logger where actually error is happened.

Related: https://scylladb.atlassian.net/browse/SCYLLADB-449

No backport, framework enhancement only.