### PR TITLE
test/cluster: Remove short_tablet_stats_refresh_interval injection

### DIFF
--- a/test/cluster/test_size_based_load_balancing.py
+++ b/test/cluster/test_size_based_load_balancing.py
@@ -15,7 +15,6 @@ logger = logging.getLogger(__name__)
 GB = 1024 * 1024 * 1024
 
 @pytest.mark.asyncio
-@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_balance_empty_tablets(manager: ManagerClient):
 
     # This test checks that size-based load balancing migrates empty tablets of a newly created
@@ -24,7 +23,7 @@ async def test_balance_empty_tablets(manager: ManagerClient):
 
     logger.info('Bootstrapping cluster')
 
-    cfg = { 'error_injections_at_startup': ['short_tablet_stats_refresh_interval'] }
+    cfg = { 'tablet_load_stats_refresh_interval_in_seconds': 1 }
 
     cfg_small = cfg | { 'data_file_capacity': 50 * GB }
     cfg_large = cfg | { 'data_file_capacity': 100 * GB }


### PR DESCRIPTION
The test `test_size_based_load_balancing.py::test_balance_empty_tablets` waits for tablet load stats to be refreshed and uses the `short_tablet_stats_refresh_interval` injection to speed up the refresh interval.

This injection has no effect; it was replaced by the `tablet_load_stats_refresh_interval_in_seconds` config option (patch: 1d6808aec47), so the test currently waits for 60 seconds (default refresh interval).

Use the config option. This reduces the execution time to ~8 seconds.

Fixes SCYLLADB-556.