### PR TITLE
tasks: increase tasks_vt_get_children timeout

### DIFF
--- a/tasks/task_manager.cc
+++ b/tasks/task_manager.cc
@@ -415,7 +415,7 @@ future<utils::chunked_vector<task_identity>> task_manager::virtual_task::impl::g
     auto nodes = module->get_nodes();
     co_await utils::get_local_injector().inject("tasks_vt_get_children", [] (auto& handler) -> future<> {
         tmlogger.info("tasks_vt_get_children: waiting");
-        co_await handler.wait_for_message(std::chrono::steady_clock::now() + std::chrono::seconds{10});
+        co_await handler.wait_for_message(std::chrono::steady_clock::now() + std::chrono::seconds{60});
     });
     co_return co_await map_reduce(nodes, [ms, parent_id, is_host_alive = std::move(is_host_alive)] (auto host_id) -> future<utils::chunked_vector<task_identity>> {
         if (is_host_alive(host_id)) {


### PR DESCRIPTION
test_node_ops_tasks.py::test_get_children fails due to timeout of tasks_vt_get_children injection in debug mode. Compared to a successful run, no clear root cause stands out.

Extend the message timeout of tasks_vt_get_children from 10s to 60s.

Fixes: #28295.

Test timeout increase, no backport.