### PR TITLE
test: increase cluster pool sizes and make them adaptive

### DIFF
--- a/test/cluster/suite.yaml
+++ b/test/cluster/suite.yaml
@@ -1,5 +1,5 @@
 type: Topology
-pool_size: 4
+pool_size_per_vcpu: 1
 cluster:
   initial_size: 0
 extra_scylla_config_options:

--- a/test/pylib/suite/python.py
+++ b/test/pylib/suite/python.py
@@ -51,7 +51,7 @@ class PythonTestSuite(TestSuite):
         elif env_pool_size is not None:
             pool_size = int(env_pool_size)
         else:
-            pool_size = cfg.get("pool_size", 2)
+            pool_size = cfg.get("pool_size_per_vcpu", 1) * os.cpu_count()
         self.dirties_cluster = set(cfg.get("dirties_cluster", []))
 
         self.create_cluster = self.get_cluster_factory(cluster_size, options)

--- a/test/storage/suite.yaml
+++ b/test/storage/suite.yaml
@@ -1,5 +1,5 @@
 type: Topology
-pool_size: 4
+pool_size_per_vcpu: 1
 cluster:
   initial_size: 0
 extra_scylla_config_options:


### PR DESCRIPTION
Instead of fixing the pool size at a measly 4, scale it with the host vcpu count at 1 cluster per vcpu. This ensures that tests aren't blocked on lack of cluster pool slots.

On my 16-core/32-vcpu workstation, `./test.py --mode dev`:

Before:

CPU utilization: 8.8%

real	58m58.215s
user	111m42.222s
sys	61m42.283s

After:

real	29m16.895s
user	149m53.671s
sys	79m18.953s

So twice as fast in real time. Strangely, a large increase in user time.

Test performance improvement, not backporting.