### PR TITLE
test: minio: tune sync setting

### DIFF
--- a/test/pylib/minio_server.py
+++ b/test/pylib/minio_server.py
@@ -172,7 +172,11 @@ class MinioServer:
             preexec_fn=os.setsid,
             stderr=self.log_file,
             stdout=self.log_file,
-            env={**os.environ, 'MINIO_BROWSER': 'off'},
+            env={
+                **os.environ,
+                'MINIO_BROWSER': 'off',
+                'MINIO_FS_OSYNC': 'off',
+            },
         )
         timeout = time.time() + 30
         while time.time() < timeout:


### PR DESCRIPTION
Disable O_DSYNC in minio to avoid unnecessary slowdown in S3 tests.

Small test performance improvement, not backporting.