### PR TITLE
tools/scylla-sstable: filter_operation(): use deferred_close() to close reader

### DIFF
--- a/tools/scylla-sstable.cc
+++ b/tools/scylla-sstable.cc
@@ -2294,11 +2294,11 @@ void filter_operation(schema_ptr schema, reader_permit permit, const std::vector
         fmt::print(std::cout, "Filtering {}... ", name);
 
         auto reader = make_reader(source);
+        auto close_reader = deferred_close(reader);
 
         // Peek the reader to see if it has any content after filtering.
         if (!reader.peek().get()) {
             fmt::print(std::cout, "no output\n");
-            reader.close().get();
             continue;
         }
 
@@ -2313,6 +2313,8 @@ void filter_operation(schema_ptr schema, reader_permit permit, const std::vector
                 schema,
                 writer_cfg,
                 encoding_stats{}).get();
+
+        close_reader.cancel();
 
         fmt::print(std::cout, "output written to {}\n", new_sst->get_filename());
     }


### PR DESCRIPTION
Manual closing is bypassed with exceptions, promoting an exception to a crash due to unclosed reader.

Backport: this is a fix for a crash, but one for a corner-case of a rarely used tool, so no backport needed.