### PR TITLE
repair: Skip auto repair for tables using RF one

### DIFF
--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -1109,6 +1109,11 @@ public:
         if (!is_auto_repair_enabled(config)) {
             co_return false;
         }
+        auto size = info.replicas.size();
+        if (size <= 1) {
+            lblogger.debug("Skipped auto repair for tablet={} replicas={}", gid, size);
+            co_return false;
+        }
         auto threshold = _db.get_config().auto_repair_threshold_default_in_seconds();
         auto repair_time_threshold = std::chrono::seconds(threshold);
         auto& last_repair_time = info.repair_time;

--- a/test/pylib/repair.py
+++ b/test/pylib/repair.py
@@ -64,7 +64,7 @@ async def load_tablet_repair_task_infos(cql, host, table_id):
 
     return repair_task_infos
 
-async def create_table_insert_data_for_repair(manager, rf = 3 , tablets = 8, fast_stats_refresh = True, nr_keys = 256, disable_flush_cache_time = False, cmdline = None) -> (list[ServerInfo], CassandraSession, list[Host], str, str):
+async def create_table_insert_data_for_repair(manager, rf = 3 , tablets = 8, fast_stats_refresh = True, nr_keys = 256, disable_flush_cache_time = False, cmdline = None, nr_nodes = 3, gc_mode = 'repair') -> (list[ServerInfo], CassandraSession, list[Host], str, str):
     assert rf <= 3, "A keyspace with RF > 3 will be RF-rack-invalid if there are fewer racks than the RF"
 
     if fast_stats_refresh:
@@ -73,12 +73,12 @@ async def create_table_insert_data_for_repair(manager, rf = 3 , tablets = 8, fas
         config = {}
     if disable_flush_cache_time:
         config.update({'repair_hints_batchlog_flush_cache_time_in_ms': 0})
-    servers = await manager.servers_add(3, config=config, cmdline=cmdline,
+    servers = await manager.servers_add(nr_nodes, config=config, cmdline=cmdline,
                                         property_file=[{"dc": "dc1", "rack": f"r{i % rf}"} for i in range(rf)])
     cql = manager.get_cql()
     ks = await create_new_test_keyspace(cql, "WITH replication = {{'class': 'NetworkTopologyStrategy', "
                   "'replication_factor': {}}} AND tablets = {{'initial': {}}};".format(rf, tablets))
-    await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int) WITH tombstone_gc = {{'mode':'repair'}};")
+    await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int) WITH tombstone_gc = {{'mode':'{gc_mode}'}};")
     keys = range(nr_keys)
     await asyncio.gather(*[cql.run_async(f"INSERT INTO {ks}.test (pk, c) VALUES ({k}, {k});") for k in keys])
     hosts = await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)


### PR DESCRIPTION
There is no point running repair for tables using RF one. Row level repair will skip it but the auto repair scheduler will keep scheduling such repairs since repair_time could not be updated.

Skip such repairs at the scheduler level for auto repair.

If the request is issued by user, we will have to schedule such repair otherwise the user request will never be finished.

Fixes SCYLLADB-561

Backport to 2026.1 which is the first release has auto repair. 