### PR TITLE
api: Remove unused (lost) local variable

### DIFF
--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -677,7 +677,6 @@ rest_get_range_to_endpoint_map(http_context& ctx, sharded<service::storage_servi
             table_id = validate_table(ctx.db.local(), keyspace, table);
         }
 
-        std::vector<ss::maplist_mapper> res;
         co_return stream_range_as_array(co_await ss.local().get_range_to_address_map(keyspace, table_id),
                 [](const std::pair<dht::token_range, inet_address_vector_replica_set>& entry){
             ss::maplist_mapper m;


### PR DESCRIPTION
Lost when the get_range_to_endpoint_map hander was implemented for real (48c3c94aa6c4c301c02c0dddac0711eb6dc262c7)

Code cleanup, not backporting