### PR TITLE
test.py: add possibility to run downloaded Scylla binary

### DIFF
--- a/test.py
+++ b/test.py
@@ -252,6 +252,12 @@ def parse_cmd_line() -> argparse.Namespace:
     parser.add_argument("--pytest-arg", action='store', type=str,
                         default=None, dest="pytest_arg",
                         help="Additional command line arguments to pass to pytest, for example ./test.py --pytest-arg=\"-v -x\"")
+    parser.add_argument('--exe-path', default=False,
+                     dest="exe_path", action="store",
+                     help="Path to the executable to run. Not working with `mode`")
+    parser.add_argument('--exe-url', default=False,
+                     dest="exe_url", action="store",
+                     help="URL to download the relocatable executable. Not working with `mode`")
     scylla_additional_options = parser.add_argument_group('Additional options for Scylla tests')
     scylla_additional_options.add_argument('--extra-scylla-cmdline-options', action="store", default="", type=str,
                                            help="Passing extra scylla cmdline options for all tests. Options should be space separated:"

--- a/test/pylib/runner.py
+++ b/test/pylib/runner.py
@@ -104,7 +104,12 @@ def pytest_addoption(parser: pytest.Parser) -> None:
     # Pass information about Scylla node from test.py to pytest.
     parser.addoption("--scylla-log-filename",
                      help="Path to a log file of a ScyllaDB node (for suites with type: Python)")
-
+    parser.addoption('--exe-path', default=False,
+                     dest="exe_path", action="store",
+                     help="Path to the executable to run. Not working with `mode`")
+    parser.addoption('--exe-url', default=False,
+                     dest="exe_url", action="store",
+                     help="URL to download the relocatable executable. Not working with `mode`")
 
 @pytest.fixture(autouse=True)
 def print_scylla_log_filename(request: pytest.FixtureRequest) -> Generator[None]:
@@ -262,6 +267,13 @@ def pytest_sessionfinish(session: pytest.Session) -> None:
 def pytest_configure(config: pytest.Config) -> None:
     global _pytest_config
     _pytest_config = config
+    if config.getoption("--exe-url") and config.getoption("--exe-path"):
+        raise RuntimeError("Can't use --exe-url and exe-path simultaneously.")
+
+    if  config.getoption("--exe-path") or config.getoption("--exe-url"):
+            if config.getoption("--mode"):
+                raise RuntimeError("Can't use --mode with --exe-path or --exe-url.")
+            config.option.modes = ["custom_exe"]
 
     config.build_modes = get_modes_to_run(config)
     repeat = int(config.getoption("--repeat"))

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -229,6 +229,13 @@ async def get_scylla_2025_1_executable(build_mode: str) -> str:
     arch = platform.machine()
     url = f'https://downloads.scylladb.com/downloads/scylla/relocatable/scylladb-2025.1/{package}-2025.1.0-0.20250325.9dca28d2b818.{arch}.tar.gz'
 
+    return await get_scylla_executable(url)
+
+async def get_scylla_executable(url: str) -> str:
+    async def run_process(cmd, **kwargs):
+        proc = await asyncio.create_subprocess_exec(*cmd, **kwargs)
+        await proc.communicate()
+        assert proc.returncode == 0
     archive_filename = urllib.parse.urlparse(url).path.split("/")[-1]
 
     xdg_cache_dir = pathlib.Path(os.getenv("XDG_CACHE_HOME", str(pathlib.Path.home() / ".cache")))

--- a/test/pylib/suite/base.py
+++ b/test/pylib/suite/base.py
@@ -34,7 +34,7 @@ from test.pylib.resource_gather import get_resource_gather, setup_cgroup
 from test.pylib.s3_proxy import S3ProxyServer
 from test.pylib.s3_server_mock import MockS3Server
 from test.pylib.util import LogPrefixAdapter, get_xdist_worker_id
-
+from test.pylib.scylla_cluster import get_scylla_executable
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterable
     from typing import Any, List
@@ -599,5 +599,9 @@ async def get_testpy_test(path: pathlib.Path, options: argparse.Namespace, mode:
     except FileNotFoundError:
         suite_config = find_suite_config(path=path, config_filename=TEST_CONFIG_FILENAME)
     suite = TestSuite.opt_create(config=suite_config, options=options, mode=mode)
+    if getattr(options, "exe_path", False):
+        suite.scylla_exe = options.exe_path
+    elif getattr(options, "exe_url", False):
+        suite.scylla_exe = await get_scylla_executable(options.exe_url)
     await suite.add_test(shortname=str(path.relative_to(suite.suite_path).with_suffix("")), casename=None)
     return suite.tests[-1]


### PR DESCRIPTION
Add possibility to run Scylla binary that is stored or download the relocatable package with Scylla.

No backport, test framework enhancement only.

Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-243