### PR TITLE
test/scylla-gdb: Show more info on error output

### DIFF
--- a/test/scylla_gdb/conftest.py
+++ b/test/scylla_gdb/conftest.py
@@ -91,5 +91,5 @@ def execute_gdb_command(
 
     # The task_histogram command may include "error::Error" in its output, so
     # allow it.
-    assert not re.search(r'(?<!error::)Error', result)
+    assert not re.search(r'(?<!error::)Error', result), f'Unexpected error reported in {result}'
     return result


### PR DESCRIPTION
When the error searcher finds "bad" error message in the output, the result itself is trimmed in the printed failure message.

Extend it to provide more debug information.

Enhancing test verbosity, not backporting