### PR TITLE
Allow arbitrary tablet boundaries and count

### DIFF
--- a/cql3/statements/cf_prop_defs.cc
+++ b/cql3/statements/cf_prop_defs.cc
@@ -197,7 +197,7 @@ void cf_prop_defs::validate(const data_dictionary::database db, sstring ks_name,
         if (!db.features().tablet_options) {
             throw exceptions::configuration_exception("tablet options cannot be used until all nodes in the cluster enable this feature");
         }
-        db::tablet_options::validate(*tablet_options_map);
+        db::tablet_options::validate(*tablet_options_map, db.features());
     }
 
     if (has_property(KW_STORAGE_ENGINE)) {

--- a/db/tablet_options.cc
+++ b/db/tablet_options.cc
@@ -9,12 +9,24 @@
 
 #include "exceptions/exceptions.hh"
 #include "db/tablet_options.hh"
+#include "gms/feature_service.hh"
 #include <seastar/core/bitops.hh>
 #include "utils/log.hh"
 
 extern logging::logger dblog;
 
 namespace db {
+
+static
+bool parse_bool_option(const sstring& value) {
+    if (strcasecmp(value.c_str(), "true") == 0 || strcasecmp(value.c_str(), "yes") == 0 || value == "1") {
+        return true;
+    }
+    if (strcasecmp(value.c_str(), "false") == 0 || strcasecmp(value.c_str(), "no") == 0 || value == "0") {
+        return false;
+    }
+    throw std::invalid_argument(format("Invalid boolean value: {}", value));
+}
 
 tablet_options::tablet_options(const map_type& map) {
     for (auto& [key, value_str] : map) {
@@ -39,6 +51,9 @@ tablet_options::tablet_options(const map_type& map) {
                 expected_data_size_in_gb.emplace(value);
             }
             break;
+        case tablet_option_type::pow2_count:
+            pow2_count = parse_bool_option(value_str);
+            break;
         }
     }
 }
@@ -49,6 +64,7 @@ sstring tablet_options::to_string(tablet_option_type hint) {
     case tablet_option_type::max_tablet_count: return "max_tablet_count";
     case tablet_option_type::min_per_shard_tablet_count: return "min_per_shard_tablet_count";
     case tablet_option_type::expected_data_size_in_gb: return "expected_data_size_in_gb";
+    case tablet_option_type::pow2_count: return "pow2_count";
     }
 }
 
@@ -61,6 +77,8 @@ tablet_option_type tablet_options::from_string(sstring hint_desc) {
         return tablet_option_type::min_per_shard_tablet_count;
     } else if (hint_desc == "expected_data_size_in_gb") {
         return tablet_option_type::expected_data_size_in_gb;
+    } else if (hint_desc == "pow2_count") {
+        return tablet_option_type::pow2_count;
     } else {
         throw exceptions::syntax_exception(fmt::format("Unknown tablet hint '{}'", hint_desc));
     }
@@ -80,13 +98,17 @@ std::map<sstring, sstring> tablet_options::to_map() const {
     if (expected_data_size_in_gb) {
         res[to_string(tablet_option_type::expected_data_size_in_gb)] = fmt::to_string(*expected_data_size_in_gb);
     }
+    if (pow2_count) {
+        res[to_string(tablet_option_type::pow2_count)] = fmt::to_string(*pow2_count);
+    }
     return res;
 }
 
