### PR TITLE
test: scylla_gdb: tighten check for Error output from gdb

### DIFF
--- a/test/scylla_gdb/conftest.py
+++ b/test/scylla_gdb/conftest.py
@@ -8,6 +8,7 @@ import os
 
 import pexpect
 import pytest
+import re
 
 from test.pylib.suite.python import PythonTest
 from test.pylib.util import LogPrefixAdapter
@@ -88,5 +89,7 @@ def execute_gdb_command(
         pytest.fail("GDB command did not complete within the timeout period")
     result = gdb_process.before.decode("utf-8")
 
-    assert "Error" not in result
+    # The task_histogram command may include "error::Error" in its output, so
+    # allow it.
+    assert not re.search(r'(?<!error::)Error', result)
     return result


### PR DESCRIPTION
When running a gdb command, we check that the string 'Error' does not appear within the output. However, if the command output includes the string 'Error' as part of its normal operation, this generates a false positive. In fact the task_histogram can include the string 'error::Error' from the Rust core::error module.

Allow for that and only match 'Error' that isn't 'error::Error'.

Fixes #28516.

While this logically applies to older branches, we've never seen it before then, and therefore will only backport if starts showing up.