### PR TITLE
service: strong_consistency: Allow for aborting operations

### DIFF
--- a/cql3/statements/strong_consistency/modification_statement.cc
+++ b/cql3/statements/strong_consistency/modification_statement.cc
@@ -66,7 +66,7 @@ future<shared_ptr<result_message>> modification_statement::execute_without_check
                     raw_cql_statement, muts.size()));
             }
             return std::move(*muts.begin());
-        }, timeout);
+        }, timeout, qs.get_client_state().get_abort_source());
 
     using namespace service::strong_consistency;
     if (const auto* redirect = get_if<need_redirect>(&mutate_result)) {

--- a/cql3/statements/strong_consistency/modification_statement.cc
+++ b/cql3/statements/strong_consistency/modification_statement.cc
@@ -52,6 +52,7 @@ future<shared_ptr<result_message>> modification_statement::execute_without_check
     }
 
     auto [coordinator, holder] = qp.acquire_strongly_consistent_coordinator();
+
     const auto mutate_result = co_await coordinator.get().mutate(_statement->s,
         keys[0].start()->value().token(),
         [&](api::timestamp_type ts) {
@@ -65,7 +66,7 @@ future<shared_ptr<result_message>> modification_statement::execute_without_check
                     raw_cql_statement, muts.size()));
             }
             return std::move(*muts.begin());
-        });
+        }, timeout);
 
     using namespace service::strong_consistency;
     if (const auto* redirect = get_if<need_redirect>(&mutate_result)) {

--- a/cql3/statements/strong_consistency/select_statement.cc
+++ b/cql3/statements/strong_consistency/select_statement.cc
@@ -42,7 +42,7 @@ future<::shared_ptr<result_message>> select_statement::do_execute(query_processo
     const auto timeout = db::timeout_clock::now() + get_timeout(state.get_client_state(), options);
     auto [coordinator, holder] = qp.acquire_strongly_consistent_coordinator();
     auto query_result = co_await coordinator.get().query(_query_schema, *read_command,
-        key_ranges, state.get_trace_state(), timeout);
+        key_ranges, state.get_trace_state(), timeout, state.get_client_state().get_abort_source());
 
     using namespace service::strong_consistency;
     if (const auto* redirect = get_if<need_redirect>(&query_result)) {

--- a/service/client_state.hh
+++ b/service/client_state.hh
@@ -76,14 +76,15 @@ public:
             : _cs(cs), _auth_service(auth_service), _sl_controller(sl_controller) {}
         friend client_state;
     public:
-        client_state get() const {
-            return client_state(_cs, _auth_service, _sl_controller);
+        client_state get(abort_source* as = nullptr) const {
+            return client_state(_cs, _auth_service, _sl_controller, as);
         }
     };
 private:
     client_state(const client_state* cs,
         seastar::sharded<auth::service>* auth_service,
-        seastar::sharded<qos::service_level_controller>* sl_controller)
+        seastar::sharded<qos::service_level_controller>* sl_controller,
+        abort_source* as)
             : _keyspace(cs->_keyspace)
             , _user(cs->_user)
             , _auth_state(cs->_auth_state)
@@ -94,6 +95,7 @@ private:
             , _sl_controller(sl_controller ? &sl_controller->local() : nullptr)
             , _default_timeout_config(cs->_default_timeout_config)
             , _timeout_config(cs->_timeout_config)
+            , _as(as)
             , _enabled_protocol_extensions(cs->_enabled_protocol_extensions)
     {}
     friend client_state_for_another_shard;
@@ -153,6 +155,11 @@ private:
 
     workload_type _workload_type = workload_type::unspecified;
 
+    // Used to communicate with the code executing user requests.
+    // It's a way to indicate that we might abort processing the
+    // request, e.g. if the corresponding connection has been severed.
+    abort_source* _as{nullptr};
+
 public:
     struct internal_tag {};
     struct external_tag {};
@@ -211,14 +218,16 @@ public:
                  qos::service_level_controller* sl_controller,
                  timeout_config timeout_config,
                  const socket_address& remote_address = socket_address(),
-                 bool bypass_auth_checks = false)
+                 bool bypass_auth_checks = false,
+                 abort_source* as = nullptr)
             : _is_internal(false)
             , _bypass_auth_checks(bypass_auth_checks)
             , _remote_address(remote_address)
             , _auth_service(&auth_service)
             , _sl_controller(sl_controller)
             , _default_timeout_config(timeout_config)
-            , _timeout_config(timeout_config) {
+            , _timeout_config(timeout_config)
+            , _as(as) {
         if (!auth_service.underlying_authenticator().require_authentication()) {
             _user = auth::authenticated_user();
         }
@@ -244,29 +253,32 @@ public:
         return *_sl_controller;
     }
 
-    client_state(internal_tag) : client_state(internal_tag{}, infinite_timeout_config)
+    client_state(internal_tag, abort_source* as = nullptr) : client_state(internal_tag{}, infinite_timeout_config, as)
     {}
 
-    client_state(internal_tag, const timeout_config& config)
+    client_state(internal_tag, const timeout_config& config, abort_source* as = nullptr)
             : _keyspace("system")
             , _is_internal(true)
             , _bypass_auth_checks(true)
             , _default_timeout_config(config)
             , _timeout_config(config)
+            , _as(as)
     {}
 
-    client_state(internal_tag, auth::service& auth_service, qos::service_level_controller& sl_controller, sstring username)
+    client_state(internal_tag, auth::service& auth_service, qos::service_level_controller& sl_controller, sstring username, abort_source* as = nullptr)
         : _user(auth::authenticated_user(username))
         , _auth_state(auth_state::READY)
         , _is_internal(true)
         , _bypass_auth_checks(true)
         , _auth_service(&auth_service)
         , _sl_controller(&sl_controller)
+        , _as(as)
     {}
 
     client_state(auth::service& auth_service,
                  qos::service_level_controller* sl_controller,
-                 forwarded_client_state&& forwarded_state)
+                 forwarded_client_state&& forwarded_state,
+                 abort_source* as = nullptr)
             : _keyspace(std::move(forwarded_state.keyspace))
             , _user(forwarded_state.username ? auth::authenticated_user(*forwarded_state.username) : auth::authenticated_user{})
             , _auth_state(auth_state::READY)
@@ -277,6 +289,7 @@ public:
             , _sl_controller(sl_controller)
             , _default_timeout_config(forwarded_state.timeout_config)
             , _timeout_config(std::move(forwarded_state.timeout_config))
+            , _as(as)
             , _enabled_protocol_extensions(cql_transport::cql_protocol_extension_enum_set::from_mask(
                     forwarded_state.protocol_extensions_mask))
     {}
@@ -390,6 +403,16 @@ public:
             throw exceptions::invalid_request_exception("No keyspace has been specified. USE a keyspace, or explicitly specify keyspace.tablename");
         }
         return _keyspace;
