### PR TITLE
tools: toolchain: adapt future toolchain to loss of toxiproxy in Fedora

### DIFF
--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -148,7 +148,6 @@ fedora_packages=(
     llvm
     openldap-servers
     openldap-devel
-    toxiproxy
     cyrus-sasl
     fipscheck
     cpp-jwt-devel
@@ -293,6 +292,7 @@ print_usage() {
     echo "  --print-pip-runtime-packages Print required pip packages for Scylla"
     echo "  --print-pip-symlinks Print list of pip provided commands which need to install to /usr/bin"
     echo "  --print-node-exporter-filename Print node_exporter filename"
+    echo "  --future Install dependencies for future toolchain (Fedora rawhide based)"
     exit 1
 }
 
@@ -300,6 +300,7 @@ PRINT_PYTHON3=false
 PRINT_PIP=false
 PRINT_PIP_SYMLINK=false
 PRINT_NODE_EXPORTER=false
+FUTURE=false
 while [ $# -gt 0 ]; do
     case "$1" in
         "--print-python3-runtime-packages")
@@ -316,6 +317,10 @@ while [ $# -gt 0 ]; do
             ;;
         "--print-node-exporter-filename")
             PRINT_NODE_EXPORTER=true
+            shift 1
+            ;;
+        "--future")
+            FUTURE=true
             shift 1
             ;;
          *)
@@ -346,6 +351,10 @@ fi
 if $PRINT_NODE_EXPORTER; then
     node_exporter_fullpath
     exit 0
+fi
+
+if ! $FUTURE; then
+    fedora_packages+=(toxiproxy)
 fi
 
 umask 0022
@@ -444,4 +453,12 @@ if [ ! -z "${CURL_ARGS}" ]; then
     chmod +x "${MINIO_BINARIES_DIR}/mc"
 else
     echo "Minio server and client are up-to-date, skipping download"
+fi
+
+if $FUTURE ; then
+    toxyproxy_version="v2.12.0"
+    for bin in toxiproxy-cli toxiproxy-server; do
+        curl -fSL -o "/usr/local/bin/${bin}" "https://github.com/Shopify/toxiproxy/releases/download/${toxyproxy_version}/${bin}-linux-$(go_arch)"
+        chmod +x "/usr/local/bin/${bin}"
+    done
 fi

--- a/tools/toolchain/future.dockerfile
+++ b/tools/toolchain/future.dockerfile
@@ -18,7 +18,7 @@ RUN echo install_weak_deps=False >> /etc/dnf/dnf.conf
 # Install dependencies using bind-mounted source tree (read-only from build context)
 RUN --mount=type=bind,source=.,target=/src \
     dnf -y update && \
-    cd /src && ./install-dependencies.sh
+    cd /src && ./install-dependencies.sh --future
 
 # Build dependencies for GCC and Clang
 RUN dnf -y install git flex texinfo gmp-devel mpfr-devel libmpc-devel zlib-devel \


### PR DESCRIPTION
Next Fedora will likely not have toxiproxy packaged [1]. Adapt by installing it directly. To avoid changing the current toolchain, add a ./install-dependencies --future option. This will allow us to easily go back to the packages if the Fedora bug is fixed.

[1] https://bugzilla.redhat.com/show_bug.cgi?id=2426954

Improvement for future toolchain, not release branches, so not backporting.