### PR TITLE
vector: Vectorize loops in similarity functions

### DIFF
--- a/cql3/functions/vector_similarity_fcts.cc
+++ b/cql3/functions/vector_similarity_fcts.cc
@@ -11,7 +11,8 @@
 #include "types/vector.hh"
 #include "exceptions/exceptions.hh"
 #include <span>
-#include <bit>
+#include <cstring>
+#include <seastar/core/byteorder.hh>
 
 namespace cql3 {
 namespace functions {
@@ -31,13 +32,15 @@ std::vector<float> extract_float_vector(const bytes_opt& param, vector_dimension
     }
 
     std::vector<float> result;
-    result.reserve(dimension);
+    result.resize(dimension);
 
-    bytes_view view(*param);
+    // Bulk copy bytes from param to result
+    std::memcpy(result.data(), param->data(), expected_size);
+
+    // Convert endianness in-place (network byte order is big-endian)
+    uint32_t* data = reinterpret_cast<uint32_t*>(result.data());
     for (size_t i = 0; i < dimension; ++i) {
-        // read_simple handles network byte order (big-endian) conversion
-        uint32_t raw = read_simple<uint32_t>(view);
-        result.push_back(std::bit_cast<float>(raw));
+        data[i] = be_to_cpu(data[i]);
     }
 
     return result;
@@ -55,13 +58,14 @@ namespace {
 // You should only use this function if you need to preserve the original vectors and cannot normalize
 // them in advance.
 float compute_cosine_similarity(std::span<const float> v1, std::span<const float> v2) {
-    double dot_product = 0.0;
-    double squared_norm_a = 0.0;
-    double squared_norm_b = 0.0;
+    #pragma clang fp contract(fast) reassociate(on) // Allow the compiler to optimize the loop.
+    float dot_product = 0.0;
+    float squared_norm_a = 0.0;
+    float squared_norm_b = 0.0;
 
     for (size_t i = 0; i < v1.size(); ++i) {
-        double a = v1[i];
-        double b = v2[i];
+        float a = v1[i];
+        float b = v2[i];
 
         dot_product += a * b;
         squared_norm_a += a * a;
@@ -79,13 +83,14 @@ float compute_cosine_similarity(std::span<const float> v1, std::span<const float
 }
 
 float compute_euclidean_similarity(std::span<const float> v1, std::span<const float> v2) {
-    double sum = 0.0;
+    #pragma clang fp contract(fast) reassociate(on) // Allow the compiler to optimize the loop.
+    float sum = 0.0;
 
     for (size_t i = 0; i < v1.size(); ++i) {
-        double a = v1[i];
-        double b = v2[i];
+        float a = v1[i];
+        float b = v2[i];
 
-        double diff = a - b;
+        float diff = a - b;
         sum += diff * diff;
     }
 
@@ -98,11 +103,12 @@ float compute_euclidean_similarity(std::span<const float> v1, std::span<const fl
 // Assumes that both vectors are L2-normalized.
 // This similarity is intended as an optimized way to perform cosine similarity calculation.
 float compute_dot_product_similarity(std::span<const float> v1, std::span<const float> v2) {
-    double dot_product = 0.0;
+    #pragma clang fp contract(fast) reassociate(on) // Allow the compiler to optimize the loop.
+    float dot_product = 0.0;
 
     for (size_t i = 0; i < v1.size(); ++i) {
-        double a = v1[i];
-        double b = v2[i];
+        float a = v1[i];
+        float b = v2[i];
         dot_product += a * b;
     }
 


### PR DESCRIPTION
The main loops iterating over vector components were not vectorized due to:
- "cannot prove it is safe to reorder floating-point operations"
- "Cannot vectorize early exit loop with more than one early exit"

The first issue is fixed with adding `#pragma clang fp contract(fast) reassociate(on)`, which allows compiler to optimize floating point operations.
The second issue is solved by refactoring the operations in the affected loop.
Additionally using float operations instead of double increases throughput and numerical accuracy is not the main consideration in vector search scenarios.

Performance measured:
- scylla built using dbuild
- using https://github.com/zilliztech/VectorDBBench (modified to call `SELECT id, similarity_cosine({vector<float, 1536>}, {vector<float, 1536>}) ...` without ANN search):
- client concurrency 20

before: ~2250 QPS
`float` operations: ~2350 QPS
`compute_cosine_similarity` vectorization: ~2500QPS
`extract_float_vector` vectorization: ~3000QPS

Follow-up https://github.com/scylladb/scylladb/pull/28615
Ref https://scylladb.atlassian.net/browse/SCYLLADB-764

Backport to 2026.1 - to improve performance of rescoring introduced in that release.