### PR TITLE
nodetool: cluster repair: do not fail if a table was dropped

### DIFF
--- a/tools/scylla-nodetool.cc
+++ b/tools/scylla-nodetool.cc
@@ -690,6 +690,9 @@ void cluster_repair_operation(scylla_rest_client& client, const bpo::variables_m
                         // will repair also their colocated tables.
                         continue;
                     }
+                    if (tables.empty() && std::string(ex.what()).contains("Can't find a column family")) {
+                        continue;
+                    }
                     log("ERROR: Repair request for keyspace={} table={} failed with {}", keyspace, table, ex);
                     exit_code = EXIT_FAILURE;
                 }


### PR DESCRIPTION
nodetool cluster repair without additional params repairs all tablet keyspaces in a cluster. Currently, if a table is dropped while the command is running, all tables are repaired but the command finishes with a failure.

nodetool cluster repair finishes successfully if a table was dropped.

Fixes: SCYLLADB-568.

Needs backport to all live versions as they all fail in case of a table drop