### PR TITLE
test: fix test_remove_node_violating_rf_rack_with_rack_list

### DIFF
--- a/test/cluster/test_topology_ops_with_rf_rack_valid.py
+++ b/test/cluster/test_topology_ops_with_rf_rack_valid.py
@@ -304,7 +304,7 @@ async def test_remove_node_violating_rf_rack_with_rack_list(manager: ManagerClie
     """
     Test removing a node when it would violate RF-rack constraints with explicit rack list.
 
-    Creates a cluster with 4 racks (r1, r2, r3, r4) and a keyspace that explicitly
+    Creates a cluster with 5 racks (r1, r2, r3, r4, r5) and a keyspace that explicitly
     specifies RF as a list of racks ['r1', 'r2', 'r4'].
 
     Tests that:
@@ -323,11 +323,12 @@ async def test_remove_node_violating_rf_rack_with_rack_list(manager: ManagerClie
         elif op == "decommission":
             await manager.decommission_node(server_id, expected_error=expected_error)
 
-    servers = await manager.servers_add(4, config=cfg, cmdline=cmdline, property_file=[
+    servers = await manager.servers_add(5, config=cfg, cmdline=cmdline, property_file=[
         {"dc": "dc1", "rack": "r1"},
         {"dc": "dc1", "rack": "r2"},
         {"dc": "dc1", "rack": "r3"},
         {"dc": "dc1", "rack": "r4"},
+        {"dc": "dc1", "rack": "r5"},
     ])
     cql = manager.get_cql()
 


### PR DESCRIPTION
test_remove_node_violating_rf_rack_with_rack_list creates a cluster with four nodes. One of the nodes is excluded, then another one is stopped, excluded, and removed. If the two stopped nodes were both voters, the majority is lost and the cluster loses its raft leader. As a result, the node cannot be removed and the operation times out.

Add the 5th node to the cluster. This way the majority is always up.

Fixes: https://github.com/scylladb/scylladb/issues/28596.

Needs backport to 2026.1 that introduces the test.