### PR TITLE
[tests] explain skip/xfail, if they are marked with a Scylla issue

### DIFF
--- a/test/alternator/test_cql_rbac.py
+++ b/test/alternator/test_cql_rbac.py
@@ -1021,7 +1021,7 @@ def test_rbac_streams(dynamodb, cql):
 # with streams enabled up-front during creation - and enabling the stream
 # later in an already existing table.
 # Reproduces issue #19798
-@pytest.mark.xfail(reason="#19798")
+@pytest.mark.xfail(reason="Auto-grant and auto-revoke missing for CDC log table #19798")
 @pytest.mark.parametrize("during_creation", [True, False])
 def test_rbac_streams_autogrant(dynamodb, cql, during_creation):
     schema = {

--- a/test/alternator/test_gsi.py
+++ b/test/alternator/test_gsi.py
@@ -2133,7 +2133,7 @@ def test_gsi_invalid_key_types(dynamodb):
 # implement this GSI needs to add "p" as an extra clustering key, but it
 # doesn't mean that "p" should be allowed in a KeyConditions or
 # KeyConditionExpression - it shouldn't because it's not a real range key.
-@pytest.mark.xfail(reason="Issue #26103")
+@pytest.mark.xfail(reason="Alternator streams may generate event even if item did not really change #26103")
 def test_faux_range_key_in_keyconditions(test_table_gsi_2):
     p = random_string()
     x = random_string()
@@ -2158,7 +2158,7 @@ def test_faux_range_key_in_keyconditions(test_table_gsi_2):
             KeyConditions={'z': {'AttributeValueList': [p], 'ComparisonOperator': 'EQ'},
                            'x': {'AttributeValueList': [x], 'ComparisonOperator': 'EQ'}})
 
-@pytest.mark.xfail(reason="Issue #26103")
+@pytest.mark.xfail(reason="Alternator streams may generate event even if item did not really change #26103")
 def test_faux_range_key_in_keyconditionexpression(test_table_gsi_2):
     p = random_string()
     x = random_string()
@@ -2318,7 +2318,7 @@ def test_gsi_query_exclusivestartkey_missing_column(test_table_gsi_5):
 # When Query'ing on a certain GSI partition key and/or sort key,
 # ExclusiveStartKey must have the same partition/sort key value.
 # Reproduces issue #26988.
-@pytest.mark.xfail(reason="issue #26988")
+@pytest.mark.xfail(reason="Alternator 'Query' is missing some checks on ExclusiveStartKey #26988")
 def test_gsi_query_exclusivestartkey_wrong_partition(test_table_gsi_5):
     # The error that DynamoDB reports if the wrong partition is mentioned
     # in ExclusiveStartKey is "The provided starting key is outside query
@@ -2369,7 +2369,7 @@ def test_gsi_query_exclusivestartkey_wrong_partition(test_table_gsi_5):
 # Check that ExclusiveStartKey cannot contain any spurious column names
 # beyond the actual primary key columns of the base and the GSI.
 # Reproduces issue #26988.
