### PR TITLE
dictionary compression: add missing co_awaits on get_units

### DIFF
--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -1341,7 +1341,7 @@ rest_estimate_compression_ratios(http_context& ctx, sharded<service::storage_ser
         apilog.warn("estimate_compression_ratios: called before the cluster feature was enabled");
         throw std::runtime_error("estimate_compression_ratios requires all nodes to support the SSTABLE_COMPRESSION_DICTS cluster feature");
     }
-    auto ticket = get_units(ss.local().get_do_sample_sstables_concurrency_limiter(), 1);
+    auto ticket = co_await get_units(ss.local().get_do_sample_sstables_concurrency_limiter(), 1);
     auto ks = api::req_param<sstring>(*req, "keyspace", {}).value;
     auto cf = api::req_param<sstring>(*req, "cf", {}).value;
     apilog.debug("estimate_compression_ratios: called with ks={} cf={}", ks, cf);
@@ -1407,7 +1407,7 @@ rest_retrain_dict(http_context& ctx, sharded<service::storage_service>& ss, serv
         apilog.warn("retrain_dict: called before the cluster feature was enabled");
         throw std::runtime_error("retrain_dict requires all nodes to support the SSTABLE_COMPRESSION_DICTS cluster feature");
     }
-    auto ticket = get_units(ss.local().get_do_sample_sstables_concurrency_limiter(), 1);
+    auto ticket = co_await get_units(ss.local().get_do_sample_sstables_concurrency_limiter(), 1);
     auto ks = api::req_param<sstring>(*req, "keyspace", {}).value;
     auto cf = api::req_param<sstring>(*req, "cf", {}).value;
     apilog.debug("retrain_dict: called with ks={} cf={}", ks, cf);

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -3781,7 +3781,7 @@ future<utils::chunked_vector<temporary_buffer<char>>> database::sample_data_file
             &result,
             chunk_size
         ] (database& local_db, state_by_shard& local_state) -> future<> {
-            auto ticket = get_units(local_db._sample_data_files_local_concurrency_limiter, 1);
+            auto ticket = co_await get_units(local_db._sample_data_files_local_concurrency_limiter, 1);
 
             // In `chosen_chunks`, the sorted array of chosen chunk offsets (in the "global chunk list"),
             // find the range of offsets which belongs to us.

--- a/sstable_dict_autotrainer.cc
+++ b/sstable_dict_autotrainer.cc
@@ -62,7 +62,7 @@ future<> sstable_dict_autotrainer::tick() {
             continue;
         }
         auto params = s->get_compressor_params();
-        auto ticket = get_units(_ss.get_do_sample_sstables_concurrency_limiter(), 1);
+        auto ticket = co_await get_units(_ss.get_do_sample_sstables_concurrency_limiter(), 1);
         // When we sample a block from a set of files, we can think of this block's
         // compression ratio like about a random variable, with value in [0;1] and
         // some underlying distribution.


### PR DESCRIPTION
There is a handful of places in the code related to dictionary compression which calls get_units to acquire semaphore units but the returned future is not awaited, seemingly by mistake. The result of get_units is assigned to a variable - which is reasonable at a glance because the semaphore units need to be assigned to a variable in order to control their scope - but at the same time if co_await is mistakenly omitted, like here, doing so will silence the nodiscard check of seastar::future and, effectively, the get_units call will be nearly useless. Unfortunately, this is an easy mistake to make.

Fix the places in the code that acquire semaphore units via get_units but never await the future returned by it. I found them by manual code inspection, so I hope that I didn't miss any.

The code modified here is present back in 2025.2, so the fix needs to be backported to 2025.3 and newer live versions.