### PR TITLE
gcp: Add handling of 429 (too many requests) to exponential backoff

### DIFF
--- a/ent/encryption/gcp_host.cc
+++ b/ent/encryption/gcp_host.cc
@@ -284,6 +284,7 @@ future<rjson::value> encryption::gcp_host::impl::gcp_auth_post_with_retry(std::s
                 }
                 [[fallthrough]];
             case httpclient::reply_status::request_timeout:
+            case httpclient::reply_status::too_many_requests:
                 if (retry < max_retries) {
                     // service unavailable etc -> backoff + retry
                     do_backoff = true;


### PR DESCRIPTION
Fixes: SCYLLADB-611

Adds http error code 429 to codes handled by exponential backoff.

Note: added in both google storage and KMS bridges.

Marked as backport since (IIRC) feature is technically alive in 2026.1