+    }
+
+    abort_source& get_abort_source() {
+        if (_as == nullptr) {
+            utils::on_internal_error("client_state::get_abort_source(): Tried to dereference nullptr");
+        }
+        return *_as;
+    }
+    abort_source* get_abort_source_ptr() noexcept {
+        return _as;
     }
 
     /**

--- a/service/strong_consistency/coordinator.cc
+++ b/service/strong_consistency/coordinator.cc
@@ -57,6 +57,34 @@ static const locator::tablet_replica* find_replica(const locator::tablet_info& t
     return it == tinfo.replicas.end() ? nullptr : &*it;
 }
 
+// Subscribe target to sources and return an array of the corresponding
+// subscriptions.
+//
+// The subscribing process will follow the order of the passed abort
+// sources. The corresponding subscriptions in the returned array will
+// also keep the same order.
+//
+// If some of the passed abort sources have already been triggered,
+// they will immediately trigger target. This will be done in their
+// relative order in the function's argument list.
+template <std::same_as<abort_source>... Ts>
+static auto chain_abort_sources(abort_source& target, Ts&... sources) {
+    static_assert(sizeof...(Ts) > 0, "We need to chain at least one abort source!");
+    auto source_array = std::array{std::ref(sources)...};
+
+    for (abort_source& source : source_array) {
+        if (source.abort_requested()) {
+            target.request_abort_ex(source.abort_requested_exception_ptr());
+        }
+    }
+
+    return std::array{
+        sources.subscribe([&target] (const std::optional<std::exception_ptr>& eptr) noexcept {
+            target.request_abort_ex(eptr.value_or(target.get_default_exception()));
+        })...
+    };
+}
+
 struct coordinator::operation_ctx {
     locator::effective_replication_map_ptr erm;
     raft_server raft_server;
@@ -147,9 +175,11 @@ coordinator::coordinator(groups_manager& groups_manager, replica::database& db, 
 future<value_or_redirect<>> coordinator::mutate(schema_ptr schema,
         const dht::token& token,
         mutation_gen&& mutation_gen,
-        timeout_clock::time_point timeout)
+        timeout_clock::time_point timeout,
+        abort_source& as)
 {
     auto aoe = abort_on_expiry<timeout_clock>(timeout);
+    [[maybe_unused]] const auto subs = chain_abort_sources(aoe.abort_source(), as);
 
     try {
         auto op_result = co_await create_operation_ctx(*schema, token, aoe.abort_source());
@@ -255,10 +285,12 @@ auto coordinator::query(schema_ptr schema,
         const query::read_command& cmd,
         const dht::partition_range_vector& ranges,
         tracing::trace_state_ptr trace_state,
-        timeout_clock::time_point timeout
+        timeout_clock::time_point timeout,
+        abort_source& as
     ) -> future<query_result_type>
 {
     auto aoe = abort_on_expiry<timeout_clock>(timeout);
+    [[maybe_unused]] const auto subs = chain_abort_sources(aoe.abort_source(), as);
 
     try {
         auto op_result = co_await create_operation_ctx(*schema, ranges[0].start()->value().token(), aoe.abort_source());

--- a/service/strong_consistency/coordinator.cc
+++ b/service/strong_consistency/coordinator.cc
@@ -119,72 +119,72 @@ future<value_or_redirect<>> coordinator::mutate(schema_ptr schema,
         mutation_gen&& mutation_gen)
 {
     try {
-    auto op_result = co_await create_operation_ctx(*schema, token);
-    if (const auto* redirect = get_if<need_redirect>(&op_result)) {
-        co_return *redirect;
-    }
-    auto& op = get<operation_ctx>(op_result);
+        auto op_result = co_await create_operation_ctx(*schema, token);
+        if (const auto* redirect = get_if<need_redirect>(&op_result)) {
+            co_return *redirect;
+        }
+        auto& op = get<operation_ctx>(op_result);
 
-    while (true) {
-        auto disposition = op.raft_server.begin_mutate();
-        if (const auto* not_a_leader = get_if<raft::not_a_leader>(&disposition)) {
-            const auto leader_host_id = locator::host_id{not_a_leader->leader.uuid()};
-            const auto* target = find_replica(op.tablet_info, leader_host_id);
-            if (!target) {
-                on_internal_error(logger,
-                    ::format("table {}.{}, tablet {}, current leader {} is not a replica, replicas {}",
-                        schema->ks_name(), schema->cf_name(), op.tablet_id, 
-                        leader_host_id, op.tablet_info.replicas));
+        while (true) {
+            auto disposition = op.raft_server.begin_mutate();
+            if (const auto* not_a_leader = get_if<raft::not_a_leader>(&disposition)) {
+                const auto leader_host_id = locator::host_id{not_a_leader->leader.uuid()};
+                const auto* target = find_replica(op.tablet_info, leader_host_id);
+                if (!target) {
+                    on_internal_error(logger,
+                        ::format("table {}.{}, tablet {}, current leader {} is not a replica, replicas {}",
+                            schema->ks_name(), schema->cf_name(), op.tablet_id,
+                            leader_host_id, op.tablet_info.replicas));
+                }
+                co_return need_redirect{*target};
             }
-            co_return need_redirect{*target};
-        }
-        if (auto* wait_for_leader = get_if<raft_server::need_wait_for_leader>(&disposition)) {
-            co_await std::move(wait_for_leader->future);
-            continue;
-        }
-        const auto [ts, term] = get<raft_server::timestamp_with_term>(disposition);
-
-        const raft_command command {
-            .mutation{mutation_gen(ts)}
-        };
-        raft::command raft_cmd;
-        ser::serialize(raft_cmd, command);
-
-        logger.debug("mutate(): add_entry({}), term {}",
-            command.mutation.pretty_printer(schema), term);
-        try {
-            co_await op.raft_server.server().add_entry(std::move(raft_cmd),
-                raft::wait_type::committed,
-                nullptr);
-            co_return std::monostate{};
-        } catch (...) {
-            auto ex = std::current_exception();
-            if (try_catch<raft::request_aborted>(ex) || try_catch<raft::stopped_error>(ex)) {
-                // Holding raft_server.holder guarantees that the raft::server is not
-                // aborted until the holder is released.
-
-                on_internal_error(logger,
-                    format("mutate(): add_entry, unexpected exception {}, table {}.{}, tablet {}, term {}", 
-                        ex, schema->ks_name(), schema->cf_name(), op.tablet_id, term));
-            } else if (try_catch<raft::not_a_leader>(ex) || try_catch<raft::dropped_entry>(ex)) {
-                logger.debug("mutate(): add_entry, got retriable error {}, table {}.{}, tablet {}, term {}",
-                    ex, schema->ks_name(), schema->cf_name(), op.tablet_id, term);
-
+            if (auto* wait_for_leader = get_if<raft_server::need_wait_for_leader>(&disposition)) {
+                co_await std::move(wait_for_leader->future);
                 continue;
-            } else if (try_catch<raft::commit_status_unknown>(ex)) {
-                logger.debug("mutate(): add_entry, got commit_status_unknown {}, table {}.{}, tablet {}, term {}",
-                    ex, schema->ks_name(), schema->cf_name(), op.tablet_id, term);
-
-                // FIXME: use a dedicated ERROR_CODE instead of SERVER_ERROR
-                throw exceptions::server_exception(
-                    "The outcome of this statement is unknown. It may or may not have been applied. "
-                    "Retrying the statement may be necessary.");
             }
+            const auto [ts, term] = get<raft_server::timestamp_with_term>(disposition);
 
-            // We know nothing about other errors, let the cql server convert them to SERVER_ERROR.
-            throw;
+            const raft_command command {
+                .mutation{mutation_gen(ts)}
+            };
+            raft::command raft_cmd;
+            ser::serialize(raft_cmd, command);
+
+            logger.debug("mutate(): add_entry({}), term {}",
+                command.mutation.pretty_printer(schema), term);
+            try {
+                co_await op.raft_server.server().add_entry(std::move(raft_cmd),
+                    raft::wait_type::committed,
+                    nullptr);
+                co_return std::monostate{};
+            } catch (...) {
+                auto ex = std::current_exception();
+                if (try_catch<raft::request_aborted>(ex) || try_catch<raft::stopped_error>(ex)) {
+                    // Holding raft_server.holder guarantees that the raft::server is not
+                    // aborted until the holder is released.
+
+                    on_internal_error(logger,
+                        format("mutate(): add_entry, unexpected exception {}, table {}.{}, tablet {}, term {}",
+                            ex, schema->ks_name(), schema->cf_name(), op.tablet_id, term));
+                } else if (try_catch<raft::not_a_leader>(ex) || try_catch<raft::dropped_entry>(ex)) {
+                    logger.debug("mutate(): add_entry, got retriable error {}, table {}.{}, tablet {}, term {}",
+                        ex, schema->ks_name(), schema->cf_name(), op.tablet_id, term);
+
+                    continue;
+                } else if (try_catch<raft::commit_status_unknown>(ex)) {
+                    logger.debug("mutate(): add_entry, got commit_status_unknown {}, table {}.{}, tablet {}, term {}",
+                        ex, schema->ks_name(), schema->cf_name(), op.tablet_id, term);
+
+                    // FIXME: use a dedicated ERROR_CODE instead of SERVER_ERROR
+                    throw exceptions::server_exception(
+                        "The outcome of this statement is unknown. It may or may not have been applied. "
+                        "Retrying the statement may be necessary.");
+                }
+
+                // We know nothing about other errors, let the cql server convert them to SERVER_ERROR.
+                throw;
+            }
         }
-    }
     } catch (...) {
         throw;
     }
@@ -198,18 +198,18 @@ auto coordinator::query(schema_ptr schema,
     ) -> future<query_result_type>
 {
     try {
-    auto op_result = co_await create_operation_ctx(*schema, ranges[0].start()->value().token());
-    if (const auto* redirect = get_if<need_redirect>(&op_result)) {
-        co_return *redirect;
-    }
-    auto& op = get<operation_ctx>(op_result);
+        auto op_result = co_await create_operation_ctx(*schema, ranges[0].start()->value().token());
+        if (const auto* redirect = get_if<need_redirect>(&op_result)) {
+            co_return *redirect;
+        }
+        auto& op = get<operation_ctx>(op_result);
 
-    co_await op.raft_server.server().read_barrier(nullptr);
+        co_await op.raft_server.server().read_barrier(nullptr);
 
-    auto [result, cache_temp] = co_await _db.query(schema, cmd,
-        query::result_options::only_result(), ranges, trace_state, timeout);
+        auto [result, cache_temp] = co_await _db.query(schema, cmd,
+            query::result_options::only_result(), ranges, trace_state, timeout);
 
-    co_return std::move(result);
+        co_return std::move(result);
     } catch (...) {
         throw;
     }

--- a/service/strong_consistency/coordinator.cc
+++ b/service/strong_consistency/coordinator.cc
@@ -116,7 +116,8 @@ coordinator::coordinator(groups_manager& groups_manager, replica::database& db, 
 
 future<value_or_redirect<>> coordinator::mutate(schema_ptr schema,
         const dht::token& token,
-        mutation_gen&& mutation_gen)
+        mutation_gen&& mutation_gen,
+        timeout_clock::time_point timeout)
 {
     try {
         auto op_result = co_await create_operation_ctx(*schema, token);
@@ -194,7 +195,7 @@ auto coordinator::query(schema_ptr schema,
         const query::read_command& cmd,
         const dht::partition_range_vector& ranges,
         tracing::trace_state_ptr trace_state,
-        db::timeout_clock::time_point timeout
+        timeout_clock::time_point timeout
     ) -> future<query_result_type>
 {
     try {

--- a/service/strong_consistency/coordinator.cc
+++ b/service/strong_consistency/coordinator.cc
@@ -118,6 +118,7 @@ future<value_or_redirect<>> coordinator::mutate(schema_ptr schema,
         const dht::token& token,
         mutation_gen&& mutation_gen)
 {
+    try {
     auto op_result = co_await create_operation_ctx(*schema, token);
     if (const auto* redirect = get_if<need_redirect>(&op_result)) {
         co_return *redirect;
@@ -184,6 +185,9 @@ future<value_or_redirect<>> coordinator::mutate(schema_ptr schema,
             throw;
         }
     }
+    } catch (...) {
+        throw;
+    }
 }
 
 auto coordinator::query(schema_ptr schema,
@@ -193,6 +197,7 @@ auto coordinator::query(schema_ptr schema,
         db::timeout_clock::time_point timeout
     ) -> future<query_result_type>
 {
+    try {
     auto op_result = co_await create_operation_ctx(*schema, ranges[0].start()->value().token());
     if (const auto* redirect = get_if<need_redirect>(&op_result)) {
         co_return *redirect;
@@ -205,6 +210,9 @@ auto coordinator::query(schema_ptr schema,
         query::result_options::only_result(), ranges, trace_state, timeout);
 
     co_return std::move(result);
+    } catch (...) {
+        throw;
+    }
 }
 
 }

--- a/service/strong_consistency/coordinator.cc
+++ b/service/strong_consistency/coordinator.cc
@@ -8,12 +8,14 @@
 
 #include "coordinator.hh"
 #include "db/consistency_level_type.hh"
+#include "exceptions/exceptions.hh"
 #include "raft/raft.hh"
 #include "schema/schema.hh"
 #include "replica/database.hh"
 #include "locator/tablet_replication_strategy.hh"
 #include "service/strong_consistency/state_machine.hh"
 #include "service/strong_consistency/groups_manager.hh"
+#include "utils/error_injection.hh"
 #include "idl/strong_consistency/state_machine.dist.hh"
 #include "idl/strong_consistency/state_machine.dist.impl.hh"
 #include "gms/gossiper.hh"
@@ -22,6 +24,30 @@ namespace service::strong_consistency {
 
 
 static logging::logger logger("sc_coordinator");
+
+// FIXME: Once the drivers support new error codes corresponding
+// to timeouts of queries to strongly consistent tables, use
+// a new, dedicated exception type instead of this.
+struct write_timeout : public exceptions::mutation_write_timeout_exception {
+    write_timeout(std::string_view ks, std::string_view cf)
+        : exceptions::mutation_write_timeout_exception(
+            seastar::format("Query timed out for {}.{}", ks, cf),
+            db::consistency_level::ONE, 0, 1, db::write_type::SIMPLE
+        )
+    {}
+};
+
+// FIXME: Once the drivers support new error codes corresponding
+// to timeouts of queries to strongly consistent tables, use
+// a new, dedicated exception type instead of this.
+struct read_timeout : public exceptions::read_timeout_exception {
+    read_timeout(std::string_view ks, std::string_view cf)
+        : exceptions::read_timeout_exception(
+            seastar::format("Query timed out for {}.{}", ks, cf),
+            db::consistency_level::ONE, 0, 1, false
+        )
+    {}
+};
 
 static const locator::tablet_replica* find_replica(const locator::tablet_info& tinfo, locator::host_id id) {
     const auto it = std::ranges::find_if(tinfo.replicas,
@@ -65,7 +91,7 @@ static locator::tablet_replica select_closest_replica(const gms::gossiper& gossi
     return *it;
 }
 
-auto coordinator::create_operation_ctx(const schema& schema, const dht::token& token) 
+auto coordinator::create_operation_ctx(const schema& schema, const dht::token& token, abort_source& as)
     -> future<value_or_redirect<operation_ctx>>
 {
     auto erm = schema.table().get_effective_replication_map();
@@ -96,7 +122,11 @@ auto coordinator::create_operation_ctx(const schema& schema, const dht::token& t
         };
     }
     const auto& raft_info = tablet_map.get_tablet_raft_info(tablet_id);
-    auto raft_server = co_await _groups_manager.acquire_server(raft_info.group_id);
+
+    co_await utils::get_local_injector().inject("sc_coordinator_wait_before_acquire_server",
+            utils::wait_for_message(5min));
+
+    auto raft_server = co_await _groups_manager.acquire_server(raft_info.group_id, as);
 
     co_return operation_ctx {
         .erm = std::move(erm),
@@ -119,15 +149,20 @@ future<value_or_redirect<>> coordinator::mutate(schema_ptr schema,
         mutation_gen&& mutation_gen,
         timeout_clock::time_point timeout)
 {
+    auto aoe = abort_on_expiry<timeout_clock>(timeout);
+
     try {
-        auto op_result = co_await create_operation_ctx(*schema, token);
+        auto op_result = co_await create_operation_ctx(*schema, token, aoe.abort_source());
         if (const auto* redirect = get_if<need_redirect>(&op_result)) {
             co_return *redirect;
         }
         auto& op = get<operation_ctx>(op_result);
 
         while (true) {
-            auto disposition = op.raft_server.begin_mutate();
+            co_await utils::get_local_injector().inject("sc_coordinator_wait_before_begin_mutate",
+                utils::wait_for_message(5min));
+
+            auto disposition = op.raft_server.begin_mutate(aoe.abort_source());
             if (const auto* not_a_leader = get_if<raft::not_a_leader>(&disposition)) {
                 const auto leader_host_id = locator::host_id{not_a_leader->leader.uuid()};
                 const auto* target = find_replica(op.tablet_info, leader_host_id);
@@ -153,14 +188,18 @@ future<value_or_redirect<>> coordinator::mutate(schema_ptr schema,
 
             logger.debug("mutate(): add_entry({}), term {}",
                 command.mutation.pretty_printer(schema), term);
+
+            co_await utils::get_local_injector().inject("sc_coordinator_wait_before_add_entry",
+                utils::wait_for_message(5min));
+
             try {
                 co_await op.raft_server.server().add_entry(std::move(raft_cmd),
                     raft::wait_type::committed,
-                    nullptr);
+                    &aoe.abort_source());
                 co_return std::monostate{};
             } catch (...) {
                 auto ex = std::current_exception();
-                if (try_catch<raft::request_aborted>(ex) || try_catch<raft::stopped_error>(ex)) {
+                if (try_catch<raft::stopped_error>(ex)) {
                     // Holding raft_server.holder guarantees that the raft::server is not
                     // aborted until the holder is released.
 
@@ -182,12 +221,33 @@ future<value_or_redirect<>> coordinator::mutate(schema_ptr schema,
                         "Retrying the statement may be necessary.");
                 }
 
-                // We know nothing about other errors, let the cql server convert them to SERVER_ERROR.
+                // Let the outer code handle other errors.
                 throw;
             }
         }
     } catch (...) {
-        throw;
+        auto ex = std::current_exception();
+        // Unfortunately, timeouts can materialize in different forms depending
+        // on which statement throws the exception.
+        //
+        // * raft::request_aborted: If the abort source passed to a raft::server's
+        //     method was triggered.
+        // * seastar::abort_requested_exception: Can be thrown by create_operation_ctx.
+        // * timed_out_error: Can be thrown by the abort_on_expiry.
+        // * condition_variable_timed_out: Can be thrown by begin_mutate.
+        //
+        // We handle them collectively here.
+        if (try_catch<raft::request_aborted>(ex) || try_catch<seastar::abort_requested_exception>(ex)
+                || try_catch<seastar::timed_out_error>(ex) || try_catch<seastar::condition_variable_timed_out>(ex)) {
+            logger.trace("mutate(): request timed out with error {}, table {}.{}, token {}",
+                ex, schema->ks_name(), schema->cf_name(), token);
+            co_return coroutine::return_exception(write_timeout(schema->ks_name(), schema->cf_name()));
+        } else {
+            logger.trace("mutate(): unknown exception {}, table {}.{}, token {}",
+                ex, schema->ks_name(), schema->cf_name(), token);
+            // We know nothing about other errors. Let the CQL server convert them to SERVER_ERROR.
+            throw;
+        }
     }
 }
 
@@ -198,21 +258,46 @@ auto coordinator::query(schema_ptr schema,
         timeout_clock::time_point timeout
     ) -> future<query_result_type>
 {
+    auto aoe = abort_on_expiry<timeout_clock>(timeout);
+
     try {
-        auto op_result = co_await create_operation_ctx(*schema, ranges[0].start()->value().token());
+        auto op_result = co_await create_operation_ctx(*schema, ranges[0].start()->value().token(), aoe.abort_source());
         if (const auto* redirect = get_if<need_redirect>(&op_result)) {
             co_return *redirect;
         }
         auto& op = get<operation_ctx>(op_result);
 
-        co_await op.raft_server.server().read_barrier(nullptr);
+        co_await utils::get_local_injector().inject("sc_coordinator_wait_before_query_read_barrier",
+            utils::wait_for_message(5min));
+
+        co_await op.raft_server.server().read_barrier(&aoe.abort_source());
 
         auto [result, cache_temp] = co_await _db.query(schema, cmd,
             query::result_options::only_result(), ranges, trace_state, timeout);
 
         co_return std::move(result);
     } catch (...) {
-        throw;
+        auto ex = std::current_exception();
+        // Unfortunately, timeouts can materialize in different forms depending
+        // on which statement throws the exception.
+        //
+        // * raft::request_aborted: If the abort source passed to a raft::server's
+        //     method was triggered.
+        // * seastar::abort_requested_exception: Can be thrown by create_operation_ctx.
+        // * timed_out_error: Can be thrown by the abort_on_expiry.
+        //
+        // We handle them collectively here.
+        if (try_catch<raft::request_aborted>(ex) || try_catch<seastar::abort_requested_exception>(ex)
+                || try_catch<timed_out_error>(ex)) {
+            logger.trace("query(): request timed out with error {}, table {}.{}, read cmd {}",
+                ex, schema->ks_name(), schema->cf_name(), cmd);
+            co_return coroutine::return_exception(read_timeout(schema->ks_name(), schema->cf_name()));
+        } else {
+            logger.trace("mutate(): unknown exception {}, table {}.{}, read cmd {}",
+                ex, schema->ks_name(), schema->cf_name(), cmd);
+            // We know nothing about other errors. Let the CQL server convert them to SERVER_ERROR.
+            throw;
+        }
     }
 }
 

--- a/service/strong_consistency/coordinator.hh
+++ b/service/strong_consistency/coordinator.hh
@@ -47,14 +47,16 @@ public:
     future<value_or_redirect<>> mutate(schema_ptr schema, 
         const dht::token& token,
         mutation_gen&& mutation_gen,
-        timeout_clock::time_point timeout);
+        timeout_clock::time_point timeout,
+        abort_source& as);
 
     using query_result_type = value_or_redirect<lw_shared_ptr<query::result>>;
     future<query_result_type> query(schema_ptr schema,
         const query::read_command& cmd,
         const dht::partition_range_vector& ranges,
         tracing::trace_state_ptr trace_state,
-        timeout_clock::time_point timeout);
+        timeout_clock::time_point timeout,
+        abort_source& as);
 };
 
 }

--- a/service/strong_consistency/coordinator.hh
+++ b/service/strong_consistency/coordinator.hh
@@ -37,7 +37,9 @@ private:
     gms::gossiper& _gossiper;
 
     struct operation_ctx;
-    future<value_or_redirect<operation_ctx>> create_operation_ctx(const schema& schema, const dht::token& token);
+    future<value_or_redirect<operation_ctx>> create_operation_ctx(const schema& schema,
+        const dht::token& token,
+        abort_source& as);
 public:
     coordinator(groups_manager& groups_manager, replica::database& db, gms::gossiper& gossiper);
 

--- a/service/strong_consistency/coordinator.hh
+++ b/service/strong_consistency/coordinator.hh
@@ -28,6 +28,10 @@ template <typename T = std::monostate>
 using value_or_redirect = std::variant<T, need_redirect>;
 
 class coordinator : public peering_sharded_service<coordinator> {
+public:
+    using timeout_clock = typename db::timeout_clock;
+
+private:
     groups_manager& _groups_manager;
     replica::database& _db;
     gms::gossiper& _gossiper;
@@ -40,14 +44,15 @@ public:
     using mutation_gen = noncopyable_function<mutation(api::timestamp_type)>;
     future<value_or_redirect<>> mutate(schema_ptr schema, 
         const dht::token& token,
-        mutation_gen&& mutation_gen);
+        mutation_gen&& mutation_gen,
+        timeout_clock::time_point timeout);
 
     using query_result_type = value_or_redirect<lw_shared_ptr<query::result>>;
     future<query_result_type> query(schema_ptr schema,
         const query::read_command& cmd,
         const dht::partition_range_vector& ranges,
         tracing::trace_state_ptr trace_state,
-        db::timeout_clock::time_point timeout);
+        timeout_clock::time_point timeout);
 };
 
 }

--- a/service/strong_consistency/groups_manager.cc
+++ b/service/strong_consistency/groups_manager.cc
@@ -253,6 +253,9 @@ future<> groups_manager::leader_info_updater(raft_group_state& state, global_tab
         // thrown from find_schema() and schema->table() when the table is dropped
         logger.debug("leader_info_updater({}-{}): got replica::no_such_column_family {}",
             tablet, gid, std::current_exception());
+    } catch (...) {
+        on_internal_error(logger, ::format("leader_info_updater({}-{}): unexpected exception: {}",
+            tablet, gid, std::current_exception()));
     }
 }
 

--- a/service/strong_consistency/groups_manager.cc
+++ b/service/strong_consistency/groups_manager.cc
@@ -175,11 +175,17 @@ void groups_manager::schedule_raft_group_deletion(raft::group_id id, raft_group_
     if (state.gate->is_closed()) {
         return;
     }
-    logger.info("schedule_raft_group_deletion(): group id {}", id);
+    logger.info("schedule_raft_group_deletion(): group id {}: scheduling", id);
     state.server_control_op = futurize_invoke([this, &state, id, g = state.gate](this auto) -> future<> {
         co_await state.server_control_op.get_future();
+        logger.debug("schedule_raft_group_deletion(): group id {}: starting", id);
+
         co_await g->close();
+        logger.debug("schedule_raft_group_deletion(): group id {}: gate closed", id);
+
         co_await _raft_gr.abort_server(id);
+        logger.debug("schedule_raft_group_deletion(): group id {}: server aborted", id);
+
         co_await std::move(state.leader_info_updater);
 
         _raft_gr.destroy_server(id);
@@ -234,6 +240,10 @@ future<> groups_manager::leader_info_updater(raft_group_state& state, global_tab
                 logger.debug("leader_info_updater({}-{}): current term {}, running read_barrier()",
                     tablet, gid,
                     current_term);
+                // We intentionally pass nullptr here. If the tablet is leaving this node,
+                // the Raft server will be aborted and the loop will break.
+                // The same will happen when the node is shutting down.
+                // There's no reason to abort this operation in any other case.
                 co_await state.server->read_barrier(nullptr);
 
                 co_await utils::get_local_injector().inject("sc_leader_info_updater_wait_before_setting_leader_info",
@@ -255,6 +265,10 @@ future<> groups_manager::leader_info_updater(raft_group_state& state, global_tab
             }
             state.leader_info_cond.broadcast();
 
+            // We intentionally pass nullptr here. If the tablet is leaving this node,
+            // the Raft server will be aborted and the loop will break.
+            // The same will happen when the node is shutting down.
+            // There's no reason to abort this operation in any other case.
             co_await state.server->wait_for_state_change(nullptr);
         }
     } catch (const raft::request_aborted&) {

--- a/service/strong_consistency/groups_manager.cc
+++ b/service/strong_consistency/groups_manager.cc
@@ -17,6 +17,8 @@
 #include "replica/database.hh"
 #include "db/config.hh"
 
+#include <seastar/core/abort_source.hh>
+
 namespace service::strong_consistency {
 
 using namespace locator;
@@ -68,10 +70,20 @@ raft_server::raft_server(groups_manager::raft_group_state& state, gate::holder h
 {
 }
 
-auto raft_server::begin_mutate() -> begin_mutate_result {
+// conditional_variable::wait doesn't have an overload taking an abort_source.
+// This is a temporary workaround until we extend the interface.
+// See: scylladb/seastar#3292.
+static future<> wait_with_abort_source(condition_variable& cv, abort_source& as) {
+    as.check();
+    const auto _ = as.subscribe([&cv] noexcept { cv.broadcast(); });
+    co_await cv.wait();
+    as.check();
+}
+
+auto raft_server::begin_mutate(abort_source& as) -> begin_mutate_result {
     const auto leader = _state.server->current_leader();
     if (!leader) {
-        return need_wait_for_leader{_state.server->wait_for_leader(nullptr)};
+        return need_wait_for_leader{_state.server->wait_for_leader(&as)};
     }
     if (leader != _state.server->id()) {
         return raft::not_a_leader{leader};
@@ -86,7 +98,7 @@ auto raft_server::begin_mutate() -> begin_mutate_result {
         // after every state change wake-up. This ensures we will not deadlock,
         // even if the raft server state changes again (e.g., we lose leadership)
         // before the updater gets a chance to run.
-        return need_wait_for_leader{_state.leader_info_cond.wait()};
+        return need_wait_for_leader{wait_with_abort_source(_state.leader_info_cond, as)};
     }
     const auto new_ts = std::max(api::new_timestamp(), _state.leader_info->last_timestamp + 1);
     _state.leader_info->last_timestamp = new_ts;
@@ -223,6 +235,10 @@ future<> groups_manager::leader_info_updater(raft_group_state& state, global_tab
                     tablet, gid,
                     current_term);
                 co_await state.server->read_barrier(nullptr);
+
+                co_await utils::get_local_injector().inject("sc_leader_info_updater_wait_before_setting_leader_info",
+                    utils::wait_for_message(5min));
+
                 state.leader_info = leader_info {
                     .term = current_term,
                     .last_timestamp = schema->table().get_max_timestamp_for_tablet(tablet.tablet)
@@ -296,7 +312,7 @@ void groups_manager::update(token_metadata_ptr new_tm) {
     schedule_raft_groups_deletion(false);
 }
 
-future<raft_server> groups_manager::acquire_server(raft::group_id group_id) {
+future<raft_server> groups_manager::acquire_server(raft::group_id group_id, abort_source& as) {
     if (!_features.strongly_consistent_tables) {
         on_internal_error(logger, "strongly consistent tables are not enabled on this shard");
     }
@@ -306,7 +322,7 @@ future<raft_server> groups_manager::acquire_server(raft::group_id group_id) {
         on_internal_error(logger, format("raft group {} not found", group_id));
     }
     auto& state = it->second;
-    return state.server_control_op.get_future().then([&state, h = state.gate->hold()] mutable {
+    return state.server_control_op.get_future(as).then([&state, h = state.gate->hold()] mutable {
         return raft_server(state, std::move(h));
     });
 }

--- a/service/strong_consistency/groups_manager.hh
+++ b/service/strong_consistency/groups_manager.hh
@@ -110,7 +110,7 @@ public:
     void update(locator::token_metadata_ptr new_tm);
 
     // The raft_server instance is used to submit write commands and perform read_barrier() before reads.
-    future<raft_server> acquire_server(raft::group_id group_id);
+    future<raft_server> acquire_server(raft::group_id group_id, abort_source& as);
 
     // Called during node boot. Waits for all raft::server instances corresponding
     // to the latest group0 state to start.
@@ -152,7 +152,7 @@ public:
         future<> future;
     };
     using begin_mutate_result = std::variant<timestamp_with_term, raft::not_a_leader, need_wait_for_leader>;
-    begin_mutate_result begin_mutate();
+    begin_mutate_result begin_mutate(abort_source&);
 };
 
 }

--- a/service/strong_consistency/state_machine.cc
+++ b/service/strong_consistency/state_machine.cc
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
  */
 
