### PR TITLE
test: fix configuration of test_autoretrain_dict

### DIFF
--- a/test/cluster/test_sstable_compression_dictionaries_autotrain.py
+++ b/test/cluster/test_sstable_compression_dictionaries_autotrain.py
@@ -54,7 +54,7 @@ async def test_autoretrain_dict(manager: ManagerClient):
     uncompressed_size = blob_size * n_blobs * rf
 
     # Start with compressor without a dictionary
-    cfg = { "sstable_compression_user_table_options": "ZstdCompressor" }
+    cfg = { "sstable_compression_user_table_options": { 'sstable_compression': 'ZstdCompressor' } }
 
     logger.info("Bootstrapping cluster")
     servers = await manager.servers_add(2, cmdline=[


### PR DESCRIPTION
`test_autoretrain_dict` sporadically fails because the default compression algorithm was changed after the test was written.

`9ffa62a986815709d0a09c705d2d0caf64776249` was an attempt to fix it by changing the compression configuration during node startup. However, the configuration change had an incorrect YAML format and was ignored by ScyllaDB. This commit fixes it.

Fixes: scylladb/scylladb#28204

Backport to 2026.1 and 2025.4, as the previous attempt to fix the test (https://github.com/scylladb/scylladb/issues/28204) is already there.