### PR TITLE
Introduce maintenance scheduling supergroup and do initial population

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,7 +96,7 @@ else()
     set(Seastar_EXCLUDE_APPS_FROM_ALL ON CACHE BOOL "" FORCE)
     set(Seastar_EXCLUDE_TESTS_FROM_ALL ON CACHE BOOL "" FORCE)
     set(Seastar_IO_URING ON CACHE BOOL "" FORCE)
-    set(Seastar_SCHEDULING_GROUPS_COUNT 21 CACHE STRING "" FORCE)
+    set(Seastar_SCHEDULING_GROUPS_COUNT 22 CACHE STRING "" FORCE)
     set(Seastar_UNUSED_RESULT_ERROR ON CACHE BOOL "" FORCE)
     add_subdirectory(seastar)
     target_compile_definitions (seastar

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,7 +96,7 @@ else()
     set(Seastar_EXCLUDE_APPS_FROM_ALL ON CACHE BOOL "" FORCE)
     set(Seastar_EXCLUDE_TESTS_FROM_ALL ON CACHE BOOL "" FORCE)
     set(Seastar_IO_URING ON CACHE BOOL "" FORCE)
-    set(Seastar_SCHEDULING_GROUPS_COUNT 22 CACHE STRING "" FORCE)
+    set(Seastar_SCHEDULING_GROUPS_COUNT 23 CACHE STRING "" FORCE)
     set(Seastar_UNUSED_RESULT_ERROR ON CACHE BOOL "" FORCE)
     add_subdirectory(seastar)
     target_compile_definitions (seastar

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,7 +96,7 @@ else()
     set(Seastar_EXCLUDE_APPS_FROM_ALL ON CACHE BOOL "" FORCE)
     set(Seastar_EXCLUDE_TESTS_FROM_ALL ON CACHE BOOL "" FORCE)
     set(Seastar_IO_URING ON CACHE BOOL "" FORCE)
-    set(Seastar_SCHEDULING_GROUPS_COUNT 23 CACHE STRING "" FORCE)
+    set(Seastar_SCHEDULING_GROUPS_COUNT 24 CACHE STRING "" FORCE)
     set(Seastar_UNUSED_RESULT_ERROR ON CACHE BOOL "" FORCE)
     add_subdirectory(seastar)
     target_compile_definitions (seastar

--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -1034,7 +1034,6 @@ compaction_manager::compaction_manager(config cfg, abort_source& as, tasks::task
     , _early_abort_subscription(as.subscribe([this] () noexcept {
         do_stop();
     }))
-    , _throughput_updater(serialized_action([this] { return update_throughput(throughput_mbs()); }))
     , _update_compaction_static_shares_action([this] { return update_static_shares(static_shares()); })
     , _compaction_static_shares_observer(_cfg.static_shares.observe(_update_compaction_static_shares_action.make_observer()))
     , _compaction_max_shares_observer(_cfg.max_shares.observe([this] (const float& max_shares) {
@@ -1045,13 +1044,6 @@ compaction_manager::compaction_manager(config cfg, abort_source& as, tasks::task
 {
     tm.register_module(_task_manager_module->get_name(), _task_manager_module);
     register_metrics();
-    // Bandwidth throttling is node-wide, updater is needed on single shard
-    if (this_shard_id() == 0) {
-        _throughput_option_observer.emplace(_cfg.throughput_mb_per_sec.observe(_throughput_updater.make_observer()));
-        // Start throttling (if configured) right at once. Any boot-time compaction
-        // jobs (reshape/reshard) run in unlimited streaming group
-        (void)_throughput_updater.trigger_later();
-    }
 }
 
 compaction_manager::compaction_manager(tasks::task_manager& tm)
@@ -1061,7 +1053,6 @@ compaction_manager::compaction_manager(tasks::task_manager& tm)
     , _compaction_submission_timer(compaction_sg(), compaction_submission_callback())
     , _compaction_controller(make_compaction_controller(compaction_sg(), 1, std::nullopt, [] () -> float { return 1.0; }))
     , _backlog_manager(_compaction_controller)
-    , _throughput_updater(serialized_action([this] { return update_throughput(throughput_mbs()); }))
     , _update_compaction_static_shares_action([] { return make_ready_future<>(); })
     , _compaction_static_shares_observer(_cfg.static_shares.observe(_update_compaction_static_shares_action.make_observer()))
     , _compaction_max_shares_observer(_cfg.max_shares.observe([] (const float& max_shares) {}))
@@ -1076,19 +1067,6 @@ compaction_manager::~compaction_manager() {
     // Assert that compaction manager was explicitly stopped, if started.
     // Otherwise, fiber(s) will be alive after the object is stopped.
     SCYLLA_ASSERT(_state == state::none || _state == state::stopped);
-}
-
-future<> compaction_manager::update_throughput(uint32_t value_mbs) {
-    uint64_t bps = ((uint64_t)(value_mbs != 0 ? value_mbs : std::numeric_limits<uint32_t>::max())) << 20;
-    return compaction_sg().update_io_bandwidth(bps).then_wrapped([value_mbs] (auto f) {
-        if (f.failed()) {
-            cmlog.warn("Couldn't update compaction bandwidth: {}", f.get_exception());
-        } else if (value_mbs != 0) {
-            cmlog.info("Set compaction bandwidth to {}MB/s", value_mbs);
-        } else {
-            cmlog.info("Set unlimited compaction bandwidth");
-        }
-    });
 }
 
 void compaction_manager::register_metrics() {
@@ -1310,7 +1288,6 @@ future<> compaction_manager::really_do_stop() noexcept {
     _weight_tracker.clear();
     _compaction_submission_timer.cancel();
     co_await _compaction_controller.shutdown();
-    co_await _throughput_updater.join();
     co_await _update_compaction_static_shares_action.join();
     cmlog.info("Stopped");
 }

--- a/compaction/compaction_manager.hh
+++ b/compaction/compaction_manager.hh
@@ -159,8 +159,6 @@ private:
     compaction_controller _compaction_controller;
     compaction_backlog_manager _backlog_manager;
     optimized_optional<abort_source::subscription> _early_abort_subscription;
-    serialized_action _throughput_updater;
-    std::optional<utils::observer<uint32_t>> _throughput_option_observer;
     serialized_action _update_compaction_static_shares_action;
     utils::observer<float> _compaction_static_shares_observer;
     utils::observer<float> _compaction_max_shares_observer;
@@ -190,7 +188,6 @@ private:
 
     void stop_tasks(const std::vector<shared_ptr<compaction::compaction_task_executor>>& tasks, sstring reason) noexcept;
     future<> await_tasks(std::vector<shared_ptr<compaction::compaction_task_executor>>, bool task_stopped) const noexcept;
-    future<> update_throughput(uint32_t value_mbs);
 
     // Return the largest fan-in of currently running compactions
     unsigned current_compaction_fan_in_threshold() const;

--- a/conf/scylla.yaml
+++ b/conf/scylla.yaml
@@ -926,9 +926,9 @@ rf_rack_valid_keyspaces: false
 #    truststore: <not set, use system trust>
 
 # 
-# io-streaming rate limiting
+# Background IO rate limiting
 # When setting this value to be non-zero scylla throttles disk throughput for
-# stream (network) activities such as backup, repair, tablet migration and more.
+# background activities such as backup, repair, tablet migration and more.
 # This limit is useful for user queries so the network interface does 
 # not get saturated by streaming activities.
 # The recommended value is 75% of network bandwidth
@@ -936,6 +936,6 @@ rf_rack_valid_keyspaces: false
 # network: 18.75 GiB/s --> 18750 Mib/s --> 1875 MB/s (from network bits to network bytes: divide by 10, not 8)
 # Converted to disk bytes: 1875 * 1000 / 1024 = 1831 MB/s (disk wise)
 # 75% of disk bytes is: 0.75 * 1831 = 1373 megabytes/s
-# stream_io_throughput_mb_per_sec: 1373
+# maintenance_io_throughput_mb_per_sec: 1373
 # 
 

--- a/configure.py
+++ b/configure.py
@@ -2148,7 +2148,7 @@ def configure_seastar(build_dir, mode, mode_config, compiler_cache=None):
         '-DSeastar_DEPRECATED_OSTREAM_FORMATTERS=OFF',
         '-DSeastar_UNUSED_RESULT_ERROR=ON',
         '-DCMAKE_EXPORT_COMPILE_COMMANDS=ON',
-        '-DSeastar_SCHEDULING_GROUPS_COUNT=23',
+        '-DSeastar_SCHEDULING_GROUPS_COUNT=24',
         '-DSeastar_IO_URING=ON',
     ]
 

--- a/configure.py
+++ b/configure.py
@@ -2148,7 +2148,7 @@ def configure_seastar(build_dir, mode, mode_config, compiler_cache=None):
         '-DSeastar_DEPRECATED_OSTREAM_FORMATTERS=OFF',
         '-DSeastar_UNUSED_RESULT_ERROR=ON',
         '-DCMAKE_EXPORT_COMPILE_COMMANDS=ON',
-        '-DSeastar_SCHEDULING_GROUPS_COUNT=21',
+        '-DSeastar_SCHEDULING_GROUPS_COUNT=22',
         '-DSeastar_IO_URING=ON',
     ]
 

--- a/configure.py
+++ b/configure.py
@@ -2148,7 +2148,7 @@ def configure_seastar(build_dir, mode, mode_config, compiler_cache=None):
         '-DSeastar_DEPRECATED_OSTREAM_FORMATTERS=OFF',
         '-DSeastar_UNUSED_RESULT_ERROR=ON',
         '-DCMAKE_EXPORT_COMPILE_COMMANDS=ON',
-        '-DSeastar_SCHEDULING_GROUPS_COUNT=22',
+        '-DSeastar_SCHEDULING_GROUPS_COUNT=23',
         '-DSeastar_IO_URING=ON',
     ]
 

--- a/db/config.cc
+++ b/db/config.cc
@@ -1652,6 +1652,8 @@ db::config::config(std::shared_ptr<db::extensions> exts)
         "Set to 0 to disable automatic flushing all tables before major compaction.")
     , maintenance_io_throughput_mb_per_sec(this, "maintenance_io_throughput_mb_per_sec", liveness::LiveUpdate, value_status::Used, 0,
         "Throttles background I/O to the specified total throughput (in MiBs/s) across the entire system. Background I/O includes the one performed by repair and both RBNO and legacy topology operations such as adding or removing a node. Setting the value to 0 disables background IO throttling. It is recommended to set the value for this parameter to be 75% of network bandwidth")
+    , backup_io_throughput_mb_per_sec(this, "backup_io_throughput_mb_per_sec", liveness::LiveUpdate, value_status::Used, 0,
+        "Throttles backup I/O to the specified total throughput (in MiBs/s) across the entire system")
     , default_log_level(this, "default_log_level", value_status::Used, seastar::log_level::info, "Default log level for log messages")
     , logger_log_level(this, "logger_log_level", value_status::Used, {}, "Map of logger name to log level. Valid log levels are 'error', 'warn', 'info', 'debug' and 'trace'")
     , log_to_stdout(this, "log_to_stdout", value_status::Used, true, "Send log output to stdout")

--- a/db/config.cc
+++ b/db/config.cc
@@ -1650,6 +1650,8 @@ db::config::config(std::shared_ptr<db::extensions> exts)
         "Set the minimum interval in seconds between flushing all tables before each major compaction (default is 86400)."
         "This option is useful for maximizing tombstone garbage collection by releasing all active commitlog segments."
         "Set to 0 to disable automatic flushing all tables before major compaction.")
+    , maintenance_io_throughput_mb_per_sec(this, "maintenance_io_throughput_mb_per_sec", liveness::LiveUpdate, value_status::Used, 0,
+        "Throttles background I/O to the specified total throughput (in MiBs/s) across the entire system. Background I/O includes the one performed by repair and both RBNO and legacy topology operations such as adding or removing a node. Setting the value to 0 disables background IO throttling. It is recommended to set the value for this parameter to be 75% of network bandwidth")
     , default_log_level(this, "default_log_level", value_status::Used, seastar::log_level::info, "Default log level for log messages")
     , logger_log_level(this, "logger_log_level", value_status::Used, {}, "Map of logger name to log level. Valid log levels are 'error', 'warn', 'info', 'debug' and 'trace'")
     , log_to_stdout(this, "log_to_stdout", value_status::Used, true, "Send log output to stdout")

--- a/db/config.hh
+++ b/db/config.hh
@@ -631,6 +631,7 @@ public:
     named_value<uint32_t> compaction_flush_all_tables_before_major_seconds;
 
     named_value<uint32_t> maintenance_io_throughput_mb_per_sec;
+    named_value<uint32_t> backup_io_throughput_mb_per_sec;
 
     static const sstring default_tls_priority;
 private:

--- a/db/config.hh
+++ b/db/config.hh
@@ -630,6 +630,8 @@ public:
     named_value<bool> compaction_enforce_min_threshold;
     named_value<uint32_t> compaction_flush_all_tables_before_major_seconds;
 
+    named_value<uint32_t> maintenance_io_throughput_mb_per_sec;
+
     static const sstring default_tls_priority;
 private:
     template<typename T>

--- a/main.cc
+++ b/main.cc
@@ -347,6 +347,43 @@ public:
     }
 };
 
+template <typename SchedGroupOrSuper>
+requires std::is_same_v<SchedGroupOrSuper, seastar::scheduling_group> || std::is_same_v<SchedGroupOrSuper, seastar::scheduling_supergroup>
+class io_throughput_updater {
+    std::string_view _name;
+    SchedGroupOrSuper _sg;
+    utils::config_file::named_value<uint32_t>& _value;
+    serialized_action _updater = serialized_action([this] { return update(_value()); });
+    utils::observer<uint32_t> _observer;
+
+    future<> update(uint32_t value) {
+        uint64_t bps = ((uint64_t)(value != 0 ? value : std::numeric_limits<uint32_t>::max())) << 20;
+        return _sg.update_io_bandwidth(bps).then_wrapped([this, value] (auto f) {
+            if (f.failed()) {
+                diaglog.warn("Couldn't update {} bandwidth: {}", _name, f.get_exception());
+            } else if (value != 0) {
+                diaglog.info("Set {} bandwidth to {}MB/s", _name, value);
+            } else {
+                diaglog.info("Set unlimited {} bandwidth", _name);
+            }
+        });
+    }
+
+public:
+    io_throughput_updater(std::string_view name, SchedGroupOrSuper ssg, utils::config_file::named_value<uint32_t>& v)
+            : _name(name)
+            , _sg(ssg)
+            , _value(v)
+            , _observer(_value.observe(_updater.make_observer()))
+    {
+        (void)_updater.trigger_later();
+    }
+
+    ~io_throughput_updater() {
+        _updater.join().get();
+    }
+};
+
 static
 void
 adjust_and_verify_rlimit(bool developer_mode) {
@@ -1216,6 +1253,8 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             });
             cm.invoke_on_all(&compaction::compaction_manager::start, std::ref(*cfg), only_on_shard0(&*disk_space_monitor_shard0)).get();
 
+            auto compaction_throughput_update = io_throughput_updater("compaction", dbcfg.compaction_scheduling_group, cfg->compaction_throughput_mb_per_sec);
+
             checkpoint(stop_signal, "starting storage manager");
             sstables::storage_manager::config stm_cfg;
             stm_cfg.object_storage_clients_memory = std::clamp<size_t>(memory::stats().total_memory() * 0.01, 10 << 20, 100 << 20);
@@ -1836,6 +1875,8 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             auto stop_stream_manager_api = defer_verbose_shutdown("stream manager api", [&ctx] {
                 api::unset_server_stream_manager(ctx).get();
             });
+
+            auto stream_throughput_update = io_throughput_updater("streaming", dbcfg.streaming_scheduling_group, cfg->stream_io_throughput_mb_per_sec);
 
             checkpoint(stop_signal, "starting auth cache");
             auth_cache.start(std::ref(qp), std::ref(stop_signal.as_sharded_abort_source())).get();

--- a/main.cc
+++ b/main.cc
@@ -1184,6 +1184,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             // Note: changed from using a move here, because we want the config object intact.
             replica::database_config dbcfg;
             dbcfg.compaction_scheduling_group = create_scheduling_group("compaction", "comp", 1000).get();
+            dbcfg.maintenance_compaction_scheduling_group = create_scheduling_group("maintenance_compaction", "manc", 200, maintenance_supergroup).get();
             dbcfg.memory_compaction_scheduling_group = create_scheduling_group("mem_compaction", "mcmp", 1000).get();
             dbcfg.streaming_scheduling_group = maintenance_scheduling_group;
             dbcfg.statement_scheduling_group = create_scheduling_group("statement", "stmt", 1000, user_ssg).get();
@@ -1244,7 +1245,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             auto get_cm_cfg = sharded_parameter([&] {
                 return compaction::compaction_manager::config {
                     .compaction_sched_group = compaction::compaction_manager::scheduling_group{dbcfg.compaction_scheduling_group},
-                    .maintenance_sched_group = compaction::compaction_manager::scheduling_group{dbcfg.streaming_scheduling_group},
+                    .maintenance_sched_group = compaction::compaction_manager::scheduling_group{dbcfg.maintenance_compaction_scheduling_group},
                     .available_memory = dbcfg.available_memory,
                     .static_shares = cfg->compaction_static_shares,
                     .max_shares = cfg->compaction_max_shares,

--- a/main.cc
+++ b/main.cc
@@ -1194,6 +1194,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             debug::gossip_scheduling_group = dbcfg.gossip_scheduling_group;
             dbcfg.commitlog_scheduling_group = create_scheduling_group("commitlog", "clog", 1000).get();
             dbcfg.schema_commitlog_scheduling_group = create_scheduling_group("schema_commitlog", "sclg", 1000).get();
+            dbcfg.backup_scheduling_group = create_scheduling_group("backup", "bckp", 200, maintenance_supergroup).get(),
             dbcfg.available_memory = memory::stats().total_memory();
 
             // Make sure to initialize the scheduling group keys at a point where we are sure
@@ -2164,12 +2165,13 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
 
             checkpoint(stop_signal, "starting REST API");
             db::snapshot_ctl::config snap_cfg = {
-                .backup_sched_group = dbcfg.streaming_scheduling_group,
+                .backup_sched_group = dbcfg.backup_scheduling_group,
             };
             snapshot_ctl.start(std::ref(db), std::ref(proxy), std::ref(task_manager), std::ref(sstm), snap_cfg).get();
             auto stop_snapshot_ctl = defer_verbose_shutdown("snapshots", [&snapshot_ctl] {
                 snapshot_ctl.stop().get();
             });
+            auto backup_throughput_update = io_throughput_updater("backup", dbcfg.backup_scheduling_group, cfg->backup_io_throughput_mb_per_sec);
 
             api::set_server_snapshot(ctx, snapshot_ctl).get();
             auto stop_api_snapshots = defer_verbose_shutdown("snapshots API", [&ctx] {

--- a/main.cc
+++ b/main.cc
@@ -1345,7 +1345,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             checkpoint(stop_signal, "starting storage proxy");
             service::storage_proxy::config spcfg {
                 .hints_directory_initializer = hints_dir_initializer,
-                .hints_sched_group = maintenance_scheduling_group,
+                .hints_sched_group = dbcfg.streaming_scheduling_group,
             };
             spcfg.hinted_handoff_enabled = hinted_handoff_enabled;
             spcfg.available_memory = memory::stats().total_memory();
@@ -1418,7 +1418,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
 
             stop_signal.check();
             ctx.http_server.server().invoke_on_all([] (auto& server) { server.set_content_streaming(true); }).get();
-            with_scheduling_group(maintenance_scheduling_group, [&] {
+            with_scheduling_group(dbcfg.streaming_scheduling_group, [&] {
                 return ctx.http_server.listen(socket_address{api_addr, cfg->api_port()});
             }).get();
             startlog.info("Scylla API server listening on {}:{} ...", api_addr, cfg->api_port());
@@ -1754,7 +1754,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
 
             checkpoint(stop_signal, "starting tablet allocator");
             service::tablet_allocator::config tacfg {
-                .background_sg = maintenance_scheduling_group,
+                .background_sg = dbcfg.streaming_scheduling_group,
             };
             sharded<service::tablet_allocator> tablet_allocator;
             tablet_allocator.start(tacfg, std::ref(mm_notifier), std::ref(db)).get();
@@ -1860,7 +1860,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
 
             debug::the_stream_manager = &stream_manager;
             checkpoint(stop_signal, "starting streaming service");
-            stream_manager.start(std::ref(*cfg), std::ref(db), std::ref(view_builder), std::ref(view_building_worker), std::ref(messaging), std::ref(mm), std::ref(gossiper), maintenance_scheduling_group).get();
+            stream_manager.start(std::ref(*cfg), std::ref(db), std::ref(view_builder), std::ref(view_building_worker), std::ref(messaging), std::ref(mm), std::ref(gossiper), dbcfg.streaming_scheduling_group).get();
             auto stop_stream_manager = defer_verbose_shutdown("stream manager", [&stream_manager] {
                 // FIXME -- keep the instances alive, just call .stop on them
                 stream_manager.invoke_on_all(&streaming::stream_manager::stop).get();
@@ -2219,7 +2219,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             });
 
             checkpoint(stop_signal, "starting sstables loader");
-            sst_loader.start(std::ref(db), std::ref(ss), std::ref(messaging), std::ref(view_builder), std::ref(view_building_worker), std::ref(task_manager), std::ref(sstm), maintenance_scheduling_group).get();
+            sst_loader.start(std::ref(db), std::ref(ss), std::ref(messaging), std::ref(view_builder), std::ref(view_building_worker), std::ref(task_manager), std::ref(sstm), dbcfg.streaming_scheduling_group).get();
             auto stop_sst_loader = defer_verbose_shutdown("sstables loader", [&sst_loader] {
                 sst_loader.stop().get();
             });
@@ -2285,7 +2285,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
                 api::unset_server_storage_service(ctx).get();
             });
 
-            with_scheduling_group(maintenance_scheduling_group, [&] {
+            with_scheduling_group(dbcfg.streaming_scheduling_group, [&] {
                 return messaging.invoke_on_all([&] (auto& ms) {
                         return ms.start_listen(token_metadata.local(), [&gossiper] (gms::inet_address ip)  {
                             // #27429. When running with broadcast_address != rpc_address, topology gets
@@ -2312,7 +2312,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             // Allow abort during join_cluster since bootstrap or replace
             // can take a long time.
             stop_signal.ready(true);
-            with_scheduling_group(maintenance_scheduling_group, [&] {
+            with_scheduling_group(dbcfg.streaming_scheduling_group, [&] {
                 return ss.local().join_cluster(proxy, service::start_hint_manager::yes, generation_number);
             }).get();
             stop_signal.ready(false);
@@ -2529,14 +2529,14 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
 
             if (cfg->view_building()) {
                 checkpoint(stop_signal, "Launching generate_mv_updates for non system tables");
-                with_scheduling_group(maintenance_scheduling_group, [] {
+                with_scheduling_group(dbcfg.streaming_scheduling_group, [] {
                     return view_update_generator.invoke_on_all(&db::view::view_update_generator::start);
                 }).get();
             }
 
             if (cfg->view_building()) {
                 checkpoint(stop_signal, "starting view builders");
-                with_scheduling_group(maintenance_scheduling_group, [&mm] {
+                with_scheduling_group(dbcfg.streaming_scheduling_group, [&mm] {
                     return view_builder.invoke_on_all(&db::view::view_builder::start, std::ref(mm), utils::cross_shard_barrier());
                 }).get();
             }
@@ -2545,7 +2545,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             });
 
             checkpoint(stop_signal, "starting view building worker's background fibers");
-            with_scheduling_group(maintenance_scheduling_group, [&] {
+            with_scheduling_group(dbcfg.streaming_scheduling_group, [&] {
                 return view_building_worker.local().init();
             }).get();
             auto drain_view_buiding_worker = defer_verbose_shutdown("draining view building worker", [&] {
@@ -2569,7 +2569,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             stop_expiration_service = defer_verbose_shutdown("expiration service", [&es] {
                 es.stop().get();
             });
-            with_scheduling_group(maintenance_scheduling_group, [&es] {
+            with_scheduling_group(dbcfg.streaming_scheduling_group, [&es] {
                 return es.invoke_on_all(&alternator::expiration_service::start);
             }).get();
 

--- a/main.cc
+++ b/main.cc
@@ -945,8 +945,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             auto maintenance_supergroup = create_scheduling_supergroup(200).get();
             auto bandwidth_updater = io_throughput_updater("maintenance supergroup", maintenance_supergroup,
                     cfg->maintenance_io_throughput_mb_per_sec.is_set() ? cfg->maintenance_io_throughput_mb_per_sec : cfg->stream_io_throughput_mb_per_sec);
-            auto maintenance_scheduling_group = create_scheduling_group("streaming", "strm", 200, maintenance_supergroup).get();
-            debug::streaming_scheduling_group = maintenance_scheduling_group;
+            auto maintenance_scheduling_group = create_scheduling_group("maintenance", "mant", 200, maintenance_supergroup).get();
 
             smp::invoke_on_all([&cfg, background_reclaim_scheduling_group] {
                 logalloc::tracker::config st_cfg;
@@ -1186,7 +1185,9 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             dbcfg.compaction_scheduling_group = create_scheduling_group("compaction", "comp", 1000).get();
             dbcfg.maintenance_compaction_scheduling_group = create_scheduling_group("maintenance_compaction", "manc", 200, maintenance_supergroup).get();
             dbcfg.memory_compaction_scheduling_group = create_scheduling_group("mem_compaction", "mcmp", 1000).get();
-            dbcfg.streaming_scheduling_group = maintenance_scheduling_group;
+            dbcfg.streaming_scheduling_group = create_scheduling_group("streaming", "strm", 200, maintenance_supergroup).get();
+            debug::streaming_scheduling_group = dbcfg.streaming_scheduling_group;
+            dbcfg.maintenance_scheduling_group = maintenance_scheduling_group;
             dbcfg.statement_scheduling_group = create_scheduling_group("statement", "stmt", 1000, user_ssg).get();
             dbcfg.memtable_scheduling_group = create_scheduling_group("memtable", "mt", 1000).get();
             dbcfg.memtable_to_cache_scheduling_group = create_scheduling_group("memtable_to_cache", "mt2c", 200).get();
@@ -1761,7 +1762,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
 
             checkpoint(stop_signal, "starting tablet allocator");
             service::tablet_allocator::config tacfg {
-                .background_sg = dbcfg.streaming_scheduling_group,
+                .background_sg = dbcfg.maintenance_scheduling_group,
             };
             sharded<service::tablet_allocator> tablet_allocator;
             tablet_allocator.start(tacfg, std::ref(mm_notifier), std::ref(db)).get();

--- a/main.cc
+++ b/main.cc
@@ -940,7 +940,12 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             schema::set_default_partitioner(cfg->partitioner(), cfg->murmur3_partitioner_ignore_msb_bits());
 
             auto background_reclaim_scheduling_group = create_scheduling_group("background_reclaim", "bgre", 50).get();
-            auto maintenance_scheduling_group = create_scheduling_group("streaming", "strm", 200).get();
+
+            // Maintenance supergroup -- the collection of background low-prio activites
+            auto maintenance_supergroup = create_scheduling_supergroup(200).get();
+            auto bandwidth_updater = io_throughput_updater("maintenance supergroup", maintenance_supergroup,
+                    cfg->maintenance_io_throughput_mb_per_sec.is_set() ? cfg->maintenance_io_throughput_mb_per_sec : cfg->stream_io_throughput_mb_per_sec);
+            auto maintenance_scheduling_group = create_scheduling_group("streaming", "strm", 200, maintenance_supergroup).get();
             debug::streaming_scheduling_group = maintenance_scheduling_group;
 
             smp::invoke_on_all([&cfg, background_reclaim_scheduling_group] {

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -1710,7 +1710,7 @@ request_class classify_request(const database_config& _dbcfg) {
             || current_group == _dbcfg.memtable_to_cache_scheduling_group) {
         return request_class::system;
     // Requests done on behalf of view update generation run in the streaming group
-    } else if (current_scheduling_group() == _dbcfg.streaming_scheduling_group) {
+    } else if (current_group == _dbcfg.streaming_scheduling_group) {
         return request_class::maintenance;
     // Everything else is considered a user request
     } else {

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -460,8 +460,8 @@ database::database(const db::config& cfg, database_config dbcfg, service::migrat
     , _nop_large_data_handler(std::make_unique<db::nop_large_data_handler>())
     , _corrupt_data_handler(std::make_unique<db::system_table_corrupt_data_handler>(db::system_table_corrupt_data_handler::config{.entry_ttl = std::chrono::days(10)}, db::corrupt_data_handler::register_metrics::yes))
     , _nop_corrupt_data_handler(std::make_unique<db::nop_corrupt_data_handler>(db::corrupt_data_handler::register_metrics::no))
-    , _user_sstables_manager(std::make_unique<sstables::sstables_manager>("user", *_large_data_handler, *_corrupt_data_handler, configure_sstables_manager(_cfg, dbcfg), feat, _row_cache_tracker, sst_dir_sem, [&stm]{ return stm.get()->get_my_id(); }, scf, abort, _cfg.extensions().sstable_file_io_extensions(), dbcfg.streaming_scheduling_group, &sstm))
-    , _system_sstables_manager(std::make_unique<sstables::sstables_manager>("system", *_nop_large_data_handler, *_nop_corrupt_data_handler, configure_sstables_manager(_cfg, dbcfg), feat, _row_cache_tracker, sst_dir_sem, [&stm]{ return stm.get()->get_my_id(); }, scf, abort, _cfg.extensions().sstable_file_io_extensions(), dbcfg.streaming_scheduling_group))
+    , _user_sstables_manager(std::make_unique<sstables::sstables_manager>("user", *_large_data_handler, *_corrupt_data_handler, configure_sstables_manager(_cfg, dbcfg), feat, _row_cache_tracker, sst_dir_sem, [&stm]{ return stm.get()->get_my_id(); }, scf, abort, _cfg.extensions().sstable_file_io_extensions(), dbcfg.maintenance_scheduling_group, &sstm))
+    , _system_sstables_manager(std::make_unique<sstables::sstables_manager>("system", *_nop_large_data_handler, *_nop_corrupt_data_handler, configure_sstables_manager(_cfg, dbcfg), feat, _row_cache_tracker, sst_dir_sem, [&stm]{ return stm.get()->get_my_id(); }, scf, abort, _cfg.extensions().sstable_file_io_extensions(), dbcfg.maintenance_scheduling_group))
     , _result_memory_limiter(dbcfg.available_memory / 10)
     , _data_listeners(std::make_unique<db::data_listeners>())
     , _mnotifier(mn)
@@ -1570,6 +1570,7 @@ keyspace::make_column_family_config(const schema& s, const database& db) const {
     cfg.memtable_scheduling_group = _config.memtable_scheduling_group;
     cfg.memtable_to_cache_scheduling_group = _config.memtable_to_cache_scheduling_group;
     cfg.streaming_scheduling_group = _config.streaming_scheduling_group;
+    cfg.maintenance_scheduling_group = _config.maintenance_scheduling_group;
     cfg.enable_metrics_reporting = db_config.enable_keyspace_column_family_metrics();
     cfg.enable_node_aggregated_table_metrics = db_config.enable_node_aggregated_table_metrics();
     cfg.tombstone_warn_threshold = db_config.tombstone_warn_threshold();
@@ -1712,6 +1713,7 @@ request_class classify_request(const database_config& _dbcfg) {
     // Requests done on behalf of view update generation run in the streaming group
     } else if (current_group == _dbcfg.streaming_scheduling_group
             || current_group == _dbcfg.backup_scheduling_group
+            || current_group == _dbcfg.maintenance_scheduling_group
             || current_group == _dbcfg.maintenance_compaction_scheduling_group) {
         return request_class::maintenance;
     // Everything else is considered a user request
@@ -2521,6 +2523,7 @@ database::make_keyspace_config(const keyspace_metadata& ksm, system_keyspace is_
     cfg.memtable_scheduling_group = _dbcfg.memtable_scheduling_group;
     cfg.memtable_to_cache_scheduling_group = _dbcfg.memtable_to_cache_scheduling_group;
     cfg.streaming_scheduling_group = _dbcfg.streaming_scheduling_group;
+    cfg.maintenance_scheduling_group = _dbcfg.maintenance_scheduling_group;
     cfg.enable_metrics_reporting = _cfg.enable_keyspace_column_family_metrics();
 
     cfg.view_update_memory_semaphore_limit = max_memory_pending_view_updates();

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -1710,7 +1710,8 @@ request_class classify_request(const database_config& _dbcfg) {
             || current_group == _dbcfg.memtable_to_cache_scheduling_group) {
         return request_class::system;
     // Requests done on behalf of view update generation run in the streaming group
-    } else if (current_group == _dbcfg.streaming_scheduling_group) {
+    } else if (current_group == _dbcfg.streaming_scheduling_group
+            || current_group == _dbcfg.maintenance_compaction_scheduling_group) {
         return request_class::maintenance;
     // Everything else is considered a user request
     } else {

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -1711,6 +1711,7 @@ request_class classify_request(const database_config& _dbcfg) {
         return request_class::system;
     // Requests done on behalf of view update generation run in the streaming group
     } else if (current_group == _dbcfg.streaming_scheduling_group
+            || current_group == _dbcfg.backup_scheduling_group
             || current_group == _dbcfg.maintenance_compaction_scheduling_group) {
         return request_class::maintenance;
     // Everything else is considered a user request

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -470,6 +470,7 @@ public:
         seastar::scheduling_group memtable_to_cache_scheduling_group;
         seastar::scheduling_group memory_compaction_scheduling_group;
         seastar::scheduling_group streaming_scheduling_group;
+        seastar::scheduling_group maintenance_scheduling_group;
         bool enable_metrics_reporting = false;
         bool enable_node_aggregated_table_metrics = true;
         size_t view_update_memory_semaphore_limit;
@@ -1456,6 +1457,7 @@ public:
         seastar::scheduling_group memtable_to_cache_scheduling_group;
         seastar::scheduling_group memory_compaction_scheduling_group;
         seastar::scheduling_group streaming_scheduling_group;
+        seastar::scheduling_group maintenance_scheduling_group;
         bool enable_metrics_reporting = false;
         size_t view_update_memory_semaphore_limit;
     };
@@ -1536,6 +1538,7 @@ struct database_config {
     seastar::scheduling_group memory_compaction_scheduling_group;
     seastar::scheduling_group statement_scheduling_group;
     seastar::scheduling_group streaming_scheduling_group;
+    seastar::scheduling_group maintenance_scheduling_group;
     seastar::scheduling_group gossip_scheduling_group;
     seastar::scheduling_group commitlog_scheduling_group;
     seastar::scheduling_group schema_commitlog_scheduling_group;

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1532,6 +1532,7 @@ struct database_config {
     seastar::scheduling_group memtable_scheduling_group;
     seastar::scheduling_group memtable_to_cache_scheduling_group; // FIXME: merge with memtable_scheduling_group
     seastar::scheduling_group compaction_scheduling_group;
+    seastar::scheduling_group maintenance_compaction_scheduling_group;
     seastar::scheduling_group memory_compaction_scheduling_group;
     seastar::scheduling_group statement_scheduling_group;
     seastar::scheduling_group streaming_scheduling_group;

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1539,6 +1539,7 @@ struct database_config {
     seastar::scheduling_group gossip_scheduling_group;
     seastar::scheduling_group commitlog_scheduling_group;
     seastar::scheduling_group schema_commitlog_scheduling_group;
+    seastar::scheduling_group backup_scheduling_group;
     size_t available_memory;
 };
 

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -3313,7 +3313,7 @@ void tablet_storage_group_manager::handle_tablet_split_completion(const locator:
 }
 
 future<> tablet_storage_group_manager::merge_completion_fiber() {
-    co_await coroutine::switch_to(_t.get_config().streaming_scheduling_group);
+    co_await coroutine::switch_to(_t.get_config().maintenance_scheduling_group);
 
     while (!_t.async_gate().is_closed()) {
         try {

--- a/streaming/stream_manager.cc
+++ b/streaming/stream_manager.cc
@@ -43,11 +43,6 @@ stream_manager::stream_manager(db::config& cfg,
 {
     namespace sm = seastar::metrics;
 
-    if (this_shard_id() == 0) {
-        _io_throughput_option_observer.emplace(_io_throughput_mbs.observe(_io_throughput_updater.make_observer()));
-        (void)_io_throughput_updater.trigger_later();
-    }
-
     _finished_percentage[streaming::stream_reason::bootstrap] = 1;
     _finished_percentage[streaming::stream_reason::decommission] = 1;
     _finished_percentage[streaming::stream_reason::removenode] = 1;
@@ -92,20 +87,6 @@ future<> stream_manager::start(abort_source& as) {
 future<> stream_manager::stop() {
     co_await _gossiper.unregister_(shared_from_this());
     co_await uninit_messaging_service_handler();
-    co_await _io_throughput_updater.join();
-}
-
-future<> stream_manager::update_io_throughput(uint32_t value_mbs) {
-    uint64_t bps = ((uint64_t)(value_mbs != 0 ? value_mbs : std::numeric_limits<uint32_t>::max())) << 20;
-    return _streaming_group.update_io_bandwidth(bps).then_wrapped([value_mbs] (auto f) {
-        if (f.failed()) {
-            sslog.warn("Couldn't update streaming bandwidth: {}", f.get_exception());
-        } else if (value_mbs != 0) {
-            sslog.info("Set streaming bandwidth to {}MB/s", value_mbs);
-        } else {
-            sslog.info("Set unlimited streaming bandwidth");
-        }
-    });
 }
 
 void stream_manager::register_sending(shared_ptr<stream_result_future> result) {

--- a/streaming/stream_manager.hh
+++ b/streaming/stream_manager.hh
@@ -101,8 +101,6 @@ private:
 
     scheduling_group _streaming_group;
     utils::updateable_value<uint32_t> _io_throughput_mbs;
-    serialized_action _io_throughput_updater = serialized_action([this] { return update_io_throughput(_io_throughput_mbs()); });
-    std::optional<utils::observer<uint32_t>> _io_throughput_option_observer;
 
 public:
     stream_manager(db::config& cfg, sharded<replica::database>& db,

--- a/test/boost/database_test.cc
+++ b/test/boost/database_test.cc
@@ -1264,6 +1264,7 @@ SEASTAR_THREAD_TEST_CASE(reader_concurrency_semaphore_selection_test) {
     auto sched_groups = get_scheduling_groups().get();
 
     scheduling_group_and_expected_semaphore.emplace_back(sched_groups.compaction_scheduling_group, system_semaphore);
+    scheduling_group_and_expected_semaphore.emplace_back(sched_groups.maintenance_compaction_scheduling_group, streaming_semaphore);
     scheduling_group_and_expected_semaphore.emplace_back(sched_groups.memory_compaction_scheduling_group, system_semaphore);
     scheduling_group_and_expected_semaphore.emplace_back(sched_groups.streaming_scheduling_group, streaming_semaphore);
     scheduling_group_and_expected_semaphore.emplace_back(sched_groups.statement_scheduling_group, user_semaphore);
@@ -1315,6 +1316,7 @@ SEASTAR_THREAD_TEST_CASE(max_result_size_for_query_selection_test) {
     auto sched_groups = get_scheduling_groups().get();
 
     scheduling_group_and_expected_max_result_size.emplace_back(sched_groups.compaction_scheduling_group, system_max_result_size);
+    scheduling_group_and_expected_max_result_size.emplace_back(sched_groups.maintenance_compaction_scheduling_group, system_max_result_size);
     scheduling_group_and_expected_max_result_size.emplace_back(sched_groups.memory_compaction_scheduling_group, system_max_result_size);
     scheduling_group_and_expected_max_result_size.emplace_back(sched_groups.streaming_scheduling_group, maintenance_max_result_size);
     scheduling_group_and_expected_max_result_size.emplace_back(sched_groups.statement_scheduling_group, user_max_result_size);

--- a/test/cluster/object_store/test_backup.py
+++ b/test/cluster/object_store/test_backup.py
@@ -101,10 +101,10 @@ async def test_simple_backup(manager: ManagerClient, object_storage, move_files)
         print(f'Check {f} is in backup')
         assert f'{prefix}/{f}' in objects
 
-    # Check that task runs in the streaming sched group
+    # Check that task runs in the backup sched group
     log = await manager.server_open_log(server.server_id)
     res = await log.grep(r'INFO.*\[shard [0-9]:([a-z]+)\] .* Backup sstables from .* to')
-    assert len(res) == 1 and res[0][1].group(1) == 'strm'
+    assert len(res) == 1 and res[0][1].group(1) == 'bckp'
 
 
 @pytest.mark.asyncio

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -90,6 +90,7 @@ future<scheduling_groups> get_scheduling_groups() {
     if (!_scheduling_groups) {
         _scheduling_groups.emplace();
         _scheduling_groups->compaction_scheduling_group = co_await create_scheduling_group("compaction", 1000);
+        _scheduling_groups->maintenance_compaction_scheduling_group = co_await create_scheduling_group("maintenance_compaction", 200);
         _scheduling_groups->memory_compaction_scheduling_group = co_await create_scheduling_group("mem_compaction", 1000);
         _scheduling_groups->streaming_scheduling_group = co_await create_scheduling_group("streaming", 200);
         _scheduling_groups->statement_scheduling_group = co_await create_scheduling_group("statement", 1000);
@@ -639,6 +640,7 @@ private:
             }
 
             dbcfg.compaction_scheduling_group = scheduling_groups.compaction_scheduling_group;
+            dbcfg.maintenance_compaction_scheduling_group = scheduling_groups.maintenance_compaction_scheduling_group;
             dbcfg.memory_compaction_scheduling_group = scheduling_groups.memory_compaction_scheduling_group;
             dbcfg.streaming_scheduling_group = scheduling_groups.streaming_scheduling_group;
             dbcfg.statement_scheduling_group = scheduling_groups.statement_scheduling_group;
@@ -672,7 +674,7 @@ private:
             auto get_cm_cfg = sharded_parameter([&] {
                 return compaction::compaction_manager::config {
                     .compaction_sched_group = compaction::compaction_manager::scheduling_group{dbcfg.compaction_scheduling_group},
-                    .maintenance_sched_group = compaction::compaction_manager::scheduling_group{dbcfg.streaming_scheduling_group},
+                    .maintenance_sched_group = compaction::compaction_manager::scheduling_group{dbcfg.maintenance_compaction_scheduling_group},
                     .available_memory = dbcfg.available_memory,
                     .static_shares = cfg->compaction_static_shares,
                     .max_shares = cfg->compaction_max_shares,

--- a/test/lib/cql_test_env.hh
+++ b/test/lib/cql_test_env.hh
@@ -76,6 +76,7 @@ namespace db {
 
 struct scheduling_groups {
     scheduling_group compaction_scheduling_group;
+    scheduling_group maintenance_compaction_scheduling_group;
     scheduling_group memory_compaction_scheduling_group;
     scheduling_group streaming_scheduling_group;
     scheduling_group statement_scheduling_group;


### PR DESCRIPTION
The supergroup replaces streaming (a.k.a. maintenance as well) group, inherits 200 shares from it and consists of four sub-groups (all have equal shares of 200 withing the new supergroup)

* maintenance_compaction. This group configures `compaction_manager::maintenance_sg()` group. User-triggered compaction runs in it
* backup. This group configures `snapshot_ctl::config::backup_sched_group`. Native backup activity runs there
* maintenance. It's a new "visible" name, everything that was called "maintenance" in the code ran in "streaming" group. Now it will run in "maintenance". The activities include those that don't communicate over RPC (see below why)
  * `tablet_allocator::balance_tablets()`
  * `sstables_manager::components_reclaim_reload_fiber()`
  * `tablet_storage_group_manager::merge_completion_fiber()`
  * metrics exporting http server altogether
* streaming. This is purely existing streaming group that just moves under the new supergroup. Everything else that was run there, continues doing so, including
  * hints sender
  * all view building related components (update generator, builder, workers)
  * repair
  * stream_manager
  * messaging service (except for verb handlers that switch groups)
  * join_cluster() activity
  * REST API
  * ... something else I forgot

The `--maintenance_io_throughput_mb_per_sec` option is introduced. It controls the IO throughput limit applied to the maintenance supergroup. If not set, the `--stream_io_throughput_mb_per_sec` option is used to preserve backward compatibility.

All new sched groups inherit `request_class::maintenance` (however, "backup" seem not to make any requests yet).

Moving more activities from "streaming" into "maintenance" (or its own group) is possible, but one will need to take care of RPC group switching. The thing is that when a client makes an RPC call, the server may switch to one of pre-negotiated scheduling groups. Verbs for existing activities that run in "streaming" group are routed through RPC index that negotiates "streaming" group on the server side. If any of that client code moves to some other group, server will still run the handlers in "streaming" which is not quite expected. That's one of the main reasons why only the selected fibers were moved to their own "maintenance" group. Similar for backup -- this code doesn't use RPC, so it can be moved. Restoring code uses load-and-stream and corresponding RPCs, so it cannot be just moved into its own new group.

Fixes SCYLLADB-351

New feature, not backporting