+#include <seastar/core/abort_source.hh>
 #include <seastar/core/shard_id.hh>
 #include <seastar/core/on_internal_error.hh>
 #include "state_machine.hh"
@@ -33,6 +34,8 @@ class state_machine : public raft_state_machine {
     replica::database& _db;
     service::migration_manager& _mm;
     db::system_keyspace& _sys_ks;
+
+    abort_source _as;
 
 public:
     state_machine(locator::global_tablet_id tablet,
@@ -70,6 +73,28 @@ public:
             // (see `schema_applier::commit_on_shard()` and `storage_service::commit_token_metadata_change()`).
             // In this case, we should just ignore mutations without throwing an error.
             logger.log(log_level::warn, rate_limit, "apply(): table {} was already dropped, ignoring mutations", _tablet.table);
+        } catch (const abort_requested_exception& ex) {
+            // The exception can be thrown by get_schema_and_upgrade_mutations.
+            // It means that the Raft group is being removed.
+            //
+            // Technically, throwing an exception from a state machine
+            // may result in killing the corresponding Raft instance:
+            // cf. the description of raft::state_machine:
+            //
+            //  "Any of the functions may return an error, but it will kill the
+            //   raft instance that uses it. Depending on what state the failure
+            //   leaves the state is the raft instance will either have to be recreated
+            //   with the same state machine and rejoined the cluster with the same server_id
+            //   or it new raft instance will have to be created with empty state machine and
+            //   it will have to rejoin to the cluster with different server_id through
+            //   configuration change."
+            //
+            // Fortunately, in strong consistency, we use the default Raft server
+            // implementation, which handles abort_requested_exception thrown by
+            // raft::state_machine::apply -- it will simply end the applier fiber.
+            logger.debug("apply(): execution for tablet {}, group_id={} aborted due to: {}",
+                _tablet, _group_id, ex);
+            throw;
         }
          catch (...) {
             throw std::runtime_error(::format(
@@ -91,6 +116,8 @@ public:
     }
 
     future<> abort() override {
+        logger.debug("abort(): Aborting state machine for group {}", _group_id);
+        _as.request_abort();
         return make_ready_future<>();
     }
 
@@ -109,6 +136,10 @@ private:
         bool barrier_executed = false;
 
         auto get_schema = [&] (table_schema_version schema_version) -> future<std::pair<schema_ptr, column_mappings_cache::value_ptr>> {
+            if (utils::get_local_injector().enter("sc_state_machine_return_empty_schema")) {
+                co_return std::pair{nullptr, nullptr};
+            }
+
             auto schema = local_schema_registry().get_or_null(schema_version);
             if (schema) {
                 co_return std::pair{std::move(schema), nullptr};
@@ -147,8 +178,7 @@ private:
                 if (utils::get_local_injector().enter("disable_raft_drop_append_entries_for_specified_group")) {
                     utils::get_local_injector().disable("raft_drop_incoming_append_entries_for_specified_group");
                 }
-                // TODO: pass valid abort source
-                co_await _mm.get_group0_barrier().trigger();
+                co_await _mm.get_group0_barrier().trigger(false, &_as);
                 barrier_executed = true;
                 schema_cm = co_await get_schema(schema_version);
             }

--- a/test/cluster/test_strong_consistency.py
+++ b/test/cluster/test_strong_consistency.py
@@ -4,11 +4,13 @@
 # SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
 #
 
+from typing import Tuple
+
 from test.pylib.manager_client import ManagerClient
-from test.pylib.util import gather_safely, wait_for
+from test.pylib.util import gather_safely, wait_for, Host
 from test.cluster.util import new_test_keyspace, new_test_table, reconnect_driver
 from test.pylib.internal_types import HostID, ServerInfo
-from cassandra import ReadTimeout, WriteTimeout
+from cassandra import InvalidRequest, ReadTimeout, WriteTimeout
 from cassandra.cluster import ConsistencyLevel
 from cassandra.policies import FallthroughRetryPolicy
 from cassandra.protocol import InvalidRequest
@@ -940,3 +942,216 @@ async def test_queries_while_dropping_table(manager: ManagerClient):
         # no exception thrown, so the write will still look like a success.
         # And that's the desired behavior.
         await write_fut
+
+
+@pytest.mark.asyncio
+@pytest.mark.skip_mode(mode="release", reason="error injections are not supported in release mode")
+async def test_queries_when_shutting_down(manager: ManagerClient):
+    """
+    A simple test verifying that pending reads and writes are canceled
+    when the node starts shutting down.
+
+    The potential cause of the hanging we're testing here comes from being
+    stuck at a Raft operation when reading from strongly consistent table.
+    """
+
+    smp = 2
+    config = DEFAULT_CONFIG | {"request_timeout_on_shutdown_in_seconds": 1}
+    cmdline = DEFAULT_CMDLINE + [
+        f"--smp={smp}",
+        "--logger-log-level", "cql_server=debug",
+        "--logger-log-level", "sc_coordinator=trace"
+    ]
+
+    servers = await manager.servers_add(3, config=config, cmdline=cmdline, auto_rack_dc="dc1")
+    cql, hosts = await manager.get_ready_cql(servers)
+
+    async def pick_leader_info(host_id: HostID) -> Tuple[Host, ServerInfo]:
+        for host, server in zip(hosts, servers):
+            srv_host_id = await manager.get_host_id(server.server_id)
+            if srv_host_id == host_id:
+                return (host, server)
+        raise RuntimeError(f"Can't find host for host_id {host_id}")
+
+    async def get_leader(keyspace: str, table: str) -> Tuple[Host, ServerInfo]:
+        logger.info("Select raft group id for the tablet")
+        group_id = await get_table_raft_group_id(manager, keyspace, table)
+
+        logger.info(f"Get current leader for the group {group_id}")
+        leader_host_id = await wait_for_leader(manager, servers[0], group_id)
+
+        logger.info(f"Leader of group {group_id} is {leader_host_id}")
+
+        leader_host, leader_info = await pick_leader_info(leader_host_id)
+        logger.info(f"Further information on leader of group {group_id}: server_id={leader_info.server_id}, ip={leader_info.ip_addr}")
+
+        return (leader_host, leader_info)
+
+    prevent_read_injection = "sc_coordinator_wait_before_query_read_barrier"
+    prevent_write_injection = "sc_coordinator_wait_before_add_entry"
+
+    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3} AND tablets = {'initial': 1} AND consistency = 'global'") as ks:
+        async with new_test_table(manager, ks, "pk int PRIMARY KEY, v int") as table:
+            _, table_name = table.split(".")
+            leader_host, leader_info = await get_leader(ks, table_name)
+
+            log = await manager.server_open_log(leader_info.server_id)
+            mark = await log.mark()
+
+            await asyncio.gather(*[
+                asyncio.create_task(manager.api.enable_injection(leader_info.ip_addr, prevent_read_injection, one_shot=True)),
+                asyncio.create_task(manager.api.enable_injection(leader_info.ip_addr, prevent_write_injection, one_shot=True))
+            ])
+
+            read_fut = cql.run_async(f"SELECT * FROM {table} WHERE pk = 0", host=leader_host)
+            write_fut = cql.run_async(f"INSERT INTO {table} (pk, v) VALUES (0, 13)", host=leader_host)
+
+            await asyncio.gather(*[
+                asyncio.create_task(log.wait_for(prevent_read_injection, from_mark=mark)),
+                asyncio.create_task(log.wait_for(prevent_write_injection, from_mark=mark))
+            ])
+
+            mark = await log.mark()
+            stop_fut = asyncio.create_task(manager.server_stop_gracefully(leader_info.server_id))
+            
+            delta = 0.1
+            timeout = 60
+
+            # We don't know which shard coordiantes the request,
+            # so we need to wait for all of them
+            while delta < timeout:
+                matches = await log.grep(r"generic_server::shutdown completed", from_mark=mark)
+                if len(matches) >= smp:
+                    break
+                logger.debug(f"Grepped matches={matches}")
+                await asyncio.sleep(delta)
+                delta *= 2
+            if delta >= timeout:
+                pytest.fail("Exceeded timeout")
+
+            mark = await log.mark()
+
+            await asyncio.gather(*[
+                asyncio.create_task(manager.api.message_injection(leader_info.ip_addr, prevent_read_injection)),
+                asyncio.create_task(manager.api.message_injection(leader_info.ip_addr, prevent_write_injection))
+            ])
+
+            await asyncio.gather(*[
+                asyncio.create_task(log.wait_for(rf"mutate\(\): request timed out with error .*, table {table}", from_mark=mark)),
+                asyncio.create_task(log.wait_for(rf"query\(\): request timed out with error .*, table {table}", from_mark=mark))
+            ])
+
+            # We cannot predict what the result of the query is going to be.
+            # Technically, we could ensure either outcome, but it requires
+            # playing with more error injections. We don't really care about
+            # the result (the test just wants to make sure we stop the node
+            # fast enough), so let's just log it and call it a day.
+            try:
+                await read_fut
+                logger.debug("The read ended successfully")
+            except Exception as e:
+                logger.debug(f"The read ended in an exception: {e}")
+                pass
+            try:
+                await write_fut
+                logger.debug("The write ended successfully")
+            except Exception as e:
+                logger.debug(f"The write ended in an exception: {e}")
+                pass
+
+            await stop_fut
+
+
+@pytest.mark.asyncio
+@pytest.mark.skip_mode(mode="release", reason="error injections are not supported in release mode")
+async def test_abort_forwarded_write_upon_shutdown(manager: ManagerClient):
+    """
+    Test verifying that forwarded writes to strongly consistent tables are
+    aborted upon the shutdown of the target replica.
+    """
+
+    smp = 2
+    config = DEFAULT_CONFIG | {"request_timeout_on_shutdown_in_seconds": 1}
+    cmdline = DEFAULT_CMDLINE + [
+        f"--smp={smp}",
+        "--logger-log-level", "cql_server=debug",
+        "--logger-log-level", "sc_coordinator=trace"
+    ]
+
+    servers = await manager.servers_add(3, config=config, cmdline=cmdline, auto_rack_dc="dc1")
+    cql, hosts = await manager.get_ready_cql(servers)
+
+    async def pick_leader_info(host_id: HostID) -> Tuple[Host, ServerInfo]:
+        for host, server in zip(hosts, servers):
+            srv_host_id = await manager.get_host_id(server.server_id)
+            if srv_host_id == host_id:
+                return (host, server)
+        raise RuntimeError(f"Can't find host for host_id {host_id}")
+
+    async def get_leader(keyspace: str, table: str) -> Tuple[Host, ServerInfo]:
+        logger.info("Select raft group id for the tablet")
+        group_id = await get_table_raft_group_id(manager, keyspace, table)
+
+        logger.info(f"Get current leader for the group {group_id}")
+        leader_host_id = await wait_for_leader(manager, servers[0], group_id)
+
+        logger.info(f"Leader of group {group_id} is {leader_host_id}")
+
+        leader_host, leader_info = await pick_leader_info(leader_host_id)
+        logger.info(f"Further information on leader of group {group_id}: server_id={leader_info.server_id}, ip={leader_info.ip_addr}")
+
+        return (leader_host, leader_info)
+
+    prevent_write_injection = "sc_coordinator_wait_before_add_entry"
+
+    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3} AND tablets = {'initial': 1} AND consistency = 'global'") as ks:
+        async with new_test_table(manager, ks, "pk int PRIMARY KEY, v int") as table:
+            _, table_name = table.split(".")
+            leader_host, leader_info = await get_leader(ks, table_name)
+
+            nonleader_host, nonleader_info = next((host, server) for host, server in zip(hosts, servers) if host != leader_host)
+            logger.debug(f"Targetting host={nonleader_host}: server_id={nonleader_info.server_id}, ip={nonleader_info.ip_addr}")
+
+            log = await manager.server_open_log(leader_info.server_id)
+            mark = await log.mark()
+
+            await manager.api.enable_injection(leader_info.ip_addr, prevent_write_injection, one_shot=True)
+
+            # Send the mutation to a NON-leader.
+            write_fut = cql.run_async(f"INSERT INTO {table} (pk, v) VALUES (0, 13)", host=nonleader_host)
+
+            await log.wait_for(prevent_write_injection, from_mark=mark)
+            mark = await log.mark()
+
+            stop_fut = asyncio.create_task(manager.server_stop_gracefully(leader_info.server_id))
+
+            delta = 0.1
+            timeout = 60
+
+            # We don't know which shard coordiantes the request,
+            # so we need to wait for all of them
+            while delta < timeout:
+                matches = await log.grep(r"generic_server::shutdown completed", from_mark=mark)
+                if len(matches) >= smp:
+                    break
+                logger.debug(f"Grepped matches={matches}")
+                await asyncio.sleep(delta)
+                delta *= 2
+            if delta >= timeout:
+                pytest.fail("Exceeded timeout")
+
+            mark = await log.mark()
+
+            await manager.api.message_injection(leader_info.ip_addr, prevent_write_injection)
+            await log.wait_for(rf"mutate\(\): request timed out with error .*, table {table}")
+
+            # It doesn't matter what the outcome is, but let's await the future
+            # (as we should) and log the result.
+            try:
+                await write_fut
+                logger.debug("The write ended successfully")
+            except Exception as e:
+                logger.debug(f"The write ended in an exception: {e}")
+                pass
+
+            await stop_fut

--- a/test/cluster/test_strong_consistency.py
+++ b/test/cluster/test_strong_consistency.py
@@ -15,6 +15,7 @@ from cassandra.protocol import InvalidRequest
 from cassandra.query import SimpleStatement, BoundStatement
 from test.pylib.tablets import get_all_tablet_replicas, get_tablet_replicas
 
+import asyncio
 import pytest
 import logging
 import time
@@ -759,3 +760,109 @@ async def test_forward_cql_exception_passthrough(manager: ManagerClient):
 
             await manager.api.message_injection(leader_host.address, "wait_before_handling_forwarded_request")
             await manager.api.message_injection(non_leader_replica_host.address, "wait_before_handling_forwarded_request")
+
+
+@pytest.mark.asyncio
+@pytest.mark.skip_mode(mode="release", reason="error injections are not supported in release mode")
+async def test_timed_out_queries(manager: ManagerClient):
+    """
+    A simple test verifying that we don't get stuck for an indefinite amount
+    of time while reading from or writing to a strongly consistent table.
+    As soon as the deadline for a query ends, the operation should be canceled\
+    and a time-out exception should be returned.
+
+    This test focuses on a Raft operation being the potential reason for
+    getting stuck. It should be aborted when we reach the deadline.
+    """
+
+    s1 = await manager.server_add(config=DEFAULT_CONFIG, cmdline=DEFAULT_CMDLINE)
+    cql, _ = await manager.get_ready_cql([s1])
+
+    log = await manager.server_open_log(s1.server_id)
+
+    async def try_query_with_timeout(exception_type, stmt: str, error_injection_name: str, timeout_sec: float):
+        await manager.api.enable_injection(s1.ip_addr, error_injection_name, one_shot=True)
+
+        mark = await log.mark()
+        request_timeout_ms = 100
+
+        stmt_fut = cql.run_async(f"{stmt} USING TIMEOUT {request_timeout_ms}ms")
+        await log.wait_for(error_injection_name, from_mark=mark)
+
+        sleep_length = timeout_sec + (request_timeout_ms / 1000)
+        await asyncio.sleep(sleep_length)
+
+        await manager.api.message_injection(s1.ip_addr, error_injection_name)
+
+        try:
+            await stmt_fut
+            return False
+        except Exception as e:
+            if isinstance(e, exception_type):
+                assert f"Query timed out for {table}" in str(e)
+                return True
+            pytest.fail(f"Unexpected exception: {e}")
+
+    async def try_query(exception_type, stmt: str, error_injection_name: str):
+        # We cannot predict if the relevant timer will be triggered in time.
+        # Even in not-really-extreme situations, it can take more time
+        # than we expect. To avoid flakiness, we're going to attempt to
+        # observe a timeout with an ever increasing margin of error.
+        #
+        # Most of the time, this will succeed during the first try,
+        # so it shouldn't have a relevant impact on the length of the test.
+        timeout_sec = 0.1
+        while True:
+            result = await try_query_with_timeout(exception_type, stmt, error_injection_name, timeout_sec)
+            if result:
+                break
+            if timeout_sec > 60:
+                pytest.fail("Reached the maximum number of attempts")
+            timeout_sec *= 2
+
+    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 1} AND consistency = 'global'") as ks:
+        async with new_test_table(manager, ks, "pk int PRIMARY KEY, v int") as table:
+            await cql.run_async(f"INSERT INTO {table} (pk, v) VALUES (0, 13)")
+
+
+            async def try_read(error_injection_name: str):
+                await try_query(ReadTimeout, f"SELECT * FROM {table} WHERE pk = 0", error_injection_name)
+
+            async def try_write(error_injection_name: str):
+                await try_query(WriteTimeout, f"INSERT INTO {table} (pk, v) VALUES (7, 23)", error_injection_name)
+
+            # Case 1: Reads.
+            read_error_injecitons = [
+                "sc_coordinator_wait_before_acquire_server",
+                "sc_coordinator_wait_before_query_read_barrier"
+            ]
+            for error_injection_name in read_error_injecitons:
+                await try_read(error_injection_name)
+
+            # Sanity check: Nothing broke and we can still read from the table.
+            res = await cql.run_async(f"SELECT * FROM {table} WHERE pk = 0")
+            assert res[0].v == 13
+
+            # Case 2: Writes.
+            write_error_injections = [
+                "sc_coordinator_wait_before_acquire_server",
+                "sc_coordinator_wait_before_begin_mutate",
+                "sc_coordinator_wait_before_add_entry"
+            ]
+            for error_injection_name in write_error_injections:
+                await try_write(error_injection_name)
+
+            # Sanity check: Nothing broke and we can still write to the table.
+            await cql.run_async(f"INSERT INTO {table} (pk, v) VALUES (17, 7)")
+
+    # Case 3: Waiting for the leader during a write.
+
+    # To trigger the timeout we want, we need to make sure that
+    # groups_manager::begin_mutate will want to return need_wait_for_leader,
+    # and that it will never succeed. This will do the job.
+    await manager.api.enable_injection(s1.ip_addr, "sc_leader_info_updater_wait_before_setting_leader_info", one_shot=True)
+
+    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 1} AND consistency = 'global'") as ks:
+        async with new_test_table(manager, ks, "pk int PRIMARY KEY, v int") as table:
+            with pytest.raises(WriteTimeout, match=f"Query timed out for {table}"):
+                await cql.run_async(f"INSERT INTO {table} (pk, v) VALUES (11, 13) USING TIMEOUT 100ms")

