### PR TITLE
dtest: wait_for speedup

### DIFF
--- a/test/cluster/dtest/dtest_class.py
+++ b/test/cluster/dtest/dtest_class.py
@@ -86,7 +86,7 @@ def forever_wait_for(func, step=1, text=None, **kwargs):
     return ok
 
 
-def wait_for(func, step=1, text=None, timeout=None, throw_exc=True, **kwargs):
+def wait_for(func, step=0.2, text=None, timeout=None, throw_exc=True, **kwargs):
     """
     Wrapper function to wait with timeout option.
     If no timeout received, 'forever_wait_for' method will be used.


### PR DESCRIPTION
Audit tests have been slow. They rely on wait_for function. This function first sleeps for the duration of the time step specified, and then calls the given function. The audit tests need 0.02-0.03 seconds for the given function, but the operation lasts around 1.02-1.03 seconds, since step is 1 second.

This patch modifies wait_for dtest function so it first executes the given function, and afterwards calls time.sleep(step). This reduces time needed for the given function from 1.03 to 0.03 seconds.

Total audit tests suite speedup is 3x. On the developer machine the time is reduced from 13+ minutes to 4 minutes.

This patch also improves performance of some alternator tests that use the same wait_for dtest function.

`wait_for` in dtest framework has default time step reduced to make the environment more responsive and test execution faster.

Refs SCYLLADB-573

This is a performance improvement of testing framework. No need to backport.