### PR TITLE
gossiper: exit failure detector sleep faster

### DIFF
--- a/gms/gossiper.hh
+++ b/gms/gossiper.hh
@@ -679,6 +679,7 @@ private:
     netw::messaging_service& _messaging;
     gossip_address_map& _address_map;
     gossip_config _gcfg;
+    condition_variable _failure_detector_loop_cv;
     // Get features supported by a particular node
     std::set<sstring> get_supported_features(locator::host_id endpoint) const;
     locator::token_metadata_ptr get_token_metadata_ptr() const noexcept;
@@ -705,6 +706,7 @@ public:
 private:
     future<> failure_detector_loop();
     future<> failure_detector_loop_for_node(locator::host_id node, generation_type gossip_generation, uint64_t live_endpoints_version);
+    future<> failure_detector_loop_sleep(std::chrono::seconds duration);
 };
 
 


### PR DESCRIPTION
When running unit tests, there's a visible ~1-second sleep when gossip exits the failure detector loop.

Improve this by adding a condition variable for exiting the loop and signaling it when any of the exit conditions are satisfied: the abort_source is pulled, the gossiper is shut down, or the sleep is complete. We can't just use the abort_source because gossip can be shut down independently of the rest of the system.

To see the improvement, I ran cql_query_test in dev mode:

Before:

$ time ./build/dev/test/boost/combined_tests -t cql_query_test -- --smp 2  > /dev/null 2>&1

real	2m26.904s
user	0m24.307s
sys	0m13.402s

After:

$ time ./build/dev/test/boost/combined_tests -t cql_query_test -- --smp 2  > /dev/null 2>&1

real	0m26.579s
user	0m24.671s
sys	0m13.636s

Two minutes of real-time saved.

Real-life improvement in test.py will be lower, because of the overhead of launching pytest for each test case.

Small test performance improvement; not backporting.