### PR TITLE
test: minio: disable web console

### DIFF
--- a/test/pylib/minio_server.py
+++ b/test/pylib/minio_server.py
@@ -172,6 +172,7 @@ class MinioServer:
             preexec_fn=os.setsid,
             stderr=self.log_file,
             stdout=self.log_file,
+            env={**os.environ, 'MINIO_BROWSER': 'off'},
         )
         timeout = time.time() + 30
         while time.time() < timeout:


### PR DESCRIPTION
minio starts a web console on a random port. This was seen to interfere with the nodetool tests when the web console port clashed with the mock API port.

Fix by disabling the web console.

Fixes https://scylladb.atlassian.net/browse/SCYLLADB-496

Rarely seen (once), not backporting.