--- a/test/cluster/test_strong_consistency.py
+++ b/test/cluster/test_strong_consistency.py
@@ -1155,3 +1155,147 @@ async def test_abort_forwarded_write_upon_shutdown(manager: ManagerClient):
                 pass
 
             await stop_fut
+
+
+@pytest.mark.skip(reason="SCYLLADB-1056")
+@pytest.mark.skip_mode(mode="release", reason="error injections are not supported in release mode")
+async def test_abort_state_machine_apply_after_dropping_table(manager: ManagerClient):
+    """
+    This test verifies that ongoing executions of state_machine::apply are
+    aborted when their corresponding Raft group is being removed. We test
+    that by dropping the table, but it should also correspond to other cases
+    like tablet migration.
+
+    For a similar scenario during a node shutdown, see test_abort_state_machine_apply_during_shutdown.
+    """
+
+    cmdline = DEFAULT_CMDLINE + ["--logger-log-level", "sc_state_machine=debug:raft=debug"]
+    leader_server = await manager.server_add(config=DEFAULT_CONFIG, cmdline=cmdline,
+                                             property_file={"dc": "dc1", "rack": "rack1"})
+
+    # We want to prevent target_server from becoming the leader of either group0
+    # or the strongly consistent Raft group so it might not have the latest
+    # schema version and is forced to perform a read barrier.
+    config = DEFAULT_CONFIG | {"error_injections_at_startup": ["avoid_being_raft_leader"]}
+    target_server = await manager.server_add(config=config, cmdline=cmdline, property_file={"dc": "dc1", "rack": "rack2"})
+
+    cql, [leader_host, _] = await manager.get_ready_cql([leader_server, target_server])
+
+    leader_host_id, target_host_id = await gather_safely(*[
+        manager.get_host_id(leader_server.server_id),
+        manager.get_host_id(target_server.server_id)
+    ])
+
+    wait_before_apply_injection = "strong_consistency_state_machine_wait_before_apply"
+
+    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 2} AND tablets = {'initial': 1} AND consistency = 'global'") as ks:
+        table_name = "my_table"
+        table = f"{ks}.{table_name}"
+
+        await cql.run_async(f"CREATE TABLE {table} (pk int PRIMARY KEY, v int)")
+
+        group_id = await get_table_raft_group_id(manager, ks, table_name)
+        leader_host_id = await wait_for_leader(manager, leader_server, group_id)
+        assert leader_host_id != target_host_id
+
+        await gather_safely(*[
+            manager.api.enable_injection(target_server.ip_addr, wait_before_apply_injection, one_shot=True),
+            manager.api.enable_injection(target_server.ip_addr, "sc_state_machine_return_empty_schema", one_shot=True)
+        ])
+
+        log = await manager.server_open_log(target_server.server_id)
+        mark = await log.mark()
+
+        # We won't wait for the follower to apply the state, so we can await this right away.
+        await cql.run_async(f"INSERT INTO {table} (pk, v) VALUES (0, 13)", host=leader_host)
+
+        await log.wait_for(wait_before_apply_injection, from_mark=mark)
+        mark = await log.mark()
+
+        await cql.run_async(f"DROP TABLE {table}")
+        # Wait until the Raft group has started being removed.
+        await log.wait_for(rf"schedule_raft_group_deletion\(\): starting aborting raft server for group id {group_id}", from_mark=mark)
+        mark = await log.mark()
+
+        # At this point, the Raft server should already be getting aborted,
+        # so we can resume state_machine::apply.
+        await manager.api.message_injection(target_server.ip_addr, wait_before_apply_injection)
+        # Verify that state_machine::apply was really aborted.
+        await log.wait_for(rf"apply\(\): execution for tablet \S+, group_id={group_id} aborted", from_mark=mark)
+
+
+@pytest.mark.asyncio
+@pytest.mark.skip(reason="SCYLLADB-1056")
+@pytest.mark.skip_mode(mode="release", reason="error injections are not supported in release mode")
+async def test_abort_state_machine_apply_during_shutdown(manager: ManagerClient):
+    """
+    This test verifies that ongoing executions of state_machine::apply are
+    aborted when a node is shutting down.
+
+    For a similar scenario after dropping a table, see test_abort_state_machine_apply_after_dropping_table.
+    """
+
+    cmdline = DEFAULT_CMDLINE + ["--logger-log-level", "sc_state_machine=debug:raft=debug"]
+    leader_server = await manager.server_add(config=DEFAULT_CONFIG, cmdline=cmdline,
+                                             property_file={"dc": "dc1", "rack": "rack1"})
+
+    # We want to prevent target_server from becoming the leader of either group0
+    # or the strongly consistent Raft group so it might not have the latest
+    # schema version and is forced to perform a read barrier.
+    config = DEFAULT_CONFIG | {"error_injections_at_startup": ["avoid_being_raft_leader"]}
+    target_server = await manager.server_add(config=config, cmdline=cmdline, property_file={"dc": "dc1", "rack": "rack2"})
+
+    cql, [leader_host, target_host] = await manager.get_ready_cql([leader_server, target_server])
+
+    leader_host_id, target_host_id = await gather_safely(*[
+        manager.get_host_id(leader_server.server_id),
+        manager.get_host_id(target_server.server_id)
+    ])
+
+    wait_before_apply_injection = "strong_consistency_state_machine_wait_before_apply"
+
+    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 2} AND tablets = {'initial': 1} AND consistency = 'global'") as ks:
+        table_name = "my_table"
+        table = f"{ks}.{table_name}"
+
+        await cql.run_async(f"CREATE TABLE {table} (pk int PRIMARY KEY, v int)")
+
+        group_id = await get_table_raft_group_id(manager, ks, table_name)
+        leader_host_id = await wait_for_leader(manager, leader_server, group_id)
+        assert leader_host_id != target_host_id
+
+        await gather_safely(*[
+            manager.api.enable_injection(target_server.ip_addr, wait_before_apply_injection, one_shot=True),
+            manager.api.enable_injection(target_server.ip_addr, "sc_state_machine_return_empty_schema", one_shot=True)
+        ])
+
+        log = await manager.server_open_log(target_server.server_id)
+        mark = await log.mark()
+
+        # We won't wait for the follower to apply the state, so we can await this right away.
+        await cql.run_async(f"INSERT INTO {table} (pk, v) VALUES (0, 13)", host=leader_host)
+
+        await log.wait_for(wait_before_apply_injection, from_mark=mark)
+        mark = await log.mark()
+
+        stop_task = asyncio.create_task(manager.server_stop_gracefully(target_server.server_id))
+        # Wait until the Raft group has started being removed.
+        await log.wait_for(rf"schedule_raft_group_deletion\(\): starting aborting raft server for group id {group_id}", from_mark=mark)
+        mark = await log.mark()
+
+        # At this point, the Raft server should already be getting aborted,
+        # so we can resume state_machine::apply.
+        await manager.api.message_injection(target_server.ip_addr, wait_before_apply_injection)
+        # Verify that state_machine::apply was really aborted.
+        await log.wait_for(rf"apply\(\): execution for tablet \S+, group_id={group_id} aborted", from_mark=mark)
+
+        # The test framework should verify that we haven't observed any errors
+        # during the stopping procedure.
+        await stop_task
+
+        await manager.server_start(target_server.server_id)
+        cql, [target_host] = await manager.get_ready_cql([target_server])
+
+        rows = await cql.run_async(f"SELECT * FROM {table} WHERE pk = 0", host=target_host)
+        assert len(rows) == 1
+        assert rows[0].v == 13

