### PR TITLE
selection: fix `add_column_for_post_processing` for ORDER BY

### DIFF
--- a/cql3/selection/selection.cc
+++ b/cql3/selection/selection.cc
@@ -212,11 +212,20 @@ public:
     }
 
     virtual uint32_t add_column_for_post_processing(const column_definition& c) override {
-        uint32_t index = selection::add_column_for_post_processing(c);
+        auto it = std::find_if(_selectors.begin(), _selectors.end(), [&c](const expr::expression& e) {
+            auto col = expr::as_if<expr::column_value>(&e);
+            return col && col->col == &c;
+        });
+        if (it != _selectors.end()) {
+            return std::distance(_selectors.begin(), it);
+        }
+
+        add_column(c);
+        get_result_metadata()->add_non_serialized_column(c.column_specification);
         _selectors.push_back(expr::column_value(&c));
         if (_inner_loop.empty()) {
             // Simple case: no aggregation
-            return index;
+            return _selectors.size() - 1;
         } else {
             // Complex case: aggregation, must pass through temporary
             auto first_func = cql3::functions::aggregate_fcts::make_first_function(c.type);
@@ -470,10 +479,21 @@ std::vector<const column_definition*> selection::wildcard_columns(schema_ptr sch
     return simple_selection::make(schema, std::move(columns), false);
 }
 
-uint32_t selection::add_column_for_post_processing(const column_definition& c) {
+selection::add_column_result selection::add_column(const column_definition& c) {
+    auto index = index_of(c);
+    if (index != -1) {
+        return {index, false};
+    }
     _columns.push_back(&c);
-    _metadata->add_non_serialized_column(c.column_specification);
-    return _columns.size() - 1;
+    return {_columns.size() - 1, true};
+}
+
+uint32_t selection::add_column_for_post_processing(const column_definition& c) {
+    auto col = add_column(c);
+    if (col.added) {
+        _metadata->add_non_serialized_column(c.column_specification);
+    }
+    return col.index;
 }
 
 ::shared_ptr<selection> selection::from_selectors(data_dictionary::database db, schema_ptr schema, const sstring& ks, const std::vector<prepared_selector>& prepared_selectors) {

--- a/cql3/selection/selection.hh
+++ b/cql3/selection/selection.hh
@@ -130,6 +130,14 @@ public:
     virtual std::vector<shared_ptr<functions::function>> used_functions() const { return {}; }
 
     query::partition_slice::option_set get_query_options();
+protected:
+    // Result of add_column: index in _columns and whether it was added now (or existed already).
+    struct add_column_result {
+        uint32_t index;
+        bool added;
+    };
+    // Adds a column to the _columns if not already present, returns add_column_result.
+    add_column_result add_column(const column_definition& c);
 private:
     static bool processes_selection(const std::vector<prepared_selector>& prepared_selectors);
 

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -2759,11 +2759,7 @@ select_statement::ordering_comparator_type select_statement::get_ordering_compar
     // even if we don't
     // ultimately ship them to the client (CASSANDRA-4911).
     for (auto&& [column_def, is_descending] : orderings) {
-        auto index = selection.index_of(*column_def);
-        if (index < 0) {
-            index = selection.add_column_for_post_processing(*column_def);
-        }
-
+        auto index = selection.add_column_for_post_processing(*column_def);
         sorters.emplace_back(index, column_def->type);
     }
 
@@ -2866,9 +2862,7 @@ void select_statement::ensure_filtering_columns_retrieval(data_dictionary::datab
                                         selection::selection& selection,
                                         const restrictions::statement_restrictions& restrictions) {
     for (auto&& cdef : restrictions.get_column_defs_for_filtering(db)) {
-        if (!selection.has_column(*cdef)) {
-            selection.add_column_for_post_processing(*cdef);
-        }
+        selection.add_column_for_post_processing(*cdef);
     }
 }
 

--- a/test/cqlpy/cassandra_tests/validation/entities/json_test.py
+++ b/test/cqlpy/cassandra_tests/validation/entities/json_test.py
@@ -1264,11 +1264,7 @@ def testEmptyStringJsonSerialization(cql, test_keyspace):
 
 # CASSANDRA-14286
 # Reproduces #8100
-# We have to *skip* this test instead of *xfail*, because our buggy
-# implementation not only fails to produce the right results, it reads
-# already-freed memory to do so, which crashes the debug build with the
-# sanitizer enabled.
-@pytest.mark.skip(reason="issue #8100")
+@pytest.mark.xfail(reason="issue #28467")
 def testJsonOrdering(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a INT, b INT, PRIMARY KEY(a, b))") as table:
         execute(cql, table, "INSERT INTO %s(a, b) VALUES (20, 30);")

--- a/test/cqlpy/cassandra_tests/validation/operations/select_order_by_test.py
+++ b/test/cqlpy/cassandra_tests/validation/operations/select_order_by_test.py
@@ -204,7 +204,6 @@ def testInvalidOrderBy(cql, test_keyspace):
 # Check that order-by works with IN (CASSANDRA-4327)
 # migrated from cql_tests.py:TestCQL.order_by_with_in_test()
 # Reproduces issue #9435
-@pytest.mark.xfail(reason="Issue #9435")
 def testOrderByForInClause(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(my_id varchar, col1 int, value varchar, PRIMARY KEY (my_id, col1))") as table:
 
@@ -320,7 +319,6 @@ def testOrderByForInClause(cql, test_keyspace):
             assert_invalid_message(cql, table, "LIMIT must be strictly positive",
                                  "SELECT v as c2 FROM %s where pk1 = ? AND pk2 IN (?, ?) ORDER BY c1 DESC , c2 DESC LIMIT 0; ", 1, 1, 2)
 
-@pytest.mark.skip(reason="Issue #22061")
 def testOrderByForInClauseWithCollectionElementSelection(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(pk int, c frozen<set<int>>, v int, PRIMARY KEY (pk, c))") as table:
         execute(cql, table, "INSERT INTO %s (pk, c, v) VALUES (0, {1, 2}, 0)")


### PR DESCRIPTION
The purpose of `add_column_for_post_processing` is to add columns that are required for processing of a query,
but are not part of SELECT clause and shouldn't be returned. They are added to the final result set, but later are not serialized.
Mainly it is used for filtering and grouping columns, with a special case of `WHERE primary_key IN ...  ORDER BY ...` when the whole result set needs additional final sorting, and ordering columns must be added as well.

There was a bug that manifested in https://github.com/scylladb/scylladb/issues/9435, https://github.com/scylladb/scylladb/issues/8100 and was actually identified in https://github.com/scylladb/scylladb/issues/22061.
In case of selection with processing (e.g functions involved), result set row is formed in two stages.
Initially it is a list of columns fetched from replicas - on which filtering and grouping is performed.
After that the actual selection is resolved and the final number of columns can change.
Ordering is performed on this final shape, but the ordering column index returned by `add_column_for_post_processing` refereed to initial shape.
If selection refereed to the same column twice (e.g. `v, TTL(v)` as in https://github.com/scylladb/scylladb/issues/9435) final row was longer than initial and ordering refereed to incorrect column.
If a function in selection refereed to multiple columns (e.g. as_json(.., ..) which https://github.com/scylladb/scylladb/issues/8100 effectively uses) the final row was shorter and ordering tried to use a non-existing column.

This patch fixes the problem by making sure that column index of the final result set is used for ordering.

The previously crashing test `cassandra_tests/validation/entities/json_test.py::testJsonOrdering` doesn't have to be skipped, but now it is failing on issue https://github.com/scylladb/scylladb/issues/28467.

Fixes https://github.com/scylladb/scylladb/issues/9435
Fixes https://github.com/scylladb/scylladb/issues/8100
Fixes https://github.com/scylladb/scylladb/issues/22061

It fixes a crash, so should be backported to all supported versions