### PR TITLE
tools: toolchain: build sanitizers for future toolchain

### DIFF
--- a/tools/toolchain/future.dockerfile
+++ b/tools/toolchain/future.dockerfile
@@ -33,7 +33,6 @@ RUN git clone --depth=1 --branch="${GCC_VERSION}" git://gcc.gnu.org/git/gcc.git 
         --enable-languages=c,c++ \
         --disable-multilib \
         --disable-bootstrap \
-        --disable-libsanitizer \
         --enable-libstdcxx-threads \
         --with-system-zlib && \
     make -j$(nproc) && \


### PR DESCRIPTION
The future toolchain did not build the sanitizers, so debug executables did not link. Fix by not disabling the sanitizers.

For future toolchain only, not backporting.