### PR TITLE
test.py: Add argus reporting to test.py runs

### DIFF
--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -190,6 +190,8 @@ declare -A pip_packages=(
     [pytest-xdist]=""
     [pykmip]=""
     [universalasync]=""
+    [argus-alm]=""
+    [pytest-argus-reporter]=""
     [boto3-stubs[dynamodb]]=""
     [setuptools_scm]=""
 )

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
 #
 
+import logging
 import pytest
 
 from test import TEST_RUNNER
@@ -11,6 +12,7 @@ from test.pylib.report_plugin import ReportPlugin
 
 
 pytest_plugins = []
+logger = logging.getLogger(__name__)
 
 
 if TEST_RUNNER == "runpy":
@@ -19,6 +21,7 @@ if TEST_RUNNER == "runpy":
         return None
 else:
     pytest_plugins.append("test.pylib.runner")
+    pytest_plugins.append("test.pylib.argus_report")
 
 
 def pytest_configure(config: pytest.Config) -> None:

--- a/test/pylib/argus_report.py
+++ b/test/pylib/argus_report.py
@@ -1,0 +1,58 @@
+#
+# Copyright (C) 2025-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+#
+
+import sys
+import logging
+import os
+import json
+from typing import Any
+
+import pytest
+
+LOGGER = logging.getLogger(__name__)
+
+
+def pytest_sessionstart(session: pytest.Session):
+    LOGGER.debug("Session start for %s", os.environ.get("PYTEST_XDIST_WORKER", "master"))
+    argus_reporter = session.config.pluginmanager.get_plugin("argus-reporter-runtime")
+    reporter_enabled = (
+        session.config.getoption("--argus-post-reports")
+        or "--pytest-arg=--argus-post-reports" in sys.argv
+        or bool(int(os.environ.get("ARGUS_XDIST_ENABLE_REPORTING", "0")))
+    )
+    LOGGER.debug("Reporting will be %s, Argv: %s", reporter_enabled, sys.argv)
+    if argus_reporter and reporter_enabled:
+        try:
+            argus_reporter.base_url = os.environ["ARGUS_BASE_URL"]
+            argus_reporter.api_key = os.environ["ARGUS_AUTH_TOKEN"]
+            argus_reporter.extra_headers = json.loads(os.environ.get("ARGUS_EXTRA_HEADERS", "{}"))
+            argus_reporter.run_id = os.environ["ARGUS_RUN_ID"]
+            argus_reporter.test_type = "test.py"
+            argus_reporter.post_reports = reporter_enabled
+            if not os.environ.get("PYTEST_XDIST_WORKER"):
+                os.environ["ARGUS_XDIST_ENABLE_REPORTING"] = "1"
+            LOGGER.debug("Initialized argus with following settings: BaseUrl: %s, Token Length: %s, Headers: %s, Run Id: %s", argus_reporter.base_url, len(argus_reporter.api_key), bool(argus_reporter.extra_headers), argus_reporter.run_id)
+        except KeyError as exc:
+            LOGGER.warning("Unable to configure Argus Reporting, missing: %s", exc.args[0], exc_info=True)
+        except Exception: 
+            LOGGER.warning("General error setting up argus reporting..", exc_info=True)
+
+
+@pytest.fixture(scope="session", autouse=True)
+def configure_argus_reporter(request: pytest.FixtureRequest, config: pytest.Config):
+    argus_reporter = None
+    try:
+        argus_reporter = request.getfixturevalue("argus_reporter")
+    except pytest.FixtureLookupError:
+        pass
+
+    if argus_reporter:
+        extra_data = {
+            "SCYLLA_ARCH": os.environ.get("SCYLLA_ARCH") or os.uname().machine,
+            "SCYLLA_MODE": config.getoption("mode"),
+            **{k.lower(): v for k, v in os.environ.items() if k.startswith("BUILD_")},
+        }
+        argus_reporter.session_data.update(**extra_data)

--- a/test/pylib/runner.py
+++ b/test/pylib/runner.py
@@ -68,7 +68,7 @@ def pytest_addoption(parser: pytest.Parser) -> None:
                      help="Run only tests for given build mode(s)")
     parser.addoption('--tmpdir', action='store', default=str(TOP_SRC_DIR / 'testlog'),
                      help='Path to temporary test data and log files.  The data is further segregated per build mode.')
-    parser.addoption('--run_id', action='store', default=None, help='Run id for the test run')
+    parser.addoption('--run_id', dest="pylib_run_id", action='store', default=None, help='Run id for the test run')
     parser.addoption('--byte-limit', action="store", default=randint(0, 2000), type=int,
                      help="Specific byte limit for failure injection (random by default)")
     parser.addoption("--gather-metrics", action=BooleanOptionalAction, default=False,

--- a/tools/toolchain/image
+++ b/tools/toolchain/image
@@ -1,1 +1,1 @@
-docker.io/scylladb/scylla-toolchain:fedora-43-20260304
+docker.io/scylladb/scylla-toolchain:fedora-43-20260219


### PR DESCRIPTION
This commit adds argus reporting for pytest test results inside test.py
runs. This is accomplished via pytest-argus-reporter pytest plugin,
which has now been added to the required package list as well as hooks
inside root conftest.py file. Currently, it reports the build
environment, the build mode and durations / status of each test.

To use the reporting, at the minimum, requires passing --argus-run-id,
--argus-test-type, --argus-post-reports, --argus-base-url and
--argus-api-key. The documentation for those can be found inside argus
repository. These params can also be provided as env vars.

Required changes to the pipeline are handled in a separate PR (passing
of newly required environment vars and cmdline args) in scylladb/scylla-pkg#5903

Task: QAINFRA-48

Backport status: unsure yet, will decide during the course of the review.
