### PR TITLE
Remove prepare_snapshot_for_backup() helper from backup/restore tests

### DIFF
--- a/test/cluster/object_store/test_backup.py
+++ b/test/cluster/object_store/test_backup.py
@@ -42,18 +42,6 @@ def create_ks_and_cf(cql):
     return ks, cf
 
 
-async def prepare_snapshot_for_backup(manager: ManagerClient, server, snap_name='backup'):
-    cql = manager.get_cql()
-    print('Create keyspace')
-    ks, cf = create_ks_and_cf(cql)
-    print('Flush keyspace')
-    await manager.api.flush_keyspace(server.ip_addr, ks)
-    print('Take keyspace snapshot')
-    await manager.api.take_snapshot(server.ip_addr, ks, snap_name)
-
-    return ks, cf
-
-
 async def take_snapshot(ks, servers, manager, logger):
     logger.info(f'Take snapshot and collect sstables lists')
     snap_name = unique_name('backup_')


### PR DESCRIPTION
The helper in question duplicates the functionality of `take_snapshot()` one from the same file. The only difference is that it additionally creates keyspace:table with yet another helper, but that helper is also going to be removed (as continuation of #28600 and #28608)

Enhancing tests, not backporting