### PR TITLE
test: scylla_gdb: loosen assert in execute_gdb_command

### DIFF
--- a/test/scylla_gdb/conftest.py
+++ b/test/scylla_gdb/conftest.py
@@ -88,7 +88,7 @@ def execute_gdb_command(
         gdb_process.expect_exact("(gdb)", timeout=1)
         pytest.fail("GDB command did not complete within the timeout period")
     result = gdb_process.before.decode("utf-8")
-    # The task_histogram command may include "error::Error" in its output, so
+    # The task_histogram command may include "::Error" in its output, so
     # allow it.
-    assert not re.search(r'(?<!error::)Error', result), f"Unexpected Error string in output:\n{result}"
+    assert not re.search(r'(?<!::)Error', result), f"Unexpected Error string in output:\n{result}"
     return result


### PR DESCRIPTION
Since output contains a lot of symbols it may happen that
it contains XXX::Error and it doesn't indicate gdb failure.

Fixes https://scylladb.atlassian.net/browse/SCYLLADB-673
Fixes https://scylladb.atlassian.net/browse/SCYLLADB-663
Fixes https://scylladb.atlassian.net/browse/SCYLLADB-558
Fixes https://scylladb.atlassian.net/browse/SCYLLADB-547

No backport it started to fail recently, and it's only a flaky test