### PR TITLE
similarity functions: Extend support to vectors of doubles

### DIFF
--- a/cql3/functions/vector_similarity_fcts.hh
+++ b/cql3/functions/vector_similarity_fcts.hh
@@ -20,7 +20,7 @@ static const function_name SIMILARITY_COSINE_FUNCTION_NAME = function_name::nati
 static const function_name SIMILARITY_EUCLIDEAN_FUNCTION_NAME = function_name::native_function("similarity_euclidean");
 static const function_name SIMILARITY_DOT_PRODUCT_FUNCTION_NAME = function_name::native_function("similarity_dot_product");
 
-using similarity_function_t = float (*)(std::span<const float>, std::span<const float>);
+using similarity_function_t = float (*)(std::span<const double>, std::span<const double>);
 extern thread_local const std::unordered_map<function_name, similarity_function_t> SIMILARITY_FUNCTIONS;
 
 std::vector<data_type> retrieve_vector_arg_types(const function_name& name, const std::vector<shared_ptr<assignment_testable>>& provided_args);
@@ -36,10 +36,11 @@ public:
 
 namespace detail {
 
-// Extract float vector directly from serialized bytes, bypassing data_value overhead.
+// Extract double vector directly from serialized bytes, bypassing data_value overhead.
+// Supports both vector<float, N> and vector<double, N> element types.
 // This is an internal API exposed for testing purposes.
-// Vector<float, N> wire format: N floats as big-endian uint32_t values, 4 bytes each.
-std::vector<float> extract_float_vector(const bytes_opt& param, size_t dimension);
+// Wire format: N elements as big-endian values (4 bytes per float, 8 bytes per double).
+std::vector<double> extract_double_vector(const bytes_opt& param, size_t dimension, data_type element_type);
 
 } // namespace detail
 

--- a/test/cqlpy/test_vector_similarity.py
+++ b/test/cqlpy/test_vector_similarity.py
@@ -24,6 +24,8 @@ def table1(cql, test_keyspace):
         v2 vector<float, 3>,
         v3 vector<float, 2>,
         v4 vector<float, 4>,
+        vd1 vector<double, 3>,
+        vd2 vector<double, 3>,
         vs vector<text, 3>,
         c int,
         s set<float>,
@@ -36,7 +38,7 @@ def table1(cql, test_keyspace):
     ]
     with new_test_table(cql, test_keyspace, schema) as table1:
         for i, v in enumerate(data):
-            cql.execute(f"INSERT INTO {table1} (pk, ck, v1, v2) VALUES ({i}, {i}, {v}, {v})")
+            cql.execute(f"INSERT INTO {table1} (pk, ck, v1, v2, vd1, vd2) VALUES ({i}, {i}, {v}, {v}, {v}, {v})")
         yield table1
 
 
@@ -59,7 +61,7 @@ def compute_similarity(similarity_function, v1, v2):
 
 @pytest.mark.parametrize("similarity_function", similarity_functions)
 def test_vector_similarity_fails_on_non_float_vector_column(cql, table1, similarity_function):
-    expected_error=f"Function system.similarity_{similarity_function} requires a float vector argument"
+    expected_error=f"Function system.similarity_{similarity_function} requires a float or double vector argument"
     with pytest.raises(InvalidRequest, match=expected_error):
         cql.execute(f"SELECT pk, similarity_{similarity_function}(pk, [1.1, 1.2, 20.25]) FROM {table1}")
     with pytest.raises(InvalidRequest, match=expected_error):
