### PR TITLE
test: remove xfail markers from SELECT JSON count(*) tests

### DIFF
--- a/test/cqlpy/cassandra_tests/validation/entities/json_test.py
+++ b/test/cqlpy/cassandra_tests/validation/entities/json_test.py
@@ -933,7 +933,6 @@ def testToJsonFct(cql, test_keyspace):
             assert_rows(execute(cql, table, "SELECT k, toJson(durationval) FROM %s WHERE k = ?", 0), [0, "\"1y1mo2d10h5m\""])
 
 # Reproduces issue #8077
-@pytest.mark.xfail(reason="issues #8077")
 def testJsonWithGroupBy(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(k int, c int, v int, PRIMARY KEY (k, c))") as table:
         # tests SELECT JSON statements
@@ -954,7 +953,6 @@ def testJsonWithGroupBy(cql, test_keyspace):
                 ["{\"count\": 1}"])
 
 # Reproduces issues #8077, #8078
-@pytest.mark.xfail(reason="issues #8077")
 def testSelectJsonSyntax(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(k int primary key, v int)") as table:
         # tests SELECT JSON statements

--- a/test/cqlpy/test_json.py
+++ b/test/cqlpy/test_json.py
@@ -520,7 +520,6 @@ def test_tojson_decimal_high_mantissa2(cql, table1):
 
 # Reproducers for issue #8077: SELECT JSON on a function call should result
 # in the same JSON strings as it does on Cassandra.
-@pytest.mark.xfail(reason="issue #8077")
 def test_select_json_function_call(cql, table1):
     p = unique_key_int()
     cql.execute(f"INSERT INTO {table1} (p, v) VALUES ({p}, 17) USING TIMESTAMP 1234")


### PR DESCRIPTION
These were marked xfail due to #8077 (the column name was wrong), but it was fixed long ago for 5.4 (exact commit not known).

Remove the xfail markers to prevent regressions.

No backport, these tests aren't important enough.