### PR TITLE
types: optimize vector deserialization for high-dimensional vectors

### DIFF
--- a/types/types.cc
+++ b/types/types.cc
@@ -1802,8 +1802,14 @@ private:
         auto value_length = t.get_elements_type()->value_length_if_fixed();
         vector_type_impl::native_type ret;
         ret.reserve(t.get_dimension());
-        for (size_t i = 0; i < t.get_dimension(); i++) {
-            ret.push_back(func(read_vector_element(v, value_length)));
+        if (value_length) {
+            for (size_t i = 0; i < t.get_dimension(); i++) {
+                ret.push_back(func(read_vector_element_fixed(v, *value_length)));
+            }
+        } else {
+            for (size_t i = 0; i < t.get_dimension(); i++) {
+                ret.push_back(func(read_vector_element_variable(v)));
+            }
         }
         return data_value::make(t.shared_from_this(),
             std::make_unique<vector_type_impl::native_type>(std::move(ret)));

--- a/types/vector.hh
+++ b/types/vector.hh
@@ -32,9 +32,16 @@ public:
                         
     std::vector<managed_bytes> split_fragmented(FragmentedView auto v) const {
         std::vector<managed_bytes> elements;
-        for (size_t i = 0; i < _dimension; ++i) {
-            auto element = read_vector_element(v, _elements_type->value_length_if_fixed());
-            elements.push_back(managed_bytes(element));
+        elements.reserve(_dimension);
+        auto fixed_len = _elements_type->value_length_if_fixed();
+        if (fixed_len) {
+            for (size_t i = 0; i < _dimension; ++i) {
+                elements.push_back(managed_bytes(read_vector_element_fixed(v, *fixed_len)));
+            }
+        } else {
+            for (size_t i = 0; i < _dimension; ++i) {
+                elements.push_back(managed_bytes(read_vector_element_variable(v)));
+            }
         }
         return elements;
     }
@@ -98,16 +105,26 @@ private:
 
 };
 
+// Read a vector element with known fixed size.
 template <FragmentedView View>
-View read_vector_element(View& v, std::optional<size_t> value_length_if_fixed) {
-    uint64_t element_size;
-    if (value_length_if_fixed) {
-        element_size = value_length_if_fixed.value();
-    } else {
-        element_size = with_linearized(v, unsigned_vint::deserialize);
-        v.remove_prefix(unsigned_vint::serialized_size(element_size));
+View read_vector_element_fixed(View& v, size_t element_size) {
+    if (element_size == 0) {
+        throw exceptions::invalid_request_exception("null/unset is not supported inside vectors");
     }
-    
+
+    if (element_size > v.size_bytes()) {
+        throw exceptions::invalid_request_exception("Not enough bytes to read a vector element");
+    }
+
+    return read_simple_bytes(v, element_size);
+}
+
+// Read a vector element with variable-length encoding (vint-prefixed size).
+template <FragmentedView View>
+View read_vector_element_variable(View& v) {
+    auto element_size = with_linearized(v, unsigned_vint::deserialize);
+    v.remove_prefix(unsigned_vint::serialized_size(element_size));
+
     if (element_size == 0) {
         throw exceptions::invalid_request_exception("null/unset is not supported inside vectors");
     }
@@ -117,6 +134,15 @@ View read_vector_element(View& v, std::optional<size_t> value_length_if_fixed) {
     }
 
     return read_simple_bytes(v, element_size);
+}
+
+template <FragmentedView View>
+View read_vector_element(View& v, std::optional<size_t> value_length_if_fixed) {
+    if (value_length_if_fixed) {
+        return read_vector_element_fixed(v, *value_length_if_fixed);
+    } else {
+        return read_vector_element_variable(v);
+    }
 }
 
 data_value make_vector_value(data_type type, vector_type_impl::native_type value);


### PR DESCRIPTION
Vector deserialization is an operation which performance is critical for 
vector similarity search feature because it is frequently executed during 
rescoring operation. Some of the identified performance bottlenecks
for it include:

1. Per-element virtual dispatch in deserialize(): each of the N elements
   went through visit() which switches on ~28 type variants. For a
   1024-dimension float vector, that's 1024 redundant type switches when
   the element type is the same for all of them.

2. Redundant work in split_fragmented(): value_length_if_fixed() was
   called inside the loop (N virtual calls), and no reserve() was done
   on the output vector causing repeated reallocations.

This series fixes both:

- Introduce deserialize_vector_visitor that dispatches on the element
  type once for the entire vector, then loops inside the resolved
  handler. Simple numeric types (float, int, etc.) call
  deserialize_value() directly with no virtual dispatch per element.
  String types (ascii, utf8) get a dedicated handler that skips
  make_empty() (sstring has no empty_t constructor). Complex types
  (list, map, tuple, etc.) fall back to per-element dispatch.

- In split_fragmented(), reserve the output vector to _dimension and
  cache value_length_if_fixed() before the loop.

Benchmark results (1024-dim float vector, release build, -O3 -flto):

  deserialize:      15.73 us -> 11.70 us  (1.34x, 26% faster)
  split_fragmented: 10.34 us ->  7.45 us  (1.39x, 28% faster)

References: SCYLLADB-471

Backport: none, unless we observe some critical performance improvement for quantization.