@@ -72,7 +74,7 @@ def test_vector_similarity_fails_on_non_float_vector_column(cql, table1, similar
 
 @pytest.mark.parametrize("similarity_function", similarity_functions)
 def test_vector_similarity_fails_on_non_vector_literal(cql, table1, similarity_function):
-    expected_error=f"Function system.similarity_{similarity_function} requires a float vector argument"
+    expected_error=f"Function system.similarity_{similarity_function} requires a float or double vector argument"
     with pytest.raises(InvalidRequest, match=expected_error):
         cql.execute(f"SELECT pk, similarity_{similarity_function}(v1, 5) FROM {table1}")
     with pytest.raises(InvalidRequest, match=expected_error):
@@ -83,7 +85,7 @@ def test_vector_similarity_fails_on_non_vector_literal(cql, table1, similarity_f
 
 @pytest.mark.parametrize("similarity_function", similarity_functions)
 def test_vector_similarity_fails_on_non_float_vector(cql, table1, similarity_function):
-    expected_error=f"Function system.similarity_{similarity_function} requires a float vector argument" if is_scylla(cql) else "Type error"
+    expected_error=f"Function system.similarity_{similarity_function} requires a float or double vector argument" if is_scylla(cql) else "Type error"
     with pytest.raises(InvalidRequest, match=expected_error):
         cql.execute(f"SELECT pk, similarity_{similarity_function}(v1, [1.1, '2003-05-187T16:20:00.000', 20.25]) FROM {table1}")
     with pytest.raises(InvalidRequest, match=expected_error):
@@ -98,7 +100,7 @@ def test_vector_similarity_fails_on_non_float_vector(cql, table1, similarity_fun
 
 @pytest.mark.parametrize("similarity_function", similarity_functions)
 def test_vector_similarity_fails_on_non_float_vector_constants(cql, table1, similarity_function):
-    expected_error=f"Function system.similarity_{similarity_function} requires a float vector argument"
+    expected_error=f"Function system.similarity_{similarity_function} requires a float or double vector argument"
     with pytest.raises(InvalidRequest, match=expected_error):
         cql.execute(f"SELECT pk, similarity_{similarity_function}(1, 2) FROM {table1}")
     with pytest.raises(InvalidRequest, match=expected_error):
@@ -212,14 +214,29 @@ def test_vector_similarity_with_column_and_literal(cql, table1, similarity_funct
     query_vector = [0.707107, 0.0, -0.707107]
     result = cql.execute(f"SELECT v1, similarity_{similarity_function}(v1, {query_vector}) FROM {table1}")
     for row in result:
-        isclose(row[1], compute_similarity(similarity_function, row.v1, query_vector))
+        assert isclose(row[1], compute_similarity(similarity_function, row.v1, query_vector), abs_tol=1e-5)
+    # Test with double vector column
+    result = cql.execute(f"SELECT vd1, similarity_{similarity_function}(vd1, {query_vector}) FROM {table1}")
+    for row in result:
+        assert isclose(row[1], compute_similarity(similarity_function, row.vd1, query_vector), abs_tol=1e-5)
 
 
 @pytest.mark.parametrize("similarity_function", similarity_functions)
 def test_vector_similarity_with_two_columns(cql, table1, similarity_function):
     result = cql.execute(f"SELECT v1, v2, similarity_{similarity_function}(v1, v2) FROM {table1}")
     for row in result:
-        isclose(row[2], compute_similarity(similarity_function, row.v1, row.v2))
+        assert isclose(row[2], compute_similarity(similarity_function, row.v1, row.v2), abs_tol=1e-5)
+    # Test with double vector columns
+    result = cql.execute(f"SELECT vd1, vd2, similarity_{similarity_function}(vd1, vd2) FROM {table1}")
+    for row in result:
+        assert isclose(row[2], compute_similarity(similarity_function, row.vd1, row.vd2), abs_tol=1e-5)
+    # Test with mixed float and double columns
+    result = cql.execute(f"SELECT v1, vd1, similarity_{similarity_function}(v1, vd1) FROM {table1}")
+    for row in result:
+        assert isclose(row[2], compute_similarity(similarity_function, row.v1, row.vd1), abs_tol=1e-5)
+    result = cql.execute(f"SELECT vd1, v1, similarity_{similarity_function}(vd1, v1) FROM {table1}")
+    for row in result:
+        assert isclose(row[2], compute_similarity(similarity_function, row.vd1, row.v1), abs_tol=1e-5)
 
 
 @pytest.mark.parametrize("similarity_function", similarity_functions)
@@ -228,7 +245,7 @@ def test_vector_similarity_with_two_literals(cql, table1, similarity_function):
     v2 = [0.707107, 0.0, -0.707107]
     result = cql.execute(f"SELECT pk, similarity_{similarity_function}({v1}, {v2}) FROM {table1}")
     for row in result:
-        isclose(row[1], compute_similarity(similarity_function, v1, v2))
+        assert isclose(row[1], compute_similarity(similarity_function, v1, v2), abs_tol=1e-5)
 
 
 @pytest.mark.parametrize("similarity_function", sorted(set(similarity_functions) - {"cosine"}))
@@ -236,13 +253,17 @@ def test_vector_similarity_with_zero_vectors(cql, table1, similarity_function):
     zero = [0.0, 0.0, 0.0]
     result = cql.execute(f"SELECT pk, v1, similarity_{similarity_function}(v1, {zero}) FROM {table1}")
     for row in result:
-        isclose(row[2], compute_similarity(similarity_function, row.v1, zero))
+        assert isclose(row[2], compute_similarity(similarity_function, row.v1, zero), abs_tol=1e-5)
     result = cql.execute(f"SELECT pk, v1, similarity_{similarity_function}({zero}, v1) FROM {table1}")
     for row in result:
-        isclose(row[2], compute_similarity(similarity_function, zero, row.v1))
+        assert isclose(row[2], compute_similarity(similarity_function, zero, row.v1), abs_tol=1e-5)
     result = cql.execute(f"SELECT pk, v1, similarity_{similarity_function}({zero}, {zero}) FROM {table1}")
     for row in result:
-        isclose(row[2], compute_similarity(similarity_function, zero, zero))
+        assert isclose(row[2], compute_similarity(similarity_function, zero, zero), abs_tol=1e-5)
+    # Test with double vector column
+    result = cql.execute(f"SELECT pk, vd1, similarity_{similarity_function}(vd1, {zero}) FROM {table1}")
+    for row in result:
+        assert isclose(row[2], compute_similarity(similarity_function, row.vd1, zero), abs_tol=1e-5)
 
 
 def test_vector_similarity_cosine_with_zero_vectors(cql, table1):
@@ -254,6 +275,11 @@ def test_vector_similarity_cosine_with_zero_vectors(cql, table1):
         cql.execute(f"SELECT pk, v1, similarity_cosine({zero}, v1) FROM {table1}")
     with pytest.raises(InvalidRequest, match=expected_error):
         cql.execute(f"SELECT pk, v1, similarity_cosine({zero}, {zero}) FROM {table1}")
+    # Test with double vector column
+    with pytest.raises(InvalidRequest, match=expected_error):
+        cql.execute(f"SELECT pk, vd1, similarity_cosine(vd1, {zero}) FROM {table1}")
+    with pytest.raises(InvalidRequest, match=expected_error):
+        cql.execute(f"SELECT pk, vd1, similarity_cosine({zero}, vd1) FROM {table1}")
 
 
 @pytest.mark.parametrize("similarity_function", similarity_functions)
@@ -262,17 +288,26 @@ def test_vector_similarity_with_bind_variables(cql, table1, similarity_function)
     stmt = cql.prepare(f"SELECT pk, v1, similarity_{similarity_function}(v1, ?) FROM {table1}")
     result = cql.execute(stmt, (query_vector,))
     for row in result:
-        isclose(row[2], compute_similarity(similarity_function, row.v1, query_vector))
+        assert isclose(row[2], compute_similarity(similarity_function, row.v1, query_vector), abs_tol=1e-5)
     stmt = cql.prepare(f"SELECT pk, v1, similarity_{similarity_function}({query_vector}, ?) FROM {table1}")
     result = cql.execute(stmt, (query_vector,))
     for row in result:
-        isclose(row[2], compute_similarity(similarity_function, query_vector, query_vector))
+        assert isclose(row[2], compute_similarity(similarity_function, query_vector, query_vector), abs_tol=1e-5)
     stmt = cql.prepare(f"SELECT pk, v1, similarity_{similarity_function}(?, v1) FROM {table1}")
     result = cql.execute(stmt, (query_vector,))
     for row in result:
-        isclose(row[2], compute_similarity(similarity_function, query_vector, row.v1))
+        assert isclose(row[2], compute_similarity(similarity_function, query_vector, row.v1), abs_tol=1e-5)
     with pytest.raises(InvalidRequest, match="Cannot infer type of argument ?"):
         cql.prepare(f"SELECT pk, v1, similarity_{similarity_function}(?, ?) FROM {table1}")
+    # Test with double vector column
+    stmt = cql.prepare(f"SELECT pk, vd1, similarity_{similarity_function}(vd1, ?) FROM {table1}")
+    result = cql.execute(stmt, (query_vector,))
+    for row in result:
+        assert isclose(row[2], compute_similarity(similarity_function, row.vd1, query_vector), abs_tol=1e-5)
+    stmt = cql.prepare(f"SELECT pk, vd1, similarity_{similarity_function}(?, vd1) FROM {table1}")
+    result = cql.execute(stmt, (query_vector,))
+    for row in result:
+        assert isclose(row[2], compute_similarity(similarity_function, query_vector, row.vd1), abs_tol=1e-5)
 
 
 # Should fail but works both on Scylla and Cassandra.
@@ -282,11 +317,11 @@ def test_vector_similarity_with_bind_variables_set(cql, table1, similarity_funct
     stmt = cql.prepare(f"SELECT pk, v1, similarity_{similarity_function}(v1, ?) FROM {table1}")
     result = cql.execute(stmt, ({1.0, 2.0, 3.0},))
     for row in result:
-        isclose(row[2], compute_similarity(similarity_function, row.v1, {1.0, 2.0, 3.0}))
+        assert isclose(row[2], compute_similarity(similarity_function, row.v1, {1.0, 2.0, 3.0}), abs_tol=1e-5)
     stmt = cql.prepare(f"SELECT pk, v1, similarity_{similarity_function}(?, v1) FROM {table1}")
     result = cql.execute(stmt, ({1.0, 2.0, 3.0},))
     for row in result:
-        isclose(row[2], compute_similarity(similarity_function, {1.0, 2.0, 3.0}, row.v1))
+        assert isclose(row[2], compute_similarity(similarity_function, {1.0, 2.0, 3.0}, row.v1), abs_tol=1e-5)
     with pytest.raises(InvalidRequest, match="Cannot infer type of argument ?"):
         cql.prepare(f"SELECT pk, v1, similarity_{similarity_function}(?, ?) FROM {table1}")
 
@@ -308,10 +343,10 @@ def test_cassandra_documentation_compatibility(cql, test_keyspace, similarity_fu
             assert row[1] is None
         result = cql.execute(f"SELECT pk, similarity_{similarity_function}(v, [0.1, 0.2]) FROM {table}")
         for row in result:
-            isclose(row[1], expected_results[similarity_function][0])
+            assert isclose(row[1], expected_results[similarity_function][0], abs_tol=1e-5)
         result = cql.execute(f"SELECT pk, similarity_{similarity_function}(v, [-0.1, -0.2]) FROM {table}")
         for row in result:
-            isclose(row[1], expected_results[similarity_function][1])
+            assert isclose(row[1], expected_results[similarity_function][1], abs_tol=1e-5)
         result = cql.execute(f"SELECT pk, similarity_{similarity_function}(v, [0.9, 0.8]) FROM {table}")
         for row in result:
-            isclose(row[1], expected_results[similarity_function][2])
+            assert isclose(row[1], expected_results[similarity_function][2], abs_tol=1e-5)


### PR DESCRIPTION
So far similarity functions supported only arguments of type vector<float, N>. With this patch arguments of type vector<double, N> are allowed and correctly handled. Mixed arguments of float and double vectors are allowed - `similarity_*(vector<float, N>, vector<double, N>)`.
Existing tests are extended to test doubles.

Follow-up #28615

New feature - no backport.