### PR TITLE
hint_sender: send hints to all tablet replicas if the tablet leaving due to RF--

### DIFF
--- a/db/hints/internal/hint_endpoint_manager.cc
+++ b/db/hints/internal/hint_endpoint_manager.cc
@@ -55,6 +55,15 @@ future<> hint_endpoint_manager::do_store_hint(schema_ptr s, lw_shared_ptr<const 
     }
 
     try {
+        co_await utils::get_local_injector().inject("drop_hint_for_host", [&] (auto& handler) -> future<> {
+            // drop the hint, but only for the host given in the parameters
+            const std::string_view host_dst = handler.template get<std::string_view>("hint_host_dst").value();
+            if (host_dst == end_point_key().to_sstring()) {
+                throw std::runtime_error(::format("Dropping hint for host {}", host_dst));
+            }
+            return make_ready_future<>();
+        });
+
         const auto shared_lock = co_await get_shared_lock(file_update_mutex());
 
         hints_store_ptr log_ptr = co_await get_or_load();

--- a/db/hints/internal/hint_sender.cc
+++ b/db/hints/internal/hint_sender.cc
@@ -252,20 +252,20 @@ future<> hint_sender::send_one_mutation(frozen_mutation_and_schema m) {
     host_id_vector_replica_set natural_endpoints = ermp->get_natural_replicas(token);
     host_id_vector_topology_change pending_endpoints  = ermp->get_pending_replicas(token);
 
-    return futurize_invoke([this, m = std::move(m), ermp = std::move(ermp), &natural_endpoints, &pending_endpoints] () mutable -> future<> {
+    return futurize_invoke([this, m = std::move(m), ermp = std::move(ermp), &natural_endpoints, &pending_endpoints, &token] () mutable -> future<> {
         // The fact that we send with CL::ALL in both cases below ensures that new hints are not going
         // to be generated as a result of hints sending.
-        const auto& tm = ermp->get_token_metadata();
         const auto dst = end_point_key();
 
-        if (std::ranges::contains(natural_endpoints, dst) && !tm.is_leaving(dst)) {
+        const bool is_leaving = ermp->is_leaving(dst, token);
+        if (std::ranges::contains(natural_endpoints, dst) && (!is_leaving || !pending_endpoints.empty())) {
             manager_logger.trace("hint_sender[{}]:send_one_mutation: Sending directly", dst);
             // dst is not duplicated in pending_endpoints because it's in natural_endpoints
             return _proxy.send_hint_to_endpoint(std::move(m), std::move(ermp), dst, std::move(pending_endpoints));
         } else {
             if (manager_logger.is_enabled(log_level::trace)) {
-                if (tm.is_leaving(end_point_key())) {
-                    manager_logger.trace("hint_sender[{}]:send_one_mutation: Original target is leaving. Mutating from scratch", dst);
+                if (is_leaving) {
+                    manager_logger.trace("hint_sender[{}]:send_one_mutation: Original target host or tablet replica is leaving. Mutating from scratch", dst);
                 } else {
                     manager_logger.trace("hint_sender[{}]:send_one_mutation: Endpoint set has changed and original target is no longer a replica. Mutating from scratch", dst);
                 }

--- a/locator/abstract_replication_strategy.hh
+++ b/locator/abstract_replication_strategy.hh
@@ -345,6 +345,8 @@ public:
     virtual dht::shard_replica_set shards_ready_for_reads(const schema& s, const token& token) const {
         return {shard_for_reads(s, token)};
     }
+
+    virtual bool is_leaving(locator::host_id host, const dht::token& token) const = 0;
 };
 
 using effective_replication_map_ptr = seastar::shared_ptr<const effective_replication_map>;
@@ -439,6 +441,10 @@ public:
 
     void unregister() noexcept {
         _factory = nullptr;
+    }
+
+    virtual bool is_leaving(locator::host_id host, const token&) const override {
+        return get_token_metadata().is_leaving(host);
     }
 };
 

--- a/locator/tablets.cc
+++ b/locator/tablets.cc
@@ -1445,6 +1445,22 @@ public:
     virtual dht::shard_replica_set shards_ready_for_reads(const schema& s, const token& token) const override {
         return _sharder.shards_ready_for_reads(token);
     }
+
+    virtual bool is_leaving(locator::host_id host, const dht::token& token) const override {
+        // Check if the token belongs to the tablet which is currently being migrated away from host
+        auto& tmap = get_tablet_map();
+        auto tid = tmap.get_tablet_id(token);
+        auto transition = tmap.get_tablet_transition_info(tid);
+        if (transition) {
+            auto& info = tmap.get_tablet_info(tid);
+            auto leaving_opt = locator::get_leaving_replica(info, *transition);
+            if (leaving_opt && leaving_opt->host == host) {
+                return true;
+            }
+        }
+
+        return false;
+    }
 };
 
 void tablet_aware_replication_strategy::validate_tablet_options(const abstract_replication_strategy& ars,

--- a/test/cluster/test_hints.py
+++ b/test/cluster/test_hints.py
@@ -421,3 +421,74 @@ async def test_hint_to_pending(manager: ManagerClient):
             task.result()
 
         assert list(await cql.run_async(f"SELECT v FROM {table} WHERE pk = 0")) == [(0,)]
+
+@pytest.mark.asyncio
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
+async def test_hint_to_leaving_when_reducing_rf(manager: ManagerClient):
+    '''
+    This test checks if hint_sender sends a mutation to a leaving replica if the mutation
+    belongs to a tablet which is being removed due to RF--. This is needed to improve
+    consistency. https://scylladb.atlassian.net/browse/SCYLLADB-287
+    '''
+    # We have only one shard to force the two sets of hints to the same shard and avoid
+    # the problem with waiting for hint sync point timing out when the only hint on a shard has been dropped
+    # https://scylladb.atlassian.net/browse/SCYLLADB-1192
+    cmdline = ['--smp=1', "--logger-log-level", "hints_manager=trace"]
+    servers = await manager.servers_add(3, property_file=[
+        {"dc": "dc1", "rack": "r1"},
+        {"dc": "dc1", "rack": "r2"},
+        {"dc": "dc1", "rack": "r3"},
+    ], cmdline=cmdline)
+    cql = await manager.get_cql_exclusive(servers[0])
+    await manager.disable_tablet_balancing()
+
+    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': ['r2', 'r3']}") as ks:
+        table = f"{ks}.t"
+        await cql.run_async(f"CREATE TABLE {table} (pk int primary key, v int) WITH tablets = {{'min_tablet_count': 1}};")
+        host_ids = [await manager.get_host_id(server.server_id) for server in servers]
+
+        # Stop the servers with replicas
+        await manager.server_stop_gracefully(servers[1].server_id)
+        await manager.others_not_see_server(servers[1].ip_addr)
+        await manager.server_stop_gracefully(servers[2].server_id)
+        await manager.others_not_see_server(servers[2].ip_addr)
+
+        # This will cause the hint for host_ids[1] to be dropped
+        await manager.api.enable_injection(servers[0].ip_addr, 'drop_hint_for_host', one_shot=False, parameters={'hint_host_dst': host_ids[1]})
+
+        # This will attempt to write the hints for both replicas, but only the write for the hint for host_ids[2] will succeed
+        await cql.run_async(SimpleStatement(f"INSERT INTO {table} (pk, v) VALUES (0, 0)", consistency_level=ConsistencyLevel.ANY))
+
+        # Write another record, but this time disable dropping the hint. This is needed to get around the problem
+        # where waiting for the hint sync point times out when we only have a single hint which was dropped
+        # https://scylladb.atlassian.net/browse/SCYLLADB-1192
+        await manager.api.disable_injection(servers[0].ip_addr, 'drop_hint_for_host')
+        await cql.run_async(SimpleStatement(f"INSERT INTO {table} (pk, v) VALUES (1, 1)", consistency_level=ConsistencyLevel.ANY))
+
+        await manager.api.enable_injection(servers[0].ip_addr, "hinted_handoff_pause_hint_replay", one_shot=False)
+        await manager.server_start(servers[1].server_id)
+        await manager.server_start(servers[2].server_id)
+
+        coord = await get_topology_coordinator(manager)
+        coord_serv = await find_server_by_host_id(manager, servers, coord)
+        await manager.api.enable_injection(coord_serv.ip_addr, "stream_tablet_wait", one_shot=False)
+
+        alter_rf_fut = cql.run_async(f"ALTER KEYSPACE {ks} WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'dc1': ['r2']}}")
+
+        async def migration_reached_streaming():
+            stages = await cql.run_async(f"SELECT stage FROM system.tablets WHERE keyspace_name='{ks}' ALLOW FILTERING")
+            logger.info(f"Current stages: {[row.stage for row in stages]}")
+            return set(["streaming"]) == set([row.stage for row in stages]) or None
+        await wait_for(migration_reached_streaming, time.time() + 60)
+
+        sync_point = await create_sync_point(manager.api.client, servers[0].ip_addr)
+
+        # Complete hints handoff
+        await manager.api.disable_injection(servers[0].ip_addr, "hinted_handoff_pause_hint_replay")
+        assert await await_sync_point(manager.api.client, servers[0].ip_addr, sync_point, 30)
+
+        await manager.api.disable_injection(coord_serv.ip_addr, "stream_tablet_wait")
+
+        await alter_rf_fut
+
+        assert list(await cql.run_async(f"SELECT v FROM {table} WHERE pk = 0")) == [(0,)]


### PR DESCRIPTION
Currently, hints that are sent to tablet replicas which are leaving due to RF-- can be lost, because `hint_sender` only checks if the destination host is leaving. To avoid this, we add a new method `effective_replication_map::is_leaving(host, token)` which checks if the tablet identified by the given token is leaving the host. This method is called by the `hint_sender` to check if the hint should be sent only to the destination host, or to all the replicas. This way, we increase consistency. For v-node based ERPs, `is_leaving()` calls `token_metadata::is_leaving(host)`.

Fixes: SCYLLADB-287

This is an improvement, and backport is not needed.