### PR TITLE
build: install cassandra-stress RPM with no signature check

### DIFF
--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -157,7 +157,10 @@ fedora_packages=(
     podman
     buildah
 
-    https://github.com/scylladb/cassandra-stress/releases/download/v3.18.1/cassandra-stress-java21-3.18.1-1.noarch.rpm
+    # for cassandra-stress
+    java-openjdk-headless
+    snappy
+
     elfutils
     jq
 
@@ -386,6 +389,10 @@ elif [ "$ID" = "fedora" ]; then
         exit 1
     fi
     dnf install -y "${fedora_packages[@]}" "${fedora_python3_packages[@]}"
+
+    # Fedora 45 tightened key checks, and cassandra-stress is not signed yet.
+    dnf install --no-gpgchecks -y https://github.com/scylladb/cassandra-stress/releases/download/v3.18.1/cassandra-stress-java21-3.18.1-1.noarch.rpm
+
     PIP_DEFAULT_ARGS="--only-binary=:all: -v"
     pip_constrained_packages=""
     for package in "${!pip_packages[@]}"


### PR DESCRIPTION
Fedora 45 tightened the default installation checks [1]. As a result the cassandra-stress rpm we provide no longer installs.

Install it with --no-gpgchecks as a workaround. It's our own package so we trust it. Later we'll sign it properly.

We install its dependencies via the normal methods so they're still checked.

[1] https://fedoraproject.org/wiki/Changes/Enforcing_signature_checking_by_default

No backport - this is looking forward to a Fedora 45 toolchain.