### PR TITLE
Revert "main: test: add future and abort_source to after_init_func"

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -571,7 +571,7 @@ sharded<service::storage_proxy> *the_storage_proxy;
 // This is used by perf-alternator to allow running scylla together with the tool
 // in a single process. So that it's easier to measure internals. It's not added
 // to main_func_type to not complicate common flow as no other tool needs such logic.
-std::function<future<>(lw_shared_ptr<db::config>, sharded<abort_source>&)> after_init_func;
+std::function<void(lw_shared_ptr<db::config>)> after_init_func;
 
 static locator::host_id initialize_local_info_thread(sharded<db::system_keyspace>& sys_ks,
         sharded<locator::snitch_ptr>& snitch,
@@ -2581,13 +2581,11 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             supervisor::notify("serving");
 
             startlog.info("Scylla version {} initialization completed.", scylla_version());
-            future<> after_init_fut = make_ready_future<>();
             if (after_init_func) {
-                after_init_fut = after_init_func(cfg, stop_signal.as_sharded_abort_source());
+                after_init_func(cfg);
             }
             stop_signal.wait().get();
             startlog.info("Signal received; shutting down");
-            std::move(after_init_fut).get();
 	    // At this point, all objects destructors and all shutdown hooks registered with defer() are executed
           } catch (const sleep_aborted&) {
             startlog.info("Startup interrupted");

--- a/test/perf/entry_point.hh
+++ b/test/perf/entry_point.hh
@@ -19,8 +19,8 @@ int scylla_row_cache_update_main(int argc, char**argv);
 int scylla_simple_query_main(int argc, char** argv);
 int scylla_sstable_main(int argc, char** argv);
 int scylla_tablets_main(int argc, char**argv);
-std::function<int(int, char**)> alternator(std::function<int(int, char**)> scylla_main, std::function<future<>(lw_shared_ptr<db::config> cfg, sharded<abort_source>& as)>* after_init_func);
+std::function<int(int, char**)> alternator(std::function<int(int, char**)> scylla_main, std::function<void(lw_shared_ptr<db::config> cfg)>* after_init_func);
 int scylla_tablet_load_balancing_main(int argc, char**argv);
-std::function<int(int, char**)> perf_cql_raw(std::function<int(int, char**)> scylla_main, std::function<future<>(lw_shared_ptr<db::config> cfg, sharded<abort_source>& as)>* after_init_func);
+std::function<int(int, char**)> perf_cql_raw(std::function<int(int, char**)> scylla_main, std::function<void(lw_shared_ptr<db::config> cfg)>* after_init_func);
 
 } // namespace tools


### PR DESCRIPTION
This reverts commit 7bf7ff785a7441f64ec864cff201d864052fcaa8. The commit tried to add clean shutdown to `scylla perf` paths, but forgot at least `scylla perf-alternator --workload wr` which now crashes on uninitialized `c.as`.

Fixes #28473

No backport - the offending commit is not in any branch.