### PR TITLE
table: Use fmt::to_string() to stringify compation group ID

### DIFF
--- a/replica/table.cc
+++ b/replica/table.cc
@@ -2754,7 +2754,7 @@ public:
         return _cg.get_backlog_tracker();
     }
     const std::string get_group_id() const noexcept override {
-        return fmt::format("{}", _cg.group_id());
+        return fmt::to_string(_cg.group_id());
     }
 
     seastar::condition_variable& get_staging_done_condition() noexcept override {


### PR DESCRIPTION
Doing it with format("{}", foo) is correct, but to_string is a bit more lightweight.

Code cleanup, not backporting