### PR TITLE
database: Remove streaming sched group getter

### DIFF
--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1796,8 +1796,6 @@ public:
         return &_cf_stats;
     }
 
-    seastar::scheduling_group get_streaming_scheduling_group() const { return _dbcfg.streaming_scheduling_group; }
-
     seastar::scheduling_group get_gossip_scheduling_group() const { return _dbcfg.gossip_scheduling_group; }
 
     compaction::compaction_manager& get_compaction_manager() {


### PR DESCRIPTION
All users of it had been updated to get the streaming group elsewhere, so this getter is no longer needed.

Code cleanup, not backporting