### PR TITLE
test.py: improve C++ fail summary in pytest

### DIFF
--- a/test/pylib/cpp/boost.py
+++ b/test/pylib/cpp/boost.py
@@ -14,6 +14,7 @@ import pathlib
 import json
 from functools import cache, cached_property
 from itertools import chain
+from pathlib import Path
 from textwrap import dedent
 from typing import TYPE_CHECKING
 from xml.etree import ElementTree
@@ -60,7 +61,7 @@ class BoostTestFile(CppFile):
             return [self.test_name]
         return get_boost_test_list_json_content(executable=self.exe_path,combined=self.combined).get(self.test_name, [])
 
-    def run_test_case(self, test_case: CppTestCase) -> tuple[None | list[CppTestFailure], str]:
+    def run_test_case(self, test_case: CppTestCase) -> tuple[list[CppTestFailure], Path] | tuple[None, Path]:
         run_test = f"{self.test_name}/{test_case.test_case_name}" if self.combined else test_case.test_case_name
 
         log_sink = tempfile.NamedTemporaryFile(mode="w+t")
@@ -86,6 +87,8 @@ class BoostTestFile(CppFile):
             log_xml = pathlib.Path(log_sink.name).read_text(encoding="utf-8")
         except IOError:
             log_xml = ""
+        finally:
+            log_sink.close()
         results = parse_boost_test_log_sink(log_xml=log_xml)
 
         if return_code := process.returncode:
@@ -100,13 +103,9 @@ class BoostTestFile(CppFile):
                     command to repeat: {subprocess.list2cmdline(process.args)}
                     error: {results[0].lines if results else 'unknown'}
                 """),
-            )], ""
+            )], stdout_file_path
 
-        if not self.config.getoption("--save-log-on-success"):
-            log_sink.close()
-            stdout_file_path.unlink(missing_ok=True)
-
-        return None, ""
+        return None, stdout_file_path
 
 
 pytest_collect_file = BoostTestFile.pytest_collect_file

--- a/test/pylib/cpp/unit.py
+++ b/test/pylib/cpp/unit.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import os
 import subprocess
+from pathlib import Path
 from textwrap import dedent
 from typing import TYPE_CHECKING
 
@@ -23,7 +24,7 @@ class UnitTestFile(CppFile):
     def list_test_cases(self) -> list[str]:
         return [self.test_name]
 
-    def run_test_case(self, test_case: CppTestCase) -> tuple[None | list[CppTestFailure], str]:
+    def run_test_case(self, test_case: CppTestCase) -> tuple[list[CppTestFailure], Path] | tuple[None, Path]:
         stdout_file_path = test_case.get_artifact_path(extra="_stdout", suffix=".log").absolute()
         process = test_case.run_exe(test_args=self.test_args, output_file=stdout_file_path)
 
@@ -38,12 +39,9 @@ class UnitTestFile(CppFile):
                     output file: {stdout_file_path}
                     command to repeat: {subprocess.list2cmdline(process.args)}
                 """),
-            )], ""
+            )], stdout_file_path
 
-        if not self.config.getoption("--save-log-on-success"):
-            stdout_file_path.unlink(missing_ok=True)
-
-        return None, ""
+        return None, stdout_file_path
 
 
 pytest_collect_file = UnitTestFile.pytest_collect_file

--- a/test/pytest.ini
+++ b/test/pytest.ini
@@ -2,6 +2,9 @@
 asyncio_mode = auto
 asyncio_default_fixture_loop_scope = session
 
+junit_logging = all
+junit_log_passing_tests = False
+
 log_format = %(asctime)s.%(msecs)03d %(levelname)s>  %(message)s
 log_date_format = %H:%M:%S
 


### PR DESCRIPTION
Currently, if the test fail, pytest will output only some basic information about the fail. With this change, it will output the last 300 lines of the boost/seastar test output.

No backporting since it's only framework enhancement.

Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-449
