### PR TITLE
install.sh: fix REST API paths for nonroot installations

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -350,8 +350,8 @@ install -d -m755 "$retc"/scylla.d
 scylla_yaml_dir=$(mktemp -d)
 scylla_yaml=$scylla_yaml_dir/scylla.yaml
 grep -v api_ui_dir conf/scylla.yaml | grep -v api_doc_dir > $scylla_yaml
-echo "api_ui_dir: /opt/scylladb/swagger-ui/dist/" >> $scylla_yaml
-echo "api_doc_dir: /opt/scylladb/api/api-doc/" >> $scylla_yaml
+echo "api_ui_dir: $prefix/swagger-ui/dist/" >> $scylla_yaml
+echo "api_doc_dir: $prefix/api/api-doc/" >> $scylla_yaml
 installconfig 644 $scylla_yaml "$retc"/scylla
 rm -rf $scylla_yaml_dir
 


### PR DESCRIPTION
In nonroot installations, the install.sh script was hardcoding the api_ui_dir and api_doc_dir paths to /opt/scylladb/ in scylla.yaml, even though the actual files were installed to a different location (typically ~/scylladb). This caused REST API endpoints like /api-doc/failure_detector/ to fail with "transfer closed with outstanding read data remaining" error because Scylla couldn't find the API documentation files at the configured paths.

Fix this by using the $prefix variable instead of hardcoded /opt/scylladb/ paths. This ensures that:
- In regular installations: $prefix = /opt/scylladb (no change)
- In nonroot installations: $prefix = ~/scylladb (paths now correct)

Fixes: SCYLLADB-721

Backport: The hardcoded paths in install.sh have been present since the nonroot installation feature was introduced, making REST API endpoints non-functional in all nonroot installations across all live versions of Scylla.
