### PR TITLE
commitlog: Always abort replenish queue on loop exit

### DIFF
--- a/db/commitlog/commitlog.cc
+++ b/db/commitlog/commitlog.cc
@@ -1986,13 +1986,13 @@ future<> db::commitlog::segment_manager::replenish_reserve() {
             }
             continue;
         } catch (shutdown_marker&) {
-            _reserve_segments.abort(std::current_exception());
             break;
         } catch (...) {
             clogger.warn("Exception in segment reservation: {}", std::current_exception());
         }
         co_await sleep(100ms);
     }
+    _reserve_segments.abort(std::make_exception_ptr(shutdown_marker()));
 }
 
 future<std::vector<db::commitlog::descriptor>>


### PR DESCRIPTION
Fixes #28678

If replenish loop exits the sleep condition, with an empty queue, when "_shutdown" is already set, a waiter might get stuck, unsignalled waiting for segments, even though we are exiting.

Simply move queue abort to always be done on loop exit.

Should be backported to all released, as this is a genuine shutdown deadlock, albeit one that will happen very rarely. Also CI impacting.