### PR TITLE
database: Remove _flush_sg member from replica::database

### DIFF
--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1617,7 +1617,6 @@ private:
     dirty_memory_manager _dirty_memory_manager;
 
     database_config _dbcfg;
-    backlog_controller::scheduling_group _flush_sg;
     flush_controller _memtable_controller;
     drain_progress _drain_progress {};
 


### PR DESCRIPTION
This field is only used to initialize the following _memtable_controller one. It's simpler just to do the initialization with whatever value the field itself is initialized and drop the field itself.

Code cleanup, not backporting