### PR TITLE
install: use `rprefix` for api_ui_dir and api_doc_dir paths

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -347,8 +347,8 @@ install -d -m755 "$retc"/scylla.d
 scylla_yaml_dir=$(mktemp -d)
 scylla_yaml=$scylla_yaml_dir/scylla.yaml
 grep -v api_ui_dir conf/scylla.yaml | grep -v api_doc_dir > $scylla_yaml
-echo "api_ui_dir: /opt/scylladb/swagger-ui/dist/" >> $scylla_yaml
-echo "api_doc_dir: /opt/scylladb/api/api-doc/" >> $scylla_yaml
+echo "api_ui_dir: $rprefix/swagger-ui/dist/" >> $scylla_yaml
+echo "api_doc_dir: $rprefix/api/api-doc/" >> $scylla_yaml
 installconfig 644 $scylla_yaml "$retc"/scylla
 rm -rf $scylla_yaml_dir
 


### PR DESCRIPTION
## Problem

The `api_ui_dir` and `api_doc_dir` paths in `scylla.yaml` were hardcoded to `/opt/scylladb`, causing REST API endpoints (`/api-doc/*`) to fail for offline rootless installations where the installation directory differs.

Example failure:
```
$ curl http://127.0.0.1:10000/api-doc/failure_detector/
curl: (18) transfer closed with outstanding read data remaining
```

## Solution

Use the `$rprefix` variable instead of hardcoded `/opt/scylladb`, ensuring the paths are correctly set for both standard installations and offline/nonroot installations.

Fixes: SCYLLADB-721

## Backport

**Backport to all supported releases** - This bug affects all versions with offline installation support.