### PR TITLE
mv: allow skipping view updates when a collection is unmodified

### DIFF
--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -951,9 +951,8 @@ bool view_updates::can_skip_view_updates(const clustering_or_static_row& update,
             return existing_cell == updated_cell;
         }
 
-        //TODO(sarna): Optimize collections case - currently they do not go under optimization
         if (!cdef.is_atomic()) {
-            return false;
+            return existing_cell->as_collection_mutation().data == updated_cell->as_collection_mutation().data;
         }
 
         atomic_cell_view existing_cell_view = existing_cell->as_atomic_cell(cdef);

--- a/test/boost/view_schema_test.cc
+++ b/test/boost/view_schema_test.cc
@@ -3224,7 +3224,7 @@ SEASTAR_TEST_CASE(test_view_update_generating_writetime) {
 // Usually if only an unselected column in the base table is modified, we expect an optimization that a view
 // update is not done, but we had an bug(https://scylladb.atlassian.net/browse/SCYLLADB-808) where the existence
 // of a collection selected in the view caused us to skip this optimization, even when it was not modified.
-// This test reproduces this bug for the case where the collection was unset during the update.
+// This test reproduces this bug.
 SEASTAR_TEST_CASE(test_view_update_unmodified_collection) {
     // In this test we verify that we correctly skip (or not) view updates to a view that selects
     // a collection column. We use two MVs, similarly as in the test above test.
@@ -3290,12 +3290,12 @@ SEASTAR_TEST_CASE(test_view_update_unmodified_collection) {
             BOOST_REQUIRE_EQUAL(results, expected);
         });
 
-        // We update an unselected column again with a non-NULL selected collection. At this point, this case
-        // is not optimized and we generate a view update to both MVs, but we should optimize it in the future.
+        // We update an unselected column again with a non-NULL selected collection. Because the liveness of the updated column is unchanged
+        // and no other selected column is updated (in particular, the collection column), we should generate no view updates.
         e.execute_cql("UPDATE t SET g=2 WHERE k=1 AND c=1;").get();
         eventually([&] {
             const update_counter results{total_mv1_updates(), total_mv2_updates(), total_t_view_updates()};
-            const update_counter expected{4, 3, 7};
+            const update_counter expected{3, 2, 5};
 
             BOOST_REQUIRE_EQUAL(results, expected);
         });


### PR DESCRIPTION
mv: allow skipping view updates when a collection is unmodified
When we generate view updates, we check whether we can skip the
entire view update if all columns selected by the view are unmodified.
However, for collection columns, we only check if they were unset
before and after the update.
In this patch we add a check for the actual collection contents.
We perform this check for both virtual and non-virtual selections.
When the column is only a virtual column in the view, it would be
enough to check the liveness of each collection cell, however for
that we'd need to deserialize the entire collection anyway, which
should be effectively as expensive as comparing all of its bytes.

Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-808