-@pytest.mark.xfail(reason="issue #26988")
+@pytest.mark.xfail(reason="Alternator 'Query' is missing some checks on ExclusiveStartKey #26988")
 def test_gsi_query_exclusivestartkey_spurious_column(test_table_gsi_5):
     query_args = {
         'ConsistentRead': False,

--- a/test/alternator/test_gsi_updatetable.py
+++ b/test/alternator/test_gsi_updatetable.py
@@ -381,7 +381,7 @@ def test_gsi_creates_and_deletes(dynamodb):
 # skipped while filling the GSI - even if Scylla actually capable of
 # representing such empty view keys (see issue #9375).
 # Reproduces issue #9424.
-@pytest.mark.xfail(reason="issue #9424")
+@pytest.mark.xfail(reason="Faux GSI range key should not be allowed in KeyConditions #9424")
 def test_gsi_backfill_empty_string(dynamodb):
     # First create, and fill, a table without GSI:
     with new_test_table(dynamodb,

--- a/test/alternator/test_lsi.py
+++ b/test/alternator/test_lsi.py
@@ -318,7 +318,7 @@ def test_lsi_describe_indexstatus(test_table_lsi_1):
 # In addition to the basic listing of an LSI in DescribeTable tested above,
 # in this test we check additional fields that should appear in each LSI's
 # description.
-@pytest.mark.xfail(reason="issues #7550, #11466")
+@pytest.mark.xfail(reason="Alternator: missing ItemCount field in return of DescribeTable #7550, Alternator: missing IndexSizeBytes field in return of DescribeTable #11466")
 def test_lsi_describe_fields(test_table_lsi_1):
     desc = test_table_lsi_1.meta.client.describe_table(TableName=test_table_lsi_1.name)
     assert 'Table' in desc

--- a/test/alternator/test_manual_requests.py
+++ b/test/alternator/test_manual_requests.py
@@ -147,7 +147,7 @@ def test_too_large_request_content_length(dynamodb, test_table, mb):
 # we can use the same limit too. In all useful cases, headers will be
 # much shorter.
 # Reproduces #23438.
-@pytest.mark.xfail(reason="issue #23438")
+@pytest.mark.xfail(reason="Alternator should reject requests with very large headers #23438")
 def test_too_large_request_headers(dynamodb, test_table):
     # First prepare a valid signed request, which works:
     req = get_signed_request(dynamodb, 'PutItem',
@@ -177,7 +177,7 @@ def test_too_large_request_headers(dynamodb, test_table):
 # can use the same limit too. In all useful cases, the request line will
 # be much shorter (for ordinary API requests, it is even empty).
 # Reproduces #23438.
-@pytest.mark.xfail(reason="issue #23438")
+@pytest.mark.xfail(reason="Alternator should reject requests with very large headers #23438")
 def test_too_large_request_line(dynamodb, test_table):
     # First prepare a valid signed request, which works:
     req = get_signed_request(dynamodb, 'PutItem',
@@ -594,7 +594,7 @@ def test_keep_alive(dynamodb, test_table, use_keep_alive):
 # We don't want to store the malformed value on disk and only discover the
 # problem when reading the value back. We want the write to fail immediately,
 # and this is what this test checks. Reproduces issue #8070.
-@pytest.mark.xfail(reason="issue #8070")
+@pytest.mark.xfail(reason="Alternator: validate user-provided nested document structure during first write #8070")
 @pytest.mark.parametrize("op", ['PutItem', 'UpdateItem', 'BatchWriteItem'])
 def test_write_malformed_value(dynamodb, test_table_s, op):
     p = random_string()

--- a/test/alternator/test_query.py
+++ b/test/alternator/test_query.py
@@ -395,7 +395,7 @@ def test_query_exclusivestartkey_missing_sortkey(test_table_sn):
 # When Query'ing on the partition key 'right', ExclusiveStartKey must be in
 # the same partition 'right' being queried - it must not be some other
 # partition. Reproduces issue #26988.
-@pytest.mark.xfail(reason="issue #26988")
+@pytest.mark.xfail(reason="Alternator 'Query' is missing some checks on ExclusiveStartKey #26988")
 def test_query_exclusivestartkey_wrong_partition(test_table_sn):
     # The error that DynamoDB reports if the wrong partition is mentioned
     # in ExclusiveStartKey is "The provided starting key is outside query
@@ -410,7 +410,7 @@ def test_query_exclusivestartkey_wrong_partition(test_table_sn):
 # Check that ExclusiveStartKey cannot contain any spurious column names
 # beyond the actual primary key (here a partition key and sort key)
 # Reproduces issue #26988.
-@pytest.mark.xfail(reason="issue #26988")
+@pytest.mark.xfail(reason="Alternator 'Query' is missing some checks on ExclusiveStartKey #26988")
 def test_query_exclusivestartkey_spurious_column(test_table_sn):
     p = random_string()
     # The error that DynamoDB reports if ExclusiveStartKey has spurious
@@ -440,7 +440,7 @@ def test_query_no_sort_key(test_table_s):
 # response shouldn't include the given key, the response would be completely
 # empty...  So DynamoDB doesn't allow this case at all.
 # Reproduces issue #26988.
-@pytest.mark.xfail(reason="issue #26988")
+@pytest.mark.xfail(reason="Alternator 'Query' is missing some checks on ExclusiveStartKey #26988")
 def test_query_no_sort_key_exclusive_start_key(test_table_s):
     p = random_string()
     # DynamoDB gives the error message "The provided exclusive start key

--- a/test/alternator/test_scan.py
+++ b/test/alternator/test_scan.py
@@ -501,7 +501,7 @@ def test_scan_exclusivestartkey_missing_sortkey(filled_test_table):
 # Check that ExclusiveStartKey cannot contain any spurious column names
 # beyond the actual primary key (here a partition key and sort key)
 # Reproduces issue #26988.
-@pytest.mark.xfail(reason="issue #26988")
+@pytest.mark.xfail(reason="Alternator 'Query' is missing some checks on ExclusiveStartKey #26988")
 def test_scan_exclusivestartkey_spurious_column(filled_test_table):
     test_table, items = filled_test_table
     p = random_string()

--- a/test/alternator/test_streams.py
+++ b/test/alternator/test_streams.py
@@ -1050,7 +1050,7 @@ def test_streams_updateitem_identical(test_table_ss_keys_only, test_table_ss_new
 # different serialization (the map's elements are ordered differently).
 # Since the value is nevertheless the same, here too we expect not to see
 # a change event in the stream. Reproduces issue #27375.
-@pytest.mark.xfail(reason="issue #27375")
+@pytest.mark.xfail(reason="Alternator streams may generate event even if item did not really change #27375")
 def test_streams_updateitem_equal_but_not_identical(test_table_ss_keys_only, test_table_ss_new_image, test_table_ss_old_image, test_table_ss_new_and_old_images, dynamodb, dynamodbstreams):
     def do_updates(table, p, c):
         events = []

--- a/test/alternator/test_tag.py
+++ b/test/alternator/test_tag.py
@@ -449,7 +449,7 @@ def test_missing_tag_value(dynamodb, test_table):
 # Reproduces #16908
 @pytest.mark.parametrize("is_ascii", [
         True,
-        pytest.param(False, marks=pytest.mark.xfail(reason="#16908"))])
+        pytest.param(False, marks=pytest.mark.xfail(reason="Alternator TagResource should allow (and count) **unicode** characters #16908"))])
 def test_tag_key_length_128_allowed(dynamodb, test_table, is_ascii):
     client = dynamodb.meta.client
     arn = client.describe_table(TableName=test_table.name)['Table']['TableArn']
@@ -472,7 +472,7 @@ def test_tag_key_length_129_forbidden(dynamodb, test_table):
 # Reproduces #16908
 @pytest.mark.parametrize("is_ascii", [
         True,
-        pytest.param(False, marks=pytest.mark.xfail(reason="#16908"))])
+        pytest.param(False, marks=pytest.mark.xfail(reason="Alternator TagResource should allow (and count) **unicode** characters #16908"))])
 def test_tag_value_length_256_allowed(dynamodb, test_table, is_ascii):
     client = dynamodb.meta.client
     arn = client.describe_table(TableName=test_table.name)['Table']['TableArn']

--- a/test/cluster/dtest/bypass_cache_test.py
+++ b/test/cluster/dtest/bypass_cache_test.py
@@ -184,7 +184,7 @@ class TestBypassCache(Tester):
             session.execute(query.format(idx, varchar_c, varchar_v))
         return session
 
-    @pytest.mark.skip(reason="https://github.com/scylladb/scylladb/issues/6045")
+    @pytest.mark.skip(reason="issue #6045: metric 'select_partition_range_scan' misbehaves: instead of increase by 1 is increasing by 2")
     def test_range_scan_bypass_cache(self):
         session = self.insert_data_for_scan_range()
         node = self.cluster.nodelist()[0]

--- a/test/cluster/mv/test_mv_topology_change.py
+++ b/test/cluster/mv/test_mv_topology_change.py
@@ -258,7 +258,7 @@ async def test_mv_pairing_during_replace(manager: ManagerClient):
 # `rf_rack_valid_keyspaces` is enabled. On the other hand, materialized views in tablet-based keyspaces
 # require the configuration option to be used.
 # Hence, we need to rewrite this test.
-@pytest.mark.skip(reason="scylladb/scylladb#26540")
+@pytest.mark.skip(reason="issue #26540: Re-enable `test_mv_rf_change`")
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_mv_rf_change(manager: ManagerClient, delayed_replica: str, altered_dc: str):
     servers = []

--- a/test/cluster/test_alternator.py
+++ b/test/cluster/test_alternator.py
@@ -1139,7 +1139,7 @@ async def test_zero_token_node_load_balancer(manager, tablets):
     assert got == expected
     table.delete()
 
-@pytest.mark.xfail(reason="#16261")
+@pytest.mark.xfail(reason="LWT: when updating the same partition concurrently, some requests immediately return a timeout. #16261")
 async def test_alternator_concurrent_rmw_same_partition_different_server(manager: ManagerClient):
     """A reproducer for issue #16261: When sending RMW (read-modify-write)
        operations to the same partition (different item) on different server

--- a/test/cluster/test_change_replication_factor_1_to_0.py
+++ b/test/cluster/test_change_replication_factor_1_to_0.py
@@ -22,7 +22,7 @@ logger = logging.getLogger(__name__)
     "use_tablets",
     [
         pytest.param(False, id="vnodes"),
-        pytest.param(True, id="tablets", marks=[pytest.mark.skip(reason="issue #20282"), pytest.mark.nightly]),
+        pytest.param(True, id="tablets", marks=[pytest.mark.skip(reason='issue #20282: (tablets only) All DC nodes got Coredump and error of: "failed to log message: fmt=\\'Requested location for node {} not in topology" on altering keyspace replication-factor of one data-center (out of 2)'), pytest.mark.nightly]),
     ],
 )
 @pytest.mark.asyncio

--- a/test/cluster/test_cluster_features.py
+++ b/test/cluster/test_cluster_features.py
@@ -181,7 +181,7 @@ async def test_downgrade_after_successful_upgrade_fails(manager: ManagerClient) 
             expected_error=f"Feature '{TEST_FEATURE_NAME}' was previously enabled in the cluster")
 
 
-@pytest.mark.skip(reason="issue #14194")
+@pytest.mark.skip(reason="issue #14194: Nodes removed from the cluster may prevent features from being enabled for A_VERY_LONG_TIME (3 days)")
 @pytest.mark.asyncio
 async def test_partial_upgrade_can_be_finished_with_removenode(manager: ManagerClient) -> None:
     """Upgrades all but one node in the cluster to enable the test feature.

--- a/test/cluster/test_incremental_repair.py
+++ b/test/cluster/test_incremental_repair.py
@@ -474,13 +474,13 @@ async def do_test_tablet_incremental_repair_with_split_and_merge(manager, do_spl
 
     await verify_repaired_and_unrepaired_keys(manager, scylla_path, servers, ks, repaired_keys, unrepaired_keys)
 
-@pytest.mark.skip(reason="https://github.com/scylladb/scylladb/issues/24153")
+@pytest.mark.skip(reason="issue #24153: token_group_based_splitting_mutation_writer - Token group id cannot go backwards, current=0, previous=1")
 @pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tablet_incremental_repair_with_split_and_merge(manager: ManagerClient):
     await do_test_tablet_incremental_repair_with_split_and_merge(manager, do_split=True, do_merge=True)
 
-@pytest.mark.skip(reason="https://github.com/scylladb/scylladb/issues/24153")
+@pytest.mark.skip(reason="issue #24153: token_group_based_splitting_mutation_writer - Token group id cannot go backwards, current=0, previous=1")
 @pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tablet_incremental_repair_with_split(manager: ManagerClient):

--- a/test/cluster/test_start_bootstrapped_with_invalid_seed.py
+++ b/test/cluster/test_start_bootstrapped_with_invalid_seed.py
@@ -16,7 +16,7 @@ pytestmark = pytest.mark.prepare_3_nodes_cluster
 
 
 @pytest.mark.asyncio
-@pytest.mark.skip(reason="Test is disabled due to scylladb/scylladb#28153")
+@pytest.mark.skip(reason="Test is disabled due to test_start_bootstrapped_with_invalid_seed is broken in CI #28153")
 async def test_start_bootstrapped_with_invalid_seed(manager: ManagerClient):
     """
     Issue https://github.com/scylladb/scylladb/issues/14945.

--- a/test/cluster/test_tablet_repair_scheduler.py
+++ b/test/cluster/test_tablet_repair_scheduler.py
@@ -117,7 +117,7 @@ async def test_tablet_repair_progress_split(manager: ManagerClient):
     await do_test_tablet_repair_progress_split_merge(manager, do_split=True)
 
 @pytest.mark.asyncio
-@pytest.mark.skip(reason="https://github.com/scylladb/scylladb/issues/26844")
+@pytest.mark.skip(reason="issue #26844: tablet merge does not finish")
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tablet_repair_progress_merge(manager: ManagerClient):
     await do_test_tablet_repair_progress_split_merge(manager, do_merge=True)

--- a/test/cluster/test_tablets_colocation.py
+++ b/test/cluster/test_tablets_colocation.py
@@ -172,7 +172,7 @@ async def test_move_tablet(manager: ManagerClient, move_table: str):
     "with_merge",
     [
         pytest.param(False, id="no_merge"),
-        pytest.param(True, id="with_merge", marks=pytest.mark.xfail(reason="issue #17265")),
+        pytest.param(True, id="with_merge", marks=pytest.mark.xfail(reason="Lowered view consistency during tablet merge (unless replica order is preserved) issue #17265")),
     ],
 )
 async def test_tablet_split_and_merge(manager: ManagerClient, with_merge: bool):

--- a/test/cqlpy/cassandra_tests/functions/cast_fcts_test.py
+++ b/test/cqlpy/cassandra_tests/functions/cast_fcts_test.py
@@ -261,7 +261,7 @@ def testCounterCastsInSelectionClause(cql, test_keyspace):
                    row(2, 2, 2, 2, 2.0, 2.0, Decimal("2"), "2", "2"))
 
 # Verifies that the {@code CAST} function can be used in the values of {@code INSERT INTO} statements.
-@pytest.mark.xfail(reason="issue #14522")
+@pytest.mark.xfail(reason="Support CAST function not only in SELECT #14522")
 def testCastsInInsertIntoValues(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(k int primary key, v int)") as table:
         # Simple cast
@@ -296,7 +296,7 @@ def testCastsInInsertIntoValues(cql, test_keyspace):
         #assertRows(execute(cql, table, "SELECT v FROM %s"), row(6))
 
 # Verifies that the {@code CAST} function can be used in the values of {@code UPDATE} statements.
-@pytest.mark.xfail(reason="issue #14522")
+@pytest.mark.xfail(reason="Support CAST function not only in SELECT #14522")
 def testCastsInUpdateValues(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(k int primary key, v int)") as table:
         # Simple cast
@@ -331,7 +331,7 @@ def testCastsInUpdateValues(cql, test_keyspace):
         #assertRows(execute(cql, table, "SELECT v FROM %s"), row(6))
 
 # Verifies that the {@code CAST} function can be used in the {@code WHERE} clause of {@code UPDATE} statements.
-@pytest.mark.xfail(reason="issue #14522")
+@pytest.mark.xfail(reason="Support CAST function not only in SELECT #14522")
 def testCastsInUpdateWhereClause(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(k int primary key, v int)") as table:
         for i in range(1,7):
@@ -369,7 +369,7 @@ def testCastsInUpdateWhereClause(cql, test_keyspace):
         #assertRows(execute(cql, table, "SELECT v FROM %s WHERE k = ?", 6), row(6))
 
 # Verifies that the {@code CAST} function can be used in the {@code WHERE} clause of {@code SELECT} statements.
-@pytest.mark.xfail(reason="issue #14522")
+@pytest.mark.xfail(reason="Support CAST function not only in SELECT #14522")
 def testCastsInSelectWhereClause(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(k int primary key)") as table:
         for i in range(1,7):
@@ -401,7 +401,7 @@ def testCastsInSelectWhereClause(cql, test_keyspace):
         #assertRows(execute(cql, table, String.format("SELECT k FROM %%s WHERE k = CAST(%s(6) AS int)", intToFloat())), row(6))
 
 # Verifies that the {@code CAST} function can be used in the {@code WHERE} clause of {@code DELETE} statements.
-@pytest.mark.xfail(reason="issue #14522")
+@pytest.mark.xfail(reason="Support CAST function not only in SELECT #14522")
 def testCastsInDeleteWhereClause(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(k int primary key)") as table:
         for i in range(1, 7):
@@ -473,7 +473,7 @@ def testCastsInDeleteWhereClause(cql, test_keyspace):
 #    }
 
 # Verifies that the {@code CAST} function can be used in the {@code WHERE} clause of {@code CREATE MATERIALIZED
-@pytest.mark.xfail(reason="issue #14522")
+@pytest.mark.xfail(reason="Support CAST function not only in SELECT #14522")
 def testCastsInCreateViewWhereClause(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(k int primary key, v int)") as table:
         viewName = test_keyspace + ".mv_with_cast"

--- a/test/cqlpy/cassandra_tests/functions/operation_fcts_test.py
+++ b/test/cqlpy/cassandra_tests/functions/operation_fcts_test.py
@@ -16,7 +16,7 @@ from cassandra.protocol import FunctionFailure
 from cassandra.util import Date
 from datetime import datetime
 
-@pytest.mark.xfail(reason="#2693")
+@pytest.mark.xfail(reason="Support CAST function not only in SELECT #2693")
 def testStringConcatenation(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a text, b ascii, c text, PRIMARY KEY(a, b, c))") as table:
         execute(cql, table, "INSERT INTO %s (a, b, c) VALUES ('जॉन', 'Doe', 'जॉन Doe')")
@@ -28,7 +28,7 @@ def testStringConcatenation(cql, test_keyspace):
         assertRows(execute(cql, table, "SELECT a + ' ' + a, a + ' ' + b, b + ' ' + a, b + ' ' + b FROM %s WHERE a = 'जॉन' AND b = 'Doe' AND c = 'जॉन Doe'"),
             row("जॉन जॉन", "जॉन Doe", "Doe जॉन", "Doe Doe"))
 
-@pytest.mark.xfail(reason="#2693")
+@pytest.mark.xfail(reason="Support CAST function not only in SELECT #2693")
 def testSingleOperations(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a tinyint, b smallint, c int, d bigint, e float, f double, g varint, h decimal, PRIMARY KEY(a, b, c))") as table:
         execute(cql, table, "INSERT INTO %s (a, b, c, d, e, f, g, h) VALUES (1, 2, 3, 4, 5.5, 6.5, 7, 8.5)")
@@ -235,7 +235,7 @@ def testSingleOperations(cql, test_keyspace):
         assertRows(execute(cql, table, "SELECT a + d, b + d, c + d, d + d, e + d, f + d, g + d, h + d FROM %s WHERE a = 1 AND b = 2"),
                    row(None, None, None, None, None, None, None, None))
 
-@pytest.mark.xfail(reason="#2693")
+@pytest.mark.xfail(reason="Support CAST function not only in SELECT #2693")
 def testModuloWithDecimals(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(numerator decimal, dec_mod decimal, int_mod int, bigint_mod bigint, PRIMARY KEY(numerator, dec_mod))") as table:
         execute(cql, table, "INSERT INTO %s (numerator, dec_mod, int_mod, bigint_mod) VALUES (123456789112345678921234567893123456, 2, 2, 2)")
@@ -243,7 +243,7 @@ def testModuloWithDecimals(cql, test_keyspace):
         assertRows(execute(cql, table, "SELECT numerator % dec_mod, numerator % int_mod, numerator % bigint_mod from %s"),
                    row(Decimal("0"), Decimal("0.0"), Decimal("0.0")))
 
-@pytest.mark.xfail(reason="#2693")
+@pytest.mark.xfail(reason="Support CAST function not only in SELECT #2693")
 def testSingleOperationsWithLiterals(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(pk int, c1 tinyint, c2 smallint, v text, PRIMARY KEY(pk, c1, c2))") as table:
         execute(cql, table, "INSERT INTO %s (pk, c1, c2, v) VALUES (2, 2, 2, 'test')")
@@ -483,7 +483,7 @@ def testSingleOperationsWithLiterals(cql, test_keyspace):
         assertRows(execute(cql, table, "SELECT a, b, 1 + 1, 2 - 1, 2 * 2, 2 / 1 , 2 % 1, (int) -1 FROM %s WHERE a = 1 AND b = 2"),
                    row(1, 2, 2, 1, 4, 2, 0, -1))
 
-@pytest.mark.xfail(reason="#2693")
+@pytest.mark.xfail(reason="Support CAST function not only in SELECT #2693")
 def testDivisionWithDecimals(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(numerator decimal, denominator decimal, PRIMARY KEY ((numerator, denominator)))") as table:
         execute(cql, table, "INSERT INTO %s (numerator, denominator) VALUES (8.5, 200000000000000000000000000000000000)")
@@ -493,7 +493,7 @@ def testDivisionWithDecimals(cql, test_keyspace):
                    row(Decimal("0.0000000000000000000000000000000000425")),
                    row(Decimal("3333.33333333333333333333333333333333")))
 
-@pytest.mark.xfail(reason="#2693")
+@pytest.mark.xfail(reason="Support CAST function not only in SELECT #2693")
 def testWithCounters(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a int PRIMARY KEY, b counter)") as table:
         execute(cql, table, "UPDATE %s SET b = b + 1 WHERE a = 1")
@@ -557,7 +557,7 @@ def testWithCounters(cql, test_keyspace):
 
         assertRows(execute(cql, table, "SELECT -b FROM %s WHERE a = 1"), row(-2))
 
-@pytest.mark.xfail(reason="#2693")
+@pytest.mark.xfail(reason="Support CAST function not only in SELECT #2693")
 def testPrecedenceAndParentheses(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a int, b int, c int, d int, PRIMARY KEY (a, b))") as table:
         execute(cql, table, "INSERT INTO %s (a, b, c, d) VALUES (2, 5, 25, 4)")
@@ -618,7 +618,7 @@ def testPrecedenceAndParentheses(cql, test_keyspace):
             assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? AND b = (int) ? / (2 + 2)", 2, 20),
                    row(2, 5, 25, 4))
 
-@pytest.mark.xfail(reason="#2693")
+@pytest.mark.xfail(reason="Support CAST function not only in SELECT #2693")
 def testWithDivisionByZero(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a tinyint, b smallint, c int, d bigint, e float, f double, g varint, h decimal, PRIMARY KEY (a, b))") as table:
         execute(cql, table, "INSERT INTO %s (a, b, c, d, e, f, g, h) VALUES (0, 2, 3, 4, 5.5, 6.5, 7, 8.5)")
@@ -655,7 +655,7 @@ def testWithDivisionByZero(cql, test_keyspace):
                                   OperationExecutionException,
                                   "SELECT h / a FROM %s WHERE a = 0 AND b = 2")
 
-@pytest.mark.xfail(reason="#2693")
+@pytest.mark.xfail(reason="Support CAST function not only in SELECT #2693")
 def testWithNanAndInfinity(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a int PRIMARY KEY, b double, c decimal)") as table:
         assertInvalidMessage(cql, table, "Ambiguous '+' operation with args ? and 1: use type hint to disambiguate, example '(int) ?'",
@@ -702,7 +702,7 @@ def testWithNanAndInfinity(cql, test_keyspace):
                                   OperationExecutionException,
                                   "SELECT c + (float) -INFINITY FROM %s")
 
-@pytest.mark.xfail(reason="#2693")
+@pytest.mark.xfail(reason="Support CAST function not only in SELECT #2693")
 def testInvalidTypes(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a int PRIMARY KEY, b boolean, c text)") as table:
         execute(cql, table, "INSERT INTO %s (a, b, c) VALUES (?, ?, ?)", 1, True, "test")
@@ -718,7 +718,7 @@ def testInvalidTypes(cql, test_keyspace):
         assertInvalidMessage(cql, table, "the '/' operation is not supported between NaN and b", "SELECT NaN / b FROM %s")
         assertInvalidMessage(cql, table, "the '/' operation is not supported between -Infinity and b", "SELECT -Infinity / b FROM %s")
 
-@pytest.mark.xfail(reason="#2693")
+@pytest.mark.xfail(reason="Support CAST function not only in SELECT #2693")
 def testOverflow(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a int PRIMARY KEY, b tinyint, c smallint)") as table:
         execute(cql, table, "INSERT INTO %s (a, b, c) VALUES (?, ?, ?)", 1, 1, 1)
@@ -727,7 +727,7 @@ def testOverflow(cql, test_keyspace):
         assertRows(execute(cql, table, "SELECT a + (int) ?, b + (tinyint) ?, c + (smallint) ? FROM %s", 2147483647, 127, 32767),
                    row(-2147483648, -128, -32768))
 
-@pytest.mark.xfail(reason="#2693")
+@pytest.mark.xfail(reason="Support CAST function not only in SELECT #2693")
 def testOperationsWithDuration(cql, test_keyspace):
     # Test with timestamp type.
     with create_table(cql, test_keyspace, "(pk int, time timestamp, v int, primary key (pk, time))") as table:
@@ -811,7 +811,7 @@ def testOperationsWithDuration(cql, test_keyspace):
                              FunctionFailure,
                              "SELECT * FROM %s WHERE pk = 1 AND time > ? - 10m", Date("2016-10-04"))
 
-@pytest.mark.xfail(reason="#2693")
+@pytest.mark.xfail(reason="Support CAST function not only in SELECT #2693")
 def testFunctionException(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(pk int, c1 int, c2 int, v text, primary key (pk, c1, c2))") as table:
         execute(cql, table, "INSERT INTO %s (pk, c1, c2, v) VALUES (1, 0, 2, 'test')")

--- a/test/cqlpy/cassandra_tests/validation/entities/json_test.py
+++ b/test/cqlpy/cassandra_tests/validation/entities/json_test.py
@@ -137,7 +137,7 @@ def testSelectJsonWithPagingWithFrozenUDT(cql, test_keyspace):
                           ["{\"a\": 1, \"b\": 2, \"c\": [\"1\", \"2\"]}", "[\"" + str(uuid) + "\", 4]", "4"])
 
 # Reproduces issue #7911, #7912, #7914, #7915, #7944, #7954
-@pytest.mark.xfail(reason="issues #7914, #7915, #7944, #7954")
+@pytest.mark.xfail(reason="fromJson() integer overflow should cause an error, not silent wrap-around #7914, fromJson() should accept \"true\" and \"false\" also as strings #7915, fromJson() should not accept the empty string \"\" as a number #7944, fromJson() fails to set null tuple elements #7954")
 def testFromJsonFct(cql, test_keyspace):
     abc_tuple = collections.namedtuple('abc_tuple', ['a', 'b', 'c'])
     with create_type(cql, test_keyspace, "(a int, b uuid, c set<text>)") as type_name:
@@ -683,7 +683,7 @@ class EquivalentIp:
         return f'EquivalentIp("{self.obj}")'
 
 # Reproduces issue #7972, #7988, #7997, #8001
-@pytest.mark.xfail(reason="issues #7997, #8001")
+@pytest.mark.xfail(reason="toJson() is missing a timezone on timestamp #7997, Documented unit \"µs\" not supported for assigning a \"duration\" type #8001")
 def testToJsonFct(cql, test_keyspace):
     abc_tuple = collections.namedtuple('abc_tuple', ['a', 'b', 'c'])
     with create_type(cql, test_keyspace, "(a int, b uuid, c set<text>)") as type_name:
@@ -996,7 +996,7 @@ def testSelectJsonSyntax(cql, test_keyspace):
                 ["{\"system.tojson(system.blobasint(system.intasblob(v)))\": \"1\"}"])
 
 # Reproduces issues #8085
-@pytest.mark.xfail(reason="issues #8085")
+@pytest.mark.xfail(reason="INSERT JSON with bad arguments should yield InvalidRequest error, not internal error #8085")
 def testInsertJsonSyntax(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(k int primary key, v int)") as table:
         execute(cql, table, "INSERT INTO %s JSON ?", "{\"k\": 0, \"v\": 0}")
@@ -1062,7 +1062,7 @@ def testInsertJsonSyntaxDefaultUnset(cql, test_keyspace):
         assert_rows(execute(cql, table, "SELECT * FROM %s WHERE k=2"), [2, None, None])
 
 # Reproduces issues #8078, #8086
-@pytest.mark.xfail(reason="issues #8086")
+@pytest.mark.xfail(reason="INSERT JSON cannot handle user-defined types with case-sensitive component names #8086")
 def testCaseSensitivity(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(k int primary key, \"Foo\" int)") as table:
         execute(cql, table, "INSERT INTO %s JSON ?", "{\"k\": 0, \"\\\"Foo\\\"\": 0}")
@@ -1120,7 +1120,7 @@ def testInsertJsonSyntaxWithCollections(cql, test_keyspace):
         assert_rows(execute(cql, table, "SELECT k, lf FROM %s"), [0, [1, 2, 3]])
 
 # Reproduces issue #8087
-@pytest.mark.xfail(reason="issue #8087")
+@pytest.mark.xfail(reason="SELECT JSON incorrectly quotes strings inside map keys #8087")
 def testInsertJsonSyntaxWithNonNativeMapKeys(cql, test_keyspace):
     # JSON doesn't allow non-string keys, so we accept string representations of any type as map keys and
     # return maps with string keys when necessary.
@@ -1229,7 +1229,7 @@ def testInsertJsonSyntaxWithTuplesAndUDTs(cql, test_keyspace):
             execute(cql, table, "INSERT INTO %s JSON ?", "{\"k\": 0, \"a\": {\"a\": 0, \"b\": [1, 2, 3], \"c\": null}, \"b\": null}")
 
 # done for CASSANDRA-11146
-@pytest.mark.xfail(reason="issue #8092")
+@pytest.mark.xfail(reason="SELECT JSON missing null component after adding field to UDT definition #8092")
 def testAlterUDT(cql, test_keyspace):
     with create_type(cql, test_keyspace, "(a int)") as type_name:
         with create_table(cql, test_keyspace, "(" +
@@ -1268,7 +1268,7 @@ def testEmptyStringJsonSerialization(cql, test_keyspace):
 # implementation not only fails to produce the right results, it reads
 # already-freed memory to do so, which crashes the debug build with the
 # sanitizer enabled.
-@pytest.mark.skip(reason="issue #8100")
+@pytest.mark.skip(reason="SELECT JSON with IN and ORDER BY does not obey the ORDER BY #8100")
 def testJsonOrdering(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a INT, b INT, PRIMARY KEY(a, b))") as table:
         execute(cql, table, "INSERT INTO %s(a, b) VALUES (20, 30);")

--- a/test/cqlpy/cassandra_tests/validation/entities/secondary_index_test.py
+++ b/test/cqlpy/cassandra_tests/validation/entities/secondary_index_test.py
@@ -451,7 +451,7 @@ TOO_BIG = 1024 * 65
 # make sure we check conditional and unconditional statements,
 # both singly and in batches (CASSANDRA-10536)
 # Reproduces #8627
-@pytest.mark.xfail(reason="issue #8627")
+@pytest.mark.xfail(reason="Comparison with UNSET_VALUE should produce an error #8627")
 @pytest.mark.parametrize("test_keyspace",
                          ["tablets", "vnodes"],
                          indirect=True)
@@ -510,7 +510,7 @@ def testIndexOnPartitionKeyInsertValueOver64k(cql, test_keyspace):
         #}
 
 # Reproduces issue #8708:
-@pytest.mark.xfail(reason="issue #8708")
+@pytest.mark.xfail(reason="Secondary index is missing partitions with only a static row #8708")
 def testIndexOnPartitionKeyWithStaticColumnAndNoRows(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(pk1 int, pk2 int, c int, s int static, v int, PRIMARY KEY((pk1, pk2), c))") as table:
         execute(cql, table, "CREATE INDEX ON %s (pk2)")
@@ -565,7 +565,7 @@ def testIndexOnClusteringColumnInsertValueOver64k(cql, test_keyspace):
         #}
 
 # Reproduces #8627
-@pytest.mark.xfail(reason="issue #8627")
+@pytest.mark.xfail(reason="Comparison with UNSET_VALUE should produce an error #8627")
 @pytest.mark.parametrize("test_keyspace",
                          ["tablets", "vnodes"],
                          indirect=True)
@@ -587,7 +587,7 @@ def testIndexOnFullCollectionEntryInsertCollectionValueOver64k(cql, test_keyspac
                    "INSERT INTO %s (a, b) VALUES (0, ?) IF NOT EXISTS;\n" +
                    "APPLY BATCH", map)
 
-@pytest.mark.xfail(reason="issue #2203")
+@pytest.mark.xfail(reason="Secondary index CREATE INDEX syntax is missing the \"values\" option #2203")
 def testPrepareStatementsWithLIKEClauses(cql, test_keyspace):
     SASI = 'org.apache.cassandra.index.sasi.SASIIndex'
     with create_table(cql, test_keyspace, "(a int, c1 text, c2 text, v1 text, v2 text, v3 int, PRIMARY KEY (a, c1, c2))") as table:
@@ -696,7 +696,7 @@ def testIndexesOnNonStaticColumnsWhereSchemaIncludesStaticColumns(cql, test_keys
 # Reproduces Scylla issues #4244 (mixing single-column and multi-columns
 # restriction) and #8711 (Finding or filtering with an empty string with
 # a secondary index seems to be broken).
-@pytest.mark.xfail(reason="issues #4244, #8711")
+@pytest.mark.xfail(reason="Add support for mixing token, multi- and single-column restrictions #4244, Finding or filtering with an empty string with a secondary index seems to be broken #8711")
 def testWithEmptyRestrictionValueAndSecondaryIndex(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(pk blob, c blob, v blob, PRIMARY KEY ((pk), c))") as table:
         execute(cql, table, "CREATE INDEX ON %s(c)")
@@ -1026,7 +1026,7 @@ def testIndexOnNonFrozenCollectionOfFrozenUDT(cql, test_keyspace):
             assert_invalid_message(cql, table, "ALLOW FILTERING",
                              "SELECT * FROM %s WHERE v CONTAINS ?", udt1)
 
-@pytest.mark.xfail(reason="#8745")
+@pytest.mark.xfail(reason="Secondary index CREATE INDEX syntax is missing the \"values\" option #8745")
 def testIndexOnNonFrozenUDT(cql, test_keyspace):
     with create_type(cql, test_keyspace, "(a int)") as t:
         with create_table(cql, test_keyspace, f"(k int PRIMARY KEY, v {t})") as table:

--- a/test/cqlpy/cassandra_tests/validation/entities/type_test.py
+++ b/test/cqlpy/cassandra_tests/validation/entities/type_test.py
@@ -20,7 +20,7 @@ def testNonExistingOnes(cql, test_keyspace):
     # reported instead of just doing nothing:
     execute(cql, test_keyspace, "DROP TYPE IF EXISTS keyspace_does_not_exist.type_does_not_exist")
 
-@pytest.mark.skip(reason="Issue #9300")
+@pytest.mark.skip(reason="testNowToUUIDCompatibility is flaky #9300")
 def testNowToUUIDCompatibility(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a int, b uuid, PRIMARY KEY (a, b))") as table:
         execute(cql, table, "INSERT INTO %s (a, b) VALUES (0, now())")
@@ -33,7 +33,7 @@ def testDateCompatibility(cql, test_keyspace):
         execute(cql, table, "INSERT INTO %s (a, b, c, d) VALUES (1, unixTimestampOf(now()), dateOf(now()), dateOf(now()))")
         assert len(list(execute(cql, table, "SELECT * FROM %s WHERE a=1 AND b <= toUnixTimestamp(now())"))) == 1
 
-@pytest.mark.skip(reason="Issue #9300")
+@pytest.mark.skip(reason="testNowToUUIDCompatibility is flaky #9300")
 def testReversedTypeCompatibility(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a int, b timeuuid, PRIMARY KEY (a, b)) WITH CLUSTERING ORDER BY (b DESC)") as table:
         execute(cql, table, "INSERT INTO %s (a, b) VALUES (0, now())")

--- a/test/cqlpy/cassandra_tests/validation/entities/uf_types_test.py
+++ b/test/cqlpy/cassandra_tests/validation/entities/uf_types_test.py
@@ -35,7 +35,7 @@ def read_function_from_file(file_name, wasm_name=None, udf_name=None):
         print(f"Can't open {wat_path}.\nPlease build Wasm examples.")
         exit(1)
 
-@pytest.mark.skip(reason="Issue #22799")
+@pytest.mark.skip(reason="CI regression in test - uf_types_test test_complex_null_values #22799")
 def test_complex_null_values(cql, test_keyspace):
     with create_type(cql, test_keyspace, "(txt text, i int)") as type:
         schema = f"(key int primary key, lst list<double>, st set<text>, mp map<int, boolean>, tup frozen<tuple<double, text, int, boolean>>, udt frozen<{type}>)"
@@ -163,10 +163,10 @@ def test_types_with_and_without_nulls(cql, test_keyspace):
                     assertRows(execute(cql, table, f"SELECT {fun_name}({type_def.column_name}) FROM %s WHERE key = 1"), row("called"))
                     assertRows(execute(cql, table, f"SELECT {fun_name}({type_def.column_name}) FROM %s WHERE key = 2"), row(None))
 
-@pytest.mark.skip(reason="Issue #13746")
-@pytest.mark.xfail(reason="Issue #13855")
-@pytest.mark.xfail(reason="Issue #13860")
-@pytest.mark.xfail(reason="Issue #13866")
+@pytest.mark.skip(reason="UDF can only be used in SELECT, and abort when used in WHERE, or in INSERT/UPDATE/DELETE commands #13746")
+@pytest.mark.xfail(reason="UDF with a non-frozen collection parameter cannot be called on a frozen value #13855")
+@pytest.mark.xfail(reason="A non-frozen collection returned by a UDF cannot be used as a frozen one #13860")
+@pytest.mark.xfail(reason="Argument and return types in UDFs can be frozen #13866")
 def test_function_with_frozen_set_type(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a int PRIMARY KEY, b frozen<set<int>>)") as table:
         with new_secondary_index(cql, table, "FULL(b)"):
@@ -200,10 +200,10 @@ def test_function_with_frozen_set_type(cql, test_keyspace):
 
             assertInvalidMessage(cql, "", "cannot be frozen", f"DROP FUNCTION {test_keyspace}.{ret_name}(frozen<set<int>>)")
 
-@pytest.mark.skip(reason="Issue #13746")
-@pytest.mark.xfail(reason="Issue #13855")
-@pytest.mark.xfail(reason="Issue #13860")
-@pytest.mark.xfail(reason="Issue #13866")
+@pytest.mark.skip(reason="UDF can only be used in SELECT, and abort when used in WHERE, or in INSERT/UPDATE/DELETE commands #13746")
+@pytest.mark.xfail(reason="UDF with a non-frozen collection parameter cannot be called on a frozen value #13855")
+@pytest.mark.xfail(reason="A non-frozen collection returned by a UDF cannot be used as a frozen one #13860")
+@pytest.mark.xfail(reason="Argument and return types in UDFs can be frozen #13866")
 def test_function_with_frozen_list_type(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a int PRIMARY KEY, b frozen<list<int>>)") as table:
         with new_secondary_index(cql, table, "FULL(b)"):
@@ -237,10 +237,10 @@ def test_function_with_frozen_list_type(cql, test_keyspace):
 
             assertInvalidMessage(cql, "", "cannot be frozen", f"DROP FUNCTION {test_keyspace}.{ret_name}(frozen<list<int>>)")
 
-@pytest.mark.skip(reason="Issue #13746")
-@pytest.mark.xfail(reason="Issue #13855")
-@pytest.mark.xfail(reason="Issue #13860")
-@pytest.mark.xfail(reason="Issue #13866")
+@pytest.mark.skip(reason="UDF can only be used in SELECT, and abort when used in WHERE, or in INSERT/UPDATE/DELETE commands #13746")
+@pytest.mark.xfail(reason="UDF with a non-frozen collection parameter cannot be called on a frozen value #13855")
+@pytest.mark.xfail(reason="A non-frozen collection returned by a UDF cannot be used as a frozen one #13860")
+@pytest.mark.xfail(reason="Argument and return types in UDFs can be frozen #13866")
 def test_function_with_frozen_map_type(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a int PRIMARY KEY, b frozen<map<int, int>>)") as table:
         with new_secondary_index(cql, table, "FULL(b)"):
@@ -274,7 +274,7 @@ def test_function_with_frozen_map_type(cql, test_keyspace):
 
             assertInvalidMessage(cql, "", "cannot be frozen", f"DROP FUNCTION {test_keyspace}.{ret_name}(frozen<map<int, int>>)")
 
-@pytest.mark.skip(reason="Issue #13746")
+@pytest.mark.skip(reason="UDF can only be used in SELECT, and abort when used in WHERE, or in INSERT/UPDATE/DELETE commands #13746")
 def test_function_with_frozen_tuple_type(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a int PRIMARY KEY, b frozen<tuple<int, int>>)") as table:
         with new_secondary_index(cql, table, "b"):
@@ -311,7 +311,7 @@ def test_function_with_frozen_tuple_type(cql, test_keyspace):
             cql.execute(f"DROP FUNCTION {test_keyspace}.{fun_name} (frozen<tuple<int, int>>)")
             assertRowCount(cql.execute(f"SELECT * from system_schema.functions WHERE keyspace_name = '{test_keyspace}' AND function_name = '{fun_name}'"), 0)
 
-@pytest.mark.skip(reason="Issue #13746")
+@pytest.mark.skip(reason="UDF can only be used in SELECT, and abort when used in WHERE, or in INSERT/UPDATE/DELETE commands #13746")
 def test_function_with_frozen_udt_type(cql, test_keyspace):
     with create_type(cql, test_keyspace, "(f int)") as type:
         with create_table(cql, test_keyspace, f"(a int PRIMARY KEY, b frozen<{type}>)") as table:

--- a/test/cqlpy/cassandra_tests/validation/operations/alter_test.py
+++ b/test/cqlpy/cassandra_tests/validation/operations/alter_test.py
@@ -93,7 +93,7 @@ def testDropWithTimestamp(cql, test_keyspace):
                [1, 4, 4, 4],
                [1, 100, 100, 100])
 
-@pytest.mark.xfail(reason="Issue #9930")
+@pytest.mark.xfail(reason="Incorrect sort order when combining IN, and ORDER BY #9930")
 def testDropAddWithDifferentKind(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a int, b int, c int, d int static,  PRIMARY KEY (a, b))") as table:
         execute(cql, table, "ALTER TABLE %s DROP c")
@@ -168,7 +168,7 @@ def testAlterIndexInterval(cql, test_keyspace):
 
 # Migrated from cql_tests.py:TestCQL.create_alter_options_test()
 # Reproduces #9935
-@pytest.mark.xfail(reason="Issue #9935")
+@pytest.mark.xfail(reason="Incorrect sort order when combining IN, GROUP BY and ORDER BY #9935")
 def testCreateAlterKeyspaces(cql, test_keyspace, this_dc):
     # ScyllaDB allows default parameters on CREATE KEYSPACE, so these checks
     # are no longer valid:
@@ -272,7 +272,7 @@ def testDoubleWith(cql, test_keyspace):
     for stmt in stmts:
         assert_invalid_throw(cql, test_keyspace, SyntaxException, stmt)
 
-@pytest.mark.xfail(reason="Issue #8948")
+@pytest.mark.xfail(reason="Cassandra 3.11.10 uses \"class\" instead of \"sstable_compression\" for compression settings by default #8948")
 def testAlterTableWithCompression(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a text, b int, c int, primary key (a, b))") as table:
         [ks, cf] = table.split('.')

--- a/test/cqlpy/cassandra_tests/validation/operations/compact_storage_test.py
+++ b/test/cqlpy/cassandra_tests/validation/operations/compact_storage_test.py
@@ -91,7 +91,7 @@ def testCompactCollections(cql, test_keyspace):
 
 # Check for a table with counters,
 # migrated from cql_tests.py:TestCQL.counters_test()
-@pytest.mark.skip(reason="Cassandra 3.10's += syntax not yet supported. Issue #7735")
+@pytest.mark.skip(reason="Cassandra 3.10's += syntax not yet supported. Issue #7735: CQL parser missing support for Cassandra 3.10's new \"+=\" syntax")
 def testCounters(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(userid int, url text, total counter, PRIMARY KEY (userid, url)) WITH COMPACT STORAGE") as table:
         execute(cql, table, "UPDATE %s SET total = total + 1 WHERE userid = 1 AND url = 'http://foo.com'")
@@ -623,7 +623,7 @@ TOO_BIG = 1024 * 65
 
 # from SecondaryIndexTest
 # Reproduces #8627
-@pytest.mark.xfail(reason="issue #8627")
+@pytest.mark.xfail(reason="Comparison with UNSET_VALUE should produce an error #8627")
 def testCompactTableWithValueOver64k(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a int,  b blob, PRIMARY KEY (a)) WITH COMPACT STORAGE") as table:
         execute(cql, table, "CREATE INDEX ON %s(b)")
@@ -760,7 +760,7 @@ def testFunctionsWithCompactStorage(cql, test_keyspace):
                    row(3, 2, 5, 2, 9.5, 18.5, 9.25))
 
 # BatchTest
-@pytest.mark.skip(reason="issue #12471")
+@pytest.mark.skip(reason="issue #12471: Range deletions on COMPACT STORAGE is not supported")
 def testBatchRangeDelete(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(partitionKey int, clustering int, value int, primary key (partitionKey, clustering)) WITH COMPACT STORAGE") as table:
         value = 0
@@ -1058,7 +1058,7 @@ def testDeleteWithOneClusteringColumns(cql, test_keyspace, forceFlush):
         assertInvalidMessage(cql, table, "value",
                              "DELETE FROM %s WHERE partitionKey = ? AND clustering = ? AND value = ?", 0, 1, 3)
 
-@pytest.mark.xfail(reason="issue #4244")
+@pytest.mark.xfail(reason="one-element multi-column restriction should be handled like a single-column restriction #4244")
 @pytest.mark.parametrize("forceFlush", [False, True])
 def testDeleteWithTwoClusteringColumns(cql, test_keyspace, forceFlush):
     with create_table(cql, test_keyspace, "(partitionKey int, clustering_1 int, clustering_2 int, value int, PRIMARY KEY (partitionKey, clustering_1, clustering_2)) WITH COMPACT STORAGE") as table:
@@ -1255,7 +1255,7 @@ def testCompactStorage(cql, test_keyspace):
         assert_rows2(execute(cql, table, "INSERT INTO %s (partition, key, owner) VALUES ('a', 'c', 'x') IF NOT EXISTS"), [row(True)], [row(True,None,None,None)])
 
 # SelectGroupByTest
-@pytest.mark.xfail(reason="issue #4244")
+@pytest.mark.xfail(reason="one-element multi-column restriction should be handled like a single-column restriction #4244")
 def testGroupByWithoutPaging(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a int, b int, c int, d int, e int, PRIMARY KEY (a, b, c, d)) WITH COMPACT STORAGE") as table:
         execute(cql, table, "INSERT INTO %s (a, b, c, d, e) VALUES (1, 2, 1, 3, 6)")
@@ -2140,7 +2140,7 @@ def testSelectDistinct(cql, test_keyspace):
 
 REQUIRES_ALLOW_FILTERING_MESSAGE = "Cannot execute this query as it might involve data filtering and thus may have unpredictable performance. If you want to execute this query despite the performance unpredictability, use ALLOW FILTERING"
 
-@pytest.mark.skip(reason="issue #12526")
+@pytest.mark.skip(reason="issue #12526: Support filtering on COMPACT tables")
 def testFilteringOnCompactTablesWithoutIndices(cql, test_keyspace):
     # Test COMPACT table with clustering columns
     with create_table(cql, test_keyspace, "(a int, b int, c int, PRIMARY KEY (a, b)) WITH COMPACT STORAGE") as table:
@@ -2278,7 +2278,7 @@ def testFilteringOnCompactTablesWithoutIndices(cql, test_keyspace):
                              "SELECT * FROM %s WHERE c > ? ALLOW FILTERING",
                              unset())
 
-@pytest.mark.skip(reason="issue #12526")
+@pytest.mark.skip(reason="issue #12526: Support filtering on COMPACT tables")
 def testFilteringOnCompactTablesWithoutIndicesAndWithLists(cql, test_keyspace):
     # Test COMPACT table with clustering columns
     with create_table(cql, test_keyspace, "(a int, b int, c frozen<list<int>>, PRIMARY KEY (a, b)) WITH COMPACT STORAGE") as table:
@@ -2426,7 +2426,7 @@ def testFilteringOnCompactTablesWithoutIndicesAndWithLists(cql, test_keyspace):
                              "SELECT * FROM %s WHERE c CONTAINS ? ALLOW FILTERING",
                              unset())
 
-@pytest.mark.skip(reason="issue #12526")
+@pytest.mark.skip(reason="issue #12526: Support filtering on COMPACT tables")
 def testFilteringOnCompactTablesWithoutIndicesAndWithSets(cql, test_keyspace):
     # Test COMPACT table with clustering columns
     with create_table(cql, test_keyspace, "(a int, b int, c frozen<set<int>>, PRIMARY KEY (a, b)) WITH COMPACT STORAGE") as table:
@@ -2609,7 +2609,7 @@ def executeFilteringOnly(cql, table, statement):
     assert_invalid(cql, table, statement)
     return execute_without_paging(cql, table, statement + " ALLOW FILTERING")
 
-@pytest.mark.skip(reason="issue #12526")
+@pytest.mark.skip(reason="issue #12526: Support filtering on COMPACT tables")
 def testAllowFilteringOnPartitionKeyWithCounters(cql, test_keyspace):
     for compactStorageClause in ["", " WITH COMPACT STORAGE"]:
         with create_table(cql, test_keyspace, "(a int, b int, c int, cnt counter, PRIMARY KEY ((a, b), c)) " + compactStorageClause) as table:
@@ -2643,7 +2643,7 @@ def testAllowFilteringOnPartitionKeyWithCounters(cql, test_keyspace):
                            row(21, 22, 23, 24),
                            row(21, 22, 26, 27))
 
-@pytest.mark.skip(reason="issue #12526")
+@pytest.mark.skip(reason="issue #12526: Support filtering on COMPACT tables")
 def testAllowFilteringOnPartitionKeyOnCompactTablesWithoutIndicesAndWithLists(cql, test_keyspace):
     # Test COMPACT table with clustering columns
     with create_table(cql, test_keyspace, "(a int, b int, c frozen<list<int>>, PRIMARY KEY (a, b)) WITH COMPACT STORAGE") as table:
@@ -2791,7 +2791,7 @@ def testAllowFilteringOnPartitionKeyOnCompactTablesWithoutIndicesAndWithLists(cq
                              unset())
 
 
-@pytest.mark.skip(reason="issue #12526")
+@pytest.mark.skip(reason="issue #12526: Support filtering on COMPACT tables")
 def testAllowFilteringOnPartitionKeyOnCompactTablesWithoutIndicesAndWithMaps(cql, test_keyspace):
     # Test COMPACT table with clustering columns
     with create_table(cql, test_keyspace, "(a int, b int, c frozen<map<int, int>>, PRIMARY KEY (a, b)) WITH COMPACT STORAGE") as table:
@@ -2953,7 +2953,7 @@ def testAllowFilteringOnPartitionKeyOnCompactTablesWithoutIndicesAndWithMaps(cql
                              "SELECT * FROM %s WHERE a >= 1 AND c CONTAINS KEY ? ALLOW FILTERING",
                              unset())
 
-@pytest.mark.skip(reason="issue #12526")
+@pytest.mark.skip(reason="issue #12526: Support filtering on COMPACT tables")
 def testAllowFilteringOnPartitionKeyOnCompactTablesWithoutIndicesAndWithSets(cql, test_keyspace):
     # Test COMPACT table with clustering columns
     with create_table(cql, test_keyspace, "(a int, b int, c frozen<set<int>>, PRIMARY KEY (a, b)) WITH COMPACT STORAGE") as table:
@@ -3103,7 +3103,7 @@ def testAllowFilteringOnPartitionKeyOnCompactTablesWithoutIndicesAndWithSets(cql
                              "SELECT * FROM %s WHERE a >= 1 AND c CONTAINS ? ALLOW FILTERING",
                              unset())
 
-@pytest.mark.skip(reason="issue #12526")
+@pytest.mark.skip(reason="issue #12526: Support filtering on COMPACT tables")
 def testAllowFilteringOnPartitionKeyOnCompactTablesWithoutIndices(cql, test_keyspace):
     # Test COMPACT table with clustering columns
     with create_table(cql, test_keyspace, "(a int, b int, c int, d int, PRIMARY KEY ((a, b), c)) WITH COMPACT STORAGE") as table:
@@ -3422,7 +3422,7 @@ def testFilteringOnCompactTablesWithoutIndicesAndWithMaps(cql, test_keyspace):
                              "SELECT * FROM %s WHERE c CONTAINS KEY ? ALLOW FILTERING",
                              unset())
 
-@pytest.mark.skip(reason="issue #12526")
+@pytest.mark.skip(reason="issue #12526: Support filtering on COMPACT tables")
 def testFilteringOnCompactTable(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a int, b int, c int, d int, PRIMARY KEY (a, b, c)) WITH COMPACT STORAGE") as table:
         execute(cql, table, "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)", 11, 12, 13, 14)
@@ -3510,7 +3510,7 @@ def testFilteringOnCompactTable(cql, test_keyspace):
             assert_rows(executeFilteringOnly(cql, table, "SELECT * FROM %s WHERE b > 12 AND c < 25 AND d CONTAINS 2"),
                        row(21, 22, 23, [2, 4]))
 
-@pytest.mark.skip(reason="issue #12526")
+@pytest.mark.skip(reason="issue #12526: Support filtering on COMPACT tables")
 def testFilteringWithCounters(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a int, b int, c int, cnt counter, PRIMARY KEY (a, b, c)) WITH COMPACT STORAGE") as table:
         execute(cql, table, "UPDATE %s SET cnt = cnt + ? WHERE a = ? AND b = ? AND c = ?", 14, 11, 12, 13)
@@ -3591,7 +3591,7 @@ def testClusteringOrderWithSlice(cql, test_keyspace):
 
 EMPTY_BYTE_BUFFER = b""
 
-@pytest.mark.parametrize("options", ["", pytest.param(" WITH COMPACT STORAGE", marks=pytest.mark.skip(reason="issue #12526, #12749"))])
+@pytest.mark.parametrize("options", ["", pytest.param(" WITH COMPACT STORAGE", marks=pytest.mark.skip(reason="issue #12526: Support filtering on COMPACT tables, #12749: Unsupported empty clustering key in COMPACT table"))])
 def testEmptyRestrictionValue(cql, test_keyspace, options):
     with create_table(cql, test_keyspace, "(pk blob, c blob, v blob, PRIMARY KEY ((pk), c))" + options) as table:
         execute(cql, table, "INSERT INTO %s (pk, c, v) VALUES (?, ?, ?)",
@@ -3712,7 +3712,7 @@ def testEmptyRestrictionValue(cql, test_keyspace, options):
             assert_rows(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND v = textAsBlob('') ALLOW FILTERING;"),
                        row(b"foo123", b"3", EMPTY_BYTE_BUFFER))
 
-@pytest.mark.skip(reason="issue #12749")
+@pytest.mark.skip(reason="issue #12749: Unsupported empty clustering key in COMPACT table")
 def testEmptyRestrictionValueWithMultipleClusteringColumns(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(pk blob, c1 blob, c2 blob, v blob, PRIMARY KEY (pk, c1, c2)) WITH COMPACT STORAGE") as table:
         execute(cql, table, "INSERT INTO %s (pk, c1, c2, v) VALUES (?, ?, ?, ?)", b"foo123", b"1", b"1", b"1")
@@ -3790,7 +3790,7 @@ def testEmptyRestrictionValueWithMultipleClusteringColumns(cql, test_keyspace):
 
             assertEmpty(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND (c1, c2) < (textAsBlob(''), textAsBlob('1'));"))
 
-@pytest.mark.skip(reason="issue #12749")
+@pytest.mark.skip(reason="issue #12749: Unsupported empty clustering key in COMPACT table")
 @pytest.mark.parametrize("options", [" WITH COMPACT STORAGE", " WITH COMPACT STORAGE AND CLUSTERING ORDER BY (c DESC)"])
 def testEmptyRestrictionValueWithOrderBy(cql, test_keyspace, options):
     orderingClause = "" if "ORDER" in options else "ORDER BY c DESC"
@@ -3824,7 +3824,7 @@ def testEmptyRestrictionValueWithOrderBy(cql, test_keyspace, options):
                              EMPTY_BYTE_BUFFER,
                              b"4")
 
-@pytest.mark.skip(reason="issue #12749")
+@pytest.mark.skip(reason="issue #12749: Unsupported empty clustering key in COMPACT table")
 @pytest.mark.parametrize("options", [" WITH COMPACT STORAGE", " WITH COMPACT STORAGE AND CLUSTERING ORDER BY (c1 DESC, c2 DESC)"])
 def testEmptyRestrictionValueWithMultipleClusteringColumnsAndOrderBy(cql, test_keyspace, options):
     orderingClause = "" if "ORDER" in options else "ORDER BY c1 DESC, c2 DESC"
@@ -4215,7 +4215,7 @@ def testDeleteWithCompactStaticFormat(cql, test_keyspace):
 
 # Test for CASSANDRA-13917
 # Reproduces #12815
-@pytest.mark.skip(reason="issue #12815")
+@pytest.mark.skip(reason="issue #12815: Hidden column \"value\" in compact table isn't completely hidden")
 def testDeleteWithCompactNonStaticFormat(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a int, b int, PRIMARY KEY (a, b)) WITH COMPACT STORAGE") as table:
         execute(cql, table, "INSERT INTO %s (a, b) VALUES (1, 1)")
@@ -4265,7 +4265,7 @@ def testInsertWithCompactStaticFormat(cql, test_keyspace):
 # Test for CASSANDRA-13917
 # Reproduces #12815.
 # Because it currently crashes Scylla we have to skip it instead of xfail...
-@pytest.mark.skip(reason="issue #12815")
+@pytest.mark.skip(reason="issue #12815: Hidden column \"value\" in compact table isn't completely hidden")
 def testInsertWithCompactNonStaticFormat(cql, test_keyspace):
     do_testInsertWithCompactTable(cql, test_keyspace, "(a int, b int, PRIMARY KEY (a, b)) WITH COMPACT STORAGE")
     do_testInsertWithCompactTable(cql, test_keyspace, "(a int, b int, v int, PRIMARY KEY (a, b)) WITH COMPACT STORAGE")
@@ -4339,7 +4339,7 @@ def testSelectWithCompactStaticFormat(cql, test_keyspace):
 # Test for CASSANDRA-13917
 # Reproduces #12815.
 # Because it currently crashes Scylla we have to skip it instead of xfail...
-@pytest.mark.skip(reason="issue #12815")
+@pytest.mark.skip(reason="issue #12815: Hidden column \"value\" in compact table isn't completely hidden")
 def testSelectWithCompactNonStaticFormat(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a int, b int, PRIMARY KEY (a,b)) WITH COMPACT STORAGE") as table:
         execute(cql, table, "INSERT INTO %s (a, b) VALUES (1, 1)")
@@ -4403,7 +4403,7 @@ def testUpdateWithCompactStaticFormat(cql, test_keyspace):
 # Test for CASSANDRA-13917
 # Reproduces #12815.
 # Because it currently crashes Scylla we have to skip it instead of xfail...
-@pytest.mark.skip(reason="issue #12815")
+@pytest.mark.skip(reason="issue #12815: Hidden column \"value\" in compact table isn't completely hidden")
 def testUpdateWithCompactNonStaticFormat(cql, test_keyspace):
     do_testUpdateWithCompactFormat(cql, test_keyspace, "(a int, b int, PRIMARY KEY (a, b)) WITH COMPACT STORAGE")
     do_testUpdateWithCompactFormat(cql, test_keyspace, "(a int, b int, v int, PRIMARY KEY (a, b)) WITH COMPACT STORAGE")

--- a/test/cqlpy/cassandra_tests/validation/operations/cql_vector_test.py
+++ b/test/cqlpy/cassandra_tests/validation/operations/cql_vector_test.py
@@ -338,7 +338,7 @@ def test_emptyValues(cql, test_keyspace):
 #         assertRows(execute("SELECT f([1.0, 2.0], value) FROM %s"), expected);
 #     }
 
-@pytest.mark.xfail(reason="Issue #5411")
+@pytest.mark.xfail(reason="Dist: deb - enable coredumps #5411")
 def test_token(cql , test_keyspace):
     with create_table(cql, test_keyspace, "(pk vector<int, 2> primary key)") as table:
 

--- a/test/cqlpy/cassandra_tests/validation/operations/create_test.py
+++ b/test/cqlpy/cassandra_tests/validation/operations/create_test.py
@@ -61,7 +61,7 @@ def testCreateTinyintColumns(cql, test_keyspace):
         #assertInvalidMessage(cql, table, "Expected 1 byte for a tinyint (0)",
         #                     "INSERT INTO %s (a, b, c) VALUES (?, ?, ?)", "3", (byte) 1, ByteBufferUtil.EMPTY_BYTE_BUFFER)
 
-@pytest.mark.xfail(reason="Issue #8001")
+@pytest.mark.xfail(reason="Documented unit \"µs\" not supported for assigning a \"duration\" type #8001")
 def testCreateTableWithDurationColumns(cql, test_keyspace):
     t = unique_name()
     # Messages in Scylla and Cassandra are slightly different - Cassandra
@@ -336,7 +336,7 @@ def testCreateKeyspaceWithNetworkTopologyStrategyNoOptions(cql):
 # Test {@link ConfigurationException} is not thrown on create SimpleStrategy keyspace without any options.
 # Reproduces one aspect of #8892 (a default_keyspace_rf allows creating
 # a keyspace without specifying a replication factor).
-@pytest.mark.xfail(reason="Issue #8892")
+@pytest.mark.xfail(reason="Forbid re-adding static columns as regular and vice versa #8892")
 def testCreateKeyspaceWithSimpleStrategyNoOptions(cql):
     n = unique_name()
     execute(cql, n, "CREATE KEYSPACE %s WITH replication = { 'class' : 'SimpleStrategy' }")
@@ -587,7 +587,7 @@ def assertSchemaOption(cql, table, option, expected):
     [ks, cf] = table.split('.')
     assertRows(execute(cql, table, "SELECT " + option + " FROM system_schema.tables WHERE keyspace_name = '" + ks + "' and table_name = '" + cf + "';"), row(expected))
 
-@pytest.mark.xfail(reason="Issue #8948, #6442")
+@pytest.mark.xfail(reason="Cassandra 3.11.10 uses \"class\" instead of \"sstable_compression\" for compression settings by default #8948, Always print all schema parameters (including default values) #6442")
 def testCreateTableWithCompression(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a text, b int, c int, primary key (a, b))") as table:
         assertSchemaOption(cql, table, "compression", {"chunk_length_in_kb": "16", "class": "org.apache.cassandra.io.compress.LZ4Compressor"})

--- a/test/cqlpy/cassandra_tests/validation/operations/delete_test.py
+++ b/test/cqlpy/cassandra_tests/validation/operations/delete_test.py
@@ -438,7 +438,7 @@ def testDeleteWithOneClusteringColumns(cql, test_keyspace, forceFlush):
         assertInvalidMessage(cql, table, "where clause",
                              "DELETE FROM %s WHERE partitionKey = ? AND clustering = ? AND value = ?", 0, 1, 3)
 
-@pytest.mark.xfail(reason="#4244")
+@pytest.mark.xfail(reason="one-element multi-column restriction should be handled like a single-column restriction #4244")
 @pytest.mark.parametrize("forceFlush", [False, True])
 def testDeleteWithTwoClusteringColumns(cql, test_keyspace, forceFlush):
     with create_table(cql, test_keyspace, "(partitionKey int, clustering_1 int, clustering_2 int, value int, PRIMARY KEY (partitionKey, clustering_1, clustering_2))") as table:
@@ -666,7 +666,7 @@ def testDeleteWithRangeAndOneClusteringColumn(cql, test_keyspace, forceFlush):
         assertInvalid(cql, table,
                              "DELETE value FROM %s WHERE partitionKey = ?", 2)
 
-@pytest.mark.xfail(reason="#13250")
+@pytest.mark.xfail(reason="Comparison with UNSET_VALUE should produce an error #13250")
 @pytest.mark.parametrize("forceFlush", [False, True])
 def testDeleteWithRangeAndTwoClusteringColumns(cql, test_keyspace, forceFlush):
     with create_table(cql, test_keyspace, "(partitionKey int, clustering_1 int, clustering_2 int, value int, primary key (partitionKey, clustering_1, clustering_2))") as table:

--- a/test/cqlpy/cassandra_tests/validation/operations/insert_invalidate_sized_records_test.py
+++ b/test/cqlpy/cassandra_tests/validation/operations/insert_invalidate_sized_records_test.py
@@ -27,7 +27,7 @@ from ...porting import *
 LARGE_BLOB = b'x' * (2**16)
 MEDIUM_BLOB = b'x' * (2**15 + 9)
 
-@pytest.mark.xfail(reason="issue #12247")
+@pytest.mark.xfail(reason="Enforce Key-length limits during SELECT #12247")
 def testsingleValuePk(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a blob PRIMARY KEY)") as table:
         # reproduces #12247:
@@ -40,7 +40,7 @@ def testsingleValuePk(cql, test_keyspace):
         with pytest.raises(InvalidRequest, match='Key may not be empty'):
             execute(cql, table, "INSERT INTO %s (a) VALUES (?)", b'')
 
-@pytest.mark.xfail(reason="issue #12247")
+@pytest.mark.xfail(reason="Enforce Key-length limits during SELECT #12247")
 # Currently fails on Cassandra due to CASSANDRA-19270
 def testcompositeValuePk(cql, test_keyspace, cassandra_bug):
     with create_table(cql, test_keyspace, "(a blob, b blob, PRIMARY KEY ((a, b)))") as table:
@@ -76,7 +76,7 @@ def testcompositeValuePk(cql, test_keyspace, cassandra_bug):
 
         execute(cql, table, "INSERT INTO %s (a, b) VALUES (?, ?)", b'', MEDIUM_BLOB)
 
-@pytest.mark.xfail(reason="issue #12247")
+@pytest.mark.xfail(reason="Enforce Key-length limits during SELECT #12247")
 def testsingleValueClustering(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a blob, b blob, PRIMARY KEY (a, b))") as table:
         # reproduces #12247:
@@ -96,7 +96,7 @@ def testsingleValueClustering(cql, test_keyspace):
         # For backwards compatability reasons, need to keep empty support
         execute(cql, table, "INSERT INTO %s (a, b) VALUES (?, ?)", MEDIUM_BLOB, b'')
 
-@pytest.mark.xfail(reason="issue #12247")
+@pytest.mark.xfail(reason="Enforce Key-length limits during SELECT #12247")
 def testcompositeValueClustering(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a blob, b blob, c blob, PRIMARY KEY (a, b, c))") as table:
         # sum of columns is too large
@@ -110,7 +110,7 @@ def testcompositeValueClustering(cql, test_keyspace):
         with pytest.raises(InvalidRequest, match=f'Key length of {len(MEDIUM_BLOB)+len(LARGE_BLOB)} is longer than maximum of 65535'):
             execute(cql, table, "INSERT INTO %s (a, b, c) VALUES (?, ?, ?)", MEDIUM_BLOB, MEDIUM_BLOB, LARGE_BLOB)
 
-@pytest.mark.xfail(reason="issue #8627")
+@pytest.mark.xfail(reason="Comparison with UNSET_VALUE should produce an error #8627")
 def testsingleValueIndex(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a blob, b blob, PRIMARY KEY (a))") as table:
         execute(cql, table, "CREATE INDEX single_value_index ON %s (b)")

--- a/test/cqlpy/cassandra_tests/validation/operations/insert_test.py
+++ b/test/cqlpy/cassandra_tests/validation/operations/insert_test.py
@@ -54,7 +54,7 @@ def testInsertWithUnset(cql, test_keyspace):
 MAX_TTL = 20 * 365 * 24 * 60 * 60
 
 # Reproduces #12243:
-@pytest.mark.xfail(reason="Issue #12243")
+@pytest.mark.xfail(reason="Maybe inconsistent handling of implicit timestamp<->bigint conversion #12243")
 def testInsertWithTtl(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(k int PRIMARY KEY, v int)") as table:
         # test with unset
@@ -164,7 +164,7 @@ def testInsertWithAStaticColumn(cql, test_keyspace, forceFlush):
                              "INSERT INTO %s (partitionKey, clustering_2, staticValue) VALUES (0, 0, 'A')")
 
 # Reproduces #6447 and #12243:
-@pytest.mark.xfail(reason="Issue #12243")
+@pytest.mark.xfail(reason="Maybe inconsistent handling of implicit timestamp<->bigint conversion #12243")
 def testInsertWithDefaultTtl(cql, test_keyspace):
     secondsPerMinute = 60
     with create_table(cql, test_keyspace, f"(a int PRIMARY KEY, b int) WITH default_time_to_live = {10*secondsPerMinute}") as table:
@@ -195,14 +195,14 @@ def testInsertWithDefaultTtl(cql, test_keyspace):
 TOO_BIG = 1024 * 65
 
 # Reproduces #12247:
-@pytest.mark.xfail(reason="Issue #12247")
+@pytest.mark.xfail(reason="Enforce Key-length limits during SELECT #12247")
 def testPKInsertWithValueOver64K(cql, test_keyspace):
     with create_table(cql, test_keyspace, f"(a text, b text, PRIMARY KEY (a, b))") as table:
         assertInvalidThrow(cql, table, InvalidRequest,
                            "INSERT INTO %s (a, b) VALUES (?, 'foo')", 'x'*TOO_BIG)
 
 # Reproduces #12247:
-@pytest.mark.xfail(reason="Issue #12247")
+@pytest.mark.xfail(reason="Enforce Key-length limits during SELECT #12247")
 def testCKInsertWithValueOver64K(cql, test_keyspace):
     with create_table(cql, test_keyspace, f"(a text, b text, PRIMARY KEY (a, b))") as table:
         assertInvalidThrow(cql, table, InvalidRequest,

--- a/test/cqlpy/cassandra_tests/validation/operations/insert_update_if_condition_collections_test.py
+++ b/test/cqlpy/cassandra_tests/validation/operations/insert_update_if_condition_collections_test.py
@@ -36,7 +36,7 @@ def testInsertSetIfNotExists(cql, test_keyspace, is_scylla):
                    row(True,None,None) if is_scylla else row(True))
         assertRows(execute(cql, table, "SELECT * FROM %s "), row(0, {1, 2, 3}))
 
-@pytest.mark.xfail(reason="Issue #13586")
+@pytest.mark.xfail(reason="Add support for CONTAINS and CONTAINS KEY in LWT expressions #13586")
 def testWholeUDT(cql, test_keyspace):
     with create_type(cql, test_keyspace, "(a int, b text)") as typename:
         for frozen in [False, True]:   
@@ -266,7 +266,7 @@ def checkInvalidUDT(cql, table, condition, value, expected):
     assertInvalidThrow(cql, table, expected, "DELETE FROM %s WHERE k = 0 IF " + condition)
     assertRows(execute(cql, table, "SELECT * FROM %s"), row(0, value))
 
-@pytest.mark.xfail(reason="Issue #13624")
+@pytest.mark.xfail(reason="Add support for UDT subfields in LWT expression #13624")
 def testUDTField(cql, test_keyspace):
     with create_type(cql, test_keyspace, "(a int, b text)") as typename:
         for frozen in [False, True]:   
@@ -395,7 +395,7 @@ def testUDTField(cql, test_keyspace):
                 checkDoesNotApplyUDT(cql, table, "v.b != null AND v.b IN ()", v)
 
 # Migrated from cql_tests.py:TestCQL.whole_list_conditional_test()
-@pytest.mark.xfail(reason="Issue #13586")
+@pytest.mark.xfail(reason="Add support for CONTAINS and CONTAINS KEY in LWT expressions #13586")
 def testWholeList(cql, test_keyspace):
     for frozen in [False, True]:   
         typename = "list<text>"
@@ -553,7 +553,7 @@ def testExpandedListItem(cql, test_keyspace):
             #check_invalid_list(cql, table, "l[null] = null", InvalidRequest)
 
 # Migrated from cql_tests.py:TestCQL.whole_set_conditional_test()
-@pytest.mark.xfail(reason="Issue #13586")
+@pytest.mark.xfail(reason="Add support for CONTAINS and CONTAINS KEY in LWT expressions #13586")
 def testWholeSet(cql, test_keyspace):
     for frozen in [False, True]:   
         typename = "set<text>"
@@ -632,7 +632,7 @@ def check_invalid_set(cql, table, condition, expected):
     assertRows(execute(cql, table, "SELECT * FROM %s"), row(0, {"bar", "foo"}))
 
 # Migrated from cql_tests.py:TestCQL.whole_map_conditional_test()
-@pytest.mark.xfail(reason="Issue #13586")
+@pytest.mark.xfail(reason="Add support for CONTAINS and CONTAINS KEY in LWT expressions #13586")
 def testWholeMap(cql, test_keyspace):
     for frozen in [False, True]:   
         typename = "map<text,text>"
@@ -800,7 +800,7 @@ def check_invalid_map(cql, table, condition, expected):
     assertInvalidThrow(cql, table, expected, "DELETE FROM %s WHERE k=0 IF " + condition)
     assertRows(execute(cql, table, "SELECT * FROM %s"), row(0, {"foo": "bar"}))
 
-@pytest.mark.xfail(reason="Issue #13586")
+@pytest.mark.xfail(reason="Add support for CONTAINS and CONTAINS KEY in LWT expressions #13586")
 def testInMarkerWithUDTs(cql, test_keyspace):
     with create_type(cql, test_keyspace, "(a int, b text)") as typename:
         for frozen in [False, True]:
@@ -856,7 +856,7 @@ def testInMarkerWithUDTs(cql, test_keyspace):
                 assertInvalidMessage(cql, table, "unset",
                                  "UPDATE %s SET v = {a: 0, b: 'bc'} WHERE k = 0 IF v.a IN ?", unset())
 
-@pytest.mark.xfail(reason="Issues #13586, #5855")
+@pytest.mark.xfail(reason="Add support for CONTAINS and CONTAINS KEY in LWT expressions #13586, lwt: comparing NULL collection with empty value in IF condition yields incorrect results #5855")
 def testNonFrozenEmptyCollection(cql, test_keyspace):
     with create_table(cql, test_keyspace, f"(k int PRIMARY KEY, l list<text>)") as table:
         execute(cql, table, "INSERT INTO %s (k, l) VALUES (0, null)")

--- a/test/cqlpy/cassandra_tests/validation/operations/select_group_by_test.py
+++ b/test/cqlpy/cassandra_tests/validation/operations/select_group_by_test.py
@@ -10,7 +10,7 @@
 
 from ...porting import *
 
-@pytest.mark.xfail(reason="Issue #2060, #13109")
+@pytest.mark.xfail(reason="Allow mixing token and partition key restrictions #2060, Incorrect sort order when combining IN, GROUP BY and ORDER BY #13109")
 def testGroupByWithoutPaging(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a int, b int, c int, d int, e int, primary key (a, b, c, d))") as table:
 
@@ -605,7 +605,7 @@ def testGroupByWithRangeNamesQueryWithoutPaging(cql, test_keyspace):
                    row(1, 1, 2, 2, 2),
                    row(2, 1, 3, 2, 3))
 
-@pytest.mark.xfail(reason="Issue #13109")
+@pytest.mark.xfail(reason="Incorrect sort order when combining IN, GROUP BY and ORDER BY #13109")
 def testGroupByWithStaticColumnsWithoutPaging(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a int, b int, c int, s int static, d int, primary key (a, b, c))") as table:
         # ------------------------------------
@@ -1570,7 +1570,7 @@ def testGroupByWithRangeNamesQueryWithPaging(cql, test_keyspace):
                           row(1, 1, 2, 2, 2),
                           row(2, 1, 3, 2, 3))
 
-@pytest.mark.xfail(reason="Issue #21267")
+@pytest.mark.xfail(reason="Group By + Order By + Limit produces incorrect results #21267")
 def testGroupByWithStaticColumnsWithPaging(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a int, b int, c int, s int static, d int, primary key (a, b, c))") as table:
         # ------------------------------------

--- a/test/cqlpy/cassandra_tests/validation/operations/select_limit_test.py
+++ b/test/cqlpy/cassandra_tests/validation/operations/select_limit_test.py
@@ -19,7 +19,7 @@ def testSparseTable(cql, test_keyspace):
                 execute(cql, table, "INSERT INTO %s (userid, url, day, month, year) VALUES (?, ?, 1, 'jan', 2012)", i, f"http://foo.{tld}")
         assertRowCount(execute(cql, table, "SELECT * FROM %s LIMIT 4"), 4)
 
-@pytest.mark.xfail(reason="issues #15099")
+@pytest.mark.xfail(reason="issues #15099: Incorrect sort order when combining IN, and ORDER BY")
 def testPerPartitionLimit(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a int, b int, c int, PRIMARY KEY (a, b))") as table:
         for i in range(5):
@@ -284,7 +284,7 @@ def testLimitWithDeletedRowsAndStaticColumns(cql, test_keyspace):
                    row(1, -1, 1, 1),
                    row(5, -1, 1, 1))
 
-@pytest.mark.xfail(reason="issue #15099")
+@pytest.mark.xfail(reason="Incorrect sort order when combining IN, and ORDER BY #15099")
 def testFilteringOnClusteringColumnsWithLimitAndStaticColumns(cql, test_keyspace):
     # With only one clustering column
     with create_table(cql, test_keyspace, "(a int, b int, s int static, c int, PRIMARY KEY (a, b))") as table:

--- a/test/cqlpy/cassandra_tests/validation/operations/select_order_by_test.py
+++ b/test/cqlpy/cassandra_tests/validation/operations/select_order_by_test.py
@@ -204,7 +204,7 @@ def testInvalidOrderBy(cql, test_keyspace):
 # Check that order-by works with IN (CASSANDRA-4327)
 # migrated from cql_tests.py:TestCQL.order_by_with_in_test()
 # Reproduces issue #9435
-@pytest.mark.xfail(reason="Issue #9435")
+@pytest.mark.xfail(reason="SELECT with IN and ORDER BY orders rows per partition instead of for the entire response #9435")
 def testOrderByForInClause(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(my_id varchar, col1 int, value varchar, PRIMARY KEY (my_id, col1))") as table:
 
@@ -320,7 +320,7 @@ def testOrderByForInClause(cql, test_keyspace):
             assert_invalid_message(cql, table, "LIMIT must be strictly positive",
                                  "SELECT v as c2 FROM %s where pk1 = ? AND pk2 IN (?, ?) ORDER BY c1 DESC , c2 DESC LIMIT 0; ", 1, 1, 2)
 
-@pytest.mark.skip(reason="Issue #22061")
+@pytest.mark.skip(reason="selection of a UDT field with ORDER BY fails with 'marshaling error: read_simple_bytes - not enough bytes' #22061")
 def testOrderByForInClauseWithCollectionElementSelection(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(pk int, c frozen<set<int>>, v int, PRIMARY KEY (pk, c))") as table:
         execute(cql, table, "INSERT INTO %s (pk, c, v) VALUES (0, {1, 2}, 0)")

--- a/test/cqlpy/cassandra_tests/validation/operations/select_test.py
+++ b/test/cqlpy/cassandra_tests/validation/operations/select_test.py
@@ -1279,7 +1279,7 @@ def testFilteringWithoutIndicesWithFrozenCollections(cql, test_keyspace):
                              "SELECT * FROM %s WHERE e[1] = ? ALLOW FILTERING",
                              UNSET_VALUE)
 # Reproduces #8627
-@pytest.mark.xfail(reason="#8627")
+@pytest.mark.xfail(reason="Comparison with UNSET_VALUE should produce an error #8627")
 def testIndexQueryWithValueOver64K(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a int, b int, c blob, PRIMARY KEY (a, b))") as table:
         TOO_BIG = 1024 * 65
@@ -1549,7 +1549,7 @@ def testAllowFilteringOnPartitionAndClusteringKey(cql, test_keyspace):
                                     [21, 12, 25, 24, 25],
                                     [21, 12, 26, 34, 35])
 
-@pytest.mark.xfail(reason="#10358")
+@pytest.mark.xfail(reason="because of static column, a of SELECT of partition no clustering rows can return a row anyway #10358")
 def testAllowFilteringOnPartitionKeyWithoutIndicesWithCollections(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a int, b int, c list<int>, d set<int>, e map<int, int>, PRIMARY KEY ((a, b)))") as table:
         execute(cql, table, "INSERT INTO %s (a, b, c, d, e) VALUES (1, 2, [1, 6], {2, 12}, {1: 6})")
@@ -1758,7 +1758,7 @@ def testFilteringOnClusteringColumns(cql, test_keyspace):
                        [21, 28, 29, 30],
                        [31, 32, 33, 34])
 
-@pytest.mark.xfail(reason="#4244")
+@pytest.mark.xfail(reason="one-element multi-column restriction should be handled like a single-column restriction #4244")
 def testFilteringWithMultiColumnSlices(cql, test_keyspace):
     #/----------------------------------------
     #/ Multi-column slices for clustering keys
@@ -1888,7 +1888,7 @@ def testContainsOnPartitionKey(cql, test_keyspace):
 def testContainsOnPartitionKeyPart(cql, test_keyspace):
     dotestContainsOnPartitionKey(cql, test_keyspace, "(pk frozen<map<int, int>>, ck int, v int, PRIMARY KEY ((pk, ck)))")
 
-@pytest.mark.xfail(reason="#10443")
+@pytest.mark.xfail(reason="Incorrect sort order when combining IN, GROUP BY and ORDER BY #10443")
 def testFilteringWithOrderClause(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a int, b int, c int, d list<int>, PRIMARY KEY (a, b, c))") as table:
         execute(cql, table, "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)", 11, 12, 13, [1,4])

--- a/test/cqlpy/cassandra_tests/validation/operations/update_test.py
+++ b/test/cqlpy/cassandra_tests/validation/operations/update_test.py
@@ -427,7 +427,7 @@ def testUpdateWithStaticList(cql, test_keyspace):
 
         assertRows(execute(cql, table, "SELECT l FROM %s WHERE k = 0"), row(["v1", "v4", "v3"]))
 
-@pytest.mark.xfail(reason="#12243")
+@pytest.mark.xfail(reason="Maybe inconsistent handling of implicit timestamp<->bigint conversion #12243")
 def testUpdateWithDefaultTtl(cql, test_keyspace):
     secondsPerMinute = 60
     with create_table(cql, test_keyspace, f"(a int PRIMARY KEY, b int) WITH default_time_to_live = {10 * secondsPerMinute}") as table:

--- a/test/cqlpy/test_aggregate.py
+++ b/test/cqlpy/test_aggregate.py
@@ -179,7 +179,7 @@ def test_aggregation_inf_nan(cql, table1):
 # scenarios tested in this test - averaging 1 and 2 or 1.1 and 1.2 -
 # don't do something that any reasonable user might expect, and will need
 # to be fixed.
-@pytest.mark.xfail(reason="issue #13601")
+@pytest.mark.xfail(reason="Average of \"decimal\" values rounds the average if all inputs are integers #13601")
 def test_avg_decimal(cql, table1, cassandra_bug):
     p = unique_key_int()
     cql.execute(f"insert into {table1} (p, c, dc) values ({p}, 1, 1.0)")

--- a/test/cqlpy/test_allow_filtering.py
+++ b/test/cqlpy/test_allow_filtering.py
@@ -114,7 +114,7 @@ def test_allow_filtering_partition_slice_and_restriction(cql, table1):
 # like 'v=2' doesn't change any of the above, so doesn't require filtering.
 # Reproduces #7964 on Scylla, and also wrong on Cassandra so marked
 # cassandra_bug.
-@pytest.mark.xfail(reason="#7964")
+@pytest.mark.xfail(reason="Further restricting a query already limited to a single row should not require ALLOW FILTERING #7964")
 def test_allow_filtering_single_row(cql, table1, cassandra_bug):
     check_af_optional(cql, table1, 'k=1 AND c=2', lambda row: row.k==1 and row.c==2)
     # Reproduces #7964, as ALLOW FILTERING is considered mandatory, not optional
@@ -465,7 +465,7 @@ def test_allow_filtering_clustering_key_multicolumn_syntax(cql, table1):
 # Moreover, if we have multiple clustering key columns, c1 and c2,
 # (c2)=(10) should be allowed just like c2=10 (and require filtering
 # just like it) - we shouldn't complain that c1 is missing. Reproduces #13250.
-@pytest.mark.xfail(reason="issue #13250")
+@pytest.mark.xfail(reason="Comparison with UNSET_VALUE should produce an error #13250")
 def test_allow_filtering_compound_clustering_key_multicolumn_syntax(cql, table3):
     check_af_mandatory(cql, table3, 'c1=10', lambda row: row.c1==10)
     check_af_mandatory(cql, table3, '(c1)=(10)', lambda row: row.c1==10)

--- a/test/cqlpy/test_counter.py
+++ b/test/cqlpy/test_counter.py
@@ -38,7 +38,7 @@ def test_counter_to_blob(cql, table1, table2):
         cql.execute(f"SELECT counterasblob(i) FROM {table1} WHERE p={p}")
     # The opposite order is allowed in Scylla because of #14319, so let's
     # split it into a second test test_counter_to_blob2:
-@pytest.mark.xfail(reason="issue #14319")
+@pytest.mark.xfail(reason="Support CAST function not only in SELECT #14319")
 def test_counter_to_blob2(cql, table1, table2):
     p = unique_key_int()
     cql.execute(f'UPDATE {table2} SET c = c + 1000 WHERE p = {p}')

--- a/test/cqlpy/test_empty.py
+++ b/test/cqlpy/test_empty.py
@@ -51,7 +51,7 @@ def test_insert_empty_string_key_with_flush(cql, table1, scylla_only):
 # In contrast with normal tables where an empty clustering key is allowed,
 # in a WITH COMPACT STORAGE table, an empty clustering key is not allowed.
 # As usual, an empty partition key is not allowed either.
-@pytest.mark.skip(reason="issue #12749, misleading error message")
+@pytest.mark.skip(reason="Unsupported empty clustering key in COMPACT table #12749, misleading error message")
 def test_insert_empty_string_key_compact(compact_storage, cql, test_keyspace):
     schema = 'p text, c text, v text, primary key (p, c)'
     with new_test_table(cql, test_keyspace, schema, 'WITH COMPACT STORAGE') as table:
@@ -63,7 +63,7 @@ def test_insert_empty_string_key_compact(compact_storage, cql, test_keyspace):
 
 # However, in a COMPACT STORAGE table with a *compound* clustering key (more
 # than one clustering key column), setting one of them to empty *is* allowed.
-@pytest.mark.skip(reason="issue #12749")
+@pytest.mark.skip(reason="Unsupported empty clustering key in COMPACT table #12749")
 def test_insert_empty_string_compound_clustering_key_compact(compact_storage, cql, test_keyspace):
     schema = 'p text, c1 text, c2 text, v text, primary key (p, c1, c2)'
     with new_test_table(cql, test_keyspace, schema, 'WITH COMPACT STORAGE') as table:
@@ -181,14 +181,14 @@ def test_empty_string_for_string_types_json(cql, table_all_scalar, t):
 # constant, but the string needs to follow a particular format and in
 # particular the empty string should not be allowed.
 # Reproduces #10625.
-@pytest.mark.xfail(reason="issue #10625")
+@pytest.mark.xfail(reason="Not covered corner case for key prefix optimization in filtering #10625")
 @pytest.mark.parametrize("t", ["date", "time"])
 def test_empty_string_for_fussy_string_types(cql, table_all_scalar, t):
     p = unique_key_int()
     with pytest.raises(InvalidRequest):
         cql.execute(f"INSERT INTO {table_all_scalar} (p,v{t}) VALUES ({p}, '')")
 
-@pytest.mark.xfail(reason="issue #10625")
+@pytest.mark.xfail(reason="Not covered corner case for key prefix optimization in filtering #10625")
 @pytest.mark.parametrize("t", ["date", "time"])
 def test_empty_string_for_fussy_string_types_json(cql, table_all_scalar, t):
     p = unique_key_int()
@@ -200,14 +200,14 @@ def test_empty_string_for_fussy_string_types_json(cql, table_all_scalar, t):
 # empty string doesn't make sense as an IP address or a timestamp.
 # We consider this a Cassandra bug, hence the tag "cassandra_bug" below.
 # Reproduces #10625.
-@pytest.mark.xfail(reason="issue #10625")
+@pytest.mark.xfail(reason="Not covered corner case for key prefix optimization in filtering #10625")
 @pytest.mark.parametrize("t", ["inet", "timestamp"])
 def test_empty_string_for_fussy_string_types2(cql, table_all_scalar, t, cassandra_bug):
     p = unique_key_int()
     with pytest.raises(InvalidRequest):
         cql.execute(f"INSERT INTO {table_all_scalar} (p,v{t}) VALUES ({p}, '')")
 
-@pytest.mark.xfail(reason="issue #10625")
+@pytest.mark.xfail(reason="Not covered corner case for key prefix optimization in filtering #10625")
 @pytest.mark.parametrize("t", ["inet", "timestamp"])
 def test_empty_string_for_fussy_string_types2_json(cql, table_all_scalar, t, cassandra_bug):
     p = unique_key_int()
@@ -227,7 +227,7 @@ def test_empty_string_for_other_types(cql, table_all_scalar, t):
 # Reproduces #7944 and #10625.
 # See also test_json.py::test_fromjson_{varint,int}_empty_string*
 # which reproduces the same bug but just for two specific types.
-@pytest.mark.xfail(reason="issue #7944")
+@pytest.mark.xfail(reason="fromJson() should not accept the empty string \"\" as a number #7944")
 @pytest.mark.parametrize("t", ["bigint", "blob", "boolean", "decimal", "double", "duration", "float", "int", "smallint", "timeuuid", "tinyint", "uuid", "varint"])
 def test_empty_string_for_other_types_json(cql, table_all_scalar, t, cassandra_bug):
     p = unique_key_int()

--- a/test/cqlpy/test_filtering.py
+++ b/test/cqlpy/test_filtering.py
@@ -397,8 +397,8 @@ def do_test_filter_UDT_restriction(cql, test_keyspace, frozen):
 # in Cassandra the behavior is the former - and this is what this test
 # expects. In Scylla it's currently the latter, causing this test to fail.
 @pytest.mark.parametrize("use_index", [
-        pytest.param(True, marks=pytest.mark.xfail(reason="#12102")),
-        pytest.param(False, marks=pytest.mark.xfail(reason="#12102"))])
+        pytest.param(True, marks=pytest.mark.xfail(reason="With filtering, page size counts unfiltered rows. Should be filtered rows? #12102")),
+        pytest.param(False, marks=pytest.mark.xfail(reason="With filtering, page size counts unfiltered rows. Should be filtered rows? #12102"))])
 def test_filter_and_fetch_size(cql, test_keyspace, use_index, driver_bug_1):
     with new_test_table(cql, test_keyspace, 'pk int primary key, x int, y int') as table:
         if use_index:

--- a/test/cqlpy/test_group_by.py
+++ b/test/cqlpy/test_group_by.py
@@ -115,7 +115,7 @@ def test_group_by_clustering_prefix_with_limit(cql, table1):
 
 # Same as the above test, but also add paging, and check that the LIMIT
 # is handled correctly (limits the total number of returned results)
-@pytest.mark.xfail(reason="issue #5362")
+@pytest.mark.xfail(reason="LIMIT is not doing it right when using GROUP BY #5362")
 def test_group_by_clustering_prefix_with_limit_and_paging(cql, table1):
     results = list(cql.execute(f'SELECT p,c1,c2,v FROM {table1} GROUP BY p,c1'))
     assert len(results) == 4
@@ -232,7 +232,7 @@ def test_group_by_non_aggregated_mutation_attribute_of_column(cql, table1):
 
 # This test is from cassandra_tests/validation/operations/select_group_by_test.py::testGroupByWithPaging()
 # Reproduces #21267
-@pytest.mark.xfail(reason="issue #21267")
+@pytest.mark.xfail(reason="Group By + Order By + Limit produces incorrect results #21267")
 def test_group_by_static_column(cql, test_keyspace):
 
     with new_test_table(cql, test_keyspace, "a int, b int, c int, s int static, d int, primary key (a, b, c)") as table:

--- a/test/cqlpy/test_json.py
+++ b/test/cqlpy/test_json.py
@@ -215,7 +215,7 @@ def test_fromjson_bigint_nonoverflow(cql, table1):
 # standard suggests it may be fine to botch it up, so it might be acceptable
 # to fail this test.
 # Reproduces #10100 and #10137.
-@pytest.mark.xfail(reason="issue #10137")
+@pytest.mark.xfail(reason="INSERT JSON of bigint (64-bit) in scientific notation is not accurate above 2^53 #10137")
 def test_fromjson_bigint_nonoverflow_scientific(cql, table1, cassandra_bug):
     p = unique_key_int()
     stmt = cql.prepare(f"INSERT INTO {table1} (p, bigv) VALUES (?, fromJson(?))")
@@ -244,12 +244,12 @@ def test_fromjson_int_empty_string_prepared(cql, table1, cassandra_bug):
     stmt = cql.prepare(f"INSERT INTO {table1} (p, v) VALUES (?, fromJson(?))")
     with pytest.raises(FunctionFailure):
         cql.execute(stmt, [p, '""'])
-@pytest.mark.xfail(reason="issue #7944")
+@pytest.mark.xfail(reason="fromJson() should not accept the empty string \"\" as a number #7944")
 def test_fromjson_varint_empty_string_unprepared(cql, table1):
     p = unique_key_int()
     with pytest.raises(FunctionFailure):
         cql.execute(f"INSERT INTO {table1} (p, vi) VALUES ({p}, fromJson('\"\"'))")
-@pytest.mark.xfail(reason="issue #7944")
+@pytest.mark.xfail(reason="fromJson() should not accept the empty string \"\" as a number #7944")
 def test_fromjson_varint_empty_string_prepared(cql, table1):
     p = unique_key_int()
     stmt = cql.prepare(f"INSERT INTO {table1} (p, vi) VALUES (?, fromJson(?))")
@@ -386,7 +386,7 @@ def test_fromjson_map_key_timestamp(cql, table1):
 # that a normal value is allowed. For example, it cannot be given as an
 # element of a list.
 # Reproduces #7954.
-@pytest.mark.xfail(reason="issue #7954")
+@pytest.mark.xfail(reason="fromJson() fails to set null tuple elements #7954")
 def test_fromjson_null_constant(cql, table1):
     p = unique_key_int()
     # Check that a "null" JSON constant can be used to unset a column
@@ -493,7 +493,7 @@ def test_fromjson_timestamp_submilli(cql, table1, cassandra_bug):
 # We need to skip this test because in debug mode memory allocation is not
 # bounded, and this test can hang or crash instead of failing immediately.
 # We also have a smaller xfailing test below, test_tojson_decimal_high_mantissa2.
-@pytest.mark.skip(reason="issue #8002")
+@pytest.mark.skip(reason="toJson() of decimal type doesn't use exponents so can produce huge output #8002")
 def test_tojson_decimal_high_mantissa(cql, table1):
     p = unique_key_int()
     stmt = cql.prepare(f"INSERT INTO {table1} (p, dec) VALUES ({p}, ?)")
@@ -505,7 +505,7 @@ def test_tojson_decimal_high_mantissa(cql, table1):
 # that a much smaller exponent, 1e1000 works (this is not surprising) but
 # results in 1000 digits of output. This hints that 1e1000000000 will not
 # work at all, without testing it directly as above.
-@pytest.mark.xfail(reason="issue #8002")
+@pytest.mark.xfail(reason="toJson() of decimal type doesn't use exponents so can produce huge output #8002")
 def test_tojson_decimal_high_mantissa2(cql, table1):
     p = unique_key_int()
     stmt = cql.prepare(f"INSERT INTO {table1} (p, dec) VALUES ({p}, ?)")
@@ -543,7 +543,7 @@ def test_select_json_function_call(cql, table1):
 # This is issue #8087.
 # This issue is also reproduced by the much more comprehensive test
 # cassandra_tests/validation/entities/json_test.py::testInsertJsonSyntaxWithNonNativeMapKeys
-@pytest.mark.xfail(reason="issue #8087")
+@pytest.mark.xfail(reason="SELECT JSON incorrectly quotes strings inside map keys #8087")
 def test_select_json_string_in_nonstring_map_key(cql, table1):
     p = unique_key_int()
     stmt = cql.prepare(f"INSERT INTO {table1} (p, tupmap) VALUES ({p}, ?)")

--- a/test/cqlpy/test_lwt.py
+++ b/test/cqlpy/test_lwt.py
@@ -190,7 +190,7 @@ def test_lwt_insert_if_not_exists(cql, table1):
 
 # Similarly to the above test, INSERT JSON should also accept IF NOT EXISTS
 # and work as expected with it. Reproduces issue #8682.
-@pytest.mark.xfail(reason="issue #8682")
+@pytest.mark.xfail(reason="INSERT JSON ... IF NOT EXISTS ignores IF_NOT_EXISTS #8682")
 def test_lwt_insert_json_if_not_exists(cql, table1):
     p = unique_key_int()
     # The row doesn't yet exist, IF NOT EXISTS will insert it.

--- a/test/cqlpy/test_materialized_view.py
+++ b/test/cqlpy/test_materialized_view.py
@@ -390,7 +390,7 @@ def test_mv_synchronous_updates(cql, test_keyspace, scylla_only):
 # message about a key being too long appears in the log.
 # Note that the same issue also applies to secondary indexes, and this is
 # tested in test_secondary_index.py.
-@pytest.mark.xfail(reason="issue #8627")
+@pytest.mark.xfail(reason="Cleanly reject updates with indexed values where value > 64k #8627")
 def test_oversized_base_regular_view_key(cql, test_keyspace, cassandra_bug):
     with new_test_table(cql, test_keyspace, 'p int primary key, v text') as table:
         with new_materialized_view(cql, table, select='*', pk='v,p', where='v is not null and p is not null') as mv:
@@ -408,11 +408,11 @@ def test_oversized_base_regular_view_key(cql, test_keyspace, cassandra_bug):
 # copied to the view. The view building cannot return an error to the user,
 # but we do expect it to skip the problematic row and continue to complete
 # the rest of the view build.
-@pytest.mark.xfail(reason="issue #8627")
+@pytest.mark.xfail(reason="Cleanly reject updates with indexed values where value > 64k #8627")
 # This test currently breaks the build (it repeats a failing build step,
 # and never complete) and we cannot quickly recognize this failure, so
 # to avoid a very slow failure, we currently "skip" this test.
-@pytest.mark.skip(reason="issue #8627, fails very slow")
+@pytest.mark.skip(reason="Cleanly reject updates with indexed values where value > 64k #8627, fails very slow")
 def test_oversized_base_regular_view_key_build(cql, test_keyspace, cassandra_bug):
     with new_test_table(cql, test_keyspace, 'p int primary key, v text') as table:
         # No materialized view yet - a "big" value in v is perfectly fine:
@@ -531,7 +531,7 @@ def test_view_builder_suspend_with_partition_tombstone(cql, test_keyspace, scyll
 # columns.
 # This test reproduces issue issue #11979, that Scylla used to require
 # IS NOT NULL inconsistently.
-@pytest.mark.xfail(reason="issue #11979")
+@pytest.mark.xfail(reason="Make requirement of \"IS NOT NULL\" in materialized view more consistent #11979")
 def test_is_not_null_requirement(cql, test_keyspace):
     with new_test_table(cql, test_keyspace, 'p int, c int, v int, primary key (p, c)') as table:
         # missing "v is not null":
@@ -705,7 +705,7 @@ def test_mv_long_delete(cql, test_keyspace):
 # this column is used in a materialized view, its order in the view inherits
 # the same reversed sort order it had in the base table.
 # Reproduces #12308
-@pytest.mark.xfail(reason="issue #12308")
+@pytest.mark.xfail(reason="In Scylla, MV CLUSTERING ORDER BY defaults to natural order. In Cassandra the base's order is inherited. #12308")
 def test_mv_inherit_clustering_order(cql, test_keyspace):
     with new_test_table(cql, test_keyspace, 'p int, c int, x int, y int, primary key (p,c)', 'with clustering order by (c DESC)') as table:
         # note no explicit clustering order on c in the materialized view:
@@ -776,7 +776,7 @@ def test_mv_override_clustering_order_quoted(cql, test_keyspace):
 # The following test verifies that these bad WITH CLUSTERING ORDER BY
 # clauses are indeed rejected.
 # Reproduces #12936.
-@pytest.mark.xfail(reason="issue #12936")
+@pytest.mark.xfail(reason="In MV definition, CLUSTERING ORDER BY should require strict clustering-column order #12936")
 def test_mv_override_clustering_order_bad1(cql, test_keyspace):
     with new_test_table(cql, test_keyspace, 'p int, c int, x int, y int, primary key (p,c)') as table:
         # Mis-ordered clustering columns: c,x on PRIMARY KEY, but

--- a/test/cqlpy/test_native_functions.py
+++ b/test/cqlpy/test_native_functions.py
@@ -30,7 +30,7 @@ def tbl_set(cql, test_keyspace):
 # take a constant. This feature is barely useful for WHERE clauses, and
 # even less useful for selectors, but should be allowed for both.
 # Reproduces #12607.
-@pytest.mark.xfail(reason="issue #12607")
+@pytest.mark.xfail(reason="Allow using terms in selection clause within SELECT statement #12607")
 def test_constant_function_parameter(cql, table1):
     p = unique_key_int()
     cql.execute(f"INSERT INTO {table1} (p, b) VALUES ({p}, 0x03)")
@@ -62,7 +62,7 @@ def test_selector_mintimeuuid(cql, table1):
 # doesn't. I'm not sure which behavior we should consider correct, but it's
 # useful to have a test that demonstrates this incompatibility.
 # Reproduces #14319.
-@pytest.mark.xfail(reason="issue #14319")
+@pytest.mark.xfail(reason="Support CAST function not only in SELECT #14319")
 def test_selector_mintimeuuid_64bit(cql, table1):
     p = unique_key_int()
     cql.execute(f"INSERT INTO {table1} (p, g) VALUES ({p}, 123)")

--- a/test/cqlpy/test_scan.py
+++ b/test/cqlpy/test_scan.py
@@ -23,7 +23,7 @@ from cassandra.query import SimpleStatement
 # This test focuses on cases which do not need ALLOW FILTERING. The next
 # test will focus on those that do.
 # Reproduces issue #64 and #4244
-@pytest.mark.xfail(reason="issues #64 and #4244")
+@pytest.mark.xfail(reason="CQL Multi column restrictions are allowed only on a clustering key prefix #64, Add support for mixing token, multi- and single-column restrictions #4244")
 def test_multi_column_restrictions_ck(cql, test_keyspace):
     with new_test_table(cql, test_keyspace, "p int, c1 int, c2 int, c3 int, PRIMARY KEY (p, c1, c2, c3)") as table:
         stmt = cql.prepare(f"INSERT INTO {table} (p, c1, c2, c3) VALUES (1, ?, ?, ?)")
@@ -99,7 +99,7 @@ def test_multi_column_range_restrictions_and_filtering(cql, test_keyspace):
 # We add another clustering key column to ensure that filtering *in*
 # a long partition is really needed - not just filtering on the partitions
 # (these are two different code paths).
-@pytest.mark.xfail(reason="issue #64")
+@pytest.mark.xfail(reason="CQL Multi column restrictions are allowed only on a clustering key prefix. #64")
 def test_multi_column_restrictions_ck_filtering(cql, test_keyspace):
     with new_test_table(cql, test_keyspace, "p int, c0 int, c1 int, c2 int, c3 int, PRIMARY KEY (p, c0, c1, c2, c3)") as table:
         stmt = cql.prepare(f"INSERT INTO {table} (p, c0, c1, c2, c3) VALUES (1, 1, ?, ?, ?)")
@@ -128,7 +128,7 @@ def test_multi_column_restrictions_ck_filtering(cql, test_keyspace):
 # Reproduces #4244. Contrasting with the other reproducers for #4244 above,
 # in this test the single-column restriction is on the same column as the
 # multi-column restriction, not a different column.
-@pytest.mark.xfail(reason="issue #4244")
+@pytest.mark.xfail(reason="one-element multi-column restriction should be handled like a single-column restriction #4244")
 def test_multi_column_and_single_column_restriction_same_ck(cql, test_keyspace):
     with new_test_table(cql, test_keyspace, "p int, c1 int, c2 int, PRIMARY KEY (p, c1, c2)") as table:
         stmt = cql.prepare(f"INSERT INTO {table} (p, c1, c2) VALUES (1, ?, ?)")
@@ -149,7 +149,7 @@ def test_multi_column_and_single_column_restriction_same_ck(cql, test_keyspace):
 # on the same column and on a different column..
 # Reproduces issue #4244 (note that this is a different aspect of #4244 than
 # the multi-column restriction problems reproduced by other tests above).
-@pytest.mark.xfail(reason="issue #4244")
+@pytest.mark.xfail(reason="one-element multi-column restriction should be handled like a single-column restriction #4244")
 def test_restriction_token_and_nontoken(cql, test_keyspace):
     with new_test_table(cql, test_keyspace, "p int, c int, PRIMARY KEY (p, c)") as table:
         stmt = cql.prepare(f"INSERT INTO {table} (p, c) VALUES (?, ?)")

--- a/test/cqlpy/test_secondary_index.py
+++ b/test/cqlpy/test_secondary_index.py
@@ -271,7 +271,7 @@ def test_range_deletion(cql, test_keyspace, scylla_only):
 # Reproduces #8627:
 # Test that trying to insert a value for an indexed column that exceeds 64KiB fails,
 # because this value is too large to be written as a key in the underlying index
-@pytest.mark.xfail(reason="issue #8627")
+@pytest.mark.xfail(reason="Comparison with UNSET_VALUE should produce an error #8627")
 def test_too_large_indexed_value(cql, test_keyspace):
     schema = 'p int, c int, v text, primary key (p,c)'
     with new_test_table(cql, test_keyspace, schema) as table:
@@ -286,7 +286,7 @@ def test_too_large_indexed_value(cql, test_keyspace):
 # to 64 KB. When a collection is indexed, the insertion of oversized elements
 # should fail cleanly at the time of write.
 # Reproduces #8627
-@pytest.mark.xfail(reason="issue #8627")
+@pytest.mark.xfail(reason="Comparison with UNSET_VALUE should produce an error #8627")
 def test_too_large_indexed_collection_value(cql, test_keyspace):
     schema = 'p int, c int, m map<text,text>, primary key (p,c)'
     with new_test_table(cql, test_keyspace, schema) as table:
@@ -303,7 +303,7 @@ def test_too_large_indexed_collection_value(cql, test_keyspace):
 # to a table with pre-existing data. The background index-building process
 # cannot return an error to the user, but we do expect it to skip the
 # problematic row and continue to complete the rest of the index build.
-@pytest.mark.xfail(reason="issue #8627")
+@pytest.mark.xfail(reason="Comparison with UNSET_VALUE should produce an error #8627")
 def test_too_large_indexed_value_build(cql, test_keyspace):
     with new_test_table(cql, test_keyspace, 'p int primary key, v text') as table:
         # No index yet - a "big" value in v is perfectly fine:
@@ -378,7 +378,7 @@ def test_instant_table_recreation(cql, test_keyspace):
 # a full-index scan (the amount of output is proportional to the read).
 # Additionally, with unnecessary parentheses the query also works, and isn't
 # handled like a multi-column restriction (reproduces #13250).
-@pytest.mark.xfail(reason="issue #13250")
+@pytest.mark.xfail(reason="Comparison with UNSET_VALUE should produce an error #13250")
 def test_index_scan_multicolumn_syntax(cql, test_keyspace):
     schema = 'p int, c1 int, c2 int, primary key (p, c1, c2)'
     with new_test_table(cql, test_keyspace, schema) as table:
@@ -507,7 +507,7 @@ def test_index_in_restriction(cql, test_keyspace, cassandra_bug):
 # Reproduces #10649 - when use_index=True the test failed because LIMIT
 # returned fewer than the requested number of rows.
 @pytest.mark.parametrize("use_index", [
-        pytest.param(True, marks=pytest.mark.xfail(reason="#10649")), False])
+        pytest.param(True, marks=pytest.mark.xfail(reason="Secondary index query may exceed the LIMIT #10649")), False])
 def test_filter_and_limit(cql, test_keyspace, use_index, driver_bug_1):
     with new_test_table(cql, test_keyspace, 'pk int primary key, x int, y int') as table:
         if use_index:
@@ -543,7 +543,7 @@ def test_filter_and_limit(cql, test_keyspace, use_index, driver_bug_1):
 # Reproduces #10649 - when use_index=True the test failed because LIMIT
 # returned fewer than the requested number of rows.
 @pytest.mark.parametrize("use_index", [
-        pytest.param(True, marks=pytest.mark.xfail(reason="#10649")), False])
+        pytest.param(True, marks=pytest.mark.xfail(reason="Secondary index query may exceed the LIMIT #10649")), False])
 def test_filter_and_limit_clustering(cql, test_keyspace, use_index):
     with new_test_table(cql, test_keyspace, 'pk int, ck int, x int, PRIMARY KEY(pk, ck)') as table:
         if use_index:
@@ -575,7 +575,7 @@ def test_filter_and_limit_clustering(cql, test_keyspace, use_index):
 # who discovered #10649, and involves slightly different code paths in
 # Scylla (the index-driver query needs to read individual rows, not
 # entire partitions, from the base table).
-@pytest.mark.xfail(reason="#10649")
+@pytest.mark.xfail(reason="Secondary index query may exceed the LIMIT #10649")
 def test_filter_and_limit_2(cql, test_keyspace):
     schema = 'pk int, ck1 int, ck2 int, x int, PRIMARY KEY (pk, ck1, ck2)'
     with new_test_table(cql, test_keyspace, schema) as table:
@@ -603,7 +603,7 @@ def test_filter_and_limit_2(cql, test_keyspace):
 # conjunction filtering. A user tried this variant in issue #12766.
 # This is a scylla_only test because local index is a Scylla-only feature.
 @pytest.mark.parametrize("use_local_index", [
-        pytest.param(True, marks=pytest.mark.xfail(reason="#10649")), False])
+        pytest.param(True, marks=pytest.mark.xfail(reason="Secondary index query may exceed the LIMIT #10649")), False])
 def test_filter_and_limit_local_index(cql, test_keyspace, use_local_index, driver_bug_1, scylla_only):
     with new_test_table(cql, test_keyspace, 'p int, c int, x int, y int, primary key (p, c)') as table:
         if use_local_index:
@@ -1287,7 +1287,7 @@ def test_index_paging_pk_only(cql, test_keyspace):
 # one component), the restriction can match the entire partition, but paging
 # still needs to page through it - and not return the entire partition as one
 # page! Reproduces #7432.
-@pytest.mark.xfail(reason="issue #7432")
+@pytest.mark.xfail(reason="Secondary index: large rows + paging cause incomplete results #7432")
 def test_index_paging_match_partition(cql, test_keyspace):
     schema = 'p1 int, p2 int, c int, primary key (p1,p2,c)'
     with new_test_table(cql, test_keyspace, schema) as table:
@@ -1320,7 +1320,7 @@ def test_index_paging_match_partition(cql, test_keyspace):
 # Currently, paging of queries that uses secondary indexes on static columns
 # is unable to page through partitions of the base table and must return them
 # in whole. Related to #7432.
-@pytest.mark.xfail(reason="issue #7432")
+@pytest.mark.xfail(reason="Secondary index: large rows + paging cause incomplete results #7432")
 def test_index_paging_static_column(cql, test_keyspace):
     schema = 'p int, c int, s int static, PRIMARY KEY(p, c)'
     with new_test_table(cql, test_keyspace, schema) as table:
@@ -1350,7 +1350,7 @@ def test_index_paging_static_column(cql, test_keyspace):
 # returns all the results in one page instead of stopping. So the following
 # test passes with use_group_by = False but failed with use_group_by = True.
 @pytest.mark.parametrize("use_group_by", [
-        pytest.param(True, marks=pytest.mark.xfail(reason="#7432")), False])
+        pytest.param(True, marks=pytest.mark.xfail(reason="Secondary index: large rows + paging cause incomplete results #7432")), False])
 def test_index_paging_group_by(cql, test_keyspace, use_group_by):
     schema = 'p int, c1 int, c2 int, primary key (p,c1,c2)'
     with new_test_table(cql, test_keyspace, schema) as table:
@@ -1722,7 +1722,7 @@ def test_index_non_eq_relation(cql, test_keyspace):
 # but failed with an index (use_index=True) - it seems the PER PARTITION LIMIT
 # request was just ignored.
 @pytest.mark.parametrize("use_index", [
-        pytest.param(True, marks=pytest.mark.xfail(reason="#12762")), False])
+        pytest.param(True, marks=pytest.mark.xfail(reason="Not covered corner case for key prefix optimization in filtering #12762")), False])
 def test_index_filtering_scan_and_per_partition_limit(cql, test_keyspace, use_index):
     with new_test_table(cql, test_keyspace, "p int, c int, v int, PRIMARY KEY (p, c)") as table:
         if use_index:
@@ -1746,7 +1746,7 @@ def test_index_filtering_scan_and_per_partition_limit(cql, test_keyspace, use_in
 # the second result, and so on, and not skip to the next partition until
 # we have one post-filtered result.
 @pytest.mark.parametrize("use_index", [
-        pytest.param(True, marks=pytest.mark.xfail(reason="#12762")), False])
+        pytest.param(True, marks=pytest.mark.xfail(reason="Not covered corner case for key prefix optimization in filtering #12762")), False])
 def test_index_filtering2_scan_and_per_partition_limit(cql, test_keyspace, use_index):
     with new_test_table(cql, test_keyspace, "p int, c int, v int, z int, PRIMARY KEY (p, c)") as table:
         if use_index:
@@ -1767,7 +1767,7 @@ def test_index_filtering2_scan_and_per_partition_limit(cql, test_keyspace, use_i
 # the ALLOW FILTERING request right after the CREATE INDEX causes an
 # exception in SecondaryIndexManagement and a failed read. This is despite
 # CASSANDRA-8505 claiming that this issue was already fixed in 2015.
-@pytest.mark.xfail(reason="issue #7963")
+@pytest.mark.xfail(reason="Secondary index shouldn't be used before fully built #7963")
 def test_unbuilt_index_not_used(cql, test_keyspace, cassandra_bug):
     # The bigger "count" is the slower the test and the higher the chance
     # of reproducing the bug #7963. With dev build on my laptop, count=100
@@ -1817,7 +1817,7 @@ def wait_for_index(cql, keyspace, index_name, timeout_sec=60):
 # pages through the results, and between two pages adds a secondary-index
 # that could be used - or not - for continuing the request, but certainly
 # shouldn't break the request. Reproduces #18992.
-@pytest.mark.xfail(reason="issue #18992")
+@pytest.mark.xfail(reason="Adding a secondary index can break an ongoing paged read using another index #18992")
 def test_paging_and_create_index(cql, test_keyspace):
     count = 20
     with new_test_table(cql, test_keyspace,
@@ -1853,7 +1853,7 @@ def test_paging_and_create_index(cql, test_keyspace):
 # This test is the same as the previous one, but in this test the request
 # filters on both v1 and v2 is already using an index for column v2, and
 # now between the pages we add an index for v1. Reproduces #18992.
-@pytest.mark.xfail(reason="issue #18992")
+@pytest.mark.xfail(reason="Adding a secondary index can break an ongoing paged read using another index #18992")
 def test_paging_and_create_index2(cql, test_keyspace):
     count = 20
     with new_test_table(cql, test_keyspace,
@@ -1897,7 +1897,7 @@ def test_paging_and_create_index2(cql, test_keyspace):
 # will do the same without ALLOW FILTERING in the query - and we'll see the
 # query can't be resumed after the index is dropped.
 # Reproduces #18992.
-@pytest.mark.xfail(reason="issue #18992")
+@pytest.mark.xfail(reason="Adding a secondary index can break an ongoing paged read using another index #18992")
 def test_paging_and_drop_index_allow_filtering(cql, test_keyspace):
     count = 20
     with new_test_table(cql, test_keyspace,
@@ -2062,7 +2062,7 @@ def test_index_in_API(cql, test_keyspace):
 # from the index view (where the LIMIT is correctly applied). A mismatch is
 # always interpreted as more pages being available, which in this case is incorrect.
 # See `generate_view_paging_state_from_base_query_results()` for more details.
-@pytest.mark.xfail(reason="issue #22158")
+@pytest.mark.xfail(reason="Secondary index query may exceed the LIMIT #22158")
 def test_limit_partition(cql, test_keyspace):
     with new_test_table(cql, test_keyspace, 'pk1 int, pk2 int, ck int, primary key ((pk1, pk2), ck)') as table:
         cql.execute(f'CREATE INDEX ON {table}(pk2)')
@@ -2084,7 +2084,7 @@ def test_limit_partition(cql, test_keyspace):
 # Same as test_limit_partition above, except that it uses partition slices
 # instead of whole partitions. This is achieved by indexing the first clustering
 # key column.
-@pytest.mark.xfail(reason="issue #22158")
+@pytest.mark.xfail(reason="Secondary index query may exceed the LIMIT #22158")
 def test_limit_partition_slice(cql, test_keyspace):
     with new_test_table(cql, test_keyspace, 'pk int, ck1 int, ck2 int, primary key (pk, ck1, ck2)') as table:
         cql.execute(f'CREATE INDEX ON {table}(ck1)')
@@ -2116,7 +2116,7 @@ def test_limit_partition_slice(cql, test_keyspace):
 # assumes that the last partition of the previous page was fully read, so it
 # completely ignores it when preparing the second page. This logic is
 # implemented in `find_index_partition_ranges()`.
-@pytest.mark.xfail(reason="issue #25839")
+@pytest.mark.xfail(reason="Secondary index: large rows + paging cause incomplete results #25839")
 def test_short_read(cql, test_keyspace):
     page_memory_limit = 1024 if is_scylla(cql) else 1024 * 1024  # 1MiB in Cassandra, 1KiB in Scylla (for faster execution)
     row_size = page_memory_limit // 2  # will cause short read after 2 rows
@@ -2137,7 +2137,7 @@ def test_short_read(cql, test_keyspace):
 # Another reproducer for issue #25839, this time asking for a count() as
 # a user tried in #28026 and noticing that adding an additional column
 # to the selection causes the count to become smaller.
-@pytest.mark.xfail(reason="issue #25839")
+@pytest.mark.xfail(reason="Secondary index: large rows + paging cause incomplete results #25839")
 def test_short_count(cql, test_keyspace):
     # Newer Scylla have configurable query_page_size_in_bytes so we can set
     # it low to have a faster test. Older Scylla and Cassandra have hard-coded

--- a/test/cqlpy/test_select_collection_element.py
+++ b/test/cqlpy/test_select_collection_element.py
@@ -147,7 +147,7 @@ def test_set_subscript(cql, test_keyspace):
         assert list(cql.execute(f"SELECT s[20] FROM {table} WHERE p={p}")) == [(20,)]
 
 # scylla only because cassandra doesn't support lua language
-@pytest.mark.xfail(reason="#22075")
+@pytest.mark.xfail(reason="Selecting collection elements with slice syntax and remaining Cassandra compatibility #22075")
 def test_subscript_function_arg(scylla_only, cql, test_keyspace, table1):
     fn = "(k int) CALLED ON NULL INPUT RETURNS int LANGUAGE Lua AS 'return k+1'"
     with new_function(cql, test_keyspace, fn, 'add_one'):

--- a/test/cqlpy/test_sstable_compression.py
+++ b/test/cqlpy/test_sstable_compression.py
@@ -16,7 +16,7 @@ from cassandra.protocol import ConfigurationException, SyntaxException
 # given as a "sstable_compression" attribute, but newer Cassandra switched
 # to "class". Check that we support this new name class.
 # Reproduces #8948.
-@pytest.mark.xfail(reason="#8948")
+@pytest.mark.xfail(reason="Cassandra 3.11.10 uses \"class\" instead of \"sstable_compression\" for compression settings by default #8948")
 def test_compression_class(cql, test_keyspace):
     with new_test_table(cql, test_keyspace, "p int primary key, v int", "with compression = { 'class': 'LZ4Compressor' }") as table:
         pass
@@ -37,7 +37,7 @@ def table_lz4(cql, test_keyspace):
 # "sstable_compression" attribute was used to set the compression class,
 # when reading the schema we should see "class".
 # Reproduces #8948.
-@pytest.mark.xfail(reason="#8948")
+@pytest.mark.xfail(reason="Cassandra 3.11.10 uses \"class\" instead of \"sstable_compression\" for compression settings by default #8948")
 def test_read_compression_class(cql, table_lz4):
     [ks, cf] = table_lz4.split('.')
     opts = cql.execute(f"SELECT compression FROM system_schema.tables WHERE keyspace_name='{ks}' AND table_name='{cf}'").one().compression
@@ -48,7 +48,7 @@ def test_read_compression_class(cql, table_lz4):
 # explicitly, some default value is nevertheless used, and its value should
 # be readable from the schema.
 # Reproduces #6442.
-@pytest.mark.xfail(reason="#6442")
+@pytest.mark.xfail(reason="Scylla stores un-expanded compaction class name in system tables #6442")
 def test_read_chunk_length(cql, table_lz4):
     [ks, cf] = table_lz4.split('.')
     opts = cql.execute(f"SELECT compression FROM system_schema.tables WHERE keyspace_name='{ks}' AND table_name='{cf}'").one().compression

--- a/test/cqlpy/test_static.py
+++ b/test/cqlpy/test_static.py
@@ -27,7 +27,7 @@ def table1(cql, test_keyspace):
 # and we have no good explanation why Scylla's behavior is more correct than
 # Cassandra. If we later decide that we consider *both* behaviors equally
 # correct, we can change the test to accept both and make it pass.
-@pytest.mark.xfail(reason="issue #10091")
+@pytest.mark.xfail(reason="GROUP BY returns incorrect values for rows with only static column set #10091")
 def test_static_not_selected(cql, table1):
     p = unique_key_int()
     # The partition p doesn't exist, so the following select yields nothing:

--- a/test/cqlpy/test_system_tables.py
+++ b/test/cqlpy/test_system_tables.py
@@ -64,7 +64,7 @@ def write_table_and_estimate_partitions(cql, test_keyspace, N):
 # up to 14%. So just to be generous let's allow a 25% inaccuracy for this
 # small test. In issue #9083 we noted that Scylla had much larger errors -
 # reporting as much as 10880 (!) partitions when we have just 1000.
-@pytest.mark.xfail(reason="issue #9083")
+@pytest.mark.xfail(reason="Always print all schema parameters (including default values) #9083")
 def test_partitions_estimate_simple_small(cql, test_keyspace):
     N = 1000
     count = write_table_and_estimate_partitions(cql, test_keyspace, N)
@@ -76,7 +76,7 @@ def test_partitions_estimate_simple_small(cql, test_keyspace):
 # This is a relatively long test (takes around 2 seconds), and isn't
 # needed to reproduce #9083 (the previous shorter test does it too),
 # so we skip this test.
-@pytest.mark.xfail(reason="issue #9083")
+@pytest.mark.xfail(reason="Always print all schema parameters (including default values) #9083")
 @pytest.mark.skip(reason="slow test, remove skip to try it anyway")
 def test_partitions_estimate_simple_large(cql, test_keyspace):
     N = 10000

--- a/test/cqlpy/test_type_duration.py
+++ b/test/cqlpy/test_type_duration.py
@@ -41,7 +41,7 @@ def table1(cql, test_keyspace):
 # Test each of the units which are supposed to be allowed, separately -
 # y, mo, w, d, h, m, s, ms, us *or* µs, ns:
 # Reproduces issue #8001
-@pytest.mark.xfail(reason="issue #8001")
+@pytest.mark.xfail(reason="Documented unit \"µs\" not supported for assigning a \"duration\" type #8001")
 def test_type_duration_human_readable_input_units(cql, table1):
     # Map of allowed units and their expected meaning.
     units = {

--- a/test/cqlpy/test_type_time.py
+++ b/test/cqlpy/test_type_time.py
@@ -25,7 +25,7 @@ def table1(cql, test_keyspace):
 # optional and if provided, can be less than the nanosecond). The following
 # tests verify that these different initialization options actually work.
 # Reproduces issue #7987
-@pytest.mark.xfail(reason="issue #7987")
+@pytest.mark.xfail(reason="Unprepared statement fails to set time column from an integer #7987")
 def test_type_time_from_int_unprepared(cql, table1):
     p = unique_key_int()
     cql.execute(f"INSERT INTO {table1} (p, t) VALUES ({p}, 123)")

--- a/test/cqlpy/test_type_timestamp.py
+++ b/test/cqlpy/test_type_timestamp.py
@@ -39,7 +39,7 @@ def table2(cql, test_keyspace):
 # and then read - so that is the Cassandra-compatible approach - but
 # arguably a more correct and useful behavior would be to fail the write
 # up-front, even before reaching the read.
-@pytest.mark.xfail(reason="issue #11588")
+@pytest.mark.xfail(reason="Timestamp validation happens during read, instead of during write #11588")
 def test_type_timestamp_overflow(cql, table1):
     p = unique_key_int()
     t = 1667215862 * 1000000
@@ -135,7 +135,7 @@ def test_type_timestamp_comparison(cql, table2):
 # Cassandra 4 added the feature of arithmetic between values in general, and
 # timestamps in particular (to which durations can be added). Scylla used to
 # be missing this feature - see #2693, #2694 and their many duplicates.
-@pytest.mark.xfail(reason="issue #2693, #2694")
+@pytest.mark.xfail(reason="issue #2693: Support arithmetic operators, #2694: Support operators on date-times")
 def test_type_timestamp_arithmetic(cql, table2):
     p = unique_key_int()
     cql.execute(f"INSERT INTO {table2} (p, c, t) VALUES ({p}, 1, '2011-02-03 04:05:12.345+0000')")


### PR DESCRIPTION
Added the title of the issue, if one existed, to the reason of why a test is skipped/xfailed.

Built on top of https://github.com/scylladb/scylladb/pull/28681 , so better wait for it to get included.


No need to backport, smallest quality of life improvement.