### PR TITLE
nodetool: fix handling of "--primary-replica-only" argument

### DIFF
--- a/test/nodetool/test_restore.py
+++ b/test/nodetool/test_restore.py
@@ -87,3 +87,17 @@ end: {end_time}
 """
         assert res.returncode == expected_returncode
         assert res.stdout == expected_output
+
+
+@pytest.mark.parametrize("scope_val", ["all", "dc", "rack"])
+@pytest.mark.parametrize("pro_val", ["--primary-replica-only", "-pro"])
+def test_restore_scope_primary_replica(nodetool, scylla_only, scope_val, pro_val):
+    nodetool("restore", "--endpoint", "s3.us-east-2.amazonaws.com", "--bucket", "test_bucket", "--prefix",
+             "test_prefix", "--keyspace", "ks", "--table", "tbl", f"--scope={scope_val}", pro_val,
+             "me-1-big-TOC.txt",
+             expected_requests=[
+                 expected_request("POST", "/storage_service/restore",
+                                  params={"endpoint": "s3.us-east-2.amazonaws.com", "bucket": "test_bucket",
+                                          "table": "tbl", "prefix": "test_prefix", "keyspace": "ks",
+                                          "scope": f"{scope_val}", "primary_replica_only": "true"}, body=["me-1-big-TOC.txt"])],
+             check_return_code=False)

--- a/tools/scylla-nodetool.cc
+++ b/tools/scylla-nodetool.cc
@@ -1890,6 +1890,9 @@ void restore_operation(scylla_rest_client& client, const bpo::variables_map& vm)
     if (not sstables_as_params and not sstables_as_file_list) {
       throw std::invalid_argument("missing both argument: sstables and --sstables-file-list (at least one is required)");
     }
+    if (vm.contains("primary-replica-only")) {
+        params["primary_replica_only"] = "true";
+    }
     if (vm.contains("scope")) {
         if (vm.contains("primary-replica-only") && vm["scope"].as<sstring>() == "node") {
             throw std::invalid_argument("Cannot set both primary_replica_only and scope=node");


### PR DESCRIPTION
The "--primary-replica-only" ("-pro") flag was previously ignored by the `restore` operation. This patch ensures the argument is parsed and applied correctly.

No backport needed since we dont use `nodetool` for the restore yet