--- a/test/cluster/test_strong_consistency.py
+++ b/test/cluster/test_strong_consistency.py
@@ -866,3 +866,77 @@ async def test_timed_out_queries(manager: ManagerClient):
         async with new_test_table(manager, ks, "pk int PRIMARY KEY, v int") as table:
             with pytest.raises(WriteTimeout, match=f"Query timed out for {table}"):
                 await cql.run_async(f"INSERT INTO {table} (pk, v) VALUES (11, 13) USING TIMEOUT 100ms")
+
+
+@pytest.mark.asyncio
+@pytest.mark.skip_mode(mode="release", reason="error injections are not supported in release mode")
+async def test_queries_while_dropping_table(manager: ManagerClient):
+    """
+    A simple test that verifies that ongoing reads and writes are not interrupted
+    by a tablet migration. We simulate the process by dropping a table.
+
+    We verify that:
+    - New reads and writes are rejected with a proper error.
+    - Ongoing reads and writes are not interrupted by a tablet migration
+      (which boils down to successful executions of Raft methods).
+    - Ongoing reads can still eventually observe that the table has
+      been dropped.
+    - Ongoing writes should also finish successfully if they've reached
+      the strongly consistent coordinator.
+    """
+
+    s1 = await manager.server_add(config=DEFAULT_CONFIG, cmdline=DEFAULT_CMDLINE)
+    cql, _ = await manager.get_ready_cql([s1])
+
+    log = await manager.server_open_log(s1.server_id)
+    mark = await log.mark()
+
+    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 1} AND consistency = 'global'") as ks:
+        table_name = "my_table"
+        table = f"{ks}.{table_name}"
+
+        await cql.run_async(f"CREATE TABLE {table} (pk int PRIMARY KEY, v int)")
+        await cql.run_async(f"INSERT INTO {table} (pk, v) VALUES (0, 13)")
+
+        await gather_safely(*[
+            manager.api.enable_injection(s1.ip_addr, "sc_coordinator_wait_before_query_read_barrier", one_shot=True),
+            manager.api.enable_injection(s1.ip_addr, "sc_coordinator_wait_before_add_entry", one_shot=True)
+        ])
+
+        read_fut = cql.run_async(f"SELECT * FROM {table} WHERE pk = 0")
+        write_fut = cql.run_async(f"INSERT INTO {table} (pk, v) VALUES (7, 17)")
+
+        await asyncio.gather(*[
+            asyncio.create_task(log.wait_for("sc_coordinator_wait_before_query_read_barrier", from_mark=mark)),
+            asyncio.create_task(log.wait_for("sc_coordinator_wait_before_add_entry", from_mark=mark))
+        ])
+
+        mark = await log.mark()
+
+        await cql.run_async(f"DROP TABLE {table}")
+
+        # Sanity check: The table was really dropped and we can no longer read or write to it.
+        with pytest.raises(InvalidRequest, match="unconfigured table"):
+            await cql.run_async(f"SELECT * FROM {table} WHERE pk = 0")
+        with pytest.raises(InvalidRequest, match="unconfigured table"):
+            await cql.run_async(f"INSERT INTO {table} (pk, v) VALUES (13, 11)")
+
+        # Wait for the Raft group to be removed. This should happen almost immediately
+        # after dropping the table, but let's avoid any potential cause of flakiness.
+        await log.wait_for(r"schedule_raft_group_deletion\(\): group id \S+: starting", from_mark=mark)
+
+        await asyncio.gather(*[
+            asyncio.create_task(manager.api.message_injection(s1.ip_addr, "sc_coordinator_wait_before_query_read_barrier")),
+            asyncio.create_task(manager.api.message_injection(s1.ip_addr, "sc_coordinator_wait_before_add_entry"))
+        ])
+
+        # Make sure that the read noticed that the table had been dropped.
+        with pytest.raises(Exception, match="Can't find a column family"):
+            await read_fut
+        # The groups manager waits for all ongoing queries to finish before
+        # it aborts the Raft server. Thanks to this, the write will succeed.
+        # No matter if we get a `no_such_column_family` exception when later
+        # applying the mutation in the state machine or not, there will be
+        # no exception thrown, so the write will still look like a success.
+        # And that's the desired behavior.
+        await write_fut

