### PR TITLE
secondary_index_manager: fix double registration bug

### DIFF
--- a/index/secondary_index_manager.hh
+++ b/index/secondary_index_manager.hh
@@ -118,6 +118,7 @@ public:
     stats(const sstring& ks_name, const sstring& index_name);
     stats(const stats&) = delete;
     stats& operator=(const stats&) = delete;
+    void deregister();
     void add_latency(std::chrono::steady_clock::duration d);
 };
 


### PR DESCRIPTION
There existed a possibility that per-index metrics does not get deregistered when we drop the index (if a request was in-flight). This patch makes it so the metrics always get deregistered, which should fix the double registration bug.

Fixes: https://github.com/scylladb/scylladb/issues/27252

Backport reasoning: While rare, this bug can cause Scylla to crash, therefore we want to backport it to 2025.4 and 2026.1