### PR TITLE
.github/workflows/trigger-scylla-ci.yaml: fix org membership check in trigger-scylla-ci workflow

### DIFF
--- a/.github/workflows/trigger-scylla-ci.yaml
+++ b/.github/workflows/trigger-scylla-ci.yaml
@@ -14,20 +14,19 @@ jobs:
     steps:
       - name: Verify Org Membership
         id: verify_author
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: bash
         run: |
           if [[ "${{ github.event_name }}" == "pull_request_target" ]]; then
             AUTHOR="${{ github.event.pull_request.user.login }}"
+            ASSOCIATION="${{ github.event.pull_request.author_association }}"
           else
             AUTHOR="${{ github.event.comment.user.login }}"
+            ASSOCIATION="${{ github.event.comment.author_association }}"
           fi
-          ORG="scylladb"
-          if gh api "/orgs/${ORG}/members/${AUTHOR}" --silent 2>/dev/null; then
+          if [[ "$ASSOCIATION" == "MEMBER" || "$ASSOCIATION" == "OWNER" ]]; then
             echo "member=true" >> $GITHUB_OUTPUT
           else
-            echo "::warning::${AUTHOR} is not a member of ${ORG}; skipping CI trigger."
+            echo "::warning::${AUTHOR} is not a member of scylladb (association: ${ASSOCIATION}); skipping CI trigger."
             echo "member=false" >> $GITHUB_OUTPUT
           fi
 


### PR DESCRIPTION
Following becb48b586f50cd6ffa08d89c29c0cbfba8cff48 it seems we have a regression with trigger CI logic

The Verify Org Membership step used gh api /orgs/scylladb/members/$AUTHOR with GITHUB_TOKEN to check if the user is an org member. However, GITHUB_TOKEN does not have read:org scope, so the API call fails for all users — even actual scylladb org members — causing CI triggers to be silently skipped.

Replace the API call with the author_association field from the GitHub event payload, which is set by GitHub itself and requires no special token permissions. This allows any scylladb org member (MEMBER or OWNER) to trigger CI via comment, regardless of whether they authored the PR.

**The patch that introduced this was backported to 2026.1 and 2025.4, so this should be backport as well**