--- a/test/cluster/test_strong_consistency.py
+++ b/test/cluster/test_strong_consistency.py
@@ -26,6 +26,13 @@ import asyncio
 logger = logging.getLogger(__name__)
 
 
+DEFAULT_CONFIG = {'experimental_features': ['strongly-consistent-tables']}
+DEFAULT_CMDLINE = [
+        '--logger-log-level', 'sc_groups_manager=debug',
+        '--logger-log-level', 'sc_coordinator=debug'
+    ]
+
+
 async def wait_for_leader(manager: ManagerClient, s: ServerInfo, group_id: str):
     async def get_leader_host_id():
         result = await manager.api.get_raft_leader(s.ip_addr, group_id)
@@ -109,14 +116,7 @@ async def get_table_raft_group_id(manager: ManagerClient, ks: str, table: str):
 async def test_basic_write_read(manager: ManagerClient):
 
     logger.info("Bootstrapping cluster")
-    config = {
-        'experimental_features': ['strongly-consistent-tables']
-    }
-    cmdline = [
-        '--logger-log-level', 'sc_groups_manager=debug',
-        '--logger-log-level', 'sc_coordinator=debug'
-    ]
-    servers = await manager.servers_add(3, config=config, cmdline=cmdline, auto_rack_dc='my_dc')
+    servers = await manager.servers_add(3, config=DEFAULT_CONFIG, cmdline=DEFAULT_CMDLINE, auto_rack_dc='my_dc')
     (cql, hosts) = await manager.get_ready_cql(servers)
 
     logger.info("Load host_id-s for servers")
