### PR TITLE
storage_service: raft_topology_cmd_handler: fix use-after-free

### DIFF
--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -6277,7 +6277,7 @@ future<raft_topology_cmd_result> storage_service::raft_topology_cmd_handler(raft
                     if (!server_rs) {
                         on_internal_error(rtlogger, format("Got {} request for node {} not found in topology", cmd.cmd, id));
                     }
-                    const auto& rs = server_rs->second;
+                    const auto rs = server_rs->second;
                     auto tstate = _topology_state_machine._topology.tstate;
                     auto session = _topology_state_machine._topology.session;
                     if (!rs.ring || rs.ring->tokens.empty()) {


### PR DESCRIPTION
8e9c7397c5f61ed6182ed2fa7f5277698c3c1759 made `rs` a reference, which can
lead to use-after-free. The `normal_nodes` map containing the referenced
value can be destroyed before the last use of `rs` when the topology state
is reloaded after a context switch on some `co_await`. The following move
assignment in `storage_service::topology_state_load` causes this:
```
_topology_state_machine._topology = co_await _sys_ks.local().load_topology_state(tablet_hosts);
```

This issue has been discovered in next-2026.1 CI after queueing the
backport of #28558. `test_truncate_during_topology_change` failed after
ASan reported a heap-use-after-free in
```
co_await _repair.local().bootstrap_with_repair(get_token_metadata_ptr(), rs.ring.value().tokens, session);
```
This test enables `delay_bootstrap_120s`, which makes the bug much more
likely to reproduce, but it could happen elsewhere.

No backport needed, as the only backport of #28558 hasn't been merged yet.
The backport PR will cherry-pick this commit.