### PR TITLE
build: install antlr3 from maven + source, not rpm packages

### DIFF
--- a/tools/antlr3-patches/0006-antlr3memory.hpp-fix-for-C-20-mode.patch
+++ b/tools/antlr3-patches/0006-antlr3memory.hpp-fix-for-C-20-mode.patch
@@ -1,0 +1,39 @@
+From 478902a7e57e2283c57410f5aa14939e743b5102 Mon Sep 17 00:00:00 2001
+From: Avi Kivity <avi@scylladb.com>
+Date: Tue, 12 May 2020 14:51:18 +0300
+Subject: [PATCH] antlr3memory.hpp: fix for C++20 mode
+
+gcc 10 in C++20 mode requires that the allocator type match
+the type used to allocate, so do that by adding "const" to the
+key type.
+---
+ runtime/Cpp/include/antlr3memory.hpp | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/runtime/Cpp/include/antlr3memory.hpp b/runtime/Cpp/include/antlr3memory.hpp
+index 7713613..4667a00 100755
+--- a/runtime/Cpp/include/antlr3memory.hpp
++++ b/runtime/Cpp/include/antlr3memory.hpp
+@@ -98,17 +98,17 @@ public:
+ 	{
+ 	};
+ 
+ 	template<class KeyType, class ValueType>
+ 	class UnOrderedMapType : public std::map< KeyType, ValueType, std::less<KeyType>, 
+-										AllocatorType<std::pair<KeyType, ValueType> > >
++										AllocatorType<std::pair<const KeyType, ValueType> > >
+ 	{
+ 	};
+ 
+ 	template<class KeyType, class ValueType>
+ 	class OrderedMapType : public std::map< KeyType, ValueType, std::less<KeyType>, 
+-										AllocatorType<std::pair<KeyType, ValueType> > >
++										AllocatorType<std::pair<const KeyType, ValueType> > >
+ 	{
+ 	};
+ 
+ 	ANTLR_INLINE static void* operator new (std::size_t bytes)
+ 	{ 
+-- 
+2.26.2
+

--- a/tools/antlr3-patches/0008-unconst-cyclicdfa-gcc-14.patch
+++ b/tools/antlr3-patches/0008-unconst-cyclicdfa-gcc-14.patch
@@ -1,0 +1,29 @@
+--- a/runtime/Cpp/include/antlr3cyclicdfa.hpp.orig	2024-02-01 14:13:33.243312124 +0200
++++ b/runtime/Cpp/include/antlr3cyclicdfa.hpp	2024-02-01 14:12:28.493542243 +0200
+@@ -61,18 +61,18 @@
+     /// Decision number that a particular static structure
+     ///  represents.
+     ///
++    ANTLR_INT32		m_decisionNumber;
+-    const ANTLR_INT32		m_decisionNumber;
+ 
+     /// What this decision represents
+     ///
+     const ANTLR_UCHAR*			m_description;
++	const ANTLR_INT32*	m_eot;
++    const ANTLR_INT32*	m_eof;
++    const ANTLR_INT32*	m_min;
++    const ANTLR_INT32*	m_max;
++    const ANTLR_INT32*	m_accept;
++    const ANTLR_INT32*	m_special;
++    const ANTLR_INT32* const *	m_transition;
+-	const ANTLR_INT32* const	m_eot;
+-    const ANTLR_INT32* const	m_eof;
+-    const ANTLR_INT32* const	m_min;
+-    const ANTLR_INT32* const	m_max;
+-    const ANTLR_INT32* const	m_accept;
+-    const ANTLR_INT32* const	m_special;
+-    const ANTLR_INT32* const *const	m_transition;
+ 
+ public:
+ 	CyclicDFA( ANTLR_INT32	decisionNumber

--- a/tools/toolchain/image
+++ b/tools/toolchain/image
@@ -1,1 +1,1 @@
-docker.io/scylladb/scylla-toolchain:fedora-43-20260203
+docker.io/scylladb/scylla-toolchain:fedora-43-20260223


### PR DESCRIPTION
Fedora removed the C++ backend from antlr3 [1], citing incompatible license. The license in question (the Unicode license) is fine for us.

To be able to continue using antlr3, build it ourselves. The main executable can be used as is from Maven, since we don't need any patches for the parser. The runtime needs to be patched, so we download the source and patch it.

Regenerated frozen toolchain with optimized clang from

  https://devpkg.scylladb.com/clang/clang-21.1.8-Fedora-43-aarch64.tar.gz
  https://devpkg.scylladb.com/clang/clang-21.1.8-Fedora-43-x86_64.tar.gz

Fixes https://scylladb.atlassian.net/browse/SCYLLADB-773

We will need to backport this to releases based on Fedora 43, though perhaps not immediately.