@@ -249,15 +249,8 @@ async def test_multi_shard_write_read(manager: ManagerClient):
     succeed and that we can read back all data correctly.
     """
     logger.info("Bootstrapping cluster with 4 shards per node")
-    config = {
-        'experimental_features': ['strongly-consistent-tables']
-    }
-    cmdline = [
-        '--smp=4',
-        '--logger-log-level', 'sc_groups_manager=debug',
-        '--logger-log-level', 'sc_coordinator=debug'
-    ]
-    servers = await manager.servers_add(3, config=config, cmdline=cmdline, auto_rack_dc='my_dc')
+    cmdline = DEFAULT_CMDLINE + ['--smp=4']
+    servers = await manager.servers_add(3, config=DEFAULT_CONFIG, cmdline=cmdline, auto_rack_dc='my_dc')
     (cql, hosts) = await manager.get_ready_cql(servers)
 
     logger.info("Creating a strongly-consistent keyspace with 4 tablets")
@@ -280,16 +273,11 @@ async def test_sc_multishard_metadata_reads(manager: ManagerClient):
     """
     Verify that multi-shard reads of raft metadata for strongly-consistent tables work correctly.
     """
-    config = {
-        'experimental_features': ['strongly-consistent-tables']
-    }
-    cmdline = [
+    cmdline = DEFAULT_CMDLINE + [
         '--smp=4',
-        '--logger-log-level', 'sc_groups_manager=debug',
-        '--logger-log-level', 'sc_coordinator=debug',
         '--logger-log-level', 'fixed_shard=trace',
     ]
-    server = await manager.server_add(config=config, cmdline=cmdline)
+    server = await manager.server_add(config=DEFAULT_CONFIG, cmdline=cmdline)
     (cql, hosts) = await manager.get_ready_cql([server])
 
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 8} AND consistency = 'global'") as ks:
@@ -379,16 +367,11 @@ async def test_sc_persistence_restart_with_smp_increase(manager: ManagerClient):
     on a single-node cluster, we don't start reading/writing raft metadata
     from/to incorrect shards.
     """
