### PR TITLE
test/cqlpy: remove xfail from test_constant_function_parameter

### DIFF
--- a/test/cqlpy/test_native_functions.py
+++ b/test/cqlpy/test_native_functions.py
@@ -30,7 +30,6 @@ def tbl_set(cql, test_keyspace):
 # take a constant. This feature is barely useful for WHERE clauses, and
 # even less useful for selectors, but should be allowed for both.
 # Reproduces #12607.
-@pytest.mark.xfail(reason="issue #12607")
 def test_constant_function_parameter(cql, table1):
     p = unique_key_int()
     cql.execute(f"INSERT INTO {table1} (p, b) VALUES ({p}, 0x03)")


### PR DESCRIPTION
The issue was fixed by commit cc03f5c89d
("cql3: support literals and bind variables in selectors"), so the xfail marker is no longer needed.

Backport: no, just test marker change