### PR TITLE
doc: remove the tablets limitation for Alternator

### DIFF
--- a/docs/alternator/alternator.md
+++ b/docs/alternator/alternator.md
@@ -142,10 +142,6 @@ want modify a non-top-level attribute directly (e.g., a.b[3].c) need RMW:
 Alternator implements such requests by reading the entire top-level
 attribute a, modifying only a.b[3].c, and then writing back a.
 
-Currently, Alternator doesn't use Tablets. That's because Alternator relies
-on LWT (lightweight transactions), and LWT is not supported in keyspaces
-with Tablets enabled.
-
 ```{eval-rst}
 .. toctree::
     :maxdepth: 2


### PR DESCRIPTION
This PR removes the information that Alternator doesn't support tablets. The limitation is no longer valid.

Fixes SCYLLADB-778

This PR must be backported to branch-2025.4 and branch-20261, because the limitation was lifted in version 2025.4. It was properly documented - the sentence removed with this PR is a leftover.