### PR TITLE
fix(scylla_gdb): use run_ctx to handle scylla server lifecycle

### DIFF
--- a/test/pylib/suite/python.py
+++ b/test/pylib/suite/python.py
@@ -260,7 +260,7 @@ class PythonTest(Test):
             self.is_before_test_ok = True
             cluster.take_log_savepoint()
 
-            yield
+            yield cluster
 
             if self.shortname in self.suite.dirties_cluster:
                 cluster.is_dirty = True

--- a/test/scylla_gdb/conftest.py
+++ b/test/scylla_gdb/conftest.py
@@ -3,93 +3,73 @@
 # SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
 """Conftest for Scylla GDB tests"""
 
-import logging
 import os
+import subprocess
 
-import pexpect
 import pytest
-import re
 
+from test.pylib.runner import testpy_test_fixture_scope
 from test.pylib.suite.python import PythonTest
-from test.pylib.util import LogPrefixAdapter
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope=testpy_test_fixture_scope)
 async def scylla_server(testpy_test: PythonTest | None):
     """Return a running Scylla server instance from the active test cluster."""
-    logger_prefix = testpy_test.mode + "/" + testpy_test.uname
-    logger = LogPrefixAdapter(
-        logging.getLogger(logger_prefix), {"prefix": logger_prefix}
-    )
-    scylla_cluster = await testpy_test.suite.clusters.get(logger)
-    scylla_server = next(iter(scylla_cluster.running.values()))
-
-    yield scylla_server
-
-    await testpy_test.suite.clusters.put(scylla_cluster, is_dirty=True)
+    async with testpy_test.run_ctx(options=testpy_test.suite.options) as cluster:
+        yield next(iter(cluster.running.values()))
 
 
 @pytest.fixture(scope="module")
-def gdb_process(scylla_server, request):
-    """Spawn an interactive GDB attached to the Scylla process.
-
-    Loads `scylla-gdb.py` and test helpers (`gdb_utils.py`) so tests can run GDB/Python helpers
-    against the live Scylla process.
+def gdb_cmd(scylla_server, request):
+    """
+    Returns a command-line (argv list) that attaches to the `scylla_server` PID, loads `scylla-gdb.py`
+    and `gdb_utils.py`. This is meant to be executed by `execute_gdb_command()` in `--batch` mode.
     """
     scylla_gdb_py = os.path.join(request.fspath.dirname, "..", "..", "scylla-gdb.py")
     script_py = os.path.join(request.fspath.dirname, "gdb_utils.py")
-    cmd = (
-        f"gdb -q "
-        "--nx "
-        "-iex 'set confirm off' "
-        "-iex 'set pagination off' "
-        f"-se {scylla_server.exe} "
-        f"-p {scylla_server.cmd.pid} "
-        f"-ex set python print-stack full "
-        f"-x {scylla_gdb_py} "
-        f"-x {script_py}"
-    )
-    gdb_process = pexpect.spawn(cmd, maxread=10, searchwindowsize=10)
-    gdb_process.expect_exact("(gdb)")
+    cmd = [
+        "gdb",
+        "-q",
+        "--batch",
+        "--nx",
+        "-se",
+        str(scylla_server.exe),
+        "-p",
+        str(scylla_server.cmd.pid),
+        "-ex",
+        "set python print-stack full",
+        "-x",
+        scylla_gdb_py,
+        "-x",
+        script_py,
+    ]
+    return cmd
 
-    yield gdb_process
 
-    gdb_process.terminate()
+def execute_gdb_command(gdb_cmd, scylla_command: str = None, full_command: str = None):
+    """Execute a single GDB command attached to the running Scylla process.
 
-
-def execute_gdb_command(
-    gdb_process, scylla_command: str = None, full_command: str = None
-):
-    """
-    Execute a command in an interactive GDB session and return its output.
-
-    The command can be provided either as a Scylla GDB command (which will be
-    wrapped and executed via GDB's Python interface) or as a full raw GDB
-    command string.
-
-    The function waits for the GDB prompt to reappear, enforces a timeout,
-    and fails the test if the command does not complete or if GDB reports an
-    error.
+    Builds on `gdb_cmd` and runs GDB via `subprocess.run()` in `--batch` mode.
+    `scylla_command` is executed as `scylla <cmd>` through GDB's Python interface.
 
     Args:
-        gdb_process (pexpect.pty_spawn.spawn): An active GDB process spawned via pexpect
-        scylla_command (str, optional): A GDB Scylla command (from scylla-gdb.py) to execute.
-        full_command (str, optional): A raw GDB command string to execute.
+        gdb_cmd: Base GDB argv list returned by the `gdb_cmd` fixture.
+        scylla_command: Scylla GDB command name/args (from scylla-gdb.py). Mutually exclusive with `full_command`.
+        full_command: Raw GDB command string to execute. Mutually exclusive with `scylla_command`.
+
+    Returns:
+        Command stdout as a decoded string.
     """
