### PR TITLE
test/scylla_gdb: skip coroutine tests if coroutine frame is not found

### DIFF
--- a/test/scylla_gdb/test_task_commands.py
+++ b/test/scylla_gdb/test_task_commands.py
@@ -47,24 +47,13 @@ def coroutine_task(gdb_cmd, scylla_server):
     Finds a coroutine task, similar to the `task` fixture.
 
     This fixture executes the `coroutine_config` script in GDB to locate a
-    specific coroutine task. If the task is not found, the `coroutine_debug_config`
-    debugging script is called which checks if scylla_find agrees with find_vptrs.
-
-    This debugging script then forces a coredump to capture additional
-    diagnostic information before the test is marked as failed.
-    Coredump is saved to `testlog/release/{scylla}`.
+    specific coroutine task.
     """
     result = execute_gdb_command(gdb_cmd, full_command="python get_coroutine()").stdout
     match = re.search(r"coroutine_config=\s*(.*)", result)
     if not match:
-        result = execute_gdb_command(
-            gdb_cmd,
-            full_command=f"python coroutine_debug_config('{scylla_server.workdir}')",
-        )
-        pytest.fail(
-            f"Failed to find coroutine task. Debugging logs have been collected\n"
-            f"Debugging code result: {result}\n"
-        )
+        # See https://github.com/scylladb/scylladb/issues/22501
+        pytest.skip("Failed to find coroutine task. Skipping test.")
 
     return match.group(1).strip()
 


### PR DESCRIPTION
For a while, we have seen coroutine related tests (those that use the coroutine_task fixture) fail occasionally, because no coroutine frame is found. Multiple attempts were made to make this problem self-diagnosing and dump enough information to be able to debug this post-mortem. To no avail so far. A lot of time was invested into this this benign issue: See the long discussion at https://github.com/scylladb/scylladb/issues/22501.

It is not known if the bug is in gdb, or the gdb script trying to find the coroutine frame. In any case, both are only used for debugging, so we can tolerate occasional failures -- we are forced to do so when working with gdb anyway.
Instead of piling on more effor there, just skip these tests when the problem occurs. This solves the CI flakyness.

Fixes: #22501

CI stability fix for a rarely failing test, no backport needed.