### PR TITLE
test.py: make HostRegistry a singleton

### DIFF
--- a/test/cluster/test_internode_compression.py
+++ b/test/cluster/test_internode_compression.py
@@ -6,10 +6,10 @@
 import logging
 import asyncio
 
+from test.pylib.host_registry import HostRegistry
 from test.pylib.manager_client import ManagerClient
 from test.pylib.internal_types import IPAddress
 from test.cluster.util import new_test_keyspace, new_test_table
-from test.pylib.host_registry import HostRegistry
 from cassandra.cluster import ConsistencyLevel
 
 logger = logging.getLogger(__name__)
@@ -108,9 +108,8 @@ async def do_test_internode_compression_between_datacenters(manager: ManagerClie
 
     logger.info("Creating a new cluster of 2 nodes in 1st DC and 1 node in 2nd DC")
 
-    hosts = HostRegistry()
     dcs = [('dc1','rack1'), ('dc1', 'rack2'), ('dc2', 'rack3')]
-    proxy_addrs = [ (await hosts.lease_host(),dc,rack) for dc,rack in dcs]
+    proxy_addrs = [ (await HostRegistry().lease_host(),dc,rack) for dc,rack in dcs]
     seeds = [IPAddress(addr) for addr,_,_ in proxy_addrs]
     seeds = [proxy_addrs[0][0]]
     config = {"internode_compression": compression, "ssl_storage_port": 0 }

--- a/test/pylib/host_registry.py
+++ b/test/pylib/host_registry.py
@@ -7,14 +7,17 @@ import errno
 import fcntl
 import os
 import random
+import threading
 from pathlib import Path
 from test.pylib.pool import Pool
-from typing import NewType, Awaitable, Optional
+from typing import NewType, Optional
 
 Host = NewType('Host', str)
 
 
 class HostRegistry:
+    _instance = None
+    _initialized = False
     """A Scylla servers needs a unique IP address and working directory
     which we need to manage and share across many running tests. Store
     all shared external resources within this class to make sure
@@ -26,7 +29,15 @@ class HostRegistry:
     across all hosts in a single run.
     """
 
+    def __new__(cls):
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+        return cls._instance
+
     def __init__(self) -> None:
+        if HostRegistry._initialized:
+            return
+        HostRegistry._initialized = True
 
         # Imagine multiple instances of test.py run concurrently.
         # Each will be trying to start and stop Scylla servers.
@@ -46,24 +57,31 @@ class HostRegistry:
         # should try again with another subnet. If the file isn't
         # locked, it remains from some previous invocation and can be
         # locked and reused.
-        while True:
-            # Avoid 127.0.*.* since CCM (a different test framework)
-            # assumes it will be available for it to run Scylla
-            # instances. 127.255.255.255 is also illegal.
-            self.subnet = "127.{}.{}".format(random.randrange(1, 254),
-                                             random.randrange(0, 255))
-            self.lock_filename: Optional[Path] = Path(os.getenv('TMPDIR', '/tmp')) / ('scylla-' + self.subnet)
-            self.lock_file = self.lock_filename.open('w')
-            try:
-                fcntl.lockf(self.lock_file, fcntl.LOCK_EX | fcntl.LOCK_NB)
-                break
-            except OSError as e:
-                if e.errno != errno.EACCES and e.errno != errno.EAGAIN:
-                    raise
-                self.lock_file.close()
-                self.lock_filename.unlink()
-
-            self.lock_file.close()
+        worker_id = os.getenv('PYTEST_XDIST_WORKER', 'gw0')
+        second_octet = int(worker_id[2:]) + 1
+        # HostRegistry is a singleton, so there should be no possibility to mess and overlap in IP for one use
+        # however, when there are several users using the same machine for testing, they can overlap,
+        # so this simple retry should help to eliminate the overlap and just find another random IP
+        max_attempts = 20
+        for attempt in range(max_attempts):
+            with threading.Lock():
+                # Avoid 127.0.*.* since CCM (a different test framework)
+                # assumes it will be available for it to run Scylla
+                # instances. 127.255.255.255 is also illegal.
+                self.subnet = "127.{}.{}".format(second_octet, random.randrange(0, 255))
+                self.lock_filename: Optional[Path] = Path(os.getenv('TMPDIR', '/tmp')) / ('scylla-' + self.subnet)
+                self.lock_file = self.lock_filename.open('w')
+                try:
+                    fcntl.lockf(self.lock_file, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                    break
+                except OSError as e:
+                    self.lock_file.close()
+                    if e.errno not in (errno.EACCES, errno.EAGAIN):
+                        raise
+        else:
+            raise RuntimeError(
+                f"Failed to acquire a subnet lock after {max_attempts} attempts"
+            )
 
         self.subnet += ".{}"
         self.next_host_id = 0
@@ -90,4 +108,3 @@ class HostRegistry:
 
     async def release_host(self, host: Host) -> None:
         return await self.pool.put(host, is_dirty=False)
-


### PR DESCRIPTION
HostRegistry initialized in several places in the framework, this can lead to the overlapping IP, even though the possibility is low it's not zero. This PR makes host registry initialized once for the master thread and pytest. To avoid communication between with workers, each worker will get its own subnet that it can use solely for its own goals. This simplifies the solution while providing the way to avoid overlapping IP's.

Related: https://scylladb.atlassian.net/browse/SCYLLADB-496

Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-637

No backport needed, framework enhancement only.