-void tablet_options::validate(const map_type& map) {
+void tablet_options::validate(const map_type& map, const gms::feature_service& features) {
     std::optional<ssize_t> min_tablets;
     std::optional<ssize_t> max_tablets;
-    
+    bool pow2_count = features.arbitrary_tablet_boundaries ? default_pow2_count : true;
+
     for (auto& [key, value_str] : map) {
         switch (tablet_options::from_string(key)) {
         case tablet_option_type::min_tablet_count:
@@ -113,12 +135,23 @@ void tablet_options::validate(const map_type& map) {
                 throw exceptions::configuration_exception(format("Invalid value '{}' for expected_data_size_in_gb", value));
             }
             break;
+        case tablet_option_type::pow2_count:
+            try {
+                pow2_count = parse_bool_option(value_str);
+            } catch (const std::invalid_argument& e) {
+                throw exceptions::configuration_exception(format("Invalid value '{}' for pow2_count", value_str));
+            }
+            if (!pow2_count && !features.arbitrary_tablet_boundaries) {
+                throw exceptions::configuration_exception(
+                        "pow2_count cannot be set to false until the arbitrary_tablet_boundaries feature is enabled");
+            }
+            break;
         }
     }
 
     if (min_tablets && max_tablets) {
-        auto effective_min = 1u << log2ceil(static_cast<size_t>(*min_tablets));
-        auto effective_max = 1u << log2floor(static_cast<size_t>(*max_tablets));
+        auto effective_min = pow2_count ? 1u << log2ceil(static_cast<size_t>(*min_tablets)) : static_cast<size_t>(*min_tablets);
+        auto effective_max = pow2_count ? 1u << log2floor(static_cast<size_t>(*max_tablets)) : static_cast<size_t>(*max_tablets);
 
         if (effective_min > effective_max) {
             throw exceptions::configuration_exception(

--- a/db/tablet_options.hh
+++ b/db/tablet_options.hh
@@ -13,6 +13,8 @@
 
 using namespace seastar;
 
+namespace gms { class feature_service; }
+
 namespace db {
 
 // Per-table tablet options
@@ -21,28 +23,33 @@ enum class tablet_option_type {
     max_tablet_count,
     min_per_shard_tablet_count,
     expected_data_size_in_gb,
+    pow2_count,
 };
 
 struct tablet_options {
+    // System-wide default for pow2_count if the option is not set.
+    static const bool default_pow2_count = true;
+
     using map_type = std::map<sstring, sstring>;
 
     std::optional<ssize_t> min_tablet_count;
     std::optional<ssize_t> max_tablet_count;
     std::optional<double> min_per_shard_tablet_count;
     std::optional<ssize_t> expected_data_size_in_gb;
+    std::optional<bool> pow2_count;
 
     tablet_options() = default;
     explicit tablet_options(const map_type& map);
 
     operator bool() const noexcept {
-        return min_tablet_count || max_tablet_count || min_per_shard_tablet_count || expected_data_size_in_gb;
+        return min_tablet_count || max_tablet_count || min_per_shard_tablet_count || expected_data_size_in_gb || pow2_count;
     }
 
     map_type to_map() const;
 
     static sstring to_string(tablet_option_type hint);
     static tablet_option_type from_string(sstring hint_desc);
-    static void validate(const map_type& map);
+    static void validate(const map_type& map, const gms::feature_service& features);
 };
 
 } // namespace db

--- a/dht/token.cc
+++ b/dht/token.cc
@@ -231,6 +231,15 @@ dht::token find_first_token_for_shard(
 }
 
 size_t
+compaction_group_of(unsigned most_significant_bits, dht::raw_token t) {
+    if (!most_significant_bits) {
+        return 0;
+    }
+    uint64_t adjusted = unbias(t);
+    return adjusted >> (64 - most_significant_bits);
+}
+
+size_t
 compaction_group_of(unsigned most_significant_bits, const token& t) {
     if (!most_significant_bits) {
         return 0;

--- a/dht/token.cc
+++ b/dht/token.cc
@@ -257,4 +257,17 @@ token last_token_of_compaction_group(unsigned most_significant_bits, size_t grou
     return bias(n);
 }
 
+utils::chunked_vector<dht::raw_token> get_uniform_tokens(size_t count) {
+    utils::chunked_vector<dht::raw_token> tokens;
+    tokens.reserve(count);
+
+    for (size_t i = 1; i <= count; ++i) {
+        uint64_t n = (uint128_t(i) * std::numeric_limits<uint64_t>::max()) / count;
+        tokens.push_back(raw_token{bias(n)});
+        assert(tokens.back().value != std::numeric_limits<int64_t>::min()); // See token::normalize()
+    }
+
+    return tokens;
+}
+
 } // namespace dht

--- a/dht/token.hh
+++ b/dht/token.hh
@@ -356,6 +356,7 @@ inline constexpr token bias(uint64_t n) {
     return token::bias(n);
 }
 size_t compaction_group_of(unsigned most_significant_bits, const token& t);
+size_t compaction_group_of(unsigned most_significant_bits, dht::raw_token);
 token last_token_of_compaction_group(unsigned most_significant_bits, size_t group);
 
 // Generates 'count' tokens uniformly distributed in the token ring. Sorted.

--- a/dht/token.hh
+++ b/dht/token.hh
@@ -358,6 +358,10 @@ inline constexpr token bias(uint64_t n) {
 size_t compaction_group_of(unsigned most_significant_bits, const token& t);
 token last_token_of_compaction_group(unsigned most_significant_bits, size_t group);
 
+// Generates 'count' tokens uniformly distributed in the token ring. Sorted.
+// All values are in the range [first_token(), last_token()]
+utils::chunked_vector<dht::raw_token> get_uniform_tokens(size_t count);
+
 struct token_comparator {
     // Return values are those of a trichotomic comparison.
     constexpr std::strong_ordering operator()(const token& t1, const token& t2) const noexcept {

--- a/docs/architecture/tablets.rst
+++ b/docs/architecture/tablets.rst
@@ -108,6 +108,8 @@ The computed number of tablets a table will have is based on several parameters 
   See :ref:`Per-table tablet options <cql-per-table-tablet-options>` for details.
 * Table-level option ``'max_tablet_count'``. This option sets the maximum number of tablets for the given table
   See :ref:`Per-table tablet options <cql-per-table-tablet-options>` for details.
+* Table-level option ``pow2_count``. This option, when set to true, forces the number of tablets for a given table to be a power of 2.
+  See :ref:`Per-table tablet options <cql-per-table-tablet-options>` for details.
 * Config option ``'tablets_initial_scale_factor'``. This option sets the minimal number of tablets per shard
   per table globally. This option can be overridden by the table-level option: ``'min_per_shard_tablet_count'``.
   ``'tablets_initial_scale_factor'`` is ignored if either the keyspace option ``'initial'`` or table-level
@@ -126,8 +128,10 @@ will be used as the number of tablets for the given table.
     When both ``'min_tablet_count'`` and ``'max_tablet_count'`` are set together, ScyllaDB validates the
     combination by computing **effective** bounds:
 
-    * The **effective minimum** is the smallest power of 2 that is greater than or equal to ``min_tablet_count``.
-    * The **effective maximum** is the largest power of 2 that is less than or equal to ``max_tablet_count``.
+    * The **effective minimum** is the smallest power of 2 that is greater than or equal to ``min_tablet_count`` if ``pow2_count`` is true,
+        or simply ``min_tablet_count`` otherwise.
+    * The **effective maximum** is the largest power of 2 that is less than or equal to ``max_tablet_count`` if ``pow2_count`` is true,
+        or simply ``max_tablet_count`` otherwise.
 
     ScyllaDB validates that the effective minimum does not exceed the effective maximum. If it does,
     the ``CREATE TABLE`` statement will be rejected with an error. To avoid ambiguity, it is recommended

--- a/docs/cql/ddl.rst
+++ b/docs/cql/ddl.rst
@@ -500,6 +500,7 @@ Creating a new table uses the ``CREATE TABLE`` statement:
    tablet_option: 'expected_data_size_in_gb' ':' <int>
              : | 'min_per_shard_tablet_count' ':' <float>
              : | 'min_tablet_count' ':' <int>
+             : | 'pow2_count' ':' ( 'true' | 'false' )
 
 For instance::
 
@@ -1138,6 +1139,8 @@ if its data size, or performance requirements are known in advance.
                                                 This enables efficient file-based streaming during restore. Setting both
                                                 ``min_tablet_count`` and ``max_tablet_count`` to the same value fixes the
                                                 tablet count for the table.
+ ``pow2_count``                 "true"          When set to ``true``, the tablet count of a table is always a power of 2. The
+                                                count wanted due to all other factors is rounded up to the nearest power of 2.
 =============================== =============== ===================================================================================
 
 When allocating tablets for a new table, ScyllaDB uses the maximum of the ``initial`` tablets configured for the keyspace

--- a/docs/dev/object_storage.md
+++ b/docs/dev/object_storage.md
@@ -290,7 +290,8 @@ The `table` member contains metadata about the table being snapshot.
 - `table_id` - a universally unique identifier (UUID) of the table set when the table is created.
 - `tablets_type`:
     - `none` - if the keyspace uses vnodes replication
-    - `powof2` - if the keyspace uses tables replication, and the tablet token ranges are based on powers of 2.
+    - `powof2` - if the keyspace uses tablets replication, and the tablet token ranges are based on powers of 2.
+    - `arbitrary` - if the keyspace uses tablets replication, and the tablet token ranges and count can be arbitrary.
 - `tablet_count` - Optional. If `tablets_type` is not `none`, contains the number of tablets allcated in the table. If `tablets_type` is `powof2`, tablet_count would be a power of 2.
 
 The `sstables` member is a list containing metadata about the SSTables in the snapshot.

--- a/gms/feature_service.hh
+++ b/gms/feature_service.hh
@@ -180,6 +180,7 @@ public:
     gms::feature batchlog_v2 { *this, "BATCHLOG_V2"sv };
     gms::feature vnodes_to_tablets_migrations { *this, "VNODES_TO_TABLETS_MIGRATIONS"sv };
     gms::feature writetime_ttl_individual_element { *this, "WRITETIME_TTL_INDIVIDUAL_ELEMENT"sv };
+    gms::feature arbitrary_tablet_boundaries { *this, "ARBITRARY_TABLET_BOUNDARIES"sv };
 public:
 
     const std::unordered_map<sstring, std::reference_wrapper<feature>>& registered_features() const;

--- a/locator/network_topology_strategy.cc
+++ b/locator/network_topology_strategy.cc
@@ -306,13 +306,7 @@ effective_replication_map_ptr network_topology_strategy::make_replication_map(ta
 }
 
 future<tablet_map> network_topology_strategy::allocate_tablets_for_new_table(schema_ptr s, token_metadata_ptr tm, size_t tablet_count) const {
-    auto aligned_tablet_count = 1ul << log2ceil(tablet_count);
-    if (tablet_count != aligned_tablet_count) {
-        rslogger.info("Rounding up tablet count from {} to {} for table {}.{}", tablet_count, aligned_tablet_count, s->ks_name(), s->cf_name());
-        tablet_count = aligned_tablet_count;
-    }
-    co_return co_await reallocate_tablets(std::move(s), std::move(tm), 
-        tablet_map(tablet_count, get_consistency() != data_dictionary::consistency_config_option::eventual));
+    co_return co_await reallocate_tablets(std::move(s), std::move(tm), tablet_map(tablet_count, get_consistency() != data_dictionary::consistency_config_option::eventual));
 }
 
 future<tablet_map> network_topology_strategy::reallocate_tablets(schema_ptr s, token_metadata_ptr tm, tablet_map tablets) const {

--- a/locator/tablets.cc
+++ b/locator/tablets.cc
@@ -947,22 +947,12 @@ const std::optional<locator::repair_scheduler_config> tablet_map::get_repair_sch
     return _repair_scheduler_config;
 }
 
-static auto to_resize_type(sstring decision) {
-    static const std::unordered_map<sstring, decltype(resize_decision::way)> string_to_type = {
-        {"none", resize_decision::none{}},
-        {"split", resize_decision::split{}},
-        {"merge", resize_decision::merge{}},
-    };
-    return string_to_type.at(decision);
-}
-
-resize_decision::resize_decision(sstring decision, uint64_t seq_number)
-    : way(to_resize_type(decision))
-    , sequence_number(seq_number) {
-}
-
 sstring resize_decision::type_name() const {
-    return fmt::format("{}", way);
+    return std::visit(seastar::make_visitor(
+        [] (const resize_decision::none&) { return "none"; },
+        [] (const resize_decision::split&) { return "split"; },
+        [] (const resize_decision::merge&) { return "merge"; }
+    ), way);
 }
 
 resize_decision::seq_number_t resize_decision::next_sequence_number() const {
@@ -1844,13 +1834,17 @@ future<> tablet_id_map::clear_gently() {
 
 auto fmt::formatter<locator::resize_decision_way>::format(const locator::resize_decision_way& way, fmt::format_context& ctx) const
         -> decltype(ctx.out()) {
-    static const std::array<sstring, 3> index_to_string = {
-        "none",
-        "split",
-        "merge",
-    };
-    static_assert(std::variant_size_v<locator::resize_decision_way> == index_to_string.size());
-    return fmt::format_to(ctx.out(), "{}", index_to_string[way.index()]);
+    std::visit(seastar::make_visitor(
+        [&] (const locator::resize_decision::none&) {
+            fmt::format_to(ctx.out(), "none");
+        },
+        [&] (const locator::resize_decision::split&) {
+            fmt::format_to(ctx.out(), "split");
+        },
+        [&] (const locator::resize_decision::merge& merge) {
+            fmt::format_to(ctx.out(), "merge");
+        }), way);
+    return ctx.out();
 }
 
 auto fmt::formatter<locator::global_tablet_id>::format(const locator::global_tablet_id& id, fmt::format_context& ctx) const

--- a/locator/tablets.cc
+++ b/locator/tablets.cc
@@ -475,8 +475,26 @@ bool tablet_metadata::operator==(const tablet_metadata& o) const {
 }
 
 tablet_map::tablet_map(size_t tablet_count, bool with_raft_info)
-        : _log2_tablets(log2ceil(tablet_count)) {
-    if (tablet_count != 1ul << _log2_tablets) {
+    : tablet_map(dht::get_uniform_tokens(tablet_count), with_raft_info)
+{ }
+
+tablet_map::tablet_map(utils::chunked_vector<dht::raw_token> last_tokens, bool with_raft_info)
+    : _tablet_ids(std::move(last_tokens))
+{
+    if (_tablet_ids.tablet_count() != 1ul << _tablet_ids.log2_count()) {
+        on_internal_error(tablet_logger, format("Tablet count not a power of 2: {}", _tablet_ids.tablet_count()));
+    }
+
+    _tablets.resize(_tablet_ids.tablet_count());
+    if (with_raft_info) {
+        _raft_info.resize(_tablet_ids.tablet_count());
+    }
+}
+
+tablet_map::tablet_map(size_t tablet_count, bool with_raft_info, tablet_map::initialized_later)
+    : _tablet_ids(tablet_count)
+{
+    if (tablet_count != 1ul << _tablet_ids.log2_count()) {
         on_internal_error(tablet_logger, format("Tablet count not a power of 2: {}", tablet_count));
     }
     _tablets.resize(tablet_count);
@@ -486,11 +504,13 @@ tablet_map::tablet_map(size_t tablet_count, bool with_raft_info)
 }
 
 tablet_map tablet_map::clone() const {
-    return tablet_map(_tablets, _log2_tablets, _transitions, _resize_decision, _resize_task_info, 
-        _repair_scheduler_config, _raft_info);
+    return tablet_map(_tablet_ids, _tablets, _transitions, _resize_decision, _resize_task_info,
+                      _repair_scheduler_config, _raft_info);
 }
 
 future<tablet_map> tablet_map::clone_gently() const {
+    auto ids = co_await _tablet_ids.clone_gently();
+
     tablet_container tablets;
     tablets.reserve(_tablets.size());
     for (const auto& t : _tablets) {
@@ -512,8 +532,8 @@ future<tablet_map> tablet_map::clone_gently() const {
         co_await coroutine::maybe_yield();
     }
 
-    co_return tablet_map(std::move(tablets), _log2_tablets, std::move(transitions), _resize_decision, 
-        _resize_task_info, _repair_scheduler_config, std::move(raft_info));
+    co_return tablet_map(std::move(ids), std::move(tablets), std::move(transitions),
+                         _resize_decision, _resize_task_info, _repair_scheduler_config, std::move(raft_info));
 }
 
 void tablet_map::check_tablet_id(tablet_id id) const {
@@ -528,7 +548,7 @@ const tablet_info& tablet_map::get_tablet_info(tablet_id id) const {
 }
 
 tablet_id tablet_map::get_tablet_id(token t) const {
-    return tablet_id(dht::compaction_group_of(_log2_tablets, t));
+    return _tablet_ids.get_tablet_id(t);
 }
 
 dht::token tablet_map::get_split_token(tablet_id id) const {
@@ -549,7 +569,7 @@ std::pair<tablet_id, tablet_range_side> tablet_map::get_tablet_id_and_range_side
 
 dht::token tablet_map::get_last_token(tablet_id id) const {
     check_tablet_id(id);
-    return dht::last_token_of_compaction_group(_log2_tablets, size_t(id));
+    return dht::token(_tablet_ids.get_last_token(id));
 }
 
 dht::token tablet_map::get_first_token(tablet_id id) const {
@@ -652,8 +672,18 @@ future<utils::chunked_vector<token>> tablet_map::get_sorted_tokens() const {
     co_return tokens;
 }
 
+const utils::chunked_vector<dht::raw_token>& tablet_map::get_sorted_raw_tokens() const {
+    return _tablet_ids.last_tokens();
+}
+
 void tablet_map::set_tablet(tablet_id id, tablet_info info) {
     check_tablet_id(id);
+    _tablets[size_t(id)] = std::move(info);
+}
+
+void tablet_map::emplace_tablet(tablet_id id, dht::token last_token, tablet_info info) {
+    check_tablet_id(id);
+    _tablet_ids.push_back(last_token, id);
     _tablets[size_t(id)] = std::move(info);
 }
 
@@ -722,7 +752,8 @@ bool tablet_map::has_replica(tablet_id tid, tablet_replica r) const {
 }
 
 future<> tablet_map::clear_gently() {
-    return utils::clear_gently(_tablets);
+    co_await utils::clear_gently(_tablets);
+    co_await utils::clear_gently(_tablet_ids);
 }
 
 const tablet_transition_info* tablet_map::get_tablet_transition_info(tablet_id id) const {
@@ -879,8 +910,13 @@ tablet_repair_incremental_mode tablet_repair_incremental_mode_from_string(const 
     return tablet_repair_incremental_mode_from_name.at(name);
 }
 
+size_t tablet_id_map::external_memory_usage() const {
+    return _buckets.external_memory_usage() +_last_tokens.external_memory_usage();
+}
+
 size_t tablet_map::external_memory_usage() const {
     size_t result = _tablets.external_memory_usage();
+    result += _tablet_ids.external_memory_usage();
     for (auto&& tablet : _tablets) {
         result += tablet.replicas.external_memory_usage();
     }
@@ -1710,6 +1746,103 @@ rack_list get_allowed_racks(const locator::token_metadata& tm, const sstring& dc
             | std::ranges::to<std::vector<sstring>>();
     }
     return {};
+}
+
+tablet_id_map::tablet_id_map(size_t tablet_count)
+    : _log2_tablets(log2ceil(tablet_count))
+{
+    _buckets.reserve(size_t(1) << _log2_tablets);
+    _last_tokens.reserve(tablet_count);
+}
+
+tablet_id_map::tablet_id_map(const utils::chunked_vector<dht::raw_token>& last_tokens)
+    : tablet_id_map(last_tokens.size())
+{
+    for (size_t i = 0; i < last_tokens.size(); i++) {
+        push_back(last_tokens[i], tablet_id(i));
+    }
+}
+
+void tablet_id_map::push_back(dht::token last_token, tablet_id id) {
+    auto i = dht::compaction_group_of(_log2_tablets, last_token);
+
+    if (_buckets.empty() && size_t(id) != 0) {
+        on_internal_error(tablet_logger, fmt::format("tablet_id_map::push_back: First tablet must have id 0, not {}", id));
+    }
+
+    if (!_buckets.empty() && (id <= _buckets.back() || last_token <= _last_tokens.back())) {
+        on_internal_error(tablet_logger, fmt::format("tablet_id_map::push_back: Order violated: last_token={} (prev={}), id={} (prev={}), bucket={}",
+                last_token, _last_tokens.back(), id, tablet_id(_buckets.back()), i));
+    }
+
+    _last_tokens.emplace_back(last_token);
+
+    while (_buckets.size() < i + 1) {
+        _buckets.push_back(id);
+    }
+}
+
+tablet_id tablet_id_map::get_tablet_id(dht::token t) const {
+    if (t.is_maximum()) {
+        return tablet_id(_last_tokens.size() - 1);
+    } else if (t.is_minimum()) {
+        return tablet_id(0);
+    } else {
+        return get_tablet_id(dht::raw_token(t));
+    }
+}
+
+tablet_id tablet_id_map::get_tablet_id(dht::raw_token t) const {
+    auto bucket = dht::compaction_group_of(_log2_tablets, t);
+    if (bucket >= _buckets.size()) {
+        throw std::out_of_range(fmt::format("tablet_id_map: No mapping for {}, bucket: {} bucket count: {}", t, bucket, _buckets.size()));
+    }
+
+    // The range [low_id, high_id] tracks range of ids which may own token t.
+    auto low_id = size_t(_buckets[bucket]);
+
+    // Common case: the taken falls into the tablet which owns the last token of a bucket.
+    // This is always the case if tablets are uniformly distributed in token space and the
+    // tablet count is a power of 2.
+    if (t <= _last_tokens[low_id]) {
+        return tablet_id(low_id);
+    }
+
+    ++low_id;
+    auto high_id = (bucket + 1 >= _buckets.size()) ? tablet_count() - 1 : size_t(_buckets[bucket + 1]);
+
+    if (high_id - low_id <= 7) { // linear search
+        while (low_id <= high_id) {
+            if (t <= _last_tokens[low_id]) {
+                return tablet_id(low_id);
+            }
+            ++low_id;
+        }
+    } else { // binary search
+        auto end = _last_tokens.begin() + high_id + 1;
+        auto it = std::lower_bound(_last_tokens.begin() + low_id, end, t);
+        if (it != end) {
+            return tablet_id(std::distance(_last_tokens.begin(), it));
+        }
+    }
+    throw std::out_of_range(fmt::format("tablet_id_map: No mapping for {}, bucket {}, last token of tablet {} is {}",
+                                        t, bucket, high_id, _last_tokens[size_t(high_id)]));
+}
+
+future<tablet_id_map> tablet_id_map::clone_gently() const {
+    tablet_id_map result(_last_tokens.size());
+    static_assert(std::is_trivially_copy_assignable_v<decltype(tablet_id_map::_buckets)::value_type>);
+    static_assert(std::is_trivially_copy_assignable_v<decltype(tablet_id_map::_last_tokens)::value_type>);
+    result._buckets = _buckets;
+    result._last_tokens = _last_tokens;
+    co_return std::move(result);
+}
+
+future<> tablet_id_map::clear_gently() {
+    // Storage is trivially destructible, so just let the destructor do the job.
+    static_assert(std::is_trivially_destructible_v<decltype(tablet_id_map::_buckets)::value_type>);
+    static_assert(std::is_trivially_destructible_v<decltype(tablet_id_map::_last_tokens)::value_type>);
+    return make_ready_future<>();
 }
 
 }

--- a/locator/tablets.cc
+++ b/locator/tablets.cc
@@ -17,6 +17,7 @@
 #include "replica/database.hh"
 #include "utils/stall_free.hh"
 #include "utils/rjson.hh"
+#include "utils/div_ceil.hh"
 #include "gms/feature_service.hh"
 
 #include <algorithm>
@@ -34,12 +35,29 @@ namespace locator {
 
 seastar::logger tablet_logger("tablets");
 
-std::optional<std::pair<tablet_id, tablet_id>> tablet_map::sibling_tablets(tablet_id t) const {
-    if (tablet_count() == 1) {
-        return std::nullopt;
+std::pair<tablet_id, std::optional<tablet_id>> tablet_map::sibling_tablets(tablet_id t) const {
+    check_tablet_id(t);
+
+    if (!needs_merge()) {
+        return std::make_pair(t, std::nullopt);
     }
-    auto first_sibling = tablet_id(t.value() & ~0x1);
-    return std::make_pair(first_sibling, *next_tablet(first_sibling));
+
+    auto& merge_plan = std::get<resize_decision::merge>(_resize_decision.way);
+
+    if (!merge_plan.isolated_tablet || t < *merge_plan.isolated_tablet) {
+        auto first_sibling = tablet_id(t.value() & ~0x1);
+        auto second_sibling = next_tablet(first_sibling);
+        return std::make_pair(first_sibling, second_sibling);
+    }
+
+    if (t == *merge_plan.isolated_tablet) {
+        return std::make_pair(t, std::nullopt);
+    }
+
+    // t is after the isolated_tablet here, which shifts the sibling pairs by one position.
+    auto first_sibling = tablet_id(((t.value() - 1) & ~0x1) + 1);
+    auto second_sibling = next_tablet(first_sibling);
+    return std::make_pair(first_sibling, second_sibling);
 }
 
 
@@ -481,10 +499,6 @@ tablet_map::tablet_map(size_t tablet_count, bool with_raft_info)
 tablet_map::tablet_map(utils::chunked_vector<dht::raw_token> last_tokens, bool with_raft_info)
     : _tablet_ids(std::move(last_tokens))
 {
-    if (_tablet_ids.tablet_count() != 1ul << _tablet_ids.log2_count()) {
-        on_internal_error(tablet_logger, format("Tablet count not a power of 2: {}", _tablet_ids.tablet_count()));
-    }
-
     _tablets.resize(_tablet_ids.tablet_count());
     if (with_raft_info) {
         _raft_info.resize(_tablet_ids.tablet_count());
@@ -494,9 +508,6 @@ tablet_map::tablet_map(utils::chunked_vector<dht::raw_token> last_tokens, bool w
 tablet_map::tablet_map(size_t tablet_count, bool with_raft_info, tablet_map::initialized_later)
     : _tablet_ids(tablet_count)
 {
-    if (tablet_count != 1ul << _tablet_ids.log2_count()) {
-        on_internal_error(tablet_logger, format("Tablet count not a power of 2: {}", tablet_count));
-    }
     _tablets.resize(tablet_count);
     if (with_raft_info) {
         _raft_info.resize(tablet_count);
@@ -721,16 +732,33 @@ future<> tablet_map::for_each_sibling_tablets(seastar::noncopyable_function<futu
     auto make_desc = [this] (tablet_id tid) {
         return tablet_desc{tid, &get_tablet_info(tid), get_tablet_transition_info(tid)};
     };
-    if (_tablets.size() == 1) {
-        co_return co_await func(make_desc(first_tablet()), std::nullopt);
+
+    if (!needs_merge()) {
+        co_await for_each_tablet([&] (tablet_id tid, const tablet_info& tinfo) -> future<> {
+            return func(tablet_desc{tid, &tinfo, get_tablet_transition_info(tid)}, std::nullopt);
+        });
+        co_return;
     }
-    for (std::optional<tablet_id> tid = first_tablet(); tid; tid = next_tablet(*tid)) {
+
+    auto& merge_plan = std::get<resize_decision::merge>(_resize_decision.way);
+
+    std::optional<tablet_id> tid = first_tablet();
+    while (tid) {
         auto tid1 = tid;
-        auto tid2 = tid = next_tablet(*tid);
-        if (!tid2) {
-            // Cannot happen with power-of-two invariant.
-            throw std::logic_error(format("Cannot retrieve sibling tablet with tablet count {}", tablet_count()));
+        tid = next_tablet(*tid);
+
+        if (merge_plan.isolated_tablet && *tid1 == *merge_plan.isolated_tablet) {
+            co_await func(make_desc(*tid1), std::nullopt);
+            continue;
         }
+
+        auto tid2 = tid;
+        if (!tid2) {
+            // Shouldn't happen. If the count is odd, there must be isolated_tablet set which skips one tablet.
+            on_internal_error(tablet_logger, format("No sibling for tablet {}", *tid1));
+        }
+
+        tid = next_tablet(*tid);
         co_await func(make_desc(*tid1), make_desc(*tid2));
     }
 }
@@ -1015,6 +1043,24 @@ std::optional<uint64_t> load_stats::get_tablet_size(host_id host, const range_ba
     return std::nullopt;
 }
 
+std::optional<uint64_t> load_stats::get_avg_tablet_size(const tablet_map& tmap, global_tablet_id tablet) const {
+    auto [table, tid] = tablet;
+    auto rbid = range_based_tablet_id{table, tmap.get_token_range(tid)};
+    auto& tinfo = tmap.get_tablet_info(tid);
+    auto* trinfo = tmap.get_tablet_transition_info(tid);
+
+    size_t tablet_size = 0;
+    for (auto&& r : tinfo.replicas) {
+        if (auto size = get_tablet_size_in_transition(r.host, rbid, tinfo, trinfo)) {
+            tablet_size += *size;
+        } else {
+            return std::nullopt;
+        }
+    }
+
+    return tablet_size / std::max(1ul, tinfo.replicas.size());
+}
+
 std::optional<uint64_t> load_stats::get_tablet_size_in_transition(host_id host, const range_based_tablet_id& rb_tid, const tablet_info& ti, const tablet_transition_info* trinfo) const {
     std::optional<uint64_t> tablet_size_opt;
     tablet_size_opt = get_tablet_size(host, rb_tid);
@@ -1102,7 +1148,7 @@ lw_shared_ptr<load_stats> load_stats::reconcile_tablets_resize(const std::unorde
                                         replica.host, old_tablet_id, rb_tid.range, new_tablet_id, new_range, *tablet_size_opt);
                 }
             }
-        } else if (old_tablet_count == new_tablet_count / 2) {
+        } else if (old_tablet_count * 2 == new_tablet_count) {
             // Reconcile for split
             for (size_t i = 0; i < old_tablet_count; i++) {
                 range_based_tablet_id rb_tid { table, old_tmap.get_token_range(tablet_id(i)) };
@@ -1842,7 +1888,7 @@ auto fmt::formatter<locator::resize_decision_way>::format(const locator::resize_
             fmt::format_to(ctx.out(), "split");
         },
         [&] (const locator::resize_decision::merge& merge) {
-            fmt::format_to(ctx.out(), "merge");
+            fmt::format_to(ctx.out(), "merge(isolated={})", merge.isolated_tablet);
         }), way);
     return ctx.out();
 }

--- a/locator/tablets.cc
+++ b/locator/tablets.cc
@@ -1091,30 +1091,25 @@ lw_shared_ptr<load_stats> load_stats::reconcile_tablets_resize(const std::unorde
         const auto& new_tmap = new_tm.tablets().get_tablet_map(table);
         size_t old_tablet_count = old_tmap.tablet_count();
         size_t new_tablet_count = new_tmap.tablet_count();
-        if (old_tablet_count == new_tablet_count * 2) {
+        if (old_tablet_count > new_tablet_count) {
             // Reconcile for merge
-            for (size_t i = 0; i < old_tablet_count; i += 2) {
-                range_based_tablet_id rb_tid1 { table, old_tmap.get_token_range(tablet_id(i)) };
-                range_based_tablet_id rb_tid2 { table, old_tmap.get_token_range(tablet_id(i + 1)) };
-                auto& tinfo = old_tmap.get_tablet_info(tablet_id(i));
+            for (size_t i = 0; i < old_tablet_count; i++) {
+                auto old_tablet_id = tablet_id(i);
+                auto new_tablet_id = new_tmap.get_tablet_id(old_tmap.get_last_token(old_tablet_id));
+                auto new_range = new_tmap.get_token_range(new_tablet_id);
+                auto rb_tid = range_based_tablet_id{table, old_tmap.get_token_range(old_tablet_id)};
+                auto& tinfo = old_tmap.get_tablet_info(old_tablet_id);
                 for (auto& replica : tinfo.replicas) {
-                    auto tablet_size_opt1 = new_stats.get_tablet_size(replica.host, rb_tid1);
-                    auto tablet_size_opt2 = new_stats.get_tablet_size(replica.host, rb_tid2);
-                    if (!tablet_size_opt1 || !tablet_size_opt2) {
-                        if (!tablet_size_opt1) {
-                            tablet_logger.debug("Unable to find tablet size in stats for table resize reconcile for tablet {} on host {}", rb_tid1, replica.host);
-                        }
-                        if (!tablet_size_opt2) {
-                            tablet_logger.debug("Unable to find tablet size in stats for table resize reconcile for tablet {} on host {}", rb_tid2, replica.host);
-                        }
+                    auto tablet_size_opt = new_stats.get_tablet_size(replica.host, rb_tid);
+                    if (!tablet_size_opt) {
+                        tablet_logger.debug("Unable to find tablet size in stats for table resize reconcile for tablet {} on host {}", rb_tid, replica.host);
                         return nullptr;
                     }
-                    dht::token_range new_range { new_tmap.get_token_range(tablet_id(i / 2)) };
                     auto& sizes_for_table = new_stats.tablet_stats.at(replica.host).tablet_sizes.at(table);
-                    uint64_t merged_tablet_size = *tablet_size_opt1 + *tablet_size_opt2;
-                    sizes_for_table[new_range] = merged_tablet_size;
-                    sizes_for_table.erase(rb_tid1.range);
-                    sizes_for_table.erase(rb_tid2.range);
+                    sizes_for_table.erase(rb_tid.range); // rb_tid.range may be equal to new_range, so do it first
+                    sizes_for_table[new_range] += *tablet_size_opt;
+                    tablet_logger.debug("reconcile merge: host {}, old tablet {}, old range {}, new tablet {}, new range {}, size {}",
+                                        replica.host, old_tablet_id, rb_tid.range, new_tablet_id, new_range, *tablet_size_opt);
                 }
             }
         } else if (old_tablet_count == new_tablet_count / 2) {

--- a/locator/tablets.cc
+++ b/locator/tablets.cc
@@ -531,24 +531,25 @@ tablet_id tablet_map::get_tablet_id(token t) const {
     return tablet_id(dht::compaction_group_of(_log2_tablets, t));
 }
 
+dht::token tablet_map::get_split_token(tablet_id id) const {
+    auto last = get_last_token(id);
+    auto prev_last = id == first_tablet() ? dht::minimum_token() : get_last_token(tablet_id(size_t(id) - 1));
+    return token::midpoint(prev_last, last);
+}
+
 tablet_range_side tablet_map::get_tablet_range_side(token t) const {
-    auto id_after_split = dht::compaction_group_of(_log2_tablets + 1, t);
-    return tablet_range_side(id_after_split & 0x1);
+    return get_tablet_id_and_range_side(t).second;
 }
 
 std::pair<tablet_id, tablet_range_side> tablet_map::get_tablet_id_and_range_side(token t) const {
-    auto id_after_split = dht::compaction_group_of(_log2_tablets + 1, t);
-    auto current_id = id_after_split >> 1;
-    return {tablet_id(current_id), tablet_range_side(id_after_split & 0x1)};
-}
-
-dht::token tablet_map::get_last_token(tablet_id id, size_t log2_tablets) const {
-    return dht::last_token_of_compaction_group(log2_tablets, size_t(id));
+    auto id = get_tablet_id(t);
+    auto id_after_split = t > get_split_token(id);
+    return {id, tablet_range_side(id_after_split & 0x1)};
 }
 
 dht::token tablet_map::get_last_token(tablet_id id) const {
     check_tablet_id(id);
-    return get_last_token(id, _log2_tablets);
+    return dht::last_token_of_compaction_group(_log2_tablets, size_t(id));
 }
 
 dht::token tablet_map::get_first_token(tablet_id id) const {
@@ -559,24 +560,24 @@ dht::token tablet_map::get_first_token(tablet_id id) const {
     }
 }
 
-dht::token_range tablet_map::get_token_range(tablet_id id, size_t log2_tablets) const {
+dht::token_range tablet_map::get_token_range(tablet_id id) const {
+    check_tablet_id(id);
     if (id == first_tablet()) {
-        return dht::token_range::make({dht::minimum_token(), false}, {get_last_token(id, log2_tablets), true});
+        return dht::token_range::make({dht::minimum_token(), false}, {get_last_token(id), true});
     } else {
-        return dht::token_range::make({get_last_token(tablet_id(size_t(id) - 1), log2_tablets), false}, {get_last_token(id, log2_tablets), true});
+       return dht::token_range::make({get_last_token(tablet_id(size_t(id) - 1)), false}, {get_last_token(id), true});
     }
 }
 
-dht::token_range tablet_map::get_token_range(tablet_id id) const {
-    check_tablet_id(id);
-    return get_token_range(id, _log2_tablets);
-}
-
 dht::token_range tablet_map::get_token_range_after_split(const token& t) const noexcept {
-    // when the tablets are split, the tablet count doubles, (i.e.) _log2_tablets increases by 1
-    const auto log2_tablets_after_split = _log2_tablets + 1;
-    auto id_after_split = tablet_id(dht::compaction_group_of(log2_tablets_after_split, t));
-    return get_token_range(id_after_split, log2_tablets_after_split);
+    auto id = get_tablet_id(t);
+    auto split_point = get_split_token(id);
+    auto r = get_token_range(id);
+    if (t <= split_point) {
+        return dht::token_range::make(*r.start_copy(), {split_point, true});
+    } else {
+        return dht::token_range::make({split_point, false}, *r.end_copy());
+    }
 }
 
 auto tablet_replica_comparator(const locator::topology& topo) {

--- a/locator/tablets.hh
+++ b/locator/tablets.hh
@@ -415,7 +415,22 @@ struct resize_decision {
     seq_number_t sequence_number = 0;
 
     resize_decision() = default;
-    resize_decision(sstring decision, uint64_t seq_number);
+
+    resize_decision(uint64_t seq_number)
+        : way(none{})
+        , sequence_number(seq_number)
+    {}
+
+    resize_decision(merge m, uint64_t seq_number)
+        : way(std::move(m))
+        , sequence_number(seq_number)
+    {}
+
+    resize_decision(split s, uint64_t seq_number)
+        : way(std::move(s))
+        , sequence_number(seq_number)
+    {}
+
     bool is_none() const {
         return std::holds_alternative<resize_decision::none>(way);
     }

--- a/locator/tablets.hh
+++ b/locator/tablets.hh
@@ -57,6 +57,33 @@ struct tablet_id {
     auto operator<=>(const tablet_id&) const = default;
 };
 
+/// Determines properties of tablet layout in a given table (tablet_map).
+enum class tablet_layout {
+    // Tablet count is a power of 2.
+    // Tablet boundaries start and end at whole tokens.
+    // Every token is owned by exactly one tablet.
+    //
+    // Tablet token ranges are adjacent, with subsequent tablets owning higher tokens.
+    // Tablet of index i covers the range (a, b], where:
+    //
+    //    a = i == 0 ? dht::minimum_token() : last_token[i-1]
+    //    b = last_token[i]
+    //
+    // Boundary tokens are evenly distributed in token space:
+    //
+    //     last_token[i] = i < tablet_count - 1 ? dht::bias((uint64_t(i + 1) << (64 - log2ceil(tablet_count))) - 1)
+    //                                          : dht::maximum_token()
+    pow_of_2,
+
+    // Tablet count can be any integer greater than 0.
+    // Tablet boundaries end and start at whole tokens.
+    // Each tablet owns at least one token.
+    // Every token is owned by exactly one tablet.
+    // Tablet token ranges are adjacent, with subsequent tablets owning higher tokens.
+    // As long as the above holds, boundary tokens can be arbitrary.
+    arbitrary
+};
+
 /// Identifies tablet (not be confused with tablet replica) in the scope of the whole cluster.
 struct global_tablet_id {
     table_id table;
@@ -604,6 +631,9 @@ public:
     [[nodiscard]] size_t tablet_count() const { return _last_tokens.size(); }
     [[nodiscard]] dht::raw_token get_last_token(tablet_id id) const { return _last_tokens[id.value()]; }
     [[nodiscard]] const utils::chunked_vector<dht::raw_token>& last_tokens() const { return _last_tokens; }
+    [[nodiscard]] tablet_layout get_layout() const;
+
+    static tablet_layout get_layout(const utils::chunked_vector<dht::raw_token>& last_tokens);
 
     /// Adds a new mapping for the next tablet whose range will be recorded to start
     /// after the last token of the previously added entry and end at last_token (inclusive).
@@ -836,6 +866,9 @@ public:
     /// Returns the token which will become the last token of the lower sibling post-split.
     /// The higher sibling will own (get_split_token(id), get_last_token(id)].
     dht::token get_split_token(tablet_id id) const;
+
+    /// Returns tablet_layout of this tablet_map.
+    tablet_layout get_layout() const;
 
     const locator::resize_decision& resize_decision() const;
     const tablet_task_info& resize_task_info() const;

--- a/locator/tablets.hh
+++ b/locator/tablets.hh
@@ -586,13 +586,6 @@ private:
         , _repair_scheduler_config(std::move(repair_scheduler_config))
         , _raft_info(std::move(raft_info))
     {}
-
-    /// Returns the largest token owned by tablet_id when the tablet_count is `1 << log2_tablets`.
-    dht::token get_last_token(tablet_id id, size_t log2_tablets) const;
-
-    /// Returns token_range which contains all tokens owned by the specified tablet
-    /// when the tablet_count is `1 << log2_tablets`.
-    dht::token_range get_token_range(tablet_id id, size_t log2_tablets) const;
 public:
     /// Constructs a tablet map.
     ///
@@ -735,6 +728,10 @@ public:
 
     /// Returns the token_range in which the given token will belong to after a tablet split
     dht::token_range get_token_range_after_split(const token& t) const noexcept;
+
+    /// Returns the token which will become the last token of the lower sibling post-split.
+    /// The higher sibling will own (get_split_token(id), get_last_token(id)].
+    dht::token get_split_token(tablet_id id) const;
 
     const locator::resize_decision& resize_decision() const;
     const tablet_task_info& resize_task_info() const;

--- a/locator/tablets.hh
+++ b/locator/tablets.hh
@@ -540,6 +540,67 @@ public:
     no_such_tablet_map(const table_id& id);
 };
 
+/// Allows looking up tablet_id of the tablet which owns a given token.
+///
+/// Conceptually like std::map<dht::token, tablet_id>, where the token
+/// is the split point (last token) for a given tablet,
+/// and get_tablet_id(token) is like lower_bound(token)->second.
+///
+/// Optimized for the typical case where tokens are more or less evenly
+/// spaced in the token space, in which case lookup will be constant time.
+class tablet_id_map {
+    // log2 of intended number of _buckets post-population.
+    uint8_t _log2_tablets;
+
+    // Covers the whole token space with assignment of tablet_id to token ranges.
+    // The elements describe a token range corresponding to the i-th range in the
+    // uniformly split token space, split into 2^_log2_tablets ranges.
+    //
+    // The tablet_id assigned to the range means that this tablet owns the first
+    // token in that range. There could be other tablets overlapping with the
+    // bucket's range, but only the lowest tablet_id is kept.
+    //
+    // If tablet count is a power-of-two and tablet boundaries align with the uniform token
+    // distribution then _buckets[i] == tablet_id(i).
+    utils::chunked_vector<tablet_id> _buckets;
+
+    // Determines tablet boundaries in token space.
+    // One entry per tablet.
+    // Tablet i owns the range (a, b], where:
+    //   a = i == 0 ? minimum_token() : _last_tokens[i-1]
+    //   b = _last_tokens[i]
+    utils::chunked_vector<dht::raw_token> _last_tokens;
+public:
+    /// Prepares an empty tablet_id_map for population with a given tablet count.
+    /// Must call push_back() tablet_count times to populate the map.
+    explicit tablet_id_map(size_t tablet_count);
+
+    /// Builds a map according to given tablet boundaries.
+    tablet_id_map(const utils::chunked_vector<dht::raw_token>& last_tokens);
+
+    [[nodiscard]] size_t log2_count() const { return _log2_tablets; }
+    [[nodiscard]] size_t tablet_count() const { return _last_tokens.size(); }
+    [[nodiscard]] dht::raw_token get_last_token(tablet_id id) const { return _last_tokens[id.value()]; }
+    [[nodiscard]] const utils::chunked_vector<dht::raw_token>& last_tokens() const { return _last_tokens; }
+
+    /// Adds a new mapping for the next tablet whose range will be recorded to start
+    /// after the last token of the previously added entry and end at last_token (inclusive).
+    /// last_token in subsequent calls must increase.
+    void push_back(dht::token last_token, tablet_id id);
+
+    /// Returns tablet_id of a tablet which owns a given token.
+    [[nodiscard]] tablet_id get_tablet_id(dht::token t) const;
+    [[nodiscard]] tablet_id get_tablet_id(dht::raw_token t) const;
+
+    bool operator==(const tablet_id_map&) const = default;
+    bool operator!=(const tablet_id_map&) const = default;
+
+    [[nodiscard]] size_t external_memory_usage() const;
+
+    [[nodiscard]] future<tablet_id_map> clone_gently() const;
+    future<> clear_gently();
+};
+
 /// Stores information about tablets of a single table.
 ///
 /// The map contains a constant number of tablets, tablet_count().
@@ -559,14 +620,11 @@ class tablet_map {
 public:
     using tablet_container = utils::chunked_vector<tablet_info>;
     using raft_info_container = utils::chunked_vector<tablet_raft_info>;
+    struct initialized_later {};
 private:
     using transitions_map = std::unordered_map<tablet_id, tablet_transition_info>;
-    // The implementation assumes that _tablets.size() is a power of 2:
-    //
-    //   _tablets.size() == 1 << _log2_tablets
-    //
+    tablet_id_map _tablet_ids;
     tablet_container _tablets;
-    size_t _log2_tablets; // log_2(_tablets.size())
     transitions_map _transitions;
     resize_decision _resize_decision;
     tablet_task_info _resize_task_info;
@@ -574,12 +632,15 @@ private:
     raft_info_container _raft_info;
 
     // Internal constructor, used by clone() and clone_gently().
-    tablet_map(tablet_container tablets, size_t log2_tablets, transitions_map transitions,
-        resize_decision resize_decision, tablet_task_info resize_task_info,
-        std::optional<repair_scheduler_config> repair_scheduler_config,
-        raft_info_container raft_info)
-        : _tablets(std::move(tablets))
-        , _log2_tablets(log2_tablets)
+    tablet_map(tablet_id_map ids,
+               tablet_container tablets,
+               transitions_map transitions,
+               resize_decision resize_decision,
+               tablet_task_info resize_task_info,
+               std::optional<repair_scheduler_config> repair_scheduler_config,
+               raft_info_container raft_info)
+        : _tablet_ids(std::move(ids))
+        , _tablets(std::move(tablets))
         , _transitions(std::move(transitions))
         , _resize_decision(resize_decision)
         , _resize_task_info(std::move(resize_task_info))
@@ -588,9 +649,29 @@ private:
     {}
 public:
     /// Constructs a tablet map.
+    /// Tablet boundaries will be uniformly distributed in token space.
     ///
     /// \param tablet_count The desired tablets to allocate. Must be a power of two.
     explicit tablet_map(size_t tablet_count, bool with_raft_info = false);
+
+    /// Constructs a tablet map.
+    /// Tablet boundaries are determined by the last_tokens parameter.
+    /// last_tokens[i] is the last token (inclusive) of tablet_id(i), where i == 0 refers to the first tablet.
+    ///
+    /// \param last_tokens The token boundaries of tablets. Size must be a power of two.
+    explicit tablet_map(utils::chunked_vector<dht::raw_token> last_tokens, bool with_raft_info = false);
+
+    /// Constructs a tablet map without initializing its contents, for incremental population.
+    /// Prepared to hold tablet_count tablets.
+    ///
+    /// It must be populated by calling emplace_tablet() tablet_count times, for every tablet.
+    /// The tablet_map is considered populated after the whole token space is covered by tablets,
+    /// no extra call is needed to seal it.
+    ///
+    /// Methods which are valid until populated:
+    ///  first_tablet(), last_tablet(), next_tablet(), emplace_tablet(), tablet_count(), transitions()
+    /// Other methods should not be used, as they may not work correctly with unpopulated state.
+    tablet_map(size_t tablet_count, bool with_raft_info, initialized_later);
 
     tablet_map(tablet_map&&) = default;
     tablet_map(const tablet_map&) = delete;
@@ -655,6 +736,7 @@ public:
 
     /// Returns a vector of sorted last tokens for tablets.
     future<utils::chunked_vector<token>> get_sorted_tokens() const;
+    const utils::chunked_vector<dht::raw_token>& get_sorted_raw_tokens() const;
 
     /// Returns the id of the first tablet.
     tablet_id first_tablet() const {
@@ -737,6 +819,9 @@ public:
     const tablet_task_info& resize_task_info() const;
     const std::optional<locator::repair_scheduler_config> get_repair_scheduler_config() const;
 public:
+    /// Use only on tablet_map constructed with initialized_later tag to populate its contents.
+    /// Must be called for consecutive tablet ids and with increasing last_token.
+    void emplace_tablet(tablet_id, dht::token last_token, tablet_info);
     void set_tablet(tablet_id, tablet_info);
     void set_tablet_transition_info(tablet_id, tablet_transition_info);
     void set_resize_decision(locator::resize_decision);

--- a/locator/tablets.hh
+++ b/locator/tablets.hh
@@ -400,6 +400,9 @@ struct resize_decision {
         auto operator<=>(const split&) const = default;
     };
     struct merge {
+        // In case the current tablet count is odd, this is the id of the tablet
+        // which will not be merged.
+        std::optional<tablet_id> isolated_tablet;
         auto operator<=>(const merge&) const = default;
     };
     using way_type = std::variant<none, split, merge>;
@@ -451,6 +454,7 @@ struct resize_decision {
 using resize_decision_way = resize_decision::way_type;
 
 struct table_load_stats {
+    // Total size of the table if it had RF=1.
     uint64_t size_in_bytes = 0;
     // Stores the minimum seq number among all replicas, as coordinator wants to know if
     // all replicas have completed splitting, which happens when they all store the
@@ -509,6 +513,9 @@ struct load_stats {
     }
 
     std::optional<uint64_t> get_tablet_size(host_id host, const range_based_tablet_id& rb_tid) const;
+
+    // Returns average size of tablet replica of a given tablet, or nullopt if information is incomplete.
+    std::optional<uint64_t> get_avg_tablet_size(const tablet_map&, global_tablet_id) const;
 
     // Returns the tablet size on the given host. If the tablet size is not found on the host, we will search for it on
     // other hosts based on the tablet transition info:
@@ -666,14 +673,14 @@ public:
     /// Constructs a tablet map.
     /// Tablet boundaries will be uniformly distributed in token space.
     ///
-    /// \param tablet_count The desired tablets to allocate. Must be a power of two.
+    /// \param tablet_count The desired tablets to allocate.
     explicit tablet_map(size_t tablet_count, bool with_raft_info = false);
 
     /// Constructs a tablet map.
     /// Tablet boundaries are determined by the last_tokens parameter.
     /// last_tokens[i] is the last token (inclusive) of tablet_id(i), where i == 0 refers to the first tablet.
     ///
-    /// \param last_tokens The token boundaries of tablets. Size must be a power of two.
+    /// \param last_tokens The token boundaries of tablets.
     explicit tablet_map(utils::chunked_vector<dht::raw_token> last_tokens, bool with_raft_info = false);
 
     /// Constructs a tablet map without initializing its contents, for incremental population.
@@ -773,9 +780,9 @@ public:
     }
 
     // Returns the pair of sibling tablets for a given tablet id.
-    // For example, if id 1 is provided, a pair of 0 and 1 is returned.
-    // Returns disengaged optional when sibling pair cannot be found.
-    std::optional<std::pair<tablet_id, tablet_id>> sibling_tablets(tablet_id t) const;
+    // If the tablet count is odd, the last tablet does not have a sibling and
+    // the second element of the pair will be disengaged.
+    std::pair<tablet_id, std::optional<tablet_id>> sibling_tablets(tablet_id t) const;
 
     /// Returns true iff tablet has a given replica.
     /// If tablet is in transition, considers both previous and next replica set.
@@ -789,7 +796,7 @@ public:
     future<> for_each_tablet(seastar::noncopyable_function<future<>(tablet_id, const tablet_info&)> func) const;
 
     /// Calls a given function for each sibling tablet in the map in token ownership order.
-    /// If tablet count == 1, then there will be only one call and 2nd tablet_desc is disengaged.
+    /// If tablet count is odd, the last call will have the 2nd tablet_desc disengaged.
     future<> for_each_sibling_tablets(seastar::noncopyable_function<future<>(tablet_desc, std::optional<tablet_desc>)> func) const;
 
     const auto& transitions() const {

--- a/replica/compaction_group.hh
+++ b/replica/compaction_group.hh
@@ -505,7 +505,6 @@ public:
     virtual compaction_group& compaction_group_for_sstable(const sstables::shared_sstable& sst) const = 0;
     virtual compaction_group& compaction_group_for_logstor_segment(logstor::log_segment_id seg_id, dht::token first_token, dht::token last_token) const = 0;
 
-    virtual size_t log2_storage_groups() const = 0;
     virtual storage_group& storage_group_for_token(dht::token) const = 0;
     virtual utils::chunked_vector<storage_group_ptr> storage_groups_for_token_range(dht::token_range tr) const = 0;
 

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -4066,7 +4066,22 @@ public:
 
 using snapshot_sstable_set = foreign_ptr<std::unique_ptr<utils::chunked_vector<sstables::sstable_snapshot_metadata>>>;
 
-static future<> write_manifest(const locator::topology& topology, snapshot_writer& writer, std::vector<snapshot_sstable_set> sstable_sets, std::vector<snapshot_tablet_info> tablets, sstring name, db::snapshot_options opts, schema_ptr schema, std::optional<int64_t> tablet_count) {
+static std::string get_tablets_type(locator::tablet_layout layout) {
+    switch (layout) {
+        case locator::tablet_layout::pow_of_2: return "powof2";
+        case locator::tablet_layout::arbitrary: return "arbitrary";
+    }
+    on_internal_error(tlogger, format("Unknown tablet layout: {}", static_cast<int>(layout)));
+}
+
+static future<> write_manifest(const locator::topology& topology,
+                               snapshot_writer& writer,
+                               std::vector<snapshot_sstable_set> sstable_sets,
+                               std::vector<snapshot_tablet_info> tablets,
+                               sstring name, db::snapshot_options opts,
+                               schema_ptr schema,
+                               std::optional<int64_t> tablet_count,
+                               std::optional<locator::tablet_layout> tablet_layout) {
     manifest_json manifest;
 
     manifest_json::info info;
@@ -4093,7 +4108,7 @@ static future<> write_manifest(const locator::topology& topology, snapshot_write
     table.keyspace_name = schema->ks_name();
     table.table_name = schema->cf_name();
     table.table_id = to_sstring(schema->id());
-    table.tablets_type = tablet_count ? "powof2" : "none";
+    table.tablets_type = tablet_layout ? get_tablets_type(*tablet_layout) : "none";
     table.tablet_count = tablet_count.value_or(0);
     manifest.table = std::move(table);
 
@@ -4229,12 +4244,14 @@ future<> database::snapshot_table_on_all_shards(sharded<database>& sharded_db, c
         tlogger.debug("snapshot {}: seal_snapshot", name);
         const auto& topology = sharded_db.local().get_token_metadata().get_topology();
         std::optional<int64_t> tablet_count;
+        std::optional<locator::tablet_layout> tablet_layout;
         std::vector<snapshot_tablet_info> tablets;
         std::unordered_set<size_t> tids;
         if (t.uses_tablets()) {
             auto erm = t.get_effective_replication_map();
             auto& tm = erm->get_token_metadata().tablets().get_tablet_map(s->id());
             tablet_count = tm.tablet_count();
+            tablet_layout = tm.get_layout();
             for (auto& ssts : sstable_sets) {
                 for (auto& sst : *ssts) {
                     auto tok = sst.first_token;
@@ -4253,7 +4270,8 @@ future<> database::snapshot_table_on_all_shards(sharded<database>& sharded_db, c
                 }
             }
         }
-        co_await write_manifest(topology, *writer, std::move(sstable_sets), std::move(tablets), name, std::move(opts), s, tablet_count).handle_exception([&] (std::exception_ptr ptr) {
+        co_await write_manifest(topology, *writer, std::move(sstable_sets), std::move(tablets), name, std::move(opts), s,
+                                tablet_count, tablet_layout).handle_exception([&] (std::exception_ptr ptr) {
             tlogger.error("Failed to seal snapshot in {}: {}.", name, ptr);
             ex = std::move(ptr);
         });

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -15,6 +15,7 @@
 #include <seastar/coroutine/parallel_for_each.hh>
 #include <seastar/coroutine/switch_to.hh>
 #include <seastar/coroutine/as_future.hh>
+#include <seastar/core/bitops.hh>
 #include <seastar/util/closeable.hh>
 #include <seastar/util/defer.hh>
 #include <seastar/json/json_elements.hh>
@@ -36,6 +37,7 @@
 #include "utils/logalloc.hh"
 #include "utils/checked-file-impl.hh"
 #include "utils/managed_bytes.hh"
+#include "utils/div_ceil.hh"
 #include "view_info.hh"
 #include "db/data_listeners.hh"
 #include "memtable-sstable.hh"
@@ -743,9 +745,6 @@ public:
     compaction_group& compaction_group_for_logstor_segment(logstor::log_segment_id seg_id, dht::token first_token, dht::token last_token) const override {
         return get_compaction_group();
     }
-    size_t log2_storage_groups() const override {
-        return 0;
-    }
     storage_group& storage_group_for_token(dht::token token) const override {
         return *_single_sg;
     }
@@ -842,8 +841,8 @@ private:
         auto idx = tablet_id_for_token(t);
 #ifndef SCYLLA_BUILD_MODE_RELEASE
         if (idx >= tablet_count()) {
-            on_fatal_internal_error(tlogger, format("storage_group_of: index out of range: idx={} size_log2={} size={} token={}",
-                                                    idx, log2_storage_groups(), tablet_count(), t));
+            on_fatal_internal_error(tlogger, format("storage_group_of: index out of range: idx={} size={} token={}",
+                                                    idx, tablet_count(), t));
         }
         auto& sg = storage_group_for_id(idx);
         if (!t.is_minimum() && !t.is_maximum() && !sg.token_range().contains(t, dht::token_comparator())) {
@@ -943,9 +942,6 @@ public:
     compaction_group& compaction_group_for_sstable(const sstables::shared_sstable& sst) const override;
     compaction_group& compaction_group_for_logstor_segment(logstor::log_segment_id seg_id, dht::token first_token, dht::token last_token) const override;
 
-    size_t log2_storage_groups() const override {
-        return log2ceil(tablet_map().tablet_count());
-    }
     storage_group& storage_group_for_token(dht::token token) const override {
         return storage_group_for_id(storage_group_of(token));
     }

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -820,9 +820,7 @@ private:
     // that were previously split.
     void handle_tablet_split_completion(const locator::tablet_map& old_tmap, const locator::tablet_map& new_tmap);
 
-    // Called when coordinator executes tablet merge. Tablet ids X and X+1 are merged into
-    // the new tablet id (X >> 1). In practice, that means storage groups for X and X+1
-    // are merged into a new storage group with id (X >> 1).
+    // Called when coordinator executes tablet merge.
     void handle_tablet_merge_completion(locator::effective_replication_map_ptr old_erm,
                                         const locator::tablet_map& old_tmap, const locator::tablet_map& new_tmap);
 
@@ -3477,43 +3475,64 @@ void tablet_storage_group_manager::handle_tablet_merge_completion(locator::effec
     size_t new_tablet_count = new_tmap.tablet_count();
     storage_group_map new_storage_groups;
 
-    unsigned log2_reduce_factor = log2ceil(old_tablet_count / new_tablet_count);
-    unsigned merge_size = 1 << log2_reduce_factor;
+    // The algorithm assumes that every new tablet has a last token which is equal to the last token of some old tablet.
+    // The old and new counts can be arbitrary, given that this holds.
 
-    if (merge_size != 2) {
-        throw std::runtime_error(format("Tablet count was not reduced by a factor of 2 (old: {}, new {}) for table {}",
+    if (old_tablet_count < new_tablet_count) {
+        throw std::runtime_error(format("Tablet count should be smaller on merge (old: {}, new {}) for table {}",
                                  old_tablet_count, new_tablet_count, table_id));
     }
 
-    for (auto& [id, sg] : _storage_groups) {
-        // Pick first (even) tablet of each sibling pair.
-        if (id % merge_size != 0) {
-            continue;
-        }
-        auto new_tid = id >> log2_reduce_factor;
-        auto new_range = new_tmap.get_token_range(locator::tablet_id(new_tid));
-        auto new_cg = make_lw_shared<compaction_group>(_t, new_tid, new_range, make_repair_sstable_classifier_func());
-        for (auto& view : new_cg->all_views()) {
+    locator::tablet_id current_new(0); // Valid when bool(new_sg)
+    lw_shared_ptr<storage_group> new_sg;
+
+    auto open_new_group = [&] (locator::tablet_id new_tid) {
+        current_new = new_tid;
+        new_sg = allocate_storage_group(new_tmap, new_tid, new_tmap.get_token_range(new_tid));
+        for (auto& view : new_sg->main_compaction_group()->all_views()) {
             auto cre = _t.get_compaction_manager().stop_and_disable_compaction_no_wait(*view, "tablet merging");
             _compaction_reenablers_for_merging.push_back(background_merge_guard{std::move(cre), old_erm});
         }
         if (_t.uses_logstor()) {
-            _compaction_reenablers_for_logstor_merging.push_back(_t.get_logstor_compaction_manager().disable_compaction_no_wait(*new_cg));
+            _compaction_reenablers_for_logstor_merging.push_back(
+                    _t.get_logstor_compaction_manager().disable_compaction_no_wait(*new_sg->main_compaction_group()));
         }
-        auto new_sg = make_lw_shared<storage_group>(std::move(new_cg));
+    };
 
-        for (unsigned i = 0; i < merge_size; i++) {
-            auto group_id = id + i;
+    auto seal_new_group = [&] {
+        new_storage_groups[size_t(current_new)] = std::move(new_sg);
+    };
 
-            auto it = _storage_groups.find(group_id);
-            if (it == _storage_groups.end()) {
-                throw std::runtime_error(format("Unable to find sibling tablet of id {} for table {}", group_id, table_id));
+    std::optional<locator::tablet_id> tid = old_tmap.first_tablet();
+    while (tid) {
+        locator::tablet_id group_id = *tid;
+        tid = old_tmap.next_tablet(*tid);
+
+        auto it = _storage_groups.find(size_t(group_id));
+        if (it == _storage_groups.end()) {
+            continue;
+        }
+
+        auto old_first_token = old_tmap.get_first_token(group_id);
+        if (new_sg && old_first_token > new_tmap.get_last_token(current_new)) {
+            seal_new_group();
+        }
+
+        if (!new_sg) {
+            auto new_id = new_tmap.get_tablet_id(old_tmap.get_last_token(group_id));
+            if (old_first_token < new_tmap.get_first_token(new_id)) {
+                on_internal_error(tlogger, format("Old tablet {} (range: {}) is not enclosed in new tablet {} (range: {})",
+                                  group_id, old_tmap.get_token_range(group_id), new_id, new_tmap.get_token_range(new_id)));
             }
+            open_new_group(new_id);
+        }
+
+        {
             auto& sg = it->second;
-            sg->for_each_compaction_group([&new_sg, new_range, new_tid, group_id] (const compaction_group_ptr& cg) {
-                cg->update_id(new_tid);
+            sg->for_each_compaction_group([&] (const compaction_group_ptr& cg) {
+                cg->update_id(size_t(current_new));
                 tlogger.debug("Adding merging_group: sstables_repaired_at={} old_range={} new_range={} old_tid={} new_tid={} old_group_id={}",
-                        cg->get_sstables_repaired_at(), cg->token_range(), new_range, cg->group_id(), new_tid, group_id);
+                        cg->get_sstables_repaired_at(), cg->token_range(), new_sg->token_range(), cg->group_id(), current_new, group_id);
                 new_sg->add_merging_group(cg);
             });
             // Cannot wait for group to be closed, since it can only return after some long-running operation
@@ -3524,7 +3543,9 @@ void tablet_storage_group_manager::handle_tablet_merge_completion(locator::effec
                });
             });
         }
-        new_storage_groups[new_tid] = std::move(new_sg);
+    }
+    if (new_sg) {
+        seal_new_group();
     }
     _storage_groups = std::move(new_storage_groups);
     _pending_merge_fiber_work = _merge_fiber_barrier.start();

--- a/replica/tablets.cc
+++ b/replica/tablets.cc
@@ -844,8 +844,17 @@ struct tablet_metadata_builder {
             if (row.has("resize_type") && row.has("resize_seq_number")) {
                 auto resize_type_name = row.get_as<sstring>("resize_type");
                 int64_t resize_seq_number = row.get_as<int64_t>("resize_seq_number");
-
-                locator::resize_decision resize_decision(std::move(resize_type_name), resize_seq_number);
+                locator::resize_decision resize_decision = std::invoke([&] {
+                    if (resize_type_name == "none") {
+                        return locator::resize_decision(resize_seq_number);
+                    } else if (resize_type_name == "split") {
+                        return locator::resize_decision(locator::resize_decision::split(), resize_seq_number);
+                    } else if (resize_type_name == "merge") {
+                        return locator::resize_decision(locator::resize_decision::merge(), resize_seq_number);
+                    } else {
+                        throw std::runtime_error(format("Unknown resize_type '{}' for table {}", resize_type_name, table));
+                    }
+                });
                 current->map.set_resize_decision(std::move(resize_decision));
             }
             if (row.has("resize_task_info")) {

--- a/replica/tablets.cc
+++ b/replica/tablets.cc
@@ -79,6 +79,7 @@ schema_ptr make_tablets_schema() {
             .with_column("session", uuid_type)
             .with_column("resize_type", utf8_type, column_kind::static_column)
             .with_column("resize_seq_number", long_type, column_kind::static_column)
+            .with_column("isolated_tablet_for_merge", long_type, column_kind::static_column)
             .with_column("repair_time", timestamp_type)
             .with_column("repair_task_info", tablet_task_info_type)
             .with_column("repair_scheduler_config", repair_scheduler_config_type, column_kind::static_column)
@@ -258,6 +259,12 @@ tablet_map_to_mutations(const tablet_map& tablets, table_id id, const sstring& k
     m.set_static_cell("table_name", data_value(table_name), ts);
     m.set_static_cell("resize_type", data_value(tablets.resize_decision().type_name()), ts);
     m.set_static_cell("resize_seq_number", data_value(int64_t(tablets.resize_decision().sequence_number)), ts);
+    if (tablets.resize_decision().is_merge()) {
+        auto& merge = std::get<resize_decision::merge>(tablets.resize_decision().way);
+        if (merge.isolated_tablet) {
+            m.set_static_cell("isolated_tablet_for_merge", data_value(int64_t(size_t(*merge.isolated_tablet))), ts);
+        }
+    }
     if (features.tablet_resize_virtual_task && tablets.resize_task_info().is_valid()) {
         m.set_static_cell("resize_task_info", tablet_task_info_to_data_value(tablets.resize_task_info()), ts);
     }
@@ -391,6 +398,12 @@ tablet_mutation_builder::set_resize_decision(locator::resize_decision resize_dec
     _m.set_static_cell("resize_type", data_value(resize_decision.type_name()), _ts);
     _m.set_static_cell("resize_seq_number", data_value(int64_t(resize_decision.sequence_number)), _ts);
     if (resize_decision.split_or_merge()) {
+        if (resize_decision.is_merge()) {
+            auto& merge = std::get<resize_decision::merge>(resize_decision.way);
+            if (merge.isolated_tablet) {
+                _m.set_static_cell("isolated_tablet_for_merge", data_value(int64_t(size_t(*merge.isolated_tablet))), _ts);
+            }
+        }
         auto resize_task_info = std::holds_alternative<resize_decision::split>(resize_decision.way)
             ? locator::tablet_task_info::make_split_request()
             : locator::tablet_task_info::make_merge_request();
@@ -850,7 +863,10 @@ struct tablet_metadata_builder {
                     } else if (resize_type_name == "split") {
                         return locator::resize_decision(locator::resize_decision::split(), resize_seq_number);
                     } else if (resize_type_name == "merge") {
-                        return locator::resize_decision(locator::resize_decision::merge(), resize_seq_number);
+                        return locator::resize_decision(locator::resize_decision::merge {
+                            .isolated_tablet = row.get_opt<int64_t>("isolated_tablet_for_merge")
+                                    .transform([] (int64_t v) { return tablet_id(v); })
+                        }, resize_seq_number);
                     } else {
                         throw std::runtime_error(format("Unknown resize_type '{}' for table {}", resize_type_name, table));
                     }

--- a/replica/tablets.cc
+++ b/replica/tablets.cc
@@ -696,7 +696,12 @@ void update_tablet_metadata_change_hint(locator::tablet_metadata_change_hint& hi
 
 namespace {
 
-tablet_id process_one_row(replica::database* db, table_id table, tablet_map& map, tablet_id tid, const cql3::untyped_result_set_row& row) {
+using updating = bool_class<struct updating_tag>;
+
+// is_updating == updating::yes means we're making random updates of an already populated tablet_map.
+// Otherwise, we're populating a tablet_map constructed with tablet_map::initialized_later.
+tablet_id process_one_row(replica::database* db, table_id table, tablet_map& map, tablet_id tid,
+                          const cql3::untyped_result_set_row& row, updating is_updating) {
     tablet_replica_set tablet_replicas;
     if (row.has("replicas")) {
         tablet_replicas = deserialize_replica_set(row.get_view("replicas"));
@@ -755,7 +760,20 @@ tablet_id process_one_row(replica::database* db, table_id table, tablet_map& map
     }
 
     tablet_logger.debug("Set sstables_repaired_at={} table={} tablet={}", sstables_repaired_at, table, tid);
-    map.set_tablet(tid, tablet_info{std::move(tablet_replicas), repair_time, repair_task_info, migration_task_info, sstables_repaired_at});
+
+    auto last_token = dht::token::from_int64(row.get_as<int64_t>("last_token"));
+    auto info = tablet_info{std::move(tablet_replicas), repair_time, repair_task_info, migration_task_info, sstables_repaired_at};
+    if (is_updating) {
+        auto old_last_token = map.get_last_token(tid);
+        if (last_token != old_last_token) {
+            // Boundary changes require a full tablet_map refresh.
+            on_internal_error(tablet_logger, format("Inconsistent last_token for table {} tablet {}: {} != {}",
+                    table, tid, last_token, old_last_token));
+        }
+        map.set_tablet(tid, std::move(info));
+    } else {
+        map.emplace_tablet(tid, last_token, std::move(info));
+    }
 
     if (row.has("raft_group_id")) {
         if (!map.has_raft_info()) {
@@ -783,14 +801,6 @@ tablet_id process_one_row(replica::database* db, table_id table, tablet_map& map
                 break;
             }
         }
-    }
-
-    auto persisted_last_token = dht::token::from_int64(row.get_as<int64_t>("last_token"));
-    auto current_last_token = map.get_last_token(tid);
-    if (current_last_token != persisted_last_token) {
-        tablet_logger.debug("current tablet_map: {}", map);
-        throw std::runtime_error(format("last_token mismatch between on-disk ({}) and in-memory ({}) tablet map for table {} tablet {}",
-                                        persisted_last_token, current_last_token, table, tid));
     }
 
     return *map.next_tablet(tid);
@@ -825,7 +835,7 @@ struct tablet_metadata_builder {
             } else {
                 auto tablet_count = row.get_as<int>("tablet_count");
                 auto with_raft_info = db->features().strongly_consistent_tables && row.has("raft_group_id");
-                auto tmap = tablet_map(tablet_count, with_raft_info);
+                auto tmap = tablet_map(tablet_count, with_raft_info, tablet_map::initialized_later());
                 auto first_tablet = tmap.first_tablet();
                 current = active_tablet_map{table, std::move(tmap), first_tablet};
             }
@@ -849,7 +859,7 @@ struct tablet_metadata_builder {
         }
 
         if (row.has("last_token")) {
-            current->tid = process_one_row(db, current->table, current->map, current->tid, row);
+            current->tid = process_one_row(db, current->table, current->map, current->tid, row, updating::no);
         }
     }
 
@@ -958,7 +968,7 @@ do_update_tablet_metadata_rows(replica::database& db, cql3::query_processor& qp,
             throw std::runtime_error("Failed to update tablet metadata: updated row is empty");
         } else {
             tmap.clear_tablet_transition_info(tid);
-            process_one_row(&db, hint.table_id, tmap, tid, res->one());
+            process_one_row(&db, hint.table_id, tmap, tid, res->one(), updating::yes);
         }
     }
 }
@@ -1022,7 +1032,7 @@ public:
 
     tablet_sstable_set(schema_ptr s, const storage_group_manager& sgm, const locator::tablet_map& tmap)
         : _schema(std::move(s))
-        , _tablet_map(tmap.tablet_count())
+        , _tablet_map(tmap.get_sorted_raw_tokens(), false)
     {
         sgm.for_each_storage_group([this] (size_t id, storage_group& sg) {
             auto set = sg.make_sstable_set();

--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -20,6 +20,7 @@
 #include "utils/error_injection.hh"
 #include "utils/stall_free.hh"
 #include "utils/overloaded_functor.hh"
+#include "utils/div_ceil.hh"
 #include "db/config.hh"
 #include "db/tablet_options.hh"
 #include "locator/load_sketch.hh"
@@ -1451,7 +1452,7 @@ public:
             }
 
             if (!t2_opt) {
-                on_internal_error(lblogger, format("Unable to find sibling tablet during co-location check for table {}", table));
+                return make_ready_future<>();
             }
             auto t2 = *t2_opt;
 
@@ -1573,8 +1574,7 @@ public:
                 // Merge finalization will have to recheck that all sibling tablets are co-located.
 
                 if (!t2_opt) {
-                    on_internal_error(lblogger, format("Unable to find sibling tablet during co-location, with tablet count {}, for table {}",
-                                                       tmap.tablet_count(), table));
+                    return make_ready_future<>(); // Tablet doesn't have a sibling, it's already colocated.
                 }
                 auto t2 = *t2_opt;
 
@@ -1716,7 +1716,10 @@ public:
         sstring target_tablet_count_reason; // Winning rule for target_tablet_count value.
         std::optional<uint64_t> avg_tablet_size; // nullopt when stats not yet available.
 
-        size_t target_tablet_count_aligned; // target_tablet_count aligned to power of 2.
+        // Final tablet count.
+        // It's target_tablet_count aligned to power of 2 if arbitrary_tablet_boundaries feature is not enabled.
+        size_t target_tablet_count_aligned;
+
         resize_decision::way_type resize_decision; // Decision which should be emitted to achieve target_tablet_count_aligned.
     };
 
@@ -1786,6 +1789,64 @@ public:
         }
 
         return {tablet_count, format("min_per_shard_tablet_count={:.3f} in DC {}", min_per_shard_tablet_count, *winning_dc)};
+    }
+
+    std::optional<uint64_t> get_avg_tablet_size(const tablet_map& tmap, table_id table, tablet_id tid) const {
+        if (!_table_load_stats) {
+            return std::nullopt;
+        }
+
+        if (_force_capacity_based_balancing) {
+            if (auto i = _table_load_stats->tables.find(table); i != _table_load_stats->tables.end()) {
+                return i->second.size_in_bytes / tmap.tablet_count();
+            }
+            return std::nullopt;
+        }
+
+        return _table_load_stats->get_avg_tablet_size(tmap, global_tablet_id{table, tid});
+    }
+
+    // Produces merge plan.
+    // This is not about deciding if we should merge, but how to do a merge.
+    // Returns resize_decision::none if we cannot decide how to do a merge, e.g. due to missing tablet stats.
+    resize_decision_way make_merge_decision(table_id table, const tablet_map& tmap) const {
+        if (tmap.tablet_count() % 2 == 0) {
+            return resize_decision::merge{};
+        }
+
+        if (!_db.features().arbitrary_tablet_boundaries) {
+            on_internal_error(lblogger, format("Odd tablet count found for table {}, but arbitrary_tablet_boundaries feature is disabled", table));
+        }
+
+        if (_force_capacity_based_balancing) {
+            // We don't have per-tablet stats. Choose at random among even-indexed ids.
+            return resize_decision::merge{
+                .isolated_tablet = tablet_id((rand_int() % div_ceil(tmap.tablet_count(), 2)) * 2)
+            };
+        }
+
+        // Choose the largest tablet because that will minimize imbalance post-merge.
+        // Choose among even-indexed ids, because only then all other tablets have siblings.
+        uint64_t max_size = 0;
+        std::optional<tablet_id> max_tid;
+        for (size_t i = 0; i < tmap.tablet_count(); i += 2) {
+            auto tid = tablet_id(i);
+            if (auto tablet_size = get_avg_tablet_size(tmap, table, tid)) {
+                lblogger.trace("Tablet {}:{} has average size of {}", table, tid, tablet_size);
+                if (!max_tid || *tablet_size > max_size) {
+                    max_size = *tablet_size;
+                    max_tid = tid;
+                }
+            } else {
+                lblogger.info("Cannot pick isolated replica for merge decision of table {}: stats incomplete for tablet {}", table, tid);
+                return resize_decision::none{};
+            }
+        }
+
+        lblogger.debug("Picked {}.{} as isolated tablet for merge", table, *max_tid);
+        return resize_decision::merge{
+            .isolated_tablet = max_tid
+        };
     }
 
     future<sizing_plan> make_sizing_plan(schema_ptr new_table = nullptr, const tablet_aware_replication_strategy* new_rs = nullptr) {
@@ -1871,7 +1932,7 @@ public:
                     // so it would get cancelled only when crossing back the half-way point.
                     if (avg_tablet_size < target_min_tablet_size(target_tablet_size) ||
                         (cur_decision.is_merge() && avg_tablet_size <= target_tablet_size)) {
-                        tablet_count_from_size /= 2;
+                        tablet_count_from_size = div_ceil(tablet_count_from_size, 2);
                     }
                 }
 
@@ -2039,7 +2100,18 @@ public:
             if (table_plan.target_tablet_count_aligned > table_plan.current_tablet_count) {
                 table_plan.resize_decision = locator::resize_decision::split();
             } else if (table_plan.target_tablet_count_aligned < table_plan.current_tablet_count) {
-                table_plan.resize_decision = locator::resize_decision::merge();
+                // Needed to avoid oscillations, because we reduce the count by a factor of 2.
+                // FIXME: Once we have a way to split individual tablets, we can achieve exactly the desired tablet count.
+                if (div_ceil(table_plan.current_tablet_count, 2) >= table_plan.target_tablet_count_aligned) {
+                    auto& tmap = _tm->tablets().get_tablet_map(table);
+                    auto cur_decision = tmap.resize_decision();
+                    if (cur_decision.is_merge()) {
+                        // Preserve isolated tablet choice if we're already merging
+                        table_plan.resize_decision = std::get<resize_decision::merge>(cur_decision.way);
+                    } else {
+                        table_plan.resize_decision = make_merge_decision(table, tmap);
+                    }
+                }
             }
 
             lblogger.debug("Table {}, {} => {} ({}: {}), resize: {}", table,
@@ -2438,12 +2510,11 @@ public:
             return;
         }
         auto siblings = tmap.sibling_tablets(tablet.tablet);
-        if (!siblings) {
-            on_internal_error(lblogger, format("Unable to find sibling tablet of {} during merge", tablet));
+        if (siblings.second) {
+            auto left_sibling = global_tablet_id{tablet.table, siblings.first};
+            auto right_sibling = global_tablet_id {tablet.table, *siblings.second};
+            erase_candidate(shard_info, migration_tablet_set {colocated_tablets {left_sibling, right_sibling}});
         }
-        auto left_sibling = global_tablet_id{tablet.table, siblings->first};
-        auto right_sibling = global_tablet_id{tablet.table, siblings->second};
-        erase_candidate(shard_info, migration_tablet_set{colocated_tablets{left_sibling, right_sibling}});
     }
 
     void erase_candidates(node_load_map& nodes, const tablet_map& tmap, const migration_tablet_set& tablets) {
@@ -3976,10 +4047,6 @@ public:
         auto lb = make_load_balancer(tm, nullptr, nullptr, nullptr, {});
         auto plan = lb.make_sizing_plan(s.shared_from_this(), tablet_rs).get();
         auto& table_plan = plan.tables[s.id()];
-        if (table_plan.target_tablet_count_aligned != table_plan.target_tablet_count) {
-            lblogger.info("Rounding up tablet count from {} to {} for table {}.{}", table_plan.target_tablet_count,
-                    table_plan.target_tablet_count_aligned, s.ks_name(), s.cf_name());
-        }
         auto tablet_count = table_plan.target_tablet_count_aligned;
         auto map = tablet_rs->allocate_tablets_for_new_table(s.shared_from_this(), tm, tablet_count).get();
         return map;
@@ -4122,7 +4189,7 @@ private:
     future<tablet_map> merge_tablets(token_metadata_ptr tm, table_id table) {
         auto& tablets = tm->tablets().get_tablet_map(table);
 
-        tablet_map new_tablets(tablets.tablet_count() / 2, tablets.has_raft_info(), tablet_map::initialized_later());
+        tablet_map new_tablets(div_ceil(tablets.tablet_count(), 2), tablets.has_raft_info(), tablet_map::initialized_later());
 
         std::optional<tablet_id> new_tid = new_tablets.first_tablet();
         co_await tablets.for_each_sibling_tablets([&] (tablet_desc left, std::optional<tablet_desc> right) {

--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -4100,7 +4100,7 @@ private:
     future<tablet_map> split_tablets(token_metadata_ptr tm, table_id table) {
         auto& tablets = tm->tablets().get_tablet_map(table);
 
-        tablet_map new_tablets(tablets.tablet_count() * 2);
+        tablet_map new_tablets(tablets.tablet_count() * 2, tablets.has_raft_info(), tablet_map::initialized_later());
 
         for (tablet_id tid : tablets.tablet_ids()) {
             co_await coroutine::maybe_yield();
@@ -4110,8 +4110,8 @@ private:
 
             auto& tablet_info = tablets.get_tablet_info(tid);
 
-            new_tablets.set_tablet(new_left_tid, tablet_info);
-            new_tablets.set_tablet(new_right_tid, tablet_info);
+            new_tablets.emplace_tablet(new_left_tid, tablets.get_split_token(tid), tablet_info);
+            new_tablets.emplace_tablet(new_right_tid, tablets.get_last_token(tid), tablet_info);
         }
 
         lblogger.info("Split tablets for table {}, increasing tablet count from {} to {}",
@@ -4124,7 +4124,7 @@ private:
     future<tablet_map> merge_tablets(token_metadata_ptr tm, table_id table) {
         auto& tablets = tm->tablets().get_tablet_map(table);
 
-        tablet_map new_tablets(tablets.tablet_count() / 2);
+        tablet_map new_tablets(tablets.tablet_count() / 2, tablets.has_raft_info(), tablet_map::initialized_later());
 
         for (tablet_id tid : new_tablets.tablet_ids()) {
             co_await coroutine::maybe_yield();
@@ -4152,7 +4152,7 @@ private:
             }
             lblogger.debug("Got merged_tablet_info with sstables_repaired_at={}", merged_tablet_info->sstables_repaired_at);
 
-            new_tablets.set_tablet(tid, *merged_tablet_info);
+            new_tablets.emplace_tablet(tid, tablets.get_last_token(old_right_tid), *merged_tablet_info);
         }
 
         lblogger.info("Merge tablets for table {}, decreasing tablet count from {} to {}",

--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -146,6 +146,15 @@ db::tablet_options combine_tablet_options(R&& opts) {
                 combined_opts.max_tablet_count = std::min(*combined_opts.max_tablet_count, *opt.max_tablet_count);
             }
         }
+        if (opt.pow2_count) {
+            // We need some way to resolve conflicts.
+            // pow2_count will be true if any of the options wants pow2_count, because
+            // we want to treat pow2_count == true as a requirement (for backwards compatibility)
+            // while pow2_count = false like a preference. Not a hard reason.
+            if (!combined_opts.pow2_count || *opt.pow2_count) {
+                combined_opts.pow2_count = *opt.pow2_count;
+            }
+        }
     }
 
     if (total_expected_data_size_in_gb_count) {
@@ -1715,9 +1724,10 @@ public:
         size_t target_tablet_count; // Tablet count wanted by scheduler.
         sstring target_tablet_count_reason; // Winning rule for target_tablet_count value.
         std::optional<uint64_t> avg_tablet_size; // nullopt when stats not yet available.
+        bool pow2_count; // Whether tablet count for the table should be a power of two.
 
         // Final tablet count.
-        // It's target_tablet_count aligned to power of 2 if arbitrary_tablet_boundaries feature is not enabled.
+        // It's target_tablet_count aligned to power of 2 if pow2_count == true.
         size_t target_tablet_count_aligned;
 
         resize_decision::way_type resize_decision; // Decision which should be emitted to achieve target_tablet_count_aligned.
@@ -1867,6 +1877,9 @@ public:
         auto process_table = [&] (table_id table, const locator::table_group_set& tables, schema_ptr s, db::tablet_options tablet_options, const tablet_aware_replication_strategy* rs, size_t tablet_count) {
             table_sizing& table_plan = plan.tables[table];
             table_plan.current_tablet_count = tablet_count;
+            table_plan.pow2_count = tablet_options.pow2_count.value_or(
+                    _db.features().arbitrary_tablet_boundaries ? db::tablet_options::default_pow2_count : true);
+
             rs_by_table[table] = rs;
 
             // for a group of co-located tablets of size g with average tablet size t, the migration unit
@@ -1963,8 +1976,8 @@ public:
             table_plan.target_tablet_count = target_tablet_count.tablet_count;
             table_plan.target_tablet_count_reason = target_tablet_count.reason;
 
-            lblogger.debug("Table {} ({}.{}) target_tablet_count: {} ({})", table, s->ks_name(), s->cf_name(),
-                    table_plan.target_tablet_count, table_plan.target_tablet_count_reason);
+            lblogger.debug("Table {} ({}.{}) target_tablet_count: {} ({}), pow2_count: {}, opt: {}", table, s->ks_name(), s->cf_name(),
+                    table_plan.target_tablet_count, table_plan.target_tablet_count_reason, table_plan.pow2_count, tablet_options.to_map());
         };
 
         for (const auto& [table, tables] : _tm->tablets().all_table_groups()) {
@@ -1973,7 +1986,6 @@ public:
             }
             const auto& tmap = _tm->tablets().get_tablet_map(table);
             auto [s, rs] = get_schema_and_rs(table);
-
             auto tablet_options = combine_tablet_options(
                     tables | std::views::transform([&] (table_id table) { return _db.get_tables_metadata().get_table_if_exists(table); })
                            | std::views::filter([] (auto t) { return t != nullptr; })
@@ -2095,7 +2107,11 @@ public:
         //   table_plan.resize_decision
 
         for (auto&& [table, table_plan] : plan.tables) {
-            table_plan.target_tablet_count_aligned = 1u << log2ceil(table_plan.target_tablet_count);
+            if (!table_plan.pow2_count) {
+                table_plan.target_tablet_count_aligned = table_plan.target_tablet_count;
+            } else {
+                table_plan.target_tablet_count_aligned = 1u << log2ceil(table_plan.target_tablet_count);
+            }
 
             if (table_plan.target_tablet_count_aligned > table_plan.current_tablet_count) {
                 table_plan.resize_decision = locator::resize_decision::split();

--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -4119,21 +4119,28 @@ private:
         co_return std::move(new_tablets);
     }
 
-    // The merging of tablet is completely based on the power-of-two constraint.
-    // Tablet of ids X and X+1 are merged into new tablet id (X >> 1).
     future<tablet_map> merge_tablets(token_metadata_ptr tm, table_id table) {
         auto& tablets = tm->tablets().get_tablet_map(table);
 
         tablet_map new_tablets(tablets.tablet_count() / 2, tablets.has_raft_info(), tablet_map::initialized_later());
 
-        for (tablet_id tid : new_tablets.tablet_ids()) {
-            co_await coroutine::maybe_yield();
+        std::optional<tablet_id> new_tid = new_tablets.first_tablet();
+        co_await tablets.for_each_sibling_tablets([&] (tablet_desc left, std::optional<tablet_desc> right) {
+            if (!new_tid) {
+                on_internal_error(lblogger, "Invalid merge, more sibling sets than new tablets.");
+            }
 
-            tablet_id old_left_tid = tablet_id(tid.value() << 1);
-            tablet_id old_right_tid = tablet_id(old_left_tid.value() + 1);
+            if (!right) {
+                new_tablets.emplace_tablet(*new_tid, tablets.get_last_token(left.tid), *left.info);
+                new_tid = new_tablets.next_tablet(*new_tid);
+                return make_ready_future<>();
+            }
 
-            auto& left_tablet_info = tablets.get_tablet_info(old_left_tid);
-            auto& right_tablet_info = tablets.get_tablet_info(old_right_tid);
+            tablet_id old_left_tid = left.tid;
+            tablet_id old_right_tid = right->tid;
+
+            auto& left_tablet_info = *left.info;
+            auto& right_tablet_info = *right->info;
 
             auto sorted = [] (tablet_replica_set set) {
                 std::ranges::sort(set, std::less<tablet_replica>());
@@ -4152,7 +4159,13 @@ private:
             }
             lblogger.debug("Got merged_tablet_info with sstables_repaired_at={}", merged_tablet_info->sstables_repaired_at);
 
-            new_tablets.emplace_tablet(tid, tablets.get_last_token(old_right_tid), *merged_tablet_info);
+            new_tablets.emplace_tablet(*new_tid, tablets.get_last_token(old_right_tid), *merged_tablet_info);
+            new_tid = new_tablets.next_tablet(*new_tid);
+            return make_ready_future<>();
+        });
+
+        if (new_tid) {
+            on_internal_error(lblogger, "Invalid merge, more new tablets than sibling sets.");
         }
 
         lblogger.info("Merge tablets for table {}, decreasing tablet count from {} to {}",

--- a/test/boost/database_test.cc
+++ b/test/boost/database_test.cc
@@ -690,12 +690,17 @@ static future<> validate_manifest(const locator::topology& topology, const fs::p
     }
     if (tablets_enabled) {
         BOOST_REQUIRE(tablets_type.has_value());
-        BOOST_REQUIRE_EQUAL(*tablets_type, "powof2");
         BOOST_REQUIRE(manifest_table.HasMember("tablet_count"));
         auto& tablet_count_json = manifest_table["tablet_count"];
         BOOST_REQUIRE(tablet_count_json.IsNumber());
         uint64_t tablet_count = tablet_count_json.GetInt64();
-        BOOST_REQUIRE_EQUAL(tablet_count, 1 << log2ceil(tablet_count));
+        if (*tablets_type == "powof2") {
+            BOOST_REQUIRE_EQUAL(tablet_count, 1 << log2ceil(tablet_count));
+        } else if (*tablets_type == "arbitrary") {
+            BOOST_REQUIRE_GE(tablet_count, 1);
+        } else {
+            BOOST_FAIL(format("Unknown tablets_type in manifest: {}", *tablets_type));
+        }
     } else {
         if (tablets_type) {
             BOOST_REQUIRE_EQUAL(*tablets_type, "none");

--- a/test/boost/sstable_set_test.cc
+++ b/test/boost/sstable_set_test.cc
@@ -9,10 +9,13 @@
 
 #undef SEASTAR_TESTING_MAIN
 #include <seastar/testing/test_case.hh>
+#include <seastar/core/abort_source.hh>
+#include <seastar/core/loop.hh>
 
 #include <fmt/ranges.h>
 #include "db/config.hh"
 #include "locator/tablets.hh"
+#include "replica/tablets.hh"
 #include "sstables/sstable_set_impl.hh"
 #include "sstables/shared_sstable.hh"
 #include "sstables/sstable_set.hh"
@@ -286,6 +289,20 @@ static future<> guarantee_all_tablet_replicas_on_shard0(cql_test_env& env) {
     });
 }
 
+// Run in a seastar thread.
+static void mutate_tablet_map(cql_test_env& env,
+                              table_id table,
+                              seastar::noncopyable_function<future<>(locator::tablet_map&)> updater) {
+    seastar::abort_source as;
+    auto guard = env.get_raft_group0_client().start_operation(as).get();
+    auto& stm = env.get_shared_token_metadata().local();
+    stm.mutate_token_metadata([table, updater = std::move(updater)] (auto& tm) mutable -> future<> {
+        return tm.tablets().mutate_tablet_map_async(table, std::move(updater));
+    }).get();
+    save_tablet_metadata(env.local_db(), stm.get()->tablets(), guard.write_timestamp()).get();
+    env.get_storage_service().local().update_tablet_metadata({}).get();
+}
+
 SEASTAR_TEST_CASE(test_tablet_sstable_set_fast_forward_across_tablet_ranges) {
     // enable tablets, to get access to tablet_storage_group_manager
     cql_test_config cfg;
@@ -421,6 +438,102 @@ SEASTAR_TEST_CASE(test_tablet_sstable_set_fast_forward_across_tablet_ranges) {
             end_of_stream_check(reader);
         }
 
+    }, std::move(cfg));
+}
+
+// Test that tablet_sstable_set respects arbitrary tablet boundaries when selecting sstables
+// overlapping with a given token range.
+SEASTAR_TEST_CASE(test_tablet_sstable_set_preserves_arbitrary_boundaries) {
+    cql_test_config cfg;
+    cfg.db_config->tablets_mode_for_new_keyspaces(db::tablets_mode_t::mode::enabled);
+
+    return do_with_cql_env_thread([&](cql_test_env& env) {
+        guarantee_all_tablet_replicas_on_shard0(env).get();
+
+        env.execute_cql("CREATE KEYSPACE test_tablet_sstable_set_arbitrary"
+                        " WITH REPLICATION = {'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}"
+                        " AND TABLETS = {'enabled': true, 'initial': 5};").get();
+        env.execute_cql("CREATE TABLE test_tablet_sstable_set_arbitrary.test (pk int PRIMARY KEY) WITH TABLETS = {'pow2_count': false}").get();
+
+        auto& table = env.local_db().find_column_family("test_tablet_sstable_set_arbitrary", "test");
+        auto s = table.schema();
+        std::vector<dht::decorated_key> emitted_keys;
+
+        // One sstable per key, so that selection of sstables
+        // based on tablet ranges will differ after marge with
+        // sub-tablet granularity.
+        for (int i = 0; i < 32; ++i) {
+            env.execute_cql(fmt::format("INSERT INTO test_tablet_sstable_set_arbitrary.test (pk) VALUES ({})", i)).discard_result().get();
+            emitted_keys.push_back(dht::decorate_key(*s, partition_key::from_singular(*s, i)));
+            table.flush().get();
+        }
+
+        // So that sstable set is stable during checks at the end,
+        // and so that sstables don't get merged into larger ones with different boundaries making
+        // the test weak. The test relies on the fact that with uniform distribution of tokens,
+        // the selection of sstables will be different from using actual arbitrary boundaries.
+        // The test relies on the fact that shifting last token of tablet 2 (post merge) to a greater value
+        // than in the uniform distribution will select different sstables than without the boundary shifted.
+        table.disable_auto_compaction().get();
+
+        auto& sgm = column_family_test::get_storage_group_manager(table);
+        std::ranges::sort(emitted_keys, dht::decorated_key::less_comparator(s));
+
+        auto original_tmap = env.get_shared_token_metadata().local().get()->tablets().get_tablet_map(s->id()).clone();
+        auto last_tokens = original_tmap.get_sorted_tokens().get();
+        auto raw_last_tokens = last_tokens
+                | std::views::transform([] (dht::token t) { return dht::raw_token(t); })
+                | std::ranges::to<utils::chunked_vector<dht::raw_token>>();
+        BOOST_REQUIRE_EQUAL(last_tokens.size(), 5);
+
+        // Create non-uniform boundaries by merging tablets with one tablet being isolated (not merged).
+        // Merge [0,1] and [2,3], isolating the last tablet.
+        utils::chunked_vector<dht::raw_token> merged_last_tokens;
+        merged_last_tokens.push_back(raw_last_tokens[1]);
+        merged_last_tokens.push_back(raw_last_tokens[3]);
+        merged_last_tokens.push_back(raw_last_tokens[4]);
+
+        locator::tablet_map merged_tmap(std::move(merged_last_tokens), false);
+        merged_tmap.set_tablet(locator::tablet_id(0), original_tmap.get_tablet_info(locator::tablet_id(1)));
+        merged_tmap.set_tablet(locator::tablet_id(1), original_tmap.get_tablet_info(locator::tablet_id(3)));
+        merged_tmap.set_tablet(locator::tablet_id(2), original_tmap.get_tablet_info(locator::tablet_id(4)));
+
+        mutate_tablet_map(env, s->id(), [merged_tmap = std::move(merged_tmap)] (locator::tablet_map& tmap) mutable -> future<> {
+            tmap = std::move(merged_tmap);
+            return make_ready_future<>();
+        });
+
+        auto& tmap = table.get_effective_replication_map()->get_token_metadata().tablets().get_tablet_map(s->id());
+        BOOST_REQUIRE(tmap.get_layout() == locator::tablet_layout::arbitrary);
+
+        sgm->split_all_storage_groups(tasks::task_info{}).get();
+
+        auto tablet_sstable_set = replica::make_tablet_sstable_set(s, *sgm.get(), tmap);
+
+        // Validate later that a copy works the same as the original.
+        auto tablet_sstable_set_copy = *tablet_sstable_set.get();
+
+        // Compare against a token-partitioned oracle for every [sorted_tokens[i], sorted_tokens[j]] range.
+        auto oracle_set = make_lw_shared<sstables::sstable_set>(std::make_unique<partitioned_sstable_set>(s, full_range));
+        for (const auto& sst : *tablet_sstable_set->all()) {
+            oracle_set->insert(sst);
+        }
+
+        auto to_set = [] (std::vector<sstables::shared_sstable> ssts) {
+            return std::set<sstables::shared_sstable>(ssts.begin(), ssts.end());
+        };
+
+        for (size_t i = 0; i < emitted_keys.size(); ++i) {
+            auto range = dht::partition_range::make({emitted_keys[i]}, {emitted_keys[i]});
+
+            auto expected = to_set(oracle_set->select(range));
+            auto selected = to_set(tablet_sstable_set->select(range));
+            auto selected_from_copy = to_set(tablet_sstable_set_copy.select(range));
+            BOOST_REQUIRE_MESSAGE(selected == expected,
+                                  fmt::format("select() mismatch for single-key range i={}", i));
+            BOOST_REQUIRE_MESSAGE(selected_from_copy == expected,
+                                  fmt::format("select() mismatch for single-key range i={}", i));
+        }
     }, std::move(cfg));
 }
 

--- a/test/boost/tablets_test.cc
+++ b/test/boost/tablets_test.cc
@@ -76,10 +76,11 @@ static api::timestamp_type current_timestamp(cql_test_env& e) {
 }
 
 static
-void verify_tablet_metadata_persistence(cql_test_env& env, const tablet_metadata& tm, api::timestamp_type& ts) {
+tablet_metadata verify_tablet_metadata_persistence(cql_test_env& env, const tablet_metadata& tm, api::timestamp_type& ts) {
     save_tablet_metadata(env.local_db(), tm, ts++).get();
     auto tm2 = read_tablet_metadata(env.local_qp()).get();
     BOOST_REQUIRE_EQUAL(tm, tm2);
+    return tm2;
 }
 
 static
@@ -530,8 +531,155 @@ SEASTAR_TEST_CASE(test_tablet_metadata_persistence) {
             }
 
             verify_tablet_metadata_persistence(e, tm, ts);
+
+            // Change resize decision of table1 to merge
+            {
+                tablet_map tmap(1);
+                tmap.set_resize_decision(locator::resize_decision(locator::resize_decision::merge{}, 2));
+                tmap.set_resize_task_info(locator::tablet_task_info::make_merge_request());
+                tm.set_tablet_map(table1, std::move(tmap));
+
+                auto tm2 = verify_tablet_metadata_persistence(e, tm, ts);
+                auto& decision = tm2.get_tablet_map(table1).resize_decision();
+                BOOST_REQUIRE(std::holds_alternative<locator::resize_decision::merge>(decision.way));
+                BOOST_REQUIRE_EQUAL(decision.sequence_number, 2);
+                BOOST_REQUIRE(std::get<locator::resize_decision::merge>(decision.way).isolated_tablet == std::nullopt);
+            }
+
+            // Change resize decision of table1 to merge
+            {
+                tablet_map tmap(1);
+                tmap.set_resize_decision(locator::resize_decision(
+                        locator::resize_decision::merge{ .isolated_tablet = tablet_id(7) }, 3));
+                tmap.set_resize_task_info(locator::tablet_task_info::make_merge_request());
+                tm.set_tablet_map(table1, std::move(tmap));
+
+                auto tm2 = verify_tablet_metadata_persistence(e, tm, ts);
+                auto& decision = tm2.get_tablet_map(table1).resize_decision();
+                BOOST_REQUIRE(std::holds_alternative<locator::resize_decision::merge>(decision.way));
+                BOOST_REQUIRE_EQUAL(decision.sequence_number, 3);
+                BOOST_REQUIRE(std::get<locator::resize_decision::merge>(decision.way).isolated_tablet == tablet_id(7));
+            }
         }
     }, tablet_cql_test_config());
+}
+
+using sibling_map = std::vector<std::pair<tablet_id, std::optional<tablet_id>>>;
+
+static
+sibling_map get_siblings(const tablet_map& tmap) {
+    sibling_map result;
+    tmap.for_each_sibling_tablets([&] (tablet_desc first, std::optional<tablet_desc> second) {
+        result.emplace_back(std::make_pair(first.tid, second.transform([] (const tablet_desc& s) { return s.tid; })));
+        return make_ready_future<>();
+    }).get();
+    return result;
+}
+
+SEASTAR_THREAD_TEST_CASE(test_siblings) {
+    {
+        tablet_map tmap(1);
+        BOOST_REQUIRE(tmap.sibling_tablets(tablet_id(0)) == std::make_pair(tablet_id(0), std::nullopt));
+        BOOST_REQUIRE(get_siblings(tmap) == sibling_map({
+            { tablet_id(0), std::nullopt }
+        }));
+    }
+
+    {
+        tablet_map tmap(2);
+        BOOST_REQUIRE(tmap.sibling_tablets(tablet_id(0)) == std::make_pair(tablet_id(0), std::nullopt));
+        BOOST_REQUIRE(tmap.sibling_tablets(tablet_id(1)) == std::make_pair(tablet_id(1), std::nullopt));
+        BOOST_REQUIRE(get_siblings(tmap) == sibling_map({
+            { tablet_id(0), std::nullopt },
+            { tablet_id(1), std::nullopt }
+        }));
+    }
+
+    {
+        tablet_map tmap(3);
+        BOOST_REQUIRE(tmap.sibling_tablets(tablet_id(0)) == std::make_pair(tablet_id(0), std::nullopt));
+        BOOST_REQUIRE(tmap.sibling_tablets(tablet_id(1)) == std::make_pair(tablet_id(1), std::nullopt));
+        BOOST_REQUIRE(tmap.sibling_tablets(tablet_id(2)) == std::make_pair(tablet_id(2), std::nullopt));
+        BOOST_REQUIRE(get_siblings(tmap) == sibling_map({
+            { tablet_id(0), std::nullopt },
+            { tablet_id(1), std::nullopt },
+            { tablet_id(2), std::nullopt }
+        }));
+    }
+
+    // Merge even count
+    {
+        tablet_map tmap(4);
+        tmap.set_resize_decision(locator::resize_decision{
+            locator::resize_decision::merge{},
+            1
+        });
+        BOOST_REQUIRE(tmap.sibling_tablets(tablet_id(0)) == std::make_pair(tablet_id(0), tablet_id(1)));
+        BOOST_REQUIRE(tmap.sibling_tablets(tablet_id(1)) == std::make_pair(tablet_id(0), tablet_id(1)));
+        BOOST_REQUIRE(tmap.sibling_tablets(tablet_id(2)) == std::make_pair(tablet_id(2), tablet_id(3)));
+        BOOST_REQUIRE(tmap.sibling_tablets(tablet_id(3)) == std::make_pair(tablet_id(2), tablet_id(3)));
+        BOOST_REQUIRE(get_siblings(tmap) == sibling_map({
+            { tablet_id(0), tablet_id(1) },
+            { tablet_id(2), tablet_id(3) }
+        }));
+    }
+
+    // Isolate middle tablet
+    {
+        tablet_map tmap(5);
+        tmap.set_resize_decision(locator::resize_decision{
+            locator::resize_decision::merge{ .isolated_tablet = tablet_id(2) },
+            1
+        });
+        BOOST_REQUIRE(tmap.sibling_tablets(tablet_id(0)) == std::make_pair(tablet_id(0), tablet_id(1)));
+        BOOST_REQUIRE(tmap.sibling_tablets(tablet_id(1)) == std::make_pair(tablet_id(0), tablet_id(1)));
+        BOOST_REQUIRE(tmap.sibling_tablets(tablet_id(2)) == std::make_pair(tablet_id(2), std::nullopt));
+        BOOST_REQUIRE(tmap.sibling_tablets(tablet_id(3)) == std::make_pair(tablet_id(3), tablet_id(4)));
+        BOOST_REQUIRE(tmap.sibling_tablets(tablet_id(4)) == std::make_pair(tablet_id(3), tablet_id(4)));
+        BOOST_REQUIRE(get_siblings(tmap) == sibling_map({
+            { tablet_id(0), tablet_id(1) },
+            { tablet_id(2), std::nullopt },
+            { tablet_id(3), tablet_id(4) }
+        }));
+    }
+
+    // Isolate first tablet
+    {
+        tablet_map tmap(5);
+        tmap.set_resize_decision(locator::resize_decision{
+            locator::resize_decision::merge{ .isolated_tablet = tablet_id(0) },
+            1
+        });
+        BOOST_REQUIRE(tmap.sibling_tablets(tablet_id(0)) == std::make_pair(tablet_id(0), std::nullopt));
+        BOOST_REQUIRE(tmap.sibling_tablets(tablet_id(1)) == std::make_pair(tablet_id(1), tablet_id(2)));
+        BOOST_REQUIRE(tmap.sibling_tablets(tablet_id(2)) == std::make_pair(tablet_id(1), tablet_id(2)));
+        BOOST_REQUIRE(tmap.sibling_tablets(tablet_id(3)) == std::make_pair(tablet_id(3), tablet_id(4)));
+        BOOST_REQUIRE(tmap.sibling_tablets(tablet_id(4)) == std::make_pair(tablet_id(3), tablet_id(4)));
+        BOOST_REQUIRE(get_siblings(tmap) == sibling_map({
+            { tablet_id(0), std::nullopt },
+            { tablet_id(1), tablet_id(2) },
+            { tablet_id(3), tablet_id(4) }
+        }));
+    }
+
+    // Isolate last tablet
+    {
+        tablet_map tmap(5);
+        tmap.set_resize_decision(locator::resize_decision{
+            locator::resize_decision::merge{ .isolated_tablet = tablet_id(4) },
+            1
+        });
+        BOOST_REQUIRE(tmap.sibling_tablets(tablet_id(0)) == std::make_pair(tablet_id(0), tablet_id(1)));
+        BOOST_REQUIRE(tmap.sibling_tablets(tablet_id(1)) == std::make_pair(tablet_id(0), tablet_id(1)));
+        BOOST_REQUIRE(tmap.sibling_tablets(tablet_id(2)) == std::make_pair(tablet_id(2), tablet_id(3)));
+        BOOST_REQUIRE(tmap.sibling_tablets(tablet_id(3)) == std::make_pair(tablet_id(2), tablet_id(3)));
+        BOOST_REQUIRE(tmap.sibling_tablets(tablet_id(4)) == std::make_pair(tablet_id(4), std::nullopt));
+        BOOST_REQUIRE(get_siblings(tmap) == sibling_map({
+            { tablet_id(0), tablet_id(1) },
+            { tablet_id(2), tablet_id(3) },
+            { tablet_id(4), std::nullopt }
+        }));
+    }
 }
 
 SEASTAR_THREAD_TEST_CASE(test_invalid_colocated_tables) {
@@ -2777,8 +2925,12 @@ SEASTAR_THREAD_TEST_CASE(test_per_shard_count_respected_with_rack_list) {
             load_sketch load(tmptr);
             load.populate_dc(dc).get();
             auto l = load.get_shard_minmax(host1);
-            BOOST_REQUIRE_EQUAL(l.min(), 16);
-            BOOST_REQUIRE_EQUAL(l.max(), 16);
+            // At least 10 because of tablets_initial_scale_factor.
+            // At most 16 due to rounding to power-of-two.
+            BOOST_REQUIRE_GE(l.min(), 10);
+            BOOST_REQUIRE_GE(l.max(), 10);
+            BOOST_REQUIRE_LE(l.min(), 16);
+            BOOST_REQUIRE_LE(l.max(), 16);
         }
 
         check_rack_list(tm_topo, tmptr->tablets().get_tablet_map(table), dc, rack_list{rack1.rack}, bad_nodes);
@@ -2846,20 +2998,21 @@ SEASTAR_THREAD_TEST_CASE(test_per_shard_goal_shrinks_respecting_rack_allocation)
         auto t3_1 = add_table(e, ks3).get();
         auto t3_2 = add_table(e, ks3).get();
 
-        stats.set_size(t1_1, 0);
-        stats.set_size(t1_2, 0);
-        stats.set_size(t1_3, 0);
-        stats.set_size(t1_4, 0);
-        stats.set_size(t1_5, 0);
-        stats.set_size(t2_1, 0);
-        stats.set_size(t3_1, 0);
-        stats.set_size(t3_2, 0);
+        auto& stm = e.shared_token_metadata().local();
+
+        {
+            auto tmptr = stm.get();
+            stats.set_tablet_sizes(tmptr, t1_1, 1);
+            stats.set_tablet_sizes(tmptr, t1_2, 1);
+            stats.set_tablet_sizes(tmptr, t1_3, 1);
+            stats.set_tablet_sizes(tmptr, t1_4, 1);
+            stats.set_tablet_sizes(tmptr, t1_5, 1);
+            stats.set_tablet_sizes(tmptr, t2_1, 1);
+            stats.set_tablet_sizes(tmptr, t3_1, 1);
+            stats.set_tablet_sizes(tmptr, t3_2, 1);
+        }
 
         rebalance_tablets(e, &stats);
-
-        auto& stm = e.shared_token_metadata().local();
-        auto tmptr = stm.get();
-        auto& tm_topo = tmptr->get_topology();
 
         auto& tmeta = stm.get()->tablets();
         BOOST_REQUIRE_EQUAL(2, tmeta.get_tablet_map(t1_1).tablet_count());
@@ -2871,6 +3024,15 @@ SEASTAR_THREAD_TEST_CASE(test_per_shard_goal_shrinks_respecting_rack_allocation)
         BOOST_REQUIRE_EQUAL(8, tmeta.get_tablet_map(t2_1).tablet_count());
 
         BOOST_REQUIRE_EQUAL(8, tmeta.get_tablet_map(t3_1).tablet_count());
+
+        // When pow2_count is switched to false, this should be changed to 6. Rationale:
+        // Both tables want 16 tablets/shard due to min_tablets_per_shard.
+        // They will be scaled down by 10/16 = 5/8 due to per-shard limit.
+        // The first table which already has 8 tablets, would have to shrink to 5, but can't - it's higher than 8/2.
+        // So it stays at 8.
+        // The second table receives the desired count at creation time, so can start with 5.
+        // Rounded up to an even number, so 6.
+        // Once we make splits per-tablet, we will be able to even out the count.
         BOOST_REQUIRE_EQUAL(8, tmeta.get_tablet_map(t3_2).tablet_count());
     }, cfg).get();
 }
@@ -4402,8 +4564,10 @@ SEASTAR_THREAD_TEST_CASE(test_size_based_load_balancing_table_load) {
             table_sizes[table_id] = table_size;
             table_size /= 2;
         }
-        // Add another table with 1 byte per tablet
-        table_size = tablet_count;
+        // Add another table with 4 bytes per tablet
+        // Should be larger than 1 to account for potential splits when capacity increases.
+        // If it had 1 byte per tablet, splits would turn tablet size into 0 on subdivision, which brings table load to 0.
+        table_size = tablet_count * 4;
         auto table_id = create_table_and_set_tablet_sizes(e, topo, ks_name, tablet_count, table_size);
         table_sizes[table_id] = table_size;
 
@@ -4529,6 +4693,7 @@ SEASTAR_THREAD_TEST_CASE(test_per_shard_goal_mixed_dc_rf) {
         {
             auto& stm = e.shared_token_metadata().local();
             auto tm = stm.get();
+            // When pow2_count is switched to false, 256 should be changed to 200.
             BOOST_REQUIRE_EQUAL(tm->tablets().get_tablet_map(table1).tablet_count(), 256);
             BOOST_REQUIRE_EQUAL(tm->tablets().get_tablet_map(table2).tablet_count(), 64);
 

--- a/test/boost/tablets_test.cc
+++ b/test/boost/tablets_test.cc
@@ -1357,7 +1357,7 @@ SEASTAR_TEST_CASE(test_mutation_builder) {
             BOOST_REQUIRE_EQUAL(expected_tmap, tm_from_disk.get_tablet_map(table1));
         }
 
-        static const auto resize_decision = locator::resize_decision("split", 1);
+        static const auto resize_decision = locator::resize_decision(locator::resize_decision::split(), 1);
 
         {
             tablet_mutation_builder b(ts++, table1);

--- a/test/boost/tablets_test.cc
+++ b/test/boost/tablets_test.cc
@@ -191,6 +191,162 @@ void mutate_tablets(cql_test_env& e, seastar::noncopyable_function<future<>(tabl
     mutate_tablets(e, guard, std::move(mutator));
 }
 
+SEASTAR_TEST_CASE(test_tablet_id_map_different_density_test) {
+    // Exercise different density of buckets by scaling token space, out of which we pick only first few tokens.
+    for (int num_tokens : {7, 8, 11, 16}) {
+        testlog.info("L{}: {} tokens", __LINE__, num_tokens);
+        auto tokens = dht::get_uniform_tokens(num_tokens);
+
+        auto map = tablet_id_map(3);
+        map.push_back(tokens[1], tablet_id(0));
+        map.push_back(tokens[3], tablet_id(1));
+        map.push_back(dht::last_token(), tablet_id(2));
+
+        BOOST_REQUIRE_EQUAL(map.get_tablet_id(dht::minimum_token()), tablet_id(0));
+        BOOST_REQUIRE_EQUAL(map.get_tablet_id(tokens[0]), tablet_id(0));
+        BOOST_REQUIRE_EQUAL(map.get_tablet_id(tokens[1]), tablet_id(0));
+        BOOST_REQUIRE_EQUAL(map.get_tablet_id(tokens[2]), tablet_id(1));
+        BOOST_REQUIRE_EQUAL(map.get_tablet_id(tokens[3]), tablet_id(1));
+        BOOST_REQUIRE_EQUAL(map.get_tablet_id(tokens[4]), tablet_id(2));
+        BOOST_REQUIRE_EQUAL(map.get_tablet_id(tokens[5]), tablet_id(2));
+        BOOST_REQUIRE_EQUAL(map.get_tablet_id(dht::maximum_token()), tablet_id(2));
+    }
+
+    for (int num_tokens : {3, 4, 7, 11}) {
+        testlog.info("L{}: {} tokens", __LINE__, num_tokens);
+        auto tokens = dht::get_uniform_tokens(num_tokens);
+
+        // Verify tokens concentrated in the front
+        {
+            auto map = tablet_id_map(3);
+            auto last0 = tokens[0];
+            auto last1 = tokens[1];
+            auto last2 = dht::last_token();
+            map.push_back(last0, tablet_id(0));
+            map.push_back(last1, tablet_id(1));
+            map.push_back(last2, tablet_id(2));
+
+            BOOST_REQUIRE_EQUAL(map.get_tablet_id(dht::minimum_token()), tablet_id(0));
+            BOOST_REQUIRE_EQUAL(map.get_tablet_id(dht::token::midpoint(dht::first_token(), last0)), tablet_id(0));
+            BOOST_REQUIRE_EQUAL(map.get_tablet_id(last0), tablet_id(0));
+            BOOST_REQUIRE_EQUAL(map.get_tablet_id(dht::token::midpoint(last0, last1)), tablet_id(1));
+            BOOST_REQUIRE_EQUAL(map.get_tablet_id(last1), tablet_id(1));
+            BOOST_REQUIRE_EQUAL(map.get_tablet_id(dht::token::midpoint(last1, last2)), tablet_id(2));
+            BOOST_REQUIRE_EQUAL(map.get_tablet_id(dht::maximum_token()), tablet_id(2));
+        }
+
+        // Verify tokens concentrated in the back
+        {
+            auto map = tablet_id_map(3);
+            auto last0 = tokens[tokens.size() - 3];
+            auto last1 = tokens[tokens.size() - 2];
+            auto last2 = tokens[tokens.size() - 1];
+            map.push_back(last0, tablet_id(0));
+            map.push_back(last1, tablet_id(1));
+            map.push_back(last2, tablet_id(2));
+
+            BOOST_REQUIRE_EQUAL(map.get_tablet_id(dht::minimum_token()), tablet_id(0));
+            BOOST_REQUIRE_EQUAL(map.get_tablet_id(dht::token::midpoint(dht::first_token(), last0)), tablet_id(0));
+            BOOST_REQUIRE_EQUAL(map.get_tablet_id(last0), tablet_id(0));
+            BOOST_REQUIRE_EQUAL(map.get_tablet_id(dht::token::midpoint(last0, last1)), tablet_id(1));
+            BOOST_REQUIRE_EQUAL(map.get_tablet_id(last1), tablet_id(1));
+            BOOST_REQUIRE_EQUAL(map.get_tablet_id(dht::token::midpoint(last1, last2)), tablet_id(2));
+            BOOST_REQUIRE_EQUAL(map.get_tablet_id(dht::maximum_token()), tablet_id(2));
+        }
+    }
+
+    return make_ready_future<>();
+}
+
+SEASTAR_TEST_CASE(test_tablet_id_map_building) {
+    auto uniform_tokens = dht::get_uniform_tokens(8);
+
+    auto map = tablet_id_map(7);
+    auto tablet_0_last = dht::token(uniform_tokens[0]).next().next();
+    auto tablet_1_last = dht::token(uniform_tokens[2]).next();
+    auto tablet_2_last = tablet_1_last.next(); // tablet 2 owns only 1 token.
+    auto tablet_3_last = tablet_2_last.next().next();
+    auto tablet_4_last = dht::token(uniform_tokens[3]);
+    auto tablet_5_last = dht::token::midpoint(dht::token(uniform_tokens[3]), dht::token(uniform_tokens[4]));
+    auto tablet_6_last = dht::last_token();
+
+    map.push_back(dht::raw_token(tablet_0_last), tablet_id(0));
+    map.push_back(dht::raw_token(tablet_1_last), tablet_id(1));
+    map.push_back(dht::raw_token(tablet_2_last), tablet_id(2));
+    map.push_back(dht::raw_token(tablet_3_last), tablet_id(3));
+    map.push_back(dht::raw_token(tablet_4_last), tablet_id(4));
+    map.push_back(dht::raw_token(tablet_5_last), tablet_id(5));
+    map.push_back(dht::raw_token(tablet_6_last), tablet_id(6));
+
+    BOOST_REQUIRE_EQUAL(map.get_tablet_id(uniform_tokens[0]), tablet_id(0));
+    BOOST_REQUIRE_EQUAL(map.get_tablet_id(uniform_tokens[1]), tablet_id(1));
+    BOOST_REQUIRE_EQUAL(map.get_tablet_id(uniform_tokens[2]), tablet_id(1));
+    BOOST_REQUIRE_EQUAL(map.get_tablet_id(uniform_tokens[3]), tablet_id(4));
+    BOOST_REQUIRE_EQUAL(map.get_tablet_id(uniform_tokens[4]), tablet_id(6));
+    BOOST_REQUIRE_EQUAL(map.get_tablet_id(uniform_tokens[5]), tablet_id(6));
+    BOOST_REQUIRE_EQUAL(map.get_tablet_id(uniform_tokens[6]), tablet_id(6));
+    BOOST_REQUIRE_EQUAL(map.get_tablet_id(uniform_tokens[7]), tablet_id(6));
+
+    BOOST_REQUIRE_EQUAL(map.get_tablet_id(tablet_0_last), tablet_id(0));
+    BOOST_REQUIRE_EQUAL(map.get_tablet_id(tablet_1_last), tablet_id(1));
+    BOOST_REQUIRE_EQUAL(map.get_tablet_id(tablet_2_last), tablet_id(2));
+    BOOST_REQUIRE_EQUAL(map.get_tablet_id(tablet_3_last), tablet_id(3));
+    BOOST_REQUIRE_EQUAL(map.get_tablet_id(tablet_4_last), tablet_id(4));
+    BOOST_REQUIRE_EQUAL(map.get_tablet_id(tablet_5_last), tablet_id(5));
+    BOOST_REQUIRE_EQUAL(map.get_tablet_id(tablet_6_last), tablet_id(6));
+
+    BOOST_REQUIRE_EQUAL(map.get_tablet_id(tablet_0_last.next()), tablet_id(1));
+    BOOST_REQUIRE_EQUAL(map.get_tablet_id(tablet_1_last.next()), tablet_id(2));
+    BOOST_REQUIRE_EQUAL(map.get_tablet_id(tablet_2_last.next()), tablet_id(3));
+    BOOST_REQUIRE_EQUAL(map.get_tablet_id(tablet_3_last.next()), tablet_id(4));
+    BOOST_REQUIRE_EQUAL(map.get_tablet_id(tablet_4_last.next()), tablet_id(5));
+    BOOST_REQUIRE_EQUAL(map.get_tablet_id(tablet_5_last.next()), tablet_id(6));
+
+    BOOST_REQUIRE_EQUAL(map.get_tablet_id(dht::minimum_token()), tablet_id(0));
+    BOOST_REQUIRE_EQUAL(map.get_tablet_id(dht::maximum_token()), tablet_id(6));
+
+    return make_ready_future<>();
+}
+
+static
+utils::chunked_vector<dht::raw_token> get_random_tokens(size_t n) {
+    utils::chunked_vector<dht::raw_token> last_tokens;
+    for (size_t i = 0; i < n; ++i) {
+        last_tokens.push_back(dht::raw_token(dht::token::get_random_token()));
+    }
+    std::sort(last_tokens.begin(), last_tokens.end());
+    return last_tokens;
+}
+
+SEASTAR_THREAD_TEST_CASE(test_tablet_id_map_cloning) {
+    for (int n_tokens : {1, 2, 7, 13, 16}) {
+        auto last_tokens = get_random_tokens(n_tokens);
+        last_tokens.back() = dht::raw_token(dht::last_token());
+        auto map = tablet_id_map(last_tokens);
+        auto map_cloned = map.clone_gently().get();
+
+        int t_idx = 0;
+        for (auto&& t: last_tokens) {
+            testlog.trace("last token {} of tablet {} bucket {}", t, t_idx, dht::compaction_group_of(map.log2_count(), t));
+            BOOST_REQUIRE_EQUAL(map.get_tablet_id(t), tablet_id(t_idx));
+            BOOST_REQUIRE_EQUAL(map.get_tablet_id(t), map_cloned.get_tablet_id(t));
+
+            if (t < last_tokens.back()) {
+                auto next_t = dht::token(t).next();
+                BOOST_REQUIRE_EQUAL(map.get_tablet_id(next_t), map_cloned.get_tablet_id(next_t));
+                BOOST_REQUIRE_EQUAL(map.get_tablet_id(next_t), tablet_id(t_idx + 1));
+            }
+
+            if (t > dht::first_token()) {
+                auto prev_t = dht::token(dht::raw_token(t.value - 1));
+                BOOST_REQUIRE_EQUAL(map.get_tablet_id(prev_t), map_cloned.get_tablet_id(prev_t));
+            }
+
+            ++t_idx;
+        }
+    }
+}
+
 SEASTAR_TEST_CASE(test_tablet_metadata_persistence) {
     return do_with_cql_env_thread([] (cql_test_env& e) {
         auto h1 = host_id(utils::UUID_gen::get_time_UUID());
@@ -3904,7 +4060,7 @@ SEASTAR_THREAD_TEST_CASE(test_load_balancing_with_random_load) {
             keyspaces.push_back(add_keyspace(e, {{topo.dc(), rf}}, initial_tablets));
             auto table = add_table(e, keyspaces.back()).get();
             mutate_tablets(e, [&] (tablet_metadata& tmeta) -> future<> {
-                tablet_map tmap(initial_tablets);
+                tablet_map tmap = tmeta.get_tablet_map(table).clone();
                 for (auto tid : tmap.tablet_ids()) {
                     // Choose replicas randomly while loading racks evenly.
                     std::vector<host_id> replica_hosts = allocate_replicas_in_racks(racks, rf, hosts_by_rack);
@@ -5012,7 +5168,7 @@ static void do_test_load_balancing_merge_colocation(cql_test_env& e, const int n
         auto guard = e.get_raft_group0_client().start_operation(as).get();
         stm.mutate_token_metadata([&](token_metadata& tm) -> future<> {
             tablet_metadata& tmeta = tm.tablets();
-            tablet_map tmap(initial_tablets);
+            tablet_map tmap = tmeta.get_tablet_map(table1).clone();
             locator::resize_decision decision;
             // leaves growing mode, allowing for merge decision.
             decision.sequence_number = decision.next_sequence_number();

--- a/test/boost/tablets_test.cc
+++ b/test/boost/tablets_test.cc
@@ -4885,6 +4885,21 @@ SEASTAR_TEST_CASE(test_load_stats_migrate_tablet_size) {
     return make_ready_future<>();
 }
 
+// We want to generate the same uniform boundaries if tablet count is a power-of-two as
+// we did before implementing support for arbitrary token boundaries.
+// So that when advertising a "power of two" layout, e.g in the snapshot descriptor,
+// it means the same thing for all scylla versions.
+SEASTAR_THREAD_TEST_CASE(test_get_uniform_tokens_is_compatible_with_dht_last_token_of_compaction_group) {
+    for (auto log2count : {0ul, 1ul, 2ul, 3ul, 10ul}) {
+        auto tokens = dht::get_uniform_tokens(1ul << log2count);
+        for (size_t i = 0; i < tokens.size(); i++) {
+            testlog.debug("i {}, token {}", i, tokens[i]);
+            BOOST_REQUIRE_EQUAL(tokens[i], dht::last_token_of_compaction_group(log2count, i));
+            thread::maybe_yield();
+        }
+    }
+}
+
 SEASTAR_TEST_CASE(test_tablet_id_and_range_side) {
     static constexpr size_t tablet_count = 128;
     locator::tablet_map tmap(tablet_count);

--- a/test/boost/tablets_test.cc
+++ b/test/boost/tablets_test.cc
@@ -4933,6 +4933,20 @@ SEASTAR_TEST_CASE(test_tablet_id_and_range_side) {
     return make_ready_future<>();
 }
 
+SEASTAR_THREAD_TEST_CASE(test_get_split_token_is_compatible_with_old_behavior) {
+    for (auto tablet_count : {1ul, 2ul, 128ul, 1ul << log2ceil(100'000ul)}) {
+        locator::tablet_map tmap(tablet_count);
+
+        for (size_t id = 0; id < tablet_count; id++) {
+            testlog.debug("tablet_count {}, id {}", tablet_count, id);
+            auto split_tok = tmap.get_split_token(tablet_id(id));
+            BOOST_REQUIRE_EQUAL(split_tok, dht::last_token_of_compaction_group(log2ceil(tablet_count * 2), id * 2));
+        }
+
+        thread::maybe_yield();
+    }
+}
+
 SEASTAR_THREAD_TEST_CASE(basic_tablet_storage_splitting_test) {
     auto cfg = tablet_cql_test_config();
     cfg.initial_tablets = std::bit_floor(smp::count);

--- a/test/boost/tablets_test.cc
+++ b/test/boost/tablets_test.cc
@@ -2432,6 +2432,152 @@ SEASTAR_THREAD_TEST_CASE(test_no_conflicting_internode_and_intra_merge_colocatio
     }, cfg).get();
 }
 
+void set_tablet_opts(cql_test_env& e, table_id table, const std::map<sstring, sstring>& opts) {
+    auto s = e.local_db().find_column_family(table).schema();
+    auto opts_string = fmt::to_string(fmt::join(opts | std::views::transform([] (auto&& e) {
+        return fmt::format("'{}': '{}'", e.first, e.second);
+    }), ", "));
+    e.execute_cql(fmt::format("alter table \"{}\".\"{}\" with tablets = {{{}}}",
+                         s->ks_name(), s->cf_name(), opts_string)).get();
+}
+
+SEASTAR_THREAD_TEST_CASE(test_merge_chooses_best_replica_with_odd_count) {
+    auto cfg = cql_test_config{};
+    cfg.db_config->tablets_per_shard_goal.set(10000); // Inhibit scaling-down of the count.
+    do_with_cql_env_thread([](auto& e) {
+        auto& stm = e.shared_token_metadata().local();
+
+        auto loc = stm.get()->get_topology().get_location();
+        topology_builder topo(e);
+        topo.add_node(node_state::normal, 1, loc);
+
+        // Choose the count so that it is even, but halving it repeatedly will produce odd numbers.
+        // In this case: 258 = binary 100000010
+        // Each merge does div_ceil() on the count, so the sequence will be:
+        // 258 -> 129 -> 65 -> 33 -> 17 -> 9 -> 5 -> 3 -> 2 -> 1
+        // This is the hard case for whole-table merge, which has to pick the right tablet to isolate
+        // to prevent large deviation of tablet sizes. If merge always chooses the last tablet to be isolated,
+        // it will be tiny after all merges are done.
+        size_t initial_count = 258;
+        auto ks_name = add_keyspace(e, {{loc.dc, 1}}, 1);
+        auto opts = std::map<sstring, sstring>({
+            {"min_tablet_count", std::to_string(initial_count)},
+            {"pow2_count", "false"}
+        });
+        auto table1 = add_table(e, ks_name, opts).get();
+
+        // Set sizes, small enough to allow for arbitrary merging.
+        topo.get_shared_load_stats().set_tablet_sizes(stm.get(), table1, 1);
+
+        {
+            auto& tmap = stm.get()->tablets().get_tablet_map(table1);
+            BOOST_REQUIRE(tmap.tablet_count() == initial_count);
+        }
+
+        // Pick a count which will make the table go through several merges,
+        // but is large enough so that we can assess imbalance.
+        size_t final_count = 5;
+        opts["min_tablet_count"] = std::to_string(final_count);
+        set_tablet_opts(e, table1, opts);
+        rebalance_tablets(e, &topo.get_shared_load_stats());
+
+        auto& tmap = stm.get()->tablets().get_tablet_map(table1);
+        BOOST_REQUIRE(tmap.tablet_count() == final_count);
+
+        min_max_tracker<uint64_t> size_minmax;
+        tmap.for_each_tablet([&] (tablet_id tid, const locator::tablet_info& tinfo) {
+            auto tablet_size = topo.get_shared_load_stats().get()->get_avg_tablet_size(tmap, global_tablet_id{table1, tid});
+            BOOST_REQUIRE(tablet_size.has_value());
+            testlog.info("Tablet {} size: {}", tid, *tablet_size);
+            size_minmax.update(*tablet_size);
+            return make_ready_future<>();
+        }).get();
+
+        // The largest tablet should be no smaller than the average tablet size (sanity check).
+        BOOST_REQUIRE_GE(size_minmax.max(), initial_count / final_count);
+
+        // The smallest tablet should be no smaller than half of the largest tablet.
+        BOOST_REQUIRE_GE(size_minmax.min(), size_minmax.max() / 2);
+    }, std::move(cfg)).get();
+}
+
+SEASTAR_THREAD_TEST_CASE(test_merge_stale_isolated_tablet_reproducer_odd_even_even) {
+    auto cfg = cql_test_config{};
+    cfg.db_config->tablets_per_shard_goal.set(10000); // Inhibit scaling-down of the count.
+    do_with_cql_env_thread([](auto& e) {
+        auto& stm = e.shared_token_metadata().local();
+
+        topology_builder topo(e);
+        topo.add_node(node_state::normal, 2);
+        topo.add_node(node_state::normal, 2);
+        topo.add_node(node_state::normal, 2);
+
+        const size_t initial_count = 7; // odd -> even -> even merge sequence starts here
+        auto ks_name = add_keyspace(e, {{topo.dc(), 1}}, 1);
+        auto opts = std::map<sstring, sstring>({
+            {"min_tablet_count", std::to_string(initial_count)},
+            {"pow2_count", "false"}
+        });
+        auto table1 = add_table(e, ks_name, opts).get();
+
+        auto& load_stats = topo.get_shared_load_stats();
+        load_stats.set_tablet_sizes(stm.get(), table1, 1);
+
+        // Make tablet 0 the largest so odd-count merge should isolate tablet 0.
+        auto& tmap = stm.get()->tablets().get_tablet_map(table1);
+        auto tid0 = tmap.first_tablet();
+        locator::range_based_tablet_id rb_tid0{table1, tmap.get_token_range(tid0)};
+        for (auto& r : tmap.get_tablet_info(tid0).replicas) {
+            load_stats.set_tablet_size(r.host, rb_tid0, 100);
+        }
+
+        // First stage: force exactly one odd->even merge: 7 -> 4.
+        opts["min_tablet_count"] = "4";
+        set_tablet_opts(e, table1, opts);
+
+        // Apply exactly one balancing iteration so the merge decision is emitted but not finalized.
+        bool first_iteration_done = false;
+        rebalance_tablets(e, &load_stats, {}, [&] (const migration_plan&) {
+            if (first_iteration_done) {
+                return true;
+            }
+            first_iteration_done = true;
+            return false;
+        });
+
+        {
+            auto& decision = stm.get()->tablets().get_tablet_map(table1).resize_decision();
+            BOOST_REQUIRE(decision.is_merge());
+            BOOST_REQUIRE(std::get<locator::resize_decision::merge>(decision.way).isolated_tablet == tablet_id(0));
+        }
+
+        // Finalize first merge fully, reaching even count 4.
+        rebalance_tablets(e, &load_stats);
+        BOOST_REQUIRE(stm.get()->tablets().get_tablet_map(table1).tablet_count() == 4);
+
+        // Second stage: another merge request on an even count, 4 -> 2.
+        opts["min_tablet_count"] = "2";
+        set_tablet_opts(e, table1, opts);
+
+        bool second_iteration_done = false;
+        rebalance_tablets(e, &load_stats, {}, [&] (const migration_plan&) {
+            if (second_iteration_done) {
+                return true;
+            }
+            second_iteration_done = true;
+            return false;
+        });
+
+        auto tm_from_disk = read_tablet_metadata(e.local_qp()).get();
+        auto& decision = tm_from_disk.get_tablet_map(table1).resize_decision();
+        BOOST_REQUIRE(std::holds_alternative<locator::resize_decision::merge>(decision.way));
+
+        // Expected for the second (even-count) merge: no isolated tablet.
+        // This assertion reproduces the current bug by failing with stale tablet_id(0).
+        BOOST_REQUIRE(std::get<locator::resize_decision::merge>(decision.way).isolated_tablet == std::nullopt);
+    }, std::move(cfg)).get();
+}
+
 SEASTAR_THREAD_TEST_CASE(test_rack_list_conversion) {
     do_with_cql_env_thread([] (auto& e) {
         topology_builder topo(e);

--- a/test/boost/tablets_test.cc
+++ b/test/boost/tablets_test.cc
@@ -2527,6 +2527,44 @@ SEASTAR_THREAD_TEST_CASE(test_rack_list_conversion) {
     }).get();
 }
 
+SEASTAR_THREAD_TEST_CASE(test_tablet_map_layout) {
+    auto cfg = cql_test_config{};
+    cfg.db_config->tablets_per_shard_goal.set(10000); // Inhibit scaling-down of the count.
+    do_with_cql_env_thread([](auto& e) {
+        auto& stm = e.shared_token_metadata().local();
+
+        topology_builder topo(e);
+        topo.add_node(node_state::normal, 1);
+
+        auto ks_name = add_keyspace(e, {{topo.dc(), 1}}, 1);
+        auto min_10 = std::map<sstring, sstring>({{"min_tablet_count", "10"}, {"pow2_count", "false"}}); // 10 -> 5 -> 3 -> 2
+        auto min_8 = std::map<sstring, sstring>({{"min_tablet_count", "8"}, {"pow2_count", "false"}});
+        auto min_2 = std::map<sstring, sstring>({{"min_tablet_count", "2"}, {"pow2_count", "false"}});
+        auto table1 = add_table(e, ks_name, min_10).get();
+        auto table2 = add_table(e, ks_name, min_8).get();
+        auto table3 = add_table(e, ks_name, min_8).get();
+
+        BOOST_REQUIRE(stm.get()->tablets().get_tablet_map(table1).tablet_count() == 10);
+        BOOST_REQUIRE(stm.get()->tablets().get_tablet_map(table2).tablet_count() == 8);
+        BOOST_REQUIRE(stm.get()->tablets().get_tablet_map(table3).tablet_count() == 8);
+
+        BOOST_REQUIRE(tablet_layout::arbitrary == stm.get()->tablets().get_tablet_map(table1).get_layout());
+        BOOST_REQUIRE(tablet_layout::pow_of_2 == stm.get()->tablets().get_tablet_map(table2).get_layout());
+        BOOST_REQUIRE(tablet_layout::pow_of_2 == stm.get()->tablets().get_tablet_map(table3).get_layout());
+
+        topo.get_shared_load_stats().set_tablet_sizes(stm.get(), table1, 1);
+
+        set_tablet_opts(e, table1, min_2);
+        rebalance_tablets(e, &topo.get_shared_load_stats());
+
+        // Even though the count is a power-of-two, boundaries are not aligned due to odd-count merge,
+        // so the layout should remain arbitrary.
+        BOOST_REQUIRE(stm.get()->tablets().get_tablet_map(table1).tablet_count() == 2);
+        BOOST_REQUIRE(tablet_layout::arbitrary == stm.get()->tablets().get_tablet_map(table1).get_layout());
+        return make_ready_future<>();
+    }, std::move(cfg)).get();
+}
+
 SEASTAR_THREAD_TEST_CASE(test_colocation_skipped_on_excluded_nodes) {
     do_with_cql_env_thread([] (auto& e) {
         topology_builder topo(e);


### PR DESCRIPTION
There are several reasons we want to do that.

One is that it will give us more flexibility in distributing the
load. We can subdivide tablets at any token, and achieve more
evenly-sized tablets. In particular, we can isolate large partitions
into separate tablets.

We can also split and merge incrementally individual tablets.
Currently, we do it for the whole table or nothing, which makes
splits and merges take longer and cause wide swings of the count.
This is not implemented in this PR yet, we still split/merge the whole table.

Another reason is vnode to tablets migration. We now could construct a
tablet map which matches exactly the vnode boundaries, so migration
can happen transparently from CQL-coordinator point of view.

Tablet count is still a power-of-two by default for newly created tables.
It may be different if tablet map is created by non-standard means,
or if per-table tablet option "pow2_count" is set to "false".

build/release/scylla perf-tablets:

Memory footprint for 131k tablets increased from 56 MiB to 58.1 MiB (+3.5%)

Before:
```
Generating tablet metadata
Total tablet count: 131072
Size of tablet_metadata in memory: 57456 KiB
Copied in 0.014346 [ms]
Cleared in 0.002698 [ms]
Saved in 1234.685303 [ms]
Read in 445.577881 [ms]
Read mutations in 299.596313 [ms] 128 mutations
Read required hosts in 247.482742 [ms]
Size of canonical mutations: 33.945053 [MiB]
Disk space used by system.tablets: 1.456761 [MiB]
Tablet metadata reload:
full      407.69ms
partial     2.65ms
```

After:
```
Generating tablet metadata
Total tablet count: 131072
Size of tablet_metadata in memory: 59504 KiB
Copied in 0.032475 [ms]
Cleared in 0.002965 [ms]
Saved in 1093.877441 [ms]
Read in 387.027100 [ms]
Read mutations in 255.752121 [ms] 128 mutations
Read required hosts in 211.202805 [ms]
Size of canonical mutations: 33.954453 [MiB]
Disk space used by system.tablets: 1.450162 [MiB]
Tablet metadata reload:
full      354.50ms
partial     2.19ms
```
