### PR TITLE
tablet aware restore: Extend tablet options with max_tablet_count hint

### DIFF
--- a/db/tablet_options.cc
+++ b/db/tablet_options.cc
@@ -9,6 +9,7 @@
 
 #include "exceptions/exceptions.hh"
 #include "db/tablet_options.hh"
+#include <seastar/core/bitops.hh>
 #include "utils/log.hh"
 
 extern logging::logger dblog;
@@ -21,6 +22,11 @@ tablet_options::tablet_options(const map_type& map) {
         case tablet_option_type::min_tablet_count:
             if (auto value = std::atol(value_str.c_str())) {
                 min_tablet_count.emplace(value);
+            }
+            break;
+        case tablet_option_type::max_tablet_count:
+            if (auto value = std::atol(value_str.c_str())) {
+                max_tablet_count.emplace(value);
             }
             break;
         case tablet_option_type::min_per_shard_tablet_count:
@@ -40,6 +46,7 @@ tablet_options::tablet_options(const map_type& map) {
 sstring tablet_options::to_string(tablet_option_type hint) {
     switch (hint) {
     case tablet_option_type::min_tablet_count: return "min_tablet_count";
+    case tablet_option_type::max_tablet_count: return "max_tablet_count";
     case tablet_option_type::min_per_shard_tablet_count: return "min_per_shard_tablet_count";
     case tablet_option_type::expected_data_size_in_gb: return "expected_data_size_in_gb";
     }
@@ -48,6 +55,8 @@ sstring tablet_options::to_string(tablet_option_type hint) {
 tablet_option_type tablet_options::from_string(sstring hint_desc) {
     if (hint_desc == "min_tablet_count") {
         return tablet_option_type::min_tablet_count;
+    } else if (hint_desc == "max_tablet_count") {
+        return tablet_option_type::max_tablet_count;
     } else if (hint_desc == "min_per_shard_tablet_count") {
         return tablet_option_type::min_per_shard_tablet_count;
     } else if (hint_desc == "expected_data_size_in_gb") {
@@ -62,6 +71,9 @@ std::map<sstring, sstring> tablet_options::to_map() const {
     if (min_tablet_count) {
         res[to_string(tablet_option_type::min_tablet_count)] = fmt::to_string(*min_tablet_count);
     }
+    if (max_tablet_count) {
+        res[to_string(tablet_option_type::max_tablet_count)] = fmt::to_string(*max_tablet_count);
+    }
     if (min_per_shard_tablet_count) {
         res[to_string(tablet_option_type::min_per_shard_tablet_count)] = fmt::to_string(*min_per_shard_tablet_count);
     }
@@ -72,11 +84,23 @@ std::map<sstring, sstring> tablet_options::to_map() const {
 }
 
 void tablet_options::validate(const map_type& map) {
+    std::optional<ssize_t> min_tablets;
+    std::optional<ssize_t> max_tablets;
+    
     for (auto& [key, value_str] : map) {
         switch (tablet_options::from_string(key)) {
         case tablet_option_type::min_tablet_count:
             if (auto value = std::atol(value_str.c_str()); value < 0) {
                 throw exceptions::configuration_exception(format("Invalid value '{}' for min_tablet_count", value));
+            } else {
+                min_tablets = value;
+            }
+            break;
+        case tablet_option_type::max_tablet_count:
+            if (auto value = std::atol(value_str.c_str()); value <= 0) {
+                throw exceptions::configuration_exception(format("Invalid value '{}' for max_tablet_count", value));
+            } else {
+                max_tablets = value;
             }
             break;
         case tablet_option_type::min_per_shard_tablet_count:
@@ -89,6 +113,20 @@ void tablet_options::validate(const map_type& map) {
                 throw exceptions::configuration_exception(format("Invalid value '{}' for expected_data_size_in_gb", value));
             }
             break;
+        }
+    }
+
+    if (min_tablets && max_tablets) {
+        auto effective_min = 1u << log2ceil(static_cast<size_t>(*min_tablets));
+        auto effective_max = 1u << log2floor(static_cast<size_t>(*max_tablets));
+
+        if (effective_min > effective_max) {
+            throw exceptions::configuration_exception(
+                    format("Invalid tablet count range: min_tablet_count={} (effective: {}) and max_tablet_count={} (effective: {}) "
+                           "result in conflicting constraints after rounding to powers of 2. "
+                           "Since tablet counts must be powers of 2, min_tablet_count rounds up and max_tablet_count rounds down"
+                           "Please adjust the values so that the smallest power of 2 greater than min_tablet_count is <= the largest power of 2 <= max_tablet_count.",
+                            *min_tablets, effective_min, *max_tablets, effective_max));
         }
     }
 }

--- a/db/tablet_options.hh
+++ b/db/tablet_options.hh
@@ -18,6 +18,7 @@ namespace db {
 // Per-table tablet options
 enum class tablet_option_type {
     min_tablet_count,
+    max_tablet_count,
     min_per_shard_tablet_count,
     expected_data_size_in_gb,
 };
@@ -26,6 +27,7 @@ struct tablet_options {
     using map_type = std::map<sstring, sstring>;
 
     std::optional<ssize_t> min_tablet_count;
+    std::optional<ssize_t> max_tablet_count;
     std::optional<double> min_per_shard_tablet_count;
     std::optional<ssize_t> expected_data_size_in_gb;
 
@@ -33,7 +35,7 @@ struct tablet_options {
     explicit tablet_options(const map_type& map);
 
     operator bool() const noexcept {
-        return min_tablet_count || min_per_shard_tablet_count || expected_data_size_in_gb;
+        return min_tablet_count || max_tablet_count || min_per_shard_tablet_count || expected_data_size_in_gb;
     }
 
     map_type to_map() const;

--- a/docs/architecture/tablets.rst
+++ b/docs/architecture/tablets.rst
@@ -106,6 +106,8 @@ The computed number of tablets a table will have is based on several parameters 
   tablets on average. See :ref:`Per-table tablet options <cql-per-table-tablet-options>` for details.
 * Table-level option ``'min_tablet_count'``. This option sets the minimal number of tablets for the given table.
   See :ref:`Per-table tablet options <cql-per-table-tablet-options>` for details.
+* Table-level option ``'max_tablet_count'``. This option sets the maximum number of tablets for the given table
+  See :ref:`Per-table tablet options <cql-per-table-tablet-options>` for details.
 * Config option ``'tablets_initial_scale_factor'``. This option sets the minimal number of tablets per shard
   per table globally. This option can be overridden by the table-level option: ``'min_per_shard_tablet_count'``.
   ``'tablets_initial_scale_factor'`` is ignored if either the keyspace option ``'initial'`` or table-level
@@ -118,6 +120,18 @@ half the target tablet size, it will be merged (the number of tablets will be ha
 
 Each of these factors is taken into consideration, and the one producing the largest number of tablets wins, and
 will be used as the number of tablets for the given table.
+
+.. note::
+
+    When both ``'min_tablet_count'`` and ``'max_tablet_count'`` are set together, ScyllaDB validates the
+    combination by computing **effective** bounds:
+
+    * The **effective minimum** is the smallest power of 2 that is greater than or equal to ``min_tablet_count``.
+    * The **effective maximum** is the largest power of 2 that is less than or equal to ``max_tablet_count``.
+
+    ScyllaDB validates that the effective minimum does not exceed the effective maximum. If it does,
+    the ``CREATE TABLE`` statement will be rejected with an error. To avoid ambiguity, it is recommended
+    to use power-of-2 values for both options.
 
 As the last step, in order to avoid having too many tablets per shard, which could potentially lead to overload
 and performance degradation, ScyllaDB will run the following algorithm to respect the ``tablets_per_shard_goal``

--- a/docs/cql/ddl.rst
+++ b/docs/cql/ddl.rst
@@ -1128,6 +1128,13 @@ if its data size, or performance requirements are known in advance.
                                                 function of the tablet count, the replication factor in the datacenter, and the number
                                                 of nodes and shards in the datacenter.  It is recommended to use higher-level options
                                                 such as ``expected_data_size_in_gb`` or ``min_per_shard_tablet_count`` instead.
+ ``max_tablet_count``           0               Sets the maximum number of tablets for the table. When set, the tablet count
+                                                will not exceed this value, even if the table grows large enough to normally
+                                                trigger tablet splits. This option is mainly intended for use during restore
+                                                operations, to ensure that each SSTable fits entirely within a single tablet.
+                                                This enables efficient file-based streaming during restore. Setting both
+                                                ``min_tablet_count`` and ``max_tablet_count`` to the same value fixes the
+                                                tablet count for the table.
 =============================== =============== ===================================================================================
 
 When allocating tablets for a new table, ScyllaDB uses the maximum of the ``initial`` tablets configured for the keyspace

--- a/docs/dev/describe_schema.md
+++ b/docs/dev/describe_schema.md
@@ -147,7 +147,7 @@ CREATE TABLE ks.t_scylla_cdc_log (
     AND comment = 'CDC log for ks.t'
     AND compaction = {'class': 'TimeWindowCompactionStrategy', 'compaction_window_size': '60', 'compaction_window_unit': 'MINUTES', 'expired_sstable_check_frequency_seconds': '1800'}
     AND compression = {'sstable_compression': 'org.apache.cassandra.io.compress.LZ4Compressor'}
-    AND tablets = {'expected_data_size_in_gb': '250', 'min_per_shard_tablet_count': '0.8', 'min_tablet_count': '1'}
+    AND tablets = {'expected_data_size_in_gb': '250', 'min_per_shard_tablet_count': '0.8', 'min_tablet_count': '1', 'max_tablet_count': '8'}
     AND crc_check_chance = 1
     AND default_time_to_live = 0
     AND gc_grace_seconds = 0

--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -138,6 +138,13 @@ db::tablet_options combine_tablet_options(R&& opts) {
             total_expected_data_size_in_gb += *opt.expected_data_size_in_gb;
             total_expected_data_size_in_gb_count++;
         }
+        if (opt.max_tablet_count) {
+            if (!combined_opts.max_tablet_count) {
+                combined_opts.max_tablet_count = *opt.max_tablet_count;
+            } else {
+                combined_opts.max_tablet_count = std::min(*combined_opts.max_tablet_count, *opt.max_tablet_count);
+            }
+        }
     }
 
     if (total_expected_data_size_in_gb_count) {
@@ -1786,10 +1793,10 @@ public:
             auto target_tablet_size = _target_tablet_size / tables.size();
 
             tablet_count_and_reason target_tablet_count = {1, ""};
-            auto maybe_apply = [&] (tablet_count_and_reason candidate) {
+            auto maybe_apply = [&] (tablet_count_and_reason candidate, bool force = false) {
                 lblogger.debug("Table {} ({}.{}) wants {} tablets due to {}", table, s->ks_name(), s->cf_name(),
                         candidate.tablet_count, candidate.reason);
-                if (candidate.tablet_count > target_tablet_count.tablet_count) {
+                if (candidate.tablet_count > target_tablet_count.tablet_count || force) {
                     target_tablet_count = candidate;
                 }
             };
@@ -1855,6 +1862,13 @@ public:
                 // can only increase the count above it, but decreasing may go against the true target count
                 // if tablet_count_from_size would demand more tablets.
                 maybe_apply({table_plan.current_tablet_count, "current count"});
+            }
+
+            // Apply max_tablet_count cap after all other factors have been considered.
+            if (tablet_options.max_tablet_count) {
+                if (target_tablet_count.tablet_count > static_cast<size_t>(*tablet_options.max_tablet_count)) {
+                    maybe_apply({static_cast<size_t>(*tablet_options.max_tablet_count), "max_tablet_count"}, true);
+                }
             }
 
             if (utils::get_local_injector().enter("tablet_force_tablet_count_increase")) {

--- a/test/boost/tablets_test.cc
+++ b/test/boost/tablets_test.cc
@@ -6175,4 +6175,140 @@ SEASTAR_THREAD_TEST_CASE(test_get_secondary_replica) {
     topo.clear_gently().get();
 }
 
+// The purpose of this test is to emulate a tablet aware restore process
+// When a snapshot is taken, load balancing is disabled, so we record the tablet count in a manifest for backup.
+// During restore, we set both min_tablet_count and max_tablet_count hints to the same value
+// The test makes sure that during restore the tablet count <= max_tablet_count hint which 
+// allows us to leverage file-based streaming of SSTables, ensuring each SSTable is fully contained within a single tablet.
+SEASTAR_THREAD_TEST_CASE(test_tablet_count_fixed_by_table_properties) {
+    auto cfg = tablet_cql_test_config();
+    cfg.db_config->tablets_per_shard_goal(16);
+    
+    do_with_cql_env_thread([&cfg] (auto& e) {
+        topology_builder topo(e);
+        auto dc = topo.dc();
+
+        topo.add_node(node_state::normal, 1);
+
+        // keyspace 'initial' wants 8 tablets. We want to make sure that initial tablet count is greater than max_tablet_count hint
+        // to ensure that the hint is respected.
+        auto ks_name1 = add_keyspace(e, {{dc, 1}}, 8);
+        
+        // Step 1: Create a table 
+        e.execute_cql(fmt::format("CREATE TABLE {}.table1 (p1 text, r1 int, PRIMARY KEY (p1))", ks_name1)).get();
+        auto table1 = e.local_db().find_schema(ks_name1, "table1")->id();
+
+        auto& stm = e.shared_token_metadata().local();
+        auto get_tablet_count = [&] {
+            auto tm = stm.get();
+            return tm->tablets().get_tablet_map(table1).tablet_count();
+        };
+
+        shared_load_stats& load_stats = topo.get_shared_load_stats();
+        load_stats.set_size(table1, 0); 
+
+        rebalance_tablets(e, &load_stats);
+        BOOST_REQUIRE_EQUAL(get_tablet_count(), 8);
+
+        // Step 2: Drop the table
+        e.execute_cql(fmt::format("DROP TABLE {}.table1", ks_name1)).get();
+
+        // Step 3: Create the same table with min_tablet_count=4 and max_tablet_count=4
+        auto force_tablet_count = 4;
+        e.execute_cql(fmt::format("CREATE TABLE {}.table1 (p1 text, r1 int, PRIMARY KEY (p1)) "
+                                  "WITH tablets = {{'min_tablet_count': {}, 'max_tablet_count': {}}}",
+                              ks_name1, force_tablet_count, force_tablet_count)).get();
+        
+        // We need fetch the table again as the previous table was dropped and recreated                      
+        table1 = e.local_db().find_schema(ks_name1, "table1")->id();
+        //Initially table will be empty
+        load_stats.set_size(table1, 0);
+
+        // Step 4: Make sure the tablet count is equal to force_tablet_count
+        BOOST_REQUIRE_EQUAL(get_tablet_count(), force_tablet_count);
+
+        // Step 5: Increase the load and make sure tablet count remains equal to force_tablet_count
+        load_stats.set_size(table1, default_target_tablet_size * force_tablet_count * 128);
+        rebalance_tablets(e, &load_stats);
+        BOOST_REQUIRE_EQUAL(get_tablet_count(), force_tablet_count);
+
+        // this should force tablets to be merged, the max_tablet_count hint will no longer be respected.
+        cfg.db_config->tablets_per_shard_goal(force_tablet_count / 2);
+        rebalance_tablets(e, &load_stats);
+        BOOST_REQUIRE_LE(get_tablet_count(), force_tablet_count);
+    }, cfg).get();
+}
+
+SEASTAR_THREAD_TEST_CASE(test_tablet_options_min_and_max_tablet_count) {
+    auto cfg = tablet_cql_test_config();
+    cfg.db_config->tablets_per_shard_goal(16);
+
+    do_with_cql_env_thread([] (auto& e) {
+        topology_builder topo(e);
+        auto dc = topo.dc();
+
+        topo.add_node(node_state::normal, 1);
+
+        auto ks_name1 = add_keyspace(e, {{dc, 1}}, 8);
+
+        // Test valid combinations
+        {
+            // min=64, max=128 - both powers of 2, should work
+            BOOST_CHECK_NO_THROW(e.execute_cql(fmt::format(
+                "CREATE TABLE {}.table1 (p1 text, r1 int, PRIMARY KEY (p1)) "
+                "WITH tablets = {{'min_tablet_count': 64, 'max_tablet_count': 128}}",
+                ks_name1)).get());
+        }
+
+        {
+            // min=100, max=200 - rounds to min=128, max=128, should work
+            BOOST_CHECK_NO_THROW(e.execute_cql(fmt::format(
+                "CREATE TABLE {}.table2 (p1 text, r1 int, PRIMARY KEY (p1)) "
+                "WITH tablets = {{'min_tablet_count': 100, 'max_tablet_count': 200}}",
+                ks_name1)).get());
+        }
+
+        // Test invalid combinations that should throw exceptions
+        {
+            // min=100, max=100 - rounds to min=128, max=64, invalid
+            BOOST_CHECK_EXCEPTION(e.execute_cql(fmt::format(
+                "CREATE TABLE {}.table3 (p1 text, r1 int, PRIMARY KEY (p1)) "
+                "WITH tablets = {{'min_tablet_count': 100, 'max_tablet_count': 100}}",
+                ks_name1)).get(),
+                exceptions::configuration_exception,
+                [&](const exceptions::configuration_exception& e) {
+                    const auto msg = sstring(e.what());
+                    return msg.contains("Invalid tablet count range");
+                });
+        }
+
+        {
+            // min=65, max=127 - rounds to min=128, max=64, invalid
+            BOOST_CHECK_EXCEPTION(e.execute_cql(fmt::format(
+                "CREATE TABLE {}.table4 (p1 text, r1 int, PRIMARY KEY (p1)) "
+                "WITH tablets = {{'min_tablet_count': 65, 'max_tablet_count': 127}}",
+                ks_name1)).get(),
+                exceptions::configuration_exception,
+                [&](const exceptions::configuration_exception& e) {
+                    const auto msg = sstring(e.what());
+                    return msg.contains("Invalid tablet count range");
+                });
+        }
+
+       {
+            // min=129, max=128 - even without rounding, min > max is invalid
+            BOOST_CHECK_EXCEPTION(e.execute_cql(fmt::format(
+                "CREATE TABLE {}.table6 (p1 text, r1 int, PRIMARY KEY (p1)) "
+                "WITH tablets = {{'min_tablet_count': 129, 'max_tablet_count': 128}}",
+                ks_name1)).get(),
+                exceptions::configuration_exception,
+                [&](const exceptions::configuration_exception& e) {
+                    const auto msg = sstring(e.what());
+                    return msg.contains("Invalid tablet count range");
+                });
+        }
+
+    }, cfg).get();
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/cluster/test_tablets.py
+++ b/test/cluster/test_tablets.py
@@ -255,14 +255,20 @@ async def test_tablets_api_consistency(manager: ManagerClient, endpoint):
     await manager.disable_tablet_balancing()
     hosts = { await manager.get_host_id(s.server_id): s.ip_addr for s in servers }
     cql = manager.get_cql()
+    expected_tablet_count = 4
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3}") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int) WITH TABLETS = {{'min_tablet_count': 4}};")
+        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int) WITH TABLETS = {{'min_tablet_count': {expected_tablet_count}, 'max_tablet_count': {expected_tablet_count}}};")
+
 
         def columnar(lst):
             return f"\n    {'\n    '.join([f'{x}' for x in lst])}"
 
         replicas = await get_all_tablet_replicas(manager, servers[0], ks, "test")
         logger.info(f'system.tablets: {columnar(replicas)}')
+        # replicas contains a list of objects, one per tablet, so in the end len(replicas) returns the current number of tablets.
+        # with load balancing disabled and min_tablet_count being equal to max_tablet_count, 
+        # we expect the same number of tablets as the min/max_tablet_count value 
+        assert len(replicas) == expected_tablet_count, f"Expected {expected_tablet_count} tablets, got {len(replicas)}"
 
         if endpoint == 'describe_ring':
             ring_info = await manager.api.describe_ring(servers[0].ip_addr, ks, "test")

--- a/test/cqlpy/test_describe.py
+++ b/test/cqlpy/test_describe.py
@@ -285,6 +285,7 @@ def test_desc_table(cql, test_keyspace, random_seed):
 def test_desc_table_with_tablet_options(cql, test_keyspace, random_seed, skip_without_tablets):
     tablet_options = {
         'min_tablet_count': '100',
+        'max_tablet_count': '200',  
         'min_per_shard_tablet_count': '0.8',   # Verify that a floating point value works for this hint
         'expected_data_size_in_gb': '50',
     }


### PR DESCRIPTION
Add `max_tablet_count` tablet option to enforce tablet count upper bounds

Introduces a new `max_tablet_count` tablet option that caps the maximum number of tablets a table can have. This feature is designed primarily for backup and restore workflows.

During backup, when load balancing is disabled for snapshot consistency, the current tablet count is recorded in the backup manifest. During restore, `max_tablet_count` is set to this recorded value, ensuring the restored table's tablet count never exceeds the original snapshot's tablet distribution.

This guarantee enables efficient file-based SSTable streaming during restore, as each SSTable remains fully contained within a single tablet boundary.


Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-242
