### PR TITLE
test: fix flaky tests

### DIFF
--- a/test/cluster/auth_cluster/test_maintenance_socket.py
+++ b/test/cluster/auth_cluster/test_maintenance_socket.py
@@ -8,6 +8,8 @@ from cassandra.auth import PlainTextAuthProvider
 from cassandra.cluster import Cluster, NoHostAvailable
 from cassandra import Unauthorized
 from cassandra.connection import UnixSocketEndPoint
+from cassandra.policies import WhiteListRoundRobinPolicy
+
 from test.cluster.conftest import cluster_con
 from test.pylib.manager_client import ManagerClient
 
@@ -58,7 +60,7 @@ async def test_maintenance_socket(manager: ManagerClient):
     else:
         pytest.fail("User 'john' has no permissions to access ks2.t1")
 
-    maintenance_cluster = cluster_con([UnixSocketEndPoint(socket)])
+    maintenance_cluster = cluster_con([UnixSocketEndPoint(socket)], load_balancing_policy=WhiteListRoundRobinPolicy([UnixSocketEndPoint(socket)]))
     maintenance_session = maintenance_cluster.connect()
 
     # check that the maintenance session has superuser permissions


### PR DESCRIPTION
test_maintenance_socket with new way of running is flaky. Looks like the driver tries to reconnect with an old maintenance socket from previous driver and fails. This PR adds white list for connection that stabilize the test
test_no_removed_node_event_on_ip_change was flaky on CI, while the issue never reproduced locally. The assumption that under load we have race condition and trying to check the logs before message is arrived. Small for loop to retry added to avoid such situation.

No backport, fix flaky tests that are move visible during execution with higher threads.