### PR TITLE
build: refine sanitization build to better simulate release

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -490,16 +490,17 @@ modes = {
         'advanced_optimizations': False,
     },
     'sanitize': {
-        'cxxflags': '-DDEBUG -DSANITIZE -DDEBUG_LSA_SANITIZER -DSCYLLA_ENABLE_ERROR_INJECTION',
+        'cxxflags': '-g -DSANITIZE -DSCYLLA_ENABLE_ERROR_INJECTION -DSEASTAR_ENABLE_ALLOC_FAILURE_INJECTION -DSCYLLA_ENABLE_PREEMPTION_SOURCE' ,
         'cxx_ld_flags': '',
         'stack-usage-threshold': 1024*50,
-        'optimization-level': 's',
+        'optimization-level': '2',
         'per_src_extra_cxxflags': {},
         'cmake_build_type': 'Sanitize',
         'can_have_debug_info': True,
         'build_seastar_shared_libs': False,
         'default': False,
-        'description': 'a mode with optimizations and sanitizers enabled, used for finding memory errors',
+        'description': 'A build mode with optimizations and sanitizers enabled,  '
+        'designed to simulate release behavior while retaining runtime checks for CI runs.',
         'advanced_optimizations': False,
     },
     'coverage': {


### PR DESCRIPTION
Update the sensitization build configuration to more closely match release behavior while keeping sanitizers enabled.
The build with sanitize mode now uses -O2, which produces code generation similar to -O3 while still allowing most sanitizers to reliably detect issues via traps.
Also with this build we will have minimal debug information -g1 so that we will have more clues if something happens from CI itself.
This configuration will be used for CI runs to improve signal quality without the cost of full debug builds.

Configure and Runtime:

Running the Boost Test on i5 laptop: 

1. Release

    Flags: -O3, no sanitizers

    Runtime: 8m 53.235s (baseline)

2. sanitize (new mode)

    Flags: -O2 -g1, sanitizers enabled

    Runtime: 16m 27.450s

3. Debug

    Flags: no optimization, sanitizers enabled

    Runtime: 45m 46.154s

Observations

    Sanitizers do add overhead, but the new sanitizer configuration is only about 2× slower than full release.

    Debug mode is significantly more expensive:

        ~6× slower than release

        ~3× slower than new sanitizer mode

fixes: [scylladb-570](https://scylladb.atlassian.net/browse/SCYLLADB-570)

backport: this is an optimization for master and next no backport is required
calebxyz