### PR TITLE
docs: improve examples in `Handling Audit Failures` section

### DIFF
--- a/docs/operating-scylla/security/auditing.rst
+++ b/docs/operating-scylla/security/auditing.rst
@@ -215,8 +215,8 @@ Handling Audit Failures
 
 In some cases, auditing may not be possible, for example, when:
 
-* A table is used as the audit’s backend, and the audit partition where the audit row is saved is not available because the node that holds this partition is down.
-* Syslog is used as the audit’s backend, and the Syslog sink (a regular unix socket) is unresponsive/unavailable.
+* A table is used as the audit’s backend, and the partitions where the audit rows are saved are unavailable because the nodes holding those partitions are down or unreachable due to network issues.
+* Syslog is used as the audit’s backend, and the Syslog sink (a regular Unix socket) is unresponsive or unavailable.
 
 If the audit fails and audit messages are not stored in the configured audit’s backend, you can still review the audit log in the regular ScyllaDB logs.
 


### PR DESCRIPTION
This commit introduces four changes:
 - In the `table` example, singular forms (node, partition) are changed to plural forms (nodes, partitions). Currently, the default `table` audit configuration is RF=3 and writes use CL=ONE. Therefore, a `table` audit log write failure should not be caused by a single node unavailability, and plural forms are more adequate.
 - In the `table` example, unreachability due to network issues is mentioned because with RF=3, audit failure due to network problems is more likely to happen than a simultaneous failure of three nodes (such network failures happened in SCYLLADB-706).
 - In the `syslog` example, a slash `/` is changed to `or`, so `table` and `syslog` examples have similar structure.
 - As the `syslog` line is already being changed, I also change `unix` to `Unix`, as the capitalized form is the correct one.

Refs SCYLLADB-706

No backport, just a clarification in the documentation.