### PR TITLE
dist: tune tcp_mem to 3% of total memory in scylla-kernel-conf package

### DIFF
--- a/dist/debian/control.template
+++ b/dist/debian/control.template
@@ -39,7 +39,7 @@ Description: debugging symbols for %{product}-server
 
 Package: %{product}-kernel-conf
 Architecture: any
-Depends: procps
+Depends: procps, sed
 Replaces: scylla-enterprise-kernel-conf (<< 2025.1.0~)
 Breaks: scylla-enterprise-kernel-conf (<< 2025.1.0~)
 Description: Scylla kernel tuning configuration

--- a/dist/debian/debian/scylla-kernel-conf.postrm
+++ b/dist/debian/debian/scylla-kernel-conf.postrm
@@ -6,6 +6,7 @@ case "$1" in
     purge|remove)
         if [ "$1" = "purge" ]; then
             rm -f /etc/sysctl.d/99-scylla-perfevent.conf
+            rm -f /etc/sysctl.d/99-scylla-tcp.conf
         fi
         ;;
 esac

--- a/dist/redhat/scylla.spec
+++ b/dist/redhat/scylla.spec
@@ -186,7 +186,7 @@ This package contains the main scylla configuration file.
 %package kernel-conf
 Group:          Applications/Databases
 Summary:        Scylla configuration package for the Linux kernel
-Requires:       kmod
+Requires:       kmod sed
 # tuned overwrites our sysctl settings
 Obsoletes:      tuned >= 2.11.0
 Provides:       scylla-enterprise-kernel-conf = %{version}-%{release}
@@ -220,6 +220,7 @@ fi
 %{_unitdir}/scylla-tune-sched.service
 /opt/scylladb/kernel_conf/*
 %ghost /etc/sysctl.d/99-scylla-perfevent.conf
+%ghost /etc/sysctl.d/99-scylla-tcp.conf
 
 
 %package node-exporter

--- a/unified/uninstall.sh
+++ b/unified/uninstall.sh
@@ -64,6 +64,7 @@ if ! $nonroot; then
     rm -fv "$retc"/bash_completion.d/nodetool-completion
     rm -fv "$retc"/supervisord.d/scylla-*.ini
     rm -fv "$rusr"/lib/sysctl.d/99-scylla-*.conf
+    rm -fv "$retc"/sysctl.d/99-scylla-tcp.conf
     rm -fv "$rusr"/bin/{scylla,iotune,scyllatop}
     rm -fv "$rusr"/sbin/{scylla_*setup,node_exporter_install,node_health_check,scylla_ec2_check,scylla_kernel_check}
     find "$rusr"/lib/scylla -type l -exec rm -fv {} \;


### PR DESCRIPTION
tcp_mem defaults to 9% of total memory. ScyllaDB defaults to 93%. The sum is more than 100%.

Fix by tuning tcp_mem to 3% of total memory.

Fixes https://scylladb.atlassian.net/browse/SCYLLADB-734

While this should be backported, it should undergo some soak testing first. Not backporting now.