### PR TITLE
scylla-sstable: query: handle nested UDTs

### DIFF
--- a/test/cqlpy/test_tools.py
+++ b/test/cqlpy/test_tools.py
@@ -1826,11 +1826,26 @@ textwrap.dedent("""
     None,
 )
 
+scylla_sstable_query_nested_udt = scylla_sstable_query_simple_table_param(
+textwrap.dedent("""
+    CREATE TABLE {}.{} (
+        pk int PRIMARY KEY,
+        col_nested_udt list<frozen<my_type>>
+    ) WITH
+        compaction = {{'class': 'NullCompactionStrategy'}};
+"""),
+    "INSERT INTO {}.{} (pk, col_nested_udt) VALUES (?, ?)",
+    (0, [my_udt(10, 'aasdad')]),
+    "CREATE TYPE {}.my_type (field_1 int, field_2 text)",
+    "DROP TYPE {}.my_type",
+)
+
 @pytest.mark.parametrize("test_keyspace", ["tablets", "vnodes"], indirect=True)
 @pytest.mark.parametrize("test_table", [
         scylla_sstable_query_simple_all_types_param,
         scylla_sstable_query_simple_collection_types_param,
         scylla_sstable_query_simple_counter_param,
+        scylla_sstable_query_nested_udt,
 ])
 def test_scylla_sstable_query_data_types(request, cql, test_keyspace, test_table, scylla_path, scylla_data_dir, temp_workdir):
     """Check read-all queries with all data-types.

--- a/tools/scylla-sstable.cc
+++ b/tools/scylla-sstable.cc
@@ -1651,9 +1651,9 @@ future<replica::table&> create_table_in_cql_env(cql_test_env& env, schema_ptr ss
             builder.with_column(col.name(), col.type, col_kind, col.view_virtual());
 
             // Register any user types, so they are known by the time we create the table.
-            if (col.type->is_user_type()) {
-                keyspace.add_user_type(dynamic_pointer_cast<const user_type_impl>(col.type));
-            }
+            invoke_on_user_type(col.type, [&keyspace] (const user_type_impl& udt) {
+                keyspace.add_user_type(dynamic_pointer_cast<const user_type_impl>(udt.shared_from_this()));
+            });
         }
     }
     auto schema = builder.build();


### PR DESCRIPTION
The query (and in certain modes the write) operations uses virtual table facility inside `cql_test_env`. The schema of the sstable is created as a table in `cql_test_env`. This involves registering all UDTs with the keyspace, so they are available for lookups.
This was done with a flat loop over all column types, but this is not enough. UDTs might be nested in other types, like collections. One has to do a traversal of the type tree and register every UDT on the way.
This PR changes the flat loop to a recursive traversal of the type tree. The query operation now works with UDTs, no matter how deeply nested they are.

Backport: Implements missing functionality of a tool, no backport.