-    config = {
-        'experimental_features': ['strongly-consistent-tables']
-    }
-    cmdline = [
+    cmdline = DEFAULT_CMDLINE + [
         '--smp=2',
-        '--logger-log-level', 'sc_groups_manager=debug',
-        '--logger-log-level', 'sc_coordinator=debug',
         '--logger-log-level', 'fixed_shard=trace',
     ]
-    server = await manager.server_add(config=config, cmdline=cmdline)
+    server = await manager.server_add(config=DEFAULT_CONFIG, cmdline=cmdline)
     (cql, hosts) = await manager.get_ready_cql([server])
 
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 2} AND consistency = 'global'") as ks:
@@ -433,15 +416,8 @@ async def test_sc_persistence_with_compaction(manager: ManagerClient):
     directly, bit it does compact SSTables written with them, so in this test we
     verify that after compaction the raft metadata is still readable and correct.
     """
-    config = {
-        'experimental_features': ['strongly-consistent-tables']
-    }
-    cmdline = [
-        '--logger-log-level', 'sc_groups_manager=debug',
-        '--logger-log-level', 'sc_coordinator=debug',
-        '--logger-log-level', 'fixed_shard=trace',
-    ]
-    server = await manager.server_add(config=config, cmdline=cmdline)
+    cmdline = DEFAULT_CMDLINE + ['--logger-log-level', 'fixed_shard=trace']
+    server = await manager.server_add(config=DEFAULT_CONFIG, cmdline=cmdline)
     (cql, hosts) = await manager.get_ready_cql([server])
 
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 4} AND consistency = 'global'") as ks:
@@ -484,15 +460,8 @@ async def test_sc_persistence_after_crash(manager: ManagerClient):
     Verify that metadata for strongly-consistent tables is recovered
     after a non-graceful stop (crash simulation).
     """
-    config = {
-        'experimental_features': ['strongly-consistent-tables']
-    }
-    cmdline = [
-        '--logger-log-level', 'sc_groups_manager=debug',
-        '--logger-log-level', 'sc_coordinator=debug',
-        '--logger-log-level', 'fixed_shard=trace',
-    ]
-    server = await manager.server_add(config=config, cmdline=cmdline)
+    cmdline = DEFAULT_CMDLINE + ['--logger-log-level', 'fixed_shard=trace']
+    server = await manager.server_add(config=DEFAULT_CONFIG, cmdline=cmdline)
     (cql, hosts) = await manager.get_ready_cql([server])
 
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 4} AND consistency = 'global'") as ks:
@@ -525,17 +494,11 @@ async def test_sc_persistence_after_crash(manager: ManagerClient):
 @pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_no_schema_when_apply_write(manager: ManagerClient):
-    config = {
-        'experimental_features': ['strongly-consistent-tables']
-    }
-    cmdline = [
-        '--logger-log-level', 'sc_groups_manager=debug',
-        '--logger-log-level', 'sc_coordinator=debug'
-    ]
-    servers = await manager.servers_add(2, config=config, cmdline=cmdline, auto_rack_dc='my_dc')
+    servers = await manager.servers_add(2, config=DEFAULT_CONFIG, cmdline=DEFAULT_CMDLINE, auto_rack_dc='my_dc')
     # We don't want `servers[2]` to be a Raft leader (for both group0 and strong consistency groups),
     # because we want `servers[2]` to receive Raft commands from others.
-    servers += [await manager.server_add(config=config | {'error_injections_at_startup': ['avoid_being_raft_leader']}, cmdline=cmdline, property_file={'dc':'my_dc', 'rack': 'rack3'})]
+    config = DEFAULT_CONFIG | {'error_injections_at_startup': ['avoid_being_raft_leader']}
+    servers += [await manager.server_add(config=config, cmdline=DEFAULT_CMDLINE, property_file={'dc':'my_dc', 'rack': 'rack3'})]
     (cql, hosts) = await manager.get_ready_cql(servers)
     host_ids = await gather_safely(*[manager.get_host_id(s.server_id) for s in servers])
 
@@ -576,17 +539,11 @@ async def test_no_schema_when_apply_write(manager: ManagerClient):
 @pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_old_schema_when_apply_write(manager: ManagerClient):
-    config = {
-        'experimental_features': ['strongly-consistent-tables']
-    }
-    cmdline = [
-        '--logger-log-level', 'sc_groups_manager=debug',
-        '--logger-log-level', 'sc_coordinator=debug'
-    ]
-    servers = await manager.servers_add(2, config=config, cmdline=cmdline, auto_rack_dc='my_dc')
+    servers = await manager.servers_add(2, config=DEFAULT_CONFIG, cmdline=DEFAULT_CMDLINE, auto_rack_dc='my_dc')
     # We don't want `servers[2]` to be a Raft leader (for both group0 and strong consistency groups),
     # because we want `servers[2]` to receive Raft commands from others.
-    servers += [await manager.server_add(config=config | {'error_injections_at_startup': ['avoid_being_raft_leader']}, cmdline=cmdline, property_file={'dc':'my_dc', 'rack': 'rack3'})]
+    config = DEFAULT_CONFIG | {'error_injections_at_startup': ['avoid_being_raft_leader']}
+    servers += [await manager.server_add(config=config, cmdline=DEFAULT_CMDLINE, property_file={'dc':'my_dc', 'rack': 'rack3'})]
     (cql, hosts) = await manager.get_ready_cql(servers)
     host_ids = await gather_safely(*[manager.get_host_id(s.server_id) for s in servers])
 
@@ -629,14 +586,7 @@ async def test_reject_user_provided_timestamps(manager: ManagerClient):
     user-provided timestamps in queries to strongly consistent tables.
     """
 
-    config = {
-        'experimental_features': ['strongly-consistent-tables']
-    }
-    cmdline = [
-        '--logger-log-level', 'sc_groups_manager=debug',
-        '--logger-log-level', 'sc_coordinator=debug'
-    ]
-    server = await manager.server_add(config=config, cmdline=cmdline)
+    server = await manager.server_add(config=DEFAULT_CONFIG, cmdline=DEFAULT_CMDLINE)
     cql, _ = await manager.get_ready_cql([server])
 
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 1} AND consistency = 'global'") as ks:

--- a/transport/generic_server.cc
+++ b/transport/generic_server.cc
@@ -308,6 +308,8 @@ future<> server::shutdown() {
         _logger.debug("shutdown connection {} out of {} done", ++nr_conn, nr_conn_total);
     });
     _abort_source.request_abort();
+
+    _logger.debug("generic_server::shutdown completed");
 }
 
 future<>

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -393,7 +393,8 @@ void cql_server::init_messaging_service() {
             co_return co_await container().invoke_on(shard, [src_host, req = std::move(req)] (cql_server& shard_svc) mutable -> future<forward_cql_execute_response> {
                 service::client_state cs(shard_svc._auth_service,
                     &shard_svc._sl_controller,
-                    std::move(req.client_state));
+                    std::move(req.client_state),
+                    &shard_svc._abort_source);
                 tracing::trace_state_ptr trace_state_ptr;
                 if (req.trace_info) {
                     trace_state_ptr = tracing::tracing::get_local_tracing_instance().create_session(*req.trace_info);
@@ -1052,7 +1053,7 @@ cql_server::connection::connection(cql_server& server, socket_address server_add
     : generic_server::connection{server, std::move(fd), sem, std::move(initial_sem_units)}
     , _server(server)
     , _server_addr(server_addr)
-    , _client_state(service::client_state::external_tag{}, server._auth_service, &server._sl_controller, server.timeout_config(), addr, bool(server._used_by_maintenance_socket))
+    , _client_state(service::client_state::external_tag{}, server._auth_service, &server._sl_controller, server.timeout_config(), addr, bool(server._used_by_maintenance_socket), &server._abort_source)
     , _current_scheduling_group(server.get_scheduling_group_for_new_connection())
 {
     _shedding_timer.set_callback([this] {
@@ -1835,7 +1836,7 @@ cql_server::process(uint16_t stream, request_reader in, service::client_state& c
             msg = co_await container().invoke_on(shard, sg, [&, stream, dialect, version] (cql_server& server) -> future<process_fn_return_type> {
                 bytes_ostream linearization_buffer;
                 request_reader in(is, linearization_buffer);
-                auto local_client_state = gcs.get();
+                auto local_client_state = gcs.get(&server._abort_source);
                 auto local_trace_state = gt.get();
                 co_return co_await process_fn(local_client_state, server._query_processor, in, stream, version,
                         /* FIXME */empty_service_permit(), std::move(local_trace_state), false, cached_vals, dialect);


### PR DESCRIPTION
### Motivation
Since strongly consistent tables are based on the concept of Raft
groups, operations on them can get stuck for indefinite amounts of
time. That may be problematic, and so we'd like to implement a way
to cancel those operations at suitable times.

### Description of solution
The situations we focus on are the following:

* Timed-out queries
* Leader changes
* Tablet migrations
* Table drops
* Node shutdowns

We handle each of them and provide validation tests.

### Implementation strategy
1. Auxiliary commits.
2. Abort operations on timeout.
3. Abort operations on tablet removal.
4. Extend `client_state`.
5. Abort operation on shutdown.
6. Help `state_machine` be aborted as soon as possible.

### Tests
We provide tests that validate the correctness of the solution.

The total time spent on `test_strong_consistency.py`
(measured on my local machine, dev mode):

Before:
```
real    0m31.809s
user    1m3.048s
sys     0m21.812s
```

After:
```
real    0m34.523s
user    1m10.307s
sys     0m27.223s
```

The incremental differences in time can be found in the commit messages.

Fixes SCYLLADB-429

Backport: not needed. This is an enhancement to an experimental feature.