### PR TITLE
cql3: suggest ALTER MATERIALIZED VIEW to users trying to use ALTER TABLE on a view

### DIFF
--- a/cql3/statements/alter_table_statement.cc
+++ b/cql3/statements/alter_table_statement.cc
@@ -296,7 +296,7 @@ void alter_table_statement::drop_column(const query_options& options, const sche
 std::pair<schema_ptr, std::vector<view_ptr>> alter_table_statement::prepare_schema_update(data_dictionary::database db, const query_options& options) const {
     auto s = validation::validate_column_family(db, keyspace(), column_family());
     if (s->is_view()) {
-        throw exceptions::invalid_request_exception("Cannot use ALTER TABLE on Materialized View");
+        throw exceptions::invalid_request_exception("Cannot use ALTER TABLE on Materialized View. (Did you mean ALTER MATERIALIZED VIEW)?");
     }
 
     const bool is_cdc_log_table = cdc::is_log_for_some_table(db.real_database(), s->ks_name(), s->cf_name());

--- a/cql3/statements/alter_view_statement.cc
+++ b/cql3/statements/alter_view_statement.cc
@@ -46,7 +46,7 @@ future<> alter_view_statement::check_access(query_processor& qp, const service::
 view_ptr alter_view_statement::prepare_view(data_dictionary::database db) const {
     schema_ptr schema = validation::validate_column_family(db, keyspace(), column_family());
     if (!schema->is_view()) {
-        throw exceptions::invalid_request_exception("Cannot use ALTER MATERIALIZED VIEW on Table");
+        throw exceptions::invalid_request_exception("Cannot use ALTER MATERIALIZED VIEW on Table. (Did you mean ALTER TABLE)?");
     }
 
     if (!_properties) {

--- a/cql3/statements/describe_statement.cc
+++ b/cql3/statements/describe_statement.cc
@@ -307,7 +307,7 @@ future<std::vector<description>> table(const data_dictionary::database& db, cons
     
     auto s = validation::validate_column_family(db, ks, name);
     if (s->is_view()) { 
-        throw exceptions::invalid_request_exception("Cannot use DESC TABLE on materialized View");
+        throw exceptions::invalid_request_exception("Cannot use DESC TABLE on materialized View. (Did you mean DESC MATERIALIZED VIEW)?");
     }
 
     auto schema = table->schema();


### PR DESCRIPTION
When a user tries to use ALTER TABLE on a materialized view, the resulting error message is `Cannot use ALTER TABLE on Materialized View`.

The intention behind this error is that ALTER MATERIALIZED VIEW should be used instead.

But we observed that some users interpret this error message as a general "You cannot do any ALTER on this thing".

This patch enhances the error message (and others similar to it) to prevent the confusion.

Enhancement, no backport needed.