### PR TITLE
test: cluster: add continue-after-error to perf tool tests

### DIFF
--- a/test/cluster/test_tools_perf.py
+++ b/test/cluster/test_tools_perf.py
@@ -34,7 +34,7 @@ def scylla_path(build_mode):
 
 @pytest.mark.parametrize("mode", ["read"])
 async def test_perf_simple_query(scylla_path, mode, tmp_path):
-    args = [scylla_path, "perf-simple-query", "--duration", "1", "--partitions", "1000"]
+    args = [scylla_path, "perf-simple-query", "--duration", "1", "--partitions", "1000", "--stop-on-error", "false"]
     await run(args)
 
 
@@ -54,7 +54,8 @@ async def test_perf_cql_raw(scylla_path, tmp_path, workload):
         "--smp", "2",
         "--workdir", str(tmp_path),
         "--developer-mode", "1",
-        "--partitions", "1000"
+        "--partitions", "1000",
+        "--continue-after-error", "true"
     ]
     try:
         await run(cmd)
@@ -81,7 +82,8 @@ async def test_perf_alternator(scylla_path, tmp_path, workload):
         "--smp", "2",
         "--workdir", str(tmp_path),
         "--developer-mode", "1",
-        "--partitions", "1000"
+        "--partitions", "1000",
+        "--continue-after-error", "true"
     ]
     try:
         await run(cmd)
@@ -101,7 +103,8 @@ async def test_perf_cql_raw_remote(scylla_path, tmp_path, workload, manager):
         "--duration", "1",
         "--remote-host", host,
         "--smp", "1",
-        "--partitions", "1000"
+        "--partitions", "1000",
+        "--continue-after-error", "true"
     ]
     await run(client_cmd)
 
@@ -121,6 +124,7 @@ async def test_perf_alternator_remote(scylla_path, tmp_path, workload, manager):
         "--duration", "1",
         "--remote-host", host,
         "--smp", "1",
-        "--partitions", "1000"
+        "--partitions", "1000",
+        "--continue-after-error", "true"
     ]
     await run(client_cmd)


### PR DESCRIPTION
Add --continue-after-error true to perf-cql-raw and perf-alternator tests, and --stop-on-error false to perf-simple-query test, so that tests don't abort on the first error.

Reason for this is that tests are flaky with example failure: Perf test failed: std::runtime_error (server returned ERROR to EXECUTE)

When CPU is starved on CI we can return timeouts and/or other errors.

The change should make tests more robust on the expense of smaller test scope. But those tests were written mostly to test startup sequence as it differs from Scylla's starup.

Fixes https://scylladb.atlassian.net/browse/SCYLLADB-759

Backport: no, not a bug