-    command = f"python gdb.execute('scylla {scylla_command}')"
     if full_command:
-        command = full_command
+        command = [*gdb_cmd, "-ex", full_command]
+    else:
+        command = [
+            *gdb_cmd,
+            "-ex",
+            f"python gdb.execute('scylla {scylla_command}')",
+        ]
 
-    gdb_process.sendline(command)
-    try:
-        gdb_process.expect_exact("(gdb)", timeout=180)
-    except pexpect.exceptions.TIMEOUT:
-        gdb_process.sendcontrol("c")
-        gdb_process.expect_exact("(gdb)", timeout=1)
-        pytest.fail("GDB command did not complete within the timeout period")
-    result = gdb_process.before.decode("utf-8")
-
-    # The task_histogram command may include "error::Error" in its output, so
-    # allow it.
-    assert not re.search(r'(?<!error::)Error', result)
+    result = subprocess.run(
+        command, capture_output=True, text=True, encoding="utf-8", errors="replace"
+    )
     return result

--- a/test/scylla_gdb/test_basic_commands.py
+++ b/test/scylla_gdb/test_basic_commands.py
@@ -26,6 +26,7 @@ pytestmark = [
 @pytest.mark.parametrize(
     "command",
     [
+        "timers",
         "features",
         "compaction-tasks",
         "databases",
@@ -58,19 +59,20 @@ pytestmark = [
         "task_histogram -a",
         "tasks",
         "threads",
-        "timers",
         "get-config-value compaction_static_shares",
         "read-stats",
         "prepared-statements",
     ],
 )
-def test_scylla_commands(gdb_process, command):
-    execute_gdb_command(gdb_process, command)
+def test_scylla_commands(gdb_cmd, command):
+    result = execute_gdb_command(gdb_cmd, command)
+    assert result.returncode == 0, (
+        f"GDB command {command} failed. stdout: {result.stdout} stderr: {result.stderr}"
+    )
 
 
-def test_nonexistent_scylla_command(gdb_process):
+def test_nonexistent_scylla_command(gdb_cmd):
     """Verifies that running unknown command will produce correct error message"""
-    with pytest.raises(
-        AssertionError, match=r'Undefined scylla command: "nonexistent_command"'
-    ):
-        execute_gdb_command(gdb_process, "nonexistent_command")
+    result = execute_gdb_command(gdb_cmd, "nonexistent_command")
+    assert result.returncode == 1
+    assert  "Undefined scylla command: \"nonexistent_command\"" in result.stderr


### PR DESCRIPTION
The previous implementation of Scylla lifecycle brought flakiness to the test. `PythonTest.run_ctx` uses checks for test success/failure, checks if Scylla is dirty, adds more logging e.t.c. All of this was ignored by the original implementation (I thought it was not necessar,y and `run_ctx` is too heavy.

This change leaves lifecycle management up to PythonTest.run_ctx, which implements more stability logic for setup/teardown. In addition, the plan for the future is to remove `PythonTest` class. Using the standard way, how to run Scylla will make it easier to refactor this in the future.

Replace pexpect-driven GDB interaction with GDB batch mode:
- Avoids DeprecationWarning: "This process is multi-threaded, use of forkpty() may lead to deadlocks in the child.", which ultimately caused CI deadlocks.
- Removes timeout-driven flakiness on slow systems (no interactive waits/timeouts to tune).
- Produces cleaner, more direct assertions around command execution and output.
- Trade-off: batch mode adds ~10s per command per test, but with --dist=worksteal this is ~10% overall runtime increase across the suite.

Running locally: ./tools/toolchain/dbuild ./test.py --mode release  --no-gather-metrics test/scylla_gdb -j 22

    Current solution: 4 min 15 sec
    This PR: 4 min 42 sec


No backport needed. Fix is for the current GDB changes.

Fixes https://scylladb.atlassian.net/browse/SCYLLADB-673
Fixes https://scylladb.atlassian.net/browse/SCYLLADB-663
Fixes https://scylladb.atlassian.net/browse/SCYLLADB-558
Fixes https://scylladb.atlassian.net/browse/SCYLLADB-547
Fixes https://github.com/scylladb/scylladb/issues/28605