### PR TITLE
[Backport 2025.1] test/pylib/util.py: Add retries and additional logging to start_writes()

### DIFF
--- a/test/pylib/util.py
+++ b/test/pylib/util.py
@@ -182,7 +182,6 @@ class KeyGenerator:
         with self.pk_lock:
             return self.pk
 
-
 async def start_writes(cql: Session, keyspace: str, table: str, concurrency: int = 3, ignore_errors=False):
     logger.info(f"Starting to asynchronously write, concurrency = {concurrency}")
 
@@ -199,6 +198,21 @@ async def start_writes(cql: Session, keyspace: str, table: str, concurrency: int
     key_gen = KeyGenerator()
 
     async def do_writes(worker_id: int):
+        async def run_retry_async(cql, *args, **kwargs):
+            retry_attempts = 1 if ignore_errors else 3
+            sleep_time = 0.05  # 50ms
+            error = None
+            for _ in range(retry_attempts):
+                try:
+                    return await cql.run_async(*args, **kwargs)
+                except Exception as e:
+                    error = e
+
+                logger.debug(f"Retrying in {sleep_time} second(s)")
+                await asyncio.sleep(sleep_time)
+                sleep_time *= 2  # Exponential backoff
+            raise error
+
         write_count = 0
         while not stop_event.is_set():
             pk = key_gen.next_pk()
@@ -206,18 +220,20 @@ async def start_writes(cql: Session, keyspace: str, table: str, concurrency: int
             # Once next_pk() is produced, key_gen.last_key() is assumed to be in the database
             # hence we can't give up on it.
             while True:
+                start_time = time.time()
                 try:
                     await cql.run_async(stmt, [pk, pk])
                     # Check read-your-writes
-                    rows = await cql.run_async(rd_stmt, [pk])
+                    rows = await run_retry_async(cql, rd_stmt, [pk])
                     assert(len(rows) == 1)
                     assert(rows[0].c == pk)
                     write_count += 1
                     break
                 except Exception as e:
                     if ignore_errors:
-                        pass # Expected when node is brought down temporarily
+                        logger.debug(f"Suppressed exception: {e} (expected when node is brought down temporarily)")
                     else:
+                        logger.error(f"Exception occurred during read/write operation for pk={pk} started {time.time() - start_time}s ago: {e}")
                         raise e
 
             if pk == warmup_writes:


### PR DESCRIPTION
Consider the following scenario:
1. Let nodes A,B,C form a cluster with RF=3
2. Write query with CL=QUORUM is submitted and is acknowledged by nodes B,C
3. Follow-up read query with CL=QUORUM is sent to verify the write from the previous step
4. Coordinator sends data/digest requests to the nodes A,B. Since the node A is missing data, digest mismatches and data reconciliation is triggered
5. The node A or B fails, becomes unavailable, etc
6. During reconciliation, data requests are sent to node A,B and fail failing the entire read query

When the above scenario happens, the tests using `start_writes()` fail with the following stacktrace:
```
...

>           await finish_writes()

test/cluster/test_tablets_migration.py:259:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
test/pylib/util.py:241: in finish
    await asyncio.gather(*tasks)
test/pylib/util.py:227: in do_writes
    raise e
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

worker_id = 1

...

>                   rows = await cql.run_async(rd_stmt, [pk])
E                   cassandra.ReadFailure: Error from server: code=1300 [Replica(s) failed to execute read] message="Operation failed for test_1767777001181_bmsvk.test - received 1 responses and 1 failures from 2 CL=QUORUM." info={'consistency': 'QUORUM', 'required_responses': 2, 'received_responses': 1, 'failures': 1}
```

Note that when a node failure happens before/during a read query, there is no test failure as the speculative retries are enabled by default. Hence an additional data/digest read is sent to the third remaining node.

However, the same speculative read is cancelled the moment, the read query reaches CL which may trigger a read-repair.

This change:
- Retries the verification read in start_writes() on failure to mitigate races between reads and node failures
- Adds additional logging to correlate Python exceptions with Scylla logs

Fixes https://github.com/scylladb/scylladb/issues/27478 Fixes https://github.com/scylladb/scylladb/issues/27974 Fixes https://github.com/scylladb/scylladb/issues/27494 Fixes https://github.com/scylladb/scylladb/issues/23529

Note that this change test flakiness observed during tablet transitions. However, it serves as a workaround for a higher-level issue https://github.com/scylladb/scylladb/issues/28125

Closes scylladb/scylladb#28140

(cherry picked from commit e07fe2536e98477ed2791ffac74d753e2165921c)

Parent PR: https://github.com/scylladb/scylladb/pull/28140