### PR TITLE
Add milestone sync to Jira based on GitHub Action

### DIFF
--- a/.github/workflows/call_jira_sync_pr_milestone.yml
+++ b/.github/workflows/call_jira_sync_pr_milestone.yml
@@ -1,0 +1,22 @@
+﻿name: Sync Jira Based on PR Milestone Events
+
+on:
+  pull_request_target:
+    types: [milestoned, demilestoned]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  jira-sync-milestone-set:
+    if: github.event.action == 'milestoned'
+    uses: scylladb/github-automation/.github/workflows/main_jira_sync_pr_milestone_set.yml@main
+    secrets:
+      caller_jira_auth: ${{ secrets.USER_AND_KEY_FOR_JIRA_AUTOMATION }}
+
+  jira-sync-milestone-removed:
+    if: github.event.action == 'demilestoned'
+    uses: scylladb/github-automation/.github/workflows/main_jira_sync_pr_milestone_removed.yml@main
+    secrets:
+      caller_jira_auth: ${{ secrets.USER_AND_KEY_FOR_JIRA_AUTOMATION }}


### PR DESCRIPTION
## What changed
- Added new workflow file `.github/workflows/call_jira_sync_pr_milestone.yml`

## Why (Requirements Summary)
- Adds a GitHub Action that will be triggered when a milestone is set or removed from a PR
- When milestone is added (milestoned event), calls `main_jira_sync_pr_milestone_set.yml` from github-automation.git, , which will add the version from the 'Fix Versions' field in the relevant linked Jira issue
- When milestone is removed (demilestoned event), calls `main_jira_sync_pr_milestone_removed.yml` from github-automation.git, which will remove the version from the 'Fix Versions' field in the relevant linked Jira issue

Testing was performed in staging.git and the STAG Jira project.

Fixes:PM-177